### PR TITLE
feat: force builder & encounter launch fixes

### DIFF
--- a/src/pages/gameplay/encounters/[id].tsx
+++ b/src/pages/gameplay/encounters/[id].tsx
@@ -94,18 +94,16 @@ export default function EncounterDetailPage(): React.ReactElement {
     }
   }, [isInitialized, id, validateEncounter]);
 
-  // Handle launch
   const handleLaunch = useCallback(async () => {
     if (!id || typeof id !== 'string') return;
     clearError();
-    const success = await launchEncounter(id);
-    if (success) {
+    const gameSessionId = await launchEncounter(id);
+    if (gameSessionId) {
       showToast({
         message: 'Battle launched! Good hunting, MechWarrior.',
         variant: 'success',
       });
-      // Navigate to game session (placeholder for now)
-      router.push('/gameplay/encounters');
+      router.push(`/gameplay/games/${gameSessionId}`);
     } else {
       showToast({ message: 'Failed to launch encounter', variant: 'error' });
     }


### PR DESCRIPTION
## Summary

PR 2 of 8 for single-player playability. Wires force builder unit selector to compendium (4,200+ units) and fixes encounter launch navigation to game session page.

### Changes

**Force Builder Unit Selector** (`src/pages/gameplay/forces/[id].tsx`)
- Replaced empty `availableUnits` placeholder with real data from `UnitSearchService`
- Initialize `unitSearchService` and `canonicalUnitService` on mount
- Populate `allUnits` state with 4,200+ compendium units
- Map `IUnitIndexEntry` → `UnitInfo` format for `UnitSelector` component
- Populate `unitMap` for `ForceBuilder` display
- Added `mapTechBase()` and `mapWeightClass()` helper functions for enum→string conversion

**Encounter Launch Navigation**
- **Store** (`src/stores/useEncounterStore.ts`): Changed `launchEncounter` return type from `Promise<boolean>` to `Promise<string | null>` (returns gameSessionId on success)
- **Page** (`src/pages/gameplay/encounters/[id].tsx`): Navigate to `/gameplay/games/${gameSessionId}` after successful launch instead of `/gameplay/encounters` placeholder
- Added `LaunchResponse` interface with `gameSessionId` field

### Verification

`npm run verify:full` passes: typecheck ✓, lint ✓ (0 errors), format ✓, 18,136 tests pass (571 suites), build ✓

### Part of

PR 2 of 8 for single-player playability ([plan](.sisyphus/plans/single-player-playable.md), [openspec](openspec/changes/single-player-playable/))