### PR TITLE
feat: implement gameplay UI (Phase 3)

### DIFF
--- a/src/components/gameplay/ActionBar.tsx
+++ b/src/components/gameplay/ActionBar.tsx
@@ -1,0 +1,152 @@
+/**
+ * Action Bar Component
+ * Phase-specific action buttons for the gameplay view.
+ *
+ * @spec openspec/changes/add-gameplay-ui/specs/gameplay-ui/spec.md
+ */
+
+import React, { useCallback } from 'react';
+import { GamePhase, getPhaseActions, IPhaseAction } from '@/types/gameplay';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ActionBarProps {
+  /** Current game phase */
+  phase: GamePhase;
+  /** Can the player undo the last action? */
+  canUndo: boolean;
+  /** Is player currently able to act? */
+  canAct: boolean;
+  /** Callback when an action is triggered */
+  onAction: (actionId: string) => void;
+  /** Optional additional info to display */
+  infoText?: string;
+  /** Optional className for styling */
+  className?: string;
+}
+
+// =============================================================================
+// Sub-Components
+// =============================================================================
+
+interface ActionButtonProps {
+  action: IPhaseAction;
+  onClick: () => void;
+  disabled: boolean;
+}
+
+function ActionButton({ action, onClick, disabled }: ActionButtonProps): React.ReactElement {
+  const baseClasses = 'px-4 py-2 rounded font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2';
+  
+  const primaryClasses = action.primary
+    ? 'bg-blue-600 hover:bg-blue-700 text-white focus:ring-blue-500'
+    : 'bg-gray-200 hover:bg-gray-300 text-gray-800 focus:ring-gray-400';
+  
+  const disabledClasses = disabled || !action.enabled
+    ? 'opacity-50 cursor-not-allowed'
+    : 'cursor-pointer';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled || !action.enabled}
+      className={`${baseClasses} ${primaryClasses} ${disabledClasses}`}
+      title={action.tooltip || (action.shortcut ? `${action.label} (${action.shortcut})` : action.label)}
+    >
+      {action.label}
+      {action.shortcut && (
+        <span className="ml-2 text-xs opacity-75">({action.shortcut})</span>
+      )}
+    </button>
+  );
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Action bar with phase-appropriate controls.
+ */
+export function ActionBar({
+  phase,
+  canUndo,
+  canAct,
+  onAction,
+  infoText,
+  className = '',
+}: ActionBarProps): React.ReactElement {
+  const actions = getPhaseActions(phase, canUndo);
+
+  const handleAction = useCallback(
+    (actionId: string) => {
+      if (canAct) {
+        onAction(actionId);
+      }
+    },
+    [canAct, onAction]
+  );
+
+  // Handle keyboard shortcuts
+  React.useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (!canAct) return;
+
+      // Find matching action by shortcut
+      for (const action of actions) {
+        if (!action.enabled || !action.shortcut) continue;
+
+        const shortcut = action.shortcut.toLowerCase();
+        const key = event.key.toLowerCase();
+
+        // Handle Ctrl+key shortcuts
+        if (shortcut.startsWith('ctrl+')) {
+          const shortcutKey = shortcut.replace('ctrl+', '');
+          if (event.ctrlKey && key === shortcutKey) {
+            event.preventDefault();
+            onAction(action.id);
+            return;
+          }
+        }
+        // Handle Enter
+        else if (shortcut === 'enter' && key === 'enter') {
+          event.preventDefault();
+          onAction(action.id);
+          return;
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [actions, canAct, onAction]);
+
+  return (
+    <div
+      className={`bg-gray-100 border-t border-gray-300 px-4 py-3 flex items-center justify-between ${className}`}
+      role="toolbar"
+      aria-label="Game actions"
+    >
+      <div className="flex items-center gap-2">
+        {actions.map((action) => (
+          <ActionButton
+            key={action.id}
+            action={action}
+            onClick={() => handleAction(action.id)}
+            disabled={!canAct}
+          />
+        ))}
+      </div>
+      {infoText && (
+        <div className="text-sm text-gray-600">
+          {infoText}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ActionBar;

--- a/src/components/gameplay/EventLogDisplay.tsx
+++ b/src/components/gameplay/EventLogDisplay.tsx
@@ -1,0 +1,343 @@
+/**
+ * Event Log Display Component
+ * Shows chronological game events with filtering.
+ *
+ * @spec openspec/changes/add-gameplay-ui/specs/gameplay-ui/spec.md
+ */
+
+import React, { useState, useMemo, useCallback } from 'react';
+import {
+  GamePhase,
+  GameSide,
+  GameEventType,
+  IGameEvent,
+  IEventLogFilter,
+  IFormattedEvent,
+} from '@/types/gameplay';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface EventLogDisplayProps {
+  /** All game events */
+  events: readonly IGameEvent[];
+  /** Current filter settings */
+  filter?: IEventLogFilter;
+  /** Callback when filter changes */
+  onFilterChange?: (filter: IEventLogFilter) => void;
+  /** Is log collapsed? */
+  collapsed?: boolean;
+  /** Callback when collapse state changes */
+  onCollapsedChange?: (collapsed: boolean) => void;
+  /** Maximum height in pixels (for scrolling) */
+  maxHeight?: number;
+  /** Optional className for styling */
+  className?: string;
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Get icon type for an event.
+ */
+function getEventIcon(type: GameEventType): IFormattedEvent['icon'] {
+  switch (type) {
+    case GameEventType.MovementDeclared:
+    case GameEventType.MovementLocked:
+    case GameEventType.FacingChanged:
+      return 'movement';
+    case GameEventType.AttackDeclared:
+    case GameEventType.AttackLocked:
+    case GameEventType.AttacksRevealed:
+    case GameEventType.AttackResolved:
+      return 'attack';
+    case GameEventType.DamageApplied:
+      return 'damage';
+    case GameEventType.HeatGenerated:
+    case GameEventType.HeatDissipated:
+    case GameEventType.HeatEffectApplied:
+      return 'heat';
+    case GameEventType.CriticalHit:
+    case GameEventType.AmmoExplosion:
+      return 'critical';
+    case GameEventType.PhaseChanged:
+    case GameEventType.TurnStarted:
+    case GameEventType.TurnEnded:
+      return 'phase';
+    default:
+      return 'status';
+  }
+}
+
+/**
+ * Get color classes for event icon.
+ */
+function getIconColor(icon: IFormattedEvent['icon']): string {
+  switch (icon) {
+    case 'movement':
+      return 'text-green-600';
+    case 'attack':
+      return 'text-red-600';
+    case 'damage':
+      return 'text-orange-600';
+    case 'heat':
+      return 'text-yellow-600';
+    case 'critical':
+      return 'text-purple-600';
+    case 'phase':
+      return 'text-blue-600';
+    default:
+      return 'text-gray-600';
+  }
+}
+
+/**
+ * Format an event for display.
+ */
+function formatEvent(event: IGameEvent): IFormattedEvent {
+  const icon = getEventIcon(event.type);
+  let text = '';
+  let unitId: string | undefined;
+  let side: GameSide | undefined;
+
+  // Format based on event type
+  switch (event.type) {
+    case GameEventType.TurnStarted:
+      text = `Turn ${event.turn} started`;
+      break;
+    case GameEventType.PhaseChanged: {
+      const payload = event.payload as { fromPhase: GamePhase; toPhase: GamePhase };
+      text = `Phase: ${payload.toPhase.replace('_', ' ')}`;
+      break;
+    }
+    case GameEventType.InitiativeRolled: {
+      const payload = event.payload as {
+        playerRoll: number;
+        opponentRoll: number;
+        winner: GameSide;
+      };
+      text = `Initiative: Player ${payload.playerRoll} vs Opponent ${payload.opponentRoll}. ${payload.winner} wins.`;
+      break;
+    }
+    case GameEventType.MovementDeclared: {
+      const payload = event.payload as {
+        unitId: string;
+        movementType: string;
+        mpUsed: number;
+      };
+      unitId = payload.unitId;
+      text = `Unit moved (${payload.movementType}, ${payload.mpUsed} MP)`;
+      break;
+    }
+    case GameEventType.AttackDeclared: {
+      const payload = event.payload as {
+        attackerId: string;
+        targetId: string;
+        weapons: readonly string[];
+        toHitNumber: number;
+      };
+      unitId = payload.attackerId;
+      text = `Attack declared: ${payload.weapons.length} weapon(s), TN ${payload.toHitNumber}`;
+      break;
+    }
+    case GameEventType.AttackResolved: {
+      const payload = event.payload as {
+        attackerId: string;
+        hit: boolean;
+        roll: number;
+        toHitNumber: number;
+        damage?: number;
+        location?: string;
+      };
+      unitId = payload.attackerId;
+      if (payload.hit) {
+        text = `Attack HIT (${payload.roll} vs ${payload.toHitNumber}): ${payload.damage} damage to ${payload.location}`;
+      } else {
+        text = `Attack MISSED (${payload.roll} vs ${payload.toHitNumber})`;
+      }
+      break;
+    }
+    case GameEventType.DamageApplied: {
+      const payload = event.payload as {
+        unitId: string;
+        location: string;
+        damage: number;
+        locationDestroyed: boolean;
+      };
+      unitId = payload.unitId;
+      text = `${payload.damage} damage to ${payload.location}${payload.locationDestroyed ? ' (DESTROYED)' : ''}`;
+      break;
+    }
+    case GameEventType.HeatGenerated: {
+      const payload = event.payload as { unitId: string; amount: number; newTotal: number };
+      unitId = payload.unitId;
+      text = `Heat +${payload.amount} (total: ${payload.newTotal})`;
+      break;
+    }
+    case GameEventType.HeatDissipated: {
+      const payload = event.payload as { unitId: string; amount: number; newTotal: number };
+      unitId = payload.unitId;
+      text = `Heat dissipated: ${Math.abs(payload.amount)} (total: ${payload.newTotal})`;
+      break;
+    }
+    case GameEventType.CriticalHit: {
+      const payload = event.payload as { unitId: string };
+      unitId = payload.unitId;
+      text = 'Critical hit!';
+      break;
+    }
+    case GameEventType.UnitDestroyed: {
+      const payload = event.payload as { unitId: string; cause: string };
+      unitId = payload.unitId;
+      text = `UNIT DESTROYED (${payload.cause})`;
+      break;
+    }
+    case GameEventType.PilotHit: {
+      const payload = event.payload as { unitId: string; wounds: number; totalWounds: number };
+      unitId = payload.unitId;
+      text = `Pilot hit: ${payload.wounds} wound(s) (${payload.totalWounds} total)`;
+      break;
+    }
+    case GameEventType.GameEnded: {
+      const payload = event.payload as { winner: GameSide | 'draw'; reason: string };
+      text = `Game ended: ${payload.winner === 'draw' ? 'Draw' : `${payload.winner} wins`} (${payload.reason})`;
+      break;
+    }
+    default:
+      text = event.type.replace(/_/g, ' ');
+  }
+
+  return {
+    id: event.id,
+    turn: event.turn,
+    phase: event.phase,
+    text,
+    icon,
+    side,
+    unitId,
+    timestamp: event.timestamp,
+  };
+}
+
+/**
+ * Filter events based on criteria.
+ */
+function filterEvents(
+  events: readonly IGameEvent[],
+  filter: IEventLogFilter
+): readonly IGameEvent[] {
+  return events.filter((event) => {
+    if (filter.turn !== undefined && event.turn !== filter.turn) {
+      return false;
+    }
+    if (filter.eventTypes && filter.eventTypes.length > 0) {
+      if (!filter.eventTypes.includes(event.type)) {
+        return false;
+      }
+    }
+    if (filter.unitId) {
+      const payload = event.payload as { unitId?: string; attackerId?: string };
+      if (payload.unitId !== filter.unitId && payload.attackerId !== filter.unitId) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+// =============================================================================
+// Sub-Components
+// =============================================================================
+
+interface EventRowProps {
+  event: IFormattedEvent;
+}
+
+function EventRow({ event }: EventRowProps): React.ReactElement {
+  const iconColor = getIconColor(event.icon);
+
+  return (
+    <div className="flex items-start gap-2 py-1 px-2 hover:bg-gray-50 text-sm">
+      <span className={`${iconColor} font-bold w-4`}>
+        {event.icon === 'movement' && '→'}
+        {event.icon === 'attack' && '⚔'}
+        {event.icon === 'damage' && '💥'}
+        {event.icon === 'heat' && '🔥'}
+        {event.icon === 'critical' && '⚠'}
+        {event.icon === 'phase' && '◆'}
+        {event.icon === 'status' && '•'}
+      </span>
+      <span className="text-gray-500 text-xs w-8">T{event.turn}</span>
+      <span className="flex-1">{event.text}</span>
+    </div>
+  );
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Event log display with filtering and collapse.
+ */
+export function EventLogDisplay({
+  events,
+  filter = {},
+  onFilterChange,
+  collapsed = false,
+  onCollapsedChange,
+  maxHeight = 200,
+  className = '',
+}: EventLogDisplayProps): React.ReactElement {
+  const [localCollapsed, setLocalCollapsed] = useState(collapsed);
+  const isCollapsed = onCollapsedChange ? collapsed : localCollapsed;
+
+  const toggleCollapse = useCallback(() => {
+    if (onCollapsedChange) {
+      onCollapsedChange(!isCollapsed);
+    } else {
+      setLocalCollapsed(!isCollapsed);
+    }
+  }, [isCollapsed, onCollapsedChange]);
+
+  // Filter and format events
+  const formattedEvents = useMemo(() => {
+    const filtered = filterEvents(events, filter);
+    return filtered.map(formatEvent).reverse(); // Newest first
+  }, [events, filter]);
+
+  return (
+    <div className={`bg-white border-t border-gray-300 ${className}`}>
+      {/* Header */}
+      <button
+        type="button"
+        onClick={toggleCollapse}
+        className="w-full px-4 py-2 flex items-center justify-between bg-gray-50 hover:bg-gray-100 transition-colors"
+      >
+        <span className="font-medium text-sm">Event Log ({events.length})</span>
+        <span className="text-gray-500">{isCollapsed ? '▼' : '▲'}</span>
+      </button>
+
+      {/* Content */}
+      {!isCollapsed && (
+        <div
+          className="overflow-y-auto border-t border-gray-200"
+          style={{ maxHeight }}
+        >
+          {formattedEvents.length === 0 ? (
+            <div className="p-4 text-center text-gray-500 text-sm">No events yet</div>
+          ) : (
+            formattedEvents.map((event) => (
+              <EventRow key={event.id} event={event} />
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default EventLogDisplay;

--- a/src/components/gameplay/GameplayLayout.tsx
+++ b/src/components/gameplay/GameplayLayout.tsx
@@ -1,0 +1,287 @@
+/**
+ * Gameplay Layout Component
+ * Main split-view layout for the gameplay interface.
+ *
+ * @spec openspec/changes/add-gameplay-ui/specs/gameplay-ui/spec.md
+ */
+
+import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import {
+  GamePhase,
+  GameSide,
+  IGameSession,
+  IGameState,
+  IUnitGameState,
+  IGameEvent,
+  IUnitToken,
+  ILayoutConfig,
+  IWeaponStatus,
+  DEFAULT_LAYOUT_CONFIG,
+  getLayoutForPhase,
+} from '@/types/gameplay';
+import { PhaseBanner } from './PhaseBanner';
+import { ActionBar } from './ActionBar';
+import { EventLogDisplay } from './EventLogDisplay';
+import { HexMapDisplay } from './HexMapDisplay';
+import { RecordSheetDisplay } from './RecordSheetDisplay';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface GameplayLayoutProps {
+  /** Game session data */
+  session: IGameSession;
+  /** Currently selected unit ID */
+  selectedUnitId: string | null;
+  /** Callback when unit is selected */
+  onUnitSelect: (unitId: string | null) => void;
+  /** Callback when action is triggered */
+  onAction: (actionId: string) => void;
+  /** Callback when hex is clicked */
+  onHexClick?: (hex: { q: number; r: number }) => void;
+  /** Can the player undo? */
+  canUndo?: boolean;
+  /** Is it the player's turn? */
+  isPlayerTurn?: boolean;
+  /** Unit weapon data for record sheet */
+  unitWeapons?: Record<string, readonly IWeaponStatus[]>;
+  /** Max armor values per unit */
+  maxArmor?: Record<string, Record<string, number>>;
+  /** Max structure values per unit */
+  maxStructure?: Record<string, Record<string, number>>;
+  /** Pilot names per unit */
+  pilotNames?: Record<string, string>;
+  /** Heat sinks per unit */
+  heatSinks?: Record<string, number>;
+  /** Optional className for styling */
+  className?: string;
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Convert unit state to display token.
+ */
+function unitStateToToken(
+  unitId: string,
+  state: IUnitGameState,
+  unitInfo: { name: string; side: GameSide },
+  isSelected: boolean,
+  isValidTarget: boolean
+): IUnitToken {
+  // Generate a short designation from the unit name
+  const designation = unitInfo.name
+    .split(/[\s-]+/)
+    .map((word) => word[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 4);
+
+  return {
+    unitId,
+    name: unitInfo.name,
+    side: unitInfo.side,
+    position: state.position,
+    facing: state.facing,
+    isSelected,
+    isValidTarget,
+    isDestroyed: state.destroyed,
+    designation,
+  };
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Main gameplay layout with split view.
+ */
+export function GameplayLayout({
+  session,
+  selectedUnitId,
+  onUnitSelect,
+  onAction,
+  onHexClick,
+  canUndo = false,
+  isPlayerTurn = true,
+  unitWeapons = {},
+  maxArmor = {},
+  maxStructure = {},
+  pilotNames = {},
+  heatSinks = {},
+  className = '',
+}: GameplayLayoutProps): React.ReactElement {
+  const { currentState, events, config, units } = session;
+  const [layout, setLayout] = useState<ILayoutConfig>(DEFAULT_LAYOUT_CONFIG);
+  const [isDragging, setIsDragging] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Update layout based on phase
+  useEffect(() => {
+    const phaseLayout = getLayoutForPhase(currentState.phase);
+    setLayout((prev) => ({ ...prev, ...phaseLayout }));
+  }, [currentState.phase]);
+
+  // Build unit info lookup
+  const unitInfoLookup = useMemo(() => {
+    const lookup: Record<string, { name: string; side: GameSide }> = {};
+    for (const unit of units) {
+      lookup[unit.id] = { name: unit.name, side: unit.side };
+    }
+    return lookup;
+  }, [units]);
+
+  // Build tokens for map display
+  const tokens = useMemo(() => {
+    return Object.entries(currentState.units).map(([unitId, state]) => {
+      const unitInfo = unitInfoLookup[unitId] || { name: 'Unknown', side: GameSide.Player };
+      const isSelected = unitId === selectedUnitId;
+      // In attack phase, opponent units are valid targets
+      const isValidTarget =
+        currentState.phase === GamePhase.WeaponAttack &&
+        unitInfo.side === GameSide.Opponent &&
+        !state.destroyed;
+
+      return unitStateToToken(unitId, state, unitInfo, isSelected, isValidTarget);
+    });
+  }, [currentState, unitInfoLookup, selectedUnitId]);
+
+  // Selected unit data
+  const selectedUnit = selectedUnitId ? currentState.units[selectedUnitId] : null;
+  const selectedUnitInfo = selectedUnitId ? unitInfoLookup[selectedUnitId] : null;
+  const selectedUnitFromSession = selectedUnitId
+    ? units.find((u) => u.id === selectedUnitId)
+    : null;
+
+  // Handle panel resize
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!isDragging || !containerRef.current) return;
+
+      const rect = containerRef.current.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const percentage = (x / rect.width) * 100;
+      const clamped = Math.max(20, Math.min(80, percentage));
+
+      setLayout((prev) => ({ ...prev, mapPanelWidth: clamped }));
+    },
+    [isDragging]
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  useEffect(() => {
+    if (isDragging) {
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+      return () => {
+        window.removeEventListener('mousemove', handleMouseMove);
+        window.removeEventListener('mouseup', handleMouseUp);
+      };
+    }
+  }, [isDragging, handleMouseMove, handleMouseUp]);
+
+  // Handle token click
+  const handleTokenClick = useCallback(
+    (unitId: string) => {
+      onUnitSelect(unitId === selectedUnitId ? null : unitId);
+    },
+    [selectedUnitId, onUnitSelect]
+  );
+
+  // Handle hex click
+  const handleHexClick = useCallback(
+    (hex: { q: number; r: number }) => {
+      onHexClick?.(hex);
+    },
+    [onHexClick]
+  );
+
+  return (
+    <div className={`flex flex-col h-full bg-gray-100 ${className}`}>
+      {/* Phase Banner */}
+      <PhaseBanner
+        phase={currentState.phase}
+        turn={currentState.turn}
+        activeSide={currentState.firstMover || GameSide.Player}
+        isPlayerTurn={isPlayerTurn}
+      />
+
+      {/* Main Content Area */}
+      <div ref={containerRef} className="flex-1 flex overflow-hidden">
+        {/* Map Panel */}
+        <div
+          className="relative"
+          style={{ width: `${layout.mapPanelWidth}%` }}
+        >
+          <HexMapDisplay
+            radius={config.mapRadius}
+            tokens={tokens}
+            selectedHex={selectedUnit?.position || null}
+            onHexClick={handleHexClick}
+            onTokenClick={handleTokenClick}
+            className="h-full"
+          />
+        </div>
+
+        {/* Resize Handle */}
+        <div
+          className="w-1 bg-gray-300 cursor-col-resize hover:bg-blue-400 transition-colors"
+          onMouseDown={() => setIsDragging(true)}
+        />
+
+        {/* Record Sheet Panel */}
+        <div
+          className="flex-1 overflow-hidden"
+          style={{ width: `${100 - layout.mapPanelWidth}%` }}
+        >
+          {selectedUnit && selectedUnitInfo && selectedUnitFromSession ? (
+            <RecordSheetDisplay
+              unitName={selectedUnitInfo.name}
+              designation={selectedUnitFromSession.unitRef}
+              state={selectedUnit}
+              maxArmor={maxArmor[selectedUnitId!] || {}}
+              maxStructure={maxStructure[selectedUnitId!] || {}}
+              weapons={unitWeapons[selectedUnitId!] || []}
+              pilotName={pilotNames[selectedUnitId!] || 'Unknown Pilot'}
+              gunnery={selectedUnitFromSession.gunnery}
+              piloting={selectedUnitFromSession.piloting}
+              heatSinks={heatSinks[selectedUnitId!] || 10}
+              className="h-full"
+            />
+          ) : (
+            <div className="h-full flex items-center justify-center text-gray-500">
+              <p>Select a unit to view details</p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Action Bar */}
+      <ActionBar
+        phase={currentState.phase}
+        canUndo={canUndo}
+        canAct={isPlayerTurn}
+        onAction={onAction}
+      />
+
+      {/* Event Log */}
+      <EventLogDisplay
+        events={events}
+        collapsed={layout.eventLogCollapsed}
+        onCollapsedChange={(collapsed) =>
+          setLayout((prev) => ({ ...prev, eventLogCollapsed: collapsed }))
+        }
+        maxHeight={150}
+      />
+    </div>
+  );
+}
+
+export default GameplayLayout;

--- a/src/components/gameplay/HexMapDisplay.tsx
+++ b/src/components/gameplay/HexMapDisplay.tsx
@@ -1,0 +1,528 @@
+/**
+ * Hex Map Display Component
+ * Interactive hex grid with unit tokens, movement ranges, and attack indicators.
+ *
+ * @spec openspec/changes/add-gameplay-ui/specs/gameplay-ui/spec.md
+ */
+
+import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import {
+  IHexCoordinate,
+  Facing,
+  GameSide,
+  IUnitToken,
+  IMovementRangeHex,
+} from '@/types/gameplay';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface HexMapDisplayProps {
+  /** Map radius (in hexes from center) */
+  radius: number;
+  /** Unit tokens to display */
+  tokens: readonly IUnitToken[];
+  /** Currently selected hex */
+  selectedHex: IHexCoordinate | null;
+  /** Hexes showing movement range */
+  movementRange?: readonly IMovementRangeHex[];
+  /** Hexes showing attack range */
+  attackRange?: readonly IHexCoordinate[];
+  /** Path to highlight (for movement preview) */
+  highlightPath?: readonly IHexCoordinate[];
+  /** Callback when hex is clicked */
+  onHexClick?: (hex: IHexCoordinate) => void;
+  /** Callback when hex is hovered */
+  onHexHover?: (hex: IHexCoordinate | null) => void;
+  /** Callback when token is clicked */
+  onTokenClick?: (unitId: string) => void;
+  /** Show coordinate labels */
+  showCoordinates?: boolean;
+  /** Optional className for styling */
+  className?: string;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Hex dimensions for flat-top hexes */
+const HEX_SIZE = 40;
+const HEX_WIDTH = HEX_SIZE * 2;
+const HEX_HEIGHT = Math.sqrt(3) * HEX_SIZE;
+
+/** Colors */
+const COLORS = {
+  gridLine: '#94a3b8',
+  hexFill: '#f8fafc',
+  hexHover: '#e2e8f0',
+  hexSelected: '#bfdbfe',
+  movementRange: '#86efac',
+  movementRangeUnreachable: '#fca5a5',
+  attackRange: '#fecaca',
+  pathHighlight: '#60a5fa',
+  playerToken: '#3b82f6',
+  opponentToken: '#ef4444',
+  destroyedToken: '#6b7280',
+};
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Convert axial hex coordinates to pixel position.
+ */
+function hexToPixel(hex: IHexCoordinate): { x: number; y: number } {
+  const x = HEX_SIZE * (3 / 2) * hex.q;
+  const y = HEX_SIZE * (Math.sqrt(3) / 2 * hex.q + Math.sqrt(3) * hex.r);
+  return { x, y };
+}
+
+/**
+ * Convert pixel position to axial hex coordinates.
+ */
+function pixelToHex(x: number, y: number): IHexCoordinate {
+  const q = (2 / 3 * x) / HEX_SIZE;
+  const r = (-1 / 3 * x + Math.sqrt(3) / 3 * y) / HEX_SIZE;
+  return roundHex(q, r);
+}
+
+/**
+ * Round fractional hex coordinates to nearest hex.
+ */
+function roundHex(q: number, r: number): IHexCoordinate {
+  const s = -q - r;
+  let rq = Math.round(q);
+  let rr = Math.round(r);
+  const rs = Math.round(s);
+
+  const qDiff = Math.abs(rq - q);
+  const rDiff = Math.abs(rr - r);
+  const sDiff = Math.abs(rs - s);
+
+  if (qDiff > rDiff && qDiff > sDiff) {
+    rq = -rr - rs;
+  } else if (rDiff > sDiff) {
+    rr = -rq - rs;
+  }
+
+  return { q: rq, r: rr };
+}
+
+/**
+ * Generate hexes within a radius.
+ */
+function generateHexesInRadius(radius: number): IHexCoordinate[] {
+  const hexes: IHexCoordinate[] = [];
+  for (let q = -radius; q <= radius; q++) {
+    const r1 = Math.max(-radius, -q - radius);
+    const r2 = Math.min(radius, -q + radius);
+    for (let r = r1; r <= r2; r++) {
+      hexes.push({ q, r });
+    }
+  }
+  return hexes;
+}
+
+/**
+ * Generate SVG path for a flat-top hexagon.
+ */
+function hexPath(cx: number, cy: number): string {
+  const points: string[] = [];
+  for (let i = 0; i < 6; i++) {
+    const angleDeg = 60 * i;
+    const angleRad = (Math.PI / 180) * angleDeg;
+    const x = cx + HEX_SIZE * Math.cos(angleRad);
+    const y = cy + HEX_SIZE * Math.sin(angleRad);
+    points.push(`${x},${y}`);
+  }
+  return `M${points.join('L')}Z`;
+}
+
+/**
+ * Get rotation angle for facing.
+ */
+function getFacingRotation(facing: Facing): number {
+  const facingAngles: Record<Facing, number> = {
+    [Facing.North]: 0,
+    [Facing.Northeast]: 60,
+    [Facing.Southeast]: 120,
+    [Facing.South]: 180,
+    [Facing.Southwest]: 240,
+    [Facing.Northwest]: 300,
+  };
+  return facingAngles[facing] ?? 0;
+}
+
+/**
+ * Check if two hex coordinates are equal.
+ */
+function hexEquals(a: IHexCoordinate, b: IHexCoordinate): boolean {
+  return a.q === b.q && a.r === b.r;
+}
+
+/**
+ * Check if a hex is in a list.
+ */
+function hexInList(hex: IHexCoordinate, list: readonly IHexCoordinate[]): boolean {
+  return list.some((h) => hexEquals(h, hex));
+}
+
+// =============================================================================
+// Sub-Components
+// =============================================================================
+
+interface HexCellProps {
+  hex: IHexCoordinate;
+  isSelected: boolean;
+  isHovered: boolean;
+  movementInfo?: IMovementRangeHex;
+  isInAttackRange: boolean;
+  isInPath: boolean;
+  showCoordinate: boolean;
+  onClick: () => void;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}
+
+function HexCell({
+  hex,
+  isSelected,
+  isHovered,
+  movementInfo,
+  isInAttackRange,
+  isInPath,
+  showCoordinate,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+}: HexCellProps): React.ReactElement {
+  const { x, y } = hexToPixel(hex);
+
+  // Determine fill color
+  let fill = COLORS.hexFill;
+  if (isSelected) {
+    fill = COLORS.hexSelected;
+  } else if (isInPath) {
+    fill = COLORS.pathHighlight;
+  } else if (movementInfo) {
+    fill = movementInfo.reachable ? COLORS.movementRange : COLORS.movementRangeUnreachable;
+  } else if (isInAttackRange) {
+    fill = COLORS.attackRange;
+  } else if (isHovered) {
+    fill = COLORS.hexHover;
+  }
+
+  return (
+    <g
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={{ cursor: 'pointer' }}
+    >
+      <path
+        d={hexPath(x, y)}
+        fill={fill}
+        stroke={COLORS.gridLine}
+        strokeWidth={1}
+      />
+      {showCoordinate && (
+        <text
+          x={x}
+          y={y + 4}
+          textAnchor="middle"
+          fontSize={10}
+          fill="#64748b"
+        >
+          {hex.q},{hex.r}
+        </text>
+      )}
+      {movementInfo && movementInfo.reachable && (
+        <text
+          x={x}
+          y={y + 12}
+          textAnchor="middle"
+          fontSize={8}
+          fill="#166534"
+        >
+          {movementInfo.mpCost}MP
+        </text>
+      )}
+    </g>
+  );
+}
+
+interface UnitTokenComponentProps {
+  token: IUnitToken;
+  onClick: () => void;
+}
+
+function UnitTokenComponent({ token, onClick }: UnitTokenComponentProps): React.ReactElement {
+  const { x, y } = hexToPixel(token.position);
+  const rotation = getFacingRotation(token.facing);
+
+  // Determine token color
+  let color = token.side === GameSide.Player ? COLORS.playerToken : COLORS.opponentToken;
+  if (token.isDestroyed) {
+    color = COLORS.destroyedToken;
+  }
+
+  // Selection ring
+  const ringColor = token.isSelected ? '#fbbf24' : token.isValidTarget ? '#f87171' : 'transparent';
+
+  return (
+    <g
+      transform={`translate(${x}, ${y})`}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      style={{ cursor: 'pointer' }}
+    >
+      {/* Selection/target ring */}
+      <circle r={HEX_SIZE * 0.7} fill="none" stroke={ringColor} strokeWidth={3} />
+
+      {/* Token body */}
+      <circle r={HEX_SIZE * 0.5} fill={color} stroke="#1e293b" strokeWidth={2} />
+
+      {/* Facing indicator (arrow) */}
+      <g transform={`rotate(${rotation - 90})`}>
+        <path
+          d="M0,-20 L8,-8 L0,-12 L-8,-8 Z"
+          fill="white"
+          stroke="#1e293b"
+          strokeWidth={1}
+        />
+      </g>
+
+      {/* Designation */}
+      <text
+        y={4}
+        textAnchor="middle"
+        fontSize={10}
+        fontWeight="bold"
+        fill="white"
+      >
+        {token.designation}
+      </text>
+
+      {/* Destroyed X */}
+      {token.isDestroyed && (
+        <g stroke="#dc2626" strokeWidth={3}>
+          <line x1={-12} y1={-12} x2={12} y2={12} />
+          <line x1={12} y1={-12} x2={-12} y2={12} />
+        </g>
+      )}
+    </g>
+  );
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Interactive hex map display.
+ */
+export function HexMapDisplay({
+  radius,
+  tokens,
+  selectedHex,
+  movementRange = [],
+  attackRange = [],
+  highlightPath = [],
+  onHexClick,
+  onHexHover,
+  onTokenClick,
+  showCoordinates = false,
+  className = '',
+}: HexMapDisplayProps): React.ReactElement {
+  const [hoveredHex, setHoveredHex] = useState<IHexCoordinate | null>(null);
+  const [viewBox, setViewBox] = useState({ x: 0, y: 0, width: 0, height: 0 });
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [isPanning, setIsPanning] = useState(false);
+  const [panStart, setPanStart] = useState({ x: 0, y: 0 });
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  // Generate all hexes
+  const hexes = useMemo(() => generateHexesInRadius(radius), [radius]);
+
+  // Create movement range lookup
+  const movementRangeLookup = useMemo(() => {
+    const map = new Map<string, IMovementRangeHex>();
+    for (const m of movementRange) {
+      map.set(`${m.hex.q},${m.hex.r}`, m);
+    }
+    return map;
+  }, [movementRange]);
+
+  // Calculate viewBox
+  useEffect(() => {
+    const padding = HEX_SIZE * 2;
+    const minX = -radius * HEX_WIDTH * 0.75 - padding;
+    const maxX = radius * HEX_WIDTH * 0.75 + padding;
+    const minY = -radius * HEX_HEIGHT - padding;
+    const maxY = radius * HEX_HEIGHT + padding;
+    setViewBox({
+      x: minX,
+      y: minY,
+      width: maxX - minX,
+      height: maxY - minY,
+    });
+  }, [radius]);
+
+  // Handle hex click
+  const handleHexClick = useCallback(
+    (hex: IHexCoordinate) => {
+      onHexClick?.(hex);
+    },
+    [onHexClick]
+  );
+
+  // Handle hex hover
+  const handleHexHover = useCallback(
+    (hex: IHexCoordinate | null) => {
+      setHoveredHex(hex);
+      onHexHover?.(hex);
+    },
+    [onHexHover]
+  );
+
+  // Handle token click
+  const handleTokenClick = useCallback(
+    (unitId: string) => {
+      onTokenClick?.(unitId);
+    },
+    [onTokenClick]
+  );
+
+  // Pan and zoom handlers
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? 0.9 : 1.1;
+    setZoom((z) => Math.max(0.5, Math.min(3, z * delta)));
+  }, []);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if (e.button === 1 || (e.button === 0 && e.altKey)) {
+      setIsPanning(true);
+      setPanStart({ x: e.clientX - pan.x, y: e.clientY - pan.y });
+    }
+  }, [pan]);
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (isPanning) {
+        setPan({
+          x: e.clientX - panStart.x,
+          y: e.clientY - panStart.y,
+        });
+      }
+    },
+    [isPanning, panStart]
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsPanning(false);
+  }, []);
+
+  // Calculate transformed viewBox
+  const transformedViewBox = useMemo(() => {
+    const scale = 1 / zoom;
+    const width = viewBox.width * scale;
+    const height = viewBox.height * scale;
+    const x = viewBox.x - pan.x * scale + (viewBox.width - width) / 2;
+    const y = viewBox.y - pan.y * scale + (viewBox.height - height) / 2;
+    return `${x} ${y} ${width} ${height}`;
+  }, [viewBox, zoom, pan]);
+
+  return (
+    <div className={`relative overflow-hidden bg-slate-100 ${className}`}>
+      <svg
+        ref={svgRef}
+        viewBox={transformedViewBox}
+        className="w-full h-full"
+        onWheel={handleWheel}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+      >
+        {/* Hex grid */}
+        <g>
+          {hexes.map((hex) => {
+            const key = `${hex.q},${hex.r}`;
+            const isSelected = selectedHex ? hexEquals(hex, selectedHex) : false;
+            const isHovered = hoveredHex ? hexEquals(hex, hoveredHex) : false;
+            const movementInfo = movementRangeLookup.get(key);
+            const isInAttackRange = hexInList(hex, attackRange);
+            const isInPath = hexInList(hex, highlightPath);
+
+            return (
+              <HexCell
+                key={key}
+                hex={hex}
+                isSelected={isSelected}
+                isHovered={isHovered}
+                movementInfo={movementInfo}
+                isInAttackRange={isInAttackRange}
+                isInPath={isInPath}
+                showCoordinate={showCoordinates}
+                onClick={() => handleHexClick(hex)}
+                onMouseEnter={() => handleHexHover(hex)}
+                onMouseLeave={() => handleHexHover(null)}
+              />
+            );
+          })}
+        </g>
+
+        {/* Unit tokens */}
+        <g>
+          {tokens.map((token) => (
+            <UnitTokenComponent
+              key={token.unitId}
+              token={token}
+              onClick={() => handleTokenClick(token.unitId)}
+            />
+          ))}
+        </g>
+      </svg>
+
+      {/* Zoom controls */}
+      <div className="absolute bottom-4 right-4 flex flex-col gap-1">
+        <button
+          type="button"
+          onClick={() => setZoom((z) => Math.min(3, z * 1.2))}
+          className="bg-white p-2 rounded shadow hover:bg-gray-100"
+          title="Zoom in"
+        >
+          +
+        </button>
+        <button
+          type="button"
+          onClick={() => setZoom((z) => Math.max(0.5, z / 1.2))}
+          className="bg-white p-2 rounded shadow hover:bg-gray-100"
+          title="Zoom out"
+        >
+          −
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setZoom(1);
+            setPan({ x: 0, y: 0 });
+          }}
+          className="bg-white p-2 rounded shadow hover:bg-gray-100"
+          title="Reset view"
+        >
+          ⟲
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default HexMapDisplay;

--- a/src/components/gameplay/PhaseBanner.tsx
+++ b/src/components/gameplay/PhaseBanner.tsx
@@ -1,0 +1,121 @@
+/**
+ * Phase Banner Component
+ * Displays the current game phase and turn information.
+ *
+ * @spec openspec/changes/add-gameplay-ui/specs/gameplay-ui/spec.md
+ */
+
+import React from 'react';
+import { GamePhase, GameSide } from '@/types/gameplay';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface PhaseBannerProps {
+  /** Current game phase */
+  phase: GamePhase;
+  /** Current turn number */
+  turn: number;
+  /** Which side's turn it is */
+  activeSide: GameSide;
+  /** Is it the player's turn to act? */
+  isPlayerTurn: boolean;
+  /** Optional additional status text */
+  statusText?: string;
+  /** Optional className for styling */
+  className?: string;
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Get display name for a phase.
+ */
+function getPhaseDisplayName(phase: GamePhase): string {
+  switch (phase) {
+    case GamePhase.Initiative:
+      return 'Initiative';
+    case GamePhase.Movement:
+      return 'Movement Phase';
+    case GamePhase.WeaponAttack:
+      return 'Weapon Attack Phase';
+    case GamePhase.PhysicalAttack:
+      return 'Physical Attack Phase';
+    case GamePhase.Heat:
+      return 'Heat Phase';
+    case GamePhase.End:
+      return 'End Phase';
+    default:
+      return 'Unknown Phase';
+  }
+}
+
+/**
+ * Get phase color for styling.
+ */
+function getPhaseColor(phase: GamePhase): string {
+  switch (phase) {
+    case GamePhase.Initiative:
+      return 'bg-blue-600';
+    case GamePhase.Movement:
+      return 'bg-green-600';
+    case GamePhase.WeaponAttack:
+      return 'bg-red-600';
+    case GamePhase.PhysicalAttack:
+      return 'bg-orange-600';
+    case GamePhase.Heat:
+      return 'bg-yellow-600';
+    case GamePhase.End:
+      return 'bg-gray-600';
+    default:
+      return 'bg-gray-500';
+  }
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Phase banner showing current game state.
+ */
+export function PhaseBanner({
+  phase,
+  turn,
+  activeSide,
+  isPlayerTurn,
+  statusText,
+  className = '',
+}: PhaseBannerProps): React.ReactElement {
+  const phaseColor = getPhaseColor(phase);
+  const turnText = isPlayerTurn ? 'Your Turn' : "Opponent's Turn";
+
+  return (
+    <div
+      className={`${phaseColor} text-white px-4 py-2 flex items-center justify-between ${className}`}
+      role="banner"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-4">
+        <span className="font-bold text-lg">{getPhaseDisplayName(phase)}</span>
+        <span className="text-sm opacity-90">-</span>
+        <span className="text-sm font-medium">{turnText}</span>
+        {statusText && (
+          <>
+            <span className="text-sm opacity-90">-</span>
+            <span className="text-sm">{statusText}</span>
+          </>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-sm opacity-75">Turn</span>
+        <span className="font-bold text-xl bg-black/20 px-3 py-1 rounded">{turn}</span>
+      </div>
+    </div>
+  );
+}
+
+export default PhaseBanner;

--- a/src/components/gameplay/RecordSheetDisplay.tsx
+++ b/src/components/gameplay/RecordSheetDisplay.tsx
@@ -1,0 +1,421 @@
+/**
+ * Record Sheet Display Component
+ * Shows unit status in traditional record sheet format.
+ *
+ * @spec openspec/changes/add-gameplay-ui/specs/gameplay-ui/spec.md
+ */
+
+import React, { useMemo } from 'react';
+import { IUnitGameState, IWeaponStatus } from '@/types/gameplay';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface RecordSheetDisplayProps {
+  /** Unit name */
+  unitName: string;
+  /** Unit designation (e.g., "ATL-7K") */
+  designation: string;
+  /** Current unit state */
+  state: IUnitGameState;
+  /** Maximum armor values per location */
+  maxArmor: Record<string, number>;
+  /** Maximum structure values per location */
+  maxStructure: Record<string, number>;
+  /** Weapons on this unit */
+  weapons: readonly IWeaponStatus[];
+  /** Pilot name */
+  pilotName: string;
+  /** Gunnery skill */
+  gunnery: number;
+  /** Piloting skill */
+  piloting: number;
+  /** Heat sink count */
+  heatSinks: number;
+  /** Selected weapon IDs (for attack UI) */
+  selectedWeaponIds?: readonly string[];
+  /** Callback when weapon selection changes */
+  onWeaponToggle?: (weaponId: string) => void;
+  /** Optional className for styling */
+  className?: string;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Standard BattleMech locations in display order */
+const LOCATION_ORDER = [
+  'head',
+  'center_torso',
+  'left_torso',
+  'right_torso',
+  'left_arm',
+  'right_arm',
+  'left_leg',
+  'right_leg',
+];
+
+/** Location display names */
+const LOCATION_NAMES: Record<string, string> = {
+  head: 'Head',
+  center_torso: 'Center Torso',
+  left_torso: 'Left Torso',
+  right_torso: 'Right Torso',
+  left_arm: 'Left Arm',
+  right_arm: 'Right Arm',
+  left_leg: 'Left Leg',
+  right_leg: 'Right Leg',
+};
+
+/** Locations with rear armor */
+const REAR_ARMOR_LOCATIONS = ['center_torso', 'left_torso', 'right_torso'];
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Get damage percentage for a location.
+ */
+function getDamagePercent(current: number, max: number): number {
+  if (max === 0) return 0;
+  return Math.round((1 - current / max) * 100);
+}
+
+/**
+ * Get status color based on remaining percentage.
+ */
+function getStatusColor(remaining: number, max: number): string {
+  const percent = max > 0 ? (remaining / max) * 100 : 0;
+  if (percent === 0) return 'text-gray-500';
+  if (percent <= 25) return 'text-red-600';
+  if (percent <= 50) return 'text-orange-500';
+  if (percent <= 75) return 'text-yellow-600';
+  return 'text-green-600';
+}
+
+// =============================================================================
+// Sub-Components
+// =============================================================================
+
+interface LocationStatusRowProps {
+  location: string;
+  armor: number;
+  maxArmor: number;
+  structure: number;
+  maxStructure: number;
+  destroyed: boolean;
+  rearArmor?: number;
+  maxRearArmor?: number;
+}
+
+function LocationStatusRow({
+  location,
+  armor,
+  maxArmor,
+  structure,
+  maxStructure,
+  destroyed,
+  rearArmor,
+  maxRearArmor,
+}: LocationStatusRowProps): React.ReactElement {
+  const displayName = LOCATION_NAMES[location] || location;
+  const armorColor = getStatusColor(armor, maxArmor);
+  const structureColor = getStatusColor(structure, maxStructure);
+
+  return (
+    <div className={`flex items-center py-1 px-2 ${destroyed ? 'opacity-50 line-through' : ''}`}>
+      <span className="w-28 text-sm font-medium">{displayName}</span>
+      <div className="flex-1 flex items-center gap-4">
+        {/* Front armor */}
+        <div className="flex items-center gap-1">
+          <span className="text-xs text-gray-500 w-6">AR:</span>
+          <span className={`text-sm font-mono w-8 text-right ${armorColor}`}>
+            {armor}/{maxArmor}
+          </span>
+        </div>
+        {/* Rear armor (if applicable) */}
+        {rearArmor !== undefined && maxRearArmor !== undefined && (
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-gray-500 w-6">RR:</span>
+            <span className={`text-sm font-mono w-8 text-right ${getStatusColor(rearArmor, maxRearArmor)}`}>
+              {rearArmor}/{maxRearArmor}
+            </span>
+          </div>
+        )}
+        {/* Structure */}
+        <div className="flex items-center gap-1">
+          <span className="text-xs text-gray-500 w-6">IS:</span>
+          <span className={`text-sm font-mono w-8 text-right ${structureColor}`}>
+            {structure}/{maxStructure}
+          </span>
+        </div>
+      </div>
+      {destroyed && (
+        <span className="text-red-600 text-xs font-bold">DESTROYED</span>
+      )}
+    </div>
+  );
+}
+
+interface WeaponRowProps {
+  weapon: IWeaponStatus;
+  isSelected: boolean;
+  onToggle?: () => void;
+}
+
+function WeaponRow({ weapon, isSelected, onToggle }: WeaponRowProps): React.ReactElement {
+  const isAvailable = !weapon.destroyed;
+  const rowClasses = weapon.destroyed
+    ? 'opacity-50 line-through'
+    : weapon.firedThisTurn
+    ? 'bg-yellow-50'
+    : '';
+
+  return (
+    <div
+      className={`flex items-center py-1 px-2 hover:bg-gray-50 ${rowClasses}`}
+      onClick={isAvailable && onToggle ? onToggle : undefined}
+      style={{ cursor: isAvailable && onToggle ? 'pointer' : 'default' }}
+    >
+      {onToggle && (
+        <input
+          type="checkbox"
+          checked={isSelected}
+          onChange={onToggle}
+          disabled={!isAvailable}
+          className="mr-2"
+        />
+      )}
+      <span className="flex-1 text-sm">{weapon.name}</span>
+      <span className="text-xs text-gray-500 w-16">{weapon.location}</span>
+      <span className="text-xs text-gray-600 w-8 text-center">{weapon.heat}H</span>
+      <span className="text-xs text-gray-600 w-8 text-center">{weapon.damage}D</span>
+      <span className="text-xs text-gray-500 w-20">
+        {weapon.ranges.short}/{weapon.ranges.medium}/{weapon.ranges.long}
+      </span>
+      {weapon.ammoRemaining !== undefined && (
+        <span className="text-xs text-gray-500 w-12 text-right">
+          {weapon.ammoRemaining} rds
+        </span>
+      )}
+    </div>
+  );
+}
+
+interface SimpleHeatDisplayProps {
+  heat: number;
+  heatSinks: number;
+}
+
+function SimpleHeatDisplay({ heat, heatSinks }: SimpleHeatDisplayProps): React.ReactElement {
+  const maxHeat = 30;
+  const heatPercent = Math.min((heat / maxHeat) * 100, 100);
+  
+  // Heat effect thresholds
+  const getHeatColor = () => {
+    if (heat >= 30) return 'bg-red-600';
+    if (heat >= 23) return 'bg-red-500';
+    if (heat >= 17) return 'bg-orange-500';
+    if (heat >= 13) return 'bg-yellow-500';
+    if (heat >= 8) return 'bg-yellow-400';
+    return 'bg-green-500';
+  };
+
+  const getHeatEffects = () => {
+    const effects: string[] = [];
+    if (heat >= 30) effects.push('SHUTDOWN');
+    if (heat >= 26) effects.push('+5 to-hit penalty');
+    if (heat >= 24) effects.push('Ammo explosion risk');
+    if (heat >= 18) effects.push('+4 to-hit penalty');
+    if (heat >= 13) effects.push('+2 to-hit penalty');
+    if (heat >= 8) effects.push('+1 to-hit penalty');
+    return effects;
+  };
+
+  const effects = getHeatEffects();
+
+  return (
+    <div className="bg-gray-50 p-2 rounded">
+      <div className="flex items-center gap-4 mb-2">
+        <div className="flex-1">
+          <div className="h-4 bg-gray-200 rounded overflow-hidden">
+            <div
+              className={`h-full ${getHeatColor()} transition-all`}
+              style={{ width: `${heatPercent}%` }}
+            />
+          </div>
+        </div>
+        <div className="text-sm font-mono">
+          <span className="font-bold">{heat}</span>
+          <span className="text-gray-500">/{maxHeat}</span>
+        </div>
+      </div>
+      {effects.length > 0 && (
+        <div className="text-xs text-red-600">
+          {effects.join(' • ')}
+        </div>
+      )}
+      <div className="text-xs text-gray-500 mt-1">
+        Dissipation: {heatSinks} heat/turn
+      </div>
+    </div>
+  );
+}
+
+interface PilotStatusProps {
+  name: string;
+  gunnery: number;
+  piloting: number;
+  wounds: number;
+  conscious: boolean;
+}
+
+function PilotStatus({ name, gunnery, piloting, wounds, conscious }: PilotStatusProps): React.ReactElement {
+  const woundIndicators = [];
+  for (let i = 0; i < 6; i++) {
+    woundIndicators.push(
+      <span
+        key={i}
+        className={`w-4 h-4 rounded-full border ${
+          i < wounds ? 'bg-red-500 border-red-600' : 'bg-white border-gray-300'
+        }`}
+      />
+    );
+  }
+
+  return (
+    <div className="p-2 bg-gray-50 rounded">
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-medium">{name}</span>
+        {!conscious && <span className="text-red-600 text-xs font-bold">UNCONSCIOUS</span>}
+      </div>
+      <div className="flex items-center gap-4 text-sm">
+        <span>Gunnery: <strong>{gunnery}</strong></span>
+        <span>Piloting: <strong>{piloting}</strong></span>
+      </div>
+      <div className="flex items-center gap-1 mt-2">
+        <span className="text-xs text-gray-500 mr-2">Wounds:</span>
+        {woundIndicators}
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Record sheet display showing full unit status.
+ */
+export function RecordSheetDisplay({
+  unitName,
+  designation,
+  state,
+  maxArmor,
+  maxStructure,
+  weapons,
+  pilotName,
+  gunnery,
+  piloting,
+  heatSinks,
+  selectedWeaponIds = [],
+  onWeaponToggle,
+  className = '',
+}: RecordSheetDisplayProps): React.ReactElement {
+  // Build location statuses
+  const locationStatuses = useMemo(() => {
+    return LOCATION_ORDER.map((location) => {
+      const hasRear = REAR_ARMOR_LOCATIONS.includes(location);
+      return {
+        location,
+        armor: state.armor[location] ?? 0,
+        maxArmor: maxArmor[location] ?? 0,
+        structure: state.structure[location] ?? 0,
+        maxStructure: maxStructure[location] ?? 0,
+        destroyed: state.destroyedLocations.includes(location),
+        rearArmor: hasRear ? state.armor[`${location}_rear`] ?? 0 : undefined,
+        maxRearArmor: hasRear ? maxArmor[`${location}_rear`] ?? 0 : undefined,
+      };
+    });
+  }, [state, maxArmor, maxStructure]);
+
+  return (
+    <div className={`bg-white p-4 overflow-y-auto ${className}`}>
+      {/* Header */}
+      <div className="border-b border-gray-300 pb-2 mb-4">
+        <h2 className="text-lg font-bold">{unitName}</h2>
+        <span className="text-sm text-gray-600">{designation}</span>
+        {state.destroyed && (
+          <span className="ml-4 text-red-600 font-bold">DESTROYED</span>
+        )}
+      </div>
+
+      {/* Pilot Status */}
+      <div className="mb-4">
+        <h3 className="text-sm font-bold text-gray-700 mb-2">PILOT</h3>
+        <PilotStatus
+          name={pilotName}
+          gunnery={gunnery}
+          piloting={piloting}
+          wounds={state.pilotWounds}
+          conscious={state.pilotConscious}
+        />
+      </div>
+
+      {/* Heat */}
+      <div className="mb-4">
+        <h3 className="text-sm font-bold text-gray-700 mb-2">HEAT ({heatSinks} sinks)</h3>
+        <SimpleHeatDisplay heat={state.heat} heatSinks={heatSinks} />
+      </div>
+
+      {/* Armor/Structure */}
+      <div className="mb-4">
+        <h3 className="text-sm font-bold text-gray-700 mb-2">ARMOR / STRUCTURE</h3>
+        <div className="border rounded divide-y">
+          {locationStatuses.map((loc) => (
+            <LocationStatusRow key={loc.location} {...loc} />
+          ))}
+        </div>
+      </div>
+
+      {/* Weapons */}
+      <div className="mb-4">
+        <h3 className="text-sm font-bold text-gray-700 mb-2">WEAPONS</h3>
+        <div className="border rounded divide-y">
+          <div className="flex items-center py-1 px-2 bg-gray-50 text-xs text-gray-600">
+            {onWeaponToggle && <span className="w-6" />}
+            <span className="flex-1">Weapon</span>
+            <span className="w-16">Loc</span>
+            <span className="w-8 text-center">Heat</span>
+            <span className="w-8 text-center">Dmg</span>
+            <span className="w-20">S/M/L</span>
+            <span className="w-12 text-right">Ammo</span>
+          </div>
+          {weapons.map((weapon) => (
+            <WeaponRow
+              key={weapon.id}
+              weapon={weapon}
+              isSelected={selectedWeaponIds.includes(weapon.id)}
+              onToggle={onWeaponToggle ? () => onWeaponToggle(weapon.id) : undefined}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Movement info */}
+      <div className="text-sm text-gray-600">
+        <span>Movement this turn: </span>
+        <strong>{state.movementThisTurn}</strong>
+        {state.hexesMovedThisTurn > 0 && (
+          <span> ({state.hexesMovedThisTurn} hexes)</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default RecordSheetDisplay;

--- a/src/components/gameplay/__tests__/ActionBar.test.tsx
+++ b/src/components/gameplay/__tests__/ActionBar.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * ActionBar Component Tests
+ *
+ * @spec openspec/changes/add-gameplay-ui/specs/gameplay-ui/spec.md
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ActionBar } from '../ActionBar';
+import { GamePhase } from '@/types/gameplay';
+
+describe('ActionBar', () => {
+  const defaultProps = {
+    phase: GamePhase.Movement,
+    canUndo: false,
+    canAct: true,
+    onAction: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render movement phase actions', () => {
+    render(<ActionBar {...defaultProps} />);
+    expect(screen.getByText(/Lock Movement/)).toBeInTheDocument();
+    expect(screen.getByText(/Undo/)).toBeInTheDocument();
+    expect(screen.getByText(/Skip/)).toBeInTheDocument();
+  });
+
+  it('should render attack phase actions', () => {
+    render(<ActionBar {...defaultProps} phase={GamePhase.WeaponAttack} />);
+    expect(screen.getByText(/Lock Attacks/)).toBeInTheDocument();
+    expect(screen.getByText(/Clear All/)).toBeInTheDocument();
+    expect(screen.getByText(/Skip Attacks/)).toBeInTheDocument();
+  });
+
+  it('should call onAction when button clicked', () => {
+    const onAction = jest.fn();
+    render(<ActionBar {...defaultProps} onAction={onAction} />);
+    
+    fireEvent.click(screen.getByText(/Lock Movement/));
+    expect(onAction).toHaveBeenCalledWith('lock');
+  });
+
+  it('should disable undo when canUndo is false', () => {
+    render(<ActionBar {...defaultProps} canUndo={false} />);
+    const undoButton = screen.getByText(/Undo/).closest('button');
+    expect(undoButton).toBeDisabled();
+  });
+
+  it('should enable undo when canUndo is true', () => {
+    render(<ActionBar {...defaultProps} canUndo={true} />);
+    const undoButton = screen.getByText(/Undo/).closest('button');
+    expect(undoButton).not.toBeDisabled();
+  });
+
+  it('should disable all buttons when canAct is false', () => {
+    render(<ActionBar {...defaultProps} canAct={false} />);
+    const buttons = screen.getAllByRole('button');
+    buttons.forEach(button => {
+      expect(button).toBeDisabled();
+    });
+  });
+
+  it('should display info text when provided', () => {
+    render(<ActionBar {...defaultProps} infoText="Select a hex to move" />);
+    expect(screen.getByText('Select a hex to move')).toBeInTheDocument();
+  });
+
+  it('should have toolbar role for accessibility', () => {
+    render(<ActionBar {...defaultProps} />);
+    expect(screen.getByRole('toolbar')).toBeInTheDocument();
+  });
+});

--- a/src/components/gameplay/__tests__/PhaseBanner.test.tsx
+++ b/src/components/gameplay/__tests__/PhaseBanner.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * PhaseBanner Component Tests
+ *
+ * @spec openspec/changes/add-gameplay-ui/specs/gameplay-ui/spec.md
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PhaseBanner } from '../PhaseBanner';
+import { GamePhase, GameSide } from '@/types/gameplay';
+
+describe('PhaseBanner', () => {
+  const defaultProps = {
+    phase: GamePhase.Movement,
+    turn: 1,
+    activeSide: GameSide.Player,
+    isPlayerTurn: true,
+  };
+
+  it('should render the phase name', () => {
+    render(<PhaseBanner {...defaultProps} />);
+    expect(screen.getByText('Movement Phase')).toBeInTheDocument();
+  });
+
+  it('should display turn number', () => {
+    render(<PhaseBanner {...defaultProps} turn={5} />);
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('should show "Your Turn" when player turn', () => {
+    render(<PhaseBanner {...defaultProps} isPlayerTurn={true} />);
+    expect(screen.getByText('Your Turn')).toBeInTheDocument();
+  });
+
+  it('should show "Opponent\'s Turn" when not player turn', () => {
+    render(<PhaseBanner {...defaultProps} isPlayerTurn={false} />);
+    expect(screen.getByText("Opponent's Turn")).toBeInTheDocument();
+  });
+
+  it('should display status text when provided', () => {
+    render(<PhaseBanner {...defaultProps} statusText="Waiting for input" />);
+    expect(screen.getByText('Waiting for input')).toBeInTheDocument();
+  });
+
+  it('should render different phases correctly', () => {
+    const { rerender } = render(<PhaseBanner {...defaultProps} phase={GamePhase.Initiative} />);
+    expect(screen.getByText('Initiative')).toBeInTheDocument();
+
+    rerender(<PhaseBanner {...defaultProps} phase={GamePhase.WeaponAttack} />);
+    expect(screen.getByText('Weapon Attack Phase')).toBeInTheDocument();
+
+    rerender(<PhaseBanner {...defaultProps} phase={GamePhase.Heat} />);
+    expect(screen.getByText('Heat Phase')).toBeInTheDocument();
+  });
+
+  it('should have banner role for accessibility', () => {
+    render(<PhaseBanner {...defaultProps} />);
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+  });
+});

--- a/src/components/gameplay/index.ts
+++ b/src/components/gameplay/index.ts
@@ -4,3 +4,17 @@ export { HeatTracker } from './HeatTracker';
 export type { HeatTrackerProps, HeatScale } from './HeatTracker';
 export { AmmoCounter } from './AmmoCounter';
 export type { AmmoCounterProps } from './AmmoCounter';
+
+// Gameplay UI Components
+export { PhaseBanner } from './PhaseBanner';
+export type { PhaseBannerProps } from './PhaseBanner';
+export { ActionBar } from './ActionBar';
+export type { ActionBarProps } from './ActionBar';
+export { EventLogDisplay } from './EventLogDisplay';
+export type { EventLogDisplayProps } from './EventLogDisplay';
+export { HexMapDisplay } from './HexMapDisplay';
+export type { HexMapDisplayProps } from './HexMapDisplay';
+export { RecordSheetDisplay } from './RecordSheetDisplay';
+export type { RecordSheetDisplayProps } from './RecordSheetDisplay';
+export { GameplayLayout } from './GameplayLayout';
+export type { GameplayLayoutProps } from './GameplayLayout';

--- a/src/pages/gameplay/games/[id].tsx
+++ b/src/pages/gameplay/games/[id].tsx
@@ -1,0 +1,160 @@
+/**
+ * Game Session Page
+ * Main gameplay interface for an active game session.
+ *
+ * @spec openspec/changes/add-gameplay-ui/specs/gameplay-ui/spec.md
+ */
+
+import { useEffect, useCallback } from 'react';
+import { useRouter } from 'next/router';
+import Head from 'next/head';
+import { GameplayLayout } from '@/components/gameplay';
+import { useGameplayStore } from '@/stores/useGameplayStore';
+import { GameSide } from '@/types/gameplay';
+
+// =============================================================================
+// Loading Component
+// =============================================================================
+
+function GameLoading(): React.ReactElement {
+  return (
+    <div className="h-screen flex items-center justify-center bg-gray-900">
+      <div className="text-center">
+        <div className="animate-spin w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full mx-auto mb-4" />
+        <p className="text-gray-400">Loading game session...</p>
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Error Component
+// =============================================================================
+
+interface GameErrorProps {
+  message: string;
+  onRetry: () => void;
+}
+
+function GameError({ message, onRetry }: GameErrorProps): React.ReactElement {
+  return (
+    <div className="h-screen flex items-center justify-center bg-gray-900">
+      <div className="text-center max-w-md">
+        <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-red-900/20 flex items-center justify-center">
+          <svg
+            className="w-8 h-8 text-red-500"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
+        </div>
+        <h2 className="text-xl font-bold text-white mb-2">Failed to Load Game</h2>
+        <p className="text-gray-400 mb-4">{message}</p>
+        <button
+          onClick={onRetry}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+        >
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Main Page Component
+// =============================================================================
+
+export default function GameSessionPage(): React.ReactElement {
+  const router = useRouter();
+  const { id } = router.query;
+
+  const {
+    session,
+    isLoading,
+    error,
+    loadSession,
+    createDemoSession,
+    ui,
+    selectUnit,
+    handleAction,
+    unitWeapons,
+    maxArmor,
+    maxStructure,
+    pilotNames,
+    heatSinks,
+    clearError,
+  } = useGameplayStore();
+
+  // Load session on mount
+  useEffect(() => {
+    if (id === 'demo') {
+      createDemoSession();
+    } else if (typeof id === 'string') {
+      loadSession(id);
+    }
+  }, [id, loadSession, createDemoSession]);
+
+  // Handle hex click
+  const handleHexClick = useCallback((hex: { q: number; r: number }) => {
+    console.log('Hex clicked:', hex);
+    // TODO: Handle movement/targeting based on current phase
+  }, []);
+
+  // Handle retry
+  const handleRetry = useCallback(() => {
+    clearError();
+    if (typeof id === 'string') {
+      loadSession(id);
+    }
+  }, [id, loadSession, clearError]);
+
+  // Loading state
+  if (isLoading) {
+    return <GameLoading />;
+  }
+
+  // Error state
+  if (error) {
+    return <GameError message={error} onRetry={handleRetry} />;
+  }
+
+  // No session
+  if (!session) {
+    return <GameLoading />;
+  }
+
+  // Determine if it's player's turn
+  const isPlayerTurn = session.currentState.firstMover === GameSide.Player;
+
+  return (
+    <>
+      <Head>
+        <title>Game Session - MekStation</title>
+      </Head>
+      <div className="h-screen overflow-hidden">
+        <GameplayLayout
+          session={session}
+          selectedUnitId={ui.selectedUnitId}
+          onUnitSelect={selectUnit}
+          onAction={handleAction}
+          onHexClick={handleHexClick}
+          canUndo={false}
+          isPlayerTurn={isPlayerTurn}
+          unitWeapons={unitWeapons}
+          maxArmor={maxArmor}
+          maxStructure={maxStructure}
+          pilotNames={pilotNames}
+          heatSinks={heatSinks}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/pages/gameplay/games/index.tsx
+++ b/src/pages/gameplay/games/index.tsx
@@ -1,0 +1,216 @@
+/**
+ * Games List Page
+ * Browse active and completed game sessions.
+ *
+ * @spec openspec/changes/add-gameplay-ui/specs/gameplay-ui/spec.md
+ */
+
+import { useCallback } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import {
+  PageLayout,
+  Card,
+  Button,
+  EmptyState,
+} from '@/components/ui';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface GameSummary {
+  id: string;
+  name: string;
+  status: 'active' | 'completed' | 'abandoned';
+  turn: number;
+  playerForce: string;
+  opponentForce: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// =============================================================================
+// Demo Data
+// =============================================================================
+
+const DEMO_GAMES: GameSummary[] = [
+  {
+    id: 'demo',
+    name: 'Demo Battle',
+    status: 'active',
+    turn: 3,
+    playerForce: 'Atlas AS7-D',
+    opponentForce: 'Hunchback HBK-4G',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+];
+
+// =============================================================================
+// Sub-Components
+// =============================================================================
+
+interface GameCardProps {
+  game: GameSummary;
+  onClick: () => void;
+}
+
+function GameCard({ game, onClick }: GameCardProps): React.ReactElement {
+  const statusColors = {
+    active: 'bg-green-100 text-green-800',
+    completed: 'bg-blue-100 text-blue-800',
+    abandoned: 'bg-gray-100 text-gray-800',
+  };
+
+  return (
+    <Card
+      className="cursor-pointer hover:ring-2 hover:ring-blue-500 transition-all"
+      onClick={onClick}
+    >
+      <div className="flex items-start justify-between mb-3">
+        <h3 className="font-bold text-lg">{game.name}</h3>
+        <span className={`px-2 py-1 rounded text-xs font-medium ${statusColors[game.status]}`}>
+          {game.status}
+        </span>
+      </div>
+      <div className="text-sm text-gray-600 space-y-1">
+        <p>
+          <span className="font-medium">Turn:</span> {game.turn}
+        </p>
+        <p>
+          <span className="font-medium">Player:</span> {game.playerForce}
+        </p>
+        <p>
+          <span className="font-medium">Opponent:</span> {game.opponentForce}
+        </p>
+      </div>
+      <div className="mt-4 pt-3 border-t border-gray-200 text-xs text-gray-500">
+        Last played: {new Date(game.updatedAt).toLocaleDateString()}
+      </div>
+    </Card>
+  );
+}
+
+// =============================================================================
+// Main Page Component
+// =============================================================================
+
+export default function GamesListPage(): React.ReactElement {
+  const router = useRouter();
+
+  // Handle game click
+  const handleGameClick = useCallback(
+    (game: GameSummary) => {
+      router.push(`/gameplay/games/${game.id}`);
+    },
+    [router]
+  );
+
+  // Handle new game
+  const handleNewGame = useCallback(() => {
+    // TODO: Navigate to encounter setup when implemented
+    router.push('/gameplay/games/demo');
+  }, [router]);
+
+  return (
+    <PageLayout
+      title="Games"
+      subtitle="Active and completed game sessions"
+      maxWidth="wide"
+      headerContent={
+        <Button variant="primary" onClick={handleNewGame}>
+          New Game (Demo)
+        </Button>
+      }
+    >
+      {/* Games Grid */}
+      {DEMO_GAMES.length === 0 ? (
+        <EmptyState
+          icon={
+            <div className="w-16 h-16 mx-auto rounded-full bg-surface-raised/50 flex items-center justify-center">
+              <svg
+                className="w-8 h-8 text-text-theme-muted"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            </div>
+          }
+          title="No games yet"
+          message="Start a new game to begin playing"
+          action={
+            <Button variant="primary" onClick={handleNewGame}>
+              Start Demo Game
+            </Button>
+          }
+        />
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {DEMO_GAMES.map((game) => (
+            <GameCard
+              key={game.id}
+              game={game}
+              onClick={() => handleGameClick(game)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Navigation links */}
+      <div className="mt-8 pt-6 border-t border-border-theme-subtle flex gap-6">
+        <Link
+          href="/gameplay/forces"
+          className="inline-flex items-center gap-2 text-accent hover:text-accent/80 transition-colors"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+            />
+          </svg>
+          Manage Forces
+        </Link>
+        <Link
+          href="/gameplay/pilots"
+          className="inline-flex items-center gap-2 text-accent hover:text-accent/80 transition-colors"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
+            />
+          </svg>
+          Manage Pilots
+        </Link>
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/stores/useGameplayStore.ts
+++ b/src/stores/useGameplayStore.ts
@@ -1,0 +1,509 @@
+/**
+ * Gameplay Store
+ * Zustand store for game session state management.
+ *
+ * @spec openspec/changes/add-gameplay-ui/specs/gameplay-ui/spec.md
+ */
+
+import { create } from 'zustand';
+import {
+  IGameSession,
+  IGameState,
+  IGameEvent,
+  GamePhase,
+  GameStatus,
+  GameSide,
+  GameEventType,
+  LockState,
+  IGameplayUIState,
+  DEFAULT_UI_STATE,
+  IWeaponStatus,
+  Facing,
+  MovementType,
+} from '@/types/gameplay';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface GameplayState {
+  /** Current game session */
+  session: IGameSession | null;
+  /** UI state */
+  ui: IGameplayUIState;
+  /** Is loading */
+  isLoading: boolean;
+  /** Error message */
+  error: string | null;
+  /** Unit weapons lookup */
+  unitWeapons: Record<string, readonly IWeaponStatus[]>;
+  /** Max armor values lookup */
+  maxArmor: Record<string, Record<string, number>>;
+  /** Max structure values lookup */
+  maxStructure: Record<string, Record<string, number>>;
+  /** Pilot names lookup */
+  pilotNames: Record<string, string>;
+  /** Heat sinks lookup */
+  heatSinks: Record<string, number>;
+}
+
+interface GameplayActions {
+  /** Load a game session */
+  loadSession: (sessionId: string) => Promise<void>;
+  /** Create a demo session for testing */
+  createDemoSession: () => void;
+  /** Select a unit */
+  selectUnit: (unitId: string | null) => void;
+  /** Set target unit */
+  setTarget: (unitId: string | null) => void;
+  /** Handle action from action bar */
+  handleAction: (actionId: string) => void;
+  /** Toggle weapon selection */
+  toggleWeapon: (weaponId: string) => void;
+  /** Clear error */
+  clearError: () => void;
+  /** Reset store */
+  reset: () => void;
+}
+
+type GameplayStore = GameplayState & GameplayActions;
+
+// =============================================================================
+// Initial State
+// =============================================================================
+
+const initialState: GameplayState = {
+  session: null,
+  ui: DEFAULT_UI_STATE,
+  isLoading: false,
+  error: null,
+  unitWeapons: {},
+  maxArmor: {},
+  maxStructure: {},
+  pilotNames: {},
+  heatSinks: {},
+};
+
+// =============================================================================
+// Demo Session Factory
+// =============================================================================
+
+function createDemoSession(): IGameSession {
+  const now = new Date().toISOString();
+  const gameId = 'demo-game-001';
+
+  // Create demo units
+  const playerUnit = {
+    id: 'unit-player-1',
+    name: 'Atlas AS7-D',
+    side: GameSide.Player,
+    unitRef: 'AS7-D',
+    pilotRef: 'pilot-1',
+    gunnery: 4,
+    piloting: 5,
+  };
+
+  const opponentUnit = {
+    id: 'unit-opponent-1',
+    name: 'Hunchback HBK-4G',
+    side: GameSide.Opponent,
+    unitRef: 'HBK-4G',
+    pilotRef: 'pilot-2',
+    gunnery: 4,
+    piloting: 5,
+  };
+
+  // Create demo unit states
+  const playerUnitState = {
+    id: playerUnit.id,
+    side: GameSide.Player,
+    position: { q: -2, r: 0 },
+    facing: Facing.Northeast,
+    heat: 5,
+    movementThisTurn: MovementType.Walk,
+    hexesMovedThisTurn: 3,
+    armor: {
+      head: 9,
+      center_torso: 40,
+      center_torso_rear: 12,
+      left_torso: 28,
+      left_torso_rear: 8,
+      right_torso: 28,
+      right_torso_rear: 8,
+      left_arm: 24,
+      right_arm: 24,
+      left_leg: 31,
+      right_leg: 31,
+    },
+    structure: {
+      head: 3,
+      center_torso: 31,
+      left_torso: 21,
+      right_torso: 21,
+      left_arm: 17,
+      right_arm: 17,
+      left_leg: 21,
+      right_leg: 21,
+    },
+    destroyedLocations: [] as string[],
+    destroyedEquipment: [] as string[],
+    ammo: {
+      'ac20-ammo': 10,
+      'lrm20-ammo': 12,
+      'srm6-ammo': 15,
+    },
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+  };
+
+  const opponentUnitState = {
+    id: opponentUnit.id,
+    side: GameSide.Opponent,
+    position: { q: 2, r: 0 },
+    facing: Facing.Southwest,
+    heat: 8,
+    movementThisTurn: MovementType.Walk,
+    hexesMovedThisTurn: 4,
+    armor: {
+      head: 8,
+      center_torso: 22,
+      center_torso_rear: 8,
+      left_torso: 18,
+      left_torso_rear: 6,
+      right_torso: 18,
+      right_torso_rear: 6,
+      left_arm: 12,
+      right_arm: 12,
+      left_leg: 20,
+      right_leg: 20,
+    },
+    structure: {
+      head: 3,
+      center_torso: 16,
+      left_torso: 12,
+      right_torso: 12,
+      left_arm: 8,
+      right_arm: 8,
+      left_leg: 12,
+      right_leg: 12,
+    },
+    destroyedLocations: [] as string[],
+    destroyedEquipment: [] as string[],
+    ammo: {
+      'ac20-ammo': 5,
+      'ml-ammo': 0,
+    },
+    pilotWounds: 1,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+  };
+
+  // Create game state
+  const gameState: IGameState = {
+    gameId,
+    status: GameStatus.Active,
+    turn: 3,
+    phase: GamePhase.WeaponAttack,
+    initiativeWinner: GameSide.Player,
+    firstMover: GameSide.Player,
+    activationIndex: 0,
+    units: {
+      [playerUnit.id]: playerUnitState,
+      [opponentUnit.id]: opponentUnitState,
+    },
+    turnEvents: [],
+  };
+
+  // Create demo events
+  const events: IGameEvent[] = [
+    {
+      id: 'evt-1',
+      gameId,
+      sequence: 1,
+      timestamp: now,
+      type: GameEventType.TurnStarted,
+      turn: 3,
+      phase: GamePhase.Initiative,
+      payload: {} as never,
+    },
+    {
+      id: 'evt-2',
+      gameId,
+      sequence: 2,
+      timestamp: now,
+      type: GameEventType.PhaseChanged,
+      turn: 3,
+      phase: GamePhase.Movement,
+      payload: {
+        fromPhase: GamePhase.Initiative,
+        toPhase: GamePhase.Movement,
+      },
+    },
+  ];
+
+  return {
+    id: gameId,
+    createdAt: now,
+    updatedAt: now,
+    config: {
+      mapRadius: 5,
+      turnLimit: 0,
+      victoryConditions: ['destroy_all'],
+      optionalRules: [],
+    },
+    units: [playerUnit, opponentUnit],
+    events,
+    currentState: gameState,
+  };
+}
+
+function createDemoWeapons(): Record<string, readonly IWeaponStatus[]> {
+  return {
+    'unit-player-1': [
+      {
+        id: 'weapon-1',
+        name: 'AC/20',
+        location: 'right_torso',
+        destroyed: false,
+        firedThisTurn: false,
+        ammoRemaining: 10,
+        heat: 7,
+        damage: 20,
+        ranges: { short: 3, medium: 6, long: 9 },
+      },
+      {
+        id: 'weapon-2',
+        name: 'LRM 20',
+        location: 'left_torso',
+        destroyed: false,
+        firedThisTurn: false,
+        ammoRemaining: 12,
+        heat: 6,
+        damage: '1/missile',
+        ranges: { short: 7, medium: 14, long: 21, minimum: 6 },
+      },
+      {
+        id: 'weapon-3',
+        name: 'Medium Laser',
+        location: 'center_torso',
+        destroyed: false,
+        firedThisTurn: false,
+        heat: 3,
+        damage: 5,
+        ranges: { short: 3, medium: 6, long: 9 },
+      },
+      {
+        id: 'weapon-4',
+        name: 'SRM 6',
+        location: 'left_torso',
+        destroyed: false,
+        firedThisTurn: false,
+        ammoRemaining: 15,
+        heat: 4,
+        damage: '2/missile',
+        ranges: { short: 3, medium: 6, long: 9 },
+      },
+    ],
+    'unit-opponent-1': [
+      {
+        id: 'weapon-5',
+        name: 'AC/20',
+        location: 'right_torso',
+        destroyed: false,
+        firedThisTurn: false,
+        ammoRemaining: 5,
+        heat: 7,
+        damage: 20,
+        ranges: { short: 3, medium: 6, long: 9 },
+      },
+      {
+        id: 'weapon-6',
+        name: 'Medium Laser',
+        location: 'head',
+        destroyed: false,
+        firedThisTurn: false,
+        heat: 3,
+        damage: 5,
+        ranges: { short: 3, medium: 6, long: 9 },
+      },
+      {
+        id: 'weapon-7',
+        name: 'Small Laser',
+        location: 'head',
+        destroyed: false,
+        firedThisTurn: false,
+        heat: 1,
+        damage: 3,
+        ranges: { short: 1, medium: 2, long: 3 },
+      },
+    ],
+  };
+}
+
+function createDemoMaxArmor(): Record<string, Record<string, number>> {
+  return {
+    'unit-player-1': {
+      head: 9,
+      center_torso: 47,
+      center_torso_rear: 14,
+      left_torso: 32,
+      left_torso_rear: 10,
+      right_torso: 32,
+      right_torso_rear: 10,
+      left_arm: 34,
+      right_arm: 34,
+      left_leg: 41,
+      right_leg: 41,
+    },
+    'unit-opponent-1': {
+      head: 9,
+      center_torso: 24,
+      center_torso_rear: 8,
+      left_torso: 18,
+      left_torso_rear: 6,
+      right_torso: 18,
+      right_torso_rear: 6,
+      left_arm: 12,
+      right_arm: 12,
+      left_leg: 20,
+      right_leg: 20,
+    },
+  };
+}
+
+function createDemoMaxStructure(): Record<string, Record<string, number>> {
+  return {
+    'unit-player-1': {
+      head: 3,
+      center_torso: 31,
+      left_torso: 21,
+      right_torso: 21,
+      left_arm: 17,
+      right_arm: 17,
+      left_leg: 21,
+      right_leg: 21,
+    },
+    'unit-opponent-1': {
+      head: 3,
+      center_torso: 16,
+      left_torso: 12,
+      right_torso: 12,
+      left_arm: 8,
+      right_arm: 8,
+      left_leg: 12,
+      right_leg: 12,
+    },
+  };
+}
+
+// =============================================================================
+// Store
+// =============================================================================
+
+export const useGameplayStore = create<GameplayStore>((set, get) => ({
+  ...initialState,
+
+  loadSession: async (sessionId: string) => {
+    set({ isLoading: true, error: null });
+    try {
+      // TODO: Load from API
+      // For now, create demo session if requested
+      if (sessionId === 'demo') {
+        get().createDemoSession();
+      } else {
+        throw new Error('Session not found');
+      }
+    } catch (err) {
+      set({
+        error: err instanceof Error ? err.message : 'Failed to load session',
+        isLoading: false,
+      });
+    }
+  },
+
+  createDemoSession: () => {
+    const session = createDemoSession();
+    set({
+      session,
+      unitWeapons: createDemoWeapons(),
+      maxArmor: createDemoMaxArmor(),
+      maxStructure: createDemoMaxStructure(),
+      pilotNames: {
+        'unit-player-1': 'Captain Marcus Chen',
+        'unit-opponent-1': 'Lieutenant Sarah Walsh',
+      },
+      heatSinks: {
+        'unit-player-1': 20,
+        'unit-opponent-1': 10,
+      },
+      isLoading: false,
+      error: null,
+    });
+  },
+
+  selectUnit: (unitId: string | null) => {
+    set((state) => ({
+      ui: { ...state.ui, selectedUnitId: unitId },
+    }));
+  },
+
+  setTarget: (unitId: string | null) => {
+    set((state) => ({
+      ui: { ...state.ui, targetUnitId: unitId },
+    }));
+  },
+
+  handleAction: (actionId: string) => {
+    const { session, ui } = get();
+    if (!session) return;
+
+    switch (actionId) {
+      case 'lock':
+        // Lock current action (movement or attacks)
+        console.log('Locking action for phase:', session.currentState.phase);
+        break;
+      case 'undo':
+        console.log('Undoing last action');
+        break;
+      case 'skip':
+        console.log('Skipping phase');
+        break;
+      case 'clear':
+        set((state) => ({
+          ui: { ...state.ui, queuedWeaponIds: [] },
+        }));
+        break;
+      case 'next-turn':
+        console.log('Starting next turn');
+        break;
+      case 'concede':
+        console.log('Conceding game');
+        break;
+      default:
+        console.log('Unknown action:', actionId);
+    }
+  },
+
+  toggleWeapon: (weaponId: string) => {
+    set((state) => {
+      const current = state.ui.queuedWeaponIds;
+      const newQueued = current.includes(weaponId)
+        ? current.filter((id) => id !== weaponId)
+        : [...current, weaponId];
+      return {
+        ui: { ...state.ui, queuedWeaponIds: newQueued },
+      };
+    });
+  },
+
+  clearError: () => {
+    set({ error: null });
+  },
+
+  reset: () => {
+    set(initialState);
+  },
+}));

--- a/src/types/gameplay/GameplayUIInterfaces.ts
+++ b/src/types/gameplay/GameplayUIInterfaces.ts
@@ -1,0 +1,425 @@
+/**
+ * Gameplay UI Interfaces
+ * Type definitions for the gameplay user interface layer.
+ *
+ * @spec openspec/changes/add-gameplay-ui/specs/gameplay-ui/spec.md
+ */
+
+import { IHexCoordinate, Facing, MovementType } from './HexGridInterfaces';
+import { GamePhase, GameSide, IGameEvent, IUnitGameState, IToHitModifier } from './GameSessionInterfaces';
+
+// =============================================================================
+// Layout Types
+// =============================================================================
+
+/**
+ * Panel emphasis state for contextual layout.
+ */
+export type PanelEmphasis = 'map' | 'recordSheet' | 'balanced';
+
+/**
+ * Layout configuration for gameplay view.
+ */
+export interface ILayoutConfig {
+  /** Current panel emphasis */
+  readonly emphasis: PanelEmphasis;
+  /** Map panel width percentage (0-100) */
+  readonly mapPanelWidth: number;
+  /** Is event log collapsed? */
+  readonly eventLogCollapsed: boolean;
+  /** Minimum panel width in pixels */
+  readonly minPanelWidth: number;
+}
+
+/**
+ * Default layout configuration.
+ */
+export const DEFAULT_LAYOUT_CONFIG: ILayoutConfig = {
+  emphasis: 'balanced',
+  mapPanelWidth: 50,
+  eventLogCollapsed: false,
+  minPanelWidth: 300,
+};
+
+/**
+ * Get layout config for a given phase.
+ */
+export function getLayoutForPhase(phase: GamePhase): Partial<ILayoutConfig> {
+  switch (phase) {
+    case GamePhase.Movement:
+      return { emphasis: 'map', mapPanelWidth: 60 };
+    case GamePhase.WeaponAttack:
+    case GamePhase.PhysicalAttack:
+      return { emphasis: 'recordSheet', mapPanelWidth: 40 };
+    case GamePhase.Heat:
+      return { emphasis: 'recordSheet', mapPanelWidth: 35 };
+    default:
+      return { emphasis: 'balanced', mapPanelWidth: 50 };
+  }
+}
+
+// =============================================================================
+// Unit Token Types
+// =============================================================================
+
+/**
+ * Visual token representing a unit on the hex map.
+ */
+export interface IUnitToken {
+  /** Unit ID */
+  readonly unitId: string;
+  /** Unit name for display */
+  readonly name: string;
+  /** Side (for coloring) */
+  readonly side: GameSide;
+  /** Current position */
+  readonly position: IHexCoordinate;
+  /** Current facing */
+  readonly facing: Facing;
+  /** Is this unit selected? */
+  readonly isSelected: boolean;
+  /** Is this unit a valid target? */
+  readonly isValidTarget: boolean;
+  /** Is this unit destroyed? */
+  readonly isDestroyed: boolean;
+  /** Short designation (e.g., "ATL-1") */
+  readonly designation: string;
+}
+
+// =============================================================================
+// Movement Preview Types
+// =============================================================================
+
+/**
+ * Preview data for a potential movement.
+ */
+export interface IMovementPreview {
+  /** Unit being moved */
+  readonly unitId: string;
+  /** Starting position */
+  readonly from: IHexCoordinate;
+  /** Target position */
+  readonly to: IHexCoordinate;
+  /** Path of hexes traversed */
+  readonly path: readonly IHexCoordinate[];
+  /** Proposed facing */
+  readonly facing: Facing;
+  /** Movement type */
+  readonly movementType: MovementType;
+  /** MP cost */
+  readonly mpCost: number;
+  /** MP available */
+  readonly mpAvailable: number;
+  /** Heat that will be generated */
+  readonly heatGenerated: number;
+  /** Target movement modifier (TMM) */
+  readonly tmm: number;
+  /** To-hit penalty from movement */
+  readonly toHitPenalty: number;
+  /** Is this movement valid? */
+  readonly isValid: boolean;
+  /** Validation error message if invalid */
+  readonly errorMessage?: string;
+}
+
+/**
+ * Hex highlight for movement range display.
+ */
+export interface IMovementRangeHex {
+  /** Hex position */
+  readonly hex: IHexCoordinate;
+  /** MP cost to reach */
+  readonly mpCost: number;
+  /** Is this hex reachable with current MP? */
+  readonly reachable: boolean;
+  /** Movement type to reach (walk/run/jump) */
+  readonly movementType: MovementType;
+}
+
+// =============================================================================
+// Attack Preview Types
+// =============================================================================
+
+/**
+ * Preview data for a potential attack.
+ */
+export interface IAttackPreview {
+  /** Attacking unit */
+  readonly attackerId: string;
+  /** Target unit */
+  readonly targetId: string;
+  /** Weapons selected for attack */
+  readonly weapons: readonly IWeaponAttackPreview[];
+  /** Total heat generated */
+  readonly totalHeat: number;
+  /** Current heat */
+  readonly currentHeat: number;
+  /** Projected heat after attacks */
+  readonly projectedHeat: number;
+  /** Heat warnings */
+  readonly heatWarnings: readonly string[];
+}
+
+/**
+ * Preview for a single weapon attack.
+ */
+export interface IWeaponAttackPreview {
+  /** Weapon ID */
+  readonly weaponId: string;
+  /** Weapon name */
+  readonly weaponName: string;
+  /** Is weapon available (not destroyed, has ammo)? */
+  readonly available: boolean;
+  /** Is target in range? */
+  readonly inRange: boolean;
+  /** Is target in arc? */
+  readonly inArc: boolean;
+  /** Range to target in hexes */
+  readonly range: number;
+  /** Range bracket */
+  readonly rangeBracket: 'short' | 'medium' | 'long' | 'out';
+  /** Base to-hit (gunnery) */
+  readonly baseToHit: number;
+  /** All modifiers */
+  readonly modifiers: readonly IToHitModifier[];
+  /** Final to-hit number */
+  readonly finalToHit: number;
+  /** Hit probability percentage */
+  readonly hitProbability: number;
+  /** Damage on hit */
+  readonly damage: number;
+  /** Heat generated */
+  readonly heat: number;
+  /** Reason weapon unavailable (if any) */
+  readonly unavailableReason?: string;
+}
+
+// =============================================================================
+// Record Sheet Display Types
+// =============================================================================
+
+/**
+ * Location status for record sheet display.
+ */
+export interface ILocationStatus {
+  /** Location name */
+  readonly location: string;
+  /** Display name */
+  readonly displayName: string;
+  /** Current armor */
+  readonly armor: number;
+  /** Maximum armor */
+  readonly maxArmor: number;
+  /** Current structure */
+  readonly structure: number;
+  /** Maximum structure */
+  readonly maxStructure: number;
+  /** Is location destroyed? */
+  readonly destroyed: boolean;
+  /** Rear armor (for torsos) */
+  readonly rearArmor?: number;
+  /** Maximum rear armor */
+  readonly maxRearArmor?: number;
+}
+
+/**
+ * Weapon status for record sheet display.
+ */
+export interface IWeaponStatus {
+  /** Weapon ID */
+  readonly id: string;
+  /** Weapon name */
+  readonly name: string;
+  /** Location mounted */
+  readonly location: string;
+  /** Is weapon destroyed? */
+  readonly destroyed: boolean;
+  /** Was weapon fired this turn? */
+  readonly firedThisTurn: boolean;
+  /** Ammo remaining (if ammo-using) */
+  readonly ammoRemaining?: number;
+  /** Heat generated */
+  readonly heat: number;
+  /** Damage */
+  readonly damage: number | string;
+  /** Range brackets */
+  readonly ranges: {
+    readonly short: number;
+    readonly medium: number;
+    readonly long: number;
+    readonly minimum?: number;
+  };
+}
+
+// =============================================================================
+// Event Log Types
+// =============================================================================
+
+/**
+ * Filter options for event log.
+ */
+export interface IEventLogFilter {
+  /** Filter by event types */
+  readonly eventTypes?: readonly string[];
+  /** Filter by unit ID */
+  readonly unitId?: string;
+  /** Filter by turn */
+  readonly turn?: number;
+  /** Filter by side */
+  readonly side?: GameSide;
+}
+
+/**
+ * Formatted event for display.
+ */
+export interface IFormattedEvent {
+  /** Event ID */
+  readonly id: string;
+  /** Turn number */
+  readonly turn: number;
+  /** Phase */
+  readonly phase: GamePhase;
+  /** Formatted text */
+  readonly text: string;
+  /** Icon/type indicator */
+  readonly icon: 'movement' | 'attack' | 'damage' | 'heat' | 'critical' | 'status' | 'phase';
+  /** Side that triggered event */
+  readonly side?: GameSide;
+  /** Related unit ID */
+  readonly unitId?: string;
+  /** Timestamp */
+  readonly timestamp: string;
+}
+
+// =============================================================================
+// Phase Controls Types
+// =============================================================================
+
+/**
+ * Action available in the current phase.
+ */
+export interface IPhaseAction {
+  /** Action ID */
+  readonly id: string;
+  /** Display label */
+  readonly label: string;
+  /** Icon name */
+  readonly icon?: string;
+  /** Is action available? */
+  readonly enabled: boolean;
+  /** Is this the primary action? */
+  readonly primary: boolean;
+  /** Keyboard shortcut */
+  readonly shortcut?: string;
+  /** Tooltip text */
+  readonly tooltip?: string;
+}
+
+/**
+ * Get available actions for a phase.
+ */
+export function getPhaseActions(phase: GamePhase, canUndo: boolean): IPhaseAction[] {
+  switch (phase) {
+    case GamePhase.Movement:
+      return [
+        { id: 'lock', label: 'Lock Movement', primary: true, enabled: true, shortcut: 'Enter' },
+        { id: 'undo', label: 'Undo', primary: false, enabled: canUndo, shortcut: 'Ctrl+Z' },
+        { id: 'skip', label: 'Skip', primary: false, enabled: true },
+      ];
+    case GamePhase.WeaponAttack:
+      return [
+        { id: 'lock', label: 'Lock Attacks', primary: true, enabled: true, shortcut: 'Enter' },
+        { id: 'clear', label: 'Clear All', primary: false, enabled: true },
+        { id: 'skip', label: 'Skip Attacks', primary: false, enabled: true },
+      ];
+    case GamePhase.Heat:
+      return [
+        { id: 'continue', label: 'Continue', primary: true, enabled: true, shortcut: 'Enter' },
+      ];
+    case GamePhase.End:
+      return [
+        { id: 'next-turn', label: 'Next Turn', primary: true, enabled: true, shortcut: 'Enter' },
+        { id: 'concede', label: 'Concede', primary: false, enabled: true },
+      ];
+    default:
+      return [];
+  }
+}
+
+// =============================================================================
+// Replay Types
+// =============================================================================
+
+/**
+ * Replay mode state.
+ */
+export interface IReplayState {
+  /** Is replay mode active? */
+  readonly active: boolean;
+  /** Is replay playing? */
+  readonly playing: boolean;
+  /** Playback speed multiplier */
+  readonly speed: number;
+  /** Current event index */
+  readonly currentEventIndex: number;
+  /** Total events */
+  readonly totalEvents: number;
+  /** Current turn being displayed */
+  readonly displayTurn: number;
+  /** Current phase being displayed */
+  readonly displayPhase: GamePhase;
+}
+
+// =============================================================================
+// Gameplay Store Types
+// =============================================================================
+
+/**
+ * UI state for the gameplay view.
+ */
+export interface IGameplayUIState {
+  /** Layout configuration */
+  readonly layout: ILayoutConfig;
+  /** Selected unit ID */
+  readonly selectedUnitId: string | null;
+  /** Targeted unit ID (for attacks) */
+  readonly targetUnitId: string | null;
+  /** Movement preview (if planning movement) */
+  readonly movementPreview: IMovementPreview | null;
+  /** Attack preview (if planning attack) */
+  readonly attackPreview: IAttackPreview | null;
+  /** Queued weapon IDs for attack */
+  readonly queuedWeaponIds: readonly string[];
+  /** Event log filter */
+  readonly eventLogFilter: IEventLogFilter;
+  /** Replay state */
+  readonly replay: IReplayState;
+  /** Is waiting for opponent? */
+  readonly waitingForOpponent: boolean;
+  /** Error message to display */
+  readonly errorMessage: string | null;
+}
+
+/**
+ * Default UI state.
+ */
+export const DEFAULT_UI_STATE: IGameplayUIState = {
+  layout: DEFAULT_LAYOUT_CONFIG,
+  selectedUnitId: null,
+  targetUnitId: null,
+  movementPreview: null,
+  attackPreview: null,
+  queuedWeaponIds: [],
+  eventLogFilter: {},
+  replay: {
+    active: false,
+    playing: false,
+    speed: 1,
+    currentEventIndex: 0,
+    totalEvents: 0,
+    displayTurn: 1,
+    displayPhase: GamePhase.Initiative,
+  },
+  waitingForOpponent: false,
+  errorMessage: null,
+};

--- a/src/types/gameplay/index.ts
+++ b/src/types/gameplay/index.ts
@@ -5,6 +5,7 @@
  * @spec openspec/changes/add-hex-grid-system/specs/hex-grid-system/spec.md
  * @spec openspec/changes/add-game-session-core/specs/game-session-core/spec.md
  * @spec openspec/changes/add-combat-resolution/specs/combat-resolution/spec.md
+ * @spec openspec/changes/add-gameplay-ui/specs/gameplay-ui/spec.md
  */
 
 // Hex Grid System
@@ -15,3 +16,6 @@ export * from './GameSessionInterfaces';
 
 // Combat Resolution
 export * from './CombatInterfaces';
+
+// Gameplay UI
+export * from './GameplayUIInterfaces';


### PR DESCRIPTION
## Summary

Phase 3 Feature 1: **add-gameplay-ui**

Implements the gameplay user interface with a split-view layout for running game sessions. This provides the visual layer for the combat system implemented in Phase 2.

## Changes

### New Types (`src/types/gameplay/GameplayUIInterfaces.ts`)
- `ILayoutConfig` - Panel sizing and emphasis configuration
- `IUnitToken` - Unit representation on hex map
- `IMovementPreview` / `IAttackPreview` - Action previews
- `ILocationStatus` / `IWeaponStatus` - Record sheet data
- `IFormattedEvent` - Event log display
- `IPhaseAction` - Phase-specific actions
- `IGameplayUIState` - Complete UI state

### New Components
- `PhaseBanner` - Displays current phase and turn info
- `ActionBar` - Phase-specific action buttons with keyboard shortcuts
- `EventLogDisplay` - Chronological game events with filtering
- `HexMapDisplay` - SVG hex grid with pan/zoom and unit tokens
- `RecordSheetDisplay` - Unit status in record sheet format
- `GameplayLayout` - Main split-view layout with resizable panels

### New Store (`src/stores/useGameplayStore.ts`)
- Game session state management
- Demo session factory for testing
- UI state (selection, preview, filters)

### New Pages
- `/gameplay/games` - List of game sessions
- `/gameplay/games/[id]` - Main gameplay interface
- `/gameplay/games/demo` - Demo game for testing

## Testing

- 15 new tests for PhaseBanner and ActionBar
- All 6866 tests passing
- TypeScript clean
- Build succeeds

## Demo

Access `/gameplay/games/demo` to see the UI with a pre-configured demo battle (Atlas vs Hunchback).

## Spec Reference

`openspec/changes/add-gameplay-ui/specs/gameplay-ui/spec.md`