### PR TITLE
feat(campaign): add campaign unit/pilot instance interfaces

### DIFF
--- a/openspec/changes/add-campaign-instances/tasks.md
+++ b/openspec/changes/add-campaign-instances/tasks.md
@@ -2,32 +2,39 @@
 
 ## 1. Type Definitions
 
-- [ ] 1.1 Define `ICampaignUnitInstance` interface:
+- [x] 1.1 Define `ICampaignUnitInstance` interface:
   - `id: string` (instance ID)
   - `campaignId: string`
   - `vaultUnitId: string` (reference to vault design)
   - `vaultUnitVersion: number` (snapshot of design version at assignment)
-  - `currentDamage: IUnitDamageState`
-  - `status: 'operational' | 'damaged' | 'destroyed' | 'repairing'`
+  - `damageState: IUnitDamageState`
+  - `status: CampaignUnitStatus` (operational, damaged, destroyed, repairing, salvage)
   - `assignedPilotInstanceId?: string`
-  - `createdAt: string`
-  - `updatedAt: string`
+  - `forceId?: string`, `forceSlot?: number`
+  - `totalKills`, `missionsParticipated`, `estimatedRepairCost`, `estimatedRepairTime`
+  - `createdAt: string`, `updatedAt: string`
+  - **Implemented in:** `src/types/campaign/CampaignInstanceInterfaces.ts`
 
-- [ ] 1.2 Define `ICampaignPilotInstance` interface:
+- [x] 1.2 Define `ICampaignPilotInstance` interface:
   - `id: string` (instance ID)
   - `campaignId: string`
-  - `vaultPilotId?: string` (reference to pilot template, optional for statblock pilots)
-  - `statblockData?: IStatblockPilot` (inline pilot data if no vault reference)
-  - `currentXP: number`
+  - `vaultPilotId: string | null` (reference to pilot template, null for statblock pilots)
+  - `statblockData: IPilotStatblock | null` (inline pilot data if no vault reference)
+  - `currentXP: number`, `campaignXPEarned: number`
   - `currentSkills: IPilotSkills`
   - `wounds: number`
-  - `status: 'active' | 'wounded' | 'incapacitated' | 'deceased'`
-  - `killCount: number`
-  - `missionsParticipated: number`
-  - `createdAt: string`
-  - `updatedAt: string`
+  - `status: CampaignPilotStatus` (active, wounded, critical, mia, kia)
+  - `killCount: number`, `missionsParticipated: number`
+  - `recoveryTime: number`
+  - `createdAt: string`, `updatedAt: string`
+  - **Implemented in:** `src/types/campaign/CampaignInstanceInterfaces.ts`
 
-- [ ] 1.3 Define `IUnitDamageState` interface for tracking damage
+- [x] 1.3 Define `IUnitDamageState` interface for tracking damage
+  - `ILocationDamageState` for per-location armor/structure/components
+  - `IComponentDamage` with `ComponentStatus` enum
+  - Engine/gyro/sensor/life-support hits tracking
+  - Ammo expenditure and heat tracking
+  - **Implemented in:** `src/types/campaign/CampaignInstanceInterfaces.ts`
 
 ## 2. Database Schema
 
@@ -64,6 +71,9 @@
 
 ## 7. Testing
 
-- [ ] 7.1 Unit tests for instance creation
-- [ ] 7.2 Unit tests for damage state updates
+- [x] 7.1 Unit tests for instance creation
+  - **Implemented in:** `src/types/campaign/__tests__/CampaignInstanceInterfaces.test.ts`
+  - 42 tests covering type guards, factory functions, damage calculations, availability checks
+- [x] 7.2 Unit tests for damage state updates
+  - `calculateDamagePercentage` and `determineUnitStatus` tests included
 - [ ] 7.3 Integration tests for event chain

