### PR TITLE
test: add validation and construction test coverage (Batch 4)

### DIFF
--- a/src/__tests__/service/equipment/EquipmentLoaderService.test.ts
+++ b/src/__tests__/service/equipment/EquipmentLoaderService.test.ts
@@ -1,10 +1,12 @@
 import { EquipmentLoaderService, getEquipmentLoader, IEquipmentFilter } from '@/services/equipment/EquipmentLoaderService';
 import { TechBase } from '@/types/enums/TechBase';
 import { RulesLevel } from '@/types/enums/RulesLevel';
+import { EquipmentBehaviorFlag } from '@/types/enums/EquipmentFlag';
 import { IWeapon, WeaponCategory } from '@/types/equipment/weapons';
 import { AmmoCategory, AmmoVariant, IAmmunition } from '@/types/equipment/AmmunitionTypes';
 import { ElectronicsCategory, IElectronics } from '@/types/equipment/ElectronicsTypes';
 import { IMiscEquipment, MiscEquipmentCategory } from '@/types/equipment/MiscEquipmentTypes';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
 
 /**
  * Interface for accessing private maps on the service for testing.
@@ -676,6 +678,1152 @@ describe('EquipmentLoaderService', () => {
       serviceMaps.miscEquipment.set('m1', {});
       
       expect(service.getTotalCount()).toBe(5);
+    });
+  });
+
+  describe('searchWeapons() - advanced filters', () => {
+    beforeEach(() => {
+      const maps = getServiceMaps(service);
+      maps.weapons.set('ac10', {
+        id: 'ac10',
+        name: 'Autocannon/10',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.STANDARD,
+        introductionYear: 2460,
+        allowedUnitTypes: [UnitType.BATTLEMECH, UnitType.VEHICLE],
+        flags: [EquipmentBehaviorFlag.DIRECT_FIRE],
+      });
+      maps.weapons.set('clan-lrm5', {
+        id: 'clan-lrm5',
+        name: 'Clan LRM 5',
+        techBase: TechBase.CLAN,
+        rulesLevel: RulesLevel.ADVANCED,
+        introductionYear: 3050,
+        allowedUnitTypes: [UnitType.BATTLEMECH, UnitType.AEROSPACE],
+        flags: [EquipmentBehaviorFlag.ARTEMIS],
+      });
+      maps.weapons.set('ba-srm', {
+        id: 'ba-srm',
+        name: 'BA SRM',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.STANDARD,
+        introductionYear: 3050,
+        allowedUnitTypes: [UnitType.BATTLE_ARMOR],
+        flags: [EquipmentBehaviorFlag.ONE_SHOT],
+      });
+      maps.weapons.set('medium-laser-no-flags', {
+        id: 'medium-laser-no-flags',
+        name: 'Medium Laser',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.INTRODUCTORY,
+        introductionYear: 2470,
+        // No allowedUnitTypes - defaults to mech/vehicle/aerospace
+        // No flags
+      });
+    });
+
+    it('should filter by single unit type', () => {
+      const results = service.searchWeapons({ unitType: UnitType.BATTLE_ARMOR });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('ba-srm');
+    });
+
+    it('should filter by multiple unit types', () => {
+      const results = service.searchWeapons({ unitType: [UnitType.AEROSPACE, UnitType.VEHICLE] });
+      // ac10 (vehicle), clan-lrm5 (aerospace), medium-laser-no-flags (defaults include aerospace/vehicle)
+      expect(results.length).toBe(3);
+    });
+
+    it('should filter by hasFlags - match equipment with ALL specified flags', () => {
+      const results = service.searchWeapons({ hasFlags: [EquipmentBehaviorFlag.DIRECT_FIRE] });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('ac10');
+    });
+
+    it('should filter by excludeFlags - exclude equipment with ANY specified flags', () => {
+      const results = service.searchWeapons({ excludeFlags: [EquipmentBehaviorFlag.ONE_SHOT] });
+      // Excludes ba-srm
+      expect(results.length).toBe(3);
+      expect(results.every(w => w.id !== 'ba-srm')).toBe(true);
+    });
+
+    it('should combine unitType and flags filters', () => {
+      const results = service.searchWeapons({
+        unitType: UnitType.BATTLEMECH,
+        excludeFlags: [EquipmentBehaviorFlag.ARTEMIS],
+      });
+      // ac10 (mech), medium-laser-no-flags (default mech) - excludes clan-lrm5 (has ARTEMIS)
+      expect(results.length).toBe(2);
+    });
+
+    it('should return weapons with default unit types when filter requests common types', () => {
+      const results = service.searchWeapons({ unitType: UnitType.BATTLEMECH });
+      // ac10, clan-lrm5, medium-laser-no-flags all support battlemech
+      expect(results.length).toBe(3);
+    });
+
+    it('should filter weapons with no flags when hasFlags is specified', () => {
+      const results = service.searchWeapons({ hasFlags: [EquipmentBehaviorFlag.MASC] });
+      expect(results.length).toBe(0);
+    });
+
+    it('should not exclude weapons with no flags when excludeFlags is specified', () => {
+      const results = service.searchWeapons({ excludeFlags: [EquipmentBehaviorFlag.MASC] });
+      // All 4 weapons pass since none have MASC
+      expect(results.length).toBe(4);
+    });
+  });
+
+  describe('searchAmmunition()', () => {
+    beforeEach(() => {
+      const maps = getServiceMaps(service);
+      maps.ammunition.set('ac10-std', {
+        id: 'ac10-std',
+        name: 'AC/10 Standard Ammo',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.STANDARD,
+        introductionYear: 2460,
+        allowedUnitTypes: [UnitType.BATTLEMECH, UnitType.VEHICLE],
+        flags: [EquipmentBehaviorFlag.EXPLOSIVE],
+      });
+      maps.ammunition.set('clan-lrm-ammo', {
+        id: 'clan-lrm-ammo',
+        name: 'Clan LRM Ammo',
+        techBase: TechBase.CLAN,
+        rulesLevel: RulesLevel.ADVANCED,
+        introductionYear: 3050,
+        allowedUnitTypes: [UnitType.BATTLEMECH, UnitType.AEROSPACE],
+      });
+      maps.ammunition.set('ba-srm-ammo', {
+        id: 'ba-srm-ammo',
+        name: 'BA SRM Ammo',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.STANDARD,
+        introductionYear: 3050,
+        allowedUnitTypes: [UnitType.BATTLE_ARMOR],
+      });
+      maps.ammunition.set('std-ammo-no-types', {
+        id: 'std-ammo-no-types',
+        name: 'Standard Ammo',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.INTRODUCTORY,
+        introductionYear: 2470,
+        // No allowedUnitTypes - defaults apply
+      });
+    });
+
+    it('should return all ammunition with no filter', () => {
+      const results = service.searchAmmunition({});
+      expect(results.length).toBe(4);
+    });
+
+    it('should filter by tech base', () => {
+      const results = service.searchAmmunition({ techBase: TechBase.CLAN });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('clan-lrm-ammo');
+    });
+
+    it('should filter by multiple tech bases', () => {
+      const results = service.searchAmmunition({ techBase: [TechBase.INNER_SPHERE, TechBase.CLAN] });
+      expect(results.length).toBe(4);
+    });
+
+    it('should filter by rules level', () => {
+      const results = service.searchAmmunition({ rulesLevel: RulesLevel.ADVANCED });
+      expect(results.length).toBe(1);
+    });
+
+    it('should filter by max year', () => {
+      const results = service.searchAmmunition({ maxYear: 2500 });
+      expect(results.length).toBe(2); // ac10-std, std-ammo-no-types
+    });
+
+    it('should filter by min year', () => {
+      const results = service.searchAmmunition({ minYear: 3000 });
+      expect(results.length).toBe(2); // clan-lrm-ammo, ba-srm-ammo
+    });
+
+    it('should filter by search text', () => {
+      const results = service.searchAmmunition({ searchText: 'lrm' });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('clan-lrm-ammo');
+    });
+
+    it('should filter by unit type', () => {
+      const results = service.searchAmmunition({ unitType: UnitType.BATTLE_ARMOR });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('ba-srm-ammo');
+    });
+
+    it('should filter by hasFlags', () => {
+      const results = service.searchAmmunition({ hasFlags: [EquipmentBehaviorFlag.EXPLOSIVE] });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('ac10-std');
+    });
+
+    it('should filter by excludeFlags', () => {
+      const results = service.searchAmmunition({ excludeFlags: [EquipmentBehaviorFlag.EXPLOSIVE] });
+      expect(results.length).toBe(3);
+    });
+
+    it('should combine multiple filters', () => {
+      const results = service.searchAmmunition({
+        techBase: TechBase.INNER_SPHERE,
+        minYear: 3000,
+        unitType: UnitType.BATTLE_ARMOR,
+      });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('ba-srm-ammo');
+    });
+  });
+
+  describe('searchElectronics()', () => {
+    beforeEach(() => {
+      const maps = getServiceMaps(service);
+      maps.electronics.set('beagle', {
+        id: 'beagle',
+        name: 'Beagle Active Probe',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.STANDARD,
+        introductionYear: 3045,
+        allowedUnitTypes: [UnitType.BATTLEMECH, UnitType.VEHICLE],
+        flags: [EquipmentBehaviorFlag.BAP],
+      });
+      maps.electronics.set('clan-ecm', {
+        id: 'clan-ecm',
+        name: 'Clan ECM Suite',
+        techBase: TechBase.CLAN,
+        rulesLevel: RulesLevel.ADVANCED,
+        introductionYear: 3050,
+        allowedUnitTypes: [UnitType.BATTLEMECH],
+        flags: [EquipmentBehaviorFlag.ECM],
+      });
+      maps.electronics.set('ba-probe', {
+        id: 'ba-probe',
+        name: 'BA Active Probe',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.STANDARD,
+        introductionYear: 3055,
+        allowedUnitTypes: [UnitType.BATTLE_ARMOR],
+      });
+      maps.electronics.set('default-elec', {
+        id: 'default-elec',
+        name: 'Generic Sensor',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.INTRODUCTORY,
+        introductionYear: 2500,
+        // No allowedUnitTypes
+      });
+    });
+
+    it('should return all electronics with no filter', () => {
+      const results = service.searchElectronics({});
+      expect(results.length).toBe(4);
+    });
+
+    it('should filter by tech base', () => {
+      const results = service.searchElectronics({ techBase: TechBase.CLAN });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('clan-ecm');
+    });
+
+    it('should filter by multiple tech bases', () => {
+      const results = service.searchElectronics({ techBase: [TechBase.INNER_SPHERE, TechBase.CLAN] });
+      expect(results.length).toBe(4);
+    });
+
+    it('should filter by rules level', () => {
+      const results = service.searchElectronics({ rulesLevel: RulesLevel.STANDARD });
+      expect(results.length).toBe(2);
+    });
+
+    it('should filter by max year', () => {
+      const results = service.searchElectronics({ maxYear: 3049 });
+      expect(results.length).toBe(2); // beagle, default-elec
+    });
+
+    it('should filter by min year', () => {
+      const results = service.searchElectronics({ minYear: 3050 });
+      expect(results.length).toBe(2); // clan-ecm, ba-probe
+    });
+
+    it('should filter by search text', () => {
+      const results = service.searchElectronics({ searchText: 'probe' });
+      expect(results.length).toBe(2);
+    });
+
+    it('should filter by unit type', () => {
+      const results = service.searchElectronics({ unitType: UnitType.BATTLE_ARMOR });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('ba-probe');
+    });
+
+    it('should filter by hasFlags', () => {
+      const results = service.searchElectronics({ hasFlags: [EquipmentBehaviorFlag.ECM] });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('clan-ecm');
+    });
+
+    it('should filter by excludeFlags', () => {
+      const results = service.searchElectronics({ excludeFlags: [EquipmentBehaviorFlag.BAP] });
+      expect(results.length).toBe(3);
+    });
+
+    it('should combine multiple filters', () => {
+      const results = service.searchElectronics({
+        techBase: TechBase.INNER_SPHERE,
+        minYear: 3050,
+      });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('ba-probe');
+    });
+  });
+
+  describe('searchMiscEquipment()', () => {
+    beforeEach(() => {
+      const maps = getServiceMaps(service);
+      maps.miscEquipment.set('masc', {
+        id: 'masc',
+        name: 'MASC',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.ADVANCED,
+        introductionYear: 3035,
+        allowedUnitTypes: [UnitType.BATTLEMECH],
+        flags: [EquipmentBehaviorFlag.MASC],
+      });
+      maps.miscEquipment.set('clan-case', {
+        id: 'clan-case',
+        name: 'Clan CASE',
+        techBase: TechBase.CLAN,
+        rulesLevel: RulesLevel.STANDARD,
+        introductionYear: 2850,
+        allowedUnitTypes: [UnitType.BATTLEMECH, UnitType.VEHICLE],
+        flags: [EquipmentBehaviorFlag.CASE],
+      });
+      maps.miscEquipment.set('ba-stealth', {
+        id: 'ba-stealth',
+        name: 'BA Stealth System',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.ADVANCED,
+        introductionYear: 3060,
+        allowedUnitTypes: [UnitType.BATTLE_ARMOR],
+        flags: [EquipmentBehaviorFlag.STEALTH],
+      });
+      maps.miscEquipment.set('default-misc', {
+        id: 'default-misc',
+        name: 'Generic Equipment',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.INTRODUCTORY,
+        introductionYear: 2400,
+        // No allowedUnitTypes
+      });
+    });
+
+    it('should return all misc equipment with no filter', () => {
+      const results = service.searchMiscEquipment({});
+      expect(results.length).toBe(4);
+    });
+
+    it('should filter by tech base', () => {
+      const results = service.searchMiscEquipment({ techBase: TechBase.CLAN });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('clan-case');
+    });
+
+    it('should filter by multiple tech bases', () => {
+      const results = service.searchMiscEquipment({ techBase: [TechBase.INNER_SPHERE, TechBase.CLAN] });
+      expect(results.length).toBe(4);
+    });
+
+    it('should filter by rules level', () => {
+      const results = service.searchMiscEquipment({ rulesLevel: RulesLevel.ADVANCED });
+      expect(results.length).toBe(2);
+    });
+
+    it('should filter by max year', () => {
+      const results = service.searchMiscEquipment({ maxYear: 3000 });
+      expect(results.length).toBe(2); // clan-case, default-misc
+    });
+
+    it('should filter by min year', () => {
+      const results = service.searchMiscEquipment({ minYear: 3035 });
+      expect(results.length).toBe(2); // masc, ba-stealth
+    });
+
+    it('should filter by search text', () => {
+      const results = service.searchMiscEquipment({ searchText: 'case' });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('clan-case');
+    });
+
+    it('should filter by unit type', () => {
+      const results = service.searchMiscEquipment({ unitType: UnitType.BATTLE_ARMOR });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('ba-stealth');
+    });
+
+    it('should filter by hasFlags', () => {
+      const results = service.searchMiscEquipment({ hasFlags: [EquipmentBehaviorFlag.CASE] });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('clan-case');
+    });
+
+    it('should filter by excludeFlags', () => {
+      const results = service.searchMiscEquipment({ excludeFlags: [EquipmentBehaviorFlag.MASC] });
+      expect(results.length).toBe(3);
+    });
+
+    it('should combine multiple filters', () => {
+      const results = service.searchMiscEquipment({
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.ADVANCED,
+      });
+      expect(results.length).toBe(2); // masc, ba-stealth
+    });
+  });
+
+  describe('searchByUnitType()', () => {
+    beforeEach(() => {
+      const maps = getServiceMaps(service);
+      // Set up equipment for multiple categories
+      maps.weapons.set('ba-weapon', {
+        id: 'ba-weapon',
+        name: 'BA Weapon',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.STANDARD,
+        introductionYear: 3050,
+        allowedUnitTypes: [UnitType.BATTLE_ARMOR],
+      });
+      maps.weapons.set('mech-weapon', {
+        id: 'mech-weapon',
+        name: 'Mech Weapon',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.STANDARD,
+        introductionYear: 2470,
+        allowedUnitTypes: [UnitType.BATTLEMECH],
+      });
+      maps.ammunition.set('ba-ammo', {
+        id: 'ba-ammo',
+        name: 'BA Ammo',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.STANDARD,
+        introductionYear: 3050,
+        allowedUnitTypes: [UnitType.BATTLE_ARMOR],
+      });
+      maps.electronics.set('ba-sensor', {
+        id: 'ba-sensor',
+        name: 'BA Sensor',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.STANDARD,
+        introductionYear: 3050,
+        allowedUnitTypes: [UnitType.BATTLE_ARMOR],
+      });
+      maps.miscEquipment.set('ba-jump', {
+        id: 'ba-jump',
+        name: 'BA Jump Pack',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.STANDARD,
+        introductionYear: 3050,
+        allowedUnitTypes: [UnitType.BATTLE_ARMOR],
+      });
+    });
+
+    it('should return all equipment types for a unit type', () => {
+      const results = service.searchByUnitType(UnitType.BATTLE_ARMOR);
+      
+      expect(results.weapons.length).toBe(1);
+      expect(results.weapons[0].id).toBe('ba-weapon');
+      expect(results.ammunition.length).toBe(1);
+      expect(results.ammunition[0].id).toBe('ba-ammo');
+      expect(results.electronics.length).toBe(1);
+      expect(results.electronics[0].id).toBe('ba-sensor');
+      expect(results.miscEquipment.length).toBe(1);
+      expect(results.miscEquipment[0].id).toBe('ba-jump');
+    });
+
+    it('should return battlemech equipment', () => {
+      const results = service.searchByUnitType(UnitType.BATTLEMECH);
+      
+      expect(results.weapons.length).toBe(1);
+      expect(results.weapons[0].id).toBe('mech-weapon');
+    });
+  });
+
+  describe('getAmmunitionById()', () => {
+    it('should return ammunition when found', () => {
+      const mockAmmo: Partial<IAmmunition> = {
+        id: 'ac10-ammo',
+        name: 'AC/10 Ammo',
+        category: AmmoCategory.AUTOCANNON,
+      };
+      
+      getServiceMaps(service).ammunition.set('ac10-ammo', mockAmmo);
+      
+      const ammo = service.getAmmunitionById('ac10-ammo');
+      expect(ammo).toEqual(mockAmmo);
+    });
+
+    it('should return null when not found', () => {
+      const ammo = service.getAmmunitionById('non-existent');
+      expect(ammo).toBeNull();
+    });
+  });
+
+  describe('getElectronicsById()', () => {
+    it('should return electronics when found', () => {
+      const mockElec: Partial<IElectronics> = {
+        id: 'ecm-suite',
+        name: 'ECM Suite',
+        category: ElectronicsCategory.ECM,
+      };
+      
+      getServiceMaps(service).electronics.set('ecm-suite', mockElec);
+      
+      const elec = service.getElectronicsById('ecm-suite');
+      expect(elec).toEqual(mockElec);
+    });
+
+    it('should return null when not found', () => {
+      const elec = service.getElectronicsById('non-existent');
+      expect(elec).toBeNull();
+    });
+  });
+
+  describe('getMiscEquipmentById()', () => {
+    it('should return misc equipment when found', () => {
+      const mockMisc: Partial<IMiscEquipment> = {
+        id: 'jump-jet',
+        name: 'Jump Jet',
+        category: MiscEquipmentCategory.JUMP_JET,
+      };
+      
+      getServiceMaps(service).miscEquipment.set('jump-jet', mockMisc);
+      
+      const misc = service.getMiscEquipmentById('jump-jet');
+      expect(misc).toEqual(mockMisc);
+    });
+
+    it('should return null when not found', () => {
+      const misc = service.getMiscEquipmentById('non-existent');
+      expect(misc).toBeNull();
+    });
+  });
+
+  describe('getAllAmmunition()', () => {
+    it('should return all ammunition as array', () => {
+      const maps = getServiceMaps(service);
+      maps.ammunition.set('ammo1', { id: 'ammo1', name: 'Ammo 1' });
+      maps.ammunition.set('ammo2', { id: 'ammo2', name: 'Ammo 2' });
+      
+      const results = service.getAllAmmunition();
+      expect(results.length).toBe(2);
+    });
+  });
+
+  describe('getAllElectronics()', () => {
+    it('should return all electronics as array', () => {
+      const maps = getServiceMaps(service);
+      maps.electronics.set('elec1', { id: 'elec1', name: 'Electronics 1' });
+      maps.electronics.set('elec2', { id: 'elec2', name: 'Electronics 2' });
+      
+      const results = service.getAllElectronics();
+      expect(results.length).toBe(2);
+    });
+  });
+
+  describe('getAllMiscEquipment()', () => {
+    it('should return all misc equipment as array', () => {
+      const maps = getServiceMaps(service);
+      maps.miscEquipment.set('misc1', { id: 'misc1', name: 'Misc 1' });
+      maps.miscEquipment.set('misc2', { id: 'misc2', name: 'Misc 2' });
+      
+      const results = service.getAllMiscEquipment();
+      expect(results.length).toBe(2);
+    });
+  });
+
+  describe('loadOfficialEquipment() - comprehensive category parsing', () => {
+    const buildEquipmentFile = <T>(items: T[]) => ({
+      $schema: 'test',
+      version: '1.0',
+      generatedAt: '2024-01-01',
+      count: items.length,
+      items,
+    });
+
+    it('should parse Artillery weapon category', async () => {
+      const weaponFile = buildEquipmentFile([{
+        id: 'long-tom',
+        name: 'Long Tom Artillery',
+        category: 'Artillery',
+        subType: 'Tube Artillery',
+        techBase: 'INNER_SPHERE',
+        rulesLevel: 'ADVANCED',
+        damage: 20,
+        heat: 0,
+        ranges: { minimum: 0, short: 6, medium: 12, long: 18 },
+        weight: 30,
+        criticalSlots: 0,
+        costCBills: 500000,
+        battleValue: 200,
+        introductionYear: 2600,
+      }]);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, json: async () => weaponFile })
+        .mockResolvedValue({ ok: false, status: 404 });
+
+      await service.loadOfficialEquipment();
+
+      const weapon = service.getWeaponById('long-tom');
+      expect(weapon?.category).toBe(WeaponCategory.ARTILLERY);
+    });
+
+    it('should parse all ammo categories', async () => {
+      const ammoFile = buildEquipmentFile([
+        { id: 'mg-ammo', name: 'MG Ammo', category: 'Machine Gun', variant: 'Standard', techBase: 'INNER_SPHERE', rulesLevel: 'STANDARD', compatibleWeaponIds: ['mg'], shotsPerTon: 200, weight: 1, criticalSlots: 1, costPerTon: 1000, battleValue: 1, isExplosive: false, introductionYear: 2400 },
+        { id: 'lrm-ammo', name: 'LRM Ammo', category: 'LRM', variant: 'Armor-Piercing', techBase: 'INNER_SPHERE', rulesLevel: 'STANDARD', compatibleWeaponIds: ['lrm5'], shotsPerTon: 24, weight: 1, criticalSlots: 1, costPerTon: 30000, battleValue: 5, isExplosive: true, introductionYear: 2400 },
+        { id: 'srm-ammo', name: 'SRM Ammo', category: 'SRM', variant: 'Cluster', techBase: 'INNER_SPHERE', rulesLevel: 'STANDARD', compatibleWeaponIds: ['srm2'], shotsPerTon: 50, weight: 1, criticalSlots: 1, costPerTon: 27000, battleValue: 3, isExplosive: true, introductionYear: 2400 },
+        { id: 'mrm-ammo', name: 'MRM Ammo', category: 'MRM', variant: 'Flechette', techBase: 'INNER_SPHERE', rulesLevel: 'ADVANCED', compatibleWeaponIds: ['mrm10'], shotsPerTon: 24, weight: 1, criticalSlots: 1, costPerTon: 5000, battleValue: 3, isExplosive: true, introductionYear: 3058 },
+        { id: 'atm-ammo', name: 'ATM Ammo', category: 'ATM', variant: 'Inferno', techBase: 'CLAN', rulesLevel: 'ADVANCED', compatibleWeaponIds: ['atm3'], shotsPerTon: 20, weight: 1, criticalSlots: 1, costPerTon: 75000, battleValue: 7, isExplosive: true, introductionYear: 3054 },
+        { id: 'narc-ammo', name: 'NARC Ammo', category: 'NARC', variant: 'Fragmentation', techBase: 'INNER_SPHERE', rulesLevel: 'ADVANCED', compatibleWeaponIds: ['narc'], shotsPerTon: 6, weight: 1, criticalSlots: 1, costPerTon: 6000, battleValue: 2, isExplosive: true, introductionYear: 3035 },
+        { id: 'arty-ammo', name: 'Artillery Ammo', category: 'Artillery', variant: 'Incendiary', techBase: 'INNER_SPHERE', rulesLevel: 'ADVANCED', compatibleWeaponIds: ['long-tom'], shotsPerTon: 5, weight: 1, criticalSlots: 1, costPerTon: 10000, battleValue: 1, isExplosive: true, introductionYear: 2600 },
+        { id: 'ams-ammo', name: 'AMS Ammo', category: 'AMS', variant: 'Smoke', techBase: 'INNER_SPHERE', rulesLevel: 'STANDARD', compatibleWeaponIds: ['ams'], shotsPerTon: 12, weight: 1, criticalSlots: 1, costPerTon: 2000, battleValue: 1, isExplosive: false, introductionYear: 3040 },
+      ]);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // energy
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // ballistic
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // missile
+        .mockResolvedValueOnce({ ok: true, json: async () => ammoFile })
+        .mockResolvedValue({ ok: false, status: 404 });
+
+      await service.loadOfficialEquipment();
+
+      expect(service.getAmmunitionById('mg-ammo')?.category).toBe(AmmoCategory.MACHINE_GUN);
+      expect(service.getAmmunitionById('lrm-ammo')?.category).toBe(AmmoCategory.LRM);
+      expect(service.getAmmunitionById('lrm-ammo')?.variant).toBe(AmmoVariant.ARMOR_PIERCING);
+      expect(service.getAmmunitionById('srm-ammo')?.category).toBe(AmmoCategory.SRM);
+      expect(service.getAmmunitionById('srm-ammo')?.variant).toBe(AmmoVariant.CLUSTER);
+      expect(service.getAmmunitionById('mrm-ammo')?.category).toBe(AmmoCategory.MRM);
+      expect(service.getAmmunitionById('mrm-ammo')?.variant).toBe(AmmoVariant.FLECHETTE);
+      expect(service.getAmmunitionById('atm-ammo')?.category).toBe(AmmoCategory.ATM);
+      expect(service.getAmmunitionById('atm-ammo')?.variant).toBe(AmmoVariant.INFERNO);
+      expect(service.getAmmunitionById('narc-ammo')?.category).toBe(AmmoCategory.NARC);
+      expect(service.getAmmunitionById('narc-ammo')?.variant).toBe(AmmoVariant.FRAGMENTATION);
+      expect(service.getAmmunitionById('arty-ammo')?.category).toBe(AmmoCategory.ARTILLERY);
+      expect(service.getAmmunitionById('arty-ammo')?.variant).toBe(AmmoVariant.INCENDIARY);
+      expect(service.getAmmunitionById('ams-ammo')?.category).toBe(AmmoCategory.AMS);
+      expect(service.getAmmunitionById('ams-ammo')?.variant).toBe(AmmoVariant.SMOKE);
+    });
+
+    it('should parse additional ammo variants', async () => {
+      const ammoFile = buildEquipmentFile([
+        { id: 'thunder-ammo', name: 'Thunder Ammo', category: 'LRM', variant: 'Thunder', techBase: 'INNER_SPHERE', rulesLevel: 'ADVANCED', compatibleWeaponIds: ['lrm5'], shotsPerTon: 24, weight: 1, criticalSlots: 1, costPerTon: 50000, battleValue: 5, isExplosive: true, introductionYear: 3055 },
+        { id: 'swarm-ammo', name: 'Swarm Ammo', category: 'LRM', variant: 'Swarm', techBase: 'INNER_SPHERE', rulesLevel: 'ADVANCED', compatibleWeaponIds: ['lrm10'], shotsPerTon: 12, weight: 1, criticalSlots: 1, costPerTon: 60000, battleValue: 6, isExplosive: true, introductionYear: 3055 },
+        { id: 'tandem-ammo', name: 'Tandem Charge Ammo', category: 'SRM', variant: 'Tandem-Charge', techBase: 'INNER_SPHERE', rulesLevel: 'ADVANCED', compatibleWeaponIds: ['srm4'], shotsPerTon: 25, weight: 1, criticalSlots: 1, costPerTon: 50000, battleValue: 8, isExplosive: true, introductionYear: 3060 },
+        { id: 'er-ammo', name: 'Extended Range Ammo', category: 'ATM', variant: 'Extended Range', techBase: 'CLAN', rulesLevel: 'ADVANCED', compatibleWeaponIds: ['atm6'], shotsPerTon: 10, weight: 1, criticalSlots: 1, costPerTon: 80000, battleValue: 10, isExplosive: true, introductionYear: 3054 },
+        { id: 'he-ammo', name: 'High Explosive Ammo', category: 'ATM', variant: 'High Explosive', techBase: 'CLAN', rulesLevel: 'ADVANCED', compatibleWeaponIds: ['atm9'], shotsPerTon: 10, weight: 1, criticalSlots: 1, costPerTon: 90000, battleValue: 12, isExplosive: true, introductionYear: 3054 },
+      ]);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // energy
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // ballistic
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // missile
+        .mockResolvedValueOnce({ ok: true, json: async () => ammoFile })
+        .mockResolvedValue({ ok: false, status: 404 });
+
+      await service.loadOfficialEquipment();
+
+      expect(service.getAmmunitionById('thunder-ammo')?.variant).toBe(AmmoVariant.THUNDER);
+      expect(service.getAmmunitionById('swarm-ammo')?.variant).toBe(AmmoVariant.SWARM);
+      expect(service.getAmmunitionById('tandem-ammo')?.variant).toBe(AmmoVariant.TANDEM_CHARGE);
+      expect(service.getAmmunitionById('er-ammo')?.variant).toBe(AmmoVariant.EXTENDED_RANGE);
+      expect(service.getAmmunitionById('he-ammo')?.variant).toBe(AmmoVariant.HIGH_EXPLOSIVE);
+    });
+
+    it('should parse all electronics categories', async () => {
+      const elecFile = buildEquipmentFile([
+        { id: 'targeting', name: 'Targeting Computer', category: 'Targeting', techBase: 'INNER_SPHERE', rulesLevel: 'ADVANCED', weight: 1, criticalSlots: 1, costCBills: 100000, battleValue: 50, introductionYear: 3050 },
+        { id: 'ecm', name: 'ECM Suite', category: 'ECM', techBase: 'INNER_SPHERE', rulesLevel: 'STANDARD', weight: 1.5, criticalSlots: 2, costCBills: 200000, battleValue: 60, introductionYear: 3045 },
+        { id: 'probe', name: 'Active Probe', category: 'Active Probe', techBase: 'INNER_SPHERE', rulesLevel: 'STANDARD', weight: 1, criticalSlots: 1, costCBills: 100000, battleValue: 30, introductionYear: 3040 },
+        { id: 'c3', name: 'C3 Master', category: 'C3 System', techBase: 'INNER_SPHERE', rulesLevel: 'ADVANCED', weight: 5, criticalSlots: 5, costCBills: 1500000, battleValue: 150, introductionYear: 3050 },
+        { id: 'tag', name: 'TAG', category: 'TAG', techBase: 'INNER_SPHERE', rulesLevel: 'STANDARD', weight: 1, criticalSlots: 1, costCBills: 50000, battleValue: 0, introductionYear: 3045 },
+        { id: 'comms', name: 'Communications Equipment', category: 'Communications', techBase: 'INNER_SPHERE', rulesLevel: 'STANDARD', weight: 1, criticalSlots: 1, costCBills: 75000, battleValue: 10, introductionYear: 2400 },
+      ]);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // energy
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // ballistic
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // missile
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // ammo
+        .mockResolvedValueOnce({ ok: true, json: async () => elecFile })
+        .mockResolvedValue({ ok: false, status: 404 });
+
+      await service.loadOfficialEquipment();
+
+      expect(service.getElectronicsById('targeting')?.category).toBe(ElectronicsCategory.TARGETING);
+      expect(service.getElectronicsById('ecm')?.category).toBe(ElectronicsCategory.ECM);
+      expect(service.getElectronicsById('probe')?.category).toBe(ElectronicsCategory.ACTIVE_PROBE);
+      expect(service.getElectronicsById('c3')?.category).toBe(ElectronicsCategory.C3);
+      expect(service.getElectronicsById('tag')?.category).toBe(ElectronicsCategory.TAG);
+      expect(service.getElectronicsById('comms')?.category).toBe(ElectronicsCategory.COMMUNICATIONS);
+    });
+
+    it('should parse all misc equipment categories', async () => {
+      const miscFile = buildEquipmentFile([
+        { id: 'hs', name: 'Heat Sink', category: 'Heat Sink', techBase: 'INNER_SPHERE', rulesLevel: 'INTRODUCTORY', weight: 1, criticalSlots: 1, costCBills: 2000, battleValue: 0, introductionYear: 2400 },
+        { id: 'jj', name: 'Jump Jet', category: 'Jump Jet', techBase: 'INNER_SPHERE', rulesLevel: 'INTRODUCTORY', weight: 1, criticalSlots: 1, costCBills: 10000, battleValue: 0, introductionYear: 2400 },
+        { id: 'masc', name: 'MASC', category: 'Movement Enhancement', techBase: 'INNER_SPHERE', rulesLevel: 'ADVANCED', weight: 2, criticalSlots: 2, costCBills: 200000, battleValue: 50, introductionYear: 3035 },
+        { id: 'case', name: 'CASE', category: 'Defensive', techBase: 'INNER_SPHERE', rulesLevel: 'STANDARD', weight: 0.5, criticalSlots: 1, costCBills: 50000, battleValue: 0, introductionYear: 3040 },
+        { id: 'tsm', name: 'Triple Strength Myomer', category: 'Myomer', techBase: 'INNER_SPHERE', rulesLevel: 'ADVANCED', weight: 0, criticalSlots: 6, costCBills: 16000, battleValue: 0, introductionYear: 3050 },
+        { id: 'backhoe', name: 'Backhoe', category: 'Industrial', techBase: 'INNER_SPHERE', rulesLevel: 'STANDARD', weight: 5, criticalSlots: 6, costCBills: 50000, battleValue: 0, introductionYear: 2400 },
+      ]);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // energy
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // ballistic
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // missile
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // ammo
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // electronics
+        .mockResolvedValueOnce({ ok: true, json: async () => miscFile });
+
+      await service.loadOfficialEquipment();
+
+      expect(service.getMiscEquipmentById('hs')?.category).toBe(MiscEquipmentCategory.HEAT_SINK);
+      expect(service.getMiscEquipmentById('jj')?.category).toBe(MiscEquipmentCategory.JUMP_JET);
+      expect(service.getMiscEquipmentById('masc')?.category).toBe(MiscEquipmentCategory.MOVEMENT);
+      expect(service.getMiscEquipmentById('case')?.category).toBe(MiscEquipmentCategory.DEFENSIVE);
+      expect(service.getMiscEquipmentById('tsm')?.category).toBe(MiscEquipmentCategory.MYOMER);
+      expect(service.getMiscEquipmentById('backhoe')?.category).toBe(MiscEquipmentCategory.INDUSTRIAL);
+    });
+
+    it('should parse weapons with optional fields (ammoPerTon, isExplosive, special, flags, allowedUnitTypes, allowedLocations)', async () => {
+      const weaponFile = buildEquipmentFile([{
+        id: 'ac5',
+        name: 'Autocannon/5',
+        category: 'Ballistic',
+        subType: 'Autocannon',
+        techBase: 'INNER_SPHERE',
+        rulesLevel: 'STANDARD',
+        damage: 5,
+        heat: 1,
+        ranges: { minimum: 3, short: 6, medium: 12, long: 18, extreme: 24 },
+        weight: 8,
+        criticalSlots: 4,
+        ammoPerTon: 20,
+        costCBills: 125000,
+        battleValue: 70,
+        introductionYear: 2250,
+        isExplosive: true,
+        special: ['Jams on 1', 'Rapid Fire'],
+        allowedUnitTypes: ['BattleMech', 'Vehicle'],
+        flags: ['DIRECT_FIRE', 'RAPID_FIRE'],
+        allowedLocations: ['RA', 'LA', 'RT', 'LT', 'CT'],
+      }]);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // energy
+        .mockResolvedValueOnce({ ok: true, json: async () => weaponFile })
+        .mockResolvedValue({ ok: false, status: 404 });
+
+      await service.loadOfficialEquipment();
+
+      const weapon = service.getWeaponById('ac5');
+      expect(weapon).not.toBeNull();
+      expect(weapon?.ammoPerTon).toBe(20);
+      expect(weapon?.isExplosive).toBe(true);
+      expect(weapon?.special).toEqual(['Jams on 1', 'Rapid Fire']);
+      expect(weapon?.allowedUnitTypes).toContain(UnitType.BATTLEMECH);
+      expect(weapon?.allowedUnitTypes).toContain(UnitType.VEHICLE);
+      expect(weapon?.flags).toContain(EquipmentBehaviorFlag.DIRECT_FIRE);
+      expect(weapon?.flags).toContain(EquipmentBehaviorFlag.RAPID_FIRE);
+      expect(weapon?.allowedLocations).toEqual(['RA', 'LA', 'RT', 'LT', 'CT']);
+    });
+
+    it('should parse ammunition with optional fields (damageModifier, rangeModifier, special, flags)', async () => {
+      const ammoFile = buildEquipmentFile([{
+        id: 'ac5-ap',
+        name: 'AC/5 Armor-Piercing Ammo',
+        category: 'Autocannon',
+        variant: 'Armor-Piercing',
+        techBase: 'INNER_SPHERE',
+        rulesLevel: 'ADVANCED',
+        compatibleWeaponIds: ['ac5'],
+        shotsPerTon: 15,
+        weight: 1,
+        criticalSlots: 1,
+        costPerTon: 15000,
+        battleValue: 8,
+        isExplosive: true,
+        introductionYear: 3060,
+        damageModifier: 1.5,
+        rangeModifier: -1,
+        special: ['Reduces target armor by 50%'],
+        flags: ['EXPLOSIVE'],
+        allowedUnitTypes: ['BattleMech', 'Vehicle'],
+      }]);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // energy
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // ballistic
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // missile
+        .mockResolvedValueOnce({ ok: true, json: async () => ammoFile })
+        .mockResolvedValue({ ok: false, status: 404 });
+
+      await service.loadOfficialEquipment();
+
+      const ammo = service.getAmmunitionById('ac5-ap');
+      expect(ammo).not.toBeNull();
+      expect(ammo?.damageModifier).toBe(1.5);
+      expect(ammo?.rangeModifier).toBe(-1);
+      expect(ammo?.special).toEqual(['Reduces target armor by 50%']);
+      expect(ammo?.flags).toContain(EquipmentBehaviorFlag.EXPLOSIVE);
+      expect(ammo?.allowedUnitTypes).toContain(UnitType.BATTLEMECH);
+    });
+
+    it('should parse electronics with optional fields (special, variableEquipmentId, flags, allowedLocations)', async () => {
+      const elecFile = buildEquipmentFile([{
+        id: 'tc-var',
+        name: 'Targeting Computer',
+        category: 'Targeting',
+        techBase: 'INNER_SPHERE',
+        rulesLevel: 'ADVANCED',
+        weight: 1,
+        criticalSlots: 1,
+        costCBills: 100000,
+        battleValue: 50,
+        introductionYear: 3050,
+        special: ['Direct fire weapons +1 to-hit'],
+        variableEquipmentId: 'tc-variable',
+        flags: ['TARGETING_COMPUTER'],
+        allowedUnitTypes: ['BattleMech'],
+        allowedLocations: ['HD', 'CT', 'RT', 'LT'],
+      }]);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // energy
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // ballistic
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // missile
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // ammo
+        .mockResolvedValueOnce({ ok: true, json: async () => elecFile })
+        .mockResolvedValue({ ok: false, status: 404 });
+
+      await service.loadOfficialEquipment();
+
+      const elec = service.getElectronicsById('tc-var');
+      expect(elec).not.toBeNull();
+      expect(elec?.special).toEqual(['Direct fire weapons +1 to-hit']);
+      expect(elec?.variableEquipmentId).toBe('tc-variable');
+      expect(elec?.flags).toContain(EquipmentBehaviorFlag.TARGETING_COMPUTER);
+      expect(elec?.allowedUnitTypes).toContain(UnitType.BATTLEMECH);
+      expect(elec?.allowedLocations).toEqual(['HD', 'CT', 'RT', 'LT']);
+    });
+
+    it('should parse misc equipment with optional fields (special, variableEquipmentId, flags, allowedLocations)', async () => {
+      const miscFile = buildEquipmentFile([{
+        id: 'dhs-var',
+        name: 'Double Heat Sink',
+        category: 'Heat Sink',
+        techBase: 'INNER_SPHERE',
+        rulesLevel: 'ADVANCED',
+        weight: 1,
+        criticalSlots: 3,
+        costCBills: 6000,
+        battleValue: 0,
+        introductionYear: 3040,
+        special: ['Dissipates 2 heat per sink'],
+        variableEquipmentId: 'dhs-variable',
+        flags: ['DOUBLE_HEAT_SINK'],
+        allowedUnitTypes: ['BattleMech'],
+        allowedLocations: ['RT', 'LT', 'RA', 'LA', 'RL', 'LL'],
+      }]);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // energy
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // ballistic
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // missile
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // ammo
+        .mockResolvedValueOnce({ ok: false, status: 404 }) // electronics
+        .mockResolvedValueOnce({ ok: true, json: async () => miscFile });
+
+      await service.loadOfficialEquipment();
+
+      const misc = service.getMiscEquipmentById('dhs-var');
+      expect(misc).not.toBeNull();
+      expect(misc?.special).toEqual(['Dissipates 2 heat per sink']);
+      expect(misc?.variableEquipmentId).toBe('dhs-variable');
+      expect(misc?.flags).toContain(EquipmentBehaviorFlag.DOUBLE_HEAT_SINK);
+      expect(misc?.allowedUnitTypes).toContain(UnitType.BATTLEMECH);
+      expect(misc?.allowedLocations).toEqual(['RT', 'LT', 'RA', 'LA', 'RL', 'LL']);
+    });
+
+    it('should parse various unit type shorthands', async () => {
+      const weaponFile = buildEquipmentFile([
+        { id: 'w1', name: 'Weapon 1', category: 'Energy', subType: 'Laser', techBase: 'IS', rulesLevel: 'STANDARD', damage: 5, heat: 3, ranges: { minimum: 0, short: 3, medium: 6, long: 9 }, weight: 1, criticalSlots: 1, costCBills: 40000, battleValue: 46, introductionYear: 2470, allowedUnitTypes: ['Mech', 'Tank', 'Fighter'] },
+        { id: 'w2', name: 'Weapon 2', category: 'Energy', subType: 'Laser', techBase: 'IS', rulesLevel: 'STANDARD', damage: 5, heat: 3, ranges: { minimum: 0, short: 3, medium: 6, long: 9 }, weight: 1, criticalSlots: 1, costCBills: 40000, battleValue: 46, introductionYear: 2470, allowedUnitTypes: ['BA', 'Proto', 'INF'] },
+        { id: 'w3', name: 'Weapon 3', category: 'Energy', subType: 'Laser', techBase: 'IS', rulesLevel: 'STANDARD', damage: 5, heat: 3, ranges: { minimum: 0, short: 3, medium: 6, long: 9 }, weight: 1, criticalSlots: 1, costCBills: 40000, battleValue: 46, introductionYear: 2470, allowedUnitTypes: ['SC', 'DS', 'JS', 'WS', 'SS'] },
+        { id: 'w4', name: 'Weapon 4', category: 'Energy', subType: 'Laser', techBase: 'IS', rulesLevel: 'STANDARD', damage: 5, heat: 3, ranges: { minimum: 0, short: 3, medium: 6, long: 9 }, weight: 1, criticalSlots: 1, costCBills: 40000, battleValue: 46, introductionYear: 2470, allowedUnitTypes: ['Support', 'ASF', 'VTOL'] },
+      ]);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, json: async () => weaponFile })
+        .mockResolvedValue({ ok: false, status: 404 });
+
+      await service.loadOfficialEquipment();
+
+      const w1 = service.getWeaponById('w1');
+      expect(w1?.allowedUnitTypes).toContain(UnitType.BATTLEMECH);
+      expect(w1?.allowedUnitTypes).toContain(UnitType.VEHICLE);
+      expect(w1?.allowedUnitTypes).toContain(UnitType.AEROSPACE);
+
+      const w2 = service.getWeaponById('w2');
+      expect(w2?.allowedUnitTypes).toContain(UnitType.BATTLE_ARMOR);
+      expect(w2?.allowedUnitTypes).toContain(UnitType.PROTOMECH);
+      expect(w2?.allowedUnitTypes).toContain(UnitType.INFANTRY);
+
+      const w3 = service.getWeaponById('w3');
+      expect(w3?.allowedUnitTypes).toContain(UnitType.SMALL_CRAFT);
+      expect(w3?.allowedUnitTypes).toContain(UnitType.DROPSHIP);
+      expect(w3?.allowedUnitTypes).toContain(UnitType.JUMPSHIP);
+      expect(w3?.allowedUnitTypes).toContain(UnitType.WARSHIP);
+      expect(w3?.allowedUnitTypes).toContain(UnitType.SPACE_STATION);
+
+      const w4 = service.getWeaponById('w4');
+      expect(w4?.allowedUnitTypes).toContain(UnitType.SUPPORT_VEHICLE);
+      expect(w4?.allowedUnitTypes).toContain(UnitType.AEROSPACE);
+      expect(w4?.allowedUnitTypes).toContain(UnitType.VTOL);
+    });
+
+    it('should handle equipment with unknown flags gracefully', async () => {
+      const weaponFile = buildEquipmentFile([{
+        id: 'w-unknown-flags',
+        name: 'Weapon with Unknown Flags',
+        category: 'Energy',
+        subType: 'Laser',
+        techBase: 'INNER_SPHERE',
+        rulesLevel: 'STANDARD',
+        damage: 5,
+        heat: 3,
+        ranges: { minimum: 0, short: 3, medium: 6, long: 9 },
+        weight: 1,
+        criticalSlots: 1,
+        costCBills: 40000,
+        battleValue: 46,
+        introductionYear: 2470,
+        flags: ['UNKNOWN_FLAG', 'DIRECT_FIRE', 'ANOTHER_UNKNOWN'],
+      }]);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, json: async () => weaponFile })
+        .mockResolvedValue({ ok: false, status: 404 });
+
+      await service.loadOfficialEquipment();
+
+      const weapon = service.getWeaponById('w-unknown-flags');
+      expect(weapon).not.toBeNull();
+      // Only valid flags should be present
+      expect(weapon?.flags).toContain(EquipmentBehaviorFlag.DIRECT_FIRE);
+      expect(weapon?.flags?.length).toBe(1);
+    });
+
+    it('should handle equipment with unknown unit types gracefully', async () => {
+      const weaponFile = buildEquipmentFile([{
+        id: 'w-unknown-units',
+        name: 'Weapon with Unknown Unit Types',
+        category: 'Energy',
+        subType: 'Laser',
+        techBase: 'INNER_SPHERE',
+        rulesLevel: 'STANDARD',
+        damage: 5,
+        heat: 3,
+        ranges: { minimum: 0, short: 3, medium: 6, long: 9 },
+        weight: 1,
+        criticalSlots: 1,
+        costCBills: 40000,
+        battleValue: 46,
+        introductionYear: 2470,
+        allowedUnitTypes: ['UnknownUnit', 'BattleMech', 'AnotherUnknown'],
+      }]);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, json: async () => weaponFile })
+        .mockResolvedValue({ ok: false, status: 404 });
+
+      await service.loadOfficialEquipment();
+
+      const weapon = service.getWeaponById('w-unknown-units');
+      expect(weapon).not.toBeNull();
+      // Only valid unit types should be present
+      expect(weapon?.allowedUnitTypes).toContain(UnitType.BATTLEMECH);
+      expect(weapon?.allowedUnitTypes?.length).toBe(1);
+    });
+  });
+
+  describe('loadCustomEquipment() - File source', () => {
+    it('should load from actual File object', async () => {
+      const weaponData = {
+        $schema: 'schemas/weapon.json',
+        version: '1.0',
+        generatedAt: '2025-01-01',
+        count: 1,
+        items: [{
+          id: 'file-laser',
+          name: 'File Loaded Laser',
+          category: 'Energy',
+          subType: 'Laser',
+          techBase: 'INNER_SPHERE',
+          rulesLevel: 'STANDARD',
+          damage: 5,
+          heat: 3,
+          ranges: { minimum: 0, short: 3, medium: 6, long: 9 },
+          weight: 1,
+          criticalSlots: 1,
+          costCBills: 40000,
+          battleValue: 46,
+          introductionYear: 2470,
+        }],
+      };
+
+      // Create an actual File object using Blob
+      const blob = new Blob([JSON.stringify(weaponData)], { type: 'application/json' });
+      const file = new File([blob], 'weapons.json', { type: 'application/json' });
+
+      const result = await service.loadCustomEquipment(file);
+
+      // File.text() returns empty string in JSDOM, so this test verifies the code path runs
+      // but won't load items successfully in the test environment
+      // The actual File API works in browsers
+      expect(result).toBeDefined();
+      expect(typeof result.success).toBe('boolean');
+      expect(typeof result.itemsLoaded).toBe('number');
+    });
+
+    it('should handle malformed JSON in File', async () => {
+      // Create a File with invalid JSON
+      const blob = new Blob(['{ invalid json }'], { type: 'application/json' });
+      const file = new File([blob], 'bad.json', { type: 'application/json' });
+
+      const result = await service.loadCustomEquipment(file);
+
+      // In JSDOM, File.text() may return empty string, which results in parse error
+      // Either way, the result will indicate failure for malformed JSON
+      expect(result.success).toBe(false);
+      expect(result.errors[0]).toContain('Failed to load custom equipment');
+    });
+  });
+
+  describe('searchWeapons() - filter by ID in search text', () => {
+    beforeEach(() => {
+      const maps = getServiceMaps(service);
+      maps.weapons.set('ml-123', {
+        id: 'ml-123',
+        name: 'Medium Laser',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.STANDARD,
+        introductionYear: 2470,
+      });
+    });
+
+    it('should match by ID in search text', () => {
+      const results = service.searchWeapons({ searchText: 'ml-123' });
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe('ml-123');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty flags array', async () => {
+      const weaponFile = {
+        $schema: 'schemas/weapon.json',
+        version: '1.0',
+        generatedAt: '2025-01-01',
+        count: 1,
+        items: [{
+          id: 'no-flags',
+          name: 'No Flags Weapon',
+          category: 'Energy',
+          subType: 'Laser',
+          techBase: 'INNER_SPHERE',
+          rulesLevel: 'STANDARD',
+          damage: 5,
+          heat: 3,
+          ranges: { minimum: 0, short: 3, medium: 6, long: 9 },
+          weight: 1,
+          criticalSlots: 1,
+          costCBills: 40000,
+          battleValue: 46,
+          introductionYear: 2470,
+          flags: [],
+        }],
+      };
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, json: async () => weaponFile })
+        .mockResolvedValue({ ok: false, status: 404 });
+
+      await service.loadOfficialEquipment();
+
+      const weapon = service.getWeaponById('no-flags');
+      expect(weapon).not.toBeNull();
+      // Empty flags array should result in no flags property (spread operator behavior)
+      expect(weapon?.flags).toBeUndefined();
+    });
+
+    it('should handle empty allowedUnitTypes array', async () => {
+      const weaponFile = {
+        $schema: 'schemas/weapon.json',
+        version: '1.0',
+        generatedAt: '2025-01-01',
+        count: 1,
+        items: [{
+          id: 'no-unit-types',
+          name: 'No Unit Types Weapon',
+          category: 'Energy',
+          subType: 'Laser',
+          techBase: 'INNER_SPHERE',
+          rulesLevel: 'STANDARD',
+          damage: 5,
+          heat: 3,
+          ranges: { minimum: 0, short: 3, medium: 6, long: 9 },
+          weight: 1,
+          criticalSlots: 1,
+          costCBills: 40000,
+          battleValue: 46,
+          introductionYear: 2470,
+          allowedUnitTypes: [],
+        }],
+      };
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, json: async () => weaponFile })
+        .mockResolvedValue({ ok: false, status: 404 });
+
+      await service.loadOfficialEquipment();
+
+      const weapon = service.getWeaponById('no-unit-types');
+      expect(weapon).not.toBeNull();
+      // Empty array should result in no allowedUnitTypes property
+      expect(weapon?.allowedUnitTypes).toBeUndefined();
+    });
+
+    it('should handle undefined flags in search filters', () => {
+      const maps = getServiceMaps(service);
+      maps.weapons.set('w1', {
+        id: 'w1',
+        name: 'Weapon 1',
+        techBase: TechBase.INNER_SPHERE,
+        rulesLevel: RulesLevel.STANDARD,
+        introductionYear: 2470,
+      });
+
+      // hasFlags with empty array should return all
+      const results1 = service.searchWeapons({ hasFlags: [] });
+      expect(results1.length).toBe(1);
+
+      // excludeFlags with empty array should return all
+      const results2 = service.searchWeapons({ excludeFlags: [] });
+      expect(results2.length).toBe(1);
     });
   });
 });

--- a/src/services/construction/__tests__/CalculationService.test.ts
+++ b/src/services/construction/__tests__/CalculationService.test.ts
@@ -1,0 +1,982 @@
+/**
+ * CalculationService Tests
+ *
+ * Tests for mech calculation service covering totals, battle value, cost,
+ * heat profiles, and movement calculations.
+ *
+ * @spec openspec/specs/construction-services/spec.md
+ */
+
+import { TechBase } from '@/types/enums/TechBase';
+import { EngineType } from '@/types/construction/EngineType';
+import { GyroType } from '@/types/construction/GyroType';
+import { InternalStructureType } from '@/types/construction/InternalStructureType';
+import { CockpitType } from '@/types/construction/CockpitType';
+import { ArmorTypeEnum } from '@/types/construction/ArmorType';
+import { HeatSinkType } from '@/types/construction/HeatSinkType';
+import { IEditableMech, IArmorAllocation, IEquipmentSlot } from '../MechBuilderService';
+import {
+  CalculationService,
+  getCalculationService,
+  _resetCalculationService,
+  IMechTotals,
+  IHeatProfile,
+  IMovementProfile,
+} from '../CalculationService';
+
+// =============================================================================
+// Mock Equipment Registry
+// =============================================================================
+
+const mockEquipment: Map<string, { battleValue?: number; heat?: number; cost?: number; category?: string }> = new Map([
+  ['medium-laser', { battleValue: 46, heat: 3, cost: 40000, category: 'Energy' }],
+  ['large-laser', { battleValue: 123, heat: 8, cost: 100000, category: 'Energy' }],
+  ['ppc', { battleValue: 176, heat: 10, cost: 200000, category: 'Energy' }],
+  ['lrm-10', { battleValue: 90, heat: 4, cost: 100000, category: 'Missile' }],
+  ['ac-10', { battleValue: 124, heat: 3, cost: 200000, category: 'Ballistic' }],
+  ['jump-jet', { battleValue: 0, heat: 0, cost: 50000, category: 'Movement' }],
+  ['jump-jet-light', { battleValue: 0, heat: 0, cost: 25000, category: 'Movement' }],
+  ['improved-jump-jet', { battleValue: 0, heat: 0, cost: 75000, category: 'Movement' }],
+  ['ammo-lrm-10', { battleValue: 11, heat: 0, cost: 30000, category: 'Ammunition' }],
+  ['ammo-ac-10', { battleValue: 8, heat: 0, cost: 12000, category: 'Ammunition' }],
+  ['heat-sink', { battleValue: 0, heat: 0, cost: 2000, category: 'Heat Sink' }],
+]);
+
+let mockRegistryReady = true;
+
+jest.mock('@/services/equipment/EquipmentRegistry', () => ({
+  getEquipmentRegistry: () => ({
+    isReady: () => mockRegistryReady,
+    initialize: jest.fn().mockResolvedValue(undefined),
+    lookup: (id: string) => {
+      const equipment = mockEquipment.get(id.toLowerCase());
+      if (equipment) {
+        return { found: true, equipment, category: equipment.category };
+      }
+      return { found: false, equipment: null, category: null };
+    },
+  }),
+}));
+
+// =============================================================================
+// Test Fixtures
+// =============================================================================
+
+/**
+ * Create a standard armor allocation for testing
+ */
+function createArmorAllocation(overrides: Partial<IArmorAllocation> = {}): IArmorAllocation {
+  return {
+    head: 9,
+    centerTorso: 30,
+    centerTorsoRear: 10,
+    leftTorso: 20,
+    leftTorsoRear: 8,
+    rightTorso: 20,
+    rightTorsoRear: 8,
+    leftArm: 16,
+    rightArm: 16,
+    leftLeg: 20,
+    rightLeg: 20,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a basic editable mech for testing
+ */
+function createTestMech(overrides: Partial<IEditableMech> = {}): IEditableMech {
+  return {
+    id: 'test-mech-001',
+    chassis: 'Atlas',
+    variant: 'AS7-D',
+    tonnage: 100,
+    techBase: TechBase.INNER_SPHERE,
+    engineType: EngineType.STANDARD,
+    engineRating: 300,
+    walkMP: 3,
+    structureType: InternalStructureType.STANDARD,
+    gyroType: GyroType.STANDARD,
+    cockpitType: CockpitType.STANDARD,
+    armorType: ArmorTypeEnum.STANDARD,
+    armorAllocation: createArmorAllocation(),
+    heatSinkType: HeatSinkType.SINGLE,
+    heatSinkCount: 10,
+    equipment: [],
+    isDirty: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Create equipment slots for testing
+ */
+function createEquipmentSlot(equipmentId: string, location: string = 'rightArm', slotIndex: number = 0): IEquipmentSlot {
+  return { equipmentId, location, slotIndex };
+}
+
+// =============================================================================
+// Test Suite
+// =============================================================================
+
+describe('CalculationService', () => {
+  let service: CalculationService;
+
+  beforeEach(() => {
+    _resetCalculationService();
+    service = getCalculationService();
+    mockRegistryReady = true;
+  });
+
+  afterEach(() => {
+    _resetCalculationService();
+  });
+
+  // ===========================================================================
+  // Singleton Pattern Tests
+  // ===========================================================================
+
+  describe('singleton pattern', () => {
+    it('should return the same instance on multiple calls', () => {
+      const instance1 = getCalculationService();
+      const instance2 = getCalculationService();
+      expect(instance1).toBe(instance2);
+    });
+
+    it('should create a new instance after reset', () => {
+      const instance1 = getCalculationService();
+      _resetCalculationService();
+      const instance2 = getCalculationService();
+      expect(instance1).not.toBe(instance2);
+    });
+  });
+
+  // ===========================================================================
+  // calculateTotals Tests
+  // ===========================================================================
+
+  describe('calculateTotals', () => {
+    it('should calculate totals for a basic 100-ton mech', () => {
+      const mech = createTestMech();
+      const totals = service.calculateTotals(mech);
+
+      expect(totals.maxWeight).toBe(100);
+      expect(totals.totalCriticalSlots).toBe(78);
+      expect(totals.usedCriticalSlots).toBe(0);
+      expect(totals.totalArmorPoints).toBe(177);
+    });
+
+    it('should calculate remaining weight correctly', () => {
+      const mech = createTestMech({ tonnage: 50 });
+      const totals = service.calculateTotals(mech);
+
+      expect(totals.maxWeight).toBe(50);
+      expect(totals.remainingWeight).toBe(50 - totals.totalWeight);
+    });
+
+    it('should count equipment as used critical slots', () => {
+      const mech = createTestMech({
+        equipment: [
+          createEquipmentSlot('medium-laser', 'rightArm', 0),
+          createEquipmentSlot('medium-laser', 'rightArm', 1),
+          createEquipmentSlot('large-laser', 'leftArm', 0),
+        ],
+      });
+      const totals = service.calculateTotals(mech);
+
+      expect(totals.usedCriticalSlots).toBe(3);
+    });
+
+    it('should calculate max armor points based on tonnage', () => {
+      const lightMech = createTestMech({ tonnage: 20 });
+      const heavyMech = createTestMech({ tonnage: 75 });
+      const assaultMech = createTestMech({ tonnage: 100 });
+
+      const lightTotals = service.calculateTotals(lightMech);
+      const heavyTotals = service.calculateTotals(heavyMech);
+      const assaultTotals = service.calculateTotals(assaultMech);
+
+      // Max armor increases with tonnage
+      expect(assaultTotals.maxArmorPoints).toBeGreaterThan(heavyTotals.maxArmorPoints);
+      expect(heavyTotals.maxArmorPoints).toBeGreaterThan(lightTotals.maxArmorPoints);
+    });
+
+    it('should calculate total armor points from all locations', () => {
+      const armor = createArmorAllocation({
+        head: 9,
+        centerTorso: 20,
+        centerTorsoRear: 5,
+        leftTorso: 10,
+        leftTorsoRear: 3,
+        rightTorso: 10,
+        rightTorsoRear: 3,
+        leftArm: 8,
+        rightArm: 8,
+        leftLeg: 10,
+        rightLeg: 10,
+      });
+      const mech = createTestMech({ armorAllocation: armor });
+      const totals = service.calculateTotals(mech);
+
+      // Total: 9 + 20 + 5 + 10 + 3 + 10 + 3 + 8 + 8 + 10 + 10 = 96
+      expect(totals.totalArmorPoints).toBe(96);
+    });
+
+    it('should handle zero armor allocation', () => {
+      const armor = createArmorAllocation({
+        head: 0,
+        centerTorso: 0,
+        centerTorsoRear: 0,
+        leftTorso: 0,
+        leftTorsoRear: 0,
+        rightTorso: 0,
+        rightTorsoRear: 0,
+        leftArm: 0,
+        rightArm: 0,
+        leftLeg: 0,
+        rightLeg: 0,
+      });
+      const mech = createTestMech({ armorAllocation: armor });
+      const totals = service.calculateTotals(mech);
+
+      expect(totals.totalArmorPoints).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // calculateBattleValue Tests
+  // ===========================================================================
+
+  describe('calculateBattleValue', () => {
+    it('should calculate BV for a basic mech without weapons', () => {
+      const mech = createTestMech();
+      const bv = service.calculateBattleValue(mech);
+
+      // BV should include defensive components and tonnage bonus
+      expect(bv).toBeGreaterThan(0);
+      expect(Number.isInteger(bv)).toBe(true);
+    });
+
+    it('should increase BV with more armor', () => {
+      const lightArmor = createArmorAllocation({
+        head: 5,
+        centerTorso: 15,
+        centerTorsoRear: 5,
+        leftTorso: 10,
+        leftTorsoRear: 4,
+        rightTorso: 10,
+        rightTorsoRear: 4,
+        leftArm: 8,
+        rightArm: 8,
+        leftLeg: 10,
+        rightLeg: 10,
+      });
+      const heavyArmor = createArmorAllocation();
+
+      const lightMech = createTestMech({ armorAllocation: lightArmor });
+      const heavyMech = createTestMech({ armorAllocation: heavyArmor });
+
+      const lightBV = service.calculateBattleValue(lightMech);
+      const heavyBV = service.calculateBattleValue(heavyMech);
+
+      expect(heavyBV).toBeGreaterThan(lightBV);
+    });
+
+    it('should include weapon BV in calculation', () => {
+      const unarmedMech = createTestMech();
+      const armedMech = createTestMech({
+        equipment: [
+          createEquipmentSlot('medium-laser', 'rightArm', 0),
+          createEquipmentSlot('large-laser', 'leftArm', 0),
+        ],
+      });
+
+      const unarmedBV = service.calculateBattleValue(unarmedMech);
+      const armedBV = service.calculateBattleValue(armedMech);
+
+      expect(armedBV).toBeGreaterThan(unarmedBV);
+    });
+
+    it('should apply heat penalty to weapons exceeding heat dissipation', () => {
+      // Mech with single heat sinks (10 dissipation)
+      const mech = createTestMech({
+        heatSinkCount: 10,
+        heatSinkType: HeatSinkType.SINGLE,
+        equipment: [
+          createEquipmentSlot('ppc', 'rightArm', 0), // 10 heat
+          createEquipmentSlot('ppc', 'leftArm', 0),  // 10 heat - should get penalty
+        ],
+      });
+
+      const bv = service.calculateBattleValue(mech);
+      
+      // BV should still be positive and include weapons
+      expect(bv).toBeGreaterThan(0);
+    });
+
+    it('should return 0 when registry is not ready', () => {
+      mockRegistryReady = false;
+      const mech = createTestMech({
+        equipment: [createEquipmentSlot('medium-laser', 'rightArm', 0)],
+      });
+      const bv = service.calculateBattleValue(mech);
+
+      // Defensive BV still calculated, but offensive weapons BV is 0
+      expect(bv).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should increase BV with higher movement', () => {
+      const slowMech = createTestMech({ walkMP: 2 });
+      const fastMech = createTestMech({ walkMP: 6 });
+
+      const slowBV = service.calculateBattleValue(slowMech);
+      const fastBV = service.calculateBattleValue(fastMech);
+
+      expect(fastBV).toBeGreaterThan(slowBV);
+    });
+
+    it('should include ammo BV without heat penalty', () => {
+      const mechWithAmmo = createTestMech({
+        equipment: [
+          createEquipmentSlot('ammo-lrm-10', 'leftTorso', 0),
+          createEquipmentSlot('ammo-ac-10', 'rightTorso', 0),
+        ],
+      });
+
+      const bv = service.calculateBattleValue(mechWithAmmo);
+      expect(bv).toBeGreaterThan(0);
+    });
+
+    it('should handle double heat sinks for heat dissipation', () => {
+      const singleHSMech = createTestMech({
+        heatSinkType: HeatSinkType.SINGLE,
+        heatSinkCount: 10,
+        equipment: [
+          createEquipmentSlot('ppc', 'rightArm', 0),
+          createEquipmentSlot('ppc', 'leftArm', 0),
+        ],
+      });
+      const doubleHSMech = createTestMech({
+        heatSinkType: HeatSinkType.DOUBLE_IS,
+        heatSinkCount: 10,
+        equipment: [
+          createEquipmentSlot('ppc', 'rightArm', 0),
+          createEquipmentSlot('ppc', 'leftArm', 0),
+        ],
+      });
+
+      const singleBV = service.calculateBattleValue(singleHSMech);
+      const doubleBV = service.calculateBattleValue(doubleHSMech);
+
+      // Double HS can dissipate more heat, so less penalty
+      expect(doubleBV).toBeGreaterThan(singleBV);
+    });
+  });
+
+  // ===========================================================================
+  // calculateCost Tests
+  // ===========================================================================
+
+  describe('calculateCost', () => {
+    it('should calculate cost for a basic mech', () => {
+      const mech = createTestMech();
+      const cost = service.calculateCost(mech);
+
+      expect(cost).toBeGreaterThan(0);
+      expect(Number.isInteger(cost)).toBe(true);
+    });
+
+    it('should increase cost with XL engine', () => {
+      const standardMech = createTestMech({ engineType: EngineType.STANDARD });
+      const xlMech = createTestMech({ engineType: EngineType.XL_IS });
+
+      const standardCost = service.calculateCost(standardMech);
+      const xlCost = service.calculateCost(xlMech);
+
+      expect(xlCost).toBeGreaterThan(standardCost);
+    });
+
+    it('should increase cost with endo steel structure', () => {
+      const standardMech = createTestMech({ structureType: InternalStructureType.STANDARD });
+      const endoMech = createTestMech({ structureType: InternalStructureType.ENDO_STEEL_IS });
+
+      const standardCost = service.calculateCost(standardMech);
+      const endoCost = service.calculateCost(endoMech);
+
+      expect(endoCost).toBeGreaterThan(standardCost);
+    });
+
+    it('should increase cost with XL gyro', () => {
+      const standardMech = createTestMech({ gyroType: GyroType.STANDARD });
+      const xlGyroMech = createTestMech({ gyroType: GyroType.XL });
+
+      const standardCost = service.calculateCost(standardMech);
+      const xlGyroCost = service.calculateCost(xlGyroMech);
+
+      expect(xlGyroCost).toBeGreaterThan(standardCost);
+    });
+
+    it('should apply compact gyro cost multiplier', () => {
+      const standardMech = createTestMech({ gyroType: GyroType.STANDARD });
+      const compactGyroMech = createTestMech({ gyroType: GyroType.COMPACT });
+
+      const standardCost = service.calculateCost(standardMech);
+      const compactCost = service.calculateCost(compactGyroMech);
+
+      // Compact gyro has 4x cost multiplier
+      expect(compactCost).toBeGreaterThan(standardCost);
+    });
+
+    it('should reduce cost with heavy-duty gyro (0.5 multiplier)', () => {
+      const standardMech = createTestMech({ gyroType: GyroType.STANDARD });
+      const heavyDutyMech = createTestMech({ gyroType: GyroType.HEAVY_DUTY });
+
+      const standardCost = service.calculateCost(standardMech);
+      const heavyDutyCost = service.calculateCost(heavyDutyMech);
+
+      // Heavy-duty has 0.5x cost multiplier on gyro
+      expect(heavyDutyCost).toBeLessThan(standardCost);
+    });
+
+    it('should increase cost with small cockpit', () => {
+      const standardMech = createTestMech({ cockpitType: CockpitType.STANDARD });
+      const smallMech = createTestMech({ cockpitType: CockpitType.SMALL });
+
+      const standardCost = service.calculateCost(standardMech);
+      const smallCost = service.calculateCost(smallMech);
+
+      // Small cockpit is cheaper (175000 vs 200000)
+      expect(smallCost).toBeLessThan(standardCost);
+    });
+
+    it('should increase cost with command console', () => {
+      const standardMech = createTestMech({ cockpitType: CockpitType.STANDARD });
+      const commandMech = createTestMech({ cockpitType: CockpitType.COMMAND_CONSOLE });
+
+      const standardCost = service.calculateCost(standardMech);
+      const commandCost = service.calculateCost(commandMech);
+
+      expect(commandCost).toBeGreaterThan(standardCost);
+    });
+
+    it('should increase cost with ferro-fibrous armor', () => {
+      const standardMech = createTestMech({ armorType: ArmorTypeEnum.STANDARD });
+      const ferroMech = createTestMech({ armorType: ArmorTypeEnum.FERRO_FIBROUS_IS });
+
+      const standardCost = service.calculateCost(standardMech);
+      const ferroCost = service.calculateCost(ferroMech);
+
+      expect(ferroCost).toBeGreaterThan(standardCost);
+    });
+
+    it('should increase cost with stealth armor', () => {
+      const standardMech = createTestMech({ armorType: ArmorTypeEnum.STANDARD });
+      const stealthMech = createTestMech({ armorType: ArmorTypeEnum.STEALTH });
+
+      const standardCost = service.calculateCost(standardMech);
+      const stealthCost = service.calculateCost(stealthMech);
+
+      expect(stealthCost).toBeGreaterThan(standardCost);
+    });
+
+    it('should include equipment costs', () => {
+      const unarmedMech = createTestMech({ equipment: [] });
+      const armedMech = createTestMech({
+        equipment: [
+          createEquipmentSlot('medium-laser', 'rightArm', 0),
+          createEquipmentSlot('ppc', 'leftArm', 0),
+        ],
+      });
+
+      const unarmedCost = service.calculateCost(unarmedMech);
+      const armedCost = service.calculateCost(armedMech);
+
+      expect(armedCost).toBeGreaterThan(unarmedCost);
+    });
+
+    it('should charge more for double heat sinks', () => {
+      const singleHSMech = createTestMech({
+        heatSinkType: HeatSinkType.SINGLE,
+        heatSinkCount: 15,
+        engineRating: 200, // 8 integral, 7 external
+      });
+      const doubleHSMech = createTestMech({
+        heatSinkType: HeatSinkType.DOUBLE_IS,
+        heatSinkCount: 15,
+        engineRating: 200, // 8 integral, 7 external
+      });
+
+      const singleCost = service.calculateCost(singleHSMech);
+      const doubleCost = service.calculateCost(doubleHSMech);
+
+      expect(doubleCost).toBeGreaterThan(singleCost);
+    });
+
+    it('should not charge for integral heat sinks', () => {
+      // Engine rating 250 = 10 integral heat sinks
+      const mech10HS = createTestMech({
+        heatSinkCount: 10,
+        engineRating: 250,
+      });
+      const mech15HS = createTestMech({
+        heatSinkCount: 15,
+        engineRating: 250,
+      });
+
+      const cost10 = service.calculateCost(mech10HS);
+      const cost15 = service.calculateCost(mech15HS);
+
+      // 5 extra external heat sinks should increase cost
+      expect(cost15).toBeGreaterThan(cost10);
+    });
+
+    it('should apply construction multiplier', () => {
+      const mech = createTestMech();
+      const cost = service.calculateCost(mech);
+
+      // Cost should be multiplied by 1.25 construction multiplier
+      // This is implicit - we just verify it's a reasonable value
+      expect(cost).toBeGreaterThan(0);
+    });
+
+    it('should handle legacy string engine types', () => {
+      const mechXL = createTestMech({ engineType: 'XL' as EngineType });
+      const mechStandard = createTestMech({ engineType: 'Standard' as EngineType });
+
+      const xlCost = service.calculateCost(mechXL);
+      const standardCost = service.calculateCost(mechStandard);
+
+      expect(xlCost).toBeGreaterThan(standardCost);
+    });
+
+    it('should handle XXL engine type', () => {
+      const mechStandard = createTestMech({ engineType: EngineType.STANDARD });
+      const mechXXL = createTestMech({ engineType: EngineType.XXL });
+
+      const standardCost = service.calculateCost(mechStandard);
+      const xxlCost = service.calculateCost(mechXXL);
+
+      expect(xxlCost).toBeGreaterThan(standardCost);
+    });
+  });
+
+  // ===========================================================================
+  // calculateHeatProfile Tests
+  // ===========================================================================
+
+  describe('calculateHeatProfile', () => {
+    it('should calculate heat dissipation for single heat sinks', () => {
+      const mech = createTestMech({
+        heatSinkType: HeatSinkType.SINGLE,
+        heatSinkCount: 10,
+      });
+      const profile = service.calculateHeatProfile(mech);
+
+      expect(profile.heatDissipated).toBe(10);
+    });
+
+    it('should calculate heat dissipation for double heat sinks', () => {
+      const mech = createTestMech({
+        heatSinkType: HeatSinkType.DOUBLE_IS,
+        heatSinkCount: 10,
+      });
+      const profile = service.calculateHeatProfile(mech);
+
+      expect(profile.heatDissipated).toBe(20);
+    });
+
+    it('should calculate heat dissipation for clan double heat sinks', () => {
+      const mech = createTestMech({
+        heatSinkType: HeatSinkType.DOUBLE_CLAN,
+        heatSinkCount: 12,
+      });
+      const profile = service.calculateHeatProfile(mech);
+
+      expect(profile.heatDissipated).toBe(24);
+    });
+
+    it('should calculate weapon heat generation', () => {
+      const mech = createTestMech({
+        equipment: [
+          createEquipmentSlot('medium-laser', 'rightArm', 0), // 3 heat
+          createEquipmentSlot('large-laser', 'leftArm', 0),   // 8 heat
+        ],
+      });
+      const profile = service.calculateHeatProfile(mech);
+
+      // 3 + 8 + 2 (running) = 13
+      expect(profile.heatGenerated).toBeGreaterThan(0);
+      expect(profile.alphaStrikeHeat).toBe(11); // Just weapons, no movement
+    });
+
+    it('should include movement heat', () => {
+      const mech = createTestMech({ equipment: [] });
+      const profile = service.calculateHeatProfile(mech);
+
+      // Running heat is 2
+      expect(profile.heatGenerated).toBe(2);
+    });
+
+    it('should include jump heat when higher than running', () => {
+      const mech = createTestMech({
+        equipment: [
+          createEquipmentSlot('jump-jet', 'rightTorso', 0),
+          createEquipmentSlot('jump-jet', 'rightTorso', 1),
+          createEquipmentSlot('jump-jet', 'leftTorso', 0),
+          createEquipmentSlot('jump-jet', 'leftTorso', 1),
+        ],
+      });
+      const profile = service.calculateHeatProfile(mech);
+
+      // 4 jump jets = 4 jump heat, higher than 2 running heat
+      expect(profile.heatGenerated).toBeGreaterThanOrEqual(4);
+    });
+
+    it('should calculate net heat correctly', () => {
+      const mech = createTestMech({
+        heatSinkType: HeatSinkType.SINGLE,
+        heatSinkCount: 10,
+        equipment: [
+          createEquipmentSlot('ppc', 'rightArm', 0), // 10 heat
+        ],
+      });
+      const profile = service.calculateHeatProfile(mech);
+
+      expect(profile.netHeat).toBe(profile.heatGenerated - profile.heatDissipated);
+    });
+
+    it('should return zeroed heat when registry not ready', () => {
+      mockRegistryReady = false;
+      const mech = createTestMech({
+        heatSinkCount: 10,
+        equipment: [createEquipmentSlot('medium-laser', 'rightArm', 0)],
+      });
+      const profile = service.calculateHeatProfile(mech);
+
+      expect(profile.heatGenerated).toBe(0);
+      expect(profile.alphaStrikeHeat).toBe(0);
+      expect(profile.heatDissipated).toBe(10);
+    });
+
+    it('should handle improved jump jets', () => {
+      const mech = createTestMech({
+        equipment: [
+          createEquipmentSlot('improved-jump-jet', 'rightTorso', 0),
+          createEquipmentSlot('improved-jump-jet', 'leftTorso', 0),
+        ],
+      });
+      const profile = service.calculateHeatProfile(mech);
+
+      // Improved jump jets still count for jump MP
+      expect(profile.heatGenerated).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should handle legacy double heat sink string', () => {
+      const mech = createTestMech({
+        heatSinkType: 'double' as HeatSinkType,
+        heatSinkCount: 10,
+      });
+      const profile = service.calculateHeatProfile(mech);
+
+      expect(profile.heatDissipated).toBe(20);
+    });
+  });
+
+  // ===========================================================================
+  // calculateMovement Tests
+  // ===========================================================================
+
+  describe('calculateMovement', () => {
+    it('should return walkMP from mech', () => {
+      const mech = createTestMech({ walkMP: 4 });
+      const movement = service.calculateMovement(mech);
+
+      expect(movement.walkMP).toBe(4);
+    });
+
+    it('should calculate runMP as floor(walkMP * 1.5)', () => {
+      const mech4 = createTestMech({ walkMP: 4 });
+      const mech5 = createTestMech({ walkMP: 5 });
+      const mech7 = createTestMech({ walkMP: 7 });
+
+      expect(service.calculateMovement(mech4).runMP).toBe(6);  // 4 * 1.5 = 6
+      expect(service.calculateMovement(mech5).runMP).toBe(7);  // 5 * 1.5 = 7.5 -> 7
+      expect(service.calculateMovement(mech7).runMP).toBe(10); // 7 * 1.5 = 10.5 -> 10
+    });
+
+    it('should calculate jumpMP from jump jet count', () => {
+      const mech = createTestMech({
+        equipment: [
+          createEquipmentSlot('jump-jet', 'rightTorso', 0),
+          createEquipmentSlot('jump-jet', 'rightTorso', 1),
+          createEquipmentSlot('jump-jet', 'leftTorso', 0),
+        ],
+      });
+      const movement = service.calculateMovement(mech);
+
+      expect(movement.jumpMP).toBe(3);
+    });
+
+    it('should count all jump jet variants', () => {
+      const mech = createTestMech({
+        equipment: [
+          createEquipmentSlot('jump-jet', 'rightTorso', 0),
+          createEquipmentSlot('jump-jet-light', 'rightTorso', 1),
+          createEquipmentSlot('improved-jump-jet', 'leftTorso', 0),
+        ],
+      });
+      const movement = service.calculateMovement(mech);
+
+      expect(movement.jumpMP).toBe(3);
+    });
+
+    it('should return 0 jumpMP without jump jets', () => {
+      const mech = createTestMech({
+        equipment: [
+          createEquipmentSlot('medium-laser', 'rightArm', 0),
+        ],
+      });
+      const movement = service.calculateMovement(mech);
+
+      expect(movement.jumpMP).toBe(0);
+    });
+
+    it('should handle empty equipment', () => {
+      const mech = createTestMech({ equipment: [] });
+      const movement = service.calculateMovement(mech);
+
+      expect(movement.jumpMP).toBe(0);
+    });
+
+    it('should handle walkMP of 0', () => {
+      const mech = createTestMech({ walkMP: 0 });
+      const movement = service.calculateMovement(mech);
+
+      expect(movement.walkMP).toBe(0);
+      expect(movement.runMP).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // Edge Cases and Type Handling
+  // ===========================================================================
+
+  describe('edge cases', () => {
+    it('should handle minimum tonnage (20)', () => {
+      const mech = createTestMech({ tonnage: 20 });
+      const totals = service.calculateTotals(mech);
+      const bv = service.calculateBattleValue(mech);
+      const cost = service.calculateCost(mech);
+
+      expect(totals.maxWeight).toBe(20);
+      expect(bv).toBeGreaterThan(0);
+      expect(cost).toBeGreaterThan(0);
+    });
+
+    it('should handle maximum tonnage (100)', () => {
+      const mech = createTestMech({ tonnage: 100 });
+      const totals = service.calculateTotals(mech);
+      const bv = service.calculateBattleValue(mech);
+      const cost = service.calculateCost(mech);
+
+      expect(totals.maxWeight).toBe(100);
+      expect(bv).toBeGreaterThan(0);
+      expect(cost).toBeGreaterThan(0);
+    });
+
+    it('should handle unknown equipment gracefully', () => {
+      const mech = createTestMech({
+        equipment: [
+          createEquipmentSlot('unknown-weapon-xyz', 'rightArm', 0),
+        ],
+      });
+
+      // Should not throw
+      expect(() => service.calculateBattleValue(mech)).not.toThrow();
+      expect(() => service.calculateCost(mech)).not.toThrow();
+      expect(() => service.calculateHeatProfile(mech)).not.toThrow();
+    });
+
+    it('should handle Clan XL engine type', () => {
+      const mech = createTestMech({ engineType: EngineType.XL_CLAN });
+      const cost = service.calculateCost(mech);
+
+      expect(cost).toBeGreaterThan(0);
+    });
+
+    it('should handle Light engine type', () => {
+      const mech = createTestMech({ engineType: EngineType.LIGHT });
+      const cost = service.calculateCost(mech);
+
+      expect(cost).toBeGreaterThan(0);
+    });
+
+    it('should handle Compact engine type', () => {
+      const mech = createTestMech({ engineType: EngineType.COMPACT });
+      const cost = service.calculateCost(mech);
+
+      expect(cost).toBeGreaterThan(0);
+    });
+
+    it('should handle Clan Endo Steel structure', () => {
+      const mech = createTestMech({ structureType: InternalStructureType.ENDO_STEEL_CLAN });
+      const cost = service.calculateCost(mech);
+
+      expect(cost).toBeGreaterThan(0);
+    });
+
+    it('should handle Endo-Composite structure', () => {
+      const mech = createTestMech({ structureType: InternalStructureType.ENDO_COMPOSITE });
+      const cost = service.calculateCost(mech);
+
+      expect(cost).toBeGreaterThan(0);
+    });
+
+    it('should handle Reactive armor', () => {
+      const mech = createTestMech({ armorType: ArmorTypeEnum.REACTIVE });
+      const cost = service.calculateCost(mech);
+
+      expect(cost).toBeGreaterThan(0);
+    });
+
+    it('should handle Reflective armor', () => {
+      const mech = createTestMech({ armorType: ArmorTypeEnum.REFLECTIVE });
+      const cost = service.calculateCost(mech);
+
+      expect(cost).toBeGreaterThan(0);
+    });
+
+    it('should handle Clan Ferro-Fibrous armor', () => {
+      const mech = createTestMech({ armorType: ArmorTypeEnum.FERRO_FIBROUS_CLAN });
+      const cost = service.calculateCost(mech);
+
+      expect(cost).toBeGreaterThan(0);
+    });
+
+    it('should handle Light Ferro-Fibrous armor', () => {
+      const mech = createTestMech({ armorType: ArmorTypeEnum.LIGHT_FERRO });
+      const cost = service.calculateCost(mech);
+
+      expect(cost).toBeGreaterThan(0);
+    });
+
+    it('should handle Heavy Ferro-Fibrous armor', () => {
+      const mech = createTestMech({ armorType: ArmorTypeEnum.HEAVY_FERRO });
+      const cost = service.calculateCost(mech);
+
+      expect(cost).toBeGreaterThan(0);
+    });
+
+    it('should handle legacy string types for all components', () => {
+      const mech = createTestMech({
+        engineType: 'xxl' as EngineType,
+        gyroType: 'heavy duty' as GyroType,
+        structureType: 'endo steel' as InternalStructureType,
+        armorType: 'ferro fibrous' as ArmorTypeEnum,
+        cockpitType: 'command console' as CockpitType,
+      });
+
+      // Should not throw and produce valid results
+      expect(() => service.calculateCost(mech)).not.toThrow();
+      const cost = service.calculateCost(mech);
+      expect(cost).toBeGreaterThan(0);
+    });
+
+    it('should handle high heat sink counts', () => {
+      const mech = createTestMech({
+        heatSinkCount: 30,
+        heatSinkType: HeatSinkType.DOUBLE_IS,
+      });
+      const profile = service.calculateHeatProfile(mech);
+
+      expect(profile.heatDissipated).toBe(60);
+    });
+
+    it('should handle very low engine rating', () => {
+      const mech = createTestMech({
+        engineRating: 60,
+        walkMP: 1,
+      });
+
+      expect(() => service.calculateCost(mech)).not.toThrow();
+      expect(() => service.calculateTotals(mech)).not.toThrow();
+    });
+
+    it('should handle high engine rating', () => {
+      const mech = createTestMech({
+        engineRating: 400,
+        walkMP: 8,
+      });
+
+      expect(() => service.calculateCost(mech)).not.toThrow();
+      expect(() => service.calculateTotals(mech)).not.toThrow();
+    });
+
+    it('should not count non-jump-jet equipment as jump jets', () => {
+      const mech = createTestMech({
+        equipment: [
+          createEquipmentSlot('medium-laser', 'rightArm', 0),
+          createEquipmentSlot('ammo-lrm-10', 'leftTorso', 0),
+          createEquipmentSlot('heat-sink', 'centerTorso', 0),
+        ],
+      });
+      const movement = service.calculateMovement(mech);
+
+      expect(movement.jumpMP).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // Interface Compliance Tests
+  // ===========================================================================
+
+  describe('interface compliance', () => {
+    it('calculateTotals should return IMechTotals', () => {
+      const mech = createTestMech();
+      const totals: IMechTotals = service.calculateTotals(mech);
+
+      expect(typeof totals.totalWeight).toBe('number');
+      expect(typeof totals.remainingWeight).toBe('number');
+      expect(typeof totals.maxWeight).toBe('number');
+      expect(typeof totals.totalArmorPoints).toBe('number');
+      expect(typeof totals.maxArmorPoints).toBe('number');
+      expect(typeof totals.usedCriticalSlots).toBe('number');
+      expect(typeof totals.totalCriticalSlots).toBe('number');
+    });
+
+    it('calculateHeatProfile should return IHeatProfile', () => {
+      const mech = createTestMech();
+      const profile: IHeatProfile = service.calculateHeatProfile(mech);
+
+      expect(typeof profile.heatGenerated).toBe('number');
+      expect(typeof profile.heatDissipated).toBe('number');
+      expect(typeof profile.netHeat).toBe('number');
+      expect(typeof profile.alphaStrikeHeat).toBe('number');
+    });
+
+    it('calculateMovement should return IMovementProfile', () => {
+      const mech = createTestMech();
+      const movement: IMovementProfile = service.calculateMovement(mech);
+
+      expect(typeof movement.walkMP).toBe('number');
+      expect(typeof movement.runMP).toBe('number');
+      expect(typeof movement.jumpMP).toBe('number');
+    });
+
+    it('calculateBattleValue should return a number', () => {
+      const mech = createTestMech();
+      const bv = service.calculateBattleValue(mech);
+
+      expect(typeof bv).toBe('number');
+      expect(Number.isFinite(bv)).toBe(true);
+    });
+
+    it('calculateCost should return a number', () => {
+      const mech = createTestMech();
+      const cost = service.calculateCost(mech);
+
+      expect(typeof cost).toBe('number');
+      expect(Number.isFinite(cost)).toBe(true);
+    });
+  });
+});

--- a/src/services/validation/rules/__tests__/vehicleCategoryRules.test.ts
+++ b/src/services/validation/rules/__tests__/vehicleCategoryRules.test.ts
@@ -1,0 +1,730 @@
+/**
+ * Vehicle Category Validation Rules Tests
+ *
+ * Tests for vehicle category validation rules including
+ * engine, motive system, turret capacity, VTOL rotor, and tonnage validation.
+ */
+
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+import {
+  IValidatableUnit,
+  IUnitValidationContext,
+  UnitCategory,
+  UnitValidationSeverity,
+} from '@/types/validation/UnitValidationInterfaces';
+import { TechBase, RulesLevel, Era } from '@/types/enums';
+import {
+  VehicleEngineRequired,
+  VehicleMotiveSystemRequired,
+  VehicleTurretCapacity,
+  VTOLRotorRequired,
+  VehicleTonnageRange,
+  VEHICLE_CATEGORY_RULES,
+} from '../vehicle/VehicleCategoryRules';
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+interface IVehicleTestUnit extends IValidatableUnit {
+  engine?: { type: string; rating: number };
+  motiveSystem?: { type: string };
+  rotor?: { type: string };
+  turret?: {
+    capacity: number;
+    usedWeight: number;
+  };
+}
+
+function createVehicleUnit(overrides: Partial<IVehicleTestUnit> = {}): IVehicleTestUnit {
+  return {
+    id: 'test-vehicle-1',
+    name: 'Test Vehicle',
+    unitType: UnitType.VEHICLE,
+    techBase: TechBase.INNER_SPHERE,
+    rulesLevel: RulesLevel.STANDARD,
+    introductionYear: 3025,
+    era: Era.LATE_SUCCESSION_WARS,
+    weight: 50,
+    cost: 1000000,
+    battleValue: 600,
+    engine: { type: 'Fusion', rating: 200 },
+    motiveSystem: { type: 'Tracked' },
+    ...overrides,
+  };
+}
+
+function createVTOLUnit(overrides: Partial<IVehicleTestUnit> = {}): IVehicleTestUnit {
+  return {
+    id: 'test-vtol-1',
+    name: 'Test VTOL',
+    unitType: UnitType.VTOL,
+    techBase: TechBase.INNER_SPHERE,
+    rulesLevel: RulesLevel.STANDARD,
+    introductionYear: 3025,
+    era: Era.LATE_SUCCESSION_WARS,
+    weight: 20,
+    cost: 500000,
+    battleValue: 400,
+    engine: { type: 'Fusion', rating: 100 },
+    motiveSystem: { type: 'VTOL' },
+    rotor: { type: 'Standard' },
+    ...overrides,
+  };
+}
+
+function createSupportVehicleUnit(overrides: Partial<IVehicleTestUnit> = {}): IVehicleTestUnit {
+  return {
+    id: 'test-support-vehicle-1',
+    name: 'Test Support Vehicle',
+    unitType: UnitType.SUPPORT_VEHICLE,
+    techBase: TechBase.INNER_SPHERE,
+    rulesLevel: RulesLevel.STANDARD,
+    introductionYear: 3025,
+    era: Era.LATE_SUCCESSION_WARS,
+    weight: 100,
+    cost: 2000000,
+    battleValue: 300,
+    engine: { type: 'ICE', rating: 150 },
+    motiveSystem: { type: 'Wheeled' },
+    ...overrides,
+  };
+}
+
+function createTestContext(
+  unit: IValidatableUnit,
+  category: UnitCategory = UnitCategory.VEHICLE
+): IUnitValidationContext {
+  return {
+    unit,
+    unitType: unit.unitType,
+    unitCategory: category,
+    techBase: unit.techBase,
+    options: {},
+    cache: new Map(),
+  };
+}
+
+// =============================================================================
+// VEHICLE_CATEGORY_RULES Export Tests
+// =============================================================================
+
+describe('Vehicle Category Rules', () => {
+  describe('VEHICLE_CATEGORY_RULES export', () => {
+    it('should export all vehicle rules', () => {
+      expect(VEHICLE_CATEGORY_RULES).toBeDefined();
+      expect(VEHICLE_CATEGORY_RULES.length).toBe(5);
+    });
+
+    it('should contain all expected rule IDs', () => {
+      const ruleIds = VEHICLE_CATEGORY_RULES.map((r) => r.id);
+      expect(ruleIds).toContain('VAL-VEH-001');
+      expect(ruleIds).toContain('VAL-VEH-002');
+      expect(ruleIds).toContain('VAL-VEH-003');
+      expect(ruleIds).toContain('VAL-VEH-004');
+      expect(ruleIds).toContain('VAL-VEH-005');
+    });
+
+    it('should have rules in correct order', () => {
+      expect(VEHICLE_CATEGORY_RULES[0].id).toBe('VAL-VEH-001');
+      expect(VEHICLE_CATEGORY_RULES[1].id).toBe('VAL-VEH-002');
+      expect(VEHICLE_CATEGORY_RULES[2].id).toBe('VAL-VEH-003');
+      expect(VEHICLE_CATEGORY_RULES[3].id).toBe('VAL-VEH-004');
+      expect(VEHICLE_CATEGORY_RULES[4].id).toBe('VAL-VEH-005');
+    });
+  });
+
+  // =============================================================================
+  // VAL-VEH-001: Engine Required
+  // =============================================================================
+
+  describe('VAL-VEH-001: Engine Required', () => {
+    it('should have correct metadata', () => {
+      expect(VehicleEngineRequired.id).toBe('VAL-VEH-001');
+      expect(VehicleEngineRequired.name).toBe('Engine Required');
+      expect(VehicleEngineRequired.priority).toBe(30);
+      expect(VehicleEngineRequired.applicableUnitTypes).toContain(UnitType.VEHICLE);
+      expect(VehicleEngineRequired.applicableUnitTypes).toContain(UnitType.VTOL);
+      expect(VehicleEngineRequired.applicableUnitTypes).toContain(UnitType.SUPPORT_VEHICLE);
+    });
+
+    describe('with Vehicle unit', () => {
+      it('should pass when engine is present', () => {
+        const unit = createVehicleUnit({ engine: { type: 'Fusion', rating: 200 } });
+        const context = createTestContext(unit);
+        const result = VehicleEngineRequired.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should fail when engine is missing', () => {
+        const unit = createVehicleUnit({ engine: undefined });
+        const context = createTestContext(unit);
+        const result = VehicleEngineRequired.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].severity).toBe(UnitValidationSeverity.CRITICAL_ERROR);
+        expect(result.errors[0].field).toBe('engine');
+        expect(result.errors[0].suggestion).toContain('Select an engine');
+      });
+    });
+
+    describe('with VTOL unit', () => {
+      it('should pass when engine is present', () => {
+        const unit = createVTOLUnit({ engine: { type: 'Fusion', rating: 100 } });
+        const context = createTestContext(unit);
+        const result = VehicleEngineRequired.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should fail when engine is missing', () => {
+        const unit = createVTOLUnit({ engine: undefined });
+        const context = createTestContext(unit);
+        const result = VehicleEngineRequired.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].severity).toBe(UnitValidationSeverity.CRITICAL_ERROR);
+      });
+    });
+
+    describe('with Support Vehicle unit', () => {
+      it('should pass when engine is present', () => {
+        const unit = createSupportVehicleUnit({ engine: { type: 'ICE', rating: 150 } });
+        const context = createTestContext(unit);
+        const result = VehicleEngineRequired.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should fail when engine is missing', () => {
+        const unit = createSupportVehicleUnit({ engine: undefined });
+        const context = createTestContext(unit);
+        const result = VehicleEngineRequired.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+      });
+    });
+
+    describe('with non-vehicle unit types', () => {
+      it('should pass for BattleMech (not a vehicle type)', () => {
+        const unit = createVehicleUnit({
+          unitType: UnitType.BATTLEMECH,
+          engine: undefined,
+        });
+        const context = createTestContext(unit, UnitCategory.MECH);
+        const result = VehicleEngineRequired.validate(context);
+
+        // Should pass because isVehicleUnit returns false
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+    });
+  });
+
+  // =============================================================================
+  // VAL-VEH-002: Motive System Required
+  // =============================================================================
+
+  describe('VAL-VEH-002: Motive System Required', () => {
+    it('should have correct metadata', () => {
+      expect(VehicleMotiveSystemRequired.id).toBe('VAL-VEH-002');
+      expect(VehicleMotiveSystemRequired.name).toBe('Motive System Required');
+      expect(VehicleMotiveSystemRequired.priority).toBe(31);
+    });
+
+    describe('with Vehicle unit', () => {
+      it('should pass when motive system is present (Tracked)', () => {
+        const unit = createVehicleUnit({ motiveSystem: { type: 'Tracked' } });
+        const context = createTestContext(unit);
+        const result = VehicleMotiveSystemRequired.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should pass with Wheeled motive system', () => {
+        const unit = createVehicleUnit({ motiveSystem: { type: 'Wheeled' } });
+        const context = createTestContext(unit);
+        const result = VehicleMotiveSystemRequired.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should pass with Hover motive system', () => {
+        const unit = createVehicleUnit({ motiveSystem: { type: 'Hover' } });
+        const context = createTestContext(unit);
+        const result = VehicleMotiveSystemRequired.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should fail when motive system is missing', () => {
+        const unit = createVehicleUnit({ motiveSystem: undefined });
+        const context = createTestContext(unit);
+        const result = VehicleMotiveSystemRequired.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].severity).toBe(UnitValidationSeverity.CRITICAL_ERROR);
+        expect(result.errors[0].field).toBe('motiveSystem');
+        expect(result.errors[0].suggestion).toContain('Wheeled');
+        expect(result.errors[0].suggestion).toContain('Tracked');
+      });
+    });
+
+    describe('with VTOL unit', () => {
+      it('should pass when motive system is present', () => {
+        const unit = createVTOLUnit({ motiveSystem: { type: 'VTOL' } });
+        const context = createTestContext(unit);
+        const result = VehicleMotiveSystemRequired.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should fail when motive system is missing', () => {
+        const unit = createVTOLUnit({ motiveSystem: undefined });
+        const context = createTestContext(unit);
+        const result = VehicleMotiveSystemRequired.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+      });
+    });
+
+    describe('with Support Vehicle unit', () => {
+      it('should pass when motive system is present', () => {
+        const unit = createSupportVehicleUnit({ motiveSystem: { type: 'Naval' } });
+        const context = createTestContext(unit);
+        const result = VehicleMotiveSystemRequired.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should fail when motive system is missing', () => {
+        const unit = createSupportVehicleUnit({ motiveSystem: undefined });
+        const context = createTestContext(unit);
+        const result = VehicleMotiveSystemRequired.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+      });
+    });
+  });
+
+  // =============================================================================
+  // VAL-VEH-003: Turret Capacity Limits
+  // =============================================================================
+
+  describe('VAL-VEH-003: Turret Capacity Limits', () => {
+    it('should have correct metadata', () => {
+      expect(VehicleTurretCapacity.id).toBe('VAL-VEH-003');
+      expect(VehicleTurretCapacity.name).toBe('Turret Capacity Limits');
+      expect(VehicleTurretCapacity.priority).toBe(32);
+      expect(VehicleTurretCapacity.applicableUnitTypes).toContain(UnitType.VEHICLE);
+      expect(VehicleTurretCapacity.applicableUnitTypes).toContain(UnitType.SUPPORT_VEHICLE);
+      // VTOLs should not be in applicableUnitTypes for turret capacity
+      expect(VehicleTurretCapacity.applicableUnitTypes).not.toContain(UnitType.VTOL);
+    });
+
+    describe('canValidate', () => {
+      it('should return true when turret is present', () => {
+        const unit = createVehicleUnit({ turret: { capacity: 10, usedWeight: 5 } });
+        const context = createTestContext(unit);
+        const result = VehicleTurretCapacity.canValidate!(context);
+
+        expect(result).toBe(true);
+      });
+
+      it('should return false when turret is not present', () => {
+        const unit = createVehicleUnit({ turret: undefined });
+        const context = createTestContext(unit);
+        const result = VehicleTurretCapacity.canValidate!(context);
+
+        expect(result).toBe(false);
+      });
+
+      it('should return false for non-vehicle types', () => {
+        const unit = createVehicleUnit({
+          unitType: UnitType.BATTLEMECH,
+          turret: { capacity: 10, usedWeight: 5 },
+        });
+        const context = createTestContext(unit, UnitCategory.MECH);
+        const result = VehicleTurretCapacity.canValidate!(context);
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('validate', () => {
+      it('should pass when turret weight is within capacity', () => {
+        const unit = createVehicleUnit({ turret: { capacity: 10, usedWeight: 5 } });
+        const context = createTestContext(unit);
+        const result = VehicleTurretCapacity.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should pass when turret weight equals capacity', () => {
+        const unit = createVehicleUnit({ turret: { capacity: 10, usedWeight: 10 } });
+        const context = createTestContext(unit);
+        const result = VehicleTurretCapacity.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should fail when turret weight exceeds capacity', () => {
+        const unit = createVehicleUnit({ turret: { capacity: 10, usedWeight: 15 } });
+        const context = createTestContext(unit);
+        const result = VehicleTurretCapacity.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].severity).toBe(UnitValidationSeverity.ERROR);
+        expect(result.errors[0].message).toContain('5.00');
+        expect(result.errors[0].field).toBe('turret.usedWeight');
+        expect(result.errors[0].expected).toBe('<= 10');
+        expect(result.errors[0].actual).toBe('15');
+      });
+
+      it('should calculate correct overflow amount', () => {
+        const unit = createVehicleUnit({ turret: { capacity: 8.5, usedWeight: 12.75 } });
+        const context = createTestContext(unit);
+        const result = VehicleTurretCapacity.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors[0].message).toContain('4.25');
+      });
+
+      it('should pass when no turret is present', () => {
+        const unit = createVehicleUnit({ turret: undefined });
+        const context = createTestContext(unit);
+        const result = VehicleTurretCapacity.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should work with Support Vehicle', () => {
+        const unit = createSupportVehicleUnit({ turret: { capacity: 20, usedWeight: 25 } });
+        const context = createTestContext(unit);
+        const result = VehicleTurretCapacity.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+      });
+    });
+  });
+
+  // =============================================================================
+  // VAL-VEH-004: VTOL Rotor Required
+  // =============================================================================
+
+  describe('VAL-VEH-004: VTOL Rotor Required', () => {
+    it('should have correct metadata', () => {
+      expect(VTOLRotorRequired.id).toBe('VAL-VEH-004');
+      expect(VTOLRotorRequired.name).toBe('VTOL Rotor Required');
+      expect(VTOLRotorRequired.priority).toBe(33);
+      expect(VTOLRotorRequired.applicableUnitTypes).toEqual([UnitType.VTOL]);
+    });
+
+    describe('with VTOL unit', () => {
+      it('should pass when rotor is present', () => {
+        const unit = createVTOLUnit({ rotor: { type: 'Standard' } });
+        const context = createTestContext(unit);
+        const result = VTOLRotorRequired.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should fail when rotor is missing', () => {
+        const unit = createVTOLUnit({ rotor: undefined });
+        const context = createTestContext(unit);
+        const result = VTOLRotorRequired.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].severity).toBe(UnitValidationSeverity.CRITICAL_ERROR);
+        expect(result.errors[0].message).toContain('rotor system');
+        expect(result.errors[0].field).toBe('rotor');
+        expect(result.errors[0].suggestion).toContain('Add a rotor system');
+      });
+    });
+
+    describe('with non-VTOL vehicle types', () => {
+      it('should pass for regular Vehicle without rotor', () => {
+        const unit = createVehicleUnit({ rotor: undefined });
+        const context = createTestContext(unit);
+        const result = VTOLRotorRequired.validate(context);
+
+        // Should pass because unit.unitType !== UnitType.VTOL
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should pass for Support Vehicle without rotor', () => {
+        const unit = createSupportVehicleUnit({ rotor: undefined });
+        const context = createTestContext(unit);
+        const result = VTOLRotorRequired.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+    });
+  });
+
+  // =============================================================================
+  // VAL-VEH-005: Vehicle Tonnage Range
+  // =============================================================================
+
+  describe('VAL-VEH-005: Vehicle Tonnage Range', () => {
+    it('should have correct metadata', () => {
+      expect(VehicleTonnageRange.id).toBe('VAL-VEH-005');
+      expect(VehicleTonnageRange.name).toBe('Vehicle Tonnage Range');
+      expect(VehicleTonnageRange.priority).toBe(34);
+      expect(VehicleTonnageRange.applicableUnitTypes).toContain(UnitType.VEHICLE);
+      expect(VehicleTonnageRange.applicableUnitTypes).toContain(UnitType.VTOL);
+      expect(VehicleTonnageRange.applicableUnitTypes).toContain(UnitType.SUPPORT_VEHICLE);
+    });
+
+    describe('Vehicle tonnage (1-100 tons)', () => {
+      it('should pass at minimum tonnage (1 ton)', () => {
+        const unit = createVehicleUnit({ weight: 1 });
+        const context = createTestContext(unit);
+        const result = VehicleTonnageRange.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should pass at maximum tonnage (100 tons)', () => {
+        const unit = createVehicleUnit({ weight: 100 });
+        const context = createTestContext(unit);
+        const result = VehicleTonnageRange.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should pass at typical tonnage (50 tons)', () => {
+        const unit = createVehicleUnit({ weight: 50 });
+        const context = createTestContext(unit);
+        const result = VehicleTonnageRange.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should fail below minimum tonnage', () => {
+        const unit = createVehicleUnit({ weight: 0 });
+        const context = createTestContext(unit);
+        const result = VehicleTonnageRange.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].severity).toBe(UnitValidationSeverity.CRITICAL_ERROR);
+        expect(result.errors[0].message).toContain('1-100');
+        expect(result.errors[0].expected).toBe('1-100');
+        expect(result.errors[0].actual).toBe('0');
+      });
+
+      it('should fail above maximum tonnage', () => {
+        const unit = createVehicleUnit({ weight: 101 });
+        const context = createTestContext(unit);
+        const result = VehicleTonnageRange.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].message).toContain('1-100');
+      });
+    });
+
+    describe('VTOL tonnage (1-30 tons)', () => {
+      it('should pass at minimum tonnage (1 ton)', () => {
+        const unit = createVTOLUnit({ weight: 1 });
+        const context = createTestContext(unit);
+        const result = VehicleTonnageRange.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should pass at maximum tonnage (30 tons)', () => {
+        const unit = createVTOLUnit({ weight: 30 });
+        const context = createTestContext(unit);
+        const result = VehicleTonnageRange.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should pass at typical tonnage (20 tons)', () => {
+        const unit = createVTOLUnit({ weight: 20 });
+        const context = createTestContext(unit);
+        const result = VehicleTonnageRange.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should fail below minimum tonnage', () => {
+        const unit = createVTOLUnit({ weight: 0 });
+        const context = createTestContext(unit);
+        const result = VehicleTonnageRange.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors[0].message).toContain('1-30');
+      });
+
+      it('should fail above maximum tonnage', () => {
+        const unit = createVTOLUnit({ weight: 31 });
+        const context = createTestContext(unit);
+        const result = VehicleTonnageRange.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors[0].message).toContain('1-30');
+        expect(result.errors[0].expected).toBe('1-30');
+        expect(result.errors[0].actual).toBe('31');
+      });
+    });
+
+    describe('Support Vehicle tonnage (1-300 tons)', () => {
+      it('should pass at minimum tonnage (1 ton)', () => {
+        const unit = createSupportVehicleUnit({ weight: 1 });
+        const context = createTestContext(unit);
+        const result = VehicleTonnageRange.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should pass at maximum tonnage (300 tons)', () => {
+        const unit = createSupportVehicleUnit({ weight: 300 });
+        const context = createTestContext(unit);
+        const result = VehicleTonnageRange.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should pass at typical tonnage (100 tons)', () => {
+        const unit = createSupportVehicleUnit({ weight: 100 });
+        const context = createTestContext(unit);
+        const result = VehicleTonnageRange.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should fail below minimum tonnage', () => {
+        const unit = createSupportVehicleUnit({ weight: 0 });
+        const context = createTestContext(unit);
+        const result = VehicleTonnageRange.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors[0].message).toContain('1-300');
+      });
+
+      it('should fail above maximum tonnage', () => {
+        const unit = createSupportVehicleUnit({ weight: 301 });
+        const context = createTestContext(unit);
+        const result = VehicleTonnageRange.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors[0].message).toContain('1-300');
+        expect(result.errors[0].expected).toBe('1-300');
+        expect(result.errors[0].actual).toBe('301');
+      });
+    });
+
+    describe('with non-vehicle unit types', () => {
+      it('should pass for BattleMech (not validated by this rule)', () => {
+        const unit = createVehicleUnit({
+          unitType: UnitType.BATTLEMECH,
+          weight: 500, // Invalid for a mech but this rule doesn't apply
+        });
+        const context = createTestContext(unit, UnitCategory.MECH);
+        const result = VehicleTonnageRange.validate(context);
+
+        // Should pass because isVehicleType returns false
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+    });
+  });
+
+  // =============================================================================
+  // Integration Tests
+  // =============================================================================
+
+  describe('Integration Tests', () => {
+    it('should validate a fully valid Vehicle', () => {
+      const unit = createVehicleUnit({
+        weight: 50,
+        engine: { type: 'Fusion', rating: 200 },
+        motiveSystem: { type: 'Tracked' },
+        turret: { capacity: 10, usedWeight: 8 },
+      });
+      const context = createTestContext(unit);
+
+      for (const rule of VEHICLE_CATEGORY_RULES) {
+        const result = rule.validate(context);
+        expect(result.passed).toBe(true);
+      }
+    });
+
+    it('should validate a fully valid VTOL', () => {
+      const unit = createVTOLUnit({
+        weight: 20,
+        engine: { type: 'Fusion', rating: 100 },
+        motiveSystem: { type: 'VTOL' },
+        rotor: { type: 'Standard' },
+      });
+      const context = createTestContext(unit);
+
+      for (const rule of VEHICLE_CATEGORY_RULES) {
+        const result = rule.validate(context);
+        expect(result.passed).toBe(true);
+      }
+    });
+
+    it('should validate a fully valid Support Vehicle', () => {
+      const unit = createSupportVehicleUnit({
+        weight: 150,
+        engine: { type: 'ICE', rating: 200 },
+        motiveSystem: { type: 'Naval' },
+      });
+      const context = createTestContext(unit);
+
+      for (const rule of VEHICLE_CATEGORY_RULES) {
+        const result = rule.validate(context);
+        expect(result.passed).toBe(true);
+      }
+    });
+
+    it('should catch multiple validation failures', () => {
+      const unit = createVehicleUnit({
+        weight: 150, // Invalid: exceeds max 100 tons
+        engine: undefined, // Invalid: no engine
+        motiveSystem: undefined, // Invalid: no motive system
+        turret: { capacity: 5, usedWeight: 10 }, // Invalid: over capacity
+      });
+      const context = createTestContext(unit);
+
+      const failedRules: string[] = [];
+      for (const rule of VEHICLE_CATEGORY_RULES) {
+        const result = rule.validate(context);
+        if (!result.passed) {
+          failedRules.push(rule.id);
+        }
+      }
+
+      expect(failedRules).toContain('VAL-VEH-001'); // Engine
+      expect(failedRules).toContain('VAL-VEH-002'); // Motive System
+      expect(failedRules).toContain('VAL-VEH-003'); // Turret Capacity
+      expect(failedRules).toContain('VAL-VEH-005'); // Tonnage Range
+    });
+  });
+});

--- a/src/services/validation/rules/equipment/__tests__/EquipmentUnitTypeRules.test.ts
+++ b/src/services/validation/rules/equipment/__tests__/EquipmentUnitTypeRules.test.ts
@@ -1,0 +1,994 @@
+/**
+ * Equipment Unit Type Validation Rules Tests
+ *
+ * Tests for equipment unit type validation rules including
+ * unit type compatibility, location compatibility, turret mounting,
+ * incompatible equipment, and required equipment checks.
+ */
+
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+import {
+  IValidatableUnit,
+  IUnitValidationContext,
+  UnitCategory,
+  UnitValidationSeverity,
+} from '@/types/validation/UnitValidationInterfaces';
+import { TechBase, RulesLevel, Era } from '@/types/enums';
+import { EquipmentBehaviorFlag } from '@/types/enums/EquipmentFlag';
+import { MechLocation } from '@/types/construction/CriticalSlotAllocation';
+import { VehicleLocation } from '@/types/construction/UnitLocation';
+import {
+  IValidatableEquipmentItem,
+  EquipmentUnitTypeCompatibility,
+  EquipmentLocationCompatibility,
+  TurretMountingRequirements,
+  IncompatibleEquipmentCheck,
+  RequiredEquipmentCheck,
+  EQUIPMENT_UNIT_TYPE_RULES,
+} from '../EquipmentUnitTypeRules';
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+interface IEquipmentTestUnit extends IValidatableUnit {
+  equipment?: readonly IValidatableEquipmentItem[];
+  hasTurret?: boolean;
+  heatSinkCount?: number;
+}
+
+function createTestUnit(overrides: Partial<IEquipmentTestUnit> = {}): IEquipmentTestUnit {
+  return {
+    id: 'test-unit-1',
+    name: 'Test Unit',
+    unitType: UnitType.BATTLEMECH,
+    techBase: TechBase.INNER_SPHERE,
+    rulesLevel: RulesLevel.STANDARD,
+    introductionYear: 3025,
+    era: Era.LATE_SUCCESSION_WARS,
+    weight: 50,
+    cost: 5000000,
+    battleValue: 1200,
+    ...overrides,
+  };
+}
+
+function createEquipmentItem(
+  overrides: Partial<IValidatableEquipmentItem> = {}
+): IValidatableEquipmentItem {
+  return {
+    id: 'equip-1',
+    equipmentId: 'test-equipment',
+    name: 'Test Equipment',
+    location: MechLocation.CENTER_TORSO,
+    ...overrides,
+  };
+}
+
+function createTestContext(
+  unit: IValidatableUnit,
+  unitCategory: UnitCategory = UnitCategory.MECH
+): IUnitValidationContext {
+  return {
+    unit,
+    unitType: unit.unitType,
+    unitCategory,
+    techBase: unit.techBase,
+    options: {},
+    cache: new Map(),
+  };
+}
+
+// =============================================================================
+// EQUIPMENT_UNIT_TYPE_RULES Export Tests
+// =============================================================================
+
+describe('Equipment Unit Type Rules', () => {
+  describe('EQUIPMENT_UNIT_TYPE_RULES export', () => {
+    it('should export all equipment unit type rules', () => {
+      expect(EQUIPMENT_UNIT_TYPE_RULES).toBeDefined();
+      expect(EQUIPMENT_UNIT_TYPE_RULES.length).toBe(5);
+    });
+
+    it('should contain all expected rule IDs', () => {
+      const ruleIds = EQUIPMENT_UNIT_TYPE_RULES.map((r) => r.id);
+      expect(ruleIds).toContain('VAL-EQUIP-UNIT-001');
+      expect(ruleIds).toContain('VAL-EQUIP-UNIT-002');
+      expect(ruleIds).toContain('VAL-EQUIP-UNIT-003');
+      expect(ruleIds).toContain('VAL-EQUIP-UNIT-004');
+      expect(ruleIds).toContain('VAL-EQUIP-UNIT-005');
+    });
+
+    it('should have correct priorities (ascending order)', () => {
+      const priorities = EQUIPMENT_UNIT_TYPE_RULES.map((r) => r.priority);
+      expect(priorities).toEqual([100, 101, 102, 103, 104]);
+    });
+  });
+
+  // ===========================================================================
+  // VAL-EQUIP-UNIT-001: Equipment Unit Type Compatibility
+  // ===========================================================================
+
+  describe('VAL-EQUIP-UNIT-001: Equipment Unit Type Compatibility', () => {
+    describe('canValidate', () => {
+      it('should return true when unit has equipment', () => {
+        const unit = createTestUnit({
+          equipment: [createEquipmentItem()],
+        });
+        const context = createTestContext(unit);
+        expect(EquipmentUnitTypeCompatibility.canValidate!(context)).toBe(true);
+      });
+
+      it('should return false when unit has no equipment', () => {
+        const unit = createTestUnit({ equipment: undefined });
+        const context = createTestContext(unit);
+        expect(EquipmentUnitTypeCompatibility.canValidate!(context)).toBe(false);
+      });
+
+      it('should return false when equipment array is empty', () => {
+        const unit = createTestUnit({ equipment: [] });
+        const context = createTestContext(unit);
+        expect(EquipmentUnitTypeCompatibility.canValidate!(context)).toBe(false);
+      });
+    });
+
+    describe('validate', () => {
+      it('should pass when equipment has no allowedUnitTypes (defaults to all standard)', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.BATTLEMECH,
+          equipment: [
+            createEquipmentItem({
+              allowedUnitTypes: undefined,
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = EquipmentUnitTypeCompatibility.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should pass when unit type is in allowedUnitTypes', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.BATTLEMECH,
+          equipment: [
+            createEquipmentItem({
+              allowedUnitTypes: [UnitType.BATTLEMECH, UnitType.OMNIMECH],
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = EquipmentUnitTypeCompatibility.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should fail when unit type is not in allowedUnitTypes', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.BATTLEMECH,
+          equipment: [
+            createEquipmentItem({
+              name: 'Vehicle-Only Equipment',
+              allowedUnitTypes: [UnitType.VEHICLE, UnitType.VTOL],
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = EquipmentUnitTypeCompatibility.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].severity).toBe(UnitValidationSeverity.ERROR);
+        expect(result.errors[0].message).toContain('Vehicle-Only Equipment');
+        expect(result.errors[0].message).toContain('cannot be mounted');
+      });
+
+      it('should return passing result when equipment is undefined', () => {
+        const unit = createTestUnit({ equipment: undefined });
+        const context = createTestContext(unit);
+        const result = EquipmentUnitTypeCompatibility.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should validate multiple equipment items', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.VEHICLE,
+          equipment: [
+            createEquipmentItem({
+              id: 'equip-1',
+              name: 'Compatible Equipment',
+              allowedUnitTypes: [UnitType.VEHICLE],
+            }),
+            createEquipmentItem({
+              id: 'equip-2',
+              name: 'Mech-Only Equipment',
+              allowedUnitTypes: [UnitType.BATTLEMECH],
+            }),
+            createEquipmentItem({
+              id: 'equip-3',
+              name: 'Also Compatible',
+              allowedUnitTypes: [UnitType.VEHICLE, UnitType.VTOL],
+            }),
+          ],
+        });
+        const context = createTestContext(unit, UnitCategory.VEHICLE);
+        const result = EquipmentUnitTypeCompatibility.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].message).toContain('Mech-Only Equipment');
+      });
+
+      it('should include equipment details in error', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.INFANTRY,
+          equipment: [
+            createEquipmentItem({
+              id: 'mech-equip-1',
+              equipmentId: 'equipment-def-123',
+              name: 'Mech Equipment',
+              location: MechLocation.LEFT_ARM,
+              allowedUnitTypes: [UnitType.BATTLEMECH],
+            }),
+          ],
+        });
+        const context = createTestContext(unit, UnitCategory.PERSONNEL);
+        const result = EquipmentUnitTypeCompatibility.validate(context);
+
+        expect(result.errors[0].field).toBe('equipment.mech-equip-1');
+        expect(result.errors[0].actual).toBe(UnitType.INFANTRY);
+        expect(result.errors[0].details?.equipmentId).toBe('equipment-def-123');
+        expect(result.errors[0].details?.location).toBe(MechLocation.LEFT_ARM);
+      });
+    });
+  });
+
+  // ===========================================================================
+  // VAL-EQUIP-UNIT-002: Equipment Location Compatibility
+  // ===========================================================================
+
+  describe('VAL-EQUIP-UNIT-002: Equipment Location Compatibility', () => {
+    describe('canValidate', () => {
+      it('should return true when unit has equipment', () => {
+        const unit = createTestUnit({
+          equipment: [createEquipmentItem()],
+        });
+        const context = createTestContext(unit);
+        expect(EquipmentLocationCompatibility.canValidate!(context)).toBe(true);
+      });
+
+      it('should return false when unit has no equipment', () => {
+        const unit = createTestUnit({ equipment: undefined });
+        const context = createTestContext(unit);
+        expect(EquipmentLocationCompatibility.canValidate!(context)).toBe(false);
+      });
+    });
+
+    describe('validate', () => {
+      it('should pass when equipment is in valid location for mech', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.BATTLEMECH,
+          equipment: [
+            createEquipmentItem({
+              location: MechLocation.CENTER_TORSO,
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = EquipmentLocationCompatibility.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should pass when equipment is in valid location for vehicle', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.VEHICLE,
+          equipment: [
+            createEquipmentItem({
+              location: VehicleLocation.FRONT,
+            }),
+          ],
+        });
+        const context = createTestContext(unit, UnitCategory.VEHICLE);
+        const result = EquipmentLocationCompatibility.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should fail when location is invalid for unit type', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.VEHICLE,
+          equipment: [
+            createEquipmentItem({
+              name: 'Misplaced Equipment',
+              location: MechLocation.LEFT_ARM, // Invalid for vehicle
+            }),
+          ],
+        });
+        const context = createTestContext(unit, UnitCategory.VEHICLE);
+        const result = EquipmentLocationCompatibility.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].message).toContain('invalid location');
+        expect(result.errors[0].message).toContain(MechLocation.LEFT_ARM);
+      });
+
+      it('should pass when equipment has no location restrictions', () => {
+        const unit = createTestUnit({
+          equipment: [
+            createEquipmentItem({
+              location: MechLocation.HEAD,
+              allowedLocations: undefined,
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = EquipmentLocationCompatibility.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should pass when equipment is in an allowed location', () => {
+        const unit = createTestUnit({
+          equipment: [
+            createEquipmentItem({
+              location: MechLocation.HEAD,
+              allowedLocations: [MechLocation.HEAD, MechLocation.CENTER_TORSO],
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = EquipmentLocationCompatibility.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should fail when equipment is not in allowed location', () => {
+        const unit = createTestUnit({
+          equipment: [
+            createEquipmentItem({
+              name: 'Restricted Equipment',
+              location: MechLocation.LEFT_ARM,
+              allowedLocations: [MechLocation.HEAD, MechLocation.CENTER_TORSO],
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = EquipmentLocationCompatibility.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].message).toContain('Restricted Equipment');
+        expect(result.errors[0].message).toContain('cannot be mounted');
+        expect(result.errors[0].suggestion).toContain('Head');
+        expect(result.errors[0].suggestion).toContain('Center Torso');
+      });
+
+      it('should return passing result when equipment is undefined', () => {
+        const unit = createTestUnit({ equipment: undefined });
+        const context = createTestContext(unit);
+        const result = EquipmentLocationCompatibility.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should check unit type location first before equipment restrictions', () => {
+        // If location is invalid for unit type, it should fail there
+        // and not also check equipment-specific restrictions
+        const unit = createTestUnit({
+          unitType: UnitType.VEHICLE,
+          equipment: [
+            createEquipmentItem({
+              name: 'Doubly Wrong Equipment',
+              location: MechLocation.LEFT_ARM, // Invalid for vehicle
+              allowedLocations: [MechLocation.HEAD], // Also not matching
+            }),
+          ],
+        });
+        const context = createTestContext(unit, UnitCategory.VEHICLE);
+        const result = EquipmentLocationCompatibility.validate(context);
+
+        // Should only get one error (for unit type location), not two
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].message).toContain('invalid location');
+      });
+    });
+  });
+
+  // ===========================================================================
+  // VAL-EQUIP-UNIT-003: Turret Mounting Requirements
+  // ===========================================================================
+
+  describe('VAL-EQUIP-UNIT-003: Turret Mounting Requirements', () => {
+    describe('canValidate', () => {
+      it('should return true when unit has equipment', () => {
+        const unit = createTestUnit({
+          equipment: [createEquipmentItem()],
+        });
+        const context = createTestContext(unit);
+        expect(TurretMountingRequirements.canValidate!(context)).toBe(true);
+      });
+
+      it('should return false when unit has no equipment', () => {
+        const unit = createTestUnit({ equipment: undefined });
+        const context = createTestContext(unit);
+        expect(TurretMountingRequirements.canValidate!(context)).toBe(false);
+      });
+    });
+
+    describe('validate', () => {
+      it('should pass when non-turret equipment on any unit type', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.BATTLEMECH,
+          equipment: [
+            createEquipmentItem({
+              isTurretMounted: false,
+              flags: [],
+              location: MechLocation.CENTER_TORSO,
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = TurretMountingRequirements.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should pass when turret-mounted equipment on vehicle', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.VEHICLE,
+          hasTurret: true,
+          equipment: [
+            createEquipmentItem({
+              isTurretMounted: true,
+              location: 'Turret',
+            }),
+          ],
+        });
+        const context = createTestContext(unit, UnitCategory.VEHICLE);
+        const result = TurretMountingRequirements.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should pass when turret-mounted equipment on VTOL', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.VTOL,
+          hasTurret: true,
+          equipment: [
+            createEquipmentItem({
+              isTurretMounted: true,
+            }),
+          ],
+        });
+        const context = createTestContext(unit, UnitCategory.VEHICLE);
+        const result = TurretMountingRequirements.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should pass when turret-mounted equipment on support vehicle', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.SUPPORT_VEHICLE,
+          hasTurret: true,
+          equipment: [
+            createEquipmentItem({
+              isTurretMounted: true,
+            }),
+          ],
+        });
+        const context = createTestContext(unit, UnitCategory.VEHICLE);
+        const result = TurretMountingRequirements.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should fail when turret-mounted equipment on BattleMech (via isTurretMounted)', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.BATTLEMECH,
+          equipment: [
+            createEquipmentItem({
+              name: 'Turret Weapon',
+              isTurretMounted: true,
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = TurretMountingRequirements.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].message).toContain('requires turret mount');
+        expect(result.errors[0].message).toContain('cannot have turrets');
+      });
+
+      it('should fail when turret-mounted equipment on BattleMech (via flag)', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.BATTLEMECH,
+          equipment: [
+            createEquipmentItem({
+              name: 'Flagged Turret Weapon',
+              flags: [EquipmentBehaviorFlag.TURRET_MOUNTED],
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = TurretMountingRequirements.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].message).toContain('Flagged Turret Weapon');
+      });
+
+      it('should fail when equipment in Turret location on non-turret-capable unit', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.AEROSPACE,
+          equipment: [
+            createEquipmentItem({
+              name: 'Turret Location Weapon',
+              location: 'Turret',
+            }),
+          ],
+        });
+        const context = createTestContext(unit, UnitCategory.AEROSPACE);
+        const result = TurretMountingRequirements.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+      });
+
+      it('should fail when vehicle has turret equipment but no turret installed', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.VEHICLE,
+          hasTurret: false,
+          equipment: [
+            createEquipmentItem({
+              name: 'Turret Weapon',
+              isTurretMounted: true,
+            }),
+          ],
+        });
+        const context = createTestContext(unit, UnitCategory.VEHICLE);
+        const result = TurretMountingRequirements.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].message).toContain('no turret installed');
+      });
+
+      it('should return passing result when equipment is undefined', () => {
+        const unit = createTestUnit({ equipment: undefined });
+        const context = createTestContext(unit);
+        const result = TurretMountingRequirements.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should pass when vehicle does not have hasTurret defined (undefined)', () => {
+        // When hasTurret is undefined (not explicitly false), don't error
+        const unit = createTestUnit({
+          unitType: UnitType.VEHICLE,
+          // hasTurret not set - undefined
+          equipment: [
+            createEquipmentItem({
+              isTurretMounted: true,
+            }),
+          ],
+        });
+        const context = createTestContext(unit, UnitCategory.VEHICLE);
+        const result = TurretMountingRequirements.validate(context);
+
+        // Should pass because hasTurret is undefined, not explicitly false
+        expect(result.passed).toBe(true);
+      });
+    });
+  });
+
+  // ===========================================================================
+  // VAL-EQUIP-UNIT-004: Incompatible Equipment Check
+  // ===========================================================================
+
+  describe('VAL-EQUIP-UNIT-004: Incompatible Equipment Check', () => {
+    describe('canValidate', () => {
+      it('should return true when unit has more than one equipment', () => {
+        const unit = createTestUnit({
+          equipment: [
+            createEquipmentItem({ id: 'equip-1' }),
+            createEquipmentItem({ id: 'equip-2' }),
+          ],
+        });
+        const context = createTestContext(unit);
+        expect(IncompatibleEquipmentCheck.canValidate!(context)).toBe(true);
+      });
+
+      it('should return false when unit has only one equipment', () => {
+        const unit = createTestUnit({
+          equipment: [createEquipmentItem()],
+        });
+        const context = createTestContext(unit);
+        expect(IncompatibleEquipmentCheck.canValidate!(context)).toBe(false);
+      });
+
+      it('should return false when unit has no equipment', () => {
+        const unit = createTestUnit({ equipment: undefined });
+        const context = createTestContext(unit);
+        expect(IncompatibleEquipmentCheck.canValidate!(context)).toBe(false);
+      });
+    });
+
+    describe('validate', () => {
+      it('should pass when no incompatible equipment present', () => {
+        const unit = createTestUnit({
+          equipment: [
+            createEquipmentItem({
+              id: 'equip-1',
+              name: 'Heat Sink',
+              flags: [EquipmentBehaviorFlag.HEAT_SINK],
+            }),
+            createEquipmentItem({
+              id: 'equip-2',
+              name: 'Jump Jet',
+              flags: [EquipmentBehaviorFlag.JUMP_JET],
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = IncompatibleEquipmentCheck.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should fail when MASC and TSM are both present', () => {
+        const unit = createTestUnit({
+          equipment: [
+            createEquipmentItem({
+              id: 'masc-1',
+              name: 'MASC',
+              flags: [EquipmentBehaviorFlag.MASC],
+            }),
+            createEquipmentItem({
+              id: 'tsm-1',
+              name: 'Triple Strength Myomer',
+              flags: [EquipmentBehaviorFlag.TSM],
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = IncompatibleEquipmentCheck.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].message).toContain('MASC cannot be combined with Triple Strength Myomer');
+      });
+
+      it('should fail when MASC and Industrial TSM are both present', () => {
+        const unit = createTestUnit({
+          equipment: [
+            createEquipmentItem({
+              id: 'masc-1',
+              name: 'MASC',
+              flags: [EquipmentBehaviorFlag.MASC],
+            }),
+            createEquipmentItem({
+              id: 'itsm-1',
+              name: 'Industrial TSM',
+              flags: [EquipmentBehaviorFlag.INDUSTRIAL_TSM],
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = IncompatibleEquipmentCheck.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+      });
+
+      it('should fail when TSM and Industrial TSM are both present', () => {
+        const unit = createTestUnit({
+          equipment: [
+            createEquipmentItem({
+              id: 'tsm-1',
+              name: 'TSM',
+              flags: [EquipmentBehaviorFlag.TSM],
+            }),
+            createEquipmentItem({
+              id: 'itsm-1',
+              name: 'Industrial TSM',
+              flags: [EquipmentBehaviorFlag.INDUSTRIAL_TSM],
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = IncompatibleEquipmentCheck.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].message).toContain('Standard TSM cannot be combined with Industrial TSM');
+      });
+
+      it('should fail when C3 Slave and C3 Improved are both present', () => {
+        const unit = createTestUnit({
+          equipment: [
+            createEquipmentItem({
+              id: 'c3s-1',
+              name: 'C3 Slave',
+              flags: [EquipmentBehaviorFlag.C3S],
+            }),
+            createEquipmentItem({
+              id: 'c3i-1',
+              name: 'C3 Improved',
+              flags: [EquipmentBehaviorFlag.C3I],
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = IncompatibleEquipmentCheck.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].message).toContain('C3 Slave cannot be combined with C3 Improved');
+      });
+
+      it('should fail when Stealth armor and Heat Sink are both present', () => {
+        const unit = createTestUnit({
+          equipment: [
+            createEquipmentItem({
+              id: 'stealth-1',
+              name: 'Stealth Armor',
+              flags: [EquipmentBehaviorFlag.STEALTH],
+            }),
+            createEquipmentItem({
+              id: 'hs-1',
+              name: 'Heat Sink',
+              flags: [EquipmentBehaviorFlag.HEAT_SINK],
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = IncompatibleEquipmentCheck.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].message).toContain('Stealth armor has special heat sink requirements');
+      });
+
+      it('should return passing result when equipment is undefined', () => {
+        const unit = createTestUnit({ equipment: undefined });
+        const context = createTestContext(unit);
+        const result = IncompatibleEquipmentCheck.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should return passing result when only one equipment present', () => {
+        const unit = createTestUnit({
+          equipment: [
+            createEquipmentItem({
+              flags: [EquipmentBehaviorFlag.MASC],
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = IncompatibleEquipmentCheck.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should detect incompatibility via equipment ID as well as flags', () => {
+        // If an equipment ID matches the incompatibility source
+        const unit = createTestUnit({
+          equipment: [
+            createEquipmentItem({
+              id: 'equip-1',
+              equipmentId: EquipmentBehaviorFlag.MASC,
+              name: 'MASC by ID',
+            }),
+            createEquipmentItem({
+              id: 'equip-2',
+              name: 'TSM by Flag',
+              flags: [EquipmentBehaviorFlag.TSM],
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = IncompatibleEquipmentCheck.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+      });
+
+      it('should include suggestion with equipment names in error', () => {
+        const unit = createTestUnit({
+          equipment: [
+            createEquipmentItem({
+              id: 'masc-1',
+              name: 'My MASC',
+              flags: [EquipmentBehaviorFlag.MASC],
+            }),
+            createEquipmentItem({
+              id: 'tsm-1',
+              name: 'My TSM',
+              flags: [EquipmentBehaviorFlag.TSM],
+            }),
+          ],
+        });
+        const context = createTestContext(unit);
+        const result = IncompatibleEquipmentCheck.validate(context);
+
+        expect(result.errors[0].suggestion).toContain('My MASC');
+        expect(result.errors[0].suggestion).toContain('My TSM');
+      });
+    });
+  });
+
+  // ===========================================================================
+  // VAL-EQUIP-UNIT-005: Required Equipment Check
+  // ===========================================================================
+
+  describe('VAL-EQUIP-UNIT-005: Required Equipment Check', () => {
+    describe('validate', () => {
+      it('should pass when mech has 10+ heat sinks', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.BATTLEMECH,
+          heatSinkCount: 10,
+        });
+        const context = createTestContext(unit);
+        const result = RequiredEquipmentCheck.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.warnings.length).toBe(0);
+      });
+
+      it('should warn when BattleMech has less than 10 heat sinks', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.BATTLEMECH,
+          heatSinkCount: 5,
+        });
+        const context = createTestContext(unit);
+        const result = RequiredEquipmentCheck.validate(context);
+
+        expect(result.passed).toBe(true); // Warnings don't fail
+        expect(result.warnings.length).toBe(1);
+        expect(result.warnings[0].severity).toBe(UnitValidationSeverity.WARNING);
+        expect(result.warnings[0].message).toContain('requires minimum 10 heat sinks');
+      });
+
+      it('should warn when OmniMech has less than 10 heat sinks', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.OMNIMECH,
+          heatSinkCount: 8,
+        });
+        const context = createTestContext(unit);
+        const result = RequiredEquipmentCheck.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.warnings.length).toBe(1);
+        expect(result.warnings[0].message).toContain('OmniMech');
+      });
+
+      it('should warn when IndustrialMech has less than 10 heat sinks', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.INDUSTRIALMECH,
+          heatSinkCount: 3,
+        });
+        const context = createTestContext(unit);
+        const result = RequiredEquipmentCheck.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.warnings.length).toBe(1);
+        expect(result.warnings[0].message).toContain('IndustrialMech');
+      });
+
+      it('should not warn for vehicles (no heat sink requirement)', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.VEHICLE,
+          heatSinkCount: 0,
+        });
+        const context = createTestContext(unit, UnitCategory.VEHICLE);
+        const result = RequiredEquipmentCheck.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.warnings.length).toBe(0);
+      });
+
+      it('should not warn for aerospace (no heat sink requirement in this rule)', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.AEROSPACE,
+          heatSinkCount: 0,
+        });
+        const context = createTestContext(unit, UnitCategory.AEROSPACE);
+        const result = RequiredEquipmentCheck.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.warnings.length).toBe(0);
+      });
+
+      it('should treat undefined heatSinkCount as 0', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.BATTLEMECH,
+          heatSinkCount: undefined,
+        });
+        const context = createTestContext(unit);
+        const result = RequiredEquipmentCheck.validate(context);
+
+        expect(result.warnings.length).toBe(1);
+        expect(result.warnings[0].actual).toBe('0');
+      });
+
+      it('should include condition details in warning', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.BATTLEMECH,
+          heatSinkCount: 5,
+        });
+        const context = createTestContext(unit);
+        const result = RequiredEquipmentCheck.validate(context);
+
+        expect(result.warnings[0].details?.condition).toContain('integral heat sinks');
+      });
+
+      it('should include suggestion in warning', () => {
+        const unit = createTestUnit({
+          unitType: UnitType.BATTLEMECH,
+          heatSinkCount: 5,
+        });
+        const context = createTestContext(unit);
+        const result = RequiredEquipmentCheck.validate(context);
+
+        expect(result.warnings[0].suggestion).toContain('Add heat sinks');
+      });
+    });
+
+    // Note: RequiredEquipmentCheck does not have a canValidate method defined,
+    // so it always runs (defaults to returning true)
+  });
+
+  // ===========================================================================
+  // Rule Metadata Tests
+  // ===========================================================================
+
+  describe('Rule Metadata', () => {
+    it('EquipmentUnitTypeCompatibility should have correct metadata', () => {
+      expect(EquipmentUnitTypeCompatibility.id).toBe('VAL-EQUIP-UNIT-001');
+      expect(EquipmentUnitTypeCompatibility.name).toBe('Equipment Unit Type Compatibility');
+      expect(EquipmentUnitTypeCompatibility.applicableUnitTypes).toBe('ALL');
+      expect(EquipmentUnitTypeCompatibility.priority).toBe(100);
+    });
+
+    it('EquipmentLocationCompatibility should have correct metadata', () => {
+      expect(EquipmentLocationCompatibility.id).toBe('VAL-EQUIP-UNIT-002');
+      expect(EquipmentLocationCompatibility.name).toBe('Equipment Location Compatibility');
+      expect(EquipmentLocationCompatibility.applicableUnitTypes).toBe('ALL');
+      expect(EquipmentLocationCompatibility.priority).toBe(101);
+    });
+
+    it('TurretMountingRequirements should have correct metadata', () => {
+      expect(TurretMountingRequirements.id).toBe('VAL-EQUIP-UNIT-003');
+      expect(TurretMountingRequirements.name).toBe('Turret Mounting Requirements');
+      expect(TurretMountingRequirements.applicableUnitTypes).toBe('ALL');
+      expect(TurretMountingRequirements.priority).toBe(102);
+    });
+
+    it('IncompatibleEquipmentCheck should have correct metadata', () => {
+      expect(IncompatibleEquipmentCheck.id).toBe('VAL-EQUIP-UNIT-004');
+      expect(IncompatibleEquipmentCheck.name).toBe('Incompatible Equipment Check');
+      expect(IncompatibleEquipmentCheck.applicableUnitTypes).toBe('ALL');
+      expect(IncompatibleEquipmentCheck.priority).toBe(103);
+    });
+
+    it('RequiredEquipmentCheck should have correct metadata', () => {
+      expect(RequiredEquipmentCheck.id).toBe('VAL-EQUIP-UNIT-005');
+      expect(RequiredEquipmentCheck.name).toBe('Required Equipment Check');
+      expect(RequiredEquipmentCheck.applicableUnitTypes).toBe('ALL');
+      expect(RequiredEquipmentCheck.priority).toBe(104);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive unit tests for validation and construction services.

## Changes

| File | Tests | Description |
|------|-------|-------------|
| `CalculationService.test.ts` | 57 | BV, cost, heat profile, movement calculations |
| `EquipmentUnitTypeRules.test.ts` | 61 | Equipment-unit type compatibility validation |
| `VehicleCategoryRules.test.ts` | 56 | Vehicle category validation rules |
| `EquipmentLoaderService.test.ts` | 103 | Equipment loading, filtering, parsing |

**Total: 277 new/improved tests**

## Test Coverage

All tests passing. This is Batch 4 of a multi-batch test coverage improvement effort.

## Testing

```bash
npm test -- --testPathPattern="(CalculationService|EquipmentUnitTypeRules|VehicleCategoryRules|EquipmentLoaderService)" --no-coverage
```