### PR TITLE
feat: armor diagram settings UX redesign with MegaMek variant

### DIFF
--- a/docs/plans/2026-01-10-armor-diagram-settings-ux.md
+++ b/docs/plans/2026-01-10-armor-diagram-settings-ux.md
@@ -1,0 +1,589 @@
+# Armor Diagram Settings UX Redesign
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the grid of diagram previews with a split-panel layout (list + large preview) using draft/save pattern for consistency with appearance settings.
+
+**Architecture:** Add draft state for customizer preferences to useAppSettingsStore, create new ArmorDiagramSettings component with split layout, add VariantThumbnail for list item previews.
+
+**Tech Stack:** React, Zustand, Tailwind CSS, SVG
+
+---
+
+## Design Summary
+
+### Layout
+```
+┌─────────────────────────────────────────────────────────┐
+│  Silhouette Aesthetic                                   │
+│  Visual style for the armor diagram                     │
+├─────────────────────┬───────────────────────────────────┤
+│  [thumb] Standard   │                                   │
+│  [thumb] Glow       │      [Large Preview of            │
+│  [thumb] LED    ←   │       Selected Variant]           │
+│  [thumb] Metallic   │                                   │
+│  [thumb] MegaMek    │                                   │
+├─────────────────────┴───────────────────────────────────┤
+│  ⚠ Diagram style preview active    [Save Diagram Style] │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Behavior
+- Left list shows all variants with mini-preview thumbnails in each variant's actual style
+- Clicking a variant updates the large preview immediately (live preview)
+- Changes NOT persisted until "Save" clicked
+- Navigating away reverts to previously saved variant
+- ArmorTab and QuickSettings show draft preview while editing
+
+---
+
+## Task 1: Add Draft State for Customizer Preferences
+
+**Files:**
+- Modify: `src/stores/useAppSettingsStore.ts`
+- Modify: `src/__tests__/stores/useAppSettingsStore.test.ts`
+
+### Step 1: Add CustomizerSettings interface and draft state
+
+Add to the store after AppearanceSettings:
+
+```typescript
+/**
+ * Customizer settings that support live preview with save/revert
+ */
+export interface CustomizerSettings {
+  armorDiagramMode: ArmorDiagramMode;
+  armorDiagramVariant: ArmorDiagramVariant;
+}
+```
+
+Add to AppSettingsState interface:
+
+```typescript
+// Draft customizer for live preview (not persisted)
+draftCustomizer: CustomizerSettings | null;
+hasUnsavedCustomizer: boolean;
+
+// Draft setters
+setDraftArmorDiagramMode: (mode: ArmorDiagramMode) => void;
+setDraftArmorDiagramVariant: (variant: ArmorDiagramVariant) => void;
+
+// Save/revert
+saveCustomizer: () => void;
+revertCustomizer: () => void;
+initDraftCustomizer: () => void;
+
+// Effective getters
+getEffectiveArmorDiagramMode: () => ArmorDiagramMode;
+getEffectiveArmorDiagramVariant: () => ArmorDiagramVariant;
+```
+
+### Step 2: Add to DEFAULT_SETTINGS
+
+```typescript
+// Draft customizer state (not persisted)
+draftCustomizer: null,
+hasUnsavedCustomizer: false,
+```
+
+### Step 3: Implement draft setters
+
+```typescript
+setDraftArmorDiagramMode: (mode) => set((state) => ({
+  draftCustomizer: {
+    armorDiagramMode: mode,
+    armorDiagramVariant: state.draftCustomizer?.armorDiagramVariant ?? state.armorDiagramVariant,
+  },
+  hasUnsavedCustomizer: true,
+})),
+
+setDraftArmorDiagramVariant: (variant) => set((state) => ({
+  draftCustomizer: {
+    armorDiagramMode: state.draftCustomizer?.armorDiagramMode ?? state.armorDiagramMode,
+    armorDiagramVariant: variant,
+  },
+  hasUnsavedCustomizer: true,
+})),
+```
+
+### Step 4: Implement save/revert/init
+
+```typescript
+initDraftCustomizer: () => set((state) => ({
+  draftCustomizer: {
+    armorDiagramMode: state.armorDiagramMode,
+    armorDiagramVariant: state.armorDiagramVariant,
+  },
+  hasUnsavedCustomizer: false,
+})),
+
+saveCustomizer: () => set((state) => {
+  if (!state.draftCustomizer) return state;
+  return {
+    armorDiagramMode: state.draftCustomizer.armorDiagramMode,
+    armorDiagramVariant: state.draftCustomizer.armorDiagramVariant,
+    hasUnsavedCustomizer: false,
+  };
+}),
+
+revertCustomizer: () => set({
+  draftCustomizer: null,
+  hasUnsavedCustomizer: false,
+}),
+```
+
+### Step 5: Implement effective getters
+
+```typescript
+getEffectiveArmorDiagramMode: () => {
+  const state = get();
+  return state.draftCustomizer?.armorDiagramMode ?? state.armorDiagramMode;
+},
+
+getEffectiveArmorDiagramVariant: () => {
+  const state = get();
+  return state.draftCustomizer?.armorDiagramVariant ?? state.armorDiagramVariant;
+},
+```
+
+### Step 6: Update ActionKeys type
+
+Add the new action keys to the ActionKeys type union.
+
+### Step 7: Write tests
+
+Add test suite for customizer draft behavior similar to appearance tests.
+
+### Step 8: Run tests
+
+```bash
+npm test -- --testPathPattern="useAppSettingsStore" --watchAll=false
+```
+
+---
+
+## Task 2: Create VariantThumbnail Component
+
+**Files:**
+- Create: `src/components/customizer/armor/VariantThumbnail.tsx`
+
+### Step 1: Create the component
+
+```typescript
+/**
+ * Variant Thumbnail
+ *
+ * Mini ~40x60px preview showing center torso in each variant's style.
+ * Self-contained styling - does not inherit from global theme.
+ */
+
+import React from 'react';
+import { ArmorDiagramVariant } from '@/stores/useAppSettingsStore';
+
+interface VariantThumbnailProps {
+  variant: ArmorDiagramVariant;
+  className?: string;
+}
+
+export function VariantThumbnail({ variant, className = '' }: VariantThumbnailProps): React.ReactElement {
+  // Render a simplified center torso shape with variant-specific styling
+  const getVariantStyles = () => {
+    switch (variant) {
+      case 'clean-tech':
+        return {
+          fill: '#22c55e',
+          stroke: '#000',
+          strokeWidth: 1.5,
+          filter: undefined,
+        };
+      case 'neon-operator':
+        return {
+          fill: 'rgba(6, 182, 212, 0.3)',
+          stroke: '#06b6d4',
+          strokeWidth: 2,
+          filter: 'url(#neon-glow)',
+        };
+      case 'tactical-hud':
+        return {
+          fill: '#1e3a5f',
+          stroke: '#3b82f6',
+          strokeWidth: 1.5,
+          filter: undefined,
+        };
+      case 'premium-material':
+        return {
+          fill: 'url(#metallic-gradient)',
+          stroke: '#94a3b8',
+          strokeWidth: 1,
+          filter: undefined,
+        };
+      case 'megamek':
+        return {
+          fill: '#22c55e',
+          stroke: '#000',
+          strokeWidth: 1.2,
+          filter: undefined,
+        };
+    }
+  };
+
+  const styles = getVariantStyles();
+
+  return (
+    <svg
+      viewBox="0 0 40 60"
+      className={`w-10 h-15 ${className}`}
+    >
+      <defs>
+        <filter id="neon-glow" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="2" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+        <linearGradient id="metallic-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="#64748b" />
+          <stop offset="50%" stopColor="#94a3b8" />
+          <stop offset="100%" stopColor="#475569" />
+        </linearGradient>
+      </defs>
+
+      {/* Simplified torso shape */}
+      <rect
+        x="8"
+        y="5"
+        width="24"
+        height="50"
+        rx="3"
+        fill={styles.fill}
+        stroke={styles.stroke}
+        strokeWidth={styles.strokeWidth}
+        filter={styles.filter}
+      />
+
+      {/* Variant-specific decorations */}
+      {variant === 'neon-operator' && (
+        <rect
+          x="12"
+          y="10"
+          width="16"
+          height="40"
+          rx="2"
+          fill="none"
+          stroke="#06b6d4"
+          strokeWidth="0.5"
+          strokeDasharray="2 2"
+        />
+      )}
+
+      {variant === 'tactical-hud' && (
+        <>
+          <rect x="14" y="20" width="12" height="4" fill="#3b82f6" opacity="0.8" />
+          <rect x="14" y="28" width="12" height="4" fill="#3b82f6" opacity="0.6" />
+          <rect x="14" y="36" width="12" height="4" fill="#3b82f6" opacity="0.4" />
+        </>
+      )}
+    </svg>
+  );
+}
+```
+
+### Step 2: Export from index
+
+Add export to appropriate index file if one exists.
+
+---
+
+## Task 3: Create ArmorDiagramSettings Component
+
+**Files:**
+- Create: `src/components/customizer/armor/ArmorDiagramSettings.tsx`
+
+### Step 1: Create the split-panel component
+
+```typescript
+/**
+ * Armor Diagram Settings
+ *
+ * Split-panel layout for selecting armor diagram variant.
+ * Left: list with thumbnails, Right: large preview.
+ * Uses draft/save pattern for consistency with appearance settings.
+ */
+
+import React, { useEffect } from 'react';
+import { useAppSettingsStore, ArmorDiagramVariant } from '@/stores/useAppSettingsStore';
+import { VariantThumbnail } from './VariantThumbnail';
+import { ArmorDiagramPreview, DIAGRAM_VARIANT_INFO } from './ArmorDiagramPreview';
+
+interface ArmorDiagramSettingsProps {
+  className?: string;
+}
+
+export function ArmorDiagramSettings({ className = '' }: ArmorDiagramSettingsProps): React.ReactElement {
+  const initDraftCustomizer = useAppSettingsStore((s) => s.initDraftCustomizer);
+  const saveCustomizer = useAppSettingsStore((s) => s.saveCustomizer);
+  const hasUnsavedCustomizer = useAppSettingsStore((s) => s.hasUnsavedCustomizer);
+  const setDraftArmorDiagramVariant = useAppSettingsStore((s) => s.setDraftArmorDiagramVariant);
+  const getEffectiveArmorDiagramVariant = useAppSettingsStore((s) => s.getEffectiveArmorDiagramVariant);
+
+  const effectiveVariant = getEffectiveArmorDiagramVariant();
+
+  // Initialize draft on mount
+  useEffect(() => {
+    initDraftCustomizer();
+  }, [initDraftCustomizer]);
+
+  const variants: ArmorDiagramVariant[] = [
+    'clean-tech',
+    'neon-operator',
+    'tactical-hud',
+    'premium-material',
+    'megamek',
+  ];
+
+  return (
+    <div className={className}>
+      <div className="flex gap-4">
+        {/* Left: Variant list */}
+        <div className="w-48 space-y-1">
+          {variants.map((variant) => {
+            const info = DIAGRAM_VARIANT_INFO[variant];
+            const isSelected = effectiveVariant === variant;
+
+            return (
+              <button
+                key={variant}
+                onClick={() => setDraftArmorDiagramVariant(variant)}
+                className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left transition-colors ${
+                  isSelected
+                    ? 'bg-accent/20 border border-accent'
+                    : 'bg-surface-raised/30 border border-transparent hover:bg-surface-raised hover:border-border-theme'
+                }`}
+              >
+                <VariantThumbnail variant={variant} />
+                <div className="flex-1 min-w-0">
+                  <div className={`text-sm font-medium ${isSelected ? 'text-accent' : 'text-text-theme-primary'}`}>
+                    {info.name}
+                  </div>
+                  <div className="text-xs text-text-theme-secondary truncate">
+                    {info.description}
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Right: Large preview */}
+        <div className="flex-1">
+          <ArmorDiagramPreview variant={effectiveVariant} />
+        </div>
+      </div>
+
+      {/* Save indicator */}
+      {hasUnsavedCustomizer && (
+        <div className="flex items-center justify-between mt-4 p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg">
+          <div className="flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 text-amber-400">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+            </svg>
+            <span className="text-sm text-amber-200">
+              Diagram style preview active — save to keep changes
+            </span>
+          </div>
+          <button
+            onClick={saveCustomizer}
+            className="px-3 py-1.5 text-sm font-medium bg-amber-600 hover:bg-amber-500 text-white rounded-md transition-colors"
+          >
+            Save Diagram Style
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+### Step 2: Export from armor components
+
+Add export to the armor components index if applicable.
+
+---
+
+## Task 4: Update Settings Page
+
+**Files:**
+- Modify: `src/pages/settings.tsx`
+
+### Step 1: Import the new component
+
+```typescript
+import { ArmorDiagramSettings } from '@/components/customizer/armor/ArmorDiagramSettings';
+```
+
+### Step 2: Add revert on route change
+
+Update the route change handler:
+
+```typescript
+const revertCustomizer = useAppSettingsStore((s) => s.revertCustomizer);
+
+useEffect(() => {
+  const handleRouteChange = () => {
+    revertAppearance();
+    revertCustomizer();  // Add this
+  };
+
+  router.events.on('routeChangeStart', handleRouteChange);
+  return () => {
+    router.events.off('routeChangeStart', handleRouteChange);
+  };
+}, [router.events, revertAppearance, revertCustomizer]);
+```
+
+### Step 3: Replace the grid preview
+
+Replace in Customizer section:
+
+```typescript
+{/* Armor Diagram Variant */}
+{settings.armorDiagramMode === 'silhouette' && (
+  <div>
+    <div className="text-sm font-medium text-text-theme-primary mb-2">Silhouette Aesthetic</div>
+    <div className="text-xs text-text-theme-secondary mb-3">
+      Visual style for the armor diagram
+    </div>
+    <ArmorDiagramSettings />
+  </div>
+)}
+```
+
+Remove the old ArmorDiagramGridPreview usage.
+
+---
+
+## Task 5: Update Components to Use Effective Getters
+
+**Files:**
+- Modify: `src/components/customizer/armor/ArmorTab.tsx`
+- Modify: `src/components/customizer/armor/ArmorDiagramQuickSettings.tsx`
+
+### Step 1: Update ArmorTab
+
+Change from:
+```typescript
+const armorDiagramVariant = useAppSettingsStore((s) => s.armorDiagramVariant);
+```
+
+To:
+```typescript
+const getEffectiveArmorDiagramVariant = useAppSettingsStore((s) => s.getEffectiveArmorDiagramVariant);
+const armorDiagramVariant = getEffectiveArmorDiagramVariant();
+```
+
+### Step 2: Update ArmorDiagramQuickSettings
+
+Same change - use `getEffectiveArmorDiagramVariant()` instead of reading `armorDiagramVariant` directly.
+
+Also update the setter to use `setDraftArmorDiagramVariant` instead of `setArmorDiagramVariant`.
+
+---
+
+## Task 6: Write Tests and Verify
+
+**Files:**
+- Modify: `src/__tests__/stores/useAppSettingsStore.test.ts`
+
+### Step 1: Add customizer draft tests
+
+```typescript
+describe('Customizer draft/save system', () => {
+  it('should initialize draft with current values', () => {
+    const { result } = renderHook(() => useAppSettingsStore());
+
+    act(() => {
+      result.current.initDraftCustomizer();
+    });
+
+    expect(result.current.draftCustomizer).toEqual({
+      armorDiagramMode: 'silhouette',
+      armorDiagramVariant: 'clean-tech',
+    });
+    expect(result.current.hasUnsavedCustomizer).toBe(false);
+  });
+
+  it('should update draft without persisting', () => {
+    const { result } = renderHook(() => useAppSettingsStore());
+
+    act(() => {
+      result.current.initDraftCustomizer();
+      result.current.setDraftArmorDiagramVariant('megamek');
+    });
+
+    expect(result.current.draftCustomizer?.armorDiagramVariant).toBe('megamek');
+    expect(result.current.armorDiagramVariant).toBe('clean-tech'); // Not persisted
+    expect(result.current.hasUnsavedCustomizer).toBe(true);
+  });
+
+  it('should persist on save', () => {
+    const { result } = renderHook(() => useAppSettingsStore());
+
+    act(() => {
+      result.current.initDraftCustomizer();
+      result.current.setDraftArmorDiagramVariant('megamek');
+      result.current.saveCustomizer();
+    });
+
+    expect(result.current.armorDiagramVariant).toBe('megamek');
+    expect(result.current.hasUnsavedCustomizer).toBe(false);
+  });
+
+  it('should revert on revertCustomizer', () => {
+    const { result } = renderHook(() => useAppSettingsStore());
+
+    act(() => {
+      result.current.initDraftCustomizer();
+      result.current.setDraftArmorDiagramVariant('megamek');
+      result.current.revertCustomizer();
+    });
+
+    expect(result.current.armorDiagramVariant).toBe('clean-tech'); // Original
+    expect(result.current.draftCustomizer).toBeNull();
+  });
+
+  it('getEffectiveArmorDiagramVariant returns draft when present', () => {
+    const { result } = renderHook(() => useAppSettingsStore());
+
+    act(() => {
+      result.current.initDraftCustomizer();
+      result.current.setDraftArmorDiagramVariant('tactical-hud');
+    });
+
+    expect(result.current.getEffectiveArmorDiagramVariant()).toBe('tactical-hud');
+  });
+});
+```
+
+### Step 2: Run all tests
+
+```bash
+npm test -- --watchAll=false
+```
+
+### Step 3: Run build
+
+```bash
+npm run build
+```
+
+---
+
+## Summary
+
+This implementation:
+1. Adds draft/save pattern for customizer settings (consistent with appearance)
+2. Creates split-panel UI with list + large preview
+3. Shows variant thumbnails with each variant's actual style
+4. Updates all components to use effective getters for live preview
+5. Handles save/revert lifecycle properly

--- a/docs/plans/2026-01-10-mech-silhouette-armor-diagram-impl.md
+++ b/docs/plans/2026-01-10-mech-silhouette-armor-diagram-impl.md
@@ -1,0 +1,1006 @@
+# Mech-Correct Armor Diagram Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a user-selectable "Schematic" mode alongside the existing SVG-based armor diagrams, with anatomically correct grid layout.
+
+**Architecture:** The existing armor diagram variants (CleanTech, NeonOperator, etc.) become the "Silhouette" mode. A new "Schematic" mode provides an anatomically correct CSS grid layout. Users choose between modes in Settings. Both modes share the same armor data and controls.
+
+**Tech Stack:** React, TypeScript, Zustand (useAppSettingsStore), Tailwind CSS, Jest/RTL
+
+---
+
+## Task 1: Add Armor Diagram Mode to Settings Store
+
+**Files:**
+- Modify: `src/stores/useAppSettingsStore.ts`
+
+**Step 1: Write the failing test**
+
+Create test file first:
+
+```typescript
+// src/stores/__tests__/useAppSettingsStore.armorMode.test.ts
+import { renderHook, act } from '@testing-library/react';
+import { useAppSettingsStore } from '../useAppSettingsStore';
+
+describe('useAppSettingsStore - armorDiagramMode', () => {
+  beforeEach(() => {
+    // Reset store to defaults
+    act(() => {
+      useAppSettingsStore.getState().resetToDefaults();
+    });
+  });
+
+  it('should have silhouette as default armor diagram mode', () => {
+    const { result } = renderHook(() => useAppSettingsStore());
+    expect(result.current.armorDiagramMode).toBe('silhouette');
+  });
+
+  it('should update armor diagram mode', () => {
+    const { result } = renderHook(() => useAppSettingsStore());
+
+    act(() => {
+      result.current.setArmorDiagramMode('schematic');
+    });
+
+    expect(result.current.armorDiagramMode).toBe('schematic');
+  });
+
+  it('should persist armor diagram mode', () => {
+    const { result } = renderHook(() => useAppSettingsStore());
+
+    act(() => {
+      result.current.setArmorDiagramMode('schematic');
+    });
+
+    // Verify it's in persisted state
+    const state = useAppSettingsStore.getState();
+    expect(state.armorDiagramMode).toBe('schematic');
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/stores/__tests__/useAppSettingsStore.armorMode.test.ts --watch=false`
+Expected: FAIL with "Property 'armorDiagramMode' does not exist"
+
+**Step 3: Add the setting to the store**
+
+```typescript
+// In src/stores/useAppSettingsStore.ts
+
+// Add type near other types (around line 23)
+export type ArmorDiagramMode = 'schematic' | 'silhouette';
+
+// Add to AppSettingsState interface (around line 84)
+armorDiagramMode: ArmorDiagramMode;
+
+// Add action to interface (around line 119)
+setArmorDiagramMode: (mode: ArmorDiagramMode) => void;
+
+// Add to ActionKeys type (around line 135)
+| 'setArmorDiagramMode'
+
+// Add to DEFAULT_SETTINGS (around line 151)
+armorDiagramMode: 'silhouette',
+
+// Add action in create() (around line 308)
+setArmorDiagramMode: (mode) => set({ armorDiagramMode: mode }),
+
+// Add to partialize() for persistence (around line 331)
+armorDiagramMode: state.armorDiagramMode,
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/stores/__tests__/useAppSettingsStore.armorMode.test.ts --watch=false`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/stores/useAppSettingsStore.ts src/stores/__tests__/useAppSettingsStore.armorMode.test.ts
+git commit -m "feat(settings): add armorDiagramMode setting for schematic/silhouette toggle"
+```
+
+---
+
+## Task 2: Create Shared Types for Armor Diagram
+
+**Files:**
+- Create: `src/components/armor/shared/types.ts`
+
+**Step 1: Create the types file**
+
+```typescript
+// src/components/armor/shared/types.ts
+import { MechLocation } from '@/types/construction';
+
+/**
+ * Armor data for a single location
+ */
+export interface LocationArmorData {
+  location: MechLocation;
+  current: number;
+  maximum: number;
+  rear?: number;
+  rearMaximum?: number;
+}
+
+/**
+ * Props shared by all armor diagram modes
+ */
+export interface ArmorDiagramBaseProps {
+  armorData: LocationArmorData[];
+  selectedLocation: MechLocation | null;
+  unallocatedPoints: number;
+  onLocationClick: (location: MechLocation) => void;
+  onAutoAllocate?: () => void;
+  className?: string;
+}
+
+/**
+ * Locations that have rear armor (torsos only)
+ */
+export const TORSO_LOCATIONS: readonly MechLocation[] = [
+  MechLocation.CENTER_TORSO,
+  MechLocation.LEFT_TORSO,
+  MechLocation.RIGHT_TORSO,
+] as const;
+
+/**
+ * Check if a location has rear armor
+ */
+export function hasRearArmor(location: MechLocation): boolean {
+  return TORSO_LOCATIONS.includes(location);
+}
+
+/**
+ * All mech locations in anatomical order (top to bottom, left to right)
+ */
+export const MECH_LOCATIONS_ORDERED: readonly MechLocation[] = [
+  MechLocation.HEAD,
+  MechLocation.LEFT_TORSO,
+  MechLocation.CENTER_TORSO,
+  MechLocation.RIGHT_TORSO,
+  MechLocation.LEFT_ARM,
+  MechLocation.RIGHT_ARM,
+  MechLocation.LEFT_LEG,
+  MechLocation.RIGHT_LEG,
+] as const;
+
+/**
+ * Short labels for locations
+ */
+export const LOCATION_SHORT_LABELS: Record<MechLocation, string> = {
+  [MechLocation.HEAD]: 'HD',
+  [MechLocation.CENTER_TORSO]: 'CT',
+  [MechLocation.LEFT_TORSO]: 'LT',
+  [MechLocation.RIGHT_TORSO]: 'RT',
+  [MechLocation.LEFT_ARM]: 'LA',
+  [MechLocation.RIGHT_ARM]: 'RA',
+  [MechLocation.LEFT_LEG]: 'LL',
+  [MechLocation.RIGHT_LEG]: 'RL',
+};
+```
+
+**Step 2: Verify file compiles**
+
+Run: `npx tsc --noEmit src/components/armor/shared/types.ts`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add src/components/armor/shared/types.ts
+git commit -m "feat(armor): add shared types for armor diagram modes"
+```
+
+---
+
+## Task 3: Create Schematic Location Component
+
+**Files:**
+- Create: `src/components/armor/schematic/SchematicLocation.tsx`
+- Create: `src/components/armor/schematic/__tests__/SchematicLocation.test.tsx`
+
+**Step 1: Write the failing test**
+
+```typescript
+// src/components/armor/schematic/__tests__/SchematicLocation.test.tsx
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SchematicLocation } from '../SchematicLocation';
+import { MechLocation } from '@/types/construction';
+
+describe('SchematicLocation', () => {
+  const defaultProps = {
+    location: MechLocation.CENTER_TORSO,
+    current: 35,
+    maximum: 47,
+    rear: 12,
+    rearMaximum: 23,
+    isSelected: false,
+    onClick: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render location label', () => {
+    render(<SchematicLocation {...defaultProps} />);
+    expect(screen.getByText('CT')).toBeInTheDocument();
+  });
+
+  it('should render front armor value', () => {
+    render(<SchematicLocation {...defaultProps} />);
+    expect(screen.getByText('35')).toBeInTheDocument();
+    expect(screen.getByText('/ 47')).toBeInTheDocument();
+  });
+
+  it('should render rear armor for torso locations', () => {
+    render(<SchematicLocation {...defaultProps} />);
+    expect(screen.getByText('Rear')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('should not render rear for non-torso locations', () => {
+    render(<SchematicLocation {...defaultProps} location={MechLocation.HEAD} rear={undefined} />);
+    expect(screen.queryByText('Rear')).not.toBeInTheDocument();
+  });
+
+  it('should call onClick when clicked', () => {
+    render(<SchematicLocation {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(defaultProps.onClick).toHaveBeenCalledWith(MechLocation.CENTER_TORSO);
+  });
+
+  it('should show selected state', () => {
+    const { container } = render(<SchematicLocation {...defaultProps} isSelected={true} />);
+    expect(container.querySelector('.ring-2')).toBeInTheDocument();
+  });
+
+  it('should have proper ARIA attributes', () => {
+    render(<SchematicLocation {...defaultProps} />);
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-label', expect.stringContaining('Center Torso'));
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/components/armor/schematic/__tests__/SchematicLocation.test.tsx --watch=false`
+Expected: FAIL with "Cannot find module '../SchematicLocation'"
+
+**Step 3: Implement SchematicLocation component**
+
+```typescript
+// src/components/armor/schematic/SchematicLocation.tsx
+import React from 'react';
+import { MechLocation } from '@/types/construction';
+import { hasRearArmor, LOCATION_SHORT_LABELS } from '../shared/types';
+
+/**
+ * Get status color based on armor percentage
+ */
+function getStatusColor(current: number, maximum: number): string {
+  if (maximum === 0) return 'bg-gray-500';
+  const percentage = (current / maximum) * 100;
+  if (percentage >= 75) return 'bg-green-500';
+  if (percentage >= 50) return 'bg-amber-500';
+  if (percentage >= 25) return 'bg-orange-500';
+  return 'bg-red-500';
+}
+
+export interface SchematicLocationProps {
+  location: MechLocation;
+  current: number;
+  maximum: number;
+  rear?: number;
+  rearMaximum?: number;
+  isSelected: boolean;
+  onClick: (location: MechLocation) => void;
+}
+
+export function SchematicLocation({
+  location,
+  current,
+  maximum,
+  rear,
+  rearMaximum,
+  isSelected,
+  onClick,
+}: SchematicLocationProps): React.ReactElement {
+  const label = LOCATION_SHORT_LABELS[location];
+  const showRear = hasRearArmor(location) && rear !== undefined;
+  const frontColor = getStatusColor(current, maximum);
+  const rearColor = showRear ? getStatusColor(rear!, rearMaximum ?? 1) : '';
+
+  const ariaLabel = showRear
+    ? `${location} armor: Front ${current} of ${maximum}, Rear ${rear} of ${rearMaximum}`
+    : `${location} armor: ${current} of ${maximum}`;
+
+  return (
+    <button
+      type="button"
+      role="button"
+      aria-label={ariaLabel}
+      aria-pressed={isSelected}
+      onClick={() => onClick(location)}
+      className={`
+        relative p-3 rounded-lg border transition-all duration-150
+        bg-surface-base hover:bg-surface-raised
+        ${isSelected ? 'ring-2 ring-blue-500 border-blue-500' : 'border-border-theme-subtle'}
+        focus:outline-none focus:ring-2 focus:ring-blue-500
+        min-h-[44px] min-w-[44px]
+      `}
+    >
+      {/* Location Label */}
+      <div className="text-xs font-semibold text-text-theme-secondary mb-1">
+        {label}
+      </div>
+
+      {/* Front Armor Section */}
+      <div className="flex items-center gap-2">
+        <div className={`w-2 h-8 rounded ${frontColor}`} />
+        <div className="flex flex-col">
+          <span className="text-lg font-bold text-white tabular-nums">{current}</span>
+          <span className="text-xs text-text-theme-secondary">/ {maximum}</span>
+        </div>
+      </div>
+
+      {/* Rear Armor Section (torso only) */}
+      {showRear && (
+        <div className="mt-2 pt-2 border-t border-border-theme-subtle">
+          <div className="text-xs text-text-theme-secondary mb-1">Rear</div>
+          <div className="flex items-center gap-2">
+            <div className={`w-2 h-6 rounded ${rearColor}`} />
+            <div className="flex flex-col">
+              <span className="text-sm font-bold text-white tabular-nums">{rear}</span>
+              <span className="text-xs text-text-theme-secondary">/ {rearMaximum}</span>
+            </div>
+          </div>
+        </div>
+      )}
+    </button>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/components/armor/schematic/__tests__/SchematicLocation.test.tsx --watch=false`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/components/armor/schematic/SchematicLocation.tsx src/components/armor/schematic/__tests__/SchematicLocation.test.tsx
+git commit -m "feat(armor): add SchematicLocation component for grid-based diagram"
+```
+
+---
+
+## Task 4: Create Schematic Diagram Component
+
+**Files:**
+- Create: `src/components/armor/schematic/SchematicDiagram.tsx`
+- Create: `src/components/armor/schematic/__tests__/SchematicDiagram.test.tsx`
+
+**Step 1: Write the failing test**
+
+```typescript
+// src/components/armor/schematic/__tests__/SchematicDiagram.test.tsx
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SchematicDiagram } from '../SchematicDiagram';
+import { MechLocation } from '@/types/construction';
+
+describe('SchematicDiagram', () => {
+  const mockArmorData = [
+    { location: MechLocation.HEAD, current: 9, maximum: 9 },
+    { location: MechLocation.CENTER_TORSO, current: 35, maximum: 47, rear: 12, rearMaximum: 23 },
+    { location: MechLocation.LEFT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.RIGHT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.LEFT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.RIGHT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.LEFT_LEG, current: 28, maximum: 32 },
+    { location: MechLocation.RIGHT_LEG, current: 28, maximum: 32 },
+  ];
+
+  const defaultProps = {
+    armorData: mockArmorData,
+    selectedLocation: null,
+    unallocatedPoints: 12,
+    onLocationClick: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render all 8 mech locations', () => {
+    render(<SchematicDiagram {...defaultProps} />);
+    expect(screen.getByText('HD')).toBeInTheDocument();
+    expect(screen.getByText('CT')).toBeInTheDocument();
+    expect(screen.getByText('LT')).toBeInTheDocument();
+    expect(screen.getByText('RT')).toBeInTheDocument();
+    expect(screen.getByText('LA')).toBeInTheDocument();
+    expect(screen.getByText('RA')).toBeInTheDocument();
+    expect(screen.getByText('LL')).toBeInTheDocument();
+    expect(screen.getByText('RL')).toBeInTheDocument();
+  });
+
+  it('should use anatomically correct grid layout', () => {
+    const { container } = render(<SchematicDiagram {...defaultProps} />);
+    const grid = container.querySelector('[style*="grid-template-areas"]');
+    expect(grid).toBeInTheDocument();
+  });
+
+  it('should call onLocationClick when a location is clicked', () => {
+    render(<SchematicDiagram {...defaultProps} />);
+    const headButton = screen.getByRole('button', { name: /Head armor/i });
+    fireEvent.click(headButton);
+    expect(defaultProps.onLocationClick).toHaveBeenCalledWith(MechLocation.HEAD);
+  });
+
+  it('should show selected state for selected location', () => {
+    const { container } = render(
+      <SchematicDiagram {...defaultProps} selectedLocation={MechLocation.HEAD} />
+    );
+    const selectedButton = container.querySelector('.ring-2');
+    expect(selectedButton).toBeInTheDocument();
+  });
+
+  it('should render auto-allocate button when handler provided', () => {
+    render(<SchematicDiagram {...defaultProps} onAutoAllocate={jest.fn()} />);
+    expect(screen.getByText(/Auto Allocate/i)).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/components/armor/schematic/__tests__/SchematicDiagram.test.tsx --watch=false`
+Expected: FAIL with "Cannot find module '../SchematicDiagram'"
+
+**Step 3: Implement SchematicDiagram component**
+
+```typescript
+// src/components/armor/schematic/SchematicDiagram.tsx
+import React from 'react';
+import { MechLocation } from '@/types/construction';
+import { ArmorDiagramBaseProps, LocationArmorData } from '../shared/types';
+import { SchematicLocation } from './SchematicLocation';
+
+/**
+ * Schematic Armor Diagram
+ *
+ * Anatomically correct CSS grid layout showing mech body parts
+ * in their proper positions with visual connectors.
+ */
+export function SchematicDiagram({
+  armorData,
+  selectedLocation,
+  unallocatedPoints,
+  onLocationClick,
+  onAutoAllocate,
+  className = '',
+}: ArmorDiagramBaseProps): React.ReactElement {
+  const getArmorData = (location: MechLocation): LocationArmorData | undefined => {
+    return armorData.find((d) => d.location === location);
+  };
+
+  const isOverAllocated = unallocatedPoints < 0;
+
+  const renderLocation = (location: MechLocation) => {
+    const data = getArmorData(location);
+    return (
+      <SchematicLocation
+        key={location}
+        location={location}
+        current={data?.current ?? 0}
+        maximum={data?.maximum ?? 1}
+        rear={data?.rear}
+        rearMaximum={data?.rearMaximum}
+        isSelected={selectedLocation === location}
+        onClick={onLocationClick}
+      />
+    );
+  };
+
+  return (
+    <div className={`bg-surface-base rounded-lg border border-border-theme-subtle p-4 ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-white">Armor Allocation</h3>
+        {onAutoAllocate && (
+          <button
+            onClick={onAutoAllocate}
+            className={`px-3 py-1.5 text-sm font-medium rounded transition-colors ${
+              isOverAllocated
+                ? 'bg-red-600 hover:bg-red-500 text-white'
+                : 'bg-accent hover:bg-accent-hover text-white'
+            }`}
+          >
+            Auto Allocate ({unallocatedPoints} pts)
+          </button>
+        )}
+      </div>
+
+      {/* Anatomically Correct Grid Layout */}
+      <div
+        className="hidden lg:grid gap-2"
+        style={{
+          gridTemplateAreas: `
+            ".    .    head   .    ."
+            "la   lt   ct     rt   ra"
+            ".    ll   .      rl   ."
+          `,
+          gridTemplateColumns: '1fr 1fr 1.2fr 1fr 1fr',
+          gridTemplateRows: 'auto auto auto',
+        }}
+      >
+        <div style={{ gridArea: 'head' }}>{renderLocation(MechLocation.HEAD)}</div>
+        <div style={{ gridArea: 'ct' }}>{renderLocation(MechLocation.CENTER_TORSO)}</div>
+        <div style={{ gridArea: 'lt' }}>{renderLocation(MechLocation.LEFT_TORSO)}</div>
+        <div style={{ gridArea: 'rt' }}>{renderLocation(MechLocation.RIGHT_TORSO)}</div>
+        <div style={{ gridArea: 'la' }}>{renderLocation(MechLocation.LEFT_ARM)}</div>
+        <div style={{ gridArea: 'ra' }}>{renderLocation(MechLocation.RIGHT_ARM)}</div>
+        <div style={{ gridArea: 'll' }}>{renderLocation(MechLocation.LEFT_LEG)}</div>
+        <div style={{ gridArea: 'rl' }}>{renderLocation(MechLocation.RIGHT_LEG)}</div>
+      </div>
+
+      {/* Mobile Stacked Layout */}
+      <div className="lg:hidden flex flex-col gap-3">
+        {/* Head */}
+        <div>
+          <h4 className="text-xs font-medium text-text-theme-secondary mb-1 px-1">Head</h4>
+          {renderLocation(MechLocation.HEAD)}
+        </div>
+
+        {/* Torso */}
+        <div>
+          <h4 className="text-xs font-medium text-text-theme-secondary mb-1 px-1">Torso</h4>
+          <div className="flex flex-col gap-2">
+            {renderLocation(MechLocation.CENTER_TORSO)}
+            <div className="flex gap-2">
+              {renderLocation(MechLocation.LEFT_TORSO)}
+              {renderLocation(MechLocation.RIGHT_TORSO)}
+            </div>
+          </div>
+        </div>
+
+        {/* Arms */}
+        <div>
+          <h4 className="text-xs font-medium text-text-theme-secondary mb-1 px-1">Arms</h4>
+          <div className="flex gap-2">
+            {renderLocation(MechLocation.LEFT_ARM)}
+            {renderLocation(MechLocation.RIGHT_ARM)}
+          </div>
+        </div>
+
+        {/* Legs */}
+        <div>
+          <h4 className="text-xs font-medium text-text-theme-secondary mb-1 px-1">Legs</h4>
+          <div className="flex gap-2">
+            {renderLocation(MechLocation.LEFT_LEG)}
+            {renderLocation(MechLocation.RIGHT_LEG)}
+          </div>
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className="flex justify-center gap-3 mt-4 text-xs">
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-green-500" />
+          <span className="text-text-theme-secondary">75%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-amber-500" />
+          <span className="text-text-theme-secondary">50%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-orange-500" />
+          <span className="text-text-theme-secondary">25%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-red-500" />
+          <span className="text-text-theme-secondary">&lt;25%</span>
+        </div>
+      </div>
+
+      {/* Instructions */}
+      <p className="text-xs text-text-theme-secondary text-center mt-2">
+        Click a location to edit armor values
+      </p>
+    </div>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/components/armor/schematic/__tests__/SchematicDiagram.test.tsx --watch=false`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/components/armor/schematic/SchematicDiagram.tsx src/components/armor/schematic/__tests__/SchematicDiagram.test.tsx
+git commit -m "feat(armor): add SchematicDiagram with anatomically correct grid layout"
+```
+
+---
+
+## Task 5: Create Index Exports for Schematic Module
+
+**Files:**
+- Create: `src/components/armor/schematic/index.ts`
+
+**Step 1: Create the index file**
+
+```typescript
+// src/components/armor/schematic/index.ts
+export { SchematicDiagram } from './SchematicDiagram';
+export { SchematicLocation } from './SchematicLocation';
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/components/armor/schematic/index.ts
+git commit -m "chore(armor): add schematic module exports"
+```
+
+---
+
+## Task 6: Create Armor Diagram Mode Switcher
+
+**Files:**
+- Create: `src/components/armor/ArmorDiagramModeSwitch.tsx`
+- Create: `src/components/armor/__tests__/ArmorDiagramModeSwitch.test.tsx`
+
+**Step 1: Write the failing test**
+
+```typescript
+// src/components/armor/__tests__/ArmorDiagramModeSwitch.test.tsx
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ArmorDiagramModeSwitch } from '../ArmorDiagramModeSwitch';
+import { useAppSettingsStore } from '@/stores/useAppSettingsStore';
+import { act } from '@testing-library/react';
+
+// Mock the store
+jest.mock('@/stores/useAppSettingsStore');
+
+describe('ArmorDiagramModeSwitch', () => {
+  const mockSetArmorDiagramMode = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAppSettingsStore as unknown as jest.Mock).mockReturnValue({
+      armorDiagramMode: 'silhouette',
+      setArmorDiagramMode: mockSetArmorDiagramMode,
+    });
+  });
+
+  it('should render mode options', () => {
+    render(<ArmorDiagramModeSwitch />);
+    expect(screen.getByText('Schematic')).toBeInTheDocument();
+    expect(screen.getByText('Silhouette')).toBeInTheDocument();
+  });
+
+  it('should show current mode as selected', () => {
+    render(<ArmorDiagramModeSwitch />);
+    const silhouetteButton = screen.getByText('Silhouette');
+    expect(silhouetteButton).toHaveClass('bg-accent');
+  });
+
+  it('should call setArmorDiagramMode when mode is changed', () => {
+    render(<ArmorDiagramModeSwitch />);
+    fireEvent.click(screen.getByText('Schematic'));
+    expect(mockSetArmorDiagramMode).toHaveBeenCalledWith('schematic');
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/components/armor/__tests__/ArmorDiagramModeSwitch.test.tsx --watch=false`
+Expected: FAIL with "Cannot find module '../ArmorDiagramModeSwitch'"
+
+**Step 3: Implement ArmorDiagramModeSwitch**
+
+```typescript
+// src/components/armor/ArmorDiagramModeSwitch.tsx
+import React from 'react';
+import { useAppSettingsStore, ArmorDiagramMode } from '@/stores/useAppSettingsStore';
+
+/**
+ * Toggle switch for armor diagram mode (Schematic vs Silhouette)
+ */
+export function ArmorDiagramModeSwitch(): React.ReactElement {
+  const { armorDiagramMode, setArmorDiagramMode } = useAppSettingsStore();
+
+  const modes: { id: ArmorDiagramMode; label: string }[] = [
+    { id: 'schematic', label: 'Schematic' },
+    { id: 'silhouette', label: 'Silhouette' },
+  ];
+
+  return (
+    <div className="flex gap-1 p-1 bg-surface-raised rounded-lg">
+      {modes.map((mode) => (
+        <button
+          key={mode.id}
+          onClick={() => setArmorDiagramMode(mode.id)}
+          className={`
+            px-3 py-1.5 text-sm font-medium rounded-md transition-colors
+            ${armorDiagramMode === mode.id
+              ? 'bg-accent text-white'
+              : 'text-text-theme-secondary hover:text-white hover:bg-surface-base'
+            }
+          `}
+          aria-pressed={armorDiagramMode === mode.id}
+        >
+          {mode.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/components/armor/__tests__/ArmorDiagramModeSwitch.test.tsx --watch=false`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/components/armor/ArmorDiagramModeSwitch.tsx src/components/armor/__tests__/ArmorDiagramModeSwitch.test.tsx
+git commit -m "feat(armor): add ArmorDiagramModeSwitch component"
+```
+
+---
+
+## Task 7: Create Unified Armor Diagram Orchestrator
+
+**Files:**
+- Modify: `src/components/armor/ArmorDiagram.tsx`
+- Create: `src/components/armor/__tests__/ArmorDiagram.mode.test.tsx`
+
+**Step 1: Write the failing test**
+
+```typescript
+// src/components/armor/__tests__/ArmorDiagram.mode.test.tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ArmorDiagram } from '../ArmorDiagram';
+import { useAppSettingsStore } from '@/stores/useAppSettingsStore';
+import { MechLocation } from '@/types/construction';
+
+// Mock the store
+jest.mock('@/stores/useAppSettingsStore');
+
+describe('ArmorDiagram mode switching', () => {
+  const mockArmorData = [
+    { location: MechLocation.HEAD, current: 9, maximum: 9 },
+    { location: MechLocation.CENTER_TORSO, current: 35, maximum: 47, rear: 12, rearMaximum: 23 },
+    { location: MechLocation.LEFT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.RIGHT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.LEFT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.RIGHT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.LEFT_LEG, current: 28, maximum: 32 },
+    { location: MechLocation.RIGHT_LEG, current: 28, maximum: 32 },
+  ];
+
+  const defaultProps = {
+    armorData: mockArmorData,
+    selectedLocation: null,
+    unallocatedPoints: 12,
+    onLocationClick: jest.fn(),
+  };
+
+  it('should render SchematicDiagram when mode is schematic', () => {
+    (useAppSettingsStore as unknown as jest.Mock).mockReturnValue({
+      armorDiagramMode: 'schematic',
+      armorDiagramVariant: 'clean-tech',
+    });
+
+    render(<ArmorDiagram {...defaultProps} />);
+
+    // Schematic uses CSS grid layout
+    const grid = document.querySelector('[style*="grid-template-areas"]');
+    expect(grid).toBeInTheDocument();
+  });
+
+  it('should render variant diagram when mode is silhouette', () => {
+    (useAppSettingsStore as unknown as jest.Mock).mockReturnValue({
+      armorDiagramMode: 'silhouette',
+      armorDiagramVariant: 'clean-tech',
+    });
+
+    render(<ArmorDiagram {...defaultProps} />);
+
+    // Silhouette uses SVG
+    expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/components/armor/__tests__/ArmorDiagram.mode.test.tsx --watch=false`
+Expected: FAIL (ArmorDiagram doesn't handle modes yet)
+
+**Step 3: Update ArmorDiagram to support mode switching**
+
+The existing `ArmorDiagram.tsx` needs to be updated to check `armorDiagramMode` and render either the schematic or the appropriate variant. Review the existing file and add mode switching:
+
+```typescript
+// At the top of ArmorDiagram.tsx, add import
+import { useAppSettingsStore } from '@/stores/useAppSettingsStore';
+import { SchematicDiagram } from './schematic';
+
+// Inside the component, add mode check
+const { armorDiagramMode, armorDiagramVariant } = useAppSettingsStore();
+
+// Early return for schematic mode
+if (armorDiagramMode === 'schematic') {
+  return (
+    <SchematicDiagram
+      armorData={armorData}
+      selectedLocation={selectedLocation}
+      unallocatedPoints={unallocatedPoints}
+      onLocationClick={onLocationClick}
+      onAutoAllocate={onAutoAllocate}
+      className={className}
+    />
+  );
+}
+
+// Existing variant rendering continues for silhouette mode...
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/components/armor/__tests__/ArmorDiagram.mode.test.tsx --watch=false`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/components/armor/ArmorDiagram.tsx src/components/armor/__tests__/ArmorDiagram.mode.test.tsx
+git commit -m "feat(armor): add mode switching to ArmorDiagram orchestrator"
+```
+
+---
+
+## Task 8: Add Mode Picker to Armor Diagram Quick Settings
+
+**Files:**
+- Modify: `src/components/customizer/armor/ArmorDiagramQuickSettings.tsx`
+
+**Step 1: Read the existing file**
+
+Run: Read the file to understand current structure
+
+**Step 2: Add mode toggle to quick settings**
+
+Add the `ArmorDiagramModeSwitch` component to the quick settings popover. The exact changes depend on the existing structure, but generally:
+
+```typescript
+// Add import
+import { ArmorDiagramModeSwitch } from '@/components/armor/ArmorDiagramModeSwitch';
+
+// Add to the popover content
+<div className="mb-3">
+  <label className="text-xs text-text-theme-secondary mb-1 block">Diagram Mode</label>
+  <ArmorDiagramModeSwitch />
+</div>
+```
+
+**Step 3: Verify it works**
+
+Run: `npm run dev` and navigate to armor tab to verify mode switch appears
+
+**Step 4: Commit**
+
+```bash
+git add src/components/customizer/armor/ArmorDiagramQuickSettings.tsx
+git commit -m "feat(armor): add diagram mode switch to quick settings"
+```
+
+---
+
+## Task 9: Run Full Test Suite
+
+**Step 1: Run all tests**
+
+Run: `npm test -- --watch=false`
+Expected: All tests pass
+
+**Step 2: Run type check**
+
+Run: `npx tsc --noEmit`
+Expected: No type errors
+
+**Step 3: Run linter**
+
+Run: `npm run lint`
+Expected: No lint errors (or only pre-existing ones)
+
+**Step 4: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix: address any test/lint issues from armor diagram mode implementation"
+```
+
+---
+
+## Task 10: Final Verification and Documentation
+
+**Step 1: Manual testing checklist**
+
+1. Open Settings, verify "Armor Diagram Mode" option appears
+2. Switch to Schematic mode, verify grid layout appears
+3. Switch to Silhouette mode, verify SVG diagram appears
+4. Click locations in both modes, verify selection works
+5. Test on mobile viewport, verify responsive layouts
+6. Verify mode preference persists after page reload
+
+**Step 2: Update design spec status**
+
+```bash
+# Update the design spec to mark as implemented
+sed -i 's/Status: Draft/Status: Implemented/' docs/plans/2026-01-10-mech-silhouette-armor-diagram.md
+git add docs/plans/2026-01-10-mech-silhouette-armor-diagram.md
+git commit -m "docs: mark armor diagram mode design as implemented"
+```
+
+**Step 3: Final commit**
+
+```bash
+git add -A
+git commit -m "feat(armor): complete schematic/silhouette mode implementation
+
+- Add armorDiagramMode setting to app settings store
+- Create SchematicDiagram with anatomically correct CSS grid layout
+- Create SchematicLocation component for grid cells
+- Add ArmorDiagramModeSwitch toggle component
+- Update ArmorDiagram orchestrator to switch between modes
+- Add mode picker to ArmorDiagramQuickSettings
+- Full test coverage for new components"
+```
+
+---
+
+## Summary
+
+**Files Created:**
+- `src/stores/__tests__/useAppSettingsStore.armorMode.test.ts`
+- `src/components/armor/shared/types.ts`
+- `src/components/armor/schematic/SchematicLocation.tsx`
+- `src/components/armor/schematic/__tests__/SchematicLocation.test.tsx`
+- `src/components/armor/schematic/SchematicDiagram.tsx`
+- `src/components/armor/schematic/__tests__/SchematicDiagram.test.tsx`
+- `src/components/armor/schematic/index.ts`
+- `src/components/armor/ArmorDiagramModeSwitch.tsx`
+- `src/components/armor/__tests__/ArmorDiagramModeSwitch.test.tsx`
+- `src/components/armor/__tests__/ArmorDiagram.mode.test.tsx`
+
+**Files Modified:**
+- `src/stores/useAppSettingsStore.ts` - Add `armorDiagramMode` setting
+- `src/components/armor/ArmorDiagram.tsx` - Add mode switching
+- `src/components/customizer/armor/ArmorDiagramQuickSettings.tsx` - Add mode picker
+
+**Total Tasks:** 10
+**Estimated Commits:** 10-12

--- a/docs/plans/2026-01-10-mech-silhouette-armor-diagram.md
+++ b/docs/plans/2026-01-10-mech-silhouette-armor-diagram.md
@@ -1,0 +1,482 @@
+# Mech-Correct Armor Diagram Design
+
+**Date:** 2026-01-10
+**Status:** Draft
+**Author:** SwerveLabs
+
+## Overview
+
+Redesign the armor diagram to be more "mech correct" with two user-selectable display modes: a schematic grid layout with proper anatomical connections, and a detailed SVG silhouette with layered visual elements.
+
+**Goals:**
+- Create anatomically accurate mech body part relationships
+- Provide detailed SVG silhouette that looks like a BattleMech
+- Support both modes via user preference in Settings
+- Handle front/rear armor in a combined view (no toggle)
+- Work at partial size on desktop and full size on mobile
+
+**Design Decisions Made:**
+- Two modes: Schematic (grid) and Silhouette (SVG)
+- Layered SVG architecture for future extensibility
+- Combined front/rear display on torso locations
+- Detailed illustration style for silhouette
+- Setting stored in UI Preferences alongside theme
+
+---
+
+## Architecture
+
+### Component Structure
+
+```
+src/components/armor/
+├── ArmorDiagram.tsx              # Orchestrator - picks mode from settings
+├── ArmorDiagramSettings.tsx      # Settings UI for mode toggle
+│
+├── schematic/                    # Mode 1: Grid-based
+│   ├── SchematicDiagram.tsx      # Anatomically correct grid layout
+│   └── SchematicLocation.tsx     # Individual location card
+│
+├── silhouette/                   # Mode 2: SVG-based
+│   ├── SilhouetteDiagram.tsx     # Composites SVG layers
+│   ├── SilhouetteLocation.tsx    # Clickable SVG region
+│   └── layers/
+│       ├── BipedBase.tsx         # Hitbox paths (required)
+│       ├── BipedFill.tsx         # Armor color fills (required)
+│       └── BipedDetail.tsx       # Panel lines, joints (optional)
+│
+└── shared/
+    ├── ArmorControls.tsx         # +/- buttons, quick add (reused)
+    ├── ArmorTooltip.tsx          # Hover info (reused)
+    └── types.ts                  # Shared interfaces
+```
+
+### Key Principle
+
+Editing logic stays shared. Only rendering differs between modes. Both modes use the same `ArmorControls` component and the same data flow.
+
+### Settings Integration
+
+Add to existing UI Preferences in Settings:
+
+```typescript
+interface UIPreferences {
+  theme: 'light' | 'dark' | 'system';
+  armorDiagramMode: 'schematic' | 'silhouette';  // NEW
+}
+```
+
+Default: `'silhouette'` (more visually impressive)
+
+Storage: localStorage via existing settings context.
+
+---
+
+## Schematic Mode
+
+### Current Problem
+
+The existing grid treats all locations as independent boxes. Arms float beside the torso instead of connecting at the shoulders. Legs sit below center torso instead of below their respective side torsos.
+
+### Anatomically Correct Layout
+
+```
+Current:                      Corrected:
+
+      [HEAD]                       [HEAD]
+                                     │
+[LT] [CT] [CT] [RT]               ┌──┴──┐
+[LA] [CT] [CT] [RA]          [LA]─┤LT CT RT├─[RA]
+[LL] [CT] [CT] [RL]               └┬────┬┘
+                                [LL]    [RL]
+```
+
+### Anatomical Rules
+
+- Head connects directly above center torso
+- Left/right torsos flank center torso horizontally
+- Arms attach to outer edges of side torsos (shoulder height)
+- Legs attach below side torsos, not center torso
+- Center torso is the structural core, slightly larger
+
+### Grid Implementation
+
+```css
+grid-template-areas:
+  ".    .    head   .    ."
+  "la   lt   ct     rt   ra"
+  ".    ll   .      rl   ."
+```
+
+Cards get visual connectors (thin lines or subtle shadows) showing structural relationships. Each location card remains expandable with existing +5/+10/Max controls.
+
+### Mobile Layout
+
+Stack vertically but group by connection:
+1. Head
+2. Torsos (CT, LT, RT)
+3. Arms (LA, RA)
+4. Legs (LL, RL)
+
+Subtle indentation shows hierarchy.
+
+---
+
+## Silhouette Mode
+
+### Layer Architecture
+
+Layers stack bottom to top:
+
+| Layer | Always Loaded | Purpose |
+|-------|---------------|---------|
+| 1. Base Hitbox | Yes | Invisible `<path>` regions for click detection |
+| 2. Armor Fill | Yes | Colored shapes showing armor status (green/amber/red) |
+| 3. Detail | Desktop: hover only, Mobile: always | Panel lines, cockpit, joints, vents |
+| 4. Interaction | Yes | CSS-driven glow/pulse on hover and selection |
+
+### Layer Responsibilities
+
+**Base Hitbox Layer:**
+- Defines clickable `<path>` regions for each location
+- Invisible but receives pointer events
+- Each path has `data-location="CENTER_TORSO"` attribute
+
+**Armor Fill Layer:**
+- Colored shapes matching hitbox paths
+- Shows armor status via color gradient
+- Updates reactively when armor values change
+
+**Detail Layer:**
+- Structural lines, cockpit glass, joints, vents
+- Pure decoration, no interactivity
+- Loaded on hover for desktop, always for mobile
+
+**Interaction Layer:**
+- CSS-driven visual feedback
+- Glow/pulse effects on hover and selection
+
+### Click Flow
+
+1. User clicks anywhere on mech silhouette
+2. Base hitbox layer catches the event
+3. Path's `data-location` attribute identifies the region
+4. Parent component receives location, opens armor controls
+5. Armor fill updates color based on new values
+
+### Responsive Behavior
+
+- **Mobile (full size):** All layers visible, detail layer always shown
+- **Desktop (partial):** Detail layer shown on hover only
+
+---
+
+## Mech Silhouette Design
+
+### Biped Anatomy
+
+```
+                 ╭───╮
+                ╭┤ H ├╮          H = Head (cockpit visible)
+               ╭┴─────┴╮
+              ╱    │    ╲
+         ╭───╮─────┼─────╭───╮
+        ╱ LA ╲  LT │ RT ╱ RA ╲   Arms angled outward
+       ╱      ╲ ╲  │  ╱╱      ╲
+      ▕        ▏ ╲ CT╱ ▕        ▏
+       ╲      ╱   ╲│╱   ╲      ╱
+        ╲    ╱     │     ╲    ╱
+         ╰──╯    ╭─┴─╮    ╰──╯
+                ╱     ╲
+              ╭╯       ╰╮
+             ▕ LL     RL ▏       Legs with knee/ankle hints
+              ▕       ▕
+              ╰┬─╮ ╭─┬╯
+               ╰─╯ ╰─╯           Feet
+```
+
+### Hitbox Regions (Base Layer)
+
+Each location is a single `<path>` element:
+
+| Location | Shape |
+|----------|-------|
+| Head | Rounded trapezoid with cockpit indent |
+| Center Torso | Tapered rectangle, widest at shoulders |
+| Side Torsos | Wedge shapes flanking CT |
+| Arms | Elongated shapes, angled 15° outward |
+| Legs | Two-segment (thigh/shin), separated by knee joint |
+
+### Detail Elements
+
+| Element | Location | Purpose |
+|---------|----------|---------|
+| Cockpit glass | Head | Reflective highlight |
+| Shoulder joints | LT/RT edge | Circular pivots |
+| Panel lines | All torsos | Horizontal segments |
+| Knee joints | Legs | Circular joints |
+| Foot pads | Leg bottoms | Ground contact |
+| Vent slats | Side torsos | 3-4 horizontal lines |
+
+### SVG Viewbox
+
+`0 0 200 300` - Tall portrait orientation, works for both mobile and sidebar.
+
+---
+
+## Front/Rear Armor Handling
+
+### Combined Display (No Toggle)
+
+Show both front and rear on torso locations simultaneously:
+
+```
+Schematic card:                 Silhouette region:
+
+┌─────────────────────┐         ┌─────────────┐
+│ Center Torso        │         │    24/47    │ ← Front (top)
+│                     │         │─────────────│
+│  Front  24/47  ███░ │         │    12/23    │ ← Rear (bottom)
+│  Rear   12/23  ██░░ │         └─────────────┘
+└─────────────────────┘
+```
+
+### Location Display Rules
+
+| Location | Display |
+|----------|---------|
+| Head | Single value (no rear) |
+| CT, LT, RT | Split: Front value on top, Rear value on bottom |
+| Arms | Single value (no rear) |
+| Legs | Single value (no rear) |
+
+### Editing Flow
+
+When clicking/expanding a torso location, both front and rear controls appear:
+
+```
+┌─────────────────────────────────┐
+│ Center Torso                    │
+├─────────────────────────────────┤
+│ Front                     24/47 │
+│  [+5]  [+10]  [+20]  [Max]      │
+│      (−)    24    (+)           │
+├─────────────────────────────────┤
+│ Rear                      12/23 │
+│  [+5]  [+10]  [+20]  [Max]      │
+│      (−)    12    (+)           │
+└─────────────────────────────────┘
+```
+
+### Silhouette Visual
+
+Torso regions have a subtle horizontal divider line. Top half = front, bottom half = rear. Each half is independently clickable.
+
+---
+
+## Interaction States & Accessibility
+
+### Visual States
+
+| State | Schematic | Silhouette |
+|-------|-----------|------------|
+| Default | White card, subtle border | Filled region, panel lines visible |
+| Hover | Light blue background | Soft glow on region edges |
+| Selected | Blue border, expanded controls | Bright glow, controls panel opens |
+| Disabled | Grayed out, no pointer | Dimmed opacity, no pointer events |
+
+### Keyboard Navigation
+
+```
+Tab order (follows anatomy top-to-bottom, left-to-right):
+HEAD → LT → CT → RT → LA → RA → LL → RL
+
+Enter/Space: Select location, open controls
+Arrow keys: Navigate between controls within location
+Escape: Close controls, return focus to location
+```
+
+### ARIA Implementation
+
+```tsx
+<path
+  role="button"
+  tabIndex={0}
+  aria-label="Center Torso: Front 24 of 47, Rear 12 of 23"
+  aria-expanded={isSelected}
+  aria-controls="ct-armor-controls"
+  data-location="CENTER_TORSO"
+/>
+```
+
+### Color Accessibility
+
+- Don't rely on color alone - include text values (24/47)
+- Progress bars have visible boundaries
+- Selected state uses border/glow, not just color change
+- All status colors meet WCAG AA contrast
+
+### Touch Targets
+
+All clickable regions minimum 44×44px, even on the silhouette.
+
+---
+
+## Testing & Validation
+
+### Unit Tests
+
+- Mode switching based on settings
+- Armor value updates propagate to both modes
+- Front/rear split display for torso locations
+- Keyboard navigation order
+- ARIA attributes present and correct
+
+### Visual Regression
+
+- Schematic layout at mobile and desktop breakpoints
+- Silhouette rendering at various sizes
+- Hover and selection states
+- Detail layer visibility rules
+
+### Accessibility Testing
+
+- Screen reader announces all location values
+- Keyboard-only navigation works completely
+- Focus indicators visible in both modes
+- Color contrast passes WCAG AA
+
+### Cross-Browser
+
+- SVG rendering in Safari, Chrome, Firefox, Edge
+- CSS grid layout in all browsers
+- Touch interactions on iOS and Android
+
+---
+
+## Success Criteria
+
+- [ ] Two modes (Schematic/Silhouette) selectable in Settings
+- [ ] Schematic shows anatomically correct body part relationships
+- [ ] Silhouette looks like a recognizable BattleMech
+- [ ] Layered SVG architecture supports future extensibility
+- [ ] Front/rear armor shown together on torso locations
+- [ ] Works at partial size (desktop sidebar) and full size (mobile)
+- [ ] Touch targets ≥44×44px
+- [ ] Keyboard navigable with proper ARIA
+- [ ] Detail layer: hover-only on desktop, always on mobile
+- [ ] Settings preference persists across sessions
+
+---
+
+## Implementation Phases
+
+### Phase 1: Shared Infrastructure
+**Goal:** Extract shared controls and set up mode switching
+
+- Extract `ArmorControls.tsx` from existing location component
+- Create shared types in `shared/types.ts`
+- Add `armorDiagramMode` to settings context
+- Update Settings UI with diagram mode picker
+- Create `ArmorDiagram.tsx` orchestrator that switches modes
+- Verify settings persistence works
+
+**Success criteria:** Mode can be changed in settings, preference persists
+
+---
+
+### Phase 2: Schematic Mode
+**Goal:** Anatomically correct grid layout
+
+- Create `SchematicDiagram.tsx` with corrected CSS grid
+- Create `SchematicLocation.tsx` card component
+- Add visual connectors between related body parts
+- Implement combined front/rear display for torsos
+- Add expand/collapse with shared `ArmorControls`
+- Mobile responsive stacking with body part groups
+
+**Success criteria:** Schematic mode fully functional with correct anatomy
+
+---
+
+### Phase 3: Silhouette Base Layer
+**Goal:** Clickable mech outline
+
+- Create `BipedBase.tsx` with hitbox `<path>` elements
+- Create `SilhouetteDiagram.tsx` layer compositor
+- Create `SilhouetteLocation.tsx` for click handling
+- Implement `data-location` attribute system
+- Add keyboard navigation and focus management
+- Connect to shared `ArmorControls`
+
+**Success criteria:** Clicking silhouette regions opens armor controls
+
+---
+
+### Phase 4: Silhouette Fill Layer
+**Goal:** Armor status visualization
+
+- Create `BipedFill.tsx` with colored regions
+- Implement status color gradient (green → red)
+- Add front/rear split visual for torsos
+- Connect to armor data for reactive updates
+- Ensure fill paths align with hitbox paths
+
+**Success criteria:** Silhouette colors reflect armor allocation status
+
+---
+
+### Phase 5: Silhouette Detail Layer
+**Goal:** Visual polish and immersion
+
+- Create `BipedDetail.tsx` with decorative elements
+- Add cockpit glass, panel lines, joints, vents
+- Implement hover-only visibility for desktop
+- Always-visible for mobile
+- CSS transitions for smooth reveal
+
+**Success criteria:** Detail layer adds visual richness without clutter
+
+---
+
+### Phase 6: Interaction Polish
+**Goal:** Refined user experience
+
+- Add hover glow effects
+- Add selection pulse/highlight
+- Implement smooth transitions between states
+- Add haptic feedback for mobile
+- Performance optimization
+- Cross-browser testing
+
+**Success criteria:** Interactions feel polished and responsive
+
+---
+
+## Future Extensibility
+
+The layered architecture supports future enhancements:
+
+| Future Feature | How It Fits |
+|----------------|-------------|
+| Quad chassis | Add `QuadBase.tsx`, `QuadFill.tsx`, `QuadDetail.tsx` |
+| LAM chassis | Add LAM-specific layer files |
+| Damage states | Add `BipedDamage.tsx` overlay layer |
+| Equipment markers | Add `BipedEquipment.tsx` layer showing weapon mounts |
+| Themes/skins | Swap detail layers for different visual styles |
+| Animation | Animate individual layers independently |
+
+Each new capability adds layers without modifying the base hitbox system.
+
+---
+
+## Implementation Notes
+
+This design prioritizes:
+1. **Modularity** — Layered architecture allows independent iteration
+2. **Accessibility** — Keyboard and screen reader support from the start
+3. **Responsiveness** — Works at all sizes without separate codebases
+4. **Extensibility** — Future chassis types and features slot in cleanly
+5. **User choice** — Two modes serve different preferences
+
+The schematic mode is functional and efficient. The silhouette mode is immersive and visually impressive. Users choose what works for them.

--- a/equipment-validation-report.json
+++ b/equipment-validation-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-01-11T01:46:45.116Z",
+  "generatedAt": "2026-01-11T04:15:24.613Z",
   "summary": {
     "unitsProcessed": 4217,
     "unitsWithIssues": 1914,

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/__tests__/components/customizer/tabs/MultiUnitTabs.test.tsx
+++ b/src/__tests__/components/customizer/tabs/MultiUnitTabs.test.tsx
@@ -64,6 +64,8 @@ describe('MultiUnitTabs', () => {
     closeNewTabModal: jest.fn(),
     getActiveTab: jest.fn(() => mockTab),
     setLoading: jest.fn(),
+    setLastSubTab: jest.fn(),
+    getLastSubTab: jest.fn(),
   };
 
   beforeEach(() => {

--- a/src/__tests__/stores/useTabManagerStore.test.ts
+++ b/src/__tests__/stores/useTabManagerStore.test.ts
@@ -503,6 +503,38 @@ describe('useTabManagerStore', () => {
   });
   
   // ===========================================================================
+  // Sub-tab Persistence
+  // ===========================================================================
+  describe('Sub-tab Persistence', () => {
+    it('should set and get last active sub-tab', () => {
+      let tabId = '';
+      act(() => {
+        tabId = useTabManagerStore.getState().createTab(UNIT_TEMPLATES[0]);
+      });
+
+      act(() => {
+        useTabManagerStore.getState().setLastSubTab(tabId, 'armor');
+      });
+
+      expect(useTabManagerStore.getState().getLastSubTab(tabId)).toBe('armor');
+      expect(useTabManagerStore.getState().tabs[0].lastSubTab).toBe('armor');
+    });
+
+    it('should return undefined for non-existent sub-tab', () => {
+      let tabId = '';
+      act(() => {
+        tabId = useTabManagerStore.getState().createTab(UNIT_TEMPLATES[0]);
+      });
+
+      expect(useTabManagerStore.getState().getLastSubTab(tabId)).toBeUndefined();
+    });
+
+    it('should return undefined for non-existent tab', () => {
+      expect(useTabManagerStore.getState().getLastSubTab('non-existent')).toBeUndefined();
+    });
+  });
+  
+  // ===========================================================================
   // Tab Manager Only Stores Tab Metadata
   // ===========================================================================
   describe('Tab Manager Data Separation', () => {

--- a/src/components/armor/ArmorDiagramModeSwitch.tsx
+++ b/src/components/armor/ArmorDiagramModeSwitch.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useAppSettingsStore, ArmorDiagramMode } from '@/stores/useAppSettingsStore';
+
+/**
+ * Toggle switch for armor diagram mode (Schematic vs Silhouette)
+ */
+export function ArmorDiagramModeSwitch(): React.ReactElement {
+  const { armorDiagramMode, setArmorDiagramMode } = useAppSettingsStore();
+
+  const modes: { id: ArmorDiagramMode; label: string }[] = [
+    { id: 'schematic', label: 'Schematic' },
+    { id: 'silhouette', label: 'Silhouette' },
+  ];
+
+  return (
+    <div className="flex gap-1 p-1 bg-surface-raised rounded-lg">
+      {modes.map((mode) => (
+        <button
+          key={mode.id}
+          onClick={() => setArmorDiagramMode(mode.id)}
+          className={`
+            px-3 py-1.5 text-sm font-medium rounded-md transition-colors
+            ${armorDiagramMode === mode.id
+              ? 'bg-accent text-white'
+              : 'text-text-theme-secondary hover:text-white hover:bg-surface-base'
+            }
+          `}
+          aria-pressed={armorDiagramMode === mode.id}
+        >
+          {mode.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/armor/__tests__/ArmorDiagramModeSwitch.test.tsx
+++ b/src/components/armor/__tests__/ArmorDiagramModeSwitch.test.tsx
@@ -5,16 +5,17 @@ import { useAppSettingsStore } from '@/stores/useAppSettingsStore';
 
 // Mock the store
 jest.mock('@/stores/useAppSettingsStore');
+const mockUseAppSettingsStore = useAppSettingsStore as jest.MockedFunction<typeof useAppSettingsStore>;
 
 describe('ArmorDiagramModeSwitch', () => {
   const mockSetArmorDiagramMode = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (useAppSettingsStore as unknown as jest.Mock).mockReturnValue({
+    mockUseAppSettingsStore.mockReturnValue({
       armorDiagramMode: 'silhouette',
       setArmorDiagramMode: mockSetArmorDiagramMode,
-    });
+    } as ReturnType<typeof useAppSettingsStore>);
   });
 
   it('should render mode options', () => {

--- a/src/components/armor/__tests__/ArmorDiagramModeSwitch.test.tsx
+++ b/src/components/armor/__tests__/ArmorDiagramModeSwitch.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ArmorDiagramModeSwitch } from '../ArmorDiagramModeSwitch';
+import { useAppSettingsStore } from '@/stores/useAppSettingsStore';
+
+// Mock the store
+jest.mock('@/stores/useAppSettingsStore');
+
+describe('ArmorDiagramModeSwitch', () => {
+  const mockSetArmorDiagramMode = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAppSettingsStore as unknown as jest.Mock).mockReturnValue({
+      armorDiagramMode: 'silhouette',
+      setArmorDiagramMode: mockSetArmorDiagramMode,
+    });
+  });
+
+  it('should render mode options', () => {
+    render(<ArmorDiagramModeSwitch />);
+    expect(screen.getByText('Schematic')).toBeInTheDocument();
+    expect(screen.getByText('Silhouette')).toBeInTheDocument();
+  });
+
+  it('should show current mode as selected', () => {
+    render(<ArmorDiagramModeSwitch />);
+    const silhouetteButton = screen.getByText('Silhouette');
+    expect(silhouetteButton).toHaveClass('bg-accent');
+  });
+
+  it('should call setArmorDiagramMode when mode is changed', () => {
+    render(<ArmorDiagramModeSwitch />);
+    fireEvent.click(screen.getByText('Schematic'));
+    expect(mockSetArmorDiagramMode).toHaveBeenCalledWith('schematic');
+  });
+});

--- a/src/components/armor/schematic/SchematicDiagram.tsx
+++ b/src/components/armor/schematic/SchematicDiagram.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { MechLocation } from '@/types/construction';
+import { ArmorDiagramBaseProps, LocationArmorData } from '../shared/types';
+import { SchematicLocation } from './SchematicLocation';
+
+/**
+ * Schematic Armor Diagram
+ *
+ * Anatomically correct CSS grid layout showing mech body parts
+ * in their proper positions with visual connectors.
+ */
+export function SchematicDiagram({
+  armorData,
+  selectedLocation,
+  unallocatedPoints,
+  onLocationClick,
+  onAutoAllocate,
+  className = '',
+}: ArmorDiagramBaseProps): React.ReactElement {
+  const getArmorData = (location: MechLocation): LocationArmorData | undefined => {
+    return armorData.find((d) => d.location === location);
+  };
+
+  const isOverAllocated = unallocatedPoints < 0;
+
+  const renderLocation = (location: MechLocation) => {
+    const data = getArmorData(location);
+    return (
+      <SchematicLocation
+        key={location}
+        location={location}
+        current={data?.current ?? 0}
+        maximum={data?.maximum ?? 1}
+        rear={data?.rear}
+        rearMaximum={data?.rearMaximum}
+        isSelected={selectedLocation === location}
+        onClick={onLocationClick}
+      />
+    );
+  };
+
+  return (
+    <div className={`bg-surface-base rounded-lg border border-border-theme-subtle p-4 ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-white">Armor Allocation</h3>
+        {onAutoAllocate && (
+          <button
+            onClick={onAutoAllocate}
+            className={`px-3 py-1.5 text-sm font-medium rounded transition-colors ${
+              isOverAllocated
+                ? 'bg-red-600 hover:bg-red-500 text-white'
+                : 'bg-accent hover:bg-accent-hover text-white'
+            }`}
+          >
+            Auto Allocate ({unallocatedPoints} pts)
+          </button>
+        )}
+      </div>
+
+      {/* Anatomically Correct Grid Layout */}
+      <div
+        className="hidden lg:grid gap-2"
+        style={{
+          gridTemplateAreas: `
+            ".    .    head   .    ."
+            "la   lt   ct     rt   ra"
+            ".    ll   .      rl   ."
+          `,
+          gridTemplateColumns: '1fr 1fr 1.2fr 1fr 1fr',
+          gridTemplateRows: 'auto auto auto',
+        }}
+      >
+        <div style={{ gridArea: 'head' }}>{renderLocation(MechLocation.HEAD)}</div>
+        <div style={{ gridArea: 'ct' }}>{renderLocation(MechLocation.CENTER_TORSO)}</div>
+        <div style={{ gridArea: 'lt' }}>{renderLocation(MechLocation.LEFT_TORSO)}</div>
+        <div style={{ gridArea: 'rt' }}>{renderLocation(MechLocation.RIGHT_TORSO)}</div>
+        <div style={{ gridArea: 'la' }}>{renderLocation(MechLocation.LEFT_ARM)}</div>
+        <div style={{ gridArea: 'ra' }}>{renderLocation(MechLocation.RIGHT_ARM)}</div>
+        <div style={{ gridArea: 'll' }}>{renderLocation(MechLocation.LEFT_LEG)}</div>
+        <div style={{ gridArea: 'rl' }}>{renderLocation(MechLocation.RIGHT_LEG)}</div>
+      </div>
+
+      {/* Mobile Stacked Layout */}
+      <div className="lg:hidden flex flex-col gap-3">
+        {/* Head */}
+        <div>
+          <h4 className="text-xs font-medium text-text-theme-secondary mb-1 px-1">Head</h4>
+          {renderLocation(MechLocation.HEAD)}
+        </div>
+
+        {/* Torso */}
+        <div>
+          <h4 className="text-xs font-medium text-text-theme-secondary mb-1 px-1">Torso</h4>
+          <div className="flex flex-col gap-2">
+            {renderLocation(MechLocation.CENTER_TORSO)}
+            <div className="flex gap-2">
+              {renderLocation(MechLocation.LEFT_TORSO)}
+              {renderLocation(MechLocation.RIGHT_TORSO)}
+            </div>
+          </div>
+        </div>
+
+        {/* Arms */}
+        <div>
+          <h4 className="text-xs font-medium text-text-theme-secondary mb-1 px-1">Arms</h4>
+          <div className="flex gap-2">
+            {renderLocation(MechLocation.LEFT_ARM)}
+            {renderLocation(MechLocation.RIGHT_ARM)}
+          </div>
+        </div>
+
+        {/* Legs */}
+        <div>
+          <h4 className="text-xs font-medium text-text-theme-secondary mb-1 px-1">Legs</h4>
+          <div className="flex gap-2">
+            {renderLocation(MechLocation.LEFT_LEG)}
+            {renderLocation(MechLocation.RIGHT_LEG)}
+          </div>
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className="flex justify-center gap-3 mt-4 text-xs">
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-green-500" />
+          <span className="text-text-theme-secondary">75%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-amber-500" />
+          <span className="text-text-theme-secondary">50%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-orange-500" />
+          <span className="text-text-theme-secondary">25%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-red-500" />
+          <span className="text-text-theme-secondary">&lt;25%</span>
+        </div>
+      </div>
+
+      {/* Instructions */}
+      <p className="text-xs text-text-theme-secondary text-center mt-2">
+        Click a location to edit armor values
+      </p>
+    </div>
+  );
+}

--- a/src/components/armor/schematic/SchematicLocation.tsx
+++ b/src/components/armor/schematic/SchematicLocation.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { MechLocation } from '@/types/construction';
+import { hasRearArmor, LOCATION_SHORT_LABELS } from '../shared/types';
+
+/**
+ * Get status color based on armor percentage
+ */
+function getStatusColor(current: number, maximum: number): string {
+  if (maximum === 0) return 'bg-gray-500';
+  const percentage = (current / maximum) * 100;
+  if (percentage >= 75) return 'bg-green-500';
+  if (percentage >= 50) return 'bg-amber-500';
+  if (percentage >= 25) return 'bg-orange-500';
+  return 'bg-red-500';
+}
+
+export interface SchematicLocationProps {
+  location: MechLocation;
+  current: number;
+  maximum: number;
+  rear?: number;
+  rearMaximum?: number;
+  isSelected: boolean;
+  onClick: (location: MechLocation) => void;
+}
+
+export function SchematicLocation({
+  location,
+  current,
+  maximum,
+  rear,
+  rearMaximum,
+  isSelected,
+  onClick,
+}: SchematicLocationProps): React.ReactElement {
+  const label = LOCATION_SHORT_LABELS[location];
+  const showRear = hasRearArmor(location) && rear !== undefined;
+  const frontColor = getStatusColor(current, maximum);
+  const rearColor = showRear ? getStatusColor(rear!, rearMaximum ?? 1) : '';
+
+  const ariaLabel = showRear
+    ? `${location} armor: Front ${current} of ${maximum}, Rear ${rear} of ${rearMaximum}`
+    : `${location} armor: ${current} of ${maximum}`;
+
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      aria-pressed={isSelected}
+      onClick={() => onClick(location)}
+      className={`
+        relative p-3 rounded-lg border transition-all duration-150
+        bg-surface-base hover:bg-surface-raised
+        ${isSelected ? 'ring-2 ring-blue-500 border-blue-500' : 'border-border-theme-subtle'}
+        focus:outline-none focus:ring-2 focus:ring-blue-500
+        min-h-[44px] min-w-[44px]
+      `}
+    >
+      {/* Location Label */}
+      <div className="text-xs font-semibold text-text-theme-secondary mb-1">
+        {label}
+      </div>
+
+      {/* Front Armor Section */}
+      <div className="flex items-center gap-2">
+        <div className={`w-2 h-8 rounded ${frontColor}`} />
+        <div className="flex flex-col">
+          <span className="text-lg font-bold text-white tabular-nums">{current}</span>
+          <span className="text-xs text-text-theme-secondary">/ {maximum}</span>
+        </div>
+      </div>
+
+      {/* Rear Armor Section (torso only) */}
+      {showRear && (
+        <div className="mt-2 pt-2 border-t border-border-theme-subtle">
+          <div className="text-xs text-text-theme-secondary mb-1">Rear</div>
+          <div className="flex items-center gap-2">
+            <div className={`w-2 h-6 rounded ${rearColor}`} />
+            <div className="flex flex-col">
+              <span className="text-sm font-bold text-white tabular-nums">{rear}</span>
+              <span className="text-xs text-text-theme-secondary">/ {rearMaximum}</span>
+            </div>
+          </div>
+        </div>
+      )}
+    </button>
+  );
+}

--- a/src/components/armor/schematic/__tests__/SchematicDiagram.test.tsx
+++ b/src/components/armor/schematic/__tests__/SchematicDiagram.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SchematicDiagram } from '../SchematicDiagram';
+import { MechLocation } from '@/types/construction';
+
+describe('SchematicDiagram', () => {
+  const mockArmorData = [
+    { location: MechLocation.HEAD, current: 9, maximum: 9 },
+    { location: MechLocation.CENTER_TORSO, current: 35, maximum: 47, rear: 12, rearMaximum: 23 },
+    { location: MechLocation.LEFT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.RIGHT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.LEFT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.RIGHT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.LEFT_LEG, current: 28, maximum: 32 },
+    { location: MechLocation.RIGHT_LEG, current: 28, maximum: 32 },
+  ];
+
+  const defaultProps = {
+    armorData: mockArmorData,
+    selectedLocation: null,
+    unallocatedPoints: 12,
+    onLocationClick: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render all 8 mech locations', () => {
+    render(<SchematicDiagram {...defaultProps} />);
+    // Both desktop and mobile layouts render, so use getAllByText
+    expect(screen.getAllByText('HD').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('CT').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('LT').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('RT').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('LA').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('RA').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('LL').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('RL').length).toBeGreaterThan(0);
+  });
+
+  it('should use anatomically correct grid layout', () => {
+    const { container } = render(<SchematicDiagram {...defaultProps} />);
+    const grid = container.querySelector('[style*="grid-template-areas"]');
+    expect(grid).toBeInTheDocument();
+  });
+
+  it('should call onLocationClick when a location is clicked', () => {
+    render(<SchematicDiagram {...defaultProps} />);
+    // Both desktop and mobile layouts render, so get all and click first
+    const headButtons = screen.getAllByRole('button', { name: /Head armor: 9 of 9/i });
+    fireEvent.click(headButtons[0]);
+    expect(defaultProps.onLocationClick).toHaveBeenCalledWith(MechLocation.HEAD);
+  });
+
+  it('should show selected state for selected location', () => {
+    const { container } = render(
+      <SchematicDiagram {...defaultProps} selectedLocation={MechLocation.HEAD} />
+    );
+    const selectedButton = container.querySelector('.ring-2');
+    expect(selectedButton).toBeInTheDocument();
+  });
+
+  it('should render auto-allocate button when handler provided', () => {
+    render(<SchematicDiagram {...defaultProps} onAutoAllocate={jest.fn()} />);
+    expect(screen.getByText(/Auto Allocate/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/armor/schematic/__tests__/SchematicLocation.test.tsx
+++ b/src/components/armor/schematic/__tests__/SchematicLocation.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SchematicLocation } from '../SchematicLocation';
+import { MechLocation } from '@/types/construction';
+
+describe('SchematicLocation', () => {
+  const defaultProps = {
+    location: MechLocation.CENTER_TORSO,
+    current: 35,
+    maximum: 47,
+    rear: 12,
+    rearMaximum: 23,
+    isSelected: false,
+    onClick: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render location label', () => {
+    render(<SchematicLocation {...defaultProps} />);
+    expect(screen.getByText('CT')).toBeInTheDocument();
+  });
+
+  it('should render front armor value', () => {
+    render(<SchematicLocation {...defaultProps} />);
+    expect(screen.getByText('35')).toBeInTheDocument();
+    expect(screen.getByText('/ 47')).toBeInTheDocument();
+  });
+
+  it('should render rear armor for torso locations', () => {
+    render(<SchematicLocation {...defaultProps} />);
+    expect(screen.getByText('Rear')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('should not render rear for non-torso locations', () => {
+    render(<SchematicLocation {...defaultProps} location={MechLocation.HEAD} rear={undefined} />);
+    expect(screen.queryByText('Rear')).not.toBeInTheDocument();
+  });
+
+  it('should call onClick when clicked', () => {
+    render(<SchematicLocation {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(defaultProps.onClick).toHaveBeenCalledWith(MechLocation.CENTER_TORSO);
+  });
+
+  it('should show selected state', () => {
+    const { container } = render(<SchematicLocation {...defaultProps} isSelected={true} />);
+    expect(container.querySelector('.ring-2')).toBeInTheDocument();
+  });
+
+  it('should have proper ARIA attributes', () => {
+    render(<SchematicLocation {...defaultProps} />);
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-label', expect.stringContaining('Center Torso'));
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+  });
+});

--- a/src/components/armor/schematic/index.ts
+++ b/src/components/armor/schematic/index.ts
@@ -1,0 +1,2 @@
+export { SchematicDiagram } from './SchematicDiagram';
+export { SchematicLocation } from './SchematicLocation';

--- a/src/components/armor/shared/types.ts
+++ b/src/components/armor/shared/types.ts
@@ -1,0 +1,69 @@
+// src/components/armor/shared/types.ts
+import { MechLocation } from '@/types/construction';
+
+/**
+ * Armor data for a single location
+ */
+export interface LocationArmorData {
+  location: MechLocation;
+  current: number;
+  maximum: number;
+  rear?: number;
+  rearMaximum?: number;
+}
+
+/**
+ * Props shared by all armor diagram modes
+ */
+export interface ArmorDiagramBaseProps {
+  armorData: LocationArmorData[];
+  selectedLocation: MechLocation | null;
+  unallocatedPoints: number;
+  onLocationClick: (location: MechLocation) => void;
+  onAutoAllocate?: () => void;
+  className?: string;
+}
+
+/**
+ * Locations that have rear armor (torsos only)
+ */
+export const TORSO_LOCATIONS: readonly MechLocation[] = [
+  MechLocation.CENTER_TORSO,
+  MechLocation.LEFT_TORSO,
+  MechLocation.RIGHT_TORSO,
+] as const;
+
+/**
+ * Check if a location has rear armor
+ */
+export function hasRearArmor(location: MechLocation): boolean {
+  return TORSO_LOCATIONS.includes(location);
+}
+
+/**
+ * All mech locations in anatomical order (top to bottom, left to right)
+ */
+export const MECH_LOCATIONS_ORDERED: readonly MechLocation[] = [
+  MechLocation.HEAD,
+  MechLocation.LEFT_TORSO,
+  MechLocation.CENTER_TORSO,
+  MechLocation.RIGHT_TORSO,
+  MechLocation.LEFT_ARM,
+  MechLocation.RIGHT_ARM,
+  MechLocation.LEFT_LEG,
+  MechLocation.RIGHT_LEG,
+] as const;
+
+/**
+ * Short labels for locations
+ */
+export const LOCATION_SHORT_LABELS: Record<MechLocation, string> = {
+  [MechLocation.HEAD]: 'HD',
+  [MechLocation.CENTER_TORSO]: 'CT',
+  [MechLocation.LEFT_TORSO]: 'LT',
+  [MechLocation.RIGHT_TORSO]: 'RT',
+  [MechLocation.LEFT_ARM]: 'LA',
+  [MechLocation.RIGHT_ARM]: 'RA',
+  [MechLocation.LEFT_LEG]: 'LL',
+  [MechLocation.RIGHT_LEG]: 'RL',
+};

--- a/src/components/customizer/armor/ArmorDiagram.tsx
+++ b/src/components/customizer/armor/ArmorDiagram.tsx
@@ -1,8 +1,9 @@
 /**
  * Armor Diagram Component
- * 
+ *
  * SVG-based interactive armor visualization for BattleMechs.
- * 
+ * Supports two display modes: Schematic (CSS grid) and Silhouette (SVG).
+ *
  * @spec openspec/specs/armor-diagram/spec.md
  */
 
@@ -10,6 +11,8 @@ import React, { useState } from 'react';
 import { ArmorLocation } from './ArmorLocation';
 import { ArmorLegend } from './ArmorLegend';
 import { MechLocation } from '@/types/construction';
+import { useAppSettingsStore } from '@/stores/useAppSettingsStore';
+import { SchematicDiagram } from '@/components/armor/schematic';
 
 /**
  * Armor allocation data for a single location
@@ -38,7 +41,8 @@ export interface ArmorDiagramProps {
 }
 
 /**
- * SVG Mech armor diagram with interactive locations
+ * Armor diagram with mode switching support.
+ * Renders either Schematic (CSS grid) or Silhouette (SVG) based on settings.
  */
 export function ArmorDiagram({
   armorData,
@@ -49,13 +53,29 @@ export function ArmorDiagram({
   className = '',
 }: ArmorDiagramProps): React.ReactElement {
   const [hoveredLocation, setHoveredLocation] = useState<MechLocation | null>(null);
-  
+  const { armorDiagramMode } = useAppSettingsStore();
+
   const getArmorData = (location: MechLocation): LocationArmorData | undefined => {
     return armorData.find((d) => d.location === location);
   };
-  
+
   const isOverAllocated = unallocatedPoints < 0;
-  
+
+  // Schematic mode: Use CSS grid-based diagram
+  if (armorDiagramMode === 'schematic') {
+    return (
+      <SchematicDiagram
+        armorData={armorData}
+        selectedLocation={selectedLocation}
+        unallocatedPoints={unallocatedPoints}
+        onLocationClick={onLocationClick}
+        onAutoAllocate={onAutoAllocate}
+        className={className}
+      />
+    );
+  }
+
+  // Silhouette mode: Use SVG-based diagram
   return (
     <div className={`bg-surface-base rounded-lg border border-border-theme-subtle p-4 ${className}`}>
       {/* Header */}

--- a/src/components/customizer/armor/ArmorDiagramPreview.tsx
+++ b/src/components/customizer/armor/ArmorDiagramPreview.tsx
@@ -13,6 +13,7 @@ import {
   NeonOperatorDiagram,
   TacticalHUDDiagram,
   PremiumMaterialDiagram,
+  MegaMekDiagram,
 } from './variants';
 import { SchematicDiagram } from '@/components/armor/schematic';
 import { ArmorDiagramVariant, ArmorDiagramMode } from '@/stores/useAppSettingsStore';
@@ -81,6 +82,16 @@ export const DIAGRAM_VARIANT_INFO: Record<
       'Stacked front/rear',
     ],
   },
+  'megamek': {
+    name: 'MegaMek Classic',
+    description: 'Authentic record sheet style',
+    features: [
+      'PDF record sheet proportions',
+      'Layered shadow/fill/outline',
+      'Hand actuator details',
+      'Knee joint articulation',
+    ],
+  },
 };
 
 interface ArmorDiagramPreviewProps {
@@ -134,6 +145,8 @@ export function ArmorDiagramPreview({
         return <TacticalHUDDiagram {...diagramProps} />;
       case 'premium-material':
         return <PremiumMaterialDiagram {...diagramProps} />;
+      case 'megamek':
+        return <MegaMekDiagram {...diagramProps} />;
       default:
         return <CleanTechDiagram {...diagramProps} />;
     }
@@ -189,6 +202,7 @@ export function ArmorDiagramGridPreview({
     'neon-operator',
     'tactical-hud',
     'premium-material',
+    'megamek',
   ];
 
   return (

--- a/src/components/customizer/armor/ArmorDiagramPreview.tsx
+++ b/src/components/customizer/armor/ArmorDiagramPreview.tsx
@@ -14,7 +14,8 @@ import {
   TacticalHUDDiagram,
   PremiumMaterialDiagram,
 } from './variants';
-import { ArmorDiagramVariant } from '@/stores/useAppSettingsStore';
+import { SchematicDiagram } from '@/components/armor/schematic';
+import { ArmorDiagramVariant, ArmorDiagramMode } from '@/stores/useAppSettingsStore';
 
 /**
  * Sample armor data for preview
@@ -258,6 +259,127 @@ export function ArmorDiagramFeatureList({
           </li>
         ))}
       </ul>
+    </div>
+  );
+}
+
+/**
+ * Mode metadata
+ */
+export const DIAGRAM_MODE_INFO: Record<
+  ArmorDiagramMode,
+  { name: string; description: string; features: string[] }
+> = {
+  schematic: {
+    name: 'Schematic',
+    description: 'Grid-based layout with anatomical positioning',
+    features: [
+      'CSS grid layout',
+      'Color-coded health bars',
+      'Front/rear split display',
+      'Desktop and mobile layouts',
+    ],
+  },
+  silhouette: {
+    name: 'Silhouette',
+    description: 'SVG mech outline with visual styling',
+    features: [
+      'Realistic mech silhouette',
+      'Multiple style variants',
+      'Interactive hover states',
+      'Visual armor fill indicators',
+    ],
+  },
+};
+
+interface ArmorDiagramModePreviewProps {
+  /** Currently selected mode */
+  selectedMode: ArmorDiagramMode;
+  /** Callback when a mode is selected */
+  onSelectMode: (mode: ArmorDiagramMode) => void;
+  /** Optional: className */
+  className?: string;
+}
+
+/**
+ * Side-by-side mode preview for selection
+ */
+export function ArmorDiagramModePreview({
+  selectedMode,
+  onSelectMode,
+  className = '',
+}: ArmorDiagramModePreviewProps): React.ReactElement {
+  const [selectedLocation, setSelectedLocation] = useState<MechLocation | null>(null);
+  const modes: ArmorDiagramMode[] = ['schematic', 'silhouette'];
+
+  const handleLocationClick = (location: MechLocation) => {
+    setSelectedLocation((prev) => (prev === location ? null : location));
+  };
+
+  return (
+    <div className={`grid grid-cols-1 lg:grid-cols-2 gap-4 ${className}`}>
+      {modes.map((mode) => {
+        const info = DIAGRAM_MODE_INFO[mode];
+        const isSelected = selectedMode === mode;
+
+        return (
+          <div
+            key={mode}
+            className={`p-3 rounded-lg border-2 transition-all cursor-pointer overflow-hidden ${
+              isSelected
+                ? 'border-accent bg-accent/5'
+                : 'border-border-theme-subtle hover:border-border-theme bg-surface-base/30'
+            }`}
+            onClick={() => onSelectMode(mode)}
+          >
+            <div className="flex items-center justify-between mb-2">
+              <div>
+                <div className="text-sm font-medium text-text-theme-primary">
+                  {info.name}
+                </div>
+                <div className="text-xs text-text-theme-secondary">
+                  {info.description}
+                </div>
+              </div>
+              {isSelected && (
+                <div className="w-5 h-5 rounded-full bg-accent flex items-center justify-center flex-shrink-0">
+                  <svg
+                    className="w-3 h-3 text-white"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </div>
+              )}
+            </div>
+            {/* Preview container */}
+            <div className="relative h-[280px] overflow-hidden">
+              <div className="absolute top-0 left-1/2 -translate-x-1/2 origin-top scale-50">
+                {mode === 'schematic' ? (
+                  <SchematicDiagram
+                    armorData={SAMPLE_ARMOR_DATA}
+                    selectedLocation={selectedLocation}
+                    unallocatedPoints={12}
+                    onLocationClick={handleLocationClick}
+                  />
+                ) : (
+                  <CleanTechDiagram
+                    armorData={SAMPLE_ARMOR_DATA}
+                    selectedLocation={selectedLocation}
+                    unallocatedPoints={12}
+                    onLocationClick={handleLocationClick}
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/customizer/armor/ArmorDiagramPreview.tsx
+++ b/src/components/customizer/armor/ArmorDiagramPreview.tsx
@@ -34,14 +34,16 @@ const SAMPLE_ARMOR_DATA: LocationArmorData[] = [
 
 /**
  * Variant metadata
+ * Note: These are independent visual styles for the armor diagram only,
+ * not related to the global UI Theme setting.
  */
 export const DIAGRAM_VARIANT_INFO: Record<
   ArmorDiagramVariant,
   { name: string; description: string; features: string[] }
 > = {
   'clean-tech': {
-    name: 'Clean Tech',
-    description: 'Maximum readability with solid colors',
+    name: 'Standard',
+    description: 'Clean design with solid colors',
     features: [
       'Realistic mech silhouette',
       'Solid gradient fills',
@@ -50,18 +52,18 @@ export const DIAGRAM_VARIANT_INFO: Record<
     ],
   },
   'neon-operator': {
-    name: 'Neon Operator',
-    description: 'Sci-fi aesthetic with glowing effects',
+    name: 'Glow Effects',
+    description: 'Sci-fi aesthetic with neon lighting',
     features: [
       'Wireframe outline',
-      'Neon glow effects',
+      'Glowing edge effects',
       'Progress ring indicators',
       'Stacked front/rear',
     ],
   },
   'tactical-hud': {
-    name: 'Tactical HUD',
-    description: 'Military feel with LED displays',
+    name: 'LED Display',
+    description: 'Military-style LED readouts',
     features: [
       'Geometric shapes',
       'LED number display',
@@ -70,8 +72,8 @@ export const DIAGRAM_VARIANT_INFO: Record<
     ],
   },
   'premium-material': {
-    name: 'Premium Material',
-    description: 'Metallic textures with 3D depth',
+    name: 'Metallic',
+    description: 'Chrome textures with 3D depth',
     features: [
       'Realistic contour',
       'Metallic textures',

--- a/src/components/customizer/armor/ArmorDiagramQuickSettings.tsx
+++ b/src/components/customizer/armor/ArmorDiagramQuickSettings.tsx
@@ -22,8 +22,11 @@ export function ArmorDiagramQuickSettings({ className = '' }: QuickSettingsProps
   const popupRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
-  const armorDiagramVariant = useAppSettingsStore((s) => s.armorDiagramVariant);
-  const setArmorDiagramVariant = useAppSettingsStore((s) => s.setArmorDiagramVariant);
+  // Use effective getter for draft preview support
+  const getEffectiveArmorDiagramVariant = useAppSettingsStore((s) => s.getEffectiveArmorDiagramVariant);
+  const armorDiagramVariant = getEffectiveArmorDiagramVariant();
+  // Use draft setter to update draft (not persisted value directly)
+  const setDraftArmorDiagramVariant = useAppSettingsStore((s) => s.setDraftArmorDiagramVariant);
 
   // Close popup when clicking outside
   useEffect(() => {
@@ -63,10 +66,11 @@ export function ArmorDiagramQuickSettings({ className = '' }: QuickSettingsProps
     'neon-operator',
     'tactical-hud',
     'premium-material',
+    'megamek',
   ];
 
   const handleSelectVariant = (variant: ArmorDiagramVariant) => {
-    setArmorDiagramVariant(variant);
+    setDraftArmorDiagramVariant(variant);
     setIsOpen(false);
   };
 

--- a/src/components/customizer/armor/ArmorDiagramSettings.tsx
+++ b/src/components/customizer/armor/ArmorDiagramSettings.tsx
@@ -1,0 +1,100 @@
+/**
+ * Armor Diagram Settings
+ *
+ * Split-panel layout for selecting armor diagram variant.
+ * Left: list with thumbnails, Right: large preview.
+ * Uses draft/save pattern for consistency with appearance settings.
+ */
+
+import React, { useEffect } from 'react';
+import { useAppSettingsStore, ArmorDiagramVariant } from '@/stores/useAppSettingsStore';
+import { VariantThumbnail } from './VariantThumbnail';
+import { ArmorDiagramPreview, DIAGRAM_VARIANT_INFO } from './ArmorDiagramPreview';
+
+interface ArmorDiagramSettingsProps {
+  className?: string;
+}
+
+export function ArmorDiagramSettings({ className = '' }: ArmorDiagramSettingsProps): React.ReactElement {
+  const initDraftCustomizer = useAppSettingsStore((s) => s.initDraftCustomizer);
+  const saveCustomizer = useAppSettingsStore((s) => s.saveCustomizer);
+  const hasUnsavedCustomizer = useAppSettingsStore((s) => s.hasUnsavedCustomizer);
+  const setDraftArmorDiagramVariant = useAppSettingsStore((s) => s.setDraftArmorDiagramVariant);
+  const getEffectiveArmorDiagramVariant = useAppSettingsStore((s) => s.getEffectiveArmorDiagramVariant);
+
+  const effectiveVariant = getEffectiveArmorDiagramVariant();
+
+  // Initialize draft on mount
+  useEffect(() => {
+    initDraftCustomizer();
+  }, [initDraftCustomizer]);
+
+  const variants: ArmorDiagramVariant[] = [
+    'clean-tech',
+    'neon-operator',
+    'tactical-hud',
+    'premium-material',
+    'megamek',
+  ];
+
+  return (
+    <div className={className}>
+      <div className="flex gap-4">
+        {/* Left: Variant list */}
+        <div className="w-48 space-y-1">
+          {variants.map((variant) => {
+            const info = DIAGRAM_VARIANT_INFO[variant];
+            const isSelected = effectiveVariant === variant;
+
+            return (
+              <button
+                key={variant}
+                onClick={() => setDraftArmorDiagramVariant(variant)}
+                className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left transition-colors ${
+                  isSelected
+                    ? 'bg-accent/20 border border-accent'
+                    : 'bg-surface-raised/30 border border-transparent hover:bg-surface-raised hover:border-border-theme'
+                }`}
+              >
+                <VariantThumbnail variant={variant} />
+                <div className="flex-1 min-w-0">
+                  <div className={`text-sm font-medium ${isSelected ? 'text-accent' : 'text-text-theme-primary'}`}>
+                    {info.name}
+                  </div>
+                  <div className="text-xs text-text-theme-secondary truncate">
+                    {info.description}
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Right: Large preview */}
+        <div className="flex-1">
+          <ArmorDiagramPreview variant={effectiveVariant} />
+        </div>
+      </div>
+
+      {/* Save indicator */}
+      {hasUnsavedCustomizer && (
+        <div className="flex items-center justify-between mt-4 p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg">
+          <div className="flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 text-amber-400">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+            </svg>
+            <span className="text-sm text-amber-200">
+              Diagram style preview active — save to keep changes
+            </span>
+          </div>
+          <button
+            onClick={saveCustomizer}
+            className="px-3 py-1.5 text-sm font-medium bg-amber-600 hover:bg-amber-500 text-white rounded-md transition-colors"
+          >
+            Save Diagram Style
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/customizer/armor/VariantThumbnail.tsx
+++ b/src/components/customizer/armor/VariantThumbnail.tsx
@@ -1,0 +1,121 @@
+/**
+ * Variant Thumbnail
+ *
+ * Mini ~40x60px preview showing center torso in each variant's style.
+ * Self-contained styling - does not inherit from global theme.
+ */
+
+import React from 'react';
+import { ArmorDiagramVariant } from '@/stores/useAppSettingsStore';
+
+interface VariantThumbnailProps {
+  variant: ArmorDiagramVariant;
+  className?: string;
+}
+
+export function VariantThumbnail({ variant, className = '' }: VariantThumbnailProps): React.ReactElement {
+  // Make filter/gradient IDs unique per variant to avoid conflicts when multiple thumbnails are rendered
+  const neonGlowId = `neon-glow-${variant}`;
+  const metallicGradientId = `metallic-gradient-${variant}`;
+
+  // Render a simplified center torso shape with variant-specific styling
+  const getVariantStyles = () => {
+    switch (variant) {
+      case 'clean-tech':
+        return {
+          fill: '#22c55e',
+          stroke: '#000',
+          strokeWidth: 1.5,
+          filter: undefined,
+        };
+      case 'neon-operator':
+        return {
+          fill: 'rgba(6, 182, 212, 0.3)',
+          stroke: '#06b6d4',
+          strokeWidth: 2,
+          filter: `url(#${neonGlowId})`,
+        };
+      case 'tactical-hud':
+        return {
+          fill: '#1e3a5f',
+          stroke: '#3b82f6',
+          strokeWidth: 1.5,
+          filter: undefined,
+        };
+      case 'premium-material':
+        return {
+          fill: `url(#${metallicGradientId})`,
+          stroke: '#94a3b8',
+          strokeWidth: 1,
+          filter: undefined,
+        };
+      case 'megamek':
+        return {
+          fill: '#22c55e',
+          stroke: '#000',
+          strokeWidth: 1.2,
+          filter: undefined,
+        };
+    }
+  };
+
+  const styles = getVariantStyles();
+
+  return (
+    <svg
+      viewBox="0 0 40 60"
+      className={`w-10 h-15 ${className}`}
+    >
+      <defs>
+        <filter id={neonGlowId} x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="2" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+        <linearGradient id={metallicGradientId} x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="#64748b" />
+          <stop offset="50%" stopColor="#94a3b8" />
+          <stop offset="100%" stopColor="#475569" />
+        </linearGradient>
+      </defs>
+
+      {/* Simplified torso shape */}
+      <rect
+        x="8"
+        y="5"
+        width="24"
+        height="50"
+        rx="3"
+        fill={styles.fill}
+        stroke={styles.stroke}
+        strokeWidth={styles.strokeWidth}
+        filter={styles.filter}
+      />
+
+      {/* Variant-specific decorations */}
+      {variant === 'neon-operator' && (
+        <rect
+          x="12"
+          y="10"
+          width="16"
+          height="40"
+          rx="2"
+          fill="none"
+          stroke="#06b6d4"
+          strokeWidth="0.5"
+          strokeDasharray="2 2"
+        />
+      )}
+
+      {variant === 'tactical-hud' && (
+        <>
+          <rect x="14" y="20" width="12" height="4" fill="#3b82f6" opacity="0.8" />
+          <rect x="14" y="28" width="12" height="4" fill="#3b82f6" opacity="0.6" />
+          <rect x="14" y="36" width="12" height="4" fill="#3b82f6" opacity="0.4" />
+        </>
+      )}
+    </svg>
+  );
+}

--- a/src/components/customizer/armor/VariantThumbnail.tsx
+++ b/src/components/customizer/armor/VariantThumbnail.tsx
@@ -56,6 +56,11 @@ export function VariantThumbnail({ variant, className = '' }: VariantThumbnailPr
           strokeWidth: 1.2,
           filter: undefined,
         };
+      default: {
+        // Exhaustive check - TypeScript should catch missing cases
+        const _exhaustiveCheck: never = variant;
+        return _exhaustiveCheck;
+      }
     }
   };
 
@@ -64,7 +69,9 @@ export function VariantThumbnail({ variant, className = '' }: VariantThumbnailPr
   return (
     <svg
       viewBox="0 0 40 60"
-      className={`w-10 h-15 ${className}`}
+      className={`w-10 h-[60px] ${className}`}
+      aria-label={`${variant} style preview`}
+      role="img"
     >
       <defs>
         <filter id={neonGlowId} x="-50%" y="-50%" width="200%" height="200%">

--- a/src/components/customizer/armor/__tests__/ArmorDiagram.test.tsx
+++ b/src/components/customizer/armor/__tests__/ArmorDiagram.test.tsx
@@ -6,6 +6,7 @@ import { MechLocation } from '@/types/construction';
 
 // Mock the store
 jest.mock('@/stores/useAppSettingsStore');
+const mockUseAppSettingsStore = useAppSettingsStore as jest.MockedFunction<typeof useAppSettingsStore>;
 
 describe('ArmorDiagram', () => {
   const mockArmorData = [
@@ -32,9 +33,9 @@ describe('ArmorDiagram', () => {
 
   describe('mode switching', () => {
     it('should render silhouette diagram when mode is silhouette', () => {
-      (useAppSettingsStore as unknown as jest.Mock).mockReturnValue({
+      mockUseAppSettingsStore.mockReturnValue({
         armorDiagramMode: 'silhouette',
-      });
+      } as ReturnType<typeof useAppSettingsStore>);
 
       const { container } = render(<ArmorDiagram {...defaultProps} />);
 
@@ -43,9 +44,9 @@ describe('ArmorDiagram', () => {
     });
 
     it('should render schematic diagram when mode is schematic', () => {
-      (useAppSettingsStore as unknown as jest.Mock).mockReturnValue({
+      mockUseAppSettingsStore.mockReturnValue({
         armorDiagramMode: 'schematic',
-      });
+      } as ReturnType<typeof useAppSettingsStore>);
 
       render(<ArmorDiagram {...defaultProps} />);
 
@@ -55,11 +56,9 @@ describe('ArmorDiagram', () => {
     });
 
     it('should pass props to schematic diagram correctly', () => {
-      (useAppSettingsStore as unknown as jest.Mock).mockReturnValue({
+      mockUseAppSettingsStore.mockReturnValue({
         armorDiagramMode: 'schematic',
-      });
-
-      render(<ArmorDiagram {...defaultProps} selectedLocation={MechLocation.HEAD} />);
+      } as ReturnType<typeof useAppSettingsStore>);
 
       // Check that the selected location has the selected styling
       const { container } = render(<ArmorDiagram {...defaultProps} selectedLocation={MechLocation.HEAD} />);

--- a/src/components/customizer/armor/__tests__/ArmorDiagram.test.tsx
+++ b/src/components/customizer/armor/__tests__/ArmorDiagram.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ArmorDiagram } from '../ArmorDiagram';
+import { useAppSettingsStore } from '@/stores/useAppSettingsStore';
+import { MechLocation } from '@/types/construction';
+
+// Mock the store
+jest.mock('@/stores/useAppSettingsStore');
+
+describe('ArmorDiagram', () => {
+  const mockArmorData = [
+    { location: MechLocation.HEAD, current: 9, maximum: 9 },
+    { location: MechLocation.CENTER_TORSO, current: 35, maximum: 47, rear: 12, rearMaximum: 23 },
+    { location: MechLocation.LEFT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.RIGHT_TORSO, current: 24, maximum: 32, rear: 8, rearMaximum: 16 },
+    { location: MechLocation.LEFT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.RIGHT_ARM, current: 20, maximum: 24 },
+    { location: MechLocation.LEFT_LEG, current: 28, maximum: 32 },
+    { location: MechLocation.RIGHT_LEG, current: 28, maximum: 32 },
+  ];
+
+  const defaultProps = {
+    armorData: mockArmorData,
+    selectedLocation: null,
+    unallocatedPoints: 12,
+    onLocationClick: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('mode switching', () => {
+    it('should render silhouette diagram when mode is silhouette', () => {
+      (useAppSettingsStore as unknown as jest.Mock).mockReturnValue({
+        armorDiagramMode: 'silhouette',
+      });
+
+      const { container } = render(<ArmorDiagram {...defaultProps} />);
+
+      // Silhouette mode uses SVG
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('should render schematic diagram when mode is schematic', () => {
+      (useAppSettingsStore as unknown as jest.Mock).mockReturnValue({
+        armorDiagramMode: 'schematic',
+      });
+
+      render(<ArmorDiagram {...defaultProps} />);
+
+      // Schematic mode uses CSS grid with location abbreviations
+      expect(screen.getAllByText('HD').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('CT').length).toBeGreaterThan(0);
+    });
+
+    it('should pass props to schematic diagram correctly', () => {
+      (useAppSettingsStore as unknown as jest.Mock).mockReturnValue({
+        armorDiagramMode: 'schematic',
+      });
+
+      render(<ArmorDiagram {...defaultProps} selectedLocation={MechLocation.HEAD} />);
+
+      // Check that the selected location has the selected styling
+      const { container } = render(<ArmorDiagram {...defaultProps} selectedLocation={MechLocation.HEAD} />);
+      const selectedButton = container.querySelector('.ring-2');
+      expect(selectedButton).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/customizer/armor/shared/MechSilhouette.tsx
+++ b/src/components/customizer/armor/shared/MechSilhouette.tsx
@@ -213,209 +213,204 @@ export const REALISTIC_SILHOUETTE: SilhouetteConfig = {
 };
 
 /**
- * BattleMech-style silhouette with iconic mech features
- * Inspired by classic designs: broad shoulders, cockpit visor, weapon pods
+ * BattleMech-style silhouette with proper MegaMek-like proportions
+ * Based on classic record sheet armor diagram layout
  */
 export const BATTLEMECH_SILHOUETTE: SilhouetteConfig = {
-  viewBox: '0 0 320 420',
+  viewBox: '0 0 200 280',
   locations: {
     [MechLocation.HEAD]: {
-      x: 125,
+      x: 75,
       y: 0,
-      width: 70,
-      height: 50,
-      // Angular cockpit with visor and sensor dome
+      width: 50,
+      height: 32,
+      // Cockpit-style head
       path: `
-        M 145 0
-        L 175 0
-        L 185 8
-        L 190 25
-        L 185 40
-        L 175 50
-        L 145 50
-        L 135 40
-        L 130 25
-        L 135 8
-        Z
-        M 140 18
-        L 180 18
-        L 180 35
-        L 140 35
+        M 82 2
+        L 118 2
+        L 122 8
+        L 122 26
+        L 118 32
+        L 82 32
+        L 78 26
+        L 78 8
         Z
       `,
     },
     [MechLocation.CENTER_TORSO]: {
-      x: 110,
-      y: 55,
-      width: 100,
-      height: 120,
-      // Broad armored chest with reactor housing
+      x: 72,
+      y: 36,
+      width: 56,
+      height: 80,
+      // Central torso - reactor housing
       path: `
-        M 120 55
-        L 200 55
-        L 210 70
-        L 210 145
-        L 200 165
-        L 185 175
-        L 135 175
-        L 120 165
-        L 110 145
-        L 110 70
+        M 76 36
+        L 124 36
+        L 128 44
+        L 128 108
+        L 124 116
+        L 76 116
+        L 72 108
+        L 72 44
         Z
       `,
     },
     [MechLocation.LEFT_TORSO]: {
-      x: 20,
-      y: 55,
-      width: 85,
-      height: 115,
-      // Left shoulder pod with missile rack styling
+      x: 30,
+      y: 38,
+      width: 40,
+      height: 78,
+      // Left side torso
       path: `
-        M 40 55
-        L 105 55
-        L 105 160
-        L 90 175
-        L 40 175
-        L 20 155
-        L 20 75
+        M 34 42
+        L 70 38
+        L 70 116
+        L 58 116
+        L 34 112
+        L 30 104
+        L 30 50
         Z
       `,
     },
     [MechLocation.RIGHT_TORSO]: {
-      x: 215,
-      y: 55,
-      width: 85,
-      height: 115,
-      // Right shoulder pod mirrored
+      x: 130,
+      y: 38,
+      width: 40,
+      height: 78,
+      // Right side torso (mirrored)
       path: `
-        M 280 55
-        L 215 55
-        L 215 160
-        L 230 175
-        L 280 175
-        L 300 155
-        L 300 75
+        M 166 42
+        L 130 38
+        L 130 116
+        L 142 116
+        L 166 112
+        L 170 104
+        L 170 50
         Z
       `,
     },
     [MechLocation.LEFT_ARM]: {
-      x: 0,
-      y: 70,
-      width: 35,
-      height: 165,
-      // Weapon arm with actuator joints
+      x: 2,
+      y: 42,
+      width: 26,
+      height: 100,
+      // Left arm with actuator segments
       path: `
-        M 10 70
-        L 35 80
-        L 35 130
-        L 30 140
-        L 30 200
-        L 25 215
-        L 20 235
-        L 5 235
-        L 0 215
-        L 0 90
+        M 8 46
+        L 26 42
+        L 26 68
+        L 22 74
+        L 22 84
+        L 26 90
+        L 26 130
+        L 22 138
+        L 14 142
+        L 8 142
+        L 2 134
+        L 2 54
         Z
       `,
     },
     [MechLocation.RIGHT_ARM]: {
-      x: 285,
-      y: 70,
-      width: 35,
-      height: 165,
-      // Mirrored weapon arm
+      x: 172,
+      y: 42,
+      width: 26,
+      height: 100,
+      // Right arm (mirrored)
       path: `
-        M 310 70
-        L 285 80
-        L 285 130
-        L 290 140
-        L 290 200
-        L 295 215
-        L 300 235
-        L 315 235
-        L 320 215
-        L 320 90
+        M 192 46
+        L 174 42
+        L 174 68
+        L 178 74
+        L 178 84
+        L 174 90
+        L 174 130
+        L 178 138
+        L 186 142
+        L 192 142
+        L 198 134
+        L 198 54
         Z
       `,
     },
     [MechLocation.LEFT_LEG]: {
-      x: 55,
-      y: 180,
-      width: 70,
-      height: 180,
-      // Heavy leg with armored thigh and foot pad
+      x: 42,
+      y: 120,
+      width: 46,
+      height: 110,
+      // Left leg with knee joint
       path: `
-        M 65 180
-        L 120 180
-        L 125 200
-        L 120 260
-        L 115 280
-        L 115 340
-        L 125 360
-        L 120 375
-        L 60 375
-        L 55 360
-        L 65 340
-        L 65 280
-        L 60 260
-        L 55 200
+        M 46 120
+        L 84 120
+        L 88 132
+        L 86 168
+        L 82 178
+        L 82 212
+        L 88 224
+        L 84 232
+        L 46 232
+        L 42 224
+        L 48 212
+        L 48 178
+        L 44 168
+        L 42 132
         Z
       `,
     },
     [MechLocation.RIGHT_LEG]: {
-      x: 195,
-      y: 180,
-      width: 70,
-      height: 180,
-      // Mirrored right leg
+      x: 112,
+      y: 120,
+      width: 46,
+      height: 110,
+      // Right leg (mirrored)
       path: `
-        M 255 180
-        L 200 180
-        L 195 200
-        L 200 260
-        L 205 280
-        L 205 340
-        L 195 360
-        L 200 375
-        L 260 375
-        L 265 360
-        L 255 340
-        L 255 280
-        L 260 260
-        L 265 200
+        M 154 120
+        L 116 120
+        L 112 132
+        L 114 168
+        L 118 178
+        L 118 212
+        L 112 224
+        L 116 232
+        L 154 232
+        L 158 224
+        L 152 212
+        L 152 178
+        L 156 168
+        L 158 132
         Z
       `,
     },
   },
   outlinePath: `
-    M 160 0
-    C 145 0, 130 8, 130 25
-    L 130 45
-    L 105 55
-    L 40 55
-    L 20 75
-    L 0 90
-    L 0 235
-    L 30 235
-    L 35 180
-    L 55 180
-    L 55 375
-    L 125 375
-    L 125 180
-    L 195 180
-    L 195 375
-    L 265 375
-    L 265 180
-    L 285 180
-    L 290 235
-    L 320 235
-    L 320 90
-    L 300 75
-    L 280 55
-    L 215 55
-    L 190 45
-    L 190 25
-    C 190 8, 175 0, 160 0
+    M 100 0
+    C 85 0, 78 4, 78 12
+    L 78 32
+    L 70 36
+    L 30 42
+    L 26 42
+    L 2 54
+    L 2 142
+    L 26 142
+    L 30 120
+    L 42 120
+    L 42 232
+    L 88 232
+    L 88 120
+    L 112 120
+    L 112 232
+    L 158 232
+    L 158 120
+    L 170 120
+    L 174 142
+    L 198 142
+    L 198 54
+    L 174 42
+    L 170 42
+    L 130 36
+    L 122 32
+    L 122 12
+    C 122 4, 115 0, 100 0
     Z
   `,
 };

--- a/src/components/customizer/armor/shared/MechSilhouette.tsx
+++ b/src/components/customizer/armor/shared/MechSilhouette.tsx
@@ -416,6 +416,190 @@ export const BATTLEMECH_SILHOUETTE: SilhouetteConfig = {
 };
 
 /**
+ * MegaMek-style silhouette - Faithful to PDF record sheet armor diagram
+ * Classic blocky/rectangular style matching MegaMek record sheets
+ * Simple, clean shapes with clear location boundaries
+ */
+export const MEGAMEK_SILHOUETTE: SilhouetteConfig = {
+  viewBox: '0 0 200 320',
+  locations: {
+    [MechLocation.HEAD]: {
+      x: 70,
+      y: 8,
+      width: 60,
+      height: 44,
+      // Classic MegaMek cockpit - rounded top, flat bottom
+      path: `
+        M 100 8
+        C 80 8, 70 18, 70 28
+        L 70 52
+        L 130 52
+        L 130 28
+        C 130 18, 120 8, 100 8
+        Z
+      `,
+    },
+    [MechLocation.CENTER_TORSO]: {
+      x: 70,
+      y: 56,
+      width: 60,
+      height: 100,
+      // Central torso - straight rectangular
+      path: `
+        M 70 56
+        L 130 56
+        L 130 156
+        L 70 156
+        Z
+      `,
+    },
+    [MechLocation.LEFT_TORSO]: {
+      x: 28,
+      y: 60,
+      width: 40,
+      height: 96,
+      // Left side torso - angled connection to CT
+      path: `
+        M 68 60
+        L 32 68
+        L 28 76
+        L 28 148
+        L 32 156
+        L 68 156
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_TORSO]: {
+      x: 132,
+      y: 60,
+      width: 40,
+      height: 96,
+      // Right side torso (mirrored)
+      path: `
+        M 132 60
+        L 168 68
+        L 172 76
+        L 172 148
+        L 168 156
+        L 132 156
+        Z
+      `,
+    },
+    [MechLocation.LEFT_ARM]: {
+      x: 4,
+      y: 56,
+      width: 22,
+      height: 120,
+      // Left arm - simple rectangle with shoulder
+      path: `
+        M 26 56
+        L 26 64
+        L 8 72
+        L 4 80
+        L 4 168
+        L 8 176
+        L 22 176
+        L 26 168
+        L 26 64
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_ARM]: {
+      x: 174,
+      y: 56,
+      width: 22,
+      height: 120,
+      // Right arm (mirrored)
+      path: `
+        M 174 56
+        L 174 64
+        L 192 72
+        L 196 80
+        L 196 168
+        L 192 176
+        L 178 176
+        L 174 168
+        L 174 64
+        Z
+      `,
+    },
+    [MechLocation.LEFT_LEG]: {
+      x: 36,
+      y: 160,
+      width: 52,
+      height: 152,
+      // Left leg - hip to foot
+      path: `
+        M 88 160
+        L 88 200
+        L 84 210
+        L 84 280
+        L 88 292
+        L 88 312
+        L 36 312
+        L 36 292
+        L 40 280
+        L 40 210
+        L 36 200
+        L 36 168
+        L 44 160
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_LEG]: {
+      x: 112,
+      y: 160,
+      width: 52,
+      height: 152,
+      // Right leg (mirrored)
+      path: `
+        M 112 160
+        L 112 200
+        L 116 210
+        L 116 280
+        L 112 292
+        L 112 312
+        L 164 312
+        L 164 292
+        L 160 280
+        L 160 210
+        L 164 200
+        L 164 168
+        L 156 160
+        Z
+      `,
+    },
+  },
+  outlinePath: `
+    M 100 8
+    C 80 8, 70 18, 70 28
+    L 70 56
+    L 26 56
+    L 4 72
+    L 4 176
+    L 26 176
+    L 28 156
+    L 36 160
+    L 36 312
+    L 88 312
+    L 88 160
+    L 112 160
+    L 112 312
+    L 164 312
+    L 164 160
+    L 172 156
+    L 174 176
+    L 196 176
+    L 196 72
+    L 174 56
+    L 130 56
+    L 130 28
+    C 130 18, 120 8, 100 8
+    Z
+  `,
+};
+
+/**
  * Geometric/polygonal silhouette with angular shapes
  * Low-poly aesthetic with hexagonal influence
  */

--- a/src/components/customizer/armor/shared/MechSilhouette.tsx
+++ b/src/components/customizer/armor/shared/MechSilhouette.tsx
@@ -213,6 +213,214 @@ export const REALISTIC_SILHOUETTE: SilhouetteConfig = {
 };
 
 /**
+ * BattleMech-style silhouette with iconic mech features
+ * Inspired by classic designs: broad shoulders, cockpit visor, weapon pods
+ */
+export const BATTLEMECH_SILHOUETTE: SilhouetteConfig = {
+  viewBox: '0 0 320 420',
+  locations: {
+    [MechLocation.HEAD]: {
+      x: 125,
+      y: 0,
+      width: 70,
+      height: 50,
+      // Angular cockpit with visor and sensor dome
+      path: `
+        M 145 0
+        L 175 0
+        L 185 8
+        L 190 25
+        L 185 40
+        L 175 50
+        L 145 50
+        L 135 40
+        L 130 25
+        L 135 8
+        Z
+        M 140 18
+        L 180 18
+        L 180 35
+        L 140 35
+        Z
+      `,
+    },
+    [MechLocation.CENTER_TORSO]: {
+      x: 110,
+      y: 55,
+      width: 100,
+      height: 120,
+      // Broad armored chest with reactor housing
+      path: `
+        M 120 55
+        L 200 55
+        L 210 70
+        L 210 145
+        L 200 165
+        L 185 175
+        L 135 175
+        L 120 165
+        L 110 145
+        L 110 70
+        Z
+      `,
+    },
+    [MechLocation.LEFT_TORSO]: {
+      x: 20,
+      y: 55,
+      width: 85,
+      height: 115,
+      // Left shoulder pod with missile rack styling
+      path: `
+        M 40 55
+        L 105 55
+        L 105 160
+        L 90 175
+        L 40 175
+        L 20 155
+        L 20 75
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_TORSO]: {
+      x: 215,
+      y: 55,
+      width: 85,
+      height: 115,
+      // Right shoulder pod mirrored
+      path: `
+        M 280 55
+        L 215 55
+        L 215 160
+        L 230 175
+        L 280 175
+        L 300 155
+        L 300 75
+        Z
+      `,
+    },
+    [MechLocation.LEFT_ARM]: {
+      x: 0,
+      y: 70,
+      width: 35,
+      height: 165,
+      // Weapon arm with actuator joints
+      path: `
+        M 10 70
+        L 35 80
+        L 35 130
+        L 30 140
+        L 30 200
+        L 25 215
+        L 20 235
+        L 5 235
+        L 0 215
+        L 0 90
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_ARM]: {
+      x: 285,
+      y: 70,
+      width: 35,
+      height: 165,
+      // Mirrored weapon arm
+      path: `
+        M 310 70
+        L 285 80
+        L 285 130
+        L 290 140
+        L 290 200
+        L 295 215
+        L 300 235
+        L 315 235
+        L 320 215
+        L 320 90
+        Z
+      `,
+    },
+    [MechLocation.LEFT_LEG]: {
+      x: 55,
+      y: 180,
+      width: 70,
+      height: 180,
+      // Heavy leg with armored thigh and foot pad
+      path: `
+        M 65 180
+        L 120 180
+        L 125 200
+        L 120 260
+        L 115 280
+        L 115 340
+        L 125 360
+        L 120 375
+        L 60 375
+        L 55 360
+        L 65 340
+        L 65 280
+        L 60 260
+        L 55 200
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_LEG]: {
+      x: 195,
+      y: 180,
+      width: 70,
+      height: 180,
+      // Mirrored right leg
+      path: `
+        M 255 180
+        L 200 180
+        L 195 200
+        L 200 260
+        L 205 280
+        L 205 340
+        L 195 360
+        L 200 375
+        L 260 375
+        L 265 360
+        L 255 340
+        L 255 280
+        L 260 260
+        L 265 200
+        Z
+      `,
+    },
+  },
+  outlinePath: `
+    M 160 0
+    C 145 0, 130 8, 130 25
+    L 130 45
+    L 105 55
+    L 40 55
+    L 20 75
+    L 0 90
+    L 0 235
+    L 30 235
+    L 35 180
+    L 55 180
+    L 55 375
+    L 125 375
+    L 125 180
+    L 195 180
+    L 195 375
+    L 265 375
+    L 265 180
+    L 285 180
+    L 290 235
+    L 320 235
+    L 320 90
+    L 300 75
+    L 280 55
+    L 215 55
+    L 190 45
+    L 190 25
+    C 190 8, 175 0, 160 0
+    Z
+  `,
+};
+
+/**
  * Geometric/polygonal silhouette with angular shapes
  * Low-poly aesthetic with hexagonal influence
  */

--- a/src/components/customizer/armor/variants/CleanTechDiagram.tsx
+++ b/src/components/customizer/armor/variants/CleanTechDiagram.tsx
@@ -276,7 +276,7 @@ export function CleanTechDiagram({
       <div className="relative">
         <svg
           viewBox={BATTLEMECH_SILHOUETTE.viewBox}
-          className="w-full max-w-[320px] mx-auto"
+          className="w-full max-w-[280px] mx-auto"
           style={{ height: 'auto' }}
         >
           <GradientDefs />
@@ -285,8 +285,8 @@ export function CleanTechDiagram({
           <rect
             x="0"
             y="0"
-            width="320"
-            height="420"
+            width="200"
+            height="280"
             fill="url(#armor-grid)"
             opacity="0.5"
           />

--- a/src/components/customizer/armor/variants/CleanTechDiagram.tsx
+++ b/src/components/customizer/armor/variants/CleanTechDiagram.tsx
@@ -14,7 +14,7 @@ import React, { useState } from 'react';
 import { MechLocation } from '@/types/construction';
 import { LocationArmorData } from '../ArmorDiagram';
 import {
-  REALISTIC_SILHOUETTE,
+  BATTLEMECH_SILHOUETTE,
   LOCATION_LABELS,
   getLocationCenter,
   hasTorsoRear,
@@ -47,7 +47,7 @@ function CleanTechLocation({
   onClick,
   onHover,
 }: CleanTechLocationProps): React.ReactElement {
-  const pos = REALISTIC_SILHOUETTE.locations[location];
+  const pos = BATTLEMECH_SILHOUETTE.locations[location];
   const label = LOCATION_LABELS[location];
   const center = getLocationCenter(pos);
   const showRear = hasTorsoRear(location);
@@ -275,8 +275,8 @@ export function CleanTechDiagram({
       {/* Diagram */}
       <div className="relative">
         <svg
-          viewBox={REALISTIC_SILHOUETTE.viewBox}
-          className="w-full max-w-[300px] mx-auto"
+          viewBox={BATTLEMECH_SILHOUETTE.viewBox}
+          className="w-full max-w-[320px] mx-auto"
           style={{ height: 'auto' }}
         >
           <GradientDefs />
@@ -285,8 +285,8 @@ export function CleanTechDiagram({
           <rect
             x="0"
             y="0"
-            width="300"
-            height="400"
+            width="320"
+            height="420"
             fill="url(#armor-grid)"
             opacity="0.5"
           />

--- a/src/components/customizer/armor/variants/MegaMekDiagram.tsx
+++ b/src/components/customizer/armor/variants/MegaMekDiagram.tsx
@@ -1,0 +1,401 @@
+/**
+ * MegaMek Armor Diagram
+ *
+ * Design Philosophy: Authentic MegaMek record sheet appearance
+ * - Layered rendering: shadow → fill → outline for depth
+ * - Detailed mech silhouette with hand actuators and knee joints
+ * - Classic record sheet proportions and styling
+ * - Clean, professional appearance matching PDF output
+ */
+
+import React, { useState } from 'react';
+import { MechLocation } from '@/types/construction';
+import { LocationArmorData } from '../ArmorDiagram';
+import {
+  MEGAMEK_SILHOUETTE,
+  LOCATION_LABELS,
+  getLocationCenter,
+  hasTorsoRear,
+} from '../shared/MechSilhouette';
+import {
+  getArmorStatusColor,
+  getTorsoFrontStatusColor,
+  getTorsoRearStatusColor,
+  lightenColor,
+  SELECTED_COLOR,
+} from '../shared/ArmorFills';
+import { ArmorDiagramQuickSettings } from '../ArmorDiagramQuickSettings';
+
+interface MegaMekLocationProps {
+  location: MechLocation;
+  data?: LocationArmorData;
+  isSelected: boolean;
+  isHovered: boolean;
+  onClick: () => void;
+  onHover: (hovered: boolean) => void;
+}
+
+function MegaMekLocation({
+  location,
+  data,
+  isSelected,
+  isHovered,
+  onClick,
+  onHover,
+}: MegaMekLocationProps): React.ReactElement {
+  const pos = MEGAMEK_SILHOUETTE.locations[location];
+  const label = LOCATION_LABELS[location];
+  const center = getLocationCenter(pos);
+  const showRear = hasTorsoRear(location);
+
+  const current = data?.current ?? 0;
+  const maximum = data?.maximum ?? 1;
+  const rear = data?.rear ?? 0;
+  const rearMax = data?.rearMaximum ?? 1;
+
+  // Status-based colors for front and rear independently
+  const frontBaseColor = isSelected
+    ? SELECTED_COLOR
+    : showRear
+      ? getTorsoFrontStatusColor(current, maximum)
+      : getArmorStatusColor(current, maximum);
+  const rearBaseColor = isSelected
+    ? SELECTED_COLOR
+    : getTorsoRearStatusColor(rear, maximum);
+
+  const fillColor = isHovered ? lightenColor(frontBaseColor, 0.1) : frontBaseColor;
+  const shadowColor = '#1a1a1a';
+  const outlineColor = isSelected ? '#fbbf24' : '#000000';
+  const outlineWidth = isSelected ? 2 : 1.2;
+
+  // Split heights for front/rear display
+  const frontHeight = showRear ? pos.height * 0.65 : pos.height;
+  const rearHeight = showRear ? pos.height * 0.35 : 0;
+  const dividerY = pos.y + frontHeight;
+
+  return (
+    <g
+      role="button"
+      tabIndex={0}
+      aria-label={`${location} armor: ${current} of ${maximum}${showRear ? `, rear: ${rear} of ${rearMax}` : ''}`}
+      aria-pressed={isSelected}
+      className="cursor-pointer focus:outline-none"
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      onMouseEnter={() => onHover(true)}
+      onMouseLeave={() => onHover(false)}
+      onFocus={() => onHover(true)}
+      onBlur={() => onHover(false)}
+    >
+      {/* Layer 1: Shadow (offset for depth) */}
+      {pos.path && (
+        <path
+          d={pos.path}
+          fill={shadowColor}
+          stroke="none"
+          className="pointer-events-none"
+          transform="translate(2, 2)"
+          opacity={0.3}
+        />
+      )}
+
+      {/* Layer 2: Fill */}
+      {pos.path ? (
+        <path
+          d={pos.path}
+          fill={fillColor}
+          stroke="none"
+          className="transition-all duration-150"
+        />
+      ) : (
+        <rect
+          x={pos.x}
+          y={pos.y}
+          width={pos.width}
+          height={frontHeight}
+          rx={4}
+          fill={fillColor}
+          className="transition-all duration-150"
+        />
+      )}
+
+      {/* Layer 3: Outline */}
+      {pos.path ? (
+        <path
+          d={pos.path}
+          fill="none"
+          stroke={outlineColor}
+          strokeWidth={outlineWidth}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          className="transition-all duration-150"
+        />
+      ) : (
+        <rect
+          x={pos.x}
+          y={pos.y}
+          width={pos.width}
+          height={frontHeight}
+          rx={4}
+          fill="none"
+          stroke={outlineColor}
+          strokeWidth={outlineWidth}
+        />
+      )}
+
+      {/* Detail lines for mechanical look */}
+      {/* Detail lines removed for cleaner MegaMek style */}
+
+      {/* Front armor section labels and values */}
+      <text
+        x={center.x}
+        y={showRear ? pos.y + 14 : pos.y + 14}
+        textAnchor="middle"
+        className="fill-white/80 font-semibold pointer-events-none"
+        style={{
+          fontSize: showRear ? '9px' : '10px',
+          textShadow: '0 1px 2px rgba(0,0,0,0.8)',
+        }}
+      >
+        {showRear ? `${label} FRONT` : label}
+      </text>
+
+      <text
+        x={center.x}
+        y={showRear ? pos.y + frontHeight / 2 + 8 : pos.y + pos.height / 2 + 10}
+        textAnchor="middle"
+        className="fill-white font-bold pointer-events-none"
+        style={{
+          fontSize: pos.width < 40 ? '16px' : '20px',
+          textShadow: '0 1px 3px rgba(0,0,0,0.9)',
+        }}
+      >
+        {current}
+      </text>
+
+      <text
+        x={center.x}
+        y={showRear ? pos.y + frontHeight / 2 + 22 : pos.y + pos.height / 2 + 24}
+        textAnchor="middle"
+        className="fill-white/60 pointer-events-none"
+        style={{ fontSize: '9px' }}
+      >
+        / {maximum}
+      </text>
+
+      {/* Rear armor section for torsos */}
+      {showRear && (
+        <>
+          {/* Rear divider line */}
+          <line
+            x1={pos.x + 8}
+            y1={dividerY}
+            x2={pos.x + pos.width - 8}
+            y2={dividerY}
+            stroke="#475569"
+            strokeWidth={1}
+            strokeDasharray="4 2"
+            className="pointer-events-none"
+          />
+
+          {/* Rear fill overlay */}
+          <rect
+            x={pos.x}
+            y={dividerY}
+            width={pos.width}
+            height={rearHeight}
+            rx={4}
+            fill={isHovered ? lightenColor(rearBaseColor, 0.1) : rearBaseColor}
+            className="transition-all duration-150"
+          />
+
+          {/* Rear outline */}
+          <rect
+            x={pos.x}
+            y={dividerY}
+            width={pos.width}
+            height={rearHeight}
+            rx={4}
+            fill="none"
+            stroke={outlineColor}
+            strokeWidth={outlineWidth}
+          />
+
+          {/* Rear label */}
+          <text
+            x={center.x}
+            y={dividerY + 12}
+            textAnchor="middle"
+            className="fill-white/80 font-semibold pointer-events-none"
+            style={{
+              fontSize: '8px',
+              textShadow: '0 1px 2px rgba(0,0,0,0.8)',
+            }}
+          >
+            REAR
+          </text>
+
+          {/* Rear armor value */}
+          <text
+            x={center.x}
+            y={dividerY + rearHeight / 2 + 8}
+            textAnchor="middle"
+            className="fill-white font-bold pointer-events-none"
+            style={{
+              fontSize: '16px',
+              textShadow: '0 1px 3px rgba(0,0,0,0.9)',
+            }}
+          >
+            {rear}
+          </text>
+        </>
+      )}
+    </g>
+  );
+}
+
+export interface MegaMekDiagramProps {
+  armorData: LocationArmorData[];
+  selectedLocation: MechLocation | null;
+  unallocatedPoints: number;
+  onLocationClick: (location: MechLocation) => void;
+  onAutoAllocate?: () => void;
+  className?: string;
+}
+
+export function MegaMekDiagram({
+  armorData,
+  selectedLocation,
+  unallocatedPoints,
+  onLocationClick,
+  onAutoAllocate,
+  className = '',
+}: MegaMekDiagramProps): React.ReactElement {
+  const [hoveredLocation, setHoveredLocation] = useState<MechLocation | null>(null);
+
+  const getArmorData = (location: MechLocation): LocationArmorData | undefined => {
+    return armorData.find((d) => d.location === location);
+  };
+
+  const isOverAllocated = unallocatedPoints < 0;
+
+  const locations: MechLocation[] = [
+    MechLocation.HEAD,
+    MechLocation.CENTER_TORSO,
+    MechLocation.LEFT_TORSO,
+    MechLocation.RIGHT_TORSO,
+    MechLocation.LEFT_ARM,
+    MechLocation.RIGHT_ARM,
+    MechLocation.LEFT_LEG,
+    MechLocation.RIGHT_LEG,
+  ];
+
+  return (
+    <div className={`bg-surface-base rounded-lg border border-border-theme-subtle p-4 ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <h3 className="text-lg font-semibold text-text-theme-primary">Armor Allocation</h3>
+          <ArmorDiagramQuickSettings />
+        </div>
+        {onAutoAllocate && (
+          <button
+            onClick={onAutoAllocate}
+            className={`px-3 py-1.5 text-sm font-medium rounded transition-colors ${
+              isOverAllocated
+                ? 'bg-red-600 hover:bg-red-500 text-white'
+                : 'bg-accent hover:bg-accent-hover text-white'
+            }`}
+          >
+            Auto Allocate ({unallocatedPoints} pts)
+          </button>
+        )}
+      </div>
+
+      {/* Diagram */}
+      <div className="relative">
+        <svg
+          viewBox={MEGAMEK_SILHOUETTE.viewBox}
+          className="w-full max-w-[280px] mx-auto"
+          style={{ height: 'auto' }}
+        >
+          <defs>
+            {/* Grid pattern for background */}
+            <pattern id="megamek-grid" width="10" height="10" patternUnits="userSpaceOnUse">
+              <path
+                d="M 10 0 L 0 0 0 10"
+                fill="none"
+                stroke="rgba(255,255,255,0.03)"
+                strokeWidth="0.5"
+              />
+            </pattern>
+          </defs>
+
+          {/* Background */}
+          <rect
+            x="0"
+            y="0"
+            width="200"
+            height="320"
+            fill="url(#megamek-grid)"
+          />
+
+          {/* Mech outline (faint wireframe) */}
+          {MEGAMEK_SILHOUETTE.outlinePath && (
+            <path
+              d={MEGAMEK_SILHOUETTE.outlinePath}
+              fill="none"
+              stroke="rgba(100, 116, 139, 0.15)"
+              strokeWidth="1"
+              strokeDasharray="6 3"
+              className="pointer-events-none"
+            />
+          )}
+
+          {/* Render all locations */}
+          {locations.map((loc) => (
+            <MegaMekLocation
+              key={loc}
+              location={loc}
+              data={getArmorData(loc)}
+              isSelected={selectedLocation === loc}
+              isHovered={hoveredLocation === loc}
+              onClick={() => onLocationClick(loc)}
+              onHover={(h) => setHoveredLocation(h ? loc : null)}
+            />
+          ))}
+        </svg>
+      </div>
+
+      {/* Legend */}
+      <div className="flex justify-center gap-3 mt-4 text-xs">
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-green-500" />
+          <span className="text-text-theme-secondary">75%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-amber-500" />
+          <span className="text-text-theme-secondary">50%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-orange-500" />
+          <span className="text-text-theme-secondary">25%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-red-500" />
+          <span className="text-text-theme-secondary">&lt;25%</span>
+        </div>
+      </div>
+
+      {/* Instructions */}
+      <p className="text-xs text-text-theme-secondary text-center mt-2">
+        Click a location to edit armor values
+      </p>
+    </div>
+  );
+}

--- a/src/components/customizer/armor/variants/NeonOperatorDiagram.tsx
+++ b/src/components/customizer/armor/variants/NeonOperatorDiagram.tsx
@@ -13,7 +13,7 @@ import React, { useState } from 'react';
 import { MechLocation } from '@/types/construction';
 import { LocationArmorData } from '../ArmorDiagram';
 import {
-  REALISTIC_SILHOUETTE,
+  BATTLEMECH_SILHOUETTE,
   LOCATION_LABELS,
   getLocationCenter,
   hasTorsoRear,
@@ -89,7 +89,7 @@ interface NeonLocationProps {
 
 // Calculate leg offset based on torso height expansion
 const TORSO_HEIGHT_MULTIPLIER = 1.4;
-const LEG_Y_OFFSET = REALISTIC_SILHOUETTE.locations[MechLocation.CENTER_TORSO].height * (TORSO_HEIGHT_MULTIPLIER - 1);
+const LEG_Y_OFFSET = BATTLEMECH_SILHOUETTE.locations[MechLocation.CENTER_TORSO].height * (TORSO_HEIGHT_MULTIPLIER - 1);
 
 function isLegLocation(location: MechLocation): boolean {
   return location === MechLocation.LEFT_LEG || location === MechLocation.RIGHT_LEG;
@@ -103,7 +103,7 @@ function NeonLocation({
   onClick,
   onHover,
 }: NeonLocationProps): React.ReactElement {
-  const basePos = REALISTIC_SILHOUETTE.locations[location];
+  const basePos = BATTLEMECH_SILHOUETTE.locations[location];
   const label = LOCATION_LABELS[location];
   const showRear = hasTorsoRear(location);
 
@@ -403,8 +403,8 @@ export function NeonOperatorDiagram({
       {/* Diagram */}
       <div className="relative">
         <svg
-          viewBox="0 0 300 480"
-          className="w-full max-w-[300px] mx-auto"
+          viewBox="0 0 320 520"
+          className="w-full max-w-[320px] mx-auto"
           style={{ height: 'auto' }}
         >
           <GradientDefs />
@@ -413,16 +413,16 @@ export function NeonOperatorDiagram({
           <rect
             x="0"
             y="0"
-            width="300"
-            height="440"
+            width="320"
+            height="520"
             fill="url(#armor-scanlines)"
             opacity="0.3"
           />
 
           {/* Wireframe outline */}
-          {REALISTIC_SILHOUETTE.outlinePath && (
+          {BATTLEMECH_SILHOUETTE.outlinePath && (
             <path
-              d={REALISTIC_SILHOUETTE.outlinePath}
+              d={BATTLEMECH_SILHOUETTE.outlinePath}
               fill="none"
               stroke="rgba(34, 211, 238, 0.2)"
               strokeWidth="1"
@@ -447,8 +447,8 @@ export function NeonOperatorDiagram({
           {hoveredLocation && (
             <g className="pointer-events-none">
               <circle
-                cx={getLocationCenter(REALISTIC_SILHOUETTE.locations[hoveredLocation]).x}
-                cy={getLocationCenter(REALISTIC_SILHOUETTE.locations[hoveredLocation]).y}
+                cx={getLocationCenter(BATTLEMECH_SILHOUETTE.locations[hoveredLocation]).x}
+                cy={getLocationCenter(BATTLEMECH_SILHOUETTE.locations[hoveredLocation]).y}
                 r={40}
                 fill="none"
                 stroke="rgba(34, 211, 238, 0.3)"

--- a/src/components/customizer/armor/variants/NeonOperatorDiagram.tsx
+++ b/src/components/customizer/armor/variants/NeonOperatorDiagram.tsx
@@ -403,8 +403,8 @@ export function NeonOperatorDiagram({
       {/* Diagram */}
       <div className="relative">
         <svg
-          viewBox="0 0 320 520"
-          className="w-full max-w-[320px] mx-auto"
+          viewBox={BATTLEMECH_SILHOUETTE.viewBox}
+          className="w-full max-w-[280px] mx-auto"
           style={{ height: 'auto' }}
         >
           <GradientDefs />
@@ -413,8 +413,8 @@ export function NeonOperatorDiagram({
           <rect
             x="0"
             y="0"
-            width="320"
-            height="520"
+            width="200"
+            height="280"
             fill="url(#armor-scanlines)"
             opacity="0.3"
           />

--- a/src/components/customizer/armor/variants/PremiumMaterialDiagram.tsx
+++ b/src/components/customizer/armor/variants/PremiumMaterialDiagram.tsx
@@ -493,18 +493,18 @@ export function PremiumMaterialDiagram({
       {/* Diagram */}
       <div className="relative">
         <svg
-          viewBox="0 0 320 520"
-          className="w-full max-w-[320px] mx-auto"
+          viewBox={BATTLEMECH_SILHOUETTE.viewBox}
+          className="w-full max-w-[280px] mx-auto"
           style={{ height: 'auto' }}
         >
           <GradientDefs />
 
           {/* Ambient glow behind mech */}
           <ellipse
-            cx="160"
-            cy="200"
-            rx="120"
-            ry="160"
+            cx="100"
+            cy="140"
+            rx="80"
+            ry="110"
             fill="url(#armor-gradient-selected)"
             opacity="0.03"
           />

--- a/src/components/customizer/armor/variants/PremiumMaterialDiagram.tsx
+++ b/src/components/customizer/armor/variants/PremiumMaterialDiagram.tsx
@@ -14,7 +14,7 @@ import React, { useState } from 'react';
 import { MechLocation } from '@/types/construction';
 import { LocationArmorData } from '../ArmorDiagram';
 import {
-  REALISTIC_SILHOUETTE,
+  BATTLEMECH_SILHOUETTE,
   LOCATION_LABELS,
   getLocationCenter,
   hasTorsoRear,
@@ -153,14 +153,14 @@ function PremiumLocation({
   onClick,
   onHover,
 }: PremiumLocationProps): React.ReactElement {
-  const basePos = REALISTIC_SILHOUETTE.locations[location];
+  const basePos = BATTLEMECH_SILHOUETTE.locations[location];
   const label = LOCATION_LABELS[location];
   const showRear = hasTorsoRear(location);
   const isLeg = location === MechLocation.LEFT_LEG || location === MechLocation.RIGHT_LEG;
 
   // Adjust height for torso locations to fit stacked layout, offset legs down
   const TORSO_MULTIPLIER = 1.4;
-  const legOffset = REALISTIC_SILHOUETTE.locations[MechLocation.CENTER_TORSO].height * (TORSO_MULTIPLIER - 1);
+  const legOffset = BATTLEMECH_SILHOUETTE.locations[MechLocation.CENTER_TORSO].height * (TORSO_MULTIPLIER - 1);
   const pos = showRear
     ? { ...basePos, height: basePos.height * TORSO_MULTIPLIER }
     : isLeg
@@ -493,7 +493,7 @@ export function PremiumMaterialDiagram({
       {/* Diagram */}
       <div className="relative">
         <svg
-          viewBox="0 0 320 490"
+          viewBox="0 0 320 520"
           className="w-full max-w-[320px] mx-auto"
           style={{ height: 'auto' }}
         >

--- a/src/components/customizer/armor/variants/index.ts
+++ b/src/components/customizer/armor/variants/index.ts
@@ -15,3 +15,6 @@ export type { TacticalHUDDiagramProps } from './TacticalHUDDiagram';
 
 export { PremiumMaterialDiagram } from './PremiumMaterialDiagram';
 export type { PremiumMaterialDiagramProps } from './PremiumMaterialDiagram';
+
+export { MegaMekDiagram } from './MegaMekDiagram';
+export type { MegaMekDiagramProps } from './MegaMekDiagram';

--- a/src/components/customizer/tabs/ArmorTab.tsx
+++ b/src/components/customizer/tabs/ArmorTab.tsx
@@ -23,6 +23,7 @@ import {
   NeonOperatorDiagram,
   TacticalHUDDiagram,
   PremiumMaterialDiagram,
+  MegaMekDiagram,
 } from '../armor/variants';
 import {
   calculateArmorPoints,
@@ -58,9 +59,11 @@ export function ArmorTab({
   readOnly = false,
   className = '',
 }: ArmorTabProps): React.ReactElement {
-  // Get app settings
-  const armorDiagramMode = useAppSettingsStore((s) => s.armorDiagramMode);
-  const armorDiagramVariant = useAppSettingsStore((s) => s.armorDiagramVariant);
+  // Get app settings - use effective getters for draft preview support
+  const getEffectiveArmorDiagramMode = useAppSettingsStore((s) => s.getEffectiveArmorDiagramMode);
+  const getEffectiveArmorDiagramVariant = useAppSettingsStore((s) => s.getEffectiveArmorDiagramVariant);
+  const armorDiagramMode = getEffectiveArmorDiagramMode();
+  const armorDiagramVariant = getEffectiveArmorDiagramVariant();
 
   // Get unit state from context
   const tonnage = useUnitStore((s) => s.tonnage);
@@ -400,6 +403,15 @@ export function ArmorTab({
           )}
           {armorDiagramMode === 'silhouette' && armorDiagramVariant === 'premium-material' && (
             <PremiumMaterialDiagram
+              armorData={armorData}
+              selectedLocation={selectedLocation}
+              unallocatedPoints={pointsDelta}
+              onLocationClick={handleLocationClick}
+              onAutoAllocate={handleAutoAllocate}
+            />
+          )}
+          {armorDiagramMode === 'silhouette' && armorDiagramVariant === 'megamek' && (
+            <MegaMekDiagram
               armorData={armorData}
               selectedLocation={selectedLocation}
               unallocatedPoints={pointsDelta}

--- a/src/components/customizer/tabs/ArmorTab.tsx
+++ b/src/components/customizer/tabs/ArmorTab.tsx
@@ -17,6 +17,7 @@ import { ArmorTypeEnum, getArmorDefinition } from '@/types/construction/ArmorTyp
 import { MechLocation } from '@/types/construction/CriticalSlotAllocation';
 import { LocationArmorData } from '../armor/ArmorDiagram';
 import { LocationArmorEditor } from '../armor/LocationArmorEditor';
+import { SchematicDiagram } from '@/components/armor/schematic';
 import {
   CleanTechDiagram,
   NeonOperatorDiagram,
@@ -58,6 +59,7 @@ export function ArmorTab({
   className = '',
 }: ArmorTabProps): React.ReactElement {
   // Get app settings
+  const armorDiagramMode = useAppSettingsStore((s) => s.armorDiagramMode);
   const armorDiagramVariant = useAppSettingsStore((s) => s.armorDiagramVariant);
 
   // Get unit state from context
@@ -357,7 +359,19 @@ export function ArmorTab({
 
         {/* RIGHT: Armor Diagram */}
         <div className="space-y-4">
-          {armorDiagramVariant === 'clean-tech' && (
+          {/* Schematic Mode */}
+          {armorDiagramMode === 'schematic' && (
+            <SchematicDiagram
+              armorData={armorData}
+              selectedLocation={selectedLocation}
+              unallocatedPoints={pointsDelta}
+              onLocationClick={handleLocationClick}
+              onAutoAllocate={handleAutoAllocate}
+            />
+          )}
+
+          {/* Silhouette Mode - render based on variant */}
+          {armorDiagramMode === 'silhouette' && armorDiagramVariant === 'clean-tech' && (
             <CleanTechDiagram
               armorData={armorData}
               selectedLocation={selectedLocation}
@@ -366,7 +380,7 @@ export function ArmorTab({
               onAutoAllocate={handleAutoAllocate}
             />
           )}
-          {armorDiagramVariant === 'neon-operator' && (
+          {armorDiagramMode === 'silhouette' && armorDiagramVariant === 'neon-operator' && (
             <NeonOperatorDiagram
               armorData={armorData}
               selectedLocation={selectedLocation}
@@ -375,7 +389,7 @@ export function ArmorTab({
               onAutoAllocate={handleAutoAllocate}
             />
           )}
-          {armorDiagramVariant === 'tactical-hud' && (
+          {armorDiagramMode === 'silhouette' && armorDiagramVariant === 'tactical-hud' && (
             <TacticalHUDDiagram
               armorData={armorData}
               selectedLocation={selectedLocation}
@@ -384,7 +398,7 @@ export function ArmorTab({
               onAutoAllocate={handleAutoAllocate}
             />
           )}
-          {armorDiagramVariant === 'premium-material' && (
+          {armorDiagramMode === 'silhouette' && armorDiagramVariant === 'premium-material' && (
             <PremiumMaterialDiagram
               armorData={armorData}
               selectedLocation={selectedLocation}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -22,6 +22,7 @@ import {
   ACCENT_COLOR_CSS,
 } from '@/stores/useAppSettingsStore';
 import { ArmorDiagramGridPreview } from '@/components/customizer/armor/ArmorDiagramPreview';
+import { ArmorDiagramModeSwitch } from '@/components/armor/ArmorDiagramModeSwitch';
 
 /**
  * Settings section wrapper
@@ -420,16 +421,28 @@ export default function SettingsPage() {
             title="Customizer"
             description="Configure the mech customizer interface"
           >
+            {/* Armor Diagram Mode */}
             <div>
-              <div className="text-sm font-medium text-white mb-2">Armor Diagram Style</div>
-              <div className="text-xs text-slate-400 mb-4">
-                Choose the visual style for the armor allocation diagram. Changes apply immediately.
+              <div className="text-sm font-medium text-text-theme-primary mb-2">Armor Diagram Mode</div>
+              <div className="text-xs text-text-theme-secondary mb-3">
+                Choose between schematic grid or silhouette SVG display
               </div>
-              <ArmorDiagramGridPreview
-                selectedVariant={settings.armorDiagramVariant}
-                onSelectVariant={settings.setArmorDiagramVariant}
-              />
+              <ArmorDiagramModeSwitch />
             </div>
+
+            {/* Armor Diagram Variant (only visible for silhouette mode) */}
+            {settings.armorDiagramMode === 'silhouette' && (
+              <div>
+                <div className="text-sm font-medium text-text-theme-primary mb-2">Silhouette Style</div>
+                <div className="text-xs text-text-theme-secondary mb-4">
+                  Choose the visual style for the silhouette armor diagram
+                </div>
+                <ArmorDiagramGridPreview
+                  selectedVariant={settings.armorDiagramVariant}
+                  onSelectVariant={settings.setArmorDiagramVariant}
+                />
+              </div>
+            )}
 
             <Toggle
               label="Show Design Selector (UAT)"

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -21,8 +21,7 @@ import {
   UITheme,
   ACCENT_COLOR_CSS,
 } from '@/stores/useAppSettingsStore';
-import { ArmorDiagramGridPreview } from '@/components/customizer/armor/ArmorDiagramPreview';
-import { ArmorDiagramModeSwitch } from '@/components/armor/ArmorDiagramModeSwitch';
+import { ArmorDiagramGridPreview, ArmorDiagramModePreview } from '@/components/customizer/armor/ArmorDiagramPreview';
 
 /**
  * Settings section wrapper
@@ -427,7 +426,10 @@ export default function SettingsPage() {
               <div className="text-xs text-text-theme-secondary mb-3">
                 Choose between schematic grid or silhouette SVG display
               </div>
-              <ArmorDiagramModeSwitch />
+              <ArmorDiagramModePreview
+                selectedMode={settings.armorDiagramMode}
+                onSelectMode={settings.setArmorDiagramMode}
+              />
             </div>
 
             {/* Armor Diagram Variant (only visible for silhouette mode) */}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -435,9 +435,15 @@ export default function SettingsPage() {
             {/* Armor Diagram Variant (only visible for silhouette mode) */}
             {settings.armorDiagramMode === 'silhouette' && (
               <div>
-                <div className="text-sm font-medium text-text-theme-primary mb-2">Silhouette Style</div>
-                <div className="text-xs text-text-theme-secondary mb-4">
-                  Choose the visual style for the silhouette armor diagram
+                <div className="text-sm font-medium text-text-theme-primary mb-2">Silhouette Aesthetic</div>
+                <div className="text-xs text-text-theme-secondary mb-2">
+                  Visual effects and textures for the armor diagram only
+                </div>
+                <div className="text-xs text-amber-400/80 mb-4 flex items-center gap-1.5">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-4 h-4 flex-shrink-0">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
+                  </svg>
+                  <span>Independent of UI Theme - changes diagram artwork only</span>
                 </div>
                 <ArmorDiagramGridPreview
                   selectedVariant={settings.armorDiagramVariant}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -21,7 +21,8 @@ import {
   UITheme,
   ACCENT_COLOR_CSS,
 } from '@/stores/useAppSettingsStore';
-import { ArmorDiagramGridPreview, ArmorDiagramModePreview } from '@/components/customizer/armor/ArmorDiagramPreview';
+import { ArmorDiagramModePreview } from '@/components/customizer/armor/ArmorDiagramPreview';
+import { ArmorDiagramSettings } from '@/components/customizer/armor/ArmorDiagramSettings';
 
 /**
  * Settings section wrapper
@@ -301,18 +302,21 @@ export default function SettingsPage() {
     saveAppearance();
   }, [saveAppearance]);
 
+  const revertCustomizer = useAppSettingsStore((s) => s.revertCustomizer);
+
   // Revert on unmount if there are unsaved changes
   useEffect(() => {
     const handleRouteChange = () => {
       // Revert appearance changes when navigating away
       revertAppearance();
+      revertCustomizer();
     };
 
     router.events.on('routeChangeStart', handleRouteChange);
     return () => {
       router.events.off('routeChangeStart', handleRouteChange);
     };
-  }, [router.events, revertAppearance]);
+  }, [router.events, revertAppearance, revertCustomizer]);
 
   return (
     <>
@@ -436,19 +440,10 @@ export default function SettingsPage() {
             {settings.armorDiagramMode === 'silhouette' && (
               <div>
                 <div className="text-sm font-medium text-text-theme-primary mb-2">Silhouette Aesthetic</div>
-                <div className="text-xs text-text-theme-secondary mb-2">
-                  Visual effects and textures for the armor diagram only
+                <div className="text-xs text-text-theme-secondary mb-3">
+                  Visual style for the armor diagram
                 </div>
-                <div className="text-xs text-amber-400/80 mb-4 flex items-center gap-1.5">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-4 h-4 flex-shrink-0">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
-                  </svg>
-                  <span>Independent of UI Theme - changes diagram artwork only</span>
-                </div>
-                <ArmorDiagramGridPreview
-                  selectedVariant={settings.armorDiagramVariant}
-                  onSelectVariant={settings.setArmorDiagramVariant}
-                />
+                <ArmorDiagramSettings />
               </div>
             )}
 

--- a/src/stores/__tests__/useAppSettingsStore.armorMode.test.ts
+++ b/src/stores/__tests__/useAppSettingsStore.armorMode.test.ts
@@ -1,0 +1,33 @@
+// src/stores/__tests__/useAppSettingsStore.armorMode.test.ts
+import { renderHook, act } from '@testing-library/react';
+import { useAppSettingsStore } from '../useAppSettingsStore';
+
+describe('useAppSettingsStore - armorDiagramMode', () => {
+  beforeEach(() => {
+    act(() => {
+      useAppSettingsStore.getState().resetToDefaults();
+    });
+  });
+
+  it('should have silhouette as default armor diagram mode', () => {
+    const { result } = renderHook(() => useAppSettingsStore());
+    expect(result.current.armorDiagramMode).toBe('silhouette');
+  });
+
+  it('should update armor diagram mode', () => {
+    const { result } = renderHook(() => useAppSettingsStore());
+    act(() => {
+      result.current.setArmorDiagramMode('schematic');
+    });
+    expect(result.current.armorDiagramMode).toBe('schematic');
+  });
+
+  it('should persist armor diagram mode', () => {
+    const { result } = renderHook(() => useAppSettingsStore());
+    act(() => {
+      result.current.setArmorDiagramMode('schematic');
+    });
+    const state = useAppSettingsStore.getState();
+    expect(state.armorDiagramMode).toBe('schematic');
+  });
+});

--- a/src/stores/useAppSettingsStore.ts
+++ b/src/stores/useAppSettingsStore.ts
@@ -29,17 +29,6 @@ export type ArmorDiagramVariant =
 export type UITheme = 'default' | 'neon' | 'tactical' | 'minimal';
 
 /**
- * Mapping from UITheme to matching ArmorDiagramVariant
- * This enables automatic synchronization of design styles across the app
- */
-export const UI_THEME_TO_DIAGRAM_VARIANT: Record<UITheme, ArmorDiagramVariant> = {
-  'default': 'clean-tech',
-  'neon': 'neon-operator',
-  'tactical': 'tactical-hud',
-  'minimal': 'premium-material',
-};
-
-/**
  * Accent color options
  */
 export type AccentColor =

--- a/src/stores/useAppSettingsStore.ts
+++ b/src/stores/useAppSettingsStore.ts
@@ -9,6 +9,11 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 /**
+ * Armor diagram display mode
+ */
+export type ArmorDiagramMode = 'schematic' | 'silhouette';
+
+/**
  * Armor diagram design variants
  */
 export type ArmorDiagramVariant =
@@ -81,6 +86,7 @@ export interface AppSettingsState {
   hasUnsavedAppearance: boolean;
 
   // Customizer preferences
+  armorDiagramMode: ArmorDiagramMode;
   armorDiagramVariant: ArmorDiagramVariant;
   showArmorDiagramSelector: boolean; // UAT feature flag
 
@@ -116,6 +122,7 @@ export interface AppSettingsState {
   getEffectiveFontSize: () => FontSize;
 
   // Other actions
+  setArmorDiagramMode: (mode: ArmorDiagramMode) => void;
   setArmorDiagramVariant: (variant: ArmorDiagramVariant) => void;
   setShowArmorDiagramSelector: (show: boolean) => void;
   setSidebarDefaultCollapsed: (collapsed: boolean) => void;
@@ -132,7 +139,7 @@ type ActionKeys =
   | 'setDraftAccentColor' | 'setDraftFontSize' | 'setDraftAnimationLevel' | 'setDraftCompactMode' | 'setDraftUITheme'
   | 'saveAppearance' | 'revertAppearance' | 'initDraftAppearance'
   | 'getEffectiveAccentColor' | 'getEffectiveUITheme' | 'getEffectiveFontSize'
-  | 'setArmorDiagramVariant' | 'setShowArmorDiagramSelector' | 'setSidebarDefaultCollapsed'
+  | 'setArmorDiagramMode' | 'setArmorDiagramVariant' | 'setShowArmorDiagramSelector' | 'setSidebarDefaultCollapsed'
   | 'setConfirmOnClose' | 'setShowTooltips' | 'setHighContrast' | 'setReduceMotion' | 'resetToDefaults';
 
 const DEFAULT_SETTINGS: Omit<AppSettingsState, ActionKeys> = {
@@ -148,6 +155,7 @@ const DEFAULT_SETTINGS: Omit<AppSettingsState, ActionKeys> = {
   hasUnsavedAppearance: false,
 
   // Customizer preferences
+  armorDiagramMode: 'silhouette',
   armorDiagramVariant: 'clean-tech',
   showArmorDiagramSelector: true, // Enable UAT selector by default
 
@@ -305,6 +313,7 @@ export const useAppSettingsStore = create<AppSettingsState>()(
       },
 
       // Other settings (immediately persisted)
+      setArmorDiagramMode: (mode) => set({ armorDiagramMode: mode }),
       setArmorDiagramVariant: (variant) => set({ armorDiagramVariant: variant }),
       setShowArmorDiagramSelector: (show) => set({ showArmorDiagramSelector: show }),
       setSidebarDefaultCollapsed: (collapsed) => set({ sidebarDefaultCollapsed: collapsed }),
@@ -328,6 +337,7 @@ export const useAppSettingsStore = create<AppSettingsState>()(
         animationLevel: state.animationLevel,
         compactMode: state.compactMode,
         uiTheme: state.uiTheme,
+        armorDiagramMode: state.armorDiagramMode,
         armorDiagramVariant: state.armorDiagramVariant,
         showArmorDiagramSelector: state.showArmorDiagramSelector,
         sidebarDefaultCollapsed: state.sidebarDefaultCollapsed,


### PR DESCRIPTION
## Summary

- **Split-panel settings UI**: Replaced grid of diagram previews with list (left) + large preview (right)
- **Draft/save pattern**: Changes preview live but only persist on explicit Save, consistent with appearance settings
- **MegaMek classic variant**: New armor diagram style matching PDF record sheet proportions
- **Independent diagram aesthetics**: Armor diagram variant is now fully independent of UI theme

## Changes

### New Components
- `VariantThumbnail` - 40x60px mini SVG previews for each variant style
- `ArmorDiagramSettings` - Split-panel layout with draft/save support
- `MegaMekDiagram` - Classic record sheet style diagram variant

### Store Updates
- Added `CustomizerSettings` interface with draft state
- Added `initDraftCustomizer`, `saveCustomizer`, `revertCustomizer` actions
- Added `getEffectiveArmorDiagramMode/Variant` getters for live preview
- Removed unused `UI_THEME_TO_DIAGRAM_VARIANT` mapping

### UI Updates
- Settings page uses new split-panel component
- ArmorTab and QuickSettings use effective getters for live preview
- Route change reverts unsaved customizer changes

## Test plan

- [x] All 60 tests passing
- [x] Build succeeds
- [ ] Manual test: Open settings, change diagram variant, verify preview updates
- [ ] Manual test: Navigate away without saving, verify revert
- [ ] Manual test: Save changes, verify persistence across page reload
- [ ] Manual test: Test MegaMek variant in customizer armor tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)