### PR TITLE
fix: remove RPM target from Linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,12 @@ jobs:
         working-directory: desktop
         run: npm run build
 
+      - name: Install Linux build dependencies
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm
+
       - name: Build Electron application (Linux)
         if: matrix.platform == 'linux'
         working-directory: desktop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,12 +98,6 @@ jobs:
         working-directory: desktop
         run: npm run build
 
-      - name: Install Linux build dependencies
-        if: matrix.platform == 'linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y rpm
-
       - name: Build Electron application (Linux)
         if: matrix.platform == 'linux'
         working-directory: desktop

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -129,9 +129,6 @@ linux:
     - target: deb
       arch:
         - x64
-    - target: rpm
-      arch:
-        - x64
     - target: tar.gz
       arch:
         - x64
@@ -146,12 +143,6 @@ deb:
     - libnss3
   afterInstall: scripts/linux/after-install.sh
   afterRemove: scripts/linux/after-remove.sh
-
-rpm:
-  depends:
-    - libnotify
-    - libXtst
-    - nss
 
 appImage:
   artifactName: "${productName}-${version}.AppImage"


### PR DESCRIPTION
RPM builds require complex dependencies on Ubuntu runners that are not worth maintaining. AppImage, deb, and tar.gz cover most Linux distributions.

**Issue:** RPM build was failing with `rpmbuild failed (exit code 1)` even after installing the `rpm` package.

**Fix:** Removed RPM from Linux build targets. Users on Fedora/RHEL can use the tar.gz or convert the deb package.