### PR TITLE
feat(campaign): add faction-specific rank system

### DIFF
--- a/src/lib/campaign/ranks/__tests__/campaignRankIntegration.test.ts
+++ b/src/lib/campaign/ranks/__tests__/campaignRankIntegration.test.ts
@@ -1,0 +1,50 @@
+import { getCampaignRankSystem } from '@/lib/campaign/ranks/campaignRankIntegration';
+import { RANK_SYSTEM_MERCENARY, RANK_SYSTEM_CLAN, RANK_SYSTEM_SLDF } from '@/lib/campaign/ranks/rankSystems';
+import { createCampaign } from '@/types/campaign/Campaign';
+
+describe('getCampaignRankSystem', () => {
+  it('should return Mercenary system by default', () => {
+    const campaign = createCampaign('Test Campaign', 'mercenary');
+    const system = getCampaignRankSystem(campaign);
+    expect(system.code).toBe('MERC');
+    expect(system).toBe(RANK_SYSTEM_MERCENARY);
+  });
+
+  it('should return the rank system matching the campaign option', () => {
+    const campaign = createCampaign('Clan Campaign', 'clan', {
+      rankSystemCode: 'CLAN',
+    });
+    const system = getCampaignRankSystem(campaign);
+    expect(system.code).toBe('CLAN');
+    expect(system).toBe(RANK_SYSTEM_CLAN);
+  });
+
+  it('should return SLDF system when configured', () => {
+    const campaign = createCampaign('SLDF Campaign', 'sldf', {
+      rankSystemCode: 'SLDF',
+    });
+    const system = getCampaignRankSystem(campaign);
+    expect(system.code).toBe('SLDF');
+    expect(system).toBe(RANK_SYSTEM_SLDF);
+  });
+
+  it('should fall back to Mercenary for unknown rank system code', () => {
+    const campaign = createCampaign('Unknown', 'mercenary', {
+      rankSystemCode: 'NONEXISTENT',
+    });
+    const system = getCampaignRankSystem(campaign);
+    expect(system.code).toBe('MERC');
+    expect(system).toBe(RANK_SYSTEM_MERCENARY);
+  });
+
+  it('should fall back to Mercenary when rankSystemCode is undefined', () => {
+    const campaign = createCampaign('No Code', 'mercenary');
+    // Force undefined by spreading without rankSystemCode
+    const modifiedCampaign = {
+      ...campaign,
+      options: { ...campaign.options, rankSystemCode: undefined },
+    };
+    const system = getCampaignRankSystem(modifiedCampaign);
+    expect(system.code).toBe('MERC');
+  });
+});

--- a/src/lib/campaign/ranks/__tests__/rankPay.test.ts
+++ b/src/lib/campaign/ranks/__tests__/rankPay.test.ts
@@ -1,0 +1,286 @@
+import { getRankPayMultiplier, getPersonMonthlySalaryWithRank, getOfficerShares } from '@/lib/campaign/ranks/rankPay';
+import { createRanks } from '@/types/campaign/ranks/rankTypes';
+import type { IRankSystem } from '@/types/campaign/ranks/rankTypes';
+import type { IPerson } from '@/types/campaign/Person';
+import { PersonnelStatus } from '@/types/campaign/enums/PersonnelStatus';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
+
+// =============================================================================
+// Mock Rank System
+// =============================================================================
+
+const mockSystem: IRankSystem = {
+  code: 'TEST',
+  name: 'Test',
+  description: 'Test',
+  type: 'default',
+  officerCut: 31,
+  ranks: createRanks({
+    0: { names: { mekwarrior: 'None' }, officer: false, payMultiplier: 1.0 },
+    5: { names: { mekwarrior: 'Sergeant' }, officer: false, payMultiplier: 1.1 },
+    31: { names: { mekwarrior: 'Lieutenant' }, officer: true, payMultiplier: 1.4 },
+    35: { names: { mekwarrior: 'Captain' }, officer: true, payMultiplier: 1.6 },
+    40: { names: { mekwarrior: 'Colonel' }, officer: true, payMultiplier: 2.0 },
+  }),
+};
+
+// =============================================================================
+// Mock Person Helper
+// =============================================================================
+
+const createMockPerson = (overrides: Partial<IPerson> = {}): IPerson => ({
+  id: 'test-1',
+  name: 'Test',
+  status: PersonnelStatus.ACTIVE,
+  primaryRole: CampaignPersonnelRole.PILOT,
+  rank: 'None',
+  rankIndex: 0,
+  recruitmentDate: new Date('3025-01-01'),
+  xp: 0,
+  totalXpEarned: 0,
+  xpSpent: 0,
+  hits: 0,
+  injuries: [],
+  daysToWaitForHealing: 0,
+  skills: {},
+  attributes: { STR: 5, BOD: 5, REF: 5, DEX: 5, INT: 5, WIL: 5, CHA: 5, Edge: 0 },
+  pilotSkills: { gunnery: 4, piloting: 5 },
+  missionsCompleted: 0,
+  totalKills: 0,
+  createdAt: '3025-01-01T00:00:00Z',
+  updatedAt: '3025-01-01T00:00:00Z',
+  ...overrides,
+});
+
+// =============================================================================
+// getRankPayMultiplier Tests
+// =============================================================================
+
+describe('getRankPayMultiplier', () => {
+  it('should return 1.0 for rank 0 (None)', () => {
+    const person = createMockPerson({ rankIndex: 0 });
+    expect(getRankPayMultiplier(person, mockSystem)).toBe(1.0);
+  });
+
+  it('should return 1.1 for rank 5 (Sergeant)', () => {
+    const person = createMockPerson({ rankIndex: 5 });
+    expect(getRankPayMultiplier(person, mockSystem)).toBe(1.1);
+  });
+
+  it('should return 1.4 for rank 31 (Lieutenant)', () => {
+    const person = createMockPerson({ rankIndex: 31 });
+    expect(getRankPayMultiplier(person, mockSystem)).toBe(1.4);
+  });
+
+  it('should return 1.6 for rank 35 (Captain)', () => {
+    const person = createMockPerson({ rankIndex: 35 });
+    expect(getRankPayMultiplier(person, mockSystem)).toBe(1.6);
+  });
+
+  it('should return 2.0 for rank 40 (Colonel)', () => {
+    const person = createMockPerson({ rankIndex: 40 });
+    expect(getRankPayMultiplier(person, mockSystem)).toBe(2.0);
+  });
+
+  it('should return 1.0 for undefined rankIndex', () => {
+    const person = createMockPerson({ rankIndex: undefined });
+    expect(getRankPayMultiplier(person, mockSystem)).toBe(1.0);
+  });
+
+  it('should return 1.0 for unpopulated rank (uses empty rank with 1.0 multiplier)', () => {
+    const person = createMockPerson({ rankIndex: 15 });
+    expect(getRankPayMultiplier(person, mockSystem)).toBe(1.0);
+  });
+
+  it('should return 1.0 for rank with payMultiplier of 0', () => {
+    const systemWithZeroMultiplier: IRankSystem = {
+      ...mockSystem,
+      ranks: createRanks({
+        0: { names: { mekwarrior: 'None' }, officer: false, payMultiplier: 0 },
+      }),
+    };
+    const person = createMockPerson({ rankIndex: 0 });
+    expect(getRankPayMultiplier(person, systemWithZeroMultiplier)).toBe(1.0);
+  });
+
+  it('should return 1.0 for rank with negative payMultiplier', () => {
+    const systemWithNegativeMultiplier: IRankSystem = {
+      ...mockSystem,
+      ranks: createRanks({
+        0: { names: { mekwarrior: 'None' }, officer: false, payMultiplier: -0.5 },
+      }),
+    };
+    const person = createMockPerson({ rankIndex: 0 });
+    expect(getRankPayMultiplier(person, systemWithNegativeMultiplier)).toBe(1.0);
+  });
+});
+
+// =============================================================================
+// getPersonMonthlySalaryWithRank Tests
+// =============================================================================
+
+describe('getPersonMonthlySalaryWithRank', () => {
+  it('should calculate 1000 * 1.0 = 1000 for rank 0', () => {
+    const person = createMockPerson({ rankIndex: 0 });
+    expect(getPersonMonthlySalaryWithRank(1000, person, mockSystem)).toBe(1000);
+  });
+
+  it('should calculate 1500 * 1.1 = 1650 for rank 5 (Sergeant)', () => {
+    const person = createMockPerson({ rankIndex: 5 });
+    expect(getPersonMonthlySalaryWithRank(1500, person, mockSystem)).toBe(1650);
+  });
+
+  it('should calculate 2000 * 2.0 = 4000 for rank 40 (Colonel)', () => {
+    const person = createMockPerson({ rankIndex: 40 });
+    expect(getPersonMonthlySalaryWithRank(2000, person, mockSystem)).toBe(4000);
+  });
+
+  it('should round correctly: 1000 * 1.1 = 1100', () => {
+    const person = createMockPerson({ rankIndex: 5 });
+    expect(getPersonMonthlySalaryWithRank(1000, person, mockSystem)).toBe(1100);
+  });
+
+  it('should round down: 1000 * 1.4 = 1400', () => {
+    const person = createMockPerson({ rankIndex: 31 });
+    expect(getPersonMonthlySalaryWithRank(1000, person, mockSystem)).toBe(1400);
+  });
+
+  it('should round up: 1000 * 1.6 = 1600', () => {
+    const person = createMockPerson({ rankIndex: 35 });
+    expect(getPersonMonthlySalaryWithRank(1000, person, mockSystem)).toBe(1600);
+  });
+
+  it('should handle decimal rounding: 1333 * 1.1 = 1466.3 rounds to 1466', () => {
+    const person = createMockPerson({ rankIndex: 5 });
+    expect(getPersonMonthlySalaryWithRank(1333, person, mockSystem)).toBe(1466);
+  });
+
+  it('should handle decimal rounding: 1333 * 1.1 = 1466.3 rounds to 1466', () => {
+    const person = createMockPerson({ rankIndex: 5 });
+    const result = getPersonMonthlySalaryWithRank(1333, person, mockSystem);
+    expect(result).toBe(1466);
+  });
+
+  it('should handle zero base salary', () => {
+    const person = createMockPerson({ rankIndex: 40 });
+    expect(getPersonMonthlySalaryWithRank(0, person, mockSystem)).toBe(0);
+  });
+
+  it('should handle large base salary: 50000 * 2.0 = 100000', () => {
+    const person = createMockPerson({ rankIndex: 40 });
+    expect(getPersonMonthlySalaryWithRank(50000, person, mockSystem)).toBe(100000);
+  });
+
+  it('should use undefined rankIndex as 0', () => {
+    const person = createMockPerson({ rankIndex: undefined });
+    expect(getPersonMonthlySalaryWithRank(1000, person, mockSystem)).toBe(1000);
+  });
+
+  it('should handle unpopulated rank (defaults to 1.0 multiplier)', () => {
+    const person = createMockPerson({ rankIndex: 15 });
+    expect(getPersonMonthlySalaryWithRank(1000, person, mockSystem)).toBe(1000);
+  });
+
+  it('should handle fractional base salary with rounding', () => {
+    const person = createMockPerson({ rankIndex: 5 });
+    expect(getPersonMonthlySalaryWithRank(999.5, person, mockSystem)).toBe(1099);
+  });
+
+  it('should handle very small multiplier', () => {
+    const systemWithSmallMultiplier: IRankSystem = {
+      ...mockSystem,
+      ranks: createRanks({
+        0: { names: { mekwarrior: 'None' }, officer: false, payMultiplier: 0.1 },
+      }),
+    };
+    const person = createMockPerson({ rankIndex: 0 });
+    expect(getPersonMonthlySalaryWithRank(1000, person, systemWithSmallMultiplier)).toBe(100);
+  });
+
+  it('should handle large multiplier', () => {
+    const systemWithLargeMultiplier: IRankSystem = {
+      ...mockSystem,
+      ranks: createRanks({
+        0: { names: { mekwarrior: 'None' }, officer: false, payMultiplier: 5.0 },
+      }),
+    };
+    const person = createMockPerson({ rankIndex: 0 });
+    expect(getPersonMonthlySalaryWithRank(1000, person, systemWithLargeMultiplier)).toBe(5000);
+  });
+});
+
+// =============================================================================
+// getOfficerShares Tests
+// =============================================================================
+
+describe('getOfficerShares', () => {
+  it('should return 0 for non-officer (rank 0)', () => {
+    const person = createMockPerson({ rankIndex: 0 });
+    expect(getOfficerShares(person, mockSystem)).toBe(0);
+  });
+
+  it('should return 0 for non-officer (rank 5, Sergeant)', () => {
+    const person = createMockPerson({ rankIndex: 5 });
+    expect(getOfficerShares(person, mockSystem)).toBe(0);
+  });
+
+  it('should return 1 for first officer rank (rank 31, Lieutenant at officerCut)', () => {
+    const person = createMockPerson({ rankIndex: 31 });
+    expect(getOfficerShares(person, mockSystem)).toBe(1);
+  });
+
+  it('should return 5 for rank 35 (Captain, 4 ranks above officerCut)', () => {
+    const person = createMockPerson({ rankIndex: 35 });
+    expect(getOfficerShares(person, mockSystem)).toBe(5);
+  });
+
+  it('should return 10 for rank 40 (Colonel, 9 ranks above officerCut)', () => {
+    const person = createMockPerson({ rankIndex: 40 });
+    expect(getOfficerShares(person, mockSystem)).toBe(10);
+  });
+
+  it('should return 0 for undefined rankIndex (defaults to 0, non-officer)', () => {
+    const person = createMockPerson({ rankIndex: undefined });
+    expect(getOfficerShares(person, mockSystem)).toBe(0);
+  });
+
+  it('should return 0 for rank just below officerCut (rank 30)', () => {
+    const person = createMockPerson({ rankIndex: 30 });
+    expect(getOfficerShares(person, mockSystem)).toBe(0);
+  });
+
+  it('should return 2 for rank 32 (1 rank above officerCut)', () => {
+    const person = createMockPerson({ rankIndex: 32 });
+    expect(getOfficerShares(person, mockSystem)).toBe(2);
+  });
+
+  it('should return 3 for rank 33 (2 ranks above officerCut)', () => {
+    const person = createMockPerson({ rankIndex: 33 });
+    expect(getOfficerShares(person, mockSystem)).toBe(3);
+  });
+
+  it('should work with different officerCut values', () => {
+    const systemWithDifferentCut: IRankSystem = {
+      ...mockSystem,
+      officerCut: 20,
+      ranks: createRanks({
+        20: { names: { mekwarrior: 'Officer' }, officer: true, payMultiplier: 1.5 },
+        25: { names: { mekwarrior: 'Senior Officer' }, officer: true, payMultiplier: 2.0 },
+      }),
+    };
+    const person = createMockPerson({ rankIndex: 25 });
+    expect(getOfficerShares(person, systemWithDifferentCut)).toBe(6);
+  });
+
+  it('should return correct shares for high rank even if officer flag is false (isOfficer checks rankIndex >= officerCut)', () => {
+    const systemWithNonOfficerHighRank: IRankSystem = {
+      ...mockSystem,
+      officerCut: 31,
+      ranks: createRanks({
+        40: { names: { mekwarrior: 'Warrant Officer' }, officer: false, payMultiplier: 1.8 },
+      }),
+    };
+    const person = createMockPerson({ rankIndex: 40 });
+    expect(getOfficerShares(person, systemWithNonOfficerHighRank)).toBe(10);
+  });
+});

