### PR TITLE
feat(campaign): add campaign instance persistence layer

### DIFF
--- a/openspec/changes/add-campaign-instances/tasks.md
+++ b/openspec/changes/add-campaign-instances/tasks.md
@@ -38,17 +38,27 @@
 
 ## 2. Database Schema
 
-- [ ] 2.1 Add `campaign_unit_instances` table
-- [ ] 2.2 Add `campaign_pilot_instances` table
-- [ ] 2.3 Add foreign keys to campaigns and vault entities
-- [ ] 2.4 Create migration script
+- [x] 2.1 Add `campaign_unit_instances` table
+  - **IndexedDB:** Added store in `src/services/persistence/IndexedDBService.ts` (DB_VERSION 4)
+  - **SQLite:** Added table in migration 3 in `src/services/persistence/SQLiteService.ts`
+- [x] 2.2 Add `campaign_pilot_instances` table
+  - **IndexedDB:** Added store in `src/services/persistence/IndexedDBService.ts`
+  - **SQLite:** Added table in migration 3 with XOR constraint for vault_pilot_id/statblock_data
+- [x] 2.3 Add foreign keys to campaigns and vault entities
+  - SQLite schema includes foreign keys to `pilots` table and between instances
+- [x] 2.4 Create migration script
+  - SQLite migration 3: `campaign_instances_schema` with indexes for common queries
 
 ## 3. Instance Creation
 
-- [ ] 3.1 Create instance when unit is assigned to campaign force
-- [ ] 3.2 Snapshot vault unit version at assignment time
-- [ ] 3.3 Create pilot instance when pilot is assigned
-- [ ] 3.4 Handle statblock pilots (inline data, no vault reference)
+- [x] 3.1 Create instance when unit is assigned to campaign force
+  - **Implemented in:** `CampaignInstanceService.createUnitInstance()`
+- [x] 3.2 Snapshot vault unit version at assignment time
+  - `vaultUnitVersion` parameter captured at creation time
+- [x] 3.3 Create pilot instance when pilot is assigned
+  - **Implemented in:** `CampaignInstanceService.createPilotInstanceFromVault()`
+- [x] 3.4 Handle statblock pilots (inline data, no vault reference)
+  - **Implemented in:** `CampaignInstanceService.createPilotInstanceFromStatblock()`
 
 ## 4. State Updates
 
@@ -65,8 +75,14 @@
 
 ## 6. API & Store
 
-- [ ] 6.1 Add campaign instance queries to store
-- [ ] 6.2 Add instance CRUD operations
+- [x] 6.1 Add campaign instance queries to store
+  - **Implemented in:** `CampaignInstanceService.listUnitInstances()`, `listPilotInstances()` with filters
+- [x] 6.2 Add instance CRUD operations
+  - **Implemented in:** `src/services/persistence/CampaignInstanceService.ts`
+  - Unit: create, get, update, delete, list
+  - Pilot: create from vault, create from statblock, get, update, delete, list
+  - Assignments: assignPilotToUnit, unassignPilot (bidirectional)
+  - Bulk: deleteInstancesForCampaign
 - [ ] 6.3 Add instance-filtered Timeline queries
 
 ## 7. Testing
@@ -76,4 +92,7 @@
   - 42 tests covering type guards, factory functions, damage calculations, availability checks
 - [x] 7.2 Unit tests for damage state updates
   - `calculateDamagePercentage` and `determineUnitStatus` tests included
-- [ ] 7.3 Integration tests for event chain
+- [x] 7.3 Service layer tests
+  - **Implemented in:** `src/services/persistence/__tests__/CampaignInstanceService.test.ts`
+  - 21 tests covering CRUD operations, filtering, assignments, bulk operations
+- [ ] 7.4 Integration tests for event chain

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
+        "fake-indexeddb": "^6.2.5",
         "husky": "^9.1.7",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
@@ -11935,6 +11936,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "fake-indexeddb": "^6.2.5",
     "husky": "^9.1.7",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",

