### PR TITLE
feat(vault): complete sync and rollback implementation

### DIFF
--- a/src/services/vault/SyncEngine.conflictResolution.ts
+++ b/src/services/vault/SyncEngine.conflictResolution.ts
@@ -1,0 +1,138 @@
+/**
+ * SyncEngine — conflict resolution helpers
+ *
+ * Pure functions that implement the acceptRemote / fork resolution paths
+ * plus conflict lookup. Extracted so the main SyncEngine class stays under
+ * the per-file line limit without losing functionality.
+ */
+
+import type { IChangeLogEntry, ISyncConflict } from '@/types/vault';
+
+import type { ChangeLogRepository } from './ChangeLogRepository';
+import type { ContentApplyFn } from './SyncEngine';
+
+/**
+ * Shape returned by the pending-conflict lookup on ChangeLogRepository.
+ * Matches what {@link mapPendingConflicts} emits and what the conflict
+ * helpers consume.
+ */
+export interface IPendingConflictRow {
+  readonly id: string;
+  readonly contentType: ISyncConflict['contentType'];
+  readonly itemId: string;
+  readonly itemName: string;
+  readonly localVersion: number;
+  readonly localHash: string;
+  readonly remoteVersion: number;
+  readonly remoteHash: string;
+  readonly remotePeerId: string;
+  readonly detectedAt: string;
+}
+
+/**
+ * Promote a stored pending-conflict row into the public ISyncConflict shape
+ * by tagging every entry with resolution: 'pending'.
+ */
+export function mapPendingConflicts(
+  rows: readonly IPendingConflictRow[],
+): ISyncConflict[] {
+  return rows.map((row) => ({
+    id: row.id,
+    contentType: row.contentType,
+    itemId: row.itemId,
+    itemName: row.itemName,
+    localVersion: row.localVersion,
+    localHash: row.localHash,
+    remoteVersion: row.remoteVersion,
+    remoteHash: row.remoteHash,
+    remotePeerId: row.remotePeerId,
+    detectedAt: row.detectedAt,
+    resolution: 'pending' as const,
+  }));
+}
+
+/**
+ * Fetch a single conflict from the pending list, or null if already
+ * resolved / never existed.
+ */
+export async function findPendingConflictById(
+  changeLog: ChangeLogRepository,
+  conflictId: string,
+): Promise<ISyncConflict | null> {
+  const rows = await changeLog.getPendingConflicts();
+  const pending = mapPendingConflicts(rows);
+  return pending.find((c) => c.id === conflictId) ?? null;
+}
+
+/**
+ * Resolve a conflict by accepting the remote version. Marks the conflict
+ * resolved and — if remoteData + applyFn are provided — writes the remote
+ * payload back to local storage.
+ */
+export async function resolveAcceptRemote(
+  changeLog: ChangeLogRepository,
+  conflictId: string,
+  options: {
+    readonly remoteData?: string;
+    readonly applyFn?: ContentApplyFn;
+  },
+): Promise<boolean> {
+  const resolved = await changeLog.resolveConflict(conflictId, 'remote');
+  if (!resolved) return false;
+
+  if (options.remoteData && options.applyFn) {
+    const conflict = await findPendingConflictById(changeLog, conflictId);
+    if (conflict) {
+      await options.applyFn(
+        conflict.itemId,
+        conflict.contentType,
+        options.remoteData,
+      );
+    }
+  }
+
+  return resolved;
+}
+
+/**
+ * Resolve a conflict by forking — keeps the local version and writes the
+ * remote payload into a new local item with a generated id. Returns the
+ * forked item id when a fork was materialized; returns `true` when only
+ * the resolution bookkeeping happened (no data and/or no applyFn).
+ */
+export async function resolveFork(
+  changeLog: ChangeLogRepository,
+  conflictId: string,
+  options: {
+    readonly remoteData?: string;
+    readonly applyFn?: ContentApplyFn;
+    readonly recordLocalChange: (
+      contentType: IChangeLogEntry['contentType'],
+      itemId: string,
+      data: string,
+    ) => Promise<IChangeLogEntry>;
+  },
+): Promise<boolean | { forkedItemId: string }> {
+  const resolved = await changeLog.resolveConflict(conflictId, 'forked');
+  if (!resolved) return false;
+
+  if (options.remoteData && options.applyFn) {
+    const conflict = await findPendingConflictById(changeLog, conflictId);
+    if (conflict) {
+      const forkedItemId = `${conflict.itemId}-fork-${Date.now()}`;
+      await options.applyFn(
+        forkedItemId,
+        conflict.contentType,
+        options.remoteData,
+      );
+      await options.recordLocalChange(
+        conflict.contentType,
+        forkedItemId,
+        options.remoteData,
+      );
+      return { forkedItemId };
+    }
+  }
+
+  return resolved;
+}

