### PR TITLE
test: add vault repository test coverage (Batch 2)

### DIFF
--- a/src/services/vault/__tests__/ContactRepository.test.ts
+++ b/src/services/vault/__tests__/ContactRepository.test.ts
@@ -1,0 +1,728 @@
+/**
+ * Contact Repository Tests
+ *
+ * Tests for contact persistence including CRUD operations and queries.
+ *
+ * @spec openspec/changes/add-vault-sharing/specs/vault-sharing/spec.md
+ */
+
+import {
+  ContactRepository,
+  getContactRepository,
+  resetContactRepository,
+} from '@/services/vault/ContactRepository';
+import type { IContact, IStoredContact } from '@/types/vault';
+
+// =============================================================================
+// Mock SQLite Service
+// =============================================================================
+
+interface MockStatement {
+  run: jest.Mock;
+  get: jest.Mock;
+  all: jest.Mock;
+}
+
+interface MockDatabase {
+  exec: jest.Mock;
+  prepare: jest.Mock;
+}
+
+const createMockStatement = (): MockStatement => ({
+  run: jest.fn().mockReturnValue({ changes: 1 }),
+  get: jest.fn(),
+  all: jest.fn().mockReturnValue([]),
+});
+
+const mockStatement = createMockStatement();
+
+const mockDatabase: MockDatabase = {
+  exec: jest.fn(),
+  prepare: jest.fn().mockReturnValue(mockStatement),
+};
+
+const mockSQLiteService = {
+  initialize: jest.fn().mockResolvedValue(undefined),
+  getDatabase: jest.fn().mockReturnValue(mockDatabase),
+};
+
+jest.mock('@/services/persistence', () => ({
+  getSQLiteService: () => mockSQLiteService,
+}));
+
+// Mock crypto.randomUUID
+const mockUUID = 'test-uuid-1234';
+Object.defineProperty(globalThis, 'crypto', {
+  value: {
+    randomUUID: jest.fn().mockReturnValue(mockUUID),
+  },
+});
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+const createMockStoredContact = (overrides: Partial<IStoredContact> = {}): IStoredContact => ({
+  id: 'contact-test-123',
+  friend_code: 'ABCD-EFGH-JKLM-NPQR',
+  public_key: 'test-public-key-base64',
+  nickname: null,
+  display_name: 'Test User',
+  avatar: null,
+  added_at: '2024-01-01T00:00:00.000Z',
+  last_seen_at: null,
+  is_trusted: 0,
+  notes: null,
+  ...overrides,
+});
+
+const createMockContact = (overrides: Partial<IContact> = {}): IContact => ({
+  id: 'contact-test-123',
+  friendCode: 'ABCD-EFGH-JKLM-NPQR',
+  publicKey: 'test-public-key-base64',
+  nickname: null,
+  displayName: 'Test User',
+  avatar: null,
+  addedAt: '2024-01-01T00:00:00.000Z',
+  lastSeenAt: null,
+  isTrusted: false,
+  notes: null,
+  ...overrides,
+});
+
+const createContactInput = (
+  overrides: Partial<Omit<IContact, 'id' | 'addedAt'>> = {}
+): Omit<IContact, 'id' | 'addedAt'> => ({
+  friendCode: 'ABCD-EFGH-JKLM-NPQR',
+  publicKey: 'test-public-key-base64',
+  nickname: null,
+  displayName: 'Test User',
+  avatar: null,
+  lastSeenAt: null,
+  isTrusted: false,
+  notes: null,
+  ...overrides,
+});
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('ContactRepository', () => {
+  let repository: ContactRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetContactRepository();
+    repository = new ContactRepository();
+
+    // Reset mock statement
+    mockStatement.run.mockReturnValue({ changes: 1 });
+    mockStatement.get.mockReturnValue(undefined);
+    mockStatement.all.mockReturnValue([]);
+  });
+
+  // ===========================================================================
+  // Initialization
+  // ===========================================================================
+
+  describe('initialize', () => {
+    it('should initialize the database and create table', async () => {
+      await repository.initialize();
+
+      expect(mockSQLiteService.initialize).toHaveBeenCalled();
+      expect(mockDatabase.exec).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE TABLE IF NOT EXISTS vault_contacts')
+      );
+    });
+
+    it('should create indexes for friend_code, public_key, and added_at', async () => {
+      await repository.initialize();
+
+      const execCall = (mockDatabase.exec.mock.calls as string[][])[0][0];
+      expect(execCall).toContain('CREATE INDEX IF NOT EXISTS idx_vault_contacts_friend_code');
+      expect(execCall).toContain('CREATE INDEX IF NOT EXISTS idx_vault_contacts_public_key');
+      expect(execCall).toContain('CREATE INDEX IF NOT EXISTS idx_vault_contacts_added_at');
+    });
+
+    it('should only initialize once', async () => {
+      await repository.initialize();
+      await repository.initialize();
+      await repository.initialize();
+
+      expect(mockSQLiteService.initialize).toHaveBeenCalledTimes(1);
+      expect(mockDatabase.exec).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ===========================================================================
+  // Create
+  // ===========================================================================
+
+  describe('create', () => {
+    it('should create a new contact with generated ID and timestamp', async () => {
+      const input = createContactInput();
+
+      const result = await repository.create(input);
+
+      expect(result.id).toBe(`contact-${mockUUID}`);
+      expect(result.friendCode).toBe(input.friendCode);
+      expect(result.publicKey).toBe(input.publicKey);
+      expect(result.displayName).toBe(input.displayName);
+      expect(result.addedAt).toBeDefined();
+    });
+
+    it('should insert contact into database with correct values', async () => {
+      const input = createContactInput({
+        nickname: 'Test Nickname',
+        isTrusted: true,
+        notes: 'Some notes',
+      });
+
+      await repository.create(input);
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO vault_contacts')
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith(
+        `contact-${mockUUID}`,
+        input.friendCode,
+        input.publicKey,
+        input.nickname,
+        input.displayName,
+        input.avatar,
+        expect.any(String), // addedAt
+        input.lastSeenAt,
+        1, // isTrusted converted to integer
+        input.notes
+      );
+    });
+
+    it('should convert isTrusted boolean to integer 0 when false', async () => {
+      const input = createContactInput({ isTrusted: false });
+
+      await repository.create(input);
+
+      // Verify the 9th argument (index 8) is 0 for isTrusted=false
+      const runArgs = mockStatement.run.mock.calls[0] as unknown[];
+      expect(runArgs[8]).toBe(0); // isTrusted = false -> 0
+    });
+
+    it('should initialize if not already initialized', async () => {
+      const input = createContactInput();
+
+      await repository.create(input);
+
+      expect(mockSQLiteService.initialize).toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // Read Operations
+  // ===========================================================================
+
+  describe('getById', () => {
+    it('should return contact when found', async () => {
+      const storedContact = createMockStoredContact();
+      mockStatement.get.mockReturnValue(storedContact);
+
+      const result = await repository.getById('contact-test-123');
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        'SELECT * FROM vault_contacts WHERE id = ?'
+      );
+      expect(mockStatement.get).toHaveBeenCalledWith('contact-test-123');
+      expect(result).toEqual(createMockContact());
+    });
+
+    it('should return null when contact not found', async () => {
+      mockStatement.get.mockReturnValue(undefined);
+
+      const result = await repository.getById('non-existent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should convert is_trusted integer to boolean', async () => {
+      const storedContact = createMockStoredContact({ is_trusted: 1 });
+      mockStatement.get.mockReturnValue(storedContact);
+
+      const result = await repository.getById('contact-test-123');
+
+      expect(result?.isTrusted).toBe(true);
+    });
+  });
+
+  describe('getByFriendCode', () => {
+    it('should return contact when found by friend code', async () => {
+      const storedContact = createMockStoredContact();
+      mockStatement.get.mockReturnValue(storedContact);
+
+      const result = await repository.getByFriendCode('ABCD-EFGH-JKLM-NPQR');
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        'SELECT * FROM vault_contacts WHERE friend_code = ?'
+      );
+      expect(mockStatement.get).toHaveBeenCalledWith('ABCD-EFGH-JKLM-NPQR');
+      expect(result).not.toBeNull();
+    });
+
+    it('should return null when friend code not found', async () => {
+      mockStatement.get.mockReturnValue(undefined);
+
+      const result = await repository.getByFriendCode('XXXX-XXXX-XXXX-XXX2');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getByPublicKey', () => {
+    it('should return contact when found by public key', async () => {
+      const storedContact = createMockStoredContact();
+      mockStatement.get.mockReturnValue(storedContact);
+
+      const result = await repository.getByPublicKey('test-public-key-base64');
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        'SELECT * FROM vault_contacts WHERE public_key = ?'
+      );
+      expect(mockStatement.get).toHaveBeenCalledWith('test-public-key-base64');
+      expect(result).not.toBeNull();
+    });
+
+    it('should return null when public key not found', async () => {
+      mockStatement.get.mockReturnValue(undefined);
+
+      const result = await repository.getByPublicKey('non-existent-key');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return all contacts sorted by name', async () => {
+      const storedContacts = [
+        createMockStoredContact({ id: 'c1', display_name: 'Zoe' }),
+        createMockStoredContact({ id: 'c2', display_name: 'Alice' }),
+      ];
+      mockStatement.all.mockReturnValue(storedContacts);
+
+      const result = await repository.getAll();
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        'SELECT * FROM vault_contacts ORDER BY COALESCE(nickname, display_name)'
+      );
+      expect(result).toHaveLength(2);
+    });
+
+    it('should return empty array when no contacts exist', async () => {
+      mockStatement.all.mockReturnValue([]);
+
+      const result = await repository.getAll();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should convert all contacts from stored format', async () => {
+      const storedContacts = [
+        createMockStoredContact({ is_trusted: 1 }),
+        createMockStoredContact({ id: 'c2', is_trusted: 0 }),
+      ];
+      mockStatement.all.mockReturnValue(storedContacts);
+
+      const result = await repository.getAll();
+
+      expect(result[0].isTrusted).toBe(true);
+      expect(result[1].isTrusted).toBe(false);
+    });
+  });
+
+  describe('getTrusted', () => {
+    it('should return only trusted contacts', async () => {
+      const trustedContacts = [
+        createMockStoredContact({ id: 'c1', is_trusted: 1 }),
+        createMockStoredContact({ id: 'c2', is_trusted: 1 }),
+      ];
+      mockStatement.all.mockReturnValue(trustedContacts);
+
+      const result = await repository.getTrusted();
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        'SELECT * FROM vault_contacts WHERE is_trusted = 1 ORDER BY COALESCE(nickname, display_name)'
+      );
+      expect(result).toHaveLength(2);
+      expect(result.every((c) => c.isTrusted)).toBe(true);
+    });
+
+    it('should return empty array when no trusted contacts', async () => {
+      mockStatement.all.mockReturnValue([]);
+
+      const result = await repository.getTrusted();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('search', () => {
+    it('should search contacts by nickname, display name, or friend code', async () => {
+      const matchingContacts = [createMockStoredContact({ nickname: 'Test' })];
+      mockStatement.all.mockReturnValue(matchingContacts);
+
+      const result = await repository.search('Test');
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('WHERE nickname LIKE ? OR display_name LIKE ? OR friend_code LIKE ?')
+      );
+      expect(mockStatement.all).toHaveBeenCalledWith('%Test%', '%Test%', '%Test%');
+      expect(result).toHaveLength(1);
+    });
+
+    it('should return empty array for no matches', async () => {
+      mockStatement.all.mockReturnValue([]);
+
+      const result = await repository.search('NonExistent');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ===========================================================================
+  // Update Operations
+  // ===========================================================================
+
+  describe('updateNickname', () => {
+    it('should update nickname and return true on success', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.updateNickname('contact-123', 'New Nickname');
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        'UPDATE vault_contacts SET nickname = ? WHERE id = ?'
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith('New Nickname', 'contact-123');
+      expect(result).toBe(true);
+    });
+
+    it('should return false when contact not found', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const result = await repository.updateNickname('non-existent', 'Nickname');
+
+      expect(result).toBe(false);
+    });
+
+    it('should allow setting nickname to null', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.updateNickname('contact-123', null);
+
+      expect(mockStatement.run).toHaveBeenCalledWith(null, 'contact-123');
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('updateTrusted', () => {
+    it('should update trusted status to true', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.updateTrusted('contact-123', true);
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        'UPDATE vault_contacts SET is_trusted = ? WHERE id = ?'
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith(1, 'contact-123');
+      expect(result).toBe(true);
+    });
+
+    it('should update trusted status to false', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.updateTrusted('contact-123', false);
+
+      expect(mockStatement.run).toHaveBeenCalledWith(0, 'contact-123');
+      expect(result).toBe(true);
+    });
+
+    it('should return false when contact not found', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const result = await repository.updateTrusted('non-existent', true);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('updateNotes', () => {
+    it('should update notes and return true on success', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.updateNotes('contact-123', 'New notes');
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        'UPDATE vault_contacts SET notes = ? WHERE id = ?'
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith('New notes', 'contact-123');
+      expect(result).toBe(true);
+    });
+
+    it('should allow setting notes to null', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.updateNotes('contact-123', null);
+
+      expect(mockStatement.run).toHaveBeenCalledWith(null, 'contact-123');
+      expect(result).toBe(true);
+    });
+
+    it('should return false when contact not found', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const result = await repository.updateNotes('non-existent', 'notes');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('updateLastSeen', () => {
+    it('should update last seen timestamp', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+      const timestamp = '2024-01-15T10:30:00.000Z';
+
+      const result = await repository.updateLastSeen('contact-123', timestamp);
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        'UPDATE vault_contacts SET last_seen_at = ? WHERE id = ?'
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith(timestamp, 'contact-123');
+      expect(result).toBe(true);
+    });
+
+    it('should return false when contact not found', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const result = await repository.updateLastSeen('non-existent', '2024-01-15T10:30:00.000Z');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('updateFromIdentity', () => {
+    it('should update display name and avatar', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.updateFromIdentity(
+        'contact-123',
+        'New Display Name',
+        'avatar-url'
+      );
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        'UPDATE vault_contacts SET display_name = ?, avatar = ? WHERE id = ?'
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith(
+        'New Display Name',
+        'avatar-url',
+        'contact-123'
+      );
+      expect(result).toBe(true);
+    });
+
+    it('should allow setting avatar to null', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.updateFromIdentity('contact-123', 'Name', null);
+
+      expect(mockStatement.run).toHaveBeenCalledWith('Name', null, 'contact-123');
+      expect(result).toBe(true);
+    });
+
+    it('should return false when contact not found', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const result = await repository.updateFromIdentity('non-existent', 'Name', null);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // Delete Operations
+  // ===========================================================================
+
+  describe('delete', () => {
+    it('should delete contact by ID and return true', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.delete('contact-123');
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        'DELETE FROM vault_contacts WHERE id = ?'
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith('contact-123');
+      expect(result).toBe(true);
+    });
+
+    it('should return false when contact not found', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const result = await repository.delete('non-existent');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('deleteByFriendCode', () => {
+    it('should delete contact by friend code and return true', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.deleteByFriendCode('ABCD-EFGH-JKLM-NPQR');
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        'DELETE FROM vault_contacts WHERE friend_code = ?'
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith('ABCD-EFGH-JKLM-NPQR');
+      expect(result).toBe(true);
+    });
+
+    it('should return false when friend code not found', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const result = await repository.deleteByFriendCode('XXXX-XXXX-XXXX-XXX2');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // Utility Methods
+  // ===========================================================================
+
+  describe('exists', () => {
+    it('should return true when friend code exists', async () => {
+      mockStatement.get.mockReturnValue({ '1': 1 });
+
+      const result = await repository.exists('ABCD-EFGH-JKLM-NPQR');
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        'SELECT 1 FROM vault_contacts WHERE friend_code = ?'
+      );
+      expect(mockStatement.get).toHaveBeenCalledWith('ABCD-EFGH-JKLM-NPQR');
+      expect(result).toBe(true);
+    });
+
+    it('should return false when friend code does not exist', async () => {
+      mockStatement.get.mockReturnValue(undefined);
+
+      const result = await repository.exists('XXXX-XXXX-XXXX-XXX2');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('count', () => {
+    it('should return the total number of contacts', async () => {
+      mockStatement.get.mockReturnValue({ count: 5 });
+
+      const result = await repository.count();
+
+      expect(mockDatabase.prepare).toHaveBeenCalledWith(
+        'SELECT COUNT(*) as count FROM vault_contacts'
+      );
+      expect(result).toBe(5);
+    });
+
+    it('should return 0 when no contacts exist', async () => {
+      mockStatement.get.mockReturnValue({ count: 0 });
+
+      const result = await repository.count();
+
+      expect(result).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // Singleton
+  // ===========================================================================
+
+  describe('getContactRepository', () => {
+    it('should return the same instance on multiple calls', () => {
+      resetContactRepository();
+
+      const instance1 = getContactRepository();
+      const instance2 = getContactRepository();
+
+      expect(instance1).toBe(instance2);
+    });
+  });
+
+  describe('resetContactRepository', () => {
+    it('should create a new instance after reset', () => {
+      const instance1 = getContactRepository();
+      resetContactRepository();
+      const instance2 = getContactRepository();
+
+      expect(instance1).not.toBe(instance2);
+    });
+  });
+
+  // ===========================================================================
+  // Row Conversion (Private Method via Public Interface)
+  // ===========================================================================
+
+  describe('rowToContact conversion', () => {
+    it('should correctly map all stored contact fields to contact fields', async () => {
+      const storedContact: IStoredContact = {
+        id: 'contact-full-test',
+        friend_code: 'WXYZ-WXYZ-WXYZ-WXY2',
+        public_key: 'full-public-key',
+        nickname: 'Full Nickname',
+        display_name: 'Full Display Name',
+        avatar: 'avatar-url',
+        added_at: '2024-06-15T12:00:00.000Z',
+        last_seen_at: '2024-06-15T14:00:00.000Z',
+        is_trusted: 1,
+        notes: 'Full notes text',
+      };
+      mockStatement.get.mockReturnValue(storedContact);
+
+      const result = await repository.getById('contact-full-test');
+
+      expect(result).toEqual({
+        id: 'contact-full-test',
+        friendCode: 'WXYZ-WXYZ-WXYZ-WXY2',
+        publicKey: 'full-public-key',
+        nickname: 'Full Nickname',
+        displayName: 'Full Display Name',
+        avatar: 'avatar-url',
+        addedAt: '2024-06-15T12:00:00.000Z',
+        lastSeenAt: '2024-06-15T14:00:00.000Z',
+        isTrusted: true,
+        notes: 'Full notes text',
+      });
+    });
+
+    it('should handle null values correctly', async () => {
+      const storedContact: IStoredContact = {
+        id: 'contact-null-test',
+        friend_code: 'NNNN-NNNN-NNNN-NNN2',
+        public_key: 'null-test-key',
+        nickname: null,
+        display_name: 'Null Test',
+        avatar: null,
+        added_at: '2024-01-01T00:00:00.000Z',
+        last_seen_at: null,
+        is_trusted: 0,
+        notes: null,
+      };
+      mockStatement.get.mockReturnValue(storedContact);
+
+      const result = await repository.getById('contact-null-test');
+
+      expect(result?.nickname).toBeNull();
+      expect(result?.avatar).toBeNull();
+      expect(result?.lastSeenAt).toBeNull();
+      expect(result?.notes).toBeNull();
+      expect(result?.isTrusted).toBe(false);
+    });
+  });
+});

--- a/src/services/vault/__tests__/PermissionRepository.test.ts
+++ b/src/services/vault/__tests__/PermissionRepository.test.ts
@@ -1,0 +1,1063 @@
+/**
+ * Permission Repository Tests
+ *
+ * Tests for the vault permission persistence layer using SQLite.
+ *
+ * @spec openspec/changes/add-vault-sharing/specs/vault-sharing/spec.md
+ */
+
+import type {
+  IPermissionGrant as _IPermissionGrant,
+  PermissionLevel as _PermissionLevel,
+  PermissionScopeType as _PermissionScopeType,
+  ContentCategory as _ContentCategory,
+} from '@/types/vault';
+import {
+  PermissionRepository,
+  getPermissionRepository,
+  resetPermissionRepository,
+} from '@/services/vault/PermissionRepository';
+
+// =============================================================================
+// Mock SQLite Service
+// =============================================================================
+
+// Create a mock in-memory database for testing
+const mockDatabaseTables = new Map<string, Map<string, Record<string, unknown>>>();
+
+const mockDatabase = {
+  statements: new Map<string, { sql: string; params: unknown[] }>(),
+  tables: mockDatabaseTables,
+  
+  exec: jest.fn().mockImplementation((sql: string) => {
+    // Initialize tables when exec is called (for CREATE TABLE statements)
+    if (sql.includes('CREATE TABLE IF NOT EXISTS vault_permissions')) {
+      mockDatabaseTables.set('vault_permissions', new Map());
+    }
+  }),
+  
+  prepare: jest.fn().mockImplementation((sql: string) => {
+    return {
+      run: jest.fn().mockImplementation((...params: unknown[]) => {
+        const table = mockDatabaseTables.get('vault_permissions')!;
+        
+        if (sql.includes('INSERT INTO')) {
+          // Handle INSERT
+          const id = params[0] as string;
+          table.set(id, {
+            id: params[0],
+            grantee_id: params[1],
+            scope_type: params[2],
+            scope_id: params[3],
+            scope_category: params[4],
+            level: params[5],
+            expires_at: params[6],
+            created_at: params[7],
+            grantee_name: params[8],
+          });
+          return { changes: 1 };
+        } else if (sql.includes('UPDATE')) {
+          // Handle UPDATE
+          const id = params[params.length - 1] as string;
+          const existing = table.get(id);
+          if (!existing) return { changes: 0 };
+          
+          if (sql.includes('SET level')) {
+            existing.level = params[0];
+          } else if (sql.includes('SET expires_at')) {
+            existing.expires_at = params[0];
+          }
+          return { changes: 1 };
+        } else           if (sql.includes('DELETE')) {
+          // Handle DELETE
+          if (sql.includes('WHERE id = ?')) {
+            const id = params[0] as string;
+            const existed = table.has(id);
+            table.delete(id);
+            return { changes: existed ? 1 : 0 };
+          } else if (sql.includes('WHERE grantee_id = ?')) {
+            const granteeId = params[0] as string;
+            let count = 0;
+            const entries = Array.from(table.entries());
+            for (const [id, row] of entries) {
+              if (row.grantee_id === granteeId) {
+                table.delete(id);
+                count++;
+              }
+            }
+            return { changes: count };
+          } else if (sql.includes('WHERE scope_type = ? AND scope_id = ?')) {
+            const scopeType = params[0] as string;
+            const scopeId = params[1] as string;
+            let count = 0;
+            const entries = Array.from(table.entries());
+            for (const [id, row] of entries) {
+              if (row.scope_type === scopeType && row.scope_id === scopeId) {
+                table.delete(id);
+                count++;
+              }
+            }
+            return { changes: count };
+          } else if (sql.includes('expires_at IS NOT NULL AND expires_at <')) {
+            const now = params[0] as string;
+            let count = 0;
+            const entries = Array.from(table.entries());
+            for (const [id, row] of entries) {
+              if (row.expires_at && (row.expires_at as string) < now) {
+                table.delete(id);
+                count++;
+              }
+            }
+            return { changes: count };
+          }
+          return { changes: 0 };
+        }
+        return { changes: 0 };
+      }),
+      
+      get: jest.fn().mockImplementation((...params: unknown[]) => {
+        const table = mockDatabaseTables.get('vault_permissions')!;
+        const rows = Array.from(table.values()) as Record<string, unknown>[];
+        
+        if (sql.includes('WHERE id = ?')) {
+          return table.get(params[0] as string) || undefined;
+        } else if (sql.includes("scope_type = 'item' AND scope_id = ?")) {
+          const granteeId = params[0] as string;
+          const scopeId = params[1] as string;
+          const now = params[2] as string;
+          for (const row of rows) {
+            if (
+              row.grantee_id === granteeId &&
+              row.scope_type === 'item' &&
+              row.scope_id === scopeId &&
+              (!row.expires_at || (row.expires_at as string) > now)
+            ) {
+              return { level: row.level };
+            }
+          }
+          return undefined;
+        } else if (sql.includes("scope_type = 'category' AND scope_category = ?")) {
+          const granteeId = params[0] as string;
+          const category = params[1] as string;
+          const now = params[2] as string;
+          for (const row of rows) {
+            if (
+              row.grantee_id === granteeId &&
+              row.scope_type === 'category' &&
+              row.scope_category === category &&
+              (!row.expires_at || (row.expires_at as string) > now)
+            ) {
+              return { level: row.level };
+            }
+          }
+          return undefined;
+        } else if (sql.includes("scope_type = 'all'")) {
+          const granteeId = params[0] as string;
+          const now = params[1] as string;
+          for (const row of rows) {
+            if (
+              row.grantee_id === granteeId &&
+              row.scope_type === 'all' &&
+              (!row.expires_at || (row.expires_at as string) > now)
+            ) {
+              return { level: row.level };
+            }
+          }
+          return undefined;
+        }
+        return undefined;
+      }),
+      
+      all: jest.fn().mockImplementation((...params: unknown[]) => {
+        const table = mockDatabaseTables.get('vault_permissions')!;
+        const rows = Array.from(table.values()) as Record<string, unknown>[];
+        
+        if (sql.includes('WHERE grantee_id = ?')) {
+          return rows.filter((r) => r.grantee_id === params[0]);
+        } else if (sql.includes('WHERE scope_type = ? AND scope_id = ?')) {
+          return rows.filter(
+            (r) => r.scope_type === params[0] && r.scope_id === params[1]
+          );
+        } else if (sql.includes('WHERE scope_category = ?')) {
+          return rows.filter((r) => r.scope_category === params[0]);
+        }
+        return rows;
+      }),
+    };
+  }),
+};
+
+const mockSQLiteService = {
+  initialize: jest.fn().mockResolvedValue(undefined),
+  getDatabase: jest.fn().mockReturnValue(mockDatabase),
+  close: jest.fn(),
+  isInitialized: jest.fn().mockReturnValue(true),
+};
+
+jest.mock('@/services/persistence', () => ({
+  getSQLiteService: jest.fn(() => mockSQLiteService),
+}));
+
+// Mock crypto.randomUUID
+let uuidCounter = 0;
+const mockRandomUUID = jest.fn(() => `test-uuid-${++uuidCounter}`);
+Object.defineProperty(global, 'crypto', {
+  value: { randomUUID: mockRandomUUID },
+});
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('PermissionRepository', () => {
+  let repository: PermissionRepository;
+
+  beforeEach(() => {
+    // Reset state
+    resetPermissionRepository();
+    mockDatabase.tables.clear();
+    mockDatabase.tables.set('vault_permissions', new Map());
+    uuidCounter = 0;
+    jest.clearAllMocks();
+  });
+
+  // ===========================================================================
+  // Initialization
+  // ===========================================================================
+
+  describe('initialize', () => {
+    it('should initialize the repository and create table', async () => {
+      repository = new PermissionRepository();
+      await repository.initialize();
+
+      expect(mockSQLiteService.initialize).toHaveBeenCalled();
+      expect(mockDatabase.exec).toHaveBeenCalled();
+    });
+
+    it('should only initialize once', async () => {
+      repository = new PermissionRepository();
+      await repository.initialize();
+      await repository.initialize();
+
+      // exec should only be called once
+      expect(mockDatabase.exec).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ===========================================================================
+  // Create
+  // ===========================================================================
+
+  describe('create', () => {
+    beforeEach(() => {
+      repository = new PermissionRepository();
+    });
+
+    it('should create an item permission', async () => {
+      const grant = await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+        granteeName: 'Test User',
+      });
+
+      expect(grant.id).toBe('perm-test-uuid-1');
+      expect(grant.granteeId).toBe('ABCD-EFGH-JKLM-NPQR');
+      expect(grant.scopeType).toBe('item');
+      expect(grant.scopeId).toBe('unit-123');
+      expect(grant.level).toBe('read');
+      expect(grant.granteeName).toBe('Test User');
+      expect(grant.createdAt).toBeDefined();
+    });
+
+    it('should create a category permission', async () => {
+      const grant = await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'category',
+        scopeId: null,
+        scopeCategory: 'units',
+        level: 'write',
+        expiresAt: null,
+      });
+
+      expect(grant.scopeType).toBe('category');
+      expect(grant.scopeCategory).toBe('units');
+      expect(grant.level).toBe('write');
+    });
+
+    it('should create a vault-wide permission', async () => {
+      const grant = await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'all',
+        scopeId: null,
+        scopeCategory: null,
+        level: 'admin',
+        expiresAt: null,
+      });
+
+      expect(grant.scopeType).toBe('all');
+      expect(grant.level).toBe('admin');
+    });
+
+    it('should create a permission with expiry', async () => {
+      const expiresAt = new Date(Date.now() + 86400000).toISOString();
+      const grant = await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt,
+      });
+
+      expect(grant.expiresAt).toBe(expiresAt);
+    });
+
+    it('should create a public permission', async () => {
+      const grant = await repository.create({
+        granteeId: 'public',
+        scopeType: 'item',
+        scopeId: 'unit-public',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+
+      expect(grant.granteeId).toBe('public');
+    });
+  });
+
+  // ===========================================================================
+  // GetById
+  // ===========================================================================
+
+  describe('getById', () => {
+    beforeEach(() => {
+      repository = new PermissionRepository();
+    });
+
+    it('should return permission by ID', async () => {
+      const created = await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+
+      const found = await repository.getById(created.id);
+
+      expect(found).not.toBeNull();
+      expect(found?.id).toBe(created.id);
+      expect(found?.granteeId).toBe('ABCD-EFGH-JKLM-NPQR');
+    });
+
+    it('should return null for non-existent ID', async () => {
+      const found = await repository.getById('non-existent-id');
+
+      expect(found).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // GetByGrantee
+  // ===========================================================================
+
+  describe('getByGrantee', () => {
+    beforeEach(() => {
+      repository = new PermissionRepository();
+    });
+
+    it('should return all permissions for a grantee', async () => {
+      await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-1',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+      await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-2',
+        scopeCategory: null,
+        level: 'write',
+        expiresAt: null,
+      });
+      await repository.create({
+        granteeId: 'OTHER-USER-CODE',
+        scopeType: 'item',
+        scopeId: 'unit-1',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+
+      const grants = await repository.getByGrantee('ABCD-EFGH-JKLM-NPQR');
+
+      expect(grants).toHaveLength(2);
+      expect(grants.every((g) => g.granteeId === 'ABCD-EFGH-JKLM-NPQR')).toBe(true);
+    });
+
+    it('should return empty array for unknown grantee', async () => {
+      const grants = await repository.getByGrantee('unknown-grantee');
+
+      expect(grants).toHaveLength(0);
+    });
+  });
+
+  // ===========================================================================
+  // GetByItem
+  // ===========================================================================
+
+  describe('getByItem', () => {
+    beforeEach(() => {
+      repository = new PermissionRepository();
+    });
+
+    it('should return all permissions for an item', async () => {
+      await repository.create({
+        granteeId: 'user-1',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+      await repository.create({
+        granteeId: 'user-2',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'write',
+        expiresAt: null,
+      });
+      await repository.create({
+        granteeId: 'user-1',
+        scopeType: 'item',
+        scopeId: 'unit-456',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+
+      const grants = await repository.getByItem('item', 'unit-123');
+
+      expect(grants).toHaveLength(2);
+      expect(grants.every((g) => g.scopeId === 'unit-123')).toBe(true);
+    });
+
+    it('should return empty array for unknown item', async () => {
+      const grants = await repository.getByItem('item', 'unknown-item');
+
+      expect(grants).toHaveLength(0);
+    });
+  });
+
+  // ===========================================================================
+  // GetByCategory
+  // ===========================================================================
+
+  describe('getByCategory', () => {
+    beforeEach(() => {
+      repository = new PermissionRepository();
+    });
+
+    it('should return all permissions for a category', async () => {
+      await repository.create({
+        granteeId: 'user-1',
+        scopeType: 'category',
+        scopeId: null,
+        scopeCategory: 'units',
+        level: 'read',
+        expiresAt: null,
+      });
+      await repository.create({
+        granteeId: 'user-2',
+        scopeType: 'category',
+        scopeId: null,
+        scopeCategory: 'units',
+        level: 'write',
+        expiresAt: null,
+      });
+      await repository.create({
+        granteeId: 'user-1',
+        scopeType: 'category',
+        scopeId: null,
+        scopeCategory: 'pilots',
+        level: 'read',
+        expiresAt: null,
+      });
+
+      const grants = await repository.getByCategory('units');
+
+      expect(grants).toHaveLength(2);
+      expect(grants.every((g) => g.scopeCategory === 'units')).toBe(true);
+    });
+
+    it('should return empty array for unknown category', async () => {
+      const grants = await repository.getByCategory('forces');
+
+      expect(grants).toHaveLength(0);
+    });
+  });
+
+  // ===========================================================================
+  // GetAll
+  // ===========================================================================
+
+  describe('getAll', () => {
+    beforeEach(() => {
+      repository = new PermissionRepository();
+    });
+
+    it('should return all permissions', async () => {
+      await repository.create({
+        granteeId: 'user-1',
+        scopeType: 'item',
+        scopeId: 'unit-1',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+      await repository.create({
+        granteeId: 'user-2',
+        scopeType: 'category',
+        scopeId: null,
+        scopeCategory: 'units',
+        level: 'write',
+        expiresAt: null,
+      });
+      await repository.create({
+        granteeId: 'user-3',
+        scopeType: 'all',
+        scopeId: null,
+        scopeCategory: null,
+        level: 'admin',
+        expiresAt: null,
+      });
+
+      const grants = await repository.getAll();
+
+      expect(grants).toHaveLength(3);
+    });
+
+    it('should return empty array when no permissions exist', async () => {
+      const grants = await repository.getAll();
+
+      expect(grants).toHaveLength(0);
+    });
+  });
+
+  // ===========================================================================
+  // CheckPermission
+  // ===========================================================================
+
+  describe('checkPermission', () => {
+    beforeEach(() => {
+      repository = new PermissionRepository();
+    });
+
+    it('should find explicit item permission', async () => {
+      await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+
+      const level = await repository.checkPermission(
+        'ABCD-EFGH-JKLM-NPQR',
+        'item',
+        'unit-123'
+      );
+
+      expect(level).toBe('read');
+    });
+
+    it('should find category permission', async () => {
+      await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'category',
+        scopeId: null,
+        scopeCategory: 'units',
+        level: 'write',
+        expiresAt: null,
+      });
+
+      const level = await repository.checkPermission(
+        'ABCD-EFGH-JKLM-NPQR',
+        'item',
+        'unit-123',
+        'units'
+      );
+
+      expect(level).toBe('write');
+    });
+
+    it('should find vault-wide permission', async () => {
+      await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'all',
+        scopeId: null,
+        scopeCategory: null,
+        level: 'admin',
+        expiresAt: null,
+      });
+
+      const level = await repository.checkPermission(
+        'ABCD-EFGH-JKLM-NPQR',
+        'item',
+        'unit-123'
+      );
+
+      expect(level).toBe('admin');
+    });
+
+    it('should find public permission for non-public grantee', async () => {
+      await repository.create({
+        granteeId: 'public',
+        scopeType: 'item',
+        scopeId: 'unit-public',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+
+      const level = await repository.checkPermission(
+        'SOME-OTHER-USER',
+        'item',
+        'unit-public'
+      );
+
+      expect(level).toBe('read');
+    });
+
+    it('should return null when no permission exists', async () => {
+      const level = await repository.checkPermission(
+        'ABCD-EFGH-JKLM-NPQR',
+        'item',
+        'unit-123'
+      );
+
+      expect(level).toBeNull();
+    });
+
+    it('should not find expired permissions', async () => {
+      const expiredAt = new Date(Date.now() - 1000).toISOString();
+      await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: expiredAt,
+      });
+
+      const level = await repository.checkPermission(
+        'ABCD-EFGH-JKLM-NPQR',
+        'item',
+        'unit-123'
+      );
+
+      expect(level).toBeNull();
+    });
+
+    it('should find non-expired permissions', async () => {
+      const futureAt = new Date(Date.now() + 86400000).toISOString();
+      await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: futureAt,
+      });
+
+      const level = await repository.checkPermission(
+        'ABCD-EFGH-JKLM-NPQR',
+        'item',
+        'unit-123'
+      );
+
+      expect(level).toBe('read');
+    });
+  });
+
+  // ===========================================================================
+  // UpdateLevel
+  // ===========================================================================
+
+  describe('updateLevel', () => {
+    beforeEach(() => {
+      repository = new PermissionRepository();
+    });
+
+    it('should update permission level', async () => {
+      const created = await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+
+      const success = await repository.updateLevel(created.id, 'write');
+
+      expect(success).toBe(true);
+
+      const updated = await repository.getById(created.id);
+      expect(updated?.level).toBe('write');
+    });
+
+    it('should return false for non-existent permission', async () => {
+      const success = await repository.updateLevel('non-existent', 'write');
+
+      expect(success).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // UpdateExpiry
+  // ===========================================================================
+
+  describe('updateExpiry', () => {
+    beforeEach(() => {
+      repository = new PermissionRepository();
+    });
+
+    it('should update permission expiry', async () => {
+      const created = await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+
+      const newExpiry = new Date(Date.now() + 86400000).toISOString();
+      const success = await repository.updateExpiry(created.id, newExpiry);
+
+      expect(success).toBe(true);
+
+      const updated = await repository.getById(created.id);
+      expect(updated?.expiresAt).toBe(newExpiry);
+    });
+
+    it('should clear expiry with null', async () => {
+      const initialExpiry = new Date().toISOString();
+      const created = await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: initialExpiry,
+      });
+
+      const success = await repository.updateExpiry(created.id, null);
+
+      expect(success).toBe(true);
+
+      const updated = await repository.getById(created.id);
+      expect(updated?.expiresAt).toBeNull();
+    });
+
+    it('should return false for non-existent permission', async () => {
+      const success = await repository.updateExpiry('non-existent', null);
+
+      expect(success).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // Delete
+  // ===========================================================================
+
+  describe('delete', () => {
+    beforeEach(() => {
+      repository = new PermissionRepository();
+    });
+
+    it('should delete a permission', async () => {
+      const created = await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+
+      const success = await repository.delete(created.id);
+
+      expect(success).toBe(true);
+
+      const found = await repository.getById(created.id);
+      expect(found).toBeNull();
+    });
+
+    it('should return false for non-existent permission', async () => {
+      const success = await repository.delete('non-existent');
+
+      expect(success).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // DeleteByGrantee
+  // ===========================================================================
+
+  describe('deleteByGrantee', () => {
+    beforeEach(() => {
+      repository = new PermissionRepository();
+    });
+
+    it('should delete all permissions for a grantee', async () => {
+      await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-1',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+      await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-2',
+        scopeCategory: null,
+        level: 'write',
+        expiresAt: null,
+      });
+      await repository.create({
+        granteeId: 'OTHER-USER',
+        scopeType: 'item',
+        scopeId: 'unit-1',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+
+      const count = await repository.deleteByGrantee('ABCD-EFGH-JKLM-NPQR');
+
+      expect(count).toBe(2);
+
+      const remaining = await repository.getAll();
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].granteeId).toBe('OTHER-USER');
+    });
+
+    it('should return 0 for unknown grantee', async () => {
+      const count = await repository.deleteByGrantee('unknown');
+
+      expect(count).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // DeleteByItem
+  // ===========================================================================
+
+  describe('deleteByItem', () => {
+    beforeEach(() => {
+      repository = new PermissionRepository();
+    });
+
+    it('should delete all permissions for an item', async () => {
+      await repository.create({
+        granteeId: 'user-1',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+      await repository.create({
+        granteeId: 'user-2',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'write',
+        expiresAt: null,
+      });
+      await repository.create({
+        granteeId: 'user-1',
+        scopeType: 'item',
+        scopeId: 'unit-456',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+
+      const count = await repository.deleteByItem('item', 'unit-123');
+
+      expect(count).toBe(2);
+
+      const remaining = await repository.getAll();
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].scopeId).toBe('unit-456');
+    });
+
+    it('should return 0 for unknown item', async () => {
+      const count = await repository.deleteByItem('item', 'unknown');
+
+      expect(count).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // CleanupExpired
+  // ===========================================================================
+
+  describe('cleanupExpired', () => {
+    beforeEach(() => {
+      repository = new PermissionRepository();
+    });
+
+    it('should remove expired permissions', async () => {
+      const expiredAt = new Date(Date.now() - 1000).toISOString();
+      const futureAt = new Date(Date.now() + 86400000).toISOString();
+
+      await repository.create({
+        granteeId: 'user-1',
+        scopeType: 'item',
+        scopeId: 'unit-1',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: expiredAt,
+      });
+      await repository.create({
+        granteeId: 'user-2',
+        scopeType: 'item',
+        scopeId: 'unit-2',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: futureAt,
+      });
+      await repository.create({
+        granteeId: 'user-3',
+        scopeType: 'item',
+        scopeId: 'unit-3',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null, // No expiry
+      });
+
+      const count = await repository.cleanupExpired();
+
+      expect(count).toBe(1);
+
+      const remaining = await repository.getAll();
+      expect(remaining).toHaveLength(2);
+    });
+
+    it('should return 0 when no expired permissions', async () => {
+      const futureAt = new Date(Date.now() + 86400000).toISOString();
+
+      await repository.create({
+        granteeId: 'user-1',
+        scopeType: 'item',
+        scopeId: 'unit-1',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: futureAt,
+      });
+      await repository.create({
+        granteeId: 'user-2',
+        scopeType: 'item',
+        scopeId: 'unit-2',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+      });
+
+      const count = await repository.cleanupExpired();
+
+      expect(count).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // Singleton
+  // ===========================================================================
+
+  describe('getPermissionRepository singleton', () => {
+    it('should return the same instance', () => {
+      resetPermissionRepository();
+      
+      const instance1 = getPermissionRepository();
+      const instance2 = getPermissionRepository();
+
+      expect(instance1).toBe(instance2);
+    });
+
+    it('should return new instance after reset', () => {
+      const instance1 = getPermissionRepository();
+      resetPermissionRepository();
+      const instance2 = getPermissionRepository();
+
+      expect(instance1).not.toBe(instance2);
+    });
+  });
+
+  // ===========================================================================
+  // Row Conversion
+  // ===========================================================================
+
+  describe('rowToGrant conversion', () => {
+    beforeEach(() => {
+      repository = new PermissionRepository();
+    });
+
+    it('should correctly convert database row to IPermissionGrant', async () => {
+      const created = await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+        granteeName: 'Test User',
+      });
+
+      const found = await repository.getById(created.id);
+
+      expect(found).not.toBeNull();
+      expect(found!.id).toEqual(expect.any(String));
+      expect(found!.granteeId).toBe('ABCD-EFGH-JKLM-NPQR');
+      expect(found!.scopeType).toBe('item');
+      expect(found!.scopeId).toBe('unit-123');
+      expect(found!.scopeCategory).toBeNull();
+      expect(found!.level).toBe('read');
+      expect(found!.expiresAt).toBeNull();
+      expect(found!.createdAt).toEqual(expect.any(String));
+      expect(found!.granteeName).toBe('Test User');
+    });
+
+    it('should handle null granteeName correctly', async () => {
+      const created = await repository.create({
+        granteeId: 'ABCD-EFGH-JKLM-NPQR',
+        scopeType: 'item',
+        scopeId: 'unit-123',
+        scopeCategory: null,
+        level: 'read',
+        expiresAt: null,
+        // No granteeName
+      });
+
+      const found = await repository.getById(created.id);
+
+      expect(found?.granteeName).toBeUndefined();
+    });
+  });
+});

--- a/src/services/vault/__tests__/ShareLinkRepository.test.ts
+++ b/src/services/vault/__tests__/ShareLinkRepository.test.ts
@@ -1,0 +1,928 @@
+/**
+ * Share Link Repository Tests
+ *
+ * Tests for share link persistence to SQLite including CRUD operations,
+ * token generation, and atomic redemption.
+ *
+ * @spec openspec/changes/add-vault-sharing/specs/vault-sharing/spec.md
+ */
+
+import {
+  ShareLinkRepository,
+  getShareLinkRepository,
+  resetShareLinkRepository,
+} from '@/services/vault/ShareLinkRepository';
+import type {
+  IStoredShareLink,
+  PermissionScopeType,
+  ContentCategory,
+} from '@/types/vault';
+
+// =============================================================================
+// Mock Setup
+// =============================================================================
+
+// Mock statement for prepared statements
+const createMockStatement = () => ({
+  run: jest.fn().mockReturnValue({ changes: 1 }),
+  get: jest.fn().mockReturnValue(undefined),
+  all: jest.fn().mockReturnValue([]),
+});
+
+// Mock database
+const mockDb = {
+  exec: jest.fn(),
+  prepare: jest.fn().mockReturnValue(createMockStatement()),
+};
+
+// Mock SQLite service
+const mockSQLiteService = {
+  initialize: jest.fn().mockResolvedValue(undefined),
+  getDatabase: jest.fn().mockReturnValue(mockDb),
+};
+
+// Mock getSQLiteService
+jest.mock('@/services/persistence', () => ({
+  getSQLiteService: () => mockSQLiteService,
+}));
+
+// Mock crypto.randomUUID
+const mockUUID = 'test-uuid-12345678';
+const originalCrypto = global.crypto;
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Creates a mock stored share link row
+ */
+function createMockStoredLink(
+  overrides: Partial<IStoredShareLink> = {}
+): IStoredShareLink {
+  return {
+    id: 'link-test-id',
+    token: 'test-token-abc123',
+    scope_type: 'item',
+    scope_id: 'unit-123',
+    scope_category: null,
+    level: 'read',
+    expires_at: null,
+    max_uses: null,
+    use_count: 0,
+    created_at: '2024-01-01T00:00:00.000Z',
+    label: null,
+    is_active: 1,
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('ShareLinkRepository', () => {
+  let repository: ShareLinkRepository;
+  let mockStatement: ReturnType<typeof createMockStatement>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetShareLinkRepository();
+
+    // Create fresh mock statement for each test
+    mockStatement = createMockStatement();
+    mockDb.prepare.mockReturnValue(mockStatement);
+
+    repository = new ShareLinkRepository();
+
+    // Mock crypto
+    global.crypto = {
+      ...originalCrypto,
+      randomUUID: jest.fn().mockReturnValue(mockUUID),
+      getRandomValues: jest.fn((arr: Uint8Array) => {
+        for (let i = 0; i < arr.length; i++) {
+          arr[i] = i % 256;
+        }
+        return arr;
+      }),
+    } as Crypto;
+  });
+
+  afterEach(() => {
+    global.crypto = originalCrypto;
+  });
+
+  // ===========================================================================
+  // Initialization
+  // ===========================================================================
+
+  describe('initialize', () => {
+    it('should initialize the database table on first call', async () => {
+      await repository.initialize();
+
+      expect(mockSQLiteService.initialize).toHaveBeenCalled();
+      expect(mockDb.exec).toHaveBeenCalledTimes(1);
+      expect(mockDb.exec).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE TABLE IF NOT EXISTS vault_share_links')
+      );
+    });
+
+    it('should not reinitialize on subsequent calls', async () => {
+      await repository.initialize();
+      await repository.initialize();
+      await repository.initialize();
+
+      expect(mockDb.exec).toHaveBeenCalledTimes(1);
+    });
+
+    it('should create required indexes', async () => {
+      await repository.initialize();
+
+      const execCalls = mockDb.exec.mock.calls as [[string]];
+      const execCall = execCalls[0][0];
+      expect(execCall).toContain('CREATE UNIQUE INDEX IF NOT EXISTS idx_vault_share_links_token');
+      expect(execCall).toContain('CREATE INDEX IF NOT EXISTS idx_vault_share_links_scope');
+      expect(execCall).toContain('CREATE INDEX IF NOT EXISTS idx_vault_share_links_active');
+    });
+  });
+
+  // ===========================================================================
+  // Create
+  // ===========================================================================
+
+  describe('create', () => {
+    it('should create an item share link', async () => {
+      const result = await repository.create('item', 'unit-123', null, {
+        level: 'read',
+      });
+
+      expect(mockStatement.run).toHaveBeenCalledWith(
+        expect.stringContaining('link-'),
+        expect.any(String), // token
+        'item',
+        'unit-123',
+        null,
+        'read',
+        null, // expiresAt
+        null, // maxUses
+        expect.any(String), // createdAt
+        null // label
+      );
+
+      expect(result.scopeType).toBe('item');
+      expect(result.scopeId).toBe('unit-123');
+      expect(result.level).toBe('read');
+      expect(result.isActive).toBe(true);
+      expect(result.useCount).toBe(0);
+    });
+
+    it('should create a category share link', async () => {
+      const result = await repository.create('category', null, 'units', {
+        level: 'write',
+      });
+
+      expect(mockStatement.run).toHaveBeenCalledWith(
+        expect.stringContaining('link-'),
+        expect.any(String),
+        'category',
+        null,
+        'units',
+        'write',
+        null,
+        null,
+        expect.any(String),
+        null
+      );
+
+      expect(result.scopeType).toBe('category');
+      expect(result.scopeCategory).toBe('units');
+      expect(result.level).toBe('write');
+    });
+
+    it('should create a link with all options', async () => {
+      const expiresAt = '2025-01-01T00:00:00.000Z';
+      const result = await repository.create('item', 'unit-123', null, {
+        level: 'admin',
+        expiresAt,
+        maxUses: 10,
+        label: 'Test Link',
+      });
+
+      expect(mockStatement.run).toHaveBeenCalledWith(
+        expect.stringContaining('link-'),
+        expect.any(String),
+        'item',
+        'unit-123',
+        null,
+        'admin',
+        expiresAt,
+        10,
+        expect.any(String),
+        'Test Link'
+      );
+
+      expect(result.expiresAt).toBe(expiresAt);
+      expect(result.maxUses).toBe(10);
+      expect(result.label).toBe('Test Link');
+    });
+
+    it('should generate a unique token for each link', async () => {
+      const result1 = await repository.create('item', 'unit-1', null, { level: 'read' });
+      const result2 = await repository.create('item', 'unit-2', null, { level: 'read' });
+
+      // Both should have tokens (we can't test uniqueness with mocked crypto)
+      expect(result1.token).toBeDefined();
+      expect(result2.token).toBeDefined();
+      expect(result1.token.length).toBeGreaterThan(0);
+    });
+
+    it('should create an "all" scope share link', async () => {
+      const result = await repository.create('all', null, null, {
+        level: 'read',
+      });
+
+      expect(result.scopeType).toBe('all');
+      expect(result.scopeId).toBeNull();
+      expect(result.scopeCategory).toBeNull();
+    });
+
+    it('should create a folder scope share link', async () => {
+      const result = await repository.create('folder', 'folder-123', null, {
+        level: 'write',
+      });
+
+      expect(result.scopeType).toBe('folder');
+      expect(result.scopeId).toBe('folder-123');
+    });
+  });
+
+  // ===========================================================================
+  // Get By ID
+  // ===========================================================================
+
+  describe('getById', () => {
+    it('should return null when link not found', async () => {
+      mockStatement.get.mockReturnValue(undefined);
+
+      const result = await repository.getById('non-existent');
+
+      expect(result).toBeNull();
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        'SELECT * FROM vault_share_links WHERE id = ?'
+      );
+      expect(mockStatement.get).toHaveBeenCalledWith('non-existent');
+    });
+
+    it('should return the link when found', async () => {
+      const storedLink = createMockStoredLink();
+      mockStatement.get.mockReturnValue(storedLink);
+
+      const result = await repository.getById('link-test-id');
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe('link-test-id');
+      expect(result?.token).toBe('test-token-abc123');
+      expect(result?.scopeType).toBe('item');
+      expect(result?.isActive).toBe(true);
+    });
+
+    it('should correctly convert is_active from number to boolean', async () => {
+      const activeLink = createMockStoredLink({ is_active: 1 });
+      mockStatement.get.mockReturnValue(activeLink);
+
+      let result = await repository.getById('link-1');
+      expect(result?.isActive).toBe(true);
+
+      const inactiveLink = createMockStoredLink({ is_active: 0 });
+      mockStatement.get.mockReturnValue(inactiveLink);
+
+      result = await repository.getById('link-2');
+      expect(result?.isActive).toBe(false);
+    });
+
+    it('should convert label null to undefined', async () => {
+      const linkWithNoLabel = createMockStoredLink({ label: null });
+      mockStatement.get.mockReturnValue(linkWithNoLabel);
+
+      const result = await repository.getById('link-1');
+      expect(result?.label).toBeUndefined();
+
+      const linkWithLabel = createMockStoredLink({ label: 'My Label' });
+      mockStatement.get.mockReturnValue(linkWithLabel);
+
+      const result2 = await repository.getById('link-2');
+      expect(result2?.label).toBe('My Label');
+    });
+  });
+
+  // ===========================================================================
+  // Get By Token
+  // ===========================================================================
+
+  describe('getByToken', () => {
+    it('should return null when token not found', async () => {
+      mockStatement.get.mockReturnValue(undefined);
+
+      const result = await repository.getByToken('invalid-token');
+
+      expect(result).toBeNull();
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        'SELECT * FROM vault_share_links WHERE token = ?'
+      );
+      expect(mockStatement.get).toHaveBeenCalledWith('invalid-token');
+    });
+
+    it('should return the link when token found', async () => {
+      const storedLink = createMockStoredLink({ token: 'valid-token' });
+      mockStatement.get.mockReturnValue(storedLink);
+
+      const result = await repository.getByToken('valid-token');
+
+      expect(result).not.toBeNull();
+      expect(result?.token).toBe('valid-token');
+    });
+  });
+
+  // ===========================================================================
+  // Get By Item
+  // ===========================================================================
+
+  describe('getByItem', () => {
+    it('should return empty array when no links for item', async () => {
+      mockStatement.all.mockReturnValue([]);
+
+      const result = await repository.getByItem('item', 'unit-no-links');
+
+      expect(result).toEqual([]);
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('WHERE scope_type = ? AND scope_id = ?')
+      );
+      expect(mockStatement.all).toHaveBeenCalledWith('item', 'unit-no-links');
+    });
+
+    it('should return all links for an item', async () => {
+      const links = [
+        createMockStoredLink({ id: 'link-1', level: 'read' }),
+        createMockStoredLink({ id: 'link-2', level: 'write' }),
+      ];
+      mockStatement.all.mockReturnValue(links);
+
+      const result = await repository.getByItem('item', 'unit-123');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('link-1');
+      expect(result[1].id).toBe('link-2');
+    });
+
+    it('should return links ordered by created_at DESC', async () => {
+      await repository.getByItem('item', 'unit-123');
+
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('ORDER BY created_at DESC')
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Get Active
+  // ===========================================================================
+
+  describe('getActive', () => {
+    it('should return only active links', async () => {
+      const activeLinks = [
+        createMockStoredLink({ id: 'link-1', is_active: 1 }),
+        createMockStoredLink({ id: 'link-2', is_active: 1 }),
+      ];
+      mockStatement.all.mockReturnValue(activeLinks);
+
+      const result = await repository.getActive();
+
+      expect(result).toHaveLength(2);
+      result.forEach((link) => expect(link.isActive).toBe(true));
+
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('WHERE is_active = 1')
+      );
+    });
+
+    it('should return empty array when no active links', async () => {
+      mockStatement.all.mockReturnValue([]);
+
+      const result = await repository.getActive();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ===========================================================================
+  // Get All
+  // ===========================================================================
+
+  describe('getAll', () => {
+    it('should return all links regardless of active status', async () => {
+      const allLinks = [
+        createMockStoredLink({ id: 'link-1', is_active: 1 }),
+        createMockStoredLink({ id: 'link-2', is_active: 0 }),
+      ];
+      mockStatement.all.mockReturnValue(allLinks);
+
+      const result = await repository.getAll();
+
+      expect(result).toHaveLength(2);
+      expect(result[0].isActive).toBe(true);
+      expect(result[1].isActive).toBe(false);
+    });
+
+    it('should return links ordered by created_at DESC', async () => {
+      await repository.getAll();
+
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('ORDER BY created_at DESC')
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Redeem
+  // ===========================================================================
+
+  describe('redeem', () => {
+    it('should successfully redeem a valid link', async () => {
+      // First call: atomic update succeeds
+      mockStatement.run.mockReturnValue({ changes: 1 });
+      // Second call: getByToken returns updated link
+      const updatedLink = createMockStoredLink({ use_count: 1 });
+      mockStatement.get.mockReturnValue(updatedLink);
+
+      const result = await repository.redeem('valid-token');
+
+      expect(result.success).toBe(true);
+      expect(result.link).toBeDefined();
+      expect(result.link?.useCount).toBe(1);
+    });
+
+    it('should return NOT_FOUND error for non-existent token', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+      mockStatement.get.mockReturnValue(undefined);
+
+      const result = await repository.redeem('non-existent-token');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('NOT_FOUND');
+      expect(result.error).toContain('not found');
+    });
+
+    it('should return INACTIVE error for deactivated link', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+      const inactiveLink = createMockStoredLink({ is_active: 0 });
+      mockStatement.get.mockReturnValue(inactiveLink);
+
+      const result = await repository.redeem('inactive-token');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('INACTIVE');
+      expect(result.error).toContain('inactive');
+      expect(result.link).toBeDefined();
+    });
+
+    it('should return EXPIRED error for expired link', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+      const expiredLink = createMockStoredLink({
+        expires_at: '2020-01-01T00:00:00.000Z',
+      });
+      mockStatement.get.mockReturnValue(expiredLink);
+
+      const result = await repository.redeem('expired-token');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('EXPIRED');
+      expect(result.error).toContain('expired');
+    });
+
+    it('should return MAX_USES error when max uses reached', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+      const maxedLink = createMockStoredLink({
+        max_uses: 5,
+        use_count: 5,
+      });
+      mockStatement.get.mockReturnValue(maxedLink);
+
+      const result = await repository.redeem('maxed-token');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('MAX_USES');
+      expect(result.error).toContain('maximum uses');
+    });
+
+    it('should use atomic update to prevent race conditions', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+      const updatedLink = createMockStoredLink({ use_count: 1 });
+      mockStatement.get.mockReturnValue(updatedLink);
+
+      await repository.redeem('valid-token');
+
+      // Verify the atomic UPDATE was called with all conditions
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE vault_share_links')
+      );
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('SET use_count = use_count + 1')
+      );
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('WHERE token = ?')
+      );
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        expect.stringContaining('AND is_active = 1')
+      );
+    });
+
+    it('should return INVALID error when all validation conditions fail unexpectedly', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+      // Link exists, is active, not expired, not maxed - but update still failed
+      const validLink = createMockStoredLink({
+        is_active: 1,
+        expires_at: '2099-01-01T00:00:00.000Z',
+        max_uses: 10,
+        use_count: 0,
+      });
+      mockStatement.get.mockReturnValue(validLink);
+
+      const result = await repository.redeem('valid-token');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('INVALID');
+    });
+  });
+
+  // ===========================================================================
+  // Deactivate
+  // ===========================================================================
+
+  describe('deactivate', () => {
+    it('should deactivate an existing link', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.deactivate('link-123');
+
+      expect(result).toBe(true);
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        'UPDATE vault_share_links SET is_active = 0 WHERE id = ?'
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith('link-123');
+    });
+
+    it('should return false when link does not exist', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const result = await repository.deactivate('non-existent');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // Reactivate
+  // ===========================================================================
+
+  describe('reactivate', () => {
+    it('should reactivate an existing link', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.reactivate('link-123');
+
+      expect(result).toBe(true);
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        'UPDATE vault_share_links SET is_active = 1 WHERE id = ?'
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith('link-123');
+    });
+
+    it('should return false when link does not exist', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const result = await repository.reactivate('non-existent');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // Update Label
+  // ===========================================================================
+
+  describe('updateLabel', () => {
+    it('should update the label', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.updateLabel('link-123', 'New Label');
+
+      expect(result).toBe(true);
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        'UPDATE vault_share_links SET label = ? WHERE id = ?'
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith('New Label', 'link-123');
+    });
+
+    it('should clear the label with null', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.updateLabel('link-123', null);
+
+      expect(result).toBe(true);
+      expect(mockStatement.run).toHaveBeenCalledWith(null, 'link-123');
+    });
+
+    it('should return false when link does not exist', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const result = await repository.updateLabel('non-existent', 'Label');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // Update Expiry
+  // ===========================================================================
+
+  describe('updateExpiry', () => {
+    it('should update the expiry date', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+      const newExpiry = '2025-06-01T00:00:00.000Z';
+
+      const result = await repository.updateExpiry('link-123', newExpiry);
+
+      expect(result).toBe(true);
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        'UPDATE vault_share_links SET expires_at = ? WHERE id = ?'
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith(newExpiry, 'link-123');
+    });
+
+    it('should remove expiry with null', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.updateExpiry('link-123', null);
+
+      expect(result).toBe(true);
+      expect(mockStatement.run).toHaveBeenCalledWith(null, 'link-123');
+    });
+
+    it('should return false when link does not exist', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const result = await repository.updateExpiry('non-existent', '2025-01-01T00:00:00.000Z');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // Update Max Uses
+  // ===========================================================================
+
+  describe('updateMaxUses', () => {
+    it('should update max uses', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.updateMaxUses('link-123', 20);
+
+      expect(result).toBe(true);
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        'UPDATE vault_share_links SET max_uses = ? WHERE id = ?'
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith(20, 'link-123');
+    });
+
+    it('should remove max uses limit with null', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.updateMaxUses('link-123', null);
+
+      expect(result).toBe(true);
+      expect(mockStatement.run).toHaveBeenCalledWith(null, 'link-123');
+    });
+
+    it('should return false when link does not exist', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const result = await repository.updateMaxUses('non-existent', 10);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // Delete
+  // ===========================================================================
+
+  describe('delete', () => {
+    it('should delete an existing link', async () => {
+      mockStatement.run.mockReturnValue({ changes: 1 });
+
+      const result = await repository.delete('link-123');
+
+      expect(result).toBe(true);
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        'DELETE FROM vault_share_links WHERE id = ?'
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith('link-123');
+    });
+
+    it('should return false when link does not exist', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const result = await repository.delete('non-existent');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // Delete By Item
+  // ===========================================================================
+
+  describe('deleteByItem', () => {
+    it('should delete all links for an item', async () => {
+      mockStatement.run.mockReturnValue({ changes: 3 });
+
+      const result = await repository.deleteByItem('item', 'unit-123');
+
+      expect(result).toBe(3);
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        'DELETE FROM vault_share_links WHERE scope_type = ? AND scope_id = ?'
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith('item', 'unit-123');
+    });
+
+    it('should return 0 when no links exist for item', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const result = await repository.deleteByItem('item', 'unit-no-links');
+
+      expect(result).toBe(0);
+    });
+
+    it('should work with folder scope type', async () => {
+      mockStatement.run.mockReturnValue({ changes: 2 });
+
+      const result = await repository.deleteByItem('folder', 'folder-123');
+
+      expect(result).toBe(2);
+      expect(mockStatement.run).toHaveBeenCalledWith('folder', 'folder-123');
+    });
+  });
+
+  // ===========================================================================
+  // Cleanup Expired
+  // ===========================================================================
+
+  describe('cleanupExpired', () => {
+    it('should delete expired links', async () => {
+      mockStatement.run.mockReturnValue({ changes: 5 });
+
+      const result = await repository.cleanupExpired();
+
+      expect(result).toBe(5);
+      expect(mockDb.prepare).toHaveBeenCalledWith(
+        'DELETE FROM vault_share_links WHERE expires_at IS NOT NULL AND expires_at < ?'
+      );
+      expect(mockStatement.run).toHaveBeenCalledWith(expect.any(String));
+    });
+
+    it('should return 0 when no expired links', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const result = await repository.cleanupExpired();
+
+      expect(result).toBe(0);
+    });
+
+    it('should use current timestamp for comparison', async () => {
+      mockStatement.run.mockReturnValue({ changes: 0 });
+
+      const before = Date.now();
+      await repository.cleanupExpired();
+      const after = Date.now();
+
+      const runCalls = mockStatement.run.mock.calls as [[string]];
+      const runCall = runCalls[0][0];
+      const callTime = new Date(runCall).getTime();
+
+      expect(callTime).toBeGreaterThanOrEqual(before);
+      expect(callTime).toBeLessThanOrEqual(after);
+    });
+  });
+
+  // ===========================================================================
+  // Singleton
+  // ===========================================================================
+
+  describe('singleton', () => {
+    beforeEach(() => {
+      resetShareLinkRepository();
+    });
+
+    it('should return same instance on multiple calls', () => {
+      const instance1 = getShareLinkRepository();
+      const instance2 = getShareLinkRepository();
+
+      expect(instance1).toBe(instance2);
+    });
+
+    it('should create new instance after reset', () => {
+      const instance1 = getShareLinkRepository();
+      resetShareLinkRepository();
+      const instance2 = getShareLinkRepository();
+
+      expect(instance1).not.toBe(instance2);
+    });
+  });
+
+  // ===========================================================================
+  // Token Generation
+  // ===========================================================================
+
+  describe('token generation', () => {
+    it('should generate base64url encoded token', async () => {
+      const result = await repository.create('item', 'unit-123', null, {
+        level: 'read',
+      });
+
+      // Token should be URL-safe (no +, /, or = characters)
+      expect(result.token).not.toMatch(/[+/=]/);
+    });
+
+    it('should generate token of appropriate length', async () => {
+      const result = await repository.create('item', 'unit-123', null, {
+        level: 'read',
+      });
+
+      // 24 bytes -> 32 base64 chars (minus padding)
+      expect(result.token.length).toBeGreaterThanOrEqual(30);
+    });
+  });
+
+  // ===========================================================================
+  // Edge Cases
+  // ===========================================================================
+
+  describe('edge cases', () => {
+    it('should handle all content categories', async () => {
+      const categories: ContentCategory[] = ['units', 'pilots', 'forces', 'encounters'];
+
+      for (const category of categories) {
+        mockStatement.run.mockReturnValue({ changes: 1 });
+        const result = await repository.create('category', null, category, {
+          level: 'read',
+        });
+        expect(result.scopeCategory).toBe(category);
+      }
+    });
+
+    it('should handle all permission levels', async () => {
+      const levels = ['read', 'write', 'admin'] as const;
+
+      for (const level of levels) {
+        mockStatement.run.mockReturnValue({ changes: 1 });
+        const result = await repository.create('item', 'unit-123', null, {
+          level,
+        });
+        expect(result.level).toBe(level);
+      }
+    });
+
+    it('should handle all scope types', async () => {
+      const scopeTypes: PermissionScopeType[] = ['item', 'folder', 'category', 'all'];
+
+      for (const scopeType of scopeTypes) {
+        mockStatement.run.mockReturnValue({ changes: 1 });
+        const result = await repository.create(
+          scopeType,
+          scopeType === 'item' || scopeType === 'folder' ? 'test-id' : null,
+          scopeType === 'category' ? 'units' : null,
+          { level: 'read' }
+        );
+        expect(result.scopeType).toBe(scopeType);
+      }
+    });
+
+    it('should handle link with zero use count correctly', async () => {
+      const storedLink = createMockStoredLink({ use_count: 0 });
+      mockStatement.get.mockReturnValue(storedLink);
+
+      const result = await repository.getById('link-123');
+
+      expect(result?.useCount).toBe(0);
+    });
+
+    it('should handle link with very high use count', async () => {
+      const storedLink = createMockStoredLink({ use_count: 999999 });
+      mockStatement.get.mockReturnValue(storedLink);
+
+      const result = await repository.getById('link-123');
+
+      expect(result?.useCount).toBe(999999);
+    });
+  });
+});

--- a/src/services/vault/__tests__/VaultFolderRepository.test.ts
+++ b/src/services/vault/__tests__/VaultFolderRepository.test.ts
@@ -1,0 +1,1226 @@
+/**
+ * VaultFolderRepository Tests
+ *
+ * Tests for vault folder persistence including folder CRUD operations
+ * and folder-item assignments.
+ *
+ * @spec openspec/changes/add-vault-sharing/specs/vault-sharing/spec.md
+ */
+
+import type { IStoredVaultFolder, IStoredFolderItem } from '@/types/vault';
+
+// =============================================================================
+// Mock Setup - must be before imports that use the mocked modules
+// =============================================================================
+
+// Mock UUID generation for predictable IDs in tests
+let uuidCounter = 0;
+const mockRandomUUID = jest.fn(() => `test-uuid-${++uuidCounter}`);
+Object.defineProperty(global, 'crypto', {
+  value: {
+    randomUUID: mockRandomUUID,
+  },
+});
+
+// Create mock database state
+interface MockStatement {
+  run: jest.Mock;
+  get: jest.Mock;
+  all: jest.Mock;
+}
+
+interface MockDatabase {
+  exec: jest.Mock;
+  prepare: jest.Mock;
+}
+
+// In-memory storage for mock database
+let mockFolders: Map<string, IStoredVaultFolder>;
+let mockFolderItems: Map<string, IStoredFolderItem[]>;
+let mockDatabase: MockDatabase;
+let mockInitialized: boolean;
+
+const createMockStatement = (): MockStatement => ({
+  run: jest.fn(),
+  get: jest.fn(),
+  all: jest.fn(),
+});
+
+// Setup mock database behavior
+const setupMockDatabase = () => {
+  mockFolders = new Map();
+  mockFolderItems = new Map();
+  mockInitialized = false;
+
+  mockDatabase = {
+    exec: jest.fn(),
+    prepare: jest.fn((sql: string) => {
+      const stmt = createMockStatement();
+
+      // INSERT INTO vault_folders
+      if (sql.includes('INSERT INTO vault_folders')) {
+        stmt.run.mockImplementation(
+          (
+            id: string,
+            name: string,
+            description: string | null,
+            parentId: string | null,
+            createdAt: string,
+            updatedAt: string,
+            itemCount: number,
+            isShared: number
+          ) => {
+            const folder: IStoredVaultFolder = {
+              id,
+              name,
+              description,
+              parent_id: parentId,
+              created_at: createdAt,
+              updated_at: updatedAt,
+              item_count: itemCount,
+              is_shared: isShared,
+            };
+            mockFolders.set(id, folder);
+            return { changes: 1 };
+          }
+        );
+      }
+
+      // SELECT * FROM vault_folders WHERE id = ?
+      if (sql.includes('SELECT * FROM vault_folders WHERE id = ?')) {
+        stmt.get.mockImplementation((id: string) => {
+          return mockFolders.get(id) ?? undefined;
+        });
+      }
+
+      // SELECT * FROM vault_folders WHERE parent_id IS NULL
+      if (sql.includes('WHERE parent_id IS NULL')) {
+        stmt.all.mockImplementation(() => {
+          return Array.from(mockFolders.values())
+            .filter((f) => f.parent_id === null)
+            .sort((a, b) => a.name.localeCompare(b.name));
+        });
+      }
+
+      // SELECT * FROM vault_folders WHERE parent_id = ?
+      if (
+        sql.includes('WHERE parent_id = ?') &&
+        !sql.includes('UPDATE') &&
+        !sql.includes('IS NULL')
+      ) {
+        stmt.all.mockImplementation((parentId: string) => {
+          return Array.from(mockFolders.values())
+            .filter((f) => f.parent_id === parentId)
+            .sort((a, b) => a.name.localeCompare(b.name));
+        });
+      }
+
+      // SELECT * FROM vault_folders ORDER BY name (getAllFolders)
+      if (
+        sql.includes('SELECT * FROM vault_folders ORDER BY name') &&
+        !sql.includes('WHERE')
+      ) {
+        stmt.all.mockImplementation(() => {
+          return Array.from(mockFolders.values()).sort((a, b) =>
+            a.name.localeCompare(b.name)
+          );
+        });
+      }
+
+      // SELECT * FROM vault_folders WHERE is_shared = 1
+      if (sql.includes('WHERE is_shared = 1')) {
+        stmt.all.mockImplementation(() => {
+          return Array.from(mockFolders.values())
+            .filter((f) => f.is_shared === 1)
+            .sort((a, b) => a.name.localeCompare(b.name));
+        });
+      }
+
+      // UPDATE vault_folders SET name
+      if (sql.includes('UPDATE vault_folders SET name')) {
+        stmt.run.mockImplementation(
+          (name: string, updatedAt: string, id: string) => {
+            const folder = mockFolders.get(id);
+            if (folder) {
+              folder.name = name;
+              folder.updated_at = updatedAt;
+              return { changes: 1 };
+            }
+            return { changes: 0 };
+          }
+        );
+      }
+
+      // UPDATE vault_folders SET description
+      if (sql.includes('UPDATE vault_folders SET description')) {
+        stmt.run.mockImplementation(
+          (description: string | null, updatedAt: string, id: string) => {
+            const folder = mockFolders.get(id);
+            if (folder) {
+              folder.description = description;
+              folder.updated_at = updatedAt;
+              return { changes: 1 };
+            }
+            return { changes: 0 };
+          }
+        );
+      }
+
+      // UPDATE vault_folders SET parent_id (moveFolder)
+      if (
+        sql.includes('UPDATE vault_folders SET parent_id') &&
+        !sql.includes('WHERE parent_id')
+      ) {
+        stmt.run.mockImplementation(
+          (parentId: string | null, updatedAt: string, id: string) => {
+            const folder = mockFolders.get(id);
+            if (folder) {
+              folder.parent_id = parentId;
+              folder.updated_at = updatedAt;
+              return { changes: 1 };
+            }
+            return { changes: 0 };
+          }
+        );
+      }
+
+      // UPDATE vault_folders SET parent_id = ? WHERE parent_id = ? (reparent children on delete)
+      if (sql.includes('UPDATE vault_folders SET parent_id = ? WHERE parent_id = ?')) {
+        stmt.run.mockImplementation(
+          (newParentId: string | null, oldParentId: string) => {
+            let changes = 0;
+            mockFolders.forEach((folder) => {
+              if (folder.parent_id === oldParentId) {
+                folder.parent_id = newParentId;
+                changes++;
+              }
+            });
+            return { changes };
+          }
+        );
+      }
+
+      // UPDATE vault_folders SET is_shared
+      if (sql.includes('UPDATE vault_folders SET is_shared')) {
+        stmt.run.mockImplementation(
+          (isShared: number, updatedAt: string, id: string) => {
+            const folder = mockFolders.get(id);
+            if (folder) {
+              folder.is_shared = isShared;
+              folder.updated_at = updatedAt;
+              return { changes: 1 };
+            }
+            return { changes: 0 };
+          }
+        );
+      }
+
+      // DELETE FROM vault_folders WHERE id = ?
+      if (sql.includes('DELETE FROM vault_folders WHERE id = ?')) {
+        stmt.run.mockImplementation((id: string) => {
+          const deleted = mockFolders.delete(id);
+          mockFolderItems.delete(id);
+          return { changes: deleted ? 1 : 0 };
+        });
+      }
+
+      // INSERT OR REPLACE INTO vault_folder_items
+      if (sql.includes('INSERT OR REPLACE INTO vault_folder_items')) {
+        stmt.run.mockImplementation(
+          (
+            folderId: string,
+            itemId: string,
+            itemType: string,
+            assignedAt: string
+          ) => {
+            const items = mockFolderItems.get(folderId) || [];
+            const existingIndex = items.findIndex(
+              (i) => i.item_id === itemId && i.item_type === itemType
+            );
+            const item: IStoredFolderItem = {
+              folder_id: folderId,
+              item_id: itemId,
+              item_type: itemType as IStoredFolderItem['item_type'],
+              assigned_at: assignedAt,
+            };
+            if (existingIndex >= 0) {
+              items[existingIndex] = item;
+            } else {
+              items.push(item);
+            }
+            mockFolderItems.set(folderId, items);
+            return { changes: 1 };
+          }
+        );
+      }
+
+      // DELETE FROM vault_folder_items WHERE folder_id = ? AND item_id = ? AND item_type = ?
+      if (
+        sql.includes('DELETE FROM vault_folder_items WHERE folder_id = ? AND item_id = ? AND item_type = ?')
+      ) {
+        stmt.run.mockImplementation(
+          (folderId: string, itemId: string, itemType: string) => {
+            const items = mockFolderItems.get(folderId) || [];
+            const newItems = items.filter(
+              (i) => !(i.item_id === itemId && i.item_type === itemType)
+            );
+            mockFolderItems.set(folderId, newItems);
+            return { changes: items.length - newItems.length };
+          }
+        );
+      }
+
+      // SELECT * FROM vault_folder_items WHERE folder_id = ?
+      if (sql.includes('SELECT * FROM vault_folder_items WHERE folder_id = ?')) {
+        stmt.all.mockImplementation((folderId: string) => {
+          const items = mockFolderItems.get(folderId) || [];
+          return items.sort(
+            (a, b) =>
+              new Date(b.assigned_at).getTime() -
+              new Date(a.assigned_at).getTime()
+          );
+        });
+      }
+
+      // SELECT f.* FROM vault_folders f INNER JOIN vault_folder_items fi (getItemFolders)
+      if (sql.includes('INNER JOIN vault_folder_items fi ON f.id = fi.folder_id')) {
+        stmt.all.mockImplementation((itemId: string, itemType: string) => {
+          const folderIds: string[] = [];
+          mockFolderItems.forEach((items, folderId) => {
+            if (
+              items.some((i) => i.item_id === itemId && i.item_type === itemType)
+            ) {
+              folderIds.push(folderId);
+            }
+          });
+          return folderIds
+            .map((id) => mockFolders.get(id))
+            .filter(Boolean)
+            .sort((a, b) => a!.name.localeCompare(b!.name));
+        });
+      }
+
+      // SELECT 1 FROM vault_folder_items WHERE folder_id = ? AND item_id = ? AND item_type = ?
+      if (
+        sql.includes('SELECT 1 FROM vault_folder_items WHERE folder_id = ? AND item_id = ? AND item_type = ?')
+      ) {
+        stmt.get.mockImplementation(
+          (folderId: string, itemId: string, itemType: string) => {
+            const items = mockFolderItems.get(folderId) || [];
+            return items.find(
+              (i) => i.item_id === itemId && i.item_type === itemType
+            )
+              ? { '1': 1 }
+              : undefined;
+          }
+        );
+      }
+
+      // UPDATE vault_folder_items SET folder_id (moveItem)
+      if (sql.includes('UPDATE vault_folder_items')) {
+        stmt.run.mockImplementation(
+          (
+            toFolderId: string,
+            assignedAt: string,
+            fromFolderId: string,
+            itemId: string,
+            itemType: string
+          ) => {
+            const fromItems = mockFolderItems.get(fromFolderId) || [];
+            const itemIndex = fromItems.findIndex(
+              (i) => i.item_id === itemId && i.item_type === itemType
+            );
+            if (itemIndex === -1) return { changes: 0 };
+
+            // Remove from source
+            const [item] = fromItems.splice(itemIndex, 1);
+            mockFolderItems.set(fromFolderId, fromItems);
+
+            // Add to destination
+            const toItems = mockFolderItems.get(toFolderId) || [];
+            toItems.push({
+              ...item,
+              folder_id: toFolderId,
+              assigned_at: assignedAt,
+            });
+            mockFolderItems.set(toFolderId, toItems);
+
+            return { changes: 1 };
+          }
+        );
+      }
+
+      // DELETE FROM vault_folder_items WHERE item_id = ? AND item_type = ?
+      if (
+        sql.includes('DELETE FROM vault_folder_items WHERE item_id = ? AND item_type = ?')
+      ) {
+        stmt.run.mockImplementation((itemId: string, itemType: string) => {
+          let totalChanges = 0;
+          mockFolderItems.forEach((items, folderId) => {
+            const newItems = items.filter(
+              (i) => !(i.item_id === itemId && i.item_type === itemType)
+            );
+            if (newItems.length !== items.length) {
+              totalChanges += items.length - newItems.length;
+              mockFolderItems.set(folderId, newItems);
+            }
+          });
+          return { changes: totalChanges };
+        });
+      }
+
+      // UPDATE vault_folders SET item_count (updateFolderItemCount - private method)
+      if (sql.includes('UPDATE vault_folders') && sql.includes('item_count')) {
+        stmt.run.mockImplementation(
+          (folderId: string, updatedAt: string, id: string) => {
+            const folder = mockFolders.get(id);
+            if (folder) {
+              const items = mockFolderItems.get(id) || [];
+              folder.item_count = items.length;
+              folder.updated_at = updatedAt;
+              return { changes: 1 };
+            }
+            return { changes: 0 };
+          }
+        );
+      }
+
+      return stmt;
+    }),
+  };
+};
+
+// Mock the SQLite service
+jest.mock('@/services/persistence', () => ({
+  getSQLiteService: jest.fn(() => ({
+    initialize: jest.fn(() => {
+      mockInitialized = true;
+    }),
+    getDatabase: jest.fn(() => mockDatabase),
+    isInitialized: jest.fn(() => mockInitialized),
+  })),
+}));
+
+// =============================================================================
+// Import after mocks are set up
+// =============================================================================
+
+import {
+  VaultFolderRepository,
+  getVaultFolderRepository,
+  resetVaultFolderRepository,
+} from '@/services/vault/VaultFolderRepository';
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('VaultFolderRepository', () => {
+  let repository: VaultFolderRepository;
+
+  beforeEach(() => {
+    // Reset all state
+    setupMockDatabase();
+    uuidCounter = 0;
+    mockRandomUUID.mockClear();
+    resetVaultFolderRepository();
+    repository = new VaultFolderRepository();
+  });
+
+  // ===========================================================================
+  // Initialization
+  // ===========================================================================
+
+  describe('initialize', () => {
+    it('should initialize the repository and create tables', async () => {
+      await repository.initialize();
+
+      expect(mockDatabase.exec).toHaveBeenCalled();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const execCall = mockDatabase.exec.mock.calls[0][0] as string;
+      expect(execCall).toContain('CREATE TABLE IF NOT EXISTS vault_folders');
+      expect(execCall).toContain('CREATE TABLE IF NOT EXISTS vault_folder_items');
+      expect(execCall).toContain('CREATE INDEX IF NOT EXISTS');
+    });
+
+    it('should only initialize once', async () => {
+      await repository.initialize();
+      await repository.initialize();
+
+      // exec should only be called once for table creation
+      expect(mockDatabase.exec).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ===========================================================================
+  // Folder CRUD
+  // ===========================================================================
+
+  describe('createFolder', () => {
+    it('should create a folder with default options', async () => {
+      const folder = await repository.createFolder('Test Folder');
+
+      expect(folder).toBeDefined();
+      expect(folder.id).toBe('folder-test-uuid-1');
+      expect(folder.name).toBe('Test Folder');
+      expect(folder.description).toBeNull();
+      expect(folder.parentId).toBeNull();
+      expect(folder.itemCount).toBe(0);
+      expect(folder.isShared).toBe(false);
+      expect(folder.createdAt).toBeDefined();
+      expect(folder.updatedAt).toBeDefined();
+    });
+
+    it('should create a folder with description', async () => {
+      const folder = await repository.createFolder('My Units', {
+        description: 'Collection of custom mechs',
+      });
+
+      expect(folder.name).toBe('My Units');
+      expect(folder.description).toBe('Collection of custom mechs');
+    });
+
+    it('should create a folder with parent', async () => {
+      const parent = await repository.createFolder('Parent');
+      const child = await repository.createFolder('Child', {
+        parentId: parent.id,
+      });
+
+      expect(child.parentId).toBe(parent.id);
+    });
+
+    it('should create a shared folder', async () => {
+      const folder = await repository.createFolder('Shared Units', {
+        isShared: true,
+      });
+
+      expect(folder.isShared).toBe(true);
+    });
+
+    it('should create a folder with all options', async () => {
+      const parent = await repository.createFolder('Parent');
+      const folder = await repository.createFolder('Complete Folder', {
+        description: 'Full options test',
+        parentId: parent.id,
+        isShared: true,
+      });
+
+      expect(folder.name).toBe('Complete Folder');
+      expect(folder.description).toBe('Full options test');
+      expect(folder.parentId).toBe(parent.id);
+      expect(folder.isShared).toBe(true);
+    });
+  });
+
+  describe('getFolderById', () => {
+    it('should return folder when found', async () => {
+      const created = await repository.createFolder('Test Folder');
+      const found = await repository.getFolderById(created.id);
+
+      expect(found).toBeDefined();
+      expect(found?.id).toBe(created.id);
+      expect(found?.name).toBe('Test Folder');
+    });
+
+    it('should return null when folder not found', async () => {
+      const found = await repository.getFolderById('non-existent-id');
+
+      expect(found).toBeNull();
+    });
+
+    it('should convert stored row to domain object correctly', async () => {
+      const folder = await repository.createFolder('Test', {
+        description: 'desc',
+        isShared: true,
+      });
+      const found = await repository.getFolderById(folder.id);
+
+      // Verify all fields are properly converted
+      expect(found?.id).toBe(folder.id);
+      expect(found?.name).toBe('Test');
+      expect(found?.description).toBe('desc');
+      expect(found?.parentId).toBeNull();
+      expect(found?.isShared).toBe(true);
+      expect(found?.itemCount).toBe(0);
+      expect(typeof found?.createdAt).toBe('string');
+      expect(typeof found?.updatedAt).toBe('string');
+    });
+  });
+
+  describe('getRootFolders', () => {
+    it('should return only folders without parents', async () => {
+      await repository.createFolder('Root 1');
+      await repository.createFolder('Root 2');
+      const parent = await repository.createFolder('Parent Root');
+      await repository.createFolder('Child', { parentId: parent.id });
+
+      const roots = await repository.getRootFolders();
+
+      expect(roots).toHaveLength(3);
+      expect(roots.every((f) => f.parentId === null)).toBe(true);
+    });
+
+    it('should return folders sorted by name', async () => {
+      await repository.createFolder('Zebra');
+      await repository.createFolder('Alpha');
+      await repository.createFolder('Middle');
+
+      const roots = await repository.getRootFolders();
+
+      expect(roots[0].name).toBe('Alpha');
+      expect(roots[1].name).toBe('Middle');
+      expect(roots[2].name).toBe('Zebra');
+    });
+
+    it('should return empty array when no folders exist', async () => {
+      const roots = await repository.getRootFolders();
+
+      expect(roots).toEqual([]);
+    });
+  });
+
+  describe('getChildFolders', () => {
+    it('should return child folders of a parent', async () => {
+      const parent = await repository.createFolder('Parent');
+      await repository.createFolder('Child 1', { parentId: parent.id });
+      await repository.createFolder('Child 2', { parentId: parent.id });
+      await repository.createFolder('Other Root');
+
+      const children = await repository.getChildFolders(parent.id);
+
+      expect(children).toHaveLength(2);
+      expect(children.every((f) => f.parentId === parent.id)).toBe(true);
+    });
+
+    it('should return folders sorted by name', async () => {
+      const parent = await repository.createFolder('Parent');
+      await repository.createFolder('Zebra', { parentId: parent.id });
+      await repository.createFolder('Alpha', { parentId: parent.id });
+
+      const children = await repository.getChildFolders(parent.id);
+
+      expect(children[0].name).toBe('Alpha');
+      expect(children[1].name).toBe('Zebra');
+    });
+
+    it('should return empty array when no children exist', async () => {
+      const parent = await repository.createFolder('Empty Parent');
+      const children = await repository.getChildFolders(parent.id);
+
+      expect(children).toEqual([]);
+    });
+  });
+
+  describe('getAllFolders', () => {
+    it('should return all folders', async () => {
+      const parent = await repository.createFolder('Parent');
+      await repository.createFolder('Child', { parentId: parent.id });
+      await repository.createFolder('Root');
+
+      const all = await repository.getAllFolders();
+
+      expect(all).toHaveLength(3);
+    });
+
+    it('should return folders sorted by name', async () => {
+      await repository.createFolder('Zebra');
+      await repository.createFolder('Alpha');
+
+      const all = await repository.getAllFolders();
+
+      expect(all[0].name).toBe('Alpha');
+      expect(all[1].name).toBe('Zebra');
+    });
+  });
+
+  describe('getSharedFolders', () => {
+    it('should return only shared folders', async () => {
+      await repository.createFolder('Shared 1', { isShared: true });
+      await repository.createFolder('Shared 2', { isShared: true });
+      await repository.createFolder('Private');
+
+      const shared = await repository.getSharedFolders();
+
+      expect(shared).toHaveLength(2);
+      expect(shared.every((f) => f.isShared)).toBe(true);
+    });
+
+    it('should return empty array when no shared folders exist', async () => {
+      await repository.createFolder('Private');
+
+      const shared = await repository.getSharedFolders();
+
+      expect(shared).toEqual([]);
+    });
+  });
+
+  describe('updateFolderName', () => {
+    it('should update folder name', async () => {
+      const folder = await repository.createFolder('Original');
+
+      const result = await repository.updateFolderName(folder.id, 'Renamed');
+
+      expect(result).toBe(true);
+
+      const updated = await repository.getFolderById(folder.id);
+      expect(updated?.name).toBe('Renamed');
+    });
+
+    it('should return false for non-existent folder', async () => {
+      const result = await repository.updateFolderName(
+        'non-existent',
+        'New Name'
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should update the updated_at timestamp', async () => {
+      const folder = await repository.createFolder('Original');
+      const originalUpdatedAt = folder.updatedAt;
+
+      // Small delay to ensure different timestamp
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      await repository.updateFolderName(folder.id, 'Renamed');
+
+      const updated = await repository.getFolderById(folder.id);
+      expect(updated?.updatedAt).not.toBe(originalUpdatedAt);
+    });
+  });
+
+  describe('updateFolderDescription', () => {
+    it('should update folder description', async () => {
+      const folder = await repository.createFolder('Test', {
+        description: 'Old description',
+      });
+
+      const result = await repository.updateFolderDescription(
+        folder.id,
+        'New description'
+      );
+
+      expect(result).toBe(true);
+
+      const updated = await repository.getFolderById(folder.id);
+      expect(updated?.description).toBe('New description');
+    });
+
+    it('should clear description with null', async () => {
+      const folder = await repository.createFolder('Test', {
+        description: 'Has description',
+      });
+
+      await repository.updateFolderDescription(folder.id, null);
+
+      const updated = await repository.getFolderById(folder.id);
+      expect(updated?.description).toBeNull();
+    });
+
+    it('should return false for non-existent folder', async () => {
+      const result = await repository.updateFolderDescription(
+        'non-existent',
+        'desc'
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('moveFolder', () => {
+    it('should move folder to new parent', async () => {
+      const parent1 = await repository.createFolder('Parent 1');
+      const parent2 = await repository.createFolder('Parent 2');
+      const child = await repository.createFolder('Child', {
+        parentId: parent1.id,
+      });
+
+      const result = await repository.moveFolder(child.id, parent2.id);
+
+      expect(result).toBe(true);
+
+      const moved = await repository.getFolderById(child.id);
+      expect(moved?.parentId).toBe(parent2.id);
+    });
+
+    it('should move folder to root (null parent)', async () => {
+      const parent = await repository.createFolder('Parent');
+      const child = await repository.createFolder('Child', {
+        parentId: parent.id,
+      });
+
+      const result = await repository.moveFolder(child.id, null);
+
+      expect(result).toBe(true);
+
+      const moved = await repository.getFolderById(child.id);
+      expect(moved?.parentId).toBeNull();
+    });
+
+    it('should prevent circular reference (direct)', async () => {
+      const parent = await repository.createFolder('Parent');
+      const child = await repository.createFolder('Child', {
+        parentId: parent.id,
+      });
+
+      // Try to make parent a child of its own child
+      const result = await repository.moveFolder(parent.id, child.id);
+
+      expect(result).toBe(false);
+
+      // Parent should still be at root
+      const unchanged = await repository.getFolderById(parent.id);
+      expect(unchanged?.parentId).toBeNull();
+    });
+
+    it('should prevent circular reference (nested)', async () => {
+      const grandparent = await repository.createFolder('Grandparent');
+      const parent = await repository.createFolder('Parent', {
+        parentId: grandparent.id,
+      });
+      const child = await repository.createFolder('Child', {
+        parentId: parent.id,
+      });
+
+      // Try to make grandparent a child of its grandchild
+      const result = await repository.moveFolder(grandparent.id, child.id);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for non-existent folder', async () => {
+      const parent = await repository.createFolder('Parent');
+
+      const result = await repository.moveFolder('non-existent', parent.id);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('setFolderShared', () => {
+    it('should set folder as shared', async () => {
+      const folder = await repository.createFolder('Private');
+
+      const result = await repository.setFolderShared(folder.id, true);
+
+      expect(result).toBe(true);
+
+      const updated = await repository.getFolderById(folder.id);
+      expect(updated?.isShared).toBe(true);
+    });
+
+    it('should unset folder sharing', async () => {
+      const folder = await repository.createFolder('Shared', { isShared: true });
+
+      const result = await repository.setFolderShared(folder.id, false);
+
+      expect(result).toBe(true);
+
+      const updated = await repository.getFolderById(folder.id);
+      expect(updated?.isShared).toBe(false);
+    });
+
+    it('should return false for non-existent folder', async () => {
+      const result = await repository.setFolderShared('non-existent', true);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('deleteFolder', () => {
+    it('should delete a folder', async () => {
+      const folder = await repository.createFolder('To Delete');
+
+      const result = await repository.deleteFolder(folder.id);
+
+      expect(result).toBe(true);
+
+      const found = await repository.getFolderById(folder.id);
+      expect(found).toBeNull();
+    });
+
+    it('should move children to deleted folders parent', async () => {
+      const grandparent = await repository.createFolder('Grandparent');
+      const parent = await repository.createFolder('Parent', {
+        parentId: grandparent.id,
+      });
+      const child = await repository.createFolder('Child', {
+        parentId: parent.id,
+      });
+
+      await repository.deleteFolder(parent.id);
+
+      // Child should now be under grandparent
+      const movedChild = await repository.getFolderById(child.id);
+      expect(movedChild?.parentId).toBe(grandparent.id);
+    });
+
+    it('should move children to root when deleting root folder', async () => {
+      const parent = await repository.createFolder('Parent');
+      const child = await repository.createFolder('Child', {
+        parentId: parent.id,
+      });
+
+      await repository.deleteFolder(parent.id);
+
+      // Child should now be at root
+      const movedChild = await repository.getFolderById(child.id);
+      expect(movedChild?.parentId).toBeNull();
+    });
+
+    it('should return false for non-existent folder', async () => {
+      const result = await repository.deleteFolder('non-existent');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // Folder Items
+  // ===========================================================================
+
+  describe('addItemToFolder', () => {
+    it('should add item to folder', async () => {
+      const folder = await repository.createFolder('Units');
+
+      const result = await repository.addItemToFolder(
+        folder.id,
+        'unit-123',
+        'unit'
+      );
+
+      expect(result).toBe(true);
+
+      const items = await repository.getFolderItems(folder.id);
+      expect(items).toHaveLength(1);
+      expect(items[0].itemId).toBe('unit-123');
+      expect(items[0].itemType).toBe('unit');
+      expect(items[0].folderId).toBe(folder.id);
+    });
+
+    it('should add different item types', async () => {
+      const folder = await repository.createFolder('Mixed');
+
+      await repository.addItemToFolder(folder.id, 'unit-1', 'unit');
+      await repository.addItemToFolder(folder.id, 'pilot-1', 'pilot');
+      await repository.addItemToFolder(folder.id, 'force-1', 'force');
+      await repository.addItemToFolder(folder.id, 'encounter-1', 'encounter');
+
+      const items = await repository.getFolderItems(folder.id);
+      expect(items).toHaveLength(4);
+    });
+
+    it('should replace existing item assignment', async () => {
+      const folder = await repository.createFolder('Units');
+
+      await repository.addItemToFolder(folder.id, 'unit-123', 'unit');
+      await repository.addItemToFolder(folder.id, 'unit-123', 'unit');
+
+      const items = await repository.getFolderItems(folder.id);
+      expect(items).toHaveLength(1);
+    });
+
+    it('should allow same item ID with different types', async () => {
+      const folder = await repository.createFolder('Mixed');
+
+      await repository.addItemToFolder(folder.id, 'id-123', 'unit');
+      await repository.addItemToFolder(folder.id, 'id-123', 'pilot');
+
+      const items = await repository.getFolderItems(folder.id);
+      expect(items).toHaveLength(2);
+    });
+  });
+
+  describe('removeItemFromFolder', () => {
+    it('should remove item from folder', async () => {
+      const folder = await repository.createFolder('Units');
+      await repository.addItemToFolder(folder.id, 'unit-123', 'unit');
+
+      const result = await repository.removeItemFromFolder(
+        folder.id,
+        'unit-123',
+        'unit'
+      );
+
+      expect(result).toBe(true);
+
+      const items = await repository.getFolderItems(folder.id);
+      expect(items).toHaveLength(0);
+    });
+
+    it('should return false when item not in folder', async () => {
+      const folder = await repository.createFolder('Units');
+
+      const result = await repository.removeItemFromFolder(
+        folder.id,
+        'unit-123',
+        'unit'
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should only remove specific item type', async () => {
+      const folder = await repository.createFolder('Mixed');
+      await repository.addItemToFolder(folder.id, 'id-123', 'unit');
+      await repository.addItemToFolder(folder.id, 'id-123', 'pilot');
+
+      await repository.removeItemFromFolder(folder.id, 'id-123', 'unit');
+
+      const items = await repository.getFolderItems(folder.id);
+      expect(items).toHaveLength(1);
+      expect(items[0].itemType).toBe('pilot');
+    });
+  });
+
+  describe('getFolderItems', () => {
+    it('should return items sorted by assigned_at descending', async () => {
+      const folder = await repository.createFolder('Units');
+
+      // Add items with slight delays to ensure different timestamps
+      await repository.addItemToFolder(folder.id, 'unit-1', 'unit');
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await repository.addItemToFolder(folder.id, 'unit-2', 'unit');
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await repository.addItemToFolder(folder.id, 'unit-3', 'unit');
+
+      const items = await repository.getFolderItems(folder.id);
+
+      // Most recently added should be first
+      expect(items[0].itemId).toBe('unit-3');
+      expect(items[2].itemId).toBe('unit-1');
+    });
+
+    it('should return empty array for folder with no items', async () => {
+      const folder = await repository.createFolder('Empty');
+
+      const items = await repository.getFolderItems(folder.id);
+
+      expect(items).toEqual([]);
+    });
+
+    it('should convert stored row to domain object', async () => {
+      const folder = await repository.createFolder('Units');
+      await repository.addItemToFolder(folder.id, 'unit-123', 'unit');
+
+      const items = await repository.getFolderItems(folder.id);
+
+      expect(items[0]).toHaveProperty('folderId');
+      expect(items[0]).toHaveProperty('itemId');
+      expect(items[0]).toHaveProperty('itemType');
+      expect(items[0]).toHaveProperty('assignedAt');
+    });
+  });
+
+  describe('getItemFolders', () => {
+    it('should return folders containing item', async () => {
+      const folder1 = await repository.createFolder('Folder 1');
+      const folder2 = await repository.createFolder('Folder 2');
+      await repository.createFolder('Folder 3');
+
+      await repository.addItemToFolder(folder1.id, 'unit-123', 'unit');
+      await repository.addItemToFolder(folder2.id, 'unit-123', 'unit');
+
+      const folders = await repository.getItemFolders('unit-123', 'unit');
+
+      expect(folders).toHaveLength(2);
+      expect(folders.map((f) => f.id).sort()).toEqual(
+        [folder1.id, folder2.id].sort()
+      );
+    });
+
+    it('should return empty array when item not in any folder', async () => {
+      await repository.createFolder('Folder');
+
+      const folders = await repository.getItemFolders('unit-123', 'unit');
+
+      expect(folders).toEqual([]);
+    });
+
+    it('should only return folders with matching item type', async () => {
+      const folder1 = await repository.createFolder('Folder 1');
+      const folder2 = await repository.createFolder('Folder 2');
+
+      await repository.addItemToFolder(folder1.id, 'id-123', 'unit');
+      await repository.addItemToFolder(folder2.id, 'id-123', 'pilot');
+
+      const unitFolders = await repository.getItemFolders('id-123', 'unit');
+      const pilotFolders = await repository.getItemFolders('id-123', 'pilot');
+
+      expect(unitFolders).toHaveLength(1);
+      expect(unitFolders[0].id).toBe(folder1.id);
+      expect(pilotFolders).toHaveLength(1);
+      expect(pilotFolders[0].id).toBe(folder2.id);
+    });
+  });
+
+  describe('isItemInFolder', () => {
+    it('should return true when item is in folder', async () => {
+      const folder = await repository.createFolder('Units');
+      await repository.addItemToFolder(folder.id, 'unit-123', 'unit');
+
+      const result = await repository.isItemInFolder(
+        folder.id,
+        'unit-123',
+        'unit'
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when item is not in folder', async () => {
+      const folder = await repository.createFolder('Units');
+
+      const result = await repository.isItemInFolder(
+        folder.id,
+        'unit-123',
+        'unit'
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for wrong item type', async () => {
+      const folder = await repository.createFolder('Mixed');
+      await repository.addItemToFolder(folder.id, 'id-123', 'unit');
+
+      const result = await repository.isItemInFolder(
+        folder.id,
+        'id-123',
+        'pilot'
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('moveItem', () => {
+    it('should move item between folders', async () => {
+      const folder1 = await repository.createFolder('From');
+      const folder2 = await repository.createFolder('To');
+      await repository.addItemToFolder(folder1.id, 'unit-123', 'unit');
+
+      const result = await repository.moveItem(
+        'unit-123',
+        'unit',
+        folder1.id,
+        folder2.id
+      );
+
+      expect(result).toBe(true);
+
+      const items1 = await repository.getFolderItems(folder1.id);
+      const items2 = await repository.getFolderItems(folder2.id);
+
+      expect(items1).toHaveLength(0);
+      expect(items2).toHaveLength(1);
+      expect(items2[0].itemId).toBe('unit-123');
+    });
+
+    it('should return false when item not in source folder', async () => {
+      const folder1 = await repository.createFolder('From');
+      const folder2 = await repository.createFolder('To');
+
+      const result = await repository.moveItem(
+        'unit-123',
+        'unit',
+        folder1.id,
+        folder2.id
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should update assigned_at timestamp', async () => {
+      const folder1 = await repository.createFolder('From');
+      const folder2 = await repository.createFolder('To');
+      await repository.addItemToFolder(folder1.id, 'unit-123', 'unit');
+
+      const itemsBefore = await repository.getFolderItems(folder1.id);
+      const originalAssignedAt = itemsBefore[0].assignedAt;
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      await repository.moveItem('unit-123', 'unit', folder1.id, folder2.id);
+
+      const itemsAfter = await repository.getFolderItems(folder2.id);
+      expect(itemsAfter[0].assignedAt).not.toBe(originalAssignedAt);
+    });
+  });
+
+  describe('removeItemFromAllFolders', () => {
+    it('should remove item from all folders', async () => {
+      const folder1 = await repository.createFolder('Folder 1');
+      const folder2 = await repository.createFolder('Folder 2');
+      const folder3 = await repository.createFolder('Folder 3');
+
+      await repository.addItemToFolder(folder1.id, 'unit-123', 'unit');
+      await repository.addItemToFolder(folder2.id, 'unit-123', 'unit');
+      await repository.addItemToFolder(folder3.id, 'other-unit', 'unit');
+
+      const count = await repository.removeItemFromAllFolders('unit-123', 'unit');
+
+      expect(count).toBe(2);
+
+      const items1 = await repository.getFolderItems(folder1.id);
+      const items2 = await repository.getFolderItems(folder2.id);
+      const items3 = await repository.getFolderItems(folder3.id);
+
+      expect(items1).toHaveLength(0);
+      expect(items2).toHaveLength(0);
+      expect(items3).toHaveLength(1);
+    });
+
+    it('should return 0 when item not in any folder', async () => {
+      await repository.createFolder('Folder');
+
+      const count = await repository.removeItemFromAllFolders('unit-123', 'unit');
+
+      expect(count).toBe(0);
+    });
+
+    it('should only remove matching item type', async () => {
+      const folder = await repository.createFolder('Mixed');
+      await repository.addItemToFolder(folder.id, 'id-123', 'unit');
+      await repository.addItemToFolder(folder.id, 'id-123', 'pilot');
+
+      await repository.removeItemFromAllFolders('id-123', 'unit');
+
+      const items = await repository.getFolderItems(folder.id);
+      expect(items).toHaveLength(1);
+      expect(items[0].itemType).toBe('pilot');
+    });
+  });
+
+  // ===========================================================================
+  // Singleton
+  // ===========================================================================
+
+  describe('getVaultFolderRepository', () => {
+    it('should return singleton instance', () => {
+      resetVaultFolderRepository();
+      const instance1 = getVaultFolderRepository();
+      const instance2 = getVaultFolderRepository();
+
+      expect(instance1).toBe(instance2);
+    });
+
+    it('should return new instance after reset', () => {
+      const instance1 = getVaultFolderRepository();
+      resetVaultFolderRepository();
+      const instance2 = getVaultFolderRepository();
+
+      expect(instance1).not.toBe(instance2);
+    });
+  });
+
+  describe('resetVaultFolderRepository', () => {
+    it('should clear the singleton', () => {
+      const instance1 = getVaultFolderRepository();
+      resetVaultFolderRepository();
+      const instance2 = getVaultFolderRepository();
+
+      expect(instance1).not.toBe(instance2);
+    });
+  });
+});

--- a/src/services/vault/__tests__/VersionHistoryRepository.test.ts
+++ b/src/services/vault/__tests__/VersionHistoryRepository.test.ts
@@ -1,0 +1,841 @@
+/**
+ * Version History Repository Tests
+ *
+ * Comprehensive tests for the VersionHistoryRepository class
+ * covering all CRUD operations and query methods.
+ *
+ * @spec openspec/changes/add-vault-sharing/specs/vault-sharing/spec.md
+ */
+
+import {
+  VersionHistoryRepository,
+  getVersionHistoryRepository,
+  resetVersionHistoryRepository,
+} from '../VersionHistoryRepository';
+import type { ShareableContentType } from '@/types/vault';
+
+// =============================================================================
+// Mock Setup
+// =============================================================================
+
+// Mock statement results
+const createMockStatement = (
+  returnValue?: unknown,
+  changes = 0
+) => ({
+  run: jest.fn().mockReturnValue({ changes }),
+  get: jest.fn().mockReturnValue(returnValue),
+  all: jest.fn().mockReturnValue(returnValue ?? []),
+});
+
+// Mock database object
+const mockDb = {
+  exec: jest.fn(),
+  prepare: jest.fn(),
+};
+
+// Mock SQLite service
+const mockSQLiteService = {
+  initialize: jest.fn().mockResolvedValue(undefined),
+  getDatabase: jest.fn().mockReturnValue(mockDb),
+};
+
+// Mock the persistence module
+jest.mock('@/services/persistence', () => ({
+  getSQLiteService: () => mockSQLiteService,
+}));
+
+// =============================================================================
+// Test Data
+// =============================================================================
+
+const TEST_CONTENT_TYPE: ShareableContentType = 'unit';
+const TEST_ITEM_ID = 'unit-atlas-1';
+const TEST_CONTENT = JSON.stringify({
+  name: 'Atlas',
+  model: 'AS7-D',
+  tonnage: 100,
+});
+const TEST_CONTENT_HASH = 'abc123hash';
+const TEST_CREATED_BY = 'local';
+const TEST_MESSAGE = 'Initial save';
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('VersionHistoryRepository', () => {
+  let repository: VersionHistoryRepository;
+
+  beforeEach(() => {
+    // Reset mocks
+    jest.clearAllMocks();
+    resetVersionHistoryRepository();
+
+    // Create fresh repository instance
+    repository = new VersionHistoryRepository();
+  });
+
+  // ===========================================================================
+  // Initialization
+  // ===========================================================================
+
+  describe('initialize', () => {
+    it('should create tables on first initialization', async () => {
+      await repository.initialize();
+
+      expect(mockSQLiteService.initialize).toHaveBeenCalled();
+      expect(mockDb.exec).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE TABLE IF NOT EXISTS version_history')
+      );
+    });
+
+    it('should create required indexes', async () => {
+      await repository.initialize();
+
+      expect(mockDb.exec).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE INDEX IF NOT EXISTS idx_version_history_item')
+      );
+      expect(mockDb.exec).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE INDEX IF NOT EXISTS idx_version_history_version')
+      );
+      expect(mockDb.exec).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE INDEX IF NOT EXISTS idx_version_history_created')
+      );
+    });
+
+    it('should only initialize once (idempotent)', async () => {
+      await repository.initialize();
+      await repository.initialize();
+      await repository.initialize();
+
+      // exec should only be called once for table creation
+      expect(mockDb.exec).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ===========================================================================
+  // saveVersion
+  // ===========================================================================
+
+  describe('saveVersion', () => {
+    beforeEach(() => {
+      // Mock MAX(version) query - no existing versions
+      const maxVersionStmt = createMockStatement({ max_version: null });
+      // Mock INSERT statement
+      const insertStmt = createMockStatement(undefined, 1);
+
+      mockDb.prepare.mockImplementation((sql: string) => {
+        if (sql.includes('MAX(version)')) {
+          return maxVersionStmt;
+        }
+        if (sql.includes('INSERT INTO')) {
+          return insertStmt;
+        }
+        return createMockStatement();
+      });
+    });
+
+    it('should save a new version with version number 1 for first version', async () => {
+      const result = await repository.saveVersion(
+        TEST_CONTENT_TYPE,
+        TEST_ITEM_ID,
+        TEST_CONTENT,
+        TEST_CONTENT_HASH,
+        TEST_CREATED_BY
+      );
+
+      expect(result).toBeDefined();
+      expect(result.id).toMatch(/^ver-/);
+      expect(result.contentType).toBe(TEST_CONTENT_TYPE);
+      expect(result.itemId).toBe(TEST_ITEM_ID);
+      expect(result.version).toBe(1);
+      expect(result.content).toBe(TEST_CONTENT);
+      expect(result.contentHash).toBe(TEST_CONTENT_HASH);
+      expect(result.createdBy).toBe(TEST_CREATED_BY);
+      expect(result.message).toBeNull();
+      expect(result.sizeBytes).toBe(new TextEncoder().encode(TEST_CONTENT).length);
+    });
+
+    it('should save version with optional message', async () => {
+      const result = await repository.saveVersion(
+        TEST_CONTENT_TYPE,
+        TEST_ITEM_ID,
+        TEST_CONTENT,
+        TEST_CONTENT_HASH,
+        TEST_CREATED_BY,
+        TEST_MESSAGE
+      );
+
+      expect(result.message).toBe(TEST_MESSAGE);
+    });
+
+    it('should increment version number for existing versions', async () => {
+      // Mock MAX(version) query - existing version 2
+      const maxVersionStmt = createMockStatement({ max_version: 2 });
+      const insertStmt = createMockStatement(undefined, 1);
+
+      mockDb.prepare.mockImplementation((sql: string) => {
+        if (sql.includes('MAX(version)')) {
+          return maxVersionStmt;
+        }
+        if (sql.includes('INSERT INTO')) {
+          return insertStmt;
+        }
+        return createMockStatement();
+      });
+
+      const result = await repository.saveVersion(
+        TEST_CONTENT_TYPE,
+        TEST_ITEM_ID,
+        TEST_CONTENT,
+        TEST_CONTENT_HASH,
+        TEST_CREATED_BY
+      );
+
+      expect(result.version).toBe(3);
+    });
+
+    it('should calculate size in bytes correctly for unicode content', async () => {
+      const unicodeContent = JSON.stringify({ name: '????????????', emoji: '????????????' });
+      
+      const result = await repository.saveVersion(
+        TEST_CONTENT_TYPE,
+        TEST_ITEM_ID,
+        unicodeContent,
+        'hash123',
+        TEST_CREATED_BY
+      );
+
+      expect(result.sizeBytes).toBe(new TextEncoder().encode(unicodeContent).length);
+    });
+
+    it('should set createdAt to current ISO timestamp', async () => {
+      const beforeSave = new Date().toISOString();
+      
+      const result = await repository.saveVersion(
+        TEST_CONTENT_TYPE,
+        TEST_ITEM_ID,
+        TEST_CONTENT,
+        TEST_CONTENT_HASH,
+        TEST_CREATED_BY
+      );
+
+      const afterSave = new Date().toISOString();
+      expect(result.createdAt >= beforeSave).toBe(true);
+      expect(result.createdAt <= afterSave).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // getVersions
+  // ===========================================================================
+
+  describe('getVersions', () => {
+    it('should return versions sorted by version number descending (newest first)', async () => {
+      const mockRows = [
+        {
+          id: 'ver-3',
+          content_type: 'unit',
+          item_id: TEST_ITEM_ID,
+          version: 3,
+          content_hash: 'hash3',
+          content: '{"v":3}',
+          created_at: '2024-01-03T00:00:00Z',
+          created_by: 'local',
+          message: null,
+          size_bytes: 10,
+        },
+        {
+          id: 'ver-2',
+          content_type: 'unit',
+          item_id: TEST_ITEM_ID,
+          version: 2,
+          content_hash: 'hash2',
+          content: '{"v":2}',
+          created_at: '2024-01-02T00:00:00Z',
+          created_by: 'local',
+          message: null,
+          size_bytes: 10,
+        },
+        {
+          id: 'ver-1',
+          content_type: 'unit',
+          item_id: TEST_ITEM_ID,
+          version: 1,
+          content_hash: 'hash1',
+          content: '{"v":1}',
+          created_at: '2024-01-01T00:00:00Z',
+          created_by: 'local',
+          message: null,
+          size_bytes: 10,
+        },
+      ];
+
+      mockDb.prepare.mockReturnValue(createMockStatement(mockRows));
+
+      const versions = await repository.getVersions(TEST_ITEM_ID, TEST_CONTENT_TYPE);
+
+      expect(versions).toHaveLength(3);
+      expect(versions[0].version).toBe(3);
+      expect(versions[1].version).toBe(2);
+      expect(versions[2].version).toBe(1);
+    });
+
+    it('should respect limit parameter', async () => {
+      const mockRows = [
+        {
+          id: 'ver-3',
+          content_type: 'unit',
+          item_id: TEST_ITEM_ID,
+          version: 3,
+          content_hash: 'hash3',
+          content: '{"v":3}',
+          created_at: '2024-01-03T00:00:00Z',
+          created_by: 'local',
+          message: null,
+          size_bytes: 10,
+        },
+        {
+          id: 'ver-2',
+          content_type: 'unit',
+          item_id: TEST_ITEM_ID,
+          version: 2,
+          content_hash: 'hash2',
+          content: '{"v":2}',
+          created_at: '2024-01-02T00:00:00Z',
+          created_by: 'local',
+          message: null,
+          size_bytes: 10,
+        },
+      ];
+
+      const stmt = createMockStatement(mockRows);
+      mockDb.prepare.mockReturnValue(stmt);
+
+      await repository.getVersions(TEST_ITEM_ID, TEST_CONTENT_TYPE, 2);
+
+      expect(stmt.all).toHaveBeenCalledWith(TEST_ITEM_ID, TEST_CONTENT_TYPE, 2);
+    });
+
+    it('should use default limit of 50', async () => {
+      const stmt = createMockStatement([]);
+      mockDb.prepare.mockReturnValue(stmt);
+
+      await repository.getVersions(TEST_ITEM_ID, TEST_CONTENT_TYPE);
+
+      expect(stmt.all).toHaveBeenCalledWith(TEST_ITEM_ID, TEST_CONTENT_TYPE, 50);
+    });
+
+    it('should return empty array when no versions exist', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement([]));
+
+      const versions = await repository.getVersions(TEST_ITEM_ID, TEST_CONTENT_TYPE);
+
+      expect(versions).toEqual([]);
+    });
+
+    it('should convert database row format to IVersionSnapshot', async () => {
+      const mockRow = {
+        id: 'ver-1',
+        content_type: 'unit',
+        item_id: TEST_ITEM_ID,
+        version: 1,
+        content_hash: 'hash1',
+        content: TEST_CONTENT,
+        created_at: '2024-01-01T00:00:00Z',
+        created_by: 'local',
+        message: 'Test message',
+        size_bytes: 50,
+      };
+
+      mockDb.prepare.mockReturnValue(createMockStatement([mockRow]));
+
+      const versions = await repository.getVersions(TEST_ITEM_ID, TEST_CONTENT_TYPE);
+
+      expect(versions[0]).toEqual({
+        id: 'ver-1',
+        contentType: 'unit',
+        itemId: TEST_ITEM_ID,
+        version: 1,
+        contentHash: 'hash1',
+        content: TEST_CONTENT,
+        createdAt: '2024-01-01T00:00:00Z',
+        createdBy: 'local',
+        message: 'Test message',
+        sizeBytes: 50,
+      });
+    });
+  });
+
+  // ===========================================================================
+  // getVersion
+  // ===========================================================================
+
+  describe('getVersion', () => {
+    it('should return specific version when it exists', async () => {
+      const mockRow = {
+        id: 'ver-2',
+        content_type: 'unit',
+        item_id: TEST_ITEM_ID,
+        version: 2,
+        content_hash: 'hash2',
+        content: '{"v":2}',
+        created_at: '2024-01-02T00:00:00Z',
+        created_by: 'local',
+        message: null,
+        size_bytes: 10,
+      };
+
+      const stmt = createMockStatement(mockRow);
+      mockDb.prepare.mockReturnValue(stmt);
+
+      const version = await repository.getVersion(TEST_ITEM_ID, TEST_CONTENT_TYPE, 2);
+
+      expect(version).toBeDefined();
+      expect(version?.version).toBe(2);
+      expect(stmt.get).toHaveBeenCalledWith(TEST_ITEM_ID, TEST_CONTENT_TYPE, 2);
+    });
+
+    it('should return null when version does not exist', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement(undefined));
+
+      const version = await repository.getVersion(TEST_ITEM_ID, TEST_CONTENT_TYPE, 999);
+
+      expect(version).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // getLatestVersion
+  // ===========================================================================
+
+  describe('getLatestVersion', () => {
+    it('should return the highest version number', async () => {
+      const mockRow = {
+        id: 'ver-5',
+        content_type: 'unit',
+        item_id: TEST_ITEM_ID,
+        version: 5,
+        content_hash: 'hash5',
+        content: '{"v":5}',
+        created_at: '2024-01-05T00:00:00Z',
+        created_by: 'local',
+        message: 'Latest',
+        size_bytes: 10,
+      };
+
+      mockDb.prepare.mockReturnValue(createMockStatement(mockRow));
+
+      const latest = await repository.getLatestVersion(TEST_ITEM_ID, TEST_CONTENT_TYPE);
+
+      expect(latest).toBeDefined();
+      expect(latest?.version).toBe(5);
+      expect(latest?.message).toBe('Latest');
+    });
+
+    it('should return null when no versions exist', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement(undefined));
+
+      const latest = await repository.getLatestVersion(TEST_ITEM_ID, TEST_CONTENT_TYPE);
+
+      expect(latest).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // getVersionById
+  // ===========================================================================
+
+  describe('getVersionById', () => {
+    it('should return version when found by ID', async () => {
+      const mockRow = {
+        id: 'ver-abc123',
+        content_type: 'pilot',
+        item_id: 'pilot-1',
+        version: 3,
+        content_hash: 'hashxyz',
+        content: '{"name":"Kerensky"}',
+        created_at: '2024-01-15T00:00:00Z',
+        created_by: 'sync-peer-1',
+        message: 'Synced from peer',
+        size_bytes: 25,
+      };
+
+      mockDb.prepare.mockReturnValue(createMockStatement(mockRow));
+
+      const version = await repository.getVersionById('ver-abc123');
+
+      expect(version).toBeDefined();
+      expect(version?.id).toBe('ver-abc123');
+      expect(version?.contentType).toBe('pilot');
+    });
+
+    it('should return null when ID not found', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement(undefined));
+
+      const version = await repository.getVersionById('non-existent-id');
+
+      expect(version).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // getCurrentVersionNumber
+  // ===========================================================================
+
+  describe('getCurrentVersionNumber', () => {
+    it('should return current max version number', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement({ max_version: 7 }));
+
+      const versionNum = await repository.getCurrentVersionNumber(TEST_ITEM_ID, TEST_CONTENT_TYPE);
+
+      expect(versionNum).toBe(7);
+    });
+
+    it('should return 0 when no versions exist', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement({ max_version: null }));
+
+      const versionNum = await repository.getCurrentVersionNumber(TEST_ITEM_ID, TEST_CONTENT_TYPE);
+
+      expect(versionNum).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // getVersionCount
+  // ===========================================================================
+
+  describe('getVersionCount', () => {
+    it('should return count of versions for item', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement({ count: 12 }));
+
+      const count = await repository.getVersionCount(TEST_ITEM_ID, TEST_CONTENT_TYPE);
+
+      expect(count).toBe(12);
+    });
+
+    it('should return 0 when no versions exist', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement({ count: 0 }));
+
+      const count = await repository.getVersionCount(TEST_ITEM_ID, TEST_CONTENT_TYPE);
+
+      expect(count).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // getStorageUsed
+  // ===========================================================================
+
+  describe('getStorageUsed', () => {
+    it('should return total storage in bytes', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement({ total: 15000 }));
+
+      const storage = await repository.getStorageUsed(TEST_ITEM_ID, TEST_CONTENT_TYPE);
+
+      expect(storage).toBe(15000);
+    });
+
+    it('should return 0 when no versions exist', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement({ total: null }));
+
+      const storage = await repository.getStorageUsed(TEST_ITEM_ID, TEST_CONTENT_TYPE);
+
+      expect(storage).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // getVersionRange
+  // ===========================================================================
+
+  describe('getVersionRange', () => {
+    it('should return versions within specified range', async () => {
+      const mockRows = [
+        {
+          id: 'ver-3',
+          content_type: 'unit',
+          item_id: TEST_ITEM_ID,
+          version: 3,
+          content_hash: 'hash3',
+          content: '{"v":3}',
+          created_at: '2024-01-03T00:00:00Z',
+          created_by: 'local',
+          message: null,
+          size_bytes: 10,
+        },
+        {
+          id: 'ver-4',
+          content_type: 'unit',
+          item_id: TEST_ITEM_ID,
+          version: 4,
+          content_hash: 'hash4',
+          content: '{"v":4}',
+          created_at: '2024-01-04T00:00:00Z',
+          created_by: 'local',
+          message: null,
+          size_bytes: 10,
+        },
+        {
+          id: 'ver-5',
+          content_type: 'unit',
+          item_id: TEST_ITEM_ID,
+          version: 5,
+          content_hash: 'hash5',
+          content: '{"v":5}',
+          created_at: '2024-01-05T00:00:00Z',
+          created_by: 'local',
+          message: null,
+          size_bytes: 10,
+        },
+      ];
+
+      const stmt = createMockStatement(mockRows);
+      mockDb.prepare.mockReturnValue(stmt);
+
+      const versions = await repository.getVersionRange(TEST_ITEM_ID, TEST_CONTENT_TYPE, 3, 5);
+
+      expect(versions).toHaveLength(3);
+      expect(versions[0].version).toBe(3); // Ascending order
+      expect(versions[2].version).toBe(5);
+      expect(stmt.all).toHaveBeenCalledWith(TEST_ITEM_ID, TEST_CONTENT_TYPE, 3, 5);
+    });
+
+    it('should return empty array when no versions in range', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement([]));
+
+      const versions = await repository.getVersionRange(TEST_ITEM_ID, TEST_CONTENT_TYPE, 100, 200);
+
+      expect(versions).toEqual([]);
+    });
+  });
+
+  // ===========================================================================
+  // deleteVersion
+  // ===========================================================================
+
+  describe('deleteVersion', () => {
+    it('should return true when version is deleted', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement(undefined, 1));
+
+      const result = await repository.deleteVersion('ver-123');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when version does not exist', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement(undefined, 0));
+
+      const result = await repository.deleteVersion('non-existent');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // deleteAllVersions
+  // ===========================================================================
+
+  describe('deleteAllVersions', () => {
+    it('should return count of deleted versions', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement(undefined, 5));
+
+      const count = await repository.deleteAllVersions(TEST_ITEM_ID, TEST_CONTENT_TYPE);
+
+      expect(count).toBe(5);
+    });
+
+    it('should return 0 when no versions to delete', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement(undefined, 0));
+
+      const count = await repository.deleteAllVersions('no-such-item', TEST_CONTENT_TYPE);
+
+      expect(count).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // pruneOldVersions
+  // ===========================================================================
+
+  describe('pruneOldVersions', () => {
+    it('should delete versions older than keepCount', async () => {
+      // First call gets cutoff version
+      const cutoffStmt = createMockStatement({ version: 3 });
+      // Second call deletes old versions
+      const deleteStmt = createMockStatement(undefined, 2);
+
+      mockDb.prepare.mockImplementation((sql: string) => {
+        if (sql.includes('OFFSET')) {
+          return cutoffStmt;
+        }
+        if (sql.includes('DELETE')) {
+          return deleteStmt;
+        }
+        return createMockStatement();
+      });
+
+      const deleted = await repository.pruneOldVersions(TEST_ITEM_ID, TEST_CONTENT_TYPE, 3);
+
+      expect(deleted).toBe(2);
+    });
+
+    it('should return 0 when not enough versions to prune', async () => {
+      // No cutoff row found (fewer versions than keepCount)
+      mockDb.prepare.mockReturnValue(createMockStatement(undefined));
+
+      const deleted = await repository.pruneOldVersions(TEST_ITEM_ID, TEST_CONTENT_TYPE, 10);
+
+      expect(deleted).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // pruneByDate
+  // ===========================================================================
+
+  describe('pruneByDate', () => {
+    it('should delete versions older than specified date', async () => {
+      const stmt = createMockStatement(undefined, 15);
+      mockDb.prepare.mockReturnValue(stmt);
+
+      const deleted = await repository.pruneByDate('2023-01-01T00:00:00Z');
+
+      expect(deleted).toBe(15);
+      expect(stmt.run).toHaveBeenCalledWith('2023-01-01T00:00:00Z');
+    });
+
+    it('should return 0 when no old versions', async () => {
+      mockDb.prepare.mockReturnValue(createMockStatement(undefined, 0));
+
+      const deleted = await repository.pruneByDate('2020-01-01T00:00:00Z');
+
+      expect(deleted).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // Singleton Functions
+  // ===========================================================================
+
+  describe('Singleton Functions', () => {
+    beforeEach(() => {
+      resetVersionHistoryRepository();
+    });
+
+    it('getVersionHistoryRepository should return singleton instance', () => {
+      const instance1 = getVersionHistoryRepository();
+      const instance2 = getVersionHistoryRepository();
+
+      expect(instance1).toBe(instance2);
+    });
+
+    it('resetVersionHistoryRepository should clear singleton', () => {
+      const instance1 = getVersionHistoryRepository();
+      resetVersionHistoryRepository();
+      const instance2 = getVersionHistoryRepository();
+
+      expect(instance1).not.toBe(instance2);
+    });
+  });
+
+  // ===========================================================================
+  // Content Type Isolation
+  // ===========================================================================
+
+  describe('Content Type Isolation', () => {
+    it('should isolate versions by content type', async () => {
+      const stmt = createMockStatement([]);
+      mockDb.prepare.mockReturnValue(stmt);
+
+      await repository.getVersions('item-1', 'unit');
+      await repository.getVersions('item-1', 'pilot');
+
+      // Verify different content types are queried separately
+      expect(stmt.all).toHaveBeenNthCalledWith(1, 'item-1', 'unit', 50);
+      expect(stmt.all).toHaveBeenNthCalledWith(2, 'item-1', 'pilot', 50);
+    });
+  });
+
+  // ===========================================================================
+  // Edge Cases
+  // ===========================================================================
+
+  describe('Edge Cases', () => {
+    it('should handle empty content', async () => {
+      const maxVersionStmt = createMockStatement({ max_version: null });
+      const insertStmt = createMockStatement(undefined, 1);
+
+      mockDb.prepare.mockImplementation((sql: string) => {
+        if (sql.includes('MAX(version)')) {
+          return maxVersionStmt;
+        }
+        if (sql.includes('INSERT INTO')) {
+          return insertStmt;
+        }
+        return createMockStatement();
+      });
+
+      const result = await repository.saveVersion(
+        TEST_CONTENT_TYPE,
+        TEST_ITEM_ID,
+        '',
+        'empty-hash',
+        TEST_CREATED_BY
+      );
+
+      expect(result.content).toBe('');
+      expect(result.sizeBytes).toBe(0);
+    });
+
+    it('should handle very long content', async () => {
+      const longContent = 'x'.repeat(1000000); // 1MB of data
+
+      const maxVersionStmt = createMockStatement({ max_version: null });
+      const insertStmt = createMockStatement(undefined, 1);
+
+      mockDb.prepare.mockImplementation((sql: string) => {
+        if (sql.includes('MAX(version)')) {
+          return maxVersionStmt;
+        }
+        if (sql.includes('INSERT INTO')) {
+          return insertStmt;
+        }
+        return createMockStatement();
+      });
+
+      const result = await repository.saveVersion(
+        TEST_CONTENT_TYPE,
+        TEST_ITEM_ID,
+        longContent,
+        'long-hash',
+        TEST_CREATED_BY
+      );
+
+      expect(result.sizeBytes).toBe(1000000);
+    });
+
+    it('should handle special characters in item ID', async () => {
+      const specialItemId = 'item-with-special!@#$%^&*()_+';
+      const stmt = createMockStatement([]);
+      mockDb.prepare.mockReturnValue(stmt);
+
+      await repository.getVersions(specialItemId, TEST_CONTENT_TYPE);
+
+      expect(stmt.all).toHaveBeenCalledWith(specialItemId, TEST_CONTENT_TYPE, 50);
+    });
+
+    it('should handle all shareable content types', async () => {
+      const contentTypes: ShareableContentType[] = ['unit', 'pilot', 'force', 'encounter'];
+      const stmt = createMockStatement([]);
+      mockDb.prepare.mockReturnValue(stmt);
+
+      for (const contentType of contentTypes) {
+        await repository.getVersions('item-1', contentType);
+      }
+
+      expect(stmt.all).toHaveBeenCalledTimes(4);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive unit tests for vault repository services, improving test coverage for the sharing, permissions, and folder management systems.

## Changes

| File | Tests | Description |
|------|-------|-------------|
| `VaultFolderRepository.test.ts` | 63 | Folder CRUD, item management, hierarchy |
| `ShareLinkRepository.test.ts` | 59 | Sharing links, redemption, expiry, scopes |
| `PermissionRepository.test.ts` | 41 | Permission CRUD, scope checking, cleanup |
| `ContactRepository.test.ts` | 47 | Contact management, trust, search |
| `VersionHistoryRepository.test.ts` | 42 | Version tracking, pruning, storage |

**Total: 252 new tests**

## Test Coverage

All 252 tests passing. This is Batch 2 of a multi-batch test coverage improvement effort.

## Testing

```bash
npm test -- --testPathPattern="(VaultFolderRepository|ShareLinkRepository|PermissionRepository|ContactRepository|VersionHistoryRepository)" --no-coverage
```