### PR TITLE
refactor: extract award store criteria helper module

### DIFF
--- a/src/stores/awardStoreUtils.ts
+++ b/src/stores/awardStoreUtils.ts
@@ -1,0 +1,29 @@
+import type { IPilotStats } from '@/types/award';
+
+import { CriteriaType } from '@/types/award';
+
+export function getCriteriaValue(
+  stats: IPilotStats,
+  criteriaType: CriteriaType,
+): number {
+  switch (criteriaType) {
+    case CriteriaType.TotalKills:
+      return stats.combat.totalKills;
+    case CriteriaType.KillsInMission:
+      return stats.combat.maxKillsInMission;
+    case CriteriaType.DamageDealt:
+      return stats.combat.totalDamageDealt;
+    case CriteriaType.DamageInMission:
+      return stats.combat.maxDamageInMission;
+    case CriteriaType.MissionsCompleted:
+      return stats.career.missionsCompleted;
+    case CriteriaType.CampaignsCompleted:
+      return stats.career.campaignsCompleted;
+    case CriteriaType.ConsecutiveSurvival:
+      return stats.career.consecutiveSurvival;
+    case CriteriaType.GamesPlayed:
+      return stats.career.gamesPlayed;
+    default:
+      return 0;
+  }
+}

--- a/src/stores/useAwardStore.ts
+++ b/src/stores/useAwardStore.ts
@@ -26,6 +26,8 @@ import {
   getAwardById,
 } from '@/types/award';
 
+import { getCriteriaValue } from './awardStoreUtils';
+
 // =============================================================================
 // Store State
 // =============================================================================
@@ -125,36 +127,6 @@ interface AwardStoreActions {
 }
 
 type AwardStore = AwardStoreState & AwardStoreActions;
-
-// =============================================================================
-// Helper Functions
-// =============================================================================
-
-function getCriteriaValue(
-  stats: IPilotStats,
-  criteriaType: CriteriaType,
-): number {
-  switch (criteriaType) {
-    case CriteriaType.TotalKills:
-      return stats.combat.totalKills;
-    case CriteriaType.KillsInMission:
-      return stats.combat.maxKillsInMission;
-    case CriteriaType.DamageDealt:
-      return stats.combat.totalDamageDealt;
-    case CriteriaType.DamageInMission:
-      return stats.combat.maxDamageInMission;
-    case CriteriaType.MissionsCompleted:
-      return stats.career.missionsCompleted;
-    case CriteriaType.CampaignsCompleted:
-      return stats.career.campaignsCompleted;
-    case CriteriaType.ConsecutiveSurvival:
-      return stats.career.consecutiveSurvival;
-    case CriteriaType.GamesPlayed:
-      return stats.career.gamesPlayed;
-    default:
-      return 0;
-  }
-}
 
 // =============================================================================
 // Store Implementation


### PR DESCRIPTION
## Summary
- extract criteria evaluation helper logic from `useAwardStore` into a focused `awardStoreUtils` module
- keep award evaluation behavior unchanged while reducing `useAwardStore` max-lines debt
- verify with targeted tests, typecheck, lint, and build

## Verification
- `npm test -- --runTestsByPath src/stores/__tests__/useAwardStore.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`