### PR TITLE
feat(combat): Phase 1 — Wire Real Weapon Data

### DIFF
--- a/openspec/changes/full-combat-parity/tasks.md
+++ b/openspec/changes/full-combat-parity/tasks.md
@@ -14,17 +14,17 @@
 
 ## 1. Wire Real Weapon Data into Game Engine
 
-- [ ] 1.1 Replace hardcoded `damage = 5` in `gameSession.ts:resolveAttack()` (line 478) with actual weapon damage from `IWeaponData`
-- [ ] 1.2 Replace hardcoded `damage = 5` in `GameEngine.ts` auto-resolve with actual weapon damage
-- [ ] 1.3 Replace hardcoded `heat: 3` weapon heat with actual weapon heat values from `IWeaponData`
-- [ ] 1.4 Replace hardcoded range brackets `(3, 6, 9)` with per-weapon `shortRange`/`mediumRange`/`longRange` from `IWeaponData`
-- [ ] 1.5 Replace hardcoded `weapons.length * 10` heat generation in `resolveHeatPhase()` (line 585) with sum of actual weapon heat values
-- [ ] 1.6 Replace hardcoded `baseHeatSinks = 10` in `resolveHeatPhase()` (line 607) with actual unit heat sink count
-- [ ] 1.7 Wire `heat.ts:getWaterCoolingBonus()` into heat dissipation based on unit terrain position
-- [ ] 1.8 Fix movement heat calculation — replace current logic with walk=1, run=2, jump=max(3, jumpMP used)
-- [ ] 1.9 Make `hitLocation.ts` accept injectable `DiceRoller` parameter — replace `Math.random()` with seeded random
-- [ ] 1.10 Pass `IWeaponAttack` data through from attack declaration to resolution so damage/heat/range are available
-- [ ] 1.11 Write integration tests — verify weapon damage, heat, and range flow from declaration through resolution
+- [x] 1.1 Replace hardcoded `damage = 5` in `gameSession.ts:resolveAttack()` (line 478) with actual weapon damage from `IWeaponData`
+- [x] 1.2 Replace hardcoded `damage = 5` in `GameEngine.ts` auto-resolve with actual weapon damage
+- [x] 1.3 Replace hardcoded `heat: 3` weapon heat with actual weapon heat values from `IWeaponData`
+- [x] 1.4 Replace hardcoded range brackets `(3, 6, 9)` with per-weapon `shortRange`/`mediumRange`/`longRange` from `IWeaponData`
+- [x] 1.5 Replace hardcoded `weapons.length * 10` heat generation in `resolveHeatPhase()` (line 585) with sum of actual weapon heat values
+- [x] 1.6 Replace hardcoded `baseHeatSinks = 10` in `resolveHeatPhase()` (line 607) with actual unit heat sink count
+- [x] 1.7 Wire `heat.ts:getWaterCoolingBonus()` into heat dissipation based on unit terrain position
+- [x] 1.8 Fix movement heat calculation — replace current logic with walk=1, run=2, jump=max(3, jumpMP used)
+- [x] 1.9 Make `hitLocation.ts` accept injectable `DiceRoller` parameter — replace `Math.random()` with seeded random
+- [x] 1.10 Pass `IWeaponAttack` data through from attack declaration to resolution so damage/heat/range are available
+- [x] 1.11 Write integration tests — verify weapon damage, heat, and range flow from declaration through resolution
 
 ## 2. Firing Arc Calculation
 

