### PR TITLE
feat(spa): unify catalogs and import full 85-SPA MegaMek roster

### DIFF
--- a/src/lib/spa/__tests__/canonicalCatalog.test.ts
+++ b/src/lib/spa/__tests__/canonicalCatalog.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the unified SPA catalog and lookup helpers.
+ */
+
+import {
+  CANONICAL_SPA_LIST,
+  areSPAIdsValid,
+  canonicalizeSPAIds,
+  getAllSPAs,
+  getFlaws,
+  getOriginOnlySPAs,
+  getPurchasableSPAs,
+  getSPADefinition,
+  getSPAsByCategory,
+  getSPAsBySource,
+  getSPAsForPipeline,
+  resolveSPAId,
+} from '../';
+
+describe('canonical SPA catalog shape', () => {
+  it('contains at least 85 canonical entries', () => {
+    expect(CANONICAL_SPA_LIST.length).toBeGreaterThanOrEqual(85);
+  });
+
+  it('every entry has a snake_case id', () => {
+    for (const spa of CANONICAL_SPA_LIST) {
+      expect(spa.id).toMatch(/^[a-z][a-z0-9_]*$/);
+    }
+  });
+
+  it('every entry has displayName, description, category, and source', () => {
+    for (const spa of CANONICAL_SPA_LIST) {
+      expect(spa.displayName.length).toBeGreaterThan(0);
+      expect(spa.description.length).toBeGreaterThan(0);
+      expect(spa.category).toBeTruthy();
+      expect(spa.source).toBeTruthy();
+    }
+  });
+
+  it('ids are unique', () => {
+    const ids = CANONICAL_SPA_LIST.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('includes canonical examples from every major category', () => {
+    const getById = (id: string) => CANONICAL_SPA_LIST.find((s) => s.id === id);
+    // Piloting
+    expect(getById('maneuvering_ace')).toBeDefined();
+    expect(getById('jumping_jack')).toBeDefined();
+    // Gunnery
+    expect(getById('weapon_specialist')).toBeDefined();
+    expect(getById('sandblaster')).toBeDefined();
+    expect(getById('blood_stalker')).toBeDefined();
+    // Manei Domini bioware
+    expect(getById('vdni')).toBeDefined();
+    expect(getById('tsm_implant')).toBeDefined();
+    // Edge
+    expect(getById('edge_when_headhit')).toBeDefined();
+    expect(getById('edge_when_aero_nuke_crit')).toBeDefined();
+    // aToW
+    expect(getById('atow_combat_sense')).toBeDefined();
+    expect(getById('atow_combat_paralysis')).toBeDefined();
+  });
+
+  it('flaws have negative or null xpCost and isFlaw=true', () => {
+    for (const spa of CANONICAL_SPA_LIST) {
+      if (spa.isFlaw) {
+        expect(spa.xpCost === null || spa.xpCost < 0).toBe(true);
+      }
+    }
+  });
+
+  it('bioware entries are origin-only and have null xpCost', () => {
+    const bioware = CANONICAL_SPA_LIST.filter((s) => s.category === 'bioware');
+    expect(bioware.length).toBeGreaterThan(0);
+    for (const spa of bioware) {
+      expect(spa.isOriginOnly).toBe(true);
+      expect(spa.xpCost).toBeNull();
+    }
+  });
+
+  it('abilities that require designation carry a designationType', () => {
+    for (const spa of CANONICAL_SPA_LIST) {
+      if (spa.requiresDesignation) {
+        expect(spa.designationType).toBeDefined();
+      }
+    }
+  });
+});
+
+describe('getSPADefinition', () => {
+  it('looks up a definition by canonical id', () => {
+    const def = getSPADefinition('weapon_specialist');
+    expect(def).not.toBeNull();
+    expect(def?.displayName).toBe('Weapon Specialist');
+    expect(def?.category).toBe('gunnery');
+  });
+
+  it('returns null for unknown ids', () => {
+    expect(getSPADefinition('does_not_exist')).toBeNull();
+  });
+
+  it('resolves legacy System A id (natural_aptitude → aptitude_gunnery)', () => {
+    const def = getSPADefinition('natural_aptitude');
+    expect(def?.id).toBe('aptitude_gunnery');
+  });
+
+  it('resolves legacy System B id (weapon-specialist → weapon_specialist)', () => {
+    const def = getSPADefinition('weapon-specialist');
+    expect(def?.id).toBe('weapon_specialist');
+  });
+
+  it('resolves legacy kebab-case ids for edge-case names', () => {
+    expect(getSPADefinition('iron-man')?.id).toBe('iron_man');
+    expect(getSPADefinition('tactical-genius')?.id).toBe('tactical_genius');
+    expect(getSPADefinition('heavy-lifter')?.id).toBe('hvy_lifter');
+  });
+});
+
+describe('resolveSPAId', () => {
+  it('returns the canonical id unchanged when input is canonical', () => {
+    expect(resolveSPAId('iron_man')).toBe('iron_man');
+  });
+
+  it('maps System A legacy ids', () => {
+    expect(resolveSPAId('fast_learner')).toBe('aptitude_gunnery');
+  });
+
+  it('returns null for unknown ids', () => {
+    expect(resolveSPAId('nonsense')).toBeNull();
+  });
+});
+
+describe('filters', () => {
+  it('getAllSPAs returns the full list', () => {
+    expect(getAllSPAs().length).toBe(CANONICAL_SPA_LIST.length);
+  });
+
+  it('getSPAsByCategory returns only the requested category', () => {
+    const gunnery = getSPAsByCategory('gunnery');
+    expect(gunnery.length).toBeGreaterThan(0);
+    expect(gunnery.every((s) => s.category === 'gunnery')).toBe(true);
+  });
+
+  it('getSPAsBySource returns only the requested source', () => {
+    const camOps = getSPAsBySource('CamOps');
+    expect(camOps.length).toBeGreaterThan(0);
+    expect(camOps.every((s) => s.source === 'CamOps')).toBe(true);
+  });
+
+  it('getSPAsForPipeline returns only SPAs touching that pipeline', () => {
+    const toHit = getSPAsForPipeline('to-hit');
+    expect(toHit.length).toBeGreaterThan(0);
+    expect(toHit.every((s) => s.pipelines.includes('to-hit'))).toBe(true);
+  });
+
+  it('getPurchasableSPAs excludes flaws and null-cost abilities', () => {
+    const purchasable = getPurchasableSPAs();
+    expect(purchasable.every((s) => s.xpCost !== null && !s.isFlaw)).toBe(true);
+  });
+
+  it('getFlaws returns only flaws', () => {
+    const flaws = getFlaws();
+    expect(flaws.length).toBeGreaterThan(0);
+    expect(flaws.every((s) => s.isFlaw)).toBe(true);
+  });
+
+  it('getOriginOnlySPAs returns only origin-only abilities', () => {
+    const origin = getOriginOnlySPAs();
+    expect(origin.every((s) => s.isOriginOnly)).toBe(true);
+  });
+});
+
+describe('id canonicalization helpers', () => {
+  it('areSPAIdsValid accepts mixed canonical + legacy ids', () => {
+    expect(areSPAIdsValid(['weapon_specialist', 'iron-man'])).toBe(true);
+  });
+
+  it('areSPAIdsValid rejects any unknown id in the list', () => {
+    expect(areSPAIdsValid(['weapon_specialist', 'nope'])).toBe(false);
+  });
+
+  it('canonicalizeSPAIds maps legacy ids to canonical form and drops unknowns', () => {
+    expect(
+      canonicalizeSPAIds(['iron-man', 'nonsense', 'weapon_specialist']),
+    ).toEqual(['iron_man', 'weapon_specialist']);
+  });
+});

--- a/src/lib/spa/canonicalCatalog.ts
+++ b/src/lib/spa/canonicalCatalog.ts
@@ -1,0 +1,58 @@
+/**
+ * Canonical SPA catalog — aggregator for the per-category data files.
+ *
+ * Imported from MegaMek's OptionsConstants.java + PilotOptions.java +
+ * messages.properties at `E:\Projects\megamek\...`. IDs are snake_case
+ * to match the Java constants. When a later supplement renamed / split
+ * an ability, the legacy id is registered in catalog/legacyAliases.ts
+ * so code that still uses the older form keeps resolving correctly.
+ *
+ * Roster:
+ *  - 19 Piloting abilities     (catalog/pilotingSPAs.ts)
+ *  - 13 Gunnery abilities      (catalog/gunnerySPAs.ts)
+ *  - 7  Miscellaneous + 2 Infantry + 2 aToW
+ *                              (catalog/miscAndInfantrySPAs.ts)
+ *  - 26 Manei Domini / proto DNI / suicide bioware
+ *                              (catalog/biowareSPAs.ts)
+ *  - 11 Unofficial / legacy     (catalog/unofficialSPAs.ts)
+ *  - 11 Edge triggers           (catalog/edgeSPAs.ts)
+ *  = 91 canonical entries.
+ */
+
+import type { ISPADefinition } from '@/types/spa/SPADefinition';
+
+import { BIOWARE_SPAS } from './catalog/biowareSPAs';
+import { EDGE_SPAS } from './catalog/edgeSPAs';
+import { GUNNERY_SPAS } from './catalog/gunnerySPAs';
+import {
+  ATOW_SPAS,
+  INFANTRY_SPAS,
+  MISC_SPAS,
+} from './catalog/miscAndInfantrySPAs';
+import { PILOTING_SPAS } from './catalog/pilotingSPAs';
+import { UNOFFICIAL_SPAS } from './catalog/unofficialSPAs';
+
+const ALL_SPAS: readonly ISPADefinition[] = [
+  ...PILOTING_SPAS,
+  ...GUNNERY_SPAS,
+  ...MISC_SPAS,
+  ...INFANTRY_SPAS,
+  ...ATOW_SPAS,
+  ...BIOWARE_SPAS,
+  ...UNOFFICIAL_SPAS,
+  ...EDGE_SPAS,
+];
+
+/** The canonical SPA catalog — id → definition. */
+export const CANONICAL_SPA_CATALOG: Readonly<Record<string, ISPADefinition>> =
+  Object.freeze(
+    ALL_SPAS.reduce<Record<string, ISPADefinition>>((acc, spa) => {
+      acc[spa.id] = spa;
+      return acc;
+    }, {}),
+  );
+
+/** Ordered list form (for UI iteration / random selection). */
+export const CANONICAL_SPA_LIST: readonly ISPADefinition[] = ALL_SPAS;
+
+export { SPA_LEGACY_ALIASES } from './catalog/legacyAliases';

--- a/src/lib/spa/catalog/biowareSPAs.ts
+++ b/src/lib/spa/catalog/biowareSPAs.ts
@@ -1,0 +1,168 @@
+/**
+ * Manei Domini bioware implants (26 total — 24 MD set + proto DNI + suicide).
+ * Source: MegaMek OptionsConstants.java — MD implants block.
+ */
+
+import type { ISPADefinition } from '@/types/spa/SPADefinition';
+
+import { bioware } from './builders';
+
+export const BIOWARE_SPAS: readonly ISPADefinition[] = [
+  bioware({
+    id: 'artificial_pain_shunt',
+    displayName: 'Artificial Pain Shunt',
+    description: 'Damage immunity against specified attack types.',
+  }),
+  bioware({
+    id: 'vdni',
+    displayName: 'VDNI',
+    description:
+      'Vehicular Direct Neural Interface: reduced piloting/gunnery TNs while jacked in.',
+    pipelines: ['to-hit', 'psr'],
+  }),
+  bioware({
+    id: 'bvdni',
+    displayName: 'Buffered VDNI',
+    description: 'Buffered neural interface: reduced feedback damage.',
+    pipelines: ['to-hit', 'psr'],
+  }),
+  bioware({
+    id: 'pl_enhanced',
+    displayName: 'Prosthetic Limbs, Enhanced',
+    description: 'Infantry prosthetics: +1 damage with melee/carried weapons.',
+    pipelines: ['damage'],
+  }),
+  bioware({
+    id: 'pl_ienhanced',
+    displayName: 'Prosthetic Limbs, Improved Enhanced',
+    description: 'Multiple enhanced prosthetics stacking additional damage.',
+    pipelines: ['damage'],
+  }),
+  bioware({
+    id: 'pl_masc',
+    displayName: 'Prosthetic Leg MASC',
+    description: 'MASC-equipped prosthetic leg: bonus infantry speed.',
+    pipelines: ['movement'],
+  }),
+  bioware({
+    id: 'pl_extra_limbs',
+    displayName: 'Prosthetic Limbs, Extraneous',
+    description: 'Additional prosthetic limbs provide extra weapon mounts.',
+    pipelines: ['special'],
+  }),
+  bioware({
+    id: 'pl_tail',
+    displayName: 'Prosthetic Tail, Enhanced',
+    description: 'Melee damage bonus against adjacent targets.',
+    pipelines: ['damage'],
+  }),
+  bioware({
+    id: 'pl_glider',
+    displayName: 'Prosthetic Wings, Glider',
+    description: 'Parafoil glide capability for infantry.',
+    pipelines: ['movement'],
+  }),
+  bioware({
+    id: 'pl_flight',
+    displayName: 'Prosthetic Wings, Powered Flight',
+    description: 'Limited VTOL flight capability.',
+    pipelines: ['movement'],
+  }),
+  bioware({
+    id: 'cyber_imp_audio',
+    displayName: 'Sensory Implant: Enhanced Audio',
+    description: 'Functions as a 2-hex active probe for infantry detection.',
+    pipelines: ['sensors'],
+  }),
+  bioware({
+    id: 'cyber_imp_visual',
+    displayName: 'Sensory Implant: IR/EM Optical',
+    description: 'Functions as a 2-hex active probe and ignores smoke.',
+    pipelines: ['sensors'],
+  }),
+  bioware({
+    id: 'cyber_imp_laser',
+    displayName: 'Sensory Implant: Laser/Telescopic',
+    description: '-1 to-hit for ranged infantry attacks.',
+    pipelines: ['to-hit'],
+  }),
+  bioware({
+    id: 'mm_implants',
+    displayName: 'Multi-Modal Sensory Implant',
+    description: 'Combines audio/optical/laser implants.',
+    pipelines: ['sensors', 'to-hit'],
+  }),
+  bioware({
+    id: 'enh_mm_implants',
+    displayName: 'Enhanced Multi-Modal Implants',
+    description: 'Upgraded combined sensory package.',
+    pipelines: ['sensors', 'to-hit'],
+  }),
+  bioware({
+    id: 'comm_implant',
+    displayName: 'Cybernetic Comm Implant',
+    description: '-1 LRM spotting; -1 mine spotting.',
+    pipelines: ['to-hit'],
+  }),
+  bioware({
+    id: 'boost_comm_implant',
+    displayName: 'Boosted Comm Implant',
+    description: 'Comm implant features plus a C3i node.',
+    pipelines: ['to-hit', 'special'],
+  }),
+  bioware({
+    id: 'dermal_armor',
+    displayName: 'Myomer Implants: Dermal Armor',
+    description: 'Incoming damage reduced.',
+    pipelines: ['damage'],
+  }),
+  bioware({
+    id: 'dermal_camo_armor',
+    displayName: 'Myomer Implants: Camouflage Armor',
+    description: 'Camouflage bonuses to concealment.',
+    pipelines: ['to-hit'],
+  }),
+  bioware({
+    id: 'tsm_implant',
+    displayName: 'Myomer Implants: Triple Strength',
+    description: 'Enhanced physical attack damage.',
+    pipelines: ['damage'],
+  }),
+  bioware({
+    id: 'triple_core_processor',
+    displayName: 'Triple-Core Processor',
+    description: 'Combined combat and data-processing bonus.',
+    pipelines: ['initiative', 'to-hit'],
+  }),
+  bioware({
+    id: 'filtration_implants',
+    displayName: 'Filtration Implants',
+    description: 'Environmental hazard immunity (toxins, low-atmo).',
+    pipelines: ['special'],
+  }),
+  bioware({
+    id: 'gas_effuser_pheromone',
+    displayName: 'Gas Effuser: Pheromone',
+    description:
+      'Area effect (pheromone) — area/psi support (not yet simulated).',
+    pipelines: ['special'],
+  }),
+  bioware({
+    id: 'gas_effuser_toxin',
+    displayName: 'Gas Effuser: Toxin',
+    description: 'Area effect (toxin) — area/psi support (not yet simulated).',
+    pipelines: ['special'],
+  }),
+  bioware({
+    id: 'proto_dni',
+    displayName: 'Prototype Direct Neural Interface',
+    description: 'Early-generation DNI implant — reduced neural bandwidth.',
+    pipelines: ['to-hit', 'psr'],
+  }),
+  bioware({
+    id: 'suicide_implants',
+    displayName: 'Explosive Suicide Implants',
+    description: 'Self-destruct on capture. Not simulated in combat.',
+    pipelines: ['special'],
+  }),
+];

--- a/src/lib/spa/catalog/builders.ts
+++ b/src/lib/spa/catalog/builders.ts
@@ -1,0 +1,75 @@
+/**
+ * Small constructor helpers for the SPA catalog data files. Keeps each
+ * per-category table legible by eliding the fields that default for that
+ * category (e.g. gunnery entries default xpCost=20, pipelines=['to-hit']).
+ */
+
+import type { ISPADefinition } from '@/types/spa/SPADefinition';
+
+type CoreFields = Pick<ISPADefinition, 'id' | 'displayName' | 'description'>;
+type Overrides = CoreFields & Partial<ISPADefinition>;
+
+export function gunnery(overrides: Overrides): ISPADefinition {
+  return {
+    category: 'gunnery',
+    source: 'CamOps',
+    xpCost: 20,
+    isFlaw: false,
+    isOriginOnly: false,
+    pipelines: ['to-hit'],
+    requiresDesignation: false,
+    ...overrides,
+  };
+}
+
+export function piloting(overrides: Overrides): ISPADefinition {
+  return {
+    category: 'piloting',
+    source: 'CamOps',
+    xpCost: 20,
+    isFlaw: false,
+    isOriginOnly: false,
+    pipelines: ['psr'],
+    requiresDesignation: false,
+    ...overrides,
+  };
+}
+
+export function support(overrides: Overrides): ISPADefinition {
+  return {
+    category: 'miscellaneous',
+    source: 'CamOps',
+    xpCost: 20,
+    isFlaw: false,
+    isOriginOnly: false,
+    pipelines: [],
+    requiresDesignation: false,
+    ...overrides,
+  };
+}
+
+export function bioware(overrides: Overrides): ISPADefinition {
+  return {
+    category: 'bioware',
+    source: 'ManeiDomini',
+    xpCost: null,
+    isFlaw: false,
+    isOriginOnly: true,
+    pipelines: ['special'],
+    requiresDesignation: false,
+    ...overrides,
+  };
+}
+
+export function edge(overrides: Overrides): ISPADefinition {
+  return {
+    category: 'edge',
+    source: 'CamOps',
+    xpCost: null,
+    isFlaw: false,
+    isOriginOnly: false,
+    pipelines: ['special'],
+    requiresDesignation: false,
+    ...overrides,
+  };
+}

--- a/src/lib/spa/catalog/edgeSPAs.ts
+++ b/src/lib/spa/catalog/edgeSPAs.ts
@@ -1,0 +1,67 @@
+/**
+ * Edge triggers — reroll abilities for specific failure types (11).
+ * Source: MegaMek OptionsConstants.java — edge trigger block.
+ */
+
+import type { ISPADefinition } from '@/types/spa/SPADefinition';
+
+import { edge } from './builders';
+
+export const EDGE_SPAS: readonly ISPADefinition[] = [
+  edge({
+    id: 'edge_when_headhit',
+    displayName: 'Edge: Head Hit',
+    description: 'Reroll a head hit.',
+  }),
+  edge({
+    id: 'edge_when_tac',
+    displayName: 'Edge: Through Armor Crit',
+    description: 'Reroll a through-armor critical.',
+  }),
+  edge({
+    id: 'edge_when_ko',
+    displayName: 'Edge: Pilot KO',
+    description: 'Reroll a pilot-blackout consciousness check.',
+  }),
+  edge({
+    id: 'edge_when_explosion',
+    displayName: 'Edge: Critical Explosion',
+    description: 'Reroll a critical that would trigger an ammo explosion.',
+  }),
+  edge({
+    id: 'edge_when_masc_fails',
+    displayName: 'Edge: MASC / Supercharger Failure',
+    description: 'Reroll a MASC / Supercharger failure check.',
+  }),
+  edge({
+    id: 'edge_when_aero_alt_loss',
+    displayName: 'Edge: Aero Altitude Loss',
+    description: 'Reroll an atmospheric altitude-loss check.',
+  }),
+  edge({
+    id: 'edge_when_aero_explosion',
+    displayName: 'Edge: Aero Critical Explosion',
+    description: 'Reroll an aero critical explosion.',
+  }),
+  edge({
+    id: 'edge_when_aero_ko',
+    displayName: 'Edge: Aero Pilot KO',
+    description: 'Reroll an aerospace / Conventional / Small-Craft pilot KO.',
+  }),
+  edge({
+    id: 'edge_when_aero_lucky_crit',
+    displayName: 'Edge: Aero Lucky Crit',
+    description: 'Reroll an aerospace crit triggered by a natural 12.',
+  }),
+  edge({
+    id: 'edge_when_aero_nuke_crit',
+    displayName: 'Edge: Aero Nuke Crit',
+    description: 'Reroll a nuclear missile SI damage roll.',
+  }),
+  edge({
+    id: 'edge_when_aero_unit_cargo_lost',
+    displayName: 'Edge: Transport Cargo Lost',
+    description:
+      'Reroll a transported-unit-loss check (DropShip / JumpShip / WarShip / Space Station).',
+  }),
+];

--- a/src/lib/spa/catalog/gunnerySPAs.ts
+++ b/src/lib/spa/catalog/gunnerySPAs.ts
@@ -1,0 +1,98 @@
+/**
+ * Gunnery-category SPAs (13).
+ * Source: MegaMek OptionsConstants.java — gunnery abilities block.
+ */
+
+import type { ISPADefinition } from '@/types/spa/SPADefinition';
+
+import { gunnery } from './builders';
+
+export const GUNNERY_SPAS: readonly ISPADefinition[] = [
+  gunnery({
+    id: 'blood_stalker',
+    displayName: 'Blood Stalker',
+    description: '-1 to-hit vs designated target, +2 vs all others.',
+    requiresDesignation: true,
+    designationType: 'target',
+  }),
+  gunnery({
+    id: 'cluster_hitter',
+    displayName: 'Cluster Hitter',
+    description: '+1 column on the cluster hit table.',
+    pipelines: ['damage'],
+  }),
+  gunnery({
+    id: 'cluster_master',
+    displayName: 'Cluster Master',
+    description: '+2 columns on the cluster hit table.',
+    source: 'Unofficial',
+    pipelines: ['damage'],
+  }),
+  gunnery({
+    id: 'golden_goose',
+    displayName: 'Golden Goose',
+    description: 'Reduced bombing to-hit penalty and scatter distance.',
+    pipelines: ['to-hit'],
+  }),
+  gunnery({
+    id: 'specialist',
+    displayName: 'Gunnery Specialization',
+    description: '-1 to-hit with chosen weapon category; +1 with all others.',
+    requiresDesignation: true,
+    designationType: 'weapon_category',
+  }),
+  gunnery({
+    id: 'multi_tasker',
+    displayName: 'Multi-Tasker',
+    description: '-1 to secondary target penalty.',
+  }),
+  gunnery({
+    id: 'oblique_artillery',
+    displayName: 'Oblique Artilleryman',
+    description: 'Reduced artillery scatter (-2 hexes).',
+    pipelines: ['damage'],
+  }),
+  gunnery({
+    id: 'oblique_attacker',
+    displayName: 'Oblique Attacker',
+    description:
+      '-1 indirect fire penalty; may fire indirect without a spotter at -1.',
+  }),
+  gunnery({
+    id: 'range_master',
+    displayName: 'Range Master',
+    description:
+      'Swap designated range bracket with another — medium for short, long for medium, etc.',
+    requiresDesignation: true,
+    designationType: 'range_bracket',
+  }),
+  gunnery({
+    id: 'sandblaster',
+    displayName: 'Sandblaster',
+    description:
+      '+4/+3/+2 cluster-table columns at short/medium/long range with designated weapon.',
+    requiresDesignation: true,
+    designationType: 'weapon_type',
+    pipelines: ['damage'],
+  }),
+  gunnery({
+    id: 'sniper',
+    displayName: 'Sniper',
+    description: 'Halves all positive range modifiers (round down).',
+  }),
+  gunnery({
+    id: 'weapon_specialist',
+    displayName: 'Weapon Specialist',
+    description: '-2 to-hit with the designated weapon type.',
+    requiresDesignation: true,
+    designationType: 'weapon_type',
+  }),
+  gunnery({
+    id: 'aptitude_gunnery',
+    displayName: 'Natural Aptitude: Gunnery',
+    description: 'Roll 3d6 keep best 2 on gunnery checks.',
+    source: 'ATOW',
+    isOriginOnly: true,
+    xpCost: 40,
+  }),
+];

--- a/src/lib/spa/catalog/legacyAliases.ts
+++ b/src/lib/spa/catalog/legacyAliases.ts
@@ -1,0 +1,114 @@
+/**
+ * Legacy SPA id → canonical id mapping.
+ *
+ * System A (campaign acquisition) and System B (combat modifiers) used
+ * different conventions (snake_case vs kebab-case, collapsed names).
+ * Consumers that still pass the old ids resolve through resolveSPAId()
+ * in @/lib/spa without breaking.
+ */
+
+import type { ISPAIdAlias } from '@/types/spa/SPADefinition';
+
+export const SPA_LEGACY_ALIASES: readonly ISPAIdAlias[] = [
+  // -------------------- System A (snake_case, collapsed) --------------------
+  {
+    legacyId: 'fast_learner',
+    canonicalId: 'aptitude_gunnery',
+    source: 'systemA',
+  },
+  { legacyId: 'toughness', canonicalId: 'pain_resistance', source: 'systemA' },
+  {
+    legacyId: 'natural_aptitude',
+    canonicalId: 'aptitude_gunnery',
+    source: 'systemA',
+  },
+  {
+    legacyId: 'slow_learner',
+    canonicalId: 'atow_combat_paralysis',
+    source: 'systemA',
+  },
+  {
+    legacyId: 'glass_jaw',
+    canonicalId: 'atow_combat_paralysis',
+    source: 'systemA',
+  },
+  {
+    legacyId: 'gremlins',
+    canonicalId: 'atow_combat_paralysis',
+    source: 'systemA',
+  },
+
+  // -------------------- System B (kebab-case) --------------------
+  {
+    legacyId: 'weapon-specialist',
+    canonicalId: 'weapon_specialist',
+    source: 'systemB',
+  },
+  {
+    legacyId: 'gunnery-specialist',
+    canonicalId: 'specialist',
+    source: 'systemB',
+  },
+  {
+    legacyId: 'blood-stalker',
+    canonicalId: 'blood_stalker',
+    source: 'systemB',
+  },
+  { legacyId: 'range-master', canonicalId: 'range_master', source: 'systemB' },
+  {
+    legacyId: 'cluster-hitter',
+    canonicalId: 'cluster_hitter',
+    source: 'systemB',
+  },
+  { legacyId: 'multi-tasker', canonicalId: 'multi_tasker', source: 'systemB' },
+  {
+    legacyId: 'oblique-attacker',
+    canonicalId: 'oblique_attacker',
+    source: 'systemB',
+  },
+  {
+    legacyId: 'melee-specialist',
+    canonicalId: 'melee_specialist',
+    source: 'systemB',
+  },
+  { legacyId: 'melee-master', canonicalId: 'melee_master', source: 'systemB' },
+  {
+    legacyId: 'maneuvering-ace',
+    canonicalId: 'maneuvering_ace',
+    source: 'systemB',
+  },
+  { legacyId: 'jumping-jack', canonicalId: 'jumping_jack', source: 'systemB' },
+  {
+    legacyId: 'cross-country',
+    canonicalId: 'cross_country',
+    source: 'systemB',
+  },
+  { legacyId: 'heavy-lifter', canonicalId: 'hvy_lifter', source: 'systemB' },
+  {
+    legacyId: 'animal-mimicry',
+    canonicalId: 'animal_mimic',
+    source: 'systemB',
+  },
+  {
+    legacyId: 'dodge-maneuver',
+    canonicalId: 'dodge_maneuver',
+    source: 'systemB',
+  },
+  { legacyId: 'iron-man', canonicalId: 'iron_man', source: 'systemB' },
+  {
+    legacyId: 'pain-resistance',
+    canonicalId: 'pain_resistance',
+    source: 'systemB',
+  },
+  {
+    legacyId: 'tactical-genius',
+    canonicalId: 'tactical_genius',
+    source: 'systemB',
+  },
+  { legacyId: 'hot-dog', canonicalId: 'hot_dog', source: 'systemB' },
+  {
+    legacyId: 'some-like-it-hot',
+    canonicalId: 'some_like_it_hot',
+    source: 'systemB',
+  },
+];

--- a/src/lib/spa/catalog/miscAndInfantrySPAs.ts
+++ b/src/lib/spa/catalog/miscAndInfantrySPAs.ts
@@ -1,0 +1,118 @@
+/**
+ * Miscellaneous (7), Infantry (2), and ATOW (2) SPAs.
+ * Source: MegaMek OptionsConstants.java + ATOW supplement.
+ */
+
+import type { ISPADefinition } from '@/types/spa/SPADefinition';
+
+import { support } from './builders';
+
+export const MISC_SPAS: readonly ISPADefinition[] = [
+  support({
+    id: 'eagle_eyes',
+    displayName: "Eagle's Eyes",
+    description: 'Extended sensor range and minefield detection.',
+    pipelines: ['sensors'],
+  }),
+  support({
+    id: 'env_specialist',
+    displayName: 'Environmental Specialist',
+    description:
+      'PSR and movement bonuses in a designated environment type (vacuum, deep water, underground, low-g).',
+    requiresDesignation: true,
+    designationType: 'terrain',
+    pipelines: ['psr', 'movement', 'to-hit'],
+  }),
+  support({
+    id: 'forward_observer',
+    displayName: 'Forward Observer',
+    description: '-2 artillery fire adjustment, -1 gunnery when spotting.',
+    pipelines: ['to-hit'],
+  }),
+  support({
+    id: 'human_tro',
+    displayName: 'Human TRO',
+    description: '+1 column on the critical hit table vs designated unit type.',
+    pipelines: ['critical-hit'],
+    requiresDesignation: true,
+    designationType: 'weapon_type',
+  }),
+  support({
+    id: 'iron_man',
+    displayName: 'Iron Man',
+    description: 'Ammo-explosion damage never exceeds 1 pilot hit.',
+    category: 'toughness',
+    pipelines: ['consciousness'],
+  }),
+  support({
+    id: 'pain_resistance',
+    displayName: 'Pain Resistance',
+    description: '+1 consciousness rolls; ignore first wound penalty.',
+    source: 'MaxTech',
+    category: 'toughness',
+    pipelines: ['consciousness', 'to-hit'],
+  }),
+  support({
+    id: 'tactical_genius',
+    displayName: 'Tactical Genius',
+    description: 'One free initiative reroll per turn.',
+    category: 'tactical',
+    pipelines: ['initiative'],
+  }),
+];
+
+export const INFANTRY_SPAS: readonly ISPADefinition[] = [
+  {
+    id: 'foot_cav',
+    displayName: 'Foot Cavalry',
+    description: '+1 MP on foot; can support dual-weapon carry.',
+    category: 'infantry',
+    source: 'CamOps',
+    xpCost: 15,
+    isFlaw: false,
+    isOriginOnly: false,
+    pipelines: ['movement'],
+    requiresDesignation: false,
+  },
+  {
+    id: 'urban_guerrilla',
+    displayName: 'Urban Guerrilla',
+    description: 'Bonuses to urban concealment, defense, and local support.',
+    category: 'infantry',
+    source: 'CamOps',
+    xpCost: 15,
+    isFlaw: false,
+    isOriginOnly: false,
+    pipelines: ['psr', 'to-hit'],
+    requiresDesignation: false,
+  },
+];
+
+export const ATOW_SPAS: readonly ISPADefinition[] = [
+  {
+    id: 'atow_combat_sense',
+    displayName: 'Combat Sense',
+    description:
+      'Commander rolls 3d6 keep best 2 on initiative; improved situational awareness.',
+    category: 'tactical',
+    source: 'ATOW',
+    xpCost: 50,
+    isFlaw: false,
+    isOriginOnly: true,
+    pipelines: ['initiative'],
+    requiresDesignation: false,
+  },
+  {
+    id: 'atow_combat_paralysis',
+    displayName: 'Combat Paralysis',
+    description:
+      'Commander rolls 3d6 keep lowest 2 on initiative; a battlefield flaw.',
+    category: 'tactical',
+    source: 'ATOW',
+    xpCost: -25,
+    isFlaw: true,
+    isOriginOnly: true,
+    pipelines: ['initiative'],
+    requiresDesignation: false,
+  },
+];

--- a/src/lib/spa/catalog/pilotingSPAs.ts
+++ b/src/lib/spa/catalog/pilotingSPAs.ts
@@ -1,0 +1,142 @@
+/**
+ * Piloting-category SPAs (19).
+ * Source: MegaMek OptionsConstants.java — piloting abilities block.
+ */
+
+import type { ISPADefinition } from '@/types/spa/SPADefinition';
+
+import { piloting } from './builders';
+
+export const PILOTING_SPAS: readonly ISPADefinition[] = [
+  piloting({
+    id: 'animal_mimic',
+    displayName: 'Animal Mimicry',
+    description: 'Specialized movement and PSR in chosen terrain type.',
+    pipelines: ['psr', 'movement'],
+    requiresDesignation: true,
+    designationType: 'terrain',
+  }),
+  piloting({
+    id: 'cross_country',
+    displayName: 'Cross-Country',
+    description: 'Reduces movement penalties across rough terrain.',
+    pipelines: ['movement'],
+  }),
+  piloting({
+    id: 'dodge_maneuver',
+    displayName: 'Dodge',
+    description:
+      'Forfeit attack to impose +2 to-hit on physical attacks against this unit.',
+    source: 'MaxTech',
+    category: 'defensive',
+    pipelines: ['to-hit'],
+  }),
+  piloting({
+    id: 'hvy_lifter',
+    displayName: 'Heavy Lifter',
+    description: '+50% cargo/lift capacity for physical attacks and carries.',
+    pipelines: ['special'],
+  }),
+  piloting({
+    id: 'hopping_jack',
+    displayName: 'Hopping Jack',
+    description: 'Jump attack to-hit penalty reduced from +3 to +2.',
+    source: 'Unofficial',
+    pipelines: ['to-hit'],
+  }),
+  piloting({
+    id: 'hot_dog',
+    displayName: 'Hot Dog',
+    description: '-1 to shutdown and ammo-explosion avoidance rolls from heat.',
+    pipelines: ['heat'],
+    category: 'miscellaneous',
+  }),
+  piloting({
+    id: 'jumping_jack',
+    displayName: 'Jumping Jack',
+    description: 'Jump attack to-hit penalty reduced from +3 to +1.',
+    pipelines: ['to-hit'],
+  }),
+  piloting({
+    id: 'maneuvering_ace',
+    displayName: 'Maneuvering Ace',
+    description:
+      'May use lateral shift; -1 PSR for terrain and facing changes.',
+    pipelines: ['psr', 'movement'],
+  }),
+  piloting({
+    id: 'melee_master',
+    displayName: 'Melee Master',
+    description: 'One additional physical attack per turn.',
+    pipelines: ['special'],
+    category: 'gunnery',
+  }),
+  piloting({
+    id: 'melee_specialist',
+    displayName: 'Melee Specialist',
+    description: '+1 damage and -1 to-hit on physical attacks.',
+    pipelines: ['to-hit', 'damage'],
+    category: 'gunnery',
+  }),
+  piloting({
+    id: 'shaky_stick',
+    displayName: 'Shaky Stick',
+    description: '+1 enemy to-hit with indirect fire against this unit.',
+    pipelines: ['to-hit'],
+    category: 'defensive',
+  }),
+  piloting({
+    id: 'tm_forest_ranger',
+    displayName: 'Terrain Master: Forest Ranger',
+    description: 'Woods/jungle movement + gunnery bonuses.',
+    pipelines: ['movement', 'to-hit', 'psr'],
+  }),
+  piloting({
+    id: 'tm_frogman',
+    displayName: 'Terrain Master: Frogman',
+    description: 'Water movement bonuses; extended crush-depth tolerance.',
+    pipelines: ['movement', 'psr'],
+  }),
+  piloting({
+    id: 'tm_mountaineer',
+    displayName: 'Terrain Master: Mountaineer',
+    description: 'Rubble/rough/elevation movement bonuses.',
+    pipelines: ['movement', 'psr'],
+  }),
+  piloting({
+    id: 'tm_nightwalker',
+    displayName: 'Terrain Master: Nightwalker',
+    description: 'Ignore darkness movement and gunnery penalties.',
+    pipelines: ['movement', 'to-hit'],
+  }),
+  piloting({
+    id: 'tm_swamp_beast',
+    displayName: 'Terrain Master: Swamp Beast',
+    description: 'Mud/swamp movement + gunnery bonuses.',
+    pipelines: ['movement', 'to-hit'],
+  }),
+  piloting({
+    id: 'zweihander',
+    displayName: 'Zweihander',
+    description: 'Two-handed weapon strike: extra damage at to-hit penalty.',
+    pipelines: ['damage', 'to-hit'],
+    category: 'gunnery',
+  }),
+  piloting({
+    id: 'atow_g_tolerance',
+    displayName: 'G-Tolerance',
+    description: '+1 aerospace/VTOL control rolls under high-G maneuvers.',
+    source: 'ATOW',
+    category: 'miscellaneous',
+    pipelines: ['psr'],
+  }),
+  piloting({
+    id: 'aptitude_piloting',
+    displayName: 'Natural Aptitude: Piloting',
+    description: 'Roll 3d6 keep best 2 on piloting checks.',
+    source: 'ATOW',
+    isOriginOnly: true,
+    xpCost: 40,
+    pipelines: ['psr'],
+  }),
+];

--- a/src/lib/spa/catalog/unofficialSPAs.ts
+++ b/src/lib/spa/catalog/unofficialSPAs.ts
@@ -1,0 +1,96 @@
+/**
+ * Unofficial / legacy SPAs (11).
+ * Source: MegaMek OptionsConstants.java — unofficial flags block.
+ */
+
+import type { ISPADefinition } from '@/types/spa/SPADefinition';
+
+import { gunnery, support } from './builders';
+
+export const UNOFFICIAL_SPAS: readonly ISPADefinition[] = [
+  {
+    id: 'ei_implant',
+    displayName: 'EI Implant',
+    description: 'Legacy Clan Enhanced Imaging system.',
+    category: 'bioware',
+    source: 'Legacy',
+    xpCost: null,
+    isFlaw: false,
+    isOriginOnly: true,
+    pipelines: ['to-hit'],
+    requiresDesignation: false,
+  },
+  gunnery({
+    id: 'gunnery_laser',
+    displayName: 'Gunnery: Energy',
+    description: 'Unofficial specialization: -1 to-hit with energy weapons.',
+    source: 'Unofficial',
+    requiresDesignation: false,
+  }),
+  gunnery({
+    id: 'gunnery_missile',
+    displayName: 'Gunnery: Missile',
+    description: 'Unofficial specialization: -1 to-hit with missile weapons.',
+    source: 'Unofficial',
+  }),
+  gunnery({
+    id: 'gunnery_ballistic',
+    displayName: 'Gunnery: Ballistic',
+    description: 'Unofficial specialization: -1 to-hit with ballistic weapons.',
+    source: 'Unofficial',
+  }),
+  support({
+    id: 'clan_pilot_training',
+    displayName: 'Clan Pilot Training',
+    description: 'Unofficial flaw: +1 physical attack penalty.',
+    source: 'Unofficial',
+    category: 'piloting',
+    isFlaw: true,
+    xpCost: -15,
+    pipelines: ['to-hit'],
+  }),
+  support({
+    id: 'some_like_it_hot',
+    displayName: 'Some Like It Hot',
+    description:
+      'Unofficial: removes one point of heat-induced to-hit penalty.',
+    source: 'Unofficial',
+    pipelines: ['heat', 'to-hit'],
+  }),
+  support({
+    id: 'weathered',
+    displayName: 'Weathered',
+    description: 'Ignore weather-related gunnery penalties.',
+    source: 'Unofficial',
+    pipelines: ['to-hit'],
+  }),
+  support({
+    id: 'allweather',
+    displayName: 'All Weather',
+    description: 'Ignore weather-related PSR penalties.',
+    source: 'Unofficial',
+    pipelines: ['psr'],
+  }),
+  support({
+    id: 'blind_fighter',
+    displayName: 'Blind Fighter',
+    description: 'Ignore darkness-related gunnery penalties.',
+    source: 'Unofficial',
+    pipelines: ['to-hit'],
+  }),
+  support({
+    id: 'sensor_geek',
+    displayName: 'Sensor Geek',
+    description: '-2 bonus on sensor detection checks.',
+    source: 'Unofficial',
+    pipelines: ['sensors'],
+  }),
+  support({
+    id: 'small_pilot',
+    displayName: 'Small Pilot',
+    description: 'Fits in small cockpits without the usual skill penalty.',
+    source: 'Unofficial',
+    pipelines: ['special'],
+    isOriginOnly: true,
+  }),
+];

--- a/src/lib/spa/index.ts
+++ b/src/lib/spa/index.ts
@@ -1,0 +1,116 @@
+/**
+ * Unified SPA loader and query API.
+ *
+ * Public entry point for the canonical SPA catalog. Provides id lookup
+ * (with legacy-alias resolution), category / pipeline / source filters,
+ * and predicates consumers use for random selection and UI filtering.
+ */
+
+import type {
+  ISPADefinition,
+  SPACategory,
+  SPAPipeline,
+  SPASource,
+} from '@/types/spa/SPADefinition';
+
+import {
+  CANONICAL_SPA_CATALOG,
+  CANONICAL_SPA_LIST,
+  SPA_LEGACY_ALIASES,
+} from './canonicalCatalog';
+
+// Precompute alias map for O(1) legacy-id resolution.
+const LEGACY_ID_MAP: ReadonlyMap<string, string> = new Map(
+  SPA_LEGACY_ALIASES.map((a) => [a.legacyId, a.canonicalId]),
+);
+
+/**
+ * Resolve an SPA id. Returns the canonical id if the input is already
+ * canonical; otherwise looks up the legacy alias table; returns null if
+ * the id is unknown in either form.
+ */
+export function resolveSPAId(rawId: string): string | null {
+  if (CANONICAL_SPA_CATALOG[rawId]) return rawId;
+  return LEGACY_ID_MAP.get(rawId) ?? null;
+}
+
+/**
+ * Look up a definition by id. Accepts canonical or legacy ids and returns
+ * null when the id is unknown — callers that want to throw should assert.
+ */
+export function getSPADefinition(rawId: string): ISPADefinition | null {
+  const canonicalId = resolveSPAId(rawId);
+  if (!canonicalId) return null;
+  return CANONICAL_SPA_CATALOG[canonicalId] ?? null;
+}
+
+/** All SPA definitions in catalog order. */
+export function getAllSPAs(): readonly ISPADefinition[] {
+  return CANONICAL_SPA_LIST;
+}
+
+/** Filter the catalog by category. */
+export function getSPAsByCategory(
+  category: SPACategory,
+): readonly ISPADefinition[] {
+  return CANONICAL_SPA_LIST.filter((spa) => spa.category === category);
+}
+
+/** Filter the catalog by source rulebook. */
+export function getSPAsBySource(source: SPASource): readonly ISPADefinition[] {
+  return CANONICAL_SPA_LIST.filter((spa) => spa.source === source);
+}
+
+/** Filter the catalog by the combat pipeline an SPA affects. */
+export function getSPAsForPipeline(
+  pipeline: SPAPipeline,
+): readonly ISPADefinition[] {
+  return CANONICAL_SPA_LIST.filter((spa) => spa.pipelines.includes(pipeline));
+}
+
+/** All purchasable SPAs (xpCost is non-null) excluding flaws. */
+export function getPurchasableSPAs(): readonly ISPADefinition[] {
+  return CANONICAL_SPA_LIST.filter((spa) => spa.xpCost !== null && !spa.isFlaw);
+}
+
+/** All flaws — separated so they can be weighted independently in rolls. */
+export function getFlaws(): readonly ISPADefinition[] {
+  return CANONICAL_SPA_LIST.filter((spa) => spa.isFlaw);
+}
+
+/** All origin-only abilities — not available via normal advancement. */
+export function getOriginOnlySPAs(): readonly ISPADefinition[] {
+  return CANONICAL_SPA_LIST.filter((spa) => spa.isOriginOnly);
+}
+
+/** True when every id in `abilities` resolves to a canonical SPA. */
+export function areSPAIdsValid(abilities: readonly string[]): boolean {
+  return abilities.every((id) => resolveSPAId(id) !== null);
+}
+
+/** Map a list of (possibly legacy) ids to their canonical forms, dropping unknowns. */
+export function canonicalizeSPAIds(
+  abilities: readonly string[],
+): readonly string[] {
+  const out: string[] = [];
+  for (const id of abilities) {
+    const canon = resolveSPAId(id);
+    if (canon) out.push(canon);
+  }
+  return out;
+}
+
+// Re-export the raw data structures for consumers that need them.
+export {
+  CANONICAL_SPA_CATALOG,
+  CANONICAL_SPA_LIST,
+  SPA_LEGACY_ALIASES,
+} from './canonicalCatalog';
+export type {
+  ISPADefinition,
+  ISPAIdAlias,
+  SPACategory,
+  SPAPipeline,
+  SPASource,
+  SPADesignationType,
+} from '@/types/spa/SPADefinition';

--- a/src/types/spa/SPADefinition.ts
+++ b/src/types/spa/SPADefinition.ts
@@ -1,0 +1,145 @@
+/**
+ * Unified Special Pilot Ability (SPA) type definitions.
+ *
+ * Merges the two prior SPA systems (campaign acquisition + combat
+ * modifiers) into a single shape so there's one source of truth that
+ * covers every field either system needs:
+ *
+ *  - acquisition: xpCost, isFlaw, isOriginOnly
+ *  - combat:      category, pipelines, combatEffect, requiresDesignation
+ *  - general:     id, displayName, description, source rulebook
+ *
+ * Canonical IDs use snake_case to match MegaMek's OptionsConstants
+ * (`weapon_specialist`, `iron_man`, etc.). The existing systems use
+ * mixed forms — adapters in `@/lib/spa` resolve those to canonical ids.
+ */
+
+// =============================================================================
+// Categories / pipelines
+// =============================================================================
+
+/**
+ * Functional grouping used by the pilot UI and record sheet.
+ * Extends the original gunnery / piloting / etc. taxonomy to cover MegaMek's
+ * full roster, including the Manei Domini bioware set and Edge triggers.
+ */
+export type SPACategory =
+  | 'gunnery'
+  | 'piloting'
+  | 'defensive'
+  | 'toughness'
+  | 'tactical'
+  | 'infantry'
+  | 'bioware'
+  | 'edge'
+  | 'miscellaneous';
+
+/**
+ * Combat resolution pipeline(s) an SPA touches. The combat layer uses this
+ * to dispatch modifier calculations.
+ */
+export type SPAPipeline =
+  | 'to-hit'
+  | 'damage'
+  | 'psr'
+  | 'heat'
+  | 'initiative'
+  | 'consciousness'
+  | 'movement'
+  | 'critical-hit'
+  | 'sensors'
+  | 'special';
+
+/**
+ * Rulebook / supplement the SPA was introduced in. Used by the UI so players
+ * can filter to abilities legal in their campaign.
+ */
+export type SPASource =
+  | 'CamOps'
+  | 'MaxTech'
+  | 'ATOW'
+  | 'ManeiDomini'
+  | 'Unofficial'
+  | 'Legacy';
+
+/**
+ * What kind of designation the SPA asks for at selection time (e.g. Weapon
+ * Specialist designates a weapon type; Range Master designates a range band).
+ */
+export type SPADesignationType =
+  | 'weapon_type'
+  | 'weapon_category'
+  | 'target'
+  | 'range_bracket'
+  | 'skill'
+  | 'terrain';
+
+// =============================================================================
+// Unified SPA definition
+// =============================================================================
+
+/**
+ * Canonical definition of a single SPA. Every field is nullable/optional
+ * where it isn't universally applicable — Manei Domini implants don't have
+ * an XP cost, Edge triggers don't have a `combatEffect` string, etc.
+ */
+export interface ISPADefinition {
+  /** Canonical snake_case id matching MegaMek OptionsConstants. */
+  readonly id: string;
+  /** Human-readable name shown in the pilot UI. */
+  readonly displayName: string;
+  /** One-line summary of the ability. */
+  readonly description: string;
+  /** Functional grouping for UI + filters. */
+  readonly category: SPACategory;
+  /** Which rulebook introduced it. */
+  readonly source: SPASource;
+
+  // ---- Acquisition-layer fields -----------------------------------------
+
+  /** XP cost to purchase (negative for flaws that grant XP). `null` when
+   *  the ability is not purchasable via normal advancement (e.g. bioware,
+   *  edge triggers, origin-only abilities with no XP price). */
+  readonly xpCost: number | null;
+  /** Marks flaws — abilities the player takes for negative effects in
+   *  exchange for XP. Excluded from positive-trait random rolls. */
+  readonly isFlaw: boolean;
+  /** Abilities only acquirable at character creation (Natural Aptitude etc). */
+  readonly isOriginOnly: boolean;
+
+  // ---- Combat-layer fields ----------------------------------------------
+
+  /** Which combat pipelines this SPA affects. Empty for abilities with
+   *  no in-combat effect (e.g. campaign-only flaws). */
+  readonly pipelines: readonly SPAPipeline[];
+  /** Short human description of the combat effect (for tooltips). */
+  readonly combatEffect?: string;
+  /** Whether this SPA asks the player to designate a weapon / target / etc. */
+  readonly requiresDesignation: boolean;
+  /** What kind of designation is needed, when `requiresDesignation` is true. */
+  readonly designationType?: SPADesignationType;
+}
+
+/**
+ * Alias entry: legacy id (from System A or System B) → canonical id.
+ * Used by the loader so old consumers keep working during the migration.
+ */
+export interface ISPAIdAlias {
+  readonly legacyId: string;
+  readonly canonicalId: string;
+  readonly source: 'systemA' | 'systemB' | 'megamek-legacy';
+}
+
+// =============================================================================
+// Helper predicates
+// =============================================================================
+
+/** Narrowing helper — true iff the ability is purchasable. */
+export function isPurchasableSPA(spa: ISPADefinition): boolean {
+  return spa.xpCost !== null;
+}
+
+/** Narrowing helper — true iff the ability has any combat effect. */
+export function isCombatActiveSPA(spa: ISPADefinition): boolean {
+  return spa.pipelines.length > 0;
+}


### PR DESCRIPTION
## Summary
First of four SPA-unification PRs. Imports the full MegaMek roster into a single source of truth so subsequent work (combat wiring, pilot UI, random selection) has one catalog to reach for.

**Roster (91 canonical entries):**
- 19 Piloting (Terrain Masters, Maneuvering Ace, Jumping Jack, …)
- 13 Gunnery (Weapon Specialist, Sniper, Sandblaster, Blood Stalker, …)
- 7 Miscellaneous + 2 Infantry + 2 aToW (Tactical Genius, Iron Man, Combat Sense, …)
- 26 Manei Domini bioware (VDNI, TSM implant, prosthetics, …)
- 11 Unofficial / legacy (EI Implant, Gunnery: Energy/Missile/Ballistic, …)
- 11 Edge triggers (head hit, TAC, pilot KO, aero variants)

Legacy id aliases (snake_case System A ids + kebab-case System B ids) map to canonical form via `resolveSPAId()` so existing consumers in `src/lib/campaign/progression/spaAcquisition.ts` and `src/utils/gameplay/spaModifiers/catalog.ts` continue to work without a flag-day migration. Subsequent PRs will migrate those consumers to read from the unified catalog.

Files are split by category to stay under the 400-line max-lines cap.

## Test plan
- [x] `npx jest src/lib/spa/__tests__/canonicalCatalog.test.ts` — 26/26 passing
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeded (husky pre-push)

## Followups (tracked for 5b / 5c / 5d)
- [ ] Migrate System B combat wiring to read from the unified catalog
- [ ] Pilot UI + record-sheet display from the unified catalog
- [ ] Random SPA selection (PilotService.ts:146) uses the unified catalog