### PR TITLE
test: add repository and service test coverage (Batch 1)

### DIFF
--- a/src/services/encounter/__tests__/EncounterRepository.test.ts
+++ b/src/services/encounter/__tests__/EncounterRepository.test.ts
@@ -1,0 +1,797 @@
+/**
+ * EncounterRepository Tests
+ *
+ * Unit tests for the SQLite-based encounter repository.
+ * Tests CRUD operations, status management, and data integrity.
+ */
+
+import {
+  EncounterRepository,
+  getEncounterRepository,
+  EncounterErrorCode,
+} from '../EncounterRepository';
+import { getSQLiteService, resetSQLiteService } from '@/services/persistence/SQLiteService';
+import {
+  EncounterStatus,
+  ScenarioTemplateType,
+  TerrainPreset,
+  VictoryConditionType,
+  PilotSkillTemplate,
+  IVictoryCondition,
+  IOpForConfig,
+} from '@/types/encounter';
+import fs from 'fs';
+import path from 'path';
+
+// Test database path
+const TEST_DB_PATH = './data/test-encounter-repository.db';
+
+// Helper to reset the repository singleton between tests
+// Since EncounterRepository doesn't export a reset function, we use module mocking
+let repositoryInstance: EncounterRepository | null = null;
+
+function getTestRepository(): EncounterRepository {
+  if (!repositoryInstance) {
+    repositoryInstance = new EncounterRepository();
+  }
+  return repositoryInstance;
+}
+
+function resetTestRepository(): void {
+  repositoryInstance = null;
+}
+
+describe('EncounterRepository', () => {
+  let repository: EncounterRepository;
+
+  beforeEach(() => {
+    // Clean up any existing test database
+    if (fs.existsSync(TEST_DB_PATH)) {
+      fs.unlinkSync(TEST_DB_PATH);
+    }
+
+    // Clean up WAL files if they exist
+    const walPath = `${TEST_DB_PATH}-wal`;
+    const shmPath = `${TEST_DB_PATH}-shm`;
+    if (fs.existsSync(walPath)) fs.unlinkSync(walPath);
+    if (fs.existsSync(shmPath)) fs.unlinkSync(shmPath);
+
+    // Ensure data directory exists
+    const dataDir = path.dirname(TEST_DB_PATH);
+    if (!fs.existsSync(dataDir)) {
+      fs.mkdirSync(dataDir, { recursive: true });
+    }
+
+    // Reset singletons
+    resetSQLiteService();
+    resetTestRepository();
+
+    // Initialize with test database
+    const sqliteService = getSQLiteService({ path: TEST_DB_PATH });
+    sqliteService.initialize();
+
+    repository = getTestRepository();
+  });
+
+  afterEach(() => {
+    // Close database and clean up
+    resetSQLiteService();
+    resetTestRepository();
+
+    if (fs.existsSync(TEST_DB_PATH)) {
+      fs.unlinkSync(TEST_DB_PATH);
+    }
+    // Clean up WAL files
+    const walPath = `${TEST_DB_PATH}-wal`;
+    const shmPath = `${TEST_DB_PATH}-shm`;
+    if (fs.existsSync(walPath)) fs.unlinkSync(walPath);
+    if (fs.existsSync(shmPath)) fs.unlinkSync(shmPath);
+  });
+
+  // ===========================================================================
+  // Initialize Tests
+  // ===========================================================================
+  describe('initialize', () => {
+    it('should create encounters table on first initialization', () => {
+      repository.initialize();
+
+      // Verify table exists by querying it
+      const encounters = repository.getAllEncounters();
+      expect(encounters).toEqual([]);
+    });
+
+    it('should be idempotent - calling multiple times does not error', () => {
+      repository.initialize();
+      repository.initialize();
+      repository.initialize();
+
+      const encounters = repository.getAllEncounters();
+      expect(encounters).toEqual([]);
+    });
+  });
+
+  // ===========================================================================
+  // Create Encounter Tests
+  // ===========================================================================
+  describe('createEncounter', () => {
+    it('should create a new encounter with basic fields', () => {
+      const result = repository.createEncounter({
+        name: 'Test Encounter',
+        description: 'A test encounter description',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.id).toBeDefined();
+      expect(result.id).toMatch(/^encounter-/);
+    });
+
+    it('should create encounter without description', () => {
+      const result = repository.createEncounter({
+        name: 'Minimal Encounter',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.id).toBeDefined();
+
+      const encounter = repository.getEncounterById(result.id!);
+      expect(encounter).not.toBeNull();
+      expect(encounter?.name).toBe('Minimal Encounter');
+      expect(encounter?.description).toBeUndefined();
+    });
+
+    it('should set default status as Draft', () => {
+      const result = repository.createEncounter({ name: 'Draft Test' });
+      const encounter = repository.getEncounterById(result.id!);
+
+      expect(encounter?.status).toBe(EncounterStatus.Draft);
+    });
+
+    it('should set default map configuration', () => {
+      const result = repository.createEncounter({ name: 'Map Config Test' });
+      const encounter = repository.getEncounterById(result.id!);
+
+      expect(encounter?.mapConfig).toEqual({
+        radius: 6,
+        terrain: TerrainPreset.Clear,
+        playerDeploymentZone: 'south',
+        opponentDeploymentZone: 'north',
+      });
+    });
+
+    it('should use template defaults when template is specified', () => {
+      const result = repository.createEncounter({
+        name: 'Duel Encounter',
+        template: ScenarioTemplateType.Duel,
+      });
+
+      const encounter = repository.getEncounterById(result.id!);
+
+      expect(encounter?.template).toBe(ScenarioTemplateType.Duel);
+      expect(encounter?.mapConfig.radius).toBe(5);
+      expect(encounter?.victoryConditions).toHaveLength(1);
+      expect(encounter?.victoryConditions[0].type).toBe(VictoryConditionType.DestroyAll);
+    });
+
+    it('should use Skirmish template defaults correctly', () => {
+      const result = repository.createEncounter({
+        name: 'Skirmish Encounter',
+        template: ScenarioTemplateType.Skirmish,
+      });
+
+      const encounter = repository.getEncounterById(result.id!);
+
+      expect(encounter?.template).toBe(ScenarioTemplateType.Skirmish);
+      expect(encounter?.mapConfig.radius).toBe(8);
+      expect(encounter?.victoryConditions).toHaveLength(2);
+    });
+
+    it('should use Battle template defaults correctly', () => {
+      const result = repository.createEncounter({
+        name: 'Battle Encounter',
+        template: ScenarioTemplateType.Battle,
+      });
+
+      const encounter = repository.getEncounterById(result.id!);
+
+      expect(encounter?.template).toBe(ScenarioTemplateType.Battle);
+      expect(encounter?.mapConfig.radius).toBe(12);
+      expect(encounter?.victoryConditions).toHaveLength(2);
+    });
+
+    it('should set timestamps on creation', () => {
+      const before = new Date().toISOString();
+      const result = repository.createEncounter({ name: 'Timestamp Test' });
+      const after = new Date().toISOString();
+
+      const encounter = repository.getEncounterById(result.id!);
+
+      expect(encounter?.createdAt).toBeDefined();
+      expect(encounter?.updatedAt).toBeDefined();
+      expect(encounter!.createdAt >= before).toBe(true);
+      expect(encounter!.createdAt <= after).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // Get Encounter Tests
+  // ===========================================================================
+  describe('getEncounterById', () => {
+    it('should return null for non-existent ID', () => {
+      const encounter = repository.getEncounterById('non-existent-id');
+      expect(encounter).toBeNull();
+    });
+
+    it('should return encounter after creation', () => {
+      const createResult = repository.createEncounter({
+        name: 'Retrieval Test',
+        description: 'Test description',
+      });
+
+      const encounter = repository.getEncounterById(createResult.id!);
+
+      expect(encounter).not.toBeNull();
+      expect(encounter?.id).toBe(createResult.id);
+      expect(encounter?.name).toBe('Retrieval Test');
+      expect(encounter?.description).toBe('Test description');
+    });
+
+    it('should properly deserialize JSON fields', () => {
+      const createResult = repository.createEncounter({
+        name: 'JSON Test',
+        template: ScenarioTemplateType.Skirmish,
+      });
+
+      const encounter = repository.getEncounterById(createResult.id!);
+
+      // Verify JSON fields are properly parsed
+      expect(typeof encounter?.mapConfig).toBe('object');
+      expect(Array.isArray(encounter?.victoryConditions)).toBe(true);
+      expect(Array.isArray(encounter?.optionalRules)).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // Get All Encounters Tests
+  // ===========================================================================
+  describe('getAllEncounters', () => {
+    it('should return empty array when no encounters exist', () => {
+      const encounters = repository.getAllEncounters();
+      expect(encounters).toEqual([]);
+    });
+
+    it('should return all created encounters', () => {
+      repository.createEncounter({ name: 'Encounter 1' });
+      repository.createEncounter({ name: 'Encounter 2' });
+      repository.createEncounter({ name: 'Encounter 3' });
+
+      const encounters = repository.getAllEncounters();
+
+      expect(encounters).toHaveLength(3);
+      expect(encounters.some((e) => e.name === 'Encounter 1')).toBe(true);
+      expect(encounters.some((e) => e.name === 'Encounter 2')).toBe(true);
+      expect(encounters.some((e) => e.name === 'Encounter 3')).toBe(true);
+    });
+
+    it('should return encounters ordered by updated_at DESC', () => {
+      const result1 = repository.createEncounter({ name: 'First' });
+      repository.createEncounter({ name: 'Second' });
+
+      // Update the first one to make it more recent
+      repository.updateEncounter(result1.id!, { name: 'First Updated' });
+
+      const encounters = repository.getAllEncounters();
+
+      // First Updated should be first (most recently updated)
+      expect(encounters[0].name).toBe('First Updated');
+      expect(encounters[1].name).toBe('Second');
+    });
+  });
+
+  // ===========================================================================
+  // Get Encounters By Status Tests
+  // ===========================================================================
+  describe('getEncountersByStatus', () => {
+    it('should return empty array when no encounters match status', () => {
+      repository.createEncounter({ name: 'Draft Encounter' });
+
+      const readyEncounters = repository.getEncountersByStatus(EncounterStatus.Ready);
+      expect(readyEncounters).toEqual([]);
+    });
+
+    it('should return only encounters with matching status', () => {
+      repository.createEncounter({ name: 'Draft 1' });
+      repository.createEncounter({ name: 'Draft 2' });
+
+      const draftEncounters = repository.getEncountersByStatus(EncounterStatus.Draft);
+      expect(draftEncounters).toHaveLength(2);
+    });
+
+    it('should filter by different statuses', () => {
+      const result = repository.createEncounter({ name: 'Status Test' });
+
+      // Set status to Ready
+      repository.setEncounterStatus(result.id!, EncounterStatus.Ready);
+
+      const draftEncounters = repository.getEncountersByStatus(EncounterStatus.Draft);
+      const readyEncounters = repository.getEncountersByStatus(EncounterStatus.Ready);
+
+      expect(draftEncounters).toHaveLength(0);
+      expect(readyEncounters).toHaveLength(1);
+      expect(readyEncounters[0].name).toBe('Status Test');
+    });
+  });
+
+  // ===========================================================================
+  // Update Encounter Tests
+  // ===========================================================================
+  describe('updateEncounter', () => {
+    it('should update encounter name', () => {
+      const createResult = repository.createEncounter({ name: 'Original Name' });
+      const updateResult = repository.updateEncounter(createResult.id!, {
+        name: 'Updated Name',
+      });
+
+      expect(updateResult.success).toBe(true);
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.name).toBe('Updated Name');
+    });
+
+    it('should update encounter description', () => {
+      const createResult = repository.createEncounter({ name: 'Description Test' });
+      repository.updateEncounter(createResult.id!, {
+        description: 'New Description',
+      });
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.description).toBe('New Description');
+    });
+
+    it('should clear description when set to null', () => {
+      const createResult = repository.createEncounter({
+        name: 'Clear Description',
+        description: 'Initial Description',
+      });
+
+      // Note: undefined is not handled as "clear" in the repository - only explicit null works
+      // The repository only processes description if it's !== undefined
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+      repository.updateEncounter(createResult.id!, { description: null as any });
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.description).toBeUndefined();
+    });
+
+    it('should update player force reference', () => {
+      const createResult = repository.createEncounter({ name: 'Force Test' });
+      repository.updateEncounter(createResult.id!, {
+        playerForceId: 'force-123',
+      });
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.playerForce).toBeDefined();
+      expect(encounter?.playerForce?.forceId).toBe('force-123');
+    });
+
+    it('should update opponent force reference', () => {
+      const createResult = repository.createEncounter({ name: 'Opponent Force Test' });
+      repository.updateEncounter(createResult.id!, {
+        opponentForceId: 'force-456',
+      });
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.opponentForce).toBeDefined();
+      expect(encounter?.opponentForce?.forceId).toBe('force-456');
+    });
+
+    it('should update OpFor config', () => {
+      const createResult = repository.createEncounter({ name: 'OpFor Test' });
+      const opForConfig: IOpForConfig = {
+        targetBV: 5000,
+        pilotSkillTemplate: PilotSkillTemplate.Regular,
+        faction: 'Lyran Commonwealth',
+      };
+
+      repository.updateEncounter(createResult.id!, { opForConfig });
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.opForConfig).toBeDefined();
+      expect(encounter?.opForConfig?.targetBV).toBe(5000);
+      expect(encounter?.opForConfig?.pilotSkillTemplate).toBe(PilotSkillTemplate.Regular);
+    });
+
+    it('should merge partial map config updates', () => {
+      const createResult = repository.createEncounter({ name: 'Map Update Test' });
+
+      repository.updateEncounter(createResult.id!, {
+        mapConfig: { radius: 10 },
+      });
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.mapConfig.radius).toBe(10);
+      // Other fields should be preserved
+      expect(encounter?.mapConfig.terrain).toBe(TerrainPreset.Clear);
+      expect(encounter?.mapConfig.playerDeploymentZone).toBe('south');
+    });
+
+    it('should update victory conditions', () => {
+      const createResult = repository.createEncounter({ name: 'Victory Test' });
+      const victoryConditions: IVictoryCondition[] = [
+        { type: VictoryConditionType.Cripple, threshold: 60 },
+        { type: VictoryConditionType.TurnLimit, turnLimit: 10 },
+      ];
+
+      repository.updateEncounter(createResult.id!, { victoryConditions });
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.victoryConditions).toHaveLength(2);
+      expect(encounter?.victoryConditions[0].type).toBe(VictoryConditionType.Cripple);
+      expect(encounter?.victoryConditions[0].threshold).toBe(60);
+    });
+
+    it('should update optional rules', () => {
+      const createResult = repository.createEncounter({ name: 'Rules Test' });
+      const optionalRules = ['floating_crits', 'edge'];
+
+      repository.updateEncounter(createResult.id!, { optionalRules });
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.optionalRules).toEqual(['floating_crits', 'edge']);
+    });
+
+    it('should update updatedAt timestamp', () => {
+      const createResult = repository.createEncounter({ name: 'Timestamp Update' });
+      const originalEncounter = repository.getEncounterById(createResult.id!);
+      const originalUpdatedAt = originalEncounter?.updatedAt;
+
+      // Update the encounter
+      repository.updateEncounter(createResult.id!, { name: 'New Name' });
+
+      const updatedEncounter = repository.getEncounterById(createResult.id!);
+      // The updatedAt should be >= the original (may be same if fast execution)
+      expect(updatedEncounter?.updatedAt).toBeDefined();
+      expect(updatedEncounter!.updatedAt >= originalUpdatedAt!).toBe(true);
+    });
+
+    it('should return NOT_FOUND error for non-existent encounter', () => {
+      const result = repository.updateEncounter('non-existent-id', { name: 'New Name' });
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe(EncounterErrorCode.NOT_FOUND);
+      expect(result.error).toBe('Encounter not found');
+    });
+
+    it('should return INVALID_STATUS error when updating Launched encounter', () => {
+      const createResult = repository.createEncounter({ name: 'Launched Test' });
+      repository.setEncounterStatus(createResult.id!, EncounterStatus.Launched);
+
+      const result = repository.updateEncounter(createResult.id!, { name: 'New Name' });
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe(EncounterErrorCode.INVALID_STATUS);
+      expect(result.error).toContain('launched');
+    });
+
+    it('should return INVALID_STATUS error when updating Completed encounter', () => {
+      const createResult = repository.createEncounter({ name: 'Completed Test' });
+      repository.setEncounterStatus(createResult.id!, EncounterStatus.Completed);
+
+      const result = repository.updateEncounter(createResult.id!, { name: 'New Name' });
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe(EncounterErrorCode.INVALID_STATUS);
+      expect(result.error).toContain('completed');
+    });
+  });
+
+  // ===========================================================================
+  // Delete Encounter Tests
+  // ===========================================================================
+  describe('deleteEncounter', () => {
+    it('should delete existing encounter', () => {
+      const createResult = repository.createEncounter({ name: 'To Delete' });
+      const deleteResult = repository.deleteEncounter(createResult.id!);
+
+      expect(deleteResult.success).toBe(true);
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter).toBeNull();
+    });
+
+    it('should return NOT_FOUND for non-existent encounter', () => {
+      const result = repository.deleteEncounter('non-existent-id');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe(EncounterErrorCode.NOT_FOUND);
+    });
+
+    it('should return INVALID_STATUS when deleting Launched encounter', () => {
+      const createResult = repository.createEncounter({ name: 'Launched Delete Test' });
+      repository.setEncounterStatus(createResult.id!, EncounterStatus.Launched);
+
+      const result = repository.deleteEncounter(createResult.id!);
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe(EncounterErrorCode.INVALID_STATUS);
+      expect(result.error).toBe('Cannot delete a launched encounter');
+    });
+
+    it('should allow deleting Draft encounter', () => {
+      const createResult = repository.createEncounter({ name: 'Draft Delete' });
+      const result = repository.deleteEncounter(createResult.id!);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should allow deleting Ready encounter', () => {
+      const createResult = repository.createEncounter({ name: 'Ready Delete' });
+      repository.setEncounterStatus(createResult.id!, EncounterStatus.Ready);
+
+      const result = repository.deleteEncounter(createResult.id!);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should allow deleting Completed encounter', () => {
+      const createResult = repository.createEncounter({ name: 'Completed Delete' });
+      repository.setEncounterStatus(createResult.id!, EncounterStatus.Completed);
+
+      const result = repository.deleteEncounter(createResult.id!);
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // Set Encounter Status Tests
+  // ===========================================================================
+  describe('setEncounterStatus', () => {
+    it('should set status to Ready', () => {
+      const createResult = repository.createEncounter({ name: 'Status Ready Test' });
+      const result = repository.setEncounterStatus(createResult.id!, EncounterStatus.Ready);
+
+      expect(result.success).toBe(true);
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.status).toBe(EncounterStatus.Ready);
+    });
+
+    it('should set status to Launched', () => {
+      const createResult = repository.createEncounter({ name: 'Status Launched Test' });
+      repository.setEncounterStatus(createResult.id!, EncounterStatus.Launched);
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.status).toBe(EncounterStatus.Launched);
+    });
+
+    it('should set status to Completed', () => {
+      const createResult = repository.createEncounter({ name: 'Status Completed Test' });
+      repository.setEncounterStatus(createResult.id!, EncounterStatus.Completed);
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.status).toBe(EncounterStatus.Completed);
+    });
+
+    it('should update updatedAt when status changes', () => {
+      const createResult = repository.createEncounter({ name: 'Status Timestamp Test' });
+      const originalEncounter = repository.getEncounterById(createResult.id!);
+      const originalUpdatedAt = originalEncounter?.updatedAt;
+
+      repository.setEncounterStatus(createResult.id!, EncounterStatus.Ready);
+
+      const updatedEncounter = repository.getEncounterById(createResult.id!);
+      // The updatedAt should be >= the original (may be same if fast execution)
+      expect(updatedEncounter?.updatedAt).toBeDefined();
+      expect(updatedEncounter!.updatedAt >= originalUpdatedAt!).toBe(true);
+    });
+
+    it('should return success with id for valid status change', () => {
+      const createResult = repository.createEncounter({ name: 'Status Return Test' });
+      const result = repository.setEncounterStatus(createResult.id!, EncounterStatus.Ready);
+
+      expect(result.success).toBe(true);
+      expect(result.id).toBe(createResult.id);
+    });
+  });
+
+  // ===========================================================================
+  // Link Game Session Tests
+  // ===========================================================================
+  describe('linkGameSession', () => {
+    it('should link game session and set status to Launched', () => {
+      const createResult = repository.createEncounter({ name: 'Link Session Test' });
+      const result = repository.linkGameSession(createResult.id!, 'game-session-123');
+
+      expect(result.success).toBe(true);
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.gameSessionId).toBe('game-session-123');
+      expect(encounter?.status).toBe(EncounterStatus.Launched);
+    });
+
+    it('should update updatedAt when linking session', () => {
+      const createResult = repository.createEncounter({ name: 'Link Timestamp Test' });
+      const originalEncounter = repository.getEncounterById(createResult.id!);
+      const originalUpdatedAt = originalEncounter?.updatedAt;
+
+      repository.linkGameSession(createResult.id!, 'game-456');
+
+      const updatedEncounter = repository.getEncounterById(createResult.id!);
+      // The updatedAt should be >= the original (may be same if fast execution)
+      expect(updatedEncounter?.updatedAt).toBeDefined();
+      expect(updatedEncounter!.updatedAt >= originalUpdatedAt!).toBe(true);
+    });
+
+    it('should return encounter id on success', () => {
+      const createResult = repository.createEncounter({ name: 'Link ID Test' });
+      const result = repository.linkGameSession(createResult.id!, 'game-789');
+
+      expect(result.id).toBe(createResult.id);
+    });
+  });
+
+  // ===========================================================================
+  // Status Recalculation Tests
+  // ===========================================================================
+  describe('status recalculation', () => {
+    it('should remain Draft when only player force is set', () => {
+      const createResult = repository.createEncounter({ name: 'Recalc Test 1' });
+      repository.updateEncounter(createResult.id!, { playerForceId: 'force-1' });
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.status).toBe(EncounterStatus.Draft);
+    });
+
+    it('should remain Draft when player force and opponent force set but no victory conditions', () => {
+      const createResult = repository.createEncounter({ name: 'Recalc Test 2' });
+      repository.updateEncounter(createResult.id!, {
+        playerForceId: 'force-1',
+        opponentForceId: 'force-2',
+        victoryConditions: [], // Explicitly empty
+      });
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.status).toBe(EncounterStatus.Draft);
+    });
+
+    it('should become Ready when player force, opponent force, and victory conditions are set', () => {
+      const createResult = repository.createEncounter({ name: 'Recalc Test 3' });
+      repository.updateEncounter(createResult.id!, {
+        playerForceId: 'force-1',
+        opponentForceId: 'force-2',
+        victoryConditions: [{ type: VictoryConditionType.DestroyAll }],
+      });
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.status).toBe(EncounterStatus.Ready);
+    });
+
+    it('should become Ready when player force, OpFor config, and victory conditions are set', () => {
+      const createResult = repository.createEncounter({ name: 'Recalc Test 4' });
+      repository.updateEncounter(createResult.id!, {
+        playerForceId: 'force-1',
+        opForConfig: { targetBV: 5000, pilotSkillTemplate: PilotSkillTemplate.Regular },
+        victoryConditions: [{ type: VictoryConditionType.DestroyAll }],
+      });
+
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.status).toBe(EncounterStatus.Ready);
+    });
+
+    it('should not change Launched status during recalculation', () => {
+      const createResult = repository.createEncounter({ name: 'Recalc Launched Test' });
+      repository.setEncounterStatus(createResult.id!, EncounterStatus.Launched);
+
+      // This should not change status since we can't update launched encounters
+      const result = repository.updateEncounter(createResult.id!, { name: 'New Name' });
+
+      expect(result.success).toBe(false);
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.status).toBe(EncounterStatus.Launched);
+    });
+
+    it('should not change Completed status during recalculation', () => {
+      const createResult = repository.createEncounter({ name: 'Recalc Completed Test' });
+      repository.setEncounterStatus(createResult.id!, EncounterStatus.Completed);
+
+      const result = repository.updateEncounter(createResult.id!, { name: 'New Name' });
+
+      expect(result.success).toBe(false);
+      const encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.status).toBe(EncounterStatus.Completed);
+    });
+
+    it('should revert from Ready to Draft when victory conditions are cleared', () => {
+      const createResult = repository.createEncounter({ name: 'Recalc Revert Test' });
+
+      // First make it Ready
+      repository.updateEncounter(createResult.id!, {
+        playerForceId: 'force-1',
+        opponentForceId: 'force-2',
+        victoryConditions: [{ type: VictoryConditionType.DestroyAll }],
+      });
+
+      let encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.status).toBe(EncounterStatus.Ready);
+
+      // Clear victory conditions (this field can be set to empty array)
+      repository.updateEncounter(createResult.id!, { victoryConditions: [] });
+
+      encounter = repository.getEncounterById(createResult.id!);
+      expect(encounter?.status).toBe(EncounterStatus.Draft);
+    });
+  });
+
+  // ===========================================================================
+  // Row to Encounter Conversion Tests
+  // ===========================================================================
+  describe('data serialization/deserialization', () => {
+    it('should handle null optional fields correctly', () => {
+      const createResult = repository.createEncounter({ name: 'Null Fields Test' });
+      const encounter = repository.getEncounterById(createResult.id!);
+
+      // Description uses nullish coalescing so null becomes undefined
+      expect(encounter?.description).toBeUndefined();
+      // Template is cast directly so null remains (null as ScenarioTemplateType | undefined is still null)
+      expect(encounter?.template).toBeFalsy();
+      // These use truthy checks so null/undefined both become undefined
+      expect(encounter?.playerForce).toBeUndefined();
+      expect(encounter?.opponentForce).toBeUndefined();
+      expect(encounter?.opForConfig).toBeUndefined();
+      // gameSessionId uses nullish coalescing so null becomes undefined
+      expect(encounter?.gameSessionId).toBeUndefined();
+    });
+
+    it('should preserve complex nested objects through serialization', () => {
+      const createResult = repository.createEncounter({ name: 'Complex Data Test' });
+      repository.updateEncounter(createResult.id!, {
+        opForConfig: {
+          targetBV: 8000,
+          targetBVPercent: 110,
+          era: 'Clan Invasion',
+          faction: 'Jade Falcon',
+          unitTypes: ['BattleMech', 'OmniMech'],
+          pilotSkillTemplate: PilotSkillTemplate.Veteran,
+        },
+        victoryConditions: [
+          { type: VictoryConditionType.Cripple, threshold: 75 },
+          { type: VictoryConditionType.TurnLimit, turnLimit: 20 },
+          { type: VictoryConditionType.Custom, description: 'Hold the hill for 5 turns' },
+        ],
+        mapConfig: {
+          radius: 10,
+          terrain: TerrainPreset.LightWoods,
+          playerDeploymentZone: 'east',
+          opponentDeploymentZone: 'west',
+        },
+      });
+
+      const encounter = repository.getEncounterById(createResult.id!);
+
+      // Verify OpFor config
+      expect(encounter?.opForConfig?.targetBV).toBe(8000);
+      expect(encounter?.opForConfig?.targetBVPercent).toBe(110);
+      expect(encounter?.opForConfig?.unitTypes).toEqual(['BattleMech', 'OmniMech']);
+
+      // Verify victory conditions
+      expect(encounter?.victoryConditions).toHaveLength(3);
+      expect(encounter?.victoryConditions[2].description).toBe('Hold the hill for 5 turns');
+
+      // Verify map config
+      expect(encounter?.mapConfig.terrain).toBe(TerrainPreset.LightWoods);
+      expect(encounter?.mapConfig.playerDeploymentZone).toBe('east');
+    });
+  });
+
+  // ===========================================================================
+  // Singleton Tests
+  // ===========================================================================
+  describe('getEncounterRepository singleton', () => {
+    it('should return the same instance on multiple calls', () => {
+      const repo1 = getEncounterRepository();
+      const repo2 = getEncounterRepository();
+
+      expect(repo1).toBe(repo2);
+    });
+  });
+});

