### PR TITLE
Optimize mac release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,12 @@ jobs:
         working-directory: desktop
         run: npm run build
 
+      - name: Install Linux build dependencies
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm
+
       - name: Build Electron application (Linux)
         if: matrix.platform == 'linux'
         working-directory: desktop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,14 +69,17 @@ jobs:
     if: startsWith(needs.release-context.outputs.tag, 'v')
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
             platform: linux
           - os: windows-latest
             platform: win
           - os: macos-latest
-            platform: mac
+            platform: mac-arm64
+            mac_arch: arm64
+          - os: macos-latest
+            platform: mac-x64
+            mac_arch: x64
 
     steps:
       - name: Checkout code
@@ -90,6 +93,20 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+
+      - name: Cache Electron downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+            ~/AppData/Local/electron/Cache
+            ~/AppData/Local/electron-builder/Cache
+          key: ${{ runner.os }}-electron-${{ hashFiles('desktop/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-
 
       - name: Install root dependencies
         run: npm ci
@@ -116,9 +133,9 @@ jobs:
         run: npx electron-builder --win --publish never
 
       - name: Build Electron application (macOS)
-        if: matrix.platform == 'mac'
+        if: startsWith(matrix.platform, 'mac')
         working-directory: desktop
-        run: npx electron-builder --mac --publish never
+        run: npx electron-builder --mac --${{ matrix.mac_arch }} --publish never
 
       - name: Prepare release artifacts
         working-directory: desktop
@@ -163,6 +180,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.release-context.outputs.ref }}
+
+      - name: Fetch tags
+        run: git fetch --tags --force
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -257,6 +277,9 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.release-context.outputs.ref }}
 
+      - name: Fetch tags
+        run: git fetch --tags --force
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -268,6 +291,18 @@ jobs:
           set -euo pipefail
           CURRENT_TAG="${{ needs.release-context.outputs.tag }}"
           PREV_TAG="${{ needs.release-context.outputs.prev_tag }}"
+
+          # Ensure current tag exists
+          if ! git rev-parse "${CURRENT_TAG}^{tag}" >/dev/null 2>&1; then
+            echo "Tag ${CURRENT_TAG} not found. Ensure it is pushed before releasing." >&2
+            exit 1
+          fi
+
+          # If previous tag is missing or not found, treat as initial release
+          if [ -n "$PREV_TAG" ] && ! git rev-parse "${PREV_TAG}^{tag}" >/dev/null 2>&1; then
+            echo "Previous tag ${PREV_TAG} not found; treating as initial release." >&2
+            PREV_TAG=""
+          fi
 
           if [ -z "$PREV_TAG" ]; then
             # No previous tag - this is the initial release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
     outputs:
       tag: ${{ steps.resolve_tag.outputs.tag }}
       ref: ${{ steps.resolve_tag.outputs.ref }}
+      prev_tag: ${{ steps.resolve_tag.outputs.prev_tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,12 +37,13 @@ jobs:
           set -euo pipefail
           TAG_INPUT="${{ inputs.release_tag }}"
 
+          git fetch --tags
+
           if [ -n "$TAG_INPUT" ]; then
             TAG="$TAG_INPUT"
           elif [ "${GITHUB_EVENT_NAME}" = "push" ]; then
             TAG="${GITHUB_REF_NAME}"
           else
-            git fetch --tags
             TAG=$(git tag -l 'v*' --sort=-version:refname | head -n 1)
           fi
 
@@ -50,12 +52,17 @@ jobs:
             exit 1
           fi
 
+          # Find the previous v* tag (second in sorted list, or empty if none)
+          PREV_TAG=$(git tag -l 'v*' --sort=-version:refname | grep -v "^${TAG}$" | head -n 1 || true)
+
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "ref=refs/tags/$TAG" >> "$GITHUB_OUTPUT"
+          echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Summary
         run: |
           echo "Release tag: ${{ steps.resolve_tag.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Previous tag: ${{ steps.resolve_tag.outputs.prev_tag }}" >> "$GITHUB_STEP_SUMMARY"
   build:
     needs: release-context
     runs-on: ${{ matrix.os }}
@@ -255,10 +262,57 @@ jobs:
         with:
           path: artifacts
 
+      - name: Generate commit list
+        id: commits
+        run: |
+          set -euo pipefail
+          CURRENT_TAG="${{ needs.release-context.outputs.tag }}"
+          PREV_TAG="${{ needs.release-context.outputs.prev_tag }}"
+
+          if [ -z "$PREV_TAG" ]; then
+            # No previous tag - this is the initial release
+            echo "Initial release - listing all commits up to $CURRENT_TAG"
+            git log "$CURRENT_TAG" --pretty=format:"- %s (%h)" > commits.md
+          else
+            # Generate commit list between previous and current tag
+            echo "Generating commits from $PREV_TAG to $CURRENT_TAG"
+            git log "${PREV_TAG}..${CURRENT_TAG}" --pretty=format:"- %s (%h)" > commits.md
+          fi
+
+          # Check if we have any commits
+          if [ ! -s commits.md ]; then
+            echo "- No commits in this release" > commits.md
+          fi
+
+      - name: Generate release notes with Docker links
+        id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name=${{ needs.release-context.outputs.tag }} > notes.json
+          body=$(jq -r '.body' notes.json)
+          {
+            echo "$body"
+            echo ""
+            echo "---"
+            echo "## Commits in this release"
+            echo ""
+            cat commits.md
+            echo ""
+            echo "---"
+            echo "## Docker images"
+            echo "- Docker Hub: https://hub.docker.com/r/anaklumos/mekstation"
+            echo "- GHCR: https://ghcr.io/${{ github.repository_owner }}/mekstation"
+          } > release-notes.md
+          echo "body_path=release-notes.md" >> "$GITHUB_OUTPUT"
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           files: artifacts/**/*
+          body_path: ${{ steps.notes.outputs.body_path }}
           draft: false
           prerelease: false
         env:


### PR DESCRIPTION
## Summary
- split mac builds into separate arm64 and x64 jobs to avoid universal builds per runner
- cache electron/electron-builder downloads before installs to reuse across steps and runs
- guard release notes generation when previous tag is missing by verifying tags and falling back to initial release behavior

## Testing
- not run (workflow change)