### PR TITLE
feat: enhance mobile loadout tray with quick actions and category filter

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/openspec/changes/archive/2026-01-14-enhance-loadout-tray/proposal.md
+++ b/openspec/changes/archive/2026-01-14-enhance-loadout-tray/proposal.md
@@ -1,0 +1,12 @@
+# Change: Enhance Loadout Tray with Category Filtering
+
+## Why
+The desktop GlobalLoadoutTray lacks category filtering that the mobile MobileLoadoutList already has. Users with many equipment items need to quickly filter by category (Energy, Ballistic, Missile, etc.) to find specific items. Additionally, the right-click context menu text was wrapping on longer location names.
+
+## What Changes
+- Add category filter bar to GlobalLoadoutTray matching mobile functionality
+- Fix context menu layout to prevent text wrapping on quick-assign options
+
+## Impact
+- Affected specs: equipment-tray
+- Affected code: `src/components/customizer/equipment/GlobalLoadoutTray.tsx`

--- a/openspec/changes/archive/2026-01-14-enhance-loadout-tray/specs/equipment-tray/spec.md
+++ b/openspec/changes/archive/2026-01-14-enhance-loadout-tray/specs/equipment-tray/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Category Filter Bar
+The Loadout Tray SHALL provide a category filter bar to filter displayed equipment by type.
+
+#### Scenario: Filter bar display
+- **WHEN** tray is expanded
+- **THEN** category filter bar SHALL appear below header
+- **AND** filter bar SHALL show icon buttons for: All, Energy, Ballistic, Missile, Ammo, Electronics, Other
+
+#### Scenario: Default filter state
+- **WHEN** tray is first opened
+- **THEN** "All" filter SHALL be active
+- **AND** all equipment SHALL be visible
+
+#### Scenario: Filter by category
+- **WHEN** user clicks a category filter button (e.g., Energy)
+- **THEN** only equipment matching that category SHALL be displayed
+- **AND** active filter button SHALL be visually highlighted
+- **AND** equipment from other categories SHALL be hidden
+
+#### Scenario: Other category grouping
+- **WHEN** user selects "Other" filter
+- **THEN** equipment from Misc, Physical, Movement, Artillery, and Structural categories SHALL be shown
+- **AND** equipment from Energy, Ballistic, Missile, Ammo, Electronics SHALL be hidden
+
+#### Scenario: Empty filter state
+- **WHEN** active filter matches no equipment
+- **THEN** message SHALL show "No items in filter"
+- **AND** hint text SHALL show "Try another category"
+
+#### Scenario: Return to all
+- **WHEN** user clicks "All" filter button
+- **THEN** all equipment SHALL be visible again
+- **AND** "All" button SHALL be highlighted as active
+
+## MODIFIED Requirements
+
+### Requirement: Context Menu Quick Assignment
+Loadout tray SHALL provide context menu for quick equipment assignment.
+
+#### Scenario: Show context menu on right-click
+- **GIVEN** equipment exists in the loadout tray
+- **WHEN** user right-clicks on equipment item
+- **THEN** context menu SHALL appear at cursor position
+- **AND** menu SHALL show equipment name and slot count
+- **AND** menu SHALL list valid assignment locations
+
+#### Scenario: Filter locations by restrictions
+- **GIVEN** equipment has location restrictions (e.g., jump jets)
+- **WHEN** context menu is displayed
+- **THEN** only valid locations SHALL show "Add to [Location]" option
+- **AND** invalid locations SHALL NOT appear or SHALL be disabled
+- **AND** available slot count SHALL be shown for each location
+
+#### Scenario: Filter locations by available space
+- **GIVEN** equipment requires N slots
+- **WHEN** a location has fewer than N contiguous empty slots
+- **THEN** that location SHALL NOT appear in quick assign options
+- **OR** SHALL be marked as unavailable
+
+#### Scenario: Context menu for allocated equipment
+- **GIVEN** equipment is allocated to a location
+- **WHEN** user right-clicks on the equipment
+- **THEN** context menu SHALL show "Unassign from [Location]" option
+- **AND** clicking option SHALL unassign the equipment
+
+#### Scenario: Context menu row layout
+- **GIVEN** context menu is displayed with location options
+- **WHEN** location names and slot counts are rendered
+- **THEN** each row SHALL display on a single line without wrapping
+- **AND** menu width SHALL be at least 200px
+- **AND** location label and "X free" text SHALL have consistent spacing

--- a/openspec/changes/archive/2026-01-14-enhance-loadout-tray/tasks.md
+++ b/openspec/changes/archive/2026-01-14-enhance-loadout-tray/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+- [x] 1.1 Add category filter configuration (CATEGORY_FILTERS, OTHER_CATEGORIES arrays)
+- [x] 1.2 Create CategoryFilterBar component with icon-based buttons
+- [x] 1.3 Add activeCategory state to GlobalLoadoutTray
+- [x] 1.4 Implement filteredEquipment useMemo with category filtering logic
+- [x] 1.5 Update empty state to distinguish "no equipment" vs "no items in filter"
+- [x] 1.6 Fix context menu min-width (160px -> 200px) and add whitespace-nowrap
+- [x] 1.7 Add flex-shrink-0 and gap-3 to context menu rows
+
+## 2. Testing
+- [x] 2.1 Add tests for category filter button rendering
+- [x] 2.2 Add tests for showing all equipment by default
+- [x] 2.3 Add tests for filtering by specific categories
+- [x] 2.4 Add tests for empty filter state message
+- [x] 2.5 Add tests for returning to "All" filter
+- [x] 2.6 Verify all existing GlobalLoadoutTray tests still pass

--- a/openspec/changes/archive/2026-01-14-enhance-mobile-loadout-tray/proposal.md
+++ b/openspec/changes/archive/2026-01-14-enhance-mobile-loadout-tray/proposal.md
@@ -1,0 +1,58 @@
+# Proposal: Enhance Mobile Loadout Tray
+
+## Change ID
+`enhance-mobile-loadout-tray`
+
+## Summary
+Redesign the mobile equipment loadout tray to maximize information density, improve touch interactions, and provide quick equipment assignment functionality.
+
+## Motivation
+The existing mobile loadout view did not effectively use screen space for displaying equipment information. Users needed:
+- A way to see equipment details (damage, range, heat, slots, weight) at a glance
+- Quick actions to assign unassigned equipment to mech locations
+- Quick actions to unassign allocated equipment
+- Confirmation steps to prevent accidental modifications
+- Better visual alignment between headers and data rows
+
+## Scope
+
+### In Scope
+- Redesigned mobile loadout tray with expandable bottom sheet
+- Two-state UI: collapsed status bar and expanded full-screen list
+- Equipment rows with detailed weapon information (damage, ranges, TC compatibility)
+- Link button for unassigned items with location dropdown
+- Unlink button for allocated items with confirmation
+- Remove button with confirmation
+- Section-specific column headers (Unassigned/Allocated)
+- Proper 36px touch targets for action buttons
+- Single dropdown open at a time (exclusive menu state)
+
+### Out of Scope
+- Desktop loadout tray changes
+- Equipment browser modifications
+- Drag-and-drop assignment
+
+## Impact
+
+### User Experience
+- Faster equipment management on mobile devices
+- Clearer visibility of equipment stats
+- Reduced accidental modifications via confirmation dialogs
+- More intuitive quick-assign workflow
+
+### Technical
+- New `MobileLoadoutList` component
+- New `MobileEquipmentRow` component
+- New `MobileLoadoutHeader` component
+- Updated `BottomSheetTray` to pass location availability
+- State lifted to parent for exclusive dropdown behavior
+
+## Dependencies
+- Existing `customizer-responsive-layout` spec for responsive behavior
+- Equipment registry for weapon data lookup
+
+## Risks
+- None identified - implementation complete and tested
+
+## Related Specs
+- `customizer-responsive-layout` - Parent spec for responsive customizer behavior

--- a/openspec/changes/archive/2026-01-14-enhance-mobile-loadout-tray/specs/mobile-loadout-tray/spec.md
+++ b/openspec/changes/archive/2026-01-14-enhance-mobile-loadout-tray/specs/mobile-loadout-tray/spec.md
@@ -1,0 +1,183 @@
+# mobile-loadout-tray Specification Delta
+
+## Purpose
+Define requirements for the mobile loadout tray that displays and manages equipment on mobile devices, providing quick access to equipment stats and assignment actions.
+
+---
+
+## ADDED Requirements
+
+### Requirement: Mobile Loadout Status Bar
+
+The mobile loadout SHALL display a compact status bar when collapsed.
+
+#### Scenario: Collapsed status bar display
+- **WHEN** the loadout tray is in collapsed state
+- **THEN** a fixed status bar appears at the bottom of the screen
+- **AND** displays Weight (used/max), Slots (used/max), Heat (generated/dissipation), and BV
+- **AND** shows equipment count badge
+- **AND** tapping the bar expands to full-screen view
+
+#### Scenario: Weight overage indication
+- **WHEN** weight used exceeds weight maximum
+- **THEN** weight value displays in red color
+
+#### Scenario: Slots overage indication
+- **WHEN** slots used exceeds slots maximum
+- **THEN** slots value displays in red color
+
+---
+
+### Requirement: Mobile Equipment Row Display
+
+Each equipment item SHALL display comprehensive information in a compact row.
+
+#### Scenario: Equipment name and category
+- **WHEN** rendering an equipment row
+- **THEN** display the equipment name
+- **AND** show a colored category indicator bar (energy=cyan, ballistic=red, missile=orange, etc.)
+- **AND** show OmniMech pod/fixed badge when applicable
+
+#### Scenario: Equipment stats columns
+- **WHEN** rendering an equipment row
+- **THEN** display columns for: Location (or dash if unassigned), Heat, Crits, Weight
+- **AND** columns align with section header columns
+
+#### Scenario: Weapon details display
+- **WHEN** equipment is a weapon
+- **THEN** display damage value, range brackets (S/M/L format)
+- **AND** show TC indicator if targeting computer compatible
+
+---
+
+### Requirement: Section Grouping with Headers
+
+Equipment SHALL be grouped into Unassigned and Allocated sections.
+
+#### Scenario: Unassigned section
+- **WHEN** equipment has no assigned location
+- **THEN** display in Unassigned section with amber background tint
+- **AND** section header shows "Unassigned" with item count
+- **AND** section is collapsible
+
+#### Scenario: Allocated section
+- **WHEN** equipment has an assigned location
+- **THEN** display in Allocated section with green background tint
+- **AND** section header shows "Allocated" with item count
+- **AND** section is collapsible
+
+#### Scenario: Section column headers
+- **WHEN** a section is expanded
+- **THEN** display compact column headers (NAME, LOC, H, C, WT, 🔗, ×)
+- **AND** headers appear inside the section content area
+- **AND** headers align exactly with data row columns
+
+---
+
+### Requirement: Quick Assign via Link Button
+
+Unassigned equipment SHALL have a link button for quick assignment.
+
+#### Scenario: Link button display
+- **WHEN** equipment is unassigned and removable
+- **AND** at least one location can fit the equipment
+- **THEN** display a link icon (🔗) in the actions column
+
+#### Scenario: Location dropdown display
+- **WHEN** user taps the link button
+- **THEN** display a dropdown with available locations
+- **AND** each location shows name and available slot count
+- **AND** only locations that can fit the equipment are selectable
+
+#### Scenario: Location selection
+- **WHEN** user selects a location from the dropdown
+- **THEN** equipment is assigned to first available slot in that location
+- **AND** dropdown closes
+- **AND** equipment moves to Allocated section
+
+#### Scenario: Exclusive dropdown behavior
+- **WHEN** user opens a link dropdown
+- **THEN** any other open dropdown closes
+- **AND** only one dropdown is visible at a time
+
+---
+
+### Requirement: Unlink Button for Allocated Equipment
+
+Allocated equipment SHALL have an unlink button with confirmation.
+
+#### Scenario: Unlink button display
+- **WHEN** equipment is allocated and removable
+- **THEN** display a breaking chain icon in the actions column
+
+#### Scenario: Unlink confirmation
+- **WHEN** user taps the unlink button
+- **THEN** button changes to show "?" confirmation indicator
+- **AND** tapping again confirms and unassigns the equipment
+- **AND** tapping elsewhere or waiting resets the confirmation state
+
+---
+
+### Requirement: Remove Button with Confirmation
+
+Removable equipment SHALL have a remove button with confirmation.
+
+#### Scenario: Remove button display
+- **WHEN** equipment is removable
+- **THEN** display an × icon in the actions column
+
+#### Scenario: Remove confirmation
+- **WHEN** user taps the remove button
+- **THEN** button changes to show "?" confirmation indicator
+- **AND** tapping again confirms and removes the equipment
+- **AND** tapping elsewhere or waiting resets the confirmation state
+
+#### Scenario: Mutual exclusivity with unlink
+- **WHEN** remove confirmation is active
+- **THEN** unlink confirmation is reset
+- **AND** vice versa
+
+---
+
+### Requirement: Touch-Friendly Action Columns
+
+Action buttons SHALL have proper touch target sizes.
+
+#### Scenario: Action column dimensions
+- **WHEN** rendering action columns (link/unlink, remove)
+- **THEN** each column is 36px wide
+- **AND** buttons fill the entire column area
+- **AND** buttons show hover/active background feedback
+
+#### Scenario: Visual feedback on interaction
+- **WHEN** user hovers or taps an action button
+- **THEN** background color changes to indicate interaction
+- **AND** confirmation state shows distinct background color
+
+---
+
+### Requirement: Category Filtering
+
+Users SHALL be able to filter equipment by category.
+
+#### Scenario: Category filter tabs
+- **WHEN** loadout tray is expanded
+- **THEN** display category filter tabs (All, Energy, Ballistic, Missile, Ammo, Electronics, Other)
+- **AND** active tab is visually highlighted
+
+#### Scenario: Filter application
+- **WHEN** user selects a category filter
+- **THEN** only equipment matching that category is displayed
+- **AND** both Unassigned and Allocated sections are filtered
+
+---
+
+### Requirement: Clear All Equipment
+
+Users SHALL be able to remove all equipment at once.
+
+#### Scenario: Clear All button
+- **WHEN** loadout tray has removable equipment
+- **THEN** display "Clear All" button in the header
+- **AND** tapping removes all removable equipment
+

--- a/openspec/changes/archive/2026-01-14-enhance-mobile-loadout-tray/tasks.md
+++ b/openspec/changes/archive/2026-01-14-enhance-mobile-loadout-tray/tasks.md
@@ -1,0 +1,113 @@
+# Tasks: Enhance Mobile Loadout Tray
+
+## Status: Complete ✅
+
+All tasks have been implemented and verified.
+
+---
+
+## Task 1: Mobile Status Bar Header ✅
+**Status**: Complete
+
+- [x] Create `MobileLoadoutHeader` component
+- [x] Display compact stats: Weight, Slots, Heat, BV
+- [x] Show equipment count badge
+- [x] Implement expand/collapse toggle
+- [x] Persist expanded state to localStorage
+
+---
+
+## Task 2: Mobile Equipment Row Component ✅
+**Status**: Complete
+
+- [x] Create `MobileEquipmentRow` component
+- [x] Display equipment name with category color indicator
+- [x] Show location, heat, crits, weight columns
+- [x] Display weapon details (damage, range brackets, TC compatibility)
+- [x] Show OmniMech pod/fixed badges
+- [x] Compact row height (36px minimum)
+
+---
+
+## Task 3: Equipment List with Sections ✅
+**Status**: Complete
+
+- [x] Create `MobileLoadoutList` component
+- [x] Implement Unassigned/Allocated section grouping
+- [x] Add collapsible section headers with counts
+- [x] Add category filter tabs
+- [x] Add section-specific column headers
+- [x] Implement "Clear All" functionality
+
+---
+
+## Task 4: Link Button for Unassigned Items ✅
+**Status**: Complete
+
+- [x] Add link icon (🔗) for unassigned equipment
+- [x] Create location selection dropdown
+- [x] Show available slots per location
+- [x] Filter locations that can fit the equipment
+- [x] Handle location restriction validation
+- [x] Close dropdown on selection
+
+---
+
+## Task 5: Unlink Button for Allocated Items ✅
+**Status**: Complete
+
+- [x] Add breaking chain icon for allocated equipment
+- [x] Implement two-tap confirmation
+- [x] Call unassign handler on confirmation
+- [x] Reset confirmation state on timeout
+
+---
+
+## Task 6: Remove Button with Confirmation ✅
+**Status**: Complete
+
+- [x] Add × icon for removable equipment
+- [x] Implement two-tap confirmation
+- [x] Ensure mutual exclusivity with unassign confirmation
+- [x] Reset confirmation state on timeout
+
+---
+
+## Task 7: Exclusive Dropdown Behavior ✅
+**Status**: Complete
+
+- [x] Lift dropdown state to `MobileLoadoutList`
+- [x] Track `openLocationMenuId` in parent
+- [x] Pass controlled props to `MobileEquipmentRow`
+- [x] Close other dropdowns when opening new one
+
+---
+
+## Task 8: Touch Target Optimization ✅
+**Status**: Complete
+
+- [x] Increase action column width to 36px
+- [x] Make buttons fill full column area
+- [x] Add hover/active background states
+- [x] Use visible emoji/text icons instead of faint SVGs
+
+---
+
+## Task 9: Section Column Headers ✅
+**Status**: Complete
+
+- [x] Remove top-level header with scrollbar padding
+- [x] Add `SectionColumnHeaders` inside each section
+- [x] Reduce header height to compact 18px
+- [x] Ensure perfect alignment with data rows
+
+---
+
+## Validation
+
+- [x] TypeScript builds without errors
+- [x] All components render correctly
+- [x] Link dropdown shows correct locations
+- [x] Unlink/remove confirmations work
+- [x] Only one dropdown open at a time
+- [x] Headers align with data rows

