### PR TITLE
feat: Add exotic mech configuration support (Quad, LAM, Tripod, QuadVee)

### DIFF
--- a/equipment-validation-report.json
+++ b/equipment-validation-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-01-11T22:11:44.946Z",
+  "generatedAt": "2026-01-12T05:18:49.152Z",
   "summary": {
     "unitsProcessed": 4217,
     "unitsWithIssues": 1914,

--- a/equipment-validation-report.json
+++ b/equipment-validation-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-01-12T05:18:49.152Z",
+  "generatedAt": "2026-01-12T21:06:22.686Z",
   "summary": {
     "unitsProcessed": 4217,
     "unitsWithIssues": 1914,

--- a/openspec/changes/add-exotic-mech-support/design.md
+++ b/openspec/changes/add-exotic-mech-support/design.md
@@ -1,0 +1,126 @@
+# Design: Exotic Mech Configuration Support
+
+## Context
+MekStation currently hardcodes biped mech assumptions throughout the codebase. The location system assumes 8 specific locations (Head, CT, LT, RT, LA, RA, LL, RL), actuator definitions assume arm/leg split, armor diagrams render only biped silhouettes, and MTF parsing expects biped location headers.
+
+BattleTech includes several exotic mech configurations:
+- **Quad**: 4-legged mechs with no arms (8 locations, all legs)
+- **Tripod**: 2 arms + 3 legs (9 locations)
+- **LAM**: Land-Air Mechs with 3 modes (Mech/AirMech/Fighter)
+- **QuadVee**: Quad mechs that transform to vehicles
+
+Reference data from MegaMekLab (mm-data repository) confirms the MTF format differences:
+- Quad uses: "Front Left Leg:", "Front Right Leg:", "Rear Left Leg:", "Rear Right Leg:"
+- Tripod uses: standard biped locations plus "Center Leg:"
+- LAM uses: biped locations plus "Landing Gear" and "Avionics" equipment
+- Armor labels differ: "FLL armor:", "CL armor:", etc.
+
+## Goals
+- Support full editing of Quad, LAM, Tripod, and QuadVee mechs
+- Maintain backward compatibility with existing biped units
+- Use data-driven configuration definitions (not hardcoded switch statements)
+- Enable future configuration additions without code changes
+
+## Non-Goals
+- Vehicle, Aerospace, Infantry, Battle Armor support (separate effort)
+- OmniMech variants of exotic configs (deferred)
+- Combat simulation rules (damage transfer, hit locations)
+
+## Decisions
+
+### Decision 1: Configuration Registry Pattern
+**What**: Create a centralized `ConfigurationRegistry` that holds `MechConfigurationDefinition` objects defining locations, actuators, rules, and diagram components per configuration.
+
+**Why**: Avoids scattered switch statements throughout codebase. Adding new configurations becomes a data definition task rather than code changes.
+
+**Alternatives considered**:
+- Inheritance/polymorphism (rejected: TypeScript data models don't benefit from OOP patterns for this)
+- Switch statements in each module (rejected: hard to maintain, easy to miss cases)
+
+### Decision 2: Expanded MechLocation Enum
+**What**: Expand `MechLocation` enum to include all possible locations across configurations:
+```typescript
+enum MechLocation {
+  // Universal
+  HEAD, CENTER_TORSO, LEFT_TORSO, RIGHT_TORSO,
+  // Biped/Tripod/LAM
+  LEFT_ARM, RIGHT_ARM, LEFT_LEG, RIGHT_LEG,
+  // Tripod
+  CENTER_LEG,
+  // Quad/QuadVee
+  FRONT_LEFT_LEG, FRONT_RIGHT_LEG, REAR_LEFT_LEG, REAR_RIGHT_LEG,
+  // LAM Fighter mode
+  NOSE, LEFT_WING, RIGHT_WING, AFT, FUSELAGE
+}
+```
+
+**Why**: Single type covers all configurations. Helper function `getLocationsForConfig(config)` returns relevant subset.
+
+**Migration**: Existing units use biped locations which remain unchanged.
+
+### Decision 3: Separate Armor Diagram Components
+**What**: Create distinct React components for each configuration's armor diagram:
+- `BipedArmorDiagram` (existing)
+- `QuadArmorDiagram` (new)
+- `TripodArmorDiagram` (new)
+- `LAMArmorDiagram` (new, with mode toggle)
+
+**Why**: Each configuration has significantly different visual representation. Separate components are cleaner than conditional rendering within one component.
+
+**Trade-off**: More files to maintain, but each is simpler and focused.
+
+### Decision 4: LAM Mode as View State
+**What**: LAM mode (Mech/AirMech/Fighter) is a display/view concern, not persisted unit data. The underlying unit data is the same; mode affects which stats and armor mapping are shown.
+
+**Why**: Simplifies data model. Unit doesn't change when switching modes in UI; only the view changes.
+
+**Exception**: Fighter mode armor uses different location mapping (Mech locations → Fighter locations).
+
+### Decision 5: Configuration-Aware MTF Parser
+**What**: MTF parser reads `Config:` line first, then selects appropriate location header mappings:
+```typescript
+const PARSER_CONFIGS = {
+  [MechConfiguration.QUAD]: {
+    locationHeaders: ['Front Left Leg:', 'Front Right Leg:', ...],
+    armorLabels: { 'FLL armor': MechLocation.FRONT_LEFT_LEG, ... }
+  },
+  // ... other configs
+};
+```
+
+**Why**: Clean separation of format knowledge from parsing logic.
+
+## Risks / Trade-offs
+
+### Risk: Enum Expansion Breaking Changes
+**Risk**: Expanding MechLocation enum could break existing serialized data.
+**Mitigation**: New values are additions, not changes. Existing biped locations (LEFT_ARM, etc.) remain unchanged. Serialization includes configuration type, so parser knows which locations to expect.
+
+### Risk: Armor Diagram SVG Complexity
+**Risk**: Creating quad/tripod silhouettes requires graphic design effort.
+**Mitigation**: Start with simplified/schematic diagrams; can enhance visuals later.
+
+### Risk: Validation Rule Explosion
+**Risk**: Each configuration adds many rules, making validation slow or complex.
+**Mitigation**: Rules are filtered by `appliesTo` before execution. Only relevant rules run for each config.
+
+## Migration Plan
+
+1. **Phase 1**: Add ConfigurationRegistry with biped + quad definitions
+2. **Phase 2**: Update MTF parser/exporter for quad
+3. **Phase 3**: Add QuadArmorDiagram
+4. **Phase 4**: Add quad validation rules
+5. **Phase 5**: Repeat for LAM, Tripod, QuadVee
+
+Rollback: Each phase is independently deployable. Revert to previous phase if issues.
+
+## Open Questions
+
+1. **Quad turret rules**: How detailed should turret weapon mounting validation be?
+   - Resolved: Full BattleTech rules per user request
+
+2. **LAM fighter armor mapping**: Should fighter mode show separate armor values or mapped values?
+   - Resolved: Hybrid diagram with mode toggle, showing mapped values
+
+3. **Tripod center leg position**: Where should center leg appear in diagram?
+   - Deferred: Design during implementation

--- a/openspec/changes/add-exotic-mech-support/proposal.md
+++ b/openspec/changes/add-exotic-mech-support/proposal.md
@@ -1,0 +1,50 @@
+# Change: Add Exotic Mech Configuration Support
+
+## Why
+The application currently only supports biped BattleMechs. Users need to import, view, and edit Quad mechs, LAMs, Tripods, and QuadVees with proper location layouts, actuator configurations, armor diagrams, and validation rules. These exotic configurations represent a significant portion of the BattleTech universe and are frequently used in MegaMekLab.
+
+## What Changes
+
+### New Capability: `mech-configuration-system`
+- Configuration registry with definitions for Biped, Quad, Tripod, LAM, QuadVee
+- Location definitions per configuration (different location sets)
+- Actuator definitions per configuration
+- Equipment mounting rules per configuration
+- LAM mode definitions (Mech/AirMech/Fighter)
+
+### Modified Capabilities
+
+**`critical-slot-allocation`**
+- Expand MechLocation enum with Quad locations (FLL, FRL, RLL, RRL), Tripod center leg (CL), and LAM fighter locations
+- Configuration-aware actuator placement
+- Quad: all 4 locations use leg actuators (Hip, Upper Leg, Lower Leg, Foot)
+- Tripod: add center leg with leg actuators
+- LAM: add Landing Gear and Avionics as fixed equipment
+
+**`armor-diagram`**
+- Add QuadArmorDiagram component (4-legged silhouette)
+- Add TripodArmorDiagram component (3-legged + arms)
+- Add LAMArmorDiagram component (hybrid with mode toggle)
+- Diagram selector based on unit configuration
+
+**`serialization-formats`**
+- MTF parser: configuration-aware location headers (Front Left Leg:, Center Leg:, etc.)
+- MTF parser: configuration-specific armor labels (FLL armor, CL armor)
+- MTF exporter: output correct location names per configuration
+
+**`validation-rules-master`**
+- Quad-specific: no hand actuators, no hand weapons, turret mounting rules
+- LAM-specific: required Landing Gear and Avionics placement
+- Tripod-specific: center leg validation
+- Configuration-scoped rule execution
+
+## Impact
+- Affected specs: mech-configuration-system (new), critical-slot-allocation, armor-diagram, serialization-formats, validation-rules-master
+- Affected code: src/types/construction/, src/components/customizer/ArmorTab/, src/services/conversion/, src/utils/validation/
+- **BREAKING**: MechLocation enum expansion requires migration of existing data
+
+## Implementation Priority
+1. Foundation + Quad support
+2. LAM support with mode switching
+3. Tripod support
+4. QuadVee support (builds on Quad)

--- a/openspec/changes/add-exotic-mech-support/specs/armor-diagram/spec.md
+++ b/openspec/changes/add-exotic-mech-support/specs/armor-diagram/spec.md
@@ -1,0 +1,141 @@
+## MODIFIED Requirements
+
+### Requirement: SVG-Based Mech Diagram
+The system SHALL display an SVG diagram showing all mech armor locations for the current configuration.
+
+#### Scenario: Biped diagram rendering
+- **WHEN** the armor diagram renders for BIPED configuration
+- **THEN** all 8 locations are displayed (HD, CT, LT, RT, LA, RA, LL, RL)
+- **AND** torso locations show both front and rear armor sections
+- **AND** diagram scales responsively within container
+
+#### Scenario: Quad diagram rendering
+- **WHEN** the armor diagram renders for QUAD configuration
+- **THEN** all 8 locations are displayed (HD, CT, LT, RT, FLL, FRL, RLL, RRL)
+- **AND** diagram shows 4-legged mech silhouette
+- **AND** front legs are positioned forward of torso
+- **AND** rear legs are positioned behind torso
+- **AND** torso locations show both front and rear armor sections
+
+#### Scenario: Tripod diagram rendering
+- **WHEN** the armor diagram renders for TRIPOD configuration
+- **THEN** all 9 locations are displayed (HD, CT, LT, RT, LA, RA, LL, RL, CL)
+- **AND** diagram shows humanoid silhouette with center leg
+- **AND** center leg is positioned centrally below torso
+- **AND** torso locations show both front and rear armor sections
+
+#### Scenario: LAM diagram rendering
+- **WHEN** the armor diagram renders for LAM configuration
+- **THEN** diagram shows biped silhouette by default (Mech mode)
+- **AND** mode toggle control is displayed
+- **AND** switching to Fighter mode shows aerospace armor mapping overlay
+
+### Requirement: Location Click Interaction
+The system SHALL support clicking locations to select them for editing based on configuration.
+
+#### Scenario: Location selection
+- **WHEN** user clicks a location
+- **THEN** the location is visually highlighted (blue)
+- **AND** the side panel editor shows that location's controls
+- **AND** previous selection is cleared
+
+#### Scenario: Configuration-appropriate click targets
+- **WHEN** user clicks on a diagram region
+- **THEN** click target SHALL correspond to valid locations for current configuration
+- **AND** clicking quad front leg SHALL select FRONT_LEFT_LEG or FRONT_RIGHT_LEG
+- **AND** clicking tripod center leg SHALL select CENTER_LEG
+
+## ADDED Requirements
+
+### Requirement: Configuration-Specific Diagram Components
+The system SHALL render different diagram components based on mech configuration.
+
+#### Scenario: Diagram component selection
+- **WHEN** armor diagram is rendered
+- **THEN** system SHALL select diagram component based on unit configuration
+- **AND** BIPED SHALL use BipedArmorDiagram
+- **AND** QUAD SHALL use QuadArmorDiagram
+- **AND** TRIPOD SHALL use TripodArmorDiagram
+- **AND** LAM SHALL use LAMArmorDiagram
+- **AND** QUADVEE SHALL use QuadVeeArmorDiagram
+
+#### Scenario: Dynamic diagram switching
+- **GIVEN** user is editing a unit in customizer
+- **WHEN** configuration is changed (e.g., BIPED to QUAD)
+- **THEN** armor diagram SHALL switch to the appropriate component
+- **AND** location selections SHALL be cleared
+- **AND** armor values SHALL be preserved where locations map
+
+### Requirement: Quad Armor Diagram
+The system SHALL display a quad mech-specific armor diagram.
+
+#### Scenario: Quad silhouette
+- **WHEN** QuadArmorDiagram renders
+- **THEN** diagram SHALL show 4-legged mech body
+- **AND** head SHALL be positioned forward on torso
+- **AND** no arm silhouettes SHALL be shown
+
+#### Scenario: Quad location regions
+- **WHEN** QuadArmorDiagram renders
+- **THEN** clickable regions SHALL exist for HEAD, CT, LT, RT, FLL, FRL, RLL, RRL
+- **AND** each region SHALL display current armor value
+- **AND** torso regions SHALL show front and rear values
+
+#### Scenario: Quad armor pip layout
+- **WHEN** armor pips are displayed on quad diagram
+- **THEN** pip positions SHALL match quad location geometry
+- **AND** leg locations SHALL accommodate higher armor values (12 slots vs 6)
+
+### Requirement: Tripod Armor Diagram
+The system SHALL display a tripod mech-specific armor diagram.
+
+#### Scenario: Tripod silhouette
+- **WHEN** TripodArmorDiagram renders
+- **THEN** diagram SHALL show humanoid mech with 3 legs
+- **AND** center leg SHALL be positioned centrally
+- **AND** arms SHALL be displayed normally
+
+#### Scenario: Tripod location regions
+- **WHEN** TripodArmorDiagram renders
+- **THEN** clickable regions SHALL exist for all 9 locations
+- **AND** CENTER_LEG region SHALL be clearly distinguishable
+
+### Requirement: LAM Armor Diagram
+The system SHALL display a LAM-specific armor diagram with mode toggle.
+
+#### Scenario: LAM mode toggle
+- **WHEN** LAMArmorDiagram renders
+- **THEN** mode toggle control SHALL be visible
+- **AND** control SHALL allow switching between MECH, AIRMECH, FIGHTER modes
+- **AND** current mode SHALL be clearly indicated
+
+#### Scenario: LAM Mech mode view
+- **WHEN** LAM is in MECH mode
+- **THEN** diagram SHALL display standard biped silhouette
+- **AND** all 8 mech locations SHALL be shown
+
+#### Scenario: LAM Fighter mode view
+- **WHEN** LAM is in FIGHTER mode
+- **THEN** diagram SHALL show fighter armor mapping
+- **AND** armor values SHALL be mapped from mech locations to fighter locations
+- **AND** NOSE SHALL show combined HEAD + CT armor
+- **AND** LEFT_WING and RIGHT_WING SHALL show LT and RT armor
+- **AND** AFT SHALL show rear torso armor
+
+#### Scenario: LAM AirMech mode view
+- **WHEN** LAM is in AIRMECH mode
+- **THEN** diagram SHALL display biped silhouette with VTOL indicators
+- **AND** movement stats SHALL reflect VTOL capabilities
+
+### Requirement: QuadVee Armor Diagram
+The system SHALL display a QuadVee-specific armor diagram with mode toggle.
+
+#### Scenario: QuadVee Mech mode
+- **WHEN** QuadVee is in MECH mode
+- **THEN** diagram SHALL display quad mech silhouette
+- **AND** all quad locations SHALL be shown
+
+#### Scenario: QuadVee Vehicle mode
+- **WHEN** QuadVee is in VEHICLE mode
+- **THEN** diagram SHALL display vehicle representation
+- **AND** armor SHALL be shown for Front, Left, Right, Rear, Turret

--- a/openspec/changes/add-exotic-mech-support/specs/critical-slot-allocation/spec.md
+++ b/openspec/changes/add-exotic-mech-support/specs/critical-slot-allocation/spec.md
@@ -1,0 +1,134 @@
+## MODIFIED Requirements
+
+### Requirement: Location Slot Counts
+Each location SHALL have a fixed number of critical slots based on mech configuration.
+
+#### Scenario: Biped slot definitions
+- **WHEN** defining location capacity for BIPED configuration
+- **THEN** Head = 6 slots
+- **AND** Center Torso = 12 slots
+- **AND** Side Torsos = 12 slots each
+- **AND** Arms = 12 slots each
+- **AND** Legs = 6 slots each
+- **AND** Total = 78 slots
+
+#### Scenario: Quad slot definitions
+- **WHEN** defining location capacity for QUAD configuration
+- **THEN** Head = 6 slots
+- **AND** Center Torso = 12 slots
+- **AND** Side Torsos = 12 slots each
+- **AND** Front Legs = 12 slots each
+- **AND** Rear Legs = 12 slots each
+- **AND** Total = 78 slots
+
+#### Scenario: Tripod slot definitions
+- **WHEN** defining location capacity for TRIPOD configuration
+- **THEN** Head = 6 slots
+- **AND** Center Torso = 12 slots
+- **AND** Side Torsos = 12 slots each
+- **AND** Arms = 12 slots each
+- **AND** Legs = 6 slots each (Left, Right, Center)
+- **AND** Total = 84 slots
+
+#### Scenario: LAM slot definitions
+- **WHEN** defining location capacity for LAM configuration
+- **THEN** slot counts SHALL match BIPED configuration
+- **AND** Landing Gear SHALL occupy 1 slot in CT, LT, RT
+- **AND** Avionics SHALL occupy 1 slot in Head, LT, RT
+
+### Requirement: Actuator Requirements
+Limbs SHALL have required actuator slots based on mech configuration.
+
+#### Scenario: Biped arm actuators
+- **WHEN** arm has full actuators in BIPED configuration
+- **THEN** shoulder = 1 slot (required)
+- **AND** upper arm = 1 slot (required)
+- **AND** lower arm = 1 slot (optional, removable)
+- **AND** hand = 1 slot (optional, removable)
+
+#### Scenario: Biped leg actuators
+- **WHEN** leg is defined in BIPED configuration
+- **THEN** hip = 1 slot (required)
+- **AND** upper leg = 1 slot (required)
+- **AND** lower leg = 1 slot (required)
+- **AND** foot = 1 slot (required)
+
+#### Scenario: Quad leg actuators
+- **WHEN** any leg is defined in QUAD configuration
+- **THEN** all four legs SHALL use leg actuators (hip, upper leg, lower leg, foot)
+- **AND** no arm actuators SHALL be present
+- **AND** all actuators SHALL be required (not removable)
+
+#### Scenario: Tripod leg actuators
+- **WHEN** legs are defined in TRIPOD configuration
+- **THEN** Left Leg, Right Leg, and Center Leg SHALL all use leg actuators
+- **AND** arms SHALL use standard arm actuators
+
+### Requirement: Fixed Slot Protection
+System component slots SHALL NOT be assignable based on configuration.
+
+#### Scenario: Head fixed slots
+- **GIVEN** user attempts to assign equipment to Head
+- **WHEN** targeting slots 0, 1, 2, 4, or 5
+- **THEN** assignment SHALL be rejected
+- **AND** only slot 3 SHALL be assignable
+
+#### Scenario: Arm fixed slots (biped/tripod/LAM)
+- **GIVEN** user attempts to assign equipment to Left Arm or Right Arm
+- **WHEN** configuration is BIPED, TRIPOD, or LAM
+- **AND** targeting slots 0-3 (actuators)
+- **THEN** assignment SHALL be rejected
+- **AND** only slots 4-11 SHALL be assignable
+
+#### Scenario: Quad leg fixed slots
+- **GIVEN** user attempts to assign equipment to any leg in QUAD configuration
+- **WHEN** targeting slots 0-3 (leg actuators)
+- **THEN** assignment SHALL be rejected
+- **AND** only slots 4-11 SHALL be assignable
+
+#### Scenario: Biped/Tripod leg fixed slots
+- **GIVEN** user attempts to assign equipment to Left Leg, Right Leg, or Center Leg
+- **WHEN** configuration is BIPED or TRIPOD
+- **AND** targeting slots 0-3 (actuators)
+- **THEN** assignment SHALL be rejected
+- **AND** only slots 4-5 SHALL be assignable
+
+#### Scenario: LAM fixed equipment slots
+- **GIVEN** user attempts to assign equipment in LAM configuration
+- **WHEN** targeting slots occupied by Landing Gear or Avionics
+- **THEN** assignment SHALL be rejected
+- **AND** Landing Gear and Avionics SHALL be fixed and not removable
+
+## ADDED Requirements
+
+### Requirement: Configuration-Aware Slot Validation
+Slot assignment SHALL validate against configuration-specific rules.
+
+#### Scenario: Validate location for configuration
+- **GIVEN** user attempts to assign equipment to a location
+- **WHEN** location is not valid for current configuration
+- **THEN** assignment SHALL be rejected with configuration mismatch error
+
+#### Scenario: Cross-configuration location rejection
+- **GIVEN** unit is QUAD configuration
+- **WHEN** attempting to assign to LEFT_ARM or RIGHT_ARM
+- **THEN** assignment SHALL be rejected
+- **AND** error message SHALL indicate location not valid for quad mechs
+
+### Requirement: MechLocation Enum Expansion
+The MechLocation enumeration SHALL include all locations for all configurations.
+
+#### Scenario: Quad-specific locations
+- **WHEN** accessing MechLocation enum
+- **THEN** FRONT_LEFT_LEG SHALL be available
+- **AND** FRONT_RIGHT_LEG SHALL be available
+- **AND** REAR_LEFT_LEG SHALL be available
+- **AND** REAR_RIGHT_LEG SHALL be available
+
+#### Scenario: Tripod-specific locations
+- **WHEN** accessing MechLocation enum
+- **THEN** CENTER_LEG SHALL be available
+
+#### Scenario: LAM fighter-mode locations
+- **WHEN** accessing MechLocation enum
+- **THEN** NOSE, LEFT_WING, RIGHT_WING, AFT, FUSELAGE SHALL be available for fighter mode armor mapping

--- a/openspec/changes/add-exotic-mech-support/specs/mech-configuration-system/spec.md
+++ b/openspec/changes/add-exotic-mech-support/specs/mech-configuration-system/spec.md
@@ -1,0 +1,156 @@
+# mech-configuration-system Specification
+
+## Purpose
+Provides a data-driven configuration registry that defines location layouts, actuator requirements, equipment rules, and visual components for each mech configuration type (Biped, Quad, Tripod, LAM, QuadVee).
+
+## ADDED Requirements
+
+### Requirement: Configuration Registry
+The system SHALL provide a centralized registry of mech configuration definitions.
+
+#### Scenario: Registry initialization
+- **WHEN** the application starts
+- **THEN** ConfigurationRegistry SHALL be initialized with all supported configurations
+- **AND** each configuration SHALL have a complete MechConfigurationDefinition
+
+#### Scenario: Configuration lookup
+- **WHEN** requesting a configuration definition
+- **THEN** registry SHALL return the definition for the specified MechConfiguration
+- **AND** SHALL return undefined for unknown configurations
+
+### Requirement: Mech Configuration Definition
+Each mech configuration SHALL have a complete definition specifying its characteristics.
+
+#### Scenario: Definition structure
+- **WHEN** defining a mech configuration
+- **THEN** definition SHALL include id (MechConfiguration enum value)
+- **AND** definition SHALL include displayName
+- **AND** definition SHALL include locations array
+- **AND** definition SHALL include actuators array
+- **AND** definition SHALL include mountingRules array
+- **AND** definition SHALL include prohibitedEquipment array
+- **AND** definition SHALL include diagramComponent reference
+
+#### Scenario: Biped configuration
+- **WHEN** accessing BIPED configuration
+- **THEN** locations SHALL include HEAD, CENTER_TORSO, LEFT_TORSO, RIGHT_TORSO, LEFT_ARM, RIGHT_ARM, LEFT_LEG, RIGHT_LEG
+- **AND** arms SHALL have Shoulder, Upper Arm, Lower Arm (optional), Hand (optional) actuators
+- **AND** legs SHALL have Hip, Upper Leg, Lower Leg, Foot actuators
+
+#### Scenario: Quad configuration
+- **WHEN** accessing QUAD configuration
+- **THEN** locations SHALL include HEAD, CENTER_TORSO, LEFT_TORSO, RIGHT_TORSO, FRONT_LEFT_LEG, FRONT_RIGHT_LEG, REAR_LEFT_LEG, REAR_RIGHT_LEG
+- **AND** all four leg locations SHALL have Hip, Upper Leg, Lower Leg, Foot actuators
+- **AND** no hand or lower arm actuators SHALL be present
+- **AND** prohibitedEquipment SHALL include hand weapons (hatchet, sword, claw)
+
+#### Scenario: Tripod configuration
+- **WHEN** accessing TRIPOD configuration
+- **THEN** locations SHALL include all biped locations plus CENTER_LEG
+- **AND** CENTER_LEG SHALL have Hip, Upper Leg, Lower Leg, Foot actuators
+- **AND** arms SHALL have standard arm actuators
+
+#### Scenario: LAM configuration
+- **WHEN** accessing LAM configuration
+- **THEN** locations SHALL include all biped locations
+- **AND** configuration SHALL include LAM mode definitions
+- **AND** Landing Gear SHALL be required in LEFT_TORSO, RIGHT_TORSO, CENTER_TORSO
+- **AND** Avionics SHALL be required in LEFT_TORSO, RIGHT_TORSO, HEAD
+
+### Requirement: Location Definition
+Each location within a configuration SHALL have a complete definition.
+
+#### Scenario: Location properties
+- **WHEN** defining a location
+- **THEN** definition SHALL include id (MechLocation enum value)
+- **AND** definition SHALL include displayName
+- **AND** definition SHALL include criticalSlots count
+- **AND** definition SHALL include hasRearArmor flag
+- **AND** definition SHALL include maxArmor calculation function
+- **AND** definition SHALL include transfersTo location (for damage transfer)
+
+#### Scenario: Head location
+- **WHEN** accessing HEAD location definition
+- **THEN** criticalSlots SHALL be 6
+- **AND** hasRearArmor SHALL be false
+- **AND** maxArmor SHALL always be 9
+
+#### Scenario: Torso locations
+- **WHEN** accessing CENTER_TORSO, LEFT_TORSO, or RIGHT_TORSO location definition
+- **THEN** criticalSlots SHALL be 12
+- **AND** hasRearArmor SHALL be true
+
+#### Scenario: Limb locations
+- **WHEN** accessing arm or leg location definitions
+- **THEN** arms SHALL have 12 criticalSlots
+- **AND** legs SHALL have 6 criticalSlots for biped/tripod
+- **AND** legs SHALL have 12 criticalSlots for quad
+- **AND** hasRearArmor SHALL be false
+
+### Requirement: Actuator Definition
+Each location SHALL define required and optional actuators.
+
+#### Scenario: Actuator properties
+- **WHEN** defining actuators for a location
+- **THEN** each actuator SHALL have name, slotIndex, required flag, removable flag
+
+#### Scenario: Arm actuators (biped/tripod/LAM)
+- **WHEN** accessing arm actuator definitions
+- **THEN** Shoulder SHALL be at slotIndex 0, required, not removable
+- **AND** Upper Arm Actuator SHALL be at slotIndex 1, required, not removable
+- **AND** Lower Arm Actuator SHALL be at slotIndex 2, not required, removable
+- **AND** Hand Actuator SHALL be at slotIndex 3, not required, removable
+
+#### Scenario: Leg actuators
+- **WHEN** accessing leg actuator definitions
+- **THEN** Hip SHALL be at slotIndex 0, required, not removable
+- **AND** Upper Leg Actuator SHALL be at slotIndex 1, required, not removable
+- **AND** Lower Leg Actuator SHALL be at slotIndex 2, required, not removable
+- **AND** Foot Actuator SHALL be at slotIndex 3, required, not removable
+
+### Requirement: LAM Mode Definitions
+LAM configurations SHALL define behavior for each operating mode.
+
+#### Scenario: LAM mode properties
+- **WHEN** defining a LAM mode
+- **THEN** definition SHALL include mode id (MECH, AIRMECH, FIGHTER)
+- **AND** definition SHALL include movementType (ground, vtol, aerospace)
+- **AND** definition SHALL include weaponRestrictions array
+- **AND** definition SHALL include armorMapping for fighter mode
+
+#### Scenario: Mech mode
+- **WHEN** LAM is in MECH mode
+- **THEN** movementType SHALL be ground
+- **AND** all weapons SHALL be available
+- **AND** standard mech armor locations SHALL be used
+
+#### Scenario: AirMech mode
+- **WHEN** LAM is in AIRMECH mode
+- **THEN** movementType SHALL be vtol
+- **AND** melee weapons SHALL be restricted
+
+#### Scenario: Fighter mode
+- **WHEN** LAM is in FIGHTER mode
+- **THEN** movementType SHALL be aerospace
+- **AND** armorMapping SHALL map mech locations to fighter locations (NOSE, LEFT_WING, RIGHT_WING, AFT, FUSELAGE)
+- **AND** leg-mounted weapons SHALL be restricted
+
+### Requirement: Configuration Helper Functions
+The system SHALL provide helper functions for configuration-aware operations.
+
+#### Scenario: Get locations for configuration
+- **WHEN** calling getLocationsForConfig(config)
+- **THEN** SHALL return array of MechLocation values valid for that configuration
+- **AND** SHALL return 8 locations for BIPED and QUAD
+- **AND** SHALL return 9 locations for TRIPOD
+
+#### Scenario: Get location display name
+- **WHEN** calling getLocationDisplayName(location, config)
+- **THEN** SHALL return configuration-appropriate display name
+- **AND** FRONT_LEFT_LEG in QUAD SHALL return "Front Left Leg"
+- **AND** LEFT_ARM in BIPED SHALL return "Left Arm"
+
+#### Scenario: Check location validity
+- **WHEN** calling isValidLocationForConfig(location, config)
+- **THEN** SHALL return true if location is part of configuration
+- **AND** SHALL return false for invalid combinations (e.g., CENTER_LEG for BIPED)

--- a/openspec/changes/add-exotic-mech-support/specs/serialization-formats/spec.md
+++ b/openspec/changes/add-exotic-mech-support/specs/serialization-formats/spec.md
@@ -1,0 +1,145 @@
+## MODIFIED Requirements
+
+### Requirement: MTF Location Headers
+The system SHALL parse and export configuration-specific location headers in MTF format.
+
+#### Scenario: Biped location parsing
+- **WHEN** parsing MTF with Config:Biped or no Config line
+- **THEN** parser SHALL recognize "Left Arm:", "Right Arm:", "Left Leg:", "Right Leg:" headers
+- **AND** parser SHALL map to LEFT_ARM, RIGHT_ARM, LEFT_LEG, RIGHT_LEG locations
+
+#### Scenario: Quad location parsing
+- **WHEN** parsing MTF with Config:Quad
+- **THEN** parser SHALL recognize "Front Left Leg:", "Front Right Leg:", "Rear Left Leg:", "Rear Right Leg:" headers
+- **AND** parser SHALL map to FRONT_LEFT_LEG, FRONT_RIGHT_LEG, REAR_LEFT_LEG, REAR_RIGHT_LEG locations
+
+#### Scenario: Tripod location parsing
+- **WHEN** parsing MTF with Config:Tripod
+- **THEN** parser SHALL recognize all biped location headers plus "Center Leg:"
+- **AND** parser SHALL map "Center Leg:" to CENTER_LEG location
+
+#### Scenario: LAM location parsing
+- **WHEN** parsing MTF with Config:LAM
+- **THEN** parser SHALL recognize biped location headers
+- **AND** parser SHALL recognize "Landing Gear" equipment in CT, LT, RT
+- **AND** parser SHALL recognize "Avionics" equipment in Head, LT, RT
+
+#### Scenario: Biped MTF export
+- **WHEN** exporting BIPED mech to MTF
+- **THEN** location headers SHALL be "Left Arm:", "Right Arm:", "Left Leg:", "Right Leg:"
+
+#### Scenario: Quad MTF export
+- **WHEN** exporting QUAD mech to MTF
+- **THEN** location headers SHALL be "Front Left Leg:", "Front Right Leg:", "Rear Left Leg:", "Rear Right Leg:"
+
+#### Scenario: Tripod MTF export
+- **WHEN** exporting TRIPOD mech to MTF
+- **THEN** location headers SHALL include "Center Leg:" in addition to biped headers
+
+### Requirement: MTF Armor Labels
+The system SHALL parse and export configuration-specific armor labels in MTF format.
+
+#### Scenario: Biped armor parsing
+- **WHEN** parsing armor section for BIPED
+- **THEN** parser SHALL recognize "LA armor:", "RA armor:", "LL armor:", "RL armor:"
+- **AND** parser SHALL map to respective MechLocation values
+
+#### Scenario: Quad armor parsing
+- **WHEN** parsing armor section for QUAD
+- **THEN** parser SHALL recognize "FLL armor:", "FRL armor:", "RLL armor:", "RRL armor:"
+- **AND** parser SHALL map to FRONT_LEFT_LEG, FRONT_RIGHT_LEG, REAR_LEFT_LEG, REAR_RIGHT_LEG
+
+#### Scenario: Tripod armor parsing
+- **WHEN** parsing armor section for TRIPOD
+- **THEN** parser SHALL recognize biped armor labels plus "CL armor:"
+- **AND** parser SHALL map "CL armor:" to CENTER_LEG
+
+#### Scenario: Quad armor export
+- **WHEN** exporting QUAD mech armor to MTF
+- **THEN** armor labels SHALL be "FLL armor:", "FRL armor:", "RLL armor:", "RRL armor:"
+
+#### Scenario: Tripod armor export
+- **WHEN** exporting TRIPOD mech armor to MTF
+- **THEN** armor labels SHALL include "CL armor:" for CENTER_LEG
+
+## ADDED Requirements
+
+### Requirement: Configuration Detection
+The system SHALL detect mech configuration from MTF content before parsing locations.
+
+#### Scenario: Config line detection
+- **WHEN** parsing MTF file
+- **THEN** parser SHALL read "Config:" line first
+- **AND** parser SHALL select appropriate location mappings based on config value
+
+#### Scenario: Config values
+- **WHEN** detecting configuration
+- **THEN** "Config:Biped" SHALL map to BIPED configuration
+- **AND** "Config:Quad" SHALL map to QUAD configuration
+- **AND** "Config:Tripod" SHALL map to TRIPOD configuration
+- **AND** "Config:LAM" SHALL map to LAM configuration
+- **AND** "Config:QuadVee" SHALL map to QUADVEE configuration
+
+#### Scenario: Default configuration
+- **WHEN** MTF has no Config line
+- **THEN** parser SHALL default to BIPED configuration
+
+#### Scenario: OmniMech config variants
+- **WHEN** Config line includes "Omnimech" (e.g., "Config:Tripod Omnimech")
+- **THEN** parser SHALL extract base configuration (TRIPOD)
+- **AND** parser SHALL set omnimech flag
+
+### Requirement: LAM Special Equipment Serialization
+The system SHALL correctly serialize and deserialize LAM-specific fixed equipment.
+
+#### Scenario: Landing Gear serialization
+- **WHEN** exporting LAM to MTF
+- **THEN** "Landing Gear" SHALL appear in CT, LT, RT critical slot sections
+- **AND** equipment SHALL be in fixed positions
+
+#### Scenario: Avionics serialization
+- **WHEN** exporting LAM to MTF
+- **THEN** "Avionics" SHALL appear in Head, LT, RT critical slot sections
+- **AND** equipment SHALL be in fixed positions
+
+#### Scenario: Landing Gear parsing
+- **WHEN** parsing LAM MTF
+- **THEN** "Landing Gear" in critical slots SHALL be recognized as fixed LAM equipment
+- **AND** equipment SHALL not be movable or removable
+
+#### Scenario: Avionics parsing
+- **WHEN** parsing LAM MTF
+- **THEN** "Avionics" in critical slots SHALL be recognized as fixed LAM equipment
+- **AND** equipment SHALL not be movable or removable
+
+### Requirement: Configuration-Aware Actuator Serialization
+The system SHALL serialize actuators based on configuration.
+
+#### Scenario: Quad actuator serialization
+- **WHEN** exporting QUAD mech to MTF
+- **THEN** all leg locations SHALL include Hip, Upper Leg Actuator, Lower Leg Actuator, Foot Actuator
+- **AND** no arm actuators SHALL be present
+
+#### Scenario: Tripod actuator serialization
+- **WHEN** exporting TRIPOD mech to MTF
+- **THEN** CENTER_LEG SHALL include Hip, Upper Leg Actuator, Lower Leg Actuator, Foot Actuator
+- **AND** arms SHALL include standard arm actuators
+
+#### Scenario: Quad actuator parsing
+- **WHEN** parsing QUAD MTF
+- **THEN** parser SHALL expect leg actuators in all 4 leg locations
+- **AND** parser SHALL NOT expect arm actuators
+
+### Requirement: Backward Compatibility
+The system SHALL maintain compatibility with existing serialized data.
+
+#### Scenario: Legacy biped import
+- **WHEN** importing MTF without Config line
+- **THEN** parser SHALL treat as BIPED configuration
+- **AND** all biped locations SHALL be correctly mapped
+
+#### Scenario: Unknown configuration handling
+- **WHEN** parsing MTF with unrecognized Config value
+- **THEN** parser SHALL log warning
+- **AND** parser SHALL attempt BIPED fallback parsing
+- **AND** parsing SHALL NOT fail completely

--- a/openspec/changes/add-exotic-mech-support/specs/validation-rules-master/spec.md
+++ b/openspec/changes/add-exotic-mech-support/specs/validation-rules-master/spec.md
@@ -1,0 +1,124 @@
+## MODIFIED Requirements
+
+### Requirement: Validation Rule Registration
+The system SHALL register all validation rules with configuration applicability.
+
+#### Scenario: Rule registration with configuration filter
+- **WHEN** registering a validation rule
+- **THEN** rule SHALL include appliesTo array of MechConfiguration values
+- **AND** empty appliesTo SHALL mean rule applies to all configurations
+
+#### Scenario: Rule execution filtering
+- **WHEN** executing validation for a unit
+- **THEN** validator SHALL filter rules by unit's configuration
+- **AND** only rules where appliesTo includes unit configuration SHALL execute
+- **AND** rules with empty appliesTo SHALL always execute
+
+## ADDED Requirements
+
+### Requirement: Quad-Specific Validation Rules
+The system SHALL validate quad mech construction rules.
+
+#### Scenario: Quad no hand actuators
+- **GIVEN** unit is QUAD configuration
+- **WHEN** validation runs
+- **THEN** validator SHALL verify no hand actuators are present
+- **AND** validator SHALL verify no lower arm actuators are present
+- **AND** violation SHALL generate ERROR severity
+
+#### Scenario: Quad no hand weapons
+- **GIVEN** unit is QUAD configuration
+- **WHEN** equipment includes hand weapons (hatchet, sword, claw, mace)
+- **THEN** validator SHALL reject equipment
+- **AND** error message SHALL indicate "Hand weapons cannot be mounted on quad mechs"
+
+#### Scenario: Quad turret mounting
+- **GIVEN** unit is QUAD configuration
+- **WHEN** weapons are mounted facing rear arc
+- **THEN** validator SHALL check turret mounting rules
+- **AND** rear-facing weapons without turret SHALL generate WARNING
+
+#### Scenario: Quad leg equipment distribution
+- **GIVEN** unit is QUAD configuration
+- **WHEN** equipment requires leg mounting (tracks, talons, jump boosters)
+- **THEN** validator SHALL verify equipment is distributed across all 4 legs
+- **AND** uneven distribution SHALL generate ERROR
+
+### Requirement: LAM-Specific Validation Rules
+The system SHALL validate LAM construction rules.
+
+#### Scenario: LAM Landing Gear required
+- **GIVEN** unit is LAM configuration
+- **WHEN** validation runs
+- **THEN** validator SHALL verify Landing Gear is present in CT, LT, RT
+- **AND** missing Landing Gear SHALL generate ERROR
+- **AND** error message SHALL indicate required locations
+
+#### Scenario: LAM Avionics required
+- **GIVEN** unit is LAM configuration
+- **WHEN** validation runs
+- **THEN** validator SHALL verify Avionics is present in Head, LT, RT
+- **AND** missing Avionics SHALL generate ERROR
+
+#### Scenario: LAM prohibited equipment
+- **GIVEN** unit is LAM configuration
+- **WHEN** equipment includes LAM-prohibited items
+- **THEN** validator SHALL reject equipment
+- **AND** prohibited items include: heavy gauss rifle, supercharger, modular armor, jump boosters
+
+#### Scenario: LAM mode weapon restrictions
+- **GIVEN** LAM unit has weapons mounted
+- **WHEN** displaying mode-specific validation
+- **THEN** Fighter mode SHALL show warnings for leg-mounted weapons
+- **AND** AirMech mode SHALL show warnings for melee weapons
+
+### Requirement: Tripod-Specific Validation Rules
+The system SHALL validate tripod mech construction rules.
+
+#### Scenario: Tripod center leg equipment
+- **GIVEN** unit is TRIPOD configuration
+- **WHEN** equipment requires leg mounting (tracks, talons, jump boosters)
+- **THEN** validator SHALL verify equipment is distributed across all 3 legs
+- **AND** center leg SHALL be included in distribution
+
+#### Scenario: Tripod environmental sealing
+- **GIVEN** unit is TRIPOD configuration
+- **WHEN** Environmental Sealing is equipped
+- **THEN** validator SHALL verify 1 slot in each location including CENTER_LEG
+- **AND** total slots SHALL be 8 (one more than biped)
+
+#### Scenario: Tripod stealth armor
+- **GIVEN** unit is TRIPOD configuration
+- **WHEN** Stealth Armor is equipped
+- **THEN** validator SHALL verify slots in all limb locations including CENTER_LEG
+
+### Requirement: QuadVee-Specific Validation Rules
+The system SHALL validate QuadVee construction rules.
+
+#### Scenario: QuadVee inherits quad rules
+- **GIVEN** unit is QUADVEE configuration
+- **WHEN** validation runs
+- **THEN** all QUAD validation rules SHALL apply
+- **AND** additional QuadVee-specific rules SHALL also apply
+
+#### Scenario: QuadVee conversion equipment
+- **GIVEN** unit is QUADVEE configuration
+- **WHEN** validation runs
+- **THEN** validator SHALL verify conversion equipment is present
+- **AND** missing conversion equipment SHALL generate ERROR
+
+### Requirement: Configuration Change Validation
+The system SHALL validate configuration changes.
+
+#### Scenario: Configuration change equipment check
+- **GIVEN** user changes unit configuration
+- **WHEN** new configuration has different equipment restrictions
+- **THEN** validator SHALL check existing equipment against new rules
+- **AND** incompatible equipment SHALL generate WARNING
+- **AND** user SHALL be prompted to remove incompatible equipment
+
+#### Scenario: Configuration change location mapping
+- **GIVEN** user changes configuration (e.g., BIPED to QUAD)
+- **WHEN** equipment is allocated to locations
+- **THEN** validator SHALL check if equipment locations are valid in new config
+- **AND** equipment in invalid locations SHALL be unallocated

--- a/openspec/changes/add-exotic-mech-support/tasks.md
+++ b/openspec/changes/add-exotic-mech-support/tasks.md
@@ -1,0 +1,148 @@
+# Tasks: Add Exotic Mech Configuration Support
+
+## Phase 1: Foundation + Quad Support
+
+### 1.1 Configuration Registry Foundation
+- [ ] 1.1.1 Create `MechConfigurationDefinition` interface in `src/types/construction/`
+- [ ] 1.1.2 Create `LocationDefinition` interface with slot counts, max armor calculations
+- [ ] 1.1.3 Create `ActuatorDefinition` interface with slot positions and removability
+- [ ] 1.1.4 Create `ConfigurationRegistry` class with definition lookup methods
+- [ ] 1.1.5 Extract biped configuration from existing hardcoded values into definition
+- [ ] 1.1.6 Add unit tests for ConfigurationRegistry
+
+### 1.2 MechLocation Enum Expansion
+- [ ] 1.2.1 Add quad locations to MechLocation enum (FRONT_LEFT_LEG, FRONT_RIGHT_LEG, REAR_LEFT_LEG, REAR_RIGHT_LEG)
+- [ ] 1.2.2 Add `getLocationsForConfig(config)` helper function
+- [ ] 1.2.3 Add `getLocationDisplayName(location, config)` helper (e.g., "Front Left Leg" vs "Left Arm")
+- [ ] 1.2.4 Update location-dependent utilities to use configuration-aware helpers
+- [ ] 1.2.5 Add unit tests for location helpers
+
+### 1.3 Quad Configuration Definition
+- [ ] 1.3.1 Create quad configuration definition (8 locations, all with leg actuators)
+- [ ] 1.3.2 Define quad actuator layout (Hip, Upper Leg, Lower Leg, Foot × 4)
+- [ ] 1.3.3 Define quad equipment restrictions (no hand weapons, turret rules)
+- [ ] 1.3.4 Register quad definition in ConfigurationRegistry
+- [ ] 1.3.5 Add unit tests for quad configuration
+
+### 1.4 MTF Parser Updates for Quad
+- [ ] 1.4.1 Add configuration-specific location header mappings to parser
+- [ ] 1.4.2 Add quad armor label mappings (FLL, FRL, RLL, RRL)
+- [ ] 1.4.3 Update parser to read Config: line before location parsing
+- [ ] 1.4.4 Add quad MTF export support with correct location names
+- [ ] 1.4.5 Add parser/exporter tests with actual quad MTF files from mm-data
+
+### 1.5 Quad Armor Diagram
+- [ ] 1.5.1 Create QuadArmorDiagram SVG component with 4-legged silhouette
+- [ ] 1.5.2 Implement location regions for Head, CT, LT, RT, FLL, FRL, RLL, RRL
+- [ ] 1.5.3 Add armor pip layout for quad locations
+- [ ] 1.5.4 Create diagram selector that switches based on unit configuration
+- [ ] 1.5.5 Integrate diagram selector into ArmorTab
+- [ ] 1.5.6 Add visual regression tests for quad diagram
+
+### 1.6 Quad Validation Rules
+- [ ] 1.6.1 Add `appliesTo` field to validation rule interface
+- [ ] 1.6.2 Create quad-no-hand-actuators rule
+- [ ] 1.6.3 Create quad-no-hand-weapons rule (hatchets, swords, claws)
+- [ ] 1.6.4 Create quad-turret-mounting rule for rear-facing weapons
+- [ ] 1.6.5 Update validation orchestrator to filter rules by configuration
+- [ ] 1.6.6 Add validation rule tests for quad mechs
+
+## Phase 2: LAM Support
+
+### 2.1 LAM Mode System
+- [ ] 2.1.1 Create LAMMode enum (MECH, AIRMECH, FIGHTER)
+- [ ] 2.1.2 Create LAMModeDefinition interface with movement type, weapon restrictions
+- [ ] 2.1.3 Implement mode-specific movement calculations
+- [ ] 2.1.4 Implement fighter mode armor location mapping (Mech → Fighter)
+- [ ] 2.1.5 Add mode switching logic to unit store
+- [ ] 2.1.6 Add unit tests for LAM mode system
+
+### 2.2 LAM Configuration Definition
+- [ ] 2.2.1 Create LAM configuration definition (biped locations + special equipment)
+- [ ] 2.2.2 Define required LAM equipment (Landing Gear × 3, Avionics × 3)
+- [ ] 2.2.3 Define LAM equipment restrictions per mode
+- [ ] 2.2.4 Register LAM definition in ConfigurationRegistry
+- [ ] 2.2.5 Add unit tests for LAM configuration
+
+### 2.3 MTF Parser Updates for LAM
+- [ ] 2.3.1 Add LAM config detection in parser
+- [ ] 2.3.2 Parse Landing Gear and Avionics as fixed equipment
+- [ ] 2.3.3 Add LAM MTF export with correct equipment placement
+- [ ] 2.3.4 Add parser/exporter tests with actual LAM MTF files
+
+### 2.4 LAM Armor Diagram
+- [ ] 2.4.1 Create LAMArmorDiagram component with mode toggle
+- [ ] 2.4.2 Implement Mech mode view (biped silhouette)
+- [ ] 2.4.3 Implement Fighter mode overlay with mapped armor values
+- [ ] 2.4.4 Add mode indicator and switch control
+- [ ] 2.4.5 Add visual tests for LAM diagram modes
+
+### 2.5 LAM Validation Rules
+- [ ] 2.5.1 Create LAM-avionics-required rule
+- [ ] 2.5.2 Create LAM-landing-gear-required rule
+- [ ] 2.5.3 Create LAM-mode-weapon-restrictions rule
+- [ ] 2.5.4 Add validation tests for LAM mechs
+
+## Phase 3: Tripod Support
+
+### 3.1 Tripod Configuration
+- [ ] 3.1.1 Add CENTER_LEG to MechLocation enum
+- [ ] 3.1.2 Create tripod configuration definition (9 locations)
+- [ ] 3.1.3 Define center leg actuators (Hip, Upper Leg, Lower Leg, Foot)
+- [ ] 3.1.4 Register tripod definition in ConfigurationRegistry
+- [ ] 3.1.5 Add unit tests for tripod configuration
+
+### 3.2 MTF Parser Updates for Tripod
+- [ ] 3.2.1 Add tripod location header mapping (Center Leg:)
+- [ ] 3.2.2 Add tripod armor label mapping (CL armor)
+- [ ] 3.2.3 Add tripod MTF export support
+- [ ] 3.2.4 Add parser/exporter tests with actual tripod MTF files
+
+### 3.3 Tripod Armor Diagram
+- [ ] 3.3.1 Create TripodArmorDiagram SVG component
+- [ ] 3.3.2 Implement 9 location regions (8 biped + center leg)
+- [ ] 3.3.3 Add armor pip layout for tripod
+- [ ] 3.3.4 Add visual tests for tripod diagram
+
+### 3.4 Tripod Validation Rules
+- [ ] 3.4.1 Create tripod-center-leg-equipment rule (tracks, talons use all 3 legs)
+- [ ] 3.4.2 Add validation tests for tripod mechs
+
+## Phase 4: QuadVee Support
+
+### 4.1 QuadVee Configuration
+- [ ] 4.1.1 Create QuadVeeMode enum (MECH, VEHICLE)
+- [ ] 4.1.2 Create QuadVee configuration definition (extends Quad)
+- [ ] 4.1.3 Define vehicle mode location mapping
+- [ ] 4.1.4 Register QuadVee definition in ConfigurationRegistry
+- [ ] 4.1.5 Add unit tests for QuadVee configuration
+
+### 4.2 MTF Parser Updates for QuadVee
+- [ ] 4.2.1 Add QuadVee config detection
+- [ ] 4.2.2 Add QuadVee MTF export support
+- [ ] 4.2.3 Add parser/exporter tests with QuadVee MTF files
+
+### 4.3 QuadVee Armor Diagram
+- [ ] 4.3.1 Create QuadVeeArmorDiagram with mode toggle
+- [ ] 4.3.2 Implement quad silhouette for mech mode
+- [ ] 4.3.3 Implement vehicle representation for vehicle mode
+- [ ] 4.3.4 Add visual tests for QuadVee diagram modes
+
+### 4.4 QuadVee Validation Rules
+- [ ] 4.4.1 Create QuadVee-specific validation rules
+- [ ] 4.4.2 Add validation tests for QuadVee mechs
+
+## Phase 5: Integration Testing
+
+### 5.1 End-to-End Testing
+- [ ] 5.1.1 Test importing quad mech from MegaMekLab JSON
+- [ ] 5.1.2 Test round-trip MTF export/import for quad
+- [ ] 5.1.3 Test importing LAM from MegaMekLab JSON
+- [ ] 5.1.4 Test LAM mode switching preserves data
+- [ ] 5.1.5 Test tripod import/export round-trip
+- [ ] 5.1.6 Test QuadVee import/export round-trip
+
+### 5.2 Migration Verification
+- [ ] 5.2.1 Verify existing biped units load correctly
+- [ ] 5.2.2 Verify no regression in biped functionality
+- [ ] 5.2.3 Run full validation suite

--- a/src/__tests__/integration/ExoticMechConfigurations.test.ts
+++ b/src/__tests__/integration/ExoticMechConfigurations.test.ts
@@ -1,0 +1,712 @@
+/**
+ * Exotic Mech Configurations Integration Tests
+ *
+ * Tests for exotic mech configurations (Quad, LAM, Tripod, QuadVee):
+ * - Export/import round-trip preservation
+ * - Configuration validation
+ * - Armor diagram data handling
+ * - Mode switching for transformable units
+ *
+ * @spec openspec/specs/mech-configuration-system/spec.md
+ */
+
+import { ISerializedUnit } from '@/types/unit/UnitSerialization';
+import { MechLocation } from '@/types/construction/CriticalSlotAllocation';
+import {
+  MechConfiguration,
+  QuadVeeMode,
+  LAMMode,
+  configurationRegistry,
+  BIPED_LOCATIONS,
+  getLocationsForConfig,
+} from '@/types/construction/MechConfigurationSystem';
+import {
+  getConfigurationValidationRules,
+  QuadNoArmsRule,
+  QuadLegCountRule,
+  LAMMaxTonnageRule,
+  TripodCenterLegRule,
+  QuadVeeConversionEquipmentRule,
+} from '@/utils/validation/rules/ConfigurationValidationRules';
+import { IValidationContext } from '@/types/validation/rules/ValidationRuleInterfaces';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+const createValidationContext = (unit: Record<string, unknown>): IValidationContext => ({
+  unit,
+  equipment: [],
+  options: {},
+});
+
+/**
+ * Create a minimal serialized unit for testing
+ */
+function createMinimalUnit(
+  configuration: string,
+  overrides?: Partial<ISerializedUnit>
+): ISerializedUnit {
+  const base: ISerializedUnit = {
+    id: `test-${configuration.toLowerCase()}-1`,
+    chassis: `Test${configuration}`,
+    model: 'TST-1',
+    unitType: 'BattleMech',
+    configuration,
+    techBase: 'INNER_SPHERE',
+    rulesLevel: 'STANDARD',
+    era: 'Succession Wars',
+    year: 3025,
+    tonnage: 50,
+    engine: { type: 'FUSION', rating: 200 },
+    gyro: { type: 'STANDARD' },
+    cockpit: 'Standard',
+    structure: { type: 'STANDARD' },
+    armor: {
+      type: 'STANDARD',
+      allocation: {},
+    },
+    heatSinks: { type: 'SINGLE', count: 10 },
+    movement: { walk: 4, jump: 0 },
+    equipment: [],
+    criticalSlots: {},
+    ...overrides,
+  };
+  return base;
+}
+
+/**
+ * Create a quad mech unit
+ */
+function createQuadMech(overrides?: Partial<ISerializedUnit>): ISerializedUnit {
+  return createMinimalUnit('QUAD', {
+    armor: {
+      type: 'STANDARD',
+      allocation: {
+        HEAD: 9,
+        CENTER_TORSO: { front: 20, rear: 10 },
+        LEFT_TORSO: { front: 16, rear: 8 },
+        RIGHT_TORSO: { front: 16, rear: 8 },
+        FRONT_LEFT_LEG: 16,
+        FRONT_RIGHT_LEG: 16,
+        REAR_LEFT_LEG: 16,
+        REAR_RIGHT_LEG: 16,
+      },
+    },
+    criticalSlots: {
+      HEAD: ['Life Support', 'Sensors', 'Cockpit', null, 'Sensors', 'Life Support'],
+      CENTER_TORSO: Array<string | null>(12).fill(null),
+      LEFT_TORSO: Array<string | null>(12).fill(null),
+      RIGHT_TORSO: Array<string | null>(12).fill(null),
+      FRONT_LEFT_LEG: ['Hip', 'Upper Leg Actuator', 'Lower Leg Actuator', 'Foot Actuator', null, null, null, null, null, null, null, null],
+      FRONT_RIGHT_LEG: ['Hip', 'Upper Leg Actuator', 'Lower Leg Actuator', 'Foot Actuator', null, null, null, null, null, null, null, null],
+      REAR_LEFT_LEG: ['Hip', 'Upper Leg Actuator', 'Lower Leg Actuator', 'Foot Actuator', null, null, null, null, null, null, null, null],
+      REAR_RIGHT_LEG: ['Hip', 'Upper Leg Actuator', 'Lower Leg Actuator', 'Foot Actuator', null, null, null, null, null, null, null, null],
+    },
+    ...overrides,
+  });
+}
+
+/**
+ * Create a LAM mech unit
+ */
+function createLAMMech(overrides?: Partial<ISerializedUnit>): ISerializedUnit {
+  return createMinimalUnit('LAM', {
+    tonnage: 55, // LAM max tonnage
+    armor: {
+      type: 'STANDARD',
+      allocation: {
+        HEAD: 9,
+        CENTER_TORSO: { front: 20, rear: 10 },
+        LEFT_TORSO: { front: 16, rear: 8 },
+        RIGHT_TORSO: { front: 16, rear: 8 },
+        LEFT_ARM: 12,
+        RIGHT_ARM: 12,
+        LEFT_LEG: 16,
+        RIGHT_LEG: 16,
+      },
+    },
+    criticalSlots: {
+      HEAD: ['Life Support', 'Sensors', 'Cockpit', 'Avionics', 'Sensors', 'Life Support'],
+      CENTER_TORSO: ['Fusion Engine', 'Fusion Engine', 'Fusion Engine', 'Gyro', 'Gyro', 'Gyro', 'Gyro', 'Fusion Engine', 'Fusion Engine', 'Fusion Engine', 'Landing Gear', null],
+      LEFT_TORSO: ['Landing Gear', 'Avionics', null, null, null, null, null, null, null, null, null, null],
+      RIGHT_TORSO: ['Landing Gear', 'Avionics', null, null, null, null, null, null, null, null, null, null],
+      LEFT_ARM: ['Shoulder', 'Upper Arm Actuator', 'Lower Arm Actuator', 'Hand Actuator', null, null, null, null, null, null, null, null],
+      RIGHT_ARM: ['Shoulder', 'Upper Arm Actuator', 'Lower Arm Actuator', 'Hand Actuator', null, null, null, null, null, null, null, null],
+      LEFT_LEG: ['Hip', 'Upper Leg Actuator', 'Lower Leg Actuator', 'Foot Actuator', null, null],
+      RIGHT_LEG: ['Hip', 'Upper Leg Actuator', 'Lower Leg Actuator', 'Foot Actuator', null, null],
+    },
+    ...overrides,
+  });
+}
+
+/**
+ * Create a Tripod mech unit
+ */
+function createTripodMech(overrides?: Partial<ISerializedUnit>): ISerializedUnit {
+  return createMinimalUnit('TRIPOD', {
+    tonnage: 100, // Tripods are typically superheavy
+    armor: {
+      type: 'STANDARD',
+      allocation: {
+        HEAD: 9,
+        CENTER_TORSO: { front: 30, rear: 15 },
+        LEFT_TORSO: { front: 24, rear: 12 },
+        RIGHT_TORSO: { front: 24, rear: 12 },
+        LEFT_ARM: 20,
+        RIGHT_ARM: 20,
+        LEFT_LEG: 24,
+        RIGHT_LEG: 24,
+        CENTER_LEG: 24,
+      },
+    },
+    // Validation rules check unit.armorAllocation (top level)
+    armorAllocation: {
+      [MechLocation.HEAD]: 9,
+      [MechLocation.CENTER_TORSO]: 30,
+      [MechLocation.LEFT_TORSO]: 24,
+      [MechLocation.RIGHT_TORSO]: 24,
+      [MechLocation.LEFT_ARM]: 20,
+      [MechLocation.RIGHT_ARM]: 20,
+      [MechLocation.LEFT_LEG]: 24,
+      [MechLocation.RIGHT_LEG]: 24,
+      [MechLocation.CENTER_LEG]: 24,
+    },
+    criticalSlots: {
+      [MechLocation.HEAD]: ['Life Support', 'Sensors', 'Cockpit', null, 'Sensors', 'Life Support'],
+      [MechLocation.CENTER_TORSO]: Array(12).fill(null),
+      [MechLocation.LEFT_TORSO]: Array(12).fill(null),
+      [MechLocation.RIGHT_TORSO]: Array(12).fill(null),
+      [MechLocation.LEFT_ARM]: ['Shoulder', 'Upper Arm Actuator', 'Lower Arm Actuator', 'Hand Actuator', null, null, null, null, null, null, null, null],
+      [MechLocation.RIGHT_ARM]: ['Shoulder', 'Upper Arm Actuator', 'Lower Arm Actuator', 'Hand Actuator', null, null, null, null, null, null, null, null],
+      [MechLocation.LEFT_LEG]: ['Hip', 'Upper Leg Actuator', 'Lower Leg Actuator', 'Foot Actuator', null, null],
+      [MechLocation.RIGHT_LEG]: ['Hip', 'Upper Leg Actuator', 'Lower Leg Actuator', 'Foot Actuator', null, null],
+      [MechLocation.CENTER_LEG]: ['Hip', 'Upper Leg Actuator', 'Lower Leg Actuator', 'Foot Actuator', null, null],
+    },
+    ...overrides,
+  } as Partial<ISerializedUnit>);
+}
+
+/**
+ * Create a QuadVee mech unit
+ */
+function createQuadVeeMech(overrides?: Partial<ISerializedUnit>): ISerializedUnit {
+  return createMinimalUnit('QUADVEE', {
+    armor: {
+      type: 'STANDARD',
+      allocation: {
+        HEAD: 9,
+        CENTER_TORSO: { front: 20, rear: 10 },
+        LEFT_TORSO: { front: 16, rear: 8 },
+        RIGHT_TORSO: { front: 16, rear: 8 },
+        FRONT_LEFT_LEG: 16,
+        FRONT_RIGHT_LEG: 16,
+        REAR_LEFT_LEG: 16,
+        REAR_RIGHT_LEG: 16,
+      },
+    },
+    criticalSlots: {
+      [MechLocation.HEAD]: ['Life Support', 'Sensors', 'Cockpit', null, 'Sensors', 'Life Support'],
+      [MechLocation.CENTER_TORSO]: Array(12).fill(null),
+      [MechLocation.LEFT_TORSO]: Array(12).fill(null),
+      [MechLocation.RIGHT_TORSO]: Array(12).fill(null),
+      [MechLocation.FRONT_LEFT_LEG]: ['Hip', 'Upper Leg Actuator', 'Lower Leg Actuator', 'Foot Actuator', 'Conversion Equipment', 'Tracks', null, null, null, null, null, null],
+      [MechLocation.FRONT_RIGHT_LEG]: ['Hip', 'Upper Leg Actuator', 'Lower Leg Actuator', 'Foot Actuator', 'Conversion Equipment', 'Tracks', null, null, null, null, null, null],
+      [MechLocation.REAR_LEFT_LEG]: ['Hip', 'Upper Leg Actuator', 'Lower Leg Actuator', 'Foot Actuator', 'Conversion Equipment', 'Tracks', null, null, null, null, null, null],
+      [MechLocation.REAR_RIGHT_LEG]: ['Hip', 'Upper Leg Actuator', 'Lower Leg Actuator', 'Foot Actuator', 'Conversion Equipment', 'Tracks', null, null, null, null, null, null],
+    },
+    ...overrides,
+  });
+}
+
+// ============================================================================
+// Configuration Registry Tests
+// ============================================================================
+
+describe('Configuration Registry Integration', () => {
+  describe('getConfiguration', () => {
+    it('should return valid definition for QUAD', () => {
+      const config = configurationRegistry.getConfiguration(MechConfiguration.QUAD);
+      expect(config.id).toBe(MechConfiguration.QUAD);
+      expect(config.displayName).toBe('Quad');
+      expect(config.locations).toHaveLength(8);
+    });
+
+    it('should return valid definition for LAM', () => {
+      const config = configurationRegistry.getConfiguration(MechConfiguration.LAM);
+      expect(config.id).toBe(MechConfiguration.LAM);
+      expect(config.displayName).toBe('Land-Air Mech');
+      expect(config.locations).toHaveLength(8);
+      expect(config.modes).toBeDefined();
+      expect(config.modes?.length).toBe(3); // Mech, AirMech, Fighter
+    });
+
+    it('should return valid definition for TRIPOD', () => {
+      const config = configurationRegistry.getConfiguration(MechConfiguration.TRIPOD);
+      expect(config.id).toBe(MechConfiguration.TRIPOD);
+      expect(config.displayName).toBe('Tripod');
+      expect(config.locations).toHaveLength(9); // 8 + center leg
+    });
+
+    it('should return valid definition for QUADVEE', () => {
+      const config = configurationRegistry.getConfiguration(MechConfiguration.QUADVEE);
+      expect(config.id).toBe(MechConfiguration.QUADVEE);
+      expect(config.displayName).toBe('QuadVee');
+      expect(config.locations).toHaveLength(8);
+      expect(config.requiredEquipment).toBeDefined();
+    });
+  });
+
+  describe('isQuadConfiguration', () => {
+    it('should return true for QUAD', () => {
+      expect(configurationRegistry.isQuadConfiguration(MechConfiguration.QUAD)).toBe(true);
+    });
+
+    it('should return true for QUADVEE', () => {
+      expect(configurationRegistry.isQuadConfiguration(MechConfiguration.QUADVEE)).toBe(true);
+    });
+
+    it('should return false for BIPED', () => {
+      expect(configurationRegistry.isQuadConfiguration(MechConfiguration.BIPED)).toBe(false);
+    });
+
+    it('should return false for LAM', () => {
+      expect(configurationRegistry.isQuadConfiguration(MechConfiguration.LAM)).toBe(false);
+    });
+  });
+
+  describe('isTransformingConfiguration', () => {
+    it('should return true for LAM', () => {
+      expect(configurationRegistry.isTransformingConfiguration(MechConfiguration.LAM)).toBe(true);
+    });
+
+    it('should return true for QUADVEE', () => {
+      expect(configurationRegistry.isTransformingConfiguration(MechConfiguration.QUADVEE)).toBe(true);
+    });
+
+    it('should return false for BIPED', () => {
+      expect(configurationRegistry.isTransformingConfiguration(MechConfiguration.BIPED)).toBe(false);
+    });
+
+    it('should return false for QUAD', () => {
+      expect(configurationRegistry.isTransformingConfiguration(MechConfiguration.QUAD)).toBe(false);
+    });
+  });
+});
+
+// ============================================================================
+// Location Set Tests
+// ============================================================================
+
+describe('Configuration Location Sets', () => {
+  describe('getLocationsForConfig', () => {
+    it('should return 8 locations for BIPED', () => {
+      const locations = getLocationsForConfig(MechConfiguration.BIPED);
+      expect(locations).toHaveLength(8);
+      expect(locations).toContain(MechLocation.LEFT_ARM);
+      expect(locations).toContain(MechLocation.RIGHT_ARM);
+    });
+
+    it('should return 8 quad locations for QUAD', () => {
+      const locations = getLocationsForConfig(MechConfiguration.QUAD);
+      expect(locations).toHaveLength(8);
+      expect(locations).toContain(MechLocation.FRONT_LEFT_LEG);
+      expect(locations).toContain(MechLocation.REAR_RIGHT_LEG);
+      expect(locations).not.toContain(MechLocation.LEFT_ARM);
+    });
+
+    it('should return 9 locations for TRIPOD', () => {
+      const locations = getLocationsForConfig(MechConfiguration.TRIPOD);
+      expect(locations).toHaveLength(9);
+      expect(locations).toContain(MechLocation.CENTER_LEG);
+      expect(locations).toContain(MechLocation.LEFT_ARM);
+    });
+
+    it('should return quad locations for QUADVEE', () => {
+      const locations = getLocationsForConfig(MechConfiguration.QUADVEE);
+      expect(locations).toHaveLength(8);
+      expect(locations).toContain(MechLocation.FRONT_LEFT_LEG);
+      expect(locations).not.toContain(MechLocation.LEFT_ARM);
+    });
+
+    it('should return biped locations for LAM', () => {
+      const locations = getLocationsForConfig(MechConfiguration.LAM);
+      expect(locations).toHaveLength(8);
+      expect(locations).toContain(MechLocation.LEFT_ARM);
+    });
+  });
+});
+
+// ============================================================================
+// Validation Rules Integration
+// ============================================================================
+
+describe('Configuration Validation Rules Integration', () => {
+  describe('getConfigurationValidationRules', () => {
+    it('should return at least 19 rules', () => {
+      const rules = getConfigurationValidationRules();
+      expect(rules.length).toBeGreaterThanOrEqual(19);
+    });
+
+    it('should include rules for all exotic configurations', () => {
+      const rules = getConfigurationValidationRules();
+      const ruleIds = rules.map(r => r.id);
+
+      // Quad rules
+      expect(ruleIds).toContain('configuration.quad.no_arms');
+      expect(ruleIds).toContain('configuration.quad.leg_count');
+
+      // LAM rules
+      expect(ruleIds).toContain('configuration.lam.max_tonnage');
+      expect(ruleIds).toContain('configuration.lam.engine_type');
+
+      // Tripod rules
+      expect(ruleIds).toContain('configuration.tripod.center_leg');
+      expect(ruleIds).toContain('configuration.tripod.leg_equipment');
+
+      // QuadVee rules
+      expect(ruleIds).toContain('configuration.quadvee.conversion_equipment');
+      expect(ruleIds).toContain('configuration.quadvee.tracks');
+    });
+  });
+
+  describe('Quad Validation', () => {
+    it('should pass for valid quad unit', () => {
+      const unit = createQuadMech();
+      const context = createValidationContext(unit);
+
+      const noArmsResult = QuadNoArmsRule.validate(context);
+      expect(noArmsResult.passed).toBe(true);
+
+      const legCountResult = QuadLegCountRule.validate(context);
+      expect(legCountResult.passed).toBe(true);
+    });
+
+    it('should fail when quad has arm equipment', () => {
+      const unit = createQuadMech({
+        equipment: [{ id: 'medium-laser', location: MechLocation.LEFT_ARM }],
+      });
+      const context = createValidationContext(unit);
+
+      const result = QuadNoArmsRule.validate(context);
+      expect(result.passed).toBe(false);
+    });
+  });
+
+  describe('LAM Validation', () => {
+    it('should pass for valid LAM unit', () => {
+      const unit = createLAMMech();
+      const context = createValidationContext(unit);
+
+      const tonnageResult = LAMMaxTonnageRule.validate(context);
+      expect(tonnageResult.passed).toBe(true);
+    });
+
+    it('should fail when LAM exceeds 55 tons', () => {
+      const unit = createLAMMech({ tonnage: 60 });
+      const context = createValidationContext(unit);
+
+      const result = LAMMaxTonnageRule.validate(context);
+      expect(result.passed).toBe(false);
+      expect(result.errors[0].message).toContain('55 tons');
+    });
+  });
+
+  describe('Tripod Validation', () => {
+    it('should pass for valid tripod unit', () => {
+      const unit = createTripodMech();
+      const context = createValidationContext(unit);
+
+      const result = TripodCenterLegRule.validate(context);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should fail when tripod missing center leg', () => {
+      const unit = createTripodMech({
+        armorAllocation: {
+          [MechLocation.HEAD]: 9,
+          [MechLocation.LEFT_LEG]: 24,
+          [MechLocation.RIGHT_LEG]: 24,
+          // Missing CENTER_LEG
+        },
+        criticalSlots: {
+          [MechLocation.LEFT_LEG]: ['Hip', 'Upper Leg Actuator'],
+          [MechLocation.RIGHT_LEG]: ['Hip', 'Upper Leg Actuator'],
+          // Missing CENTER_LEG
+        },
+      });
+      const context = createValidationContext(unit);
+
+      const result = TripodCenterLegRule.validate(context);
+      expect(result.passed).toBe(false);
+    });
+  });
+
+  describe('QuadVee Validation', () => {
+    it('should pass for valid quadvee unit', () => {
+      const unit = createQuadVeeMech();
+      const context = createValidationContext(unit);
+
+      const result = QuadVeeConversionEquipmentRule.validate(context);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should fail when quadvee missing conversion equipment', () => {
+      const unit = createQuadVeeMech({
+        criticalSlots: {
+          [MechLocation.HEAD]: ['Life Support', 'Sensors', 'Cockpit', null, 'Sensors', 'Life Support'],
+          [MechLocation.CENTER_TORSO]: Array(12).fill(null),
+          [MechLocation.LEFT_TORSO]: Array(12).fill(null),
+          [MechLocation.RIGHT_TORSO]: Array(12).fill(null),
+          [MechLocation.FRONT_LEFT_LEG]: ['Hip', 'Upper Leg Actuator', null, null, null, null, null, null, null, null, null, null],
+          [MechLocation.FRONT_RIGHT_LEG]: ['Hip', 'Upper Leg Actuator', null, null, null, null, null, null, null, null, null, null],
+          [MechLocation.REAR_LEFT_LEG]: ['Hip', 'Upper Leg Actuator', null, null, null, null, null, null, null, null, null, null],
+          [MechLocation.REAR_RIGHT_LEG]: ['Hip', 'Upper Leg Actuator', null, null, null, null, null, null, null, null, null, null],
+        },
+      });
+      const context = createValidationContext(unit);
+
+      const result = QuadVeeConversionEquipmentRule.validate(context);
+      expect(result.passed).toBe(false);
+    });
+  });
+});
+
+// ============================================================================
+// Mode System Tests
+// ============================================================================
+
+describe('Transformable Configuration Modes', () => {
+  describe('LAM Modes', () => {
+    it('should have three modes defined', () => {
+      const modes = configurationRegistry.getModes(MechConfiguration.LAM);
+      expect(modes).toBeDefined();
+      expect(modes?.length).toBe(3);
+    });
+
+    it('should have Mech, AirMech, and Fighter modes', () => {
+      const modes = configurationRegistry.getModes(MechConfiguration.LAM);
+      const modeValues = modes?.map(m => m.mode);
+
+      expect(modeValues).toContain(LAMMode.MECH);
+      expect(modeValues).toContain(LAMMode.AIRMECH);
+      expect(modeValues).toContain(LAMMode.FIGHTER);
+    });
+
+    it('should provide fighter armor location mapping', () => {
+      const mapping = configurationRegistry.getFighterArmorMapping(MechConfiguration.LAM);
+      expect(mapping).toBeDefined();
+      expect(mapping?.[MechLocation.HEAD]).toBe(MechLocation.NOSE);
+      expect(mapping?.[MechLocation.CENTER_TORSO]).toBe(MechLocation.FUSELAGE);
+    });
+  });
+
+  describe('QuadVee Modes', () => {
+    it('should have two modes defined', () => {
+      const modes = configurationRegistry.getQuadVeeModes();
+      expect(modes).toHaveLength(2);
+    });
+
+    it('should have Mech and Vehicle modes', () => {
+      const modes = configurationRegistry.getQuadVeeModes();
+      const modeValues = modes.map(m => m.mode);
+
+      expect(modeValues).toContain(QuadVeeMode.MECH);
+      expect(modeValues).toContain(QuadVeeMode.VEHICLE);
+    });
+
+    it('should provide mode definitions with movement types', () => {
+      const mechMode = configurationRegistry.getQuadVeeModeDefinition(QuadVeeMode.MECH);
+      const vehicleMode = configurationRegistry.getQuadVeeModeDefinition(QuadVeeMode.VEHICLE);
+
+      expect(mechMode?.movementType).toBe('ground');
+      expect(vehicleMode?.movementType).toBe('tracked');
+    });
+  });
+});
+
+// ============================================================================
+// Required Equipment Tests
+// ============================================================================
+
+describe('Required Equipment', () => {
+  describe('LAM Required Equipment', () => {
+    it('should require landing gear and avionics', () => {
+      const config = configurationRegistry.getConfiguration(MechConfiguration.LAM);
+      const required = config.requiredEquipment;
+
+      expect(required).toBeDefined();
+      expect(required?.some(e => e.equipmentId === 'landing-gear')).toBe(true);
+      expect(required?.some(e => e.equipmentId === 'avionics')).toBe(true);
+    });
+
+    it('should specify correct locations for landing gear', () => {
+      const config = configurationRegistry.getConfiguration(MechConfiguration.LAM);
+      const landingGear = config.requiredEquipment?.find(e => e.equipmentId === 'landing-gear');
+
+      expect(landingGear?.locations).toContain(MechLocation.CENTER_TORSO);
+      expect(landingGear?.locations).toContain(MechLocation.LEFT_TORSO);
+      expect(landingGear?.locations).toContain(MechLocation.RIGHT_TORSO);
+    });
+  });
+
+  describe('QuadVee Required Equipment', () => {
+    it('should require conversion equipment', () => {
+      const config = configurationRegistry.getConfiguration(MechConfiguration.QUADVEE);
+      const required = config.requiredEquipment;
+
+      expect(required).toBeDefined();
+      expect(required?.some(e => e.equipmentId === 'conversion-equipment')).toBe(true);
+    });
+
+    it('should specify conversion equipment in all legs', () => {
+      const config = configurationRegistry.getConfiguration(MechConfiguration.QUADVEE);
+      const conversion = config.requiredEquipment?.find(e => e.equipmentId === 'conversion-equipment');
+
+      expect(conversion?.locations).toContain(MechLocation.FRONT_LEFT_LEG);
+      expect(conversion?.locations).toContain(MechLocation.FRONT_RIGHT_LEG);
+      expect(conversion?.locations).toContain(MechLocation.REAR_LEFT_LEG);
+      expect(conversion?.locations).toContain(MechLocation.REAR_RIGHT_LEG);
+    });
+  });
+});
+
+// ============================================================================
+// Diagram Component Name Tests
+// ============================================================================
+
+describe('Diagram Component Names', () => {
+  it('should return QuadArmorDiagram for QUAD', () => {
+    const name = configurationRegistry.getDiagramComponentName(MechConfiguration.QUAD);
+    expect(name).toBe('QuadArmorDiagram');
+  });
+
+  it('should return LAMArmorDiagram for LAM', () => {
+    const name = configurationRegistry.getDiagramComponentName(MechConfiguration.LAM);
+    expect(name).toBe('LAMArmorDiagram');
+  });
+
+  it('should return TripodArmorDiagram for TRIPOD', () => {
+    const name = configurationRegistry.getDiagramComponentName(MechConfiguration.TRIPOD);
+    expect(name).toBe('TripodArmorDiagram');
+  });
+
+  it('should return QuadVeeArmorDiagram for QUADVEE', () => {
+    const name = configurationRegistry.getDiagramComponentName(MechConfiguration.QUADVEE);
+    expect(name).toBe('QuadVeeArmorDiagram');
+  });
+
+  it('should return BipedArmorDiagram for BIPED', () => {
+    const name = configurationRegistry.getDiagramComponentName(MechConfiguration.BIPED);
+    expect(name).toBe('BipedArmorDiagram');
+  });
+});
+
+// ============================================================================
+// Prohibited Equipment Tests
+// ============================================================================
+
+describe('Prohibited Equipment', () => {
+  describe('LAM Prohibited Equipment', () => {
+    it('should prohibit advanced armor and structure types', () => {
+      const config = configurationRegistry.getConfiguration(MechConfiguration.LAM);
+      const prohibited = config.prohibitedEquipment;
+
+      expect(prohibited).toContain('endo-steel');
+      expect(prohibited).toContain('ferro-fibrous');
+      expect(prohibited).toContain('stealth-armor');
+    });
+  });
+
+  describe('Other Configurations', () => {
+    it('should not prohibit equipment for QUAD', () => {
+      const config = configurationRegistry.getConfiguration(MechConfiguration.QUAD);
+      expect(config.prohibitedEquipment).toHaveLength(0);
+    });
+
+    it('should not prohibit equipment for TRIPOD', () => {
+      const config = configurationRegistry.getConfiguration(MechConfiguration.TRIPOD);
+      expect(config.prohibitedEquipment).toHaveLength(0);
+    });
+
+    it('should not prohibit equipment for QUADVEE', () => {
+      const config = configurationRegistry.getConfiguration(MechConfiguration.QUADVEE);
+      expect(config.prohibitedEquipment).toHaveLength(0);
+    });
+  });
+});
+
+// ============================================================================
+// Max Tonnage Tests
+// ============================================================================
+
+describe('Configuration Max Tonnage', () => {
+  it('should return 55 for LAM', () => {
+    const maxTonnage = configurationRegistry.getMaxTonnage(MechConfiguration.LAM);
+    expect(maxTonnage).toBe(55);
+  });
+
+  it('should return undefined for QUAD (no limit)', () => {
+    const maxTonnage = configurationRegistry.getMaxTonnage(MechConfiguration.QUAD);
+    expect(maxTonnage).toBeUndefined();
+  });
+
+  it('should return undefined for TRIPOD (no limit)', () => {
+    const maxTonnage = configurationRegistry.getMaxTonnage(MechConfiguration.TRIPOD);
+    expect(maxTonnage).toBeUndefined();
+  });
+
+  it('should return undefined for QUADVEE (no limit)', () => {
+    const maxTonnage = configurationRegistry.getMaxTonnage(MechConfiguration.QUADVEE);
+    expect(maxTonnage).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Biped Regression Tests
+// ============================================================================
+
+describe('Biped Configuration Regression', () => {
+  it('should maintain standard biped location set', () => {
+    const locations = BIPED_LOCATIONS;
+    expect(locations).toHaveLength(8);
+    expect(locations).toContain(MechLocation.HEAD);
+    expect(locations).toContain(MechLocation.CENTER_TORSO);
+    expect(locations).toContain(MechLocation.LEFT_ARM);
+    expect(locations).toContain(MechLocation.RIGHT_ARM);
+    expect(locations).toContain(MechLocation.LEFT_LEG);
+    expect(locations).toContain(MechLocation.RIGHT_LEG);
+  });
+
+  it('should return valid biped configuration', () => {
+    const config = configurationRegistry.getConfiguration(MechConfiguration.BIPED);
+    expect(config.id).toBe(MechConfiguration.BIPED);
+    expect(config.displayName).toBe('Biped');
+    expect(config.locations).toHaveLength(8);
+  });
+
+  it('should not affect biped validation rules', () => {
+    const unit = createMinimalUnit('BIPED', {
+      armor: {
+        type: 'STANDARD',
+        allocation: {
+          HEAD: 9,
+          CENTER_TORSO: { front: 20, rear: 10 },
+          LEFT_TORSO: { front: 16, rear: 8 },
+          RIGHT_TORSO: { front: 16, rear: 8 },
+          LEFT_ARM: 12,
+          RIGHT_ARM: 12,
+          LEFT_LEG: 16,
+          RIGHT_LEG: 16,
+        },
+      },
+    });
+    const context = createValidationContext(unit);
+
+    // Biped should not trigger exotic configuration rules
+    expect(QuadNoArmsRule.canValidate?.(context)).toBe(false);
+    expect(LAMMaxTonnageRule.canValidate?.(context)).toBe(false);
+    expect(TripodCenterLegRule.canValidate?.(context)).toBe(false);
+    expect(QuadVeeConversionEquipmentRule.canValidate?.(context)).toBe(false);
+  });
+});

--- a/src/__tests__/integration/ExoticMechConfigurations.test.ts
+++ b/src/__tests__/integration/ExoticMechConfigurations.test.ts
@@ -34,10 +34,10 @@ import { IValidationContext } from '@/types/validation/rules/ValidationRuleInter
 // Test Helpers
 // ============================================================================
 
-const createValidationContext = (unit: Record<string, unknown>): IValidationContext => ({
-  unit,
-  equipment: [],
+const createValidationContext = (unit: ISerializedUnit): IValidationContext => ({
+  unit: unit as unknown,
   options: {},
+  cache: new Map(),
 });
 
 /**
@@ -423,6 +423,7 @@ describe('Configuration Validation Rules Integration', () => {
 
     it('should fail when tripod missing center leg', () => {
       const unit = createTripodMech({
+        // Validation rules check armorAllocation at top level
         armorAllocation: {
           [MechLocation.HEAD]: 9,
           [MechLocation.LEFT_LEG]: 24,
@@ -434,7 +435,8 @@ describe('Configuration Validation Rules Integration', () => {
           [MechLocation.RIGHT_LEG]: ['Hip', 'Upper Leg Actuator'],
           // Missing CENTER_LEG
         },
-      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
       const context = createValidationContext(unit);
 
       const result = TripodCenterLegRule.validate(context);

--- a/src/__tests__/unit/types/construction/MechConfigurationSystem.test.ts
+++ b/src/__tests__/unit/types/construction/MechConfigurationSystem.test.ts
@@ -1,0 +1,407 @@
+/**
+ * MechConfigurationSystem Unit Tests
+ *
+ * Tests for the mech configuration system including:
+ * - Configuration definitions (Biped, Quad, Tripod, LAM, QuadVee)
+ * - Location validation and mapping
+ * - Actuator definitions
+ * - ConfigurationRegistry functionality
+ */
+
+import {
+  MechLocation,
+  MechConfiguration,
+  BIPED_LOCATIONS,
+  QUAD_LOCATIONS,
+  TRIPOD_LOCATIONS,
+  LAM_FIGHTER_LOCATIONS,
+  BIPED_CONFIGURATION,
+  QUAD_CONFIGURATION,
+  TRIPOD_CONFIGURATION,
+  LAM_CONFIGURATION,
+  QUADVEE_CONFIGURATION,
+  configurationRegistry,
+  getLocationsForConfig,
+  isValidLocationForConfig,
+  getLocationDisplayName,
+  getLocationAbbreviation,
+  getLocationSlotCount,
+  isLegLocation,
+  isArmLocation,
+  hasRearArmor,
+  getActuatorsForLocation,
+  isBipedLocation,
+  ActuatorType,
+} from '@/types/construction/MechConfigurationSystem';
+
+describe('MechConfigurationSystem', () => {
+  describe('Location Arrays', () => {
+    it('should define all 8 biped locations', () => {
+      expect(BIPED_LOCATIONS).toHaveLength(8);
+      expect(BIPED_LOCATIONS).toContain(MechLocation.HEAD);
+      expect(BIPED_LOCATIONS).toContain(MechLocation.CENTER_TORSO);
+      expect(BIPED_LOCATIONS).toContain(MechLocation.LEFT_TORSO);
+      expect(BIPED_LOCATIONS).toContain(MechLocation.RIGHT_TORSO);
+      expect(BIPED_LOCATIONS).toContain(MechLocation.LEFT_ARM);
+      expect(BIPED_LOCATIONS).toContain(MechLocation.RIGHT_ARM);
+      expect(BIPED_LOCATIONS).toContain(MechLocation.LEFT_LEG);
+      expect(BIPED_LOCATIONS).toContain(MechLocation.RIGHT_LEG);
+    });
+
+    it('should define all 8 quad locations', () => {
+      expect(QUAD_LOCATIONS).toHaveLength(8);
+      expect(QUAD_LOCATIONS).toContain(MechLocation.HEAD);
+      expect(QUAD_LOCATIONS).toContain(MechLocation.CENTER_TORSO);
+      expect(QUAD_LOCATIONS).toContain(MechLocation.LEFT_TORSO);
+      expect(QUAD_LOCATIONS).toContain(MechLocation.RIGHT_TORSO);
+      expect(QUAD_LOCATIONS).toContain(MechLocation.FRONT_LEFT_LEG);
+      expect(QUAD_LOCATIONS).toContain(MechLocation.FRONT_RIGHT_LEG);
+      expect(QUAD_LOCATIONS).toContain(MechLocation.REAR_LEFT_LEG);
+      expect(QUAD_LOCATIONS).toContain(MechLocation.REAR_RIGHT_LEG);
+    });
+
+    it('should not include arm locations in quad mechs', () => {
+      expect(QUAD_LOCATIONS).not.toContain(MechLocation.LEFT_ARM);
+      expect(QUAD_LOCATIONS).not.toContain(MechLocation.RIGHT_ARM);
+    });
+
+    it('should not include quad legs in biped mechs', () => {
+      expect(BIPED_LOCATIONS).not.toContain(MechLocation.FRONT_LEFT_LEG);
+      expect(BIPED_LOCATIONS).not.toContain(MechLocation.FRONT_RIGHT_LEG);
+      expect(BIPED_LOCATIONS).not.toContain(MechLocation.REAR_LEFT_LEG);
+      expect(BIPED_LOCATIONS).not.toContain(MechLocation.REAR_RIGHT_LEG);
+    });
+
+    it('should define all 9 tripod locations including center leg', () => {
+      expect(TRIPOD_LOCATIONS).toHaveLength(9);
+      expect(TRIPOD_LOCATIONS).toContain(MechLocation.CENTER_LEG);
+    });
+  });
+
+  describe('Configuration Definitions', () => {
+    describe('BIPED_CONFIGURATION', () => {
+      it('should have correct id and name', () => {
+        expect(BIPED_CONFIGURATION.id).toBe(MechConfiguration.BIPED);
+        expect(BIPED_CONFIGURATION.displayName).toBe('Biped');
+      });
+
+      it('should have 8 locations defined', () => {
+        expect(BIPED_CONFIGURATION.locations).toHaveLength(8);
+      });
+
+      it('should have torso locations with rear armor', () => {
+        const ctDef = BIPED_CONFIGURATION.locations.find(
+          (l) => l.id === MechLocation.CENTER_TORSO
+        );
+        expect(ctDef?.hasRearArmor).toBe(true);
+      });
+
+      it('should have arm locations marked as limbs', () => {
+        const laDef = BIPED_CONFIGURATION.locations.find(
+          (l) => l.id === MechLocation.LEFT_ARM
+        );
+        expect(laDef?.isLimb).toBe(true);
+      });
+    });
+
+    describe('QUAD_CONFIGURATION', () => {
+      it('should have correct id and name', () => {
+        expect(QUAD_CONFIGURATION.id).toBe(MechConfiguration.QUAD);
+        expect(QUAD_CONFIGURATION.displayName).toBe('Quad');
+      });
+
+      it('should have 8 locations (4 legs, 3 torsos, 1 head)', () => {
+        expect(QUAD_CONFIGURATION.locations).toHaveLength(8);
+      });
+
+      it('should have all four legs as limbs', () => {
+        const legLocations = [
+          MechLocation.FRONT_LEFT_LEG,
+          MechLocation.FRONT_RIGHT_LEG,
+          MechLocation.REAR_LEFT_LEG,
+          MechLocation.REAR_RIGHT_LEG,
+        ];
+
+        for (const legLoc of legLocations) {
+          const legDef = QUAD_CONFIGURATION.locations.find(
+            (l) => l.id === legLoc
+          );
+          expect(legDef?.isLimb).toBe(true);
+        }
+      });
+
+      it('should not have any arm locations', () => {
+        const hasArms = QUAD_CONFIGURATION.locations.some(
+          (l) =>
+            l.id === MechLocation.LEFT_ARM ||
+            l.id === MechLocation.RIGHT_ARM
+        );
+        expect(hasArms).toBe(false);
+      });
+
+      it('should specify QuadArmorDiagram as the diagram component', () => {
+        expect(QUAD_CONFIGURATION.diagramComponentName).toBe('QuadArmorDiagram');
+      });
+    });
+
+    describe('TRIPOD_CONFIGURATION', () => {
+      it('should have center leg location', () => {
+        const centerLegDef = TRIPOD_CONFIGURATION.locations.find(
+          (l) => l.id === MechLocation.CENTER_LEG
+        );
+        expect(centerLegDef).toBeDefined();
+        expect(centerLegDef?.isLimb).toBe(true);
+      });
+    });
+
+    describe('LAM_CONFIGURATION', () => {
+      it('should be defined as LAM configuration', () => {
+        expect(LAM_CONFIGURATION.id).toBe(MechConfiguration.LAM);
+        expect(LAM_CONFIGURATION.displayName).toBe('Land-Air Mech');
+      });
+    });
+
+    describe('QUADVEE_CONFIGURATION', () => {
+      it('should be defined as QuadVee configuration', () => {
+        expect(QUADVEE_CONFIGURATION.id).toBe(MechConfiguration.QUADVEE);
+        expect(QUADVEE_CONFIGURATION.displayName).toBe('QuadVee');
+      });
+    });
+  });
+
+  describe('ConfigurationRegistry', () => {
+    it('should return configuration by type', () => {
+      const bipedConfig = configurationRegistry.getConfiguration(
+        MechConfiguration.BIPED
+      );
+      expect(bipedConfig).toBe(BIPED_CONFIGURATION);
+
+      const quadConfig = configurationRegistry.getConfiguration(
+        MechConfiguration.QUAD
+      );
+      expect(quadConfig).toBe(QUAD_CONFIGURATION);
+    });
+
+    it('should return all registered configurations', () => {
+      const all = configurationRegistry.getAllConfigurations();
+      expect(all).toHaveLength(5);
+    });
+
+    it('should return valid locations for configuration', () => {
+      const quadLocations = configurationRegistry.getValidLocations(
+        MechConfiguration.QUAD
+      );
+      expect(quadLocations).toHaveLength(8);
+      expect(quadLocations).toContain(MechLocation.FRONT_LEFT_LEG);
+      expect(quadLocations).not.toContain(MechLocation.LEFT_ARM);
+    });
+
+    it('should correctly identify quad configurations', () => {
+      expect(
+        configurationRegistry.isQuadConfiguration(MechConfiguration.QUAD)
+      ).toBe(true);
+      expect(
+        configurationRegistry.isQuadConfiguration(MechConfiguration.QUADVEE)
+      ).toBe(true);
+      expect(
+        configurationRegistry.isQuadConfiguration(MechConfiguration.BIPED)
+      ).toBe(false);
+    });
+  });
+
+  describe('Helper Functions', () => {
+    describe('getLocationsForConfig', () => {
+      it('should return biped locations for biped config', () => {
+        const locs = getLocationsForConfig(MechConfiguration.BIPED);
+        expect(locs).toEqual(BIPED_LOCATIONS);
+      });
+
+      it('should return quad locations for quad config', () => {
+        const locs = getLocationsForConfig(MechConfiguration.QUAD);
+        expect(locs).toEqual(QUAD_LOCATIONS);
+      });
+
+      it('should return quad locations for quadvee config', () => {
+        const locs = getLocationsForConfig(MechConfiguration.QUADVEE);
+        expect(locs).toEqual(QUAD_LOCATIONS);
+      });
+    });
+
+    describe('isValidLocationForConfig', () => {
+      it('should validate biped locations correctly', () => {
+        expect(
+          isValidLocationForConfig(MechLocation.LEFT_ARM, MechConfiguration.BIPED)
+        ).toBe(true);
+        expect(
+          isValidLocationForConfig(
+            MechLocation.FRONT_LEFT_LEG,
+            MechConfiguration.BIPED
+          )
+        ).toBe(false);
+      });
+
+      it('should validate quad locations correctly', () => {
+        expect(
+          isValidLocationForConfig(
+            MechLocation.FRONT_LEFT_LEG,
+            MechConfiguration.QUAD
+          )
+        ).toBe(true);
+        expect(
+          isValidLocationForConfig(MechLocation.LEFT_ARM, MechConfiguration.QUAD)
+        ).toBe(false);
+      });
+    });
+
+    describe('getLocationDisplayName', () => {
+      it('should return correct display names', () => {
+        expect(getLocationDisplayName(MechLocation.HEAD)).toBe('Head');
+        expect(getLocationDisplayName(MechLocation.CENTER_TORSO)).toBe(
+          'Center Torso'
+        );
+        expect(getLocationDisplayName(MechLocation.FRONT_LEFT_LEG)).toBe(
+          'Front Left Leg'
+        );
+      });
+    });
+
+    describe('getLocationAbbreviation', () => {
+      it('should return correct abbreviations', () => {
+        expect(getLocationAbbreviation(MechLocation.HEAD)).toBe('HD');
+        expect(getLocationAbbreviation(MechLocation.CENTER_TORSO)).toBe('CT');
+        expect(getLocationAbbreviation(MechLocation.FRONT_LEFT_LEG)).toBe('FLL');
+        expect(getLocationAbbreviation(MechLocation.REAR_RIGHT_LEG)).toBe('RRL');
+      });
+    });
+
+    describe('getLocationSlotCount', () => {
+      it('should return 6 slots for head in all configs', () => {
+        expect(getLocationSlotCount(MechLocation.HEAD, MechConfiguration.BIPED)).toBe(
+          6
+        );
+        expect(getLocationSlotCount(MechLocation.HEAD, MechConfiguration.QUAD)).toBe(
+          6
+        );
+      });
+
+      it('should return 12 slots for torso locations', () => {
+        expect(
+          getLocationSlotCount(MechLocation.CENTER_TORSO, MechConfiguration.BIPED)
+        ).toBe(12);
+      });
+
+      it('should return 12 slots for quad legs', () => {
+        expect(
+          getLocationSlotCount(MechLocation.FRONT_LEFT_LEG, MechConfiguration.QUAD)
+        ).toBe(12);
+      });
+    });
+
+    describe('isLegLocation', () => {
+      it('should identify biped legs', () => {
+        expect(isLegLocation(MechLocation.LEFT_LEG)).toBe(true);
+        expect(isLegLocation(MechLocation.RIGHT_LEG)).toBe(true);
+      });
+
+      it('should identify quad legs', () => {
+        expect(isLegLocation(MechLocation.FRONT_LEFT_LEG)).toBe(true);
+        expect(isLegLocation(MechLocation.FRONT_RIGHT_LEG)).toBe(true);
+        expect(isLegLocation(MechLocation.REAR_LEFT_LEG)).toBe(true);
+        expect(isLegLocation(MechLocation.REAR_RIGHT_LEG)).toBe(true);
+      });
+
+      it('should not identify arms as legs', () => {
+        expect(isLegLocation(MechLocation.LEFT_ARM)).toBe(false);
+      });
+    });
+
+    describe('isArmLocation', () => {
+      it('should identify arm locations', () => {
+        expect(isArmLocation(MechLocation.LEFT_ARM)).toBe(true);
+        expect(isArmLocation(MechLocation.RIGHT_ARM)).toBe(true);
+      });
+
+      it('should not identify legs as arms', () => {
+        expect(isArmLocation(MechLocation.LEFT_LEG)).toBe(false);
+        expect(isArmLocation(MechLocation.FRONT_LEFT_LEG)).toBe(false);
+      });
+    });
+
+    describe('hasRearArmor', () => {
+      it('should return true for torso locations', () => {
+        expect(hasRearArmor(MechLocation.CENTER_TORSO)).toBe(true);
+        expect(hasRearArmor(MechLocation.LEFT_TORSO)).toBe(true);
+        expect(hasRearArmor(MechLocation.RIGHT_TORSO)).toBe(true);
+      });
+
+      it('should return false for limbs', () => {
+        expect(hasRearArmor(MechLocation.LEFT_ARM)).toBe(false);
+        expect(hasRearArmor(MechLocation.LEFT_LEG)).toBe(false);
+        expect(hasRearArmor(MechLocation.FRONT_LEFT_LEG)).toBe(false);
+      });
+    });
+
+    describe('getActuatorsForLocation', () => {
+      it('should return arm actuators for biped arms', () => {
+        const actuators = getActuatorsForLocation(
+          MechLocation.LEFT_ARM,
+          MechConfiguration.BIPED
+        );
+        expect(actuators).toHaveLength(4);
+        expect(actuators.map((a) => a.type)).toContain(ActuatorType.SHOULDER);
+        expect(actuators.map((a) => a.type)).toContain(ActuatorType.UPPER_ARM);
+        expect(actuators.map((a) => a.type)).toContain(ActuatorType.LOWER_ARM);
+        expect(actuators.map((a) => a.type)).toContain(ActuatorType.HAND);
+      });
+
+      it('should return leg actuators for biped legs', () => {
+        const actuators = getActuatorsForLocation(
+          MechLocation.LEFT_LEG,
+          MechConfiguration.BIPED
+        );
+        expect(actuators).toHaveLength(4);
+        expect(actuators.map((a) => a.type)).toContain(ActuatorType.HIP);
+        expect(actuators.map((a) => a.type)).toContain(ActuatorType.UPPER_LEG);
+        expect(actuators.map((a) => a.type)).toContain(ActuatorType.LOWER_LEG);
+        expect(actuators.map((a) => a.type)).toContain(ActuatorType.FOOT);
+      });
+
+      it('should return leg actuators for quad legs', () => {
+        const actuators = getActuatorsForLocation(
+          MechLocation.FRONT_LEFT_LEG,
+          MechConfiguration.QUAD
+        );
+        expect(actuators).toHaveLength(4);
+      });
+
+      it('should return empty array for torso locations', () => {
+        const actuators = getActuatorsForLocation(
+          MechLocation.CENTER_TORSO,
+          MechConfiguration.BIPED
+        );
+        expect(actuators).toHaveLength(0);
+      });
+
+      it('should return empty array for invalid location/config', () => {
+        const actuators = getActuatorsForLocation(
+          MechLocation.LEFT_ARM,
+          MechConfiguration.QUAD
+        );
+        expect(actuators).toHaveLength(0);
+      });
+    });
+
+    describe('isBipedLocation', () => {
+      it('should return true for biped locations', () => {
+        expect(isBipedLocation(MechLocation.LEFT_ARM)).toBe(true);
+        expect(isBipedLocation(MechLocation.LEFT_LEG)).toBe(true);
+        expect(isBipedLocation(MechLocation.HEAD)).toBe(true);
+      });
+
+      it('should return false for quad-only locations', () => {
+        expect(isBipedLocation(MechLocation.FRONT_LEFT_LEG)).toBe(false);
+        expect(isBipedLocation(MechLocation.CENTER_LEG)).toBe(false);
+      });
+    });
+  });
+});

--- a/src/__tests__/unit/types/construction/MechConfigurationSystem.test.ts
+++ b/src/__tests__/unit/types/construction/MechConfigurationSystem.test.ts
@@ -20,6 +20,8 @@ import {
   TRIPOD_CONFIGURATION,
   LAM_CONFIGURATION,
   QUADVEE_CONFIGURATION,
+  LAM_EQUIPMENT,
+  LAMMode,
   configurationRegistry,
   getLocationsForConfig,
   isValidLocationForConfig,
@@ -159,6 +161,59 @@ describe('MechConfigurationSystem', () => {
         expect(LAM_CONFIGURATION.id).toBe(MechConfiguration.LAM);
         expect(LAM_CONFIGURATION.displayName).toBe('Land-Air Mech');
       });
+
+      it('should have 8 biped locations', () => {
+        expect(LAM_CONFIGURATION.locations).toHaveLength(8);
+        expect(LAM_CONFIGURATION.locations.map(l => l.id)).toContain(MechLocation.HEAD);
+        expect(LAM_CONFIGURATION.locations.map(l => l.id)).toContain(MechLocation.LEFT_ARM);
+        expect(LAM_CONFIGURATION.locations.map(l => l.id)).toContain(MechLocation.LEFT_LEG);
+      });
+
+      it('should have three operating modes', () => {
+        expect(LAM_CONFIGURATION.modes).toHaveLength(3);
+        expect(LAM_CONFIGURATION.modes?.map(m => m.mode)).toContain(LAMMode.MECH);
+        expect(LAM_CONFIGURATION.modes?.map(m => m.mode)).toContain(LAMMode.AIRMECH);
+        expect(LAM_CONFIGURATION.modes?.map(m => m.mode)).toContain(LAMMode.FIGHTER);
+      });
+
+      it('should have fighter mode armor location mapping', () => {
+        const fighterMode = LAM_CONFIGURATION.modes?.find(m => m.mode === LAMMode.FIGHTER);
+        expect(fighterMode?.armorLocationMapping).toBeDefined();
+        expect(fighterMode?.armorLocationMapping?.[MechLocation.HEAD]).toBe(MechLocation.NOSE);
+        expect(fighterMode?.armorLocationMapping?.[MechLocation.CENTER_TORSO]).toBe(MechLocation.FUSELAGE);
+        expect(fighterMode?.armorLocationMapping?.[MechLocation.LEFT_TORSO]).toBe(MechLocation.LEFT_WING);
+        expect(fighterMode?.armorLocationMapping?.[MechLocation.RIGHT_TORSO]).toBe(MechLocation.RIGHT_WING);
+        expect(fighterMode?.armorLocationMapping?.[MechLocation.LEFT_LEG]).toBe(MechLocation.AFT);
+        expect(fighterMode?.armorLocationMapping?.[MechLocation.RIGHT_LEG]).toBe(MechLocation.AFT);
+      });
+
+      it('should have required equipment for Landing Gear and Avionics', () => {
+        expect(LAM_CONFIGURATION.requiredEquipment).toBeDefined();
+        expect(LAM_CONFIGURATION.requiredEquipment).toHaveLength(2);
+
+        const landingGear = LAM_CONFIGURATION.requiredEquipment?.find(e => e.equipmentId === 'landing-gear');
+        expect(landingGear).toBeDefined();
+        expect(landingGear?.locations).toContain(MechLocation.CENTER_TORSO);
+        expect(landingGear?.locations).toContain(MechLocation.LEFT_TORSO);
+        expect(landingGear?.locations).toContain(MechLocation.RIGHT_TORSO);
+
+        const avionics = LAM_CONFIGURATION.requiredEquipment?.find(e => e.equipmentId === 'avionics');
+        expect(avionics).toBeDefined();
+        expect(avionics?.locations).toContain(MechLocation.HEAD);
+        expect(avionics?.locations).toContain(MechLocation.LEFT_TORSO);
+        expect(avionics?.locations).toContain(MechLocation.RIGHT_TORSO);
+      });
+
+      it('should have prohibited equipment list', () => {
+        expect(LAM_CONFIGURATION.prohibitedEquipment).toBeDefined();
+        expect(LAM_CONFIGURATION.prohibitedEquipment).toContain('endo-steel');
+        expect(LAM_CONFIGURATION.prohibitedEquipment).toContain('ferro-fibrous');
+        expect(LAM_CONFIGURATION.prohibitedEquipment).toContain('stealth-armor');
+      });
+
+      it('should specify LAMArmorDiagram as the diagram component', () => {
+        expect(LAM_CONFIGURATION.diagramComponentName).toBe('LAMArmorDiagram');
+      });
     });
 
     describe('QUADVEE_CONFIGURATION', () => {
@@ -206,6 +261,90 @@ describe('MechConfigurationSystem', () => {
       expect(
         configurationRegistry.isQuadConfiguration(MechConfiguration.BIPED)
       ).toBe(false);
+    });
+
+    it('should correctly identify LAM configurations', () => {
+      expect(
+        configurationRegistry.isLAMConfiguration(MechConfiguration.LAM)
+      ).toBe(true);
+      expect(
+        configurationRegistry.isLAMConfiguration(MechConfiguration.BIPED)
+      ).toBe(false);
+      expect(
+        configurationRegistry.isLAMConfiguration(MechConfiguration.QUAD)
+      ).toBe(false);
+    });
+
+    it('should correctly identify transforming configurations', () => {
+      expect(
+        configurationRegistry.isTransformingConfiguration(MechConfiguration.LAM)
+      ).toBe(true);
+      expect(
+        configurationRegistry.isTransformingConfiguration(MechConfiguration.QUADVEE)
+      ).toBe(true);
+      expect(
+        configurationRegistry.isTransformingConfiguration(MechConfiguration.BIPED)
+      ).toBe(false);
+      expect(
+        configurationRegistry.isTransformingConfiguration(MechConfiguration.QUAD)
+      ).toBe(false);
+    });
+
+    it('should return LAM modes', () => {
+      const modes = configurationRegistry.getModes(MechConfiguration.LAM);
+      expect(modes).toHaveLength(3);
+      expect(modes?.map(m => m.mode)).toEqual([LAMMode.MECH, LAMMode.AIRMECH, LAMMode.FIGHTER]);
+    });
+
+    it('should return undefined modes for non-transforming configs', () => {
+      const modes = configurationRegistry.getModes(MechConfiguration.BIPED);
+      expect(modes).toBeUndefined();
+    });
+
+    it('should return fighter armor mapping for LAM', () => {
+      const mapping = configurationRegistry.getFighterArmorMapping(MechConfiguration.LAM);
+      expect(mapping).toBeDefined();
+      expect(mapping?.[MechLocation.HEAD]).toBe(MechLocation.NOSE);
+      expect(mapping?.[MechLocation.CENTER_TORSO]).toBe(MechLocation.FUSELAGE);
+    });
+
+    it('should return max tonnage for LAM (55 tons)', () => {
+      const maxTonnage = configurationRegistry.getMaxTonnage(MechConfiguration.LAM);
+      expect(maxTonnage).toBe(55);
+    });
+
+    it('should return undefined max tonnage for non-LAM configs', () => {
+      expect(configurationRegistry.getMaxTonnage(MechConfiguration.BIPED)).toBeUndefined();
+      expect(configurationRegistry.getMaxTonnage(MechConfiguration.QUAD)).toBeUndefined();
+    });
+
+    it('should return required equipment for LAM', () => {
+      const requiredEquip = configurationRegistry.getRequiredEquipment(MechConfiguration.LAM);
+      expect(requiredEquip).toHaveLength(2);
+      expect(requiredEquip.some(e => e.equipmentId === 'landing-gear')).toBe(true);
+      expect(requiredEquip.some(e => e.equipmentId === 'avionics')).toBe(true);
+    });
+
+    it('should return prohibited equipment for LAM', () => {
+      const prohibitedEquip = configurationRegistry.getProhibitedEquipment(MechConfiguration.LAM);
+      expect(prohibitedEquip).toContain('endo-steel');
+      expect(prohibitedEquip).toContain('ferro-fibrous');
+    });
+  });
+
+  describe('LAM Equipment Constants', () => {
+    it('should define Landing Gear equipment', () => {
+      expect(LAM_EQUIPMENT.LANDING_GEAR.id).toBe('landing-gear');
+      expect(LAM_EQUIPMENT.LANDING_GEAR.name).toBe('Landing Gear');
+      expect(LAM_EQUIPMENT.LANDING_GEAR.slots).toBe(1);
+      expect(LAM_EQUIPMENT.LANDING_GEAR.locations).toHaveLength(3);
+    });
+
+    it('should define Avionics equipment', () => {
+      expect(LAM_EQUIPMENT.AVIONICS.id).toBe('avionics');
+      expect(LAM_EQUIPMENT.AVIONICS.name).toBe('Avionics');
+      expect(LAM_EQUIPMENT.AVIONICS.slots).toBe(1);
+      expect(LAM_EQUIPMENT.AVIONICS.locations).toHaveLength(3);
     });
   });
 

--- a/src/__tests__/unit/utils/construction/slotOperations.test.ts
+++ b/src/__tests__/unit/utils/construction/slotOperations.test.ts
@@ -8,6 +8,7 @@ import {
   sortEquipmentBySize,
 } from '@/utils/construction/slotOperations';
 import { MechLocation, LOCATION_SLOT_COUNTS } from '@/types/construction/CriticalSlotAllocation';
+import { BIPED_LOCATIONS } from '@/types/construction/MechConfigurationSystem';
 import { EngineType } from '@/types/construction/EngineType';
 import { GyroType } from '@/types/construction/GyroType';
 import { InternalStructureType } from '@/types/construction/InternalStructureType';
@@ -228,12 +229,13 @@ describe('slotOperations', () => {
         GyroType.STANDARD
       );
 
-      const expectedCapacity = Object.values(MechLocation).reduce<Record<MechLocation, number>>(
+      // Only check biped locations since fillUnhittableSlots only works with biped mechs
+      const expectedCapacity = BIPED_LOCATIONS.reduce<Partial<Record<MechLocation, number>>>(
         (acc, location) => {
-          acc[location] = capacityForLocation(location as MechLocation);
+          acc[location] = capacityForLocation(location);
           return acc;
         },
-        {} as Record<MechLocation, number>
+        {}
       );
 
       const countByLocation = result.assignments.reduce<Record<MechLocation, number>>((acc, assignment) => {

--- a/src/__tests__/unit/utils/validation/ConfigurationValidationRules.test.ts
+++ b/src/__tests__/unit/utils/validation/ConfigurationValidationRules.test.ts
@@ -4,6 +4,7 @@
  * Tests for configuration-specific validation rules including:
  * - Quad mech validation (no arms, correct legs)
  * - Biped mech validation (no quad legs)
+ * - LAM mech validation (tonnage, engine, structure/armor, equipment)
  * - Location validity checks
  */
 
@@ -14,6 +15,11 @@ import {
   QuadLegArmorBalanceRule,
   BipedNoQuadLegsRule,
   ValidLocationsRule,
+  LAMMaxTonnageRule,
+  LAMEngineTypeRule,
+  LAMStructureArmorRule,
+  LAMLandingGearRule,
+  LAMAvionicsRule,
   getConfigurationValidationRules,
 } from '@/utils/validation/rules/ConfigurationValidationRules';
 import { MechLocation } from '@/types/construction/CriticalSlotAllocation';
@@ -271,13 +277,234 @@ describe('ConfigurationValidationRules', () => {
     });
   });
 
+  // ==========================================================================
+  // LAM VALIDATION RULES
+  // ==========================================================================
+
+  describe('LAMMaxTonnageRule', () => {
+    it('should pass when LAM is 55 tons or less', () => {
+      const context = createContext({
+        configuration: 'LAM',
+        tonnage: 50,
+      });
+
+      const result = LAMMaxTonnageRule.validate(context);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should pass when LAM is exactly 55 tons', () => {
+      const context = createContext({
+        configuration: 'LAM',
+        tonnage: 55,
+      });
+
+      const result = LAMMaxTonnageRule.validate(context);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should fail when LAM exceeds 55 tons', () => {
+      const context = createContext({
+        configuration: 'LAM',
+        tonnage: 60,
+      });
+
+      const result = LAMMaxTonnageRule.validate(context);
+      expect(result.passed).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('55 tons');
+    });
+
+    it('should only apply to LAM mechs', () => {
+      expect(
+        LAMMaxTonnageRule.canValidate?.(createContext({ configuration: 'Biped' }))
+      ).toBe(false);
+      expect(
+        LAMMaxTonnageRule.canValidate?.(createContext({ configuration: 'LAM' }))
+      ).toBe(true);
+    });
+  });
+
+  describe('LAMEngineTypeRule', () => {
+    it('should pass when LAM uses Fusion engine', () => {
+      const context = createContext({
+        configuration: 'LAM',
+        engine: { type: 'FUSION', rating: 250 },
+      });
+
+      const result = LAMEngineTypeRule.validate(context);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should fail when LAM uses XL engine', () => {
+      const context = createContext({
+        configuration: 'LAM',
+        engine: { type: 'XL', rating: 250 },
+      });
+
+      const result = LAMEngineTypeRule.validate(context);
+      expect(result.passed).toBe(false);
+      expect(result.errors[0].message).toContain('XL');
+    });
+
+    it('should fail when LAM uses Light engine', () => {
+      const context = createContext({
+        configuration: 'LAM',
+        engine: { type: 'LIGHT', rating: 250 },
+      });
+
+      const result = LAMEngineTypeRule.validate(context);
+      expect(result.passed).toBe(false);
+    });
+
+    it('should only apply to LAM mechs', () => {
+      expect(
+        LAMEngineTypeRule.canValidate?.(createContext({ configuration: 'Biped' }))
+      ).toBe(false);
+      expect(
+        LAMEngineTypeRule.canValidate?.(createContext({ configuration: 'LAM' }))
+      ).toBe(true);
+    });
+  });
+
+  describe('LAMStructureArmorRule', () => {
+    it('should pass when LAM uses Standard structure and armor', () => {
+      const context = createContext({
+        configuration: 'LAM',
+        structure: { type: 'STANDARD' },
+        armor: { type: 'STANDARD' },
+      });
+
+      const result = LAMStructureArmorRule.validate(context);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should fail when LAM uses Endo Steel structure', () => {
+      const context = createContext({
+        configuration: 'LAM',
+        structure: { type: 'ENDO_STEEL' },
+        armor: { type: 'STANDARD' },
+      });
+
+      const result = LAMStructureArmorRule.validate(context);
+      expect(result.passed).toBe(false);
+      expect(result.errors[0].message).toContain('ENDO_STEEL');
+    });
+
+    it('should fail when LAM uses Ferro-Fibrous armor', () => {
+      const context = createContext({
+        configuration: 'LAM',
+        structure: { type: 'STANDARD' },
+        armor: { type: 'FERRO_FIBROUS' },
+      });
+
+      const result = LAMStructureArmorRule.validate(context);
+      expect(result.passed).toBe(false);
+      expect(result.errors[0].message).toContain('FERRO_FIBROUS');
+    });
+
+    it('should only apply to LAM mechs', () => {
+      expect(
+        LAMStructureArmorRule.canValidate?.(createContext({ configuration: 'Biped' }))
+      ).toBe(false);
+      expect(
+        LAMStructureArmorRule.canValidate?.(createContext({ configuration: 'LAM' }))
+      ).toBe(true);
+    });
+  });
+
+  describe('LAMLandingGearRule', () => {
+    it('should pass when LAM has Landing Gear in CT, LT, RT', () => {
+      const context = createContext({
+        configuration: 'LAM',
+        criticalSlots: {
+          [MechLocation.CENTER_TORSO]: ['Fusion Engine', 'Landing Gear', null],
+          [MechLocation.LEFT_TORSO]: ['Landing Gear', null, null],
+          [MechLocation.RIGHT_TORSO]: ['Landing Gear', null, null],
+        },
+      });
+
+      const result = LAMLandingGearRule.validate(context);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should fail when LAM is missing Landing Gear in CT', () => {
+      const context = createContext({
+        configuration: 'LAM',
+        criticalSlots: {
+          [MechLocation.CENTER_TORSO]: ['Fusion Engine', null, null],
+          [MechLocation.LEFT_TORSO]: ['Landing Gear', null, null],
+          [MechLocation.RIGHT_TORSO]: ['Landing Gear', null, null],
+        },
+      });
+
+      const result = LAMLandingGearRule.validate(context);
+      expect(result.passed).toBe(false);
+      expect(result.errors[0].message).toContain('Center Torso');
+    });
+
+    it('should only apply to LAM mechs', () => {
+      expect(
+        LAMLandingGearRule.canValidate?.(createContext({ configuration: 'Biped' }))
+      ).toBe(false);
+      expect(
+        LAMLandingGearRule.canValidate?.(createContext({ configuration: 'LAM' }))
+      ).toBe(true);
+    });
+  });
+
+  describe('LAMAvionicsRule', () => {
+    it('should pass when LAM has Avionics in HD, LT, RT', () => {
+      const context = createContext({
+        configuration: 'LAM',
+        criticalSlots: {
+          [MechLocation.HEAD]: ['Life Support', 'Sensors', 'Cockpit', 'Avionics'],
+          [MechLocation.LEFT_TORSO]: ['Avionics', null, null],
+          [MechLocation.RIGHT_TORSO]: ['Avionics', null, null],
+        },
+      });
+
+      const result = LAMAvionicsRule.validate(context);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should fail when LAM is missing Avionics in Head', () => {
+      const context = createContext({
+        configuration: 'LAM',
+        criticalSlots: {
+          [MechLocation.HEAD]: ['Life Support', 'Sensors', 'Cockpit', null],
+          [MechLocation.LEFT_TORSO]: ['Avionics', null, null],
+          [MechLocation.RIGHT_TORSO]: ['Avionics', null, null],
+        },
+      });
+
+      const result = LAMAvionicsRule.validate(context);
+      expect(result.passed).toBe(false);
+      expect(result.errors[0].message).toContain('Head');
+    });
+
+    it('should only apply to LAM mechs', () => {
+      expect(
+        LAMAvionicsRule.canValidate?.(createContext({ configuration: 'Biped' }))
+      ).toBe(false);
+      expect(
+        LAMAvionicsRule.canValidate?.(createContext({ configuration: 'LAM' }))
+      ).toBe(true);
+    });
+  });
+
   describe('getConfigurationValidationRules', () => {
     it('should return all configuration validation rules', () => {
       const rules = getConfigurationValidationRules();
-      expect(rules.length).toBeGreaterThanOrEqual(6);
+      expect(rules.length).toBeGreaterThanOrEqual(11);
       expect(rules.map((r) => r.id)).toContain('configuration.quad.no_arms');
       expect(rules.map((r) => r.id)).toContain('configuration.quad.leg_count');
       expect(rules.map((r) => r.id)).toContain('configuration.valid_locations');
+      // LAM rules
+      expect(rules.map((r) => r.id)).toContain('configuration.lam.max_tonnage');
+      expect(rules.map((r) => r.id)).toContain('configuration.lam.engine_type');
+      expect(rules.map((r) => r.id)).toContain('configuration.lam.structure_armor');
+      expect(rules.map((r) => r.id)).toContain('configuration.lam.landing_gear');
+      expect(rules.map((r) => r.id)).toContain('configuration.lam.avionics');
     });
   });
 });

--- a/src/__tests__/unit/utils/validation/ConfigurationValidationRules.test.ts
+++ b/src/__tests__/unit/utils/validation/ConfigurationValidationRules.test.ts
@@ -36,8 +36,8 @@ import { IValidationContext } from '@/types/validation/rules/ValidationRuleInter
 describe('ConfigurationValidationRules', () => {
   const createContext = (unit: Record<string, unknown>): IValidationContext => ({
     unit,
-    equipment: [],
     options: {},
+    cache: new Map(),
   });
 
   describe('QuadNoArmsRule', () => {

--- a/src/__tests__/unit/utils/validation/ConfigurationValidationRules.test.ts
+++ b/src/__tests__/unit/utils/validation/ConfigurationValidationRules.test.ts
@@ -1,0 +1,283 @@
+/**
+ * ConfigurationValidationRules Unit Tests
+ *
+ * Tests for configuration-specific validation rules including:
+ * - Quad mech validation (no arms, correct legs)
+ * - Biped mech validation (no quad legs)
+ * - Location validity checks
+ */
+
+import {
+  QuadNoArmsRule,
+  QuadLegCountRule,
+  QuadTotalSlotsRule,
+  QuadLegArmorBalanceRule,
+  BipedNoQuadLegsRule,
+  ValidLocationsRule,
+  getConfigurationValidationRules,
+} from '@/utils/validation/rules/ConfigurationValidationRules';
+import { MechLocation } from '@/types/construction/CriticalSlotAllocation';
+import { IValidationContext } from '@/types/validation/rules/ValidationRuleInterfaces';
+
+describe('ConfigurationValidationRules', () => {
+  const createContext = (unit: Record<string, unknown>): IValidationContext => ({
+    unit,
+    equipment: [],
+    options: {},
+  });
+
+  describe('QuadNoArmsRule', () => {
+    it('should pass when no equipment in arm locations', () => {
+      const context = createContext({
+        configuration: 'Quad',
+        equipment: [
+          { name: 'Medium Laser', location: MechLocation.LEFT_TORSO },
+          { name: 'Medium Laser', location: MechLocation.FRONT_LEFT_LEG },
+        ],
+      });
+
+      const result = QuadNoArmsRule.validate(context);
+      expect(result.passed).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should fail when equipment in left arm', () => {
+      const context = createContext({
+        configuration: 'Quad',
+        equipment: [{ name: 'Medium Laser', location: MechLocation.LEFT_ARM }],
+      });
+
+      const result = QuadNoArmsRule.validate(context);
+      expect(result.passed).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('Left Arm');
+    });
+
+    it('should fail when equipment in both arms', () => {
+      const context = createContext({
+        configuration: 'Quad',
+        equipment: [
+          { name: 'Medium Laser', location: MechLocation.LEFT_ARM },
+          { name: 'PPC', location: MechLocation.RIGHT_ARM },
+        ],
+      });
+
+      const result = QuadNoArmsRule.validate(context);
+      expect(result.passed).toBe(false);
+      expect(result.errors).toHaveLength(2);
+    });
+
+    it('should only apply to quad mechs', () => {
+      const bipedContext = createContext({
+        configuration: 'Biped',
+        equipment: [],
+      });
+
+      expect(QuadNoArmsRule.canValidate?.(bipedContext)).toBe(false);
+
+      const quadContext = createContext({
+        configuration: 'Quad',
+        equipment: [],
+      });
+
+      expect(QuadNoArmsRule.canValidate?.(quadContext)).toBe(true);
+    });
+  });
+
+  describe('QuadLegCountRule', () => {
+    it('should pass when all quad legs have armor allocation', () => {
+      const context = createContext({
+        configuration: 'Quad',
+        armorAllocation: {
+          [MechLocation.FRONT_LEFT_LEG]: 20,
+          [MechLocation.FRONT_RIGHT_LEG]: 20,
+          [MechLocation.REAR_LEFT_LEG]: 18,
+          [MechLocation.REAR_RIGHT_LEG]: 18,
+        },
+      });
+
+      const result = QuadLegCountRule.validate(context);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should only apply to quad mechs', () => {
+      expect(
+        QuadLegCountRule.canValidate?.(
+          createContext({ configuration: 'Biped' })
+        )
+      ).toBe(false);
+      expect(
+        QuadLegCountRule.canValidate?.(
+          createContext({ configuration: 'Quad' })
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('QuadTotalSlotsRule', () => {
+    it('should pass when slots under maximum', () => {
+      const context = createContext({
+        configuration: 'Quad',
+        criticalSlots: {
+          [MechLocation.HEAD]: ['Cockpit', null, null, null, null, null],
+          [MechLocation.CENTER_TORSO]: Array(12).fill('Gyro'),
+        },
+      });
+
+      const result = QuadTotalSlotsRule.validate(context);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should only apply to quad mechs', () => {
+      expect(
+        QuadTotalSlotsRule.canValidate?.(
+          createContext({ configuration: 'Biped' })
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('QuadLegArmorBalanceRule', () => {
+    it('should pass when leg armor is balanced', () => {
+      const context = createContext({
+        configuration: 'Quad',
+        armorAllocation: {
+          [MechLocation.FRONT_LEFT_LEG]: 20,
+          [MechLocation.FRONT_RIGHT_LEG]: 20,
+          [MechLocation.REAR_LEFT_LEG]: 20,
+          [MechLocation.REAR_RIGHT_LEG]: 20,
+        },
+      });
+
+      const result = QuadLegArmorBalanceRule.validate(context);
+      expect(result.passed).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it('should warn when leg armor is significantly unbalanced', () => {
+      const context = createContext({
+        configuration: 'Quad',
+        armorAllocation: {
+          [MechLocation.FRONT_LEFT_LEG]: 30,
+          [MechLocation.FRONT_RIGHT_LEG]: 30,
+          [MechLocation.REAR_LEFT_LEG]: 10,
+          [MechLocation.REAR_RIGHT_LEG]: 10,
+        },
+      });
+
+      const result = QuadLegArmorBalanceRule.validate(context);
+      expect(result.passed).toBe(true); // Still passes, just warning
+      expect(result.warnings.length).toBeGreaterThan(0);
+    });
+
+    it('should only apply to quad mechs', () => {
+      expect(
+        QuadLegArmorBalanceRule.canValidate?.(
+          createContext({ configuration: 'Biped' })
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('BipedNoQuadLegsRule', () => {
+    it('should pass for biped with normal locations', () => {
+      const context = createContext({
+        configuration: 'Biped',
+        equipment: [
+          { name: 'Medium Laser', location: MechLocation.LEFT_ARM },
+          { name: 'Medium Laser', location: MechLocation.LEFT_LEG },
+        ],
+      });
+
+      const result = BipedNoQuadLegsRule.validate(context);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should fail when biped has quad leg location', () => {
+      const context = createContext({
+        configuration: 'Biped',
+        equipment: [
+          { name: 'Medium Laser', location: MechLocation.FRONT_LEFT_LEG },
+        ],
+      });
+
+      const result = BipedNoQuadLegsRule.validate(context);
+      expect(result.passed).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('Front Left Leg');
+    });
+
+    it('should only apply to non-quad mechs', () => {
+      expect(
+        BipedNoQuadLegsRule.canValidate?.(
+          createContext({ configuration: 'Quad' })
+        )
+      ).toBe(false);
+      expect(
+        BipedNoQuadLegsRule.canValidate?.(
+          createContext({ configuration: 'Biped' })
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('ValidLocationsRule', () => {
+    it('should pass for valid biped locations', () => {
+      const context = createContext({
+        configuration: 'Biped',
+        equipment: [
+          { name: 'Medium Laser', location: MechLocation.LEFT_ARM },
+          { name: 'PPC', location: MechLocation.RIGHT_TORSO },
+        ],
+      });
+
+      const result = ValidLocationsRule.validate(context);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should pass for valid quad locations', () => {
+      const context = createContext({
+        configuration: 'Quad',
+        equipment: [
+          { name: 'Medium Laser', location: MechLocation.LEFT_TORSO },
+          { name: 'PPC', location: MechLocation.FRONT_LEFT_LEG },
+        ],
+      });
+
+      const result = ValidLocationsRule.validate(context);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should fail for invalid quad location (arm)', () => {
+      const context = createContext({
+        configuration: 'Quad',
+        equipment: [{ name: 'Medium Laser', location: MechLocation.LEFT_ARM }],
+      });
+
+      const result = ValidLocationsRule.validate(context);
+      expect(result.passed).toBe(false);
+    });
+
+    it('should fail for invalid biped location (quad leg)', () => {
+      const context = createContext({
+        configuration: 'Biped',
+        equipment: [
+          { name: 'Medium Laser', location: MechLocation.FRONT_LEFT_LEG },
+        ],
+      });
+
+      const result = ValidLocationsRule.validate(context);
+      expect(result.passed).toBe(false);
+    });
+  });
+
+  describe('getConfigurationValidationRules', () => {
+    it('should return all configuration validation rules', () => {
+      const rules = getConfigurationValidationRules();
+      expect(rules.length).toBeGreaterThanOrEqual(6);
+      expect(rules.map((r) => r.id)).toContain('configuration.quad.no_arms');
+      expect(rules.map((r) => r.id)).toContain('configuration.quad.leg_count');
+      expect(rules.map((r) => r.id)).toContain('configuration.valid_locations');
+    });
+  });
+});

--- a/src/components/armor/ArmorDiagram.tsx
+++ b/src/components/armor/ArmorDiagram.tsx
@@ -7,9 +7,9 @@ import { MechLocation } from '../../types/construction/CriticalSlotAllocation';
  * Uses MechLocation enum from base types for consistency
  */
 export interface ArmorData {
-  front: Record<MechLocation, number>;
-  rear: Record<MechLocation, number>;
-  max: Record<MechLocation, number>;
+  front: Partial<Record<MechLocation, number>>;
+  rear: Partial<Record<MechLocation, number>>;
+  max: Partial<Record<MechLocation, number>>;
 }
 
 export type ArmorAllocationType = 'even' | 'front-weighted' | 'rear-weighted';
@@ -133,8 +133,8 @@ export function ArmorDiagram({ armor, onArmorChange, onAutoAllocate, className =
         <div style={{ gridArea: 'head' }}>
           <ArmorLocation
             location={MechLocation.HEAD}
-            currentArmor={armor[facing][MechLocation.HEAD]}
-            maxArmor={armor.max[MechLocation.HEAD]}
+            currentArmor={armor[facing][MechLocation.HEAD] ?? 0}
+            maxArmor={armor.max[MechLocation.HEAD] ?? 0}
             onArmorChange={(value) => handleArmorChange(MechLocation.HEAD, value)}
           />
         </div>
@@ -143,8 +143,8 @@ export function ArmorDiagram({ armor, onArmorChange, onAutoAllocate, className =
         <div style={{ gridArea: 'center-torso' }}>
           <ArmorLocation
             location={MechLocation.CENTER_TORSO}
-            currentArmor={armor[facing][MechLocation.CENTER_TORSO]}
-            maxArmor={armor.max[MechLocation.CENTER_TORSO]}
+            currentArmor={armor[facing][MechLocation.CENTER_TORSO] ?? 0}
+            maxArmor={armor.max[MechLocation.CENTER_TORSO] ?? 0}
             onArmorChange={(value) => handleArmorChange(MechLocation.CENTER_TORSO, value)}
           />
         </div>
@@ -153,8 +153,8 @@ export function ArmorDiagram({ armor, onArmorChange, onAutoAllocate, className =
         <div style={{ gridArea: 'left-torso' }}>
           <ArmorLocation
             location={MechLocation.LEFT_TORSO}
-            currentArmor={armor[facing][MechLocation.LEFT_TORSO]}
-            maxArmor={armor.max[MechLocation.LEFT_TORSO]}
+            currentArmor={armor[facing][MechLocation.LEFT_TORSO] ?? 0}
+            maxArmor={armor.max[MechLocation.LEFT_TORSO] ?? 0}
             onArmorChange={(value) => handleArmorChange(MechLocation.LEFT_TORSO, value)}
           />
         </div>
@@ -163,8 +163,8 @@ export function ArmorDiagram({ armor, onArmorChange, onAutoAllocate, className =
         <div style={{ gridArea: 'right-torso' }}>
           <ArmorLocation
             location={MechLocation.RIGHT_TORSO}
-            currentArmor={armor[facing][MechLocation.RIGHT_TORSO]}
-            maxArmor={armor.max[MechLocation.RIGHT_TORSO]}
+            currentArmor={armor[facing][MechLocation.RIGHT_TORSO] ?? 0}
+            maxArmor={armor.max[MechLocation.RIGHT_TORSO] ?? 0}
             onArmorChange={(value) => handleArmorChange(MechLocation.RIGHT_TORSO, value)}
           />
         </div>
@@ -173,8 +173,8 @@ export function ArmorDiagram({ armor, onArmorChange, onAutoAllocate, className =
         <div style={{ gridArea: 'left-arm' }}>
           <ArmorLocation
             location={MechLocation.LEFT_ARM}
-            currentArmor={armor[facing][MechLocation.LEFT_ARM]}
-            maxArmor={armor.max[MechLocation.LEFT_ARM]}
+            currentArmor={armor[facing][MechLocation.LEFT_ARM] ?? 0}
+            maxArmor={armor.max[MechLocation.LEFT_ARM] ?? 0}
             onArmorChange={(value) => handleArmorChange(MechLocation.LEFT_ARM, value)}
           />
         </div>
@@ -183,8 +183,8 @@ export function ArmorDiagram({ armor, onArmorChange, onAutoAllocate, className =
         <div style={{ gridArea: 'right-arm' }}>
           <ArmorLocation
             location={MechLocation.RIGHT_ARM}
-            currentArmor={armor[facing][MechLocation.RIGHT_ARM]}
-            maxArmor={armor.max[MechLocation.RIGHT_ARM]}
+            currentArmor={armor[facing][MechLocation.RIGHT_ARM] ?? 0}
+            maxArmor={armor.max[MechLocation.RIGHT_ARM] ?? 0}
             onArmorChange={(value) => handleArmorChange(MechLocation.RIGHT_ARM, value)}
           />
         </div>
@@ -193,8 +193,8 @@ export function ArmorDiagram({ armor, onArmorChange, onAutoAllocate, className =
         <div style={{ gridArea: 'left-leg' }}>
           <ArmorLocation
             location={MechLocation.LEFT_LEG}
-            currentArmor={armor[facing][MechLocation.LEFT_LEG]}
-            maxArmor={armor.max[MechLocation.LEFT_LEG]}
+            currentArmor={armor[facing][MechLocation.LEFT_LEG] ?? 0}
+            maxArmor={armor.max[MechLocation.LEFT_LEG] ?? 0}
             onArmorChange={(value) => handleArmorChange(MechLocation.LEFT_LEG, value)}
           />
         </div>
@@ -203,8 +203,8 @@ export function ArmorDiagram({ armor, onArmorChange, onAutoAllocate, className =
         <div style={{ gridArea: 'right-leg' }}>
           <ArmorLocation
             location={MechLocation.RIGHT_LEG}
-            currentArmor={armor[facing][MechLocation.RIGHT_LEG]}
-            maxArmor={armor.max[MechLocation.RIGHT_LEG]}
+            currentArmor={armor[facing][MechLocation.RIGHT_LEG] ?? 0}
+            maxArmor={armor.max[MechLocation.RIGHT_LEG] ?? 0}
             onArmorChange={(value) => handleArmorChange(MechLocation.RIGHT_LEG, value)}
           />
         </div>
@@ -215,8 +215,8 @@ export function ArmorDiagram({ armor, onArmorChange, onAutoAllocate, className =
         {/* Head */}
         <ArmorLocation
           location={MechLocation.HEAD}
-          currentArmor={armor[facing][MechLocation.HEAD]}
-          maxArmor={armor.max[MechLocation.HEAD]}
+          currentArmor={armor[facing][MechLocation.HEAD] ?? 0}
+          maxArmor={armor.max[MechLocation.HEAD] ?? 0}
           onArmorChange={(value) => handleArmorChange(MechLocation.HEAD, value)}
         />
 
@@ -227,8 +227,8 @@ export function ArmorDiagram({ armor, onArmorChange, onAutoAllocate, className =
             <ArmorLocation
               key={location}
               location={location}
-              currentArmor={armor[facing][location]}
-              maxArmor={armor.max[location]}
+              currentArmor={armor[facing][location] ?? 0}
+              maxArmor={armor.max[location] ?? 0}
               onArmorChange={(value) => handleArmorChange(location, value)}
             />
           ))}
@@ -241,8 +241,8 @@ export function ArmorDiagram({ armor, onArmorChange, onAutoAllocate, className =
             <ArmorLocation
               key={location}
               location={location}
-              currentArmor={armor[facing][location]}
-              maxArmor={armor.max[location]}
+              currentArmor={armor[facing][location] ?? 0}
+              maxArmor={armor.max[location] ?? 0}
               onArmorChange={(value) => handleArmorChange(location, value)}
             />
           ))}
@@ -255,8 +255,8 @@ export function ArmorDiagram({ armor, onArmorChange, onAutoAllocate, className =
             <ArmorLocation
               key={location}
               location={location}
-              currentArmor={armor[facing][location]}
-              maxArmor={armor.max[location]}
+              currentArmor={armor[facing][location] ?? 0}
+              maxArmor={armor.max[location] ?? 0}
               onArmorChange={(value) => handleArmorChange(location, value)}
             />
           ))}

--- a/src/components/armor/shared/types.ts
+++ b/src/components/armor/shared/types.ts
@@ -55,15 +55,30 @@ export const MECH_LOCATIONS_ORDERED: readonly MechLocation[] = [
 ] as const;
 
 /**
- * Short labels for locations
+ * Short labels for locations (all configurations)
  */
 export const LOCATION_SHORT_LABELS: Record<MechLocation, string> = {
+  // Universal
   [MechLocation.HEAD]: 'HD',
   [MechLocation.CENTER_TORSO]: 'CT',
   [MechLocation.LEFT_TORSO]: 'LT',
   [MechLocation.RIGHT_TORSO]: 'RT',
+  // Biped/Tripod/LAM
   [MechLocation.LEFT_ARM]: 'LA',
   [MechLocation.RIGHT_ARM]: 'RA',
   [MechLocation.LEFT_LEG]: 'LL',
   [MechLocation.RIGHT_LEG]: 'RL',
+  // Tripod
+  [MechLocation.CENTER_LEG]: 'CL',
+  // Quad/QuadVee
+  [MechLocation.FRONT_LEFT_LEG]: 'FLL',
+  [MechLocation.FRONT_RIGHT_LEG]: 'FRL',
+  [MechLocation.REAR_LEFT_LEG]: 'RLL',
+  [MechLocation.REAR_RIGHT_LEG]: 'RRL',
+  // LAM Fighter
+  [MechLocation.NOSE]: 'NOS',
+  [MechLocation.LEFT_WING]: 'LW',
+  [MechLocation.RIGHT_WING]: 'RW',
+  [MechLocation.AFT]: 'AFT',
+  [MechLocation.FUSELAGE]: 'FUS',
 };

--- a/src/components/customizer/UnitEditorWithRouting.tsx
+++ b/src/components/customizer/UnitEditorWithRouting.tsx
@@ -453,7 +453,7 @@ export function UnitEditorWithRouting({
     const locations: AvailableLocation[] = [];
     
     // Location labels for display
-    const locationLabels: Record<MechLocation, string> = {
+    const locationLabels: Partial<Record<MechLocation, string>> = {
       [MechLocation.HEAD]: 'Head',
       [MechLocation.CENTER_TORSO]: 'Center Torso',
       [MechLocation.LEFT_TORSO]: 'Left Torso',
@@ -472,7 +472,7 @@ export function UnitEditorWithRouting({
         // Location is forbidden for this equipment type
         locations.push({
           location: loc,
-          label: locationLabels[loc],
+          label: locationLabels[loc] ?? loc,
           availableSlots: 0,
           canFit: false,
         });
@@ -516,7 +516,7 @@ export function UnitEditorWithRouting({
       
       locations.push({
         location: loc,
-        label: locationLabels[loc],
+        label: locationLabels[loc] ?? loc,
         availableSlots,
         canFit: maxContiguous >= slotsNeeded,
       });

--- a/src/components/customizer/armor/shared/MechSilhouette.tsx
+++ b/src/components/customizer/armor/shared/MechSilhouette.tsx
@@ -23,7 +23,7 @@ export interface LocationPosition {
  */
 export interface SilhouetteConfig {
   viewBox: string;
-  locations: Record<MechLocation, LocationPosition>;
+  locations: Partial<Record<MechLocation, LocationPosition>>;
   /** Optional outline path for wireframe style */
   outlinePath?: string;
 }
@@ -770,9 +770,199 @@ export function getTorsoSplit(
 }
 
 /**
- * Location labels
+ * Quad Mech silhouette - four-legged configuration
+ * Used for QuadMechs with four legs instead of arms
  */
-export const LOCATION_LABELS: Record<MechLocation, string> = {
+export const QUAD_SILHOUETTE: SilhouetteConfig = {
+  viewBox: '0 0 300 280',
+  locations: {
+    [MechLocation.HEAD]: {
+      x: 115,
+      y: 0,
+      width: 70,
+      height: 45,
+      path: `
+        M 150 0
+        L 175 10
+        L 185 25
+        L 185 40
+        L 165 45
+        L 135 45
+        L 115 40
+        L 115 25
+        L 125 10
+        Z
+      `,
+    },
+    [MechLocation.CENTER_TORSO]: {
+      x: 95,
+      y: 50,
+      width: 110,
+      height: 90,
+      path: `
+        M 110 50
+        L 190 50
+        L 205 65
+        L 205 125
+        L 190 140
+        L 110 140
+        L 95 125
+        L 95 65
+        Z
+      `,
+    },
+    [MechLocation.LEFT_TORSO]: {
+      x: 45,
+      y: 55,
+      width: 48,
+      height: 85,
+      path: `
+        M 93 55
+        L 93 135
+        L 65 140
+        L 45 130
+        L 45 70
+        L 55 55
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_TORSO]: {
+      x: 207,
+      y: 55,
+      width: 48,
+      height: 85,
+      path: `
+        M 207 55
+        L 207 135
+        L 235 140
+        L 255 130
+        L 255 70
+        L 245 55
+        Z
+      `,
+    },
+    [MechLocation.FRONT_LEFT_LEG]: {
+      x: 10,
+      y: 45,
+      width: 35,
+      height: 115,
+      path: `
+        M 35 45
+        L 45 55
+        L 45 95
+        L 40 105
+        L 40 145
+        L 35 160
+        L 15 160
+        L 10 150
+        L 10 95
+        L 15 80
+        L 15 55
+        L 25 45
+        Z
+      `,
+    },
+    [MechLocation.FRONT_RIGHT_LEG]: {
+      x: 255,
+      y: 45,
+      width: 35,
+      height: 115,
+      path: `
+        M 265 45
+        L 255 55
+        L 255 95
+        L 260 105
+        L 260 145
+        L 265 160
+        L 285 160
+        L 290 150
+        L 290 95
+        L 285 80
+        L 285 55
+        L 275 45
+        Z
+      `,
+    },
+    [MechLocation.REAR_LEFT_LEG]: {
+      x: 55,
+      y: 145,
+      width: 40,
+      height: 125,
+      path: `
+        M 75 145
+        L 95 155
+        L 95 200
+        L 90 215
+        L 90 255
+        L 85 270
+        L 60 270
+        L 55 260
+        L 55 205
+        L 60 185
+        L 60 155
+        L 65 145
+        Z
+      `,
+    },
+    [MechLocation.REAR_RIGHT_LEG]: {
+      x: 205,
+      y: 145,
+      width: 40,
+      height: 125,
+      path: `
+        M 225 145
+        L 205 155
+        L 205 200
+        L 210 215
+        L 210 255
+        L 215 270
+        L 240 270
+        L 245 260
+        L 245 205
+        L 240 185
+        L 240 155
+        L 235 145
+        Z
+      `,
+    },
+  },
+  outlinePath: `
+    M 150 0
+    L 175 10
+    L 185 25
+    L 185 50
+    L 245 55
+    L 285 55
+    L 290 95
+    L 290 160
+    L 265 160
+    L 255 145
+    L 255 140
+    L 245 270
+    L 215 270
+    L 205 200
+    L 205 155
+    L 110 155
+    L 95 200
+    L 85 270
+    L 55 270
+    L 45 140
+    L 35 145
+    L 10 160
+    L 10 95
+    L 15 55
+    L 55 55
+    L 115 50
+    L 115 25
+    L 125 10
+    Z
+  `,
+};
+
+/**
+ * Location labels for biped mechs
+ */
+export const LOCATION_LABELS: Partial<Record<MechLocation, string>> = {
   [MechLocation.HEAD]: 'HD',
   [MechLocation.CENTER_TORSO]: 'CT',
   [MechLocation.LEFT_TORSO]: 'LT',
@@ -781,6 +971,20 @@ export const LOCATION_LABELS: Record<MechLocation, string> = {
   [MechLocation.RIGHT_ARM]: 'RA',
   [MechLocation.LEFT_LEG]: 'LL',
   [MechLocation.RIGHT_LEG]: 'RL',
+};
+
+/**
+ * Location labels for quad mechs
+ */
+export const QUAD_LOCATION_LABELS: Partial<Record<MechLocation, string>> = {
+  [MechLocation.HEAD]: 'HD',
+  [MechLocation.CENTER_TORSO]: 'CT',
+  [MechLocation.LEFT_TORSO]: 'LT',
+  [MechLocation.RIGHT_TORSO]: 'RT',
+  [MechLocation.FRONT_LEFT_LEG]: 'FLL',
+  [MechLocation.FRONT_RIGHT_LEG]: 'FRL',
+  [MechLocation.REAR_LEFT_LEG]: 'RLL',
+  [MechLocation.REAR_RIGHT_LEG]: 'RRL',
 };
 
 /**

--- a/src/components/customizer/armor/shared/MechSilhouette.tsx
+++ b/src/components/customizer/armor/shared/MechSilhouette.tsx
@@ -1111,6 +1111,227 @@ export const FIGHTER_LOCATION_LABELS: Partial<Record<MechLocation, string>> = {
 };
 
 /**
+ * Tripod Mech silhouette - three-legged configuration with arms
+ * Standard biped upper body with three legs (left, right, center)
+ */
+export const TRIPOD_SILHOUETTE: SilhouetteConfig = {
+  viewBox: '0 0 300 380',
+  locations: {
+    [MechLocation.HEAD]: {
+      x: 120,
+      y: 5,
+      width: 60,
+      height: 50,
+      path: `
+        M 135 5
+        C 125 5, 120 15, 120 25
+        L 120 45
+        C 120 50, 125 55, 135 55
+        L 165 55
+        C 175 55, 180 50, 180 45
+        L 180 25
+        C 180 15, 175 5, 165 5
+        Z
+      `,
+    },
+    [MechLocation.CENTER_TORSO]: {
+      x: 100,
+      y: 60,
+      width: 100,
+      height: 100,
+      path: `
+        M 115 60
+        L 185 60
+        C 195 60, 200 70, 200 80
+        L 200 140
+        C 200 150, 195 160, 185 160
+        L 115 160
+        C 105 160, 100 150, 100 140
+        L 100 80
+        C 100 70, 105 60, 115 60
+        Z
+      `,
+    },
+    [MechLocation.LEFT_TORSO]: {
+      x: 30,
+      y: 70,
+      width: 65,
+      height: 90,
+      path: `
+        M 45 70
+        L 95 70
+        L 95 150
+        C 95 155, 90 160, 85 160
+        L 45 160
+        C 35 160, 30 155, 30 145
+        L 30 85
+        C 30 75, 35 70, 45 70
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_TORSO]: {
+      x: 205,
+      y: 70,
+      width: 65,
+      height: 90,
+      path: `
+        M 255 70
+        L 205 70
+        L 205 150
+        C 205 155, 210 160, 215 160
+        L 255 160
+        C 265 160, 270 155, 270 145
+        L 270 85
+        C 270 75, 265 70, 255 70
+        Z
+      `,
+    },
+    [MechLocation.LEFT_ARM]: {
+      x: 0,
+      y: 75,
+      width: 28,
+      height: 130,
+      path: `
+        M 8 75
+        L 25 75
+        C 28 75, 28 80, 28 85
+        L 28 185
+        C 28 195, 25 205, 20 205
+        L 8 205
+        C 3 205, 0 195, 0 185
+        L 0 85
+        C 0 80, 3 75, 8 75
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_ARM]: {
+      x: 272,
+      y: 75,
+      width: 28,
+      height: 130,
+      path: `
+        M 292 75
+        L 275 75
+        C 272 75, 272 80, 272 85
+        L 272 185
+        C 272 195, 275 205, 280 205
+        L 292 205
+        C 297 205, 300 195, 300 185
+        L 300 85
+        C 300 80, 297 75, 292 75
+        Z
+      `,
+    },
+    [MechLocation.LEFT_LEG]: {
+      x: 40,
+      y: 170,
+      width: 50,
+      height: 130,
+      path: `
+        M 50 170
+        L 85 170
+        C 90 170, 90 175, 90 180
+        L 90 280
+        C 90 290, 85 300, 75 300
+        L 55 300
+        C 45 300, 40 290, 40 280
+        L 40 180
+        C 40 175, 45 170, 50 170
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_LEG]: {
+      x: 210,
+      y: 170,
+      width: 50,
+      height: 130,
+      path: `
+        M 250 170
+        L 215 170
+        C 210 170, 210 175, 210 180
+        L 210 280
+        C 210 290, 215 300, 225 300
+        L 245 300
+        C 255 300, 260 290, 260 280
+        L 260 180
+        C 260 175, 255 170, 250 170
+        Z
+      `,
+    },
+    [MechLocation.CENTER_LEG]: {
+      x: 125,
+      y: 165,
+      width: 50,
+      height: 145,
+      path: `
+        M 135 165
+        L 165 165
+        C 172 165, 175 172, 175 180
+        L 175 290
+        C 175 302, 168 310, 158 310
+        L 142 310
+        C 132 310, 125 302, 125 290
+        L 125 180
+        C 125 172, 128 165, 135 165
+        Z
+      `,
+    },
+  },
+  outlinePath: `
+    M 150 5
+    C 130 5, 120 20, 120 35
+    L 120 50
+    L 95 60
+    L 30 70
+    L 0 80
+    L 0 205
+    L 28 205
+    L 28 75
+    L 95 70
+    L 95 160
+    L 40 170
+    L 40 300
+    L 90 300
+    L 90 170
+    L 125 165
+    L 125 310
+    L 175 310
+    L 175 165
+    L 210 170
+    L 210 300
+    L 260 300
+    L 260 170
+    L 205 160
+    L 205 70
+    L 272 75
+    L 272 205
+    L 300 205
+    L 300 80
+    L 270 70
+    L 205 60
+    L 180 50
+    L 180 35
+    C 180 20, 170 5, 150 5
+    Z
+  `,
+};
+
+/**
+ * Location labels for tripod mechs
+ */
+export const TRIPOD_LOCATION_LABELS: Partial<Record<MechLocation, string>> = {
+  [MechLocation.HEAD]: 'HD',
+  [MechLocation.CENTER_TORSO]: 'CT',
+  [MechLocation.LEFT_TORSO]: 'LT',
+  [MechLocation.RIGHT_TORSO]: 'RT',
+  [MechLocation.LEFT_ARM]: 'LA',
+  [MechLocation.RIGHT_ARM]: 'RA',
+  [MechLocation.LEFT_LEG]: 'LL',
+  [MechLocation.RIGHT_LEG]: 'RL',
+  [MechLocation.CENTER_LEG]: 'CL',
+};
+
+/**
  * Locations that have rear armor
  */
 export const TORSO_LOCATIONS = [

--- a/src/components/customizer/armor/shared/MechSilhouette.tsx
+++ b/src/components/customizer/armor/shared/MechSilhouette.tsx
@@ -960,6 +960,118 @@ export const QUAD_SILHOUETTE: SilhouetteConfig = {
 };
 
 /**
+ * LAM Fighter Mode silhouette - aerospace fighter configuration
+ * Shows the transformed LAM with Nose, Wings, Aft, and Fuselage
+ */
+export const FIGHTER_SILHOUETTE: SilhouetteConfig = {
+  viewBox: '0 0 300 280',
+  locations: {
+    [MechLocation.NOSE]: {
+      x: 115,
+      y: 0,
+      width: 70,
+      height: 60,
+      path: `
+        M 150 0
+        L 175 15
+        L 185 35
+        L 180 60
+        L 120 60
+        L 115 35
+        L 125 15
+        Z
+      `,
+    },
+    [MechLocation.FUSELAGE]: {
+      x: 105,
+      y: 65,
+      width: 90,
+      height: 150,
+      path: `
+        M 120 65
+        L 180 65
+        L 185 80
+        L 185 200
+        L 175 215
+        L 125 215
+        L 115 200
+        L 115 80
+        Z
+      `,
+    },
+    [MechLocation.LEFT_WING]: {
+      x: 5,
+      y: 70,
+      width: 105,
+      height: 100,
+      path: `
+        M 110 70
+        L 110 140
+        L 70 165
+        L 5 145
+        L 5 120
+        L 50 85
+        L 90 70
+        Z
+      `,
+    },
+    [MechLocation.RIGHT_WING]: {
+      x: 190,
+      y: 70,
+      width: 105,
+      height: 100,
+      path: `
+        M 190 70
+        L 190 140
+        L 230 165
+        L 295 145
+        L 295 120
+        L 250 85
+        L 210 70
+        Z
+      `,
+    },
+    [MechLocation.AFT]: {
+      x: 115,
+      y: 220,
+      width: 70,
+      height: 55,
+      path: `
+        M 125 220
+        L 175 220
+        L 180 235
+        L 185 270
+        L 170 275
+        L 130 275
+        L 115 270
+        L 120 235
+        Z
+      `,
+    },
+  },
+  outlinePath: `
+    M 150 0
+    L 175 15
+    L 185 35
+    L 185 70
+    L 295 120
+    L 295 145
+    L 185 200
+    L 185 270
+    L 170 275
+    L 130 275
+    L 115 270
+    L 115 200
+    L 5 145
+    L 5 120
+    L 115 70
+    L 115 35
+    L 125 15
+    Z
+  `,
+};
+
+/**
  * Location labels for biped mechs
  */
 export const LOCATION_LABELS: Partial<Record<MechLocation, string>> = {
@@ -985,6 +1097,17 @@ export const QUAD_LOCATION_LABELS: Partial<Record<MechLocation, string>> = {
   [MechLocation.FRONT_RIGHT_LEG]: 'FRL',
   [MechLocation.REAR_LEFT_LEG]: 'RLL',
   [MechLocation.REAR_RIGHT_LEG]: 'RRL',
+};
+
+/**
+ * Location labels for LAM fighter mode
+ */
+export const FIGHTER_LOCATION_LABELS: Partial<Record<MechLocation, string>> = {
+  [MechLocation.NOSE]: 'NOS',
+  [MechLocation.FUSELAGE]: 'FUS',
+  [MechLocation.LEFT_WING]: 'LW',
+  [MechLocation.RIGHT_WING]: 'RW',
+  [MechLocation.AFT]: 'AFT',
 };
 
 /**

--- a/src/components/customizer/armor/variants/CleanTechDiagram.tsx
+++ b/src/components/customizer/armor/variants/CleanTechDiagram.tsx
@@ -46,9 +46,13 @@ function CleanTechLocation({
   isHovered,
   onClick,
   onHover,
-}: CleanTechLocationProps): React.ReactElement {
+}: CleanTechLocationProps): React.ReactElement | null {
   const pos = BATTLEMECH_SILHOUETTE.locations[location];
   const label = LOCATION_LABELS[location];
+
+  // Skip rendering if this location is not defined in this silhouette
+  if (!pos) return null;
+
   const center = getLocationCenter(pos);
   const showRear = hasTorsoRear(location);
 

--- a/src/components/customizer/armor/variants/LAMArmorDiagram.tsx
+++ b/src/components/customizer/armor/variants/LAMArmorDiagram.tsx
@@ -1,0 +1,480 @@
+/**
+ * LAM (Land-Air Mech) Armor Diagram
+ *
+ * Design Philosophy: Mode-switchable visualization for transformable mechs
+ * - Mech mode uses standard biped silhouette
+ * - AirMech mode shows hybrid view
+ * - Fighter mode shows aerospace silhouette with mapped armor values
+ * - Mode toggle allows viewing armor allocation in different configurations
+ */
+
+import React, { useState } from 'react';
+import { MechLocation } from '@/types/construction';
+import {
+  LAMMode,
+  LAM_CONFIGURATION,
+  configurationRegistry,
+} from '@/types/construction/MechConfigurationSystem';
+import { LocationArmorData } from '../ArmorDiagram';
+import {
+  REALISTIC_SILHOUETTE,
+  FIGHTER_SILHOUETTE,
+  LOCATION_LABELS,
+  FIGHTER_LOCATION_LABELS,
+  getLocationCenter,
+  hasTorsoRear,
+} from '../shared/MechSilhouette';
+import {
+  GradientDefs,
+  getArmorStatusColor,
+  getTorsoFrontStatusColor,
+  getTorsoRearStatusColor,
+  lightenColor,
+  SELECTED_COLOR,
+  SELECTED_STROKE,
+} from '../shared/ArmorFills';
+import { ArmorDiagramQuickSettings } from '../ArmorDiagramQuickSettings';
+
+interface LAMLocationProps {
+  location: MechLocation;
+  data?: LocationArmorData;
+  isSelected: boolean;
+  isHovered: boolean;
+  onClick: () => void;
+  onHover: (hovered: boolean) => void;
+  isFighterMode: boolean;
+}
+
+function LAMLocation({
+  location,
+  data,
+  isSelected,
+  isHovered,
+  onClick,
+  onHover,
+  isFighterMode,
+}: LAMLocationProps): React.ReactElement | null {
+  const silhouette = isFighterMode ? FIGHTER_SILHOUETTE : REALISTIC_SILHOUETTE;
+  const labels = isFighterMode ? FIGHTER_LOCATION_LABELS : LOCATION_LABELS;
+
+  const pos = silhouette.locations[location];
+  const label = labels[location];
+
+  // Skip rendering if this location is not defined in this silhouette
+  if (!pos) return null;
+
+  const center = getLocationCenter(pos);
+  // Fighter mode doesn't have rear armor on individual locations
+  const showRear = !isFighterMode && hasTorsoRear(location);
+
+  const current = data?.current ?? 0;
+  const maximum = data?.maximum ?? 1;
+  const rear = data?.rear ?? 0;
+  const rearMax = data?.rearMaximum ?? 1;
+
+  // Status-based colors for front and rear independently
+  const frontBaseColor = isSelected
+    ? SELECTED_COLOR
+    : showRear
+      ? getTorsoFrontStatusColor(current, maximum)
+      : getArmorStatusColor(current, maximum);
+  const rearBaseColor = isSelected
+    ? SELECTED_COLOR
+    : getTorsoRearStatusColor(rear, maximum);
+
+  const fillColor = isHovered ? lightenColor(frontBaseColor, 0.15) : frontBaseColor;
+  const rearFillColor = isHovered ? lightenColor(rearBaseColor, 0.15) : rearBaseColor;
+  const strokeColor = isSelected ? SELECTED_STROKE : '#475569';
+  const strokeWidth = isSelected ? 2.5 : 1;
+
+  // Split positions for front/rear - adjusted for divider
+  const dividerHeight = showRear ? 2 : 0;
+  const frontHeight = showRear ? pos.height * 0.65 : pos.height;
+  const rearHeight = showRear ? pos.height * 0.35 - dividerHeight : 0;
+  const dividerY = pos.y + frontHeight;
+  const rearY = dividerY + dividerHeight;
+
+  return (
+    <g
+      role="button"
+      tabIndex={0}
+      aria-label={`${location} armor: ${current} of ${maximum}${showRear ? `, rear: ${rear} of ${rearMax}` : ''}`}
+      aria-pressed={isSelected}
+      className="cursor-pointer focus:outline-none"
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      onMouseEnter={() => onHover(true)}
+      onMouseLeave={() => onHover(false)}
+      onFocus={() => onHover(true)}
+      onBlur={() => onHover(false)}
+    >
+      {/* Front armor section */}
+      {pos.path ? (
+        <path
+          d={pos.path}
+          fill={fillColor}
+          stroke={strokeColor}
+          strokeWidth={strokeWidth}
+          className="transition-all duration-150"
+          style={{
+            clipPath: showRear ? `inset(0 0 ${rearHeight}px 0)` : undefined,
+          }}
+        />
+      ) : (
+        <rect
+          x={pos.x}
+          y={pos.y}
+          width={pos.width}
+          height={frontHeight}
+          rx={6}
+          fill={fillColor}
+          stroke={strokeColor}
+          strokeWidth={strokeWidth}
+          className="transition-all duration-150"
+        />
+      )}
+
+      {/* Front armor value - large bold number */}
+      <text
+        x={center.x}
+        y={pos.y + frontHeight / 2 + 5}
+        textAnchor="middle"
+        className="fill-white font-bold pointer-events-none"
+        style={{ fontSize: pos.width < 40 ? '12px' : '16px' }}
+      >
+        {current}
+      </text>
+
+      {/* Capacity text */}
+      <text
+        x={center.x}
+        y={pos.y + frontHeight / 2 + 16}
+        textAnchor="middle"
+        className="fill-white/60 pointer-events-none"
+        style={{ fontSize: '8px' }}
+      >
+        / {maximum}
+      </text>
+
+      {/* Location label */}
+      <text
+        x={center.x}
+        y={pos.y + 12}
+        textAnchor="middle"
+        className="fill-white/80 font-semibold pointer-events-none"
+        style={{ fontSize: showRear ? '8px' : '9px' }}
+      >
+        {showRear ? `${label} FRONT` : label}
+      </text>
+
+      {/* Divider line between front and rear */}
+      {showRear && (
+        <line
+          x1={pos.x + 4}
+          y1={dividerY + 1}
+          x2={pos.x + pos.width - 4}
+          y2={dividerY + 1}
+          stroke="#334155"
+          strokeWidth={1}
+          strokeDasharray="3 2"
+          className="pointer-events-none"
+        />
+      )}
+
+      {/* Rear armor section for torsos */}
+      {showRear && (
+        <>
+          <rect
+            x={pos.x}
+            y={rearY}
+            width={pos.width}
+            height={rearHeight}
+            rx={6}
+            fill={rearFillColor}
+            stroke={strokeColor}
+            strokeWidth={strokeWidth}
+            className="transition-all duration-150"
+          />
+
+          {/* Rear label */}
+          <text
+            x={center.x}
+            y={rearY + 11}
+            textAnchor="middle"
+            className="fill-white/80 font-semibold pointer-events-none"
+            style={{ fontSize: '8px' }}
+          >
+            REAR
+          </text>
+
+          {/* Rear armor value */}
+          <text
+            x={center.x}
+            y={rearY + rearHeight / 2 + 6}
+            textAnchor="middle"
+            className="fill-white font-bold pointer-events-none"
+            style={{ fontSize: '12px' }}
+          >
+            {rear}
+          </text>
+        </>
+      )}
+    </g>
+  );
+}
+
+export interface LAMArmorDiagramProps {
+  armorData: LocationArmorData[];
+  selectedLocation: MechLocation | null;
+  unallocatedPoints: number;
+  onLocationClick: (location: MechLocation) => void;
+  onAutoAllocate?: () => void;
+  className?: string;
+}
+
+/**
+ * Biped mech locations for LAM Mech mode
+ */
+const MECH_LOCATIONS: MechLocation[] = [
+  MechLocation.HEAD,
+  MechLocation.CENTER_TORSO,
+  MechLocation.LEFT_TORSO,
+  MechLocation.RIGHT_TORSO,
+  MechLocation.LEFT_ARM,
+  MechLocation.RIGHT_ARM,
+  MechLocation.LEFT_LEG,
+  MechLocation.RIGHT_LEG,
+];
+
+/**
+ * Fighter locations for LAM Fighter mode
+ */
+const FIGHTER_LOCATIONS: MechLocation[] = [
+  MechLocation.NOSE,
+  MechLocation.FUSELAGE,
+  MechLocation.LEFT_WING,
+  MechLocation.RIGHT_WING,
+  MechLocation.AFT,
+];
+
+/**
+ * Calculate fighter mode armor values from mech mode armor
+ * Uses the armor location mapping from LAM configuration
+ */
+function calculateFighterArmor(
+  mechArmorData: LocationArmorData[]
+): LocationArmorData[] {
+  const armorMapping = configurationRegistry.getFighterArmorMapping(
+    LAM_CONFIGURATION.id
+  );
+
+  if (!armorMapping) {
+    return [];
+  }
+
+  // Create a map of mech armor data for quick lookup
+  const mechArmorMap = new Map<MechLocation, LocationArmorData>();
+  for (const data of mechArmorData) {
+    mechArmorMap.set(data.location, data);
+  }
+
+  // Calculate fighter armor by summing mapped mech locations
+  const fighterArmor: Map<MechLocation, LocationArmorData> = new Map();
+
+  // Initialize fighter locations
+  for (const fighterLoc of FIGHTER_LOCATIONS) {
+    fighterArmor.set(fighterLoc, {
+      location: fighterLoc,
+      current: 0,
+      maximum: 0,
+    });
+  }
+
+  // Sum armor from mech locations to fighter locations
+  for (const mechLoc of MECH_LOCATIONS) {
+    const fighterLoc = armorMapping[mechLoc];
+    if (!fighterLoc || !FIGHTER_LOCATIONS.includes(fighterLoc)) continue;
+
+    const mechData = mechArmorMap.get(mechLoc);
+    if (!mechData) continue;
+
+    const fighterData = fighterArmor.get(fighterLoc)!;
+
+    // Add front armor + rear armor to the fighter location
+    const totalMechArmor = mechData.current + (mechData.rear ?? 0);
+    const totalMechMax = mechData.maximum + (mechData.rearMaximum ?? 0);
+
+    fighterArmor.set(fighterLoc, {
+      location: fighterLoc,
+      current: fighterData.current + totalMechArmor,
+      maximum: fighterData.maximum + totalMechMax,
+    });
+  }
+
+  return Array.from(fighterArmor.values());
+}
+
+export function LAMArmorDiagram({
+  armorData,
+  selectedLocation,
+  unallocatedPoints,
+  onLocationClick,
+  onAutoAllocate,
+  className = '',
+}: LAMArmorDiagramProps): React.ReactElement {
+  const [hoveredLocation, setHoveredLocation] = useState<MechLocation | null>(null);
+  const [currentMode, setCurrentMode] = useState<LAMMode>(LAMMode.MECH);
+
+  const isFighterMode = currentMode === LAMMode.FIGHTER;
+
+  // Get locations and armor data based on current mode
+  const displayLocations = isFighterMode ? FIGHTER_LOCATIONS : MECH_LOCATIONS;
+  const displayArmorData = isFighterMode
+    ? calculateFighterArmor(armorData)
+    : armorData;
+
+  const getArmorData = (location: MechLocation): LocationArmorData | undefined => {
+    return displayArmorData.find((d) => d.location === location);
+  };
+
+  const isOverAllocated = unallocatedPoints < 0;
+  const silhouette = isFighterMode ? FIGHTER_SILHOUETTE : REALISTIC_SILHOUETTE;
+
+  return (
+    <div className={`bg-surface-base rounded-lg border border-border-theme-subtle p-4 ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <h3 className="text-lg font-semibold text-white">LAM Armor Allocation</h3>
+          <ArmorDiagramQuickSettings />
+        </div>
+        {onAutoAllocate && !isFighterMode && (
+          <button
+            onClick={onAutoAllocate}
+            className={`px-3 py-1.5 text-sm font-medium rounded transition-colors ${
+              isOverAllocated
+                ? 'bg-red-600 hover:bg-red-500 text-white'
+                : 'bg-accent hover:bg-accent text-white'
+            }`}
+          >
+            Auto Allocate ({unallocatedPoints} pts)
+          </button>
+        )}
+      </div>
+
+      {/* Mode Toggle */}
+      <div className="flex justify-center mb-4">
+        <div className="inline-flex rounded-lg bg-surface-subtle p-1">
+          {([LAMMode.MECH, LAMMode.AIRMECH, LAMMode.FIGHTER] as LAMMode[]).map((mode) => (
+            <button
+              key={mode}
+              onClick={() => setCurrentMode(mode)}
+              className={`px-3 py-1.5 text-sm font-medium rounded transition-colors ${
+                currentMode === mode
+                  ? 'bg-accent text-white'
+                  : 'text-text-theme-secondary hover:text-white'
+              }`}
+            >
+              {mode}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Mode Description */}
+      {isFighterMode && (
+        <div className="text-center text-xs text-text-theme-secondary mb-3">
+          Fighter mode armor is calculated from Mech mode allocation
+        </div>
+      )}
+
+      {/* Diagram */}
+      <div className="relative">
+        <svg
+          viewBox={silhouette.viewBox}
+          className="w-full max-w-[300px] mx-auto"
+          style={{ height: 'auto' }}
+        >
+          <GradientDefs />
+
+          {/* Background grid pattern */}
+          <rect
+            x="0"
+            y="0"
+            width="300"
+            height="280"
+            fill="url(#armor-grid)"
+            opacity="0.5"
+          />
+
+          {/* Render all locations for current mode */}
+          {displayLocations.map((loc) => (
+            <LAMLocation
+              key={loc}
+              location={loc}
+              data={getArmorData(loc)}
+              isSelected={selectedLocation === loc}
+              isHovered={hoveredLocation === loc}
+              onClick={() => !isFighterMode && onLocationClick(loc)}
+              onHover={(h) => setHoveredLocation(h ? loc : null)}
+              isFighterMode={isFighterMode}
+            />
+          ))}
+        </svg>
+      </div>
+
+      {/* Legend */}
+      <div className="flex justify-center gap-3 mt-4 text-xs">
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-green-500" />
+          <span className="text-text-theme-secondary">75%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-amber-500" />
+          <span className="text-text-theme-secondary">50%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-orange-500" />
+          <span className="text-text-theme-secondary">25%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-red-500" />
+          <span className="text-text-theme-secondary">&lt;25%</span>
+        </div>
+      </div>
+
+      {/* Location Key */}
+      <div className="mt-3 pt-3 border-t border-border-theme-subtle">
+        {isFighterMode ? (
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-text-theme-secondary">
+            <div>NOS = Nose</div>
+            <div>FUS = Fuselage</div>
+            <div>LW = Left Wing</div>
+            <div>RW = Right Wing</div>
+            <div>AFT = Aft</div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-text-theme-secondary">
+            <div>HD = Head</div>
+            <div>CT = Center Torso</div>
+            <div>LT/RT = Left/Right Torso</div>
+            <div>LA/RA = Left/Right Arm</div>
+            <div>LL/RL = Left/Right Leg</div>
+          </div>
+        )}
+      </div>
+
+      {/* Instructions */}
+      <p className="text-xs text-text-theme-secondary text-center mt-2">
+        {isFighterMode
+          ? 'Switch to Mech mode to edit armor values'
+          : 'Click a location to edit armor values'}
+      </p>
+    </div>
+  );
+}

--- a/src/components/customizer/armor/variants/NeonOperatorDiagram.tsx
+++ b/src/components/customizer/armor/variants/NeonOperatorDiagram.tsx
@@ -89,7 +89,7 @@ interface NeonLocationProps {
 
 // Calculate leg offset based on torso height expansion
 const TORSO_HEIGHT_MULTIPLIER = 1.4;
-const LEG_Y_OFFSET = BATTLEMECH_SILHOUETTE.locations[MechLocation.CENTER_TORSO].height * (TORSO_HEIGHT_MULTIPLIER - 1);
+const LEG_Y_OFFSET = BATTLEMECH_SILHOUETTE.locations[MechLocation.CENTER_TORSO]!.height * (TORSO_HEIGHT_MULTIPLIER - 1);
 
 function isLegLocation(location: MechLocation): boolean {
   return location === MechLocation.LEFT_LEG || location === MechLocation.RIGHT_LEG;
@@ -102,8 +102,11 @@ function NeonLocation({
   isHovered,
   onClick,
   onHover,
-}: NeonLocationProps): React.ReactElement {
+}: NeonLocationProps): React.ReactElement | null {
   const basePos = BATTLEMECH_SILHOUETTE.locations[location];
+
+  // Skip rendering if this location is not defined in this silhouette
+  if (!basePos) return null;
   const label = LOCATION_LABELS[location];
   const showRear = hasTorsoRear(location);
 
@@ -444,11 +447,11 @@ export function NeonOperatorDiagram({
           ))}
 
           {/* Targeting reticle on hovered */}
-          {hoveredLocation && (
+          {hoveredLocation && BATTLEMECH_SILHOUETTE.locations[hoveredLocation] && (
             <g className="pointer-events-none">
               <circle
-                cx={getLocationCenter(BATTLEMECH_SILHOUETTE.locations[hoveredLocation]).x}
-                cy={getLocationCenter(BATTLEMECH_SILHOUETTE.locations[hoveredLocation]).y}
+                cx={getLocationCenter(BATTLEMECH_SILHOUETTE.locations[hoveredLocation]!).x}
+                cy={getLocationCenter(BATTLEMECH_SILHOUETTE.locations[hoveredLocation]!).y}
                 r={40}
                 fill="none"
                 stroke="rgba(34, 211, 238, 0.3)"

--- a/src/components/customizer/armor/variants/PremiumMaterialDiagram.tsx
+++ b/src/components/customizer/armor/variants/PremiumMaterialDiagram.tsx
@@ -152,15 +152,19 @@ function PremiumLocation({
   isHovered,
   onClick,
   onHover,
-}: PremiumLocationProps): React.ReactElement {
+}: PremiumLocationProps): React.ReactElement | null {
   const basePos = BATTLEMECH_SILHOUETTE.locations[location];
+
+  // Skip rendering if this location is not defined in this silhouette
+  if (!basePos) return null;
+
   const label = LOCATION_LABELS[location];
   const showRear = hasTorsoRear(location);
   const isLeg = location === MechLocation.LEFT_LEG || location === MechLocation.RIGHT_LEG;
 
   // Adjust height for torso locations to fit stacked layout, offset legs down
   const TORSO_MULTIPLIER = 1.4;
-  const legOffset = BATTLEMECH_SILHOUETTE.locations[MechLocation.CENTER_TORSO].height * (TORSO_MULTIPLIER - 1);
+  const legOffset = BATTLEMECH_SILHOUETTE.locations[MechLocation.CENTER_TORSO]!.height * (TORSO_MULTIPLIER - 1);
   const pos = showRear
     ? { ...basePos, height: basePos.height * TORSO_MULTIPLIER }
     : isLeg

--- a/src/components/customizer/armor/variants/QuadArmorDiagram.tsx
+++ b/src/components/customizer/armor/variants/QuadArmorDiagram.tsx
@@ -1,32 +1,34 @@
 /**
- * MegaMek Armor Diagram
+ * Quad Mech Armor Diagram
  *
- * Design Philosophy: Authentic MegaMek record sheet appearance
- * - Layered rendering: shadow → fill → outline for depth
- * - Detailed mech silhouette with hand actuators and knee joints
- * - Classic record sheet proportions and styling
- * - Clean, professional appearance matching PDF output
+ * Design Philosophy: Clear visualization for four-legged mechs
+ * - Quad mech silhouette with four legs instead of arms
+ * - Same status colors and interaction patterns as biped diagrams
+ * - Front/rear armor display for torsos
+ * - Distinct labels for all four legs (FLL, FRL, RLL, RRL)
  */
 
 import React, { useState } from 'react';
 import { MechLocation } from '@/types/construction';
 import { LocationArmorData } from '../ArmorDiagram';
 import {
-  MEGAMEK_SILHOUETTE,
-  LOCATION_LABELS,
+  QUAD_SILHOUETTE,
+  QUAD_LOCATION_LABELS,
   getLocationCenter,
   hasTorsoRear,
 } from '../shared/MechSilhouette';
 import {
+  GradientDefs,
   getArmorStatusColor,
   getTorsoFrontStatusColor,
   getTorsoRearStatusColor,
   lightenColor,
   SELECTED_COLOR,
+  SELECTED_STROKE,
 } from '../shared/ArmorFills';
 import { ArmorDiagramQuickSettings } from '../ArmorDiagramQuickSettings';
 
-interface MegaMekLocationProps {
+interface QuadLocationProps {
   location: MechLocation;
   data?: LocationArmorData;
   isSelected: boolean;
@@ -35,16 +37,16 @@ interface MegaMekLocationProps {
   onHover: (hovered: boolean) => void;
 }
 
-function MegaMekLocation({
+function QuadLocation({
   location,
   data,
   isSelected,
   isHovered,
   onClick,
   onHover,
-}: MegaMekLocationProps): React.ReactElement | null {
-  const pos = MEGAMEK_SILHOUETTE.locations[location];
-  const label = LOCATION_LABELS[location];
+}: QuadLocationProps): React.ReactElement | null {
+  const pos = QUAD_SILHOUETTE.locations[location];
+  const label = QUAD_LOCATION_LABELS[location];
 
   // Skip rendering if this location is not defined in this silhouette
   if (!pos) return null;
@@ -67,15 +69,17 @@ function MegaMekLocation({
     ? SELECTED_COLOR
     : getTorsoRearStatusColor(rear, maximum);
 
-  const fillColor = isHovered ? lightenColor(frontBaseColor, 0.1) : frontBaseColor;
-  const shadowColor = '#1a1a1a';
-  const outlineColor = isSelected ? '#fbbf24' : '#000000';
-  const outlineWidth = isSelected ? 2 : 1.2;
+  const fillColor = isHovered ? lightenColor(frontBaseColor, 0.15) : frontBaseColor;
+  const rearFillColor = isHovered ? lightenColor(rearBaseColor, 0.15) : rearBaseColor;
+  const strokeColor = isSelected ? SELECTED_STROKE : '#475569';
+  const strokeWidth = isSelected ? 2.5 : 1;
 
-  // Split heights for front/rear display
+  // Split positions for front/rear - adjusted for divider
+  const dividerHeight = showRear ? 2 : 0;
   const frontHeight = showRear ? pos.height * 0.65 : pos.height;
-  const rearHeight = showRear ? pos.height * 0.35 : 0;
+  const rearHeight = showRear ? pos.height * 0.35 - dividerHeight : 0;
   const dividerY = pos.y + frontHeight;
+  const rearY = dividerY + dividerHeight;
 
   return (
     <g
@@ -96,25 +100,17 @@ function MegaMekLocation({
       onFocus={() => onHover(true)}
       onBlur={() => onHover(false)}
     >
-      {/* Layer 1: Shadow (offset for depth) */}
-      {pos.path && (
-        <path
-          d={pos.path}
-          fill={shadowColor}
-          stroke="none"
-          className="pointer-events-none"
-          transform="translate(2, 2)"
-          opacity={0.3}
-        />
-      )}
-
-      {/* Layer 2: Fill */}
+      {/* Front armor section */}
       {pos.path ? (
         <path
           d={pos.path}
           fill={fillColor}
-          stroke="none"
+          stroke={strokeColor}
+          strokeWidth={strokeWidth}
           className="transition-all duration-150"
+          style={{
+            clipPath: showRear ? `inset(0 0 ${rearHeight}px 0)` : undefined,
+          }}
         />
       ) : (
         <rect
@@ -122,124 +118,83 @@ function MegaMekLocation({
           y={pos.y}
           width={pos.width}
           height={frontHeight}
-          rx={4}
+          rx={6}
           fill={fillColor}
+          stroke={strokeColor}
+          strokeWidth={strokeWidth}
           className="transition-all duration-150"
         />
       )}
 
-      {/* Layer 3: Outline */}
-      {pos.path ? (
-        <path
-          d={pos.path}
-          fill="none"
-          stroke={outlineColor}
-          strokeWidth={outlineWidth}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-          className="transition-all duration-150"
-        />
-      ) : (
-        <rect
-          x={pos.x}
-          y={pos.y}
-          width={pos.width}
-          height={frontHeight}
-          rx={4}
-          fill="none"
-          stroke={outlineColor}
-          strokeWidth={outlineWidth}
-        />
-      )}
-
-      {/* Detail lines for mechanical look */}
-      {/* Detail lines removed for cleaner MegaMek style */}
-
-      {/* Front armor section labels and values */}
+      {/* Front armor value - large bold number */}
       <text
         x={center.x}
-        y={showRear ? pos.y + 14 : pos.y + 14}
-        textAnchor="middle"
-        className="fill-white/80 font-semibold pointer-events-none"
-        style={{
-          fontSize: showRear ? '9px' : '10px',
-          textShadow: '0 1px 2px rgba(0,0,0,0.8)',
-        }}
-      >
-        {showRear ? `${label} FRONT` : label}
-      </text>
-
-      <text
-        x={center.x}
-        y={showRear ? pos.y + frontHeight / 2 + 8 : pos.y + pos.height / 2 + 10}
+        y={pos.y + frontHeight / 2 + 5}
         textAnchor="middle"
         className="fill-white font-bold pointer-events-none"
-        style={{
-          fontSize: pos.width < 40 ? '16px' : '20px',
-          textShadow: '0 1px 3px rgba(0,0,0,0.9)',
-        }}
+        style={{ fontSize: pos.width < 40 ? '12px' : '16px' }}
       >
         {current}
       </text>
 
+      {/* Capacity text */}
       <text
         x={center.x}
-        y={showRear ? pos.y + frontHeight / 2 + 22 : pos.y + pos.height / 2 + 24}
+        y={pos.y + frontHeight / 2 + 16}
         textAnchor="middle"
         className="fill-white/60 pointer-events-none"
-        style={{ fontSize: '9px' }}
+        style={{ fontSize: '8px' }}
       >
         / {maximum}
       </text>
 
+      {/* Location label */}
+      <text
+        x={center.x}
+        y={pos.y + 12}
+        textAnchor="middle"
+        className="fill-white/80 font-semibold pointer-events-none"
+        style={{ fontSize: showRear ? '8px' : '9px' }}
+      >
+        {showRear ? `${label} FRONT` : label}
+      </text>
+
+      {/* Divider line between front and rear */}
+      {showRear && (
+        <line
+          x1={pos.x + 4}
+          y1={dividerY + 1}
+          x2={pos.x + pos.width - 4}
+          y2={dividerY + 1}
+          stroke="#334155"
+          strokeWidth={1}
+          strokeDasharray="3 2"
+          className="pointer-events-none"
+        />
+      )}
+
       {/* Rear armor section for torsos */}
       {showRear && (
         <>
-          {/* Rear divider line */}
-          <line
-            x1={pos.x + 8}
-            y1={dividerY}
-            x2={pos.x + pos.width - 8}
-            y2={dividerY}
-            stroke="#475569"
-            strokeWidth={1}
-            strokeDasharray="4 2"
-            className="pointer-events-none"
-          />
-
-          {/* Rear fill overlay */}
           <rect
             x={pos.x}
-            y={dividerY}
+            y={rearY}
             width={pos.width}
             height={rearHeight}
-            rx={4}
-            fill={isHovered ? lightenColor(rearBaseColor, 0.1) : rearBaseColor}
+            rx={6}
+            fill={rearFillColor}
+            stroke={strokeColor}
+            strokeWidth={strokeWidth}
             className="transition-all duration-150"
-          />
-
-          {/* Rear outline */}
-          <rect
-            x={pos.x}
-            y={dividerY}
-            width={pos.width}
-            height={rearHeight}
-            rx={4}
-            fill="none"
-            stroke={outlineColor}
-            strokeWidth={outlineWidth}
           />
 
           {/* Rear label */}
           <text
             x={center.x}
-            y={dividerY + 12}
+            y={rearY + 11}
             textAnchor="middle"
             className="fill-white/80 font-semibold pointer-events-none"
-            style={{
-              fontSize: '8px',
-              textShadow: '0 1px 2px rgba(0,0,0,0.8)',
-            }}
+            style={{ fontSize: '8px' }}
           >
             REAR
           </text>
@@ -247,13 +202,10 @@ function MegaMekLocation({
           {/* Rear armor value */}
           <text
             x={center.x}
-            y={dividerY + rearHeight / 2 + 8}
+            y={rearY + rearHeight / 2 + 6}
             textAnchor="middle"
             className="fill-white font-bold pointer-events-none"
-            style={{
-              fontSize: '16px',
-              textShadow: '0 1px 3px rgba(0,0,0,0.9)',
-            }}
+            style={{ fontSize: '12px' }}
           >
             {rear}
           </text>
@@ -263,7 +215,7 @@ function MegaMekLocation({
   );
 }
 
-export interface MegaMekDiagramProps {
+export interface QuadArmorDiagramProps {
   armorData: LocationArmorData[];
   selectedLocation: MechLocation | null;
   unallocatedPoints: number;
@@ -272,14 +224,28 @@ export interface MegaMekDiagramProps {
   className?: string;
 }
 
-export function MegaMekDiagram({
+/**
+ * Quad mech locations in display order
+ */
+const QUAD_LOCATIONS: MechLocation[] = [
+  MechLocation.HEAD,
+  MechLocation.CENTER_TORSO,
+  MechLocation.LEFT_TORSO,
+  MechLocation.RIGHT_TORSO,
+  MechLocation.FRONT_LEFT_LEG,
+  MechLocation.FRONT_RIGHT_LEG,
+  MechLocation.REAR_LEFT_LEG,
+  MechLocation.REAR_RIGHT_LEG,
+];
+
+export function QuadArmorDiagram({
   armorData,
   selectedLocation,
   unallocatedPoints,
   onLocationClick,
   onAutoAllocate,
   className = '',
-}: MegaMekDiagramProps): React.ReactElement {
+}: QuadArmorDiagramProps): React.ReactElement {
   const [hoveredLocation, setHoveredLocation] = useState<MechLocation | null>(null);
 
   const getArmorData = (location: MechLocation): LocationArmorData | undefined => {
@@ -288,23 +254,12 @@ export function MegaMekDiagram({
 
   const isOverAllocated = unallocatedPoints < 0;
 
-  const locations: MechLocation[] = [
-    MechLocation.HEAD,
-    MechLocation.CENTER_TORSO,
-    MechLocation.LEFT_TORSO,
-    MechLocation.RIGHT_TORSO,
-    MechLocation.LEFT_ARM,
-    MechLocation.RIGHT_ARM,
-    MechLocation.LEFT_LEG,
-    MechLocation.RIGHT_LEG,
-  ];
-
   return (
     <div className={`bg-surface-base rounded-lg border border-border-theme-subtle p-4 ${className}`}>
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
-          <h3 className="text-lg font-semibold text-text-theme-primary">Armor Allocation</h3>
+          <h3 className="text-lg font-semibold text-white">Quad Armor Allocation</h3>
           <ArmorDiagramQuickSettings />
         </div>
         {onAutoAllocate && (
@@ -313,7 +268,7 @@ export function MegaMekDiagram({
             className={`px-3 py-1.5 text-sm font-medium rounded transition-colors ${
               isOverAllocated
                 ? 'bg-red-600 hover:bg-red-500 text-white'
-                : 'bg-accent hover:bg-accent-hover text-white'
+                : 'bg-accent hover:bg-accent text-white'
             }`}
           >
             Auto Allocate ({unallocatedPoints} pts)
@@ -324,46 +279,25 @@ export function MegaMekDiagram({
       {/* Diagram */}
       <div className="relative">
         <svg
-          viewBox={MEGAMEK_SILHOUETTE.viewBox}
-          className="w-full max-w-[280px] mx-auto"
+          viewBox={QUAD_SILHOUETTE.viewBox}
+          className="w-full max-w-[300px] mx-auto"
           style={{ height: 'auto' }}
         >
-          <defs>
-            {/* Grid pattern for background */}
-            <pattern id="megamek-grid" width="10" height="10" patternUnits="userSpaceOnUse">
-              <path
-                d="M 10 0 L 0 0 0 10"
-                fill="none"
-                stroke="rgba(255,255,255,0.03)"
-                strokeWidth="0.5"
-              />
-            </pattern>
-          </defs>
+          <GradientDefs />
 
-          {/* Background */}
+          {/* Background grid pattern */}
           <rect
             x="0"
             y="0"
-            width="200"
-            height="320"
-            fill="url(#megamek-grid)"
+            width="300"
+            height="280"
+            fill="url(#armor-grid)"
+            opacity="0.5"
           />
 
-          {/* Mech outline (faint wireframe) */}
-          {MEGAMEK_SILHOUETTE.outlinePath && (
-            <path
-              d={MEGAMEK_SILHOUETTE.outlinePath}
-              fill="none"
-              stroke="rgba(100, 116, 139, 0.15)"
-              strokeWidth="1"
-              strokeDasharray="6 3"
-              className="pointer-events-none"
-            />
-          )}
-
-          {/* Render all locations */}
-          {locations.map((loc) => (
-            <MegaMekLocation
+          {/* Render all quad locations */}
+          {QUAD_LOCATIONS.map((loc) => (
+            <QuadLocation
               key={loc}
               location={loc}
               data={getArmorData(loc)}
@@ -393,6 +327,16 @@ export function MegaMekDiagram({
         <div className="flex items-center gap-1.5">
           <div className="w-3 h-3 rounded bg-red-500" />
           <span className="text-text-theme-secondary">&lt;25%</span>
+        </div>
+      </div>
+
+      {/* Location Key */}
+      <div className="mt-3 pt-3 border-t border-border-theme-subtle">
+        <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-text-theme-secondary">
+          <div>FLL = Front Left Leg</div>
+          <div>FRL = Front Right Leg</div>
+          <div>RLL = Rear Left Leg</div>
+          <div>RRL = Rear Right Leg</div>
         </div>
       </div>
 

--- a/src/components/customizer/armor/variants/QuadVeeArmorDiagram.tsx
+++ b/src/components/customizer/armor/variants/QuadVeeArmorDiagram.tsx
@@ -1,0 +1,427 @@
+/**
+ * QuadVee Armor Diagram
+ *
+ * Design Philosophy: Transformable quad mech visualization
+ * - Mode toggle between Mech (quad legs) and Vehicle (tracked) modes
+ * - Same 8 locations as standard quad in both modes
+ * - Different silhouette representation per mode
+ * - Status colors and interaction patterns consistent with other diagrams
+ */
+
+import React, { useState } from 'react';
+import { MechLocation } from '@/types/construction';
+import { QuadVeeMode, QUADVEE_MODES } from '@/types/construction/MechConfigurationSystem';
+import { LocationArmorData } from '../ArmorDiagram';
+import {
+  QUAD_SILHOUETTE,
+  QUAD_LOCATION_LABELS,
+  getLocationCenter,
+  hasTorsoRear,
+} from '../shared/MechSilhouette';
+import {
+  GradientDefs,
+  getArmorStatusColor,
+  getTorsoFrontStatusColor,
+  getTorsoRearStatusColor,
+  lightenColor,
+  SELECTED_COLOR,
+  SELECTED_STROKE,
+} from '../shared/ArmorFills';
+import { ArmorDiagramQuickSettings } from '../ArmorDiagramQuickSettings';
+
+interface QuadVeeLocationProps {
+  location: MechLocation;
+  data?: LocationArmorData;
+  isSelected: boolean;
+  isHovered: boolean;
+  onClick: () => void;
+  onHover: (hovered: boolean) => void;
+  mode: QuadVeeMode;
+}
+
+function QuadVeeLocation({
+  location,
+  data,
+  isSelected,
+  isHovered,
+  onClick,
+  onHover,
+  mode,
+}: QuadVeeLocationProps): React.ReactElement | null {
+  const pos = QUAD_SILHOUETTE.locations[location];
+  const label = QUAD_LOCATION_LABELS[location];
+
+  // Skip rendering if this location is not defined in this silhouette
+  if (!pos) return null;
+
+  const center = getLocationCenter(pos);
+  const showRear = hasTorsoRear(location);
+
+  const current = data?.current ?? 0;
+  const maximum = data?.maximum ?? 1;
+  const rear = data?.rear ?? 0;
+  const rearMax = data?.rearMaximum ?? 1;
+
+  // Status-based colors for front and rear independently
+  const frontBaseColor = isSelected
+    ? SELECTED_COLOR
+    : showRear
+      ? getTorsoFrontStatusColor(current, maximum)
+      : getArmorStatusColor(current, maximum);
+  const rearBaseColor = isSelected
+    ? SELECTED_COLOR
+    : getTorsoRearStatusColor(rear, maximum);
+
+  const fillColor = isHovered ? lightenColor(frontBaseColor, 0.15) : frontBaseColor;
+  const rearFillColor = isHovered ? lightenColor(rearBaseColor, 0.15) : rearBaseColor;
+  const strokeColor = isSelected ? SELECTED_STROKE : '#475569';
+  const strokeWidth = isSelected ? 2.5 : 1;
+
+  // Split positions for front/rear - adjusted for divider
+  const dividerHeight = showRear ? 2 : 0;
+  const frontHeight = showRear ? pos.height * 0.65 : pos.height;
+  const rearHeight = showRear ? pos.height * 0.35 - dividerHeight : 0;
+  const dividerY = pos.y + frontHeight;
+  const rearY = dividerY + dividerHeight;
+
+  // Vehicle mode: add visual indication (wheels/treads)
+  const isLeg = [
+    MechLocation.FRONT_LEFT_LEG,
+    MechLocation.FRONT_RIGHT_LEG,
+    MechLocation.REAR_LEFT_LEG,
+    MechLocation.REAR_RIGHT_LEG,
+  ].includes(location);
+
+  return (
+    <g
+      role="button"
+      tabIndex={0}
+      aria-label={`${location} armor: ${current} of ${maximum}${showRear ? `, rear: ${rear} of ${rearMax}` : ''}`}
+      aria-pressed={isSelected}
+      className="cursor-pointer focus:outline-none"
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      onMouseEnter={() => onHover(true)}
+      onMouseLeave={() => onHover(false)}
+      onFocus={() => onHover(true)}
+      onBlur={() => onHover(false)}
+    >
+      {/* Front armor section */}
+      {pos.path ? (
+        <path
+          d={pos.path}
+          fill={fillColor}
+          stroke={strokeColor}
+          strokeWidth={strokeWidth}
+          className="transition-all duration-150"
+          style={{
+            clipPath: showRear ? `inset(0 0 ${rearHeight}px 0)` : undefined,
+          }}
+        />
+      ) : (
+        <rect
+          x={pos.x}
+          y={pos.y}
+          width={pos.width}
+          height={frontHeight}
+          rx={6}
+          fill={fillColor}
+          stroke={strokeColor}
+          strokeWidth={strokeWidth}
+          className="transition-all duration-150"
+        />
+      )}
+
+      {/* Vehicle mode: wheel/tread indicator on legs */}
+      {mode === QuadVeeMode.VEHICLE && isLeg && (
+        <>
+          {/* Track indicator */}
+          <rect
+            x={pos.x + 2}
+            y={pos.y + pos.height - 18}
+            width={pos.width - 4}
+            height={14}
+            rx={4}
+            fill="#374151"
+            stroke="#6B7280"
+            strokeWidth={1}
+            className="pointer-events-none"
+          />
+          {/* Track ridges */}
+          <line
+            x1={pos.x + 6}
+            y1={pos.y + pos.height - 11}
+            x2={pos.x + pos.width - 6}
+            y2={pos.y + pos.height - 11}
+            stroke="#6B7280"
+            strokeWidth={1}
+            strokeDasharray="4 2"
+            className="pointer-events-none"
+          />
+        </>
+      )}
+
+      {/* Front armor value - large bold number */}
+      <text
+        x={center.x}
+        y={pos.y + frontHeight / 2 + 5}
+        textAnchor="middle"
+        className="fill-white font-bold pointer-events-none"
+        style={{ fontSize: pos.width < 40 ? '12px' : '16px' }}
+      >
+        {current}
+      </text>
+
+      {/* Capacity text */}
+      <text
+        x={center.x}
+        y={pos.y + frontHeight / 2 + 16}
+        textAnchor="middle"
+        className="fill-white/60 pointer-events-none"
+        style={{ fontSize: '8px' }}
+      >
+        / {maximum}
+      </text>
+
+      {/* Location label */}
+      <text
+        x={center.x}
+        y={pos.y + 12}
+        textAnchor="middle"
+        className="fill-white/80 font-semibold pointer-events-none"
+        style={{ fontSize: showRear ? '8px' : '9px' }}
+      >
+        {showRear ? `${label} FRONT` : label}
+      </text>
+
+      {/* Divider line between front and rear */}
+      {showRear && (
+        <line
+          x1={pos.x + 4}
+          y1={dividerY + 1}
+          x2={pos.x + pos.width - 4}
+          y2={dividerY + 1}
+          stroke="#334155"
+          strokeWidth={1}
+          strokeDasharray="3 2"
+          className="pointer-events-none"
+        />
+      )}
+
+      {/* Rear armor section for torsos */}
+      {showRear && (
+        <>
+          <rect
+            x={pos.x}
+            y={rearY}
+            width={pos.width}
+            height={rearHeight}
+            rx={6}
+            fill={rearFillColor}
+            stroke={strokeColor}
+            strokeWidth={strokeWidth}
+            className="transition-all duration-150"
+          />
+
+          {/* Rear label */}
+          <text
+            x={center.x}
+            y={rearY + 11}
+            textAnchor="middle"
+            className="fill-white/80 font-semibold pointer-events-none"
+            style={{ fontSize: '8px' }}
+          >
+            REAR
+          </text>
+
+          {/* Rear armor value */}
+          <text
+            x={center.x}
+            y={rearY + rearHeight / 2 + 6}
+            textAnchor="middle"
+            className="fill-white font-bold pointer-events-none"
+            style={{ fontSize: '12px' }}
+          >
+            {rear}
+          </text>
+        </>
+      )}
+    </g>
+  );
+}
+
+export interface QuadVeeArmorDiagramProps {
+  armorData: LocationArmorData[];
+  selectedLocation: MechLocation | null;
+  unallocatedPoints: number;
+  onLocationClick: (location: MechLocation) => void;
+  onAutoAllocate?: () => void;
+  className?: string;
+  initialMode?: QuadVeeMode;
+  onModeChange?: (mode: QuadVeeMode) => void;
+}
+
+/**
+ * QuadVee mech locations in display order
+ */
+const QUADVEE_LOCATIONS: MechLocation[] = [
+  MechLocation.HEAD,
+  MechLocation.CENTER_TORSO,
+  MechLocation.LEFT_TORSO,
+  MechLocation.RIGHT_TORSO,
+  MechLocation.FRONT_LEFT_LEG,
+  MechLocation.FRONT_RIGHT_LEG,
+  MechLocation.REAR_LEFT_LEG,
+  MechLocation.REAR_RIGHT_LEG,
+];
+
+export function QuadVeeArmorDiagram({
+  armorData,
+  selectedLocation,
+  unallocatedPoints,
+  onLocationClick,
+  onAutoAllocate,
+  className = '',
+  initialMode = QuadVeeMode.MECH,
+  onModeChange,
+}: QuadVeeArmorDiagramProps): React.ReactElement {
+  const [hoveredLocation, setHoveredLocation] = useState<MechLocation | null>(null);
+  const [currentMode, setCurrentMode] = useState<QuadVeeMode>(initialMode);
+
+  const handleModeChange = (mode: QuadVeeMode) => {
+    setCurrentMode(mode);
+    onModeChange?.(mode);
+  };
+
+  const getArmorData = (location: MechLocation): LocationArmorData | undefined => {
+    return armorData.find((d) => d.location === location);
+  };
+
+  const isOverAllocated = unallocatedPoints < 0;
+
+  return (
+    <div className={`bg-surface-base rounded-lg border border-border-theme-subtle p-4 ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <h3 className="text-lg font-semibold text-white">QuadVee Armor Allocation</h3>
+          <ArmorDiagramQuickSettings />
+        </div>
+        {onAutoAllocate && (
+          <button
+            onClick={onAutoAllocate}
+            className={`px-3 py-1.5 text-sm font-medium rounded transition-colors ${
+              isOverAllocated
+                ? 'bg-red-600 hover:bg-red-500 text-white'
+                : 'bg-accent hover:bg-accent text-white'
+            }`}
+          >
+            Auto Allocate ({unallocatedPoints} pts)
+          </button>
+        )}
+      </div>
+
+      {/* Mode Toggle */}
+      <div className="flex justify-center mb-4">
+        <div className="inline-flex rounded-lg bg-surface-elevated p-1 gap-1">
+          {QUADVEE_MODES.map((modeDefinition) => (
+            <button
+              key={modeDefinition.mode}
+              onClick={() => handleModeChange(modeDefinition.mode)}
+              className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+                currentMode === modeDefinition.mode
+                  ? 'bg-accent text-white'
+                  : 'text-text-theme-secondary hover:text-white hover:bg-surface-base'
+              }`}
+              title={modeDefinition.description}
+            >
+              {modeDefinition.displayName}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Mode Description */}
+      <p className="text-xs text-text-theme-secondary text-center mb-3">
+        {currentMode === QuadVeeMode.MECH
+          ? 'Mech Mode: Standard quad mech movement'
+          : 'Vehicle Mode: Tracked vehicle movement'}
+      </p>
+
+      {/* Diagram */}
+      <div className="relative">
+        <svg
+          viewBox={QUAD_SILHOUETTE.viewBox}
+          className="w-full max-w-[300px] mx-auto"
+          style={{ height: 'auto' }}
+        >
+          <GradientDefs />
+
+          {/* Background grid pattern */}
+          <rect
+            x="0"
+            y="0"
+            width="300"
+            height="280"
+            fill="url(#armor-grid)"
+            opacity="0.5"
+          />
+
+          {/* Render all QuadVee locations */}
+          {QUADVEE_LOCATIONS.map((loc) => (
+            <QuadVeeLocation
+              key={loc}
+              location={loc}
+              data={getArmorData(loc)}
+              isSelected={selectedLocation === loc}
+              isHovered={hoveredLocation === loc}
+              onClick={() => onLocationClick(loc)}
+              onHover={(h) => setHoveredLocation(h ? loc : null)}
+              mode={currentMode}
+            />
+          ))}
+        </svg>
+      </div>
+
+      {/* Legend */}
+      <div className="flex justify-center gap-3 mt-4 text-xs">
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-green-500" />
+          <span className="text-text-theme-secondary">75%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-amber-500" />
+          <span className="text-text-theme-secondary">50%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-orange-500" />
+          <span className="text-text-theme-secondary">25%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-red-500" />
+          <span className="text-text-theme-secondary">&lt;25%</span>
+        </div>
+      </div>
+
+      {/* Location Key */}
+      <div className="mt-3 pt-3 border-t border-border-theme-subtle">
+        <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-text-theme-secondary">
+          <div>FLL = Front Left Leg</div>
+          <div>FRL = Front Right Leg</div>
+          <div>RLL = Rear Left Leg</div>
+          <div>RRL = Rear Right Leg</div>
+        </div>
+      </div>
+
+      {/* Instructions */}
+      <p className="text-xs text-text-theme-secondary text-center mt-2">
+        Click a location to edit armor values
+      </p>
+    </div>
+  );
+}

--- a/src/components/customizer/armor/variants/TacticalHUDDiagram.tsx
+++ b/src/components/customizer/armor/variants/TacticalHUDDiagram.tsx
@@ -157,15 +157,19 @@ function TacticalLocation({
   isHovered,
   onClick,
   onHover,
-}: TacticalLocationProps): React.ReactElement {
+}: TacticalLocationProps): React.ReactElement | null {
   const basePos = GEOMETRIC_SILHOUETTE.locations[location];
+
+  // Skip rendering if this location is not defined in this silhouette
+  if (!basePos) return null;
+
   const label = LOCATION_LABELS[location];
   const showRear = hasTorsoRear(location);
   const isLeg = location === MechLocation.LEFT_LEG || location === MechLocation.RIGHT_LEG;
 
   // Adjust height for torso locations to fit stacked layout, offset legs down
   const TORSO_MULTIPLIER = 1.5;
-  const legOffset = GEOMETRIC_SILHOUETTE.locations[MechLocation.CENTER_TORSO].height * (TORSO_MULTIPLIER - 1);
+  const legOffset = GEOMETRIC_SILHOUETTE.locations[MechLocation.CENTER_TORSO]!.height * (TORSO_MULTIPLIER - 1);
   const pos = showRear
     ? { ...basePos, height: basePos.height * TORSO_MULTIPLIER }
     : isLeg

--- a/src/components/customizer/armor/variants/TripodArmorDiagram.tsx
+++ b/src/components/customizer/armor/variants/TripodArmorDiagram.tsx
@@ -1,0 +1,337 @@
+/**
+ * Tripod Armor Diagram
+ *
+ * Design Philosophy: Three-legged mech with standard biped upper body
+ * - Standard biped locations (HD, CT, LT, RT, LA, RA, LL, RL)
+ * - Plus Center Leg (CL) for the third leg
+ * - Torsos have front/rear armor sections
+ */
+
+import React, { useState } from 'react';
+import { MechLocation } from '@/types/construction';
+import { TRIPOD_LOCATIONS } from '@/types/construction/MechConfigurationSystem';
+import { LocationArmorData } from '../ArmorDiagram';
+import {
+  TRIPOD_SILHOUETTE,
+  TRIPOD_LOCATION_LABELS,
+  getLocationCenter,
+  hasTorsoRear,
+} from '../shared/MechSilhouette';
+import {
+  GradientDefs,
+  getArmorStatusColor,
+  getTorsoFrontStatusColor,
+  getTorsoRearStatusColor,
+  lightenColor,
+  SELECTED_COLOR,
+  SELECTED_STROKE,
+} from '../shared/ArmorFills';
+import { ArmorDiagramQuickSettings } from '../ArmorDiagramQuickSettings';
+
+interface TripodLocationProps {
+  location: MechLocation;
+  data?: LocationArmorData;
+  isSelected: boolean;
+  isHovered: boolean;
+  onClick: () => void;
+  onHover: (hovered: boolean) => void;
+}
+
+function TripodLocation({
+  location,
+  data,
+  isSelected,
+  isHovered,
+  onClick,
+  onHover,
+}: TripodLocationProps): React.ReactElement | null {
+  const pos = TRIPOD_SILHOUETTE.locations[location];
+  const label = TRIPOD_LOCATION_LABELS[location];
+
+  // Skip rendering if this location is not defined
+  if (!pos) return null;
+
+  const center = getLocationCenter(pos);
+  const showRear = hasTorsoRear(location);
+
+  const current = data?.current ?? 0;
+  const maximum = data?.maximum ?? 1;
+  const rear = data?.rear ?? 0;
+  const rearMax = data?.rearMaximum ?? 1;
+
+  // Status-based colors for front and rear independently
+  const frontBaseColor = isSelected
+    ? SELECTED_COLOR
+    : showRear
+      ? getTorsoFrontStatusColor(current, maximum)
+      : getArmorStatusColor(current, maximum);
+  const rearBaseColor = isSelected
+    ? SELECTED_COLOR
+    : getTorsoRearStatusColor(rear, maximum);
+
+  const fillColor = isHovered ? lightenColor(frontBaseColor, 0.15) : frontBaseColor;
+  const rearFillColor = isHovered ? lightenColor(rearBaseColor, 0.15) : rearBaseColor;
+  const strokeColor = isSelected ? SELECTED_STROKE : '#475569';
+  const strokeWidth = isSelected ? 2.5 : 1;
+
+  // Split positions for front/rear - adjusted for divider
+  const dividerHeight = showRear ? 2 : 0;
+  const frontHeight = showRear ? pos.height * 0.65 : pos.height;
+  const rearHeight = showRear ? pos.height * 0.35 - dividerHeight : 0;
+  const dividerY = pos.y + frontHeight;
+  const rearY = dividerY + dividerHeight;
+
+  return (
+    <g
+      role="button"
+      tabIndex={0}
+      aria-label={`${location} armor: ${current} of ${maximum}${showRear ? `, rear: ${rear} of ${rearMax}` : ''}`}
+      aria-pressed={isSelected}
+      className="cursor-pointer focus:outline-none"
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      onMouseEnter={() => onHover(true)}
+      onMouseLeave={() => onHover(false)}
+      onFocus={() => onHover(true)}
+      onBlur={() => onHover(false)}
+    >
+      {/* Front armor section */}
+      {pos.path ? (
+        <path
+          d={pos.path}
+          fill={fillColor}
+          stroke={strokeColor}
+          strokeWidth={strokeWidth}
+          className="transition-all duration-150"
+          style={{
+            clipPath: showRear ? `inset(0 0 ${rearHeight}px 0)` : undefined,
+          }}
+        />
+      ) : (
+        <rect
+          x={pos.x}
+          y={pos.y}
+          width={pos.width}
+          height={frontHeight}
+          rx={6}
+          fill={fillColor}
+          stroke={strokeColor}
+          strokeWidth={strokeWidth}
+          className="transition-all duration-150"
+        />
+      )}
+
+      {/* Front armor value - large bold number */}
+      <text
+        x={center.x}
+        y={pos.y + frontHeight / 2 + 5}
+        textAnchor="middle"
+        className="fill-white font-bold pointer-events-none"
+        style={{ fontSize: pos.width < 40 ? '12px' : '16px' }}
+      >
+        {current}
+      </text>
+
+      {/* Capacity text */}
+      <text
+        x={center.x}
+        y={pos.y + frontHeight / 2 + 16}
+        textAnchor="middle"
+        className="fill-white/60 pointer-events-none"
+        style={{ fontSize: '8px' }}
+      >
+        / {maximum}
+      </text>
+
+      {/* Location label */}
+      <text
+        x={center.x}
+        y={pos.y + 12}
+        textAnchor="middle"
+        className="fill-white/80 font-semibold pointer-events-none"
+        style={{ fontSize: showRear ? '8px' : '9px' }}
+      >
+        {showRear ? `${label} FRONT` : label}
+      </text>
+
+      {/* Divider line between front and rear */}
+      {showRear && (
+        <line
+          x1={pos.x + 4}
+          y1={dividerY + 1}
+          x2={pos.x + pos.width - 4}
+          y2={dividerY + 1}
+          stroke="#334155"
+          strokeWidth={1}
+          strokeDasharray="3 2"
+          className="pointer-events-none"
+        />
+      )}
+
+      {/* Rear armor section for torsos */}
+      {showRear && (
+        <>
+          <rect
+            x={pos.x}
+            y={rearY}
+            width={pos.width}
+            height={rearHeight}
+            rx={6}
+            fill={rearFillColor}
+            stroke={strokeColor}
+            strokeWidth={strokeWidth}
+            className="transition-all duration-150"
+          />
+
+          {/* Rear label */}
+          <text
+            x={center.x}
+            y={rearY + 11}
+            textAnchor="middle"
+            className="fill-white/80 font-semibold pointer-events-none"
+            style={{ fontSize: '8px' }}
+          >
+            REAR
+          </text>
+
+          {/* Rear armor value */}
+          <text
+            x={center.x}
+            y={rearY + rearHeight / 2 + 6}
+            textAnchor="middle"
+            className="fill-white font-bold pointer-events-none"
+            style={{ fontSize: '12px' }}
+          >
+            {rear}
+          </text>
+        </>
+      )}
+    </g>
+  );
+}
+
+export interface TripodArmorDiagramProps {
+  armorData: LocationArmorData[];
+  selectedLocation: MechLocation | null;
+  unallocatedPoints: number;
+  onLocationClick: (location: MechLocation) => void;
+  onAutoAllocate?: () => void;
+  className?: string;
+}
+
+export function TripodArmorDiagram({
+  armorData,
+  selectedLocation,
+  unallocatedPoints,
+  onLocationClick,
+  onAutoAllocate,
+  className = '',
+}: TripodArmorDiagramProps): React.ReactElement {
+  const [hoveredLocation, setHoveredLocation] = useState<MechLocation | null>(null);
+
+  const getArmorData = (location: MechLocation): LocationArmorData | undefined => {
+    return armorData.find((d) => d.location === location);
+  };
+
+  const isOverAllocated = unallocatedPoints < 0;
+
+  return (
+    <div className={`bg-surface-base rounded-lg border border-border-theme-subtle p-4 ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <h3 className="text-lg font-semibold text-white">Tripod Armor Allocation</h3>
+          <ArmorDiagramQuickSettings />
+        </div>
+        {onAutoAllocate && (
+          <button
+            onClick={onAutoAllocate}
+            className={`px-3 py-1.5 text-sm font-medium rounded transition-colors ${
+              isOverAllocated
+                ? 'bg-red-600 hover:bg-red-500 text-white'
+                : 'bg-accent hover:bg-accent text-white'
+            }`}
+          >
+            Auto Allocate ({unallocatedPoints} pts)
+          </button>
+        )}
+      </div>
+
+      {/* Diagram */}
+      <div className="relative">
+        <svg
+          viewBox={TRIPOD_SILHOUETTE.viewBox}
+          className="w-full max-w-[300px] mx-auto"
+          style={{ height: 'auto' }}
+        >
+          <GradientDefs />
+
+          {/* Background grid pattern */}
+          <rect
+            x="0"
+            y="0"
+            width="300"
+            height="380"
+            fill="url(#armor-grid)"
+            opacity="0.5"
+          />
+
+          {/* Render all tripod locations */}
+          {TRIPOD_LOCATIONS.map((loc) => (
+            <TripodLocation
+              key={loc}
+              location={loc}
+              data={getArmorData(loc)}
+              isSelected={selectedLocation === loc}
+              isHovered={hoveredLocation === loc}
+              onClick={() => onLocationClick(loc)}
+              onHover={(h) => setHoveredLocation(h ? loc : null)}
+            />
+          ))}
+        </svg>
+      </div>
+
+      {/* Legend */}
+      <div className="flex justify-center gap-3 mt-4 text-xs">
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-green-500" />
+          <span className="text-text-theme-secondary">75%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-amber-500" />
+          <span className="text-text-theme-secondary">50%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-orange-500" />
+          <span className="text-text-theme-secondary">25%+</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-red-500" />
+          <span className="text-text-theme-secondary">&lt;25%</span>
+        </div>
+      </div>
+
+      {/* Location Key */}
+      <div className="mt-3 pt-3 border-t border-border-theme-subtle">
+        <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-text-theme-secondary">
+          <div>HD = Head</div>
+          <div>CT = Center Torso</div>
+          <div>LT/RT = Left/Right Torso</div>
+          <div>LA/RA = Left/Right Arm</div>
+          <div>LL/RL = Left/Right Leg</div>
+          <div>CL = Center Leg</div>
+        </div>
+      </div>
+
+      {/* Instructions */}
+      <p className="text-xs text-text-theme-secondary text-center mt-2">
+        Click a location to edit armor values
+      </p>
+    </div>
+  );
+}

--- a/src/components/customizer/armor/variants/index.ts
+++ b/src/components/customizer/armor/variants/index.ts
@@ -24,3 +24,6 @@ export type { QuadArmorDiagramProps } from './QuadArmorDiagram';
 
 export { LAMArmorDiagram } from './LAMArmorDiagram';
 export type { LAMArmorDiagramProps } from './LAMArmorDiagram';
+
+export { TripodArmorDiagram } from './TripodArmorDiagram';
+export type { TripodArmorDiagramProps } from './TripodArmorDiagram';

--- a/src/components/customizer/armor/variants/index.ts
+++ b/src/components/customizer/armor/variants/index.ts
@@ -18,3 +18,6 @@ export type { PremiumMaterialDiagramProps } from './PremiumMaterialDiagram';
 
 export { MegaMekDiagram } from './MegaMekDiagram';
 export type { MegaMekDiagramProps } from './MegaMekDiagram';
+
+export { QuadArmorDiagram } from './QuadArmorDiagram';
+export type { QuadArmorDiagramProps } from './QuadArmorDiagram';

--- a/src/components/customizer/armor/variants/index.ts
+++ b/src/components/customizer/armor/variants/index.ts
@@ -21,3 +21,6 @@ export type { MegaMekDiagramProps } from './MegaMekDiagram';
 
 export { QuadArmorDiagram } from './QuadArmorDiagram';
 export type { QuadArmorDiagramProps } from './QuadArmorDiagram';
+
+export { LAMArmorDiagram } from './LAMArmorDiagram';
+export type { LAMArmorDiagramProps } from './LAMArmorDiagram';

--- a/src/components/customizer/armor/variants/index.ts
+++ b/src/components/customizer/armor/variants/index.ts
@@ -27,3 +27,6 @@ export type { LAMArmorDiagramProps } from './LAMArmorDiagram';
 
 export { TripodArmorDiagram } from './TripodArmorDiagram';
 export type { TripodArmorDiagramProps } from './TripodArmorDiagram';
+
+export { QuadVeeArmorDiagram } from './QuadVeeArmorDiagram';
+export type { QuadVeeArmorDiagramProps } from './QuadVeeArmorDiagram';

--- a/src/services/conversion/EquipmentNameResolver.ts
+++ b/src/services/conversion/EquipmentNameResolver.ts
@@ -472,7 +472,13 @@ const MEGAMEKLAB_TYPE_MAP: Record<string, string> = {
   'ISJumpJet': 'jump-jet',
   'CLJumpJet': 'clan-jump-jet',
   'ImprovedJumpJet': 'improved-jump-jet',
-  
+
+  // LAM Equipment
+  'LandingGear': 'landing-gear',
+  'Landing Gear': 'landing-gear',
+  'Avionics': 'avionics',
+  'ISAvionics': 'avionics',
+
   // CASE
   'CASE': 'case',
   'ISCASE': 'case',

--- a/src/services/conversion/LocationMappings.ts
+++ b/src/services/conversion/LocationMappings.ts
@@ -16,47 +16,68 @@ import { IArmorAllocation } from '@/types/construction/ComponentInterfaces';
 
 /**
  * Map of all possible location name variations to MechLocation enum
+ * Supports both biped and quad configurations
  */
 const LOCATION_MAP: Record<string, MechLocation> = {
   // Head
   'Head': MechLocation.HEAD,
   'HD': MechLocation.HEAD,
   'H': MechLocation.HEAD,
-  
+
   // Center Torso
   'Center Torso': MechLocation.CENTER_TORSO,
   'CT': MechLocation.CENTER_TORSO,
   'CenterTorso': MechLocation.CENTER_TORSO,
-  
+
   // Left Torso
   'Left Torso': MechLocation.LEFT_TORSO,
   'LT': MechLocation.LEFT_TORSO,
   'LeftTorso': MechLocation.LEFT_TORSO,
-  
+
   // Right Torso
   'Right Torso': MechLocation.RIGHT_TORSO,
   'RT': MechLocation.RIGHT_TORSO,
   'RightTorso': MechLocation.RIGHT_TORSO,
-  
-  // Left Arm
+
+  // Left Arm (Biped)
   'Left Arm': MechLocation.LEFT_ARM,
   'LA': MechLocation.LEFT_ARM,
   'LeftArm': MechLocation.LEFT_ARM,
-  
-  // Right Arm
+
+  // Right Arm (Biped)
   'Right Arm': MechLocation.RIGHT_ARM,
   'RA': MechLocation.RIGHT_ARM,
   'RightArm': MechLocation.RIGHT_ARM,
-  
-  // Left Leg
+
+  // Left Leg (Biped)
   'Left Leg': MechLocation.LEFT_LEG,
   'LL': MechLocation.LEFT_LEG,
   'LeftLeg': MechLocation.LEFT_LEG,
-  
-  // Right Leg
+
+  // Right Leg (Biped)
   'Right Leg': MechLocation.RIGHT_LEG,
   'RL': MechLocation.RIGHT_LEG,
   'RightLeg': MechLocation.RIGHT_LEG,
+
+  // Front Left Leg (Quad)
+  'Front Left Leg': MechLocation.FRONT_LEFT_LEG,
+  'FLL': MechLocation.FRONT_LEFT_LEG,
+  'FrontLeftLeg': MechLocation.FRONT_LEFT_LEG,
+
+  // Front Right Leg (Quad)
+  'Front Right Leg': MechLocation.FRONT_RIGHT_LEG,
+  'FRL': MechLocation.FRONT_RIGHT_LEG,
+  'FrontRightLeg': MechLocation.FRONT_RIGHT_LEG,
+
+  // Rear Left Leg (Quad)
+  'Rear Left Leg': MechLocation.REAR_LEFT_LEG,
+  'RLL': MechLocation.REAR_LEFT_LEG,
+  'RearLeftLeg': MechLocation.REAR_LEFT_LEG,
+
+  // Rear Right Leg (Quad)
+  'Rear Right Leg': MechLocation.REAR_RIGHT_LEG,
+  'RRL': MechLocation.REAR_RIGHT_LEG,
+  'RearRightLeg': MechLocation.REAR_RIGHT_LEG,
 };
 
 /**
@@ -132,39 +153,57 @@ export function parseLocation(source: string): ParsedLocation | undefined {
   
   // Fuzzy matching
   const lowerSource = normalized.toLowerCase();
-  
+
   if (lowerSource.includes('head')) {
     return { location: MechLocation.HEAD, isRear: false };
   }
-  
+
   if (lowerSource.includes('center') && lowerSource.includes('torso')) {
     return { location: MechLocation.CENTER_TORSO, isRear: false };
   }
-  
+
   if (lowerSource.includes('left') && lowerSource.includes('torso')) {
     return { location: MechLocation.LEFT_TORSO, isRear: false };
   }
-  
+
   if (lowerSource.includes('right') && lowerSource.includes('torso')) {
     return { location: MechLocation.RIGHT_TORSO, isRear: false };
   }
-  
+
   if (lowerSource.includes('left') && lowerSource.includes('arm')) {
     return { location: MechLocation.LEFT_ARM, isRear: false };
   }
-  
+
   if (lowerSource.includes('right') && lowerSource.includes('arm')) {
     return { location: MechLocation.RIGHT_ARM, isRear: false };
   }
-  
+
+  // Quad leg locations (check front/rear before generic legs)
+  if (lowerSource.includes('front') && lowerSource.includes('left') && lowerSource.includes('leg')) {
+    return { location: MechLocation.FRONT_LEFT_LEG, isRear: false };
+  }
+
+  if (lowerSource.includes('front') && lowerSource.includes('right') && lowerSource.includes('leg')) {
+    return { location: MechLocation.FRONT_RIGHT_LEG, isRear: false };
+  }
+
+  if (lowerSource.includes('rear') && lowerSource.includes('left') && lowerSource.includes('leg')) {
+    return { location: MechLocation.REAR_LEFT_LEG, isRear: false };
+  }
+
+  if (lowerSource.includes('rear') && lowerSource.includes('right') && lowerSource.includes('leg')) {
+    return { location: MechLocation.REAR_RIGHT_LEG, isRear: false };
+  }
+
+  // Biped leg locations (generic left/right leg)
   if (lowerSource.includes('left') && lowerSource.includes('leg')) {
     return { location: MechLocation.LEFT_LEG, isRear: false };
   }
-  
+
   if (lowerSource.includes('right') && lowerSource.includes('leg')) {
     return { location: MechLocation.RIGHT_LEG, isRear: false };
   }
-  
+
   return undefined;
 }
 
@@ -325,7 +364,7 @@ export const LOCATION_SLOT_ORDER: readonly MechLocation[] = [
 /**
  * Slot counts per location for biped mechs
  */
-export const BIPED_SLOT_COUNTS: Record<MechLocation, number> = {
+export const BIPED_SLOT_COUNTS: Partial<Record<MechLocation, number>> = {
   [MechLocation.HEAD]: 6,
   [MechLocation.CENTER_TORSO]: 12,
   [MechLocation.LEFT_TORSO]: 12,
@@ -335,6 +374,34 @@ export const BIPED_SLOT_COUNTS: Record<MechLocation, number> = {
   [MechLocation.LEFT_LEG]: 6,
   [MechLocation.RIGHT_LEG]: 6,
 };
+
+/**
+ * Slot counts per location for quad mechs
+ */
+export const QUAD_SLOT_COUNTS: Partial<Record<MechLocation, number>> = {
+  [MechLocation.HEAD]: 6,
+  [MechLocation.CENTER_TORSO]: 12,
+  [MechLocation.LEFT_TORSO]: 12,
+  [MechLocation.RIGHT_TORSO]: 12,
+  [MechLocation.FRONT_LEFT_LEG]: 6,
+  [MechLocation.FRONT_RIGHT_LEG]: 6,
+  [MechLocation.REAR_LEFT_LEG]: 6,
+  [MechLocation.REAR_RIGHT_LEG]: 6,
+};
+
+/**
+ * Order of locations in MegaMekLab's combined criticals array for quad mechs
+ */
+export const QUAD_LOCATION_SLOT_ORDER: readonly MechLocation[] = [
+  MechLocation.HEAD,
+  MechLocation.FRONT_LEFT_LEG,
+  MechLocation.FRONT_RIGHT_LEG,
+  MechLocation.REAR_LEFT_LEG,
+  MechLocation.REAR_RIGHT_LEG,
+  MechLocation.LEFT_TORSO,
+  MechLocation.RIGHT_TORSO,
+  MechLocation.CENTER_TORSO,
+];
 
 /**
  * Padded slot counts - MegaMekLab converter pads all locations to 12 slots
@@ -393,7 +460,7 @@ export function parseCriticalSlots(entries: SourceCriticalEntry[]): ParsedCritic
     
     // Split by padded slot count (12 per location)
     for (const location of LOCATION_SLOT_ORDER) {
-      const actualSlotCount = BIPED_SLOT_COUNTS[location];
+      const actualSlotCount = BIPED_SLOT_COUNTS[location] ?? 0;
       // Take only the actual slot count for this location (not the padded amount)
       const locationSlots = allSlots.slice(offset, offset + actualSlotCount);
       

--- a/src/services/conversion/LocationMappings.ts
+++ b/src/services/conversion/LocationMappings.ts
@@ -7,7 +7,7 @@
  * @spec unit-json.plan.md
  */
 
-import { MechLocation } from '@/types/construction/CriticalSlotAllocation';
+import { MechLocation, LOCATION_SLOT_COUNTS } from '@/types/construction/CriticalSlotAllocation';
 import { IArmorAllocation } from '@/types/construction/ComponentInterfaces';
 
 // ============================================================================
@@ -362,32 +362,51 @@ export const LOCATION_SLOT_ORDER: readonly MechLocation[] = [
 ];
 
 /**
- * Slot counts per location for biped mechs
+ * Biped mech locations for slot extraction
  */
-export const BIPED_SLOT_COUNTS: Partial<Record<MechLocation, number>> = {
-  [MechLocation.HEAD]: 6,
-  [MechLocation.CENTER_TORSO]: 12,
-  [MechLocation.LEFT_TORSO]: 12,
-  [MechLocation.RIGHT_TORSO]: 12,
-  [MechLocation.LEFT_ARM]: 12,
-  [MechLocation.RIGHT_ARM]: 12,
-  [MechLocation.LEFT_LEG]: 6,
-  [MechLocation.RIGHT_LEG]: 6,
-};
+const BIPED_LOCATIONS = [
+  MechLocation.HEAD,
+  MechLocation.CENTER_TORSO,
+  MechLocation.LEFT_TORSO,
+  MechLocation.RIGHT_TORSO,
+  MechLocation.LEFT_ARM,
+  MechLocation.RIGHT_ARM,
+  MechLocation.LEFT_LEG,
+  MechLocation.RIGHT_LEG,
+] as const;
+
+/**
+ * Quad mech locations for slot extraction
+ */
+const QUAD_LOCATIONS = [
+  MechLocation.HEAD,
+  MechLocation.CENTER_TORSO,
+  MechLocation.LEFT_TORSO,
+  MechLocation.RIGHT_TORSO,
+  MechLocation.FRONT_LEFT_LEG,
+  MechLocation.FRONT_RIGHT_LEG,
+  MechLocation.REAR_LEFT_LEG,
+  MechLocation.REAR_RIGHT_LEG,
+] as const;
+
+/**
+ * Slot counts per location for biped mechs
+ *
+ * @deprecated Use LOCATION_SLOT_COUNTS from CriticalSlotAllocation instead
+ */
+export const BIPED_SLOT_COUNTS: Partial<Record<MechLocation, number>> = Object.fromEntries(
+  BIPED_LOCATIONS.map(loc => [loc, LOCATION_SLOT_COUNTS[loc]])
+) as Partial<Record<MechLocation, number>>;
 
 /**
  * Slot counts per location for quad mechs
+ *
+ * Note: Quad legs have 12 slots each (same as biped arms).
+ * @deprecated Use LOCATION_SLOT_COUNTS from CriticalSlotAllocation instead
  */
-export const QUAD_SLOT_COUNTS: Partial<Record<MechLocation, number>> = {
-  [MechLocation.HEAD]: 6,
-  [MechLocation.CENTER_TORSO]: 12,
-  [MechLocation.LEFT_TORSO]: 12,
-  [MechLocation.RIGHT_TORSO]: 12,
-  [MechLocation.FRONT_LEFT_LEG]: 6,
-  [MechLocation.FRONT_RIGHT_LEG]: 6,
-  [MechLocation.REAR_LEFT_LEG]: 6,
-  [MechLocation.REAR_RIGHT_LEG]: 6,
-};
+export const QUAD_SLOT_COUNTS: Partial<Record<MechLocation, number>> = Object.fromEntries(
+  QUAD_LOCATIONS.map(loc => [loc, LOCATION_SLOT_COUNTS[loc]])
+) as Partial<Record<MechLocation, number>>;
 
 /**
  * Order of locations in MegaMekLab's combined criticals array for quad mechs
@@ -445,7 +464,7 @@ export function parseCriticalSlots(entries: SourceCriticalEntry[]): ParsedCritic
       if (location) {
         result.push({
           location,
-          slots: entry.slots.slice(0, BIPED_SLOT_COUNTS[location]),
+          slots: entry.slots.slice(0, LOCATION_SLOT_COUNTS[location]),
         });
       }
     }
@@ -460,7 +479,7 @@ export function parseCriticalSlots(entries: SourceCriticalEntry[]): ParsedCritic
     
     // Split by padded slot count (12 per location)
     for (const location of LOCATION_SLOT_ORDER) {
-      const actualSlotCount = BIPED_SLOT_COUNTS[location] ?? 0;
+      const actualSlotCount = LOCATION_SLOT_COUNTS[location] ?? 0;
       // Take only the actual slot count for this location (not the padded amount)
       const locationSlots = allSlots.slice(offset, offset + actualSlotCount);
       
@@ -488,7 +507,7 @@ export function parseCriticalSlots(entries: SourceCriticalEntry[]): ParsedCritic
       processedLocations.add(location);
       result.push({
         location,
-        slots: entry.slots.slice(0, BIPED_SLOT_COUNTS[location]),
+        slots: entry.slots.slice(0, LOCATION_SLOT_COUNTS[location]),
       });
     }
   }

--- a/src/services/conversion/MTFExportService.ts
+++ b/src/services/conversion/MTFExportService.ts
@@ -19,9 +19,9 @@ export interface IMTFExportResult {
 }
 
 /**
- * Location order for MTF output (matches MegaMek convention)
+ * Location order for MTF output by configuration (matches MegaMek convention)
  */
-const LOCATION_ORDER = [
+const BIPED_LOCATION_ORDER = [
   'LEFT_ARM',
   'RIGHT_ARM',
   'LEFT_TORSO',
@@ -32,10 +32,34 @@ const LOCATION_ORDER = [
   'RIGHT_LEG',
 ];
 
+const QUAD_LOCATION_ORDER = [
+  'FRONT_LEFT_LEG',
+  'FRONT_RIGHT_LEG',
+  'LEFT_TORSO',
+  'RIGHT_TORSO',
+  'CENTER_TORSO',
+  'HEAD',
+  'REAR_LEFT_LEG',
+  'REAR_RIGHT_LEG',
+];
+
+const TRIPOD_LOCATION_ORDER = [
+  'LEFT_ARM',
+  'RIGHT_ARM',
+  'LEFT_TORSO',
+  'RIGHT_TORSO',
+  'CENTER_TORSO',
+  'HEAD',
+  'LEFT_LEG',
+  'RIGHT_LEG',
+  'CENTER_LEG',
+];
+
 /**
  * Location display names for MTF format
  */
 const LOCATION_NAMES: Record<string, string> = {
+  // Biped locations
   LEFT_ARM: 'Left Arm',
   RIGHT_ARM: 'Right Arm',
   LEFT_TORSO: 'Left Torso',
@@ -44,6 +68,13 @@ const LOCATION_NAMES: Record<string, string> = {
   HEAD: 'Head',
   LEFT_LEG: 'Left Leg',
   RIGHT_LEG: 'Right Leg',
+  // Quad locations
+  FRONT_LEFT_LEG: 'Front Left Leg',
+  FRONT_RIGHT_LEG: 'Front Right Leg',
+  REAR_LEFT_LEG: 'Rear Left Leg',
+  REAR_RIGHT_LEG: 'Rear Right Leg',
+  // Tripod locations
+  CENTER_LEG: 'Center Leg',
 };
 
 /**
@@ -140,7 +171,7 @@ export class MTFExportService {
 
       // Armor
       lines.push(`armor:${this.formatArmorType(unit.armor.type)}`);
-      this.writeArmorValues(lines, unit.armor.allocation);
+      this.writeArmorValues(lines, unit.armor.allocation, unit.configuration);
       lines.push('');
 
       // Weapons
@@ -153,9 +184,11 @@ export class MTFExportService {
       }
       lines.push('');
 
-      // Critical slots (always 12 slots per location to match MegaMek format)
+      // Critical slots - determine location order based on configuration
+      // MegaMek pads all locations to 12 slots for consistency
       const MTF_SLOTS_PER_LOCATION = 12;
-      for (const location of LOCATION_ORDER) {
+      const locationOrder = this.getLocationOrder(unit.configuration);
+      for (const location of locationOrder) {
         lines.push(`${LOCATION_NAMES[location]}:`);
         const slots = unit.criticalSlots[location] || [];
         // Output actual slots
@@ -166,7 +199,7 @@ export class MTFExportService {
             lines.push(slot);
           }
         }
-        // Pad to 12 slots
+        // Pad to 12 slots for MTF format compatibility
         for (let i = slots.length; i < MTF_SLOTS_PER_LOCATION; i++) {
           lines.push('-Empty-');
         }
@@ -293,19 +326,83 @@ export class MTFExportService {
   }
 
   /**
+   * Get location order based on configuration
+   */
+  private getLocationOrder(configuration: string): string[] {
+    const config = configuration.toUpperCase();
+    // Handle variations like "Quad", "Quad Omnimech", "QuadVee"
+    if (config.startsWith('QUAD') || config === 'QUADVEE') {
+      return QUAD_LOCATION_ORDER;
+    }
+    // Handle "Tripod" and variations
+    if (config.startsWith('TRIPOD')) {
+      return TRIPOD_LOCATION_ORDER;
+    }
+    // Biped, LAM, and others use biped order
+    return BIPED_LOCATION_ORDER;
+  }
+
+  /**
+   * Get slot count for a location
+   */
+  private getSlotCount(location: string): number {
+    const slotCounts: Record<string, number> = {
+      HEAD: 6,
+      CENTER_TORSO: 12,
+      LEFT_TORSO: 12,
+      RIGHT_TORSO: 12,
+      LEFT_ARM: 12,
+      RIGHT_ARM: 12,
+      LEFT_LEG: 6,
+      RIGHT_LEG: 6,
+      FRONT_LEFT_LEG: 6,
+      FRONT_RIGHT_LEG: 6,
+      REAR_LEFT_LEG: 6,
+      REAR_RIGHT_LEG: 6,
+      CENTER_LEG: 6,
+    };
+    return slotCounts[location] || 12;
+  }
+
+  /**
    * Write armor values in MTF format
    */
-  private writeArmorValues(lines: string[], allocation: Record<string, number | { front: number; rear: number }>): void {
-    const fieldMap: Record<string, string> = {
-      LEFT_ARM: 'LA armor',
-      RIGHT_ARM: 'RA armor',
-      LEFT_TORSO: 'LT armor',
-      RIGHT_TORSO: 'RT armor',
-      CENTER_TORSO: 'CT armor',
-      HEAD: 'HD armor',
-      LEFT_LEG: 'LL armor',
-      RIGHT_LEG: 'RL armor',
-    };
+  private writeArmorValues(
+    lines: string[],
+    allocation: Record<string, number | { front: number; rear: number }>,
+    configuration: string
+  ): void {
+    const config = configuration.toUpperCase();
+    // Handle variations like "Quad", "Quad Omnimech", "QuadVee"
+    const isQuad = config.startsWith('QUAD') || config === 'QUADVEE';
+
+    // Define armor field mappings based on configuration
+    const fieldMap: Record<string, string> = isQuad
+      ? {
+          FRONT_LEFT_LEG: 'FLL armor',
+          FRONT_RIGHT_LEG: 'FRL armor',
+          LEFT_TORSO: 'LT armor',
+          RIGHT_TORSO: 'RT armor',
+          CENTER_TORSO: 'CT armor',
+          HEAD: 'HD armor',
+          REAR_LEFT_LEG: 'RLL armor',
+          REAR_RIGHT_LEG: 'RRL armor',
+        }
+      : {
+          LEFT_ARM: 'LA armor',
+          RIGHT_ARM: 'RA armor',
+          LEFT_TORSO: 'LT armor',
+          RIGHT_TORSO: 'RT armor',
+          CENTER_TORSO: 'CT armor',
+          HEAD: 'HD armor',
+          LEFT_LEG: 'LL armor',
+          RIGHT_LEG: 'RL armor',
+        };
+
+    // Add center leg for tripod
+    if (config.startsWith('TRIPOD')) {
+      fieldMap['CENTER_LEG'] = 'CL armor';
+    }
 
     // Write front armor
     for (const [location, field] of Object.entries(fieldMap)) {

--- a/src/services/conversion/MTFExportService.ts
+++ b/src/services/conversion/MTFExportService.ts
@@ -362,6 +362,9 @@ export class MTFExportService {
       'machine-gun': 'Machine Gun',
       'flamer': 'Flamer',
       'gauss-rifle': 'Gauss Rifle',
+      // LAM Equipment
+      'landing-gear': 'Landing Gear',
+      'avionics': 'Avionics',
     };
 
     if (nameMap[id]) {

--- a/src/services/conversion/MTFParserService.ts
+++ b/src/services/conversion/MTFParserService.ts
@@ -199,10 +199,22 @@ export class MTFParserService {
     mulId?: number;
     role?: string;
     source?: string;
+    clanname?: string;
   } {
+    const chassis = this.parseField(lines, 'chassis') || '';
+    const model = this.parseField(lines, 'model');
+    const clanname = this.parseField(lines, 'clanname');
+
+    // Handle empty model field - use clanname or chassis variant as fallback
+    // Some Clan mechs have format: chassis:Baboon, clanname:Howler, model: (empty)
+    let effectiveModel = model || '';
+    if (!effectiveModel && clanname) {
+      effectiveModel = clanname;
+    }
+
     return {
-      chassis: this.parseField(lines, 'chassis') || '',
-      model: this.parseField(lines, 'model') || '',
+      chassis,
+      model: effectiveModel,
       config: this.parseField(lines, 'Config') || 'Biped',
       techBase: this.parseField(lines, 'techbase') || 'Inner Sphere',
       year: parseInt(this.parseField(lines, 'era') || '3025', 10),
@@ -210,6 +222,7 @@ export class MTFParserService {
       mulId: parseInt(this.parseField(lines, 'mul id') || '0', 10) || undefined,
       role: this.parseField(lines, 'role') || undefined,
       source: this.parseField(lines, 'source') || undefined,
+      clanname,
     };
   }
 

--- a/src/services/conversion/MTFParserService.ts
+++ b/src/services/conversion/MTFParserService.ts
@@ -20,8 +20,10 @@ export interface IMTFParseResult {
 
 /**
  * Location header patterns in MTF files
+ * Supports both biped and quad configurations
  */
 const LOCATION_HEADERS: Record<string, string> = {
+  // Biped locations
   'Left Arm:': 'LEFT_ARM',
   'Right Arm:': 'RIGHT_ARM',
   'Left Torso:': 'LEFT_TORSO',
@@ -30,12 +32,18 @@ const LOCATION_HEADERS: Record<string, string> = {
   'Head:': 'HEAD',
   'Left Leg:': 'LEFT_LEG',
   'Right Leg:': 'RIGHT_LEG',
+  // Quad locations
+  'Front Left Leg:': 'FRONT_LEFT_LEG',
+  'Front Right Leg:': 'FRONT_RIGHT_LEG',
+  'Rear Left Leg:': 'REAR_LEFT_LEG',
+  'Rear Right Leg:': 'REAR_RIGHT_LEG',
 };
 
 /**
- * Slot counts per location for biped mechs
+ * Slot counts per location for all mech configurations
  */
 const SLOT_COUNTS: Record<string, number> = {
+  // Biped locations
   HEAD: 6,
   CENTER_TORSO: 12,
   LEFT_TORSO: 12,
@@ -44,6 +52,11 @@ const SLOT_COUNTS: Record<string, number> = {
   RIGHT_ARM: 12,
   LEFT_LEG: 6,
   RIGHT_LEG: 6,
+  // Quad locations (12 slots each for legs)
+  FRONT_LEFT_LEG: 6,
+  FRONT_RIGHT_LEG: 6,
+  REAR_LEFT_LEG: 6,
+  REAR_RIGHT_LEG: 6,
 };
 
 /**
@@ -267,8 +280,9 @@ export class MTFParserService {
 
     const allocation: Record<string, number | { front: number; rear: number }> = {};
 
-    // Parse per-location armor values
+    // Parse per-location armor values (biped and quad)
     const armorFields: Record<string, string> = {
+      // Biped locations
       'LA armor': 'LEFT_ARM',
       'RA armor': 'RIGHT_ARM',
       'LT armor': 'LEFT_TORSO',
@@ -280,6 +294,11 @@ export class MTFParserService {
       'RTL armor': 'LEFT_TORSO_REAR',
       'RTR armor': 'RIGHT_TORSO_REAR',
       'RTC armor': 'CENTER_TORSO_REAR',
+      // Quad leg locations
+      'FLL armor': 'FRONT_LEFT_LEG',
+      'FRL armor': 'FRONT_RIGHT_LEG',
+      'RLL armor': 'REAR_LEFT_LEG',
+      'RRL armor': 'REAR_RIGHT_LEG',
     };
 
     const frontValues: Record<string, number> = {};
@@ -507,9 +526,11 @@ export class MTFParserService {
 
   /**
    * Normalize location name to enum format
+   * Supports both biped and quad locations
    */
   private normalizeLocation(location: string): string {
     const locationMap: Record<string, string> = {
+      // Biped locations
       'Left Arm': 'LEFT_ARM',
       'Right Arm': 'RIGHT_ARM',
       'Left Torso': 'LEFT_TORSO',
@@ -518,6 +539,11 @@ export class MTFParserService {
       'Head': 'HEAD',
       'Left Leg': 'LEFT_LEG',
       'Right Leg': 'RIGHT_LEG',
+      // Quad locations
+      'Front Left Leg': 'FRONT_LEFT_LEG',
+      'Front Right Leg': 'FRONT_RIGHT_LEG',
+      'Rear Left Leg': 'REAR_LEFT_LEG',
+      'Rear Right Leg': 'REAR_RIGHT_LEG',
     };
 
     return locationMap[location] || location.toUpperCase().replace(/\s+/g, '_');

--- a/src/services/conversion/ParityValidationService.ts
+++ b/src/services/conversion/ParityValidationService.ts
@@ -242,8 +242,17 @@ export class ParityValidationService {
     this.compareField('walk mp', originalMap, generatedMap, issues, DiscrepancyCategory.MOVEMENT_MISMATCH);
     this.compareField('jump mp', originalMap, generatedMap, issues, DiscrepancyCategory.MOVEMENT_MISMATCH);
 
-    // Compare armor values
-    const armorFields = ['LA armor', 'RA armor', 'LT armor', 'RT armor', 'CT armor', 'HD armor', 'LL armor', 'RL armor', 'RTL armor', 'RTR armor', 'RTC armor'];
+    // Compare armor values (biped, quad, and tripod configurations)
+    const armorFields = [
+      // Biped locations
+      'LA armor', 'RA armor', 'LT armor', 'RT armor', 'CT armor', 'HD armor', 'LL armor', 'RL armor',
+      // Quad locations
+      'FLL armor', 'FRL armor', 'RLL armor', 'RRL armor',
+      // Tripod locations
+      'CL armor',
+      // Rear torso armor (all configurations)
+      'RTL armor', 'RTR armor', 'RTC armor',
+    ];
     for (const field of armorFields) {
       this.compareField(field, originalMap, generatedMap, issues, DiscrepancyCategory.ARMOR_MISMATCH);
     }
@@ -429,6 +438,7 @@ export class ParityValidationService {
     let currentLocation: string | null = null;
 
     const locationHeaders: Record<string, string> = {
+      // Biped locations
       'Left Arm:': 'LEFT_ARM',
       'Right Arm:': 'RIGHT_ARM',
       'Left Torso:': 'LEFT_TORSO',
@@ -437,6 +447,13 @@ export class ParityValidationService {
       'Head:': 'HEAD',
       'Left Leg:': 'LEFT_LEG',
       'Right Leg:': 'RIGHT_LEG',
+      // Quad locations
+      'Front Left Leg:': 'FRONT_LEFT_LEG',
+      'Front Right Leg:': 'FRONT_RIGHT_LEG',
+      'Rear Left Leg:': 'REAR_LEFT_LEG',
+      'Rear Right Leg:': 'REAR_RIGHT_LEG',
+      // Tripod locations
+      'Center Leg:': 'CENTER_LEG',
     };
 
     for (const line of lines) {

--- a/src/services/conversion/__tests__/EquipmentNameResolver.test.ts
+++ b/src/services/conversion/__tests__/EquipmentNameResolver.test.ts
@@ -7,11 +7,25 @@
  */
 
 import { EquipmentNameResolver, equipmentNameResolver } from '../EquipmentNameResolver';
+import { TechBase } from '@/types/enums/TechBase';
+import * as EquipmentLoaderService from '@/services/equipment/EquipmentLoaderService';
+
+// Mock the equipment loader
+jest.mock('@/services/equipment/EquipmentLoaderService', () => ({
+  getEquipmentLoader: jest.fn(() => ({
+    getIsLoaded: jest.fn().mockReturnValue(false),
+    getAllWeapons: jest.fn().mockReturnValue([]),
+    getAllAmmunition: jest.fn().mockReturnValue([]),
+    getAllElectronics: jest.fn().mockReturnValue([]),
+    getAllMiscEquipment: jest.fn().mockReturnValue([]),
+  })),
+}));
 
 describe('EquipmentNameResolver', () => {
   let resolver: EquipmentNameResolver;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     resolver = new EquipmentNameResolver();
     resolver.initialize();
   });
@@ -130,6 +144,333 @@ describe('EquipmentNameResolver', () => {
   describe('singleton instance', () => {
     it('should export a singleton instance', () => {
       expect(equipmentNameResolver).toBeInstanceOf(EquipmentNameResolver);
+    });
+  });
+
+  describe('resolve with loaded equipment', () => {
+    beforeEach(() => {
+      // Mock loaded equipment data
+      (EquipmentLoaderService.getEquipmentLoader as jest.Mock).mockReturnValue({
+        getIsLoaded: jest.fn().mockReturnValue(true),
+        getAllWeapons: jest.fn().mockReturnValue([
+          {
+            id: 'medium-laser',
+            name: 'Medium Laser',
+            category: 'ENERGY',
+            techBase: TechBase.INNER_SPHERE,
+            rulesLevel: 1,
+            weight: 1,
+            criticalSlots: 1,
+            costCBills: 40000,
+            battleValue: 46,
+            introductionYear: 2300,
+          },
+          {
+            id: 'clan-er-medium-laser',
+            name: 'Clan ER Medium Laser',
+            category: 'ENERGY',
+            techBase: TechBase.CLAN,
+            rulesLevel: 2,
+            weight: 1,
+            criticalSlots: 1,
+            costCBills: 80000,
+            battleValue: 108,
+            introductionYear: 2824,
+          },
+          {
+            id: 'arrow-iv',
+            name: 'Arrow IV',
+            category: 'ARTILLERY',
+            techBase: TechBase.INNER_SPHERE,
+            rulesLevel: 3,
+            weight: 15,
+            criticalSlots: 15,
+            costCBills: 450000,
+            battleValue: 171,
+            introductionYear: 2593,
+          },
+        ]),
+        getAllAmmunition: jest.fn().mockReturnValue([
+          {
+            id: 'ac-10-ammo',
+            name: 'AC/10 Ammo',
+            techBase: TechBase.INNER_SPHERE,
+            rulesLevel: 1,
+            weight: 1,
+            criticalSlots: 1,
+            costPerTon: 6000,
+            battleValue: 15,
+            introductionYear: 2443,
+          },
+        ]),
+        getAllElectronics: jest.fn().mockReturnValue([
+          {
+            id: 'guardian-ecm',
+            name: 'Guardian ECM Suite',
+            techBase: TechBase.INNER_SPHERE,
+            rulesLevel: 2,
+            weight: 1.5,
+            criticalSlots: 2,
+            costCBills: 200000,
+            battleValue: 61,
+            introductionYear: 2597,
+          },
+        ]),
+        getAllMiscEquipment: jest.fn().mockReturnValue([
+          {
+            id: 'case',
+            name: 'CASE',
+            techBase: TechBase.INNER_SPHERE,
+            rulesLevel: 2,
+            weight: 0.5,
+            criticalSlots: 1,
+            costCBills: 50000,
+            battleValue: 0,
+            introductionYear: 3036,
+          },
+        ]),
+      });
+
+      // Create fresh resolver with loaded data
+      resolver = new EquipmentNameResolver();
+      resolver.initialize();
+    });
+
+    it('should resolve equipment by direct type mapping', () => {
+      const result = resolver.resolve('MediumLaser', 'Medium Laser');
+      expect(result.found).toBe(true);
+      expect(result.equipmentId).toBe('medium-laser');
+      expect(result.confidence).toBe('exact');
+    });
+
+    it('should resolve equipment by item name', () => {
+      const result = resolver.resolve('UnknownType', 'Medium Laser');
+      expect(result.found).toBe(true);
+      expect(result.equipmentId).toBe('medium-laser');
+      expect(result.confidence).toBe('exact');
+    });
+
+    it('should resolve equipment by normalized name', () => {
+      const result = resolver.resolve('UnknownType', 'MEDIUM LASER');
+      expect(result.found).toBe(true);
+      expect(result.confidence).toBe('exact');
+    });
+
+    it('should resolve with quantity prefix stripped', () => {
+      const result = resolver.resolve('1MediumLaser', 'Medium Laser');
+      expect(result.found).toBe(true);
+      expect(result.equipmentId).toBe('medium-laser');
+    });
+
+    it('should handle IS prefix in type', () => {
+      const result = resolver.resolve('1ISmediumlaser', 'Medium Laser');
+      // Should strip 1 and try ISMediumLaser
+      expect(result.originalType).toBe('1ISmediumlaser');
+    });
+
+    it('should resolve CASE equipment', () => {
+      const result = resolver.resolve('CASE', 'CASE');
+      expect(result.found).toBe(true);
+      expect(result.equipmentId).toBe('case');
+    });
+
+    it('should resolve Guardian ECM', () => {
+      const result = resolver.resolve('GuardianECM', 'Guardian ECM Suite');
+      expect(result.found).toBe(true);
+      expect(result.equipmentId).toBe('guardian-ecm');
+    });
+
+    it('should return not found for unresolvable equipment', () => {
+      const result = resolver.resolve('TotallyUnknownWeapon', 'Unknown Weapon XYZ');
+      expect(result.found).toBe(false);
+      expect(result.confidence).toBe('none');
+    });
+
+    it('should try tech-base specific lookup for Clan', () => {
+      const result = resolver.resolve('UnknownClanThing', 'SomeWeapon', TechBase.CLAN);
+      // Won't find it, but should try the tech base path
+      expect(result.found).toBe(false);
+    });
+
+    it('should resolve artillery weapons', () => {
+      const result = resolver.resolve('ISArrowIV', 'Arrow IV');
+      expect(result.found).toBe(true);
+      expect(result.equipmentId).toBe('arrow-iv');
+    });
+
+    it('should resolve ammunition', () => {
+      const result = resolver.resolve('UnknownType', 'AC/10 Ammo');
+      expect(result.found).toBe(true);
+      expect(result.equipmentId).toBe('ac-10-ammo');
+    });
+
+    it('should getById for known equipment', () => {
+      const equipment = resolver.getById('medium-laser');
+      expect(equipment).toBeDefined();
+      expect(equipment?.name).toBe('Medium Laser');
+    });
+  });
+
+  describe('stripQuantityPrefix edge cases', () => {
+    beforeEach(() => {
+      (EquipmentLoaderService.getEquipmentLoader as jest.Mock).mockReturnValue({
+        getIsLoaded: jest.fn().mockReturnValue(true),
+        getAllWeapons: jest.fn().mockReturnValue([]),
+        getAllAmmunition: jest.fn().mockReturnValue([]),
+        getAllElectronics: jest.fn().mockReturnValue([]),
+        getAllMiscEquipment: jest.fn().mockReturnValue([]),
+      });
+      resolver = new EquipmentNameResolver();
+      resolver.initialize();
+    });
+
+    it('should handle type with no prefix', () => {
+      const result = resolver.resolve('laser', 'Laser');
+      expect(result.originalType).toBe('laser');
+    });
+
+    it('should handle CL prefix', () => {
+      const result = resolver.resolve('2CLmediumlaser', 'Clan Medium Laser');
+      expect(result.originalType).toBe('2CLmediumlaser');
+    });
+
+    it('should handle Clan prefix', () => {
+      const result = resolver.resolve('3ClanLaser', 'Clan Laser');
+      expect(result.originalType).toBe('3ClanLaser');
+    });
+
+    it('should handle empty type', () => {
+      const result = resolver.resolve('', 'Unknown');
+      expect(result.found).toBe(false);
+    });
+  });
+
+  describe('weapon category mapping', () => {
+    it('should map ballistic weapons correctly', () => {
+      (EquipmentLoaderService.getEquipmentLoader as jest.Mock).mockReturnValue({
+        getIsLoaded: jest.fn().mockReturnValue(true),
+        getAllWeapons: jest.fn().mockReturnValue([
+          {
+            id: 'ac-10',
+            name: 'AC/10',
+            category: 'BALLISTIC',
+            techBase: TechBase.INNER_SPHERE,
+            rulesLevel: 1,
+            weight: 12,
+            criticalSlots: 7,
+            costCBills: 200000,
+            battleValue: 124,
+            introductionYear: 2443,
+          },
+        ]),
+        getAllAmmunition: jest.fn().mockReturnValue([]),
+        getAllElectronics: jest.fn().mockReturnValue([]),
+        getAllMiscEquipment: jest.fn().mockReturnValue([]),
+      });
+
+      const freshResolver = new EquipmentNameResolver();
+      freshResolver.initialize();
+
+      const result = freshResolver.resolve('Unknown', 'AC/10');
+      expect(result.found).toBe(true);
+    });
+
+    it('should map missile weapons correctly', () => {
+      (EquipmentLoaderService.getEquipmentLoader as jest.Mock).mockReturnValue({
+        getIsLoaded: jest.fn().mockReturnValue(true),
+        getAllWeapons: jest.fn().mockReturnValue([
+          {
+            id: 'lrm-20',
+            name: 'LRM 20',
+            category: 'MISSILE',
+            techBase: TechBase.INNER_SPHERE,
+            rulesLevel: 1,
+            weight: 10,
+            criticalSlots: 5,
+            costCBills: 250000,
+            battleValue: 181,
+            introductionYear: 2300,
+          },
+        ]),
+        getAllAmmunition: jest.fn().mockReturnValue([]),
+        getAllElectronics: jest.fn().mockReturnValue([]),
+        getAllMiscEquipment: jest.fn().mockReturnValue([]),
+      });
+
+      const freshResolver = new EquipmentNameResolver();
+      freshResolver.initialize();
+
+      const result = freshResolver.resolve('Unknown', 'LRM 20');
+      expect(result.found).toBe(true);
+    });
+
+    it('should map unknown category to misc', () => {
+      (EquipmentLoaderService.getEquipmentLoader as jest.Mock).mockReturnValue({
+        getIsLoaded: jest.fn().mockReturnValue(true),
+        getAllWeapons: jest.fn().mockReturnValue([
+          {
+            id: 'unknown-weapon',
+            name: 'Unknown Weapon',
+            category: 'UNKNOWN_CATEGORY',
+            techBase: TechBase.INNER_SPHERE,
+            rulesLevel: 1,
+            weight: 1,
+            criticalSlots: 1,
+            costCBills: 1000,
+            battleValue: 10,
+            introductionYear: 3000,
+          },
+        ]),
+        getAllAmmunition: jest.fn().mockReturnValue([]),
+        getAllElectronics: jest.fn().mockReturnValue([]),
+        getAllMiscEquipment: jest.fn().mockReturnValue([]),
+      });
+
+      const freshResolver = new EquipmentNameResolver();
+      freshResolver.initialize();
+
+      const result = freshResolver.resolve('Unknown', 'Unknown Weapon');
+      expect(result.found).toBe(true);
+    });
+  });
+
+  describe('normalized name fuzzy matching', () => {
+    beforeEach(() => {
+      (EquipmentLoaderService.getEquipmentLoader as jest.Mock).mockReturnValue({
+        getIsLoaded: jest.fn().mockReturnValue(true),
+        getAllWeapons: jest.fn().mockReturnValue([
+          {
+            id: 'medium-laser',
+            name: 'Medium Laser',
+            category: 'ENERGY',
+            techBase: TechBase.INNER_SPHERE,
+            rulesLevel: 1,
+            weight: 1,
+            criticalSlots: 1,
+            costCBills: 40000,
+            battleValue: 46,
+            introductionYear: 2300,
+          },
+        ]),
+        getAllAmmunition: jest.fn().mockReturnValue([]),
+        getAllElectronics: jest.fn().mockReturnValue([]),
+        getAllMiscEquipment: jest.fn().mockReturnValue([]),
+      });
+      resolver = new EquipmentNameResolver();
+      resolver.initialize();
+    });
+
+    it('should resolve by normalized type', () => {
+      // Type normalization removes IS prefix and normalizes
+      const result = resolver.resolve('ISMediumlaser', 'Different Name');
+      // Should try normalized type path
+      expect(result.originalType).toBe('ISMediumlaser');
+    });
+
+    it('should resolve by normalized name when type fails', () => {
+      const result = resolver.resolve('Unknown', 'Medium-Laser');
+      // Normalized name should match 'medium laser' -> 'mediumlaser'
+      expect(result.originalName).toBe('Medium-Laser');
     });
   });
 });

--- a/src/services/conversion/__tests__/ValueMappings.test.ts
+++ b/src/services/conversion/__tests__/ValueMappings.test.ts
@@ -179,6 +179,19 @@ describe('ValueMappings', () => {
       expect(mapEngineType('compact fusion')).toBe(EngineType.COMPACT);
     });
 
+    it('should fuzzy match ICE/combustion engines', () => {
+      expect(mapEngineType('internal combustion type')).toBe(EngineType.ICE);
+      expect(mapEngineType('some ice engine')).toBe(EngineType.ICE);
+    });
+
+    it('should fuzzy match fuel cell engines', () => {
+      expect(mapEngineType('some fuel cell type')).toBe(EngineType.FUEL_CELL);
+    });
+
+    it('should fuzzy match fission engines', () => {
+      expect(mapEngineType('some fission type')).toBe(EngineType.FISSION);
+    });
+
     it('should default to STANDARD for unknown', () => {
       expect(mapEngineType('Unknown')).toBe(EngineType.STANDARD);
     });
@@ -215,6 +228,22 @@ describe('ValueMappings', () => {
       expect(mapStructureType('Industrial')).toBe(InternalStructureType.INDUSTRIAL);
     });
 
+    it('should fuzzy match endo-composite structure', () => {
+      expect(mapStructureType('some endo composite type')).toBe(InternalStructureType.ENDO_COMPOSITE);
+    });
+
+    it('should fuzzy match reinforced structure', () => {
+      expect(mapStructureType('some reinforced type')).toBe(InternalStructureType.REINFORCED);
+    });
+
+    it('should fuzzy match composite structure', () => {
+      expect(mapStructureType('some composite type')).toBe(InternalStructureType.COMPOSITE);
+    });
+
+    it('should fuzzy match industrial structure', () => {
+      expect(mapStructureType('some industrial type')).toBe(InternalStructureType.INDUSTRIAL);
+    });
+
     it('should default to STANDARD for unknown', () => {
       expect(mapStructureType('Unknown')).toBe(InternalStructureType.STANDARD);
     });
@@ -246,6 +275,14 @@ describe('ValueMappings', () => {
     it('should map other heat sink types', () => {
       expect(mapHeatSinkType('Compact')).toBe(HeatSinkType.COMPACT);
       expect(mapHeatSinkType('Laser')).toBe(HeatSinkType.LASER);
+    });
+
+    it('should fuzzy match laser heat sinks', () => {
+      expect(mapHeatSinkType('some laser heat sink')).toBe(HeatSinkType.LASER);
+    });
+
+    it('should fuzzy match compact heat sinks', () => {
+      expect(mapHeatSinkType('some compact heat sink')).toBe(HeatSinkType.COMPACT);
     });
 
     it('should default to SINGLE for unknown', () => {
@@ -284,6 +321,31 @@ describe('ValueMappings', () => {
       expect(mapArmorType('Hardened')).toBe(ArmorTypeEnum.HARDENED);
     });
 
+    it('should fuzzy match stealth armor', () => {
+      expect(mapArmorType('some stealth armor')).toBe(ArmorTypeEnum.STEALTH);
+    });
+
+    it('should fuzzy match reactive armor', () => {
+      expect(mapArmorType('some reactive armor')).toBe(ArmorTypeEnum.REACTIVE);
+    });
+
+    it('should fuzzy match reflective armor', () => {
+      expect(mapArmorType('some reflective armor')).toBe(ArmorTypeEnum.REFLECTIVE);
+      expect(mapArmorType('laser-reflective type')).toBe(ArmorTypeEnum.REFLECTIVE);
+    });
+
+    it('should fuzzy match hardened armor', () => {
+      expect(mapArmorType('some hardened armor')).toBe(ArmorTypeEnum.HARDENED);
+    });
+
+    it('should fuzzy match heavy ferro armor', () => {
+      expect(mapArmorType('some heavy ferro armor')).toBe(ArmorTypeEnum.HEAVY_FERRO);
+    });
+
+    it('should fuzzy match light ferro armor', () => {
+      expect(mapArmorType('some light ferro armor')).toBe(ArmorTypeEnum.LIGHT_FERRO);
+    });
+
     it('should default to STANDARD for unknown', () => {
       expect(mapArmorType('Unknown')).toBe(ArmorTypeEnum.STANDARD);
     });
@@ -306,6 +368,11 @@ describe('ValueMappings', () => {
     it('should use fuzzy matching', () => {
       expect(mapGyroType('some compact gyro')).toBe(GyroType.COMPACT);
       expect(mapGyroType('heavy duty type')).toBe(GyroType.HEAVY_DUTY);
+    });
+
+    it('should fuzzy match XL gyro', () => {
+      expect(mapGyroType('some xl gyro')).toBe(GyroType.XL);
+      expect(mapGyroType('extra-light gyro')).toBe(GyroType.XL);
     });
 
     it('should default to STANDARD for unknown', () => {
@@ -331,6 +398,23 @@ describe('ValueMappings', () => {
     it('should use fuzzy matching', () => {
       expect(mapCockpitType('small cockpit')).toBe(CockpitType.SMALL);
       expect(mapCockpitType('torso mounted')).toBe(CockpitType.TORSO_MOUNTED);
+    });
+
+    it('should fuzzy match command console', () => {
+      expect(mapCockpitType('command console type')).toBe(CockpitType.COMMAND_CONSOLE);
+    });
+
+    it('should fuzzy match industrial cockpit', () => {
+      expect(mapCockpitType('industrial cockpit type')).toBe(CockpitType.INDUSTRIAL);
+    });
+
+    it('should fuzzy match primitive cockpit', () => {
+      expect(mapCockpitType('primitive cockpit type')).toBe(CockpitType.PRIMITIVE);
+    });
+
+    it('should fuzzy match superheavy cockpit', () => {
+      expect(mapCockpitType('superheavy cockpit type')).toBe(CockpitType.SUPER_HEAVY);
+      expect(mapCockpitType('super-heavy cockpit')).toBe(CockpitType.SUPER_HEAVY);
     });
 
     it('should default to STANDARD for unknown', () => {
@@ -359,6 +443,10 @@ describe('ValueMappings', () => {
       expect(mapMechConfiguration('quad mech')).toBe(MechConfiguration.QUAD);
       expect(mapMechConfiguration('tripod omni')).toBe(MechConfiguration.TRIPOD);
       expect(mapMechConfiguration('quad vee type')).toBe(MechConfiguration.QUADVEE);
+    });
+
+    it('should fuzzy match LAM configuration', () => {
+      expect(mapMechConfiguration('some lam type')).toBe(MechConfiguration.LAM);
     });
 
     it('should default to BIPED for unknown', () => {

--- a/src/services/units/UnitFactoryService.ts
+++ b/src/services/units/UnitFactoryService.ts
@@ -523,7 +523,7 @@ export class UnitFactoryService {
   /**
    * Build structure points map
    */
-  private buildStructurePoints(tonnage: number): Record<MechLocation, number> {
+  private buildStructurePoints(tonnage: number): Partial<Record<MechLocation, number>> {
     return {
       [MechLocation.HEAD]: getStructurePoints(MechLocation.HEAD, tonnage),
       [MechLocation.CENTER_TORSO]: getStructurePoints(MechLocation.CENTER_TORSO, tonnage),

--- a/src/services/units/UnitLoaderService.ts
+++ b/src/services/units/UnitLoaderService.ts
@@ -480,7 +480,7 @@ function mapArmorAllocation(
 type UnitCriticalSlots = Readonly<Record<string, ReadonlyArray<string | null>>>;
 type TechHint = 'clan' | 'is';
 
-const CRITICAL_SLOTS_LOCATION_KEYS: Readonly<Record<MechLocation, string>> = {
+const CRITICAL_SLOTS_LOCATION_KEYS: Partial<Readonly<Record<MechLocation, string>>> = {
   [MechLocation.HEAD]: 'HEAD',
   [MechLocation.CENTER_TORSO]: 'CENTER_TORSO',
   [MechLocation.LEFT_TORSO]: 'LEFT_TORSO',
@@ -728,7 +728,7 @@ function mapEquipment(
   return equipment.map((item) => {
     const location = mapMechLocation(item.location);
     const locationCriticalSlots = unitCriticalSlots
-      ? (location ? unitCriticalSlots[CRITICAL_SLOTS_LOCATION_KEYS[location]] : unitCriticalSlots[item.location])
+      ? (location ? unitCriticalSlots[CRITICAL_SLOTS_LOCATION_KEYS[location] ?? ''] : unitCriticalSlots[item.location])
       : undefined;
     
     // Look up equipment using multiple resolution strategies

--- a/src/stores/unitState.ts
+++ b/src/stores/unitState.ts
@@ -36,6 +36,8 @@ import { JumpJetType } from '@/utils/construction/movementCalculations';
  * Stores armor points assigned to each location (front and rear for torsos)
  */
 export interface IArmorAllocation {
+  /** Index signature allowing any MechLocation key */
+  [key: string]: number;
   /** Head armor points */
   [MechLocation.HEAD]: number;
   /** Center Torso front armor points */

--- a/src/types/construction/CriticalSlotAllocation.ts
+++ b/src/types/construction/CriticalSlotAllocation.ts
@@ -8,30 +8,84 @@
 
 /**
  * Mech locations for critical slot allocation
+ *
+ * Includes all locations across all mech configurations:
+ * - Biped: HEAD, CT, LT, RT, LA, RA, LL, RL (8 locations)
+ * - Quad: HEAD, CT, LT, RT, FLL, FRL, RLL, RRL (8 locations)
+ * - Tripod: HEAD, CT, LT, RT, LA, RA, LL, RL, CL (9 locations)
+ * - LAM Mech: Same as Biped
+ * - LAM Fighter: NOSE, LW, RW, AFT, FUSELAGE (5 locations, for armor mapping)
+ *
+ * @spec openspec/specs/mech-configuration-system/spec.md
  */
 export enum MechLocation {
+  // Universal locations (all configurations)
   HEAD = 'Head',
   CENTER_TORSO = 'Center Torso',
   LEFT_TORSO = 'Left Torso',
   RIGHT_TORSO = 'Right Torso',
+
+  // Biped/Tripod/LAM arm locations
   LEFT_ARM = 'Left Arm',
   RIGHT_ARM = 'Right Arm',
+
+  // Biped/Tripod/LAM leg locations
   LEFT_LEG = 'Left Leg',
   RIGHT_LEG = 'Right Leg',
+
+  // Tripod-specific location
+  CENTER_LEG = 'Center Leg',
+
+  // Quad/QuadVee-specific locations
+  FRONT_LEFT_LEG = 'Front Left Leg',
+  FRONT_RIGHT_LEG = 'Front Right Leg',
+  REAR_LEFT_LEG = 'Rear Left Leg',
+  REAR_RIGHT_LEG = 'Rear Right Leg',
+
+  // LAM Fighter mode locations (for armor mapping)
+  NOSE = 'Nose',
+  LEFT_WING = 'Left Wing',
+  RIGHT_WING = 'Right Wing',
+  AFT = 'Aft',
+  FUSELAGE = 'Fuselage',
 }
 
 /**
  * Critical slot counts per location
+ *
+ * Note: Quad legs have 12 slots (same as arms in biped).
+ * LAM fighter locations are for armor mapping only, not critical slots.
  */
 export const LOCATION_SLOT_COUNTS: Readonly<Record<MechLocation, number>> = {
+  // Universal locations
   [MechLocation.HEAD]: 6,
   [MechLocation.CENTER_TORSO]: 12,
   [MechLocation.LEFT_TORSO]: 12,
   [MechLocation.RIGHT_TORSO]: 12,
+
+  // Biped/Tripod/LAM arm locations
   [MechLocation.LEFT_ARM]: 12,
   [MechLocation.RIGHT_ARM]: 12,
+
+  // Biped/Tripod/LAM leg locations (6 slots)
   [MechLocation.LEFT_LEG]: 6,
   [MechLocation.RIGHT_LEG]: 6,
+
+  // Tripod center leg
+  [MechLocation.CENTER_LEG]: 6,
+
+  // Quad/QuadVee leg locations (12 slots each)
+  [MechLocation.FRONT_LEFT_LEG]: 12,
+  [MechLocation.FRONT_RIGHT_LEG]: 12,
+  [MechLocation.REAR_LEFT_LEG]: 12,
+  [MechLocation.REAR_RIGHT_LEG]: 12,
+
+  // LAM Fighter mode locations (not used for critical slots, 0 by convention)
+  [MechLocation.NOSE]: 0,
+  [MechLocation.LEFT_WING]: 0,
+  [MechLocation.RIGHT_WING]: 0,
+  [MechLocation.AFT]: 0,
+  [MechLocation.FUSELAGE]: 0,
 };
 
 /**

--- a/src/types/construction/MechConfigurationSystem.ts
+++ b/src/types/construction/MechConfigurationSystem.ts
@@ -129,6 +129,34 @@ export enum QuadVeeMode {
 }
 
 /**
+ * QuadVee mode definition
+ */
+export interface IQuadVeeModeDefinition {
+  readonly mode: QuadVeeMode;
+  readonly displayName: string;
+  readonly movementType: 'ground' | 'tracked';
+  readonly description: string;
+}
+
+/**
+ * QuadVee mode definitions
+ */
+export const QUADVEE_MODES: readonly IQuadVeeModeDefinition[] = [
+  {
+    mode: QuadVeeMode.MECH,
+    displayName: 'Mech Mode',
+    movementType: 'ground',
+    description: 'Standard quad mech movement with legs',
+  },
+  {
+    mode: QuadVeeMode.VEHICLE,
+    displayName: 'Vehicle Mode',
+    movementType: 'tracked',
+    description: 'Tracked vehicle movement with wheels/treads',
+  },
+];
+
+/**
  * Complete mech configuration definition
  */
 export interface IMechConfigurationDefinition {
@@ -591,6 +619,35 @@ export const LAM_CONFIGURATION: IMechConfigurationDefinition = {
 };
 
 /**
+ * QuadVee required equipment definitions
+ * Conversion Equipment: Required in each leg for transformation
+ */
+export const QUADVEE_EQUIPMENT = {
+  CONVERSION_EQUIPMENT: {
+    id: 'conversion-equipment',
+    name: 'Conversion Equipment',
+    slots: 1,
+    locations: [
+      MechLocation.FRONT_LEFT_LEG,
+      MechLocation.FRONT_RIGHT_LEG,
+      MechLocation.REAR_LEFT_LEG,
+      MechLocation.REAR_RIGHT_LEG,
+    ],
+  },
+  TRACKS: {
+    id: 'tracks',
+    name: 'Tracks',
+    slots: 1,
+    locations: [
+      MechLocation.FRONT_LEFT_LEG,
+      MechLocation.FRONT_RIGHT_LEG,
+      MechLocation.REAR_LEFT_LEG,
+      MechLocation.REAR_RIGHT_LEG,
+    ],
+  },
+} as const;
+
+/**
  * QuadVee mech configuration definition
  */
 export const QUADVEE_CONFIGURATION: IMechConfigurationDefinition = {
@@ -611,9 +668,9 @@ export const QUADVEE_CONFIGURATION: IMechConfigurationDefinition = {
   prohibitedEquipment: [],
   baseMovementModifier: 0,
   requiredEquipment: [
-    { equipmentId: 'conversion-equipment', locations: [MechLocation.CENTER_TORSO] },
+    { equipmentId: QUADVEE_EQUIPMENT.CONVERSION_EQUIPMENT.id, locations: QUADVEE_EQUIPMENT.CONVERSION_EQUIPMENT.locations },
   ],
-  diagramComponentName: 'QuadArmorDiagram',
+  diagramComponentName: 'QuadVeeArmorDiagram',
 };
 
 // =============================================================================
@@ -732,6 +789,27 @@ class MechConfigurationRegistry {
   getFighterArmorMapping(type: MechConfiguration): Readonly<Record<MechLocation, MechLocation>> | undefined {
     const fighterMode = this.getModeDefinition(type, LAMMode.FIGHTER);
     return fighterMode?.armorLocationMapping;
+  }
+
+  /**
+   * Check if configuration is a QuadVee
+   */
+  isQuadVeeConfiguration(type: MechConfiguration): boolean {
+    return type === MechConfiguration.QUADVEE;
+  }
+
+  /**
+   * Get QuadVee mode definitions
+   */
+  getQuadVeeModes(): readonly IQuadVeeModeDefinition[] {
+    return QUADVEE_MODES;
+  }
+
+  /**
+   * Get QuadVee mode definition by mode value
+   */
+  getQuadVeeModeDefinition(mode: QuadVeeMode): IQuadVeeModeDefinition | undefined {
+    return QUADVEE_MODES.find(m => m.mode === mode);
   }
 
   /**

--- a/src/types/construction/MechConfigurationSystem.ts
+++ b/src/types/construction/MechConfigurationSystem.ts
@@ -1,0 +1,685 @@
+/**
+ * Mech Configuration System
+ *
+ * Provides a data-driven configuration registry that defines location layouts,
+ * actuator requirements, equipment rules, and visual components for each mech
+ * configuration type (Biped, Quad, Tripod, LAM, QuadVee).
+ *
+ * @spec openspec/specs/mech-configuration-system/spec.md
+ */
+
+import { MechConfiguration } from '../unit/BattleMechInterfaces';
+import { MechLocation } from './CriticalSlotAllocation';
+
+// Re-export for convenience
+export { MechLocation, MechConfiguration };
+
+/**
+ * Biped-only locations (for backward compatibility with existing code)
+ */
+export type BipedLocation =
+  | MechLocation.HEAD
+  | MechLocation.CENTER_TORSO
+  | MechLocation.LEFT_TORSO
+  | MechLocation.RIGHT_TORSO
+  | MechLocation.LEFT_ARM
+  | MechLocation.RIGHT_ARM
+  | MechLocation.LEFT_LEG
+  | MechLocation.RIGHT_LEG;
+
+/**
+ * All biped locations as an array
+ */
+export const BIPED_LOCATION_VALUES: BipedLocation[] = [
+  MechLocation.HEAD,
+  MechLocation.CENTER_TORSO,
+  MechLocation.LEFT_TORSO,
+  MechLocation.RIGHT_TORSO,
+  MechLocation.LEFT_ARM,
+  MechLocation.RIGHT_ARM,
+  MechLocation.LEFT_LEG,
+  MechLocation.RIGHT_LEG,
+];
+
+/**
+ * Check if a location is a biped location
+ */
+export function isBipedLocation(location: MechLocation): location is BipedLocation {
+  return BIPED_LOCATION_VALUES.includes(location as BipedLocation);
+}
+
+/**
+ * Actuator types
+ */
+export enum ActuatorType {
+  // Arm actuators
+  SHOULDER = 'Shoulder',
+  UPPER_ARM = 'Upper Arm Actuator',
+  LOWER_ARM = 'Lower Arm Actuator',
+  HAND = 'Hand Actuator',
+
+  // Leg actuators
+  HIP = 'Hip',
+  UPPER_LEG = 'Upper Leg Actuator',
+  LOWER_LEG = 'Lower Leg Actuator',
+  FOOT = 'Foot Actuator',
+}
+
+/**
+ * Actuator slot definition
+ */
+export interface IActuatorSlot {
+  readonly type: ActuatorType;
+  readonly slotIndex: number;
+  readonly required: boolean;
+  readonly removable: boolean;
+}
+
+/**
+ * Location definition within a configuration
+ */
+export interface ILocationDefinition {
+  readonly id: MechLocation;
+  readonly displayName: string;
+  readonly abbreviation: string;
+  readonly criticalSlots: number;
+  readonly hasRearArmor: boolean;
+  readonly isLimb: boolean;
+  readonly actuators: readonly IActuatorSlot[];
+  readonly transfersTo?: MechLocation;
+  readonly maxArmorMultiplier: number; // Multiplied by internal structure points
+}
+
+/**
+ * Equipment mounting rule
+ */
+export interface IMountingRule {
+  readonly equipmentCategory: string;
+  readonly allowedLocations: readonly MechLocation[];
+  readonly requiresActuator?: ActuatorType;
+  readonly prohibitedReason?: string;
+}
+
+/**
+ * LAM operating mode
+ */
+export enum LAMMode {
+  MECH = 'Mech',
+  AIRMECH = 'AirMech',
+  FIGHTER = 'Fighter',
+}
+
+/**
+ * LAM mode definition
+ */
+export interface ILAMModeDefinition {
+  readonly mode: LAMMode;
+  readonly displayName: string;
+  readonly movementType: 'ground' | 'vtol' | 'aerospace';
+  readonly weaponRestrictions: readonly string[];
+  readonly armorLocationMapping?: Readonly<Record<MechLocation, MechLocation>>;
+}
+
+/**
+ * QuadVee operating mode
+ */
+export enum QuadVeeMode {
+  MECH = 'Mech',
+  VEHICLE = 'Vehicle',
+}
+
+/**
+ * Complete mech configuration definition
+ */
+export interface IMechConfigurationDefinition {
+  readonly id: MechConfiguration;
+  readonly displayName: string;
+  readonly description: string;
+
+  // Location layout
+  readonly locations: readonly ILocationDefinition[];
+
+  // Equipment restrictions
+  readonly mountingRules: readonly IMountingRule[];
+  readonly prohibitedEquipment: readonly string[];
+
+  // Movement modifiers
+  readonly baseMovementModifier: number;
+
+  // For transforming units (LAM, QuadVee)
+  readonly modes?: readonly ILAMModeDefinition[];
+
+  // Required equipment (e.g., LAM needs Landing Gear and Avionics)
+  readonly requiredEquipment?: readonly {
+    readonly equipmentId: string;
+    readonly locations: readonly MechLocation[];
+  }[];
+
+  // Visual component reference
+  readonly diagramComponentName: string;
+}
+
+/**
+ * Standard arm actuators (biped/tripod/LAM)
+ */
+export const ARM_ACTUATORS: readonly IActuatorSlot[] = [
+  { type: ActuatorType.SHOULDER, slotIndex: 0, required: true, removable: false },
+  { type: ActuatorType.UPPER_ARM, slotIndex: 1, required: true, removable: false },
+  { type: ActuatorType.LOWER_ARM, slotIndex: 2, required: false, removable: true },
+  { type: ActuatorType.HAND, slotIndex: 3, required: false, removable: true },
+];
+
+/**
+ * Standard leg actuators (all configurations)
+ */
+export const LEG_ACTUATORS: readonly IActuatorSlot[] = [
+  { type: ActuatorType.HIP, slotIndex: 0, required: true, removable: false },
+  { type: ActuatorType.UPPER_LEG, slotIndex: 1, required: true, removable: false },
+  { type: ActuatorType.LOWER_LEG, slotIndex: 2, required: true, removable: false },
+  { type: ActuatorType.FOOT, slotIndex: 3, required: true, removable: false },
+];
+
+/**
+ * Biped location set
+ */
+export const BIPED_LOCATIONS: MechLocation[] = [
+  MechLocation.HEAD,
+  MechLocation.CENTER_TORSO,
+  MechLocation.LEFT_TORSO,
+  MechLocation.RIGHT_TORSO,
+  MechLocation.LEFT_ARM,
+  MechLocation.RIGHT_ARM,
+  MechLocation.LEFT_LEG,
+  MechLocation.RIGHT_LEG,
+];
+
+/**
+ * Quad location set
+ */
+export const QUAD_LOCATIONS: MechLocation[] = [
+  MechLocation.HEAD,
+  MechLocation.CENTER_TORSO,
+  MechLocation.LEFT_TORSO,
+  MechLocation.RIGHT_TORSO,
+  MechLocation.FRONT_LEFT_LEG,
+  MechLocation.FRONT_RIGHT_LEG,
+  MechLocation.REAR_LEFT_LEG,
+  MechLocation.REAR_RIGHT_LEG,
+];
+
+/**
+ * Tripod location set
+ */
+export const TRIPOD_LOCATIONS: MechLocation[] = [
+  MechLocation.HEAD,
+  MechLocation.CENTER_TORSO,
+  MechLocation.LEFT_TORSO,
+  MechLocation.RIGHT_TORSO,
+  MechLocation.LEFT_ARM,
+  MechLocation.RIGHT_ARM,
+  MechLocation.LEFT_LEG,
+  MechLocation.RIGHT_LEG,
+  MechLocation.CENTER_LEG,
+];
+
+/**
+ * LAM Fighter mode location set
+ */
+export const LAM_FIGHTER_LOCATIONS: MechLocation[] = [
+  MechLocation.NOSE,
+  MechLocation.LEFT_WING,
+  MechLocation.RIGHT_WING,
+  MechLocation.AFT,
+  MechLocation.FUSELAGE,
+];
+
+/**
+ * Get locations for a specific configuration
+ */
+export function getLocationsForConfig(config: MechConfiguration): MechLocation[] {
+  switch (config) {
+    case MechConfiguration.QUAD:
+    case MechConfiguration.QUADVEE:
+      return QUAD_LOCATIONS;
+    case MechConfiguration.TRIPOD:
+      return TRIPOD_LOCATIONS;
+    case MechConfiguration.LAM:
+    case MechConfiguration.BIPED:
+    default:
+      return BIPED_LOCATIONS;
+  }
+}
+
+/**
+ * Check if a location is valid for a configuration
+ */
+export function isValidLocationForConfig(location: MechLocation, config: MechConfiguration): boolean {
+  const validLocations = getLocationsForConfig(config);
+  return validLocations.includes(location);
+}
+
+/**
+ * Get display name for a location in a specific configuration context
+ */
+export function getLocationDisplayName(location: MechLocation): string {
+  return location; // The enum value is already the display name
+}
+
+/**
+ * Get the short abbreviation for a location (used in MTF format)
+ */
+export function getLocationAbbreviation(location: MechLocation): string {
+  const abbreviations: Record<MechLocation, string> = {
+    [MechLocation.HEAD]: 'HD',
+    [MechLocation.CENTER_TORSO]: 'CT',
+    [MechLocation.LEFT_TORSO]: 'LT',
+    [MechLocation.RIGHT_TORSO]: 'RT',
+    [MechLocation.LEFT_ARM]: 'LA',
+    [MechLocation.RIGHT_ARM]: 'RA',
+    [MechLocation.LEFT_LEG]: 'LL',
+    [MechLocation.RIGHT_LEG]: 'RL',
+    [MechLocation.CENTER_LEG]: 'CL',
+    [MechLocation.FRONT_LEFT_LEG]: 'FLL',
+    [MechLocation.FRONT_RIGHT_LEG]: 'FRL',
+    [MechLocation.REAR_LEFT_LEG]: 'RLL',
+    [MechLocation.REAR_RIGHT_LEG]: 'RRL',
+    [MechLocation.NOSE]: 'NOS',
+    [MechLocation.LEFT_WING]: 'LW',
+    [MechLocation.RIGHT_WING]: 'RW',
+    [MechLocation.AFT]: 'AFT',
+    [MechLocation.FUSELAGE]: 'FUS',
+  };
+  return abbreviations[location] || location;
+}
+
+/**
+ * Get critical slot count for a location based on configuration
+ */
+export function getLocationSlotCount(location: MechLocation, config: MechConfiguration): number {
+  // Head always has 6 slots
+  if (location === MechLocation.HEAD) {
+    return 6;
+  }
+
+  // Torsos always have 12 slots
+  if ([MechLocation.CENTER_TORSO, MechLocation.LEFT_TORSO, MechLocation.RIGHT_TORSO].includes(location)) {
+    return 12;
+  }
+
+  // Arms have 12 slots
+  if ([MechLocation.LEFT_ARM, MechLocation.RIGHT_ARM].includes(location)) {
+    return 12;
+  }
+
+  // Biped/Tripod legs have 6 slots
+  if ([MechLocation.LEFT_LEG, MechLocation.RIGHT_LEG, MechLocation.CENTER_LEG].includes(location)) {
+    return 6;
+  }
+
+  // Quad legs have 12 slots (same as arms in biped)
+  if ([MechLocation.FRONT_LEFT_LEG, MechLocation.FRONT_RIGHT_LEG,
+       MechLocation.REAR_LEFT_LEG, MechLocation.REAR_RIGHT_LEG].includes(location)) {
+    return 12;
+  }
+
+  return 0;
+}
+
+/**
+ * Check if a location is a leg (for actuator purposes)
+ */
+export function isLegLocation(location: MechLocation): boolean {
+  return [
+    MechLocation.LEFT_LEG,
+    MechLocation.RIGHT_LEG,
+    MechLocation.CENTER_LEG,
+    MechLocation.FRONT_LEFT_LEG,
+    MechLocation.FRONT_RIGHT_LEG,
+    MechLocation.REAR_LEFT_LEG,
+    MechLocation.REAR_RIGHT_LEG,
+  ].includes(location);
+}
+
+/**
+ * Check if a location is an arm
+ */
+export function isArmLocation(location: MechLocation): boolean {
+  return [MechLocation.LEFT_ARM, MechLocation.RIGHT_ARM].includes(location);
+}
+
+/**
+ * Check if a location has rear armor
+ */
+export function hasRearArmor(location: MechLocation): boolean {
+  return [
+    MechLocation.CENTER_TORSO,
+    MechLocation.LEFT_TORSO,
+    MechLocation.RIGHT_TORSO,
+  ].includes(location);
+}
+
+/**
+ * Get actuators for a location based on configuration
+ */
+export function getActuatorsForLocation(
+  location: MechLocation,
+  config: MechConfiguration
+): readonly IActuatorSlot[] {
+  // Head, torsos have no actuators
+  if ([MechLocation.HEAD, MechLocation.CENTER_TORSO,
+       MechLocation.LEFT_TORSO, MechLocation.RIGHT_TORSO].includes(location)) {
+    return [];
+  }
+
+  // Arms use arm actuators (biped, tripod, LAM only)
+  if (isArmLocation(location)) {
+    if (config === MechConfiguration.QUAD || config === MechConfiguration.QUADVEE) {
+      return []; // Quads don't have arms
+    }
+    return ARM_ACTUATORS;
+  }
+
+  // All legs use leg actuators
+  if (isLegLocation(location)) {
+    return LEG_ACTUATORS;
+  }
+
+  return [];
+}
+
+// =============================================================================
+// Configuration Definitions
+// =============================================================================
+
+/**
+ * Helper to create a location definition
+ */
+function createLocationDef(
+  id: MechLocation,
+  displayName: string,
+  abbreviation: string,
+  criticalSlots: number,
+  options: {
+    hasRearArmor?: boolean;
+    isLimb?: boolean;
+    actuators?: readonly IActuatorSlot[];
+    transfersTo?: MechLocation;
+    maxArmorMultiplier?: number;
+  } = {}
+): ILocationDefinition {
+  return {
+    id,
+    displayName,
+    abbreviation,
+    criticalSlots,
+    hasRearArmor: options.hasRearArmor ?? false,
+    isLimb: options.isLimb ?? false,
+    actuators: options.actuators ?? [],
+    transfersTo: options.transfersTo,
+    maxArmorMultiplier: options.maxArmorMultiplier ?? 2,
+  };
+}
+
+/**
+ * Biped mech configuration definition
+ */
+export const BIPED_CONFIGURATION: IMechConfigurationDefinition = {
+  id: MechConfiguration.BIPED,
+  displayName: 'Biped',
+  description: 'Standard two-legged BattleMech with arms',
+  locations: [
+    createLocationDef(MechLocation.HEAD, 'Head', 'HD', 6, { maxArmorMultiplier: 3 }),
+    createLocationDef(MechLocation.CENTER_TORSO, 'Center Torso', 'CT', 12, { hasRearArmor: true }),
+    createLocationDef(MechLocation.LEFT_TORSO, 'Left Torso', 'LT', 12, { hasRearArmor: true, transfersTo: MechLocation.CENTER_TORSO }),
+    createLocationDef(MechLocation.RIGHT_TORSO, 'Right Torso', 'RT', 12, { hasRearArmor: true, transfersTo: MechLocation.CENTER_TORSO }),
+    createLocationDef(MechLocation.LEFT_ARM, 'Left Arm', 'LA', 12, { isLimb: true, actuators: ARM_ACTUATORS, transfersTo: MechLocation.LEFT_TORSO }),
+    createLocationDef(MechLocation.RIGHT_ARM, 'Right Arm', 'RA', 12, { isLimb: true, actuators: ARM_ACTUATORS, transfersTo: MechLocation.RIGHT_TORSO }),
+    createLocationDef(MechLocation.LEFT_LEG, 'Left Leg', 'LL', 6, { isLimb: true, actuators: LEG_ACTUATORS, transfersTo: MechLocation.LEFT_TORSO }),
+    createLocationDef(MechLocation.RIGHT_LEG, 'Right Leg', 'RL', 6, { isLimb: true, actuators: LEG_ACTUATORS, transfersTo: MechLocation.RIGHT_TORSO }),
+  ],
+  mountingRules: [],
+  prohibitedEquipment: [],
+  baseMovementModifier: 0,
+  diagramComponentName: 'BipedArmorDiagram',
+};
+
+/**
+ * Quad mech configuration definition
+ */
+export const QUAD_CONFIGURATION: IMechConfigurationDefinition = {
+  id: MechConfiguration.QUAD,
+  displayName: 'Quad',
+  description: 'Four-legged BattleMech without arms',
+  locations: [
+    createLocationDef(MechLocation.HEAD, 'Head', 'HD', 6, { maxArmorMultiplier: 3 }),
+    createLocationDef(MechLocation.CENTER_TORSO, 'Center Torso', 'CT', 12, { hasRearArmor: true }),
+    createLocationDef(MechLocation.LEFT_TORSO, 'Left Torso', 'LT', 12, { hasRearArmor: true, transfersTo: MechLocation.CENTER_TORSO }),
+    createLocationDef(MechLocation.RIGHT_TORSO, 'Right Torso', 'RT', 12, { hasRearArmor: true, transfersTo: MechLocation.CENTER_TORSO }),
+    createLocationDef(MechLocation.FRONT_LEFT_LEG, 'Front Left Leg', 'FLL', 12, { isLimb: true, actuators: LEG_ACTUATORS, transfersTo: MechLocation.LEFT_TORSO }),
+    createLocationDef(MechLocation.FRONT_RIGHT_LEG, 'Front Right Leg', 'FRL', 12, { isLimb: true, actuators: LEG_ACTUATORS, transfersTo: MechLocation.RIGHT_TORSO }),
+    createLocationDef(MechLocation.REAR_LEFT_LEG, 'Rear Left Leg', 'RLL', 12, { isLimb: true, actuators: LEG_ACTUATORS, transfersTo: MechLocation.LEFT_TORSO }),
+    createLocationDef(MechLocation.REAR_RIGHT_LEG, 'Rear Right Leg', 'RRL', 12, { isLimb: true, actuators: LEG_ACTUATORS, transfersTo: MechLocation.RIGHT_TORSO }),
+  ],
+  mountingRules: [],
+  prohibitedEquipment: [],
+  baseMovementModifier: 0,
+  diagramComponentName: 'QuadArmorDiagram',
+};
+
+/**
+ * Tripod mech configuration definition
+ */
+export const TRIPOD_CONFIGURATION: IMechConfigurationDefinition = {
+  id: MechConfiguration.TRIPOD,
+  displayName: 'Tripod',
+  description: 'Three-legged BattleMech with arms and center leg',
+  locations: [
+    createLocationDef(MechLocation.HEAD, 'Head', 'HD', 6, { maxArmorMultiplier: 3 }),
+    createLocationDef(MechLocation.CENTER_TORSO, 'Center Torso', 'CT', 12, { hasRearArmor: true }),
+    createLocationDef(MechLocation.LEFT_TORSO, 'Left Torso', 'LT', 12, { hasRearArmor: true, transfersTo: MechLocation.CENTER_TORSO }),
+    createLocationDef(MechLocation.RIGHT_TORSO, 'Right Torso', 'RT', 12, { hasRearArmor: true, transfersTo: MechLocation.CENTER_TORSO }),
+    createLocationDef(MechLocation.LEFT_ARM, 'Left Arm', 'LA', 12, { isLimb: true, actuators: ARM_ACTUATORS, transfersTo: MechLocation.LEFT_TORSO }),
+    createLocationDef(MechLocation.RIGHT_ARM, 'Right Arm', 'RA', 12, { isLimb: true, actuators: ARM_ACTUATORS, transfersTo: MechLocation.RIGHT_TORSO }),
+    createLocationDef(MechLocation.LEFT_LEG, 'Left Leg', 'LL', 6, { isLimb: true, actuators: LEG_ACTUATORS, transfersTo: MechLocation.LEFT_TORSO }),
+    createLocationDef(MechLocation.RIGHT_LEG, 'Right Leg', 'RL', 6, { isLimb: true, actuators: LEG_ACTUATORS, transfersTo: MechLocation.RIGHT_TORSO }),
+    createLocationDef(MechLocation.CENTER_LEG, 'Center Leg', 'CL', 6, { isLimb: true, actuators: LEG_ACTUATORS, transfersTo: MechLocation.CENTER_TORSO }),
+  ],
+  mountingRules: [],
+  prohibitedEquipment: [],
+  baseMovementModifier: 0,
+  diagramComponentName: 'TripodArmorDiagram',
+};
+
+/**
+ * LAM mech configuration definition
+ */
+export const LAM_CONFIGURATION: IMechConfigurationDefinition = {
+  id: MechConfiguration.LAM,
+  displayName: 'Land-Air Mech',
+  description: 'Transformable BattleMech capable of flight',
+  locations: [
+    createLocationDef(MechLocation.HEAD, 'Head', 'HD', 6, { maxArmorMultiplier: 3 }),
+    createLocationDef(MechLocation.CENTER_TORSO, 'Center Torso', 'CT', 12, { hasRearArmor: true }),
+    createLocationDef(MechLocation.LEFT_TORSO, 'Left Torso', 'LT', 12, { hasRearArmor: true, transfersTo: MechLocation.CENTER_TORSO }),
+    createLocationDef(MechLocation.RIGHT_TORSO, 'Right Torso', 'RT', 12, { hasRearArmor: true, transfersTo: MechLocation.CENTER_TORSO }),
+    createLocationDef(MechLocation.LEFT_ARM, 'Left Arm', 'LA', 12, { isLimb: true, actuators: ARM_ACTUATORS, transfersTo: MechLocation.LEFT_TORSO }),
+    createLocationDef(MechLocation.RIGHT_ARM, 'Right Arm', 'RA', 12, { isLimb: true, actuators: ARM_ACTUATORS, transfersTo: MechLocation.RIGHT_TORSO }),
+    createLocationDef(MechLocation.LEFT_LEG, 'Left Leg', 'LL', 6, { isLimb: true, actuators: LEG_ACTUATORS, transfersTo: MechLocation.LEFT_TORSO }),
+    createLocationDef(MechLocation.RIGHT_LEG, 'Right Leg', 'RL', 6, { isLimb: true, actuators: LEG_ACTUATORS, transfersTo: MechLocation.RIGHT_TORSO }),
+  ],
+  mountingRules: [],
+  prohibitedEquipment: [],
+  baseMovementModifier: 0,
+  modes: [
+    {
+      mode: LAMMode.MECH,
+      displayName: 'Mech Mode',
+      movementType: 'ground',
+      weaponRestrictions: [],
+    },
+    {
+      mode: LAMMode.AIRMECH,
+      displayName: 'AirMech Mode',
+      movementType: 'vtol',
+      weaponRestrictions: [],
+    },
+    {
+      mode: LAMMode.FIGHTER,
+      displayName: 'Fighter Mode',
+      movementType: 'aerospace',
+      weaponRestrictions: ['physical'],
+      armorLocationMapping: {
+        [MechLocation.HEAD]: MechLocation.NOSE,
+        [MechLocation.CENTER_TORSO]: MechLocation.FUSELAGE,
+        [MechLocation.LEFT_TORSO]: MechLocation.LEFT_WING,
+        [MechLocation.RIGHT_TORSO]: MechLocation.RIGHT_WING,
+        [MechLocation.LEFT_ARM]: MechLocation.LEFT_WING,
+        [MechLocation.RIGHT_ARM]: MechLocation.RIGHT_WING,
+        [MechLocation.LEFT_LEG]: MechLocation.AFT,
+        [MechLocation.RIGHT_LEG]: MechLocation.AFT,
+        // Fighter-only locations map to themselves
+        [MechLocation.NOSE]: MechLocation.NOSE,
+        [MechLocation.LEFT_WING]: MechLocation.LEFT_WING,
+        [MechLocation.RIGHT_WING]: MechLocation.RIGHT_WING,
+        [MechLocation.AFT]: MechLocation.AFT,
+        [MechLocation.FUSELAGE]: MechLocation.FUSELAGE,
+        // Non-LAM locations (should not be used but required by type)
+        [MechLocation.CENTER_LEG]: MechLocation.AFT,
+        [MechLocation.FRONT_LEFT_LEG]: MechLocation.AFT,
+        [MechLocation.FRONT_RIGHT_LEG]: MechLocation.AFT,
+        [MechLocation.REAR_LEFT_LEG]: MechLocation.AFT,
+        [MechLocation.REAR_RIGHT_LEG]: MechLocation.AFT,
+      },
+    },
+  ],
+  requiredEquipment: [
+    { equipmentId: 'landing-gear', locations: [MechLocation.CENTER_TORSO] },
+    { equipmentId: 'avionics', locations: [MechLocation.HEAD] },
+  ],
+  diagramComponentName: 'LAMArmorDiagram',
+};
+
+/**
+ * QuadVee mech configuration definition
+ */
+export const QUADVEE_CONFIGURATION: IMechConfigurationDefinition = {
+  id: MechConfiguration.QUADVEE,
+  displayName: 'QuadVee',
+  description: 'Transformable quad mech capable of vehicle mode',
+  locations: [
+    createLocationDef(MechLocation.HEAD, 'Head', 'HD', 6, { maxArmorMultiplier: 3 }),
+    createLocationDef(MechLocation.CENTER_TORSO, 'Center Torso', 'CT', 12, { hasRearArmor: true }),
+    createLocationDef(MechLocation.LEFT_TORSO, 'Left Torso', 'LT', 12, { hasRearArmor: true, transfersTo: MechLocation.CENTER_TORSO }),
+    createLocationDef(MechLocation.RIGHT_TORSO, 'Right Torso', 'RT', 12, { hasRearArmor: true, transfersTo: MechLocation.CENTER_TORSO }),
+    createLocationDef(MechLocation.FRONT_LEFT_LEG, 'Front Left Leg', 'FLL', 12, { isLimb: true, actuators: LEG_ACTUATORS, transfersTo: MechLocation.LEFT_TORSO }),
+    createLocationDef(MechLocation.FRONT_RIGHT_LEG, 'Front Right Leg', 'FRL', 12, { isLimb: true, actuators: LEG_ACTUATORS, transfersTo: MechLocation.RIGHT_TORSO }),
+    createLocationDef(MechLocation.REAR_LEFT_LEG, 'Rear Left Leg', 'RLL', 12, { isLimb: true, actuators: LEG_ACTUATORS, transfersTo: MechLocation.LEFT_TORSO }),
+    createLocationDef(MechLocation.REAR_RIGHT_LEG, 'Rear Right Leg', 'RRL', 12, { isLimb: true, actuators: LEG_ACTUATORS, transfersTo: MechLocation.RIGHT_TORSO }),
+  ],
+  mountingRules: [],
+  prohibitedEquipment: [],
+  baseMovementModifier: 0,
+  requiredEquipment: [
+    { equipmentId: 'conversion-equipment', locations: [MechLocation.CENTER_TORSO] },
+  ],
+  diagramComponentName: 'QuadArmorDiagram',
+};
+
+// =============================================================================
+// Configuration Registry
+// =============================================================================
+
+/**
+ * Registry of all mech configuration definitions
+ */
+class MechConfigurationRegistry {
+  private readonly configurations: Map<MechConfiguration, IMechConfigurationDefinition>;
+
+  constructor() {
+    this.configurations = new Map([
+      [MechConfiguration.BIPED, BIPED_CONFIGURATION],
+      [MechConfiguration.QUAD, QUAD_CONFIGURATION],
+      [MechConfiguration.TRIPOD, TRIPOD_CONFIGURATION],
+      [MechConfiguration.LAM, LAM_CONFIGURATION],
+      [MechConfiguration.QUADVEE, QUADVEE_CONFIGURATION],
+    ]);
+  }
+
+  /**
+   * Get configuration definition by type
+   */
+  getConfiguration(type: MechConfiguration): IMechConfigurationDefinition {
+    const config = this.configurations.get(type);
+    if (!config) {
+      // Default to biped if unknown configuration
+      return BIPED_CONFIGURATION;
+    }
+    return config;
+  }
+
+  /**
+   * Get all configuration definitions
+   */
+  getAllConfigurations(): IMechConfigurationDefinition[] {
+    return Array.from(this.configurations.values());
+  }
+
+  /**
+   * Get location definitions for a configuration
+   */
+  getLocationDefinitions(type: MechConfiguration): readonly ILocationDefinition[] {
+    return this.getConfiguration(type).locations;
+  }
+
+  /**
+   * Get a specific location definition
+   */
+  getLocationDefinition(type: MechConfiguration, location: MechLocation): ILocationDefinition | undefined {
+    return this.getConfiguration(type).locations.find(loc => loc.id === location);
+  }
+
+  /**
+   * Check if a configuration supports a specific location
+   */
+  hasLocation(type: MechConfiguration, location: MechLocation): boolean {
+    return this.getConfiguration(type).locations.some(loc => loc.id === location);
+  }
+
+  /**
+   * Get all valid locations for a configuration
+   */
+  getValidLocations(type: MechConfiguration): MechLocation[] {
+    return this.getConfiguration(type).locations.map(loc => loc.id);
+  }
+
+  /**
+   * Get the diagram component name for a configuration
+   */
+  getDiagramComponentName(type: MechConfiguration): string {
+    return this.getConfiguration(type).diagramComponentName;
+  }
+
+  /**
+   * Check if configuration is a quad type (Quad or QuadVee)
+   */
+  isQuadConfiguration(type: MechConfiguration): boolean {
+    return type === MechConfiguration.QUAD || type === MechConfiguration.QUADVEE;
+  }
+
+  /**
+   * Check if configuration is a transforming type (LAM or QuadVee)
+   */
+  isTransformingConfiguration(type: MechConfiguration): boolean {
+    return type === MechConfiguration.LAM || type === MechConfiguration.QUADVEE;
+  }
+}
+
+/**
+ * Singleton instance of the configuration registry
+ */
+export const configurationRegistry = new MechConfigurationRegistry();
+
+/**
+ * Type alias for export
+ */
+export type { MechConfigurationRegistry };

--- a/src/types/construction/MechConfigurationSystem.ts
+++ b/src/types/construction/MechConfigurationSystem.ts
@@ -294,30 +294,37 @@ export function getLocationDisplayName(location: MechLocation): string {
 }
 
 /**
+ * Canonical location abbreviations for all mech locations
+ *
+ * Includes all configurations: biped, quad, tripod, and LAM fighter mode.
+ * Use this as the single source of truth for location abbreviations.
+ */
+export const LOCATION_ABBREVIATION_MAP: Readonly<Record<MechLocation, string>> = {
+  [MechLocation.HEAD]: 'HD',
+  [MechLocation.CENTER_TORSO]: 'CT',
+  [MechLocation.LEFT_TORSO]: 'LT',
+  [MechLocation.RIGHT_TORSO]: 'RT',
+  [MechLocation.LEFT_ARM]: 'LA',
+  [MechLocation.RIGHT_ARM]: 'RA',
+  [MechLocation.LEFT_LEG]: 'LL',
+  [MechLocation.RIGHT_LEG]: 'RL',
+  [MechLocation.CENTER_LEG]: 'CL',
+  [MechLocation.FRONT_LEFT_LEG]: 'FLL',
+  [MechLocation.FRONT_RIGHT_LEG]: 'FRL',
+  [MechLocation.REAR_LEFT_LEG]: 'RLL',
+  [MechLocation.REAR_RIGHT_LEG]: 'RRL',
+  [MechLocation.NOSE]: 'NOS',
+  [MechLocation.LEFT_WING]: 'LW',
+  [MechLocation.RIGHT_WING]: 'RW',
+  [MechLocation.AFT]: 'AFT',
+  [MechLocation.FUSELAGE]: 'FUS',
+};
+
+/**
  * Get the short abbreviation for a location (used in MTF format)
  */
 export function getLocationAbbreviation(location: MechLocation): string {
-  const abbreviations: Record<MechLocation, string> = {
-    [MechLocation.HEAD]: 'HD',
-    [MechLocation.CENTER_TORSO]: 'CT',
-    [MechLocation.LEFT_TORSO]: 'LT',
-    [MechLocation.RIGHT_TORSO]: 'RT',
-    [MechLocation.LEFT_ARM]: 'LA',
-    [MechLocation.RIGHT_ARM]: 'RA',
-    [MechLocation.LEFT_LEG]: 'LL',
-    [MechLocation.RIGHT_LEG]: 'RL',
-    [MechLocation.CENTER_LEG]: 'CL',
-    [MechLocation.FRONT_LEFT_LEG]: 'FLL',
-    [MechLocation.FRONT_RIGHT_LEG]: 'FRL',
-    [MechLocation.REAR_LEFT_LEG]: 'RLL',
-    [MechLocation.REAR_RIGHT_LEG]: 'RRL',
-    [MechLocation.NOSE]: 'NOS',
-    [MechLocation.LEFT_WING]: 'LW',
-    [MechLocation.RIGHT_WING]: 'RW',
-    [MechLocation.AFT]: 'AFT',
-    [MechLocation.FUSELAGE]: 'FUS',
-  };
-  return abbreviations[location] || location;
+  return LOCATION_ABBREVIATION_MAP[location] || location;
 }
 
 /**

--- a/src/types/construction/index.ts
+++ b/src/types/construction/index.ts
@@ -12,6 +12,7 @@ export * from './ArmorType';
 export * from './CockpitType';
 export * from './ComponentInterfaces';
 export * from './CriticalSlotAllocation';
+export * from './MechConfigurationSystem';
 export * from './MovementEnhancement';
 export * from './TechBaseConfiguration';
 

--- a/src/types/core/UnitInterfaces.ts
+++ b/src/types/core/UnitInterfaces.ts
@@ -39,14 +39,7 @@ export interface MountedBattleArmor {
   troopers: number;
 }
 
-export enum LAMMode {
-  MECH = 'BattleMech',
-  AIRMECH = 'AirMech',
-  FIGHTER = 'Fighter',
-}
-
-export enum QuadVeeMode {
-  MECH = 'Mech',
-  VEHICLE = 'Vehicle',
-}
+// LAMMode and QuadVeeMode enums are defined in MechConfigurationSystem.ts
+// Re-export them here for backward compatibility if needed
+export { LAMMode, QuadVeeMode } from '../construction/MechConfigurationSystem';
 

--- a/src/types/pages/UnitPageTypes.ts
+++ b/src/types/pages/UnitPageTypes.ts
@@ -58,7 +58,7 @@ export interface IUnitDetails {
   movement?: IMovementConfig;
   equipment?: IMountedEquipmentEntry[];
   quirks?: string[];
-  metadata?: IUnitMetadata;
+  metadata?: IPageUnitMetadata;
 }
 
 /**
@@ -128,9 +128,12 @@ export interface IMountedEquipmentEntry {
 }
 
 /**
- * Unit metadata
+ * Lightweight unit metadata for page display
+ *
+ * Note: This is a simplified subset of IUnitMetadata from BattleMechInterfaces.
+ * Use this for page-level display; use the full IUnitMetadata for unit data.
  */
-export interface IUnitMetadata {
+export interface IPageUnitMetadata {
   chassis?: string;
   model?: string;
   role?: string;

--- a/src/types/pages/index.ts
+++ b/src/types/pages/index.ts
@@ -14,7 +14,7 @@ export {
   type IHeatSinkConfig,
   type IMovementConfig,
   type IMountedEquipmentEntry,
-  type IUnitMetadata,
+  type IPageUnitMetadata,
   type IUnitFilterState,
   isArmorFrontRear,
   calculateTotalArmor,

--- a/src/types/printing/RecordSheetTypes.ts
+++ b/src/types/printing/RecordSheetTypes.ts
@@ -7,6 +7,7 @@
  */
 
 import { MechLocation } from '../construction/CriticalSlotAllocation';
+import { LOCATION_ABBREVIATION_MAP, BIPED_LOCATION_VALUES } from '../construction/MechConfigurationSystem';
 
 /**
  * Paper size options for PDF generation
@@ -209,32 +210,22 @@ export interface IRect {
 }
 
 /**
- * Location abbreviation mapping
+ * Location abbreviation mapping (biped locations only for record sheets)
+ *
+ * @see LOCATION_ABBREVIATION_MAP in MechConfigurationSystem for full mapping
  */
-export const LOCATION_ABBREVIATIONS: Record<string, string> = {
-  [MechLocation.HEAD]: 'HD',
-  [MechLocation.CENTER_TORSO]: 'CT',
-  [MechLocation.LEFT_TORSO]: 'LT',
-  [MechLocation.RIGHT_TORSO]: 'RT',
-  [MechLocation.LEFT_ARM]: 'LA',
-  [MechLocation.RIGHT_ARM]: 'RA',
-  [MechLocation.LEFT_LEG]: 'LL',
-  [MechLocation.RIGHT_LEG]: 'RL',
-};
+export const LOCATION_ABBREVIATIONS: Record<string, string> = Object.fromEntries(
+  BIPED_LOCATION_VALUES.map(loc => [loc, LOCATION_ABBREVIATION_MAP[loc]])
+);
 
 /**
- * Location display names
+ * Location display names (biped locations only for record sheets)
+ *
+ * Note: MechLocation enum values are already display names (e.g., 'Left Arm')
  */
-export const LOCATION_NAMES: Record<string, string> = {
-  [MechLocation.HEAD]: 'Head',
-  [MechLocation.CENTER_TORSO]: 'Center Torso',
-  [MechLocation.LEFT_TORSO]: 'Left Torso',
-  [MechLocation.RIGHT_TORSO]: 'Right Torso',
-  [MechLocation.LEFT_ARM]: 'Left Arm',
-  [MechLocation.RIGHT_ARM]: 'Right Arm',
-  [MechLocation.LEFT_LEG]: 'Left Leg',
-  [MechLocation.RIGHT_LEG]: 'Right Leg',
-};
+export const LOCATION_NAMES: Record<string, string> = Object.fromEntries(
+  BIPED_LOCATION_VALUES.map(loc => [loc, loc])
+);
 
 /**
  * Options for PDF export

--- a/src/types/unit/BattleMechInterfaces.ts
+++ b/src/types/unit/BattleMechInterfaces.ts
@@ -91,7 +91,7 @@ export interface IGyroConfiguration {
  */
 export interface IStructureConfiguration {
   readonly type: InternalStructureType;
-  readonly points: Record<MechLocation, number>;
+  readonly points: Partial<Record<MechLocation, number>>;
 }
 
 /**

--- a/src/utils/validation/rules/ConfigurationValidationRules.ts
+++ b/src/utils/validation/rules/ConfigurationValidationRules.ts
@@ -405,6 +405,316 @@ export const BipedNoQuadLegsRule: IValidationRuleDefinition = {
 };
 
 // ============================================================================
+// LAM CONFIGURATION RULES
+// ============================================================================
+
+/**
+ * LAM maximum tonnage is 55 tons
+ */
+export const LAMMaxTonnageRule: IValidationRuleDefinition = {
+  id: 'configuration.lam.max_tonnage',
+  name: 'LAM Max Tonnage',
+  description: 'LAMs cannot exceed 55 tons',
+  category: ValidationCategory.CONSTRUCTION,
+  priority: 1,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'lam';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const tonnage = unit.tonnage as number | undefined;
+
+    if (tonnage !== undefined && tonnage > 55) {
+      return fail(this.id, [
+        {
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.ERROR,
+          category: this.category,
+          message: `LAMs cannot exceed 55 tons (current: ${tonnage} tons)`,
+          path: 'tonnage',
+          expected: '<= 55',
+          actual: `${tonnage}`,
+          suggestion: 'Reduce the mech tonnage to 55 or less',
+        },
+      ]);
+    }
+
+    return pass(this.id);
+  },
+};
+
+/**
+ * LAM engine type restriction - only standard fusion allowed
+ */
+export const LAMEngineTypeRule: IValidationRuleDefinition = {
+  id: 'configuration.lam.engine_type',
+  name: 'LAM Engine Type',
+  description: 'LAMs can only use standard Fusion engines (no XL, Light, Compact)',
+  category: ValidationCategory.CONSTRUCTION,
+  priority: 5,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'lam';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const engine = unit.engine as Record<string, unknown> | undefined;
+
+    if (!engine) {
+      return pass(this.id);
+    }
+
+    const engineType = (engine.type as string)?.toLowerCase() ?? '';
+    const prohibitedEngines = ['xl', 'light', 'compact', 'xxl', 'ice', 'fuel_cell', 'fission'];
+
+    for (const prohibited of prohibitedEngines) {
+      if (engineType.includes(prohibited)) {
+        return fail(this.id, [
+          {
+            ruleId: this.id,
+            ruleName: this.name,
+            severity: ValidationSeverity.ERROR,
+            category: this.category,
+            message: `LAMs cannot use ${engine.type} engines`,
+            path: 'engine.type',
+            expected: 'FUSION (Standard)',
+            actual: `${engine.type}`,
+            suggestion: 'Use a standard Fusion engine',
+          },
+        ]);
+      }
+    }
+
+    return pass(this.id);
+  },
+};
+
+/**
+ * LAM structure/armor restrictions - no Endo Steel or Ferro-Fibrous
+ */
+export const LAMStructureArmorRule: IValidationRuleDefinition = {
+  id: 'configuration.lam.structure_armor',
+  name: 'LAM Structure/Armor Restrictions',
+  description: 'LAMs cannot use Endo Steel or Ferro-Fibrous armor/structure',
+  category: ValidationCategory.CONSTRUCTION,
+  priority: 5,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'lam';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const structure = unit.structure as Record<string, unknown> | undefined;
+    const armor = unit.armor as Record<string, unknown> | undefined;
+    const errors: IValidationError[] = [];
+
+    // Check structure type
+    if (structure) {
+      const structureType = (structure.type as string)?.toLowerCase() ?? '';
+      if (structureType.includes('endo')) {
+        errors.push({
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.ERROR,
+          category: this.category,
+          message: `LAMs cannot use ${structure.type} structure`,
+          path: 'structure.type',
+          expected: 'STANDARD',
+          actual: `${structure.type}`,
+          suggestion: 'Use standard internal structure',
+        });
+      }
+    }
+
+    // Check armor type
+    if (armor) {
+      const armorType = (armor.type as string)?.toLowerCase() ?? '';
+      const prohibitedArmor = ['ferro', 'stealth', 'reactive', 'reflective', 'hardened'];
+
+      for (const prohibited of prohibitedArmor) {
+        if (armorType.includes(prohibited)) {
+          errors.push({
+            ruleId: this.id,
+            ruleName: this.name,
+            severity: ValidationSeverity.ERROR,
+            category: this.category,
+            message: `LAMs cannot use ${armor.type} armor`,
+            path: 'armor.type',
+            expected: 'STANDARD',
+            actual: `${armor.type}`,
+            suggestion: 'Use standard armor',
+          });
+          break;
+        }
+      }
+    }
+
+    if (errors.length > 0) {
+      return fail(this.id, errors);
+    }
+
+    return pass(this.id);
+  },
+};
+
+/**
+ * LAM requires Landing Gear equipment
+ */
+export const LAMLandingGearRule: IValidationRuleDefinition = {
+  id: 'configuration.lam.landing_gear',
+  name: 'LAM Landing Gear Required',
+  description: 'LAMs must have Landing Gear in CT, LT, and RT',
+  category: ValidationCategory.CONSTRUCTION,
+  priority: 10,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'lam';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const criticalSlots = unit.criticalSlots as Record<string, Array<string | null>> | undefined;
+
+    if (!criticalSlots) {
+      return warn(this.id, [
+        {
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.WARNING,
+          category: this.category,
+          message: 'Cannot verify Landing Gear - no critical slot data',
+          path: 'criticalSlots',
+        },
+      ]);
+    }
+
+    const requiredLocations = [
+      MechLocation.CENTER_TORSO,
+      MechLocation.LEFT_TORSO,
+      MechLocation.RIGHT_TORSO,
+    ];
+    const missingLocations: string[] = [];
+
+    for (const loc of requiredLocations) {
+      const slots = criticalSlots[loc];
+      if (!slots) {
+        missingLocations.push(loc);
+        continue;
+      }
+
+      const hasLandingGear = slots.some(
+        (s) => s && s.toLowerCase().includes('landing gear')
+      );
+      if (!hasLandingGear) {
+        missingLocations.push(loc);
+      }
+    }
+
+    if (missingLocations.length > 0) {
+      return fail(this.id, [
+        {
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.ERROR,
+          category: this.category,
+          message: `LAM missing Landing Gear in: ${missingLocations.join(', ')}`,
+          path: 'criticalSlots',
+          suggestion: 'Add Landing Gear to CT, LT, and RT',
+        },
+      ]);
+    }
+
+    return pass(this.id);
+  },
+};
+
+/**
+ * LAM requires Avionics equipment
+ */
+export const LAMAvionicsRule: IValidationRuleDefinition = {
+  id: 'configuration.lam.avionics',
+  name: 'LAM Avionics Required',
+  description: 'LAMs must have Avionics in HD, LT, and RT',
+  category: ValidationCategory.CONSTRUCTION,
+  priority: 10,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'lam';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const criticalSlots = unit.criticalSlots as Record<string, Array<string | null>> | undefined;
+
+    if (!criticalSlots) {
+      return warn(this.id, [
+        {
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.WARNING,
+          category: this.category,
+          message: 'Cannot verify Avionics - no critical slot data',
+          path: 'criticalSlots',
+        },
+      ]);
+    }
+
+    const requiredLocations = [
+      MechLocation.HEAD,
+      MechLocation.LEFT_TORSO,
+      MechLocation.RIGHT_TORSO,
+    ];
+    const missingLocations: string[] = [];
+
+    for (const loc of requiredLocations) {
+      const slots = criticalSlots[loc];
+      if (!slots) {
+        missingLocations.push(loc);
+        continue;
+      }
+
+      const hasAvionics = slots.some(
+        (s) => s && s.toLowerCase().includes('avionics')
+      );
+      if (!hasAvionics) {
+        missingLocations.push(loc);
+      }
+    }
+
+    if (missingLocations.length > 0) {
+      return fail(this.id, [
+        {
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.ERROR,
+          category: this.category,
+          message: `LAM missing Avionics in: ${missingLocations.join(', ')}`,
+          path: 'criticalSlots',
+          suggestion: 'Add Avionics to HD, LT, and RT',
+        },
+      ]);
+    }
+
+    return pass(this.id);
+  },
+};
+
+// ============================================================================
 // EXPORTS
 // ============================================================================
 
@@ -420,6 +730,12 @@ export function getConfigurationValidationRules(): IValidationRuleDefinition[] {
     QuadLegArmorBalanceRule,
     // Biped rules
     BipedNoQuadLegsRule,
+    // LAM rules
+    LAMMaxTonnageRule,
+    LAMEngineTypeRule,
+    LAMStructureArmorRule,
+    LAMLandingGearRule,
+    LAMAvionicsRule,
     // Generic configuration rules
     ValidLocationsRule,
   ];

--- a/src/utils/validation/rules/ConfigurationValidationRules.ts
+++ b/src/utils/validation/rules/ConfigurationValidationRules.ts
@@ -958,6 +958,275 @@ export const TripodLegArmorBalanceRule: IValidationRuleDefinition = {
 };
 
 // ============================================================================
+// QUADVEE CONFIGURATION RULES
+// ============================================================================
+
+/**
+ * QuadVee must have conversion equipment in all four legs
+ */
+export const QuadVeeConversionEquipmentRule: IValidationRuleDefinition = {
+  id: 'configuration.quadvee.conversion_equipment',
+  name: 'QuadVee Conversion Equipment',
+  description: 'QuadVees require conversion equipment in all four legs',
+  category: ValidationCategory.CONSTRUCTION,
+  priority: 5,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'quadvee';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const criticalSlots = unit.criticalSlots as Record<string, Array<string | null>> | undefined;
+
+    if (!criticalSlots) {
+      return warn(this.id, [
+        {
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.WARNING,
+          category: this.category,
+          message: 'Cannot verify conversion equipment - no critical slot data',
+          path: 'criticalSlots',
+        },
+      ]);
+    }
+
+    const legLocations = [
+      MechLocation.FRONT_LEFT_LEG,
+      MechLocation.FRONT_RIGHT_LEG,
+      MechLocation.REAR_LEFT_LEG,
+      MechLocation.REAR_RIGHT_LEG,
+    ];
+
+    const missingLocations: string[] = [];
+
+    for (const loc of legLocations) {
+      const slots = criticalSlots[loc];
+      const hasConversion = slots?.some(
+        (s) => s && s.toLowerCase().includes('conversion')
+      );
+      if (!hasConversion) {
+        missingLocations.push(loc);
+      }
+    }
+
+    if (missingLocations.length > 0) {
+      return fail(this.id, [
+        {
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.ERROR,
+          category: this.category,
+          message: `QuadVee missing conversion equipment in: ${missingLocations.join(', ')}`,
+          path: 'criticalSlots',
+          suggestion: 'Add conversion equipment to all four legs',
+        },
+      ]);
+    }
+
+    return pass(this.id);
+  },
+};
+
+/**
+ * QuadVee tracks must be in all four legs if present
+ */
+export const QuadVeeTracksRule: IValidationRuleDefinition = {
+  id: 'configuration.quadvee.tracks',
+  name: 'QuadVee Tracks Spanning',
+  description: 'QuadVee tracks must be installed in all four legs',
+  category: ValidationCategory.CONSTRUCTION,
+  priority: 10,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'quadvee';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const criticalSlots = unit.criticalSlots as Record<string, Array<string | null>> | undefined;
+
+    if (!criticalSlots) {
+      return pass(this.id);
+    }
+
+    const legLocations = [
+      MechLocation.FRONT_LEFT_LEG,
+      MechLocation.FRONT_RIGHT_LEG,
+      MechLocation.REAR_LEFT_LEG,
+      MechLocation.REAR_RIGHT_LEG,
+    ];
+
+    const legsWithTracks: string[] = [];
+
+    for (const loc of legLocations) {
+      const slots = criticalSlots[loc];
+      if (slots?.some((s) => s && s.toLowerCase().includes('track'))) {
+        legsWithTracks.push(loc);
+      }
+    }
+
+    // If tracks found in some but not all legs, it's an error
+    if (legsWithTracks.length > 0 && legsWithTracks.length < 4) {
+      const missingLegs = legLocations.filter((l) => !legsWithTracks.includes(l));
+      return fail(this.id, [
+        {
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.ERROR,
+          category: this.category,
+          message: 'Tracks must be installed in all four legs',
+          path: 'criticalSlots',
+          suggestion: `Add tracks to: ${missingLegs.join(', ')}`,
+        },
+      ]);
+    }
+
+    return pass(this.id);
+  },
+};
+
+/**
+ * QuadVee mech total critical slots (same as Quad)
+ */
+export const QuadVeeTotalSlotsRule: IValidationRuleDefinition = {
+  id: 'configuration.quadvee.total_slots',
+  name: 'QuadVee Total Slots',
+  description: 'Validates that QuadVee mech critical slots do not exceed maximum',
+  category: ValidationCategory.SLOTS,
+  priority: 10,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'quadvee';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const criticalSlots = unit.criticalSlots as Record<string, Array<unknown>> | undefined;
+
+    if (!criticalSlots) {
+      return pass(this.id);
+    }
+
+    // QuadVee: 6 (head) + 12*3 (torsos) + 12*4 (legs) = 6 + 36 + 48 = 90 slots available
+    // But with conversion equipment in each leg (1 slot each), effective is 86
+    const maxSlots = 90;
+    let usedSlots = 0;
+
+    for (const [_location, slots] of Object.entries(criticalSlots)) {
+      if (Array.isArray(slots)) {
+        usedSlots += slots.filter((s) => s !== null && s !== '-Empty-').length;
+      }
+    }
+
+    if (usedSlots > maxSlots) {
+      return fail(this.id, [
+        {
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.ERROR,
+          category: this.category,
+          message: `Used critical slots (${usedSlots}) exceed QuadVee maximum (${maxSlots})`,
+          path: 'criticalSlots',
+          expected: `<= ${maxSlots}`,
+          actual: `${usedSlots}`,
+        },
+      ]);
+    }
+
+    return pass(this.id);
+  },
+};
+
+/**
+ * QuadVee leg armor balance warning
+ */
+export const QuadVeeLegArmorBalanceRule: IValidationRuleDefinition = {
+  id: 'configuration.quadvee.leg_armor_balance',
+  name: 'QuadVee Leg Armor Balance',
+  description: 'Warns if QuadVee leg armor is significantly unbalanced',
+  category: ValidationCategory.ARMOR,
+  priority: 50,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'quadvee';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const armorAllocation = unit.armorAllocation as Record<string, number> | undefined;
+
+    if (!armorAllocation) {
+      return pass(this.id);
+    }
+
+    const legArmor = [
+      armorAllocation[MechLocation.FRONT_LEFT_LEG] ?? 0,
+      armorAllocation[MechLocation.FRONT_RIGHT_LEG] ?? 0,
+      armorAllocation[MechLocation.REAR_LEFT_LEG] ?? 0,
+      armorAllocation[MechLocation.REAR_RIGHT_LEG] ?? 0,
+    ];
+
+    const maxArmor = Math.max(...legArmor);
+    const minArmor = Math.min(...legArmor);
+    const warnings: IValidationError[] = [];
+
+    // Warn if legs differ by more than 50%
+    if (maxArmor > 0 && (maxArmor - minArmor) / maxArmor > 0.5) {
+      warnings.push({
+        ruleId: this.id,
+        ruleName: this.name,
+        severity: ValidationSeverity.WARNING,
+        category: this.category,
+        message: `QuadVee leg armor varies significantly (${minArmor} to ${maxArmor})`,
+        path: 'armorAllocation',
+        suggestion: 'Consider balancing leg armor - uneven armor affects vehicle mode stability',
+      });
+    }
+
+    // Front vs rear leg balance (important for vehicle mode)
+    const avgFrontArmor =
+      ((armorAllocation[MechLocation.FRONT_LEFT_LEG] ?? 0) +
+        (armorAllocation[MechLocation.FRONT_RIGHT_LEG] ?? 0)) /
+      2;
+    const avgRearArmor =
+      ((armorAllocation[MechLocation.REAR_LEFT_LEG] ?? 0) +
+        (armorAllocation[MechLocation.REAR_RIGHT_LEG] ?? 0)) /
+      2;
+
+    if (avgFrontArmor > 0 && avgRearArmor > 0) {
+      const ratio = Math.min(avgFrontArmor, avgRearArmor) / Math.max(avgFrontArmor, avgRearArmor);
+      if (ratio < 0.5) {
+        warnings.push({
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.WARNING,
+          category: this.category,
+          message: 'Front and rear leg armor significantly unbalanced',
+          path: 'armorAllocation',
+          suggestion: 'Balance front/rear armor for vehicle mode - both ends need protection',
+        });
+      }
+    }
+
+    if (warnings.length > 0) {
+      return warn(this.id, warnings);
+    }
+
+    return pass(this.id);
+  },
+};
+
+// ============================================================================
 // EXPORTS
 // ============================================================================
 
@@ -984,6 +1253,11 @@ export function getConfigurationValidationRules(): IValidationRuleDefinition[] {
     TripodLegEquipmentRule,
     TripodTotalSlotsRule,
     TripodLegArmorBalanceRule,
+    // QuadVee rules
+    QuadVeeConversionEquipmentRule,
+    QuadVeeTracksRule,
+    QuadVeeTotalSlotsRule,
+    QuadVeeLegArmorBalanceRule,
     // Generic configuration rules
     ValidLocationsRule,
   ];

--- a/src/utils/validation/rules/ConfigurationValidationRules.ts
+++ b/src/utils/validation/rules/ConfigurationValidationRules.ts
@@ -1,0 +1,437 @@
+/**
+ * Configuration-Specific Validation Rules
+ *
+ * Validation rules for different mech configurations (Biped, Quad, LAM, etc.)
+ *
+ * @spec openspec/specs/quad-mech-support/spec.md
+ */
+
+import {
+  IValidationRuleDefinition,
+  IValidationRuleResult,
+  IValidationContext,
+  IValidationError,
+  ValidationCategory,
+  ValidationSeverity,
+} from '../../../types/validation/rules/ValidationRuleInterfaces';
+import { MechLocation } from '../../../types/construction/CriticalSlotAllocation';
+import {
+  MechConfiguration,
+  QUAD_LOCATIONS,
+  BIPED_LOCATIONS,
+  configurationRegistry,
+} from '../../../types/construction/MechConfigurationSystem';
+
+/**
+ * Helper to create a passing result
+ */
+function pass(ruleId: string): IValidationRuleResult {
+  return {
+    ruleId,
+    passed: true,
+    errors: [],
+    warnings: [],
+    infos: [],
+    executionTime: 0,
+  };
+}
+
+/**
+ * Helper to create a failing result
+ */
+function fail(ruleId: string, errors: IValidationError[]): IValidationRuleResult {
+  return {
+    ruleId,
+    passed: false,
+    errors,
+    warnings: [],
+    infos: [],
+    executionTime: 0,
+  };
+}
+
+/**
+ * Helper to create a result with warnings
+ */
+function warn(ruleId: string, warnings: IValidationError[]): IValidationRuleResult {
+  return {
+    ruleId,
+    passed: true,
+    errors: [],
+    warnings,
+    infos: [],
+    executionTime: 0,
+  };
+}
+
+// ============================================================================
+// CONFIGURATION-SPECIFIC RULES
+// ============================================================================
+
+/**
+ * Quad mechs cannot have arm-mounted equipment
+ */
+export const QuadNoArmsRule: IValidationRuleDefinition = {
+  id: 'configuration.quad.no_arms',
+  name: 'Quad No Arms',
+  description: 'Validates that quad mechs do not have equipment in arm locations',
+  category: ValidationCategory.CONSTRUCTION,
+  priority: 5,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'quad';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const equipment = unit.equipment as Array<Record<string, unknown>> | undefined;
+
+    if (!equipment) {
+      return pass(this.id);
+    }
+
+    const armLocations = [MechLocation.LEFT_ARM, MechLocation.RIGHT_ARM];
+    const errors: IValidationError[] = [];
+
+    for (const item of equipment) {
+      const location = item.location as string | undefined;
+      if (location && armLocations.includes(location as MechLocation)) {
+        errors.push({
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.ERROR,
+          category: this.category,
+          message: `Quad mechs cannot have equipment in ${location}`,
+          path: `equipment.${item.name}`,
+          suggestion: 'Move equipment to a leg or torso location',
+        });
+      }
+    }
+
+    if (errors.length > 0) {
+      return fail(this.id, errors);
+    }
+
+    return pass(this.id);
+  },
+};
+
+/**
+ * Quad mechs must have exactly 4 legs
+ */
+export const QuadLegCountRule: IValidationRuleDefinition = {
+  id: 'configuration.quad.leg_count',
+  name: 'Quad Leg Count',
+  description: 'Validates that quad mechs have all four leg locations defined',
+  category: ValidationCategory.CONSTRUCTION,
+  priority: 5,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'quad';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const armorAllocation = unit.armorAllocation as Record<string, unknown> | undefined;
+
+    const quadLegs = [
+      MechLocation.FRONT_LEFT_LEG,
+      MechLocation.FRONT_RIGHT_LEG,
+      MechLocation.REAR_LEFT_LEG,
+      MechLocation.REAR_RIGHT_LEG,
+    ];
+
+    const errors: IValidationError[] = [];
+
+    // Check armor allocation has all quad legs
+    if (armorAllocation) {
+      for (const leg of quadLegs) {
+        if (!(leg in armorAllocation) && armorAllocation[leg] === undefined) {
+          errors.push({
+            ruleId: this.id,
+            ruleName: this.name,
+            severity: ValidationSeverity.ERROR,
+            category: this.category,
+            message: `Quad mech missing ${leg} location`,
+            path: `armorAllocation.${leg}`,
+          });
+        }
+      }
+    }
+
+    if (errors.length > 0) {
+      return fail(this.id, errors);
+    }
+
+    return pass(this.id);
+  },
+};
+
+/**
+ * Validate location is valid for configuration
+ */
+export const ValidLocationsRule: IValidationRuleDefinition = {
+  id: 'configuration.valid_locations',
+  name: 'Valid Locations',
+  description: 'Validates that all used locations are valid for the mech configuration',
+  category: ValidationCategory.CONSTRUCTION,
+  priority: 5,
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const config = (unit.configuration as string) ?? 'Biped';
+    const equipment = unit.equipment as Array<Record<string, unknown>> | undefined;
+
+    const configType = config.toLowerCase() === 'quad'
+      ? MechConfiguration.QUAD
+      : MechConfiguration.BIPED;
+
+    const validLocations = new Set(configurationRegistry.getValidLocations(configType));
+    const errors: IValidationError[] = [];
+
+    if (equipment) {
+      for (const item of equipment) {
+        const location = item.location as MechLocation | undefined;
+        if (location && !validLocations.has(location)) {
+          errors.push({
+            ruleId: this.id,
+            ruleName: this.name,
+            severity: ValidationSeverity.ERROR,
+            category: this.category,
+            message: `Location ${location} is not valid for ${config} mechs`,
+            path: `equipment.${item.name}`,
+            suggestion: `Use one of: ${Array.from(validLocations).join(', ')}`,
+          });
+        }
+      }
+    }
+
+    if (errors.length > 0) {
+      return fail(this.id, errors);
+    }
+
+    return pass(this.id);
+  },
+};
+
+/**
+ * Quad mech total critical slots (different from biped)
+ */
+export const QuadTotalSlotsRule: IValidationRuleDefinition = {
+  id: 'configuration.quad.total_slots',
+  name: 'Quad Total Slots',
+  description: 'Validates that quad mech critical slots do not exceed maximum',
+  category: ValidationCategory.SLOTS,
+  priority: 10,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'quad';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const criticalSlots = unit.criticalSlots as Record<string, Array<unknown>> | undefined;
+
+    if (!criticalSlots) {
+      return pass(this.id);
+    }
+
+    // Quad mechs: 6 (head) + 12*3 (torsos) + 6*4 (legs) = 6 + 36 + 24 = 66 slots
+    const maxSlots = 66;
+    let usedSlots = 0;
+
+    for (const [_location, slots] of Object.entries(criticalSlots)) {
+      if (Array.isArray(slots)) {
+        usedSlots += slots.filter((s) => s !== null && s !== '-Empty-').length;
+      }
+    }
+
+    if (usedSlots > maxSlots) {
+      return fail(this.id, [
+        {
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.ERROR,
+          category: this.category,
+          message: `Used critical slots (${usedSlots}) exceed quad maximum (${maxSlots})`,
+          path: 'criticalSlots',
+          expected: `<= ${maxSlots}`,
+          actual: `${usedSlots}`,
+        },
+      ]);
+    }
+
+    return pass(this.id);
+  },
+};
+
+/**
+ * Quad leg armor balance warning
+ */
+export const QuadLegArmorBalanceRule: IValidationRuleDefinition = {
+  id: 'configuration.quad.leg_armor_balance',
+  name: 'Quad Leg Armor Balance',
+  description: 'Warns if quad leg armor is significantly unbalanced',
+  category: ValidationCategory.ARMOR,
+  priority: 50,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'quad';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const armorAllocation = unit.armorAllocation as Record<string, number> | undefined;
+
+    if (!armorAllocation) {
+      return pass(this.id);
+    }
+
+    const legArmor = [
+      armorAllocation[MechLocation.FRONT_LEFT_LEG] ?? 0,
+      armorAllocation[MechLocation.FRONT_RIGHT_LEG] ?? 0,
+      armorAllocation[MechLocation.REAR_LEFT_LEG] ?? 0,
+      armorAllocation[MechLocation.REAR_RIGHT_LEG] ?? 0,
+    ];
+
+    const maxArmor = Math.max(...legArmor);
+    const minArmor = Math.min(...legArmor);
+    const warnings: IValidationError[] = [];
+
+    // Warn if legs differ by more than 50%
+    if (maxArmor > 0 && (maxArmor - minArmor) / maxArmor > 0.5) {
+      warnings.push({
+        ruleId: this.id,
+        ruleName: this.name,
+        severity: ValidationSeverity.WARNING,
+        category: this.category,
+        message: `Quad leg armor varies significantly (${minArmor} to ${maxArmor})`,
+        path: 'armorAllocation',
+        suggestion: 'Consider balancing leg armor for consistent protection',
+      });
+    }
+
+    // Warn if front legs have much less armor than rear
+    const frontAvg =
+      ((armorAllocation[MechLocation.FRONT_LEFT_LEG] ?? 0) +
+        (armorAllocation[MechLocation.FRONT_RIGHT_LEG] ?? 0)) /
+      2;
+    const rearAvg =
+      ((armorAllocation[MechLocation.REAR_LEFT_LEG] ?? 0) +
+        (armorAllocation[MechLocation.REAR_RIGHT_LEG] ?? 0)) /
+      2;
+
+    if (frontAvg > 0 && rearAvg > frontAvg * 1.5) {
+      warnings.push({
+        ruleId: this.id,
+        ruleName: this.name,
+        severity: ValidationSeverity.WARNING,
+        category: this.category,
+        message: 'Front legs have significantly less armor than rear legs',
+        path: 'armorAllocation',
+        suggestion: 'Front legs typically face more combat exposure',
+      });
+    }
+
+    if (warnings.length > 0) {
+      return warn(this.id, warnings);
+    }
+
+    return pass(this.id);
+  },
+};
+
+/**
+ * Biped cannot have quad leg locations
+ */
+export const BipedNoQuadLegsRule: IValidationRuleDefinition = {
+  id: 'configuration.biped.no_quad_legs',
+  name: 'Biped No Quad Legs',
+  description: 'Validates that biped mechs do not use quad leg locations',
+  category: ValidationCategory.CONSTRUCTION,
+  priority: 5,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() !== 'quad';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const equipment = unit.equipment as Array<Record<string, unknown>> | undefined;
+
+    if (!equipment) {
+      return pass(this.id);
+    }
+
+    const quadLegLocations = [
+      MechLocation.FRONT_LEFT_LEG,
+      MechLocation.FRONT_RIGHT_LEG,
+      MechLocation.REAR_LEFT_LEG,
+      MechLocation.REAR_RIGHT_LEG,
+    ];
+    const errors: IValidationError[] = [];
+
+    for (const item of equipment) {
+      const location = item.location as string | undefined;
+      if (location && quadLegLocations.includes(location as MechLocation)) {
+        errors.push({
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.ERROR,
+          category: this.category,
+          message: `Biped mechs cannot use quad leg location ${location}`,
+          path: `equipment.${item.name}`,
+          suggestion: 'Use standard leg or arm locations',
+        });
+      }
+    }
+
+    if (errors.length > 0) {
+      return fail(this.id, errors);
+    }
+
+    return pass(this.id);
+  },
+};
+
+// ============================================================================
+// EXPORTS
+// ============================================================================
+
+/**
+ * Get all configuration-specific validation rules
+ */
+export function getConfigurationValidationRules(): IValidationRuleDefinition[] {
+  return [
+    // Quad rules
+    QuadNoArmsRule,
+    QuadLegCountRule,
+    QuadTotalSlotsRule,
+    QuadLegArmorBalanceRule,
+    // Biped rules
+    BipedNoQuadLegsRule,
+    // Generic configuration rules
+    ValidLocationsRule,
+  ];
+}
+
+/**
+ * Register all configuration rules with a registry
+ */
+export function registerConfigurationRules(registry: {
+  register: (rule: IValidationRuleDefinition) => void;
+}): void {
+  for (const rule of getConfigurationValidationRules()) {
+    registry.register(rule);
+  }
+}

--- a/src/utils/validation/rules/ConfigurationValidationRules.ts
+++ b/src/utils/validation/rules/ConfigurationValidationRules.ts
@@ -715,6 +715,249 @@ export const LAMAvionicsRule: IValidationRuleDefinition = {
 };
 
 // ============================================================================
+// TRIPOD CONFIGURATION RULES
+// ============================================================================
+
+/**
+ * Tripod mech must have center leg location
+ */
+export const TripodCenterLegRule: IValidationRuleDefinition = {
+  id: 'configuration.tripod.center_leg',
+  name: 'Tripod Center Leg Required',
+  description: 'Validates that tripod mechs have a center leg location',
+  category: ValidationCategory.CONSTRUCTION,
+  priority: 5,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'tripod';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const armorAllocation = unit.armorAllocation as Record<string, number> | undefined;
+    const criticalSlots = unit.criticalSlots as Record<string, Array<unknown>> | undefined;
+
+    const hasCenterLegArmor =
+      armorAllocation && MechLocation.CENTER_LEG in armorAllocation;
+    const hasCenterLegSlots =
+      criticalSlots && MechLocation.CENTER_LEG in criticalSlots;
+
+    if (!hasCenterLegArmor && !hasCenterLegSlots) {
+      return fail(this.id, [
+        {
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.ERROR,
+          category: this.category,
+          message: 'Tripod mech missing Center Leg location',
+          path: 'configuration',
+          suggestion: 'Add Center Leg (CL) location for tripod configuration',
+        },
+      ]);
+    }
+
+    return pass(this.id);
+  },
+};
+
+/**
+ * Tripod mech leg equipment spanning rule
+ * Certain equipment (tracks, talons) must be installed in all three legs
+ */
+export const TripodLegEquipmentRule: IValidationRuleDefinition = {
+  id: 'configuration.tripod.leg_equipment',
+  name: 'Tripod Leg Equipment Spanning',
+  description: 'Validates that leg-spanning equipment is in all three legs',
+  category: ValidationCategory.CONSTRUCTION,
+  priority: 10,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'tripod';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const criticalSlots = unit.criticalSlots as Record<string, Array<string | null>> | undefined;
+
+    if (!criticalSlots) {
+      return pass(this.id);
+    }
+
+    // Equipment that must span all three legs
+    const legSpanningEquipment = ['tracks', 'talons', 'claws'];
+    const legLocations = [
+      MechLocation.LEFT_LEG,
+      MechLocation.RIGHT_LEG,
+      MechLocation.CENTER_LEG,
+    ];
+    const errors: IValidationError[] = [];
+
+    // Check each leg-spanning equipment type
+    for (const equipType of legSpanningEquipment) {
+      const legsWithEquip: string[] = [];
+
+      for (const loc of legLocations) {
+        const slots = criticalSlots[loc];
+        if (slots?.some((s) => s && s.toLowerCase().includes(equipType))) {
+          legsWithEquip.push(loc);
+        }
+      }
+
+      // If equipment found in some but not all legs, it's an error
+      if (legsWithEquip.length > 0 && legsWithEquip.length < 3) {
+        const missingLegs = legLocations.filter((l) => !legsWithEquip.includes(l));
+        errors.push({
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.ERROR,
+          category: this.category,
+          message: `${equipType.charAt(0).toUpperCase() + equipType.slice(1)} must be installed in all three legs`,
+          path: 'criticalSlots',
+          suggestion: `Add ${equipType} to: ${missingLegs.join(', ')}`,
+        });
+      }
+    }
+
+    if (errors.length > 0) {
+      return fail(this.id, errors);
+    }
+
+    return pass(this.id);
+  },
+};
+
+/**
+ * Tripod mech total critical slots
+ */
+export const TripodTotalSlotsRule: IValidationRuleDefinition = {
+  id: 'configuration.tripod.total_slots',
+  name: 'Tripod Total Slots',
+  description: 'Validates that tripod mech critical slots do not exceed maximum',
+  category: ValidationCategory.SLOTS,
+  priority: 10,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'tripod';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const criticalSlots = unit.criticalSlots as Record<string, Array<unknown>> | undefined;
+
+    if (!criticalSlots) {
+      return pass(this.id);
+    }
+
+    // Tripod mechs: 6 (head) + 12*3 (torsos) + 12*2 (arms) + 6*3 (legs) = 6 + 36 + 24 + 18 = 84 slots
+    const maxSlots = 84;
+    let usedSlots = 0;
+
+    for (const [_location, slots] of Object.entries(criticalSlots)) {
+      if (Array.isArray(slots)) {
+        usedSlots += slots.filter((s) => s !== null && s !== '-Empty-').length;
+      }
+    }
+
+    if (usedSlots > maxSlots) {
+      return fail(this.id, [
+        {
+          ruleId: this.id,
+          ruleName: this.name,
+          severity: ValidationSeverity.ERROR,
+          category: this.category,
+          message: `Used critical slots (${usedSlots}) exceed tripod maximum (${maxSlots})`,
+          path: 'criticalSlots',
+          expected: `<= ${maxSlots}`,
+          actual: `${usedSlots}`,
+        },
+      ]);
+    }
+
+    return pass(this.id);
+  },
+};
+
+/**
+ * Tripod leg armor balance warning
+ */
+export const TripodLegArmorBalanceRule: IValidationRuleDefinition = {
+  id: 'configuration.tripod.leg_armor_balance',
+  name: 'Tripod Leg Armor Balance',
+  description: 'Warns if tripod leg armor is significantly unbalanced',
+  category: ValidationCategory.ARMOR,
+  priority: 50,
+
+  canValidate(context: IValidationContext): boolean {
+    const unit = context.unit as Record<string, unknown>;
+    const config = unit.configuration as string | undefined;
+    return config?.toLowerCase() === 'tripod';
+  },
+
+  validate(context: IValidationContext): IValidationRuleResult {
+    const unit = context.unit as Record<string, unknown>;
+    const armorAllocation = unit.armorAllocation as Record<string, number> | undefined;
+
+    if (!armorAllocation) {
+      return pass(this.id);
+    }
+
+    const legArmor = [
+      armorAllocation[MechLocation.LEFT_LEG] ?? 0,
+      armorAllocation[MechLocation.RIGHT_LEG] ?? 0,
+      armorAllocation[MechLocation.CENTER_LEG] ?? 0,
+    ];
+
+    const maxArmor = Math.max(...legArmor);
+    const minArmor = Math.min(...legArmor);
+    const warnings: IValidationError[] = [];
+
+    // Warn if legs differ by more than 50%
+    if (maxArmor > 0 && (maxArmor - minArmor) / maxArmor > 0.5) {
+      warnings.push({
+        ruleId: this.id,
+        ruleName: this.name,
+        severity: ValidationSeverity.WARNING,
+        category: this.category,
+        message: `Tripod leg armor varies significantly (${minArmor} to ${maxArmor})`,
+        path: 'armorAllocation',
+        suggestion: 'Consider balancing leg armor for consistent protection',
+      });
+    }
+
+    // Center leg typically needs good armor as loss is critical
+    const centerLegArmor = armorAllocation[MechLocation.CENTER_LEG] ?? 0;
+    const avgSideLegArmor =
+      ((armorAllocation[MechLocation.LEFT_LEG] ?? 0) +
+        (armorAllocation[MechLocation.RIGHT_LEG] ?? 0)) /
+      2;
+
+    if (centerLegArmor > 0 && centerLegArmor < avgSideLegArmor * 0.75) {
+      warnings.push({
+        ruleId: this.id,
+        ruleName: this.name,
+        severity: ValidationSeverity.WARNING,
+        category: this.category,
+        message: 'Center leg has significantly less armor than side legs',
+        path: `armorAllocation.${MechLocation.CENTER_LEG}`,
+        suggestion: 'Center leg loss is critical for tripods - consider more armor',
+      });
+    }
+
+    if (warnings.length > 0) {
+      return warn(this.id, warnings);
+    }
+
+    return pass(this.id);
+  },
+};
+
+// ============================================================================
 // EXPORTS
 // ============================================================================
 
@@ -736,6 +979,11 @@ export function getConfigurationValidationRules(): IValidationRuleDefinition[] {
     LAMStructureArmorRule,
     LAMLandingGearRule,
     LAMAvionicsRule,
+    // Tripod rules
+    TripodCenterLegRule,
+    TripodLegEquipmentRule,
+    TripodTotalSlotsRule,
+    TripodLegArmorBalanceRule,
     // Generic configuration rules
     ValidLocationsRule,
   ];

--- a/src/utils/validation/rules/index.ts
+++ b/src/utils/validation/rules/index.ts
@@ -7,4 +7,5 @@
 export * from './ValidationRuleRegistry';
 export * from './ValidationOrchestrator';
 export * from './StandardValidationRules';
+export * from './ConfigurationValidationRules';
 


### PR DESCRIPTION
## Summary

This PR implements comprehensive support for exotic BattleMech configurations beyond standard bipeds:

- **Quad mechs**: Four-legged mechs with front/rear leg pairs instead of arms
- **LAM (Land-Air Mechs)**: Transformable mechs with three operating modes (Mech, AirMech, Fighter)
- **Tripod mechs**: Three-legged superheavy mechs with center leg
- **QuadVee mechs**: Transformable quad mechs that convert between mech and tracked vehicle modes

### Key Changes

**Configuration System** (`MechConfigurationSystem.ts`):
- New `IMechConfigurationDefinition` interface with locations, actuators, equipment rules
- `MechConfigurationRegistry` singleton for configuration lookup
- Mode systems for LAM (3 modes) and QuadVee (2 modes)
- Required equipment definitions (LAM avionics/landing gear, QuadVee conversion equipment)

**Armor Diagrams**:
- `QuadArmorDiagram` - 8-location quad silhouette
- `LAMArmorDiagram` - Mode toggle with fighter silhouette
- `TripodArmorDiagram` - 9-location with center leg
- `QuadVeeArmorDiagram` - Mode toggle for mech/vehicle

**Validation Rules** (`ConfigurationValidationRules.ts`):
- 4 Quad rules (no arms, leg count, slots, armor balance)
- 5 LAM rules (max tonnage, engine type, structure/armor, landing gear, avionics)
- 4 Tripod rules (center leg, leg equipment, slots, armor balance)
- 4 QuadVee rules (conversion equipment, tracks, slots, armor balance)

**MTF Parser Updates**:
- Location mappings for all exotic configurations
- Config detection for Quad, LAM, Tripod, QuadVee

### Test Coverage

| Category | New Tests |
|----------|-----------|
| Configuration validation | 15 (Tripod) + 14 (QuadVee) |
| Integration tests | 53 |
| **Total new tests** | **82+** |

All **4978 tests passing**.

## Test plan

- [ ] Run `npm test` - all 4978 tests pass
- [ ] Run `npm run lint` - no errors (warnings only)
- [ ] Run `npm run build` - builds successfully
- [ ] Verify Quad mech armor diagram renders correctly
- [ ] Verify LAM mode toggle works (Mech → AirMech → Fighter)
- [ ] Verify Tripod armor diagram shows center leg
- [ ] Verify QuadVee mode toggle works (Mech ↔ Vehicle)
- [ ] Verify biped functionality unchanged (regression tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)