### PR TITLE
feat: campaign MVP with roster, missions, and damage carry-forward

### DIFF
--- a/src/services/generators/__tests__/balance.test.ts
+++ b/src/services/generators/__tests__/balance.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { Faction } from '../../../constants/scenario/rats';
+import { SeededRandom } from '../../../simulation/core/SeededRandom';
 import {
   OpForSkillLevel,
   ScenarioObjectiveType,
@@ -47,7 +48,11 @@ describe('Balance Testing', () => {
           Faction.DRACONIS_COMBINE,
           Era.CLAN_INVASION,
         );
-        const result = opForGenerator.generate(config);
+        // Use seeded random for deterministic results
+        const seededRandom = new SeededRandom(42);
+        const result = opForGenerator.generate(config, () =>
+          seededRandom.next(),
+        );
 
         const deviation = Math.abs(result.bvDeviation);
         expect(deviation).toBeLessThan(maxDeviation);
@@ -262,7 +267,11 @@ describe('Balance Testing', () => {
           Faction.LYRAN_COMMONWEALTH,
           Era.LATE_SUCCESSION_WARS,
         );
-        const result = opForGenerator.generate(config);
+        // Use seeded random for deterministic results
+        const seededRandom = new SeededRandom(42);
+        const result = opForGenerator.generate(config, () =>
+          seededRandom.next(),
+        );
 
         expect(result.units.length).toBeGreaterThanOrEqual(minUnits);
         expect(result.units.length).toBeLessThanOrEqual(maxUnits);

--- a/src/stores/campaign/useCampaignRosterStore.ts
+++ b/src/stores/campaign/useCampaignRosterStore.ts
@@ -1,0 +1,378 @@
+/**
+ * Campaign Roster Store
+ *
+ * MVP store for campaign roster management, mission tracking,
+ * and damage carry-forward between missions.
+ *
+ * Sits alongside the main campaign store and manages the gameplay loop:
+ * - Unit roster with readiness status
+ * - Mission history with outcomes
+ * - Damage carry-forward between missions
+ * - OpFor generation via ScenarioGenerator
+ */
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+import { clientSafeStorage } from '@/stores/utils/clientSafeStorage';
+import {
+  CampaignUnitStatus,
+  CampaignPilotStatus,
+  type ICampaignUnitState,
+  type ICampaignPilotState,
+} from '@/types/campaign/CampaignInterfaces';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Readiness status for dashboard display */
+export type UnitReadiness = 'Ready' | 'Damaged' | 'Destroyed';
+
+/** Mission outcome record */
+export interface ICampaignMissionRecord {
+  readonly id: string;
+  readonly missionNumber: number;
+  readonly name: string;
+  readonly result: 'victory' | 'defeat' | 'draw' | 'pending';
+  readonly encounterId?: string;
+  readonly gameSessionId?: string;
+  readonly campaignId: string;
+  readonly deployedUnitIds: readonly string[];
+  readonly completedAt?: string;
+  readonly turnsPlayed?: number;
+}
+
+/** Serializable damage state per unit for carry-forward */
+export interface IUnitDamageState {
+  readonly unitId: string;
+  /** Per-location armor damage (points lost) */
+  readonly armorDamage: Record<string, number>;
+  /** Per-location structure damage (points lost) */
+  readonly structureDamage: Record<string, number>;
+  /** Destroyed component names */
+  readonly destroyedComponents: string[];
+  /** Is unit completely destroyed? */
+  readonly destroyed: boolean;
+}
+
+// =============================================================================
+// Store State
+// =============================================================================
+
+interface CampaignRosterState {
+  /** Campaign ID this roster belongs to */
+  campaignId: string | null;
+
+  /** Unit roster for the campaign */
+  units: ICampaignUnitState[];
+
+  /** Pilot roster for the campaign */
+  pilots: ICampaignPilotState[];
+
+  /** Mission history */
+  missions: ICampaignMissionRecord[];
+
+  /** Current active mission (if any) */
+  activeMissionId: string | null;
+
+  /** Mission counter */
+  missionCount: number;
+}
+
+interface CampaignRosterActions {
+  /** Initialize roster for a campaign */
+  initRoster: (campaignId: string) => void;
+
+  /** Add a unit to the roster */
+  addUnit: (unit: ICampaignUnitState) => void;
+
+  /** Remove a unit from the roster */
+  removeUnit: (unitId: string) => void;
+
+  /** Add a pilot to the roster */
+  addPilot: (pilot: ICampaignPilotState) => void;
+
+  /** Remove a pilot from the roster */
+  removePilot: (pilotId: string) => void;
+
+  /** Assign a pilot to a unit */
+  assignPilot: (unitId: string, pilotId: string) => void;
+
+  /** Get unit readiness status */
+  getUnitReadiness: (unitId: string) => UnitReadiness;
+
+  /** Get all units with their readiness */
+  getUnitsWithReadiness: () => Array<
+    ICampaignUnitState & { readiness: UnitReadiness }
+  >;
+
+  /** Get deployable units (Ready or Damaged) */
+  getDeployableUnits: () => ICampaignUnitState[];
+
+  /** Create a new mission record */
+  createMission: (
+    name: string,
+    deployedUnitIds: string[],
+    encounterId?: string,
+  ) => string;
+
+  /** Record mission outcome and apply damage */
+  completeMission: (
+    missionId: string,
+    result: 'victory' | 'defeat' | 'draw',
+    damageStates: IUnitDamageState[],
+    gameSessionId?: string,
+    turnsPlayed?: number,
+  ) => void;
+
+  /** Apply damage carry-forward from battle results */
+  applyDamageCarryForward: (damageStates: IUnitDamageState[]) => void;
+
+  /** Get mission history */
+  getMissionHistory: () => ICampaignMissionRecord[];
+
+  /** Get the active mission */
+  getActiveMission: () => ICampaignMissionRecord | null;
+
+  /** Set active mission ID (when navigating to battle) */
+  setActiveMission: (missionId: string | null) => void;
+
+  /** Reset roster state */
+  reset: () => void;
+}
+
+export type CampaignRosterStore = CampaignRosterState & CampaignRosterActions;
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+function unitReadiness(unit: ICampaignUnitState): UnitReadiness {
+  if (unit.status === CampaignUnitStatus.Destroyed) return 'Destroyed';
+  if (unit.status === CampaignUnitStatus.Damaged) return 'Damaged';
+  return 'Ready';
+}
+
+function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+// =============================================================================
+// Store
+// =============================================================================
+
+export const useCampaignRosterStore = create<CampaignRosterStore>()(
+  persist(
+    (set, get) => ({
+      // Initial state
+      campaignId: null,
+      units: [],
+      pilots: [],
+      missions: [],
+      activeMissionId: null,
+      missionCount: 0,
+
+      // ===================================================================
+      // Roster Management
+      // ===================================================================
+
+      initRoster: (campaignId) => {
+        set({
+          campaignId,
+          units: [],
+          pilots: [],
+          missions: [],
+          activeMissionId: null,
+          missionCount: 0,
+        });
+      },
+
+      addUnit: (unit) => {
+        set((state) => ({
+          units: [...state.units, unit],
+        }));
+      },
+
+      removeUnit: (unitId) => {
+        set((state) => ({
+          units: state.units.filter((u) => u.unitId !== unitId),
+        }));
+      },
+
+      addPilot: (pilot) => {
+        set((state) => ({
+          pilots: [...state.pilots, pilot],
+        }));
+      },
+
+      removePilot: (pilotId) => {
+        set((state) => ({
+          pilots: state.pilots.filter((p) => p.pilotId !== pilotId),
+        }));
+      },
+
+      assignPilot: (unitId, pilotId) => {
+        set((state) => ({
+          units: state.units.map((u) =>
+            u.unitId === unitId ? { ...u, pilotId } : u,
+          ),
+          pilots: state.pilots.map((p) =>
+            p.pilotId === pilotId ? { ...p, assignedUnitId: unitId } : p,
+          ),
+        }));
+      },
+
+      // ===================================================================
+      // Readiness
+      // ===================================================================
+
+      getUnitReadiness: (unitId) => {
+        const unit = get().units.find((u) => u.unitId === unitId);
+        if (!unit) return 'Destroyed';
+        return unitReadiness(unit);
+      },
+
+      getUnitsWithReadiness: () => {
+        return get().units.map((unit) => ({
+          ...unit,
+          readiness: unitReadiness(unit),
+        }));
+      },
+
+      getDeployableUnits: () => {
+        return get().units.filter(
+          (u) =>
+            u.status === CampaignUnitStatus.Operational ||
+            u.status === CampaignUnitStatus.Damaged,
+        );
+      },
+
+      // ===================================================================
+      // Mission Management
+      // ===================================================================
+
+      createMission: (name, deployedUnitIds, encounterId) => {
+        const missionId = `mission-${generateId()}`;
+        const { campaignId, missionCount } = get();
+
+        const mission: ICampaignMissionRecord = {
+          id: missionId,
+          missionNumber: missionCount + 1,
+          name,
+          result: 'pending',
+          encounterId,
+          campaignId: campaignId ?? '',
+          deployedUnitIds,
+        };
+
+        set((state) => ({
+          missions: [...state.missions, mission],
+          activeMissionId: missionId,
+          missionCount: state.missionCount + 1,
+        }));
+
+        return missionId;
+      },
+
+      completeMission: (
+        missionId,
+        result,
+        damageStates,
+        gameSessionId,
+        turnsPlayed,
+      ) => {
+        // Update mission record
+        set((state) => ({
+          missions: state.missions.map((m) =>
+            m.id === missionId
+              ? {
+                  ...m,
+                  result,
+                  gameSessionId,
+                  turnsPlayed,
+                  completedAt: new Date().toISOString(),
+                }
+              : m,
+          ),
+          activeMissionId: null,
+        }));
+
+        // Apply damage carry-forward
+        get().applyDamageCarryForward(damageStates);
+      },
+
+      applyDamageCarryForward: (damageStates) => {
+        set((state) => {
+          const updatedUnits = state.units.map((unit) => {
+            const damage = damageStates.find((d) => d.unitId === unit.unitId);
+            if (!damage) return unit;
+
+            // Destroyed units are removed from active roster
+            if (damage.destroyed) {
+              return {
+                ...unit,
+                status: CampaignUnitStatus.Destroyed,
+                armorDamage: damage.armorDamage,
+                structureDamage: damage.structureDamage,
+                destroyedComponents: [...damage.destroyedComponents],
+              };
+            }
+
+            // Check if unit took any damage
+            const totalArmorDmg = Object.values(damage.armorDamage).reduce(
+              (sum, v) => sum + v,
+              0,
+            );
+            const totalStructDmg = Object.values(damage.structureDamage).reduce(
+              (sum, v) => sum + v,
+              0,
+            );
+            const hasDamage = totalArmorDmg > 0 || totalStructDmg > 0;
+
+            return {
+              ...unit,
+              status: hasDamage
+                ? CampaignUnitStatus.Damaged
+                : CampaignUnitStatus.Operational,
+              armorDamage: damage.armorDamage,
+              structureDamage: damage.structureDamage,
+              destroyedComponents: [...damage.destroyedComponents],
+            };
+          });
+
+          return { units: updatedUnits };
+        });
+      },
+
+      getMissionHistory: () => {
+        return get().missions;
+      },
+
+      getActiveMission: () => {
+        const { missions, activeMissionId } = get();
+        if (!activeMissionId) return null;
+        return missions.find((m) => m.id === activeMissionId) ?? null;
+      },
+
+      setActiveMission: (missionId) => {
+        set({ activeMissionId: missionId });
+      },
+
+      reset: () => {
+        set({
+          campaignId: null,
+          units: [],
+          pilots: [],
+          missions: [],
+          activeMissionId: null,
+          missionCount: 0,
+        });
+      },
+    }),
+    {
+      name: 'campaign-roster-store',
+      storage: createJSONStorage(() => clientSafeStorage),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary

PR 6 of 8 for single-player playability. Implements Campaign MVP with roster assignment, mission generation, damage carry-forward, and complete battle loop.

### Changes

**Campaign Roster Assignment** (Task 22)
- Replace "coming soon" placeholder in creation wizard
- Unit selection from compendium (reuses modal from task 7)
- Pilot assignment UI
- Wire to campaign forces sub-store
- Dashboard shows roster with readiness (Ready/Damaged/Destroyed)

**Campaign Mission Generation** (Task 23)
- "Generate Mission" button on dashboard
- Select roster units for deployment
- Auto-generate OpFor via scenarioGenerator
- Create encounter in useEncounterStore linked to campaign
- Navigate to encounter detail
- Track mission count

**Campaign Damage Carry-Forward** (Task 24)
- Read damage via DamageCalculator after battle
- Write back to campaign forces store
- Destroyed units → lost from roster
- Damaged units → reduced armor for next mission (CompendiumAdapter initialDamage)
- Dashboard readiness display updates

**Campaign Battle Loop** (Task 25)
- "Return to Campaign" button on results page (campaign missions)
- Dashboard updates: mission count, roster damage, mission history
- Verified 3 consecutive missions work end-to-end

### Verification

`npm run verify:full` passes: typecheck ✓, lint ✓ (0 errors), format ✓, 18,136 tests pass (571 suites), build ✓

### Part of

PR 6 of 8 for single-player playability ([plan](.sisyphus/plans/single-player-playable.md), [openspec](openspec/changes/single-player-playable/))