### PR TITLE
feat: expand contract types to 19 AtB types with negotiation and events

### DIFF
--- a/src/lib/campaign/contracts/__tests__/contractEvents.test.ts
+++ b/src/lib/campaign/contracts/__tests__/contractEvents.test.ts
@@ -1,0 +1,365 @@
+import {
+  ContractEventType,
+  BetrayalSubType,
+  checkMonthlyEvents,
+  getAllEventTypes,
+  getAllBetrayalSubTypes,
+  EVENT_CHECK_CHANCE,
+  type IContractEvent,
+  type ContractEventEffect,
+  type RandomFn,
+} from '../contractEvents';
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+function fixedRandom(value: number): RandomFn {
+  return () => value;
+}
+
+function createSequenceRandom(values: number[]): RandomFn {
+  let index = 0;
+  return () => {
+    const value = values[index % values.length];
+    index++;
+    return value;
+  };
+}
+
+function createSeededRandom(seed: number): RandomFn {
+  let state = seed;
+  return () => {
+    state = (1103515245 * state + 12345) & 0x7fffffff;
+    return state / 0x7fffffff;
+  };
+}
+
+// =============================================================================
+// ContractEventType Enum Tests
+// =============================================================================
+
+describe('ContractEventType enum', () => {
+  it('should have exactly 10 event types', () => {
+    const types = Object.values(ContractEventType);
+    expect(types).toHaveLength(10);
+  });
+
+  it('should contain all expected event type values', () => {
+    expect(ContractEventType.BONUS_ROLL).toBe('bonus_roll');
+    expect(ContractEventType.SPECIAL_SCENARIO).toBe('special_scenario');
+    expect(ContractEventType.CIVIL_DISTURBANCE).toBe('civil_disturbance');
+    expect(ContractEventType.REBELLION).toBe('rebellion');
+    expect(ContractEventType.BETRAYAL).toBe('betrayal');
+    expect(ContractEventType.TREACHERY).toBe('treachery');
+    expect(ContractEventType.LOGISTICS_FAILURE).toBe('logistics_failure');
+    expect(ContractEventType.REINFORCEMENTS).toBe('reinforcements');
+    expect(ContractEventType.SPECIAL_EVENTS).toBe('special_events');
+    expect(ContractEventType.BIG_BATTLE).toBe('big_battle');
+  });
+});
+
+// =============================================================================
+// BetrayalSubType Enum Tests
+// =============================================================================
+
+describe('BetrayalSubType enum', () => {
+  it('should have exactly 6 betrayal sub-types', () => {
+    const subTypes = Object.values(BetrayalSubType);
+    expect(subTypes).toHaveLength(6);
+  });
+
+  it('should contain all expected betrayal sub-type values', () => {
+    expect(BetrayalSubType.SUPPLY_CUTOFF).toBe('supply_cutoff');
+    expect(BetrayalSubType.FALSE_INTEL).toBe('false_intel');
+    expect(BetrayalSubType.REDIRECT_REINFORCEMENTS).toBe('redirect_reinforcements');
+    expect(BetrayalSubType.POSITION_LEAKED).toBe('position_leaked');
+    expect(BetrayalSubType.AMBUSH_SETUP).toBe('ambush_setup');
+    expect(BetrayalSubType.CONTRACT_BREACH).toBe('contract_breach');
+  });
+});
+
+// =============================================================================
+// checkMonthlyEvents Tests
+// =============================================================================
+
+describe('checkMonthlyEvents', () => {
+  it('should return empty array when no events triggered', () => {
+    const random = fixedRandom(0.99); // Always above 5%
+    const events = checkMonthlyEvents(random);
+    expect(events).toEqual([]);
+  });
+
+  it('should return events when triggered', () => {
+    const random = createSequenceRandom([0.01, 0.99]); // First < 5%, rest >= 5%
+    const events = checkMonthlyEvents(random);
+    expect(events.length).toBeGreaterThan(0);
+    expect(events[0]).toHaveProperty('type');
+    expect(events[0]).toHaveProperty('description');
+    expect(events[0]).toHaveProperty('effects');
+  });
+
+  it('should allow multiple events to occur in same month', () => {
+    const random = fixedRandom(0.01); // Always below 5%
+    const events = checkMonthlyEvents(random);
+    expect(events).toHaveLength(10); // All 10 event types should trigger
+  });
+
+  it('should have valid event structure', () => {
+    const random = fixedRandom(0.01);
+    const events = checkMonthlyEvents(random);
+    
+    for (const event of events) {
+      expect(event).toHaveProperty('type');
+      expect(Object.values(ContractEventType)).toContain(event.type);
+      expect(event).toHaveProperty('description');
+      expect(typeof event.description).toBe('string');
+      expect(event).toHaveProperty('effects');
+      expect(Array.isArray(event.effects)).toBe(true);
+      expect(event.effects.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// =============================================================================
+// Event Effects by Type Tests
+// =============================================================================
+
+describe('Event effects by type', () => {
+  it('CIVIL_DISTURBANCE should have morale_change +1', () => {
+    const random = fixedRandom(0.01);
+    const events = checkMonthlyEvents(random);
+    const civilEvent = events.find(e => e.type === ContractEventType.CIVIL_DISTURBANCE);
+    
+    expect(civilEvent).toBeDefined();
+    const moraleEffect = civilEvent!.effects.find(e => e.type === 'morale_change');
+    expect(moraleEffect).toBeDefined();
+    expect(moraleEffect).toEqual({ type: 'morale_change', value: 1 });
+  });
+
+  it('LOGISTICS_FAILURE should have parts_modifier -1', () => {
+    const random = fixedRandom(0.01);
+    const events = checkMonthlyEvents(random);
+    const logisticsEvent = events.find(e => e.type === ContractEventType.LOGISTICS_FAILURE);
+    
+    expect(logisticsEvent).toBeDefined();
+    const partsEffect = logisticsEvent!.effects.find(e => e.type === 'parts_modifier');
+    expect(partsEffect).toBeDefined();
+    expect(partsEffect).toEqual({ type: 'parts_modifier', value: -1 });
+  });
+
+  it('REINFORCEMENTS should have morale_change -1', () => {
+    const random = fixedRandom(0.01);
+    const events = checkMonthlyEvents(random);
+    const reinforcementsEvent = events.find(e => e.type === ContractEventType.REINFORCEMENTS);
+    
+    expect(reinforcementsEvent).toBeDefined();
+    const moraleEffect = reinforcementsEvent!.effects.find(e => e.type === 'morale_change');
+    expect(moraleEffect).toBeDefined();
+    expect(moraleEffect).toEqual({ type: 'morale_change', value: -1 });
+  });
+
+  it('BONUS_ROLL should have payment_modifier 1.1', () => {
+    const random = fixedRandom(0.01);
+    const events = checkMonthlyEvents(random);
+    const bonusEvent = events.find(e => e.type === ContractEventType.BONUS_ROLL);
+    
+    expect(bonusEvent).toBeDefined();
+    const paymentEffect = bonusEvent!.effects.find(e => e.type === 'payment_modifier');
+    expect(paymentEffect).toBeDefined();
+    expect(paymentEffect).toEqual({ type: 'payment_modifier', multiplier: 1.1 });
+  });
+
+  it('SPECIAL_SCENARIO should have scenario_trigger', () => {
+    const random = fixedRandom(0.01);
+    const events = checkMonthlyEvents(random);
+    const specialEvent = events.find(e => e.type === ContractEventType.SPECIAL_SCENARIO);
+    
+    expect(specialEvent).toBeDefined();
+    const scenarioEffect = specialEvent!.effects.find(e => e.type === 'scenario_trigger');
+    expect(scenarioEffect).toBeDefined();
+    expect(scenarioEffect).toEqual({ type: 'scenario_trigger', scenarioType: 'special_mission' });
+  });
+
+  it('REBELLION should have both morale_change and scenario_trigger', () => {
+    const random = fixedRandom(0.01);
+    const events = checkMonthlyEvents(random);
+    const rebellionEvent = events.find(e => e.type === ContractEventType.REBELLION);
+    
+    expect(rebellionEvent).toBeDefined();
+    expect(rebellionEvent!.effects).toHaveLength(2);
+    
+    const moraleEffect = rebellionEvent!.effects.find(e => e.type === 'morale_change');
+    expect(moraleEffect).toEqual({ type: 'morale_change', value: 2 });
+    
+    const scenarioEffect = rebellionEvent!.effects.find(e => e.type === 'scenario_trigger');
+    expect(scenarioEffect).toEqual({ type: 'scenario_trigger', scenarioType: 'rebellion_battle' });
+  });
+
+  it('TREACHERY should have both morale_change and scenario_trigger', () => {
+    const random = fixedRandom(0.01);
+    const events = checkMonthlyEvents(random);
+    const treacheryEvent = events.find(e => e.type === ContractEventType.TREACHERY);
+    
+    expect(treacheryEvent).toBeDefined();
+    expect(treacheryEvent!.effects).toHaveLength(2);
+    
+    const moraleEffect = treacheryEvent!.effects.find(e => e.type === 'morale_change');
+    expect(moraleEffect).toEqual({ type: 'morale_change', value: 1 });
+    
+    const scenarioEffect = treacheryEvent!.effects.find(e => e.type === 'scenario_trigger');
+    expect(scenarioEffect).toEqual({ type: 'scenario_trigger', scenarioType: 'ambush' });
+  });
+
+  it('BIG_BATTLE should have scenario_trigger with big_battle', () => {
+    const random = fixedRandom(0.01);
+    const events = checkMonthlyEvents(random);
+    const bigBattleEvent = events.find(e => e.type === ContractEventType.BIG_BATTLE);
+    
+    expect(bigBattleEvent).toBeDefined();
+    const scenarioEffect = bigBattleEvent!.effects.find(e => e.type === 'scenario_trigger');
+    expect(scenarioEffect).toBeDefined();
+    expect(scenarioEffect).toEqual({ type: 'scenario_trigger', scenarioType: 'big_battle' });
+  });
+});
+
+// =============================================================================
+// Betrayal Event Tests
+// =============================================================================
+
+describe('Betrayal events', () => {
+  it('BETRAYAL should have betrayalSubType field set', () => {
+    const random = fixedRandom(0.01);
+    const events = checkMonthlyEvents(random);
+    const betrayalEvent = events.find(e => e.type === ContractEventType.BETRAYAL);
+    
+    expect(betrayalEvent).toBeDefined();
+    expect(betrayalEvent!.betrayalSubType).toBeDefined();
+    expect(Object.values(BetrayalSubType)).toContain(betrayalEvent!.betrayalSubType);
+  });
+
+  it('SUPPLY_CUTOFF should have parts_modifier -2', () => {
+    let found = false;
+    for (let seed = 0; seed < 5000; seed++) {
+      const random = createSeededRandom(seed);
+      const events = checkMonthlyEvents(random);
+      const betrayalEvent = events.find(e => e.type === ContractEventType.BETRAYAL);
+      
+      if (betrayalEvent?.betrayalSubType === BetrayalSubType.SUPPLY_CUTOFF) {
+        const partsEffect = betrayalEvent.effects.find(e => e.type === 'parts_modifier');
+        expect(partsEffect).toEqual({ type: 'parts_modifier', value: -2 });
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+  });
+
+  it('CONTRACT_BREACH should have payment_modifier 0.5', () => {
+    let found = false;
+    for (let seed = 0; seed < 5000; seed++) {
+      const random = createSeededRandom(seed);
+      const events = checkMonthlyEvents(random);
+      const betrayalEvent = events.find(e => e.type === ContractEventType.BETRAYAL);
+      
+      if (betrayalEvent?.betrayalSubType === BetrayalSubType.CONTRACT_BREACH) {
+        const paymentEffect = betrayalEvent.effects.find(e => e.type === 'payment_modifier');
+        expect(paymentEffect).toEqual({ type: 'payment_modifier', multiplier: 0.5 });
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+  });
+
+  it('POSITION_LEAKED should have both scenario_trigger and morale_change', () => {
+    let found = false;
+    for (let seed = 0; seed < 200; seed++) {
+      const random = createSeededRandom(seed);
+      const events = checkMonthlyEvents(random);
+      const betrayalEvent = events.find(e => e.type === ContractEventType.BETRAYAL);
+      
+      if (betrayalEvent?.betrayalSubType === BetrayalSubType.POSITION_LEAKED) {
+        expect(betrayalEvent.effects).toHaveLength(2);
+        
+        const scenarioEffect = betrayalEvent.effects.find(e => e.type === 'scenario_trigger');
+        expect(scenarioEffect).toEqual({ type: 'scenario_trigger', scenarioType: 'ambush' });
+        
+        const moraleEffect = betrayalEvent.effects.find(e => e.type === 'morale_change');
+        expect(moraleEffect).toEqual({ type: 'morale_change', value: 1 });
+        
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+  });
+
+  it('should have 6 different betrayal sub-types with different effects', () => {
+    const subTypesFound = new Set<BetrayalSubType>();
+    
+    for (let seed = 0; seed < 1000; seed++) {
+      const random = createSeededRandom(seed);
+      const events = checkMonthlyEvents(random);
+      const betrayalEvent = events.find(e => e.type === ContractEventType.BETRAYAL);
+      
+      if (betrayalEvent?.betrayalSubType) {
+        subTypesFound.add(betrayalEvent.betrayalSubType);
+      }
+    }
+    
+    expect(subTypesFound.size).toBe(6);
+  });
+});
+
+// =============================================================================
+// Helper Function Tests
+// =============================================================================
+
+describe('getAllEventTypes', () => {
+  it('should return 10 event types', () => {
+    const types = getAllEventTypes();
+    expect(types).toHaveLength(10);
+  });
+
+  it('should return all ContractEventType values', () => {
+    const types = getAllEventTypes();
+    expect(types).toContain(ContractEventType.BONUS_ROLL);
+    expect(types).toContain(ContractEventType.SPECIAL_SCENARIO);
+    expect(types).toContain(ContractEventType.CIVIL_DISTURBANCE);
+    expect(types).toContain(ContractEventType.REBELLION);
+    expect(types).toContain(ContractEventType.BETRAYAL);
+    expect(types).toContain(ContractEventType.TREACHERY);
+    expect(types).toContain(ContractEventType.LOGISTICS_FAILURE);
+    expect(types).toContain(ContractEventType.REINFORCEMENTS);
+    expect(types).toContain(ContractEventType.SPECIAL_EVENTS);
+    expect(types).toContain(ContractEventType.BIG_BATTLE);
+  });
+});
+
+describe('getAllBetrayalSubTypes', () => {
+  it('should return 6 betrayal sub-types', () => {
+    const subTypes = getAllBetrayalSubTypes();
+    expect(subTypes).toHaveLength(6);
+  });
+
+  it('should return all BetrayalSubType values', () => {
+    const subTypes = getAllBetrayalSubTypes();
+    expect(subTypes).toContain(BetrayalSubType.SUPPLY_CUTOFF);
+    expect(subTypes).toContain(BetrayalSubType.FALSE_INTEL);
+    expect(subTypes).toContain(BetrayalSubType.REDIRECT_REINFORCEMENTS);
+    expect(subTypes).toContain(BetrayalSubType.POSITION_LEAKED);
+    expect(subTypes).toContain(BetrayalSubType.AMBUSH_SETUP);
+    expect(subTypes).toContain(BetrayalSubType.CONTRACT_BREACH);
+  });
+});
+
+// =============================================================================
+// Constants Tests
+// =============================================================================
+
+describe('EVENT_CHECK_CHANCE constant', () => {
+  it('should be 0.05 (5%)', () => {
+    expect(EVENT_CHECK_CHANCE).toBe(0.05);
+  });
+});

--- a/src/lib/campaign/contracts/__tests__/contractLength.test.ts
+++ b/src/lib/campaign/contracts/__tests__/contractLength.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Tests for variable contract length calculation
+ *
+ * Verifies the MekHQ AtB formula implementation across all 19 contract types
+ * with deterministic and randomized test cases.
+ *
+ * @module campaign/contracts/__tests__/contractLength
+ */
+
+import {
+  calculateContractLength,
+  contractLengthToDays,
+  getContractLengthRange,
+  type RandomFn,
+} from '../contractLength';
+import { AtBContractType } from '@/types/campaign/contracts/contractTypes';
+
+/**
+ * Create a seeded random number generator for deterministic testing.
+ * Uses a linear congruential generator (LCG) for reproducibility.
+ */
+function createSeededRandom(seed: number): RandomFn {
+  let state = seed;
+  return () => {
+    state = (1103515245 * state + 12345) & 0x7fffffff;
+    return state / 0x7fffffff;
+  };
+}
+
+describe('contractLength', () => {
+  describe('calculateContractLength', () => {
+    describe('Garrison Duty (18 months)', () => {
+      const type = AtBContractType.GARRISON_DUTY;
+      // min = round(18 * 0.75) = 14
+      // variance = round(18 * 0.5) = 9
+      // range: 14-22
+
+      it('should return minimum length when random returns 0', () => {
+        const result = calculateContractLength(type, () => 0);
+        expect(result).toBe(14);
+      });
+
+      it('should return maximum length when random returns 0.999', () => {
+        const result = calculateContractLength(type, () => 0.999);
+        expect(result).toBe(22);
+      });
+
+      it('should return value in valid range', () => {
+        const random = createSeededRandom(42);
+        const result = calculateContractLength(type, random);
+        expect(result).toBeGreaterThanOrEqual(14);
+        expect(result).toBeLessThanOrEqual(22);
+      });
+    });
+
+    describe('Diversionary Raid (3 months)', () => {
+      const type = AtBContractType.DIVERSIONARY_RAID;
+      // min = round(3 * 0.75) = 2
+      // variance = round(3 * 0.5) = 2
+      // range: 2-3
+
+      it('should return minimum length when random returns 0', () => {
+        const result = calculateContractLength(type, () => 0);
+        expect(result).toBe(2);
+      });
+
+      it('should return maximum length when random returns 0.999', () => {
+        const result = calculateContractLength(type, () => 0.999);
+        expect(result).toBe(3);
+      });
+    });
+
+    describe('Guerrilla Warfare (24 months)', () => {
+      const type = AtBContractType.GUERRILLA_WARFARE;
+      // min = round(24 * 0.75) = 18
+      // variance = round(24 * 0.5) = 12
+      // range: 18-29
+
+      it('should return minimum length when random returns 0', () => {
+        const result = calculateContractLength(type, () => 0);
+        expect(result).toBe(18);
+      });
+
+      it('should return maximum length when random returns 0.999', () => {
+        const result = calculateContractLength(type, () => 0.999);
+        expect(result).toBe(29);
+      });
+    });
+
+    describe('Cadre Duty (12 months)', () => {
+      const type = AtBContractType.CADRE_DUTY;
+      // min = round(12 * 0.75) = 9
+      // variance = round(12 * 0.5) = 6
+      // range: 9-14
+
+      it('should return minimum length when random returns 0', () => {
+        const result = calculateContractLength(type, () => 0);
+        expect(result).toBe(9);
+      });
+
+      it('should return maximum length when random returns 0.999', () => {
+        const result = calculateContractLength(type, () => 0.999);
+        expect(result).toBe(14);
+      });
+    });
+
+    describe('Riot Duty (4 months)', () => {
+      const type = AtBContractType.RIOT_DUTY;
+      // min = round(4 * 0.75) = 3
+      // variance = round(4 * 0.5) = 2
+      // range: 3-4
+
+      it('should return minimum length when random returns 0', () => {
+        const result = calculateContractLength(type, () => 0);
+        expect(result).toBe(3);
+      });
+
+      it('should return maximum length when random returns 0.999', () => {
+        const result = calculateContractLength(type, () => 0.999);
+        expect(result).toBe(4);
+      });
+    });
+
+    describe('All 19 contract types', () => {
+      it('should produce positive lengths for all types', () => {
+        const allTypes = Object.values(AtBContractType);
+        const random = () => 0.5;
+
+        allTypes.forEach((type) => {
+          const result = calculateContractLength(type, random);
+          expect(result).toBeGreaterThan(0);
+        });
+      });
+
+      it('should produce consistent results with same random seed', () => {
+        const allTypes = Object.values(AtBContractType);
+        const results1 = allTypes.map((type) =>
+          calculateContractLength(type, createSeededRandom(123))
+        );
+        const results2 = allTypes.map((type) =>
+          calculateContractLength(type, createSeededRandom(123))
+        );
+
+        expect(results1).toEqual(results2);
+      });
+    });
+
+    describe('Deterministic behavior', () => {
+      it('should always return min when random is 0', () => {
+        const allTypes = Object.values(AtBContractType);
+        allTypes.forEach((type) => {
+          const result = calculateContractLength(type, () => 0);
+          const range = getContractLengthRange(type);
+          expect(result).toBe(range.min);
+        });
+      });
+
+      it('should always return max when random is 0.999', () => {
+        const allTypes = Object.values(AtBContractType);
+        allTypes.forEach((type) => {
+          const result = calculateContractLength(type, () => 0.999);
+          const range = getContractLengthRange(type);
+          expect(result).toBe(range.max);
+        });
+      });
+    });
+  });
+
+  describe('contractLengthToDays', () => {
+    it('should convert 1 month to 30 days', () => {
+      expect(contractLengthToDays(1)).toBe(30);
+    });
+
+    it('should convert 6 months to 180 days', () => {
+      expect(contractLengthToDays(6)).toBe(180);
+    });
+
+    it('should convert 18 months to 540 days', () => {
+      expect(contractLengthToDays(18)).toBe(540);
+    });
+
+    it('should convert 0 months to 0 days', () => {
+      expect(contractLengthToDays(0)).toBe(0);
+    });
+
+    it('should handle fractional months', () => {
+      expect(contractLengthToDays(1.5)).toBe(45);
+    });
+  });
+
+  describe('getContractLengthRange', () => {
+    it('should return correct range for Garrison Duty', () => {
+      const range = getContractLengthRange(AtBContractType.GARRISON_DUTY);
+      expect(range).toEqual({ min: 14, max: 22 });
+    });
+
+    it('should return correct range for Diversionary Raid', () => {
+      const range = getContractLengthRange(AtBContractType.DIVERSIONARY_RAID);
+      expect(range).toEqual({ min: 2, max: 3 });
+    });
+
+    it('should return correct range for Guerrilla Warfare', () => {
+      const range = getContractLengthRange(AtBContractType.GUERRILLA_WARFARE);
+      expect(range).toEqual({ min: 18, max: 29 });
+    });
+
+    it('should return correct range for Cadre Duty', () => {
+      const range = getContractLengthRange(AtBContractType.CADRE_DUTY);
+      expect(range).toEqual({ min: 9, max: 14 });
+    });
+
+    it('should return correct range for Riot Duty', () => {
+      const range = getContractLengthRange(AtBContractType.RIOT_DUTY);
+      expect(range).toEqual({ min: 3, max: 4 });
+    });
+
+    it('should return correct range for Security Duty', () => {
+      const range = getContractLengthRange(AtBContractType.SECURITY_DUTY);
+      expect(range).toEqual({ min: 5, max: 7 });
+    });
+
+    it('should return correct range for Retainer', () => {
+      const range = getContractLengthRange(AtBContractType.RETAINER);
+      expect(range).toEqual({ min: 9, max: 14 });
+    });
+
+    it('should return correct range for Objective Raid', () => {
+      const range = getContractLengthRange(AtBContractType.OBJECTIVE_RAID);
+      expect(range).toEqual({ min: 2, max: 3 });
+    });
+
+    it('should return correct range for Recon Raid', () => {
+      const range = getContractLengthRange(AtBContractType.RECON_RAID);
+      expect(range).toEqual({ min: 2, max: 3 });
+    });
+
+    it('should return correct range for Extraction Raid', () => {
+      const range = getContractLengthRange(AtBContractType.EXTRACTION_RAID);
+      expect(range).toEqual({ min: 2, max: 3 });
+    });
+
+    it('should return correct range for Assassination', () => {
+      const range = getContractLengthRange(AtBContractType.ASSASSINATION);
+      expect(range).toEqual({ min: 2, max: 3 });
+    });
+
+    it('should return correct range for Observation Raid', () => {
+      const range = getContractLengthRange(AtBContractType.OBSERVATION_RAID);
+      expect(range).toEqual({ min: 2, max: 3 });
+    });
+
+    it('should return correct range for Espionage', () => {
+      const range = getContractLengthRange(AtBContractType.ESPIONAGE);
+      expect(range).toEqual({ min: 9, max: 14 });
+    });
+
+    it('should return correct range for Sabotage', () => {
+      const range = getContractLengthRange(AtBContractType.SABOTAGE);
+      expect(range).toEqual({ min: 18, max: 29 });
+    });
+
+    it('should return correct range for Terrorism', () => {
+      const range = getContractLengthRange(AtBContractType.TERRORISM);
+      expect(range).toEqual({ min: 2, max: 3 });
+    });
+
+    it('should return correct range for Planetary Assault', () => {
+      const range = getContractLengthRange(AtBContractType.PLANETARY_ASSAULT);
+      expect(range).toEqual({ min: 7, max: 11 });
+    });
+
+    it('should return correct range for Relief Duty', () => {
+      const range = getContractLengthRange(AtBContractType.RELIEF_DUTY);
+      expect(range).toEqual({ min: 7, max: 11 });
+    });
+
+    it('should return correct range for Pirate Hunting', () => {
+      const range = getContractLengthRange(AtBContractType.PIRATE_HUNTING);
+      expect(range).toEqual({ min: 5, max: 7 });
+    });
+
+    it('should return correct range for Mole Hunting', () => {
+      const range = getContractLengthRange(AtBContractType.MOLE_HUNTING);
+      expect(range).toEqual({ min: 5, max: 7 });
+    });
+
+    it('should return valid ranges for all 19 types', () => {
+      const allTypes = Object.values(AtBContractType);
+      allTypes.forEach((type) => {
+        const range = getContractLengthRange(type);
+        expect(range.min).toBeGreaterThan(0);
+        expect(range.max).toBeGreaterThanOrEqual(range.min);
+      });
+    });
+  });
+});

--- a/src/lib/campaign/contracts/__tests__/contractNegotiation.test.ts
+++ b/src/lib/campaign/contracts/__tests__/contractNegotiation.test.ts
@@ -1,0 +1,227 @@
+import {
+  roll2d6,
+  negotiateClause,
+  negotiateAllClauses,
+  getClauseLevelName,
+  getClauseLevelDescription,
+} from '../contractNegotiation';
+
+import {
+  ContractClauseType,
+  CLAUSE_LEVELS,
+} from '@/types/campaign/contracts/contractTypes';
+
+/** Returns a fixed value each time. Use for deterministic dice. */
+function fixedRandom(value: number) {
+  return () => value;
+}
+
+function createSeededRandom(seed: number) {
+  let state = seed;
+  return () => {
+    state = (1103515245 * state + 12345) & 0x7fffffff;
+    return state / 0x7fffffff;
+  };
+}
+
+describe('contractNegotiation', () => {
+  describe('roll2d6', () => {
+    it('should return 2 for minimum roll (both dice = 1)', () => {
+      const result = roll2d6(fixedRandom(0));
+      expect(result).toBe(2);
+    });
+
+    it('should return 12 for maximum roll (both dice = 6)', () => {
+      const result = roll2d6(fixedRandom(0.999));
+      expect(result).toBe(12);
+    });
+
+    it('should return value in range [2, 12] for seeded random', () => {
+      const random = createSeededRandom(42);
+      const result = roll2d6(random);
+      expect(result).toBeGreaterThanOrEqual(2);
+      expect(result).toBeLessThanOrEqual(12);
+    });
+
+    it('should return values in range [2, 12] for 100 random rolls', () => {
+      for (let i = 0; i < 100; i++) {
+        const random = createSeededRandom(i);
+        const result = roll2d6(random);
+        expect(result).toBeGreaterThanOrEqual(2);
+        expect(result).toBeLessThanOrEqual(12);
+      }
+    });
+  });
+
+  describe('negotiateClause', () => {
+    it('should return level 0 for low roll + low skill', () => {
+      // roll=2 + skill=0 + standing=0 = total=2 → level 0
+      const result = negotiateClause(
+        ContractClauseType.COMMAND,
+        0,
+        0,
+        fixedRandom(0)
+      );
+      expect(result.level).toBe(0);
+      expect(result.type).toBe(ContractClauseType.COMMAND);
+    });
+
+    it('should return level 1 for medium roll', () => {
+      // roll=5 + skill=0 + standing=0 = total=5 → level 1
+      const result = negotiateClause(
+        ContractClauseType.SALVAGE,
+        0,
+        0,
+        fixedRandom(0.333)
+      );
+      expect(result.level).toBe(1);
+      expect(result.type).toBe(ContractClauseType.SALVAGE);
+    });
+
+    it('should return level 2 for high roll', () => {
+      // roll=8 + skill=0 + standing=0 = total=8 → level 2
+      const result = negotiateClause(
+        ContractClauseType.SUPPORT,
+        0,
+        0,
+        fixedRandom(0.666)
+      );
+      expect(result.level).toBe(2);
+      expect(result.type).toBe(ContractClauseType.SUPPORT);
+    });
+
+    it('should return level 3 for very high roll', () => {
+      // roll=10 + skill=0 + standing=0 = total=10 → level 3
+      const result = negotiateClause(
+        ContractClauseType.TRANSPORT,
+        0,
+        0,
+        fixedRandom(0.833)
+      );
+      expect(result.level).toBe(3);
+      expect(result.type).toBe(ContractClauseType.TRANSPORT);
+    });
+
+    it('should raise level with skill modifier', () => {
+      // roll=5 + skill=3 + standing=2 = total=10 → level 3
+      // fixedRandom(0.5) gives die1=floor(0.5*6)+1=3, die2=floor(0.5*6)+1=3, roll=6
+      // So we need: roll=6 + skill=2 + standing=2 = total=10 → level 3
+      const result = negotiateClause(
+        ContractClauseType.COMMAND,
+        2,
+        2,
+        fixedRandom(0.5)
+      );
+      expect(result.level).toBe(3);
+    });
+
+    it('should lower level with negative standing', () => {
+      // roll=7 + skill=0 + standing=-5 = total=2 → level 0
+      const result = negotiateClause(
+        ContractClauseType.SALVAGE,
+        0,
+        -5,
+        fixedRandom(0.5)
+      );
+      expect(result.level).toBe(0);
+    });
+
+    it('should clamp level at 0 (no negative)', () => {
+      // roll=2 + skill=0 + standing=-10 = total=-8 → level 0
+      const result = negotiateClause(
+        ContractClauseType.SUPPORT,
+        0,
+        -10,
+        fixedRandom(0)
+      );
+      expect(result.level).toBe(0);
+    });
+
+    it('should clamp level at 3 (no overflow)', () => {
+      // roll=12 + skill=5 + standing=5 = total=22 → level 3
+      const result = negotiateClause(
+        ContractClauseType.TRANSPORT,
+        5,
+        5,
+        fixedRandom(0.999)
+      );
+      expect(result.level).toBe(3);
+    });
+
+    it('should return correct clause type in output', () => {
+      const result = negotiateClause(
+        ContractClauseType.COMMAND,
+        0,
+        0,
+        fixedRandom(0.5)
+      );
+      expect(result.type).toBe(ContractClauseType.COMMAND);
+    });
+  });
+
+  describe('negotiateAllClauses', () => {
+    it('should return exactly 4 clauses', () => {
+      const random = createSeededRandom(42);
+      const result = negotiateAllClauses(0, 0, random);
+      expect(result).toHaveLength(4);
+    });
+
+    it('should return one clause per ContractClauseType', () => {
+      const random = createSeededRandom(42);
+      const result = negotiateAllClauses(0, 0, random);
+      const types = result.map((c) => c.type);
+      expect(types).toContain(ContractClauseType.COMMAND);
+      expect(types).toContain(ContractClauseType.SALVAGE);
+      expect(types).toContain(ContractClauseType.SUPPORT);
+      expect(types).toContain(ContractClauseType.TRANSPORT);
+    });
+
+    it('should have all levels in range [0, 3]', () => {
+      const random = createSeededRandom(42);
+      const result = negotiateAllClauses(0, 0, random);
+      result.forEach((clause) => {
+        expect(clause.level).toBeGreaterThanOrEqual(0);
+        expect(clause.level).toBeLessThanOrEqual(3);
+      });
+    });
+  });
+
+  describe('getClauseLevelName', () => {
+    it('should return "Integrated" for Command level 0', () => {
+      const clause = { type: ContractClauseType.COMMAND, level: 0 as const };
+      expect(getClauseLevelName(clause)).toBe('Integrated');
+    });
+
+    it('should return "Independent" for Command level 3', () => {
+      const clause = { type: ContractClauseType.COMMAND, level: 3 as const };
+      expect(getClauseLevelName(clause)).toBe('Independent');
+    });
+
+    it('should return "None" for Salvage level 0', () => {
+      const clause = { type: ContractClauseType.SALVAGE, level: 0 as const };
+      expect(getClauseLevelName(clause)).toBe('None');
+    });
+
+    it('should return "Full" for Transport level 3', () => {
+      const clause = { type: ContractClauseType.TRANSPORT, level: 3 as const };
+      expect(getClauseLevelName(clause)).toBe('Full');
+    });
+  });
+
+  describe('getClauseLevelDescription', () => {
+    it('should return non-empty string for all clause type/level combinations', () => {
+      Object.values(ContractClauseType).forEach((clauseType) => {
+        for (let level = 0; level <= 3; level++) {
+          const clause = {
+            type: clauseType,
+            level: level as 0 | 1 | 2 | 3,
+          };
+          const description = getClauseLevelDescription(clause);
+          expect(description).toBeTruthy();
+          expect(typeof description).toBe('string');
+          expect(description.length).toBeGreaterThan(0);
+        }
+      });
+    });
+  });
+});

--- a/src/lib/campaign/contracts/contractEvents.ts
+++ b/src/lib/campaign/contracts/contractEvents.ts
@@ -1,0 +1,246 @@
+/**
+ * Contract Events System
+ * 
+ * Implements monthly contract event checking for AtB campaigns.
+ * Events are checked once per month during active contracts and
+ * can affect morale, parts availability, scenario generation, and payments.
+ *
+ * Based on MekHQ's AtBContract event checking.
+ * 
+ * @module campaign/contracts/contractEvents
+ */
+
+/** Random number generator function type. Returns [0, 1). */
+export type RandomFn = () => number;
+
+// =============================================================================
+// Contract Event Types
+// =============================================================================
+
+/**
+ * 10 contract event types that can occur during active contracts.
+ */
+export enum ContractEventType {
+  /** Bonus payment for exceeding expectations */
+  BONUS_ROLL = 'bonus_roll',
+  /** Special scenario triggered by contract conditions */
+  SPECIAL_SCENARIO = 'special_scenario',
+  /** Civil disturbance requiring additional security */
+  CIVIL_DISTURBANCE = 'civil_disturbance',
+  /** Full rebellion breaks out */
+  REBELLION = 'rebellion',
+  /** Employer betrayal — multiple sub-types */
+  BETRAYAL = 'betrayal',
+  /** Treacherous ambush or double-cross */
+  TREACHERY = 'treachery',
+  /** Supply chain failure */
+  LOGISTICS_FAILURE = 'logistics_failure',
+  /** Friendly reinforcements arrive */
+  REINFORCEMENTS = 'reinforcements',
+  /** Miscellaneous special events */
+  SPECIAL_EVENTS = 'special_events',
+  /** Large-scale battle event */
+  BIG_BATTLE = 'big_battle',
+}
+
+// =============================================================================
+// Betrayal Sub-Types
+// =============================================================================
+
+/**
+ * 6 sub-types of betrayal events.
+ */
+export enum BetrayalSubType {
+  /** Employer withholds supplies */
+  SUPPLY_CUTOFF = 'supply_cutoff',
+  /** Employer feeds false intelligence */
+  FALSE_INTEL = 'false_intel',
+  /** Employer redirects reinforcements */
+  REDIRECT_REINFORCEMENTS = 'redirect_reinforcements',
+  /** Employer leaks position to enemy */
+  POSITION_LEAKED = 'position_leaked',
+  /** Employer sets up ambush */
+  AMBUSH_SETUP = 'ambush_setup',
+  /** Full contract breach by employer */
+  CONTRACT_BREACH = 'contract_breach',
+}
+
+// =============================================================================
+// Event Effect Types
+// =============================================================================
+
+/**
+ * Union type for contract event effects.
+ */
+export type ContractEventEffect =
+  | { readonly type: 'morale_change'; readonly value: number }
+  | { readonly type: 'parts_modifier'; readonly value: number }
+  | { readonly type: 'scenario_trigger'; readonly scenarioType: string }
+  | { readonly type: 'payment_modifier'; readonly multiplier: number };
+
+// =============================================================================
+// Contract Event Interface
+// =============================================================================
+
+/**
+ * A contract event that has occurred.
+ */
+export interface IContractEvent {
+  /** Event type */
+  readonly type: ContractEventType;
+  /** Betrayal sub-type (only if type is BETRAYAL) */
+  readonly betrayalSubType?: BetrayalSubType;
+  /** Human-readable description */
+  readonly description: string;
+  /** Gameplay effects of the event */
+  readonly effects: readonly ContractEventEffect[];
+}
+
+// =============================================================================
+// Event Definitions
+// =============================================================================
+
+/**
+ * Create a contract event with standard effects for each type.
+ */
+function createEventByType(
+  type: ContractEventType,
+  random: RandomFn,
+): IContractEvent {
+  switch (type) {
+    case ContractEventType.BONUS_ROLL:
+      return {
+        type,
+        description: 'Employer provides a bonus payment for excellent performance',
+        effects: [{ type: 'payment_modifier', multiplier: 1.1 }],
+      };
+    case ContractEventType.SPECIAL_SCENARIO:
+      return {
+        type,
+        description: 'Intelligence reports an opportunity for a special operation',
+        effects: [{ type: 'scenario_trigger', scenarioType: 'special_mission' }],
+      };
+    case ContractEventType.CIVIL_DISTURBANCE:
+      return {
+        type,
+        description: 'Civil unrest erupts in the contract area',
+        effects: [{ type: 'morale_change', value: 1 }], // +1 enemy morale (harder)
+      };
+    case ContractEventType.REBELLION:
+      return {
+        type,
+        description: 'A full-scale rebellion breaks out, complicating operations',
+        effects: [
+          { type: 'morale_change', value: 2 },
+          { type: 'scenario_trigger', scenarioType: 'rebellion_battle' },
+        ],
+      };
+    case ContractEventType.BETRAYAL: {
+      const subTypes = Object.values(BetrayalSubType);
+      const subType = subTypes[Math.floor(random() * subTypes.length)];
+      return createBetrayalEvent(subType);
+    }
+    case ContractEventType.TREACHERY:
+      return {
+        type,
+        description: 'Treacherous forces ambush your unit',
+        effects: [
+          { type: 'morale_change', value: 1 },
+          { type: 'scenario_trigger', scenarioType: 'ambush' },
+        ],
+      };
+    case ContractEventType.LOGISTICS_FAILURE:
+      return {
+        type,
+        description: 'Supply lines have been disrupted',
+        effects: [{ type: 'parts_modifier', value: -1 }],
+      };
+    case ContractEventType.REINFORCEMENTS:
+      return {
+        type,
+        description: 'Friendly reinforcements arrive to assist operations',
+        effects: [{ type: 'morale_change', value: -1 }], // -1 enemy morale (easier)
+      };
+    case ContractEventType.SPECIAL_EVENTS:
+      return {
+        type,
+        description: 'An unexpected event occurs during the contract',
+        effects: [{ type: 'morale_change', value: 0 }], // Neutral — flavor event
+      };
+    case ContractEventType.BIG_BATTLE:
+      return {
+        type,
+        description: 'A major battle erupts, drawing all available forces',
+        effects: [{ type: 'scenario_trigger', scenarioType: 'big_battle' }],
+      };
+  }
+}
+
+/**
+ * Create a betrayal event with sub-type specific effects.
+ */
+function createBetrayalEvent(subType: BetrayalSubType): IContractEvent {
+  const baseEvent = {
+    type: ContractEventType.BETRAYAL as const,
+    betrayalSubType: subType,
+  };
+
+  switch (subType) {
+    case BetrayalSubType.SUPPLY_CUTOFF:
+      return { ...baseEvent, description: 'Employer has cut off supply shipments', effects: [{ type: 'parts_modifier', value: -2 }] };
+    case BetrayalSubType.FALSE_INTEL:
+      return { ...baseEvent, description: 'Employer provided false intelligence', effects: [{ type: 'scenario_trigger', scenarioType: 'ambush' }] };
+    case BetrayalSubType.REDIRECT_REINFORCEMENTS:
+      return { ...baseEvent, description: 'Employer redirected promised reinforcements', effects: [{ type: 'morale_change', value: 1 }] };
+    case BetrayalSubType.POSITION_LEAKED:
+      return { ...baseEvent, description: 'Your position has been leaked to the enemy', effects: [{ type: 'scenario_trigger', scenarioType: 'ambush' }, { type: 'morale_change', value: 1 }] };
+    case BetrayalSubType.AMBUSH_SETUP:
+      return { ...baseEvent, description: 'Employer set up an ambush against your forces', effects: [{ type: 'scenario_trigger', scenarioType: 'ambush' }, { type: 'morale_change', value: 2 }] };
+    case BetrayalSubType.CONTRACT_BREACH:
+      return { ...baseEvent, description: 'Employer has breached the contract terms', effects: [{ type: 'payment_modifier', multiplier: 0.5 }] };
+  }
+}
+
+// =============================================================================
+// Event Checking
+// =============================================================================
+
+/** Monthly event check chance (1-in-20, i.e., 5% per event type slot). */
+export const EVENT_CHECK_CHANCE = 0.05;
+
+/**
+ * Check for monthly contract events.
+ * Each event type has a 5% chance of occurring per month.
+ * Multiple events can occur in the same month.
+ * 
+ * @param random - Injectable random function
+ * @returns Array of events that occurred (may be empty)
+ */
+export function checkMonthlyEvents(random: RandomFn): IContractEvent[] {
+  const events: IContractEvent[] = [];
+  const allEventTypes = Object.values(ContractEventType);
+
+  for (const eventType of allEventTypes) {
+    if (random() < EVENT_CHECK_CHANCE) {
+      events.push(createEventByType(eventType, random));
+    }
+  }
+
+  return events;
+}
+
+/**
+ * Get all possible event types.
+ * @returns Array of all ContractEventType values
+ */
+export function getAllEventTypes(): ContractEventType[] {
+  return Object.values(ContractEventType);
+}
+
+/**
+ * Get all betrayal sub-types.
+ * @returns Array of all BetrayalSubType values
+ */
+export function getAllBetrayalSubTypes(): BetrayalSubType[] {
+  return Object.values(BetrayalSubType);
+}

--- a/src/lib/campaign/contracts/contractLength.ts
+++ b/src/lib/campaign/contracts/contractLength.ts
@@ -1,0 +1,56 @@
+/**
+ * Variable Contract Length Calculation
+ *
+ * Calculates variable contract durations using the MekHQ AtB formula:
+ * actualLength = round(constantLength × 0.75) + randomInt(round(constantLength × 0.5))
+ *
+ * @module campaign/contracts/contractLength
+ */
+
+import { AtBContractType, CONTRACT_TYPE_DEFINITIONS } from '@/types/campaign/contracts/contractTypes';
+
+/** Random number generator function type. Returns [0, 1). */
+export type RandomFn = () => number;
+
+/**
+ * Calculate variable contract length in months using MekHQ formula.
+ * Formula: round(constantLength × 0.75) + floor(random() × round(constantLength × 0.5))
+ *
+ * @param contractType - The AtB contract type
+ * @param random - Injectable random function for testability
+ * @returns Contract length in months
+ */
+export function calculateContractLength(
+  contractType: AtBContractType,
+  random: RandomFn
+): number {
+  const def = CONTRACT_TYPE_DEFINITIONS[contractType];
+  const base = def.durationMonths;
+  const minLength = Math.round(base * 0.75);
+  const variance = Math.round(base * 0.5);
+  if (variance === 0) return minLength;
+  const roll = Math.floor(random() * variance);
+  return minLength + roll;
+}
+
+/**
+ * Convert months to days (simplified 30-day months).
+ * @param months - Number of months
+ * @returns Number of days
+ */
+export function contractLengthToDays(months: number): number {
+  return months * 30;
+}
+
+/**
+ * Get the valid range of contract lengths for a given type.
+ * @param contractType - The AtB contract type
+ * @returns Object with min and max months
+ */
+export function getContractLengthRange(contractType: AtBContractType): { min: number; max: number } {
+  const def = CONTRACT_TYPE_DEFINITIONS[contractType];
+  const base = def.durationMonths;
+  const minLength = Math.round(base * 0.75);
+  const variance = Math.round(base * 0.5);
+  return { min: minLength, max: minLength + Math.max(0, variance - 1) };
+}

--- a/src/lib/campaign/contracts/contractNegotiation.ts
+++ b/src/lib/campaign/contracts/contractNegotiation.ts
@@ -1,0 +1,110 @@
+/**
+ * Contract Negotiation System
+ * 
+ * Implements the AtB contract clause negotiation mechanics.
+ * Each contract has 4 negotiation clauses (Command, Salvage, Support, Transport),
+ * each with levels 0-3. Negotiation rolls use 2d6 + skill + faction standing modifiers.
+ *
+ * Based on MekHQ's AbstractContractMarket clause negotiation.
+ * 
+ * @module campaign/contracts/contractNegotiation
+ */
+
+import {
+  ContractClauseType,
+  IContractClause,
+  CLAUSE_LEVELS,
+} from '@/types/campaign/contracts/contractTypes';
+
+/** Random number generator function type. Returns [0, 1). */
+export type RandomFn = () => number;
+
+/**
+ * Roll 2d6 using an injectable random function.
+ * Each die produces 1-6, total range 2-12.
+ */
+export function roll2d6(random: RandomFn): number {
+  const die1 = Math.floor(random() * 6) + 1;
+  const die2 = Math.floor(random() * 6) + 1;
+  return die1 + die2;
+}
+
+/**
+ * Negotiate a single contract clause.
+ * 
+ * Formula: roll 2d6 + negotiatorSkill + factionStandingMod
+ * Result mapping to level:
+ *   result < 4  → level 0
+ *   4 ≤ result < 7  → level 1
+ *   7 ≤ result < 10 → level 2
+ *   result ≥ 10 → level 3
+ * 
+ * Levels are clamped to [0, 3].
+ * 
+ * @param clauseType - Type of clause to negotiate
+ * @param negotiatorSkill - Negotiation skill modifier (typically 0-3)
+ * @param factionStandingMod - Faction standing modifier (can be negative)
+ * @param random - Injectable random function
+ * @returns Negotiated contract clause with level
+ */
+export function negotiateClause(
+  clauseType: ContractClauseType,
+  negotiatorSkill: number,
+  factionStandingMod: number,
+  random: RandomFn
+): IContractClause {
+  const roll = roll2d6(random);
+  const totalResult = roll + negotiatorSkill + factionStandingMod;
+  
+  let level: 0 | 1 | 2 | 3;
+  if (totalResult < 4) {
+    level = 0;
+  } else if (totalResult < 7) {
+    level = 1;
+  } else if (totalResult < 10) {
+    level = 2;
+  } else {
+    level = 3;
+  }
+  
+  return { type: clauseType, level };
+}
+
+/**
+ * Negotiate all 4 contract clauses.
+ * Returns an array of 4 clauses, one for each ContractClauseType.
+ * 
+ * @param negotiatorSkill - Negotiation skill modifier
+ * @param factionStandingMod - Faction standing modifier
+ * @param random - Injectable random function
+ * @returns Array of 4 negotiated contract clauses
+ */
+export function negotiateAllClauses(
+  negotiatorSkill: number,
+  factionStandingMod: number,
+  random: RandomFn
+): IContractClause[] {
+  return Object.values(ContractClauseType).map((clauseType) =>
+    negotiateClause(clauseType, negotiatorSkill, factionStandingMod, random)
+  );
+}
+
+/**
+ * Get the display name of a clause at its negotiated level.
+ * 
+ * @param clause - The negotiated clause
+ * @returns Display name string
+ */
+export function getClauseLevelName(clause: IContractClause): string {
+  return CLAUSE_LEVELS[clause.type][clause.level].name;
+}
+
+/**
+ * Get the description of a clause at its negotiated level.
+ * 
+ * @param clause - The negotiated clause
+ * @returns Description string
+ */
+export function getClauseLevelDescription(clause: IContractClause): string {
+  return CLAUSE_LEVELS[clause.type][clause.level].description;
+}

--- a/src/types/campaign/Mission.ts
+++ b/src/types/campaign/Mission.ts
@@ -15,6 +15,7 @@ import { Money } from './Money';
 import { IPaymentTerms, calculateTotalPayout, createDefaultPaymentTerms } from './PaymentTerms';
 import type { IScenario } from './Scenario';
 import type { AtBMoraleLevel } from './scenario/scenarioTypes';
+import type { AtBContractType } from './contracts/contractTypes';
 
 // =============================================================================
 // Salvage Rights
@@ -147,6 +148,9 @@ export interface IContract extends IMission {
 
   /** AtB morale level for this contract (optional, defaults to STALEMATE) */
   readonly moraleLevel?: AtBMoraleLevel;
+
+  /** AtB contract type (optional) */
+  readonly atbContractType?: AtBContractType;
 }
 
 // =============================================================================

--- a/src/types/campaign/contracts/__tests__/contractTypes.test.ts
+++ b/src/types/campaign/contracts/__tests__/contractTypes.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Tests for contract types, definitions, and clause levels
+ *
+ * @module campaign/contracts/__tests__/contractTypes
+ */
+
+import {
+  AtBContractType,
+  ContractClauseType,
+  CONTRACT_TYPE_DEFINITIONS,
+  CLAUSE_LEVELS,
+  getContractTypesByGroup,
+  getOpsTempo,
+  getContractDuration,
+  getAvailableContractTypes,
+  isAtBContractType,
+  isContractClauseType,
+} from '../contractTypes';
+import { CombatRole } from '@/types/campaign/scenario/scenarioTypes';
+
+describe('AtBContractType Enum', () => {
+  it('should have exactly 19 contract types', () => {
+    const types = Object.values(AtBContractType);
+    expect(types).toHaveLength(19);
+  });
+
+  it('should have 5 garrison types', () => {
+    const garrisonTypes = [
+      AtBContractType.GARRISON_DUTY,
+      AtBContractType.CADRE_DUTY,
+      AtBContractType.SECURITY_DUTY,
+      AtBContractType.RIOT_DUTY,
+      AtBContractType.RETAINER,
+    ];
+    expect(garrisonTypes).toHaveLength(5);
+    garrisonTypes.forEach((type) => {
+      expect(Object.values(AtBContractType)).toContain(type);
+    });
+  });
+
+  it('should have 6 raid types', () => {
+    const raidTypes = [
+      AtBContractType.DIVERSIONARY_RAID,
+      AtBContractType.OBJECTIVE_RAID,
+      AtBContractType.RECON_RAID,
+      AtBContractType.EXTRACTION_RAID,
+      AtBContractType.ASSASSINATION,
+      AtBContractType.OBSERVATION_RAID,
+    ];
+    expect(raidTypes).toHaveLength(6);
+    raidTypes.forEach((type) => {
+      expect(Object.values(AtBContractType)).toContain(type);
+    });
+  });
+
+  it('should have 4 guerrilla types including terrorism', () => {
+    const guerrillaTypes = [
+      AtBContractType.GUERRILLA_WARFARE,
+      AtBContractType.ESPIONAGE,
+      AtBContractType.SABOTAGE,
+      AtBContractType.TERRORISM,
+    ];
+    expect(guerrillaTypes).toHaveLength(4);
+    guerrillaTypes.forEach((type) => {
+      expect(Object.values(AtBContractType)).toContain(type);
+    });
+  });
+
+  it('should have 4 special types', () => {
+    const specialTypes = [
+      AtBContractType.PLANETARY_ASSAULT,
+      AtBContractType.RELIEF_DUTY,
+      AtBContractType.PIRATE_HUNTING,
+      AtBContractType.MOLE_HUNTING,
+    ];
+    expect(specialTypes).toHaveLength(4);
+    specialTypes.forEach((type) => {
+      expect(Object.values(AtBContractType)).toContain(type);
+    });
+  });
+
+  it('should use lowercase with underscores for enum values', () => {
+    Object.values(AtBContractType).forEach((value) => {
+      expect(value).toMatch(/^[a-z_]+$/);
+    });
+  });
+});
+
+describe('CONTRACT_TYPE_DEFINITIONS', () => {
+  it('should have an entry for every contract type', () => {
+    Object.values(AtBContractType).forEach((type) => {
+      expect(CONTRACT_TYPE_DEFINITIONS[type]).toBeDefined();
+    });
+  });
+
+  it('should have exactly 19 definitions', () => {
+    const definitions = Object.keys(CONTRACT_TYPE_DEFINITIONS);
+    expect(definitions).toHaveLength(19);
+  });
+
+  it('should define all garrison types correctly', () => {
+    const garrisonDef = CONTRACT_TYPE_DEFINITIONS[AtBContractType.GARRISON_DUTY];
+    expect(garrisonDef.name).toBe('Garrison Duty');
+    expect(garrisonDef.group).toBe('garrison');
+    expect(garrisonDef.durationMonths).toBe(18);
+    expect(garrisonDef.opsTempo.min).toBe(1.0);
+    expect(garrisonDef.opsTempo.max).toBe(1.0);
+    expect(garrisonDef.available).toBe(true);
+  });
+
+  it('should define cadre duty with 0.8 ops tempo', () => {
+    const cadreDef = CONTRACT_TYPE_DEFINITIONS[AtBContractType.CADRE_DUTY];
+    expect(cadreDef.opsTempo.min).toBe(0.8);
+    expect(cadreDef.opsTempo.max).toBe(0.8);
+    expect(cadreDef.durationMonths).toBe(12);
+  });
+
+  it('should define security duty with 1.2 ops tempo', () => {
+    const securityDef = CONTRACT_TYPE_DEFINITIONS[AtBContractType.SECURITY_DUTY];
+    expect(securityDef.opsTempo.min).toBe(1.2);
+    expect(securityDef.opsTempo.max).toBe(1.2);
+    expect(securityDef.durationMonths).toBe(6);
+  });
+
+  it('should define retainer with 1.3 ops tempo', () => {
+    const retainerDef = CONTRACT_TYPE_DEFINITIONS[AtBContractType.RETAINER];
+    expect(retainerDef.opsTempo.min).toBe(1.3);
+    expect(retainerDef.opsTempo.max).toBe(1.3);
+    expect(retainerDef.durationMonths).toBe(12);
+  });
+
+  it('should define raid types with 3-month duration', () => {
+    const raidTypes = [
+      AtBContractType.DIVERSIONARY_RAID,
+      AtBContractType.OBJECTIVE_RAID,
+      AtBContractType.RECON_RAID,
+      AtBContractType.EXTRACTION_RAID,
+      AtBContractType.ASSASSINATION,
+      AtBContractType.OBSERVATION_RAID,
+    ];
+    raidTypes.forEach((type) => {
+      const def = CONTRACT_TYPE_DEFINITIONS[type];
+      expect(def.group).toBe('raid');
+      expect(def.durationMonths).toBe(3);
+    });
+  });
+
+  it('should define diversionary raid with 1.8 ops tempo', () => {
+    const def = CONTRACT_TYPE_DEFINITIONS[AtBContractType.DIVERSIONARY_RAID];
+    expect(def.opsTempo.min).toBe(1.8);
+    expect(def.opsTempo.max).toBe(1.8);
+  });
+
+  it('should define objective raid with 1.6 ops tempo', () => {
+    const def = CONTRACT_TYPE_DEFINITIONS[AtBContractType.OBJECTIVE_RAID];
+    expect(def.opsTempo.min).toBe(1.6);
+    expect(def.opsTempo.max).toBe(1.6);
+  });
+
+  it('should define assassination with 1.9 ops tempo', () => {
+    const def = CONTRACT_TYPE_DEFINITIONS[AtBContractType.ASSASSINATION];
+    expect(def.opsTempo.min).toBe(1.9);
+    expect(def.opsTempo.max).toBe(1.9);
+  });
+
+  it('should define guerrilla warfare with 2.1 ops tempo and 24 months', () => {
+    const def = CONTRACT_TYPE_DEFINITIONS[AtBContractType.GUERRILLA_WARFARE];
+    expect(def.group).toBe('guerrilla');
+    expect(def.opsTempo.min).toBe(2.1);
+    expect(def.opsTempo.max).toBe(2.1);
+    expect(def.durationMonths).toBe(24);
+  });
+
+  it('should define espionage with 2.4 ops tempo', () => {
+    const def = CONTRACT_TYPE_DEFINITIONS[AtBContractType.ESPIONAGE];
+    expect(def.opsTempo.min).toBe(2.4);
+    expect(def.opsTempo.max).toBe(2.4);
+    expect(def.durationMonths).toBe(12);
+  });
+
+  it('should define sabotage with 2.4 ops tempo and 24 months', () => {
+    const def = CONTRACT_TYPE_DEFINITIONS[AtBContractType.SABOTAGE];
+    expect(def.opsTempo.min).toBe(2.4);
+    expect(def.opsTempo.max).toBe(2.4);
+    expect(def.durationMonths).toBe(24);
+  });
+
+  it('should define terrorism with 1.9 ops tempo and 3 months', () => {
+    const def = CONTRACT_TYPE_DEFINITIONS[AtBContractType.TERRORISM];
+    expect(def.group).toBe('guerrilla');
+    expect(def.opsTempo.min).toBe(1.9);
+    expect(def.opsTempo.max).toBe(1.9);
+    expect(def.durationMonths).toBe(3);
+  });
+
+  it('should define planetary assault with 1.5 ops tempo and 9 months', () => {
+    const def = CONTRACT_TYPE_DEFINITIONS[AtBContractType.PLANETARY_ASSAULT];
+    expect(def.group).toBe('special');
+    expect(def.opsTempo.min).toBe(1.5);
+    expect(def.opsTempo.max).toBe(1.5);
+    expect(def.durationMonths).toBe(9);
+  });
+
+  it('should define relief duty with 1.4 ops tempo and 9 months', () => {
+    const def = CONTRACT_TYPE_DEFINITIONS[AtBContractType.RELIEF_DUTY];
+    expect(def.group).toBe('special');
+    expect(def.opsTempo.min).toBe(1.4);
+    expect(def.opsTempo.max).toBe(1.4);
+    expect(def.durationMonths).toBe(9);
+  });
+
+  it('should define pirate hunting with 1.0 ops tempo and 6 months', () => {
+    const def = CONTRACT_TYPE_DEFINITIONS[AtBContractType.PIRATE_HUNTING];
+    expect(def.group).toBe('special');
+    expect(def.opsTempo.min).toBe(1.0);
+    expect(def.opsTempo.max).toBe(1.0);
+    expect(def.durationMonths).toBe(6);
+  });
+
+  it('should define mole hunting with 1.2 ops tempo and 6 months', () => {
+    const def = CONTRACT_TYPE_DEFINITIONS[AtBContractType.MOLE_HUNTING];
+    expect(def.group).toBe('special');
+    expect(def.opsTempo.min).toBe(1.2);
+    expect(def.opsTempo.max).toBe(1.2);
+    expect(def.durationMonths).toBe(6);
+  });
+
+  it('should have ops tempo range with min 0.8 and max 2.4', () => {
+    let minTempo = Infinity;
+    let maxTempo = -Infinity;
+
+    Object.values(CONTRACT_TYPE_DEFINITIONS).forEach((def) => {
+      minTempo = Math.min(minTempo, def.opsTempo.min);
+      maxTempo = Math.max(maxTempo, def.opsTempo.max);
+    });
+
+    expect(minTempo).toBe(0.8);
+    expect(maxTempo).toBe(2.4);
+  });
+
+  it('should have primary roles for each contract type', () => {
+    Object.values(CONTRACT_TYPE_DEFINITIONS).forEach((def) => {
+      expect(def.primaryRoles).toBeDefined();
+      expect(Array.isArray(def.primaryRoles)).toBe(true);
+      expect(def.primaryRoles.length).toBeGreaterThan(0);
+      def.primaryRoles.forEach((role) => {
+        expect(Object.values(CombatRole)).toContain(role);
+      });
+    });
+  });
+
+  it('should have all definitions marked as available', () => {
+    Object.values(CONTRACT_TYPE_DEFINITIONS).forEach((def) => {
+      expect(def.available).toBe(true);
+    });
+  });
+});
+
+describe('ContractClauseType Enum', () => {
+  it('should have exactly 4 clause types', () => {
+    const types = Object.values(ContractClauseType);
+    expect(types).toHaveLength(4);
+  });
+
+  it('should have command, salvage, support, and transport', () => {
+    expect(ContractClauseType.COMMAND).toBe('command');
+    expect(ContractClauseType.SALVAGE).toBe('salvage');
+    expect(ContractClauseType.SUPPORT).toBe('support');
+    expect(ContractClauseType.TRANSPORT).toBe('transport');
+  });
+});
+
+describe('CLAUSE_LEVELS', () => {
+  it('should have 4 levels for each clause type', () => {
+    Object.values(ContractClauseType).forEach((clauseType) => {
+      const levels = CLAUSE_LEVELS[clauseType];
+      expect(levels).toBeDefined();
+      expect(Object.keys(levels)).toHaveLength(4);
+      expect(levels[0]).toBeDefined();
+      expect(levels[1]).toBeDefined();
+      expect(levels[2]).toBeDefined();
+      expect(levels[3]).toBeDefined();
+    });
+  });
+
+  it('should define command levels correctly', () => {
+    const commandLevels = CLAUSE_LEVELS[ContractClauseType.COMMAND];
+    expect(commandLevels[0].name).toBe('Integrated');
+    expect(commandLevels[1].name).toBe('House');
+    expect(commandLevels[2].name).toBe('Liaison');
+    expect(commandLevels[3].name).toBe('Independent');
+  });
+
+  it('should define salvage levels correctly', () => {
+    const salvageLevels = CLAUSE_LEVELS[ContractClauseType.SALVAGE];
+    expect(salvageLevels[0].name).toBe('None');
+    expect(salvageLevels[1].name).toBe('Exchange');
+    expect(salvageLevels[2].name).toBe('Employer');
+    expect(salvageLevels[3].name).toBe('Integrated');
+  });
+
+  it('should define support levels correctly', () => {
+    const supportLevels = CLAUSE_LEVELS[ContractClauseType.SUPPORT];
+    expect(supportLevels[0].name).toBe('None');
+    expect(supportLevels[1].name).toBe('Supplies Only');
+    expect(supportLevels[2].name).toBe('Partial');
+    expect(supportLevels[3].name).toBe('Full');
+  });
+
+  it('should define transport levels correctly', () => {
+    const transportLevels = CLAUSE_LEVELS[ContractClauseType.TRANSPORT];
+    expect(transportLevels[0].name).toBe('None');
+    expect(transportLevels[1].name).toBe('Limited');
+    expect(transportLevels[2].name).toBe('Partial');
+    expect(transportLevels[3].name).toBe('Full');
+  });
+
+  it('should have descriptions for all levels', () => {
+    Object.values(ContractClauseType).forEach((clauseType) => {
+      const levels = CLAUSE_LEVELS[clauseType];
+      [0, 1, 2, 3].forEach((level) => {
+        expect(levels[level as 0 | 1 | 2 | 3].description).toBeDefined();
+        expect(levels[level as 0 | 1 | 2 | 3].description.length).toBeGreaterThan(0);
+      });
+    });
+  });
+});
+
+describe('Type Guards', () => {
+  it('isAtBContractType should return true for valid contract types', () => {
+    expect(isAtBContractType(AtBContractType.GARRISON_DUTY)).toBe(true);
+    expect(isAtBContractType(AtBContractType.ASSASSINATION)).toBe(true);
+    expect(isAtBContractType(AtBContractType.ESPIONAGE)).toBe(true);
+  });
+
+  it('isAtBContractType should return false for invalid values', () => {
+    expect(isAtBContractType('invalid_type')).toBe(false);
+    expect(isAtBContractType(null)).toBe(false);
+    expect(isAtBContractType(undefined)).toBe(false);
+    expect(isAtBContractType(123)).toBe(false);
+  });
+
+  it('isContractClauseType should return true for valid clause types', () => {
+    expect(isContractClauseType(ContractClauseType.COMMAND)).toBe(true);
+    expect(isContractClauseType(ContractClauseType.SALVAGE)).toBe(true);
+    expect(isContractClauseType(ContractClauseType.SUPPORT)).toBe(true);
+    expect(isContractClauseType(ContractClauseType.TRANSPORT)).toBe(true);
+  });
+
+  it('isContractClauseType should return false for invalid values', () => {
+    expect(isContractClauseType('invalid_clause')).toBe(false);
+    expect(isContractClauseType(null)).toBe(false);
+    expect(isContractClauseType(undefined)).toBe(false);
+    expect(isContractClauseType(123)).toBe(false);
+  });
+});
+
+describe('Helper Functions', () => {
+  describe('getContractTypesByGroup', () => {
+    it('should return 5 garrison types', () => {
+      const garrison = getContractTypesByGroup('garrison');
+      expect(garrison).toHaveLength(5);
+      expect(garrison).toContain(AtBContractType.GARRISON_DUTY);
+      expect(garrison).toContain(AtBContractType.CADRE_DUTY);
+      expect(garrison).toContain(AtBContractType.SECURITY_DUTY);
+      expect(garrison).toContain(AtBContractType.RIOT_DUTY);
+      expect(garrison).toContain(AtBContractType.RETAINER);
+    });
+
+    it('should return 6 raid types', () => {
+      const raid = getContractTypesByGroup('raid');
+      expect(raid).toHaveLength(6);
+      expect(raid).toContain(AtBContractType.DIVERSIONARY_RAID);
+      expect(raid).toContain(AtBContractType.OBJECTIVE_RAID);
+      expect(raid).toContain(AtBContractType.ASSASSINATION);
+    });
+
+    it('should return 4 guerrilla types', () => {
+      const guerrilla = getContractTypesByGroup('guerrilla');
+      expect(guerrilla).toHaveLength(4);
+      expect(guerrilla).toContain(AtBContractType.GUERRILLA_WARFARE);
+      expect(guerrilla).toContain(AtBContractType.ESPIONAGE);
+      expect(guerrilla).toContain(AtBContractType.SABOTAGE);
+      expect(guerrilla).toContain(AtBContractType.TERRORISM);
+    });
+
+    it('should return 4 special types', () => {
+      const special = getContractTypesByGroup('special');
+      expect(special).toHaveLength(4);
+      expect(special).toContain(AtBContractType.PLANETARY_ASSAULT);
+      expect(special).toContain(AtBContractType.RELIEF_DUTY);
+      expect(special).toContain(AtBContractType.PIRATE_HUNTING);
+      expect(special).toContain(AtBContractType.MOLE_HUNTING);
+    });
+  });
+
+  describe('getOpsTempo', () => {
+    it('should return correct ops tempo for garrison duty', () => {
+      const tempo = getOpsTempo(AtBContractType.GARRISON_DUTY);
+      expect(tempo.min).toBe(1.0);
+      expect(tempo.max).toBe(1.0);
+    });
+
+    it('should return correct ops tempo for espionage', () => {
+      const tempo = getOpsTempo(AtBContractType.ESPIONAGE);
+      expect(tempo.min).toBe(2.4);
+      expect(tempo.max).toBe(2.4);
+    });
+  });
+
+  describe('getContractDuration', () => {
+    it('should return correct duration for garrison duty', () => {
+      const duration = getContractDuration(AtBContractType.GARRISON_DUTY);
+      expect(duration).toBe(18);
+    });
+
+    it('should return correct duration for raid types', () => {
+      const duration = getContractDuration(AtBContractType.OBJECTIVE_RAID);
+      expect(duration).toBe(3);
+    });
+
+    it('should return correct duration for guerrilla warfare', () => {
+      const duration = getContractDuration(AtBContractType.GUERRILLA_WARFARE);
+      expect(duration).toBe(24);
+    });
+  });
+
+  describe('getAvailableContractTypes', () => {
+    it('should return all 19 contract types as available', () => {
+      const available = getAvailableContractTypes();
+      expect(available).toHaveLength(19);
+      expect(available).toContain(AtBContractType.GARRISON_DUTY);
+      expect(available).toContain(AtBContractType.ASSASSINATION);
+      expect(available).toContain(AtBContractType.ESPIONAGE);
+    });
+  });
+});

--- a/src/types/campaign/contracts/contractTypes.ts
+++ b/src/types/campaign/contracts/contractTypes.ts
@@ -1,0 +1,590 @@
+/**
+ * Against the Bot (AtB) Contract Types and Definitions
+ *
+ * Defines 19 contract types organized into 4 groups (Garrison, Raid, Guerrilla, Special),
+ * with operational tempo ranges, negotiation clause types, and clause levels.
+ *
+ * Based on MekHQ's AtB contract system.
+ *
+ * @module campaign/contracts/contractTypes
+ */
+
+import { CombatRole } from '@/types/campaign/scenario/scenarioTypes';
+
+// =============================================================================
+// Contract Type Enum
+// =============================================================================
+
+/**
+ * 19 Against the Bot contract types organized into 4 groups.
+ *
+ * Each type has an operational tempo range (multiplier on base pay) and
+ * typical contract duration.
+ *
+ * @example
+ * const type: AtBContractType = AtBContractType.GARRISON_DUTY;
+ */
+export enum AtBContractType {
+  // Garrison Group (5 types) - defensive, low-intensity operations
+  GARRISON_DUTY = 'garrison_duty',
+  CADRE_DUTY = 'cadre_duty',
+  SECURITY_DUTY = 'security_duty',
+  RIOT_DUTY = 'riot_duty',
+  RETAINER = 'retainer',
+
+  // Raid Group (6 types) - offensive, short-duration operations
+  DIVERSIONARY_RAID = 'diversionary_raid',
+  OBJECTIVE_RAID = 'objective_raid',
+  RECON_RAID = 'recon_raid',
+  EXTRACTION_RAID = 'extraction_raid',
+  ASSASSINATION = 'assassination',
+  OBSERVATION_RAID = 'observation_raid',
+
+  // Guerrilla Group (4 types) - long-duration, high-intensity operations
+  GUERRILLA_WARFARE = 'guerrilla_warfare',
+  ESPIONAGE = 'espionage',
+  SABOTAGE = 'sabotage',
+  TERRORISM = 'terrorism',
+
+  // Special Group (4 types) - specialized operations
+  PLANETARY_ASSAULT = 'planetary_assault',
+  RELIEF_DUTY = 'relief_duty',
+  PIRATE_HUNTING = 'pirate_hunting',
+  MOLE_HUNTING = 'mole_hunting',
+}
+
+// =============================================================================
+// Contract Group Type
+// =============================================================================
+
+/**
+ * Contract groups for organizing contract types.
+ *
+ * @example
+ * const group: ContractGroup = 'garrison';
+ */
+export type ContractGroup = 'garrison' | 'raid' | 'guerrilla' | 'special';
+
+// =============================================================================
+// Contract Type Definition Interface
+// =============================================================================
+
+/**
+ * Definition of a contract type with operational parameters.
+ *
+ * @example
+ * const def = CONTRACT_TYPE_DEFINITIONS[AtBContractType.GARRISON_DUTY];
+ * console.log(def.name); // 'Garrison Duty'
+ * console.log(def.opsTempo.min); // 1.0
+ * console.log(def.opsTempo.max); // 1.0
+ */
+export interface IContractTypeDefinition {
+  /** Display name of the contract type */
+  readonly name: string;
+
+  /** Contract group this type belongs to */
+  readonly group: ContractGroup;
+
+  /** Description of the contract type */
+  readonly description: string;
+
+  /** Typical contract duration in months */
+  readonly durationMonths: number;
+
+  /** Operational tempo range (pay multiplier) */
+  readonly opsTempo: {
+    readonly min: number;
+    readonly max: number;
+  };
+
+  /** Primary combat roles for this contract type */
+  readonly primaryRoles: readonly CombatRole[];
+
+  /** Whether this contract type is available for player selection */
+  readonly available: boolean;
+}
+
+// =============================================================================
+// Contract Type Definitions
+// =============================================================================
+
+/**
+ * Complete definitions for all 19 contract types.
+ *
+ * Organized by group for easy lookup and filtering.
+ *
+ * @example
+ * const garrison = Object.entries(CONTRACT_TYPE_DEFINITIONS)
+ *   .filter(([_, def]) => def.group === 'garrison')
+ *   .map(([type, def]) => ({ type, ...def }));
+ */
+export const CONTRACT_TYPE_DEFINITIONS: Record<
+  AtBContractType,
+  IContractTypeDefinition
+> = {
+  // =========================================================================
+  // Garrison Group (5 types)
+  // =========================================================================
+
+  [AtBContractType.GARRISON_DUTY]: {
+    name: 'Garrison Duty',
+    group: 'garrison',
+    description: 'Defend a fixed position or installation',
+    durationMonths: 18,
+    opsTempo: { min: 1.0, max: 1.0 },
+    primaryRoles: [CombatRole.FRONTLINE, CombatRole.AUXILIARY],
+    available: true,
+  },
+
+  [AtBContractType.CADRE_DUTY]: {
+    name: 'Cadre Duty',
+    group: 'garrison',
+    description: 'Train and mentor local forces',
+    durationMonths: 12,
+    opsTempo: { min: 0.8, max: 0.8 },
+    primaryRoles: [CombatRole.TRAINING, CombatRole.CADRE],
+    available: true,
+  },
+
+  [AtBContractType.SECURITY_DUTY]: {
+    name: 'Security Duty',
+    group: 'garrison',
+    description: 'Provide security for a location or convoy',
+    durationMonths: 6,
+    opsTempo: { min: 1.2, max: 1.2 },
+    primaryRoles: [CombatRole.PATROL, CombatRole.AUXILIARY],
+    available: true,
+  },
+
+  [AtBContractType.RIOT_DUTY]: {
+    name: 'Riot Duty',
+    group: 'garrison',
+    description: 'Suppress civil unrest and maintain order',
+    durationMonths: 4,
+    opsTempo: { min: 1.0, max: 1.0 },
+    primaryRoles: [CombatRole.FRONTLINE, CombatRole.PATROL],
+    available: true,
+  },
+
+  [AtBContractType.RETAINER]: {
+    name: 'Retainer',
+    group: 'garrison',
+    description: 'Maintain readiness on standby',
+    durationMonths: 12,
+    opsTempo: { min: 1.3, max: 1.3 },
+    primaryRoles: [CombatRole.RESERVE, CombatRole.AUXILIARY],
+    available: true,
+  },
+
+  // =========================================================================
+  // Raid Group (6 types)
+  // =========================================================================
+
+  [AtBContractType.DIVERSIONARY_RAID]: {
+    name: 'Diversionary Raid',
+    group: 'raid',
+    description: 'Conduct a raid to distract enemy forces',
+    durationMonths: 3,
+    opsTempo: { min: 1.8, max: 1.8 },
+    primaryRoles: [CombatRole.MANEUVER, CombatRole.PATROL],
+    available: true,
+  },
+
+  [AtBContractType.OBJECTIVE_RAID]: {
+    name: 'Objective Raid',
+    group: 'raid',
+    description: 'Raid to capture or destroy a specific objective',
+    durationMonths: 3,
+    opsTempo: { min: 1.6, max: 1.6 },
+    primaryRoles: [CombatRole.MANEUVER, CombatRole.FRONTLINE],
+    available: true,
+  },
+
+  [AtBContractType.RECON_RAID]: {
+    name: 'Recon Raid',
+    group: 'raid',
+    description: 'Conduct reconnaissance in force',
+    durationMonths: 3,
+    opsTempo: { min: 1.6, max: 1.6 },
+    primaryRoles: [CombatRole.PATROL, CombatRole.MANEUVER],
+    available: true,
+  },
+
+  [AtBContractType.EXTRACTION_RAID]: {
+    name: 'Extraction Raid',
+    group: 'raid',
+    description: 'Raid to extract personnel or assets',
+    durationMonths: 3,
+    opsTempo: { min: 1.6, max: 1.6 },
+    primaryRoles: [CombatRole.MANEUVER, CombatRole.FRONTLINE],
+    available: true,
+  },
+
+  [AtBContractType.ASSASSINATION]: {
+    name: 'Assassination',
+    group: 'raid',
+    description: 'Eliminate a high-value target',
+    durationMonths: 3,
+    opsTempo: { min: 1.9, max: 1.9 },
+    primaryRoles: [CombatRole.MANEUVER, CombatRole.PATROL],
+    available: true,
+  },
+
+  [AtBContractType.OBSERVATION_RAID]: {
+    name: 'Observation Raid',
+    group: 'raid',
+    description: 'Raid to observe and report on enemy activity',
+    durationMonths: 3,
+    opsTempo: { min: 1.6, max: 1.6 },
+    primaryRoles: [CombatRole.PATROL, CombatRole.MANEUVER],
+    available: true,
+  },
+
+  // =========================================================================
+  // Guerrilla Group (4 types)
+  // =========================================================================
+
+  [AtBContractType.GUERRILLA_WARFARE]: {
+    name: 'Guerrilla Warfare',
+    group: 'guerrilla',
+    description: 'Conduct sustained guerrilla operations',
+    durationMonths: 24,
+    opsTempo: { min: 2.1, max: 2.1 },
+    primaryRoles: [CombatRole.MANEUVER, CombatRole.PATROL],
+    available: true,
+  },
+
+  [AtBContractType.ESPIONAGE]: {
+    name: 'Espionage',
+    group: 'guerrilla',
+    description: 'Gather intelligence through covert operations',
+    durationMonths: 12,
+    opsTempo: { min: 2.4, max: 2.4 },
+    primaryRoles: [CombatRole.PATROL, CombatRole.AUXILIARY],
+    available: true,
+  },
+
+  [AtBContractType.SABOTAGE]: {
+    name: 'Sabotage',
+    group: 'guerrilla',
+    description: 'Conduct sabotage operations against enemy infrastructure',
+    durationMonths: 24,
+    opsTempo: { min: 2.4, max: 2.4 },
+    primaryRoles: [CombatRole.MANEUVER, CombatRole.PATROL],
+    available: true,
+  },
+
+  [AtBContractType.TERRORISM]: {
+    name: 'Terrorism',
+    group: 'guerrilla',
+    description: 'Conduct terror operations to demoralize enemy',
+    durationMonths: 3,
+    opsTempo: { min: 1.9, max: 1.9 },
+    primaryRoles: [CombatRole.MANEUVER, CombatRole.PATROL],
+    available: true,
+  },
+
+  // =========================================================================
+  // Special Group (4 types)
+  // =========================================================================
+
+  [AtBContractType.PLANETARY_ASSAULT]: {
+    name: 'Planetary Assault',
+    group: 'special',
+    description: 'Conduct a large-scale planetary assault',
+    durationMonths: 9,
+    opsTempo: { min: 1.5, max: 1.5 },
+    primaryRoles: [CombatRole.FRONTLINE, CombatRole.MANEUVER],
+    available: true,
+  },
+
+  [AtBContractType.RELIEF_DUTY]: {
+    name: 'Relief Duty',
+    group: 'special',
+    description: 'Provide relief and humanitarian assistance',
+    durationMonths: 9,
+    opsTempo: { min: 1.4, max: 1.4 },
+    primaryRoles: [CombatRole.AUXILIARY, CombatRole.TRAINING],
+    available: true,
+  },
+
+  [AtBContractType.PIRATE_HUNTING]: {
+    name: 'Pirate Hunting',
+    group: 'special',
+    description: 'Hunt and eliminate pirate forces',
+    durationMonths: 6,
+    opsTempo: { min: 1.0, max: 1.0 },
+    primaryRoles: [CombatRole.PATROL, CombatRole.MANEUVER],
+    available: true,
+  },
+
+  [AtBContractType.MOLE_HUNTING]: {
+    name: 'Mole Hunting',
+    group: 'special',
+    description: 'Hunt and eliminate infiltrators and saboteurs',
+    durationMonths: 6,
+    opsTempo: { min: 1.2, max: 1.2 },
+    primaryRoles: [CombatRole.PATROL, CombatRole.FRONTLINE],
+    available: true,
+  },
+};
+
+// =============================================================================
+// Contract Clause Type Enum
+// =============================================================================
+
+/**
+ * Types of negotiation clauses for contracts.
+ *
+ * Each clause type has 4 levels (0-3) representing increasing commitment
+ * or benefit to the player unit.
+ *
+ * @example
+ * const clauseType: ContractClauseType = ContractClauseType.COMMAND;
+ */
+export enum ContractClauseType {
+  /** Command authority and tactical autonomy */
+  COMMAND = 'command',
+
+  /** Salvage rights and equipment recovery */
+  SALVAGE = 'salvage',
+
+  /** Support and logistics provided by employer */
+  SUPPORT = 'support',
+
+  /** Transport and deployment logistics */
+  TRANSPORT = 'transport',
+}
+
+// =============================================================================
+// Contract Clause Interface
+// =============================================================================
+
+/**
+ * A negotiation clause for a contract.
+ *
+ * Clauses define specific terms and conditions of the contract.
+ *
+ * @example
+ * const clause: IContractClause = {
+ *   type: ContractClauseType.COMMAND,
+ *   level: 2,
+ * };
+ */
+export interface IContractClause {
+  /** Type of clause */
+  readonly type: ContractClauseType;
+
+  /** Level of the clause (0-3) */
+  readonly level: 0 | 1 | 2 | 3;
+}
+
+// =============================================================================
+// Clause Level Definitions
+// =============================================================================
+
+/**
+ * Definition of a clause level.
+ *
+ * @example
+ * const level = CLAUSE_LEVELS[ContractClauseType.COMMAND][2];
+ * console.log(level.name); // 'Liaison'
+ */
+export interface IClauseLevelDefinition {
+  /** Display name of the level */
+  readonly name: string;
+
+  /** Description of what this level provides */
+  readonly description: string;
+}
+
+/**
+ * Definitions for all clause levels by type.
+ *
+ * Each clause type has 4 levels (0-3) with increasing benefits/commitment.
+ *
+ * @example
+ * const commandLevels = CLAUSE_LEVELS[ContractClauseType.COMMAND];
+ * console.log(commandLevels[0].name); // 'Integrated'
+ */
+export const CLAUSE_LEVELS: Record<
+  ContractClauseType,
+  Record<0 | 1 | 2 | 3, IClauseLevelDefinition>
+> = {
+  [ContractClauseType.COMMAND]: {
+    0: {
+      name: 'Integrated',
+      description: 'Unit is fully integrated into employer command structure',
+    },
+    1: {
+      name: 'House',
+      description: 'Employer provides strategic direction, unit handles tactics',
+    },
+    2: {
+      name: 'Liaison',
+      description: 'Liaison officer coordinates with employer',
+    },
+    3: {
+      name: 'Independent',
+      description: 'Unit has full tactical autonomy',
+    },
+  },
+
+  [ContractClauseType.SALVAGE]: {
+    0: {
+      name: 'None',
+      description: 'No salvage rights (employer keeps all)',
+    },
+    1: {
+      name: 'Exchange',
+      description: 'Unit can exchange salvage for cash at a percentage',
+    },
+    2: {
+      name: 'Employer',
+      description: 'Employer provides salvage from their stores',
+    },
+    3: {
+      name: 'Integrated',
+      description: 'Unit keeps a percentage of salvage directly',
+    },
+  },
+
+  [ContractClauseType.SUPPORT]: {
+    0: {
+      name: 'None',
+      description: 'No support provided by employer',
+    },
+    1: {
+      name: 'Supplies Only',
+      description: 'Employer provides ammunition and supplies',
+    },
+    2: {
+      name: 'Partial',
+      description: 'Employer provides supplies and repair facilities',
+    },
+    3: {
+      name: 'Full',
+      description: 'Employer provides full logistics and medical support',
+    },
+  },
+
+  [ContractClauseType.TRANSPORT]: {
+    0: {
+      name: 'None',
+      description: 'Unit provides own transport',
+    },
+    1: {
+      name: 'Limited',
+      description: 'Employer provides limited transport for personnel',
+    },
+    2: {
+      name: 'Partial',
+      description: 'Employer provides transport for personnel and light equipment',
+    },
+    3: {
+      name: 'Full',
+      description: 'Employer provides full transport for all personnel and equipment',
+    },
+  },
+};
+
+// =============================================================================
+// Type Guards
+// =============================================================================
+
+/**
+ * Type guard to check if a value is an AtBContractType.
+ *
+ * @param value - The value to check
+ * @returns true if the value is a valid AtBContractType
+ *
+ * @example
+ * if (isAtBContractType(value)) {
+ *   // value is AtBContractType
+ * }
+ */
+export function isAtBContractType(value: unknown): value is AtBContractType {
+  return Object.values(AtBContractType).includes(value as AtBContractType);
+}
+
+/**
+ * Type guard to check if a value is a ContractClauseType.
+ *
+ * @param value - The value to check
+ * @returns true if the value is a valid ContractClauseType
+ *
+ * @example
+ * if (isContractClauseType(value)) {
+ *   // value is ContractClauseType
+ * }
+ */
+export function isContractClauseType(
+  value: unknown
+): value is ContractClauseType {
+  return Object.values(ContractClauseType).includes(value as ContractClauseType);
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Gets all contract types in a specific group.
+ *
+ * @param group - The contract group to filter by
+ * @returns Array of contract types in the group
+ *
+ * @example
+ * const garrisonTypes = getContractTypesByGroup('garrison');
+ * // Returns: [GARRISON_DUTY, CADRE_DUTY, SECURITY_DUTY, RIOT_DUTY, RETAINER]
+ */
+export function getContractTypesByGroup(group: ContractGroup): AtBContractType[] {
+  return Object.entries(CONTRACT_TYPE_DEFINITIONS)
+    .filter(([_, def]) => def.group === group)
+    .map(([type]) => type as AtBContractType);
+}
+
+/**
+ * Gets the operational tempo range for a contract type.
+ *
+ * @param contractType - The contract type
+ * @returns The ops tempo range (min and max multipliers)
+ *
+ * @example
+ * const tempo = getOpsTempo(AtBContractType.GARRISON_DUTY);
+ * // Returns: { min: 1.0, max: 1.0 }
+ */
+export function getOpsTempo(
+  contractType: AtBContractType
+): { min: number; max: number } {
+  const def = CONTRACT_TYPE_DEFINITIONS[contractType];
+  return def.opsTempo;
+}
+
+/**
+ * Gets the contract duration in months for a contract type.
+ *
+ * @param contractType - The contract type
+ * @returns Duration in months
+ *
+ * @example
+ * const duration = getContractDuration(AtBContractType.GARRISON_DUTY);
+ * // Returns: 18
+ */
+export function getContractDuration(contractType: AtBContractType): number {
+  return CONTRACT_TYPE_DEFINITIONS[contractType].durationMonths;
+}
+
+/**
+ * Gets all available contract types.
+ *
+ * @returns Array of available contract types
+ *
+ * @example
+ * const available = getAvailableContractTypes();
+ */
+export function getAvailableContractTypes(): AtBContractType[] {
+  return Object.entries(CONTRACT_TYPE_DEFINITIONS)
+    .filter(([_, def]) => def.available)
+    .map(([type]) => type as AtBContractType);
+}


### PR DESCRIPTION
## Summary
- Expands contract system from 5 hardcoded types to 19 MekHQ Against the Bot (AtB) contract types
- Adds variable contract length calculation using MekHQ formula
- Adds 4-clause negotiation system (Command, Salvage, Support, Transport) with 2d6 + skill + standing rolls
- Adds 10 monthly contract event types with morale/parts/scenario/payment effects
- Expands contract market with weighted group selection and ops tempo payment scaling

## Changes
### New Files
- `src/types/campaign/contracts/contractTypes.ts` — 19-type enum, definitions, clause system
- `src/lib/campaign/contracts/contractLength.ts` — Variable duration formula
- `src/lib/campaign/contracts/contractNegotiation.ts` — 2d6 clause negotiation
- `src/lib/campaign/contracts/contractEvents.ts` — 10 event types, 6 betrayal sub-types

### Modified Files
- `src/types/campaign/Mission.ts` — Added optional `atbContractType` field to IContract
- `src/lib/campaign/contractMarket.ts` — Added `generateAtBContracts`, `selectAtBContractType`, group weights

### Tests
- 196 new tests across 5 test files, all passing
- All existing contract market tests preserved and passing
- Task 12.6 (UI) deferred per convention

## OpenSpec
Change ID: `add-contract-types` (PR #193 merged)