### PR TITLE
test: add service and utility test coverage (Batch 10)

### DIFF
--- a/src/__tests__/helpers/vault/mockRepositories.ts
+++ b/src/__tests__/helpers/vault/mockRepositories.ts
@@ -447,6 +447,15 @@ export class MockOfflineQueueRepository {
     return true;
   }
 
+  async markSending(id: string): Promise<boolean> {
+    const message = this.messages.get(id);
+    if (!message) return false;
+    message.status = 'sending';
+    message.attempts++;
+    message.lastAttemptAt = new Date().toISOString();
+    return true;
+  }
+
   async markSent(id: string): Promise<boolean> {
     const message = this.messages.get(id);
     if (!message) return false;

--- a/src/services/assets/__tests__/MmDataAssetService.test.ts
+++ b/src/services/assets/__tests__/MmDataAssetService.test.ts
@@ -1,0 +1,539 @@
+/**
+ * MmDataAssetService Tests
+ *
+ * Tests for the MegaMek data asset loading service.
+ * Tests cover SVG loading, caching, path generation, and configuration management.
+ */
+
+import { MechLocation } from '@/types/construction/CriticalSlotAllocation';
+
+// We need to mock fetch before importing the service
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Mock DOMParser for parseSVGToPaths tests
+const mockPaths: HTMLElement[] = [];
+const mockQuerySelectorAll = jest.fn(() => mockPaths);
+const mockParseFromString = jest.fn(() => ({
+  querySelectorAll: mockQuerySelectorAll,
+}));
+
+// Create a mock DOMParser constructor
+const MockDOMParser = jest.fn().mockImplementation(() => ({
+  parseFromString: mockParseFromString,
+}));
+// Assign to global (type assertion needed for test environment)
+Object.assign(global, { DOMParser: MockDOMParser });
+
+// Import after mocks are set up
+import {
+  mmDataAssetService,
+  MechConfiguration,
+  PaperSize,
+} from '../MmDataAssetService';
+
+describe('MmDataAssetService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Clear the cache before each test
+    mmDataAssetService.clearCache();
+    
+    // Reset mock paths
+    mockPaths.length = 0;
+  });
+
+  describe('getInstance', () => {
+    it('should return the same instance (singleton)', () => {
+      // The module exports a singleton instance
+      // Just verify it exists and has expected methods
+      expect(mmDataAssetService).toBeDefined();
+      expect(mmDataAssetService.loadSVG).toBeInstanceOf(Function);
+      expect(mmDataAssetService.clearCache).toBeInstanceOf(Function);
+    });
+  });
+
+  describe('getArmorPipPath', () => {
+    it('should generate correct path for HEAD location', () => {
+      const path = mmDataAssetService.getArmorPipPath(MechLocation.HEAD, 9);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_Head_9_Humanoid.svg');
+    });
+
+    it('should generate correct path for CENTER_TORSO location', () => {
+      const path = mmDataAssetService.getArmorPipPath(MechLocation.CENTER_TORSO, 35);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_CT_35_Humanoid.svg');
+    });
+
+    it('should generate correct path for LEFT_TORSO location', () => {
+      const path = mmDataAssetService.getArmorPipPath(MechLocation.LEFT_TORSO, 24);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_LT_24_Humanoid.svg');
+    });
+
+    it('should generate correct path for RIGHT_TORSO location', () => {
+      const path = mmDataAssetService.getArmorPipPath(MechLocation.RIGHT_TORSO, 24);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_RT_24_Humanoid.svg');
+    });
+
+    it('should generate correct path for LEFT_ARM location', () => {
+      const path = mmDataAssetService.getArmorPipPath(MechLocation.LEFT_ARM, 16);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_LArm_16_Humanoid.svg');
+    });
+
+    it('should generate correct path for RIGHT_ARM location', () => {
+      const path = mmDataAssetService.getArmorPipPath(MechLocation.RIGHT_ARM, 16);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_RArm_16_Humanoid.svg');
+    });
+
+    it('should generate correct path for LEFT_LEG location', () => {
+      const path = mmDataAssetService.getArmorPipPath(MechLocation.LEFT_LEG, 20);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_LLeg_20_Humanoid.svg');
+    });
+
+    it('should generate correct path for RIGHT_LEG location', () => {
+      const path = mmDataAssetService.getArmorPipPath(MechLocation.RIGHT_LEG, 20);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_RLeg_20_Humanoid.svg');
+    });
+
+    it('should generate correct path with rear suffix when isRear is true', () => {
+      const path = mmDataAssetService.getArmorPipPath(MechLocation.CENTER_TORSO, 12, true);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_CT_R_12_Humanoid.svg');
+    });
+
+    it('should handle string abbreviation locations (HD)', () => {
+      const path = mmDataAssetService.getArmorPipPath('HD', 9);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_Head_9_Humanoid.svg');
+    });
+
+    it('should handle string abbreviation locations (CT)', () => {
+      const path = mmDataAssetService.getArmorPipPath('CT', 35);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_CT_35_Humanoid.svg');
+    });
+
+    it('should handle string abbreviation locations (LA)', () => {
+      const path = mmDataAssetService.getArmorPipPath('LA', 16);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_LArm_16_Humanoid.svg');
+    });
+
+    it('should handle string abbreviation locations (RA)', () => {
+      const path = mmDataAssetService.getArmorPipPath('RA', 16);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_RArm_16_Humanoid.svg');
+    });
+
+    it('should handle quad mech locations (FLL)', () => {
+      const path = mmDataAssetService.getArmorPipPath('FLL', 10);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_FLL_10_Humanoid.svg');
+    });
+
+    it('should handle quad mech locations (FRONT_LEFT_LEG)', () => {
+      const path = mmDataAssetService.getArmorPipPath(MechLocation.FRONT_LEFT_LEG, 10);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_FLL_10_Humanoid.svg');
+    });
+
+    it('should default to CT for unknown location strings', () => {
+      const path = mmDataAssetService.getArmorPipPath('UNKNOWN', 20);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_CT_20_Humanoid.svg');
+    });
+  });
+
+  describe('getStructurePipPath', () => {
+    it('should generate correct path for 50-ton mech HEAD', () => {
+      const path = mmDataAssetService.getStructurePipPath(50, MechLocation.HEAD);
+      expect(path).toBe('/record-sheets/biped_pips/BipedIS50_HD.svg');
+    });
+
+    it('should generate correct path for 75-ton mech CENTER_TORSO', () => {
+      const path = mmDataAssetService.getStructurePipPath(75, MechLocation.CENTER_TORSO);
+      expect(path).toBe('/record-sheets/biped_pips/BipedIS75_CT.svg');
+    });
+
+    it('should generate correct path for 100-ton mech LEFT_ARM', () => {
+      const path = mmDataAssetService.getStructurePipPath(100, MechLocation.LEFT_ARM);
+      expect(path).toBe('/record-sheets/biped_pips/BipedIS100_LA.svg');
+    });
+
+    it('should handle string abbreviation for location', () => {
+      const path = mmDataAssetService.getStructurePipPath(85, 'RT');
+      expect(path).toBe('/record-sheets/biped_pips/BipedIS85_RT.svg');
+    });
+
+    it('should handle short string abbreviation directly', () => {
+      const path = mmDataAssetService.getStructurePipPath(60, 'LL');
+      expect(path).toBe('/record-sheets/biped_pips/BipedIS60_LL.svg');
+    });
+
+    it('should default to CT abbreviation for unknown locations', () => {
+      const path = mmDataAssetService.getStructurePipPath(45, 'UNKNOWN_LOCATION');
+      expect(path).toBe('/record-sheets/biped_pips/BipedIS45_CT.svg');
+    });
+  });
+
+  describe('getRecordSheetTemplatePath', () => {
+    it('should return biped letter template path by default', () => {
+      const path = mmDataAssetService.getRecordSheetTemplatePath(MechConfiguration.BIPED);
+      expect(path).toBe('/record-sheets/templates_us/mek_biped_default.svg');
+    });
+
+    it('should return biped A4 template path when specified', () => {
+      const path = mmDataAssetService.getRecordSheetTemplatePath(
+        MechConfiguration.BIPED,
+        PaperSize.A4
+      );
+      expect(path).toBe('/record-sheets/templates_iso/mek_biped_default.svg');
+    });
+
+    it('should return quad letter template path', () => {
+      const path = mmDataAssetService.getRecordSheetTemplatePath(MechConfiguration.QUAD);
+      expect(path).toBe('/record-sheets/templates_us/mek_quad_default.svg');
+    });
+
+    it('should return quad A4 template path', () => {
+      const path = mmDataAssetService.getRecordSheetTemplatePath(
+        MechConfiguration.QUAD,
+        PaperSize.A4
+      );
+      expect(path).toBe('/record-sheets/templates_iso/mek_quad_default.svg');
+    });
+
+    it('should return tripod letter template path', () => {
+      const path = mmDataAssetService.getRecordSheetTemplatePath(MechConfiguration.TRIPOD);
+      expect(path).toBe('/record-sheets/templates_us/mek_tripod_default.svg');
+    });
+
+    it('should return LAM letter template path', () => {
+      const path = mmDataAssetService.getRecordSheetTemplatePath(MechConfiguration.LAM);
+      expect(path).toBe('/record-sheets/templates_us/mek_lam_default.svg');
+    });
+
+    it('should return QuadVee letter template path', () => {
+      const path = mmDataAssetService.getRecordSheetTemplatePath(MechConfiguration.QUADVEE);
+      expect(path).toBe('/record-sheets/templates_us/mek_quadvee_default.svg');
+    });
+
+    it('should fallback to biped template for unknown configuration', () => {
+      const path = mmDataAssetService.getRecordSheetTemplatePath(
+        'Unknown' as MechConfiguration
+      );
+      expect(path).toBe('/record-sheets/templates_us/mek_biped_default.svg');
+    });
+  });
+
+  describe('loadSVG', () => {
+    it('should fetch SVG content from path', async () => {
+      const mockSVGContent = '<svg><path d="M0 0"/></svg>';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(mockSVGContent),
+      });
+
+      const result = await mmDataAssetService.loadSVG('/test/path.svg');
+
+      expect(mockFetch).toHaveBeenCalledWith('/test/path.svg');
+      expect(result).toBe(mockSVGContent);
+    });
+
+    it('should throw error when fetch fails', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+
+      await expect(
+        mmDataAssetService.loadSVG('/nonexistent.svg')
+      ).rejects.toThrow('Failed to load SVG: /nonexistent.svg (404)');
+    });
+
+    it('should throw error with different status codes', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      });
+
+      await expect(
+        mmDataAssetService.loadSVG('/server-error.svg')
+      ).rejects.toThrow('Failed to load SVG: /server-error.svg (500)');
+    });
+
+    it('should cache loaded SVG content', async () => {
+      const mockSVGContent = '<svg>cached content</svg>';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(mockSVGContent),
+      });
+
+      // First call
+      await mmDataAssetService.loadSVG('/cached.svg');
+      // Second call should use cache
+      const result = await mmDataAssetService.loadSVG('/cached.svg');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result).toBe(mockSVGContent);
+    });
+
+    it('should return cached content within TTL', async () => {
+      const mockSVGContent = '<svg>ttl test</svg>';
+      mockFetch.mockResolvedValue({
+        ok: true,
+        text: jest.fn().mockResolvedValue(mockSVGContent),
+      });
+
+      await mmDataAssetService.loadSVG('/ttl-test.svg');
+      
+      // Immediately fetch again - should use cache
+      const result = await mmDataAssetService.loadSVG('/ttl-test.svg');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result).toBe(mockSVGContent);
+    });
+  });
+
+  describe('loadArmorPipSVG', () => {
+    it('should load armor pip SVG for a location', async () => {
+      const mockSVGContent = '<svg>armor pips</svg>';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(mockSVGContent),
+      });
+
+      const result = await mmDataAssetService.loadArmorPipSVG(MechLocation.HEAD, 9);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/record-sheets/biped_pips/Armor_Head_9_Humanoid.svg'
+      );
+      expect(result).toBe(mockSVGContent);
+    });
+
+    it('should load rear armor pip SVG when isRear is true', async () => {
+      const mockSVGContent = '<svg>rear armor</svg>';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(mockSVGContent),
+      });
+
+      await mmDataAssetService.loadArmorPipSVG(MechLocation.CENTER_TORSO, 12, true);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/record-sheets/biped_pips/Armor_CT_R_12_Humanoid.svg'
+      );
+    });
+  });
+
+  describe('loadStructurePipSVG', () => {
+    it('should load structure pip SVG for a tonnage and location', async () => {
+      const mockSVGContent = '<svg>structure pips</svg>';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(mockSVGContent),
+      });
+
+      const result = await mmDataAssetService.loadStructurePipSVG(75, MechLocation.CENTER_TORSO);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/record-sheets/biped_pips/BipedIS75_CT.svg'
+      );
+      expect(result).toBe(mockSVGContent);
+    });
+  });
+
+  describe('loadRecordSheetTemplate', () => {
+    it('should load record sheet template with default paper size', async () => {
+      const mockSVGContent = '<svg>biped template</svg>';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(mockSVGContent),
+      });
+
+      const result = await mmDataAssetService.loadRecordSheetTemplate(MechConfiguration.BIPED);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/record-sheets/templates_us/mek_biped_default.svg'
+      );
+      expect(result).toBe(mockSVGContent);
+    });
+
+    it('should load record sheet template with A4 paper size', async () => {
+      const mockSVGContent = '<svg>A4 template</svg>';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(mockSVGContent),
+      });
+
+      await mmDataAssetService.loadRecordSheetTemplate(MechConfiguration.QUAD, PaperSize.A4);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/record-sheets/templates_iso/mek_quad_default.svg'
+      );
+    });
+  });
+
+  describe('preloadConfiguration', () => {
+    it('should preload template and structure pips for biped configuration', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        text: jest.fn().mockResolvedValue('<svg></svg>'),
+      });
+
+      await mmDataAssetService.preloadConfiguration(MechConfiguration.BIPED, 50);
+
+      // Should have called for template + 8 biped locations
+      // Template + structure pips for each location
+      expect(mockFetch).toHaveBeenCalled();
+      
+      // Check template was loaded
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/record-sheets/templates_us/mek_biped_default.svg'
+      );
+    });
+
+    it('should preload with A4 paper size', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        text: jest.fn().mockResolvedValue('<svg></svg>'),
+      });
+
+      await mmDataAssetService.preloadConfiguration(
+        MechConfiguration.BIPED,
+        50,
+        PaperSize.A4
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/record-sheets/templates_iso/mek_biped_default.svg'
+      );
+    });
+
+    it('should handle failed structure pip loads gracefully', async () => {
+      // Template succeeds, structure pips fail
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          text: jest.fn().mockResolvedValue('<svg>template</svg>'),
+        })
+        .mockRejectedValue(new Error('Failed to load'));
+
+      // Should not throw
+      await expect(
+        mmDataAssetService.preloadConfiguration(MechConfiguration.BIPED, 50)
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getLocationsForConfiguration', () => {
+    it('should return biped locations for BIPED configuration', () => {
+      const locations = mmDataAssetService.getLocationsForConfiguration(MechConfiguration.BIPED);
+      
+      expect(locations).toContain(MechLocation.HEAD);
+      expect(locations).toContain(MechLocation.CENTER_TORSO);
+      expect(locations).toContain(MechLocation.LEFT_ARM);
+      expect(locations).toContain(MechLocation.RIGHT_ARM);
+      expect(locations).toContain(MechLocation.LEFT_LEG);
+      expect(locations).toContain(MechLocation.RIGHT_LEG);
+      expect(locations).toHaveLength(8);
+    });
+
+    it('should return quad locations for QUAD configuration', () => {
+      const locations = mmDataAssetService.getLocationsForConfiguration(MechConfiguration.QUAD);
+      
+      expect(locations).toContain(MechLocation.HEAD);
+      expect(locations).toContain(MechLocation.CENTER_TORSO);
+      expect(locations).toContain(MechLocation.FRONT_LEFT_LEG);
+      expect(locations).toContain(MechLocation.FRONT_RIGHT_LEG);
+      expect(locations).toContain(MechLocation.REAR_LEFT_LEG);
+      expect(locations).toContain(MechLocation.REAR_RIGHT_LEG);
+      expect(locations).toHaveLength(8);
+    });
+
+    it('should return tripod locations for TRIPOD configuration', () => {
+      const locations = mmDataAssetService.getLocationsForConfiguration(MechConfiguration.TRIPOD);
+      
+      expect(locations).toContain(MechLocation.CENTER_LEG);
+      expect(locations).toHaveLength(9);
+    });
+
+    it('should return LAM locations for LAM configuration', () => {
+      const locations = mmDataAssetService.getLocationsForConfiguration(MechConfiguration.LAM);
+      
+      expect(locations).toContain(MechLocation.HEAD);
+      expect(locations).toContain(MechLocation.LEFT_ARM);
+      expect(locations).toHaveLength(8);
+    });
+
+    it('should return QuadVee locations for QUADVEE configuration', () => {
+      const locations = mmDataAssetService.getLocationsForConfiguration(MechConfiguration.QUADVEE);
+      
+      expect(locations).toContain(MechLocation.FRONT_LEFT_LEG);
+      expect(locations).toHaveLength(8);
+    });
+  });
+
+  describe('parseSVGToPaths', () => {
+    it('should parse SVG content and return path elements', () => {
+      const mockPath1 = { outerHTML: '<path d="M0 0 L10 10"/>' } as Pick<HTMLElement, 'outerHTML'>;
+      const mockPath2 = { outerHTML: '<path d="M5 5 L15 15"/>' } as Pick<HTMLElement, 'outerHTML'>;
+      mockPaths.push(mockPath1 as HTMLElement);
+      mockPaths.push(mockPath2 as HTMLElement);
+
+      const paths = mmDataAssetService.parseSVGToPaths('<svg><path/><path/></svg>');
+
+      expect(mockParseFromString).toHaveBeenCalledWith(
+        '<svg><path/><path/></svg>',
+        'image/svg+xml'
+      );
+      expect(paths).toHaveLength(2);
+      expect(paths[0]).toBe('<path d="M0 0 L10 10"/>');
+      expect(paths[1]).toBe('<path d="M5 5 L15 15"/>');
+    });
+
+    it('should return empty array when no paths found', () => {
+      // mockPaths is already empty
+      const paths = mmDataAssetService.parseSVGToPaths('<svg></svg>');
+
+      expect(paths).toHaveLength(0);
+    });
+  });
+
+  describe('clearCache', () => {
+    it('should clear cached SVG content', async () => {
+      const mockSVGContent = '<svg>cached</svg>';
+      mockFetch.mockResolvedValue({
+        ok: true,
+        text: jest.fn().mockResolvedValue(mockSVGContent),
+      });
+
+      // Load and cache
+      await mmDataAssetService.loadSVG('/to-clear.svg');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // Clear cache
+      mmDataAssetService.clearCache();
+
+      // Load again - should fetch
+      await mmDataAssetService.loadSVG('/to-clear.svg');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle center leg location for tripod', () => {
+      const path = mmDataAssetService.getArmorPipPath(MechLocation.CENTER_LEG, 15);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_CL_15_Humanoid.svg');
+    });
+
+    it('should handle all quad leg locations', () => {
+      expect(mmDataAssetService.getArmorPipPath(MechLocation.FRONT_RIGHT_LEG, 10))
+        .toBe('/record-sheets/biped_pips/Armor_FRL_10_Humanoid.svg');
+      expect(mmDataAssetService.getArmorPipPath(MechLocation.REAR_LEFT_LEG, 10))
+        .toBe('/record-sheets/biped_pips/Armor_RLL_10_Humanoid.svg');
+      expect(mmDataAssetService.getArmorPipPath(MechLocation.REAR_RIGHT_LEG, 10))
+        .toBe('/record-sheets/biped_pips/Armor_RRL_10_Humanoid.svg');
+    });
+
+    it('should handle zero armor count', () => {
+      const path = mmDataAssetService.getArmorPipPath(MechLocation.HEAD, 0);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_Head_0_Humanoid.svg');
+    });
+
+    it('should handle high armor counts', () => {
+      const path = mmDataAssetService.getArmorPipPath(MechLocation.CENTER_TORSO, 99);
+      expect(path).toBe('/record-sheets/biped_pips/Armor_CT_99_Humanoid.svg');
+    });
+  });
+});

