### PR TITLE
chore(openspec): add campaign presets proposal (Plan 6)

### DIFF
--- a/openspec/changes/add-campaign-presets/proposal.md
+++ b/openspec/changes/add-campaign-presets/proposal.md
@@ -1,0 +1,20 @@
+# Change: Add Campaign Options & Presets System
+
+## Why
+MekStation's ICampaignOptions has grown to 80+ fields across 10+ categories. New players face a wall of options during campaign creation. A preset system (Casual/Standard/Full/Custom) bundles sensible defaults so newcomers can start quickly while veterans can fine-tune everything.
+
+## What Changes
+- Add `CampaignType` enum (Mercenary, House Command, Clan, Pirate, ComStar) with display metadata
+- Add `CampaignPreset` enum (Casual, Standard, Full, Custom) with preset definitions
+- Add `ICampaignOptionMeta` metadata for every ICampaignOptions field (group, label, type, range)
+- Add `OptionGroupId` enum for UI organization (13 groups)
+- Add `applyPreset()` service to apply preset + campaign type defaults
+- Add export/import preset as JSON for community sharing
+- Add `validateCampaignOptions()` for range and dependency validation
+- Add `campaignType` and `activePreset` fields to ICampaign
+- Add campaign creation wizard UI with 4-step flow
+
+## Impact
+- Affected specs: `campaign-management` (MODIFIED), `campaign-ui` (MODIFIED), `campaign-presets` (NEW)
+- Affected code: `src/types/campaign/Campaign.ts`, new type/lib/component files
+- **BREAKING**: `campaignType` is a new required field on ICampaign (existing campaigns default to MERCENARY)

--- a/openspec/changes/add-campaign-presets/specs/campaign-management/spec.md
+++ b/openspec/changes/add-campaign-presets/specs/campaign-management/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Campaign Type Classification
+The system SHALL define a CampaignType enum with values MERCENARY, HOUSE_COMMAND, CLAN, PIRATE, and COMSTAR, each with display name and description metadata.
+
+#### Scenario: All campaign types defined
+- **GIVEN** the CampaignType enum is imported
+- **WHEN** all values are enumerated
+- **THEN** exactly 5 types exist: mercenary, house_command, clan, pirate, comstar
+
+#### Scenario: Campaign type display metadata
+- **GIVEN** CampaignType.MERCENARY
+- **WHEN** CAMPAIGN_TYPE_DISPLAY is queried
+- **THEN** the display name is "Mercenary Company" and a description string is available
+
+### Requirement: Campaign Type and Preset on Campaign Entity
+The system SHALL add `campaignType` (required CampaignType) and `activePreset` (optional CampaignPreset) fields to ICampaign. Existing campaigns default campaignType to MERCENARY and activePreset to CUSTOM.
+
+#### Scenario: New campaign has campaign type
+- **GIVEN** a campaign is created with campaignType CLAN
+- **WHEN** the campaign is inspected
+- **THEN** campaignType is CampaignType.CLAN
+
+#### Scenario: Existing campaigns default to MERCENARY
+- **GIVEN** a campaign created before this feature exists
+- **WHEN** campaignType is not set
+- **THEN** it defaults to CampaignType.MERCENARY
+
+## MODIFIED Requirements
+
+### Requirement: Campaign Creation
+The system SHALL create a new campaign with default values for all required fields including personnel, forces, missions, finances, campaign type, and active preset.
+
+#### Scenario: Create campaign with minimal parameters
+- **GIVEN** a user provides campaign name "First Company" and faction ID "davion"
+- **WHEN** createCampaign is called
+- **THEN** a campaign is created with unique ID, name, faction, current date set to now, empty personnel Map, empty forces Map, empty missions Map, zero balance, default options, campaignType MERCENARY, and activePreset CUSTOM
+
+#### Scenario: Create campaign with custom options
+- **GIVEN** a user provides name, faction, and custom options (startingFunds: 10000000, salaryMultiplier: 1.5)
+- **WHEN** createCampaign is called
+- **THEN** a campaign is created with custom options merged with defaults, and starting balance set to 10000000 C-bills
+
+#### Scenario: Campaign has unique root force
+- **GIVEN** a campaign is created
+- **WHEN** the campaign is inspected
+- **THEN** the campaign has a rootForceId field with a unique force ID
+
+#### Scenario: Create campaign with preset
+- **GIVEN** a user provides name, faction, campaign type CLAN, and preset FULL
+- **WHEN** createCampaign is called with preset application
+- **THEN** the campaign options reflect the FULL preset overrides applied on top of CLAN type defaults

