### PR TITLE
feat(combat): Phase 2 — Firing Arc Calculation

### DIFF
--- a/openspec/changes/full-combat-parity/tasks.md
+++ b/openspec/changes/full-combat-parity/tasks.md
@@ -28,13 +28,13 @@
 
 ## 2. Firing Arc Calculation
 
-- [ ] 2.1 Create `src/utils/gameplay/firingArc.ts` — implement `calculateFiringArc(attackerPos, targetPos, targetFacing)` returning `FiringArc` enum
-- [ ] 2.2 Implement hex coordinate math: determine relative hex direction from attacker to target, map against target facing to derive arc (front ±1, left +2, rear +3, right -2)
-- [ ] 2.3 Replace hardcoded `FiringArc.Front` in `resolveAttack()` (line 474) with computed firing arc
-- [ ] 2.4 Replace hardcoded `FiringArc.Front` in `GameEngine.ts` with computed firing arc
-- [ ] 2.5 Implement torso twist modifier — extend front arc by 1 hex-side in twist direction
-- [ ] 2.6 Write unit tests for all 4 arc directions with various hex positions and facings
-- [ ] 2.7 Write unit tests for torso twist arc extension
+- [x] 2.1 Create `src/utils/gameplay/firingArc.ts` — implement `calculateFiringArc(attackerPos, targetPos, targetFacing)` returning `FiringArc` enum
+- [x] 2.2 Implement hex coordinate math: determine relative hex direction from attacker to target, map against target facing to derive arc (front ±1, left +2, rear +3, right -2)
+- [x] 2.3 Replace hardcoded `FiringArc.Front` in `resolveAttack()` (line 474) with computed firing arc
+- [x] 2.4 Replace hardcoded `FiringArc.Front` in `GameEngine.ts` with computed firing arc
+- [x] 2.5 Implement torso twist modifier — extend front arc by 1 hex-side in twist direction
+- [x] 2.6 Write unit tests for all 4 arc directions with various hex positions and facings
+- [x] 2.7 Write unit tests for torso twist arc extension
 
 ## 3. Wire Damage Pipeline
 

--- a/src/__tests__/unit/utils/gameplay/attackResolution.test.ts
+++ b/src/__tests__/unit/utils/gameplay/attackResolution.test.ts
@@ -86,8 +86,8 @@ describe('Attack Resolution', () => {
     session = declareMovement(
       session,
       'unit-2',
-      { q: 3, r: 0 },
-      { q: 3, r: 0 },
+      { q: 0, r: -3 },
+      { q: 0, r: -3 },
       Facing.South,
       MovementType.Stationary,
       0,

--- a/src/engine/GameEngine.ts
+++ b/src/engine/GameEngine.ts
@@ -27,12 +27,12 @@ import {
   Facing,
   MovementType,
   RangeBracket,
-  FiringArc,
   type IHexCoordinate,
   type IHexGrid,
   type IHex,
   type IMovementCapability,
 } from '@/types/gameplay/HexGridInterfaces';
+import { calculateFiringArc } from '@/utils/gameplay/firingArc';
 import {
   createGameSession,
   startGame,
@@ -242,6 +242,14 @@ export class GameEngine {
             },
           );
 
+          const targetUnit =
+            session.currentState.units[atkEvt.payload.targetId];
+          const firingArc = calculateFiringArc(
+            unit.position,
+            targetUnit.position,
+            targetUnit.facing,
+          );
+
           session = declareAttack(
             session,
             unitId,
@@ -249,7 +257,7 @@ export class GameEngine {
             weaponAttacks,
             3,
             RangeBracket.Short,
-            FiringArc.Front,
+            firingArc,
           );
         }
         session = lockAttack(session, unitId);
@@ -445,6 +453,14 @@ export class InteractiveSession {
       };
     });
 
+    const attackerState = this.session.currentState.units[attackerId];
+    const targetState = this.session.currentState.units[targetId];
+    const firingArc = calculateFiringArc(
+      attackerState.position,
+      targetState.position,
+      targetState.facing,
+    );
+
     this.session = declareAttack(
       this.session,
       attackerId,
@@ -452,7 +468,7 @@ export class InteractiveSession {
       weaponAttacks,
       3,
       RangeBracket.Short,
-      FiringArc.Front,
+      firingArc,
     );
     this.session = lockAttack(this.session, attackerId);
   }
@@ -571,6 +587,14 @@ export class InteractiveSession {
             },
           );
 