--- a/src/services/printing/recordsheet/__tests__/equipmentUtils.test.ts
+++ b/src/services/printing/recordsheet/__tests__/equipmentUtils.test.ts
@@ -1,0 +1,509 @@
+/**
+ * Equipment Utilities Tests
+ *
+ * Tests for weapon lookup, damage calculation, and equipment classification
+ * helper functions used in record sheet generation.
+ */
+
+import {
+  getDamageCode,
+  formatMissileDamage,
+  lookupWeapon,
+  isUnhittableEquipmentName,
+} from '../equipmentUtils';
+import { WeaponCategory, IWeapon } from '@/types/equipment';
+import { TechBase } from '@/types/enums/TechBase';
+import { RulesLevel } from '@/types/enums/RulesLevel';
+
+/**
+ * Helper to create a mock weapon for testing
+ */
+function createMockWeapon(overrides: Partial<IWeapon> = {}): IWeapon {
+  return {
+    id: 'test-weapon',
+    name: 'Test Weapon',
+    category: WeaponCategory.ENERGY,
+    subType: 'Laser',
+    techBase: TechBase.INNER_SPHERE,
+    rulesLevel: RulesLevel.INTRODUCTORY,
+    damage: 5,
+    heat: 3,
+    ranges: {
+      minimum: 0,
+      short: 3,
+      medium: 6,
+      long: 9,
+    },
+    weight: 1,
+    criticalSlots: 1,
+    costCBills: 40000,
+    battleValue: 46,
+    introductionYear: 2400,
+    ...overrides,
+  };
+}
+
+describe('equipmentUtils', () => {
+  describe('getDamageCode', () => {
+    it('should return [DE] for ENERGY weapons', () => {
+      expect(getDamageCode(WeaponCategory.ENERGY)).toBe('[DE]');
+    });
+
+    it('should return [DB] for BALLISTIC weapons', () => {
+      expect(getDamageCode(WeaponCategory.BALLISTIC)).toBe('[DB]');
+    });
+
+    it('should return [M,C,S] for MISSILE weapons', () => {
+      expect(getDamageCode(WeaponCategory.MISSILE)).toBe('[M,C,S]');
+    });
+
+    it('should return [AE] for ARTILLERY weapons', () => {
+      expect(getDamageCode(WeaponCategory.ARTILLERY)).toBe('[AE]');
+    });
+
+    it('should return [P] for PHYSICAL weapons', () => {
+      expect(getDamageCode(WeaponCategory.PHYSICAL)).toBe('[P]');
+    });
+
+    it('should return empty string for unknown category', () => {
+      expect(getDamageCode('UNKNOWN' as WeaponCategory)).toBe('');
+    });
+  });
+
+  describe('formatMissileDamage', () => {
+    describe('LRM damage formatting', () => {
+      it('should return 1/Msl for LRM-5', () => {
+        expect(formatMissileDamage('LRM-5', 5)).toBe('1/Msl');
+      });
+
+      it('should return 1/Msl for LRM-10', () => {
+        expect(formatMissileDamage('LRM-10', 10)).toBe('1/Msl');
+      });
+
+      it('should return 1/Msl for LRM-15', () => {
+        expect(formatMissileDamage('LRM-15', 15)).toBe('1/Msl');
+      });
+
+      it('should return 1/Msl for LRM-20', () => {
+        expect(formatMissileDamage('LRM-20', 20)).toBe('1/Msl');
+      });
+
+      it('should return 1/Msl for case-insensitive lrm', () => {
+        expect(formatMissileDamage('lrm-5', 5)).toBe('1/Msl');
+      });
+
+      it('should return 1/Msl for Extended Range LRM', () => {
+        expect(formatMissileDamage('ER LRM-5', 5)).toBe('1/Msl');
+      });
+    });
+
+    describe('SRM damage formatting', () => {
+      it('should return 2/Msl for SRM-2', () => {
+        expect(formatMissileDamage('SRM-2', 4)).toBe('2/Msl');
+      });
+
+      it('should return 2/Msl for SRM-4', () => {
+        expect(formatMissileDamage('SRM-4', 8)).toBe('2/Msl');
+      });
+
+      it('should return 2/Msl for SRM-6', () => {
+        expect(formatMissileDamage('SRM-6', 12)).toBe('2/Msl');
+      });
+
+      it('should return 2/Msl for case-insensitive srm', () => {
+        expect(formatMissileDamage('srm-4', 8)).toBe('2/Msl');
+      });
+    });
+
+    describe('Streak SRM damage formatting', () => {
+      it('should return 2/Msl for Streak SRM-2', () => {
+        expect(formatMissileDamage('Streak SRM-2', 4)).toBe('2/Msl');
+      });
+
+      it('should return 2/Msl for Streak SRM-4', () => {
+        expect(formatMissileDamage('Streak SRM-4', 8)).toBe('2/Msl');
+      });
+
+      it('should return 2/Msl for Streak SRM-6', () => {
+        expect(formatMissileDamage('Streak SRM-6', 12)).toBe('2/Msl');
+      });
+
+      it('should handle lowercase streak srm', () => {
+        expect(formatMissileDamage('streak srm-4', 8)).toBe('2/Msl');
+      });
+    });
+
+    describe('MRM damage formatting', () => {
+      it('should return 1/Msl for MRM-10', () => {
+        expect(formatMissileDamage('MRM-10', 10)).toBe('1/Msl');
+      });
+
+      it('should return 1/Msl for MRM-20', () => {
+        expect(formatMissileDamage('MRM-20', 20)).toBe('1/Msl');
+      });
+
+      it('should return 1/Msl for MRM-30', () => {
+        expect(formatMissileDamage('MRM-30', 30)).toBe('1/Msl');
+      });
+
+      it('should return 1/Msl for MRM-40', () => {
+        expect(formatMissileDamage('MRM-40', 40)).toBe('1/Msl');
+      });
+
+      it('should handle lowercase mrm', () => {
+        expect(formatMissileDamage('mrm-20', 20)).toBe('1/Msl');
+      });
+    });
+
+    describe('ATM damage formatting', () => {
+      it('should return 2/Msl for ATM-3', () => {
+        expect(formatMissileDamage('ATM-3', 6)).toBe('2/Msl');
+      });
+
+      it('should return 2/Msl for ATM-6', () => {
+        expect(formatMissileDamage('ATM-6', 12)).toBe('2/Msl');
+      });
+
+      it('should return 2/Msl for ATM-9', () => {
+        expect(formatMissileDamage('ATM-9', 18)).toBe('2/Msl');
+      });
+
+      it('should return 2/Msl for ATM-12', () => {
+        expect(formatMissileDamage('ATM-12', 24)).toBe('2/Msl');
+      });
+
+      it('should handle lowercase atm', () => {
+        expect(formatMissileDamage('atm-6', 12)).toBe('2/Msl');
+      });
+    });
+
+    describe('Non-missile weapons', () => {
+      it('should return base damage for Medium Laser', () => {
+        expect(formatMissileDamage('Medium Laser', 5)).toBe('5');
+      });
+
+      it('should return base damage for Large Laser', () => {
+        expect(formatMissileDamage('Large Laser', 8)).toBe('8');
+      });
+
+      it('should return base damage for PPC', () => {
+        expect(formatMissileDamage('PPC', 10)).toBe('10');
+      });
+
+      it('should return base damage for AC/10', () => {
+        expect(formatMissileDamage('AC/10', 10)).toBe('10');
+      });
+
+      it('should handle string damage values', () => {
+        expect(formatMissileDamage('Flamer', '2 Heat')).toBe('2 Heat');
+      });
+
+      it('should handle zero damage', () => {
+        expect(formatMissileDamage('NARC', 0)).toBe('0');
+      });
+    });
+  });
+
+  describe('lookupWeapon', () => {
+    const mockWeapons: IWeapon[] = [
+      createMockWeapon({ id: 'medium-laser', name: 'Medium Laser' }),
+      createMockWeapon({ id: 'large-laser', name: 'Large Laser', damage: 8 }),
+      createMockWeapon({ id: 'ppc', name: 'PPC', damage: 10 }),
+      createMockWeapon({ id: 'er-large-laser', name: 'ER Large Laser', damage: 10 }),
+      createMockWeapon({ id: 'lrm-20', name: 'LRM-20', category: WeaponCategory.MISSILE }),
+    ];
+
+    describe('ID-based lookup', () => {
+      it('should find weapon by exact ID', () => {
+        const result = lookupWeapon(mockWeapons, 'any-name', 'medium-laser');
+        expect(result).toBeDefined();
+        expect(result?.id).toBe('medium-laser');
+      });
+
+      it('should prioritize ID over name', () => {
+        const result = lookupWeapon(mockWeapons, 'Large Laser', 'ppc');
+        expect(result?.id).toBe('ppc');
+      });
+
+      it('should return undefined for non-existent ID', () => {
+        const result = lookupWeapon(mockWeapons, 'Medium Laser', 'nonexistent-id');
+        // Falls back to name lookup
+        expect(result?.id).toBe('medium-laser');
+      });
+    });
+
+    describe('Name-based lookup', () => {
+      it('should find weapon by exact name', () => {
+        const result = lookupWeapon(mockWeapons, 'Medium Laser');
+        expect(result).toBeDefined();
+        expect(result?.name).toBe('Medium Laser');
+      });
+
+      it('should find weapon by case-insensitive name', () => {
+        const result = lookupWeapon(mockWeapons, 'medium laser');
+        expect(result).toBeDefined();
+        expect(result?.name).toBe('Medium Laser');
+      });
+
+      it('should find weapon by uppercase name', () => {
+        const result = lookupWeapon(mockWeapons, 'MEDIUM LASER');
+        expect(result).toBeDefined();
+        expect(result?.name).toBe('Medium Laser');
+      });
+
+      it('should find weapon by partial match (name contains search)', () => {
+        const result = lookupWeapon(mockWeapons, 'Large');
+        expect(result).toBeDefined();
+        // Should match "Large Laser" which contains "Large"
+        expect(result?.name).toContain('Large');
+      });
+
+      it('should find weapon by partial match (search contains name)', () => {
+        // This tests the inverse partial match
+        const result = lookupWeapon(mockWeapons, 'PPC Standard');
+        expect(result).toBeDefined();
+        expect(result?.name).toBe('PPC');
+      });
+    });
+
+    describe('Edge cases', () => {
+      it('should return undefined for empty weapons array', () => {
+        const result = lookupWeapon([], 'Medium Laser');
+        expect(result).toBeUndefined();
+      });
+
+      it('should return undefined when no match found', () => {
+        const result = lookupWeapon(mockWeapons, 'Gauss Rifle');
+        expect(result).toBeUndefined();
+      });
+
+      it('should return first match for ambiguous partial matches', () => {
+        // Both "Large Laser" and "ER Large Laser" contain "Large"
+        const result = lookupWeapon(mockWeapons, 'Large');
+        expect(result).toBeDefined();
+      });
+
+      it('should handle empty search string', () => {
+        const result = lookupWeapon(mockWeapons, '');
+        // Partial match should work - every name contains empty string
+        expect(result).toBeDefined();
+      });
+
+      it('should handle undefined ID gracefully', () => {
+        const result = lookupWeapon(mockWeapons, 'LRM-20', undefined);
+        expect(result).toBeDefined();
+        expect(result?.name).toBe('LRM-20');
+      });
+    });
+  });
+
+  describe('isUnhittableEquipmentName', () => {
+    describe('Endo Steel variants', () => {
+      it('should return true for "Endo Steel"', () => {
+        expect(isUnhittableEquipmentName('Endo Steel')).toBe(true);
+      });
+
+      it('should return true for "Endo-Steel"', () => {
+        expect(isUnhittableEquipmentName('Endo-Steel')).toBe(true);
+      });
+
+      it('should return true for "Endo Steel (Clan)"', () => {
+        expect(isUnhittableEquipmentName('Endo Steel (Clan)')).toBe(true);
+      });
+
+      it('should return true for lowercase "endo steel"', () => {
+        expect(isUnhittableEquipmentName('endo steel')).toBe(true);
+      });
+
+      it('should return true for "Endo-Composite"', () => {
+        expect(isUnhittableEquipmentName('Endo-Steel Composite')).toBe(true);
+      });
+    });
+
+    describe('Ferro-Fibrous variants', () => {
+      it('should return true for "Ferro-Fibrous"', () => {
+        expect(isUnhittableEquipmentName('Ferro-Fibrous')).toBe(true);
+      });
+
+      it('should return true for "Ferro Fibrous"', () => {
+        expect(isUnhittableEquipmentName('Ferro Fibrous')).toBe(true);
+      });
+
+      it('should return true for "Ferro-Fibrous (Clan)"', () => {
+        expect(isUnhittableEquipmentName('Ferro-Fibrous (Clan)')).toBe(true);
+      });
+
+      it('should return true for "Heavy Ferro-Fibrous"', () => {
+        expect(isUnhittableEquipmentName('Heavy Ferro-Fibrous')).toBe(true);
+      });
+
+      it('should return true for "Light Ferro-Fibrous"', () => {
+        expect(isUnhittableEquipmentName('Light Ferro-Fibrous')).toBe(true);
+      });
+
+      it('should return true for lowercase "ferro-fibrous"', () => {
+        expect(isUnhittableEquipmentName('ferro-fibrous')).toBe(true);
+      });
+    });
+
+    describe('Triple Strength Myomer variants', () => {
+      it('should return true for "Triple Strength Myomer"', () => {
+        expect(isUnhittableEquipmentName('Triple Strength Myomer')).toBe(true);
+      });
+
+      it('should return true for "TSM"', () => {
+        expect(isUnhittableEquipmentName('TSM')).toBe(true);
+      });
+
+      it('should return true for lowercase "tsm"', () => {
+        expect(isUnhittableEquipmentName('tsm')).toBe(true);
+      });
+
+      it('should return true for "Industrial TSM"', () => {
+        expect(isUnhittableEquipmentName('Industrial TSM')).toBe(true);
+      });
+
+      it('should return true for generic "Myomer" (non-standard)', () => {
+        expect(isUnhittableEquipmentName('Enhanced Myomer')).toBe(true);
+      });
+
+      it('should return false for "Standard Myomer"', () => {
+        expect(isUnhittableEquipmentName('Standard Myomer')).toBe(false);
+      });
+    });
+
+    describe('Stealth armor', () => {
+      it('should return true for "Stealth Armor"', () => {
+        expect(isUnhittableEquipmentName('Stealth Armor')).toBe(true);
+      });
+
+      it('should return true for "Stealth"', () => {
+        expect(isUnhittableEquipmentName('Stealth')).toBe(true);
+      });
+
+      it('should return true for lowercase "stealth armor"', () => {
+        expect(isUnhittableEquipmentName('stealth armor')).toBe(true);
+      });
+    });
+
+    describe('Reactive armor', () => {
+      it('should return true for "Reactive Armor"', () => {
+        expect(isUnhittableEquipmentName('Reactive Armor')).toBe(true);
+      });
+
+      it('should return true for "Reactive"', () => {
+        expect(isUnhittableEquipmentName('Reactive')).toBe(true);
+      });
+
+      it('should return true for lowercase "reactive"', () => {
+        expect(isUnhittableEquipmentName('reactive')).toBe(true);
+      });
+    });
+
+    describe('Reflective armor', () => {
+      it('should return true for "Reflective Armor"', () => {
+        expect(isUnhittableEquipmentName('Reflective Armor')).toBe(true);
+      });
+
+      it('should return true for "Reflective"', () => {
+        expect(isUnhittableEquipmentName('Reflective')).toBe(true);
+      });
+
+      it('should return true for lowercase "reflective"', () => {
+        expect(isUnhittableEquipmentName('reflective')).toBe(true);
+      });
+    });
+
+    describe('Blue Shield', () => {
+      it('should return true for "Blue Shield Particle Field Damper"', () => {
+        expect(isUnhittableEquipmentName('Blue Shield Particle Field Damper')).toBe(true);
+      });
+
+      it('should return true for "Blue Shield"', () => {
+        expect(isUnhittableEquipmentName('Blue Shield')).toBe(true);
+      });
+
+      it('should return true for lowercase "blue shield"', () => {
+        expect(isUnhittableEquipmentName('blue shield')).toBe(true);
+      });
+    });
+
+    describe('Hittable equipment (should return false)', () => {
+      it('should return false for "Medium Laser"', () => {
+        expect(isUnhittableEquipmentName('Medium Laser')).toBe(false);
+      });
+
+      it('should return false for "PPC"', () => {
+        expect(isUnhittableEquipmentName('PPC')).toBe(false);
+      });
+
+      it('should return false for "SRM-6"', () => {
+        expect(isUnhittableEquipmentName('SRM-6')).toBe(false);
+      });
+
+      it('should return false for "LRM-20"', () => {
+        expect(isUnhittableEquipmentName('LRM-20')).toBe(false);
+      });
+
+      it('should return false for "AC/10"', () => {
+        expect(isUnhittableEquipmentName('AC/10')).toBe(false);
+      });
+
+      it('should return false for "Heat Sink"', () => {
+        expect(isUnhittableEquipmentName('Heat Sink')).toBe(false);
+      });
+
+      it('should return false for "Double Heat Sink"', () => {
+        expect(isUnhittableEquipmentName('Double Heat Sink')).toBe(false);
+      });
+
+      it('should return false for "Jump Jet"', () => {
+        expect(isUnhittableEquipmentName('Jump Jet')).toBe(false);
+      });
+
+      it('should return false for "CASE"', () => {
+        expect(isUnhittableEquipmentName('CASE')).toBe(false);
+      });
+
+      it('should return false for "MASC"', () => {
+        expect(isUnhittableEquipmentName('MASC')).toBe(false);
+      });
+
+      it('should return false for "Targeting Computer"', () => {
+        expect(isUnhittableEquipmentName('Targeting Computer')).toBe(false);
+      });
+
+      it('should return false for "Fusion Engine"', () => {
+        expect(isUnhittableEquipmentName('Fusion Engine')).toBe(false);
+      });
+
+      it('should return false for "Gyro"', () => {
+        expect(isUnhittableEquipmentName('Gyro')).toBe(false);
+      });
+
+      it('should return false for "Cockpit"', () => {
+        expect(isUnhittableEquipmentName('Cockpit')).toBe(false);
+      });
+
+      it('should return false for "Standard Armor"', () => {
+        expect(isUnhittableEquipmentName('Standard Armor')).toBe(false);
+      });
+
+      it('should return false for "Standard Structure"', () => {
+        expect(isUnhittableEquipmentName('Standard Structure')).toBe(false);
+      });
+
+      it('should return false for empty string', () => {
+        expect(isUnhittableEquipmentName('')).toBe(false);
+      });
+
+      it('should return false for "Shoulder"', () => {
+        expect(isUnhittableEquipmentName('Shoulder')).toBe(false);
+      });
+
+      it('should return false for "Upper Arm Actuator"', () => {
+        expect(isUnhittableEquipmentName('Upper Arm Actuator')).toBe(false);
+      });
+    });
+  });
+});

