### PR TITLE
chore: centralize build version metadata

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,57 @@
 import type { NextConfig } from 'next';
 import type { Configuration, WebpackPluginInstance } from 'webpack';
 
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+
+const FALLBACK_APP_VERSION = '0.0.0';
+const FALLBACK_BUILD_NUMBER = '0';
+
+function runCommand(command: string): string | undefined {
+  try {
+    const output = execSync(command, {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+
+    return output.length > 0 ? output : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readPackageVersion(): string {
+  try {
+    const packageJsonPath = join(process.cwd(), 'package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+      version?: unknown;
+    };
+
+    if (typeof packageJson.version === 'string') {
+      const version = packageJson.version.trim();
+      if (version.length > 0) {
+        return version;
+      }
+    }
+  } catch {
+    return FALLBACK_APP_VERSION;
+  }
+
+  return FALLBACK_APP_VERSION;
+}
+
+const appVersion =
+  process.env.npm_package_version?.trim() || readPackageVersion();
+const buildNumber =
+  process.env.BUILD_NUMBER?.trim() ||
+  process.env.GITHUB_RUN_NUMBER?.trim() ||
+  runCommand('git rev-list --count HEAD') ||
+  FALLBACK_BUILD_NUMBER;
+const gitSha = runCommand('git rev-parse --short HEAD') || 'unknown';
+const buildVersion = `${appVersion}+${buildNumber}`;
 
 interface WebpackContext {
   buildId: string;
@@ -174,6 +224,14 @@ const nextConfig: NextConfig = {
   env: {
     BUNDLE_ANALYZE: process.env.ANALYZE === 'true' ? 'true' : 'false',
     BUILD_TIME: new Date().toISOString(),
+    APP_VERSION: appVersion,
+    BUILD_NUMBER: buildNumber,
+    BUILD_VERSION: buildVersion,
+    GIT_SHA: gitSha,
+    NEXT_PUBLIC_APP_VERSION: appVersion,
+    NEXT_PUBLIC_BUILD_NUMBER: buildNumber,
+    NEXT_PUBLIC_BUILD_VERSION: buildVersion,
+    NEXT_PUBLIC_GIT_SHA: gitSha,
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mekstation-app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mekstation-app",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mekstation-app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "BattleTech unit construction and customization tool",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/components/common/TopBar.tsx
+++ b/src/components/common/TopBar.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router';
  */
 import React, { ReactElement, useState, useRef, useEffect } from 'react';
 
+import { APP_VERSION_LABEL } from '@/constants/appVersion';
 import { useMobileSidebarStore } from '@/stores/useNavigationStore';
 
 import {
@@ -337,7 +338,7 @@ function MobileMenu({
         {/* Footer */}
         <div className="border-border-theme-subtle border-t px-4 py-3">
           <div className="text-text-theme-muted flex items-center justify-between text-xs">
-            <span>v0.1.0</span>
+            <span>{APP_VERSION_LABEL}</span>
             <a
               href="https://github.com"
               target="_blank"

--- a/src/constants/appVersion.ts
+++ b/src/constants/appVersion.ts
@@ -1,0 +1,24 @@
+const FALLBACK_APP_VERSION = '0.0.0';
+
+function readEnv(name: string): string | undefined {
+  const value = process.env[name];
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export const APP_VERSION =
+  readEnv('NEXT_PUBLIC_APP_VERSION') ??
+  readEnv('APP_VERSION') ??
+  readEnv('npm_package_version') ??
+  FALLBACK_APP_VERSION;
+
+export const BUILD_VERSION =
+  readEnv('NEXT_PUBLIC_BUILD_VERSION') ??
+  readEnv('BUILD_VERSION') ??
+  APP_VERSION;
+
+export const APP_VERSION_LABEL = `v${BUILD_VERSION}`;

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -11,6 +11,8 @@
 
 import type { NextApiRequest, NextApiResponse } from 'next';
 
+import { BUILD_VERSION } from '@/constants/appVersion';
+
 interface IHealthResponse {
   status: 'healthy' | 'unhealthy';
   timestamp: string;
@@ -65,7 +67,7 @@ export default function handler(
       status: isHealthy ? 'healthy' : 'unhealthy',
       timestamp: new Date().toISOString(),
       uptime: Math.floor((Date.now() - startTime) / 1000),
-      version: process.env.npm_package_version || '1.0.0',
+      version: BUILD_VERSION,
       environment: process.env.NODE_ENV || 'development',
       checks: {
         server: 'ok',
@@ -93,7 +95,7 @@ export default function handler(
       status: 'unhealthy',
       timestamp: new Date().toISOString(),
       uptime: Math.floor((Date.now() - startTime) / 1000),
-      version: process.env.npm_package_version || '1.0.0',
+      version: BUILD_VERSION,
       environment: process.env.NODE_ENV || 'development',
       checks: {
         server: 'error',

--- a/src/pages/api/units/custom/[id]/export.ts
+++ b/src/pages/api/units/custom/[id]/export.ts
@@ -8,14 +8,12 @@
 
 import type { NextApiRequest, NextApiResponse } from 'next';
 
+import { BUILD_VERSION } from '@/constants/appVersion';
 import { getSQLiteService } from '@/services/persistence/SQLiteService';
 import { getUnitRepository } from '@/services/units/UnitRepository';
 import { ISerializedUnitEnvelope } from '@/types/persistence/UnitPersistence';
 
-/**
- * Package version (would normally come from package.json)
- */
-const APP_VERSION = '1.0.0';
+const APP_VERSION = BUILD_VERSION;
 const FORMAT_VERSION = '1.0.0';
 
 /**

--- a/src/pages/api/vault/sign.ts
+++ b/src/pages/api/vault/sign.ts
@@ -17,6 +17,7 @@ import type {
   ShareableContentType,
 } from '@/types/vault';
 
+import { BUILD_VERSION } from '@/constants/appVersion';
 import { getIdentityRepository } from '@/services/vault/IdentityRepository';
 import {
   unlockIdentity,
@@ -102,7 +103,7 @@ export default async function handler(
       createdAt: new Date().toISOString(),
       description: typeof description === 'string' ? description : undefined,
       tags: Array.isArray(tags) ? (tags as string[]) : undefined,
-      appVersion: process.env.npm_package_version ?? '0.1.0',
+      appVersion: BUILD_VERSION,
     };
 
     // Serialize payload

--- a/src/services/vault/BundleService.ts
+++ b/src/services/vault/BundleService.ts
@@ -17,6 +17,8 @@ import type {
   IExportResult,
 } from '@/types/vault';
 
+import { BUILD_VERSION } from '@/constants/appVersion';
+
 import {
   signMessage,
   verifyMessage,
@@ -283,8 +285,7 @@ export function validateBundleMetadata(metadata: IBundleMetadata): string[] {
  * Get application version for bundle metadata
  */
 function getAppVersion(): string {
-  // In a real app, this would come from package.json or environment
-  return '0.1.0';
+  return BUILD_VERSION;
 }
 
 /**

--- a/src/simulation/reporting/ReportGenerator.ts
+++ b/src/simulation/reporting/ReportGenerator.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { BUILD_VERSION } from '../../constants/appVersion';
 import { ISimulationConfig } from '../core/types';
 import { ISimulationMetrics, IAggregateMetrics } from '../metrics/types';
 import { ISimulationReport, IReportViolation } from './types';
@@ -58,7 +59,7 @@ export class ReportGenerator {
 
     return {
       timestamp,
-      generatedBy: 'MekStation Simulation System v0.1.0',
+      generatedBy: `MekStation Simulation System v${BUILD_VERSION}`,
       config,
       summary: {
         total: metrics.length,


### PR DESCRIPTION
## Summary
- introduce centralized `APP_VERSION`/`BUILD_VERSION` constants and wire them to UI/API/service version outputs
- compute build metadata in `next.config.ts` (package version + build number + git SHA) and expose both server and `NEXT_PUBLIC_*` env vars
- bump package version to `0.1.1` so build metadata no longer defaults to `0.1.0`

## Validation
- `npm test -- --watchAll=false src/services/vault/__tests__/BundleService.test.ts`
- `npm test -- --watchAll=false src/services/vault/__tests__/ExportService.test.ts`
- `npm test -- --watchAll=false src/services/vault/__tests__/ImportService.test.ts`
- `npm test -- --watchAll=false src/hooks/__tests__/useVaultExport.test.ts`
- `npm test -- --watchAll=false src/hooks/__tests__/useVaultImport.test.ts`
- `npm test -- --watchAll=false src/simulation/__tests__/reportGenerator.test.ts`
- `npm test -- --watchAll=false src/__tests__/api/units/custom/\[id\]/export.test.ts`
- `npm run typecheck`
- `npm run lint` (82 warnings, 0 errors)
- `npm run build`
- `npm run analyze:dependencies` (no cycles: `[]`)