### PR TITLE
fix: Desktop menu and startup bugs

### DIFF
--- a/desktop/electron/MenuManager.ts
+++ b/desktop/electron/MenuManager.ts
@@ -266,7 +266,7 @@ export class MenuManager {
       { type: 'separator' },
       {
         label: 'Clear Recent',
-        click: () => this.sendCommand('file:open') // Will trigger clear in the handler
+        click: () => this.sendCommand('file:clear-recent')
       }
     );
 

--- a/desktop/types/BaseTypes.ts
+++ b/desktop/types/BaseTypes.ts
@@ -185,6 +185,7 @@ export type FileMenuCommand =
   | 'file:export'
   | 'file:print'
   | 'file:preferences'
+  | 'file:clear-recent'
   | 'file:quit';
 
 /**

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Bug Fixes

### Bug 1: Clear Recent menu command
- **Issue**: The "Clear Recent" menu button was sending `file:open` command instead of clearing recent files
- **Fix**: 
  - Added `file:clear-recent` to FileMenuCommand type
  - Updated MenuManager to send correct command
  - Added handler to clear recent files and update menu

### Bug 2: Reopen last unit timing issue
- **Issue**: The `did-finish-load` listener was registered after `createMainWindow()` had already loaded the URL, so the event had already fired
- **Fix**: 
  - Moved listener registration to `createMainWindow()` before `loadURL()` is called
  - Ensures listener catches the initial page load event
  - Removed duplicate logic from `applyStartupSettings()`

## Changes
- `desktop/types/BaseTypes.ts`: Added `file:clear-recent` command type
- `desktop/electron/MenuManager.ts`: Fixed Clear Recent command
- `desktop/electron/main.ts`: Fixed timing for reopen last unit feature