### PR TITLE
feat(unit-card): wire duplication and deletion to the unit store

### DIFF
--- a/src/components/unit-card/__tests__/useUnitCardActions.test.ts
+++ b/src/components/unit-card/__tests__/useUnitCardActions.test.ts
@@ -1,0 +1,218 @@
+/**
+ * useUnitCardActions Hook Tests
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+import { useUnitCardActions } from '../useUnitCardActions';
+
+const pushMock = jest.fn();
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+const customService = {
+  getById: jest.fn(),
+  create: jest.fn(),
+  exists: jest.fn(),
+  delete: jest.fn(),
+};
+const canonicalService = {
+  getById: jest.fn(),
+};
+
+jest.mock('@/services/units', () => ({
+  getCustomUnitService: () => customService,
+  getCanonicalUnitService: () => canonicalService,
+}));
+
+describe('useUnitCardActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('handleEdit', () => {
+    it('navigates to /customizer/:id for mech type by default', () => {
+      const { result } = renderHook(() =>
+        useUnitCardActions({ unitId: 'unit-42' }),
+      );
+      act(() => result.current.handleEdit());
+      expect(pushMock).toHaveBeenCalledWith('/customizer/unit-42');
+    });
+
+    it('prefixes the route with the unit type for non-mech units', () => {
+      const { result } = renderHook(() =>
+        useUnitCardActions({ unitId: 'veh-1', unitType: 'vehicle' }),
+      );
+      act(() => result.current.handleEdit());
+      expect(pushMock).toHaveBeenCalledWith('/vehicle/customizer/veh-1');
+    });
+  });
+
+  describe('export and share dialogs', () => {
+    it('toggles export dialog open/closed', () => {
+      const { result } = renderHook(() => useUnitCardActions({ unitId: 'u1' }));
+      expect(result.current.isExportDialogOpen).toBe(false);
+      act(() => result.current.handleExport());
+      expect(result.current.isExportDialogOpen).toBe(true);
+      act(() => result.current.closeExportDialog());
+      expect(result.current.isExportDialogOpen).toBe(false);
+    });
+
+    it('toggles share dialog open/closed', () => {
+      const { result } = renderHook(() => useUnitCardActions({ unitId: 'u1' }));
+      act(() => result.current.handleShare());
+      expect(result.current.isShareDialogOpen).toBe(true);
+      act(() => result.current.closeShareDialog());
+      expect(result.current.isShareDialogOpen).toBe(false);
+    });
+  });
+
+  describe('handleDuplicate', () => {
+    it('duplicates a custom unit by cloning and persisting via CustomUnitService', async () => {
+      customService.getById.mockResolvedValue({
+        id: 'src-id',
+        chassis: 'Atlas',
+        variant: 'AS7-D',
+        tonnage: 100,
+        techBase: 'Inner Sphere',
+        era: 'Star League',
+        unitType: 'BattleMech',
+      });
+      customService.create.mockResolvedValue('new-id-1');
+      const onSuccess = jest.fn();
+
+      const { result } = renderHook(() =>
+        useUnitCardActions({
+          unitId: 'src-id',
+          onDuplicateSuccess: onSuccess,
+        }),
+      );
+      act(() => result.current.handleDuplicate());
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith('new-id-1');
+      });
+      expect(customService.create).toHaveBeenCalledTimes(1);
+      const clonePayload = customService.create.mock.calls[0][0];
+      expect(clonePayload.variant).toBe('AS7-D (Copy)');
+      expect(clonePayload.chassis).toBe('Atlas');
+    });
+
+    it('falls back to CanonicalUnitService when the unit is not a custom unit', async () => {
+      customService.getById.mockResolvedValue(null);
+      canonicalService.getById.mockResolvedValue({
+        id: 'canon-id',
+        chassis: 'Hunchback',
+        variant: 'HBK-4G',
+        tonnage: 50,
+        techBase: 'Inner Sphere',
+        era: 'Star League',
+        unitType: 'BattleMech',
+      });
+      customService.create.mockResolvedValue('new-id-2');
+      const onSuccess = jest.fn();
+
+      const { result } = renderHook(() =>
+        useUnitCardActions({
+          unitId: 'canon-id',
+          onDuplicateSuccess: onSuccess,
+        }),
+      );
+      act(() => result.current.handleDuplicate());
+
+      await waitFor(() => expect(onSuccess).toHaveBeenCalledWith('new-id-2'));
+      expect(canonicalService.getById).toHaveBeenCalledWith('canon-id');
+    });
+
+    it('reports an error when the source unit cannot be found', async () => {
+      customService.getById.mockResolvedValue(null);
+      canonicalService.getById.mockResolvedValue(null);
+      const onError = jest.fn();
+
+      const { result } = renderHook(() =>
+        useUnitCardActions({
+          unitId: 'missing',
+          onDuplicateError: onError,
+        }),
+      );
+      act(() => result.current.handleDuplicate());
+
+      await waitFor(() => expect(onError).toHaveBeenCalled());
+      expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+      expect(customService.create).not.toHaveBeenCalled();
+    });
+
+    it('ignores rapid double-clicks while a duplicate is in-flight', async () => {
+      customService.getById.mockResolvedValue({
+        id: 'src',
+        chassis: 'A',
+        variant: 'B',
+        tonnage: 50,
+        techBase: 'Inner Sphere',
+        era: 'Star League',
+        unitType: 'BattleMech',
+      });
+      customService.create.mockResolvedValue('new');
+
+      const { result } = renderHook(() =>
+        useUnitCardActions({ unitId: 'src' }),
+      );
+      act(() => {
+        result.current.handleDuplicate();
+        result.current.handleDuplicate();
+      });
+      await waitFor(() =>
+        expect(customService.create).toHaveBeenCalledTimes(1),
+      );
+    });
+  });
+
+  describe('delete flow', () => {
+    it('handleDelete opens the confirmation, cancelDelete closes it', () => {
+      const { result } = renderHook(() => useUnitCardActions({ unitId: 'u1' }));
+      act(() => result.current.handleDelete());
+      expect(result.current.isDeletePending).toBe(true);
+      act(() => result.current.cancelDelete());
+      expect(result.current.isDeletePending).toBe(false);
+    });
+
+    it('confirmDelete removes the custom unit and fires onDeleteSuccess', async () => {
+      customService.exists.mockResolvedValue(true);
+      customService.delete.mockResolvedValue(undefined);
+      const onSuccess = jest.fn();
+
+      const { result } = renderHook(() =>
+        useUnitCardActions({ unitId: 'u1', onDeleteSuccess: onSuccess }),
+      );
+      act(() => result.current.confirmDelete());
+      await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+      expect(customService.delete).toHaveBeenCalledWith('u1');
+    });
+
+    it('refuses to delete a canonical unit and reports the error', async () => {
+      customService.exists.mockResolvedValue(false);
+      const onError = jest.fn();
+
+      const { result } = renderHook(() =>
+        useUnitCardActions({ unitId: 'canon', onDeleteError: onError }),
+      );
+      act(() => result.current.confirmDelete());
+
+      await waitFor(() => expect(onError).toHaveBeenCalled());
+      expect(onError.mock.calls[0][0].message).toMatch(/canonical/i);
+      expect(customService.delete).not.toHaveBeenCalled();
+    });
+
+    it('clears isDeletePending after the operation completes', async () => {
+      customService.exists.mockResolvedValue(true);
+      customService.delete.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useUnitCardActions({ unitId: 'u1' }));
+      act(() => result.current.handleDelete());
+      expect(result.current.isDeletePending).toBe(true);
+      act(() => result.current.confirmDelete());
+      await waitFor(() => expect(result.current.isDeletePending).toBe(false));
+    });
+  });
+});

--- a/src/components/unit-card/useUnitCardActions.ts
+++ b/src/components/unit-card/useUnitCardActions.ts
@@ -2,11 +2,17 @@
  * Unit Card Actions Hook
  *
  * Provides action handlers for unit cards (export, share, edit, duplicate, delete).
- * Integrates with existing vault services and navigation.
+ * Integrates with unit services for persistence.
  */
 
 import { useRouter } from 'next/router';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+
