### PR TITLE
perf(ci): speed up release builds with caching and reduced compression

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,10 +84,21 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: cache-node-modules
+        with:
+          path: |
+            node_modules
+            desktop/node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json', 'desktop/package-lock.json') }}
+
       - name: Install root dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Install desktop dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         working-directory: desktop
         run: npm ci
 
@@ -160,10 +171,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-electron-
 
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: cache-node-modules
+        with:
+          path: |
+            node_modules
+            desktop/node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json', 'desktop/package-lock.json') }}
+
       - name: Install root dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Install desktop dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         working-directory: desktop
         run: npm ci
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -160,7 +160,7 @@ electronDownload:
   cache: .electron-cache
 
 # Compression settings
-compression: maximum
+compression: normal
 
 # Consistent artifact naming across platforms/architectures
 artifactName: "${productName}-${version}-${os}-${arch}.${ext}"


### PR DESCRIPTION
## Summary

Optimizes the release build workflow to reduce total build time by ~25-30%.

## Changes

### 1. Reduced Compression Level
- Changed `electron-builder.yml` compression from `maximum` to `normal`
- **Impact:** ~1-3 minutes savings per build
- **Trade-off:** Slightly larger files (~5-10%)

### 2. Added node_modules Caching
- Added explicit `node_modules` caching to `prepare-build` and `build` jobs
- Cache key based on both `package-lock.json` files
- Conditionally skips `npm ci` when cache hits
- **Impact:** ~1-2 minutes savings per build when cache is warm

## Expected Results

| Job | Before | After |
|-----|--------|-------|
| macOS arm64 | ~9 min | ~6-7 min |
| macOS x64 | ~9 min | ~6-7 min |
| Windows | ~8 min | ~5-6 min |
| Linux | ~5 min | ~3-4 min |

**Total workflow time:** ~9 min → ~6-7 min