--- a/openspec/specs/equipment-tray/spec.md
+++ b/openspec/specs/equipment-tray/spec.md
@@ -250,6 +250,13 @@ Loadout tray SHALL provide context menu for quick equipment assignment.
 - **THEN** context menu SHALL show "Unassign from [Location]" option
 - **AND** clicking option SHALL unassign the equipment
 
+#### Scenario: Context menu row layout
+- **GIVEN** context menu is displayed with location options
+- **WHEN** location names and slot counts are rendered
+- **THEN** each row SHALL display on a single line without wrapping
+- **AND** menu width SHALL be at least 200px
+- **AND** location label and "X free" text SHALL have consistent spacing
+
 ### Requirement: Equipment Selection State
 Loadout tray SHALL support equipment selection for slot assignment workflow.
 
@@ -301,4 +308,38 @@ Loadout tray SHALL display equipment in separate sections by allocation status.
 - **AND** equipment SHALL show location name (e.g., "@ Left Torso")
 - **AND** section SHALL show count of allocated items
 - **AND** section SHALL be collapsible
+
+### Requirement: Category Filter Bar
+The Loadout Tray SHALL provide a category filter bar to filter displayed equipment by type.
+
+#### Scenario: Filter bar display
+- **WHEN** tray is expanded
+- **THEN** category filter bar SHALL appear below header
+- **AND** filter bar SHALL show icon buttons for: All, Energy, Ballistic, Missile, Ammo, Electronics, Other
+
+#### Scenario: Default filter state
+- **WHEN** tray is first opened
+- **THEN** "All" filter SHALL be active
+- **AND** all equipment SHALL be visible
+
+#### Scenario: Filter by category
+- **WHEN** user clicks a category filter button (e.g., Energy)
+- **THEN** only equipment matching that category SHALL be displayed
+- **AND** active filter button SHALL be visually highlighted
+- **AND** equipment from other categories SHALL be hidden
+
+#### Scenario: Other category grouping
+- **WHEN** user selects "Other" filter
+- **THEN** equipment from Misc, Physical, Movement, Artillery, and Structural categories SHALL be shown
+- **AND** equipment from Energy, Ballistic, Missile, Ammo, Electronics SHALL be hidden
+
+#### Scenario: Empty filter state
+- **WHEN** active filter matches no equipment
+- **THEN** message SHALL show "No items in filter"
+- **AND** hint text SHALL show "Try another category"
+
+#### Scenario: Return to all
+- **WHEN** user clicks "All" filter button
+- **THEN** all equipment SHALL be visible again
+- **AND** "All" button SHALL be highlighted as active
 

--- a/openspec/specs/mobile-loadout-tray/spec.md
+++ b/openspec/specs/mobile-loadout-tray/spec.md
@@ -1,0 +1,179 @@
+# mobile-loadout-tray Specification
+
+## Purpose
+TBD - created by archiving change enhance-mobile-loadout-tray. Update Purpose after archive.
+## Requirements
+### Requirement: Mobile Loadout Status Bar
+
+The mobile loadout SHALL display a compact status bar when collapsed.
+
+#### Scenario: Collapsed status bar display
+- **WHEN** the loadout tray is in collapsed state
+- **THEN** a fixed status bar appears at the bottom of the screen
+- **AND** displays Weight (used/max), Slots (used/max), Heat (generated/dissipation), and BV
+- **AND** shows equipment count badge
+- **AND** tapping the bar expands to full-screen view
+
+#### Scenario: Weight overage indication
+- **WHEN** weight used exceeds weight maximum
+- **THEN** weight value displays in red color
+
+#### Scenario: Slots overage indication
+- **WHEN** slots used exceeds slots maximum
+- **THEN** slots value displays in red color
+
+---
+
+### Requirement: Mobile Equipment Row Display
+
+Each equipment item SHALL display comprehensive information in a compact row.
+
+#### Scenario: Equipment name and category
+- **WHEN** rendering an equipment row
+- **THEN** display the equipment name
+- **AND** show a colored category indicator bar (energy=cyan, ballistic=red, missile=orange, etc.)
+- **AND** show OmniMech pod/fixed badge when applicable
+
+#### Scenario: Equipment stats columns
+- **WHEN** rendering an equipment row
+- **THEN** display columns for: Location (or dash if unassigned), Heat, Crits, Weight
+- **AND** columns align with section header columns
+
+#### Scenario: Weapon details display
+- **WHEN** equipment is a weapon
+- **THEN** display damage value, range brackets (S/M/L format)
+- **AND** show TC indicator if targeting computer compatible
+
+---
+
+### Requirement: Section Grouping with Headers
+
+Equipment SHALL be grouped into Unassigned and Allocated sections.
+
+#### Scenario: Unassigned section
+- **WHEN** equipment has no assigned location
+- **THEN** display in Unassigned section with amber background tint
+- **AND** section header shows "Unassigned" with item count
+- **AND** section is collapsible
+
+#### Scenario: Allocated section
+- **WHEN** equipment has an assigned location
+- **THEN** display in Allocated section with green background tint
+- **AND** section header shows "Allocated" with item count
+- **AND** section is collapsible
+
+#### Scenario: Section column headers
+- **WHEN** a section is expanded
+- **THEN** display compact column headers (NAME, LOC, H, C, WT, 🔗, ×)
+- **AND** headers appear inside the section content area
+- **AND** headers align exactly with data row columns
+
+---
+
+### Requirement: Quick Assign via Link Button
+
+Unassigned equipment SHALL have a link button for quick assignment.
+
+#### Scenario: Link button display
+- **WHEN** equipment is unassigned and removable
+- **AND** at least one location can fit the equipment
+- **THEN** display a link icon (🔗) in the actions column
+
+#### Scenario: Location dropdown display
+- **WHEN** user taps the link button
+- **THEN** display a dropdown with available locations
+- **AND** each location shows name and available slot count
+- **AND** only locations that can fit the equipment are selectable
+
+#### Scenario: Location selection
+- **WHEN** user selects a location from the dropdown
+- **THEN** equipment is assigned to first available slot in that location
+- **AND** dropdown closes
+- **AND** equipment moves to Allocated section
+
+#### Scenario: Exclusive dropdown behavior
+- **WHEN** user opens a link dropdown
+- **THEN** any other open dropdown closes
+- **AND** only one dropdown is visible at a time
+
+---
+
+### Requirement: Unlink Button for Allocated Equipment
+
+Allocated equipment SHALL have an unlink button with confirmation.
+
+#### Scenario: Unlink button display
+- **WHEN** equipment is allocated and removable
+- **THEN** display a breaking chain icon in the actions column
+
+#### Scenario: Unlink confirmation
+- **WHEN** user taps the unlink button
+- **THEN** button changes to show "?" confirmation indicator
+- **AND** tapping again confirms and unassigns the equipment
+- **AND** tapping elsewhere or waiting resets the confirmation state
+
+---
+
+### Requirement: Remove Button with Confirmation
+
+Removable equipment SHALL have a remove button with confirmation.
+
+#### Scenario: Remove button display
+- **WHEN** equipment is removable
+- **THEN** display an × icon in the actions column
+
+#### Scenario: Remove confirmation
+- **WHEN** user taps the remove button
+- **THEN** button changes to show "?" confirmation indicator
+- **AND** tapping again confirms and removes the equipment
+- **AND** tapping elsewhere or waiting resets the confirmation state
+
+#### Scenario: Mutual exclusivity with unlink
+- **WHEN** remove confirmation is active
+- **THEN** unlink confirmation is reset
+- **AND** vice versa
+
+---
+
+### Requirement: Touch-Friendly Action Columns
+
+Action buttons SHALL have proper touch target sizes.
+
+#### Scenario: Action column dimensions
+- **WHEN** rendering action columns (link/unlink, remove)
+- **THEN** each column is 36px wide
+- **AND** buttons fill the entire column area
+- **AND** buttons show hover/active background feedback
+
+#### Scenario: Visual feedback on interaction
+- **WHEN** user hovers or taps an action button
+- **THEN** background color changes to indicate interaction
+- **AND** confirmation state shows distinct background color
+
+---
+
+### Requirement: Category Filtering
+
+Users SHALL be able to filter equipment by category.
+
+#### Scenario: Category filter tabs
+- **WHEN** loadout tray is expanded
+- **THEN** display category filter tabs (All, Energy, Ballistic, Missile, Ammo, Electronics, Other)
+- **AND** active tab is visually highlighted
+
+#### Scenario: Filter application
+- **WHEN** user selects a category filter
+- **THEN** only equipment matching that category is displayed
+- **AND** both Unassigned and Allocated sections are filtered
+
+---
+
+### Requirement: Clear All Equipment
+
+Users SHALL be able to remove all equipment at once.
+
+#### Scenario: Clear All button
+- **WHEN** loadout tray has removable equipment
+- **THEN** display "Clear All" button in the header
+- **AND** tapping removes all removable equipment
+

