### PR TITLE
fix(ci): run electron-builder in bash on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,7 @@ jobs:
       - name: Build Electron application (Windows)
         if: matrix.platform == 'win'
         working-directory: desktop
+        shell: bash
         run: npx electron-builder --win --config.extraMetadata.version="$APP_VERSION" --publish never
 
       - name: Build Electron application (macOS)


### PR DESCRIPTION
## Summary
- Fixes Windows release builds where `$APP_VERSION` was treated as an empty PowerShell variable, causing electron-builder to think the app version was missing.
- Runs the Windows electron-builder step in bash so `$APP_VERSION` expands correctly.

## Test plan
- CI: confirm the release workflow’s Windows build passes and produces artifacts.