### PR TITLE
feat(campaign): add awards auto-granting system

### DIFF
--- a/src/lib/campaign/awards/__tests__/autoAwardEngine.test.ts
+++ b/src/lib/campaign/awards/__tests__/autoAwardEngine.test.ts
@@ -1,0 +1,680 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { ICampaign, createDefaultCampaignOptions } from '@/types/campaign/Campaign';
+import { IPerson } from '@/types/campaign/Person';
+import { PersonnelStatus } from '@/types/campaign/enums/PersonnelStatus';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
+import {
+  AutoAwardCategory,
+  createDefaultAutoAwardConfig,
+} from '@/types/campaign/awards/autoAwardTypes';
+import { Money } from '@/types/campaign/Money';
+import { processAutoAwards, getEligiblePersonnel } from '../autoAwardEngine';
+
+function createTestCampaign(overrides?: Partial<ICampaign>): ICampaign {
+  const options = {
+    ...createDefaultCampaignOptions(),
+    autoAwardConfig: createDefaultAutoAwardConfig(),
+  };
+
+  return {
+    id: 'campaign-test',
+    name: 'Test Campaign',
+    currentDate: new Date('3025-06-15'),
+    factionId: 'mercenary',
+    personnel: new Map(),
+    forces: new Map(),
+    rootForceId: 'root',
+    missions: new Map(),
+    finances: { transactions: [], balance: new Money(0) },
+    factionStandings: {},
+    options,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function createTestPerson(overrides?: Partial<IPerson>): IPerson {
+  return {
+    id: 'person-test',
+    name: 'Test Pilot',
+    status: PersonnelStatus.ACTIVE,
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rank: 'MechWarrior',
+    recruitmentDate: new Date('3020-01-01'),
+    missionsCompleted: 0,
+    totalKills: 0,
+    xp: 0,
+    totalXpEarned: 0,
+    xpSpent: 0,
+    hits: 0,
+    injuries: [],
+    daysToWaitForHealing: 0,
+    skills: {},
+    attributes: {
+      STR: 5,
+      BOD: 5,
+      REF: 5,
+      DEX: 5,
+      INT: 5,
+      WIL: 5,
+      CHA: 5,
+      Edge: 0,
+    },
+    pilotSkills: { gunnery: 4, piloting: 5 },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('autoAwardEngine', () => {
+  let campaign: ICampaign;
+
+  beforeEach(() => {
+    campaign = createTestCampaign();
+  });
+
+  describe('processAutoAwards', () => {
+    it('returns empty array when autoAwardConfig is undefined', () => {
+      const campaignNoConfig = createTestCampaign({
+        options: { ...campaign.options, autoAwardConfig: undefined },
+      });
+      const person = createTestPerson({ totalKills: 10 });
+      campaignNoConfig.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaignNoConfig, 'manual');
+
+      expect(events).toEqual([]);
+    });
+
+    it('returns empty array when enableAutoAwards is false', () => {
+      const config = { ...createDefaultAutoAwardConfig(), enableAutoAwards: false };
+      const campaignWithConfig = createTestCampaign({
+        options: { ...campaign.options, autoAwardConfig: config },
+      });
+
+      const person = createTestPerson({ totalKills: 10 });
+      campaignWithConfig.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaignWithConfig, 'manual');
+
+      expect(events).toEqual([]);
+    });
+
+    it('returns empty array when personnel map is empty', () => {
+      const events = processAutoAwards(campaign, 'manual');
+
+      expect(events).toEqual([]);
+    });
+
+    it('grants kill award when person has enough kills', () => {
+      const person = createTestPerson({ totalKills: 10 });
+      campaign.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaign, 'manual');
+
+      const killEvents = events.filter(e => e.category === AutoAwardCategory.KILL);
+      expect(killEvents.length).toBeGreaterThan(0);
+      expect(killEvents.some(e => e.awardId === 'double-ace')).toBe(true);
+    });
+
+    it('does NOT grant kill award when kills below threshold', () => {
+      const person = createTestPerson({ totalKills: 2 });
+      campaign.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaign, 'manual');
+
+      const killEvents = events.filter(e => e.category === AutoAwardCategory.KILL);
+      expect(killEvents.some(e => e.awardId === 'double-ace')).toBe(false);
+    });
+
+    it('only checks enabled categories', () => {
+      const baseConfig = createDefaultAutoAwardConfig();
+      const config = {
+        ...baseConfig,
+        enabledCategories: { ...baseConfig.enabledCategories, [AutoAwardCategory.KILL]: false },
+      };
+      const campaignWithConfig = createTestCampaign({
+        options: { ...campaign.options, autoAwardConfig: config },
+      });
+
+      const person = createTestPerson({ totalKills: 10 });
+      campaignWithConfig.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaignWithConfig, 'manual');
+
+      const killEvents = events.filter(e => e.category === AutoAwardCategory.KILL);
+      expect(killEvents).toEqual([]);
+    });
+
+    it('bestAwardOnly=true returns only highest threshold award', () => {
+      const config = { ...createDefaultAutoAwardConfig(), bestAwardOnly: true };
+      const campaignWithConfig = createTestCampaign({
+        options: { ...campaign.options, autoAwardConfig: config },
+      });
+
+      const person = createTestPerson({ totalKills: 25 });
+      campaignWithConfig.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaignWithConfig, 'manual');
+
+      const killEvents = events.filter(e => e.category === AutoAwardCategory.KILL);
+      expect(killEvents.length).toBe(1);
+      expect(killEvents[0].awardId).toBe('legend');
+    });
+
+    it('bestAwardOnly=false returns all qualifying awards', () => {
+      const config = { ...createDefaultAutoAwardConfig(), bestAwardOnly: false };
+      const campaignWithConfig = createTestCampaign({
+        options: { ...campaign.options, autoAwardConfig: config },
+      });
+
+      const person = createTestPerson({ totalKills: 25 });
+      campaignWithConfig.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaignWithConfig, 'manual');
+
+      const killEvents = events.filter(e => e.category === AutoAwardCategory.KILL);
+      expect(killEvents.length).toBeGreaterThan(1);
+      expect(killEvents.map(e => e.awardId)).toContain('first-blood');
+      expect(killEvents.map(e => e.awardId)).toContain('legend');
+    });
+
+    it('non-stackable awards NOT re-granted', () => {
+      const config = createDefaultAutoAwardConfig();
+      const campaignWithConfig = createTestCampaign({
+        options: { ...campaign.options, autoAwardConfig: config },
+      });
+
+      const person = createTestPerson({
+        totalKills: 10,
+        awards: ['double-ace'],
+      });
+      campaignWithConfig.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaignWithConfig, 'manual');
+
+      const doubleAceEvents = events.filter(e => e.awardId === 'double-ace');
+      expect(doubleAceEvents).toEqual([]);
+    });
+
+    it('stackable awards CAN be re-granted', () => {
+      const config = createDefaultAutoAwardConfig();
+      const campaignWithConfig = createTestCampaign({
+        options: { ...campaign.options, autoAwardConfig: config },
+      });
+
+      const person = createTestPerson({
+        totalKills: 10,
+        awards: [],
+      });
+      campaignWithConfig.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaignWithConfig, 'manual');
+
+      const killEvents = events.filter(e => e.category === AutoAwardCategory.KILL);
+      expect(killEvents.length).toBeGreaterThan(0);
+    });
+
+    it('dead personnel excluded when enablePosthumous=false', () => {
+      const config = { ...createDefaultAutoAwardConfig(), enablePosthumous: false };
+      const campaignWithConfig = createTestCampaign({
+        options: { ...campaign.options, autoAwardConfig: config },
+      });
+
+      const person = createTestPerson({
+        status: PersonnelStatus.KIA,
+        totalKills: 10,
+      });
+      campaignWithConfig.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaignWithConfig, 'manual');
+
+      expect(events).toEqual([]);
+    });
+
+    it('dead personnel included when enablePosthumous=true', () => {
+      const config = { ...createDefaultAutoAwardConfig(), enablePosthumous: true };
+      const campaignWithConfig = createTestCampaign({
+        options: { ...campaign.options, autoAwardConfig: config },
+      });
+
+      const person = createTestPerson({
+        status: PersonnelStatus.KIA,
+        totalKills: 10,
+      });
+      campaignWithConfig.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaignWithConfig, 'manual');
+
+      expect(events.length).toBeGreaterThan(0);
+    });
+
+    it('civilians excluded', () => {
+      const person = createTestPerson({
+        primaryRole: CampaignPersonnelRole.DEPENDENT,
+        totalKills: 10,
+      });
+      campaign.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaign, 'manual');
+
+      expect(events).toEqual([]);
+    });
+
+    it('multiple personnel processed', () => {
+      const person1 = createTestPerson({
+        id: 'person-1',
+        totalKills: 10,
+      });
+      const person2 = createTestPerson({
+        id: 'person-2',
+        totalKills: 5,
+      });
+      campaign.personnel.set(person1.id, person1);
+      campaign.personnel.set(person2.id, person2);
+
+      const events = processAutoAwards(campaign, 'manual');
+
+      const person1Events = events.filter(e => e.personId === 'person-1');
+      const person2Events = events.filter(e => e.personId === 'person-2');
+
+      expect(person1Events.length).toBeGreaterThan(0);
+      expect(person2Events.length).toBeGreaterThan(0);
+    });
+
+    it('includes trigger type in grant events', () => {
+      const person = createTestPerson({ totalKills: 10 });
+      campaign.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaign, 'post_mission');
+
+      expect(events.length).toBeGreaterThan(0);
+      expect(events.every(e => e.trigger === 'post_mission')).toBe(true);
+    });
+
+    it('includes timestamp in grant events', () => {
+      const person = createTestPerson({ totalKills: 10 });
+      campaign.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaign, 'manual');
+
+      expect(events.length).toBeGreaterThan(0);
+      expect(events.every(e => typeof e.timestamp === 'string')).toBe(true);
+      expect(events.every(e => e.timestamp.length > 0)).toBe(true);
+    });
+
+    it('includes award name in grant events', () => {
+      const person = createTestPerson({ totalKills: 10 });
+      campaign.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaign, 'manual');
+
+      expect(events.length).toBeGreaterThan(0);
+      expect(events.every(e => typeof e.awardName === 'string')).toBe(true);
+      expect(events.every(e => e.awardName.length > 0)).toBe(true);
+    });
+
+    it('grants scenario awards for missions completed', () => {
+      const person = createTestPerson({ missionsCompleted: 10 });
+      campaign.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaign, 'manual');
+
+      const scenarioEvents = events.filter(e => e.category === AutoAwardCategory.SCENARIO);
+      expect(scenarioEvents.length).toBeGreaterThan(0);
+    });
+
+    it('grants time awards based on recruitment date', () => {
+      const person = createTestPerson({
+        recruitmentDate: new Date('3020-01-01'),
+      });
+      campaign.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaign, 'manual');
+
+      const timeEvents = events.filter(e => e.category === AutoAwardCategory.TIME);
+      expect(timeEvents.length).toBeGreaterThan(0);
+    });
+
+    it('grants injury awards based on injury count', () => {
+      const person = createTestPerson({
+        injuries: [
+          {
+            id: 'inj-1',
+            type: 'Broken Arm',
+            location: 'Left Arm',
+            severity: 2,
+            daysToHeal: 14,
+            permanent: false,
+            acquired: new Date(),
+          },
+          {
+            id: 'inj-2',
+            type: 'Concussion',
+            location: 'Head',
+            severity: 1,
+            daysToHeal: 7,
+            permanent: false,
+            acquired: new Date(),
+          },
+          {
+            id: 'inj-3',
+            type: 'Burn',
+            location: 'Torso',
+            severity: 2,
+            daysToHeal: 21,
+            permanent: false,
+            acquired: new Date(),
+          },
+        ],
+      });
+      campaign.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaign, 'manual');
+
+      const injuryEvents = events.filter(e => e.category === AutoAwardCategory.INJURY);
+      expect(injuryEvents.length).toBeGreaterThan(0);
+    });
+
+    it('grants skill awards based on pilot skills', () => {
+      const person = createTestPerson({
+        pilotSkills: { gunnery: 2, piloting: 3 },
+      });
+      campaign.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaign, 'manual');
+
+      const skillEvents = events.filter(e => e.category === AutoAwardCategory.SKILL);
+      expect(skillEvents.length).toBeGreaterThan(0);
+    });
+
+    it('grants rank awards based on rank level', () => {
+      const person = createTestPerson({
+        rank: 'Captain',
+        rankLevel: 3,
+      });
+      campaign.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaign, 'manual');
+
+      const rankEvents = events.filter(e => e.category === AutoAwardCategory.RANK);
+      expect(rankEvents.length).toBeGreaterThan(0);
+    });
+
+    it('handles multiple triggers correctly', () => {
+      const person = createTestPerson({ totalKills: 10 });
+      campaign.personnel.set(person.id, person);
+
+      const manualEvents = processAutoAwards(campaign, 'manual');
+      const monthlyEvents = processAutoAwards(campaign, 'monthly');
+      const postMissionEvents = processAutoAwards(campaign, 'post_mission');
+
+      expect(manualEvents.every(e => e.trigger === 'manual')).toBe(true);
+      expect(monthlyEvents.every(e => e.trigger === 'monthly')).toBe(true);
+      expect(postMissionEvents.every(e => e.trigger === 'post_mission')).toBe(true);
+    });
+
+    it('handles currentDate as Date object', () => {
+      const campaignWithDate = createTestCampaign({
+        currentDate: new Date('3025-06-15'),
+      });
+      const person = createTestPerson({ totalKills: 10 });
+      campaignWithDate.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaignWithDate, 'manual');
+
+      expect(events.length).toBeGreaterThan(0);
+      expect(events.every(e => typeof e.timestamp === 'string')).toBe(true);
+    });
+
+    it('handles currentDate as Date object', () => {
+      const campaignWithDate = createTestCampaign({
+        currentDate: new Date('3025-06-15'),
+      });
+      const person = createTestPerson({ totalKills: 10 });
+      campaignWithDate.personnel.set(person.id, person);
+
+      const events = processAutoAwards(campaignWithDate, 'manual');
+
+      expect(events.length).toBeGreaterThan(0);
+      expect(events.every(e => typeof e.timestamp === 'string')).toBe(true);
+    });
+
+    it('grants awards to support roles (they are not civilians)', () => {
+      const testCampaign = createTestCampaign();
+      const person = createTestPerson({
+        primaryRole: CampaignPersonnelRole.TECH,
+        totalKills: 10,
+      });
+      testCampaign.personnel.set(person.id, person);
+
+      const eligible = getEligiblePersonnel(testCampaign, testCampaign.options.autoAwardConfig!);
+
+      expect(eligible.map(p => p.id)).toContain(person.id);
+    });
+
+    it('grants awards to combat roles', () => {
+      const testCampaign = createTestCampaign();
+      const person = createTestPerson({
+        primaryRole: CampaignPersonnelRole.PILOT,
+        totalKills: 10,
+      });
+      testCampaign.personnel.set(person.id, person);
+
+      const events = processAutoAwards(testCampaign, 'manual');
+
+      expect(events.length).toBeGreaterThan(0);
+    });
+
+    it('grants awards to aerospace pilots', () => {
+      const testCampaign = createTestCampaign();
+      const person = createTestPerson({
+        primaryRole: CampaignPersonnelRole.AEROSPACE_PILOT,
+        totalKills: 10,
+      });
+      testCampaign.personnel.set(person.id, person);
+
+      const events = processAutoAwards(testCampaign, 'manual');
+
+      expect(events.length).toBeGreaterThan(0);
+    });
+
+    it('grants awards to vehicle drivers', () => {
+      const testCampaign = createTestCampaign();
+      const person = createTestPerson({
+        primaryRole: CampaignPersonnelRole.VEHICLE_DRIVER,
+        totalKills: 10,
+      });
+      testCampaign.personnel.set(person.id, person);
+
+      const events = processAutoAwards(testCampaign, 'manual');
+
+      expect(events.length).toBeGreaterThan(0);
+    });
+
+    it('grants awards to doctors (they are not civilians)', () => {
+      const testCampaign = createTestCampaign();
+      const person = createTestPerson({
+        primaryRole: CampaignPersonnelRole.DOCTOR,
+        totalKills: 10,
+      });
+      testCampaign.personnel.set(person.id, person);
+
+      const eligible = getEligiblePersonnel(testCampaign, testCampaign.options.autoAwardConfig!);
+
+      expect(eligible.map(p => p.id)).toContain(person.id);
+    });
+
+    it('grants awards to admin staff (they are not civilians)', () => {
+      const testCampaign = createTestCampaign();
+      const person = createTestPerson({
+        primaryRole: CampaignPersonnelRole.ADMIN_COMMAND,
+        totalKills: 10,
+      });
+      testCampaign.personnel.set(person.id, person);
+
+      const eligible = getEligiblePersonnel(testCampaign, testCampaign.options.autoAwardConfig!);
+
+      expect(eligible.map(p => p.id)).toContain(person.id);
+    });
+  });
+
+  describe('getEligiblePersonnel', () => {
+    it('filters correctly', () => {
+      const config = { ...createDefaultAutoAwardConfig(), enablePosthumous: false };
+
+      const activePilot = createTestPerson({
+        id: 'active-pilot',
+        status: PersonnelStatus.ACTIVE,
+        primaryRole: CampaignPersonnelRole.PILOT,
+      });
+      const kiaPilot = createTestPerson({
+        id: 'kia-pilot',
+        status: PersonnelStatus.KIA,
+        primaryRole: CampaignPersonnelRole.PILOT,
+      });
+      const civilian = createTestPerson({
+        id: 'civilian',
+        status: PersonnelStatus.ACTIVE,
+        primaryRole: CampaignPersonnelRole.DEPENDENT,
+      });
+
+      campaign.personnel.set(activePilot.id, activePilot);
+      campaign.personnel.set(kiaPilot.id, kiaPilot);
+      campaign.personnel.set(civilian.id, civilian);
+
+      const eligible = getEligiblePersonnel(campaign, config);
+
+      expect(eligible.map(p => p.id)).toContain('active-pilot');
+      expect(eligible.map(p => p.id)).not.toContain('civilian');
+      expect(eligible.map(p => p.id)).not.toContain('kia-pilot');
+    });
+
+    it('includes dead personnel when enablePosthumous=true', () => {
+      const config = { ...createDefaultAutoAwardConfig(), enablePosthumous: true };
+
+      const kiaPilot = createTestPerson({
+        id: 'kia-pilot',
+        status: PersonnelStatus.KIA,
+        primaryRole: CampaignPersonnelRole.PILOT,
+      });
+
+      campaign.personnel.set(kiaPilot.id, kiaPilot);
+
+      const eligible = getEligiblePersonnel(campaign, config);
+
+      expect(eligible.map(p => p.id)).toContain('kia-pilot');
+    });
+
+    it('excludes dead personnel when enablePosthumous=false', () => {
+      const config = { ...createDefaultAutoAwardConfig(), enablePosthumous: false };
+
+      const kiaPilot = createTestPerson({
+        id: 'kia-pilot',
+        status: PersonnelStatus.KIA,
+        primaryRole: CampaignPersonnelRole.PILOT,
+      });
+
+      campaign.personnel.set(kiaPilot.id, kiaPilot);
+
+      const eligible = getEligiblePersonnel(campaign, config);
+
+      expect(eligible.map(p => p.id)).not.toContain('kia-pilot');
+    });
+
+    it('excludes all civilian roles', () => {
+      const config = createDefaultAutoAwardConfig();
+
+      const civilianRoles = [
+        CampaignPersonnelRole.DEPENDENT,
+        CampaignPersonnelRole.CIVILIAN_OTHER,
+        CampaignPersonnelRole.MERCHANT,
+        CampaignPersonnelRole.TEACHER,
+      ];
+
+      civilianRoles.forEach((role, index) => {
+        const person = createTestPerson({
+          id: `civilian-${index}`,
+          primaryRole: role,
+        });
+        campaign.personnel.set(person.id, person);
+      });
+
+      const eligible = getEligiblePersonnel(campaign, config);
+
+      expect(eligible).toEqual([]);
+    });
+
+    it('includes all combat roles', () => {
+      const config = createDefaultAutoAwardConfig();
+
+      const combatRoles = [
+        CampaignPersonnelRole.PILOT,
+        CampaignPersonnelRole.AEROSPACE_PILOT,
+        CampaignPersonnelRole.VEHICLE_DRIVER,
+        CampaignPersonnelRole.SOLDIER,
+      ];
+
+      combatRoles.forEach((role, index) => {
+        const person = createTestPerson({
+          id: `combat-${index}`,
+          primaryRole: role,
+        });
+        campaign.personnel.set(person.id, person);
+      });
+
+      const eligible = getEligiblePersonnel(campaign, config);
+
+      expect(eligible.length).toBe(combatRoles.length);
+    });
+
+    it('includes all support roles (they are not civilians)', () => {
+      const testCampaign = createTestCampaign();
+      const config = createDefaultAutoAwardConfig();
+
+      const supportRoles = [
+        CampaignPersonnelRole.TECH,
+        CampaignPersonnelRole.DOCTOR,
+        CampaignPersonnelRole.MEDIC,
+        CampaignPersonnelRole.ADMIN_COMMAND,
+      ];
+
+      supportRoles.forEach((role, index) => {
+        const person = createTestPerson({
+          id: `support-${index}`,
+          primaryRole: role,
+        });
+        testCampaign.personnel.set(person.id, person);
+      });
+
+      const eligible = getEligiblePersonnel(testCampaign, config);
+
+      expect(eligible.length).toBe(supportRoles.length);
+    });
+
+    it('excludes non-active personnel', () => {
+      const config = createDefaultAutoAwardConfig();
+
+      const statuses = [
+        PersonnelStatus.WOUNDED,
+        PersonnelStatus.ON_LEAVE,
+        PersonnelStatus.RETIRED,
+      ];
+
+      statuses.forEach((status, index) => {
+        const person = createTestPerson({
+          id: `person-${index}`,
+          status,
+          primaryRole: CampaignPersonnelRole.PILOT,
+        });
+        campaign.personnel.set(person.id, person);
+      });
+
+      const eligible = getEligiblePersonnel(campaign, config);
+
+      expect(eligible).toEqual([]);
+    });
+  });
+});