--- a/src/__tests__/components/customizer/equipment/CompactFilterBar.test.tsx
+++ b/src/__tests__/components/customizer/equipment/CompactFilterBar.test.tsx
@@ -1,0 +1,216 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CompactFilterBar } from '@/components/customizer/equipment/CompactFilterBar';
+import { EquipmentCategory } from '@/types/equipment';
+
+describe('CompactFilterBar', () => {
+  const defaultProps = {
+    activeCategories: new Set<EquipmentCategory>(),
+    showAll: true,
+    hidePrototype: false,
+    hideOneShot: false,
+    hideUnavailable: false,
+    hideAmmoWithoutWeapon: false,
+    search: '',
+    onSelectCategory: jest.fn(),
+    onShowAll: jest.fn(),
+    onTogglePrototype: jest.fn(),
+    onToggleOneShot: jest.fn(),
+    onToggleUnavailable: jest.fn(),
+    onToggleAmmoWithoutWeapon: jest.fn(),
+    onSearchChange: jest.fn(),
+    onClearFilters: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Category Buttons', () => {
+    it('should render all category buttons with icons', () => {
+      render(<CompactFilterBar {...defaultProps} />);
+      
+      expect(screen.getByText('⚡')).toBeInTheDocument();
+      expect(screen.getByText('🎯')).toBeInTheDocument();
+      expect(screen.getByText('🚀')).toBeInTheDocument();
+      expect(screen.getByText('💥')).toBeInTheDocument();
+      expect(screen.getByText('🔨')).toBeInTheDocument();
+      expect(screen.getByText('📦')).toBeInTheDocument();
+      expect(screen.getByText('⚙️')).toBeInTheDocument();
+    });
+
+    it('should render All button', () => {
+      render(<CompactFilterBar {...defaultProps} />);
+      expect(screen.getByText('All')).toBeInTheDocument();
+    });
+
+    it('should highlight All button when showAll is true', () => {
+      render(<CompactFilterBar {...defaultProps} showAll={true} />);
+      const allButton = screen.getByText('All').closest('button');
+      expect(allButton).toHaveClass('bg-accent');
+    });
+
+    it('should call onSelectCategory when category is clicked', async () => {
+      const user = userEvent.setup();
+      render(<CompactFilterBar {...defaultProps} showAll={false} />);
+      
+      const energyButton = screen.getByText('⚡').closest('button');
+      await user.click(energyButton!);
+      
+      expect(defaultProps.onSelectCategory).toHaveBeenCalledWith(
+        EquipmentCategory.ENERGY_WEAPON,
+        false
+      );
+    });
+
+    it('should call onShowAll when All is clicked', async () => {
+      const user = userEvent.setup();
+      render(<CompactFilterBar {...defaultProps} />);
+      
+      const allButton = screen.getByText('All');
+      await user.click(allButton);
+      
+      expect(defaultProps.onShowAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('should highlight active category', () => {
+      const activeCategories = new Set([EquipmentCategory.ENERGY_WEAPON]);
+      render(<CompactFilterBar {...defaultProps} activeCategories={activeCategories} showAll={false} />);
+      
+      const energyButton = screen.getByText('⚡').closest('button');
+      expect(energyButton).toHaveClass('ring-1');
+    });
+  });
+
+  describe('Hide Filters Toggle', () => {
+    it('should render Hide button', () => {
+      render(<CompactFilterBar {...defaultProps} />);
+      expect(screen.getByText('Hide')).toBeInTheDocument();
+    });
+
+    it('should show active hide filter count badge', () => {
+      render(<CompactFilterBar {...defaultProps} hidePrototype={true} hideOneShot={true} />);
+      expect(screen.getByText('2')).toBeInTheDocument();
+    });
+
+    it('should toggle hide filters when clicked', async () => {
+      const user = userEvent.setup();
+      render(<CompactFilterBar {...defaultProps} />);
+      
+      const hideButton = screen.getByText('Hide').closest('button');
+      await user.click(hideButton!);
+      
+      expect(screen.getByText('Proto')).toBeInTheDocument();
+      expect(screen.getByText('1-Shot')).toBeInTheDocument();
+      expect(screen.getByText('No Wpn')).toBeInTheDocument();
+      expect(screen.getByText('Unavail')).toBeInTheDocument();
+    });
+
+    it('should call onTogglePrototype when Proto is clicked', async () => {
+      const user = userEvent.setup();
+      render(<CompactFilterBar {...defaultProps} />);
+      
+      const hideButton = screen.getByText('Hide').closest('button');
+      await user.click(hideButton!);
+      
+      const protoButton = screen.getByText('Proto');
+      await user.click(protoButton);
+      
+      expect(defaultProps.onTogglePrototype).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onToggleOneShot when 1-Shot is clicked', async () => {
+      const user = userEvent.setup();
+      render(<CompactFilterBar {...defaultProps} />);
+      
+      const hideButton = screen.getByText('Hide').closest('button');
+      await user.click(hideButton!);
+      
+      const oneShotButton = screen.getByText('1-Shot');
+      await user.click(oneShotButton);
+      
+      expect(defaultProps.onToggleOneShot).toHaveBeenCalledTimes(1);
+    });
+
+    it('should highlight active hide toggles', async () => {
+      const user = userEvent.setup();
+      render(<CompactFilterBar {...defaultProps} hidePrototype={true} />);
+      
+      const hideButton = screen.getByText('Hide').closest('button');
+      await user.click(hideButton!);
+      
+      const protoButton = screen.getByText('Proto').closest('button');
+      expect(protoButton).toHaveClass('bg-red-900/50');
+    });
+  });
+
+  describe('Search Input', () => {
+    it('should render search input', () => {
+      render(<CompactFilterBar {...defaultProps} />);
+      expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+    });
+
+    it('should display current search value', () => {
+      render(<CompactFilterBar {...defaultProps} search="laser" />);
+      expect(screen.getByDisplayValue('laser')).toBeInTheDocument();
+    });
+
+    it('should call onSearchChange when typing', async () => {
+      const user = userEvent.setup();
+      render(<CompactFilterBar {...defaultProps} />);
+      
+      const searchInput = screen.getByPlaceholderText('Search...');
+      await user.type(searchInput, 'ppc');
+      
+      expect(defaultProps.onSearchChange).toHaveBeenCalled();
+    });
+
+    it('should show clear button when search has value', () => {
+      render(<CompactFilterBar {...defaultProps} search="laser" />);
+      expect(screen.getByTitle('Clear search')).toBeInTheDocument();
+    });
+
+    it('should clear search when clear button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<CompactFilterBar {...defaultProps} search="laser" />);
+      
+      const clearButton = screen.getByTitle('Clear search');
+      await user.click(clearButton);
+      
+      expect(defaultProps.onSearchChange).toHaveBeenCalledWith('');
+    });
+  });
+
+  describe('Clear All Filters', () => {
+    it('should show Clear button when filters are active', () => {
+      render(<CompactFilterBar {...defaultProps} search="test" />);
+      expect(screen.getByText('Clear')).toBeInTheDocument();
+    });
+
+    it('should show Clear button when showAll is false', () => {
+      render(<CompactFilterBar {...defaultProps} showAll={false} />);
+      expect(screen.getByText('Clear')).toBeInTheDocument();
+    });
+
+    it('should show Clear button when hide filters are active', () => {
+      render(<CompactFilterBar {...defaultProps} hidePrototype={true} />);
+      expect(screen.getByText('Clear')).toBeInTheDocument();
+    });
+
+    it('should not show Clear button when no filters active', () => {
+      render(<CompactFilterBar {...defaultProps} showAll={true} />);
+      expect(screen.queryByText('Clear')).not.toBeInTheDocument();
+    });
+
+    it('should call onClearFilters when Clear is clicked', async () => {
+      const user = userEvent.setup();
+      render(<CompactFilterBar {...defaultProps} search="test" />);
+      
+      const clearButton = screen.getByText('Clear');
+      await user.click(clearButton);
+      
+      expect(defaultProps.onClearFilters).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/__tests__/components/customizer/equipment/EquippedSummary.test.tsx
+++ b/src/__tests__/components/customizer/equipment/EquippedSummary.test.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EquippedSummary } from '@/components/customizer/equipment/EquippedSummary';
+import { EquipmentCategory } from '@/types/equipment';
+import type { LoadoutEquipmentItem } from '@/components/customizer/equipment/GlobalLoadoutTray';
+
+describe('EquippedSummary', () => {
+  const createEquipment = (overrides?: Partial<LoadoutEquipmentItem>): LoadoutEquipmentItem => ({
+    instanceId: 'equip-1',
+    equipmentId: 'medium-laser',
+    name: 'Medium Laser',
+    category: EquipmentCategory.ENERGY_WEAPON,
+    weight: 1,
+    criticalSlots: 1,
+    isAllocated: false,
+    isRemovable: true,
+    ...overrides,
+  });
+
+  const defaultProps = {
+    equipment: [createEquipment()],
+    onRemoveEquipment: jest.fn(),
+    onSelectEquipment: jest.fn(),
+    selectedEquipmentId: null,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render nothing when no removable equipment', () => {
+      const { container } = render(
+        <EquippedSummary {...defaultProps} equipment={[]} />
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should render nothing when all equipment is non-removable', () => {
+      const equipment = [createEquipment({ isRemovable: false })];
+      const { container } = render(
+        <EquippedSummary {...defaultProps} equipment={equipment} />
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should render Equipped header', () => {
+      render(<EquippedSummary {...defaultProps} />);
+      expect(screen.getByText('Equipped')).toBeInTheDocument();
+    });
+
+    it('should display equipment count', () => {
+      const equipment = [
+        createEquipment({ instanceId: 'e1' }),
+        createEquipment({ instanceId: 'e2' }),
+      ];
+      render(<EquippedSummary {...defaultProps} equipment={equipment} />);
+      expect(screen.getByText('2')).toBeInTheDocument();
+    });
+
+    it('should display total weight', () => {
+      const equipment = [
+        createEquipment({ instanceId: 'e1', weight: 2 }),
+        createEquipment({ instanceId: 'e2', weight: 3 }),
+      ];
+      render(<EquippedSummary {...defaultProps} equipment={equipment} />);
+      expect(screen.getByText('5t')).toBeInTheDocument();
+    });
+
+    it('should display total slots', () => {
+      const equipment = [
+        createEquipment({ instanceId: 'e1', criticalSlots: 2 }),
+        createEquipment({ instanceId: 'e2', criticalSlots: 3 }),
+      ];
+      render(<EquippedSummary {...defaultProps} equipment={equipment} />);
+      expect(screen.getByText('5 slots')).toBeInTheDocument();
+    });
+
+    it('should display equipment name', () => {
+      render(<EquippedSummary {...defaultProps} />);
+      expect(screen.getByText('Medium Laser')).toBeInTheDocument();
+    });
+  });
+
+  describe('Grouping', () => {
+    it('should group identical equipment with count', () => {
+      const equipment = [
+        createEquipment({ instanceId: 'e1', name: 'Medium Laser' }),
+        createEquipment({ instanceId: 'e2', name: 'Medium Laser' }),
+        createEquipment({ instanceId: 'e3', name: 'Medium Laser' }),
+      ];
+      render(<EquippedSummary {...defaultProps} equipment={equipment} />);
+      expect(screen.getByText('×3')).toBeInTheDocument();
+    });
+
+    it('should not show count for single items', () => {
+      render(<EquippedSummary {...defaultProps} />);
+      expect(screen.queryByText('×1')).not.toBeInTheDocument();
+    });
+
+    it('should group by name and category', () => {
+      const equipment = [
+        createEquipment({ instanceId: 'e1', name: 'Medium Laser', category: EquipmentCategory.ENERGY_WEAPON }),
+        createEquipment({ instanceId: 'e2', name: 'LRM 10', category: EquipmentCategory.MISSILE_WEAPON }),
+      ];
+      render(<EquippedSummary {...defaultProps} equipment={equipment} />);
+      expect(screen.getByText('Medium Laser')).toBeInTheDocument();
+      expect(screen.getByText('LRM 10')).toBeInTheDocument();
+    });
+  });
+
+  describe('Filtering non-removable equipment', () => {
+    it('should only show removable equipment', () => {
+      const equipment = [
+        createEquipment({ instanceId: 'e1', name: 'Medium Laser', isRemovable: true }),
+        createEquipment({ instanceId: 'e2', name: 'Endo Steel', isRemovable: false }),
+      ];
+      render(<EquippedSummary {...defaultProps} equipment={equipment} />);
+      expect(screen.getByText('Medium Laser')).toBeInTheDocument();
+      expect(screen.queryByText('Endo Steel')).not.toBeInTheDocument();
+    });
+
+    it('should only count removable equipment in totals', () => {
+      const equipment = [
+        createEquipment({ instanceId: 'e1', weight: 2, isRemovable: true }),
+        createEquipment({ instanceId: 'e2', weight: 10, isRemovable: false }),
+      ];
+      render(<EquippedSummary {...defaultProps} equipment={equipment} />);
+      expect(screen.getByText('2t')).toBeInTheDocument();
+      expect(screen.getByText('1')).toBeInTheDocument();
+    });
+  });
+
+  describe('Collapse/Expand', () => {
+    it('should start expanded by default', () => {
+      render(<EquippedSummary {...defaultProps} />);
+      expect(screen.getByText('Medium Laser')).toBeInTheDocument();
+    });
+
+    it('should toggle collapse when header is clicked', async () => {
+      const user = userEvent.setup();
+      render(<EquippedSummary {...defaultProps} />);
+      
+      const header = screen.getByText('Equipped').closest('button');
+      await user.click(header!);
+      
+      expect(screen.queryByText('Medium Laser')).not.toBeInTheDocument();
+      
+      await user.click(header!);
+      expect(screen.getByText('Medium Laser')).toBeInTheDocument();
+    });
+  });
+
+  describe('Selection', () => {
+    it('should call onSelectEquipment when unallocated equipment is clicked', async () => {
+      const user = userEvent.setup();
+      const equipment = [createEquipment({ isAllocated: false })];
+      render(<EquippedSummary {...defaultProps} equipment={equipment} />);
+      
+      const chip = screen.getByText('Medium Laser').closest('div');
+      await user.click(chip!);
+      
+      expect(defaultProps.onSelectEquipment).toHaveBeenCalledWith('equip-1');
+    });
+
+    it('should highlight selected equipment', () => {
+      const equipment = [createEquipment({ instanceId: 'selected-1' })];
+      render(
+        <EquippedSummary
+          {...defaultProps}
+          equipment={equipment}
+          selectedEquipmentId="selected-1"
+        />
+      );
+      
+      const chip = screen.getByText('Medium Laser').closest('div');
+      expect(chip).toHaveClass('ring-1');
+    });
+
+    it('should deselect when clicking selected equipment', async () => {
+      const user = userEvent.setup();
+      const equipment = [createEquipment({ instanceId: 'selected-1', isAllocated: false })];
+      render(
+        <EquippedSummary
+          {...defaultProps}
+          equipment={equipment}
+          selectedEquipmentId="selected-1"
+        />
+      );
+      
+      const chip = screen.getByText('Medium Laser').closest('div');
+      await user.click(chip!);
+      
+      expect(defaultProps.onSelectEquipment).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('Removal', () => {
+    it('should show remove button on hover', () => {
+      render(<EquippedSummary {...defaultProps} />);
+      expect(screen.getByTitle('Remove one Medium Laser')).toBeInTheDocument();
+    });
+
+    it('should call onRemoveEquipment when remove is clicked', async () => {
+      const user = userEvent.setup();
+      render(<EquippedSummary {...defaultProps} />);
+      
+      const removeButton = screen.getByTitle('Remove one Medium Laser');
+      await user.click(removeButton);
+      
+      expect(defaultProps.onRemoveEquipment).toHaveBeenCalledWith('equip-1');
+    });
+
+    it('should remove one item from a group', async () => {
+      const user = userEvent.setup();
+      const equipment = [
+        createEquipment({ instanceId: 'e1', name: 'Medium Laser' }),
+        createEquipment({ instanceId: 'e2', name: 'Medium Laser' }),
+      ];
+      render(<EquippedSummary {...defaultProps} equipment={equipment} />);
+      
+      const removeButton = screen.getByTitle('Remove one Medium Laser');
+      await user.click(removeButton);
+      
+      expect(defaultProps.onRemoveEquipment).toHaveBeenCalledWith('e1');
+    });
+  });
+});

--- a/src/__tests__/components/customizer/equipment/GlobalLoadoutTray.test.tsx
+++ b/src/__tests__/components/customizer/equipment/GlobalLoadoutTray.test.tsx
@@ -8,6 +8,7 @@ import { MechLocation } from '@/types/construction';
 describe('GlobalLoadoutTray', () => {
   const createEquipment = (overrides?: Partial<LoadoutEquipmentItem>): LoadoutEquipmentItem => ({
     instanceId: 'equip-1',
+    equipmentId: 'medium-laser',
     name: 'Medium Laser',
     category: EquipmentCategory.ENERGY_WEAPON,
     weight: 1,

--- a/src/__tests__/components/customizer/equipment/GlobalLoadoutTray.test.tsx
+++ b/src/__tests__/components/customizer/equipment/GlobalLoadoutTray.test.tsx
@@ -181,5 +181,75 @@ describe('GlobalLoadoutTray', () => {
     
     expect(screen.getByText(/No equipment/i)).toBeInTheDocument();
   });
+
+  describe('Category Filter', () => {
+    const mixedEquipment = [
+      createEquipment({ instanceId: 'e1', name: 'Medium Laser', category: EquipmentCategory.ENERGY_WEAPON }),
+      createEquipment({ instanceId: 'e2', name: 'AC/10', category: EquipmentCategory.BALLISTIC_WEAPON }),
+      createEquipment({ instanceId: 'e3', name: 'LRM 20', category: EquipmentCategory.MISSILE_WEAPON }),
+      createEquipment({ instanceId: 'e4', name: 'Ammo LRM', category: EquipmentCategory.AMMUNITION }),
+    ];
+
+    it('should render category filter buttons', () => {
+      render(<GlobalLoadoutTray {...defaultProps} equipment={mixedEquipment} />);
+      
+      expect(screen.getByTitle('All Categories')).toBeInTheDocument();
+      expect(screen.getByTitle('Energy')).toBeInTheDocument();
+      expect(screen.getByTitle('Ballistic')).toBeInTheDocument();
+    });
+
+    it('should show all equipment by default', () => {
+      render(<GlobalLoadoutTray {...defaultProps} equipment={mixedEquipment} />);
+      
+      expect(screen.getByText('Medium Laser')).toBeInTheDocument();
+      expect(screen.getByText('AC/10')).toBeInTheDocument();
+      expect(screen.getByText('LRM 20')).toBeInTheDocument();
+      expect(screen.getByText('Ammo LRM')).toBeInTheDocument();
+    });
+
+    it('should filter to energy weapons when energy filter clicked', async () => {
+      const user = userEvent.setup();
+      render(<GlobalLoadoutTray {...defaultProps} equipment={mixedEquipment} />);
+      
+      await user.click(screen.getByTitle('Energy'));
+      
+      expect(screen.getByText('Medium Laser')).toBeInTheDocument();
+      expect(screen.queryByText('AC/10')).not.toBeInTheDocument();
+      expect(screen.queryByText('LRM 20')).not.toBeInTheDocument();
+    });
+
+    it('should filter to ballistic weapons when ballistic filter clicked', async () => {
+      const user = userEvent.setup();
+      render(<GlobalLoadoutTray {...defaultProps} equipment={mixedEquipment} />);
+      
+      await user.click(screen.getByTitle('Ballistic'));
+      
+      expect(screen.queryByText('Medium Laser')).not.toBeInTheDocument();
+      expect(screen.getByText('AC/10')).toBeInTheDocument();
+      expect(screen.queryByText('LRM 20')).not.toBeInTheDocument();
+    });
+
+    it('should show empty filter state when no items match filter', async () => {
+      const user = userEvent.setup();
+      const energyOnly = [createEquipment({ instanceId: 'e1', name: 'Laser', category: EquipmentCategory.ENERGY_WEAPON })];
+      render(<GlobalLoadoutTray {...defaultProps} equipment={energyOnly} />);
+      
+      await user.click(screen.getByTitle('Ballistic'));
+      
+      expect(screen.getByText(/No items in filter/i)).toBeInTheDocument();
+    });
+
+    it('should return to showing all when All filter clicked', async () => {
+      const user = userEvent.setup();
+      render(<GlobalLoadoutTray {...defaultProps} equipment={mixedEquipment} />);
+      
+      await user.click(screen.getByTitle('Energy'));
+      expect(screen.queryByText('AC/10')).not.toBeInTheDocument();
+      
+      await user.click(screen.getByTitle('All Categories'));
+      expect(screen.getByText('AC/10')).toBeInTheDocument();
+      expect(screen.getByText('Medium Laser')).toBeInTheDocument();
+    });
+  });
 });
 

--- a/src/__tests__/components/customizer/mobile/MobileEquipmentRow.test.tsx
+++ b/src/__tests__/components/customizer/mobile/MobileEquipmentRow.test.tsx
@@ -1,0 +1,301 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MobileEquipmentRow, MobileEquipmentItem } from '@/components/customizer/mobile/MobileEquipmentRow';
+import { EquipmentCategory } from '@/types/equipment';
+
+describe('MobileEquipmentRow', () => {
+  const createItem = (overrides?: Partial<MobileEquipmentItem>): MobileEquipmentItem => ({
+    instanceId: 'equip-1',
+    name: 'Medium Laser',
+    category: EquipmentCategory.ENERGY_WEAPON,
+    weight: 1,
+    criticalSlots: 1,
+    isAllocated: false,
+    isRemovable: true,
+    ...overrides,
+  });
+
+  const defaultProps = {
+    item: createItem(),
+    onSelect: jest.fn(),
+    onRemove: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('Basic Rendering', () => {
+    it('should render equipment name', () => {
+      render(<MobileEquipmentRow {...defaultProps} />);
+      expect(screen.getByText('Medium Laser')).toBeInTheDocument();
+    });
+
+    it('should render weight and crits', () => {
+      // Default item has weight=1, criticalSlots=1, heat=0
+      // Structure is: [Location] [Heat] [Crits] [Weight]
+      render(<MobileEquipmentRow {...defaultProps} />);
+      // Weight and crits are both 1, heat is 0 - find all "1"s and verify count
+      const ones = screen.getAllByText('1');
+      expect(ones.length).toBeGreaterThanOrEqual(2); // weight + crits
+    });
+
+    it('should render critical slots', () => {
+      // Use different values for crits vs weight to distinguish them
+      const item = createItem({ criticalSlots: 3, weight: 2 });
+      render(<MobileEquipmentRow {...defaultProps} item={item} />);
+      expect(screen.getByText('3')).toBeInTheDocument(); // crits
+      expect(screen.getByText('2')).toBeInTheDocument(); // weight
+    });
+
+    it('should show dash for unallocated location', () => {
+      render(<MobileEquipmentRow {...defaultProps} />);
+      expect(screen.getByText('—')).toBeInTheDocument();
+    });
+
+    it('should show location shorthand for allocated item', () => {
+      const item = createItem({ isAllocated: true, location: 'Right Torso' });
+      render(<MobileEquipmentRow {...defaultProps} item={item} />);
+      expect(screen.getByText('RT')).toBeInTheDocument();
+    });
+  });
+
+  describe('Weapon Details', () => {
+    it('should display damage for weapons', () => {
+      const item = createItem({ damage: 5 });
+      render(<MobileEquipmentRow {...defaultProps} item={item} />);
+      expect(screen.getByText('5dmg')).toBeInTheDocument();
+    });
+
+    it('should display range brackets', () => {
+      const item = createItem({ 
+        ranges: { minimum: 0, short: 3, medium: 6, long: 9 } 
+      });
+      render(<MobileEquipmentRow {...defaultProps} item={item} />);
+      expect(screen.getByText('0/3/6/9')).toBeInTheDocument();
+    });
+
+    it('should display TC indicator for targeting computer compatible weapons', () => {
+      const item = createItem({ targetingComputerCompatible: true, damage: 5 });
+      render(<MobileEquipmentRow {...defaultProps} item={item} />);
+      expect(screen.getByText('TC')).toBeInTheDocument();
+    });
+
+    it('should display heat value', () => {
+      const item = createItem({ heat: 7, weight: 2, criticalSlots: 3 });
+      render(<MobileEquipmentRow {...defaultProps} item={item} />);
+      expect(screen.getByText('7')).toBeInTheDocument();
+    });
+  });
+
+  describe('OmniMech Indicators', () => {
+    it('should show Pod indicator for pod-mounted equipment', () => {
+      const item = createItem({ isOmniPodMounted: true });
+      render(<MobileEquipmentRow {...defaultProps} item={item} isOmni={true} />);
+      expect(screen.getByText('P')).toBeInTheDocument();
+    });
+
+    it('should show Fixed indicator for fixed equipment', () => {
+      const item = createItem({ isOmniPodMounted: false });
+      render(<MobileEquipmentRow {...defaultProps} item={item} isOmni={true} />);
+      expect(screen.getByText('F')).toBeInTheDocument();
+    });
+
+    it('should reduce opacity for fixed equipment on OmniMech', () => {
+      const item = createItem({ isOmniPodMounted: false });
+      const { container } = render(<MobileEquipmentRow {...defaultProps} item={item} isOmni={true} />);
+      expect(container.firstChild).toHaveClass('opacity-60');
+    });
+  });
+
+  describe('Selection', () => {
+    it('should call onSelect when clicked', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<MobileEquipmentRow {...defaultProps} />);
+      
+      const row = screen.getByText('Medium Laser').closest('div');
+      await user.click(row!);
+      
+      expect(defaultProps.onSelect).toHaveBeenCalled();
+    });
+
+    it('should highlight when selected', () => {
+      const { container } = render(<MobileEquipmentRow {...defaultProps} isSelected={true} />);
+      expect(container.firstChild).toHaveClass('bg-accent/10');
+    });
+  });
+
+  describe('Remove Button', () => {
+    it('should show remove button for removable equipment', () => {
+      render(<MobileEquipmentRow {...defaultProps} />);
+      expect(screen.getByTitle('Remove from unit')).toBeInTheDocument();
+    });
+
+    it('should not show remove button for non-removable equipment', () => {
+      const item = createItem({ isRemovable: false });
+      render(<MobileEquipmentRow {...defaultProps} item={item} />);
+      expect(screen.queryByTitle('Remove from unit')).not.toBeInTheDocument();
+    });
+
+    it('should require confirmation to remove', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<MobileEquipmentRow {...defaultProps} />);
+      
+      const removeButton = screen.getByTitle('Remove from unit');
+      await user.click(removeButton);
+      
+      expect(defaultProps.onRemove).not.toHaveBeenCalled();
+      expect(screen.getByTitle('Confirm remove')).toBeInTheDocument();
+    });
+
+    it('should call onRemove after confirmation click', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<MobileEquipmentRow {...defaultProps} />);
+      
+      const removeButton = screen.getByTitle('Remove from unit');
+      await user.click(removeButton);
+      
+      const confirmButton = screen.getByTitle('Confirm remove');
+      await user.click(confirmButton);
+      
+      expect(defaultProps.onRemove).toHaveBeenCalled();
+    });
+
+    it('should reset confirmation after timeout', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<MobileEquipmentRow {...defaultProps} />);
+      
+      const removeButton = screen.getByTitle('Remove from unit');
+      await user.click(removeButton);
+      
+      expect(screen.getByTitle('Confirm remove')).toBeInTheDocument();
+      
+      act(() => {
+        jest.advanceTimersByTime(3500);
+      });
+      
+      expect(screen.getByTitle('Remove from unit')).toBeInTheDocument();
+    });
+  });
+
+  describe('Unassign Button', () => {
+    it('should show unassign button for allocated equipment', () => {
+      const item = createItem({ isAllocated: true, location: 'Right Torso' });
+      render(<MobileEquipmentRow {...defaultProps} item={item} onUnassign={jest.fn()} />);
+      expect(screen.getByTitle('Unassign from slot')).toBeInTheDocument();
+    });
+
+    it('should require confirmation to unassign', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const onUnassign = jest.fn();
+      const item = createItem({ isAllocated: true, location: 'Right Torso' });
+      render(<MobileEquipmentRow {...defaultProps} item={item} onUnassign={onUnassign} />);
+      
+      const unassignButton = screen.getByTitle('Unassign from slot');
+      await user.click(unassignButton);
+      
+      expect(onUnassign).not.toHaveBeenCalled();
+      expect(screen.getByTitle('Confirm unassign')).toBeInTheDocument();
+    });
+
+    it('should call onUnassign after confirmation', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const onUnassign = jest.fn();
+      const item = createItem({ isAllocated: true, location: 'Right Torso' });
+      render(<MobileEquipmentRow {...defaultProps} item={item} onUnassign={onUnassign} />);
+      
+      const unassignButton = screen.getByTitle('Unassign from slot');
+      await user.click(unassignButton);
+      
+      const confirmButton = screen.getByTitle('Confirm unassign');
+      await user.click(confirmButton);
+      
+      expect(onUnassign).toHaveBeenCalled();
+    });
+  });
+
+  describe('Quick Assign', () => {
+    const availableLocations = [
+      { location: 'Right Torso', label: 'Right Torso', availableSlots: 5, canFit: true },
+      { location: 'Left Torso', label: 'Left Torso', availableSlots: 3, canFit: true },
+    ];
+
+    it('should show link button for unallocated equipment with available locations', () => {
+      render(
+        <MobileEquipmentRow
+          {...defaultProps}
+          onQuickAssign={jest.fn()}
+          availableLocations={availableLocations}
+        />
+      );
+      expect(screen.getByTitle('Assign to location')).toBeInTheDocument();
+    });
+
+    it('should show location dropdown when link button is clicked', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(
+        <MobileEquipmentRow
+          {...defaultProps}
+          onQuickAssign={jest.fn()}
+          availableLocations={availableLocations}
+          isLocationMenuOpen={true}
+          onToggleLocationMenu={jest.fn()}
+        />
+      );
+      
+      expect(screen.getByText('Assign to Location')).toBeInTheDocument();
+      expect(screen.getByText('Right Torso')).toBeInTheDocument();
+      expect(screen.getByText('Left Torso')).toBeInTheDocument();
+    });
+
+    it('should show available slots in dropdown', () => {
+      render(
+        <MobileEquipmentRow
+          {...defaultProps}
+          onQuickAssign={jest.fn()}
+          availableLocations={availableLocations}
+          isLocationMenuOpen={true}
+          onToggleLocationMenu={jest.fn()}
+        />
+      );
+      
+      expect(screen.getByText('5 free')).toBeInTheDocument();
+      expect(screen.getByText('3 free')).toBeInTheDocument();
+    });
+
+    it('should call onQuickAssign when location is selected', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const onQuickAssign = jest.fn();
+      const onToggleLocationMenu = jest.fn();
+      
+      render(
+        <MobileEquipmentRow
+          {...defaultProps}
+          onQuickAssign={onQuickAssign}
+          availableLocations={availableLocations}
+          isLocationMenuOpen={true}
+          onToggleLocationMenu={onToggleLocationMenu}
+        />
+      );
+      
+      const rtButton = screen.getByText('Right Torso').closest('button');
+      await user.click(rtButton!);
+      
+      expect(onQuickAssign).toHaveBeenCalledWith('Right Torso');
+    });
+  });
+
+  describe('Lock Icon', () => {
+    it('should show lock icon for non-removable equipment', () => {
+      const item = createItem({ isRemovable: false });
+      render(<MobileEquipmentRow {...defaultProps} item={item} />);
+      expect(screen.getByText('🔒')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/__tests__/components/customizer/mobile/MobileLoadoutHeader.test.tsx
+++ b/src/__tests__/components/customizer/mobile/MobileLoadoutHeader.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MobileLoadoutHeader, MobileLoadoutStats } from '@/components/customizer/mobile/MobileLoadoutHeader';
+
+describe('MobileLoadoutHeader', () => {
+  const createStats = (overrides?: Partial<MobileLoadoutStats>): MobileLoadoutStats => ({
+    weightUsed: 45,
+    weightMax: 75,
+    slotsUsed: 42,
+    slotsMax: 78,
+    heatGenerated: 15,
+    heatDissipation: 20,
+    battleValue: 1500,
+    equipmentCount: 12,
+    unassignedCount: 3,
+    ...overrides,
+  });
+
+  const defaultProps = {
+    stats: createStats(),
+    isExpanded: false,
+    onToggle: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Stats Display', () => {
+    it('should display weight stats', () => {
+      render(<MobileLoadoutHeader {...defaultProps} />);
+      expect(screen.getByText('45.0')).toBeInTheDocument();
+      expect(screen.getByText('75')).toBeInTheDocument();
+    });
+
+    it('should display slot stats', () => {
+      render(<MobileLoadoutHeader {...defaultProps} />);
+      expect(screen.getByText('42')).toBeInTheDocument();
+      expect(screen.getByText('78')).toBeInTheDocument();
+    });
+
+    it('should display heat stats', () => {
+      render(<MobileLoadoutHeader {...defaultProps} />);
+      expect(screen.getByText('15')).toBeInTheDocument();
+      expect(screen.getByText('20')).toBeInTheDocument();
+    });
+
+    it('should display battle value', () => {
+      render(<MobileLoadoutHeader {...defaultProps} />);
+      expect(screen.getByText('1,500')).toBeInTheDocument();
+    });
+  });
+
+  describe('Overage Indicators', () => {
+    it('should show red for weight overage', () => {
+      const stats = createStats({ weightUsed: 80, weightMax: 75 });
+      const { container } = render(<MobileLoadoutHeader {...defaultProps} stats={stats} />);
+      const weightValue = container.querySelector('.text-red-400');
+      expect(weightValue).toBeInTheDocument();
+    });
+
+    it('should show red for slot overage', () => {
+      const stats = createStats({ slotsUsed: 85, slotsMax: 78 });
+      const { container } = render(<MobileLoadoutHeader {...defaultProps} stats={stats} />);
+      const slotValue = container.querySelector('.text-red-400');
+      expect(slotValue).toBeInTheDocument();
+    });
+
+    it('should show red for heat overage', () => {
+      const stats = createStats({ heatGenerated: 25, heatDissipation: 20 });
+      const { container } = render(<MobileLoadoutHeader {...defaultProps} stats={stats} />);
+      const heatValue = container.querySelector('.text-red-400');
+      expect(heatValue).toBeInTheDocument();
+    });
+  });
+
+  describe('Equipment Count Badge', () => {
+    it('should show equipment count', () => {
+      render(<MobileLoadoutHeader {...defaultProps} />);
+      expect(screen.getByText('12')).toBeInTheDocument();
+    });
+
+    it('should show unassigned count if greater than zero', () => {
+      const stats = createStats({ unassignedCount: 5 });
+      render(<MobileLoadoutHeader {...defaultProps} stats={stats} />);
+      expect(screen.getByText('5 unassigned')).toBeInTheDocument();
+    });
+  });
+
+  describe('Toggle Behavior', () => {
+    it('should call onToggle when clicked', async () => {
+      const user = userEvent.setup();
+      render(<MobileLoadoutHeader {...defaultProps} />);
+      
+      const header = screen.getByRole('button');
+      await user.click(header);
+      
+      expect(defaultProps.onToggle).toHaveBeenCalled();
+    });
+
+    it('should show expand indicator', () => {
+      render(<MobileLoadoutHeader {...defaultProps} isExpanded={false} />);
+      expect(screen.getByText('▲')).toBeInTheDocument();
+    });
+
+    it('should rotate indicator when expanded', () => {
+      const { container } = render(<MobileLoadoutHeader {...defaultProps} isExpanded={true} />);
+      const indicator = container.querySelector('.rotate-180');
+      expect(indicator).toBeInTheDocument();
+    });
+  });
+
+  describe('Formatting', () => {
+    it('should format large battle values with commas', () => {
+      const stats = createStats({ battleValue: 12345 });
+      render(<MobileLoadoutHeader {...defaultProps} stats={stats} />);
+      expect(screen.getByText('12,345')).toBeInTheDocument();
+    });
+
+    it('should handle zero equipment count', () => {
+      const stats = createStats({ equipmentCount: 0 });
+      render(<MobileLoadoutHeader {...defaultProps} stats={stats} />);
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/__tests__/components/customizer/tabs/EquipmentTab.test.tsx
+++ b/src/__tests__/components/customizer/tabs/EquipmentTab.test.tsx
@@ -5,7 +5,6 @@ import { EquipmentTab } from '@/components/customizer/tabs/EquipmentTab';
 import { useUnitStore } from '@/stores/useUnitStore';
 import { EquipmentBrowserProps } from '@/components/customizer/equipment/EquipmentBrowser';
 
-// Mock EquipmentBrowser
 jest.mock('@/components/customizer/equipment/EquipmentBrowser', () => ({
   EquipmentBrowser: ({ onAddEquipment }: Pick<EquipmentBrowserProps, 'onAddEquipment'>) => (
     <div data-testid="equipment-browser">
@@ -16,20 +15,26 @@ jest.mock('@/components/customizer/equipment/EquipmentBrowser', () => ({
   ),
 }));
 
-// Mock useUnitStore
+jest.mock('@/components/customizer/equipment/EquippedSummary', () => ({
+  EquippedSummary: () => <div data-testid="equipped-summary" />,
+}));
+
 jest.mock('@/stores/useUnitStore', () => ({
   useUnitStore: jest.fn(),
 }));
 
 describe('EquipmentTab', () => {
   const mockAddEquipment = jest.fn();
+  const mockRemoveEquipment = jest.fn();
+  const mockEquipment: unknown[] = [];
 
   beforeEach(() => {
     jest.clearAllMocks();
     (useUnitStore as jest.Mock).mockImplementation((selector: (state: unknown) => unknown) => {
-      if (selector.toString().includes('addEquipment')) {
-        return mockAddEquipment;
-      }
+      const selectorStr = selector.toString();
+      if (selectorStr.includes('addEquipment')) return mockAddEquipment;
+      if (selectorStr.includes('removeEquipment')) return mockRemoveEquipment;
+      if (selectorStr.includes('equipment')) return mockEquipment;
       return undefined;
     });
   });

--- a/src/components/customizer/equipment/CompactFilterBar.tsx
+++ b/src/components/customizer/equipment/CompactFilterBar.tsx
@@ -1,0 +1,238 @@
+/**
+ * Compact Filter Bar - space-efficient unified filter bar
+ * @spec openspec/specs/equipment-browser/spec.md
+ */
+
+import React, { useState, useCallback } from 'react';
+import { EquipmentCategory } from '@/types/equipment';
+import { getCategoryColorsLegacy } from '@/utils/colors/equipmentColors';
+
+export interface CompactFilterBarProps {
+  activeCategories: Set<EquipmentCategory>;
+  showAll: boolean;
+  hidePrototype: boolean;
+  hideOneShot: boolean;
+  hideUnavailable: boolean;
+  hideAmmoWithoutWeapon: boolean;
+  search: string;
+  onSelectCategory: (category: EquipmentCategory, isMultiSelect: boolean) => void;
+  onShowAll: () => void;
+  onTogglePrototype: () => void;
+  onToggleOneShot: () => void;
+  onToggleUnavailable: () => void;
+  onToggleAmmoWithoutWeapon: () => void;
+  onSearchChange: (search: string) => void;
+  onClearFilters: () => void;
+  className?: string;
+}
+
+interface CategoryConfig {
+  category: EquipmentCategory;
+  label: string;
+  icon: string;
+}
+
+const CATEGORY_CONFIGS: CategoryConfig[] = [
+  { category: EquipmentCategory.ENERGY_WEAPON, label: 'Energy', icon: '⚡' },
+  { category: EquipmentCategory.BALLISTIC_WEAPON, label: 'Ballistic', icon: '🎯' },
+  { category: EquipmentCategory.MISSILE_WEAPON, label: 'Missile', icon: '🚀' },
+  { category: EquipmentCategory.ARTILLERY, label: 'Artillery', icon: '💥' },
+  { category: EquipmentCategory.PHYSICAL_WEAPON, label: 'Physical', icon: '🔨' },
+  { category: EquipmentCategory.AMMUNITION, label: 'Ammo', icon: '📦' },
+  { category: EquipmentCategory.MISC_EQUIPMENT, label: 'Other', icon: '⚙️' },
+];
+
+const OTHER_COMBINED_CATEGORIES: readonly EquipmentCategory[] = [
+  EquipmentCategory.MISC_EQUIPMENT,
+  EquipmentCategory.ELECTRONICS,
+];
+
+export function CompactFilterBar({
+  activeCategories,
+  showAll,
+  hidePrototype,
+  hideOneShot,
+  hideUnavailable,
+  hideAmmoWithoutWeapon,
+  search,
+  onSelectCategory,
+  onShowAll,
+  onTogglePrototype,
+  onToggleOneShot,
+  onToggleUnavailable,
+  onToggleAmmoWithoutWeapon,
+  onSearchChange,
+  onClearFilters,
+  className = '',
+}: CompactFilterBarProps): React.ReactElement {
+  const [hideFiltersExpanded, setHideFiltersExpanded] = useState(false);
+  
+  const activeHideCount = [hidePrototype, hideOneShot, hideUnavailable, hideAmmoWithoutWeapon].filter(Boolean).length;
+  const hasActiveFilters = search || !showAll || activeHideCount > 0;
+  
+  const handleCategoryClick = useCallback((category: EquipmentCategory, event: React.MouseEvent) => {
+    const isMultiSelect = event.ctrlKey || event.metaKey;
+    onSelectCategory(category, isMultiSelect);
+  }, [onSelectCategory]);
+  
+  return (
+    <div className={`space-y-1.5 ${className}`}>
+      <div className="flex items-center gap-1.5 flex-wrap">
+        <div className="flex items-center gap-0.5 flex-wrap">
+          {CATEGORY_CONFIGS.map(({ category, label, icon }) => {
+            const isActive = showAll || (
+              category === EquipmentCategory.MISC_EQUIPMENT
+                ? OTHER_COMBINED_CATEGORIES.some(cat => activeCategories.has(cat))
+                : activeCategories.has(category)
+            );
+            const colors = getCategoryColorsLegacy(category);
+            
+            return (
+              <button
+                key={category}
+                onClick={(e) => handleCategoryClick(category, e)}
+                className={`
+                  px-1.5 py-0.5 text-[10px] rounded transition-all
+                  flex items-center gap-0.5
+                  ${isActive
+                    ? `${colors.bg} ${colors.text} ring-1 ${colors.border} shadow-sm`
+                    : 'bg-surface-raised/60 text-text-theme-secondary hover:text-white hover:bg-surface-raised'
+                  }
+                `}
+                title={`${label} (Ctrl+click to multi-select)`}
+              >
+                <span className="text-[9px]">{icon}</span>
+                <span className="hidden sm:inline">{label}</span>
+              </button>
+            );
+          })}
+          
+          <button
+            onClick={onShowAll}
+            className={`
+              px-1.5 py-0.5 text-[10px] rounded transition-all
+              ${showAll
+                ? 'bg-accent text-white ring-1 ring-accent shadow-sm'
+                : 'bg-surface-raised/60 text-text-theme-secondary hover:text-white hover:bg-surface-raised'
+              }
+            `}
+            title="Show all categories"
+          >
+            All
+          </button>
+        </div>
+        
+        <div className="w-px h-4 bg-border-theme-subtle hidden sm:block" />
+        
+        <button
+          onClick={() => setHideFiltersExpanded(!hideFiltersExpanded)}
+          className={`
+            px-1.5 py-0.5 text-[10px] rounded transition-all flex items-center gap-1
+            ${activeHideCount > 0
+              ? 'bg-red-900/50 text-red-300 ring-1 ring-red-700'
+              : 'bg-surface-raised/60 text-text-theme-secondary hover:text-white hover:bg-surface-raised'
+            }
+          `}
+          title={hideFiltersExpanded ? 'Hide filter options' : 'Show filter options'}
+        >
+          <span>Hide</span>
+          {activeHideCount > 0 && (
+            <span className="bg-red-600 text-white text-[8px] rounded-full px-1 min-w-[14px] text-center">
+              {activeHideCount}
+            </span>
+          )}
+          <span className={`text-[8px] transition-transform ${hideFiltersExpanded ? 'rotate-180' : ''}`}>▼</span>
+        </button>
+        
+        <div className="flex-1 min-w-[60px]" />
+        
+        <div className="relative flex-shrink-0 w-32 sm:w-40">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Search..."
+            className="w-full px-2 py-1 text-[11px] bg-surface-raised border border-border-theme-subtle rounded text-white placeholder-text-theme-secondary focus:outline-none focus:ring-1 focus:ring-accent"
+          />
+          {search && (
+            <button
+              onClick={() => onSearchChange('')}
+              className="absolute right-1.5 top-1/2 -translate-y-1/2 text-text-theme-secondary hover:text-white text-[10px]"
+              title="Clear search"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+        
+        {hasActiveFilters && (
+          <button
+            onClick={onClearFilters}
+            className="px-1.5 py-0.5 text-[10px] bg-surface-raised/60 hover:bg-surface-raised text-text-theme-secondary hover:text-white rounded transition-colors"
+            title="Clear all filters"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+      
+      {hideFiltersExpanded && (
+        <div className="flex items-center gap-1 pl-1 animate-fadeIn">
+          <span className="text-[9px] text-text-theme-secondary mr-0.5">Hide:</span>
+          
+          <HideToggle
+            label="Proto"
+            fullLabel="Prototype"
+            isActive={hidePrototype}
+            onClick={onTogglePrototype}
+          />
+          <HideToggle
+            label="1-Shot"
+            fullLabel="One-Shot"
+            isActive={hideOneShot}
+            onClick={onToggleOneShot}
+          />
+          <HideToggle
+            label="No Wpn"
+            fullLabel="Ammo without Weapon"
+            isActive={hideAmmoWithoutWeapon}
+            onClick={onToggleAmmoWithoutWeapon}
+          />
+          <HideToggle
+            label="Unavail"
+            fullLabel="Unavailable (tech/era)"
+            isActive={hideUnavailable}
+            onClick={onToggleUnavailable}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface HideToggleProps {
+  label: string;
+  fullLabel: string;
+  isActive: boolean;
+  onClick: () => void;
+}
+
+function HideToggle({ label, fullLabel, isActive, onClick }: HideToggleProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`
+        px-1.5 py-0.5 text-[10px] rounded transition-colors
+        ${isActive
+          ? 'bg-red-900/50 text-red-300 ring-1 ring-red-700'
+          : 'bg-surface-raised/60 text-text-theme-secondary hover:text-white hover:bg-surface-raised'
+        }
+      `}
+      title={`${isActive ? 'Show' : 'Hide'} ${fullLabel.toLowerCase()}`}
+    >
+      {label}
+    </button>
+  );
+}
+
+export default CompactFilterBar;

--- a/src/components/customizer/equipment/EquipmentBrowser.tsx
+++ b/src/components/customizer/equipment/EquipmentBrowser.tsx
@@ -1,19 +1,15 @@
 /**
- * Equipment Browser Component
- * 
- * Searchable, filterable equipment catalog with toggle button filters.
- * 
+ * Equipment Browser - searchable, filterable equipment catalog
  * @spec openspec/specs/equipment-browser/spec.md
  * @spec openspec/changes/unify-equipment-tab/specs/equipment-browser/spec.md
  */
 
 import React from 'react';
 import { EquipmentRow } from './EquipmentRow';
-import { CategoryToggleBar, HideToggleBar } from './CategoryToggleBar';
+import { CompactFilterBar } from './CompactFilterBar';
 import { useEquipmentBrowser } from '@/hooks/useEquipmentBrowser';
 import { SortColumn } from '@/stores/useEquipmentStore';
 import { IEquipmentItem } from '@/types/equipment';
-import { PaginationButtons } from '@/components/ui/Button';
 
 export interface EquipmentBrowserProps {
   /** Called when equipment is added to unit */
@@ -79,80 +75,43 @@ export function EquipmentBrowser({
   
   return (
     <div className={`bg-surface-base rounded-lg border border-border-theme-subtle flex flex-col ${className}`}>
-      {/* Header */}
-      <div className="px-4 py-3 border-b border-border-theme-subtle">
-        <h3 className="text-lg font-semibold text-white">Equipment Database</h3>
+      <div className="px-3 py-2 border-b border-border-theme-subtle flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-white">Equipment Database</h3>
+        <span className="text-[10px] text-text-theme-secondary">{totalItems} items</span>
       </div>
 
-      {/* Toggle Filters */}
-      <div className="px-4 py-2 space-y-2 border-b border-border-theme-subtle bg-surface-base/50">
-        {/* Category toggles */}
-        <CategoryToggleBar
+      <div className="px-3 py-2 border-b border-border-theme-subtle bg-surface-base/50">
+        <CompactFilterBar
           activeCategories={activeCategories}
-          onSelectCategory={selectCategory}
-          onShowAll={showAll}
           showAll={showAllCategories}
-        />
-        
-        {/* Hide toggles */}
-        <HideToggleBar
           hidePrototype={hidePrototype}
           hideOneShot={hideOneShot}
           hideUnavailable={hideUnavailable}
           hideAmmoWithoutWeapon={hideAmmoWithoutWeapon}
+          search={search}
+          onSelectCategory={selectCategory}
+          onShowAll={showAll}
           onTogglePrototype={toggleHidePrototype}
           onToggleOneShot={toggleHideOneShot}
           onToggleUnavailable={toggleHideUnavailable}
           onToggleAmmoWithoutWeapon={toggleHideAmmoWithoutWeapon}
+          onSearchChange={setSearch}
+          onClearFilters={clearFilters}
         />
         
-        {/* Unit context info - shows when filtering by availability */}
         {hideUnavailable && (unitYear || unitTechBase) && (
-          <div className="flex items-center gap-2 text-xs text-text-theme-secondary px-1">
+          <div className="flex items-center gap-2 text-[10px] text-text-theme-secondary mt-1.5">
             <span className="text-slate-500">Filtering:</span>
             {unitYear && (
-              <span className="bg-surface-raised px-2 py-0.5 rounded">Year ≤ {unitYear}</span>
+              <span className="bg-surface-raised px-1.5 py-0.5 rounded">Year ≤ {unitYear}</span>
             )}
             {unitTechBase && (
-              <span className="bg-surface-raised px-2 py-0.5 rounded">{unitTechBase}</span>
+              <span className="bg-surface-raised px-1.5 py-0.5 rounded">{unitTechBase}</span>
             )}
           </div>
         )}
-        
-        {/* Text filter */}
-        <div className="flex items-center gap-2">
-          <span className="hidden sm:inline text-xs text-text-theme-secondary">Filter:</span>
-          <div className="flex-1 relative">
-            <input
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search equipment..."
-              inputMode="search"
-              className="w-full px-3 py-2 sm:py-1.5 text-sm bg-surface-raised border border-border-theme rounded text-white placeholder-text-theme-secondary focus:outline-none focus:ring-1 focus:ring-accent"
-            />
-            {search && (
-              <button
-                onClick={() => setSearch('')}
-                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-text-theme-secondary hover:text-white"
-                title="Clear search"
-              >
-                ✕
-              </button>
-            )}
-          </div>
-          {(search || !showAllCategories || hidePrototype || hideOneShot || hideAmmoWithoutWeapon) && (
-            <button
-              onClick={clearFilters}
-              className="px-3 py-2 sm:px-2 sm:py-1 text-xs bg-surface-raised hover:bg-surface-raised/80 text-text-theme-secondary rounded transition-colors whitespace-nowrap"
-            >
-              Clear
-            </button>
-          )}
-        </div>
       </div>
       
-      {/* Table */}
       <div className="flex-1 overflow-auto">
         {isLoading ? (
           <div className="p-8 text-center">
@@ -161,7 +120,7 @@ export function EquipmentBrowser({
         ) : (
           <table className="w-full">
             <thead className="sticky top-0 bg-surface-base">
-              <tr className="text-left text-xs text-text-theme-secondary uppercase border-b border-border-theme-subtle">
+              <tr className="text-left text-[10px] text-text-theme-secondary uppercase border-b border-border-theme-subtle">
                 <SortableHeader
                   label="Name"
                   column="name"
@@ -169,9 +128,9 @@ export function EquipmentBrowser({
                   direction={sortDirection}
                   onSort={setSort}
                 />
-                <th className="hidden sm:table-cell px-2 py-2">Dmg</th>
-                <th className="hidden sm:table-cell px-2 py-2">Heat</th>
-                <th className="hidden md:table-cell px-2 py-2">Range</th>
+                <th className="hidden sm:table-cell px-1 py-1">Dmg</th>
+                <th className="hidden sm:table-cell px-1 py-1">Heat</th>
+                <th className="hidden md:table-cell px-1 py-1">Range</th>
                 <SortableHeader
                   label="Wt"
                   column="weight"
@@ -186,7 +145,7 @@ export function EquipmentBrowser({
                   direction={sortDirection}
                   onSort={setSort}
                 />
-                <th className="px-2 py-2 w-14 sm:w-16">Action</th>
+                <th className="px-1 py-1 w-10 sm:w-12"></th>
               </tr>
             </thead>
             <tbody>
@@ -211,16 +170,40 @@ export function EquipmentBrowser({
         )}
       </div>
       
-      {/* Pagination */}
-      <div className="px-4 py-2 border-t border-border-theme-subtle flex items-center justify-between">
-        <div className="text-xs text-text-theme-secondary">
-          {paginatedEquipment.length} of {totalItems}
+      <div className="px-3 py-1.5 border-t border-border-theme-subtle flex items-center justify-between">
+        <div className="text-[10px] text-text-theme-secondary">
+          Page {currentPage}/{totalPages}
         </div>
-        <PaginationButtons
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={setPage}
-        />
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => setPage(1)}
+            disabled={currentPage === 1}
+            className="px-1.5 py-0.5 text-[10px] bg-surface-raised hover:bg-surface-raised/80 text-text-theme-secondary disabled:opacity-40 rounded transition-colors"
+          >
+            ««
+          </button>
+          <button
+            onClick={() => setPage(Math.max(1, currentPage - 1))}
+            disabled={currentPage === 1}
+            className="px-1.5 py-0.5 text-[10px] bg-surface-raised hover:bg-surface-raised/80 text-text-theme-secondary disabled:opacity-40 rounded transition-colors"
+          >
+            ‹
+          </button>
+          <button
+            onClick={() => setPage(Math.min(totalPages, currentPage + 1))}
+            disabled={currentPage === totalPages}
+            className="px-1.5 py-0.5 text-[10px] bg-surface-raised hover:bg-surface-raised/80 text-text-theme-secondary disabled:opacity-40 rounded transition-colors"
+          >
+            ›
+          </button>
+          <button
+            onClick={() => setPage(totalPages)}
+            disabled={currentPage === totalPages}
+            className="px-1.5 py-0.5 text-[10px] bg-surface-raised hover:bg-surface-raised/80 text-text-theme-secondary disabled:opacity-40 rounded transition-colors"
+          >
+            »»
+          </button>
+        </div>
       </div>
     </div>
   );
@@ -248,13 +231,13 @@ function SortableHeader({
   
   return (
     <th
-      className="px-2 py-2 cursor-pointer hover:text-white transition-colors"
+      className="px-1.5 py-1 cursor-pointer hover:text-white transition-colors"
       onClick={() => onSort(column)}
     >
-      <span className="flex items-center gap-1">
+      <span className="flex items-center gap-0.5">
         {label}
         {isActive && (
-          <span className="text-accent text-[10px]">
+          <span className="text-accent text-[8px]">
             {direction === 'asc' ? '▲' : '▼'}
           </span>
         )}

--- a/src/components/customizer/equipment/EquipmentRow.tsx
+++ b/src/components/customizer/equipment/EquipmentRow.tsx
@@ -106,52 +106,38 @@ export const EquipmentRow = memo(function EquipmentRow({
   const colors = getCategoryColorsLegacy(equipment.category);
   
   if (compact) {
-    // Compact layout - fewer columns, MekLab-style, touch-friendly on mobile
     return (
-      <tr className="border-t border-border-theme-subtle/30 hover:bg-surface-raised/30 transition-colors text-xs">
-        {/* Name with category color indicator */}
-        <td className="px-2 py-2 sm:py-1.5">
-          <div className="flex items-center gap-1.5">
-            <span className={`w-1.5 h-1.5 rounded-sm flex-shrink-0 ${colors.bg}`} />
+      <tr className="border-t border-border-theme-subtle/20 hover:bg-surface-raised/30 transition-colors text-[11px]">
+        <td className="px-1.5 py-0.5">
+          <div className="flex items-center gap-1">
+            <span className={`w-1 h-1 rounded-sm flex-shrink-0 ${colors.bg}`} />
             <span className="text-white truncate" title={equipment.name}>
               {equipment.name}
             </span>
           </div>
         </td>
-
-        {/* Damage - hidden on small screens */}
-        <td className="hidden sm:table-cell px-2 py-2 sm:py-1.5 text-slate-300 text-center">
+        <td className="hidden sm:table-cell px-1 py-0.5 text-slate-300 text-center">
           {formatDamage(equipment)}
         </td>
-
-        {/* Heat - hidden on small screens */}
-        <td className="hidden sm:table-cell px-2 py-2 sm:py-1.5 text-slate-300 text-center">
+        <td className="hidden sm:table-cell px-1 py-0.5 text-slate-300 text-center">
           {formatHeat(equipment)}
         </td>
-
-        {/* Range - hidden on medium screens and below */}
-        <td className="hidden md:table-cell px-2 py-2 sm:py-1.5 text-text-theme-secondary text-center">
+        <td className="hidden md:table-cell px-1 py-0.5 text-text-theme-secondary text-center">
           {formatRange(equipment)}
         </td>
-
-        {/* Weight */}
-        <td className="px-2 py-2 sm:py-1.5 text-slate-300 text-right">
+        <td className="px-1 py-0.5 text-slate-300 text-right tabular-nums">
           {equipment.weight}
         </td>
-
-        {/* Critical Slots */}
-        <td className="px-2 py-2 sm:py-1.5 text-slate-300 text-center">
+        <td className="px-1 py-0.5 text-slate-300 text-center tabular-nums">
           {equipment.criticalSlots}
         </td>
-
-        {/* Add button - larger touch target on mobile */}
-        <td className="px-2 py-2 sm:py-1.5">
+        <td className="px-1 py-0.5">
           <button
             onClick={onAdd}
-            className="w-full px-2 py-1.5 sm:px-1.5 sm:py-0.5 text-xs sm:text-[10px] bg-accent hover:bg-accent/80 text-white rounded transition-colors min-h-[32px] sm:min-h-0"
+            className="w-full px-1 py-0 text-[10px] bg-accent hover:bg-accent/80 text-white rounded transition-colors"
             title={`Add ${equipment.name}`}
           >
-            Add
+            +
           </button>
         </td>
       </tr>

--- a/src/components/customizer/equipment/EquippedSummary.tsx
+++ b/src/components/customizer/equipment/EquippedSummary.tsx
@@ -1,0 +1,186 @@
+/**
+ * Equipped Summary - compact view of currently equipped items
+ * @spec openspec/specs/equipment-browser/spec.md
+ */
+
+import React, { useState, useMemo, useCallback } from 'react';
+import { EquipmentCategory } from '@/types/equipment';
+import { getCategoryColorsLegacy } from '@/utils/colors/equipmentColors';
+import type { LoadoutEquipmentItem } from './GlobalLoadoutTray';
+
+export interface EquippedSummaryProps {
+  equipment: LoadoutEquipmentItem[];
+  onRemoveEquipment: (instanceId: string) => void;
+  onSelectEquipment?: (instanceId: string | null) => void;
+  selectedEquipmentId?: string | null;
+  className?: string;
+}
+
+interface EquipmentGroup {
+  name: string;
+  category: EquipmentCategory;
+  items: LoadoutEquipmentItem[];
+  totalWeight: number;
+  totalSlots: number;
+}
+
+const CATEGORY_ORDER: EquipmentCategory[] = [
+  EquipmentCategory.ENERGY_WEAPON,
+  EquipmentCategory.BALLISTIC_WEAPON,
+  EquipmentCategory.MISSILE_WEAPON,
+  EquipmentCategory.ARTILLERY,
+  EquipmentCategory.AMMUNITION,
+  EquipmentCategory.ELECTRONICS,
+  EquipmentCategory.PHYSICAL_WEAPON,
+  EquipmentCategory.MOVEMENT,
+  EquipmentCategory.STRUCTURAL,
+  EquipmentCategory.MISC_EQUIPMENT,
+];
+
+function groupEquipmentByName(equipment: LoadoutEquipmentItem[]): EquipmentGroup[] {
+  const groupMap = new Map<string, EquipmentGroup>();
+  
+  for (const item of equipment) {
+    const key = `${item.name}-${item.category}`;
+    const existing = groupMap.get(key);
+    
+    if (existing) {
+      existing.items.push(item);
+      existing.totalWeight += item.weight;
+      existing.totalSlots += item.criticalSlots;
+    } else {
+      groupMap.set(key, {
+        name: item.name,
+        category: item.category,
+        items: [item],
+        totalWeight: item.weight,
+        totalSlots: item.criticalSlots,
+      });
+    }
+  }
+  
+  return Array.from(groupMap.values()).sort((a, b) => {
+    const aIdx = CATEGORY_ORDER.indexOf(a.category);
+    const bIdx = CATEGORY_ORDER.indexOf(b.category);
+    if (aIdx !== bIdx) return aIdx - bIdx;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+export function EquippedSummary({
+  equipment,
+  onRemoveEquipment,
+  onSelectEquipment,
+  selectedEquipmentId,
+  className = '',
+}: EquippedSummaryProps): React.ReactElement {
+  const [isExpanded, setIsExpanded] = useState(true);
+  
+  const userEquipment = useMemo(() => equipment.filter(e => e.isRemovable), [equipment]);
+  
+  const groupedEquipment = useMemo(() => groupEquipmentByName(userEquipment), [userEquipment]);
+  
+  const totals = useMemo(() => {
+    let weight = 0;
+    let slots = 0;
+    for (const item of userEquipment) {
+      weight += item.weight;
+      slots += item.criticalSlots;
+    }
+    return { weight, slots, count: userEquipment.length };
+  }, [userEquipment]);
+  
+  const handleRemoveOne = useCallback((group: EquipmentGroup) => {
+    if (group.items.length > 0) {
+      onRemoveEquipment(group.items[0].instanceId);
+    }
+  }, [onRemoveEquipment]);
+  
+  const handleSelectGroup = useCallback((group: EquipmentGroup) => {
+    const firstUnallocated = group.items.find(item => !item.isAllocated);
+    if (firstUnallocated && onSelectEquipment) {
+      onSelectEquipment(
+        selectedEquipmentId === firstUnallocated.instanceId ? null : firstUnallocated.instanceId
+      );
+    }
+  }, [onSelectEquipment, selectedEquipmentId]);
+  
+  if (userEquipment.length === 0) {
+    return <></>;
+  }
+  
+  return (
+    <div className={`bg-surface-base/30 rounded-lg border border-border-theme-subtle overflow-hidden ${className}`}>
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full px-3 py-1.5 flex items-center justify-between hover:bg-surface-raised/30 transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          <span className={`text-[10px] text-text-theme-secondary transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
+            ▼
+          </span>
+          <span className="text-xs font-medium text-white">Equipped</span>
+          <span className="text-[10px] text-accent bg-accent/20 px-1.5 rounded">
+            {totals.count}
+          </span>
+        </div>
+        <div className="flex items-center gap-3 text-[10px] text-text-theme-secondary">
+          <span>{totals.weight}t</span>
+          <span>{totals.slots} slots</span>
+        </div>
+      </button>
+      
+      {isExpanded && (
+        <div className="px-2 pb-2 pt-1">
+          <div className="flex flex-wrap gap-1">
+            {groupedEquipment.map((group) => {
+              const colors = getCategoryColorsLegacy(group.category);
+              const hasUnallocated = group.items.some(item => !item.isAllocated);
+              const isSelected = group.items.some(item => item.instanceId === selectedEquipmentId);
+              
+              return (
+                <div
+                  key={`${group.name}-${group.category}`}
+                  className={`
+                    group relative flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px]
+                    ${colors.bg} ${colors.text} border ${colors.border}
+                    ${hasUnallocated ? 'cursor-pointer hover:brightness-110' : ''}
+                    ${isSelected ? 'ring-1 ring-white ring-offset-1 ring-offset-surface-base' : ''}
+                    transition-all
+                  `}
+                  onClick={() => hasUnallocated && handleSelectGroup(group)}
+                  title={hasUnallocated ? 'Click to select for placement' : `${group.name} - all allocated`}
+                >
+                  <span className="truncate max-w-[120px]">{group.name}</span>
+                  
+                  {group.items.length > 1 && (
+                    <span className="opacity-70">×{group.items.length}</span>
+                  )}
+                  
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRemoveOne(group);
+                    }}
+                    className="opacity-0 group-hover:opacity-100 ml-0.5 text-[8px] hover:text-red-300 transition-opacity"
+                    title={`Remove one ${group.name}`}
+                  >
+                    ✕
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+          
+          {groupedEquipment.length === 0 && (
+            <div className="text-[10px] text-text-theme-secondary text-center py-2">
+              No equipment added yet
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default EquippedSummary;

--- a/src/components/customizer/equipment/GlobalLoadoutTray.tsx
+++ b/src/components/customizer/equipment/GlobalLoadoutTray.tsx
@@ -24,15 +24,26 @@ import { MechLocation } from '@/types/construction';
 
 export interface LoadoutEquipmentItem {
   instanceId: string;
+  equipmentId: string;
   name: string;
   category: EquipmentCategory;
   weight: number;
   criticalSlots: number;
+  heat?: number;
+  damage?: number | string;
+  ranges?: {
+    minimum: number;
+    short: number;
+    medium: number;
+    long: number;
+  };
   isAllocated: boolean;
   location?: string;
   isRemovable: boolean;
   /** Whether this is pod-mounted equipment on an OmniMech (false = fixed) */
   isOmniPodMounted?: boolean;
+  /** Whether this weapon is compatible with a Targeting Computer */
+  targetingComputerCompatible?: boolean;
 }
 
 /** Location with available slot info for context menu */

--- a/src/components/customizer/equipment/ResponsiveLoadoutTray.tsx
+++ b/src/components/customizer/equipment/ResponsiveLoadoutTray.tsx
@@ -22,6 +22,7 @@ import React from 'react';
 import { GlobalLoadoutTray, LoadoutEquipmentItem, AvailableLocation } from './GlobalLoadoutTray';
 import { BottomSheetTray } from './BottomSheetTray';
 import { MechLocation } from '@/types/construction';
+import type { MobileLoadoutStats } from '../mobile';
 
 // =============================================================================
 // Types
@@ -50,8 +51,12 @@ export interface ResponsiveLoadoutTrayProps {
   onQuickAssign?: (instanceId: string, location: MechLocation) => void;
   /** Available locations with slot info for context menu */
   availableLocations?: AvailableLocation[];
+  /** Function to get available locations for any equipment item */
+  getAvailableLocationsForEquipment?: (instanceId: string) => AvailableLocation[];
   /** Whether this is an OmniMech */
   isOmni?: boolean;
+  /** Unit stats for mobile status bar */
+  mobileStats?: MobileLoadoutStats;
 }
 
 // =============================================================================
@@ -79,7 +84,9 @@ export function ResponsiveLoadoutTray({
   onUnassignEquipment,
   onQuickAssign,
   availableLocations = [],
+  getAvailableLocationsForEquipment,
   isOmni = false,
+  mobileStats,
 }: ResponsiveLoadoutTrayProps): React.ReactElement {
   // No auto-collapse behavior - state is persisted and only changed by user interaction
   
@@ -115,7 +122,9 @@ export function ResponsiveLoadoutTray({
           onUnassignEquipment={onUnassignEquipment}
           onQuickAssign={onQuickAssign}
           availableLocations={availableLocations}
+          getAvailableLocationsForEquipment={getAvailableLocationsForEquipment}
           isOmni={isOmni}
+          stats={mobileStats}
         />
       </div>
     </>

--- a/src/components/customizer/mobile/MobileEquipmentRow.tsx
+++ b/src/components/customizer/mobile/MobileEquipmentRow.tsx
@@ -1,0 +1,324 @@
+/**
+ * Mobile Equipment Row Component
+ * 
+ * Compact list row for displaying equipment items in the mobile loadout view.
+ * Shows Name, Location, Heat, Crits, Weight with edit/remove actions.
+ * Touch-friendly with 44px minimum height for accessibility.
+ * 
+ * @spec c:\Users\wroll\.cursor\plans\mobile_loadout_full-screen_redesign_00a59d27.plan.md
+ */
+
+import React, { useState } from 'react';
+import { EquipmentCategory } from '@/types/equipment';
+import { getCategoryColorsLegacy } from '@/utils/colors/equipmentColors';
+import { MechLocation } from '@/types/construction';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface MobileEquipmentItem {
+  instanceId: string;
+  name: string;
+  category: EquipmentCategory;
+  weight: number;
+  criticalSlots: number;
+  heat?: number;
+  damage?: number | string;
+  ranges?: {
+    minimum: number;
+    short: number;
+    medium: number;
+    long: number;
+  };
+  isAllocated: boolean;
+  location?: string;
+  isRemovable: boolean;
+  isOmniPodMounted?: boolean;
+  /** Whether this weapon is compatible with a Targeting Computer */
+  targetingComputerCompatible?: boolean;
+}
+
+/** Available location for quick assignment */
+export interface AvailableLocationOption {
+  location: string;
+  label: string;
+  availableSlots: number;
+  canFit: boolean;
+}
+
+interface MobileEquipmentRowProps {
+  item: MobileEquipmentItem;
+  isSelected?: boolean;
+  isOmni?: boolean;
+  onSelect?: () => void;
+  onRemove?: () => void;
+  onEditLocation?: () => void;
+  onUnassign?: () => void;
+  /** Quick assign to a location (for unassigned items) */
+  onQuickAssign?: (location: string) => void;
+  /** Available locations for quick assignment */
+  availableLocations?: AvailableLocationOption[];
+  /** Whether this item's location menu is open (controlled externally) */
+  isLocationMenuOpen?: boolean;
+  /** Callback to toggle this item's location menu */
+  onToggleLocationMenu?: () => void;
+  showActions?: boolean;
+  className?: string;
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/** Convert location names to shorthand (e.g., "Right Torso" -> "RT") */
+function getLocationShorthand(location: string): string {
+  const shortcuts: Record<string, string> = {
+    'Head': 'HD',
+    'Center Torso': 'CT',
+    'Left Torso': 'LT',
+    'Right Torso': 'RT',
+    'Left Arm': 'LA',
+    'Right Arm': 'RA',
+    'Left Leg': 'LL',
+    'Right Leg': 'RL',
+  };
+  return shortcuts[location] || location;
+}
+
+/** Format range brackets like "0/3/6/9" or "-/3/6/9" for min range */
+function formatRangeBrackets(ranges: { minimum: number; short: number; medium: number; long: number }): string {
+  const min = ranges.minimum > 0 ? ranges.minimum : 0;
+  return `${min}/${ranges.short}/${ranges.medium}/${ranges.long}`;
+}
+
+/** Get range band description based on short range */
+function getRangeBand(ranges: { short: number; medium: number }): string {
+  // Rough heuristics based on typical BattleTech weapon ranges
+  if (ranges.short <= 2) return 'PD'; // Point Defense (very short range)
+  if (ranges.short <= 4) return 'Short';
+  if (ranges.short <= 7) return 'Medium';
+  if (ranges.short <= 12) return 'Long';
+  return 'Extreme';
+}
+
+// =============================================================================
+// Main Component
+// =============================================================================
+
+export function MobileEquipmentRow({
+  item,
+  isSelected = false,
+  isOmni = false,
+  onSelect,
+  onRemove,
+  onEditLocation,
+  onUnassign,
+  onQuickAssign,
+  availableLocations = [],
+  isLocationMenuOpen = false,
+  onToggleLocationMenu,
+  showActions = true,
+  className = '',
+}: MobileEquipmentRowProps): React.ReactElement {
+  const [showConfirmRemove, setShowConfirmRemove] = useState(false);
+  const [showConfirmUnassign, setShowConfirmUnassign] = useState(false);
+  const colors = getCategoryColorsLegacy(item.category);
+  
+  // Check if this is fixed equipment on an OmniMech
+  const isFixedOnOmni = isOmni && item.isOmniPodMounted === false;
+  
+  const handleRemoveClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (showConfirmRemove) {
+      onRemove?.();
+      setShowConfirmRemove(false);
+    } else {
+      setShowConfirmRemove(true);
+      setShowConfirmUnassign(false); // Cancel unassign confirmation
+      // Auto-reset after 3 seconds
+      setTimeout(() => setShowConfirmRemove(false), 3000);
+    }
+  };
+  
+  const handleUnassignClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (showConfirmUnassign) {
+      onUnassign?.();
+      setShowConfirmUnassign(false);
+    } else {
+      setShowConfirmUnassign(true);
+      setShowConfirmRemove(false); // Cancel remove confirmation
+      // Auto-reset after 3 seconds
+      setTimeout(() => setShowConfirmUnassign(false), 3000);
+    }
+  };
+
+  return (
+    <div
+      onClick={onSelect}
+      className={`
+        min-h-[36px] px-2 py-1 flex items-center gap-1.5
+        border-b border-border-theme-subtle/30
+        ${onSelect ? 'cursor-pointer active:bg-surface-raised/50' : ''}
+        ${isSelected ? 'bg-accent/10 border-l-2 border-l-accent' : ''}
+        ${isFixedOnOmni ? 'opacity-60' : ''}
+        ${className}
+      `}
+    >
+      {/* Category indicator */}
+      <div className={`w-1 h-6 rounded-sm flex-shrink-0 ${colors.bg}`} />
+      
+      {/* Main content */}
+      <div className="flex-1 min-w-0">
+        {/* Single compact row with all info */}
+        <div className="flex items-center justify-between gap-1">
+          {/* Name and details */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-1">
+              <span className="text-xs text-white font-medium truncate">
+                {item.name}
+              </span>
+              {isOmni && (
+                <span className={`text-[8px] px-0.5 rounded flex-shrink-0 ${
+                  item.isOmniPodMounted 
+                    ? 'bg-accent/20 text-accent' 
+                    : 'bg-slate-700 text-slate-400'
+                }`}>
+                  {item.isOmniPodMounted ? 'P' : 'F'}
+                </span>
+              )}
+              {!item.isRemovable && (
+                <span className="text-[8px] text-slate-500 flex-shrink-0">🔒</span>
+              )}
+            </div>
+            {/* Weapon details inline */}
+            {(item.damage !== undefined || item.ranges) && (
+              <div className="flex items-center gap-1.5 text-[9px] text-text-theme-secondary/60 leading-none">
+                {item.damage !== undefined && (
+                  <span className="text-cyan-400/80">{item.damage}dmg</span>
+                )}
+                {item.ranges && (
+                  <span>{formatRangeBrackets(item.ranges)}</span>
+                )}
+                {item.targetingComputerCompatible && (
+                  <span className="text-green-400/70">TC</span>
+                )}
+              </div>
+            )}
+          </div>
+          
+          {/* Stats columns with separators - matching header widths */}
+          <div className="flex items-center text-[10px] text-text-theme-secondary flex-shrink-0 font-mono">
+            <span className={`w-[28px] text-center border-l border-border-theme-subtle/20 ${item.isAllocated ? 'text-green-400' : 'text-amber-400/70'}`}>
+              {item.isAllocated && item.location ? getLocationShorthand(item.location) : '—'}
+            </span>
+            <span className={`w-[20px] text-center border-l border-border-theme-subtle/20 ${item.heat && item.heat > 0 ? 'text-red-400' : 'text-slate-600'}`}>
+              {item.heat ?? 0}
+            </span>
+            <span className="w-[20px] text-center border-l border-border-theme-subtle/20">{item.criticalSlots}</span>
+            <span className="w-[28px] text-center border-l border-border-theme-subtle/20">{item.weight}</span>
+          </div>
+        </div>
+      </div>
+      
+      {/* Actions - fixed width columns with proper touch targets */}
+      {showActions && item.isRemovable && (
+        <div className="flex items-center flex-shrink-0 relative">
+          {/* Link/Unlink column - 36px for proper touch target */}
+          <div className="w-[36px] h-[36px] flex items-center justify-center border-l border-border-theme-subtle/20">
+            {item.isAllocated && onUnassign ? (
+              // Unlink button for allocated items
+              <button
+                onClick={handleUnassignClick}
+                className={`
+                  w-full h-full flex items-center justify-center transition-all active:scale-95 text-base
+                  ${showConfirmUnassign 
+                    ? 'text-amber-400 bg-amber-900/40' 
+                    : 'text-slate-400 hover:text-amber-400 hover:bg-amber-900/20'
+                  }
+                `}
+                title={showConfirmUnassign ? 'Confirm unassign' : 'Unassign from slot'}
+              >
+                {showConfirmUnassign ? '?' : '⛓️‍💥'}
+              </button>
+            ) : !item.isAllocated && onQuickAssign && availableLocations.length > 0 ? (
+              // Link button for unassigned items
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleLocationMenu?.();
+                }}
+                className={`
+                  w-full h-full flex items-center justify-center transition-all active:scale-95 text-base
+                  ${isLocationMenuOpen 
+                    ? 'text-green-400 bg-green-900/40' 
+                    : 'text-slate-400 hover:text-green-400 hover:bg-green-900/20'
+                  }
+                `}
+                title="Assign to location"
+              >
+                🔗
+              </button>
+            ) : null}
+          </div>
+          
+          {/* Remove column - 36px for proper touch target */}
+          <div className="w-[36px] h-[36px] flex items-center justify-center border-l border-border-theme-subtle/20">
+            {onRemove && (
+              <button
+                onClick={handleRemoveClick}
+                className={`
+                  w-full h-full flex items-center justify-center transition-all active:scale-95 text-lg font-medium
+                  ${showConfirmRemove 
+                    ? 'text-red-400 bg-red-900/40' 
+                    : 'text-slate-400 hover:text-red-400 hover:bg-red-900/20'
+                  }
+                `}
+                title={showConfirmRemove ? 'Confirm remove' : 'Remove from unit'}
+              >
+                {showConfirmRemove ? '?' : '×'}
+              </button>
+            )}
+          </div>
+          
+          {/* Location selection dropdown - wider grid layout */}
+          {isLocationMenuOpen && !item.isAllocated && (
+            <div 
+              className="absolute right-0 top-full mt-1 z-50 bg-surface-base border border-accent/40 rounded-lg shadow-xl py-2 px-2 min-w-[200px]"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="text-[10px] text-text-theme-secondary uppercase tracking-wide mb-2 px-1 font-medium">
+                Assign to Location
+              </div>
+              {availableLocations.filter(loc => loc.canFit).length > 0 ? (
+                <div className="grid grid-cols-2 gap-1">
+                  {availableLocations.filter(loc => loc.canFit).map((loc) => (
+                    <button
+                      key={loc.location}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onQuickAssign?.(loc.location);
+                        onToggleLocationMenu?.();
+                      }}
+                      className="px-2 py-2 text-left text-xs bg-surface-raised hover:bg-accent/20 hover:border-accent/50 border border-border-theme-subtle rounded transition-colors"
+                    >
+                      <div className="text-white font-medium text-[11px]">{loc.label}</div>
+                      <div className="text-[9px] text-green-400/80">{loc.availableSlots} free</div>
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <div className="px-2 py-3 text-xs text-amber-400/80 text-center bg-amber-900/10 rounded">
+                  No locations with enough slots
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MobileEquipmentRow;

--- a/src/components/customizer/mobile/MobileLoadoutHeader.tsx
+++ b/src/components/customizer/mobile/MobileLoadoutHeader.tsx
@@ -1,0 +1,187 @@
+/**
+ * Mobile Loadout Header Component
+ * 
+ * Compact always-visible status bar for mobile devices showing key unit stats.
+ * Displays Weight, Slots, Heat, and BV with color-coded status indicators.
+ * Tapping expands to full-screen equipment list.
+ * 
+ * @spec c:\Users\wroll\.cursor\plans\mobile_loadout_full-screen_redesign_00a59d27.plan.md
+ */
+
+import React from 'react';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface MobileLoadoutStats {
+  /** Weight used in tons */
+  weightUsed: number;
+  /** Maximum weight (tonnage) */
+  weightMax: number;
+  /** Critical slots used */
+  slotsUsed: number;
+  /** Total critical slots */
+  slotsMax: number;
+  /** Heat generated */
+  heatGenerated: number;
+  /** Heat dissipation */
+  heatDissipation: number;
+  /** Battle Value */
+  battleValue: number;
+  /** Total equipment count */
+  equipmentCount: number;
+  /** Unassigned equipment count */
+  unassignedCount: number;
+}
+
+interface MobileLoadoutHeaderProps {
+  stats: MobileLoadoutStats;
+  isExpanded: boolean;
+  onToggle: () => void;
+  className?: string;
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+type StatusLevel = 'normal' | 'warning' | 'error';
+
+function getWeightStatus(used: number, max: number): StatusLevel {
+  if (used > max) return 'error';
+  if (max - used < 0.5) return 'warning';
+  return 'normal';
+}
+
+function getSlotsStatus(used: number, max: number): StatusLevel {
+  if (used > max) return 'error';
+  return 'normal';
+}
+
+function getHeatStatus(generated: number, dissipation: number): StatusLevel {
+  if (generated > dissipation) return 'error';
+  if (generated === dissipation) return 'warning';
+  return 'normal';
+}
+
+const statusColors: Record<StatusLevel, string> = {
+  normal: 'text-white',
+  warning: 'text-amber-400',
+  error: 'text-red-400',
+};
+
+// =============================================================================
+// Stat Display Component
+// =============================================================================
+
+interface StatDisplayProps {
+  label: string;
+  value: string | number;
+  max?: string | number;
+  status?: StatusLevel;
+}
+
+function StatDisplay({ label, value, max, status = 'normal' }: StatDisplayProps) {
+  return (
+    <div className="flex flex-col items-center px-1.5 min-w-0">
+      <span className="text-[8px] text-text-theme-secondary uppercase tracking-wider truncate">
+        {label}
+      </span>
+      <div className="flex items-baseline gap-0.5">
+        <span className={`text-xs font-bold ${statusColors[status]}`}>
+          {value}
+        </span>
+        {max !== undefined && (
+          <>
+            <span className="text-[9px] text-slate-500">/</span>
+            <span className="text-[9px] text-slate-500">{max}</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Main Component
+// =============================================================================
+
+export function MobileLoadoutHeader({
+  stats,
+  isExpanded,
+  onToggle,
+  className = '',
+}: MobileLoadoutHeaderProps): React.ReactElement {
+  const weightStatus = getWeightStatus(stats.weightUsed, stats.weightMax);
+  const slotsStatus = getSlotsStatus(stats.slotsUsed, stats.slotsMax);
+  const heatStatus = getHeatStatus(stats.heatGenerated, stats.heatDissipation);
+
+  return (
+    <button
+      onClick={onToggle}
+      className={`
+        w-full h-11 px-2 flex items-center justify-between
+        bg-surface-base border-t border-border-theme
+        active:bg-surface-raised/50 transition-colors
+        ${className}
+      `}
+      aria-expanded={isExpanded}
+      aria-label={isExpanded ? 'Collapse loadout' : 'Expand loadout'}
+    >
+      {/* Stats row */}
+      <div className="flex items-center gap-1 flex-1 min-w-0 overflow-hidden">
+        <StatDisplay
+          label="Weight"
+          value={stats.weightUsed.toFixed(1)}
+          max={stats.weightMax}
+          status={weightStatus}
+        />
+        
+        <div className="w-px h-5 bg-border-theme-subtle flex-shrink-0" />
+        
+        <StatDisplay
+          label="Slots"
+          value={stats.slotsUsed}
+          max={stats.slotsMax}
+          status={slotsStatus}
+        />
+        
+        <div className="w-px h-5 bg-border-theme-subtle flex-shrink-0" />
+        
+        <StatDisplay
+          label="Heat"
+          value={stats.heatGenerated}
+          max={stats.heatDissipation}
+          status={heatStatus}
+        />
+        
+        <div className="w-px h-5 bg-border-theme-subtle flex-shrink-0" />
+        
+        <StatDisplay
+          label="BV"
+          value={stats.battleValue.toLocaleString()}
+        />
+      </div>
+
+      {/* Expand indicator with equipment count */}
+      <div className="flex items-center gap-1.5 flex-shrink-0 ml-2">
+        {stats.unassignedCount > 0 && (
+          <span className="text-[9px] text-amber-400 font-medium">
+            {stats.unassignedCount} unassigned
+          </span>
+        )}
+        <div className="flex items-center gap-1 bg-accent/20 rounded-full px-2 py-0.5">
+          <span className="text-xs font-bold text-accent">
+            {stats.equipmentCount}
+          </span>
+          <span className={`text-[10px] text-accent transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
+            ▲
+          </span>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+export default MobileLoadoutHeader;

--- a/src/components/customizer/mobile/MobileLoadoutList.tsx
+++ b/src/components/customizer/mobile/MobileLoadoutList.tsx
@@ -1,0 +1,442 @@
+/**
+ * Mobile Loadout List Component
+ * 
+ * Full-screen scrollable equipment list for mobile devices.
+ * Features category filter tabs, separate unassigned/allocated sections,
+ * and only shows removable equipment items.
+ * 
+ * @spec c:\Users\wroll\.cursor\plans\mobile_loadout_full-screen_redesign_00a59d27.plan.md
+ */
+
+import React, { useState, useMemo, useCallback } from 'react';
+import { EquipmentCategory } from '@/types/equipment';
+import { MechLocation } from '@/types/construction';
+import { getCategoryColorsLegacy } from '@/utils/colors/equipmentColors';
+import { MobileEquipmentRow, MobileEquipmentItem } from './MobileEquipmentRow';
+import { MobileLoadoutStats } from './MobileLoadoutHeader';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Available location for quick assignment */
+interface AvailableLocationForList {
+  location: string;
+  label: string;
+  availableSlots: number;
+  canFit: boolean;
+}
+
+interface MobileLoadoutListProps {
+  equipment: MobileEquipmentItem[];
+  stats: MobileLoadoutStats;
+  isOmni?: boolean;
+  selectedEquipmentId?: string | null;
+  onSelectEquipment?: (instanceId: string | null) => void;
+  onRemoveEquipment: (instanceId: string) => void;
+  onRemoveAllEquipment: () => void;
+  onUnassignEquipment?: (instanceId: string) => void;
+  /** Quick assign equipment to a location */
+  onQuickAssign?: (instanceId: string, location: string) => void;
+  /** Get available locations for a specific equipment item */
+  getAvailableLocations?: (instanceId: string) => AvailableLocationForList[];
+  onClose: () => void;
+  className?: string;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+interface CategoryConfig {
+  category: EquipmentCategory | 'ALL';
+  label: string;
+  icon: string;
+}
+
+const CATEGORY_FILTERS: CategoryConfig[] = [
+  { category: 'ALL', label: 'All', icon: '∑' },
+  { category: EquipmentCategory.ENERGY_WEAPON, label: 'Energy', icon: '⚡' },
+  { category: EquipmentCategory.BALLISTIC_WEAPON, label: 'Ballistic', icon: '🎯' },
+  { category: EquipmentCategory.MISSILE_WEAPON, label: 'Missile', icon: '🚀' },
+  { category: EquipmentCategory.AMMUNITION, label: 'Ammo', icon: '📦' },
+  { category: EquipmentCategory.ELECTRONICS, label: 'Elec', icon: '📡' },
+  { category: EquipmentCategory.MISC_EQUIPMENT, label: 'Other', icon: '⚙️' },
+];
+
+// Categories to group under "Other" filter
+const OTHER_CATEGORIES: EquipmentCategory[] = [
+  EquipmentCategory.MISC_EQUIPMENT,
+  EquipmentCategory.PHYSICAL_WEAPON,
+  EquipmentCategory.MOVEMENT,
+  EquipmentCategory.ARTILLERY,
+];
+
+// =============================================================================
+// Category Filter Bar Component
+// =============================================================================
+
+interface CategoryFilterBarProps {
+  activeCategory: EquipmentCategory | 'ALL';
+  onSelectCategory: (category: EquipmentCategory | 'ALL') => void;
+}
+
+function CategoryFilterBar({ activeCategory, onSelectCategory }: CategoryFilterBarProps) {
+  return (
+    <div className="flex items-center gap-1 px-2 py-2 overflow-x-auto scrollbar-none bg-surface-base/50">
+      {CATEGORY_FILTERS.map(({ category, label, icon }) => {
+        const isActive = category === activeCategory;
+        const colors = category === 'ALL' 
+          ? { bg: 'bg-accent', text: 'text-white', border: 'border-accent' }
+          : getCategoryColorsLegacy(category as EquipmentCategory);
+        
+        return (
+          <button
+            key={category}
+            onClick={() => onSelectCategory(category)}
+            className={`
+              flex-shrink-0 flex items-center gap-1 px-2 py-1.5 rounded-lg
+              text-xs font-medium transition-all active:scale-95
+              ${isActive
+                ? `${colors.bg} text-white ring-1 ring-white/20`
+                : 'bg-surface-raised/60 text-text-theme-secondary'
+              }
+            `}
+          >
+            <span className="text-sm">{icon}</span>
+            <span className="hidden xs:inline">{label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// =============================================================================
+// Section Header Component
+// =============================================================================
+
+interface SectionHeaderProps {
+  title: string;
+  count: number;
+  isExpanded: boolean;
+  onToggle: () => void;
+  titleColor?: string;
+}
+
+function SectionHeader({ title, count, isExpanded, onToggle, titleColor = 'text-white' }: SectionHeaderProps) {
+  return (
+    <button
+      onClick={onToggle}
+      className="w-full px-2 py-1 flex items-center justify-between bg-surface-raised/50 border-y border-border-theme-subtle/50 active:bg-surface-raised transition-colors"
+    >
+      <span className={`text-xs font-semibold ${titleColor}`}>{title}</span>
+      <div className="flex items-center gap-1.5">
+        <span className="text-[10px] text-text-theme-secondary">({count})</span>
+        <span className={`text-[10px] text-slate-500 transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
+          ▲
+        </span>
+      </div>
+    </button>
+  );
+}
+
+// =============================================================================
+// Stats Summary Component
+// =============================================================================
+
+interface StatsSummaryProps {
+  stats: MobileLoadoutStats;
+}
+
+function StatsSummary({ stats }: StatsSummaryProps) {
+  const weightOverage = stats.weightUsed > stats.weightMax;
+  const slotsOverage = stats.slotsUsed > stats.slotsMax;
+  const heatNegative = stats.heatGenerated > stats.heatDissipation;
+  
+  return (
+    <div className="px-3 py-2 bg-surface-deep border-b border-border-theme flex items-center justify-around text-center">
+      <div>
+        <div className="text-[10px] text-text-theme-secondary uppercase">Weight</div>
+        <div className={`text-sm font-bold ${weightOverage ? 'text-red-400' : 'text-white'}`}>
+          {stats.weightUsed.toFixed(1)}
+          <span className="text-slate-500 font-normal">/{stats.weightMax}t</span>
+        </div>
+      </div>
+      <div className="w-px h-8 bg-border-theme-subtle" />
+      <div>
+        <div className="text-[10px] text-text-theme-secondary uppercase">Slots</div>
+        <div className={`text-sm font-bold ${slotsOverage ? 'text-red-400' : 'text-white'}`}>
+          {stats.slotsUsed}
+          <span className="text-slate-500 font-normal">/{stats.slotsMax}</span>
+        </div>
+      </div>
+      <div className="w-px h-8 bg-border-theme-subtle" />
+      <div>
+        <div className="text-[10px] text-text-theme-secondary uppercase">Heat</div>
+        <div className={`text-sm font-bold ${heatNegative ? 'text-red-400' : heatNegative ? 'text-amber-400' : 'text-green-400'}`}>
+          {stats.heatGenerated}
+          <span className="text-slate-500 font-normal">/{stats.heatDissipation}</span>
+        </div>
+      </div>
+      <div className="w-px h-8 bg-border-theme-subtle" />
+      <div>
+        <div className="text-[10px] text-text-theme-secondary uppercase">BV</div>
+        <div className="text-sm font-bold text-cyan-400">
+          {stats.battleValue.toLocaleString()}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Section Column Headers Component
+// =============================================================================
+
+function SectionColumnHeaders(): React.ReactElement {
+  return (
+    <div className="flex items-center gap-1.5 px-2 py-0.5 bg-surface-raised/30 border-b border-border-theme-subtle/50 text-[8px] text-text-theme-secondary/50 uppercase tracking-wide">
+      {/* Category indicator spacer */}
+      <div className="w-1 flex-shrink-0" />
+      
+      {/* Main content area - matches row structure */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between gap-1">
+          {/* Name column */}
+          <div className="flex-1 min-w-0">Name</div>
+          
+          {/* Stats columns with separators */}
+          <div className="flex items-center flex-shrink-0 font-mono">
+            <span className="w-[28px] text-center border-l border-border-theme-subtle/30 pl-1">Loc</span>
+            <span className="w-[20px] text-center border-l border-border-theme-subtle/30">H</span>
+            <span className="w-[20px] text-center border-l border-border-theme-subtle/30">C</span>
+            <span className="w-[28px] text-center border-l border-border-theme-subtle/30">Wt</span>
+          </div>
+        </div>
+      </div>
+      
+      {/* Actions columns - 36px width to match rows, compact height for header */}
+      <div className="flex items-center flex-shrink-0 text-[8px]">
+        <span className="w-[36px] h-[18px] flex items-center justify-center border-l border-border-theme-subtle/30" title="Link/Unlink">🔗</span>
+        <span className="w-[36px] h-[18px] flex items-center justify-center border-l border-border-theme-subtle/30" title="Remove">✕</span>
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Main Component
+// =============================================================================
+
+export function MobileLoadoutList({
+  equipment,
+  stats,
+  isOmni = false,
+  selectedEquipmentId,
+  onSelectEquipment,
+  onRemoveEquipment,
+  onRemoveAllEquipment,
+  onUnassignEquipment,
+  onQuickAssign,
+  getAvailableLocations,
+  onClose,
+  className = '',
+}: MobileLoadoutListProps): React.ReactElement {
+  const [activeCategory, setActiveCategory] = useState<EquipmentCategory | 'ALL'>('ALL');
+  const [unassignedExpanded, setUnassignedExpanded] = useState(true);
+  const [allocatedExpanded, setAllocatedExpanded] = useState(true);
+  // Track which item has its location menu open (only one at a time)
+  const [openLocationMenuId, setOpenLocationMenuId] = useState<string | null>(null);
+  
+  // Filter out non-removable equipment (structural components)
+  const removableEquipment = useMemo(() => {
+    return equipment.filter(item => item.isRemovable);
+  }, [equipment]);
+  
+  // Apply category filter
+  const filteredEquipment = useMemo(() => {
+    if (activeCategory === 'ALL') return removableEquipment;
+    
+    // "Other" category includes misc, physical, movement, artillery
+    if (activeCategory === EquipmentCategory.MISC_EQUIPMENT) {
+      return removableEquipment.filter(item => 
+        OTHER_CATEGORIES.includes(item.category)
+      );
+    }
+    
+    return removableEquipment.filter(item => item.category === activeCategory);
+  }, [removableEquipment, activeCategory]);
+  
+  // Split by allocation status
+  const { unassigned, allocated } = useMemo(() => {
+    const unalloc: MobileEquipmentItem[] = [];
+    const alloc: MobileEquipmentItem[] = [];
+    for (const item of filteredEquipment) {
+      if (item.isAllocated) {
+        alloc.push(item);
+      } else {
+        unalloc.push(item);
+      }
+    }
+    return { unassigned: unalloc, allocated: alloc };
+  }, [filteredEquipment]);
+  
+  // Handle equipment selection
+  const handleSelect = useCallback((instanceId: string) => {
+    onSelectEquipment?.(selectedEquipmentId === instanceId ? null : instanceId);
+  }, [selectedEquipmentId, onSelectEquipment]);
+  
+  // Handle remove all
+  const removableCount = removableEquipment.length;
+  const handleRemoveAll = useCallback(() => {
+    if (removableCount === 0) return;
+    if (window.confirm(`Remove all ${removableCount} equipment items?`)) {
+      onRemoveAllEquipment();
+    }
+  }, [removableCount, onRemoveAllEquipment]);
+  
+  return (
+    <div 
+      className={`
+        fixed inset-0 z-50 flex flex-col
+        bg-surface-deep
+        ${className}
+      `}
+      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+    >
+      {/* Header */}
+      <div className="flex-shrink-0 flex items-center justify-between px-3 py-2 bg-surface-base border-b border-border-theme">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onClose}
+            className="p-1.5 -ml-1.5 text-text-theme-secondary hover:text-white active:scale-95 transition-all"
+            aria-label="Close loadout"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <h2 className="text-base font-bold text-white">Equipment Loadout</h2>
+          <span className="bg-accent text-white text-xs rounded-full px-2 py-0.5">
+            {removableEquipment.length}
+          </span>
+        </div>
+        
+        {removableCount > 0 && (
+          <button
+            onClick={handleRemoveAll}
+            className="px-3 py-1.5 text-xs bg-red-900/40 hover:bg-red-900/60 active:scale-95 rounded text-red-300 transition-all"
+          >
+            Clear All
+          </button>
+        )}
+      </div>
+      
+      {/* Stats Summary */}
+      <StatsSummary stats={stats} />
+      
+      {/* Category Filters */}
+      <CategoryFilterBar 
+        activeCategory={activeCategory} 
+        onSelectCategory={setActiveCategory} 
+      />
+      
+      {/* Equipment List */}
+      <div className="flex-1 overflow-y-auto">
+        {filteredEquipment.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full p-8 text-center">
+            <div className="text-4xl mb-3">⚙️</div>
+            <div className="text-lg text-white font-medium mb-1">No Equipment</div>
+            <div className="text-sm text-text-theme-secondary">
+              {activeCategory === 'ALL' 
+                ? 'Add equipment from the Equipment tab'
+                : 'No items in this category'
+              }
+            </div>
+          </div>
+        ) : (
+          <>
+            {/* Unassigned Section */}
+            {unassigned.length > 0 && (
+              <>
+                <SectionHeader
+                  title="Unassigned"
+                  count={unassigned.length}
+                  isExpanded={unassignedExpanded}
+                  onToggle={() => setUnassignedExpanded(!unassignedExpanded)}
+                  titleColor="text-amber-400"
+                />
+                {unassignedExpanded && (
+                  <div className="bg-amber-900/10">
+                    <SectionColumnHeaders />
+                    {unassigned.map(item => (
+                      <MobileEquipmentRow
+                        key={item.instanceId}
+                        item={item}
+                        isOmni={isOmni}
+                        isSelected={selectedEquipmentId === item.instanceId}
+                        onSelect={() => handleSelect(item.instanceId)}
+                        onRemove={() => onRemoveEquipment(item.instanceId)}
+                        onQuickAssign={onQuickAssign ? (location) => {
+                          onQuickAssign(item.instanceId, location);
+                          setOpenLocationMenuId(null);
+                        } : undefined}
+                        availableLocations={getAvailableLocations?.(item.instanceId) ?? []}
+                        isLocationMenuOpen={openLocationMenuId === item.instanceId}
+                        onToggleLocationMenu={() => setOpenLocationMenuId(
+                          openLocationMenuId === item.instanceId ? null : item.instanceId
+                        )}
+                      />
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+            
+            {/* Allocated Section */}
+            {allocated.length > 0 && (
+              <>
+                <SectionHeader
+                  title="Allocated"
+                  count={allocated.length}
+                  isExpanded={allocatedExpanded}
+                  onToggle={() => setAllocatedExpanded(!allocatedExpanded)}
+                  titleColor="text-green-400"
+                />
+                {allocatedExpanded && (
+                  <div className="bg-green-900/10">
+                    <SectionColumnHeaders />
+                    {allocated.map(item => (
+                      <MobileEquipmentRow
+                        key={item.instanceId}
+                        item={item}
+                        isOmni={isOmni}
+                        isSelected={selectedEquipmentId === item.instanceId}
+                        onSelect={() => handleSelect(item.instanceId)}
+                        onRemove={() => onRemoveEquipment(item.instanceId)}
+                        onUnassign={onUnassignEquipment ? () => onUnassignEquipment(item.instanceId) : undefined}
+                      />
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </div>
+      
+      {/* Footer with close button */}
+      <div className="flex-shrink-0 px-3 py-3 bg-surface-base border-t border-border-theme">
+        <button
+          onClick={onClose}
+          className="w-full py-3 bg-surface-raised hover:bg-surface-raised/80 active:scale-[0.98] text-white font-medium rounded-lg transition-all"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default MobileLoadoutList;

--- a/src/components/customizer/mobile/index.ts
+++ b/src/components/customizer/mobile/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Mobile Components for MekStation Customizer
+ * 
+ * Optimized components for mobile device interaction with
+ * full-screen layouts and touch-friendly controls.
+ */
+
+export { MobileLoadoutHeader } from './MobileLoadoutHeader';
+export type { MobileLoadoutStats } from './MobileLoadoutHeader';
+
+export { MobileEquipmentRow } from './MobileEquipmentRow';
+export type { MobileEquipmentItem, AvailableLocationOption } from './MobileEquipmentRow';
+
+export { MobileLoadoutList } from './MobileLoadoutList';

--- a/src/components/customizer/tabs/EquipmentTab.tsx
+++ b/src/components/customizer/tabs/EquipmentTab.tsx
@@ -1,62 +1,79 @@
 /**
- * Equipment Tab Component
- * 
- * Full-width equipment browser for adding equipment to the unit.
- * The loadout tray is now a global component visible across all tabs.
- * 
+ * Equipment Tab - equipment browser with equipped summary
  * @spec openspec/specs/equipment-browser/spec.md
  * @spec openspec/changes/unify-equipment-tab/specs/customizer-tabs/spec.md
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useUnitStore } from '@/stores/useUnitStore';
 import { EquipmentBrowser } from '../equipment/EquipmentBrowser';
-import { IEquipmentItem } from '@/types/equipment';
-
-// =============================================================================
-// Types
-// =============================================================================
+import { EquippedSummary } from '../equipment/EquippedSummary';
+import { IEquipmentItem, EquipmentCategory } from '@/types/equipment';
+import type { LoadoutEquipmentItem } from '../equipment/GlobalLoadoutTray';
 
 interface EquipmentTabProps {
-  /** Read-only mode */
   readOnly?: boolean;
-  /** Additional CSS classes */
   className?: string;
 }
 
-// =============================================================================
-// Main Component
-// =============================================================================
-
-/**
- * Equipment configuration tab
- * 
- * Full-width equipment browser. The loadout tray with mounted equipment
- * is now a global sidebar visible across all tabs.
- */
 export function EquipmentTab({
   readOnly = false,
   className = '',
 }: EquipmentTabProps): React.ReactElement {
-  // Get unit state from context
   const addEquipment = useUnitStore((s) => s.addEquipment);
+  const removeEquipment = useUnitStore((s) => s.removeEquipment);
+  const equipment = useUnitStore((s) => s.equipment);
   
-  // Handle adding equipment
+  const [selectedEquipmentId, setSelectedEquipmentId] = useState<string | null>(null);
+  
   const handleAddEquipment = useCallback((item: IEquipmentItem) => {
     if (readOnly) return;
     addEquipment(item);
   }, [addEquipment, readOnly]);
   
+  const handleRemoveEquipment = useCallback((instanceId: string) => {
+    if (readOnly) return;
+    removeEquipment(instanceId);
+    if (selectedEquipmentId === instanceId) {
+      setSelectedEquipmentId(null);
+    }
+  }, [removeEquipment, readOnly, selectedEquipmentId]);
+  
+  const handleSelectEquipment = useCallback((instanceId: string | null) => {
+    setSelectedEquipmentId(instanceId);
+  }, []);
+  
+  const loadoutEquipment: LoadoutEquipmentItem[] = useMemo(() => {
+    return equipment.map(eq => ({
+      instanceId: eq.instanceId,
+      equipmentId: eq.equipmentId,
+      name: eq.name,
+      category: eq.category as EquipmentCategory,
+      weight: eq.weight,
+      criticalSlots: eq.criticalSlots,
+      isAllocated: eq.location !== undefined,
+      location: eq.location,
+      isRemovable: eq.isRemovable ?? true,
+      isOmniPodMounted: eq.isOmniPodMounted,
+    }));
+  }, [equipment]);
+  
   return (
-    <div className={`flex flex-col h-full p-4 ${className}`}>
-      {/* Full-width Equipment Browser */}
+    <div className={`flex flex-col h-full p-3 gap-2 ${className}`}>
+      <EquippedSummary
+        equipment={loadoutEquipment}
+        onRemoveEquipment={handleRemoveEquipment}
+        onSelectEquipment={handleSelectEquipment}
+        selectedEquipmentId={selectedEquipmentId}
+      />
+      
       <EquipmentBrowser
         onAddEquipment={handleAddEquipment}
         className="flex-1 min-h-0"
       />
       
       {readOnly && (
-        <div className="mt-4 bg-blue-900/30 border border-blue-700 rounded-lg p-4 text-blue-300 text-sm">
+        <div className="bg-blue-900/30 border border-blue-700 rounded-lg p-3 text-blue-300 text-xs">
           This unit is in read-only mode. Changes cannot be made.
         </div>
       )}


### PR DESCRIPTION
## Summary
- Add quick assign/unassign buttons to mobile equipment rows with 2-tap confirmation
- Add category filter bar to GlobalLoadoutTray matching mobile functionality
- Fix context menu text wrapping on longer location names

## Changes

### Mobile Loadout Enhancements
- **MobileLoadoutHeader**: Compact stats bar showing weight, slots, heat, BV with overage indicators
- **MobileEquipmentRow**: Touch-friendly rows with:
  - Quick assign via link button with location dropdown
  - Unassign via chain-break button with 2-tap confirmation
  - Remove via × button with 2-tap confirmation
  - Weapon details (damage, ranges, TC indicator)
- **MobileLoadoutList**: Full-screen list with category filtering, Unassigned/Allocated sections

### Desktop Loadout Enhancements
- Added icon-based category filter bar (Energy, Ballistic, Missile, Ammo, Electronics, Other)
- Fixed context menu min-width (160px → 200px) and added whitespace-nowrap to prevent wrapping

### Tests Added
- CompactFilterBar tests (category buttons, hide filters, search, clear)
- EquippedSummary tests (rendering, grouping, filtering, selection, removal)
- MobileLoadoutHeader tests (stats display, overage indicators)
- MobileEquipmentRow tests (rendering, actions, confirmation flows)
- GlobalLoadoutTray category filter tests (6 new tests)

## Spec Updates
- Added "Category Filter Bar" requirement to equipment-tray spec
- Modified "Context Menu Quick Assignment" requirement with row layout scenario