### PR TITLE
feat(pilots): Add complete pilot system

### DIFF
--- a/src/components/pilots/AbilityPurchaseModal.tsx
+++ b/src/components/pilots/AbilityPurchaseModal.tsx
@@ -1,0 +1,536 @@
+/**
+ * Ability Purchase Modal
+ * 
+ * Modal for browsing and purchasing pilot special abilities.
+ * Abilities are grouped by category with visual indicators for status.
+ * 
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+import React, { useState, useMemo, useCallback } from 'react';
+import { ModalOverlay } from '@/components/customizer/dialogs/ModalOverlay';
+import { Button, Badge } from '@/components/ui';
+import { usePilotStore } from '@/stores/usePilotStore';
+import {
+  IPilot,
+  ISpecialAbility,
+  AbilityCategory,
+  getAbilitiesByCategory,
+  getAvailableAbilities,
+  meetsPrerequisites,
+  getAbility,
+  SPECIAL_ABILITIES,
+} from '@/types/pilot';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface AbilityPurchaseModalProps {
+  /** Whether the modal is open */
+  isOpen: boolean;
+  /** Called when the modal is closed */
+  onClose: () => void;
+  /** The pilot purchasing abilities */
+  pilot: IPilot;
+  /** Called when an ability is purchased */
+  onPurchase?: () => void;
+}
+
+type AbilityStatus = 'owned' | 'available' | 'affordable' | 'missing-prereqs' | 'need-xp';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const CATEGORY_INFO: Record<AbilityCategory, { label: string; icon: React.ReactNode; color: string }> = {
+  [AbilityCategory.Gunnery]: {
+    label: 'Gunnery',
+    color: 'rose',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  },
+  [AbilityCategory.Piloting]: {
+    label: 'Piloting',
+    color: 'cyan',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 10V3L4 14h7v7l9-11h-7z" />
+      </svg>
+    ),
+  },
+  [AbilityCategory.Toughness]: {
+    label: 'Toughness',
+    color: 'emerald',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+      </svg>
+    ),
+  },
+  [AbilityCategory.Tactical]: {
+    label: 'Tactical',
+    color: 'violet',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+      </svg>
+    ),
+  },
+};
+
+const CATEGORY_COLOR_MAP: Record<string, { badge: 'rose' | 'cyan' | 'emerald' | 'violet'; bg: string; border: string }> = {
+  rose: { badge: 'rose', bg: 'bg-rose-500/10', border: 'border-rose-500/30' },
+  cyan: { badge: 'cyan', bg: 'bg-cyan-500/10', border: 'border-cyan-500/30' },
+  emerald: { badge: 'emerald', bg: 'bg-emerald-500/10', border: 'border-emerald-500/30' },
+  violet: { badge: 'violet', bg: 'bg-violet-500/10', border: 'border-violet-500/30' },
+};
+
+// =============================================================================
+// Sub-Components
+// =============================================================================
+
+interface AbilityCardProps {
+  ability: ISpecialAbility;
+  status: AbilityStatus;
+  missingPrereqs: string[];
+  availableXp: number;
+  onPurchase: () => void;
+  isPurchasing: boolean;
+  categoryColor: string;
+}
+
+function AbilityCard({
+  ability,
+  status,
+  missingPrereqs,
+  availableXp,
+  onPurchase,
+  isPurchasing,
+  categoryColor,
+}: AbilityCardProps): React.ReactElement {
+  const colors = CATEGORY_COLOR_MAP[categoryColor] || CATEGORY_COLOR_MAP.violet;
+  
+  const isOwned = status === 'owned';
+  const canPurchase = status === 'affordable';
+  const needsXp = status === 'need-xp';
+  const missingReqs = status === 'missing-prereqs';
+  
+  // Status badge config
+  const getStatusBadge = () => {
+    if (isOwned) {
+      return { variant: 'emerald' as const, text: 'Owned' };
+    }
+    if (canPurchase) {
+      return { variant: 'amber' as const, text: 'Available' };
+    }
+    if (needsXp) {
+      return { variant: 'orange' as const, text: `Need ${ability.xpCost - availableXp} more XP` };
+    }
+    return { variant: 'slate' as const, text: 'Locked' };
+  };
+  
+  const statusBadge = getStatusBadge();
+
+  return (
+    <div
+      className={`
+        relative p-4 rounded-lg border transition-all duration-200
+        ${isOwned 
+          ? 'bg-emerald-900/10 border-emerald-600/30' 
+          : canPurchase 
+            ? `${colors.bg} ${colors.border} hover:border-accent/50` 
+            : 'bg-surface-raised/20 border-border-theme-subtle/30 opacity-75'
+        }
+      `}
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h4 className={`font-semibold ${isOwned ? 'text-emerald-400' : 'text-text-theme-primary'}`}>
+              {ability.name}
+            </h4>
+            <Badge variant={statusBadge.variant} size="sm">
+              {statusBadge.text}
+            </Badge>
+          </div>
+        </div>
+        
+        {/* XP Cost */}
+        <div className="flex-shrink-0 text-right">
+          <div className={`text-lg font-bold tabular-nums ${canPurchase ? 'text-accent' : 'text-text-theme-secondary'}`}>
+            {ability.xpCost}
+          </div>
+          <div className="text-xs text-text-theme-muted">XP</div>
+        </div>
+      </div>
+      
+      {/* Description */}
+      <p className="text-sm text-text-theme-secondary leading-relaxed mb-3">
+        {ability.description}
+      </p>
+      
+      {/* Prerequisites */}
+      {(ability.prerequisites.length > 0 || ability.minGunnery || ability.minPiloting) && (
+        <div className="mb-3 space-y-1">
+          <div className="text-xs text-text-theme-muted uppercase tracking-wide">Prerequisites</div>
+          <div className="flex flex-wrap gap-2">
+            {ability.minGunnery && (
+              <Badge 
+                variant={missingPrereqs.some(m => m.includes('Gunnery')) ? 'red' : 'slate'} 
+                size="sm"
+              >
+                Gunnery {ability.minGunnery}+
+              </Badge>
+            )}
+            {ability.minPiloting && (
+              <Badge 
+                variant={missingPrereqs.some(m => m.includes('Piloting')) ? 'red' : 'slate'} 
+                size="sm"
+              >
+                Piloting {ability.minPiloting}+
+              </Badge>
+            )}
+            {ability.prerequisites.map((prereqId) => {
+              const prereq = getAbility(prereqId);
+              const isMissing = missingPrereqs.some(m => m.includes(prereq?.name || prereqId));
+              return (
+                <Badge 
+                  key={prereqId} 
+                  variant={isMissing ? 'red' : 'emerald'} 
+                  size="sm"
+                >
+                  {prereq?.name || prereqId}
+                </Badge>
+              );
+            })}
+          </div>
+        </div>
+      )}
+      
+      {/* Missing Prerequisites Warning */}
+      {missingReqs && missingPrereqs.length > 0 && (
+        <div className="mb-3 p-2 rounded bg-red-900/20 border border-red-600/20">
+          <div className="flex items-start gap-2">
+            <svg className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            <div className="text-xs text-red-400">
+              {missingPrereqs.map((msg, i) => (
+                <div key={i}>{msg}</div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+      
+      {/* Action Button */}
+      {!isOwned && (
+        <Button
+          variant={canPurchase ? 'primary' : 'secondary'}
+          size="sm"
+          fullWidth
+          disabled={!canPurchase || isPurchasing}
+          onClick={onPurchase}
+          isLoading={isPurchasing}
+          leftIcon={
+            !isPurchasing && (
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+            )
+          }
+        >
+          {canPurchase ? `Purchase for ${ability.xpCost} XP` : 'Cannot Purchase'}
+        </Button>
+      )}
+      
+      {/* Owned Checkmark */}
+      {isOwned && (
+        <div className="flex items-center justify-center gap-2 text-emerald-400">
+          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+            <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+          </svg>
+          <span className="text-sm font-medium">Already Learned</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface CategorySectionProps {
+  category: AbilityCategory;
+  abilities: ISpecialAbility[];
+  pilot: IPilot;
+  onPurchase: (ability: ISpecialAbility) => void;
+  purchasingId: string | null;
+}
+
+function CategorySection({
+  category,
+  abilities,
+  pilot,
+  onPurchase,
+  purchasingId,
+}: CategorySectionProps): React.ReactElement {
+  const info = CATEGORY_INFO[category];
+  const colors = CATEGORY_COLOR_MAP[info.color];
+  const availableXp = pilot.career?.xp ?? 0;
+  const ownedIds = (pilot.abilities || []).map((a) => a.abilityId);
+  
+  // Calculate status for each ability
+  const getAbilityStatus = (ability: ISpecialAbility): { status: AbilityStatus; missing: string[] } => {
+    if (ownedIds.includes(ability.id)) {
+      return { status: 'owned', missing: [] };
+    }
+    
+    const prereqCheck = meetsPrerequisites(
+      ability.id,
+      pilot.skills.gunnery,
+      pilot.skills.piloting,
+      ownedIds
+    );
+    
+    if (!prereqCheck.meets) {
+      return { status: 'missing-prereqs', missing: prereqCheck.missing };
+    }
+    
+    if (availableXp >= ability.xpCost) {
+      return { status: 'affordable', missing: [] };
+    }
+    
+    return { status: 'need-xp', missing: [] };
+  };
+  
+  // Sort abilities: owned first, then affordable, then by cost
+  const sortedAbilities = [...abilities].sort((a, b) => {
+    const statusA = getAbilityStatus(a);
+    const statusB = getAbilityStatus(b);
+    
+    const order: Record<AbilityStatus, number> = {
+      'owned': 0,
+      'affordable': 1,
+      'need-xp': 2,
+      'available': 3,
+      'missing-prereqs': 4,
+    };
+    
+    const orderDiff = order[statusA.status] - order[statusB.status];
+    if (orderDiff !== 0) return orderDiff;
+    
+    return a.xpCost - b.xpCost;
+  });
+
+  return (
+    <div className="space-y-4">
+      {/* Category Header */}
+      <div className={`flex items-center gap-3 p-3 rounded-lg ${colors.bg} ${colors.border} border`}>
+        <div className={`text-${info.color}-400`}>
+          {info.icon}
+        </div>
+        <div>
+          <h3 className="font-semibold text-text-theme-primary">{info.label} Abilities</h3>
+          <p className="text-xs text-text-theme-secondary">
+            {abilities.length} {abilities.length === 1 ? 'ability' : 'abilities'} available
+          </p>
+        </div>
+        <div className="ml-auto">
+          <Badge variant={colors.badge} size="sm">
+            {ownedIds.filter(id => abilities.some(a => a.id === id)).length} / {abilities.length} owned
+          </Badge>
+        </div>
+      </div>
+      
+      {/* Ability Cards */}
+      <div className="grid grid-cols-1 gap-3">
+        {sortedAbilities.map((ability) => {
+          const { status, missing } = getAbilityStatus(ability);
+          return (
+            <AbilityCard
+              key={ability.id}
+              ability={ability}
+              status={status}
+              missingPrereqs={missing}
+              availableXp={availableXp}
+              onPurchase={() => onPurchase(ability)}
+              isPurchasing={purchasingId === ability.id}
+              categoryColor={info.color}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Main Component
+// =============================================================================
+
+export function AbilityPurchaseModal({
+  isOpen,
+  onClose,
+  pilot,
+  onPurchase,
+}: AbilityPurchaseModalProps): React.ReactElement | null {
+  const { purchaseAbility, error } = usePilotStore();
+  const [purchasingId, setPurchasingId] = useState<string | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<AbilityCategory | 'all'>('all');
+  
+  // Get abilities grouped by category
+  const abilitiesByCategory = useMemo(() => getAbilitiesByCategory(), []);
+  
+  // Available XP
+  const availableXp = pilot.career?.xp ?? 0;
+  const ownedIds = (pilot.abilities || []).map((a) => a.abilityId);
+  
+  // Stats
+  const stats = useMemo(() => {
+    const total = Object.values(SPECIAL_ABILITIES).length;
+    const owned = ownedIds.length;
+    const affordable = getAvailableAbilities(
+      pilot.skills.gunnery,
+      pilot.skills.piloting,
+      ownedIds
+    ).filter(a => a.xpCost <= availableXp).length;
+    
+    return { total, owned, affordable };
+  }, [ownedIds, pilot.skills, availableXp]);
+  
+  // Handle purchase
+  const handlePurchase = useCallback(async (ability: ISpecialAbility) => {
+    setPurchasingId(ability.id);
+    const success = await purchaseAbility(pilot.id, ability.id, ability.xpCost);
+    setPurchasingId(null);
+    
+    if (success) {
+      onPurchase?.();
+    }
+  }, [purchaseAbility, pilot.id, onPurchase]);
+  
+  // Filter categories
+  const visibleCategories = selectedCategory === 'all' 
+    ? Object.values(AbilityCategory)
+    : [selectedCategory];
+
+  return (
+    <ModalOverlay
+      isOpen={isOpen}
+      onClose={onClose}
+      preventClose={purchasingId !== null}
+      className="w-[720px] max-h-[85vh] overflow-hidden"
+    >
+      <div className="flex flex-col h-full max-h-[85vh]">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border-theme-subtle bg-surface-deep/50 flex-shrink-0">
+          <div>
+            <h2 className="text-xl font-bold text-text-theme-primary">Special Abilities</h2>
+            <p className="text-sm text-text-theme-secondary">
+              Enhance {pilot.name}&apos;s combat capabilities
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={purchasingId !== null}
+            className="p-2 text-text-theme-secondary hover:text-text-theme-primary hover:bg-surface-raised rounded-lg transition-colors"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        
+        {/* Stats Bar */}
+        <div className="px-6 py-3 bg-surface-base border-b border-border-theme-subtle flex-shrink-0">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-6">
+              <div className="flex items-center gap-2">
+                <svg className="w-5 h-5 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                </svg>
+                <span className="text-lg font-bold text-accent tabular-nums">{availableXp}</span>
+                <span className="text-sm text-text-theme-secondary">XP available</span>
+              </div>
+              
+              <div className="h-6 w-px bg-border-theme-subtle" />
+              
+              <div className="flex items-center gap-4 text-sm">
+                <span className="text-text-theme-secondary">
+                  <span className="font-medium text-emerald-400">{stats.owned}</span> owned
+                </span>
+                <span className="text-text-theme-secondary">
+                  <span className="font-medium text-accent">{stats.affordable}</span> purchasable
+                </span>
+              </div>
+            </div>
+            
+            {/* Category Filter */}
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setSelectedCategory('all')}
+                className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
+                  selectedCategory === 'all'
+                    ? 'bg-accent/20 text-accent border border-accent/30'
+                    : 'bg-surface-raised text-text-theme-secondary hover:text-text-theme-primary border border-border-theme-subtle'
+                }`}
+              >
+                All
+              </button>
+              {Object.values(AbilityCategory).map((cat) => {
+                const info = CATEGORY_INFO[cat];
+                return (
+                  <button
+                    key={cat}
+                    onClick={() => setSelectedCategory(cat)}
+                    className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
+                      selectedCategory === cat
+                        ? 'bg-accent/20 text-accent border border-accent/30'
+                        : 'bg-surface-raised text-text-theme-secondary hover:text-text-theme-primary border border-border-theme-subtle'
+                    }`}
+                  >
+                    {info.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+        
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-6">
+          {visibleCategories.map((category) => (
+            <CategorySection
+              key={category}
+              category={category}
+              abilities={abilitiesByCategory[category]}
+              pilot={pilot}
+              onPurchase={handlePurchase}
+              purchasingId={purchasingId}
+            />
+          ))}
+        </div>
+        
+        {/* Error Display */}
+        {error && (
+          <div className="mx-6 mb-4 p-4 rounded-lg bg-red-900/20 border border-red-600/30 flex-shrink-0">
+            <p className="text-sm text-red-400">{error}</p>
+          </div>
+        )}
+        
+        {/* Footer */}
+        <div className="flex items-center justify-end px-6 py-4 border-t border-border-theme-subtle bg-surface-deep/50 flex-shrink-0">
+          <Button variant="secondary" onClick={onClose} disabled={purchasingId !== null}>
+            Close
+          </Button>
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+}
+
+export default AbilityPurchaseModal;

--- a/src/components/pilots/PilotCreationWizard.tsx
+++ b/src/components/pilots/PilotCreationWizard.tsx
@@ -1,0 +1,931 @@
+/**
+ * Pilot Creation Wizard
+ * 
+ * Multi-step wizard for creating pilots with 4 modes:
+ * - Template: Quick creation using experience level presets
+ * - Custom: Point-buy skill configuration
+ * - Random: Randomly generated skills
+ * - Statblock: Quick NPC creation (no persistence)
+ * 
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+import React, { useState, useCallback, useMemo } from 'react';
+import { ModalOverlay } from '@/components/customizer/dialogs/ModalOverlay';
+import { Button, Input, Badge, Card } from '@/components/ui';
+import { usePilotStore } from '@/stores/usePilotStore';
+import {
+  PilotExperienceLevel,
+  IPilotIdentity,
+  IPilotSkills,
+  IPilotStatblock,
+  PilotType,
+  PILOT_TEMPLATES,
+  DEFAULT_PILOT_SKILLS,
+  MIN_SKILL_VALUE,
+  MAX_SKILL_VALUE,
+  getSkillLabel,
+  getPilotRating,
+  GUNNERY_IMPROVEMENT_COSTS,
+  PILOTING_IMPROVEMENT_COSTS,
+} from '@/types/pilot';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+type CreationMode = 'template' | 'custom' | 'random' | 'statblock';
+type WizardStep = 'mode' | 'identity' | 'skills' | 'review';
+
+interface WizardState {
+  mode: CreationMode | null;
+  identity: IPilotIdentity;
+  templateLevel: PilotExperienceLevel;
+  customSkills: IPilotSkills;
+  randomSkills: IPilotSkills | null;
+  statblockSkills: IPilotSkills;
+}
+
+interface PilotCreationWizardProps {
+  /** Whether the wizard is open */
+  isOpen: boolean;
+  /** Called when the wizard is closed */
+  onClose: () => void;
+  /** Called when a pilot is successfully created */
+  onCreated?: (pilotId: string | null) => void;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const INITIAL_STATE: WizardState = {
+  mode: null,
+  identity: { name: '' },
+  templateLevel: PilotExperienceLevel.Regular,
+  customSkills: { ...DEFAULT_PILOT_SKILLS },
+  randomSkills: null,
+  statblockSkills: { ...DEFAULT_PILOT_SKILLS },
+};
+
+const MODE_INFO: Record<CreationMode, { title: string; description: string; icon: React.ReactNode }> = {
+  template: {
+    title: 'Template',
+    description: 'Quick creation using experience level presets. Perfect for starting campaigns.',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+      </svg>
+    ),
+  },
+  custom: {
+    title: 'Custom',
+    description: 'Build your pilot from scratch with point-buy skill allocation.',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+      </svg>
+    ),
+  },
+  random: {
+    title: 'Random',
+    description: 'Generate a pilot with randomized skills. Let fate decide.',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
+      </svg>
+    ),
+  },
+  statblock: {
+    title: 'Statblock',
+    description: 'Quick NPC creation without persistence. For one-off encounters.',
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 10V3L4 14h7v7l9-11h-7z" />
+      </svg>
+    ),
+  },
+};
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+function generateRandomSkills(): IPilotSkills {
+  // Generate skills with weighted distribution (Regular is most common)
+  const roll = Math.random();
+  let gunnery: number;
+  let piloting: number;
+  
+  if (roll < 0.1) {
+    // 10% Elite
+    gunnery = 2 + Math.floor(Math.random() * 2); // 2-3
+    piloting = 3 + Math.floor(Math.random() * 2); // 3-4
+  } else if (roll < 0.35) {
+    // 25% Veteran
+    gunnery = 3 + Math.floor(Math.random() * 2); // 3-4
+    piloting = 4 + Math.floor(Math.random() * 2); // 4-5
+  } else if (roll < 0.75) {
+    // 40% Regular
+    gunnery = 4 + Math.floor(Math.random() * 2); // 4-5
+    piloting = 5 + Math.floor(Math.random() * 2); // 5-6
+  } else {
+    // 25% Green
+    gunnery = 5 + Math.floor(Math.random() * 2); // 5-6
+    piloting = 6 + Math.floor(Math.random() * 2); // 6-7
+  }
+  
+  return { gunnery, piloting };
+}
+
+function calculatePointCost(skills: IPilotSkills): number {
+  // Calculate total "points spent" improving from baseline 4/5
+  let cost = 0;
+  
+  // Gunnery improvements from 4
+  for (let i = DEFAULT_PILOT_SKILLS.gunnery; i > skills.gunnery; i--) {
+    cost += GUNNERY_IMPROVEMENT_COSTS[i] || 0;
+  }
+  
+  // Piloting improvements from 5
+  for (let i = DEFAULT_PILOT_SKILLS.piloting; i > skills.piloting; i--) {
+    cost += PILOTING_IMPROVEMENT_COSTS[i] || 0;
+  }
+  
+  return cost;
+}
+
+// =============================================================================
+// Sub-Components
+// =============================================================================
+
+interface StepIndicatorProps {
+  currentStep: WizardStep;
+  mode: CreationMode | null;
+}
+
+function StepIndicator({ currentStep, mode }: StepIndicatorProps): React.ReactElement {
+  const steps: { id: WizardStep; label: string }[] = [
+    { id: 'mode', label: 'Mode' },
+    { id: 'identity', label: 'Identity' },
+    { id: 'skills', label: 'Skills' },
+    { id: 'review', label: 'Review' },
+  ];
+  
+  // For statblock, skip the skills step indicator
+  const visibleSteps = mode === 'statblock' 
+    ? steps.filter(s => s.id !== 'skills')
+    : steps;
+  
+  const currentIndex = visibleSteps.findIndex(s => s.id === currentStep);
+  
+  return (
+    <div className="flex items-center justify-center gap-2 mb-6">
+      {visibleSteps.map((step, index) => {
+        const isActive = step.id === currentStep;
+        const isCompleted = index < currentIndex;
+        
+        return (
+          <React.Fragment key={step.id}>
+            {index > 0 && (
+              <div className={`h-px w-8 transition-colors ${
+                isCompleted ? 'bg-accent' : 'bg-border-theme-subtle'
+              }`} />
+            )}
+            <div className="flex flex-col items-center gap-1">
+              <div className={`
+                w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium
+                transition-all duration-200
+                ${isActive 
+                  ? 'bg-accent text-surface-deep ring-2 ring-accent/30 ring-offset-2 ring-offset-surface-base' 
+                  : isCompleted
+                    ? 'bg-accent/20 text-accent border border-accent/50'
+                    : 'bg-surface-raised text-text-theme-secondary border border-border-theme-subtle'
+                }
+              `}>
+                {isCompleted ? (
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                ) : (
+                  index + 1
+                )}
+              </div>
+              <span className={`text-xs transition-colors ${
+                isActive ? 'text-accent font-medium' : 'text-text-theme-secondary'
+              }`}>
+                {step.label}
+              </span>
+            </div>
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
+interface ModeCardProps {
+  mode: CreationMode;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+function ModeCard({ mode, isSelected, onClick }: ModeCardProps): React.ReactElement {
+  const info = MODE_INFO[mode];
+  
+  return (
+    <button
+      onClick={onClick}
+      className={`
+        relative w-full p-4 rounded-lg border-2 text-left transition-all duration-200
+        group hover:scale-[1.02]
+        ${isSelected 
+          ? 'border-accent bg-accent/10 shadow-lg shadow-accent/20' 
+          : 'border-border-theme-subtle bg-surface-raised/30 hover:border-border-theme hover:bg-surface-raised/50'
+        }
+      `}
+    >
+      {/* Selection indicator */}
+      <div className={`
+        absolute top-3 right-3 w-5 h-5 rounded-full border-2 flex items-center justify-center
+        transition-all duration-200
+        ${isSelected 
+          ? 'border-accent bg-accent' 
+          : 'border-border-theme group-hover:border-text-theme-secondary'
+        }
+      `}>
+        {isSelected && (
+          <svg className="w-3 h-3 text-surface-deep" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+          </svg>
+        )}
+      </div>
+      
+      {/* Content */}
+      <div className={`
+        w-10 h-10 rounded-lg flex items-center justify-center mb-3
+        ${isSelected ? 'bg-accent/20 text-accent' : 'bg-surface-raised text-text-theme-secondary group-hover:text-text-theme-primary'}
+      `}>
+        {info.icon}
+      </div>
+      
+      <h3 className={`text-lg font-semibold mb-1 transition-colors ${
+        isSelected ? 'text-accent' : 'text-text-theme-primary'
+      }`}>
+        {info.title}
+      </h3>
+      
+      <p className="text-sm text-text-theme-secondary leading-relaxed">
+        {info.description}
+      </p>
+      
+      {/* Mode badge */}
+      {mode === 'statblock' && (
+        <Badge variant="amber" size="sm" className="mt-3">
+          No Persistence
+        </Badge>
+      )}
+    </button>
+  );
+}
+
+interface SkillSliderProps {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  improvementCosts: Record<number, number>;
+}
+
+function SkillSlider({ label, value, onChange, improvementCosts }: SkillSliderProps): React.ReactElement {
+  const skillLabel = getSkillLabel(value);
+  const nextCost = improvementCosts[value];
+  
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-text-theme-primary">{label}</span>
+        <div className="flex items-center gap-2">
+          <span className="text-2xl font-bold text-accent tabular-nums">{value}</span>
+          <Badge variant={value <= 3 ? 'emerald' : value <= 5 ? 'amber' : 'slate'} size="sm">
+            {skillLabel}
+          </Badge>
+        </div>
+      </div>
+      
+      {/* Custom slider track */}
+      <div className="relative">
+        <input
+          type="range"
+          min={MIN_SKILL_VALUE}
+          max={MAX_SKILL_VALUE}
+          value={value}
+          onChange={(e) => onChange(parseInt(e.target.value))}
+          className="w-full h-2 bg-surface-raised rounded-lg appearance-none cursor-pointer
+            [&::-webkit-slider-thumb]:appearance-none
+            [&::-webkit-slider-thumb]:w-5
+            [&::-webkit-slider-thumb]:h-5
+            [&::-webkit-slider-thumb]:rounded-full
+            [&::-webkit-slider-thumb]:bg-accent
+            [&::-webkit-slider-thumb]:shadow-lg
+            [&::-webkit-slider-thumb]:shadow-accent/30
+            [&::-webkit-slider-thumb]:cursor-pointer
+            [&::-webkit-slider-thumb]:transition-transform
+            [&::-webkit-slider-thumb]:hover:scale-110
+            [&::-moz-range-thumb]:w-5
+            [&::-moz-range-thumb]:h-5
+            [&::-moz-range-thumb]:rounded-full
+            [&::-moz-range-thumb]:bg-accent
+            [&::-moz-range-thumb]:border-0
+            [&::-moz-range-thumb]:cursor-pointer"
+        />
+        
+        {/* Tick marks */}
+        <div className="flex justify-between px-2 mt-1">
+          {Array.from({ length: MAX_SKILL_VALUE - MIN_SKILL_VALUE + 1 }, (_, i) => (
+            <div 
+              key={i}
+              className={`w-0.5 h-1.5 rounded-full ${
+                i + MIN_SKILL_VALUE <= value ? 'bg-accent' : 'bg-border-theme-subtle'
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+      
+      {/* XP cost hint */}
+      {nextCost && value > MIN_SKILL_VALUE && (
+        <p className="text-xs text-text-theme-secondary">
+          Cost to improve: <span className="text-accent font-medium">{nextCost} XP</span>
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface TemplateSelectorProps {
+  selected: PilotExperienceLevel;
+  onChange: (level: PilotExperienceLevel) => void;
+}
+
+function TemplateSelector({ selected, onChange }: TemplateSelectorProps): React.ReactElement {
+  const levels = Object.values(PilotExperienceLevel);
+  
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {levels.map((level) => {
+        const template = PILOT_TEMPLATES[level];
+        const isSelected = selected === level;
+        
+        return (
+          <button
+            key={level}
+            onClick={() => onChange(level)}
+            className={`
+              p-4 rounded-lg border-2 text-left transition-all duration-200
+              ${isSelected 
+                ? 'border-accent bg-accent/10' 
+                : 'border-border-theme-subtle bg-surface-raised/30 hover:border-border-theme'
+              }
+            `}
+          >
+            <div className="flex items-center justify-between mb-2">
+              <h4 className={`font-semibold ${isSelected ? 'text-accent' : 'text-text-theme-primary'}`}>
+                {template.name}
+              </h4>
+              <span className="text-lg font-bold text-accent tabular-nums">
+                {getPilotRating(template.skills)}
+              </span>
+            </div>
+            <p className="text-xs text-text-theme-secondary mb-2">
+              {template.description}
+            </p>
+            {template.startingXp > 0 && (
+              <Badge variant="amber" size="sm">
+                +{template.startingXp} XP
+              </Badge>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface SkillPreviewProps {
+  skills: IPilotSkills;
+  label?: string;
+  showPointCost?: boolean;
+}
+
+function SkillPreview({ skills, label, showPointCost }: SkillPreviewProps): React.ReactElement {
+  const pointCost = showPointCost ? calculatePointCost(skills) : 0;
+  
+  return (
+    <div className="bg-surface-raised/50 rounded-lg p-4 border border-border-theme-subtle">
+      {label && (
+        <h4 className="text-sm font-medium text-text-theme-secondary mb-3">{label}</h4>
+      )}
+      <div className="flex items-center justify-center gap-8">
+        <div className="text-center">
+          <div className="text-3xl font-bold text-accent tabular-nums">{skills.gunnery}</div>
+          <div className="text-xs text-text-theme-secondary mt-1">Gunnery</div>
+          <Badge variant={skills.gunnery <= 3 ? 'emerald' : skills.gunnery <= 5 ? 'amber' : 'slate'} size="sm" className="mt-2">
+            {getSkillLabel(skills.gunnery)}
+          </Badge>
+        </div>
+        <div className="text-4xl text-border-theme font-light">/</div>
+        <div className="text-center">
+          <div className="text-3xl font-bold text-accent tabular-nums">{skills.piloting}</div>
+          <div className="text-xs text-text-theme-secondary mt-1">Piloting</div>
+          <Badge variant={skills.piloting <= 3 ? 'emerald' : skills.piloting <= 5 ? 'amber' : 'slate'} size="sm" className="mt-2">
+            {getSkillLabel(skills.piloting)}
+          </Badge>
+        </div>
+      </div>
+      {showPointCost && pointCost > 0 && (
+        <div className="text-center mt-4 pt-3 border-t border-border-theme-subtle">
+          <span className="text-sm text-text-theme-secondary">Total XP Investment: </span>
+          <span className="text-lg font-bold text-accent">{pointCost}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// =============================================================================
+// Main Component
+// =============================================================================
+
+export function PilotCreationWizard({
+  isOpen,
+  onClose,
+  onCreated,
+}: PilotCreationWizardProps): React.ReactElement | null {
+  const { createFromTemplate, createRandom, createPilot, createStatblock, isLoading } = usePilotStore();
+  
+  const [state, setState] = useState<WizardState>(INITIAL_STATE);
+  const [currentStep, setCurrentStep] = useState<WizardStep>('mode');
+  const [error, setError] = useState<string | null>(null);
+  
+  // Reset state when modal opens
+  React.useEffect(() => {
+    if (isOpen) {
+      setState(INITIAL_STATE);
+      setCurrentStep('mode');
+      setError(null);
+    }
+  }, [isOpen]);
+  
+  // Get skills for current mode
+  const currentSkills = useMemo((): IPilotSkills => {
+    switch (state.mode) {
+      case 'template':
+        return PILOT_TEMPLATES[state.templateLevel].skills;
+      case 'custom':
+        return state.customSkills;
+      case 'random':
+        return state.randomSkills || DEFAULT_PILOT_SKILLS;
+      case 'statblock':
+        return state.statblockSkills;
+      default:
+        return DEFAULT_PILOT_SKILLS;
+    }
+  }, [state]);
+  
+  // Handlers
+  const handleModeSelect = useCallback((mode: CreationMode) => {
+    setState(prev => ({ ...prev, mode }));
+    
+    // Generate random skills immediately when random mode is selected
+    if (mode === 'random') {
+      setState(prev => ({ ...prev, randomSkills: generateRandomSkills() }));
+    }
+  }, []);
+  
+  const handleIdentityChange = useCallback((field: keyof IPilotIdentity, value: string) => {
+    setState(prev => ({
+      ...prev,
+      identity: { ...prev.identity, [field]: value || undefined },
+    }));
+  }, []);
+  
+  const handleCustomSkillChange = useCallback((skill: keyof IPilotSkills, value: number) => {
+    setState(prev => ({
+      ...prev,
+      customSkills: { ...prev.customSkills, [skill]: value },
+    }));
+  }, []);
+  
+  const handleStatblockSkillChange = useCallback((skill: keyof IPilotSkills, value: number) => {
+    setState(prev => ({
+      ...prev,
+      statblockSkills: { ...prev.statblockSkills, [skill]: value },
+    }));
+  }, []);
+  
+  const handleReroll = useCallback(() => {
+    setState(prev => ({ ...prev, randomSkills: generateRandomSkills() }));
+  }, []);
+  
+  const handleNext = useCallback(() => {
+    setError(null);
+    
+    if (currentStep === 'mode') {
+      if (!state.mode) {
+        setError('Please select a creation mode');
+        return;
+      }
+      setCurrentStep('identity');
+    } else if (currentStep === 'identity') {
+      if (!state.identity.name.trim()) {
+        setError('Pilot name is required');
+        return;
+      }
+      // Statblock mode skips the skills step
+      if (state.mode === 'statblock') {
+        setCurrentStep('review');
+      } else {
+        setCurrentStep('skills');
+      }
+    } else if (currentStep === 'skills') {
+      setCurrentStep('review');
+    }
+  }, [currentStep, state.mode, state.identity.name]);
+  
+  const handleBack = useCallback(() => {
+    setError(null);
+    
+    if (currentStep === 'identity') {
+      setCurrentStep('mode');
+    } else if (currentStep === 'skills') {
+      setCurrentStep('identity');
+    } else if (currentStep === 'review') {
+      if (state.mode === 'statblock') {
+        setCurrentStep('identity');
+      } else {
+        setCurrentStep('skills');
+      }
+    }
+  }, [currentStep, state.mode]);
+  
+  const handleCreate = useCallback(async () => {
+    setError(null);
+    
+    try {
+      let pilotId: string | null = null;
+      
+      switch (state.mode) {
+        case 'template':
+          pilotId = await createFromTemplate(state.templateLevel, state.identity);
+          break;
+          
+        case 'custom':
+          pilotId = await createPilot({
+            identity: state.identity,
+            type: PilotType.Persistent,
+            skills: state.customSkills,
+          });
+          break;
+          
+        case 'random':
+          pilotId = await createRandom(state.identity);
+          break;
+          
+        case 'statblock': {
+          const statblock: IPilotStatblock = {
+            name: state.identity.name,
+            gunnery: state.statblockSkills.gunnery,
+            piloting: state.statblockSkills.piloting,
+          };
+          const pilot = createStatblock(statblock);
+          pilotId = pilot.id;
+          break;
+        }
+      }
+      
+      onCreated?.(pilotId);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create pilot');
+    }
+  }, [state, createFromTemplate, createRandom, createPilot, createStatblock, onCreated, onClose]);
+  
+  // Render step content
+  const renderStepContent = (): React.ReactElement => {
+    switch (currentStep) {
+      case 'mode':
+        return (
+          <div className="space-y-4">
+            <div className="text-center mb-6">
+              <h3 className="text-lg font-semibold text-text-theme-primary">Choose Creation Mode</h3>
+              <p className="text-sm text-text-theme-secondary mt-1">
+                Select how you want to create your pilot
+              </p>
+            </div>
+            
+            <div className="grid grid-cols-2 gap-4">
+              {(Object.keys(MODE_INFO) as CreationMode[]).map((mode) => (
+                <ModeCard
+                  key={mode}
+                  mode={mode}
+                  isSelected={state.mode === mode}
+                  onClick={() => handleModeSelect(mode)}
+                />
+              ))}
+            </div>
+          </div>
+        );
+        
+      case 'identity':
+        return (
+          <div className="space-y-6">
+            <div className="text-center mb-6">
+              <h3 className="text-lg font-semibold text-text-theme-primary">Pilot Identity</h3>
+              <p className="text-sm text-text-theme-secondary mt-1">
+                Enter your pilot&apos;s basic information
+              </p>
+            </div>
+            
+            <div className="space-y-4">
+              <Input
+                label="Name *"
+                placeholder="Enter pilot name"
+                value={state.identity.name}
+                onChange={(e) => handleIdentityChange('name', e.target.value)}
+                autoFocus
+              />
+              
+              <Input
+                label="Callsign"
+                placeholder="Enter callsign (optional)"
+                value={state.identity.callsign || ''}
+                onChange={(e) => handleIdentityChange('callsign', e.target.value)}
+              />
+              
+              <Input
+                label="Affiliation"
+                placeholder="Enter faction/house (optional)"
+                value={state.identity.affiliation || ''}
+                onChange={(e) => handleIdentityChange('affiliation', e.target.value)}
+              />
+              
+              {/* Statblock mode: inline skill entry */}
+              {state.mode === 'statblock' && (
+                <div className="pt-4 border-t border-border-theme-subtle">
+                  <h4 className="text-sm font-medium text-text-theme-secondary mb-4">Combat Skills</h4>
+                  <div className="space-y-4">
+                    <SkillSlider
+                      label="Gunnery"
+                      value={state.statblockSkills.gunnery}
+                      onChange={(v) => handleStatblockSkillChange('gunnery', v)}
+                      improvementCosts={GUNNERY_IMPROVEMENT_COSTS}
+                    />
+                    <SkillSlider
+                      label="Piloting"
+                      value={state.statblockSkills.piloting}
+                      onChange={(v) => handleStatblockSkillChange('piloting', v)}
+                      improvementCosts={PILOTING_IMPROVEMENT_COSTS}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        );
+        
+      case 'skills':
+        return (
+          <div className="space-y-6">
+            <div className="text-center mb-6">
+              <h3 className="text-lg font-semibold text-text-theme-primary">
+                {state.mode === 'template' && 'Select Experience Level'}
+                {state.mode === 'custom' && 'Configure Skills'}
+                {state.mode === 'random' && 'Random Skills'}
+              </h3>
+              <p className="text-sm text-text-theme-secondary mt-1">
+                {state.mode === 'template' && 'Choose a preset skill configuration'}
+                {state.mode === 'custom' && 'Set gunnery and piloting values'}
+                {state.mode === 'random' && 'Your randomly generated pilot skills'}
+              </p>
+            </div>
+            
+            {state.mode === 'template' && (
+              <TemplateSelector
+                selected={state.templateLevel}
+                onChange={(level) => setState(prev => ({ ...prev, templateLevel: level }))}
+              />
+            )}
+            
+            {state.mode === 'custom' && (
+              <div className="space-y-6">
+                <SkillSlider
+                  label="Gunnery"
+                  value={state.customSkills.gunnery}
+                  onChange={(v) => handleCustomSkillChange('gunnery', v)}
+                  improvementCosts={GUNNERY_IMPROVEMENT_COSTS}
+                />
+                <SkillSlider
+                  label="Piloting"
+                  value={state.customSkills.piloting}
+                  onChange={(v) => handleCustomSkillChange('piloting', v)}
+                  improvementCosts={PILOTING_IMPROVEMENT_COSTS}
+                />
+                <SkillPreview skills={state.customSkills} showPointCost />
+              </div>
+            )}
+            
+            {state.mode === 'random' && state.randomSkills && (
+              <div className="space-y-4">
+                <SkillPreview skills={state.randomSkills} label="Generated Skills" />
+                
+                <div className="flex justify-center">
+                  <Button
+                    variant="secondary"
+                    onClick={handleReroll}
+                    leftIcon={
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                      </svg>
+                    }
+                  >
+                    Reroll
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+        
+      case 'review':
+        return (
+          <div className="space-y-6">
+            <div className="text-center mb-6">
+              <h3 className="text-lg font-semibold text-text-theme-primary">Review &amp; Confirm</h3>
+              <p className="text-sm text-text-theme-secondary mt-1">
+                Verify your pilot details before creation
+              </p>
+            </div>
+            
+            {/* Pilot summary card */}
+            <Card variant="accent-left" accentColor="amber" className="p-5">
+              <div className="flex items-start gap-4">
+                {/* Avatar placeholder */}
+                <div className="w-16 h-16 rounded-lg bg-surface-raised flex items-center justify-center flex-shrink-0">
+                  <svg className="w-8 h-8 text-text-theme-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                  </svg>
+                </div>
+                
+                {/* Info */}
+                <div className="flex-1 min-w-0">
+                  <h4 className="text-xl font-bold text-text-theme-primary truncate">
+                    {state.identity.name}
+                  </h4>
+                  {state.identity.callsign && (
+                    <p className="text-accent font-medium">&quot;{state.identity.callsign}&quot;</p>
+                  )}
+                  {state.identity.affiliation && (
+                    <p className="text-sm text-text-theme-secondary mt-1">
+                      {state.identity.affiliation}
+                    </p>
+                  )}
+                  
+                  <div className="flex items-center gap-2 mt-2">
+                    <Badge variant={state.mode === 'statblock' ? 'amber' : 'emerald'} size="sm">
+                      {state.mode === 'statblock' ? 'Statblock' : 'Persistent'}
+                    </Badge>
+                    <Badge variant="slate" size="sm">
+                      {MODE_INFO[state.mode!].title}
+                    </Badge>
+                  </div>
+                </div>
+                
+                {/* Skills */}
+                <div className="text-right flex-shrink-0">
+                  <div className="text-3xl font-bold text-accent tabular-nums">
+                    {getPilotRating(currentSkills)}
+                  </div>
+                  <div className="text-xs text-text-theme-secondary">Gunnery/Piloting</div>
+                </div>
+              </div>
+            </Card>
+            
+            {/* Skills breakdown */}
+            <SkillPreview 
+              skills={currentSkills} 
+              label="Combat Skills" 
+              showPointCost={state.mode === 'custom'}
+            />
+            
+            {/* Warning for statblock */}
+            {state.mode === 'statblock' && (
+              <div className="flex items-start gap-3 p-3 rounded-lg bg-amber-900/20 border border-amber-600/30">
+                <svg className="w-5 h-5 text-amber-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+                <p className="text-sm text-amber-200">
+                  Statblock pilots are not saved to the database. They&apos;re intended for quick NPC creation during gameplay.
+                </p>
+              </div>
+            )}
+          </div>
+        );
+    }
+  };
+  
+  // Navigation buttons
+  const canProceed = currentStep === 'mode' 
+    ? state.mode !== null 
+    : currentStep === 'identity'
+      ? state.identity.name.trim() !== ''
+      : true;
+  
+  return (
+    <ModalOverlay
+      isOpen={isOpen}
+      onClose={onClose}
+      preventClose={isLoading}
+      className="w-[560px] max-h-[85vh] overflow-hidden"
+    >
+      <div className="flex flex-col h-full">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border-theme-subtle bg-surface-deep/50">
+          <div>
+            <h2 className="text-xl font-bold text-text-theme-primary">Create Pilot</h2>
+            <p className="text-sm text-text-theme-secondary">MechWarrior personnel record</p>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={isLoading}
+            className="p-2 text-text-theme-secondary hover:text-text-theme-primary hover:bg-surface-raised rounded-lg transition-colors"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        
+        {/* Step indicator */}
+        <div className="px-6 pt-4 bg-surface-base">
+          <StepIndicator currentStep={currentStep} mode={state.mode} />
+        </div>
+        
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          {renderStepContent()}
+          
+          {/* Error message */}
+          {error && (
+            <div className="mt-4 p-3 rounded-lg bg-red-900/20 border border-red-600/30">
+              <p className="text-sm text-red-400">{error}</p>
+            </div>
+          )}
+        </div>
+        
+        {/* Footer */}
+        <div className="flex items-center justify-between px-6 py-4 border-t border-border-theme-subtle bg-surface-deep/50">
+          <Button
+            variant="ghost"
+            onClick={currentStep === 'mode' ? onClose : handleBack}
+            disabled={isLoading}
+          >
+            {currentStep === 'mode' ? 'Cancel' : 'Back'}
+          </Button>
+          
+          <div className="flex items-center gap-3">
+            {currentStep === 'review' ? (
+              <Button
+                variant="primary"
+                onClick={handleCreate}
+                isLoading={isLoading}
+                leftIcon={
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                  </svg>
+                }
+              >
+                Create Pilot
+              </Button>
+            ) : (
+              <Button
+                variant="primary"
+                onClick={handleNext}
+                disabled={!canProceed}
+                rightIcon={
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                  </svg>
+                }
+              >
+                Continue
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+}
+
+export default PilotCreationWizard;

--- a/src/components/pilots/PilotProgressionPanel.tsx
+++ b/src/components/pilots/PilotProgressionPanel.tsx
@@ -1,0 +1,361 @@
+/**
+ * Pilot Progression Panel
+ * 
+ * Displays pilot XP, skills, and upgrade options.
+ * Allows skill advancement and opens ability purchase modal.
+ * 
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+import React, { useState, useMemo } from 'react';
+import { Button, Badge, Card } from '@/components/ui';
+import { usePilotStore } from '@/stores/usePilotStore';
+import {
+  IPilot,
+  getGunneryImprovementCost,
+  getPilotingImprovementCost,
+  getSkillLabel,
+  getAbility,
+  MIN_SKILL_VALUE,
+} from '@/types/pilot';
+import { AbilityPurchaseModal } from './AbilityPurchaseModal';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface PilotProgressionPanelProps {
+  /** The pilot to display progression for */
+  pilot: IPilot;
+  /** Optional callback when pilot is updated */
+  onUpdate?: () => void;
+}
+
+// =============================================================================
+// Sub-Components
+// =============================================================================
+
+interface SkillUpgradeRowProps {
+  label: string;
+  currentValue: number;
+  xpCost: number | null;
+  availableXp: number;
+  onUpgrade: () => void;
+  isUpgrading: boolean;
+}
+
+function SkillUpgradeRow({
+  label,
+  currentValue,
+  xpCost,
+  availableXp,
+  onUpgrade,
+  isUpgrading,
+}: SkillUpgradeRowProps): React.ReactElement {
+  const skillLabel = getSkillLabel(currentValue);
+  const canAfford = xpCost !== null && availableXp >= xpCost;
+  const isMaxed = currentValue <= MIN_SKILL_VALUE;
+  
+  // Color based on skill level
+  const getSkillColor = (value: number): string => {
+    if (value <= 2) return 'text-emerald-400';
+    if (value <= 3) return 'text-cyan-400';
+    if (value <= 4) return 'text-accent';
+    if (value <= 5) return 'text-orange-400';
+    return 'text-red-400';
+  };
+  
+  const getBadgeVariant = (value: number): 'emerald' | 'cyan' | 'amber' | 'orange' | 'red' => {
+    if (value <= 2) return 'emerald';
+    if (value <= 3) return 'cyan';
+    if (value <= 4) return 'amber';
+    if (value <= 5) return 'orange';
+    return 'red';
+  };
+
+  return (
+    <div className="flex items-center justify-between p-4 bg-surface-raised/30 rounded-lg border border-border-theme-subtle/50 group hover:border-border-theme/50 transition-all">
+      {/* Skill Info */}
+      <div className="flex items-center gap-4">
+        <div className="w-14 h-14 rounded-lg bg-surface-deep/80 flex items-center justify-center border border-border-theme-subtle">
+          <span className={`text-2xl font-bold tabular-nums ${getSkillColor(currentValue)}`}>
+            {currentValue}
+          </span>
+        </div>
+        <div>
+          <div className="flex items-center gap-2">
+            <span className="text-text-theme-primary font-semibold">{label}</span>
+            <Badge variant={getBadgeVariant(currentValue)} size="sm">
+              {skillLabel}
+            </Badge>
+          </div>
+          {!isMaxed && xpCost !== null && (
+            <p className="text-xs text-text-theme-secondary mt-1">
+              Upgrade cost: <span className="text-accent font-medium">{xpCost} XP</span>
+              {currentValue > 1 && (
+                <span className="text-text-theme-muted ml-2">
+                  ({currentValue} &rarr; {currentValue - 1})
+                </span>
+              )}
+            </p>
+          )}
+          {isMaxed && (
+            <p className="text-xs text-emerald-400 mt-1 flex items-center gap-1">
+              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+              </svg>
+              Maximum level reached
+            </p>
+          )}
+        </div>
+      </div>
+      
+      {/* Upgrade Button */}
+      <Button
+        variant={canAfford ? 'primary' : 'secondary'}
+        size="sm"
+        disabled={!canAfford || isMaxed || isUpgrading}
+        onClick={onUpgrade}
+        isLoading={isUpgrading}
+        leftIcon={
+          !isUpgrading && !isMaxed && (
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 10l7-7m0 0l7 7m-7-7v18" />
+            </svg>
+          )
+        }
+      >
+        {isMaxed ? 'Maxed' : canAfford ? 'Upgrade' : 'Need XP'}
+      </Button>
+    </div>
+  );
+}
+
+interface OwnedAbilityCardProps {
+  abilityId: string;
+  acquiredDate: string;
+}
+
+function OwnedAbilityCard({ abilityId, acquiredDate }: OwnedAbilityCardProps): React.ReactElement {
+  const ability = getAbility(abilityId);
+  
+  if (!ability) {
+    return (
+      <div className="p-3 bg-surface-raised/20 rounded-lg border border-border-theme-subtle/30 text-text-theme-muted text-sm">
+        Unknown ability: {abilityId}
+      </div>
+    );
+  }
+  
+  const formattedDate = new Date(acquiredDate).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  return (
+    <div className="p-4 bg-gradient-to-br from-surface-raised/40 to-surface-raised/20 rounded-lg border border-accent/20 hover:border-accent/40 transition-all group">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <h4 className="text-text-theme-primary font-semibold group-hover:text-accent transition-colors">
+            {ability.name}
+          </h4>
+          <p className="text-xs text-text-theme-secondary mt-1 line-clamp-2">
+            {ability.description}
+          </p>
+        </div>
+        <div className="flex-shrink-0">
+          <div className="w-8 h-8 rounded-full bg-accent/20 flex items-center justify-center">
+            <svg className="w-4 h-4 text-accent" fill="currentColor" viewBox="0 0 20 20">
+              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div className="mt-2 pt-2 border-t border-border-theme-subtle/30">
+        <span className="text-xs text-text-theme-muted">
+          Acquired {formattedDate}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Main Component
+// =============================================================================
+
+export function PilotProgressionPanel({
+  pilot,
+  onUpdate,
+}: PilotProgressionPanelProps): React.ReactElement {
+  const { improveGunnery, improvePiloting, error } = usePilotStore();
+  const [isUpgradingGunnery, setIsUpgradingGunnery] = useState(false);
+  const [isUpgradingPiloting, setIsUpgradingPiloting] = useState(false);
+  const [isAbilityModalOpen, setIsAbilityModalOpen] = useState(false);
+  
+  // Calculate XP and costs
+  const availableXp = pilot.career?.xp ?? 0;
+  const totalXpEarned = pilot.career?.totalXpEarned ?? 0;
+  const gunneryCost = getGunneryImprovementCost(pilot.skills.gunnery);
+  const pilotingCost = getPilotingImprovementCost(pilot.skills.piloting);
+  
+  // Owned abilities
+  const ownedAbilities = useMemo(() => pilot.abilities || [], [pilot.abilities]);
+  
+  // Handlers
+  const handleUpgradeGunnery = async () => {
+    setIsUpgradingGunnery(true);
+    const success = await improveGunnery(pilot.id);
+    setIsUpgradingGunnery(false);
+    if (success) {
+      onUpdate?.();
+    }
+  };
+  
+  const handleUpgradePiloting = async () => {
+    setIsUpgradingPiloting(true);
+    const success = await improvePiloting(pilot.id);
+    setIsUpgradingPiloting(false);
+    if (success) {
+      onUpdate?.();
+    }
+  };
+  
+  const handleAbilityPurchased = () => {
+    onUpdate?.();
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* XP Display */}
+      <Card variant="accent-left" accentColor="amber" className="p-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-text-theme-primary flex items-center gap-2">
+              <svg className="w-5 h-5 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+              Experience Points
+            </h3>
+            <p className="text-sm text-text-theme-secondary mt-1">
+              Use XP to improve skills and unlock abilities
+            </p>
+          </div>
+          <div className="text-right">
+            <div className="text-4xl font-bold text-accent tabular-nums">
+              {availableXp}
+            </div>
+            <div className="text-xs text-text-theme-muted mt-1">
+              {totalXpEarned} total earned
+            </div>
+          </div>
+        </div>
+        
+        {/* XP Progress Bar */}
+        <div className="mt-4 pt-4 border-t border-border-theme-subtle/30">
+          <div className="flex justify-between text-xs text-text-theme-secondary mb-2">
+            <span>Available</span>
+            <span>Spent: {totalXpEarned - availableXp} XP</span>
+          </div>
+          <div className="h-2 bg-surface-deep rounded-full overflow-hidden">
+            <div 
+              className="h-full bg-gradient-to-r from-accent to-amber-500 transition-all duration-500"
+              style={{ width: totalXpEarned > 0 ? `${(availableXp / totalXpEarned) * 100}%` : '0%' }}
+            />
+          </div>
+        </div>
+      </Card>
+      
+      {/* Skills Section */}
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-text-theme-primary">Combat Skills</h3>
+          <Badge variant="slate" size="sm">
+            {pilot.skills.gunnery}/{pilot.skills.piloting}
+          </Badge>
+        </div>
+        
+        <div className="space-y-3">
+          <SkillUpgradeRow
+            label="Gunnery"
+            currentValue={pilot.skills.gunnery}
+            xpCost={gunneryCost}
+            availableXp={availableXp}
+            onUpgrade={handleUpgradeGunnery}
+            isUpgrading={isUpgradingGunnery}
+          />
+          
+          <SkillUpgradeRow
+            label="Piloting"
+            currentValue={pilot.skills.piloting}
+            xpCost={pilotingCost}
+            availableXp={availableXp}
+            onUpgrade={handleUpgradePiloting}
+            isUpgrading={isUpgradingPiloting}
+          />
+        </div>
+      </div>
+      
+      {/* Abilities Section */}
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-text-theme-primary">Special Abilities</h3>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => setIsAbilityModalOpen(true)}
+            leftIcon={
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+            }
+          >
+            Browse Abilities
+          </Button>
+        </div>
+        
+        {ownedAbilities.length === 0 ? (
+          <div className="p-8 text-center bg-surface-raised/20 rounded-lg border border-dashed border-border-theme-subtle">
+            <div className="w-12 h-12 mx-auto mb-3 rounded-full bg-surface-raised/50 flex items-center justify-center">
+              <svg className="w-6 h-6 text-text-theme-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+              </svg>
+            </div>
+            <p className="text-text-theme-secondary text-sm">No abilities unlocked yet</p>
+            <p className="text-text-theme-muted text-xs mt-1">
+              Spend XP to learn new combat abilities
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-3">
+            {ownedAbilities.map((ref) => (
+              <OwnedAbilityCard
+                key={ref.abilityId}
+                abilityId={ref.abilityId}
+                acquiredDate={ref.acquiredDate}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+      
+      {/* Error Display */}
+      {error && (
+        <div className="p-4 rounded-lg bg-red-900/20 border border-red-600/30">
+          <p className="text-sm text-red-400">{error}</p>
+        </div>
+      )}
+      
+      {/* Ability Purchase Modal */}
+      <AbilityPurchaseModal
+        isOpen={isAbilityModalOpen}
+        onClose={() => setIsAbilityModalOpen(false)}
+        pilot={pilot}
+        onPurchase={handleAbilityPurchased}
+      />
+    </div>
+  );
+}
+
+export default PilotProgressionPanel;

--- a/src/components/pilots/index.ts
+++ b/src/components/pilots/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Pilots Components Index
+ * Centralized exports for pilot-related UI components.
+ */
+
+export { PilotCreationWizard } from './PilotCreationWizard';
+export { PilotProgressionPanel } from './PilotProgressionPanel';
+export { AbilityPurchaseModal } from './AbilityPurchaseModal';

--- a/src/pages/api/pilots/[id].ts
+++ b/src/pages/api/pilots/[id].ts
@@ -1,0 +1,155 @@
+/**
+ * Pilots API - Single Pilot Operations
+ *
+ * GET /api/pilots/[id] - Get a pilot by ID
+ * PUT /api/pilots/[id] - Update a pilot
+ * DELETE /api/pilots/[id] - Delete a pilot
+ *
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getSQLiteService } from '@/services/persistence/SQLiteService';
+import { getPilotService, IPilotOperationResult } from '@/services/pilots';
+import { IPilot } from '@/types/pilot';
+
+// =============================================================================
+// Response Types
+// =============================================================================
+
+type GetResponse = {
+  pilot: IPilot;
+};
+
+type UpdateResponse = IPilotOperationResult & {
+  pilot?: IPilot;
+};
+
+type DeleteResponse = IPilotOperationResult;
+
+type ErrorResponse = {
+  error: string;
+  code?: string;
+};
+
+// =============================================================================
+// Handler
+// =============================================================================
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<GetResponse | UpdateResponse | DeleteResponse | ErrorResponse>
+): Promise<void> {
+  // Initialize database
+  try {
+    getSQLiteService().initialize();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Database initialization failed';
+    return res.status(500).json({ error: message });
+  }
+
+  const { id } = req.query;
+  if (typeof id !== 'string') {
+    return res.status(400).json({ error: 'Invalid pilot ID' });
+  }
+
+  const pilotService = getPilotService();
+
+  switch (req.method) {
+    case 'GET':
+      return handleGet(pilotService, id, res);
+    case 'PUT':
+      return handlePut(pilotService, id, req, res);
+    case 'DELETE':
+      return handleDelete(pilotService, id, res);
+    default:
+      res.setHeader('Allow', ['GET', 'PUT', 'DELETE']);
+      return res.status(405).json({ error: `Method ${req.method} Not Allowed` });
+  }
+}
+
+/**
+ * GET /api/pilots/[id] - Get a pilot by ID
+ */
+function handleGet(
+  pilotService: ReturnType<typeof getPilotService>,
+  id: string,
+  res: NextApiResponse<GetResponse | ErrorResponse>
+) {
+  try {
+    const pilot = pilotService.getPilot(id);
+
+    if (!pilot) {
+      return res.status(404).json({ error: `Pilot ${id} not found` });
+    }
+
+    return res.status(200).json({ pilot });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to get pilot';
+    return res.status(500).json({ error: message });
+  }
+}
+
+/**
+ * PUT /api/pilots/[id] - Update a pilot
+ */
+function handlePut(
+  pilotService: ReturnType<typeof getPilotService>,
+  id: string,
+  req: NextApiRequest,
+  res: NextApiResponse<UpdateResponse | ErrorResponse>
+) {
+  try {
+    const body = req.body as Partial<IPilot>;
+
+    // Don't allow changing ID, type, or createdAt - extract only mutable fields
+    const {
+      id: _id,
+      type: _type,
+      createdAt: _createdAt,
+      ...updates
+    } = body;
+
+    const result = pilotService.updatePilot(id, updates);
+
+    if (result.success) {
+      const pilot = pilotService.getPilot(id);
+      return res.status(200).json({ ...result, pilot: pilot || undefined });
+    } else {
+      return res.status(400).json({
+        success: false,
+        error: result.error || 'Failed to update pilot',
+        errorCode: result.errorCode,
+      });
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to update pilot';
+    return res.status(500).json({ error: message });
+  }
+}
+
+/**
+ * DELETE /api/pilots/[id] - Delete a pilot
+ */
+function handleDelete(
+  pilotService: ReturnType<typeof getPilotService>,
+  id: string,
+  res: NextApiResponse<DeleteResponse | ErrorResponse>
+) {
+  try {
+    const result = pilotService.deletePilot(id);
+
+    if (result.success) {
+      return res.status(200).json(result);
+    } else {
+      return res.status(404).json({
+        success: false,
+        error: result.error || 'Failed to delete pilot',
+        errorCode: result.errorCode,
+      });
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to delete pilot';
+    return res.status(500).json({ error: message });
+  }
+}

--- a/src/pages/api/pilots/[id]/improve-gunnery.ts
+++ b/src/pages/api/pilots/[id]/improve-gunnery.ts
@@ -1,0 +1,75 @@
+/**
+ * Pilots API - Improve Gunnery
+ *
+ * POST /api/pilots/[id]/improve-gunnery - Improve gunnery skill (enforces XP cost)
+ *
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getSQLiteService } from '@/services/persistence/SQLiteService';
+import { getPilotService } from '@/services/pilots';
+
+type Response = {
+  success: boolean;
+  error?: string;
+  newGunnery?: number;
+  xpSpent?: number;
+  xpRemaining?: number;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Response>
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).json({ success: false, error: `Method ${req.method} Not Allowed` });
+  }
+
+  try {
+    getSQLiteService().initialize();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Database initialization failed';
+    return res.status(500).json({ success: false, error: message });
+  }
+
+  const { id } = req.query;
+  if (typeof id !== 'string') {
+    return res.status(400).json({ success: false, error: 'Invalid pilot ID' });
+  }
+
+  const pilotService = getPilotService();
+
+  // Get pilot before improvement to report XP cost
+  const pilot = pilotService.getPilot(id);
+  if (!pilot) {
+    return res.status(404).json({ success: false, error: `Pilot ${id} not found` });
+  }
+
+  const { canImprove, cost } = pilotService.canImproveGunnery(pilot);
+  if (!canImprove) {
+    const reason = cost === null 
+      ? 'Gunnery is already at maximum (1)'
+      : `Insufficient XP. Need ${cost}, have ${pilot.career?.xp || 0}`;
+    return res.status(400).json({ success: false, error: reason });
+  }
+
+  // Perform improvement (validates and deducts XP in service)
+  const result = pilotService.improveGunnery(id);
+
+  if (result.success) {
+    const updatedPilot = pilotService.getPilot(id);
+    return res.status(200).json({
+      success: true,
+      newGunnery: updatedPilot?.skills.gunnery,
+      xpSpent: cost ?? 0,
+      xpRemaining: updatedPilot?.career?.xp ?? 0,
+    });
+  } else {
+    return res.status(400).json({
+      success: false,
+      error: result.error || 'Failed to improve gunnery',
+    });
+  }
+}

--- a/src/pages/api/pilots/[id]/improve-piloting.ts
+++ b/src/pages/api/pilots/[id]/improve-piloting.ts
@@ -1,0 +1,75 @@
+/**
+ * Pilots API - Improve Piloting
+ *
+ * POST /api/pilots/[id]/improve-piloting - Improve piloting skill (enforces XP cost)
+ *
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getSQLiteService } from '@/services/persistence/SQLiteService';
+import { getPilotService } from '@/services/pilots';
+
+type Response = {
+  success: boolean;
+  error?: string;
+  newPiloting?: number;
+  xpSpent?: number;
+  xpRemaining?: number;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Response>
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).json({ success: false, error: `Method ${req.method} Not Allowed` });
+  }
+
+  try {
+    getSQLiteService().initialize();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Database initialization failed';
+    return res.status(500).json({ success: false, error: message });
+  }
+
+  const { id } = req.query;
+  if (typeof id !== 'string') {
+    return res.status(400).json({ success: false, error: 'Invalid pilot ID' });
+  }
+
+  const pilotService = getPilotService();
+
+  // Get pilot before improvement to report XP cost
+  const pilot = pilotService.getPilot(id);
+  if (!pilot) {
+    return res.status(404).json({ success: false, error: `Pilot ${id} not found` });
+  }
+
+  const { canImprove, cost } = pilotService.canImprovePiloting(pilot);
+  if (!canImprove) {
+    const reason = cost === null 
+      ? 'Piloting is already at maximum (1)'
+      : `Insufficient XP. Need ${cost}, have ${pilot.career?.xp || 0}`;
+    return res.status(400).json({ success: false, error: reason });
+  }
+
+  // Perform improvement (validates and deducts XP in service)
+  const result = pilotService.improvePiloting(id);
+
+  if (result.success) {
+    const updatedPilot = pilotService.getPilot(id);
+    return res.status(200).json({
+      success: true,
+      newPiloting: updatedPilot?.skills.piloting,
+      xpSpent: cost ?? 0,
+      xpRemaining: updatedPilot?.career?.xp ?? 0,
+    });
+  } else {
+    return res.status(400).json({
+      success: false,
+      error: result.error || 'Failed to improve piloting',
+    });
+  }
+}

--- a/src/pages/api/pilots/[id]/purchase-ability.ts
+++ b/src/pages/api/pilots/[id]/purchase-ability.ts
@@ -1,0 +1,127 @@
+/**
+ * Pilots API - Purchase Ability
+ *
+ * POST /api/pilots/[id]/purchase-ability - Purchase an ability (enforces XP cost and prerequisites)
+ *
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getSQLiteService } from '@/services/persistence/SQLiteService';
+import { getPilotService, getPilotRepository } from '@/services/pilots';
+import { getAbility, meetsPrerequisites } from '@/types/pilot';
+
+interface RequestBody {
+  abilityId: string;
+}
+
+type Response = {
+  success: boolean;
+  error?: string;
+  abilityId?: string;
+  xpSpent?: number;
+  xpRemaining?: number;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Response>
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).json({ success: false, error: `Method ${req.method} Not Allowed` });
+  }
+
+  try {
+    getSQLiteService().initialize();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Database initialization failed';
+    return res.status(500).json({ success: false, error: message });
+  }
+
+  const { id } = req.query;
+  if (typeof id !== 'string') {
+    return res.status(400).json({ success: false, error: 'Invalid pilot ID' });
+  }
+
+  const body = req.body as RequestBody;
+  if (!body.abilityId) {
+    return res.status(400).json({ success: false, error: 'Missing abilityId in request body' });
+  }
+
+  const pilotService = getPilotService();
+  const pilotRepository = getPilotRepository();
+
+  // Get pilot
+  const pilot = pilotService.getPilot(id);
+  if (!pilot) {
+    return res.status(404).json({ success: false, error: `Pilot ${id} not found` });
+  }
+
+  // Get ability
+  const ability = getAbility(body.abilityId);
+  if (!ability) {
+    return res.status(400).json({ success: false, error: `Unknown ability: ${body.abilityId}` });
+  }
+
+  // Check if already owned
+  const alreadyOwned = pilot.abilities.some((a) => a.abilityId === body.abilityId);
+  if (alreadyOwned) {
+    return res.status(400).json({ success: false, error: `Pilot already has ability: ${ability.name}` });
+  }
+
+  // Check prerequisites
+  const ownedAbilityIds = pilot.abilities.map((a) => a.abilityId);
+  const prereqCheck = meetsPrerequisites(
+    body.abilityId,
+    pilot.skills.gunnery,
+    pilot.skills.piloting,
+    ownedAbilityIds
+  );
+
+  if (!prereqCheck.meets) {
+    return res.status(400).json({
+      success: false,
+      error: `Prerequisites not met: ${prereqCheck.missing.join(', ')}`,
+    });
+  }
+
+  // Check XP
+  const availableXp = pilot.career?.xp ?? 0;
+  if (availableXp < ability.xpCost) {
+    return res.status(400).json({
+      success: false,
+      error: `Insufficient XP. Need ${ability.xpCost}, have ${availableXp}`,
+    });
+  }
+
+  // Spend XP
+  const spendResult = pilotRepository.spendXp(id, ability.xpCost);
+  if (!spendResult.success) {
+    return res.status(400).json({
+      success: false,
+      error: spendResult.error || 'Failed to spend XP',
+    });
+  }
+
+  // Add ability
+  const addResult = pilotRepository.addAbility(id, body.abilityId);
+  if (!addResult.success) {
+    // Refund XP if ability add failed
+    pilotRepository.addXp(id, ability.xpCost);
+    return res.status(400).json({
+      success: false,
+      error: addResult.error || 'Failed to add ability',
+    });
+  }
+
+  // Get updated pilot for response
+  const updatedPilot = pilotService.getPilot(id);
+
+  return res.status(200).json({
+    success: true,
+    abilityId: body.abilityId,
+    xpSpent: ability.xpCost,
+    xpRemaining: updatedPilot?.career?.xp ?? 0,
+  });
+}

--- a/src/pages/api/pilots/index.ts
+++ b/src/pages/api/pilots/index.ts
@@ -1,0 +1,177 @@
+/**
+ * Pilots API - List and Create
+ *
+ * GET /api/pilots - List all pilots
+ * POST /api/pilots - Create a new pilot
+ *
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getSQLiteService } from '@/services/persistence/SQLiteService';
+import { getPilotService, IPilotOperationResult } from '@/services/pilots';
+import { IPilot, ICreatePilotOptions, PilotExperienceLevel } from '@/types/pilot';
+
+// =============================================================================
+// Response Types
+// =============================================================================
+
+type ListResponse = {
+  pilots: readonly IPilot[];
+  count: number;
+};
+
+type CreateResponse = IPilotOperationResult & {
+  pilot?: IPilot;
+};
+
+type ErrorResponse = {
+  error: string;
+  code?: string;
+};
+
+// =============================================================================
+// Request Types
+// =============================================================================
+
+interface CreatePilotBody {
+  mode: 'full' | 'template' | 'random';
+  // For 'full' mode
+  options?: ICreatePilotOptions;
+  // For 'template' mode
+  template?: PilotExperienceLevel;
+  // For 'template' and 'random' mode
+  identity?: {
+    name: string;
+    callsign?: string;
+    affiliation?: string;
+    portrait?: string;
+    background?: string;
+  };
+}
+
+// =============================================================================
+// Handler
+// =============================================================================
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ListResponse | CreateResponse | ErrorResponse>
+): Promise<void> {
+  // Initialize database
+  try {
+    getSQLiteService().initialize();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Database initialization failed';
+    return res.status(500).json({ error: message });
+  }
+
+  const pilotService = getPilotService();
+
+  switch (req.method) {
+    case 'GET':
+      return handleGet(pilotService, req, res);
+    case 'POST':
+      return handlePost(pilotService, req, res);
+    default:
+      res.setHeader('Allow', ['GET', 'POST']);
+      return res.status(405).json({ error: `Method ${req.method} Not Allowed` });
+  }
+}
+
+/**
+ * GET /api/pilots - List all pilots
+ */
+function handleGet(
+  pilotService: ReturnType<typeof getPilotService>,
+  req: NextApiRequest,
+  res: NextApiResponse<ListResponse | ErrorResponse>
+) {
+  try {
+    const { status } = req.query;
+
+    let pilots: readonly IPilot[];
+    if (status === 'active') {
+      pilots = pilotService.listActivePilots();
+    } else {
+      pilots = pilotService.listPilots();
+    }
+
+    return res.status(200).json({
+      pilots,
+      count: pilots.length,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to list pilots';
+    return res.status(500).json({ error: message });
+  }
+}
+
+/**
+ * POST /api/pilots - Create a new pilot
+ */
+function handlePost(
+  pilotService: ReturnType<typeof getPilotService>,
+  req: NextApiRequest,
+  res: NextApiResponse<CreateResponse | ErrorResponse>
+) {
+  try {
+    const body = req.body as CreatePilotBody;
+
+    if (!body.mode) {
+      return res.status(400).json({
+        error: 'Missing required field: mode (full | template | random)',
+      });
+    }
+
+    let result: IPilotOperationResult;
+
+    switch (body.mode) {
+      case 'full':
+        if (!body.options) {
+          return res.status(400).json({
+            error: 'Missing required field: options (for full mode)',
+          });
+        }
+        result = pilotService.createPilot(body.options);
+        break;
+
+      case 'template':
+        if (!body.template || !body.identity) {
+          return res.status(400).json({
+            error: 'Missing required fields: template, identity (for template mode)',
+          });
+        }
+        result = pilotService.createFromTemplate(body.template, body.identity);
+        break;
+
+      case 'random':
+        if (!body.identity) {
+          return res.status(400).json({
+            error: 'Missing required field: identity (for random mode)',
+          });
+        }
+        result = pilotService.createRandom(body.identity);
+        break;
+
+      default:
+        return res.status(400).json({
+          error: `Invalid mode: ${body.mode}. Must be full, template, or random`,
+        });
+    }
+
+    if (result.success && result.id) {
+      const pilot = pilotService.getPilot(result.id);
+      return res.status(201).json({ ...result, pilot: pilot || undefined });
+    } else {
+      return res.status(400).json({
+        success: false,
+        error: result.error || 'Failed to create pilot',
+        errorCode: result.errorCode,
+      });
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to create pilot';
+    return res.status(500).json({ error: message });
+  }
+}

--- a/src/pages/gameplay/pilots/create.tsx
+++ b/src/pages/gameplay/pilots/create.tsx
@@ -1,0 +1,86 @@
+/**
+ * Pilot Creation Page
+ * Simple page wrapper for the PilotCreationWizard component.
+ */
+import { useState, useCallback } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import { PageLayout, Card, Button } from '@/components/ui';
+import { PilotCreationWizard } from '@/components/pilots';
+
+// =============================================================================
+// Main Page Component
+// =============================================================================
+
+export default function CreatePilotPage(): React.ReactElement {
+  const router = useRouter();
+  const [isWizardOpen, setIsWizardOpen] = useState(true);
+
+  // Handle wizard close (back to roster)
+  const handleClose = useCallback(() => {
+    setIsWizardOpen(false);
+    router.push('/gameplay/pilots');
+  }, [router]);
+
+  // Handle successful pilot creation
+  const handleCreated = useCallback((pilotId: string | null) => {
+    if (pilotId) {
+      // Navigate to the new pilot's detail page
+      router.push(`/gameplay/pilots/${pilotId}`);
+    } else {
+      // If no ID (statblock pilot), go back to roster
+      router.push('/gameplay/pilots');
+    }
+  }, [router]);
+
+  // Handle reopen wizard
+  const handleReopenWizard = useCallback(() => {
+    setIsWizardOpen(true);
+  }, []);
+
+  return (
+    <PageLayout
+      title="Create Pilot"
+      subtitle="Add a new MechWarrior to your roster"
+      backLink="/gameplay/pilots"
+      backLabel="Back to Roster"
+    >
+      {/* Info Card shown when wizard is closed */}
+      {!isWizardOpen && (
+        <Card variant="dark" className="text-center py-12">
+          <div className="w-20 h-20 mx-auto mb-6 rounded-2xl bg-accent/10 flex items-center justify-center">
+            <svg className="w-10 h-10 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+            </svg>
+          </div>
+          
+          <h2 className="text-xl font-bold text-text-theme-primary mb-2">
+            Create a New Pilot
+          </h2>
+          <p className="text-text-theme-secondary mb-6 max-w-md mx-auto">
+            Use the wizard to create a new MechWarrior with customized skills, 
+            or generate one from templates.
+          </p>
+
+          <div className="flex items-center justify-center gap-4">
+            <Button variant="primary" onClick={handleReopenWizard}>
+              Open Creation Wizard
+            </Button>
+            <Link href="/gameplay/pilots">
+              <Button variant="secondary">
+                Return to Roster
+              </Button>
+            </Link>
+          </div>
+        </Card>
+      )}
+
+      {/* Creation Wizard Modal */}
+      <PilotCreationWizard
+        isOpen={isWizardOpen}
+        onClose={handleClose}
+        onCreated={handleCreated}
+      />
+    </PageLayout>
+  );
+}

--- a/src/pages/gameplay/pilots/index.tsx
+++ b/src/pages/gameplay/pilots/index.tsx
@@ -1,0 +1,290 @@
+/**
+ * Pilot Roster Page
+ * Browse, search, and manage all pilots in the roster.
+ */
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import {
+  PageLayout,
+  PageLoading,
+  Card,
+  Input,
+  Button,
+  Badge,
+  EmptyState,
+} from '@/components/ui';
+import { usePilotStore, useFilteredPilots } from '@/stores/usePilotStore';
+import { IPilot, PilotStatus, getPilotRating } from '@/types/pilot';
+
+// =============================================================================
+// Status Badge Component
+// =============================================================================
+
+interface StatusBadgeProps {
+  status: PilotStatus;
+}
+
+function StatusBadge({ status }: StatusBadgeProps): React.ReactElement {
+  const variants: Record<PilotStatus, { variant: 'emerald' | 'amber' | 'orange' | 'red' | 'slate'; label: string }> = {
+    [PilotStatus.Active]: { variant: 'emerald', label: 'Active' },
+    [PilotStatus.Injured]: { variant: 'orange', label: 'Injured' },
+    [PilotStatus.MIA]: { variant: 'amber', label: 'MIA' },
+    [PilotStatus.KIA]: { variant: 'red', label: 'KIA' },
+    [PilotStatus.Retired]: { variant: 'slate', label: 'Retired' },
+  };
+
+  const { variant, label } = variants[status] || { variant: 'slate', label: status };
+
+  return <Badge variant={variant} size="sm">{label}</Badge>;
+}
+
+// =============================================================================
+// Pilot Card Component
+// =============================================================================
+
+interface PilotCardProps {
+  pilot: IPilot;
+}
+
+function PilotCard({ pilot }: PilotCardProps): React.ReactElement {
+  const rating = getPilotRating(pilot.skills);
+  const isInactive = pilot.status === PilotStatus.KIA || pilot.status === PilotStatus.Retired;
+
+  return (
+    <Link href={`/gameplay/pilots/${pilot.id}`}>
+      <div
+        className={`
+          group relative p-5 rounded-xl border-2 transition-all duration-300 cursor-pointer
+          bg-gradient-to-br from-surface-raised/60 to-surface-raised/30
+          ${isInactive
+            ? 'border-border-theme-subtle/50 opacity-60 hover:opacity-80'
+            : 'border-border-theme-subtle hover:border-accent/50 hover:shadow-lg hover:shadow-accent/10'
+          }
+          hover:scale-[1.02] hover:-translate-y-0.5
+        `}
+      >
+        {/* Accent Line */}
+        <div className={`absolute top-0 left-4 right-4 h-0.5 rounded-full transition-all duration-300 ${
+          isInactive ? 'bg-border-theme-subtle' : 'bg-accent/30 group-hover:bg-accent'
+        }`} />
+
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 mb-4">
+          <div className="flex-1 min-w-0">
+            <h3 className="text-lg font-bold text-text-theme-primary truncate group-hover:text-accent transition-colors">
+              {pilot.name}
+            </h3>
+            {pilot.callsign && (
+              <p className="text-accent/80 text-sm font-medium truncate">
+                &quot;{pilot.callsign}&quot;
+              </p>
+            )}
+          </div>
+
+          {/* Skills Display */}
+          <div className="flex-shrink-0 text-right">
+            <div className="text-2xl font-bold text-accent tabular-nums tracking-tight">
+              {rating}
+            </div>
+            <div className="text-[10px] text-text-theme-muted uppercase tracking-wider">
+              G / P
+            </div>
+          </div>
+        </div>
+
+        {/* Stats Row */}
+        <div className="flex items-center justify-between">
+          <StatusBadge status={pilot.status} />
+
+          {pilot.affiliation && (
+            <span className="text-xs text-text-theme-secondary truncate max-w-[120px]">
+              {pilot.affiliation}
+            </span>
+          )}
+        </div>
+
+        {/* Wounds indicator */}
+        {pilot.wounds > 0 && pilot.status !== PilotStatus.KIA && (
+          <div className="mt-3 pt-3 border-t border-border-theme-subtle/50">
+            <div className="flex items-center gap-1.5">
+              <svg className="w-3.5 h-3.5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clipRule="evenodd" />
+              </svg>
+              <span className="text-xs text-red-400 font-medium">
+                {pilot.wounds} wound{pilot.wounds !== 1 ? 's' : ''}
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* Career stats preview */}
+        {pilot.career && pilot.career.missionsCompleted > 0 && (
+          <div className="mt-3 pt-3 border-t border-border-theme-subtle/50 flex items-center gap-4 text-xs text-text-theme-secondary">
+            <span>{pilot.career.missionsCompleted} missions</span>
+            <span>{pilot.career.totalKills} kills</span>
+          </div>
+        )}
+
+        {/* Hover arrow indicator */}
+        <div className="absolute bottom-4 right-4 opacity-0 group-hover:opacity-100 transition-opacity">
+          <svg className="w-5 h-5 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+// =============================================================================
+// Main Page Component
+// =============================================================================
+
+export default function PilotRosterPage(): React.ReactElement {
+  const router = useRouter();
+  const {
+    isLoading,
+    error,
+    loadPilots,
+    showActiveOnly,
+    setShowActiveOnly,
+    searchQuery,
+    setSearchQuery,
+  } = usePilotStore();
+
+  const filteredPilots = useFilteredPilots();
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // Load pilots on mount
+  useEffect(() => {
+    const initialize = async () => {
+      await loadPilots();
+      setIsInitialized(true);
+    };
+    initialize();
+  }, [loadPilots]);
+
+  // Handle search input
+  const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+  }, [setSearchQuery]);
+
+  // Toggle active only filter
+  const handleToggleActive = useCallback(() => {
+    setShowActiveOnly(!showActiveOnly);
+  }, [showActiveOnly, setShowActiveOnly]);
+
+  // Navigate to create page
+  const handleCreatePilot = useCallback(() => {
+    router.push('/gameplay/pilots/create');
+  }, [router]);
+
+  if (!isInitialized || isLoading) {
+    return <PageLoading message="Loading pilot roster..." />;
+  }
+
+  return (
+    <PageLayout
+      title="Pilot Roster"
+      subtitle="Manage your MechWarrior personnel"
+      maxWidth="wide"
+      headerContent={
+        <Button
+          variant="primary"
+          onClick={handleCreatePilot}
+          leftIcon={
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+          }
+        >
+          Create Pilot
+        </Button>
+      }
+    >
+      {/* Filters */}
+      <Card className="mb-6">
+        <div className="flex flex-col sm:flex-row gap-4">
+          {/* Search */}
+          <div className="flex-1">
+            <Input
+              type="text"
+              placeholder="Search by name, callsign, or affiliation..."
+              value={searchQuery}
+              onChange={handleSearchChange}
+              aria-label="Search pilots"
+            />
+          </div>
+
+          {/* Active Only Toggle */}
+          <button
+            onClick={handleToggleActive}
+            className={`
+              flex items-center gap-2 px-4 py-2.5 rounded-lg border-2 transition-all duration-200
+              ${showActiveOnly
+                ? 'bg-accent/10 border-accent text-accent'
+                : 'bg-surface-raised/30 border-border-theme-subtle text-text-theme-secondary hover:border-border-theme'
+              }
+            `}
+          >
+            <div className={`
+              w-5 h-5 rounded border-2 flex items-center justify-center transition-all
+              ${showActiveOnly ? 'bg-accent border-accent' : 'border-current'}
+            `}>
+              {showActiveOnly && (
+                <svg className="w-3 h-3 text-surface-deep" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+            </div>
+            <span className="text-sm font-medium whitespace-nowrap">Active Only</span>
+          </button>
+        </div>
+
+        {/* Results count */}
+        <div className="mt-4 text-sm text-text-theme-secondary">
+          Showing {filteredPilots.length} pilot{filteredPilots.length !== 1 ? 's' : ''}
+          {(searchQuery || showActiveOnly) && (
+            <span className="text-accent ml-1">(filtered)</span>
+          )}
+        </div>
+      </Card>
+
+      {/* Error Display */}
+      {error && (
+        <div className="mb-6 p-4 rounded-lg bg-red-900/20 border border-red-600/30">
+          <p className="text-sm text-red-400">{error}</p>
+        </div>
+      )}
+
+      {/* Pilot Grid */}
+      {filteredPilots.length === 0 ? (
+        <EmptyState
+          icon={
+            <div className="w-16 h-16 mx-auto rounded-full bg-surface-raised/50 flex items-center justify-center">
+              <svg className="w-8 h-8 text-text-theme-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+              </svg>
+            </div>
+          }
+          title={searchQuery || showActiveOnly ? 'No pilots match your filters' : 'No pilots yet'}
+          message={searchQuery || showActiveOnly ? 'Try adjusting your search or filters' : 'Create your first pilot to get started'}
+          action={
+            !searchQuery && !showActiveOnly && (
+              <Button variant="primary" onClick={handleCreatePilot}>
+                Create First Pilot
+              </Button>
+            )
+          }
+        />
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          {filteredPilots.map((pilot) => (
+            <PilotCard key={pilot.id} pilot={pilot} />
+          ))}
+        </div>
+      )}
+    </PageLayout>
+  );
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -31,6 +31,9 @@ export * from './conversion';
 // Re-export asset services
 export * from './assets';
 
+// Re-export pilot services
+export * from './pilots';
+
 // ============================================================================
 // SERVICE REGISTRY
 // ============================================================================
@@ -40,6 +43,7 @@ import { getEquipmentLoader, getEquipmentRegistry, getEquipmentNameMapper } from
 import { getUnitFactory } from './units';
 import { mechBuilderService, validationService, calculationService } from './construction';
 import { getMTFImportService } from './conversion';
+import { getPilotService, getPilotRepository } from './pilots';
 
 /**
  * Centralized service registry for singleton access
@@ -73,6 +77,12 @@ export const services = {
   // Conversion
   conversion: {
     importer: getMTFImportService(),
+  },
+
+  // Pilots
+  pilots: {
+    service: getPilotService(),
+    repository: getPilotRepository(),
   },
 } as const;
 

--- a/src/services/persistence/IndexedDBService.ts
+++ b/src/services/persistence/IndexedDBService.ts
@@ -9,7 +9,7 @@
 import { StorageError } from '../common/errors';
 
 const DB_NAME = 'mekstation';
-const DB_VERSION = 2;  // Bumped for custom-formulas store
+const DB_VERSION = 3;  // Bumped for pilots store
 
 /**
  * Object store names
@@ -18,6 +18,7 @@ export const STORES = {
   CUSTOM_UNITS: 'custom-units',
   UNIT_METADATA: 'unit-metadata',
   CUSTOM_FORMULAS: 'custom-formulas',
+  PILOTS: 'pilots',
 } as const;
 
 type StoreName = typeof STORES[keyof typeof STORES];
@@ -88,6 +89,9 @@ export class IndexedDBService implements IIndexedDBService {
         }
         if (!db.objectStoreNames.contains(STORES.CUSTOM_FORMULAS)) {
           db.createObjectStore(STORES.CUSTOM_FORMULAS);
+        }
+        if (!db.objectStoreNames.contains(STORES.PILOTS)) {
+          db.createObjectStore(STORES.PILOTS);
         }
       };
     });

--- a/src/services/persistence/SQLiteService.ts
+++ b/src/services/persistence/SQLiteService.ts
@@ -99,6 +99,79 @@ const MIGRATIONS: readonly IMigration[] = [
       );
     `,
   },
+  {
+    version: 2,
+    name: 'pilots_schema',
+    up: `
+      -- Pilots table
+      CREATE TABLE IF NOT EXISTS pilots (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        callsign TEXT,
+        affiliation TEXT,
+        portrait TEXT,
+        background TEXT,
+        type TEXT NOT NULL DEFAULT 'persistent',
+        status TEXT NOT NULL DEFAULT 'active',
+        gunnery INTEGER NOT NULL DEFAULT 4,
+        piloting INTEGER NOT NULL DEFAULT 5,
+        wounds INTEGER NOT NULL DEFAULT 0,
+        missions_completed INTEGER NOT NULL DEFAULT 0,
+        victories INTEGER NOT NULL DEFAULT 0,
+        defeats INTEGER NOT NULL DEFAULT 0,
+        draws INTEGER NOT NULL DEFAULT 0,
+        total_kills INTEGER NOT NULL DEFAULT 0,
+        xp INTEGER NOT NULL DEFAULT 0,
+        total_xp_earned INTEGER NOT NULL DEFAULT 0,
+        rank TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      -- Pilot abilities junction table
+      CREATE TABLE IF NOT EXISTS pilot_abilities (
+        id TEXT PRIMARY KEY,
+        pilot_id TEXT NOT NULL,
+        ability_id TEXT NOT NULL,
+        acquired_date TEXT NOT NULL,
+        acquired_game_id TEXT,
+        UNIQUE(pilot_id, ability_id),
+        FOREIGN KEY (pilot_id) REFERENCES pilots(id) ON DELETE CASCADE
+      );
+
+      -- Pilot kill records
+      CREATE TABLE IF NOT EXISTS pilot_kills (
+        id TEXT PRIMARY KEY,
+        pilot_id TEXT NOT NULL,
+        target_id TEXT NOT NULL,
+        target_name TEXT NOT NULL,
+        weapon_used TEXT NOT NULL,
+        kill_date TEXT NOT NULL,
+        game_id TEXT NOT NULL,
+        FOREIGN KEY (pilot_id) REFERENCES pilots(id) ON DELETE CASCADE
+      );
+
+      -- Pilot mission history
+      CREATE TABLE IF NOT EXISTS pilot_missions (
+        id TEXT PRIMARY KEY,
+        pilot_id TEXT NOT NULL,
+        game_id TEXT NOT NULL,
+        mission_name TEXT NOT NULL,
+        mission_date TEXT NOT NULL,
+        outcome TEXT NOT NULL,
+        xp_earned INTEGER NOT NULL DEFAULT 0,
+        kills INTEGER NOT NULL DEFAULT 0,
+        FOREIGN KEY (pilot_id) REFERENCES pilots(id) ON DELETE CASCADE
+      );
+
+      -- Indexes for pilot queries
+      CREATE INDEX IF NOT EXISTS idx_pilots_status ON pilots(status);
+      CREATE INDEX IF NOT EXISTS idx_pilots_affiliation ON pilots(affiliation);
+      CREATE INDEX IF NOT EXISTS idx_pilot_abilities_pilot_id ON pilot_abilities(pilot_id);
+      CREATE INDEX IF NOT EXISTS idx_pilot_kills_pilot_id ON pilot_kills(pilot_id);
+      CREATE INDEX IF NOT EXISTS idx_pilot_missions_pilot_id ON pilot_missions(pilot_id);
+    `,
+  },
 ];
 
 /**

--- a/src/services/pilots/PilotRepository.ts
+++ b/src/services/pilots/PilotRepository.ts
@@ -1,0 +1,666 @@
+/**
+ * Pilot Repository
+ *
+ * Data access layer for pilots stored in SQLite.
+ * Handles CRUD operations for persistent pilots.
+ *
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { getSQLiteService } from '../persistence/SQLiteService';
+import {
+  IPilot,
+  IPilotCareer,
+  IPilotAbilityRef,
+  IKillRecord,
+  IMissionRecord,
+  ICreatePilotOptions,
+  PilotType,
+  PilotStatus,
+  DEFAULT_PILOT_SKILLS,
+} from '@/types/pilot';
+
+// =============================================================================
+// Database Row Types
+// =============================================================================
+
+interface PilotRow {
+  id: string;
+  name: string;
+  callsign: string | null;
+  affiliation: string | null;
+  portrait: string | null;
+  background: string | null;
+  type: string;
+  status: string;
+  gunnery: number;
+  piloting: number;
+  wounds: number;
+  missions_completed: number;
+  victories: number;
+  defeats: number;
+  draws: number;
+  total_kills: number;
+  xp: number;
+  total_xp_earned: number;
+  rank: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface PilotAbilityRow {
+  id: string;
+  pilot_id: string;
+  ability_id: string;
+  acquired_date: string;
+  acquired_game_id: string | null;
+}
+
+interface PilotKillRow {
+  id: string;
+  pilot_id: string;
+  target_id: string;
+  target_name: string;
+  weapon_used: string;
+  kill_date: string;
+  game_id: string;
+}
+
+interface PilotMissionRow {
+  id: string;
+  pilot_id: string;
+  game_id: string;
+  mission_name: string;
+  mission_date: string;
+  outcome: string;
+  xp_earned: number;
+  kills: number;
+}
+
+// =============================================================================
+// Result Types
+// =============================================================================
+
+export enum PilotErrorCode {
+  NOT_FOUND = 'NOT_FOUND',
+  DUPLICATE_NAME = 'DUPLICATE_NAME',
+  VALIDATION_ERROR = 'VALIDATION_ERROR',
+  DATABASE_ERROR = 'DATABASE_ERROR',
+  INSUFFICIENT_XP = 'INSUFFICIENT_XP',
+}
+
+export interface IPilotOperationResult {
+  readonly success: boolean;
+  readonly id?: string;
+  readonly error?: string;
+  readonly errorCode?: PilotErrorCode;
+}
+
+// =============================================================================
+// Repository Interface
+// =============================================================================
+
+export interface IPilotRepository {
+  create(options: ICreatePilotOptions): IPilotOperationResult;
+  update(id: string, updates: Partial<IPilot>): IPilotOperationResult;
+  delete(id: string): IPilotOperationResult;
+  getById(id: string): IPilot | null;
+  list(): readonly IPilot[];
+  listByStatus(status: PilotStatus): readonly IPilot[];
+  exists(id: string): boolean;
+  addAbility(pilotId: string, abilityId: string, gameId?: string): IPilotOperationResult;
+  removeAbility(pilotId: string, abilityId: string): IPilotOperationResult;
+  recordKill(pilotId: string, kill: Omit<IKillRecord, 'date'>): IPilotOperationResult;
+  recordMission(pilotId: string, mission: Omit<IMissionRecord, 'date'>): IPilotOperationResult;
+  addXp(pilotId: string, amount: number): IPilotOperationResult;
+  spendXp(pilotId: string, amount: number): IPilotOperationResult;
+}
+
+// =============================================================================
+// Repository Implementation
+// =============================================================================
+
+export class PilotRepository implements IPilotRepository {
+  /**
+   * Create a new pilot
+   */
+  create(options: ICreatePilotOptions): IPilotOperationResult {
+    const db = getSQLiteService().getDatabase();
+    const now = new Date().toISOString();
+    const id = `pilot-${uuidv4()}`;
+
+    const skills = options.skills || DEFAULT_PILOT_SKILLS;
+
+    try {
+      const insertPilot = db.prepare(`
+        INSERT INTO pilots (
+          id, name, callsign, affiliation, portrait, background,
+          type, status, gunnery, piloting, wounds,
+          missions_completed, victories, defeats, draws, total_kills,
+          xp, total_xp_earned, rank, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+
+      insertPilot.run(
+        id,
+        options.identity.name,
+        options.identity.callsign || null,
+        options.identity.affiliation || null,
+        options.identity.portrait || null,
+        options.identity.background || null,
+        options.type,
+        PilotStatus.Active,
+        skills.gunnery,
+        skills.piloting,
+        0, // wounds
+        0, // missions_completed
+        0, // victories
+        0, // defeats
+        0, // draws
+        0, // total_kills
+        options.startingXp || 0,
+        options.startingXp || 0,
+        options.rank || null,
+        now,
+        now
+      );
+
+      // Add initial abilities if provided
+      if (options.abilityIds && options.abilityIds.length > 0) {
+        const insertAbility = db.prepare(`
+          INSERT INTO pilot_abilities (id, pilot_id, ability_id, acquired_date, acquired_game_id)
+          VALUES (?, ?, ?, ?, NULL)
+        `);
+
+        for (const abilityId of options.abilityIds) {
+          insertAbility.run(uuidv4(), id, abilityId, now);
+        }
+      }
+
+      return { success: true, id };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        error: `Failed to create pilot: ${message}`,
+        errorCode: PilotErrorCode.DATABASE_ERROR,
+      };
+    }
+  }
+
+  /**
+   * Update an existing pilot
+   */
+  update(id: string, updates: Partial<IPilot>): IPilotOperationResult {
+    const db = getSQLiteService().getDatabase();
+    const now = new Date().toISOString();
+
+    if (!this.exists(id)) {
+      return {
+        success: false,
+        error: `Pilot ${id} not found`,
+        errorCode: PilotErrorCode.NOT_FOUND,
+      };
+    }
+
+    try {
+      // Build dynamic update query
+      const fields: string[] = [];
+      const values: unknown[] = [];
+
+      if (updates.name !== undefined) {
+        fields.push('name = ?');
+        values.push(updates.name);
+      }
+      if (updates.callsign !== undefined) {
+        fields.push('callsign = ?');
+        values.push(updates.callsign || null);
+      }
+      if (updates.affiliation !== undefined) {
+        fields.push('affiliation = ?');
+        values.push(updates.affiliation || null);
+      }
+      if (updates.portrait !== undefined) {
+        fields.push('portrait = ?');
+        values.push(updates.portrait || null);
+      }
+      if (updates.background !== undefined) {
+        fields.push('background = ?');
+        values.push(updates.background || null);
+      }
+      if (updates.status !== undefined) {
+        fields.push('status = ?');
+        values.push(updates.status);
+      }
+      if (updates.skills !== undefined) {
+        fields.push('gunnery = ?', 'piloting = ?');
+        values.push(updates.skills.gunnery, updates.skills.piloting);
+      }
+      if (updates.wounds !== undefined) {
+        fields.push('wounds = ?');
+        values.push(updates.wounds);
+      }
+
+      if (fields.length === 0) {
+        return { success: true, id };
+      }
+
+      fields.push('updated_at = ?');
+      values.push(now);
+      values.push(id);
+
+      const sql = `UPDATE pilots SET ${fields.join(', ')} WHERE id = ?`;
+      db.prepare(sql).run(...values);
+
+      return { success: true, id };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        error: `Failed to update pilot: ${message}`,
+        errorCode: PilotErrorCode.DATABASE_ERROR,
+      };
+    }
+  }
+
+  /**
+   * Delete a pilot
+   */
+  delete(id: string): IPilotOperationResult {
+    const db = getSQLiteService().getDatabase();
+
+    if (!this.exists(id)) {
+      return {
+        success: false,
+        error: `Pilot ${id} not found`,
+        errorCode: PilotErrorCode.NOT_FOUND,
+      };
+    }
+
+    try {
+      db.prepare('DELETE FROM pilots WHERE id = ?').run(id);
+      return { success: true, id };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        error: `Failed to delete pilot: ${message}`,
+        errorCode: PilotErrorCode.DATABASE_ERROR,
+      };
+    }
+  }
+
+  /**
+   * Get a pilot by ID
+   */
+  getById(id: string): IPilot | null {
+    const db = getSQLiteService().getDatabase();
+
+    const row = db.prepare('SELECT * FROM pilots WHERE id = ?').get(id) as PilotRow | undefined;
+    if (!row) return null;
+
+    return this.rowToPilot(row);
+  }
+
+  /**
+   * List all pilots
+   */
+  list(): readonly IPilot[] {
+    const db = getSQLiteService().getDatabase();
+
+    const rows = db.prepare('SELECT * FROM pilots ORDER BY name').all() as PilotRow[];
+    return rows.map((row) => this.rowToPilot(row));
+  }
+
+  /**
+   * List pilots by status
+   */
+  listByStatus(status: PilotStatus): readonly IPilot[] {
+    const db = getSQLiteService().getDatabase();
+
+    const rows = db
+      .prepare('SELECT * FROM pilots WHERE status = ? ORDER BY name')
+      .all(status) as PilotRow[];
+    return rows.map((row) => this.rowToPilot(row));
+  }
+
+  /**
+   * Check if a pilot exists
+   */
+  exists(id: string): boolean {
+    const db = getSQLiteService().getDatabase();
+    const result = db.prepare('SELECT 1 FROM pilots WHERE id = ?').get(id);
+    return result !== undefined;
+  }
+
+  /**
+   * Add an ability to a pilot
+   */
+  addAbility(pilotId: string, abilityId: string, gameId?: string): IPilotOperationResult {
+    const db = getSQLiteService().getDatabase();
+    const now = new Date().toISOString();
+
+    if (!this.exists(pilotId)) {
+      return {
+        success: false,
+        error: `Pilot ${pilotId} not found`,
+        errorCode: PilotErrorCode.NOT_FOUND,
+      };
+    }
+
+    try {
+      db.prepare(`
+        INSERT INTO pilot_abilities (id, pilot_id, ability_id, acquired_date, acquired_game_id)
+        VALUES (?, ?, ?, ?, ?)
+      `).run(uuidv4(), pilotId, abilityId, now, gameId || null);
+
+      return { success: true, id: pilotId };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        error: `Failed to add ability: ${message}`,
+        errorCode: PilotErrorCode.DATABASE_ERROR,
+      };
+    }
+  }
+
+  /**
+   * Remove an ability from a pilot
+   */
+  removeAbility(pilotId: string, abilityId: string): IPilotOperationResult {
+    const db = getSQLiteService().getDatabase();
+
+    try {
+      db.prepare('DELETE FROM pilot_abilities WHERE pilot_id = ? AND ability_id = ?').run(
+        pilotId,
+        abilityId
+      );
+      return { success: true, id: pilotId };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        error: `Failed to remove ability: ${message}`,
+        errorCode: PilotErrorCode.DATABASE_ERROR,
+      };
+    }
+  }
+
+  /**
+   * Record a kill for a pilot
+   */
+  recordKill(pilotId: string, kill: Omit<IKillRecord, 'date'>): IPilotOperationResult {
+    const db = getSQLiteService().getDatabase();
+    const now = new Date().toISOString();
+
+    if (!this.exists(pilotId)) {
+      return {
+        success: false,
+        error: `Pilot ${pilotId} not found`,
+        errorCode: PilotErrorCode.NOT_FOUND,
+      };
+    }
+
+    try {
+      // Insert kill record
+      db.prepare(`
+        INSERT INTO pilot_kills (id, pilot_id, target_id, target_name, weapon_used, kill_date, game_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `).run(uuidv4(), pilotId, kill.targetId, kill.targetName, kill.weaponUsed, now, kill.gameId);
+
+      // Update total kills
+      db.prepare(`
+        UPDATE pilots SET total_kills = total_kills + 1, updated_at = ? WHERE id = ?
+      `).run(now, pilotId);
+
+      return { success: true, id: pilotId };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        error: `Failed to record kill: ${message}`,
+        errorCode: PilotErrorCode.DATABASE_ERROR,
+      };
+    }
+  }
+
+  /**
+   * Record a mission for a pilot
+   */
+  recordMission(
+    pilotId: string,
+    mission: Omit<IMissionRecord, 'date'>
+  ): IPilotOperationResult {
+    const db = getSQLiteService().getDatabase();
+    const now = new Date().toISOString();
+
+    if (!this.exists(pilotId)) {
+      return {
+        success: false,
+        error: `Pilot ${pilotId} not found`,
+        errorCode: PilotErrorCode.NOT_FOUND,
+      };
+    }
+
+    try {
+      // Insert mission record
+      db.prepare(`
+        INSERT INTO pilot_missions (id, pilot_id, game_id, mission_name, mission_date, outcome, xp_earned, kills)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        uuidv4(),
+        pilotId,
+        mission.gameId,
+        mission.missionName,
+        now,
+        mission.outcome,
+        mission.xpEarned,
+        mission.kills
+      );
+
+      // Update career stats
+      const outcomeField =
+        mission.outcome === 'victory'
+          ? 'victories'
+          : mission.outcome === 'defeat'
+            ? 'defeats'
+            : 'draws';
+
+      db.prepare(`
+        UPDATE pilots SET 
+          missions_completed = missions_completed + 1,
+          ${outcomeField} = ${outcomeField} + 1,
+          xp = xp + ?,
+          total_xp_earned = total_xp_earned + ?,
+          updated_at = ?
+        WHERE id = ?
+      `).run(mission.xpEarned, mission.xpEarned, now, pilotId);
+
+      return { success: true, id: pilotId };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        error: `Failed to record mission: ${message}`,
+        errorCode: PilotErrorCode.DATABASE_ERROR,
+      };
+    }
+  }
+
+  /**
+   * Add XP to a pilot
+   */
+  addXp(pilotId: string, amount: number): IPilotOperationResult {
+    const db = getSQLiteService().getDatabase();
+    const now = new Date().toISOString();
+
+    if (!this.exists(pilotId)) {
+      return {
+        success: false,
+        error: `Pilot ${pilotId} not found`,
+        errorCode: PilotErrorCode.NOT_FOUND,
+      };
+    }
+
+    try {
+      db.prepare(`
+        UPDATE pilots SET 
+          xp = xp + ?,
+          total_xp_earned = total_xp_earned + ?,
+          updated_at = ?
+        WHERE id = ?
+      `).run(amount, amount, now, pilotId);
+
+      return { success: true, id: pilotId };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        error: `Failed to add XP: ${message}`,
+        errorCode: PilotErrorCode.DATABASE_ERROR,
+      };
+    }
+  }
+
+  /**
+   * Spend XP from a pilot's pool
+   */
+  spendXp(pilotId: string, amount: number): IPilotOperationResult {
+    const db = getSQLiteService().getDatabase();
+    const now = new Date().toISOString();
+
+    const pilot = this.getById(pilotId);
+    if (!pilot) {
+      return {
+        success: false,
+        error: `Pilot ${pilotId} not found`,
+        errorCode: PilotErrorCode.NOT_FOUND,
+      };
+    }
+
+    if (!pilot.career || pilot.career.xp < amount) {
+      return {
+        success: false,
+        error: `Insufficient XP. Have ${pilot.career?.xp || 0}, need ${amount}`,
+        errorCode: PilotErrorCode.INSUFFICIENT_XP,
+      };
+    }
+
+    try {
+      db.prepare(`
+        UPDATE pilots SET xp = xp - ?, updated_at = ? WHERE id = ?
+      `).run(amount, now, pilotId);
+
+      return { success: true, id: pilotId };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        error: `Failed to spend XP: ${message}`,
+        errorCode: PilotErrorCode.DATABASE_ERROR,
+      };
+    }
+  }
+
+  // =============================================================================
+  // Private Helpers
+  // =============================================================================
+
+  /**
+   * Convert a database row to an IPilot object
+   */
+  private rowToPilot(row: PilotRow): IPilot {
+    const db = getSQLiteService().getDatabase();
+
+    // Load abilities
+    const abilityRows = db
+      .prepare('SELECT * FROM pilot_abilities WHERE pilot_id = ?')
+      .all(row.id) as PilotAbilityRow[];
+
+    const abilities: IPilotAbilityRef[] = abilityRows.map((a) => ({
+      abilityId: a.ability_id,
+      acquiredDate: a.acquired_date,
+      acquiredGameId: a.acquired_game_id || undefined,
+    }));
+
+    // Load career data for persistent pilots
+    let career: IPilotCareer | undefined;
+    if (row.type === PilotType.Persistent) {
+      const killRows = db
+        .prepare('SELECT * FROM pilot_kills WHERE pilot_id = ? ORDER BY kill_date DESC')
+        .all(row.id) as PilotKillRow[];
+
+      const missionRows = db
+        .prepare('SELECT * FROM pilot_missions WHERE pilot_id = ? ORDER BY mission_date DESC')
+        .all(row.id) as PilotMissionRow[];
+
+      career = {
+        missionsCompleted: row.missions_completed,
+        victories: row.victories,
+        defeats: row.defeats,
+        draws: row.draws,
+        totalKills: row.total_kills,
+        killRecords: killRows.map((k) => ({
+          targetId: k.target_id,
+          targetName: k.target_name,
+          weaponUsed: k.weapon_used,
+          date: k.kill_date,
+          gameId: k.game_id,
+        })),
+        missionHistory: missionRows.map((m) => ({
+          gameId: m.game_id,
+          missionName: m.mission_name,
+          date: m.mission_date,
+          outcome: m.outcome as 'victory' | 'defeat' | 'draw',
+          xpEarned: m.xp_earned,
+          kills: m.kills,
+        })),
+        xp: row.xp,
+        totalXpEarned: row.total_xp_earned,
+        rank: row.rank || 'MechWarrior',
+      };
+    }
+
+    return {
+      id: row.id,
+      name: row.name,
+      callsign: row.callsign || undefined,
+      affiliation: row.affiliation || undefined,
+      portrait: row.portrait || undefined,
+      background: row.background || undefined,
+      type: row.type as PilotType,
+      status: row.status as PilotStatus,
+      skills: {
+        gunnery: row.gunnery,
+        piloting: row.piloting,
+      },
+      wounds: row.wounds,
+      career,
+      abilities,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+}
+
+// Singleton instance
+let pilotRepositoryInstance: PilotRepository | null = null;
+
+/**
+ * Get or create the PilotRepository singleton
+ */
+export function getPilotRepository(): PilotRepository {
+  if (!pilotRepositoryInstance) {
+    pilotRepositoryInstance = new PilotRepository();
+  }
+  return pilotRepositoryInstance;
+}
+
+/**
+ * Reset the singleton (for testing)
+ */
+export function resetPilotRepository(): void {
+  pilotRepositoryInstance = null;
+}

--- a/src/services/pilots/PilotService.ts
+++ b/src/services/pilots/PilotService.ts
@@ -1,0 +1,511 @@
+/**
+ * Pilot Service
+ *
+ * Business logic layer for pilot operations.
+ * Handles skill advancement, XP calculations, and pilot creation modes.
+ *
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+import {
+  IPilot,
+  ICreatePilotOptions,
+  IPilotIdentity,
+  IPilotStatblock,
+  PilotType,
+  PilotStatus,
+  PilotExperienceLevel,
+  PILOT_TEMPLATES,
+  getGunneryImprovementCost,
+  getPilotingImprovementCost,
+  isValidSkillValue,
+  isValidWoundsValue,
+  MIN_SKILL_VALUE,
+  MAX_SKILL_VALUE,
+  XP_AWARDS,
+} from '@/types/pilot';
+import {
+  getPilotRepository,
+  IPilotOperationResult,
+  PilotErrorCode,
+} from './PilotRepository';
+
+// =============================================================================
+// Service Interface
+// =============================================================================
+
+export interface IPilotService {
+  // CRUD operations
+  createPilot(options: ICreatePilotOptions): IPilotOperationResult;
+  createFromTemplate(
+    level: PilotExperienceLevel,
+    identity: IPilotIdentity
+  ): IPilotOperationResult;
+  createRandom(identity: IPilotIdentity): IPilotOperationResult;
+  createStatblock(statblock: IPilotStatblock): IPilot;
+  updatePilot(id: string, updates: Partial<IPilot>): IPilotOperationResult;
+  deletePilot(id: string): IPilotOperationResult;
+  getPilot(id: string): IPilot | null;
+  listPilots(): readonly IPilot[];
+  listActivePilots(): readonly IPilot[];
+
+  // Skill advancement
+  improveGunnery(pilotId: string): IPilotOperationResult;
+  improvePiloting(pilotId: string): IPilotOperationResult;
+  canImproveGunnery(pilot: IPilot): { canImprove: boolean; cost: number | null };
+  canImprovePiloting(pilot: IPilot): { canImprove: boolean; cost: number | null };
+
+  // XP operations
+  awardMissionXp(
+    pilotId: string,
+    outcome: 'victory' | 'defeat' | 'draw',
+    kills: number,
+    bonuses?: { firstBlood?: boolean; higherBVOpponent?: boolean }
+  ): IPilotOperationResult;
+
+  // Wounds
+  applyWound(pilotId: string): IPilotOperationResult;
+  healWounds(pilotId: string): IPilotOperationResult;
+
+  // Validation
+  validatePilot(pilot: Partial<IPilot>): string[];
+}
+
+// =============================================================================
+// Service Implementation
+// =============================================================================
+
+export class PilotService implements IPilotService {
+  private repo = getPilotRepository();
+
+  // ===========================================================================
+  // CRUD Operations
+  // ===========================================================================
+
+  /**
+   * Create a new pilot with full options
+   */
+  createPilot(options: ICreatePilotOptions): IPilotOperationResult {
+    const errors = this.validateCreateOptions(options);
+    if (errors.length > 0) {
+      return {
+        success: false,
+        error: errors.join('; '),
+        errorCode: PilotErrorCode.VALIDATION_ERROR,
+      };
+    }
+
+    return this.repo.create(options);
+  }
+
+  /**
+   * Create a pilot from a predefined template
+   */
+  createFromTemplate(
+    level: PilotExperienceLevel,
+    identity: IPilotIdentity
+  ): IPilotOperationResult {
+    const template = PILOT_TEMPLATES[level];
+
+    return this.repo.create({
+      identity,
+      type: PilotType.Persistent,
+      skills: template.skills,
+      startingXp: template.startingXp,
+      rank: this.getRankForLevel(level),
+    });
+  }
+
+  /**
+   * Create a pilot with random skills
+   */
+  createRandom(identity: IPilotIdentity): IPilotOperationResult {
+    // Random skills weighted toward Regular (4/5)
+    const gunneryRoll = this.rollSkill();
+    const pilotingRoll = this.rollSkill();
+
+    // Small chance of a bonus ability
+    const hasAbility = Math.random() < 0.2;
+
+    return this.repo.create({
+      identity,
+      type: PilotType.Persistent,
+      skills: { gunnery: gunneryRoll, piloting: pilotingRoll },
+      startingXp: 0,
+      // TODO: Add random ability selection when abilities are implemented
+      abilityIds: hasAbility ? [] : undefined,
+    });
+  }
+
+  /**
+   * Create a statblock pilot (not persisted)
+   */
+  createStatblock(statblock: IPilotStatblock): IPilot {
+    const now = new Date().toISOString();
+
+    return {
+      id: `statblock-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+      name: statblock.name,
+      type: PilotType.Statblock,
+      status: PilotStatus.Active,
+      skills: {
+        gunnery: statblock.gunnery,
+        piloting: statblock.piloting,
+      },
+      wounds: 0,
+      abilities: (statblock.abilityIds || []).map((id) => ({
+        abilityId: id,
+        acquiredDate: now,
+      })),
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  /**
+   * Update a pilot
+   */
+  updatePilot(id: string, updates: Partial<IPilot>): IPilotOperationResult {
+    return this.repo.update(id, updates);
+  }
+
+  /**
+   * Delete a pilot
+   */
+  deletePilot(id: string): IPilotOperationResult {
+    return this.repo.delete(id);
+  }
+
+  /**
+   * Get a pilot by ID
+   */
+  getPilot(id: string): IPilot | null {
+    return this.repo.getById(id);
+  }
+
+  /**
+   * List all pilots
+   */
+  listPilots(): readonly IPilot[] {
+    return this.repo.list();
+  }
+
+  /**
+   * List only active pilots
+   */
+  listActivePilots(): readonly IPilot[] {
+    return this.repo.listByStatus(PilotStatus.Active);
+  }
+
+  // ===========================================================================
+  // Skill Advancement
+  // ===========================================================================
+
+  /**
+   * Check if pilot can improve gunnery
+   */
+  canImproveGunnery(pilot: IPilot): { canImprove: boolean; cost: number | null } {
+    const cost = getGunneryImprovementCost(pilot.skills.gunnery);
+    if (cost === null) {
+      return { canImprove: false, cost: null };
+    }
+
+    const hasXp = pilot.career && pilot.career.xp >= cost;
+    return { canImprove: hasXp || false, cost };
+  }
+
+  /**
+   * Check if pilot can improve piloting
+   */
+  canImprovePiloting(pilot: IPilot): { canImprove: boolean; cost: number | null } {
+    const cost = getPilotingImprovementCost(pilot.skills.piloting);
+    if (cost === null) {
+      return { canImprove: false, cost: null };
+    }
+
+    const hasXp = pilot.career && pilot.career.xp >= cost;
+    return { canImprove: hasXp || false, cost };
+  }
+
+  /**
+   * Improve gunnery skill by spending XP
+   */
+  improveGunnery(pilotId: string): IPilotOperationResult {
+    const pilot = this.repo.getById(pilotId);
+    if (!pilot) {
+      return {
+        success: false,
+        error: `Pilot ${pilotId} not found`,
+        errorCode: PilotErrorCode.NOT_FOUND,
+      };
+    }
+
+    const { canImprove, cost } = this.canImproveGunnery(pilot);
+    if (!canImprove || cost === null) {
+      return {
+        success: false,
+        error: cost === null 
+          ? 'Gunnery is already at maximum (1)'
+          : `Insufficient XP. Need ${cost}, have ${pilot.career?.xp || 0}`,
+        errorCode: cost === null 
+          ? PilotErrorCode.VALIDATION_ERROR 
+          : PilotErrorCode.INSUFFICIENT_XP,
+      };
+    }
+
+    // Spend XP
+    const spendResult = this.repo.spendXp(pilotId, cost);
+    if (!spendResult.success) {
+      return spendResult;
+    }
+
+    // Improve skill
+    return this.repo.update(pilotId, {
+      skills: {
+        gunnery: pilot.skills.gunnery - 1,
+        piloting: pilot.skills.piloting,
+      },
+    });
+  }
+
+  /**
+   * Improve piloting skill by spending XP
+   */
+  improvePiloting(pilotId: string): IPilotOperationResult {
+    const pilot = this.repo.getById(pilotId);
+    if (!pilot) {
+      return {
+        success: false,
+        error: `Pilot ${pilotId} not found`,
+        errorCode: PilotErrorCode.NOT_FOUND,
+      };
+    }
+
+    const { canImprove, cost } = this.canImprovePiloting(pilot);
+    if (!canImprove || cost === null) {
+      return {
+        success: false,
+        error: cost === null 
+          ? 'Piloting is already at maximum (1)'
+          : `Insufficient XP. Need ${cost}, have ${pilot.career?.xp || 0}`,
+        errorCode: cost === null 
+          ? PilotErrorCode.VALIDATION_ERROR 
+          : PilotErrorCode.INSUFFICIENT_XP,
+      };
+    }
+
+    // Spend XP
+    const spendResult = this.repo.spendXp(pilotId, cost);
+    if (!spendResult.success) {
+      return spendResult;
+    }
+
+    // Improve skill
+    return this.repo.update(pilotId, {
+      skills: {
+        gunnery: pilot.skills.gunnery,
+        piloting: pilot.skills.piloting - 1,
+      },
+    });
+  }
+
+  // ===========================================================================
+  // XP Operations
+  // ===========================================================================
+
+  /**
+   * Award XP for completing a mission
+   */
+  awardMissionXp(
+    pilotId: string,
+    outcome: 'victory' | 'defeat' | 'draw',
+    kills: number,
+    bonuses?: { firstBlood?: boolean; higherBVOpponent?: boolean }
+  ): IPilotOperationResult {
+    let totalXp = XP_AWARDS.missionSurvival;
+
+    // Kill XP
+    totalXp += kills * XP_AWARDS.kill;
+
+    // Victory bonus
+    if (outcome === 'victory') {
+      totalXp += XP_AWARDS.victoryBonus;
+    }
+
+    // Optional bonuses
+    if (bonuses?.firstBlood) {
+      totalXp += XP_AWARDS.firstBlood;
+    }
+    if (bonuses?.higherBVOpponent) {
+      totalXp += XP_AWARDS.higherBVOpponent;
+    }
+
+    // Record the mission (this also adds XP)
+    return this.repo.recordMission(pilotId, {
+      gameId: `mission-${Date.now()}`,
+      missionName: 'Combat Mission',
+      outcome,
+      xpEarned: totalXp,
+      kills,
+    });
+  }
+
+  // ===========================================================================
+  // Wounds
+  // ===========================================================================
+
+  /**
+   * Apply a wound to a pilot
+   */
+  applyWound(pilotId: string): IPilotOperationResult {
+    const pilot = this.repo.getById(pilotId);
+    if (!pilot) {
+      return {
+        success: false,
+        error: `Pilot ${pilotId} not found`,
+        errorCode: PilotErrorCode.NOT_FOUND,
+      };
+    }
+
+    const newWounds = pilot.wounds + 1;
+
+    // Check for death
+    if (newWounds >= 6) {
+      return this.repo.update(pilotId, {
+        wounds: 6,
+        status: PilotStatus.KIA,
+      });
+    }
+
+    // Check for injured status
+    const newStatus = newWounds >= 3 ? PilotStatus.Injured : pilot.status;
+
+    return this.repo.update(pilotId, {
+      wounds: newWounds,
+      status: newStatus,
+    });
+  }
+
+  /**
+   * Heal all wounds (between games)
+   */
+  healWounds(pilotId: string): IPilotOperationResult {
+    const pilot = this.repo.getById(pilotId);
+    if (!pilot) {
+      return {
+        success: false,
+        error: `Pilot ${pilotId} not found`,
+        errorCode: PilotErrorCode.NOT_FOUND,
+      };
+    }
+
+    // Can't heal the dead
+    if (pilot.status === PilotStatus.KIA) {
+      return {
+        success: false,
+        error: 'Cannot heal a KIA pilot',
+        errorCode: PilotErrorCode.VALIDATION_ERROR,
+      };
+    }
+
+    return this.repo.update(pilotId, {
+      wounds: 0,
+      status: PilotStatus.Active,
+    });
+  }
+
+  // ===========================================================================
+  // Validation
+  // ===========================================================================
+
+  /**
+   * Validate pilot data
+   */
+  validatePilot(pilot: Partial<IPilot>): string[] {
+    const errors: string[] = [];
+
+    if (pilot.skills) {
+      if (!isValidSkillValue(pilot.skills.gunnery)) {
+        errors.push(`Gunnery must be between ${MIN_SKILL_VALUE} and ${MAX_SKILL_VALUE}`);
+      }
+      if (!isValidSkillValue(pilot.skills.piloting)) {
+        errors.push(`Piloting must be between ${MIN_SKILL_VALUE} and ${MAX_SKILL_VALUE}`);
+      }
+    }
+
+    if (pilot.wounds !== undefined && !isValidWoundsValue(pilot.wounds)) {
+      errors.push('Wounds must be between 0 and 6');
+    }
+
+    if (pilot.name !== undefined && pilot.name.trim().length === 0) {
+      errors.push('Pilot name is required');
+    }
+
+    return errors;
+  }
+
+  // ===========================================================================
+  // Private Helpers
+  // ===========================================================================
+
+  private validateCreateOptions(options: ICreatePilotOptions): string[] {
+    const errors: string[] = [];
+
+    if (!options.identity.name || options.identity.name.trim().length === 0) {
+      errors.push('Pilot name is required');
+    }
+
+    if (options.skills) {
+      if (!isValidSkillValue(options.skills.gunnery)) {
+        errors.push(`Gunnery must be between ${MIN_SKILL_VALUE} and ${MAX_SKILL_VALUE}`);
+      }
+      if (!isValidSkillValue(options.skills.piloting)) {
+        errors.push(`Piloting must be between ${MIN_SKILL_VALUE} and ${MAX_SKILL_VALUE}`);
+      }
+    }
+
+    return errors;
+  }
+
+  private rollSkill(): number {
+    // Weighted roll: mostly 4-5, occasionally 3 or 6
+    const roll = Math.random();
+    if (roll < 0.1) return 3; // 10% veteran
+    if (roll < 0.3) return 6; // 20% untrained
+    if (roll < 0.6) return 5; // 30% green
+    return 4; // 40% regular
+  }
+
+  private getRankForLevel(level: PilotExperienceLevel): string {
+    switch (level) {
+      case PilotExperienceLevel.Green:
+        return 'Cadet';
+      case PilotExperienceLevel.Regular:
+        return 'MechWarrior';
+      case PilotExperienceLevel.Veteran:
+        return 'Sergeant';
+      case PilotExperienceLevel.Elite:
+        return 'Lieutenant';
+    }
+  }
+}
+
+// Singleton instance
+let pilotServiceInstance: PilotService | null = null;
+
+/**
+ * Get or create the PilotService singleton
+ */
+export function getPilotService(): PilotService {
+  if (!pilotServiceInstance) {
+    pilotServiceInstance = new PilotService();
+  }
+  return pilotServiceInstance;
+}
+
+/**
+ * Reset the singleton (for testing)
+ */
+export function resetPilotService(): void {
+  pilotServiceInstance = null;
+}

--- a/src/services/pilots/index.ts
+++ b/src/services/pilots/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Pilots Services Barrel Export
+ *
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+export * from './PilotRepository';
+export * from './PilotService';

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -30,3 +30,6 @@ export * from './useUIBehaviorStore';
 // Navigation
 export * from './useNavigationStore';
 
+// Pilots
+export * from './usePilotStore';
+

--- a/src/stores/usePilotStore.ts
+++ b/src/stores/usePilotStore.ts
@@ -1,0 +1,484 @@
+/**
+ * Pilot Store
+ *
+ * Zustand store for managing pilot state in the UI.
+ * Uses API routes for persistence to avoid bundling SQLite in the browser.
+ *
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+import { create } from 'zustand';
+import {
+  IPilot,
+  IPilotStatblock,
+  PilotStatus,
+  PilotExperienceLevel,
+  IPilotIdentity,
+  ICreatePilotOptions,
+  PilotType,
+} from '@/types/pilot';
+
+// =============================================================================
+// API Response Types
+// =============================================================================
+
+interface ListPilotsResponse {
+  pilots: IPilot[];
+  count: number;
+}
+
+interface CreatePilotResponse {
+  success: boolean;
+  id?: string;
+  pilot?: IPilot;
+  error?: string;
+}
+
+interface UpdatePilotResponse {
+  success: boolean;
+  pilot?: IPilot;
+  error?: string;
+}
+
+interface DeletePilotResponse {
+  success: boolean;
+  error?: string;
+}
+
+// =============================================================================
+// Store State
+// =============================================================================
+
+interface PilotStoreState {
+  /** All loaded pilots */
+  pilots: IPilot[];
+  /** Currently selected pilot ID */
+  selectedPilotId: string | null;
+  /** Loading state */
+  isLoading: boolean;
+  /** Error message */
+  error: string | null;
+  /** Filter: show only active pilots */
+  showActiveOnly: boolean;
+  /** Search query */
+  searchQuery: string;
+}
+
+interface PilotStoreActions {
+  /** Load all pilots from API */
+  loadPilots: () => Promise<void>;
+  /** Create a new pilot */
+  createPilot: (options: ICreatePilotOptions) => Promise<string | null>;
+  /** Create pilot from template */
+  createFromTemplate: (
+    level: PilotExperienceLevel,
+    identity: IPilotIdentity
+  ) => Promise<string | null>;
+  /** Create random pilot */
+  createRandom: (identity: IPilotIdentity) => Promise<string | null>;
+  /** Create statblock pilot (not persisted) */
+  createStatblock: (statblock: IPilotStatblock) => IPilot;
+  /** Update a pilot */
+  updatePilot: (id: string, updates: Partial<IPilot>) => Promise<boolean>;
+  /** Delete a pilot */
+  deletePilot: (id: string) => Promise<boolean>;
+  /** Select a pilot */
+  selectPilot: (id: string | null) => void;
+  /** Get selected pilot */
+  getSelectedPilot: () => IPilot | null;
+  /** Improve gunnery skill */
+  improveGunnery: (pilotId: string) => Promise<boolean>;
+  /** Improve piloting skill */
+  improvePiloting: (pilotId: string) => Promise<boolean>;
+  /** Apply wound to pilot */
+  applyWound: (pilotId: string) => Promise<boolean>;
+  /** Heal pilot wounds */
+  healWounds: (pilotId: string) => Promise<boolean>;
+  /** Purchase an ability for a pilot */
+  purchaseAbility: (pilotId: string, abilityId: string, xpCost: number) => Promise<boolean>;
+  /** Set filter */
+  setShowActiveOnly: (value: boolean) => void;
+  /** Set search query */
+  setSearchQuery: (query: string) => void;
+  /** Clear error */
+  clearError: () => void;
+}
+
+type PilotStore = PilotStoreState & PilotStoreActions;
+
+// =============================================================================
+// Store Implementation
+// =============================================================================
+
+export const usePilotStore = create<PilotStore>((set, get) => ({
+  // Initial state
+  pilots: [],
+  selectedPilotId: null,
+  isLoading: false,
+  error: null,
+  showActiveOnly: false,
+  searchQuery: '',
+
+  // Actions
+  loadPilots: async () => {
+    set({ isLoading: true, error: null });
+
+    try {
+      const response = await fetch('/api/pilots');
+      if (!response.ok) {
+        throw new Error(`Failed to load pilots: ${response.statusText}`);
+      }
+      const data = (await response.json()) as ListPilotsResponse;
+      set({ pilots: data.pilots, isLoading: false });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to load pilots';
+      set({ error: message, isLoading: false });
+    }
+  },
+
+  createPilot: async (options) => {
+    set({ isLoading: true, error: null });
+
+    try {
+      const response = await fetch('/api/pilots', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode: 'full', options }),
+      });
+
+      const data = (await response.json()) as CreatePilotResponse;
+
+      if (data.success && data.id) {
+        await get().loadPilots();
+        set({ selectedPilotId: data.id, isLoading: false });
+        return data.id;
+      } else {
+        set({ error: data.error || 'Failed to create pilot', isLoading: false });
+        return null;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to create pilot';
+      set({ error: message, isLoading: false });
+      return null;
+    }
+  },
+
+  createFromTemplate: async (level, identity) => {
+    set({ isLoading: true, error: null });
+
+    try {
+      const response = await fetch('/api/pilots', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode: 'template', template: level, identity }),
+      });
+
+      const data = (await response.json()) as CreatePilotResponse;
+
+      if (data.success && data.id) {
+        await get().loadPilots();
+        set({ selectedPilotId: data.id, isLoading: false });
+        return data.id;
+      } else {
+        set({ error: data.error || 'Failed to create pilot', isLoading: false });
+        return null;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to create pilot';
+      set({ error: message, isLoading: false });
+      return null;
+    }
+  },
+
+  createRandom: async (identity) => {
+    set({ isLoading: true, error: null });
+
+    try {
+      const response = await fetch('/api/pilots', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode: 'random', identity }),
+      });
+
+      const data = (await response.json()) as CreatePilotResponse;
+
+      if (data.success && data.id) {
+        await get().loadPilots();
+        set({ selectedPilotId: data.id, isLoading: false });
+        return data.id;
+      } else {
+        set({ error: data.error || 'Failed to create pilot', isLoading: false });
+        return null;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to create pilot';
+      set({ error: message, isLoading: false });
+      return null;
+    }
+  },
+
+  createStatblock: (statblock) => {
+    // Statblocks are not persisted, just create in memory
+    const now = new Date().toISOString();
+    return {
+      id: `statblock-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+      name: statblock.name,
+      type: PilotType.Statblock,
+      status: PilotStatus.Active,
+      skills: {
+        gunnery: statblock.gunnery,
+        piloting: statblock.piloting,
+      },
+      wounds: 0,
+      abilities: (statblock.abilityIds || []).map((id) => ({
+        abilityId: id,
+        acquiredDate: now,
+      })),
+      createdAt: now,
+      updatedAt: now,
+    };
+  },
+
+  updatePilot: async (id, updates) => {
+    set({ error: null });
+
+    try {
+      const response = await fetch(`/api/pilots/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updates),
+      });
+
+      const data = (await response.json()) as UpdatePilotResponse;
+
+      if (data.success) {
+        await get().loadPilots();
+        return true;
+      } else {
+        set({ error: data.error || 'Failed to update pilot' });
+        return false;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to update pilot';
+      set({ error: message });
+      return false;
+    }
+  },
+
+  deletePilot: async (id) => {
+    set({ error: null });
+
+    try {
+      const response = await fetch(`/api/pilots/${id}`, {
+        method: 'DELETE',
+      });
+
+      const data = (await response.json()) as DeletePilotResponse;
+
+      if (data.success) {
+        const { selectedPilotId } = get();
+        if (selectedPilotId === id) {
+          set({ selectedPilotId: null });
+        }
+        await get().loadPilots();
+        return true;
+      } else {
+        set({ error: data.error || 'Failed to delete pilot' });
+        return false;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to delete pilot';
+      set({ error: message });
+      return false;
+    }
+  },
+
+  selectPilot: (id) => {
+    set({ selectedPilotId: id });
+  },
+
+  getSelectedPilot: () => {
+    const { pilots, selectedPilotId } = get();
+    if (!selectedPilotId) return null;
+    return pilots.find((p) => p.id === selectedPilotId) || null;
+  },
+
+  improveGunnery: async (pilotId) => {
+    set({ error: null });
+
+    try {
+      const pilot = get().pilots.find((p) => p.id === pilotId);
+      if (!pilot) {
+        set({ error: 'Pilot not found' });
+        return false;
+      }
+
+      // Update skills via API
+      const newSkills = {
+        ...pilot.skills,
+        gunnery: pilot.skills.gunnery - 1,
+      };
+
+      return get().updatePilot(pilotId, { skills: newSkills });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to improve gunnery';
+      set({ error: message });
+      return false;
+    }
+  },
+
+  improvePiloting: async (pilotId) => {
+    set({ error: null });
+
+    try {
+      const pilot = get().pilots.find((p) => p.id === pilotId);
+      if (!pilot) {
+        set({ error: 'Pilot not found' });
+        return false;
+      }
+
+      // Update skills via API
+      const newSkills = {
+        ...pilot.skills,
+        piloting: pilot.skills.piloting - 1,
+      };
+
+      return get().updatePilot(pilotId, { skills: newSkills });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to improve piloting';
+      set({ error: message });
+      return false;
+    }
+  },
+
+  applyWound: async (pilotId) => {
+    set({ error: null });
+
+    try {
+      const pilot = get().pilots.find((p) => p.id === pilotId);
+      if (!pilot) {
+        set({ error: 'Pilot not found' });
+        return false;
+      }
+
+      const newWounds = pilot.wounds + 1;
+
+      // Check for death or injury status
+      let newStatus = pilot.status;
+      if (newWounds >= 6) {
+        newStatus = PilotStatus.KIA;
+      } else if (newWounds >= 3) {
+        newStatus = PilotStatus.Injured;
+      }
+
+      return get().updatePilot(pilotId, { wounds: newWounds, status: newStatus });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to apply wound';
+      set({ error: message });
+      return false;
+    }
+  },
+
+  healWounds: async (pilotId) => {
+    set({ error: null });
+
+    try {
+      const pilot = get().pilots.find((p) => p.id === pilotId);
+      if (!pilot) {
+        set({ error: 'Pilot not found' });
+        return false;
+      }
+
+      if (pilot.status === PilotStatus.KIA) {
+        set({ error: 'Cannot heal a KIA pilot' });
+        return false;
+      }
+
+      return get().updatePilot(pilotId, {
+        wounds: 0,
+        status: PilotStatus.Active,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to heal wounds';
+      set({ error: message });
+      return false;
+    }
+  },
+
+  purchaseAbility: async (pilotId, abilityId, _xpCost) => {
+    set({ error: null });
+
+    try {
+      const pilot = get().pilots.find((p) => p.id === pilotId);
+      if (!pilot) {
+        set({ error: 'Pilot not found' });
+        return false;
+      }
+
+      // Add ability to pilot's list
+      const now = new Date().toISOString();
+      const newAbilities = [
+        ...pilot.abilities,
+        { abilityId, acquiredDate: now },
+      ];
+
+      return get().updatePilot(pilotId, { abilities: newAbilities } as Partial<IPilot>);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to purchase ability';
+      set({ error: message });
+      return false;
+    }
+  },
+
+  setShowActiveOnly: (value) => {
+    set({ showActiveOnly: value });
+  },
+
+  setSearchQuery: (query) => {
+    set({ searchQuery: query });
+  },
+
+  clearError: () => {
+    set({ error: null });
+  },
+}));
+
+// =============================================================================
+// Selectors
+// =============================================================================
+
+/**
+ * Get filtered pilots based on current filters.
+ */
+export function useFilteredPilots(): IPilot[] {
+  const { pilots, showActiveOnly, searchQuery } = usePilotStore();
+
+  let filtered = pilots;
+
+  // Filter by status
+  if (showActiveOnly) {
+    filtered = filtered.filter((p) => p.status === PilotStatus.Active);
+  }
+
+  // Filter by search query
+  if (searchQuery.trim()) {
+    const query = searchQuery.toLowerCase();
+    filtered = filtered.filter(
+      (p) =>
+        p.name.toLowerCase().includes(query) ||
+        p.callsign?.toLowerCase().includes(query) ||
+        p.affiliation?.toLowerCase().includes(query)
+    );
+  }
+
+  return filtered;
+}
+
+/**
+ * Get a pilot by ID.
+ */
+export function usePilotById(id: string | null): IPilot | null {
+  const pilots = usePilotStore((state) => state.pilots);
+  if (!id) return null;
+  return pilots.find((p) => p.id === id) || null;
+}

--- a/src/stores/usePilotStore.ts
+++ b/src/stores/usePilotStore.ts
@@ -307,19 +307,20 @@ export const usePilotStore = create<PilotStore>((set, get) => ({
     set({ error: null });
 
     try {
-      const pilot = get().pilots.find((p) => p.id === pilotId);
-      if (!pilot) {
-        set({ error: 'Pilot not found' });
+      // Call dedicated endpoint that enforces XP cost via service
+      const response = await fetch(`/api/pilots/${pilotId}/improve-gunnery`, {
+        method: 'POST',
+      });
+
+      const data = (await response.json()) as { success: boolean; error?: string };
+
+      if (data.success) {
+        await get().loadPilots();
+        return true;
+      } else {
+        set({ error: data.error || 'Failed to improve gunnery' });
         return false;
       }
-
-      // Update skills via API
-      const newSkills = {
-        ...pilot.skills,
-        gunnery: pilot.skills.gunnery - 1,
-      };
-
-      return get().updatePilot(pilotId, { skills: newSkills });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to improve gunnery';
       set({ error: message });
@@ -331,19 +332,20 @@ export const usePilotStore = create<PilotStore>((set, get) => ({
     set({ error: null });
 
     try {
-      const pilot = get().pilots.find((p) => p.id === pilotId);
-      if (!pilot) {
-        set({ error: 'Pilot not found' });
+      // Call dedicated endpoint that enforces XP cost via service
+      const response = await fetch(`/api/pilots/${pilotId}/improve-piloting`, {
+        method: 'POST',
+      });
+
+      const data = (await response.json()) as { success: boolean; error?: string };
+
+      if (data.success) {
+        await get().loadPilots();
+        return true;
+      } else {
+        set({ error: data.error || 'Failed to improve piloting' });
         return false;
       }
-
-      // Update skills via API
-      const newSkills = {
-        ...pilot.skills,
-        piloting: pilot.skills.piloting - 1,
-      };
-
-      return get().updatePilot(pilotId, { skills: newSkills });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to improve piloting';
       set({ error: message });
@@ -409,20 +411,21 @@ export const usePilotStore = create<PilotStore>((set, get) => ({
     set({ error: null });
 
     try {
-      const pilot = get().pilots.find((p) => p.id === pilotId);
-      if (!pilot) {
-        set({ error: 'Pilot not found' });
+      const response = await fetch(`/api/pilots/${pilotId}/purchase-ability`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ abilityId }),
+      });
+
+      const data = (await response.json()) as { success: boolean; error?: string };
+
+      if (data.success) {
+        await get().loadPilots();
+        return true;
+      } else {
+        set({ error: data.error || 'Failed to purchase ability' });
         return false;
       }
-
-      // Add ability to pilot's list
-      const now = new Date().toISOString();
-      const newAbilities = [
-        ...pilot.abilities,
-        { abilityId, acquiredDate: now },
-      ];
-
-      return get().updatePilot(pilotId, { abilities: newAbilities } as Partial<IPilot>);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to purchase ability';
       set({ error: message });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,3 +26,6 @@ export * from './unit';
 // Temporal types - only export non-conflicting items
 // (Era is already exported from enums)
 export type { EraDefinition } from './temporal';
+
+// Pilot types (spec-driven implementation)
+export * from './pilot';

--- a/src/types/pilot/PilotConstants.ts
+++ b/src/types/pilot/PilotConstants.ts
@@ -1,0 +1,228 @@
+/**
+ * Pilot System Constants
+ * XP costs, skill limits, and other game constants for the pilot system.
+ *
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+import {
+  IPilotSkills,
+  IPilotTemplate,
+  PilotExperienceLevel,
+} from './PilotInterfaces';
+
+// =============================================================================
+// Skill Constants
+// =============================================================================
+
+/** Minimum skill value (best possible) */
+export const MIN_SKILL_VALUE = 1;
+
+/** Maximum skill value (worst possible) */
+export const MAX_SKILL_VALUE = 8;
+
+/** Default gunnery skill for new pilots */
+export const DEFAULT_GUNNERY = 4;
+
+/** Default piloting skill for new pilots */
+export const DEFAULT_PILOTING = 5;
+
+/** Default skills for a new pilot */
+export const DEFAULT_PILOT_SKILLS: IPilotSkills = {
+  gunnery: DEFAULT_GUNNERY,
+  piloting: DEFAULT_PILOTING,
+};
+
+// =============================================================================
+// Wound Constants
+// =============================================================================
+
+/** Maximum wounds before death */
+export const MAX_WOUNDS = 6;
+
+/** Skill penalty per wound */
+export const WOUND_SKILL_PENALTY = 1;
+
+// =============================================================================
+// XP Constants
+// =============================================================================
+
+/**
+ * XP awarded for various actions.
+ */
+export const XP_AWARDS = {
+  /** XP for surviving a mission */
+  missionSurvival: 10,
+  /** XP per kill */
+  kill: 15,
+  /** Bonus XP for mission victory */
+  victoryBonus: 10,
+  /** Bonus XP for first blood */
+  firstBlood: 5,
+  /** Bonus XP for defeating higher BV opponent */
+  higherBVOpponent: 5,
+} as const;
+
+/**
+ * XP costs to improve gunnery skill.
+ * Key is the current skill level, value is cost to improve by 1.
+ */
+export const GUNNERY_IMPROVEMENT_COSTS: Record<number, number> = {
+  8: 50,
+  7: 75,
+  6: 100,
+  5: 100,
+  4: 200,
+  3: 400,
+  2: 800,
+  // 1 is the best, cannot improve further
+};
+
+/**
+ * XP costs to improve piloting skill.
+ * Key is the current skill level, value is cost to improve by 1.
+ */
+export const PILOTING_IMPROVEMENT_COSTS: Record<number, number> = {
+  8: 40,
+  7: 60,
+  6: 75,
+  5: 75,
+  4: 150,
+  3: 300,
+  2: 600,
+  // 1 is the best, cannot improve further
+};
+
+/**
+ * Get XP cost to improve gunnery from current level.
+ * @returns XP cost, or null if cannot improve
+ */
+export function getGunneryImprovementCost(currentLevel: number): number | null {
+  if (currentLevel <= MIN_SKILL_VALUE) return null;
+  return GUNNERY_IMPROVEMENT_COSTS[currentLevel] ?? null;
+}
+
+/**
+ * Get XP cost to improve piloting from current level.
+ * @returns XP cost, or null if cannot improve
+ */
+export function getPilotingImprovementCost(currentLevel: number): number | null {
+  if (currentLevel <= MIN_SKILL_VALUE) return null;
+  return PILOTING_IMPROVEMENT_COSTS[currentLevel] ?? null;
+}
+
+// =============================================================================
+// Pilot Templates
+// =============================================================================
+
+/**
+ * Predefined pilot templates for quick generation.
+ */
+export const PILOT_TEMPLATES: Record<PilotExperienceLevel, IPilotTemplate> = {
+  [PilotExperienceLevel.Green]: {
+    level: PilotExperienceLevel.Green,
+    name: 'Green',
+    skills: { gunnery: 5, piloting: 6 },
+    startingXp: 0,
+    description: 'Inexperienced pilot fresh from training.',
+  },
+  [PilotExperienceLevel.Regular]: {
+    level: PilotExperienceLevel.Regular,
+    name: 'Regular',
+    skills: { gunnery: 4, piloting: 5 },
+    startingXp: 0,
+    description: 'Standard combat-ready pilot.',
+  },
+  [PilotExperienceLevel.Veteran]: {
+    level: PilotExperienceLevel.Veteran,
+    name: 'Veteran',
+    skills: { gunnery: 3, piloting: 4 },
+    startingXp: 50,
+    description: 'Experienced pilot with multiple campaigns.',
+  },
+  [PilotExperienceLevel.Elite]: {
+    level: PilotExperienceLevel.Elite,
+    name: 'Elite',
+    skills: { gunnery: 2, piloting: 3 },
+    startingXp: 100,
+    description: 'Highly skilled ace pilot.',
+  },
+};
+
+/**
+ * Get template by experience level.
+ */
+export function getPilotTemplate(level: PilotExperienceLevel): IPilotTemplate {
+  return PILOT_TEMPLATES[level];
+}
+
+// =============================================================================
+// Skill Rating Helpers
+// =============================================================================
+
+/**
+ * Get descriptive label for a skill level.
+ */
+export function getSkillLabel(skillValue: number): string {
+  if (skillValue <= 1) return 'Legendary';
+  if (skillValue === 2) return 'Elite';
+  if (skillValue === 3) return 'Veteran';
+  if (skillValue === 4) return 'Regular';
+  if (skillValue === 5) return 'Green';
+  if (skillValue === 6) return 'Untrained';
+  if (skillValue === 7) return 'Poor';
+  return 'Terrible';
+}
+
+/**
+ * Get combined pilot rating (gunnery/piloting) label.
+ */
+export function getPilotRating(skills: IPilotSkills): string {
+  return `${skills.gunnery}/${skills.piloting}`;
+}
+
+/**
+ * Calculate effective skill after wound penalties.
+ */
+export function getEffectiveSkill(baseSkill: number, wounds: number): number {
+  return Math.min(MAX_SKILL_VALUE, baseSkill + wounds * WOUND_SKILL_PENALTY);
+}
+
+// =============================================================================
+// Validation Helpers
+// =============================================================================
+
+/**
+ * Validate a skill value is within bounds.
+ */
+export function isValidSkillValue(value: number): boolean {
+  return (
+    Number.isInteger(value) &&
+    value >= MIN_SKILL_VALUE &&
+    value <= MAX_SKILL_VALUE
+  );
+}
+
+/**
+ * Validate a wounds value is within bounds.
+ */
+export function isValidWoundsValue(value: number): boolean {
+  return Number.isInteger(value) && value >= 0 && value <= MAX_WOUNDS;
+}
+
+/**
+ * Validate pilot skills object.
+ */
+export function validatePilotSkills(skills: IPilotSkills): string[] {
+  const errors: string[] = [];
+
+  if (!isValidSkillValue(skills.gunnery)) {
+    errors.push(`Gunnery must be between ${MIN_SKILL_VALUE} and ${MAX_SKILL_VALUE}`);
+  }
+
+  if (!isValidSkillValue(skills.piloting)) {
+    errors.push(`Piloting must be between ${MIN_SKILL_VALUE} and ${MAX_SKILL_VALUE}`);
+  }
+
+  return errors;
+}

--- a/src/types/pilot/PilotInterfaces.ts
+++ b/src/types/pilot/PilotInterfaces.ts
@@ -1,0 +1,307 @@
+/**
+ * Pilot Interfaces
+ * Core type definitions for the pilot system.
+ *
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+import { IEntity } from '../core/IEntity';
+
+// =============================================================================
+// Enums
+// =============================================================================
+
+/**
+ * Pilot type determines persistence and tracking behavior.
+ */
+export enum PilotType {
+  /** Full database storage with career tracking */
+  Persistent = 'persistent',
+  /** Inline definition, no storage - for quick NPCs */
+  Statblock = 'statblock',
+}
+
+/**
+ * Pilot status for campaign tracking.
+ */
+export enum PilotStatus {
+  Active = 'active',
+  Injured = 'injured',
+  MIA = 'mia',
+  KIA = 'kia',
+  Retired = 'retired',
+}
+
+/**
+ * Experience level templates for quick pilot generation.
+ */
+export enum PilotExperienceLevel {
+  Green = 'green',
+  Regular = 'regular',
+  Veteran = 'veteran',
+  Elite = 'elite',
+}
+
+// =============================================================================
+// Core Interfaces
+// =============================================================================
+
+/**
+ * Pilot combat skills.
+ * Lower values are better (BattleTech convention).
+ */
+export interface IPilotSkills {
+  /** Gunnery skill (1-8, lower is better). Default: 4 */
+  readonly gunnery: number;
+  /** Piloting skill (1-8, lower is better). Default: 5 */
+  readonly piloting: number;
+}
+
+/**
+ * Kill record for tracking pilot achievements.
+ */
+export interface IKillRecord {
+  /** ID of the killed unit */
+  readonly targetId: string;
+  /** Name of the killed unit */
+  readonly targetName: string;
+  /** Weapon used for the kill */
+  readonly weaponUsed: string;
+  /** Date of the kill */
+  readonly date: string;
+  /** Game session ID where kill occurred */
+  readonly gameId: string;
+}
+
+/**
+ * Mission record for tracking pilot history.
+ */
+export interface IMissionRecord {
+  /** Mission/game session ID */
+  readonly gameId: string;
+  /** Mission name or description */
+  readonly missionName: string;
+  /** Date of the mission */
+  readonly date: string;
+  /** Outcome of the mission */
+  readonly outcome: 'victory' | 'defeat' | 'draw';
+  /** XP earned in this mission */
+  readonly xpEarned: number;
+  /** Kills in this mission */
+  readonly kills: number;
+}
+
+/**
+ * Pilot career statistics and progression.
+ */
+export interface IPilotCareer {
+  /** Total missions completed */
+  readonly missionsCompleted: number;
+  /** Total victories */
+  readonly victories: number;
+  /** Total defeats */
+  readonly defeats: number;
+  /** Total draws */
+  readonly draws: number;
+  /** Total kills across all missions */
+  readonly totalKills: number;
+  /** Detailed kill records */
+  readonly killRecords: readonly IKillRecord[];
+  /** Mission history */
+  readonly missionHistory: readonly IMissionRecord[];
+  /** Current XP pool (available for spending) */
+  readonly xp: number;
+  /** Total XP ever earned */
+  readonly totalXpEarned: number;
+  /** Pilot rank/title */
+  readonly rank: string;
+}
+
+/**
+ * Special ability that modifies pilot performance.
+ */
+export interface ISpecialAbility {
+  /** Unique ability identifier */
+  readonly id: string;
+  /** Display name */
+  readonly name: string;
+  /** Description of the ability */
+  readonly description: string;
+  /** XP cost to acquire */
+  readonly xpCost: number;
+  /** Prerequisites (ability IDs that must be owned first) */
+  readonly prerequisites: readonly string[];
+  /** Minimum gunnery skill required (optional) */
+  readonly minGunnery?: number;
+  /** Minimum piloting skill required (optional) */
+  readonly minPiloting?: number;
+  /** Effect type for game mechanics */
+  readonly effectType: AbilityEffectType;
+  /** Effect parameters (varies by effect type) */
+  readonly effectParams: Record<string, unknown>;
+}
+
+/**
+ * Types of ability effects for game mechanics.
+ */
+export enum AbilityEffectType {
+  /** Modifies to-hit roll */
+  ToHitModifier = 'to_hit_modifier',
+  /** Modifies damage */
+  DamageModifier = 'damage_modifier',
+  /** Modifies piloting checks */
+  PilotingModifier = 'piloting_modifier',
+  /** Modifies target movement modifier */
+  TMMModifier = 'tmm_modifier',
+  /** Modifies consciousness checks */
+  ConsciousnessModifier = 'consciousness_modifier',
+  /** Modifies heat management */
+  HeatModifier = 'heat_modifier',
+  /** Modifies initiative */
+  InitiativeModifier = 'initiative_modifier',
+  /** Special/custom effect */
+  Special = 'special',
+}
+
+/**
+ * Reference to an ability owned by a pilot.
+ */
+export interface IPilotAbilityRef {
+  /** Ability ID */
+  readonly abilityId: string;
+  /** Date acquired */
+  readonly acquiredDate: string;
+  /** Game session where acquired (if applicable) */
+  readonly acquiredGameId?: string;
+}
+
+/**
+ * Pilot identity information.
+ */
+export interface IPilotIdentity {
+  /** Display name */
+  readonly name: string;
+  /** Callsign/nickname (optional) */
+  readonly callsign?: string;
+  /** Faction/house affiliation (optional) */
+  readonly affiliation?: string;
+  /** Portrait image URL or identifier (optional) */
+  readonly portrait?: string;
+  /** Background notes/biography (optional) */
+  readonly background?: string;
+}
+
+/**
+ * Complete pilot entity.
+ */
+export interface IPilot extends IEntity, IPilotIdentity {
+  /** Pilot type (persistent or statblock) */
+  readonly type: PilotType;
+  /** Current status */
+  readonly status: PilotStatus;
+  /** Combat skills */
+  readonly skills: IPilotSkills;
+  /** Current wounds (0-6, 6 = death) */
+  readonly wounds: number;
+  /** Career statistics (only for persistent pilots) */
+  readonly career?: IPilotCareer;
+  /** Special abilities owned */
+  readonly abilities: readonly IPilotAbilityRef[];
+  /** Creation timestamp */
+  readonly createdAt: string;
+  /** Last update timestamp */
+  readonly updatedAt: string;
+}
+
+// =============================================================================
+// Creation Types
+// =============================================================================
+
+/**
+ * Options for creating a new pilot.
+ */
+export interface ICreatePilotOptions {
+  /** Pilot identity */
+  readonly identity: IPilotIdentity;
+  /** Pilot type */
+  readonly type: PilotType;
+  /** Initial skills */
+  readonly skills: IPilotSkills;
+  /** Initial abilities (by ID) */
+  readonly abilityIds?: readonly string[];
+  /** Starting XP (for persistent pilots) */
+  readonly startingXp?: number;
+  /** Initial rank */
+  readonly rank?: string;
+}
+
+/**
+ * Template for quick pilot generation.
+ */
+export interface IPilotTemplate {
+  /** Template level */
+  readonly level: PilotExperienceLevel;
+  /** Display name */
+  readonly name: string;
+  /** Default skills for this level */
+  readonly skills: IPilotSkills;
+  /** Starting XP budget */
+  readonly startingXp: number;
+  /** Description */
+  readonly description: string;
+}
+
+// =============================================================================
+// Statblock Type (Inline Pilot Definition)
+// =============================================================================
+
+/**
+ * Minimal pilot definition for quick NPC creation.
+ * Not persisted to database.
+ */
+export interface IPilotStatblock {
+  /** Display name */
+  readonly name: string;
+  /** Gunnery skill */
+  readonly gunnery: number;
+  /** Piloting skill */
+  readonly piloting: number;
+  /** Optional abilities (by ID) */
+  readonly abilityIds?: readonly string[];
+}
+
+// =============================================================================
+// Type Guards
+// =============================================================================
+
+/**
+ * Type guard to check if an object is an IPilot.
+ */
+export function isPilot(obj: unknown): obj is IPilot {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const pilot = obj as IPilot;
+  return (
+    typeof pilot.id === 'string' &&
+    typeof pilot.name === 'string' &&
+    typeof pilot.type === 'string' &&
+    typeof pilot.status === 'string' &&
+    typeof pilot.skills === 'object' &&
+    typeof pilot.skills.gunnery === 'number' &&
+    typeof pilot.skills.piloting === 'number' &&
+    typeof pilot.wounds === 'number' &&
+    Array.isArray(pilot.abilities)
+  );
+}
+
+/**
+ * Type guard to check if an object is an IPilotStatblock.
+ */
+export function isPilotStatblock(obj: unknown): obj is IPilotStatblock {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const statblock = obj as IPilotStatblock;
+  return (
+    typeof statblock.name === 'string' &&
+    typeof statblock.gunnery === 'number' &&
+    typeof statblock.piloting === 'number'
+  );
+}

--- a/src/types/pilot/SpecialAbilities.ts
+++ b/src/types/pilot/SpecialAbilities.ts
@@ -1,0 +1,436 @@
+/**
+ * Special Abilities Definitions
+ *
+ * Defines the starter set of pilot special abilities.
+ * Abilities can modify combat performance in various ways.
+ *
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+import { ISpecialAbility, AbilityEffectType } from './PilotInterfaces';
+
+// =============================================================================
+// Ability Definitions
+// =============================================================================
+
+/**
+ * All available special abilities.
+ * Indexed by ability ID for fast lookup.
+ */
+export const SPECIAL_ABILITIES: Record<string, ISpecialAbility> = {
+  // ===========================================================================
+  // Gunnery Abilities
+  // ===========================================================================
+
+  'weapon-specialist': {
+    id: 'weapon-specialist',
+    name: 'Weapon Specialist',
+    description:
+      'Specialized training with a specific weapon type grants -1 to-hit modifier when using that weapon.',
+    xpCost: 50,
+    prerequisites: [],
+    minGunnery: 4,
+    effectType: AbilityEffectType.ToHitModifier,
+    effectParams: {
+      modifier: -1,
+      weaponType: 'selected', // User selects weapon type on acquisition
+    },
+  },
+
+  'marksman': {
+    id: 'marksman',
+    name: 'Marksman',
+    description:
+      'Expert marksmanship training grants -1 to-hit modifier for all aimed shots.',
+    xpCost: 75,
+    prerequisites: ['weapon-specialist'],
+    minGunnery: 3,
+    effectType: AbilityEffectType.ToHitModifier,
+    effectParams: {
+      modifier: -1,
+      condition: 'aimed_shot',
+    },
+  },
+
+  'sniper': {
+    id: 'sniper',
+    name: 'Sniper',
+    description:
+      'Ignores +1 range modifier for medium range when using direct-fire weapons.',
+    xpCost: 100,
+    prerequisites: ['marksman'],
+    minGunnery: 2,
+    effectType: AbilityEffectType.ToHitModifier,
+    effectParams: {
+      modifier: -1,
+      condition: 'medium_range',
+      weaponCategory: 'direct_fire',
+    },
+  },
+
+  'multi-target': {
+    id: 'multi-target',
+    name: 'Multi-Target',
+    description:
+      'Can engage two targets in the same attack phase with only +1 to-hit penalty (instead of +2).',
+    xpCost: 75,
+    prerequisites: [],
+    minGunnery: 3,
+    effectType: AbilityEffectType.ToHitModifier,
+    effectParams: {
+      modifier: -1,
+      condition: 'multi_target',
+    },
+  },
+
+  'cluster-hitter': {
+    id: 'cluster-hitter',
+    name: 'Cluster Hitter',
+    description:
+      'When firing LRMs or SRMs, roll on the cluster hits table as if one column higher.',
+    xpCost: 50,
+    prerequisites: [],
+    minGunnery: 4,
+    effectType: AbilityEffectType.DamageModifier,
+    effectParams: {
+      clusterColumnShift: 1,
+      weaponCategory: 'missile',
+    },
+  },
+
+  // ===========================================================================
+  // Piloting Abilities
+  // ===========================================================================
+
+  'evasive': {
+    id: 'evasive',
+    name: 'Evasive',
+    description:
+      'Exceptional evasive maneuvering grants +1 TMM when running or jumping.',
+    xpCost: 50,
+    prerequisites: [],
+    minPiloting: 4,
+    effectType: AbilityEffectType.TMMModifier,
+    effectParams: {
+      modifier: 1,
+      condition: 'running_or_jumping',
+    },
+  },
+
+  'jumping-jack': {
+    id: 'jumping-jack',
+    name: 'Jumping Jack',
+    description:
+      'Expert jump jet pilot. -1 to piloting skill rolls when landing from a jump.',
+    xpCost: 50,
+    prerequisites: [],
+    minPiloting: 4,
+    effectType: AbilityEffectType.PilotingModifier,
+    effectParams: {
+      modifier: -1,
+      condition: 'jump_landing',
+    },
+  },
+
+  'acrobat': {
+    id: 'acrobat',
+    name: 'Acrobat',
+    description:
+      'Can perform Death From Above attacks with -1 to piloting roll. Requires Jumping Jack.',
+    xpCost: 75,
+    prerequisites: ['jumping-jack'],
+    minPiloting: 3,
+    effectType: AbilityEffectType.PilotingModifier,
+    effectParams: {
+      modifier: -1,
+      condition: 'dfa_attack',
+    },
+  },
+
+  'terrain-master': {
+    id: 'terrain-master',
+    name: 'Terrain Master',
+    description:
+      'Ignores +1 piloting modifier for woods and rough terrain.',
+    xpCost: 50,
+    prerequisites: [],
+    minPiloting: 4,
+    effectType: AbilityEffectType.PilotingModifier,
+    effectParams: {
+      modifier: -1,
+      condition: 'difficult_terrain',
+    },
+  },
+
+  // ===========================================================================
+  // Toughness Abilities
+  // ===========================================================================
+
+  'iron-will': {
+    id: 'iron-will',
+    name: 'Iron Will',
+    description:
+      'Mental fortitude grants -2 to consciousness check target numbers.',
+    xpCost: 75,
+    prerequisites: [],
+    effectType: AbilityEffectType.ConsciousnessModifier,
+    effectParams: {
+      modifier: -2,
+    },
+  },
+
+  'pain-tolerance': {
+    id: 'pain-tolerance',
+    name: 'Pain Tolerance',
+    description:
+      'First wound does not apply skill penalty. Additional wounds still apply penalties normally.',
+    xpCost: 50,
+    prerequisites: [],
+    effectType: AbilityEffectType.Special,
+    effectParams: {
+      ignoreFirstWoundPenalty: true,
+    },
+  },
+
+  'edge': {
+    id: 'edge',
+    name: 'Edge',
+    description:
+      'Once per game, can reroll a single die roll (gunnery, piloting, or consciousness).',
+    xpCost: 100,
+    prerequisites: [],
+    effectType: AbilityEffectType.Special,
+    effectParams: {
+      rerollsPerGame: 1,
+    },
+  },
+
+  // ===========================================================================
+  // Tactical Abilities
+  // ===========================================================================
+
+  'tactical-genius': {
+    id: 'tactical-genius',
+    name: 'Tactical Genius',
+    description:
+      '+1 to initiative roll for the controlling player.',
+    xpCost: 75,
+    prerequisites: [],
+    effectType: AbilityEffectType.InitiativeModifier,
+    effectParams: {
+      modifier: 1,
+    },
+  },
+
+  'speed-demon': {
+    id: 'speed-demon',
+    name: 'Speed Demon',
+    description:
+      'Can push movement by +1 hex when running, at the cost of +1 heat.',
+    xpCost: 50,
+    prerequisites: [],
+    minPiloting: 4,
+    effectType: AbilityEffectType.Special,
+    effectParams: {
+      extraMovement: 1,
+      heatCost: 1,
+      condition: 'running',
+    },
+  },
+
+  'cool-under-fire': {
+    id: 'cool-under-fire',
+    name: 'Cool Under Fire',
+    description:
+      'Mech generates 1 less heat per turn (minimum 0).',
+    xpCost: 50,
+    prerequisites: [],
+    effectType: AbilityEffectType.HeatModifier,
+    effectParams: {
+      heatReduction: 1,
+    },
+  },
+
+  'hot-dog': {
+    id: 'hot-dog',
+    name: 'Hot Dog',
+    description:
+      'Can fire at +3 heat above normal shutdown threshold without triggering shutdown checks.',
+    xpCost: 75,
+    prerequisites: ['cool-under-fire'],
+    effectType: AbilityEffectType.HeatModifier,
+    effectParams: {
+      shutdownThresholdIncrease: 3,
+    },
+  },
+};
+
+// =============================================================================
+// Ability Lookup Functions
+// =============================================================================
+
+/**
+ * Get an ability by ID.
+ */
+export function getAbility(id: string): ISpecialAbility | undefined {
+  return SPECIAL_ABILITIES[id];
+}
+
+/**
+ * Get all abilities.
+ */
+export function getAllAbilities(): ISpecialAbility[] {
+  return Object.values(SPECIAL_ABILITIES);
+}
+
+/**
+ * Get abilities available to a pilot based on their skills and existing abilities.
+ */
+export function getAvailableAbilities(
+  gunnery: number,
+  piloting: number,
+  ownedAbilityIds: string[]
+): ISpecialAbility[] {
+  return getAllAbilities().filter((ability) => {
+    // Check if already owned
+    if (ownedAbilityIds.includes(ability.id)) {
+      return false;
+    }
+
+    // Check gunnery prerequisite
+    if (ability.minGunnery !== undefined && gunnery > ability.minGunnery) {
+      return false;
+    }
+
+    // Check piloting prerequisite
+    if (ability.minPiloting !== undefined && piloting > ability.minPiloting) {
+      return false;
+    }
+
+    // Check ability prerequisites
+    if (ability.prerequisites.length > 0) {
+      const hasAllPrereqs = ability.prerequisites.every((prereq) =>
+        ownedAbilityIds.includes(prereq)
+      );
+      if (!hasAllPrereqs) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+/**
+ * Get abilities that can be purchased with available XP.
+ */
+export function getAffordableAbilities(
+  gunnery: number,
+  piloting: number,
+  ownedAbilityIds: string[],
+  availableXp: number
+): ISpecialAbility[] {
+  return getAvailableAbilities(gunnery, piloting, ownedAbilityIds).filter(
+    (ability) => ability.xpCost <= availableXp
+  );
+}
+
+/**
+ * Check if a pilot meets prerequisites for an ability.
+ */
+export function meetsPrerequisites(
+  abilityId: string,
+  gunnery: number,
+  piloting: number,
+  ownedAbilityIds: string[]
+): { meets: boolean; missing: string[] } {
+  const ability = getAbility(abilityId);
+  if (!ability) {
+    return { meets: false, missing: ['Ability not found'] };
+  }
+
+  const missing: string[] = [];
+
+  // Check gunnery
+  if (ability.minGunnery !== undefined && gunnery > ability.minGunnery) {
+    missing.push(`Gunnery ${ability.minGunnery} or better required`);
+  }
+
+  // Check piloting
+  if (ability.minPiloting !== undefined && piloting > ability.minPiloting) {
+    missing.push(`Piloting ${ability.minPiloting} or better required`);
+  }
+
+  // Check prerequisites
+  for (const prereqId of ability.prerequisites) {
+    if (!ownedAbilityIds.includes(prereqId)) {
+      const prereq = getAbility(prereqId);
+      missing.push(`Requires ${prereq?.name || prereqId}`);
+    }
+  }
+
+  return { meets: missing.length === 0, missing };
+}
+
+// =============================================================================
+// Ability Categories for UI
+// =============================================================================
+
+export enum AbilityCategory {
+  Gunnery = 'gunnery',
+  Piloting = 'piloting',
+  Toughness = 'toughness',
+  Tactical = 'tactical',
+}
+
+/**
+ * Get the category for an ability.
+ */
+export function getAbilityCategory(abilityId: string): AbilityCategory {
+  const gunneryAbilities = [
+    'weapon-specialist',
+    'marksman',
+    'sniper',
+    'multi-target',
+    'cluster-hitter',
+  ];
+  const pilotingAbilities = [
+    'evasive',
+    'jumping-jack',
+    'acrobat',
+    'terrain-master',
+  ];
+  const toughnessAbilities = ['iron-will', 'pain-tolerance', 'edge'];
+  const tacticalAbilities = [
+    'tactical-genius',
+    'speed-demon',
+    'cool-under-fire',
+    'hot-dog',
+  ];
+
+  if (gunneryAbilities.includes(abilityId)) return AbilityCategory.Gunnery;
+  if (pilotingAbilities.includes(abilityId)) return AbilityCategory.Piloting;
+  if (toughnessAbilities.includes(abilityId)) return AbilityCategory.Toughness;
+  if (tacticalAbilities.includes(abilityId)) return AbilityCategory.Tactical;
+
+  return AbilityCategory.Tactical; // Default
+}
+
+/**
+ * Get abilities grouped by category.
+ */
+export function getAbilitiesByCategory(): Record<AbilityCategory, ISpecialAbility[]> {
+  const result: Record<AbilityCategory, ISpecialAbility[]> = {
+    [AbilityCategory.Gunnery]: [],
+    [AbilityCategory.Piloting]: [],
+    [AbilityCategory.Toughness]: [],
+    [AbilityCategory.Tactical]: [],
+  };
+
+  for (const ability of getAllAbilities()) {
+    const category = getAbilityCategory(ability.id);
+    result[category].push(ability);
+  }
+
+  return result;
+}

--- a/src/types/pilot/index.ts
+++ b/src/types/pilot/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Pilot Types Barrel Export
+ * Central export point for all pilot-related types.
+ *
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+export * from './PilotInterfaces';
+export * from './PilotConstants';
+export * from './SpecialAbilities';


### PR DESCRIPTION
Implement full pilot management system with:

Types & Data Model:
- IPilot, IPilotSkills, IPilotCareer interfaces
- 15 special abilities with prerequisites and effects
- XP costs for skill advancement
- Pilot templates (Green/Regular/Veteran/Elite)

Database:
- SQLite migration for pilots, pilot_abilities, pilot_kills, pilot_missions tables
- IndexedDB store for browser persistence
- PilotRepository with full CRUD operations

Services:
- PilotService with skill advancement, XP management, wound tracking
- Template, random, and custom pilot creation modes
- Ability purchase with prerequisite validation

State Management:
- usePilotStore (Zustand) using API routes for persistence
- useFilteredPilots selector for search/filter

API Routes:
- GET/POST /api/pilots - list and create
- GET/PUT/DELETE /api/pilots/[id] - single pilot operations

UI Components:
- PilotCreationWizard - 4-mode creation flow
- PilotProgressionPanel - skill upgrades and XP display
- AbilityPurchaseModal - ability browser and purchase

Pages:
- /gameplay/pilots - roster with search and filters
- /gameplay/pilots/create - creation wizard
- /gameplay/pilots/[id] - detail view with progression

Implements add-pilot-system proposal from OpenSpec.