### PR TITLE
chore(ui): resolve or remove Coming Soon placeholders

### DIFF
--- a/src/__tests__/components/customizer/tabs/NewTabModal.test.tsx
+++ b/src/__tests__/components/customizer/tabs/NewTabModal.test.tsx
@@ -32,7 +32,7 @@ describe('NewTabModal', () => {
 
     expect(screen.getByText('New Unit')).toBeInTheDocument();
     expect(screen.getByText('Copy Current')).toBeInTheDocument();
-    expect(screen.getByText('Import Data')).toBeInTheDocument();
+    expect(screen.queryByText('Import Data')).not.toBeInTheDocument();
   });
 
   it('should call onCreateUnit when create button is clicked', async () => {

--- a/src/__tests__/pages/settings.test.tsx
+++ b/src/__tests__/pages/settings.test.tsx
@@ -367,18 +367,23 @@ describe('Settings Page', () => {
   });
 
   describe('Audit Log Section', () => {
-    it('renders audit log content with event timeline link', () => {
+    it('renders audit log content with event timeline and replay player links', () => {
       renderSettings();
       clickSectionHeader('Audit Log');
 
       expect(screen.getByText('Event Timeline')).toBeInTheDocument();
       expect(screen.getByText('Replay Player')).toBeInTheDocument();
-      expect(screen.getByText('Coming soon')).toBeInTheDocument();
+      expect(screen.getByText('Pick a game to replay')).toBeInTheDocument();
 
       const timelineLink = screen
         .getAllByRole('link')
         .find((link) => link.getAttribute('href') === '/audit/timeline');
       expect(timelineLink).toBeDefined();
+
+      const replayLink = screen
+        .getAllByRole('link')
+        .find((link) => link.getAttribute('href') === '/gameplay/games');
+      expect(replayLink).toBeDefined();
     });
   });
 

--- a/src/components/customizer/tabs/NewTabModal.constants.ts
+++ b/src/components/customizer/tabs/NewTabModal.constants.ts
@@ -1,7 +1,7 @@
 import { TechBase } from '@/types/enums/TechBase';
 import { UnitType } from '@/types/unit/BattleMechInterfaces';
 
-export type CreationMode = 'new' | 'copy' | 'import';
+export type CreationMode = 'new' | 'copy';
 
 export type SupportedUnitType =
   | UnitType.BATTLEMECH

--- a/src/components/customizer/tabs/NewTabModal.tsx
+++ b/src/components/customizer/tabs/NewTabModal.tsx
@@ -141,7 +141,7 @@ export function NewTabModal({
         </div>
 
         <div className="border-border-theme-subtle flex border-b">
-          {(['new', 'copy', 'import'] as CreationMode[]).map((tabMode) => (
+          {(['new', 'copy'] as CreationMode[]).map((tabMode) => (
             <button
               key={tabMode}
               onClick={() => setMode(tabMode)}
@@ -153,7 +153,6 @@ export function NewTabModal({
             >
               {tabMode === 'new' && 'New Unit'}
               {tabMode === 'copy' && 'Copy Current'}
-              {tabMode === 'import' && 'Import Data'}
             </button>
           ))}
         </div>
@@ -188,13 +187,6 @@ export function NewTabModal({
               </p>
             </div>
           )}
-
-          {mode === 'import' && (
-            <div className="text-text-theme-secondary py-8 text-center">
-              <p>Import from MTF, SSW, or MegaMek formats.</p>
-              <p className="mt-2 text-sm">(Coming soon)</p>
-            </div>
-          )}
         </div>
 
         <div className="border-border-theme-subtle flex justify-end gap-2 border-t px-4 py-3">
@@ -206,8 +198,7 @@ export function NewTabModal({
           </button>
           <button
             onClick={handleCreate}
-            disabled={mode === 'import'}
-            className="bg-accent hover:bg-accent-hover rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+            className="bg-accent hover:bg-accent-hover rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors"
           >
             Create Unit
           </button>

--- a/src/components/settings/AuditSettings.tsx
+++ b/src/components/settings/AuditSettings.tsx
@@ -54,8 +54,11 @@ export function AuditSettings({
             </div>
           </Link>
 
-          <div className="bg-surface-raised/30 border-border-theme-subtle/50 flex items-center gap-3 rounded-lg border p-4 opacity-60">
-            <div className="bg-surface-raised text-text-theme-muted flex h-10 w-10 items-center justify-center rounded-lg">
+          <Link
+            href="/gameplay/games"
+            className="bg-surface-raised/50 border-border-theme-subtle hover:bg-surface-raised hover:border-border-theme group flex items-center gap-3 rounded-lg border p-4 transition-all"
+          >
+            <div className="bg-accent/20 text-accent group-hover:bg-accent flex h-10 w-10 items-center justify-center rounded-lg transition-colors group-hover:text-white">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
@@ -77,12 +80,14 @@ export function AuditSettings({
               </svg>
             </div>
             <div>
-              <div className="text-text-theme-secondary text-sm font-medium">
+              <div className="text-text-theme-primary group-hover:text-accent text-sm font-medium transition-colors">
                 Replay Player
               </div>
-              <div className="text-text-theme-muted text-xs">Coming soon</div>
+              <div className="text-text-theme-muted text-xs">
+                Pick a game to replay
+              </div>
             </div>
-          </div>
+          </Link>
         </div>
 
         <div className="border-border-theme-subtle border-t pt-4">


### PR DESCRIPTION
## Summary
Final Tier A PR. Addresses the two customer-facing "Coming soon" placeholders flagged in the evaluation:

1. **NewTabModal Import tab** — Import Data tab was inert (disabled Create button, static "Coming soon" text, references MTF/SSW formats that have no frontend implementation). Removed the tab, the 'import' variant of `CreationMode`, and the associated disabled-button logic. `/api/units/import` endpoint remains available for programmatic imports.

2. **AuditSettings Replay Player card** — previously rendered at opacity 60% with static "Coming soon" text. The replay page at `/gameplay/games/[id]/replay` already exists, so the card now links to `/gameplay/games` (the picker) with copy "Pick a game to replay". Settings test updated to assert both links render.

Explicitly out of scope:
- `FluffTab.tsx` quirks placeholder (requires real quirks feature)
- `replay.tsx` "Full game state visualization coming soon" — explanatory note, not inert UI; the controls below work

## Test plan
- [x] `npx jest src/__tests__/pages/settings.test.tsx` — 26/26 passing
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeded (husky pre-push)