### PR TITLE
feat: add Chemical Laser weapons and ammo

### DIFF
--- a/public/data/equipment/official/ammunition.json
+++ b/public/data/equipment/official/ammunition.json
@@ -2,7 +2,7 @@
   "$schema": "../_schema/ammunition-schema.json",
   "version": "1.0.0",
   "generatedAt": "2025-12-05T08:19:50.521Z",
-  "count": 284,
+  "count": 287,
   "items": [
     {
       "id": "ac-2-ammo",
@@ -4964,7 +4964,7 @@
       "introductionYear": 3060,
       "special": []
     },
-    {
+{
       "id": "ammo-gac-8",
       "name": "GAC/8 Ammo",
       "category": "Autocannon",
@@ -4979,6 +4979,63 @@
       "battleValue": 53,
       "isExplosive": true,
       "introductionYear": 3060,
+      "special": []
+    },
+    {
+      "id": "clan-small-chemical-laser-ammo",
+      "name": "Small Chemical Laser Ammo (Clan)",
+      "category": "Energy",
+      "variant": "Standard",
+      "techBase": "CLAN",
+      "rulesLevel": "ADVANCED",
+      "compatibleWeaponIds": [
+        "clan-small-chemical-laser"
+      ],
+      "shotsPerTon": 60,
+      "weight": 1,
+      "criticalSlots": 1,
+      "costPerTon": 30000,
+      "battleValue": 1,
+      "isExplosive": true,
+      "introductionYear": 3059,
+      "special": []
+    },
+    {
+      "id": "clan-medium-chemical-laser-ammo",
+      "name": "Medium Chemical Laser Ammo (Clan)",
+      "category": "Energy",
+      "variant": "Standard",
+      "techBase": "CLAN",
+      "rulesLevel": "ADVANCED",
+      "compatibleWeaponIds": [
+        "clan-medium-chemical-laser"
+      ],
+      "shotsPerTon": 30,
+      "weight": 1,
+      "criticalSlots": 1,
+      "costPerTon": 30000,
+      "battleValue": 5,
+      "isExplosive": true,
+      "introductionYear": 3059,
+      "special": []
+    },
+    {
+      "id": "clan-large-chemical-laser-ammo",
+      "name": "Large Chemical Laser Ammo (Clan)",
+      "category": "Energy",
+      "variant": "Standard",
+      "techBase": "CLAN",
+      "rulesLevel": "ADVANCED",
+      "compatibleWeaponIds": [
+        "clan-large-chemical-laser"
+      ],
+      "shotsPerTon": 10,
+      "weight": 1,
+      "criticalSlots": 1,
+      "costPerTon": 30000,
+      "battleValue": 12,
+      "isExplosive": true,
+      "introductionYear": 3059,
       "special": []
     }
   ]

--- a/public/data/equipment/official/weapons/energy.json
+++ b/public/data/equipment/official/weapons/energy.json
@@ -2,7 +2,7 @@
   "$schema": "../_schema/weapon-schema.json",
   "version": "1.0.0",
   "generatedAt": "2025-12-05T03:18:04.830Z",
-  "count": 33,
+  "count": 36,
   "items": [
     {
       "id": "small-laser",
@@ -751,6 +751,81 @@
       "introductionYear": 3070,
       "special": [],
       "allowedUnitTypes": ["Battle Armor"]
+    },
+    {
+      "id": "clan-small-chemical-laser",
+      "name": "Small Chemical Laser (Clan)",
+      "category": "Energy",
+      "subType": "Chemical Laser",
+      "techBase": "CLAN",
+      "rulesLevel": "ADVANCED",
+      "damage": 3,
+      "heat": 1,
+      "ranges": {
+        "minimum": 0,
+        "short": 1,
+        "medium": 2,
+        "long": 3
+      },
+      "weight": 0.5,
+      "criticalSlots": 1,
+      "ammoPerTon": 60,
+      "costCBills": 10000,
+      "battleValue": 7,
+      "introductionYear": 3059,
+      "special": [
+        "Requires ammo"
+      ]
+    },
+    {
+      "id": "clan-medium-chemical-laser",
+      "name": "Medium Chemical Laser (Clan)",
+      "category": "Energy",
+      "subType": "Chemical Laser",
+      "techBase": "CLAN",
+      "rulesLevel": "ADVANCED",
+      "damage": 5,
+      "heat": 2,
+      "ranges": {
+        "minimum": 0,
+        "short": 3,
+        "medium": 6,
+        "long": 9
+      },
+      "weight": 1,
+      "criticalSlots": 1,
+      "ammoPerTon": 30,
+      "costCBills": 30000,
+      "battleValue": 37,
+      "introductionYear": 3059,
+      "special": [
+        "Requires ammo"
+      ]
+    },
+    {
+      "id": "clan-large-chemical-laser",
+      "name": "Large Chemical Laser (Clan)",
+      "category": "Energy",
+      "subType": "Chemical Laser",
+      "techBase": "CLAN",
+      "rulesLevel": "ADVANCED",
+      "damage": 8,
+      "heat": 6,
+      "ranges": {
+        "minimum": 0,
+        "short": 5,
+        "medium": 10,
+        "long": 15
+      },
+      "weight": 5,
+      "criticalSlots": 2,
+      "ammoPerTon": 10,
+      "costCBills": 75000,
+      "battleValue": 99,
+      "introductionYear": 3059,
+      "special": [
+        "Requires ammo"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add Clan Chemical Laser family (Small, Medium, Large) to energy weapons
- Add corresponding ammunition types with proper weapon linkage
- These are Advanced-level energy weapons that uniquely require ammo

## Changes
### Weapons (`energy.json`)
| Weapon | Damage | Heat | Range (S/M/L) | Weight | Slots | Cost | BV |
|--------|--------|------|---------------|--------|-------|------|-----|
| Small Chemical Laser (Clan) | 3 | 1 | 1/2/3 | 0.5t | 1 | 10,000 | 7 |
| Medium Chemical Laser (Clan) | 5 | 2 | 3/6/9 | 1t | 1 | 30,000 | 37 |
| Large Chemical Laser (Clan) | 8 | 6 | 5/10/15 | 5t | 2 | 75,000 | 99 |

### Ammunition (`ammunition.json`)
| Ammo | Shots/Ton | Cost/Ton | BV |
|------|-----------|----------|-----|
| Small Chemical Laser Ammo | 60 | 30,000 | 1 |
| Medium Chemical Laser Ammo | 30 | 30,000 | 5 |
| Large Chemical Laser Ammo | 10 | 30,000 | 12 |

## Details
- **Tech Base**: Clan (Clan Hell's Horses origin)
- **Rules Level**: Advanced
- **Introduction Year**: 3059 (from Sarna - to be verified against MegaMek data)
- **Source**: Tactical Operations

## TODO
- [ ] Verify introduction year against MegaMek/mm-data source files

## Testing
- [x] Lint passes
- [x] All 6281 tests pass
- [x] Build succeeds
- [x] JSON syntax validated