### PR TITLE
feat(pilots): implement random SPA selection using unified catalog

### DIFF
--- a/src/lib/spa/__tests__/random.test.ts
+++ b/src/lib/spa/__tests__/random.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the random SPA picker.
+ */
+
+import { getEligibleSPAs, pickRandomSPA } from '../random';
+
+describe('getEligibleSPAs', () => {
+  it('excludes flaws by default', () => {
+    const pool = getEligibleSPAs();
+    expect(pool.every((spa) => !spa.isFlaw)).toBe(true);
+  });
+
+  it('excludes origin-only abilities by default', () => {
+    const pool = getEligibleSPAs();
+    expect(pool.every((spa) => !spa.isOriginOnly)).toBe(true);
+  });
+
+  it('excludes abilities with null xpCost by default', () => {
+    const pool = getEligibleSPAs();
+    expect(pool.every((spa) => spa.xpCost !== null)).toBe(true);
+  });
+
+  it('respects the excludeIds list', () => {
+    const baseline = getEligibleSPAs();
+    const firstId = baseline[0].id;
+    const pool = getEligibleSPAs({ excludeIds: [firstId] });
+    expect(pool.find((s) => s.id === firstId)).toBeUndefined();
+  });
+
+  it('respects the category filter', () => {
+    const pool = getEligibleSPAs({ category: 'gunnery' });
+    expect(pool.length).toBeGreaterThan(0);
+    expect(pool.every((s) => s.category === 'gunnery')).toBe(true);
+  });
+
+  it('includes flaws when includeFlaws is true', () => {
+    const pool = getEligibleSPAs({ includeFlaws: true });
+    expect(pool.some((spa) => spa.isFlaw)).toBe(true);
+  });
+});
+
+describe('pickRandomSPA', () => {
+  it('returns a deterministic choice for a given random() value', () => {
+    // A stable 0 pins the choice to pool[0].
+    const deterministicRandom = () => 0;
+    const first = pickRandomSPA(deterministicRandom);
+    expect(first).not.toBeNull();
+    const second = pickRandomSPA(deterministicRandom);
+    expect(second?.id).toBe(first?.id);
+  });
+
+  it('different random values return different SPAs', () => {
+    const a = pickRandomSPA(() => 0);
+    const b = pickRandomSPA(() => 0.9999);
+    expect(a?.id).not.toBe(b?.id);
+  });
+
+  it('never returns a flaw by default', () => {
+    // Sample a range of random values; none should produce a flaw.
+    for (let i = 0; i < 20; i++) {
+      const r = i / 20;
+      const spa = pickRandomSPA(() => r);
+      expect(spa?.isFlaw).toBe(false);
+    }
+  });
+
+  it('never returns an origin-only ability by default', () => {
+    for (let i = 0; i < 20; i++) {
+      const r = i / 20;
+      const spa = pickRandomSPA(() => r);
+      expect(spa?.isOriginOnly).toBe(false);
+    }
+  });
+
+  it('respects a custom catalog', () => {
+    const onlyOne = getEligibleSPAs({ category: 'gunnery' }).slice(0, 1);
+    const spa = pickRandomSPA(() => 0.5, { catalog: onlyOne });
+    expect(spa?.id).toBe(onlyOne[0].id);
+  });
+
+  it('returns null when the pool is empty', () => {
+    const spa = pickRandomSPA(() => 0.5, { catalog: [] });
+    expect(spa).toBeNull();
+  });
+});