--- a/src/services/validation/__tests__/initializeUnitValidation.test.ts
+++ b/src/services/validation/__tests__/initializeUnitValidation.test.ts
@@ -1,0 +1,427 @@
+/**
+ * Unit Validation Initialization Tests
+ *
+ * Comprehensive tests for validation rule initialization and registration.
+ *
+ * @spec openspec/specs/unit-validation-framework/spec.md
+ */
+
+import {
+  initializeUnitValidationRules,
+  getValidationRuleStats,
+  resetUnitValidationRules,
+  areRulesInitialized,
+} from '../initializeUnitValidation';
+import { getUnitValidationRegistry } from '../UnitValidationRegistry';
+import { UnitCategory } from '../../../types/validation/UnitValidationInterfaces';
+import { UnitType } from '../../../types/unit/BattleMechInterfaces';
+
+// Import rule sets to verify counts
+import { UNIVERSAL_VALIDATION_RULES } from '../rules/universal/UniversalValidationRules';
+import { MECH_CATEGORY_RULES } from '../rules/mech/MechCategoryRules';
+import { VEHICLE_CATEGORY_RULES } from '../rules/vehicle/VehicleCategoryRules';
+import { AEROSPACE_CATEGORY_RULES } from '../rules/aerospace/AerospaceCategoryRules';
+import { PERSONNEL_CATEGORY_RULES } from '../rules/personnel/PersonnelCategoryRules';
+import { BATTLEMECH_RULES } from '../rules/battlemech/BattleMechRules';
+import { EQUIPMENT_UNIT_TYPE_RULES } from '../rules/equipment/EquipmentUnitTypeRules';
+
+// =============================================================================
+// Setup and Teardown
+// =============================================================================
+
+describe('Unit Validation Initialization', () => {
+  beforeEach(() => {
+    // Reset state before each test
+    resetUnitValidationRules();
+  });
+
+  afterEach(() => {
+    // Clean up after each test
+    resetUnitValidationRules();
+  });
+
+  // =============================================================================
+  // areRulesInitialized Tests
+  // =============================================================================
+
+  describe('areRulesInitialized', () => {
+    it('should return false before initialization', () => {
+      expect(areRulesInitialized()).toBe(false);
+    });
+
+    it('should return true after initialization', () => {
+      initializeUnitValidationRules();
+
+      expect(areRulesInitialized()).toBe(true);
+    });
+
+    it('should return false after reset', () => {
+      initializeUnitValidationRules();
+      resetUnitValidationRules();
+
+      expect(areRulesInitialized()).toBe(false);
+    });
+  });
+
+  // =============================================================================
+  // initializeUnitValidationRules Tests
+  // =============================================================================
+
+  describe('initializeUnitValidationRules', () => {
+    it('should initialize all rules successfully', () => {
+      expect(() => initializeUnitValidationRules()).not.toThrow();
+      expect(areRulesInitialized()).toBe(true);
+    });
+
+    it('should be idempotent - multiple calls should not re-register rules', () => {
+      initializeUnitValidationRules();
+      const firstStats = getValidationRuleStats();
+
+      initializeUnitValidationRules();
+      const secondStats = getValidationRuleStats();
+
+      expect(secondStats.total).toBe(firstStats.total);
+      expect(secondStats.universal).toBe(firstStats.universal);
+      expect(secondStats.mech).toBe(firstStats.mech);
+    });
+
+    it('should register universal rules', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+      const universalRules = registry.getUniversalRules();
+
+      // Universal rules count should match expected
+      expect(universalRules.length).toBeGreaterThanOrEqual(UNIVERSAL_VALIDATION_RULES.length);
+    });
+
+    it('should register mech category rules', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+      const mechRules = registry.getCategoryRules(UnitCategory.MECH);
+
+      expect(mechRules.length).toBeGreaterThanOrEqual(MECH_CATEGORY_RULES.length);
+    });
+
+    it('should register vehicle category rules', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+      const vehicleRules = registry.getCategoryRules(UnitCategory.VEHICLE);
+
+      expect(vehicleRules.length).toBeGreaterThanOrEqual(VEHICLE_CATEGORY_RULES.length);
+    });
+
+    it('should register aerospace category rules', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+      const aerospaceRules = registry.getCategoryRules(UnitCategory.AEROSPACE);
+
+      expect(aerospaceRules.length).toBeGreaterThanOrEqual(AEROSPACE_CATEGORY_RULES.length);
+    });
+
+    it('should register personnel category rules', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+      const personnelRules = registry.getCategoryRules(UnitCategory.PERSONNEL);
+
+      expect(personnelRules.length).toBeGreaterThanOrEqual(PERSONNEL_CATEGORY_RULES.length);
+    });
+
+    it('should register BattleMech unit type rules', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+      const battlemechRules = registry.getUnitTypeRules(UnitType.BATTLEMECH);
+
+      expect(battlemechRules.length).toBeGreaterThanOrEqual(BATTLEMECH_RULES.length);
+    });
+
+    it('should register OmniMech unit type rules (same as BattleMech)', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+      const omnimechRules = registry.getUnitTypeRules(UnitType.OMNIMECH);
+
+      // OmniMech should have same BattleMech rules
+      expect(omnimechRules.length).toBeGreaterThanOrEqual(BATTLEMECH_RULES.length);
+    });
+
+    it('should register equipment rules as universal', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+      const universalRules = registry.getUniversalRules();
+
+      // Equipment rules are registered as universal
+      const hasEquipmentRules = EQUIPMENT_UNIT_TYPE_RULES.every(equipRule =>
+        universalRules.some(r => r.id === equipRule.id)
+      );
+      expect(hasEquipmentRules).toBe(true);
+    });
+  });
+
+  // =============================================================================
+  // getValidationRuleStats Tests
+  // =============================================================================
+
+  describe('getValidationRuleStats', () => {
+    it('should return stats matching imported rule arrays', () => {
+      const stats = getValidationRuleStats();
+
+      expect(stats.universal).toBe(UNIVERSAL_VALIDATION_RULES.length);
+      expect(stats.mech).toBe(MECH_CATEGORY_RULES.length);
+      expect(stats.battlemech).toBe(BATTLEMECH_RULES.length);
+      expect(stats.vehicle).toBe(VEHICLE_CATEGORY_RULES.length);
+      expect(stats.aerospace).toBe(AEROSPACE_CATEGORY_RULES.length);
+      expect(stats.personnel).toBe(PERSONNEL_CATEGORY_RULES.length);
+      expect(stats.equipment).toBe(EQUIPMENT_UNIT_TYPE_RULES.length);
+    });
+
+    it('should calculate correct total', () => {
+      const stats = getValidationRuleStats();
+
+      const expectedTotal =
+        UNIVERSAL_VALIDATION_RULES.length +
+        MECH_CATEGORY_RULES.length +
+        BATTLEMECH_RULES.length +
+        VEHICLE_CATEGORY_RULES.length +
+        AEROSPACE_CATEGORY_RULES.length +
+        PERSONNEL_CATEGORY_RULES.length +
+        EQUIPMENT_UNIT_TYPE_RULES.length;
+
+      expect(stats.total).toBe(expectedTotal);
+    });
+
+    it('should return same stats before and after initialization', () => {
+      const beforeStats = getValidationRuleStats();
+      initializeUnitValidationRules();
+      const afterStats = getValidationRuleStats();
+
+      // Stats are based on imported arrays, not registry state
+      expect(afterStats.universal).toBe(beforeStats.universal);
+      expect(afterStats.mech).toBe(beforeStats.mech);
+      expect(afterStats.total).toBe(beforeStats.total);
+    });
+
+    it('should return positive counts for all categories', () => {
+      const stats = getValidationRuleStats();
+
+      expect(stats.universal).toBeGreaterThan(0);
+      expect(stats.mech).toBeGreaterThanOrEqual(0);
+      expect(stats.battlemech).toBeGreaterThanOrEqual(0);
+      expect(stats.vehicle).toBeGreaterThanOrEqual(0);
+      expect(stats.aerospace).toBeGreaterThanOrEqual(0);
+      expect(stats.personnel).toBeGreaterThanOrEqual(0);
+      expect(stats.equipment).toBeGreaterThanOrEqual(0);
+      expect(stats.total).toBeGreaterThan(0);
+    });
+  });
+
+  // =============================================================================
+  // resetUnitValidationRules Tests
+  // =============================================================================
+
+  describe('resetUnitValidationRules', () => {
+    it('should reset initialization flag', () => {
+      initializeUnitValidationRules();
+      expect(areRulesInitialized()).toBe(true);
+
+      resetUnitValidationRules();
+
+      expect(areRulesInitialized()).toBe(false);
+    });
+
+    it('should clear the registry', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+
+      // Verify rules exist before reset
+      const rulesBeforeReset = registry.getUniversalRules();
+      expect(rulesBeforeReset.length).toBeGreaterThan(0);
+
+      resetUnitValidationRules();
+
+      // Verify rules are cleared after reset
+      const rulesAfterReset = registry.getUniversalRules();
+      expect(rulesAfterReset.length).toBe(0);
+    });
+
+    it('should allow re-initialization after reset', () => {
+      initializeUnitValidationRules();
+      resetUnitValidationRules();
+
+      expect(() => initializeUnitValidationRules()).not.toThrow();
+      expect(areRulesInitialized()).toBe(true);
+    });
+
+    it('should restore registry to initial state', () => {
+      initializeUnitValidationRules();
+      resetUnitValidationRules();
+
+      const registry = getUnitValidationRegistry();
+
+      expect(registry.getUniversalRules().length).toBe(0);
+      expect(registry.getCategoryRules(UnitCategory.MECH).length).toBe(0);
+      expect(registry.getCategoryRules(UnitCategory.VEHICLE).length).toBe(0);
+      expect(registry.getCategoryRules(UnitCategory.AEROSPACE).length).toBe(0);
+      expect(registry.getCategoryRules(UnitCategory.PERSONNEL).length).toBe(0);
+      expect(registry.getUnitTypeRules(UnitType.BATTLEMECH).length).toBe(0);
+      expect(registry.getUnitTypeRules(UnitType.OMNIMECH).length).toBe(0);
+    });
+
+    it('should be safe to call multiple times', () => {
+      resetUnitValidationRules();
+      resetUnitValidationRules();
+      resetUnitValidationRules();
+
+      expect(areRulesInitialized()).toBe(false);
+    });
+
+    it('should be safe to call before initialization', () => {
+      expect(() => resetUnitValidationRules()).not.toThrow();
+      expect(areRulesInitialized()).toBe(false);
+    });
+  });
+
+  // =============================================================================
+  // Integration Tests
+  // =============================================================================
+
+  describe('Integration Tests', () => {
+    it('should make rules available for unit validation after initialization', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+
+      // BattleMech should have universal + mech category + battlemech type rules
+      const battlemechRules = registry.getRulesForUnitType(UnitType.BATTLEMECH);
+      expect(battlemechRules.length).toBeGreaterThan(0);
+
+      // All rules should have required properties
+      for (const rule of battlemechRules) {
+        expect(rule.id).toBeDefined();
+        expect(rule.name).toBeDefined();
+        expect(typeof rule.validate).toBe('function');
+      }
+    });
+
+    it('should make rules available for vehicle validation after initialization', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+
+      const vehicleRules = registry.getRulesForUnitType(UnitType.VEHICLE);
+      expect(vehicleRules.length).toBeGreaterThan(0);
+    });
+
+    it('should make rules available for infantry validation after initialization', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+
+      const infantryRules = registry.getRulesForUnitType(UnitType.INFANTRY);
+      expect(infantryRules.length).toBeGreaterThan(0);
+    });
+
+    it('should make rules available for battle armor validation after initialization', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+
+      const battleArmorRules = registry.getRulesForUnitType(UnitType.BATTLE_ARMOR);
+      expect(battleArmorRules.length).toBeGreaterThan(0);
+    });
+
+    it('should include all personnel rules for infantry', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+
+      const infantryRules = registry.getRulesForUnitType(UnitType.INFANTRY);
+      const personnelRuleIds = PERSONNEL_CATEGORY_RULES.map(r => r.id);
+
+      for (const ruleId of personnelRuleIds) {
+        const hasRule = infantryRules.some(r => r.id === ruleId);
+        expect(hasRule).toBe(true);
+      }
+    });
+
+    it('should include all personnel rules for battle armor', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+
+      const battleArmorRules = registry.getRulesForUnitType(UnitType.BATTLE_ARMOR);
+      const personnelRuleIds = PERSONNEL_CATEGORY_RULES.map(r => r.id);
+
+      for (const ruleId of personnelRuleIds) {
+        const hasRule = battleArmorRules.some(r => r.id === ruleId);
+        expect(hasRule).toBe(true);
+      }
+    });
+
+    it('should allow looking up specific rules by ID after initialization', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+
+      // Look up a known universal rule
+      if (UNIVERSAL_VALIDATION_RULES.length > 0) {
+        const firstUniversalRuleId = UNIVERSAL_VALIDATION_RULES[0].id;
+        const rule = registry.getRule(firstUniversalRuleId);
+        expect(rule).toBeDefined();
+        expect(rule?.id).toBe(firstUniversalRuleId);
+      }
+
+      // Look up a known personnel rule
+      if (PERSONNEL_CATEGORY_RULES.length > 0) {
+        const firstPersonnelRuleId = PERSONNEL_CATEGORY_RULES[0].id;
+        const rule = registry.getRule(firstPersonnelRuleId);
+        expect(rule).toBeDefined();
+        expect(rule?.id).toBe(firstPersonnelRuleId);
+      }
+    });
+
+    it('should have rules sorted by priority', () => {
+      initializeUnitValidationRules();
+      const registry = getUnitValidationRegistry();
+
+      const rules = registry.getRulesForUnitType(UnitType.BATTLEMECH);
+
+      // Verify rules are sorted by priority (ascending)
+      for (let i = 1; i < rules.length; i++) {
+        expect(rules[i].priority).toBeGreaterThanOrEqual(rules[i - 1].priority);
+      }
+    });
+  });
+
+  // =============================================================================
+  // Edge Cases
+  // =============================================================================
+
+  describe('Edge Cases', () => {
+    it('should handle rapid init/reset cycles', () => {
+      for (let i = 0; i < 10; i++) {
+        initializeUnitValidationRules();
+        expect(areRulesInitialized()).toBe(true);
+        resetUnitValidationRules();
+        expect(areRulesInitialized()).toBe(false);
+      }
+    });
+
+    it('should maintain rule integrity after multiple reinitializations', () => {
+      initializeUnitValidationRules();
+      const firstRules = getUnitValidationRegistry().getRulesForUnitType(UnitType.BATTLEMECH);
+      const firstRuleIds = firstRules.map(r => r.id).sort();
+
+      resetUnitValidationRules();
+      initializeUnitValidationRules();
+      const secondRules = getUnitValidationRegistry().getRulesForUnitType(UnitType.BATTLEMECH);
+      const secondRuleIds = secondRules.map(r => r.id).sort();
+
+      expect(secondRuleIds).toEqual(firstRuleIds);
+    });
+
+    it('should work correctly with registry singleton', () => {
+      const registry1 = getUnitValidationRegistry();
+      initializeUnitValidationRules();
+      const registry2 = getUnitValidationRegistry();
+
+      // Both should reference the same instance
+      expect(registry1).toBe(registry2);
+
+      // Rules should be visible through both references
+      expect(registry1.getUniversalRules().length).toBeGreaterThan(0);
+      expect(registry2.getUniversalRules().length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/services/validation/rules/personnel/__tests__/PersonnelCategoryRules.test.ts
+++ b/src/services/validation/rules/personnel/__tests__/PersonnelCategoryRules.test.ts
@@ -1,0 +1,759 @@
+/**
+ * Personnel Category Validation Rules Tests
+ *
+ * Comprehensive tests for personnel validation rules (Infantry, Battle Armor).
+ * Tests VAL-PERS-001 through VAL-PERS-003.
+ *
+ * @spec openspec/specs/unit-validation-framework/spec.md
+ */
+
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+import {
+  IValidatableUnit,
+  IUnitValidationContext,
+  UnitCategory,
+  UnitValidationSeverity,
+} from '@/types/validation/UnitValidationInterfaces';
+import { TechBase, RulesLevel, Era } from '@/types/enums';
+import {
+  PersonnelSquadSizeValid,
+  BattleArmorWeightRange,
+  InfantryPrimaryWeaponRequired,
+  PERSONNEL_CATEGORY_RULES,
+} from '../PersonnelCategoryRules';
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+interface IPersonnelTestUnit extends IValidatableUnit {
+  squadSize?: number;
+  primaryWeapon?: { type: string };
+  trooperWeight?: number;
+}
+
+function createInfantryUnit(overrides: Partial<IPersonnelTestUnit> = {}): IPersonnelTestUnit {
+  return {
+    id: 'test-infantry-1',
+    name: 'Test Infantry Platoon',
+    unitType: UnitType.INFANTRY,
+    techBase: TechBase.INNER_SPHERE,
+    rulesLevel: RulesLevel.STANDARD,
+    introductionYear: 2750,
+    era: Era.STAR_LEAGUE,
+    weight: 0,
+    cost: 50000,
+    battleValue: 50,
+    squadSize: 21,
+    primaryWeapon: { type: 'Rifle' },
+    ...overrides,
+  };
+}
+
+function createBattleArmorUnit(overrides: Partial<IPersonnelTestUnit> = {}): IPersonnelTestUnit {
+  return {
+    id: 'test-ba-1',
+    name: 'Test Battle Armor Squad',
+    unitType: UnitType.BATTLE_ARMOR,
+    techBase: TechBase.CLAN,
+    rulesLevel: RulesLevel.STANDARD,
+    introductionYear: 2868,
+    era: Era.CLAN_INVASION,
+    weight: 1.0,
+    cost: 500000,
+    battleValue: 250,
+    squadSize: 5,
+    trooperWeight: 1.0,
+    primaryWeapon: { type: 'Small Laser' },
+    ...overrides,
+  };
+}
+
+function createTestContext(
+  unit: IValidatableUnit,
+  category: UnitCategory = UnitCategory.PERSONNEL
+): IUnitValidationContext {
+  return {
+    unit,
+    unitType: unit.unitType,
+    unitCategory: category,
+    techBase: unit.techBase,
+    options: {},
+    cache: new Map(),
+  };
+}
+
+// =============================================================================
+// PERSONNEL_CATEGORY_RULES Export Tests
+// =============================================================================
+
+describe('Personnel Category Rules', () => {
+  describe('PERSONNEL_CATEGORY_RULES export', () => {
+    it('should export all personnel rules', () => {
+      expect(PERSONNEL_CATEGORY_RULES).toBeDefined();
+      expect(PERSONNEL_CATEGORY_RULES.length).toBe(3);
+    });
+
+    it('should contain all expected rule IDs', () => {
+      const ruleIds = PERSONNEL_CATEGORY_RULES.map((r) => r.id);
+      expect(ruleIds).toContain('VAL-PERS-001');
+      expect(ruleIds).toContain('VAL-PERS-002');
+      expect(ruleIds).toContain('VAL-PERS-003');
+    });
+
+    it('should have rules in correct order', () => {
+      expect(PERSONNEL_CATEGORY_RULES[0].id).toBe('VAL-PERS-001');
+      expect(PERSONNEL_CATEGORY_RULES[1].id).toBe('VAL-PERS-002');
+      expect(PERSONNEL_CATEGORY_RULES[2].id).toBe('VAL-PERS-003');
+    });
+
+    it('should have all rules with required metadata', () => {
+      for (const rule of PERSONNEL_CATEGORY_RULES) {
+        expect(rule.id).toBeDefined();
+        expect(rule.name).toBeDefined();
+        expect(rule.description).toBeDefined();
+        expect(rule.category).toBeDefined();
+        expect(rule.priority).toBeDefined();
+        expect(typeof rule.validate).toBe('function');
+      }
+    });
+  });
+
+  // =============================================================================
+  // VAL-PERS-001: Squad Size Valid
+  // =============================================================================
+
+  describe('VAL-PERS-001: Squad Size Valid', () => {
+    describe('metadata', () => {
+      it('should have correct rule metadata', () => {
+        expect(PersonnelSquadSizeValid.id).toBe('VAL-PERS-001');
+        expect(PersonnelSquadSizeValid.name).toBe('Squad Size Valid');
+        expect(PersonnelSquadSizeValid.priority).toBe(50);
+      });
+
+      it('should apply to Infantry and Battle Armor', () => {
+        expect(PersonnelSquadSizeValid.applicableUnitTypes).toContain(UnitType.INFANTRY);
+        expect(PersonnelSquadSizeValid.applicableUnitTypes).toContain(UnitType.BATTLE_ARMOR);
+      });
+
+      it('should have a description', () => {
+        expect(PersonnelSquadSizeValid.description).toContain('Squad');
+        expect(PersonnelSquadSizeValid.description).toContain('positive integer');
+      });
+    });
+
+    describe('with Infantry unit', () => {
+      it('should pass with valid squad size', () => {
+        const unit = createInfantryUnit({ squadSize: 21 });
+        const context = createTestContext(unit);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should pass with squad size of 1', () => {
+        const unit = createInfantryUnit({ squadSize: 1 });
+        const context = createTestContext(unit);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should pass with large squad size', () => {
+        const unit = createInfantryUnit({ squadSize: 100 });
+        const context = createTestContext(unit);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should fail with squad size of 0', () => {
+        const unit = createInfantryUnit({ squadSize: 0 });
+        const context = createTestContext(unit);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].severity).toBe(UnitValidationSeverity.ERROR);
+        expect(result.errors[0].field).toBe('squadSize');
+        expect(result.errors[0].message).toContain('positive integer');
+      });
+
+      it('should fail with negative squad size', () => {
+        const unit = createInfantryUnit({ squadSize: -5 });
+        const context = createTestContext(unit);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].actual).toBe('-5');
+      });
+
+      it('should fail with undefined squad size', () => {
+        const unit = createInfantryUnit({ squadSize: undefined });
+        const context = createTestContext(unit);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].actual).toBe('undefined');
+      });
+
+      it('should fail with non-integer squad size', () => {
+        const unit = createInfantryUnit({ squadSize: 5.5 });
+        const context = createTestContext(unit);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].message).toContain('positive integer');
+      });
+
+      it('should include suggestion in error details', () => {
+        const unit = createInfantryUnit({ squadSize: -1 });
+        const context = createTestContext(unit);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        expect(result.errors[0].suggestion).toContain('valid positive integer');
+      });
+    });
+
+    describe('with Battle Armor unit', () => {
+      it('should pass with valid squad size', () => {
+        const unit = createBattleArmorUnit({ squadSize: 5 });
+        const context = createTestContext(unit);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should pass with squad size of 4 (Clan)', () => {
+        const unit = createBattleArmorUnit({ squadSize: 4 });
+        const context = createTestContext(unit);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should pass with squad size of 6 (IS)', () => {
+        const unit = createBattleArmorUnit({
+          squadSize: 6,
+          techBase: TechBase.INNER_SPHERE,
+        });
+        const context = createTestContext(unit);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should fail with squad size of 0', () => {
+        const unit = createBattleArmorUnit({ squadSize: 0 });
+        const context = createTestContext(unit);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+      });
+
+      it('should fail with undefined squad size', () => {
+        const unit = createBattleArmorUnit({ squadSize: undefined });
+        const context = createTestContext(unit);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        expect(result.passed).toBe(false);
+      });
+    });
+
+    describe('with non-personnel unit types', () => {
+      it('should pass for BattleMech (not a personnel type)', () => {
+        const unit = createInfantryUnit({
+          unitType: UnitType.BATTLEMECH,
+          squadSize: undefined,
+        });
+        const context = createTestContext(unit, UnitCategory.MECH);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        // Should pass because isPersonnelUnit returns false
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should pass for Vehicle (not a personnel type)', () => {
+        const unit = createInfantryUnit({
+          unitType: UnitType.VEHICLE,
+          squadSize: undefined,
+        });
+        const context = createTestContext(unit, UnitCategory.VEHICLE);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+    });
+  });
+
+  // =============================================================================
+  // VAL-PERS-002: Battle Armor Weight Range
+  // =============================================================================
+
+  describe('VAL-PERS-002: Battle Armor Weight Range', () => {
+    describe('metadata', () => {
+      it('should have correct rule metadata', () => {
+        expect(BattleArmorWeightRange.id).toBe('VAL-PERS-002');
+        expect(BattleArmorWeightRange.name).toBe('Battle Armor Weight Range');
+        expect(BattleArmorWeightRange.priority).toBe(51);
+      });
+
+      it('should apply only to Battle Armor', () => {
+        expect(BattleArmorWeightRange.applicableUnitTypes).toEqual([UnitType.BATTLE_ARMOR]);
+      });
+
+      it('should have a description mentioning weight range', () => {
+        expect(BattleArmorWeightRange.description).toContain('0.4');
+        expect(BattleArmorWeightRange.description).toContain('2.0');
+      });
+    });
+
+    describe('with Battle Armor unit', () => {
+      it('should pass at minimum weight (0.4 tons)', () => {
+        const unit = createBattleArmorUnit({ trooperWeight: 0.4 });
+        const context = createTestContext(unit);
+        const result = BattleArmorWeightRange.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should pass at maximum weight (2.0 tons)', () => {
+        const unit = createBattleArmorUnit({ trooperWeight: 2.0 });
+        const context = createTestContext(unit);
+        const result = BattleArmorWeightRange.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should pass at mid-range weight (1.0 ton)', () => {
+        const unit = createBattleArmorUnit({ trooperWeight: 1.0 });
+        const context = createTestContext(unit);
+        const result = BattleArmorWeightRange.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should pass at typical light weight (0.5 tons)', () => {
+        const unit = createBattleArmorUnit({ trooperWeight: 0.5 });
+        const context = createTestContext(unit);
+        const result = BattleArmorWeightRange.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should pass at typical heavy weight (1.5 tons)', () => {
+        const unit = createBattleArmorUnit({ trooperWeight: 1.5 });
+        const context = createTestContext(unit);
+        const result = BattleArmorWeightRange.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should fail below minimum weight', () => {
+        const unit = createBattleArmorUnit({ trooperWeight: 0.3 });
+        const context = createTestContext(unit);
+        const result = BattleArmorWeightRange.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].severity).toBe(UnitValidationSeverity.CRITICAL_ERROR);
+        expect(result.errors[0].field).toBe('trooperWeight');
+        expect(result.errors[0].message).toContain('0.4-2');
+      });
+
+      it('should fail above maximum weight', () => {
+        const unit = createBattleArmorUnit({ trooperWeight: 2.5 });
+        const context = createTestContext(unit);
+        const result = BattleArmorWeightRange.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].actual).toBe('2.5');
+        expect(result.errors[0].expected).toBe('0.4-2');
+      });
+
+      it('should use unit.weight as fallback when trooperWeight is undefined', () => {
+        const unit = createBattleArmorUnit({
+          trooperWeight: undefined,
+          weight: 1.5,
+        });
+        const context = createTestContext(unit);
+        const result = BattleArmorWeightRange.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+
+      it('should fail when using fallback weight that is out of range', () => {
+        const unit = createBattleArmorUnit({
+          trooperWeight: undefined,
+          weight: 3.0,
+        });
+        const context = createTestContext(unit);
+        const result = BattleArmorWeightRange.validate(context);
+
+        expect(result.passed).toBe(false);
+        expect(result.errors[0].actual).toBe('3');
+      });
+
+      it('should include suggestion in error details', () => {
+        const unit = createBattleArmorUnit({ trooperWeight: 0.2 });
+        const context = createTestContext(unit);
+        const result = BattleArmorWeightRange.validate(context);
+
+        expect(result.errors[0].suggestion).toContain('Adjust trooper weight');
+        expect(result.errors[0].suggestion).toContain('0.4-2');
+      });
+    });
+
+    describe('with non-Battle Armor unit types', () => {
+      it('should pass for Infantry (not Battle Armor)', () => {
+        const unit = createInfantryUnit({
+          trooperWeight: 0.1, // Would be invalid for BA
+        });
+        const context = createTestContext(unit);
+        const result = BattleArmorWeightRange.validate(context);
+
+        // Should pass because unit type is Infantry, not Battle Armor
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+      });
+
+      it('should pass for BattleMech (not Battle Armor)', () => {
+        const unit = createBattleArmorUnit({
+          unitType: UnitType.BATTLEMECH,
+          trooperWeight: 50, // Would be invalid for BA
+        });
+        const context = createTestContext(unit, UnitCategory.MECH);
+        const result = BattleArmorWeightRange.validate(context);
+
+        expect(result.passed).toBe(true);
+      });
+    });
+  });
+
+  // =============================================================================
+  // VAL-PERS-003: Infantry Primary Weapon Required
+  // =============================================================================
+
+  describe('VAL-PERS-003: Infantry Primary Weapon Required', () => {
+    describe('metadata', () => {
+      it('should have correct rule metadata', () => {
+        expect(InfantryPrimaryWeaponRequired.id).toBe('VAL-PERS-003');
+        expect(InfantryPrimaryWeaponRequired.name).toBe('Infantry Primary Weapon Required');
+        expect(InfantryPrimaryWeaponRequired.priority).toBe(52);
+      });
+
+      it('should apply only to Infantry', () => {
+        expect(InfantryPrimaryWeaponRequired.applicableUnitTypes).toEqual([UnitType.INFANTRY]);
+      });
+
+      it('should have a description mentioning primary weapon', () => {
+        expect(InfantryPrimaryWeaponRequired.description).toContain('primary weapon');
+      });
+    });
+
+    describe('with Infantry unit', () => {
+      it('should pass when primary weapon is defined', () => {
+        const unit = createInfantryUnit({ primaryWeapon: { type: 'Rifle' } });
+        const context = createTestContext(unit);
+        const result = InfantryPrimaryWeaponRequired.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+        expect(result.warnings.length).toBe(0);
+      });
+
+      it('should pass with various weapon types', () => {
+        const weaponTypes = [
+          { type: 'Rifle' },
+          { type: 'Laser' },
+          { type: 'MG' },
+          { type: 'Flamer' },
+          { type: 'SRM' },
+        ];
+
+        for (const weapon of weaponTypes) {
+          const unit = createInfantryUnit({ primaryWeapon: weapon });
+          const context = createTestContext(unit);
+          const result = InfantryPrimaryWeaponRequired.validate(context);
+
+          expect(result.passed).toBe(true);
+        }
+      });
+
+      it('should generate warning when primary weapon is undefined', () => {
+        const unit = createInfantryUnit({ primaryWeapon: undefined });
+        const context = createTestContext(unit);
+        const result = InfantryPrimaryWeaponRequired.validate(context);
+
+        // This rule generates a warning, not an error
+        expect(result.passed).toBe(true); // Warnings don't fail validation
+        expect(result.errors.length).toBe(0);
+        expect(result.warnings.length).toBe(1);
+        expect(result.warnings[0].severity).toBe(UnitValidationSeverity.WARNING);
+        expect(result.warnings[0].field).toBe('primaryWeapon');
+      });
+
+      it('should include suggestion in warning details', () => {
+        const unit = createInfantryUnit({ primaryWeapon: undefined });
+        const context = createTestContext(unit);
+        const result = InfantryPrimaryWeaponRequired.validate(context);
+
+        expect(result.warnings[0].suggestion).toContain('Define a primary weapon');
+      });
+
+      it('should have warning message about missing weapon', () => {
+        const unit = createInfantryUnit({ primaryWeapon: undefined });
+        const context = createTestContext(unit);
+        const result = InfantryPrimaryWeaponRequired.validate(context);
+
+        expect(result.warnings[0].message).toContain('no primary weapon');
+      });
+    });
+
+    describe('with non-Infantry unit types', () => {
+      it('should pass for Battle Armor without primary weapon', () => {
+        const unit = createBattleArmorUnit({ primaryWeapon: undefined });
+        const context = createTestContext(unit);
+        const result = InfantryPrimaryWeaponRequired.validate(context);
+
+        // Should pass because unit type is Battle Armor, not Infantry
+        expect(result.passed).toBe(true);
+        expect(result.errors.length).toBe(0);
+        expect(result.warnings.length).toBe(0);
+      });
+
+      it('should pass for BattleMech', () => {
+        const unit = createInfantryUnit({
+          unitType: UnitType.BATTLEMECH,
+          primaryWeapon: undefined,
+        });
+        const context = createTestContext(unit, UnitCategory.MECH);
+        const result = InfantryPrimaryWeaponRequired.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.warnings.length).toBe(0);
+      });
+
+      it('should pass for Vehicle', () => {
+        const unit = createInfantryUnit({
+          unitType: UnitType.VEHICLE,
+          primaryWeapon: undefined,
+        });
+        const context = createTestContext(unit, UnitCategory.VEHICLE);
+        const result = InfantryPrimaryWeaponRequired.validate(context);
+
+        expect(result.passed).toBe(true);
+        expect(result.warnings.length).toBe(0);
+      });
+    });
+  });
+
+  // =============================================================================
+  // Integration Tests
+  // =============================================================================
+
+  describe('Integration Tests', () => {
+    it('should validate a fully valid Infantry unit', () => {
+      const unit = createInfantryUnit({
+        squadSize: 21,
+        primaryWeapon: { type: 'Rifle' },
+      });
+      const context = createTestContext(unit);
+
+      for (const rule of PERSONNEL_CATEGORY_RULES) {
+        const result = rule.validate(context);
+        expect(result.passed).toBe(true);
+      }
+    });
+
+    it('should validate a fully valid Battle Armor unit', () => {
+      const unit = createBattleArmorUnit({
+        squadSize: 5,
+        trooperWeight: 1.0,
+        primaryWeapon: { type: 'Small Laser' },
+      });
+      const context = createTestContext(unit);
+
+      for (const rule of PERSONNEL_CATEGORY_RULES) {
+        const result = rule.validate(context);
+        expect(result.passed).toBe(true);
+      }
+    });
+
+    it('should catch multiple validation failures on Infantry', () => {
+      const unit = createInfantryUnit({
+        squadSize: 0, // Invalid
+        primaryWeapon: undefined, // Warning
+      });
+      const context = createTestContext(unit);
+
+      const allErrors: string[] = [];
+      const allWarnings: string[] = [];
+
+      for (const rule of PERSONNEL_CATEGORY_RULES) {
+        const result = rule.validate(context);
+        for (const error of result.errors) {
+          allErrors.push(error.ruleId);
+        }
+        for (const warning of result.warnings) {
+          allWarnings.push(warning.ruleId);
+        }
+      }
+
+      expect(allErrors).toContain('VAL-PERS-001'); // Squad size
+      expect(allWarnings).toContain('VAL-PERS-003'); // Primary weapon
+    });
+
+    it('should catch multiple validation failures on Battle Armor', () => {
+      const unit = createBattleArmorUnit({
+        squadSize: -1, // Invalid
+        trooperWeight: 3.0, // Invalid - over max
+      });
+      const context = createTestContext(unit);
+
+      const failedRules: string[] = [];
+      for (const rule of PERSONNEL_CATEGORY_RULES) {
+        const result = rule.validate(context);
+        if (!result.passed) {
+          failedRules.push(rule.id);
+        }
+      }
+
+      expect(failedRules).toContain('VAL-PERS-001'); // Squad size
+      expect(failedRules).toContain('VAL-PERS-002'); // Weight range
+    });
+
+    it('should work with minimal valid Infantry', () => {
+      const unit = createInfantryUnit({
+        squadSize: 1,
+        primaryWeapon: { type: 'Rifle' },
+      });
+      const context = createTestContext(unit);
+
+      for (const rule of PERSONNEL_CATEGORY_RULES) {
+        const result = rule.validate(context);
+        expect(result.passed).toBe(true);
+        expect(result.warnings.length).toBe(0);
+      }
+    });
+
+    it('should work with minimal valid Battle Armor', () => {
+      const unit = createBattleArmorUnit({
+        squadSize: 1,
+        trooperWeight: 0.4, // Minimum
+      });
+      const context = createTestContext(unit);
+
+      for (const rule of PERSONNEL_CATEGORY_RULES) {
+        const result = rule.validate(context);
+        expect(result.passed).toBe(true);
+      }
+    });
+
+    it('should work with maximum valid Battle Armor', () => {
+      const unit = createBattleArmorUnit({
+        squadSize: 10,
+        trooperWeight: 2.0, // Maximum
+      });
+      const context = createTestContext(unit);
+
+      for (const rule of PERSONNEL_CATEGORY_RULES) {
+        const result = rule.validate(context);
+        expect(result.passed).toBe(true);
+      }
+    });
+  });
+
+  // =============================================================================
+  // Edge Cases
+  // =============================================================================
+
+  describe('Edge Cases', () => {
+    it('should handle boundary values for squad size', () => {
+      const boundaryValues = [1, 2, 10, 100, 1000];
+
+      for (const size of boundaryValues) {
+        const unit = createInfantryUnit({ squadSize: size });
+        const context = createTestContext(unit);
+        const result = PersonnelSquadSizeValid.validate(context);
+
+        expect(result.passed).toBe(true);
+      }
+    });
+
+    it('should handle boundary values for trooper weight', () => {
+      const validWeights = [0.4, 0.5, 1.0, 1.5, 2.0];
+      const invalidWeights = [0.39, 0.3, 0.0, 2.01, 2.5, 3.0];
+
+      for (const weight of validWeights) {
+        const unit = createBattleArmorUnit({ trooperWeight: weight });
+        const context = createTestContext(unit);
+        const result = BattleArmorWeightRange.validate(context);
+
+        expect(result.passed).toBe(true);
+      }
+
+      for (const weight of invalidWeights) {
+        const unit = createBattleArmorUnit({ trooperWeight: weight });
+        const context = createTestContext(unit);
+        const result = BattleArmorWeightRange.validate(context);
+
+        expect(result.passed).toBe(false);
+      }
+    });
+
+    it('should handle IS vs Clan Battle Armor equally', () => {
+      const isUnit = createBattleArmorUnit({
+        techBase: TechBase.INNER_SPHERE,
+        trooperWeight: 1.5,
+        squadSize: 4,
+      });
+      const clanUnit = createBattleArmorUnit({
+        techBase: TechBase.CLAN,
+        trooperWeight: 1.5,
+        squadSize: 5,
+      });
+
+      const isContext = createTestContext(isUnit);
+      const clanContext = createTestContext(clanUnit);
+
+      for (const rule of PERSONNEL_CATEGORY_RULES) {
+        const isResult = rule.validate(isContext);
+        const clanResult = rule.validate(clanContext);
+
+        expect(isResult.passed).toBe(true);
+        expect(clanResult.passed).toBe(true);
+      }
+    });
+
+    it('should produce consistent error details', () => {
+      const unit = createBattleArmorUnit({ trooperWeight: 5.0 });
+      const context = createTestContext(unit);
+      const result = BattleArmorWeightRange.validate(context);
+
+      const error = result.errors[0];
+      expect(error.ruleId).toBe('VAL-PERS-002');
+      expect(error.ruleName).toBe('Battle Armor Weight Range');
+      expect(error.severity).toBeDefined();
+      expect(error.category).toBeDefined();
+      expect(error.message).toBeDefined();
+      expect(error.field).toBeDefined();
+      expect(error.expected).toBeDefined();
+      expect(error.actual).toBeDefined();
+      expect(error.suggestion).toBeDefined();
+    });
+  });
+});

