### PR TITLE
Add auto-versioning workflow for automatic releases

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -1,0 +1,181 @@
+name: Auto Version and Release
+
+on:
+  push:
+    branches:
+      - main
+    # Only trigger on actual code changes, not workflow changes
+    paths-ignore:
+      - '.github/workflows/**'
+      - '*.md'
+      - 'docs/**'
+      - 'LICENSE*'
+
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  version-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for tags
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get latest version tag
+        id: get_version
+        run: |
+          # Fetch all tags
+          git fetch --tags
+          
+          # Get the latest version tag (excluding pre-release tags like -test, -alpha, etc.)
+          LATEST_TAG=$(git tag -l "v*" --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | head -n 1)
+          
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No previous version tag found, starting at v0.0.0"
+            LATEST_TAG="v0.0.0"
+          fi
+          
+          echo "Latest tag: $LATEST_TAG"
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          
+          # Parse version components
+          VERSION=${LATEST_TAG#v}
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          MINOR=$(echo $VERSION | cut -d. -f2)
+          PATCH=$(echo $VERSION | cut -d. -f3)
+          
+          echo "major=$MAJOR" >> $GITHUB_OUTPUT
+          echo "minor=$MINOR" >> $GITHUB_OUTPUT
+          echo "patch=$PATCH" >> $GITHUB_OUTPUT
+
+      - name: Determine bump type from commit
+        id: bump_type
+        run: |
+          # Use input if manually triggered, otherwise detect from commit message
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            BUMP_TYPE="${{ inputs.bump_type }}"
+          else
+            # Get the commit message
+            COMMIT_MSG=$(git log -1 --pretty=%B)
+            
+            # Check for version bump indicators in commit message
+            if echo "$COMMIT_MSG" | grep -qiE "\[major\]|BREAKING CHANGE"; then
+              BUMP_TYPE="major"
+            elif echo "$COMMIT_MSG" | grep -qiE "\[minor\]|feat:|feature:"; then
+              BUMP_TYPE="minor"
+            else
+              BUMP_TYPE="patch"
+            fi
+          fi
+          
+          echo "Bump type: $BUMP_TYPE"
+          echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
+
+      - name: Calculate new version
+        id: new_version
+        run: |
+          MAJOR=${{ steps.get_version.outputs.major }}
+          MINOR=${{ steps.get_version.outputs.minor }}
+          PATCH=${{ steps.get_version.outputs.patch }}
+          BUMP_TYPE=${{ steps.bump_type.outputs.bump_type }}
+          
+          case $BUMP_TYPE in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+          
+          NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "New version: $NEW_VERSION"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if tag already exists
+        id: check_tag
+        run: |
+          NEW_VERSION=${{ steps.new_version.outputs.new_version }}
+          if git rev-parse "$NEW_VERSION" >/dev/null 2>&1; then
+            echo "Tag $NEW_VERSION already exists, skipping"
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Tag $NEW_VERSION does not exist, will create"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate release notes
+        id: release_notes
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          LATEST_TAG=${{ steps.get_version.outputs.latest_tag }}
+          NEW_VERSION=${{ steps.new_version.outputs.new_version }}
+          
+          # Generate changelog from commits since last tag
+          if [ "$LATEST_TAG" != "v0.0.0" ]; then
+            CHANGELOG=$(git log ${LATEST_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges | head -50)
+          else
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges -20)
+          fi
+          
+          # Create release notes
+          cat << EOF > release_notes.md
+          ## What's Changed in $NEW_VERSION
+          
+          $CHANGELOG
+          
+          **Full Changelog**: https://github.com/${{ github.repository }}/compare/${LATEST_TAG}...${NEW_VERSION}
+          EOF
+          
+          echo "Release notes generated"
+
+      - name: Create and push tag
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          NEW_VERSION=${{ steps.new_version.outputs.new_version }}
+          
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION"
+          git push origin "$NEW_VERSION"
+          
+          echo "✅ Created and pushed tag: $NEW_VERSION"
+
+      - name: Summary
+        run: |
+          echo "## Version Bump Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Previous Version | ${{ steps.get_version.outputs.latest_tag }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Bump Type | ${{ steps.bump_type.outputs.bump_type }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| New Version | ${{ steps.new_version.outputs.new_version }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Tag Created | ${{ steps.check_tag.outputs.exists == 'false' && '✅ Yes' || '⏭️ Skipped (already exists)' }} |" >> $GITHUB_STEP_SUMMARY
+          
+          if [ "${{ steps.check_tag.outputs.exists }}" == "false" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "🚀 The release workflow will now build and publish artifacts for ${{ steps.new_version.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY
+          fi
+

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -135,8 +135,10 @@ jobs:
           # Generate changelog from commits since last tag
           if [ "$LATEST_TAG" != "v0.0.0" ]; then
             CHANGELOG=$(git log ${LATEST_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges | head -50)
+            COMPARE_URL="**Full Changelog**: https://github.com/${{ github.repository }}/compare/${LATEST_TAG}...${NEW_VERSION}"
           else
             CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges -20)
+            COMPARE_URL="🎉 **Initial Release**"
           fi
           
           # Create release notes
@@ -145,7 +147,7 @@ jobs:
           
           $CHANGELOG
           
-          **Full Changelog**: https://github.com/${{ github.repository }}/compare/${LATEST_TAG}...${NEW_VERSION}
+          $COMPARE_URL
           EOF
           
           echo "Release notes generated"

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# version-bump.sh - Manual version bump script
+# Usage: ./scripts/version-bump.sh [patch|minor|major]
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Default bump type
+BUMP_TYPE=${1:-patch}
+
+# Validate bump type
+if [[ ! "$BUMP_TYPE" =~ ^(patch|minor|major)$ ]]; then
+    echo -e "${RED}Error: Invalid bump type '$BUMP_TYPE'${NC}"
+    echo "Usage: $0 [patch|minor|major]"
+    exit 1
+fi
+
+echo -e "${BLUE}🔍 Fetching tags...${NC}"
+git fetch --tags
+
+# Get the latest version tag (excluding pre-release)
+LATEST_TAG=$(git tag -l "v*" --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | head -n 1)
+
+if [ -z "$LATEST_TAG" ]; then
+    echo -e "${YELLOW}No previous version tag found, starting at v0.0.0${NC}"
+    LATEST_TAG="v0.0.0"
+fi
+
+echo -e "${BLUE}📌 Latest version: ${GREEN}$LATEST_TAG${NC}"
+
+# Parse version components
+VERSION=${LATEST_TAG#v}
+MAJOR=$(echo $VERSION | cut -d. -f1)
+MINOR=$(echo $VERSION | cut -d. -f2)
+PATCH=$(echo $VERSION | cut -d. -f3)
+
+# Calculate new version
+case $BUMP_TYPE in
+    major)
+        MAJOR=$((MAJOR + 1))
+        MINOR=0
+        PATCH=0
+        ;;
+    minor)
+        MINOR=$((MINOR + 1))
+        PATCH=0
+        ;;
+    patch)
+        PATCH=$((PATCH + 1))
+        ;;
+esac
+
+NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+
+echo -e "${BLUE}📦 Bump type: ${YELLOW}$BUMP_TYPE${NC}"
+echo -e "${BLUE}🆕 New version: ${GREEN}$NEW_VERSION${NC}"
+
+# Check if tag already exists
+if git rev-parse "$NEW_VERSION" >/dev/null 2>&1; then
+    echo -e "${RED}Error: Tag $NEW_VERSION already exists!${NC}"
+    exit 1
+fi
+
+# Confirm with user
+echo ""
+read -p "Create and push tag $NEW_VERSION? (y/N) " -n 1 -r
+echo ""
+
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    # Make sure we're on main and up to date
+    CURRENT_BRANCH=$(git branch --show-current)
+    if [ "$CURRENT_BRANCH" != "main" ]; then
+        echo -e "${YELLOW}⚠️  Warning: You're not on main branch (current: $CURRENT_BRANCH)${NC}"
+        read -p "Continue anyway? (y/N) " -n 1 -r
+        echo ""
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            echo -e "${RED}Aborted.${NC}"
+            exit 1
+        fi
+    fi
+    
+    # Pull latest changes
+    echo -e "${BLUE}📥 Pulling latest changes...${NC}"
+    git pull origin $CURRENT_BRANCH
+    
+    # Create annotated tag
+    echo -e "${BLUE}🏷️  Creating tag...${NC}"
+    git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION"
+    
+    # Push tag
+    echo -e "${BLUE}🚀 Pushing tag...${NC}"
+    git push origin "$NEW_VERSION"
+    
+    echo ""
+    echo -e "${GREEN}✅ Successfully created and pushed $NEW_VERSION${NC}"
+    echo -e "${BLUE}📋 The release workflow will now build and publish artifacts.${NC}"
+    echo -e "${BLUE}🔗 Check progress at: https://github.com/\$(git remote get-url origin | sed 's/.*github.com[:/]//;s/.git$//')/actions${NC}"
+else
+    echo -e "${YELLOW}Aborted.${NC}"
+    exit 0
+fi
+

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -100,7 +100,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     echo ""
     echo -e "${GREEN}✅ Successfully created and pushed $NEW_VERSION${NC}"
     echo -e "${BLUE}📋 The release workflow will now build and publish artifacts.${NC}"
