### PR TITLE
feat: Armor diagram design variants with settings page

### DIFF
--- a/docs/plans/2026-01-10-armor-diagram-redesign.md
+++ b/docs/plans/2026-01-10-armor-diagram-redesign.md
@@ -1,0 +1,211 @@
+# Armor Diagram Redesign - Design Specification
+
+## Overview
+
+Complete visual overhaul of the armor diagram in the customizer's Armor Tab. The current implementation uses simple rectangles with numbers. The redesign will create 4 distinct prototypes for user acceptance testing (UAT), allowing stakeholders to pick the best approach or combine elements from different designs.
+
+## Current State
+
+**Location:** `src/components/customizer/armor/`
+- `ArmorDiagram.tsx` - Main SVG container (300x400 viewBox)
+- `ArmorLocation.tsx` - Individual clickable location (rect + text)
+- `ArmorLegend.tsx` - Color legend
+
+**Current Issues:**
+- Simple rectangles don't look like a BattleMech
+- Hard to quickly assess armor allocation status
+- Visual style doesn't match modern app aesthetic
+- Front/rear armor display feels cramped
+
+## Design Matrix
+
+The redesign explores these independent properties:
+
+### A. Silhouette Shape
+| ID | Name | Description |
+|----|------|-------------|
+| A1 | Realistic Contour | Smooth SVG paths forming actual mech shape |
+| A2 | Geometric/Polygonal | Angular low-poly shapes suggesting mech form |
+| A3 | Simplified Iconic | Basic shapes with better proportions |
+| A4 | Wireframe Outline | Thin line drawing with floating panels |
+
+### B. Fill Style
+| ID | Name | Description |
+|----|------|-------------|
+| B1 | Solid Gradient | Status color gradient (green to red) |
+| B2 | Bottom-Up Tank | Fill rises from bottom based on % full |
+| B3 | Metallic/Textured | Brushed metal or carbon fiber texture |
+| B4 | Glow/Neon | Semi-transparent fill with glowing edges |
+
+### C. Number Display
+| ID | Name | Description |
+|----|------|-------------|
+| C1 | Plain Bold | Large centered number, clean font |
+| C2 | LED Segmented | Digital clock-style segmented display |
+| C3 | Circular Badge | Number inside hexagon or circle |
+| C4 | With Progress Ring | Number surrounded by circular progress arc |
+
+### D. Capacity Indicator
+| ID | Name | Description |
+|----|------|-------------|
+| D1 | Color Only | Location color shifts green/amber/red |
+| D2 | Horizontal Bar | Small gauge bar under the number |
+| D3 | Small Text | "24/32" or "75%" shown |
+| D4 | Dot Indicators | 3-5 dots like battery level |
+
+### E. Front/Rear Display
+| ID | Name | Description |
+|----|------|-------------|
+| E1 | Stacked | Front/rear as top/bottom sections |
+| E2 | Side-by-Side | Front mech left, rear mech right |
+| E3 | Toggle Switch | Button to flip between views |
+| E4 | Slide-out Panel | Click to reveal rear in side panel |
+| E5 | 3D Layered | Rear plate visually behind front plate |
+
+### F. Interaction Style
+| ID | Name | Description |
+|----|------|-------------|
+| F1 | Glow Pulse | Edges glow brighter, pulse on select |
+| F2 | Lift/Shadow | Location raises with drop shadow |
+| F3 | Bracket Focus | Corner brackets and targeting reticle |
+| F4 | Border Highlight | Simple thick colored border |
+
+---
+
+## 4 Prototype Combinations
+
+### Combo 1: "Clean Tech"
+**Philosophy:** Maximum readability and usability
+
+| Property | Selection |
+|----------|-----------|
+| Silhouette | A1: Realistic Contour |
+| Fill | B1: Solid Gradient |
+| Numbers | C1: Plain Bold |
+| Capacity | D1: Color Only + D3: Small Text |
+| Front/Rear | E1: Stacked |
+| Interaction | F4: Border Highlight |
+
+**Target Users:** Players who prioritize function over form, quick builders
+
+### Combo 2: "Neon Operator"
+**Philosophy:** Sci-fi aesthetic and visual impact
+
+| Property | Selection |
+|----------|-----------|
+| Silhouette | A4: Wireframe Outline |
+| Fill | B4: Glow/Neon |
+| Numbers | C4: With Progress Ring |
+| Capacity | D1: Color Only |
+| Front/Rear | E3: Toggle Switch |
+| Interaction | F1: Glow Pulse |
+
+**Target Users:** Players who want immersive cockpit experience
+
+### Combo 3: "Tactical HUD"
+**Philosophy:** Information density and military feel
+
+| Property | Selection |
+|----------|-----------|
+| Silhouette | A2: Geometric/Polygonal |
+| Fill | B2: Bottom-Up Tank |
+| Numbers | C2: LED Segmented |
+| Capacity | D2: Horizontal Bar |
+| Front/Rear | E2: Side-by-Side |
+| Interaction | F3: Bracket Focus |
+
+**Target Users:** Detail-oriented players, competitive builders
+
+### Combo 4: "Premium Material"
+**Philosophy:** Modern app polish and tactile feel
+
+| Property | Selection |
+|----------|-----------|
+| Silhouette | A1: Realistic Contour |
+| Fill | B3: Metallic/Textured |
+| Numbers | C3: Circular Badge |
+| Capacity | D4: Dot Indicators |
+| Front/Rear | E5: 3D Layered |
+| Interaction | F2: Lift/Shadow |
+
+**Target Users:** Design-conscious players, those who appreciate polish
+
+---
+
+## Implementation Plan
+
+### File Structure
+```
+src/components/customizer/armor/
+├── ArmorDiagram.tsx          # Existing - will add variant support
+├── ArmorLocation.tsx         # Existing - will add variant support
+├── ArmorLegend.tsx           # Existing
+├── ArmorDiagramSelector.tsx  # NEW - UAT design picker
+├── variants/
+│   ├── CleanTechDiagram.tsx
+│   ├── NeonOperatorDiagram.tsx
+│   ├── TacticalHUDDiagram.tsx
+│   └── PremiumMaterialDiagram.tsx
+└── shared/
+    ├── MechSilhouette.tsx    # SVG path definitions
+    ├── ArmorFills.tsx        # Fill patterns/gradients
+    └── InteractionStyles.tsx # Hover/select effects
+```
+
+### Shared Components
+
+**MechSilhouette.tsx:**
+- Export SVG path data for realistic and geometric silhouettes
+- Provide position coordinates for each location
+- Support both biped and (future) quad layouts
+
+**ArmorFills.tsx:**
+- SVG gradient definitions
+- Filter definitions for glow/metallic effects
+- Reusable fill patterns
+
+### UAT Design Selector
+
+For testing, create a selector component that:
+1. Shows all 4 designs in a grid
+2. Allows switching between them in the actual ArmorTab
+3. Persists selection to localStorage for continued testing
+4. Can be removed after final design is chosen
+
+---
+
+## Color Palette
+
+All designs share these status colors:
+
+| Status | Hex | Usage |
+|--------|-----|-------|
+| Healthy (100-75%) | `#22c55e` (green-500) | Full or near-full armor |
+| Moderate (74-50%) | `#f59e0b` (amber-500) | Partially allocated |
+| Low (49-25%) | `#f97316` (orange-500) | Getting thin |
+| Critical (<25%) | `#ef4444` (red-500) | Dangerously low |
+| Selected | `#3b82f6` (blue-500) | Active selection |
+| Hover | Lightened version | Mouse over |
+
+---
+
+## Accessibility Requirements
+
+All designs must maintain:
+- `role="button"` on clickable locations
+- `aria-label` with full armor details
+- `aria-pressed` for selected state
+- Keyboard navigation (Tab, Enter, Space)
+- Focus visible indicators
+- Color contrast ratios meeting WCAG AA
+
+---
+
+## Success Criteria
+
+After UAT testing, the winning design must:
+1. Be clearly preferred by majority of testers
+2. Show armor allocation at a glance
+3. Make front/rear armor intuitive
+4. Feel consistent with MekStation's visual language
+5. Perform well (no jank on mobile devices)