--- a/src/services/persistence/CampaignInstanceService.ts
+++ b/src/services/persistence/CampaignInstanceService.ts
@@ -1,0 +1,538 @@
+/**
+ * Campaign Instance Persistence Service
+ *
+ * Provides CRUD operations for campaign unit and pilot instances.
+ * Uses IndexedDB for browser storage and SQLite for desktop/server.
+ *
+ * @spec openspec/changes/add-campaign-instances/specs/campaign-instances/spec.md
+ */
+
+import { getIndexedDBService, STORES } from './IndexedDBService';
+import type {
+  ICampaignUnitInstance,
+  ICampaignPilotInstance,
+  ICreateUnitInstanceInput,
+  ICreatePilotInstanceFromVaultInput,
+  ICreatePilotInstanceFromStatblockInput,
+  IUnitDamageState,
+} from '../../types/campaign/CampaignInstanceInterfaces';
+import {
+  createUnitInstance,
+  createPilotInstanceFromVault,
+  createPilotInstanceFromStatblock,
+  createEmptyDamageState,
+} from '../../types/campaign/CampaignInstanceInterfaces';
+import { CampaignUnitStatus, CampaignPilotStatus } from '../../types/campaign/CampaignInterfaces';
+import type { IPilotSkills } from '../../types/pilot/PilotInterfaces';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Query options for listing instances
+ */
+export interface IInstanceQueryOptions {
+  /** Filter by campaign ID */
+  readonly campaignId?: string;
+  /** Filter by status */
+  readonly status?: CampaignUnitStatus | CampaignPilotStatus;
+  /** Filter by force ID */
+  readonly forceId?: string;
+  /** Include only available (deployable) instances */
+  readonly availableOnly?: boolean;
+}
+
+/**
+ * Unit instance update input
+ */
+export interface IUpdateUnitInstanceInput {
+  readonly status?: CampaignUnitStatus;
+  readonly damageState?: IUnitDamageState;
+  readonly assignedPilotInstanceId?: string | null;
+  readonly forceId?: string | null;
+  readonly forceSlot?: number | null;
+  readonly totalKills?: number;
+  readonly missionsParticipated?: number;
+  readonly estimatedRepairCost?: number;
+  readonly estimatedRepairTime?: number;
+  readonly notes?: string;
+}
+
+/**
+ * Pilot instance update input
+ */
+export interface IUpdatePilotInstanceInput {
+  readonly status?: CampaignPilotStatus;
+  readonly currentSkills?: IPilotSkills;
+  readonly wounds?: number;
+  readonly currentXP?: number;
+  readonly campaignXPEarned?: number;
+  readonly killCount?: number;
+  readonly missionsParticipated?: number;
+  readonly assignedUnitInstanceId?: string | null;
+  readonly recoveryTime?: number;
+  readonly notes?: string;
+}
+
+// =============================================================================
+// Service Interface
+// =============================================================================
+
+/**
+ * Campaign Instance Service interface
+ */
+export interface ICampaignInstanceService {
+  // Unit Instances
+  createUnitInstance(input: ICreateUnitInstanceInput, unitData: {
+    version: number;
+    name: string;
+    chassis: string;
+    variant: string;
+    damageState?: IUnitDamageState;
+  }): Promise<ICampaignUnitInstance>;
+  getUnitInstance(id: string): Promise<ICampaignUnitInstance | undefined>;
+  updateUnitInstance(id: string, updates: IUpdateUnitInstanceInput): Promise<ICampaignUnitInstance>;
+  deleteUnitInstance(id: string): Promise<void>;
+  listUnitInstances(options?: IInstanceQueryOptions): Promise<ICampaignUnitInstance[]>;
+
+  // Pilot Instances
+  createPilotInstanceFromVault(input: ICreatePilotInstanceFromVaultInput, pilotData: {
+    name: string;
+    callsign?: string;
+    skills: IPilotSkills;
+  }): Promise<ICampaignPilotInstance>;
+  createPilotInstanceFromStatblock(input: ICreatePilotInstanceFromStatblockInput): Promise<ICampaignPilotInstance>;
+  getPilotInstance(id: string): Promise<ICampaignPilotInstance | undefined>;
+  updatePilotInstance(id: string, updates: IUpdatePilotInstanceInput): Promise<ICampaignPilotInstance>;
+  deletePilotInstance(id: string): Promise<void>;
+  listPilotInstances(options?: IInstanceQueryOptions): Promise<ICampaignPilotInstance[]>;
+
+  // Assignments
+  assignPilotToUnit(pilotInstanceId: string, unitInstanceId: string): Promise<void>;
+  unassignPilot(pilotInstanceId: string): Promise<void>;
+
+  // Bulk Operations
+  deleteInstancesForCampaign(campaignId: string): Promise<void>;
+}
+
+// =============================================================================
+// IndexedDB Implementation
+// =============================================================================
+
+/**
+ * Generate a unique ID for instances
+ */
+function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+}
+
+/**
+ * Campaign Instance Service implementation using IndexedDB
+ */
+export class CampaignInstanceService implements ICampaignInstanceService {
+  private initialized = false;
+
+  /**
+   * Ensure the database is initialized
+   */
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) return;
+    await getIndexedDBService().initialize();
+    this.initialized = true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Unit Instances
+  // ---------------------------------------------------------------------------
+
+  async createUnitInstance(
+    input: ICreateUnitInstanceInput,
+    unitData: {
+      version: number;
+      name: string;
+      chassis: string;
+      variant: string;
+      damageState?: IUnitDamageState;
+    }
+  ): Promise<ICampaignUnitInstance> {
+    await this.ensureInitialized();
+
+    const id = generateId();
+    const damageState = unitData.damageState ?? createEmptyDamageState();
+
+    const instance = createUnitInstance(
+      id,
+      input.campaignId,
+      input.vaultUnitId,
+      unitData.version,
+      unitData.name,
+      unitData.chassis,
+      unitData.variant,
+      damageState
+    );
+
+    // Apply optional fields from input
+    const fullInstance: ICampaignUnitInstance = {
+      ...instance,
+      forceId: input.forceId,
+      forceSlot: input.forceSlot,
+      notes: input.notes,
+    };
+
+    await getIndexedDBService().put(
+      STORES.CAMPAIGN_UNIT_INSTANCES,
+      id,
+      fullInstance
+    );
+
+    return fullInstance;
+  }
+
+  async getUnitInstance(id: string): Promise<ICampaignUnitInstance | undefined> {
+    await this.ensureInitialized();
+    return getIndexedDBService().get<ICampaignUnitInstance>(
+      STORES.CAMPAIGN_UNIT_INSTANCES,
+      id
+    );
+  }
+
+  async updateUnitInstance(
+    id: string,
+    updates: IUpdateUnitInstanceInput
+  ): Promise<ICampaignUnitInstance> {
+    await this.ensureInitialized();
+
+    const existing = await this.getUnitInstance(id);
+    if (!existing) {
+      throw new Error(`Unit instance not found: ${id}`);
+    }
+
+    const updated: ICampaignUnitInstance = {
+      ...existing,
+      ...updates,
+      // Handle null values for optional fields
+      assignedPilotInstanceId:
+        updates.assignedPilotInstanceId === null
+          ? undefined
+          : updates.assignedPilotInstanceId ?? existing.assignedPilotInstanceId,
+      forceId:
+        updates.forceId === null
+          ? undefined
+          : updates.forceId ?? existing.forceId,
+      forceSlot:
+        updates.forceSlot === null
+          ? undefined
+          : updates.forceSlot ?? existing.forceSlot,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await getIndexedDBService().put(
+      STORES.CAMPAIGN_UNIT_INSTANCES,
+      id,
+      updated
+    );
+
+    return updated;
+  }
+
+  async deleteUnitInstance(id: string): Promise<void> {
+    await this.ensureInitialized();
+
+    // Unassign any pilot first
+    const instance = await this.getUnitInstance(id);
+    if (instance?.assignedPilotInstanceId) {
+      await this.unassignPilot(instance.assignedPilotInstanceId);
+    }
+
+    await getIndexedDBService().delete(STORES.CAMPAIGN_UNIT_INSTANCES, id);
+  }
+
+  async listUnitInstances(
+    options: IInstanceQueryOptions = {}
+  ): Promise<ICampaignUnitInstance[]> {
+    await this.ensureInitialized();
+
+    const all = await getIndexedDBService().getAll<ICampaignUnitInstance>(
+      STORES.CAMPAIGN_UNIT_INSTANCES
+    );
+
+    return all.filter((instance) => {
+      if (options.campaignId && instance.campaignId !== options.campaignId) {
+        return false;
+      }
+      if (options.status && instance.status !== options.status) {
+        return false;
+      }
+      if (options.forceId && instance.forceId !== options.forceId) {
+        return false;
+      }
+      if (options.availableOnly) {
+        if (
+          instance.status !== CampaignUnitStatus.Operational &&
+          instance.status !== CampaignUnitStatus.Damaged
+        ) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pilot Instances
+  // ---------------------------------------------------------------------------
+
+  async createPilotInstanceFromVault(
+    input: ICreatePilotInstanceFromVaultInput,
+    pilotData: {
+      name: string;
+      callsign?: string;
+      skills: IPilotSkills;
+    }
+  ): Promise<ICampaignPilotInstance> {
+    await this.ensureInitialized();
+
+    const id = generateId();
+
+    const instance = createPilotInstanceFromVault(
+      id,
+      input.campaignId,
+      input.vaultPilotId,
+      pilotData.name,
+      pilotData.callsign,
+      pilotData.skills
+    );
+
+    const fullInstance: ICampaignPilotInstance = {
+      ...instance,
+      notes: input.notes,
+    };
+
+    await getIndexedDBService().put(
+      STORES.CAMPAIGN_PILOT_INSTANCES,
+      id,
+      fullInstance
+    );
+
+    return fullInstance;
+  }
+
+  async createPilotInstanceFromStatblock(
+    input: ICreatePilotInstanceFromStatblockInput
+  ): Promise<ICampaignPilotInstance> {
+    await this.ensureInitialized();
+
+    const id = generateId();
+
+    const instance = createPilotInstanceFromStatblock(
+      id,
+      input.campaignId,
+      input.statblock
+    );
+
+    const fullInstance: ICampaignPilotInstance = {
+      ...instance,
+      notes: input.notes,
+    };
+
+    await getIndexedDBService().put(
+      STORES.CAMPAIGN_PILOT_INSTANCES,
+      id,
+      fullInstance
+    );
+
+    return fullInstance;
+  }
+
+  async getPilotInstance(id: string): Promise<ICampaignPilotInstance | undefined> {
+    await this.ensureInitialized();
+    return getIndexedDBService().get<ICampaignPilotInstance>(
+      STORES.CAMPAIGN_PILOT_INSTANCES,
+      id
+    );
+  }
+
+  async updatePilotInstance(
+    id: string,
+    updates: IUpdatePilotInstanceInput
+  ): Promise<ICampaignPilotInstance> {
+    await this.ensureInitialized();
+
+    const existing = await this.getPilotInstance(id);
+    if (!existing) {
+      throw new Error(`Pilot instance not found: ${id}`);
+    }
+
+    const updated: ICampaignPilotInstance = {
+      ...existing,
+      ...updates,
+      // Handle null values for optional fields
+      assignedUnitInstanceId:
+        updates.assignedUnitInstanceId === null
+          ? undefined
+          : updates.assignedUnitInstanceId ?? existing.assignedUnitInstanceId,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await getIndexedDBService().put(
+      STORES.CAMPAIGN_PILOT_INSTANCES,
+      id,
+      updated
+    );
+
+    return updated;
+  }
+
+  async deletePilotInstance(id: string): Promise<void> {
+    await this.ensureInitialized();
+
+    // Unassign from unit first
+    const instance = await this.getPilotInstance(id);
+    if (instance?.assignedUnitInstanceId) {
+      const unit = await this.getUnitInstance(instance.assignedUnitInstanceId);
+      if (unit && unit.assignedPilotInstanceId === id) {
+        await this.updateUnitInstance(unit.id, { assignedPilotInstanceId: null });
+      }
+    }
+
+    await getIndexedDBService().delete(STORES.CAMPAIGN_PILOT_INSTANCES, id);
+  }
+
+  async listPilotInstances(
+    options: IInstanceQueryOptions = {}
+  ): Promise<ICampaignPilotInstance[]> {
+    await this.ensureInitialized();
+
+    const all = await getIndexedDBService().getAll<ICampaignPilotInstance>(
+      STORES.CAMPAIGN_PILOT_INSTANCES
+    );
+
+    return all.filter((instance) => {
+      if (options.campaignId && instance.campaignId !== options.campaignId) {
+        return false;
+      }
+      if (options.status && instance.status !== options.status) {
+        return false;
+      }
+      if (options.availableOnly) {
+        if (
+          instance.status !== CampaignPilotStatus.Active ||
+          instance.recoveryTime > 0 ||
+          instance.assignedUnitInstanceId !== undefined
+        ) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Assignments
+  // ---------------------------------------------------------------------------
+
+  async assignPilotToUnit(
+    pilotInstanceId: string,
+    unitInstanceId: string
+  ): Promise<void> {
+    await this.ensureInitialized();
+
+    const pilot = await this.getPilotInstance(pilotInstanceId);
+    const unit = await this.getUnitInstance(unitInstanceId);
+
+    if (!pilot) {
+      throw new Error(`Pilot instance not found: ${pilotInstanceId}`);
+    }
+    if (!unit) {
+      throw new Error(`Unit instance not found: ${unitInstanceId}`);
+    }
+
+    // Unassign current pilot from unit if any
+    if (unit.assignedPilotInstanceId && unit.assignedPilotInstanceId !== pilotInstanceId) {
+      await this.updatePilotInstance(unit.assignedPilotInstanceId, {
+        assignedUnitInstanceId: null,
+      });
+    }
+
+    // Unassign pilot from current unit if any
+    if (pilot.assignedUnitInstanceId && pilot.assignedUnitInstanceId !== unitInstanceId) {
+      await this.updateUnitInstance(pilot.assignedUnitInstanceId, {
+        assignedPilotInstanceId: null,
+      });
+    }
+
+    // Create bidirectional assignment
+    await this.updatePilotInstance(pilotInstanceId, {
+      assignedUnitInstanceId: unitInstanceId,
+    });
+    await this.updateUnitInstance(unitInstanceId, {
+      assignedPilotInstanceId: pilotInstanceId,
+    });
+  }
+
+  async unassignPilot(pilotInstanceId: string): Promise<void> {
+    await this.ensureInitialized();
+
+    const pilot = await this.getPilotInstance(pilotInstanceId);
+    if (!pilot) {
+      throw new Error(`Pilot instance not found: ${pilotInstanceId}`);
+    }
+
+    if (pilot.assignedUnitInstanceId) {
+      await this.updateUnitInstance(pilot.assignedUnitInstanceId, {
+        assignedPilotInstanceId: null,
+      });
+    }
+
+    await this.updatePilotInstance(pilotInstanceId, {
+      assignedUnitInstanceId: null,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bulk Operations
+  // ---------------------------------------------------------------------------
+
+  async deleteInstancesForCampaign(campaignId: string): Promise<void> {
+    await this.ensureInitialized();
+
+    // Get all instances for this campaign
+    const units = await this.listUnitInstances({ campaignId });
+    const pilots = await this.listPilotInstances({ campaignId });
+
+    // Delete all unit instances
+    for (const unit of units) {
+      await getIndexedDBService().delete(STORES.CAMPAIGN_UNIT_INSTANCES, unit.id);
+    }
+
+    // Delete all pilot instances
+    for (const pilot of pilots) {
+      await getIndexedDBService().delete(STORES.CAMPAIGN_PILOT_INSTANCES, pilot.id);
+    }
+  }
+}
+
+// =============================================================================
+// Singleton
+// =============================================================================
+
+let _instance: CampaignInstanceService | null = null;
+
+/**
+ * Get the singleton CampaignInstanceService instance
+ */
+export function getCampaignInstanceService(): CampaignInstanceService {
+  if (!_instance) {
+    _instance = new CampaignInstanceService();
+  }
+  return _instance;
+}
+
+/**
+ * Reset the singleton instance (for testing)
+ * @internal
+ */
+export function _resetCampaignInstanceService(): void {
+  _instance = null;
+}

--- a/src/services/persistence/IndexedDBService.ts
+++ b/src/services/persistence/IndexedDBService.ts
@@ -9,7 +9,7 @@
 import { StorageError } from '../common/errors';
 
 const DB_NAME = 'mekstation';
-const DB_VERSION = 3;  // Bumped for pilots store
+const DB_VERSION = 4;  // Bumped for campaign instances stores
 
 /**
  * Object store names
@@ -19,6 +19,8 @@ export const STORES = {
   UNIT_METADATA: 'unit-metadata',
   CUSTOM_FORMULAS: 'custom-formulas',
   PILOTS: 'pilots',
+  CAMPAIGN_UNIT_INSTANCES: 'campaign-unit-instances',
+  CAMPAIGN_PILOT_INSTANCES: 'campaign-pilot-instances',
 } as const;
 
 type StoreName = typeof STORES[keyof typeof STORES];
@@ -92,6 +94,13 @@ export class IndexedDBService implements IIndexedDBService {
         }
         if (!db.objectStoreNames.contains(STORES.PILOTS)) {
           db.createObjectStore(STORES.PILOTS);
+        }
+        // Campaign instance stores (added in v4)
+        if (!db.objectStoreNames.contains(STORES.CAMPAIGN_UNIT_INSTANCES)) {
+          db.createObjectStore(STORES.CAMPAIGN_UNIT_INSTANCES);
+        }
+        if (!db.objectStoreNames.contains(STORES.CAMPAIGN_PILOT_INSTANCES)) {
+          db.createObjectStore(STORES.CAMPAIGN_PILOT_INSTANCES);
         }
       };
     });

--- a/src/services/persistence/__tests__/CampaignInstanceService.test.ts
+++ b/src/services/persistence/__tests__/CampaignInstanceService.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Campaign Instance Service Tests
+ *
+ * Tests for the CampaignInstanceService CRUD operations.
+ * Uses fake-indexeddb for browser storage simulation.
+ */
+
+// Polyfill structuredClone for Node.js < 17
+if (typeof structuredClone === 'undefined') {
+  Object.defineProperty(global, 'structuredClone', {
+    value: <T>(obj: T): T => JSON.parse(JSON.stringify(obj)) as T,
+    writable: true,
+    configurable: true,
+  });
+}
+
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
+import {
+  CampaignInstanceService,
+  _resetCampaignInstanceService,
+} from '../CampaignInstanceService';
+import { _resetIndexedDBService } from '../IndexedDBService';
+import { CampaignUnitStatus, CampaignPilotStatus } from '../../../types/campaign/CampaignInterfaces';
+import type { ICampaignUnitInstance, ICampaignPilotInstance } from '../../../types/campaign/CampaignInstanceInterfaces';
+
+// Reset singletons and IndexedDB before each test
+beforeEach(() => {
+  // Create a fresh IndexedDB for each test
+  Object.defineProperty(global, 'indexedDB', {
+    value: new IDBFactory(),
+    writable: true,
+    configurable: true,
+  });
+  _resetIndexedDBService();
+  _resetCampaignInstanceService();
+});
+
+// =============================================================================
+// Unit Instance Tests
+// =============================================================================
+
+describe('CampaignInstanceService - Unit Instances', () => {
+  let service: CampaignInstanceService;
+
+  beforeEach(() => {
+    service = new CampaignInstanceService();
+  });
+
+  describe('createUnitInstance', () => {
+    it('should create a new unit instance', async () => {
+      const instance = await service.createUnitInstance(
+        {
+          campaignId: 'campaign-1',
+          vaultUnitId: 'vault-unit-1',
+        },
+        {
+          version: 1,
+          name: 'Atlas AS7-D',
+          chassis: 'Atlas',
+          variant: 'AS7-D',
+        }
+      );
+
+      expect(instance.id).toBeTruthy();
+      expect(instance.campaignId).toBe('campaign-1');
+      expect(instance.vaultUnitId).toBe('vault-unit-1');
+      expect(instance.vaultUnitVersion).toBe(1);
+      expect(instance.unitName).toBe('Atlas AS7-D');
+      expect(instance.unitChassis).toBe('Atlas');
+      expect(instance.unitVariant).toBe('AS7-D');
+      expect(instance.status).toBe(CampaignUnitStatus.Operational);
+      expect(instance.damageState).toBeDefined();
+      expect(instance.totalKills).toBe(0);
+      expect(instance.missionsParticipated).toBe(0);
+      expect(instance.createdAt).toBeTruthy();
+      expect(instance.updatedAt).toBeTruthy();
+    });
+
+    it('should create with optional force assignment', async () => {
+      const instance = await service.createUnitInstance(
+        {
+          campaignId: 'campaign-1',
+          vaultUnitId: 'vault-unit-1',
+          forceId: 'force-1',
+          forceSlot: 2,
+          notes: 'Test notes',
+        },
+        {
+          version: 1,
+          name: 'Marauder MAD-3R',
+          chassis: 'Marauder',
+          variant: 'MAD-3R',
+        }
+      );
+
+      expect(instance.forceId).toBe('force-1');
+      expect(instance.forceSlot).toBe(2);
+      expect(instance.notes).toBe('Test notes');
+    });
+  });
+
+  describe('getUnitInstance', () => {
+    it('should retrieve a created unit instance', async () => {
+      const created = await service.createUnitInstance(
+        { campaignId: 'campaign-1', vaultUnitId: 'vault-1' },
+        { version: 1, name: 'Test', chassis: 'Test', variant: 'T-1' }
+      );
+
+      const retrieved = await service.getUnitInstance(created.id);
+
+      expect(retrieved).toBeDefined();
+      expect(retrieved?.id).toBe(created.id);
+      expect(retrieved?.unitName).toBe('Test');
+    });
+
+    it('should return undefined for non-existent instance', async () => {
+      const result = await service.getUnitInstance('non-existent');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('updateUnitInstance', () => {
+    it('should update unit instance fields', async () => {
+      const created = await service.createUnitInstance(
+        { campaignId: 'campaign-1', vaultUnitId: 'vault-1' },
+        { version: 1, name: 'Test', chassis: 'Test', variant: 'T-1' }
+      );
+
+      const updated = await service.updateUnitInstance(created.id, {
+        status: CampaignUnitStatus.Damaged,
+        totalKills: 3,
+        missionsParticipated: 5,
+        notes: 'Updated notes',
+      });
+
+      expect(updated.status).toBe(CampaignUnitStatus.Damaged);
+      expect(updated.totalKills).toBe(3);
+      expect(updated.missionsParticipated).toBe(5);
+      expect(updated.notes).toBe('Updated notes');
+      // updatedAt should be set (may be same as createdAt if very fast)
+      expect(updated.updatedAt).toBeTruthy();
+    });
+
+    it('should throw for non-existent instance', async () => {
+      await expect(
+        service.updateUnitInstance('non-existent', { status: CampaignUnitStatus.Damaged })
+      ).rejects.toThrow('Unit instance not found');
+    });
+  });
+
+  describe('deleteUnitInstance', () => {
+    it('should delete a unit instance', async () => {
+      const created = await service.createUnitInstance(
+        { campaignId: 'campaign-1', vaultUnitId: 'vault-1' },
+        { version: 1, name: 'Test', chassis: 'Test', variant: 'T-1' }
+      );
+
+      await service.deleteUnitInstance(created.id);
+
+      const retrieved = await service.getUnitInstance(created.id);
+      expect(retrieved).toBeUndefined();
+    });
+  });
+
+  describe('listUnitInstances', () => {
+    beforeEach(async () => {
+      // Create test instances
+      await service.createUnitInstance(
+        { campaignId: 'campaign-1', vaultUnitId: 'vault-1', forceId: 'force-1' },
+        { version: 1, name: 'Unit 1', chassis: 'Atlas', variant: 'AS7-D' }
+      );
+      await service.createUnitInstance(
+        { campaignId: 'campaign-1', vaultUnitId: 'vault-2', forceId: 'force-2' },
+        { version: 1, name: 'Unit 2', chassis: 'Marauder', variant: 'MAD-3R' }
+      );
+      await service.createUnitInstance(
+        { campaignId: 'campaign-2', vaultUnitId: 'vault-3' },
+        { version: 1, name: 'Unit 3', chassis: 'Warhammer', variant: 'WHM-6R' }
+      );
+    });
+
+    it('should list all unit instances', async () => {
+      const instances = await service.listUnitInstances();
+      expect(instances).toHaveLength(3);
+    });
+
+    it('should filter by campaign ID', async () => {
+      const instances = await service.listUnitInstances({ campaignId: 'campaign-1' });
+      expect(instances).toHaveLength(2);
+      expect(instances.every((i) => i.campaignId === 'campaign-1')).toBe(true);
+    });
+
+    it('should filter by force ID', async () => {
+      const instances = await service.listUnitInstances({ forceId: 'force-1' });
+      expect(instances).toHaveLength(1);
+      expect(instances[0].forceId).toBe('force-1');
+    });
+
+    it('should filter available only', async () => {
+      // Update one to destroyed
+      const all = await service.listUnitInstances({ campaignId: 'campaign-1' });
+      await service.updateUnitInstance(all[0].id, { status: CampaignUnitStatus.Destroyed });
+
+      const available = await service.listUnitInstances({
+        campaignId: 'campaign-1',
+        availableOnly: true,
+      });
+      expect(available).toHaveLength(1);
+    });
+  });
+});
+
+// =============================================================================
+// Pilot Instance Tests
+// =============================================================================
+
+describe('CampaignInstanceService - Pilot Instances', () => {
+  let service: CampaignInstanceService;
+
+  beforeEach(() => {
+    service = new CampaignInstanceService();
+  });
+
+  describe('createPilotInstanceFromVault', () => {
+    it('should create pilot instance from vault pilot', async () => {
+      const instance = await service.createPilotInstanceFromVault(
+        { campaignId: 'campaign-1', vaultPilotId: 'vault-pilot-1' },
+        { name: 'John Doe', callsign: 'Maverick', skills: { gunnery: 3, piloting: 4 } }
+      );
+
+      expect(instance.id).toBeTruthy();
+      expect(instance.campaignId).toBe('campaign-1');
+      expect(instance.vaultPilotId).toBe('vault-pilot-1');
+      expect(instance.statblockData).toBeNull();
+      expect(instance.pilotName).toBe('John Doe');
+      expect(instance.pilotCallsign).toBe('Maverick');
+      expect(instance.currentSkills).toEqual({ gunnery: 3, piloting: 4 });
+      expect(instance.status).toBe(CampaignPilotStatus.Active);
+      expect(instance.wounds).toBe(0);
+      expect(instance.currentXP).toBe(0);
+    });
+  });
+
+  describe('createPilotInstanceFromStatblock', () => {
+    it('should create pilot instance from statblock', async () => {
+      const instance = await service.createPilotInstanceFromStatblock({
+        campaignId: 'campaign-1',
+        statblock: { name: 'Generic Pilot', gunnery: 4, piloting: 5 },
+      });
+
+      expect(instance.id).toBeTruthy();
+      expect(instance.campaignId).toBe('campaign-1');
+      expect(instance.vaultPilotId).toBeNull();
+      expect(instance.statblockData).toEqual({ name: 'Generic Pilot', gunnery: 4, piloting: 5 });
+      expect(instance.pilotName).toBe('Generic Pilot');
+      expect(instance.currentSkills).toEqual({ gunnery: 4, piloting: 5 });
+    });
+  });
+
+  describe('updatePilotInstance', () => {
+    it('should update pilot instance fields', async () => {
+      const created = await service.createPilotInstanceFromVault(
+        { campaignId: 'campaign-1', vaultPilotId: 'vault-pilot-1' },
+        { name: 'Test Pilot', skills: { gunnery: 4, piloting: 5 } }
+      );
+
+      const updated = await service.updatePilotInstance(created.id, {
+        wounds: 2,
+        currentXP: 10,
+        killCount: 5,
+        status: CampaignPilotStatus.Wounded,
+      });
+
+      expect(updated.wounds).toBe(2);
+      expect(updated.currentXP).toBe(10);
+      expect(updated.killCount).toBe(5);
+      expect(updated.status).toBe(CampaignPilotStatus.Wounded);
+    });
+  });
+
+  describe('listPilotInstances', () => {
+    beforeEach(async () => {
+      await service.createPilotInstanceFromVault(
+        { campaignId: 'campaign-1', vaultPilotId: 'pilot-1' },
+        { name: 'Pilot 1', skills: { gunnery: 4, piloting: 5 } }
+      );
+      await service.createPilotInstanceFromVault(
+        { campaignId: 'campaign-1', vaultPilotId: 'pilot-2' },
+        { name: 'Pilot 2', skills: { gunnery: 3, piloting: 4 } }
+      );
+      await service.createPilotInstanceFromStatblock({
+        campaignId: 'campaign-2',
+        statblock: { name: 'NPC', gunnery: 5, piloting: 6 },
+      });
+    });
+
+    it('should list all pilot instances', async () => {
+      const instances = await service.listPilotInstances();
+      expect(instances).toHaveLength(3);
+    });
+
+    it('should filter by campaign ID', async () => {
+      const instances = await service.listPilotInstances({ campaignId: 'campaign-1' });
+      expect(instances).toHaveLength(2);
+    });
+
+    it('should filter available only', async () => {
+      const all = await service.listPilotInstances({ campaignId: 'campaign-1' });
+      await service.updatePilotInstance(all[0].id, { recoveryTime: 5 });
+
+      const available = await service.listPilotInstances({
+        campaignId: 'campaign-1',
+        availableOnly: true,
+      });
+      expect(available).toHaveLength(1);
+    });
+  });
+});
+
+// =============================================================================
+// Assignment Tests
+// =============================================================================
+
+describe('CampaignInstanceService - Assignments', () => {
+  let service: CampaignInstanceService;
+  let unitInstance: ICampaignUnitInstance;
+  let pilotInstance: ICampaignPilotInstance;
+
+  beforeEach(async () => {
+    service = new CampaignInstanceService();
+
+    unitInstance = await service.createUnitInstance(
+      { campaignId: 'campaign-1', vaultUnitId: 'vault-1' },
+      { version: 1, name: 'Atlas', chassis: 'Atlas', variant: 'AS7-D' }
+    );
+
+    pilotInstance = await service.createPilotInstanceFromVault(
+      { campaignId: 'campaign-1', vaultPilotId: 'pilot-1' },
+      { name: 'Test Pilot', skills: { gunnery: 4, piloting: 5 } }
+    );
+  });
+
+  describe('assignPilotToUnit', () => {
+    it('should create bidirectional assignment', async () => {
+      await service.assignPilotToUnit(pilotInstance.id, unitInstance.id);
+
+      const updatedPilot = await service.getPilotInstance(pilotInstance.id);
+      const updatedUnit = await service.getUnitInstance(unitInstance.id);
+
+      expect(updatedPilot?.assignedUnitInstanceId).toBe(unitInstance.id);
+      expect(updatedUnit?.assignedPilotInstanceId).toBe(pilotInstance.id);
+    });
+
+    it('should unassign previous pilot when assigning new one', async () => {
+      // Create second pilot
+      const pilot2 = await service.createPilotInstanceFromVault(
+        { campaignId: 'campaign-1', vaultPilotId: 'pilot-2' },
+        { name: 'Pilot 2', skills: { gunnery: 3, piloting: 4 } }
+      );
+
+      // Assign first pilot
+      await service.assignPilotToUnit(pilotInstance.id, unitInstance.id);
+
+      // Assign second pilot (should unassign first)
+      await service.assignPilotToUnit(pilot2.id, unitInstance.id);
+
+      const pilot1Updated = await service.getPilotInstance(pilotInstance.id);
+      const pilot2Updated = await service.getPilotInstance(pilot2.id);
+      const unitUpdated = await service.getUnitInstance(unitInstance.id);
+
+      expect(pilot1Updated?.assignedUnitInstanceId).toBeUndefined();
+      expect(pilot2Updated?.assignedUnitInstanceId).toBe(unitInstance.id);
+      expect(unitUpdated?.assignedPilotInstanceId).toBe(pilot2.id);
+    });
+  });
+
+  describe('unassignPilot', () => {
+    it('should remove bidirectional assignment', async () => {
+      await service.assignPilotToUnit(pilotInstance.id, unitInstance.id);
+      await service.unassignPilot(pilotInstance.id);
+
+      const updatedPilot = await service.getPilotInstance(pilotInstance.id);
+      const updatedUnit = await service.getUnitInstance(unitInstance.id);
+
+      expect(updatedPilot?.assignedUnitInstanceId).toBeUndefined();
+      expect(updatedUnit?.assignedPilotInstanceId).toBeUndefined();
+    });
+  });
+});
+
+// =============================================================================
+// Bulk Operations Tests
+// =============================================================================
+
+describe('CampaignInstanceService - Bulk Operations', () => {
+  let service: CampaignInstanceService;
+
+  beforeEach(async () => {
+    service = new CampaignInstanceService();
+
+    // Create instances for multiple campaigns
+    await service.createUnitInstance(
+      { campaignId: 'campaign-1', vaultUnitId: 'v1' },
+      { version: 1, name: 'U1', chassis: 'C', variant: 'V' }
+    );
+    await service.createUnitInstance(
+      { campaignId: 'campaign-1', vaultUnitId: 'v2' },
+      { version: 1, name: 'U2', chassis: 'C', variant: 'V' }
+    );
+    await service.createUnitInstance(
+      { campaignId: 'campaign-2', vaultUnitId: 'v3' },
+      { version: 1, name: 'U3', chassis: 'C', variant: 'V' }
+    );
+
+    await service.createPilotInstanceFromVault(
+      { campaignId: 'campaign-1', vaultPilotId: 'p1' },
+      { name: 'P1', skills: { gunnery: 4, piloting: 5 } }
+    );
+    await service.createPilotInstanceFromVault(
+      { campaignId: 'campaign-2', vaultPilotId: 'p2' },
+      { name: 'P2', skills: { gunnery: 4, piloting: 5 } }
+    );
+  });
+
+  describe('deleteInstancesForCampaign', () => {
+    it('should delete all instances for a campaign', async () => {
+      await service.deleteInstancesForCampaign('campaign-1');
+
+      const units1 = await service.listUnitInstances({ campaignId: 'campaign-1' });
+      const pilots1 = await service.listPilotInstances({ campaignId: 'campaign-1' });
+      const units2 = await service.listUnitInstances({ campaignId: 'campaign-2' });
+      const pilots2 = await service.listPilotInstances({ campaignId: 'campaign-2' });
+
+      expect(units1).toHaveLength(0);
+      expect(pilots1).toHaveLength(0);
+      expect(units2).toHaveLength(1); // Other campaign unaffected
+      expect(pilots2).toHaveLength(1);
+    });
+  });
+});

--- a/src/services/persistence/index.ts
+++ b/src/services/persistence/index.ts
@@ -32,3 +32,15 @@ export type { ISQLiteService, IDatabaseConfig, IMigration } from './SQLiteServic
 export { MigrationService, migrationService } from './MigrationService';
 export type { IMigrationService, IMigrationResult, IMigrationError } from './MigrationService';
 
+export {
+  CampaignInstanceService,
+  getCampaignInstanceService,
+  _resetCampaignInstanceService,
+} from './CampaignInstanceService';
+export type {
+  ICampaignInstanceService,
+  IInstanceQueryOptions,
+  IUpdateUnitInstanceInput,
+  IUpdatePilotInstanceInput,
+} from './CampaignInstanceService';
+


### PR DESCRIPTION
## Summary
Implements Phase 2 (Database Schema & Service Layer) of the `add-campaign-instances` proposal.

This PR adds the persistence layer for campaign unit and pilot instances.

## Changes

### IndexedDB (Browser)
- Added `CAMPAIGN_UNIT_INSTANCES` and `CAMPAIGN_PILOT_INSTANCES` object stores
- Bumped DB_VERSION to 4 (handles migration automatically)

### SQLite (Desktop/Server)
- Added migration 3: `campaign_instances_schema`
- `campaign_unit_instances` table with damage state, status, force assignment
- `campaign_pilot_instances` table with XOR constraint (vault_pilot_id OR statblock_data)
- Foreign keys to pilots table and between instances
- Indexes for campaign, status, force, and vault queries

### CampaignInstanceService
Full CRUD operations:
- `createUnitInstance()` - Create unit instance with damage state
- `createPilotInstanceFromVault()` - Create pilot from vault reference
- `createPilotInstanceFromStatblock()` - Create pilot from inline statblock
- `get/update/delete` for both unit and pilot instances
- `list*Instances()` with filtering by campaign, status, force, availability

Assignment management:
- `assignPilotToUnit()` - Bidirectional assignment
- `unassignPilot()` - Clean up both sides

Bulk operations:
- `deleteInstancesForCampaign()` - Clean up when campaign is deleted

## Files Changed
- `src/services/persistence/IndexedDBService.ts` - New stores
- `src/services/persistence/SQLiteService.ts` - Migration 3
- `src/services/persistence/CampaignInstanceService.ts` - New service
- `src/services/persistence/index.ts` - Export service
- `openspec/changes/add-campaign-instances/tasks.md` - Updated task tracking

## Testing
- 21 new tests using fake-indexeddb
- Tests cover CRUD, filtering, assignments, bulk operations
- All 11,199+ tests pass

## Dependencies
- Added `fake-indexeddb` as dev dependency for testing

## Next Steps
Remaining tasks:
- Event integration (emit events for state changes)
- Instance-filtered Timeline queries
- Integration with campaign store for automatic instance creation