### PR TITLE
refactor: split analysis bugs page modules

### DIFF
--- a/src/components/simulation-viewer/pages/AnalysisBugs.cards.tsx
+++ b/src/components/simulation-viewer/pages/AnalysisBugs.cards.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+
+import { FOCUS_RING_CLASSES } from '@/utils/accessibility';
+
+import type { IInvariant } from './AnalysisBugs.types';
+
+import { INVARIANT_STATUS_CLASSES } from './AnalysisBugs.constants';
+import { formatTimestamp } from './AnalysisBugs.utils';
+
+export const InvariantCard: React.FC<{
+  invariant: IInvariant;
+  onClick?: (invariantId: string) => void;
+}> = ({ invariant, onClick }) => {
+  const handleClick = () => onClick?.(invariant.id);
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClick?.(invariant.id);
+    }
+  };
+
+  return (
+    <div
+      className={`cursor-pointer rounded-lg border border-gray-200 bg-white p-4 transition-shadow hover:shadow-md dark:border-gray-700 dark:bg-gray-800 ${FOCUS_RING_CLASSES}`}
+      data-testid="invariant-card"
+      data-status={invariant.status}
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      aria-label={`${invariant.name}: ${invariant.status}`}
+    >
+      <div className="mb-2 flex items-center justify-between">
+        <h3
+          className="mr-2 truncate text-sm font-semibold text-gray-900 dark:text-gray-100"
+          data-testid="invariant-name"
+          title={invariant.name}
+        >
+          {invariant.name}
+        </h3>
+        <span
+          className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-bold uppercase ${INVARIANT_STATUS_CLASSES[invariant.status]}`}
+          data-testid="invariant-status-badge"
+        >
+          {invariant.status}
+        </span>
+      </div>
+      <p
+        className="mb-2 line-clamp-2 text-xs text-gray-500 dark:text-gray-400"
+        data-testid="invariant-description"
+      >
+        {invariant.description}
+      </p>
+      <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+        <span data-testid="invariant-last-checked">
+          {formatTimestamp(invariant.lastChecked)}
+        </span>
+        {invariant.failureCount > 0 && (
+          <span
+            className="font-medium text-red-600 dark:text-red-400"
+            data-testid="invariant-failure-count"
+          >
+            {invariant.failureCount} failure
+            {invariant.failureCount !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const ThresholdSlider: React.FC<{
+  detectorKey: string;
+  label: string;
+  description: string;
+  value: number;
+  affectedCount: number;
+  onChange: (detector: string, value: number) => void;
+}> = ({ detectorKey, label, description, value, affectedCount, onChange }) => (
+  <div data-testid={`threshold-slider-${detectorKey}`}>
+    <div className="mb-1 flex items-center justify-between">
+      <label
+        htmlFor={`slider-${detectorKey}`}
+        className="text-sm font-medium text-gray-700 dark:text-gray-300"
+      >
+        {label}
+      </label>
+      <span
+        className="font-mono text-sm text-gray-900 dark:text-gray-100"
+        data-testid={`threshold-value-${detectorKey}`}
+      >
+        {value}
+      </span>
+    </div>
+    <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+      {description}
+    </p>
+    <input
+      id={`slider-${detectorKey}`}
+      type="range"
+      min={0}
+      max={100}
+      value={value}
+      onChange={(event) => onChange(detectorKey, Number(event.target.value))}
+      className={`h-2 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-blue-600 dark:bg-gray-600 dark:accent-blue-400 ${FOCUS_RING_CLASSES}`}
+      data-testid={`threshold-input-${detectorKey}`}
+      aria-label={`${label} threshold`}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={value}
+    />
+    {affectedCount > 0 && (
+      <p
+        className="mt-1 text-xs text-amber-600 dark:text-amber-400"
+        data-testid={`threshold-affected-${detectorKey}`}
+      >
+        {affectedCount} anomal{affectedCount === 1 ? 'y' : 'ies'} from this
+        detector
+      </p>
+    )}
+  </div>
+);
+
+export const ToggleSwitch: React.FC<{
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}> = ({ id, label, checked, onChange }) => (
+  <label
+    htmlFor={id}
+    className="group flex cursor-pointer items-center justify-between"
+    data-testid={`toggle-${id}`}
+  >
+    <span className="text-sm text-gray-700 transition-colors group-hover:text-gray-900 dark:text-gray-300 dark:group-hover:text-gray-100">
+      {label}
+    </span>
+    <div className="relative">
+      <input
+        id={id}
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        className="peer sr-only"
+        data-testid={`toggle-input-${id}`}
+        role="switch"
+        aria-checked={checked}
+        aria-label={label}
+      />
+      <div className="h-5 w-9 rounded-full bg-gray-300 transition-colors peer-checked:bg-blue-600 peer-focus:ring-2 peer-focus:ring-blue-500 dark:bg-gray-600 dark:peer-checked:bg-blue-500" />
+      <div className="absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform peer-checked:translate-x-4" />
+    </div>
+  </label>
+);

--- a/src/components/simulation-viewer/pages/AnalysisBugs.constants.ts
+++ b/src/components/simulation-viewer/pages/AnalysisBugs.constants.ts
@@ -1,0 +1,40 @@
+import type {
+  IThresholds,
+  InvariantStatus,
+  Severity,
+} from './AnalysisBugs.types';
+
+export const SEVERITY_ORDER: Record<Severity, number> = {
+  critical: 2,
+  warning: 1,
+  info: 0,
+};
+
+export const INVARIANT_STATUS_CLASSES: Record<InvariantStatus, string> = {
+  pass: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300',
+  fail: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+};
+
+export const DEFAULT_THRESHOLDS: IThresholds = {
+  heatSuicide: 80,
+  passiveUnit: 60,
+  noProgress: 70,
+  longGame: 90,
+  stateCycle: 75,
+};
+
+export const DETECTOR_LABELS: Record<string, string> = {
+  heatSuicide: 'Heat Suicide',
+  passiveUnit: 'Passive Unit',
+  noProgress: 'No Progress',
+  longGame: 'Long Game',
+  stateCycle: 'State Cycle',
+};
+
+export const DETECTOR_DESCRIPTIONS: Record<string, string> = {
+  heatSuicide: 'Threshold for heat suicide detection',
+  passiveUnit: 'Threshold for passive unit detection',
+  noProgress: 'Threshold for no progress detection',
+  longGame: 'Threshold for long game detection',
+  stateCycle: 'Threshold for state cycle detection',
+};

--- a/src/components/simulation-viewer/pages/AnalysisBugs.sections.tsx
+++ b/src/components/simulation-viewer/pages/AnalysisBugs.sections.tsx
@@ -1,0 +1,319 @@
+import React from 'react';
+
+import type { IFilterDefinition } from '@/components/simulation-viewer/types';
+import type { IAnomaly } from '@/types/simulation-viewer';
+import type { IViolation } from '@/types/simulation-viewer/IViolation';
+
+import { AnomalyAlertCard } from '@/components/simulation-viewer/AnomalyAlertCard';
+import { FilterPanel } from '@/components/simulation-viewer/FilterPanel';
+import { VirtualizedViolationLog } from '@/components/simulation-viewer/VirtualizedViolationLog';
+import { FOCUS_RING_CLASSES } from '@/utils/accessibility';
+
+import type {
+  IInvariant,
+  IPageAnomaly,
+  IThresholds,
+} from './AnalysisBugs.types';
+
+import {
+  InvariantCard,
+  ThresholdSlider,
+  ToggleSwitch,
+} from './AnalysisBugs.cards';
+import {
+  DETECTOR_DESCRIPTIONS,
+  DETECTOR_LABELS,
+} from './AnalysisBugs.constants';
+import { mapToCardAnomaly } from './AnalysisBugs.utils';
+
+interface InvariantStatusSectionProps {
+  invariants: IInvariant[];
+  onViewInvariant?: (invariantId: string) => void;
+}
+
+export const InvariantStatusSection: React.FC<InvariantStatusSectionProps> = ({
+  invariants,
+  onViewInvariant,
+}) => (
+  <section aria-label="Invariant status" data-testid="invariant-section">
+    <h2
+      className="mb-4 text-lg font-semibold text-gray-800 dark:text-gray-200"
+      data-testid="invariant-heading"
+    >
+      Invariant Status
+    </h2>
+
+    {invariants.length === 0 ? (
+      <p
+        className="text-sm text-gray-500 italic dark:text-gray-400"
+        data-testid="invariant-empty"
+      >
+        No invariants configured.
+      </p>
+    ) : (
+      <div
+        className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4"
+        data-testid="invariant-grid"
+      >
+        {invariants.map((invariant) => (
+          <InvariantCard
+            key={invariant.id}
+            invariant={invariant}
+            onClick={onViewInvariant}
+          />
+        ))}
+      </div>
+    )}
+  </section>
+);
+
+interface AnomalyAlertsSectionProps {
+  anomalies: IPageAnomaly[];
+  visibleAnomalies: IPageAnomaly[];
+  showDismissed: boolean;
+  onToggleDismissed: () => void;
+  onDismissAnomaly?: (anomalyId: string) => void;
+  onViewSnapshot?: (snapshotId: string) => void;
+  onViewBattle?: (battleId: string) => void;
+  onConfigureThreshold?: (detector: string) => void;
+}
+
+export const AnomalyAlertsSection: React.FC<AnomalyAlertsSectionProps> = ({
+  anomalies,
+  visibleAnomalies,
+  showDismissed,
+  onToggleDismissed,
+  onDismissAnomaly,
+  onViewSnapshot,
+  onViewBattle,
+  onConfigureThreshold,
+}) => {
+  const handleViewSnapshot = (anomaly: IAnomaly) => {
+    const pageAnomaly = anomalies.find((item) => item.id === anomaly.id);
+    if (pageAnomaly) {
+      onViewSnapshot?.(pageAnomaly.snapshotId);
+    }
+  };
+
+  return (
+    <section aria-label="Anomaly alerts" data-testid="anomaly-section">
+      <div className="mb-4 flex items-center justify-between">
+        <h2
+          className="text-lg font-semibold text-gray-800 dark:text-gray-200"
+          data-testid="anomaly-heading"
+        >
+          Anomaly Alerts
+          {anomalies.length > 0 && (
+            <span className="ml-2 text-sm font-normal text-gray-500 dark:text-gray-400">
+              ({visibleAnomalies.length})
+            </span>
+          )}
+        </h2>
+
+        {anomalies.some((anomaly) => anomaly.dismissed) && (
+          <button
+            type="button"
+            onClick={onToggleDismissed}
+            className={`min-h-[44px] rounded-md px-3 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 md:min-h-0 md:py-1 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200 ${FOCUS_RING_CLASSES}`}
+            data-testid="toggle-dismissed"
+            aria-pressed={showDismissed}
+          >
+            {showDismissed ? 'Hide Dismissed' : 'Show Dismissed'}
+          </button>
+        )}
+      </div>
+
+      {visibleAnomalies.length === 0 ? (
+        <p
+          className="text-sm text-gray-500 italic dark:text-gray-400"
+          data-testid="anomaly-empty"
+        >
+          No anomalies detected.
+        </p>
+      ) : (
+        <div
+          className="overflow-x-auto pb-2"
+          data-testid="anomaly-scroll-container"
+        >
+          <div className="flex min-w-max gap-4">
+            {visibleAnomalies.map((anomaly) => (
+              <div
+                key={anomaly.id}
+                className="w-80 flex-shrink-0"
+                data-testid={`anomaly-card-wrapper-${anomaly.id}`}
+              >
+                <AnomalyAlertCard
+                  anomaly={mapToCardAnomaly(anomaly)}
+                  onViewSnapshot={
+                    onViewSnapshot ? handleViewSnapshot : undefined
+                  }
+                  onViewBattle={onViewBattle}
+                  onConfigureThreshold={onConfigureThreshold}
+                  onDismiss={onDismissAnomaly}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};
+
+interface ViolationLogSectionProps {
+  violationFilters: IFilterDefinition[];
+  activeFilters: Record<string, string[]>;
+  onFilterChange: (filters: Record<string, string[]>) => void;
+  filteredViolations: IViolation[];
+  onViewBattle?: (battleId: string) => void;
+}
+
+export const ViolationLogSection: React.FC<ViolationLogSectionProps> = ({
+  violationFilters,
+  activeFilters,
+  onFilterChange,
+  filteredViolations,
+  onViewBattle,
+}) => (
+  <section
+    className="lg:col-span-3"
+    aria-label="Violation log"
+    data-testid="violation-section"
+  >
+    <h2
+      className="mb-4 text-lg font-semibold text-gray-800 dark:text-gray-200"
+      data-testid="violation-heading"
+    >
+      Violation Log
+      {filteredViolations.length > 0 && (
+        <span className="ml-2 text-sm font-normal text-gray-500 dark:text-gray-400">
+          ({filteredViolations.length})
+        </span>
+      )}
+    </h2>
+
+    <FilterPanel
+      filters={violationFilters}
+      activeFilters={activeFilters}
+      onFilterChange={onFilterChange}
+      className="mb-4"
+    />
+
+    <VirtualizedViolationLog
+      violations={filteredViolations}
+      height={480}
+      itemHeight={56}
+      onViewBattle={onViewBattle}
+    />
+  </section>
+);
+
+interface ThresholdConfigurationSectionProps {
+  localThresholds: IThresholds;
+  affectedAnomalyCounts: Record<string, number>;
+  onSliderChange: (detector: string, value: number) => void;
+  onResetThresholds: () => void;
+  onSaveThresholds: () => void;
+  autoSnapshotCritical: boolean;
+  autoSnapshotWarning: boolean;
+  autoSnapshotInfo: boolean;
+  setAutoSnapshotCritical: (checked: boolean) => void;
+  setAutoSnapshotWarning: (checked: boolean) => void;
+  setAutoSnapshotInfo: (checked: boolean) => void;
+}
+
+export const ThresholdConfigurationSection: React.FC<
+  ThresholdConfigurationSectionProps
+> = ({
+  localThresholds,
+  affectedAnomalyCounts,
+  onSliderChange,
+  onResetThresholds,
+  onSaveThresholds,
+  autoSnapshotCritical,
+  autoSnapshotWarning,
+  autoSnapshotInfo,
+  setAutoSnapshotCritical,
+  setAutoSnapshotWarning,
+  setAutoSnapshotInfo,
+}) => (
+  <section
+    className="lg:col-span-2"
+    aria-label="Threshold configuration"
+    data-testid="threshold-section"
+  >
+    <h2
+      className="mb-4 text-lg font-semibold text-gray-800 dark:text-gray-200"
+      data-testid="threshold-heading"
+    >
+      Threshold Configuration
+    </h2>
+
+    <div className="space-y-5 rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+      {(Object.keys(DETECTOR_LABELS) as Array<keyof IThresholds>).map(
+        (detectorKey) => (
+          <ThresholdSlider
+            key={detectorKey}
+            detectorKey={detectorKey}
+            label={DETECTOR_LABELS[detectorKey]}
+            description={DETECTOR_DESCRIPTIONS[detectorKey]}
+            value={localThresholds[detectorKey]}
+            affectedCount={affectedAnomalyCounts[detectorKey] ?? 0}
+            onChange={onSliderChange}
+          />
+        ),
+      )}
+
+      <div
+        className="flex gap-3 border-t border-gray-200 pt-2 dark:border-gray-700"
+        data-testid="threshold-actions"
+      >
+        <button
+          type="button"
+          onClick={onResetThresholds}
+          className={`min-h-[44px] rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-100 md:min-h-0 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 ${FOCUS_RING_CLASSES}`}
+          data-testid="threshold-reset"
+        >
+          Reset to Defaults
+        </button>
+        <button
+          type="button"
+          onClick={onSaveThresholds}
+          className={`min-h-[44px] rounded-md bg-blue-600 px-4 py-2 text-sm text-white transition-colors hover:bg-blue-700 md:min-h-0 dark:bg-blue-500 dark:hover:bg-blue-600 ${FOCUS_RING_CLASSES}`}
+          data-testid="threshold-save"
+        >
+          Save Thresholds
+        </button>
+      </div>
+
+      <div
+        className="border-t border-gray-200 pt-4 dark:border-gray-700"
+        data-testid="auto-snapshot-config"
+      >
+        <h3 className="mb-3 text-sm font-semibold tracking-wide text-gray-700 uppercase dark:text-gray-300">
+          Auto-Snapshot
+        </h3>
+        <div className="space-y-2">
+          <ToggleSwitch
+            id="auto-snapshot-critical"
+            label="Critical anomalies"
+            checked={autoSnapshotCritical}
+            onChange={setAutoSnapshotCritical}
+          />
+          <ToggleSwitch
+            id="auto-snapshot-warning"
+            label="Warning anomalies"
+            checked={autoSnapshotWarning}
+            onChange={setAutoSnapshotWarning}
+          />
+          <ToggleSwitch
+            id="auto-snapshot-info"
+            label="Info anomalies"
+            checked={autoSnapshotInfo}
+            onChange={setAutoSnapshotInfo}
+          />
+        </div>
+      </div>
+    </div>
+  </section>
+);

--- a/src/components/simulation-viewer/pages/AnalysisBugs.tsx
+++ b/src/components/simulation-viewer/pages/AnalysisBugs.tsx
@@ -1,248 +1,40 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
-import type { IFilterDefinition } from '@/components/simulation-viewer/types';
-import type { IAnomaly } from '@/types/simulation-viewer';
 import type { IViolation } from '@/types/simulation-viewer/IViolation';
 
-import { AnomalyAlertCard } from '@/components/simulation-viewer/AnomalyAlertCard';
-import { FilterPanel } from '@/components/simulation-viewer/FilterPanel';
-import { VirtualizedViolationLog } from '@/components/simulation-viewer/VirtualizedViolationLog';
-import { FOCUS_RING_CLASSES, announce } from '@/utils/accessibility';
+import { announce } from '@/utils/accessibility';
 
-export type { IViolation } from '@/types/simulation-viewer/IViolation';
+import type {
+  IAnalysisBugsProps,
+  IInvariant,
+  IPageAnomaly,
+  IThresholds,
+  SortDirection,
+  ViolationSortKey,
+} from './AnalysisBugs.types';
 
-/* ========================================================================== */
-/*  Types                                                                      */
-/* ========================================================================== */
+import { DEFAULT_THRESHOLDS, SEVERITY_ORDER } from './AnalysisBugs.constants';
+import {
+  AnomalyAlertsSection,
+  InvariantStatusSection,
+  ThresholdConfigurationSection,
+  ViolationLogSection,
+} from './AnalysisBugs.sections';
+import {
+  buildViolationFilters,
+  formatTimestamp,
+  getThresholdKeyForDetector,
+} from './AnalysisBugs.utils';
 
-/** Status of an invariant check — pass or fail */
-type InvariantStatus = 'pass' | 'fail';
-
-/** Severity level for anomalies and violations */
-type Severity = 'critical' | 'warning' | 'info';
-
-/** Detector type identifiers matching Wave 3 detectors */
-type DetectorType =
-  | 'heat-suicide'
-  | 'passive-unit'
-  | 'no-progress'
-  | 'long-game'
-  | 'state-cycle';
-
-/** Sort direction for table columns */
-type SortDirection = 'asc' | 'desc';
-
-/** Sortable columns in the violation log */
-type ViolationSortKey = 'severity' | 'timestamp';
-
-/**
- * Represents a single invariant check result.
- */
-export interface IInvariant {
-  readonly id: string;
-  readonly name: string;
-  readonly description: string;
-  readonly status: InvariantStatus;
-  readonly lastChecked: string;
-  readonly failureCount: number;
-}
-
-/**
- * Represents a detected anomaly from a Wave 3 detector.
- */
-export interface IPageAnomaly {
-  readonly id: string;
-  readonly detector: DetectorType;
-  readonly severity: Severity;
-  readonly title: string;
-  readonly description: string;
-  readonly battleId: string;
-  readonly snapshotId: string;
-  readonly timestamp: string;
-  readonly dismissed: boolean;
-}
-
-/**
- * Threshold configuration for all five Wave 3 detectors.
- * Each value represents a sensitivity percentage (0–100).
- */
-export interface IThresholds {
-  readonly heatSuicide: number;
-  readonly passiveUnit: number;
-  readonly noProgress: number;
-  readonly longGame: number;
-  readonly stateCycle: number;
-}
-
-/**
- * Props for the Analysis & Bugs page component.
- *
- * @example
- * ```tsx
- * <AnalysisBugs
- *   campaignId="campaign-001"
- *   invariants={invariantData}
- *   anomalies={anomalyData}
- *   violations={violationData}
- *   thresholds={thresholdData}
- *   onThresholdChange={(detector, value) => updateThreshold(detector, value)}
- * />
- * ```
- */
-export interface IAnalysisBugsProps {
-  /** Campaign identifier */
-  readonly campaignId: string;
-  /** Array of invariant check results */
-  readonly invariants: IInvariant[];
-  /** Array of detected anomalies */
-  readonly anomalies: IPageAnomaly[];
-  /** Array of violation log entries */
-  readonly violations: IViolation[];
-  /** Current threshold configuration */
-  readonly thresholds: IThresholds;
-  /** Callback when a threshold slider is changed */
-  readonly onThresholdChange?: (detector: string, value: number) => void;
-  /** Callback when an anomaly is dismissed */
-  readonly onDismissAnomaly?: (anomalyId: string) => void;
-  /** Callback to view a snapshot */
-  readonly onViewSnapshot?: (snapshotId: string) => void;
-  /** Callback to view a battle */
-  readonly onViewBattle?: (battleId: string) => void;
-  /** Callback to configure a detector threshold */
-  readonly onConfigureThreshold?: (detector: string) => void;
-  /** Callback when an invariant card is clicked */
-  readonly onViewInvariant?: (invariantId: string) => void;
-}
-
-/* ========================================================================== */
-/*  Constants                                                                  */
-/* ========================================================================== */
-
-const SEVERITY_ORDER: Record<Severity, number> = {
-  critical: 2,
-  warning: 1,
-  info: 0,
+export type {
+  IAnalysisBugsProps,
+  IInvariant,
+  IPageAnomaly,
+  IThresholds,
+  IViolation,
 };
+export { formatTimestamp };
 
-const INVARIANT_STATUS_CLASSES: Record<InvariantStatus, string> = {
-  pass: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300',
-  fail: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
-};
-
-const DEFAULT_THRESHOLDS: IThresholds = {
-  heatSuicide: 80,
-  passiveUnit: 60,
-  noProgress: 70,
-  longGame: 90,
-  stateCycle: 75,
-};
-
-const DETECTOR_LABELS: Record<string, string> = {
-  heatSuicide: 'Heat Suicide',
-  passiveUnit: 'Passive Unit',
-  noProgress: 'No Progress',
-  longGame: 'Long Game',
-  stateCycle: 'State Cycle',
-};
-
-const DETECTOR_DESCRIPTIONS: Record<string, string> = {
-  heatSuicide: 'Threshold for heat suicide detection',
-  passiveUnit: 'Threshold for passive unit detection',
-  noProgress: 'Threshold for no progress detection',
-  longGame: 'Threshold for long game detection',
-  stateCycle: 'Threshold for state cycle detection',
-};
-
-/* ========================================================================== */
-/*  Utility functions                                                          */
-/* ========================================================================== */
-
-/**
- * Format an ISO timestamp into a human-readable date-time string.
- */
-export function formatTimestamp(iso: string): string {
-  try {
-    const date = new Date(iso);
-    if (isNaN(date.getTime())) return iso;
-    return date.toLocaleString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  } catch {
-    return iso;
-  }
-}
-
-/**
- * Map a page-level anomaly to the IAnomaly shape expected by AnomalyAlertCard.
- */
-function mapToCardAnomaly(anomaly: IPageAnomaly): IAnomaly {
-  return {
-    id: anomaly.id,
-    type: anomaly.detector,
-    severity: anomaly.severity,
-    battleId: anomaly.battleId,
-    turn: null,
-    unitId: null,
-    message: anomaly.description,
-    configKey:
-      anomaly.detector === 'heat-suicide'
-        ? 'heatSuicideThreshold'
-        : anomaly.detector === 'passive-unit'
-          ? 'passiveUnitThreshold'
-          : anomaly.detector === 'no-progress'
-            ? 'noProgressThreshold'
-            : anomaly.detector === 'long-game'
-              ? 'longGameThreshold'
-              : 'stateCycleThreshold',
-    timestamp: Date.parse(anomaly.timestamp) || Date.now(),
-  };
-}
-
-/**
- * Build the filter definitions for the violation log.
- */
-function buildViolationFilters(violations: IViolation[]): IFilterDefinition[] {
-  const types = Array.from(new Set(violations.map((v) => v.type))).sort();
-  const battles = Array.from(new Set(violations.map((v) => v.battleId))).sort();
-
-  return [
-    {
-      id: 'severity',
-      label: 'Severity',
-      options: ['critical', 'warning', 'info'],
-      optionLabels: { critical: 'Critical', warning: 'Warning', info: 'Info' },
-    },
-    {
-      id: 'type',
-      label: 'Type',
-      options: types,
-    },
-    {
-      id: 'battle',
-      label: 'Battle',
-      options: battles,
-    },
-  ];
-}
-
-/* ========================================================================== */
-/*  Component                                                                  */
-/* ========================================================================== */
-
-/**
- * Analysis & Bugs page — invariant status, anomaly cards, violation log,
- * and threshold configuration for the simulation viewer.
- *
- * Renders four sections:
- * 1. Invariant Status — grid of 12 invariant check cards
- * 2. Anomaly Cards — horizontal scrollable AnomalyAlertCard list
- * 3. Violation Log — filterable, sortable table with pagination
- * 4. Threshold Configuration — 5 detector sliders + auto-snapshot toggles
- */
 export const AnalysisBugs: React.FC<IAnalysisBugsProps> = ({
   campaignId,
   invariants,
@@ -256,7 +48,6 @@ export const AnalysisBugs: React.FC<IAnalysisBugsProps> = ({
   onConfigureThreshold,
   onViewInvariant,
 }) => {
-  /* ---- state ---- */
   const [showDismissed, setShowDismissed] = useState(false);
   const [activeFilters, setActiveFilters] = useState<Record<string, string[]>>(
     {},
@@ -271,10 +62,11 @@ export const AnalysisBugs: React.FC<IAnalysisBugsProps> = ({
   const [autoSnapshotWarning, setAutoSnapshotWarning] = useState(false);
   const [autoSnapshotInfo, setAutoSnapshotInfo] = useState(false);
 
-  /* ---- derived data ---- */
   const visibleAnomalies = useMemo(() => {
-    if (showDismissed) return anomalies;
-    return anomalies.filter((a) => !a.dismissed);
+    if (showDismissed) {
+      return anomalies;
+    }
+    return anomalies.filter((anomaly) => !anomaly.dismissed);
   }, [anomalies, showDismissed]);
 
   const violationFilters = useMemo(
@@ -287,17 +79,23 @@ export const AnalysisBugs: React.FC<IAnalysisBugsProps> = ({
 
     const severityFilter = activeFilters['severity'];
     if (severityFilter && severityFilter.length > 0) {
-      result = result.filter((v) => severityFilter.includes(v.severity));
+      result = result.filter((violation) =>
+        severityFilter.includes(violation.severity),
+      );
     }
 
     const typeFilter = activeFilters['type'];
     if (typeFilter && typeFilter.length > 0) {
-      result = result.filter((v) => typeFilter.includes(v.type));
+      result = result.filter((violation) =>
+        typeFilter.includes(violation.type),
+      );
     }
 
     const battleFilter = activeFilters['battle'];
     if (battleFilter && battleFilter.length > 0) {
-      result = result.filter((v) => battleFilter.includes(v.battleId));
+      result = result.filter((violation) =>
+        battleFilter.includes(violation.battleId),
+      );
     }
 
     result.sort((a, b) => {
@@ -305,6 +103,7 @@ export const AnalysisBugs: React.FC<IAnalysisBugsProps> = ({
         const diff = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
         return violationSort.direction === 'asc' ? diff : -diff;
       }
+
       const diff =
         new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
       return violationSort.direction === 'asc' ? diff : -diff;
@@ -315,29 +114,18 @@ export const AnalysisBugs: React.FC<IAnalysisBugsProps> = ({
 
   const affectedAnomalyCounts = useMemo(() => {
     const counts: Record<string, number> = {};
-    const detectorMap: Record<string, keyof IThresholds> = {
-      'heat-suicide': 'heatSuicide',
-      'passive-unit': 'passiveUnit',
-      'no-progress': 'noProgress',
-      'long-game': 'longGame',
-      'state-cycle': 'stateCycle',
-    };
-
     for (const key of Object.keys(localThresholds)) {
       counts[key] = 0;
     }
 
     for (const anomaly of anomalies) {
-      const thresholdKey = detectorMap[anomaly.detector];
-      if (thresholdKey) {
-        counts[thresholdKey] = (counts[thresholdKey] || 0) + 1;
-      }
+      const thresholdKey = getThresholdKeyForDetector(anomaly.detector);
+      counts[thresholdKey] = (counts[thresholdKey] || 0) + 1;
     }
 
     return counts;
   }, [anomalies, localThresholds]);
 
-  /* ---- handlers ---- */
   const handleFilterChange = useCallback(
     (filters: Record<string, string[]>) => {
       setActiveFilters(filters);
@@ -346,7 +134,7 @@ export const AnalysisBugs: React.FC<IAnalysisBugsProps> = ({
   );
 
   const handleSliderChange = useCallback((detector: string, value: number) => {
-    setLocalThresholds((prev) => ({ ...prev, [detector]: value }));
+    setLocalThresholds((previous) => ({ ...previous, [detector]: value }));
   }, []);
 
   const handleResetThresholds = useCallback(() => {
@@ -355,45 +143,15 @@ export const AnalysisBugs: React.FC<IAnalysisBugsProps> = ({
   }, []);
 
   const handleSaveThresholds = useCallback(() => {
-    if (!onThresholdChange) return;
+    if (!onThresholdChange) {
+      return;
+    }
     for (const [key, value] of Object.entries(localThresholds)) {
       onThresholdChange(key, value);
     }
     announce('Thresholds saved');
   }, [localThresholds, onThresholdChange]);
 
-  const handleDismissAnomaly = useCallback(
-    (anomalyId: string) => {
-      onDismissAnomaly?.(anomalyId);
-    },
-    [onDismissAnomaly],
-  );
-
-  const handleViewSnapshot = useCallback(
-    (anomaly: IAnomaly) => {
-      const pageAnomaly = anomalies.find((a) => a.id === anomaly.id);
-      if (pageAnomaly) {
-        onViewSnapshot?.(pageAnomaly.snapshotId);
-      }
-    },
-    [anomalies, onViewSnapshot],
-  );
-
-  const handleViewBattle = useCallback(
-    (battleId: string) => {
-      onViewBattle?.(battleId);
-    },
-    [onViewBattle],
-  );
-
-  const handleConfigureThreshold = useCallback(
-    (configKey: string) => {
-      onConfigureThreshold?.(configKey);
-    },
-    [onConfigureThreshold],
-  );
-
-  /* ---- render ---- */
   return (
     <main
       className="min-h-screen bg-gray-50 p-4 md:p-6 lg:p-8 dark:bg-gray-900"
@@ -408,224 +166,42 @@ export const AnalysisBugs: React.FC<IAnalysisBugsProps> = ({
       </h1>
 
       <div className="space-y-6">
-        {/* ── 1. INVARIANT STATUS ──────────────────────────────────── */}
-        <section aria-label="Invariant status" data-testid="invariant-section">
-          <h2
-            className="mb-4 text-lg font-semibold text-gray-800 dark:text-gray-200"
-            data-testid="invariant-heading"
-          >
-            Invariant Status
-          </h2>
+        <InvariantStatusSection
+          invariants={invariants}
+          onViewInvariant={onViewInvariant}
+        />
+        <AnomalyAlertsSection
+          anomalies={anomalies}
+          visibleAnomalies={visibleAnomalies}
+          showDismissed={showDismissed}
+          onToggleDismissed={() => setShowDismissed((previous) => !previous)}
+          onDismissAnomaly={onDismissAnomaly}
+          onViewSnapshot={onViewSnapshot}
+          onViewBattle={onViewBattle}
+          onConfigureThreshold={onConfigureThreshold}
+        />
 
-          {invariants.length === 0 ? (
-            <p
-              className="text-sm text-gray-500 italic dark:text-gray-400"
-              data-testid="invariant-empty"
-            >
-              No invariants configured.
-            </p>
-          ) : (
-            <div
-              className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4"
-              data-testid="invariant-grid"
-            >
-              {invariants.map((inv) => (
-                <InvariantCard
-                  key={inv.id}
-                  invariant={inv}
-                  onClick={onViewInvariant}
-                />
-              ))}
-            </div>
-          )}
-        </section>
-
-        {/* ── 2. ANOMALY CARDS ─────────────────────────────────────── */}
-        <section aria-label="Anomaly alerts" data-testid="anomaly-section">
-          <div className="mb-4 flex items-center justify-between">
-            <h2
-              className="text-lg font-semibold text-gray-800 dark:text-gray-200"
-              data-testid="anomaly-heading"
-            >
-              Anomaly Alerts
-              {anomalies.length > 0 && (
-                <span className="ml-2 text-sm font-normal text-gray-500 dark:text-gray-400">
-                  ({visibleAnomalies.length})
-                </span>
-              )}
-            </h2>
-
-            {anomalies.some((a) => a.dismissed) && (
-              <button
-                type="button"
-                onClick={() => setShowDismissed((prev) => !prev)}
-                className={`min-h-[44px] rounded-md px-3 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 md:min-h-0 md:py-1 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200 ${FOCUS_RING_CLASSES}`}
-                data-testid="toggle-dismissed"
-                aria-pressed={showDismissed}
-              >
-                {showDismissed ? 'Hide Dismissed' : 'Show Dismissed'}
-              </button>
-            )}
-          </div>
-
-          {visibleAnomalies.length === 0 ? (
-            <p
-              className="text-sm text-gray-500 italic dark:text-gray-400"
-              data-testid="anomaly-empty"
-            >
-              No anomalies detected.
-            </p>
-          ) : (
-            <div
-              className="overflow-x-auto pb-2"
-              data-testid="anomaly-scroll-container"
-            >
-              <div className="flex min-w-max gap-4">
-                {visibleAnomalies.map((anomaly) => (
-                  <div
-                    key={anomaly.id}
-                    className="w-80 flex-shrink-0"
-                    data-testid={`anomaly-card-wrapper-${anomaly.id}`}
-                  >
-                    <AnomalyAlertCard
-                      anomaly={mapToCardAnomaly(anomaly)}
-                      onViewSnapshot={
-                        onViewSnapshot ? handleViewSnapshot : undefined
-                      }
-                      onViewBattle={onViewBattle ? handleViewBattle : undefined}
-                      onConfigureThreshold={
-                        onConfigureThreshold
-                          ? handleConfigureThreshold
-                          : undefined
-                      }
-                      onDismiss={
-                        onDismissAnomaly ? handleDismissAnomaly : undefined
-                      }
-                    />
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-        </section>
-
-        {/* ── 3 & 4. VIOLATION LOG + THRESHOLD CONFIG ─────────────── */}
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-5">
-          {/* Violation Log — 60% (3 cols) */}
-          <section
-            className="lg:col-span-3"
-            aria-label="Violation log"
-            data-testid="violation-section"
-          >
-            <h2
-              className="mb-4 text-lg font-semibold text-gray-800 dark:text-gray-200"
-              data-testid="violation-heading"
-            >
-              Violation Log
-              {filteredViolations.length > 0 && (
-                <span className="ml-2 text-sm font-normal text-gray-500 dark:text-gray-400">
-                  ({filteredViolations.length})
-                </span>
-              )}
-            </h2>
-
-            <FilterPanel
-              filters={violationFilters}
-              activeFilters={activeFilters}
-              onFilterChange={handleFilterChange}
-              className="mb-4"
-            />
-
-            <VirtualizedViolationLog
-              violations={filteredViolations}
-              height={480}
-              itemHeight={56}
-              onViewBattle={onViewBattle}
-            />
-          </section>
-
-          {/* Threshold Config — 40% (2 cols) */}
-          <section
-            className="lg:col-span-2"
-            aria-label="Threshold configuration"
-            data-testid="threshold-section"
-          >
-            <h2
-              className="mb-4 text-lg font-semibold text-gray-800 dark:text-gray-200"
-              data-testid="threshold-heading"
-            >
-              Threshold Configuration
-            </h2>
-
-            <div className="space-y-5 rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
-              {(Object.keys(DETECTOR_LABELS) as Array<keyof IThresholds>).map(
-                (detectorKey) => (
-                  <ThresholdSlider
-                    key={detectorKey}
-                    detectorKey={detectorKey}
-                    label={DETECTOR_LABELS[detectorKey]}
-                    description={DETECTOR_DESCRIPTIONS[detectorKey]}
-                    value={localThresholds[detectorKey]}
-                    affectedCount={affectedAnomalyCounts[detectorKey] ?? 0}
-                    onChange={handleSliderChange}
-                  />
-                ),
-              )}
-
-              {/* Action Buttons */}
-              <div
-                className="flex gap-3 border-t border-gray-200 pt-2 dark:border-gray-700"
-                data-testid="threshold-actions"
-              >
-                <button
-                  type="button"
-                  onClick={handleResetThresholds}
-                  className={`min-h-[44px] rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-100 md:min-h-0 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 ${FOCUS_RING_CLASSES}`}
-                  data-testid="threshold-reset"
-                >
-                  Reset to Defaults
-                </button>
-                <button
-                  type="button"
-                  onClick={handleSaveThresholds}
-                  className={`min-h-[44px] rounded-md bg-blue-600 px-4 py-2 text-sm text-white transition-colors hover:bg-blue-700 md:min-h-0 dark:bg-blue-500 dark:hover:bg-blue-600 ${FOCUS_RING_CLASSES}`}
-                  data-testid="threshold-save"
-                >
-                  Save Thresholds
-                </button>
-              </div>
-
-              {/* Auto-Snapshot Configuration */}
-              <div
-                className="border-t border-gray-200 pt-4 dark:border-gray-700"
-                data-testid="auto-snapshot-config"
-              >
-                <h3 className="mb-3 text-sm font-semibold tracking-wide text-gray-700 uppercase dark:text-gray-300">
-                  Auto-Snapshot
-                </h3>
-                <div className="space-y-2">
-                  <ToggleSwitch
-                    id="auto-snapshot-critical"
-                    label="Critical anomalies"
-                    checked={autoSnapshotCritical}
-                    onChange={setAutoSnapshotCritical}
-                  />
-                  <ToggleSwitch
-                    id="auto-snapshot-warning"
-                    label="Warning anomalies"
-                    checked={autoSnapshotWarning}
-                    onChange={setAutoSnapshotWarning}
-                  />
-                  <ToggleSwitch
-                    id="auto-snapshot-info"
-                    label="Info anomalies"
-                    checked={autoSnapshotInfo}
-                    onChange={setAutoSnapshotInfo}
-                  />
-                </div>
-              </div>
-            </div>
-          </section>
+          <ViolationLogSection
+            violationFilters={violationFilters}
+            activeFilters={activeFilters}
+            onFilterChange={handleFilterChange}
+            filteredViolations={filteredViolations}
+            onViewBattle={onViewBattle}
+          />
+          <ThresholdConfigurationSection
+            localThresholds={localThresholds}
+            affectedAnomalyCounts={affectedAnomalyCounts}
+            onSliderChange={handleSliderChange}
+            onResetThresholds={handleResetThresholds}
+            onSaveThresholds={handleSaveThresholds}
+            autoSnapshotCritical={autoSnapshotCritical}
+            autoSnapshotWarning={autoSnapshotWarning}
+            autoSnapshotInfo={autoSnapshotInfo}
+            setAutoSnapshotCritical={setAutoSnapshotCritical}
+            setAutoSnapshotWarning={setAutoSnapshotWarning}
+            setAutoSnapshotInfo={setAutoSnapshotInfo}
+          />
         </div>
       </div>
     </main>
@@ -633,163 +209,3 @@ export const AnalysisBugs: React.FC<IAnalysisBugsProps> = ({
 };
 
 export default AnalysisBugs;
-
-/* ========================================================================== */
-/*  Sub-components                                                             */
-/* ========================================================================== */
-
-/**
- * Card showing a single invariant check result.
- */
-const InvariantCard: React.FC<{
-  invariant: IInvariant;
-  onClick?: (invariantId: string) => void;
-}> = ({ invariant, onClick }) => {
-  const handleClick = () => onClick?.(invariant.id);
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      onClick?.(invariant.id);
-    }
-  };
-
-  return (
-    <div
-      className={`cursor-pointer rounded-lg border border-gray-200 bg-white p-4 transition-shadow hover:shadow-md dark:border-gray-700 dark:bg-gray-800 ${FOCUS_RING_CLASSES}`}
-      data-testid="invariant-card"
-      data-status={invariant.status}
-      role="button"
-      tabIndex={0}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      aria-label={`${invariant.name}: ${invariant.status}`}
-    >
-      <div className="mb-2 flex items-center justify-between">
-        <h3
-          className="mr-2 truncate text-sm font-semibold text-gray-900 dark:text-gray-100"
-          data-testid="invariant-name"
-          title={invariant.name}
-        >
-          {invariant.name}
-        </h3>
-        <span
-          className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-bold uppercase ${INVARIANT_STATUS_CLASSES[invariant.status]}`}
-          data-testid="invariant-status-badge"
-        >
-          {invariant.status}
-        </span>
-      </div>
-      <p
-        className="mb-2 line-clamp-2 text-xs text-gray-500 dark:text-gray-400"
-        data-testid="invariant-description"
-      >
-        {invariant.description}
-      </p>
-      <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
-        <span data-testid="invariant-last-checked">
-          {formatTimestamp(invariant.lastChecked)}
-        </span>
-        {invariant.failureCount > 0 && (
-          <span
-            className="font-medium text-red-600 dark:text-red-400"
-            data-testid="invariant-failure-count"
-          >
-            {invariant.failureCount} failure
-            {invariant.failureCount !== 1 ? 's' : ''}
-          </span>
-        )}
-      </div>
-    </div>
-  );
-};
-
-/**
- * Slider for configuring a single detector threshold.
- */
-const ThresholdSlider: React.FC<{
-  detectorKey: string;
-  label: string;
-  description: string;
-  value: number;
-  affectedCount: number;
-  onChange: (detector: string, value: number) => void;
-}> = ({ detectorKey, label, description, value, affectedCount, onChange }) => (
-  <div data-testid={`threshold-slider-${detectorKey}`}>
-    <div className="mb-1 flex items-center justify-between">
-      <label
-        htmlFor={`slider-${detectorKey}`}
-        className="text-sm font-medium text-gray-700 dark:text-gray-300"
-      >
-        {label}
-      </label>
-      <span
-        className="font-mono text-sm text-gray-900 dark:text-gray-100"
-        data-testid={`threshold-value-${detectorKey}`}
-      >
-        {value}
-      </span>
-    </div>
-    <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
-      {description}
-    </p>
-    <input
-      id={`slider-${detectorKey}`}
-      type="range"
-      min={0}
-      max={100}
-      value={value}
-      onChange={(e) => onChange(detectorKey, Number(e.target.value))}
-      className={`h-2 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-blue-600 dark:bg-gray-600 dark:accent-blue-400 ${FOCUS_RING_CLASSES}`}
-      data-testid={`threshold-input-${detectorKey}`}
-      aria-label={`${label} threshold`}
-      aria-valuemin={0}
-      aria-valuemax={100}
-      aria-valuenow={value}
-    />
-    {affectedCount > 0 && (
-      <p
-        className="mt-1 text-xs text-amber-600 dark:text-amber-400"
-        data-testid={`threshold-affected-${detectorKey}`}
-      >
-        {affectedCount} anomal{affectedCount === 1 ? 'y' : 'ies'} from this
-        detector
-      </p>
-    )}
-  </div>
-);
-
-/**
- * Toggle switch for auto-snapshot configuration.
- */
-const ToggleSwitch: React.FC<{
-  id: string;
-  label: string;
-  checked: boolean;
-  onChange: (checked: boolean) => void;
-}> = ({ id, label, checked, onChange }) => (
-  <label
-    htmlFor={id}
-    className="group flex cursor-pointer items-center justify-between"
-    data-testid={`toggle-${id}`}
-  >
-    <span className="text-sm text-gray-700 transition-colors group-hover:text-gray-900 dark:text-gray-300 dark:group-hover:text-gray-100">
-      {label}
-    </span>
-    <div className="relative">
-      <input
-        id={id}
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-        className="peer sr-only"
-        data-testid={`toggle-input-${id}`}
-        role="switch"
-        aria-checked={checked}
-        aria-label={label}
-      />
-      <div className="h-5 w-9 rounded-full bg-gray-300 transition-colors peer-checked:bg-blue-600 peer-focus:ring-2 peer-focus:ring-blue-500 dark:bg-gray-600 dark:peer-checked:bg-blue-500" />
-      <div className="absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform peer-checked:translate-x-4" />
-    </div>
-  </label>
-);