+          const targetUnit =
+            this.session.currentState.units[atkEvt.payload.targetId];
+          const firingArc = calculateFiringArc(
+            unit.position,
+            targetUnit.position,
+            targetUnit.facing,
+          );
+
           this.session = declareAttack(
             this.session,
             unitId,
@@ -578,7 +602,7 @@ export class InteractiveSession {
             weaponAttacks,
             3,
             RangeBracket.Short,
-            FiringArc.Front,
+            firingArc,
           );
         }
         this.session = lockAttack(this.session, unitId);

--- a/src/utils/gameplay/__tests__/firingArc.test.ts
+++ b/src/utils/gameplay/__tests__/firingArc.test.ts
@@ -1,0 +1,384 @@
+import { Facing, FiringArc, IHexCoordinate } from '@/types/gameplay';
+
+import { calculateFiringArc, getTwistedFacing } from '../firingArc';
+
+// =============================================================================
+// calculateFiringArc — All 4 arcs × 6 facings
+// =============================================================================
+
+describe('calculateFiringArc', () => {
+  describe('same hex', () => {
+    it('returns Front when attacker and target are in the same hex', () => {
+      const pos: IHexCoordinate = { q: 3, r: 3 };
+      expect(calculateFiringArc(pos, pos, Facing.North)).toBe(FiringArc.Front);
+      expect(calculateFiringArc(pos, pos, Facing.South)).toBe(FiringArc.Front);
+    });
+  });
+
+  describe('target facing North (0)', () => {
+    const targetPos: IHexCoordinate = { q: 0, r: 0 };
+    const facing = Facing.North;
+
+    it('detects Front arc — attacker directly ahead (north)', () => {
+      expect(calculateFiringArc({ q: 0, r: -2 }, targetPos, facing)).toBe(
+        FiringArc.Front,
+      );
+    });
+
+    it('detects Right arc — attacker at northeast adjacent (on boundary)', () => {
+      // NE adjacent hex is exactly on the front/right boundary — falls to Right
+      expect(calculateFiringArc({ q: 1, r: -1 }, targetPos, facing)).toBe(
+        FiringArc.Right,
+      );
+    });
+
+    it('detects Left arc — attacker at northwest adjacent (on boundary)', () => {
+      // NW adjacent hex is exactly on the front/left boundary — falls to Left
+      expect(calculateFiringArc({ q: -1, r: 0 }, targetPos, facing)).toBe(
+        FiringArc.Left,
+      );
+    });
+
+    it('detects Rear arc — attacker directly behind (south)', () => {
+      expect(calculateFiringArc({ q: 0, r: 2 }, targetPos, facing)).toBe(
+        FiringArc.Rear,
+      );
+    });
+
+    it('detects Right arc — attacker to the right side', () => {
+      expect(calculateFiringArc({ q: 2, r: -1 }, targetPos, facing)).toBe(
+        FiringArc.Right,
+      );
+    });
+
+    it('detects Left arc — attacker to the left side', () => {
+      expect(calculateFiringArc({ q: -2, r: 1 }, targetPos, facing)).toBe(
+        FiringArc.Left,
+      );
+    });
+  });
+
+  describe('target facing South (3)', () => {
+    const targetPos: IHexCoordinate = { q: 0, r: 0 };
+    const facing = Facing.South;
+
+    it('detects Front arc — attacker south of target', () => {
+      expect(calculateFiringArc({ q: 0, r: 2 }, targetPos, facing)).toBe(
+        FiringArc.Front,
+      );
+    });
+
+    it('detects Rear arc — attacker north of target', () => {
+      expect(calculateFiringArc({ q: 0, r: -2 }, targetPos, facing)).toBe(
+        FiringArc.Rear,
+      );
+    });
+  });
+
+  describe('target facing Southeast (2)', () => {
+    const targetPos: IHexCoordinate = { q: 0, r: 0 };
+    const facing = Facing.Southeast;
+
+    it('detects Front arc — attacker in southeast direction', () => {
+      expect(calculateFiringArc({ q: 1, r: 0 }, targetPos, facing)).toBe(
+        FiringArc.Front,
+      );
+    });
+
+    it('detects Rear arc — attacker in northwest direction', () => {
+      expect(calculateFiringArc({ q: -1, r: 0 }, targetPos, facing)).toBe(
+        FiringArc.Rear,
+      );
+    });
+  });
+
+  describe('target facing Northeast (1)', () => {
+    const targetPos: IHexCoordinate = { q: 0, r: 0 };
+    const facing = Facing.Northeast;
+
+    it('detects Front arc — attacker in northeast direction', () => {
+      expect(calculateFiringArc({ q: 1, r: -1 }, targetPos, facing)).toBe(
+        FiringArc.Front,
+      );
+    });
+
+    it('detects Rear arc — attacker in southwest direction', () => {
+      expect(calculateFiringArc({ q: -1, r: 1 }, targetPos, facing)).toBe(
+        FiringArc.Rear,
+      );
+    });
+  });
+
+  describe('target facing Southwest (4)', () => {
+    const targetPos: IHexCoordinate = { q: 0, r: 0 };
+    const facing = Facing.Southwest;
+
+    it('detects Front arc — attacker in southwest direction', () => {
+      expect(calculateFiringArc({ q: -1, r: 1 }, targetPos, facing)).toBe(
+        FiringArc.Front,
+      );
+    });
+
+    it('detects Rear arc — attacker in northeast direction', () => {
+      expect(calculateFiringArc({ q: 1, r: -1 }, targetPos, facing)).toBe(
+        FiringArc.Rear,
+      );
+    });
+  });
+
+  describe('target facing Northwest (5)', () => {
+    const targetPos: IHexCoordinate = { q: 0, r: 0 };
+    const facing = Facing.Northwest;
+
+    it('detects Front arc — attacker in northwest direction', () => {
+      expect(calculateFiringArc({ q: -1, r: 0 }, targetPos, facing)).toBe(
+        FiringArc.Front,
+      );
+    });
+
+    it('detects Rear arc — attacker in southeast direction', () => {
+      expect(calculateFiringArc({ q: 1, r: 0 }, targetPos, facing)).toBe(
+        FiringArc.Rear,
+      );
+    });
+  });
+
+  describe('all 6 facings × front/rear symmetry', () => {
+    const targetPos: IHexCoordinate = { q: 5, r: 5 };
+
+    // For each facing, a target 2 hexes directly ahead should be Front,
+    // and 2 hexes directly behind should be Rear.
+    const facingToFrontDelta: Record<number, IHexCoordinate> = {
+      [Facing.North]: { q: 0, r: -2 },
+      [Facing.Northeast]: { q: 2, r: -2 },
+      [Facing.Southeast]: { q: 2, r: 0 },
+      [Facing.South]: { q: 0, r: 2 },
+      [Facing.Southwest]: { q: -2, r: 2 },
+      [Facing.Northwest]: { q: -2, r: 0 },
+    };
+
+    for (let f = 0; f < 6; f++) {
+      const facing = f as Facing;
+      const frontDelta = facingToFrontDelta[f];
+      const rearDelta = { q: -frontDelta.q, r: -frontDelta.r };
+
+      it(`facing ${Facing[facing]}: directly ahead is Front`, () => {
+        const attackerPos = {
+          q: targetPos.q + frontDelta.q,
+          r: targetPos.r + frontDelta.r,
+        };
+        expect(calculateFiringArc(attackerPos, targetPos, facing)).toBe(
+          FiringArc.Front,
+        );
+      });
+
+      it(`facing ${Facing[facing]}: directly behind is Rear`, () => {
+        const attackerPos = {
+          q: targetPos.q + rearDelta.q,
+          r: targetPos.r + rearDelta.r,
+        };
+        expect(calculateFiringArc(attackerPos, targetPos, facing)).toBe(
+          FiringArc.Rear,
+        );
+      });
+    }
+  });
+
+  describe('long range', () => {
+    it('detects correct arc at distance 5', () => {
+      const targetPos: IHexCoordinate = { q: 0, r: 0 };
+      expect(calculateFiringArc({ q: 0, r: -5 }, targetPos, Facing.North)).toBe(
+        FiringArc.Front,
+      );
+      expect(calculateFiringArc({ q: 0, r: 5 }, targetPos, Facing.North)).toBe(
+        FiringArc.Rear,
+      );
+    });
+
+    it('detects correct arc at distance 10', () => {
+      const targetPos: IHexCoordinate = { q: 0, r: 0 };
+      expect(
+        calculateFiringArc({ q: 0, r: -10 }, targetPos, Facing.North),
+      ).toBe(FiringArc.Front);
+    });
+  });
+
+  describe('non-origin positions', () => {
+    it('works correctly with offset positions', () => {
+      const targetPos: IHexCoordinate = { q: 10, r: 10 };
+      expect(calculateFiringArc({ q: 10, r: 8 }, targetPos, Facing.North)).toBe(
+        FiringArc.Front,
+      );
+      expect(
+        calculateFiringArc({ q: 10, r: 12 }, targetPos, Facing.North),
+      ).toBe(FiringArc.Rear);
+    });
+  });
+
+  describe('spec scenario: target at (5,5) facing North, attacker at (5,3)', () => {
+    it('returns Front arc per spec', () => {
+      expect(
+        calculateFiringArc({ q: 5, r: 3 }, { q: 5, r: 5 }, Facing.North),
+      ).toBe(FiringArc.Front);
+    });
+  });
+});
+
+// =============================================================================
+// getTwistedFacing
+// =============================================================================
+
+describe('getTwistedFacing', () => {
+  it('left twist from North yields Northeast', () => {
+    expect(getTwistedFacing(Facing.North, 'left')).toBe(Facing.Northeast);
+  });
+
+  it('right twist from North yields Northwest', () => {
+    expect(getTwistedFacing(Facing.North, 'right')).toBe(Facing.Northwest);
+  });
+
+  it('left twist wraps from Northwest to North', () => {
+    expect(getTwistedFacing(Facing.Northwest, 'left')).toBe(Facing.North);
+  });
+
+  it('right twist wraps from North to Northwest', () => {
+    expect(getTwistedFacing(Facing.North, 'right')).toBe(Facing.Northwest);
+  });
+
+  it('left twist from South yields Southwest', () => {
+    expect(getTwistedFacing(Facing.South, 'left')).toBe(Facing.Southwest);
+  });
+
+  it('right twist from South yields Southeast', () => {
+    expect(getTwistedFacing(Facing.South, 'right')).toBe(Facing.Southeast);
+  });
+});
+
+// =============================================================================
+// Torso Twist Arc Extension (Task 2.7)
+// =============================================================================
+
+describe('calculateFiringArc with torso twist', () => {
+  const targetPos: IHexCoordinate = { q: 0, r: 0 };
+
+  describe('North-facing target, left twist', () => {
+    it('extends front arc to include left-side attacker position', () => {
+      // Without twist, attacker at right side might be Right arc.
+      // With left twist (facing shifts to NE), front arc shifts left,
+      // so position that was Right may now be Front.
+      const attackerInRightSide: IHexCoordinate = { q: 2, r: -1 };
+
+      const withoutTwist = calculateFiringArc(
+        attackerInRightSide,
+        targetPos,
+        Facing.North,
+      );
+      const withLeftTwist = calculateFiringArc(
+        attackerInRightSide,
+        targetPos,
+        Facing.North,
+        'left',
+      );
+
+      // Left twist shifts facing clockwise (N→NE), which moves front arc rightward
+      // So a right-side attacker may now be in front
+      if (withoutTwist === FiringArc.Right) {
+        expect(withLeftTwist).toBe(FiringArc.Front);
+      }
+    });
+  });
+
+  describe('North-facing target, right twist', () => {
+    it('extends front arc to include right-side attacker position', () => {
+      const attackerInLeftSide: IHexCoordinate = { q: -2, r: 1 };
+
+      const withoutTwist = calculateFiringArc(
+        attackerInLeftSide,
+        targetPos,
+        Facing.North,
+      );
+      const withRightTwist = calculateFiringArc(
+        attackerInLeftSide,
+        targetPos,
+        Facing.North,
+        'right',
+      );
+
+      // Right twist shifts facing counter-clockwise (N→NW), which moves front arc leftward
+      if (withoutTwist === FiringArc.Left) {
+        expect(withRightTwist).toBe(FiringArc.Front);
+      }
+    });
+  });
+
+  describe('torso twist shifts rear arc accordingly', () => {
+    it('left twist shifts rear arc to the right', () => {
+      // Attacker directly south of north-facing target is Rear
+      const attackerBehind: IHexCoordinate = { q: 0, r: 2 };
+      expect(calculateFiringArc(attackerBehind, targetPos, Facing.North)).toBe(
+        FiringArc.Rear,
+      );
+
+      // With left twist (facing shifts N→NE), south position might shift to left side
+      const withTwist = calculateFiringArc(
+        attackerBehind,
+        targetPos,
+        Facing.North,
+        'left',
+      );
+      expect([FiringArc.Rear, FiringArc.Left]).toContain(withTwist);
+    });
+  });
+
+  describe('twist for all 6 facings', () => {
+    it('left twist always shifts effective facing by +1', () => {
+      for (let f = 0; f < 6; f++) {
+        const facing = f as Facing;
+        const expected = ((f + 1) % 6) as Facing;
+        expect(getTwistedFacing(facing, 'left')).toBe(expected);
+      }
+    });
+
+    it('right twist always shifts effective facing by -1', () => {
+      for (let f = 0; f < 6; f++) {
+        const facing = f as Facing;
+        const expected = ((f - 1 + 6) % 6) as Facing;
+        expect(getTwistedFacing(facing, 'right')).toBe(expected);
+      }
+    });
+  });
+
+  describe('twist produces different result from no-twist for side positions', () => {
+    it('demonstrates arc shift via left twist', () => {
+      // North-facing target, attacker at (2, -1) is Right arc without twist
+      const attackerPos: IHexCoordinate = { q: 2, r: -1 };
+      const noTwist = calculateFiringArc(attackerPos, targetPos, Facing.North);
+      // Left twist shifts facing N→NE, pulling front arc rightward
+      const leftTwist = calculateFiringArc(
+        attackerPos,
+        targetPos,
+        Facing.North,
+        'left',
+      );
+
+      expect(noTwist).toBe(FiringArc.Right);
+      expect(leftTwist).toBe(FiringArc.Front);
+    });
+
+    it('demonstrates arc shift via right twist', () => {
+      // North-facing target, attacker at (-2, 1) is Left arc without twist
+      const attackerPos: IHexCoordinate = { q: -2, r: 1 };
+      const noTwist = calculateFiringArc(attackerPos, targetPos, Facing.North);
+      // Right twist shifts facing N→NW, pulling front arc leftward
+      const rightTwist = calculateFiringArc(
+        attackerPos,
+        targetPos,
+        Facing.North,
+        'right',
+      );
+
+      expect(noTwist).toBe(FiringArc.Left);
+      expect(rightTwist).toBe(FiringArc.Front);
+    });
+  });
+});

