### PR TITLE
fix: address quality issues from retrospective review

### DIFF
--- a/e2e/mobile-navigation.spec.ts
+++ b/e2e/mobile-navigation.spec.ts
@@ -430,12 +430,14 @@ test.describe('Gameplay Navigation', () => {
     const campaignsLink = sidebar.locator('a[href="/gameplay/campaigns"]');
     const encountersLink = sidebar.locator('a[href="/gameplay/encounters"]');
     const gamesLink = sidebar.locator('a[href="/gameplay/games"]');
+    const quickGameLink = sidebar.locator('a[href="/gameplay/quick"]');
     
     await expect(pilotsLink).toBeVisible();
     await expect(forcesLink).toBeVisible();
     await expect(campaignsLink).toBeVisible();
     await expect(encountersLink).toBeVisible();
     await expect(gamesLink).toBeVisible();
+    await expect(quickGameLink).toBeVisible();
     
     // Verify labels
     await expect(sidebar.getByText('Pilots')).toBeVisible();
@@ -443,6 +445,7 @@ test.describe('Gameplay Navigation', () => {
     await expect(sidebar.getByText('Campaigns')).toBeVisible();
     await expect(sidebar.getByText('Encounters')).toBeVisible();
     await expect(sidebar.getByText('Games')).toBeVisible();
+    await expect(sidebar.getByText('Quick Game')).toBeVisible();
   });
 
   test('should have navigable gameplay routes', async ({ page }) => {
@@ -453,6 +456,7 @@ test.describe('Gameplay Navigation', () => {
       '/gameplay/campaigns',
       '/gameplay/encounters',
       '/gameplay/games',
+      '/gameplay/quick',
     ];
     
     for (const route of routes) {

--- a/src/components/common/Sidebar.stories.tsx
+++ b/src/components/common/Sidebar.stories.tsx
@@ -187,6 +187,20 @@ export const OnGamesPage: Story = {
   },
 };
 
+export const OnQuickGamePage: Story = {
+  render: () => <SidebarWrapper initialCollapsed={false} />,
+  parameters: {
+    nextRouter: {
+      pathname: '/gameplay/quick',
+    },
+    docs: {
+      description: {
+        story: 'Quick Game page for standalone battles without campaign context.',
+      },
+    },
+  },
+};
+
 // History/Timeline section stories
 export const OnTimelinePage: Story = {
   render: () => <SidebarWrapper initialCollapsed={false} />,

--- a/src/components/quickgame/QuickGamePlay.tsx
+++ b/src/components/quickgame/QuickGamePlay.tsx
@@ -151,17 +151,6 @@ export function QuickGamePlay(): React.ReactElement {
   const opponentAlive =
     game.opponentForce?.units.filter((u) => !u.isDestroyed && !u.isWithdrawn).length ?? 0;
 
-  // Check for victory conditions
-  const checkVictory = () => {
-    if (playerAlive === 0 && opponentAlive > 0) {
-      endGame('opponent', 'All player units destroyed');
-    } else if (opponentAlive === 0 && playerAlive > 0) {
-      endGame('player', 'All enemy units destroyed');
-    } else if (playerAlive === 0 && opponentAlive === 0) {
-      endGame('draw', 'Mutual destruction');
-    }
-  };
-
   const handleEndGame = (winner: 'player' | 'opponent' | 'draw') => {
     const reasons = {
       player: 'Player victory',

--- a/src/components/quickgame/QuickGameReview.tsx
+++ b/src/components/quickgame/QuickGameReview.tsx
@@ -243,7 +243,7 @@ export function QuickGameReview(): React.ReactElement {
             </span>
           </div>
           <p className="text-center text-xs text-gray-500 mt-2">
-            Difficulty: {((game.opponentForce.totalBV / game.playerForce.totalBV) * 100).toFixed(0)}%
+            Difficulty: {game.playerForce.totalBV > 0 ? ((game.opponentForce.totalBV / game.playerForce.totalBV) * 100).toFixed(0) : 0}%
           </p>
         </div>
       </Card>

--- a/src/components/quickgame/QuickGameSetup.tsx
+++ b/src/components/quickgame/QuickGameSetup.tsx
@@ -5,7 +5,7 @@
  * @spec openspec/changes/add-quick-session-mode/proposal.md
  */
 
-import { useState, useCallback } from 'react';
+import { useEffect, useRef } from 'react';
 import { useQuickGameStore } from '@/stores/useQuickGameStore';
 import { QuickGameStep, IQuickGameUnitRequest } from '@/types/quickgame';
 import { Button, Card, Select } from '@/components/ui';
@@ -18,7 +18,6 @@ import { BiomeType } from '@/types/scenario';
 
 function UnitSelectionStep(): React.ReactElement {
   const { game, addUnit, removeUnit, updateUnitSkills, nextStep } = useQuickGameStore();
-  const [showAddUnit, setShowAddUnit] = useState(false);
 
   // Demo unit data - in production would come from compendium/vault
   const demoUnits: IQuickGameUnitRequest[] = [
@@ -98,7 +97,6 @@ function UnitSelectionStep(): React.ReactElement {
 
   const handleAddUnit = (unit: IQuickGameUnitRequest) => {
     addUnit(unit);
-    setShowAddUnit(false);
   };
 
   const playerUnits = game?.playerForce.units ?? [];
@@ -230,12 +228,21 @@ function UnitSelectionStep(): React.ReactElement {
 function ScenarioConfigStep(): React.ReactElement {
   const { game, setScenarioConfig, generateScenario, previousStep, nextStep, isLoading } =
     useQuickGameStore();
+  const wasLoadingRef = useRef(false);
+
+  // Advance to next step after scenario generation completes
+  useEffect(() => {
+    if (wasLoadingRef.current && !isLoading && game?.scenario) {
+      nextStep();
+    }
+    wasLoadingRef.current = isLoading;
+  }, [isLoading, game?.scenario, nextStep]);
 
   const config = game?.scenarioConfig;
 
   const handleGenerate = () => {
     generateScenario();
-    nextStep();
+    // nextStep() is called via useEffect after scenario generation completes
   };
 
   const factionOptions = Object.values(Faction).map((f) => ({

--- a/src/constants/scenario/rats.ts
+++ b/src/constants/scenario/rats.ts
@@ -317,10 +317,14 @@ export function getAvailableErasForFaction(faction: string): readonly Era[] {
 
 /**
  * Select a random unit from a RAT based on weights.
+ * @param rat - The random assignment table to select from
+ * @param unitTypeFilter - Optional filter for unit type
+ * @param randomFn - Optional random function for seeded PRNG (defaults to Math.random)
  */
 export function selectUnitFromRAT(
   rat: IRandomAssignmentTable,
-  unitTypeFilter?: UnitTypeCategory
+  unitTypeFilter?: UnitTypeCategory,
+  randomFn: () => number = Math.random
 ): IRATEntry {
   // Filter entries if type specified
   const entries = unitTypeFilter
@@ -336,7 +340,7 @@ export function selectUnitFromRAT(
   const totalWeight = entries.reduce((sum, e) => sum + e.weight, 0);
 
   // Random roll
-  let roll = Math.random() * totalWeight;
+  let roll = randomFn() * totalWeight;
 
   for (const entry of entries) {
     roll -= entry.weight;
@@ -351,6 +355,9 @@ export function selectUnitFromRAT(
 
 /**
  * Select multiple units from a RAT targeting a BV budget.
+ * @param rat - The random assignment table to select from
+ * @param targetBV - Target battle value budget
+ * @param options - Selection options including randomFn for seeded PRNG
  */
 export function selectUnitsFromRAT(
   rat: IRandomAssignmentTable,
@@ -360,6 +367,7 @@ export function selectUnitsFromRAT(
     minUnits?: number;
     maxUnits?: number;
     bvTolerance?: number; // Percentage tolerance (default 10%)
+    randomFn?: () => number; // Optional random function for seeded PRNG
   } = {}
 ): readonly IRATEntry[] {
   const {
@@ -367,6 +375,7 @@ export function selectUnitsFromRAT(
     minUnits = 1,
     maxUnits = 12,
     bvTolerance = 0.1,
+    randomFn = Math.random,
   } = options;
 
   const selected: IRATEntry[] = [];
@@ -388,7 +397,8 @@ export function selectUnitsFromRAT(
 
     const unit = selectUnitFromRAT(
       { ...rat, entries: availableEntries, totalWeight: availableEntries.reduce((s, e) => s + e.weight, 0) },
-      unitTypeFilter
+      unitTypeFilter,
+      randomFn
     );
     
     selected.push(unit);

--- a/src/services/game-resolution/GameOutcomeCalculator.ts
+++ b/src/services/game-resolution/GameOutcomeCalculator.ts
@@ -112,14 +112,6 @@ function isSideEliminated(state: IGameState, side: GameSide): boolean {
 }
 
 /**
- * Map GameSide to simplified winner type.
- */
-function _gameSideToWinner(side: GameSide | 'draw'): 'player' | 'opponent' | 'draw' {
-  if (side === 'draw') return 'draw';
-  return side === GameSide.Player ? 'player' : 'opponent';
-}
-
-/**
  * Generate human-readable victory description.
  */
 function generateVictoryDescription(
@@ -335,7 +327,7 @@ export function isGameEnded(state: IGameState, config: IGameConfig): boolean {
   }
 
   // Turn limit reached
-  if (config.turnLimit > 0 && state.turn > config.turnLimit) {
+  if (config.turnLimit > 0 && state.turn >= config.turnLimit) {
     return true;
   }
 
@@ -368,7 +360,7 @@ export function determineWinner(
   }
 
   // Check turn limit
-  if (config.turnLimit > 0 && state.turn > config.turnLimit) {
+  if (config.turnLimit > 0 && state.turn >= config.turnLimit) {
     if (playerSurviving > opponentSurviving) {
       return 'player';
     } else if (opponentSurviving > playerSurviving) {

--- a/src/stores/useQuickGameStore.ts
+++ b/src/stores/useQuickGameStore.ts
@@ -10,7 +10,6 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { GameStatus, GamePhase, IGameEvent } from '@/types/gameplay';
 import {
-  IQuickGameInstance,
   IQuickGameState,
   IQuickGameActions,
   IQuickGameUnitRequest,
@@ -358,14 +357,15 @@ export const useQuickGameStore = create<QuickGameStore>()(
         const newGame = createQuickGameInstance();
 
         if (!resetUnits) {
-          // Keep the same units but reset their damage
+          // Keep the same units but reset their damage and restore armor/structure to max
           const resetPlayerUnits = game.playerForce.units.map((unit) => ({
             ...unit,
             instanceId: `unit-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
             heat: 0,
             isDestroyed: false,
             isWithdrawn: false,
-            // Note: armor/structure would need to be reset to max values
+            armor: { ...unit.maxArmor },
+            structure: { ...unit.maxStructure },
           }));
 
           newGame.playerForce = {

--- a/src/types/quickgame/QuickGameInterfaces.ts
+++ b/src/types/quickgame/QuickGameInterfaces.ts
@@ -57,6 +57,10 @@ export interface IQuickGameUnit {
   readonly piloting: number;
   /** Pilot name (optional) */
   readonly pilotName?: string;
+  /** Maximum armor by location (for reset) */
+  readonly maxArmor: Record<string, number>;
+  /** Maximum internal structure by location (for reset) */
+  readonly maxStructure: Record<string, number>;
   /** Current armor by location */
   armor: Record<string, number>;
   /** Current internal structure by location */
@@ -274,6 +278,8 @@ export function createQuickGameUnit(request: IQuickGameUnitRequest): IQuickGameU
     gunnery: request.gunnery ?? 4,
     piloting: request.piloting ?? 5,
     pilotName: request.pilotName,
+    maxArmor: { ...request.maxArmor },
+    maxStructure: { ...request.maxStructure },
     armor: { ...request.maxArmor },
     structure: { ...request.maxStructure },
     heat: 0,


### PR DESCRIPTION
## Summary

Retrospective quality review of PRs #158, #159, #160 identified 16 issues (8 high, 5 medium, 3 low severity). This PR addresses all of them.

## Quick Game Fixes (PR #160)

- **Race condition**: `QuickGameSetup` called `nextStep()` immediately after `generateScenario()`, transitioning before scenario was ready. Fixed with useEffect that waits for generation to complete.
- **Turn limit inconsistency**: `GameOutcomeCalculator` used `>=` in one place and `>` in others for turn limit checks. Standardized to `>=` everywhere.
- **Dead code removed**: Unused `checkVictory` function and `_gameSideToWinner` helper.
- **Incomplete reset**: `playAgain()` now properly resets armor/structure to max values.
- **Division by zero**: Added guard in `QuickGameReview` for BV percentage calculation.
- **Unused state**: Removed `showAddUnit` state that was never read.

## Scenario Generator Fixes (PR #159)

- **Seeded RNG propagation**: The reproducibility feature was broken because `OpForGeneratorService` and RAT selection used `Math.random()` directly instead of the seeded PRNG. Fixed by:
  - Adding `randomFn` parameter to `OpForGeneratorService.generate()`
  - Adding `randomFn` parameter to `selectUnitFromRAT()` and `selectUnitsFromRAT()`
  - Passing `this.random.bind(this)` from ScenarioGeneratorService
- **Seed mutation**: Split `seed` and `prngState` fields so original seed is preserved.
- **Non-deterministic fallback**: Map preset selection fallback now uses seeded RNG.

## E2E Test Fixes (PR #158)

- Added missing `/gameplay/quick` route to mobile navigation tests.
- Added `OnQuickGamePage` Storybook story for sidebar coverage.

## Testing

- All 11,411 tests pass
- Pre-commit hooks pass (lint, type check, build)

## Files Changed

| File | Changes |
|------|---------|
| `QuickGameSetup.tsx` | Race condition fix, unused state removal |
| `QuickGamePlay.tsx` | Dead code removal |
| `QuickGameReview.tsx` | Division by zero guard |
| `GameOutcomeCalculator.ts` | Turn limit standardization, dead code removal |
| `useQuickGameStore.ts` | playAgain reset fix |
| `QuickGameInterfaces.ts` | Added maxArmor/maxStructure to interface |
| `ScenarioGeneratorService.ts` | Seed/state separation, RNG propagation |
| `OpForGeneratorService.ts` | randomFn parameter support |
| `rats.ts` | randomFn parameter support |
| `mobile-navigation.spec.ts` | Quick Game test coverage |
| `Sidebar.stories.tsx` | OnQuickGamePage story |