### PR TITLE
fix: install rpm dependency for Linux electron builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,12 @@ jobs:
         working-directory: desktop
         run: npm run build
 
+      - name: Install Linux build dependencies
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm
+
       - name: Build Electron application (Linux)
         if: matrix.platform == 'linux'
         working-directory: desktop


### PR DESCRIPTION
The Linux build was failing because `rpmbuild` is not installed on Ubuntu runners by default. This PR adds a step to install the `rpm` package before running electron-builder.

**Issue:** RPM build failed with `rpmbuild failed (exit code 1)`

**Fix:** Added `sudo apt-get install -y rpm` in the Linux build step.