--- a/src/lib/spa/random.ts
+++ b/src/lib/spa/random.ts
@@ -1,0 +1,63 @@
+/**
+ * Random SPA selection.
+ *
+ * Lets the pilot service pick a bonus SPA for randomized pilots without
+ * hardcoding a list. Eligible pool defaults to purchasable non-flaw,
+ * non-origin-only abilities — i.e. things you'd expect a line pilot to
+ * roll up organically. Callers can widen or narrow the pool via options.
+ */
+
+import type { ISPADefinition } from '@/types/spa/SPADefinition';
+
+import { getAllSPAs } from './index';
+
+/** Injectable random source. Must return a value in [0, 1). */
+export type RandomFn = () => number;
+
+export interface IPickRandomSPAOptions {
+  /** Include flaws in the eligible pool. Default false. */
+  readonly includeFlaws?: boolean;
+  /** Include origin-only abilities. Default false (creation-only path). */
+  readonly includeOriginOnly?: boolean;
+  /** Only pick from this category. Default: any. */
+  readonly category?: ISPADefinition['category'];
+  /** Exclude these ids from the pool (e.g. already-owned abilities). */
+  readonly excludeIds?: readonly string[];
+  /** Exact catalog to pick from (for testing). Defaults to the full catalog. */
+  readonly catalog?: readonly ISPADefinition[];
+}
+
+/**
+ * Build the eligibility pool for random selection given the options.
+ * Exposed for testing so callers can assert pool-shape without mocking
+ * the random source.
+ */
+export function getEligibleSPAs(
+  options: IPickRandomSPAOptions = {},
+): readonly ISPADefinition[] {
+  const catalog = options.catalog ?? getAllSPAs();
+  const excluded = new Set(options.excludeIds ?? []);
+
+  return catalog.filter((spa) => {
+    if (excluded.has(spa.id)) return false;
+    if (!options.includeFlaws && spa.isFlaw) return false;
+    if (!options.includeOriginOnly && spa.isOriginOnly) return false;
+    if (spa.xpCost === null && !options.includeOriginOnly) return false;
+    if (options.category && spa.category !== options.category) return false;
+    return true;
+  });
+}
+
+/**
+ * Pick a random SPA from the eligible pool. Returns null when the pool
+ * is empty (e.g. every eligible id was excluded).
+ */
+export function pickRandomSPA(
+  random: RandomFn,
+  options: IPickRandomSPAOptions = {},
+): ISPADefinition | null {
+  const pool = getEligibleSPAs(options);
+  if (pool.length === 0) return null;
+  const index = Math.floor(random() * pool.length);
+  return pool[Math.min(index, pool.length - 1)] ?? null;
+}

--- a/src/services/pilots/PilotService.ts
+++ b/src/services/pilots/PilotService.ts
@@ -7,6 +7,7 @@
  * @spec openspec/changes/add-pilot-system/specs/pilot-system/spec.md
  */
 
+import { pickRandomSPA } from '@/lib/spa/random';
 import {
   IPilot,
   ICreatePilotOptions,
@@ -46,7 +47,10 @@ export interface IPilotService {
     level: PilotExperienceLevel,
     identity: IPilotIdentity,
   ): IPilotOperationResult;
-  createRandom(identity: IPilotIdentity): IPilotOperationResult;
+  createRandom(
+    identity: IPilotIdentity,
+    randomFn?: () => number,
+  ): IPilotOperationResult;
   createStatblock(statblock: IPilotStatblock): IPilot;
   updatePilot(id: string, updates: Partial<IPilot>): IPilotOperationResult;
   deletePilot(id: string): IPilotOperationResult;
@@ -128,23 +132,34 @@ export class PilotService implements IPilotService {
   }
 
   /**
-   * Create a pilot with random skills
+   * Create a pilot with random skills.
+   *
+   * 20% chance of rolling up a single bonus SPA from the unified
+   * catalog — positive, purchasable, non-origin-only. The RNG is
+   * injectable (defaults to Math.random) so tests can pin down the
+   * chosen ability deterministically.
    */
-  createRandom(identity: IPilotIdentity): IPilotOperationResult {
+  createRandom(
+    identity: IPilotIdentity,
+    randomFn: () => number = Math.random,
+  ): IPilotOperationResult {
     // Random skills weighted toward Regular (4/5)
     const gunneryRoll = this.rollSkill();
     const pilotingRoll = this.rollSkill();
 
-    // Small chance of a bonus ability
-    const hasAbility = Math.random() < 0.2;
+    // ~20% chance of a bonus ability. If we roll one, draw a random
+    // eligible SPA from the unified catalog; if the pool is empty for
+    // any reason, fall back to no ability rather than an empty list.
+    const hasAbility = randomFn() < 0.2;
+    const spa = hasAbility ? pickRandomSPA(randomFn) : null;
+    const abilityIds = spa ? [spa.id] : undefined;
 
     return this.repo.create({
       identity,
       type: PilotType.Persistent,
       skills: { gunnery: gunneryRoll, piloting: pilotingRoll },
       startingXp: 0,
-      // TODO: Add random ability selection when abilities are implemented
-      abilityIds: hasAbility ? [] : undefined,
+      abilityIds,
     });
   }
 


### PR DESCRIPTION
## Summary
Stacked on [#295](https://github.com/SwiggitySwerve/MekStation/pull/295). Closes the Tier A #5 stub at PilotService.ts:146 ("TODO: Add random ability selection when abilities are implemented").

Adds `src/lib/spa/random.ts`:
- `getEligibleSPAs(options)` — builds the random pool with sensible defaults (no flaws, no origin-only, no null-cost, optional category filter)
- `pickRandomSPA(random, options)` — picks one from the pool using an injected random() source

`PilotService.createRandom()` now draws a canonical SPA id when the 20% ability roll succeeds. The RNG is injectable — defaults to `Math.random` for production, deterministic functions for tests.

## Test plan
- [x] `npx jest src/lib/spa src/services/pilots` — 170/170 passing (12 new random tests)
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeded (husky pre-push)