--- a/src/components/simulation-viewer/pages/AnalysisBugs.types.ts
+++ b/src/components/simulation-viewer/pages/AnalysisBugs.types.ts
@@ -1,0 +1,59 @@
+import type { IViolation } from '@/types/simulation-viewer/IViolation';
+
+export type InvariantStatus = 'pass' | 'fail';
+
+export type Severity = 'critical' | 'warning' | 'info';
+
+export type DetectorType =
+  | 'heat-suicide'
+  | 'passive-unit'
+  | 'no-progress'
+  | 'long-game'
+  | 'state-cycle';
+
+export type SortDirection = 'asc' | 'desc';
+
+export type ViolationSortKey = 'severity' | 'timestamp';
+
+export interface IInvariant {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly status: InvariantStatus;
+  readonly lastChecked: string;
+  readonly failureCount: number;
+}
+
+export interface IPageAnomaly {
+  readonly id: string;
+  readonly detector: DetectorType;
+  readonly severity: Severity;
+  readonly title: string;
+  readonly description: string;
+  readonly battleId: string;
+  readonly snapshotId: string;
+  readonly timestamp: string;
+  readonly dismissed: boolean;
+}
+
+export interface IThresholds {
+  readonly heatSuicide: number;
+  readonly passiveUnit: number;
+  readonly noProgress: number;
+  readonly longGame: number;
+  readonly stateCycle: number;
+}
+
+export interface IAnalysisBugsProps {
+  readonly campaignId: string;
+  readonly invariants: IInvariant[];
+  readonly anomalies: IPageAnomaly[];
+  readonly violations: IViolation[];
+  readonly thresholds: IThresholds;
+  readonly onThresholdChange?: (detector: string, value: number) => void;
+  readonly onDismissAnomaly?: (anomalyId: string) => void;
+  readonly onViewSnapshot?: (snapshotId: string) => void;
+  readonly onViewBattle?: (battleId: string) => void;
+  readonly onConfigureThreshold?: (detector: string) => void;
+  readonly onViewInvariant?: (invariantId: string) => void;
+}