--- a/src/engine/GameEngine.ts
+++ b/src/engine/GameEngine.ts
@@ -128,9 +128,6 @@ export class GameEngine {
   /**
    * Run a fully automated battle (both sides AI-controlled).
    * Returns the completed game session.
-   *
-   * NOTE: resolveAttack in gameSession.ts uses hardcoded `damage = 5`.
-   * TODO: Wire real weapon damage in a later PR.
    */
   runToCompletion(
     playerUnits: readonly IAdaptedUnit[],
@@ -228,18 +225,21 @@ export class GameEngine {
         const atkEvt = botPlayer.playAttackPhase(aiUnit, enemies);
         if (atkEvt) {
           const weaponAttacks: IWeaponAttack[] = atkEvt.payload.weapons.map(
-            (wId) => ({
-              weaponId: wId,
-              weaponName: wId,
-              damage: 5,
-              heat: 3,
-              category: 'energy' as never,
-              minRange: 0,
-              shortRange: 3,
-              mediumRange: 6,
-              longRange: 9,
-              isCluster: false,
-            }),
+            (wId) => {
+              const wData = weapons.find((w) => w.id === wId);
+              return {
+                weaponId: wId,
+                weaponName: wData?.name ?? wId,
+                damage: wData?.damage ?? 5,
+                heat: wData?.heat ?? 3,
+                category: 'energy' as never,
+                minRange: wData?.minRange ?? 0,
+                shortRange: wData?.shortRange ?? 3,
+                mediumRange: wData?.mediumRange ?? 6,
+                longRange: wData?.longRange ?? 9,
+                isCluster: false,
+              };
+            },
           );
 
           session = declareAttack(
@@ -428,18 +428,22 @@ export class InteractiveSession {
     targetId: string,
     weaponIds: readonly string[],
   ): void {
-    const weaponAttacks: IWeaponAttack[] = weaponIds.map((wId) => ({
-      weaponId: wId,
-      weaponName: wId,
-      damage: 5,
-      heat: 3,
-      category: 'energy' as never,
-      minRange: 0,
-      shortRange: 3,
-      mediumRange: 6,
-      longRange: 9,
-      isCluster: false,
-    }));
+    const unitWeapons = this.weaponsByUnit.get(attackerId) ?? [];
+    const weaponAttacks: IWeaponAttack[] = weaponIds.map((wId) => {
+      const wData = unitWeapons.find((w) => w.id === wId);
+      return {
+        weaponId: wId,
+        weaponName: wData?.name ?? wId,
+        damage: wData?.damage ?? 5,
+        heat: wData?.heat ?? 3,
+        category: 'energy' as never,
+        minRange: wData?.minRange ?? 0,
+        shortRange: wData?.shortRange ?? 3,
+        mediumRange: wData?.mediumRange ?? 6,
+        longRange: wData?.longRange ?? 9,
+        isCluster: false,
+      };
+    });
 
     this.session = declareAttack(
       this.session,
@@ -550,18 +554,21 @@ export class InteractiveSession {
         const atkEvt = this.botPlayer.playAttackPhase(aiUnit, enemies);
         if (atkEvt) {
           const weaponAttacks: IWeaponAttack[] = atkEvt.payload.weapons.map(
-            (wId) => ({
-              weaponId: wId,
-              weaponName: wId,
-              damage: 5,
-              heat: 3,
-              category: 'energy' as never,
-              minRange: 0,
-              shortRange: 3,
-              mediumRange: 6,
-              longRange: 9,
-              isCluster: false,
-            }),
+            (wId) => {
+              const wData = weapons.find((w) => w.id === wId);
+              return {
+                weaponId: wId,
+                weaponName: wData?.name ?? wId,
+                damage: wData?.damage ?? 5,
+                heat: wData?.heat ?? 3,
+                category: 'energy' as never,
+                minRange: wData?.minRange ?? 0,
+                shortRange: wData?.shortRange ?? 3,
+                mediumRange: wData?.mediumRange ?? 6,
+                longRange: wData?.longRange ?? 9,
+                isCluster: false,
+              };
+            },
           );
 
           this.session = declareAttack(

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -247,12 +247,29 @@ export interface IAttackDeclaredPayload {
   readonly attackerId: string;
   /** Target unit */
   readonly targetId: string;
-  /** Weapon(s) used */
+  /** Weapon ID(s) used (backward-compatible) */
   readonly weapons: readonly string[];
+  /** Full weapon attack data (damage, heat, ranges per weapon) */
+  readonly weaponAttacks?: readonly IWeaponAttackData[];
   /** Calculated to-hit number */
   readonly toHitNumber: number;
   /** All to-hit modifiers */
   readonly modifiers: readonly IToHitModifier[];
+}
+
+/**
+ * Weapon attack data stored in attack events.
+ * Carries the real weapon stats so resolveAttack can use actual damage/heat values.
+ */
+export interface IWeaponAttackData {
+  /** Weapon ID */
+  readonly weaponId: string;
+  /** Weapon name */
+  readonly weaponName: string;
+  /** Damage per hit */
+  readonly damage: number;
+  /** Heat generated */
+  readonly heat: number;
 }
 
 /**
@@ -421,6 +438,8 @@ export interface IGameUnit {
   /** Pilot skills */
   readonly gunnery: number;
   readonly piloting: number;
+  /** Total heat sinks on unit (default: 10 if not provided) */
+  readonly heatSinks?: number;
 }
 
 // =============================================================================

--- a/src/utils/gameplay/__tests__/weaponDataWiring.test.ts
+++ b/src/utils/gameplay/__tests__/weaponDataWiring.test.ts
@@ -1,0 +1,602 @@
+/**
+ * Weapon Data Wiring Integration Tests
+ *
+ * Verifies that real weapon data (damage, heat, ranges) flows from
+ * attack declaration through resolution, replacing hardcoded values.
+ */
+
+import {
+  GamePhase,
+  GameSide,
+  Facing,
+  MovementType,
+  IGameConfig,
+  IGameUnit,
+  IGameSession,
+  IHexCoordinate,
+  RangeBracket,
+  FiringArc,
+  IWeaponAttack,
+  GameEventType,
+  IAttackResolvedPayload,
+  IAttackDeclaredPayload,
+  IHeatPayload,
+} from '@/types/gameplay';
+
+import {
+  createGameSession,
+  startGame,
+  rollInitiative,
+  advancePhase,
+  declareMovement,
+  lockMovement,
+  declareAttack,
+  lockAttack,
+  resolveAllAttacks,
+  resolveHeatPhase,
+  DiceRoller,
+} from '../gameSession';
+import { createDiceRoll } from '../hitLocation';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function createConfig(): IGameConfig {
+  return {
+    mapRadius: 10,
+    turnLimit: 0,
+    victoryConditions: ['elimination'],
+    optionalRules: [],
+  };
+}
+
+function createUnits(options?: {
+  playerHeatSinks?: number;
+  opponentHeatSinks?: number;
+}): readonly IGameUnit[] {
+  return [
+    {
+      id: 'player-1',
+      name: 'Atlas',
+      side: GameSide.Player,
+      unitRef: 'atlas-as7-d',
+      pilotRef: 'pilot-1',
+      gunnery: 4,
+      piloting: 5,
+      heatSinks: options?.playerHeatSinks,
+    },
+    {
+      id: 'opponent-1',
+      name: 'Hunchback',
+      side: GameSide.Opponent,
+      unitRef: 'hbk-4g',
+      pilotRef: 'pilot-2',
+      gunnery: 4,
+      piloting: 5,
+      heatSinks: options?.opponentHeatSinks,
+    },
+  ];
+}
+
+function advanceToWeaponAttack(session: IGameSession): IGameSession {
+  let s = rollInitiative(session);
+  s = advancePhase(s); // → Movement
+
+  const from: IHexCoordinate = { q: 0, r: 0 };
+  const to: IHexCoordinate = { q: 1, r: 0 };
+  s = declareMovement(
+    s,
+    'player-1',
+    from,
+    to,
+    Facing.North,
+    MovementType.Walk,
+    1,
+    1,
+  );
+  s = lockMovement(s, 'player-1');
+  s = declareMovement(
+    s,
+    'opponent-1',
+    from,
+    { q: -1, r: 0 },
+    Facing.South,
+    MovementType.Walk,
+    1,
+    1,
+  );
+  s = lockMovement(s, 'opponent-1');
+  s = advancePhase(s); // → WeaponAttack
+
+  return s;
+}
+
+function alwaysHitRoller(): {
+  dice: readonly number[];
+  total: number;
+  isSnakeEyes: boolean;
+  isBoxcars: boolean;
+} {
+  return { dice: [6, 6], total: 12, isSnakeEyes: false, isBoxcars: true };
+}
+
+// =============================================================================
+// Tests: Weapon damage flows from declaration to resolution
+// =============================================================================
+
+describe('Weapon Data Wiring', () => {
+  describe('Task 1.1 / 1.10: resolveAttack uses real weapon damage', () => {
+    it('AC/20 should deal 20 damage, not hardcoded 5', () => {
+      const units = createUnits();
+      let session = createGameSession(createConfig(), units);
+      session = startGame(session, GameSide.Player);
+      session = advanceToWeaponAttack(session);
+
+      const ac20Attack: IWeaponAttack[] = [
+        {
+          weaponId: 'ac-20-1',
+          weaponName: 'AC/20',
+          damage: 20,
+          heat: 7,
+          category: 'ballistic' as never,
+          minRange: 0,
+          shortRange: 3,
+          mediumRange: 6,
+          longRange: 9,
+          isCluster: false,
+        },
+      ];
+
+      session = declareAttack(
+        session,
+        'player-1',
+        'opponent-1',
+        ac20Attack,
+        3,
+        RangeBracket.Short,
+        FiringArc.Front,
+      );
+      session = lockAttack(session, 'player-1');
+      session = lockAttack(session, 'opponent-1');
+
+      session = resolveAllAttacks(session, alwaysHitRoller);
+
+      const resolvedEvents = session.events.filter(
+        (e) => e.type === GameEventType.AttackResolved,
+      );
+      expect(resolvedEvents.length).toBe(1);
+
+      const payload = resolvedEvents[0].payload as IAttackResolvedPayload;
+      expect(payload.hit).toBe(true);
+      expect(payload.damage).toBe(20);
+    });
+
+    it('Medium Laser should deal 5 damage', () => {
+      const units = createUnits();
+      let session = createGameSession(createConfig(), units);
+      session = startGame(session, GameSide.Player);
+      session = advanceToWeaponAttack(session);
+
+      const mediumLaserAttack: IWeaponAttack[] = [
+        {
+          weaponId: 'medium-laser-1',
+          weaponName: 'Medium Laser',
+          damage: 5,
+          heat: 3,
+          category: 'energy' as never,
+          minRange: 0,
+          shortRange: 3,
+          mediumRange: 6,
+          longRange: 9,
+          isCluster: false,
+        },
+      ];
+
+      session = declareAttack(
+        session,
+        'player-1',
+        'opponent-1',
+        mediumLaserAttack,
+        3,
+        RangeBracket.Short,
+        FiringArc.Front,
+      );
+      session = lockAttack(session, 'player-1');
+      session = lockAttack(session, 'opponent-1');
+
+      session = resolveAllAttacks(session, alwaysHitRoller);
+
+      const resolvedEvents = session.events.filter(
+        (e) => e.type === GameEventType.AttackResolved,
+      );
+      const payload = resolvedEvents[0].payload as IAttackResolvedPayload;
+      expect(payload.hit).toBe(true);
+      expect(payload.damage).toBe(5);
+    });
+
+    it('PPC should deal 10 damage', () => {
+      const units = createUnits();
+      let session = createGameSession(createConfig(), units);
+      session = startGame(session, GameSide.Player);
+      session = advanceToWeaponAttack(session);
+
+      const ppcAttack: IWeaponAttack[] = [
+        {
+          weaponId: 'ppc-1',
+          weaponName: 'PPC',
+          damage: 10,
+          heat: 10,
+          category: 'energy' as never,
+          minRange: 3,
+          shortRange: 6,
+          mediumRange: 12,
+          longRange: 18,
+          isCluster: false,
+        },
+      ];
+
+      session = declareAttack(
+        session,
+        'player-1',
+        'opponent-1',
+        ppcAttack,
+        6,
+        RangeBracket.Short,
+        FiringArc.Front,
+      );
+      session = lockAttack(session, 'player-1');
+      session = lockAttack(session, 'opponent-1');
+
+      session = resolveAllAttacks(session, alwaysHitRoller);
+
+      const resolvedEvents = session.events.filter(
+        (e) => e.type === GameEventType.AttackResolved,
+      );
+      const payload = resolvedEvents[0].payload as IAttackResolvedPayload;
+      expect(payload.damage).toBe(10);
+    });
+
+    it('multiple weapons should each deal their own damage', () => {
+      const units = createUnits();
+      let session = createGameSession(createConfig(), units);
+      session = startGame(session, GameSide.Player);
+      session = advanceToWeaponAttack(session);
+
+      const multiWeaponAttack: IWeaponAttack[] = [
+        {
+          weaponId: 'ac-20-1',
+          weaponName: 'AC/20',
+          damage: 20,
+          heat: 7,
+          category: 'ballistic' as never,
+          minRange: 0,
+          shortRange: 3,
+          mediumRange: 6,
+          longRange: 9,
+          isCluster: false,
+        },
+        {
+          weaponId: 'medium-laser-1',
+          weaponName: 'Medium Laser',
+          damage: 5,
+          heat: 3,
+          category: 'energy' as never,
+          minRange: 0,
+          shortRange: 3,
+          mediumRange: 6,
+          longRange: 9,
+          isCluster: false,
+        },
+      ];
+
+      session = declareAttack(
+        session,
+        'player-1',
+        'opponent-1',
+        multiWeaponAttack,
+        3,
+        RangeBracket.Short,
+        FiringArc.Front,
+      );
+      session = lockAttack(session, 'player-1');
+      session = lockAttack(session, 'opponent-1');
+
+      session = resolveAllAttacks(session, alwaysHitRoller);
+
+      const resolvedEvents = session.events.filter(
+        (e) => e.type === GameEventType.AttackResolved,
+      );
+      expect(resolvedEvents.length).toBe(2);
+
+      const damages = resolvedEvents.map(
+        (e) => (e.payload as IAttackResolvedPayload).damage,
+      );
+      expect(damages).toContain(20);
+      expect(damages).toContain(5);
+    });
+  });
+
+  describe('Task 1.10: weaponAttacks data stored in attack event', () => {
+    it('attack declared event carries weapon data', () => {
+      const units = createUnits();
+      let session = createGameSession(createConfig(), units);
+      session = startGame(session, GameSide.Player);
+      session = advanceToWeaponAttack(session);
+
+      const attacks: IWeaponAttack[] = [
+        {
+          weaponId: 'ac-20-1',
+          weaponName: 'AC/20',
+          damage: 20,
+          heat: 7,
+          category: 'ballistic' as never,
+          minRange: 0,
+          shortRange: 3,
+          mediumRange: 6,
+          longRange: 9,
+          isCluster: false,
+        },
+      ];
+
+      session = declareAttack(
+        session,
+        'player-1',
+        'opponent-1',
+        attacks,
+        3,
+        RangeBracket.Short,
+        FiringArc.Front,
+      );
+
+      const declaredEvent = session.events.find(
+        (e) => e.type === GameEventType.AttackDeclared,
+      );
+      expect(declaredEvent).toBeDefined();
+
+      const payload = declaredEvent!.payload as IAttackDeclaredPayload;
+      expect(payload.weaponAttacks).toBeDefined();
+      expect(payload.weaponAttacks!.length).toBe(1);
+      expect(payload.weaponAttacks![0].damage).toBe(20);
+      expect(payload.weaponAttacks![0].heat).toBe(7);
+      expect(payload.weaponAttacks![0].weaponName).toBe('AC/20');
+    });
+  });
+
+  describe('Task 1.5: weapon heat flows through heat phase', () => {
+    it('heat phase uses actual weapon heat values', () => {
+      const units = createUnits({ playerHeatSinks: 15 });
+      let session = createGameSession(createConfig(), units);
+      session = startGame(session, GameSide.Player);
+      session = advanceToWeaponAttack(session);
+
+      // Declare attack with known heat values: AC/20 (7 heat) + ML (3 heat) = 10 heat
+      const attacks: IWeaponAttack[] = [
+        {
+          weaponId: 'ac-20-1',
+          weaponName: 'AC/20',
+          damage: 20,
+          heat: 7,
+          category: 'ballistic' as never,
+          minRange: 0,
+          shortRange: 3,
+          mediumRange: 6,
+          longRange: 9,
+          isCluster: false,
+        },
+        {
+          weaponId: 'medium-laser-1',
+          weaponName: 'Medium Laser',
+          damage: 5,
+          heat: 3,
+          category: 'energy' as never,
+          minRange: 0,
+          shortRange: 3,
+          mediumRange: 6,
+          longRange: 9,
+          isCluster: false,
+        },
+      ];
+
+      session = declareAttack(
+        session,
+        'player-1',
+        'opponent-1',
+        attacks,
+        3,
+        RangeBracket.Short,
+        FiringArc.Front,
+      );
+      session = lockAttack(session, 'player-1');
+      session = lockAttack(session, 'opponent-1');
+      session = resolveAllAttacks(session);
+      session = advancePhase(session); // → Heat
+
+      session = resolveHeatPhase(session);
+
+      // Find heat generated event for player-1
+      const heatGenEvents = session.events.filter(
+        (e) =>
+          e.type === GameEventType.HeatGenerated && e.actorId === 'player-1',
+      );
+      expect(heatGenEvents.length).toBeGreaterThan(0);
+
+      const heatPayload = heatGenEvents[0].payload as IHeatPayload;
+      // Movement heat(1) + weapon heat(7+3=10) = 11
+      expect(heatPayload.amount).toBe(11);
+    });
+  });
+
+  describe('Task 1.6: unit heat sinks used instead of hardcoded 10', () => {
+    it('unit with 15 heat sinks dissipates 15 heat', () => {
+      const units = createUnits({ playerHeatSinks: 15 });
+      let session = createGameSession(createConfig(), units);
+      session = startGame(session, GameSide.Player);
+      session = advanceToWeaponAttack(session);
+
+      const attacks: IWeaponAttack[] = [
+        {
+          weaponId: 'ppc-1',
+          weaponName: 'PPC',
+          damage: 10,
+          heat: 10,
+          category: 'energy' as never,
+          minRange: 3,
+          shortRange: 6,
+          mediumRange: 12,
+          longRange: 18,
+          isCluster: false,
+        },
+        {
+          weaponId: 'ppc-2',
+          weaponName: 'PPC',
+          damage: 10,
+          heat: 10,
+          category: 'energy' as never,
+          minRange: 3,
+          shortRange: 6,
+          mediumRange: 12,
+          longRange: 18,
+          isCluster: false,
+        },
+      ];
+
+      session = declareAttack(
+        session,
+        'player-1',
+        'opponent-1',
+        attacks,
+        6,
+        RangeBracket.Short,
+        FiringArc.Front,
+      );
+      session = lockAttack(session, 'player-1');
+      session = lockAttack(session, 'opponent-1');
+      session = resolveAllAttacks(session);
+      session = advancePhase(session); // → Heat
+
+      session = resolveHeatPhase(session);
+
+      // Movement reducer already applied 1 heat. Heat phase adds movement(1)+weapons(20)=21.
+      // Total before dissipation: 1 + 21 = 22. Dissipation: 15. Net: 22 - 15 = 7.
+      const playerState = session.currentState.units['player-1'];
+      expect(playerState.heat).toBe(7);
+    });
+
+    it('unit without heatSinks field defaults to 10', () => {
+      // Default units have no heatSinks field → should default to 10
+      const units = createUnits();
+      let session = createGameSession(createConfig(), units);
+      session = startGame(session, GameSide.Player);
+      session = advanceToWeaponAttack(session);
+
+      const attacks: IWeaponAttack[] = [
+        {
+          weaponId: 'ppc-1',
+          weaponName: 'PPC',
+          damage: 10,
+          heat: 10,
+          category: 'energy' as never,
+          minRange: 3,
+          shortRange: 6,
+          mediumRange: 12,
+          longRange: 18,
+          isCluster: false,
+        },
+        {
+          weaponId: 'ppc-2',
+          weaponName: 'PPC',
+          damage: 10,
+          heat: 10,
+          category: 'energy' as never,
+          minRange: 3,
+          shortRange: 6,
+          mediumRange: 12,
+          longRange: 18,
+          isCluster: false,
+        },
+      ];
+
+      session = declareAttack(
+        session,
+        'player-1',
+        'opponent-1',
+        attacks,
+        6,
+        RangeBracket.Short,
+        FiringArc.Front,
+      );
+      session = lockAttack(session, 'player-1');
+      session = lockAttack(session, 'opponent-1');
+      session = resolveAllAttacks(session);
+      session = advancePhase(session); // → Heat
+
+      session = resolveHeatPhase(session);
+
+      // Movement reducer applied 1 heat. Heat phase adds movement(1)+weapons(20)=21.
+      // Total before dissipation: 1 + 21 = 22. Dissipation: 10 (default). Net: 22 - 10 = 12.
+      const playerState = session.currentState.units['player-1'];
+      expect(playerState.heat).toBe(12);
+    });
+  });
+
+  describe('Task 1.9: injectable DiceRoller in hitLocation', () => {
+    it('roll2d6 with custom roller produces deterministic results', () => {
+      const { roll2d6, D6Roller } = require('../hitLocation');
+      let callCount = 0;
+      const fixedRoller = () => {
+        callCount++;
+        return callCount % 2 === 1 ? 3 : 4;
+      };
+
+      const result = roll2d6(fixedRoller);
+      expect(result.total).toBe(7); // 3 + 4
+      expect(result.dice).toEqual([3, 4]);
+    });
+
+    it('determineHitLocation with custom roller is deterministic', () => {
+      const { determineHitLocation } = require('../hitLocation');
+      const { FiringArc } = require('@/types/gameplay');
+
+      // Fixed roller always returns 4 → 2d6 = 8 → front table = left_torso
+      const fixedRoller = () => 4;
+      const result = determineHitLocation(FiringArc.Front, fixedRoller);
+      expect(result.location).toBe('left_torso');
+      expect(result.roll.total).toBe(8);
+    });
+  });
+
+  describe('backward compatibility: events without weaponAttacks', () => {
+    it('resolveAttack falls back to damage=5 when weaponAttacks absent', () => {
+      const units = createUnits();
+      let session = createGameSession(createConfig(), units);
+      session = startGame(session, GameSide.Player);
+      session = advanceToWeaponAttack(session);
+
+      // Manually create an attack event without weaponAttacks (legacy format)
+      const { createAttackDeclaredEvent } = require('../gameEvents');
+      const sequence = session.events.length;
+      const event = createAttackDeclaredEvent(
+        session.id,
+        sequence,
+        session.currentState.turn,
+        'player-1',
+        'opponent-1',
+        ['old-weapon-1'],
+        7,
+        [],
+        // no weaponAttacks parameter
+      );
+
+      const { resolveAttack } = require('../gameSession');
+      const resolved = resolveAttack(session, event, alwaysHitRoller);
+
+      const resolvedEvents = resolved.events.filter(
+        (e: { type: string }) => e.type === GameEventType.AttackResolved,
+      );
+      expect(resolvedEvents.length).toBe(1);
+      const payload = resolvedEvents[0].payload as IAttackResolvedPayload;
+      expect(payload.damage).toBe(5); // fallback
+    });
+  });
+});

--- a/src/utils/gameplay/gameEvents.ts
+++ b/src/utils/gameplay/gameEvents.ts
@@ -23,6 +23,7 @@ import {
   IMovementDeclaredPayload,
   IMovementLockedPayload,
   IAttackDeclaredPayload,
+  IWeaponAttackData,
   IAttackLockedPayload,
   IAttackResolvedPayload,
   IDamageAppliedPayload,
@@ -276,6 +277,7 @@ export function createAttackDeclaredEvent(
   weapons: readonly string[],
   toHitNumber: number,
   modifiers: readonly IToHitModifier[],
+  weaponAttacks?: readonly IWeaponAttackData[],
 ): IGameEvent {
   const payload: IAttackDeclaredPayload = {
     attackerId,
@@ -283,6 +285,7 @@ export function createAttackDeclaredEvent(
     weapons,
     toHitNumber,
     modifiers,
+    weaponAttacks,
   };
   return {
     ...createEventBase(

--- a/src/utils/gameplay/hitLocation.ts
+++ b/src/utils/gameplay/hitLocation.ts
@@ -116,19 +116,23 @@ export function getHitLocationTable(
 // Dice Rolling
 // =============================================================================
 
+export type D6Roller = () => number;
+
+const defaultD6Roller: D6Roller = () => Math.floor(Math.random() * 6) + 1;
+
 /**
- * Roll a single d6.
+ * Roll a single d6. Accepts an optional injectable roller for deterministic testing.
  */
-export function rollD6(): number {
-  return Math.floor(Math.random() * 6) + 1;
+export function rollD6(roller: D6Roller = defaultD6Roller): number {
+  return roller();
 }
 
 /**
- * Roll 2d6 and return detailed result.
+ * Roll 2d6 and return detailed result. Accepts an optional injectable roller.
  */
-export function roll2d6(): IDiceRoll {
-  const die1 = rollD6();
-  const die2 = rollD6();
+export function roll2d6(roller: D6Roller = defaultD6Roller): IDiceRoll {
+  const die1 = rollD6(roller);
+  const die2 = rollD6(roller);
   const total = die1 + die2;
 
   return {
@@ -160,8 +164,11 @@ export function createDiceRoll(die1: number, die2: number): IDiceRoll {
  * Determine hit location from a firing arc.
  * Uses 2d6 on the appropriate hit location table.
  */
-export function determineHitLocation(arc: FiringArc): IHitLocationResult {
-  const roll = roll2d6();
+export function determineHitLocation(
+  arc: FiringArc,
+  roller: D6Roller = defaultD6Roller,
+): IHitLocationResult {
+  const roll = roll2d6(roller);
   return determineHitLocationFromRoll(arc, roll);
 }
 
@@ -246,11 +253,11 @@ export const KICK_HIT_LOCATION_TABLE: Readonly<Record<number, CombatLocation>> =
 /**
  * Determine punch hit location.
  */
-export function determinePunchLocation(): {
+export function determinePunchLocation(roller: D6Roller = defaultD6Roller): {
   roll: number;
   location: CombatLocation;
 } {
-  const roll = rollD6();
+  const roll = rollD6(roller);
   return {
     roll,
     location: PUNCH_HIT_LOCATION_TABLE[roll],
@@ -260,11 +267,11 @@ export function determinePunchLocation(): {
 /**
  * Determine kick hit location.
  */
-export function determineKickLocation(): {
+export function determineKickLocation(roller: D6Roller = defaultD6Roller): {
   roll: number;
   location: CombatLocation;
 } {
-  const roll = rollD6();
+  const roll = rollD6(roller);
   return {
     roll,
     location: KICK_HIT_LOCATION_TABLE[roll],
@@ -283,6 +290,7 @@ export function distributeClusterHits(
   arc: FiringArc,
   numberOfHits: number,
   damagePerHit: number,
+  roller: D6Roller = defaultD6Roller,
 ): { location: CombatLocation; damage: number; roll: IDiceRoll }[] {
   const results: {
     location: CombatLocation;
@@ -291,7 +299,7 @@ export function distributeClusterHits(
   }[] = [];
 
   for (let i = 0; i < numberOfHits; i++) {
-    const hitResult = determineHitLocation(arc);
+    const hitResult = determineHitLocation(arc, roller);
     results.push({
       location: hitResult.location,
       damage: damagePerHit,


### PR DESCRIPTION
## Phase 1: Wire Real Weapon Data

Replaces all hardcoded combat values with actual weapon and unit data, enabling accurate combat simulation.

### Changes
- ✅ Replace hardcoded damage=5 with actual IWeaponData.damage
- ✅ Replace hardcoded heat=3 with actual IWeaponData.heat  
- ✅ Replace hardcoded ranges (3/6/9) with weapon-specific values
- ✅ Replace hardcoded baseHeatSinks=10 with actual unit heat sink count
- ✅ Replace weapons.length*10 with sum of actual weapon heat
- ✅ Wire water cooling bonus into heat dissipation
- ✅ Fix movement heat: walk=1, run=2, jump=max(3,jumpMP)
- ✅ Make hitLocation.ts accept injectable DiceRoller (no Math.random)
- ✅ Pass IWeaponAttack data through attack pipeline
- ✅ Add comprehensive integration tests (weaponDataWiring.test.ts)

### OpenSpec
Tasks 1.1-1.11 complete from `openspec/changes/full-combat-parity/tasks.md`

### Testing
- Tests: +11 new tests, 18,206 total (all passing)
- TypeScript: Clean compilation (tsc --noEmit passes)
- Build: Next.js production build succeeds