### PR TITLE
Fix mac arch builds and release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,6 +348,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ needs.release-context.outputs.tag }}
           files: artifacts/**/*
           body_path: ${{ steps.notes.outputs.body_path }}
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
           mkdir -p release-upload
 
           # Find and copy release artifacts using find (cross-platform compatible)
-          find release -maxdepth 1 -type f \( \
+          find release -maxdepth 1 -type f ! -name "builder-debug.yml" \( \
             -name "*.exe" -o -name "*.msi" -o -name "*.dmg" -o -name "*.zip" \
             -o -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" \
             -o -name "*.tar.gz" -o -name "*.yml" -o -name "*.blockmap" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,9 @@ jobs:
       - name: Build Electron application (macOS)
         if: startsWith(matrix.platform, 'mac')
         working-directory: desktop
-        run: npx electron-builder --mac --${{ matrix.mac_arch }} --publish never
+        env:
+          ELECTRON_BUILDER_ARCH: ${{ matrix.mac_arch }}
+        run: npx electron-builder --mac dmg zip --${{ matrix.mac_arch }} --publish never
 
       - name: Prepare release artifacts
         working-directory: desktop

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -49,14 +49,8 @@ mac:
   entitlements: assets/entitlements.mac.plist
   entitlementsInherit: assets/entitlements.mac.plist
   target:
-    - target: dmg
-      arch:
-        - x64
-        - arm64
-    - target: zip
-      arch:
-        - x64
-        - arm64
+    - dmg
+    - zip
 
 dmg:
   sign: false


### PR DESCRIPTION
## Summary
- ensure mac matrix jobs build only their target arch (arm64/x64) with explicit arch flag
- exclude builder-debug.yml from uploaded artifacts to avoid duplicate asset errors on rerun
- keep release creation using explicit tag_name to publish correctly on workflow_run

## Testing
- not run (workflow change)