### PR TITLE
feat(campaign): add day advancement pipeline with plugin registry

### DIFF
--- a/.sisyphus/boulder.json
+++ b/.sisyphus/boulder.json
@@ -1,6 +1,6 @@
 {
-  "active_plan": "E:\\Projects\\MekStation\\.sisyphus\\plans\\mekhq-campaign-system.md",
-  "started_at": "2026-01-26T01:09:07.642Z",
+  "active_plan": "E:\\Projects\\MekStation\\.sisyphus\\plans\\day-advancement-expansion.md",
+  "started_at": "2026-01-26T00:48:00.000Z",
   "session_ids": ["ses_40827124fffeVuYRC4fmgVm3Gs"],
-  "plan_name": "mekhq-campaign-system"
+  "plan_name": "day-advancement-expansion"
 }

--- a/src/components/campaign/DayReportPanel.tsx
+++ b/src/components/campaign/DayReportPanel.tsx
@@ -1,0 +1,174 @@
+import { Card } from '@/components/ui';
+import {
+  DayReport,
+  HealedPersonEvent,
+  ExpiredContractEvent,
+  DailyCostBreakdown,
+} from '@/lib/campaign/dayAdvancement';
+import { Money } from '@/types/campaign/Money';
+
+interface DayReportPanelProps {
+  reports: DayReport[];
+  onDismiss: () => void;
+}
+
+function aggregateCosts(reports: DayReport[]): DailyCostBreakdown {
+  let salariesTotal = 0;
+  let maintenanceTotal = 0;
+  let maxPersonnel = 0;
+  let maxUnits = 0;
+
+  for (const report of reports) {
+    salariesTotal += report.costs.salaries.amount;
+    maintenanceTotal += report.costs.maintenance.amount;
+    maxPersonnel = Math.max(maxPersonnel, report.costs.personnelCount);
+    maxUnits = Math.max(maxUnits, report.costs.unitCount);
+  }
+
+  return {
+    salaries: new Money(salariesTotal),
+    maintenance: new Money(maintenanceTotal),
+    total: new Money(salariesTotal + maintenanceTotal),
+    personnelCount: maxPersonnel,
+    unitCount: maxUnits,
+  };
+}
+
+function collectHealedPersonnel(reports: DayReport[]): HealedPersonEvent[] {
+  const seen = new Set<string>();
+  const result: HealedPersonEvent[] = [];
+
+  for (const report of reports) {
+    for (const evt of report.healedPersonnel) {
+      if (!seen.has(evt.personId)) {
+        seen.add(evt.personId);
+        result.push(evt);
+      }
+    }
+  }
+
+  return result;
+}
+
+function collectExpiredContracts(reports: DayReport[]): ExpiredContractEvent[] {
+  const seen = new Set<string>();
+  const result: ExpiredContractEvent[] = [];
+
+  for (const report of reports) {
+    for (const evt of report.expiredContracts) {
+      if (!seen.has(evt.contractId)) {
+        seen.add(evt.contractId);
+        result.push(evt);
+      }
+    }
+  }
+
+  return result;
+}
+
+export function DayReportPanel({ reports, onDismiss }: DayReportPanelProps): React.ReactElement {
+  if (reports.length === 0) {
+    return <></>;
+  }
+
+  const isMultiDay = reports.length > 1;
+  const costs = isMultiDay ? aggregateCosts(reports) : reports[0].costs;
+  const healedPersonnel = isMultiDay ? collectHealedPersonnel(reports) : reports[0].healedPersonnel;
+  const expiredContracts = isMultiDay ? collectExpiredContracts(reports) : reports[0].expiredContracts;
+  const lastReport = reports[reports.length - 1];
+  const balanceNegative = lastReport.campaign.finances.balance.isNegative();
+
+  const hasEvents = healedPersonnel.length > 0 || expiredContracts.length > 0 || costs.total.amount > 0;
+
+  return (
+    <Card className="mb-6 border-l-4 border-l-accent">
+      <div className="p-4">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-base font-semibold text-text-theme-primary">
+            {isMultiDay
+              ? `Day Report — ${reports.length} days processed`
+              : `Day Report — ${reports[0].date.toLocaleDateString()}`}
+          </h3>
+          <button
+            onClick={onDismiss}
+            className="text-text-theme-secondary hover:text-text-theme-primary transition-colors p-1"
+            aria-label="Dismiss report"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {!hasEvents && (
+          <p className="text-sm text-text-theme-secondary">Nothing notable happened.</p>
+        )}
+
+        {costs.total.amount > 0 && (
+          <div className="mb-3">
+            <h4 className="text-sm font-medium text-text-theme-secondary mb-1">Costs</h4>
+            <div className="grid grid-cols-3 gap-2 text-sm">
+              <div>
+                <span className="text-text-theme-secondary">Salaries:</span>{' '}
+                <span className="text-text-theme-primary">{costs.salaries.format()}</span>
+              </div>
+              <div>
+                <span className="text-text-theme-secondary">Maintenance:</span>{' '}
+                <span className="text-text-theme-primary">{costs.maintenance.format()}</span>
+              </div>
+              <div>
+                <span className="text-text-theme-secondary font-medium">Total:</span>{' '}
+                <span className={`font-medium ${balanceNegative ? 'text-red-400' : 'text-text-theme-primary'}`}>
+                  {costs.total.format()}
+                </span>
+              </div>
+            </div>
+            {balanceNegative && (
+              <p className="text-sm text-red-400 mt-1 flex items-center gap-1">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+                Balance is negative: {lastReport.campaign.finances.balance.format()}
+              </p>
+            )}
+          </div>
+        )}
+
+        {healedPersonnel.length > 0 && (
+          <div className="mb-3">
+            <h4 className="text-sm font-medium text-text-theme-secondary mb-1">Personnel Healed</h4>
+            <ul className="text-sm space-y-0.5">
+              {healedPersonnel.map((evt) => (
+                <li key={evt.personId} className="text-text-theme-primary">
+                  <span className="font-medium">{evt.personName}</span>
+                  {evt.returnedToActive && (
+                    <span className="text-green-400 ml-2">— returned to active duty</span>
+                  )}
+                  {evt.healedInjuries.length > 0 && !evt.returnedToActive && (
+                    <span className="text-text-theme-secondary ml-2">
+                      — {evt.healedInjuries.length} injury(s) healed
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {expiredContracts.length > 0 && (
+          <div>
+            <h4 className="text-sm font-medium text-text-theme-secondary mb-1">Contracts Completed</h4>
+            <ul className="text-sm space-y-0.5">
+              {expiredContracts.map((evt) => (
+                <li key={evt.contractId} className="text-text-theme-primary">
+                  <span className="font-medium">{evt.contractName}</span>
+                  <span className="text-green-400 ml-2">— completed</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/lib/campaign/__tests__/dayPipeline.test.ts
+++ b/src/lib/campaign/__tests__/dayPipeline.test.ts
@@ -1,0 +1,557 @@
+import { ICampaign, createDefaultCampaignOptions } from '@/types/campaign/Campaign';
+import { IPerson, createInjury } from '@/types/campaign/Person';
+import { Money } from '@/types/campaign/Money';
+import { IMission } from '@/types/campaign/Mission';
+import { IForce } from '@/types/campaign/Force';
+import { PersonnelStatus, CampaignPersonnelRole } from '@/types/campaign/enums';
+import {
+  DayPhase,
+  DayPipelineRegistry,
+  IDayProcessor,
+  IDayProcessorResult,
+  IDayEvent,
+  getDayPipeline,
+  _resetDayPipeline,
+  isFirstOfMonth,
+  isMonday,
+  isFirstOfYear,
+} from '../dayPipeline';
+import { advanceDays } from '../dayAdvancement';
+
+// =============================================================================
+// Test Fixtures
+// =============================================================================
+
+function createTestCampaign(overrides?: Partial<ICampaign>): ICampaign {
+  return {
+    id: 'campaign-001',
+    name: 'Test Campaign',
+    currentDate: new Date('3025-06-15T00:00:00Z'),
+    factionId: 'mercenary',
+    personnel: new Map<string, IPerson>(),
+    forces: new Map<string, IForce>(),
+    rootForceId: 'force-root',
+    missions: new Map<string, IMission>(),
+    finances: { transactions: [], balance: new Money(1000000) },
+    options: createDefaultCampaignOptions(),
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function createNoopProcessor(
+  id: string,
+  phase: DayPhase,
+  events: IDayEvent[] = []
+): IDayProcessor {
+  return {
+    id,
+    phase,
+    displayName: `Test Processor ${id}`,
+    process(campaign: ICampaign): IDayProcessorResult {
+      return { events, campaign };
+    },
+  };
+}
+
+function createThrowingProcessor(id: string, phase: DayPhase): IDayProcessor {
+  return {
+    id,
+    phase,
+    displayName: `Throwing Processor ${id}`,
+    process(): IDayProcessorResult {
+      throw new Error(`Processor ${id} failed`);
+    },
+  };
+}
+
+// =============================================================================
+// DayPhase Tests
+// =============================================================================
+
+describe('DayPhase', () => {
+  it('should have correct ascending order', () => {
+    expect(DayPhase.SETUP).toBeLessThan(DayPhase.PERSONNEL);
+    expect(DayPhase.PERSONNEL).toBeLessThan(DayPhase.FACILITIES);
+    expect(DayPhase.FACILITIES).toBeLessThan(DayPhase.MARKETS);
+    expect(DayPhase.MARKETS).toBeLessThan(DayPhase.MISSIONS);
+    expect(DayPhase.MISSIONS).toBeLessThan(DayPhase.UNITS);
+    expect(DayPhase.UNITS).toBeLessThan(DayPhase.FORCES);
+    expect(DayPhase.FORCES).toBeLessThan(DayPhase.FINANCES);
+    expect(DayPhase.FINANCES).toBeLessThan(DayPhase.EVENTS);
+    expect(DayPhase.EVENTS).toBeLessThan(DayPhase.CLEANUP);
+  });
+
+  it('should have 10 phases', () => {
+    const phases = Object.values(DayPhase).filter((v) => typeof v === 'number');
+    expect(phases).toHaveLength(10);
+  });
+
+  it('should be spaced by 100 for future insertion', () => {
+    expect(DayPhase.SETUP).toBe(0);
+    expect(DayPhase.PERSONNEL).toBe(100);
+    expect(DayPhase.FACILITIES).toBe(200);
+    expect(DayPhase.MARKETS).toBe(300);
+    expect(DayPhase.MISSIONS).toBe(400);
+    expect(DayPhase.UNITS).toBe(500);
+    expect(DayPhase.FORCES).toBe(600);
+    expect(DayPhase.FINANCES).toBe(700);
+    expect(DayPhase.EVENTS).toBe(800);
+    expect(DayPhase.CLEANUP).toBe(900);
+  });
+});
+
+// =============================================================================
+// DayPipelineRegistry Tests
+// =============================================================================
+
+describe('DayPipelineRegistry', () => {
+  let registry: DayPipelineRegistry;
+
+  beforeEach(() => {
+    registry = new DayPipelineRegistry();
+  });
+
+  describe('register', () => {
+    it('should add a processor', () => {
+      const processor = createNoopProcessor('test', DayPhase.PERSONNEL);
+      registry.register(processor);
+
+      expect(registry.getProcessors()).toHaveLength(1);
+      expect(registry.getProcessors()[0].id).toBe('test');
+    });
+
+    it('should replace processor with same ID', () => {
+      const processor1 = createNoopProcessor('test', DayPhase.PERSONNEL);
+      const processor2 = createNoopProcessor('test', DayPhase.FINANCES);
+
+      registry.register(processor1);
+      registry.register(processor2);
+
+      expect(registry.getProcessors()).toHaveLength(1);
+      expect(registry.getProcessors()[0].phase).toBe(DayPhase.FINANCES);
+    });
+
+    it('should allow multiple processors in same phase', () => {
+      registry.register(createNoopProcessor('a', DayPhase.PERSONNEL));
+      registry.register(createNoopProcessor('b', DayPhase.PERSONNEL));
+
+      expect(registry.getProcessors()).toHaveLength(2);
+    });
+  });
+
+  describe('unregister', () => {
+    it('should remove a processor by ID', () => {
+      registry.register(createNoopProcessor('test', DayPhase.PERSONNEL));
+      registry.unregister('test');
+
+      expect(registry.getProcessors()).toHaveLength(0);
+    });
+
+    it('should be a no-op for non-existent ID', () => {
+      registry.register(createNoopProcessor('test', DayPhase.PERSONNEL));
+      registry.unregister('nonexistent');
+
+      expect(registry.getProcessors()).toHaveLength(1);
+    });
+  });
+
+  describe('getProcessors', () => {
+    it('should return processors sorted by phase', () => {
+      registry.register(createNoopProcessor('finances', DayPhase.FINANCES));
+      registry.register(createNoopProcessor('personnel', DayPhase.PERSONNEL));
+      registry.register(createNoopProcessor('setup', DayPhase.SETUP));
+
+      const processors = registry.getProcessors();
+      expect(processors[0].id).toBe('setup');
+      expect(processors[1].id).toBe('personnel');
+      expect(processors[2].id).toBe('finances');
+    });
+
+    it('should return empty array when no processors registered', () => {
+      expect(registry.getProcessors()).toHaveLength(0);
+    });
+  });
+
+  describe('getProcessorsByPhase', () => {
+    it('should return only processors for specified phase', () => {
+      registry.register(createNoopProcessor('a', DayPhase.PERSONNEL));
+      registry.register(createNoopProcessor('b', DayPhase.FINANCES));
+      registry.register(createNoopProcessor('c', DayPhase.PERSONNEL));
+
+      const personnelProcessors = registry.getProcessorsByPhase(DayPhase.PERSONNEL);
+      expect(personnelProcessors).toHaveLength(2);
+      expect(personnelProcessors.map((p) => p.id)).toEqual(['a', 'c']);
+    });
+
+    it('should return empty array for phase with no processors', () => {
+      registry.register(createNoopProcessor('a', DayPhase.PERSONNEL));
+      expect(registry.getProcessorsByPhase(DayPhase.FINANCES)).toHaveLength(0);
+    });
+  });
+
+  describe('processDay', () => {
+    it('should call processors in phase order', () => {
+      const callOrder: string[] = [];
+
+      const makeTrackingProcessor = (id: string, phase: DayPhase): IDayProcessor => ({
+        id,
+        phase,
+        displayName: id,
+        process(campaign: ICampaign): IDayProcessorResult {
+          callOrder.push(id);
+          return { events: [], campaign };
+        },
+      });
+
+      registry.register(makeTrackingProcessor('finances', DayPhase.FINANCES));
+      registry.register(makeTrackingProcessor('personnel', DayPhase.PERSONNEL));
+      registry.register(makeTrackingProcessor('setup', DayPhase.SETUP));
+
+      const campaign = createTestCampaign();
+      registry.processDay(campaign);
+
+      expect(callOrder).toEqual(['setup', 'personnel', 'finances']);
+    });
+
+    it('should chain campaign state between processors', () => {
+      const mutatingProcessor: IDayProcessor = {
+        id: 'mutator',
+        phase: DayPhase.PERSONNEL,
+        displayName: 'Mutator',
+        process(campaign: ICampaign): IDayProcessorResult {
+          return {
+            events: [],
+            campaign: { ...campaign, name: 'Modified by mutator' },
+          };
+        },
+      };
+
+      const verifyingProcessor: IDayProcessor = {
+        id: 'verifier',
+        phase: DayPhase.FINANCES,
+        displayName: 'Verifier',
+        process(campaign: ICampaign): IDayProcessorResult {
+          expect(campaign.name).toBe('Modified by mutator');
+          return { events: [], campaign };
+        },
+      };
+
+      registry.register(mutatingProcessor);
+      registry.register(verifyingProcessor);
+
+      const campaign = createTestCampaign({ name: 'Original' });
+      const result = registry.processDay(campaign);
+
+      expect(result.campaign.name).toBe('Modified by mutator');
+    });
+
+    it('should aggregate events from all processors', () => {
+      const event1: IDayEvent = {
+        type: 'healing',
+        description: 'Person healed',
+        severity: 'info',
+      };
+      const event2: IDayEvent = {
+        type: 'cost',
+        description: 'Costs deducted',
+        severity: 'info',
+      };
+
+      registry.register(createNoopProcessor('a', DayPhase.PERSONNEL, [event1]));
+      registry.register(createNoopProcessor('b', DayPhase.FINANCES, [event2]));
+
+      const campaign = createTestCampaign();
+      const result = registry.processDay(campaign);
+
+      expect(result.events).toHaveLength(2);
+      expect(result.events[0].type).toBe('healing');
+      expect(result.events[1].type).toBe('cost');
+    });
+
+    it('should track which processors were run', () => {
+      registry.register(createNoopProcessor('a', DayPhase.PERSONNEL));
+      registry.register(createNoopProcessor('b', DayPhase.FINANCES));
+
+      const campaign = createTestCampaign();
+      const result = registry.processDay(campaign);
+
+      expect(result.processorsRun).toEqual(['a', 'b']);
+    });
+
+    it('should advance date by one day after all processors', () => {
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-06-15T00:00:00Z'),
+      });
+
+      const result = registry.processDay(campaign);
+
+      expect(result.date.getUTCDate()).toBe(15);
+      expect(result.campaign.currentDate.getUTCDate()).toBe(16);
+    });
+
+    it('should skip failing processor and continue pipeline', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const callOrder: string[] = [];
+      const trackingProcessor = (id: string, phase: DayPhase): IDayProcessor => ({
+        id,
+        phase,
+        displayName: id,
+        process(campaign: ICampaign): IDayProcessorResult {
+          callOrder.push(id);
+          return { events: [], campaign };
+        },
+      });
+
+      registry.register(trackingProcessor('before', DayPhase.PERSONNEL));
+      registry.register(createThrowingProcessor('broken', DayPhase.FACILITIES));
+      registry.register(trackingProcessor('after', DayPhase.FINANCES));
+
+      const campaign = createTestCampaign();
+      const result = registry.processDay(campaign);
+
+      expect(callOrder).toEqual(['before', 'after']);
+      expect(result.processorsRun).toEqual(['before', 'broken', 'after']);
+      expect(consoleSpy).toHaveBeenCalledTimes(1);
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should use unchanged campaign state when processor fails', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const mutator: IDayProcessor = {
+        id: 'mutator',
+        phase: DayPhase.SETUP,
+        displayName: 'Mutator',
+        process(campaign: ICampaign): IDayProcessorResult {
+          return {
+            events: [],
+            campaign: { ...campaign, name: 'Before failure' },
+          };
+        },
+      };
+
+      registry.register(mutator);
+      registry.register(createThrowingProcessor('broken', DayPhase.PERSONNEL));
+
+      const verifier: IDayProcessor = {
+        id: 'verifier',
+        phase: DayPhase.FINANCES,
+        displayName: 'Verifier',
+        process(campaign: ICampaign): IDayProcessorResult {
+          expect(campaign.name).toBe('Before failure');
+          return { events: [], campaign };
+        },
+      };
+      registry.register(verifier);
+
+      const campaign = createTestCampaign({ name: 'Original' });
+      const result = registry.processDay(campaign);
+
+      expect(result.campaign.name).toBe('Before failure');
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle empty registry', () => {
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-06-15T00:00:00Z'),
+      });
+
+      const result = registry.processDay(campaign);
+
+      expect(result.events).toHaveLength(0);
+      expect(result.processorsRun).toHaveLength(0);
+      expect(result.campaign.currentDate.getUTCDate()).toBe(16);
+    });
+
+    it('should set report date to the processed date (before advancement)', () => {
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-06-15T00:00:00Z'),
+      });
+
+      const result = registry.processDay(campaign);
+
+      expect(result.date.getUTCDate()).toBe(15);
+    });
+  });
+});
+
+// =============================================================================
+// Singleton Tests
+// =============================================================================
+
+describe('getDayPipeline / _resetDayPipeline', () => {
+  afterEach(() => {
+    _resetDayPipeline();
+  });
+
+  it('should return the same instance on multiple calls', () => {
+    const a = getDayPipeline();
+    const b = getDayPipeline();
+    expect(a).toBe(b);
+  });
+
+  it('should return a fresh instance after reset', () => {
+    const a = getDayPipeline();
+    a.register(createNoopProcessor('test', DayPhase.SETUP));
+
+    _resetDayPipeline();
+
+    const b = getDayPipeline();
+    expect(b).not.toBe(a);
+    expect(b.getProcessors()).toHaveLength(0);
+  });
+});
+
+// =============================================================================
+// Date Helper Tests
+// =============================================================================
+
+describe('date helpers', () => {
+  describe('isFirstOfMonth', () => {
+    it('should return true for first of month', () => {
+      expect(isFirstOfMonth(new Date('3025-06-01T00:00:00Z'))).toBe(true);
+    });
+
+    it('should return false for other days', () => {
+      expect(isFirstOfMonth(new Date('3025-06-15T00:00:00Z'))).toBe(false);
+    });
+  });
+
+  describe('isMonday', () => {
+    it('should return true for Monday', () => {
+      expect(isMonday(new Date('3025-06-20T00:00:00Z'))).toBe(true);
+    });
+
+    it('should return false for non-Monday', () => {
+      expect(isMonday(new Date('3025-06-15T00:00:00Z'))).toBe(false);
+    });
+  });
+
+  describe('isFirstOfYear', () => {
+    it('should return true for January 1', () => {
+      expect(isFirstOfYear(new Date('3025-01-01T00:00:00Z'))).toBe(true);
+    });
+
+    it('should return false for other days', () => {
+      expect(isFirstOfYear(new Date('3025-06-01T00:00:00Z'))).toBe(false);
+    });
+  });
+});
+
+// =============================================================================
+// advanceDays Tests
+// =============================================================================
+
+describe('advanceDays', () => {
+  it('should return N DayReports for N days', () => {
+    const campaign = createTestCampaign();
+    const reports = advanceDays(campaign, 7);
+
+    expect(reports).toHaveLength(7);
+  });
+
+  it('should chain campaign state between days', () => {
+    const campaign = createTestCampaign({
+      currentDate: new Date('3025-06-15T00:00:00Z'),
+    });
+
+    const reports = advanceDays(campaign, 3);
+
+    expect(reports[0].campaign.currentDate.getUTCDate()).toBe(16);
+    expect(reports[1].campaign.currentDate.getUTCDate()).toBe(17);
+    expect(reports[2].campaign.currentDate.getUTCDate()).toBe(18);
+  });
+
+  it('should process healing correctly over multiple days', () => {
+    const injury = createInjury({
+      id: 'inj-1',
+      type: 'Broken Arm',
+      location: 'Left Arm',
+      severity: 2,
+      daysToHeal: 3,
+      permanent: false,
+      acquired: new Date('3025-01-01'),
+    });
+
+    const personnel = new Map<string, IPerson>();
+    personnel.set(
+      'p1',
+      {
+        id: 'p1',
+        name: 'Test',
+        callsign: 'T',
+        status: PersonnelStatus.WOUNDED,
+        primaryRole: CampaignPersonnelRole.PILOT,
+        rank: 'MechWarrior',
+        recruitmentDate: new Date('3025-01-01'),
+        missionsCompleted: 0,
+        totalKills: 0,
+        xp: 0,
+        totalXpEarned: 0,
+        xpSpent: 0,
+        hits: 0,
+        injuries: [injury],
+        daysToWaitForHealing: 0,
+        skills: {},
+        attributes: { STR: 5, BOD: 5, REF: 5, DEX: 5, INT: 5, WIL: 5, CHA: 5, Edge: 0 },
+        pilotSkills: { gunnery: 4, piloting: 5 },
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      }
+    );
+
+    const campaign = createTestCampaign({ personnel });
+    const reports = advanceDays(campaign, 5);
+
+    expect(reports[2].campaign.personnel.get('p1')!.status).toBe(PersonnelStatus.ACTIVE);
+    expect(reports[2].campaign.personnel.get('p1')!.injuries).toHaveLength(0);
+  });
+
+  it('should not stop on negative balance', () => {
+    const personnel = new Map<string, IPerson>();
+    personnel.set('p1', {
+      id: 'p1',
+      name: 'Test',
+      callsign: 'T',
+      status: PersonnelStatus.ACTIVE,
+      primaryRole: CampaignPersonnelRole.PILOT,
+      rank: 'MechWarrior',
+      recruitmentDate: new Date('3025-01-01'),
+      missionsCompleted: 0,
+      totalKills: 0,
+      xp: 0,
+      totalXpEarned: 0,
+      xpSpent: 0,
+      hits: 0,
+      injuries: [],
+      daysToWaitForHealing: 0,
+      skills: {},
+      attributes: { STR: 5, BOD: 5, REF: 5, DEX: 5, INT: 5, WIL: 5, CHA: 5, Edge: 0 },
+      pilotSkills: { gunnery: 4, piloting: 5 },
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+
+    const campaign = createTestCampaign({
+      personnel,
+      finances: { transactions: [], balance: new Money(10) },
+    });
+
+    const reports = advanceDays(campaign, 5);
+
+    expect(reports).toHaveLength(5);
+    expect(reports[4].campaign.finances.balance.isNegative()).toBe(true);
+  });
+
+  it('should return empty array for 0 days', () => {
+    const campaign = createTestCampaign();
+    const reports = advanceDays(campaign, 0);
+
+    expect(reports).toHaveLength(0);
+  });
+});

--- a/src/lib/campaign/dayPipeline.ts
+++ b/src/lib/campaign/dayPipeline.ts
@@ -1,0 +1,311 @@
+/**
+ * Day Pipeline - Plugin/registry architecture for daily campaign processing
+ *
+ * Provides a registry where campaign modules register daily processors.
+ * Processors are sorted by phase and executed in deterministic order.
+ * Each processor receives the current campaign state and returns an updated
+ * campaign with events describing what happened.
+ *
+ * This is the backbone for all Phase 2 campaign systems (turnover, repair,
+ * financial, faction standing, etc.) — they register processors into this pipeline.
+ *
+ * Based on MekHQ's CampaignNewDayManager 24-phase ordering.
+ *
+ * @module lib/campaign/dayPipeline
+ */
+
+import { ICampaign } from '@/types/campaign/Campaign';
+import { createSingleton } from '@/services/core/createSingleton';
+
+// =============================================================================
+// Pipeline Phase Enum
+// =============================================================================
+
+/**
+ * Phases for day advancement processing.
+ *
+ * Processors are sorted by phase value (ascending).
+ * Phases are spaced by 100 to allow future insertion.
+ *
+ * Based on MekHQ's CampaignNewDayManager ordering:
+ * - Personnel processing (healing, medical, education) first
+ * - Then facilities, markets, missions
+ * - Financial processing near the end
+ * - Cleanup/events last
+ */
+export enum DayPhase {
+  /** Pre-processing setup */
+  SETUP = 0,
+  /** Personnel: healing, medical, education */
+  PERSONNEL = 100,
+  /** Facilities: field kitchen, MASH */
+  FACILITIES = 200,
+  /** Market refreshes */
+  MARKETS = 300,
+  /** Contract/scenario processing */
+  MISSIONS = 400,
+  /** Maintenance, parts, refits */
+  UNITS = 500,
+  /** Force processing, combat teams */
+  FORCES = 600,
+  /** Financial processing (salaries, taxes) */
+  FINANCES = 700,
+  /** Random events, faction standing */
+  EVENTS = 800,
+  /** Cleanup and reporting */
+  CLEANUP = 900,
+}
+
+// =============================================================================
+// Pipeline Event Types
+// =============================================================================
+
+/**
+ * A generic event produced by a day processor.
+ *
+ * Events are the primary communication mechanism between processors and
+ * the UI. Each processor produces events describing what happened during
+ * its processing phase.
+ *
+ * The `type` field is used for backward compatibility mapping to legacy
+ * DayReport types (e.g., 'healing', 'contract_expired', 'daily_costs').
+ */
+export interface IDayEvent {
+  /** Event type identifier (e.g., 'healing', 'contract_expired', 'daily_costs') */
+  readonly type: string;
+  /** Human-readable description of the event */
+  readonly description: string;
+  /** Severity level for UI display */
+  readonly severity: 'info' | 'warning' | 'critical';
+  /** Arbitrary event-specific data */
+  readonly data?: Record<string, unknown>;
+}
+
+// =============================================================================
+// Processor Interface
+// =============================================================================
+
+/**
+ * Result returned by a single day processor.
+ */
+export interface IDayProcessorResult {
+  /** Events produced by this processor */
+  readonly events: readonly IDayEvent[];
+  /** Updated campaign state after processing */
+  readonly campaign: ICampaign;
+}
+
+/**
+ * Interface for a day processor plugin.
+ *
+ * Processors are pure functions that receive the current campaign state
+ * and return an updated campaign with events. They must not have side effects.
+ *
+ * @example
+ * ```typescript
+ * const healingProcessor: IDayProcessor = {
+ *   id: 'healing',
+ *   phase: DayPhase.PERSONNEL,
+ *   displayName: 'Personnel Healing',
+ *   process(campaign, date) {
+ *     // Process healing logic
+ *     return { events: [...], campaign: updatedCampaign };
+ *   }
+ * };
+ * ```
+ */
+export interface IDayProcessor {
+  /** Unique identifier for this processor */
+  readonly id: string;
+  /** Phase in which this processor runs */
+  readonly phase: DayPhase;
+  /** Human-readable name for UI display */
+  readonly displayName: string;
+  /** Process one day for the campaign. Must be pure (no side effects). */
+  process(campaign: ICampaign, date: Date): IDayProcessorResult;
+}
+
+// =============================================================================
+// Pipeline Result
+// =============================================================================
+
+/**
+ * Aggregated result from running all processors for one day.
+ */
+export interface IDayPipelineResult {
+  /** The date that was processed */
+  readonly date: Date;
+  /** All events from all processors, in processing order */
+  readonly events: readonly IDayEvent[];
+  /** The final campaign state after all processors */
+  readonly campaign: ICampaign;
+  /** IDs of processors that were run, in order */
+  readonly processorsRun: readonly string[];
+}
+
+// =============================================================================
+// Pipeline Registry
+// =============================================================================
+
+/**
+ * Registry and orchestrator for day processors.
+ *
+ * Processors register themselves with the registry. When `processDay()` is called,
+ * processors are sorted by phase and executed in order. Each processor receives
+ * the campaign state from the previous processor (chain pattern).
+ *
+ * If a processor throws, it is skipped and the pipeline continues with the
+ * unchanged campaign state.
+ *
+ * @example
+ * ```typescript
+ * const pipeline = getDayPipeline();
+ * pipeline.register(healingProcessor);
+ * pipeline.register(contractProcessor);
+ * const result = pipeline.processDay(campaign);
+ * ```
+ */
+export class DayPipelineRegistry {
+  private processors: IDayProcessor[] = [];
+
+  /**
+   * Register a processor with the pipeline.
+   *
+   * If a processor with the same ID already exists, it is replaced.
+   *
+   * @param processor - The processor to register
+   */
+  register(processor: IDayProcessor): void {
+    const existingIndex = this.processors.findIndex((p) => p.id === processor.id);
+    if (existingIndex !== -1) {
+      this.processors[existingIndex] = processor;
+    } else {
+      this.processors.push(processor);
+    }
+  }
+
+  /**
+   * Unregister a processor by ID.
+   *
+   * @param id - The processor ID to remove
+   */
+  unregister(id: string): void {
+    this.processors = this.processors.filter((p) => p.id !== id);
+  }
+
+  /**
+   * Get all registered processors, sorted by phase (ascending).
+   *
+   * Within the same phase, processors are ordered by registration order.
+   */
+  getProcessors(): readonly IDayProcessor[] {
+    return [...this.processors].sort((a, b) => a.phase - b.phase);
+  }
+
+  /**
+   * Get processors registered for a specific phase.
+   *
+   * @param phase - The phase to filter by
+   */
+  getProcessorsByPhase(phase: DayPhase): readonly IDayProcessor[] {
+    return this.processors
+      .filter((p) => p.phase === phase)
+      .sort((a, b) => a.phase - b.phase);
+  }
+
+  /**
+   * Process one day through all registered processors.
+   *
+   * Processors are executed in phase order. Each processor receives
+   * the campaign state from the previous processor. If a processor throws,
+   * it is skipped and processing continues with the unchanged state.
+   *
+   * The date is advanced by one day AFTER all processors run.
+   *
+   * @param campaign - The campaign to process
+   * @returns Aggregated result from all processors
+   */
+  processDay(campaign: ICampaign): IDayPipelineResult {
+    const processedDate = campaign.currentDate;
+    const sortedProcessors = this.getProcessors();
+    const allEvents: IDayEvent[] = [];
+    const processorsRun: string[] = [];
+    let currentCampaign = campaign;
+
+    for (const processor of sortedProcessors) {
+      try {
+        const result = processor.process(currentCampaign, processedDate);
+        currentCampaign = result.campaign;
+        allEvents.push(...result.events);
+        processorsRun.push(processor.id);
+      } catch (error) {
+        // Log error but continue pipeline — processor is skipped
+        console.error(
+          `[DayPipeline] Processor "${processor.id}" (${processor.displayName}) failed:`,
+          error
+        );
+        processorsRun.push(processor.id);
+      }
+    }
+
+    // Advance the date by one day AFTER all processors
+    const nextDate = new Date(processedDate.getTime() + 24 * 60 * 60 * 1000);
+    const finalCampaign: ICampaign = {
+      ...currentCampaign,
+      currentDate: nextDate,
+      updatedAt: new Date().toISOString(),
+    };
+
+    return {
+      date: processedDate,
+      events: allEvents,
+      campaign: finalCampaign,
+      processorsRun,
+    };
+  }
+}
+
+// =============================================================================
+// Singleton Instance
+// =============================================================================
+
+const pipelineRegistry = createSingleton(() => new DayPipelineRegistry());
+
+/**
+ * Get the singleton DayPipelineRegistry instance.
+ */
+export function getDayPipeline(): DayPipelineRegistry {
+  return pipelineRegistry.get();
+}
+
+/**
+ * Reset the singleton pipeline (for testing).
+ */
+export function _resetDayPipeline(): void {
+  pipelineRegistry.reset();
+}
+
+// =============================================================================
+// Date Helper Functions
+// =============================================================================
+
+/**
+ * Check if a date is the first day of the month.
+ */
+export function isFirstOfMonth(date: Date): boolean {
+  return date.getUTCDate() === 1;
+}
+
+/**
+ * Check if a date is a Monday.
+ */
+export function isMonday(date: Date): boolean {
+  return date.getUTCDay() === 1;
+}
+
+/**
+ * Check if a date is the first day of the year.
+ */
+export function isFirstOfYear(date: Date): boolean {
+  return date.getUTCMonth() === 0 && date.getUTCDate() === 1;
+}

--- a/src/lib/campaign/processors/__tests__/processors.test.ts
+++ b/src/lib/campaign/processors/__tests__/processors.test.ts
@@ -1,0 +1,228 @@
+import { ICampaign, createDefaultCampaignOptions } from '@/types/campaign/Campaign';
+import { IPerson } from '@/types/campaign/Person';
+import { createInjury } from '@/types/campaign/Person';
+import { IMission, createContract } from '@/types/campaign/Mission';
+import { IForce } from '@/types/campaign/Force';
+import { Money } from '@/types/campaign/Money';
+import {
+  PersonnelStatus,
+  MissionStatus,
+  CampaignPersonnelRole,
+  ForceType,
+  FormationLevel,
+} from '@/types/campaign/enums';
+
+import { healingProcessor } from '../healingProcessor';
+import { contractProcessor } from '../contractProcessor';
+import { dailyCostsProcessor } from '../dailyCostsProcessor';
+import { registerBuiltinProcessors, _resetBuiltinRegistration } from '../index';
+import { DayPhase, getDayPipeline, _resetDayPipeline } from '../../dayPipeline';
+
+function createTestPerson(overrides?: Partial<IPerson>): IPerson {
+  return {
+    id: 'person-001',
+    name: 'John Smith',
+    callsign: 'Hammer',
+    status: PersonnelStatus.ACTIVE,
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rank: 'MechWarrior',
+    recruitmentDate: new Date('3025-01-01'),
+    missionsCompleted: 5,
+    totalKills: 3,
+    xp: 100,
+    totalXpEarned: 200,
+    xpSpent: 100,
+    hits: 0,
+    injuries: [],
+    daysToWaitForHealing: 0,
+    skills: {},
+    attributes: { STR: 5, BOD: 5, REF: 5, DEX: 5, INT: 5, WIL: 5, CHA: 5, Edge: 0 },
+    pilotSkills: { gunnery: 4, piloting: 5 },
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function createTestForce(id: string, unitIds: string[] = []): IForce {
+  return {
+    id,
+    name: `Force ${id}`,
+    parentForceId: undefined,
+    subForceIds: [],
+    unitIds,
+    forceType: ForceType.STANDARD,
+    formationLevel: FormationLevel.LANCE,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  };
+}
+
+function createTestCampaign(overrides?: Partial<ICampaign>): ICampaign {
+  return {
+    id: 'campaign-001',
+    name: 'Test Campaign',
+    currentDate: new Date('3025-06-15T00:00:00Z'),
+    factionId: 'mercenary',
+    personnel: new Map<string, IPerson>(),
+    forces: new Map<string, IForce>(),
+    rootForceId: 'force-root',
+    missions: new Map<string, IMission>(),
+    finances: { transactions: [], balance: new Money(1000000) },
+    options: createDefaultCampaignOptions(),
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('healingProcessor', () => {
+  it('should have correct id, phase, and displayName', () => {
+    expect(healingProcessor.id).toBe('healing');
+    expect(healingProcessor.phase).toBe(DayPhase.PERSONNEL);
+    expect(healingProcessor.displayName).toBe('Personnel Healing');
+  });
+
+  it('should return healing events for wounded personnel', () => {
+    const injury = createInjury({
+      id: 'inj-1',
+      type: 'Broken Arm',
+      location: 'Left Arm',
+      severity: 2,
+      daysToHeal: 1,
+      permanent: false,
+      acquired: new Date('3025-01-01'),
+    });
+
+    const personnel = new Map<string, IPerson>();
+    personnel.set(
+      'p1',
+      createTestPerson({
+        id: 'p1',
+        name: 'Jane',
+        status: PersonnelStatus.WOUNDED,
+        injuries: [injury],
+        daysToWaitForHealing: 0,
+      })
+    );
+
+    const campaign = createTestCampaign({ personnel });
+    const result = healingProcessor.process(campaign, campaign.currentDate);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].type).toBe('healing');
+    expect(result.campaign.personnel.get('p1')!.status).toBe(PersonnelStatus.ACTIVE);
+  });
+
+  it('should return empty events when no healing occurs', () => {
+    const campaign = createTestCampaign();
+    const result = healingProcessor.process(campaign, campaign.currentDate);
+
+    expect(result.events).toHaveLength(0);
+  });
+});
+
+describe('contractProcessor', () => {
+  it('should have correct id, phase, and displayName', () => {
+    expect(contractProcessor.id).toBe('contracts');
+    expect(contractProcessor.phase).toBe(DayPhase.MISSIONS);
+    expect(contractProcessor.displayName).toBe('Contract Processing');
+  });
+
+  it('should return events for expired contracts', () => {
+    const missions = new Map<string, IMission>();
+    missions.set(
+      'c1',
+      createContract({
+        id: 'c1',
+        name: 'Garrison',
+        employerId: 'davion',
+        targetId: 'liao',
+        status: MissionStatus.ACTIVE,
+        endDate: '3025-01-01',
+      })
+    );
+
+    const campaign = createTestCampaign({ missions });
+    const result = contractProcessor.process(campaign, campaign.currentDate);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].type).toBe('contract_expired');
+    expect(result.campaign.missions.get('c1')!.status).toBe(MissionStatus.SUCCESS);
+  });
+});
+
+describe('dailyCostsProcessor', () => {
+  it('should have correct id, phase, and displayName', () => {
+    expect(dailyCostsProcessor.id).toBe('dailyCosts');
+    expect(dailyCostsProcessor.phase).toBe(DayPhase.FINANCES);
+    expect(dailyCostsProcessor.displayName).toBe('Daily Costs');
+  });
+
+  it('should return cost events when there are costs', () => {
+    const personnel = new Map<string, IPerson>();
+    personnel.set('p1', createTestPerson({ id: 'p1', status: PersonnelStatus.ACTIVE }));
+
+    const forces = new Map<string, IForce>();
+    forces.set('force-root', createTestForce('force-root', ['unit-1']));
+
+    const campaign = createTestCampaign({ personnel, forces });
+    const result = dailyCostsProcessor.process(campaign, campaign.currentDate);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].type).toBe('daily_costs');
+    expect(result.events[0].severity).toBe('info');
+  });
+
+  it('should return warning severity when balance goes negative', () => {
+    const personnel = new Map<string, IPerson>();
+    personnel.set('p1', createTestPerson({ id: 'p1', status: PersonnelStatus.ACTIVE }));
+
+    const campaign = createTestCampaign({
+      personnel,
+      finances: { transactions: [], balance: new Money(0) },
+    });
+    const result = dailyCostsProcessor.process(campaign, campaign.currentDate);
+
+    expect(result.events[0].severity).toBe('warning');
+  });
+
+  it('should return empty events when no costs', () => {
+    const campaign = createTestCampaign();
+    const result = dailyCostsProcessor.process(campaign, campaign.currentDate);
+
+    expect(result.events).toHaveLength(0);
+  });
+});
+
+describe('registerBuiltinProcessors', () => {
+  afterEach(() => {
+    _resetDayPipeline();
+    _resetBuiltinRegistration();
+  });
+
+  it('should register all three builtin processors', () => {
+    registerBuiltinProcessors();
+    const processors = getDayPipeline().getProcessors();
+
+    expect(processors).toHaveLength(3);
+    expect(processors.map((p) => p.id)).toEqual(['healing', 'contracts', 'dailyCosts']);
+  });
+
+  it('should be idempotent (calling twice registers once)', () => {
+    registerBuiltinProcessors();
+    registerBuiltinProcessors();
+
+    const processors = getDayPipeline().getProcessors();
+    expect(processors).toHaveLength(3);
+  });
+
+  it('should register processors in correct phase order', () => {
+    registerBuiltinProcessors();
+    const processors = getDayPipeline().getProcessors();
+
+    expect(processors[0].phase).toBe(DayPhase.PERSONNEL);
+    expect(processors[1].phase).toBe(DayPhase.MISSIONS);
+    expect(processors[2].phase).toBe(DayPhase.FINANCES);
+  });
+});

--- a/src/lib/campaign/processors/contractProcessor.ts
+++ b/src/lib/campaign/processors/contractProcessor.ts
@@ -1,0 +1,32 @@
+import { IDayProcessor, IDayProcessorResult, DayPhase, IDayEvent } from '../dayPipeline';
+import { ICampaign } from '@/types/campaign/Campaign';
+import { processContracts } from '../dayAdvancement';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function castToRecord(data: any): Record<string, unknown> {
+  return data as Record<string, unknown>;
+}
+
+export const contractProcessor: IDayProcessor = {
+  id: 'contracts',
+  phase: DayPhase.MISSIONS,
+  displayName: 'Contract Processing',
+
+  process(campaign: ICampaign): IDayProcessorResult {
+    const result = processContracts(campaign);
+
+    const events: IDayEvent[] = result.events.map((evt) => ({
+      type: 'contract_expired',
+      description: `Contract "${evt.contractName}" completed`,
+      severity: 'info' as const,
+      data: castToRecord(evt),
+    }));
+
+    const updatedCampaign: ICampaign = {
+      ...campaign,
+      missions: result.missions,
+    };
+
+    return { events, campaign: updatedCampaign };
+  },
+};

--- a/src/lib/campaign/processors/dailyCostsProcessor.ts
+++ b/src/lib/campaign/processors/dailyCostsProcessor.ts
@@ -1,0 +1,36 @@
+import { IDayProcessor, IDayProcessorResult, DayPhase, IDayEvent } from '../dayPipeline';
+import { ICampaign } from '@/types/campaign/Campaign';
+import { processDailyCosts } from '../dayAdvancement';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function castToRecord(data: any): Record<string, unknown> {
+  return data as Record<string, unknown>;
+}
+
+export const dailyCostsProcessor: IDayProcessor = {
+  id: 'dailyCosts',
+  phase: DayPhase.FINANCES,
+  displayName: 'Daily Costs',
+
+  process(campaign: ICampaign): IDayProcessorResult {
+    const result = processDailyCosts(campaign);
+
+    const events: IDayEvent[] = [];
+
+    if (result.costs.total.amount > 0) {
+      events.push({
+        type: 'daily_costs',
+        description: `Daily costs: ${result.costs.total.format()} (${result.costs.personnelCount} personnel, ${result.costs.unitCount} units)`,
+        severity: result.finances.balance.isNegative() ? 'warning' : 'info',
+        data: castToRecord(result.costs),
+      });
+    }
+
+    const updatedCampaign: ICampaign = {
+      ...campaign,
+      finances: result.finances,
+    };
+
+    return { events, campaign: updatedCampaign };
+  },
+};

--- a/src/lib/campaign/processors/healingProcessor.ts
+++ b/src/lib/campaign/processors/healingProcessor.ts
@@ -1,0 +1,34 @@
+import { IDayProcessor, IDayProcessorResult, DayPhase, IDayEvent } from '../dayPipeline';
+import { ICampaign } from '@/types/campaign/Campaign';
+import { processHealing } from '../dayAdvancement';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function castToRecord(data: any): Record<string, unknown> {
+  return data as Record<string, unknown>;
+}
+
+export const healingProcessor: IDayProcessor = {
+  id: 'healing',
+  phase: DayPhase.PERSONNEL,
+  displayName: 'Personnel Healing',
+
+  process(campaign: ICampaign): IDayProcessorResult {
+    const result = processHealing(campaign.personnel);
+
+    const events: IDayEvent[] = result.events.map((evt) => ({
+      type: 'healing',
+      description: evt.returnedToActive
+        ? `${evt.personName} returned to active duty`
+        : `${evt.personName} healed ${evt.healedInjuries.length} injury(s)`,
+      severity: 'info' as const,
+      data: castToRecord(evt),
+    }));
+
+    const updatedCampaign: ICampaign = {
+      ...campaign,
+      personnel: result.personnel,
+    };
+
+    return { events, campaign: updatedCampaign };
+  },
+};

--- a/src/lib/campaign/processors/index.ts
+++ b/src/lib/campaign/processors/index.ts
@@ -1,0 +1,25 @@
+import { getDayPipeline } from '../dayPipeline';
+import { healingProcessor } from './healingProcessor';
+import { contractProcessor } from './contractProcessor';
+import { dailyCostsProcessor } from './dailyCostsProcessor';
+
+export { healingProcessor } from './healingProcessor';
+export { contractProcessor } from './contractProcessor';
+export { dailyCostsProcessor } from './dailyCostsProcessor';
+
+let registered = false;
+
+export function registerBuiltinProcessors(): void {
+  if (registered) return;
+
+  const pipeline = getDayPipeline();
+  pipeline.register(healingProcessor);
+  pipeline.register(contractProcessor);
+  pipeline.register(dailyCostsProcessor);
+
+  registered = true;
+}
+
+export function _resetBuiltinRegistration(): void {
+  registered = false;
+}

--- a/src/types/campaign/Campaign.ts
+++ b/src/types/campaign/Campaign.ts
@@ -190,6 +190,9 @@ export interface ICampaignOptions {
 
   /** Whether to use random events */
   readonly useRandomEvents: boolean;
+
+  /** Whether to show day report notifications after advancing */
+  readonly enableDayReportNotifications: boolean;
 }
 
 // =============================================================================
@@ -630,6 +633,7 @@ export function createDefaultCampaignOptions(): ICampaignOptions {
     limitByYear: true,
     allowClanEquipment: false,
     useRandomEvents: false,
+    enableDayReportNotifications: true,
   };
 }
 


### PR DESCRIPTION
## Summary

Implements Plan 1 of the MekStation campaign system expansion: refactors day advancement from hardcoded 3-phase processing into a plugin/registry architecture that all 16 remaining plans will hook into.

## Changes

- **DayPipelineRegistry**: Plugin registry with 10-phase ordering (SETUP → PERSONNEL → FACILITIES → MARKETS → MISSIONS → UNITS → FORCES → FINANCES → EVENTS → CLEANUP). Processors register by phase, execute in order, chain campaign state between them.
- **Processor plugins**: Extracted existing healing, contracts, and daily costs logic into `IDayProcessor` implementations (`healingProcessor`, `contractProcessor`, `dailyCostsProcessor`)
- **Store bug fix**: `advanceDay()` previously only incremented the date — now calls the full processing pipeline (healing + contracts + costs)
- **Multi-day advancement**: `advanceDays(count)` processes N days with chained state, exposed in store
- **DayReportPanel UI**: Dismissible report panel showing costs breakdown, healed personnel, expired contracts. Advance Week (7 days) and Advance Month (30 days) buttons added to dashboard header
- **Campaign option**: `enableDayReportNotifications` (default: true)

## Architecture

Future plans register processors like:
```typescript
getDayPipeline().register({
  id: 'turnover',
  phase: DayPhase.PERSONNEL,
  displayName: 'Turnover & Retention',
  process(campaign, date) { ... }
});
```

## Testing

- 364 tests passing across 9 test suites
- All 45 original `dayAdvancement.test.ts` tests preserved unchanged
- New tests: 29 (pipeline) + 12 (processors) + 5 (multi-day) = 46 new tests