### PR TITLE
fix(printing): add helpful error messages for missing record sheet assets

### DIFF
--- a/src/__tests__/service/printing/SVGRecordSheetRenderer.test.ts
+++ b/src/__tests__/service/printing/SVGRecordSheetRenderer.test.ts
@@ -20,6 +20,7 @@ const createMockSVGResponse = (content: string) => {
   return Promise.resolve({
     ok: true,
     text: () => Promise.resolve(content),
+    headers: new Headers({ 'content-type': 'image/svg+xml' }),
   } as Response);
 };
 


### PR DESCRIPTION
## Summary

Fixes the cryptic `SVG template root element is not a valid SVGSVGElement` error when record sheet assets are missing after a fresh clone.

## Changes

- Check HTTP response status before parsing SVG (catches actual 404s)
- Detect HTML content-type indicating a soft 404 page from dev server
- Check for HTML doctype/tags in response body as final fallback
- All error messages guide user to run `npm run fetch:assets`

## Before

```
Error: SVG template root element is not a valid SVGSVGElement
```

## After

```
Error: Failed to load SVG template "/record-sheets/templates_us/mek_biped_default.svg": HTTP 404.
Run 'npm run fetch:assets' to download required record sheet assets.
```

## Testing

- All 116 svgRecordSheetRenderer tests pass
- Build passes