### PR TITLE
Trigger auto-version on all main merges

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches:
       - main
-    # Only trigger on actual code changes, not workflow changes
-    paths-ignore:
-      - '.github/workflows/**'
-      - '*.md'
-      - 'docs/**'
-      - 'LICENSE*'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
- remove paths-ignore so Auto Version and Release runs on every merge to main, including workflow changes
- ensures tags are created automatically and Build and Release fires after merges

## Testing
- not run (workflow trigger change)