--- a/docs/plans/2026-01-10-armor-editor-redesign.md
+++ b/docs/plans/2026-01-10-armor-editor-redesign.md
@@ -1,0 +1,199 @@
+# Armor Editor UX Redesign
+
+**Date:** 2026-01-10
+**Status:** Approved
+**Author:** Claude + User
+
+## Problem Statement
+
+The current armor customization UI has two issues:
+
+1. **LocationArmorEditor UX** - Uses a confusing "total slider + split slider" approach that requires mental math to understand
+2. **Diagram inconsistency** - NeonOperator variant uses a toggle to switch between front/rear views, hiding one at a time. Other variants show both but use different layouts.
+
+## Design Goals
+
+- Simple, direct controls for front and rear armor
+- All diagram variants show front and rear simultaneously
+- Consistent stacked layout across all variants
+- Consistent color coding (amber = front, sky blue = rear)
+
+---
+
+## LocationArmorEditor Redesign
+
+### Current State
+
+```
+Total:  ──●━━━━━━━━━━━━━━━━━━━━  [47]
+Split:  ████████████░░░░░░░░░░░  (drag to adjust ratio)
+Front:  [35]    Rear: [12]
+```
+
+Problems:
+- Two sliders is confusing
+- Split slider only works after setting total
+- Mental model unclear
+
+### New Design
+
+```
+┌─────────────────────────────────────────┐
+│  CENTER TORSO                        ✕  │
+├─────────────────────────────────────────┤
+│                                         │
+│  FRONT                                  │
+│  ──●━━━━━━━━━━━━━━━━━━━━━━━──  [35] /47 │
+│  (amber slider)                         │
+│                                         │
+│  REAR                                   │
+│  ━━━━━━━●────────────────────  [12] /47 │
+│  (sky blue slider)                      │
+│                                         │
+│  ┌─────────────────────────────────┐    │
+│  │ ████████████████░░░░░░░░░░░░░░░ │    │
+│  │ 47 / 94 total                   │    │
+│  └─────────────────────────────────┘    │
+│  (combined bar - read only)             │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+### Behavior
+
+- **Front slider**: Independent, capped at `maxArmor - rearValue`
+- **Rear slider**: Independent, capped at `maxArmor - frontValue`
+- **Number inputs**: Allow precise entry with same capping rules
+- **Total bar**: Read-only display showing combined value vs location max
+- **Colors**: Front = amber (#f59e0b), Rear = sky blue (#0ea5e9)
+
+---
+
+## Diagram Variants - Standardized Stacked Layout
+
+All 4 variants will use a consistent stacked front/rear layout for torso locations (CT, LT, RT), adapted to each variant's visual style.
+
+### CleanTech (solid gradients)
+
+```
+┌─────────────┐
+│     CT      │
+│  ┌───────┐  │
+│  │  35   │  │  ← front section (amber gradient fill)
+│  │ ───── │  │  ← subtle divider
+│  │  12   │  │  ← rear section (sky gradient fill)
+│  └───────┘  │
+└─────────────┘
+```
+
+### NeonOperator (glowing rings)
+
+```
+┌─────────────┐
+│     CT      │
+│    ◎35     │  ← front progress ring (amber glow)
+│   ─ ─ ─    │  ← glowing dashed divider
+│    ○12     │  ← rear progress ring (sky glow)
+└─────────────┘
+```
+
+**Note:** Remove existing FRONT/REAR toggle buttons entirely.
+
+### TacticalHUD (LED + bars)
+
+```
+┌─────────────┐
+│     CT      │
+│  [35] ████  │  ← front LED display + bar gauge
+│  ─────────  │  ← divider line
+│  [12] ██░░  │  ← rear LED display + bar gauge
+└─────────────┘
+```
+
+**Note:** Replace current side-by-side layout with stacked.
+
+### PremiumMaterial (badges + dots)
+
+```
+┌─────────────┐
+│     CT      │
+│    ⬡35     │  ← front circular badge + dot indicators
+│   ─────    │  ← divider
+│    ⬡12     │  ← rear circular badge + dot indicators
+└─────────────┘
+```
+
+**Note:** Replace current 3D layered plates with stacked.
+
+### Consistent Elements
+
+- Front section always on top
+- Rear section always below
+- Amber color (#f59e0b) for front
+- Sky blue color (#0ea5e9) for rear
+- Subtle divider line between sections
+- Non-torso locations (HD, LA, RA, LL, RL) unchanged - single section
+
+---
+
+## Color Constants
+
+Add to `src/components/customizer/armor/shared/ArmorFills.tsx`:
+
+```typescript
+export const FRONT_ARMOR_COLOR = '#f59e0b';  // amber-500
+export const REAR_ARMOR_COLOR = '#0ea5e9';   // sky-500
+```
+
+---
+
+## Files to Modify
+
+```
+src/components/customizer/armor/
+├── LocationArmorEditor.tsx        ← REWRITE (direct front/rear controls)
+├── variants/
+│   ├── CleanTechDiagram.tsx       ← UPDATE (stacked layout, color consistency)
+│   ├── NeonOperatorDiagram.tsx    ← UPDATE (stacked rings, remove toggle)
+│   ├── TacticalHUDDiagram.tsx     ← UPDATE (stacked layout, remove side-by-side)
+│   └── PremiumMaterialDiagram.tsx ← UPDATE (stacked layout, remove 3D layers)
+└── shared/
+    └── ArmorFills.tsx             ← ADD front/rear color constants
+```
+
+---
+
+## Testing
+
+### Unit Tests
+
+**LocationArmorEditor.test.tsx:**
+- Front slider changes only front value
+- Rear slider changes only rear value
+- Each slider caps at `maxArmor - otherValue`
+- Number inputs work correctly
+- Total display shows combined value
+
+**Variant Tests (all 4):**
+- Torso locations render both front and rear sections
+- Correct colors applied (amber front, sky rear)
+- Non-torso locations unchanged (single section)
+- Click handlers work on stacked layout
+
+### Manual Testing Checklist
+
+- [ ] Select each torso location, verify editor shows direct controls
+- [ ] Adjust front slider, verify rear is unaffected
+- [ ] Adjust rear slider, verify front is unaffected
+- [ ] Verify all 4 diagram variants show stacked front/rear
+- [ ] Verify status colors (green/amber/red) work on both sections
+- [ ] Test on mobile viewport sizes
+
+---
+
+## Out of Scope
+
+- Data model changes (none needed)
+- ArmorTab layout changes
+- Auto-allocate logic changes
+- Settings page changes

--- a/equipment-validation-report.json
+++ b/equipment-validation-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-12-14T20:45:45.860Z",
+  "generatedAt": "2026-01-10T21:09:37.395Z",
   "summary": {
     "unitsProcessed": 4217,
     "unitsWithIssues": 1914,

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/openspec/specs/app-settings/spec.md
+++ b/openspec/specs/app-settings/spec.md
@@ -1,0 +1,156 @@
+# App Settings Specification
+
+## Overview
+
+The app settings system provides user-configurable preferences for appearance, behavior, and accessibility. Settings are persisted to localStorage and apply immediately across the application.
+
+## Requirements
+
+### Requirement: Settings Page
+The system SHALL provide a dedicated settings page accessible from the sidebar.
+
+#### Scenario: Settings page access
+- **WHEN** user clicks Settings in the sidebar
+- **THEN** the settings page is displayed at /settings
+- **AND** settings are organized into logical sections
+- **AND** current values are pre-populated from stored preferences
+
+### Requirement: Appearance Settings
+The system SHALL provide appearance customization options.
+
+#### Scenario: Accent color selection
+- **WHEN** user views appearance settings
+- **THEN** 6 accent color options are available:
+  - Amber (default)
+  - Cyan
+  - Emerald
+  - Rose
+  - Violet
+  - Blue
+- **AND** clicking a color applies it immediately
+- **AND** selection is visually indicated
+
+#### Scenario: Font size selection
+- **WHEN** user selects font size
+- **THEN** options are: Small (14px), Medium (16px), Large (18px)
+- **AND** selection applies to base font size across app
+
+#### Scenario: Animation level
+- **WHEN** user selects animation level
+- **THEN** options are: Full, Reduced, None
+- **AND** selection controls transition and animation behavior
+
+#### Scenario: Compact mode
+- **WHEN** user enables compact mode
+- **THEN** spacing and padding are reduced throughout the app
+- **AND** more information fits on screen
+
+### Requirement: Customizer Settings
+The system SHALL provide customizer-specific settings.
+
+#### Scenario: Armor diagram variant
+- **WHEN** user views customizer settings
+- **THEN** 4 armor diagram variants are shown with live previews
+- **AND** clicking a variant selects it
+- **AND** selection applies immediately to the armor tab
+
+#### Scenario: UAT design selector toggle
+- **WHEN** UAT selector is enabled
+- **THEN** design variant dropdown is shown in armor tab
+- **AND** this is for testing purposes only
+
+### Requirement: UI Behavior Settings
+The system SHALL provide UI behavior preferences.
+
+#### Scenario: Sidebar default state
+- **WHEN** user sets sidebar default collapsed
+- **THEN** sidebar starts collapsed on fresh page loads
+
+#### Scenario: Confirm on close
+- **WHEN** confirm on close is enabled
+- **THEN** closing tabs with unsaved changes shows confirmation
+
+#### Scenario: Tooltips toggle
+- **WHEN** tooltips are disabled
+- **THEN** hover tooltips are not shown
+
+### Requirement: Accessibility Settings
+The system SHALL provide accessibility options.
+
+#### Scenario: High contrast
+- **WHEN** high contrast is enabled
+- **THEN** contrast ratios are increased throughout app
+
+#### Scenario: Reduce motion
+- **WHEN** reduce motion is enabled
+- **THEN** animations are minimized or disabled
+- **AND** respects user's system preference
+
+### Requirement: Settings Persistence
+The system SHALL persist all settings to localStorage.
+
+#### Scenario: Settings storage
+- **WHEN** any setting is changed
+- **THEN** value is immediately saved to localStorage
+- **AND** key is 'mekstation-app-settings'
+- **AND** values persist across browser sessions
+
+#### Scenario: Settings reset
+- **WHEN** user clicks Reset All Settings
+- **THEN** confirmation dialog is shown
+- **AND** confirming restores all default values
+
+### Requirement: Settings Store Integration
+Components SHALL access settings via Zustand store.
+
+#### Scenario: Store usage
+- **WHEN** a component needs a setting value
+- **THEN** it uses `useAppSettingsStore` hook
+- **AND** component re-renders when setting changes
+- **AND** no prop drilling is required
+
+## Settings Schema
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| accentColor | AccentColor | 'amber' | Primary accent color |
+| fontSize | FontSize | 'medium' | Base font size |
+| animationLevel | AnimationLevel | 'full' | Animation amount |
+| compactMode | boolean | false | Reduce spacing |
+| armorDiagramVariant | ArmorDiagramVariant | 'clean-tech' | Diagram design |
+| showArmorDiagramSelector | boolean | true | Show UAT selector |
+| sidebarDefaultCollapsed | boolean | false | Start collapsed |
+| confirmOnClose | boolean | true | Confirm unsaved |
+| showTooltips | boolean | true | Enable tooltips |
+| highContrast | boolean | false | Increase contrast |
+| reduceMotion | boolean | false | Minimize animation |
+
+## Component Reference
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| Settings Page | `pages/settings.tsx` | Main settings UI |
+| useAppSettingsStore | `stores/useAppSettingsStore.ts` | Settings state management |
+| ArmorDiagramGridPreview | `armor/ArmorDiagramPreview.tsx` | Live variant preview |
+
+## UI Components
+
+### Toggle Switch
+- Binary on/off control
+- Displays label and optional description
+- Immediate visual feedback
+
+### Select Dropdown
+- Multiple choice selection
+- Shows current value
+- Supports descriptions per option
+
+### Color Picker
+- Grid of color swatches
+- Visual selection indicator
+- Hover and focus states
+
+### Design Grid
+- 2x2 grid of variant previews
+- Live diagrams with sample data
+- Selection ring indicator

--- a/openspec/specs/armor-diagram-variants/spec.md
+++ b/openspec/specs/armor-diagram-variants/spec.md
@@ -1,0 +1,127 @@
+# Armor Diagram Variants Specification
+
+## Overview
+
+The armor diagram in the customizer supports multiple visual design variants. Users can choose their preferred style from the settings page, and the selection persists across sessions.
+
+## Requirements
+
+### Requirement: Multiple Design Variants
+The system SHALL provide 4 distinct armor diagram designs for user selection.
+
+#### Scenario: Available variants
+- **WHEN** the armor diagram is rendered
+- **THEN** the system supports these variants:
+  - Clean Tech (default)
+  - Neon Operator
+  - Tactical HUD
+  - Premium Material
+- **AND** each variant maintains identical functionality
+- **AND** each variant displays all 8 mech locations
+
+### Requirement: Clean Tech Variant
+The system SHALL provide a Clean Tech design focused on maximum readability.
+
+#### Scenario: Clean Tech visual elements
+- **WHEN** Clean Tech variant is active
+- **THEN** diagram uses realistic mech contour silhouette
+- **AND** locations use solid gradient fills based on armor status
+- **AND** armor values are displayed as plain bold numbers
+- **AND** capacity is shown as small text (e.g., "/ 32")
+- **AND** torso locations show stacked front/rear sections
+- **AND** selected location shows simple border highlight
+
+### Requirement: Neon Operator Variant
+The system SHALL provide a Neon Operator design with sci-fi aesthetic.
+
+#### Scenario: Neon Operator visual elements
+- **WHEN** Neon Operator variant is active
+- **THEN** diagram uses wireframe outline style
+- **AND** locations use semi-transparent fills with glowing edges
+- **AND** armor values are surrounded by circular progress rings
+- **AND** a front/rear toggle switch is provided
+- **AND** hovering triggers glow pulse animation
+- **AND** scanline effects are applied as overlay
+
+### Requirement: Tactical HUD Variant
+The system SHALL provide a Tactical HUD design with military feel.
+
+#### Scenario: Tactical HUD visual elements
+- **WHEN** Tactical HUD variant is active
+- **THEN** diagram uses geometric/polygonal shapes
+- **AND** armor values use LED-style segmented display
+- **AND** locations show tank-fill style (bottom-up) fill indicator
+- **AND** horizontal bar gauges show capacity
+- **AND** front and rear views are shown side-by-side
+- **AND** corner brackets appear on hover/selection
+
+### Requirement: Premium Material Variant
+The system SHALL provide a Premium Material design with tactile feel.
+
+#### Scenario: Premium Material visual elements
+- **WHEN** Premium Material variant is active
+- **THEN** diagram uses realistic mech contour silhouette
+- **AND** locations use metallic/textured fills
+- **AND** armor values are displayed in circular badges
+- **AND** dot indicators show capacity (like battery level)
+- **AND** rear armor plates are layered behind front with 3D offset
+- **AND** hovering triggers lift/shadow effect
+
+### Requirement: Consistent Functionality
+All variants SHALL maintain identical armor management functionality.
+
+#### Scenario: Functional consistency
+- **GIVEN** any diagram variant is active
+- **WHEN** user interacts with the diagram
+- **THEN** clicking a location selects it for editing
+- **AND** armor values update in real-time
+- **AND** auto-allocate button functions identically
+- **AND** keyboard navigation works (Tab, Enter, Space)
+- **AND** ARIA labels are provided for accessibility
+
+### Requirement: Status Color Coding
+All variants SHALL use consistent color coding for armor status.
+
+#### Scenario: Status colors
+- **WHEN** armor is displayed on any variant
+- **THEN** 75-100% capacity shows green (#22c55e)
+- **AND** 50-74% capacity shows amber (#f59e0b)
+- **AND** 25-49% capacity shows orange (#f97316)
+- **AND** 0-24% capacity shows red (#ef4444)
+- **AND** selected location shows blue (#3b82f6)
+
+### Requirement: Variant Persistence
+The system SHALL persist the user's variant selection.
+
+#### Scenario: Selection persistence
+- **WHEN** user selects a diagram variant
+- **THEN** selection is saved to localStorage
+- **AND** selection is restored on page reload
+- **AND** selection applies across all customizer sessions
+
+## Component Reference
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| CleanTechDiagram | `armor/variants/CleanTechDiagram.tsx` | Clean Tech variant |
+| NeonOperatorDiagram | `armor/variants/NeonOperatorDiagram.tsx` | Neon Operator variant |
+| TacticalHUDDiagram | `armor/variants/TacticalHUDDiagram.tsx` | Tactical HUD variant |
+| PremiumMaterialDiagram | `armor/variants/PremiumMaterialDiagram.tsx` | Premium Material variant |
+| MechSilhouette | `armor/shared/MechSilhouette.tsx` | SVG path definitions |
+| ArmorFills | `armor/shared/ArmorFills.tsx` | Gradients and filters |
+
+## Shared Resources
+
+### Silhouette Types
+- `REALISTIC_SILHOUETTE` - Smooth curved mech shape
+- `GEOMETRIC_SILHOUETTE` - Angular polygonal shapes
+
+### SVG Filter Effects
+- `armor-glow` - Standard glow effect
+- `armor-neon-glow` - Strong neon glow for Neon Operator
+- `armor-lift-shadow` - Drop shadow for Premium Material
+- `armor-inner-shadow` - Depth effect
+- `armor-scanlines` - CRT scanline pattern
+- `armor-grid` - Technical grid overlay
+- `armor-carbon` - Carbon fiber texture
+- `armor-metallic` - Metallic gradient overlay

--- a/src/__tests__/components/customizer/armor/ArmorDiagram.test.tsx
+++ b/src/__tests__/components/customizer/armor/ArmorDiagram.test.tsx
@@ -70,7 +70,7 @@ describe('ArmorDiagram', () => {
   it('should display auto-allocate button when onAutoAllocate is provided', () => {
     render(<ArmorDiagram {...defaultProps} onAutoAllocate={jest.fn()} />);
     
-    expect(screen.getByText(/Auto-Allocate/i)).toBeInTheDocument();
+    expect(screen.getByText(/Auto Allocate/i)).toBeInTheDocument();
   });
 
   it('should call onAutoAllocate when button is clicked', async () => {
@@ -78,7 +78,7 @@ describe('ArmorDiagram', () => {
     const onAutoAllocate = jest.fn();
     render(<ArmorDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} />);
     
-    const autoAllocateButton = screen.getByText(/Auto-Allocate/i);
+    const autoAllocateButton = screen.getByText(/Auto Allocate/i);
     await user.click(autoAllocateButton);
     
     expect(onAutoAllocate).toHaveBeenCalledTimes(1);

--- a/src/__tests__/components/customizer/armor/LocationArmorEditor.test.tsx
+++ b/src/__tests__/components/customizer/armor/LocationArmorEditor.test.tsx
@@ -120,7 +120,7 @@ describe('LocationArmorEditor', () => {
     // Verify onChange was called (exact values vary due to intermediate calls during typing)
     expect(onChange).toHaveBeenCalled();
     // Last call should include rear value 5
-    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1] as [number, number];
     expect(lastCall[1]).toBe(5); // rear should be preserved
   });
 
@@ -144,7 +144,7 @@ describe('LocationArmorEditor', () => {
     // Verify onChange was called
     expect(onChange).toHaveBeenCalled();
     // Last call should have front value 20 preserved
-    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1] as [number, number];
     expect(lastCall[0]).toBe(20); // front should be preserved
   });
 

--- a/src/__tests__/components/customizer/armor/LocationArmorEditor.test.tsx
+++ b/src/__tests__/components/customizer/armor/LocationArmorEditor.test.tsx
@@ -19,117 +19,182 @@ describe('LocationArmorEditor', () => {
 
   it('should render location name', () => {
     render(<LocationArmorEditor {...defaultProps} />);
-    
+
     expect(screen.getByText(MechLocation.HEAD)).toBeInTheDocument();
   });
 
-  it('should render total armor input', () => {
+  it('should render front armor input for non-torso locations', () => {
     render(<LocationArmorEditor {...defaultProps} />);
-    
-    // Get the number input specifically (there's also a range input with the same value)
-    const totalInput = screen.getByRole('spinbutton');
-    expect(totalInput).toBeInTheDocument();
-    expect(totalInput).toHaveValue(9);
+
+    // Front label should be present for non-torso (though it may just show armor value)
+    const frontInput = screen.getByRole('spinbutton');
+    expect(frontInput).toBeInTheDocument();
+    expect(frontInput).toHaveValue(9);
   });
 
   it('should render max armor value', () => {
     render(<LocationArmorEditor {...defaultProps} />);
-    
-    expect(screen.getByText(/\/9/)).toBeInTheDocument();
+
+    // Total should show current and max
+    expect(screen.getByText(/\/ 9/)).toBeInTheDocument();
   });
 
-  it('should call onChange when total armor changes', async () => {
+  it('should call onChange when armor changes', async () => {
     const user = userEvent.setup();
     render(<LocationArmorEditor {...defaultProps} />);
-    
-    // Get the number input specifically
-    const totalInput = screen.getByRole('spinbutton');
-    await user.clear(totalInput);
-    await user.type(totalInput, '8');
-    
+
+    const armorInput = screen.getByRole('spinbutton');
+    await user.clear(armorInput);
+    await user.type(armorInput, '8');
+
     expect(defaultProps.onChange).toHaveBeenCalled();
   });
 
   it('should call onClose when close button is clicked', async () => {
     const user = userEvent.setup();
     render(<LocationArmorEditor {...defaultProps} />);
-    
-    // Find the close button by its role or by finding button with × icon
-    const buttons = screen.getAllByRole('button');
-    const closeButton = buttons.find(btn => 
-      btn.textContent?.includes('×') || 
-      btn.querySelector('svg') !== null ||
-      btn.getAttribute('aria-label')?.toLowerCase().includes('close')
-    ) || buttons[buttons.length - 1]; // Fallback to last button
-    
+
+    const closeButton = screen.getByRole('button', { name: /close/i });
     await user.click(closeButton);
-    
+
     expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('should show front/rear inputs for torso locations', () => {
+  it('should show front and rear inputs for torso locations', () => {
     render(
       <LocationArmorEditor
         {...defaultProps}
         location={MechLocation.CENTER_TORSO}
-        data={{ location: MechLocation.CENTER_TORSO, current: 20, maximum: 46, rear: 5 }}
+        data={{ location: MechLocation.CENTER_TORSO, current: 20, maximum: 46, rear: 5, rearMaximum: 26 }}
       />
     );
-    
-    expect(screen.getByText(/Front/i)).toBeInTheDocument();
-    expect(screen.getByText(/Rear/i)).toBeInTheDocument();
+
+    // Use getAllByText since there are multiple "Front" and "Rear" elements (label and legend)
+    expect(screen.getAllByText(/Front/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/Rear/i).length).toBeGreaterThanOrEqual(1);
   });
 
-  it('should not show front/rear inputs for non-torso locations', () => {
+  it('should not show rear input for non-torso locations', () => {
     render(<LocationArmorEditor {...defaultProps} location={MechLocation.HEAD} />);
-    
-    expect(screen.queryByText(/Front/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Rear/i)).not.toBeInTheDocument();
+
+    // Should have Front label but no Rear label
+    expect(screen.getByText('Front')).toBeInTheDocument();
+    // Non-torso locations should not show "Rear" as a section label
+    // (there may still be a Total section showing just front)
+    expect(screen.queryByText('Rear')).not.toBeInTheDocument();
   });
 
-  it('should call onChange with front and rear for torso locations', async () => {
-    const user = userEvent.setup();
+  it('should render two spinbutton inputs for torso locations', () => {
     render(
       <LocationArmorEditor
         {...defaultProps}
         location={MechLocation.CENTER_TORSO}
-        data={{ location: MechLocation.CENTER_TORSO, current: 20, maximum: 46, rear: 5 }}
+        data={{ location: MechLocation.CENTER_TORSO, current: 20, maximum: 46, rear: 5, rearMaximum: 26 }}
       />
     );
-    
-    const frontInputs = screen.getAllByDisplayValue('20');
-    const frontInput = frontInputs[frontInputs.length - 1]; // Get the front input
-    await user.clear(frontInput);
-    await user.type(frontInput, '22');
-    
-    expect(defaultProps.onChange).toHaveBeenCalled();
+
+    // Should have two number inputs - one for front, one for rear
+    const inputs = screen.getAllByRole('spinbutton');
+    expect(inputs.length).toBe(2);
+    expect(inputs[0]).toHaveValue(20); // front
+    expect(inputs[1]).toHaveValue(5);  // rear
   });
 
-  it('should disable inputs in read-only mode', () => {
-    render(<LocationArmorEditor {...defaultProps} readOnly={true} />);
-    
-    // Get the number input specifically
-    const totalInput = screen.getByRole('spinbutton');
-    expect(totalInput).toBeDisabled();
-  });
-
-  it('should call onChange when total armor changes via number input', async () => {
+  it('should call onChange when front value changes', async () => {
     const user = userEvent.setup();
     const onChange = jest.fn();
     render(
       <LocationArmorEditor
         {...defaultProps}
         onChange={onChange}
-        data={{ location: MechLocation.HEAD, current: 9, maximum: 9 }}
+        location={MechLocation.CENTER_TORSO}
+        data={{ location: MechLocation.CENTER_TORSO, current: 20, maximum: 46, rear: 5, rearMaximum: 26 }}
       />
     );
-    
-    // Get the number input specifically
-    const totalInput = screen.getByRole('spinbutton');
-    await user.clear(totalInput);
-    await user.type(totalInput, '8');
-    
+
+    const inputs = screen.getAllByRole('spinbutton');
+    const frontInput = inputs[0];
+    await user.clear(frontInput);
+    await user.type(frontInput, '22');
+
+    // Verify onChange was called (exact values vary due to intermediate calls during typing)
     expect(onChange).toHaveBeenCalled();
+    // Last call should include rear value 5
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+    expect(lastCall[1]).toBe(5); // rear should be preserved
+  });
+
+  it('should call onChange when rear value changes', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(
+      <LocationArmorEditor
+        {...defaultProps}
+        onChange={onChange}
+        location={MechLocation.CENTER_TORSO}
+        data={{ location: MechLocation.CENTER_TORSO, current: 20, maximum: 46, rear: 5, rearMaximum: 26 }}
+      />
+    );
+
+    const inputs = screen.getAllByRole('spinbutton');
+    const rearInput = inputs[1];
+    await user.clear(rearInput);
+    await user.type(rearInput, '8');
+
+    // Verify onChange was called
+    expect(onChange).toHaveBeenCalled();
+    // Last call should have front value 20 preserved
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+    expect(lastCall[0]).toBe(20); // front should be preserved
+  });
+
+  it('should disable inputs in read-only mode', () => {
+    render(<LocationArmorEditor {...defaultProps} readOnly={true} />);
+
+    const armorInput = screen.getByRole('spinbutton');
+    expect(armorInput).toBeDisabled();
+  });
+
+  it('should show total summary for torso locations', () => {
+    render(
+      <LocationArmorEditor
+        {...defaultProps}
+        location={MechLocation.CENTER_TORSO}
+        data={{ location: MechLocation.CENTER_TORSO, current: 20, maximum: 46, rear: 5, rearMaximum: 26 }}
+      />
+    );
+
+    // Total should be 25 (20 front + 5 rear)
+    expect(screen.getByText('25')).toBeInTheDocument();
+  });
+
+  it('should show max values for front and rear', () => {
+    render(
+      <LocationArmorEditor
+        {...defaultProps}
+        location={MechLocation.CENTER_TORSO}
+        data={{ location: MechLocation.CENTER_TORSO, current: 20, maximum: 46, rear: 5, rearMaximum: 26 }}
+      />
+    );
+
+    // Should show "max X" indicators for both sliders
+    // The max for front is maxArmor - rear = 46 - 5 = 41 (but actual is calculated from tonnage)
+    // We just verify the "max" text appears
+    expect(screen.getAllByText(/max \d+/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should disable both inputs in read-only mode for torso', () => {
+    render(
+      <LocationArmorEditor
+        {...defaultProps}
+        readOnly={true}
+        location={MechLocation.CENTER_TORSO}
+        data={{ location: MechLocation.CENTER_TORSO, current: 20, maximum: 46, rear: 5, rearMaximum: 26 }}
+      />
+    );
+
+    const inputs = screen.getAllByRole('spinbutton');
+    expect(inputs[0]).toBeDisabled();
+    expect(inputs[1]).toBeDisabled();
   });
 });
-

--- a/src/__tests__/components/customizer/armor/variants/CleanTechDiagram.test.tsx
+++ b/src/__tests__/components/customizer/armor/variants/CleanTechDiagram.test.tsx
@@ -35,11 +35,11 @@ describe('CleanTechDiagram', () => {
   it('should render all 8 mech locations', () => {
     render(<CleanTechDiagram {...defaultProps} />);
 
-    // Check for location labels
+    // Check for location labels (torso locations show "X FRONT" format)
     expect(screen.getByText('HD')).toBeInTheDocument();
-    expect(screen.getByText('CT')).toBeInTheDocument();
-    expect(screen.getByText('LT')).toBeInTheDocument();
-    expect(screen.getByText('RT')).toBeInTheDocument();
+    expect(screen.getByText('CT FRONT')).toBeInTheDocument();
+    expect(screen.getByText('LT FRONT')).toBeInTheDocument();
+    expect(screen.getByText('RT FRONT')).toBeInTheDocument();
     expect(screen.getByText('LA')).toBeInTheDocument();
     expect(screen.getByText('RA')).toBeInTheDocument();
     expect(screen.getByText('LL')).toBeInTheDocument();
@@ -58,7 +58,7 @@ describe('CleanTechDiagram', () => {
     const onAutoAllocate = jest.fn();
     render(<CleanTechDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} />);
 
-    expect(screen.getByText(/Auto-Allocate/i)).toBeInTheDocument();
+    expect(screen.getByText(/Auto Allocate/i)).toBeInTheDocument();
     expect(screen.getByText(/12 pts/i)).toBeInTheDocument();
   });
 
@@ -67,7 +67,7 @@ describe('CleanTechDiagram', () => {
     const onAutoAllocate = jest.fn();
     render(<CleanTechDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} />);
 
-    await user.click(screen.getByText(/Auto-Allocate/i));
+    await user.click(screen.getByText(/Auto Allocate/i));
     expect(onAutoAllocate).toHaveBeenCalledTimes(1);
   });
 
@@ -86,8 +86,8 @@ describe('CleanTechDiagram', () => {
     render(<CleanTechDiagram {...defaultProps} />);
 
     expect(screen.getByText('75%+')).toBeInTheDocument();
-    expect(screen.getByText('50-74%')).toBeInTheDocument();
-    expect(screen.getByText('25-49%')).toBeInTheDocument();
+    expect(screen.getByText('50%+')).toBeInTheDocument();
+    expect(screen.getByText('25%+')).toBeInTheDocument();
     expect(screen.getByText('<25%')).toBeInTheDocument();
   });
 
@@ -113,7 +113,7 @@ describe('CleanTechDiagram', () => {
       />
     );
 
-    const button = screen.getByText(/Auto-Allocate/i);
+    const button = screen.getByText(/Auto Allocate/i);
     expect(button).toHaveClass('bg-red-600');
   });
 });

--- a/src/__tests__/components/customizer/armor/variants/CleanTechDiagram.test.tsx
+++ b/src/__tests__/components/customizer/armor/variants/CleanTechDiagram.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CleanTechDiagram } from '@/components/customizer/armor/variants/CleanTechDiagram';
+import { MechLocation } from '@/types/construction';
+
+describe('CleanTechDiagram', () => {
+  const mockArmorData = [
+    { location: MechLocation.HEAD, current: 9, maximum: 9 },
+    { location: MechLocation.CENTER_TORSO, current: 35, maximum: 47, rear: 12, rearMaximum: 23 },
+    { location: MechLocation.LEFT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.RIGHT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.LEFT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.RIGHT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.LEFT_LEG, current: 28, maximum: 32 },
+    { location: MechLocation.RIGHT_LEG, current: 28, maximum: 32 },
+  ];
+
+  const defaultProps = {
+    armorData: mockArmorData,
+    selectedLocation: null,
+    unallocatedPoints: 12,
+    onLocationClick: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the diagram with title', () => {
+    render(<CleanTechDiagram {...defaultProps} />);
+    expect(screen.getByText('Armor Allocation')).toBeInTheDocument();
+  });
+
+  it('should render all 8 mech locations', () => {
+    render(<CleanTechDiagram {...defaultProps} />);
+
+    // Check for location labels
+    expect(screen.getByText('HD')).toBeInTheDocument();
+    expect(screen.getByText('CT')).toBeInTheDocument();
+    expect(screen.getByText('LT')).toBeInTheDocument();
+    expect(screen.getByText('RT')).toBeInTheDocument();
+    expect(screen.getByText('LA')).toBeInTheDocument();
+    expect(screen.getByText('RA')).toBeInTheDocument();
+    expect(screen.getByText('LL')).toBeInTheDocument();
+    expect(screen.getByText('RL')).toBeInTheDocument();
+  });
+
+  it('should display armor values', () => {
+    render(<CleanTechDiagram {...defaultProps} />);
+
+    // Check for armor values
+    expect(screen.getByText('9')).toBeInTheDocument(); // Head
+    expect(screen.getByText('35')).toBeInTheDocument(); // CT front
+  });
+
+  it('should render auto-allocate button when onAutoAllocate is provided', () => {
+    const onAutoAllocate = jest.fn();
+    render(<CleanTechDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} />);
+
+    expect(screen.getByText(/Auto-Allocate/i)).toBeInTheDocument();
+    expect(screen.getByText(/12 pts/i)).toBeInTheDocument();
+  });
+
+  it('should call onAutoAllocate when button is clicked', async () => {
+    const user = userEvent.setup();
+    const onAutoAllocate = jest.fn();
+    render(<CleanTechDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} />);
+
+    await user.click(screen.getByText(/Auto-Allocate/i));
+    expect(onAutoAllocate).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onLocationClick when a location is clicked', async () => {
+    const user = userEvent.setup();
+    render(<CleanTechDiagram {...defaultProps} />);
+
+    // Click on Head location (the first button group)
+    const headGroup = screen.getByRole('button', { name: /Head armor/i });
+    await user.click(headGroup);
+
+    expect(defaultProps.onLocationClick).toHaveBeenCalledWith(MechLocation.HEAD);
+  });
+
+  it('should display legend with status colors', () => {
+    render(<CleanTechDiagram {...defaultProps} />);
+
+    expect(screen.getByText('75%+')).toBeInTheDocument();
+    expect(screen.getByText('50-74%')).toBeInTheDocument();
+    expect(screen.getByText('25-49%')).toBeInTheDocument();
+    expect(screen.getByText('<25%')).toBeInTheDocument();
+  });
+
+  it('should display instructions text', () => {
+    render(<CleanTechDiagram {...defaultProps} />);
+
+    expect(screen.getByText('Click a location to edit armor values')).toBeInTheDocument();
+  });
+
+  it('should apply custom className', () => {
+    const { container } = render(<CleanTechDiagram {...defaultProps} className="custom-class" />);
+
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  it('should show red button when over-allocated', () => {
+    const onAutoAllocate = jest.fn();
+    render(
+      <CleanTechDiagram
+        {...defaultProps}
+        unallocatedPoints={-5}
+        onAutoAllocate={onAutoAllocate}
+      />
+    );
+
+    const button = screen.getByText(/Auto-Allocate/i);
+    expect(button).toHaveClass('bg-red-600');
+  });
+});

--- a/src/__tests__/components/customizer/armor/variants/NeonOperatorDiagram.test.tsx
+++ b/src/__tests__/components/customizer/armor/variants/NeonOperatorDiagram.test.tsx
@@ -32,32 +32,21 @@ describe('NeonOperatorDiagram', () => {
     expect(screen.getByText('ARMOR STATUS')).toBeInTheDocument();
   });
 
-  it('should render front/rear toggle buttons', () => {
+  it('should render front/rear labels on torso locations', () => {
     render(<NeonOperatorDiagram {...defaultProps} />);
 
-    expect(screen.getByText('FRONT')).toBeInTheDocument();
-    expect(screen.getByText('REAR')).toBeInTheDocument();
-  });
-
-  it('should toggle between front and rear views', async () => {
-    const user = userEvent.setup();
-    render(<NeonOperatorDiagram {...defaultProps} />);
-
-    // Initially in front view
-    expect(screen.getByText('VIEW: FRONT')).toBeInTheDocument();
-
-    // Click rear button
-    await user.click(screen.getByText('REAR'));
-
-    // Should now show rear view
-    expect(screen.getByText('VIEW: REAR')).toBeInTheDocument();
+    // Torso locations have stacked front/rear with FRONT label
+    expect(screen.getByText('CT FRONT')).toBeInTheDocument();
+    // Multiple REAR labels for each torso
+    const rearLabels = screen.getAllByText('REAR');
+    expect(rearLabels.length).toBe(3);
   });
 
   it('should display auto button with unallocated points', () => {
     const onAutoAllocate = jest.fn();
     render(<NeonOperatorDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} />);
 
-    expect(screen.getByText(/AUTO \[12\]/i)).toBeInTheDocument();
+    expect(screen.getByText(/Auto Allocate \(12 pts\)/)).toBeInTheDocument();
   });
 
   it('should call onAutoAllocate when button is clicked', async () => {
@@ -65,7 +54,7 @@ describe('NeonOperatorDiagram', () => {
     const onAutoAllocate = jest.fn();
     render(<NeonOperatorDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} />);
 
-    await user.click(screen.getByText(/AUTO/i));
+    await user.click(screen.getByText(/Auto Allocate/));
     expect(onAutoAllocate).toHaveBeenCalledTimes(1);
   });
 
@@ -79,10 +68,9 @@ describe('NeonOperatorDiagram', () => {
     expect(defaultProps.onLocationClick).toHaveBeenCalledWith(MechLocation.HEAD);
   });
 
-  it('should display system status info', () => {
+  it('should display unallocated points info', () => {
     render(<NeonOperatorDiagram {...defaultProps} />);
 
-    expect(screen.getByText('SYS: ONLINE')).toBeInTheDocument();
     expect(screen.getByText('UNALLOC: 12')).toBeInTheDocument();
   });
 
@@ -96,18 +84,5 @@ describe('NeonOperatorDiagram', () => {
     const { container } = render(<NeonOperatorDiagram {...defaultProps} className="custom-class" />);
 
     expect(container.firstChild).toHaveClass('custom-class');
-  });
-
-  it('should show only torso locations in rear view', async () => {
-    const user = userEvent.setup();
-    render(<NeonOperatorDiagram {...defaultProps} />);
-
-    // Switch to rear view
-    await user.click(screen.getByText('REAR'));
-
-    // Rear view should show torso locations with R suffix
-    expect(screen.getByText('CTR')).toBeInTheDocument();
-    expect(screen.getByText('LTR')).toBeInTheDocument();
-    expect(screen.getByText('RTR')).toBeInTheDocument();
   });
 });

--- a/src/__tests__/components/customizer/armor/variants/NeonOperatorDiagram.test.tsx
+++ b/src/__tests__/components/customizer/armor/variants/NeonOperatorDiagram.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NeonOperatorDiagram } from '@/components/customizer/armor/variants/NeonOperatorDiagram';
+import { MechLocation } from '@/types/construction';
+
+describe('NeonOperatorDiagram', () => {
+  const mockArmorData = [
+    { location: MechLocation.HEAD, current: 9, maximum: 9 },
+    { location: MechLocation.CENTER_TORSO, current: 35, maximum: 47, rear: 12, rearMaximum: 23 },
+    { location: MechLocation.LEFT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.RIGHT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.LEFT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.RIGHT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.LEFT_LEG, current: 28, maximum: 32 },
+    { location: MechLocation.RIGHT_LEG, current: 28, maximum: 32 },
+  ];
+
+  const defaultProps = {
+    armorData: mockArmorData,
+    selectedLocation: null,
+    unallocatedPoints: 12,
+    onLocationClick: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the diagram with sci-fi title', () => {
+    render(<NeonOperatorDiagram {...defaultProps} />);
+    expect(screen.getByText('ARMOR STATUS')).toBeInTheDocument();
+  });
+
+  it('should render front/rear toggle buttons', () => {
+    render(<NeonOperatorDiagram {...defaultProps} />);
+
+    expect(screen.getByText('FRONT')).toBeInTheDocument();
+    expect(screen.getByText('REAR')).toBeInTheDocument();
+  });
+
+  it('should toggle between front and rear views', async () => {
+    const user = userEvent.setup();
+    render(<NeonOperatorDiagram {...defaultProps} />);
+
+    // Initially in front view
+    expect(screen.getByText('VIEW: FRONT')).toBeInTheDocument();
+
+    // Click rear button
+    await user.click(screen.getByText('REAR'));
+
+    // Should now show rear view
+    expect(screen.getByText('VIEW: REAR')).toBeInTheDocument();
+  });
+
+  it('should display auto button with unallocated points', () => {
+    const onAutoAllocate = jest.fn();
+    render(<NeonOperatorDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} />);
+
+    expect(screen.getByText(/AUTO \[12\]/i)).toBeInTheDocument();
+  });
+
+  it('should call onAutoAllocate when button is clicked', async () => {
+    const user = userEvent.setup();
+    const onAutoAllocate = jest.fn();
+    render(<NeonOperatorDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} />);
+
+    await user.click(screen.getByText(/AUTO/i));
+    expect(onAutoAllocate).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onLocationClick when a location is clicked', async () => {
+    const user = userEvent.setup();
+    render(<NeonOperatorDiagram {...defaultProps} />);
+
+    const headGroup = screen.getByRole('button', { name: /Head armor/i });
+    await user.click(headGroup);
+
+    expect(defaultProps.onLocationClick).toHaveBeenCalledWith(MechLocation.HEAD);
+  });
+
+  it('should display system status info', () => {
+    render(<NeonOperatorDiagram {...defaultProps} />);
+
+    expect(screen.getByText('SYS: ONLINE')).toBeInTheDocument();
+    expect(screen.getByText('UNALLOC: 12')).toBeInTheDocument();
+  });
+
+  it('should display targeting instruction', () => {
+    render(<NeonOperatorDiagram {...defaultProps} />);
+
+    expect(screen.getByText('SELECT TARGET LOCATION')).toBeInTheDocument();
+  });
+
+  it('should apply custom className', () => {
+    const { container } = render(<NeonOperatorDiagram {...defaultProps} className="custom-class" />);
+
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  it('should show only torso locations in rear view', async () => {
+    const user = userEvent.setup();
+    render(<NeonOperatorDiagram {...defaultProps} />);
+
+    // Switch to rear view
+    await user.click(screen.getByText('REAR'));
+
+    // Rear view should show torso locations with R suffix
+    expect(screen.getByText('CTR')).toBeInTheDocument();
+    expect(screen.getByText('LTR')).toBeInTheDocument();
+    expect(screen.getByText('RTR')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/customizer/armor/variants/PremiumMaterialDiagram.test.tsx
+++ b/src/__tests__/components/customizer/armor/variants/PremiumMaterialDiagram.test.tsx
@@ -36,9 +36,7 @@ describe('PremiumMaterialDiagram', () => {
     const onAutoAllocate = jest.fn();
     render(<PremiumMaterialDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} unallocatedPoints={55} />);
 
-    expect(screen.getByText('Auto-Allocate')).toBeInTheDocument();
-    // Use a unique unallocatedPoints value to avoid collision with armor values
-    expect(screen.getByText('55')).toBeInTheDocument();
+    expect(screen.getByText(/Auto Allocate \(55 pts\)/)).toBeInTheDocument();
   });
 
   it('should call onAutoAllocate when button is clicked', async () => {
@@ -46,16 +44,17 @@ describe('PremiumMaterialDiagram', () => {
     const onAutoAllocate = jest.fn();
     render(<PremiumMaterialDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} />);
 
-    await user.click(screen.getByText('Auto-Allocate'));
+    await user.click(screen.getByText(/Auto Allocate/));
     expect(onAutoAllocate).toHaveBeenCalledTimes(1);
   });
 
   it('should display legend with status indicators', () => {
     render(<PremiumMaterialDiagram {...defaultProps} />);
 
-    expect(screen.getByText('Optimal')).toBeInTheDocument();
-    expect(screen.getByText('Moderate')).toBeInTheDocument();
-    expect(screen.getByText('Critical')).toBeInTheDocument();
+    expect(screen.getByText('75%+')).toBeInTheDocument();
+    expect(screen.getByText('50%+')).toBeInTheDocument();
+    expect(screen.getByText('25%+')).toBeInTheDocument();
+    expect(screen.getByText('<25%')).toBeInTheDocument();
   });
 
   it('should display instruction text', () => {
@@ -83,11 +82,11 @@ describe('PremiumMaterialDiagram', () => {
   it('should render all 8 mech locations', () => {
     render(<PremiumMaterialDiagram {...defaultProps} />);
 
-    // Check for location labels
+    // Check for location labels (torso locations show "X FRONT" format)
     expect(screen.getByText('HD')).toBeInTheDocument();
-    expect(screen.getByText('CT')).toBeInTheDocument();
-    expect(screen.getByText('LT')).toBeInTheDocument();
-    expect(screen.getByText('RT')).toBeInTheDocument();
+    expect(screen.getByText('CT FRONT')).toBeInTheDocument();
+    expect(screen.getByText('LT FRONT')).toBeInTheDocument();
+    expect(screen.getByText('RT FRONT')).toBeInTheDocument();
     expect(screen.getByText('LA')).toBeInTheDocument();
     expect(screen.getByText('RA')).toBeInTheDocument();
     expect(screen.getByText('LL')).toBeInTheDocument();
@@ -97,9 +96,8 @@ describe('PremiumMaterialDiagram', () => {
   it('should display rear armor labels for torso locations', () => {
     render(<PremiumMaterialDiagram {...defaultProps} />);
 
-    // Check for rear labels
-    expect(screen.getByText('CT REAR')).toBeInTheDocument();
-    expect(screen.getByText('LT REAR')).toBeInTheDocument();
-    expect(screen.getByText('RT REAR')).toBeInTheDocument();
+    // Check for rear labels (3 torso locations have REAR labels)
+    const rearLabels = screen.getAllByText('REAR');
+    expect(rearLabels.length).toBe(3);
   });
 });

--- a/src/__tests__/components/customizer/armor/variants/PremiumMaterialDiagram.test.tsx
+++ b/src/__tests__/components/customizer/armor/variants/PremiumMaterialDiagram.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PremiumMaterialDiagram } from '@/components/customizer/armor/variants/PremiumMaterialDiagram';
+import { MechLocation } from '@/types/construction';
+
+describe('PremiumMaterialDiagram', () => {
+  const mockArmorData = [
+    { location: MechLocation.HEAD, current: 9, maximum: 9 },
+    { location: MechLocation.CENTER_TORSO, current: 35, maximum: 47, rear: 12, rearMaximum: 23 },
+    { location: MechLocation.LEFT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.RIGHT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.LEFT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.RIGHT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.LEFT_LEG, current: 28, maximum: 32 },
+    { location: MechLocation.RIGHT_LEG, current: 28, maximum: 32 },
+  ];
+
+  const defaultProps = {
+    armorData: mockArmorData,
+    selectedLocation: null,
+    unallocatedPoints: 12,
+    onLocationClick: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the diagram with title', () => {
+    render(<PremiumMaterialDiagram {...defaultProps} />);
+    expect(screen.getByText('Armor Configuration')).toBeInTheDocument();
+  });
+
+  it('should render auto-allocate button with points', () => {
+    const onAutoAllocate = jest.fn();
+    render(<PremiumMaterialDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} unallocatedPoints={55} />);
+
+    expect(screen.getByText('Auto-Allocate')).toBeInTheDocument();
+    // Use a unique unallocatedPoints value to avoid collision with armor values
+    expect(screen.getByText('55')).toBeInTheDocument();
+  });
+
+  it('should call onAutoAllocate when button is clicked', async () => {
+    const user = userEvent.setup();
+    const onAutoAllocate = jest.fn();
+    render(<PremiumMaterialDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} />);
+
+    await user.click(screen.getByText('Auto-Allocate'));
+    expect(onAutoAllocate).toHaveBeenCalledTimes(1);
+  });
+
+  it('should display legend with status indicators', () => {
+    render(<PremiumMaterialDiagram {...defaultProps} />);
+
+    expect(screen.getByText('Optimal')).toBeInTheDocument();
+    expect(screen.getByText('Moderate')).toBeInTheDocument();
+    expect(screen.getByText('Critical')).toBeInTheDocument();
+  });
+
+  it('should display instruction text', () => {
+    render(<PremiumMaterialDiagram {...defaultProps} />);
+
+    expect(screen.getByText('Tap any plate to adjust armor values')).toBeInTheDocument();
+  });
+
+  it('should call onLocationClick when a location is clicked', async () => {
+    const user = userEvent.setup();
+    render(<PremiumMaterialDiagram {...defaultProps} />);
+
+    const headGroup = screen.getByRole('button', { name: /Head armor/i });
+    await user.click(headGroup);
+
+    expect(defaultProps.onLocationClick).toHaveBeenCalledWith(MechLocation.HEAD);
+  });
+
+  it('should apply custom className', () => {
+    const { container } = render(<PremiumMaterialDiagram {...defaultProps} className="custom-class" />);
+
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  it('should render all 8 mech locations', () => {
+    render(<PremiumMaterialDiagram {...defaultProps} />);
+
+    // Check for location labels
+    expect(screen.getByText('HD')).toBeInTheDocument();
+    expect(screen.getByText('CT')).toBeInTheDocument();
+    expect(screen.getByText('LT')).toBeInTheDocument();
+    expect(screen.getByText('RT')).toBeInTheDocument();
+    expect(screen.getByText('LA')).toBeInTheDocument();
+    expect(screen.getByText('RA')).toBeInTheDocument();
+    expect(screen.getByText('LL')).toBeInTheDocument();
+    expect(screen.getByText('RL')).toBeInTheDocument();
+  });
+
+  it('should display rear armor labels for torso locations', () => {
+    render(<PremiumMaterialDiagram {...defaultProps} />);
+
+    // Check for rear labels
+    expect(screen.getByText('CT REAR')).toBeInTheDocument();
+    expect(screen.getByText('LT REAR')).toBeInTheDocument();
+    expect(screen.getByText('RT REAR')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/customizer/armor/variants/TacticalHUDDiagram.test.tsx
+++ b/src/__tests__/components/customizer/armor/variants/TacticalHUDDiagram.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TacticalHUDDiagram } from '@/components/customizer/armor/variants/TacticalHUDDiagram';
+import { MechLocation } from '@/types/construction';
+
+describe('TacticalHUDDiagram', () => {
+  const mockArmorData = [
+    { location: MechLocation.HEAD, current: 9, maximum: 9 },
+    { location: MechLocation.CENTER_TORSO, current: 35, maximum: 47, rear: 12, rearMaximum: 23 },
+    { location: MechLocation.LEFT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.RIGHT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.LEFT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.RIGHT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.LEFT_LEG, current: 28, maximum: 32 },
+    { location: MechLocation.RIGHT_LEG, current: 28, maximum: 32 },
+  ];
+
+  const defaultProps = {
+    armorData: mockArmorData,
+    selectedLocation: null,
+    unallocatedPoints: 12,
+    onLocationClick: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the diagram with military title', () => {
+    render(<TacticalHUDDiagram {...defaultProps} />);
+    expect(screen.getByText('ARMOR DIAGNOSTIC')).toBeInTheDocument();
+  });
+
+  it('should display front and rear view labels', () => {
+    render(<TacticalHUDDiagram {...defaultProps} />);
+
+    expect(screen.getByText('[ FRONT VIEW ]')).toBeInTheDocument();
+    expect(screen.getByText('[ REAR VIEW ]')).toBeInTheDocument();
+  });
+
+  it('should render auto-alloc button with points', () => {
+    const onAutoAllocate = jest.fn();
+    render(<TacticalHUDDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} />);
+
+    expect(screen.getByText(/AUTO-ALLOC \[\+12\]/i)).toBeInTheDocument();
+  });
+
+  it('should call onAutoAllocate when button is clicked', async () => {
+    const user = userEvent.setup();
+    const onAutoAllocate = jest.fn();
+    render(<TacticalHUDDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} />);
+
+    await user.click(screen.getByText(/AUTO-ALLOC/i));
+    expect(onAutoAllocate).toHaveBeenCalledTimes(1);
+  });
+
+  it('should display status readout', () => {
+    render(<TacticalHUDDiagram {...defaultProps} />);
+
+    expect(screen.getByText('STATUS:')).toBeInTheDocument();
+    expect(screen.getByText('NOMINAL')).toBeInTheDocument();
+    expect(screen.getByText('AVAIL:')).toBeInTheDocument();
+  });
+
+  it('should show OVERALLOC status when negative points', () => {
+    render(<TacticalHUDDiagram {...defaultProps} unallocatedPoints={-5} />);
+
+    expect(screen.getByText('OVERALLOC')).toBeInTheDocument();
+  });
+
+  it('should display instruction text', () => {
+    render(<TacticalHUDDiagram {...defaultProps} />);
+
+    expect(screen.getByText('SELECT LOCATION TO MODIFY')).toBeInTheDocument();
+  });
+
+  it('should call onLocationClick when a location is clicked', async () => {
+    const user = userEvent.setup();
+    render(<TacticalHUDDiagram {...defaultProps} />);
+
+    const headGroup = screen.getByRole('button', { name: /Head armor/i });
+    await user.click(headGroup);
+
+    expect(defaultProps.onLocationClick).toHaveBeenCalledWith(MechLocation.HEAD);
+  });
+
+  it('should apply custom className', () => {
+    const { container } = render(<TacticalHUDDiagram {...defaultProps} className="custom-class" />);
+
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  it('should show online indicator', () => {
+    const { container } = render(<TacticalHUDDiagram {...defaultProps} />);
+
+    // Check for the animated pulse indicator
+    const indicator = container.querySelector('.animate-pulse');
+    expect(indicator).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/customizer/armor/variants/TacticalHUDDiagram.test.tsx
+++ b/src/__tests__/components/customizer/armor/variants/TacticalHUDDiagram.test.tsx
@@ -32,18 +32,19 @@ describe('TacticalHUDDiagram', () => {
     expect(screen.getByText('ARMOR DIAGNOSTIC')).toBeInTheDocument();
   });
 
-  it('should display front and rear view labels', () => {
+  it('should display front and rear labels on torso locations', () => {
     render(<TacticalHUDDiagram {...defaultProps} />);
 
-    expect(screen.getByText('[ FRONT VIEW ]')).toBeInTheDocument();
-    expect(screen.getByText('[ REAR VIEW ]')).toBeInTheDocument();
+    // Torso locations show stacked front/rear with "-F" and "-R" labels
+    expect(screen.getByText('CT-F')).toBeInTheDocument();
+    expect(screen.getByText('CT-R')).toBeInTheDocument();
   });
 
-  it('should render auto-alloc button with points', () => {
+  it('should render auto-allocate button with points', () => {
     const onAutoAllocate = jest.fn();
     render(<TacticalHUDDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} />);
 
-    expect(screen.getByText(/AUTO-ALLOC \[\+12\]/i)).toBeInTheDocument();
+    expect(screen.getByText(/Auto Allocate \(12 pts\)/)).toBeInTheDocument();
   });
 
   it('should call onAutoAllocate when button is clicked', async () => {
@@ -51,7 +52,7 @@ describe('TacticalHUDDiagram', () => {
     const onAutoAllocate = jest.fn();
     render(<TacticalHUDDiagram {...defaultProps} onAutoAllocate={onAutoAllocate} />);
 
-    await user.click(screen.getByText(/AUTO-ALLOC/i));
+    await user.click(screen.getByText(/Auto Allocate/));
     expect(onAutoAllocate).toHaveBeenCalledTimes(1);
   });
 

--- a/src/__tests__/components/customizer/tabs/ArmorTab.test.tsx
+++ b/src/__tests__/components/customizer/tabs/ArmorTab.test.tsx
@@ -47,6 +47,30 @@ jest.mock('@/components/customizer/armor/ArmorDiagram', () => ({
   ),
 }));
 
+// Mock the variant diagrams used by ArmorTab
+jest.mock('@/components/customizer/armor/variants', () => ({
+  CleanTechDiagram: ({ onLocationClick }: Pick<ArmorDiagramProps, 'onLocationClick'>) => (
+    <div data-testid="armor-diagram">
+      <button onClick={(): void => { (onLocationClick as (location: string) => void)('Head'); }}>Head</button>
+    </div>
+  ),
+  NeonOperatorDiagram: ({ onLocationClick }: Pick<ArmorDiagramProps, 'onLocationClick'>) => (
+    <div data-testid="armor-diagram">
+      <button onClick={(): void => { (onLocationClick as (location: string) => void)('Head'); }}>Head</button>
+    </div>
+  ),
+  TacticalHUDDiagram: ({ onLocationClick }: Pick<ArmorDiagramProps, 'onLocationClick'>) => (
+    <div data-testid="armor-diagram">
+      <button onClick={(): void => { (onLocationClick as (location: string) => void)('Head'); }}>Head</button>
+    </div>
+  ),
+  PremiumMaterialDiagram: ({ onLocationClick }: Pick<ArmorDiagramProps, 'onLocationClick'>) => (
+    <div data-testid="armor-diagram">
+      <button onClick={(): void => { (onLocationClick as (location: string) => void)('Head'); }}>Head</button>
+    </div>
+  ),
+}));
+
 jest.mock('@/components/customizer/armor/LocationArmorEditor', () => ({
   LocationArmorEditor: ({ onClose }: { onClose: () => void }) => (
     <div data-testid="location-armor-editor">

--- a/src/__tests__/stores/useAppSettingsStore.test.ts
+++ b/src/__tests__/stores/useAppSettingsStore.test.ts
@@ -1,0 +1,287 @@
+import { act, renderHook } from '@testing-library/react';
+import { useAppSettingsStore } from '@/stores/useAppSettingsStore';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+describe('useAppSettingsStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Reset store to defaults
+    const { result } = renderHook(() => useAppSettingsStore());
+    act(() => {
+      result.current.resetToDefaults();
+    });
+  });
+
+  describe('Default values', () => {
+    it('should have amber as default accent color', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+      expect(result.current.accentColor).toBe('amber');
+    });
+
+    it('should have medium as default font size', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+      expect(result.current.fontSize).toBe('medium');
+    });
+
+    it('should have full as default animation level', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+      expect(result.current.animationLevel).toBe('full');
+    });
+
+    it('should have clean-tech as default armor diagram variant', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+      expect(result.current.armorDiagramVariant).toBe('clean-tech');
+    });
+
+    it('should have showArmorDiagramSelector enabled by default', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+      expect(result.current.showArmorDiagramSelector).toBe(true);
+    });
+
+    it('should have compactMode disabled by default', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+      expect(result.current.compactMode).toBe(false);
+    });
+
+    it('should have confirmOnClose enabled by default', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+      expect(result.current.confirmOnClose).toBe(true);
+    });
+
+    it('should have showTooltips enabled by default', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+      expect(result.current.showTooltips).toBe(true);
+    });
+
+    it('should have highContrast disabled by default', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+      expect(result.current.highContrast).toBe(false);
+    });
+
+    it('should have reduceMotion disabled by default', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+      expect(result.current.reduceMotion).toBe(false);
+    });
+  });
+
+  describe('Accent color', () => {
+    it('should update accent color', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      act(() => {
+        result.current.setAccentColor('cyan');
+      });
+
+      expect(result.current.accentColor).toBe('cyan');
+    });
+
+    it('should accept all valid accent colors', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+      const colors = ['amber', 'cyan', 'emerald', 'rose', 'violet', 'blue'] as const;
+
+      colors.forEach((color) => {
+        act(() => {
+          result.current.setAccentColor(color);
+        });
+        expect(result.current.accentColor).toBe(color);
+      });
+    });
+  });
+
+  describe('Font size', () => {
+    it('should update font size', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      act(() => {
+        result.current.setFontSize('large');
+      });
+
+      expect(result.current.fontSize).toBe('large');
+    });
+
+    it('should accept all valid font sizes', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+      const sizes = ['small', 'medium', 'large'] as const;
+
+      sizes.forEach((size) => {
+        act(() => {
+          result.current.setFontSize(size);
+        });
+        expect(result.current.fontSize).toBe(size);
+      });
+    });
+  });
+
+  describe('Animation level', () => {
+    it('should update animation level', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      act(() => {
+        result.current.setAnimationLevel('reduced');
+      });
+
+      expect(result.current.animationLevel).toBe('reduced');
+    });
+
+    it('should accept all valid animation levels', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+      const levels = ['full', 'reduced', 'none'] as const;
+
+      levels.forEach((level) => {
+        act(() => {
+          result.current.setAnimationLevel(level);
+        });
+        expect(result.current.animationLevel).toBe(level);
+      });
+    });
+  });
+
+  describe('Armor diagram variant', () => {
+    it('should update armor diagram variant', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      act(() => {
+        result.current.setArmorDiagramVariant('neon-operator');
+      });
+
+      expect(result.current.armorDiagramVariant).toBe('neon-operator');
+    });
+
+    it('should accept all valid variants', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+      const variants = ['clean-tech', 'neon-operator', 'tactical-hud', 'premium-material'] as const;
+
+      variants.forEach((variant) => {
+        act(() => {
+          result.current.setArmorDiagramVariant(variant);
+        });
+        expect(result.current.armorDiagramVariant).toBe(variant);
+      });
+    });
+  });
+
+  describe('Boolean toggles', () => {
+    it('should toggle compact mode', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      act(() => {
+        result.current.setCompactMode(true);
+      });
+      expect(result.current.compactMode).toBe(true);
+
+      act(() => {
+        result.current.setCompactMode(false);
+      });
+      expect(result.current.compactMode).toBe(false);
+    });
+
+    it('should toggle sidebar default collapsed', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      act(() => {
+        result.current.setSidebarDefaultCollapsed(true);
+      });
+      expect(result.current.sidebarDefaultCollapsed).toBe(true);
+    });
+
+    it('should toggle confirm on close', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      act(() => {
+        result.current.setConfirmOnClose(false);
+      });
+      expect(result.current.confirmOnClose).toBe(false);
+    });
+
+    it('should toggle show tooltips', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      act(() => {
+        result.current.setShowTooltips(false);
+      });
+      expect(result.current.showTooltips).toBe(false);
+    });
+
+    it('should toggle high contrast', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      act(() => {
+        result.current.setHighContrast(true);
+      });
+      expect(result.current.highContrast).toBe(true);
+    });
+
+    it('should toggle reduce motion', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      act(() => {
+        result.current.setReduceMotion(true);
+      });
+      expect(result.current.reduceMotion).toBe(true);
+    });
+
+    it('should toggle show armor diagram selector', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      act(() => {
+        result.current.setShowArmorDiagramSelector(false);
+      });
+      expect(result.current.showArmorDiagramSelector).toBe(false);
+    });
+  });
+
+  describe('Reset to defaults', () => {
+    it('should reset all settings to defaults', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      // Change multiple settings
+      act(() => {
+        result.current.setAccentColor('violet');
+        result.current.setFontSize('large');
+        result.current.setAnimationLevel('none');
+        result.current.setArmorDiagramVariant('tactical-hud');
+        result.current.setCompactMode(true);
+        result.current.setHighContrast(true);
+      });
+
+      // Verify changes
+      expect(result.current.accentColor).toBe('violet');
+      expect(result.current.fontSize).toBe('large');
+      expect(result.current.animationLevel).toBe('none');
+      expect(result.current.armorDiagramVariant).toBe('tactical-hud');
+      expect(result.current.compactMode).toBe(true);
+      expect(result.current.highContrast).toBe(true);
+
+      // Reset
+      act(() => {
+        result.current.resetToDefaults();
+      });
+
+      // Verify defaults
+      expect(result.current.accentColor).toBe('amber');
+      expect(result.current.fontSize).toBe('medium');
+      expect(result.current.animationLevel).toBe('full');
+      expect(result.current.armorDiagramVariant).toBe('clean-tech');
+      expect(result.current.compactMode).toBe(false);
+      expect(result.current.highContrast).toBe(false);
+    });
+  });
+});

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -121,13 +121,21 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, setIsCollapsed }) => {
   const toolsItems = [
     {
       href: '/customizer',
-      icon: <GearIcon />,
+      icon: <CustomizerIcon />,
       label: 'Customizer',
     },
     {
       href: '/compare',
       icon: <CompareIcon />,
       label: 'Compare',
+    },
+  ];
+
+  const settingsItems = [
+    {
+      href: '/settings',
+      icon: <GearIcon />,
+      label: 'Settings',
     },
   ];
 
@@ -214,6 +222,21 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, setIsCollapsed }) => {
             />
           ))}
         </NavSection>
+
+        {/* Divider */}
+        {!isCollapsed && <div className="mx-4 border-t border-slate-800 my-4" />}
+
+        {/* Settings Section */}
+        <NavSection isCollapsed={isCollapsed}>
+          {settingsItems.map((item) => (
+            <NavItem
+              key={item.href}
+              {...item}
+              isCollapsed={isCollapsed}
+              isActive={isPathActive(item.href)}
+            />
+          ))}
+        </NavSection>
       </nav>
 
       {/* Footer */}
@@ -283,6 +306,14 @@ function BookIcon() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
       <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
+    </svg>
+  );
+}
+
+function CustomizerIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z" />
     </svg>
   );
 }

--- a/src/components/customizer/armor/ArmorDiagram.tsx
+++ b/src/components/customizer/armor/ArmorDiagram.tsx
@@ -70,7 +70,7 @@ export function ArmorDiagram({
                 : 'bg-amber-600 hover:bg-amber-500 text-white'
             }`}
           >
