### PR TITLE
feat: sync ArmorDiagramVariant when UITheme changes

### DIFF
--- a/openspec/specs/app-settings/spec.md
+++ b/openspec/specs/app-settings/spec.md
@@ -45,6 +45,17 @@ The system SHALL provide appearance customization options.
 - **THEN** spacing and padding are reduced throughout the app
 - **AND** more information fits on screen
 
+#### Scenario: UI Theme selection
+- **WHEN** user selects a UI theme
+- **THEN** theme options are: Default, Neon, Tactical, Minimal
+- **AND** selection applies immediately (live preview)
+- **AND** selection must be saved to persist
+- **AND** armor diagram variant auto-syncs to match:
+  - Default → Clean Tech
+  - Neon → Neon Operator
+  - Tactical → Tactical HUD
+  - Minimal → Premium Material
+
 ### Requirement: Customizer Settings
 The system SHALL provide customizer-specific settings.
 
@@ -117,7 +128,8 @@ Components SHALL access settings via Zustand store.
 | fontSize | FontSize | 'medium' | Base font size |
 | animationLevel | AnimationLevel | 'full' | Animation amount |
 | compactMode | boolean | false | Reduce spacing |
-| armorDiagramVariant | ArmorDiagramVariant | 'clean-tech' | Diagram design |
+| uiTheme | UITheme | 'default' | Global UI theme (auto-syncs armor diagram) |
+| armorDiagramVariant | ArmorDiagramVariant | 'clean-tech' | Diagram design (synced from uiTheme) |
 | showArmorDiagramSelector | boolean | true | Show UAT selector |
 | sidebarDefaultCollapsed | boolean | false | Start collapsed |
 | confirmOnClose | boolean | true | Confirm unsaved |

--- a/src/__tests__/stores/useAppSettingsStore.test.ts
+++ b/src/__tests__/stores/useAppSettingsStore.test.ts
@@ -284,4 +284,108 @@ describe('useAppSettingsStore', () => {
       expect(result.current.highContrast).toBe(false);
     });
   });
+
+  describe('UITheme to ArmorDiagramVariant synchronization', () => {
+    it('should sync armorDiagramVariant when setUITheme is called', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      // Default should be clean-tech for default theme
+      expect(result.current.uiTheme).toBe('default');
+      expect(result.current.armorDiagramVariant).toBe('clean-tech');
+
+      // Change to neon theme - should auto-select neon-operator diagram
+      act(() => {
+        result.current.setUITheme('neon');
+      });
+      expect(result.current.uiTheme).toBe('neon');
+      expect(result.current.armorDiagramVariant).toBe('neon-operator');
+
+      // Change to tactical theme - should auto-select tactical-hud diagram
+      act(() => {
+        result.current.setUITheme('tactical');
+      });
+      expect(result.current.uiTheme).toBe('tactical');
+      expect(result.current.armorDiagramVariant).toBe('tactical-hud');
+
+      // Change to minimal theme - should auto-select premium-material diagram
+      act(() => {
+        result.current.setUITheme('minimal');
+      });
+      expect(result.current.uiTheme).toBe('minimal');
+      expect(result.current.armorDiagramVariant).toBe('premium-material');
+
+      // Change back to default
+      act(() => {
+        result.current.setUITheme('default');
+      });
+      expect(result.current.uiTheme).toBe('default');
+      expect(result.current.armorDiagramVariant).toBe('clean-tech');
+    });
+
+    it('should sync armorDiagramVariant during draft preview with setDraftUITheme', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      // Initialize draft
+      act(() => {
+        result.current.initDraftAppearance();
+      });
+
+      // Change draft theme to neon - should also update diagram variant
+      act(() => {
+        result.current.setDraftUITheme('neon');
+      });
+      expect(result.current.draftAppearance?.uiTheme).toBe('neon');
+      expect(result.current.armorDiagramVariant).toBe('neon-operator');
+
+      // Change draft theme to tactical
+      act(() => {
+        result.current.setDraftUITheme('tactical');
+      });
+      expect(result.current.draftAppearance?.uiTheme).toBe('tactical');
+      expect(result.current.armorDiagramVariant).toBe('tactical-hud');
+    });
+
+    it('should restore armorDiagramVariant when reverting appearance changes', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      // Verify initial state
+      expect(result.current.uiTheme).toBe('default');
+      expect(result.current.armorDiagramVariant).toBe('clean-tech');
+
+      // Initialize draft and change theme
+      act(() => {
+        result.current.initDraftAppearance();
+        result.current.setDraftUITheme('neon');
+      });
+
+      // Diagram variant should have changed
+      expect(result.current.armorDiagramVariant).toBe('neon-operator');
+
+      // Revert - should restore diagram variant to match saved theme
+      act(() => {
+        result.current.revertAppearance();
+      });
+
+      expect(result.current.draftAppearance).toBeNull();
+      expect(result.current.uiTheme).toBe('default'); // Saved theme unchanged
+      expect(result.current.armorDiagramVariant).toBe('clean-tech'); // Restored to match saved theme
+    });
+
+    it('should allow independent armorDiagramVariant changes after theme sync', () => {
+      const { result } = renderHook(() => useAppSettingsStore());
+
+      // Set theme to neon (auto-syncs diagram)
+      act(() => {
+        result.current.setUITheme('neon');
+      });
+      expect(result.current.armorDiagramVariant).toBe('neon-operator');
+
+      // Manually override to a different diagram variant
+      act(() => {
+        result.current.setArmorDiagramVariant('clean-tech');
+      });
+      expect(result.current.armorDiagramVariant).toBe('clean-tech');
+      expect(result.current.uiTheme).toBe('neon'); // Theme unchanged
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- When selecting a UI theme, the armor diagram variant now automatically syncs to match
- Mapping: default→clean-tech, neon→neon-operator, tactical→tactical-hud, minimal→premium-material
- Live preview works during settings draft mode, and reverts properly if changes are cancelled

## Test plan
- [ ] Verify changing UI theme in settings also changes armor diagram variant
- [ ] Verify draft preview shows synced diagram variant
- [ ] Verify reverting settings restores original diagram variant
- [ ] Verify users can still manually override diagram variant after theme sync
- [ ] Run `npm test -- --testPathPattern=useAppSettingsStore` (30 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)