+import {
+  getCanonicalUnitService,
+  getCustomUnitService,
+  type IFullUnit,
+} from '@/services/units';
 
 export interface UseUnitCardActionsOptions {
   /** Unit ID */
@@ -21,8 +27,12 @@ export interface UseUnitCardActionsOptions {
     | 'protomech';
   /** Callback after successful duplication */
   onDuplicateSuccess?: (newUnitId: string) => void;
+  /** Callback when duplication fails */
+  onDuplicateError?: (error: Error) => void;
   /** Callback after successful deletion */
   onDeleteSuccess?: () => void;
+  /** Callback when deletion fails */
+  onDeleteError?: (error: Error) => void;
 }
 
 export interface UnitCardActions {
@@ -42,6 +52,10 @@ export interface UnitCardActions {
   isShareDialogOpen: boolean;
   /** Whether delete confirmation is pending */
   isDeletePending: boolean;
+  /** Whether a duplicate operation is in-flight */
+  isDuplicating: boolean;
+  /** Whether a delete operation is in-flight */
+  isDeleting: boolean;
   /** Close export dialog */
   closeExportDialog: () => void;
   /** Close share dialog */
@@ -52,6 +66,17 @@ export interface UnitCardActions {
   cancelDelete: () => void;
 }
 
+function stripIdentity(unit: IFullUnit): Omit<IFullUnit, 'id'> {
+  const { id: _id, ...rest } = unit;
+  return rest;
+}
+
+async function loadFullUnit(unitId: string): Promise<IFullUnit | null> {
+  const custom = await getCustomUnitService().getById(unitId);
+  if (custom) return custom;
+  return getCanonicalUnitService().getById(unitId);
+}
+
 /**
  * Hook for unit card action handlers
  */
@@ -59,13 +84,21 @@ export function useUnitCardActions({
   unitId,
   unitType = 'mech',
   onDuplicateSuccess,
+  onDuplicateError,
   onDeleteSuccess,
+  onDeleteError,
 }: UseUnitCardActionsOptions): UnitCardActions {
   const router = useRouter();
 
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
   const [isDeletePending, setIsDeletePending] = useState(false);
+  const [isDuplicating, setIsDuplicating] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  // Synchronous guards against rapid double-invocations — state won't update
+  // fast enough when two clicks fire in the same tick.
+  const duplicatingRef = useRef(false);
+  const deletingRef = useRef(false);
 
   // Navigate to unit editor
   const handleEdit = useCallback(() => {
@@ -96,26 +129,71 @@ export function useUnitCardActions({
     setIsShareDialogOpen(false);
   }, []);
 
-  // Duplicate unit
+  // Duplicate unit: load full data (custom first, canonical fallback), save as new custom unit
   const handleDuplicate = useCallback(() => {
-    // For now, just navigate to a new unit with cloned data
-    // This would need integration with the unit store to actually clone
-    // TODO: Implement actual duplication via unit store
-    const newId = `${unitId}-copy-${Date.now()}`;
-    onDuplicateSuccess?.(newId);
-  }, [unitId, onDuplicateSuccess]);
+    if (duplicatingRef.current) return;
+    duplicatingRef.current = true;
+    setIsDuplicating(true);
+
+    (async () => {
+      try {
+        const source = await loadFullUnit(unitId);
+        if (!source) {
+          throw new Error(`Unit not found: ${unitId}`);
+        }
+        // New custom unit: strip id so CustomUnitService.create assigns a fresh one.
+        // Mark variant as a copy so the user sees it's a duplicate.
+        const suffix = source.variant ? `${source.variant} (Copy)` : '(Copy)';
+        const clone: IFullUnit = {
+          ...stripIdentity(source),
+          id: '',
+          variant: suffix,
+        } as IFullUnit;
+        const newId = await getCustomUnitService().create(clone);
+        onDuplicateSuccess?.(newId);
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        onDuplicateError?.(error);
+      } finally {
+        duplicatingRef.current = false;
+        setIsDuplicating(false);
+      }
+    })();
+  }, [unitId, onDuplicateSuccess, onDuplicateError]);
 
   // Request delete confirmation
   const handleDelete = useCallback(() => {
     setIsDeletePending(true);
   }, []);
 
-  // Confirm deletion
+  // Confirm deletion: delete the custom unit via CustomUnitService.
+  // Canonical units cannot be deleted — surface an error in that case.
   const confirmDelete = useCallback(() => {
-    // TODO: Implement actual deletion via unit store
-    setIsDeletePending(false);
-    onDeleteSuccess?.();
-  }, [onDeleteSuccess]);
+    if (deletingRef.current) return;
+    deletingRef.current = true;
+    setIsDeleting(true);
+
+    (async () => {
+      try {
+        const service = getCustomUnitService();
+        const existsAsCustom = await service.exists(unitId);
+        if (!existsAsCustom) {
+          throw new Error(
+            'Cannot delete a canonical unit — only custom units can be removed.',
+          );
+        }
+        await service.delete(unitId);
+        onDeleteSuccess?.();
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        onDeleteError?.(error);
+      } finally {
+        deletingRef.current = false;
+        setIsDeleting(false);
+        setIsDeletePending(false);
+      }
+    })();
+  }, [unitId, onDeleteSuccess, onDeleteError]);
 
   // Cancel deletion
   const cancelDelete = useCallback(() => {
@@ -131,6 +209,8 @@ export function useUnitCardActions({
     isExportDialogOpen,
     isShareDialogOpen,
     isDeletePending,
+    isDuplicating,
+    isDeleting,
     closeExportDialog,
     closeShareDialog,
     confirmDelete,


### PR DESCRIPTION
## Summary
- Replace stubbed `handleDuplicate` / `confirmDelete` in `useUnitCardActions` with real implementations backed by `CustomUnitService` + `CanonicalUnitService`
- Duplicate loads the source unit (custom first, canonical fallback), clones it with a fresh id, and persists the new variant as `"<variant> (Copy)"`
- Delete refuses canonical units and removes custom units from IndexedDB
- Adds `isDuplicating` / `isDeleting` flags plus `onDuplicateError` / `onDeleteError` callbacks; rapid double-invocations are guarded with refs

## Test plan
- [x] `npx jest src/components/unit-card/__tests__/useUnitCardActions.test.ts` — 12/12 passing
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeded (husky pre-push)
- [ ] Manual smoke: right-click unit card → Duplicate creates a copy; Delete on a custom unit removes it; Delete on a canonical unit surfaces an error