-            Auto-Allocate ({unallocatedPoints} pts)
+            Auto Allocate ({unallocatedPoints} pts)
           </button>
         )}
       </div>

--- a/src/components/customizer/armor/ArmorDiagramPreview.tsx
+++ b/src/components/customizer/armor/ArmorDiagramPreview.tsx
@@ -55,7 +55,7 @@ export const DIAGRAM_VARIANT_INFO: Record<
       'Wireframe outline',
       'Neon glow effects',
       'Progress ring indicators',
-      'Toggle front/rear view',
+      'Stacked front/rear',
     ],
   },
   'tactical-hud': {
@@ -65,7 +65,7 @@ export const DIAGRAM_VARIANT_INFO: Record<
       'Geometric shapes',
       'LED number display',
       'Tank-fill gauges',
-      'Side-by-side views',
+      'Stacked front/rear',
     ],
   },
   'premium-material': {
@@ -75,7 +75,7 @@ export const DIAGRAM_VARIANT_INFO: Record<
       'Realistic contour',
       'Metallic textures',
       'Circular badges',
-      '3D layered plates',
+      'Stacked front/rear',
     ],
   },
 };
@@ -225,7 +225,7 @@ export function ArmorDiagramGridPreview({
               </div>
             )}
           </div>
-          <div className="transform scale-[0.65] origin-top-left h-[260px] overflow-hidden">
+          <div className="transform scale-[0.65] origin-top-left h-[340px] overflow-hidden">
             <ArmorDiagramPreview variant={variant} />
           </div>
         </div>