--- a/src/lib/campaign/ranks/__tests__/rankService.test.ts
+++ b/src/lib/campaign/ranks/__tests__/rankService.test.ts
@@ -1,0 +1,609 @@
+import {
+  mapRoleToProfession,
+  getRankName,
+  getRankNameByIndex,
+  isOfficer,
+  isOfficerByIndex,
+  promoteToRank,
+  demoteToRank,
+  getTimeInRank,
+  isRecentlyPromoted,
+} from '../rankService';
+import { Profession, IRankSystem, createRanks } from '@/types/campaign/ranks/rankTypes';
+import type { IPerson } from '@/types/campaign/Person';
+import { PersonnelStatus } from '@/types/campaign/enums/PersonnelStatus';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
+
+const mockRankSystem: IRankSystem = {
+  code: 'TEST',
+  name: 'Test System',
+  description: 'For testing',
+  type: 'default',
+  officerCut: 31,
+  ranks: createRanks({
+    0: { names: { mekwarrior: 'None', aerospace: 'None' }, officer: false, payMultiplier: 1.0 },
+    1: { names: { mekwarrior: 'Private', aerospace: 'Airman', tech: 'Tech' }, officer: false, payMultiplier: 1.0 },
+    5: { names: { mekwarrior: 'Sergeant' }, officer: false, payMultiplier: 1.1 },
+    31: { names: { mekwarrior: 'Lieutenant' }, officer: true, payMultiplier: 1.4 },
+    40: { names: { mekwarrior: 'Colonel' }, officer: true, payMultiplier: 2.0 },
+  }),
+};
+
+const createMockPerson = (overrides: Partial<IPerson> = {}): IPerson => ({
+  id: 'test-1',
+  name: 'Test Person',
+  callsign: undefined,
+  status: PersonnelStatus.ACTIVE,
+  primaryRole: CampaignPersonnelRole.PILOT,
+  rank: 'None',
+  rankIndex: 0,
+  recruitmentDate: new Date('3025-01-01'),
+  xp: 0,
+  totalXpEarned: 0,
+  xpSpent: 0,
+  hits: 0,
+  injuries: [],
+  daysToWaitForHealing: 0,
+  skills: {},
+  attributes: { STR: 5, BOD: 5, REF: 5, DEX: 5, INT: 5, WIL: 5, CHA: 5, Edge: 0 },
+  pilotSkills: { gunnery: 4, piloting: 5 },
+  missionsCompleted: 0,
+  totalKills: 0,
+  createdAt: '3025-01-01T00:00:00Z',
+  updatedAt: '3025-01-01T00:00:00Z',
+  ...overrides,
+});
+
+// =============================================================================
+// mapRoleToProfession
+// =============================================================================
+
+describe('mapRoleToProfession', () => {
+  it('maps PILOT to MEKWARRIOR', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.PILOT)).toBe(Profession.MEKWARRIOR);
+  });
+
+  it('maps LAM_PILOT to MEKWARRIOR', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.LAM_PILOT)).toBe(Profession.MEKWARRIOR);
+  });
+
+  it('maps PROTOMEK_PILOT to MEKWARRIOR', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.PROTOMEK_PILOT)).toBe(Profession.MEKWARRIOR);
+  });
+
+  it('maps AEROSPACE_PILOT to AEROSPACE', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.AEROSPACE_PILOT)).toBe(Profession.AEROSPACE);
+  });
+
+  it('maps CONVENTIONAL_AIRCRAFT_PILOT to AEROSPACE', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.CONVENTIONAL_AIRCRAFT_PILOT)).toBe(Profession.AEROSPACE);
+  });
+
+  it('maps VEHICLE_DRIVER to VEHICLE', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.VEHICLE_DRIVER)).toBe(Profession.VEHICLE);
+  });
+
+  it('maps VEHICLE_CREW_VTOL to VEHICLE', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.VEHICLE_CREW_VTOL)).toBe(Profession.VEHICLE);
+  });
+
+  it('maps VEHICLE_CREW_NAVAL to NAVAL', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.VEHICLE_CREW_NAVAL)).toBe(Profession.NAVAL);
+  });
+
+  it('maps VESSEL_PILOT to NAVAL', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.VESSEL_PILOT)).toBe(Profession.NAVAL);
+  });
+
+  it('maps VESSEL_GUNNER to NAVAL', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.VESSEL_GUNNER)).toBe(Profession.NAVAL);
+  });
+
+  it('maps VESSEL_CREW to NAVAL', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.VESSEL_CREW)).toBe(Profession.NAVAL);
+  });
+
+  it('maps VESSEL_NAVIGATOR to NAVAL', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.VESSEL_NAVIGATOR)).toBe(Profession.NAVAL);
+  });
+
+  it('maps BATTLE_ARMOUR to INFANTRY', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.BATTLE_ARMOUR)).toBe(Profession.INFANTRY);
+  });
+
+  it('maps SOLDIER to INFANTRY', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.SOLDIER)).toBe(Profession.INFANTRY);
+  });
+
+  it('maps TECH to TECH', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.TECH)).toBe(Profession.TECH);
+  });
+
+  it('maps MEK_TECH to TECH', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.MEK_TECH)).toBe(Profession.TECH);
+  });
+
+  it('maps MECHANIC to TECH', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.MECHANIC)).toBe(Profession.TECH);
+  });
+
+  it('maps AERO_TEK to TECH', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.AERO_TEK)).toBe(Profession.TECH);
+  });
+
+  it('maps BA_TECH to TECH', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.BA_TECH)).toBe(Profession.TECH);
+  });
+
+  it('maps ASTECH to TECH', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.ASTECH)).toBe(Profession.TECH);
+  });
+
+  it('maps DOCTOR to MEDICAL', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.DOCTOR)).toBe(Profession.MEDICAL);
+  });
+
+  it('maps MEDIC to MEDICAL', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.MEDIC)).toBe(Profession.MEDICAL);
+  });
+
+  it('maps ADMIN_COMMAND to ADMINISTRATOR', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.ADMIN_COMMAND)).toBe(Profession.ADMINISTRATOR);
+  });
+
+  it('maps ADMIN_LOGISTICS to ADMINISTRATOR', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.ADMIN_LOGISTICS)).toBe(Profession.ADMINISTRATOR);
+  });
+
+  it('maps ADMIN_TRANSPORT to ADMINISTRATOR', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.ADMIN_TRANSPORT)).toBe(Profession.ADMINISTRATOR);
+  });
+
+  it('maps ADMIN_HR to ADMINISTRATOR', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.ADMIN_HR)).toBe(Profession.ADMINISTRATOR);
+  });
+
+  it('maps ADMIN (legacy) to ADMINISTRATOR', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.ADMIN)).toBe(Profession.ADMINISTRATOR);
+  });
+
+  it('maps DEPENDENT to CIVILIAN', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.DEPENDENT)).toBe(Profession.CIVILIAN);
+  });
+
+  it('maps CIVILIAN_OTHER to CIVILIAN', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.CIVILIAN_OTHER)).toBe(Profession.CIVILIAN);
+  });
+
+  it('maps SUPPORT to CIVILIAN', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.SUPPORT)).toBe(Profession.CIVILIAN);
+  });
+
+  it('maps UNASSIGNED to CIVILIAN', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.UNASSIGNED)).toBe(Profession.CIVILIAN);
+  });
+
+  it('maps MERCHANT to CIVILIAN', () => {
+    expect(mapRoleToProfession(CampaignPersonnelRole.MERCHANT)).toBe(Profession.CIVILIAN);
+  });
+});
+
+// =============================================================================
+// getRankName
+// =============================================================================
+
+describe('getRankName', () => {
+  it('returns profession-specific name for PILOT at rank 1', () => {
+    const person = createMockPerson({ rankIndex: 1, primaryRole: CampaignPersonnelRole.PILOT });
+    expect(getRankName(person, mockRankSystem)).toBe('Private');
+  });
+
+  it('returns aerospace-specific name for AEROSPACE_PILOT at rank 1', () => {
+    const person = createMockPerson({ rankIndex: 1, primaryRole: CampaignPersonnelRole.AEROSPACE_PILOT });
+    expect(getRankName(person, mockRankSystem)).toBe('Airman');
+  });
+
+  it('returns tech-specific name for TECH at rank 1', () => {
+    const person = createMockPerson({ rankIndex: 1, primaryRole: CampaignPersonnelRole.TECH });
+    expect(getRankName(person, mockRankSystem)).toBe('Tech');
+  });
+
+  it('falls back to mekwarrior name when profession name is missing', () => {
+    const person = createMockPerson({ rankIndex: 5, primaryRole: CampaignPersonnelRole.AEROSPACE_PILOT });
+    expect(getRankName(person, mockRankSystem)).toBe('Sergeant');
+  });
+
+  it('returns None for empty rank (no names defined)', () => {
+    const person = createMockPerson({ rankIndex: 10, primaryRole: CampaignPersonnelRole.PILOT });
+    expect(getRankName(person, mockRankSystem)).toBe('None');
+  });
+
+  it('defaults to rankIndex 0 when rankIndex is undefined', () => {
+    const person = createMockPerson({ rankIndex: undefined, primaryRole: CampaignPersonnelRole.PILOT });
+    expect(getRankName(person, mockRankSystem)).toBe('None');
+  });
+
+  it('returns officer rank name at index 31', () => {
+    const person = createMockPerson({ rankIndex: 31, primaryRole: CampaignPersonnelRole.PILOT });
+    expect(getRankName(person, mockRankSystem)).toBe('Lieutenant');
+  });
+});
+
+// =============================================================================
+// getRankNameByIndex
+// =============================================================================
+
+describe('getRankNameByIndex', () => {
+  it('returns profession-specific name by index and role', () => {
+    expect(getRankNameByIndex(1, CampaignPersonnelRole.AEROSPACE_PILOT, mockRankSystem)).toBe('Airman');
+  });
+
+  it('falls back to mekwarrior name when profession name is missing', () => {
+    expect(getRankNameByIndex(5, CampaignPersonnelRole.DOCTOR, mockRankSystem)).toBe('Sergeant');
+  });
+
+  it('returns None for empty rank slot', () => {
+    expect(getRankNameByIndex(10, CampaignPersonnelRole.PILOT, mockRankSystem)).toBe('None');
+  });
+
+  it('returns correct name at officer rank', () => {
+    expect(getRankNameByIndex(40, CampaignPersonnelRole.PILOT, mockRankSystem)).toBe('Colonel');
+  });
+});
+
+// =============================================================================
+// isOfficer
+// =============================================================================
+
+describe('isOfficer', () => {
+  it('returns false for enlisted rank (index 0)', () => {
+    const person = createMockPerson({ rankIndex: 0 });
+    expect(isOfficer(person, mockRankSystem)).toBe(false);
+  });
+
+  it('returns false for rank just below officer cut (index 30)', () => {
+    const person = createMockPerson({ rankIndex: 30 });
+    expect(isOfficer(person, mockRankSystem)).toBe(false);
+  });
+
+  it('returns true at exactly officer cut (index 31)', () => {
+    const person = createMockPerson({ rankIndex: 31 });
+    expect(isOfficer(person, mockRankSystem)).toBe(true);
+  });
+
+  it('returns true for rank above officer cut (index 40)', () => {
+    const person = createMockPerson({ rankIndex: 40 });
+    expect(isOfficer(person, mockRankSystem)).toBe(true);
+  });
+
+  it('returns false when rankIndex is undefined (defaults to 0)', () => {
+    const person = createMockPerson({ rankIndex: undefined });
+    expect(isOfficer(person, mockRankSystem)).toBe(false);
+  });
+});
+
+// =============================================================================
+// isOfficerByIndex
+// =============================================================================
+
+describe('isOfficerByIndex', () => {
+  it('returns false for index 0', () => {
+    expect(isOfficerByIndex(0, mockRankSystem)).toBe(false);
+  });
+
+  it('returns false for index 30', () => {
+    expect(isOfficerByIndex(30, mockRankSystem)).toBe(false);
+  });
+
+  it('returns true for index 31', () => {
+    expect(isOfficerByIndex(31, mockRankSystem)).toBe(true);
+  });
+
+  it('returns true for index 50', () => {
+    expect(isOfficerByIndex(50, mockRankSystem)).toBe(true);
+  });
+});
+
+// =============================================================================
+// promoteToRank
+// =============================================================================
+
+describe('promoteToRank', () => {
+  it('promotes from rank 0 to rank 1 successfully', () => {
+    const person = createMockPerson({ rankIndex: 0 });
+    const result = promoteToRank(person, 1, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(true);
+    expect(result.reason).toBeUndefined();
+    expect(result.updatedPerson.rankIndex).toBe(1);
+    expect(result.updatedPerson.rank).toBe('Private');
+    expect(result.updatedPerson.lastRankChangeDate).toEqual(new Date('3025-06-15'));
+    expect(result.updatedPerson.lastPromotionDate).toEqual(new Date('3025-06-15'));
+  });
+
+  it('promotes from enlisted to officer rank', () => {
+    const person = createMockPerson({ rankIndex: 5 });
+    const result = promoteToRank(person, 31, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(true);
+    expect(result.updatedPerson.rankIndex).toBe(31);
+    expect(result.updatedPerson.rank).toBe('Lieutenant');
+  });
+
+  it('rejects invalid rank index (-1)', () => {
+    const person = createMockPerson({ rankIndex: 0 });
+    const result = promoteToRank(person, -1, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Rank index out of range (0-50)');
+    expect(result.updatedPerson).toBe(person);
+  });
+
+  it('rejects invalid rank index (51)', () => {
+    const person = createMockPerson({ rankIndex: 0 });
+    const result = promoteToRank(person, 51, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Rank index out of range (0-50)');
+  });
+
+  it('rejects non-integer rank index', () => {
+    const person = createMockPerson({ rankIndex: 0 });
+    const result = promoteToRank(person, 1.5, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Rank index out of range (0-50)');
+  });
+
+  it('rejects promotion to same rank', () => {
+    const person = createMockPerson({ rankIndex: 5 });
+    const result = promoteToRank(person, 5, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('New rank must be higher than current rank');
+    expect(result.updatedPerson).toBe(person);
+  });
+
+  it('rejects promotion to lower rank', () => {
+    const person = createMockPerson({ rankIndex: 5 });
+    const result = promoteToRank(person, 1, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('New rank must be higher than current rank');
+  });
+
+  it('uses correct profession name for aerospace pilot promotion', () => {
+    const person = createMockPerson({ rankIndex: 0, primaryRole: CampaignPersonnelRole.AEROSPACE_PILOT });
+    const result = promoteToRank(person, 1, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(true);
+    expect(result.updatedPerson.rank).toBe('Airman');
+  });
+
+  it('handles undefined rankIndex (defaults to 0)', () => {
+    const person = createMockPerson({ rankIndex: undefined });
+    const result = promoteToRank(person, 1, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(true);
+    expect(result.updatedPerson.rankIndex).toBe(1);
+  });
+});
+
+// =============================================================================
+// demoteToRank
+// =============================================================================
+
+describe('demoteToRank', () => {
+  it('demotes from rank 5 to rank 1 successfully', () => {
+    const person = createMockPerson({ rankIndex: 5 });
+    const result = demoteToRank(person, 1, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(true);
+    expect(result.reason).toBeUndefined();
+    expect(result.updatedPerson.rankIndex).toBe(1);
+    expect(result.updatedPerson.rank).toBe('Private');
+    expect(result.updatedPerson.lastRankChangeDate).toEqual(new Date('3025-06-15'));
+  });
+
+  it('does NOT update lastPromotionDate on demotion', () => {
+    const promotionDate = new Date('3025-03-01');
+    const person = createMockPerson({ rankIndex: 5, lastPromotionDate: promotionDate });
+    const result = demoteToRank(person, 1, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(true);
+    expect(result.updatedPerson.lastPromotionDate).toEqual(promotionDate);
+  });
+
+  it('demotes from officer to enlisted', () => {
+    const person = createMockPerson({ rankIndex: 31 });
+    const result = demoteToRank(person, 5, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(true);
+    expect(result.updatedPerson.rankIndex).toBe(5);
+    expect(result.updatedPerson.rank).toBe('Sergeant');
+  });
+
+  it('rejects invalid rank index (-1)', () => {
+    const person = createMockPerson({ rankIndex: 5 });
+    const result = demoteToRank(person, -1, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Rank index out of range (0-50)');
+    expect(result.updatedPerson).toBe(person);
+  });
+
+  it('rejects invalid rank index (51)', () => {
+    const person = createMockPerson({ rankIndex: 5 });
+    const result = demoteToRank(person, 51, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('Rank index out of range (0-50)');
+  });
+
+  it('rejects demotion to same rank', () => {
+    const person = createMockPerson({ rankIndex: 5 });
+    const result = demoteToRank(person, 5, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('New rank must be lower than current rank');
+    expect(result.updatedPerson).toBe(person);
+  });
+
+  it('rejects demotion to higher rank', () => {
+    const person = createMockPerson({ rankIndex: 5 });
+    const result = demoteToRank(person, 31, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('New rank must be lower than current rank');
+  });
+
+  it('can demote to rank 0', () => {
+    const person = createMockPerson({ rankIndex: 1 });
+    const result = demoteToRank(person, 0, '3025-06-15', mockRankSystem);
+
+    expect(result.valid).toBe(true);
+    expect(result.updatedPerson.rankIndex).toBe(0);
+    expect(result.updatedPerson.rank).toBe('None');
+  });
+});
+
+// =============================================================================
+// getTimeInRank
+// =============================================================================
+
+describe('getTimeInRank', () => {
+  it('calculates days for short duration', () => {
+    const person = createMockPerson({
+      lastRankChangeDate: new Date('3025-06-01'),
+    });
+    const result = getTimeInRank(person, '3025-06-15');
+
+    expect(result.days).toBe(14);
+    expect(result.months).toBe(0);
+    expect(result.years).toBe(0);
+    expect(result.display).toBe('14 days');
+  });
+
+  it('calculates months and days', () => {
+    const person = createMockPerson({
+      lastRankChangeDate: new Date('3025-01-15'),
+    });
+    const result = getTimeInRank(person, '3025-04-15');
+
+    expect(result.months).toBe(3);
+    expect(result.years).toBe(0);
+    expect(result.display).toBe('3 months, 0 days');
+  });
+
+  it('calculates years and months', () => {
+    const person = createMockPerson({
+      lastRankChangeDate: new Date('3023-06-01'),
+    });
+    const result = getTimeInRank(person, '3025-09-01');
+
+    expect(result.years).toBe(2);
+    expect(result.months).toBe(3);
+    expect(result.display).toBe('2 years, 3 months');
+  });
+
+  it('falls back to recruitmentDate when lastRankChangeDate is undefined', () => {
+    const person = createMockPerson({
+      recruitmentDate: new Date('3025-01-01'),
+      lastRankChangeDate: undefined,
+    });
+    const result = getTimeInRank(person, '3025-01-11');
+
+    expect(result.days).toBe(10);
+    expect(result.display).toBe('10 days');
+  });
+
+  it('handles exactly 1 year', () => {
+    const person = createMockPerson({
+      lastRankChangeDate: new Date('3024-06-01'),
+    });
+    const result = getTimeInRank(person, '3025-06-01');
+
+    expect(result.years).toBe(1);
+    expect(result.months).toBe(0);
+    expect(result.display).toBe('1 year, 0 months');
+  });
+
+  it('handles exactly 1 day', () => {
+    const person = createMockPerson({
+      lastRankChangeDate: new Date('3025-06-01'),
+    });
+    const result = getTimeInRank(person, '3025-06-02');
+
+    expect(result.days).toBe(1);
+    expect(result.display).toBe('1 day');
+  });
+
+  it('handles 0 days (same date)', () => {
+    const person = createMockPerson({
+      lastRankChangeDate: new Date('3025-06-01'),
+    });
+    const result = getTimeInRank(person, '3025-06-01');
+
+    expect(result.days).toBe(0);
+    expect(result.display).toBe('0 days');
+  });
+
+  it('handles exactly 1 month', () => {
+    const person = createMockPerson({
+      lastRankChangeDate: new Date('3025-06-01'),
+    });
+    const result = getTimeInRank(person, '3025-07-01');
+
+    expect(result.months).toBe(1);
+    expect(result.years).toBe(0);
+    expect(result.display).toBe('1 month, 0 days');
+  });
+});
+
+// =============================================================================
+// isRecentlyPromoted
+// =============================================================================
+
+describe('isRecentlyPromoted', () => {
+  it('returns true when promoted within default 6-month threshold', () => {
+    const person = createMockPerson({
+      lastPromotionDate: new Date('3025-04-01'),
+    });
+    expect(isRecentlyPromoted(person, '3025-06-15')).toBe(true);
+  });
+
+  it('returns false when promoted more than 6 months ago', () => {
+    const person = createMockPerson({
+      lastPromotionDate: new Date('3024-01-01'),
+    });
+    expect(isRecentlyPromoted(person, '3025-06-15')).toBe(false);
+  });
+
+  it('returns false when lastPromotionDate is undefined', () => {
+    const person = createMockPerson({
+      lastPromotionDate: undefined,
+    });
+    expect(isRecentlyPromoted(person, '3025-06-15')).toBe(false);
+  });
+
+  it('respects custom monthsThreshold', () => {
+    const person = createMockPerson({
+      lastPromotionDate: new Date('3025-04-01'),
+    });
+    expect(isRecentlyPromoted(person, '3025-06-15', 3)).toBe(true);
+  });
+
+  it('returns false when outside custom threshold', () => {
+    const person = createMockPerson({
+      lastPromotionDate: new Date('3025-01-01'),
+    });
+    expect(isRecentlyPromoted(person, '3025-06-15', 3)).toBe(false);
+  });
+
+  it('returns true at exactly the threshold boundary', () => {
+    const person = createMockPerson({
+      lastPromotionDate: new Date('3025-01-15'),
+    });
+    expect(isRecentlyPromoted(person, '3025-07-15', 6)).toBe(true);
+  });
+});

--- a/src/lib/campaign/ranks/__tests__/rankSystems.test.ts
+++ b/src/lib/campaign/ranks/__tests__/rankSystems.test.ts
@@ -1,0 +1,436 @@
+import { Profession } from '@/types/campaign/ranks/rankTypes';
+import {
+  RANK_SYSTEM_MERCENARY,
+  RANK_SYSTEM_SLDF,
+  RANK_SYSTEM_CLAN,
+  RANK_SYSTEM_COMSTAR,
+  RANK_SYSTEM_GENERIC_HOUSE,
+  BUILT_IN_RANK_SYSTEMS,
+  getRankSystem,
+  getDefaultRankSystem,
+} from '@/lib/campaign/ranks/rankSystems';
+
+const ALL_SYSTEMS = [
+  RANK_SYSTEM_MERCENARY,
+  RANK_SYSTEM_SLDF,
+  RANK_SYSTEM_CLAN,
+  RANK_SYSTEM_COMSTAR,
+  RANK_SYSTEM_GENERIC_HOUSE,
+];
+
+describe('rankSystems', () => {
+  describe('all systems share structural invariants', () => {
+    it.each(ALL_SYSTEMS.map((s) => [s.code, s] as const))(
+      '%s has exactly 51 ranks',
+      (_code, system) => {
+        expect(system.ranks).toHaveLength(51);
+      },
+    );
+
+    it.each(ALL_SYSTEMS.map((s) => [s.code, s] as const))(
+      '%s has type "default"',
+      (_code, system) => {
+        expect(system.type).toBe('default');
+      },
+    );
+
+    it.each(ALL_SYSTEMS.map((s) => [s.code, s] as const))(
+      '%s has a non-empty code',
+      (_code, system) => {
+        expect(system.code.length).toBeGreaterThan(0);
+      },
+    );
+
+    it.each(ALL_SYSTEMS.map((s) => [s.code, s] as const))(
+      '%s has a non-empty name',
+      (_code, system) => {
+        expect(system.name.length).toBeGreaterThan(0);
+      },
+    );
+
+    it.each(ALL_SYSTEMS.map((s) => [s.code, s] as const))(
+      '%s has a non-empty description',
+      (_code, system) => {
+        expect(system.description.length).toBeGreaterThan(0);
+      },
+    );
+
+    it.each(ALL_SYSTEMS.map((s) => [s.code, s] as const))(
+      '%s officerCut is 31',
+      (_code, system) => {
+        expect(system.officerCut).toBe(31);
+      },
+    );
+
+    it.each(ALL_SYSTEMS.map((s) => [s.code, s] as const))(
+      '%s pay multipliers are in [1.0, 3.5]',
+      (_code, system) => {
+        for (const r of system.ranks) {
+          expect(r.payMultiplier).toBeGreaterThanOrEqual(1.0);
+          expect(r.payMultiplier).toBeLessThanOrEqual(3.5);
+        }
+      },
+    );
+
+    it.each(ALL_SYSTEMS.map((s) => [s.code, s] as const))(
+      '%s is frozen',
+      (_code, system) => {
+        expect(Object.isFrozen(system)).toBe(true);
+      },
+    );
+  });
+
+  describe('RANK_SYSTEM_MERCENARY', () => {
+    const sys = RANK_SYSTEM_MERCENARY;
+
+    it('has code MERC', () => {
+      expect(sys.code).toBe('MERC');
+    });
+
+    it('has name Mercenary', () => {
+      expect(sys.name).toBe('Mercenary');
+    });
+
+    it('rank 0 has "None" for all 8 professions', () => {
+      const r = sys.ranks[0];
+      expect(r.names[Profession.MEKWARRIOR]).toBe('None');
+      expect(r.names[Profession.AEROSPACE]).toBe('None');
+      expect(r.names[Profession.VEHICLE]).toBe('None');
+      expect(r.names[Profession.NAVAL]).toBe('None');
+      expect(r.names[Profession.INFANTRY]).toBe('None');
+      expect(r.names[Profession.TECH]).toBe('None');
+      expect(r.names[Profession.MEDICAL]).toBe('None');
+      expect(r.names[Profession.ADMINISTRATOR]).toBe('None');
+      expect(r.officer).toBe(false);
+      expect(r.payMultiplier).toBe(1.0);
+    });
+
+    it('rank 1 has profession-specific enlisted names', () => {
+      const r = sys.ranks[1];
+      expect(r.names[Profession.MEKWARRIOR]).toBe('Private');
+      expect(r.names[Profession.AEROSPACE]).toBe('Airman');
+      expect(r.names[Profession.VEHICLE]).toBe('Crewman');
+      expect(r.names[Profession.NAVAL]).toBe('Seaman');
+      expect(r.names[Profession.INFANTRY]).toBe('Trooper');
+      expect(r.names[Profession.TECH]).toBe('Tech');
+      expect(r.names[Profession.MEDICAL]).toBe('Orderly');
+      expect(r.names[Profession.ADMINISTRATOR]).toBe('Clerk');
+    });
+
+    it('rank 5 has branch-specific sergeant names', () => {
+      const r = sys.ranks[5];
+      expect(r.names[Profession.MEKWARRIOR]).toBe('Sergeant');
+      expect(r.names[Profession.AEROSPACE]).toBe('Flight Sergeant');
+      expect(r.names[Profession.VEHICLE]).toBe('Crew Chief');
+      expect(r.names[Profession.NAVAL]).toBe('Petty Officer');
+      expect(r.names[Profession.INFANTRY]).toBe('Squad Leader');
+      expect(r.payMultiplier).toBe(1.1);
+    });
+
+    it('rank 31 is the first officer rank', () => {
+      const r = sys.ranks[31];
+      expect(r.officer).toBe(true);
+      expect(r.names[Profession.MEKWARRIOR]).toBe('Lieutenant');
+      expect(r.names[Profession.AEROSPACE]).toBe('Flight Lieutenant');
+      expect(r.names[Profession.NAVAL]).toBe('Ensign');
+      expect(r.payMultiplier).toBe(1.4);
+    });
+
+    it('rank 50 is General with pay 3.0', () => {
+      const r = sys.ranks[50];
+      expect(r.names[Profession.MEKWARRIOR]).toBe('General');
+      expect(r.officer).toBe(true);
+      expect(r.payMultiplier).toBe(3.0);
+    });
+
+    it('unpopulated rank 2 is empty', () => {
+      const r = sys.ranks[2];
+      expect(Object.keys(r.names)).toHaveLength(0);
+      expect(r.officer).toBe(false);
+      expect(r.payMultiplier).toBe(1.0);
+    });
+
+    it('unpopulated rank 20 is empty', () => {
+      const r = sys.ranks[20];
+      expect(Object.keys(r.names)).toHaveLength(0);
+      expect(r.officer).toBe(false);
+      expect(r.payMultiplier).toBe(1.0);
+    });
+
+    it('enlisted ranks (0-20) are not officers', () => {
+      for (let i = 0; i <= 20; i++) {
+        expect(sys.ranks[i].officer).toBe(false);
+      }
+    });
+  });
+
+  describe('RANK_SYSTEM_SLDF', () => {
+    const sys = RANK_SYSTEM_SLDF;
+
+    it('has code SLDF', () => {
+      expect(sys.code).toBe('SLDF');
+    });
+
+    it('has name Star League Defense Force', () => {
+      expect(sys.name).toBe('Star League Defense Force');
+    });
+
+    it('rank 1 is Recruit', () => {
+      expect(sys.ranks[1].names[Profession.MEKWARRIOR]).toBe('Recruit');
+    });
+
+    it('rank 25 is Senior Warrant Officer', () => {
+      expect(sys.ranks[25].names[Profession.MEKWARRIOR]).toBe('Senior Warrant Officer');
+      expect(sys.ranks[25].payMultiplier).toBe(1.35);
+    });
+
+    it('rank 50 is General with pay 3.0', () => {
+      expect(sys.ranks[50].names[Profession.MEKWARRIOR]).toBe('General');
+      expect(sys.ranks[50].officer).toBe(true);
+      expect(sys.ranks[50].payMultiplier).toBe(3.0);
+    });
+
+    it('uses only mekwarrior profession', () => {
+      for (const r of sys.ranks) {
+        const keys = Object.keys(r.names);
+        if (keys.length > 0) {
+          expect(keys).toEqual([Profession.MEKWARRIOR]);
+        }
+      }
+    });
+  });
+
+  describe('RANK_SYSTEM_CLAN', () => {
+    const sys = RANK_SYSTEM_CLAN;
+
+    it('has code CLAN', () => {
+      expect(sys.code).toBe('CLAN');
+    });
+
+    it('rank 0 is Freeborn', () => {
+      expect(sys.ranks[0].names[Profession.MEKWARRIOR]).toBe('Freeborn');
+    });
+
+    it('rank 5 is Point Commander', () => {
+      expect(sys.ranks[5].names[Profession.MEKWARRIOR]).toBe('Point Commander');
+      expect(sys.ranks[5].payMultiplier).toBe(1.1);
+    });
+
+    it('rank 10 is Star Commander', () => {
+      expect(sys.ranks[10].names[Profession.MEKWARRIOR]).toBe('Star Commander');
+      expect(sys.ranks[10].payMultiplier).toBe(1.2);
+    });
+
+    it('rank 50 is ilKhan with pay 3.5', () => {
+      expect(sys.ranks[50].names[Profession.MEKWARRIOR]).toBe('ilKhan');
+      expect(sys.ranks[50].officer).toBe(true);
+      expect(sys.ranks[50].payMultiplier).toBe(3.5);
+    });
+
+    it('rank 40 is saKhan', () => {
+      expect(sys.ranks[40].names[Profession.MEKWARRIOR]).toBe('saKhan');
+      expect(sys.ranks[40].officer).toBe(true);
+    });
+
+    it('rank 31 is Star Colonel (first officer)', () => {
+      expect(sys.ranks[31].names[Profession.MEKWARRIOR]).toBe('Star Colonel');
+      expect(sys.ranks[31].officer).toBe(true);
+      expect(sys.ranks[31].payMultiplier).toBe(1.5);
+    });
+
+    it('has fewer populated ranks than Mercenary', () => {
+      const clanPopulated = sys.ranks.filter((r) => Object.keys(r.names).length > 0).length;
+      const mercPopulated = RANK_SYSTEM_MERCENARY.ranks.filter(
+        (r) => Object.keys(r.names).length > 0,
+      ).length;
+      expect(clanPopulated).toBeLessThan(mercPopulated);
+    });
+  });
+
+  describe('RANK_SYSTEM_COMSTAR', () => {
+    const sys = RANK_SYSTEM_COMSTAR;
+
+    it('has code COMSTAR', () => {
+      expect(sys.code).toBe('COMSTAR');
+    });
+
+    it('rank 0 is Acolyte', () => {
+      expect(sys.ranks[0].names[Profession.MEKWARRIOR]).toBe('Acolyte');
+    });
+
+    it('rank 3 is Adept', () => {
+      expect(sys.ranks[3].names[Profession.MEKWARRIOR]).toBe('Adept');
+      expect(sys.ranks[3].payMultiplier).toBe(1.05);
+    });
+
+    it('rank 8 is Demi-Precentor', () => {
+      expect(sys.ranks[8].names[Profession.MEKWARRIOR]).toBe('Demi-Precentor');
+    });
+
+    it('rank 31 is Precentor Martial (first officer)', () => {
+      expect(sys.ranks[31].names[Profession.MEKWARRIOR]).toBe('Precentor Martial');
+      expect(sys.ranks[31].officer).toBe(true);
+    });
+
+    it('rank 40 is Primus with pay 2.5', () => {
+      expect(sys.ranks[40].names[Profession.MEKWARRIOR]).toBe('Primus');
+      expect(sys.ranks[40].payMultiplier).toBe(2.5);
+    });
+
+    it('is the most sparse system (fewest populated ranks)', () => {
+      const comstarPopulated = sys.ranks.filter((r) => Object.keys(r.names).length > 0).length;
+      for (const other of ALL_SYSTEMS) {
+        if (other.code === 'COMSTAR') continue;
+        const otherPopulated = other.ranks.filter((r) => Object.keys(r.names).length > 0).length;
+        expect(comstarPopulated).toBeLessThanOrEqual(otherPopulated);
+      }
+    });
+  });
+
+  describe('RANK_SYSTEM_GENERIC_HOUSE', () => {
+    const sys = RANK_SYSTEM_GENERIC_HOUSE;
+
+    it('has code HOUSE', () => {
+      expect(sys.code).toBe('HOUSE');
+    });
+
+    it('rank 31 is Leutnant (Lyran-style)', () => {
+      expect(sys.ranks[31].names[Profession.MEKWARRIOR]).toBe('Leutnant');
+      expect(sys.ranks[31].officer).toBe(true);
+    });
+
+    it('rank 34 is Hauptmann', () => {
+      expect(sys.ranks[34].names[Profession.MEKWARRIOR]).toBe('Hauptmann');
+    });
+
+    it('rank 37 is Kommandant', () => {
+      expect(sys.ranks[37].names[Profession.MEKWARRIOR]).toBe('Kommandant');
+    });
+
+    it("rank 50 is Archon's Champion with pay 3.0", () => {
+      expect(sys.ranks[50].names[Profession.MEKWARRIOR]).toBe("Archon's Champion");
+      expect(sys.ranks[50].payMultiplier).toBe(3.0);
+    });
+
+    it('rank 48 is Marshal', () => {
+      expect(sys.ranks[48].names[Profession.MEKWARRIOR]).toBe('Marshal');
+      expect(sys.ranks[48].payMultiplier).toBe(2.8);
+    });
+  });
+
+  describe('BUILT_IN_RANK_SYSTEMS', () => {
+    it('contains exactly 5 entries', () => {
+      expect(Object.keys(BUILT_IN_RANK_SYSTEMS)).toHaveLength(5);
+    });
+
+    it('maps MERC to RANK_SYSTEM_MERCENARY', () => {
+      expect(BUILT_IN_RANK_SYSTEMS['MERC']).toBe(RANK_SYSTEM_MERCENARY);
+    });
+
+    it('maps SLDF to RANK_SYSTEM_SLDF', () => {
+      expect(BUILT_IN_RANK_SYSTEMS['SLDF']).toBe(RANK_SYSTEM_SLDF);
+    });
+
+    it('maps CLAN to RANK_SYSTEM_CLAN', () => {
+      expect(BUILT_IN_RANK_SYSTEMS['CLAN']).toBe(RANK_SYSTEM_CLAN);
+    });
+
+    it('maps COMSTAR to RANK_SYSTEM_COMSTAR', () => {
+      expect(BUILT_IN_RANK_SYSTEMS['COMSTAR']).toBe(RANK_SYSTEM_COMSTAR);
+    });
+
+    it('maps HOUSE to RANK_SYSTEM_GENERIC_HOUSE', () => {
+      expect(BUILT_IN_RANK_SYSTEMS['HOUSE']).toBe(RANK_SYSTEM_GENERIC_HOUSE);
+    });
+
+    it('is frozen', () => {
+      expect(Object.isFrozen(BUILT_IN_RANK_SYSTEMS)).toBe(true);
+    });
+  });
+
+  describe('getRankSystem', () => {
+    it('returns RANK_SYSTEM_MERCENARY for "MERC"', () => {
+      expect(getRankSystem('MERC')).toBe(RANK_SYSTEM_MERCENARY);
+    });
+
+    it('returns RANK_SYSTEM_SLDF for "SLDF"', () => {
+      expect(getRankSystem('SLDF')).toBe(RANK_SYSTEM_SLDF);
+    });
+
+    it('returns RANK_SYSTEM_CLAN for "CLAN"', () => {
+      expect(getRankSystem('CLAN')).toBe(RANK_SYSTEM_CLAN);
+    });
+
+    it('returns RANK_SYSTEM_COMSTAR for "COMSTAR"', () => {
+      expect(getRankSystem('COMSTAR')).toBe(RANK_SYSTEM_COMSTAR);
+    });
+
+    it('returns RANK_SYSTEM_GENERIC_HOUSE for "HOUSE"', () => {
+      expect(getRankSystem('HOUSE')).toBe(RANK_SYSTEM_GENERIC_HOUSE);
+    });
+
+    it('returns undefined for unknown code', () => {
+      expect(getRankSystem('UNKNOWN')).toBeUndefined();
+    });
+
+    it('returns undefined for empty string', () => {
+      expect(getRankSystem('')).toBeUndefined();
+    });
+
+    it('is case-sensitive', () => {
+      expect(getRankSystem('merc')).toBeUndefined();
+      expect(getRankSystem('Merc')).toBeUndefined();
+    });
+  });
+
+  describe('getDefaultRankSystem', () => {
+    it('returns RANK_SYSTEM_MERCENARY', () => {
+      expect(getDefaultRankSystem()).toBe(RANK_SYSTEM_MERCENARY);
+    });
+
+    it('returns a system with code MERC', () => {
+      expect(getDefaultRankSystem().code).toBe('MERC');
+    });
+  });
+
+  describe('officer flag consistency', () => {
+    it.each(ALL_SYSTEMS.map((s) => [s.code, s] as const))(
+      '%s: populated ranks at/above officerCut have officer=true',
+      (_code, system) => {
+        for (let i = system.officerCut; i < 51; i++) {
+          const r = system.ranks[i];
+          if (Object.keys(r.names).length > 0) {
+            expect(r.officer).toBe(true);
+          }
+        }
+      },
+    );
+
+    it.each(ALL_SYSTEMS.map((s) => [s.code, s] as const))(
+      '%s: populated ranks below officerCut have officer=false',
+      (_code, system) => {
+        for (let i = 0; i < system.officerCut; i++) {
+          const r = system.ranks[i];
+          if (Object.keys(r.names).length > 0) {
+            expect(r.officer).toBe(false);
+          }
+        }
+      },
+    );
+  });
+
+  describe('pay multiplier ordering', () => {
+    it.each(ALL_SYSTEMS.map((s) => [s.code, s] as const))(
+      '%s: populated ranks have non-decreasing pay multipliers',
+      (_code, system) => {
+        let lastPay = 0;
+        for (const r of system.ranks) {
+          if (Object.keys(r.names).length > 0) {
+            expect(r.payMultiplier).toBeGreaterThanOrEqual(lastPay);
+            lastPay = r.payMultiplier;
+          }
+        }
+      },
+    );
+  });
+});

--- a/src/lib/campaign/ranks/campaignRankIntegration.ts
+++ b/src/lib/campaign/ranks/campaignRankIntegration.ts
@@ -1,0 +1,8 @@
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { IRankSystem } from '@/types/campaign/ranks/rankTypes';
+import { getRankSystem, getDefaultRankSystem } from '@/lib/campaign/ranks/rankSystems';
+
+export function getCampaignRankSystem(campaign: ICampaign): IRankSystem {
+  const code = campaign.options.rankSystemCode ?? 'MERC';
+  return getRankSystem(code) ?? getDefaultRankSystem();
+}

--- a/src/lib/campaign/ranks/rankPay.ts
+++ b/src/lib/campaign/ranks/rankPay.ts
@@ -1,0 +1,87 @@
+/**
+ * Rank Pay Functions - Campaign salary and officer share calculations
+ *
+ * Provides functions for calculating salary multipliers based on rank,
+ * monthly salary with rank adjustments, and officer profit shares.
+ *
+ * @module campaign/ranks/rankPay
+ */
+
+import type { IPerson } from '@/types/campaign/Person';
+import type { IRankSystem } from '@/types/campaign/ranks/rankTypes';
+import { isOfficer } from '@/lib/campaign/ranks/rankService';
+
+/**
+ * Gets the pay multiplier for a person based on their rank.
+ *
+ * Returns the payMultiplier from the rank at the person's rankIndex.
+ * If the rank is undefined or has a payMultiplier <= 0, returns 1.0.
+ *
+ * @param person - The person whose pay multiplier to calculate
+ * @param rankSystem - The rank system containing rank definitions
+ * @returns The pay multiplier (default 1.0)
+ *
+ * @example
+ * getRankPayMultiplier(person, rankSystem) // 1.1 for Sergeant
+ * getRankPayMultiplier(person, rankSystem) // 2.0 for Colonel
+ */
+export function getRankPayMultiplier(person: IPerson, rankSystem: IRankSystem): number {
+  const rankIndex = person.rankIndex ?? 0;
+  const rank = rankSystem.ranks[rankIndex];
+
+  if (!rank || rank.payMultiplier <= 0) {
+    return 1.0;
+  }
+
+  return rank.payMultiplier;
+}
+
+/**
+ * Calculates monthly salary with rank adjustment.
+ *
+ * Multiplies the base salary by the rank pay multiplier and rounds to nearest integer.
+ * Note: This function takes baseSalary as a parameter. When Plan 4 salary calculation
+ * is built, this will be integrated with role-based salary lookups.
+ *
+ * @param baseSalary - The base monthly salary before rank adjustment
+ * @param person - The person whose salary to calculate
+ * @param rankSystem - The rank system for rank pay multiplier lookup
+ * @returns The monthly salary rounded to nearest integer
+ *
+ * @example
+ * getPersonMonthlySalaryWithRank(1000, person, rankSystem) // 1100 for Sergeant
+ * getPersonMonthlySalaryWithRank(2000, person, rankSystem) // 4000 for Colonel
+ */
+export function getPersonMonthlySalaryWithRank(
+  baseSalary: number,
+  person: IPerson,
+  rankSystem: IRankSystem,
+): number {
+  return Math.round(baseSalary * getRankPayMultiplier(person, rankSystem));
+}
+
+/**
+ * Calculates the number of profit shares an officer receives.
+ *
+ * Non-officers receive 0 shares. Officers receive shares based on their rank:
+ * - First officer rank (at officerCut) = 1 share
+ * - Each rank above officerCut = +1 share
+ *
+ * Formula: (rankIndex - officerCut) + 1
+ *
+ * @param person - The person whose officer shares to calculate
+ * @param rankSystem - The rank system defining officer status and cut
+ * @returns The number of profit shares (0 for non-officers)
+ *
+ * @example
+ * getOfficerShares(person, rankSystem) // 0 for enlisted
+ * getOfficerShares(person, rankSystem) // 1 for Lieutenant (at officerCut)
+ * getOfficerShares(person, rankSystem) // 5 for Captain (4 ranks above officerCut)
+ */
+export function getOfficerShares(person: IPerson, rankSystem: IRankSystem): number {
+  if (!isOfficer(person, rankSystem)) {
+    return 0;
+  }
+
+  return (person.rankIndex ?? 0) - rankSystem.officerCut + 1;
+}

--- a/src/lib/campaign/ranks/rankService.ts
+++ b/src/lib/campaign/ranks/rankService.ts
@@ -1,0 +1,343 @@
+/**
+ * Rank Service - Campaign rank management functions
+ *
+ * Provides functions for rank name resolution, officer status checks,
+ * promotion/demotion operations, and time-in-rank calculations.
+ *
+ * @module campaign/ranks/rankService
+ */
+
+import {
+  Profession,
+  IRankSystem,
+  isValidRankIndex,
+} from '@/types/campaign/ranks/rankTypes';
+import type { IRank } from '@/types/campaign/ranks/rankTypes';
+import type { IPerson } from '@/types/campaign/Person';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
+
+// =============================================================================
+// Role → Profession Mapping
+// =============================================================================
+
+const ROLE_TO_PROFESSION: ReadonlyMap<CampaignPersonnelRole, Profession> = new Map([
+  // MekWarrior
+  [CampaignPersonnelRole.PILOT, Profession.MEKWARRIOR],
+  [CampaignPersonnelRole.LAM_PILOT, Profession.MEKWARRIOR],
+  [CampaignPersonnelRole.PROTOMEK_PILOT, Profession.MEKWARRIOR],
+
+  // Aerospace
+  [CampaignPersonnelRole.AEROSPACE_PILOT, Profession.AEROSPACE],
+  [CampaignPersonnelRole.CONVENTIONAL_AIRCRAFT_PILOT, Profession.AEROSPACE],
+
+  // Vehicle
+  [CampaignPersonnelRole.VEHICLE_DRIVER, Profession.VEHICLE],
+  [CampaignPersonnelRole.VEHICLE_CREW_VTOL, Profession.VEHICLE],
+
+  // Naval
+  [CampaignPersonnelRole.VEHICLE_CREW_NAVAL, Profession.NAVAL],
+  [CampaignPersonnelRole.VESSEL_PILOT, Profession.NAVAL],
+  [CampaignPersonnelRole.VESSEL_GUNNER, Profession.NAVAL],
+  [CampaignPersonnelRole.VESSEL_CREW, Profession.NAVAL],
+  [CampaignPersonnelRole.VESSEL_NAVIGATOR, Profession.NAVAL],
+
+  // Infantry
+  [CampaignPersonnelRole.BATTLE_ARMOUR, Profession.INFANTRY],
+  [CampaignPersonnelRole.SOLDIER, Profession.INFANTRY],
+
+  // Tech
+  [CampaignPersonnelRole.TECH, Profession.TECH],
+  [CampaignPersonnelRole.MEK_TECH, Profession.TECH],
+  [CampaignPersonnelRole.MECHANIC, Profession.TECH],
+  [CampaignPersonnelRole.AERO_TEK, Profession.TECH],
+  [CampaignPersonnelRole.BA_TECH, Profession.TECH],
+  [CampaignPersonnelRole.ASTECH, Profession.TECH],
+
+  // Medical
+  [CampaignPersonnelRole.DOCTOR, Profession.MEDICAL],
+  [CampaignPersonnelRole.MEDIC, Profession.MEDICAL],
+
+  // Administrator
+  [CampaignPersonnelRole.ADMIN_COMMAND, Profession.ADMINISTRATOR],
+  [CampaignPersonnelRole.ADMIN_LOGISTICS, Profession.ADMINISTRATOR],
+  [CampaignPersonnelRole.ADMIN_TRANSPORT, Profession.ADMINISTRATOR],
+  [CampaignPersonnelRole.ADMIN_HR, Profession.ADMINISTRATOR],
+  [CampaignPersonnelRole.ADMIN, Profession.ADMINISTRATOR],
+]);
+
+/**
+ * Maps a CampaignPersonnelRole to its corresponding Profession.
+ *
+ * Used to determine which rank name column to use for a given person.
+ * Unmapped roles (civilians, support staff, unassigned) default to CIVILIAN.
+ *
+ * @param role - The personnel role to map
+ * @returns The corresponding Profession enum value
+ */
+export function mapRoleToProfession(role: CampaignPersonnelRole): Profession {
+  return ROLE_TO_PROFESSION.get(role) ?? Profession.CIVILIAN;
+}
+
+// =============================================================================
+// Rank Name Resolution
+// =============================================================================
+
+/**
+ * Resolves the display name for a rank entry given a profession.
+ *
+ * Falls back to the MekWarrior name if the profession-specific name is not set,
+ * then falls back to 'None' if no name is available at all.
+ */
+function resolveRankName(rank: IRank | undefined, profession: Profession): string {
+  if (!rank) {
+    return 'None';
+  }
+  return rank.names[profession] ?? rank.names[Profession.MEKWARRIOR] ?? 'None';
+}
+
+/**
+ * Gets the display rank name for a person within a rank system.
+ *
+ * @param person - The person whose rank name to resolve
+ * @param rankSystem - The rank system to look up names in
+ * @returns The display rank name string
+ */
+export function getRankName(person: IPerson, rankSystem: IRankSystem): string {
+  const rankIndex = person.rankIndex ?? 0;
+  const rank = rankSystem.ranks[rankIndex];
+  const profession = mapRoleToProfession(person.primaryRole);
+  return resolveRankName(rank, profession);
+}
+
+/**
+ * Gets the display rank name by index and role directly.
+ *
+ * Useful for preview/display without a full IPerson object.
+ *
+ * @param rankIndex - The rank index (0-50)
+ * @param role - The personnel role for profession mapping
+ * @param rankSystem - The rank system to look up names in
+ * @returns The display rank name string
+ */
+export function getRankNameByIndex(
+  rankIndex: number,
+  role: CampaignPersonnelRole,
+  rankSystem: IRankSystem,
+): string {
+  const rank = rankSystem.ranks[rankIndex];
+  const profession = mapRoleToProfession(role);
+  return resolveRankName(rank, profession);
+}
+
+// =============================================================================
+// Officer Status
+// =============================================================================
+
+/**
+ * Checks if a person holds an officer rank.
+ *
+ * @param person - The person to check
+ * @param rankSystem - The rank system defining the officer cutoff
+ * @returns true if the person's rank index is at or above the officer cut
+ */
+export function isOfficer(person: IPerson, rankSystem: IRankSystem): boolean {
+  return (person.rankIndex ?? 0) >= rankSystem.officerCut;
+}
+
+/**
+ * Checks if a rank index is at officer level.
+ *
+ * @param rankIndex - The rank index to check
+ * @param rankSystem - The rank system defining the officer cutoff
+ * @returns true if the rank index is at or above the officer cut
+ */
+export function isOfficerByIndex(rankIndex: number, rankSystem: IRankSystem): boolean {
+  return rankIndex >= rankSystem.officerCut;
+}
+
+// =============================================================================
+// Promotion / Demotion Result Type
+// =============================================================================
+
+export interface RankChangeResult {
+  readonly updatedPerson: IPerson;
+  readonly valid: boolean;
+  readonly reason?: string;
+}
+
+// =============================================================================
+// Promotion
+// =============================================================================
+
+/**
+ * Promotes a person to a new (higher) rank index.
+ *
+ * Validates the new rank index and ensures it is higher than the current rank.
+ * On success, updates the person's rankIndex, rank display name,
+ * lastRankChangeDate, and lastPromotionDate.
+ *
+ * @param person - The person to promote
+ * @param newRankIndex - The target rank index (must be higher than current)
+ * @param currentDate - ISO date string for the promotion date
+ * @param rankSystem - The rank system for name resolution
+ * @returns A RankChangeResult with the updated person and validity info
+ */
+export function promoteToRank(
+  person: IPerson,
+  newRankIndex: number,
+  currentDate: string,
+  rankSystem: IRankSystem,
+): RankChangeResult {
+  if (!isValidRankIndex(newRankIndex)) {
+    return { updatedPerson: person, valid: false, reason: 'Rank index out of range (0-50)' };
+  }
+
+  const currentRankIndex = person.rankIndex ?? 0;
+  if (newRankIndex <= currentRankIndex) {
+    return { updatedPerson: person, valid: false, reason: 'New rank must be higher than current rank' };
+  }
+
+  const newRankName = getRankNameByIndex(newRankIndex, person.primaryRole, rankSystem);
+  const changeDate = new Date(currentDate);
+
+  const updatedPerson: IPerson = {
+    ...person,
+    rankIndex: newRankIndex,
+    rank: newRankName,
+    lastRankChangeDate: changeDate,
+    lastPromotionDate: changeDate,
+  };
+
+  return { updatedPerson, valid: true };
+}
+
+// =============================================================================
+// Demotion
+// =============================================================================
+
+/**
+ * Demotes a person to a new (lower) rank index.
+ *
+ * Validates the new rank index and ensures it is lower than the current rank.
+ * On success, updates the person's rankIndex, rank display name, and
+ * lastRankChangeDate. Does NOT update lastPromotionDate on demotion.
+ *
+ * @param person - The person to demote
+ * @param newRankIndex - The target rank index (must be lower than current)
+ * @param currentDate - ISO date string for the demotion date
+ * @param rankSystem - The rank system for name resolution
+ * @returns A RankChangeResult with the updated person and validity info
+ */
+export function demoteToRank(
+  person: IPerson,
+  newRankIndex: number,
+  currentDate: string,
+  rankSystem: IRankSystem,
+): RankChangeResult {
+  if (!isValidRankIndex(newRankIndex)) {
+    return { updatedPerson: person, valid: false, reason: 'Rank index out of range (0-50)' };
+  }
+
+  const currentRankIndex = person.rankIndex ?? 0;
+  if (newRankIndex >= currentRankIndex) {
+    return { updatedPerson: person, valid: false, reason: 'New rank must be lower than current rank' };
+  }
+
+  const newRankName = getRankNameByIndex(newRankIndex, person.primaryRole, rankSystem);
+  const changeDate = new Date(currentDate);
+
+  const updatedPerson: IPerson = {
+    ...person,
+    rankIndex: newRankIndex,
+    rank: newRankName,
+    lastRankChangeDate: changeDate,
+  };
+
+  return { updatedPerson, valid: true };
+}
+
+// =============================================================================
+// Time in Rank
+// =============================================================================
+
+export interface TimeInRankResult {
+  readonly days: number;
+  readonly months: number;
+  readonly years: number;
+  readonly display: string;
+}
+
+/**
+ * Calculates how long a person has held their current rank.
+ *
+ * Uses lastRankChangeDate if available, otherwise falls back to recruitmentDate.
+ *
+ * @param person - The person to check
+ * @param currentDate - ISO date string for the current date
+ * @returns An object with days, months, years, and a formatted display string
+ */
+export function getTimeInRank(person: IPerson, currentDate: string): TimeInRankResult {
+  const startDate = person.lastRankChangeDate ?? person.recruitmentDate;
+  const endDate = new Date(currentDate);
+  const start = new Date(startDate);
+
+  const totalMs = endDate.getTime() - start.getTime();
+  const totalDays = Math.floor(totalMs / (1000 * 60 * 60 * 24));
+
+  // Use UTC methods to avoid timezone shifts with ISO date strings
+  let years = endDate.getUTCFullYear() - start.getUTCFullYear();
+  let months = endDate.getUTCMonth() - start.getUTCMonth();
+  let days = endDate.getUTCDate() - start.getUTCDate();
+
+  if (days < 0) {
+    months -= 1;
+    const prevMonth = new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), 0));
+    days += prevMonth.getUTCDate();
+  }
+
+  if (months < 0) {
+    years -= 1;
+    months += 12;
+  }
+
+  let display: string;
+  if (years > 0) {
+    display = `${years} year${years !== 1 ? 's' : ''}, ${months} month${months !== 1 ? 's' : ''}`;
+  } else if (months > 0) {
+    display = `${months} month${months !== 1 ? 's' : ''}, ${days} day${days !== 1 ? 's' : ''}`;
+  } else {
+    display = `${totalDays} day${totalDays !== 1 ? 's' : ''}`;
+  }
+
+  return { days: totalDays, months, years, display };
+}
+
+// =============================================================================
+// Recently Promoted Check
+// =============================================================================
+
+/**
+ * Checks if a person was recently promoted (within a threshold).
+ *
+ * @param person - The person to check
+ * @param currentDate - ISO date string for the current date
+ * @param monthsThreshold - Number of months to consider "recent" (default: 6)
+ * @returns true if the person was promoted within the threshold period
+ */
+export function isRecentlyPromoted(
+  person: IPerson,
+  currentDate: string,
+  monthsThreshold: number = 6,
+): boolean {
+  if (!person.lastPromotionDate) {
+    return false;
+  }
+
+  const promotionDate = new Date(person.lastPromotionDate);
+  const current = new Date(currentDate);
+
+  const thresholdDate = new Date(current);
+  thresholdDate.setUTCMonth(thresholdDate.getUTCMonth() - monthsThreshold);
+
+  return promotionDate >= thresholdDate;
+}

--- a/src/lib/campaign/ranks/rankSystems.ts
+++ b/src/lib/campaign/ranks/rankSystems.ts
@@ -1,0 +1,260 @@
+import { IRank, IRankSystem, Profession, createRanks } from '@/types/campaign/ranks/rankTypes';
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function createRankSystem(
+  code: string,
+  name: string,
+  description: string,
+  officerCut: number,
+  populatedRanks: Record<number, IRank>,
+): IRankSystem {
+  return Object.freeze({
+    code,
+    name,
+    description,
+    type: 'default' as const,
+    ranks: createRanks(populatedRanks),
+    officerCut,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Rank builder helpers (reduce repetition)
+// ---------------------------------------------------------------------------
+
+function rank(
+  names: Partial<Record<Profession, string>>,
+  officer: boolean,
+  payMultiplier: number,
+): IRank {
+  return { names, officer, payMultiplier };
+}
+
+/** Shorthand: single mekwarrior-only name */
+function mekRank(name: string, officer: boolean, payMultiplier: number): IRank {
+  return rank({ [Profession.MEKWARRIOR]: name }, officer, payMultiplier);
+}
+
+// ---------------------------------------------------------------------------
+// 1. MERCENARY
+// ---------------------------------------------------------------------------
+
+export const RANK_SYSTEM_MERCENARY: IRankSystem = createRankSystem(
+  'MERC',
+  'Mercenary',
+  'Standard mercenary command rank structure used by most Inner Sphere mercenary units.',
+  31,
+  {
+    0: rank(
+      {
+        [Profession.MEKWARRIOR]: 'None',
+        [Profession.AEROSPACE]: 'None',
+        [Profession.VEHICLE]: 'None',
+        [Profession.NAVAL]: 'None',
+        [Profession.INFANTRY]: 'None',
+        [Profession.TECH]: 'None',
+        [Profession.MEDICAL]: 'None',
+        [Profession.ADMINISTRATOR]: 'None',
+      },
+      false,
+      1.0,
+    ),
+    1: rank(
+      {
+        [Profession.MEKWARRIOR]: 'Private',
+        [Profession.AEROSPACE]: 'Airman',
+        [Profession.VEHICLE]: 'Crewman',
+        [Profession.NAVAL]: 'Seaman',
+        [Profession.INFANTRY]: 'Trooper',
+        [Profession.TECH]: 'Tech',
+        [Profession.MEDICAL]: 'Orderly',
+        [Profession.ADMINISTRATOR]: 'Clerk',
+      },
+      false,
+      1.0,
+    ),
+    3: mekRank('Corporal', false, 1.05),
+    5: rank(
+      {
+        [Profession.MEKWARRIOR]: 'Sergeant',
+        [Profession.AEROSPACE]: 'Flight Sergeant',
+        [Profession.VEHICLE]: 'Crew Chief',
+        [Profession.NAVAL]: 'Petty Officer',
+        [Profession.INFANTRY]: 'Squad Leader',
+      },
+      false,
+      1.1,
+    ),
+    8: mekRank('Staff Sergeant', false, 1.15),
+    11: rank(
+      {
+        [Profession.MEKWARRIOR]: 'Master Sergeant',
+        [Profession.AEROSPACE]: 'Chief Master Sergeant',
+        [Profession.NAVAL]: 'Master Chief',
+      },
+      false,
+      1.2,
+    ),
+    15: mekRank('Sergeant Major', false, 1.25),
+    21: mekRank('Warrant Officer', false, 1.3),
+    25: mekRank('Chief Warrant Officer', false, 1.35),
+    31: rank(
+      {
+        [Profession.MEKWARRIOR]: 'Lieutenant',
+        [Profession.AEROSPACE]: 'Flight Lieutenant',
+        [Profession.NAVAL]: 'Ensign',
+      },
+      true,
+      1.4,
+    ),
+    34: rank(
+      {
+        [Profession.MEKWARRIOR]: 'Captain',
+        [Profession.AEROSPACE]: 'Flight Captain',
+        [Profession.NAVAL]: 'Lieutenant Commander',
+      },
+      true,
+      1.6,
+    ),
+    37: rank(
+      {
+        [Profession.MEKWARRIOR]: 'Major',
+        [Profession.AEROSPACE]: 'Wing Commander',
+        [Profession.NAVAL]: 'Commander',
+      },
+      true,
+      1.8,
+    ),
+    40: mekRank('Colonel', true, 2.0),
+    43: mekRank('Brigadier General', true, 2.2),
+    45: mekRank('Major General', true, 2.5),
+    48: mekRank('Lieutenant General', true, 2.8),
+    50: mekRank('General', true, 3.0),
+  },
+);
+
+// ---------------------------------------------------------------------------
+// 2. SLDF
+// ---------------------------------------------------------------------------
+
+export const RANK_SYSTEM_SLDF: IRankSystem = createRankSystem(
+  'SLDF',
+  'Star League Defense Force',
+  'Rank structure of the original Star League Defense Force.',
+  31,
+  {
+    0: mekRank('None', false, 1.0),
+    1: mekRank('Recruit', false, 1.0),
+    3: mekRank('Private', false, 1.05),
+    5: mekRank('Corporal', false, 1.1),
+    8: mekRank('Sergeant', false, 1.15),
+    11: mekRank('Staff Sergeant', false, 1.2),
+    15: mekRank('Master Sergeant', false, 1.25),
+    21: mekRank('Warrant Officer', false, 1.3),
+    25: mekRank('Senior Warrant Officer', false, 1.35),
+    31: mekRank('Lieutenant', true, 1.4),
+    34: mekRank('Captain', true, 1.6),
+    37: mekRank('Major', true, 1.8),
+    40: mekRank('Colonel', true, 2.0),
+    43: mekRank('Brigadier General', true, 2.2),
+    45: mekRank('Major General', true, 2.5),
+    48: mekRank('Lieutenant General', true, 2.8),
+    50: mekRank('General', true, 3.0),
+  },
+);
+
+// ---------------------------------------------------------------------------
+// 3. CLAN
+// ---------------------------------------------------------------------------
+
+export const RANK_SYSTEM_CLAN: IRankSystem = createRankSystem(
+  'CLAN',
+  'Clan Warrior Caste',
+  'Clan warrior caste rank structure used by all Clans.',
+  31,
+  {
+    0: mekRank('Freeborn', false, 1.0),
+    1: mekRank('Warrior', false, 1.0),
+    5: mekRank('Point Commander', false, 1.1),
+    10: mekRank('Star Commander', false, 1.2),
+    15: mekRank('Nova Commander', false, 1.3),
+    21: mekRank('Star Captain', false, 1.35),
+    31: mekRank('Star Colonel', true, 1.5),
+    35: mekRank('Galaxy Commander', true, 1.8),
+    40: mekRank('saKhan', true, 2.2),
+    45: mekRank('Khan', true, 2.8),
+    50: mekRank('ilKhan', true, 3.5),
+  },
+);
+
+// ---------------------------------------------------------------------------
+// 4. COMSTAR
+// ---------------------------------------------------------------------------
+
+export const RANK_SYSTEM_COMSTAR: IRankSystem = createRankSystem(
+  'COMSTAR',
+  'ComStar',
+  'ComStar religious-themed rank hierarchy.',
+  31,
+  {
+    0: mekRank('Acolyte', false, 1.0),
+    3: mekRank('Adept', false, 1.05),
+    8: mekRank('Demi-Precentor', false, 1.15),
+    15: mekRank('Precentor', false, 1.3),
+    31: mekRank('Precentor Martial', true, 1.6),
+    37: mekRank('Precentor ROM', true, 1.8),
+    40: mekRank('Primus', true, 2.5),
+  },
+);
+
+// ---------------------------------------------------------------------------
+// 5. GENERIC HOUSE
+// ---------------------------------------------------------------------------
+
+export const RANK_SYSTEM_GENERIC_HOUSE: IRankSystem = createRankSystem(
+  'HOUSE',
+  'Great House (Generic)',
+  'Generic Great House military rank structure blending Lyran, Davion, Liao, Marik, and Kurita conventions.',
+  31,
+  {
+    0: mekRank('None', false, 1.0),
+    1: mekRank('Private', false, 1.0),
+    3: mekRank('Corporal', false, 1.05),
+    5: mekRank('Sergeant', false, 1.1),
+    8: mekRank('Staff Sergeant', false, 1.15),
+    11: mekRank('Master Sergeant', false, 1.2),
+    15: mekRank('Sergeant Major', false, 1.25),
+    21: mekRank('Warrant Officer', false, 1.3),
+    31: mekRank('Leutnant', true, 1.4),
+    34: mekRank('Hauptmann', true, 1.6),
+    37: mekRank('Kommandant', true, 1.8),
+    40: mekRank('Colonel', true, 2.0),
+    43: mekRank('Leutnant-General', true, 2.2),
+    45: mekRank('General', true, 2.5),
+    48: mekRank('Marshal', true, 2.8),
+    50: mekRank("Archon's Champion", true, 3.0),
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Lookup helpers
+// ---------------------------------------------------------------------------
+
+export const BUILT_IN_RANK_SYSTEMS: Record<string, IRankSystem> = Object.freeze({
+  [RANK_SYSTEM_MERCENARY.code]: RANK_SYSTEM_MERCENARY,
+  [RANK_SYSTEM_SLDF.code]: RANK_SYSTEM_SLDF,
+  [RANK_SYSTEM_CLAN.code]: RANK_SYSTEM_CLAN,
+  [RANK_SYSTEM_COMSTAR.code]: RANK_SYSTEM_COMSTAR,
+  [RANK_SYSTEM_GENERIC_HOUSE.code]: RANK_SYSTEM_GENERIC_HOUSE,
+});
+
+export function getRankSystem(code: string): IRankSystem | undefined {
+  return BUILT_IN_RANK_SYSTEMS[code];
+}
+
+export function getDefaultRankSystem(): IRankSystem {
+  return RANK_SYSTEM_MERCENARY;
+}

--- a/src/types/campaign/Campaign.ts
+++ b/src/types/campaign/Campaign.ts
@@ -343,6 +343,13 @@ export interface ICampaignOptions {
 
     /** Auto-award system configuration (optional, defaults to all enabled) */
     readonly autoAwardConfig?: IAutoAwardConfig;
+
+    // =========================================================================
+    // Rank System Options
+    // =========================================================================
+
+    /** Code of the active rank system (e.g., 'MERC', 'SLDF', 'CLAN', 'COMSTAR', 'HOUSE') */
+    readonly rankSystemCode?: string;
 }
 
 // =============================================================================
@@ -845,6 +852,9 @@ export function createDefaultCampaignOptions(): ICampaignOptions {
       usePlanetaryModifiers: true,
       acquisitionTransitUnit: 'month',
       clanPartsPenalty: true,
+
+      // Rank system
+      rankSystemCode: 'MERC',
     };
 }
 

--- a/src/types/campaign/Person.ts
+++ b/src/types/campaign/Person.ts
@@ -308,18 +308,21 @@ export interface IPerson extends IPersonIdentity, IPersonBackground {
   /** Secondary role (optional) */
   readonly secondaryRole?: CampaignPersonnelRole;
 
-  // =========================================================================
-  // Career (from IPersonCareer)
-  // =========================================================================
+   // =========================================================================
+   // Career (from IPersonCareer)
+   // =========================================================================
 
-  /** Current rank title */
-  readonly rank: string;
+   /** Current rank title */
+   readonly rank: string;
 
-  /** Rank level (numeric for sorting) */
-  readonly rankLevel?: number;
+   /** Rank level (numeric for sorting) */
+   readonly rankLevel?: number;
 
-  /** Date joined the campaign/unit */
-  readonly recruitmentDate: Date;
+   /** Numeric rank index (0-50) in the rank system */
+   readonly rankIndex?: number;
+
+   /** Date joined the campaign/unit */
+   readonly recruitmentDate: Date;
 
   /** Date of death (if deceased) */
   readonly deathDate?: Date;

--- a/src/types/campaign/ranks/__tests__/rankTypes.test.ts
+++ b/src/types/campaign/ranks/__tests__/rankTypes.test.ts
@@ -1,0 +1,193 @@
+import {
+  Profession,
+  IRank,
+  IRankSystem,
+  RANK_TIERS,
+  RankTier,
+  getRankTier,
+  isValidRankIndex,
+  createEmptyRank,
+  createRanks,
+  isProfession,
+  isRankTier,
+  ALL_PROFESSIONS,
+} from '../rankTypes';
+
+describe('rankTypes', () => {
+  describe('RANK_TIERS', () => {
+    it('should have TOTAL equal to 51', () => {
+      expect(RANK_TIERS.TOTAL).toBe(51);
+    });
+
+    it('should have correct enlisted tier boundaries', () => {
+      expect(RANK_TIERS.ENLISTED_MIN).toBe(0);
+      expect(RANK_TIERS.ENLISTED_MAX).toBe(20);
+    });
+
+    it('should have correct warrant officer tier boundaries', () => {
+      expect(RANK_TIERS.WARRANT_MIN).toBe(21);
+      expect(RANK_TIERS.WARRANT_MAX).toBe(30);
+    });
+
+    it('should have correct officer tier boundaries', () => {
+      expect(RANK_TIERS.OFFICER_MIN).toBe(31);
+      expect(RANK_TIERS.OFFICER_MAX).toBe(50);
+    });
+  });
+
+  describe('Profession enum', () => {
+    it('should have 9 profession values', () => {
+      const professions = Object.values(Profession);
+      expect(professions).toHaveLength(9);
+    });
+
+    it('should have all unique profession values', () => {
+      const professions = Object.values(Profession);
+      const uniqueProfessions = new Set(professions);
+      expect(uniqueProfessions.size).toBe(professions.length);
+    });
+  });
+
+  describe('getRankTier', () => {
+    it('should return enlisted for rank 0', () => {
+      expect(getRankTier(0)).toBe('enlisted');
+    });
+
+    it('should return enlisted for rank 20 (boundary)', () => {
+      expect(getRankTier(20)).toBe('enlisted');
+    });
+
+    it('should return warrant_officer for rank 21', () => {
+      expect(getRankTier(21)).toBe('warrant_officer');
+    });
+
+    it('should return warrant_officer for rank 30 (boundary)', () => {
+      expect(getRankTier(30)).toBe('warrant_officer');
+    });
+
+    it('should return officer for rank 31', () => {
+      expect(getRankTier(31)).toBe('officer');
+    });
+
+    it('should return officer for rank 50 (boundary)', () => {
+      expect(getRankTier(50)).toBe('officer');
+    });
+  });
+
+  describe('isValidRankIndex', () => {
+    it('should return true for rank 0', () => {
+      expect(isValidRankIndex(0)).toBe(true);
+    });
+
+    it('should return true for rank 50', () => {
+      expect(isValidRankIndex(50)).toBe(true);
+    });
+
+    it('should return false for rank 51', () => {
+      expect(isValidRankIndex(51)).toBe(false);
+    });
+
+    it('should return false for rank -1', () => {
+      expect(isValidRankIndex(-1)).toBe(false);
+    });
+
+    it('should return false for non-integer values', () => {
+      expect(isValidRankIndex(10.5)).toBe(false);
+    });
+  });
+
+  describe('createEmptyRank', () => {
+    it('should return a rank with empty names object', () => {
+      const rank = createEmptyRank();
+      expect(rank.names).toEqual({});
+    });
+
+    it('should return a rank with officer set to false', () => {
+      const rank = createEmptyRank();
+      expect(rank.officer).toBe(false);
+    });
+
+    it('should return a rank with payMultiplier of 1.0', () => {
+      const rank = createEmptyRank();
+      expect(rank.payMultiplier).toBe(1.0);
+    });
+  });
+
+  describe('createRanks', () => {
+    it('should return an array of length 51', () => {
+      const ranks = createRanks({});
+      expect(ranks).toHaveLength(51);
+    });
+
+    it('should populate specified indices with provided ranks', () => {
+      const customRank: IRank = {
+        names: { [Profession.MEKWARRIOR]: 'Colonel' },
+        officer: true,
+        payMultiplier: 2.5,
+      };
+      const ranks = createRanks({ 50: customRank });
+      expect(ranks[50]).toBe(customRank);
+    });
+
+    it('should fill unpopulated indices with empty ranks', () => {
+      const customRank: IRank = {
+        names: { [Profession.MEKWARRIOR]: 'Major' },
+        officer: true,
+        payMultiplier: 2.0,
+      };
+      const ranks = createRanks({ 0: customRank });
+      expect(ranks[1]).toEqual(createEmptyRank());
+    });
+
+    it('should return a frozen array', () => {
+      const ranks = createRanks({});
+      expect(Object.isFrozen(ranks)).toBe(true);
+    });
+  });
+
+  describe('isProfession', () => {
+    it('should return true for valid profession values', () => {
+      expect(isProfession(Profession.MEKWARRIOR)).toBe(true);
+      expect(isProfession(Profession.TECH)).toBe(true);
+      expect(isProfession(Profession.CIVILIAN)).toBe(true);
+    });
+
+    it('should return false for invalid values', () => {
+      expect(isProfession('invalid')).toBe(false);
+      expect(isProfession(123)).toBe(false);
+      expect(isProfession(null)).toBe(false);
+    });
+  });
+
+  describe('isRankTier', () => {
+    it('should return true for valid rank tier values', () => {
+      expect(isRankTier('enlisted')).toBe(true);
+      expect(isRankTier('warrant_officer')).toBe(true);
+      expect(isRankTier('officer')).toBe(true);
+    });
+
+    it('should return false for invalid values', () => {
+      expect(isRankTier('invalid')).toBe(false);
+      expect(isRankTier(123)).toBe(false);
+      expect(isRankTier(null)).toBe(false);
+    });
+  });
+
+  describe('ALL_PROFESSIONS', () => {
+    it('should be a frozen array', () => {
+      expect(Object.isFrozen(ALL_PROFESSIONS)).toBe(true);
+    });
+
+    it('should contain all profession values', () => {
+      expect(ALL_PROFESSIONS).toContain(Profession.MEKWARRIOR);
+      expect(ALL_PROFESSIONS).toContain(Profession.AEROSPACE);
+      expect(ALL_PROFESSIONS).toContain(Profession.VEHICLE);
+      expect(ALL_PROFESSIONS).toContain(Profession.NAVAL);
+      expect(ALL_PROFESSIONS).toContain(Profession.INFANTRY);
+      expect(ALL_PROFESSIONS).toContain(Profession.TECH);
+      expect(ALL_PROFESSIONS).toContain(Profession.MEDICAL);
+      expect(ALL_PROFESSIONS).toContain(Profession.ADMINISTRATOR);
+      expect(ALL_PROFESSIONS).toContain(Profession.CIVILIAN);
+    });
+  });
+});

--- a/src/types/campaign/ranks/rankTypes.ts
+++ b/src/types/campaign/ranks/rankTypes.ts
@@ -1,0 +1,71 @@
+export enum Profession {
+  MEKWARRIOR = 'mekwarrior',
+  AEROSPACE = 'aerospace',
+  VEHICLE = 'vehicle',
+  NAVAL = 'naval',
+  INFANTRY = 'infantry',
+  TECH = 'tech',
+  MEDICAL = 'medical',
+  ADMINISTRATOR = 'administrator',
+  CIVILIAN = 'civilian',
+}
+
+export interface IRank {
+  readonly names: Partial<Record<Profession, string>>;
+  readonly officer: boolean;
+  readonly payMultiplier: number;
+}
+
+export interface IRankSystem {
+  readonly code: string;
+  readonly name: string;
+  readonly description: string;
+  readonly type: 'default' | 'custom' | 'campaign';
+  readonly ranks: readonly IRank[];
+  readonly officerCut: number;
+}
+
+export const RANK_TIERS = {
+  ENLISTED_MIN: 0,
+  ENLISTED_MAX: 20,
+  WARRANT_MIN: 21,
+  WARRANT_MAX: 30,
+  OFFICER_MIN: 31,
+  OFFICER_MAX: 50,
+  TOTAL: 51,
+} as const;
+
+export type RankTier = 'enlisted' | 'warrant_officer' | 'officer';
+
+export function getRankTier(rankIndex: number): RankTier {
+  if (rankIndex >= RANK_TIERS.OFFICER_MIN) return 'officer';
+  if (rankIndex >= RANK_TIERS.WARRANT_MIN) return 'warrant_officer';
+  return 'enlisted';
+}
+
+export function isValidRankIndex(rankIndex: number): boolean {
+  return Number.isInteger(rankIndex) && rankIndex >= 0 && rankIndex < RANK_TIERS.TOTAL;
+}
+
+export function createEmptyRank(): IRank {
+  return { names: {}, officer: false, payMultiplier: 1.0 };
+}
+
+export function createRanks(populatedRanks: Record<number, IRank>): readonly IRank[] {
+  const ranks: IRank[] = [];
+  for (let i = 0; i < RANK_TIERS.TOTAL; i++) {
+    ranks.push(populatedRanks[i] ?? createEmptyRank());
+  }
+  return Object.freeze(ranks);
+}
+
+// Type guards
+export function isProfession(value: unknown): value is Profession {
+  return typeof value === 'string' && Object.values(Profession).includes(value as Profession);
+}
+
+export function isRankTier(value: unknown): value is RankTier {
+  return value === 'enlisted' || value === 'warrant_officer' || value === 'officer';
+}
+
+export const ALL_PROFESSIONS: readonly Profession[] = Object.freeze(Object.values(Profession));


### PR DESCRIPTION
## Summary
- Implement Plan 15 (Rank System) from the Campaign Meta-Execution Plan
- Add 51-slot rank structure with 9 professions (MekWarrior, Aerospace, Vehicle, Naval, Infantry, Tech, Medical, Administrator, Civilian)
- Define 5 built-in faction rank systems (Mercenary, SLDF, Clan, ComStar, Generic House)
- Implement rank service with promotion/demotion, name resolution, officer status, and time-in-rank tracking
- Add rank pay multiplier and officer shares calculations
- Integrate rank system with campaign options (default: Mercenary)
- 262 new tests across 5 test files

## Files Added
- `src/types/campaign/ranks/rankTypes.ts` — Profession enum, IRank, IRankSystem, RANK_TIERS, utility functions
- `src/lib/campaign/ranks/rankSystems.ts` — 5 built-in faction rank systems with profession-specific names
- `src/lib/campaign/ranks/rankService.ts` — Promote/demote, name resolution, officer check, time-in-rank
- `src/lib/campaign/ranks/rankPay.ts` — Pay multiplier, salary with rank, officer shares
- `src/lib/campaign/ranks/campaignRankIntegration.ts` — getCampaignRankSystem helper

## Files Modified
- `src/types/campaign/Person.ts` — Added `rankIndex?: number` field
- `src/types/campaign/Campaign.ts` — Added `rankSystemCode?: string` to ICampaignOptions

## Task Breakdown
- 15.1: Define rank types with 51-slot structure ✅
- 15.2: Define 5 built-in faction rank systems ✅
- 15.3: Implement rank service with promotion and name resolution ✅
- 15.4: Implement rank pay multiplier and officer shares ✅
- 15.5: Integrate rank system with campaign options ✅
- 15.6: UI (deferred)