--- a/src/lib/campaign/awards/__tests__/categoryCheckers.test.ts
+++ b/src/lib/campaign/awards/__tests__/categoryCheckers.test.ts
@@ -1,0 +1,676 @@
+import {
+  checkKillAwards,
+  checkScenarioAwards,
+  checkTimeAwards,
+  checkSkillAwards,
+  checkRankAwards,
+  checkInjuryAwards,
+  checkContractAwards,
+  checkFactionHunterAwards,
+  checkTheatreOfWarAwards,
+  checkTrainingAwards,
+  checkScenarioKillAwards,
+  checkMiscAwards,
+  checkCombatAwards,
+  checkSurvivalAwards,
+  checkServiceAwards,
+  checkCampaignAwards,
+  checkSpecialAwards,
+  checkAwardsForCategory,
+  ICheckerContext,
+} from '../categoryCheckers';
+import { AutoAwardCategory } from '@/types/campaign/awards/autoAwardTypes';
+import { IAward, AwardCategory, AwardRarity, CriteriaType } from '@/types/award/AwardInterfaces';
+import { IPerson } from '@/types/campaign/Person';
+import { PersonnelStatus, CampaignPersonnelRole } from '@/types/campaign/enums';
+
+function createMockPerson(overrides?: Partial<IPerson>): IPerson {
+  return {
+    id: 'person-001',
+    name: 'Test Pilot',
+    status: PersonnelStatus.ACTIVE,
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rank: 'MechWarrior',
+    rankLevel: 0,
+    recruitmentDate: new Date('3020-01-01'),
+    missionsCompleted: 0,
+    totalKills: 0,
+    xp: 0,
+    totalXpEarned: 0,
+    xpSpent: 0,
+    hits: 0,
+    injuries: [],
+    daysToWaitForHealing: 0,
+    skills: {},
+    attributes: {
+      STR: 5,
+      BOD: 5,
+      REF: 5,
+      DEX: 5,
+      INT: 5,
+      WIL: 5,
+      CHA: 5,
+      Edge: 0,
+    },
+    pilotSkills: {
+      gunnery: 4,
+      piloting: 5,
+    },
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function createMockAward(
+  category: AutoAwardCategory,
+  threshold: number,
+  thresholdType: string,
+  overrides?: Partial<IAward>
+): IAward {
+  return {
+    id: `award-${category}-${threshold}`,
+    name: `Test ${category} Award`,
+    description: `Test award for ${category}`,
+    category: AwardCategory.Combat,
+    rarity: AwardRarity.Common,
+    icon: 'test-icon',
+    criteria: {
+      type: CriteriaType.TotalKills,
+      threshold,
+      description: `Test criteria for ${category}`,
+    },
+    repeatable: false,
+    sortOrder: 0,
+    autoGrantCriteria: {
+      category,
+      threshold,
+      thresholdType,
+      stackable: false,
+    },
+    ...overrides,
+  };
+}
+
+describe('categoryCheckers', () => {
+  describe('checkKillAwards', () => {
+    it('grants award when kills >= threshold', () => {
+      const person = createMockPerson({ totalKills: 10 });
+      const awards = [createMockAward(AutoAwardCategory.KILL, 5, 'kills')];
+
+      const result = checkKillAwards(person, awards);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('award-kill-5');
+    });
+
+    it('does not grant award when kills < threshold', () => {
+      const person = createMockPerson({ totalKills: 3 });
+      const awards = [createMockAward(AutoAwardCategory.KILL, 5, 'kills')];
+
+      const result = checkKillAwards(person, awards);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('grants multiple awards at different thresholds', () => {
+      const person = createMockPerson({ totalKills: 15 });
+      const awards = [
+        createMockAward(AutoAwardCategory.KILL, 5, 'kills'),
+        createMockAward(AutoAwardCategory.KILL, 10, 'kills'),
+        createMockAward(AutoAwardCategory.KILL, 20, 'kills'),
+      ];
+
+      const result = checkKillAwards(person, awards);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('ignores awards from other categories', () => {
+      const person = createMockPerson({ totalKills: 10 });
+      const awards = [
+        createMockAward(AutoAwardCategory.KILL, 5, 'kills'),
+        createMockAward(AutoAwardCategory.SCENARIO, 5, 'missions'),
+      ];
+
+      const result = checkKillAwards(person, awards);
+
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('checkScenarioAwards', () => {
+    it('grants award when missions >= threshold', () => {
+      const person = createMockPerson({ missionsCompleted: 20 });
+      const awards = [createMockAward(AutoAwardCategory.SCENARIO, 10, 'missions')];
+
+      const result = checkScenarioAwards(person, awards);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('does not grant award when missions < threshold', () => {
+      const person = createMockPerson({ missionsCompleted: 5 });
+      const awards = [createMockAward(AutoAwardCategory.SCENARIO, 10, 'missions')];
+
+      const result = checkScenarioAwards(person, awards);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('grants multiple scenario awards', () => {
+      const person = createMockPerson({ missionsCompleted: 30 });
+      const awards = [
+        createMockAward(AutoAwardCategory.SCENARIO, 10, 'missions'),
+        createMockAward(AutoAwardCategory.SCENARIO, 20, 'missions'),
+        createMockAward(AutoAwardCategory.SCENARIO, 40, 'missions'),
+      ];
+
+      const result = checkScenarioAwards(person, awards);
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('checkTimeAwards', () => {
+    it('grants award when years of service >= threshold', () => {
+      const person = createMockPerson({ recruitmentDate: new Date('3020-01-01') });
+      const context: ICheckerContext = { currentDate: '3025-06-15' };
+      const awards = [createMockAward(AutoAwardCategory.TIME, 5, 'years')];
+
+      const result = checkTimeAwards(person, awards, context);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('does not grant award when service < threshold', () => {
+      const person = createMockPerson({ recruitmentDate: new Date('3024-01-01') });
+      const context: ICheckerContext = { currentDate: '3025-06-15' };
+      const awards = [createMockAward(AutoAwardCategory.TIME, 5, 'years')];
+
+      const result = checkTimeAwards(person, awards, context);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('calculates years correctly with fractional years', () => {
+      const person = createMockPerson({ recruitmentDate: new Date('3020-01-01') });
+      const context: ICheckerContext = { currentDate: '3025-06-15' };
+      const awards = [
+        createMockAward(AutoAwardCategory.TIME, 5, 'years'),
+        createMockAward(AutoAwardCategory.TIME, 6, 'years'),
+      ];
+
+      const result = checkTimeAwards(person, awards, context);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('handles recruitment date as string', () => {
+      const person = createMockPerson({ recruitmentDate: new Date('3020-01-01') });
+      const context: ICheckerContext = { currentDate: '3025-06-15' };
+      const awards = [createMockAward(AutoAwardCategory.TIME, 5, 'years')];
+
+      const result = checkTimeAwards(person, awards, context);
+
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('checkSkillAwards', () => {
+    it('grants gunnery award when gunnery <= threshold', () => {
+      const person = createMockPerson({ pilotSkills: { gunnery: 3, piloting: 5 } });
+      const awards = [
+        createMockAward(AutoAwardCategory.SKILL, 4, 'skill_level', {
+          autoGrantCriteria: {
+            category: AutoAwardCategory.SKILL,
+            threshold: 4,
+            thresholdType: 'skill_level',
+            stackable: false,
+            skillId: 'gunnery',
+          },
+        }),
+      ];
+
+      const result = checkSkillAwards(person, awards);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('does not grant gunnery award when gunnery > threshold', () => {
+      const person = createMockPerson({ pilotSkills: { gunnery: 5, piloting: 5 } });
+      const awards = [
+        createMockAward(AutoAwardCategory.SKILL, 4, 'skill_level', {
+          autoGrantCriteria: {
+            category: AutoAwardCategory.SKILL,
+            threshold: 4,
+            thresholdType: 'skill_level',
+            stackable: false,
+            skillId: 'gunnery',
+          },
+        }),
+      ];
+
+      const result = checkSkillAwards(person, awards);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('grants piloting award when piloting <= threshold', () => {
+      const person = createMockPerson({ pilotSkills: { gunnery: 4, piloting: 3 } });
+      const awards = [
+        createMockAward(AutoAwardCategory.SKILL, 4, 'skill_level', {
+          autoGrantCriteria: {
+            category: AutoAwardCategory.SKILL,
+            threshold: 4,
+            thresholdType: 'skill_level',
+            stackable: false,
+            skillId: 'piloting',
+          },
+        }),
+      ];
+
+      const result = checkSkillAwards(person, awards);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('grants generic skill award when best skill <= threshold', () => {
+      const person = createMockPerson({ pilotSkills: { gunnery: 3, piloting: 5 } });
+      const awards = [createMockAward(AutoAwardCategory.SKILL, 4, 'skill_level')];
+
+      const result = checkSkillAwards(person, awards);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('does not grant generic skill award when best skill > threshold', () => {
+      const person = createMockPerson({ pilotSkills: { gunnery: 5, piloting: 6 } });
+      const awards = [createMockAward(AutoAwardCategory.SKILL, 4, 'skill_level')];
+
+      const result = checkSkillAwards(person, awards);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('checkRankAwards', () => {
+    it('grants award in inclusive mode when rankLevel >= threshold', () => {
+      const person = createMockPerson({ rankLevel: 5 });
+      const awards = [
+        createMockAward(AutoAwardCategory.RANK, 3, 'rank_level', {
+          autoGrantCriteria: {
+            category: AutoAwardCategory.RANK,
+            threshold: 3,
+            thresholdType: 'rank_level',
+            stackable: false,
+            rankMode: 'inclusive',
+          },
+        }),
+      ];
+
+      const result = checkRankAwards(person, awards);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('does not grant award in inclusive mode when rankLevel < threshold', () => {
+      const person = createMockPerson({ rankLevel: 2 });
+      const awards = [
+        createMockAward(AutoAwardCategory.RANK, 3, 'rank_level', {
+          autoGrantCriteria: {
+            category: AutoAwardCategory.RANK,
+            threshold: 3,
+            thresholdType: 'rank_level',
+            stackable: false,
+            rankMode: 'inclusive',
+          },
+        }),
+      ];
+
+      const result = checkRankAwards(person, awards);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('grants award in exclusive mode only when rankLevel > threshold', () => {
+      const person = createMockPerson({ rankLevel: 4 });
+      const awards = [
+        createMockAward(AutoAwardCategory.RANK, 3, 'rank_level', {
+          autoGrantCriteria: {
+            category: AutoAwardCategory.RANK,
+            threshold: 3,
+            thresholdType: 'rank_level',
+            stackable: false,
+            rankMode: 'exclusive',
+          },
+        }),
+      ];
+
+      const result = checkRankAwards(person, awards);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('does not grant award in exclusive mode when rankLevel <= threshold', () => {
+      const person = createMockPerson({ rankLevel: 3 });
+      const awards = [
+        createMockAward(AutoAwardCategory.RANK, 3, 'rank_level', {
+          autoGrantCriteria: {
+            category: AutoAwardCategory.RANK,
+            threshold: 3,
+            thresholdType: 'rank_level',
+            stackable: false,
+            rankMode: 'exclusive',
+          },
+        }),
+      ];
+
+      const result = checkRankAwards(person, awards);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('grants award in promotion mode only on exact match', () => {
+      const person = createMockPerson({ rankLevel: 3 });
+      const awards = [
+        createMockAward(AutoAwardCategory.RANK, 3, 'rank_level', {
+          autoGrantCriteria: {
+            category: AutoAwardCategory.RANK,
+            threshold: 3,
+            thresholdType: 'rank_level',
+            stackable: false,
+            rankMode: 'promotion',
+          },
+        }),
+      ];
+
+      const result = checkRankAwards(person, awards);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('does not grant award in promotion mode when rankLevel != threshold', () => {
+      const person = createMockPerson({ rankLevel: 4 });
+      const awards = [
+        createMockAward(AutoAwardCategory.RANK, 3, 'rank_level', {
+          autoGrantCriteria: {
+            category: AutoAwardCategory.RANK,
+            threshold: 3,
+            thresholdType: 'rank_level',
+            stackable: false,
+            rankMode: 'promotion',
+          },
+        }),
+      ];
+
+      const result = checkRankAwards(person, awards);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('defaults to inclusive mode when rankMode not specified', () => {
+      const person = createMockPerson({ rankLevel: 3 });
+      const awards = [
+        createMockAward(AutoAwardCategory.RANK, 3, 'rank_level', {
+          autoGrantCriteria: {
+            category: AutoAwardCategory.RANK,
+            threshold: 3,
+            thresholdType: 'rank_level',
+            stackable: false,
+          },
+        }),
+      ];
+
+      const result = checkRankAwards(person, awards);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('handles undefined rankLevel as 0', () => {
+      const person = createMockPerson({ rankLevel: undefined });
+      const awards = [
+        createMockAward(AutoAwardCategory.RANK, 1, 'rank_level', {
+          autoGrantCriteria: {
+            category: AutoAwardCategory.RANK,
+            threshold: 1,
+            thresholdType: 'rank_level',
+            stackable: false,
+            rankMode: 'inclusive',
+          },
+        }),
+      ];
+
+      const result = checkRankAwards(person, awards);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('checkInjuryAwards', () => {
+    it('grants award when injuries.length >= threshold', () => {
+      const person = createMockPerson({
+        injuries: [
+          { id: 'inj-1', type: 'Broken Arm', location: 'Left Arm', severity: 2, daysToHeal: 14, permanent: false, acquired: new Date() },
+          { id: 'inj-2', type: 'Burn', location: 'Torso', severity: 1, daysToHeal: 7, permanent: false, acquired: new Date() },
+        ],
+      });
+      const awards = [createMockAward(AutoAwardCategory.INJURY, 2, 'injuries')];
+
+      const result = checkInjuryAwards(person, awards);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('does not grant award when injuries.length < threshold', () => {
+      const person = createMockPerson({
+        injuries: [
+          { id: 'inj-1', type: 'Broken Arm', location: 'Left Arm', severity: 2, daysToHeal: 14, permanent: false, acquired: new Date() },
+        ],
+      });
+      const awards = [createMockAward(AutoAwardCategory.INJURY, 2, 'injuries')];
+
+      const result = checkInjuryAwards(person, awards);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('grants multiple injury awards at different thresholds', () => {
+      const person = createMockPerson({
+        injuries: [
+          { id: 'inj-1', type: 'Broken Arm', location: 'Left Arm', severity: 2, daysToHeal: 14, permanent: false, acquired: new Date() },
+          { id: 'inj-2', type: 'Burn', location: 'Torso', severity: 1, daysToHeal: 7, permanent: false, acquired: new Date() },
+          { id: 'inj-3', type: 'Concussion', location: 'Head', severity: 1, daysToHeal: 10, permanent: false, acquired: new Date() },
+        ],
+      });
+      const awards = [
+        createMockAward(AutoAwardCategory.INJURY, 1, 'injuries'),
+        createMockAward(AutoAwardCategory.INJURY, 2, 'injuries'),
+        createMockAward(AutoAwardCategory.INJURY, 4, 'injuries'),
+      ];
+
+      const result = checkInjuryAwards(person, awards);
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('stubbed categories', () => {
+    const person = createMockPerson();
+    const awards = [createMockAward(AutoAwardCategory.CONTRACT, 1, 'test')];
+
+    it('checkContractAwards returns empty array', () => {
+      expect(checkContractAwards(person, awards)).toEqual([]);
+    });
+
+    it('checkFactionHunterAwards returns empty array', () => {
+      expect(checkFactionHunterAwards(person, awards)).toEqual([]);
+    });
+
+    it('checkTheatreOfWarAwards returns empty array', () => {
+      expect(checkTheatreOfWarAwards(person, awards)).toEqual([]);
+    });
+
+    it('checkTrainingAwards returns empty array', () => {
+      expect(checkTrainingAwards(person, awards)).toEqual([]);
+    });
+
+    it('checkScenarioKillAwards returns empty array', () => {
+      expect(checkScenarioKillAwards(person, awards)).toEqual([]);
+    });
+
+    it('checkMiscAwards returns empty array', () => {
+      expect(checkMiscAwards(person, awards)).toEqual([]);
+    });
+
+    it('checkCombatAwards returns empty array', () => {
+      expect(checkCombatAwards(person, awards)).toEqual([]);
+    });
+
+    it('checkSurvivalAwards returns empty array', () => {
+      expect(checkSurvivalAwards(person, awards)).toEqual([]);
+    });
+
+    it('checkServiceAwards returns empty array', () => {
+      expect(checkServiceAwards(person, awards)).toEqual([]);
+    });
+
+    it('checkCampaignAwards returns empty array', () => {
+      expect(checkCampaignAwards(person, awards)).toEqual([]);
+    });
+
+    it('checkSpecialAwards returns empty array', () => {
+      expect(checkSpecialAwards(person, awards)).toEqual([]);
+    });
+  });
+
+  describe('checkAwardsForCategory dispatcher', () => {
+    it('routes KILL category to checkKillAwards', () => {
+      const person = createMockPerson({ totalKills: 10 });
+      const awards = [createMockAward(AutoAwardCategory.KILL, 5, 'kills')];
+      const context: ICheckerContext = { currentDate: '3025-01-01' };
+
+      const result = checkAwardsForCategory(AutoAwardCategory.KILL, person, awards, context);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('routes SCENARIO category to checkScenarioAwards', () => {
+      const person = createMockPerson({ missionsCompleted: 20 });
+      const awards = [createMockAward(AutoAwardCategory.SCENARIO, 10, 'missions')];
+      const context: ICheckerContext = { currentDate: '3025-01-01' };
+
+      const result = checkAwardsForCategory(AutoAwardCategory.SCENARIO, person, awards, context);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('routes TIME category to checkTimeAwards', () => {
+      const person = createMockPerson({ recruitmentDate: new Date('3020-01-01') });
+      const awards = [createMockAward(AutoAwardCategory.TIME, 5, 'years')];
+      const context: ICheckerContext = { currentDate: '3025-06-15' };
+
+      const result = checkAwardsForCategory(AutoAwardCategory.TIME, person, awards, context);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('routes SKILL category to checkSkillAwards', () => {
+      const person = createMockPerson({ pilotSkills: { gunnery: 3, piloting: 5 } });
+      const awards = [createMockAward(AutoAwardCategory.SKILL, 4, 'skill_level')];
+      const context: ICheckerContext = { currentDate: '3025-01-01' };
+
+      const result = checkAwardsForCategory(AutoAwardCategory.SKILL, person, awards, context);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('routes RANK category to checkRankAwards', () => {
+      const person = createMockPerson({ rankLevel: 5 });
+      const awards = [
+        createMockAward(AutoAwardCategory.RANK, 3, 'rank_level', {
+          autoGrantCriteria: {
+            category: AutoAwardCategory.RANK,
+            threshold: 3,
+            thresholdType: 'rank_level',
+            stackable: false,
+            rankMode: 'inclusive',
+          },
+        }),
+      ];
+      const context: ICheckerContext = { currentDate: '3025-01-01' };
+
+      const result = checkAwardsForCategory(AutoAwardCategory.RANK, person, awards, context);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('routes INJURY category to checkInjuryAwards', () => {
+      const person = createMockPerson({
+        injuries: [
+          { id: 'inj-1', type: 'Broken Arm', location: 'Left Arm', severity: 2, daysToHeal: 14, permanent: false, acquired: new Date() },
+        ],
+      });
+      const awards = [createMockAward(AutoAwardCategory.INJURY, 1, 'injuries')];
+      const context: ICheckerContext = { currentDate: '3025-01-01' };
+
+      const result = checkAwardsForCategory(AutoAwardCategory.INJURY, person, awards, context);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('routes stubbed categories to their respective functions', () => {
+      const person = createMockPerson();
+      const awards = [createMockAward(AutoAwardCategory.CONTRACT, 1, 'test')];
+      const context: ICheckerContext = { currentDate: '3025-01-01' };
+
+      expect(checkAwardsForCategory(AutoAwardCategory.CONTRACT, person, awards, context)).toEqual([]);
+      expect(checkAwardsForCategory(AutoAwardCategory.FACTION_HUNTER, person, awards, context)).toEqual([]);
+      expect(checkAwardsForCategory(AutoAwardCategory.THEATRE_OF_WAR, person, awards, context)).toEqual([]);
+      expect(checkAwardsForCategory(AutoAwardCategory.TRAINING, person, awards, context)).toEqual([]);
+      expect(checkAwardsForCategory(AutoAwardCategory.SCENARIO_KILL, person, awards, context)).toEqual([]);
+      expect(checkAwardsForCategory(AutoAwardCategory.MISC, person, awards, context)).toEqual([]);
+      expect(checkAwardsForCategory(AutoAwardCategory.COMBAT, person, awards, context)).toEqual([]);
+      expect(checkAwardsForCategory(AutoAwardCategory.SURVIVAL, person, awards, context)).toEqual([]);
+      expect(checkAwardsForCategory(AutoAwardCategory.SERVICE, person, awards, context)).toEqual([]);
+      expect(checkAwardsForCategory(AutoAwardCategory.CAMPAIGN, person, awards, context)).toEqual([]);
+      expect(checkAwardsForCategory(AutoAwardCategory.SPECIAL, person, awards, context)).toEqual([]);
+    });
+  });
+
+  describe('award filtering', () => {
+    it('ignores awards without autoGrantCriteria', () => {
+      const person = createMockPerson({ totalKills: 10 });
+      const awards = [
+        {
+          id: 'award-no-criteria',
+          name: 'Test Award',
+          description: 'Test',
+          category: AwardCategory.Combat,
+          rarity: AwardRarity.Common,
+          icon: 'test',
+          criteria: {
+            type: CriteriaType.TotalKills,
+            threshold: 5,
+            description: 'Test',
+          },
+          repeatable: false,
+          sortOrder: 0,
+        } as IAward,
+      ];
+
+      const result = checkKillAwards(person, awards);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('ignores awards with wrong category', () => {
+      const person = createMockPerson({ totalKills: 10 });
+      const awards = [createMockAward(AutoAwardCategory.SCENARIO, 5, 'missions')];
+
+      const result = checkKillAwards(person, awards);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/src/lib/campaign/awards/autoAwardEngine.ts
+++ b/src/lib/campaign/awards/autoAwardEngine.ts
@@ -1,0 +1,114 @@
+import { ICampaign } from '@/types/campaign/Campaign';
+import { IPerson } from '@/types/campaign/Person';
+import { PersonnelStatus } from '@/types/campaign/enums/PersonnelStatus';
+import { isCivilianRole } from '@/types/campaign/enums/CampaignPersonnelRole';
+import {
+  AutoAwardCategory,
+  AutoAwardTrigger,
+  IAutoAwardConfig,
+  IAwardGrantEvent,
+} from '@/types/campaign/awards/autoAwardTypes';
+import { IAward } from '@/types/award/AwardInterfaces';
+import { getAutoGrantableAwards } from '@/types/award/AwardCatalog';
+import { checkAwardsForCategory, ICheckerContext } from './categoryCheckers';
+
+// Dead statuses for posthumous check
+const DEAD_STATUSES = new Set<PersonnelStatus>([
+  PersonnelStatus.KIA,
+  PersonnelStatus.ACCIDENTAL_DEATH,
+  PersonnelStatus.DISEASE,
+  PersonnelStatus.NATURAL_CAUSES,
+  PersonnelStatus.MURDER,
+  PersonnelStatus.WOUNDS,
+  PersonnelStatus.MIA_PRESUMED_DEAD,
+  PersonnelStatus.OLD_AGE,
+  PersonnelStatus.PREGNANCY_COMPLICATIONS,
+  PersonnelStatus.UNDETERMINED,
+  PersonnelStatus.MEDICAL_COMPLICATIONS,
+  PersonnelStatus.SUICIDE,
+  PersonnelStatus.EXECUTION,
+  PersonnelStatus.MISSING_PRESUMED_DEAD,
+]);
+
+function isDead(status: PersonnelStatus): boolean {
+  return DEAD_STATUSES.has(status);
+}
+
+function personHasAward(person: IPerson, awardId: string): boolean {
+  return person.awards?.includes(awardId) ?? false;
+}
+
+function getBestAward(awards: IAward[]): IAward | undefined {
+  if (awards.length === 0) return undefined;
+  return awards.reduce((best, current) => {
+    const bestThreshold = best.autoGrantCriteria?.threshold ?? 0;
+    const currentThreshold = current.autoGrantCriteria?.threshold ?? 0;
+    return currentThreshold > bestThreshold ? current : best;
+  });
+}
+
+export function getEligiblePersonnel(campaign: ICampaign, config: IAutoAwardConfig): IPerson[] {
+  return Array.from(campaign.personnel.values()).filter(p => {
+    if (isDead(p.status)) return config.enablePosthumous;
+    return p.status === PersonnelStatus.ACTIVE && !isCivilianRole(p.primaryRole);
+  });
+}
+
+export function processAutoAwards(
+  campaign: ICampaign,
+  trigger: AutoAwardTrigger,
+  _context?: { missionId?: string; scenarioId?: string }
+): IAwardGrantEvent[] {
+  const config = campaign.options.autoAwardConfig;
+  if (!config?.enableAutoAwards) return [];
+
+  const allAwards = getAutoGrantableAwards();
+  const events: IAwardGrantEvent[] = [];
+  const checkerContext: ICheckerContext = {
+    currentDate: campaign.currentDate instanceof Date
+      ? campaign.currentDate.toISOString()
+      : String(campaign.currentDate),
+  };
+
+  for (const person of getEligiblePersonnel(campaign, config)) {
+    for (const category of Object.values(AutoAwardCategory)) {
+      if (!config.enabledCategories[category]) continue;
+
+      const categoryAwards = allAwards.filter(
+        a => a.autoGrantCriteria?.category === category
+      );
+
+      const qualifying = checkAwardsForCategory(
+        category,
+        person,
+        categoryAwards,
+        checkerContext
+      );
+
+      // Filter out already-earned non-stackable awards
+      const newAwards = qualifying.filter(award =>
+        award.autoGrantCriteria?.stackable || !personHasAward(person, award.id)
+      );
+
+      if (newAwards.length === 0) continue;
+
+      // Best award only: keep highest threshold per category
+      const toGrant = config.bestAwardOnly
+        ? [getBestAward(newAwards)].filter(Boolean) as IAward[]
+        : newAwards;
+
+      for (const award of toGrant) {
+        events.push({
+          personId: person.id,
+          awardId: award.id,
+          awardName: award.name,
+          category,
+          trigger,
+          timestamp: checkerContext.currentDate,
+        });
+      }
+    }
+  }
+
+  return events;
+}

--- a/src/lib/campaign/awards/categoryCheckers.ts
+++ b/src/lib/campaign/awards/categoryCheckers.ts
@@ -1,0 +1,174 @@
+import { AutoAwardCategory } from '@/types/campaign/awards/autoAwardTypes';
+import { IAward } from '@/types/award/AwardInterfaces';
+import { IPerson } from '@/types/campaign/Person';
+
+// =============================================================================
+// Checker Context
+// =============================================================================
+
+export interface ICheckerContext {
+  readonly currentDate: string;
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+function getAwardsForCategory(awards: readonly IAward[], category: AutoAwardCategory): IAward[] {
+  return awards.filter(a => a.autoGrantCriteria?.category === category);
+}
+
+// =============================================================================
+// Category Checkers
+// =============================================================================
+
+export function checkKillAwards(person: IPerson, awards: readonly IAward[]): IAward[] {
+  return getAwardsForCategory(awards, AutoAwardCategory.KILL)
+    .filter(award => person.totalKills >= award.autoGrantCriteria!.threshold);
+}
+
+export function checkScenarioAwards(person: IPerson, awards: readonly IAward[]): IAward[] {
+  return getAwardsForCategory(awards, AutoAwardCategory.SCENARIO)
+    .filter(award => person.missionsCompleted >= award.autoGrantCriteria!.threshold);
+}
+
+export function checkTimeAwards(person: IPerson, awards: readonly IAward[], context: ICheckerContext): IAward[] {
+  const recruitDate = person.recruitmentDate instanceof Date ? person.recruitmentDate : new Date(person.recruitmentDate);
+  const currentDate = new Date(context.currentDate);
+  const yearsOfService = (currentDate.getTime() - recruitDate.getTime()) / (365.25 * 24 * 60 * 60 * 1000);
+
+  return getAwardsForCategory(awards, AutoAwardCategory.TIME)
+    .filter(award => yearsOfService >= award.autoGrantCriteria!.threshold);
+}
+
+export function checkSkillAwards(person: IPerson, awards: readonly IAward[]): IAward[] {
+  return getAwardsForCategory(awards, AutoAwardCategory.SKILL)
+    .filter(award => {
+      const criteria = award.autoGrantCriteria!;
+      const skillId = criteria.skillId;
+
+      if (skillId === 'gunnery') {
+        return person.pilotSkills.gunnery <= criteria.threshold;
+      }
+      if (skillId === 'piloting') {
+        return person.pilotSkills.piloting <= criteria.threshold;
+      }
+      return Math.min(person.pilotSkills.gunnery, person.pilotSkills.piloting) <= criteria.threshold;
+    });
+}
+
+export function checkRankAwards(person: IPerson, awards: readonly IAward[]): IAward[] {
+  return getAwardsForCategory(awards, AutoAwardCategory.RANK)
+    .filter(award => {
+      const criteria = award.autoGrantCriteria!;
+      const rankLevel = person.rankLevel ?? 0;
+      const mode = criteria.rankMode ?? 'inclusive';
+
+      if (mode === 'promotion') return rankLevel === criteria.threshold;
+      if (mode === 'exclusive') return rankLevel > criteria.threshold;
+      return rankLevel >= criteria.threshold;
+    });
+}
+
+export function checkInjuryAwards(person: IPerson, awards: readonly IAward[]): IAward[] {
+  return getAwardsForCategory(awards, AutoAwardCategory.INJURY)
+    .filter(award => person.injuries.length >= award.autoGrantCriteria!.threshold);
+}
+
+// =============================================================================
+// Stubbed Categories
+// =============================================================================
+
+export function checkContractAwards(_person: IPerson, _awards: readonly IAward[]): IAward[] {
+  return [];
+}
+
+export function checkFactionHunterAwards(_person: IPerson, _awards: readonly IAward[]): IAward[] {
+  return [];
+}
+
+export function checkTheatreOfWarAwards(_person: IPerson, _awards: readonly IAward[]): IAward[] {
+  return [];
+}
+
+export function checkTrainingAwards(_person: IPerson, _awards: readonly IAward[]): IAward[] {
+  return [];
+}
+
+export function checkScenarioKillAwards(_person: IPerson, _awards: readonly IAward[]): IAward[] {
+  return [];
+}
+
+export function checkMiscAwards(_person: IPerson, _awards: readonly IAward[]): IAward[] {
+  return [];
+}
+
+export function checkCombatAwards(_person: IPerson, _awards: readonly IAward[]): IAward[] {
+  return [];
+}
+
+export function checkSurvivalAwards(_person: IPerson, _awards: readonly IAward[]): IAward[] {
+  return [];
+}
+
+export function checkServiceAwards(_person: IPerson, _awards: readonly IAward[]): IAward[] {
+  return [];
+}
+
+export function checkCampaignAwards(_person: IPerson, _awards: readonly IAward[]): IAward[] {
+  return [];
+}
+
+export function checkSpecialAwards(_person: IPerson, _awards: readonly IAward[]): IAward[] {
+  return [];
+}
+
+// =============================================================================
+// Master Dispatcher
+// =============================================================================
+
+export function checkAwardsForCategory(
+  category: AutoAwardCategory,
+  person: IPerson,
+  awards: readonly IAward[],
+  context: ICheckerContext
+): IAward[] {
+  switch (category) {
+    case AutoAwardCategory.KILL:
+      return checkKillAwards(person, awards);
+    case AutoAwardCategory.SCENARIO:
+      return checkScenarioAwards(person, awards);
+    case AutoAwardCategory.TIME:
+      return checkTimeAwards(person, awards, context);
+    case AutoAwardCategory.SKILL:
+      return checkSkillAwards(person, awards);
+    case AutoAwardCategory.RANK:
+      return checkRankAwards(person, awards);
+    case AutoAwardCategory.INJURY:
+      return checkInjuryAwards(person, awards);
+    case AutoAwardCategory.CONTRACT:
+      return checkContractAwards(person, awards);
+    case AutoAwardCategory.FACTION_HUNTER:
+      return checkFactionHunterAwards(person, awards);
+    case AutoAwardCategory.THEATRE_OF_WAR:
+      return checkTheatreOfWarAwards(person, awards);
+    case AutoAwardCategory.TRAINING:
+      return checkTrainingAwards(person, awards);
+    case AutoAwardCategory.SCENARIO_KILL:
+      return checkScenarioKillAwards(person, awards);
+    case AutoAwardCategory.MISC:
+      return checkMiscAwards(person, awards);
+    case AutoAwardCategory.COMBAT:
+      return checkCombatAwards(person, awards);
+    case AutoAwardCategory.SURVIVAL:
+      return checkSurvivalAwards(person, awards);
+    case AutoAwardCategory.SERVICE:
+      return checkServiceAwards(person, awards);
+    case AutoAwardCategory.CAMPAIGN:
+      return checkCampaignAwards(person, awards);
+    case AutoAwardCategory.SPECIAL:
+      return checkSpecialAwards(person, awards);
+    default:
+      return [];
+  }
+}

--- a/src/lib/campaign/processors/__tests__/autoAwardsProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/autoAwardsProcessor.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import type { IPerson } from '@/types/campaign/Person';
+import type { ICampaign } from '@/types/campaign/Campaign';
+import { createDefaultCampaignOptions } from '@/types/campaign/Campaign';
+import { PersonnelStatus } from '@/types/campaign/enums/PersonnelStatus';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
+import { Money } from '@/types/campaign/Money';
+import { DayPhase } from '../../dayPipeline';
+import { autoAwardsProcessor, processPostMissionAwards, processPostScenarioAwards } from '../autoAwardsProcessor';
+import { createDefaultAutoAwardConfig } from '@/types/campaign/awards/autoAwardTypes';
+
+function createTestPerson(overrides: Partial<IPerson> = {}): IPerson {
+  return {
+    id: 'person-001',
+    name: 'Test Pilot',
+    status: PersonnelStatus.ACTIVE,
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rank: 'MechWarrior',
+    recruitmentDate: new Date('3000-01-01'),
+    missionsCompleted: 5,
+    totalKills: 0,
+    xp: 100,
+    totalXpEarned: 500,
+    xpSpent: 100,
+    hits: 0,
+    injuries: [],
+    daysToWaitForHealing: 0,
+    skills: {},
+    attributes: { STR: 5, BOD: 5, REF: 5, DEX: 5, INT: 5, WIL: 5, CHA: 5, Edge: 0 },
+    pilotSkills: { gunnery: 4, piloting: 5 },
+    createdAt: '3000-01-01T00:00:00Z',
+    updatedAt: '3025-06-15T00:00:00Z',
+    awards: [],
+    ...overrides,
+  };
+}
+
+function createTestCampaign(overrides: Partial<ICampaign> = {}): ICampaign {
+  const defaultOptions = createDefaultCampaignOptions();
+  return {
+    id: 'campaign-001',
+    name: 'Test Campaign',
+    currentDate: new Date('3025-01-01T00:00:00Z'),
+    factionId: 'mercenary',
+    personnel: new Map<string, IPerson>(),
+    forces: new Map(),
+    rootForceId: 'force-root',
+    missions: new Map(),
+    finances: { transactions: [], balance: new Money(0) },
+    factionStandings: {},
+    shoppingList: { items: [] },
+    options: {
+      ...defaultOptions,
+      autoAwardConfig: createDefaultAutoAwardConfig(),
+    },
+    createdAt: '3020-01-01T00:00:00Z',
+    updatedAt: '3025-06-15T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('autoAwardsProcessor', () => {
+  describe('metadata', () => {
+    it('should have correct id', () => {
+      expect(autoAwardsProcessor.id).toBe('auto-awards');
+    });
+
+    it('should have correct phase (PERSONNEL)', () => {
+      expect(autoAwardsProcessor.phase).toBe(DayPhase.PERSONNEL);
+    });
+
+    it('should have correct displayName', () => {
+      expect(autoAwardsProcessor.displayName).toBe('Auto Awards');
+    });
+  });
+
+  describe('monthly processing', () => {
+    it('should return no events when not 1st of month', () => {
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-01-15T00:00:00Z'),
+      });
+
+      const result = autoAwardsProcessor.process(campaign, new Date('3025-01-15T00:00:00Z'));
+
+      expect(result.events).toHaveLength(0);
+      expect(result.campaign).toEqual(campaign);
+    });
+
+    it('should return no events when autoAwardConfig is undefined', () => {
+      const campaign = createTestCampaign({
+        options: {
+          ...createDefaultCampaignOptions(),
+          autoAwardConfig: undefined,
+        },
+      });
+
+      const result = autoAwardsProcessor.process(campaign, new Date('3025-01-01T00:00:00Z'));
+
+      expect(result.events).toHaveLength(0);
+    });
+
+    it('should return events when 1st of month and awards qualify', () => {
+      const personnel = new Map<string, IPerson>();
+      personnel.set('p1', createTestPerson({
+        id: 'p1',
+        totalKills: 10,
+      }));
+
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-01-01T00:00:00Z'),
+        personnel,
+      });
+
+      const result = autoAwardsProcessor.process(campaign, new Date('3025-01-01T00:00:00Z'));
+
+      expect(result.events.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should apply awards to person awards array after processing', () => {
+      const personnel = new Map<string, IPerson>();
+      personnel.set('p1', createTestPerson({
+        id: 'p1',
+        totalKills: 10,
+        awards: [],
+      }));
+
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-01-01T00:00:00Z'),
+        personnel,
+      });
+
+      const result = autoAwardsProcessor.process(campaign, new Date('3025-01-01T00:00:00Z'));
+      const updatedPerson = result.campaign.personnel.get('p1');
+
+      expect(updatedPerson).toBeDefined();
+      expect(Array.isArray(updatedPerson?.awards)).toBe(true);
+    });
+  });
+
+  describe('day events', () => {
+    it('should create day events with type award_granted', () => {
+      const personnel = new Map<string, IPerson>();
+      personnel.set('p1', createTestPerson({
+        id: 'p1',
+        totalKills: 10,
+      }));
+
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-01-01T00:00:00Z'),
+        personnel,
+      });
+
+      const result = autoAwardsProcessor.process(campaign, new Date('3025-01-01T00:00:00Z'));
+
+      for (const event of result.events) {
+        expect(event.type).toBe('award_granted');
+      }
+    });
+
+    it('should create day events with info severity', () => {
+      const personnel = new Map<string, IPerson>();
+      personnel.set('p1', createTestPerson({
+        id: 'p1',
+        totalKills: 10,
+      }));
+
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-01-01T00:00:00Z'),
+        personnel,
+      });
+
+      const result = autoAwardsProcessor.process(campaign, new Date('3025-01-01T00:00:00Z'));
+
+      for (const event of result.events) {
+        expect(event.severity).toBe('info');
+      }
+    });
+
+    it('should include award data in day events', () => {
+      const personnel = new Map<string, IPerson>();
+      personnel.set('p1', createTestPerson({
+        id: 'p1',
+        totalKills: 10,
+      }));
+
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-01-01T00:00:00Z'),
+        personnel,
+      });
+
+      const result = autoAwardsProcessor.process(campaign, new Date('3025-01-01T00:00:00Z'));
+
+      for (const event of result.events) {
+        expect(event.data).toBeDefined();
+        expect(event.data?.personId).toBeDefined();
+        expect(event.data?.awardId).toBeDefined();
+        expect(event.data?.awardName).toBeDefined();
+        expect(event.data?.category).toBeDefined();
+      }
+    });
+  });
+
+  describe('post-mission awards', () => {
+    it('should return events for qualifying personnel', () => {
+      const personnel = new Map<string, IPerson>();
+      personnel.set('p1', createTestPerson({
+        id: 'p1',
+        totalKills: 10,
+      }));
+
+      const campaign = createTestCampaign({
+        personnel,
+      });
+
+      const result = processPostMissionAwards(campaign, 'mission-001');
+
+      expect(result.events).toBeDefined();
+      expect(Array.isArray(result.events)).toBe(true);
+    });
+
+    it('should return updated campaign with awards applied', () => {
+      const personnel = new Map<string, IPerson>();
+      personnel.set('p1', createTestPerson({
+        id: 'p1',
+        totalKills: 10,
+        awards: [],
+      }));
+
+      const campaign = createTestCampaign({
+        personnel,
+      });
+
+      const result = processPostMissionAwards(campaign, 'mission-001');
+
+      expect(result.updatedCampaign).toBeDefined();
+      expect(result.updatedCampaign.personnel).toBeDefined();
+    });
+  });
+
+  describe('post-scenario awards', () => {
+    it('should return events for qualifying personnel', () => {
+      const personnel = new Map<string, IPerson>();
+      personnel.set('p1', createTestPerson({
+        id: 'p1',
+        totalKills: 10,
+      }));
+
+      const campaign = createTestCampaign({
+        personnel,
+      });
+
+      const result = processPostScenarioAwards(campaign, 'scenario-001');
+
+      expect(result.events).toBeDefined();
+      expect(Array.isArray(result.events)).toBe(true);
+    });
+
+    it('should return updated campaign with awards applied', () => {
+      const personnel = new Map<string, IPerson>();
+      personnel.set('p1', createTestPerson({
+        id: 'p1',
+        totalKills: 10,
+        awards: [],
+      }));
+
+      const campaign = createTestCampaign({
+        personnel,
+      });
+
+      const result = processPostScenarioAwards(campaign, 'scenario-001');
+
+      expect(result.updatedCampaign).toBeDefined();
+      expect(result.updatedCampaign.personnel).toBeDefined();
+    });
+  });
+
+  describe('award application', () => {
+    it('should add award IDs to personnel awards array', () => {
+      const personnel = new Map<string, IPerson>();
+      personnel.set('p1', createTestPerson({
+        id: 'p1',
+        totalKills: 10,
+        awards: [],
+      }));
+
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-01-01T00:00:00Z'),
+        personnel,
+      });
+
+      const result = autoAwardsProcessor.process(campaign, new Date('3025-01-01T00:00:00Z'));
+      const updatedPerson = result.campaign.personnel.get('p1');
+
+      expect(updatedPerson?.awards).toBeDefined();
+      expect(Array.isArray(updatedPerson?.awards)).toBe(true);
+    });
+
+    it('should grant multiple awards to same person', () => {
+      const personnel = new Map<string, IPerson>();
+      personnel.set('p1', createTestPerson({
+        id: 'p1',
+        totalKills: 50,
+        awards: [],
+      }));
+
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-01-01T00:00:00Z'),
+        personnel,
+      });
+
+      const result = autoAwardsProcessor.process(campaign, new Date('3025-01-01T00:00:00Z'));
+      const updatedPerson = result.campaign.personnel.get('p1');
+
+      expect(updatedPerson?.awards).toBeDefined();
+    });
+
+    it('should grant awards to multiple personnel', () => {
+      const personnel = new Map<string, IPerson>();
+      personnel.set('p1', createTestPerson({
+        id: 'p1',
+        totalKills: 10,
+        awards: [],
+      }));
+      personnel.set('p2', createTestPerson({
+        id: 'p2',
+        totalKills: 15,
+        awards: [],
+      }));
+
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-01-01T00:00:00Z'),
+        personnel,
+      });
+
+      const result = autoAwardsProcessor.process(campaign, new Date('3025-01-01T00:00:00Z'));
+
+      const p1 = result.campaign.personnel.get('p1');
+      const p2 = result.campaign.personnel.get('p2');
+
+      expect(p1?.awards).toBeDefined();
+      expect(p2?.awards).toBeDefined();
+    });
+
+    it('should return no events for empty personnel', () => {
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-01-01T00:00:00Z'),
+        personnel: new Map(),
+      });
+
+      const result = autoAwardsProcessor.process(campaign, new Date('3025-01-01T00:00:00Z'));
+
+      expect(result.events).toHaveLength(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle person with no existing awards', () => {
+      const personnel = new Map<string, IPerson>();
+      personnel.set('p1', createTestPerson({
+        id: 'p1',
+        totalKills: 10,
+        awards: undefined,
+      }));
+
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-01-01T00:00:00Z'),
+        personnel,
+      });
+
+      const result = autoAwardsProcessor.process(campaign, new Date('3025-01-01T00:00:00Z'));
+      const updatedPerson = result.campaign.personnel.get('p1');
+
+      expect(updatedPerson?.awards).toBeDefined();
+      expect(Array.isArray(updatedPerson?.awards)).toBe(true);
+    });
+
+    it('should preserve existing awards when adding new ones', () => {
+      const personnel = new Map<string, IPerson>();
+      personnel.set('p1', createTestPerson({
+        id: 'p1',
+        totalKills: 10,
+        awards: ['award-existing'],
+      }));
+
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-01-01T00:00:00Z'),
+        personnel,
+      });
+
+      const result = autoAwardsProcessor.process(campaign, new Date('3025-01-01T00:00:00Z'));
+      const updatedPerson = result.campaign.personnel.get('p1');
+
+      expect(updatedPerson?.awards).toContain('award-existing');
+    });
+
+    it('should not modify campaign when no awards granted', () => {
+      const personnel = new Map<string, IPerson>();
+      personnel.set('p1', createTestPerson({
+        id: 'p1',
+        totalKills: 0,
+        awards: [],
+      }));
+
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-01-01T00:00:00Z'),
+        personnel,
+      });
+
+      const result = autoAwardsProcessor.process(campaign, new Date('3025-01-01T00:00:00Z'));
+
+      expect(result.campaign.personnel.size).toBe(campaign.personnel.size);
+    });
+  });
+});

--- a/src/lib/campaign/processors/__tests__/processors.test.ts
+++ b/src/lib/campaign/processors/__tests__/processors.test.ts
@@ -203,12 +203,12 @@ describe('registerBuiltinProcessors', () => {
     _resetBuiltinRegistration();
   });
 
-  it('should register all four builtin processors', () => {
+  it('should register all five builtin processors', () => {
     registerBuiltinProcessors();
     const processors = getDayPipeline().getProcessors();
 
-    expect(processors).toHaveLength(4);
-    expect(processors.map((p) => p.id)).toEqual(['healing', 'contracts', 'dailyCosts', 'acquisition']);
+    expect(processors).toHaveLength(5);
+    expect(processors.map((p) => p.id)).toEqual(['healing', 'auto-awards', 'contracts', 'dailyCosts', 'acquisition']);
   });
 
   it('should be idempotent (calling twice registers once)', () => {
@@ -216,7 +216,7 @@ describe('registerBuiltinProcessors', () => {
     registerBuiltinProcessors();
 
     const processors = getDayPipeline().getProcessors();
-    expect(processors).toHaveLength(4);
+    expect(processors).toHaveLength(5);
   });
 
   it('should register processors in correct phase order', () => {
@@ -224,8 +224,9 @@ describe('registerBuiltinProcessors', () => {
     const processors = getDayPipeline().getProcessors();
 
     expect(processors[0].phase).toBe(DayPhase.PERSONNEL);
-    expect(processors[1].phase).toBe(DayPhase.MISSIONS);
-    expect(processors[2].phase).toBe(DayPhase.FINANCES);
-    expect(processors[3].phase).toBe(DayPhase.EVENTS);
+    expect(processors[1].phase).toBe(DayPhase.PERSONNEL);
+    expect(processors[2].phase).toBe(DayPhase.MISSIONS);
+    expect(processors[3].phase).toBe(DayPhase.FINANCES);
+    expect(processors[4].phase).toBe(DayPhase.EVENTS);
   });
 });

--- a/src/lib/campaign/processors/autoAwardsProcessor.ts
+++ b/src/lib/campaign/processors/autoAwardsProcessor.ts
@@ -1,0 +1,73 @@
+import { IDayProcessor, IDayProcessorResult, IDayEvent, DayPhase, isFirstOfMonth } from '../dayPipeline';
+import { ICampaign } from '@/types/campaign/Campaign';
+import { processAutoAwards } from '../awards/autoAwardEngine';
+import { IAwardGrantEvent } from '@/types/campaign/awards/autoAwardTypes';
+
+function applyAwardGrants(campaign: ICampaign, grantEvents: IAwardGrantEvent[]): ICampaign {
+  if (grantEvents.length === 0) return campaign;
+
+  const updatedPersonnel = new Map(campaign.personnel);
+
+  for (const event of grantEvents) {
+    const person = updatedPersonnel.get(event.personId);
+    if (!person) continue;
+
+    const existingAwards = person.awards ?? [];
+    const updatedPerson = {
+      ...person,
+      awards: [...existingAwards, event.awardId],
+    };
+    updatedPersonnel.set(event.personId, updatedPerson);
+  }
+
+  return {
+    ...campaign,
+    personnel: updatedPersonnel,
+  };
+}
+
+export const autoAwardsProcessor: IDayProcessor = {
+  id: 'auto-awards',
+  phase: DayPhase.PERSONNEL,
+  displayName: 'Auto Awards',
+  process(campaign: ICampaign, date: Date): IDayProcessorResult {
+    if (!isFirstOfMonth(date)) {
+      return { events: [], campaign };
+    }
+
+    const grantEvents = processAutoAwards(campaign, 'monthly');
+    const updatedCampaign = applyAwardGrants(campaign, grantEvents);
+
+    const dayEvents: IDayEvent[] = grantEvents.map(event => ({
+      type: 'award_granted',
+      description: `${event.awardName} awarded to personnel ${event.personId}`,
+      severity: 'info' as const,
+      data: {
+        personId: event.personId,
+        awardId: event.awardId,
+        awardName: event.awardName,
+        category: event.category,
+      },
+    }));
+
+    return { events: dayEvents, campaign: updatedCampaign };
+  },
+};
+
+export function processPostMissionAwards(
+  campaign: ICampaign,
+  _missionId: string
+): { updatedCampaign: ICampaign; events: IAwardGrantEvent[] } {
+  const events = processAutoAwards(campaign, 'post_mission');
+  const updatedCampaign = applyAwardGrants(campaign, events);
+  return { updatedCampaign, events };
+}
+
+export function processPostScenarioAwards(
+  campaign: ICampaign,
+  _scenarioId: string
+): { updatedCampaign: ICampaign; events: IAwardGrantEvent[] } {
+  const events = processAutoAwards(campaign, 'post_scenario');
+  const updatedCampaign = applyAwardGrants(campaign, events);
+  return { updatedCampaign, events };
+}

--- a/src/lib/campaign/processors/index.ts
+++ b/src/lib/campaign/processors/index.ts
@@ -3,11 +3,13 @@ import { healingProcessor } from './healingProcessor';
 import { contractProcessor } from './contractProcessor';
 import { dailyCostsProcessor } from './dailyCostsProcessor';
 import { registerAcquisitionProcessor } from './acquisitionProcessor';
+import { autoAwardsProcessor } from './autoAwardsProcessor';
 
 export { healingProcessor } from './healingProcessor';
 export { contractProcessor } from './contractProcessor';
 export { dailyCostsProcessor } from './dailyCostsProcessor';
 export { registerAcquisitionProcessor } from './acquisitionProcessor';
+export { autoAwardsProcessor } from './autoAwardsProcessor';
 
 let registered = false;
 
@@ -18,6 +20,7 @@ export function registerBuiltinProcessors(): void {
   pipeline.register(healingProcessor);
   pipeline.register(contractProcessor);
   pipeline.register(dailyCostsProcessor);
+  pipeline.register(autoAwardsProcessor);
   registerAcquisitionProcessor();
 
   registered = true;

--- a/src/types/award/AwardCatalog.ts
+++ b/src/types/award/AwardCatalog.ts
@@ -8,6 +8,7 @@
  */
 
 import { IAward, AwardRarity, AwardCategory, CriteriaType } from './AwardInterfaces';
+import { AutoAwardCategory } from '../campaign/awards/autoAwardTypes';
 
 // =============================================================================
 // Combat Awards
@@ -28,6 +29,7 @@ const COMBAT_AWARDS: readonly IAward[] = [
     },
     repeatable: false,
     sortOrder: 100,
+    autoGrantCriteria: { category: AutoAwardCategory.KILL, threshold: 1, thresholdType: 'kills', stackable: false },
   },
   {
     id: 'warrior',
@@ -43,6 +45,7 @@ const COMBAT_AWARDS: readonly IAward[] = [
     },
     repeatable: false,
     sortOrder: 110,
+    autoGrantCriteria: { category: AutoAwardCategory.KILL, threshold: 3, thresholdType: 'kills', stackable: false },
   },
   {
     id: 'ace',
@@ -58,6 +61,7 @@ const COMBAT_AWARDS: readonly IAward[] = [
     },
     repeatable: false,
     sortOrder: 120,
+    autoGrantCriteria: { category: AutoAwardCategory.KILL, threshold: 5, thresholdType: 'kills', stackable: false },
   },
   {
     id: 'double-ace',
@@ -73,6 +77,7 @@ const COMBAT_AWARDS: readonly IAward[] = [
     },
     repeatable: false,
     sortOrder: 130,
+    autoGrantCriteria: { category: AutoAwardCategory.KILL, threshold: 10, thresholdType: 'kills', stackable: false },
   },
   {
     id: 'triple-ace',
@@ -88,6 +93,7 @@ const COMBAT_AWARDS: readonly IAward[] = [
     },
     repeatable: false,
     sortOrder: 140,
+    autoGrantCriteria: { category: AutoAwardCategory.KILL, threshold: 15, thresholdType: 'kills', stackable: false },
   },
   {
     id: 'legend',
@@ -103,6 +109,7 @@ const COMBAT_AWARDS: readonly IAward[] = [
     },
     repeatable: false,
     sortOrder: 150,
+    autoGrantCriteria: { category: AutoAwardCategory.KILL, threshold: 25, thresholdType: 'kills', stackable: false },
   },
   {
     id: 'marksman',
@@ -302,6 +309,7 @@ const CAMPAIGN_AWARDS: readonly IAward[] = [
     },
     repeatable: false,
     sortOrder: 400,
+    autoGrantCriteria: { category: AutoAwardCategory.SCENARIO, threshold: 1, thresholdType: 'missions', stackable: false },
   },
   {
     id: 'campaign-veteran',
@@ -317,6 +325,7 @@ const CAMPAIGN_AWARDS: readonly IAward[] = [
     },
     repeatable: false,
     sortOrder: 410,
+    autoGrantCriteria: { category: AutoAwardCategory.SCENARIO, threshold: 10, thresholdType: 'missions', stackable: false },
   },
   {
     id: 'campaign-elite',
@@ -332,6 +341,7 @@ const CAMPAIGN_AWARDS: readonly IAward[] = [
     },
     repeatable: false,
     sortOrder: 420,
+    autoGrantCriteria: { category: AutoAwardCategory.SCENARIO, threshold: 25, thresholdType: 'missions', stackable: false },
   },
   {
     id: 'campaign-victor',
@@ -554,6 +564,477 @@ const SPECIAL_AWARDS: readonly IAward[] = [
 ];
 
 // =============================================================================
+// Auto-Grant Kill Awards (Extended Tiers)
+// =============================================================================
+
+const AUTO_KILL_AWARDS: readonly IAward[] = [
+  {
+    id: 'destroyer',
+    name: 'Destroyer',
+    description: 'Eliminate 50 enemy units. A force of destruction on the battlefield.',
+    category: AwardCategory.Combat,
+    rarity: AwardRarity.Legendary,
+    icon: 'award-destroyer',
+    criteria: {
+      type: CriteriaType.TotalKills,
+      threshold: 50,
+      description: 'Destroy 50 enemy units',
+    },
+    repeatable: false,
+    sortOrder: 160,
+    autoGrantCriteria: { category: AutoAwardCategory.KILL, threshold: 50, thresholdType: 'kills', stackable: false },
+  },
+  {
+    id: 'centurion-kills',
+    name: 'Centurion of War',
+    description: 'A century of confirmed kills. Your name echoes across the battlefields.',
+    category: AwardCategory.Combat,
+    rarity: AwardRarity.Legendary,
+    icon: 'award-centurion-kills',
+    criteria: {
+      type: CriteriaType.TotalKills,
+      threshold: 100,
+      description: 'Destroy 100 enemy units',
+    },
+    repeatable: false,
+    sortOrder: 170,
+    autoGrantCriteria: { category: AutoAwardCategory.KILL, threshold: 100, thresholdType: 'kills', stackable: false },
+  },
+  {
+    id: 'warlord',
+    name: 'Warlord',
+    description: '250 confirmed kills. Few warriors in history have matched this feat.',
+    category: AwardCategory.Combat,
+    rarity: AwardRarity.Legendary,
+    icon: 'award-warlord',
+    criteria: {
+      type: CriteriaType.TotalKills,
+      threshold: 250,
+      description: 'Destroy 250 enemy units',
+    },
+    repeatable: false,
+    sortOrder: 180,
+    autoGrantCriteria: { category: AutoAwardCategory.KILL, threshold: 250, thresholdType: 'kills', stackable: false },
+  },
+  {
+    id: 'extinction-event',
+    name: 'Extinction Event',
+    description: '500 confirmed kills. You are a walking apocalypse.',
+    category: AwardCategory.Combat,
+    rarity: AwardRarity.Legendary,
+    icon: 'award-extinction-event',
+    criteria: {
+      type: CriteriaType.TotalKills,
+      threshold: 500,
+      description: 'Destroy 500 enemy units',
+    },
+    repeatable: false,
+    sortOrder: 190,
+    autoGrantCriteria: { category: AutoAwardCategory.KILL, threshold: 500, thresholdType: 'kills', stackable: false },
+  },
+];
+
+// =============================================================================
+// Auto-Grant Scenario Awards (Extended Tiers)
+// =============================================================================
+
+const AUTO_SCENARIO_AWARDS: readonly IAward[] = [
+  {
+    id: 'mission-runner',
+    name: 'Mission Runner',
+    description: 'Complete 5 missions. Starting to build a reputation.',
+    category: AwardCategory.Campaign,
+    rarity: AwardRarity.Common,
+    icon: 'award-mission-runner',
+    criteria: {
+      type: CriteriaType.MissionsCompleted,
+      threshold: 5,
+      description: 'Complete 5 missions',
+    },
+    repeatable: false,
+    sortOrder: 405,
+    autoGrantCriteria: { category: AutoAwardCategory.SCENARIO, threshold: 5, thresholdType: 'missions', stackable: false },
+  },
+  {
+    id: 'campaign-legend',
+    name: 'Campaign Legend',
+    description: 'Complete 50 missions. Your tactical acumen is unmatched.',
+    category: AwardCategory.Campaign,
+    rarity: AwardRarity.Legendary,
+    icon: 'award-campaign-legend',
+    criteria: {
+      type: CriteriaType.MissionsCompleted,
+      threshold: 50,
+      description: 'Complete 50 missions',
+    },
+    repeatable: false,
+    sortOrder: 460,
+    autoGrantCriteria: { category: AutoAwardCategory.SCENARIO, threshold: 50, thresholdType: 'missions', stackable: false },
+  },
+  {
+    id: 'centurion-missions',
+    name: 'Centurion of Campaigns',
+    description: 'Complete 100 missions. A century of operations.',
+    category: AwardCategory.Campaign,
+    rarity: AwardRarity.Legendary,
+    icon: 'award-centurion-missions',
+    criteria: {
+      type: CriteriaType.MissionsCompleted,
+      threshold: 100,
+      description: 'Complete 100 missions',
+    },
+    repeatable: false,
+    sortOrder: 470,
+    autoGrantCriteria: { category: AutoAwardCategory.SCENARIO, threshold: 100, thresholdType: 'missions', stackable: false },
+  },
+];
+
+// =============================================================================
+// Auto-Grant Time Awards (Years of Service)
+// =============================================================================
+
+const AUTO_TIME_AWARDS: readonly IAward[] = [
+  {
+    id: 'one-year-service',
+    name: 'Year of Service',
+    description: 'One year of loyal service to the unit.',
+    category: AwardCategory.Service,
+    rarity: AwardRarity.Common,
+    icon: 'award-one-year',
+    criteria: {
+      type: CriteriaType.GamesPlayed,
+      threshold: 1,
+      description: '1 year of service',
+    },
+    repeatable: false,
+    sortOrder: 550,
+    autoGrantCriteria: { category: AutoAwardCategory.TIME, threshold: 1, thresholdType: 'years', stackable: false },
+  },
+  {
+    id: 'two-year-service',
+    name: 'Two Years of Service',
+    description: 'Two years serving with distinction.',
+    category: AwardCategory.Service,
+    rarity: AwardRarity.Common,
+    icon: 'award-two-year',
+    criteria: {
+      type: CriteriaType.GamesPlayed,
+      threshold: 2,
+      description: '2 years of service',
+    },
+    repeatable: false,
+    sortOrder: 560,
+    autoGrantCriteria: { category: AutoAwardCategory.TIME, threshold: 2, thresholdType: 'years', stackable: false },
+  },
+  {
+    id: 'five-year-service',
+    name: 'Five Years of Service',
+    description: 'Five years of dedicated service. A true veteran.',
+    category: AwardCategory.Service,
+    rarity: AwardRarity.Uncommon,
+    icon: 'award-five-year',
+    criteria: {
+      type: CriteriaType.GamesPlayed,
+      threshold: 5,
+      description: '5 years of service',
+    },
+    repeatable: false,
+    sortOrder: 570,
+    autoGrantCriteria: { category: AutoAwardCategory.TIME, threshold: 5, thresholdType: 'years', stackable: false },
+  },
+  {
+    id: 'ten-year-service',
+    name: 'Decade of Service',
+    description: 'A decade of loyal service. Your commitment is exceptional.',
+    category: AwardCategory.Service,
+    rarity: AwardRarity.Rare,
+    icon: 'award-ten-year',
+    criteria: {
+      type: CriteriaType.GamesPlayed,
+      threshold: 10,
+      description: '10 years of service',
+    },
+    repeatable: false,
+    sortOrder: 580,
+    autoGrantCriteria: { category: AutoAwardCategory.TIME, threshold: 10, thresholdType: 'years', stackable: false },
+  },
+  {
+    id: 'twenty-year-service',
+    name: 'Twenty Years of Service',
+    description: 'Two decades of unwavering loyalty.',
+    category: AwardCategory.Service,
+    rarity: AwardRarity.Rare,
+    icon: 'award-twenty-year',
+    criteria: {
+      type: CriteriaType.GamesPlayed,
+      threshold: 20,
+      description: '20 years of service',
+    },
+    repeatable: false,
+    sortOrder: 590,
+    autoGrantCriteria: { category: AutoAwardCategory.TIME, threshold: 20, thresholdType: 'years', stackable: false },
+  },
+  {
+    id: 'thirty-year-service',
+    name: 'Thirty Years of Service',
+    description: 'Three decades of service. A living legend of the unit.',
+    category: AwardCategory.Service,
+    rarity: AwardRarity.Legendary,
+    icon: 'award-thirty-year',
+    criteria: {
+      type: CriteriaType.GamesPlayed,
+      threshold: 30,
+      description: '30 years of service',
+    },
+    repeatable: false,
+    sortOrder: 595,
+    autoGrantCriteria: { category: AutoAwardCategory.TIME, threshold: 30, thresholdType: 'years', stackable: false },
+  },
+];
+
+// =============================================================================
+// Auto-Grant Injury Awards
+// =============================================================================
+
+const AUTO_INJURY_AWARDS: readonly IAward[] = [
+  {
+    id: 'purple-heart',
+    name: 'Purple Heart',
+    description: 'Sustained your first injury in the line of duty.',
+    category: AwardCategory.Survival,
+    rarity: AwardRarity.Common,
+    icon: 'award-purple-heart',
+    criteria: {
+      type: CriteriaType.SpecificEvent,
+      threshold: 1,
+      conditions: { eventType: 'injury' },
+      description: 'Sustain 1 injury',
+    },
+    repeatable: false,
+    sortOrder: 360,
+    autoGrantCriteria: { category: AutoAwardCategory.INJURY, threshold: 1, thresholdType: 'injuries', stackable: false },
+  },
+  {
+    id: 'battle-scarred',
+    name: 'Battle Scarred',
+    description: 'Survived 3 injuries. Your scars tell stories.',
+    category: AwardCategory.Survival,
+    rarity: AwardRarity.Uncommon,
+    icon: 'award-battle-scarred',
+    criteria: {
+      type: CriteriaType.SpecificEvent,
+      threshold: 3,
+      conditions: { eventType: 'injury' },
+      description: 'Sustain 3 injuries',
+    },
+    repeatable: false,
+    sortOrder: 370,
+    autoGrantCriteria: { category: AutoAwardCategory.INJURY, threshold: 3, thresholdType: 'injuries', stackable: false },
+  },
+  {
+    id: 'iron-constitution',
+    name: 'Iron Constitution',
+    description: 'Survived 5 injuries. Nothing keeps you down.',
+    category: AwardCategory.Survival,
+    rarity: AwardRarity.Rare,
+    icon: 'award-iron-constitution',
+    criteria: {
+      type: CriteriaType.SpecificEvent,
+      threshold: 5,
+      conditions: { eventType: 'injury' },
+      description: 'Sustain 5 injuries',
+    },
+    repeatable: false,
+    sortOrder: 380,
+    autoGrantCriteria: { category: AutoAwardCategory.INJURY, threshold: 5, thresholdType: 'injuries', stackable: false },
+  },
+  {
+    id: 'unkillable',
+    name: 'Unkillable',
+    description: 'Survived 10 injuries. You defy death itself.',
+    category: AwardCategory.Survival,
+    rarity: AwardRarity.Legendary,
+    icon: 'award-unkillable',
+    criteria: {
+      type: CriteriaType.SpecificEvent,
+      threshold: 10,
+      conditions: { eventType: 'injury' },
+      description: 'Sustain 10 injuries',
+    },
+    repeatable: false,
+    sortOrder: 390,
+    autoGrantCriteria: { category: AutoAwardCategory.INJURY, threshold: 10, thresholdType: 'injuries', stackable: false },
+  },
+];
+
+// =============================================================================
+// Auto-Grant Rank Awards
+// =============================================================================
+
+const AUTO_RANK_AWARDS: readonly IAward[] = [
+  {
+    id: 'officer-commission',
+    name: 'Officer Commission',
+    description: 'Achieved the rank of officer.',
+    category: AwardCategory.Service,
+    rarity: AwardRarity.Uncommon,
+    icon: 'award-officer',
+    criteria: {
+      type: CriteriaType.SpecificEvent,
+      threshold: 1,
+      conditions: { eventType: 'promotion' },
+      description: 'Reach officer rank (level 3+)',
+    },
+    repeatable: false,
+    sortOrder: 700,
+    autoGrantCriteria: { category: AutoAwardCategory.RANK, threshold: 3, thresholdType: 'rank_level', stackable: false, rankMode: 'inclusive' },
+  },
+  {
+    id: 'senior-officer',
+    name: 'Senior Officer',
+    description: 'Achieved senior officer rank.',
+    category: AwardCategory.Service,
+    rarity: AwardRarity.Rare,
+    icon: 'award-senior-officer',
+    criteria: {
+      type: CriteriaType.SpecificEvent,
+      threshold: 1,
+      conditions: { eventType: 'promotion' },
+      description: 'Reach senior officer rank (level 6+)',
+    },
+    repeatable: false,
+    sortOrder: 710,
+    autoGrantCriteria: { category: AutoAwardCategory.RANK, threshold: 6, thresholdType: 'rank_level', stackable: false, rankMode: 'inclusive' },
+  },
+  {
+    id: 'command-rank',
+    name: 'Command Rank',
+    description: 'Achieved command rank. You lead from the front.',
+    category: AwardCategory.Service,
+    rarity: AwardRarity.Legendary,
+    icon: 'award-command-rank',
+    criteria: {
+      type: CriteriaType.SpecificEvent,
+      threshold: 1,
+      conditions: { eventType: 'promotion' },
+      description: 'Reach command rank (level 9+)',
+    },
+    repeatable: false,
+    sortOrder: 720,
+    autoGrantCriteria: { category: AutoAwardCategory.RANK, threshold: 9, thresholdType: 'rank_level', stackable: false, rankMode: 'inclusive' },
+  },
+];
+
+// =============================================================================
+// Auto-Grant Skill Awards
+// =============================================================================
+
+const AUTO_SKILL_AWARDS: readonly IAward[] = [
+  {
+    id: 'expert-marksman',
+    name: 'Expert Marksman',
+    description: 'Achieved expert gunnery skill.',
+    category: AwardCategory.Combat,
+    rarity: AwardRarity.Uncommon,
+    icon: 'award-expert-marksman',
+    criteria: {
+      type: CriteriaType.SpecificEvent,
+      threshold: 1,
+      conditions: { eventType: 'skill_level' },
+      description: 'Reach gunnery skill 3 or better',
+    },
+    repeatable: false,
+    sortOrder: 250,
+    autoGrantCriteria: { category: AutoAwardCategory.SKILL, threshold: 3, thresholdType: 'skill_level', stackable: false, skillId: 'gunnery' },
+  },
+  {
+    id: 'master-marksman',
+    name: 'Master Marksman',
+    description: 'Achieved master gunnery skill. Your aim is legendary.',
+    category: AwardCategory.Combat,
+    rarity: AwardRarity.Rare,
+    icon: 'award-master-marksman',
+    criteria: {
+      type: CriteriaType.SpecificEvent,
+      threshold: 1,
+      conditions: { eventType: 'skill_level' },
+      description: 'Reach gunnery skill 2 or better',
+    },
+    repeatable: false,
+    sortOrder: 260,
+    autoGrantCriteria: { category: AutoAwardCategory.SKILL, threshold: 2, thresholdType: 'skill_level', stackable: false, skillId: 'gunnery' },
+  },
+  {
+    id: 'elite-marksman',
+    name: 'Elite Marksman',
+    description: 'Achieved elite gunnery skill. Perfection incarnate.',
+    category: AwardCategory.Combat,
+    rarity: AwardRarity.Legendary,
+    icon: 'award-elite-marksman',
+    criteria: {
+      type: CriteriaType.SpecificEvent,
+      threshold: 1,
+      conditions: { eventType: 'skill_level' },
+      description: 'Reach gunnery skill 0',
+    },
+    repeatable: false,
+    sortOrder: 270,
+    autoGrantCriteria: { category: AutoAwardCategory.SKILL, threshold: 0, thresholdType: 'skill_level', stackable: false, skillId: 'gunnery' },
+  },
+  {
+    id: 'expert-pilot',
+    name: 'Expert Pilot',
+    description: 'Achieved expert piloting skill.',
+    category: AwardCategory.Combat,
+    rarity: AwardRarity.Uncommon,
+    icon: 'award-expert-pilot',
+    criteria: {
+      type: CriteriaType.SpecificEvent,
+      threshold: 1,
+      conditions: { eventType: 'skill_level' },
+      description: 'Reach piloting skill 3 or better',
+    },
+    repeatable: false,
+    sortOrder: 280,
+    autoGrantCriteria: { category: AutoAwardCategory.SKILL, threshold: 3, thresholdType: 'skill_level', stackable: false, skillId: 'piloting' },
+  },
+  {
+    id: 'master-pilot',
+    name: 'Master Pilot',
+    description: 'Achieved master piloting skill. Grace under fire.',
+    category: AwardCategory.Combat,
+    rarity: AwardRarity.Rare,
+    icon: 'award-master-pilot',
+    criteria: {
+      type: CriteriaType.SpecificEvent,
+      threshold: 1,
+      conditions: { eventType: 'skill_level' },
+      description: 'Reach piloting skill 2 or better',
+    },
+    repeatable: false,
+    sortOrder: 290,
+    autoGrantCriteria: { category: AutoAwardCategory.SKILL, threshold: 2, thresholdType: 'skill_level', stackable: false, skillId: 'piloting' },
+  },
+  {
+    id: 'elite-pilot',
+    name: 'Elite Pilot',
+    description: 'Achieved elite piloting skill. One with the machine.',
+    category: AwardCategory.Combat,
+    rarity: AwardRarity.Legendary,
+    icon: 'award-elite-pilot',
+    criteria: {
+      type: CriteriaType.SpecificEvent,
+      threshold: 1,
+      conditions: { eventType: 'skill_level' },
+      description: 'Reach piloting skill 0',
+    },
+    repeatable: false,
+    sortOrder: 295,
+    autoGrantCriteria: { category: AutoAwardCategory.SKILL, threshold: 0, thresholdType: 'skill_level', stackable: false, skillId: 'piloting' },
+  },
+];
+
+// =============================================================================
 // Award Catalog
 // =============================================================================
 
@@ -566,6 +1047,12 @@ export const AWARD_CATALOG: readonly IAward[] = [
   ...CAMPAIGN_AWARDS,
   ...SERVICE_AWARDS,
   ...SPECIAL_AWARDS,
+  ...AUTO_KILL_AWARDS,
+  ...AUTO_SCENARIO_AWARDS,
+  ...AUTO_TIME_AWARDS,
+  ...AUTO_INJURY_AWARDS,
+  ...AUTO_RANK_AWARDS,
+  ...AUTO_SKILL_AWARDS,
 ];
 
 // =============================================================================
@@ -605,4 +1092,11 @@ export function getVisibleAwards(): readonly IAward[] {
  */
 export function getSortedAwards(awards: readonly IAward[]): readonly IAward[] {
   return [...awards].sort((a, b) => a.sortOrder - b.sortOrder);
+}
+
+/**
+ * Get all awards that have auto-grant criteria.
+ */
+export function getAutoGrantableAwards(): readonly IAward[] {
+  return AWARD_CATALOG.filter(award => award.autoGrantCriteria !== undefined);
 }

--- a/src/types/award/AwardInterfaces.ts
+++ b/src/types/award/AwardInterfaces.ts
@@ -5,6 +5,8 @@
  * @spec openspec/changes/add-awards-system/specs/awards/spec.md
  */
 
+import type { IAutoGrantCriteria } from '../campaign/awards/autoAwardTypes';
+
 // =============================================================================
 // Enums
 // =============================================================================
@@ -123,6 +125,8 @@ export interface IAward {
   readonly sortOrder: number;
   /** Whether award is hidden until earned */
   readonly secret?: boolean;
+  /** Auto-grant criteria for the auto-award engine (optional) */
+  readonly autoGrantCriteria?: IAutoGrantCriteria;
 }
 
 /**

--- a/src/types/award/__tests__/AwardCatalog.test.ts
+++ b/src/types/award/__tests__/AwardCatalog.test.ts
@@ -1,0 +1,430 @@
+/**
+ * Award Catalog Tests
+ *
+ * Validates the award catalog structure, counts, and auto-grant criteria.
+ */
+
+import { AWARD_CATALOG, getAutoGrantableAwards } from '../AwardCatalog';
+import { AutoAwardCategory } from '../../campaign/awards/autoAwardTypes';
+
+describe('AwardCatalog', () => {
+  describe('Catalog Structure', () => {
+    it('should have all awards including new auto-grant awards', () => {
+      expect(AWARD_CATALOG.length).toBeGreaterThan(54);
+      expect(AWARD_CATALOG.some(a => a.id === 'destroyer')).toBe(true);
+      expect(AWARD_CATALOG.some(a => a.id === 'purple-heart')).toBe(true);
+      expect(AWARD_CATALOG.some(a => a.id === 'expert-marksman')).toBe(true);
+    });
+
+    it('should preserve all 54 existing awards', () => {
+      const existingAwardIds = [
+        // Combat Awards (11)
+        'first-blood',
+        'warrior',
+        'ace',
+        'double-ace',
+        'triple-ace',
+        'legend',
+        'marksman',
+        'sharpshooter',
+        'one-man-army',
+        'devastator',
+        'annihilator',
+        // Survival Awards (6)
+        'survivor',
+        'veteran',
+        'iron-will',
+        'immortal',
+        'phoenix',
+        'lucky-star',
+        // Campaign Awards (6)
+        'campaign-initiate',
+        'campaign-veteran',
+        'campaign-elite',
+        'campaign-victor',
+        'campaign-master',
+        'flawless-campaign',
+        // Service Awards (5)
+        'recruit',
+        'regular',
+        'seasoned',
+        'centurion',
+        'grand-master',
+        // Special Awards (5)
+        'against-all-odds',
+        'david-vs-goliath',
+        'last-mech-standing',
+        'mercy',
+        'no-quarter',
+      ];
+
+      for (const id of existingAwardIds) {
+        const award = AWARD_CATALOG.find(a => a.id === id);
+        expect(award).toBeDefined();
+        expect(award?.id).toBe(id);
+      }
+    });
+
+    it('should have no duplicate award IDs', () => {
+      const ids = AWARD_CATALOG.map(a => a.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(AWARD_CATALOG.length);
+    });
+  });
+
+  describe('Auto-Grant Kill Awards', () => {
+    it('should have 4 new kill awards at thresholds 50, 100, 250, 500', () => {
+      const killAwards = AWARD_CATALOG.filter(
+        a => a.autoGrantCriteria?.category === AutoAwardCategory.KILL
+      );
+      expect(killAwards.length).toBeGreaterThanOrEqual(10); // 6 existing + 4 new
+    });
+
+    it('should have destroyer award at 50 kills', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'destroyer');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(50);
+      expect(award?.autoGrantCriteria?.category).toBe(AutoAwardCategory.KILL);
+    });
+
+    it('should have centurion-kills award at 100 kills', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'centurion-kills');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(100);
+    });
+
+    it('should have warlord award at 250 kills', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'warlord');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(250);
+    });
+
+    it('should have extinction-event award at 500 kills', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'extinction-event');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(500);
+    });
+  });
+
+  describe('Auto-Grant Scenario Awards', () => {
+    it('should have 3 new scenario awards at thresholds 5, 50, 100', () => {
+      const scenarioAwards = AWARD_CATALOG.filter(
+        a => a.autoGrantCriteria?.category === AutoAwardCategory.SCENARIO
+      );
+      expect(scenarioAwards.length).toBeGreaterThanOrEqual(6); // 3 existing + 3 new
+    });
+
+    it('should have mission-runner award at 5 missions', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'mission-runner');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(5);
+      expect(award?.autoGrantCriteria?.category).toBe(AutoAwardCategory.SCENARIO);
+    });
+
+    it('should have campaign-legend award at 50 missions', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'campaign-legend');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(50);
+    });
+
+    it('should have centurion-missions award at 100 missions', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'centurion-missions');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(100);
+    });
+  });
+
+  describe('Auto-Grant Time Awards', () => {
+    it('should have 6 time awards at thresholds 1, 2, 5, 10, 20, 30 years', () => {
+      const timeAwards = AWARD_CATALOG.filter(
+        a => a.autoGrantCriteria?.category === AutoAwardCategory.TIME
+      );
+      expect(timeAwards.length).toBe(6);
+    });
+
+    it('should have one-year-service award', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'one-year-service');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(1);
+      expect(award?.autoGrantCriteria?.thresholdType).toBe('years');
+    });
+
+    it('should have two-year-service award', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'two-year-service');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(2);
+    });
+
+    it('should have five-year-service award', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'five-year-service');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(5);
+    });
+
+    it('should have ten-year-service award', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'ten-year-service');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(10);
+    });
+
+    it('should have twenty-year-service award', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'twenty-year-service');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(20);
+    });
+
+    it('should have thirty-year-service award', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'thirty-year-service');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(30);
+    });
+  });
+
+  describe('Auto-Grant Injury Awards', () => {
+    it('should have 4 injury awards at thresholds 1, 3, 5, 10', () => {
+      const injuryAwards = AWARD_CATALOG.filter(
+        a => a.autoGrantCriteria?.category === AutoAwardCategory.INJURY
+      );
+      expect(injuryAwards.length).toBe(4);
+    });
+
+    it('should have purple-heart award at 1 injury', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'purple-heart');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(1);
+      expect(award?.autoGrantCriteria?.category).toBe(AutoAwardCategory.INJURY);
+    });
+
+    it('should have battle-scarred award at 3 injuries', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'battle-scarred');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(3);
+    });
+
+    it('should have iron-constitution award at 5 injuries', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'iron-constitution');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(5);
+    });
+
+    it('should have unkillable award at 10 injuries', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'unkillable');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(10);
+    });
+  });
+
+  describe('Auto-Grant Rank Awards', () => {
+    it('should have 3 rank awards at thresholds 3, 6, 9', () => {
+      const rankAwards = AWARD_CATALOG.filter(
+        a => a.autoGrantCriteria?.category === AutoAwardCategory.RANK
+      );
+      expect(rankAwards.length).toBe(3);
+    });
+
+    it('should have officer-commission award at rank level 3', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'officer-commission');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(3);
+      expect(award?.autoGrantCriteria?.category).toBe(AutoAwardCategory.RANK);
+      expect(award?.autoGrantCriteria?.rankMode).toBe('inclusive');
+    });
+
+    it('should have senior-officer award at rank level 6', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'senior-officer');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(6);
+    });
+
+    it('should have command-rank award at rank level 9', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'command-rank');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(9);
+    });
+  });
+
+  describe('Auto-Grant Skill Awards', () => {
+    it('should have 6 skill awards (3 gunnery + 3 piloting)', () => {
+      const skillAwards = AWARD_CATALOG.filter(
+        a => a.autoGrantCriteria?.category === AutoAwardCategory.SKILL
+      );
+      expect(skillAwards.length).toBe(6);
+    });
+
+    it('should have expert-marksman gunnery award at skill level 3', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'expert-marksman');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(3);
+      expect(award?.autoGrantCriteria?.category).toBe(AutoAwardCategory.SKILL);
+      expect(award?.autoGrantCriteria?.skillId).toBe('gunnery');
+    });
+
+    it('should have master-marksman gunnery award at skill level 2', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'master-marksman');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(2);
+      expect(award?.autoGrantCriteria?.skillId).toBe('gunnery');
+    });
+
+    it('should have elite-marksman gunnery award at skill level 0', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'elite-marksman');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(0);
+      expect(award?.autoGrantCriteria?.skillId).toBe('gunnery');
+    });
+
+    it('should have expert-pilot piloting award at skill level 3', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'expert-pilot');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(3);
+      expect(award?.autoGrantCriteria?.skillId).toBe('piloting');
+    });
+
+    it('should have master-pilot piloting award at skill level 2', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'master-pilot');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(2);
+      expect(award?.autoGrantCriteria?.skillId).toBe('piloting');
+    });
+
+    it('should have elite-pilot piloting award at skill level 0', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'elite-pilot');
+      expect(award).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(0);
+      expect(award?.autoGrantCriteria?.skillId).toBe('piloting');
+    });
+  });
+
+  describe('Existing Awards with Auto-Grant Criteria', () => {
+    it('should have autoGrantCriteria on first-blood', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'first-blood');
+      expect(award?.autoGrantCriteria).toBeDefined();
+      expect(award?.autoGrantCriteria?.category).toBe(AutoAwardCategory.KILL);
+      expect(award?.autoGrantCriteria?.threshold).toBe(1);
+    });
+
+    it('should have autoGrantCriteria on warrior', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'warrior');
+      expect(award?.autoGrantCriteria).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(3);
+    });
+
+    it('should have autoGrantCriteria on ace', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'ace');
+      expect(award?.autoGrantCriteria).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(5);
+    });
+
+    it('should have autoGrantCriteria on double-ace', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'double-ace');
+      expect(award?.autoGrantCriteria).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(10);
+    });
+
+    it('should have autoGrantCriteria on triple-ace', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'triple-ace');
+      expect(award?.autoGrantCriteria).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(15);
+    });
+
+    it('should have autoGrantCriteria on legend', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'legend');
+      expect(award?.autoGrantCriteria).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(25);
+    });
+
+    it('should have autoGrantCriteria on campaign-initiate', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'campaign-initiate');
+      expect(award?.autoGrantCriteria).toBeDefined();
+      expect(award?.autoGrantCriteria?.category).toBe(AutoAwardCategory.SCENARIO);
+      expect(award?.autoGrantCriteria?.threshold).toBe(1);
+    });
+
+    it('should have autoGrantCriteria on campaign-veteran', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'campaign-veteran');
+      expect(award?.autoGrantCriteria).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(10);
+    });
+
+    it('should have autoGrantCriteria on campaign-elite', () => {
+      const award = AWARD_CATALOG.find(a => a.id === 'campaign-elite');
+      expect(award?.autoGrantCriteria).toBeDefined();
+      expect(award?.autoGrantCriteria?.threshold).toBe(25);
+    });
+  });
+
+  describe('getAutoGrantableAwards()', () => {
+    it('should return only awards with autoGrantCriteria', () => {
+      const autoGrantable = getAutoGrantableAwards();
+      expect(autoGrantable.length).toBeGreaterThan(0);
+
+      for (const award of autoGrantable) {
+        expect(award.autoGrantCriteria).toBeDefined();
+      }
+    });
+
+    it('should include all 26 new awards', () => {
+      const autoGrantable = getAutoGrantableAwards();
+      const newAwardIds = [
+        // Kill awards
+        'destroyer',
+        'centurion-kills',
+        'warlord',
+        'extinction-event',
+        // Scenario awards
+        'mission-runner',
+        'campaign-legend',
+        'centurion-missions',
+        // Time awards
+        'one-year-service',
+        'two-year-service',
+        'five-year-service',
+        'ten-year-service',
+        'twenty-year-service',
+        'thirty-year-service',
+        // Injury awards
+        'purple-heart',
+        'battle-scarred',
+        'iron-constitution',
+        'unkillable',
+        // Rank awards
+        'officer-commission',
+        'senior-officer',
+        'command-rank',
+        // Skill awards
+        'expert-marksman',
+        'master-marksman',
+        'elite-marksman',
+        'expert-pilot',
+        'master-pilot',
+        'elite-pilot',
+      ];
+
+      expect(newAwardIds.length).toBe(26);
+      for (const id of newAwardIds) {
+        const award = autoGrantable.find(a => a.id === id);
+        expect(award).toBeDefined();
+      }
+    });
+
+    it('should include all 9 existing awards with autoGrantCriteria', () => {
+      const autoGrantable = getAutoGrantableAwards();
+      const existingAwardIds = [
+        'first-blood',
+        'warrior',
+        'ace',
+        'double-ace',
+        'triple-ace',
+        'legend',
+        'campaign-initiate',
+        'campaign-veteran',
+        'campaign-elite',
+      ];
+
+      for (const id of existingAwardIds) {
+        const award = autoGrantable.find(a => a.id === id);
+        expect(award).toBeDefined();
+      }
+    });
+  });
+});

--- a/src/types/campaign/Campaign.ts
+++ b/src/types/campaign/Campaign.ts
@@ -26,6 +26,7 @@ import {
 } from './Mission';
 import type { SalvageRights, CommandRights } from './Mission';
 import { MedicalSystem } from '../../lib/campaign/medical/medicalTypes';
+import type { IAutoAwardConfig } from './awards/autoAwardTypes';
 
 // Re-export Mission types for backwards compatibility
 export type { IMission, IContract, SalvageRights, CommandRights };
@@ -330,11 +331,18 @@ export interface ICampaignOptions {
    // Faction Standing Options (~2)
    // =========================================================================
 
-   /** Whether to track faction standing */
-   readonly trackFactionStanding: boolean;
+    /** Whether to track faction standing */
+    readonly trackFactionStanding: boolean;
 
-   /** Multiplier for regard changes (1.0 = normal) */
-   readonly regardChangeMultiplier: number;
+    /** Multiplier for regard changes (1.0 = normal) */
+    readonly regardChangeMultiplier: number;
+
+    // =========================================================================
+    // Auto-Award Options
+    // =========================================================================
+
+    /** Auto-award system configuration (optional, defaults to all enabled) */
+    readonly autoAwardConfig?: IAutoAwardConfig;
 }
 
 // =============================================================================

--- a/src/types/campaign/awards/__tests__/autoAwardTypes.test.ts
+++ b/src/types/campaign/awards/__tests__/autoAwardTypes.test.ts
@@ -1,0 +1,182 @@
+import {
+  AutoAwardCategory,
+  ALL_AUTO_AWARD_TRIGGERS,
+  createDefaultAutoAwardConfig,
+  isAutoAwardCategory,
+  isAutoAwardTrigger,
+  isAutoAwardConfig,
+  isAutoGrantCriteria,
+  isAwardGrantEvent,
+} from '../autoAwardTypes';
+import type {
+  AutoAwardTrigger,
+  IAutoAwardConfig,
+  IAutoGrantCriteria,
+  IAwardGrantEvent,
+} from '../autoAwardTypes';
+
+describe('AutoAwardCategory', () => {
+  it('should have 17 values (12 MekHQ + 5 MekStation)', () => {
+    const values = Object.values(AutoAwardCategory);
+    expect(values).toHaveLength(17);
+  });
+
+  it('should include all 12 MekHQ categories', () => {
+    expect(AutoAwardCategory.CONTRACT).toBe('contract');
+    expect(AutoAwardCategory.FACTION_HUNTER).toBe('faction_hunter');
+    expect(AutoAwardCategory.INJURY).toBe('injury');
+    expect(AutoAwardCategory.KILL).toBe('kill');
+    expect(AutoAwardCategory.SCENARIO_KILL).toBe('scenario_kill');
+    expect(AutoAwardCategory.RANK).toBe('rank');
+    expect(AutoAwardCategory.SCENARIO).toBe('scenario');
+    expect(AutoAwardCategory.SKILL).toBe('skill');
+    expect(AutoAwardCategory.THEATRE_OF_WAR).toBe('theatre_of_war');
+    expect(AutoAwardCategory.TIME).toBe('time');
+    expect(AutoAwardCategory.TRAINING).toBe('training');
+    expect(AutoAwardCategory.MISC).toBe('misc');
+  });
+
+  it('should include all 5 MekStation existing categories', () => {
+    expect(AutoAwardCategory.COMBAT).toBe('combat');
+    expect(AutoAwardCategory.SURVIVAL).toBe('survival');
+    expect(AutoAwardCategory.SERVICE).toBe('service');
+    expect(AutoAwardCategory.CAMPAIGN).toBe('campaign');
+    expect(AutoAwardCategory.SPECIAL).toBe('special');
+  });
+
+  it('should have unique values', () => {
+    const values = Object.values(AutoAwardCategory);
+    const unique = new Set(values);
+    expect(unique.size).toBe(values.length);
+  });
+});
+
+describe('AutoAwardTrigger', () => {
+  it('should have 5 values', () => {
+    expect(ALL_AUTO_AWARD_TRIGGERS).toHaveLength(5);
+  });
+
+  it('should include all trigger types', () => {
+    expect(ALL_AUTO_AWARD_TRIGGERS).toContain('monthly');
+    expect(ALL_AUTO_AWARD_TRIGGERS).toContain('post_mission');
+    expect(ALL_AUTO_AWARD_TRIGGERS).toContain('post_scenario');
+    expect(ALL_AUTO_AWARD_TRIGGERS).toContain('post_promotion');
+    expect(ALL_AUTO_AWARD_TRIGGERS).toContain('manual');
+  });
+});
+
+describe('IAutoAwardConfig', () => {
+  it('should be created with all fields via factory', () => {
+    const config = createDefaultAutoAwardConfig();
+    expect(typeof config.enableAutoAwards).toBe('boolean');
+    expect(typeof config.bestAwardOnly).toBe('boolean');
+    expect(typeof config.enabledCategories).toBe('object');
+    expect(typeof config.enablePosthumous).toBe('boolean');
+  });
+
+  it('should default to all categories enabled', () => {
+    const config = createDefaultAutoAwardConfig();
+    for (const category of Object.values(AutoAwardCategory)) {
+      expect(config.enabledCategories[category]).toBe(true);
+    }
+  });
+
+  it('should default to enableAutoAwards=true', () => {
+    const config = createDefaultAutoAwardConfig();
+    expect(config.enableAutoAwards).toBe(true);
+  });
+
+  it('should default to bestAwardOnly=false', () => {
+    const config = createDefaultAutoAwardConfig();
+    expect(config.bestAwardOnly).toBe(false);
+  });
+
+  it('should default to enablePosthumous=true', () => {
+    const config = createDefaultAutoAwardConfig();
+    expect(config.enablePosthumous).toBe(true);
+  });
+
+  it('should have enabledCategories with exactly 17 entries', () => {
+    const config = createDefaultAutoAwardConfig();
+    const entries = Object.keys(config.enabledCategories);
+    expect(entries).toHaveLength(17);
+  });
+});
+
+describe('type guards', () => {
+  describe('isAutoAwardCategory', () => {
+    it('should return true for valid categories', () => {
+      expect(isAutoAwardCategory('kill')).toBe(true);
+      expect(isAutoAwardCategory('combat')).toBe(true);
+      expect(isAutoAwardCategory('time')).toBe(true);
+    });
+
+    it('should return false for invalid values', () => {
+      expect(isAutoAwardCategory('invalid')).toBe(false);
+      expect(isAutoAwardCategory(42)).toBe(false);
+      expect(isAutoAwardCategory(null)).toBe(false);
+    });
+  });
+
+  describe('isAutoAwardTrigger', () => {
+    it('should return true for valid triggers', () => {
+      expect(isAutoAwardTrigger('monthly')).toBe(true);
+      expect(isAutoAwardTrigger('post_mission')).toBe(true);
+      expect(isAutoAwardTrigger('manual')).toBe(true);
+    });
+
+    it('should return false for invalid values', () => {
+      expect(isAutoAwardTrigger('daily')).toBe(false);
+      expect(isAutoAwardTrigger(123)).toBe(false);
+    });
+  });
+
+  describe('isAutoAwardConfig', () => {
+    it('should return true for valid config', () => {
+      const config = createDefaultAutoAwardConfig();
+      expect(isAutoAwardConfig(config)).toBe(true);
+    });
+
+    it('should return false for invalid values', () => {
+      expect(isAutoAwardConfig(null)).toBe(false);
+      expect(isAutoAwardConfig({})).toBe(false);
+      expect(isAutoAwardConfig({ enableAutoAwards: 'yes' })).toBe(false);
+    });
+  });
+
+  describe('isAutoGrantCriteria', () => {
+    it('should return true for valid criteria', () => {
+      const criteria: IAutoGrantCriteria = {
+        category: AutoAwardCategory.KILL,
+        threshold: 5,
+        thresholdType: 'kills',
+        stackable: false,
+      };
+      expect(isAutoGrantCriteria(criteria)).toBe(true);
+    });
+
+    it('should return false for invalid values', () => {
+      expect(isAutoGrantCriteria(null)).toBe(false);
+      expect(isAutoGrantCriteria({ category: 'invalid' })).toBe(false);
+    });
+  });
+
+  describe('isAwardGrantEvent', () => {
+    it('should return true for valid events', () => {
+      const event: IAwardGrantEvent = {
+        personId: 'p-1',
+        awardId: 'a-1',
+        awardName: 'Test Award',
+        category: AutoAwardCategory.KILL,
+        trigger: 'monthly',
+        timestamp: '3025-01-01T00:00:00Z',
+      };
+      expect(isAwardGrantEvent(event)).toBe(true);
+    });
+
+    it('should return false for invalid values', () => {
+      expect(isAwardGrantEvent(null)).toBe(false);
+      expect(isAwardGrantEvent({})).toBe(false);
+    });
+  });
+});

--- a/src/types/campaign/awards/autoAwardTypes.ts
+++ b/src/types/campaign/awards/autoAwardTypes.ts
@@ -1,0 +1,250 @@
+/**
+ * Auto-Award System Types
+ *
+ * Defines the auto-award categories, triggers, configuration, and event types
+ * for the automatic award granting engine. Based on MekHQ's 13 award categories
+ * plus MekStation's existing 5 award categories.
+ *
+ * @module campaign/awards/autoAwardTypes
+ */
+
+// =============================================================================
+// Auto-Award Category Enum
+// =============================================================================
+
+/**
+ * Award categories for the auto-award engine.
+ *
+ * Combines MekHQ's 13 auto-award categories with MekStation's existing 5
+ * AwardCategory values. Some overlap is intentional — the auto-award engine
+ * uses these categories while the existing AwardCategory enum is used for
+ * display grouping.
+ *
+ * 17 total values: 12 from MekHQ + 5 from MekStation existing
+ */
+export enum AutoAwardCategory {
+  // MekHQ categories (12)
+  CONTRACT = 'contract',
+  FACTION_HUNTER = 'faction_hunter',
+  INJURY = 'injury',
+  KILL = 'kill',
+  SCENARIO_KILL = 'scenario_kill',
+  RANK = 'rank',
+  SCENARIO = 'scenario',
+  SKILL = 'skill',
+  THEATRE_OF_WAR = 'theatre_of_war',
+  TIME = 'time',
+  TRAINING = 'training',
+  MISC = 'misc',
+
+  // MekStation existing categories (5)
+  COMBAT = 'combat',
+  SURVIVAL = 'survival',
+  SERVICE = 'service',
+  CAMPAIGN = 'campaign',
+  SPECIAL = 'special',
+}
+
+// =============================================================================
+// Auto-Award Trigger Type
+// =============================================================================
+
+/**
+ * Trigger types that initiate auto-award processing.
+ *
+ * - monthly: Checked on the 1st of each month via day processor
+ * - post_mission: Checked after a mission completes
+ * - post_scenario: Checked after a scenario resolves
+ * - post_promotion: Checked after a personnel promotion
+ * - manual: Triggered manually by the player
+ */
+export type AutoAwardTrigger =
+  | 'monthly'
+  | 'post_mission'
+  | 'post_scenario'
+  | 'post_promotion'
+  | 'manual';
+
+/**
+ * All valid auto-award trigger values.
+ */
+export const ALL_AUTO_AWARD_TRIGGERS: readonly AutoAwardTrigger[] = [
+  'monthly',
+  'post_mission',
+  'post_scenario',
+  'post_promotion',
+  'manual',
+] as const;
+
+// =============================================================================
+// Auto-Award Configuration
+// =============================================================================
+
+/**
+ * Configuration for the auto-award system.
+ *
+ * Stored as part of ICampaignOptions. Controls which categories are
+ * enabled, whether posthumous awards are granted, and whether only
+ * the best (highest threshold) award per category is granted.
+ */
+export interface IAutoAwardConfig {
+  /** Master toggle for the auto-award system */
+  readonly enableAutoAwards: boolean;
+
+  /** If true, only grant the highest qualifying award per category per person */
+  readonly bestAwardOnly: boolean;
+
+  /** Per-category enable/disable toggles */
+  readonly enabledCategories: Record<AutoAwardCategory, boolean>;
+
+  /** Whether to grant awards to recently deceased personnel */
+  readonly enablePosthumous: boolean;
+}
+
+// =============================================================================
+// Award Grant Event
+// =============================================================================
+
+/**
+ * Event emitted when an award is automatically granted.
+ *
+ * These events are collected by the auto-award engine and can be
+ * used for day reports, notifications, and logging.
+ */
+export interface IAwardGrantEvent {
+  /** ID of the person receiving the award */
+  readonly personId: string;
+
+  /** ID of the award being granted */
+  readonly awardId: string;
+
+  /** Display name of the award */
+  readonly awardName: string;
+
+  /** Category of the auto-grant criteria */
+  readonly category: AutoAwardCategory;
+
+  /** What triggered this auto-award check */
+  readonly trigger: AutoAwardTrigger;
+
+  /** ISO 8601 timestamp of when the award was granted */
+  readonly timestamp: string;
+}
+
+// =============================================================================
+// Auto-Grant Criteria (Extension to IAward)
+// =============================================================================
+
+/**
+ * Auto-grant criteria attached to an IAward.
+ *
+ * Awards with this criteria can be automatically evaluated by the
+ * auto-award engine. The threshold and thresholdType define what
+ * personnel stat is checked and what value must be met or exceeded.
+ */
+export interface IAutoGrantCriteria {
+  /** Which auto-award category this criteria belongs to */
+  readonly category: AutoAwardCategory;
+
+  /** Numeric threshold value to meet or exceed */
+  readonly threshold: number;
+
+  /** What the threshold measures (e.g., 'kills', 'missions', 'years', 'skill_level') */
+  readonly thresholdType: string;
+
+  /** Whether this award can be earned multiple times */
+  readonly stackable: boolean;
+
+  /** Optional: specific skill ID for skill-based awards */
+  readonly skillId?: string;
+
+  /** Optional: rank level for rank-based awards */
+  readonly rankLevel?: number;
+
+  /** Optional: rank check mode for rank-based awards */
+  readonly rankMode?: 'promotion' | 'inclusive' | 'exclusive';
+}
+
+// =============================================================================
+// Factory Functions
+// =============================================================================
+
+/**
+ * Creates a default auto-award configuration with all categories enabled.
+ */
+export function createDefaultAutoAwardConfig(): IAutoAwardConfig {
+  const enabledCategories = {} as Record<AutoAwardCategory, boolean>;
+  for (const category of Object.values(AutoAwardCategory)) {
+    enabledCategories[category] = true;
+  }
+
+  return {
+    enableAutoAwards: true,
+    bestAwardOnly: false,
+    enabledCategories,
+    enablePosthumous: true,
+  };
+}
+
+// =============================================================================
+// Type Guards
+// =============================================================================
+
+/**
+ * Type guard for AutoAwardCategory.
+ */
+export function isAutoAwardCategory(value: unknown): value is AutoAwardCategory {
+  return typeof value === 'string' && Object.values(AutoAwardCategory).includes(value as AutoAwardCategory);
+}
+
+/**
+ * Type guard for AutoAwardTrigger.
+ */
+export function isAutoAwardTrigger(value: unknown): value is AutoAwardTrigger {
+  return typeof value === 'string' && ALL_AUTO_AWARD_TRIGGERS.includes(value as AutoAwardTrigger);
+}
+
+/**
+ * Type guard for IAutoAwardConfig.
+ */
+export function isAutoAwardConfig(value: unknown): value is IAutoAwardConfig {
+  if (typeof value !== 'object' || value === null) return false;
+  const config = value as IAutoAwardConfig;
+  return (
+    typeof config.enableAutoAwards === 'boolean' &&
+    typeof config.bestAwardOnly === 'boolean' &&
+    typeof config.enabledCategories === 'object' &&
+    config.enabledCategories !== null &&
+    typeof config.enablePosthumous === 'boolean'
+  );
+}
+
+/**
+ * Type guard for IAutoGrantCriteria.
+ */
+export function isAutoGrantCriteria(value: unknown): value is IAutoGrantCriteria {
+  if (typeof value !== 'object' || value === null) return false;
+  const criteria = value as IAutoGrantCriteria;
+  return (
+    isAutoAwardCategory(criteria.category) &&
+    typeof criteria.threshold === 'number' &&
+    typeof criteria.thresholdType === 'string' &&
+    typeof criteria.stackable === 'boolean'
+  );
+}
+
+/**
+ * Type guard for IAwardGrantEvent.
+ */
+export function isAwardGrantEvent(value: unknown): value is IAwardGrantEvent {
+  if (typeof value !== 'object' || value === null) return false;
+  const event = value as IAwardGrantEvent;
+  return (
+    typeof event.personId === 'string' &&
+    typeof event.awardId === 'string' &&
+    typeof event.awardName === 'string' &&
+    isAutoAwardCategory(event.category) &&
+    isAutoAwardTrigger(event.trigger) &&
+    typeof event.timestamp === 'string'
+  );
+}


### PR DESCRIPTION
## Summary

Implements Plan 14 (Awards & Auto-Granting) — an auto-award engine that automatically grants awards based on personnel achievements during campaign play.

### Changes

**New Files:**
- `src/types/campaign/awards/autoAwardTypes.ts` — 17-value AutoAwardCategory enum, 5 trigger types, IAutoAwardConfig, IAwardGrantEvent, IAutoGrantCriteria
- `src/lib/campaign/awards/categoryCheckers.ts` — 6 implemented checkers (kill, scenario, time, skill, rank, injury) + 11 stubs for future categories
- `src/lib/campaign/awards/autoAwardEngine.ts` — Main orchestrator: eligibility filtering, category routing, duplicate prevention, best-award-only mode, posthumous awards
- `src/lib/campaign/processors/autoAwardsProcessor.ts` — Monthly day processor (1st of month) + post-mission/post-scenario hooks
- 4 test files with 175+ new tests

**Modified Files:**
- `src/types/award/AwardInterfaces.ts` — Added optional `autoGrantCriteria` field to IAward
- `src/types/award/AwardCatalog.ts` — Extended with 26 new awards (kill, scenario, time, injury, rank, skill tiers) + auto-grant criteria on 9 existing awards
- `src/types/campaign/Campaign.ts` — Added optional `autoAwardConfig` to ICampaignOptions
- `src/lib/campaign/processors/index.ts` — Registered auto-awards processor

### Features
- 17 award categories (12 MekHQ + 5 MekStation existing)
- 5 trigger types: monthly, post-mission, post-scenario, post-promotion, manual
- Per-category enable/disable toggles
- "Best Award Only" mode (highest threshold per category)
- Posthumous award support
- 80 total awards in catalog (54 existing + 26 new)
- Task 14.6 (UI) deferred per convention