### PR TITLE
Bundle node_modules in electron build

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -16,7 +16,7 @@ directories:
 files:
   - "dist/**/*"
   - "assets/**/*"
-  - "!node_modules/**/*"
+  - "node_modules/**/*"
   # Include the Next.js standalone build (relative to project root)
   - "../.next/standalone/**/*"
   - "../.next/static/**/*"


### PR DESCRIPTION
## Summary
- include node_modules in electron builder bundle so runtime deps ship
- prevent installer crash from missing electron-updater module at startup

## Test plan
- not run (packaging/build not executed in this environment)