--- a/openspec/changes/add-campaign-presets/specs/campaign-presets/spec.md
+++ b/openspec/changes/add-campaign-presets/specs/campaign-presets/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Preset Definitions
+The system SHALL define 4 built-in presets (CASUAL, STANDARD, FULL, CUSTOM) as IPresetDefinition objects with id, name, description, icon, and option overrides (Partial<ICampaignOptions>).
+
+#### Scenario: Casual preset configuration
+- **GIVEN** the CASUAL preset definition
+- **WHEN** its overrides are inspected
+- **THEN** useTurnover is false, useTaxes is false, trackFactionStanding is false, useRandomEvents is false, and healingRateMultiplier is 2.0
+
+#### Scenario: Standard preset configuration
+- **GIVEN** the STANDARD preset definition
+- **WHEN** its overrides are inspected
+- **THEN** useTurnover is true, useRoleBasedSalaries is true, trackFactionStanding is true, useRandomEvents is true, and useTaxes is false
+
+#### Scenario: Full preset configuration
+- **GIVEN** the FULL preset definition
+- **WHEN** its overrides are inspected
+- **THEN** useTurnover is true, useRoleBasedSalaries is true, useTaxes is true, trackFactionStanding is true, and useRandomEvents is true
+
+#### Scenario: Custom preset has no overrides
+- **GIVEN** the CUSTOM preset definition
+- **WHEN** its overrides are inspected
+- **THEN** the overrides object is empty (uses createDefaultCampaignOptions defaults)
+
+### Requirement: Option Metadata Registry
+The system SHALL maintain an OPTION_META registry mapping every ICampaignOptions key to metadata including group (OptionGroupId), label, description, type (boolean/number/string/enum), optional min/max/step for numbers, optional enumValues, and defaultValue.
+
+#### Scenario: Every option has metadata
+- **GIVEN** the ICampaignOptions interface has N keys
+- **WHEN** OPTION_META is inspected
+- **THEN** exactly N entries exist, one per ICampaignOptions key
+
+#### Scenario: Metadata includes valid group assignment
+- **GIVEN** OPTION_META entry for 'healingRateMultiplier'
+- **WHEN** the entry is inspected
+- **THEN** group is OptionGroupId.PERSONNEL, type is 'number', min is 0, and a label and description are present
+
+### Requirement: Preset Application Service
+The system SHALL provide an applyPreset function that layers defaults, campaign type adjustments, and preset overrides to produce a complete ICampaignOptions.
+
+#### Scenario: Apply preset layers correctly
+- **GIVEN** campaign type MERCENARY and preset CASUAL
+- **WHEN** applyPreset is called
+- **THEN** the result contains all default options with MERCENARY type adjustments and CASUAL overrides applied on top
+
+#### Scenario: Apply preset for CLAN type
+- **GIVEN** campaign type CLAN and preset STANDARD
+- **WHEN** applyPreset is called
+- **THEN** allowClanEquipment is true (from CLAN type defaults) and useTurnover is true (from STANDARD preset)
+
+### Requirement: Preset Export and Import
+The system SHALL provide exportPreset (ICampaignOptions to JSON string) and importPreset (JSON string to Partial<ICampaignOptions>) functions for community sharing.
+
+#### Scenario: Export roundtrip
+- **GIVEN** a set of campaign options
+- **WHEN** exportPreset is called and the result is passed to importPreset
+- **THEN** the imported options match the original options exactly
+
+#### Scenario: Import invalid JSON
+- **GIVEN** an invalid JSON string "not valid json"
+- **WHEN** importPreset is called
+- **THEN** an error is thrown
+
+### Requirement: Option Validation
+The system SHALL validate campaign options for numeric ranges, type correctness, and logical consistency, returning errors for invalid values and warnings for suboptimal combinations.
+
+#### Scenario: Negative salary multiplier
+- **GIVEN** options with salaryMultiplier set to -1
+- **WHEN** validateCampaignOptions is called
+- **THEN** the result contains an error for salaryMultiplier being below minimum
+
+#### Scenario: Tax rate out of range
+- **GIVEN** options with taxRate set to 150
+- **WHEN** validateCampaignOptions is called
+- **THEN** the result contains an error for taxRate exceeding maximum of 100
+
+#### Scenario: Logical dependency warning
+- **GIVEN** options with useTaxes true but useRoleBasedSalaries false
+- **WHEN** validateCampaignOptions is called
+- **THEN** the result contains a warning about taxes requiring salary tracking for meaningful impact
+
+### Requirement: Campaign Type Defaults
+The system SHALL provide getCampaignTypeDefaults that returns type-specific option overrides (e.g., CLAN enables allowClanEquipment, HOUSE_COMMAND sets salaryMultiplier to 0, PIRATE adjusts salvage rates).
+
+#### Scenario: Clan type defaults
+- **GIVEN** CampaignType.CLAN
+- **WHEN** getCampaignTypeDefaults is called
+- **THEN** allowClanEquipment is true and useFactionRules is true
+
+#### Scenario: House Command type defaults
+- **GIVEN** CampaignType.HOUSE_COMMAND
+- **WHEN** getCampaignTypeDefaults is called
+- **THEN** salaryMultiplier is 0 (house pays salaries)
+
+#### Scenario: Mercenary type has no special defaults
+- **GIVEN** CampaignType.MERCENARY
+- **WHEN** getCampaignTypeDefaults is called
+- **THEN** an empty overrides object is returned (uses standard defaults)