-    echo -e "${BLUE}🔗 Check progress at: https://github.com/\$(git remote get-url origin | sed 's/.*github.com[:/]//;s/.git$//')/actions${NC}"
+    echo -e "${BLUE}🔗 Check progress at: https://github.com/$(git remote get-url origin | sed 's/.*github.com[:/]//;s/.git$//')/actions${NC}"
 else
     echo -e "${YELLOW}Aborted.${NC}"
     exit 0


### PR DESCRIPTION
## Summary

Adds automatic version bumping and release triggering when PRs are merged to main.

## Changes

### New Workflow: `.github/workflows/auto-version.yml`
- Triggers automatically on merge to main (excludes docs/workflow changes)
- Auto-increments patch version by default
- Supports version bump keywords in commit messages:
  - `[major]` or `BREAKING CHANGE` → Major bump (1.0.0)
  - `[minor]` or `feat:` → Minor bump (0.2.0)
  - Default → Patch bump (0.1.2)
- Manual trigger option from Actions tab
- Generates release notes from commit history
- Pushes tag which triggers existing `release.yml` workflow

### New Script: `scripts/version-bump.sh`
- Local helper for manual version bumps
- Usage: `./scripts/version-bump.sh [patch|minor|major]`

## Flow After This PR

```
PR Merged → auto-version.yml → Creates tag → release.yml → Build & Release
```

## Testing

- Workflow syntax validated
- Will test on first merge after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce auto-versioning GitHub Action and a manual script to calculate, tag, and push semantic version releases.
> 
> - **CI/Workflows**:
>   - Add `/.github/workflows/auto-version.yml` to auto-bump semantic versions on `main` pushes (ignores docs/workflow changes) and via `workflow_dispatch`.
>   - Detect bump type from commit messages (`[major]`/`BREAKING CHANGE`, `[minor]`/`feat:`) else patch; compute next `vMAJOR.MINOR.PATCH`.
>   - Generate release notes from commits, create annotated Git tag, and push to trigger downstream release.
> - **Scripts**:
>   - Add `scripts/version-bump.sh` for local manual bumps (`patch|minor|major`): calculates next version, confirms, tags, and pushes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a490c4425b00a19e8bc6d7978604c628c8cac7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->