--- a/src/components/simulation-viewer/pages/AnalysisBugs.utils.ts
+++ b/src/components/simulation-viewer/pages/AnalysisBugs.utils.ts
@@ -1,0 +1,101 @@
+import type { IFilterDefinition } from '@/components/simulation-viewer/types';
+import type { IAnomaly } from '@/types/simulation-viewer';
+import type { IViolation } from '@/types/simulation-viewer/IViolation';
+
+import type { IPageAnomaly, IThresholds } from './AnalysisBugs.types';
+
+export function formatTimestamp(iso: string): string {
+  try {
+    const date = new Date(iso);
+    if (isNaN(date.getTime())) {
+      return iso;
+    }
+    return date.toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function mapToCardAnomaly(anomaly: IPageAnomaly): IAnomaly {
+  return {
+    id: anomaly.id,
+    type: anomaly.detector,
+    severity: anomaly.severity,
+    battleId: anomaly.battleId,
+    turn: null,
+    unitId: null,
+    message: anomaly.description,
+    configKey: getAnomalyConfigKey(anomaly.detector),
+    timestamp: Date.parse(anomaly.timestamp) || Date.now(),
+  };
+}
+
+export function buildViolationFilters(
+  violations: IViolation[],
+): IFilterDefinition[] {
+  const types = Array.from(
+    new Set(violations.map((violation) => violation.type)),
+  ).sort();
+  const battles = Array.from(
+    new Set(violations.map((violation) => violation.battleId)),
+  ).sort();
+
+  return [
+    {
+      id: 'severity',
+      label: 'Severity',
+      options: ['critical', 'warning', 'info'],
+      optionLabels: { critical: 'Critical', warning: 'Warning', info: 'Info' },
+    },
+    {
+      id: 'type',
+      label: 'Type',
+      options: types,
+    },
+    {
+      id: 'battle',
+      label: 'Battle',
+      options: battles,
+    },
+  ];
+}
+
+export function getThresholdKeyForDetector(
+  detector: IPageAnomaly['detector'],
+): keyof IThresholds {
+  if (detector === 'heat-suicide') {
+    return 'heatSuicide';
+  }
+  if (detector === 'passive-unit') {
+    return 'passiveUnit';
+  }
+  if (detector === 'no-progress') {
+    return 'noProgress';
+  }
+  if (detector === 'long-game') {
+    return 'longGame';
+  }
+  return 'stateCycle';
+}
+
+function getAnomalyConfigKey(detector: IPageAnomaly['detector']): string {
+  if (detector === 'heat-suicide') {
+    return 'heatSuicideThreshold';
+  }
+  if (detector === 'passive-unit') {
+    return 'passiveUnitThreshold';
+  }
+  if (detector === 'no-progress') {
+    return 'noProgressThreshold';
+  }
+  if (detector === 'long-game') {
+    return 'longGameThreshold';
+  }
+  return 'stateCycleThreshold';
+}


### PR DESCRIPTION
## Summary
- Split `AnalysisBugs` into focused modules for types/constants/utilities, page sections, and shared cards/controls while keeping the main page as orchestration.
- Preserved existing API compatibility by re-exporting page-facing types and `formatTimestamp` from `AnalysisBugs.tsx` for current tests/callers.
- Reduced `max-lines` debt by removing the oversized `AnalysisBugs.tsx` hotspot and lowering lint warning baseline from 78 to 77.

## Validation
- `npm test -- --runTestsByPath src/__tests__/pages/simulation-viewer/AnalysisBugs.test.tsx`
- `npm run typecheck`
- `npm run lint` (warnings only, 77 total)
- `npm run build`
- `npm run analyze:dependencies`