--- a/src/utils/gameplay/firingArc.ts
+++ b/src/utils/gameplay/firingArc.ts
@@ -1,0 +1,53 @@
+/**
+ * Firing Arc Calculation
+ *
+ * @spec openspec/changes/full-combat-parity/specs/firing-arc-calculation/spec.md
+ */
+
+import { IHexCoordinate, Facing, FiringArc } from '@/types/gameplay';
+
+import { determineArc } from './firingArcs';
+
+// =============================================================================
+// Core Firing Arc Calculation
+// =============================================================================
+
+/**
+ * Which arc the attacker is in relative to the target's facing.
+ * Selects the correct hit location table column (front/left/right/rear).
+ */
+export function calculateFiringArc(
+  attackerPos: IHexCoordinate,
+  targetPos: IHexCoordinate,
+  targetFacing: Facing,
+  torsoTwist?: 'left' | 'right',
+): FiringArc {
+  const targetAsUnit = {
+    unitId: '_target',
+    coord: targetPos,
+    facing: torsoTwist
+      ? getTwistedFacing(targetFacing, torsoTwist)
+      : targetFacing,
+    prone: false,
+  };
+
+  return determineArc(targetAsUnit, attackerPos).arc;
+}
+
+// =============================================================================
+// Torso Twist Support
+// =============================================================================
+
+/**
+ * Effective facing when torso twist is applied.
+ * Shifts center of front arc by 1 hex-side (60°) in twist direction.
+ */
+export function getTwistedFacing(
+  facing: Facing,
+  twist: 'left' | 'right',
+): Facing {
+  // Left: +1 (clockwise), Right: -1 (counter-clockwise) mod 6
+  return twist === 'left'
+    ? (((facing + 1) % 6) as Facing)
+    : (((facing - 1 + 6) % 6) as Facing);
+}

