### PR TITLE
fix(ci): filter release assets to only include distributable files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -373,10 +373,12 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags --force
 
-      - name: Download all artifacts
+      - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
+          pattern: '*-artifacts'
           path: artifacts
+          merge-multiple: true
 
       - name: Generate commit list
         id: commits


### PR DESCRIPTION
## Problem

Release v0.1.19 had 56 assets because it was downloading ALL artifacts including `web-build` (intermediate build files that shouldn't be published).

## Solution

Use the `pattern` parameter of `actions/download-artifact@v4` to only download platform-specific artifacts:

```yaml
- name: Download release artifacts
  uses: actions/download-artifact@v4
  with:
    pattern: '*-artifacts'
    path: artifacts
    merge-multiple: true
```

## Result

Only distributable files will be included in releases:
- **Windows:** x64 exe, ia32 exe, portable + blockmaps + latest.yml
- **Linux:** AppImage, deb, tar.gz + latest-linux.yml
- **macOS:** arm64/x64 dmg + zip + latest-mac-*.yml

Intermediate build artifacts (`web-build` with .next/standalone, etc.) are excluded.

**Expected:** ~15-20 files instead of 56

This follows industry standard practices used by VS Code, Slack, and other major Electron apps.