### PR TITLE
chore: fix lint warnings from code review (#94)

### DIFF
--- a/src/components/customizer/vehicle/VehicleArmorTab.tsx
+++ b/src/components/customizer/vehicle/VehicleArmorTab.tsx
@@ -7,7 +7,7 @@
  * @spec openspec/changes/add-multi-unit-type-support/tasks.md Phase 3.2
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useVehicleStore } from '@/stores/useVehicleStore';
 import { ArmorTypeEnum, getArmorDefinition } from '@/types/construction/ArmorType';
 import { VehicleLocation, VTOLLocation } from '@/types/construction/UnitLocation';

--- a/src/components/customizer/vehicle/VehicleDiagram.tsx
+++ b/src/components/customizer/vehicle/VehicleDiagram.tsx
@@ -11,7 +11,7 @@ import React, { useMemo } from 'react';
 import { useVehicleStore } from '@/stores/useVehicleStore';
 import { VehicleLocation, VTOLLocation } from '@/types/construction/UnitLocation';
 import { GroundMotionType } from '@/types/unit/BaseUnitInterfaces';
-import { TurretType } from '@/types/unit/VehicleInterfaces';
+
 
 // =============================================================================
 // Types

--- a/src/components/customizer/vehicle/VehicleStatusBar.tsx
+++ b/src/components/customizer/vehicle/VehicleStatusBar.tsx
@@ -10,7 +10,7 @@
 import React, { useMemo } from 'react';
 import { useVehicleStore } from '@/stores/useVehicleStore';
 import { GroundMotionType } from '@/types/unit/BaseUnitInterfaces';
-import { VehicleLocation, VTOLLocation } from '@/types/construction/UnitLocation';
+
 import { getArmorDefinition } from '@/types/construction/ArmorType';
 import { EngineType, getEngineDefinition } from '@/types/construction/EngineType';
 import { getTotalVehicleArmor } from '@/stores/vehicleState';