--- a/src/services/vault/SyncEngine.folders.ts
+++ b/src/services/vault/SyncEngine.folders.ts
@@ -1,0 +1,117 @@
+/**
+ * SyncEngine — folder-level sync helpers
+ *
+ * Pure functions that operate on a ChangeLogRepository + sync-state map.
+ * SyncEngine's folder methods delegate to these so the main class stays
+ * under the per-file line limit.
+ */
+
+import type {
+  IChangeLogEntry,
+  ISyncState,
+  ShareableContentType,
+} from '@/types/vault';
+
+import type { ChangeLogRepository } from './ChangeLogRepository';
+
+/**
+ * Check whether a change belongs to an item that lives in a given folder.
+ * Folder membership is encoded in the change's JSON data payload.
+ */
+export function isChangeForFolderItem(
+  change: IChangeLogEntry,
+  folderId: string,
+): boolean {
+  if (!change.data) return false;
+  try {
+    const data = JSON.parse(change.data) as { folderId?: string };
+    return data.folderId === folderId;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fetch the change set for a folder — folder-level changes plus any item
+ * changes that reference this folder in their data payload.
+ */
+export async function getChangesForFolder(
+  changeLog: ChangeLogRepository,
+  folderId: string,
+  fromVersion = 0,
+  limit = 100,
+): Promise<IChangeLogEntry[]> {
+  const allChanges = await changeLog.getChangesSince(fromVersion, limit * 10);
+  return allChanges.filter(
+    (change) =>
+      (change.contentType === 'folder' && change.itemId === folderId) ||
+      isChangeForFolderItem(change, folderId),
+  );
+}
+
+/**
+ * Fetch the changes for a folder that a peer hasn't seen yet.
+ */
+export async function getFolderChangesForPeer(
+  changeLog: ChangeLogRepository,
+  syncStates: Map<string, ISyncState>,
+  folderId: string,
+  peerId: string,
+  limit = 100,
+): Promise<IChangeLogEntry[]> {
+  const state = syncStates.get(peerId);
+  const fromVersion = state?.lastVersion ?? 0;
+  return getChangesForFolder(changeLog, folderId, fromVersion, limit);
+}
+
+/**
+ * Filter incoming peer changes down to just the ones for the given folder.
+ */
+export function filterFolderChanges(
+  changes: readonly IChangeLogEntry[],
+  folderId: string,
+): IChangeLogEntry[] {
+  return changes.filter(
+    (change) =>
+      (change.contentType === 'folder' && change.itemId === folderId) ||
+      isChangeForFolderItem(change, folderId),
+  );
+}
+
+/**
+ * Enumerate folders with at least one unsynced change, either at the folder
+ * level or via a descendant item whose change data references the folder.
+ */
+export async function getFoldersWithUnsyncedChanges(
+  changeLog: ChangeLogRepository,
+): Promise<string[]> {
+  const unsynced = await changeLog.getUnsynced();
+  const folderIds = new Set<string>();
+  for (const change of unsynced) {
+    if (change.contentType === 'folder') {
+      folderIds.add(change.itemId);
+    } else if (change.data) {
+      try {
+        const data = JSON.parse(change.data) as { folderId?: string };
+        if (data.folderId) {
+          folderIds.add(data.folderId);
+        }
+      } catch {
+        // Ignore parse errors — bad JSON just means no folder attribution.
+      }
+    }
+  }
+  return Array.from(folderIds);
+}
+
+/**
+ * Build the canonical JSON payload for a folder-membership update.
+ */
+export function buildFolderMembershipPayload(
+  action: 'item_added' | 'item_removed',
+  folderId: string,
+  itemId: string,
+  itemType: ShareableContentType,
+): string {
+  return JSON.stringify({ action, folderId, itemId, itemType });
+}

--- a/src/services/vault/SyncEngine.ts
+++ b/src/services/vault/SyncEngine.ts
@@ -23,6 +23,18 @@ import {
   ChangeLogRepository,
   getChangeLogRepository,
 } from './ChangeLogRepository';
+import {
+  mapPendingConflicts,
+  resolveAcceptRemote as resolveAcceptRemoteHelper,
+  resolveFork as resolveForkHelper,
+} from './SyncEngine.conflictResolution';
+import {
+  buildFolderMembershipPayload,
+  filterFolderChanges,
+  getChangesForFolder as getChangesForFolderHelper,
+  getFolderChangesForPeer as getFolderChangesForPeerHelper,
+  getFoldersWithUnsyncedChanges as getFoldersWithUnsyncedChangesHelper,
+} from './SyncEngine.folders';
 
 // =============================================================================
 // Types
@@ -65,6 +77,26 @@ export type ContentDataFn = (
   contentType: ShareableContentType | 'folder',
 ) => Promise<string | null>;
 
+/**
+ * Item name resolver — returns a human-readable display name for a
+ * conflicting item so conflict records aren't labelled with raw ids.
+ */
+export type ItemNameFn = (
+  itemId: string,
+  contentType: ShareableContentType | 'folder',
+) => Promise<string | null>;
+
+/**
+ * Content apply function — writes remote content back to local storage.
+ * Registered by the caller that owns persistence (e.g. a vault store)
+ * so the sync engine stays storage-agnostic.
+ */
+export type ContentApplyFn = (
+  itemId: string,
+  contentType: ShareableContentType | 'folder',
+  data: string,
+) => Promise<void>;
+
 // =============================================================================
 // Service
 // =============================================================================
@@ -77,6 +109,8 @@ export class SyncEngine {
   private syncStates: Map<string, ISyncState> = new Map();
   private contentHashFn?: ContentHashFn;
   private contentDataFn?: ContentDataFn;
+  private itemNameFn?: ItemNameFn;
+  private contentApplyFn?: ContentApplyFn;
 
   constructor(changeLog?: ChangeLogRepository) {
     this.changeLog = changeLog ?? getChangeLogRepository();
@@ -94,6 +128,23 @@ export class SyncEngine {
    */
   setContentDataFn(fn: ContentDataFn): void {
     this.contentDataFn = fn;
+  }
+
+  /**
+   * Register a resolver that maps (itemId, contentType) → display name.
+   * Used so conflict records carry a human-readable name rather than a raw id.
+   */
+  setItemNameFn(fn: ItemNameFn): void {
+    this.itemNameFn = fn;
+  }
+
+  /**
+   * Register a callback that persists remote content to local storage.
+   * Used by applyChange (no-conflict path) and by conflict resolution paths
+   * (acceptRemote, fork) so the sync engine stays storage-agnostic.
+   */
+  setContentApplyFn(fn: ContentApplyFn): void {
+    this.contentApplyFn = fn;
   }
 
   // ===========================================================================
@@ -235,17 +286,24 @@ export class SyncEngine {
   }
 
   /**
-   * Create a conflict record
+   * Create a conflict record. Resolves a human-readable item name via the
+   * registered itemNameFn when available, otherwise falls back to the raw id
+   * so the conflict row always carries something the UI can display.
    */
   private async createConflict(
     local: IChangeLogEntry,
     remote: IChangeLogEntry,
     peerId: string,
   ): Promise<ISyncConflict> {
+    const resolvedName =
+      (this.itemNameFn
+        ? await this.itemNameFn(local.itemId, local.contentType)
+        : null) ?? local.itemId;
+
     const conflictId = await this.changeLog.recordConflict({
       contentType: local.contentType,
       itemId: local.itemId,
-      itemName: local.itemId, // TODO: Get actual item name
+      itemName: resolvedName,
       localVersion: local.version,
       localHash: local.contentHash || '',
       remoteVersion: remote.version,
@@ -257,7 +315,7 @@ export class SyncEngine {
       id: conflictId,
       contentType: local.contentType,
       itemId: local.itemId,
-      itemName: local.itemId,
+      itemName: resolvedName,
       localVersion: local.version,
       localHash: local.contentHash || '',
       remoteVersion: remote.version,
@@ -269,13 +327,14 @@ export class SyncEngine {
   }
 
   /**
-   * Apply a remote change locally
+   * Apply a remote change locally. Records the incoming change against the
+   * changelog, then — if a content-apply callback is registered and the
+   * change carries data — writes that data back to local storage.
    */
   private async applyChange(
     change: IChangeLogEntry,
     sourceId: string,
   ): Promise<void> {
-    // Record the change as coming from a remote source
     await this.changeLog.recordChange(
       change.changeType,
       change.contentType,
@@ -285,8 +344,9 @@ export class SyncEngine {
       sourceId,
     );
 
-    // The actual content update would be handled by a callback
-    // registered with the sync engine
+    if (this.contentApplyFn && change.data) {
+      await this.contentApplyFn(change.itemId, change.contentType, change.data);
+    }
   }
 
   // ===========================================================================
@@ -298,19 +358,7 @@ export class SyncEngine {
    */
   async getPendingConflicts(): Promise<ISyncConflict[]> {
     const rows = await this.changeLog.getPendingConflicts();
-    return rows.map((row) => ({
-      id: row.id,
-      contentType: row.contentType,
-      itemId: row.itemId,
-      itemName: row.itemName,
-      localVersion: row.localVersion,
-      localHash: row.localHash,
-      remoteVersion: row.remoteVersion,
-      remoteHash: row.remoteHash,
-      remotePeerId: row.remotePeerId,
-      detectedAt: row.detectedAt,
-      resolution: 'pending' as const,
-    }));
+    return mapPendingConflicts(rows);
   }
 
   /**
@@ -321,27 +369,33 @@ export class SyncEngine {
   }
 
   /**
-   * Resolve a conflict by accepting remote version
+   * Resolve a conflict by accepting the remote version. Writes the supplied
+   * remote payload to local storage via the registered apply callback.
    */
-  async resolveAcceptRemote(conflictId: string): Promise<boolean> {
-    // Mark conflict as resolved
-    const resolved = await this.changeLog.resolveConflict(conflictId, 'remote');
-
-    // TODO: Apply the remote content to local storage
-
-    return resolved;
+  async resolveAcceptRemote(
+    conflictId: string,
+    remoteData?: string,
+  ): Promise<boolean> {
+    return resolveAcceptRemoteHelper(this.changeLog, conflictId, {
+      remoteData,
+      applyFn: this.contentApplyFn,
+    });
   }
 
   /**
-   * Resolve a conflict by forking (keep both versions)
+   * Resolve a conflict by forking — keep the local version and write the
+   * remote version into a new local item with a generated id.
    */
-  async resolveFork(conflictId: string): Promise<boolean> {
-    // Mark conflict as resolved
-    const resolved = await this.changeLog.resolveConflict(conflictId, 'forked');
-
-    // TODO: Create a copy of the item with the remote content
-
-    return resolved;
+  async resolveFork(
+    conflictId: string,
+    remoteData?: string,
+  ): Promise<boolean | { forkedItemId: string }> {
+    return resolveForkHelper(this.changeLog, conflictId, {
+      remoteData,
+      applyFn: this.contentApplyFn,
+      recordLocalChange: (contentType, itemId, data) =>
+        this.recordChange('create', contentType, itemId, data),
+    });
   }
 
   // ===========================================================================
@@ -438,13 +492,12 @@ export class SyncEngine {
     itemId: string,
     itemType: ShareableContentType,
   ): Promise<IChangeLogEntry> {
-    const data = JSON.stringify({
-      action: 'item_added',
+    return this.recordChange(
+      'update',
+      'folder',
       folderId,
-      itemId,
-      itemType,
-    });
-    return this.recordChange('update', 'folder', folderId, data);
+      buildFolderMembershipPayload('item_added', folderId, itemId, itemType),
+    );
   }
 
   /**
@@ -455,13 +508,12 @@ export class SyncEngine {
     itemId: string,
     itemType: ShareableContentType,
   ): Promise<IChangeLogEntry> {
-    const data = JSON.stringify({
-      action: 'item_removed',
+    return this.recordChange(
+      'update',
+      'folder',
       folderId,
-      itemId,
-      itemType,
-    });
-    return this.recordChange('update', 'folder', folderId, data);
+      buildFolderMembershipPayload('item_removed', folderId, itemId, itemType),
+    );
   }
 
   /**
@@ -472,38 +524,12 @@ export class SyncEngine {
     fromVersion = 0,
     limit = 100,
   ): Promise<IChangeLogEntry[]> {
-    // Get all changes since version
-    const allChanges = await this.changeLog.getChangesSince(
+    return getChangesForFolderHelper(
+      this.changeLog,
+      folderId,
       fromVersion,
-      limit * 10,
+      limit,
     );
-
-    // Filter to folder changes and items in that folder
-    // For now, we track folder-level changes directly
-    // Item membership tracking is via the folder update entries
-    return allChanges.filter(
-      (change) =>
-        (change.contentType === 'folder' && change.itemId === folderId) ||
-        this.isChangeForFolderItem(change, folderId),
-    );
-  }
-
-  /**
-   * Check if a change is for an item that belongs to a folder
-   * This uses the change data to determine folder membership
-   */
-  private isChangeForFolderItem(
-    change: IChangeLogEntry,
-    folderId: string,
-  ): boolean {
-    if (!change.data) return false;
-
-    try {
-      const data = JSON.parse(change.data) as { folderId?: string };
-      return data.folderId === folderId;
-    } catch {
-      return false;
-    }
   }
 
   /**
@@ -515,10 +541,13 @@ export class SyncEngine {
     peerId: string,
     limit = 100,
   ): Promise<IChangeLogEntry[]> {
-    const state = this.syncStates.get(peerId);
-    const fromVersion = state?.lastVersion ?? 0;
-
-    return this.getChangesForFolder(folderId, fromVersion, limit);
+    return getFolderChangesForPeerHelper(
+      this.changeLog,
+      this.syncStates,
+      folderId,
+      peerId,
+      limit,
+    );
   }
 
   /**
@@ -529,39 +558,17 @@ export class SyncEngine {
     peerId: string,
     changes: IChangeLogEntry[],
   ): Promise<IReconciliationResult> {
-    // Filter changes to only those for this folder
-    const folderChanges = changes.filter(
-      (change) =>
-        (change.contentType === 'folder' && change.itemId === folderId) ||
-        this.isChangeForFolderItem(change, folderId),
+    return this.applyRemoteChanges(
+      peerId,
+      filterFolderChanges(changes, folderId),
     );
-
-    return this.applyRemoteChanges(peerId, folderChanges);
   }
 
   /**
    * Get folders that have unsynced changes
    */
   async getFoldersWithUnsyncedChanges(): Promise<string[]> {
-    const unsynced = await this.getUnsyncedChanges();
-    const folderIds = new Set<string>();
-
-    for (const change of unsynced) {
-      if (change.contentType === 'folder') {
-        folderIds.add(change.itemId);
-      } else if (change.data) {
-        try {
-          const data = JSON.parse(change.data) as { folderId?: string };
-          if (data.folderId) {
-            folderIds.add(data.folderId);
-          }
-        } catch {
-          // Ignore parse errors
-        }
-      }
-    }
-
-    return Array.from(folderIds);
+    return getFoldersWithUnsyncedChangesHelper(this.changeLog);
   }
 
   /**

--- a/src/services/vault/__tests__/SyncEngine.test.ts
+++ b/src/services/vault/__tests__/SyncEngine.test.ts
@@ -827,6 +827,191 @@ describe('SyncEngine', () => {
   });
 
   // ===========================================================================
+  // setItemNameFn / createConflict naming
+  // ===========================================================================
+
+  describe('setItemNameFn', () => {
+    it('names conflict records using the registered resolver', async () => {
+      mockRecordConflict.mockResolvedValue('conflict-1');
+      mockGetLatestForItem.mockResolvedValue(
+        createMockChangeLogEntry({
+          itemId: 'unit-atlas-1',
+          version: 1,
+          contentHash: 'hashA',
+          synced: false,
+        }),
+      );
+      const itemNameFn = jest
+        .fn()
+        .mockResolvedValue('Atlas AS7-D — Hero Variant');
+      syncEngine.setItemNameFn(itemNameFn);
+
+      const remote = createMockChangeLogEntry({
+        itemId: 'unit-atlas-1',
+        version: 2,
+        contentHash: 'hashB',
+      });
+      await syncEngine.applyRemoteChanges('peer-1', [remote]);
+
+      expect(itemNameFn).toHaveBeenCalledWith('unit-atlas-1', 'unit');
+      expect(mockRecordConflict).toHaveBeenCalledWith(
+        expect.objectContaining({
+          itemName: 'Atlas AS7-D — Hero Variant',
+        }),
+      );
+    });
+
+    it('falls back to the item id when no resolver is registered', async () => {
+      mockRecordConflict.mockResolvedValue('conflict-1');
+      mockGetLatestForItem.mockResolvedValue(
+        createMockChangeLogEntry({
+          itemId: 'unit-atlas-1',
+          version: 1,
+          contentHash: 'hashA',
+          synced: false,
+        }),
+      );
+
+      const remote = createMockChangeLogEntry({
+        itemId: 'unit-atlas-1',
+        version: 2,
+        contentHash: 'hashB',
+      });
+      await syncEngine.applyRemoteChanges('peer-1', [remote]);
+
+      expect(mockRecordConflict).toHaveBeenCalledWith(
+        expect.objectContaining({ itemName: 'unit-atlas-1' }),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // setContentApplyFn — applyChange + acceptRemote + fork integration
+  // ===========================================================================
+
+  describe('setContentApplyFn', () => {
+    it('invokes the apply callback for non-conflicting remote changes', async () => {
+      mockGetLatestForItem.mockResolvedValue(null);
+      mockRecordChange.mockResolvedValue(createMockChangeLogEntry());
+      const applyFn = jest.fn().mockResolvedValue(undefined);
+      syncEngine.setContentApplyFn(applyFn);
+
+      const remote = createMockChangeLogEntry({
+        itemId: 'unit-atlas-1',
+        data: '{"name":"Atlas AS7-D"}',
+      });
+      await syncEngine.applyRemoteChanges('peer-1', [remote]);
+
+      expect(applyFn).toHaveBeenCalledWith(
+        'unit-atlas-1',
+        'unit',
+        '{"name":"Atlas AS7-D"}',
+      );
+    });
+
+    it('skips the apply callback when the remote change has no data', async () => {
+      mockGetLatestForItem.mockResolvedValue(null);
+      mockRecordChange.mockResolvedValue(createMockChangeLogEntry());
+      const applyFn = jest.fn();
+      syncEngine.setContentApplyFn(applyFn);
+
+      const remote = createMockChangeLogEntry({ data: null });
+      await syncEngine.applyRemoteChanges('peer-1', [remote]);
+
+      expect(applyFn).not.toHaveBeenCalled();
+    });
+
+    it('resolveAcceptRemote applies remote data via the callback', async () => {
+      mockResolveConflict.mockResolvedValue(true);
+      mockGetPendingConflicts.mockResolvedValue([
+        {
+          id: 'conflict-1',
+          contentType: 'unit' as ShareableContentType,
+          itemId: 'unit-atlas-1',
+          itemName: 'Atlas',
+          localVersion: 1,
+          localHash: 'a',
+          remoteVersion: 2,
+          remoteHash: 'b',
+          remotePeerId: 'peer-1',
+          detectedAt: '2024-01-15T10:00:00.000Z',
+        },
+      ]);
+      const applyFn = jest.fn().mockResolvedValue(undefined);
+      syncEngine.setContentApplyFn(applyFn);
+
+      const ok = await syncEngine.resolveAcceptRemote(
+        'conflict-1',
+        '{"remote":"payload"}',
+      );
+
+      expect(ok).toBe(true);
+      expect(applyFn).toHaveBeenCalledWith(
+        'unit-atlas-1',
+        'unit',
+        '{"remote":"payload"}',
+      );
+    });
+
+    it('resolveAcceptRemote skips apply when no remote data is supplied', async () => {
+      mockResolveConflict.mockResolvedValue(true);
+      const applyFn = jest.fn();
+      syncEngine.setContentApplyFn(applyFn);
+
+      await syncEngine.resolveAcceptRemote('conflict-1');
+
+      expect(applyFn).not.toHaveBeenCalled();
+    });
+
+    it('resolveFork creates a forked item via the callback and returns its id', async () => {
+      mockResolveConflict.mockResolvedValue(true);
+      mockGetPendingConflicts.mockResolvedValue([
+        {
+          id: 'conflict-1',
+          contentType: 'unit' as ShareableContentType,
+          itemId: 'unit-atlas-1',
+          itemName: 'Atlas',
+          localVersion: 1,
+          localHash: 'a',
+          remoteVersion: 2,
+          remoteHash: 'b',
+          remotePeerId: 'peer-1',
+          detectedAt: '2024-01-15T10:00:00.000Z',
+        },
+      ]);
+      mockRecordChange.mockResolvedValue(createMockChangeLogEntry());
+      const applyFn = jest.fn().mockResolvedValue(undefined);
+      syncEngine.setContentApplyFn(applyFn);
+
+      const result = await syncEngine.resolveFork(
+        'conflict-1',
+        '{"remote":"payload"}',
+      );
+
+      expect(typeof result).toBe('object');
+      if (typeof result === 'object') {
+        expect(result.forkedItemId).toMatch(/^unit-atlas-1-fork-\d+$/);
+        expect(applyFn).toHaveBeenCalledWith(
+          result.forkedItemId,
+          'unit',
+          '{"remote":"payload"}',
+        );
+      }
+    });
+
+    it('resolveFork marks resolved without forking when no data is supplied', async () => {
+      mockResolveConflict.mockResolvedValue(true);
+      const applyFn = jest.fn();
+      syncEngine.setContentApplyFn(applyFn);
+
+      const result = await syncEngine.resolveFork('conflict-1');
+
+      expect(result).toBe(true);
+      expect(applyFn).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
   // getSyncState
   // ===========================================================================
 


### PR DESCRIPTION
## Summary
Fill in the three SyncEngine stubs:
- `createConflict` used the raw itemId as `itemName` → now resolves via a new `setItemNameFn` callback
- `resolveAcceptRemote` previously marked the conflict resolved without writing remote content → now accepts `remoteData` and applies it via a new `setContentApplyFn` callback
- `resolveFork` previously marked forked without creating a copy → now generates `<itemId>-fork-<ts>`, writes remote data under it, records a local change, returns `{ forkedItemId }`

Both callbacks are optional — callers without them get backward-compatible behaviour.

`applyChange` (non-conflict path) also invokes the apply callback so incoming remote data lands in local storage on happy-path syncs.

Split folder sync and conflict resolution into `SyncEngine.folders.ts` and `SyncEngine.conflictResolution.ts` to keep the main class under the 400-line cap.

## Test plan
- [x] `npx jest src/services/vault/__tests__/SyncEngine.test.ts` — 105/105 passing (8 new tests for the callbacks)
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeded (husky pre-push)