### PR TITLE
feat(encounter): create game session from encounter definition

### DIFF
--- a/src/services/encounter/EncounterService.ts
+++ b/src/services/encounter/EncounterService.ts
@@ -17,17 +17,23 @@ import {
   SCENARIO_TEMPLATES,
   ScenarioTemplateType,
 } from '@/types/encounter';
+import { createGameSession } from '@/utils/gameplay/gameSessionCore';
 
 import {
   createSingleton,
   type SingletonFactory,
 } from '../core/createSingleton';
 import { getForceRepository } from '../forces/ForceRepository';
+import { getPilotService } from '../pilots/PilotService';
 import {
   getEncounterRepository,
   EncounterRepository,
   IEncounterOperationResult,
 } from './EncounterRepository';
+import {
+  buildGameConfigFromEncounter,
+  buildGameUnitsFromEncounter,
+} from './encounterToGameSession';
 
 // =============================================================================
 // Service Interface
@@ -262,18 +268,29 @@ export class EncounterService implements IEncounterService {
       };
     }
 
-    // TODO: Create game session from encounter
-    // For now, just update status to launched
-    // In full implementation:
-    // 1. Create game session
-    // 2. Initialize hex grid from map config
-    // 3. Place units from forces
-    // 4. Generate OpFor if using opForConfig
-    // 5. Link game session to encounter
+    // Build the game config and units from the encounter. Force/pilot
+    // resolvers are injected so this helper stays trivially testable.
+    const forceRepo = getForceRepository();
+    const pilotService = getPilotService();
+    const { units, errors } = buildGameUnitsFromEncounter(encounter, {
+      getForceById: (forceId) => forceRepo.getForceById(forceId),
+      getPilotById: (pilotId) => pilotService.getPilot(pilotId),
+    });
 
-    // For MVP, just create a placeholder game session ID
-    const gameSessionId = `session-${Date.now()}`;
-    return this.repository.linkGameSession(id, gameSessionId);
+    if (errors.length > 0) {
+      return {
+        success: false,
+        error: `Cannot launch: ${errors.join(', ')}`,
+      };
+    }
+
+    // createGameSession returns a fully-formed IGameSession with a fresh
+    // uuid. The session object itself is ephemeral (no server-side store),
+    // but its id is what we persist on the encounter — the UI rehydrates
+    // play state from the encounter + forces, using this id as the handle.
+    const config = buildGameConfigFromEncounter(encounter);
+    const session = createGameSession(config, units);
+    return this.repository.linkGameSession(id, session.id);
   }
 
   // ===========================================================================

--- a/src/services/encounter/__tests__/EncounterService.test.ts
+++ b/src/services/encounter/__tests__/EncounterService.test.ts
@@ -19,7 +19,7 @@ import {
   PilotSkillTemplate,
   SCENARIO_TEMPLATES,
 } from '@/types/encounter';
-import { IForce, ForceType, ForceStatus } from '@/types/force';
+import { IForce, ForceType, ForcePosition, ForceStatus } from '@/types/force';
 
 import { IEncounterOperationResult } from '../EncounterRepository';
 
@@ -47,6 +47,16 @@ jest.mock('../../forces/ForceRepository', () => ({
   getForceRepository: () => ({
     getForceById: (id: string) => mockForces.get(id) ?? null,
     getAllForces: () => Array.from(mockForces.values()),
+  }),
+}));
+
+// =============================================================================
+// Mock Pilot Service — launchEncounter resolves pilots through PilotService
+// =============================================================================
+
+jest.mock('../../pilots/PilotService', () => ({
+  getPilotService: () => ({
+    getPilot: () => null,
   }),
 }));
 