--- a/src/utils/gameplay/gameSession.ts
+++ b/src/utils/gameplay/gameSession.ts
@@ -31,6 +31,7 @@ import {
   IMovementDeclaredPayload,
 } from '@/types/gameplay';
 
+import { calculateFiringArc } from './firingArc';
 import {
   createGameCreatedEvent,
   createGameStartedEvent,
@@ -484,9 +485,16 @@ export function resolveAttack(
     const { turn } = currentSession.currentState;
 
     if (hit) {
+      const attackerState = currentSession.currentState.units[attackerId];
+      const targetState = currentSession.currentState.units[targetId];
+      const firingArc = calculateFiringArc(
+        attackerState.position,
+        targetState.position,
+        targetState.facing,
+      );
       const locationRoll = diceRoller();
       const hitLocationResult = determineHitLocationFromRoll(
-        FiringArc.Front,
+        firingArc,
         locationRoll,
       );
       const location = hitLocationResult.location;


### PR DESCRIPTION
## Summary

- **New module** `src/utils/gameplay/firingArc.ts` with `calculateFiringArc()` that computes which arc (Front/Left/Right/Rear) the attacker is in relative to the target's facing using hex coordinate math
- **Torso twist support** via `getTwistedFacing()` that shifts the effective facing by ±1 hex-side (60°) in the twist direction
- **Replaced all hardcoded `FiringArc.Front`** in combat resolution (`gameSession.ts:resolveAttack()` and all 3 callsites in `GameEngine.ts`) with computed firing arcs from actual unit positions and facings
- **46 comprehensive unit tests** covering all 4 arcs × 6 facings, torso twist arc extension, boundary cases, long range, and non-origin positions
- **Fixed test positioning** in `attackResolution.test.ts` — units now face each other correctly so the computed arc matches test expectations

## OpenSpec Change

`full-combat-parity` — Tasks 2.1-2.7 (Phase 2: Firing Arc Calculation)

## Verification

- ✅ 18,240 tests pass (46 new tests added)
- ✅ Build succeeds
- ✅ TypeScript compiles clean
- ✅ Zero hardcoded `FiringArc.Front` in combat resolution code

## Files Changed

| File | Change |
|------|--------|
| `src/utils/gameplay/firingArc.ts` | **NEW** — core `calculateFiringArc()` + `getTwistedFacing()` |
| `src/utils/gameplay/__tests__/firingArc.test.ts` | **NEW** — 46 comprehensive unit tests |
| `src/utils/gameplay/gameSession.ts` | Replace hardcoded arc in `resolveAttack()` |
| `src/engine/GameEngine.ts` | Replace hardcoded arc in 3 `declareAttack()` callsites |
| `src/__tests__/unit/utils/gameplay/attackResolution.test.ts` | Fix unit positions for correct arc |
| `openspec/changes/full-combat-parity/tasks.md` | Mark tasks 2.1-2.7 complete |