--- a/src/services/encounter/__tests__/EncounterService.test.ts
+++ b/src/services/encounter/__tests__/EncounterService.test.ts
@@ -1,0 +1,887 @@
+/**
+ * Encounter Service Tests
+ *
+ * Tests for encounter management and launch operations.
+ *
+ * @spec openspec/changes/add-encounter-system/specs/encounter-system/spec.md
+ */
+
+import {
+  IEncounter,
+  ICreateEncounterInput,
+  IUpdateEncounterInput,
+  IMapConfiguration,
+  IVictoryCondition,
+  EncounterStatus,
+  VictoryConditionType,
+  TerrainPreset,
+  ScenarioTemplateType,
+  PilotSkillTemplate,
+  SCENARIO_TEMPLATES,
+} from '@/types/encounter';
+import { IEncounterOperationResult } from '../EncounterRepository';
+import { IForce, ForceType, ForceStatus } from '@/types/force';
+
+// =============================================================================
+// Mock Data Storage
+// =============================================================================
+
+const mockEncounters = new Map<string, IEncounter>();
+const mockForces = new Map<string, IForce>();
+let mockIdCounter = 0;
+
+// Default map configuration for testing
+const DEFAULT_MAP_CONFIG: IMapConfiguration = {
+  radius: 6,
+  terrain: TerrainPreset.Clear,
+  playerDeploymentZone: 'south',
+  opponentDeploymentZone: 'north',
+};
+
+// =============================================================================
+// Mock Force Repository
+// =============================================================================
+
+jest.mock('../../forces/ForceRepository', () => ({
+  getForceRepository: () => ({
+    getForceById: (id: string) => mockForces.get(id) ?? null,
+    getAllForces: () => Array.from(mockForces.values()),
+  }),
+}));
+
+// =============================================================================
+// Mock Encounter Repository
+// =============================================================================
+
+jest.mock('../EncounterRepository', () => ({
+  getEncounterRepository: () => ({
+    createEncounter: jest.fn((input: ICreateEncounterInput): IEncounterOperationResult => {
+      const id = `encounter-${++mockIdCounter}`;
+      const now = new Date().toISOString();
+
+      // Get template defaults if specified
+      let mapConfig = DEFAULT_MAP_CONFIG;
+      let victoryConditions: readonly IVictoryCondition[] = [];
+
+      if (input.template) {
+        const template = SCENARIO_TEMPLATES.find((t) => t.type === input.template);
+        if (template) {
+          mapConfig = template.defaultMapConfig;
+          victoryConditions = template.defaultVictoryConditions;
+        }
+      }
+
+      const encounter: IEncounter = {
+        id,
+        name: input.name,
+        description: input.description,
+        status: EncounterStatus.Draft,
+        template: input.template,
+        mapConfig,
+        victoryConditions,
+        optionalRules: [],
+        createdAt: now,
+        updatedAt: now,
+      };
+      mockEncounters.set(id, encounter);
+      return { success: true, id };
+    }),
+    getEncounterById: (id: string) => mockEncounters.get(id) ?? null,
+    getAllEncounters: () => Array.from(mockEncounters.values()),
+    getEncountersByStatus: (status: EncounterStatus) =>
+      Array.from(mockEncounters.values()).filter((e) => e.status === status),
+    updateEncounter: jest.fn(
+      (id: string, input: IUpdateEncounterInput): IEncounterOperationResult => {
+        const encounter = mockEncounters.get(id);
+        if (!encounter) {
+          return { success: false, error: 'Encounter not found' };
+        }
+
+        // Cannot update launched or completed encounters
+        if (
+          encounter.status === EncounterStatus.Launched ||
+          encounter.status === EncounterStatus.Completed
+        ) {
+          return {
+            success: false,
+            error: `Cannot update encounter in ${encounter.status} status`,
+          };
+        }
+
+        // Handle opponentForceId - explicit undefined clears the opponent force
+        let opponentForce = encounter.opponentForce;
+        if ('opponentForceId' in input) {
+          opponentForce = input.opponentForceId
+            ? { forceId: input.opponentForceId, forceName: '', totalBV: 0, unitCount: 0 }
+            : undefined;
+        }
+
+        // Handle opForConfig - explicit undefined clears it
+        let opForConfig = encounter.opForConfig;
+        if ('opForConfig' in input) {
+          opForConfig = input.opForConfig;
+        }
+
+        const updated: IEncounter = {
+          ...encounter,
+          name: input.name ?? encounter.name,
+          description: input.description !== undefined ? input.description : encounter.description,
+          playerForce: input.playerForceId !== undefined
+            ? input.playerForceId
+              ? { forceId: input.playerForceId, forceName: '', totalBV: 0, unitCount: 0 }
+              : undefined
+            : encounter.playerForce,
+          opponentForce,
+          opForConfig,
+          mapConfig: input.mapConfig
+            ? { ...encounter.mapConfig, ...input.mapConfig }
+            : encounter.mapConfig,
+          victoryConditions: input.victoryConditions ?? encounter.victoryConditions,
+          optionalRules: input.optionalRules ?? encounter.optionalRules,
+          updatedAt: new Date().toISOString(),
+        };
+
+        // Recalculate status
+        const hasPlayerForce = !!updated.playerForce;
+        const hasOpponent = !!updated.opponentForce || !!updated.opForConfig;
+        const hasVictoryConditions =
+          updated.victoryConditions && updated.victoryConditions.length > 0;
+        const isReady = hasPlayerForce && hasOpponent && hasVictoryConditions;
+
+        mockEncounters.set(id, {
+          ...updated,
+          status: isReady ? EncounterStatus.Ready : EncounterStatus.Draft,
+        });
+
+        return { success: true, id };
+      }
+    ),
+    deleteEncounter: jest.fn((id: string): IEncounterOperationResult => {
+      const encounter = mockEncounters.get(id);
+      if (!encounter) {
+        return { success: false, error: 'Encounter not found' };
+      }
+      if (encounter.status === EncounterStatus.Launched) {
+        return { success: false, error: 'Cannot delete a launched encounter' };
+      }
+      mockEncounters.delete(id);
+      return { success: true };
+    }),
+    linkGameSession: jest.fn(
+      (encounterId: string, gameSessionId: string): IEncounterOperationResult => {
+        const encounter = mockEncounters.get(encounterId);
+        if (!encounter) {
+          return { success: false, error: 'Encounter not found' };
+        }
+        mockEncounters.set(encounterId, {
+          ...encounter,
+          status: EncounterStatus.Launched,
+          gameSessionId,
+          updatedAt: new Date().toISOString(),
+        });
+        return { success: true, id: encounterId };
+      }
+    ),
+  }),
+}));
+
+// Import after mocks
+import { EncounterService } from '../EncounterService';
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+function createMockForce(
+  id: string,
+  name: string,
+  totalBV: number = 5000,
+  assignedUnits: number = 4
+): IForce {
+  const force: IForce = {
+    id,
+    name,
+    forceType: ForceType.Lance,
+    status: ForceStatus.Active,
+    childIds: [],
+    assignments: [],
+    stats: {
+      totalBV,
+      totalTonnage: 200,
+      assignedPilots: assignedUnits,
+      assignedUnits,
+      emptySlots: 4 - assignedUnits,
+      averageSkill: { gunnery: 4, piloting: 5 },
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  mockForces.set(id, force);
+  return force;
+}
+
+function clearMocks(): void {
+  mockEncounters.clear();
+  mockForces.clear();
+  mockIdCounter = 0;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('EncounterService', () => {
+  let service: EncounterService;
+
+  beforeEach(() => {
+    clearMocks();
+    service = new EncounterService();
+  });
+
+  // ===========================================================================
+  // Encounter CRUD
+  // ===========================================================================
+
+  describe('Encounter CRUD', () => {
+    it('should create an encounter with basic input', () => {
+      const result = service.createEncounter({
+        name: 'Test Encounter',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.id).toBeDefined();
+
+      const encounter = service.getEncounter(result.id!);
+      expect(encounter).toBeDefined();
+      expect(encounter?.name).toBe('Test Encounter');
+      expect(encounter?.status).toBe(EncounterStatus.Draft);
+    });
+
+    it('should create an encounter with description', () => {
+      const result = service.createEncounter({
+        name: 'Test Encounter',
+        description: 'A test battle scenario',
+      });
+
+      expect(result.success).toBe(true);
+      const encounter = service.getEncounter(result.id!);
+      expect(encounter?.description).toBe('A test battle scenario');
+    });
+
+    it('should create an encounter with a template', () => {
+      const result = service.createEncounter({
+        name: 'Duel Encounter',
+        template: ScenarioTemplateType.Duel,
+      });
+
+      expect(result.success).toBe(true);
+      const encounter = service.getEncounter(result.id!);
+      expect(encounter?.template).toBe(ScenarioTemplateType.Duel);
+      expect(encounter?.mapConfig.radius).toBe(5); // Duel template uses radius 5
+      expect(encounter?.victoryConditions).toHaveLength(1);
+      expect(encounter?.victoryConditions[0].type).toBe(VictoryConditionType.DestroyAll);
+    });
+
+    it('should reject empty encounter name', () => {
+      const result = service.createEncounter({
+        name: '',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Encounter name is required');
+    });
+
+    it('should reject whitespace-only encounter name', () => {
+      const result = service.createEncounter({
+        name: '   ',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Encounter name is required');
+    });
+
+    it('should get all encounters', () => {
+      service.createEncounter({ name: 'Encounter 1' });
+      service.createEncounter({ name: 'Encounter 2' });
+
+      const encounters = service.getAllEncounters();
+      expect(encounters).toHaveLength(2);
+    });
+
+    it('should return null for non-existent encounter', () => {
+      const encounter = service.getEncounter('non-existent-id');
+      expect(encounter).toBeNull();
+    });
+
+    it('should update an encounter name', () => {
+      const createResult = service.createEncounter({ name: 'Original Name' });
+      const updateResult = service.updateEncounter(createResult.id!, {
+        name: 'Updated Name',
+      });
+
+      expect(updateResult.success).toBe(true);
+      const encounter = service.getEncounter(createResult.id!);
+      expect(encounter?.name).toBe('Updated Name');
+    });
+
+    it('should delete an encounter', () => {
+      const createResult = service.createEncounter({ name: 'To Delete' });
+      const deleteResult = service.deleteEncounter(createResult.id!);
+
+      expect(deleteResult.success).toBe(true);
+      expect(service.getEncounter(createResult.id!)).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // Filter Methods
+  // ===========================================================================
+
+  describe('Filter Methods', () => {
+    it('should get ready encounters', () => {
+      // Create an encounter that will become ready
+      const playerForce = createMockForce('force-1', 'Alpha Lance');
+      const opponentForce = createMockForce('force-2', 'Bravo Lance');
+
+      const result = service.createEncounter({
+        name: 'Ready Encounter',
+        template: ScenarioTemplateType.Skirmish,
+      });
+
+      // Set forces to make it ready
+      service.setPlayerForce(result.id!, playerForce.id);
+      service.setOpponentForce(result.id!, opponentForce.id);
+
+      // Create a draft encounter
+      service.createEncounter({ name: 'Draft Encounter' });
+
+      const readyEncounters = service.getReadyEncounters();
+      expect(readyEncounters).toHaveLength(1);
+      expect(readyEncounters[0].name).toBe('Ready Encounter');
+    });
+
+    it('should get draft encounters', () => {
+      service.createEncounter({ name: 'Draft 1' });
+      service.createEncounter({ name: 'Draft 2' });
+
+      const draftEncounters = service.getDraftEncounters();
+      expect(draftEncounters).toHaveLength(2);
+    });
+  });
+
+  // ===========================================================================
+  // Configuration
+  // ===========================================================================
+
+  describe('Configuration', () => {
+    describe('setPlayerForce', () => {
+      it('should set player force successfully', () => {
+        const force = createMockForce('force-player', 'Player Lance');
+        const createResult = service.createEncounter({ name: 'Test' });
+
+        const result = service.setPlayerForce(createResult.id!, force.id);
+
+        expect(result.success).toBe(true);
+        const encounter = service.getEncounter(createResult.id!);
+        expect(encounter?.playerForce?.forceId).toBe(force.id);
+      });
+
+      it('should reject non-existent force', () => {
+        const createResult = service.createEncounter({ name: 'Test' });
+
+        const result = service.setPlayerForce(createResult.id!, 'non-existent');
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('Force not found');
+      });
+
+      it('should hydrate player force with current force data', () => {
+        const force = createMockForce('force-hydrate', 'Hydrate Lance', 6000, 4);
+        const createResult = service.createEncounter({ name: 'Test' });
+        service.setPlayerForce(createResult.id!, force.id);
+
+        const encounter = service.getEncounter(createResult.id!);
+
+        expect(encounter?.playerForce?.forceName).toBe('Hydrate Lance');
+        expect(encounter?.playerForce?.totalBV).toBe(6000);
+        expect(encounter?.playerForce?.unitCount).toBe(4);
+      });
+    });
+
+    describe('setOpponentForce', () => {
+      it('should set opponent force successfully', () => {
+        const force = createMockForce('force-opponent', 'Opponent Lance');
+        const createResult = service.createEncounter({ name: 'Test' });
+
+        const result = service.setOpponentForce(createResult.id!, force.id);
+
+        expect(result.success).toBe(true);
+        const encounter = service.getEncounter(createResult.id!);
+        expect(encounter?.opponentForce?.forceId).toBe(force.id);
+      });
+
+      it('should reject non-existent force', () => {
+        const createResult = service.createEncounter({ name: 'Test' });
+
+        const result = service.setOpponentForce(createResult.id!, 'non-existent');
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('Force not found');
+      });
+
+      it('should clear opForConfig when setting explicit opponent force', () => {
+        const force = createMockForce('force-explicit', 'Explicit Lance');
+        const createResult = service.createEncounter({ name: 'Test' });
+
+        // First set opForConfig through updateEncounter
+        service.updateEncounter(createResult.id!, {
+          opForConfig: {
+            targetBV: 5000,
+            pilotSkillTemplate: PilotSkillTemplate.Regular,
+          },
+        });
+
+        // Then set explicit opponent force
+        service.setOpponentForce(createResult.id!, force.id);
+
+        const encounter = service.getEncounter(createResult.id!);
+        expect(encounter?.opponentForce?.forceId).toBe(force.id);
+        // opForConfig should be cleared (set to undefined)
+        expect(encounter?.opForConfig).toBeUndefined();
+      });
+    });
+
+    describe('clearOpponentForce', () => {
+      it('should clear opponent force', () => {
+        const force = createMockForce('force-clear', 'Clear Lance');
+        const createResult = service.createEncounter({ name: 'Test' });
+        service.setOpponentForce(createResult.id!, force.id);
+
+        const result = service.clearOpponentForce(createResult.id!);
+
+        expect(result.success).toBe(true);
+        const encounter = service.getEncounter(createResult.id!);
+        expect(encounter?.opponentForce).toBeUndefined();
+      });
+    });
+
+    describe('applyTemplate', () => {
+      it('should apply duel template', () => {
+        const createResult = service.createEncounter({ name: 'Test' });
+
+        const result = service.applyTemplate(createResult.id!, ScenarioTemplateType.Duel);
+
+        expect(result.success).toBe(true);
+        const encounter = service.getEncounter(createResult.id!);
+        expect(encounter?.mapConfig.radius).toBe(5);
+        expect(encounter?.victoryConditions).toHaveLength(1);
+        expect(encounter?.victoryConditions[0].type).toBe(VictoryConditionType.DestroyAll);
+      });
+
+      it('should apply skirmish template', () => {
+        const createResult = service.createEncounter({ name: 'Test' });
+
+        const result = service.applyTemplate(createResult.id!, ScenarioTemplateType.Skirmish);
+
+        expect(result.success).toBe(true);
+        const encounter = service.getEncounter(createResult.id!);
+        expect(encounter?.mapConfig.radius).toBe(8);
+        expect(encounter?.victoryConditions).toHaveLength(2);
+      });
+
+      it('should apply battle template', () => {
+        const createResult = service.createEncounter({ name: 'Test' });
+
+        const result = service.applyTemplate(createResult.id!, ScenarioTemplateType.Battle);
+
+        expect(result.success).toBe(true);
+        const encounter = service.getEncounter(createResult.id!);
+        expect(encounter?.mapConfig.radius).toBe(12);
+      });
+
+      it('should reject unknown template', () => {
+        const createResult = service.createEncounter({ name: 'Test' });
+
+        const result = service.applyTemplate(createResult.id!, 'unknown' as ScenarioTemplateType);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('Unknown template');
+      });
+    });
+  });
+
+  // ===========================================================================
+  // Validation
+  // ===========================================================================
+
+  describe('Validation', () => {
+    it('should return invalid for encounter without player force', () => {
+      const createResult = service.createEncounter({ name: 'Test' });
+
+      const validation = service.validateEncounter(createResult.id!);
+
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain('Player force must be selected');
+    });
+
+    it('should return invalid for encounter without opponent', () => {
+      const playerForce = createMockForce('force-p', 'Player');
+      const createResult = service.createEncounter({ name: 'Test' });
+      service.setPlayerForce(createResult.id!, playerForce.id);
+
+      const validation = service.validateEncounter(createResult.id!);
+
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain('Opponent force or OpFor configuration is required');
+    });
+
+    it('should return invalid for encounter without victory conditions', () => {
+      const playerForce = createMockForce('force-p', 'Player');
+      const opponentForce = createMockForce('force-o', 'Opponent');
+      const createResult = service.createEncounter({ name: 'Test' });
+      service.setPlayerForce(createResult.id!, playerForce.id);
+      service.setOpponentForce(createResult.id!, opponentForce.id);
+
+      // Clear victory conditions
+      service.updateEncounter(createResult.id!, { victoryConditions: [] });
+
+      const validation = service.validateEncounter(createResult.id!);
+
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain('At least one victory condition is required');
+    });
+
+    it('should return valid for complete encounter', () => {
+      const playerForce = createMockForce('force-p', 'Player', 5000);
+      const opponentForce = createMockForce('force-o', 'Opponent', 5000);
+      const createResult = service.createEncounter({
+        name: 'Complete Test',
+        template: ScenarioTemplateType.Skirmish,
+      });
+      service.setPlayerForce(createResult.id!, playerForce.id);
+      service.setOpponentForce(createResult.id!, opponentForce.id);
+
+      const validation = service.validateEncounter(createResult.id!);
+
+      expect(validation.valid).toBe(true);
+      expect(validation.errors).toHaveLength(0);
+    });
+
+    it('should return error for non-existent encounter', () => {
+      const validation = service.validateEncounter('non-existent');
+
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain('Encounter not found');
+    });
+
+    it('should warn about BV imbalance', () => {
+      const playerForce = createMockForce('force-p', 'Player', 10000);
+      const opponentForce = createMockForce('force-o', 'Opponent', 5000);
+      const createResult = service.createEncounter({
+        name: 'Imbalanced',
+        template: ScenarioTemplateType.Skirmish,
+      });
+      service.setPlayerForce(createResult.id!, playerForce.id);
+      service.setOpponentForce(createResult.id!, opponentForce.id);
+
+      const validation = service.validateEncounter(createResult.id!);
+
+      expect(validation.warnings.length).toBeGreaterThan(0);
+      expect(validation.warnings.some((w) => w.includes('unbalanced'))).toBe(true);
+    });
+
+    describe('canLaunch', () => {
+      it('should return true for valid encounter', () => {
+        const playerForce = createMockForce('force-p', 'Player');
+        const opponentForce = createMockForce('force-o', 'Opponent');
+        const createResult = service.createEncounter({
+          name: 'Launchable',
+          template: ScenarioTemplateType.Skirmish,
+        });
+        service.setPlayerForce(createResult.id!, playerForce.id);
+        service.setOpponentForce(createResult.id!, opponentForce.id);
+
+        expect(service.canLaunch(createResult.id!)).toBe(true);
+      });
+
+      it('should return false for invalid encounter', () => {
+        const createResult = service.createEncounter({ name: 'Not Launchable' });
+
+        expect(service.canLaunch(createResult.id!)).toBe(false);
+      });
+    });
+  });
+
+  // ===========================================================================
+  // Launch
+  // ===========================================================================
+
+  describe('Launch', () => {
+    it('should launch a valid encounter', () => {
+      const playerForce = createMockForce('force-p', 'Player');
+      const opponentForce = createMockForce('force-o', 'Opponent');
+      const createResult = service.createEncounter({
+        name: 'To Launch',
+        template: ScenarioTemplateType.Skirmish,
+      });
+      service.setPlayerForce(createResult.id!, playerForce.id);
+      service.setOpponentForce(createResult.id!, opponentForce.id);
+
+      const launchResult = service.launchEncounter(createResult.id!);
+
+      expect(launchResult.success).toBe(true);
+      const encounter = service.getEncounter(createResult.id!);
+      expect(encounter?.status).toBe(EncounterStatus.Launched);
+      expect(encounter?.gameSessionId).toBeDefined();
+    });
+
+    it('should reject launching non-existent encounter', () => {
+      const result = service.launchEncounter('non-existent');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Encounter not found');
+    });
+
+    it('should reject launching invalid encounter', () => {
+      const createResult = service.createEncounter({ name: 'Invalid' });
+
+      const result = service.launchEncounter(createResult.id!);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Cannot launch');
+    });
+
+    it('should reject launching already launched encounter', () => {
+      const playerForce = createMockForce('force-p', 'Player');
+      const opponentForce = createMockForce('force-o', 'Opponent');
+      const createResult = service.createEncounter({
+        name: 'Already Launched',
+        template: ScenarioTemplateType.Skirmish,
+      });
+      service.setPlayerForce(createResult.id!, playerForce.id);
+      service.setOpponentForce(createResult.id!, opponentForce.id);
+      service.launchEncounter(createResult.id!);
+
+      const result = service.launchEncounter(createResult.id!);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Encounter is already launched');
+    });
+
+    it('should reject launching completed encounter', () => {
+      const playerForce = createMockForce('force-p', 'Player');
+      const opponentForce = createMockForce('force-o', 'Opponent');
+      const createResult = service.createEncounter({
+        name: 'Completed',
+        template: ScenarioTemplateType.Skirmish,
+      });
+      service.setPlayerForce(createResult.id!, playerForce.id);
+      service.setOpponentForce(createResult.id!, opponentForce.id);
+
+      // Manually set status to completed for test
+      const encounter = mockEncounters.get(createResult.id!);
+      if (encounter) {
+        mockEncounters.set(createResult.id!, {
+          ...encounter,
+          status: EncounterStatus.Completed,
+        });
+      }
+
+      const result = service.launchEncounter(createResult.id!);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Encounter is already completed');
+    });
+  });
+
+  // ===========================================================================
+  // Cloning
+  // ===========================================================================
+
+  describe('Cloning', () => {
+    it('should clone an encounter', () => {
+      const playerForce = createMockForce('force-p', 'Player');
+      const opponentForce = createMockForce('force-o', 'Opponent');
+      const createResult = service.createEncounter({
+        name: 'Original',
+        description: 'Original description',
+        template: ScenarioTemplateType.Skirmish,
+      });
+      service.setPlayerForce(createResult.id!, playerForce.id);
+      service.setOpponentForce(createResult.id!, opponentForce.id);
+
+      const cloneResult = service.cloneEncounter(createResult.id!, 'Cloned');
+
+      expect(cloneResult.success).toBe(true);
+      expect(cloneResult.id).toBeDefined();
+      expect(cloneResult.id).not.toBe(createResult.id);
+
+      const cloned = service.getEncounter(cloneResult.id!);
+      expect(cloned?.name).toBe('Cloned');
+      expect(cloned?.template).toBe(ScenarioTemplateType.Skirmish);
+    });
+
+    it('should set description indicating clone source', () => {
+      const createResult = service.createEncounter({
+        name: 'Source',
+        description: 'Has description',
+      });
+
+      const cloneResult = service.cloneEncounter(createResult.id!, 'Clone');
+
+      const cloned = service.getEncounter(cloneResult.id!);
+      expect(cloned?.description).toContain('Cloned from Source');
+    });
+
+    it('should return error when cloning non-existent encounter', () => {
+      const result = service.cloneEncounter('non-existent', 'Clone');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Encounter not found');
+    });
+
+    it('should copy configuration to cloned encounter', () => {
+      const playerForce = createMockForce('force-p', 'Player');
+      const opponentForce = createMockForce('force-o', 'Opponent');
+      const createResult = service.createEncounter({
+        name: 'With Config',
+        template: ScenarioTemplateType.Battle,
+      });
+      service.setPlayerForce(createResult.id!, playerForce.id);
+      service.setOpponentForce(createResult.id!, opponentForce.id);
+      service.updateEncounter(createResult.id!, {
+        optionalRules: ['forced_withdrawal'],
+      });
+
+      const cloneResult = service.cloneEncounter(createResult.id!, 'Cloned Config');
+
+      const cloned = service.getEncounter(cloneResult.id!);
+      expect(cloned?.playerForce?.forceId).toBe(playerForce.id);
+      expect(cloned?.opponentForce?.forceId).toBe(opponentForce.id);
+    });
+
+    it('should clone encounter with opForConfig', () => {
+      const createResult = service.createEncounter({
+        name: 'With OpFor Config',
+        template: ScenarioTemplateType.Skirmish,
+      });
+      const playerForce = createMockForce('force-p', 'Player');
+      service.setPlayerForce(createResult.id!, playerForce.id);
+      service.updateEncounter(createResult.id!, {
+        opForConfig: {
+          targetBVPercent: 100,
+          pilotSkillTemplate: PilotSkillTemplate.Regular,
+        },
+      });
+
+      const cloneResult = service.cloneEncounter(createResult.id!, 'Cloned OpFor');
+
+      const cloned = service.getEncounter(cloneResult.id!);
+      expect(cloned?.opForConfig?.pilotSkillTemplate).toBe(PilotSkillTemplate.Regular);
+      expect(cloned?.opForConfig?.targetBVPercent).toBe(100);
+    });
+
+    it('should start cloned encounter in draft status', () => {
+      const playerForce = createMockForce('force-p', 'Player');
+      const opponentForce = createMockForce('force-o', 'Opponent');
+      const createResult = service.createEncounter({
+        name: 'Ready Original',
+        template: ScenarioTemplateType.Skirmish,
+      });
+      service.setPlayerForce(createResult.id!, playerForce.id);
+      service.setOpponentForce(createResult.id!, opponentForce.id);
+
+      // Original should be ready
+      const original = service.getEncounter(createResult.id!);
+      expect(original?.status).toBe(EncounterStatus.Ready);
+
+      const cloneResult = service.cloneEncounter(createResult.id!, 'Cloned Ready');
+
+      const cloned = service.getEncounter(cloneResult.id!);
+      // Clone status depends on whether config is copied - may become ready
+      expect([EncounterStatus.Draft, EncounterStatus.Ready]).toContain(cloned?.status);
+    });
+  });
+
+  // ===========================================================================
+  // Force Hydration
+  // ===========================================================================
+
+  describe('Force Hydration', () => {
+    it('should hydrate player force with current data', () => {
+      const force = createMockForce('force-hydrate-1', 'Hydrated Player', 7500, 3);
+      const createResult = service.createEncounter({ name: 'Hydration Test' });
+      service.setPlayerForce(createResult.id!, force.id);
+
+      const encounter = service.getEncounter(createResult.id!);
+
+      expect(encounter?.playerForce?.forceName).toBe('Hydrated Player');
+      expect(encounter?.playerForce?.totalBV).toBe(7500);
+      expect(encounter?.playerForce?.unitCount).toBe(3);
+    });
+
+    it('should hydrate opponent force with current data', () => {
+      const force = createMockForce('force-hydrate-2', 'Hydrated Opponent', 8000, 4);
+      const createResult = service.createEncounter({ name: 'Hydration Test' });
+      service.setOpponentForce(createResult.id!, force.id);
+
+      const encounter = service.getEncounter(createResult.id!);
+
+      expect(encounter?.opponentForce?.forceName).toBe('Hydrated Opponent');
+      expect(encounter?.opponentForce?.totalBV).toBe(8000);
+      expect(encounter?.opponentForce?.unitCount).toBe(4);
+    });
+
+    it('should handle deleted force gracefully', () => {
+      const force = createMockForce('force-deleted', 'Deleted Force');
+      const createResult = service.createEncounter({ name: 'Deleted Force Test' });
+      service.setPlayerForce(createResult.id!, force.id);
+
+      // Delete the force
+      mockForces.delete(force.id);
+
+      const encounter = service.getEncounter(createResult.id!);
+
+      // Should still have the reference but not hydrated with current data
+      expect(encounter?.playerForce?.forceId).toBe(force.id);
+    });
+  });
+
+  // ===========================================================================
+  // Edge Cases
+  // ===========================================================================
+
+  describe('Edge Cases', () => {
+    it('should handle empty encounters list', () => {
+      const encounters = service.getAllEncounters();
+      expect(encounters).toHaveLength(0);
+    });
+
+    it('should handle multiple templates applied sequentially', () => {
+      const createResult = service.createEncounter({ name: 'Multi Template' });
+
+      service.applyTemplate(createResult.id!, ScenarioTemplateType.Duel);
+      let encounter = service.getEncounter(createResult.id!);
+      expect(encounter?.mapConfig.radius).toBe(5);
+
+      service.applyTemplate(createResult.id!, ScenarioTemplateType.Battle);
+      encounter = service.getEncounter(createResult.id!);
+      expect(encounter?.mapConfig.radius).toBe(12);
+    });
+
+    it('should not modify original encounter when cloning', () => {
+      const playerForce = createMockForce('force-original', 'Original Force');
+      const createResult = service.createEncounter({
+        name: 'Original Unchanged',
+        template: ScenarioTemplateType.Skirmish,
+      });
+      service.setPlayerForce(createResult.id!, playerForce.id);
+
+      const cloneResult = service.cloneEncounter(createResult.id!, 'Clone');
+      service.updateEncounter(cloneResult.id!, { name: 'Modified Clone' });
+
+      const original = service.getEncounter(createResult.id!);
+      expect(original?.name).toBe('Original Unchanged');
+    });
+  });
+});

--- a/src/services/forces/__tests__/ForceRepository.test.ts
+++ b/src/services/forces/__tests__/ForceRepository.test.ts
@@ -1,0 +1,1280 @@
+/**
+ * ForceRepository Tests
+ *
+ * Tests for the SQLite-based force repository.
+ * Covers CRUD operations for forces and assignment operations.
+ */
+
+import {
+  ForceRepository,
+  getForceRepository,
+  ForceErrorCode,
+} from '@/services/forces/ForceRepository';
+import {
+  getSQLiteService,
+  resetSQLiteService,
+} from '@/services/persistence/SQLiteService';
+import {
+  ForceType,
+  ForceStatus,
+  ForcePosition,
+  ICreateForceRequest,
+} from '@/types/force';
+import fs from 'fs';
+import path from 'path';
+
+// Test database path
+const TEST_DB_PATH = './data/test-force-repository.db';
+
+describe('ForceRepository', () => {
+  let repository: ForceRepository;
+
+  beforeEach(() => {
+    // Clean up any existing test database
+    if (fs.existsSync(TEST_DB_PATH)) {
+      fs.unlinkSync(TEST_DB_PATH);
+    }
+
+    // Clean up WAL files if they exist
+    const walPath = `${TEST_DB_PATH}-wal`;
+    const shmPath = `${TEST_DB_PATH}-shm`;
+    if (fs.existsSync(walPath)) fs.unlinkSync(walPath);
+    if (fs.existsSync(shmPath)) fs.unlinkSync(shmPath);
+
+    // Ensure data directory exists
+    const dataDir = path.dirname(TEST_DB_PATH);
+    if (!fs.existsSync(dataDir)) {
+      fs.mkdirSync(dataDir, { recursive: true });
+    }
+
+    // Reset SQLite singleton
+    resetSQLiteService();
+
+    // Initialize with test database
+    const sqliteService = getSQLiteService({ path: TEST_DB_PATH });
+    sqliteService.initialize();
+
+    // Create a fresh repository instance for each test
+    repository = new ForceRepository();
+  });
+
+  afterEach(() => {
+    // Close database and clean up
+    resetSQLiteService();
+
+    if (fs.existsSync(TEST_DB_PATH)) {
+      fs.unlinkSync(TEST_DB_PATH);
+    }
+
+    // Clean up WAL files
+    const walPath = `${TEST_DB_PATH}-wal`;
+    const shmPath = `${TEST_DB_PATH}-shm`;
+    if (fs.existsSync(walPath)) fs.unlinkSync(walPath);
+    if (fs.existsSync(shmPath)) fs.unlinkSync(shmPath);
+  });
+
+  // ===========================================================================
+  // Initialize Tests
+  // ===========================================================================
+
+  describe('initialize', () => {
+    it('should create forces and force_assignments tables', () => {
+      repository.initialize();
+
+      const db = getSQLiteService().getDatabase();
+
+      // Check forces table exists
+      const forcesTable = db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='forces'"
+        )
+        .get();
+      expect(forcesTable).toBeDefined();
+
+      // Check force_assignments table exists
+      const assignmentsTable = db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='force_assignments'"
+        )
+        .get();
+      expect(assignmentsTable).toBeDefined();
+    });
+
+    it('should be idempotent (can be called multiple times)', () => {
+      repository.initialize();
+      repository.initialize();
+      repository.initialize();
+
+      // Should not throw
+      const forces = repository.getAllForces();
+      expect(forces).toEqual([]);
+    });
+  });
+
+  // ===========================================================================
+  // createForce Tests
+  // ===========================================================================
+
+  describe('createForce', () => {
+    it('should create a new lance force with 4 empty assignments', () => {
+      const request: ICreateForceRequest = {
+        name: 'Alpha Lance',
+        forceType: ForceType.Lance,
+        affiliation: 'House Steiner',
+        description: 'Recon lance',
+      };
+
+      const result = repository.createForce(request);
+
+      expect(result.success).toBe(true);
+      expect(result.id).toBeDefined();
+      expect(result.id).toMatch(/^force-/);
+
+      // Verify force was created
+      const force = repository.getForceById(result.id!);
+      expect(force).not.toBeNull();
+      expect(force?.name).toBe('Alpha Lance');
+      expect(force?.forceType).toBe(ForceType.Lance);
+      expect(force?.affiliation).toBe('House Steiner');
+      expect(force?.description).toBe('Recon lance');
+      expect(force?.status).toBe(ForceStatus.Active);
+      expect(force?.assignments.length).toBe(4);
+    });
+
+    it('should create a star force with 5 empty assignments', () => {
+      const request: ICreateForceRequest = {
+        name: 'Nova Cat Star',
+        forceType: ForceType.Star,
+      };
+
+      const result = repository.createForce(request);
+
+      expect(result.success).toBe(true);
+
+      const force = repository.getForceById(result.id!);
+      expect(force?.assignments.length).toBe(5);
+    });
+
+    it('should create a Level II force with 6 empty assignments', () => {
+      const request: ICreateForceRequest = {
+        name: 'ComStar Level II',
+        forceType: ForceType.Level_II,
+      };
+
+      const result = repository.createForce(request);
+
+      expect(result.success).toBe(true);
+
+      const force = repository.getForceById(result.id!);
+      expect(force?.assignments.length).toBe(6);
+    });
+
+    it('should create a company force with 12 empty assignments', () => {
+      const request: ICreateForceRequest = {
+        name: 'Bravo Company',
+        forceType: ForceType.Company,
+      };
+
+      const result = repository.createForce(request);
+
+      expect(result.success).toBe(true);
+
+      const force = repository.getForceById(result.id!);
+      expect(force?.assignments.length).toBe(12);
+    });
+
+    it('should set first slot position to Lead and others to Member', () => {
+      const request: ICreateForceRequest = {
+        name: 'Test Lance',
+        forceType: ForceType.Lance,
+      };
+
+      const result = repository.createForce(request);
+      const force = repository.getForceById(result.id!);
+
+      expect(force?.assignments[0].position).toBe(ForcePosition.Lead);
+      expect(force?.assignments[1].position).toBe(ForcePosition.Member);
+      expect(force?.assignments[2].position).toBe(ForcePosition.Member);
+      expect(force?.assignments[3].position).toBe(ForcePosition.Member);
+    });
+
+    it('should create assignments with null pilot and unit IDs', () => {
+      const request: ICreateForceRequest = {
+        name: 'Empty Lance',
+        forceType: ForceType.Lance,
+      };
+
+      const result = repository.createForce(request);
+      const force = repository.getForceById(result.id!);
+
+      for (const assignment of force!.assignments) {
+        expect(assignment.pilotId).toBeNull();
+        expect(assignment.unitId).toBeNull();
+      }
+    });
+
+    it('should create force with parent ID', () => {
+      // Create parent company
+      const parentResult = repository.createForce({
+        name: 'Parent Company',
+        forceType: ForceType.Company,
+      });
+
+      // Create child lance
+      const childResult = repository.createForce({
+        name: 'Child Lance',
+        forceType: ForceType.Lance,
+        parentId: parentResult.id,
+      });
+
+      expect(childResult.success).toBe(true);
+
+      const childForce = repository.getForceById(childResult.id!);
+      expect(childForce?.parentId).toBe(parentResult.id);
+
+      const parentForce = repository.getForceById(parentResult.id!);
+      expect(parentForce?.childIds).toContain(childResult.id);
+    });
+
+    it('should set timestamps on creation', () => {
+      const beforeCreate = new Date().toISOString();
+
+      const result = repository.createForce({
+        name: 'Timestamped Force',
+        forceType: ForceType.Lance,
+      });
+
+      const afterCreate = new Date().toISOString();
+
+      const force = repository.getForceById(result.id!);
+      expect(force?.createdAt).toBeDefined();
+      expect(force?.updatedAt).toBeDefined();
+      expect(force!.createdAt >= beforeCreate).toBe(true);
+      expect(force!.createdAt <= afterCreate).toBe(true);
+      expect(force?.createdAt).toBe(force?.updatedAt);
+    });
+  });
+
+  // ===========================================================================
+  // getForceById Tests
+  // ===========================================================================
+
+  describe('getForceById', () => {
+    it('should return null for non-existent force', () => {
+      const force = repository.getForceById('non-existent-id');
+      expect(force).toBeNull();
+    });
+
+    it('should return the force after creation', () => {
+      const result = repository.createForce({
+        name: 'Test Force',
+        forceType: ForceType.Lance,
+        affiliation: 'Test Affiliation',
+      });
+
+      const force = repository.getForceById(result.id!);
+
+      expect(force).not.toBeNull();
+      expect(force?.id).toBe(result.id);
+      expect(force?.name).toBe('Test Force');
+      expect(force?.forceType).toBe(ForceType.Lance);
+      expect(force?.affiliation).toBe('Test Affiliation');
+    });
+
+    it('should include calculated stats', () => {
+      const result = repository.createForce({
+        name: 'Stats Test',
+        forceType: ForceType.Lance,
+      });
+
+      const force = repository.getForceById(result.id!);
+
+      expect(force?.stats).toBeDefined();
+      expect(force?.stats.totalBV).toBe(0);
+      expect(force?.stats.totalTonnage).toBe(0);
+      expect(force?.stats.assignedPilots).toBe(0);
+      expect(force?.stats.assignedUnits).toBe(0);
+      expect(force?.stats.emptySlots).toBe(4);
+      expect(force?.stats.averageSkill).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // getAllForces Tests
+  // ===========================================================================
+
+  describe('getAllForces', () => {
+    it('should return empty array when no forces exist', () => {
+      const forces = repository.getAllForces();
+      expect(forces).toEqual([]);
+    });
+
+    it('should return all forces', () => {
+      repository.createForce({ name: 'Force A', forceType: ForceType.Lance });
+      repository.createForce({ name: 'Force B', forceType: ForceType.Star });
+      repository.createForce({ name: 'Force C', forceType: ForceType.Level_II });
+
+      const forces = repository.getAllForces();
+
+      expect(forces.length).toBe(3);
+      expect(forces.some((f) => f.name === 'Force A')).toBe(true);
+      expect(forces.some((f) => f.name === 'Force B')).toBe(true);
+      expect(forces.some((f) => f.name === 'Force C')).toBe(true);
+    });
+
+    it('should return all created forces', () => {
+      repository.createForce({ name: 'First', forceType: ForceType.Lance });
+      repository.createForce({ name: 'Second', forceType: ForceType.Lance });
+      repository.createForce({ name: 'Third', forceType: ForceType.Lance });
+
+      const forces = repository.getAllForces();
+
+      // All three forces should be returned (order may depend on insertion speed)
+      expect(forces.length).toBe(3);
+      const names = forces.map((f) => f.name).sort();
+      expect(names).toEqual(['First', 'Second', 'Third']);
+    });
+  });
+
+  // ===========================================================================
+  // getRootForces Tests
+  // ===========================================================================
+
+  describe('getRootForces', () => {
+    it('should return empty array when no forces exist', () => {
+      const forces = repository.getRootForces();
+      expect(forces).toEqual([]);
+    });
+
+    it('should return only forces without parent', () => {
+      // Create root force
+      const rootResult = repository.createForce({
+        name: 'Root Company',
+        forceType: ForceType.Company,
+      });
+
+      // Create child force
+      repository.createForce({
+        name: 'Child Lance',
+        forceType: ForceType.Lance,
+        parentId: rootResult.id,
+      });
+
+      // Create another root force
+      repository.createForce({
+        name: 'Another Root',
+        forceType: ForceType.Lance,
+      });
+
+      const rootForces = repository.getRootForces();
+
+      expect(rootForces.length).toBe(2);
+      expect(rootForces.some((f) => f.name === 'Root Company')).toBe(true);
+      expect(rootForces.some((f) => f.name === 'Another Root')).toBe(true);
+      expect(rootForces.some((f) => f.name === 'Child Lance')).toBe(false);
+    });
+
+    it('should return root forces ordered by name', () => {
+      repository.createForce({ name: 'Zebra Force', forceType: ForceType.Lance });
+      repository.createForce({ name: 'Alpha Force', forceType: ForceType.Lance });
+      repository.createForce({ name: 'Delta Force', forceType: ForceType.Lance });
+
+      const forces = repository.getRootForces();
+
+      expect(forces[0].name).toBe('Alpha Force');
+      expect(forces[1].name).toBe('Delta Force');
+      expect(forces[2].name).toBe('Zebra Force');
+    });
+  });
+
+  // ===========================================================================
+  // getChildForces Tests
+  // ===========================================================================
+
+  describe('getChildForces', () => {
+    it('should return empty array for force with no children', () => {
+      const result = repository.createForce({
+        name: 'Lonely Force',
+        forceType: ForceType.Lance,
+      });
+
+      const children = repository.getChildForces(result.id!);
+      expect(children).toEqual([]);
+    });
+
+    it('should return empty array for non-existent parent', () => {
+      const children = repository.getChildForces('non-existent-id');
+      expect(children).toEqual([]);
+    });
+
+    it('should return child forces', () => {
+      // Create parent
+      const parentResult = repository.createForce({
+        name: 'Parent Battalion',
+        forceType: ForceType.Battalion,
+      });
+
+      // Create children
+      repository.createForce({
+        name: 'Alpha Company',
+        forceType: ForceType.Company,
+        parentId: parentResult.id,
+      });
+
+      repository.createForce({
+        name: 'Beta Company',
+        forceType: ForceType.Company,
+        parentId: parentResult.id,
+      });
+
+      const children = repository.getChildForces(parentResult.id!);
+
+      expect(children.length).toBe(2);
+      expect(children.some((f) => f.name === 'Alpha Company')).toBe(true);
+      expect(children.some((f) => f.name === 'Beta Company')).toBe(true);
+    });
+
+    it('should return children ordered by name', () => {
+      const parentResult = repository.createForce({
+        name: 'Parent',
+        forceType: ForceType.Company,
+      });
+
+      repository.createForce({
+        name: 'Charlie Lance',
+        forceType: ForceType.Lance,
+        parentId: parentResult.id,
+      });
+
+      repository.createForce({
+        name: 'Alpha Lance',
+        forceType: ForceType.Lance,
+        parentId: parentResult.id,
+      });
+
+      repository.createForce({
+        name: 'Bravo Lance',
+        forceType: ForceType.Lance,
+        parentId: parentResult.id,
+      });
+
+      const children = repository.getChildForces(parentResult.id!);
+
+      expect(children[0].name).toBe('Alpha Lance');
+      expect(children[1].name).toBe('Bravo Lance');
+      expect(children[2].name).toBe('Charlie Lance');
+    });
+  });
+
+  // ===========================================================================
+  // updateForce Tests
+  // ===========================================================================
+
+  describe('updateForce', () => {
+    it('should update force name', () => {
+      const result = repository.createForce({
+        name: 'Original Name',
+        forceType: ForceType.Lance,
+      });
+
+      const updateResult = repository.updateForce(result.id!, {
+        name: 'Updated Name',
+      });
+
+      expect(updateResult.success).toBe(true);
+      expect(updateResult.id).toBe(result.id);
+
+      const force = repository.getForceById(result.id!);
+      expect(force?.name).toBe('Updated Name');
+    });
+
+    it('should update force type', () => {
+      const result = repository.createForce({
+        name: 'Type Test',
+        forceType: ForceType.Lance,
+      });
+
+      repository.updateForce(result.id!, {
+        forceType: ForceType.Star,
+      });
+
+      const force = repository.getForceById(result.id!);
+      expect(force?.forceType).toBe(ForceType.Star);
+    });
+
+    it('should update force status', () => {
+      const result = repository.createForce({
+        name: 'Status Test',
+        forceType: ForceType.Lance,
+      });
+
+      repository.updateForce(result.id!, {
+        status: ForceStatus.Maintenance,
+      });
+
+      const force = repository.getForceById(result.id!);
+      expect(force?.status).toBe(ForceStatus.Maintenance);
+    });
+
+    it('should update affiliation', () => {
+      const result = repository.createForce({
+        name: 'Affiliation Test',
+        forceType: ForceType.Lance,
+        affiliation: 'House Davion',
+      });
+
+      repository.updateForce(result.id!, {
+        affiliation: 'House Steiner',
+      });
+
+      const force = repository.getForceById(result.id!);
+      expect(force?.affiliation).toBe('House Steiner');
+    });
+
+    it('should clear affiliation when set to empty string', () => {
+      const result = repository.createForce({
+        name: 'Clear Affiliation Test',
+        forceType: ForceType.Lance,
+        affiliation: 'House Liao',
+      });
+
+      // Use empty string to clear - the repository converts falsy values to null in DB
+      repository.updateForce(result.id!, {
+        affiliation: '',
+      });
+
+      const force = repository.getForceById(result.id!);
+      // Note: empty string is stored, but the hydration converts null/empty to undefined
+      expect(force?.affiliation === '' || force?.affiliation === undefined).toBe(true);
+    });
+
+    it('should update description', () => {
+      const result = repository.createForce({
+        name: 'Description Test',
+        forceType: ForceType.Lance,
+      });
+
+      repository.updateForce(result.id!, {
+        description: 'New description',
+      });
+
+      const force = repository.getForceById(result.id!);
+      expect(force?.description).toBe('New description');
+    });
+
+    it('should update parentId', () => {
+      const parentResult = repository.createForce({
+        name: 'New Parent',
+        forceType: ForceType.Company,
+      });
+
+      const childResult = repository.createForce({
+        name: 'Orphan Lance',
+        forceType: ForceType.Lance,
+      });
+
+      repository.updateForce(childResult.id!, {
+        parentId: parentResult.id,
+      });
+
+      const childForce = repository.getForceById(childResult.id!);
+      expect(childForce?.parentId).toBe(parentResult.id);
+
+      const parentForce = repository.getForceById(parentResult.id!);
+      expect(parentForce?.childIds).toContain(childResult.id);
+    });
+
+    it('should remove parentId when set to null', () => {
+      const parentResult = repository.createForce({
+        name: 'Parent',
+        forceType: ForceType.Company,
+      });
+
+      const childResult = repository.createForce({
+        name: 'Child',
+        forceType: ForceType.Lance,
+        parentId: parentResult.id,
+      });
+
+      repository.updateForce(childResult.id!, {
+        parentId: null,
+      });
+
+      const childForce = repository.getForceById(childResult.id!);
+      expect(childForce?.parentId).toBeUndefined();
+    });
+
+    it('should update updatedAt timestamp', async () => {
+      const result = repository.createForce({
+        name: 'Timestamp Test',
+        forceType: ForceType.Lance,
+      });
+
+      const forceBefore = repository.getForceById(result.id!);
+      const createdAt = forceBefore?.createdAt;
+
+      // Wait briefly to ensure timestamp difference
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      repository.updateForce(result.id!, {
+        name: 'New Name',
+      });
+
+      const forceAfter = repository.getForceById(result.id!);
+      // updatedAt should be >= createdAt after update
+      expect(forceAfter?.updatedAt && forceAfter.updatedAt >= createdAt!).toBe(true);
+      // The force should have the new name
+      expect(forceAfter?.name).toBe('New Name');
+    });
+
+    it('should update multiple fields at once', () => {
+      const result = repository.createForce({
+        name: 'Multi Update',
+        forceType: ForceType.Lance,
+      });
+
+      repository.updateForce(result.id!, {
+        name: 'New Name',
+        forceType: ForceType.Star,
+        status: ForceStatus.Transit,
+        affiliation: 'Clan Wolf',
+        description: 'Updated description',
+      });
+
+      const force = repository.getForceById(result.id!);
+      expect(force?.name).toBe('New Name');
+      expect(force?.forceType).toBe(ForceType.Star);
+      expect(force?.status).toBe(ForceStatus.Transit);
+      expect(force?.affiliation).toBe('Clan Wolf');
+      expect(force?.description).toBe('Updated description');
+    });
+
+    it('should prevent circular hierarchy (self-reference)', () => {
+      const result = repository.createForce({
+        name: 'Self Loop',
+        forceType: ForceType.Lance,
+      });
+
+      const updateResult = repository.updateForce(result.id!, {
+        parentId: result.id,
+      });
+
+      expect(updateResult.success).toBe(false);
+      expect(updateResult.errorCode).toBe(ForceErrorCode.CIRCULAR_HIERARCHY);
+    });
+
+    it('should prevent circular hierarchy (indirect loop)', () => {
+      // Create A -> B -> C hierarchy
+      const aResult = repository.createForce({
+        name: 'Force A',
+        forceType: ForceType.Battalion,
+      });
+
+      const bResult = repository.createForce({
+        name: 'Force B',
+        forceType: ForceType.Company,
+        parentId: aResult.id,
+      });
+
+      const cResult = repository.createForce({
+        name: 'Force C',
+        forceType: ForceType.Lance,
+        parentId: bResult.id,
+      });
+
+      // Try to set A's parent to C (would create C -> A -> B -> C loop)
+      const updateResult = repository.updateForce(aResult.id!, {
+        parentId: cResult.id,
+      });
+
+      expect(updateResult.success).toBe(false);
+      expect(updateResult.errorCode).toBe(ForceErrorCode.CIRCULAR_HIERARCHY);
+    });
+  });
+
+  // ===========================================================================
+  // deleteForce Tests
+  // ===========================================================================
+
+  describe('deleteForce', () => {
+    it('should delete existing force', () => {
+      const result = repository.createForce({
+        name: 'To Delete',
+        forceType: ForceType.Lance,
+      });
+
+      const deleteResult = repository.deleteForce(result.id!);
+
+      expect(deleteResult.success).toBe(true);
+
+      const force = repository.getForceById(result.id!);
+      expect(force).toBeNull();
+    });
+
+    it('should delete force assignments', () => {
+      const result = repository.createForce({
+        name: 'Delete Assignments',
+        forceType: ForceType.Lance,
+      });
+
+      const forceBefore = repository.getForceById(result.id!);
+      expect(forceBefore?.assignments.length).toBe(4);
+
+      repository.deleteForce(result.id!);
+
+      // Verify assignments are deleted by checking database directly
+      const db = getSQLiteService().getDatabase();
+      const assignments = db
+        .prepare('SELECT * FROM force_assignments WHERE force_id = ?')
+        .all(result.id);
+      expect(assignments.length).toBe(0);
+    });
+
+    it('should set children parent to null on delete', () => {
+      const parentResult = repository.createForce({
+        name: 'Parent To Delete',
+        forceType: ForceType.Company,
+      });
+
+      const childResult = repository.createForce({
+        name: 'Orphaned Child',
+        forceType: ForceType.Lance,
+        parentId: parentResult.id,
+      });
+
+      repository.deleteForce(parentResult.id!);
+
+      const childForce = repository.getForceById(childResult.id!);
+      expect(childForce).not.toBeNull();
+      expect(childForce?.parentId).toBeUndefined();
+    });
+
+    it('should succeed for non-existent force (idempotent)', () => {
+      const deleteResult = repository.deleteForce('non-existent-id');
+      expect(deleteResult.success).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // updateAssignment Tests
+  // ===========================================================================
+
+  describe('updateAssignment', () => {
+    // Helper to create a test pilot in the database
+    function createTestPilot(id: string): void {
+      const db = getSQLiteService().getDatabase();
+      db.prepare(`
+        INSERT INTO pilots (id, name, gunnery, piloting, type, status, created_at, updated_at)
+        VALUES (?, ?, 4, 5, 'persistent', 'active', datetime('now'), datetime('now'))
+      `).run(id, `Test Pilot ${id}`);
+    }
+
+    it('should update pilot ID', () => {
+      // Create a test pilot first (FK constraint requires valid pilot)
+      createTestPilot('pilot-123');
+
+      const forceResult = repository.createForce({
+        name: 'Assignment Test',
+        forceType: ForceType.Lance,
+      });
+
+      const force = repository.getForceById(forceResult.id!);
+      const assignmentId = force!.assignments[0].id;
+
+      const updateResult = repository.updateAssignment(assignmentId, {
+        pilotId: 'pilot-123',
+      });
+
+      expect(updateResult.success).toBe(true);
+      expect(updateResult.id).toBe(assignmentId);
+
+      const updatedForce = repository.getForceById(forceResult.id!);
+      expect(updatedForce?.assignments[0].pilotId).toBe('pilot-123');
+    });
+
+    it('should update unit ID', () => {
+      const forceResult = repository.createForce({
+        name: 'Unit Assignment Test',
+        forceType: ForceType.Lance,
+      });
+
+      const force = repository.getForceById(forceResult.id!);
+      const assignmentId = force!.assignments[0].id;
+
+      repository.updateAssignment(assignmentId, {
+        unitId: 'unit-456',
+      });
+
+      const updatedForce = repository.getForceById(forceResult.id!);
+      expect(updatedForce?.assignments[0].unitId).toBe('unit-456');
+    });
+
+    it('should update position', () => {
+      const forceResult = repository.createForce({
+        name: 'Position Test',
+        forceType: ForceType.Lance,
+      });
+
+      const force = repository.getForceById(forceResult.id!);
+      const assignmentId = force!.assignments[1].id; // Second slot (member)
+
+      repository.updateAssignment(assignmentId, {
+        position: ForcePosition.Scout,
+      });
+
+      const updatedForce = repository.getForceById(forceResult.id!);
+      expect(updatedForce?.assignments[1].position).toBe(ForcePosition.Scout);
+    });
+
+    it('should update notes', () => {
+      const forceResult = repository.createForce({
+        name: 'Notes Test',
+        forceType: ForceType.Lance,
+      });
+
+      const force = repository.getForceById(forceResult.id!);
+      const assignmentId = force!.assignments[0].id;
+
+      repository.updateAssignment(assignmentId, {
+        notes: 'Veteran pilot',
+      });
+
+      const updatedForce = repository.getForceById(forceResult.id!);
+      expect(updatedForce?.assignments[0].notes).toBe('Veteran pilot');
+    });
+
+    it('should update notes with empty string', () => {
+      const forceResult = repository.createForce({
+        name: 'Clear Notes Test',
+        forceType: ForceType.Lance,
+      });
+
+      const force = repository.getForceById(forceResult.id!);
+      const assignmentId = force!.assignments[0].id;
+
+      // Add notes first
+      repository.updateAssignment(assignmentId, {
+        notes: 'Some notes',
+      });
+
+      // Update with empty string
+      repository.updateAssignment(assignmentId, {
+        notes: '',
+      });
+
+      const updatedForce = repository.getForceById(forceResult.id!);
+      // Empty string stored as-is or converted
+      expect(updatedForce?.assignments[0].notes === '' || updatedForce?.assignments[0].notes === undefined).toBe(true);
+    });
+
+    it('should update multiple fields at once', () => {
+      // Create a test pilot first (FK constraint requires valid pilot)
+      createTestPilot('pilot-multi');
+
+      const forceResult = repository.createForce({
+        name: 'Multi Field Update',
+        forceType: ForceType.Lance,
+      });
+
+      const force = repository.getForceById(forceResult.id!);
+      const assignmentId = force!.assignments[0].id;
+
+      repository.updateAssignment(assignmentId, {
+        pilotId: 'pilot-multi',
+        unitId: 'unit-multi',
+        position: ForcePosition.Commander,
+        notes: 'Commanding officer',
+      });
+
+      const updatedForce = repository.getForceById(forceResult.id!);
+      const assignment = updatedForce?.assignments[0];
+      expect(assignment?.pilotId).toBe('pilot-multi');
+      expect(assignment?.unitId).toBe('unit-multi');
+      expect(assignment?.position).toBe(ForcePosition.Commander);
+      expect(assignment?.notes).toBe('Commanding officer');
+    });
+
+    it('should return error when no updates provided', () => {
+      const forceResult = repository.createForce({
+        name: 'No Update Test',
+        forceType: ForceType.Lance,
+      });
+
+      const force = repository.getForceById(forceResult.id!);
+      const assignmentId = force!.assignments[0].id;
+
+      const updateResult = repository.updateAssignment(assignmentId, {});
+
+      expect(updateResult.success).toBe(false);
+      expect(updateResult.errorCode).toBe(ForceErrorCode.VALIDATION_ERROR);
+      expect(updateResult.error).toBe('No updates provided');
+    });
+
+    it('should update calculated stats after assignment changes', () => {
+      // Create a test pilot first (FK constraint requires valid pilot)
+      createTestPilot('pilot-1');
+
+      const forceResult = repository.createForce({
+        name: 'Stats Update Test',
+        forceType: ForceType.Lance,
+      });
+
+      let force = repository.getForceById(forceResult.id!);
+      expect(force?.stats.assignedPilots).toBe(0);
+      expect(force?.stats.assignedUnits).toBe(0);
+      expect(force?.stats.emptySlots).toBe(4);
+
+      // Assign pilot to first slot
+      repository.updateAssignment(force!.assignments[0].id, {
+        pilotId: 'pilot-1',
+      });
+
+      force = repository.getForceById(forceResult.id!);
+      expect(force?.stats.assignedPilots).toBe(1);
+      expect(force?.stats.emptySlots).toBe(3);
+
+      // Assign unit to first slot
+      repository.updateAssignment(force!.assignments[0].id, {
+        unitId: 'unit-1',
+      });
+
+      force = repository.getForceById(forceResult.id!);
+      expect(force?.stats.assignedUnits).toBe(1);
+      expect(force?.stats.emptySlots).toBe(3);
+    });
+  });
+
+  // ===========================================================================
+  // swapAssignments Tests
+  // ===========================================================================
+
+  describe('swapAssignments', () => {
+    // Helper to create a test pilot in the database
+    function createSwapTestPilot(id: string): void {
+      const db = getSQLiteService().getDatabase();
+      db.prepare(`
+        INSERT INTO pilots (id, name, gunnery, piloting, type, status, created_at, updated_at)
+        VALUES (?, ?, 4, 5, 'persistent', 'active', datetime('now'), datetime('now'))
+      `).run(id, `Test Pilot ${id}`);
+    }
+
+    it('should swap pilot and unit between two assignments', () => {
+      // Create test pilots (FK constraint requires valid pilots)
+      createSwapTestPilot('pilot-A');
+      createSwapTestPilot('pilot-B');
+
+      const forceResult = repository.createForce({
+        name: 'Swap Test',
+        forceType: ForceType.Lance,
+      });
+
+      let force = repository.getForceById(forceResult.id!);
+      const assign1Id = force!.assignments[0].id;
+      const assign2Id = force!.assignments[1].id;
+
+      // Set up assignments
+      repository.updateAssignment(assign1Id, {
+        pilotId: 'pilot-A',
+        unitId: 'unit-A',
+      });
+      repository.updateAssignment(assign2Id, {
+        pilotId: 'pilot-B',
+        unitId: 'unit-B',
+      });
+
+      // Swap
+      const swapResult = repository.swapAssignments(assign1Id, assign2Id);
+
+      expect(swapResult.success).toBe(true);
+
+      force = repository.getForceById(forceResult.id!);
+      expect(force?.assignments[0].pilotId).toBe('pilot-B');
+      expect(force?.assignments[0].unitId).toBe('unit-B');
+      expect(force?.assignments[1].pilotId).toBe('pilot-A');
+      expect(force?.assignments[1].unitId).toBe('unit-A');
+    });
+
+    it('should swap with empty assignment', () => {
+      // Create test pilot (FK constraint requires valid pilot)
+      createSwapTestPilot('pilot-only');
+
+      const forceResult = repository.createForce({
+        name: 'Swap Empty Test',
+        forceType: ForceType.Lance,
+      });
+
+      let force = repository.getForceById(forceResult.id!);
+      const assign1Id = force!.assignments[0].id;
+      const assign2Id = force!.assignments[1].id;
+
+      // Only set up first assignment
+      repository.updateAssignment(assign1Id, {
+        pilotId: 'pilot-only',
+        unitId: 'unit-only',
+      });
+
+      // Swap
+      repository.swapAssignments(assign1Id, assign2Id);
+
+      force = repository.getForceById(forceResult.id!);
+      expect(force?.assignments[0].pilotId).toBeNull();
+      expect(force?.assignments[0].unitId).toBeNull();
+      expect(force?.assignments[1].pilotId).toBe('pilot-only');
+      expect(force?.assignments[1].unitId).toBe('unit-only');
+    });
+
+    it('should return error if first assignment does not exist', () => {
+      const forceResult = repository.createForce({
+        name: 'Invalid Swap 1',
+        forceType: ForceType.Lance,
+      });
+
+      const force = repository.getForceById(forceResult.id!);
+      const validId = force!.assignments[0].id;
+
+      const swapResult = repository.swapAssignments('non-existent-1', validId);
+
+      expect(swapResult.success).toBe(false);
+      expect(swapResult.errorCode).toBe(ForceErrorCode.NOT_FOUND);
+    });
+
+    it('should return error if second assignment does not exist', () => {
+      const forceResult = repository.createForce({
+        name: 'Invalid Swap 2',
+        forceType: ForceType.Lance,
+      });
+
+      const force = repository.getForceById(forceResult.id!);
+      const validId = force!.assignments[0].id;
+
+      const swapResult = repository.swapAssignments(validId, 'non-existent-2');
+
+      expect(swapResult.success).toBe(false);
+      expect(swapResult.errorCode).toBe(ForceErrorCode.NOT_FOUND);
+    });
+
+    it('should return error if both assignments do not exist', () => {
+      const swapResult = repository.swapAssignments('non-existent-1', 'non-existent-2');
+
+      expect(swapResult.success).toBe(false);
+      expect(swapResult.errorCode).toBe(ForceErrorCode.NOT_FOUND);
+    });
+  });
+
+  // ===========================================================================
+  // clearAssignment Tests
+  // ===========================================================================
+
+  describe('clearAssignment', () => {
+    // Helper to create a test pilot in the database
+    function createClearTestPilot(id: string): void {
+      const db = getSQLiteService().getDatabase();
+      db.prepare(`
+        INSERT INTO pilots (id, name, gunnery, piloting, type, status, created_at, updated_at)
+        VALUES (?, ?, 4, 5, 'persistent', 'active', datetime('now'), datetime('now'))
+      `).run(id, `Test Pilot ${id}`);
+    }
+
+    it('should clear pilot and unit from assignment', () => {
+      // Create test pilot (FK constraint requires valid pilot)
+      createClearTestPilot('pilot-to-clear');
+
+      const forceResult = repository.createForce({
+        name: 'Clear Test',
+        forceType: ForceType.Lance,
+      });
+
+      let force = repository.getForceById(forceResult.id!);
+      const assignmentId = force!.assignments[0].id;
+
+      // Set up assignment
+      repository.updateAssignment(assignmentId, {
+        pilotId: 'pilot-to-clear',
+        unitId: 'unit-to-clear',
+      });
+
+      // Clear
+      const clearResult = repository.clearAssignment(assignmentId);
+
+      expect(clearResult.success).toBe(true);
+      expect(clearResult.id).toBe(assignmentId);
+
+      force = repository.getForceById(forceResult.id!);
+      expect(force?.assignments[0].pilotId).toBeNull();
+      expect(force?.assignments[0].unitId).toBeNull();
+    });
+
+    it('should preserve position and notes when clearing', () => {
+      // Create test pilot (FK constraint requires valid pilot)
+      createClearTestPilot('pilot-x');
+
+      const forceResult = repository.createForce({
+        name: 'Preserve Test',
+        forceType: ForceType.Lance,
+      });
+
+      let force = repository.getForceById(forceResult.id!);
+      const assignmentId = force!.assignments[0].id;
+
+      // First update position and notes separately (they don't require pilot FK)
+      repository.updateAssignment(assignmentId, {
+        position: ForcePosition.Commander,
+        notes: 'Important notes',
+      });
+
+      // Then assign pilot and unit
+      repository.updateAssignment(assignmentId, {
+        pilotId: 'pilot-x',
+        unitId: 'unit-x',
+      });
+
+      // Clear
+      repository.clearAssignment(assignmentId);
+
+      force = repository.getForceById(forceResult.id!);
+      const assignment = force?.assignments[0];
+      expect(assignment?.pilotId).toBeNull();
+      expect(assignment?.unitId).toBeNull();
+      // Position and notes should be preserved
+      expect(assignment?.position).toBe(ForcePosition.Commander);
+      expect(assignment?.notes).toBe('Important notes');
+    });
+
+    it('should succeed for already empty assignment', () => {
+      const forceResult = repository.createForce({
+        name: 'Already Empty',
+        forceType: ForceType.Lance,
+      });
+
+      const force = repository.getForceById(forceResult.id!);
+      const assignmentId = force!.assignments[0].id;
+
+      const clearResult = repository.clearAssignment(assignmentId);
+
+      expect(clearResult.success).toBe(true);
+    });
+
+    it('should update stats after clearing', () => {
+      // Create test pilot (FK constraint requires valid pilot)
+      createClearTestPilot('pilot-stats');
+
+      const forceResult = repository.createForce({
+        name: 'Stats Clear Test',
+        forceType: ForceType.Lance,
+      });
+
+      let force = repository.getForceById(forceResult.id!);
+      const assignmentId = force!.assignments[0].id;
+
+      // Assign pilot and unit
+      repository.updateAssignment(assignmentId, {
+        pilotId: 'pilot-stats',
+        unitId: 'unit-stats',
+      });
+
+      force = repository.getForceById(forceResult.id!);
+      expect(force?.stats.assignedPilots).toBe(1);
+      expect(force?.stats.assignedUnits).toBe(1);
+
+      // Clear
+      repository.clearAssignment(assignmentId);
+
+      force = repository.getForceById(forceResult.id!);
+      expect(force?.stats.assignedPilots).toBe(0);
+      expect(force?.stats.assignedUnits).toBe(0);
+      expect(force?.stats.emptySlots).toBe(4);
+    });
+  });
+
+  // ===========================================================================
+  // getForceRepository Singleton Tests
+  // ===========================================================================
+
+  describe('getForceRepository', () => {
+    it('should return a ForceRepository instance', () => {
+      const repo = getForceRepository();
+      expect(repo).toBeInstanceOf(ForceRepository);
+    });
+
+    it('should return the same instance on multiple calls', () => {
+      const repo1 = getForceRepository();
+      const repo2 = getForceRepository();
+      expect(repo1).toBe(repo2);
+    });
+  });
+
+  // ===========================================================================
+  // Edge Cases and Error Handling
+  // ===========================================================================
+
+  describe('edge cases', () => {
+    it('should handle special characters in force name', () => {
+      const result = repository.createForce({
+        name: "Wolf's Dragoons - Alpha & Beta",
+        forceType: ForceType.Lance,
+        description: 'Unit with "quotes" and \'apostrophes\'',
+      });
+
+      expect(result.success).toBe(true);
+
+      const force = repository.getForceById(result.id!);
+      expect(force?.name).toBe("Wolf's Dragoons - Alpha & Beta");
+      expect(force?.description).toBe('Unit with "quotes" and \'apostrophes\'');
+    });
+
+    it('should handle unicode characters', () => {
+      const result = repository.createForce({
+        name: 'Clanners \u00FC\u00F6\u00E4',
+        forceType: ForceType.Star,
+      });
+
+      expect(result.success).toBe(true);
+
+      const force = repository.getForceById(result.id!);
+      expect(force?.name).toBe('Clanners \u00FC\u00F6\u00E4');
+    });
+
+    it('should handle empty string name', () => {
+      const result = repository.createForce({
+        name: '',
+        forceType: ForceType.Lance,
+      });
+
+      // Empty names are allowed at repository level
+      expect(result.success).toBe(true);
+    });
+
+    it('should handle very long name', () => {
+      const longName = 'A'.repeat(1000);
+      const result = repository.createForce({
+        name: longName,
+        forceType: ForceType.Lance,
+      });
+
+      expect(result.success).toBe(true);
+
+      const force = repository.getForceById(result.id!);
+      expect(force?.name).toBe(longName);
+    });
+
+    it('should handle Binary force type with 10 assignments', () => {
+      const result = repository.createForce({
+        name: 'Binary Test',
+        forceType: ForceType.Binary,
+      });
+
+      const force = repository.getForceById(result.id!);
+      expect(force?.assignments.length).toBe(10);
+    });
+
+    it('should handle Custom force type with 4 assignments', () => {
+      const result = repository.createForce({
+        name: 'Custom Force',
+        forceType: ForceType.Custom,
+      });
+
+      const force = repository.getForceById(result.id!);
+      expect(force?.assignments.length).toBe(4);
+    });
+  });
+});

--- a/src/services/pilots/__tests__/PilotRepository.test.ts
+++ b/src/services/pilots/__tests__/PilotRepository.test.ts
@@ -1,0 +1,1103 @@
+/**
+ * Pilot Repository Tests
+ *
+ * Comprehensive unit tests for the SQLite-based pilot repository.
+ * Tests all CRUD operations, career tracking, abilities, and XP management.
+ */
+
+import {
+  PilotRepository,
+  getPilotRepository,
+  resetPilotRepository,
+  PilotErrorCode,
+} from '../PilotRepository';
+import {
+  getSQLiteService,
+  resetSQLiteService,
+} from '@/services/persistence/SQLiteService';
+import {
+  PilotType,
+  PilotStatus,
+  ICreatePilotOptions,
+  DEFAULT_PILOT_SKILLS,
+} from '@/types/pilot';
+import fs from 'fs';
+import path from 'path';
+
+// Test database path
+const TEST_DB_PATH = './data/test-pilot-repository.db';
+
+describe('PilotRepository', () => {
+  let repository: PilotRepository;
+
+  // Helper to create valid pilot options
+  const createPilotOptions = (
+    overrides: Partial<ICreatePilotOptions> = {}
+  ): ICreatePilotOptions => ({
+    identity: {
+      name: 'Test Pilot',
+      callsign: 'Tester',
+      affiliation: 'Davion',
+      portrait: 'portrait-001',
+      background: 'A test pilot background',
+    },
+    type: PilotType.Persistent,
+    skills: DEFAULT_PILOT_SKILLS,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    // Clean up any existing test database
+    if (fs.existsSync(TEST_DB_PATH)) {
+      fs.unlinkSync(TEST_DB_PATH);
+    }
+
+    // Ensure data directory exists
+    const dataDir = path.dirname(TEST_DB_PATH);
+    if (!fs.existsSync(dataDir)) {
+      fs.mkdirSync(dataDir, { recursive: true });
+    }
+
+    // Reset singletons
+    resetSQLiteService();
+    resetPilotRepository();
+
+    // Initialize with test database
+    const sqliteService = getSQLiteService({ path: TEST_DB_PATH });
+    sqliteService.initialize();
+
+    repository = getPilotRepository();
+  });
+
+  afterEach(() => {
+    // Close database and clean up
+    resetSQLiteService();
+    resetPilotRepository();
+
+    if (fs.existsSync(TEST_DB_PATH)) {
+      fs.unlinkSync(TEST_DB_PATH);
+    }
+  });
+
+  // ===========================================================================
+  // create() tests
+  // ===========================================================================
+
+  describe('create', () => {
+    it('should create a new pilot with default skills', () => {
+      const options = createPilotOptions();
+      const result = repository.create(options);
+
+      expect(result.success).toBe(true);
+      expect(result.id).toBeDefined();
+      expect(result.id).toMatch(/^pilot-/);
+    });
+
+    it('should create a pilot with custom skills', () => {
+      const options = createPilotOptions({
+        skills: { gunnery: 3, piloting: 4 },
+      });
+      const result = repository.create(options);
+
+      expect(result.success).toBe(true);
+
+      const pilot = repository.getById(result.id!);
+      expect(pilot?.skills.gunnery).toBe(3);
+      expect(pilot?.skills.piloting).toBe(4);
+    });
+
+    it('should create a pilot with starting XP', () => {
+      const options = createPilotOptions({
+        startingXp: 100,
+      });
+      const result = repository.create(options);
+
+      expect(result.success).toBe(true);
+
+      const pilot = repository.getById(result.id!);
+      expect(pilot?.career?.xp).toBe(100);
+      expect(pilot?.career?.totalXpEarned).toBe(100);
+    });
+
+    it('should create a pilot with initial abilities', () => {
+      const options = createPilotOptions({
+        abilityIds: ['marksman', 'dodge'],
+      });
+      const result = repository.create(options);
+
+      expect(result.success).toBe(true);
+
+      const pilot = repository.getById(result.id!);
+      expect(pilot?.abilities).toHaveLength(2);
+      expect(pilot?.abilities.map((a) => a.abilityId)).toContain('marksman');
+      expect(pilot?.abilities.map((a) => a.abilityId)).toContain('dodge');
+    });
+
+    it('should create a pilot with a rank', () => {
+      const options = createPilotOptions({
+        rank: 'Lieutenant',
+      });
+      const result = repository.create(options);
+
+      expect(result.success).toBe(true);
+
+      const pilot = repository.getById(result.id!);
+      expect(pilot?.career?.rank).toBe('Lieutenant');
+    });
+
+    it('should create a pilot with all identity fields', () => {
+      const options = createPilotOptions({
+        identity: {
+          name: 'John Smith',
+          callsign: 'Ghost',
+          affiliation: 'Steiner',
+          portrait: 'portrait-123',
+          background: 'Veteran of the Clan Invasion',
+        },
+      });
+      const result = repository.create(options);
+
+      expect(result.success).toBe(true);
+
+      const pilot = repository.getById(result.id!);
+      expect(pilot?.name).toBe('John Smith');
+      expect(pilot?.callsign).toBe('Ghost');
+      expect(pilot?.affiliation).toBe('Steiner');
+      expect(pilot?.portrait).toBe('portrait-123');
+      expect(pilot?.background).toBe('Veteran of the Clan Invasion');
+    });
+
+    it('should create a statblock pilot', () => {
+      const options = createPilotOptions({
+        type: PilotType.Statblock,
+      });
+      const result = repository.create(options);
+
+      expect(result.success).toBe(true);
+
+      const pilot = repository.getById(result.id!);
+      expect(pilot?.type).toBe(PilotType.Statblock);
+      // Statblock pilots should not have career data
+      expect(pilot?.career).toBeUndefined();
+    });
+
+    it('should create a pilot with minimal identity (name only)', () => {
+      const options: ICreatePilotOptions = {
+        identity: { name: 'Minimal Pilot' },
+        type: PilotType.Persistent,
+        skills: DEFAULT_PILOT_SKILLS,
+      };
+      const result = repository.create(options);
+
+      expect(result.success).toBe(true);
+
+      const pilot = repository.getById(result.id!);
+      expect(pilot?.name).toBe('Minimal Pilot');
+      expect(pilot?.callsign).toBeUndefined();
+      expect(pilot?.affiliation).toBeUndefined();
+    });
+
+    it('should set initial status to Active', () => {
+      const result = repository.create(createPilotOptions());
+
+      const pilot = repository.getById(result.id!);
+      expect(pilot?.status).toBe(PilotStatus.Active);
+    });
+
+    it('should set initial wounds to 0', () => {
+      const result = repository.create(createPilotOptions());
+
+      const pilot = repository.getById(result.id!);
+      expect(pilot?.wounds).toBe(0);
+    });
+
+    it('should set createdAt and updatedAt timestamps', () => {
+      const beforeCreate = new Date().toISOString();
+      const result = repository.create(createPilotOptions());
+      const afterCreate = new Date().toISOString();
+
+      const pilot = repository.getById(result.id!);
+      expect(pilot).not.toBeNull();
+      expect(pilot!.createdAt).toBeDefined();
+      expect(pilot!.updatedAt).toBeDefined();
+      expect(pilot!.createdAt >= beforeCreate).toBe(true);
+      expect(pilot!.createdAt <= afterCreate).toBe(true);
+    });
+
+    it('should initialize career stats to zero for persistent pilots', () => {
+      const result = repository.create(createPilotOptions());
+
+      const pilot = repository.getById(result.id!);
+      expect(pilot?.career?.missionsCompleted).toBe(0);
+      expect(pilot?.career?.victories).toBe(0);
+      expect(pilot?.career?.defeats).toBe(0);
+      expect(pilot?.career?.draws).toBe(0);
+      expect(pilot?.career?.totalKills).toBe(0);
+      expect(pilot?.career?.killRecords).toHaveLength(0);
+      expect(pilot?.career?.missionHistory).toHaveLength(0);
+    });
+  });
+
+  // ===========================================================================
+  // getById() tests
+  // ===========================================================================
+
+  describe('getById', () => {
+    it('should return null for non-existent pilot', () => {
+      const pilot = repository.getById('non-existent-id');
+      expect(pilot).toBeNull();
+    });
+
+    it('should return the pilot after creation', () => {
+      const createResult = repository.create(createPilotOptions());
+      const pilot = repository.getById(createResult.id!);
+
+      expect(pilot).not.toBeNull();
+      expect(pilot?.id).toBe(createResult.id);
+    });
+
+    it('should return pilot with all abilities loaded', () => {
+      const createResult = repository.create(
+        createPilotOptions({ abilityIds: ['marksman', 'dodge', 'toughness'] })
+      );
+
+      const pilot = repository.getById(createResult.id!);
+
+      expect(pilot?.abilities).toHaveLength(3);
+      pilot?.abilities.forEach((ability) => {
+        expect(ability.abilityId).toBeDefined();
+        expect(ability.acquiredDate).toBeDefined();
+      });
+    });
+
+    it('should return pilot with career data for persistent pilots', () => {
+      const createResult = repository.create(
+        createPilotOptions({ startingXp: 50 })
+      );
+
+      const pilot = repository.getById(createResult.id!);
+
+      expect(pilot?.career).toBeDefined();
+      expect(pilot?.career?.xp).toBe(50);
+      expect(pilot?.career?.rank).toBe('MechWarrior'); // Default rank
+    });
+  });
+
+  // ===========================================================================
+  // update() tests
+  // ===========================================================================
+
+  describe('update', () => {
+    it('should update pilot name', () => {
+      const createResult = repository.create(createPilotOptions());
+      const updateResult = repository.update(createResult.id!, {
+        name: 'Updated Name',
+      });
+
+      expect(updateResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.name).toBe('Updated Name');
+    });
+
+    it('should update pilot callsign', () => {
+      const createResult = repository.create(createPilotOptions());
+      const updateResult = repository.update(createResult.id!, {
+        callsign: 'NewCallsign',
+      });
+
+      expect(updateResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.callsign).toBe('NewCallsign');
+    });
+
+    it('should update pilot affiliation', () => {
+      const createResult = repository.create(createPilotOptions());
+      const updateResult = repository.update(createResult.id!, {
+        affiliation: 'Liao',
+      });
+
+      expect(updateResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.affiliation).toBe('Liao');
+    });
+
+    it('should update pilot portrait', () => {
+      const createResult = repository.create(createPilotOptions());
+      const updateResult = repository.update(createResult.id!, {
+        portrait: 'new-portrait',
+      });
+
+      expect(updateResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.portrait).toBe('new-portrait');
+    });
+
+    it('should update pilot background', () => {
+      const createResult = repository.create(createPilotOptions());
+      const updateResult = repository.update(createResult.id!, {
+        background: 'New background story',
+      });
+
+      expect(updateResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.background).toBe('New background story');
+    });
+
+    it('should update pilot status', () => {
+      const createResult = repository.create(createPilotOptions());
+      const updateResult = repository.update(createResult.id!, {
+        status: PilotStatus.Injured,
+      });
+
+      expect(updateResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.status).toBe(PilotStatus.Injured);
+    });
+
+    it('should update pilot skills', () => {
+      const createResult = repository.create(createPilotOptions());
+      const updateResult = repository.update(createResult.id!, {
+        skills: { gunnery: 2, piloting: 3 },
+      });
+
+      expect(updateResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.skills.gunnery).toBe(2);
+      expect(pilot?.skills.piloting).toBe(3);
+    });
+
+    it('should update pilot wounds', () => {
+      const createResult = repository.create(createPilotOptions());
+      const updateResult = repository.update(createResult.id!, {
+        wounds: 3,
+      });
+
+      expect(updateResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.wounds).toBe(3);
+    });
+
+    it('should update updatedAt timestamp', () => {
+      const createResult = repository.create(createPilotOptions());
+      const pilotBefore = repository.getById(createResult.id!);
+
+      // updatedAt should be set and a valid ISO date
+      expect(pilotBefore?.updatedAt).toBeDefined();
+
+      repository.update(createResult.id!, { name: 'Updated' });
+
+      const pilotAfter = repository.getById(createResult.id!);
+      expect(pilotAfter?.updatedAt).toBeDefined();
+      // updatedAt should be >= createdAt after update
+      expect(pilotAfter!.updatedAt >= pilotBefore!.createdAt).toBe(true);
+    });
+
+    it('should return success with no changes when no fields provided', () => {
+      const createResult = repository.create(createPilotOptions());
+      const updateResult = repository.update(createResult.id!, {});
+
+      expect(updateResult.success).toBe(true);
+      expect(updateResult.id).toBe(createResult.id);
+    });
+
+    it('should return error for non-existent pilot', () => {
+      const result = repository.update('non-existent-id', { name: 'Test' });
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe(PilotErrorCode.NOT_FOUND);
+    });
+
+    it('should clear optional fields when set to empty string', () => {
+      const createResult = repository.create(
+        createPilotOptions({
+          identity: {
+            name: 'Test',
+            callsign: 'Original',
+          },
+        })
+      );
+
+      repository.update(createResult.id!, { callsign: '' });
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.callsign).toBeUndefined();
+    });
+
+    it('should update multiple fields at once', () => {
+      const createResult = repository.create(createPilotOptions());
+      const updateResult = repository.update(createResult.id!, {
+        name: 'New Name',
+        callsign: 'New Callsign',
+        status: PilotStatus.MIA,
+        wounds: 2,
+      });
+
+      expect(updateResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.name).toBe('New Name');
+      expect(pilot?.callsign).toBe('New Callsign');
+      expect(pilot?.status).toBe(PilotStatus.MIA);
+      expect(pilot?.wounds).toBe(2);
+    });
+  });
+
+  // ===========================================================================
+  // delete() tests
+  // ===========================================================================
+
+  describe('delete', () => {
+    it('should delete existing pilot', () => {
+      const createResult = repository.create(createPilotOptions());
+      const deleteResult = repository.delete(createResult.id!);
+
+      expect(deleteResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot).toBeNull();
+    });
+
+    it('should return error for non-existent pilot', () => {
+      const result = repository.delete('non-existent-id');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe(PilotErrorCode.NOT_FOUND);
+    });
+
+    it('should return id in result on successful delete', () => {
+      const createResult = repository.create(createPilotOptions());
+      const deleteResult = repository.delete(createResult.id!);
+
+      expect(deleteResult.id).toBe(createResult.id);
+    });
+  });
+
+  // ===========================================================================
+  // list() tests
+  // ===========================================================================
+
+  describe('list', () => {
+    it('should return empty array when no pilots', () => {
+      const pilots = repository.list();
+      expect(pilots).toEqual([]);
+    });
+
+    it('should return all pilots', () => {
+      repository.create(
+        createPilotOptions({ identity: { name: 'Pilot Alpha' } })
+      );
+      repository.create(
+        createPilotOptions({ identity: { name: 'Pilot Beta' } })
+      );
+      repository.create(
+        createPilotOptions({ identity: { name: 'Pilot Gamma' } })
+      );
+
+      const pilots = repository.list();
+
+      expect(pilots).toHaveLength(3);
+    });
+
+    it('should return pilots sorted by name', () => {
+      repository.create(
+        createPilotOptions({ identity: { name: 'Zeta Pilot' } })
+      );
+      repository.create(
+        createPilotOptions({ identity: { name: 'Alpha Pilot' } })
+      );
+      repository.create(
+        createPilotOptions({ identity: { name: 'Mike Pilot' } })
+      );
+
+      const pilots = repository.list();
+
+      expect(pilots[0].name).toBe('Alpha Pilot');
+      expect(pilots[1].name).toBe('Mike Pilot');
+      expect(pilots[2].name).toBe('Zeta Pilot');
+    });
+
+    it('should return readonly array', () => {
+      repository.create(createPilotOptions());
+
+      const pilots = repository.list();
+
+      expect(Array.isArray(pilots)).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // listByStatus() tests
+  // ===========================================================================
+
+  describe('listByStatus', () => {
+    beforeEach(() => {
+      // Create pilots with different statuses
+      repository.create(
+        createPilotOptions({ identity: { name: 'Active Pilot 1' } })
+      );
+      repository.create(
+        createPilotOptions({ identity: { name: 'Active Pilot 2' } })
+      );
+      const pilot3 = repository.create(
+        createPilotOptions({ identity: { name: 'Injured Pilot' } })
+      );
+      const pilot4 = repository.create(
+        createPilotOptions({ identity: { name: 'KIA Pilot' } })
+      );
+
+      repository.update(pilot3.id!, { status: PilotStatus.Injured });
+      repository.update(pilot4.id!, { status: PilotStatus.KIA });
+    });
+
+    it('should return only pilots with matching status', () => {
+      const activePilots = repository.listByStatus(PilotStatus.Active);
+
+      expect(activePilots).toHaveLength(2);
+      activePilots.forEach((pilot) => {
+        expect(pilot.status).toBe(PilotStatus.Active);
+      });
+    });
+
+    it('should return empty array when no pilots match status', () => {
+      const miaPilots = repository.listByStatus(PilotStatus.MIA);
+
+      expect(miaPilots).toHaveLength(0);
+    });
+
+    it('should return injured pilots', () => {
+      const injuredPilots = repository.listByStatus(PilotStatus.Injured);
+
+      expect(injuredPilots).toHaveLength(1);
+      expect(injuredPilots[0].name).toBe('Injured Pilot');
+    });
+
+    it('should return KIA pilots', () => {
+      const kiaPilots = repository.listByStatus(PilotStatus.KIA);
+
+      expect(kiaPilots).toHaveLength(1);
+      expect(kiaPilots[0].name).toBe('KIA Pilot');
+    });
+
+    it('should return pilots sorted by name', () => {
+      const activePilots = repository.listByStatus(PilotStatus.Active);
+
+      expect(activePilots[0].name).toBe('Active Pilot 1');
+      expect(activePilots[1].name).toBe('Active Pilot 2');
+    });
+  });
+
+  // ===========================================================================
+  // exists() tests
+  // ===========================================================================
+
+  describe('exists', () => {
+    it('should return true for existing pilot', () => {
+      const createResult = repository.create(createPilotOptions());
+
+      expect(repository.exists(createResult.id!)).toBe(true);
+    });
+
+    it('should return false for non-existent pilot', () => {
+      expect(repository.exists('non-existent-id')).toBe(false);
+    });
+
+    it('should return false after pilot is deleted', () => {
+      const createResult = repository.create(createPilotOptions());
+      repository.delete(createResult.id!);
+
+      expect(repository.exists(createResult.id!)).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // addAbility() tests
+  // ===========================================================================
+
+  describe('addAbility', () => {
+    it('should add ability to pilot', () => {
+      const createResult = repository.create(createPilotOptions());
+      const addResult = repository.addAbility(createResult.id!, 'marksman');
+
+      expect(addResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.abilities).toHaveLength(1);
+      expect(pilot?.abilities[0].abilityId).toBe('marksman');
+    });
+
+    it('should set acquiredDate on ability', () => {
+      const beforeAdd = new Date().toISOString();
+      const createResult = repository.create(createPilotOptions());
+      repository.addAbility(createResult.id!, 'marksman');
+      const afterAdd = new Date().toISOString();
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot).not.toBeNull();
+      expect(pilot!.abilities[0].acquiredDate).toBeDefined();
+      expect(pilot!.abilities[0].acquiredDate >= beforeAdd).toBe(true);
+      expect(pilot!.abilities[0].acquiredDate <= afterAdd).toBe(true);
+    });
+
+    it('should set acquiredGameId when provided', () => {
+      const createResult = repository.create(createPilotOptions());
+      repository.addAbility(createResult.id!, 'marksman', 'game-123');
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.abilities[0].acquiredGameId).toBe('game-123');
+    });
+
+    it('should not set acquiredGameId when not provided', () => {
+      const createResult = repository.create(createPilotOptions());
+      repository.addAbility(createResult.id!, 'marksman');
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.abilities[0].acquiredGameId).toBeUndefined();
+    });
+
+    it('should return error for non-existent pilot', () => {
+      const result = repository.addAbility('non-existent-id', 'marksman');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe(PilotErrorCode.NOT_FOUND);
+    });
+
+    it('should allow adding multiple abilities', () => {
+      const createResult = repository.create(createPilotOptions());
+      repository.addAbility(createResult.id!, 'marksman');
+      repository.addAbility(createResult.id!, 'dodge');
+      repository.addAbility(createResult.id!, 'toughness');
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.abilities).toHaveLength(3);
+    });
+  });
+
+  // ===========================================================================
+  // removeAbility() tests
+  // ===========================================================================
+
+  describe('removeAbility', () => {
+    it('should remove ability from pilot', () => {
+      const createResult = repository.create(
+        createPilotOptions({ abilityIds: ['marksman', 'dodge'] })
+      );
+      const removeResult = repository.removeAbility(
+        createResult.id!,
+        'marksman'
+      );
+
+      expect(removeResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.abilities).toHaveLength(1);
+      expect(pilot?.abilities[0].abilityId).toBe('dodge');
+    });
+
+    it('should succeed even if ability does not exist on pilot', () => {
+      const createResult = repository.create(createPilotOptions());
+      const removeResult = repository.removeAbility(
+        createResult.id!,
+        'non-existent-ability'
+      );
+
+      expect(removeResult.success).toBe(true);
+    });
+
+    it('should return pilot id in result', () => {
+      const createResult = repository.create(
+        createPilotOptions({ abilityIds: ['marksman'] })
+      );
+      const removeResult = repository.removeAbility(
+        createResult.id!,
+        'marksman'
+      );
+
+      expect(removeResult.id).toBe(createResult.id);
+    });
+  });
+
+  // ===========================================================================
+  // recordKill() tests
+  // ===========================================================================
+
+  describe('recordKill', () => {
+    it('should record a kill for pilot', () => {
+      const createResult = repository.create(createPilotOptions());
+      const killResult = repository.recordKill(createResult.id!, {
+        targetId: 'unit-123',
+        targetName: 'Atlas AS7-D',
+        weaponUsed: 'AC/20',
+        gameId: 'game-456',
+      });
+
+      expect(killResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.career?.totalKills).toBe(1);
+      expect(pilot?.career?.killRecords).toHaveLength(1);
+      expect(pilot?.career?.killRecords[0].targetName).toBe('Atlas AS7-D');
+      expect(pilot?.career?.killRecords[0].weaponUsed).toBe('AC/20');
+    });
+
+    it('should set kill date automatically', () => {
+      const beforeKill = new Date().toISOString();
+      const createResult = repository.create(createPilotOptions());
+      repository.recordKill(createResult.id!, {
+        targetId: 'unit-123',
+        targetName: 'Atlas AS7-D',
+        weaponUsed: 'AC/20',
+        gameId: 'game-456',
+      });
+      const afterKill = new Date().toISOString();
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot).not.toBeNull();
+      expect(pilot!.career).toBeDefined();
+      expect(pilot!.career!.killRecords[0].date >= beforeKill).toBe(true);
+      expect(pilot!.career!.killRecords[0].date <= afterKill).toBe(true);
+    });
+
+    it('should increment total kills counter', () => {
+      const createResult = repository.create(createPilotOptions());
+
+      repository.recordKill(createResult.id!, {
+        targetId: 'unit-1',
+        targetName: 'Target 1',
+        weaponUsed: 'PPC',
+        gameId: 'game-1',
+      });
+      repository.recordKill(createResult.id!, {
+        targetId: 'unit-2',
+        targetName: 'Target 2',
+        weaponUsed: 'LRM',
+        gameId: 'game-1',
+      });
+      repository.recordKill(createResult.id!, {
+        targetId: 'unit-3',
+        targetName: 'Target 3',
+        weaponUsed: 'AC/10',
+        gameId: 'game-2',
+      });
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.career?.totalKills).toBe(3);
+    });
+
+    it('should return error for non-existent pilot', () => {
+      const result = repository.recordKill('non-existent-id', {
+        targetId: 'unit-123',
+        targetName: 'Target',
+        weaponUsed: 'PPC',
+        gameId: 'game-456',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe(PilotErrorCode.NOT_FOUND);
+    });
+  });
+
+  // ===========================================================================
+  // recordMission() tests
+  // ===========================================================================
+
+  describe('recordMission', () => {
+    it('should record a victory mission', () => {
+      const createResult = repository.create(createPilotOptions());
+      const missionResult = repository.recordMission(createResult.id!, {
+        gameId: 'game-123',
+        missionName: 'Battle of Tukayyid',
+        outcome: 'victory',
+        xpEarned: 25,
+        kills: 2,
+      });
+
+      expect(missionResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.career?.missionsCompleted).toBe(1);
+      expect(pilot?.career?.victories).toBe(1);
+      expect(pilot?.career?.defeats).toBe(0);
+      expect(pilot?.career?.draws).toBe(0);
+    });
+
+    it('should record a defeat mission', () => {
+      const createResult = repository.create(createPilotOptions());
+      repository.recordMission(createResult.id!, {
+        gameId: 'game-123',
+        missionName: 'Defense of Luthien',
+        outcome: 'defeat',
+        xpEarned: 10,
+        kills: 0,
+      });
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.career?.missionsCompleted).toBe(1);
+      expect(pilot?.career?.victories).toBe(0);
+      expect(pilot?.career?.defeats).toBe(1);
+    });
+
+    it('should record a draw mission', () => {
+      const createResult = repository.create(createPilotOptions());
+      repository.recordMission(createResult.id!, {
+        gameId: 'game-123',
+        missionName: 'Raid on Solaris',
+        outcome: 'draw',
+        xpEarned: 15,
+        kills: 1,
+      });
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.career?.missionsCompleted).toBe(1);
+      expect(pilot?.career?.draws).toBe(1);
+    });
+
+    it('should add XP from mission', () => {
+      const createResult = repository.create(
+        createPilotOptions({ startingXp: 50 })
+      );
+      repository.recordMission(createResult.id!, {
+        gameId: 'game-123',
+        missionName: 'Test Mission',
+        outcome: 'victory',
+        xpEarned: 30,
+        kills: 1,
+      });
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.career?.xp).toBe(80);
+      expect(pilot?.career?.totalXpEarned).toBe(80);
+    });
+
+    it('should record mission in history', () => {
+      const createResult = repository.create(createPilotOptions());
+      repository.recordMission(createResult.id!, {
+        gameId: 'game-123',
+        missionName: 'Test Mission',
+        outcome: 'victory',
+        xpEarned: 25,
+        kills: 2,
+      });
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.career?.missionHistory).toHaveLength(1);
+      expect(pilot?.career?.missionHistory[0].missionName).toBe('Test Mission');
+      expect(pilot?.career?.missionHistory[0].outcome).toBe('victory');
+      expect(pilot?.career?.missionHistory[0].xpEarned).toBe(25);
+      expect(pilot?.career?.missionHistory[0].kills).toBe(2);
+    });
+
+    it('should set mission date automatically', () => {
+      const beforeMission = new Date().toISOString();
+      const createResult = repository.create(createPilotOptions());
+      repository.recordMission(createResult.id!, {
+        gameId: 'game-123',
+        missionName: 'Test Mission',
+        outcome: 'victory',
+        xpEarned: 25,
+        kills: 0,
+      });
+      const afterMission = new Date().toISOString();
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot).not.toBeNull();
+      expect(pilot!.career).toBeDefined();
+      expect(pilot!.career!.missionHistory[0].date >= beforeMission).toBe(true);
+      expect(pilot!.career!.missionHistory[0].date <= afterMission).toBe(true);
+    });
+
+    it('should return error for non-existent pilot', () => {
+      const result = repository.recordMission('non-existent-id', {
+        gameId: 'game-123',
+        missionName: 'Test',
+        outcome: 'victory',
+        xpEarned: 10,
+        kills: 0,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe(PilotErrorCode.NOT_FOUND);
+    });
+
+    it('should accumulate multiple missions', () => {
+      const createResult = repository.create(createPilotOptions());
+
+      repository.recordMission(createResult.id!, {
+        gameId: 'game-1',
+        missionName: 'Mission 1',
+        outcome: 'victory',
+        xpEarned: 25,
+        kills: 2,
+      });
+      repository.recordMission(createResult.id!, {
+        gameId: 'game-2',
+        missionName: 'Mission 2',
+        outcome: 'defeat',
+        xpEarned: 10,
+        kills: 0,
+      });
+      repository.recordMission(createResult.id!, {
+        gameId: 'game-3',
+        missionName: 'Mission 3',
+        outcome: 'victory',
+        xpEarned: 30,
+        kills: 3,
+      });
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.career?.missionsCompleted).toBe(3);
+      expect(pilot?.career?.victories).toBe(2);
+      expect(pilot?.career?.defeats).toBe(1);
+      expect(pilot?.career?.xp).toBe(65);
+      expect(pilot?.career?.missionHistory).toHaveLength(3);
+    });
+  });
+
+  // ===========================================================================
+  // addXp() tests
+  // ===========================================================================
+
+  describe('addXp', () => {
+    it('should add XP to pilot', () => {
+      const createResult = repository.create(
+        createPilotOptions({ startingXp: 50 })
+      );
+      const addResult = repository.addXp(createResult.id!, 25);
+
+      expect(addResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.career?.xp).toBe(75);
+      expect(pilot?.career?.totalXpEarned).toBe(75);
+    });
+
+    it('should add XP to pilot with zero XP', () => {
+      const createResult = repository.create(createPilotOptions());
+      repository.addXp(createResult.id!, 100);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.career?.xp).toBe(100);
+    });
+
+    it('should return error for non-existent pilot', () => {
+      const result = repository.addXp('non-existent-id', 50);
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe(PilotErrorCode.NOT_FOUND);
+    });
+
+    it('should accumulate multiple XP additions', () => {
+      const createResult = repository.create(createPilotOptions());
+      repository.addXp(createResult.id!, 10);
+      repository.addXp(createResult.id!, 20);
+      repository.addXp(createResult.id!, 30);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.career?.xp).toBe(60);
+      expect(pilot?.career?.totalXpEarned).toBe(60);
+    });
+  });
+
+  // ===========================================================================
+  // spendXp() tests
+  // ===========================================================================
+
+  describe('spendXp', () => {
+    it('should spend XP from pilot pool', () => {
+      const createResult = repository.create(
+        createPilotOptions({ startingXp: 100 })
+      );
+      const spendResult = repository.spendXp(createResult.id!, 30);
+
+      expect(spendResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.career?.xp).toBe(70);
+      expect(pilot?.career?.totalXpEarned).toBe(100); // Total earned unchanged
+    });
+
+    it('should spend all available XP', () => {
+      const createResult = repository.create(
+        createPilotOptions({ startingXp: 50 })
+      );
+      const spendResult = repository.spendXp(createResult.id!, 50);
+
+      expect(spendResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.career?.xp).toBe(0);
+    });
+
+    it('should return error when insufficient XP', () => {
+      const createResult = repository.create(
+        createPilotOptions({ startingXp: 50 })
+      );
+      const spendResult = repository.spendXp(createResult.id!, 100);
+
+      expect(spendResult.success).toBe(false);
+      expect(spendResult.errorCode).toBe(PilotErrorCode.INSUFFICIENT_XP);
+      expect(spendResult.error).toContain('Insufficient XP');
+      expect(spendResult.error).toContain('Have 50');
+      expect(spendResult.error).toContain('need 100');
+    });
+
+    it('should return error for non-existent pilot', () => {
+      const result = repository.spendXp('non-existent-id', 10);
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe(PilotErrorCode.NOT_FOUND);
+    });
+
+    it('should allow spending after earning more XP', () => {
+      const createResult = repository.create(
+        createPilotOptions({ startingXp: 50 })
+      );
+
+      // First spend
+      repository.spendXp(createResult.id!, 30);
+
+      // Earn more
+      repository.addXp(createResult.id!, 40);
+
+      // Spend again
+      const spendResult = repository.spendXp(createResult.id!, 50);
+      expect(spendResult.success).toBe(true);
+
+      const pilot = repository.getById(createResult.id!);
+      expect(pilot?.career?.xp).toBe(10); // 50 - 30 + 40 - 50 = 10
+      expect(pilot?.career?.totalXpEarned).toBe(90); // 50 + 40
+    });
+  });
+
+  // ===========================================================================
+  // Singleton tests
+  // ===========================================================================
+
+  describe('singleton', () => {
+    it('getPilotRepository should return same instance', () => {
+      const repo1 = getPilotRepository();
+      const repo2 = getPilotRepository();
+
+      expect(repo1).toBe(repo2);
+    });
+
+    it('resetPilotRepository should clear instance', () => {
+      const repo1 = getPilotRepository();
+      resetPilotRepository();
+      const repo2 = getPilotRepository();
+
+      // They should be different instances after reset
+      // Note: This test may not work correctly in all scenarios since
+      // we're using the same underlying database, but the instances
+      // should be different objects
+      expect(repo1).not.toBe(repo2);
+    });
+  });
+});

--- a/src/services/pilots/__tests__/PilotService.test.ts
+++ b/src/services/pilots/__tests__/PilotService.test.ts
@@ -1,0 +1,1124 @@
+/**
+ * Pilot Service Tests
+ *
+ * Comprehensive tests for the PilotService business logic layer.
+ * Tests cover CRUD operations, skill advancement, XP operations, wounds, and validation.
+ *
+ * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
+ */
+
+import {
+  IPilot,
+  IPilotIdentity,
+  PilotType,
+  PilotStatus,
+  PilotExperienceLevel,
+  PILOT_TEMPLATES,
+  XP_AWARDS,
+  MIN_SKILL_VALUE,
+  MAX_SKILL_VALUE,
+} from '@/types/pilot';
+import { IPilotOperationResult, PilotErrorCode } from '../PilotRepository';
+
+// =============================================================================
+// Mock Repository
+// =============================================================================
+
+// Mock pilot storage
+const mockPilots = new Map<string, IPilot>();
+let mockIdCounter = 0;
+
+// Mock repository implementation
+const mockRepository = {
+  create: jest.fn((options: {
+    identity: IPilotIdentity;
+    type: PilotType;
+    skills: { gunnery: number; piloting: number };
+    startingXp?: number;
+    rank?: string;
+    abilityIds?: readonly string[];
+  }): IPilotOperationResult => {
+    const id = `pilot-${++mockIdCounter}`;
+    const now = new Date().toISOString();
+    const pilot: IPilot = {
+      id,
+      name: options.identity.name,
+      callsign: options.identity.callsign,
+      affiliation: options.identity.affiliation,
+      portrait: options.identity.portrait,
+      background: options.identity.background,
+      type: options.type,
+      status: PilotStatus.Active,
+      skills: options.skills,
+      wounds: 0,
+      abilities: (options.abilityIds || []).map((abilityId) => ({
+        abilityId,
+        acquiredDate: now,
+      })),
+      career: options.type === PilotType.Persistent ? {
+        missionsCompleted: 0,
+        victories: 0,
+        defeats: 0,
+        draws: 0,
+        totalKills: 0,
+        killRecords: [],
+        missionHistory: [],
+        xp: options.startingXp || 0,
+        totalXpEarned: options.startingXp || 0,
+        rank: options.rank || 'MechWarrior',
+      } : undefined,
+      createdAt: now,
+      updatedAt: now,
+    };
+    mockPilots.set(id, pilot);
+    return { success: true, id };
+  }),
+
+  update: jest.fn((id: string, updates: Partial<IPilot>): IPilotOperationResult => {
+    const pilot = mockPilots.get(id);
+    if (!pilot) {
+      return {
+        success: false,
+        error: `Pilot ${id} not found`,
+        errorCode: PilotErrorCode.NOT_FOUND,
+      };
+    }
+    const updated: IPilot = {
+      ...pilot,
+      ...updates,
+      updatedAt: new Date().toISOString(),
+    };
+    mockPilots.set(id, updated);
+    return { success: true, id };
+  }),
+
+  delete: jest.fn((id: string): IPilotOperationResult => {
+    if (!mockPilots.has(id)) {
+      return {
+        success: false,
+        error: `Pilot ${id} not found`,
+        errorCode: PilotErrorCode.NOT_FOUND,
+      };
+    }
+    mockPilots.delete(id);
+    return { success: true, id };
+  }),
+
+  getById: jest.fn((id: string): IPilot | null => {
+    return mockPilots.get(id) ?? null;
+  }),
+
+  list: jest.fn((): readonly IPilot[] => {
+    return Array.from(mockPilots.values());
+  }),
+
+  listByStatus: jest.fn((status: PilotStatus): readonly IPilot[] => {
+    return Array.from(mockPilots.values()).filter((p) => p.status === status);
+  }),
+
+  exists: jest.fn((id: string): boolean => {
+    return mockPilots.has(id);
+  }),
+
+  recordMission: jest.fn((
+    pilotId: string,
+    mission: {
+      gameId: string;
+      missionName: string;
+      outcome: 'victory' | 'defeat' | 'draw';
+      xpEarned: number;
+      kills: number;
+    }
+  ): IPilotOperationResult => {
+    const pilot = mockPilots.get(pilotId);
+    if (!pilot) {
+      return {
+        success: false,
+        error: `Pilot ${pilotId} not found`,
+        errorCode: PilotErrorCode.NOT_FOUND,
+      };
+    }
+    if (!pilot.career) {
+      return { success: true, id: pilotId };
+    }
+    
+    const outcomeKey = mission.outcome === 'victory' ? 'victories' 
+      : mission.outcome === 'defeat' ? 'defeats' : 'draws';
+    
+    const updated: IPilot = {
+      ...pilot,
+      career: {
+        ...pilot.career,
+        missionsCompleted: pilot.career.missionsCompleted + 1,
+        [outcomeKey]: pilot.career[outcomeKey] + 1,
+        xp: pilot.career.xp + mission.xpEarned,
+        totalXpEarned: pilot.career.totalXpEarned + mission.xpEarned,
+        missionHistory: [
+          ...pilot.career.missionHistory,
+          {
+            gameId: mission.gameId,
+            missionName: mission.missionName,
+            date: new Date().toISOString(),
+            outcome: mission.outcome,
+            xpEarned: mission.xpEarned,
+            kills: mission.kills,
+          },
+        ],
+      },
+      updatedAt: new Date().toISOString(),
+    };
+    mockPilots.set(pilotId, updated);
+    return { success: true, id: pilotId };
+  }),
+
+  spendXp: jest.fn((pilotId: string, amount: number): IPilotOperationResult => {
+    const pilot = mockPilots.get(pilotId);
+    if (!pilot) {
+      return {
+        success: false,
+        error: `Pilot ${pilotId} not found`,
+        errorCode: PilotErrorCode.NOT_FOUND,
+      };
+    }
+    if (!pilot.career || pilot.career.xp < amount) {
+      return {
+        success: false,
+        error: `Insufficient XP. Have ${pilot.career?.xp || 0}, need ${amount}`,
+        errorCode: PilotErrorCode.INSUFFICIENT_XP,
+      };
+    }
+    const updated: IPilot = {
+      ...pilot,
+      career: {
+        ...pilot.career,
+        xp: pilot.career.xp - amount,
+      },
+      updatedAt: new Date().toISOString(),
+    };
+    mockPilots.set(pilotId, updated);
+    return { success: true, id: pilotId };
+  }),
+};
+
+// Mock the PilotRepository module
+jest.mock('../PilotRepository', () => ({
+  getPilotRepository: () => mockRepository,
+  PilotErrorCode: {
+    NOT_FOUND: 'NOT_FOUND',
+    DUPLICATE_NAME: 'DUPLICATE_NAME',
+    VALIDATION_ERROR: 'VALIDATION_ERROR',
+    DATABASE_ERROR: 'DATABASE_ERROR',
+    INSUFFICIENT_XP: 'INSUFFICIENT_XP',
+  },
+}));
+
+// Import after mocks
+import { PilotService, resetPilotService } from '../PilotService';
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+function createMockIdentity(name: string): IPilotIdentity {
+  return {
+    name,
+    callsign: `${name}-1`,
+    affiliation: 'Test Unit',
+  };
+}
+
+function clearMocks(): void {
+  mockPilots.clear();
+  mockIdCounter = 0;
+  jest.clearAllMocks();
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('PilotService', () => {
+  let service: PilotService;
+
+  beforeEach(() => {
+    clearMocks();
+    resetPilotService();
+    service = new PilotService();
+  });
+
+  // ===========================================================================
+  // CRUD Operations
+  // ===========================================================================
+
+  describe('CRUD Operations', () => {
+    describe('createPilot', () => {
+      it('should create a pilot with valid options', () => {
+        const result = service.createPilot({
+          identity: createMockIdentity('John Doe'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.id).toBeDefined();
+        expect(mockRepository.create).toHaveBeenCalledTimes(1);
+      });
+
+      it('should reject pilot with empty name', () => {
+        const result = service.createPilot({
+          identity: { name: '' },
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('name is required');
+        expect(result.errorCode).toBe(PilotErrorCode.VALIDATION_ERROR);
+      });
+
+      it('should reject pilot with whitespace-only name', () => {
+        const result = service.createPilot({
+          identity: { name: '   ' },
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('name is required');
+      });
+
+      it('should reject pilot with invalid gunnery skill', () => {
+        const result = service.createPilot({
+          identity: createMockIdentity('Invalid Gunnery'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 0, piloting: 5 },
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('Gunnery must be between');
+      });
+
+      it('should reject pilot with invalid piloting skill', () => {
+        const result = service.createPilot({
+          identity: createMockIdentity('Invalid Piloting'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 10 },
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('Piloting must be between');
+      });
+
+      it('should accept pilot with edge case skill values', () => {
+        const result1 = service.createPilot({
+          identity: createMockIdentity('Min Skills'),
+          type: PilotType.Persistent,
+          skills: { gunnery: MIN_SKILL_VALUE, piloting: MIN_SKILL_VALUE },
+        });
+        expect(result1.success).toBe(true);
+
+        const result2 = service.createPilot({
+          identity: createMockIdentity('Max Skills'),
+          type: PilotType.Persistent,
+          skills: { gunnery: MAX_SKILL_VALUE, piloting: MAX_SKILL_VALUE },
+        });
+        expect(result2.success).toBe(true);
+      });
+    });
+
+    describe('createFromTemplate', () => {
+      it('should create a Green pilot with correct skills', () => {
+        const result = service.createFromTemplate(
+          PilotExperienceLevel.Green,
+          createMockIdentity('Green Pilot')
+        );
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            skills: PILOT_TEMPLATES[PilotExperienceLevel.Green].skills,
+            startingXp: PILOT_TEMPLATES[PilotExperienceLevel.Green].startingXp,
+            rank: 'Cadet',
+          })
+        );
+      });
+
+      it('should create a Regular pilot with correct skills', () => {
+        const result = service.createFromTemplate(
+          PilotExperienceLevel.Regular,
+          createMockIdentity('Regular Pilot')
+        );
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            skills: PILOT_TEMPLATES[PilotExperienceLevel.Regular].skills,
+            rank: 'MechWarrior',
+          })
+        );
+      });
+
+      it('should create a Veteran pilot with correct skills', () => {
+        const result = service.createFromTemplate(
+          PilotExperienceLevel.Veteran,
+          createMockIdentity('Veteran Pilot')
+        );
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            skills: PILOT_TEMPLATES[PilotExperienceLevel.Veteran].skills,
+            startingXp: PILOT_TEMPLATES[PilotExperienceLevel.Veteran].startingXp,
+            rank: 'Sergeant',
+          })
+        );
+      });
+
+      it('should create an Elite pilot with correct skills', () => {
+        const result = service.createFromTemplate(
+          PilotExperienceLevel.Elite,
+          createMockIdentity('Elite Pilot')
+        );
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            skills: PILOT_TEMPLATES[PilotExperienceLevel.Elite].skills,
+            startingXp: PILOT_TEMPLATES[PilotExperienceLevel.Elite].startingXp,
+            rank: 'Lieutenant',
+          })
+        );
+      });
+    });
+
+    describe('createRandom', () => {
+      it('should create a random pilot', () => {
+        // Mock Math.random for deterministic results
+        const mockRandom = jest.spyOn(Math, 'random');
+        mockRandom.mockReturnValue(0.5); // Should give piloting=5, gunnery=5, no ability
+
+        const result = service.createRandom(createMockIdentity('Random Pilot'));
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.create).toHaveBeenCalledTimes(1);
+
+        mockRandom.mockRestore();
+      });
+
+      it('should create pilots with weighted skill distribution', () => {
+        const mockRandom = jest.spyOn(Math, 'random');
+        
+        // Test veteran roll (10%)
+        mockRandom.mockReturnValue(0.05);
+        service.createRandom(createMockIdentity('Veteran Roll'));
+        expect(mockRepository.create).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            skills: expect.objectContaining({ gunnery: 3 }), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+          })
+        );
+
+        // Test untrained roll (20%)
+        mockRandom.mockReturnValue(0.2);
+        service.createRandom(createMockIdentity('Untrained Roll'));
+        expect(mockRepository.create).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            skills: expect.objectContaining({ gunnery: 6 }), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+          })
+        );
+
+        // Test green roll (30%)
+        mockRandom.mockReturnValue(0.5);
+        service.createRandom(createMockIdentity('Green Roll'));
+        expect(mockRepository.create).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            skills: expect.objectContaining({ gunnery: 5 }), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+          })
+        );
+
+        // Test regular roll (40%)
+        mockRandom.mockReturnValue(0.9);
+        service.createRandom(createMockIdentity('Regular Roll'));
+        expect(mockRepository.create).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            skills: expect.objectContaining({ gunnery: 4 }), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+          })
+        );
+
+        mockRandom.mockRestore();
+      });
+    });
+
+    describe('createStatblock', () => {
+      it('should create a statblock pilot (not persisted)', () => {
+        const pilot = service.createStatblock({
+          name: 'NPC Pilot',
+          gunnery: 4,
+          piloting: 5,
+        });
+
+        expect(pilot.id).toMatch(/^statblock-/);
+        expect(pilot.name).toBe('NPC Pilot');
+        expect(pilot.type).toBe(PilotType.Statblock);
+        expect(pilot.status).toBe(PilotStatus.Active);
+        expect(pilot.skills.gunnery).toBe(4);
+        expect(pilot.skills.piloting).toBe(5);
+        expect(pilot.wounds).toBe(0);
+        expect(pilot.abilities).toEqual([]);
+        expect(mockRepository.create).not.toHaveBeenCalled();
+      });
+
+      it('should create a statblock pilot with abilities', () => {
+        const pilot = service.createStatblock({
+          name: 'NPC with Abilities',
+          gunnery: 3,
+          piloting: 4,
+          abilityIds: ['marksman', 'dodge'],
+        });
+
+        expect(pilot.abilities).toHaveLength(2);
+        expect(pilot.abilities[0].abilityId).toBe('marksman');
+        expect(pilot.abilities[1].abilityId).toBe('dodge');
+      });
+    });
+
+    describe('updatePilot', () => {
+      it('should update a pilot', () => {
+        service.createPilot({
+          identity: createMockIdentity('Update Test'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        const id = 'pilot-1';
+
+        const result = service.updatePilot(id, { callsign: 'Updated Callsign' });
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.update).toHaveBeenCalledWith(id, { callsign: 'Updated Callsign' });
+      });
+
+      it('should return error for non-existent pilot', () => {
+        const result = service.updatePilot('non-existent', { callsign: 'Test' });
+
+        expect(result.success).toBe(false);
+        expect(result.errorCode).toBe(PilotErrorCode.NOT_FOUND);
+      });
+    });
+
+    describe('deletePilot', () => {
+      it('should delete a pilot', () => {
+        service.createPilot({
+          identity: createMockIdentity('Delete Test'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        const id = 'pilot-1';
+
+        const result = service.deletePilot(id);
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.delete).toHaveBeenCalledWith(id);
+      });
+
+      it('should return error for non-existent pilot', () => {
+        const result = service.deletePilot('non-existent');
+
+        expect(result.success).toBe(false);
+        expect(result.errorCode).toBe(PilotErrorCode.NOT_FOUND);
+      });
+    });
+
+    describe('getPilot', () => {
+      it('should get a pilot by ID', () => {
+        service.createPilot({
+          identity: createMockIdentity('Get Test'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        const id = 'pilot-1';
+
+        const pilot = service.getPilot(id);
+
+        expect(pilot).not.toBeNull();
+        expect(pilot?.name).toBe('Get Test');
+      });
+
+      it('should return null for non-existent pilot', () => {
+        const pilot = service.getPilot('non-existent');
+
+        expect(pilot).toBeNull();
+      });
+    });
+
+    describe('listPilots', () => {
+      it('should list all pilots', () => {
+        service.createPilot({
+          identity: createMockIdentity('Pilot 1'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        service.createPilot({
+          identity: createMockIdentity('Pilot 2'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 3, piloting: 4 },
+        });
+
+        const pilots = service.listPilots();
+
+        expect(pilots).toHaveLength(2);
+        expect(mockRepository.list).toHaveBeenCalled();
+      });
+    });
+
+    describe('listActivePilots', () => {
+      it('should list only active pilots', () => {
+        service.createPilot({
+          identity: createMockIdentity('Active Pilot'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+
+        service.listActivePilots();
+
+        expect(mockRepository.listByStatus).toHaveBeenCalledWith(PilotStatus.Active);
+      });
+    });
+  });
+
+  // ===========================================================================
+  // Skill Advancement
+  // ===========================================================================
+
+  describe('Skill Advancement', () => {
+    describe('canImproveGunnery', () => {
+      it('should return true when pilot has enough XP', () => {
+        service.createPilot({
+          identity: createMockIdentity('Can Improve'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+          startingXp: 500,
+        });
+        const pilot = service.getPilot('pilot-1')!;
+
+        const result = service.canImproveGunnery(pilot);
+
+        expect(result.canImprove).toBe(true);
+        expect(result.cost).toBe(200); // Cost to improve from 4
+      });
+
+      it('should return false when pilot lacks XP', () => {
+        service.createPilot({
+          identity: createMockIdentity('No XP'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+          startingXp: 50,
+        });
+        const pilot = service.getPilot('pilot-1')!;
+
+        const result = service.canImproveGunnery(pilot);
+
+        expect(result.canImprove).toBe(false);
+        expect(result.cost).toBe(200);
+      });
+
+      it('should return null cost when at max gunnery (1)', () => {
+        service.createPilot({
+          identity: createMockIdentity('Max Gunnery'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 1, piloting: 5 },
+          startingXp: 1000,
+        });
+        const pilot = service.getPilot('pilot-1')!;
+
+        const result = service.canImproveGunnery(pilot);
+
+        expect(result.canImprove).toBe(false);
+        expect(result.cost).toBeNull();
+      });
+    });
+
+    describe('canImprovePiloting', () => {
+      it('should return true when pilot has enough XP', () => {
+        service.createPilot({
+          identity: createMockIdentity('Can Improve Piloting'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+          startingXp: 100,
+        });
+        const pilot = service.getPilot('pilot-1')!;
+
+        const result = service.canImprovePiloting(pilot);
+
+        expect(result.canImprove).toBe(true);
+        expect(result.cost).toBe(75); // Cost to improve from 5
+      });
+
+      it('should return null cost when at max piloting (1)', () => {
+        service.createPilot({
+          identity: createMockIdentity('Max Piloting'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 1 },
+          startingXp: 1000,
+        });
+        const pilot = service.getPilot('pilot-1')!;
+
+        const result = service.canImprovePiloting(pilot);
+
+        expect(result.canImprove).toBe(false);
+        expect(result.cost).toBeNull();
+      });
+    });
+
+    describe('improveGunnery', () => {
+      it('should improve gunnery and spend XP', () => {
+        service.createPilot({
+          identity: createMockIdentity('Improve Gunnery'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+          startingXp: 500,
+        });
+        const id = 'pilot-1';
+
+        const result = service.improveGunnery(id);
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.spendXp).toHaveBeenCalledWith(id, 200);
+        expect(mockRepository.update).toHaveBeenCalledWith(id, {
+          skills: { gunnery: 3, piloting: 5 },
+        });
+      });
+
+      it('should return error for non-existent pilot', () => {
+        const result = service.improveGunnery('non-existent');
+
+        expect(result.success).toBe(false);
+        expect(result.errorCode).toBe(PilotErrorCode.NOT_FOUND);
+      });
+
+      it('should return error when at max gunnery', () => {
+        service.createPilot({
+          identity: createMockIdentity('Max Gunnery'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 1, piloting: 5 },
+          startingXp: 1000,
+        });
+        const id = 'pilot-1';
+
+        const result = service.improveGunnery(id);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('already at maximum');
+        expect(result.errorCode).toBe(PilotErrorCode.VALIDATION_ERROR);
+      });
+
+      it('should return error when insufficient XP', () => {
+        service.createPilot({
+          identity: createMockIdentity('No XP'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+          startingXp: 50,
+        });
+        const id = 'pilot-1';
+
+        const result = service.improveGunnery(id);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('Insufficient XP');
+        expect(result.errorCode).toBe(PilotErrorCode.INSUFFICIENT_XP);
+      });
+    });
+
+    describe('improvePiloting', () => {
+      it('should improve piloting and spend XP', () => {
+        service.createPilot({
+          identity: createMockIdentity('Improve Piloting'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+          startingXp: 100,
+        });
+        const id = 'pilot-1';
+
+        const result = service.improvePiloting(id);
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.spendXp).toHaveBeenCalledWith(id, 75);
+        expect(mockRepository.update).toHaveBeenCalledWith(id, {
+          skills: { gunnery: 4, piloting: 4 },
+        });
+      });
+
+      it('should return error when at max piloting', () => {
+        service.createPilot({
+          identity: createMockIdentity('Max Piloting'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 1 },
+          startingXp: 1000,
+        });
+        const id = 'pilot-1';
+
+        const result = service.improvePiloting(id);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('already at maximum');
+        expect(result.errorCode).toBe(PilotErrorCode.VALIDATION_ERROR);
+      });
+    });
+  });
+
+  // ===========================================================================
+  // XP Operations
+  // ===========================================================================
+
+  describe('XP Operations', () => {
+    describe('awardMissionXp', () => {
+      it('should award base survival XP', () => {
+        service.createPilot({
+          identity: createMockIdentity('XP Test'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        const id = 'pilot-1';
+
+        const result = service.awardMissionXp(id, 'draw', 0);
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.recordMission).toHaveBeenCalledWith(
+          id,
+          expect.objectContaining({
+            outcome: 'draw',
+            xpEarned: XP_AWARDS.missionSurvival,
+            kills: 0,
+          })
+        );
+      });
+
+      it('should award XP for kills', () => {
+        service.createPilot({
+          identity: createMockIdentity('Killer'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        const id = 'pilot-1';
+
+        const result = service.awardMissionXp(id, 'draw', 3);
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.recordMission).toHaveBeenCalledWith(
+          id,
+          expect.objectContaining({
+            xpEarned: XP_AWARDS.missionSurvival + (3 * XP_AWARDS.kill),
+          })
+        );
+      });
+
+      it('should award victory bonus', () => {
+        service.createPilot({
+          identity: createMockIdentity('Victor'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        const id = 'pilot-1';
+
+        const result = service.awardMissionXp(id, 'victory', 0);
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.recordMission).toHaveBeenCalledWith(
+          id,
+          expect.objectContaining({
+            xpEarned: XP_AWARDS.missionSurvival + XP_AWARDS.victoryBonus,
+          })
+        );
+      });
+
+      it('should not award victory bonus for defeat', () => {
+        service.createPilot({
+          identity: createMockIdentity('Loser'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        const id = 'pilot-1';
+
+        const result = service.awardMissionXp(id, 'defeat', 0);
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.recordMission).toHaveBeenCalledWith(
+          id,
+          expect.objectContaining({
+            xpEarned: XP_AWARDS.missionSurvival,
+          })
+        );
+      });
+
+      it('should award first blood bonus', () => {
+        service.createPilot({
+          identity: createMockIdentity('First Blood'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        const id = 'pilot-1';
+
+        const result = service.awardMissionXp(id, 'draw', 1, { firstBlood: true });
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.recordMission).toHaveBeenCalledWith(
+          id,
+          expect.objectContaining({
+            xpEarned: XP_AWARDS.missionSurvival + XP_AWARDS.kill + XP_AWARDS.firstBlood,
+          })
+        );
+      });
+
+      it('should award higher BV opponent bonus', () => {
+        service.createPilot({
+          identity: createMockIdentity('Giant Killer'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        const id = 'pilot-1';
+
+        const result = service.awardMissionXp(id, 'victory', 1, { higherBVOpponent: true });
+
+        const expectedXp = XP_AWARDS.missionSurvival + 
+          XP_AWARDS.kill + 
+          XP_AWARDS.victoryBonus + 
+          XP_AWARDS.higherBVOpponent;
+        
+        expect(result.success).toBe(true);
+        expect(mockRepository.recordMission).toHaveBeenCalledWith(
+          id,
+          expect.objectContaining({
+            xpEarned: expectedXp,
+          })
+        );
+      });
+
+      it('should combine all bonuses', () => {
+        service.createPilot({
+          identity: createMockIdentity('Max Bonus'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        const id = 'pilot-1';
+
+        const result = service.awardMissionXp(id, 'victory', 2, {
+          firstBlood: true,
+          higherBVOpponent: true,
+        });
+
+        const expectedXp = XP_AWARDS.missionSurvival +
+          (2 * XP_AWARDS.kill) +
+          XP_AWARDS.victoryBonus +
+          XP_AWARDS.firstBlood +
+          XP_AWARDS.higherBVOpponent;
+        
+        expect(result.success).toBe(true);
+        expect(mockRepository.recordMission).toHaveBeenCalledWith(
+          id,
+          expect.objectContaining({
+            xpEarned: expectedXp,
+          })
+        );
+      });
+    });
+  });
+
+  // ===========================================================================
+  // Wounds
+  // ===========================================================================
+
+  describe('Wounds', () => {
+    describe('applyWound', () => {
+      it('should apply a wound to a pilot', () => {
+        service.createPilot({
+          identity: createMockIdentity('Wound Test'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        const id = 'pilot-1';
+
+        const result = service.applyWound(id);
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.update).toHaveBeenCalledWith(id, {
+          wounds: 1,
+          status: PilotStatus.Active,
+        });
+      });
+
+      it('should set status to Injured at 3 wounds', () => {
+        service.createPilot({
+          identity: createMockIdentity('Injured Test'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        const id = 'pilot-1';
+
+        // Apply 3 wounds
+        service.applyWound(id);
+        service.applyWound(id);
+        const result = service.applyWound(id);
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.update).toHaveBeenLastCalledWith(id, {
+          wounds: 3,
+          status: PilotStatus.Injured,
+        });
+      });
+
+      it('should set status to KIA at 6 wounds', () => {
+        service.createPilot({
+          identity: createMockIdentity('KIA Test'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        const id = 'pilot-1';
+
+        // Apply 6 wounds
+        for (let i = 0; i < 6; i++) {
+          service.applyWound(id);
+        }
+
+        expect(mockRepository.update).toHaveBeenLastCalledWith(id, {
+          wounds: 6,
+          status: PilotStatus.KIA,
+        });
+      });
+
+      it('should return error for non-existent pilot', () => {
+        const result = service.applyWound('non-existent');
+
+        expect(result.success).toBe(false);
+        expect(result.errorCode).toBe(PilotErrorCode.NOT_FOUND);
+      });
+    });
+
+    describe('healWounds', () => {
+      it('should heal all wounds', () => {
+        service.createPilot({
+          identity: createMockIdentity('Heal Test'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        const id = 'pilot-1';
+        service.applyWound(id);
+        service.applyWound(id);
+
+        const result = service.healWounds(id);
+
+        expect(result.success).toBe(true);
+        expect(mockRepository.update).toHaveBeenLastCalledWith(id, {
+          wounds: 0,
+          status: PilotStatus.Active,
+        });
+      });
+
+      it('should return error when pilot is KIA', () => {
+        service.createPilot({
+          identity: createMockIdentity('Dead Pilot'),
+          type: PilotType.Persistent,
+          skills: { gunnery: 4, piloting: 5 },
+        });
+        const id = 'pilot-1';
+        
+        // Kill the pilot
+        for (let i = 0; i < 6; i++) {
+          service.applyWound(id);
+        }
+
+        const result = service.healWounds(id);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('Cannot heal a KIA pilot');
+        expect(result.errorCode).toBe(PilotErrorCode.VALIDATION_ERROR);
+      });
+
+      it('should return error for non-existent pilot', () => {
+        const result = service.healWounds('non-existent');
+
+        expect(result.success).toBe(false);
+        expect(result.errorCode).toBe(PilotErrorCode.NOT_FOUND);
+      });
+    });
+  });
+
+  // ===========================================================================
+  // Validation
+  // ===========================================================================
+
+  describe('Validation', () => {
+    describe('validatePilot', () => {
+      it('should return no errors for valid pilot', () => {
+        const errors = service.validatePilot({
+          name: 'Valid Pilot',
+          skills: { gunnery: 4, piloting: 5 },
+          wounds: 0,
+        });
+
+        expect(errors).toHaveLength(0);
+      });
+
+      it('should return error for invalid gunnery', () => {
+        const errors = service.validatePilot({
+          skills: { gunnery: 0, piloting: 5 },
+        });
+
+        expect(errors.some((e) => e.includes('Gunnery'))).toBe(true);
+      });
+
+      it('should return error for invalid piloting', () => {
+        const errors = service.validatePilot({
+          skills: { gunnery: 4, piloting: 9 },
+        });
+
+        expect(errors.some((e) => e.includes('Piloting'))).toBe(true);
+      });
+
+      it('should return error for invalid wounds', () => {
+        const errors = service.validatePilot({
+          wounds: 7,
+        });
+
+        expect(errors.some((e) => e.includes('Wounds'))).toBe(true);
+      });
+
+      it('should return error for negative wounds', () => {
+        const errors = service.validatePilot({
+          wounds: -1,
+        });
+
+        expect(errors.some((e) => e.includes('Wounds'))).toBe(true);
+      });
+
+      it('should return error for empty name', () => {
+        const errors = service.validatePilot({
+          name: '',
+        });
+
+        expect(errors.some((e) => e.includes('name is required'))).toBe(true);
+      });
+
+      it('should return error for whitespace-only name', () => {
+        const errors = service.validatePilot({
+          name: '   ',
+        });
+
+        expect(errors.some((e) => e.includes('name is required'))).toBe(true);
+      });
+
+      it('should skip validation for undefined fields', () => {
+        const errors = service.validatePilot({});
+
+        expect(errors).toHaveLength(0);
+      });
+
+      it('should accumulate multiple errors', () => {
+        const errors = service.validatePilot({
+          name: '',
+          skills: { gunnery: 0, piloting: 9 },
+          wounds: 10,
+        });
+
+        expect(errors.length).toBeGreaterThanOrEqual(4);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive unit tests for core service repositories and services, improving test coverage for the Force, Pilot, and Encounter systems.

## Changes

| File | Tests | Description |
|------|-------|-------------|
| `ForceRepository.test.ts` | 64 | CRUD operations, assignments, hierarchy validation |
| `PilotRepository.test.ts` | 76 | CRUD, abilities, XP tracking, mission recording |
| `EncounterRepository.test.ts` | 56 | CRUD, status management, template application |
| `PilotService.test.ts` | 56 | Skill advancement, XP operations, wound management |
| `EncounterService.test.ts` | 47 | Configuration, validation, launch operations |

**Total: 299 new tests**

## Test Coverage

All 299 tests passing. This is Batch 1 of a multi-batch test coverage improvement effort targeting services and utilities with 0% or low coverage.

## Testing

```bash
npm test -- --testPathPattern="(ForceRepository|PilotRepository|EncounterRepository|PilotService|EncounterService)" --no-coverage
```