### PR TITLE
feat(customizer): integrate vehicle customizer with multi-unit tab system

### DIFF
--- a/openspec/changes/add-gameplay-roadmap/tasks.md
+++ b/openspec/changes/add-gameplay-roadmap/tasks.md
@@ -2,8 +2,14 @@
 
 ## 1. Phase 1 Proposals - Build & Share MVP
 - [x] 1.1 Create and validate `add-multi-unit-types` proposal
+  - [x] 1.1a `add-multi-unit-type-support` foundation (archived 2026-01-18)
+  - [x] 1.1b `add-vehicle-customizer` UI integration (PR #91)
+  - [ ] 1.1c `add-aerospace-customizer` (pending)
+  - [ ] 1.1d `add-infantry-customizer` (pending)
+  - [ ] 1.1e `add-battle-armor-customizer` (pending)
 - [x] 1.2 Create and validate `add-pilot-system` proposal
 - [x] 1.3 Create and validate `add-vault-sharing` proposal (Phase 1 scope)
+  - [x] 1.3a `add-vault-sharing` Phase 1 UI (archived 2026-01-18)
 - [x] 1.4 Create and validate `add-unit-card-view` proposal
 - [ ] 1.5 Review Phase 1 proposals for consistency
 
@@ -24,15 +30,31 @@
 - [ ] 4.1 Verify all cross-references between proposals
 - [ ] 4.2 Confirm dependency graph is acyclic
 - [ ] 4.3 Get approval on roadmap priorities
-- [ ] 4.4 Begin Phase 1 implementation
+- [x] 4.4 Begin Phase 1 implementation
+
+## Implementation Progress
+
+### Phase 1 Implementation Status
+
+| Component | Proposal | Status | Notes |
+|-----------|----------|--------|-------|
+| Multi-Unit Foundation | add-multi-unit-type-support | **Archived** | BLK parsing, handlers for all 13 unit types |
+| Vehicle Customizer | add-vehicle-customizer | **In Review** | PR #91 - tab integration, store registry |
+| Aerospace Customizer | add-aerospace-customizer | Pending | Requires proposal |
+| Infantry Customizer | add-infantry-customizer | Pending | Requires proposal |
+| Battle Armor Customizer | add-battle-armor-customizer | Pending | Requires proposal |
+| Pilot System | add-pilot-system | Created | Awaiting implementation |
+| Vault Sharing Phase 1 | add-vault-sharing | **Archived** | File export/import with signatures |
+| Unit Card View | add-unit-card-view | Created | Awaiting implementation |
 
 ## Proposal Summary
 
 | Phase | Proposal | Tasks | Status |
 |-------|----------|-------|--------|
-| 1 | add-multi-unit-types | 37 | Created |
+| 1 | add-multi-unit-type-support | 37 | **Archived** |
+| 1 | add-vehicle-customizer | 51 | **In Review** |
 | 1 | add-pilot-system | 38 | Created |
-| 1 | add-vault-sharing | 57 | Created |
+| 1 | add-vault-sharing | 57 | **Archived** |
 | 1 | add-unit-card-view | 27 | Created |
 | 2 | add-force-management | 34 | Created |
 | 2 | add-pilot-mech-card | 33 | Created |
@@ -42,4 +64,4 @@
 | 3 | add-encounter-system | 39 | Created |
 | 3 | add-gameplay-ui | 66 | Created |
 
-**Total: 11 proposals, 472 tasks**
+**Total: 12 proposals, 523 tasks (2 archived, 1 in review, 9 pending)**

--- a/openspec/changes/add-gameplay-roadmap/tasks.md
+++ b/openspec/changes/add-gameplay-roadmap/tasks.md
@@ -1,67 +1,58 @@
 # Tasks: Gameplay Roadmap
 
-## 1. Phase 1 Proposals - Build & Share MVP
-- [x] 1.1 Create and validate `add-multi-unit-types` proposal
-  - [x] 1.1a `add-multi-unit-type-support` foundation (archived 2026-01-18)
-  - [x] 1.1b `add-vehicle-customizer` UI integration (PR #91)
-  - [ ] 1.1c `add-aerospace-customizer` (pending)
-  - [ ] 1.1d `add-infantry-customizer` (pending)
-  - [ ] 1.1e `add-battle-armor-customizer` (pending)
-- [x] 1.2 Create and validate `add-pilot-system` proposal
-- [x] 1.3 Create and validate `add-vault-sharing` proposal (Phase 1 scope)
-  - [x] 1.3a `add-vault-sharing` Phase 1 UI (archived 2026-01-18)
-- [x] 1.4 Create and validate `add-unit-card-view` proposal
-- [ ] 1.5 Review Phase 1 proposals for consistency
+## Phase 1 - Build & Share MVP
 
-## 2. Phase 2 Proposals - Organize & Collaborate
-- [x] 2.1 Create and validate `add-force-management` proposal
-- [x] 2.2 Create and validate `add-pilot-mech-card` proposal
-- [ ] 2.3 Review Phase 2 proposals for consistency
+### Unit Customizers
+- [x] `add-multi-unit-type-support` - Foundation for all unit types (archived 2026-01-18)
+- [x] `add-vehicle-customizer` - Vehicle customizer UI integration (PR #91)
+- [ ] `add-aerospace-customizer` - Aerospace/fighter customizer
+- [ ] `add-personnel-customizer` - Infantry & Battle Armor customizer
 
-## 3. Phase 3 Proposals - Gameplay Simulation
-- [x] 3.1 Create and validate `add-game-session-core` proposal
-- [x] 3.2 Create and validate `add-hex-grid-system` proposal
-- [x] 3.3 Create and validate `add-combat-resolution` proposal
-- [x] 3.4 Create and validate `add-encounter-system` proposal
-- [x] 3.5 Create and validate `add-gameplay-ui` proposal
-- [ ] 3.6 Review Phase 3 proposals for consistency
+### Sharing & Export
+- [x] `add-vault-sharing` - File export/import with signatures (archived 2026-01-18)
+- [ ] `add-unit-export-integration` - MTF/BLK export from customizer
 
-## 4. Roadmap Finalization
-- [ ] 4.1 Verify all cross-references between proposals
-- [ ] 4.2 Confirm dependency graph is acyclic
-- [ ] 4.3 Get approval on roadmap priorities
-- [x] 4.4 Begin Phase 1 implementation
+### Pilots & Display
+- [ ] `add-pilot-system` - Pilot creation, skills, abilities
+- [ ] `add-unit-card-view` - Quick reference unit cards
 
-## Implementation Progress
+## Phase 2 - Organize & Collaborate
 
-### Phase 1 Implementation Status
+### Force Organization
+- [ ] `add-force-management` - Lance/Star/Level II organization
+- [ ] `add-pilot-mech-card` - Combined pilot + unit display
 
-| Component | Proposal | Status | Notes |
-|-----------|----------|--------|-------|
-| Multi-Unit Foundation | add-multi-unit-type-support | **Archived** | BLK parsing, handlers for all 13 unit types |
-| Vehicle Customizer | add-vehicle-customizer | **In Review** | PR #91 - tab integration, store registry |
-| Aerospace Customizer | add-aerospace-customizer | Pending | Requires proposal |
-| Infantry Customizer | add-infantry-customizer | Pending | Requires proposal |
-| Battle Armor Customizer | add-battle-armor-customizer | Pending | Requires proposal |
-| Pilot System | add-pilot-system | Created | Awaiting implementation |
-| Vault Sharing Phase 1 | add-vault-sharing | **Archived** | File export/import with signatures |
-| Unit Card View | add-unit-card-view | Created | Awaiting implementation |
+## Phase 3 - Gameplay Simulation
 
-## Proposal Summary
+### Core Systems
+- [ ] `add-game-session-core` - Game state, turn structure, persistence
+- [ ] `add-hex-grid-system` - Hex map rendering, movement, LOS
 
-| Phase | Proposal | Tasks | Status |
-|-------|----------|-------|--------|
-| 1 | add-multi-unit-type-support | 37 | **Archived** |
-| 1 | add-vehicle-customizer | 51 | **In Review** |
-| 1 | add-pilot-system | 38 | Created |
-| 1 | add-vault-sharing | 57 | **Archived** |
-| 1 | add-unit-card-view | 27 | Created |
-| 2 | add-force-management | 34 | Created |
-| 2 | add-pilot-mech-card | 33 | Created |
-| 3 | add-game-session-core | 48 | Created |
-| 3 | add-hex-grid-system | 41 | Created |
-| 3 | add-combat-resolution | 52 | Created |
-| 3 | add-encounter-system | 39 | Created |
-| 3 | add-gameplay-ui | 66 | Created |
+### Combat
+- [ ] `add-combat-resolution` - Attack resolution, damage application
+- [ ] `add-encounter-system` - Scenario setup, victory conditions
 
-**Total: 12 proposals, 523 tasks (2 archived, 1 in review, 9 pending)**
+### UI
+- [ ] `add-gameplay-ui` - Game controls, action panels, status displays
+
+## Implementation Status
+
+| Phase | Proposal | Status | Notes |
+|-------|----------|--------|-------|
+| 1 | `add-multi-unit-type-support` | **Archived** | BLK parsing, 13 unit type handlers |
+| 1 | `add-vehicle-customizer` | **In Review** | PR #91 - tab integration |
+| 1 | `add-aerospace-customizer` | Pending | Proposal created |
+| 1 | `add-personnel-customizer` | Pending | Proposal created |
+| 1 | `add-vault-sharing` | **Archived** | Export/import with signatures |
+| 1 | `add-unit-export-integration` | Pending | Proposal created |
+| 1 | `add-pilot-system` | Pending | Proposal created |
+| 1 | `add-unit-card-view` | Pending | Proposal created |
+| 2 | `add-force-management` | Pending | Proposal created |
+| 2 | `add-pilot-mech-card` | Pending | Proposal created |
+| 3 | `add-game-session-core` | Pending | Proposal created |
+| 3 | `add-hex-grid-system` | Pending | Proposal created |
+| 3 | `add-combat-resolution` | Pending | Proposal created |
+| 3 | `add-encounter-system` | Pending | Proposal created |
+| 3 | `add-gameplay-ui` | Pending | Proposal created |
+
+**Total: 15 proposals (2 archived, 1 in review, 12 pending)**

--- a/openspec/changes/add-vehicle-customizer/tasks.md
+++ b/openspec/changes/add-vehicle-customizer/tasks.md
@@ -1,40 +1,40 @@
 # Tasks: Vehicle Customizer UI
 
 ## 1. Vehicle State Management
-- [ ] 1.1 Create `VehicleState` interface extending UnitState patterns
-- [ ] 1.2 Add vehicle-specific fields (motionType, turretType, etc.)
-- [ ] 1.3 Create `useVehicleStore` or extend `useUnitStore`
-- [ ] 1.4 Implement vehicle state <-> serialization mapping
+- [x] 1.1 Create `VehicleState` interface extending UnitState patterns
+- [x] 1.2 Add vehicle-specific fields (motionType, turretType, etc.)
+- [x] 1.3 Create `useVehicleStore` or extend `useUnitStore`
+- [x] 1.4 Implement vehicle state <-> serialization mapping
 
 ## 2. Vehicle Customizer Tabs
-- [ ] 2.1 Create `VehicleStructureTab` component
-  - [ ] Chassis selection (tonnage, motion type)
-  - [ ] Engine type/rating selection
-  - [ ] Turret configuration toggle
-  - [ ] Special options (amphibious, sealed, etc.)
-- [ ] 2.2 Create `VehicleArmorTab` component
-  - [ ] Front/Left/Right/Rear allocation
-  - [ ] Turret armor (if applicable)
-  - [ ] Rotor armor (VTOL)
-- [ ] 2.3 Create `VehicleEquipmentTab` component
-  - [ ] Equipment browser filtered for vehicles
-  - [ ] Turret-mountable equipment distinction
-- [ ] 2.4 Create `VehicleTurretTab` component (if has turret)
-  - [ ] Turret weapon arrangement
-  - [ ] Turret weight tracking
+- [x] 2.1 Create `VehicleStructureTab` component
+  - [x] Chassis selection (tonnage, motion type)
+  - [x] Engine type/rating selection
+  - [x] Turret configuration toggle
+  - [x] Special options (amphibious, sealed, etc.)
+- [x] 2.2 Create `VehicleArmorTab` component
+  - [x] Front/Left/Right/Rear allocation
+  - [x] Turret armor (if applicable)
+  - [x] Rotor armor (VTOL)
+- [x] 2.3 Create `VehicleEquipmentTab` component
+  - [x] Equipment browser filtered for vehicles
+  - [x] Turret-mountable equipment distinction
+- [x] 2.4 Create `VehicleTurretTab` component (if has turret)
+  - [x] Turret weapon arrangement
+  - [x] Turret weight tracking
 
 ## 3. Vehicle Diagram
-- [ ] 3.1 Create `VehicleDiagram` component
-- [ ] 3.2 Implement location click targets for vehicle shape
-- [ ] 3.3 Display armor pips per location
-- [ ] 3.4 Handle VTOL rotor location
+- [x] 3.1 Create `VehicleDiagram` component
+- [x] 3.2 Implement location click targets for vehicle shape
+- [x] 3.3 Display armor pips per location
+- [x] 3.4 Handle VTOL rotor location
 - [ ] 3.5 Integrate with mm-data vehicle assets (if available)
 
 ## 4. Vehicle Status Bar
-- [ ] 4.1 Create `VehicleStatusBar` extending base StatusBar
-- [ ] 4.2 Show vehicle-specific calculations (cruise/flank MP)
-- [ ] 4.3 Show turret weight allocation
-- [ ] 4.4 Show vehicle-specific validation errors
+- [x] 4.1 Create `VehicleStatusBar` extending base StatusBar
+- [x] 4.2 Show vehicle-specific calculations (cruise/flank MP)
+- [x] 4.3 Show turret weight allocation
+- [x] 4.4 Show vehicle-specific validation errors
 
 ## 5. Vehicle Validation Rules
 - [ ] 5.1 Create `VehicleValidationRules` extending validation framework
@@ -44,7 +44,7 @@
 - [ ] 5.5 Register rules with validation orchestrator
 
 ## 6. Integration
-- [ ] 6.1 Add vehicle to unit type selector in construction flow
-- [ ] 6.2 Route vehicle units to VehicleCustomizer
+- [x] 6.1 Add vehicle to unit type selector in construction flow
+- [x] 6.2 Route vehicle units to VehicleCustomizer
 - [ ] 6.3 Add unit type filter to equipment browser
 - [ ] 6.4 Auto-filter equipment based on active unit type

--- a/openspec/changes/add-vehicle-customizer/tasks.md
+++ b/openspec/changes/add-vehicle-customizer/tasks.md
@@ -28,7 +28,8 @@
 - [x] 3.2 Implement location click targets for vehicle shape
 - [x] 3.3 Display armor pips per location
 - [x] 3.4 Handle VTOL rotor location
-- [ ] 3.5 Integrate with mm-data vehicle assets (if available)
+- [x] 3.5 Integrate with mm-data vehicle assets (if available)
+  - Note: No mm-data vehicle assets exist; SVG-based implementation is complete
 
 ## 4. Vehicle Status Bar
 - [x] 4.1 Create `VehicleStatusBar` extending base StatusBar
@@ -37,14 +38,21 @@
 - [x] 4.4 Show vehicle-specific validation errors
 
 ## 5. Vehicle Validation Rules
-- [ ] 5.1 Create `VehicleValidationRules` extending validation framework
-- [ ] 5.2 Validate motion type constraints
-- [ ] 5.3 Validate turret weight limits
-- [ ] 5.4 Validate equipment compatibility
-- [ ] 5.5 Register rules with validation orchestrator
+- [x] 5.1 Create `VehicleValidationRules` extending validation framework
+  - Already exists in `src/services/validation/rules/vehicle/VehicleCategoryRules.ts`
+- [x] 5.2 Validate motion type constraints
+  - VAL-VEH-002 and VAL-VEH-005 cover this
+- [x] 5.3 Validate turret weight limits
+  - VAL-VEH-003 validates turret capacity
+- [x] 5.4 Validate equipment compatibility
+  - Equipment unit type rules in `src/services/validation/rules/equipment/EquipmentUnitTypeRules.ts`
+- [x] 5.5 Register rules with validation orchestrator
+  - Registered in `src/services/validation/initializeUnitValidation.ts`
 
 ## 6. Integration
 - [x] 6.1 Add vehicle to unit type selector in construction flow
 - [x] 6.2 Route vehicle units to VehicleCustomizer
-- [ ] 6.3 Add unit type filter to equipment browser
-- [ ] 6.4 Auto-filter equipment based on active unit type
+- [x] 6.3 Add unit type filter to equipment browser
+  - Equipment browser now supports both UnitStoreContext and VehicleStoreContext
+- [x] 6.4 Auto-filter equipment based on active unit type
+  - useEquipmentBrowser hook reads from either context for year/techBase filtering

--- a/src/__tests__/components/customizer/tabs/MultiUnitTabs.test.tsx
+++ b/src/__tests__/components/customizer/tabs/MultiUnitTabs.test.tsx
@@ -4,6 +4,7 @@ import { MultiUnitTabs } from '@/components/customizer/tabs/MultiUnitTabs';
 import { useTabManagerStore, TabManagerState, TabInfo } from '@/stores/useTabManagerStore';
 import { useRouter } from 'next/router';
 import { TechBase } from '@/types/enums/TechBase';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
 import { ToastProvider } from '@/components/shared/Toast';
 
 // Mock dependencies
@@ -47,6 +48,7 @@ describe('MultiUnitTabs', () => {
     name: 'Atlas AS7-D',
     tonnage: 100,
     techBase: TechBase.INNER_SPHERE,
+    unitType: UnitType.BATTLEMECH,
   };
 
   const mockTabManager: TabManagerState = {

--- a/src/components/customizer/CustomizerWithRouter.tsx
+++ b/src/components/customizer/CustomizerWithRouter.tsx
@@ -16,12 +16,11 @@ import { HTML5Backend } from 'react-dnd-html5-backend';
 import { useCustomizerRouter, CustomizerTabId, isValidTabId } from '@/hooks/useCustomizerRouter';
 
 // Stores
-import { useTabManagerStore } from '@/stores/useTabManagerStore';
-import { UnitStoreProvider, ActiveTabInfo } from '@/stores/UnitStoreProvider';
+import { useTabManagerStore, TabInfo } from '@/stores/useTabManagerStore';
 
 // Components
 import { MultiUnitTabs } from '@/components/customizer/tabs';
-import { UnitEditorWithRouting } from './UnitEditorWithRouting';
+import { UnitTypeRouter } from './UnitTypeRouter';
 
 // =============================================================================
 // Main Component
@@ -136,11 +135,7 @@ export default function CustomizerWithRouter(): React.ReactElement {
     }
   }, [isHydrated, isLoading, activeTabId, routerUnitId, routerTabId, routerSyncUrl]);
   
-  // ==========================================================================
-  // Derive active tab info for provider
-  // ==========================================================================
-  
-  const activeTab: ActiveTabInfo | null = useMemo(() => {
+  const activeTab: TabInfo | null = useMemo(() => {
     if (!activeTabId || tabs.length === 0) {
       return null;
     }
@@ -182,32 +177,17 @@ export default function CustomizerWithRouter(): React.ReactElement {
   return (
     <DndProvider backend={HTML5Backend}>
       <div className="min-h-screen bg-surface-deep flex flex-col">
-        {/* Multi-unit tabs at top */}
         <MultiUnitTabs>
-          {/* UnitStoreProvider - activeTab passed as prop */}
-          <UnitStoreProvider
+          <UnitTypeRouter
             activeTab={activeTab}
-            fallback={
-              <div className="flex-1 flex items-center justify-center">
-                <div className="text-center text-text-theme-secondary p-8">
-                  <p className="text-lg mb-2">No unit selected</p>
-                  <p className="text-sm">Click &quot;New Unit&quot; to create a new BattleMech</p>
-                </div>
-              </div>
-            }
-          >
-            {/* Unit editor with routing support */}
-            <UnitEditorWithRouting
-              activeTabId={effectiveTabId}
-              onTabChange={(tabId) => {
-                // Save the last sub-tab for this unit
-                if (activeTabId) {
-                  setLastSubTab(activeTabId, tabId);
-                }
-                router.navigateToTab(tabId);
-              }}
-            />
-          </UnitStoreProvider>
+            activeTabId={effectiveTabId}
+            onTabChange={(tabId) => {
+              if (activeTabId) {
+                setLastSubTab(activeTabId, tabId);
+              }
+              router.navigateToTab(tabId);
+            }}
+          />
         </MultiUnitTabs>
       </div>
     </DndProvider>

--- a/src/components/customizer/UnitTypeRouter.tsx
+++ b/src/components/customizer/UnitTypeRouter.tsx
@@ -1,0 +1,95 @@
+/**
+ * Unit Type Router
+ * 
+ * Routes to the appropriate customizer based on unit type.
+ * Provides the correct store context for each unit type.
+ */
+
+import React, { useMemo } from 'react';
+
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+import { TabInfo } from '@/stores/useTabManagerStore';
+import { UnitStoreProvider, ActiveTabInfo } from '@/stores/UnitStoreProvider';
+import { getVehicleStore, hydrateOrCreateVehicle } from '@/stores/vehicleStoreRegistry';
+import { VehicleStoreContext } from '@/stores/useVehicleStore';
+
+import { UnitEditorWithRouting } from './UnitEditorWithRouting';
+import { VehicleCustomizer } from './vehicle/VehicleCustomizer';
+import { CustomizerTabId } from '@/hooks/useCustomizerRouter';
+
+interface UnitTypeRouterProps {
+  activeTab: TabInfo | null;
+  activeTabId: CustomizerTabId;
+  onTabChange: (tabId: CustomizerTabId) => void;
+}
+
+export function UnitTypeRouter({
+  activeTab,
+  activeTabId,
+  onTabChange,
+}: UnitTypeRouterProps): React.ReactElement {
+  const isVehicle = activeTab?.unitType === UnitType.VEHICLE || activeTab?.unitType === UnitType.VTOL;
+  
+  const vehicleStore = useMemo(() => {
+    if (!isVehicle || !activeTab) return null;
+    
+    const existing = getVehicleStore(activeTab.id);
+    if (existing) return existing;
+    
+    return hydrateOrCreateVehicle(activeTab.id, {
+      name: activeTab.name,
+      tonnage: activeTab.tonnage,
+      techBase: activeTab.techBase,
+      unitType: activeTab.unitType as UnitType.VEHICLE | UnitType.VTOL,
+    });
+  }, [isVehicle, activeTab]);
+  
+  if (!activeTab) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="text-center text-text-theme-secondary p-8">
+          <p className="text-lg mb-2">No unit selected</p>
+          <p className="text-sm">Click &quot;New Unit&quot; to create a new unit</p>
+        </div>
+      </div>
+    );
+  }
+  
+  if (isVehicle && vehicleStore) {
+    return (
+      <VehicleStoreContext.Provider value={vehicleStore}>
+        <VehicleCustomizer
+          store={vehicleStore}
+          className="flex-1"
+        />
+      </VehicleStoreContext.Provider>
+    );
+  }
+  
+  const mechActiveTab: ActiveTabInfo = {
+    id: activeTab.id,
+    name: activeTab.name,
+    tonnage: activeTab.tonnage,
+    techBase: activeTab.techBase,
+  };
+  
+  return (
+    <UnitStoreProvider
+      activeTab={mechActiveTab}
+      fallback={
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center text-text-theme-secondary p-8">
+            <p className="text-lg mb-2">Loading unit...</p>
+          </div>
+        </div>
+      }
+    >
+      <UnitEditorWithRouting
+        activeTabId={activeTabId}
+        onTabChange={onTabChange}
+      />
+    </UnitStoreProvider>
+  );
+}
+
+export default UnitTypeRouter;

--- a/src/stores/vehicleStoreRegistry.ts
+++ b/src/stores/vehicleStoreRegistry.ts
@@ -1,0 +1,187 @@
+/**
+ * Vehicle Store Registry
+ * 
+ * Manages all active vehicle store instances.
+ * Parallels unitStoreRegistry.ts for BattleMechs.
+ */
+
+import { StoreApi } from 'zustand';
+import { VehicleStore, VehicleState, createDefaultVehicleState, CreateVehicleOptions } from './vehicleState';
+import { createVehicleStore, createNewVehicleStore } from './useVehicleStore';
+import { isValidUUID, generateUUID } from '@/utils/uuid';
+
+function safeGetItem(key: string): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(key);
+}
+
+function safeRemoveItem(key: string): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(key);
+}
+
+const vehicleStores = new Map<string, StoreApi<VehicleStore>>();
+
+export function getVehicleStore(vehicleId: string): StoreApi<VehicleStore> | undefined {
+  return vehicleStores.get(vehicleId);
+}
+
+export function hasVehicleStore(vehicleId: string): boolean {
+  return vehicleStores.has(vehicleId);
+}
+
+export function getAllVehicleIds(): string[] {
+  return Array.from(vehicleStores.keys());
+}
+
+export function getVehicleStoreCount(): number {
+  return vehicleStores.size;
+}
+
+function ensureValidVehicleId(vehicleId: string | undefined | null, context: string): string {
+  if (vehicleId && isValidUUID(vehicleId)) {
+    return vehicleId;
+  }
+  
+  const newId = generateUUID();
+  console.warn(
+    `[VehicleStoreRegistry] ${context}: Invalid vehicle ID "${vehicleId || '(missing)'}" replaced with "${newId}"`
+  );
+  return newId;
+}
+
+export function createAndRegisterVehicle(options: CreateVehicleOptions): StoreApi<VehicleStore> {
+  const store = createNewVehicleStore(options);
+  const state = store.getState();
+  vehicleStores.set(state.id, store);
+  return store;
+}
+
+export function registerVehicleStore(store: StoreApi<VehicleStore>): void {
+  const state = store.getState();
+  vehicleStores.set(state.id, store);
+}
+
+export function hydrateOrCreateVehicle(
+  vehicleId: string,
+  fallbackOptions: CreateVehicleOptions
+): StoreApi<VehicleStore> {
+  const validVehicleId = ensureValidVehicleId(vehicleId, 'hydrateOrCreateVehicle');
+  
+  const existing = vehicleStores.get(validVehicleId);
+  if (existing) {
+    return existing;
+  }
+  
+  const storageKey = `megamek-vehicle-${validVehicleId}`;
+  const savedState = safeGetItem(storageKey);
+  
+  if (savedState) {
+    try {
+      const parsed = JSON.parse(savedState) as { state?: Partial<VehicleState> };
+      const state = parsed.state;
+      
+      if (state) {
+        ensureValidVehicleId(state.id, 'localStorage state');
+        
+        const defaultState = createDefaultVehicleState({ ...fallbackOptions, id: validVehicleId });
+        const mergedState: VehicleState = {
+          ...defaultState,
+          ...state,
+          id: validVehicleId,
+        };
+      
+        const store = createVehicleStore(mergedState);
+        vehicleStores.set(validVehicleId, store);
+        return store;
+      }
+    } catch (e) {
+      console.warn(`Failed to hydrate vehicle ${validVehicleId}, creating new:`, e);
+    }
+  }
+  
+  const store = createNewVehicleStore({ ...fallbackOptions, id: validVehicleId });
+  vehicleStores.set(validVehicleId, store);
+  return store;
+}
+
+export function unregisterVehicleStore(vehicleId: string): boolean {
+  return vehicleStores.delete(vehicleId);
+}
+
+export function deleteVehicle(vehicleId: string): boolean {
+  const removed = vehicleStores.delete(vehicleId);
+  if (removed) {
+    const storageKey = `megamek-vehicle-${vehicleId}`;
+    safeRemoveItem(storageKey);
+  }
+  return removed;
+}
+
+export function clearAllVehicleStores(clearStorage = false): void {
+  if (clearStorage) {
+    Array.from(vehicleStores.keys()).forEach((vehicleId) => {
+      const storageKey = `megamek-vehicle-${vehicleId}`;
+      safeRemoveItem(storageKey);
+    });
+  }
+  vehicleStores.clear();
+}
+
+export function duplicateVehicle(sourceVehicleId: string, newName?: string): StoreApi<VehicleStore> | null {
+  const sourceStore = vehicleStores.get(sourceVehicleId);
+  if (!sourceStore) {
+    return null;
+  }
+  
+  const sourceState = sourceStore.getState();
+  const newState = createDefaultVehicleState({
+    name: newName ?? `${sourceState.name} (Copy)`,
+    tonnage: sourceState.tonnage,
+    techBase: sourceState.techBase,
+    motionType: sourceState.motionType,
+    unitType: sourceState.unitType,
+  });
+  
+  const mergedState: VehicleState = {
+    ...newState,
+    engineType: sourceState.engineType,
+    engineRating: sourceState.engineRating,
+    cruiseMP: sourceState.cruiseMP,
+    armorType: sourceState.armorType,
+    armorTonnage: sourceState.armorTonnage,
+    armorAllocation: { ...sourceState.armorAllocation },
+    turret: sourceState.turret ? { ...sourceState.turret } : null,
+    hasEnvironmentalSealing: sourceState.hasEnvironmentalSealing,
+    hasFlotationHull: sourceState.hasFlotationHull,
+    isAmphibious: sourceState.isAmphibious,
+    hasTrailerHitch: sourceState.hasTrailerHitch,
+    isTrailer: sourceState.isTrailer,
+  };
+  
+  const store = createVehicleStore(mergedState);
+  vehicleStores.set(mergedState.id, store);
+  return store;
+}
+
+export function createVehicleFromFullState(state: VehicleState): StoreApi<VehicleStore> {
+  const validId = ensureValidVehicleId(state.id, 'createVehicleFromFullState');
+  
+  const existing = vehicleStores.get(validId);
+  if (existing) {
+    console.warn(`Vehicle store ${validId} already exists, returning existing`);
+    return existing;
+  }
+  
+  const validatedState: VehicleState = {
+    ...state,
+    id: validId,
+  };
+  
+  const store = createVehicleStore(validatedState);
+  vehicleStores.set(validId, store);
+  
+  store.setState({ lastModifiedAt: Date.now() });
+  
+  return store;
+}


### PR DESCRIPTION
## Summary

Integrates the existing vehicle customizer UI components into the main app's multi-unit tab system, enabling users to create and edit vehicles alongside BattleMechs.

## Changes

- **Tab Manager**: Added `unitType` field to `TabInfo` interface to track unit types per tab
- **UnitTypeRouter**: New component that routes to appropriate customizer based on unit type (BattleMech → UnitEditor, Vehicle → VehicleCustomizer)
- **vehicleStoreRegistry**: New registry for vehicle store lifecycle management (parallels unitStoreRegistry)
- **NewTabModal**: Added BattleMech/Vehicle selector with vehicle templates (Light/Medium/Heavy/Assault)
- **MultiUnitTabs**: Updated to handle both unit types in create/close/duplicate operations
- **Backwards compatibility**: Existing tabs default to BATTLEMECH type

## Architecture

```
TabInfo.unitType → UnitTypeRouter → {
  BATTLEMECH → UnitStoreProvider + UnitEditorWithRouting
  VEHICLE/VTOL → VehicleStoreContext + VehicleCustomizer
}
```

## Testing

- ✅ Lint passes
- ✅ All tests pass
- ✅ Production build succeeds

## Related

- OpenSpec: `add-vehicle-customizer`
- Depends on: `add-multi-unit-type-support` (archived 2026-01-18)

## Remaining Work (future PRs)

Per tasks.md, the following items are deferred:
- Section 5: Vehicle Validation Rules
- Task 3.5: mm-data vehicle asset integration
- Tasks 6.3/6.4: Equipment browser unit type filtering