### PR TITLE
feat: Quick Play auto-resolve and results

### DIFF
--- a/src/components/quickgame/__tests__/QuickGameResults.test.tsx
+++ b/src/components/quickgame/__tests__/QuickGameResults.test.tsx
@@ -249,9 +249,9 @@ describe('QuickGameResults', () => {
   });
 
   describe('Summary Tab Content', () => {
-    it('displays battle summary', () => {
+    it('displays battle statistics', () => {
       render(<QuickGameResults />);
-      expect(screen.getByText('Battle Summary')).toBeInTheDocument();
+      expect(screen.getByText('Battle Statistics')).toBeInTheDocument();
     });
 
     it('displays scenario information', () => {

--- a/src/stores/useGameplayStore.ts
+++ b/src/stores/useGameplayStore.ts
@@ -63,6 +63,8 @@ interface GameplayActions {
   loadSession: (sessionId: string) => Promise<void>;
   /** Create a demo session for testing */
   createDemoSession: () => void;
+  /** Set a completed game session (e.g. from GameEngine auto-resolve) */
+  setSession: (session: IGameSession) => void;
   /** Select a unit */
   selectUnit: (unitId: string | null) => void;
   /** Set target unit */
@@ -129,6 +131,14 @@ export const useGameplayStore = create<GameplayStore>((set, get) => ({
       maxStructure: createDemoMaxStructure(),
       pilotNames: createDemoPilotNames(),
       heatSinks: createDemoHeatSinks(),
+      isLoading: false,
+      error: null,
+    });
+  },
+
+  setSession: (session: IGameSession) => {
+    set({
+      session,
       isLoading: false,
       error: null,
     });

--- a/src/types/quickgame/QuickGameInterfaces.ts
+++ b/src/types/quickgame/QuickGameInterfaces.ts
@@ -218,6 +218,8 @@ export interface IQuickGameActions {
   previousStep: () => void;
   /** Start the game (move to playing) */
   startGame: () => void;
+  /** Run auto-resolved battle via GameEngine */
+  startBattle: () => Promise<void>;
   /** Record a game event */
   recordEvent: (event: IGameEvent) => void;
   /** End the game */


### PR DESCRIPTION
## Summary

PR 3 of 8 for single-player playability. Replaces demo gameplay with real auto-resolve using GameEngine and builds comprehensive results page with battle statistics and key moments.

### Changes

**Quick Play Auto-Resolve** (`useQuickGameStore.ts`, `QuickGamePlay.tsx`)
- Added `startBattle()` action that converts units via `CompendiumAdapter` and calls `GameEngine.runToCompletion()`
- Removed demo banner, "Mark Destroyed" buttons, and manual end game modal
- Added loading state during battle resolution
- Auto-navigates to results when battle completes

**Game Results Page** (`QuickGameResults.tsx`)
- Integrated `KeyMomentDetector` for key moments display (18 moment types across 3 tiers)
- Integrated `DamageCalculator` for per-unit damage assessment (armor %, structure %, destroyed locations)
- Integrated `GameOutcomeCalculator` for winner/stats (turns, duration, damage dealt/taken, kills)
- Enhanced tabbed interface: Summary (winner + key moments), Units (per-unit status cards), Damage (damage matrix), Timeline (event log)
- Added battle statistics section with comprehensive combat data

**Store Integration** (`useGameplayStore.ts`)
- Added `setSession()` action to store game session from GameEngine

### Verification

`npm run verify:full` passes: typecheck ✓, lint ✓ (0 errors), format ✓, 18,136 tests pass (571 suites), build ✓

### Part of

PR 3 of 8 for single-player playability ([plan](.sisyphus/plans/single-player-playable.md), [openspec](openspec/changes/single-player-playable/))