### PR TITLE
Fix equipment database filtering

### DIFF
--- a/src/components/customizer/equipment/EquipmentBrowser.tsx
+++ b/src/components/customizer/equipment/EquipmentBrowser.tsx
@@ -33,6 +33,8 @@ export function EquipmentBrowser({
     paginatedEquipment,
     isLoading,
     error,
+    unitYear,
+    unitTechBase,
     currentPage,
     totalPages,
     totalItems,
@@ -99,6 +101,19 @@ export function EquipmentBrowser({
           onToggleOneShot={toggleHideOneShot}
           onToggleUnavailable={toggleHideUnavailable}
         />
+        
+        {/* Unit context info - shows when filtering by availability */}
+        {hideUnavailable && (unitYear || unitTechBase) && (
+          <div className="flex items-center gap-2 text-xs text-slate-400 px-1">
+            <span className="text-slate-500">Filtering:</span>
+            {unitYear && (
+              <span className="bg-slate-700 px-2 py-0.5 rounded">Year ≤ {unitYear}</span>
+            )}
+            {unitTechBase && (
+              <span className="bg-slate-700 px-2 py-0.5 rounded">{unitTechBase}</span>
+            )}
+          </div>
+        )}
         
         {/* Text filter */}
         <div className="flex items-center gap-2">


### PR DESCRIPTION
Implement `hideUnavailable` filtering in the equipment browser based on unit year and tech base.

The equipment browser was not filtering items by the mech's year or tech type, despite the `hideUnavailable` toggle being present. This change connects the equipment store to the unit's context to enable proper availability filtering.

---
<a href="https://cursor.com/background-agent?bcId=bc-724580e5-cda7-4fb3-879a-a6c7176f44e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-724580e5-cda7-4fb3-879a-a6c7176f44e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