--- a/src/components/customizer/armor/ArmorDiagramPreview.tsx
+++ b/src/components/customizer/armor/ArmorDiagramPreview.tsx
@@ -1,0 +1,260 @@
+/**
+ * Armor Diagram Preview Component
+ *
+ * Shows a preview of armor diagram designs with sample data.
+ * Used in settings page to let users see design variants before selecting.
+ */
+
+import React, { useState } from 'react';
+import { MechLocation } from '@/types/construction';
+import { LocationArmorData } from './ArmorDiagram';
+import {
+  CleanTechDiagram,
+  NeonOperatorDiagram,
+  TacticalHUDDiagram,
+  PremiumMaterialDiagram,
+} from './variants';
+import { ArmorDiagramVariant } from '@/stores/useAppSettingsStore';
+
+/**
+ * Sample armor data for preview
+ * Represents a typical 75-ton mech with varied armor allocation
+ */
+const SAMPLE_ARMOR_DATA: LocationArmorData[] = [
+  { location: MechLocation.HEAD, current: 9, maximum: 9 },
+  { location: MechLocation.CENTER_TORSO, current: 35, maximum: 47, rear: 12, rearMaximum: 23 },
+  { location: MechLocation.LEFT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+  { location: MechLocation.RIGHT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+  { location: MechLocation.LEFT_ARM, current: 20, maximum: 24 },
+  { location: MechLocation.RIGHT_ARM, current: 20, maximum: 24 },
+  { location: MechLocation.LEFT_LEG, current: 28, maximum: 32 },
+  { location: MechLocation.RIGHT_LEG, current: 28, maximum: 32 },
+];
+
+/**
+ * Variant metadata
+ */
+export const DIAGRAM_VARIANT_INFO: Record<
+  ArmorDiagramVariant,
+  { name: string; description: string; features: string[] }
+> = {
+  'clean-tech': {
+    name: 'Clean Tech',
+    description: 'Maximum readability with solid colors',
+    features: [
+      'Realistic mech silhouette',
+      'Solid gradient fills',
+      'Plain bold numbers',
+      'Stacked front/rear',
+    ],
+  },
+  'neon-operator': {
+    name: 'Neon Operator',
+    description: 'Sci-fi aesthetic with glowing effects',
+    features: [
+      'Wireframe outline',
+      'Neon glow effects',
+      'Progress ring indicators',
+      'Toggle front/rear view',
+    ],
+  },
+  'tactical-hud': {
+    name: 'Tactical HUD',
+    description: 'Military feel with LED displays',
+    features: [
+      'Geometric shapes',
+      'LED number display',
+      'Tank-fill gauges',
+      'Side-by-side views',
+    ],
+  },
+  'premium-material': {
+    name: 'Premium Material',
+    description: 'Metallic textures with 3D depth',
+    features: [
+      'Realistic contour',
+      'Metallic textures',
+      'Circular badges',
+      '3D layered plates',
+    ],
+  },
+};
+
+interface ArmorDiagramPreviewProps {
+  /** The variant to preview */
+  variant: ArmorDiagramVariant;
+  /** Optional: compact mode (smaller size) */
+  compact?: boolean;
+  /** Optional: show variant label */
+  showLabel?: boolean;
+  /** Optional: onClick handler for selection */
+  onClick?: () => void;
+  /** Optional: is this variant selected */
+  isSelected?: boolean;
+  /** Optional: additional className */
+  className?: string;
+}
+
+/**
+ * Single diagram preview with sample data
+ */
+export function ArmorDiagramPreview({
+  variant,
+  compact = false,
+  showLabel = false,
+  onClick,
+  isSelected = false,
+  className = '',
+}: ArmorDiagramPreviewProps): React.ReactElement {
+  const [selectedLocation, setSelectedLocation] = useState<MechLocation | null>(null);
+
+  const handleLocationClick = (location: MechLocation) => {
+    setSelectedLocation((prev) => (prev === location ? null : location));
+  };
+
+  // Common props for all diagrams
+  const diagramProps = {
+    armorData: SAMPLE_ARMOR_DATA,
+    selectedLocation,
+    unallocatedPoints: 12,
+    onLocationClick: handleLocationClick,
+    className: compact ? 'transform scale-90 origin-top' : '',
+  };
+
+  const renderDiagram = () => {
+    switch (variant) {
+      case 'clean-tech':
+        return <CleanTechDiagram {...diagramProps} />;
+      case 'neon-operator':
+        return <NeonOperatorDiagram {...diagramProps} />;
+      case 'tactical-hud':
+        return <TacticalHUDDiagram {...diagramProps} />;
+      case 'premium-material':
+        return <PremiumMaterialDiagram {...diagramProps} />;
+      default:
+        return <CleanTechDiagram {...diagramProps} />;
+    }
+  };
+
+  const info = DIAGRAM_VARIANT_INFO[variant];
+
+  return (
+    <div
+      className={`${className} ${onClick ? 'cursor-pointer' : ''}`}
+      onClick={onClick}
+    >
+      {showLabel && (
+        <div className="mb-2">
+          <div className="text-sm font-medium text-white">{info.name}</div>
+          <div className="text-xs text-slate-400">{info.description}</div>
+        </div>
+      )}
+      <div
+        className={`rounded-lg overflow-hidden transition-all ${
+          isSelected
+            ? 'ring-2 ring-amber-500 ring-offset-2 ring-offset-slate-900'
+            : onClick
+            ? 'hover:ring-2 hover:ring-slate-500 hover:ring-offset-2 hover:ring-offset-slate-900'
+            : ''
+        }`}
+      >
+        {renderDiagram()}
+      </div>
+    </div>
+  );
+}
+
+interface ArmorDiagramGridPreviewProps {
+  /** Currently selected variant */
+  selectedVariant: ArmorDiagramVariant;
+  /** Callback when a variant is selected */
+  onSelectVariant: (variant: ArmorDiagramVariant) => void;
+  /** Optional: className */
+  className?: string;
+}
+
+/**
+ * Grid showing all diagram variants for selection
+ */
+export function ArmorDiagramGridPreview({
+  selectedVariant,
+  onSelectVariant,
+  className = '',
+}: ArmorDiagramGridPreviewProps): React.ReactElement {
+  const variants: ArmorDiagramVariant[] = [
+    'clean-tech',
+    'neon-operator',
+    'tactical-hud',
+    'premium-material',
+  ];
+
+  return (
+    <div className={`grid grid-cols-1 lg:grid-cols-2 gap-4 ${className}`}>
+      {variants.map((variant) => (
+        <div
+          key={variant}
+          className={`p-3 rounded-lg border-2 transition-all cursor-pointer ${
+            selectedVariant === variant
+              ? 'border-amber-500 bg-amber-500/5'
+              : 'border-slate-700 hover:border-slate-600 bg-slate-800/30'
+          }`}
+          onClick={() => onSelectVariant(variant)}
+        >
+          <div className="flex items-center justify-between mb-2">
+            <div>
+              <div className="text-sm font-medium text-white">
+                {DIAGRAM_VARIANT_INFO[variant].name}
+              </div>
+              <div className="text-xs text-slate-400">
+                {DIAGRAM_VARIANT_INFO[variant].description}
+              </div>
+            </div>
+            {selectedVariant === variant && (
+              <div className="w-5 h-5 rounded-full bg-amber-500 flex items-center justify-center">
+                <svg
+                  className="w-3 h-3 text-white"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </div>
+            )}
+          </div>
+          <div className="transform scale-[0.65] origin-top-left h-[260px] overflow-hidden">
+            <ArmorDiagramPreview variant={variant} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Feature list for a variant
+ */
+export function ArmorDiagramFeatureList({
+  variant,
+}: {
+  variant: ArmorDiagramVariant;
+}): React.ReactElement {
+  const info = DIAGRAM_VARIANT_INFO[variant];
+
+  return (
+    <div className="space-y-1">
+      <div className="text-sm font-medium text-white">{info.name}</div>
+      <ul className="text-xs text-slate-400 space-y-0.5">
+        {info.features.map((feature, i) => (
+          <li key={i} className="flex items-center gap-1.5">
+            <span className="w-1 h-1 rounded-full bg-amber-500" />
+            {feature}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/customizer/armor/ArmorDiagramPreview.tsx
+++ b/src/components/customizer/armor/ArmorDiagramPreview.tsx
@@ -193,7 +193,7 @@ export function ArmorDiagramGridPreview({
       {variants.map((variant) => (
         <div
           key={variant}
-          className={`p-3 rounded-lg border-2 transition-all cursor-pointer ${
+          className={`p-3 rounded-lg border-2 transition-all cursor-pointer overflow-hidden ${
             selectedVariant === variant
               ? 'border-amber-500 bg-amber-500/5'
               : 'border-slate-700 hover:border-slate-600 bg-slate-800/30'
@@ -210,7 +210,7 @@ export function ArmorDiagramGridPreview({
               </div>
             </div>
             {selectedVariant === variant && (
-              <div className="w-5 h-5 rounded-full bg-amber-500 flex items-center justify-center">
+              <div className="w-5 h-5 rounded-full bg-amber-500 flex items-center justify-center flex-shrink-0">
                 <svg
                   className="w-3 h-3 text-white"
                   fill="currentColor"
@@ -225,8 +225,11 @@ export function ArmorDiagramGridPreview({
               </div>
             )}
           </div>
-          <div className="transform scale-[0.55] origin-top-left h-[300px]">
-            <ArmorDiagramPreview variant={variant} />
+          {/* Container sized to fit scaled content: ~320px * 0.5 = 160px wide, ~500px * 0.5 = 250px tall */}
+          <div className="relative h-[280px] overflow-hidden">
+            <div className="absolute top-0 left-1/2 -translate-x-1/2 origin-top scale-50">
+              <ArmorDiagramPreview variant={variant} />
+            </div>
           </div>
         </div>
       ))}

--- a/src/components/customizer/armor/ArmorDiagramPreview.tsx
+++ b/src/components/customizer/armor/ArmorDiagramPreview.tsx
@@ -225,7 +225,7 @@ export function ArmorDiagramGridPreview({
               </div>
             )}
           </div>
-          <div className="transform scale-[0.65] origin-top-left h-[340px] overflow-hidden">
+          <div className="transform scale-[0.55] origin-top-left h-[300px]">
             <ArmorDiagramPreview variant={variant} />
           </div>
         </div>

--- a/src/components/customizer/armor/ArmorDiagramQuickSettings.tsx
+++ b/src/components/customizer/armor/ArmorDiagramQuickSettings.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState, useRef, useEffect } from 'react';
+import Link from 'next/link';
 import { useAppSettingsStore, ArmorDiagramVariant } from '@/stores/useAppSettingsStore';
 import { DIAGRAM_VARIANT_INFO } from './ArmorDiagramPreview';
 
@@ -161,9 +162,9 @@ export function ArmorDiagramQuickSettings({ className = '' }: QuickSettingsProps
           <div className="px-4 py-2 border-t border-slate-700 bg-slate-800/50 rounded-b-lg">
             <p className="text-xs text-slate-500">
               More options in{' '}
-              <a href="/settings" className="text-amber-400 hover:underline">
+              <Link href="/settings" className="text-amber-400 hover:underline">
                 Settings
-              </a>
+              </Link>
             </p>
           </div>
         </div>

--- a/src/components/customizer/armor/ArmorDiagramQuickSettings.tsx
+++ b/src/components/customizer/armor/ArmorDiagramQuickSettings.tsx
@@ -1,0 +1,173 @@
+/**
+ * Armor Diagram Quick Settings
+ *
+ * Inline popup for quickly changing armor diagram variant
+ * without navigating to the settings page.
+ */
+
+import React, { useState, useRef, useEffect } from 'react';
+import { useAppSettingsStore, ArmorDiagramVariant } from '@/stores/useAppSettingsStore';
+import { DIAGRAM_VARIANT_INFO } from './ArmorDiagramPreview';
+
+interface QuickSettingsProps {
+  className?: string;
+}
+
+/**
+ * Gear icon button with popup for armor diagram settings
+ */
+export function ArmorDiagramQuickSettings({ className = '' }: QuickSettingsProps): React.ReactElement {
+  const [isOpen, setIsOpen] = useState(false);
+  const popupRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const armorDiagramVariant = useAppSettingsStore((s) => s.armorDiagramVariant);
+  const setArmorDiagramVariant = useAppSettingsStore((s) => s.setArmorDiagramVariant);
+
+  // Close popup when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        popupRef.current &&
+        !popupRef.current.contains(event.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [isOpen]);
+
+  // Close on escape key
+  useEffect(() => {
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      return () => document.removeEventListener('keydown', handleEscape);
+    }
+  }, [isOpen]);
+
+  const variants: ArmorDiagramVariant[] = [
+    'clean-tech',
+    'neon-operator',
+    'tactical-hud',
+    'premium-material',
+  ];
+
+  const handleSelectVariant = (variant: ArmorDiagramVariant) => {
+    setArmorDiagramVariant(variant);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className={`relative ${className}`}>
+      {/* Gear Button */}
+      <button
+        ref={buttonRef}
+        onClick={() => setIsOpen(!isOpen)}
+        className={`p-1.5 rounded-lg transition-colors ${
+          isOpen
+            ? 'bg-amber-500/20 text-amber-400'
+            : 'text-slate-400 hover:text-white hover:bg-slate-700'
+        }`}
+        title="Change diagram style"
+        aria-label="Diagram style settings"
+        aria-expanded={isOpen}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="w-5 h-5"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+          />
+        </svg>
+      </button>
+
+      {/* Popup */}
+      {isOpen && (
+        <div
+          ref={popupRef}
+          className="absolute right-0 top-full mt-2 w-72 bg-slate-800 rounded-lg border border-slate-700 shadow-xl z-50"
+        >
+          {/* Header */}
+          <div className="px-4 py-3 border-b border-slate-700">
+            <h4 className="text-sm font-semibold text-white">Diagram Style</h4>
+            <p className="text-xs text-slate-400 mt-0.5">
+              Choose how the armor diagram looks
+            </p>
+          </div>
+
+          {/* Variant Options */}
+          <div className="p-2">
+            {variants.map((variant) => {
+              const info = DIAGRAM_VARIANT_INFO[variant];
+              const isSelected = armorDiagramVariant === variant;
+
+              return (
+                <button
+                  key={variant}
+                  onClick={() => handleSelectVariant(variant)}
+                  className={`w-full text-left px-3 py-2.5 rounded-lg transition-colors ${
+                    isSelected
+                      ? 'bg-amber-500/20 text-amber-400'
+                      : 'hover:bg-slate-700 text-slate-300'
+                  }`}
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium text-sm">{info.name}</span>
+                    {isSelected && (
+                      <svg
+                        className="w-4 h-4 text-amber-400"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                      >
+                        <path
+                          fillRule="evenodd"
+                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                    )}
+                  </div>
+                  <p className="text-xs text-slate-400 mt-0.5">{info.description}</p>
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Footer */}
+          <div className="px-4 py-2 border-t border-slate-700 bg-slate-800/50 rounded-b-lg">
+            <p className="text-xs text-slate-500">
+              More options in{' '}
+              <a href="/settings" className="text-amber-400 hover:underline">
+                Settings
+              </a>
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/customizer/armor/ArmorDiagramSelector.tsx
+++ b/src/components/customizer/armor/ArmorDiagramSelector.tsx
@@ -1,0 +1,222 @@
+/**
+ * Armor Diagram Design Selector
+ *
+ * UAT component for switching between armor diagram design variants.
+ * Stores selection in localStorage for persistent testing.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { MechLocation } from '@/types/construction';
+import { LocationArmorData } from './ArmorDiagram';
+import {
+  CleanTechDiagram,
+  NeonOperatorDiagram,
+  TacticalHUDDiagram,
+  PremiumMaterialDiagram,
+} from './variants';
+
+export type DiagramVariant = 'clean-tech' | 'neon-operator' | 'tactical-hud' | 'premium-material';
+
+const STORAGE_KEY = 'mekstation-armor-diagram-variant';
+
+const VARIANT_INFO: Record<DiagramVariant, { name: string; description: string }> = {
+  'clean-tech': {
+    name: 'Clean Tech',
+    description: 'Maximum readability, solid colors, stacked front/rear',
+  },
+  'neon-operator': {
+    name: 'Neon Operator',
+    description: 'Sci-fi glow, progress rings, toggle front/rear',
+  },
+  'tactical-hud': {
+    name: 'Tactical HUD',
+    description: 'Military feel, LED numbers, side-by-side views',
+  },
+  'premium-material': {
+    name: 'Premium Material',
+    description: 'Metallic textures, 3D layered plates',
+  },
+};
+
+export interface ArmorDiagramSelectorProps {
+  armorData: LocationArmorData[];
+  selectedLocation: MechLocation | null;
+  unallocatedPoints: number;
+  onLocationClick: (location: MechLocation) => void;
+  onAutoAllocate?: () => void;
+  className?: string;
+  /** Show variant selector UI (defaults to true for UAT) */
+  showSelector?: boolean;
+  /** Force a specific variant (overrides user selection) */
+  forceVariant?: DiagramVariant;
+}
+
+/**
+ * Get stored variant preference
+ */
+function getStoredVariant(): DiagramVariant {
+  if (typeof window === 'undefined') return 'clean-tech';
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored && stored in VARIANT_INFO) {
+    return stored as DiagramVariant;
+  }
+  return 'clean-tech';
+}
+
+/**
+ * Store variant preference
+ */
+function setStoredVariant(variant: DiagramVariant): void {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, variant);
+  }
+}
+
+/**
+ * UAT Armor Diagram with design variant selector
+ */
+export function ArmorDiagramSelector({
+  armorData,
+  selectedLocation,
+  unallocatedPoints,
+  onLocationClick,
+  onAutoAllocate,
+  className = '',
+  showSelector = true,
+  forceVariant,
+}: ArmorDiagramSelectorProps): React.ReactElement {
+  const [variant, setVariant] = useState<DiagramVariant>('clean-tech');
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  // Load stored preference on mount
+  useEffect(() => {
+    if (!forceVariant) {
+      setVariant(getStoredVariant());
+    }
+  }, [forceVariant]);
+
+  // Handle variant change
+  const handleVariantChange = (newVariant: DiagramVariant) => {
+    setVariant(newVariant);
+    setStoredVariant(newVariant);
+    setIsDropdownOpen(false);
+  };
+
+  const activeVariant = forceVariant ?? variant;
+
+  // Common props for all diagrams
+  const diagramProps = {
+    armorData,
+    selectedLocation,
+    unallocatedPoints,
+    onLocationClick,
+    onAutoAllocate,
+    className: showSelector ? '' : className,
+  };
+
+  // Render the selected diagram variant
+  const renderDiagram = () => {
+    switch (activeVariant) {
+      case 'clean-tech':
+        return <CleanTechDiagram {...diagramProps} />;
+      case 'neon-operator':
+        return <NeonOperatorDiagram {...diagramProps} />;
+      case 'tactical-hud':
+        return <TacticalHUDDiagram {...diagramProps} />;
+      case 'premium-material':
+        return <PremiumMaterialDiagram {...diagramProps} />;
+      default:
+        return <CleanTechDiagram {...diagramProps} />;
+    }
+  };
+
+  if (!showSelector) {
+    return renderDiagram();
+  }
+
+  return (
+    <div className={`space-y-3 ${className}`}>
+      {/* Variant Selector */}
+      <div className="bg-slate-800/50 rounded-lg border border-slate-700 p-3">
+        <div className="flex items-center justify-between">
+          <div className="text-xs text-slate-400 font-medium">
+            UAT Design Testing
+          </div>
+          <div className="relative">
+            <button
+              onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+              className="flex items-center gap-2 px-3 py-1.5 bg-slate-700 hover:bg-slate-600 rounded text-sm text-white transition-colors"
+            >
+              <span>{VARIANT_INFO[activeVariant].name}</span>
+              <svg
+                className={`w-4 h-4 transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`}
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+
+            {isDropdownOpen && (
+              <div className="absolute right-0 mt-1 w-64 bg-slate-700 rounded-lg shadow-xl border border-slate-600 z-50">
+                {(Object.keys(VARIANT_INFO) as DiagramVariant[]).map((v) => (
+                  <button
+                    key={v}
+                    onClick={() => handleVariantChange(v)}
+                    className={`w-full text-left px-4 py-3 hover:bg-slate-600 transition-colors first:rounded-t-lg last:rounded-b-lg ${
+                      activeVariant === v ? 'bg-slate-600' : ''
+                    }`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium text-white">
+                        {VARIANT_INFO[v].name}
+                      </span>
+                      {activeVariant === v && (
+                        <svg className="w-4 h-4 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+                          <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                        </svg>
+                      )}
+                    </div>
+                    <p className="text-xs text-slate-400 mt-0.5">
+                      {VARIANT_INFO[v].description}
+                    </p>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Close dropdown when clicking outside */}
+      {isDropdownOpen && (
+        <div
+          className="fixed inset-0 z-40"
+          onClick={() => setIsDropdownOpen(false)}
+        />
+      )}
+
+      {/* Selected Diagram */}
+      {renderDiagram()}
+    </div>
+  );
+}
+
+/**
+ * Hook to get/set diagram variant preference
+ */
+export function useDiagramVariant(): [DiagramVariant, (v: DiagramVariant) => void] {
+  const [variant, setVariant] = useState<DiagramVariant>('clean-tech');
+
+  useEffect(() => {
+    setVariant(getStoredVariant());
+  }, []);
+
+  const updateVariant = (newVariant: DiagramVariant) => {
+    setVariant(newVariant);
+    setStoredVariant(newVariant);
+  };
+
+  return [variant, updateVariant];
+}

--- a/src/components/customizer/armor/LocationArmorEditor.tsx
+++ b/src/components/customizer/armor/LocationArmorEditor.tsx
@@ -1,10 +1,9 @@
 /**
  * Location Armor Editor Component
- * 
+ *
  * Compact panel for editing armor values on a selected location.
- * Full control over total, front, and rear armor values.
- * Visual split slider shows front (orange) vs rear (blue).
- * 
+ * Direct controls for front and rear armor with independent sliders.
+ *
  * @spec openspec/specs/armor-diagram/spec.md
  */
 
@@ -12,6 +11,7 @@ import React, { useCallback, useMemo } from 'react';
 import { MechLocation } from '@/types/construction/CriticalSlotAllocation';
 import { LocationArmorData } from './ArmorDiagram';
 import { getMaxArmorForLocation } from '@/utils/construction/armorCalculations';
+import { FRONT_ARMOR_COLOR, REAR_ARMOR_COLOR } from './shared/ArmorFills';
 
 // =============================================================================
 // Types
@@ -60,6 +60,7 @@ function getLocationName(location: MechLocation): string {
 
 /**
  * Compact editor panel for a single armor location
+ * Uses direct front/rear controls instead of split slider
  */
 export function LocationArmorEditor({
   location,
@@ -74,163 +75,156 @@ export function LocationArmorEditor({
     () => getMaxArmorForLocation(tonnage, location),
     [tonnage, location]
   );
-  
-  // Total armor pool for this location
-  const totalPool = data.current + (data.rear ?? 0);
-  
-  // Calculate percentages for the split slider
-  const frontPercent = totalPool > 0 ? (data.current / totalPool) * 100 : 75;
-  const rearPercent = totalPool > 0 ? ((data.rear ?? 0) / totalPool) * 100 : 25;
-  
+
+  const front = data.current;
+  const rear = data.rear ?? 0;
+  const total = front + rear;
+
+  // Calculate max for each slider (capped by what the other allows)
+  const maxFront = maxArmor - rear;
+  const maxRear = maxArmor - front;
+
   // Handlers
-  const handleTotalChange = useCallback((value: number) => {
-    const newTotal = Math.max(0, Math.min(value, maxArmor));
-    if (showRear) {
-      // Maintain front/rear ratio when changing total
-      const currentRatio = totalPool > 0 ? data.current / totalPool : 0.75;
-      const newFront = Math.round(newTotal * currentRatio);
-      const newRear = newTotal - newFront;
-      onChange(newFront, newRear);
-    } else {
-      onChange(newTotal);
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- data is a prop, not a ref; using data.current directly is intentional
-  }, [maxArmor, onChange, showRear, totalPool, data.current]);
-  
   const handleFrontChange = useCallback((value: number) => {
-    const rear = data.rear ?? 0;
-    // Front can go from 0 to maxArmor - rear
-    const maxFront = maxArmor - rear;
     const newFront = Math.max(0, Math.min(value, maxFront));
     onChange(newFront, showRear ? rear : undefined);
-  }, [maxArmor, onChange, showRear, data.rear]);
-  
+  }, [maxFront, onChange, showRear, rear]);
+
   const handleRearChange = useCallback((value: number) => {
-    // Rear can go from 0 to maxArmor - front
-    const maxRear = maxArmor - data.current;
     const newRear = Math.max(0, Math.min(value, maxRear));
-    onChange(data.current, newRear);
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- data is a prop, not a ref; using data.current directly is intentional
-  }, [maxArmor, onChange, data.current]);
-  
-  // Handle split slider - adjusts front within current total pool
-  const handleSplitChange = useCallback((value: number) => {
-    if (totalPool === 0) return;
-    const newFront = Math.max(0, Math.min(value, totalPool));
-    const newRear = totalPool - newFront;
-    onChange(newFront, newRear);
-  }, [totalPool, onChange]);
-  
+    onChange(front, newRear);
+  }, [maxRear, onChange, front]);
+
   // Common styles
-  const inputClass = "w-12 px-1 py-0.5 bg-slate-700 border border-slate-600 rounded text-white text-xs text-center [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none";
-  const labelClass = "text-[10px] font-medium uppercase w-10";
-  const sliderClass = "flex-1 h-2 bg-slate-600 rounded-lg appearance-none cursor-pointer";
+  const inputClass = "w-14 px-1.5 py-1 bg-slate-700 border border-slate-600 rounded text-white text-sm text-center font-medium [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none";
+  const labelClass = "text-xs font-semibold uppercase tracking-wide";
+  const sliderTrackClass = "flex-1 h-2 rounded-lg appearance-none cursor-pointer";
 
   return (
-    <div className="bg-slate-800 rounded-lg border border-slate-700 p-3" data-testid="location-armor-editor">
+    <div className="bg-slate-800 rounded-lg border border-slate-700 p-4" data-testid="location-armor-editor">
       {/* Header Row */}
-      <div className="flex items-center justify-between mb-2">
-        <h4 className="text-sm font-semibold text-white">{getLocationName(location)}</h4>
+      <div className="flex items-center justify-between mb-4">
+        <h4 className="text-base font-semibold text-white">{getLocationName(location)}</h4>
         <button
           onClick={onClose}
-          className="p-0.5 hover:bg-slate-700 rounded transition-colors"
+          className="p-1 hover:bg-slate-700 rounded transition-colors"
           aria-label="Close editor"
         >
-          <svg className="w-3.5 h-3.5 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg className="w-4 h-4 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
           </svg>
         </button>
       </div>
-      
-      {/* Total row with slider */}
-      <div className="flex items-center gap-2 mb-2">
-        <span className={`${labelClass} text-slate-300`}>Total</span>
-        <input
-          type="range"
-          min={0}
-          max={maxArmor}
-          value={totalPool}
-          onChange={(e) => handleTotalChange(parseInt(e.target.value, 10))}
-          disabled={readOnly}
-          className={`${sliderClass} accent-slate-400`}
-        />
-        <input
-          type="number"
-          value={totalPool}
-          onChange={(e) => handleTotalChange(parseInt(e.target.value, 10) || 0)}
-          disabled={readOnly}
-          min={0}
-          max={maxArmor}
-          className={inputClass}
-        />
-        <span className="text-[10px] text-slate-500">/{maxArmor}</span>
+
+      {/* Front Armor Control */}
+      <div className="mb-4">
+        <div className="flex items-center justify-between mb-1.5">
+          <span className={labelClass} style={{ color: FRONT_ARMOR_COLOR }}>Front</span>
+          <span className="text-xs text-slate-500">max {maxFront}</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <input
+            type="range"
+            min={0}
+            max={maxFront}
+            value={front}
+            onChange={(e) => handleFrontChange(parseInt(e.target.value, 10))}
+            disabled={readOnly}
+            className={sliderTrackClass}
+            style={{
+              background: `linear-gradient(to right, ${FRONT_ARMOR_COLOR} 0%, ${FRONT_ARMOR_COLOR} ${maxFront > 0 ? (front / maxFront) * 100 : 0}%, #475569 ${maxFront > 0 ? (front / maxFront) * 100 : 0}%, #475569 100%)`,
+            }}
+          />
+          <input
+            type="number"
+            value={front}
+            onChange={(e) => handleFrontChange(parseInt(e.target.value, 10) || 0)}
+            disabled={readOnly}
+            min={0}
+            max={maxFront}
+            className={inputClass}
+            style={{ borderColor: FRONT_ARMOR_COLOR }}
+          />
+        </div>
       </div>
-      
+
+      {/* Rear Armor Control (only for torso locations) */}
       {showRear && (
-        <>
-          {/* Split slider with visual front/rear display */}
-          <div className="mb-2">
-            <div className="flex items-center gap-2">
-              <span className={`${labelClass} text-slate-300`}>Split</span>
-              {/* Custom visual split bar */}
-              <div className="flex-1 relative">
-                {/* Background bar showing front (orange) and rear (blue) */}
-                <div className="h-3 rounded overflow-hidden flex">
-                  <div 
-                    className="bg-amber-500 transition-all"
-                    style={{ width: `${frontPercent}%` }}
-                  />
-                  <div 
-                    className="bg-sky-500 transition-all"
-                    style={{ width: `${rearPercent}%` }}
-                  />
-                </div>
-                {/* Invisible range input for interaction */}
-                <input
-                  type="range"
-                  min={0}
-                  max={totalPool}
-                  value={data.current}
-                  onChange={(e) => handleSplitChange(parseInt(e.target.value, 10))}
-                  disabled={readOnly || totalPool === 0}
-                  className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
-                />
-              </div>
-            </div>
+        <div className="mb-4">
+          <div className="flex items-center justify-between mb-1.5">
+            <span className={labelClass} style={{ color: REAR_ARMOR_COLOR }}>Rear</span>
+            <span className="text-xs text-slate-500">max {maxRear}</span>
           </div>
-          
-          {/* Front/Rear number inputs */}
           <div className="flex items-center gap-3">
-            {/* Front */}
-            <div className="flex items-center gap-1.5">
-              <span className={`${labelClass} text-amber-400`}>Front</span>
-              <input
-                type="number"
-                value={data.current}
-                onChange={(e) => handleFrontChange(parseInt(e.target.value, 10) || 0)}
-                disabled={readOnly}
-                min={0}
-                max={maxArmor - (data.rear ?? 0)}
-                className={inputClass}
-              />
+            <input
+              type="range"
+              min={0}
+              max={maxRear}
+              value={rear}
+              onChange={(e) => handleRearChange(parseInt(e.target.value, 10))}
+              disabled={readOnly}
+              className={sliderTrackClass}
+              style={{
+                background: `linear-gradient(to right, ${REAR_ARMOR_COLOR} 0%, ${REAR_ARMOR_COLOR} ${maxRear > 0 ? (rear / maxRear) * 100 : 0}%, #475569 ${maxRear > 0 ? (rear / maxRear) * 100 : 0}%, #475569 100%)`,
+              }}
+            />
+            <input
+              type="number"
+              value={rear}
+              onChange={(e) => handleRearChange(parseInt(e.target.value, 10) || 0)}
+              disabled={readOnly}
+              min={0}
+              max={maxRear}
+              className={inputClass}
+              style={{ borderColor: REAR_ARMOR_COLOR }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Total Summary Bar */}
+      <div className="pt-3 border-t border-slate-700">
+        <div className="flex items-center justify-between mb-1.5">
+          <span className="text-xs font-medium text-slate-400 uppercase tracking-wide">Total</span>
+          <span className="text-sm font-semibold text-white">
+            {total} <span className="text-slate-500 font-normal">/ {maxArmor}</span>
+          </span>
+        </div>
+        {/* Visual bar showing total allocation */}
+        <div className="h-2 bg-slate-700 rounded-full overflow-hidden flex">
+          {/* Front portion */}
+          <div
+            className="h-full transition-all duration-150"
+            style={{
+              width: `${maxArmor > 0 ? (front / maxArmor) * 100 : 0}%`,
+              backgroundColor: FRONT_ARMOR_COLOR,
+            }}
+          />
+          {/* Rear portion */}
+          {showRear && (
+            <div
+              className="h-full transition-all duration-150"
+              style={{
+                width: `${maxArmor > 0 ? (rear / maxArmor) * 100 : 0}%`,
+                backgroundColor: REAR_ARMOR_COLOR,
+              }}
+            />
+          )}
+        </div>
+        {/* Legend for torso */}
+        {showRear && (
+          <div className="flex items-center justify-center gap-4 mt-2 text-xs">
+            <div className="flex items-center gap-1">
+              <div className="w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: FRONT_ARMOR_COLOR }} />
+              <span className="text-slate-400">Front ({front})</span>
             </div>
-            
-            {/* Rear */}
-            <div className="flex items-center gap-1.5">
-              <span className={`${labelClass} text-sky-400`}>Rear</span>
-              <input
-                type="number"
-                value={data.rear ?? 0}
-                onChange={(e) => handleRearChange(parseInt(e.target.value, 10) || 0)}
-                disabled={readOnly}
-                min={0}
-                max={maxArmor - data.current}
-                className={inputClass}
-              />
+            <div className="flex items-center gap-1">
+              <div className="w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: REAR_ARMOR_COLOR }} />
+              <span className="text-slate-400">Rear ({rear})</span>
             </div>
           </div>
-        </>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/customizer/armor/shared/ArmorFills.tsx
+++ b/src/components/customizer/armor/shared/ArmorFills.tsx
@@ -20,6 +20,12 @@ export const SELECTED_COLOR = '#3b82f6';        // blue-500
 export const SELECTED_STROKE = '#60a5fa';       // blue-400
 export const HOVER_LIGHTEN = 0.15;
 
+// Front/Rear armor colors for consistent UI
+export const FRONT_ARMOR_COLOR = '#f59e0b';     // amber-500
+export const REAR_ARMOR_COLOR = '#0ea5e9';      // sky-500
+export const FRONT_ARMOR_LIGHT = '#fbbf24';     // amber-400
+export const REAR_ARMOR_LIGHT = '#38bdf8';      // sky-400
+
 /**
  * Get status color based on armor percentage
  */
@@ -117,6 +123,18 @@ export function GradientDefs(): React.ReactElement {
       <linearGradient id="armor-gradient-selected" x1="0%" y1="0%" x2="0%" y2="100%">
         <stop offset="0%" stopColor="#60a5fa" />
         <stop offset="100%" stopColor="#2563eb" />
+      </linearGradient>
+
+      {/* Front armor gradient (amber) */}
+      <linearGradient id="armor-gradient-front" x1="0%" y1="0%" x2="0%" y2="100%">
+        <stop offset="0%" stopColor="#fbbf24" />
+        <stop offset="100%" stopColor="#d97706" />
+      </linearGradient>
+
+      {/* Rear armor gradient (sky blue) */}
+      <linearGradient id="armor-gradient-rear" x1="0%" y1="0%" x2="0%" y2="100%">
+        <stop offset="0%" stopColor="#38bdf8" />
+        <stop offset="100%" stopColor="#0284c7" />
       </linearGradient>
 
       {/* Metallic effect */}

--- a/src/components/customizer/armor/shared/ArmorFills.tsx
+++ b/src/components/customizer/armor/shared/ArmorFills.tsx
@@ -1,0 +1,222 @@
+/**
+ * Armor Fill Styles and Gradients
+ *
+ * SVG definitions for various fill styles used by armor diagrams.
+ */
+
+import React from 'react';
+
+/**
+ * Status thresholds for armor coloring
+ */
+export const ARMOR_STATUS = {
+  HEALTHY: { min: 0.75, color: '#22c55e' },    // green-500
+  MODERATE: { min: 0.5, color: '#f59e0b' },    // amber-500
+  LOW: { min: 0.25, color: '#f97316' },        // orange-500
+  CRITICAL: { min: 0, color: '#ef4444' },      // red-500
+} as const;
+
+export const SELECTED_COLOR = '#3b82f6';        // blue-500
+export const SELECTED_STROKE = '#60a5fa';       // blue-400
+export const HOVER_LIGHTEN = 0.15;
+
+/**
+ * Get status color based on armor percentage
+ */
+export function getArmorStatusColor(current: number, maximum: number): string {
+  if (maximum === 0) return ARMOR_STATUS.CRITICAL.color;
+  const ratio = current / maximum;
+
+  if (ratio >= ARMOR_STATUS.HEALTHY.min) return ARMOR_STATUS.HEALTHY.color;
+  if (ratio >= ARMOR_STATUS.MODERATE.min) return ARMOR_STATUS.MODERATE.color;
+  if (ratio >= ARMOR_STATUS.LOW.min) return ARMOR_STATUS.LOW.color;
+  return ARMOR_STATUS.CRITICAL.color;
+}
+
+/**
+ * Get status color for a torso location based on total (front + rear) armor
+ * For non-torso locations, use getArmorStatusColor instead
+ */
+export function getTorsoStatusColor(
+  frontCurrent: number,
+  frontMax: number,
+  rearCurrent: number = 0
+): string {
+  // Total max is frontMax (which is the full location max)
+  // Total current is front + rear
+  const totalCurrent = frontCurrent + rearCurrent;
+  const totalMax = frontMax;
+
+  return getArmorStatusColor(totalCurrent, totalMax);
+}
+
+/**
+ * Calculate fill percentage for a torso location based on total (front + rear)
+ */
+export function getTorsoFillPercent(
+  frontCurrent: number,
+  frontMax: number,
+  rearCurrent: number = 0
+): number {
+  const totalCurrent = frontCurrent + rearCurrent;
+  const totalMax = frontMax;
+
+  if (totalMax === 0) return 0;
+  return Math.min(100, (totalCurrent / totalMax) * 100);
+}
+
+/**
+ * Lighten a hex color
+ */
+export function lightenColor(hex: string, amount: number): string {
+  const num = parseInt(hex.replace('#', ''), 16);
+  const r = Math.min(255, ((num >> 16) & 0xff) + Math.round(255 * amount));
+  const g = Math.min(255, ((num >> 8) & 0xff) + Math.round(255 * amount));
+  const b = Math.min(255, (num & 0xff) + Math.round(255 * amount));
+  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, '0')}`;
+}
+
+/**
+ * Darken a hex color
+ */
+export function darkenColor(hex: string, amount: number): string {
+  const num = parseInt(hex.replace('#', ''), 16);
+  const r = Math.max(0, ((num >> 16) & 0xff) - Math.round(255 * amount));
+  const g = Math.max(0, ((num >> 8) & 0xff) - Math.round(255 * amount));
+  const b = Math.max(0, (num & 0xff) - Math.round(255 * amount));
+  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, '0')}`;
+}
+
+/**
+ * SVG Definitions for gradient fills
+ */
+export function GradientDefs(): React.ReactElement {
+  return (
+    <defs>
+      {/* Solid status gradients */}
+      <linearGradient id="armor-gradient-healthy" x1="0%" y1="0%" x2="0%" y2="100%">
+        <stop offset="0%" stopColor="#4ade80" />
+        <stop offset="100%" stopColor="#16a34a" />
+      </linearGradient>
+
+      <linearGradient id="armor-gradient-moderate" x1="0%" y1="0%" x2="0%" y2="100%">
+        <stop offset="0%" stopColor="#fbbf24" />
+        <stop offset="100%" stopColor="#d97706" />
+      </linearGradient>
+
+      <linearGradient id="armor-gradient-low" x1="0%" y1="0%" x2="0%" y2="100%">
+        <stop offset="0%" stopColor="#fb923c" />
+        <stop offset="100%" stopColor="#ea580c" />
+      </linearGradient>
+
+      <linearGradient id="armor-gradient-critical" x1="0%" y1="0%" x2="0%" y2="100%">
+        <stop offset="0%" stopColor="#f87171" />
+        <stop offset="100%" stopColor="#dc2626" />
+      </linearGradient>
+
+      <linearGradient id="armor-gradient-selected" x1="0%" y1="0%" x2="0%" y2="100%">
+        <stop offset="0%" stopColor="#60a5fa" />
+        <stop offset="100%" stopColor="#2563eb" />
+      </linearGradient>
+
+      {/* Metallic effect */}
+      <linearGradient id="armor-metallic" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stopColor="#ffffff" stopOpacity="0.3" />
+        <stop offset="50%" stopColor="#ffffff" stopOpacity="0" />
+        <stop offset="100%" stopColor="#000000" stopOpacity="0.2" />
+      </linearGradient>
+
+      {/* Glow filter */}
+      <filter id="armor-glow" x="-50%" y="-50%" width="200%" height="200%">
+        <feGaussianBlur stdDeviation="3" result="coloredBlur" />
+        <feMerge>
+          <feMergeNode in="coloredBlur" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+
+      {/* Strong glow for neon effect */}
+      <filter id="armor-neon-glow" x="-100%" y="-100%" width="300%" height="300%">
+        <feGaussianBlur stdDeviation="4" result="blur1" />
+        <feGaussianBlur stdDeviation="8" result="blur2" />
+        <feMerge>
+          <feMergeNode in="blur2" />
+          <feMergeNode in="blur1" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+
+      {/* Drop shadow for lift effect */}
+      <filter id="armor-lift-shadow" x="-20%" y="-20%" width="140%" height="140%">
+        <feDropShadow dx="2" dy="4" stdDeviation="3" floodColor="#000000" floodOpacity="0.4" />
+      </filter>
+
+      {/* Inner shadow for depth */}
+      <filter id="armor-inner-shadow" x="-10%" y="-10%" width="120%" height="120%">
+        <feOffset dx="1" dy="1" />
+        <feGaussianBlur stdDeviation="2" result="offset-blur" />
+        <feComposite operator="out" in="SourceGraphic" in2="offset-blur" result="inverse" />
+        <feFlood floodColor="black" floodOpacity="0.3" result="color" />
+        <feComposite operator="in" in="color" in2="inverse" result="shadow" />
+        <feComposite operator="over" in="shadow" in2="SourceGraphic" />
+      </filter>
+
+      {/* Scanline pattern for HUD effect */}
+      <pattern id="armor-scanlines" patternUnits="userSpaceOnUse" width="4" height="4">
+        <line x1="0" y1="0" x2="4" y2="0" stroke="rgba(0,0,0,0.1)" strokeWidth="1" />
+      </pattern>
+
+      {/* Grid pattern for technical look */}
+      <pattern id="armor-grid" patternUnits="userSpaceOnUse" width="10" height="10">
+        <path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(255,255,255,0.05)" strokeWidth="0.5" />
+      </pattern>
+
+      {/* Carbon fiber texture */}
+      <pattern id="armor-carbon" patternUnits="userSpaceOnUse" width="4" height="4">
+        <rect width="4" height="4" fill="#1e293b" />
+        <rect x="0" y="0" width="2" height="2" fill="#334155" />
+        <rect x="2" y="2" width="2" height="2" fill="#334155" />
+      </pattern>
+    </defs>
+  );
+}
+
+/**
+ * Get gradient ID based on armor ratio
+ */
+export function getArmorGradientId(current: number, maximum: number, isSelected: boolean): string {
+  if (isSelected) return 'url(#armor-gradient-selected)';
+  if (maximum === 0) return 'url(#armor-gradient-critical)';
+
+  const ratio = current / maximum;
+  if (ratio >= 0.75) return 'url(#armor-gradient-healthy)';
+  if (ratio >= 0.5) return 'url(#armor-gradient-moderate)';
+  if (ratio >= 0.25) return 'url(#armor-gradient-low)';
+  return 'url(#armor-gradient-critical)';
+}
+
+/**
+ * Props for creating a tank-fill clip path
+ */
+export interface TankFillProps {
+  id: string;
+  fillPercent: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Create a clip path for tank-style bottom-up fill
+ */
+export function TankFillClipPath({ id, fillPercent, x, y, width, height }: TankFillProps): React.ReactElement {
+  const fillHeight = height * (fillPercent / 100);
+  const fillY = y + height - fillHeight;
+
+  return (
+    <clipPath id={id}>
+      <rect x={x} y={fillY} width={width} height={fillHeight} />
+    </clipPath>
+  );
+}

--- a/src/components/customizer/armor/shared/ArmorFills.tsx
+++ b/src/components/customizer/armor/shared/ArmorFills.tsx
@@ -40,6 +40,42 @@ export function getArmorStatusColor(current: number, maximum: number): string {
 }
 
 /**
+ * Standard front/rear armor distribution ratio (75/25 split)
+ */
+const FRONT_RATIO = 0.75;
+const REAR_RATIO = 0.25;
+
+/**
+ * Get status color for torso front armor based on expected capacity
+ *
+ * Uses 75/25 split as baseline - front "expected max" is 75% of total max.
+ * This ensures front armor shows green when at expected capacity,
+ * even though front has more raw points than rear.
+ *
+ * @param frontCurrent - Current front armor points
+ * @param totalMax - Total max armor for location (front + rear combined)
+ * @returns Status color
+ */
+export function getTorsoFrontStatusColor(frontCurrent: number, totalMax: number): string {
+  const expectedFrontMax = Math.round(totalMax * FRONT_RATIO);
+  return getArmorStatusColor(frontCurrent, expectedFrontMax);
+}
+
+/**
+ * Get status color for torso rear armor based on expected capacity
+ *
+ * Uses 75/25 split as baseline - rear "expected max" is 25% of total max.
+ *
+ * @param rearCurrent - Current rear armor points
+ * @param totalMax - Total max armor for location (front + rear combined)
+ * @returns Status color
+ */
+export function getTorsoRearStatusColor(rearCurrent: number, totalMax: number): string {
+  const expectedRearMax = Math.round(totalMax * REAR_RATIO);
+  return getArmorStatusColor(rearCurrent, expectedRearMax);
+}
+
+/**
  * Get status color for a torso location based on total (front + rear) armor
  * For non-torso locations, use getArmorStatusColor instead
  */

--- a/src/components/customizer/armor/shared/MechSilhouette.tsx
+++ b/src/components/customizer/armor/shared/MechSilhouette.tsx
@@ -1,0 +1,410 @@
+/**
+ * Mech Silhouette SVG Paths
+ *
+ * Provides path data and positioning for different mech silhouette styles.
+ */
+
+import { MechLocation } from '@/types/construction';
+
+/**
+ * Position and dimensions for an armor location
+ */
+export interface LocationPosition {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  /** Optional path for non-rectangular shapes */
+  path?: string;
+}
+
+/**
+ * Silhouette configuration for a mech type
+ */
+export interface SilhouetteConfig {
+  viewBox: string;
+  locations: Record<MechLocation, LocationPosition>;
+  /** Optional outline path for wireframe style */
+  outlinePath?: string;
+}
+
+/**
+ * Realistic mech silhouette with smooth contours
+ * Based on a classic BattleMech humanoid form
+ */
+export const REALISTIC_SILHOUETTE: SilhouetteConfig = {
+  viewBox: '0 0 300 400',
+  locations: {
+    [MechLocation.HEAD]: {
+      x: 120,
+      y: 5,
+      width: 60,
+      height: 55,
+      path: `
+        M 135 5
+        C 125 5, 120 15, 120 25
+        L 120 50
+        C 120 55, 125 60, 135 60
+        L 165 60
+        C 175 60, 180 55, 180 50
+        L 180 25
+        C 180 15, 175 5, 165 5
+        Z
+      `,
+    },
+    [MechLocation.CENTER_TORSO]: {
+      x: 100,
+      y: 65,
+      width: 100,
+      height: 110,
+      path: `
+        M 115 65
+        L 185 65
+        C 195 65, 200 75, 200 85
+        L 200 155
+        C 200 165, 195 175, 185 175
+        L 115 175
+        C 105 175, 100 165, 100 155
+        L 100 85
+        C 100 75, 105 65, 115 65
+        Z
+      `,
+    },
+    [MechLocation.LEFT_TORSO]: {
+      x: 30,
+      y: 75,
+      width: 65,
+      height: 100,
+      path: `
+        M 45 75
+        L 95 75
+        L 95 165
+        C 95 170, 90 175, 85 175
+        L 45 175
+        C 35 175, 30 170, 30 160
+        L 30 90
+        C 30 80, 35 75, 45 75
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_TORSO]: {
+      x: 205,
+      y: 75,
+      width: 65,
+      height: 100,
+      path: `
+        M 255 75
+        L 205 75
+        L 205 165
+        C 205 170, 210 175, 215 175
+        L 255 175
+        C 265 175, 270 170, 270 160
+        L 270 90
+        C 270 80, 265 75, 255 75
+        Z
+      `,
+    },
+    [MechLocation.LEFT_ARM]: {
+      x: 0,
+      y: 80,
+      width: 28,
+      height: 140,
+      path: `
+        M 8 80
+        L 25 80
+        C 28 80, 28 85, 28 90
+        L 28 200
+        C 28 210, 25 220, 20 220
+        L 8 220
+        C 3 220, 0 210, 0 200
+        L 0 90
+        C 0 85, 3 80, 8 80
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_ARM]: {
+      x: 272,
+      y: 80,
+      width: 28,
+      height: 140,
+      path: `
+        M 292 80
+        L 275 80
+        C 272 80, 272 85, 272 90
+        L 272 200
+        C 272 210, 275 220, 280 220
+        L 292 220
+        C 297 220, 300 210, 300 200
+        L 300 90
+        C 300 85, 297 80, 292 80
+        Z
+      `,
+    },
+    [MechLocation.LEFT_LEG]: {
+      x: 50,
+      y: 185,
+      width: 55,
+      height: 150,
+      path: `
+        M 60 185
+        L 100 185
+        C 105 185, 105 190, 105 195
+        L 105 310
+        C 105 320, 100 335, 90 335
+        L 70 335
+        C 55 335, 50 320, 50 310
+        L 50 195
+        C 50 190, 55 185, 60 185
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_LEG]: {
+      x: 195,
+      y: 185,
+      width: 55,
+      height: 150,
+      path: `
+        M 240 185
+        L 200 185
+        C 195 185, 195 190, 195 195
+        L 195 310
+        C 195 320, 200 335, 210 335
+        L 230 335
+        C 245 335, 250 320, 250 310
+        L 250 195
+        C 250 190, 245 185, 240 185
+        Z
+      `,
+    },
+  },
+  outlinePath: `
+    M 150 5
+    C 130 5, 120 20, 120 35
+    L 120 55
+    L 95 65
+    L 30 75
+    L 0 85
+    L 0 220
+    L 28 220
+    L 28 80
+    L 95 75
+    L 95 175
+    L 50 185
+    L 50 335
+    L 105 335
+    L 105 185
+    L 195 185
+    L 195 335
+    L 250 335
+    L 250 185
+    L 205 175
+    L 205 75
+    L 272 80
+    L 272 220
+    L 300 220
+    L 300 85
+    L 270 75
+    L 205 65
+    L 180 55
+    L 180 35
+    C 180 20, 170 5, 150 5
+    Z
+  `,
+};
+
+/**
+ * Geometric/polygonal silhouette with angular shapes
+ * Low-poly aesthetic with hexagonal influence
+ */
+export const GEOMETRIC_SILHOUETTE: SilhouetteConfig = {
+  viewBox: '0 0 300 400',
+  locations: {
+    [MechLocation.HEAD]: {
+      x: 115,
+      y: 0,
+      width: 70,
+      height: 55,
+      path: `
+        M 150 0
+        L 185 15
+        L 185 45
+        L 150 55
+        L 115 45
+        L 115 15
+        Z
+      `,
+    },
+    [MechLocation.CENTER_TORSO]: {
+      x: 95,
+      y: 60,
+      width: 110,
+      height: 115,
+      path: `
+        M 115 60
+        L 185 60
+        L 205 90
+        L 205 145
+        L 185 175
+        L 115 175
+        L 95 145
+        L 95 90
+        Z
+      `,
+    },
+    [MechLocation.LEFT_TORSO]: {
+      x: 25,
+      y: 70,
+      width: 65,
+      height: 105,
+      path: `
+        M 50 70
+        L 90 70
+        L 90 165
+        L 70 175
+        L 25 175
+        L 25 85
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_TORSO]: {
+      x: 210,
+      y: 70,
+      width: 65,
+      height: 105,
+      path: `
+        M 250 70
+        L 210 70
+        L 210 165
+        L 230 175
+        L 275 175
+        L 275 85
+        Z
+      `,
+    },
+    [MechLocation.LEFT_ARM]: {
+      x: 0,
+      y: 75,
+      width: 22,
+      height: 150,
+      path: `
+        M 5 75
+        L 22 85
+        L 22 205
+        L 15 225
+        L 0 225
+        L 0 85
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_ARM]: {
+      x: 278,
+      y: 75,
+      width: 22,
+      height: 150,
+      path: `
+        M 295 75
+        L 278 85
+        L 278 205
+        L 285 225
+        L 300 225
+        L 300 85
+        Z
+      `,
+    },
+    [MechLocation.LEFT_LEG]: {
+      x: 45,
+      y: 180,
+      width: 60,
+      height: 160,
+      path: `
+        M 55 180
+        L 105 180
+        L 105 310
+        L 95 340
+        L 55 340
+        L 45 310
+        L 45 195
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_LEG]: {
+      x: 195,
+      y: 180,
+      width: 60,
+      height: 160,
+      path: `
+        M 245 180
+        L 195 180
+        L 195 310
+        L 205 340
+        L 245 340
+        L 255 310
+        L 255 195
+        Z
+      `,
+    },
+  },
+};
+
+/**
+ * Get the center point of a location for text placement
+ */
+export function getLocationCenter(pos: LocationPosition): { x: number; y: number } {
+  return {
+    x: pos.x + pos.width / 2,
+    y: pos.y + pos.height / 2,
+  };
+}
+
+/**
+ * Get split positions for front/rear on torso locations
+ */
+export function getTorsoSplit(
+  pos: LocationPosition,
+  frontRatio: number = 0.7
+): { front: LocationPosition; rear: LocationPosition } {
+  const frontHeight = pos.height * frontRatio;
+  const rearHeight = pos.height * (1 - frontRatio);
+
+  return {
+    front: {
+      x: pos.x,
+      y: pos.y,
+      width: pos.width,
+      height: frontHeight,
+    },
+    rear: {
+      x: pos.x,
+      y: pos.y + frontHeight,
+      width: pos.width,
+      height: rearHeight,
+    },
+  };
+}
+
+/**
+ * Location labels
+ */
+export const LOCATION_LABELS: Record<MechLocation, string> = {
+  [MechLocation.HEAD]: 'HD',
+  [MechLocation.CENTER_TORSO]: 'CT',
+  [MechLocation.LEFT_TORSO]: 'LT',
+  [MechLocation.RIGHT_TORSO]: 'RT',
+  [MechLocation.LEFT_ARM]: 'LA',
+  [MechLocation.RIGHT_ARM]: 'RA',
+  [MechLocation.LEFT_LEG]: 'LL',
+  [MechLocation.RIGHT_LEG]: 'RL',
+};
+
+/**
+ * Locations that have rear armor
+ */
+export const TORSO_LOCATIONS = [
+  MechLocation.CENTER_TORSO,
+  MechLocation.LEFT_TORSO,
+  MechLocation.RIGHT_TORSO,
+] as const;
+
+export function hasTorsoRear(location: MechLocation): boolean {
+  return TORSO_LOCATIONS.includes(location as typeof TORSO_LOCATIONS[number]);
+}

--- a/src/components/customizer/armor/shared/index.ts
+++ b/src/components/customizer/armor/shared/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Shared armor diagram components and utilities
+ */
+
+export * from './MechSilhouette';
+export * from './ArmorFills';

--- a/src/components/customizer/armor/variants/CleanTechDiagram.tsx
+++ b/src/components/customizer/armor/variants/CleanTechDiagram.tsx
@@ -22,6 +22,8 @@ import {
 import {
   GradientDefs,
   getArmorStatusColor,
+  getTorsoFrontStatusColor,
+  getTorsoRearStatusColor,
   lightenColor,
   SELECTED_COLOR,
   SELECTED_STROKE,
@@ -55,9 +57,19 @@ function CleanTechLocation({
   const rear = data?.rear ?? 0;
   const rearMax = data?.rearMaximum ?? 1;
 
+  // For torso locations, use expected capacity (75/25 split) as baseline
+  const expectedFrontMax = showRear ? Math.round(maximum * 0.75) : maximum;
+  const expectedRearMax = showRear ? Math.round(maximum * 0.25) : 1;
+
   // Status-based colors for front and rear independently
-  const frontBaseColor = isSelected ? SELECTED_COLOR : getArmorStatusColor(current, maximum);
-  const rearBaseColor = isSelected ? SELECTED_COLOR : getArmorStatusColor(rear, rearMax);
+  const frontBaseColor = isSelected
+    ? SELECTED_COLOR
+    : showRear
+      ? getTorsoFrontStatusColor(current, maximum)
+      : getArmorStatusColor(current, maximum);
+  const rearBaseColor = isSelected
+    ? SELECTED_COLOR
+    : getTorsoRearStatusColor(rear, maximum);
 
   const fillColor = isHovered ? lightenColor(frontBaseColor, 0.15) : frontBaseColor;
   const rearFillColor = isHovered ? lightenColor(rearBaseColor, 0.15) : rearBaseColor;
@@ -258,7 +270,7 @@ export function CleanTechDiagram({
                 : 'bg-amber-600 hover:bg-amber-500 text-white'
             }`}
           >
-            Auto-Allocate ({unallocatedPoints} pts)
+            Auto Allocate ({unallocatedPoints} pts)
           </button>
         )}
       </div>

--- a/src/components/customizer/armor/variants/CleanTechDiagram.tsx
+++ b/src/components/customizer/armor/variants/CleanTechDiagram.tsx
@@ -57,11 +57,8 @@ function CleanTechLocation({
   const rear = data?.rear ?? 0;
   const rearMax = data?.rearMaximum ?? 1;
 
-  // For torso locations, use expected capacity (75/25 split) as baseline
-  const expectedFrontMax = showRear ? Math.round(maximum * 0.75) : maximum;
-  const expectedRearMax = showRear ? Math.round(maximum * 0.25) : 1;
-
   // Status-based colors for front and rear independently
+  // For torso locations, use expected capacity (75/25 split) as baseline
   const frontBaseColor = isSelected
     ? SELECTED_COLOR
     : showRear

--- a/src/components/customizer/armor/variants/CleanTechDiagram.tsx
+++ b/src/components/customizer/armor/variants/CleanTechDiagram.tsx
@@ -1,0 +1,316 @@
+/**
+ * Clean Tech Armor Diagram
+ *
+ * Design Philosophy: Maximum readability and usability
+ * - Realistic mech contour silhouette
+ * - Solid gradient fills based on armor status
+ * - Plain bold numbers for armor values
+ * - Color + small text for capacity indication
+ * - Stacked front/rear display
+ * - Simple border highlight on interaction
+ */
+
+import React, { useState } from 'react';
+import { MechLocation } from '@/types/construction';
+import { LocationArmorData } from '../ArmorDiagram';
+import {
+  REALISTIC_SILHOUETTE,
+  LOCATION_LABELS,
+  getLocationCenter,
+  hasTorsoRear,
+} from '../shared/MechSilhouette';
+import {
+  GradientDefs,
+  getArmorStatusColor,
+  getTorsoStatusColor,
+  lightenColor,
+  SELECTED_COLOR,
+  SELECTED_STROKE,
+} from '../shared/ArmorFills';
+import { ArmorDiagramQuickSettings } from '../ArmorDiagramQuickSettings';
+
+interface CleanTechLocationProps {
+  location: MechLocation;
+  data?: LocationArmorData;
+  isSelected: boolean;
+  isHovered: boolean;
+  onClick: () => void;
+  onHover: (hovered: boolean) => void;
+}
+
+function CleanTechLocation({
+  location,
+  data,
+  isSelected,
+  isHovered,
+  onClick,
+  onHover,
+}: CleanTechLocationProps): React.ReactElement {
+  const pos = REALISTIC_SILHOUETTE.locations[location];
+  const label = LOCATION_LABELS[location];
+  const center = getLocationCenter(pos);
+  const showRear = hasTorsoRear(location);
+
+  const current = data?.current ?? 0;
+  const maximum = data?.maximum ?? 1;
+  const rear = data?.rear ?? 0;
+  const rearMax = data?.rearMaximum ?? 1;
+
+  // Calculate fill colors
+  // For torso locations, use combined front+rear for status color
+  const baseColor = isSelected
+    ? SELECTED_COLOR
+    : showRear
+      ? getTorsoStatusColor(current, maximum, rear)
+      : getArmorStatusColor(current, maximum);
+  const fillColor = isHovered ? lightenColor(baseColor, 0.15) : baseColor;
+  const strokeColor = isSelected ? SELECTED_STROKE : '#475569';
+  const strokeWidth = isSelected ? 2.5 : 1;
+
+  // Split positions for front/rear
+  const frontHeight = showRear ? pos.height * 0.7 : pos.height;
+  const rearHeight = showRear ? pos.height * 0.3 : 0;
+  const rearY = pos.y + frontHeight;
+
+  // Rear uses same base color as front (they share the status)
+  const rearFillColor = isHovered ? lightenColor(baseColor, 0.1) : baseColor;
+
+  return (
+    <g
+      role="button"
+      tabIndex={0}
+      aria-label={`${location} armor: ${current} of ${maximum}${showRear ? `, rear: ${rear} of ${rearMax}` : ''}`}
+      aria-pressed={isSelected}
+      className="cursor-pointer focus:outline-none"
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      onMouseEnter={() => onHover(true)}
+      onMouseLeave={() => onHover(false)}
+      onFocus={() => onHover(true)}
+      onBlur={() => onHover(false)}
+    >
+      {/* Front armor section */}
+      {pos.path ? (
+        <path
+          d={pos.path}
+          fill={fillColor}
+          stroke={strokeColor}
+          strokeWidth={strokeWidth}
+          className="transition-all duration-150"
+          style={{
+            clipPath: showRear ? `inset(0 0 ${rearHeight}px 0)` : undefined,
+          }}
+        />
+      ) : (
+        <rect
+          x={pos.x}
+          y={pos.y}
+          width={pos.width}
+          height={frontHeight}
+          rx={6}
+          fill={fillColor}
+          stroke={strokeColor}
+          strokeWidth={strokeWidth}
+          className="transition-all duration-150"
+        />
+      )}
+
+      {/* Front armor value - large bold number */}
+      <text
+        x={center.x}
+        y={pos.y + frontHeight / 2 + 5}
+        textAnchor="middle"
+        className="fill-white font-bold pointer-events-none"
+        style={{ fontSize: pos.width < 40 ? '14px' : '18px' }}
+      >
+        {current}
+      </text>
+
+      {/* Capacity text */}
+      <text
+        x={center.x}
+        y={pos.y + frontHeight / 2 + 18}
+        textAnchor="middle"
+        className="fill-white/60 pointer-events-none"
+        style={{ fontSize: '9px' }}
+      >
+        / {maximum}
+      </text>
+
+      {/* Location label */}
+      <text
+        x={center.x}
+        y={pos.y + 14}
+        textAnchor="middle"
+        className="fill-white/80 font-semibold pointer-events-none"
+        style={{ fontSize: '10px' }}
+      >
+        {label}
+      </text>
+
+      {/* Rear armor section for torsos */}
+      {showRear && (
+        <>
+          <rect
+            x={pos.x}
+            y={rearY}
+            width={pos.width}
+            height={rearHeight}
+            rx={6}
+            fill={rearFillColor}
+            stroke={strokeColor}
+            strokeWidth={strokeWidth}
+            className="transition-all duration-150"
+          />
+
+          {/* Rear armor value */}
+          <text
+            x={center.x}
+            y={rearY + rearHeight / 2 + 4}
+            textAnchor="middle"
+            className="fill-white font-bold pointer-events-none"
+            style={{ fontSize: '12px' }}
+          >
+            {rear}
+          </text>
+
+          {/* Rear label */}
+          <text
+            x={center.x}
+            y={rearY + 10}
+            textAnchor="middle"
+            className="fill-white/60 pointer-events-none"
+            style={{ fontSize: '7px' }}
+          >
+            R
+          </text>
+        </>
+      )}
+    </g>
+  );
+}
+
+export interface CleanTechDiagramProps {
+  armorData: LocationArmorData[];
+  selectedLocation: MechLocation | null;
+  unallocatedPoints: number;
+  onLocationClick: (location: MechLocation) => void;
+  onAutoAllocate?: () => void;
+  className?: string;
+}
+
+export function CleanTechDiagram({
+  armorData,
+  selectedLocation,
+  unallocatedPoints,
+  onLocationClick,
+  onAutoAllocate,
+  className = '',
+}: CleanTechDiagramProps): React.ReactElement {
+  const [hoveredLocation, setHoveredLocation] = useState<MechLocation | null>(null);
+
+  const getArmorData = (location: MechLocation): LocationArmorData | undefined => {
+    return armorData.find((d) => d.location === location);
+  };
+
+  const isOverAllocated = unallocatedPoints < 0;
+
+  const locations: MechLocation[] = [
+    MechLocation.HEAD,
+    MechLocation.CENTER_TORSO,
+    MechLocation.LEFT_TORSO,
+    MechLocation.RIGHT_TORSO,
+    MechLocation.LEFT_ARM,
+    MechLocation.RIGHT_ARM,
+    MechLocation.LEFT_LEG,
+    MechLocation.RIGHT_LEG,
+  ];
+
+  return (
+    <div className={`bg-slate-800 rounded-lg border border-slate-700 p-4 ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <h3 className="text-lg font-semibold text-white">Armor Allocation</h3>
+          <ArmorDiagramQuickSettings />
+        </div>
+        {onAutoAllocate && (
+          <button
+            onClick={onAutoAllocate}
+            className={`px-3 py-1.5 text-sm font-medium rounded transition-colors ${
+              isOverAllocated
+                ? 'bg-red-600 hover:bg-red-500 text-white'
+                : 'bg-amber-600 hover:bg-amber-500 text-white'
+            }`}
+          >
+            Auto-Allocate ({unallocatedPoints} pts)
+          </button>
+        )}
+      </div>
+
+      {/* Diagram */}
+      <div className="relative">
+        <svg
+          viewBox={REALISTIC_SILHOUETTE.viewBox}
+          className="w-full max-w-[300px] mx-auto"
+          style={{ height: 'auto' }}
+        >
+          <GradientDefs />
+
+          {/* Background grid pattern */}
+          <rect
+            x="0"
+            y="0"
+            width="300"
+            height="400"
+            fill="url(#armor-grid)"
+            opacity="0.5"
+          />
+
+          {/* Render all locations */}
+          {locations.map((loc) => (
+            <CleanTechLocation
+              key={loc}
+              location={loc}
+              data={getArmorData(loc)}
+              isSelected={selectedLocation === loc}
+              isHovered={hoveredLocation === loc}
+              onClick={() => onLocationClick(loc)}
+              onHover={(h) => setHoveredLocation(h ? loc : null)}
+            />
+          ))}
+        </svg>
+      </div>
+
+      {/* Legend */}
+      <div className="flex justify-center gap-4 mt-4 text-xs">
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-green-500" />
+          <span className="text-slate-400">75%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-amber-500" />
+          <span className="text-slate-400">50-74%</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-orange-500" />
+          <span className="text-slate-400">25-49%</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-red-500" />
+          <span className="text-slate-400">&lt;25%</span>
+        </div>
+      </div>
+
+      {/* Instructions */}
+      <p className="text-xs text-slate-400 text-center mt-2">
+        Click a location to edit armor values
+      </p>
+    </div>
+  );
+}

--- a/src/components/customizer/armor/variants/CleanTechDiagram.tsx
+++ b/src/components/customizer/armor/variants/CleanTechDiagram.tsx
@@ -25,8 +25,6 @@ import {
   lightenColor,
   SELECTED_COLOR,
   SELECTED_STROKE,
-  FRONT_ARMOR_COLOR,
-  REAR_ARMOR_COLOR,
 } from '../shared/ArmorFills';
 import { ArmorDiagramQuickSettings } from '../ArmorDiagramQuickSettings';
 
@@ -57,15 +55,9 @@ function CleanTechLocation({
   const rear = data?.rear ?? 0;
   const rearMax = data?.rearMaximum ?? 1;
 
-  // Calculate fill colors
-  // For torso locations, use distinct amber (front) and sky (rear) colors
-  // For non-torso locations, use status-based colors
-  const frontBaseColor = isSelected
-    ? SELECTED_COLOR
-    : showRear
-      ? FRONT_ARMOR_COLOR
-      : getArmorStatusColor(current, maximum);
-  const rearBaseColor = isSelected ? SELECTED_COLOR : REAR_ARMOR_COLOR;
+  // Status-based colors for front and rear independently
+  const frontBaseColor = isSelected ? SELECTED_COLOR : getArmorStatusColor(current, maximum);
+  const rearBaseColor = isSelected ? SELECTED_COLOR : getArmorStatusColor(rear, rearMax);
 
   const fillColor = isHovered ? lightenColor(frontBaseColor, 0.15) : frontBaseColor;
   const rearFillColor = isHovered ? lightenColor(rearBaseColor, 0.15) : rearBaseColor;
@@ -306,19 +298,18 @@ export function CleanTechDiagram({
       </div>
 
       {/* Legend */}
-      <div className="flex justify-center gap-4 mt-4 text-xs">
-        <div className="flex items-center gap-1.5">
-          <div className="w-3 h-3 rounded" style={{ backgroundColor: FRONT_ARMOR_COLOR }} />
-          <span className="text-slate-400">Front</span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <div className="w-3 h-3 rounded" style={{ backgroundColor: REAR_ARMOR_COLOR }} />
-          <span className="text-slate-400">Rear</span>
-        </div>
-        <div className="w-px h-3 bg-slate-600" />
+      <div className="flex justify-center gap-3 mt-4 text-xs">
         <div className="flex items-center gap-1.5">
           <div className="w-3 h-3 rounded bg-green-500" />
           <span className="text-slate-400">75%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-amber-500" />
+          <span className="text-slate-400">50%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-orange-500" />
+          <span className="text-slate-400">25%+</span>
         </div>
         <div className="flex items-center gap-1.5">
           <div className="w-3 h-3 rounded bg-red-500" />

--- a/src/components/customizer/armor/variants/NeonOperatorDiagram.tsx
+++ b/src/components/customizer/armor/variants/NeonOperatorDiagram.tsx
@@ -21,6 +21,8 @@ import {
 import {
   GradientDefs,
   getArmorStatusColor,
+  getTorsoFrontStatusColor,
+  getTorsoRearStatusColor,
   lightenColor,
   SELECTED_COLOR,
 } from '../shared/ArmorFills';
@@ -117,12 +119,23 @@ function NeonLocation({
   const rear = data?.rear ?? 0;
   const rearMax = data?.rearMaximum ?? 1;
 
-  const frontPercent = frontMax > 0 ? (front / frontMax) * 100 : 0;
-  const rearPercent = rearMax > 0 ? (rear / rearMax) * 100 : 0;
+  // For torso locations, use expected capacity (75/25 split) as baseline
+  const expectedFrontMax = showRear ? Math.round(frontMax * 0.75) : frontMax;
+  const expectedRearMax = showRear ? Math.round(frontMax * 0.25) : 1;
+
+  // Fill percentages based on expected capacity
+  const frontPercent = expectedFrontMax > 0 ? Math.min(100, (front / expectedFrontMax) * 100) : 0;
+  const rearPercent = expectedRearMax > 0 ? Math.min(100, (rear / expectedRearMax) * 100) : 0;
 
   // Status-based colors for front and rear independently
-  const frontColor = isSelected ? SELECTED_COLOR : getArmorStatusColor(front, frontMax);
-  const rearColor = isSelected ? SELECTED_COLOR : getArmorStatusColor(rear, rearMax);
+  const frontColor = isSelected
+    ? SELECTED_COLOR
+    : showRear
+      ? getTorsoFrontStatusColor(front, frontMax)
+      : getArmorStatusColor(front, frontMax);
+  const rearColor = isSelected
+    ? SELECTED_COLOR
+    : getTorsoRearStatusColor(rear, frontMax);
 
   const glowColor = isHovered ? lightenColor(frontColor, 0.2) : frontColor;
 
@@ -382,7 +395,7 @@ export function NeonOperatorDiagram({
                 : '0 0 10px rgba(34, 211, 238, 0.3)',
             }}
           >
-            AUTO [{unallocatedPoints}]
+            Auto Allocate ({unallocatedPoints} pts)
           </button>
         )}
       </div>

--- a/src/components/customizer/armor/variants/NeonOperatorDiagram.tsx
+++ b/src/components/customizer/armor/variants/NeonOperatorDiagram.tsx
@@ -1,0 +1,411 @@
+/**
+ * Neon Operator Armor Diagram
+ *
+ * Design Philosophy: Sci-fi aesthetic and visual impact
+ * - Wireframe outline silhouette
+ * - Glow/neon fills with glowing edges
+ * - Progress ring around numbers
+ * - Color-only capacity indication
+ * - Toggle switch for front/rear
+ * - Glow pulse interaction
+ */
+
+import React, { useState } from 'react';
+import { MechLocation } from '@/types/construction';
+import { LocationArmorData } from '../ArmorDiagram';
+import {
+  REALISTIC_SILHOUETTE,
+  LOCATION_LABELS,
+  getLocationCenter,
+  hasTorsoRear,
+} from '../shared/MechSilhouette';
+import {
+  GradientDefs,
+  getArmorStatusColor,
+  getTorsoStatusColor,
+  lightenColor,
+  SELECTED_COLOR,
+} from '../shared/ArmorFills';
+import { ArmorDiagramQuickSettings } from '../ArmorDiagramQuickSettings';
+
+interface ProgressRingProps {
+  cx: number;
+  cy: number;
+  radius: number;
+  progress: number;
+  color: string;
+  strokeWidth?: number;
+}
+
+function ProgressRing({
+  cx,
+  cy,
+  radius,
+  progress,
+  color,
+  strokeWidth = 3,
+}: ProgressRingProps): React.ReactElement {
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (progress / 100) * circumference;
+
+  return (
+    <g>
+      {/* Background ring */}
+      <circle
+        cx={cx}
+        cy={cy}
+        r={radius}
+        fill="none"
+        stroke="rgba(255,255,255,0.1)"
+        strokeWidth={strokeWidth}
+      />
+      {/* Progress ring */}
+      <circle
+        cx={cx}
+        cy={cy}
+        r={radius}
+        fill="none"
+        stroke={color}
+        strokeWidth={strokeWidth}
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        transform={`rotate(-90 ${cx} ${cy})`}
+        className="transition-all duration-300"
+        style={{ filter: 'url(#armor-glow)' }}
+      />
+    </g>
+  );
+}
+
+interface NeonLocationProps {
+  location: MechLocation;
+  data?: LocationArmorData;
+  isSelected: boolean;
+  isHovered: boolean;
+  onClick: () => void;
+  onHover: (hovered: boolean) => void;
+  showRear?: boolean;
+}
+
+function NeonLocation({
+  location,
+  data,
+  isSelected,
+  isHovered,
+  onClick,
+  onHover,
+  showRear = false,
+}: NeonLocationProps): React.ReactElement {
+  const pos = REALISTIC_SILHOUETTE.locations[location];
+  const label = LOCATION_LABELS[location];
+  const center = getLocationCenter(pos);
+  const hasTorso = hasTorsoRear(location);
+
+  const current = showRear ? (data?.rear ?? 0) : (data?.current ?? 0);
+  const maximum = showRear ? (data?.rearMaximum ?? 1) : (data?.maximum ?? 1);
+  const percentage = maximum > 0 ? (current / maximum) * 100 : 0;
+
+  // Calculate colors - for torso locations, use combined front+rear for status
+  const baseColor = isSelected
+    ? SELECTED_COLOR
+    : hasTorso
+      ? getTorsoStatusColor(data?.current ?? 0, data?.maximum ?? 1, data?.rear ?? 0)
+      : getArmorStatusColor(current, maximum);
+  const glowColor = isHovered ? lightenColor(baseColor, 0.3) : baseColor;
+  const fillOpacity = isHovered ? 0.4 : 0.25;
+
+  // Ring size based on location
+  const ringRadius = Math.min(pos.width, pos.height) * 0.35;
+
+  return (
+    <g
+      role="button"
+      tabIndex={0}
+      aria-label={`${location} ${showRear ? 'rear ' : ''}armor: ${current} of ${maximum}`}
+      aria-pressed={isSelected}
+      className="cursor-pointer focus:outline-none"
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      onMouseEnter={() => onHover(true)}
+      onMouseLeave={() => onHover(false)}
+      onFocus={() => onHover(true)}
+      onBlur={() => onHover(false)}
+    >
+      {/* Glow background */}
+      <rect
+        x={pos.x}
+        y={pos.y}
+        width={pos.width}
+        height={pos.height}
+        rx={4}
+        fill={glowColor}
+        fillOpacity={fillOpacity}
+        className="transition-all duration-200"
+      />
+
+      {/* Neon edge outline */}
+      <rect
+        x={pos.x}
+        y={pos.y}
+        width={pos.width}
+        height={pos.height}
+        rx={4}
+        fill="none"
+        stroke={glowColor}
+        strokeWidth={isSelected ? 2.5 : 1.5}
+        className="transition-all duration-200"
+        style={{
+          filter: isHovered || isSelected ? 'url(#armor-neon-glow)' : 'url(#armor-glow)',
+        }}
+      />
+
+      {/* Progress ring */}
+      <ProgressRing
+        cx={center.x}
+        cy={center.y}
+        radius={ringRadius}
+        progress={percentage}
+        color={glowColor}
+        strokeWidth={isHovered ? 4 : 3}
+      />
+
+      {/* Armor value */}
+      <text
+        x={center.x}
+        y={center.y + 5}
+        textAnchor="middle"
+        className="fill-white font-bold pointer-events-none"
+        style={{
+          fontSize: pos.width < 40 ? '12px' : '16px',
+          textShadow: `0 0 10px ${glowColor}`,
+        }}
+      >
+        {current}
+      </text>
+
+      {/* Location label */}
+      <text
+        x={center.x}
+        y={pos.y + 12}
+        textAnchor="middle"
+        className="fill-white/70 font-medium pointer-events-none"
+        style={{
+          fontSize: '8px',
+          textShadow: `0 0 5px ${glowColor}`,
+        }}
+      >
+        {showRear ? `${label}R` : label}
+      </text>
+
+      {/* Has rear indicator dot */}
+      {hasTorso && !showRear && (
+        <circle
+          cx={pos.x + pos.width - 8}
+          cy={pos.y + 8}
+          r={3}
+          fill={getArmorStatusColor(data?.rear ?? 0, data?.rearMaximum ?? 1)}
+          style={{ filter: 'url(#armor-glow)' }}
+        />
+      )}
+    </g>
+  );
+}
+
+export interface NeonOperatorDiagramProps {
+  armorData: LocationArmorData[];
+  selectedLocation: MechLocation | null;
+  unallocatedPoints: number;
+  onLocationClick: (location: MechLocation) => void;
+  onAutoAllocate?: () => void;
+  className?: string;
+}
+
+export function NeonOperatorDiagram({
+  armorData,
+  selectedLocation,
+  unallocatedPoints,
+  onLocationClick,
+  onAutoAllocate,
+  className = '',
+}: NeonOperatorDiagramProps): React.ReactElement {
+  const [hoveredLocation, setHoveredLocation] = useState<MechLocation | null>(null);
+  const [showRearView, setShowRearView] = useState(false);
+
+  const getArmorData = (location: MechLocation): LocationArmorData | undefined => {
+    return armorData.find((d) => d.location === location);
+  };
+
+  const isOverAllocated = unallocatedPoints < 0;
+
+  // Front view shows all locations
+  const frontLocations: MechLocation[] = [
+    MechLocation.HEAD,
+    MechLocation.CENTER_TORSO,
+    MechLocation.LEFT_TORSO,
+    MechLocation.RIGHT_TORSO,
+    MechLocation.LEFT_ARM,
+    MechLocation.RIGHT_ARM,
+    MechLocation.LEFT_LEG,
+    MechLocation.RIGHT_LEG,
+  ];
+
+  // Rear view only shows torso locations
+  const rearLocations: MechLocation[] = [
+    MechLocation.CENTER_TORSO,
+    MechLocation.LEFT_TORSO,
+    MechLocation.RIGHT_TORSO,
+  ];
+
+  const currentLocations = showRearView ? rearLocations : frontLocations;
+
+  return (
+    <div className={`bg-slate-900 rounded-lg border border-cyan-900/50 p-4 ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <h3
+            className="text-lg font-semibold text-cyan-400"
+            style={{ textShadow: '0 0 10px rgba(34, 211, 238, 0.5)' }}
+          >
+            ARMOR STATUS
+          </h3>
+          <ArmorDiagramQuickSettings />
+        </div>
+        {onAutoAllocate && (
+          <button
+            onClick={onAutoAllocate}
+            className={`px-3 py-1.5 text-sm font-medium rounded border transition-all ${
+              isOverAllocated
+                ? 'border-red-500 text-red-400 hover:bg-red-500/20'
+                : 'border-cyan-500 text-cyan-400 hover:bg-cyan-500/20'
+            }`}
+            style={{
+              boxShadow: isOverAllocated
+                ? '0 0 10px rgba(239, 68, 68, 0.3)'
+                : '0 0 10px rgba(34, 211, 238, 0.3)',
+            }}
+          >
+            AUTO [{unallocatedPoints}]
+          </button>
+        )}
+      </div>
+
+      {/* Front/Rear Toggle */}
+      <div className="flex justify-center mb-4">
+        <div className="inline-flex rounded border border-cyan-800 overflow-hidden">
+          <button
+            onClick={() => setShowRearView(false)}
+            className={`px-4 py-1.5 text-sm font-medium transition-all ${
+              !showRearView
+                ? 'bg-cyan-500/30 text-cyan-300'
+                : 'text-cyan-600 hover:bg-cyan-500/10'
+            }`}
+            style={{
+              textShadow: !showRearView ? '0 0 10px rgba(34, 211, 238, 0.5)' : undefined,
+            }}
+          >
+            FRONT
+          </button>
+          <button
+            onClick={() => setShowRearView(true)}
+            className={`px-4 py-1.5 text-sm font-medium transition-all ${
+              showRearView
+                ? 'bg-cyan-500/30 text-cyan-300'
+                : 'text-cyan-600 hover:bg-cyan-500/10'
+            }`}
+            style={{
+              textShadow: showRearView ? '0 0 10px rgba(34, 211, 238, 0.5)' : undefined,
+            }}
+          >
+            REAR
+          </button>
+        </div>
+      </div>
+
+      {/* Diagram */}
+      <div className="relative">
+        <svg
+          viewBox={REALISTIC_SILHOUETTE.viewBox}
+          className="w-full max-w-[300px] mx-auto"
+          style={{ height: 'auto' }}
+        >
+          <GradientDefs />
+
+          {/* Scanline overlay */}
+          <rect
+            x="0"
+            y="0"
+            width="300"
+            height="400"
+            fill="url(#armor-scanlines)"
+            opacity="0.3"
+          />
+
+          {/* Wireframe outline */}
+          {REALISTIC_SILHOUETTE.outlinePath && (
+            <path
+              d={REALISTIC_SILHOUETTE.outlinePath}
+              fill="none"
+              stroke="rgba(34, 211, 238, 0.2)"
+              strokeWidth="1"
+              strokeDasharray="4 2"
+            />
+          )}
+
+          {/* Render locations */}
+          {currentLocations.map((loc) => (
+            <NeonLocation
+              key={`${loc}-${showRearView ? 'rear' : 'front'}`}
+              location={loc}
+              data={getArmorData(loc)}
+              isSelected={selectedLocation === loc}
+              isHovered={hoveredLocation === loc}
+              onClick={() => onLocationClick(loc)}
+              onHover={(h) => setHoveredLocation(h ? loc : null)}
+              showRear={showRearView && hasTorsoRear(loc)}
+            />
+          ))}
+
+          {/* Targeting reticle on hovered */}
+          {hoveredLocation && (
+            <g className="pointer-events-none">
+              <circle
+                cx={getLocationCenter(REALISTIC_SILHOUETTE.locations[hoveredLocation]).x}
+                cy={getLocationCenter(REALISTIC_SILHOUETTE.locations[hoveredLocation]).y}
+                r={40}
+                fill="none"
+                stroke="rgba(34, 211, 238, 0.3)"
+                strokeWidth="1"
+                strokeDasharray="8 4"
+                className="animate-spin"
+                style={{ animationDuration: '8s' }}
+              />
+            </g>
+          )}
+        </svg>
+      </div>
+
+      {/* Status bar */}
+      <div className="flex justify-center items-center gap-2 mt-4 text-xs text-cyan-500/70">
+        <span>SYS: ONLINE</span>
+        <span>|</span>
+        <span>VIEW: {showRearView ? 'REAR' : 'FRONT'}</span>
+        <span>|</span>
+        <span className={unallocatedPoints < 0 ? 'text-red-400' : ''}>
+          UNALLOC: {unallocatedPoints}
+        </span>
+      </div>
+
+      {/* Instructions */}
+      <p className="text-xs text-cyan-600/50 text-center mt-2">
+        SELECT TARGET LOCATION
+      </p>
+    </div>
+  );
+}

--- a/src/components/customizer/armor/variants/NeonOperatorDiagram.tsx
+++ b/src/components/customizer/armor/variants/NeonOperatorDiagram.tsx
@@ -23,10 +23,6 @@ import {
   getArmorStatusColor,
   lightenColor,
   SELECTED_COLOR,
-  FRONT_ARMOR_COLOR,
-  REAR_ARMOR_COLOR,
-  FRONT_ARMOR_LIGHT,
-  REAR_ARMOR_LIGHT,
 } from '../shared/ArmorFills';
 import { ArmorDiagramQuickSettings } from '../ArmorDiagramQuickSettings';
 
@@ -124,14 +120,11 @@ function NeonLocation({
   const frontPercent = frontMax > 0 ? (front / frontMax) * 100 : 0;
   const rearPercent = rearMax > 0 ? (rear / rearMax) * 100 : 0;
 
-  // Colors
-  const frontColor = isSelected ? SELECTED_COLOR : FRONT_ARMOR_COLOR;
-  const rearColor = isSelected ? SELECTED_COLOR : REAR_ARMOR_COLOR;
-  const nonTorsoColor = isSelected ? SELECTED_COLOR : getArmorStatusColor(front, frontMax);
+  // Status-based colors for front and rear independently
+  const frontColor = isSelected ? SELECTED_COLOR : getArmorStatusColor(front, frontMax);
+  const rearColor = isSelected ? SELECTED_COLOR : getArmorStatusColor(rear, rearMax);
 
-  const glowColor = showRear
-    ? (isHovered ? lightenColor(frontColor, 0.2) : frontColor)
-    : (isHovered ? lightenColor(nonTorsoColor, 0.3) : nonTorsoColor);
+  const glowColor = isHovered ? lightenColor(frontColor, 0.2) : frontColor;
 
   const fillOpacity = isHovered ? 0.4 : 0.25;
 
@@ -241,11 +234,10 @@ function NeonLocation({
             y1={dividerY}
             x2={pos.x + pos.width - 6}
             y2={dividerY}
-            stroke={FRONT_ARMOR_LIGHT}
+            stroke="#64748b"
             strokeWidth={1}
             strokeDasharray="4 3"
-            opacity={0.5}
-            style={{ filter: 'url(#armor-glow)' }}
+            opacity={0.6}
           />
 
           {/* Rear section */}
@@ -460,18 +452,20 @@ export function NeonOperatorDiagram({
       {/* Legend */}
       <div className="flex justify-center items-center gap-3 mt-4 text-xs">
         <div className="flex items-center gap-1.5">
-          <div
-            className="w-2.5 h-2.5 rounded-full"
-            style={{ backgroundColor: FRONT_ARMOR_COLOR, boxShadow: `0 0 6px ${FRONT_ARMOR_COLOR}` }}
-          />
-          <span className="text-slate-400">Front</span>
+          <div className="w-2.5 h-2.5 rounded-full bg-green-500" style={{ boxShadow: '0 0 6px #22c55e' }} />
+          <span className="text-slate-400">75%+</span>
         </div>
         <div className="flex items-center gap-1.5">
-          <div
-            className="w-2.5 h-2.5 rounded-full"
-            style={{ backgroundColor: REAR_ARMOR_COLOR, boxShadow: `0 0 6px ${REAR_ARMOR_COLOR}` }}
-          />
-          <span className="text-slate-400">Rear</span>
+          <div className="w-2.5 h-2.5 rounded-full bg-amber-500" style={{ boxShadow: '0 0 6px #f59e0b' }} />
+          <span className="text-slate-400">50%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-2.5 h-2.5 rounded-full bg-orange-500" style={{ boxShadow: '0 0 6px #f97316' }} />
+          <span className="text-slate-400">25%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-2.5 h-2.5 rounded-full bg-red-500" style={{ boxShadow: '0 0 6px #ef4444' }} />
+          <span className="text-slate-400">&lt;25%</span>
         </div>
         <div className="w-px h-3 bg-slate-700" />
         <span className={`${unallocatedPoints < 0 ? 'text-red-400' : 'text-cyan-400'}`}>

--- a/src/components/customizer/armor/variants/NeonOperatorDiagram.tsx
+++ b/src/components/customizer/armor/variants/NeonOperatorDiagram.tsx
@@ -89,6 +89,14 @@ interface NeonLocationProps {
   onHover: (hovered: boolean) => void;
 }
 
+// Calculate leg offset based on torso height expansion
+const TORSO_HEIGHT_MULTIPLIER = 1.4;
+const LEG_Y_OFFSET = REALISTIC_SILHOUETTE.locations[MechLocation.CENTER_TORSO].height * (TORSO_HEIGHT_MULTIPLIER - 1);
+
+function isLegLocation(location: MechLocation): boolean {
+  return location === MechLocation.LEFT_LEG || location === MechLocation.RIGHT_LEG;
+}
+
 function NeonLocation({
   location,
   data,
@@ -101,10 +109,12 @@ function NeonLocation({
   const label = LOCATION_LABELS[location];
   const showRear = hasTorsoRear(location);
 
-  // Adjust position for torso locations to be taller
+  // Adjust position for torso locations to be taller, and offset legs down
   const pos = showRear
-    ? { ...basePos, height: basePos.height * 1.4 }
-    : basePos;
+    ? { ...basePos, height: basePos.height * TORSO_HEIGHT_MULTIPLIER }
+    : isLegLocation(location)
+      ? { ...basePos, y: basePos.y + LEG_Y_OFFSET }
+      : basePos;
 
   const front = data?.current ?? 0;
   const frontMax = data?.maximum ?? 1;
@@ -388,7 +398,7 @@ export function NeonOperatorDiagram({
       {/* Diagram */}
       <div className="relative">
         <svg
-          viewBox="0 0 300 440"
+          viewBox="0 0 300 480"
           className="w-full max-w-[300px] mx-auto"
           style={{ height: 'auto' }}
         >

--- a/src/components/customizer/armor/variants/PremiumMaterialDiagram.tsx
+++ b/src/components/customizer/armor/variants/PremiumMaterialDiagram.tsx
@@ -1,0 +1,490 @@
+/**
+ * Premium Material Armor Diagram
+ *
+ * Design Philosophy: Modern app polish and tactile feel
+ * - Realistic contour silhouette
+ * - Metallic/textured fills
+ * - Circular badge number display
+ * - Dot indicator capacity
+ * - 3D layered front/rear display
+ * - Lift/shadow interaction
+ */
+
+import React, { useState } from 'react';
+import { MechLocation } from '@/types/construction';
+import { LocationArmorData } from '../ArmorDiagram';
+import {
+  REALISTIC_SILHOUETTE,
+  LOCATION_LABELS,
+  getLocationCenter,
+  hasTorsoRear,
+} from '../shared/MechSilhouette';
+import {
+  GradientDefs,
+  getArmorStatusColor,
+  getTorsoStatusColor,
+  darkenColor,
+  lightenColor,
+} from '../shared/ArmorFills';
+import { ArmorDiagramQuickSettings } from '../ArmorDiagramQuickSettings';
+
+/**
+ * Circular badge with number
+ */
+function NumberBadge({
+  x,
+  y,
+  value,
+  color,
+  size = 24,
+}: {
+  x: number;
+  y: number;
+  value: number;
+  color: string;
+  size?: number;
+}): React.ReactElement {
+  const radius = size / 2;
+  return (
+    <g>
+      {/* Outer ring */}
+      <circle
+        cx={x}
+        cy={y}
+        r={radius + 2}
+        fill="none"
+        stroke={lightenColor(color, 0.2)}
+        strokeWidth={1.5}
+        opacity={0.6}
+      />
+      {/* Badge background */}
+      <circle
+        cx={x}
+        cy={y}
+        r={radius}
+        fill={darkenColor(color, 0.3)}
+        stroke={color}
+        strokeWidth={1}
+      />
+      {/* Inner highlight */}
+      <circle
+        cx={x}
+        cy={y - radius * 0.3}
+        r={radius * 0.6}
+        fill="url(#armor-metallic)"
+        opacity={0.5}
+      />
+      {/* Number */}
+      <text
+        x={x}
+        y={y + size * 0.15}
+        textAnchor="middle"
+        fontSize={size * 0.55}
+        fontWeight="bold"
+        fill="white"
+        style={{ textShadow: '0 1px 2px rgba(0,0,0,0.5)' }}
+      >
+        {value}
+      </text>
+    </g>
+  );
+}
+
+/**
+ * Dot indicator row (like battery level)
+ */
+function DotIndicator({
+  x,
+  y,
+  fillPercent,
+  color,
+  dots = 5,
+  dotSize = 4,
+  gap = 2,
+}: {
+  x: number;
+  y: number;
+  fillPercent: number;
+  color: string;
+  dots?: number;
+  dotSize?: number;
+  gap?: number;
+}): React.ReactElement {
+  const filledDots = Math.ceil((fillPercent / 100) * dots);
+  const totalWidth = dots * dotSize + (dots - 1) * gap;
+  const startX = x - totalWidth / 2;
+
+  return (
+    <g>
+      {Array.from({ length: dots }).map((_, i) => {
+        const isFilled = i < filledDots;
+        return (
+          <circle
+            key={i}
+            cx={startX + i * (dotSize + gap) + dotSize / 2}
+            cy={y}
+            r={dotSize / 2}
+            fill={isFilled ? color : '#334155'}
+            stroke={isFilled ? lightenColor(color, 0.2) : '#475569'}
+            strokeWidth={0.5}
+            className="transition-all duration-200"
+          />
+        );
+      })}
+    </g>
+  );
+}
+
+interface PremiumLocationProps {
+  location: MechLocation;
+  data?: LocationArmorData;
+  isSelected: boolean;
+  isHovered: boolean;
+  onClick: () => void;
+  onHover: (hovered: boolean) => void;
+}
+
+function PremiumLocation({
+  location,
+  data,
+  isSelected,
+  isHovered,
+  onClick,
+  onHover,
+}: PremiumLocationProps): React.ReactElement {
+  const pos = REALISTIC_SILHOUETTE.locations[location];
+  const label = LOCATION_LABELS[location];
+  const center = getLocationCenter(pos);
+  const showRear = hasTorsoRear(location);
+
+  const current = data?.current ?? 0;
+  const maximum = data?.maximum ?? 1;
+  const rear = data?.rear ?? 0;
+  const rearMax = data?.rearMaximum ?? 1;
+
+  const frontPercent = maximum > 0 ? (current / maximum) * 100 : 0;
+  const rearPercent = rearMax > 0 ? (rear / rearMax) * 100 : 0;
+
+  // Colors - for torso locations, use combined front+rear for status
+  // Both plates share the same status color since they represent one location
+  const combinedStatusColor = showRear
+    ? getTorsoStatusColor(current, maximum, rear)
+    : getArmorStatusColor(current, maximum);
+  const baseColor = isSelected ? '#3b82f6' : combinedStatusColor;
+  const rearBaseColor = isSelected ? '#2563eb' : combinedStatusColor;
+
+  // 3D effect positioning for rear plate
+  const rearOffsetX = 6;
+  const rearOffsetY = 6;
+
+  // Lift effect when hovered
+  const liftOffset = isHovered ? -2 : 0;
+
+  return (
+    <g
+      role="button"
+      tabIndex={0}
+      aria-label={`${location} armor: ${current} of ${maximum}${showRear ? `, rear: ${rear} of ${rearMax}` : ''}`}
+      aria-pressed={isSelected}
+      className="cursor-pointer focus:outline-none"
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      onMouseEnter={() => onHover(true)}
+      onMouseLeave={() => onHover(false)}
+      onFocus={() => onHover(true)}
+      onBlur={() => onHover(false)}
+    >
+      {/* Rear plate (behind, offset for 3D effect) */}
+      {showRear && (
+        <g transform={`translate(${rearOffsetX}, ${rearOffsetY})`}>
+          <rect
+            x={pos.x}
+            y={pos.y}
+            width={pos.width}
+            height={pos.height * 0.85}
+            rx={8}
+            fill={darkenColor(rearBaseColor, 0.4)}
+            stroke={darkenColor(rearBaseColor, 0.2)}
+            strokeWidth={1}
+          />
+          {/* Carbon fiber texture */}
+          <rect
+            x={pos.x}
+            y={pos.y}
+            width={pos.width}
+            height={pos.height * 0.85}
+            rx={8}
+            fill="url(#armor-carbon)"
+            opacity={0.3}
+          />
+          {/* Rear badge */}
+          <NumberBadge
+            x={pos.x + pos.width / 2}
+            y={pos.y + pos.height * 0.42}
+            value={rear}
+            color={rearBaseColor}
+            size={pos.width < 50 ? 18 : 22}
+          />
+          {/* Rear label */}
+          <text
+            x={pos.x + pos.width / 2}
+            y={pos.y + 14}
+            textAnchor="middle"
+            fontSize="8"
+            fill="rgba(255,255,255,0.5)"
+            fontWeight="500"
+          >
+            {label} REAR
+          </text>
+          {/* Rear dots */}
+          <DotIndicator
+            x={pos.x + pos.width / 2}
+            y={pos.y + pos.height * 0.75}
+            fillPercent={rearPercent}
+            color={rearBaseColor}
+            dots={4}
+            dotSize={3}
+          />
+        </g>
+      )}
+
+      {/* Front plate (main, on top) */}
+      <g
+        transform={`translate(0, ${liftOffset})`}
+        style={{
+          filter: isHovered ? 'url(#armor-lift-shadow)' : undefined,
+          transition: 'transform 0.15s ease-out',
+        }}
+      >
+        {/* Main plate background */}
+        <rect
+          x={pos.x}
+          y={pos.y}
+          width={pos.width}
+          height={pos.height}
+          rx={8}
+          fill={darkenColor(baseColor, 0.3)}
+          stroke={isSelected ? '#60a5fa' : darkenColor(baseColor, 0.1)}
+          strokeWidth={isSelected ? 2 : 1}
+          className="transition-colors duration-150"
+        />
+
+        {/* Metallic gradient overlay */}
+        <rect
+          x={pos.x}
+          y={pos.y}
+          width={pos.width}
+          height={pos.height}
+          rx={8}
+          fill="url(#armor-metallic)"
+          opacity={0.6}
+        />
+
+        {/* Top highlight edge */}
+        <rect
+          x={pos.x + 2}
+          y={pos.y + 2}
+          width={pos.width - 4}
+          height={pos.height * 0.15}
+          rx={6}
+          fill="white"
+          opacity={0.1}
+        />
+
+        {/* Filled state indicator */}
+        <rect
+          x={pos.x}
+          y={pos.y + pos.height * (1 - frontPercent / 100)}
+          width={pos.width}
+          height={pos.height * (frontPercent / 100)}
+          rx={8}
+          fill={baseColor}
+          opacity={0.4}
+          className="transition-all duration-300"
+          style={{
+            clipPath: `inset(0 0 0 0 round 8px)`,
+          }}
+        />
+
+        {/* Location label */}
+        <text
+          x={center.x}
+          y={pos.y + 14}
+          textAnchor="middle"
+          fontSize="9"
+          fill="rgba(255,255,255,0.8)"
+          fontWeight="600"
+          letterSpacing="0.5"
+        >
+          {label}
+        </text>
+
+        {/* Number badge */}
+        <NumberBadge
+          x={center.x}
+          y={center.y}
+          value={current}
+          color={baseColor}
+          size={pos.width < 50 ? 20 : 28}
+        />
+
+        {/* Dot indicators */}
+        <DotIndicator
+          x={center.x}
+          y={pos.y + pos.height - 12}
+          fillPercent={frontPercent}
+          color={baseColor}
+          dots={5}
+          dotSize={pos.width < 50 ? 3 : 4}
+        />
+
+        {/* Rivets/bolts at corners */}
+        {pos.width > 40 && (
+          <>
+            <circle cx={pos.x + 8} cy={pos.y + 8} r={2} fill="#64748b" />
+            <circle cx={pos.x + pos.width - 8} cy={pos.y + 8} r={2} fill="#64748b" />
+            <circle cx={pos.x + 8} cy={pos.y + pos.height - 8} r={2} fill="#64748b" />
+            <circle cx={pos.x + pos.width - 8} cy={pos.y + pos.height - 8} r={2} fill="#64748b" />
+          </>
+        )}
+      </g>
+    </g>
+  );
+}
+
+export interface PremiumMaterialDiagramProps {
+  armorData: LocationArmorData[];
+  selectedLocation: MechLocation | null;
+  unallocatedPoints: number;
+  onLocationClick: (location: MechLocation) => void;
+  onAutoAllocate?: () => void;
+  className?: string;
+}
+
+export function PremiumMaterialDiagram({
+  armorData,
+  selectedLocation,
+  unallocatedPoints,
+  onLocationClick,
+  onAutoAllocate,
+  className = '',
+}: PremiumMaterialDiagramProps): React.ReactElement {
+  const [hoveredLocation, setHoveredLocation] = useState<MechLocation | null>(null);
+
+  const getArmorData = (location: MechLocation): LocationArmorData | undefined => {
+    return armorData.find((d) => d.location === location);
+  };
+
+  const isOverAllocated = unallocatedPoints < 0;
+
+  const locations: MechLocation[] = [
+    MechLocation.HEAD,
+    MechLocation.CENTER_TORSO,
+    MechLocation.LEFT_TORSO,
+    MechLocation.RIGHT_TORSO,
+    MechLocation.LEFT_ARM,
+    MechLocation.RIGHT_ARM,
+    MechLocation.LEFT_LEG,
+    MechLocation.RIGHT_LEG,
+  ];
+
+  return (
+    <div
+      className={`rounded-xl border p-5 ${className}`}
+      style={{
+        background: 'linear-gradient(180deg, #1e293b 0%, #0f172a 100%)',
+        borderColor: '#334155',
+      }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-5">
+        <div className="flex items-center gap-2">
+          <h3 className="text-lg font-semibold text-slate-200">
+            Armor Configuration
+          </h3>
+          <ArmorDiagramQuickSettings />
+        </div>
+        {onAutoAllocate && (
+          <button
+            onClick={onAutoAllocate}
+            className={`px-4 py-2 text-sm font-medium rounded-lg transition-all ${
+              isOverAllocated
+                ? 'bg-red-500/20 text-red-400 border border-red-500/50 hover:bg-red-500/30'
+                : 'bg-amber-500/20 text-amber-400 border border-amber-500/50 hover:bg-amber-500/30'
+            }`}
+            style={{
+              boxShadow: isOverAllocated
+                ? '0 0 20px rgba(239, 68, 68, 0.1)'
+                : '0 0 20px rgba(245, 158, 11, 0.1)',
+            }}
+          >
+            Auto-Allocate
+            <span className="ml-2 px-2 py-0.5 rounded bg-black/20 text-xs">
+              {unallocatedPoints}
+            </span>
+          </button>
+        )}
+      </div>
+
+      {/* Diagram */}
+      <div className="relative">
+        <svg
+          viewBox="0 0 320 380"
+          className="w-full max-w-[320px] mx-auto"
+          style={{ height: 'auto' }}
+        >
+          <GradientDefs />
+
+          {/* Ambient glow behind mech */}
+          <ellipse
+            cx="160"
+            cy="200"
+            rx="120"
+            ry="160"
+            fill="url(#armor-gradient-selected)"
+            opacity="0.03"
+          />
+
+          {/* Render all locations */}
+          {locations.map((loc) => (
+            <PremiumLocation
+              key={loc}
+              location={loc}
+              data={getArmorData(loc)}
+              isSelected={selectedLocation === loc}
+              isHovered={hoveredLocation === loc}
+              onClick={() => onLocationClick(loc)}
+              onHover={(h) => setHoveredLocation(h ? loc : null)}
+            />
+          ))}
+        </svg>
+      </div>
+
+      {/* Legend */}
+      <div className="flex justify-center gap-5 mt-5">
+        <div className="flex items-center gap-2">
+          <div className="w-3 h-3 rounded-full bg-green-500 shadow-lg shadow-green-500/30" />
+          <span className="text-xs text-slate-400">Optimal</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-3 h-3 rounded-full bg-amber-500 shadow-lg shadow-amber-500/30" />
+          <span className="text-xs text-slate-400">Moderate</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-3 h-3 rounded-full bg-red-500 shadow-lg shadow-red-500/30" />
+          <span className="text-xs text-slate-400">Critical</span>
+        </div>
+      </div>
+
+      {/* Instructions */}
+      <p className="text-xs text-slate-500 text-center mt-3">
+        Tap any plate to adjust armor values
+      </p>
+    </div>
+  );
+}

--- a/src/components/customizer/armor/variants/PremiumMaterialDiagram.tsx
+++ b/src/components/customizer/armor/variants/PremiumMaterialDiagram.tsx
@@ -154,11 +154,16 @@ function PremiumLocation({
   const basePos = REALISTIC_SILHOUETTE.locations[location];
   const label = LOCATION_LABELS[location];
   const showRear = hasTorsoRear(location);
+  const isLeg = location === MechLocation.LEFT_LEG || location === MechLocation.RIGHT_LEG;
 
-  // Adjust height for torso locations to fit stacked layout
+  // Adjust height for torso locations to fit stacked layout, offset legs down
+  const TORSO_MULTIPLIER = 1.4;
+  const legOffset = REALISTIC_SILHOUETTE.locations[MechLocation.CENTER_TORSO].height * (TORSO_MULTIPLIER - 1);
   const pos = showRear
-    ? { ...basePos, height: basePos.height * 1.4 }
-    : basePos;
+    ? { ...basePos, height: basePos.height * TORSO_MULTIPLIER }
+    : isLeg
+      ? { ...basePos, y: basePos.y + legOffset }
+      : basePos;
 
   const front = data?.current ?? 0;
   const frontMax = data?.maximum ?? 1;
@@ -478,7 +483,7 @@ export function PremiumMaterialDiagram({
       {/* Diagram */}
       <div className="relative">
         <svg
-          viewBox="0 0 320 440"
+          viewBox="0 0 320 490"
           className="w-full max-w-[320px] mx-auto"
           style={{ height: 'auto' }}
         >

--- a/src/components/customizer/armor/variants/PremiumMaterialDiagram.tsx
+++ b/src/components/customizer/armor/variants/PremiumMaterialDiagram.tsx
@@ -22,6 +22,8 @@ import {
 import {
   GradientDefs,
   getArmorStatusColor,
+  getTorsoFrontStatusColor,
+  getTorsoRearStatusColor,
   darkenColor,
   lightenColor,
 } from '../shared/ArmorFills';
@@ -170,12 +172,23 @@ function PremiumLocation({
   const rear = data?.rear ?? 0;
   const rearMax = data?.rearMaximum ?? 1;
 
-  const frontPercent = frontMax > 0 ? (front / frontMax) * 100 : 0;
-  const rearPercent = rearMax > 0 ? (rear / rearMax) * 100 : 0;
+  // For torso locations, use expected capacity (75/25 split) as baseline
+  const expectedFrontMax = showRear ? Math.round(frontMax * 0.75) : frontMax;
+  const expectedRearMax = showRear ? Math.round(frontMax * 0.25) : 1;
+
+  // Fill percentages based on expected capacity
+  const frontPercent = expectedFrontMax > 0 ? Math.min(100, (front / expectedFrontMax) * 100) : 0;
+  const rearPercent = expectedRearMax > 0 ? Math.min(100, (rear / expectedRearMax) * 100) : 0;
 
   // Status-based colors for front and rear independently
-  const frontColor = isSelected ? '#3b82f6' : getArmorStatusColor(front, frontMax);
-  const rearColor = isSelected ? '#2563eb' : getArmorStatusColor(rear, rearMax);
+  const frontColor = isSelected
+    ? '#3b82f6'
+    : showRear
+      ? getTorsoFrontStatusColor(front, frontMax)
+      : getArmorStatusColor(front, frontMax);
+  const rearColor = isSelected
+    ? '#2563eb'
+    : getTorsoRearStatusColor(rear, frontMax);
 
   // Lift effect when hovered
   const liftOffset = isHovered ? -2 : 0;
@@ -472,10 +485,7 @@ export function PremiumMaterialDiagram({
                 : '0 0 20px rgba(245, 158, 11, 0.1)',
             }}
           >
-            Auto-Allocate
-            <span className="ml-2 px-2 py-0.5 rounded bg-black/20 text-xs">
-              {unallocatedPoints}
-            </span>
+            Auto Allocate ({unallocatedPoints} pts)
           </button>
         )}
       </div>

--- a/src/components/customizer/armor/variants/TacticalHUDDiagram.tsx
+++ b/src/components/customizer/armor/variants/TacticalHUDDiagram.tsx
@@ -1,0 +1,482 @@
+/**
+ * Tactical HUD Armor Diagram
+ *
+ * Design Philosophy: Information density and military feel
+ * - Geometric/polygonal silhouette
+ * - Bottom-up tank fill style
+ * - LED segmented number display
+ * - Horizontal bar capacity indicator
+ * - Side-by-side front/rear view
+ * - Bracket focus interaction
+ */
+
+import React, { useState } from 'react';
+import { MechLocation } from '@/types/construction';
+import { LocationArmorData } from '../ArmorDiagram';
+import {
+  GEOMETRIC_SILHOUETTE,
+  LOCATION_LABELS,
+  hasTorsoRear,
+} from '../shared/MechSilhouette';
+import {
+  GradientDefs,
+  getArmorStatusColor,
+  getTorsoStatusColor,
+  darkenColor,
+} from '../shared/ArmorFills';
+import { ArmorDiagramQuickSettings } from '../ArmorDiagramQuickSettings';
+
+/**
+ * LED-style segmented digit display
+ */
+function LEDDigit({ value, x, y, size = 12 }: { value: string; x: number; y: number; size?: number }): React.ReactElement {
+  return (
+    <text
+      x={x}
+      y={y}
+      textAnchor="middle"
+      fontFamily="'Courier New', monospace"
+      fontWeight="bold"
+      fontSize={size}
+      fill="#22d3ee"
+      style={{
+        textShadow: '0 0 4px #22d3ee, 0 0 8px rgba(34, 211, 238, 0.5)',
+        letterSpacing: '1px',
+      }}
+    >
+      {value}
+    </text>
+  );
+}
+
+/**
+ * Horizontal bar gauge
+ */
+function BarGauge({
+  x,
+  y,
+  width,
+  height,
+  fillPercent,
+  color,
+}: {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  fillPercent: number;
+  color: string;
+}): React.ReactElement {
+  const fillWidth = (width - 2) * (fillPercent / 100);
+
+  return (
+    <g>
+      {/* Background */}
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        rx={1}
+        fill="#1e293b"
+        stroke="#334155"
+        strokeWidth={0.5}
+      />
+      {/* Fill */}
+      <rect
+        x={x + 1}
+        y={y + 1}
+        width={Math.max(0, fillWidth)}
+        height={height - 2}
+        rx={0.5}
+        fill={color}
+        className="transition-all duration-300"
+      />
+      {/* Tick marks */}
+      {[25, 50, 75].map((tick) => (
+        <line
+          key={tick}
+          x1={x + (width * tick) / 100}
+          y1={y}
+          x2={x + (width * tick) / 100}
+          y2={y + height}
+          stroke="#475569"
+          strokeWidth={0.5}
+        />
+      ))}
+    </g>
+  );
+}
+
+/**
+ * Corner bracket decorations
+ */
+function CornerBrackets({
+  x,
+  y,
+  width,
+  height,
+  size = 8,
+  color = '#22d3ee',
+}: {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  size?: number;
+  color?: string;
+}): React.ReactElement {
+  return (
+    <g stroke={color} strokeWidth={1.5} fill="none" style={{ filter: 'url(#armor-glow)' }}>
+      {/* Top-left */}
+      <path d={`M ${x} ${y + size} L ${x} ${y} L ${x + size} ${y}`} />
+      {/* Top-right */}
+      <path d={`M ${x + width - size} ${y} L ${x + width} ${y} L ${x + width} ${y + size}`} />
+      {/* Bottom-left */}
+      <path d={`M ${x} ${y + height - size} L ${x} ${y + height} L ${x + size} ${y + height}`} />
+      {/* Bottom-right */}
+      <path d={`M ${x + width - size} ${y + height} L ${x + width} ${y + height} L ${x + width} ${y + height - size}`} />
+    </g>
+  );
+}
+
+interface TacticalLocationProps {
+  location: MechLocation;
+  data?: LocationArmorData;
+  isSelected: boolean;
+  isHovered: boolean;
+  onClick: () => void;
+  onHover: (hovered: boolean) => void;
+  isRear?: boolean;
+  scale?: number;
+  offsetX?: number;
+}
+
+function TacticalLocation({
+  location,
+  data,
+  isSelected,
+  isHovered,
+  onClick,
+  onHover,
+  isRear = false,
+  scale = 1,
+  offsetX = 0,
+}: TacticalLocationProps): React.ReactElement {
+  const basePos = GEOMETRIC_SILHOUETTE.locations[location];
+  const pos = {
+    x: basePos.x * scale + offsetX,
+    y: basePos.y * scale,
+    width: basePos.width * scale,
+    height: basePos.height * scale,
+    path: basePos.path,
+  };
+
+  const label = LOCATION_LABELS[location];
+  const center = {
+    x: pos.x + pos.width / 2,
+    y: pos.y + pos.height / 2,
+  };
+
+  const current = isRear ? (data?.rear ?? 0) : (data?.current ?? 0);
+  const maximum = isRear ? (data?.rearMaximum ?? 1) : (data?.maximum ?? 1);
+  const percentage = maximum > 0 ? (current / maximum) * 100 : 0;
+  const isTorso = hasTorsoRear(location);
+
+  // For torso locations, use combined front+rear for status color
+  const baseColor = isTorso
+    ? getTorsoStatusColor(data?.current ?? 0, data?.maximum ?? 1, data?.rear ?? 0)
+    : getArmorStatusColor(current, maximum);
+  const fillColor = isSelected ? '#3b82f6' : baseColor;
+  const darkFill = darkenColor(fillColor, 0.6);
+
+  // Calculate tank fill
+  const fillHeight = pos.height * (percentage / 100);
+  const fillY = pos.y + pos.height - fillHeight;
+
+  return (
+    <g
+      role="button"
+      tabIndex={0}
+      aria-label={`${location} ${isRear ? 'rear ' : ''}armor: ${current} of ${maximum}`}
+      aria-pressed={isSelected}
+      className="cursor-pointer focus:outline-none"
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      onMouseEnter={() => onHover(true)}
+      onMouseLeave={() => onHover(false)}
+      onFocus={() => onHover(true)}
+      onBlur={() => onHover(false)}
+    >
+      {/* Background (empty state) */}
+      <rect
+        x={pos.x}
+        y={pos.y}
+        width={pos.width}
+        height={pos.height}
+        fill={darkFill}
+        stroke="#475569"
+        strokeWidth={1}
+        className="transition-colors duration-200"
+      />
+
+      {/* Tank fill */}
+      <rect
+        x={pos.x}
+        y={fillY}
+        width={pos.width}
+        height={fillHeight}
+        fill={fillColor}
+        opacity={0.8}
+        className="transition-all duration-300"
+      />
+
+      {/* Grid overlay */}
+      <rect
+        x={pos.x}
+        y={pos.y}
+        width={pos.width}
+        height={pos.height}
+        fill="url(#armor-grid)"
+        opacity={0.5}
+      />
+
+      {/* Border */}
+      <rect
+        x={pos.x}
+        y={pos.y}
+        width={pos.width}
+        height={pos.height}
+        fill="none"
+        stroke={isSelected ? '#60a5fa' : '#64748b'}
+        strokeWidth={isSelected ? 2 : 1}
+      />
+
+      {/* Corner brackets on hover/select */}
+      {(isHovered || isSelected) && (
+        <CornerBrackets
+          x={pos.x - 2}
+          y={pos.y - 2}
+          width={pos.width + 4}
+          height={pos.height + 4}
+          color={isSelected ? '#60a5fa' : '#22d3ee'}
+        />
+      )}
+
+      {/* Location label */}
+      <text
+        x={center.x}
+        y={pos.y + 10 * scale}
+        textAnchor="middle"
+        fontSize={7 * scale}
+        fill="#94a3b8"
+        fontFamily="monospace"
+      >
+        {isRear ? `${label}-R` : label}
+      </text>
+
+      {/* LED armor value */}
+      <LEDDigit
+        value={current.toString().padStart(2, '0')}
+        x={center.x}
+        y={center.y + 2}
+        size={Math.max(10, 14 * scale)}
+      />
+
+      {/* Bar gauge */}
+      <BarGauge
+        x={pos.x + 4}
+        y={pos.y + pos.height - 8 * scale}
+        width={pos.width - 8}
+        height={4 * scale}
+        fillPercent={percentage}
+        color={fillColor}
+      />
+    </g>
+  );
+}
+
+export interface TacticalHUDDiagramProps {
+  armorData: LocationArmorData[];
+  selectedLocation: MechLocation | null;
+  unallocatedPoints: number;
+  onLocationClick: (location: MechLocation) => void;
+  onAutoAllocate?: () => void;
+  className?: string;
+}
+
+export function TacticalHUDDiagram({
+  armorData,
+  selectedLocation,
+  unallocatedPoints,
+  onLocationClick,
+  onAutoAllocate,
+  className = '',
+}: TacticalHUDDiagramProps): React.ReactElement {
+  const [hoveredLocation, setHoveredLocation] = useState<MechLocation | null>(null);
+
+  const getArmorData = (location: MechLocation): LocationArmorData | undefined => {
+    return armorData.find((d) => d.location === location);
+  };
+
+  const isOverAllocated = unallocatedPoints < 0;
+
+  const allLocations: MechLocation[] = [
+    MechLocation.HEAD,
+    MechLocation.CENTER_TORSO,
+    MechLocation.LEFT_TORSO,
+    MechLocation.RIGHT_TORSO,
+    MechLocation.LEFT_ARM,
+    MechLocation.RIGHT_ARM,
+    MechLocation.LEFT_LEG,
+    MechLocation.RIGHT_LEG,
+  ];
+
+  const torsoLocations: MechLocation[] = [
+    MechLocation.CENTER_TORSO,
+    MechLocation.LEFT_TORSO,
+    MechLocation.RIGHT_TORSO,
+  ];
+
+  // Scale factors for side-by-side layout
+  const frontScale = 0.65;
+  const rearScale = 0.45;
+  const frontOffset = 0;
+  const rearOffset = 195;
+
+  return (
+    <div className={`bg-slate-900 rounded-lg border border-slate-700 p-4 ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
+          <h3 className="text-sm font-mono font-bold text-slate-300 tracking-wider">
+            ARMOR DIAGNOSTIC
+          </h3>
+          <ArmorDiagramQuickSettings />
+        </div>
+        {onAutoAllocate && (
+          <button
+            onClick={onAutoAllocate}
+            className={`px-2 py-1 text-xs font-mono font-bold rounded border transition-colors ${
+              isOverAllocated
+                ? 'border-red-600 text-red-400 hover:bg-red-900/30'
+                : 'border-amber-600 text-amber-400 hover:bg-amber-900/30'
+            }`}
+          >
+            AUTO-ALLOC [{unallocatedPoints > 0 ? '+' : ''}{unallocatedPoints}]
+          </button>
+        )}
+      </div>
+
+      {/* View labels */}
+      <div className="flex justify-between px-4 mb-2 text-xs font-mono text-slate-500">
+        <span>[ FRONT VIEW ]</span>
+        <span>[ REAR VIEW ]</span>
+      </div>
+
+      {/* Diagram - side by side */}
+      <div className="relative">
+        <svg
+          viewBox="0 0 340 280"
+          className="w-full mx-auto"
+          style={{ height: 'auto', maxWidth: '400px' }}
+        >
+          <GradientDefs />
+
+          {/* Divider line */}
+          <line
+            x1="170"
+            y1="10"
+            x2="170"
+            y2="270"
+            stroke="#334155"
+            strokeWidth="1"
+            strokeDasharray="4 2"
+          />
+
+          {/* Front view - all locations */}
+          {allLocations.map((loc) => (
+            <TacticalLocation
+              key={`front-${loc}`}
+              location={loc}
+              data={getArmorData(loc)}
+              isSelected={selectedLocation === loc}
+              isHovered={hoveredLocation === loc}
+              onClick={() => onLocationClick(loc)}
+              onHover={(h) => setHoveredLocation(h ? loc : null)}
+              scale={frontScale}
+              offsetX={frontOffset}
+            />
+          ))}
+
+          {/* Rear view - torso locations only */}
+          {torsoLocations.map((loc) => (
+            <TacticalLocation
+              key={`rear-${loc}`}
+              location={loc}
+              data={getArmorData(loc)}
+              isSelected={selectedLocation === loc}
+              isHovered={hoveredLocation === loc}
+              onClick={() => onLocationClick(loc)}
+              onHover={(h) => setHoveredLocation(h ? loc : null)}
+              isRear
+              scale={rearScale}
+              offsetX={rearOffset}
+            />
+          ))}
+
+          {/* Scan line animation */}
+          <line
+            x1="0"
+            y1="0"
+            x2="340"
+            y2="0"
+            stroke="#22d3ee"
+            strokeWidth="1"
+            opacity="0.3"
+          >
+            <animate
+              attributeName="y1"
+              values="0;280;0"
+              dur="4s"
+              repeatCount="indefinite"
+            />
+            <animate
+              attributeName="y2"
+              values="0;280;0"
+              dur="4s"
+              repeatCount="indefinite"
+            />
+          </line>
+        </svg>
+      </div>
+
+      {/* Status readout */}
+      <div className="flex justify-between items-center mt-3 px-2 py-1.5 bg-slate-800/50 rounded text-xs font-mono">
+        <div className="flex items-center gap-4">
+          <span className="text-slate-500">STATUS:</span>
+          <span className={isOverAllocated ? 'text-red-400' : 'text-green-400'}>
+            {isOverAllocated ? 'OVERALLOC' : 'NOMINAL'}
+          </span>
+        </div>
+        <div className="flex items-center gap-4">
+          <span className="text-slate-500">AVAIL:</span>
+          <span className={unallocatedPoints < 0 ? 'text-red-400' : 'text-cyan-400'}>
+            {unallocatedPoints}
+          </span>
+        </div>
+      </div>
+
+      {/* Instructions */}
+      <p className="text-xs text-slate-600 text-center mt-2 font-mono">
+        SELECT LOCATION TO MODIFY
+      </p>
+    </div>
+  );
+}

--- a/src/components/customizer/armor/variants/TacticalHUDDiagram.tsx
+++ b/src/components/customizer/armor/variants/TacticalHUDDiagram.tsx
@@ -21,6 +21,8 @@ import {
 import {
   GradientDefs,
   getArmorStatusColor,
+  getTorsoFrontStatusColor,
+  getTorsoRearStatusColor,
   darkenColor,
 } from '../shared/ArmorFills';
 import { ArmorDiagramQuickSettings } from '../ArmorDiagramQuickSettings';
@@ -180,12 +182,23 @@ function TacticalLocation({
   const rear = data?.rear ?? 0;
   const rearMax = data?.rearMaximum ?? 1;
 
-  const frontPercent = frontMax > 0 ? (front / frontMax) * 100 : 0;
-  const rearPercent = rearMax > 0 ? (rear / rearMax) * 100 : 0;
+  // For torso locations, use expected capacity (75/25 split) as baseline
+  const expectedFrontMax = showRear ? Math.round(frontMax * 0.75) : frontMax;
+  const expectedRearMax = showRear ? Math.round(frontMax * 0.25) : 1;
+
+  // Fill percentages based on expected capacity
+  const frontPercent = expectedFrontMax > 0 ? Math.min(100, (front / expectedFrontMax) * 100) : 0;
+  const rearPercent = expectedRearMax > 0 ? Math.min(100, (rear / expectedRearMax) * 100) : 0;
 
   // Status-based colors for front and rear
-  const frontColor = isSelected ? '#3b82f6' : getArmorStatusColor(front, frontMax);
-  const rearColor = isSelected ? '#3b82f6' : getArmorStatusColor(rear, rearMax);
+  const frontColor = isSelected
+    ? '#3b82f6'
+    : showRear
+      ? getTorsoFrontStatusColor(front, frontMax)
+      : getArmorStatusColor(front, frontMax);
+  const rearColor = isSelected
+    ? '#3b82f6'
+    : getTorsoRearStatusColor(rear, frontMax);
   const darkFrontFill = darkenColor(frontColor, 0.6);
   const darkRearFill = darkenColor(rearColor, 0.6);
 
@@ -443,7 +456,7 @@ export function TacticalHUDDiagram({
                 : 'border-amber-600 text-amber-400 hover:bg-amber-900/30'
             }`}
           >
-            AUTO-ALLOC [{unallocatedPoints > 0 ? '+' : ''}{unallocatedPoints}]
+            Auto Allocate ({unallocatedPoints} pts)
           </button>
         )}
       </div>

--- a/src/components/customizer/armor/variants/TacticalHUDDiagram.tsx
+++ b/src/components/customizer/armor/variants/TacticalHUDDiagram.tsx
@@ -159,11 +159,16 @@ function TacticalLocation({
   const basePos = GEOMETRIC_SILHOUETTE.locations[location];
   const label = LOCATION_LABELS[location];
   const showRear = hasTorsoRear(location);
+  const isLeg = location === MechLocation.LEFT_LEG || location === MechLocation.RIGHT_LEG;
 
-  // Adjust height for torso locations to fit stacked layout
+  // Adjust height for torso locations to fit stacked layout, offset legs down
+  const TORSO_MULTIPLIER = 1.5;
+  const legOffset = GEOMETRIC_SILHOUETTE.locations[MechLocation.CENTER_TORSO].height * (TORSO_MULTIPLIER - 1);
   const pos = showRear
-    ? { ...basePos, height: basePos.height * 1.5 }
-    : basePos;
+    ? { ...basePos, height: basePos.height * TORSO_MULTIPLIER }
+    : isLeg
+      ? { ...basePos, y: basePos.y + legOffset }
+      : basePos;
 
   const center = {
     x: pos.x + pos.width / 2,
@@ -446,7 +451,7 @@ export function TacticalHUDDiagram({
       {/* Diagram */}
       <div className="relative">
         <svg
-          viewBox="0 0 300 420"
+          viewBox="0 0 300 500"
           className="w-full max-w-[300px] mx-auto"
           style={{ height: 'auto' }}
         >

--- a/src/components/customizer/armor/variants/index.ts
+++ b/src/components/customizer/armor/variants/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Armor Diagram Design Variants
+ *
+ * Export all diagram variants for UAT testing and selection.
+ */
+
+export { CleanTechDiagram } from './CleanTechDiagram';
+export type { CleanTechDiagramProps } from './CleanTechDiagram';
+
+export { NeonOperatorDiagram } from './NeonOperatorDiagram';
+export type { NeonOperatorDiagramProps } from './NeonOperatorDiagram';
+
+export { TacticalHUDDiagram } from './TacticalHUDDiagram';
+export type { TacticalHUDDiagramProps } from './TacticalHUDDiagram';
+
+export { PremiumMaterialDiagram } from './PremiumMaterialDiagram';
+export type { PremiumMaterialDiagramProps } from './PremiumMaterialDiagram';

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -54,8 +54,8 @@ function Toggle({
   onChange: (checked: boolean) => void;
 }) {
   return (
-    <div className="flex items-start justify-between gap-4">
-      <div>
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex-1 min-w-0">
         <div className="text-sm font-medium text-white">{label}</div>
         {description && (
           <div className="text-xs text-slate-400 mt-0.5">{description}</div>
@@ -65,13 +65,13 @@ function Toggle({
         role="switch"
         aria-checked={checked}
         onClick={() => onChange(!checked)}
-        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+        className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 focus:ring-offset-slate-800 ${
           checked ? 'bg-amber-500' : 'bg-slate-600'
         }`}
       >
         <span
-          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-            checked ? 'translate-x-6' : 'translate-x-1'
+          className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform duration-200 ease-in-out ${
+            checked ? 'translate-x-[22px]' : 'translate-x-1'
           }`}
         />
       </button>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,0 +1,318 @@
+/**
+ * Settings Page
+ *
+ * App configuration and preferences.
+ */
+
+import React from 'react';
+import Head from 'next/head';
+import { PageLayout } from '@/components/ui/PageLayout';
+import {
+  useAppSettingsStore,
+  AccentColor,
+  FontSize,
+  AnimationLevel,
+  ACCENT_COLOR_CSS,
+} from '@/stores/useAppSettingsStore';
+import { ArmorDiagramGridPreview } from '@/components/customizer/armor/ArmorDiagramPreview';
+
+/**
+ * Settings section wrapper
+ */
+function SettingsSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="bg-slate-800/50 rounded-lg border border-slate-700 p-5">
+      <h3 className="text-lg font-semibold text-white mb-1">{title}</h3>
+      {description && (
+        <p className="text-sm text-slate-400 mb-4">{description}</p>
+      )}
+      <div className="space-y-4">{children}</div>
+    </div>
+  );
+}
+
+/**
+ * Toggle switch component
+ */
+function Toggle({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string;
+  description?: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <div className="text-sm font-medium text-white">{label}</div>
+        {description && (
+          <div className="text-xs text-slate-400 mt-0.5">{description}</div>
+        )}
+      </div>
+      <button
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+          checked ? 'bg-amber-500' : 'bg-slate-600'
+        }`}
+      >
+        <span
+          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+            checked ? 'translate-x-6' : 'translate-x-1'
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Select dropdown component
+ */
+function Select<T extends string>({
+  label,
+  description,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  description?: string;
+  value: T;
+  options: { value: T; label: string; description?: string }[];
+  onChange: (value: T) => void;
+}) {
+  return (
+    <div>
+      <div className="text-sm font-medium text-white mb-1">{label}</div>
+      {description && (
+        <div className="text-xs text-slate-400 mb-2">{description}</div>
+      )}
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value as T)}
+        className="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+/**
+ * Color picker for accent colors
+ */
+function AccentColorPicker({
+  value,
+  onChange,
+}: {
+  value: AccentColor;
+  onChange: (color: AccentColor) => void;
+}) {
+  const colors: { value: AccentColor; label: string }[] = [
+    { value: 'amber', label: 'Amber' },
+    { value: 'cyan', label: 'Cyan' },
+    { value: 'emerald', label: 'Emerald' },
+    { value: 'rose', label: 'Rose' },
+    { value: 'violet', label: 'Violet' },
+    { value: 'blue', label: 'Blue' },
+  ];
+
+  return (
+    <div>
+      <div className="text-sm font-medium text-white mb-2">Accent Color</div>
+      <div className="text-xs text-slate-400 mb-3">
+        Customize the highlight color throughout the app
+      </div>
+      <div className="flex gap-3 flex-wrap">
+        {colors.map((color) => (
+          <button
+            key={color.value}
+            onClick={() => onChange(color.value)}
+            className={`w-10 h-10 rounded-lg border-2 transition-all ${
+              value === color.value
+                ? 'border-white scale-110 shadow-lg'
+                : 'border-transparent hover:border-slate-500'
+            }`}
+            style={{ backgroundColor: ACCENT_COLOR_CSS[color.value].primary }}
+            aria-label={color.label}
+            title={color.label}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+
+export default function SettingsPage() {
+  const settings = useAppSettingsStore();
+
+  return (
+    <>
+      <Head>
+        <title>Settings | MekStation</title>
+      </Head>
+
+      <PageLayout
+        title="Settings"
+        subtitle="Customize your MekStation experience"
+        maxWidth="narrow"
+      >
+        <div className="space-y-6 pb-8">
+          {/* Appearance Section */}
+          <SettingsSection
+            title="Appearance"
+            description="Customize colors, fonts, and visual effects"
+          >
+            <AccentColorPicker
+              value={settings.accentColor}
+              onChange={settings.setAccentColor}
+            />
+
+            <Select<FontSize>
+              label="Font Size"
+              description="Base font size for the application"
+              value={settings.fontSize}
+              onChange={settings.setFontSize}
+              options={[
+                { value: 'small', label: 'Small (14px)' },
+                { value: 'medium', label: 'Medium (16px)' },
+                { value: 'large', label: 'Large (18px)' },
+              ]}
+            />
+
+            <Select<AnimationLevel>
+              label="Animation Level"
+              description="Control the amount of motion and transitions"
+              value={settings.animationLevel}
+              onChange={settings.setAnimationLevel}
+              options={[
+                { value: 'full', label: 'Full - All animations enabled' },
+                { value: 'reduced', label: 'Reduced - Essential animations only' },
+                { value: 'none', label: 'None - Disable all animations' },
+              ]}
+            />
+
+            <Toggle
+              label="Compact Mode"
+              description="Reduce spacing and padding for more information density"
+              checked={settings.compactMode}
+              onChange={settings.setCompactMode}
+            />
+          </SettingsSection>
+
+          {/* Customizer Section */}
+          <SettingsSection
+            title="Customizer"
+            description="Configure the mech customizer interface"
+          >
+            <div>
+              <div className="text-sm font-medium text-white mb-2">Armor Diagram Style</div>
+              <div className="text-xs text-slate-400 mb-4">
+                Choose the visual style for the armor allocation diagram. Changes apply immediately.
+              </div>
+              <ArmorDiagramGridPreview
+                selectedVariant={settings.armorDiagramVariant}
+                onSelectVariant={settings.setArmorDiagramVariant}
+              />
+            </div>
+
+            <Toggle
+              label="Show Design Selector (UAT)"
+              description="Display the design variant dropdown in the armor tab for testing"
+              checked={settings.showArmorDiagramSelector}
+              onChange={settings.setShowArmorDiagramSelector}
+            />
+          </SettingsSection>
+
+          {/* UI Behavior Section */}
+          <SettingsSection
+            title="UI Behavior"
+            description="Control how the interface behaves"
+          >
+            <Toggle
+              label="Collapse Sidebar by Default"
+              description="Start with the sidebar in collapsed state"
+              checked={settings.sidebarDefaultCollapsed}
+              onChange={settings.setSidebarDefaultCollapsed}
+            />
+
+            <Toggle
+              label="Confirm Before Closing"
+              description="Show a confirmation when closing tabs with unsaved changes"
+              checked={settings.confirmOnClose}
+              onChange={settings.setConfirmOnClose}
+            />
+
+            <Toggle
+              label="Show Tooltips"
+              description="Display helpful tooltips on hover"
+              checked={settings.showTooltips}
+              onChange={settings.setShowTooltips}
+            />
+          </SettingsSection>
+
+          {/* Accessibility Section */}
+          <SettingsSection
+            title="Accessibility"
+            description="Options for better accessibility"
+          >
+            <Toggle
+              label="High Contrast"
+              description="Increase contrast for better visibility"
+              checked={settings.highContrast}
+              onChange={settings.setHighContrast}
+            />
+
+            <Toggle
+              label="Reduce Motion"
+              description="Minimize animations for motion sensitivity"
+              checked={settings.reduceMotion}
+              onChange={settings.setReduceMotion}
+            />
+          </SettingsSection>
+
+          {/* Reset Section */}
+          <SettingsSection title="Reset">
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-sm font-medium text-white">Reset All Settings</div>
+                <div className="text-xs text-slate-400 mt-0.5">
+                  Restore all settings to their default values
+                </div>
+              </div>
+              <button
+                onClick={() => {
+                  if (confirm('Are you sure you want to reset all settings to defaults?')) {
+                    settings.resetToDefaults();
+                  }
+                }}
+                className="px-4 py-2 bg-red-600 hover:bg-red-500 text-white text-sm font-medium rounded-lg transition-colors"
+              >
+                Reset
+              </button>
+            </div>
+          </SettingsSection>
+        </div>
+      </PageLayout>
+    </>
+  );
+}

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -20,3 +20,6 @@ export { useTabManagerStore } from './useTabManagerStore';
 export type { TabInfo, TabManagerState } from './useTabManagerStore';
 export { UnitStoreProvider, useHasUnitStore } from './UnitStoreProvider';
 
+// App settings
+export * from './useAppSettingsStore';
+

--- a/src/stores/useAppSettingsStore.ts
+++ b/src/stores/useAppSettingsStore.ts
@@ -1,0 +1,171 @@
+/**
+ * App Settings Store
+ *
+ * Global app preferences stored in localStorage.
+ * Includes appearance, UI preferences, and feature settings.
+ */
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+/**
+ * Armor diagram design variants
+ */
+export type ArmorDiagramVariant =
+  | 'clean-tech'
+  | 'neon-operator'
+  | 'tactical-hud'
+  | 'premium-material';
+
+/**
+ * Accent color options
+ */
+export type AccentColor =
+  | 'amber'
+  | 'cyan'
+  | 'emerald'
+  | 'rose'
+  | 'violet'
+  | 'blue';
+
+/**
+ * Font size options
+ */
+export type FontSize = 'small' | 'medium' | 'large';
+
+/**
+ * Animation preference
+ */
+export type AnimationLevel = 'full' | 'reduced' | 'none';
+
+/**
+ * App settings state
+ */
+export interface AppSettingsState {
+  // Appearance
+  accentColor: AccentColor;
+  fontSize: FontSize;
+  animationLevel: AnimationLevel;
+  compactMode: boolean;
+
+  // Customizer preferences
+  armorDiagramVariant: ArmorDiagramVariant;
+  showArmorDiagramSelector: boolean; // UAT feature flag
+
+  // UI behavior
+  sidebarDefaultCollapsed: boolean;
+  confirmOnClose: boolean;
+  showTooltips: boolean;
+
+  // Accessibility
+  highContrast: boolean;
+  reduceMotion: boolean;
+
+  // Actions
+  setAccentColor: (color: AccentColor) => void;
+  setFontSize: (size: FontSize) => void;
+  setAnimationLevel: (level: AnimationLevel) => void;
+  setCompactMode: (compact: boolean) => void;
+  setArmorDiagramVariant: (variant: ArmorDiagramVariant) => void;
+  setShowArmorDiagramSelector: (show: boolean) => void;
+  setSidebarDefaultCollapsed: (collapsed: boolean) => void;
+  setConfirmOnClose: (confirm: boolean) => void;
+  setShowTooltips: (show: boolean) => void;
+  setHighContrast: (enabled: boolean) => void;
+  setReduceMotion: (enabled: boolean) => void;
+  resetToDefaults: () => void;
+}
+
+const DEFAULT_SETTINGS: Omit<AppSettingsState, 'setAccentColor' | 'setFontSize' | 'setAnimationLevel' | 'setCompactMode' | 'setArmorDiagramVariant' | 'setShowArmorDiagramSelector' | 'setSidebarDefaultCollapsed' | 'setConfirmOnClose' | 'setShowTooltips' | 'setHighContrast' | 'setReduceMotion' | 'resetToDefaults'> = {
+  // Appearance
+  accentColor: 'amber',
+  fontSize: 'medium',
+  animationLevel: 'full',
+  compactMode: false,
+
+  // Customizer preferences
+  armorDiagramVariant: 'clean-tech',
+  showArmorDiagramSelector: true, // Enable UAT selector by default
+
+  // UI behavior
+  sidebarDefaultCollapsed: false,
+  confirmOnClose: true,
+  showTooltips: true,
+
+  // Accessibility
+  highContrast: false,
+  reduceMotion: false,
+};
+
+/**
+ * App settings store with localStorage persistence
+ */
+export const useAppSettingsStore = create<AppSettingsState>()(
+  persist(
+    (set) => ({
+      ...DEFAULT_SETTINGS,
+
+      setAccentColor: (color) => set({ accentColor: color }),
+      setFontSize: (size) => set({ fontSize: size }),
+      setAnimationLevel: (level) => set({ animationLevel: level }),
+      setCompactMode: (compact) => set({ compactMode: compact }),
+      setArmorDiagramVariant: (variant) => set({ armorDiagramVariant: variant }),
+      setShowArmorDiagramSelector: (show) => set({ showArmorDiagramSelector: show }),
+      setSidebarDefaultCollapsed: (collapsed) => set({ sidebarDefaultCollapsed: collapsed }),
+      setConfirmOnClose: (confirm) => set({ confirmOnClose: confirm }),
+      setShowTooltips: (show) => set({ showTooltips: show }),
+      setHighContrast: (enabled) => set({ highContrast: enabled }),
+      setReduceMotion: (enabled) => set({ reduceMotion: enabled }),
+
+      resetToDefaults: () => set(DEFAULT_SETTINGS),
+    }),
+    {
+      name: 'mekstation-app-settings',
+    }
+  )
+);
+
+/**
+ * Accent color CSS variable mappings
+ */
+export const ACCENT_COLOR_CSS: Record<AccentColor, { primary: string; hover: string; muted: string }> = {
+  amber: {
+    primary: '#f59e0b',
+    hover: '#d97706',
+    muted: 'rgba(245, 158, 11, 0.15)',
+  },
+  cyan: {
+    primary: '#06b6d4',
+    hover: '#0891b2',
+    muted: 'rgba(6, 182, 212, 0.15)',
+  },
+  emerald: {
+    primary: '#10b981',
+    hover: '#059669',
+    muted: 'rgba(16, 185, 129, 0.15)',
+  },
+  rose: {
+    primary: '#f43f5e',
+    hover: '#e11d48',
+    muted: 'rgba(244, 63, 94, 0.15)',
+  },
+  violet: {
+    primary: '#8b5cf6',
+    hover: '#7c3aed',
+    muted: 'rgba(139, 92, 246, 0.15)',
+  },
+  blue: {
+    primary: '#3b82f6',
+    hover: '#2563eb',
+    muted: 'rgba(59, 130, 246, 0.15)',
+  },
+};
+
+/**
+ * Font size CSS mappings
+ */
+export const FONT_SIZE_CSS: Record<FontSize, string> = {
+  small: '14px',
+  medium: '16px',
+  large: '18px',
+};

--- a/src/utils/construction/armorCalculations.ts
+++ b/src/utils/construction/armorCalculations.ts
@@ -321,7 +321,7 @@ function createAllocationResult(
 
 /**
  * Calculate armor cost
- * 
+ *
  * @param armorPoints - Total armor points
  * @param armorType - Type of armor
  * @returns Cost in C-Bills
@@ -330,5 +330,45 @@ export function calculateArmorCost(armorPoints: number, armorType: ArmorTypeEnum
   const definition = getArmorDefinition(armorType);
   const baseCost = armorPoints * 10000; // Base 10000 C-Bills per point
   return baseCost * (definition?.costMultiplier ?? 1);
+}
+
+/**
+ * Standard front/rear armor distribution ratio
+ * Based on BattleTech conventions: 75% front, 25% rear
+ */
+export const FRONT_ARMOR_RATIO = 0.75;
+export const REAR_ARMOR_RATIO = 0.25;
+
+/**
+ * Get expected armor capacity for front and rear based on standard distribution
+ *
+ * Uses the 75/25 front/rear split as the baseline for calculating
+ * what the "expected" max is for each side. This allows armor status
+ * colors to show green when at expected capacity, even if front has
+ * more points than rear.
+ *
+ * @param totalMaxArmor - Total max armor for the location (front + rear)
+ * @returns Expected max for front and rear
+ */
+export function getExpectedArmorCapacity(totalMaxArmor: number): { front: number; rear: number } {
+  return {
+    front: Math.round(totalMaxArmor * FRONT_ARMOR_RATIO),
+    rear: Math.round(totalMaxArmor * REAR_ARMOR_RATIO),
+  };
+}
+
+/**
+ * Calculate armor fill percentage based on expected capacity
+ *
+ * Returns a percentage that can exceed 100% if the armor exceeds
+ * the expected allocation (e.g., heavily front-armored).
+ *
+ * @param current - Current armor points
+ * @param expectedMax - Expected max based on front/rear ratio
+ * @returns Fill percentage (can exceed 100)
+ */
+export function getArmorFillPercent(current: number, expectedMax: number): number {
+  if (expectedMax <= 0) return 0;
+  return (current / expectedMax) * 100;
 }
 


### PR DESCRIPTION
## Summary

This PR adds 4 distinct armor diagram design variants for user acceptance testing, along with a new settings page and quick settings functionality.

### Armor Diagram Variants
- **Clean Tech**: Maximum readability with solid gradient fills, plain bold numbers, and stacked front/rear display
- **Neon Operator**: Sci-fi aesthetic with wireframe outlines, glowing edges, progress rings, and toggle front/rear
- **Tactical HUD**: Military feel with geometric shapes, LED numbers, tank-fill gauges, and side-by-side views
- **Premium Material**: Metallic textures, circular badges, 3D layered plates, and dot indicators

### Features
- Settings page accessible from sidebar (`/settings`)
- App settings store with localStorage persistence
- Live preview grid for selecting armor diagram style
- Quick settings popup (gear icon) on diagram for fast variant switching
- ArmorTab now uses selected variant from settings

### Improvements
- Torso armor status now properly reflects front+rear combined totals
- Added `getTorsoStatusColor` and `getTorsoFillPercent` utility functions

### Documentation
- OpenSpec documentation for `armor-diagram-variants`
- OpenSpec documentation for `app-settings`

### Testing
- Unit tests for all 4 diagram variants (39 tests)
- Unit tests for useAppSettingsStore (26 tests)

## Test plan
- [ ] Verify all 4 armor diagram variants render correctly
- [ ] Test settings page loads and persists selections
- [ ] Verify quick settings popup works on all diagram variants
- [ ] Confirm torso locations show combined front+rear status colors
- [ ] Run full test suite (`npm test`)
- [ ] Run build (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)