--- a/src/pages/api/vault/folders/[id].ts
+++ b/src/pages/api/vault/folders/[id].ts
@@ -41,7 +41,7 @@ interface ErrorResponse {
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<FolderResponse | DeleteResponse | ErrorResponse>
-) {
+): Promise<void> {
   const { id } = req.query;
 
   if (typeof id !== 'string') {

--- a/src/pages/api/vault/folders/[id]/items.ts
+++ b/src/pages/api/vault/folders/[id]/items.ts
@@ -55,7 +55,7 @@ interface ErrorResponse {
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ListItemsResponse | SuccessResponse | ErrorResponse>
-) {
+): Promise<void> {
   const { id } = req.query;
 
   if (typeof id !== 'string') {

--- a/src/pages/api/vault/folders/[id]/share.ts
+++ b/src/pages/api/vault/folders/[id]/share.ts
@@ -57,7 +57,7 @@ interface ErrorResponse {
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<SharesResponse | SuccessResponse | ErrorResponse>
-) {
+): Promise<void> {
   const { id } = req.query;
 
   if (typeof id !== 'string') {

--- a/src/pages/api/vault/folders/index.ts
+++ b/src/pages/api/vault/folders/index.ts
@@ -41,7 +41,7 @@ interface ErrorResponse {
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ListFoldersResponse | CreateFolderResponse | ErrorResponse>
-) {
+): Promise<void> {
   try {
     const vaultService = getVaultService();
 

--- a/src/pages/api/vault/permissions/bulk.ts
+++ b/src/pages/api/vault/permissions/bulk.ts
@@ -103,7 +103,7 @@ interface ErrorResponse {
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<BulkResponse | ErrorResponse>
-) {
+): Promise<void> {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }

--- a/src/pages/api/vault/public.ts
+++ b/src/pages/api/vault/public.ts
@@ -57,7 +57,7 @@ interface ErrorResponse {
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<SuccessResponse | ListResponse | ErrorResponse>
-) {
+): Promise<void> {
   try {
     const vaultService = getVaultService();
 

--- a/src/pages/api/vault/versions/[id].ts
+++ b/src/pages/api/vault/versions/[id].ts
@@ -34,7 +34,7 @@ interface ErrorResponse {
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<VersionResponse | DeleteResponse | ErrorResponse>
-) {
+): Promise<void> {
   const { id } = req.query;
 
   if (typeof id !== 'string') {

--- a/src/pages/api/vault/versions/diff.ts
+++ b/src/pages/api/vault/versions/diff.ts
@@ -29,7 +29,7 @@ interface ErrorResponse {
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<DiffResponse | ErrorResponse>
-) {
+): Promise<void> {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' });
   }

--- a/src/pages/api/vault/versions/index.ts
+++ b/src/pages/api/vault/versions/index.ts
@@ -44,7 +44,7 @@ interface ErrorResponse {
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ListVersionsResponse | CreateVersionResponse | ErrorResponse>
-) {
+): Promise<void> {
   try {
     const versionService = getVersionHistoryService();
 

--- a/src/pages/api/vault/versions/rollback.ts
+++ b/src/pages/api/vault/versions/rollback.ts
@@ -39,7 +39,7 @@ interface RollbackResponse {
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<RollbackResponse>
-) {
+): Promise<void> {
   if (req.method !== 'POST') {
     return res.status(405).json({ success: false, error: 'Method not allowed' });
   }

--- a/src/services/units/handlers/AerospaceUnitHandler.ts
+++ b/src/services/units/handlers/AerospaceUnitHandler.ts
@@ -35,7 +35,7 @@ import {
  * Aerospace armor arc order for array parsing
  * BLK format: Nose, Left Wing, Right Wing, Aft
  */
-const AEROSPACE_ARMOR_ARCS = ['nose', 'leftWing', 'rightWing', 'aft'] as const;
+const _AEROSPACE_ARMOR_ARCS = ['nose', 'leftWing', 'rightWing', 'aft'] as const;
 
 /**
  * Map location strings to AerospaceLocation enum
@@ -362,7 +362,7 @@ export class AerospaceUnitHandler extends AbstractUnitTypeHandler<IAerospace> {
   /**
    * Deserialize from standard format
    */
-  deserialize(serialized: ISerializedUnit): IUnitParseResult<IAerospace> {
+  deserialize(_serialized: ISerializedUnit): IUnitParseResult<IAerospace> {
     return createFailureResult(['Aerospace deserialization not yet implemented']);
   }
 

--- a/src/services/units/handlers/BattleArmorUnitHandler.ts
+++ b/src/services/units/handlers/BattleArmorUnitHandler.ts
@@ -386,7 +386,7 @@ export class BattleArmorUnitHandler extends AbstractUnitTypeHandler<IBattleArmor
   /**
    * Deserialize from standard format
    */
-  deserialize(serialized: ISerializedUnit): IUnitParseResult<IBattleArmor> {
+  deserialize(_serialized: ISerializedUnit): IUnitParseResult<IBattleArmor> {
     return createFailureResult(['Battle Armor deserialization not yet implemented']);
   }
 

--- a/src/services/units/handlers/ConventionalFighterUnitHandler.ts
+++ b/src/services/units/handlers/ConventionalFighterUnitHandler.ts
@@ -340,7 +340,7 @@ export class ConventionalFighterUnitHandler extends AbstractUnitTypeHandler<ICon
   /**
    * Deserialize from standard format
    */
-  deserialize(serialized: ISerializedUnit): IUnitParseResult<IConventionalFighter> {
+  deserialize(_serialized: ISerializedUnit): IUnitParseResult<IConventionalFighter> {
     return createFailureResult(['Conventional Fighter deserialization not yet implemented']);
   }
 

--- a/src/services/units/handlers/DropShipUnitHandler.ts
+++ b/src/services/units/handlers/DropShipUnitHandler.ts
@@ -39,7 +39,7 @@ import {
 /**
  * DropShip armor arc order for array parsing
  */
-const DROPSHIP_ARMOR_ARCS = [
+const _DROPSHIP_ARMOR_ARCS = [
   'nose',
   'frontLeftSide',
   'frontRightSide',
@@ -454,7 +454,7 @@ export class DropShipUnitHandler extends AbstractUnitTypeHandler<IDropShip> {
   /**
    * Deserialize from standard format
    */
-  deserialize(serialized: ISerializedUnit): IUnitParseResult<IDropShip> {
+  deserialize(_serialized: ISerializedUnit): IUnitParseResult<IDropShip> {
     return createFailureResult(['DropShip deserialization not yet implemented']);
   }
 

--- a/src/services/units/handlers/InfantryUnitHandler.ts
+++ b/src/services/units/handlers/InfantryUnitHandler.ts
@@ -308,7 +308,7 @@ export class InfantryUnitHandler extends AbstractUnitTypeHandler<IInfantry> {
   /**
    * Deserialize from standard format
    */
-  deserialize(serialized: ISerializedUnit): IUnitParseResult<IInfantry> {
+  deserialize(_serialized: ISerializedUnit): IUnitParseResult<IInfantry> {
     return createFailureResult(['Infantry deserialization not yet implemented']);
   }
 
@@ -364,7 +364,7 @@ export class InfantryUnitHandler extends AbstractUnitTypeHandler<IInfantry> {
     let weight = unit.platoonStrength * soldierWeight;
 
     // Add field gun weight
-    for (const gun of unit.fieldGuns) {
+    for (const _gun of unit.fieldGuns) {
       weight += 0.5; // Assume 0.5 tons per field gun
     }
 
@@ -420,7 +420,7 @@ export class InfantryUnitHandler extends AbstractUnitTypeHandler<IInfantry> {
 
     // Field gun cost
     let fieldGunCost = 0;
-    for (const gun of unit.fieldGuns) {
+    for (const _gun of unit.fieldGuns) {
       fieldGunCost += 50000;
     }
 

--- a/src/services/units/handlers/JumpShipUnitHandler.ts
+++ b/src/services/units/handlers/JumpShipUnitHandler.ts
@@ -503,7 +503,7 @@ export class JumpShipUnitHandler extends AbstractUnitTypeHandler<IJumpShip> {
   /**
    * Deserialize from standard format
    */
-  deserialize(serialized: ISerializedUnit): IUnitParseResult<IJumpShip> {
+  deserialize(_serialized: ISerializedUnit): IUnitParseResult<IJumpShip> {
     return createFailureResult(['JumpShip deserialization not yet implemented']);
   }
 

--- a/src/services/units/handlers/ProtoMechUnitHandler.ts
+++ b/src/services/units/handlers/ProtoMechUnitHandler.ts
@@ -322,7 +322,7 @@ export class ProtoMechUnitHandler extends AbstractUnitTypeHandler<IProtoMech> {
   /**
    * Deserialize from standard format
    */
-  deserialize(serialized: ISerializedUnit): IUnitParseResult<IProtoMech> {
+  deserialize(_serialized: ISerializedUnit): IUnitParseResult<IProtoMech> {
     return createFailureResult(['ProtoMech deserialization not yet implemented']);
   }
 

--- a/src/services/units/handlers/SmallCraftUnitHandler.ts
+++ b/src/services/units/handlers/SmallCraftUnitHandler.ts
@@ -309,7 +309,7 @@ export class SmallCraftUnitHandler extends AbstractUnitTypeHandler<ISmallCraft> 
   /**
    * Deserialize from standard format
    */
-  deserialize(serialized: ISerializedUnit): IUnitParseResult<ISmallCraft> {
+  deserialize(_serialized: ISerializedUnit): IUnitParseResult<ISmallCraft> {
     return createFailureResult(['Small Craft deserialization not yet implemented']);
   }
 

--- a/src/services/units/handlers/SpaceStationUnitHandler.ts
+++ b/src/services/units/handlers/SpaceStationUnitHandler.ts
@@ -527,7 +527,7 @@ export class SpaceStationUnitHandler extends AbstractUnitTypeHandler<ISpaceStati
   /**
    * Deserialize from standard format
    */
-  deserialize(serialized: ISerializedUnit): IUnitParseResult<ISpaceStation> {
+  deserialize(_serialized: ISerializedUnit): IUnitParseResult<ISpaceStation> {
     return createFailureResult(['Space Station deserialization not yet implemented']);
   }
 

--- a/src/services/units/handlers/SupportVehicleUnitHandler.ts
+++ b/src/services/units/handlers/SupportVehicleUnitHandler.ts
@@ -14,8 +14,6 @@ import { ISerializedUnit } from '../../../types/unit/UnitSerialization';
 import {
   ISupportVehicle,
   IVehicleMountedEquipment,
-  ITurretConfiguration,
-  TurretType,
   SupportVehicleSizeClass,
 } from '../../../types/unit/VehicleInterfaces';
 import {
@@ -357,7 +355,7 @@ export class SupportVehicleUnitHandler extends AbstractUnitTypeHandler<ISupportV
   /**
    * Deserialize from standard format
    */
-  deserialize(serialized: ISerializedUnit): IUnitParseResult<ISupportVehicle> {
+  deserialize(_serialized: ISerializedUnit): IUnitParseResult<ISupportVehicle> {
     return createFailureResult(['Support Vehicle deserialization not yet implemented']);
   }
 

--- a/src/services/units/handlers/VTOLUnitHandler.ts
+++ b/src/services/units/handlers/VTOLUnitHandler.ts
@@ -324,7 +324,7 @@ export class VTOLUnitHandler extends AbstractUnitTypeHandler<IVTOL> {
    * Determine weight class from tonnage
    * VTOLs are always light (max 30 tons)
    */
-  private getWeightClass(tonnage: number): WeightClass {
+  private getWeightClass(_tonnage: number): WeightClass {
     return WeightClass.LIGHT;
   }
 
@@ -372,7 +372,7 @@ export class VTOLUnitHandler extends AbstractUnitTypeHandler<IVTOL> {
   /**
    * Deserialize from standard format
    */
-  deserialize(serialized: ISerializedUnit): IUnitParseResult<IVTOL> {
+  deserialize(_serialized: ISerializedUnit): IUnitParseResult<IVTOL> {
     return createFailureResult(['VTOL deserialization not yet implemented']);
   }
 

--- a/src/services/units/handlers/VehicleUnitHandler.ts
+++ b/src/services/units/handlers/VehicleUnitHandler.ts
@@ -25,8 +25,6 @@ import { IUnitParseResult } from '../../../types/unit/UnitTypeHandler';
 import { TechBase, Era, WeightClass, RulesLevel } from '../../../types/enums';
 import {
   AbstractUnitTypeHandler,
-  parseIntField,
-  parseNumericField,
   createFailureResult,
 } from './AbstractUnitTypeHandler';
 
@@ -421,7 +419,7 @@ export class VehicleUnitHandler extends AbstractUnitTypeHandler<IVehicle> {
   /**
    * Deserialize from standard format
    */
-  deserialize(serialized: ISerializedUnit): IUnitParseResult<IVehicle> {
+  deserialize(_serialized: ISerializedUnit): IUnitParseResult<IVehicle> {
     // Full deserialization would require mapping all serialized fields back
     return createFailureResult(['Vehicle deserialization not yet implemented']);
   }

--- a/src/services/units/handlers/WarShipUnitHandler.ts
+++ b/src/services/units/handlers/WarShipUnitHandler.ts
@@ -40,7 +40,7 @@ import {
 /**
  * WarShip armor arc order for array parsing (includes broadsides)
  */
-const WARSHIP_ARMOR_ARCS = [
+const _WARSHIP_ARMOR_ARCS = [
   'nose',
   'frontLeftSide',
   'frontRightSide',
@@ -517,7 +517,7 @@ export class WarShipUnitHandler extends AbstractUnitTypeHandler<IWarShip> {
   /**
    * Deserialize from standard format
    */
-  deserialize(serialized: ISerializedUnit): IUnitParseResult<IWarShip> {
+  deserialize(_serialized: ISerializedUnit): IUnitParseResult<IWarShip> {
     return createFailureResult(['WarShip deserialization not yet implemented']);
   }
 

--- a/src/services/units/handlers/__tests__/AerospaceUnitHandler.test.ts
+++ b/src/services/units/handlers/__tests__/AerospaceUnitHandler.test.ts
@@ -8,7 +8,7 @@ import { AerospaceUnitHandler, createAerospaceHandler } from '../AerospaceUnitHa
 import { IBlkDocument } from '../../../../types/formats/BlkFormat';
 import { UnitType } from '../../../../types/unit/BattleMechInterfaces';
 import { AerospaceMotionType } from '../../../../types/unit/BaseUnitInterfaces';
-import { AerospaceCockpitType } from '../../../../types/unit/AerospaceInterfaces';
+
 
 // ============================================================================
 // Test Fixtures


### PR DESCRIPTION
## Summary

Resolves all 30 eslint warnings identified during code review of recent PR merges (#79-93).

## Changes

### Unit Handler Files (13 files)
- Prefix unused `serialized` parameters with `_` in deserialize methods
- Prefix unused loop variables (`gun`) with `_`
- Prefix unused constants (`AEROSPACE_ARMOR_ARCS`, `DROPSHIP_ARMOR_ARCS`, `WARSHIP_ARMOR_ARCS`) with `_`
- Remove unused imports (`ITurretConfiguration`, `TurretType`, `parseIntField`, `parseNumericField`)

### Vault API Handlers (10 files)
- Add explicit `Promise<void>` return type to all handler functions

### Vehicle Customizer Components (3 files)
- Remove unused imports (`useState`, `TurretType`, `VehicleLocation`, `VTOLLocation`)

### Test Files (1 file)
- Remove unused import (`AerospaceCockpitType`)

## Verification

- ✅ `npm run lint` → 0 warnings (was 30)
- ✅ `npm run typecheck` → Pass
- ✅ `npm run test` → 270 suites, 6,551 tests passing