### PR TITLE
feat(customizer): integrate aerospace and personnel customizers

### DIFF
--- a/openspec/changes/add-aerospace-customizer/tasks.md
+++ b/openspec/changes/add-aerospace-customizer/tasks.md
@@ -1,34 +1,34 @@
 # Tasks: Aerospace Customizer UI
 
 ## 1. Aerospace State Management
-- [ ] 1.1 Create `AerospaceState` interface
-- [ ] 1.2 Add aerospace-specific fields (thrust, fuel, SI)
-- [ ] 1.3 Implement aerospace state <-> serialization mapping
+- [x] 1.1 Create `AerospaceState` interface
+- [x] 1.2 Add aerospace-specific fields (thrust, fuel, SI)
+- [x] 1.3 Implement aerospace state <-> serialization mapping
 
 ## 2. Aerospace Customizer Tabs
-- [ ] 2.1 Create `AerospaceStructureTab` component
-  - [ ] Tonnage and engine selection
-  - [ ] Heat sink configuration
-  - [ ] Fuel capacity
-  - [ ] Structural integrity
-- [ ] 2.2 Create `AerospaceArmorTab` component
-  - [ ] Nose/Wings/Aft allocation
-  - [ ] Capital armor for large aero
-- [ ] 2.3 Create `AerospaceEquipmentTab` component
-  - [ ] Arc-based weapon mounting
-  - [ ] Bomb bay equipment (if applicable)
+- [x] 2.1 Create `AerospaceStructureTab` component
+  - [x] Tonnage and engine selection
+  - [x] Heat sink configuration
+  - [x] Fuel capacity
+  - [x] Structural integrity
+- [x] 2.2 Create `AerospaceArmorTab` component
+  - [x] Nose/Wings/Aft allocation
+  - [ ] Capital armor for large aero (future enhancement)
+- [x] 2.3 Create `AerospaceEquipmentTab` component
+  - [x] Arc-based weapon mounting
+  - [x] Bomb bay equipment (if applicable)
 
 ## 3. Aerospace Diagram
-- [ ] 3.1 Create `AerospaceDiagram` component
-- [ ] 3.2 Implement weapon arc visualization
-- [ ] 3.3 Show nose/wing/aft locations
-- [ ] 3.4 Display armor and equipment
+- [x] 3.1 Create `AerospaceDiagram` component
+- [x] 3.2 Implement weapon arc visualization
+- [x] 3.3 Show nose/wing/aft locations
+- [x] 3.4 Display armor and equipment
 
 ## 4. Aerospace Status Bar
-- [ ] 4.1 Create `AerospaceStatusBar` extending base
-- [ ] 4.2 Show thrust ratings
-- [ ] 4.3 Show fuel consumption
-- [ ] 4.4 Show heat tracking
+- [x] 4.1 Create `AerospaceStatusBar` extending base
+- [x] 4.2 Show thrust ratings
+- [x] 4.3 Show fuel consumption
+- [x] 4.4 Show heat tracking
 
 ## 5. Aerospace Validation Rules
 - [ ] 5.1 Create `AerospaceValidationRules` extending validation framework
@@ -38,6 +38,8 @@
 - [ ] 5.5 Register rules with validation orchestrator
 
 ## 6. Integration
-- [ ] 6.1 Add aerospace to unit type selector
-- [ ] 6.2 Route aerospace units to AerospaceCustomizer
-- [ ] 6.3 Handle conventional fighter variant
+- [x] 6.1 Add aerospace to unit type selector (NewTabModal)
+- [x] 6.2 Route aerospace units to AerospaceCustomizer (UnitTypeRouter)
+- [x] 6.3 Handle conventional fighter variant
+- [x] 6.4 Create aerospaceStoreRegistry.ts for store management
+- [x] 6.5 Update MultiUnitTabs to handle aerospace unit creation

--- a/src/components/customizer/UnitTypeRouter.tsx
+++ b/src/components/customizer/UnitTypeRouter.tsx
@@ -10,11 +10,34 @@ import React, { useMemo } from 'react';
 import { UnitType } from '@/types/unit/BattleMechInterfaces';
 import { TabInfo } from '@/stores/useTabManagerStore';
 import { UnitStoreProvider, ActiveTabInfo } from '@/stores/UnitStoreProvider';
+
+// Vehicle
 import { getVehicleStore, hydrateOrCreateVehicle } from '@/stores/vehicleStoreRegistry';
 import { VehicleStoreContext } from '@/stores/useVehicleStore';
-
-import { UnitEditorWithRouting } from './UnitEditorWithRouting';
 import { VehicleCustomizer } from './vehicle/VehicleCustomizer';
