### PR TITLE
feat(combat): bridge spaModifiers through the unified SPA catalog

### DIFF
--- a/src/lib/spa/catalog/legacyAliases.ts
+++ b/src/lib/spa/catalog/legacyAliases.ts
@@ -95,6 +95,8 @@ export const SPA_LEGACY_ALIASES: readonly ISPAIdAlias[] = [
     source: 'systemB',
   },
   { legacyId: 'iron-man', canonicalId: 'iron_man', source: 'systemB' },
+  { legacyId: 'iron-will', canonicalId: 'iron_man', source: 'systemB' },
+  { legacyId: 'iron_will', canonicalId: 'iron_man', source: 'systemB' },
   {
     legacyId: 'pain-resistance',
     canonicalId: 'pain_resistance',

--- a/src/utils/gameplay/spaModifiers/__tests__/canonicalize.test.ts
+++ b/src/utils/gameplay/spaModifiers/__tests__/canonicalize.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the canonicalization bridge between pilot ability ids and
+ * the unified SPA catalog. Confirms that each combat modifier fires
+ * regardless of whether the pilot record uses legacy System B ids
+ * (kebab-case) or the canonical snake_case ids introduced in the
+ * unified catalog.
+ */
+
+import { MovementType, RangeBracket } from '@/types/gameplay';
+
+import {
+  calculateBloodStalkerModifier,
+  calculateDodgeManeuverModifier,
+  calculateJumpingJackModifier,
+  calculateMeleeSpecialistModifier,
+  calculateMultiTaskerModifier,
+  getClusterHitterBonus,
+  getHotDogShutdownThresholdBonus,
+  getIronManModifier,
+  getMeleeMasterDamageBonus,
+  getTacticalGeniusBonus,
+} from '../abilityModifiers';
+import { hasSPA } from '../canonicalize';
+import {
+  getConsciousnessCheckModifier,
+  getObliqueAttackerBonus,
+  hasSPA as catalogHasSPA,
+} from '../catalog';
+import {
+  calculateGunnerySpecialistModifier,
+  calculateRangeMasterModifier,
+  calculateSniperModifier,
+  calculateWeaponSpecialistModifier,
+} from '../weaponSpecialists';
+
+describe('hasSPA bridge', () => {
+  it('matches the canonical snake_case id directly', () => {
+    expect(hasSPA(['weapon_specialist'], 'weapon_specialist')).toBe(true);
+  });
+
+  it('resolves the legacy kebab-case id', () => {
+    expect(hasSPA(['weapon-specialist'], 'weapon_specialist')).toBe(true);
+  });
+
+  it('returns false for unrelated ids', () => {
+    expect(hasSPA(['sniper'], 'weapon_specialist')).toBe(false);
+  });
+
+  it('returns false for empty arrays', () => {
+    expect(hasSPA([], 'weapon_specialist')).toBe(false);
+  });
+});
+
+describe('combat modifiers accept canonical ids', () => {
+  it('Weapon Specialist fires on canonical id', () => {
+    const mod = calculateWeaponSpecialistModifier(
+      ['weapon_specialist'],
+      'large_laser',
+      'large_laser',
+    );
+    expect(mod?.value).toBe(-2);
+  });
+
+  it('Gunnery Specialist fires on canonical id', () => {
+    const mod = calculateGunnerySpecialistModifier(
+      ['specialist'],
+      'energy',
+      'energy',
+    );
+    expect(mod?.value).toBe(-1);
+  });
+
+  it('Blood Stalker fires on canonical id', () => {
+    const mod = calculateBloodStalkerModifier(
+      ['blood_stalker'],
+      'tgt-1',
+      'tgt-1',
+    );
+    expect(mod?.value).toBe(-1);
+  });
+
+  it('Range Master fires on canonical id', () => {
+    const mod = calculateRangeMasterModifier(
+      ['range_master'],
+      RangeBracket.Short,
+      RangeBracket.Short,
+      2,
+    );
+    expect(mod?.value).toBe(-2);
+  });
+
+  it('Sniper fires on canonical id', () => {
+    const mod = calculateSniperModifier(['sniper'], 4);
+    expect(mod?.value).toBe(-2);
+  });
+
+  it('Multi-Tasker fires on canonical id', () => {
+    const mod = calculateMultiTaskerModifier(['multi_tasker'], true);
+    expect(mod?.value).toBe(-1);
+  });
+
+  it('Jumping Jack fires on canonical id', () => {
+    const mod = calculateJumpingJackModifier(
+      ['jumping_jack'],
+      MovementType.Jump,
+    );
+    expect(mod?.value).toBe(-2);
+  });
+
+  it('Dodge Maneuver fires on canonical id', () => {
+    const mod = calculateDodgeManeuverModifier(['dodge_maneuver'], true);
+    expect(mod?.value).toBe(2);
+  });
+
+  it('Melee Specialist fires on canonical id', () => {
+    const mod = calculateMeleeSpecialistModifier(['melee_specialist']);
+    expect(mod?.value).toBe(-1);
+  });
+
+  it('getMeleeMasterDamageBonus fires on canonical id', () => {
+    expect(getMeleeMasterDamageBonus(['melee_master'])).toBe(1);
+  });
+
+  it('getTacticalGeniusBonus fires on canonical id', () => {
+    expect(getTacticalGeniusBonus(['tactical_genius'])).toBe(1);
+  });
+
+  it('getIronManModifier fires on canonical id', () => {
+    expect(getIronManModifier(['iron_man'])).toBe(-2);
+  });
+
+  it('getClusterHitterBonus fires on canonical id', () => {
+    expect(getClusterHitterBonus(['cluster_hitter'])).toBe(1);
+  });
+
+  it('getHotDogShutdownThresholdBonus fires on canonical id', () => {
+    expect(getHotDogShutdownThresholdBonus(['hot_dog'])).toBe(3);
+  });
+
+  it('getObliqueAttackerBonus fires on canonical id', () => {
+    expect(getObliqueAttackerBonus(['oblique_attacker'])).toBe(-1);
+  });
+
+  it('getConsciousnessCheckModifier combines canonical ids', () => {
+    expect(getConsciousnessCheckModifier(['iron_man', 'pain_resistance'])).toBe(
+      -3,
+    );
+  });
+
+  it('catalog.hasSPA resolves via canonical bridge', () => {
+    expect(catalogHasSPA(['iron-man'], 'iron_man')).toBe(true);
+    expect(catalogHasSPA(['iron_man'], 'iron_man')).toBe(true);
+  });
+});

--- a/src/utils/gameplay/spaModifiers/abilityModifiers.ts
+++ b/src/utils/gameplay/spaModifiers/abilityModifiers.ts
@@ -7,6 +7,8 @@
 import { MovementType } from '@/types/gameplay';
 import { IToHitModifierDetail } from '@/types/gameplay';
 
+import { hasSPA } from './canonicalize';
+
 /**
  * Blood Stalker: -1 vs designated target, +2 vs all others.
  */
@@ -15,7 +17,7 @@ export function calculateBloodStalkerModifier(
   targetId?: string,
   designatedTargetId?: string,
 ): IToHitModifierDetail | null {
-  if (!abilities.includes('blood-stalker')) return null;
+  if (!hasSPA(abilities, 'blood_stalker')) return null;
   if (!targetId || !designatedTargetId) return null;
 
   const isDesignated = targetId === designatedTargetId;
@@ -36,7 +38,7 @@ export function calculateMultiTaskerModifier(
   abilities: readonly string[],
   isSecondaryTarget?: boolean,
 ): IToHitModifierDetail | null {
-  if (!abilities.includes('multi-tasker')) return null;
+  if (!hasSPA(abilities, 'multi_tasker')) return null;
   if (!isSecondaryTarget) return null;
 
   return {
@@ -53,7 +55,7 @@ export function calculateMultiTaskerModifier(
  * Used when resolving cluster weapon hits.
  */
 export function getClusterHitterBonus(abilities: readonly string[]): number {
-  return abilities.includes('cluster-hitter') ? 1 : 0;
+  return hasSPA(abilities, 'cluster_hitter') ? 1 : 0;
 }
 
 /**
@@ -63,7 +65,7 @@ export function calculateJumpingJackModifier(
   abilities: readonly string[],
   movementType: MovementType,
 ): IToHitModifierDetail | null {
-  if (!abilities.includes('jumping-jack')) return null;
+  if (!hasSPA(abilities, 'jumping_jack')) return null;
   if (movementType !== MovementType.Jump) return null;
 
   return {
@@ -82,7 +84,7 @@ export function calculateDodgeManeuverModifier(
   targetAbilities: readonly string[],
   isDodging?: boolean,
 ): IToHitModifierDetail | null {
-  if (!targetAbilities.includes('dodge-maneuver')) return null;
+  if (!hasSPA(targetAbilities, 'dodge_maneuver')) return null;
   if (!isDodging) return null;
 
   return {
@@ -99,7 +101,7 @@ export function calculateDodgeManeuverModifier(
 export function calculateMeleeSpecialistModifier(
   abilities: readonly string[],
 ): IToHitModifierDetail | null {
-  if (!abilities.includes('melee-specialist')) return null;
+  if (!hasSPA(abilities, 'melee_specialist')) return null;
 
   return {
     name: 'Melee Specialist',
@@ -116,14 +118,14 @@ export function calculateMeleeSpecialistModifier(
 export function getMeleeMasterDamageBonus(
   abilities: readonly string[],
 ): number {
-  return abilities.includes('melee-master') ? 1 : 0;
+  return hasSPA(abilities, 'melee_master') ? 1 : 0;
 }
 
 /**
  * Tactical Genius: +1 initiative.
  */
 export function getTacticalGeniusBonus(abilities: readonly string[]): number {
-  return abilities.includes('tactical-genius') ? 1 : 0;
+  return hasSPA(abilities, 'tactical_genius') ? 1 : 0;
 }
 
 /**
@@ -134,7 +136,7 @@ export function getEffectiveWounds(
   abilities: readonly string[],
   pilotWounds: number,
 ): number {
-  if (abilities.includes('pain-resistance') && pilotWounds > 0) {
+  if (hasSPA(abilities, 'pain_resistance') && pilotWounds > 0) {
     return pilotWounds - 1;
   }
   return pilotWounds;
@@ -144,7 +146,7 @@ export function getEffectiveWounds(
  * Iron Man: -2 to consciousness check target numbers.
  */
 export function getIronManModifier(abilities: readonly string[]): number {
-  return abilities.includes('iron-man') ? -2 : 0;
+  return hasSPA(abilities, 'iron_man') ? -2 : 0;
 }
 
 /**
@@ -154,5 +156,5 @@ export function getIronManModifier(abilities: readonly string[]): number {
 export function getHotDogShutdownThresholdBonus(
   abilities: readonly string[],
 ): number {
-  return abilities.includes('hot-dog') ? 3 : 0;
+  return hasSPA(abilities, 'hot_dog') ? 3 : 0;
 }

--- a/src/utils/gameplay/spaModifiers/canonicalize.ts
+++ b/src/utils/gameplay/spaModifiers/canonicalize.ts
@@ -1,0 +1,29 @@
+/**
+ * Canonicalization bridge between pilot ability ids and the unified SPA
+ * catalog. The combat modifier files used to hardcode kebab-case ids
+ * (`'weapon-specialist'`, `'iron-man'`) matching System B's original
+ * catalog. With the unified catalog landing snake_case canonical ids
+ * (matching MegaMek's OptionsConstants), we normalize both forms at the
+ * modifier boundary so a pilot record works regardless of whether its
+ * `abilities` field uses the legacy or canonical form.
+ *
+ * Every modifier function should call `hasSPA(abilities, 'canonical_id')`
+ * rather than `abilities.includes('some-legacy-id')`. The helper below
+ * handles the snake→kebab mapping automatically via the unified catalog's
+ * legacy-alias table.
+ */
+
+import { canonicalizeSPAIds } from '@/lib/spa';
+
+/**
+ * True iff `abilities` (either canonical or legacy ids) contains the
+ * canonical ability id after legacy-alias resolution.
+ */
+export function hasSPA(
+  abilities: readonly string[],
+  canonicalId: string,
+): boolean {
+  if (abilities.includes(canonicalId)) return true;
+  const canonicalized = canonicalizeSPAIds(abilities);
+  return canonicalized.includes(canonicalId);
+}

--- a/src/utils/gameplay/spaModifiers/catalog.ts
+++ b/src/utils/gameplay/spaModifiers/catalog.ts
@@ -3,6 +3,7 @@
  * Complete catalog with all BattleTech special pilot abilities.
  */
 
+import { hasSPA as hasCanonicalSPA } from './canonicalize';
 import { ISPACatalogEntry, SPACategory, SPAPipeline } from './types';
 
 /**
@@ -342,26 +343,31 @@ export function getSPAsByCategory(category: SPACategory): ISPACatalogEntry[] {
 }
 
 export function hasSPA(abilities: readonly string[], spaId: string): boolean {
-  return abilities.includes(spaId);
+  // Delegate to the canonical resolver so callers can pass either the
+  // legacy kebab-case id or the canonical snake_case id and still match.
+  return hasCanonicalSPA(abilities, spaId);
 }
 
 export function getConsciousnessCheckModifier(
   abilities: readonly string[],
 ): number {
   let modifier = 0;
-  if (abilities.includes('iron-man') || abilities.includes('iron-will')) {
+  if (hasCanonicalSPA(abilities, 'iron_man')) {
     modifier -= 2;
   }
-  if (abilities.includes('toughness')) {
+  if (hasCanonicalSPA(abilities, 'pain_resistance')) {
     modifier -= 1;
   }
   return modifier;
 }
 
 export function getObliqueAttackerBonus(abilities: readonly string[]): number {
-  return abilities.includes('oblique-attacker') ? -1 : 0;
+  return hasCanonicalSPA(abilities, 'oblique_attacker') ? -1 : 0;
 }
 
 export function getSharpshooterBonus(abilities: readonly string[]): number {
+  // 'sharpshooter' doesn't exist in the canonical catalog — it's a
+  // System-B-only legacy alias. Fall back to the raw match for the id
+  // so existing callers keep working until the UI offers a real alternative.
   return abilities.includes('sharpshooter') ? -1 : 0;
 }

--- a/src/utils/gameplay/spaModifiers/weaponSpecialists.ts
+++ b/src/utils/gameplay/spaModifiers/weaponSpecialists.ts
@@ -6,6 +6,8 @@
 import { RangeBracket } from '@/types/gameplay';
 import { IToHitModifierDetail } from '@/types/gameplay';
 
+import { hasSPA } from './canonicalize';
+
 /**
  * Weapon Specialist: -2 to-hit for designated weapon type.
  */
@@ -14,7 +16,7 @@ export function calculateWeaponSpecialistModifier(
   weaponType?: string,
   designatedWeaponType?: string,
 ): IToHitModifierDetail | null {
-  if (!abilities.includes('weapon-specialist')) return null;
+  if (!hasSPA(abilities, 'weapon_specialist')) return null;
   if (!weaponType || !designatedWeaponType) return null;
   if (weaponType.toLowerCase() !== designatedWeaponType.toLowerCase())
     return null;
@@ -35,7 +37,7 @@ export function calculateGunnerySpecialistModifier(
   weaponCategory?: string,
   designatedCategory?: string,
 ): IToHitModifierDetail | null {
-  if (!abilities.includes('gunnery-specialist')) return null;
+  if (!hasSPA(abilities, 'specialist')) return null;
   if (!weaponCategory || !designatedCategory) return null;
 
   const isDesignated =
@@ -60,7 +62,7 @@ export function calculateRangeMasterModifier(
   designatedBracket?: RangeBracket,
   currentRangeModifier?: number,
 ): IToHitModifierDetail | null {
-  if (!abilities.includes('range-master')) return null;
+  if (!hasSPA(abilities, 'range_master')) return null;
   if (!rangeBracket || !designatedBracket) return null;
   if (rangeBracket !== designatedBracket) return null;
   if (currentRangeModifier === undefined || currentRangeModifier <= 0)
@@ -82,7 +84,7 @@ export function calculateSniperModifier(
   abilities: readonly string[],
   currentRangeModifier?: number,
 ): IToHitModifierDetail | null {
-  if (!abilities.includes('sniper')) return null;
+  if (!hasSPA(abilities, 'sniper')) return null;
   if (currentRangeModifier === undefined || currentRangeModifier <= 0)
     return null;
 


### PR DESCRIPTION
## Summary
Stacked on [#295](https://github.com/SwiggitySwerve/MekStation/pull/295). Migrates every combat modifier in `src/utils/gameplay/spaModifiers/` from hardcoded kebab-case id checks to the unified SPA catalog's canonical snake_case ids.

- Adds a thin bridge `spaModifiers/canonicalize.ts` exposing `hasSPA(abilities, canonicalId)` which resolves legacy aliases via `@/lib/spa.canonicalizeSPAIds()`.
- Every modifier now uses `hasSPA()` with the canonical id: Blood Stalker, Multi-Tasker, Jumping Jack, Dodge, Melee Specialist, Cluster Hitter, Melee Master, Tactical Genius, Pain Resistance, Iron Man, Hot Dog, Weapon Specialist, Gunnery Specialist, Range Master, Sniper, Oblique Attacker.
- `catalog.hasSPA()` now delegates to the bridge so external callers also pick up alias resolution.
- `'iron-will'` / `'iron_will'` added to the alias table so it keeps resolving to `'iron_man'`.
- `getConsciousnessCheckModifier` switches from `'toughness'` → `'pain_resistance'` (same -1 semantics; System A's `toughness` already aliases to `pain_resistance`).

All legacy kebab-case pilot records continue to work. Pilots with canonical ids now also fire the combat modifiers.

## Test plan
- [x] `npx jest src/utils/gameplay src/lib/spa` — 1,975 passing (21 new from canonicalize.test.ts, 73 existing spaModifiers tests)
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeded (husky pre-push)