### PR TITLE
Prep auto-updates (GitHub feed, version from tag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,12 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Set app version from tag
+        run: |
+          APP_VERSION="${{ needs.release-context.outputs.tag }}"
+          APP_VERSION="${APP_VERSION#v}"
+          echo "APP_VERSION=$APP_VERSION" >> "$GITHUB_ENV"
+
       - name: Cache Electron downloads
         uses: actions/cache@v4
         with:
@@ -125,19 +131,19 @@ jobs:
       - name: Build Electron application (Linux)
         if: matrix.platform == 'linux'
         working-directory: desktop
-        run: npx electron-builder --linux --publish never
+        run: npx electron-builder --linux --config.extraMetadata.version="$APP_VERSION" --publish never
 
       - name: Build Electron application (Windows)
         if: matrix.platform == 'win'
         working-directory: desktop
-        run: npx electron-builder --win --publish never
+        run: npx electron-builder --win --config.extraMetadata.version="$APP_VERSION" --publish never
 
       - name: Build Electron application (macOS)
         if: startsWith(matrix.platform, 'mac')
         working-directory: desktop
         env:
           ELECTRON_BUILDER_ARCH: ${{ matrix.mac_arch }}
-        run: npx electron-builder --mac dmg zip --${{ matrix.mac_arch }} --publish never
+        run: npx electron-builder --mac dmg zip --${{ matrix.mac_arch }} --config.extraMetadata.version="$APP_VERSION" --publish never
 
       - name: Prepare release artifacts
         working-directory: desktop

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -228,14 +228,21 @@ class MekStationApp {
    * Initialize auto-updater
    */
   private initializeAutoUpdater(): void {
-    // Configure auto-updater
-    autoUpdater.checkForUpdatesAndNotify();
+    const updateChannel = process.env.MEKSTATION_UPDATE_CHANNEL || 'latest';
+
+    // Configure auto-updater feed (GitHub Releases, per electron-builder publish config)
+    autoUpdater.channel = updateChannel;
+    autoUpdater.allowDowngrade = false;
+    autoUpdater.autoDownload = true;
     autoUpdater.setFeedURL({
       provider: 'github',
-      owner: 'swervelabs',
-      repo: 'mekstation',
+      owner: 'SwiggitySwerve',
+      repo: 'MekStation',
       private: false
     });
+
+    // Initial check
+    autoUpdater.checkForUpdatesAndNotify();
 
     autoUpdater.on('checking-for-update', () => {
       console.log('🔍 Checking for updates...');

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -17,15 +17,17 @@ files:
   - "dist/**/*"
   - "assets/**/*"
   - "node_modules/**/*"
-  # Include the Next.js standalone build (relative to project root)
-  - "../.next/standalone/**/*"
-  - "../.next/static/**/*"
-  - "../public/**/*"
 
 # Extra resources to include (outside of app.asar)
 extraResources:
   - from: "assets"
     to: "assets"
+  # Next.js standalone output (self-contained server + deps)
+  - from: "../.next/standalone"
+    to: "next-standalone"
+  # Next.js static assets (CSS/JS) for standalone server
+  - from: "../.next/static"
+    to: "next-standalone/.next/static"
   - from: "../public/data"
     to: "data"
   - from: "../public/record-sheets"

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -147,7 +147,7 @@ appImage:
 publish:
   provider: github
   owner: SwiggitySwerve
-  repo: megamek-web
+  repo: MekStation
   private: false
   releaseType: release
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -16,7 +16,7 @@ directories:
 files:
   - "dist/**/*"
   - "assets/**/*"
-  - "!node_modules/**/*"
+  - "node_modules/**/*"
   # Include the Next.js standalone build (relative to project root)
   - "../.next/standalone/**/*"
   - "../.next/static/**/*"


### PR DESCRIPTION
## Summary
- set app version in CI from the release tag and pass it to electron-builder so artifacts match the tagged release
- update electron-builder publish target to the current repo (SwiggitySwerve/MekStation)
- align auto-updater feed in main process to the correct repo and allow channel selection via MEKSTATION_UPDATE_CHANNEL

## Testing
- not run (workflow/app config changes)