+
+// Aerospace
+import { getAerospaceStore, hydrateOrCreateAerospace } from '@/stores/aerospaceStoreRegistry';
+import { AerospaceStoreContext } from '@/stores/useAerospaceStore';
+import { AerospaceCustomizer } from './aerospace/AerospaceCustomizer';
+
+// Battle Armor
+import { getBattleArmorStore, hydrateOrCreateBattleArmor } from '@/stores/battleArmorStoreRegistry';
+import { BattleArmorStoreContext } from '@/stores/useBattleArmorStore';
+import { BattleArmorCustomizer } from './battlearmor/BattleArmorCustomizer';
+
+// Infantry
+import { getInfantryStore, hydrateOrCreateInfantry } from '@/stores/infantryStoreRegistry';
+import { InfantryStoreContext } from '@/stores/useInfantryStore';
+import { InfantryCustomizer } from './infantry/InfantryCustomizer';
+
+// ProtoMech
+import { getProtoMechStore, hydrateOrCreateProtoMech } from '@/stores/protoMechStoreRegistry';
+import { ProtoMechStoreContext } from '@/stores/useProtoMechStore';
+import { ProtoMechCustomizer } from './protomech/ProtoMechCustomizer';
+
+// BattleMech
+import { UnitEditorWithRouting } from './UnitEditorWithRouting';
 import { CustomizerTabId } from '@/hooks/useCustomizerRouter';
 
 interface UnitTypeRouterProps {
@@ -28,8 +51,14 @@ export function UnitTypeRouter({
   activeTabId,
   onTabChange,
 }: UnitTypeRouterProps): React.ReactElement {
+  // Determine unit type categories
   const isVehicle = activeTab?.unitType === UnitType.VEHICLE || activeTab?.unitType === UnitType.VTOL;
+  const isAerospace = activeTab?.unitType === UnitType.AEROSPACE || activeTab?.unitType === UnitType.CONVENTIONAL_FIGHTER;
+  const isBattleArmor = activeTab?.unitType === UnitType.BATTLE_ARMOR;
+  const isInfantry = activeTab?.unitType === UnitType.INFANTRY;
+  const isProtoMech = activeTab?.unitType === UnitType.PROTOMECH;
   
+  // Vehicle store
   const vehicleStore = useMemo(() => {
     if (!isVehicle || !activeTab) return null;
     
@@ -44,6 +73,61 @@ export function UnitTypeRouter({
     });
   }, [isVehicle, activeTab]);
   
+  // Aerospace store
+  const aerospaceStore = useMemo(() => {
+    if (!isAerospace || !activeTab) return null;
+    
+    const existing = getAerospaceStore(activeTab.id);
+    if (existing) return existing;
+    
+    return hydrateOrCreateAerospace(activeTab.id, {
+      name: activeTab.name,
+      tonnage: activeTab.tonnage,
+      techBase: activeTab.techBase,
+      isConventional: activeTab.unitType === UnitType.CONVENTIONAL_FIGHTER,
+    });
+  }, [isAerospace, activeTab]);
+  
+  // Battle Armor store
+  const battleArmorStore = useMemo(() => {
+    if (!isBattleArmor || !activeTab) return null;
+    
+    const existing = getBattleArmorStore(activeTab.id);
+    if (existing) return existing;
+    
+    return hydrateOrCreateBattleArmor(activeTab.id, {
+      name: activeTab.name,
+      techBase: activeTab.techBase,
+    });
+  }, [isBattleArmor, activeTab]);
+  
+  // Infantry store
+  const infantryStore = useMemo(() => {
+    if (!isInfantry || !activeTab) return null;
+    
+    const existing = getInfantryStore(activeTab.id);
+    if (existing) return existing;
+    
+    return hydrateOrCreateInfantry(activeTab.id, {
+      name: activeTab.name,
+      techBase: activeTab.techBase,
+    });
+  }, [isInfantry, activeTab]);
+  
+  // ProtoMech store
+  const protoMechStore = useMemo(() => {
+    if (!isProtoMech || !activeTab) return null;
+    
+    const existing = getProtoMechStore(activeTab.id);
+    if (existing) return existing;
+    
+    return hydrateOrCreateProtoMech(activeTab.id, {
+      name: activeTab.name,
+      tonnage: activeTab.tonnage,
+    });
+  }, [isProtoMech, activeTab]);
+  
+  // No active tab
   if (!activeTab) {
     return (
       <div className="flex-1 flex items-center justify-center">
@@ -55,6 +139,7 @@ export function UnitTypeRouter({
     );
   }
   
+  // Vehicle customizer
   if (isVehicle && vehicleStore) {
     return (
       <VehicleStoreContext.Provider value={vehicleStore}>
@@ -66,6 +151,55 @@ export function UnitTypeRouter({
     );
   }
   
+  // Aerospace customizer
+  if (isAerospace && aerospaceStore) {
+    return (
+      <AerospaceStoreContext.Provider value={aerospaceStore}>
+        <AerospaceCustomizer
+          store={aerospaceStore}
+          className="flex-1"
+        />
+      </AerospaceStoreContext.Provider>
+    );
+  }
+  
+  // Battle Armor customizer
+  if (isBattleArmor && battleArmorStore) {
+    return (
+      <BattleArmorStoreContext.Provider value={battleArmorStore}>
+        <BattleArmorCustomizer
+          store={battleArmorStore}
+          className="flex-1"
+        />
+      </BattleArmorStoreContext.Provider>
+    );
+  }
+  
+  // Infantry customizer
+  if (isInfantry && infantryStore) {
+    return (
+      <InfantryStoreContext.Provider value={infantryStore}>
+        <InfantryCustomizer
+          store={infantryStore}
+          className="flex-1"
+        />
+      </InfantryStoreContext.Provider>
+    );
+  }
+  
+  // ProtoMech customizer
+  if (isProtoMech && protoMechStore) {
+    return (
+      <ProtoMechStoreContext.Provider value={protoMechStore}>
+        <ProtoMechCustomizer
+          store={protoMechStore}
+          className="flex-1"
+        />
+      </ProtoMechStoreContext.Provider>
+    );
+  }
+  
+  // Default: BattleMech editor
   const mechActiveTab: ActiveTabInfo = {
     id: activeTab.id,
     name: activeTab.name,

--- a/src/components/customizer/tabs/NewTabModal.tsx
+++ b/src/components/customizer/tabs/NewTabModal.tsx
@@ -2,6 +2,7 @@
  * New Tab Modal Component
  * 
  * Modal dialog for creating new unit tabs.
+ * Supports all unit types: BattleMech, Vehicle, Aerospace, Battle Armor, Infantry, ProtoMech.
  * 
  * @spec openspec/specs/multi-unit-tabs/spec.md
  */
@@ -13,7 +14,17 @@ import { UNIT_TEMPLATES, UnitTemplate } from '@/stores/useMultiUnitStore';
 
 type CreationMode = 'new' | 'copy' | 'import';
 
-type SupportedUnitType = UnitType.BATTLEMECH | UnitType.VEHICLE;
+type SupportedUnitType = 
+  | UnitType.BATTLEMECH 
+  | UnitType.VEHICLE 
+  | UnitType.AEROSPACE 
+  | UnitType.BATTLE_ARMOR 
+  | UnitType.INFANTRY 
+  | UnitType.PROTOMECH;
+
+// =============================================================================
+// Templates
+// =============================================================================
 
 interface VehicleTemplate {
   readonly id: string;
@@ -23,6 +34,35 @@ interface VehicleTemplate {
   readonly cruiseMP: number;
 }
 
+interface AerospaceTemplate {
+  readonly id: string;
+  readonly name: string;
+  readonly tonnage: number;
+  readonly techBase: TechBase;
+  readonly safeThrust: number;
+}
+
+interface BattleArmorTemplate {
+  readonly id: string;
+  readonly name: string;
+  readonly squadSize: number;
+  readonly techBase: TechBase;
+}
+
+interface InfantryTemplate {
+  readonly id: string;
+  readonly name: string;
+  readonly squadSize: number;
+  readonly numberOfSquads: number;
+  readonly techBase: TechBase;
+}
+
+interface ProtoMechTemplate {
+  readonly id: string;
+  readonly name: string;
+  readonly tonnage: number;
+}
+
 const VEHICLE_TEMPLATES: readonly VehicleTemplate[] = [
   { id: 'light-veh', name: 'Light Vehicle', tonnage: 20, techBase: TechBase.INNER_SPHERE, cruiseMP: 6 },
   { id: 'medium-veh', name: 'Medium Vehicle', tonnage: 40, techBase: TechBase.INNER_SPHERE, cruiseMP: 5 },
@@ -30,11 +70,67 @@ const VEHICLE_TEMPLATES: readonly VehicleTemplate[] = [
   { id: 'assault-veh', name: 'Assault Vehicle', tonnage: 80, techBase: TechBase.INNER_SPHERE, cruiseMP: 3 },
 ];
 
+const AEROSPACE_TEMPLATES: readonly AerospaceTemplate[] = [
+  { id: 'light-aero', name: 'Light Fighter', tonnage: 20, techBase: TechBase.INNER_SPHERE, safeThrust: 7 },
+  { id: 'medium-aero', name: 'Medium Fighter', tonnage: 45, techBase: TechBase.INNER_SPHERE, safeThrust: 5 },
+  { id: 'heavy-aero', name: 'Heavy Fighter', tonnage: 75, techBase: TechBase.INNER_SPHERE, safeThrust: 4 },
+  { id: 'assault-aero', name: 'Assault Fighter', tonnage: 100, techBase: TechBase.INNER_SPHERE, safeThrust: 3 },
+];
+
+const BATTLE_ARMOR_TEMPLATES: readonly BattleArmorTemplate[] = [
+  { id: 'light-ba', name: 'Light BA (4-trooper)', squadSize: 4, techBase: TechBase.INNER_SPHERE },
+  { id: 'medium-ba', name: 'Medium BA (4-trooper)', squadSize: 4, techBase: TechBase.INNER_SPHERE },
+  { id: 'heavy-ba', name: 'Heavy BA (4-trooper)', squadSize: 4, techBase: TechBase.INNER_SPHERE },
+  { id: 'clan-ba', name: 'Clan Elemental (5-point)', squadSize: 5, techBase: TechBase.CLAN },
+];
+
+const INFANTRY_TEMPLATES: readonly InfantryTemplate[] = [
+  { id: 'rifle-platoon', name: 'Rifle Platoon', squadSize: 7, numberOfSquads: 4, techBase: TechBase.INNER_SPHERE },
+  { id: 'laser-platoon', name: 'Laser Platoon', squadSize: 7, numberOfSquads: 4, techBase: TechBase.INNER_SPHERE },
+  { id: 'jump-platoon', name: 'Jump Platoon', squadSize: 7, numberOfSquads: 4, techBase: TechBase.INNER_SPHERE },
+  { id: 'mechanized-platoon', name: 'Mechanized Platoon', squadSize: 6, numberOfSquads: 4, techBase: TechBase.INNER_SPHERE },
+];
+
+const PROTOMECH_TEMPLATES: readonly ProtoMechTemplate[] = [
+  { id: 'light-proto', name: 'Light ProtoMech', tonnage: 3 },
+  { id: 'medium-proto', name: 'Medium ProtoMech', tonnage: 5 },
+  { id: 'heavy-proto', name: 'Heavy ProtoMech', tonnage: 7 },
+  { id: 'assault-proto', name: 'Assault ProtoMech', tonnage: 9 },
+];
+
+// =============================================================================
+// Unit Type Button Config
+// =============================================================================
+
+interface UnitTypeConfig {
+  type: SupportedUnitType;
+  label: string;
+  color: string;
+  activeColor: string;
+}
+
+const UNIT_TYPE_CONFIGS: UnitTypeConfig[] = [
+  { type: UnitType.BATTLEMECH, label: 'BattleMech', color: 'amber', activeColor: 'border-amber-500 bg-amber-900/30 text-amber-300' },
+  { type: UnitType.VEHICLE, label: 'Vehicle', color: 'cyan', activeColor: 'border-cyan-500 bg-cyan-900/30 text-cyan-300' },
+  { type: UnitType.AEROSPACE, label: 'Aerospace', color: 'sky', activeColor: 'border-sky-500 bg-sky-900/30 text-sky-300' },
+  { type: UnitType.BATTLE_ARMOR, label: 'Battle Armor', color: 'purple', activeColor: 'border-purple-500 bg-purple-900/30 text-purple-300' },
+  { type: UnitType.INFANTRY, label: 'Infantry', color: 'emerald', activeColor: 'border-emerald-500 bg-emerald-900/30 text-emerald-300' },
+  { type: UnitType.PROTOMECH, label: 'ProtoMech', color: 'rose', activeColor: 'border-rose-500 bg-rose-900/30 text-rose-300' },
+];
+
+// =============================================================================
+// Component Props
+// =============================================================================
+
 interface NewTabModalProps {
   isOpen: boolean;
   onClose: () => void;
   onCreateUnit: (tonnage: number, techBase?: TechBase, unitType?: UnitType) => string;
 }
+
+// =============================================================================
+// Component
+// =============================================================================
 
 /**
  * New unit tab creation modal
@@ -48,18 +144,43 @@ export function NewTabModal({
   const [unitType, setUnitType] = useState<SupportedUnitType>(UnitType.BATTLEMECH);
   const [selectedMechTemplate, setSelectedMechTemplate] = useState<UnitTemplate>(UNIT_TEMPLATES[1]);
   const [selectedVehicleTemplate, setSelectedVehicleTemplate] = useState<VehicleTemplate>(VEHICLE_TEMPLATES[1]);
+  const [selectedAerospaceTemplate, setSelectedAerospaceTemplate] = useState<AerospaceTemplate>(AEROSPACE_TEMPLATES[1]);
+  const [selectedBattleArmorTemplate, setSelectedBattleArmorTemplate] = useState<BattleArmorTemplate>(BATTLE_ARMOR_TEMPLATES[0]);
+  const [selectedInfantryTemplate, setSelectedInfantryTemplate] = useState<InfantryTemplate>(INFANTRY_TEMPLATES[0]);
+  const [selectedProtoMechTemplate, setSelectedProtoMechTemplate] = useState<ProtoMechTemplate>(PROTOMECH_TEMPLATES[1]);
   const [techBase, setTechBase] = useState<TechBase>(TechBase.INNER_SPHERE);
   
+  // Calculate selected tonnage based on unit type
   const selectedTonnage = useMemo(() => {
-    return unitType === UnitType.BATTLEMECH 
-      ? selectedMechTemplate.tonnage 
-      : selectedVehicleTemplate.tonnage;
-  }, [unitType, selectedMechTemplate, selectedVehicleTemplate]);
+    switch (unitType) {
+      case UnitType.BATTLEMECH:
+        return selectedMechTemplate.tonnage;
+      case UnitType.VEHICLE:
+        return selectedVehicleTemplate.tonnage;
+      case UnitType.AEROSPACE:
+        return selectedAerospaceTemplate.tonnage;
+      case UnitType.BATTLE_ARMOR:
+        return 0; // BA doesn't use tonnage in the same way
+      case UnitType.INFANTRY:
+        return 0; // Infantry doesn't use tonnage
+      case UnitType.PROTOMECH:
+        return selectedProtoMechTemplate.tonnage;
+      default:
+        return 50;
+    }
+  }, [unitType, selectedMechTemplate, selectedVehicleTemplate, selectedAerospaceTemplate, selectedProtoMechTemplate]);
+  
+  // Determine effective tech base (ProtoMech forces Clan)
+  const effectiveTechBase = useMemo(() => {
+    if (unitType === UnitType.PROTOMECH) return TechBase.CLAN;
+    if (unitType === UnitType.BATTLE_ARMOR && selectedBattleArmorTemplate.techBase === TechBase.CLAN) return TechBase.CLAN;
+    return techBase;
+  }, [unitType, techBase, selectedBattleArmorTemplate]);
   
   if (!isOpen) return null;
   
   const handleCreate = () => {
-    onCreateUnit(selectedTonnage, techBase, unitType);
+    onCreateUnit(selectedTonnage, effectiveTechBase, unitType);
     onClose();
   };
   
@@ -81,7 +202,7 @@ export function NewTabModal({
       onClick={handleOverlayClick}
       onKeyDown={handleKeyDown}
     >
-      <div className="bg-surface-base rounded-lg border border-border-theme-subtle shadow-xl w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto">
+      <div className="bg-surface-base rounded-lg border border-border-theme-subtle shadow-xl w-full max-w-2xl mx-4 max-h-[90vh] overflow-y-auto">
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-border-theme-subtle sticky top-0 bg-surface-base z-10">
           <h2 className="text-lg font-semibold text-white">Create New Unit</h2>
@@ -118,32 +239,25 @@ export function NewTabModal({
         <div className="p-4">
           {mode === 'new' && (
             <div className="space-y-4">
-              {/* Unit Type Selection */}
+              {/* Unit Type Selection - Grid of 6 */}
               <div>
                 <label className="block text-sm font-medium text-slate-300 mb-2">
                   Unit Type
                 </label>
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => setUnitType(UnitType.BATTLEMECH)}
-                    className={`flex-1 px-4 py-2 rounded-lg border text-sm font-medium transition-colors ${
-                      unitType === UnitType.BATTLEMECH
-                        ? 'border-amber-500 bg-amber-900/30 text-amber-300'
-                        : 'border-border-theme text-text-theme-secondary hover:border-border-theme-subtle'
-                    }`}
-                  >
-                    BattleMech
-                  </button>
-                  <button
-                    onClick={() => setUnitType(UnitType.VEHICLE)}
-                    className={`flex-1 px-4 py-2 rounded-lg border text-sm font-medium transition-colors ${
-                      unitType === UnitType.VEHICLE
-                        ? 'border-cyan-500 bg-cyan-900/30 text-cyan-300'
-                        : 'border-border-theme text-text-theme-secondary hover:border-border-theme-subtle'
-                    }`}
-                  >
-                    Vehicle
-                  </button>
+                <div className="grid grid-cols-3 gap-2">
+                  {UNIT_TYPE_CONFIGS.map((config) => (
+                    <button
+                      key={config.type}
+                      onClick={() => setUnitType(config.type)}
+                      className={`px-3 py-2 rounded-lg border text-sm font-medium transition-colors ${
+                        unitType === config.type
+                          ? config.activeColor
+                          : 'border-border-theme text-text-theme-secondary hover:border-border-theme-subtle'
+                      }`}
+                    >
+                      {config.label}
+                    </button>
+                  ))}
                 </div>
               </div>
 
@@ -200,35 +314,145 @@ export function NewTabModal({
                   </div>
                 </div>
               )}
-              
-              {/* Tech base selection */}
-              <div>
-                <label className="block text-sm font-medium text-slate-300 mb-2">
-                  Tech Base
-                </label>
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => setTechBase(TechBase.INNER_SPHERE)}
-                    className={`flex-1 px-4 py-2 rounded-lg border text-sm font-medium transition-colors ${
-                      techBase === TechBase.INNER_SPHERE
-                        ? 'border-blue-500 bg-blue-900/30 text-blue-300'
-                        : 'border-border-theme text-text-theme-secondary hover:border-border-theme-subtle'
-                    }`}
-                  >
-                    Inner Sphere
-                  </button>
-                  <button
-                    onClick={() => setTechBase(TechBase.CLAN)}
-                    className={`flex-1 px-4 py-2 rounded-lg border text-sm font-medium transition-colors ${
-                      techBase === TechBase.CLAN
-                        ? 'border-green-500 bg-green-900/30 text-green-300'
-                        : 'border-border-theme text-text-theme-secondary hover:border-border-theme-subtle'
-                    }`}
-                  >
-                    Clan
-                  </button>
+
+              {/* Template selection - Aerospace */}
+              {unitType === UnitType.AEROSPACE && (
+                <div>
+                  <label className="block text-sm font-medium text-slate-300 mb-2">
+                    Select Template
+                  </label>
+                  <div className="grid grid-cols-2 gap-2">
+                    {AEROSPACE_TEMPLATES.map((template) => (
+                      <button
+                        key={template.id}
+                        onClick={() => setSelectedAerospaceTemplate(template)}
+                        className={`p-3 rounded-lg border text-left transition-colors ${
+                          selectedAerospaceTemplate.id === template.id
+                            ? 'border-blue-500 bg-blue-900/30'
+                            : 'border-border-theme hover:border-border-theme-subtle'
+                        }`}
+                      >
+                        <div className="text-sm font-medium text-white">{template.name}</div>
+                        <div className="text-xs text-text-theme-secondary">
+                          {template.tonnage}t • Thrust {template.safeThrust}/{Math.floor(template.safeThrust * 1.5)}
+                        </div>
+                      </button>
+                    ))}
+                  </div>
                 </div>
-              </div>
+              )}
+
+              {/* Template selection - Battle Armor */}
+              {unitType === UnitType.BATTLE_ARMOR && (
+                <div>
+                  <label className="block text-sm font-medium text-slate-300 mb-2">
+                    Select Template
+                  </label>
+                  <div className="grid grid-cols-2 gap-2">
+                    {BATTLE_ARMOR_TEMPLATES.map((template) => (
+                      <button
+                        key={template.id}
+                        onClick={() => setSelectedBattleArmorTemplate(template)}
+                        className={`p-3 rounded-lg border text-left transition-colors ${
+                          selectedBattleArmorTemplate.id === template.id
+                            ? 'border-blue-500 bg-blue-900/30'
+                            : 'border-border-theme hover:border-border-theme-subtle'
+                        }`}
+                      >
+                        <div className="text-sm font-medium text-white">{template.name}</div>
+                        <div className="text-xs text-text-theme-secondary">
+                          {template.squadSize} troopers • {template.techBase === TechBase.CLAN ? 'Clan' : 'IS'}
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Template selection - Infantry */}
+              {unitType === UnitType.INFANTRY && (
+                <div>
+                  <label className="block text-sm font-medium text-slate-300 mb-2">
+                    Select Template
+                  </label>
+                  <div className="grid grid-cols-2 gap-2">
+                    {INFANTRY_TEMPLATES.map((template) => (
+                      <button
+                        key={template.id}
+                        onClick={() => setSelectedInfantryTemplate(template)}
+                        className={`p-3 rounded-lg border text-left transition-colors ${
+                          selectedInfantryTemplate.id === template.id
+                            ? 'border-blue-500 bg-blue-900/30'
+                            : 'border-border-theme hover:border-border-theme-subtle'
+                        }`}
+                      >
+                        <div className="text-sm font-medium text-white">{template.name}</div>
+                        <div className="text-xs text-text-theme-secondary">
+                          {template.squadSize * template.numberOfSquads} troops ({template.numberOfSquads} squads)
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Template selection - ProtoMech */}
+              {unitType === UnitType.PROTOMECH && (
+                <div>
+                  <label className="block text-sm font-medium text-slate-300 mb-2">
+                    Select Template
+                  </label>
+                  <div className="grid grid-cols-2 gap-2">
+                    {PROTOMECH_TEMPLATES.map((template) => (
+                      <button
+                        key={template.id}
+                        onClick={() => setSelectedProtoMechTemplate(template)}
+                        className={`p-3 rounded-lg border text-left transition-colors ${
+                          selectedProtoMechTemplate.id === template.id
+                            ? 'border-blue-500 bg-blue-900/30'
+                            : 'border-border-theme hover:border-border-theme-subtle'
+                        }`}
+                      >
+                        <div className="text-sm font-medium text-white">{template.name}</div>
+                        <div className="text-xs text-text-theme-secondary">
+                          {template.tonnage}t • Clan Tech
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+              
+              {/* Tech base selection (not for ProtoMech) */}
+              {unitType !== UnitType.PROTOMECH && (
+                <div>
+                  <label className="block text-sm font-medium text-slate-300 mb-2">
+                    Tech Base
+                  </label>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => setTechBase(TechBase.INNER_SPHERE)}
+                      className={`flex-1 px-4 py-2 rounded-lg border text-sm font-medium transition-colors ${
+                        techBase === TechBase.INNER_SPHERE
+                          ? 'border-blue-500 bg-blue-900/30 text-blue-300'
+                          : 'border-border-theme text-text-theme-secondary hover:border-border-theme-subtle'
+                      }`}
+                    >
+                      Inner Sphere
+                    </button>
+                    <button
+                      onClick={() => setTechBase(TechBase.CLAN)}
+                      className={`flex-1 px-4 py-2 rounded-lg border text-sm font-medium transition-colors ${
+                        techBase === TechBase.CLAN
+                          ? 'border-green-500 bg-green-900/30 text-green-300'
+                          : 'border-border-theme text-text-theme-secondary hover:border-border-theme-subtle'
+                      }`}
+                    >
+                      Clan
+                    </button>
+                  </div>
+                </div>
+              )}
             </div>
           )}
           
@@ -267,4 +491,3 @@ export function NewTabModal({
     </div>
   );
 }
-

--- a/src/stores/aerospaceStoreRegistry.ts
+++ b/src/stores/aerospaceStoreRegistry.ts
@@ -1,0 +1,190 @@
+/**
+ * Aerospace Store Registry
+ * 
+ * Manages all active aerospace store instances.
+ * Parallels vehicleStoreRegistry.ts for Combat Vehicles.
+ * 
+ * @spec openspec/changes/add-aerospace-customizer/tasks.md
+ */
+
+import { StoreApi } from 'zustand';
+import { AerospaceStore, AerospaceState, createDefaultAerospaceState, CreateAerospaceOptions } from './aerospaceState';
+import { createAerospaceStore, createNewAerospaceStore } from './useAerospaceStore';
+import { isValidUUID, generateUUID } from '@/utils/uuid';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+
+function safeGetItem(key: string): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(key);
+}
+
+function safeRemoveItem(key: string): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(key);
+}
+
+const aerospaceStores = new Map<string, StoreApi<AerospaceStore>>();
+
+export function getAerospaceStore(aerospaceId: string): StoreApi<AerospaceStore> | undefined {
+  return aerospaceStores.get(aerospaceId);
+}
+
+export function hasAerospaceStore(aerospaceId: string): boolean {
+  return aerospaceStores.has(aerospaceId);
+}
+
+export function getAllAerospaceIds(): string[] {
+  return Array.from(aerospaceStores.keys());
+}
+
+export function getAerospaceStoreCount(): number {
+  return aerospaceStores.size;
+}
+
+function ensureValidAerospaceId(aerospaceId: string | undefined | null, context: string): string {
+  if (aerospaceId && isValidUUID(aerospaceId)) {
+    return aerospaceId;
+  }
+  
+  const newId = generateUUID();
+  console.warn(
+    `[AerospaceStoreRegistry] ${context}: Invalid aerospace ID "${aerospaceId || '(missing)'}" replaced with "${newId}"`
+  );
+  return newId;
+}
+
+export function createAndRegisterAerospace(options: CreateAerospaceOptions): StoreApi<AerospaceStore> {
+  const store = createNewAerospaceStore(options);
+  const state = store.getState();
+  aerospaceStores.set(state.id, store);
+  return store;
+}
+
+export function registerAerospaceStore(store: StoreApi<AerospaceStore>): void {
+  const state = store.getState();
+  aerospaceStores.set(state.id, store);
+}
+
+export function hydrateOrCreateAerospace(
+  aerospaceId: string,
+  fallbackOptions: CreateAerospaceOptions
+): StoreApi<AerospaceStore> {
+  const validAerospaceId = ensureValidAerospaceId(aerospaceId, 'hydrateOrCreateAerospace');
+  
+  const existing = aerospaceStores.get(validAerospaceId);
+  if (existing) {
+    return existing;
+  }
+  
+  const storageKey = `megamek-aerospace-${validAerospaceId}`;
+  const savedState = safeGetItem(storageKey);
+  
+  if (savedState) {
+    try {
+      const parsed = JSON.parse(savedState) as { state?: Partial<AerospaceState> };
+      const state = parsed.state;
+      
+      if (state) {
+        ensureValidAerospaceId(state.id, 'localStorage state');
+        
+        const defaultState = createDefaultAerospaceState({ ...fallbackOptions, id: validAerospaceId });
+        const mergedState: AerospaceState = {
+          ...defaultState,
+          ...state,
+          id: validAerospaceId,
+        };
+      
+        const store = createAerospaceStore(mergedState);
+        aerospaceStores.set(validAerospaceId, store);
+        return store;
+      }
+    } catch (e) {
+      console.warn(`Failed to hydrate aerospace ${validAerospaceId}, creating new:`, e);
+    }
+  }
+  
+  const store = createNewAerospaceStore({ ...fallbackOptions, id: validAerospaceId });
+  aerospaceStores.set(validAerospaceId, store);
+  return store;
+}
+
+export function unregisterAerospaceStore(aerospaceId: string): boolean {
+  return aerospaceStores.delete(aerospaceId);
+}
+
+export function deleteAerospace(aerospaceId: string): boolean {
+  const removed = aerospaceStores.delete(aerospaceId);
+  if (removed) {
+    const storageKey = `megamek-aerospace-${aerospaceId}`;
+    safeRemoveItem(storageKey);
+  }
+  return removed;
+}
+
+export function clearAllAerospaceStores(clearStorage = false): void {
+  if (clearStorage) {
+    Array.from(aerospaceStores.keys()).forEach((aerospaceId) => {
+      const storageKey = `megamek-aerospace-${aerospaceId}`;
+      safeRemoveItem(storageKey);
+    });
+  }
+  aerospaceStores.clear();
+}
+
+export function duplicateAerospace(sourceAerospaceId: string, newName?: string): StoreApi<AerospaceStore> | null {
+  const sourceStore = aerospaceStores.get(sourceAerospaceId);
+  if (!sourceStore) {
+    return null;
+  }
+  
+  const sourceState = sourceStore.getState();
+  const newState = createDefaultAerospaceState({
+    name: newName ?? `${sourceState.name} (Copy)`,
+    tonnage: sourceState.tonnage,
+    techBase: sourceState.techBase,
+    isConventional: sourceState.unitType === UnitType.CONVENTIONAL_FIGHTER,
+  });
+  
+  const mergedState: AerospaceState = {
+    ...newState,
+    engineType: sourceState.engineType,
+    engineRating: sourceState.engineRating,
+    safeThrust: sourceState.safeThrust,
+    fuel: sourceState.fuel,
+    armorType: sourceState.armorType,
+    armorTonnage: sourceState.armorTonnage,
+    armorAllocation: { ...sourceState.armorAllocation },
+    heatSinks: sourceState.heatSinks,
+    doubleHeatSinks: sourceState.doubleHeatSinks,
+    hasBombBay: sourceState.hasBombBay,
+    bombCapacity: sourceState.bombCapacity,
+    hasReinforcedCockpit: sourceState.hasReinforcedCockpit,
+    hasEjectionSeat: sourceState.hasEjectionSeat,
+  };
+  
+  const store = createAerospaceStore(mergedState);
+  aerospaceStores.set(mergedState.id, store);
+  return store;
+}
+
+export function createAerospaceFromFullState(state: AerospaceState): StoreApi<AerospaceStore> {
+  const validId = ensureValidAerospaceId(state.id, 'createAerospaceFromFullState');
+  
+  const existing = aerospaceStores.get(validId);
+  if (existing) {
+    console.warn(`Aerospace store ${validId} already exists, returning existing`);
+    return existing;
+  }
+  
+  const validatedState: AerospaceState = {
+    ...state,
+    id: validId,
+  };
+  
+  const store = createAerospaceStore(validatedState);
+  aerospaceStores.set(validId, store);
+  
+  store.setState({ lastModifiedAt: Date.now() });
+  
+  return store;
+}

--- a/src/stores/battleArmorStoreRegistry.ts
+++ b/src/stores/battleArmorStoreRegistry.ts
@@ -1,0 +1,188 @@
+/**
+ * Battle Armor Store Registry
+ * 
+ * Manages all active battle armor store instances.
+ * Parallels vehicleStoreRegistry.ts for Combat Vehicles.
+ * 
+ * @spec openspec/changes/add-personnel-customizer/tasks.md
+ */
+
+import { StoreApi } from 'zustand';
+import { BattleArmorStore, BattleArmorState, createDefaultBattleArmorState, CreateBattleArmorOptions } from './battleArmorState';
+import { createBattleArmorStore, createNewBattleArmorStore } from './useBattleArmorStore';
+import { isValidUUID, generateUUID } from '@/utils/uuid';
+
+function safeGetItem(key: string): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(key);
+}
+
+function safeRemoveItem(key: string): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(key);
+}
+
+const battleArmorStores = new Map<string, StoreApi<BattleArmorStore>>();
+
+export function getBattleArmorStore(battleArmorId: string): StoreApi<BattleArmorStore> | undefined {
+  return battleArmorStores.get(battleArmorId);
+}
+
+export function hasBattleArmorStore(battleArmorId: string): boolean {
+  return battleArmorStores.has(battleArmorId);
+}
+
+export function getAllBattleArmorIds(): string[] {
+  return Array.from(battleArmorStores.keys());
+}
+
+export function getBattleArmorStoreCount(): number {
+  return battleArmorStores.size;
+}
+
+function ensureValidBattleArmorId(battleArmorId: string | undefined | null, context: string): string {
+  if (battleArmorId && isValidUUID(battleArmorId)) {
+    return battleArmorId;
+  }
+  
+  const newId = generateUUID();
+  console.warn(
+    `[BattleArmorStoreRegistry] ${context}: Invalid battle armor ID "${battleArmorId || '(missing)'}" replaced with "${newId}"`
+  );
+  return newId;
+}
+
+export function createAndRegisterBattleArmor(options: CreateBattleArmorOptions): StoreApi<BattleArmorStore> {
+  const store = createNewBattleArmorStore(options);
+  const state = store.getState();
+  battleArmorStores.set(state.id, store);
+  return store;
+}
+
+export function registerBattleArmorStore(store: StoreApi<BattleArmorStore>): void {
+  const state = store.getState();
+  battleArmorStores.set(state.id, store);
+}
+
+export function hydrateOrCreateBattleArmor(
+  battleArmorId: string,
+  fallbackOptions: CreateBattleArmorOptions
+): StoreApi<BattleArmorStore> {
+  const validBattleArmorId = ensureValidBattleArmorId(battleArmorId, 'hydrateOrCreateBattleArmor');
+  
+  const existing = battleArmorStores.get(validBattleArmorId);
+  if (existing) {
+    return existing;
+  }
+  
+  const storageKey = `megamek-battlearmor-${validBattleArmorId}`;
+  const savedState = safeGetItem(storageKey);
+  
+  if (savedState) {
+    try {
+      const parsed = JSON.parse(savedState) as { state?: Partial<BattleArmorState> };
+      const state = parsed.state;
+      
+      if (state) {
+        ensureValidBattleArmorId(state.id, 'localStorage state');
+        
+        const defaultState = createDefaultBattleArmorState({ ...fallbackOptions, id: validBattleArmorId });
+        const mergedState: BattleArmorState = {
+          ...defaultState,
+          ...state,
+          id: validBattleArmorId,
+        };
+      
+        const store = createBattleArmorStore(mergedState);
+        battleArmorStores.set(validBattleArmorId, store);
+        return store;
+      }
+    } catch (e) {
+      console.warn(`Failed to hydrate battle armor ${validBattleArmorId}, creating new:`, e);
+    }
+  }
+  
+  const store = createNewBattleArmorStore({ ...fallbackOptions, id: validBattleArmorId });
+  battleArmorStores.set(validBattleArmorId, store);
+  return store;
+}
+
+export function unregisterBattleArmorStore(battleArmorId: string): boolean {
+  return battleArmorStores.delete(battleArmorId);
+}
+
+export function deleteBattleArmor(battleArmorId: string): boolean {
+  const removed = battleArmorStores.delete(battleArmorId);
+  if (removed) {
+    const storageKey = `megamek-battlearmor-${battleArmorId}`;
+    safeRemoveItem(storageKey);
+  }
+  return removed;
+}
+
+export function clearAllBattleArmorStores(clearStorage = false): void {
+  if (clearStorage) {
+    Array.from(battleArmorStores.keys()).forEach((battleArmorId) => {
+      const storageKey = `megamek-battlearmor-${battleArmorId}`;
+      safeRemoveItem(storageKey);
+    });
+  }
+  battleArmorStores.clear();
+}
+
+export function duplicateBattleArmor(sourceBattleArmorId: string, newName?: string): StoreApi<BattleArmorStore> | null {
+  const sourceStore = battleArmorStores.get(sourceBattleArmorId);
+  if (!sourceStore) {
+    return null;
+  }
+  
+  const sourceState = sourceStore.getState();
+  const newState = createDefaultBattleArmorState({
+    name: newName ?? `${sourceState.name} (Copy)`,
+    techBase: sourceState.techBase,
+    chassisType: sourceState.chassisType,
+    weightClass: sourceState.weightClass,
+    squadSize: sourceState.squadSize,
+  });
+  
+  const mergedState: BattleArmorState = {
+    ...newState,
+    motionType: sourceState.motionType,
+    groundMP: sourceState.groundMP,
+    jumpMP: sourceState.jumpMP,
+    armorPerTrooper: sourceState.armorPerTrooper,
+    leftManipulator: sourceState.leftManipulator,
+    rightManipulator: sourceState.rightManipulator,
+    hasAPMount: sourceState.hasAPMount,
+    hasModularMount: sourceState.hasModularMount,
+    hasTurretMount: sourceState.hasTurretMount,
+    hasStealthSystem: sourceState.hasStealthSystem,
+    stealthType: sourceState.stealthType,
+  };
+  
+  const store = createBattleArmorStore(mergedState);
+  battleArmorStores.set(mergedState.id, store);
+  return store;
+}
+
+export function createBattleArmorFromFullState(state: BattleArmorState): StoreApi<BattleArmorStore> {
+  const validId = ensureValidBattleArmorId(state.id, 'createBattleArmorFromFullState');
+  
+  const existing = battleArmorStores.get(validId);
+  if (existing) {
+    console.warn(`Battle armor store ${validId} already exists, returning existing`);
+    return existing;
+  }
+  
+  const validatedState: BattleArmorState = {
+    ...state,
+    id: validId,
+  };
+  
+  const store = createBattleArmorStore(validatedState);
+  battleArmorStores.set(validId, store);
+  
+  store.setState({ lastModifiedAt: Date.now() });
+  
+  return store;
+}

--- a/src/stores/infantryStoreRegistry.ts
+++ b/src/stores/infantryStoreRegistry.ts
@@ -1,0 +1,187 @@
+/**
+ * Infantry Store Registry
+ * 
+ * Manages all active infantry store instances.
+ * Parallels vehicleStoreRegistry.ts for Combat Vehicles.
+ * 
+ * @spec openspec/changes/add-personnel-customizer/tasks.md
+ */
+
+import { StoreApi } from 'zustand';
+import { InfantryStore, InfantryState, createDefaultInfantryState, CreateInfantryOptions } from './infantryState';
+import { createInfantryStore, createNewInfantryStore } from './useInfantryStore';
+import { isValidUUID, generateUUID } from '@/utils/uuid';
+
+function safeGetItem(key: string): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(key);
+}
+
+function safeRemoveItem(key: string): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(key);
+}
+
+const infantryStores = new Map<string, StoreApi<InfantryStore>>();
+
+export function getInfantryStore(infantryId: string): StoreApi<InfantryStore> | undefined {
+  return infantryStores.get(infantryId);
+}
+
+export function hasInfantryStore(infantryId: string): boolean {
+  return infantryStores.has(infantryId);
+}
+
+export function getAllInfantryIds(): string[] {
+  return Array.from(infantryStores.keys());
+}
+
+export function getInfantryStoreCount(): number {
+  return infantryStores.size;
+}
+
+function ensureValidInfantryId(infantryId: string | undefined | null, context: string): string {
+  if (infantryId && isValidUUID(infantryId)) {
+    return infantryId;
+  }
+  
+  const newId = generateUUID();
+  console.warn(
+    `[InfantryStoreRegistry] ${context}: Invalid infantry ID "${infantryId || '(missing)'}" replaced with "${newId}"`
+  );
+  return newId;
+}
+
+export function createAndRegisterInfantry(options: CreateInfantryOptions): StoreApi<InfantryStore> {
+  const store = createNewInfantryStore(options);
+  const state = store.getState();
+  infantryStores.set(state.id, store);
+  return store;
+}
+
+export function registerInfantryStore(store: StoreApi<InfantryStore>): void {
+  const state = store.getState();
+  infantryStores.set(state.id, store);
+}
+
+export function hydrateOrCreateInfantry(
+  infantryId: string,
+  fallbackOptions: CreateInfantryOptions
+): StoreApi<InfantryStore> {
+  const validInfantryId = ensureValidInfantryId(infantryId, 'hydrateOrCreateInfantry');
+  
+  const existing = infantryStores.get(validInfantryId);
+  if (existing) {
+    return existing;
+  }
+  
+  const storageKey = `megamek-infantry-${validInfantryId}`;
+  const savedState = safeGetItem(storageKey);
+  
+  if (savedState) {
+    try {
+      const parsed = JSON.parse(savedState) as { state?: Partial<InfantryState> };
+      const state = parsed.state;
+      
+      if (state) {
+        ensureValidInfantryId(state.id, 'localStorage state');
+        
+        const defaultState = createDefaultInfantryState({ ...fallbackOptions, id: validInfantryId });
+        const mergedState: InfantryState = {
+          ...defaultState,
+          ...state,
+          id: validInfantryId,
+        };
+      
+        const store = createInfantryStore(mergedState);
+        infantryStores.set(validInfantryId, store);
+        return store;
+      }
+    } catch (e) {
+      console.warn(`Failed to hydrate infantry ${validInfantryId}, creating new:`, e);
+    }
+  }
+  
+  const store = createNewInfantryStore({ ...fallbackOptions, id: validInfantryId });
+  infantryStores.set(validInfantryId, store);
+  return store;
+}
+
+export function unregisterInfantryStore(infantryId: string): boolean {
+  return infantryStores.delete(infantryId);
+}
+
+export function deleteInfantry(infantryId: string): boolean {
+  const removed = infantryStores.delete(infantryId);
+  if (removed) {
+    const storageKey = `megamek-infantry-${infantryId}`;
+    safeRemoveItem(storageKey);
+  }
+  return removed;
+}
+
+export function clearAllInfantryStores(clearStorage = false): void {
+  if (clearStorage) {
+    Array.from(infantryStores.keys()).forEach((infantryId) => {
+      const storageKey = `megamek-infantry-${infantryId}`;
+      safeRemoveItem(storageKey);
+    });
+  }
+  infantryStores.clear();
+}
+
+export function duplicateInfantry(sourceInfantryId: string, newName?: string): StoreApi<InfantryStore> | null {
+  const sourceStore = infantryStores.get(sourceInfantryId);
+  if (!sourceStore) {
+    return null;
+  }
+  
+  const sourceState = sourceStore.getState();
+  const newState = createDefaultInfantryState({
+    name: newName ?? `${sourceState.name} (Copy)`,
+    techBase: sourceState.techBase,
+    motionType: sourceState.motionType,
+    squadSize: sourceState.squadSize,
+    numberOfSquads: sourceState.numberOfSquads,
+  });
+  
+  const mergedState: InfantryState = {
+    ...newState,
+    primaryWeapon: sourceState.primaryWeapon,
+    primaryWeaponId: sourceState.primaryWeaponId,
+    secondaryWeapon: sourceState.secondaryWeapon,
+    secondaryWeaponId: sourceState.secondaryWeaponId,
+    secondaryWeaponCount: sourceState.secondaryWeaponCount,
+    armorKit: sourceState.armorKit,
+    damageDivisor: sourceState.damageDivisor,
+    specialization: sourceState.specialization,
+    hasAntiMechTraining: sourceState.hasAntiMechTraining,
+    isAugmented: sourceState.isAugmented,
+  };
+  
+  const store = createInfantryStore(mergedState);
+  infantryStores.set(mergedState.id, store);
+  return store;
+}
+
+export function createInfantryFromFullState(state: InfantryState): StoreApi<InfantryStore> {
+  const validId = ensureValidInfantryId(state.id, 'createInfantryFromFullState');
+  
+  const existing = infantryStores.get(validId);
+  if (existing) {
+    console.warn(`Infantry store ${validId} already exists, returning existing`);
+    return existing;
+  }
+  
+  const validatedState: InfantryState = {
+    ...state,
+    id: validId,
+  };
+  
+  const store = createInfantryStore(validatedState);
+  infantryStores.set(validId, store);
+  
+  store.setState({ lastModifiedAt: Date.now() });
+  
+  return store;
+}

--- a/src/stores/protoMechStoreRegistry.ts
+++ b/src/stores/protoMechStoreRegistry.ts
@@ -1,0 +1,183 @@
+/**
+ * ProtoMech Store Registry
+ * 
+ * Manages all active ProtoMech store instances.
+ * Parallels vehicleStoreRegistry.ts for Combat Vehicles.
+ * 
+ * @spec openspec/changes/add-personnel-customizer/tasks.md
+ */
+
+import { StoreApi } from 'zustand';
+import { ProtoMechStore, ProtoMechState, createDefaultProtoMechState, CreateProtoMechOptions } from './protoMechState';
+import { createProtoMechStore, createNewProtoMechStore } from './useProtoMechStore';
+import { isValidUUID, generateUUID } from '@/utils/uuid';
+
+function safeGetItem(key: string): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(key);
+}
+
+function safeRemoveItem(key: string): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(key);
+}
+
+const protoMechStores = new Map<string, StoreApi<ProtoMechStore>>();
+
+export function getProtoMechStore(protoMechId: string): StoreApi<ProtoMechStore> | undefined {
+  return protoMechStores.get(protoMechId);
+}
+
+export function hasProtoMechStore(protoMechId: string): boolean {
+  return protoMechStores.has(protoMechId);
+}
+
+export function getAllProtoMechIds(): string[] {
+  return Array.from(protoMechStores.keys());
+}
+
+export function getProtoMechStoreCount(): number {
+  return protoMechStores.size;
+}
+
+function ensureValidProtoMechId(protoMechId: string | undefined | null, context: string): string {
+  if (protoMechId && isValidUUID(protoMechId)) {
+    return protoMechId;
+  }
+  
+  const newId = generateUUID();
+  console.warn(
+    `[ProtoMechStoreRegistry] ${context}: Invalid protomech ID "${protoMechId || '(missing)'}" replaced with "${newId}"`
+  );
+  return newId;
+}
+
+export function createAndRegisterProtoMech(options: CreateProtoMechOptions): StoreApi<ProtoMechStore> {
+  const store = createNewProtoMechStore(options);
+  const state = store.getState();
+  protoMechStores.set(state.id, store);
+  return store;
+}
+
+export function registerProtoMechStore(store: StoreApi<ProtoMechStore>): void {
+  const state = store.getState();
+  protoMechStores.set(state.id, store);
+}
+
+export function hydrateOrCreateProtoMech(
+  protoMechId: string,
+  fallbackOptions: CreateProtoMechOptions
+): StoreApi<ProtoMechStore> {
+  const validProtoMechId = ensureValidProtoMechId(protoMechId, 'hydrateOrCreateProtoMech');
+  
+  const existing = protoMechStores.get(validProtoMechId);
+  if (existing) {
+    return existing;
+  }
+  
+  const storageKey = `megamek-protomech-${validProtoMechId}`;
+  const savedState = safeGetItem(storageKey);
+  
+  if (savedState) {
+    try {
+      const parsed = JSON.parse(savedState) as { state?: Partial<ProtoMechState> };
+      const state = parsed.state;
+      
+      if (state) {
+        ensureValidProtoMechId(state.id, 'localStorage state');
+        
+        const defaultState = createDefaultProtoMechState({ ...fallbackOptions, id: validProtoMechId });
+        const mergedState: ProtoMechState = {
+          ...defaultState,
+          ...state,
+          id: validProtoMechId,
+        };
+      
+        const store = createProtoMechStore(mergedState);
+        protoMechStores.set(validProtoMechId, store);
+        return store;
+      }
+    } catch (e) {
+      console.warn(`Failed to hydrate protomech ${validProtoMechId}, creating new:`, e);
+    }
+  }
+  
+  const store = createNewProtoMechStore({ ...fallbackOptions, id: validProtoMechId });
+  protoMechStores.set(validProtoMechId, store);
+  return store;
+}
+
+export function unregisterProtoMechStore(protoMechId: string): boolean {
+  return protoMechStores.delete(protoMechId);
+}
+
+export function deleteProtoMech(protoMechId: string): boolean {
+  const removed = protoMechStores.delete(protoMechId);
+  if (removed) {
+    const storageKey = `megamek-protomech-${protoMechId}`;
+    safeRemoveItem(storageKey);
+  }
+  return removed;
+}
+
+export function clearAllProtoMechStores(clearStorage = false): void {
+  if (clearStorage) {
+    Array.from(protoMechStores.keys()).forEach((protoMechId) => {
+      const storageKey = `megamek-protomech-${protoMechId}`;
+      safeRemoveItem(storageKey);
+    });
+  }
+  protoMechStores.clear();
+}
+
+export function duplicateProtoMech(sourceProtoMechId: string, newName?: string): StoreApi<ProtoMechStore> | null {
+  const sourceStore = protoMechStores.get(sourceProtoMechId);
+  if (!sourceStore) {
+    return null;
+  }
+  
+  const sourceState = sourceStore.getState();
+  const newState = createDefaultProtoMechState({
+    name: newName ?? `${sourceState.name} (Copy)`,
+    tonnage: sourceState.tonnage,
+    isQuad: sourceState.isQuad,
+  });
+  
+  const mergedState: ProtoMechState = {
+    ...newState,
+    engineRating: sourceState.engineRating,
+    cruiseMP: sourceState.cruiseMP,
+    jumpMP: sourceState.jumpMP,
+    armorByLocation: { ...sourceState.armorByLocation },
+    hasMainGun: sourceState.hasMainGun,
+    hasMyomerBooster: sourceState.hasMyomerBooster,
+    hasMagneticClamps: sourceState.hasMagneticClamps,
+    hasExtendedTorsoTwist: sourceState.hasExtendedTorsoTwist,
+  };
+  
+  const store = createProtoMechStore(mergedState);
+  protoMechStores.set(mergedState.id, store);
+  return store;
+}
+
+export function createProtoMechFromFullState(state: ProtoMechState): StoreApi<ProtoMechStore> {
+  const validId = ensureValidProtoMechId(state.id, 'createProtoMechFromFullState');
+  
+  const existing = protoMechStores.get(validId);
+  if (existing) {
+    console.warn(`ProtoMech store ${validId} already exists, returning existing`);
+    return existing;
+  }
+  
+  const validatedState: ProtoMechState = {
+    ...state,
+    id: validId,
+  };
+  
+  const store = createProtoMechStore(validatedState);
+  protoMechStores.set(validId, store);
+  
+  store.setState({ lastModifiedAt: Date.now() });
+  
+  return store;
+}


### PR DESCRIPTION
## Summary

Integrates all existing aerospace and personnel customizer components into the multi-unit tab system, completing the UI integration for two Phase 1 roadmap proposals.

## Changes

### New Files
- `src/stores/aerospaceStoreRegistry.ts` - Store registry for aerospace units
- `src/stores/battleArmorStoreRegistry.ts` - Store registry for battle armor units
- `src/stores/infantryStoreRegistry.ts` - Store registry for infantry units
- `src/stores/protoMechStoreRegistry.ts` - Store registry for protomech units

### Modified Files
- `src/components/customizer/UnitTypeRouter.tsx` - Routes all 6 unit types to their customizers
- `src/components/customizer/tabs/NewTabModal.tsx` - Expanded from 2 to 6 unit type options with grid layout
- `src/components/customizer/tabs/MultiUnitTabs.tsx` - Creates and manages all unit types with proper store integration

## What This Enables

Users can now:
- Create new tabs for **all 6 unit types**: BattleMech, Vehicle, Aerospace, Battle Armor, Infantry, ProtoMech
- Edit units using the existing customizer components that were already built
- Manage multiple units of different types in the tabbed interface
- Have unsaved changes tracked per-tab for all unit types

## Proposals Completed

- [x] `add-aerospace-customizer` - UI integration complete
- [x] `add-personnel-customizer` - UI integration complete (Battle Armor, Infantry, ProtoMech)

## Testing

- [x] `npm run build` passes
- [x] All new unit types route correctly to their customizers
- [x] NewTabModal shows all 6 unit type options
- [x] Tab creation works for all unit types

## Notes

- The existing customizer components, stores, and state interfaces were already implemented
- This PR only adds the **routing and UI integration** to make them accessible
- Validation rules (tasks 5.x in aerospace spec) are optional enhancements for later