@@ -221,13 +231,20 @@ function createMockForce(
   totalBV: number = 5000,
   assignedUnits: number = 4,
 ): IForce {
+  const assignments = Array.from({ length: assignedUnits }, (_, i) => ({
+    id: `${id}-assign-${i + 1}`,
+    pilotId: `${id}-pilot-${i + 1}`,
+    unitId: `${id}-unit-${i + 1}`,
+    position: ForcePosition.Member,
+    slot: i + 1,
+  }));
   const force: IForce = {
     id,
     name,
     forceType: ForceType.Lance,
     status: ForceStatus.Active,
     childIds: [],
-    assignments: [],
+    assignments,
     stats: {
       totalBV,
       totalTonnage: 200,

--- a/src/services/encounter/__tests__/encounterToGameSession.test.ts
+++ b/src/services/encounter/__tests__/encounterToGameSession.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for the encounter → game session bridge.
+ */
+
+import type { IEncounter } from '@/types/encounter';
+import type { IForce } from '@/types/force';
+import type { IPilot } from '@/types/pilot';
+
+import {
+  EncounterStatus,
+  PilotSkillTemplate,
+  ScenarioTemplateType,
+  TerrainPreset,
+  VictoryConditionType,
+} from '@/types/encounter';
+import { ForcePosition, ForceStatus, ForceType } from '@/types/force';
+import { GameSide } from '@/types/gameplay';
+import { PilotStatus, PilotType } from '@/types/pilot';
+
+import {
+  buildGameConfigFromEncounter,
+  buildGameUnitsFromEncounter,
+  type IEncounterResolvers,
+} from '../encounterToGameSession';
+
+function makeEncounter(overrides: Partial<IEncounter> = {}): IEncounter {
+  const now = new Date('2026-04-17').toISOString();
+  return {
+    id: 'enc-1',
+    name: 'Test Encounter',
+    status: EncounterStatus.Ready,
+    template: ScenarioTemplateType.Skirmish,
+    mapConfig: {
+      radius: 7,
+      terrain: TerrainPreset.Clear,
+      playerDeploymentZone: 'south',
+      opponentDeploymentZone: 'north',
+    },
+    victoryConditions: [{ type: VictoryConditionType.DestroyAll }],
+    optionalRules: [],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function makeForce(id: string, assignmentCount: number): IForce {
+  const now = new Date('2026-04-17').toISOString();
+  return {
+    id,
+    name: `Force ${id}`,
+    forceType: ForceType.Lance,
+    status: ForceStatus.Active,
+    childIds: [],
+    assignments: Array.from({ length: assignmentCount }, (_, i) => ({
+      id: `${id}-assign-${i + 1}`,
+      pilotId: `pilot-${id}-${i + 1}`,
+      unitId: `unit-${id}-${i + 1}`,
+      position: ForcePosition.Member,
+      slot: i + 1,
+    })),
+    stats: {
+      totalBV: 4000,
+      totalTonnage: 200,
+      assignedPilots: assignmentCount,
+      assignedUnits: assignmentCount,
+      emptySlots: 0,
+      averageSkill: { gunnery: 4, piloting: 5 },
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function makePilot(id: string, gunnery = 3, piloting = 4): IPilot {
+  const now = new Date('2026-04-17').toISOString();
+  return {
+    id,
+    name: `Pilot ${id}`,
+    callsign: `CS-${id}`,
+    type: PilotType.Persistent,
+    status: PilotStatus.Active,
+    skills: { gunnery, piloting },
+    wounds: 0,
+    abilities: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe('buildGameConfigFromEncounter', () => {
+  it('maps mapConfig.radius into mapRadius', () => {
+    const encounter = makeEncounter({
+      mapConfig: {
+        radius: 12,
+        terrain: TerrainPreset.Urban,
+        playerDeploymentZone: 'west',
+        opponentDeploymentZone: 'east',
+      },
+    });
+    const config = buildGameConfigFromEncounter(encounter);
+    expect(config.mapRadius).toBe(12);
+  });
+
+  it('extracts turnLimit from a VictoryConditionType.TurnLimit entry', () => {
+    const encounter = makeEncounter({
+      victoryConditions: [
+        { type: VictoryConditionType.DestroyAll },
+        { type: VictoryConditionType.TurnLimit, turnLimit: 20 },
+      ],
+    });
+    const config = buildGameConfigFromEncounter(encounter);
+    expect(config.turnLimit).toBe(20);
+  });
+
+  it('defaults turnLimit to 0 when no TurnLimit condition is present', () => {
+    const encounter = makeEncounter({
+      victoryConditions: [{ type: VictoryConditionType.DestroyAll }],
+    });
+    expect(buildGameConfigFromEncounter(encounter).turnLimit).toBe(0);
+  });
+
+  it('encodes every victory condition as a string', () => {
+    const encounter = makeEncounter({
+      victoryConditions: [
+        { type: VictoryConditionType.DestroyAll },
+        { type: VictoryConditionType.TurnLimit, turnLimit: 15 },
+        { type: VictoryConditionType.Cripple, threshold: 75 },
+        { type: VictoryConditionType.Custom, description: 'escape zone' },
+      ],
+    });
+    const config = buildGameConfigFromEncounter(encounter);
+    expect(config.victoryConditions).toEqual([
+      'destroy_all',
+      'turn_limit:15',
+      'cripple:75',
+      'custom:escape zone',
+    ]);
+  });
+
+  it('copies optionalRules', () => {
+    const encounter = makeEncounter({
+      optionalRules: ['forest_fire', 'double_blind'],
+    });
+    expect(buildGameConfigFromEncounter(encounter).optionalRules).toEqual([
+      'forest_fire',
+      'double_blind',
+    ]);
+  });
+});
+
+describe('buildGameUnitsFromEncounter', () => {
+  const pilotMap = new Map<string, IPilot>([
+    ['pilot-p-1', makePilot('p-1', 3, 4)],
+    ['pilot-p-2', makePilot('p-2', 2, 3)],
+    ['pilot-o-1', makePilot('o-1', 5, 6)],
+  ]);
+  const playerForce = makeForce('p', 2);
+  const opponentForce = makeForce('o', 1);
+
+  const resolvers: IEncounterResolvers = {
+    getForceById: (id) => {
+      if (id === 'p') return playerForce;
+      if (id === 'o') return opponentForce;
+      return null;
+    },
+    getPilotById: (id) => pilotMap.get(id) ?? null,
+  };
+
+  it('errors when no player force is attached', () => {
+    const encounter = makeEncounter({ playerForce: undefined });
+    const result = buildGameUnitsFromEncounter(encounter, resolvers);
+    expect(result.units).toEqual([]);
+    expect(result.errors).toContain('Encounter has no player force assigned');
+  });
+
+  it('errors when the player force id does not resolve', () => {
+    const encounter = makeEncounter({
+      playerForce: {
+        forceId: 'nope',
+        forceName: 'N',
+        totalBV: 0,
+        unitCount: 0,
+      },
+    });
+    const result = buildGameUnitsFromEncounter(encounter, resolvers);
+    expect(result.errors.some((e) => e.includes('nope'))).toBe(true);
+  });
+
+  it('errors when neither opponent force nor opForConfig is set', () => {
+    const encounter = makeEncounter({
+      playerForce: {
+        forceId: 'p',
+        forceName: 'P',
+        totalBV: 4000,
+        unitCount: 2,
+      },
+    });
+    const result = buildGameUnitsFromEncounter(encounter, resolvers);
+    expect(result.errors).toContain(
+      'Encounter has neither an opponent force nor an OpFor config',
+    );
+  });
+
+  it('accepts opForConfig in lieu of an explicit opponent force', () => {
+    const encounter = makeEncounter({
+      playerForce: {
+        forceId: 'p',
+        forceName: 'P',
+        totalBV: 4000,
+        unitCount: 2,
+      },
+      opForConfig: {
+        targetBVPercent: 100,
+        pilotSkillTemplate: PilotSkillTemplate.Regular,
+      },
+    });
+    const result = buildGameUnitsFromEncounter(encounter, resolvers);
+    expect(result.errors).toEqual([]);
+    expect(result.units).toHaveLength(2);
+    expect(result.units.every((u) => u.side === GameSide.Player)).toBe(true);
+  });
+
+  it('builds IGameUnit entries for both sides with pilot skills filled in', () => {
+    const encounter = makeEncounter({
+      playerForce: {
+        forceId: 'p',
+        forceName: 'P',
+        totalBV: 4000,
+        unitCount: 2,
+      },
+      opponentForce: {
+        forceId: 'o',
+        forceName: 'O',
+        totalBV: 2000,
+        unitCount: 1,
+      },
+    });
+    const result = buildGameUnitsFromEncounter(encounter, resolvers);
+
+    expect(result.errors).toEqual([]);
+    expect(result.units).toHaveLength(3);
+
+    const player1 = result.units[0];
+    expect(player1.side).toBe(GameSide.Player);
+    expect(player1.unitRef).toBe('unit-p-1');
+    expect(player1.pilotRef).toBe('pilot-p-1');
+    expect(player1.gunnery).toBe(3);
+    expect(player1.piloting).toBe(4);
+
+    const opp = result.units[2];
+    expect(opp.side).toBe(GameSide.Opponent);
+    expect(opp.gunnery).toBe(5);
+    expect(opp.piloting).toBe(6);
+  });
+
+  it('uses default skills when a pilot id is unresolved', () => {
+    const encounter = makeEncounter({
+      playerForce: {
+        forceId: 'p',
+        forceName: 'P',
+        totalBV: 4000,
+        unitCount: 2,
+      },
+      opponentForce: {
+        forceId: 'o',
+        forceName: 'O',
+        totalBV: 2000,
+        unitCount: 1,
+      },
+    });
+    // Resolver that never finds pilots
+    const noPilots: IEncounterResolvers = {
+      getForceById: resolvers.getForceById,
+      getPilotById: () => null,
+    };
+    const result = buildGameUnitsFromEncounter(encounter, noPilots);
+    expect(result.units[0].gunnery).toBe(4);
+    expect(result.units[0].piloting).toBe(5);
+  });
+});

--- a/src/services/encounter/encounterToGameSession.ts
+++ b/src/services/encounter/encounterToGameSession.ts
@@ -1,0 +1,178 @@
+/**
+ * Encounter → GameSession bridge
+ *
+ * Pure helpers that translate an IEncounter (with resolved forces + pilots)
+ * into the shapes expected by the gameplay layer (IGameConfig, IGameUnit[]).
+ *
+ * Kept sync and side-effect-free so EncounterService.launchEncounter can
+ * compose it without adopting async. Force and pilot lookups are threaded in
+ * as dependencies rather than imported, which keeps the helper trivially
+ * testable without mocking service singletons.
+ */
+
+import type { IEncounter, IVictoryCondition } from '@/types/encounter';
+import type { IForce } from '@/types/force';
+import type { IPilot } from '@/types/pilot';
+
+import { VictoryConditionType } from '@/types/encounter';
+import { GameSide, type IGameConfig, type IGameUnit } from '@/types/gameplay';
+
+/** Default pilot skills when no pilot is assigned (standard regular pilot). */
+const DEFAULT_GUNNERY = 4;
+const DEFAULT_PILOTING = 5;
+
+/**
+ * Convert a single IVictoryCondition into the plain-string form that
+ * IGameConfig.victoryConditions carries. The game engine later parses these
+ * strings back into behaviour, so we encode enough context (turn count,
+ * threshold) for downstream consumers.
+ */
+function victoryConditionToString(condition: IVictoryCondition): string {
+  switch (condition.type) {
+    case VictoryConditionType.DestroyAll:
+      return 'destroy_all';
+    case VictoryConditionType.Retreat:
+      return 'retreat';
+    case VictoryConditionType.TurnLimit:
+      return `turn_limit:${condition.turnLimit ?? 0}`;
+    case VictoryConditionType.Cripple:
+      return `cripple:${condition.threshold ?? 50}`;
+    case VictoryConditionType.Custom:
+      return condition.description
+        ? `custom:${condition.description}`
+        : 'custom';
+    default:
+      return 'custom';
+  }
+}
+
+/**
+ * Derive turn limit from victory conditions. If no TurnLimit condition is
+ * present, the engine's 0 means "no limit".
+ */
+function deriveTurnLimit(conditions: readonly IVictoryCondition[]): number {
+  const turnCondition = conditions.find(
+    (c) => c.type === VictoryConditionType.TurnLimit,
+  );
+  return turnCondition?.turnLimit ?? 0;
+}
+
+/**
+ * Build an IGameConfig from an encounter's map/victory/optional-rules fields.
+ * Pure and sync — no force lookups required.
+ */
+export function buildGameConfigFromEncounter(
+  encounter: IEncounter,
+): IGameConfig {
+  return {
+    mapRadius: encounter.mapConfig.radius,
+    turnLimit: deriveTurnLimit(encounter.victoryConditions),
+    victoryConditions: encounter.victoryConditions.map(
+      victoryConditionToString,
+    ),
+    optionalRules: [...encounter.optionalRules],
+  };
+}
+
+/** Resolvers injected by the service layer for force/pilot lookup. */
+export interface IEncounterResolvers {
+  readonly getForceById: (id: string) => IForce | null;
+  readonly getPilotById: (id: string) => IPilot | null;
+}
+
+interface IBuildGameUnitsResult {
+  readonly units: readonly IGameUnit[];
+  readonly errors: readonly string[];
+}
+
+/**
+ * Build IGameUnit[] from an encounter's resolved forces + pilot assignments.
+ * Returns both the built units and any structural errors (missing force,
+ * force with no assignments, etc.) so the caller can report them cleanly.
+ *
+ * If an opForConfig is present instead of an explicit opponent force, the
+ * opponent side is returned empty and the caller is expected to generate
+ * the OpFor separately — this stays compatible with the existing
+ * generate-OpFor-later flow in the UI.
+ */
+export function buildGameUnitsFromEncounter(
+  encounter: IEncounter,
+  resolvers: IEncounterResolvers,
+): IBuildGameUnitsResult {
+  const errors: string[] = [];
+
+  if (!encounter.playerForce) {
+    errors.push('Encounter has no player force assigned');
+    return { units: [], errors };
+  }
+
+  const playerForce = resolvers.getForceById(encounter.playerForce.forceId);
+  if (!playerForce) {
+    errors.push(
+      `Player force ${encounter.playerForce.forceId} could not be resolved`,
+    );
+    return { units: [], errors };
+  }
+
+  const playerUnits = assignmentsToGameUnits(
+    playerForce,
+    GameSide.Player,
+    resolvers.getPilotById,
+  );
+  if (playerUnits.length === 0) {
+    errors.push('Player force has no assigned units');
+  }
+
+  let opponentUnits: readonly IGameUnit[] = [];
+  if (encounter.opponentForce) {
+    const opponentForce = resolvers.getForceById(
+      encounter.opponentForce.forceId,
+    );
+    if (!opponentForce) {
+      errors.push(
+        `Opponent force ${encounter.opponentForce.forceId} could not be resolved`,
+      );
+    } else {
+      opponentUnits = assignmentsToGameUnits(
+        opponentForce,
+        GameSide.Opponent,
+        resolvers.getPilotById,
+      );
+      if (opponentUnits.length === 0) {
+        errors.push('Opponent force has no assigned units');
+      }
+    }
+  } else if (!encounter.opForConfig) {
+    errors.push('Encounter has neither an opponent force nor an OpFor config');
+  }
+
+  return {
+    units: [...playerUnits, ...opponentUnits],
+    errors,
+  };
+}
+
+function assignmentsToGameUnits(
+  force: IForce,
+  side: GameSide,
+  getPilotById: (id: string) => IPilot | null,
+): readonly IGameUnit[] {
+  const units: IGameUnit[] = [];
+
+  for (const assignment of force.assignments) {
+    if (!assignment.unitId) continue;
+
+    const pilot = assignment.pilotId ? getPilotById(assignment.pilotId) : null;
+    units.push({
+      id: `${force.id}:${assignment.id}`,
+      name: pilot?.callsign ?? pilot?.name ?? assignment.id,
+      side,
+      unitRef: assignment.unitId,
+      pilotRef: assignment.pilotId ?? '',
+      gunnery: pilot?.skills.gunnery ?? DEFAULT_GUNNERY,
+      piloting: pilot?.skills.piloting ?? DEFAULT_PILOTING,
+    });
+  }
+
+  return units;
+}


### PR DESCRIPTION
## Summary
- `EncounterService.launchEncounter` used to stub a `session-<timestamp>` id and mark the encounter launched
- It now builds a real `IGameConfig` from the encounter's `mapConfig` + victory conditions + optional rules
- Resolves player and opponent forces into `IGameUnit[]` with pilot skills threaded in
- Calls `createGameSession(config, units)` so the session id persisted on the encounter is a uuid tied to a well-formed session
- New sync helper `encounterToGameSession.ts` keeps the conversion pure and testable — force/pilot resolvers are injected
- Existing launch tests updated: previously used forces with zero assignments, which the new path correctly rejects

## Test plan
- [x] `npx jest src/services/encounter` — 114/114 passing (including 13 new tests for the helper)
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeded (husky pre-push)