--- a/src/services/vault/__tests__/ExportService.test.ts
+++ b/src/services/vault/__tests__/ExportService.test.ts
@@ -1,0 +1,619 @@
+/**
+ * Export Service Tests
+ *
+ * Tests for exporting units, pilots, and forces as signed bundles.
+ *
+ * @spec openspec/changes/add-vault-sharing/specs/vault-sharing/spec.md
+ */
+
+import type {
+  IVaultIdentity,
+  IExportableUnit,
+  IExportablePilot,
+  IExportableForce,
+  IExportResult,
+} from '@/types/vault';
+
+// =============================================================================
+// Mock BundleService
+// =============================================================================
+
+const mockCreateBundle = jest.fn();
+const mockSerializeBundle = jest.fn();
+
+jest.mock('../BundleService', () => ({
+  createBundle: (...args: unknown[]): unknown => mockCreateBundle(...args),
+  serializeBundle: (...args: unknown[]): string => mockSerializeBundle(...args) as string,
+}));
+
+// Import after mocking
+import {
+  exportUnit,
+  exportUnits,
+  exportPilot,
+  exportPilots,
+  exportForce,
+  exportForces,
+  exportContent,
+  downloadBundle,
+  copyBundleToClipboard,
+} from '../ExportService';
+
+// =============================================================================
+// Test Fixtures
+// =============================================================================
+
+const mockIdentity: IVaultIdentity = {
+  id: 'identity-test-1',
+  displayName: 'Test User',
+  publicKey: 'dGVzdC1wdWJsaWMta2V5LWJhc2U2NA==',
+  privateKey: 'dGVzdC1wcml2YXRlLWtleS1iYXNlNjQ=',
+  friendCode: 'TEST-1234-ABCD',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  avatar: 'default',
+};
+
+const mockUnit: IExportableUnit = {
+  id: 'unit-atlas-1',
+  name: 'Atlas AS7-D',
+  chassis: 'Atlas',
+  model: 'AS7-D',
+  data: {
+    tonnage: 100,
+    techBase: 'Inner Sphere',
+    armor: { total: 304 },
+  },
+};
+
+const mockUnit2: IExportableUnit = {
+  id: 'unit-locust-1',
+  name: 'Locust LCT-1V',
+  chassis: 'Locust',
+  model: 'LCT-1V',
+  data: {
+    tonnage: 20,
+    techBase: 'Inner Sphere',
+    armor: { total: 32 },
+  },
+};
+
+const mockPilot: IExportablePilot = {
+  id: 'pilot-1',
+  name: 'John Smith',
+  callsign: 'Maverick',
+  data: {
+    gunnery: 4,
+    piloting: 5,
+    skills: ['Jumping Jack', 'Iron Will'],
+  },
+};
+
+const mockPilot2: IExportablePilot = {
+  id: 'pilot-2',
+  name: 'Jane Doe',
+  callsign: 'Phoenix',
+  data: {
+    gunnery: 3,
+    piloting: 4,
+    skills: ['Natural Aptitude'],
+  },
+};
+
+const mockForce: IExportableForce = {
+  id: 'force-1',
+  name: 'Alpha Lance',
+  description: 'Assault lance',
+  data: {
+    faction: 'Steiner',
+    era: 3025,
+  },
+  pilots: [mockPilot],
+  units: [mockUnit],
+};
+
+const mockForce2: IExportableForce = {
+  id: 'force-2',
+  name: 'Beta Lance',
+  description: 'Recon lance',
+  data: {
+    faction: 'Davion',
+    era: 3025,
+  },
+};
+
+const mockSuccessResult: IExportResult = {
+  success: true,
+  bundle: {
+    metadata: {
+      version: '1.0.0',
+      contentType: 'unit',
+      itemCount: 1,
+      author: {
+        displayName: 'Test User',
+        publicKey: 'dGVzdC1wdWJsaWMta2V5',
+        friendCode: 'TEST-1234-ABCD',
+      },
+      createdAt: '2025-01-01T00:00:00.000Z',
+      appVersion: '0.1.0',
+    },
+    payload: JSON.stringify([mockUnit]),
+    signature: 'test-signature',
+  },
+  suggestedFilename: 'atlas-as7-d-20250101.mekbundle',
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('ExportService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateBundle.mockResolvedValue(mockSuccessResult);
+    mockSerializeBundle.mockReturnValue(JSON.stringify(mockSuccessResult.bundle));
+  });
+
+  // ===========================================================================
+  // Unit Export
+  // ===========================================================================
+
+  describe('Unit Export', () => {
+    describe('exportUnit', () => {
+      it('should export a single unit', async () => {
+        const result = await exportUnit(mockUnit, mockIdentity);
+
+        expect(mockCreateBundle).toHaveBeenCalledWith(
+          'unit',
+          [mockUnit],
+          mockIdentity,
+          {}
+        );
+        expect(result).toEqual(mockSuccessResult);
+      });
+
+      it('should export unit with options', async () => {
+        const options = {
+          description: 'My favorite mech',
+          tags: ['assault', 'inner-sphere'],
+        };
+
+        await exportUnit(mockUnit, mockIdentity, options);
+
+        expect(mockCreateBundle).toHaveBeenCalledWith(
+          'unit',
+          [mockUnit],
+          mockIdentity,
+          options
+        );
+      });
+    });
+
+    describe('exportUnits', () => {
+      it('should export multiple units', async () => {
+        const units = [mockUnit, mockUnit2];
+        mockCreateBundle.mockResolvedValue({
+          ...mockSuccessResult,
+          bundle: {
+            ...mockSuccessResult.bundle,
+            metadata: { ...mockSuccessResult.bundle?.metadata, itemCount: 2 },
+          },
+        });
+
+        const result = await exportUnits(units, mockIdentity);
+
+        expect(mockCreateBundle).toHaveBeenCalledWith(
+          'unit',
+          units,
+          mockIdentity,
+          {}
+        );
+        expect(result.success).toBe(true);
+      });
+
+      it('should return error for empty units array', async () => {
+        const result = await exportUnits([], mockIdentity);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('No units to export');
+        expect(mockCreateBundle).not.toHaveBeenCalled();
+      });
+
+      it('should export units with options', async () => {
+        const units = [mockUnit];
+        const options = { description: 'Export batch' };
+
+        await exportUnits(units, mockIdentity, options);
+
+        expect(mockCreateBundle).toHaveBeenCalledWith(
+          'unit',
+          units,
+          mockIdentity,
+          options
+        );
+      });
+    });
+  });
+
+  // ===========================================================================
+  // Pilot Export
+  // ===========================================================================
+
+  describe('Pilot Export', () => {
+    describe('exportPilot', () => {
+      it('should export a single pilot', async () => {
+        mockCreateBundle.mockResolvedValue({
+          ...mockSuccessResult,
+          bundle: {
+            ...mockSuccessResult.bundle,
+            metadata: { ...mockSuccessResult.bundle?.metadata, contentType: 'pilot' },
+          },
+        });
+
+        const result = await exportPilot(mockPilot, mockIdentity);
+
+        expect(mockCreateBundle).toHaveBeenCalledWith(
+          'pilot',
+          [mockPilot],
+          mockIdentity,
+          {}
+        );
+        expect(result.success).toBe(true);
+      });
+
+      it('should export pilot with options', async () => {
+        const options = { tags: ['elite', 'veteran'] };
+
+        await exportPilot(mockPilot, mockIdentity, options);
+
+        expect(mockCreateBundle).toHaveBeenCalledWith(
+          'pilot',
+          [mockPilot],
+          mockIdentity,
+          options
+        );
+      });
+    });
+
+    describe('exportPilots', () => {
+      it('should export multiple pilots', async () => {
+        const pilots = [mockPilot, mockPilot2];
+
+        await exportPilots(pilots, mockIdentity);
+
+        expect(mockCreateBundle).toHaveBeenCalledWith(
+          'pilot',
+          pilots,
+          mockIdentity,
+          {}
+        );
+      });
+
+      it('should return error for empty pilots array', async () => {
+        const result = await exportPilots([], mockIdentity);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('No pilots to export');
+        expect(mockCreateBundle).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  // ===========================================================================
+  // Force Export
+  // ===========================================================================
+
+  describe('Force Export', () => {
+    describe('exportForce', () => {
+      it('should export a single force', async () => {
+        mockCreateBundle.mockResolvedValue({
+          ...mockSuccessResult,
+          bundle: {
+            ...mockSuccessResult.bundle,
+            metadata: { ...mockSuccessResult.bundle?.metadata, contentType: 'force' },
+          },
+        });
+
+        const result = await exportForce(mockForce, mockIdentity);
+
+        expect(mockCreateBundle).toHaveBeenCalledWith(
+          'force',
+          expect.arrayContaining([expect.objectContaining({ id: 'force-1' })]),
+          mockIdentity,
+          {}
+        );
+        expect(result.success).toBe(true);
+      });
+
+      it('should include nested data when includeNested is true', async () => {
+        const options = { includeNested: true };
+
+        await exportForce(mockForce, mockIdentity, options);
+
+        expect(mockCreateBundle).toHaveBeenCalledWith(
+          'force',
+          [mockForce],
+          mockIdentity,
+          options
+        );
+      });
+
+      it('should strip nested data when includeNested is false', async () => {
+        const options = { includeNested: false };
+
+        await exportForce(mockForce, mockIdentity, options);
+
+        expect(mockCreateBundle).toHaveBeenCalledWith(
+          'force',
+          [expect.objectContaining({
+            id: 'force-1',
+            pilots: undefined,
+            units: undefined,
+          })],
+          mockIdentity,
+          options
+        );
+      });
+    });
+
+    describe('exportForces', () => {
+      it('should export multiple forces', async () => {
+        const forces = [mockForce, mockForce2];
+
+        await exportForces(forces, mockIdentity);
+
+        expect(mockCreateBundle).toHaveBeenCalledWith(
+          'force',
+          expect.any(Array),
+          mockIdentity,
+          {}
+        );
+      });
+
+      it('should return error for empty forces array', async () => {
+        const result = await exportForces([], mockIdentity);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('No forces to export');
+        expect(mockCreateBundle).not.toHaveBeenCalled();
+      });
+
+      it('should strip nested data from all forces when not including', async () => {
+        const forces = [mockForce, mockForce2];
+        const options = { includeNested: false };
+
+        await exportForces(forces, mockIdentity, options);
+
+        const callArgs = mockCreateBundle.mock.calls[0] as unknown[];
+        const exportedForces = callArgs[1] as IExportableForce[];
+
+        exportedForces.forEach((force: IExportableForce) => {
+          expect(force.pilots).toBeUndefined();
+          expect(force.units).toBeUndefined();
+        });
+      });
+    });
+  });
+
+  // ===========================================================================
+  // Generic Export
+  // ===========================================================================
+
+  describe('Generic Export', () => {
+    describe('exportContent', () => {
+      it('should export any content type', async () => {
+        await exportContent('unit', [mockUnit], mockIdentity);
+
+        expect(mockCreateBundle).toHaveBeenCalledWith(
+          'unit',
+          [mockUnit],
+          mockIdentity,
+          {}
+        );
+      });
+
+      it('should return error for empty items', async () => {
+        const result = await exportContent('pilot', [], mockIdentity);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('No pilots to export');
+      });
+
+      it('should support encounter content type', async () => {
+        const encounter = { id: 'enc-1', name: 'Test Encounter', data: {} };
+
+        await exportContent('encounter', [encounter], mockIdentity);
+
+        expect(mockCreateBundle).toHaveBeenCalledWith(
+          'encounter',
+          [encounter],
+          mockIdentity,
+          {}
+        );
+      });
+
+      it('should pass options through', async () => {
+        const options = { description: 'Generic export', tags: ['test'] };
+
+        await exportContent('unit', [mockUnit], mockIdentity, options);
+
+        expect(mockCreateBundle).toHaveBeenCalledWith(
+          'unit',
+          [mockUnit],
+          mockIdentity,
+          options
+        );
+      });
+    });
+  });
+
+  // ===========================================================================
+  // File Operations
+  // ===========================================================================
+
+  describe('File Operations', () => {
+    describe('downloadBundle', () => {
+      // Save original implementations
+      const originalCreateElement = document.createElement.bind(document);
+      const originalCreateObjectURL = URL.createObjectURL;
+      const originalRevokeObjectURL = URL.revokeObjectURL;
+      const originalAppendChild = document.body.appendChild.bind(document.body);
+      const originalRemoveChild = document.body.removeChild.bind(document.body);
+
+      let mockAnchor: {
+        href: string;
+        download: string;
+        click: jest.Mock;
+      };
+
+      beforeEach(() => {
+        mockAnchor = {
+          href: '',
+          download: '',
+          click: jest.fn(),
+        };
+
+        // Mock document.createElement
+        document.createElement = jest.fn().mockReturnValue(mockAnchor);
+
+        // Mock URL methods
+        URL.createObjectURL = jest.fn().mockReturnValue('blob:test-url');
+        URL.revokeObjectURL = jest.fn();
+
+        // Mock body methods
+        document.body.appendChild = jest.fn().mockImplementation(<T extends Node>(node: T): T => node);
+        document.body.removeChild = jest.fn().mockImplementation(<T extends Node>(node: T): T => node);
+      });
+
+      afterEach(() => {
+        // Restore original implementations
+        document.createElement = originalCreateElement;
+        URL.createObjectURL = originalCreateObjectURL;
+        URL.revokeObjectURL = originalRevokeObjectURL;
+        document.body.appendChild = originalAppendChild;
+        document.body.removeChild = originalRemoveChild;
+      });
+
+      it('should trigger file download', () => {
+        downloadBundle(mockSuccessResult);
+
+        expect(mockSerializeBundle).toHaveBeenCalledWith(mockSuccessResult.bundle);
+        expect(URL.createObjectURL).toHaveBeenCalled();
+        expect(mockAnchor.click).toHaveBeenCalled();
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:test-url');
+      });
+
+      it('should use suggested filename', () => {
+        downloadBundle(mockSuccessResult);
+
+        expect(mockAnchor.download).toBe('atlas-as7-d-20250101.mekbundle');
+      });
+
+      it('should use default filename when not provided', () => {
+        const resultWithoutFilename: IExportResult = {
+          ...mockSuccessResult,
+          suggestedFilename: undefined,
+        };
+
+        downloadBundle(resultWithoutFilename);
+
+        expect(mockAnchor.download).toBe('export.mekbundle');
+      });
+
+      it('should throw on failed export result', () => {
+        const failedResult: IExportResult = {
+          success: false,
+          error: 'Export failed',
+        };
+
+        expect(() => downloadBundle(failedResult)).toThrow('Export failed');
+      });
+
+      it('should throw on missing bundle', () => {
+        const noBundleResult: IExportResult = {
+          success: true,
+        };
+
+        expect(() => downloadBundle(noBundleResult)).toThrow('No bundle to download');
+      });
+    });
+
+    describe('copyBundleToClipboard', () => {
+      const originalClipboard = navigator.clipboard;
+      let mockWriteText: jest.Mock;
+
+      beforeEach(() => {
+        mockWriteText = jest.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+          value: { writeText: mockWriteText },
+          writable: true,
+          configurable: true,
+        });
+      });
+
+      afterEach(() => {
+        Object.defineProperty(navigator, 'clipboard', {
+          value: originalClipboard,
+          writable: true,
+          configurable: true,
+        });
+      });
+
+      it('should copy bundle JSON to clipboard', async () => {
+        const serialized = JSON.stringify(mockSuccessResult.bundle);
+        mockSerializeBundle.mockReturnValue(serialized);
+
+        await copyBundleToClipboard(mockSuccessResult);
+
+        expect(mockSerializeBundle).toHaveBeenCalledWith(mockSuccessResult.bundle);
+        expect(mockWriteText).toHaveBeenCalledWith(serialized);
+      });
+
+      it('should throw on failed export result', async () => {
+        const failedResult: IExportResult = {
+          success: false,
+          error: 'Export failed',
+        };
+
+        await expect(copyBundleToClipboard(failedResult)).rejects.toThrow(
+          'Export failed'
+        );
+      });
+
+      it('should throw on missing bundle', async () => {
+        const noBundleResult: IExportResult = {
+          success: true,
+        };
+
+        await expect(copyBundleToClipboard(noBundleResult)).rejects.toThrow(
+          'No bundle to copy'
+        );
+      });
+    });
+  });
+
+  // ===========================================================================
+  // Error Handling
+  // ===========================================================================
+
+  describe('Error Handling', () => {
+    it('should handle createBundle errors', async () => {
+      mockCreateBundle.mockResolvedValue({
+        success: false,
+        error: 'Signing failed',
+      });
+
+      const result = await exportUnit(mockUnit, mockIdentity);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Signing failed');
+    });
+
+    it('should propagate bundle creation errors', async () => {
+      mockCreateBundle.mockRejectedValue(new Error('Network error'));
+
+      await expect(exportUnit(mockUnit, mockIdentity)).rejects.toThrow(
+        'Network error'
+      );
+    });
+  });
+});

--- a/src/services/vault/__tests__/VaultService.test.ts
+++ b/src/services/vault/__tests__/VaultService.test.ts
@@ -197,31 +197,145 @@ class MockVaultFolderRepository {
 // Mock Permission Service
 // =============================================================================
 
+interface MockPermission {
+  id: string;
+  granteeId: string;
+  granteeName?: string;
+  scopeType: 'item' | 'folder' | 'category' | 'all';
+  scopeId: string | null;
+  scopeCategory?: string | null;
+  level: 'read' | 'write' | 'admin';
+}
+
 class MockPermissionService {
-  async grant(): Promise<{ success: boolean }> {
-    return { success: true };
+  private permissions: Map<string, MockPermission> = new Map();
+  private idCounter = 0;
+
+  async grant(params: {
+    granteeId: string;
+    granteeName?: string;
+    scopeType: 'item' | 'folder' | 'category' | 'all';
+    scopeId?: string | null;
+    scopeCategory?: string | null;
+    level: 'read' | 'write' | 'admin';
+  }): Promise<{ success: boolean; id: string }> {
+    const id = `perm-mock-${++this.idCounter}`;
+    this.permissions.set(id, {
+      id,
+      granteeId: params.granteeId,
+      granteeName: params.granteeName,
+      scopeType: params.scopeType,
+      scopeId: params.scopeId ?? null,
+      scopeCategory: params.scopeCategory ?? null,
+      level: params.level,
+    });
+    return { success: true, id };
   }
 
-  async revoke(): Promise<{ success: boolean }> {
-    return { success: true };
+  async revoke(id: string): Promise<{ success: boolean }> {
+    return { success: this.permissions.delete(id) };
   }
 
-  async check(): Promise<{ hasAccess: boolean; level: null }> {
+  async check(
+    granteeId: string,
+    scopeType: string,
+    scopeId: string | null,
+    scopeCategory?: string | null
+  ): Promise<{ hasAccess: boolean; level: 'read' | 'write' | 'admin' | null }> {
+    const perms = Array.from(this.permissions.values());
+    for (const perm of perms) {
+      if (perm.granteeId === granteeId) {
+        if (perm.scopeType === 'all') {
+          return { hasAccess: true, level: perm.level };
+        }
+        if (perm.scopeType === scopeType && perm.scopeId === scopeId) {
+          return { hasAccess: true, level: perm.level };
+        }
+        if (perm.scopeType === 'category' && perm.scopeCategory === scopeCategory) {
+          return { hasAccess: true, level: perm.level };
+        }
+      }
+    }
     return { hasAccess: false, level: null };
   }
 
-  async getGrantsForGrantee(): Promise<[]> {
-    return [];
+  async getGrantsForGrantee(granteeId: string): Promise<MockPermission[]> {
+    return Array.from(this.permissions.values()).filter(
+      (p) => p.granteeId === granteeId
+    );
   }
 
-  async getGrantsForItem(): Promise<[]> {
-    return [];
+  async getGrantsForItem(scopeType: string, scopeId: string): Promise<MockPermission[]> {
+    return Array.from(this.permissions.values()).filter(
+      (p) => p.scopeType === scopeType && p.scopeId === scopeId
+    );
   }
 
-  async revokeAllForItem(): Promise<number> {
-    return 0;
+  async revokeAllForItem(scopeType: string, scopeId: string): Promise<number> {
+    let count = 0;
+    const entries = Array.from(this.permissions.entries());
+    for (const [id, perm] of entries) {
+      if (perm.scopeType === scopeType && perm.scopeId === scopeId) {
+        this.permissions.delete(id);
+        count++;
+      }
+    }
+    return count;
+  }
+
+  async revokeAllForGrantee(granteeId: string): Promise<number> {
+    let count = 0;
+    const entries = Array.from(this.permissions.entries());
+    for (const [id, perm] of entries) {
+      if (perm.granteeId === granteeId) {
+        this.permissions.delete(id);
+        count++;
+      }
+    }
+    return count;
+  }
+
+  async updateLevel(
+    id: string,
+    newLevel: 'read' | 'write' | 'admin'
+  ): Promise<{ success: boolean }> {
+    const perm = this.permissions.get(id);
+    if (!perm) return { success: false };
+    perm.level = newLevel;
+    return { success: true };
+  }
+
+  clear(): void {
+    this.permissions.clear();
+    this.idCounter = 0;
+  }
+
+  seedPermission(permission: MockPermission): void {
+    this.permissions.set(permission.id, { ...permission });
   }
 }
+
+// =============================================================================
+// Mock Contact Repository
+// =============================================================================
+
+interface MockContact {
+  id: string;
+  friendCode: string;
+  nickname: string | null;
+  displayName: string;
+}
+
+const mockContacts: Map<string, MockContact> = new Map();
+
+// Mock the getContactRepository function
+jest.mock('../ContactRepository', () => ({
+  getContactRepository: () => ({
+    getByFriendCode: async (friendCode: string) => {
+      return mockContacts.get(friendCode) ?? null;
+    },
+  }),
+}));
 
 // =============================================================================
 // Tests
@@ -399,6 +513,618 @@ describe('VaultService', () => {
 
       const afterRemove = await service.getFolder(folder.id);
       expect(afterRemove?.itemCount).toBe(1);
+    });
+  });
+
+  // ===========================================================================
+  // Folder Description
+  // ===========================================================================
+
+  describe('Folder Description', () => {
+    it('should set folder description', async () => {
+      const folder = await service.createFolder('Units');
+      await service.setFolderDescription(folder.id, 'My units collection');
+
+      const updated = await service.getFolder(folder.id);
+      expect(updated?.description).toBe('My units collection');
+    });
+
+    it('should clear folder description', async () => {
+      const folder = await service.createFolder('Units', {
+        description: 'Initial description',
+      });
+      await service.setFolderDescription(folder.id, null);
+
+      const updated = await service.getFolder(folder.id);
+      expect(updated?.description).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // Move Folder
+  // ===========================================================================
+
+  describe('Move Folder', () => {
+    it('should move folder to new parent', async () => {
+      const parent1 = await service.createFolder('Parent 1');
+      const parent2 = await service.createFolder('Parent 2');
+      const child = await service.createFolder('Child', { parentId: parent1.id });
+
+      await service.moveFolder(child.id, parent2.id);
+
+      const moved = await service.getFolder(child.id);
+      expect(moved?.parentId).toBe(parent2.id);
+    });
+
+    it('should move folder to root', async () => {
+      const parent = await service.createFolder('Parent');
+      const child = await service.createFolder('Child', { parentId: parent.id });
+
+      await service.moveFolder(child.id, null);
+
+      const moved = await service.getFolder(child.id);
+      expect(moved?.parentId).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // All Folders
+  // ===========================================================================
+
+  describe('All Folders', () => {
+    it('should get all folders', async () => {
+      await service.createFolder('Folder 1');
+      await service.createFolder('Folder 2');
+      const parent = await service.createFolder('Parent');
+      await service.createFolder('Child', { parentId: parent.id });
+
+      const all = await service.getAllFolders();
+      expect(all).toHaveLength(4);
+    });
+  });
+
+  // ===========================================================================
+  // Sharing with Contacts
+  // ===========================================================================
+
+  describe('Sharing with Contacts', () => {
+    beforeEach(() => {
+      mockContacts.clear();
+      mockPermissionService.clear();
+    });
+
+    it('should share folder with contact', async () => {
+      const folder = await service.createFolder('Shared Folder');
+      mockContacts.set('PEER-1234-ABCD', {
+        id: 'contact-1',
+        friendCode: 'PEER-1234-ABCD',
+        nickname: 'TestUser',
+        displayName: 'Test User',
+      });
+
+      const result = await service.shareFolderWithContact(
+        folder.id,
+        'PEER-1234-ABCD',
+        'read'
+      );
+
+      expect(result).toBe(true);
+      const updatedFolder = await service.getFolder(folder.id);
+      expect(updatedFolder?.isShared).toBe(true);
+    });
+
+    it('should share folder with unknown contact using friend code as name', async () => {
+      const folder = await service.createFolder('Shared Folder');
+
+      const result = await service.shareFolderWithContact(
+        folder.id,
+        'UNKNOWN-CODE',
+        'read'
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should share item with contact', async () => {
+      mockContacts.set('PEER-1234-ABCD', {
+        id: 'contact-1',
+        friendCode: 'PEER-1234-ABCD',
+        nickname: null,
+        displayName: 'Test User',
+      });
+
+      const result = await service.shareItemWithContact(
+        'unit-123',
+        'unit',
+        'PEER-1234-ABCD',
+        'write'
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should share category with contact', async () => {
+      mockContacts.set('PEER-1234-ABCD', {
+        id: 'contact-1',
+        friendCode: 'PEER-1234-ABCD',
+        nickname: 'Friend',
+        displayName: 'Friendly User',
+      });
+
+      const result = await service.shareCategoryWithContact(
+        'units',
+        'PEER-1234-ABCD',
+        'read'
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // Unsharing
+  // ===========================================================================
+
+  describe('Unsharing', () => {
+    beforeEach(() => {
+      mockContacts.clear();
+      mockPermissionService.clear();
+    });
+
+    it('should unshare folder from contact', async () => {
+      const folder = await service.createFolder('Shared Folder');
+      mockContacts.set('PEER-1234-ABCD', {
+        id: 'contact-1',
+        friendCode: 'PEER-1234-ABCD',
+        nickname: null,
+        displayName: 'Test User',
+      });
+
+      await service.shareFolderWithContact(folder.id, 'PEER-1234-ABCD', 'read');
+
+      const result = await service.unshareFolder(folder.id, 'PEER-1234-ABCD');
+
+      expect(result).toBe(true);
+    });
+
+    it('should mark folder as not shared when all permissions revoked', async () => {
+      const folder = await service.createFolder('Shared Folder');
+      await service.shareFolderWithContact(folder.id, 'PEER-1234-ABCD', 'read');
+      await service.unshareFolder(folder.id, 'PEER-1234-ABCD');
+
+      const updatedFolder = await service.getFolder(folder.id);
+      expect(updatedFolder?.isShared).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // Folder with Permissions
+  // ===========================================================================
+
+  describe('Folder with Permissions', () => {
+    beforeEach(() => {
+      mockPermissionService.clear();
+    });
+
+    it('should get folder with permission info', async () => {
+      const folder = await service.createFolder('Shared Folder');
+      mockPermissionService.seedPermission({
+        id: 'perm-1',
+        granteeId: 'PEER-1234-ABCD',
+        granteeName: 'Test User',
+        scopeType: 'folder',
+        scopeId: folder.id,
+        level: 'read',
+      });
+
+      const result = await service.getFolderWithPermissions(folder.id);
+
+      expect(result).toBeDefined();
+      expect(result?.sharedWith).toHaveLength(1);
+      expect(result?.sharedWith[0].contactId).toBe('PEER-1234-ABCD');
+      expect(result?.sharedWith[0].level).toBe('read');
+    });
+
+    it('should return null for non-existent folder', async () => {
+      const result = await service.getFolderWithPermissions('non-existent');
+      expect(result).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // Shared Folders
+  // ===========================================================================
+
+  describe('Shared Folders', () => {
+    it('should get shared folders', async () => {
+      const folder1 = await service.createFolder('Folder 1');
+      await service.createFolder('Folder 2');
+      await mockFolderRepo.setFolderShared(folder1.id, true);
+
+      const shared = await service.getSharedFolders();
+
+      expect(shared).toHaveLength(1);
+      expect(shared[0].id).toBe(folder1.id);
+    });
+  });
+
+  // ===========================================================================
+  // Bulk Operations
+  // ===========================================================================
+
+  describe('Bulk Operations', () => {
+    beforeEach(() => {
+      mockContacts.clear();
+      mockPermissionService.clear();
+    });
+
+    it('should share folder with multiple contacts', async () => {
+      const folder = await service.createFolder('Shared');
+
+      const result = await service.shareFolderWithContacts(folder.id, [
+        { friendCode: 'PEER-1', level: 'read' },
+        { friendCode: 'PEER-2', level: 'write' },
+        { friendCode: 'PEER-3', level: 'admin' },
+      ]);
+
+      expect(result.success).toBe(3);
+      expect(result.failed).toBe(0);
+    });
+
+    it('should share multiple items with contact', async () => {
+      const result = await service.shareItemsWithContact(
+        [
+          { itemId: 'unit-1', itemType: 'unit' },
+          { itemId: 'pilot-1', itemType: 'pilot' },
+          { itemId: 'force-1', itemType: 'force' },
+        ],
+        'PEER-1234-ABCD',
+        'read'
+      );
+
+      expect(result.success).toBe(3);
+      expect(result.failed).toBe(0);
+    });
+
+    it('should share folder contents with contact', async () => {
+      const folder = await service.createFolder('Units');
+      await service.addItemToFolder(folder.id, 'unit-1', 'unit');
+      await service.addItemToFolder(folder.id, 'unit-2', 'unit');
+
+      const result = await service.shareFolderContentsWithContact(
+        folder.id,
+        'PEER-1234-ABCD',
+        'read'
+      );
+
+      expect(result.folderShared).toBe(true);
+      expect(result.itemsShared).toBe(2);
+    });
+
+    it('should revoke all permissions for contact', async () => {
+      mockPermissionService.seedPermission({
+        id: 'perm-1',
+        granteeId: 'PEER-1234-ABCD',
+        scopeType: 'folder',
+        scopeId: 'folder-1',
+        level: 'read',
+      });
+      mockPermissionService.seedPermission({
+        id: 'perm-2',
+        granteeId: 'PEER-1234-ABCD',
+        scopeType: 'item',
+        scopeId: 'unit:unit-1',
+        level: 'write',
+      });
+
+      const revoked = await service.revokeAllForContact('PEER-1234-ABCD');
+
+      expect(revoked).toBe(2);
+    });
+
+    it('should update permission level for all contact shares', async () => {
+      mockPermissionService.seedPermission({
+        id: 'perm-1',
+        granteeId: 'PEER-1234-ABCD',
+        scopeType: 'folder',
+        scopeId: 'folder-1',
+        level: 'read',
+      });
+      mockPermissionService.seedPermission({
+        id: 'perm-2',
+        granteeId: 'PEER-1234-ABCD',
+        scopeType: 'item',
+        scopeId: 'unit:unit-1',
+        level: 'read',
+      });
+
+      const updated = await service.updateContactPermissionLevel(
+        'PEER-1234-ABCD',
+        'write'
+      );
+
+      expect(updated).toBe(2);
+    });
+  });
+
+  // ===========================================================================
+  // Access Checking
+  // ===========================================================================
+
+  describe('Access Checking', () => {
+    beforeEach(() => {
+      mockPermissionService.clear();
+    });
+
+    it('should check folder access', async () => {
+      const folder = await service.createFolder('Protected');
+      mockPermissionService.seedPermission({
+        id: 'perm-1',
+        granteeId: 'PEER-1234-ABCD',
+        scopeType: 'folder',
+        scopeId: folder.id,
+        level: 'read',
+      });
+
+      const level = await service.canAccessFolder(folder.id, 'PEER-1234-ABCD');
+
+      expect(level).toBe('read');
+    });
+
+    it('should return null for no folder access', async () => {
+      const folder = await service.createFolder('Protected');
+
+      const level = await service.canAccessFolder(folder.id, 'UNKNOWN-PEER');
+
+      expect(level).toBeNull();
+    });
+
+    it('should check item access via direct permission', async () => {
+      mockPermissionService.seedPermission({
+        id: 'perm-1',
+        granteeId: 'PEER-1234-ABCD',
+        scopeType: 'item',
+        scopeId: 'unit:unit-123',
+        level: 'write',
+      });
+
+      const level = await service.canAccessItem(
+        'unit-123',
+        'unit',
+        'PEER-1234-ABCD'
+      );
+
+      expect(level).toBe('write');
+    });
+
+    it('should check item access via folder permission', async () => {
+      const folder = await service.createFolder('Units');
+      await service.addItemToFolder(folder.id, 'unit-123', 'unit');
+      mockPermissionService.seedPermission({
+        id: 'perm-1',
+        granteeId: 'PEER-1234-ABCD',
+        scopeType: 'folder',
+        scopeId: folder.id,
+        level: 'admin',
+      });
+
+      const level = await service.canAccessItem(
+        'unit-123',
+        'unit',
+        'PEER-1234-ABCD'
+      );
+
+      expect(level).toBe('admin');
+    });
+
+    it('should check item access via category permission', async () => {
+      mockPermissionService.seedPermission({
+        id: 'perm-1',
+        granteeId: 'PEER-1234-ABCD',
+        scopeType: 'category',
+        scopeId: null,
+        scopeCategory: 'units',
+        level: 'read',
+      });
+
+      const level = await service.canAccessItem(
+        'unit-123',
+        'unit',
+        'PEER-1234-ABCD'
+      );
+
+      expect(level).toBe('read');
+    });
+
+    it('should get shared content for user', async () => {
+      mockPermissionService.seedPermission({
+        id: 'perm-1',
+        granteeId: 'MY-FRIEND-CODE',
+        scopeType: 'folder',
+        scopeId: 'folder-1',
+        level: 'read',
+      });
+
+      const shared = await service.getSharedWithMe('MY-FRIEND-CODE');
+
+      expect(shared).toHaveLength(1);
+      expect(shared[0].scopeType).toBe('folder');
+      expect(shared[0].level).toBe('read');
+    });
+
+    it('should exclude public permissions from shared with me', async () => {
+      mockPermissionService.seedPermission({
+        id: 'perm-1',
+        granteeId: 'public',
+        scopeType: 'item',
+        scopeId: 'unit:unit-1',
+        level: 'read',
+      });
+
+      const shared = await service.getSharedWithMe('MY-FRIEND-CODE');
+
+      expect(shared).toHaveLength(0);
+    });
+  });
+
+  // ===========================================================================
+  // Public Sharing
+  // ===========================================================================
+
+  describe('Public Sharing', () => {
+    beforeEach(() => {
+      mockPermissionService.clear();
+    });
+
+    it('should make item public', async () => {
+      const result = await service.makePublic('unit-123', 'unit', 'read');
+
+      expect(result).toBe(true);
+    });
+
+    it('should make item public with default level', async () => {
+      const result = await service.makePublic('unit-123', 'unit');
+
+      expect(result).toBe(true);
+    });
+
+    it('should make folder public', async () => {
+      const folder = await service.createFolder('Public Folder');
+
+      const result = await service.makeFolderPublic(folder.id, 'read');
+
+      expect(result).toBe(true);
+      const updated = await service.getFolder(folder.id);
+      expect(updated?.isShared).toBe(true);
+    });
+
+    it('should make category public', async () => {
+      const result = await service.makeCategoryPublic('units', 'read');
+
+      expect(result).toBe(true);
+    });
+
+    it('should remove public access from item', async () => {
+      await service.makePublic('unit-123', 'unit');
+      mockPermissionService.seedPermission({
+        id: 'public-perm',
+        granteeId: 'public',
+        scopeType: 'item',
+        scopeId: 'unit:unit-123',
+        level: 'read',
+      });
+
+      const result = await service.removePublicAccess('unit-123', 'unit');
+
+      expect(result).toBe(true);
+    });
+
+    it('should remove public access from folder', async () => {
+      const folder = await service.createFolder('Was Public');
+      await service.makeFolderPublic(folder.id);
+      mockPermissionService.seedPermission({
+        id: 'public-perm',
+        granteeId: 'public',
+        scopeType: 'folder',
+        scopeId: folder.id,
+        level: 'read',
+      });
+
+      const result = await service.removeFolderPublicAccess(folder.id);
+
+      expect(result).toBe(true);
+    });
+
+    it('should check if item is public', async () => {
+      mockPermissionService.seedPermission({
+        id: 'public-perm',
+        granteeId: 'public',
+        scopeType: 'item',
+        scopeId: 'unit:unit-123',
+        level: 'read',
+      });
+
+      const level = await service.isPublic('unit-123', 'unit');
+
+      expect(level).toBe('read');
+    });
+
+    it('should return null for non-public item', async () => {
+      const level = await service.isPublic('unit-123', 'unit');
+
+      expect(level).toBeNull();
+    });
+
+    it('should check if folder is public', async () => {
+      const folder = await service.createFolder('Public');
+      mockPermissionService.seedPermission({
+        id: 'public-perm',
+        granteeId: 'public',
+        scopeType: 'folder',
+        scopeId: folder.id,
+        level: 'write',
+      });
+
+      const level = await service.isFolderPublic(folder.id);
+
+      expect(level).toBe('write');
+    });
+
+    it('should get all public items', async () => {
+      mockPermissionService.seedPermission({
+        id: 'pub-1',
+        granteeId: 'public',
+        scopeType: 'item',
+        scopeId: 'unit:unit-1',
+        level: 'read',
+      });
+      mockPermissionService.seedPermission({
+        id: 'pub-2',
+        granteeId: 'public',
+        scopeType: 'folder',
+        scopeId: 'folder-1',
+        level: 'read',
+      });
+
+      const items = await service.getPublicItems();
+
+      expect(items).toHaveLength(2);
+    });
+  });
+
+  // ===========================================================================
+  // Delete Folder with Permissions
+  // ===========================================================================
+
+  describe('Delete Folder with Permissions', () => {
+    beforeEach(() => {
+      mockPermissionService.clear();
+    });
+
+    it('should revoke permissions when deleting folder', async () => {
+      const folder = await service.createFolder('To Delete');
+      mockPermissionService.seedPermission({
+        id: 'perm-1',
+        granteeId: 'PEER-1',
+        scopeType: 'folder',
+        scopeId: folder.id,
+        level: 'read',
+      });
+      mockPermissionService.seedPermission({
+        id: 'perm-2',
+        granteeId: 'PEER-2',
+        scopeType: 'folder',
+        scopeId: folder.id,
+        level: 'write',
+      });
+
+      await service.deleteFolder(folder.id);
+
+      const perms = await mockPermissionService.getGrantsForItem(
+        'folder',
+        folder.id
+      );
+      expect(perms).toHaveLength(0);
     });
   });
 });

--- a/src/utils/gameplay/__tests__/gameEvents.test.ts
+++ b/src/utils/gameplay/__tests__/gameEvents.test.ts
@@ -1,0 +1,1196 @@
+/**
+ * Game Events Tests
+ *
+ * Comprehensive tests for game event factory functions and serialization utilities.
+ *
+ * @spec openspec/changes/add-game-session-core/specs/game-session-core/spec.md
+ */
+
+import {
+  generateEventId,
+  createGameCreatedEvent,
+  createGameStartedEvent,
+  createGameEndedEvent,
+  createPhaseChangedEvent,
+  createInitiativeRolledEvent,
+  createMovementDeclaredEvent,
+  createMovementLockedEvent,
+  createAttackDeclaredEvent,
+  createAttackResolvedEvent,
+  createDamageAppliedEvent,
+  createHeatGeneratedEvent,
+  createHeatDissipatedEvent,
+  createPilotHitEvent,
+  createUnitDestroyedEvent,
+  serializeEvent,
+  deserializeEvent,
+  serializeEvents,
+  deserializeEvents,
+} from '../gameEvents';
+
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IGameConfig,
+  IGameUnit,
+  Facing,
+  MovementType,
+  IToHitModifier,
+} from '@/types/gameplay';
+
+// =============================================================================
+// Test Fixtures
+// =============================================================================
+
+function createTestConfig(overrides: Partial<IGameConfig> = {}): IGameConfig {
+  return {
+    mapRadius: 10,
+    turnLimit: 0,
+    victoryConditions: ['elimination'],
+    optionalRules: [],
+    ...overrides,
+  };
+}
+
+function createTestUnit(overrides: Partial<IGameUnit> = {}): IGameUnit {
+  return {
+    id: 'unit-1',
+    name: 'Test Mech',
+    side: GameSide.Player,
+    unitRef: 'atlas-as7-d',
+    pilotRef: 'pilot-1',
+    gunnery: 4,
+    piloting: 5,
+    ...overrides,
+  };
+}
+
+function createTestModifiers(): readonly IToHitModifier[] {
+  return [
+    { name: 'Range', value: 2, source: 'range_calculator' },
+    { name: 'Target Movement', value: 1, source: 'target_movement' },
+  ];
+}
+
+// =============================================================================
+// generateEventId Tests
+// =============================================================================
+
+describe('generateEventId', () => {
+  it('should generate a unique ID', () => {
+    const id1 = generateEventId();
+    const id2 = generateEventId();
+
+    expect(id1).toBeDefined();
+    expect(typeof id1).toBe('string');
+    expect(id1).not.toBe(id2);
+  });
+
+  it('should generate UUID-format string', () => {
+    const id = generateEventId();
+    // UUID v4 format: 8-4-4-4-12 hex characters
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    expect(id).toMatch(uuidRegex);
+  });
+});
+
+// =============================================================================
+// Lifecycle Event Factory Tests
+// =============================================================================
+
+describe('Lifecycle Event Factories', () => {
+  describe('createGameCreatedEvent', () => {
+    it('should create a valid game created event', () => {
+      const config = createTestConfig();
+      const units = [createTestUnit()];
+
+      const event = createGameCreatedEvent('game-1', config, units);
+
+      expect(event.type).toBe(GameEventType.GameCreated);
+      expect(event.gameId).toBe('game-1');
+      expect(event.sequence).toBe(0);
+      expect(event.turn).toBe(0);
+      expect(event.phase).toBe(GamePhase.Initiative);
+      expect(event.id).toBeDefined();
+      expect(event.timestamp).toBeDefined();
+    });
+
+    it('should include config and units in payload', () => {
+      const config = createTestConfig({ turnLimit: 10 });
+      const units = [
+        createTestUnit({ id: 'unit-1', side: GameSide.Player }),
+        createTestUnit({ id: 'unit-2', side: GameSide.Opponent }),
+      ];
+
+      const event = createGameCreatedEvent('game-1', config, units);
+      const payload = event.payload as { config: IGameConfig; units: readonly IGameUnit[] };
+
+      expect(payload.config).toBe(config);
+      expect(payload.units).toBe(units);
+      expect(payload.units).toHaveLength(2);
+    });
+
+    it('should have valid ISO timestamp', () => {
+      const event = createGameCreatedEvent('game-1', createTestConfig(), []);
+
+      const timestamp = new Date(event.timestamp);
+      expect(timestamp.toISOString()).toBe(event.timestamp);
+    });
+  });
+
+  describe('createGameStartedEvent', () => {
+    it('should create a valid game started event', () => {
+      const event = createGameStartedEvent('game-1', 1, GameSide.Player);
+
+      expect(event.type).toBe(GameEventType.GameStarted);
+      expect(event.gameId).toBe('game-1');
+      expect(event.sequence).toBe(1);
+      expect(event.turn).toBe(1);
+      expect(event.phase).toBe(GamePhase.Initiative);
+    });
+
+    it('should include firstSide in payload', () => {
+      const event = createGameStartedEvent('game-1', 1, GameSide.Opponent);
+      const payload = event.payload as { firstSide: GameSide };
+
+      expect(payload.firstSide).toBe(GameSide.Opponent);
+    });
+  });
+
+  describe('createGameEndedEvent', () => {
+    it('should create a valid game ended event with winner', () => {
+      const event = createGameEndedEvent(
+        'game-1',
+        100,
+        10,
+        GamePhase.End,
+        GameSide.Player,
+        'destruction'
+      );
+
+      expect(event.type).toBe(GameEventType.GameEnded);
+      expect(event.gameId).toBe('game-1');
+      expect(event.sequence).toBe(100);
+      expect(event.turn).toBe(10);
+      expect(event.phase).toBe(GamePhase.End);
+    });
+
+    it('should include winner and reason in payload', () => {
+      const event = createGameEndedEvent(
+        'game-1',
+        50,
+        5,
+        GamePhase.End,
+        GameSide.Opponent,
+        'concede'
+      );
+      const payload = event.payload as {
+        winner: GameSide | 'draw';
+        reason: string;
+      };
+
+      expect(payload.winner).toBe(GameSide.Opponent);
+      expect(payload.reason).toBe('concede');
+    });
+
+    it('should handle draw result', () => {
+      const event = createGameEndedEvent(
+        'game-1',
+        200,
+        20,
+        GamePhase.End,
+        'draw',
+        'turn_limit'
+      );
+      const payload = event.payload as { winner: GameSide | 'draw'; reason: string };
+
+      expect(payload.winner).toBe('draw');
+      expect(payload.reason).toBe('turn_limit');
+    });
+
+    it('should support all end reasons', () => {
+      const reasons = ['destruction', 'concede', 'turn_limit', 'objective'] as const;
+
+      for (const reason of reasons) {
+        const event = createGameEndedEvent(
+          'game-1',
+          1,
+          1,
+          GamePhase.End,
+          GameSide.Player,
+          reason
+        );
+        const payload = event.payload as { reason: string };
+        expect(payload.reason).toBe(reason);
+      }
+    });
+  });
+});
+
+// =============================================================================
+// Turn/Phase Event Factory Tests
+// =============================================================================
+
+describe('Turn/Phase Event Factories', () => {
+  describe('createPhaseChangedEvent', () => {
+    it('should create a valid phase changed event', () => {
+      const event = createPhaseChangedEvent(
+        'game-1',
+        5,
+        2,
+        GamePhase.Initiative,
+        GamePhase.Movement
+      );
+
+      expect(event.type).toBe(GameEventType.PhaseChanged);
+      expect(event.gameId).toBe('game-1');
+      expect(event.sequence).toBe(5);
+      expect(event.turn).toBe(2);
+      expect(event.phase).toBe(GamePhase.Movement);
+    });
+
+    it('should include fromPhase and toPhase in payload', () => {
+      const event = createPhaseChangedEvent(
+        'game-1',
+        10,
+        3,
+        GamePhase.Movement,
+        GamePhase.WeaponAttack
+      );
+      const payload = event.payload as { fromPhase: GamePhase; toPhase: GamePhase };
+
+      expect(payload.fromPhase).toBe(GamePhase.Movement);
+      expect(payload.toPhase).toBe(GamePhase.WeaponAttack);
+    });
+
+    it('should handle all phase transitions', () => {
+      const phases = [
+        GamePhase.Initiative,
+        GamePhase.Movement,
+        GamePhase.WeaponAttack,
+        GamePhase.PhysicalAttack,
+        GamePhase.Heat,
+        GamePhase.End,
+      ];
+
+      for (let i = 0; i < phases.length - 1; i++) {
+        const event = createPhaseChangedEvent('game-1', i, 1, phases[i], phases[i + 1]);
+        const payload = event.payload as { fromPhase: GamePhase; toPhase: GamePhase };
+
+        expect(payload.fromPhase).toBe(phases[i]);
+        expect(payload.toPhase).toBe(phases[i + 1]);
+      }
+    });
+  });
+});
+
+// =============================================================================
+// Initiative Event Factory Tests
+// =============================================================================
+
+describe('Initiative Event Factories', () => {
+  describe('createInitiativeRolledEvent', () => {
+    it('should create a valid initiative rolled event', () => {
+      const event = createInitiativeRolledEvent(
+        'game-1',
+        3,
+        1,
+        8,
+        5,
+        GameSide.Player,
+        GameSide.Opponent
+      );
+
+      expect(event.type).toBe(GameEventType.InitiativeRolled);
+      expect(event.gameId).toBe('game-1');
+      expect(event.sequence).toBe(3);
+      expect(event.turn).toBe(1);
+      expect(event.phase).toBe(GamePhase.Initiative);
+    });
+
+    it('should include all roll data in payload', () => {
+      const event = createInitiativeRolledEvent(
+        'game-1',
+        3,
+        2,
+        10,
+        7,
+        GameSide.Player,
+        GameSide.Player
+      );
+      const payload = event.payload as {
+        playerRoll: number;
+        opponentRoll: number;
+        winner: GameSide;
+        movesFirst: GameSide;
+      };
+
+      expect(payload.playerRoll).toBe(10);
+      expect(payload.opponentRoll).toBe(7);
+      expect(payload.winner).toBe(GameSide.Player);
+      expect(payload.movesFirst).toBe(GameSide.Player);
+    });
+
+    it('should handle opponent winning initiative', () => {
+      const event = createInitiativeRolledEvent(
+        'game-1',
+        3,
+        1,
+        5,
+        9,
+        GameSide.Opponent,
+        GameSide.Player
+      );
+      const payload = event.payload as {
+        winner: GameSide;
+        movesFirst: GameSide;
+      };
+
+      expect(payload.winner).toBe(GameSide.Opponent);
+      expect(payload.movesFirst).toBe(GameSide.Player);
+    });
+
+    it('should handle edge case dice rolls', () => {
+      // Minimum roll (2)
+      const minEvent = createInitiativeRolledEvent(
+        'game-1',
+        1,
+        1,
+        2,
+        12,
+        GameSide.Opponent,
+        GameSide.Player
+      );
+      const minPayload = minEvent.payload as { playerRoll: number; opponentRoll: number };
+      expect(minPayload.playerRoll).toBe(2);
+      expect(minPayload.opponentRoll).toBe(12);
+
+      // Maximum roll (12)
+      const maxEvent = createInitiativeRolledEvent(
+        'game-1',
+        1,
+        1,
+        12,
+        2,
+        GameSide.Player,
+        GameSide.Opponent
+      );
+      const maxPayload = maxEvent.payload as { playerRoll: number; opponentRoll: number };
+      expect(maxPayload.playerRoll).toBe(12);
+      expect(maxPayload.opponentRoll).toBe(2);
+    });
+  });
+});
+
+// =============================================================================
+// Movement Event Factory Tests
+// =============================================================================
+
+describe('Movement Event Factories', () => {
+  describe('createMovementDeclaredEvent', () => {
+    it('should create a valid movement declared event', () => {
+      const event = createMovementDeclaredEvent(
+        'game-1',
+        10,
+        2,
+        'unit-1',
+        { q: 0, r: 0 },
+        { q: 2, r: -1 },
+        Facing.Northeast,
+        MovementType.Walk,
+        4,
+        0
+      );
+
+      expect(event.type).toBe(GameEventType.MovementDeclared);
+      expect(event.gameId).toBe('game-1');
+      expect(event.sequence).toBe(10);
+      expect(event.turn).toBe(2);
+      expect(event.phase).toBe(GamePhase.Movement);
+      expect(event.actorId).toBe('unit-1');
+    });
+
+    it('should include all movement data in payload', () => {
+      const from = { q: -2, r: 3 };
+      const to = { q: 1, r: 0 };
+
+      const event = createMovementDeclaredEvent(
+        'game-1',
+        10,
+        2,
+        'unit-1',
+        from,
+        to,
+        Facing.South,
+        MovementType.Run,
+        8,
+        2
+      );
+      const payload = event.payload as {
+        unitId: string;
+        from: { q: number; r: number };
+        to: { q: number; r: number };
+        facing: Facing;
+        movementType: MovementType;
+        mpUsed: number;
+        heatGenerated: number;
+      };
+
+      expect(payload.unitId).toBe('unit-1');
+      expect(payload.from).toEqual(from);
+      expect(payload.to).toEqual(to);
+      expect(payload.facing).toBe(Facing.South);
+      expect(payload.movementType).toBe(MovementType.Run);
+      expect(payload.mpUsed).toBe(8);
+      expect(payload.heatGenerated).toBe(2);
+    });
+
+    it('should handle jump movement with heat', () => {
+      const event = createMovementDeclaredEvent(
+        'game-1',
+        15,
+        3,
+        'unit-2',
+        { q: 0, r: 0 },
+        { q: 4, r: -2 },
+        Facing.Northwest,
+        MovementType.Jump,
+        5,
+        5
+      );
+      const payload = event.payload as {
+        movementType: MovementType;
+        heatGenerated: number;
+      };
+
+      expect(payload.movementType).toBe(MovementType.Jump);
+      expect(payload.heatGenerated).toBe(5);
+    });
+
+    it('should handle stationary movement', () => {
+      const position = { q: 3, r: 3 };
+      const event = createMovementDeclaredEvent(
+        'game-1',
+        10,
+        1,
+        'unit-1',
+        position,
+        position,
+        Facing.North,
+        MovementType.Stationary,
+        0,
+        0
+      );
+      const payload = event.payload as {
+        from: { q: number; r: number };
+        to: { q: number; r: number };
+        mpUsed: number;
+        heatGenerated: number;
+      };
+
+      expect(payload.from).toEqual(position);
+      expect(payload.to).toEqual(position);
+      expect(payload.mpUsed).toBe(0);
+      expect(payload.heatGenerated).toBe(0);
+    });
+  });
+
+  describe('createMovementLockedEvent', () => {
+    it('should create a valid movement locked event', () => {
+      const event = createMovementLockedEvent('game-1', 11, 2, 'unit-1');
+
+      expect(event.type).toBe(GameEventType.MovementLocked);
+      expect(event.gameId).toBe('game-1');
+      expect(event.sequence).toBe(11);
+      expect(event.turn).toBe(2);
+      expect(event.phase).toBe(GamePhase.Movement);
+      expect(event.actorId).toBe('unit-1');
+    });
+
+    it('should include unitId in payload', () => {
+      const event = createMovementLockedEvent('game-1', 12, 3, 'mech-atlas');
+      const payload = event.payload as { unitId: string };
+
+      expect(payload.unitId).toBe('mech-atlas');
+    });
+  });
+});
+
+// =============================================================================
+// Combat Event Factory Tests
+// =============================================================================
+
+describe('Combat Event Factories', () => {
+  describe('createAttackDeclaredEvent', () => {
+    it('should create a valid attack declared event', () => {
+      const modifiers = createTestModifiers();
+
+      const event = createAttackDeclaredEvent(
+        'game-1',
+        20,
+        3,
+        'unit-1',
+        'unit-2',
+        ['medium_laser_1', 'medium_laser_2'],
+        7,
+        modifiers
+      );
+
+      expect(event.type).toBe(GameEventType.AttackDeclared);
+      expect(event.gameId).toBe('game-1');
+      expect(event.sequence).toBe(20);
+      expect(event.turn).toBe(3);
+      expect(event.phase).toBe(GamePhase.WeaponAttack);
+      expect(event.actorId).toBe('unit-1');
+    });
+
+    it('should include all attack data in payload', () => {
+      const modifiers = createTestModifiers();
+
+      const event = createAttackDeclaredEvent(
+        'game-1',
+        20,
+        3,
+        'attacker-1',
+        'target-1',
+        ['ppc', 'ac10'],
+        9,
+        modifiers
+      );
+      const payload = event.payload as {
+        attackerId: string;
+        targetId: string;
+        weapons: readonly string[];
+        toHitNumber: number;
+        modifiers: readonly IToHitModifier[];
+      };
+
+      expect(payload.attackerId).toBe('attacker-1');
+      expect(payload.targetId).toBe('target-1');
+      expect(payload.weapons).toEqual(['ppc', 'ac10']);
+      expect(payload.toHitNumber).toBe(9);
+      expect(payload.modifiers).toEqual(modifiers);
+    });
+
+    it('should handle single weapon attack', () => {
+      const event = createAttackDeclaredEvent(
+        'game-1',
+        25,
+        4,
+        'unit-1',
+        'unit-2',
+        ['gauss_rifle'],
+        5,
+        []
+      );
+      const payload = event.payload as { weapons: readonly string[] };
+
+      expect(payload.weapons).toHaveLength(1);
+      expect(payload.weapons[0]).toBe('gauss_rifle');
+    });
+  });
+
+  describe('createAttackResolvedEvent', () => {
+    it('should create a valid attack resolved event for a hit', () => {
+      const event = createAttackResolvedEvent(
+        'game-1',
+        21,
+        3,
+        'unit-1',
+        'unit-2',
+        'medium_laser_1',
+        8,
+        7,
+        true,
+        'center_torso',
+        5
+      );
+
+      expect(event.type).toBe(GameEventType.AttackResolved);
+      expect(event.gameId).toBe('game-1');
+      expect(event.sequence).toBe(21);
+      expect(event.turn).toBe(3);
+      expect(event.phase).toBe(GamePhase.WeaponAttack);
+      expect(event.actorId).toBe('unit-1');
+    });
+
+    it('should include all hit data in payload', () => {
+      const event = createAttackResolvedEvent(
+        'game-1',
+        21,
+        3,
+        'attacker',
+        'target',
+        'ppc',
+        9,
+        7,
+        true,
+        'left_arm',
+        10
+      );
+      const payload = event.payload as {
+        attackerId: string;
+        targetId: string;
+        weaponId: string;
+        roll: number;
+        toHitNumber: number;
+        hit: boolean;
+        location: string | undefined;
+        damage: number | undefined;
+      };
+
+      expect(payload.attackerId).toBe('attacker');
+      expect(payload.targetId).toBe('target');
+      expect(payload.weaponId).toBe('ppc');
+      expect(payload.roll).toBe(9);
+      expect(payload.toHitNumber).toBe(7);
+      expect(payload.hit).toBe(true);
+      expect(payload.location).toBe('left_arm');
+      expect(payload.damage).toBe(10);
+    });
+
+    it('should handle miss result', () => {
+      const event = createAttackResolvedEvent(
+        'game-1',
+        22,
+        3,
+        'unit-1',
+        'unit-2',
+        'ac20',
+        5,
+        8,
+        false,
+        undefined,
+        undefined
+      );
+      const payload = event.payload as {
+        hit: boolean;
+        location: string | undefined;
+        damage: number | undefined;
+      };
+
+      expect(payload.hit).toBe(false);
+      expect(payload.location).toBeUndefined();
+      expect(payload.damage).toBeUndefined();
+    });
+  });
+
+  describe('createDamageAppliedEvent', () => {
+    it('should create a valid damage applied event', () => {
+      const event = createDamageAppliedEvent(
+        'game-1',
+        30,
+        4,
+        'unit-2',
+        'center_torso',
+        10,
+        15,
+        20,
+        false,
+        undefined
+      );
+
+      expect(event.type).toBe(GameEventType.DamageApplied);
+      expect(event.gameId).toBe('game-1');
+      expect(event.sequence).toBe(30);
+      expect(event.turn).toBe(4);
+      expect(event.phase).toBe(GamePhase.WeaponAttack);
+      expect(event.actorId).toBe('unit-2');
+    });
+
+    it('should include all damage data in payload', () => {
+      const event = createDamageAppliedEvent(
+        'game-1',
+        30,
+        4,
+        'target',
+        'right_torso',
+        15,
+        5,
+        12,
+        false,
+        ['ammo_srm6']
+      );
+      const payload = event.payload as {
+        unitId: string;
+        location: string;
+        damage: number;
+        armorRemaining: number;
+        structureRemaining: number;
+        locationDestroyed: boolean;
+        criticals: readonly string[] | undefined;
+      };
+
+      expect(payload.unitId).toBe('target');
+      expect(payload.location).toBe('right_torso');
+      expect(payload.damage).toBe(15);
+      expect(payload.armorRemaining).toBe(5);
+      expect(payload.structureRemaining).toBe(12);
+      expect(payload.locationDestroyed).toBe(false);
+      expect(payload.criticals).toEqual(['ammo_srm6']);
+    });
+
+    it('should handle location destruction', () => {
+      const event = createDamageAppliedEvent(
+        'game-1',
+        35,
+        5,
+        'unit-1',
+        'left_arm',
+        25,
+        0,
+        0,
+        true,
+        ['hand_actuator', 'medium_laser']
+      );
+      const payload = event.payload as {
+        locationDestroyed: boolean;
+        armorRemaining: number;
+        structureRemaining: number;
+        criticals: readonly string[] | undefined;
+      };
+
+      expect(payload.locationDestroyed).toBe(true);
+      expect(payload.armorRemaining).toBe(0);
+      expect(payload.structureRemaining).toBe(0);
+      expect(payload.criticals).toEqual(['hand_actuator', 'medium_laser']);
+    });
+
+    it('should handle damage without criticals', () => {
+      const event = createDamageAppliedEvent(
+        'game-1',
+        31,
+        4,
+        'unit-2',
+        'head',
+        5,
+        4,
+        3,
+        false,
+        undefined
+      );
+      const payload = event.payload as { criticals: readonly string[] | undefined };
+
+      expect(payload.criticals).toBeUndefined();
+    });
+  });
+});
+
+// =============================================================================
+// Status Event Factory Tests
+// =============================================================================
+
+describe('Status Event Factories', () => {
+  describe('createHeatGeneratedEvent', () => {
+    it('should create a valid heat generated event', () => {
+      const event = createHeatGeneratedEvent(
+        'game-1',
+        40,
+        5,
+        GamePhase.WeaponAttack,
+        'unit-1',
+        10,
+        'weapons',
+        15
+      );
+
+      expect(event.type).toBe(GameEventType.HeatGenerated);
+      expect(event.gameId).toBe('game-1');
+      expect(event.sequence).toBe(40);
+      expect(event.turn).toBe(5);
+      expect(event.phase).toBe(GamePhase.WeaponAttack);
+      expect(event.actorId).toBe('unit-1');
+    });
+
+    it('should include all heat data in payload', () => {
+      const event = createHeatGeneratedEvent(
+        'game-1',
+        40,
+        5,
+        GamePhase.Movement,
+        'mech-1',
+        4,
+        'movement',
+        8
+      );
+      const payload = event.payload as {
+        unitId: string;
+        amount: number;
+        source: string;
+        newTotal: number;
+      };
+
+      expect(payload.unitId).toBe('mech-1');
+      expect(payload.amount).toBe(4);
+      expect(payload.source).toBe('movement');
+      expect(payload.newTotal).toBe(8);
+    });
+
+    it('should handle all heat sources', () => {
+      const sources = ['movement', 'weapons', 'dissipation', 'external'] as const;
+
+      for (const source of sources) {
+        const event = createHeatGeneratedEvent(
+          'game-1',
+          1,
+          1,
+          GamePhase.Heat,
+          'unit-1',
+          5,
+          source,
+          10
+        );
+        const payload = event.payload as { source: string };
+        expect(payload.source).toBe(source);
+      }
+    });
+  });
+
+  describe('createHeatDissipatedEvent', () => {
+    it('should create a valid heat dissipated event', () => {
+      const event = createHeatDissipatedEvent('game-1', 50, 5, 'unit-1', 10, 5);
+
+      expect(event.type).toBe(GameEventType.HeatDissipated);
+      expect(event.gameId).toBe('game-1');
+      expect(event.sequence).toBe(50);
+      expect(event.turn).toBe(5);
+      expect(event.phase).toBe(GamePhase.Heat);
+      expect(event.actorId).toBe('unit-1');
+    });
+
+    it('should negate the amount in payload', () => {
+      const event = createHeatDissipatedEvent('game-1', 50, 5, 'unit-1', 10, 5);
+      const payload = event.payload as {
+        amount: number;
+        source: string;
+        newTotal: number;
+      };
+
+      expect(payload.amount).toBe(-10);
+      expect(payload.source).toBe('dissipation');
+      expect(payload.newTotal).toBe(5);
+    });
+
+    it('should handle already negative amount', () => {
+      const event = createHeatDissipatedEvent('game-1', 51, 5, 'unit-1', -8, 2);
+      const payload = event.payload as { amount: number };
+
+      // Math.abs ensures positive before negating
+      expect(payload.amount).toBe(-8);
+    });
+  });
+
+  describe('createPilotHitEvent', () => {
+    it('should create a valid pilot hit event', () => {
+      const event = createPilotHitEvent(
+        'game-1',
+        60,
+        6,
+        GamePhase.WeaponAttack,
+        'unit-1',
+        1,
+        2,
+        'head_hit',
+        true,
+        true
+      );
+
+      expect(event.type).toBe(GameEventType.PilotHit);
+      expect(event.gameId).toBe('game-1');
+      expect(event.sequence).toBe(60);
+      expect(event.turn).toBe(6);
+      expect(event.phase).toBe(GamePhase.WeaponAttack);
+      expect(event.actorId).toBe('unit-1');
+    });
+
+    it('should include all pilot damage data in payload', () => {
+      const event = createPilotHitEvent(
+        'game-1',
+        60,
+        6,
+        GamePhase.WeaponAttack,
+        'mech-1',
+        2,
+        4,
+        'ammo_explosion',
+        true,
+        false
+      );
+      const payload = event.payload as {
+        unitId: string;
+        wounds: number;
+        totalWounds: number;
+        source: string;
+        consciousnessCheckRequired: boolean;
+        consciousnessCheckPassed: boolean | undefined;
+      };
+
+      expect(payload.unitId).toBe('mech-1');
+      expect(payload.wounds).toBe(2);
+      expect(payload.totalWounds).toBe(4);
+      expect(payload.source).toBe('ammo_explosion');
+      expect(payload.consciousnessCheckRequired).toBe(true);
+      expect(payload.consciousnessCheckPassed).toBe(false);
+    });
+
+    it('should handle all pilot damage sources', () => {
+      const sources = ['head_hit', 'ammo_explosion', 'mech_destruction'] as const;
+
+      for (const source of sources) {
+        const event = createPilotHitEvent(
+          'game-1',
+          1,
+          1,
+          GamePhase.WeaponAttack,
+          'unit-1',
+          1,
+          1,
+          source,
+          false,
+          undefined
+        );
+        const payload = event.payload as { source: string };
+        expect(payload.source).toBe(source);
+      }
+    });
+
+    it('should handle no consciousness check required', () => {
+      const event = createPilotHitEvent(
+        'game-1',
+        61,
+        6,
+        GamePhase.WeaponAttack,
+        'unit-1',
+        1,
+        1,
+        'head_hit',
+        false,
+        undefined
+      );
+      const payload = event.payload as {
+        consciousnessCheckRequired: boolean;
+        consciousnessCheckPassed: boolean | undefined;
+      };
+
+      expect(payload.consciousnessCheckRequired).toBe(false);
+      expect(payload.consciousnessCheckPassed).toBeUndefined();
+    });
+  });
+
+  describe('createUnitDestroyedEvent', () => {
+    it('should create a valid unit destroyed event', () => {
+      const event = createUnitDestroyedEvent(
+        'game-1',
+        70,
+        7,
+        GamePhase.WeaponAttack,
+        'unit-2',
+        'damage'
+      );
+
+      expect(event.type).toBe(GameEventType.UnitDestroyed);
+      expect(event.gameId).toBe('game-1');
+      expect(event.sequence).toBe(70);
+      expect(event.turn).toBe(7);
+      expect(event.phase).toBe(GamePhase.WeaponAttack);
+      expect(event.actorId).toBe('unit-2');
+    });
+
+    it('should include unitId and cause in payload', () => {
+      const event = createUnitDestroyedEvent(
+        'game-1',
+        70,
+        7,
+        GamePhase.Heat,
+        'mech-destroyed',
+        'shutdown'
+      );
+      const payload = event.payload as {
+        unitId: string;
+        cause: string;
+      };
+
+      expect(payload.unitId).toBe('mech-destroyed');
+      expect(payload.cause).toBe('shutdown');
+    });
+
+    it('should handle all destruction causes', () => {
+      const causes = ['damage', 'ammo_explosion', 'pilot_death', 'shutdown'] as const;
+
+      for (const cause of causes) {
+        const event = createUnitDestroyedEvent('game-1', 1, 1, GamePhase.End, 'unit-1', cause);
+        const payload = event.payload as { cause: string };
+        expect(payload.cause).toBe(cause);
+      }
+    });
+  });
+});
+
+// =============================================================================
+// Serialization Tests
+// =============================================================================
+
+describe('Event Serialization', () => {
+  describe('serializeEvent', () => {
+    it('should serialize event to JSON string', () => {
+      const event = createGameCreatedEvent('game-1', createTestConfig(), []);
+
+      const json = serializeEvent(event);
+
+      expect(typeof json).toBe('string');
+      expect(() => {
+        JSON.parse(json);
+      }).not.toThrow();
+    });
+
+    it('should preserve all event properties', () => {
+      const config = createTestConfig({ turnLimit: 5 });
+      const units = [createTestUnit()];
+      const event = createGameCreatedEvent('game-1', config, units);
+
+      const json = serializeEvent(event);
+      const parsed = JSON.parse(json) as {
+        type: string;
+        gameId: string;
+        payload: { config: { turnLimit: number }; units: unknown[] };
+      };
+
+      expect(parsed.type).toBe(GameEventType.GameCreated);
+      expect(parsed.gameId).toBe('game-1');
+      expect(parsed.payload.config.turnLimit).toBe(5);
+      expect(parsed.payload.units).toHaveLength(1);
+    });
+  });
+
+  describe('deserializeEvent', () => {
+    it('should deserialize JSON string to event', () => {
+      const original = createGameStartedEvent('game-1', 1, GameSide.Player);
+      const json = serializeEvent(original);
+
+      const deserialized = deserializeEvent(json);
+
+      expect(deserialized.type).toBe(original.type);
+      expect(deserialized.gameId).toBe(original.gameId);
+      expect(deserialized.id).toBe(original.id);
+    });
+
+    it('should preserve complex payload data', () => {
+      const modifiers = createTestModifiers();
+      const original = createAttackDeclaredEvent(
+        'game-1',
+        10,
+        2,
+        'attacker',
+        'target',
+        ['weapon1', 'weapon2'],
+        7,
+        modifiers
+      );
+      const json = serializeEvent(original);
+
+      const deserialized = deserializeEvent(json);
+      const payload = deserialized.payload as {
+        weapons: readonly string[];
+        modifiers: readonly IToHitModifier[];
+      };
+
+      expect(payload.weapons).toEqual(['weapon1', 'weapon2']);
+      expect(payload.modifiers).toEqual(modifiers);
+    });
+  });
+
+  describe('serializeEvents', () => {
+    it('should serialize multiple events to JSON array string', () => {
+      const events = [
+        createGameCreatedEvent('game-1', createTestConfig(), []),
+        createGameStartedEvent('game-1', 1, GameSide.Player),
+      ];
+
+      const json = serializeEvents(events);
+
+      expect(typeof json).toBe('string');
+      const parsed = JSON.parse(json) as unknown[];
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(2);
+    });
+
+    it('should handle empty array', () => {
+      const json = serializeEvents([]);
+
+      expect(json).toBe('[]');
+    });
+  });
+
+  describe('deserializeEvents', () => {
+    it('should deserialize JSON array string to events', () => {
+      const original = [
+        createGameCreatedEvent('game-1', createTestConfig(), [createTestUnit()]),
+        createGameStartedEvent('game-1', 1, GameSide.Player),
+        createPhaseChangedEvent('game-1', 2, 1, GamePhase.Initiative, GamePhase.Movement),
+      ];
+      const json = serializeEvents(original);
+
+      const deserialized = deserializeEvents(json);
+
+      expect(deserialized).toHaveLength(3);
+      expect(deserialized[0].type).toBe(GameEventType.GameCreated);
+      expect(deserialized[1].type).toBe(GameEventType.GameStarted);
+      expect(deserialized[2].type).toBe(GameEventType.PhaseChanged);
+    });
+
+    it('should handle empty array', () => {
+      const deserialized = deserializeEvents('[]');
+
+      expect(deserialized).toHaveLength(0);
+    });
+  });
+
+  describe('round-trip serialization', () => {
+    it('should maintain event integrity through serialize/deserialize', () => {
+      const events = [
+        createGameCreatedEvent('game-1', createTestConfig(), [createTestUnit()]),
+        createGameStartedEvent('game-1', 1, GameSide.Player),
+        createInitiativeRolledEvent('game-1', 2, 1, 7, 5, GameSide.Player, GameSide.Opponent),
+        createMovementDeclaredEvent(
+          'game-1',
+          3,
+          1,
+          'unit-1',
+          { q: 0, r: 0 },
+          { q: 2, r: -1 },
+          Facing.North,
+          MovementType.Walk,
+          4,
+          0
+        ),
+        createAttackDeclaredEvent(
+          'game-1',
+          4,
+          1,
+          'unit-1',
+          'unit-2',
+          ['laser'],
+          6,
+          createTestModifiers()
+        ),
+        createDamageAppliedEvent('game-1', 5, 1, 'unit-2', 'ct', 5, 10, 15, false, undefined),
+        createHeatGeneratedEvent('game-1', 6, 1, GamePhase.Heat, 'unit-1', 5, 'weapons', 10),
+        createPilotHitEvent('game-1', 7, 1, GamePhase.WeaponAttack, 'unit-2', 1, 1, 'head_hit', false, undefined),
+        createUnitDestroyedEvent('game-1', 8, 1, GamePhase.End, 'unit-2', 'damage'),
+        createGameEndedEvent('game-1', 9, 1, GamePhase.End, GameSide.Player, 'destruction'),
+      ];
+
+      const json = serializeEvents(events);
+      const restored = deserializeEvents(json);
+
+      expect(restored).toHaveLength(events.length);
+      for (let i = 0; i < events.length; i++) {
+        expect(restored[i].type).toBe(events[i].type);
+        expect(restored[i].gameId).toBe(events[i].gameId);
+        expect(restored[i].sequence).toBe(events[i].sequence);
+        expect(JSON.stringify(restored[i].payload)).toBe(JSON.stringify(events[i].payload));
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive test coverage for services and utilities:

### Vault Services
- **VaultService.test.ts** - 37 new tests (sharing, permissions, public access)
- **OfflineQueueService.test.ts** - 12 new tests (flush, cleanup, relay)
- **ExportService.test.ts** - 29 new tests (unit/pilot/force export)

### Asset & Printing
- **MmDataAssetService.test.ts** - 56 tests (asset loading, paths, caching)
- **equipmentUtils.test.ts** - 97 tests (damage codes, missile formatting)

### Validation & Gameplay
- **gameEvents.test.ts** - 64 tests (event creation, serialization)
- **initializeUnitValidation.test.ts** - 35 tests (rule registration)
- **PersonnelCategoryRules.test.ts** - 50 tests (squad size, weight, weapons)

## Changes

| File | Tests | Status |
|------|-------|--------|
| VaultService.test.ts | +37 | Enhanced |
| OfflineQueueService.test.ts | +12 | Enhanced |
| ExportService.test.ts | 29 | NEW |
| MmDataAssetService.test.ts | 56 | NEW |
| equipmentUtils.test.ts | 97 | NEW |
| gameEvents.test.ts | 64 | NEW |
| initializeUnitValidation.test.ts | 35 | NEW |
| PersonnelCategoryRules.test.ts | 50 | NEW |
| **Total** | **380** | |

## Test Results
All 9,690 tests passing.