--- a/openspec/changes/add-campaign-presets/specs/campaign-ui/spec.md
+++ b/openspec/changes/add-campaign-presets/specs/campaign-ui/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Campaign Creation Wizard
+The system SHALL provide a multi-step campaign creation wizard with 4 steps: campaign type selection, preset selection, option customization, and summary/confirmation.
+
+#### Scenario: Wizard step 1 - Campaign type selection
+- **WHEN** the user opens the campaign creation wizard
+- **THEN** 5 campaign types are displayed as selectable cards with name, icon, and description
+
+#### Scenario: Wizard step 2 - Preset selection
+- **WHEN** the user selects a campaign type and proceeds
+- **THEN** 4 presets (Casual, Standard, Full, Custom) are displayed with feature comparison highlights
+
+#### Scenario: Wizard step 3 - Option customization
+- **WHEN** the user selects a preset and proceeds
+- **THEN** all campaign options are displayed grouped by OptionGroupId in collapsible panels, pre-filled with the selected preset's values
+
+#### Scenario: Wizard step 4 - Summary
+- **WHEN** the user completes customization and proceeds
+- **THEN** a summary of all selected options is displayed with campaign name input and a create button
+
+### Requirement: Option Group Panel
+The system SHALL render campaign options grouped by OptionGroupId with appropriate input controls (toggles for booleans, number inputs with min/max for numbers, dropdowns for enums).
+
+#### Scenario: Boolean option rendering
+- **GIVEN** an option with type 'boolean'
+- **WHEN** the option group panel renders
+- **THEN** a toggle switch is displayed with the option's label and description
+
+#### Scenario: Number option with range
+- **GIVEN** an option with type 'number', min 0, max 100, step 1
+- **WHEN** the option group panel renders
+- **THEN** a number input is displayed constrained to the specified range

--- a/openspec/changes/add-campaign-presets/tasks.md
+++ b/openspec/changes/add-campaign-presets/tasks.md
@@ -1,0 +1,8 @@
+## 1. Implementation
+
+- [ ] 1.1 Define CampaignType enum with display names and descriptions
+- [ ] 1.2 Define OptionGroupId enum and ICampaignOptionMeta metadata for all ICampaignOptions fields
+- [ ] 1.3 Define CampaignPreset enum and 4 built-in preset definitions (Casual, Standard, Full, Custom)
+- [ ] 1.4 Implement preset service (applyPreset, getCampaignTypeDefaults, export/import)
+- [ ] 1.5 Implement option validation (range checks, dependency warnings)
+- [ ] 1.6 Create campaign creation wizard UI (4-step: type, preset, customize, summary)


### PR DESCRIPTION
## Summary
- OpenSpec proposal for Plan 6: Campaign Options & Presets System (Tier 4 capstone)
- Adds `campaign-presets` new capability spec (preset definitions, option metadata, preset service, validation, export/import, campaign type defaults)
- Modifies `campaign-management` spec (adds campaign type classification, updates campaign creation)
- Modifies `campaign-ui` spec (adds campaign creation wizard, option group panel)
- Tasks: 6 implementation tasks (types, metadata, presets, service, validation, UI wizard)

This is the FINAL plan in the campaign meta-execution sequence.