--- a/src/types/campaign/CampaignInstanceInterfaces.ts
+++ b/src/types/campaign/CampaignInstanceInterfaces.ts
@@ -1,0 +1,541 @@
+/**
+ * Campaign Instance Interfaces
+ *
+ * Defines campaign unit and pilot instances - the deployed versions of
+ * vault designs that track gameplay state (damage, XP, wounds) within
+ * a specific campaign context.
+ *
+ * Key distinction:
+ * - Vault units/pilots are "templates" or "designs" with version history
+ * - Campaign instances are "deployed" versions that track gameplay history
+ *
+ * @spec openspec/changes/add-campaign-instances/specs/campaign-instances/spec.md
+ */
+
+import type { IPilotSkills, IPilotStatblock } from '../pilot/PilotInterfaces';
+import { CampaignUnitStatus, CampaignPilotStatus } from './CampaignInterfaces';
+
+// =============================================================================
+// Enums
+// =============================================================================
+
+/**
+ * Component damage status for tracking destroyed equipment.
+ */
+export enum ComponentStatus {
+  /** Fully operational */
+  Operational = 'operational',
+  /** Damaged but functional (reduced performance) */
+  Damaged = 'damaged',
+  /** Destroyed and non-functional */
+  Destroyed = 'destroyed',
+}
+
+// =============================================================================
+// Damage State Interfaces
+// =============================================================================
+
+/**
+ * Damage state for a single location (head, torso, arm, leg).
+ */
+export interface ILocationDamageState {
+  /** Location identifier (e.g., 'head', 'center_torso', 'left_arm') */
+  readonly location: string;
+  /** Current armor points remaining */
+  readonly armorCurrent: number;
+  /** Maximum armor points for this location */
+  readonly armorMax: number;
+  /** Rear armor current (for torso locations) */
+  readonly rearArmorCurrent?: number;
+  /** Rear armor maximum (for torso locations) */
+  readonly rearArmorMax?: number;
+  /** Current internal structure points remaining */
+  readonly structureCurrent: number;
+  /** Maximum internal structure points for this location */
+  readonly structureMax: number;
+  /** Component damage status for equipment in this location */
+  readonly components: readonly IComponentDamage[];
+}
+
+/**
+ * Damage state for a specific component/equipment.
+ */
+export interface IComponentDamage {
+  /** Component name or ID */
+  readonly componentId: string;
+  /** Component display name */
+  readonly componentName: string;
+  /** Current status */
+  readonly status: ComponentStatus;
+  /** Critical hit slots affected (if applicable) */
+  readonly criticalSlots?: number;
+}
+
+/**
+ * Complete unit damage state tracking all locations.
+ */
+export interface IUnitDamageState {
+  /** Damage per location */
+  readonly locations: readonly ILocationDamageState[];
+  /** Ammunition expended (keyed by ammo type ID) */
+  readonly ammoExpended: Readonly<Record<string, number>>;
+  /** Current heat level */
+  readonly currentHeat: number;
+  /** Engine hits (0-3, 3 = destroyed) */
+  readonly engineHits: number;
+  /** Gyro hits (0-2, 2 = destroyed) */
+  readonly gyroHits: number;
+  /** Sensor hits (0-2, 2 = destroyed) */
+  readonly sensorHits: number;
+  /** Life support hits (0-1) */
+  readonly lifeSupportHits: number;
+  /** Is the unit immobilized (leg/hip damage) */
+  readonly isImmobilized: boolean;
+  /** Last damage applied timestamp */
+  readonly lastDamageAt?: string;
+}
+
+// =============================================================================
+// Campaign Unit Instance
+// =============================================================================
+
+/**
+ * Campaign unit instance - a deployed unit within a campaign that tracks
+ * gameplay state independently from the vault design.
+ *
+ * Created when a vault unit is assigned to a campaign force.
+ * Persists damage, status, and history across missions.
+ */
+export interface ICampaignUnitInstance {
+  /** Unique instance identifier */
+  readonly id: string;
+  /** Campaign this instance belongs to */
+  readonly campaignId: string;
+  /** Reference to the vault unit design */
+  readonly vaultUnitId: string;
+  /** Version of the vault unit at time of assignment (snapshot) */
+  readonly vaultUnitVersion: number;
+  /** Cached unit name for display */
+  readonly unitName: string;
+  /** Cached unit chassis for display */
+  readonly unitChassis: string;
+  /** Cached unit variant for display */
+  readonly unitVariant: string;
+  /** Current operational status */
+  readonly status: CampaignUnitStatus;
+  /** Current damage state */
+  readonly damageState: IUnitDamageState;
+  /** Assigned pilot instance ID (if any) */
+  readonly assignedPilotInstanceId?: string;
+  /** Force ID this unit is assigned to (if any) */
+  readonly forceId?: string;
+  /** Force slot number (if assigned to force) */
+  readonly forceSlot?: number;
+  /** Total kills by this unit in campaign */
+  readonly totalKills: number;
+  /** Total missions this unit participated in */
+  readonly missionsParticipated: number;
+  /** Estimated repair cost (C-Bills) */
+  readonly estimatedRepairCost: number;
+  /** Estimated repair time (in campaign days/cycles) */
+  readonly estimatedRepairTime: number;
+  /** Notes about this instance */
+  readonly notes?: string;
+  /** Instance creation timestamp */
+  readonly createdAt: string;
+  /** Instance last update timestamp */
+  readonly updatedAt: string;
+}
+
+// =============================================================================
+// Campaign Pilot Instance
+// =============================================================================
+
+/**
+ * Campaign pilot instance - a deployed pilot within a campaign that tracks
+ * XP, wounds, and career history independently from the vault pilot.
+ *
+ * Can be created from:
+ * 1. A vault pilot (vaultPilotId reference)
+ * 2. A statblock (inline data, no vault reference) for quick NPCs
+ */
+export interface ICampaignPilotInstance {
+  /** Unique instance identifier */
+  readonly id: string;
+  /** Campaign this instance belongs to */
+  readonly campaignId: string;
+  /** Reference to vault pilot (null for statblock pilots) */
+  readonly vaultPilotId: string | null;
+  /** Inline pilot data for statblock pilots (null for vault pilots) */
+  readonly statblockData: IPilotStatblock | null;
+  /** Cached pilot name for display */
+  readonly pilotName: string;
+  /** Cached pilot callsign for display */
+  readonly pilotCallsign?: string;
+  /** Current operational status */
+  readonly status: CampaignPilotStatus;
+  /** Current skills (may differ from vault due to campaign progression) */
+  readonly currentSkills: IPilotSkills;
+  /** Current wounds (0-6, 6 = deceased) */
+  readonly wounds: number;
+  /** Current XP available to spend */
+  readonly currentXP: number;
+  /** Total XP earned in this campaign */
+  readonly campaignXPEarned: number;
+  /** Total kills in this campaign */
+  readonly killCount: number;
+  /** Total missions participated in this campaign */
+  readonly missionsParticipated: number;
+  /** Assigned unit instance ID (if any) */
+  readonly assignedUnitInstanceId?: string;
+  /** Recovery time remaining (in campaign days/cycles) */
+  readonly recoveryTime: number;
+  /** Notes about this instance */
+  readonly notes?: string;
+  /** Instance creation timestamp */
+  readonly createdAt: string;
+  /** Instance last update timestamp */
+  readonly updatedAt: string;
+}
+
+// =============================================================================
+// Instance Creation Types
+// =============================================================================
+
+/**
+ * Input for creating a campaign unit instance from a vault unit.
+ */
+export interface ICreateUnitInstanceInput {
+  /** Campaign to add instance to */
+  readonly campaignId: string;
+  /** Vault unit ID to create instance from */
+  readonly vaultUnitId: string;
+  /** Force ID to assign to (optional) */
+  readonly forceId?: string;
+  /** Force slot number (optional) */
+  readonly forceSlot?: number;
+  /** Initial notes (optional) */
+  readonly notes?: string;
+}
+
+/**
+ * Input for creating a campaign pilot instance from a vault pilot.
+ */
+export interface ICreatePilotInstanceFromVaultInput {
+  /** Campaign to add instance to */
+  readonly campaignId: string;
+  /** Vault pilot ID to create instance from */
+  readonly vaultPilotId: string;
+  /** Initial notes (optional) */
+  readonly notes?: string;
+}
+
+/**
+ * Input for creating a campaign pilot instance from a statblock.
+ */
+export interface ICreatePilotInstanceFromStatblockInput {
+  /** Campaign to add instance to */
+  readonly campaignId: string;
+  /** Statblock data for the pilot */
+  readonly statblock: IPilotStatblock;
+  /** Initial notes (optional) */
+  readonly notes?: string;
+}
+
+// =============================================================================
+// Instance Update Types
+// =============================================================================
+
+/**
+ * Input for applying damage to a unit instance.
+ */
+export interface IApplyDamageInput {
+  /** Instance ID to apply damage to */
+  readonly instanceId: string;
+  /** Updated damage state */
+  readonly damageState: Partial<IUnitDamageState>;
+  /** Game/mission ID where damage occurred */
+  readonly gameId?: string;
+  /** Cause of damage (for event logging) */
+  readonly cause?: string;
+}
+
+/**
+ * Input for updating pilot instance after a mission.
+ */
+export interface IUpdatePilotInstanceInput {
+  /** Instance ID to update */
+  readonly instanceId: string;
+  /** XP earned this mission */
+  readonly xpEarned?: number;
+  /** Kills this mission */
+  readonly kills?: number;
+  /** Wounds received this mission */
+  readonly woundsReceived?: number;
+  /** New status (if changed) */
+  readonly status?: CampaignPilotStatus;
+  /** Game/mission ID */
+  readonly gameId?: string;
+}
+
+/**
+ * Input for assigning a pilot instance to a unit instance.
+ */
+export interface IAssignPilotToUnitInput {
+  /** Pilot instance ID */
+  readonly pilotInstanceId: string;
+  /** Unit instance ID */
+  readonly unitInstanceId: string;
+}
+
+// =============================================================================
+// Type Guards
+// =============================================================================
+
+/**
+ * Type guard for ICampaignUnitInstance.
+ */
+export function isCampaignUnitInstance(obj: unknown): obj is ICampaignUnitInstance {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const instance = obj as ICampaignUnitInstance;
+  return (
+    typeof instance.id === 'string' &&
+    typeof instance.campaignId === 'string' &&
+    typeof instance.vaultUnitId === 'string' &&
+    typeof instance.vaultUnitVersion === 'number' &&
+    typeof instance.status === 'string' &&
+    typeof instance.damageState === 'object' &&
+    typeof instance.createdAt === 'string'
+  );
+}
+
+/**
+ * Type guard for ICampaignPilotInstance.
+ */
+export function isCampaignPilotInstance(obj: unknown): obj is ICampaignPilotInstance {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const instance = obj as ICampaignPilotInstance;
+  return (
+    typeof instance.id === 'string' &&
+    typeof instance.campaignId === 'string' &&
+    typeof instance.status === 'string' &&
+    typeof instance.currentSkills === 'object' &&
+    typeof instance.wounds === 'number' &&
+    typeof instance.currentXP === 'number' &&
+    typeof instance.createdAt === 'string' &&
+    // Must have either vaultPilotId OR statblockData (XOR)
+    ((instance.vaultPilotId !== null && instance.statblockData === null) ||
+      (instance.vaultPilotId === null && instance.statblockData !== null))
+  );
+}
+
+/**
+ * Type guard for IUnitDamageState.
+ */
+export function isUnitDamageState(obj: unknown): obj is IUnitDamageState {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const state = obj as IUnitDamageState;
+  return (
+    Array.isArray(state.locations) &&
+    typeof state.ammoExpended === 'object' &&
+    typeof state.currentHeat === 'number' &&
+    typeof state.engineHits === 'number' &&
+    typeof state.gyroHits === 'number'
+  );
+}
+
+// =============================================================================
+// Factory Functions
+// =============================================================================
+
+/**
+ * Create an empty/pristine damage state for a new unit instance.
+ * Actual armor/structure values should be populated from the unit design.
+ */
+export function createEmptyDamageState(): IUnitDamageState {
+  return {
+    locations: [],
+    ammoExpended: {},
+    currentHeat: 0,
+    engineHits: 0,
+    gyroHits: 0,
+    sensorHits: 0,
+    lifeSupportHits: 0,
+    isImmobilized: false,
+  };
+}
+
+/**
+ * Create a new campaign unit instance.
+ * Note: This creates the instance structure; actual creation should use
+ * the campaign service to properly snapshot vault data.
+ */
+export function createUnitInstance(
+  id: string,
+  campaignId: string,
+  vaultUnitId: string,
+  vaultUnitVersion: number,
+  unitName: string,
+  unitChassis: string,
+  unitVariant: string,
+  damageState: IUnitDamageState
+): ICampaignUnitInstance {
+  const now = new Date().toISOString();
+  return {
+    id,
+    campaignId,
+    vaultUnitId,
+    vaultUnitVersion,
+    unitName,
+    unitChassis,
+    unitVariant,
+    status: CampaignUnitStatus.Operational,
+    damageState,
+    totalKills: 0,
+    missionsParticipated: 0,
+    estimatedRepairCost: 0,
+    estimatedRepairTime: 0,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Create a new campaign pilot instance from a vault pilot.
+ */
+export function createPilotInstanceFromVault(
+  id: string,
+  campaignId: string,
+  vaultPilotId: string,
+  pilotName: string,
+  pilotCallsign: string | undefined,
+  skills: IPilotSkills
+): ICampaignPilotInstance {
+  const now = new Date().toISOString();
+  return {
+    id,
+    campaignId,
+    vaultPilotId,
+    statblockData: null,
+    pilotName,
+    pilotCallsign,
+    status: CampaignPilotStatus.Active,
+    currentSkills: skills,
+    wounds: 0,
+    currentXP: 0,
+    campaignXPEarned: 0,
+    killCount: 0,
+    missionsParticipated: 0,
+    recoveryTime: 0,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Create a new campaign pilot instance from a statblock.
+ */
+export function createPilotInstanceFromStatblock(
+  id: string,
+  campaignId: string,
+  statblock: IPilotStatblock
+): ICampaignPilotInstance {
+  const now = new Date().toISOString();
+  return {
+    id,
+    campaignId,
+    vaultPilotId: null,
+    statblockData: statblock,
+    pilotName: statblock.name,
+    pilotCallsign: undefined,
+    status: CampaignPilotStatus.Active,
+    currentSkills: {
+      gunnery: statblock.gunnery,
+      piloting: statblock.piloting,
+    },
+    wounds: 0,
+    currentXP: 0,
+    campaignXPEarned: 0,
+    killCount: 0,
+    missionsParticipated: 0,
+    recoveryTime: 0,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/**
+ * Calculate total damage percentage for a unit instance.
+ * Returns 0-100 representing overall damage level.
+ */
+export function calculateDamagePercentage(damageState: IUnitDamageState): number {
+  if (damageState.locations.length === 0) return 0;
+
+  let totalDamage = 0;
+  let totalMax = 0;
+
+  for (const loc of damageState.locations) {
+    // Armor damage
+    totalDamage += loc.armorMax - loc.armorCurrent;
+    totalMax += loc.armorMax;
+
+    // Rear armor (if present)
+    if (loc.rearArmorMax !== undefined && loc.rearArmorCurrent !== undefined) {
+      totalDamage += loc.rearArmorMax - loc.rearArmorCurrent;
+      totalMax += loc.rearArmorMax;
+    }
+
+    // Structure damage
+    totalDamage += loc.structureMax - loc.structureCurrent;
+    totalMax += loc.structureMax;
+  }
+
+  if (totalMax === 0) return 0;
+  return Math.round((totalDamage / totalMax) * 100);
+}
+
+/**
+ * Determine unit status based on damage state.
+ */
+export function determineUnitStatus(damageState: IUnitDamageState): CampaignUnitStatus {
+  // Check for destroyed (any location structure at 0)
+  const hasDestroyedLocation = damageState.locations.some(
+    (loc) => loc.structureCurrent <= 0
+  );
+  if (hasDestroyedLocation) {
+    return CampaignUnitStatus.Destroyed;
+  }
+
+  // Check for damage
+  const damagePercentage = calculateDamagePercentage(damageState);
+  if (damagePercentage > 0) {
+    return CampaignUnitStatus.Damaged;
+  }
+
+  return CampaignUnitStatus.Operational;
+}
+
+/**
+ * Check if a pilot instance is available for assignment.
+ */
+export function isPilotAvailable(instance: ICampaignPilotInstance): boolean {
+  return (
+    instance.status === CampaignPilotStatus.Active &&
+    instance.recoveryTime === 0 &&
+    instance.assignedUnitInstanceId === undefined
+  );
+}
+
+/**
+ * Check if a unit instance is available for deployment.
+ */
+export function isUnitAvailable(instance: ICampaignUnitInstance): boolean {
+  return (
+    instance.status === CampaignUnitStatus.Operational ||
+    instance.status === CampaignUnitStatus.Damaged
+  );
+}

--- a/src/types/campaign/__tests__/CampaignInstanceInterfaces.test.ts
+++ b/src/types/campaign/__tests__/CampaignInstanceInterfaces.test.ts
@@ -1,0 +1,611 @@
+/**
+ * Campaign Instance Interfaces Tests
+ */
+
+import {
+  ICampaignUnitInstance,
+  ICampaignPilotInstance,
+  IUnitDamageState,
+  ILocationDamageState,
+  ComponentStatus,
+  isCampaignUnitInstance,
+  isCampaignPilotInstance,
+  isUnitDamageState,
+  createEmptyDamageState,
+  createUnitInstance,
+  createPilotInstanceFromVault,
+  createPilotInstanceFromStatblock,
+  calculateDamagePercentage,
+  determineUnitStatus,
+  isPilotAvailable,
+  isUnitAvailable,
+} from '../CampaignInstanceInterfaces';
+import { CampaignUnitStatus, CampaignPilotStatus } from '../CampaignInterfaces';
+
+// =============================================================================
+// Test Data Factories
+// =============================================================================
+
+function createTestLocationDamage(
+  overrides: Partial<ILocationDamageState> = {}
+): ILocationDamageState {
+  return {
+    location: 'center_torso',
+    armorCurrent: 40,
+    armorMax: 40,
+    structureCurrent: 20,
+    structureMax: 20,
+    components: [],
+    ...overrides,
+  };
+}
+
+function createTestDamageState(
+  overrides: Partial<IUnitDamageState> = {}
+): IUnitDamageState {
+  return {
+    locations: [
+      createTestLocationDamage({ location: 'center_torso' }),
+      createTestLocationDamage({ location: 'left_torso' }),
+      createTestLocationDamage({ location: 'right_torso' }),
+    ],
+    ammoExpended: {},
+    currentHeat: 0,
+    engineHits: 0,
+    gyroHits: 0,
+    sensorHits: 0,
+    lifeSupportHits: 0,
+    isImmobilized: false,
+    ...overrides,
+  };
+}
+
+function createTestUnitInstance(
+  overrides: Partial<ICampaignUnitInstance> = {}
+): ICampaignUnitInstance {
+  const now = new Date().toISOString();
+  return {
+    id: 'unit-instance-1',
+    campaignId: 'campaign-1',
+    vaultUnitId: 'vault-unit-1',
+    vaultUnitVersion: 1,
+    unitName: 'Atlas AS7-D',
+    unitChassis: 'Atlas',
+    unitVariant: 'AS7-D',
+    status: CampaignUnitStatus.Operational,
+    damageState: createTestDamageState(),
+    totalKills: 0,
+    missionsParticipated: 0,
+    estimatedRepairCost: 0,
+    estimatedRepairTime: 0,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function createTestPilotInstance(
+  overrides: Partial<ICampaignPilotInstance> = {}
+): ICampaignPilotInstance {
+  const now = new Date().toISOString();
+  return {
+    id: 'pilot-instance-1',
+    campaignId: 'campaign-1',
+    vaultPilotId: 'vault-pilot-1',
+    statblockData: null,
+    pilotName: 'John Doe',
+    pilotCallsign: 'Maverick',
+    status: CampaignPilotStatus.Active,
+    currentSkills: { gunnery: 4, piloting: 5 },
+    wounds: 0,
+    currentXP: 0,
+    campaignXPEarned: 0,
+    killCount: 0,
+    missionsParticipated: 0,
+    recoveryTime: 0,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// Enum Tests
+// =============================================================================
+
+describe('ComponentStatus Enum', () => {
+  it('should have all expected values', () => {
+    expect(ComponentStatus.Operational).toBe('operational');
+    expect(ComponentStatus.Damaged).toBe('damaged');
+    expect(ComponentStatus.Destroyed).toBe('destroyed');
+  });
+});
+
+// =============================================================================
+// Type Guard Tests
+// =============================================================================
+
+describe('isCampaignUnitInstance', () => {
+  it('should return true for valid unit instance', () => {
+    const instance = createTestUnitInstance();
+    expect(isCampaignUnitInstance(instance)).toBe(true);
+  });
+
+  it('should return false for null', () => {
+    expect(isCampaignUnitInstance(null)).toBe(false);
+  });
+
+  it('should return false for non-object', () => {
+    expect(isCampaignUnitInstance('string')).toBe(false);
+    expect(isCampaignUnitInstance(123)).toBe(false);
+    expect(isCampaignUnitInstance(undefined)).toBe(false);
+  });
+
+  it('should return false for object missing required fields', () => {
+    expect(isCampaignUnitInstance({ id: 'test' })).toBe(false);
+    expect(
+      isCampaignUnitInstance({
+        id: 'test',
+        campaignId: 'campaign-1',
+        vaultUnitId: 'vault-1',
+      })
+    ).toBe(false);
+  });
+
+  it('should return false if vaultUnitVersion is not a number', () => {
+    const instance = {
+      ...createTestUnitInstance(),
+      vaultUnitVersion: 'not-a-number',
+    };
+    expect(isCampaignUnitInstance(instance)).toBe(false);
+  });
+});
+
+describe('isCampaignPilotInstance', () => {
+  it('should return true for valid vault pilot instance', () => {
+    const instance = createTestPilotInstance();
+    expect(isCampaignPilotInstance(instance)).toBe(true);
+  });
+
+  it('should return true for valid statblock pilot instance', () => {
+    const instance = createTestPilotInstance({
+      vaultPilotId: null,
+      statblockData: { name: 'NPC Pilot', gunnery: 4, piloting: 5 },
+    });
+    expect(isCampaignPilotInstance(instance)).toBe(true);
+  });
+
+  it('should return false for null', () => {
+    expect(isCampaignPilotInstance(null)).toBe(false);
+  });
+
+  it('should return false for non-object', () => {
+    expect(isCampaignPilotInstance('string')).toBe(false);
+  });
+
+  it('should return false if both vaultPilotId and statblockData are set', () => {
+    const instance = {
+      ...createTestPilotInstance(),
+      vaultPilotId: 'vault-pilot-1',
+      statblockData: { name: 'NPC', gunnery: 4, piloting: 5 },
+    };
+    expect(isCampaignPilotInstance(instance)).toBe(false);
+  });
+
+  it('should return false if both vaultPilotId and statblockData are null', () => {
+    const instance = {
+      ...createTestPilotInstance(),
+      vaultPilotId: null,
+      statblockData: null,
+    };
+    expect(isCampaignPilotInstance(instance)).toBe(false);
+  });
+});
+
+describe('isUnitDamageState', () => {
+  it('should return true for valid damage state', () => {
+    const state = createTestDamageState();
+    expect(isUnitDamageState(state)).toBe(true);
+  });
+
+  it('should return false for null', () => {
+    expect(isUnitDamageState(null)).toBe(false);
+  });
+
+  it('should return false for object missing locations array', () => {
+    expect(isUnitDamageState({ ammoExpended: {} })).toBe(false);
+  });
+});
+
+// =============================================================================
+// Factory Function Tests
+// =============================================================================
+
+describe('createEmptyDamageState', () => {
+  it('should create a pristine damage state', () => {
+    const state = createEmptyDamageState();
+    expect(state.locations).toHaveLength(0);
+    expect(state.ammoExpended).toEqual({});
+    expect(state.currentHeat).toBe(0);
+    expect(state.engineHits).toBe(0);
+    expect(state.gyroHits).toBe(0);
+    expect(state.sensorHits).toBe(0);
+    expect(state.lifeSupportHits).toBe(0);
+    expect(state.isImmobilized).toBe(false);
+  });
+});
+
+describe('createUnitInstance', () => {
+  it('should create a unit instance with correct properties', () => {
+    const damageState = createEmptyDamageState();
+    const instance = createUnitInstance(
+      'inst-1',
+      'camp-1',
+      'vault-1',
+      3,
+      'Marauder MAD-3R',
+      'Marauder',
+      'MAD-3R',
+      damageState
+    );
+
+    expect(instance.id).toBe('inst-1');
+    expect(instance.campaignId).toBe('camp-1');
+    expect(instance.vaultUnitId).toBe('vault-1');
+    expect(instance.vaultUnitVersion).toBe(3);
+    expect(instance.unitName).toBe('Marauder MAD-3R');
+    expect(instance.unitChassis).toBe('Marauder');
+    expect(instance.unitVariant).toBe('MAD-3R');
+    expect(instance.status).toBe(CampaignUnitStatus.Operational);
+    expect(instance.damageState).toBe(damageState);
+    expect(instance.totalKills).toBe(0);
+    expect(instance.missionsParticipated).toBe(0);
+    expect(instance.estimatedRepairCost).toBe(0);
+    expect(instance.estimatedRepairTime).toBe(0);
+    expect(instance.createdAt).toBeTruthy();
+    expect(instance.updatedAt).toBeTruthy();
+  });
+});
+
+describe('createPilotInstanceFromVault', () => {
+  it('should create a pilot instance from vault pilot', () => {
+    const instance = createPilotInstanceFromVault(
+      'pilot-inst-1',
+      'camp-1',
+      'vault-pilot-1',
+      'Jane Smith',
+      'Viper',
+      { gunnery: 3, piloting: 4 }
+    );
+
+    expect(instance.id).toBe('pilot-inst-1');
+    expect(instance.campaignId).toBe('camp-1');
+    expect(instance.vaultPilotId).toBe('vault-pilot-1');
+    expect(instance.statblockData).toBeNull();
+    expect(instance.pilotName).toBe('Jane Smith');
+    expect(instance.pilotCallsign).toBe('Viper');
+    expect(instance.status).toBe(CampaignPilotStatus.Active);
+    expect(instance.currentSkills).toEqual({ gunnery: 3, piloting: 4 });
+    expect(instance.wounds).toBe(0);
+    expect(instance.currentXP).toBe(0);
+    expect(instance.campaignXPEarned).toBe(0);
+    expect(instance.killCount).toBe(0);
+    expect(instance.missionsParticipated).toBe(0);
+    expect(instance.recoveryTime).toBe(0);
+  });
+
+  it('should handle undefined callsign', () => {
+    const instance = createPilotInstanceFromVault(
+      'pilot-inst-1',
+      'camp-1',
+      'vault-pilot-1',
+      'Jane Smith',
+      undefined,
+      { gunnery: 3, piloting: 4 }
+    );
+
+    expect(instance.pilotCallsign).toBeUndefined();
+  });
+});
+
+describe('createPilotInstanceFromStatblock', () => {
+  it('should create a pilot instance from statblock', () => {
+    const statblock = {
+      name: 'Generic MechWarrior',
+      gunnery: 4,
+      piloting: 5,
+    };
+    const instance = createPilotInstanceFromStatblock('pilot-inst-2', 'camp-1', statblock);
+
+    expect(instance.id).toBe('pilot-inst-2');
+    expect(instance.campaignId).toBe('camp-1');
+    expect(instance.vaultPilotId).toBeNull();
+    expect(instance.statblockData).toBe(statblock);
+    expect(instance.pilotName).toBe('Generic MechWarrior');
+    expect(instance.pilotCallsign).toBeUndefined();
+    expect(instance.status).toBe(CampaignPilotStatus.Active);
+    expect(instance.currentSkills).toEqual({ gunnery: 4, piloting: 5 });
+  });
+
+  it('should include abilities from statblock', () => {
+    const statblock = {
+      name: 'Elite Pilot',
+      gunnery: 2,
+      piloting: 3,
+      abilityIds: ['marksman', 'mech_melee_specialist'],
+    };
+    const instance = createPilotInstanceFromStatblock('pilot-inst-3', 'camp-1', statblock);
+
+    expect(instance.statblockData?.abilityIds).toEqual(['marksman', 'mech_melee_specialist']);
+  });
+});
+
+// =============================================================================
+// Damage Calculation Tests
+// =============================================================================
+
+describe('calculateDamagePercentage', () => {
+  it('should return 0 for empty locations', () => {
+    const state = createEmptyDamageState();
+    expect(calculateDamagePercentage(state)).toBe(0);
+  });
+
+  it('should return 0 for undamaged unit', () => {
+    const state = createTestDamageState();
+    expect(calculateDamagePercentage(state)).toBe(0);
+  });
+
+  it('should calculate damage percentage correctly', () => {
+    const state = createTestDamageState({
+      locations: [
+        createTestLocationDamage({
+          location: 'center_torso',
+          armorCurrent: 20, // 50% armor damage
+          armorMax: 40,
+          structureCurrent: 20,
+          structureMax: 20,
+        }),
+      ],
+    });
+    // Total: 40 armor + 20 structure = 60 max
+    // Damage: 20 armor damage = 20
+    // Percentage: 20/60 = 33.33... -> rounded to 33%
+    expect(calculateDamagePercentage(state)).toBe(33);
+  });
+
+  it('should include rear armor in calculation', () => {
+    const state = createTestDamageState({
+      locations: [
+        createTestLocationDamage({
+          location: 'center_torso',
+          armorCurrent: 40,
+          armorMax: 40,
+          rearArmorCurrent: 10, // 50% rear armor damage
+          rearArmorMax: 20,
+          structureCurrent: 20,
+          structureMax: 20,
+        }),
+      ],
+    });
+    // Total: 40 front + 20 rear + 20 structure = 80 max
+    // Damage: 10 rear armor damage = 10
+    // Percentage: 10/80 = 12.5% -> rounded to 13%
+    expect(calculateDamagePercentage(state)).toBe(13);
+  });
+
+  it('should return 100 for fully destroyed unit', () => {
+    const state = createTestDamageState({
+      locations: [
+        createTestLocationDamage({
+          location: 'center_torso',
+          armorCurrent: 0,
+          armorMax: 40,
+          structureCurrent: 0,
+          structureMax: 20,
+        }),
+      ],
+    });
+    expect(calculateDamagePercentage(state)).toBe(100);
+  });
+});
+
+describe('determineUnitStatus', () => {
+  it('should return Operational for undamaged unit', () => {
+    const state = createTestDamageState();
+    expect(determineUnitStatus(state)).toBe(CampaignUnitStatus.Operational);
+  });
+
+  it('should return Damaged for unit with armor damage only', () => {
+    const state = createTestDamageState({
+      locations: [
+        createTestLocationDamage({
+          armorCurrent: 20, // Half armor gone
+          armorMax: 40,
+          structureCurrent: 20,
+          structureMax: 20,
+        }),
+      ],
+    });
+    expect(determineUnitStatus(state)).toBe(CampaignUnitStatus.Damaged);
+  });
+
+  it('should return Destroyed if any location has 0 structure', () => {
+    const state = createTestDamageState({
+      locations: [
+        createTestLocationDamage({
+          location: 'center_torso',
+          structureCurrent: 0,
+          structureMax: 20,
+        }),
+      ],
+    });
+    expect(determineUnitStatus(state)).toBe(CampaignUnitStatus.Destroyed);
+  });
+});
+
+// =============================================================================
+// Availability Tests
+// =============================================================================
+
+describe('isPilotAvailable', () => {
+  it('should return true for active pilot with no recovery and no assignment', () => {
+    const instance = createTestPilotInstance({
+      status: CampaignPilotStatus.Active,
+      recoveryTime: 0,
+      assignedUnitInstanceId: undefined,
+    });
+    expect(isPilotAvailable(instance)).toBe(true);
+  });
+
+  it('should return false for wounded pilot', () => {
+    const instance = createTestPilotInstance({
+      status: CampaignPilotStatus.Wounded,
+    });
+    expect(isPilotAvailable(instance)).toBe(false);
+  });
+
+  it('should return false for pilot in recovery', () => {
+    const instance = createTestPilotInstance({
+      status: CampaignPilotStatus.Active,
+      recoveryTime: 5,
+    });
+    expect(isPilotAvailable(instance)).toBe(false);
+  });
+
+  it('should return false for assigned pilot', () => {
+    const instance = createTestPilotInstance({
+      status: CampaignPilotStatus.Active,
+      recoveryTime: 0,
+      assignedUnitInstanceId: 'unit-instance-1',
+    });
+    expect(isPilotAvailable(instance)).toBe(false);
+  });
+
+  it('should return false for KIA pilot', () => {
+    const instance = createTestPilotInstance({
+      status: CampaignPilotStatus.KIA,
+    });
+    expect(isPilotAvailable(instance)).toBe(false);
+  });
+});
+
+describe('isUnitAvailable', () => {
+  it('should return true for operational unit', () => {
+    const instance = createTestUnitInstance({
+      status: CampaignUnitStatus.Operational,
+    });
+    expect(isUnitAvailable(instance)).toBe(true);
+  });
+
+  it('should return true for damaged unit', () => {
+    const instance = createTestUnitInstance({
+      status: CampaignUnitStatus.Damaged,
+    });
+    expect(isUnitAvailable(instance)).toBe(true);
+  });
+
+  it('should return false for destroyed unit', () => {
+    const instance = createTestUnitInstance({
+      status: CampaignUnitStatus.Destroyed,
+    });
+    expect(isUnitAvailable(instance)).toBe(false);
+  });
+
+  it('should return false for repairing unit', () => {
+    const instance = createTestUnitInstance({
+      status: CampaignUnitStatus.Repairing,
+    });
+    expect(isUnitAvailable(instance)).toBe(false);
+  });
+
+  it('should return false for salvage unit', () => {
+    const instance = createTestUnitInstance({
+      status: CampaignUnitStatus.Salvage,
+    });
+    expect(isUnitAvailable(instance)).toBe(false);
+  });
+});
+
+// =============================================================================
+// Interface Structure Tests
+// =============================================================================
+
+describe('ICampaignUnitInstance structure', () => {
+  it('should have all required properties', () => {
+    const instance = createTestUnitInstance();
+
+    // Core identifiers
+    expect(instance).toHaveProperty('id');
+    expect(instance).toHaveProperty('campaignId');
+    expect(instance).toHaveProperty('vaultUnitId');
+    expect(instance).toHaveProperty('vaultUnitVersion');
+
+    // Display properties
+    expect(instance).toHaveProperty('unitName');
+    expect(instance).toHaveProperty('unitChassis');
+    expect(instance).toHaveProperty('unitVariant');
+
+    // State properties
+    expect(instance).toHaveProperty('status');
+    expect(instance).toHaveProperty('damageState');
+
+    // Campaign stats
+    expect(instance).toHaveProperty('totalKills');
+    expect(instance).toHaveProperty('missionsParticipated');
+
+    // Repair estimates
+    expect(instance).toHaveProperty('estimatedRepairCost');
+    expect(instance).toHaveProperty('estimatedRepairTime');
+
+    // Timestamps
+    expect(instance).toHaveProperty('createdAt');
+    expect(instance).toHaveProperty('updatedAt');
+  });
+
+  it('should have optional properties', () => {
+    const instance = createTestUnitInstance({
+      assignedPilotInstanceId: 'pilot-1',
+      forceId: 'force-1',
+      forceSlot: 2,
+      notes: 'Test notes',
+    });
+
+    expect(instance.assignedPilotInstanceId).toBe('pilot-1');
+    expect(instance.forceId).toBe('force-1');
+    expect(instance.forceSlot).toBe(2);
+    expect(instance.notes).toBe('Test notes');
+  });
+});
+
+describe('ICampaignPilotInstance structure', () => {
+  it('should have all required properties', () => {
+    const instance = createTestPilotInstance();
+
+    // Core identifiers
+    expect(instance).toHaveProperty('id');
+    expect(instance).toHaveProperty('campaignId');
+
+    // Source (XOR relationship)
+    expect(instance).toHaveProperty('vaultPilotId');
+    expect(instance).toHaveProperty('statblockData');
+
+    // Display properties
+    expect(instance).toHaveProperty('pilotName');
+
+    // State properties
+    expect(instance).toHaveProperty('status');
+    expect(instance).toHaveProperty('currentSkills');
+    expect(instance).toHaveProperty('wounds');
+
+    // Campaign progression
+    expect(instance).toHaveProperty('currentXP');
+    expect(instance).toHaveProperty('campaignXPEarned');
+    expect(instance).toHaveProperty('killCount');
+    expect(instance).toHaveProperty('missionsParticipated');
+    expect(instance).toHaveProperty('recoveryTime');
+
+    // Timestamps
+    expect(instance).toHaveProperty('createdAt');
+    expect(instance).toHaveProperty('updatedAt');
+  });
+});

--- a/src/types/campaign/index.ts
+++ b/src/types/campaign/index.ts
@@ -4,3 +4,4 @@
  */
 
 export * from './CampaignInterfaces';
+export * from './CampaignInstanceInterfaces';


### PR DESCRIPTION
## Summary
Implements Phase 1 (Type Definitions) of the `add-campaign-instances` proposal.

This PR adds the foundational type definitions for campaign instances - the deployed versions of vault units/pilots that track gameplay state within campaigns.

## Key Concept
- **Vault units/pilots** = Templates/designs with version history
- **Campaign instances** = Deployed versions that track damage, XP, wounds, kills across missions

## Changes

### New Interfaces
- `ICampaignUnitInstance` - Deployed unit tracking:
  - Reference to vault design with version snapshot
  - Damage state (armor, structure, components per location)
  - Status (operational, damaged, destroyed, repairing, salvage)
  - Force assignment, kills, missions participated
  - Repair cost/time estimates

- `ICampaignPilotInstance` - Deployed pilot tracking:
  - Reference to vault pilot OR inline statblock data (XOR)
  - Current skills (may differ from vault due to progression)
  - Wounds, XP, kills, missions participated
  - Status (active, wounded, critical, MIA, KIA)
  - Recovery time

- `IUnitDamageState` - Comprehensive damage tracking:
  - Per-location damage (armor, rear armor, structure)
  - Component damage with status enum
  - Engine/gyro/sensor/life-support hits
  - Ammo expenditure and heat

### Factory Functions
- `createUnitInstance()` - Create new unit instance
- `createPilotInstanceFromVault()` - Create pilot instance from vault pilot
- `createPilotInstanceFromStatblock()` - Create pilot instance from statblock (NPCs)
- `createEmptyDamageState()` - Create pristine damage state

### Utility Functions
- `calculateDamagePercentage()` - Calculate overall damage level
- `determineUnitStatus()` - Determine status based on damage
- `isPilotAvailable()` / `isUnitAvailable()` - Check deployment availability

### Type Guards
- `isCampaignUnitInstance()`
- `isCampaignPilotInstance()`
- `isUnitDamageState()`

## Files
- `src/types/campaign/CampaignInstanceInterfaces.ts` - New interfaces
- `src/types/campaign/__tests__/CampaignInstanceInterfaces.test.ts` - 42 tests
- `src/types/campaign/index.ts` - Export new module
- `openspec/changes/add-campaign-instances/tasks.md` - Updated task tracking

## Testing
- 42 unit tests passing
- TypeScript compilation passes
- Build passes

## Next Steps (Future PRs)
- Phase 2: Database schema (campaign_unit_instances, campaign_pilot_instances tables)
- Phase 3: Instance creation service (on force assignment)
- Phase 4: Event integration (emit events for state changes)
- Phase 5: Store/API integration