### PR TITLE
docs(openspec): phase 1-7 combat and multiplayer roadmap (61 change proposals)

### DIFF
--- a/docs/plans/2026-04-17-combat-and-multiplayer-roadmap.md
+++ b/docs/plans/2026-04-17-combat-and-multiplayer-roadmap.md
@@ -1,0 +1,328 @@
+# MekStation — Combat & Multiplayer Roadmap
+
+> Date: 2026-04-17
+> Status: Draft — awaiting review
+> Scope: End-to-end plan from today's post-Tier-A state to playable multiplayer BattleTech
+
+## North Star
+
+Realistic BattleTech tabletop experience with three pillars:
+
+1. **Editor** — mech construction (largely done — 99.8% BV parity, 91 SPA catalog, 4,226 canonical units)
+2. **Single-player campaign** — MekHQ-style outer loop already built; combat is what players trigger between day advancements
+3. **Multiplayer co-op + PvP (2–8 players)** — full tabletop parity, either side can be human or AI, authoritative server
+
+Combat itself in two presentation modes:
+
+- **Quick simulation** — auto-resolve with probability output, for decision support
+- **Deep visualization (Civ-style)** — hex grid, stateful units, full phase play, 2D presentation (no 3D — licensing friction on mech IP)
+
+## Confirmed scope decisions (from interview)
+
+| Decision                | Answer                                                                          |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| Multiplayer model       | PvP + co-op, 2–8 players, authoritative state                                   |
+| Critical-path unit type | BattleMechs only (non-mechs follow later)                                       |
+| Campaign integration    | Existing system IS the outer loop — wire combat outcomes back in                |
+| MVP demo                | 4-mech skirmish end-to-end (2v2, AI opponent, full phases, no campaign wrapper) |
+
+## Current state summary (what we start from)
+
+| Area                             | State                                                                                           |
+| -------------------------------- | ----------------------------------------------------------------------------------------------- |
+| BattleMech construction          | ✅ Full, 99.8% BV parity                                                                        |
+| Equipment + unit catalogs        | ✅ 1,107 items, 4,226 canonical mechs                                                           |
+| SPA system                       | ✅ 91-entry unified catalog, combat modifiers bridged, random picker                            |
+| Campaign system (day processors) | ✅ 16 processors live — turnover / acquisition / finances / faction standing / medical / awards |
+| GameEngine                       | ✅ Auto-resolve with AI bot, phase orchestration                                                |
+| Hex grid + math                  | ✅ Complete                                                                                     |
+| `EncounterService → GameSession` | ✅ Wired (PR 293)                                                                               |
+| Vault sync + rollback            | ✅ Complete                                                                                     |
+| Interactive combat UI            | ❌ `InteractiveSession.ts` exists but no front-end player                                       |
+| Multiplayer networking           | ❌ Yjs used for customizer tabs only; no game-session sync                                      |
+| Non-mech construction            | ❌ Aerospace / Vehicle / BA / Infantry / ProtoMech are skeletons                                |
+
+---
+
+## Phase 0 — Foundation cleanup (IN FLIGHT, ~this session)
+
+**Goal:** close every known stub so Phase 1 builds on a clean base.
+
+- 8 Tier A PRs shipped or shipping — unit card actions, SHA-256, encounter→session, vault sync/rollback, unified SPA catalog, combat wiring, random SPA, Coming-Soon cleanup
+- One deferred item: pilot SPA picker UI (becomes Phase 6)
+
+**Checkpoint:** `main` is green with zero known stubs in customer-facing paths.
+
+---
+
+## Phase 1 — Interactive Combat MVP (the 4-mech skirmish)
+
+**Goal:** two humans (hot-seat) or one human vs AI pit two lances against each other, play all BattleTech phases through to a winner, on an open hex map.
+
+### Current gaps
+
+- `InteractiveSession.ts` exists but is headless — no UI consumes it.
+- Hex grid renders (in `components/gameplay/HexMapDisplay/`) but no unit tokens, no click-to-select, no action panels.
+- Phase transitions exist in `GameEngine.phases.ts` but aren't driven by human input.
+- No end-of-turn summary, no victory screen.
+
+### Specs
+
+Each phase of combat needs an interactive surface:
+
+| Phase               | UI required                                                                                                      | Engine wiring                                                      |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| **Initiative**      | Roll animation, side that wins shown                                                                             | `rollInitiative()` already exists                                  |
+| **Movement**        | Click unit → pathfinder overlay shows reachable hexes colored by walk/run/jump cost; click destination to commit | `runMovementPhase` — needs pathfinder + MP accounting hooks        |
+| **Weapon attack**   | Click unit → weapon list with to-hit calc per target (range, movement, terrain, heat, SPA) → fire or hold        | `resolveAllAttacks` + `calculateToHit` (both exist); UI is missing |
+| **Physical attack** | Punch / kick / charge / DFA options with to-hit + damage                                                         | Logic exists in `gameSessionAttackResolution`                      |
+| **Heat**            | Heat buildup, shutdown rolls, ammo explosion rolls, PSR triggers                                                 | `gameSessionHeat` exists                                           |
+| **End of turn**     | Damage/crit summary per unit, pilot KO / conscious rolls, PSRs                                                   | `gameSessionPSR` exists                                            |
+
+### Tasks (suggested atomic PRs)
+
+1. **Unit token layer** on `HexMapDisplay` — render mech silhouettes at hex coords, facing indicator, selection ring.
+2. **Movement overlay + pathfinder** — BFS over walkable hexes, MP cost per path, honor elevation / terrain modifiers.
+3. **Action panel component** — right-side panel bound to selected unit; shows armor diagram, heat bar, weapons, pilot stats, SPA list.
+4. **Weapon attack flow** — click target → to-hit breakdown modal (list every modifier) → confirm → engine resolves → damage animation + log entry.
+5. **Physical attack flow** — same pattern, restricted to adjacent targets.
+6. **Heat phase driver** — end-of-turn heat application triggers UI confirmation for each shutdown / ammo roll.
+7. **Turn-end summary** — list of events, pending PSRs, damage taken.
+8. **AI opponent driver** — wire `BotPlayer` into the phase flow so CPU-controlled units play without human input.
+9. **Victory detection + screen** — last-side-standing, eject option, post-battle report.
+10. **Record-sheet overlay** — hover/click unit to see full record sheet (damage, crits, ammo remaining).
+
+### Out of scope for Phase 1
+
+- Terrain rendering beyond flat hexes (woods / buildings / elevation visible as overlays only)
+- Animations (damage is shown as numbers, not explosions)
+- Networked multiplayer (hot-seat + AI opponent only)
+- Salvage, XP, campaign integration
+
+### Checkpoint
+
+"I can sit down with a friend at one laptop, pick 2 mechs each, play a full match to a decisive outcome." Auto-save of the match log.
+
+**Rough size:** 10 PRs, 4–6 weeks if solo.
+
+---
+
+## Phase 2 — Quick Simulation mode
+
+**Goal:** decision-support during campaign play and pre-battle planning.
+
+### Deliverables
+
+- "Quick resolve" button on any encounter — runs `GameEngine.runToCompletion()` with seeded RNG, reports outcome distribution across N runs (e.g. 100 sims).
+- "What if" calculator on any selected weapon/target pair — shows to-hit, expected damage, crit probability without committing.
+- Pre-battle force comparison — BV delta, tonnage, pilot skill averages, SPA summary, expected salvage if won.
+
+### Tasks
+
+1. Monte Carlo wrapper on `runToCompletion` — N seeds, aggregate winner/loss/turns/casualties.
+2. Stats-aggregation helpers (mean, stddev, percentile) in `src/utils/gameplay/`.
+3. Result-display component — win probability bar, likely casualties, turn-count distribution.
+4. "What if" modal from the Phase 1 weapon picker — reuses the modifier calc, shows probabilistic outcome instead of triggering the attack.
+
+**Checkpoint:** campaign players can evaluate a prospective encounter without committing to the full visual fight.
+
+**Rough size:** 4 PRs, 1–2 weeks.
+
+---
+
+## Phase 3 — Campaign ↔ Combat integration
+
+**Goal:** fights launched from a campaign feed their outcomes back — damage, XP, pilot wounds, salvage all persist.
+
+### Current gaps
+
+- `EncounterService.launchEncounter` now produces a `gameSessionId` (PR 293) but nothing listens for the finished session to update campaign state.
+- Salvage rules aren't implemented.
+- Post-battle XP distribution exists in `src/lib/campaign/progression/xpAwards.ts` but isn't invoked from combat.
+- Mech damage from combat doesn't persist back to the unit record — repair system can't see it.
+
+### Specs
+
+- Post-battle handler: given a completed `IGameSession`, update:
+  - Pilot XP (from `xpAwards`)
+  - Pilot wounds / status (from consciousness checks during battle)
+  - Unit damage (armor / internals / crits)
+  - Contract salvage (BattleTech standard: defeated units auction between employer and mercenary)
+  - Mission completion → contract status
+- Post-battle review UI — shows casualties, XP gained, salvage picked, repair cost estimate.
+
+### Tasks
+
+1. `CombatOutcome` shape — serializes `IGameSession` final state into campaign-consumable form.
+2. `PostBattleProcessor` — applies pilot XP, wounds, unit damage.
+3. Salvage rules engine — implement Total Warfare / Campaign Ops salvage tables.
+4. Repair queue integration — damaged units flow to the existing maintenance system.
+5. Post-battle review page — readable summary replacing raw game log.
+
+**Checkpoint:** complete a mercenary contract end-to-end: accept contract → encounter → battle → outcome applied → payment → next day advances.
+
+**Rough size:** 5 PRs, 2–3 weeks.
+
+---
+
+## Phase 4 — Multiplayer foundation
+
+**Goal:** 2–8 players on a live match, any mix of sides, authoritative state, roll arbitration.
+
+### Architectural decision points (to confirm early in this phase)
+
+- **Authority model:** server-authoritative (needs hosting) vs. P2P-with-host (cheaper, but host-leaves = game over). Lean server-authoritative given the 2–8 player scope and cheating resistance.
+- **State sync:** event-sourced (the engine is already event-sourced — this is a big tailwind) vs. state snapshots. Event-sourced fits naturally.
+- **Hosting:** cloud (AWS/Fly/Railway) or self-hosted. Needs a decision per target audience.
+- **Identity:** reuse existing vault identity (if vault-sharing auth is in place) or add OAuth.
+
+### Specs
+
+- Game sessions persist server-side, identified by code/URL for invites.
+- Clients send "intent" events (move, fire, etc.); server validates and broadcasts the resolved event back.
+- Authoritative RNG on server — clients can't fabricate rolls.
+- Reconnect on disconnect — client replays event log from persistence.
+- Optional fog-of-war — each client receives only the events visible to their side (double-blind rules).
+
+### Tasks (big, roughly ordered)
+
+1. Game-session persistence layer — SQLite or Postgres backing store for `IGameSession`.
+2. WebSocket or similar real-time transport — broadcast engine events.
+3. Server-side engine authority — server runs `GameEngine`, clients are view-only (send intents).
+4. Lobby + matchmaking — create game, invite by code, assign sides.
+5. Authentication — tie player identity to session participation.
+6. Reconnection flow — re-hydrate client from event log.
+7. Fog of war (optional for Phase 4, could be Phase 4.5) — per-side event filtering.
+8. AI + human mix — `BotPlayer` continues to drive any unoccupied side.
+
+### Checkpoint
+
+Two humans on different machines play a full match against each other; a third joins the same side as co-op; AI fills remaining slots.
+
+**Rough size:** 12–15 PRs, 2–3 months. Biggest phase.
+
+---
+
+## Phase 5 — Pilot SPA UI (formerly Tier A #5c, deferred)
+
+**Goal:** pilot editor lets users browse all 91 SPAs by category, purchase with XP, designate options (weapon type, target, etc.); pilot sheets render SPAs; PDF export includes them.
+
+### Tasks
+
+1. SPA picker component — category tabs, search, description tooltip, XP cost, origin-only tag.
+2. Pilot editor integration — "Add SPA" button on pilot detail page.
+3. Designation prompts — when an SPA requires a weapon type / range bracket / target id at selection time.
+4. Unit card + pilot sheet display — badge list with category colors.
+5. PDF export extension — SPA section on the printed pilot sheet.
+
+**Checkpoint:** a pilot's SPAs are visible everywhere the pilot appears; they can be purchased / assigned / removed.
+
+**Rough size:** 4 PRs, 1–2 weeks. Can run in parallel with Phase 2/3.
+
+---
+
+## Phase 6 — Non-mech unit types (combined arms)
+
+**Goal:** vehicles, aerospace, BattleArmor, Infantry, ProtoMechs get full construction + combat support.
+
+### Scope per unit type
+
+- Construction rules (chassis, motive, weapons slots, crew)
+- BV calculation
+- Combat behavior (speed, hit locations, firing arcs)
+- Record-sheet rendering
+- Unit-type-specific validation
+
+### Ordering suggestion (revenue/impact)
+
+1. **Ground vehicles** (most common second unit type in campaigns)
+2. **Aerospace fighters** (air-to-ground contributions matter in campaigns)
+3. **BattleArmor** (common hostile infantry in contracts)
+4. **Conventional infantry** (occupy-ground role)
+5. **ProtoMechs** (niche, Clan-only)
+
+Each is effectively a mini-phase mirroring the mech work: construction specs → validation → BV → combat behavior → display.
+
+**Rough size:** ~5 PRs per unit type × 5 types = 25 PRs, 4–6 months if sequential. Could be parallelized with different contributors.
+
+---
+
+## Phase 7 — 2D art + animation polish (final presentation layer)
+
+**Goal:** the combat experience looks and feels like Civilization — animated movement, attack effects, visible damage, terrain art. **No 3D.** Licensing on mech IP (MechWarrior / BattleTech visual assets) makes a 3D upgrade not worth the build; 2D with good art direction is both legally safer and more faithful to the tabletop identity.
+
+### Tasks
+
+1. Mech sprite set (silhouettes with armor / hit-location overlays — homemade, not licensed).
+2. Terrain rendering (woods, buildings, water, elevation shading).
+3. Movement interpolation animations.
+4. Attack visuals (laser beams, missile trails, physical impact).
+5. Heat / shutdown visual indicators.
+6. Damage feedback (screen shake, hit flash, smoke).
+7. Line-of-sight / firing-arc overlays.
+8. Minimap + camera controls.
+
+**Checkpoint:** a stranger watching the screen understands what's happening without reading the log.
+
+**Rough size:** 8–10 PRs, 2–3 months. This is the final presentation layer — there is no Phase 8.
+
+---
+
+## Cross-cutting concerns (attention throughout)
+
+- **Performance** — `GameEngine` state derivation happens on every event. For long matches (100+ turns) verify no O(n²) pitfalls.
+- **Testing** — every new combat pipeline needs unit tests + fixture scenarios. Integration tests that run whole seeded matches and assert winners are fast and high-signal.
+- **Save / load** — event sourcing means any match is fully replayable. Wire save/load on interactive sessions too.
+- **Accessibility** — hex grids are hard for color-blind players. Use shape + color for terrain.
+- **BattleTech rules accuracy** — cite Total Warfare page numbers in code comments for any rule implementation.
+
+---
+
+## Critical files to keep in mind
+
+| File                                          | Why it matters                                           |
+| --------------------------------------------- | -------------------------------------------------------- |
+| `src/engine/GameEngine.ts`                    | Orchestrates battles — extend for interactive sessions   |
+| `src/engine/InteractiveSession.ts`            | Currently headless; the Phase 1 UI binds here            |
+| `src/utils/gameplay/gameSessionCore.ts`       | `createGameSession`, `appendEvent` — event-sourced spine |
+| `src/utils/gameplay/gameSession*.ts`          | Per-phase resolvers                                      |
+| `src/types/gameplay/GameSessionInterfaces.ts` | The contract everything implements                       |
+| `src/components/gameplay/HexMapDisplay/`      | Phase 1 UI home                                          |
+| `src/lib/campaign/processors/`                | Phase 3 wiring target                                    |
+| `src/lib/spa/`                                | Phase 5 consumer                                         |
+| `src/services/encounter/EncounterService.ts`  | Phase 3 campaign ↔ combat bridge                         |
+
+---
+
+## Phase dependency / parallelization
+
+```
+Phase 0 (cleanup) ──► Phase 1 (Combat MVP) ──┬─► Phase 2 (Quick Sim)
+                                              │
+                                              ├─► Phase 3 (Campaign integration) ──► Phase 4 (Multiplayer)
+                                              │                                             │
+                                              └─► Phase 5 (Pilot SPA UI)                    │
+                                                                                            │
+                                              Phase 6 (non-mech) ──────────────────────────▶ merge
+                                              Phase 7 (2D art + polish) ───────────────────▶ merge (final)
+```
+
+Phase 1 is the single-threaded critical path. Phases 2/3/5/6/7 can be parallelized once Phase 1 is playable. Phase 4 depends on Phase 3's post-battle hooks being real.
+
+---
+
+## Open questions / decisions to revisit
+
+- **Multiplayer hosting target** — decide early in Phase 4 (self-host vs cloud vs hybrid).
+- **AI quality ceiling** — current `BotPlayer` is simple. How smart does the AI need to be for single-player to be fun? Could become its own mini-phase.
+- **Mission scripting** — Phase 3 covers "complete a mercenary contract," but not scripted campaign story missions. If story campaigns are desired, scripting DSL becomes a new phase.
+- **Performance ceiling** — Phase 7 / 8 may require WebGL / Canvas2D optimization work not yet budgeted.
+
+---
+
+## How to use this doc
+
+- Each phase is a sequence of PRs, not a branch of work. Spin an OpenSpec change for each phase when it comes up.
+- Deliverables + tasks here are **suggested atomic PRs** — implementers will refine as they start.
+- Phase checkpoints are the acceptance criteria — when the phase ships, the checkpoint should be demonstrable.
+- Update this doc as decisions get made / scope changes. Archive it once everything ships.

--- a/openspec/changes/add-aerospace-battle-value/proposal.md
+++ b/openspec/changes/add-aerospace-battle-value/proposal.md
@@ -1,0 +1,36 @@
+# Change: Add Aerospace Battle Value
+
+## Why
+
+Aerospace units currently compute BV as 0, which distorts force composition whenever an ASF or small craft is included in a campaign force. This change introduces aerospace BV 2.0 following TechManual rules — defensive BV uses SI in place of the mech gyro term, offensive BV uses nose/wing/aft weapon grouping with an arc-weighted fire-pool, and the speed factor uses `(safeThrust + maxThrust)/2` rather than ground MP.
+
+## What Changes
+
+- Add aerospace defensive BV = (armor BV + SI BV + defensive equipment BV − explosive penalties) × defensive factor
+- Add SI BV = SI × 0.5 × tonnage (scales with fighter durability)
+- Add defensive factor = 1 + (maxThrust / 10) (aero analog to TMM factor)
+- Add aerospace offensive BV = Σ(arc fire pool × 1.0) + fuselage weapons (already full BV) + ammo BV + offensive equipment BV
+- Add arc fire pool: the single highest-BV arc contributes 100%, opposite arc 25%, side arcs 50%
+- Add speed factor = round(pow(1 + ((avgThrust − 5) / 10), 1.2) × 100) / 100 where avgThrust = (safeThrust + maxThrust) / 2
+- Apply conventional-fighter multiplier 0.8 (fragile airframe)
+- Apply small-craft multiplier 1.2 for armor tonnage bonus
+- Integrate pilot skill multiplier via shared gunnery × piloting table
+- Record aerospace BV breakdown on unit and surface via status bar
+- Add validation harness to compare computed BV against MegaMekLab canonical aerospace units
+
+## Non-goals
+
+- Warship BV
+- BV recalculation during combat fuel depletion
+- Dynamic bombing-load BV adjustments (those are pod configurations, not aggregate BV)
+
+## Dependencies
+
+- **Requires**: `add-aerospace-construction`, `battle-value-system`
+- **Blocks**: `add-aerospace-combat-behavior` (AI uses BV for target selection)
+
+## Impact
+
+- **Affected specs**: `battle-value-system` (MODIFIED — aerospace path), `aerospace-unit-system` (ADDED — BV breakdown)
+- **Affected code**: `src/utils/construction/aerospace/aerospaceBV.ts` (new), `src/utils/construction/battleValueCalculations.ts` (dispatch), `src/utils/construction/equipmentBVResolver.ts` (arc weighting), `src/components/customizer/aerospace/AerospaceStatusBar.tsx`
+- **Validation target**: ≥ 90% within 5% vs canonical aerospace units (catalog is smaller so parity target lower)

--- a/openspec/changes/add-aerospace-battle-value/specs/aerospace-unit-system/spec.md
+++ b/openspec/changes/add-aerospace-battle-value/specs/aerospace-unit-system/spec.md
@@ -1,0 +1,30 @@
+# aerospace-unit-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Aerospace BV Breakdown on Unit State
+
+Every `IAerospaceUnit` SHALL carry an `IAerospaceBVBreakdown`.
+
+#### Scenario: Breakdown shape
+
+- **GIVEN** an aerospace unit after construction completes
+- **WHEN** BV is computed
+- **THEN** `unit.bvBreakdown` SHALL contain at minimum `defensive`, `offensive`, `pilotMultiplier`, `arcContributions`, `final`
+
+#### Scenario: Arc contributions exposed
+
+- **GIVEN** an ASF with 200 BV in Nose, 100 BV in each Wing, 50 in Aft
+- **WHEN** arc contributions are computed
+- **THEN** the breakdown SHALL include per-arc percentage and weighted BV
+- **AND** the status bar SHALL display the primary-arc label
+
+### Requirement: Aerospace BV Parity Harness
+
+The validation tooling SHALL produce an aerospace BV parity report.
+
+#### Scenario: Validator output
+
+- **WHEN** the aerospace BV validator runs
+- **THEN** it SHALL emit `validation-output/aerospace-bv-validation-report.json`
+- **AND** the report SHALL list each fighter with `computedBV`, `mulBV`, `delta`, `deltaPct`

--- a/openspec/changes/add-aerospace-battle-value/specs/battle-value-system/spec.md
+++ b/openspec/changes/add-aerospace-battle-value/specs/battle-value-system/spec.md
@@ -1,0 +1,68 @@
+# battle-value-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Aerospace BV Dispatch
+
+The BV calculator SHALL route `IAerospaceUnit` inputs to an aerospace-specific calculation path.
+
+#### Scenario: ASF dispatch
+
+- **GIVEN** an aerospace fighter
+- **WHEN** `calculateBattleValue` is called
+- **THEN** the aerospace calculator SHALL be invoked
+- **AND** the return SHALL include an `IAerospaceBVBreakdown`
+
+#### Scenario: Conventional fighter multiplier
+
+- **GIVEN** a conventional fighter
+- **WHEN** final BV is computed
+- **THEN** `(defensive + offensive)` SHALL be multiplied by 0.8 before pilot adjustment
+
+### Requirement: Aerospace Defensive BV
+
+Aerospace defensive BV SHALL use Structural Integrity in place of the mech gyro term.
+
+#### Scenario: SI BV
+
+- **GIVEN** a 50-ton ASF with SI 5
+- **WHEN** SI BV is computed
+- **THEN** siBV SHALL equal `5 × 0.5 × 50 = 125`
+
+#### Scenario: Defensive factor uses Max Thrust
+
+- **GIVEN** an ASF with maxThrust 9
+- **WHEN** defensive factor is computed
+- **THEN** defensive factor SHALL equal `1 + (9 / 10) = 1.9`
+
+### Requirement: Aerospace Offensive BV Arc Fire Pool
+
+Aerospace offensive BV SHALL combine arc-weighted weapon contributions.
+
+#### Scenario: Primary arc contributes 100%
+
+- **GIVEN** an ASF whose Nose arc holds the highest-BV weapon pool
+- **WHEN** offensive BV is computed
+- **THEN** the Nose arc SHALL contribute at 100%
+- **AND** the Aft arc SHALL contribute at 25%
+- **AND** the LeftWing and RightWing SHALL each contribute at 50%
+- **AND** Fuselage weapons SHALL always contribute at 100%
+
+#### Scenario: Primary arc not Nose
+
+- **GIVEN** an ASF whose LeftWing arc has higher BV than Nose
+- **WHEN** fire-pool weighting is applied
+- **THEN** LeftWing SHALL contribute at 100%
+- **AND** RightWing (opposite arc) SHALL contribute at 25%
+- **AND** Nose / Aft SHALL contribute at 50% each
+
+### Requirement: Aerospace Speed Factor
+
+Aerospace speed factor SHALL use the average of Safe and Max Thrust.
+
+#### Scenario: Speed factor calculation
+
+- **GIVEN** an ASF with safeThrust 5, maxThrust 7
+- **WHEN** speed factor is computed
+- **THEN** avgThrust SHALL equal 6
+- **AND** speed factor SHALL equal `round(pow(1 + (6 − 5) / 10, 1.2) × 100) / 100 = 1.12`

--- a/openspec/changes/add-aerospace-battle-value/tasks.md
+++ b/openspec/changes/add-aerospace-battle-value/tasks.md
@@ -1,0 +1,66 @@
+# Tasks: Add Aerospace Battle Value
+
+## 1. Calculator Scaffolding
+
+- [ ] 1.1 Create `src/utils/construction/aerospace/aerospaceBV.ts`
+- [ ] 1.2 Export `calculateAerospaceBV(unit: IAerospaceUnit): IAerospaceBVBreakdown`
+- [ ] 1.3 Wire dispatch in `battleValueCalculations.ts`
+- [ ] 1.4 Define `IAerospaceBVBreakdown`
+
+## 2. Defensive BV
+
+- [ ] 2.1 armorBV = totalArmor × 2.5 × armorTypeMultiplier
+- [ ] 2.2 siBV = structuralIntegrity × 0.5 × tonnage
+- [ ] 2.3 defEquipBV (ECM, active probe, chaff pod, etc.)
+- [ ] 2.4 Explosive penalty sum
+- [ ] 2.5 defensiveFactor = 1 + (maxThrust / 10)
+- [ ] 2.6 defensiveBV = (armorBV + siBV + defEquipBV − explosive) × defensiveFactor
+
+## 3. Offensive BV
+
+- [ ] 3.1 Compute per-arc weapon BV sum (Nose, LeftWing, RightWing, Aft, Fuselage)
+- [ ] 3.2 Identify the primary arc (highest BV): 100% contribution
+- [ ] 3.3 Opposite arc: 25%; side arcs: 50%; fuselage: 100%
+- [ ] 3.4 Sum ammo BV
+- [ ] 3.5 Add offensive equipment BV (TAG, Targeting Computer, C3, etc.)
+
+## 4. Speed Factor
+
+- [ ] 4.1 avgThrust = (safeThrust + maxThrust) / 2
+- [ ] 4.2 sf = round(pow(1 + (avgThrust − 5) / 10, 1.2) × 100) / 100
+- [ ] 4.3 Apply sf to offensive BV
+
+## 5. Sub-Type Multipliers
+
+- [ ] 5.1 Conventional fighter: final BV × 0.8
+- [ ] 5.2 Small craft: armor BV × 1.2 inside defensive block
+- [ ] 5.3 ASF: no adjustment (baseline)
+
+## 6. Pilot Skill Multiplier
+
+- [ ] 6.1 Reuse shared gunnery × piloting table
+- [ ] 6.2 finalBV = (defensiveBV + offensiveBV) × pilotMult
+
+## 7. Small Craft Specifics
+
+- [ ] 7.1 Side arcs (LeftSide / RightSide) treated like wings for fire-pool weighting
+- [ ] 7.2 Passenger / cargo bays have no BV contribution
+- [ ] 7.3 Bomb bays count as Fuselage slots for BV purposes
+
+## 8. Status Bar
+
+- [ ] 8.1 `AerospaceStatusBar.tsx` displays live BV breakdown
+- [ ] 8.2 Per-arc contribution visible in breakdown dialog
+
+## 9. BV Parity Harness
+
+- [ ] 9.1 Extend validation harness to load aerospace canonical units
+- [ ] 9.2 Compare against MegaMekLab BV values
+- [ ] 9.3 Emit `validation-output/aerospace-bv-validation-report.json`
+- [ ] 9.4 Baseline target: ≥ 90% within 5%, ≥ 75% within 1%
+
+## 10. Validation
+
+- [ ] 10.1 `openspec validate add-aerospace-battle-value --strict`
+- [ ] 10.2 Unit tests: Shilone, Stingray, Sabre, SL-17 Shilone, generic small craft
+- [ ] 10.3 Build + lint clean

--- a/openspec/changes/add-aerospace-combat-behavior/proposal.md
+++ b/openspec/changes/add-aerospace-combat-behavior/proposal.md
@@ -1,0 +1,42 @@
+# Change: Add Aerospace Combat Behavior (2D simplified)
+
+## Why
+
+Aerospace combat in BattleTech uses altitude levels, thrust-point economy, heading changes, and aero-specific movement paperwork that, taken together, is effectively a second combat engine. Shipping a full implementation in Phase 6 would dominate the schedule. This change adds a **2D-simplified** aerospace combat mode good enough for ground-map air support: flying units travel 2× their ground-equivalent MP per turn, fire like gun platforms using arc-based BV, take damage through the aerospace arc / SI / fuselage chain, and leave / re-enter the board as simple off-map events. Full altitude, vectoring, thrust economy, and atmospheric turning is explicitly out of scope and becomes a Phase 6-adjacent follow-up.
+
+## What Changes
+
+- Add aerospace hit-location tables (Nose / LeftWing / RightWing / Aft per attack direction)
+- Add aerospace damage pipeline: armor-arc → SI → crit → pilot
+- Add SI threshold damage (TW: `damage > 0.1 × SI` triggers control roll; excess depletes SI)
+- Add aerospace critical-hit table: 2 = no crit, 3 = crew stunned, 4-5 = cargo/fuel, 6-7 = avionics, 8-9 = engine / SI, 10-11 = control surfaces, 12 = catastrophic
+- Add 2D simplified movement: flying units move at `2 × safeThrust hexes` per turn in a straight line plus one ≤60° turn; no altitude tracking
+- Add "off-map" state: a flying unit that reaches a board edge enters off-map for N turns then may re-enter
+- Add `FlyOver` attack resolution: a flying unit strafes hexes along its 2D path, applying bomb / strafe damage
+- Add aerospace firing arc computation: Nose 60° forward, Wings 120° each side, Aft 60° rear (mirrored against chassis facing)
+- Add heat-per-turn tracking (aerospace heat-sink pool)
+- Add basic fuel burn (1 point per thrust per turn); when fuel = 0, unit must leave board
+- Add AI bot "aerospace" behavior: pick strafe target, prioritize survival / heat
+
+## Non-goals
+
+- Altitude levels, altitude-change thrust costs, vectoring arcs, heading markers, atmospheric turning
+- Thrust-point economy and expenditure rules
+- Capital-scale weapons, bay firing, PDS batteries
+- DropShip / JumpShip / WarShip combat
+- Aero-vs-aero dogfighting tables (flying-on-flying uses standard 2D rules)
+
+## Dependencies
+
+- **Requires**: `add-aerospace-construction`, `add-aerospace-battle-value`, `integrate-damage-pipeline` (A4 damage pipeline), `wire-heat-generation-and-effects` (A5 heat wiring — aero heat exempt from mech table but shares bus)
+- **Blocks**: (nothing downstream in Phase 6; full aerospace rules is Phase 6-adjacent follow-up)
+
+## Ordering in Phase 6
+
+Aerospace combat lands **after** aerospace construction and BV. The 2D simplification keeps the scope bounded so it fits alongside the other four unit types in Phase 6.
+
+## Impact
+
+- **Affected specs**: `combat-resolution` (MODIFIED — aerospace path), `damage-system` (MODIFIED — aerospace transfer chain), `critical-hit-system` (MODIFIED — aerospace crit table), `hit-location-tables` (ADDED — aerospace arcs), `movement-system` (MODIFIED — flying mode), `aerospace-unit-system` (ADDED — combat state)
+- **Affected code**: `src/utils/gameplay/aerospaceDamage.ts` (new), `src/utils/gameplay/aerospaceHitLocation.ts` (new), `src/utils/gameplay/aerospaceMovement.ts` (new), `src/utils/gameplay/aerospaceCriticalHitResolution.ts` (new), `src/engine/GameEngine.ts` (dispatch), `src/engine/InteractiveSession.ts` (fly-over phase)
+- **New events**: `AerospaceEntered`, `AerospaceFlyOver`, `AerospaceExited`, `ControlRoll`, `FuelDepleted`

--- a/openspec/changes/add-aerospace-combat-behavior/specs/aerospace-unit-system/spec.md
+++ b/openspec/changes/add-aerospace-combat-behavior/specs/aerospace-unit-system/spec.md
@@ -1,0 +1,19 @@
+# aerospace-unit-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Aerospace Combat State
+
+Aerospace units SHALL carry a combat state struct updated by the combat engine.
+
+#### Scenario: Combat state shape
+
+- **GIVEN** any `IAerospaceUnit`
+- **WHEN** combat begins
+- **THEN** `unit.combatState.aero` SHALL contain `currentSI`, `armorByArc`, `heat`, `fuelRemaining`, `controlRollsFailed`, `thrustPenalty`, `offMap`, `offMapReturnTurn`
+
+#### Scenario: SI capped by max
+
+- **GIVEN** an ASF with construction SI 6 that takes negative-damage events (e.g., repair mid-combat, future)
+- **WHEN** SI changes
+- **THEN** `currentSI` SHALL never exceed the unit's construction SI

--- a/openspec/changes/add-aerospace-combat-behavior/specs/combat-resolution/spec.md
+++ b/openspec/changes/add-aerospace-combat-behavior/specs/combat-resolution/spec.md
@@ -1,0 +1,88 @@
+# combat-resolution (delta)
+
+## ADDED Requirements
+
+### Requirement: Aerospace Combat Dispatch
+
+The combat resolution engine SHALL route aerospace targets to an aerospace-specific damage pipeline distinct from the BattleMech and Vehicle paths.
+
+#### Scenario: Aerospace target routing
+
+- **GIVEN** an attack whose target has `unitType === UnitType.AEROSPACE_FIGHTER`, `CONVENTIONAL_FIGHTER`, or `SMALL_CRAFT`
+- **WHEN** the engine resolves the hit
+- **THEN** `aerospaceResolveDamage()` SHALL be invoked
+- **AND** aerospace-specific hit-location and critical-hit tables SHALL be used
+
+### Requirement: Aerospace Damage Chain
+
+The system SHALL apply aerospace damage to arc armor first, then reduce Structural Integrity.
+
+#### Scenario: Damage absorbed by armor
+
+- **GIVEN** an ASF whose Nose arc has 20 armor and the current SI is 6
+- **WHEN** 15 damage hits the Nose
+- **THEN** Nose armor SHALL be reduced to 5
+- **AND** SI SHALL remain 6
+
+#### Scenario: Damage reduces SI
+
+- **GIVEN** the same ASF after Nose armor has dropped to 0
+- **WHEN** 20 additional damage hits the Nose
+- **THEN** SI SHALL be reduced by `floor(20 / 10) = 2`
+- **AND** SI SHALL equal 4
+
+#### Scenario: SI destruction destroys unit
+
+- **GIVEN** an aerospace unit with SI 1
+- **WHEN** damage reduces SI to 0 or below
+- **THEN** the unit SHALL be destroyed
+- **AND** a `UnitDestroyed` event SHALL fire
+
+### Requirement: Aerospace Control Roll
+
+Damage exceeding 10% of current SI SHALL trigger a Control Roll.
+
+#### Scenario: Control roll trigger
+
+- **GIVEN** an ASF with SI 10 that takes 3 damage in a single hit
+- **WHEN** damage is applied
+- **THEN** a Control Roll SHALL be required (3 > 10 × 0.1 = 1.0)
+- **AND** a `ControlRoll` event SHALL fire with its pass/fail result
+
+#### Scenario: Control roll failure penalty
+
+- **GIVEN** a failed Control Roll
+- **WHEN** effects are applied
+- **THEN** the unit SHALL take 1 additional SI damage
+- **AND** the next movement phase SHALL begin with a −1 thrust penalty
+
+## MODIFIED Requirements
+
+### Requirement: Damage Distribution
+
+The system SHALL distribute damage across units based on battle intensity and outcome.
+
+#### Scenario: Victory results in light damage
+
+- **GIVEN** a battle with outcome VICTORY and 4 player units
+- **WHEN** distributeDamage is called
+- **THEN** units receive 0-30% damage on average
+
+#### Scenario: Defeat results in heavy damage
+
+- **GIVEN** a battle with outcome DEFEAT and 4 player units
+- **WHEN** distributeDamage is called
+- **THEN** units receive 40-80% damage on average
+
+#### Scenario: Draw results in moderate damage
+
+- **GIVEN** a battle with outcome DRAW and 4 player units
+- **WHEN** distributeDamage is called
+- **THEN** units receive 20-50% damage on average
+
+#### Scenario: Aerospace fly-off counts as surviving
+
+- **GIVEN** a battle where an aerospace unit exited the map before destruction
+- **WHEN** distributeDamage is called
+- **THEN** the aerospace unit SHALL be treated as surviving (not wrecked)
+- **AND** only actual SI/arc damage SHALL be recorded

--- a/openspec/changes/add-aerospace-combat-behavior/specs/movement-system/spec.md
+++ b/openspec/changes/add-aerospace-combat-behavior/specs/movement-system/spec.md
@@ -1,0 +1,59 @@
+# movement-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Aerospace 2D Simplified Movement
+
+Aerospace units SHALL move under a 2D-simplified flight model for Phase 6 combat.
+
+#### Scenario: Flying unit range per turn
+
+- **GIVEN** an ASF with safeThrust 6
+- **WHEN** computing legal movement for the turn
+- **THEN** the unit SHALL be allowed to move up to `2 × safeThrust = 12 hexes`
+- **AND** the path SHALL be a straight line from the current hex plus at most one ≤ 60° turn
+
+#### Scenario: No altitude tracking
+
+- **GIVEN** any flying unit in Phase 6 2D mode
+- **WHEN** reading combat state
+- **THEN** the unit SHALL NOT have an altitude property
+- **AND** line-of-sight SHALL always treat flying units as "above the board"
+
+#### Scenario: Reaching board edge exits unit
+
+- **GIVEN** a flying unit whose path reaches a board-edge hex
+- **WHEN** movement is resolved
+- **THEN** an `AerospaceExited` event SHALL fire
+- **AND** the unit SHALL enter off-map state for the scenario-defined return delay (default 2 turns)
+
+#### Scenario: Re-entry from off-map
+
+- **GIVEN** a flying unit in off-map state whose return delay has elapsed
+- **WHEN** its owner chooses a board-edge re-entry hex
+- **THEN** an `AerospaceEntered` event SHALL fire
+- **AND** the unit SHALL resume movement with the facing it had at exit
+
+### Requirement: Fuel Consumption per Turn
+
+Flying units SHALL consume fuel equal to the thrust used each turn.
+
+#### Scenario: Fuel burn
+
+- **GIVEN** an ASF that moves its full 2 × safeThrust during a turn
+- **WHEN** end-of-turn cleanup runs
+- **THEN** fuel points SHALL decrease by the thrust actually used that turn
+- **AND** when fuel reaches 0 a `FuelDepleted` event SHALL fire
+- **AND** the unit SHALL leave the board at the next movement phase (cannot re-enter this scenario)
+
+### Requirement: Fly-Over Strafe Movement
+
+The system SHALL allow a flying unit to declare a strafe path during movement, applying attacks to ground units in the path hexes.
+
+#### Scenario: Strafe declaration
+
+- **GIVEN** an ASF moving over 4 hexes, 2 of which contain enemy ground units
+- **WHEN** the player declares strafe on those hexes
+- **THEN** Nose or Wing weapons SHALL fire at ground units in those hexes during movement
+- **AND** each strafed hex SHALL add +2 to-hit penalty to that shot
+- **AND** an `AerospaceFlyOver` event SHALL record affected hexes and damage applied

--- a/openspec/changes/add-aerospace-combat-behavior/tasks.md
+++ b/openspec/changes/add-aerospace-combat-behavior/tasks.md
@@ -1,0 +1,101 @@
+# Tasks: Add Aerospace Combat Behavior (2D simplified)
+
+## 1. Unit-Type Dispatch
+
+- [ ] 1.1 Route `resolveDamage()` to `aerospaceResolveDamage()` when target is `IAerospaceUnit`
+- [ ] 1.2 Route `resolveCriticalHits()` to aerospace variant
+- [ ] 1.3 Route `hitLocation.ts` to aerospace arc tables
+- [ ] 1.4 Route `movement` to aerospace 2D flight rules
+
+## 2. Aerospace Hit Location Tables
+
+- [ ] 2.1 Front attack: 2=Nose(TAC), 3-4=RightWing, 5-7=Nose, 8-9=LeftWing, 10-11=Aft, 12=Nose(TAC)
+- [ ] 2.2 Side attack: 2=Side(TAC), 3-5=Nose, 6-8=NearWing, 9-10=Aft, 11-12=Side(TAC)
+- [ ] 2.3 Rear attack: 2=Aft(TAC), 3-5=Wing (random L/R), 6-8=Aft, 9-10=Nose, 11-12=Aft(TAC)
+- [ ] 2.4 Small craft: swap LeftWing/RightWing → LeftSide/RightSide tables
+- [ ] 2.5 Unit tests for every (direction × roll) combo
+
+## 3. Armor → SI Damage Chain
+
+- [ ] 3.1 Apply damage to hit-arc armor first
+- [ ] 3.2 Excess reduces SI by (excess / 10) rounded down
+- [ ] 3.3 When SI reaches 0, the unit is destroyed
+- [ ] 3.4 Emit `SIReduced` event when SI changes
+- [ ] 3.5 No arc-to-arc transfer (aerospace damage does not carry over)
+
+## 4. Control Roll Trigger
+
+- [ ] 4.1 Damage > (0.1 × current SI) triggers a Control Roll
+- [ ] 4.2 Control Roll = 2d6 + pilot skill + damage modifier vs TN 8
+- [ ] 4.3 Failure: unit takes 1 additional SI damage and may lose control heading
+- [ ] 4.4 Emit `ControlRoll` event (pass/fail)
+
+## 5. Aerospace Critical Hit Table
+
+- [ ] 5.1 Trigger on TAC (roll 2) or SI-exposing damage
+- [ ] 5.2 Table: 2 = nothing, 3 = crew stunned, 4-5 = cargo/fuel hit, 6-7 = avionics, 8-9 = engine hit (+5 heat, can destroy), 10-11 = control surfaces (−1 thrust), 12 = catastrophic (destroyed)
+- [ ] 5.3 Fuel hit: bleed 5 fuel points + ignition chance
+- [ ] 5.4 Avionics: +1 to-hit on all subsequent attacks
+- [ ] 5.5 Engine: aerospace engine crits count separately from mech rules
+- [ ] 5.6 Emit `ComponentDestroyed` events per hit
+
+## 6. 2D Simplified Movement
+
+- [ ] 6.1 Flying unit moves `2 × safeThrust` hexes per turn (MVP simplification)
+- [ ] 6.2 Movement is a straight line plus one ≤60° turn
+- [ ] 6.3 No altitude tracking — all flying units are at a single shared "above-board" layer
+- [ ] 6.4 No thrust-point economy — each turn pays nothing from a budget
+- [ ] 6.5 Unit tests: flying unit traversing board, turning, reaching edge
+
+## 7. Off-Map / Re-Entry
+
+- [ ] 7.1 Flying unit that reaches board edge enters off-map state
+- [ ] 7.2 Off-map state lasts N turns (configurable per scenario, default 2)
+- [ ] 7.3 Re-entry hex chosen by unit owner on any edge; original facing restored
+- [ ] 7.4 Emit `AerospaceExited` and `AerospaceEntered` events
+
+## 8. Fly-Over Attack
+
+- [ ] 8.1 During movement, aerospace unit declares a strafe path (series of hexes)
+- [ ] 8.2 Weapons in Nose / Wings may fire at ground units in path hexes
+- [ ] 8.3 Bomb loads drop one bomb per declared drop hex (bomb bays only)
+- [ ] 8.4 Each strafed hex incurs +2 to-hit penalty for the aerospace attacker (simplified)
+- [ ] 8.5 Emit `AerospaceFlyOver` event listing affected hexes
+
+## 9. Firing Arcs
+
+- [ ] 9.1 Nose arc: 60° forward cone
+- [ ] 9.2 Wings: 120° each side (LeftWing / RightWing)
+- [ ] 9.3 Aft: 60° rear cone
+- [ ] 9.4 Fuselage weapons: fire in whichever arc the pilot declares
+- [ ] 9.5 Small craft arcs rename Wings → Sides
+
+## 10. Heat System for Aerospace
+
+- [ ] 10.1 Heat pool uses aerospace heat-sink count (10 baseline + extras)
+- [ ] 10.2 Heat generated same as mech weapon fire
+- [ ] 10.3 Heat 9+: −1 thrust (speed penalty), heat 15+: shutdown check
+- [ ] 10.4 Aerospace heat table is NOT identical to mech — use TW aerospace table
+
+## 11. Fuel Burn
+
+- [ ] 11.1 Each turn a flying unit spends fuel equal to the thrust used
+- [ ] 11.2 Fuel 0: unit must leave board, may not re-enter this scenario
+- [ ] 11.3 Emit `FuelDepleted` event at depletion
+
+## 12. AI Adaptations
+
+- [ ] 12.1 Bot flying an aero unit prefers strafe targets by mech/vehicle BV
+- [ ] 12.2 Bot withdraws when SI ≤ 30% or fuel < 2 turns
+- [ ] 12.3 Bot uses heat-safe attack cadence
+
+## 13. Validation
+
+- [ ] 13.1 `openspec validate add-aerospace-combat-behavior --strict`
+- [ ] 13.2 Simulation harness: 1 ASF vs 2 mechs resolves in ≤ 10 turns
+- [ ] 13.3 Unit tests cover hit-location / SI / control-roll / crit paths
+- [ ] 13.4 Build + lint clean
+
+## 14. Documentation
+
+- [ ] 14.1 Add `docs/architecture/aerospace-combat-2d.md` noting 2D simplification and pointers to the full-rules follow-up

--- a/openspec/changes/add-aerospace-construction/proposal.md
+++ b/openspec/changes/add-aerospace-construction/proposal.md
@@ -1,0 +1,43 @@
+# Change: Add Aerospace Construction
+
+## Why
+
+Aerospace fighters, conventional fighters, and small craft play meaningful air-to-ground roles in campaigns, but their construction pipeline is a skeleton. `src/components/customizer/aerospace/` has four tabs but the store doesn't enforce engine/thrust coupling, structural integrity limits, fuel tonnage, armor arc max, or equipment-per-arc slot counts. This change completes aerospace construction so Phase 6 BV and 2D combat behavior have legal inputs.
+
+## What Changes
+
+- Add chassis configuration: aerospace fighter (5–100t) / conventional fighter (5–50t) / small craft (100–200t)
+- Add engine selection tuned for aerospace: Fusion / XL / Compact Fusion / ICE / Fuel Cell, with rating-to-thrust tables and bay-location rules
+- Add Safe Thrust / Max Thrust calculation: `maxThrust = floor(safeThrust × 1.5)`, safeThrust = engineRating / tonnage
+- Add Structural Integrity (SI) defaulting to `ceil(tonnage / 10)`, rising to max table
+- Add fuel tonnage minimums by unit sub-type and burn rate per thrust; `fuelTons × pointsPerTon = fuelPoints`
+- Add armor allocation across 4 arcs (Nose, Left Wing, Right Wing, Aft) — small craft uses Left Side / Right Side
+- Add armor max per arc = tonnage × armor-factor table (heavier = more)
+- Add equipment mounting per firing arc + Fuselage (internal) with arc-based slot counts
+- Add crew calculation: small craft requires crew + passengers with life support tonnage
+- Add heat sink pool (aerospace uses 10 engine-free heat sinks baseline)
+- Add construction validation rule set `VAL-AERO-*` — tonnage ranges, engine / thrust legality, SI within table, fuel minimum, armor max per arc
+- Wire the pipeline into the aerospace store and customizer tabs
+
+## Non-goals
+
+- Aerospace combat (altitude / vectoring / fuel burn during combat) — `add-aerospace-combat-behavior`
+- BV calculation — `add-aerospace-battle-value`
+- DropShip / JumpShip / WarShip construction — out of scope
+- Atmospheric re-entry and gravity adaptation — future work
+
+## Dependencies
+
+- **Requires**: existing `aerospace-unit-system` spec stubs, `construction-services`, `engine-system`, `armor-system`
+- **Blocks**: `add-aerospace-battle-value`, `add-aerospace-combat-behavior`
+- **Phase 1 coupling**: none at construction — BV / combat handle coupling
+
+## Ordering in Phase 6
+
+Aerospace is the second of five unit types after vehicles.
+
+## Impact
+
+- **Affected specs**: `aerospace-unit-system` (ADDED — engine / SI / fuel / armor / crew / validation), `construction-rules-core` (MODIFIED to dispatch aerospace path), `validation-rules-master` (MODIFIED)
+- **Affected code**: `src/stores/aerospace/`, `src/utils/construction/aerospace/`, `src/components/customizer/aerospace/*`, `src/types/aerospace/`
+- **New files**: aerospace engine/thrust calculator, SI tables, fuel burn constants, aerospace armor arc tables

--- a/openspec/changes/add-aerospace-construction/specs/aerospace-unit-system/spec.md
+++ b/openspec/changes/add-aerospace-construction/specs/aerospace-unit-system/spec.md
@@ -1,0 +1,137 @@
+# aerospace-unit-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Aerospace Thrust Derivation
+
+The system SHALL derive Safe Thrust and Max Thrust from engine rating and tonnage.
+
+#### Scenario: ASF safe-thrust calculation
+
+- **GIVEN** a 50-ton aerospace fighter with engine rating 250
+- **WHEN** thrust is computed
+- **THEN** `safeThrust` SHALL equal 5 (250 / 50)
+- **AND** `maxThrust` SHALL equal 7 (floor(5 × 1.5))
+
+#### Scenario: Conventional fighter fusion exclusion
+
+- **GIVEN** a conventional fighter
+- **WHEN** engine type is set to Fusion
+- **THEN** validation SHALL emit an error — conventional fighters require ICE or Fuel Cell engines
+
+#### Scenario: Exceeds class thrust cap
+
+- **GIVEN** a 5-ton aerospace fighter with rating 100 → safeThrust 20
+- **WHEN** thrust is validated
+- **THEN** validation SHALL cap safeThrust at the class maximum from the thrust-by-tonnage table
+
+### Requirement: Structural Integrity Calculation
+
+The system SHALL compute and validate Structural Integrity (SI) per aerospace sub-type.
+
+#### Scenario: Default SI
+
+- **GIVEN** a 60-ton ASF with no SI override
+- **WHEN** SI is computed
+- **THEN** `structuralIntegrity` SHALL equal `ceil(60 / 10) = 6`
+
+#### Scenario: SI weight cost
+
+- **GIVEN** a 50-ton ASF with SI = 7 (one above default 5)
+- **WHEN** SI weight is computed
+- **THEN** the weight cost SHALL reflect `(7 − 5) × (50 / 10) × 0.5 = 5.0 tons` of additional mass
+- **AND** the calculator SHALL charge this mass against total tonnage
+
+#### Scenario: SI over class max
+
+- **GIVEN** a CF with SI requested 20 (class max 15)
+- **WHEN** SI is validated
+- **THEN** `VAL-AERO-SI` SHALL emit an error
+
+### Requirement: Fuel Tonnage Minimum
+
+Each aerospace sub-type SHALL enforce a minimum fuel tonnage, with fuel points derived from engine type.
+
+#### Scenario: ASF minimum fuel
+
+- **GIVEN** an aerospace fighter configured with 4 tons of fuel
+- **WHEN** validation runs
+- **THEN** `VAL-AERO-FUEL` SHALL emit an error — ASF requires minimum 5 tons
+
+#### Scenario: Fusion fuel points
+
+- **GIVEN** a fusion-engined ASF with 5 tons of fuel
+- **WHEN** fuel points are computed
+- **THEN** `fuelPoints` SHALL equal `5 × 80 = 400`
+
+#### Scenario: Small craft minimum fuel
+
+- **GIVEN** a small craft with 15 tons of fuel
+- **WHEN** validation runs
+- **THEN** `VAL-AERO-FUEL` SHALL emit an error — small craft require minimum 20 tons
+
+### Requirement: Armor Allocation per Firing Arc
+
+The system SHALL split armor across aerospace arcs and enforce per-arc maxima.
+
+#### Scenario: ASF four-arc maxima
+
+- **GIVEN** a 50-ton ASF
+- **WHEN** per-arc armor max is computed
+- **THEN** Nose, LeftWing, RightWing, and Aft SHALL each have a defined max derived from tonnage × arc-factor
+- **AND** total armor SHALL NOT exceed the sum of arc maxima
+
+#### Scenario: Exceed arc max
+
+- **GIVEN** a 50-ton ASF where the Nose max is 40 points
+- **WHEN** the user sets Nose armor to 45
+- **THEN** `VAL-AERO-ARC-MAX` SHALL emit an error
+
+#### Scenario: Small craft side arcs
+
+- **GIVEN** a small craft
+- **WHEN** armor arcs are listed
+- **THEN** the four arcs SHALL be Nose, LeftSide, RightSide, Aft (not LeftWing / RightWing)
+
+### Requirement: Equipment Mounting per Arc
+
+The system SHALL mount equipment to legal aerospace arcs and enforce slot counts.
+
+#### Scenario: Nose slot count
+
+- **GIVEN** an ASF
+- **WHEN** the user tries to mount 7 weapons in the Nose
+- **THEN** mounting SHALL fail — Nose arc holds at most 6
+
+#### Scenario: Fuselage unlimited slots
+
+- **GIVEN** an ASF with 8 tons of equipment destined for Fuselage
+- **WHEN** mounting is attempted
+- **THEN** mounting SHALL succeed if total tonnage fits
+- **AND** Fuselage SHALL have no arc-slot count limit
+
+### Requirement: Small Craft Crew Quarters
+
+Small craft SHALL require crew and passenger quarters weight in construction.
+
+#### Scenario: Minimum crew
+
+- **GIVEN** a 150-ton small craft
+- **WHEN** minimum crew is computed
+- **THEN** the minimum SHALL equal the small-craft-crew table value (≥ 3)
+- **AND** quarters weight SHALL equal crew × 5 tons (Standard quarters)
+
+#### Scenario: No quarters → validation error
+
+- **GIVEN** a small craft with 0 tons quarters
+- **WHEN** validation runs
+- **THEN** `VAL-AERO-CREW` SHALL emit an error
+
+### Requirement: Aerospace Construction Validation Rules
+
+The validation registry SHALL include the `VAL-AERO-*` rule group.
+
+#### Scenario: Rule ids registered
+
+- **WHEN** the validation registry initializes
+- **THEN** `VAL-AERO-TONNAGE`, `VAL-AERO-THRUST`, `VAL-AERO-SI`, `VAL-AERO-FUEL`, `VAL-AERO-ARC-MAX`, and `VAL-AERO-CREW` SHALL be registered

--- a/openspec/changes/add-aerospace-construction/tasks.md
+++ b/openspec/changes/add-aerospace-construction/tasks.md
@@ -1,0 +1,88 @@
+# Tasks: Add Aerospace Construction
+
+## 1. Types and Interfaces
+
+- [ ] 1.1 Extend `IAerospaceUnit` with `safeThrust`, `maxThrust`, `structuralIntegrity`, `fuelTons`, `fuelPoints`, `heatSinkPool`
+- [ ] 1.2 Add `AerospaceArc` enum (Nose, LeftWing, RightWing, Aft, Fuselage; LeftSide, RightSide for small craft)
+- [ ] 1.3 Add `AerospaceEngineType` enum (Fusion, XL, CompactFusion, ICE, FuelCell)
+- [ ] 1.4 Add `ISmallCraftCrew` interface with crew / passenger / marine slots
+- [ ] 1.5 Add `IAerospaceBreakdown` for weight usage summary
+
+## 2. Tonnage Ranges
+
+- [ ] 2.1 Aerospace Fighter: 5–100 tons
+- [ ] 2.2 Conventional Fighter: 5–50 tons (ICE / Fuel Cell only)
+- [ ] 2.3 Small Craft: 100–200 tons
+- [ ] 2.4 Validation error for out-of-range tonnage
+
+## 3. Engine + Thrust Calculation
+
+- [ ] 3.1 safeThrust = engineRating / tonnage (floor), clamped to maximum thrust by size class
+- [ ] 3.2 maxThrust = floor(safeThrust × 1.5)
+- [ ] 3.3 Engine weight = ratingToWeight(engineType, rating)
+- [ ] 3.4 Conventional fighters: ICE doubles weight; Fusion excluded
+- [ ] 3.5 XL engine: half weight, reduced damage threshold (tracked for combat)
+
+## 4. Structural Integrity
+
+- [ ] 4.1 Default SI = ceil(tonnage / 10)
+- [ ] 4.2 SI weight = SI × (tonnage / 10) × 0.5
+- [ ] 4.3 SI max per size class: ASF max 20, CF max 15, Small Craft max 30
+- [ ] 4.4 Increasing SI beyond default increments costs weight
+
+## 5. Fuel Tonnage and Burn Rate
+
+- [ ] 5.1 Minimum fuel: ASF 5 tons, CF 2 tons, Small Craft 20 tons
+- [ ] 5.2 Fuel points per ton: Fusion 80, ICE 40, FuelCell 60
+- [ ] 5.3 Burn per thrust point per turn — stored for combat use
+- [ ] 5.4 Validation: reject < minimum fuel tonnage
+
+## 6. Armor Allocation per Arc
+
+- [ ] 6.1 Four arcs for ASF / CF: Nose, LeftWing, RightWing, Aft
+- [ ] 6.2 Small craft arcs: Nose, LeftSide, RightSide, Aft
+- [ ] 6.3 Max armor per arc = tonnage × aerospace-armor-max-table
+- [ ] 6.4 Total armor ≤ sum of arc maxes
+- [ ] 6.5 Armor weight = totalPoints / pointsPerTon by armor type (Standard, Ferro-Aluminum, Heavy FA, Light FA)
+
+## 7. Equipment Mounting per Arc
+
+- [ ] 7.1 Equipment can be mounted in Nose, LWing, RWing, Aft, or Fuselage (internal; no arc restriction)
+- [ ] 7.2 Slot count per arc: Nose 6, each Wing 6, Aft 4, Fuselage unlimited (bounded by tonnage)
+- [ ] 7.3 Wing-mounted heavy weapons (PPC, Gauss) — tonnage cap per wing
+- [ ] 7.4 Bomb bays — small craft only, configurable bays
+
+## 8. Heat Sink Pool
+
+- [ ] 8.1 Baseline 10 engine-free heat sinks
+- [ ] 8.2 Additional heat sinks weigh 1 ton each (single) or DHS rules (double)
+- [ ] 8.3 Heat-sink tonnage is part of overall weight budget
+
+## 9. Crew (Small Craft)
+
+- [ ] 9.1 Small craft require crew quarters and life support
+- [ ] 9.2 Standard quarters: 5 tons per crew
+- [ ] 9.3 Steerage quarters: 3 tons per passenger
+- [ ] 9.4 Validation: minimum crew per small craft tonnage
+
+## 10. Construction Validation Rules
+
+- [ ] 10.1 `VAL-AERO-TONNAGE` — within sub-type range
+- [ ] 10.2 `VAL-AERO-THRUST` — safeThrust ≤ engine-derived max
+- [ ] 10.3 `VAL-AERO-SI` — SI within table
+- [ ] 10.4 `VAL-AERO-FUEL` — fuel ≥ minimum
+- [ ] 10.5 `VAL-AERO-ARC-MAX` — armor per arc ≤ arc max
+- [ ] 10.6 `VAL-AERO-CREW` — small craft crew / life support present
+
+## 11. Store and UI Wiring
+
+- [ ] 11.1 Wire `aerospaceStore` to persist all new construction state
+- [ ] 11.2 Hook calculators into `AerospaceStructureTab`, `AerospaceArmorTab`, `AerospaceEquipmentTab`
+- [ ] 11.3 `AerospaceStatusBar` shows live tonnage / SI / fuel / armor totals and validation errors
+- [ ] 11.4 `AerospaceDiagram` renders 4-arc armor allocation visually
+
+## 12. Validation
+
+- [ ] 12.1 `openspec validate add-aerospace-construction --strict`
+- [ ] 12.2 Fixtures: Shilone, Stingray, Sabre, SB-27, Union DropShip small-craft shuttle
+- [ ] 12.3 Build + lint clean

--- a/openspec/changes/add-attack-phase-ui/proposal.md
+++ b/openspec/changes/add-attack-phase-ui/proposal.md
@@ -1,0 +1,51 @@
+# Change: Add Attack Phase UI
+
+## Why
+
+The engine can resolve weapon attacks, compute to-hit numbers, roll, and
+apply damage — but the player has no surface to pick weapons, see range
+brackets against the target, preview the to-hit forecast, and confirm
+fire. Without this UI the Weapon Attack phase is invisible to players.
+This change introduces the weapon selector (multi-select, range-aware,
+ammo-aware), the to-hit forecast modal (breaks down every modifier to a
+final target number), and the fire-confirmation handshake. Damage
+animation and post-resolution log entries land in `add-damage-feedback-ui`.
+
+## What Changes
+
+- Add a weapon selector in the action panel when phase is Weapon Attack
+  and a target is locked in
+- Each weapon row shows range badges (Short/Medium/Long vs. target),
+  ammo count, and a checkbox to include it in the attack
+- Add a to-hit forecast modal that opens when the player clicks "Preview
+  Forecast", showing every modifier (base, range, attacker movement,
+  target movement, terrain, heat, SPA adjustments) with a final TN per
+  weapon
+- Add fire confirmation: clicking "Fire" appends an `AttackDeclared`
+  event; resolution happens when both sides lock (existing engine
+  behavior)
+- Resolution results stream into the event log as one entry per weapon
+
+## Dependencies
+
+- **Requires**: `add-interactive-combat-core-ui` (phase HUD, action
+  panel), `add-movement-phase-ui` (movement must commit before attack),
+  `to-hit-resolution`, `weapon-resolution-system`, Lane A A2/A3/A4
+  (weapon data wired, firing arc resolved, damage pipeline connected)
+- **Required By**: `add-damage-feedback-ui` (damage feedback depends on
+  attacks being fireable from the UI)
+
+## Impact
+
+- Affected specs: `to-hit-resolution` (MODIFIED — forecast breakdown
+  projection), `weapon-resolution-system` (MODIFIED — UI-facing weapon
+  state projection including range-to-target and ammo), and
+  `tactical-map-interface` (ADDED — target lock visualization, forecast
+  modal contract)
+- Affected code: `src/components/gameplay/ActionBar.tsx` (extend with
+  weapon selector), `src/components/gameplay/` (new `ToHitForecastModal`
+  component), `src/stores/useGameplayStore.ts` (target lock state +
+  selected weapons set)
+- Non-goals: multi-target attacks (secondary target support deferred),
+  called shots (future rules-level feature), physical attack UI (Lane A
+  A7)

--- a/openspec/changes/add-attack-phase-ui/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-attack-phase-ui/specs/tactical-map-interface/spec.md
@@ -1,0 +1,93 @@
+# tactical-map-interface Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Target Lock Visualization
+
+The tactical map interface SHALL render a pulsing red target ring around a
+locked-in enemy unit token during the Weapon Attack phase, binding the
+ring's visibility to `useGameplayStore.attackPlan.targetId`.
+
+**Priority**: Critical
+
+#### Scenario: Target lock pulses red
+
+- **GIVEN** `attackPlan.targetId = "unit-42"` during Weapon Attack phase
+- **WHEN** the token for unit-42 renders
+- **THEN** a red target ring SHALL pulse around the token
+- **AND** the ring stroke width SHALL be 3px
+
+#### Scenario: Clearing target removes ring
+
+- **GIVEN** a target ring is visible
+- **WHEN** `attackPlan.targetId` becomes `null`
+- **THEN** the ring SHALL disappear within a single re-render
+
+#### Scenario: Target ring only in Weapon Attack phase
+
+- **GIVEN** `attackPlan.targetId` is set but phase is Heat
+- **WHEN** the token renders
+- **THEN** the red target ring SHALL NOT be visible
+
+### Requirement: To-Hit Forecast Modal
+
+The tactical map interface SHALL provide a modal surface that displays the
+breakdown of to-hit modifiers for each selected weapon and the final TN
+for each, based on the `forecastToHit` projection from
+`to-hit-resolution`.
+
+**Priority**: Critical
+
+#### Scenario: Modal opens from Preview Forecast
+
+- **GIVEN** a valid attack plan with at least one selected weapon
+- **WHEN** the player clicks "Preview Forecast"
+- **THEN** the modal SHALL open centered over the combat surface
+- **AND** each selected weapon SHALL render a row with the final TN and
+  an expandable modifier breakdown
+
+#### Scenario: Modifier breakdown expands
+
+- **GIVEN** the modal is open and a weapon row is collapsed
+- **WHEN** the player clicks the row
+- **THEN** the row SHALL expand to show per-modifier labels and signed
+  integer values
+- **AND** zero-value modifiers SHALL be omitted from the breakdown
+
+#### Scenario: Hit probability shown per weapon
+
+- **GIVEN** a weapon with final TN 8
+- **WHEN** the modal renders
+- **THEN** the row SHALL display the probability from `hitProbability(8)`
+  formatted as a percentage (e.g., `"41.7%"`)
+
+#### Scenario: Modal footer shows expected hits
+
+- **GIVEN** three selected weapons with probabilities 0.9, 0.5, 0.1
+- **WHEN** the modal renders
+- **THEN** the footer SHALL display `"Expected hits: 1.5"` (sum of
+  probabilities rounded to 1 decimal)
+
+### Requirement: Waiting-for-Opponent Banner
+
+The tactical map interface SHALL render a dismissible "Waiting for
+Opponent..." banner after the Player side confirms fire during Weapon
+Attack phase and before `attacks_revealed` fires.
+
+**Priority**: High
+
+#### Scenario: Banner appears on Player confirm fire
+
+- **GIVEN** the Player side appends `AttackDeclared` events for all its
+  active units
+- **WHEN** the combat surface re-renders
+- **THEN** a "Waiting for Opponent..." banner SHALL be visible
+- **AND** the weapon selector checkboxes SHALL be disabled
+
+#### Scenario: Banner dismisses on attacks revealed
+
+- **GIVEN** the banner is visible
+- **WHEN** the session emits `attacks_revealed`
+- **THEN** the banner SHALL dismiss
+- **AND** weapon selector checkboxes SHALL remain disabled (locked for
+  phase)

--- a/openspec/changes/add-attack-phase-ui/specs/to-hit-resolution/spec.md
+++ b/openspec/changes/add-attack-phase-ui/specs/to-hit-resolution/spec.md
@@ -1,0 +1,68 @@
+# to-hit-resolution Specification Delta
+
+## ADDED Requirements
+
+### Requirement: To-Hit Forecast Projection
+
+The to-hit resolution system SHALL expose a `forecastToHit(attack)`
+projection that returns the complete modifier breakdown and final target
+number for a prospective weapon attack, without mutating state and without
+rolling dice.
+
+#### Scenario: Forecast returns per-modifier contribution
+
+- **GIVEN** an attacker with gunnery 4, weapon at medium range, attacker
+  moved 2 hexes, target prone, no SPA adjustments, no terrain modifiers
+- **WHEN** `forecastToHit(attack)` is called
+- **THEN** the result SHALL contain entries for
+  `{label, value}` covering base gunnery, range, attacker movement,
+  target movement, terrain, heat, and any active SPAs
+- **AND** the result SHALL contain a `finalTn` equal to the sum of
+  contributions
+
+#### Scenario: Zero-contribution modifiers omitted
+
+- **GIVEN** an attack with zero terrain modifier and zero heat modifier
+- **WHEN** `forecastToHit(attack)` is called
+- **THEN** the `modifiers` list SHALL omit any entry whose value is 0
+- **AND** the `finalTn` SHALL remain correct
+
+#### Scenario: SPA modifiers labeled by SPA name
+
+- **GIVEN** the attacker's pilot has Sniper and Weapon Specialist SPAs
+- **WHEN** `forecastToHit(attack)` is called for a weapon matching Weapon
+  Specialist's chosen weapon
+- **THEN** the modifiers list SHALL contain a `{label: "Sniper", value}`
+  entry
+- **AND** a `{label: "Weapon Specialist", value: -2}` entry
+
+### Requirement: Hit Probability Derivation
+
+The to-hit resolution system SHALL expose a `hitProbability(finalTn)`
+helper that returns the probability of rolling at least `finalTn` on 2d6,
+so the UI can display expected hit counts without implementing dice
+probability locally.
+
+#### Scenario: Probability for TN 7
+
+- **GIVEN** `finalTn = 7`
+- **WHEN** `hitProbability(7)` is called
+- **THEN** the result SHALL equal 21/36 (≈ 0.583)
+
+#### Scenario: Probability for TN 12
+
+- **GIVEN** `finalTn = 12`
+- **WHEN** `hitProbability(12)` is called
+- **THEN** the result SHALL equal 1/36 (≈ 0.028)
+
+#### Scenario: Probability clamped for TN below 2
+
+- **GIVEN** `finalTn = 1`
+- **WHEN** `hitProbability(1)` is called
+- **THEN** the result SHALL equal 1.0 (guaranteed hit)
+
+#### Scenario: Probability for TN above 12 returns zero
+
+- **GIVEN** `finalTn = 13`
+- **WHEN** `hitProbability(13)` is called
+- **THEN** the result SHALL equal 0.0 (impossible)

--- a/openspec/changes/add-attack-phase-ui/specs/weapon-resolution-system/spec.md
+++ b/openspec/changes/add-attack-phase-ui/specs/weapon-resolution-system/spec.md
@@ -1,0 +1,71 @@
+# weapon-resolution-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: UI Weapon State Projection
+
+The weapon resolution system SHALL expose an `IUIWeaponState` projection
+per weapon on a given unit that the attack-phase UI uses to render the
+weapon selector without querying multiple subsystems.
+
+#### Scenario: Projection contains range, ammo, status
+
+- **GIVEN** a BattleMech with a Medium Laser in the right arm
+- **WHEN** the UI requests the projection for that mech at a target 5
+  hexes away
+- **THEN** the projection SHALL contain `{weaponId, name, location,
+damage, heat, rangeBracket, inRange, ammoRemaining, status}`
+- **AND** `rangeBracket` SHALL be one of `Short | Medium | Long |
+OutOfRange`
+
+#### Scenario: Projection reflects destroyed weapons
+
+- **GIVEN** a weapon whose location has been destroyed
+- **WHEN** the projection is requested
+- **THEN** the `status` field SHALL be `"destroyed"`
+- **AND** the UI SHALL render the row as disabled
+
+#### Scenario: Projection reflects jammed weapons
+
+- **GIVEN** a weapon with `jammed = true`
+- **WHEN** the projection is requested
+- **THEN** the `status` field SHALL be `"jammed"`
+
+#### Scenario: Projection reflects ammo exhaustion
+
+- **GIVEN** an ammo-consuming weapon with `ammoRemaining = 0`
+- **WHEN** the projection is requested
+- **THEN** the `ammoRemaining` field SHALL be 0
+- **AND** `status` SHALL include `"no_ammo"` marker
+
+### Requirement: Attack Declaration Event Emission
+
+The weapon resolution system SHALL, on UI-confirmed fire, append an
+`AttackDeclared` event to the session event stream whose payload contains
+the attacker id, target id, and ordered list of weapon ids selected for
+the attack.
+
+#### Scenario: Confirm Fire appends AttackDeclared
+
+- **GIVEN** a Player-side unit with an attack plan (target locked, at
+  least one weapon selected)
+- **WHEN** the player clicks "Confirm Fire"
+- **THEN** an `AttackDeclared` event SHALL be appended with
+  `{attackerId, targetId, weaponIds}`
+- **AND** the attacker SHALL be marked as "attack_locked" until phase
+  reveal
+
+#### Scenario: Confirm Fire with empty weapons rejected
+
+- **GIVEN** an attack plan with an empty `selectedWeapons` set
+- **WHEN** the player clicks "Confirm Fire"
+- **THEN** no event SHALL be appended
+- **AND** the confirm button SHALL be disabled
+
+#### Scenario: Confirm Fire with out-of-range-only weapons rejected
+
+- **GIVEN** an attack plan whose selected weapons are all out of range
+- **WHEN** the player clicks "Confirm Fire"
+- **THEN** no event SHALL be appended
+- **AND** an inline error `"All selected weapons are out of range"`
+  SHALL display

--- a/openspec/changes/add-attack-phase-ui/tasks.md
+++ b/openspec/changes/add-attack-phase-ui/tasks.md
@@ -1,0 +1,98 @@
+# Tasks: Add Attack Phase UI
+
+## 1. Attack Phase State
+
+- [ ] 1.1 Extend `useGameplayStore` with `attackPlan: {attackerId,
+    targetId, selectedWeapons: Set<weaponId>}`
+- [ ] 1.2 Clear `attackPlan` on phase change away from Weapon Attack
+- [ ] 1.3 Selector `getAttackPlan(attackerId)` returns current plan
+
+## 2. Target Lock Flow
+
+- [ ] 2.1 During Weapon Attack phase, clicking an enemy token while a
+      friendly unit is selected locks that enemy as the target
+- [ ] 2.2 Target token receives a pulsing red target ring
+- [ ] 2.3 Clicking the target again or clicking empty hex clears the
+      target
+
+## 3. Weapon Selector List
+
+- [ ] 3.1 Action panel shows a collapsible "Weapons" list during Weapon
+      Attack phase
+- [ ] 3.2 Each weapon row shows name, location, damage, heat
+- [ ] 3.3 Each row has a checkbox bound to
+      `attackPlan.selectedWeapons`
+- [ ] 3.4 Destroyed/jammed weapons render disabled with a status badge
+
+## 4. Range Badges
+
+- [ ] 4.1 Each weapon row shows three range badges (S/M/L)
+- [ ] 4.2 The badge matching current range-to-target is highlighted
+- [ ] 4.3 Weapons out of range show a red "Out of range" indicator
+
+## 5. Ammo Counters
+
+- [ ] 5.1 Ammo-consuming weapons show an inline `AmmoCounter`
+- [ ] 5.2 Weapons with 0 ammo render disabled
+- [ ] 5.3 Selected ammo-consuming weapons with 0 ammo block forecast
+      preview
+
+## 6. To-Hit Forecast Modal
+
+- [ ] 6.1 "Preview Forecast" button opens the forecast modal
+- [ ] 6.2 Modal lists each selected weapon with its final TN
+- [ ] 6.3 Each weapon row expands to show modifier breakdown: base
+      gunnery, range, attacker movement, target movement, terrain, heat,
+      SPA adjustments
+- [ ] 6.4 Modifiers show both the label and signed integer contribution
+      (`Range +2`, `Heat +1`, `Sniper -1`)
+- [ ] 6.5 Modal footer shows the overall expected hits count (sum of
+      per-weapon hit probabilities)
+
+## 7. Fire Confirmation
+
+- [ ] 7.1 Modal has "Confirm Fire" and "Back" buttons
+- [ ] 7.2 "Confirm Fire" appends an `AttackDeclared` event with the
+      selected weapons and target
+- [ ] 7.3 After confirm, the action panel marks the attacker as "locked"
+      and grays out weapon checkboxes
+- [ ] 7.4 Phase advances when both sides have locked attacks (existing
+      engine behavior; UI must reflect wait state)
+
+## 8. Resolution Log
+
+- [ ] 8.1 On `AttackResolved` events, the event log receives one entry per
+      weapon with hit/miss + location + damage
+- [ ] 8.2 Entries link back to the attacker and target by designation
+- [ ] 8.3 Misses explicitly state the roll vs. TN
+
+## 9. Waiting-for-Opponent State
+
+- [ ] 9.1 After the Player side locks attacks, the combat screen shows a
+      "Waiting for Opponent..." banner
+- [ ] 9.2 Banner dismisses when the session emits `attacks_revealed`
+- [ ] 9.3 Forecast modal cannot be re-opened after commit
+
+## 10. SPA Modifier Display
+
+- [ ] 10.1 Pilot SPAs affecting the attack (e.g., Sniper, Weapon
+      Specialist, Jumping Jack) appear explicitly in the modifier
+      breakdown
+- [ ] 10.2 Zero-impact SPAs SHALL NOT render (avoid noise)
+
+## 11. Tests
+
+- [ ] 11.1 Unit test: selecting a weapon adds it to `attackPlan`
+- [ ] 11.2 Unit test: out-of-range weapons cannot be fired
+- [ ] 11.3 Unit test: forecast shows correct final TN for known modifier
+      stack
+- [ ] 11.4 Integration test: pick target → select weapons → preview →
+      confirm → event log has AttackDeclared entry
+- [ ] 11.5 Integration test: zero-ammo ammo-weapon cannot be fired
+
+## 12. Spec Compliance
+
+- [ ] 12.1 Every delta requirement across `to-hit-resolution`,
+      `weapon-resolution-system`, and `tactical-map-interface` has at
+      least one GIVEN/WHEN/THEN scenario
+- [ ] 12.2 `openspec validate add-attack-phase-ui --strict` passes clean

--- a/openspec/changes/add-attack-phase-ui/tasks.md
+++ b/openspec/changes/add-attack-phase-ui/tasks.md
@@ -3,7 +3,7 @@
 ## 1. Attack Phase State
 
 - [ ] 1.1 Extend `useGameplayStore` with `attackPlan: {attackerId,
-    targetId, selectedWeapons: Set<weaponId>}`
+targetId, selectedWeapons: Set<weaponId>}`
 - [ ] 1.2 Clear `attackPlan` on phase change away from Weapon Attack
 - [ ] 1.3 Selector `getAttackPlan(attackerId)` returns current plan
 

--- a/openspec/changes/add-attack-visual-effects/proposal.md
+++ b/openspec/changes/add-attack-visual-effects/proposal.md
@@ -1,0 +1,53 @@
+# Change: Add Attack Visual Effects
+
+## Why
+
+Attack resolution currently fires events into the log and updates state,
+but the map is silent — no beam, no trail, no impact. A player watching
+two mechs trade fire sees nothing until armor pips start to decay. Phase
+7's presentation bar says the attack itself should be legible: a laser
+is a colored beam, a missile is a dashed trail, a ballistic is a tracer,
+a physical is a shockwave. Impact hexes flash briefly so the origin and
+destination of every hit are obvious.
+
+## What Changes
+
+- Render a beam/trail/tracer/shockwave per weapon category when an
+  `AttackResolved` event fires
+- Lasers: solid colored beam; color keyed to weapon subtype (small/med
+  pulse = IR, med/large = green, ER variants = red-orange)
+- Missiles: dashed line with an arrowhead traveling from origin to target
+- Ballistics (AC, Gauss, MG): short bright tracer dashes
+- Physical (punch, kick, club): circular shockwave at the target hex
+- Brief flash at the impact hex (white burst, 150ms) confirms landing
+- Miss animations use a faded version that terminates past the target
+  hex, so hits and misses are distinguishable
+- All animations respect `prefers-reduced-motion` (degrade to a 300ms
+  connecting line that fades)
+
+## Dependencies
+
+- **Requires**: `add-interactive-combat-core-ui` (Phase 1 MVP),
+  `add-attack-phase-ui` (attacks actually fire from the UI),
+  `weapon-resolution-system`, `tactical-map-interface`
+- **Related**: `add-damage-feedback-effects` (pip decay, damage numbers
+  are upstream of impact flash), `add-mech-silhouette-sprite-set`
+- **Required By**: none — Phase 7 presentation layer
+
+## Impact
+
+- Affected specs: `weapon-resolution-system` (MODIFIED — attack events
+  declare a visual-effect category per weapon for UI playback),
+  `tactical-map-interface` (MODIFIED — new attack effects layer above
+  tokens; click-through preserved), new `attack-effects-system` (ADDED —
+  effect catalog, color keys, timing, impact flash, miss variants)
+- Affected code: new
+  `src/components/gameplay/effects/AttackEffectsLayer.tsx` rendering
+  effect primitives, new `src/utils/effects/weaponEffectMap.ts` mapping
+  weapon type -> visual category + color, new
+  `src/components/gameplay/effects/primitives/` housing LaserBeam,
+  MissileTrail, Tracer, Shockwave, ImpactFlash SVG components
+- Non-goals: sound effects (out of scope), per-salvo animations for
+  ultra/rotary ACs beyond staggered dashes (future refinement),
+  cinematic camera pulls, 3D effects (explicitly shelved)
+- Database: none

--- a/openspec/changes/add-attack-visual-effects/specs/attack-effects-system/spec.md
+++ b/openspec/changes/add-attack-visual-effects/specs/attack-effects-system/spec.md
@@ -1,0 +1,130 @@
+# attack-effects-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Per-Category Effect Primitive
+
+The attack effects system SHALL render one of four effect primitives
+per weapon category: laser beam, missile trail, ballistic tracer, or
+physical shockwave.
+
+#### Scenario: Laser renders as colored beam
+
+- **GIVEN** an attack from a medium laser resolves
+- **WHEN** the effect plays
+- **THEN** a solid colored beam SHALL render from origin to target
+- **AND** the beam duration SHALL be 400ms
+- **AND** the beam color SHALL be green per the medium laser mapping
+
+#### Scenario: Missile renders as dashed trail with arrowhead
+
+- **GIVEN** an attack from a medium laser... no, from an LRM-10 resolves
+- **WHEN** the effect plays
+- **THEN** a dashed line with an arrowhead SHALL animate from origin
+  to target
+- **AND** the duration SHALL be 600ms
+
+#### Scenario: Ballistic renders as tracer dashes
+
+- **GIVEN** an AC/10 attack resolves
+- **WHEN** the effect plays
+- **THEN** short bright tracer dashes SHALL move along the line
+- **AND** the duration SHALL be 300ms
+
+#### Scenario: Physical renders as shockwave
+
+- **GIVEN** a kick attack resolves
+- **WHEN** the effect plays
+- **THEN** an expanding ring SHALL render at the target hex
+- **AND** the duration SHALL be 400ms
+
+### Requirement: Weapon Color Mapping
+
+Each weapon type SHALL resolve to a specific color so that players can
+identify weapons at a glance.
+
+#### Scenario: ER variants use red-orange
+
+- **GIVEN** an ER large laser resolves
+- **WHEN** the beam renders
+- **THEN** the beam color SHALL be red-orange per the mapping
+
+#### Scenario: Pulse lasers use IR tint
+
+- **GIVEN** a medium pulse laser resolves
+- **WHEN** the beam renders
+- **THEN** the beam color SHALL be the IR-tinted variant per mapping
+
+#### Scenario: Standard medium/large lasers use green
+
+- **GIVEN** a standard large laser resolves
+- **WHEN** the beam renders
+- **THEN** the beam color SHALL be green
+
+### Requirement: Impact Flash
+
+On a hit, an impact flash SHALL render at the target hex to mark the
+landing moment.
+
+#### Scenario: Hit triggers impact flash
+
+- **GIVEN** an attack resolves as a hit
+- **WHEN** the primary effect animation completes
+- **THEN** a 150ms white impact flash SHALL render at the target hex
+
+#### Scenario: Miss suppresses impact flash
+
+- **GIVEN** an attack resolves as a miss
+- **WHEN** the primary effect plays
+- **THEN** no impact flash SHALL render
+- **AND** the effect primitive SHALL render at 40% opacity
+- **AND** the primitive SHALL overshoot the target by one hex in the
+  attack direction
+
+### Requirement: Cluster and Multi-Shot Staggering
+
+Multi-projectile weapons SHALL stagger their effect primitives in time
+to read as a salvo rather than a single line.
+
+#### Scenario: LRM salvo staggers trails
+
+- **GIVEN** an LRM-20 volley resolves
+- **WHEN** the effects render
+- **THEN** 20 missile trails SHALL fire with 30ms offsets
+- **AND** total volley duration SHALL not exceed 1200ms
+
+#### Scenario: Ultra AC double-tap staggers tracers
+
+- **GIVEN** an Ultra AC/10 firing both shots resolves
+- **WHEN** the effects render
+- **THEN** two ballistic tracers SHALL fire with 80ms offset
+
+#### Scenario: Rotary AC burst staggers five tracers
+
+- **GIVEN** a Rotary AC/5 at full rate of fire resolves
+- **WHEN** the effects render
+- **THEN** five ballistic tracers SHALL fire with 40ms offset
+
+### Requirement: Reduced Motion Fallback
+
+When `prefers-reduced-motion: reduce` is set, the system SHALL collapse
+all attack effects to a simplified connecting line with a dimmed flash.
+
+#### Scenario: Reduced motion collapses effect
+
+- **GIVEN** `prefers-reduced-motion: reduce` is enabled
+- **WHEN** an attack resolves
+- **THEN** a single 300ms fading line from origin to target SHALL render
+- **AND** the impact flash SHALL shorten to 80ms at 50% opacity
+- **AND** no arcs, shockwaves, or staggered trails SHALL render
+
+### Requirement: Click-Through Preserved
+
+The attack effects layer SHALL not intercept pointer events.
+
+#### Scenario: Effects do not block clicks
+
+- **GIVEN** an active beam renders over a unit token
+- **WHEN** the user clicks the unit
+- **THEN** the click SHALL register on the token (effects layer has
+  `pointer-events: none`)

--- a/openspec/changes/add-attack-visual-effects/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-attack-visual-effects/specs/tactical-map-interface/spec.md
@@ -1,0 +1,26 @@
+# tactical-map-interface Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: Attack Effects Layer
+
+The tactical map interface SHALL include an attack effects layer that
+renders above the unit token layer and subscribes to
+`AttackResolved` events.
+
+#### Scenario: Effects layer renders above tokens
+
+- **GIVEN** an attack animation plays
+- **WHEN** the effect primitive renders
+- **THEN** it SHALL render above unit tokens so beams are not
+  occluded
+- **AND** it SHALL render beneath modal overlays (HUD, minimap,
+  action panel)
+
+#### Scenario: Effects coordinate with damage feedback
+
+- **GIVEN** an attack resolves as a hit causing 5 damage
+- **WHEN** the primary effect plays
+- **THEN** the impact flash SHALL fire at the tail of the effect
+- **AND** damage-pip decay animations SHALL begin synchronized with
+  the impact flash

--- a/openspec/changes/add-attack-visual-effects/specs/weapon-resolution-system/spec.md
+++ b/openspec/changes/add-attack-visual-effects/specs/weapon-resolution-system/spec.md
@@ -1,0 +1,27 @@
+# weapon-resolution-system Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: Attack Events Declare Visual Category
+
+Attack-related events SHALL carry metadata identifying the visual
+effect category so the UI can select the right primitive without
+re-resolving the weapon.
+
+#### Scenario: Event payload carries effect category
+
+- **GIVEN** an attack resolves
+- **WHEN** the `AttackResolved` event is emitted
+- **THEN** the payload SHALL contain `visualCategory: 'laser' |
+'missile' | 'ballistic' | 'physical'`
+- **AND** the payload SHALL contain `visualSubtype` that keys the
+  color mapping (e.g., `med-laser`, `er-large`, `lrm`, `ac-standard`,
+  `kick`)
+
+#### Scenario: Cluster weapons enumerate projectile count
+
+- **GIVEN** a missile weapon resolves
+- **WHEN** the event is emitted
+- **THEN** the payload SHALL contain `projectileCount` so the UI knows
+  how many trails to stagger
+- **AND** `projectileCount` SHALL match the number of missiles launched

--- a/openspec/changes/add-attack-visual-effects/tasks.md
+++ b/openspec/changes/add-attack-visual-effects/tasks.md
@@ -4,7 +4,7 @@
 
 - [ ] 1.1 Create `src/utils/effects/weaponEffectMap.ts`
 - [ ] 1.2 Map weapon types to categories: `laser | missile | ballistic
-    | physical`
+| physical`
 - [ ] 1.3 Map subtypes to colors (small/med pulse -> IR tint; med/large
       laser -> green; ER variants -> red-orange; missiles -> yellow
       trail; ballistic -> cyan tracer; physical -> white shockwave)

--- a/openspec/changes/add-attack-visual-effects/tasks.md
+++ b/openspec/changes/add-attack-visual-effects/tasks.md
@@ -1,0 +1,109 @@
+# Tasks: Add Attack Visual Effects
+
+## 1. Weapon Visual Map
+
+- [ ] 1.1 Create `src/utils/effects/weaponEffectMap.ts`
+- [ ] 1.2 Map weapon types to categories: `laser | missile | ballistic
+    | physical`
+- [ ] 1.3 Map subtypes to colors (small/med pulse -> IR tint; med/large
+      laser -> green; ER variants -> red-orange; missiles -> yellow
+      trail; ballistic -> cyan tracer; physical -> white shockwave)
+- [ ] 1.4 Unit tests covering every weapon type represented in the
+      catalog
+
+## 2. Effect Primitives
+
+- [ ] 2.1 Create `LaserBeam.tsx`: solid line with glow filter from
+      origin to target, 400ms duration
+- [ ] 2.2 Create `MissileTrail.tsx`: dashed line animating from origin
+      to target with an arrowhead, 600ms duration
+- [ ] 2.3 Create `Tracer.tsx`: short bright dashes moving along the
+      line, 300ms duration
+- [ ] 2.4 Create `Shockwave.tsx`: expanding ring at target hex, 400ms
+      duration
+- [ ] 2.5 Create `ImpactFlash.tsx`: white burst at impact hex, 150ms
+      duration
+
+## 3. Attack Effects Layer
+
+- [ ] 3.1 Create `src/components/gameplay/effects/AttackEffectsLayer.tsx`
+- [ ] 3.2 Subscribes to `AttackResolved` events
+- [ ] 3.3 For each hit, emits the appropriate primitive + impact flash
+- [ ] 3.4 For each miss, emits a faded primitive that terminates past
+      the target hex
+- [ ] 3.5 Layer sits above the token layer, `pointer-events: none` so
+      click-through is preserved
+
+## 4. Miss vs Hit Differentiation
+
+- [ ] 4.1 Hit: full opacity primitive ending at target center; impact
+      flash at target
+- [ ] 4.2 Miss: 40% opacity primitive overshooting the target by 1 hex
+      in the attack direction; no impact flash
+- [ ] 4.3 Partial (cluster half-hit) renders split dashes: solid hit
+      portion, faded miss portion
+- [ ] 4.4 Unit tests for each variant
+
+## 5. Cluster Weapon Staggering
+
+- [ ] 5.1 Multi-missile launchers (LRM/SRM) stagger trails with 30ms
+      offset so a salvo reads as multiple missiles
+- [ ] 5.2 Ultra AC double-tap staggers two tracers at 80ms offset
+- [ ] 5.3 Rotary AC burst fires five tracers at 40ms offset
+- [ ] 5.4 Visual stagger does not affect damage math (pure presentation)
+
+## 6. Physical Attack Effects
+
+- [ ] 6.1 Punch: shockwave at target hex, thin ring
+- [ ] 6.2 Kick: shockwave at target hex, thicker ring
+- [ ] 6.3 Club / hatchet / sword: shockwave plus faint arc from attacker
+      to target hex
+- [ ] 6.4 Charge / DFA: shockwave at both attacker and target hexes
+- [ ] 6.5 Physical impact flashes use a red tint (distinct from
+      ballistic white)
+
+## 7. Event Timing
+
+- [ ] 7.1 Effects queue alongside damage animations in
+      `useAnimationQueue`
+- [ ] 7.2 Beam/tracer/trail plays 300-600ms, then impact flash fires
+- [ ] 7.3 Damage-pip decay fires on impact flash (coordinate with
+      `add-damage-feedback-effects`)
+- [ ] 7.4 Phase advancement waits for all queued effects to drain
+
+## 8. Reduced Motion Fallback
+
+- [ ] 8.1 On `prefers-reduced-motion: reduce`, render a single 300ms
+      fading connecting line from origin to target
+- [ ] 8.2 Impact flash is still shown but dimmed to 50% opacity and
+      shortened to 80ms
+- [ ] 8.3 Arcs and shockwaves collapse to a static line
+- [ ] 8.4 Unit test: reduced motion path emits only the simplified line
+
+## 9. Performance
+
+- [ ] 9.1 Use CSS transforms + opacity animations (no layout thrash)
+- [ ] 9.2 Reuse `<defs>` for glow filters across all beams
+- [ ] 9.3 Budget: 30 concurrent effects at 60 FPS on a 30x30 map
+- [ ] 9.4 Profile regression checked in CI
+
+## 10. Tests
+
+- [ ] 10.1 Unit test: `weaponEffectMap` returns correct category for
+      each weapon type
+- [ ] 10.2 Unit test: hit renders full-opacity primitive + flash
+- [ ] 10.3 Unit test: miss renders faded primitive with no flash
+- [ ] 10.4 Integration test: resolving a PPC hit produces a green beam
+      and impact flash within 600ms
+- [ ] 10.5 Integration test: LRM-20 hit produces 20 staggered trails
+
+## 11. Spec Compliance
+
+- [ ] 11.1 Every requirement in `attack-effects-system` spec has a
+      GIVEN/WHEN/THEN scenario
+- [ ] 11.2 Every requirement in `tactical-map-interface` delta has a
+      scenario
+- [ ] 11.3 Every requirement in `weapon-resolution-system` delta has a
+      scenario
+- [ ] 11.4 `openspec validate add-attack-visual-effects --strict` passes
+      clean

--- a/openspec/changes/add-authoritative-roll-arbitration/proposal.md
+++ b/openspec/changes/add-authoritative-roll-arbitration/proposal.md
@@ -1,0 +1,53 @@
+# Change: Add Authoritative Roll Arbitration
+
+## Why
+
+**Sub-phase 4b.** Once the server runs the canonical session, all dice
+rolls must originate there. Otherwise a malicious client could forge a
+"boxcars" hit-location roll or a "snake eyes" shutdown save. BattleTech
+has many roll sources (initiative 2d6, to-hit 2d6, cluster hits 2d6, hit
+location 2d6, crit rolls 2d6, consciousness 3+ targets, shutdown 4+
+targets, fall PSRs). All of them need to run server-side and be embedded
+in the resulting events so clients display the same outcome the server
+saw. This change formalizes a server-only `DiceRoller` contract and a
+"rolls embedded in events" rule that makes replay trivial and forgery
+impossible.
+
+## What Changes
+
+- `multiplayer-server` spec adds an "authoritative RNG" requirement:
+  server generates all randomness; no client intent carries dice values
+- Server's `DiceRoller` uses Node's `crypto.randomBytes` (not
+  `Math.random`) to produce unbiased rolls
+- Each event whose resolution consumed dice SHALL carry a `rolls: number[]`
+  array on its payload, in the order consumed
+- `dice-system` spec's existing "injectable DiceRoller" pattern is
+  reused — server wires its crypto-backed roller; clients ignore any
+  local roller and purely render rolls from event payloads
+- Intent messages that include dice values are rejected as malformed
+- Seeded RNG is available via an admin/debug flag for reproducing
+  specific bug reports but is off by default
+
+## Dependencies
+
+- **Requires**: `add-multiplayer-server-infrastructure` (server
+  transport + session host), existing `dice-system`,
+  `game-session-management`
+- **Required By**: `add-multiplayer-lobby-and-matchmaking-2-8`,
+  `add-fog-of-war-event-filtering` (fog filtering must trust the
+  resolved rolls)
+
+## Impact
+
+- Affected specs: `multiplayer-server` (MODIFIED — adds roll authority
+  requirement), `game-session-management` (MODIFIED — requires `rolls`
+  on randomness-consuming events for all networked matches),
+  `dice-system` (MODIFIED — defines a crypto-backed `DiceRoller` factory
+  and a strict "rolls must be recorded" rule on resolved events)
+- Affected code: new `src/server/multiplayer/serverDiceRoller.ts`,
+  extension of `src/utils/gameplay/dice.ts` to export an
+  event-recording wrapper, extension of all phase resolvers to record
+  the dice consumed on each event
+- Non-goals: verifiable dice (commit-reveal cryptography), dice streams
+  shared over hash chains, client-side anti-tamper. Trust boundary is
+  "the server binary"

--- a/openspec/changes/add-authoritative-roll-arbitration/specs/dice-system/spec.md
+++ b/openspec/changes/add-authoritative-roll-arbitration/specs/dice-system/spec.md
@@ -1,0 +1,84 @@
+# dice-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Crypto-Backed Server DiceRoller
+
+The dice system SHALL expose a cryptographically strong `DiceRoller`
+factory suitable for server-authoritative play, distinct from the
+default Math.random-backed roller used client-side.
+
+#### Scenario: Crypto roller factory exists
+
+- **GIVEN** the dice system's exports
+- **WHEN** inspected
+- **THEN** a `createCryptoDiceRoller()` factory SHALL be available
+- **AND** rollers from this factory SHALL use `crypto.randomBytes` (or
+  an equivalent cryptographic primitive)
+
+#### Scenario: Crypto roller satisfies DiceRoller contract
+
+- **GIVEN** a crypto roller
+- **WHEN** called
+- **THEN** the return value SHALL satisfy the existing `DiceRoller`
+  type (`dice`, `total`, `isSnakeEyes`, `isBoxcars`)
+- **AND** each die value SHALL be in `[1, 6]`
+
+#### Scenario: Crypto roller avoids modulo bias
+
+- **GIVEN** a uniform byte stream input
+- **WHEN** the roller converts bytes into d6 values
+- **THEN** it SHALL use rejection sampling (or equivalent) to avoid
+  modulo bias
+- **AND** a sample of 100,000 rolls SHALL have each face appear within
+  a 1% tolerance of 1/6
+
+### Requirement: Recording DiceRoller Wrapper
+
+The dice system SHALL provide a wrapper that captures every roll
+produced by an inner roller so the capturing code can attach the rolls
+to its emitted event.
+
+#### Scenario: Wrapper captures rolls
+
+- **GIVEN** an inner `DiceRoller` and a `recordingDiceRoller` wrapping
+  it
+- **WHEN** the wrapper's roller is called three times
+- **THEN** the wrapper's `collected` array SHALL contain three entries
+  in call order
+- **AND** each entry SHALL contain the raw dice values
+
+#### Scenario: Wrapper is transparent to callers
+
+- **GIVEN** a function that accepts a `DiceRoller`
+- **WHEN** it is called with a wrapper
+- **THEN** the function SHALL behave identically to being called with
+  the inner roller
+- **AND** the only side effect SHALL be the wrapper's captured array
+  growing
+
+### Requirement: Client Must Not Generate Rolls in Networked Matches
+
+The system SHALL forbid client-side dice generation for any session
+with a non-null `hostPlayerId` (i.e., a server-authoritative session);
+client-side code paths SHALL NOT call any `DiceRoller` directly, and
+display values SHALL come from event payloads.
+
+#### Scenario: Client renders rolls from event
+
+- **GIVEN** a networked match and an `AttackResolved` event with
+  `payload.rolls = [8, 7, 3]`
+- **WHEN** the client renders the attack result
+- **THEN** the displayed attack roll SHALL be `8`, hit location `7`,
+  crit `3`
+- **AND** no call to `Math.random` or any local `DiceRoller` SHALL
+  occur during rendering
+
+#### Scenario: Missing rolls logs and fallbacks safely
+
+- **GIVEN** a networked match event that should carry `rolls` but does
+  not
+- **WHEN** the client renders the event
+- **THEN** a console error SHALL be logged with the event's `type`
+  and `sequence`
+- **AND** the display SHALL show `"?"` rather than a fabricated value

--- a/openspec/changes/add-authoritative-roll-arbitration/specs/game-session-management/spec.md
+++ b/openspec/changes/add-authoritative-roll-arbitration/specs/game-session-management/spec.md
@@ -1,0 +1,48 @@
+# game-session-management Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Rolls Embedded on Randomness-Consuming Events
+
+For networked matches, every event whose resolution consumed dice SHALL
+carry the rolled values on its payload so mirror clients and post-match
+replays can display the identical outcome without re-rolling.
+
+#### Scenario: InitiativeRolled carries rolls
+
+- **GIVEN** the server resolves initiative with dice `(3,5)` for Player
+  and `(2,4)` for Opponent
+- **WHEN** the `InitiativeRolled` event is emitted
+- **THEN** `payload.rolls` SHALL contain both sides' dice values keyed
+  by side
+- **AND** the payload SHALL be sufficient to reproduce the initiative
+  winner without additional randomness
+
+#### Scenario: AttackResolved carries all attack rolls
+
+- **GIVEN** a weapon attack resolving in the Attack phase
+- **WHEN** the `AttackResolved` event is emitted
+- **THEN** `payload.rolls` SHALL include, in order, the attack roll,
+  hit-location roll, cluster-hit roll (if applicable), and crit roll
+  (if applicable)
+- **AND** the order SHALL match the rule-book resolution sequence
+
+#### Scenario: Deterministic events omit rolls
+
+- **GIVEN** an event whose resolution is deterministic (e.g.,
+  `MovementLocked`, `PhaseChanged`, `GameEnded`)
+- **WHEN** the event is emitted in a networked match
+- **THEN** the event MAY omit `payload.rolls`
+- **AND** the absence SHALL NOT be treated as an error
+
+### Requirement: Hot-Seat Backward Compatibility
+
+For non-networked local matches, the system SHALL NOT require events to
+carry `payload.rolls`, preserving existing event shapes from Phase 1.
+
+#### Scenario: Local match event without rolls
+
+- **GIVEN** a hot-seat session with no `hostPlayerId`
+- **WHEN** an attack resolves
+- **THEN** the emitted event MAY include or omit `payload.rolls`
+- **AND** validation SHALL pass either way

--- a/openspec/changes/add-authoritative-roll-arbitration/specs/multiplayer-server/spec.md
+++ b/openspec/changes/add-authoritative-roll-arbitration/specs/multiplayer-server/spec.md
@@ -1,0 +1,68 @@
+# multiplayer-server Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Authoritative Randomness
+
+The server SHALL be the sole source of randomness in networked matches.
+Client intents SHALL NOT carry dice values, and the server SHALL never
+trust a value claimed by a client.
+
+#### Scenario: Server generates initiative roll
+
+- **GIVEN** a networked match in the Initiative phase
+- **WHEN** the server resolves initiative
+- **THEN** the server SHALL use its own `DiceRoller`
+- **AND** the resulting dice values SHALL be embedded in the emitted
+  `InitiativeRolled` event's `payload.rolls`
+
+#### Scenario: Intent with rolls rejected
+
+- **GIVEN** a client sends an intent whose payload includes `rolls`
+- **WHEN** the server validates the intent
+- **THEN** the server SHALL respond `Error {code: 'INVALID_INTENT',
+reason: 'client-rolls-forbidden'}`
+- **AND** no events SHALL be appended
+
+#### Scenario: Crypto-backed roller
+
+- **GIVEN** the server's default `DiceRoller`
+- **WHEN** the source is inspected
+- **THEN** it SHALL use `crypto.randomBytes` (or an equivalent
+  cryptographically strong RNG)
+- **AND** it SHALL NOT use `Math.random`
+
+### Requirement: Seeded Debug Mode
+
+The system SHALL allow deterministic play for bug reproduction via an
+explicit seed flag, off by default, never permitted in production.
+
+#### Scenario: Seeded mode activates roller
+
+- **GIVEN** the server starts with `MP_DEV_SEED=12345`
+- **WHEN** a match is created
+- **THEN** the match's `config.seed` SHALL equal `12345`
+- **AND** a deterministic roller SHALL be used in place of the crypto
+  roller
+- **AND** two matches created with the same seed and the same intent
+  sequence SHALL produce identical event streams
+
+#### Scenario: Production rejects seed
+
+- **GIVEN** `NODE_ENV=production` and `MP_DEV_SEED` is set
+- **WHEN** the server starts
+- **THEN** startup SHALL fail with a clear error
+- **AND** the process SHALL exit with a non-zero code
+
+### Requirement: Client Cannot Override Rolls
+
+The system SHALL reject any client attempt to submit a `DiceRoller`
+override via configuration, intent, or websocket message.
+
+#### Scenario: DiceRoller in config rejected
+
+- **GIVEN** a client creates a match via REST with a body containing
+  `config.diceRoller`
+- **WHEN** the server validates the request
+- **THEN** the field SHALL be stripped or rejected
+- **AND** the server's own roller SHALL be used

--- a/openspec/changes/add-authoritative-roll-arbitration/tasks.md
+++ b/openspec/changes/add-authoritative-roll-arbitration/tasks.md
@@ -1,0 +1,104 @@
+# Tasks: Add Authoritative Roll Arbitration
+
+## 1. Server Dice Roller
+
+- [ ] 1.1 Add `serverDiceRoller.ts` that implements the existing
+      `DiceRoller` type using `crypto.randomBytes`
+- [ ] 1.2 Each call produces a new 2-byte buffer; mod 6 per byte
+- [ ] 1.3 Include a rejection-sampling loop to avoid mod bias
+- [ ] 1.4 Unit test: 100,000 rolls show uniform distribution across
+      1–6 within a 1% tolerance per face
+
+## 2. Event-Recording Wrapper
+
+- [ ] 2.1 Add `recordingDiceRoller(inner: DiceRoller): {roller,
+    collected}` where `collected` accumulates every roll result
+- [ ] 2.2 Before each phase resolver runs, a fresh recorder is created
+- [ ] 2.3 After resolution, the recorded rolls are attached to the
+      emitted event's `payload.rolls`
+- [ ] 2.4 If multiple events emit from a single resolver call, rolls
+      are split per event according to consumption order
+
+## 3. Event Payload Schema
+
+- [ ] 3.1 Extend event type definitions so any event whose resolution
+      is non-deterministic carries `rolls: number[]`
+- [ ] 3.2 Events affected: `InitiativeRolled`, `AttackResolved`,
+      `HitLocationDetermined`, `ClusterHits`, `CriticalHitRolled`,
+      `ConsciousnessCheck`, `ShutdownCheck`, `AmmoExplosionRolled`,
+      `PilotingSkillRolled`, `FallMechanicsRolled`
+- [ ] 3.3 Update event factories to accept and record rolls
+- [ ] 3.4 Schema validation rejects networked events that omit `rolls`
+      when they should carry them
+
+## 4. Intent Validation
+
+- [ ] 4.1 Any intent payload that contains a `rolls` field is rejected
+      with `Error {code: 'INVALID_INTENT', reason: 'client-rolls-
+    forbidden'}`
+- [ ] 4.2 Intents carry only declarations (targets, directions,
+      choices) — never outcomes
+- [ ] 4.3 Zod schemas enforce the absence of result fields
+
+## 5. Server Resolver Wiring
+
+- [ ] 5.1 All phase resolvers on `ServerMatchHost` construct a
+      recording roller, run resolution, capture rolls per event
+- [ ] 5.2 `ServerMatchHost` never accepts a `DiceRoller` from a client
+      or an intent
+- [ ] 5.3 Unit tests cover initiative, movement PSR, attack resolution,
+      cluster hit determination, crit rolls, consciousness, shutdown,
+      ammo explosion, fall
+
+## 6. Client Rendering From Recorded Rolls
+
+- [ ] 6.1 Client UI ignores any local dice roller for networked
+      matches; it reads `event.payload.rolls` and displays those values
+- [ ] 6.2 Dice-roll animations on the client are purely cosmetic and
+      MUST converge to the recorded outcome
+- [ ] 6.3 If an event is missing `rolls` where they are expected, the
+      client logs an error and displays `"?"` rather than fabricating
+      a value
+
+## 7. Debug Seeded RNG
+
+- [ ] 7.1 Admin endpoint or env flag `MP_DEV_SEED=<number>` replaces
+      the crypto roller with a deterministic seeded roller for bug
+      reproduction
+- [ ] 7.2 Seeded mode is off by default
+- [ ] 7.3 If the seeded mode is active, every match meta record gains
+      `seed: number` in its `config` payload
+- [ ] 7.4 Production deployments SHALL reject startup with a non-null
+      seed flag
+
+## 8. Hot-Seat Compatibility
+
+- [ ] 8.1 Non-networked hot-seat matches continue to use whatever local
+      roller the UI already wires
+- [ ] 8.2 Local matches are NOT required to record rolls on events
+      (backwards-compatible with Phase 1 MVP changes)
+- [ ] 8.3 The recording wrapper MAY be opt-in for networked matches
+      only, keyed by `session.hostPlayerId != null` (server-managed)
+
+## 9. Tests
+
+- [ ] 9.1 Unit test: a seeded server session produces deterministic
+      outputs given a fixed seed
+- [ ] 9.2 Integration test: attempting to send an intent with embedded
+      rolls is rejected
+- [ ] 9.3 Integration test: every networked event inspected across a
+      20-turn match either carries no `rolls` (deterministic event) or
+      a non-empty `rolls` array (dice event)
+- [ ] 9.4 Integration test: a new client joining mid-match sees
+      identical rolls on the replayed events
+
+## 10. Spec Compliance
+
+- [ ] 10.1 Every requirement in the `multiplayer-server` delta has at
+      least one GIVEN/WHEN/THEN scenario
+- [ ] 10.2 Every requirement in the `game-session-management` delta has
+      at least one GIVEN/WHEN/THEN scenario
+- [ ] 10.3 Every requirement in the `dice-system` delta has at least
+      one GIVEN/WHEN/THEN scenario
+- [ ] 10.4 `openspec validate add-authoritative-roll-arbitration
+    --strict` passes clean

--- a/openspec/changes/add-authoritative-roll-arbitration/tasks.md
+++ b/openspec/changes/add-authoritative-roll-arbitration/tasks.md
@@ -12,7 +12,7 @@
 ## 2. Event-Recording Wrapper
 
 - [ ] 2.1 Add `recordingDiceRoller(inner: DiceRoller): {roller,
-    collected}` where `collected` accumulates every roll result
+collected}` where `collected` accumulates every roll result
 - [ ] 2.2 Before each phase resolver runs, a fresh recorder is created
 - [ ] 2.3 After resolution, the recorded rolls are attached to the
       emitted event's `payload.rolls`
@@ -35,7 +35,7 @@
 
 - [ ] 4.1 Any intent payload that contains a `rolls` field is rejected
       with `Error {code: 'INVALID_INTENT', reason: 'client-rolls-
-    forbidden'}`
+forbidden'}`
 - [ ] 4.2 Intents carry only declarations (targets, directions,
       choices) — never outcomes
 - [ ] 4.3 Zod schemas enforce the absence of result fields
@@ -101,4 +101,4 @@
 - [ ] 10.3 Every requirement in the `dice-system` delta has at least
       one GIVEN/WHEN/THEN scenario
 - [ ] 10.4 `openspec validate add-authoritative-roll-arbitration
-    --strict` passes clean
+--strict` passes clean

--- a/openspec/changes/add-battlearmor-battle-value/proposal.md
+++ b/openspec/changes/add-battlearmor-battle-value/proposal.md
@@ -1,0 +1,35 @@
+# Change: Add BattleArmor Battle Value
+
+## Why
+
+BA squads are costed in contracts by BV, so BA BV=0 materially breaks campaign balance wherever hostile BA appear. Current spec even explicitly flags "detailed BA BV calculation beyond simplified armor-based formula" as out of scope. This change adds the full BV 2.0 BA formula per TechManual so BA squads price correctly. It depends on `add-battlearmor-construction` for legal inputs.
+
+## What Changes
+
+- Add per-trooper BV = (offensive BV + defensive BV) × squad-size multiplier
+- Add per-trooper defensive BV: armor BV + move BV + anti-mech flag bonus
+- Add per-trooper offensive BV: weapon BV + ammo BV + manipulator melee BV
+- Add move BV = MP × class multiplier (PA(L)/Light: 0.5; Medium: 0.75; Heavy: 1.0; Assault: 1.5)
+- Add armor BV = armorPoints × 2.5 × armorTypeMultiplier (Stealth 1.5, Mimetic 1.5, Reactive 1.3, Reflective 1.3, Fire-Resistant 1.1, Standard 1.0)
+- Add anti-mech bonus: Magnetic Clamps + swarm capability add flat 5 BV per trooper
+- Add manipulator melee BV: Vibro-Claw 3 BV, Heavy Claw 2 BV, Battle Claw 1 BV
+- Add squad-size multiplier: 4 troopers = 4.0×, 5 troopers = 5.0×, etc. (simple linear)
+- Add pilot skill multiplier using shared gunnery/piloting table
+- Expose breakdown on unit for UI
+- Add parity harness comparing against MegaMekLab canonical BA
+
+## Non-goals
+
+- Field-gun BV (field guns are infantry, handled in `add-infantry-battle-value`)
+- Mixed-squad BV (non-homogeneous squads)
+
+## Dependencies
+
+- **Requires**: `add-battlearmor-construction`, `battle-value-system`
+- **Blocks**: `add-battlearmor-combat-behavior` (AI prioritization)
+
+## Impact
+
+- **Affected specs**: `battle-value-system` (MODIFIED — BA path), `battle-armor-unit-system` (MODIFIED — remove "simplified BV" scope exclusion; ADDED BV breakdown)
+- **Affected code**: `src/utils/construction/battlearmor/battleArmorBV.ts` (new), `src/utils/construction/battleValueCalculations.ts` (dispatch), `src/components/customizer/battlearmor/BattleArmorStatusBar.tsx` (new or existing)
+- **Validation target**: ≥ 95% within 5% vs canonical (BA BV is simpler math than mechs so parity should converge fast)

--- a/openspec/changes/add-battlearmor-battle-value/specs/battle-armor-unit-system/spec.md
+++ b/openspec/changes/add-battlearmor-battle-value/specs/battle-armor-unit-system/spec.md
@@ -1,0 +1,43 @@
+# battle-armor-unit-system (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Scope — BV Calculation Included
+
+BA construction SHALL include full BV 2.0 calculation (previously scoped as simplified only).
+
+#### Scenario: Full BA BV supported
+
+- **GIVEN** any legally constructed BA squad
+- **WHEN** `calculateBattleValue` runs
+- **THEN** the full BV 2.0 BA formula SHALL be applied (per-trooper defensive + offensive, squad scaled, pilot adjusted)
+- **AND** the legacy simplified formula SHALL no longer be used
+
+## ADDED Requirements
+
+### Requirement: BA BV Breakdown on Unit State
+
+Every BA squad SHALL carry an `IBABreakdown` populated by the calculator.
+
+#### Scenario: Breakdown shape
+
+- **GIVEN** a BA squad after construction completes
+- **WHEN** BV is computed
+- **THEN** `unit.bvBreakdown` SHALL contain `perTrooper.defensive`, `perTrooper.offensive`, `squadTotal`, `pilotMultiplier`, `final`
+
+#### Scenario: Breakdown recomputed on edit
+
+- **GIVEN** an existing squad with BV 500
+- **WHEN** the user adds an SRM-2 to each trooper
+- **THEN** `unit.bvBreakdown.perTrooper.offensive` SHALL increase
+- **AND** `unit.bvBreakdown.final` SHALL update live
+
+### Requirement: BA BV Parity Harness
+
+The validation tooling SHALL produce a BA BV parity report.
+
+#### Scenario: Validator output
+
+- **WHEN** the BA BV validator runs
+- **THEN** it SHALL emit `validation-output/battle-armor-bv-validation-report.json`
+- **AND** the report SHALL list each squad with `computedBV`, `mulBV`, `delta`, `deltaPct`

--- a/openspec/changes/add-battlearmor-battle-value/specs/battle-value-system/spec.md
+++ b/openspec/changes/add-battlearmor-battle-value/specs/battle-value-system/spec.md
@@ -1,0 +1,84 @@
+# battle-value-system (delta)
+
+## ADDED Requirements
+
+### Requirement: BattleArmor BV Dispatch
+
+The BV calculator SHALL route `IBattleArmorUnit` inputs to a BA-specific calculation path.
+
+#### Scenario: BA dispatch
+
+- **GIVEN** a BA squad
+- **WHEN** `calculateBattleValue` is called
+- **THEN** the BA calculator SHALL be invoked
+- **AND** the return SHALL include an `IBABreakdown`
+
+### Requirement: Per-Trooper Defensive BV
+
+BA defensive BV SHALL combine armor points, movement, and anti-mech equipment per trooper.
+
+#### Scenario: Armor BV with Standard armor
+
+- **GIVEN** a trooper with 5 points Standard BA armor
+- **WHEN** defensive BV is computed
+- **THEN** armorBV SHALL equal `5 × 2.5 × 1.0 = 12.5`
+
+#### Scenario: Stealth armor multiplier
+
+- **GIVEN** a trooper with 5 points Basic Stealth BA armor
+- **WHEN** defensive BV is computed
+- **THEN** armorBV SHALL equal `5 × 2.5 × 1.5 = 18.75`
+
+#### Scenario: Magnetic Clamp anti-mech bonus
+
+- **GIVEN** a trooper equipped with Magnetic Clamps
+- **WHEN** defensive BV is computed
+- **THEN** an additional 5 BV SHALL be added per trooper
+
+#### Scenario: Move BV by class
+
+- **GIVEN** a Medium-class trooper with ground MP 2
+- **WHEN** move BV is computed
+- **THEN** moveBV SHALL equal `2 × 0.75 = 1.5`
+
+### Requirement: Per-Trooper Offensive BV
+
+BA offensive BV SHALL combine weapon, ammo, and manipulator BV per trooper.
+
+#### Scenario: Manipulator melee BV
+
+- **GIVEN** a trooper with Vibro-Claws on both arms
+- **WHEN** offensive BV is computed
+- **THEN** manipulator BV SHALL contribute `3 × 2 = 6` BV
+
+#### Scenario: Weapon BV identical to catalog
+
+- **GIVEN** a trooper with an SRM-2 (catalog BV 21)
+- **WHEN** offensive BV is computed
+- **THEN** weaponBV SHALL equal 21
+
+### Requirement: Squad-Scale BV
+
+BA BV SHALL scale linearly with squad size.
+
+#### Scenario: Clan 5-trooper squad
+
+- **GIVEN** a Clan squad with trooperBV = 100 and squadSize = 5
+- **WHEN** squad BV is computed
+- **THEN** squadBV SHALL equal 500 (before pilot skill)
+
+#### Scenario: IS 4-trooper squad
+
+- **GIVEN** an IS squad with trooperBV = 80 and squadSize = 4
+- **WHEN** squad BV is computed
+- **THEN** squadBV SHALL equal 320 (before pilot skill)
+
+### Requirement: BA Pilot Skill Multiplier
+
+The shared gunnery × piloting table SHALL apply to BA final BV.
+
+#### Scenario: Elite BA crew
+
+- **GIVEN** a BA squad with gunnery 3 piloting 4
+- **WHEN** final BV is computed
+- **THEN** the pilot multiplier SHALL be read from the table row g=3 p=4

--- a/openspec/changes/add-battlearmor-battle-value/tasks.md
+++ b/openspec/changes/add-battlearmor-battle-value/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: Add BattleArmor Battle Value
+
+## 1. Calculator Scaffolding
+
+- [ ] 1.1 Create `src/utils/construction/battlearmor/battleArmorBV.ts`
+- [ ] 1.2 Export `calculateBattleArmorBV(unit: IBattleArmorUnit): IBABreakdown`
+- [ ] 1.3 Wire dispatch in `battleValueCalculations.ts`
+- [ ] 1.4 Define `IBABreakdown` (per-trooper, squad total, pilot-adjusted final)
+
+## 2. Defensive BV (Per Trooper)
+
+- [ ] 2.1 armorBV = armorPoints × 2.5 × armorTypeMultiplier
+- [ ] 2.2 Armor type multipliers: Standard 1.0, Stealth 1.5, Mimetic 1.5, Reactive 1.3, Reflective 1.3, Fire-Resistant 1.1
+- [ ] 2.3 moveBV = groundMP × classMultiplier where classMultiplier = {PA(L) 0.5, Light 0.5, Medium 0.75, Heavy 1.0, Assault 1.5}
+- [ ] 2.4 jumpBV = jumpMP × 0.5 (uniform)
+- [ ] 2.5 antiMechBonus = 5 BV if Magnetic Clamps present
+- [ ] 2.6 defensiveBV = armorBV + moveBV + jumpBV + antiMechBonus
+
+## 3. Offensive BV (Per Trooper)
+
+- [ ] 3.1 weaponBV from resolver (same catalog as mech)
+- [ ] 3.2 ammoBV from resolver
+- [ ] 3.3 manipulatorBV: Vibro-Claw 3, Heavy Claw 2, Battle Claw 1, others 0
+- [ ] 3.4 offensiveBV = weaponBV + ammoBV + manipulatorBV
+
+## 4. Trooper BV and Squad Scaling
+
+- [ ] 4.1 trooperBV = offensiveBV + defensiveBV
+- [ ] 4.2 squadBV = trooperBV × squadSize
+- [ ] 4.3 Apply pilot skill multiplier
+
+## 5. Stealth / Mimetic Armor Bonus
+
+- [ ] 5.1 Mimetic grants +1 target-movement modifier (documented in combat spec, not BV)
+- [ ] 5.2 BV armor type multiplier already captures the defensive premium
+- [ ] 5.3 No double-counting
+
+## 6. Parity Harness
+
+- [ ] 6.1 Extend validation harness to load BA canonical units
+- [ ] 6.2 Compare against MegaMekLab BA BV values
+- [ ] 6.3 Emit `validation-output/battle-armor-bv-validation-report.json`
+
+## 7. Status Bar
+
+- [ ] 7.1 Add or extend a BA status bar to show trooper BV and squad BV
+- [ ] 7.2 Breakdown dialog accessible
+
+## 8. Validation
+
+- [ ] 8.1 `openspec validate add-battlearmor-battle-value --strict`
+- [ ] 8.2 Unit tests: Elemental, Cavalier, Sylph, IS Standard, Gnome
+- [ ] 8.3 Build + lint clean

--- a/openspec/changes/add-battlearmor-combat-behavior/proposal.md
+++ b/openspec/changes/add-battlearmor-combat-behavior/proposal.md
@@ -1,0 +1,35 @@
+# Change: Add BattleArmor Combat Behavior
+
+## Why
+
+Battle armor behaves materially differently from mechs and vehicles in combat: squad damage distributes across troopers one-at-a-time, each trooper has its own armor pool, and BA can attack mechs through anti-mech / swarm / leg / vibroclaw moves unique to the type. The existing combat engine does not handle squad-per-unit state, squad damage distribution, or BA-vs-mech interactions. This change adds BA combat behavior on top of the Phase 1 damage pipeline, mirroring the way `add-vehicle-combat-behavior` did it for vehicles.
+
+## What Changes
+
+- Add BA squad combat state: per-trooper damage pool, per-trooper alive flag, squad anti-mech attach state (swarming unit id, leg-attack target)
+- Add BA hit-location table: hits distribute across troopers by cluster-hits table (similar to missiles)
+- Add trooper damage pipeline: each hit reduces one trooper's armor; excess kills the trooper (trooper removed from combat state)
+- Add anti-mech attack: leg attack (rolled against Mech, succeeds → damage to mech leg + BA takes return damage), swarm attack (attaches to mech, deals 2d6 damage per turn until dismounted)
+- Add swarm dismount actions for attached mech: Piloting skill roll to dismount, successful → BA takes fall damage; can also shoot own location with own AP weapons
+- Add vibro-claw melee bonus to physical attacks
+- Add squad fire resolution: each trooper fires independently; weapons sum into squad attack; number of dice = number of surviving troopers
+- Add mimetic armor to-hit penalty (+1 to hit when stationary)
+- Add stealth armor to-hit penalty (+1 to hit + blocks targeting computer locks)
+- Emit BA-specific events: `SwarmAttached`, `SwarmDamage`, `SwarmDismounted`, `LegAttack`, `TrooperKilled`, `SquadEliminated`
+
+## Non-goals
+
+- Field guns (infantry) — handled in `add-infantry-combat-behavior`
+- Support vehicles carrying BA — will be handled in future transport-rules change
+- Manei Domini / Exo-specific rules
+
+## Dependencies
+
+- **Requires**: `add-battlearmor-construction`, `add-battlearmor-battle-value`, `integrate-damage-pipeline`, `wire-heat-generation-and-effects` (BA doesn't heat, but shares event bus)
+- **Blocks**: fully combined-arms combat
+
+## Impact
+
+- **Affected specs**: `combat-resolution` (MODIFIED — BA path), `damage-system` (MODIFIED — squad damage distribution), `critical-hit-system` (MODIFIED — no crits on BA, but swarm damage routes differently), `hit-location-tables` (ADDED — BA trooper distribution table), `battle-armor-unit-system` (ADDED — combat state)
+- **Affected code**: `src/utils/gameplay/battleArmorDamage.ts` (new), `src/utils/gameplay/battleArmorSwarm.ts` (new), `src/utils/gameplay/battleArmorLegAttack.ts` (new), `src/engine/GameEngine.ts` (dispatch)
+- **New events**: `SwarmAttached`, `SwarmDamage`, `SwarmDismounted`, `LegAttack`, `TrooperKilled`, `SquadEliminated`, `MimeticBonus`, `StealthBonus`

--- a/openspec/changes/add-battlearmor-combat-behavior/specs/battle-armor-unit-system/spec.md
+++ b/openspec/changes/add-battlearmor-combat-behavior/specs/battle-armor-unit-system/spec.md
@@ -1,0 +1,29 @@
+# battle-armor-unit-system (delta)
+
+## ADDED Requirements
+
+### Requirement: BA Squad Combat State
+
+Each BA squad SHALL carry per-trooper and squad-wide combat state.
+
+#### Scenario: Combat state initialization
+
+- **GIVEN** a 4-trooper BA squad entering combat
+- **WHEN** combat state is initialized
+- **THEN** `unit.combatState.squad.troopers` SHALL be a 4-element array
+- **AND** each element SHALL have `alive=true`, `armorRemaining=armorPoints`, `equipmentDestroyed=[]`
+- **AND** `unit.combatState.squad.swarmingUnitId` SHALL be undefined
+- **AND** `unit.combatState.squad.mimeticActiveThisTurn` SHALL reflect whether the squad moved
+
+#### Scenario: Swarm state on attach
+
+- **GIVEN** a BA squad that successfully swarms a mech
+- **WHEN** `SwarmAttached` fires
+- **THEN** `unit.combatState.squad.swarmingUnitId` SHALL be set to the target mech's id
+
+#### Scenario: Dead trooper retained in state
+
+- **GIVEN** a 4-trooper squad where trooper index 2 has died
+- **WHEN** combat state is read
+- **THEN** `troopers[2].alive` SHALL be `false`
+- **AND** squad fire SHALL skip trooper 2 when counting attack dice

--- a/openspec/changes/add-battlearmor-combat-behavior/specs/combat-resolution/spec.md
+++ b/openspec/changes/add-battlearmor-combat-behavior/specs/combat-resolution/spec.md
@@ -1,0 +1,142 @@
+# combat-resolution (delta)
+
+## ADDED Requirements
+
+### Requirement: BattleArmor Combat Dispatch
+
+The combat resolution engine SHALL route BA targets to a BA-specific damage pipeline.
+
+#### Scenario: BA target routing
+
+- **GIVEN** an attack whose target has `unitType === UnitType.BATTLE_ARMOR`
+- **WHEN** the engine resolves the hit
+- **THEN** `battleArmorResolveDamage()` SHALL be invoked
+- **AND** damage SHALL distribute across surviving troopers per the cluster-hits table
+
+#### Scenario: No mech-style criticals on BA
+
+- **GIVEN** damage applied to a BA squad
+- **WHEN** critical-hit resolution runs
+- **THEN** mech-style crit slot effects SHALL NOT be computed
+- **AND** trooper death SHALL be the only structural consequence
+
+### Requirement: Squad Damage Distribution
+
+Damage to a BA squad SHALL distribute across surviving troopers one hit at a time.
+
+#### Scenario: One hit kills one trooper
+
+- **GIVEN** a BA squad with 4 troopers each having 5 armor
+- **WHEN** a single 5-damage weapon hits the squad
+- **THEN** exactly one random surviving trooper SHALL take 5 damage and be eliminated
+- **AND** a `TrooperKilled` event SHALL fire
+
+#### Scenario: Cluster weapon distributes per table
+
+- **GIVEN** the same squad hit by an LRM-10 (10 missiles)
+- **WHEN** damage is resolved
+- **THEN** the cluster-hits table SHALL determine how many missiles hit
+- **AND** each hit SHALL land on a random surviving trooper (seeded RNG)
+
+#### Scenario: Squad eliminated
+
+- **GIVEN** a BA squad with 1 surviving trooper on 2 armor
+- **WHEN** 5 damage is dealt
+- **THEN** the trooper SHALL die
+- **AND** a `SquadEliminated` event SHALL fire
+- **AND** the squad SHALL be removed from active play
+
+### Requirement: Anti-Mech Leg Attack
+
+BA in base contact with a mech SHALL be able to declare a Leg Attack during the physical-attack phase.
+
+#### Scenario: Leg attack success
+
+- **GIVEN** a BA squad adjacent to a mech with 4 surviving troopers
+- **WHEN** Leg Attack is declared and the roll succeeds
+- **THEN** the mech SHALL take `4 × 4 = 16` damage to the target leg
+- **AND** the `LegAttack` event SHALL record success
+
+#### Scenario: Leg attack failure
+
+- **GIVEN** the same attack failing its roll
+- **WHEN** failure effect is applied
+- **THEN** the BA squad SHALL take 1d6 damage distributed across troopers
+
+### Requirement: Anti-Mech Swarm Attack
+
+BA with Magnetic Clamps SHALL be able to swarm an adjacent mech and deal damage each turn.
+
+#### Scenario: Swarm attach
+
+- **GIVEN** a clamped BA squad in base contact with a mech
+- **WHEN** Swarm is declared and the roll succeeds
+- **THEN** `swarmingUnitId` SHALL be set to the mech
+- **AND** a `SwarmAttached` event SHALL fire
+
+#### Scenario: Swarm damage per turn
+
+- **GIVEN** a swarming BA squad with 3 surviving troopers
+- **WHEN** a combat turn ends with the squad still swarming
+- **THEN** the attached mech SHALL take `1d6 + 3 = 4-9` damage to a random location
+- **AND** a `SwarmDamage` event SHALL fire
+
+#### Scenario: Dismount attempt
+
+- **GIVEN** a mech with a swarming BA squad
+- **WHEN** the mech declares a dismount action with a successful Piloting roll
+- **THEN** the BA squad SHALL take 2d6 damage
+- **AND** the swarm SHALL end
+- **AND** a `SwarmDismounted` event SHALL fire
+
+### Requirement: Mimetic and Stealth Armor To-Hit Penalties
+
+The system SHALL apply mimetic and stealth to-hit penalties to attackers targeting BA.
+
+#### Scenario: Mimetic active
+
+- **GIVEN** a BA squad that did not move this turn and is wearing Mimetic armor
+- **WHEN** an attacker shoots at the squad
+- **THEN** the attack's to-hit TN SHALL increase by 1
+
+#### Scenario: Basic Stealth
+
+- **GIVEN** a BA squad wearing Basic Stealth armor
+- **WHEN** any attacker shoots at the squad
+- **THEN** the to-hit TN SHALL increase by 1 at all ranges
+
+#### Scenario: Improved Stealth with range
+
+- **GIVEN** a BA squad wearing Improved Stealth armor
+- **WHEN** an attacker shoots at long range
+- **THEN** the to-hit TN SHALL increase by 3
+
+## MODIFIED Requirements
+
+### Requirement: Damage Distribution
+
+The system SHALL distribute damage across units based on battle intensity and outcome.
+
+#### Scenario: Victory results in light damage
+
+- **GIVEN** a battle with outcome VICTORY and 4 player units
+- **WHEN** distributeDamage is called
+- **THEN** units receive 0-30% damage on average
+
+#### Scenario: Defeat results in heavy damage
+
+- **GIVEN** a battle with outcome DEFEAT and 4 player units
+- **WHEN** distributeDamage is called
+- **THEN** units receive 40-80% damage on average
+
+#### Scenario: Draw results in moderate damage
+
+- **GIVEN** a battle with outcome DRAW and 4 player units
+- **WHEN** distributeDamage is called
+- **THEN** units receive 20-50% damage on average
+
+#### Scenario: Partial BA squad survival
+
+- **GIVEN** a battle where a 4-trooper BA squad ends with 2 surviving troopers
+- **WHEN** distributeDamage is called
+- **THEN** the squad SHALL be counted at 50% strength for post-battle reporting

--- a/openspec/changes/add-battlearmor-combat-behavior/tasks.md
+++ b/openspec/changes/add-battlearmor-combat-behavior/tasks.md
@@ -1,0 +1,79 @@
+# Tasks: Add BattleArmor Combat Behavior
+
+## 1. Unit-Type Dispatch
+
+- [ ] 1.1 Route `resolveDamage()` to `battleArmorResolveDamage()` when target is `IBattleArmorUnit`
+- [ ] 1.2 Route attack declaration for BA to handle squad fire (each trooper contributes its weapons)
+- [ ] 1.3 Route physical-attack declaration for BA to include leg/swarm/vibroclaw options
+- [ ] 1.4 Skip mech-style critical hits on BA (no crit slots)
+
+## 2. BA Squad Combat State
+
+- [ ] 2.1 Initialize `unit.combatState.squad.troopers` as array length `squadSize`
+- [ ] 2.2 Per-trooper fields: `alive`, `armorRemaining`, `equipmentDestroyed[]`
+- [ ] 2.3 Squad-wide fields: `swarmingUnitId?`, `legAttackCommitted?`, `mimeticActiveThisTurn`
+
+## 3. Squad Damage Distribution
+
+- [ ] 3.1 On hit, roll cluster-hits table with cluster-size = squadSize
+- [ ] 3.2 Each hit lands on a random surviving trooper (seeded RNG)
+- [ ] 3.3 Damage to a trooper reduces `armorRemaining`; when ≤ 0 the trooper is killed and next hits bypass them
+- [ ] 3.4 When all troopers dead, emit `SquadEliminated`
+- [ ] 3.5 Emit `TrooperKilled` per casualty
+
+## 4. Squad Fire Resolution
+
+- [ ] 4.1 When squad fires, number of attack dice = surviving troopers
+- [ ] 4.2 Weapon BV / damage scales with surviving count
+- [ ] 4.3 Heat exemption (BA has no heat)
+
+## 5. Anti-Mech Leg Attack
+
+- [ ] 5.1 BA in base contact with a Mech may declare Leg Attack
+- [ ] 5.2 Roll 2d6 + BA piloting vs Mech piloting + 4 (TW)
+- [ ] 5.3 Success: damage to target leg = 4 × surviving troopers
+- [ ] 5.4 Failure: BA squad takes 1d6 damage (distributed)
+- [ ] 5.5 Emit `LegAttack` event with success/failure
+
+## 6. Anti-Mech Swarm Attack
+
+- [ ] 6.1 BA with Magnetic Clamps in base contact may declare Swarm
+- [ ] 6.2 Roll 2d6 + BA piloting vs Mech piloting + 4
+- [ ] 6.3 Success: `swarmingUnitId` set; emit `SwarmAttached`
+- [ ] 6.4 Each subsequent turn: squad deals 1d6 + surviving troopers damage to random location on attached mech
+- [ ] 6.5 Attached mech may dismount: Piloting skill roll vs TN 8; success = BA takes 2d6 + dismounts; failure = nothing
+- [ ] 6.6 Attached mech may also damage attacker location at -1 penalty: sends 1 weapon back at self
+
+## 7. Mimetic / Stealth Armor
+
+- [ ] 7.1 Mimetic: attacker +1 to-hit when squad is stationary (didn't move this turn)
+- [ ] 7.2 Basic Stealth: attacker +1 to-hit at any range
+- [ ] 7.3 Improved Stealth: attacker +2 short/medium, +3 long
+- [ ] 7.4 Prototype Stealth: TW rules (+1)
+- [ ] 7.5 Emit `MimeticBonus` / `StealthBonus` events for audit
+
+## 8. Vibro-Claw Physical Attack
+
+- [ ] 8.1 BA with Vibro-Claws can declare Vibro-Claw Attack in physical phase
+- [ ] 8.2 Damage = 1 + (0.5 × surviving troopers) rounded up per claw
+- [ ] 8.3 Can target mech, vehicle, or ProtoMech
+
+## 9. Per-Location Hit Distribution on BA
+
+- [ ] 9.1 No location on a trooper — armor is flat pool per trooper
+- [ ] 9.2 Cluster attacks treat squad as cluster table input (squadSize rolls against table)
+- [ ] 9.3 Area-effect weapons (Inferno) apply to all alive troopers equally
+- [ ] 9.4 Flamer damage doubles per TW anti-BA rule (2× per infantry-like unit)
+
+## 10. AI Adaptations
+
+- [ ] 10.1 Bot moves BA into melee range if Magnetic Clamps present
+- [ ] 10.2 Bot avoids BA-on-BA engagements; uses ranged if no clamps
+- [ ] 10.3 Bot prioritizes slow / immobilized mechs for swarm
+
+## 11. Validation
+
+- [ ] 11.1 `openspec validate add-battlearmor-combat-behavior --strict`
+- [ ] 11.2 Simulation tests: BA squad vs single mech, mech vs BA squad, BA vs BA
+- [ ] 11.3 Unit tests for squad damage distribution, swarm/leg/vibroclaw flows
+- [ ] 11.4 Build + lint clean

--- a/openspec/changes/add-battlearmor-construction/proposal.md
+++ b/openspec/changes/add-battlearmor-construction/proposal.md
@@ -1,0 +1,40 @@
+# Change: Add BattleArmor Construction
+
+## Why
+
+Battle Armor squads are the most common hostile infantry in contracts and appear in virtually every campaign. The existing `battle-armor-unit-system` spec declares chassis / weight class / manipulators but the construction pipeline does not enforce squad composition, ground/jump/VTOL movement, manipulator-mounted weapons, anti-mech attack equipment, or armor-per-trooper. This change completes BA construction so Phase 6 BV and combat can take a legally built squad.
+
+## What Changes
+
+- Add chassis configuration: Biped / Quad (with manipulator count implication)
+- Add weight class selection: PA(L) / Light / Medium / Heavy / Assault with per-trooper mass thresholds
+- Add squad size: 4 or 5 troopers (IS 4, Clan 5 standard; configurable)
+- Add movement type: Ground (walk) / Jump / VTOL / UMU (underwater) — with per-weight-class MP cap
+- Add ground MP allocation paying weight per MP beyond base 1
+- Add armor per trooper (points), weight per point by armor type (Standard BA, Stealth, Mimetic, Reactive, Reflective, Fire-Resistant), max per weight class
+- Add manipulator selection per arm (Biped only): Battle Claw / Battle Claw (Vibro) / Basic / Heavy / Mine Clearance / Cargo Lifter etc., each with weight and ability set
+- Add weapon / equipment mounting with body/arm/leg slots; heavy weapons require specific weight class and manipulator type
+- Add anti-mech equipment: Anti-Personnel weapon slots, Mechanical Jump Boosters, Magnetic Clamps for swarm attack, Partial Wing
+- Add construction validation rule set `VAL-BA-*` covering weight class thresholds, trooper mass, movement MP cap, armor max, weapon weight class gate, chassis/manipulator compatibility
+- Wire into BA store and customizer tabs
+
+## Non-goals
+
+- BA combat (swarm / leg / anti-mech damage table) — `add-battlearmor-combat-behavior`
+- BV calculation — `add-battlearmor-battle-value`
+- Pilot / warrior skill progression
+
+## Dependencies
+
+- **Requires**: existing `battle-armor-unit-system` spec stubs, `construction-services`, `armor-system`, `equipment-database`
+- **Blocks**: `add-battlearmor-battle-value`, `add-battlearmor-combat-behavior`
+
+## Ordering in Phase 6
+
+Battle armor is third after vehicles and aerospace.
+
+## Impact
+
+- **Affected specs**: `battle-armor-unit-system` (ADDED — chassis / squad / movement / manipulator / equipment / armor / validation), `construction-rules-core` (MODIFIED — dispatch BA path), `validation-rules-master` (MODIFIED)
+- **Affected code**: `src/stores/battlearmor/`, `src/utils/construction/battlearmor/`, `src/components/customizer/battlearmor/*`, `src/types/battlearmor/`
+- **New files**: BA weight class table, manipulator catalog, BA armor table, BA anti-mech equipment list

--- a/openspec/changes/add-battlearmor-construction/specs/battle-armor-unit-system/spec.md
+++ b/openspec/changes/add-battlearmor-construction/specs/battle-armor-unit-system/spec.md
@@ -1,0 +1,145 @@
+# battle-armor-unit-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Trooper Mass Validation
+
+Each trooper's combined mass (armor + weapons + equipment) SHALL fall within the selected weight class range.
+
+#### Scenario: Valid Medium trooper
+
+- **GIVEN** a Medium-class trooper with total mass 900 kg
+- **WHEN** validation runs
+- **THEN** no `VAL-BA-CLASS` errors SHALL fire
+
+#### Scenario: Overweight trooper
+
+- **GIVEN** a Light-class trooper with total mass 800 kg (above 750 kg cap)
+- **WHEN** validation runs
+- **THEN** `VAL-BA-CLASS` SHALL emit "Light class trooper mass 800 kg exceeds maximum 750 kg"
+
+### Requirement: Armor Points per Trooper
+
+The system SHALL enforce armor points per trooper ≤ class maximum, with weight per point depending on armor type.
+
+#### Scenario: Maximum armor Light class
+
+- **GIVEN** a Light-class trooper
+- **WHEN** armor is set to 5 points Standard BA
+- **THEN** armor mass SHALL equal `5 × 50 = 250 kg`
+- **AND** validation SHALL pass
+
+#### Scenario: Exceeds class cap
+
+- **GIVEN** a Light-class trooper
+- **WHEN** armor is set to 6 points
+- **THEN** `VAL-BA-ARMOR` SHALL emit "Light class cap is 5 armor points"
+
+#### Scenario: Stealth armor slot cost
+
+- **GIVEN** a trooper with Basic Stealth BA armor
+- **WHEN** the camouflage generator slot is computed
+- **THEN** 1 Body slot SHALL be reserved for the camo generator
+
+### Requirement: Movement MP Caps by Class and Type
+
+The system SHALL enforce per-weight-class caps on ground, jump, VTOL, and UMU movement points.
+
+#### Scenario: Medium class ground MP cap
+
+- **GIVEN** a Medium-class squad
+- **WHEN** the user requests ground MP 3
+- **THEN** `VAL-BA-MP` SHALL emit "Medium class ground MP cap is 2"
+
+#### Scenario: Assault jump illegal
+
+- **GIVEN** an Assault-class squad
+- **WHEN** jump MP is set to 1
+- **THEN** `VAL-BA-MP` SHALL emit "Assault class cannot jump"
+
+#### Scenario: VTOL class restriction
+
+- **GIVEN** a Heavy-class squad
+- **WHEN** movement type is set to VTOL
+- **THEN** `VAL-BA-MOVE-TYPE` SHALL emit "VTOL movement requires Light or Medium class"
+
+### Requirement: Manipulator Configuration
+
+The system SHALL configure exactly two manipulators for Biped chassis and zero for Quad chassis.
+
+#### Scenario: Biped default manipulators
+
+- **GIVEN** a new Biped squad with no overrides
+- **WHEN** manipulators are initialized
+- **THEN** each arm SHALL default to Basic Claw
+
+#### Scenario: Quad has no manipulators
+
+- **GIVEN** a Quad squad
+- **WHEN** manipulator slots are accessed
+- **THEN** manipulators SHALL be an empty array
+- **AND** arm-mounted equipment SHALL be disallowed
+
+### Requirement: Weapon / Manipulator Compatibility
+
+The system SHALL gate heavy weapons behind appropriate manipulators.
+
+#### Scenario: Heavy weapon with Heavy Claw
+
+- **GIVEN** a Biped squad with Heavy Claws on both arms
+- **WHEN** an SRM-4 is arm-mounted
+- **THEN** mounting SHALL succeed
+
+#### Scenario: Heavy weapon with Basic Claw
+
+- **GIVEN** a Biped squad with Basic Claws
+- **WHEN** an SRM-4 is arm-mounted
+- **THEN** `VAL-BA-MANIPULATOR` SHALL emit "SRM-4 requires Heavy Claw or Battle Claw"
+
+### Requirement: Anti-Mech Equipment
+
+The system SHALL support anti-mech equipment with class and slot restrictions.
+
+#### Scenario: Magnetic Clamp body-mounted
+
+- **GIVEN** any BA squad
+- **WHEN** a Magnetic Clamp is body-mounted
+- **THEN** mounting SHALL succeed (1 body slot)
+- **AND** the squad SHALL become eligible for swarm attacks
+
+#### Scenario: Partial Wing class restriction
+
+- **GIVEN** a Medium-class squad
+- **WHEN** Partial Wing is added
+- **THEN** validation SHALL emit an error — Partial Wing is Light class only
+
+### Requirement: Squad Composition
+
+The system SHALL configure squad size per tech base default and validate within 1-6.
+
+#### Scenario: IS default squad
+
+- **GIVEN** a new Inner Sphere BA squad
+- **WHEN** squad is initialized
+- **THEN** `squadSize` SHALL equal 4
+
+#### Scenario: Clan default squad
+
+- **GIVEN** a new Clan BA squad
+- **WHEN** squad is initialized
+- **THEN** `squadSize` SHALL equal 5 (Elemental Point)
+
+#### Scenario: Squad size warning
+
+- **GIVEN** a squad with size 2
+- **WHEN** validation runs
+- **THEN** `VAL-BA-SQUAD` SHALL emit a warning (not error) — non-standard squad size
+
+### Requirement: Construction Validation Rule Set
+
+The validation registry SHALL include the `VAL-BA-*` rule group.
+
+#### Scenario: Rule ids registered
+
+- **WHEN** the validation registry initializes
+- **THEN** `VAL-BA-CLASS`, `VAL-BA-ARMOR`, `VAL-BA-MP`, `VAL-BA-MANIPULATOR`, `VAL-BA-SQUAD`, and `VAL-BA-MOVE-TYPE` SHALL be registered

--- a/openspec/changes/add-battlearmor-construction/tasks.md
+++ b/openspec/changes/add-battlearmor-construction/tasks.md
@@ -1,0 +1,87 @@
+# Tasks: Add BattleArmor Construction
+
+## 1. Types and Interfaces
+
+- [ ] 1.1 Extend `IBattleArmorUnit` with `chassisType`, `weightClass`, `squadSize`, `movementType`, `groundMP`, `jumpMP`, `armorType`, `armorPointsPerTrooper`
+- [ ] 1.2 Add `BAChassisType` enum (Biped, Quad)
+- [ ] 1.3 Add `BAWeightClass` enum (PA(L), Light, Medium, Heavy, Assault)
+- [ ] 1.4 Add `BAMovementType` enum (Ground, Jump, VTOL, UMU)
+- [ ] 1.5 Add `BAManipulator` enum (None, BasicClaw, BattleClaw, VibroClaw, HeavyClaw, MineClearance, CargoLifter, IndustrialDrill, Magnet)
+- [ ] 1.6 Add `BALocation` enum (Body, LeftArm, RightArm, LeftLeg, RightLeg)
+- [ ] 1.7 Add `IBAWeaponMount`, `IBAEquipmentMount` interfaces
+
+## 2. Weight Class and Trooper Mass
+
+- [ ] 2.1 Implement per-weight-class mass range per existing spec: PA(L) 80-400 kg, Light 401-750, Medium 751-1000, Heavy 1001-1500, Assault 1501-2000
+- [ ] 2.2 Validate total trooper mass (armor + weapons + equipment) stays in range
+- [ ] 2.3 Max armor per trooper per weight class: PA(L) 2, Light 5, Medium 8, Heavy 10, Assault 14
+- [ ] 2.4 Unit tests per class
+
+## 3. Squad Composition
+
+- [ ] 3.1 IS squads default to 4 troopers
+- [ ] 3.2 Clan squads default to 5 troopers (Elemental Point)
+- [ ] 3.3 Support squadSize 1–6 with validation warning outside 4/5
+- [ ] 3.4 All troopers in a squad share identical loadout (homogeneous)
+
+## 4. Movement and MP
+
+- [ ] 4.1 Ground MP cap by weight class: PA(L) 3, Light 3, Medium 2, Heavy 2, Assault 1
+- [ ] 4.2 Jump MP cap by weight class: PA(L) 3, Light 3, Medium 3, Heavy 2, Assault 0
+- [ ] 4.3 VTOL MP: Light / Medium only, max 5
+- [ ] 4.4 UMU MP: any class, max 3
+- [ ] 4.5 Extra MP beyond base 1 costs weight (mass table by class)
+- [ ] 4.6 Reject illegal combos (Assault + VTOL, Assault + Jump ≥ 1)
+
+## 5. Armor per Trooper
+
+- [ ] 5.1 Armor types: Standard BA, Stealth (Basic/Improved/Prototype), Mimetic, Reactive, Reflective, Fire-Resistant
+- [ ] 5.2 Weight per point depends on armor type (Standard 50 kg, Stealth 60 kg, etc.)
+- [ ] 5.3 Stealth adds equipment slots in body for camouflage generator
+- [ ] 5.4 Enforce max points ≤ class cap
+- [ ] 5.5 Reject armor type illegal for class (Mimetic not on Heavy/Assault in standard ruleset)
+
+## 6. Manipulator Selection
+
+- [ ] 6.1 Biped chassis: two manipulators (left arm, right arm)
+- [ ] 6.2 Quad chassis: zero manipulators (arms replaced with extra legs)
+- [ ] 6.3 Manipulator catalog: Basic Claw (free), Battle Claw (+ability), Vibro Claw (+bonus damage melee), Heavy Claw (+weight), Mine Clearance (+special), Cargo Lifter (+lift), Industrial Drill, Magnet
+- [ ] 6.4 Some weapons require a specific manipulator (heavy → Heavy Claw)
+
+## 7. Weapon and Equipment Mounting
+
+- [ ] 7.1 Mount heavy weapons (like SRM-2, Machine Gun) — require weight class threshold
+- [ ] 7.2 Body-mounted equipment is unrestricted; arm-mounted requires manipulator
+- [ ] 7.3 Leg-mounted restricted: only anti-personnel weapons permitted
+- [ ] 7.4 Per-location slot counts: Body 2, each Arm 2 (Biped), each Leg 1
+- [ ] 7.5 Validation: reject over-slot loadouts
+
+## 8. Anti-Mech Equipment
+
+- [ ] 8.1 Magnetic Clamps: enables swarm attack (body mount, +15 kg)
+- [ ] 8.2 Mechanical Jump Boosters: +1 jump MP, +30 kg
+- [ ] 8.3 Partial Wing: gliding bonus, Light class only
+- [ ] 8.4 Anti-Personnel weapon slot: flamer / pistol variants, light class only
+- [ ] 8.5 Detachable Weapon Pack: extra mass + weapon, lost on first leg attack
+
+## 9. Construction Validation Rules
+
+- [ ] 9.1 `VAL-BA-CLASS` — trooper mass within weight class range
+- [ ] 9.2 `VAL-BA-ARMOR` — points ≤ class max
+- [ ] 9.3 `VAL-BA-MP` — MP ≤ class/move-type cap
+- [ ] 9.4 `VAL-BA-MANIPULATOR` — weapon/manipulator compatibility
+- [ ] 9.5 `VAL-BA-SQUAD` — squad size 1-6, warn outside 4/5
+- [ ] 9.6 `VAL-BA-MOVE-TYPE` — move-type legal for class
+
+## 10. Store and UI Wiring
+
+- [ ] 10.1 Wire `battleArmorStore` to persist new state
+- [ ] 10.2 Hook calculators into `BattleArmorStructureTab`, `BattleArmorSquadTab`, `BattleArmorDiagram`
+- [ ] 10.3 Diagram shows trooper silhouette with armor / arm mounts / leg mounts
+- [ ] 10.4 Add new `BattleArmorEquipmentTab` (currently no dedicated tab — add one)
+
+## 11. Validation
+
+- [ ] 11.1 `openspec validate add-battlearmor-construction --strict`
+- [ ] 11.2 Fixtures: Elemental (Clan), Cavalier (IS Heavy), Sylph (Clan Light), Inner Sphere Standard (IS Medium)
+- [ ] 11.3 Build + lint clean

--- a/openspec/changes/add-bot-retreat-behavior/proposal.md
+++ b/openspec/changes/add-bot-retreat-behavior/proposal.md
@@ -1,0 +1,36 @@
+# Change: Add Bot Retreat Behavior
+
+## Why
+
+`IBotBehavior` already declares `retreatThreshold` and `retreatEdge` fields, but nothing consumes them — crippled bot units keep trading blows until destroyed, which feels unrealistic and drags out matches. Once a unit has lost more than half its internal structure or suffered a through-armor critical to the cockpit, gyro, or engine, a real MechWarrior would try to disengage. This change wires the existing retreat fields into the AI decision layer so crippled bots head for a map edge, maintain forward facing toward escape, and avoid frying themselves en route.
+
+## What Changes
+
+- Retreat trigger: bot unit enters retreat mode when cumulative internal-structure damage across all locations exceeds `IBotBehavior.retreatThreshold` (default 0.5 — half of starting structure destroyed), OR when the unit suffers a through-armor critical to cockpit, gyro, or engine
+- Retreat direction: bot moves toward the map edge specified by `IBotBehavior.retreatEdge` (`north`, `south`, `east`, `west`); if `nearest`, the closest edge by Chebyshev distance is chosen at retreat-start and locked for the rest of the match; if `none`, retreat is disabled even at extreme damage
+- Movement style: retreating units SHALL move at Run MP toward the target edge; SHALL NOT use Jump (jump heat risks shutdown during escape); SHALL commit the facing that maximizes forward progress toward the edge, not one that faces the nearest enemy
+- Attack behavior: retreating units MAY fire weapons whose mount arc aligns with their forward-retreat facing, but SHALL reduce their `safeHeatThreshold` by 2 points (or to the unit's current dissipation, whichever is lower) to prevent shutdown during escape
+- Retreat-complete: when a retreating unit reaches a hex on the target edge, emit a `UnitRetreated` event and remove the unit from the active-unit list
+- Retreat is sticky: once triggered, a unit SHALL stay in retreat mode for the rest of the match — it does not return to normal combat even if healing occurs (healing mid-match is out of scope for Phase 1 anyway)
+
+## Dependencies
+
+- **Requires**: `improve-bot-basic-combat-competence` (C1) — reuses threat scoring, firing-arc filter, heat management, and SeededRandom discipline
+- **Requires**: `integrate-damage-pipeline` (A4) — structural-damage tracking and through-armor crit events must flow through the game engine before the trigger can fire reliably
+- **Required By**: none within Phase 1
+
+## Impact
+
+- Affected specs: `simulation-system` (new retreat-mode requirements)
+- Affected code: `src/simulation/ai/BotPlayer.ts` (retreat-mode gating), `src/simulation/ai/MoveAI.ts` (edge-ward move scoring), `src/simulation/ai/AttackAI.ts` (retreat-aware heat threshold), `src/simulation/ai/types.ts` (retreat-state fields on `IAIUnitState`), `src/engine/InteractiveSession.ts` (emit `UnitRetreated`)
+- New event type: `UnitRetreated` payload `{ unitId, retreatEdge, turn }` added to `GameEventType`
+- No database changes; no UI changes beyond the existing event log consuming the new event
+- Reproducibility preserved: retreat triggers SHALL be deterministic given game state, not random
+
+## Non-Goals
+
+- Player-driven retreat UI — human players already quit a unit by not moving it; retreat is a bot-only behavior
+- Withdrawal bonuses or morale effects on the winning side — Phase 3 campaign territory
+- Coordinated team retreat (all units retreat together) — this change handles per-unit retreat only
+- Surrender or "concede" negotiation — Phase 4 multiplayer scope
+- Re-entry after reaching map edge — a retreated unit is gone for the rest of the match

--- a/openspec/changes/add-bot-retreat-behavior/specs/simulation-system/spec.md
+++ b/openspec/changes/add-bot-retreat-behavior/specs/simulation-system/spec.md
@@ -1,0 +1,212 @@
+## ADDED Requirements
+
+### Requirement: Bot Retreat Trigger Conditions
+
+`BotPlayer` SHALL place a unit into retreat mode (`isRetreating = true`) when either of the following conditions becomes true:
+
+1. **Structural damage trigger**: The fraction of destroyed internal structure across all locations exceeds `IBotBehavior.retreatThreshold` (default `0.5`). Destroyed internal structure is counted as `sum(startingInternalStructure - currentInternalStructure) / sum(startingInternalStructure)`.
+
+2. **Critical hit trigger**: The unit has received any through-armor critical hit on cockpit, gyro, or engine at any prior point in the match. This trigger fires independent of total damage level.
+
+Retreat is sticky: once triggered, `isRetreating` SHALL remain `true` for the rest of the match regardless of later state changes. If `IBotBehavior.retreatEdge === 'none'`, retreat SHALL NOT trigger under any condition.
+
+#### Scenario: Structural-damage trigger fires at threshold
+
+- **GIVEN** a bot unit with starting total internal structure of 100 points across all locations
+- **WHEN** the unit accumulates 51 points of total internal-structure destruction
+- **THEN** `shouldRetreat` SHALL return `true`
+- **AND** `isRetreating` SHALL be set on the unit
+- **AND** `retreatTargetEdge` SHALL be resolved from `IBotBehavior.retreatEdge`
+
+#### Scenario: Cockpit TAC triggers retreat regardless of damage
+
+- **GIVEN** a bot unit at full structural integrity that receives a through-armor critical hit on the cockpit
+- **WHEN** the critical-hit event is processed
+- **THEN** `shouldRetreat` SHALL return `true` in the next AI evaluation
+- **AND** retreat mode SHALL engage before the unit's next movement phase
+
+#### Scenario: Gyro or engine TAC also triggers
+
+- **GIVEN** a bot unit that receives a through-armor critical on the gyro (or engine) without cockpit damage
+- **WHEN** retreat evaluation runs
+- **THEN** retreat SHALL trigger on that single critical
+
+#### Scenario: retreatEdge 'none' disables retreat
+
+- **GIVEN** a bot unit with `IBotBehavior.retreatEdge === 'none'` that is crippled to 10% structure remaining
+- **WHEN** retreat evaluation runs
+- **THEN** `shouldRetreat` SHALL return `false`
+- **AND** the unit SHALL continue fighting normally until destroyed
+
+#### Scenario: Retreat is sticky once triggered
+
+- **GIVEN** a unit in retreat mode that somehow has its critical-hit trigger condition reversed (not possible in Phase 1 but defended against)
+- **WHEN** retreat evaluation runs again
+- **THEN** `isRetreating` SHALL remain `true`
+- **AND** the unit SHALL NOT resume normal combat behavior
+
+### Requirement: Retreat Edge Resolution
+
+The concrete map edge used for retreat SHALL be resolved once, at the moment retreat triggers, and locked for the rest of the match. The resolution SHALL be deterministic.
+
+- Explicit values `'north'`, `'south'`, `'east'`, `'west'` SHALL return themselves.
+- Value `'nearest'` SHALL return the map edge with minimum Chebyshev distance from the unit's current hex. Ties SHALL break in priority order: north > east > south > west.
+- Value `'none'` SHALL return `null` and retreat SHALL NOT engage.
+
+#### Scenario: Nearest edge resolution picks closest
+
+- **GIVEN** a bot unit positioned 3 hexes from the north edge, 8 hexes from the east edge, 12 hexes from the south edge, and 15 hexes from the west edge, with `retreatEdge: 'nearest'`
+- **WHEN** retreat triggers
+- **THEN** `retreatTargetEdge` SHALL resolve to `'north'`
+
+#### Scenario: Nearest edge ties break deterministically
+
+- **GIVEN** a bot unit exactly equidistant from north and east edges with `retreatEdge: 'nearest'`
+- **WHEN** retreat triggers
+- **THEN** `retreatTargetEdge` SHALL resolve to `'north'` (tiebreaker priority)
+
+#### Scenario: Locked edge survives subsequent moves
+
+- **GIVEN** a unit that triggered retreat with `retreatTargetEdge = 'north'` and then moved laterally so that `'east'` is now closer
+- **WHEN** the next movement phase begins
+- **THEN** the unit SHALL continue retreating toward `'north'`
+- **AND** the target edge SHALL NOT be re-resolved
+
+### Requirement: Retreat Movement Scoring
+
+While `unit.isRetreating === true`, `MoveAI` SHALL use a retreat-specific scoring formula that prioritizes progress toward the locked retreat edge over line-of-sight maintenance or firing-arc considerations.
+
+Retreat move scoring:
+
+- `+1000 * progressTowardEdge` where `progressTowardEdge = distanceToEdgeBefore - distanceToEdgeAfter` (positive means move reduces distance to edge)
+- `+200` if the move's resulting facing points the unit's forward arc toward the retreat edge
+- `-50` if the move is a jump move (discourage jumping)
+- Standard line-of-sight and threat-arc bonuses SHALL NOT be applied
+
+Ties SHALL be broken via `SeededRandom` so decisions remain reproducible.
+
+#### Scenario: Retreating unit picks move with greatest edge progress
+
+- **GIVEN** a unit retreating toward `'north'` with two candidate moves: move A reduces distance to north edge by 2 hexes, move B reduces it by 1 hex
+- **WHEN** move scoring runs
+- **THEN** move A SHALL score higher (+2000 vs +1000)
+- **AND** the bot SHALL commit move A
+
+#### Scenario: Retreating unit rotates forward toward edge
+
+- **GIVEN** two moves with equal edge progress but different ending facings — facing 0 points north (toward retreat edge), facing 3 points south
+- **WHEN** move scoring runs
+- **THEN** facing-0 move SHALL receive the `+200` bonus
+- **AND** the bot SHALL commit the forward-facing move
+
+#### Scenario: Retreating unit prefers run over jump with equal progress
+
+- **GIVEN** a run move and a jump move that cover identical ground toward the retreat edge
+- **WHEN** move scoring runs
+- **THEN** the run move SHALL score higher by 50 points
+- **AND** the bot SHALL NOT jump while retreating
+
+#### Scenario: Immobilized retreating unit stays in place without error
+
+- **GIVEN** a retreating unit with zero Walk and zero Run MP (all legs destroyed)
+- **WHEN** the movement phase begins
+- **THEN** `playMovementPhase` SHALL return `null` without throwing
+- **AND** no `UnitRetreated` event SHALL fire
+- **AND** the unit SHALL continue to be considered alive for attack and victory-check purposes
+
+### Requirement: Retreating Units Run, Not Jump or Walk
+
+`BotPlayer.selectMovementType` SHALL return `MovementType.Run` for retreating units whenever Run MP is available. If Run is unavailable, Walk SHALL be used. Jump SHALL NOT be selected during retreat under any circumstance.
+
+#### Scenario: Run selected when available
+
+- **GIVEN** a retreating unit with `runMP = 8`, `walkMP = 5`, `jumpMP = 4`
+- **WHEN** movement-type selection runs
+- **THEN** `MovementType.Run` SHALL be returned
+
+#### Scenario: Walk fallback when run is unavailable
+
+- **GIVEN** a retreating unit with damaged leg actuators preventing running (`runMP = 0`, `walkMP = 3`)
+- **WHEN** movement-type selection runs
+- **THEN** `MovementType.Walk` SHALL be returned
+
+#### Scenario: Jump never selected during retreat
+
+- **GIVEN** a retreating unit with `runMP = 0`, `walkMP = 0`, `jumpMP = 5`
+- **WHEN** movement-type selection runs
+- **THEN** `MovementType.Walk` SHALL be returned (even though Walk is also 0, yielding a zero-progress turn)
+- **AND** `MovementType.Jump` SHALL NOT be returned
+
+### Requirement: Retreating Units Fire with Reduced Heat Threshold
+
+Retreating units MAY continue to declare weapon attacks, but SHALL reduce the effective `safeHeatThreshold` passed to heat management by 2 points (minimum 0). Retreating units SHALL NOT declare physical attacks. Weapons fired during retreat SHALL be limited to those whose mount arc aligns with the unit's forward-retreat facing — no torso twist to engage enemies behind the retreat vector.
+
+#### Scenario: Retreating unit fires with tighter heat budget
+
+- **GIVEN** a retreating unit with `IBotBehavior.safeHeatThreshold = 13`
+- **WHEN** heat management runs for its attack phase
+- **THEN** the effective threshold SHALL be `11`
+- **AND** weapons that would push projected heat above 11 SHALL be culled
+
+#### Scenario: Retreating unit with low base threshold clamps at zero
+
+- **GIVEN** a retreating unit with `IBotBehavior.safeHeatThreshold = 1`
+- **WHEN** heat management runs
+- **THEN** the effective threshold SHALL be `0` (clamped, not -1)
+- **AND** only zero-heat weapons SHALL fire
+
+#### Scenario: Retreating unit does not torso-twist backward
+
+- **GIVEN** a retreating unit with its forward facing pointed toward the retreat edge and an enemy directly behind it
+- **WHEN** attack selection runs
+- **THEN** forward-mounted weapons SHALL NOT be declared against the rear enemy (no torso twist is attempted)
+- **AND** rear-mounted weapons MAY be declared against the rear enemy under the reduced heat threshold
+
+#### Scenario: Retreating unit skips physical attacks
+
+- **GIVEN** a retreating unit adjacent to an enemy that would normally warrant a punch or kick
+- **WHEN** physical-attack evaluation runs
+- **THEN** no physical attack SHALL be declared
+- **AND** the retreating unit SHALL continue to the next phase
+
+### Requirement: UnitRetreated Event on Reaching Map Edge
+
+When a retreating unit's movement takes it onto a hex that lies on the locked `retreatTargetEdge`, a `GameEventType.UnitRetreated` event SHALL be emitted in the same turn as the movement. The unit SHALL be marked as no longer participating in combat (analogous to destruction for victory-check purposes) but SHALL be distinguished from combat destruction in the post-battle summary.
+
+The event payload SHALL include:
+
+```typescript
+interface IUnitRetreatedPayload {
+  readonly unitId: string;
+  readonly retreatEdge: 'north' | 'south' | 'east' | 'west';
+  readonly turn: number;
+}
+```
+
+#### Scenario: Unit retreats off the north edge
+
+- **GIVEN** a retreating unit one hex south of the north map edge with `retreatTargetEdge = 'north'` and enough Run MP to reach the edge
+- **WHEN** the movement phase resolves
+- **THEN** both a `MovementDeclared` event and a `UnitRetreated` event SHALL be emitted, in that order
+- **AND** the `UnitRetreated` payload SHALL record `unitId`, `retreatEdge: 'north'`, and the current turn number
+
+#### Scenario: Retreated unit removed from active list
+
+- **GIVEN** a unit has emitted `UnitRetreated` in turn 6
+- **WHEN** the victory-condition check runs at end of turn 6
+- **THEN** the retreated unit SHALL NOT count toward its side's remaining-unit total
+- **AND** if this causes its side's remaining unit count to reach zero, the opposing side SHALL be declared the winner
+
+#### Scenario: Post-battle summary distinguishes retreat from destruction
+
+- **GIVEN** a match ending with one unit destroyed in combat and one unit retreated
+- **WHEN** the post-battle summary is generated (via `add-victory-and-post-battle-summary`)
+- **THEN** the summary SHALL list the destroyed unit under "combat losses" and the retreated unit under "withdrawn"
+- **AND** no XP or salvage SHALL be awarded for the retreated unit (campaign integration — Phase 3)
+
+#### Scenario: Retreating unit that reaches edge on the same turn it triggered
+
+- **GIVEN** a unit that triggers retreat while already adjacent to its chosen edge
+- **WHEN** the next movement phase begins
+- **THEN** the unit SHALL reach the edge on that turn
+- **AND** `UnitRetreated` SHALL fire normally (single-turn retreat is valid)

--- a/openspec/changes/add-bot-retreat-behavior/tasks.md
+++ b/openspec/changes/add-bot-retreat-behavior/tasks.md
@@ -1,0 +1,62 @@
+# Tasks: Add Bot Retreat Behavior
+
+## 1. Retreat State on IAIUnitState
+
+- [ ] 1.1 Add `isRetreating: boolean` and `retreatTargetEdge: 'north' | 'south' | 'east' | 'west' | null` fields to `IAIUnitState` in `src/simulation/ai/types.ts`
+- [ ] 1.2 Default both to `false` / `null` when the session builder constructs the unit state
+- [ ] 1.3 Write unit tests confirming defaults and that fields survive event replay
+
+## 2. Retreat Trigger Evaluation
+
+- [ ] 2.1 Add `shouldRetreat(unit, behavior)` helper in `BotPlayer` (or new `RetreatAI.ts` module) that returns true when either trigger fires
+- [ ] 2.2 Trigger A: `sum(destroyed internal structure points) / sum(starting internal structure points) > behavior.retreatThreshold`
+- [ ] 2.3 Trigger B: unit has received any through-armor critical on cockpit, gyro, or engine this match (check game event log for `CriticalHitApplied` events with matching locations)
+- [ ] 2.4 Set `isRetreating = true` and `retreatTargetEdge = resolveEdge(behavior, unit, grid)` once triggered — lock the edge for the rest of the match
+- [ ] 2.5 Write unit tests: unit at 51% structural loss triggers; cockpit TAC triggers even at 0% structural loss; `retreatEdge = 'none'` suppresses trigger
+
+## 3. Target Edge Resolution
+
+- [ ] 3.1 Implement `resolveEdge(behavior, unit, grid)` that returns the concrete edge to retreat toward
+- [ ] 3.2 For explicit edges (`north`/`south`/`east`/`west`), return the field value directly
+- [ ] 3.3 For `nearest`, compute the edge with minimum axial distance from the unit's current hex; break ties deterministically (north → east → south → west)
+- [ ] 3.4 For `none`, return `null` and retreat stays disabled
+- [ ] 3.5 Write unit tests covering each branch, including edge-distance ties
+
+## 4. Retreat Movement Scoring
+
+- [ ] 4.1 In `MoveAI`, when `attacker.isRetreating === true`, override the scoring formula with retreat-specific weights
+- [ ] 4.2 Score `+1000 * progressTowardEdge` where progress is the delta in Chebyshev distance from the retreat edge before vs. after the move (positive = closer to edge)
+- [ ] 4.3 Score `+200` if the move's ending facing points the forward arc toward the retreat edge (maximizes future run MP)
+- [ ] 4.4 Score `-50` for jump moves (discourage jumping during retreat) — effectively force Run by making Run always outscore Jump when progress is equal
+- [ ] 4.5 Skip the standard line-of-sight scoring — retreating units do not care about maintaining LoS
+- [ ] 4.6 Write unit tests: retreating unit with edge `north` picks the move with largest northward progress; equal-progress moves pick the one facing north; jump move loses to equivalent run move
+
+## 5. Movement Type Selection While Retreating
+
+- [ ] 5.1 Override `BotPlayer.selectMovementType` so that when `unit.isRetreating === true`, the return value is `MovementType.Run` whenever `capability.runMP > 0`
+- [ ] 5.2 Fall back to `MovementType.Walk` if Run is unavailable (e.g., leg actuator damage prevents running)
+- [ ] 5.3 Never return `MovementType.Jump` during retreat
+- [ ] 5.4 Write unit tests covering each fallback path
+
+## 6. Retreat-Aware Attack Behavior
+
+- [ ] 6.1 When `unit.isRetreating === true`, reduce the effective `safeHeatThreshold` passed to `AttackAI` heat management by 2 (minimum 0)
+- [ ] 6.2 Exclude weapons whose mount arc does not align with the retreat forward facing (retreating units do not twist away from the escape path)
+- [ ] 6.3 Skip physical-attack declarations entirely for retreating units
+- [ ] 6.4 Write unit tests: retreating unit with threshold 13 uses effective 11; retreating unit with rear-mounted weapons and target behind still fires rear weapons (rear mounts align with escape facing when escape is away from enemy)
+
+## 7. Retreat Completion Event
+
+- [ ] 7.1 Add `GameEventType.UnitRetreated` with payload `{ unitId: string; retreatEdge: 'north'|'south'|'east'|'west'; turn: number }`
+- [ ] 7.2 In `BotPlayer.playMovementPhase`, detect when the move reaches a hex on the target edge (`grid.isEdgeHex(destination, retreatTargetEdge) === true`)
+- [ ] 7.3 Emit `UnitRetreated` in addition to the movement event for that turn
+- [ ] 7.4 In the session reducer, mark the retreated unit as `destroyed: true` for victory-check purposes but distinguish it from combat destruction (for post-battle summary accuracy)
+- [ ] 7.5 Write integration tests covering the full retreat arc: trigger → multi-turn withdrawal → edge reached → event emitted → unit removed from active list
+
+## 8. Determinism & Edge Cases
+
+- [ ] 8.1 Retreat triggers SHALL be pure functions of game state — no randomness — so identical states always yield identical retreat decisions
+- [ ] 8.2 If a retreating unit cannot move (immobilized, all legs destroyed) it SHALL remain in place, continue firing under reduced-heat rules, and SHALL NOT emit `UnitRetreated`
+- [ ] 8.3 If both triggers fire in the same turn, `isRetreating` is set once — no double-trigger side effects
+- [ ] 8.4 If the retreat edge is directly adjacent at trigger time, the unit SHALL reach the edge on its next movement phase (single-turn retreat is valid)
+- [ ] 8.5 Write unit tests covering each edge case above

--- a/openspec/changes/add-combat-outcome-model/proposal.md
+++ b/openspec/changes/add-combat-outcome-model/proposal.md
@@ -1,0 +1,52 @@
+# Change: Add Combat Outcome Model
+
+## Why
+
+Phase 3 wires combat outcomes back into the campaign. The Phase 1 game engine
+produces a rich event-sourced `IGameSession` — full turn log, per-unit damage,
+heat excursions, pilot consciousness rolls, weapons fired. The campaign
+consumer (XP awards, medical, repair, salvage, contract progression) cannot
+ingest a raw event stream — it needs a single, serialized, versioned payload
+with every fact the downstream processors need. Without this bridge, a
+completed battle is an orphan: the session ends but nothing persists.
+
+## What Changes
+
+- Add `ICombatOutcome` interface — the canonical hand-off shape from Phase 1
+  engine to Phase 3 campaign processors (derived from event log, deterministic)
+- Add `IUnitCasualty` per participating unit: armor lost per location,
+  structure lost per location, destroyed components, critical hits taken,
+  ammo consumed, weapons fired, max heat reached, shutdowns, final status
+  (intact / damaged / destroyed / crippled)
+- Add `IPilotOutcome` per pilot: XP-eligible events (kills, task completions,
+  mission role), wounds taken, consciousness rolls, pilot status (active /
+  wounded / unconscious / KIA / MIA)
+- Add `deriveCombatOutcome(session: IGameSession): ICombatOutcome` — pure
+  derivation, no mutation, same session produces identical outcome
+- Add `combatOutcomeVersion` for forward compatibility as engine evolves
+- Add match-side metadata (winner, reason, turn count, scenario id, encounter
+  id, contract id) so downstream processors can route effects correctly
+
+## Dependencies
+
+- **Requires (Phase 1)**: `add-interactive-combat-core-ui`,
+  `integrate-damage-pipeline` (A1–A7 — correct damage/crit/heat math must land
+  first or outcomes will be wrong), `add-victory-and-post-battle-summary` (B6
+  — provides `IPostBattleReport` which this change supersets)
+- **Required By**: `add-post-battle-processor` (consumes `ICombatOutcome`),
+  `add-salvage-rules-engine`, `add-repair-queue-integration`,
+  `add-post-battle-review-ui`, `wire-encounter-to-campaign-round-trip`
+
+## Impact
+
+- Affected specs: `after-combat-report` (MODIFIED — supersedes
+  `IPostBattleReport` with the richer `ICombatOutcome`), `combat-resolution`
+  (MODIFIED — adds outcome derivation as terminal step), `game-session-management`
+  (MODIFIED — session exposes `toCombatOutcome()` on completion)
+- Affected code: new `src/lib/combat/outcome/combatOutcome.ts` (derivation),
+  new `src/types/combat/CombatOutcome.ts` (interfaces), extends
+  `src/engine/InteractiveSession.ts` with `getOutcome()`, extends
+  `/api/matches` to persist outcomes alongside existing post-battle reports
+- Non-goals: applying the outcome (that's `add-post-battle-processor`),
+  salvage calculation (that's `add-salvage-rules-engine`), UI rendering
+  (that's `add-post-battle-review-ui`)

--- a/openspec/changes/add-combat-outcome-model/specs/after-combat-report/spec.md
+++ b/openspec/changes/add-combat-outcome-model/specs/after-combat-report/spec.md
@@ -1,0 +1,184 @@
+# after-combat-report Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Combat Outcome Schema
+
+The after-combat report system SHALL define an `ICombatOutcome` schema that
+supersedes `IPostBattleReport` as the canonical serialized result of a
+completed tactical session. `ICombatOutcome` SHALL carry every fact the
+campaign consumes: winner, casualties per unit with location-level detail,
+pilot outcomes with XP-eligible events and wounds, ammo consumption, heat
+problems, and scenario/contract linkage.
+
+#### Scenario: Outcome contains required top-level fields
+
+- **GIVEN** a session that has completed via `GameEnded`
+- **WHEN** `deriveCombatOutcome(session)` is called
+- **THEN** the returned `ICombatOutcome` SHALL contain `version`, `matchId`,
+  `sessionId`, `encounterId`, `contractId`, `scenarioId`, `winner`,
+  `endReason`, `turnCount`, `startedAt`, `completedAt`, `units`, `pilots`,
+  `events`
+- **AND** `winner` SHALL be one of `GameSide.Player`, `GameSide.Opponent`,
+  or `"draw"`
+- **AND** `endReason` SHALL be one of `DESTRUCTION`, `CONCEDE`, `TURN_LIMIT`,
+  `OBJECTIVE_MET`, `WITHDRAWAL`
+- **AND** `version` SHALL equal the current `COMBAT_OUTCOME_VERSION`
+
+#### Scenario: Unit casualty captures per-location damage
+
+- **GIVEN** a unit that took 18 damage to the left torso (12 armor, 6
+  structure) and 5 damage to the right arm (all armor)
+- **WHEN** the unit casualty is derived
+- **THEN** the `IUnitCasualty` SHALL include
+  `armorLostPerLocation: { LT: 12, RA: 5 }`
+- **AND** `structureLostPerLocation: { LT: 6 }`
+- **AND** all other locations SHALL be absent or zero
+
+#### Scenario: Unit casualty captures destroyed components
+
+- **GIVEN** a unit whose Medium Laser in the right arm was destroyed by a
+  critical hit during combat
+- **WHEN** the unit casualty is derived
+- **THEN** the `IUnitCasualty.destroyedComponents` SHALL contain an entry
+  `{ location: RA, slot: <n>, componentType: "weapon", name: "Medium Laser" }`
+
+#### Scenario: Unit casualty captures ammo consumption
+
+- **GIVEN** a unit that fired 8 LRM-15 shots and 3 MG bursts
+- **WHEN** the unit casualty is derived
+- **THEN** the `IUnitCasualty.ammoConsumed` SHALL be
+  `{ "LRM 15 Ammo": 8, "Machine Gun Ammo": 3 }`
+
+#### Scenario: Pilot outcome captures XP-eligible events
+
+- **GIVEN** a pilot whose unit destroyed two enemy units and completed one
+  objective task
+- **WHEN** the pilot outcome is derived
+- **THEN** the `IPilotOutcome.kills` SHALL equal 2
+- **AND** the `IPilotOutcome.tasksCompleted` SHALL equal 1
+- **AND** the `IPilotOutcome.missionRole` SHALL be set (e.g., `LANCE_LEADER`)
+
+#### Scenario: Pilot outcome captures wounds and consciousness
+
+- **GIVEN** a pilot that took 2 head hits and failed one consciousness roll
+- **WHEN** the pilot outcome is derived
+- **THEN** the `IPilotOutcome.woundsTaken` SHALL equal 2
+- **AND** the `IPilotOutcome.consciousnessRollsFailed` SHALL equal 1
+- **AND** the `IPilotOutcome.finalStatus` SHALL be `UNCONSCIOUS` or higher
+
+### Requirement: Deterministic Outcome Derivation
+
+`ICombatOutcome` SHALL be derived purely from the session's event log and
+initial configuration, with zero session-state mutation. The same inputs
+SHALL always yield a deeply-equal outcome.
+
+#### Scenario: Derivation is deterministic
+
+- **GIVEN** a fixed `IGameSession` with event log L
+- **WHEN** `deriveCombatOutcome(session)` is called twice
+- **THEN** both returned outcomes SHALL be deeply equal
+
+#### Scenario: Derivation does not mutate session
+
+- **GIVEN** an `IGameSession` with status `Completed`
+- **WHEN** `deriveCombatOutcome(session)` is called
+- **THEN** no field of the session SHALL be modified
+- **AND** the session event log SHALL remain byte-identical
+
+### Requirement: Final Unit Status Classification
+
+Each `IUnitCasualty.finalStatus` SHALL be computed from damage state using
+deterministic rules.
+
+#### Scenario: Intact unit
+
+- **GIVEN** a unit that took zero damage to armor or structure
+- **WHEN** final status is computed
+- **THEN** `finalStatus` SHALL be `INTACT`
+
+#### Scenario: Damaged unit
+
+- **GIVEN** a unit with ≤50% structure lost across all locations and no
+  location destroyed
+- **WHEN** final status is computed
+- **THEN** `finalStatus` SHALL be `DAMAGED`
+
+#### Scenario: Crippled unit
+
+- **GIVEN** a unit with either >50% structure lost or any non-CT location
+  destroyed
+- **WHEN** final status is computed
+- **THEN** `finalStatus` SHALL be `CRIPPLED`
+
+#### Scenario: Destroyed unit
+
+- **GIVEN** a unit whose CT structure reached zero or whose engine took
+  three critical hits
+- **WHEN** final status is computed
+- **THEN** `finalStatus` SHALL be `DESTROYED`
+
+#### Scenario: Ejected unit
+
+- **GIVEN** a unit whose pilot ejected before destruction
+- **WHEN** final status is computed
+- **THEN** `finalStatus` SHALL be `EJECTED`
+- **AND** the unit SHALL NOT be classified as `DESTROYED`
+
+### Requirement: Final Pilot Status Classification
+
+Each `IPilotOutcome.finalStatus` SHALL be computed from pilot damage and
+events using deterministic rules.
+
+#### Scenario: Active pilot
+
+- **GIVEN** a pilot that took zero hits and passed all consciousness rolls
+- **WHEN** final status is computed
+- **THEN** `finalStatus` SHALL be `ACTIVE`
+
+#### Scenario: Wounded pilot
+
+- **GIVEN** a pilot that took 1–5 hits but was conscious at end of battle
+- **WHEN** final status is computed
+- **THEN** `finalStatus` SHALL be `WOUNDED`
+
+#### Scenario: KIA pilot
+
+- **GIVEN** a pilot that took 6+ hits or whose unit was destroyed without
+  successful ejection
+- **WHEN** final status is computed
+- **THEN** `finalStatus` SHALL be `KIA`
+
+### Requirement: Schema Versioning
+
+Every derived `ICombatOutcome` SHALL include a `version` field equal to
+`COMBAT_OUTCOME_VERSION` so consumers can detect incompatible payloads.
+
+#### Scenario: Current version stamped on derivation
+
+- **GIVEN** a session being derived today
+- **WHEN** `deriveCombatOutcome(session)` is called
+- **THEN** `outcome.version` SHALL equal `COMBAT_OUTCOME_VERSION`
+
+#### Scenario: Consumer rejects unknown version
+
+- **GIVEN** a stored outcome with `version` greater than
+  `COMBAT_OUTCOME_VERSION`
+- **WHEN** a consumer calls `assertCombatOutcomeCurrent(outcome)`
+- **THEN** the guard SHALL throw `UnsupportedCombatOutcomeVersionError`
+
+## MODIFIED Requirements
+
+### Requirement: Post-Battle Report Schema
+
+The `IPostBattleReport` schema SHALL remain valid for UI backward
+compatibility but SHALL now be derivable from `ICombatOutcome`.
+
+#### Scenario: Adapter produces equivalent report
+
+- **GIVEN** an `ICombatOutcome` derived from a session
+- **WHEN** `fromCombatOutcome(outcome)` is called
+- **THEN** the returned `IPostBattleReport` SHALL contain `matchId`,
+  `winner`, `reason`, `turnCount`, `units`, `mvpUnitId`, `log`
+- **AND** its field values SHALL agree with the outcome fields of the same
+  name, with `reason` mapped from `outcome.endReason`

--- a/openspec/changes/add-combat-outcome-model/specs/combat-resolution/spec.md
+++ b/openspec/changes/add-combat-outcome-model/specs/combat-resolution/spec.md
@@ -1,0 +1,47 @@
+# combat-resolution Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Terminal Outcome Derivation
+
+Every completed combat session SHALL produce a single `ICombatOutcome` as
+its terminal artifact. The session pipeline SHALL NOT be considered complete
+until the outcome has been derived and made available to campaign consumers.
+
+#### Scenario: Completion triggers outcome derivation
+
+- **GIVEN** an `InteractiveSession` that emits `GameEnded`
+- **WHEN** the session status transitions to `Completed`
+- **THEN** `ICombatOutcome` SHALL be derivable via `session.getOutcome()`
+- **AND** a `CombatOutcomeReady` event SHALL be emitted to the session event
+  stream
+
+#### Scenario: Outcome unavailable before completion
+
+- **GIVEN** an `InteractiveSession` with status `InProgress`
+- **WHEN** `session.getOutcome()` is called
+- **THEN** `CombatNotCompleteError` SHALL be thrown
+
+### Requirement: Outcome Carries Scenario Linkage
+
+`ICombatOutcome` SHALL carry `encounterId`, `contractId`, and `scenarioId`
+fields populated from the session's configuration, enabling downstream
+campaign processors to route effects back to the correct campaign entities.
+
+#### Scenario: Encounter-launched session carries encounter id
+
+- **GIVEN** a session launched by `EncounterService.launchEncounter`
+- **WHEN** the session completes and outcome is derived
+- **THEN** `outcome.encounterId` SHALL equal the source encounter's id
+- **AND** `outcome.contractId` SHALL equal the encounter's contract id when
+  the encounter was generated from a contract
+- **AND** `outcome.scenarioId` SHALL equal the encounter's scenario id when
+  the encounter was generated from a scenario template
+
+#### Scenario: Standalone skirmish has null linkage
+
+- **GIVEN** a session launched via the standalone skirmish setup (not from a
+  campaign encounter)
+- **WHEN** the outcome is derived
+- **THEN** `outcome.encounterId`, `outcome.contractId`, and
+  `outcome.scenarioId` SHALL be `null`

--- a/openspec/changes/add-combat-outcome-model/specs/game-session-management/spec.md
+++ b/openspec/changes/add-combat-outcome-model/specs/game-session-management/spec.md
@@ -1,0 +1,43 @@
+# game-session-management Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Session Exposes Combat Outcome
+
+Every `IGameSession` SHALL expose a `getOutcome()` method that returns the
+derived `ICombatOutcome` once the session is `Completed`. The outcome SHALL
+be memoized per session instance so repeated calls return the same object
+reference.
+
+#### Scenario: Completed session exposes outcome
+
+- **GIVEN** an `IGameSession` with status `Completed`
+- **WHEN** `session.getOutcome()` is called
+- **THEN** it SHALL return a valid `ICombatOutcome` with current `version`
+- **AND** a second call SHALL return a reference-equal object
+
+#### Scenario: Active session throws on outcome request
+
+- **GIVEN** an `IGameSession` with status `InProgress` or `Setup`
+- **WHEN** `session.getOutcome()` is called
+- **THEN** `CombatNotCompleteError` SHALL be thrown
+
+### Requirement: Session Persists Outcome
+
+When a session completes, the derived `ICombatOutcome` SHALL be persisted to
+the match store alongside the event log. Reloads of the match SHALL restore
+the outcome without re-deriving.
+
+#### Scenario: Outcome written on completion
+
+- **GIVEN** a session that has just emitted `GameEnded`
+- **WHEN** the match persistence layer handles the event
+- **THEN** a POST to `/api/matches` SHALL include `outcome: ICombatOutcome`
+- **AND** the stored record SHALL contain the outcome JSON
+
+#### Scenario: Outcome retrieval
+
+- **GIVEN** a persisted match with id M
+- **WHEN** `GET /api/matches/M/outcome` is called
+- **THEN** the response body SHALL equal the originally persisted outcome
+- **AND** the response status SHALL be 200

--- a/openspec/changes/add-combat-outcome-model/tasks.md
+++ b/openspec/changes/add-combat-outcome-model/tasks.md
@@ -1,0 +1,83 @@
+# Tasks: Add Combat Outcome Model
+
+## 1. Type Definitions
+
+- [ ] 1.1 Create `src/types/combat/CombatOutcome.ts`
+- [ ] 1.2 Define `ICombatOutcome` with `version`, `matchId`, `sessionId`,
+      `encounterId`, `contractId`, `scenarioId`, `winner`, `endReason`,
+      `turnCount`, `startedAt`, `completedAt`, `units`, `pilots`, `events`
+- [ ] 1.3 Define `IUnitCasualty` with `unitId`, `side`, `ownerPlayerId`,
+      `armorLostPerLocation`, `structureLostPerLocation`,
+      `criticalHitsTaken`, `destroyedComponents`, `ammoConsumed`,
+      `weaponsFired`, `maxHeatReached`, `shutdownCount`, `finalStatus`,
+      `wasMvp`
+- [ ] 1.4 Define `IPilotOutcome` with `personId`, `unitId`, `side`,
+      `kills`, `tasksCompleted`, `missionRole`, `woundsTaken`,
+      `consciousnessRollsFailed`, `finalStatus`, `capturedBy`
+- [ ] 1.5 Define `CombatEndReason` enum: `DESTRUCTION`, `CONCEDE`,
+      `TURN_LIMIT`, `OBJECTIVE_MET`, `WITHDRAWAL`
+- [ ] 1.6 Define `UnitFinalStatus` enum: `INTACT`, `DAMAGED`,
+      `CRIPPLED`, `DESTROYED`, `EJECTED`
+- [ ] 1.7 Define `PilotFinalStatus` enum: `ACTIVE`, `WOUNDED`,
+      `UNCONSCIOUS`, `KIA`, `MIA`, `CAPTURED`
+- [ ] 1.8 Set `COMBAT_OUTCOME_VERSION = 1` constant for forward compatibility
+
+## 2. Derivation Logic
+
+- [ ] 2.1 Create `src/lib/combat/outcome/combatOutcome.ts`
+- [ ] 2.2 Implement `deriveCombatOutcome(session: IGameSession): ICombatOutcome`
+- [ ] 2.3 Implement `deriveUnitCasualties(events, unitStates)` — aggregate
+      `DamageApplied`, `CriticalHitResolved`, `AmmoConsumed`,
+      `UnitDestroyed` events per unit
+- [ ] 2.4 Implement `derivePilotOutcomes(events, pilots)` — aggregate
+      `PilotHit`, `PilotConsciousnessCheck`, `UnitDestroyed` (killerId),
+      task-completed events
+- [ ] 2.5 Implement `computeFinalUnitStatus(casualty)` — map damage state to
+      enum (INTACT if no armor lost, DAMAGED if ≤50% structure, CRIPPLED if >50% structure or any location destroyed, DESTROYED if CT gone)
+- [ ] 2.6 Implement `computeFinalPilotStatus(outcome)` — KIA if pilot hits
+      reach fatal threshold, UNCONSCIOUS if failed consciousness roll,
+      WOUNDED if any hit, ACTIVE otherwise
+- [ ] 2.7 Guarantee determinism — same event log always produces
+      deep-equal `ICombatOutcome`
+
+## 3. Session Integration
+
+- [ ] 3.1 Extend `InteractiveSession` with `getOutcome(): ICombatOutcome`
+      (only valid once status is `Completed`)
+- [ ] 3.2 Throw `CombatNotCompleteError` if called on active session
+- [ ] 3.3 Emit `CombatOutcomeReady` event when outcome is first derived
+
+## 4. Persistence
+
+- [ ] 4.1 Extend `/api/matches` POST body to accept `outcome: ICombatOutcome`
+- [ ] 4.2 Store outcome JSON alongside existing match log
+- [ ] 4.3 Extend `GET /api/matches/[id]` response with `outcome` field
+- [ ] 4.4 Add `GET /api/matches/[id]/outcome` for outcome-only retrieval
+
+## 5. Versioning & Forward Compatibility
+
+- [ ] 5.1 Stamp `version` on every derived outcome from `COMBAT_OUTCOME_VERSION`
+- [ ] 5.2 Document migration path for future outcome-schema changes
+- [ ] 5.3 Add `assertCombatOutcomeCurrent(outcome)` guard for consumers
+
+## 6. Superseding B6's `IPostBattleReport`
+
+- [ ] 6.1 Keep `IPostBattleReport` for UI backward compatibility; add
+      `fromCombatOutcome(outcome): IPostBattleReport` adapter
+- [ ] 6.2 Mark `IPostBattleReport` fields as derivable from `ICombatOutcome`
+
+## 7. Tests
+
+- [ ] 7.1 Unit test: deterministic derivation (run twice, deep-equal)
+- [ ] 7.2 Unit test: unit final status classification across all five states
+- [ ] 7.3 Unit test: pilot final status across all five states
+- [ ] 7.4 Unit test: kill attribution via `UnitDestroyed.killerId`
+- [ ] 7.5 Unit test: consciousness roll accumulation
+- [ ] 7.6 Unit test: serialization round-trip through JSON
+- [ ] 7.7 Integration test: full 4-mech match → outcome → assert shape
+- [ ] 7.8 Fuzz test: random event streams produce valid outcomes (no throws)
+
+## 8. Documentation
+
+- [ ] 8.1 Inline JSDoc on every interface member
+- [ ] 8.2 Add `docs/combat/combat-outcome.md` with worked example

--- a/openspec/changes/add-damage-feedback-effects/proposal.md
+++ b/openspec/changes/add-damage-feedback-effects/proposal.md
@@ -1,0 +1,56 @@
+# Change: Add Damage Feedback Effects
+
+## Why
+
+Phase 1's `add-damage-feedback-ui` gives us armor-pip decay, crit
+bursts, damage number floaters, and a pilot-wound flash — all on the
+selected unit's action panel or directly over the token. Phase 7 broadens
+that to the _battlefield_: a heavy hit shakes the screen, a destroyed
+location vents smoke, engine crits ignite fire, and a dying unit bursts
+into a debris cloud. Persistent effects (smoke, fire) stick around for
+the rest of the unit's life so even a player scrolling back into the
+fight can read the wound history at a glance.
+
+## What Changes
+
+- Screen shake on impacts >= 10 damage in a single resolved hit
+  (intensity scales with damage; clamped and dampened under reduced
+  motion)
+- Hit-location flash: the specific pip group on the sprite ring glows
+  white briefly when its location takes damage
+- Smoke puffs continuously from any destroyed location while the unit
+  is alive (LA destroyed -> smoke above left arm pip group)
+- Fire on engine crits — small animated flame at the unit's torso
+  persists for the rest of its life
+- Debris cloud + sprite fade when a unit is destroyed (center torso
+  gone or pilot killed); final token state is a wreck silhouette
+
+## Dependencies
+
+- **Requires**: `add-interactive-combat-core-ui` (Phase 1 MVP),
+  `add-mech-silhouette-sprite-set` (sprite + pip ring),
+  `add-damage-feedback-ui` (pip decay, crit burst, damage numbers),
+  `damage-system`, `tactical-map-interface`
+- **Related**: `add-attack-visual-effects` (impact flash is upstream of
+  these effects), `add-heat-and-shutdown-visual-indicators` (shared
+  visual grammar)
+- **Required By**: none — Phase 7 presentation layer
+
+## Impact
+
+- Affected specs: `damage-system` (MODIFIED — destroyed-location and
+  engine-crit events must carry enough metadata for UI playback; unit
+  destruction event carries cause), `tactical-map-interface` (MODIFIED
+  — new persistent-effect layer for smoke/fire, screen-shake controller,
+  wreck sprite rendering, hit-location flash)
+- Affected code: new
+  `src/components/gameplay/effects/HitLocationFlash.tsx`,
+  `src/components/gameplay/effects/SmokePuff.tsx`,
+  `src/components/gameplay/effects/EngineFire.tsx`,
+  `src/components/gameplay/effects/DebrisCloud.tsx`, new
+  `src/hooks/useScreenShake.ts`, new wreck sprite variants per
+  archetype under `public/sprites/mechs/wrecks/`
+- Non-goals: camera effects beyond screen shake (zoom punch, chromatic
+  aberration, cinematic pulls — future), sound (out), real-time
+  destruction physics, 3D effects (shelved)
+- Database: none

--- a/openspec/changes/add-damage-feedback-effects/specs/damage-system/spec.md
+++ b/openspec/changes/add-damage-feedback-effects/specs/damage-system/spec.md
@@ -1,0 +1,56 @@
+# damage-system Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: Destruction Events Carry UI Metadata
+
+Damage-related events SHALL carry enough metadata for the UI to render
+presentation-layer effects without recomputing state.
+
+#### Scenario: LocationDestroyed carries anchor location
+
+- **GIVEN** a location is destroyed
+- **WHEN** the `LocationDestroyed` event is emitted
+- **THEN** the payload SHALL contain the location identifier (RA, LT,
+  etc.)
+- **AND** the payload SHALL indicate whether destruction was direct or
+  via transfer from an adjacent location
+
+#### Scenario: CriticalHit carries slot identity
+
+- **GIVEN** a critical hit lands on an engine slot
+- **WHEN** the `CriticalHit` event is emitted
+- **THEN** the payload SHALL contain the slot identifier (e.g.,
+  `ENGINE`, `GYRO`, `COCKPIT`)
+- **AND** the payload SHALL contain which location the slot was in
+- **AND** engine crits SHALL be distinguishable from other crits by
+  slot value
+
+#### Scenario: UnitDestroyed carries cause
+
+- **GIVEN** a unit is destroyed
+- **WHEN** the `UnitDestroyed` event is emitted
+- **THEN** the payload SHALL contain `cause: 'ct-destroyed' |
+'pilot-killed' | 'ammo-explosion' | 'engine-destroyed' | 'crew-kia'`
+- **AND** the UI SHALL use `cause` to choose the appropriate debris
+  variant
+
+### Requirement: Persistent Effect State Derivable From Snapshot
+
+The current unit state projection SHALL expose enough information for
+the UI to derive persistent effects (smoke, fire) without replaying
+the event log.
+
+#### Scenario: Projection exposes destroyed locations
+
+- **GIVEN** a unit with multiple destroyed locations
+- **WHEN** the UI queries the unit projection
+- **THEN** the projection SHALL list destroyed locations explicitly
+- **AND** the UI SHALL render smoke for each without scanning events
+
+#### Scenario: Projection exposes engine crit count
+
+- **GIVEN** a unit with engine crits
+- **WHEN** the UI queries the unit projection
+- **THEN** the projection SHALL expose `engineCrits: 0 | 1 | 2 | 3`
+- **AND** the UI SHALL pick flame intensity from that count

--- a/openspec/changes/add-damage-feedback-effects/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-damage-feedback-effects/specs/tactical-map-interface/spec.md
@@ -1,0 +1,148 @@
+# tactical-map-interface Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Screen Shake On Heavy Hits
+
+The tactical map interface SHALL shake the map root when a single hit
+applies 10 or more damage, with intensity scaling with damage and
+dampened for reduced-motion users.
+
+#### Scenario: 10+ damage triggers shake
+
+- **GIVEN** a unit takes 12 damage from a single weapon hit
+- **WHEN** the shake fires
+- **THEN** the map root SHALL offset by small pseudo-random x/y within
+  the intensity radius
+- **AND** intensity SHALL scale linearly with damage, clamped at 8px
+- **AND** total duration SHALL be 300ms
+
+#### Scenario: Under 10 damage does not shake
+
+- **GIVEN** a unit takes 6 damage from a single hit
+- **WHEN** the event fires
+- **THEN** no shake SHALL occur
+
+#### Scenario: Reduced motion dampens shake
+
+- **GIVEN** `prefers-reduced-motion: reduce` is set
+- **WHEN** a 20-damage hit would trigger a large shake
+- **THEN** shake amplitude SHALL be halved
+- **AND** shakes with effective intensity below 2px SHALL be skipped
+
+### Requirement: Hit Location Flash
+
+The tactical map interface SHALL flash the specific armor-pip group of
+a hit location white for 250ms when damage applies there.
+
+#### Scenario: Flash targets hit location
+
+- **GIVEN** a unit's RA takes 5 damage
+- **WHEN** the flash renders
+- **THEN** the RA pip group SHALL flash white at 60% opacity for 250ms
+- **AND** other pip groups SHALL NOT flash
+
+#### Scenario: Transferred damage flashes destination
+
+- **GIVEN** damage overflows from LA into LT
+- **WHEN** the flashes render
+- **THEN** the LA pip group SHALL flash first
+- **AND** the LT pip group SHALL flash second (sequential)
+
+### Requirement: Smoke From Destroyed Locations
+
+The tactical map interface SHALL render a looping smoke animation near
+each destroyed location of a living unit, persisting until the unit
+becomes a wreck.
+
+#### Scenario: Destroyed arm vents smoke
+
+- **GIVEN** a unit's LA is destroyed
+- **WHEN** the effect layer renders
+- **THEN** a looping smoke sprite SHALL render near the LA pip group
+- **AND** the smoke SHALL persist across frames while the unit is alive
+
+#### Scenario: Multiple destroyed locations = multiple smoke streams
+
+- **GIVEN** a unit has both LA and RL destroyed
+- **WHEN** the effects render
+- **THEN** two concurrent smoke streams SHALL render
+- **AND** each SHALL anchor to its pip group
+
+#### Scenario: Wreck replaces live smoke streams
+
+- **GIVEN** a unit with two smoke streams is destroyed
+- **WHEN** the unit becomes a wreck
+- **THEN** both live smoke streams SHALL stop
+- **AND** a single quieter wreck-smoke stream SHALL replace them
+
+### Requirement: Engine Fire
+
+The tactical map interface SHALL render a flame animation on any unit
+with one or more engine critical hits, persisting until destruction.
+
+#### Scenario: First engine crit ignites a small flame
+
+- **GIVEN** a unit takes its first engine critical hit
+- **WHEN** the effect renders
+- **THEN** a small animated flame SHALL render at the unit's torso
+  anchor
+- **AND** the flame SHALL persist until the unit dies
+
+#### Scenario: Second engine crit intensifies flame
+
+- **GIVEN** a unit takes a second engine critical hit
+- **WHEN** the effect renders
+- **THEN** the flame SHALL scale larger and brighter
+- **AND** the flame SHALL remain a single effect (not two flames)
+
+### Requirement: Debris Cloud And Wreck Sprite
+
+On unit destruction, the tactical map interface SHALL play a debris
+cloud burst and transition the token to a wreck sprite variant.
+
+#### Scenario: Unit destroyed plays debris + wreck
+
+- **GIVEN** a unit's CT reaches 0 internal structure (unit destroyed)
+- **WHEN** the effect renders
+- **THEN** an 800ms debris cloud burst SHALL play over the token
+- **AND** the token SHALL transition to a homemade wreck sprite variant
+  for its archetype
+- **AND** the wreck SHALL render at ~50% opacity
+- **AND** the wreck SHALL remain on the hex blocking LOS per existing
+  rules
+
+#### Scenario: Pilot killed triggers destruction effect
+
+- **GIVEN** a pilot dies from consciousness failures
+- **WHEN** the UnitDestroyed event fires
+- **THEN** the same debris cloud + wreck transition SHALL play
+
+#### Scenario: Wreck badge for accessibility
+
+- **GIVEN** a unit is a wreck
+- **WHEN** the token renders
+- **THEN** a textual "WRECK" badge SHALL render on the token for
+  colorblind-safe legibility
+
+### Requirement: Persistent Effects Survive Replay
+
+Smoke and fire SHALL be derived from unit state (destroyed locations,
+engine crits) so they render correctly after a page reload or replay
+scrub.
+
+#### Scenario: Reload preserves smoke
+
+- **GIVEN** a unit has a destroyed LA emitting smoke
+- **WHEN** the page reloads and state rehydrates
+- **THEN** smoke SHALL render from LA without replaying the
+  LocationDestroyed event
+
+#### Scenario: Replay scrub derives effects from state
+
+- **GIVEN** a replay scrubs from turn 1 to turn 5 where a unit has
+  engine crits
+- **WHEN** the scrub settles
+- **THEN** engine fire SHALL render on that unit immediately
+- **AND** the effect SHALL not require replaying every intermediate
+  event

--- a/openspec/changes/add-damage-feedback-effects/tasks.md
+++ b/openspec/changes/add-damage-feedback-effects/tasks.md
@@ -1,0 +1,115 @@
+# Tasks: Add Damage Feedback Effects
+
+## 1. Screen Shake Hook
+
+- [ ] 1.1 Create `src/hooks/useScreenShake.ts`
+- [ ] 1.2 Exposes `shake(intensity, duration)` which offsets the map
+      root by pseudo-random x/y within the intensity radius
+- [ ] 1.3 Subscribes to `DamageApplied` events, fires shake when hit
+      damage >= 10
+- [ ] 1.4 Intensity scales linearly with damage, clamped at 8px
+- [ ] 1.5 Duration fixed at 300ms
+- [ ] 1.6 Reduced motion halves amplitude and skips if intensity < 2px
+
+## 2. Hit Location Flash
+
+- [ ] 2.1 Create `src/components/gameplay/effects/HitLocationFlash.tsx`
+- [ ] 2.2 On `DamageApplied`, flash the specific pip group white at
+      60% opacity for 250ms
+- [ ] 2.3 Works for both attached location (RA, LT, etc.) and
+      transferred locations
+- [ ] 2.4 Stacks with armor-pip decay already defined in
+      `add-damage-feedback-ui`
+
+## 3. Smoke Puff
+
+- [ ] 3.1 Create `src/components/gameplay/effects/SmokePuff.tsx`
+- [ ] 3.2 Renders a looping animated smoke sprite near the location's
+      pip group
+- [ ] 3.3 Activates when a location is destroyed (structure = 0 or
+      location marked destroyed)
+- [ ] 3.4 Persists until the unit dies or is removed
+- [ ] 3.5 Supports multiple concurrent smoke streams per unit (one per
+      destroyed location)
+
+## 4. Engine Fire
+
+- [ ] 4.1 Create `src/components/gameplay/effects/EngineFire.tsx`
+- [ ] 4.2 Triggered on engine critical hit events
+- [ ] 4.3 Renders a small animated flame at the unit's torso anchor
+- [ ] 4.4 Persists until the unit dies
+- [ ] 4.5 Second engine crit intensifies the flame (larger, brighter)
+
+## 5. Debris Cloud + Wreck Sprite
+
+- [ ] 5.1 Create `src/components/gameplay/effects/DebrisCloud.tsx`
+- [ ] 5.2 Triggered on `UnitDestroyed` event
+- [ ] 5.3 Plays 800ms debris burst centered on the token
+- [ ] 5.4 Token transitions to a wreck sprite variant (homemade, per
+      archetype) with ~50% opacity
+- [ ] 5.5 Wreck remains on the hex blocking LOS per existing rules
+- [ ] 5.6 Persistent smoke / fire from this unit clear when it becomes
+      a wreck (replaced by a single quieter smoke stream)
+
+## 6. Event Subscriptions
+
+- [ ] 6.1 `HitLocationFlash` subscribes to `DamageApplied`
+- [ ] 6.2 `SmokePuff` subscribes to `LocationDestroyed`
+- [ ] 6.3 `EngineFire` subscribes to `CriticalHit` events where slot =
+      ENGINE
+- [ ] 6.4 `DebrisCloud` subscribes to `UnitDestroyed`
+- [ ] 6.5 Screen shake subscribes to `DamageApplied`
+- [ ] 6.6 All subscriptions tear down on unmount
+
+## 7. Persistent Effect Layer
+
+- [ ] 7.1 Create `PersistentEffectsLayer.tsx` rendering smoke and fire
+      across every live unit with destroyed parts / engine damage
+- [ ] 7.2 Layer reads derived state (not events) so persistent effects
+      survive page reload / replay
+- [ ] 7.3 Layer sits between sprite-ring and selection ring
+
+## 8. Reduced Motion
+
+- [ ] 8.1 Screen shake halves amplitude and skips tiny shakes
+- [ ] 8.2 Smoke and fire reduce to a static icon (no animation)
+- [ ] 8.3 Debris cloud collapses to a single frame puff
+- [ ] 8.4 Hit location flash becomes an instant color change for 80ms
+
+## 9. Accessibility
+
+- [ ] 9.1 Screen shake announces via `aria-live` "heavy hit" when
+      triggered
+- [ ] 9.2 Persistent smoke / fire include `<title>` SVG elements for
+      screen readers
+- [ ] 9.3 Destroyed units render a textual "WRECK" badge on the token
+      for colorblind-safe legibility
+
+## 10. Performance
+
+- [ ] 10.1 Smoke and fire use a single shared SVG animation definition
+      referenced via `<use>`
+- [ ] 10.2 Screen shake uses CSS transform only on the map root
+      (doesn't invalidate children)
+- [ ] 10.3 Wreck sprite replaces live sprite — no double render
+- [ ] 10.4 Budget: 20 concurrent persistent effects at 60 FPS
+
+## 11. Tests
+
+- [ ] 11.1 Unit test: screen shake intensity scales with damage
+- [ ] 11.2 Unit test: hit location flash targets correct pip group
+- [ ] 11.3 Unit test: smoke activates on LocationDestroyed
+- [ ] 11.4 Unit test: engine fire activates on engine crit
+- [ ] 11.5 Unit test: debris cloud + wreck transition on UnitDestroyed
+- [ ] 11.6 Integration test: unit takes 25-damage CT hit — shake
+      triggers, pip flashes, no destruction events fire
+- [ ] 11.7 Integration test: unit destroyed — cloud plays, wreck sprite
+      appears, prior smoke streams collapse
+
+## 12. Spec Compliance
+
+- [ ] 12.1 Every requirement in `tactical-map-interface` delta has a
+      GIVEN/WHEN/THEN scenario
+- [ ] 12.2 Every requirement in `damage-system` delta has a scenario
+- [ ] 12.3 `openspec validate add-damage-feedback-effects --strict`
+      passes clean

--- a/openspec/changes/add-damage-feedback-ui/proposal.md
+++ b/openspec/changes/add-damage-feedback-ui/proposal.md
@@ -1,0 +1,44 @@
+# Change: Add Damage Feedback UI
+
+## Why
+
+Once attacks resolve and damage is applied (via `damage.ts` post-A4), the
+player needs visual confirmation that a hit landed, that armor decayed,
+that a critical hit happened, and that a pilot rolled consciousness. Right
+now events silently update the session's state; nothing flashes, nothing
+animates, nothing draws the player's eye. This change wires damage-related
+session events into visible feedback on both the map and the action panel.
+
+## What Changes
+
+- Animate the `ArmorPip` decay on the action panel when the selected unit
+  takes damage — pips fade from filled to empty with a brief red flash
+- Display a critical hit indicator (burst animation) on the affected
+  token when a critical hit resolves
+- Add per-hit entries in the event log: hit location, weapon, damage
+  amount, crit flag, transfer chain
+- Show a pilot-wound flash on the action panel's pilot wound track when a
+  consciousness roll fires (regardless of pass/fail), plus a badge if
+  the pilot becomes unconscious
+
+## Dependencies
+
+- **Requires**: `add-interactive-combat-core-ui` (action panel + event
+  log), `add-attack-phase-ui` (attacks actually get fired from the UI),
+  Lane A A4 `integrate-damage-pipeline` (damage events must flow from
+  `damage.ts`)
+- **Required By**: `add-victory-and-post-battle-summary` (victory
+  detection reads the same damage events)
+
+## Impact
+
+- Affected specs: `damage-system` (MODIFIED — emit structured
+  `DamageApplied`, `CriticalHit`, and `ConsciousnessRoll` events with
+  enough detail for UI rendering), `tactical-map-interface` (ADDED — pip
+  decay animation, crit burst overlay, pilot-wound flash)
+- Affected code: `src/components/gameplay/ArmorPip.tsx` (animated
+  decay state), new `CritHitOverlay` component on
+  `HexMapDisplay`, `EventLogDisplay` entry renderer extended for damage
+  events
+- Non-goals: full replay scrubber (Phase 2 territory), 3D wreck effects
+  (3D shelved), sound effects (out)

--- a/openspec/changes/add-damage-feedback-ui/specs/damage-system/spec.md
+++ b/openspec/changes/add-damage-feedback-ui/specs/damage-system/spec.md
@@ -1,0 +1,68 @@
+# damage-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Structured Damage Events For UI Feedback
+
+The damage system SHALL emit structured `DamageApplied`, `CriticalHit`,
+`PilotHit`, and `ConsciousnessRoll` events containing enough detail for
+the UI to render pip decay, crit bursts, log entries, and pilot wound
+flashes without additional queries.
+
+#### Scenario: DamageApplied carries location, amount, source, transfer chain
+
+- **GIVEN** a weapon attack that hits the Right Arm for 8 damage (5
+  absorbed by armor, 3 transferred to structure)
+- **WHEN** the damage pipeline resolves
+- **THEN** a `DamageApplied` event SHALL be appended containing
+  `{targetId, location: "RA", armorDamage: 5, structureDamage: 3,
+sourceWeaponId, transferChain: []}`
+
+#### Scenario: Transfer chain populated for overflow damage
+
+- **GIVEN** 15 damage applied to a destroyed Right Arm (0 armor, 0
+  structure), overflow transferring to Right Torso
+- **WHEN** the damage pipeline resolves
+- **THEN** a `DamageApplied` event SHALL be appended whose
+  `transferChain` contains `[{from: "RA", to: "RT", overflow: 15}]`
+
+#### Scenario: CriticalHit event emitted on critical resolution
+
+- **GIVEN** a `resolveCriticalHit` call that destroys a Medium Laser
+- **WHEN** the critical is applied
+- **THEN** a `CriticalHit` event SHALL be appended with
+  `{targetId, location, slotIndex, equipmentId, effect: "destroyed"}`
+
+#### Scenario: ConsciousnessRoll event emitted whenever a roll fires
+
+- **GIVEN** a pilot with 1 hit receives a second pilot hit that triggers
+  a consciousness check
+- **WHEN** the check runs
+- **THEN** a `ConsciousnessRoll` event SHALL be appended with
+  `{pilotId, wounds, targetNumber, roll, passed}`
+- **AND** if `passed = false`, a `PilotHit` event SHALL follow with
+  `{pilotId, consciousnessState: "unconscious"}`
+
+### Requirement: Damage Event Ordering and Batching
+
+The damage system SHALL emit damage events in canonical order so the UI
+can animate them sequentially: armor decay → structure damage → transfer
+→ critical → pilot hit → consciousness roll.
+
+#### Scenario: Events ordered within one attack resolution
+
+- **GIVEN** an attack that damages armor, transfers into structure,
+  triggers a crit, and causes a pilot hit via head damage
+- **WHEN** the attack resolves
+- **THEN** events SHALL be appended in the order `DamageApplied`
+  (armor portion), `DamageApplied` (structure portion), `CriticalHit`,
+  `PilotHit`, `ConsciousnessRoll`
+- **AND** each event's `sequence` SHALL be strictly increasing
+
+#### Scenario: Cluster attacks batched under parent declaration
+
+- **GIVEN** a cluster weapon that produces 4 hits
+- **WHEN** each hit resolves
+- **THEN** each `DamageApplied` event SHALL reference the same
+  `parentDeclarationId`
+- **AND** the UI SHALL use that id to group entries in the event log

--- a/openspec/changes/add-damage-feedback-ui/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-damage-feedback-ui/specs/tactical-map-interface/spec.md
@@ -1,0 +1,121 @@
+# tactical-map-interface Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Armor Pip Decay Animation
+
+The tactical map interface SHALL animate the transition of armor pips on
+the action panel from filled to empty when a `DamageApplied` event lands,
+giving the player a visible pulse per hit.
+
+**Priority**: High
+
+#### Scenario: Pip flashes then clears on damage
+
+- **GIVEN** the action panel is showing unit A with 5 armor pips at RA
+- **WHEN** a `DamageApplied` event reports 3 armor damage to RA
+- **THEN** three rightmost filled pips SHALL flash red at 60% opacity
+  for 400ms
+- **AND** after the flash the three pips SHALL render empty
+- **AND** the 2 remaining pips SHALL stay filled
+
+#### Scenario: Armor then structure animate sequentially
+
+- **GIVEN** 8 damage applied to RA (5 armor, 3 structure)
+- **WHEN** the animation runs
+- **THEN** armor pips SHALL animate first
+- **AND** structure pips SHALL begin animating when the armor animation
+  completes
+- **AND** total animation time SHALL not exceed 900ms
+
+#### Scenario: Unselected unit's damage does not animate
+
+- **GIVEN** unit B takes damage but the action panel shows unit A
+- **WHEN** the `DamageApplied` event fires
+- **THEN** the action panel SHALL NOT animate
+- **AND** switching selection to unit B after the event SHALL show the
+  post-damage state without replaying the animation
+
+### Requirement: Critical Hit Burst Overlay
+
+The tactical map interface SHALL render a short burst animation over a
+unit's token when a `CriticalHit` event fires, and the overlay SHALL
+auto-dismiss without blocking map interactions.
+
+**Priority**: High
+
+#### Scenario: Crit burst animates over token
+
+- **GIVEN** a `CriticalHit` event for unit-42
+- **WHEN** the overlay renders
+- **THEN** a burst animation SHALL play centered on unit-42's token for
+  ~600ms
+- **AND** the overlay SHALL dismiss automatically
+
+#### Scenario: Crit overlay does not intercept clicks
+
+- **GIVEN** the crit burst is visible over a token
+- **WHEN** the user clicks on that token
+- **THEN** the token click SHALL still register (overlay is
+  pointer-events: none)
+
+#### Scenario: Simultaneous crits queue
+
+- **GIVEN** two `CriticalHit` events fire in the same frame for the
+  same unit
+- **WHEN** the overlays render
+- **THEN** the second burst SHALL start after the first completes
+- **AND** no more than one burst SHALL be on-screen at a time per unit
+
+### Requirement: Damage Number Floater
+
+The tactical map interface SHALL render a floating red damage number
+above each token that takes damage, visualizing the magnitude of hits.
+
+**Priority**: Medium
+
+#### Scenario: Floater appears on damage
+
+- **GIVEN** unit-42 takes 10 damage from a weapon hit
+- **WHEN** the floater renders
+- **THEN** a red number `"10"` SHALL appear above the token
+- **AND** the number SHALL rise upward ~40 pixels over 800ms while
+  fading to transparent
+
+#### Scenario: Multiple hits stack vertically
+
+- **GIVEN** a cluster attack that lands 3 hits for 2 damage each
+- **WHEN** the floaters render
+- **THEN** three floaters SHALL render with 50ms stagger
+- **AND** each floater SHALL rise independently
+
+### Requirement: Pilot Wound Flash
+
+The tactical map interface SHALL visually emphasize pilot consciousness
+rolls on the action panel's pilot wound track, so the player sees when a
+roll fires and how it resolved.
+
+**Priority**: High
+
+#### Scenario: Consciousness roll pulses yellow
+
+- **GIVEN** a `ConsciousnessRoll` event fires for the selected unit's
+  pilot
+- **WHEN** the wound track renders
+- **THEN** the track SHALL pulse yellow for 500ms
+
+#### Scenario: Failed roll shows Unconscious badge
+
+- **GIVEN** a `ConsciousnessRoll` event with `passed = false`
+- **WHEN** the wound track renders post-pulse
+- **THEN** a persistent red "Unconscious" badge SHALL appear across the
+  track
+- **AND** the badge SHALL stay until pilot state changes back to
+  conscious
+
+#### Scenario: Passed roll leaves no badge
+
+- **GIVEN** a `ConsciousnessRoll` event with `passed = true`
+- **WHEN** the wound track renders post-pulse
+- **THEN** the yellow pulse SHALL fade
+- **AND** no badge SHALL appear

--- a/openspec/changes/add-damage-feedback-ui/tasks.md
+++ b/openspec/changes/add-damage-feedback-ui/tasks.md
@@ -31,7 +31,7 @@
 
 - [ ] 4.1 Extend `EventLogDisplay` renderer to handle `DamageApplied`
 - [ ] 4.2 Entry reads: `"<Target> took <N> damage to <Location> from
-    <Weapon>"`
+<Weapon>"`
 - [ ] 4.3 Entries with transfer chains render each step indented
       (`→ overflow to LT`, `→ structure breach`)
 - [ ] 4.4 Critical hit entries render with a distinct orange accent bar

--- a/openspec/changes/add-damage-feedback-ui/tasks.md
+++ b/openspec/changes/add-damage-feedback-ui/tasks.md
@@ -1,0 +1,87 @@
+# Tasks: Add Damage Feedback UI
+
+## 1. Event Subscription
+
+- [ ] 1.1 Action panel subscribes to `DamageApplied`, `CriticalHit`,
+      `ConsciousnessRoll`, `PilotHit` events for the selected unit
+- [ ] 1.2 Map subscribes to the same events for any unit with a token
+- [ ] 1.3 Subscriptions tear down on selection change
+
+## 2. Armor Pip Decay Animation
+
+- [ ] 2.1 Extend `ArmorPip` with a `justDamaged` prop
+- [ ] 2.2 On `DamageApplied` for a location, pips for that location set
+      `justDamaged = true` for 400ms
+- [ ] 2.3 During that window, pip flashes red at 60% opacity then fades
+      to empty
+- [ ] 2.4 Armor-to-structure transfers animate in sequence (armor pip
+      drains first, then structure pip flashes)
+
+## 3. Critical Hit Overlay
+
+- [ ] 3.1 New `CritHitOverlay` component positioned over the affected
+      unit's token
+- [ ] 3.2 On `CriticalHit`, overlay plays a burst animation lasting
+      ~600ms
+- [ ] 3.3 Overlay dismisses automatically; no click-through blocking the
+      map
+- [ ] 3.4 Concurrent crits on the same token queue, not stack
+
+## 4. Event Log — Damage Entries
+
+- [ ] 4.1 Extend `EventLogDisplay` renderer to handle `DamageApplied`
+- [ ] 4.2 Entry reads: `"<Target> took <N> damage to <Location> from
+    <Weapon>"`
+- [ ] 4.3 Entries with transfer chains render each step indented
+      (`→ overflow to LT`, `→ structure breach`)
+- [ ] 4.4 Critical hit entries render with a distinct orange accent bar
+
+## 5. Pilot Wound Flash
+
+- [ ] 5.1 Pilot wound track on action panel subscribes to
+      `ConsciousnessRoll` events for the selected pilot
+- [ ] 5.2 On roll, the track pulses yellow briefly (roll happening)
+- [ ] 5.3 If roll fails, a red "Unconscious" badge appears and persists
+- [ ] 5.4 If pilot consciousness state changes without a roll, the
+      badge still reconciles with state
+
+## 6. Head Hit Emphasis
+
+- [ ] 6.1 Head hits render with an extra warning icon in the event log
+- [ ] 6.2 Pilot damage from head hits renders `"Pilot takes 1 hit"` in
+      the log
+- [ ] 6.3 Killing head hit renders `"Pilot killed"` in red
+
+## 7. Multi-Hit Batching
+
+- [ ] 7.1 Multiple `DamageApplied` events from one weapon's cluster roll
+      animate sequentially with a 50ms stagger
+- [ ] 7.2 Event log groups them under a parent entry for the attack
+- [ ] 7.3 Animation queue drains without dropping events
+
+## 8. Damage Number Floater
+
+- [ ] 8.1 On `DamageApplied`, a red floating number rises above the hit
+      token for ~800ms
+- [ ] 8.2 Number shows the damage amount
+- [ ] 8.3 Floater does not block map interactions; it's a pure overlay
+
+## 9. Tests
+
+- [ ] 9.1 Unit test: `ArmorPip` flashes red when `justDamaged` flips to
+      true
+- [ ] 9.2 Unit test: crit overlay dismisses automatically after 600ms
+- [ ] 9.3 Integration test: a resolved attack that does 10 damage +
+      triggers a crit produces a pip decay, a crit burst, and two log
+      entries
+- [ ] 9.4 Integration test: pilot consciousness roll triggers yellow
+      pulse; failure triggers red badge
+
+## 10. Spec Compliance
+
+- [ ] 10.1 Every requirement in `damage-system` delta has at least one
+      GIVEN/WHEN/THEN scenario
+- [ ] 10.2 Every requirement in `tactical-map-interface` delta has at
+      least one scenario
+- [ ] 10.3 `openspec validate add-damage-feedback-ui --strict` passes
+      clean

--- a/openspec/changes/add-fog-of-war-event-filtering/proposal.md
+++ b/openspec/changes/add-fog-of-war-event-filtering/proposal.md
@@ -1,0 +1,68 @@
+# Change: Add Fog of War Event Filtering
+
+## Why
+
+**Sub-phase 4c.** Open-information play (both sides see everything) is
+the easy default, but competitive multiplayer and double-blind scenario
+play require each client to receive only what their own units can
+perceive. BattleTech has canonical double-blind rules — units outside
+sensor range / line-of-sight are hidden until detected. Because the
+server already arbitrates every event in 4b, fog-of-war is a natural
+extension: per-event, per-player visibility filtering in the broadcast
+path. This change defines the visibility model, the filter rules, and
+the minimal event schema so the server can redact or omit events that
+a given player must not see.
+
+## What Changes
+
+- Introduce `fog-of-war` spec describing visibility rules:
+  per-player LOS (line-of-sight) + sensor range per unit, derived from
+  the existing `spatial-combat-system`
+- Visibility evaluated once per event: for each connected client, the
+  server computes `isVisible(event, player)` and redacts the payload
+  (or skips the broadcast entirely) for hidden events
+- Four visibility classes per event:
+  - `public` — everyone sees (`PhaseChanged`, `GameEnded`, `match_
+paused`, initiative-phase announcements without unit detail)
+  - `actor-only` — only the controlling player sees (`MovementDeclared`
+    by an enemy before it resolves visibly)
+  - `observer-visible` — visible if any of the player's units has LOS
+    to the target or the actor (`MovementLocked`, `AttackResolved`
+    when target or shooter is in LOS)
+  - `target-visible` — visible to the player who owns the target even
+    when the shooter is not in LOS (damage taken is always known to
+    the recipient; the shooter's identity may be redacted)
+- Server emits a filtered event stream per client; each client sees a
+  coherent narrative for their own side
+- Fog-of-war is opt-in per match; `config.fogOfWar: boolean` defaults
+  to `false` for backwards compatibility
+- Existing sync flow still works without fog — the filter is a no-op
+  when disabled
+
+## Dependencies
+
+- **Requires**: `add-multiplayer-server-infrastructure` (server +
+  per-client broadcast), `add-authoritative-roll-arbitration` (rolls
+  must be embedded so the client can render the visible portion of an
+  event), `add-multiplayer-lobby-and-matchmaking-2-8` (side
+  assignments), existing `spatial-combat-system` (LOS + range math)
+- **Required By**: future advanced-scenarios changes (hidden units,
+  recon scenarios, electronic warfare) and Phase 7 presentation
+  polish
+
+## Impact
+
+- Affected specs: `fog-of-war` (ADDED — visibility model, event
+  classes, filter contract), `multiplayer-server` (MODIFIED — per-
+  client broadcast with visibility filter), `multiplayer-sync`
+  (MODIFIED — redacted event shape), `spatial-combat-system`
+  (MODIFIED — exposes `canPlayerSeeUnit(playerId, unitId, state)` as
+  a shared helper)
+- Affected code: new `src/server/multiplayer/fogOfWar.ts`, extension
+  of `ServerMatchHost` broadcast to run the filter per connected
+  client, extension of events with a `visibility` class discriminator,
+  extension of `spatial-combat-system`'s line-of-sight helpers with a
+  per-player aggregate `canPlayerSeeUnit`
+- Non-goals: ECM / ECCM modelling beyond what `ecm-electronic-warfare`
+  already defines, sensor-type nuances (active vs passive), stealth
+  armor interactions (reuse existing rules), spectator fog

--- a/openspec/changes/add-fog-of-war-event-filtering/specs/fog-of-war/spec.md
+++ b/openspec/changes/add-fog-of-war-event-filtering/specs/fog-of-war/spec.md
@@ -1,0 +1,151 @@
+# fog-of-war Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Visibility Model
+
+The system SHALL determine per-player visibility of units using line-of-
+sight and sensor range computed over the current `IGameState`.
+
+#### Scenario: Own unit always visible
+
+- **GIVEN** a player owns unit `U`
+- **WHEN** visibility is evaluated
+- **THEN** `canPlayerSeeUnit(playerId, U, state)` SHALL return `true`
+- **AND** this SHALL hold even if `U` is prone, shut down, or
+  destroyed
+
+#### Scenario: LOS from any owned unit grants visibility
+
+- **GIVEN** a player owns units `U1` and `U2`, and an enemy unit `E`
+- **AND** only `U2` has clear LOS to `E`
+- **WHEN** visibility is evaluated
+- **THEN** `canPlayerSeeUnit(playerId, E, state)` SHALL return `true`
+
+#### Scenario: Blocked LOS hides enemy
+
+- **GIVEN** a player's only unit `U1` has LOS to an enemy `E` blocked
+  by heavy woods beyond elevation rules
+- **WHEN** visibility is evaluated
+- **THEN** `canPlayerSeeUnit(playerId, E, state)` SHALL return `false`
+
+#### Scenario: Sensor range boundary
+
+- **GIVEN** a player's unit `U1` with sensor range 10 hexes and an
+  enemy `E` at range 11
+- **WHEN** visibility is evaluated
+- **THEN** `canPlayerSeeUnit(playerId, E, state)` SHALL return `false`
+
+### Requirement: Event Visibility Classes
+
+The system SHALL classify every event type into one of four visibility
+classes: `public`, `actor-only`, `observer-visible`, `target-visible`.
+
+#### Scenario: Public events reach everyone
+
+- **GIVEN** a `PhaseChanged` event
+- **WHEN** the filter is applied for any player
+- **THEN** the event SHALL be delivered unchanged
+
+#### Scenario: Actor-only events reach only the actor
+
+- **GIVEN** a `MovementDeclared` event authored by a unit owned by
+  `playerA`
+- **WHEN** the filter is applied for `playerB`
+- **THEN** the event SHALL NOT be delivered to `playerB`
+- **AND** the event SHALL be delivered to `playerA`
+
+#### Scenario: Observer-visible delivered when LOS exists
+
+- **GIVEN** a `MovementLocked` event for a unit `U`
+- **WHEN** the filter is applied for `playerB`
+- **THEN** delivery SHALL be contingent on
+  `canPlayerSeeUnit(playerB, U, state)`
+- **AND** the owner of `U` SHALL always receive it
+
+#### Scenario: Target-visible always reaches target
+
+- **GIVEN** an `AttackResolved` event targeting unit `T` owned by
+  `playerT`
+- **WHEN** `playerT` cannot see the attacker
+- **THEN** `playerT` SHALL still receive a filtered form of the event
+  with `attackerId` redacted
+
+### Requirement: Event Redaction Rules
+
+The system SHALL apply specific redaction rules for partially visible
+events, preserving the recipient's ability to render the parts they
+legitimately know.
+
+#### Scenario: Hidden attacker redacted from target
+
+- **GIVEN** `AttackResolved` where the target cannot see the shooter
+- **WHEN** the filter runs for the target's player
+- **THEN** the delivered event SHALL contain `targetId`, `damage`,
+  `hitLocation`, `rolls`
+- **AND** the delivered event SHALL NOT contain `attackerId` or
+  any attacker weapon/location identifiers
+
+#### Scenario: Out-of-LOS destruction omits details
+
+- **GIVEN** `UnitDestroyed` for an enemy unit the observer cannot see
+- **WHEN** the filter runs for the observer
+- **THEN** the event SHALL be delivered in a reduced form with
+  `{type: 'unit_destroyed', payload: {unitId}}`
+- **AND** no damage, crit, or pilot detail SHALL be included
+
+#### Scenario: Out-of-LOS movement skipped
+
+- **GIVEN** `MovementLocked` for a unit not in the observer's LOS
+- **WHEN** the filter runs for the observer
+- **THEN** the event SHALL NOT be delivered
+- **AND** the observer SHALL NOT learn the unit's new coordinate
+
+### Requirement: Fog Mode Opt-In Per Match
+
+The system SHALL treat fog-of-war as an opt-in match configuration
+that defaults to off, and SHALL forbid mid-match toggling.
+
+#### Scenario: Default is open information
+
+- **GIVEN** a match created without `config.fogOfWar`
+- **WHEN** the default is evaluated
+- **THEN** `config.fogOfWar` SHALL be `false`
+- **AND** the filter SHALL behave as a no-op
+
+#### Scenario: Fog-on honored throughout match
+
+- **GIVEN** a match created with `config.fogOfWar: true`
+- **WHEN** events are broadcast
+- **THEN** the per-player filter SHALL be applied for every event
+- **AND** the fog setting SHALL NOT be mutable after match launch
+
+#### Scenario: Host cannot toggle fog mid-match
+
+- **GIVEN** an active match
+- **WHEN** the host sends `Intent {kind: 'SetFog', value: true}`
+- **THEN** the server SHALL respond `Error {code: 'CANNOT_TOGGLE_
+MID_MATCH'}`
+
+### Requirement: Replay Reflects Fog History
+
+The system SHALL apply fog filtering to replay streams so a
+reconnecting client sees the same history they would have seen live,
+never more.
+
+#### Scenario: Reconnect replay is filtered
+
+- **GIVEN** a reconnecting client in a fog-on match
+- **WHEN** the server streams the replay
+- **THEN** every event in the replay SHALL pass through
+  `filterEventForPlayer` before being sent
+- **AND** the client's visible history SHALL be consistent with what
+  was visible at the time the event was originally broadcast
+
+#### Scenario: Post-match unfiltered log privileged
+
+- **GIVEN** a match has ended
+- **WHEN** a non-privileged player requests the log
+- **THEN** the server SHALL serve the filtered log for that player
+- **AND** the unfiltered log SHALL require privileged access (not
+  addressed by this change)

--- a/openspec/changes/add-fog-of-war-event-filtering/specs/multiplayer-server/spec.md
+++ b/openspec/changes/add-fog-of-war-event-filtering/specs/multiplayer-server/spec.md
@@ -1,0 +1,68 @@
+# multiplayer-server Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Per-Client Broadcast With Visibility Filter
+
+The server SHALL broadcast events to connected clients on a per-client
+basis when a match has fog-of-war enabled, applying the visibility
+filter to each event for each destination player.
+
+#### Scenario: Filter runs per connected client
+
+- **GIVEN** a fog-on match with 4 connected clients belonging to
+  different sides
+- **WHEN** the server broadcasts an event
+- **THEN** the server SHALL run `filterEventForPlayer` once per
+  connected client
+- **AND** SHALL send the (possibly redacted) result only if the
+  filter returned a non-null value
+
+#### Scenario: Filter is bypassed when fog disabled
+
+- **GIVEN** a match with `config.fogOfWar: false`
+- **WHEN** the server broadcasts an event
+- **THEN** the server SHALL send the identical event to every
+  connected client
+- **AND** SHALL NOT invoke the visibility filter
+
+#### Scenario: Spec visibility of deterministic events
+
+- **GIVEN** a `PhaseChanged` event in a fog-on match
+- **WHEN** the server broadcasts it
+- **THEN** every connected client SHALL receive the event in full
+- **AND** the filter SHALL not redact any fields
+
+### Requirement: Visibility Tied to Authoritative State
+
+The server SHALL evaluate visibility using its authoritative
+`IGameState`, NOT any client-provided state, so fog decisions cannot
+be gamed by a malicious client reporting false LOS.
+
+#### Scenario: Authoritative state consulted
+
+- **GIVEN** a fog-on match
+- **WHEN** the visibility filter runs
+- **THEN** the `state` argument passed to `canPlayerSeeUnit` SHALL be
+  the server's `currentState`
+- **AND** no client-reported value SHALL factor into visibility
+
+### Requirement: Broadcast Performance Under Fog
+
+The server SHALL meet a broadcast budget of at most 5ms per event on
+an 8-player match when fog is enabled, achieved through per-turn LOS
+caching and invalidation on movement.
+
+#### Scenario: LOS cache invalidation on movement
+
+- **GIVEN** a unit's position changes via `MovementLocked`
+- **WHEN** the visibility filter runs for the next event
+- **THEN** any cached LOS result involving the moved unit SHALL be
+  invalidated and re-computed
+
+#### Scenario: Repeated LOS queries hit cache
+
+- **GIVEN** two events in the same phase and no unit has moved
+- **WHEN** the filter evaluates visibility for the same
+  `(playerId, unitId)` pair on both events
+- **THEN** the second evaluation SHALL reuse the cached result

--- a/openspec/changes/add-fog-of-war-event-filtering/specs/multiplayer-sync/spec.md
+++ b/openspec/changes/add-fog-of-war-event-filtering/specs/multiplayer-sync/spec.md
@@ -1,0 +1,50 @@
+# multiplayer-sync Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Redacted Event Shape
+
+The system SHALL support a redacted variant of any event so that
+partially-visible events can be transmitted without leaking hidden
+fields to the recipient.
+
+#### Scenario: Attack event redacts attacker
+
+- **GIVEN** an `AttackResolved` event whose full payload includes
+  `{attackerId, targetId, damage, hitLocation, rolls, weapon}`
+- **WHEN** the event is redacted for a target who cannot see the
+  attacker
+- **THEN** the redacted form SHALL contain `{targetId, damage,
+hitLocation, rolls}`
+- **AND** the redacted form SHALL omit `attackerId` and `weapon`
+
+#### Scenario: Destruction event redaction
+
+- **GIVEN** a full `UnitDestroyed` event payload with cause, last
+  damage event, crit history
+- **WHEN** the event is redacted for an observer who cannot see the
+  destroyed enemy
+- **THEN** the redacted form SHALL contain only `{unitId}`
+
+### Requirement: Client Gracefully Handles Missing Events
+
+Clients SHALL gracefully handle the absence of events they would see
+in an open-information match, without crashing or producing
+inconsistent UI state.
+
+#### Scenario: Enemy disappears from map
+
+- **GIVEN** a fog-on match and an enemy unit that moves out of LOS
+- **WHEN** the observing client stops receiving that enemy's events
+- **THEN** the enemy token SHALL be displayed at its last-known
+  position with a `"last seen"` indicator
+- **AND** the client SHALL NOT crash attempting to animate an event
+  it never received
+
+#### Scenario: Enemy reappears with new known position
+
+- **GIVEN** an enemy previously hidden that re-enters LOS
+- **WHEN** the first visible event referencing that unit arrives
+- **THEN** the enemy token SHALL jump to the newly revealed position
+  without intermediate animation frames
+- **AND** the UI MAY show a brief `"spotted!"` indicator

--- a/openspec/changes/add-fog-of-war-event-filtering/specs/spatial-combat-system/spec.md
+++ b/openspec/changes/add-fog-of-war-event-filtering/specs/spatial-combat-system/spec.md
@@ -1,0 +1,65 @@
+# spatial-combat-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Per-Player Visibility Helper
+
+The spatial combat system SHALL expose a helper that determines whether
+any unit owned by a player can see a given target unit, enabling the
+fog-of-war filter to run in O(own-units) per query.
+
+#### Scenario: Helper signature
+
+- **GIVEN** the spatial combat module's public API
+- **WHEN** inspected
+- **THEN** it SHALL export `canPlayerSeeUnit(playerId: string,
+unitId: string, state: IGameState): boolean`
+- **AND** it SHALL export `visibleUnitsForPlayer(playerId: string,
+state: IGameState): string[]`
+
+#### Scenario: Returns true for own units
+
+- **GIVEN** `playerId = 'pid_a'` and a unit `U` owned by `pid_a`
+- **WHEN** `canPlayerSeeUnit('pid_a', U.id, state)` is called
+- **THEN** the result SHALL be `true`
+- **AND** no LOS computation SHALL be performed
+
+#### Scenario: Returns true when any owned unit has LOS
+
+- **GIVEN** three units owned by `pid_a` and one enemy unit `E`
+- **AND** exactly one of the owned units has clear LOS to `E`
+- **WHEN** `canPlayerSeeUnit('pid_a', E.id, state)` is called
+- **THEN** the result SHALL be `true`
+
+#### Scenario: Returns false when no owned unit can see
+
+- **GIVEN** all units owned by `pid_a` have LOS to `E` blocked or `E`
+  is outside every owned unit's sensor range
+- **WHEN** `canPlayerSeeUnit('pid_a', E.id, state)` is called
+- **THEN** the result SHALL be `false`
+
+### Requirement: Visible Units Aggregate Helper
+
+The system SHALL provide a per-player aggregate that lists every unit
+the player can currently see, for UI rendering and broadcast
+optimization.
+
+#### Scenario: Aggregate includes own units
+
+- **GIVEN** a player owns 3 units
+- **WHEN** `visibleUnitsForPlayer(playerId, state)` is called
+- **THEN** the result SHALL include all 3 owned unit ids
+
+#### Scenario: Aggregate includes seen enemies
+
+- **GIVEN** a player owns 3 units and can see 2 enemies
+- **WHEN** the helper is called
+- **THEN** the result SHALL contain exactly 5 ids (3 own + 2 seen)
+
+#### Scenario: Aggregate sorted and unique
+
+- **GIVEN** any state
+- **WHEN** the helper returns its result
+- **THEN** ids SHALL be unique
+- **AND** ids SHALL be sorted lexicographically so the output is
+  deterministic for cache hashing

--- a/openspec/changes/add-fog-of-war-event-filtering/tasks.md
+++ b/openspec/changes/add-fog-of-war-event-filtering/tasks.md
@@ -1,0 +1,115 @@
+# Tasks: Add Fog of War Event Filtering
+
+## 1. Visibility Model
+
+- [ ] 1.1 Define `canPlayerSeeUnit(playerId, unitId, state): boolean`
+      in `spatial-combat-system` as a shared helper
+- [ ] 1.2 Implementation: true if any unit owned by `playerId` has LOS
+      to `unitId` within its sensor range, OR the target is itself
+      owned by `playerId`
+- [ ] 1.3 Add convenience `visibleUnitsForPlayer(playerId, state):
+    UnitId[]` that returns the set
+- [ ] 1.4 Unit tests covering: adjacent LOS, LOS blocked by terrain,
+      sensor range boundary, own units always visible
+
+## 2. Event Visibility Classification
+
+- [ ] 2.1 Add `visibility` tag on every event type; values `'public' |
+    'actor-only' | 'observer-visible' | 'target-visible'`
+- [ ] 2.2 Classify existing event types: - `GameCreated`, `PhaseChanged`, `TurnAdvanced`, `GameEnded`,
+      `match_paused`, `match_resumed` → `'public'` - `MovementDeclared` → `'actor-only'` (pre-commit) - `MovementLocked`, `FacingChanged` → `'observer-visible'` - `AttackDeclared` → `'actor-only'` - `AttackResolved`, `DamageApplied` → split:
+      `'target-visible'` (target always knows they got hit) plus
+      `'observer-visible'` for the full detail - `HeatGenerated`, `HeatDissipated` → `'observer-visible'` - `PilotHit`, `UnitDestroyed` → `'observer-visible'` - `InitiativeRolled` → `'public'` (initiative result itself);
+      the dice roll payload SHALL be visible to all
+
+## 3. Server-Side Filter
+
+- [ ] 3.1 Add `fogOfWar.ts` with `filterEventForPlayer(event,
+    playerId, state): IGameEvent | null`
+- [ ] 3.2 Returns `null` if the event must not be sent to this player
+- [ ] 3.3 Returns a potentially redacted copy if partial visibility
+      applies (e.g., target knows a hit was taken but not the shooter
+      when the shooter is not in LOS)
+- [ ] 3.4 The filter is a no-op (returns original) when
+      `config.fogOfWar === false`
+
+## 4. Broadcast Integration
+
+- [ ] 4.1 `ServerMatchHost.broadcastEvent` in fog mode runs
+      `filterEventForPlayer` per connected client
+- [ ] 4.2 Non-public events are sent only to clients the filter
+      approves
+- [ ] 4.3 A player's own socket always receives events authored by
+      their units (actor-visible events)
+
+## 5. Redaction Rules
+
+- [ ] 5.1 `AttackResolved` when shooter is not visible to target
+      owner: redact `attackerId`, keep `targetId`, `damage`,
+      `hitLocation`, `rolls` for target's own damage display
+- [ ] 5.2 `MovementLocked` when the moving unit is not in the
+      observer's LOS: skip the event entirely
+- [ ] 5.3 `HeatGenerated` for an enemy unit outside LOS: skip entirely
+- [ ] 5.4 `UnitDestroyed` for an enemy unit outside LOS: send a
+      reduced form `{type: 'unit_destroyed', payload: {unitId}}`
+      without damage/crit detail
+
+## 6. Fog-Enable Configuration
+
+- [ ] 6.1 `IMatchMeta.config.fogOfWar: boolean` defaults to `false`
+- [ ] 6.2 Host sets fog on at match creation; cannot be toggled mid-
+      match
+- [ ] 6.3 Lobby UI surfaces a `"Double-blind (fog of war)"` checkbox
+
+## 7. Client Rendering With Fog
+
+- [ ] 7.1 Client UI detects fog mode from `IMatchMeta` and gracefully
+      handles missing events (enemy unit disappears from map when it
+      leaves LOS)
+- [ ] 7.2 Enemy units render with `"?"` designations when hidden
+- [ ] 7.3 Known-but-not-visible units show last-known position grayed
+      out
+- [ ] 7.4 Radar / sensor ring visual indicator for each owned unit
+
+## 8. Replay Handling
+
+- [ ] 8.1 On reconnect, the filter is applied to the replay stream so
+      the replay matches what the client would have seen live
+- [ ] 8.2 Post-match spectator / admin mode MAY view the un-filtered
+      log (separate privileged endpoint, not in this change)
+
+## 9. Sanity Tests
+
+- [ ] 9.1 Unit tests: three units on a map with terrain between enemy
+      pairs, verify `canPlayerSeeUnit` returns correct values
+- [ ] 9.2 Integration test: Player A moves out of LOS; Player B stops
+      receiving A's events until A re-enters LOS
+- [ ] 9.3 Integration test: A attacks B from ambush (outside B's LOS)
+      — B receives a redacted `AttackResolved` without `attackerId`;
+      A receives full event
+- [ ] 9.4 Integration test: fog disabled → filter is a no-op; both
+      clients see identical event streams
+- [ ] 9.5 Reconnect test: fog-on match, reconnect mid-game; replay is
+      filtered
+
+## 10. Performance
+
+- [ ] 10.1 LOS checks are cached per-turn per-(observer, target)
+      pair; invalidated on movement events
+- [ ] 10.2 `canPlayerSeeUnit` target: sub-millisecond per check on
+      8-player, 32-unit maps
+- [ ] 10.3 A smoke benchmark in the test suite ensures performance
+      does not regress past a 5ms-per-event broadcast budget
+
+## 11. Spec Compliance
+
+- [ ] 11.1 Every requirement in the `fog-of-war` ADDED delta has at
+      least one GIVEN/WHEN/THEN scenario
+- [ ] 11.2 Every requirement in the `multiplayer-server` delta has at
+      least one GIVEN/WHEN/THEN scenario
+- [ ] 11.3 Every requirement in the `multiplayer-sync` delta has at
+      least one GIVEN/WHEN/THEN scenario
+- [ ] 11.4 Every requirement in the `spatial-combat-system` delta has
+      at least one GIVEN/WHEN/THEN scenario
+- [ ] 11.5 `openspec validate add-fog-of-war-event-filtering --strict`
+      passes clean

--- a/openspec/changes/add-fog-of-war-event-filtering/tasks.md
+++ b/openspec/changes/add-fog-of-war-event-filtering/tasks.md
@@ -8,14 +8,14 @@
       to `unitId` within its sensor range, OR the target is itself
       owned by `playerId`
 - [ ] 1.3 Add convenience `visibleUnitsForPlayer(playerId, state):
-    UnitId[]` that returns the set
+UnitId[]` that returns the set
 - [ ] 1.4 Unit tests covering: adjacent LOS, LOS blocked by terrain,
       sensor range boundary, own units always visible
 
 ## 2. Event Visibility Classification
 
 - [ ] 2.1 Add `visibility` tag on every event type; values `'public' |
-    'actor-only' | 'observer-visible' | 'target-visible'`
+'actor-only' | 'observer-visible' | 'target-visible'`
 - [ ] 2.2 Classify existing event types: - `GameCreated`, `PhaseChanged`, `TurnAdvanced`, `GameEnded`,
       `match_paused`, `match_resumed` → `'public'` - `MovementDeclared` → `'actor-only'` (pre-commit) - `MovementLocked`, `FacingChanged` → `'observer-visible'` - `AttackDeclared` → `'actor-only'` - `AttackResolved`, `DamageApplied` → split:
       `'target-visible'` (target always knows they got hit) plus
@@ -25,7 +25,7 @@
 ## 3. Server-Side Filter
 
 - [ ] 3.1 Add `fogOfWar.ts` with `filterEventForPlayer(event,
-    playerId, state): IGameEvent | null`
+playerId, state): IGameEvent | null`
 - [ ] 3.2 Returns `null` if the event must not be sent to this player
 - [ ] 3.3 Returns a potentially redacted copy if partial visibility
       applies (e.g., target knows a hit was taken but not the shooter

--- a/openspec/changes/add-game-session-invite-and-lobby-1v1/proposal.md
+++ b/openspec/changes/add-game-session-invite-and-lobby-1v1/proposal.md
@@ -1,0 +1,50 @@
+# Change: Add Game Session Invite and Lobby (1v1)
+
+## Why
+
+**Sub-phase 4a.** `add-p2p-game-session-sync` delivers the wire
+protocol, but players also need a way to meet in a room, pick their
+mechs + pilots, agree on map config, and launch together. The existing
+sync-room UI already handles room codes for vault sharing; Phase 4a
+reuses that flow and extends it with a pre-battle lobby panel where the
+host and guest assemble a match before the first event is appended. No
+lobby UI means no usable P2P demo, even though the transport works.
+
+## What Changes
+
+- Add a lobby view at `/gameplay/lobby/[roomCode]` that the host lands
+  on after creating a "Networked 1v1" match
+- Add a lobby join flow: guest enters a room code, sees the lobby, gets
+  assigned to the open side
+- Both peers pick their side's mechs + pilots from their own vault; the
+  picks are shared over the Yjs room as lobby state (Y.Map), so both
+  peers see the same loadout
+- Host picks map radius, terrain preset, and turn limit; those are
+  likewise shared
+- "Ready" flags: each peer toggles ready; when both are ready, the host
+  launches the match and the session is created with both loadouts
+  deployed per side
+- Pre-battle deployment zone selection is deferred to the MVP's existing
+  Phase 1 `add-skirmish-setup-ui` rules (fixed zones per side)
+
+## Dependencies
+
+- **Requires**: `add-p2p-game-session-sync` (provides peer channel),
+  existing `p2p-sync-system` (room codes + Yjs), existing
+  `add-skirmish-setup-ui` (Phase 1 single-player setup is the fallback
+  template)
+- **Required By**: `add-game-session-persistence-for-reconnect`
+  (reconnect re-enters at the lobby or active match depending on state),
+  `add-multiplayer-lobby-and-matchmaking-2-8` (4b generalizes to 2–8)
+
+## Impact
+
+- Affected specs: `multiplayer-sync` (ADDED — lobby state and readiness
+  protocol), `game-session-management` (MODIFIED — session creation
+  accepts peer-sourced loadouts)
+- Affected code: new `src/pages/gameplay/lobby/[roomCode].tsx`, new
+  `src/components/gameplay/lobby/LobbyPanel.tsx`, new
+  `src/lib/p2p/lobbyChannel.ts` (Y.Map wrapper), extension of
+  `src/stores/useGameplayStore.ts` with a lobby slice
+- Non-goals: 3+ players (4b), spectator slots (4b), chat (out of scope),
+  custom deployment zone painting

--- a/openspec/changes/add-game-session-invite-and-lobby-1v1/specs/game-session-management/spec.md
+++ b/openspec/changes/add-game-session-invite-and-lobby-1v1/specs/game-session-management/spec.md
@@ -1,0 +1,43 @@
+# game-session-management Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Session Creation from Peer-Sourced Loadouts
+
+The system SHALL accept a session-creation configuration that sources
+one side's loadout from a remote peer's vault, so networked matches can
+start with units neither player had to pre-export.
+
+#### Scenario: Create session with host + guest loadouts
+
+- **GIVEN** a completed 1v1 lobby with `hostLoadout` and `guestLoadout`
+- **WHEN** the host invokes session creation with
+  `{hostLoadout, guestLoadout, mapConfig, hostPeerId, guestPeerId}`
+- **THEN** a session SHALL be created with units from both loadouts
+- **AND** `sideOwners[GameSide.Player]` SHALL equal `hostPeerId`
+- **AND** `sideOwners[GameSide.Opponent]` SHALL equal `guestPeerId`
+- **AND** the initial `GameCreated` event SHALL reference the remote
+  guest's units even though the host's vault did not own them
+
+#### Scenario: Guest units are not imported to host vault
+
+- **GIVEN** a networked session created from a guest's loadout
+- **WHEN** the host inspects their vault after session creation
+- **THEN** the guest's units SHALL NOT appear in the host's vault
+- **AND** the units SHALL exist only on the live session's event log
+
+### Requirement: Match Id Propagation From Lobby
+
+The system SHALL treat the `matchId` field written into lobby state as
+the definitive session id, so both peers route to the same session
+URL without out-of-band coordination.
+
+#### Scenario: Both peers navigate via shared matchId
+
+- **GIVEN** a host launches a match and the lobby state now contains
+  `matchId: 'sess_abc123'`
+- **WHEN** the guest observes the lobby update
+- **THEN** the guest's router SHALL navigate to
+  `/gameplay/games/sess_abc123`
+- **AND** both peers' `InteractiveSession` instances SHALL use that
+  same id

--- a/openspec/changes/add-game-session-invite-and-lobby-1v1/specs/multiplayer-sync/spec.md
+++ b/openspec/changes/add-game-session-invite-and-lobby-1v1/specs/multiplayer-sync/spec.md
@@ -1,0 +1,101 @@
+# multiplayer-sync Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Lobby State Shared Over Yjs
+
+The system SHALL store pre-match lobby state in a shared Y.Map on the
+existing sync room, so both peers see the same loadouts and map config
+as they assemble a match.
+
+#### Scenario: Lobby state shape
+
+- **GIVEN** a host has created a networked 1v1 lobby
+- **WHEN** the lobby is inspected
+- **THEN** the shared state SHALL include `mode: '1v1'`, `hostPeerId`,
+  `guestPeerId`, `hostLoadout`, `guestLoadout`, `mapConfig`,
+  `hostReady`, `guestReady`, and optional `matchId`
+
+#### Scenario: Peer update visible on other peer
+
+- **GIVEN** both peers are on the lobby page
+- **WHEN** the host edits `mapConfig.radius` from 10 to 14
+- **THEN** the guest's page SHALL display `radius: 14` without reload
+
+#### Scenario: Peer cannot modify foreign loadout slot
+
+- **GIVEN** the host tries to update `guestLoadout`
+- **WHEN** the lobby channel receives that update
+- **THEN** the update SHALL be rejected
+- **AND** a `peer-rejected` notification SHALL be surfaced locally with
+  `reason: 'unauthorized-slot'`
+
+### Requirement: Loadout Picking
+
+The system SHALL let each peer pick their side's mechs and pilots from
+their own local vault before the match launches.
+
+#### Scenario: Host picks 2 mechs and 2 pilots
+
+- **GIVEN** the host is on the lobby page
+- **WHEN** the host selects 2 mechs and assigns 1 pilot each
+- **THEN** `hostLoadout.units` SHALL contain 2 entries
+- **AND** `hostLoadout.pilots` SHALL contain 2 entries
+- **AND** the guest's view SHALL display the same 2 entries (read-only)
+
+#### Scenario: Mismatched side counts blocks readiness
+
+- **GIVEN** the host has picked 3 mechs and the guest has picked 2 mechs
+- **WHEN** either peer attempts to toggle ready
+- **THEN** the ready toggle SHALL be disabled
+- **AND** a hint SHALL display `"Both sides must pick the same number
+of mechs"`
+
+### Requirement: Readiness and Launch
+
+The system SHALL require both peers to mark themselves ready before the
+host may launch the match, and SHALL lock the loadouts at launch.
+
+#### Scenario: Both peers ready enables launch button
+
+- **GIVEN** `hostReady = true` and `guestReady = true` and loadouts are
+  valid
+- **WHEN** the host's UI renders
+- **THEN** the "Launch Match" button SHALL be enabled
+- **AND** the guest's UI SHALL show `"Waiting for host to launch..."`
+
+#### Scenario: Host launches match
+
+- **GIVEN** both peers are ready
+- **WHEN** the host clicks "Launch Match"
+- **THEN** a new game session SHALL be created with both loadouts
+  deployed per side
+- **AND** `matchId` SHALL be written into the lobby state
+- **AND** both peers SHALL navigate to `/gameplay/games/[matchId]`
+
+#### Scenario: Guest cannot launch
+
+- **GIVEN** both peers are ready
+- **WHEN** the guest's UI renders
+- **THEN** no launch button SHALL be visible to the guest
+
+### Requirement: Lobby Survives Peer Reconnect (Pre-Launch)
+
+The system SHALL keep the lobby Y.Map alive across transient peer
+disconnects before a match has launched.
+
+#### Scenario: Guest reconnect restores lobby view
+
+- **GIVEN** a guest on the lobby with `guestLoadout` populated
+- **WHEN** the guest disconnects and reconnects within 60 seconds
+- **THEN** the guest SHALL land back on the lobby page
+- **AND** the guest's previously-picked loadout SHALL still be present
+- **AND** the guest's `guestReady` flag SHALL be `false` (auto-reset)
+
+#### Scenario: Host disconnect closes lobby
+
+- **GIVEN** an active lobby with a host and a guest
+- **WHEN** the host disconnects for more than 60 seconds
+- **THEN** the lobby SHALL be marked `closed`
+- **AND** the guest SHALL be navigated to the landing page with a toast
+  `"Host left the lobby"`

--- a/openspec/changes/add-game-session-invite-and-lobby-1v1/tasks.md
+++ b/openspec/changes/add-game-session-invite-and-lobby-1v1/tasks.md
@@ -3,12 +3,12 @@
 ## 1. Lobby State Contract
 
 - [ ] 1.1 Define `ILobbyState` with `{mode: '1v1', hostPeerId,
-    guestPeerId, hostLoadout, guestLoadout, mapConfig, hostReady,
-    guestReady, matchId?}`
+guestPeerId, hostLoadout, guestLoadout, mapConfig, hostReady,
+guestReady, matchId?}`
 - [ ] 1.2 Define `ILoadout` with `{units: ISelectedUnit[],
-    pilots: ISelectedPilot[]}` for a single side
+pilots: ISelectedPilot[]}` for a single side
 - [ ] 1.3 Define `IMapConfig` with `{radius: number, terrainPreset:
-    string, turnLimit: number}`
+string, turnLimit: number}`
 - [ ] 1.4 Schema validation (zod) for incoming lobby updates from
       remote peers
 
@@ -100,4 +100,4 @@
 - [ ] 11.2 Every requirement in the `game-session-management` delta has
       at least one GIVEN/WHEN/THEN scenario
 - [ ] 11.3 `openspec validate add-game-session-invite-and-lobby-1v1
-    --strict` passes clean
+--strict` passes clean

--- a/openspec/changes/add-game-session-invite-and-lobby-1v1/tasks.md
+++ b/openspec/changes/add-game-session-invite-and-lobby-1v1/tasks.md
@@ -1,0 +1,103 @@
+# Tasks: Add Game Session Invite and Lobby (1v1)
+
+## 1. Lobby State Contract
+
+- [ ] 1.1 Define `ILobbyState` with `{mode: '1v1', hostPeerId,
+    guestPeerId, hostLoadout, guestLoadout, mapConfig, hostReady,
+    guestReady, matchId?}`
+- [ ] 1.2 Define `ILoadout` with `{units: ISelectedUnit[],
+    pilots: ISelectedPilot[]}` for a single side
+- [ ] 1.3 Define `IMapConfig` with `{radius: number, terrainPreset:
+    string, turnLimit: number}`
+- [ ] 1.4 Schema validation (zod) for incoming lobby updates from
+      remote peers
+
+## 2. Lobby Channel
+
+- [ ] 2.1 Add `lobbyChannel.ts` that wraps a Y.Map named `lobby` in the
+      existing sync room
+- [ ] 2.2 Channel exposes `getState()`, `updateLoadout(side, loadout)`,
+      `updateMapConfig(config)`, `setReady(peerId, ready)`, `launch()`
+- [ ] 2.3 Channel rejects updates authored by a peer for a loadout slot
+      they don't own
+- [ ] 2.4 Store mirrors lobby state in Zustand so UI can render
+      reactively
+
+## 3. Lobby Page
+
+- [ ] 3.1 Add route `/gameplay/lobby/[roomCode]`
+- [ ] 3.2 Page renders two loadout cards (host / guest), the map config
+      panel, and two ready toggles
+- [ ] 3.3 Cards for the local peer are editable; the remote peer's card
+      is read-only (shows what they've picked so far)
+- [ ] 3.4 A shareable room code is prominently displayed with
+      copy-to-clipboard
+
+## 4. Loadout Picker
+
+- [ ] 4.1 Each peer picks 1–4 mechs from their own vault
+- [ ] 4.2 Each peer picks 1 pilot per mech from their own vault
+- [ ] 4.3 Picks publish to the lobby channel on change
+- [ ] 4.4 Invalid loadouts (no mechs, pilot count mismatch) disable the
+      ready toggle
+- [ ] 4.5 For 4a scope, mech counts between the two sides must match
+      (1v1, 2v2, up to 4v4)
+
+## 5. Map Config
+
+- [ ] 5.1 Host picks map radius, terrain preset, turn limit
+- [ ] 5.2 Guest can see but not change map config
+- [ ] 5.3 Changes propagate in real time via the lobby channel
+
+## 6. Readiness + Launch
+
+- [ ] 6.1 Each peer toggles their own ready flag
+- [ ] 6.2 When both peers are ready, host sees a "Launch Match" button
+- [ ] 6.3 Clicking launch: host creates the session with both loadouts,
+      writes `matchId` into lobby state, both peers navigate to
+      `/gameplay/games/[matchId]`
+- [ ] 6.4 Guest cannot launch; button is host-only
+
+## 7. Invite Flow
+
+- [ ] 7.1 Adding "Networked 1v1" to the skirmish setup (from
+      `add-p2p-game-session-sync`) now routes to a newly created lobby
+      instead of launching directly
+- [ ] 7.2 Joining a networked match: user enters a room code in the
+      existing sync-join UI; if the room has an active lobby, the UI
+      routes to `/gameplay/lobby/[roomCode]`
+
+## 8. Guest Assignment
+
+- [ ] 8.1 On guest join, the first unassigned side slot is assigned
+      (`hostPeerId` owns one side, `guestPeerId` owns the other)
+- [ ] 8.2 The host side is chosen at room creation; guest gets the
+      remaining side
+- [ ] 8.3 Assignment writes `sideOwners` on the eventual session
+
+## 9. Disconnect Mid-Lobby
+
+- [ ] 9.1 If either peer disconnects before launch, their ready flag
+      auto-resets to false
+- [ ] 9.2 If the host disconnects, the lobby closes and the guest is
+      kicked back to the landing page with a toast
+- [ ] 9.3 If the guest disconnects, the host sees "Waiting for
+      opponent..." until a new guest joins
+
+## 10. Tests
+
+- [ ] 10.1 Integration test: host creates lobby, guest joins, both pick
+      loadouts, both ready, host launches, both land on the combat page
+- [ ] 10.2 Integration test: host disconnect closes the lobby
+- [ ] 10.3 Integration test: guest cannot modify the host's loadout
+- [ ] 10.4 Integration test: third peer joining the room cannot join
+      the 1v1 lobby
+
+## 11. Spec Compliance
+
+- [ ] 11.1 Every requirement in the `multiplayer-sync` delta has at
+      least one GIVEN/WHEN/THEN scenario
+- [ ] 11.2 Every requirement in the `game-session-management` delta has
+      at least one GIVEN/WHEN/THEN scenario
+- [ ] 11.3 `openspec validate add-game-session-invite-and-lobby-1v1
+    --strict` passes clean

--- a/openspec/changes/add-game-session-persistence-for-reconnect/proposal.md
+++ b/openspec/changes/add-game-session-persistence-for-reconnect/proposal.md
@@ -1,0 +1,52 @@
+# Change: Add Game Session Persistence for Reconnect
+
+## Why
+
+**Sub-phase 4a.** Networked matches will lose peers to flaky wifi, laptop
+sleep, and accidental browser refreshes. Because `gameSessionCore` is
+event-sourced, a client can be fully re-hydrated from the event log —
+but only if the log exists locally and can be fetched from the
+authoritative host on reconnect. Today, session events live in memory
+only. Without persistence, a guest who refreshes the tab is dropped from
+the match entirely. This change adds (1) local IndexedDB persistence of
+the match event log on both peers, (2) a host-served event-log replay
+so a reconnecting guest can catch up, and (3) an on-session "peer
+pending" status the host enters when the guest drops.
+
+## What Changes
+
+- Persist every appended event to IndexedDB under `match:[matchId]` on
+  both host and guest
+- On page reload, if a match id is present in the URL, the local session
+  is re-hydrated from IndexedDB first, then reconciled with the peer
+- Host maintains an in-memory event log and exposes `replayEvents(fromSeq)`
+  over the peer channel
+- Guest on reconnect requests events `fromSeq = localHighestSeq + 1`;
+  host streams missing events; guest applies them to catch up
+- Host adds a local `PeerPending` match status when the guest is absent;
+  match does NOT auto-end on transient disconnect (30-second grace
+  window before the host falls back to "continue solo vs AI" or
+  `reason: 'aborted'`)
+- Reconnect window is configurable; default 60 seconds
+
+## Dependencies
+
+- **Requires**: `add-p2p-game-session-sync` (peer channel + host
+  authority), `add-game-session-invite-and-lobby-1v1` (session created
+  with a shareable id), existing `auto-save-persistence`,
+  `game-session-management`
+- **Required By**: `add-reconnection-and-session-rehydration` (4b
+  generalizes reconnect to server-authoritative)
+
+## Impact
+
+- Affected specs: `multiplayer-sync` (ADDED — replay protocol, peer
+  pending state, reconnect contract), `auto-save-persistence` (MODIFIED
+  — adds game-event-log storage path and multi-session support),
+  `game-session-management` (MODIFIED — peer-pending local status)
+- Affected code: new `src/lib/p2p/matchLogStorage.ts` (IndexedDB
+  wrapper), new `src/lib/p2p/reconnectProtocol.ts`, extension of
+  `src/engine/InteractiveSession.ts` with hydration-from-log factory,
+  extension of `useGameplayStore.ts` for pending-peer status
+- Non-goals: server-side persistence (4b), cross-device continue-where-
+  you-left (4b), event log compaction

--- a/openspec/changes/add-game-session-persistence-for-reconnect/specs/auto-save-persistence/spec.md
+++ b/openspec/changes/add-game-session-persistence-for-reconnect/specs/auto-save-persistence/spec.md
@@ -1,0 +1,58 @@
+# auto-save-persistence Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Game Event Log Storage
+
+The auto-save persistence system SHALL provide an IndexedDB-backed
+storage path for game event logs, keyed by match id and event sequence.
+
+#### Scenario: Event log storage schema
+
+- **GIVEN** the app initializes its IndexedDB
+- **WHEN** the schema is inspected
+- **THEN** an object store `matchEvents` SHALL exist
+- **AND** records SHALL have shape `{matchId, sequence, event, savedAt}`
+- **AND** the primary key SHALL be the tuple `[matchId, sequence]`
+
+#### Scenario: Match metadata store
+
+- **GIVEN** the same IndexedDB
+- **WHEN** the schema is inspected
+- **THEN** an object store `matches` SHALL exist
+- **AND** records SHALL have shape `{matchId, hostPeerId, guestPeerId,
+status, lastActivity}`
+
+### Requirement: Multi-Session Local Storage
+
+The system SHALL allow multiple concurrent match logs to coexist in
+local storage so a completed match remains inspectable while a new one
+begins.
+
+#### Scenario: Two match logs coexist
+
+- **GIVEN** match `sess_abc` is completed and its log is on disk
+- **WHEN** a new match `sess_xyz` starts and appends events
+- **THEN** both match logs SHALL be queryable by match id
+- **AND** writes to `sess_xyz` SHALL NOT overwrite `sess_abc` records
+
+#### Scenario: Query events for a specific match
+
+- **GIVEN** multiple match logs in IndexedDB
+- **WHEN** `getEventsForMatch('sess_abc')` is called
+- **THEN** the result SHALL include only events whose `matchId` equals
+  `'sess_abc'`
+- **AND** results SHALL be returned in ascending sequence order
+
+### Requirement: Batched Writes
+
+The system SHALL batch event-log writes to minimize IndexedDB
+transaction overhead during high-frequency event bursts (e.g., the
+attack-resolution phase that emits many events in sequence).
+
+#### Scenario: Burst writes share a transaction
+
+- **GIVEN** 20 events are appended within a single animation frame
+- **WHEN** the persistence layer flushes
+- **THEN** the 20 writes SHALL share a single IndexedDB transaction
+- **AND** the flush SHALL complete within 50ms on a baseline device

--- a/openspec/changes/add-game-session-persistence-for-reconnect/specs/game-session-management/spec.md
+++ b/openspec/changes/add-game-session-persistence-for-reconnect/specs/game-session-management/spec.md
@@ -1,0 +1,47 @@
+# game-session-management Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Session Rehydration Factory
+
+The system SHALL provide a factory that rehydrates an `IGameSession`
+from a persisted event log identified by match id.
+
+#### Scenario: Factory rebuilds session from log
+
+- **GIVEN** a persisted log of 40 events for `matchId='sess_abc'`
+- **WHEN** `InteractiveSession.fromMatchLog('sess_abc')` is called
+- **THEN** the returned session SHALL have 40 events in its `events`
+  array
+- **AND** the returned session's `currentState` SHALL equal the state
+  derived by folding all 40 events through `deriveState`
+- **AND** the session's `id` SHALL equal the log's `matchId`
+
+#### Scenario: Factory throws on unknown match id
+
+- **GIVEN** no persisted log for `matchId='sess_unknown'`
+- **WHEN** `InteractiveSession.fromMatchLog('sess_unknown')` is called
+- **THEN** the factory SHALL throw `"Match log not found"`
+
+### Requirement: Non-Authoritative Local Match Status
+
+The system SHALL recognize a local-only match status separate from the
+session's authoritative `status`, used purely for UI feedback during
+peer-pending windows in networked matches.
+
+#### Scenario: Local status distinct from session status
+
+- **GIVEN** a live networked match with `currentState.status =
+GameStatus.Active`
+- **WHEN** the guest disconnects
+- **THEN** the host's `localMatchStatus` SHALL become `'guestPending'`
+- **AND** the session's authoritative `currentState.status` SHALL
+  remain `GameStatus.Active`
+
+#### Scenario: Local status not persisted to event log
+
+- **GIVEN** the host enters `localMatchStatus: 'guestPending'`
+- **WHEN** the event log is inspected
+- **THEN** no event SHALL record the pending state
+- **AND** replaying the log on a fresh client SHALL NOT reproduce the
+  local status

--- a/openspec/changes/add-game-session-persistence-for-reconnect/specs/multiplayer-sync/spec.md
+++ b/openspec/changes/add-game-session-persistence-for-reconnect/specs/multiplayer-sync/spec.md
@@ -1,0 +1,105 @@
+# multiplayer-sync Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Local Event Log Persistence
+
+The system SHALL persist every appended game event to IndexedDB under
+the active match id, on both the host and the guest peer, so a browser
+refresh does not lose match state.
+
+#### Scenario: Every append reaches disk
+
+- **GIVEN** a live networked match
+- **WHEN** the host appends a movement event
+- **THEN** the event SHALL be written to IndexedDB under
+  `matchEvents` with key `[matchId, sequence]`
+- **AND** the guest's own IndexedDB SHALL also contain that event after
+  it arrives via the peer channel
+
+#### Scenario: Session rehydrates from log
+
+- **GIVEN** a match log for `matchId='sess_abc'` is present in
+  IndexedDB with 40 events
+- **WHEN** `InteractiveSession.fromMatchLog('sess_abc')` is called
+- **THEN** the returned session SHALL have 40 events
+- **AND** `currentState` SHALL match the state produced by replaying
+  those 40 events in order
+
+### Requirement: Reconnect Protocol
+
+The system SHALL define a peer-channel protocol that reconciles a
+reconnecting guest's local event log with the host's authoritative log.
+
+#### Scenario: Guest requests missing events
+
+- **GIVEN** a guest reconnecting with `lastLocalSeq = 25`
+- **WHEN** the guest's reconnect handler runs
+- **THEN** it SHALL send `{kind: 'reconnect-request', matchId,
+lastLocalSeq: 25}` over the peer channel
+- **AND** the host SHALL respond with `{kind: 'replay-stream', events}`
+  containing all events whose sequence > 25
+
+#### Scenario: Replay chunked for large logs
+
+- **GIVEN** the host has 200 events newer than the guest's `lastLocal
+Seq`
+- **WHEN** the replay stream is sent
+- **THEN** it SHALL be split into chunks of at most 64 events per
+  message
+- **AND** the final chunk SHALL carry a flag `done: true`
+
+#### Scenario: Matchid mismatch rejected
+
+- **GIVEN** the host's current session is `sess_abc`
+- **WHEN** a reconnect-request arrives with `matchId: 'sess_xyz'`
+- **THEN** the host SHALL respond `{kind: 'peer-rejected', reason:
+'wrong-match'}`
+
+### Requirement: Peer Pending Grace Window
+
+The system SHALL pause phase advancement and run a grace window before
+ending a match when a peer becomes unreachable.
+
+#### Scenario: Grace window starts on peer loss
+
+- **GIVEN** a live networked match
+- **WHEN** the guest's Yjs awareness is lost
+- **THEN** the host SHALL enter `localMatchStatus: 'guestPending'`
+- **AND** a 60-second grace timer SHALL start
+- **AND** phase advancement SHALL be paused
+
+#### Scenario: Peer returns within grace window
+
+- **GIVEN** a host in `'guestPending'` at `T+30 seconds`
+- **WHEN** the guest reconnects and completes the reconnect protocol
+- **THEN** `localMatchStatus` SHALL return to `'live'`
+- **AND** phase advancement SHALL resume
+
+#### Scenario: Grace window expires
+
+- **GIVEN** a host in `'guestPending'` at `T+60 seconds` with no
+  reconnect
+- **WHEN** the grace timer fires
+- **THEN** the host SHALL append `GameEnded` with
+  `{winner: 'draw', reason: 'aborted'}`
+- **AND** the session SHALL become `Completed`
+
+### Requirement: Match Log Retention
+
+The system SHALL retain the event log for completed matches for 7 days,
+enabling post-match inspection and re-replay.
+
+#### Scenario: Completed match log kept
+
+- **GIVEN** a match that ended normally 3 days ago
+- **WHEN** the app starts up
+- **THEN** the match log SHALL still be present in IndexedDB
+- **AND** re-hydration via `fromMatchLog` SHALL still work
+
+#### Scenario: Old match log purged
+
+- **GIVEN** a completed match log that is 8 days old
+- **WHEN** `purgeOldMatches()` runs at app startup
+- **THEN** the log SHALL be deleted from IndexedDB
+- **AND** `matches` metadata for that match SHALL also be deleted

--- a/openspec/changes/add-game-session-persistence-for-reconnect/tasks.md
+++ b/openspec/changes/add-game-session-persistence-for-reconnect/tasks.md
@@ -1,0 +1,109 @@
+# Tasks: Add Game Session Persistence for Reconnect
+
+## 1. IndexedDB Schema
+
+- [ ] 1.1 Add `matchLogStorage.ts` in `src/lib/p2p/` wrapping IndexedDB
+      with an object store `matchEvents`
+- [ ] 1.2 Record shape: `{matchId: string, sequence: number, event:
+    IGameEvent, savedAt: ISO8601}`; primary key `[matchId, sequence]`
+- [ ] 1.3 Add a `matches` object store for metadata:
+      `{matchId, hostPeerId, guestPeerId, status, lastActivity}`
+- [ ] 1.4 Writes SHALL be batched (single txn per animation frame)
+- [ ] 1.5 Add migration path for existing IndexedDB schema
+
+## 2. Persistence Wiring
+
+- [ ] 2.1 `InteractiveSession.appendEvent` on both host and guest writes
+      to IndexedDB after the in-memory append succeeds
+- [ ] 2.2 `IGameSession` carries a `matchId` (already present after
+      `add-game-session-invite-and-lobby-1v1`)
+- [ ] 2.3 Persistence is fire-and-forget but errors are logged; state
+      mismatch between disk and memory is surfaced as a toast
+
+## 3. Hydration From Log
+
+- [ ] 3.1 `InteractiveSession.fromMatchLog(matchId)` reads all events
+      from IndexedDB and rebuilds the session
+- [ ] 3.2 Hydration replays events into `deriveState` in sequence
+- [ ] 3.3 Unit test: a session saved then hydrated produces an
+      identical `currentState`
+
+## 4. Reconnect Protocol (Guest → Host)
+
+- [ ] 4.1 On page load, if URL has a `matchId`, guest opens the sync
+      room and sends `{kind: 'reconnect-request', matchId,
+    lastLocalSeq}`
+- [ ] 4.2 Host responds with `{kind: 'replay-stream', events:
+    IGameEvent[]}` containing all events with `seq > lastLocalSeq`
+- [ ] 4.3 Guest applies the replayed events in order via `appendEvent`
+- [ ] 4.4 If the host is not present within 10 seconds, the guest falls
+      back to hydrate-from-local-log and enters a `HostPending` local
+      state
+
+## 5. Peer Pending Local Status
+
+- [ ] 5.1 Add `localMatchStatus: 'live' | 'guestPending' | 'hostPending'
+    | 'aborted'` to `useGameplayStore`
+- [ ] 5.2 Host sets `guestPending` when the guest's Yjs awareness is
+      lost and the match is mid-play
+- [ ] 5.3 Guest sets `hostPending` when the host's Yjs awareness is lost
+      but the local log is preserved
+- [ ] 5.4 `localMatchStatus` is a local UI concern; it is NOT written
+      to the session event log
+
+## 6. Grace Window
+
+- [ ] 6.1 Grace window defaults to 60 seconds (configurable per match)
+- [ ] 6.2 During the grace window, the host pauses phase advancement
+      and shows a banner: `"Waiting for opponent to reconnect
+    (NN seconds remaining)..."`
+- [ ] 6.3 If grace expires: host appends `GameEnded` with `reason:
+    'aborted'`; the session enters `Completed` normally
+- [ ] 6.4 If the guest reconnects within the grace window, `localMatch
+    Status` returns to `'live'` and play resumes
+
+## 7. Host-Side Replay API
+
+- [ ] 7.1 Host exposes `getEventsFromSeq(seq: number): IGameEvent[]`
+      from its in-memory log
+- [ ] 7.2 Replay response is streamed in chunks of 64 events max per
+      message to avoid large single messages
+- [ ] 7.3 Host rejects `reconnect-request` if `matchId` doesn't match
+      the host's current session
+
+## 8. Guest-Side Late Join
+
+- [ ] 8.1 If a guest loads a lobby URL after the match has launched and
+      they were the original guest, the reconnect protocol activates
+      automatically
+- [ ] 8.2 If a different peer tries to join a running 1v1 session, the
+      host rejects them with `"Match in progress"`
+
+## 9. Persistence Cleanup
+
+- [ ] 9.1 On `GameEnded`, mark the match metadata as `status:
+    'completed'` but retain the event log for 7 days
+- [ ] 9.2 Add a `purgeOldMatches()` helper that deletes match logs
+      older than 7 days on app startup
+- [ ] 9.3 Manual purge via debug console (`window.__mekstationDebug`)
+
+## 10. Tests
+
+- [ ] 10.1 Unit test: save 20 events, hydrate, verify `currentState`
+- [ ] 10.2 Integration test using mock sync: guest drops after turn 3
+      event 5, reconnects, catches up to turn 4 event 9
+- [ ] 10.3 Integration test: guest drops, grace window expires, host
+      match ends with `aborted`
+- [ ] 10.4 Integration test: host drops, guest holds its local log,
+      host returns, guest catches up from host's log
+
+## 11. Spec Compliance
+
+- [ ] 11.1 Every requirement in the `multiplayer-sync` delta has at
+      least one GIVEN/WHEN/THEN scenario
+- [ ] 11.2 Every requirement in the `auto-save-persistence` delta has
+      at least one GIVEN/WHEN/THEN scenario
+- [ ] 11.3 Every requirement in the `game-session-management` delta has
+      at least one GIVEN/WHEN/THEN scenario
+- [ ] 11.4 `openspec validate add-game-session-persistence-for-reconnect
+    --strict` passes clean

--- a/openspec/changes/add-game-session-persistence-for-reconnect/tasks.md
+++ b/openspec/changes/add-game-session-persistence-for-reconnect/tasks.md
@@ -5,7 +5,7 @@
 - [ ] 1.1 Add `matchLogStorage.ts` in `src/lib/p2p/` wrapping IndexedDB
       with an object store `matchEvents`
 - [ ] 1.2 Record shape: `{matchId: string, sequence: number, event:
-    IGameEvent, savedAt: ISO8601}`; primary key `[matchId, sequence]`
+IGameEvent, savedAt: ISO8601}`; primary key `[matchId, sequence]`
 - [ ] 1.3 Add a `matches` object store for metadata:
       `{matchId, hostPeerId, guestPeerId, status, lastActivity}`
 - [ ] 1.4 Writes SHALL be batched (single txn per animation frame)
@@ -32,9 +32,9 @@
 
 - [ ] 4.1 On page load, if URL has a `matchId`, guest opens the sync
       room and sends `{kind: 'reconnect-request', matchId,
-    lastLocalSeq}`
+lastLocalSeq}`
 - [ ] 4.2 Host responds with `{kind: 'replay-stream', events:
-    IGameEvent[]}` containing all events with `seq > lastLocalSeq`
+IGameEvent[]}` containing all events with `seq > lastLocalSeq`
 - [ ] 4.3 Guest applies the replayed events in order via `appendEvent`
 - [ ] 4.4 If the host is not present within 10 seconds, the guest falls
       back to hydrate-from-local-log and enters a `HostPending` local
@@ -43,7 +43,7 @@
 ## 5. Peer Pending Local Status
 
 - [ ] 5.1 Add `localMatchStatus: 'live' | 'guestPending' | 'hostPending'
-    | 'aborted'` to `useGameplayStore`
+| 'aborted'` to `useGameplayStore`
 - [ ] 5.2 Host sets `guestPending` when the guest's Yjs awareness is
       lost and the match is mid-play
 - [ ] 5.3 Guest sets `hostPending` when the host's Yjs awareness is lost
@@ -56,11 +56,11 @@
 - [ ] 6.1 Grace window defaults to 60 seconds (configurable per match)
 - [ ] 6.2 During the grace window, the host pauses phase advancement
       and shows a banner: `"Waiting for opponent to reconnect
-    (NN seconds remaining)..."`
+(NN seconds remaining)..."`
 - [ ] 6.3 If grace expires: host appends `GameEnded` with `reason:
-    'aborted'`; the session enters `Completed` normally
+'aborted'`; the session enters `Completed` normally
 - [ ] 6.4 If the guest reconnects within the grace window, `localMatch
-    Status` returns to `'live'` and play resumes
+Status` returns to `'live'` and play resumes
 
 ## 7. Host-Side Replay API
 
@@ -82,7 +82,7 @@
 ## 9. Persistence Cleanup
 
 - [ ] 9.1 On `GameEnded`, mark the match metadata as `status:
-    'completed'` but retain the event log for 7 days
+'completed'` but retain the event log for 7 days
 - [ ] 9.2 Add a `purgeOldMatches()` helper that deletes match logs
       older than 7 days on app startup
 - [ ] 9.3 Manual purge via debug console (`window.__mekstationDebug`)
@@ -106,4 +106,4 @@
 - [ ] 11.3 Every requirement in the `game-session-management` delta has
       at least one GIVEN/WHEN/THEN scenario
 - [ ] 11.4 `openspec validate add-game-session-persistence-for-reconnect
-    --strict` passes clean
+--strict` passes clean

--- a/openspec/changes/add-heat-and-shutdown-visual-indicators/proposal.md
+++ b/openspec/changes/add-heat-and-shutdown-visual-indicators/proposal.md
@@ -1,0 +1,52 @@
+# Change: Add Heat and Shutdown Visual Indicators
+
+## Why
+
+Heat state is one of the biggest drivers of BattleTech tactical decisions
+— a mech running hot is about to shut down, fail PSR, or cook off ammo —
+and today nothing on the map telegraphs that. The heat bar lives in the
+action panel only; the map shows an unchanged token even when the pilot
+is one bad roll from a reactor shutdown. Phase 7 makes heat legible: a
+token glows warmer as heat climbs, shutdown renders a powered-down
+overlay, startup pulses, and an ammo-explosion-threshold warning halo
+appears when the stars align for a reactor boom.
+
+## What Changes
+
+- Token glow shifts from neutral to orange to red as heat climbs
+  through thresholds (5, 10, 15, 20)
+- Shutdown state overlays a dimmed grayscale token with a "POWERED DOWN"
+  label and a subtle flicker
+- Startup animation plays a short radial pulse on the turn a unit
+  reboots (success or failure branches both play — failure is shorter
+  and fades to gray, success settles into full color)
+- Overheat warning aura renders when a unit's heat is within ammo-
+  explosion threshold territory (red-purple pulsing halo)
+- Indicators layer over the sprite and damage overlay, beneath selection
+- Respect reduced motion — glow becomes a static colored outline; pulse
+  animations collapse to a single state change
+
+## Dependencies
+
+- **Requires**: `add-interactive-combat-core-ui` (Phase 1 MVP),
+  `add-mech-silhouette-sprite-set` (glow renders around sprite),
+  `heat-overflow-effects` (heat thresholds), `tactical-map-interface`
+- **Related**: `add-damage-feedback-effects` (visual grammar shared)
+- **Required By**: none — Phase 7 presentation layer
+
+## Impact
+
+- Affected specs: `heat-overflow-effects` (MODIFIED — expose heat
+  threshold states for UI subscription), `tactical-map-interface`
+  (MODIFIED — new heat glow layer, shutdown overlay, startup pulse,
+  ammo-explosion warning halo)
+- Affected code: new
+  `src/components/gameplay/effects/HeatGlow.tsx`,
+  `src/components/gameplay/effects/ShutdownOverlay.tsx`,
+  `src/components/gameplay/effects/StartupPulse.tsx`,
+  `src/components/gameplay/effects/AmmoExplosionAura.tsx`, new
+  `src/utils/effects/heatVisualMap.ts` mapping heat levels to glow
+  color/opacity
+- Non-goals: sound effects (out), detailed damage cause-of-shutdown
+  breakdown (panel concern), 3D effects (shelved)
+- Database: none

--- a/openspec/changes/add-heat-and-shutdown-visual-indicators/specs/heat-overflow-effects/spec.md
+++ b/openspec/changes/add-heat-and-shutdown-visual-indicators/specs/heat-overflow-effects/spec.md
@@ -1,0 +1,33 @@
+# heat-overflow-effects Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: Heat Threshold Events For UI
+
+The heat overflow system SHALL emit structured heat-threshold events
+so the UI layer can subscribe to transitions without polling state.
+
+#### Scenario: HeatChanged event carries old and new thresholds
+
+- **GIVEN** a unit's heat changes
+- **WHEN** `HeatChanged` is emitted
+- **THEN** the payload SHALL contain `previousHeat`, `currentHeat`,
+  `previousThreshold`, and `currentThreshold`
+- **AND** threshold values SHALL be one of `normal | warm | hot |
+overheat | critical`
+
+#### Scenario: AmmoExplosionRiskEntered fires on threshold cross
+
+- **GIVEN** a unit's heat enters the ammo-explosion-risk range
+- **WHEN** the crossing happens
+- **THEN** an `AmmoExplosionRiskEntered` event SHALL be emitted
+- **AND** when heat drops out of the range, an
+  `AmmoExplosionRiskExited` event SHALL be emitted
+
+#### Scenario: Startup event carries pass/fail outcome
+
+- **GIVEN** a shutdown unit attempts restart
+- **WHEN** the `Startup` event is emitted
+- **THEN** the payload SHALL contain `success: boolean`
+- **AND** failure SHALL be distinguishable from success so the UI can
+  pick the correct pulse variant

--- a/openspec/changes/add-heat-and-shutdown-visual-indicators/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-heat-and-shutdown-visual-indicators/specs/tactical-map-interface/spec.md
@@ -1,0 +1,112 @@
+# tactical-map-interface Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Heat Glow Around Unit Tokens
+
+The tactical map interface SHALL render a heat glow around each unit
+token that intensifies with the unit's heat level.
+
+#### Scenario: Glow intensifies with heat
+
+- **GIVEN** a unit's heat rises from 0 to 12 over the course of a turn
+- **WHEN** heat events fire
+- **THEN** the glow color SHALL transition neutral -> amber at heat 5
+- **AND** the glow color SHALL transition amber -> orange at heat 10
+- **AND** transitions SHALL ease over 300ms
+
+#### Scenario: Critical heat adds pulse
+
+- **GIVEN** a unit's heat exceeds 20
+- **WHEN** the glow renders
+- **THEN** the glow SHALL be red-white
+- **AND** the glow SHALL pulse with a ~1.5s period
+
+#### Scenario: Textual badge for high heat
+
+- **GIVEN** a unit's heat is at or above 15
+- **WHEN** the token renders
+- **THEN** a textual badge ("HOT", "OVERHEAT", or "CRITICAL") SHALL
+  render on the token
+- **AND** the badge SHALL remain visible for colorblind users
+
+### Requirement: Shutdown Overlay
+
+The tactical map interface SHALL render a powered-down overlay on any
+unit in shutdown state.
+
+#### Scenario: Shutdown desaturates token
+
+- **GIVEN** a unit enters shutdown state
+- **WHEN** the overlay applies
+- **THEN** the sprite SHALL render desaturated via color matrix filter
+- **AND** a "POWERED DOWN" label SHALL render beneath the token
+- **AND** a subtle ~3s flicker SHALL hint at failed restart attempts
+
+#### Scenario: Shutdown overrides heat glow
+
+- **GIVEN** a unit was glowing red from heat 22 and now shuts down
+- **WHEN** the shutdown overlay activates
+- **THEN** the heat glow SHALL be suppressed
+- **AND** only the shutdown overlay SHALL render on the token
+
+#### Scenario: Shutdown announces via aria-live
+
+- **GIVEN** an assistive technology user
+- **WHEN** a unit enters shutdown
+- **THEN** an `aria-live` region SHALL announce the shutdown event
+
+### Requirement: Startup Pulse
+
+When a unit exits shutdown state, the tactical map interface SHALL
+play a short startup pulse animation.
+
+#### Scenario: Successful restart plays amber pulse
+
+- **GIVEN** a unit passes its restart roll
+- **WHEN** the pulse plays
+- **THEN** a radial pulse SHALL expand from 0 to 1.2x sprite scale
+- **AND** the pulse color SHALL fade from amber to neutral over 800ms
+- **AND** the shutdown overlay SHALL clear when the pulse finishes
+
+#### Scenario: Failed restart plays short gray pulse
+
+- **GIVEN** a unit fails its restart roll
+- **WHEN** the pulse plays
+- **THEN** a shorter 400ms pulse SHALL fade to gray
+- **AND** the shutdown overlay SHALL remain active
+
+### Requirement: Ammo Explosion Warning Aura
+
+The tactical map interface SHALL render a warning aura when a unit's
+heat enters the ammo-explosion-risk range defined by
+`heat-overflow-effects`.
+
+#### Scenario: Aura activates in danger range
+
+- **GIVEN** a unit's heat enters the ammo-explosion-risk range
+- **WHEN** the aura renders
+- **THEN** a red-purple halo SHALL pulse with a ~1s period around the
+  token
+- **AND** the aura SHALL render above the sprite and armor pips
+
+#### Scenario: Aura auto-dismisses when risk clears
+
+- **GIVEN** a unit's heat drops out of the ammo-explosion-risk range
+- **WHEN** the heat event fires
+- **THEN** the aura SHALL fade out over 300ms
+- **AND** the heat glow SHALL resume its current threshold color
+
+### Requirement: Reduced Motion Collapse
+
+All heat and shutdown indicators SHALL collapse to static forms under
+`prefers-reduced-motion: reduce`.
+
+#### Scenario: Reduced motion eliminates pulses
+
+- **GIVEN** `prefers-reduced-motion: reduce` is set
+- **WHEN** heat indicators render
+- **THEN** HeatGlow SHALL render as a static colored outline
+- **AND** the ammo explosion aura SHALL render as a static ring
+- **AND** startup pulses SHALL collapse to an instant color change
+- **AND** shutdown flicker SHALL stop

--- a/openspec/changes/add-heat-and-shutdown-visual-indicators/tasks.md
+++ b/openspec/changes/add-heat-and-shutdown-visual-indicators/tasks.md
@@ -1,0 +1,100 @@
+# Tasks: Add Heat and Shutdown Visual Indicators
+
+## 1. Heat Visual Map
+
+- [ ] 1.1 Create `src/utils/effects/heatVisualMap.ts`
+- [ ] 1.2 Thresholds: 0-4 neutral, 5-9 amber glow, 10-14 orange glow,
+      15-19 red glow, 20+ red-white glow with subtle pulse
+- [ ] 1.3 Map heat level to `{color, intensity, pulse}` tuple
+- [ ] 1.4 Unit tests for every threshold boundary
+
+## 2. HeatGlow Component
+
+- [ ] 2.1 Create `src/components/gameplay/effects/HeatGlow.tsx`
+- [ ] 2.2 Renders a radial glow around the sprite using SVG filter
+- [ ] 2.3 Smoothly transitions between thresholds over 300ms
+- [ ] 2.4 Pulse animation only above heat 20 (1.5s period, subtle)
+- [ ] 2.5 Layer sits above sprite + armor pips, below selection ring
+
+## 3. Shutdown Overlay
+
+- [ ] 3.1 Create `src/components/gameplay/effects/ShutdownOverlay.tsx`
+- [ ] 3.2 Desaturates the sprite via `<feColorMatrix>` filter
+- [ ] 3.3 Adds a dim "POWERED DOWN" label beneath the token
+- [ ] 3.4 Subtle flicker (~3s period) hints at failed restart attempts
+- [ ] 3.5 Layer overrides HeatGlow while active (shutdown is definitive)
+
+## 4. Startup Pulse
+
+- [ ] 4.1 Create `src/components/gameplay/effects/StartupPulse.tsx`
+- [ ] 4.2 Triggered on the frame a unit leaves shutdown state
+- [ ] 4.3 Success branch: radial pulse 0 -> 1.2x scale, amber fading
+      to neutral over 800ms
+- [ ] 4.4 Failure branch: shorter pulse (400ms) fading to gray,
+      shutdown overlay remains
+- [ ] 4.5 Plays exactly once per restart attempt
+
+## 5. Ammo Explosion Warning Aura
+
+- [ ] 5.1 Create `src/components/gameplay/effects/AmmoExplosionAura.tsx`
+- [ ] 5.2 Triggered when heat level would risk ammo cookoff per
+      `heat-overflow-effects` rules
+- [ ] 5.3 Red-purple halo pulsing at 1s period
+- [ ] 5.4 Renders beneath HeatGlow and above sprite
+- [ ] 5.5 Auto-dismisses when heat drops out of danger range
+
+## 6. Event Subscription
+
+- [ ] 6.1 Token wrappers subscribe to `HeatChanged`, `Shutdown`,
+      `Startup`, `AmmoExplosionRiskEntered`, `AmmoExplosionRiskExited`
+- [ ] 6.2 Effects update per subscription, not per tick
+- [ ] 6.3 Subscriptions tear down on unmount
+
+## 7. Layering Rules
+
+- [ ] 7.1 Sprite (bottom)
+- [ ] 7.2 Armor pip ring (above sprite)
+- [ ] 7.3 Ammo explosion aura (above pips)
+- [ ] 7.4 Heat glow (above aura, unless shutdown)
+- [ ] 7.5 Shutdown overlay (overrides heat glow entirely)
+- [ ] 7.6 Startup pulse (transient, above shutdown overlay)
+- [ ] 7.7 Selection ring (always top)
+
+## 8. Reduced Motion
+
+- [ ] 8.1 Detect `prefers-reduced-motion: reduce`
+- [ ] 8.2 HeatGlow collapses to a static colored outline matching the
+      current threshold (no pulse)
+- [ ] 8.3 Shutdown overlay removes flicker
+- [ ] 8.4 Startup pulse becomes a single color snap
+- [ ] 8.5 Ammo explosion aura becomes a static ring
+
+## 9. Accessibility
+
+- [ ] 9.1 Heat thresholds use both color and a textual badge ("HOT",
+      "OVERHEAT", "CRITICAL") on the token when heat >= 15
+- [ ] 9.2 Shutdown state announces via `aria-live` region
+- [ ] 9.3 Colorblind palette uses amber -> orange -> red per heat ramp
+      (distinguishable without red-green)
+
+## 10. Tests
+
+- [ ] 10.1 Unit test: `heatVisualMap` resolves correctly at each
+      threshold
+- [ ] 10.2 Unit test: HeatGlow transitions between thresholds over
+      300ms
+- [ ] 10.3 Unit test: shutdown overlay desaturates the sprite
+- [ ] 10.4 Unit test: startup pulse plays once per restart
+- [ ] 10.5 Integration test: heat climbs from 0 to 22; glow progresses
+      through thresholds; at 22, ammo explosion aura activates
+- [ ] 10.6 Integration test: reduced-motion mode renders static
+      outlines only
+
+## 11. Spec Compliance
+
+- [ ] 11.1 Every requirement in `tactical-map-interface` delta has a
+      GIVEN/WHEN/THEN scenario
+- [ ] 11.2 Every requirement in `heat-overflow-effects` delta has a
+      scenario
+- [ ] 11.3 `openspec validate add-heat-and-shutdown-visual-indicators
+    --strict` passes clean

--- a/openspec/changes/add-heat-and-shutdown-visual-indicators/tasks.md
+++ b/openspec/changes/add-heat-and-shutdown-visual-indicators/tasks.md
@@ -97,4 +97,4 @@
 - [ ] 11.2 Every requirement in `heat-overflow-effects` delta has a
       scenario
 - [ ] 11.3 `openspec validate add-heat-and-shutdown-visual-indicators
-    --strict` passes clean
+--strict` passes clean

--- a/openspec/changes/add-infantry-battle-value/proposal.md
+++ b/openspec/changes/add-infantry-battle-value/proposal.md
@@ -1,0 +1,33 @@
+# Change: Add Infantry Battle Value
+
+## Why
+
+Conventional infantry BV currently returns 0, misstating contract payouts and scenario balance whenever infantry are on the board. This change adds infantry BV 2.0 computation per TechManual, scaling per trooper, armor kit, weapons, field gun (if any), motive, and anti-mech training. Depends on `add-infantry-construction` for legal inputs.
+
+## What Changes
+
+- Add per-trooper BV = (primary weapon BV / damageDivisor) × 1.0 + secondary contribution + armor kit modifier
+- Add platoon BV = perTrooperBV × troopers × motiveMultiplier
+- Add field gun BV: mech-scale weapon BV × 1.0 (the gun keeps full BV value) + ammo BV
+- Add anti-mech training multiplier: 1.1× final BV
+- Add armor kit modifier per kit type (Flak +5%, Camo +10%, Sneak Camo +15%, etc.)
+- Add motive multiplier: Foot 1.0, Jump 1.1, Motorized 1.05, Mechanized 1.15
+- Add pilot skill multiplier using shared table
+- Expose breakdown on unit
+- Add parity harness vs MegaMekLab canonical infantry
+
+## Non-goals
+
+- Civilian infantry BV (non-combatants)
+- Partisan / irregular modifications
+
+## Dependencies
+
+- **Requires**: `add-infantry-construction`, `battle-value-system`
+- **Blocks**: `add-infantry-combat-behavior`
+
+## Impact
+
+- **Affected specs**: `battle-value-system` (MODIFIED — infantry path), `infantry-unit-system` (ADDED — BV breakdown)
+- **Affected code**: `src/utils/construction/infantry/infantryBV.ts` (new), `src/utils/construction/battleValueCalculations.ts` (dispatch), infantry status bar (new)
+- **Validation target**: ≥ 90% within 5% vs canonical infantry platoons

--- a/openspec/changes/add-infantry-battle-value/specs/battle-value-system/spec.md
+++ b/openspec/changes/add-infantry-battle-value/specs/battle-value-system/spec.md
@@ -1,0 +1,73 @@
+# battle-value-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Infantry BV Dispatch
+
+The BV calculator SHALL route `IInfantryUnit` inputs to an infantry-specific calculation path.
+
+#### Scenario: Infantry dispatch
+
+- **GIVEN** an infantry platoon
+- **WHEN** `calculateBattleValue` is called
+- **THEN** the infantry calculator SHALL be invoked
+- **AND** the return SHALL include an `IInfantryBVBreakdown`
+
+### Requirement: Infantry Per-Trooper BV
+
+Infantry per-trooper BV SHALL combine primary weapon, secondary weapon (ratio-adjusted), and armor kit modifier.
+
+#### Scenario: Primary weapon contribution
+
+- **GIVEN** a trooper with primary Laser Rifle (BV 12, damageDivisor 1.0)
+- **WHEN** per-trooper BV is computed
+- **THEN** primary contribution SHALL equal `12 / 1.0 = 12`
+
+#### Scenario: Secondary ratio scaling
+
+- **GIVEN** a platoon with secondary SRM Launcher (BV 25) at ratio 1-per-4
+- **WHEN** per-trooper secondary is computed
+- **THEN** secondary contribution SHALL equal `25 × (1 / 4) = 6.25`
+
+#### Scenario: Armor kit modifier
+
+- **GIVEN** a trooper wearing Sneak Camo
+- **WHEN** per-trooper BV is computed
+- **THEN** an additional 3 BV SHALL be added from the kit modifier
+
+### Requirement: Infantry Platoon BV with Motive Multiplier
+
+Infantry platoon BV SHALL scale by trooper count with a motive-type multiplier.
+
+#### Scenario: Foot platoon BV
+
+- **GIVEN** a 28-trooper Foot platoon with perTrooperBV 15
+- **WHEN** platoon BV is computed
+- **THEN** platoonBV SHALL equal `15 × 28 × 1.0 = 420`
+
+#### Scenario: Mechanized multiplier
+
+- **GIVEN** a 20-trooper Mechanized-Tracked platoon with perTrooperBV 20
+- **WHEN** platoon BV is computed
+- **THEN** platoonBV SHALL equal `20 × 20 × 1.15 = 460`
+
+### Requirement: Infantry Anti-Mech Training Multiplier
+
+Platoons with anti-mech training SHALL have final BV multiplied by 1.1.
+
+#### Scenario: Anti-mech trained platoon
+
+- **GIVEN** an anti-mech-trained Foot platoon with platoonBV 420
+- **WHEN** final BV is computed (before pilot multiplier)
+- **THEN** BV SHALL equal `420 × 1.1 = 462`
+
+### Requirement: Infantry Field Gun BV Addition
+
+A field gun's BV SHALL be added to the platoon BV using the mech-scale equipment resolver.
+
+#### Scenario: AC/5 field gun
+
+- **GIVEN** a Foot platoon crewing an AC/5 field gun with 20 rounds of ammo
+- **WHEN** BV is computed
+- **THEN** field gun contribution SHALL equal `AC/5 BV (70) + ammo BV` per catalog
+- **AND** this SHALL be added to platoonBV before pilot multiplier

--- a/openspec/changes/add-infantry-battle-value/specs/infantry-unit-system/spec.md
+++ b/openspec/changes/add-infantry-battle-value/specs/infantry-unit-system/spec.md
@@ -1,0 +1,30 @@
+# infantry-unit-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Infantry BV Breakdown on Unit State
+
+Every infantry platoon SHALL carry an `IInfantryBVBreakdown` populated by the calculator.
+
+#### Scenario: Breakdown shape
+
+- **GIVEN** an infantry platoon after construction completes
+- **WHEN** BV is computed
+- **THEN** `unit.bvBreakdown` SHALL contain `perTrooper`, `motiveMultiplier`, `antiMechMultiplier`, `fieldGunBV`, `platoonBV`, `pilotMultiplier`, `final`
+
+#### Scenario: Breakdown live update
+
+- **GIVEN** an existing platoon with BV 420
+- **WHEN** the user toggles Anti-Mech training on
+- **THEN** `unit.bvBreakdown.antiMechMultiplier` SHALL become 1.1
+- **AND** `unit.bvBreakdown.final` SHALL update live
+
+### Requirement: Infantry BV Parity Harness
+
+The validation tooling SHALL produce an infantry BV parity report.
+
+#### Scenario: Validator output
+
+- **WHEN** the infantry BV validator runs
+- **THEN** it SHALL emit `validation-output/infantry-bv-validation-report.json`
+- **AND** the report SHALL list each platoon with `computedBV`, `mulBV`, `delta`, `deltaPct`

--- a/openspec/changes/add-infantry-battle-value/tasks.md
+++ b/openspec/changes/add-infantry-battle-value/tasks.md
@@ -1,0 +1,51 @@
+# Tasks: Add Infantry Battle Value
+
+## 1. Calculator Scaffolding
+
+- [ ] 1.1 Create `src/utils/construction/infantry/infantryBV.ts`
+- [ ] 1.2 Export `calculateInfantryBV(unit: IInfantryUnit): IInfantryBVBreakdown`
+- [ ] 1.3 Wire dispatch in `battleValueCalculations.ts`
+- [ ] 1.4 Define `IInfantryBVBreakdown`
+
+## 2. Per-Trooper BV
+
+- [ ] 2.1 primaryBV = primaryWeapon.bv / primaryWeapon.damageDivisor
+- [ ] 2.2 secondaryBV = (secondaryWeapon.bv / secondaryWeapon.damageDivisor) × (1 / ratio) (e.g., 1-per-4 divides by 4)
+- [ ] 2.3 armorKitBV = armorKit modifier table (Flak 2, Camo 1, Sneak-Camo 3, etc.)
+- [ ] 2.4 perTrooperBV = primaryBV + secondaryBV + armorKitBV
+
+## 3. Platoon BV
+
+- [ ] 3.1 platoonBV = perTrooperBV × totalTroopers × motiveMultiplier
+- [ ] 3.2 motiveMultiplier: Foot 1.0, Jump 1.1, Motorized 1.05, Mechanized 1.15
+- [ ] 3.3 If anti-mech training: multiply platoonBV by 1.1
+- [ ] 3.4 If field gun: add field gun BV (full mech-scale BV + ammo)
+
+## 4. Field Gun BV
+
+- [ ] 4.1 Resolve field gun weapon BV via existing equipment resolver
+- [ ] 4.2 Add ammo BV
+- [ ] 4.3 Apply speed factor 1.0 (infantry field guns don't move at combat speeds)
+- [ ] 4.4 Field gun counts only when field gun is present
+
+## 5. Pilot Skill Multiplier
+
+- [ ] 5.1 Apply shared gunnery × piloting table
+- [ ] 5.2 finalBV = platoonBV × pilotMult
+
+## 6. Status Bar
+
+- [ ] 6.1 Extend infantry status bar to show perTrooperBV, platoonBV, field gun BV, final
+- [ ] 6.2 Breakdown dialog with motive / armor / training multipliers
+
+## 7. Parity Harness
+
+- [ ] 7.1 Load canonical infantry platoons (Foot, Jump, Motorized, Mechanized samples)
+- [ ] 7.2 Compare against MegaMekLab BV values
+- [ ] 7.3 Emit `validation-output/infantry-bv-validation-report.json`
+
+## 8. Validation
+
+- [ ] 8.1 `openspec validate add-infantry-battle-value --strict`
+- [ ] 8.2 Unit tests: Foot Rifle Platoon, Jump SRM Platoon, Mechanized MG, Field Gun AC/5 platoon
+- [ ] 8.3 Build + lint clean

--- a/openspec/changes/add-infantry-combat-behavior/proposal.md
+++ b/openspec/changes/add-infantry-combat-behavior/proposal.md
@@ -1,0 +1,36 @@
+# Change: Add Infantry Combat Behavior
+
+## Why
+
+Conventional infantry take damage via platoon attrition (troopers lost per hit) rather than through a location / structure chain, and their own attacks apply damage using the TW damage divisor table (anti-infantry weapons double damage vs infantry, many weapons halve). The Phase 1 damage pipeline knows none of this. This change teaches the engine how to damage an infantry platoon, how the platoon returns fire using primary/secondary weapon-per-squad math, and how field gun firing works.
+
+## What Changes
+
+- Add platoon combat state: surviving troopers, morale, field-gun-operational flag, pinned flag, anti-mech attack committed flag
+- Add infantry damage pipeline: incoming damage × damage divisor (per TW weapon table vs infantry) → troopers killed = damage (after modifiers) / trooperArmorValue
+- Add platoon firing resolution: attacks hit single target; weapon damage scales with surviving troopers; damage divisor for target type (infantry vs mech) applied
+- Add field gun firing: field gun fires as a mech-scale weapon at mech-scale damage (one shot per turn)
+- Add anti-infantry weapons: flamer, machine gun, burst-fire weapons apply doubled damage
+- Add morale rule: when platoon < 25% strength, platoon must make a morale check; fail → pinned (no firing) or routed (flee)
+- Add pinned state: skip firing and movement next phase
+- Add infantry leg / swarm attack (if anti-mech trained) — simplified version of BA leg attack
+- Add cover bonus: infantry in woods / buildings / hull-down gets to-hit penalty for attacker (−1 woods, −2 buildings, −3 hardened)
+- Add field gun crew damage: when field gun is hit, lose 1 crew per 2 damage
+- Emit events: `InfantryCasualties`, `InfantryMoraleCheck`, `InfantryPinned`, `InfantryRouted`, `FieldGunFired`, `FieldGunDestroyed`
+
+## Non-goals
+
+- Urban fighting rules (room-by-room)
+- Cavalry / mounted rules (beyond Motorized/Mechanized)
+- Civilian infantry (non-combatants)
+
+## Dependencies
+
+- **Requires**: `add-infantry-construction`, `add-infantry-battle-value`, `integrate-damage-pipeline`, `wire-heat-generation-and-effects`
+- **Blocks**: full combined-arms play
+
+## Impact
+
+- **Affected specs**: `combat-resolution` (MODIFIED — infantry path), `damage-system` (MODIFIED — damage divisor + trooper attrition), `infantry-unit-system` (ADDED — combat state + morale)
+- **Affected code**: `src/utils/gameplay/infantryDamage.ts` (new), `src/utils/gameplay/infantryMorale.ts` (new), `src/utils/gameplay/fieldGunFire.ts` (new), `src/engine/GameEngine.ts` (dispatch)
+- **New events**: `InfantryCasualties`, `InfantryMoraleCheck`, `InfantryPinned`, `InfantryRouted`, `FieldGunFired`, `FieldGunDestroyed`

--- a/openspec/changes/add-infantry-combat-behavior/specs/combat-resolution/spec.md
+++ b/openspec/changes/add-infantry-combat-behavior/specs/combat-resolution/spec.md
@@ -1,0 +1,133 @@
+# combat-resolution (delta)
+
+## ADDED Requirements
+
+### Requirement: Infantry Combat Dispatch
+
+The combat resolution engine SHALL route infantry targets to an infantry-specific damage pipeline.
+
+#### Scenario: Infantry target routing
+
+- **GIVEN** an attack whose target has `unitType === UnitType.INFANTRY`
+- **WHEN** the engine resolves the hit
+- **THEN** `infantryResolveDamage()` SHALL be invoked
+- **AND** damage SHALL convert to trooper casualties after applying the weapon damage divisor
+
+#### Scenario: No mech-style criticals on infantry
+
+- **GIVEN** damage applied to an infantry platoon
+- **WHEN** critical-hit resolution runs
+- **THEN** mech-style crit slot effects SHALL NOT be computed
+
+### Requirement: Infantry Damage Divisor
+
+Incoming damage on infantry SHALL be multiplied by the weapon's anti-infantry divisor before converting to casualties.
+
+#### Scenario: Flamer doubles damage
+
+- **GIVEN** a Flamer dealing 2 damage base to an infantry platoon
+- **WHEN** effective damage is computed
+- **THEN** effective damage SHALL equal `2 × 2 = 4`
+
+#### Scenario: Machine Gun doubles damage
+
+- **GIVEN** an MG dealing 2 damage base to infantry
+- **WHEN** effective damage is computed
+- **THEN** effective damage SHALL equal `2 × 2 = 4`
+
+#### Scenario: PPC baseline on infantry
+
+- **GIVEN** a PPC dealing 10 damage base to infantry
+- **WHEN** effective damage is computed
+- **THEN** effective damage SHALL equal 10 (multiplier 1.0)
+
+### Requirement: Infantry Casualties from Effective Damage
+
+The system SHALL convert effective damage to casualties using trooper resilience.
+
+#### Scenario: Simple casualty math
+
+- **GIVEN** a 28-trooper Foot platoon with trooper resilience 1 (no Flak)
+- **WHEN** effective damage of 5 is applied
+- **THEN** 5 troopers SHALL die
+- **AND** `survivingTroopers` SHALL become 23
+- **AND** an `InfantryCasualties` event SHALL fire
+
+#### Scenario: Flak reduces ballistic damage
+
+- **GIVEN** the same platoon wearing Flak kit taking 10 effective ballistic damage
+- **WHEN** casualties are computed
+- **THEN** ballistic damage SHALL be divided by 2 per Flak rule, yielding 5 casualties
+
+### Requirement: Infantry Morale Rule
+
+When a platoon drops below 25% of starting strength, the system SHALL roll morale.
+
+#### Scenario: Morale check trigger
+
+- **GIVEN** a 28-trooper Foot platoon reduced to 6 troopers (below 25% = 7)
+- **WHEN** the Casualties event fires
+- **THEN** an `InfantryMoraleCheck` SHALL be queued
+
+#### Scenario: Failed morale → pinned
+
+- **GIVEN** a morale check that fails by 1 (e.g., rolls 7 vs TN 8)
+- **WHEN** the result is applied
+- **THEN** `InfantryPinned` SHALL fire
+- **AND** the platoon SHALL skip firing and movement next phase
+
+#### Scenario: Failed morale by 2+ → routed
+
+- **GIVEN** a morale check that fails by 3 or more
+- **WHEN** the result is applied
+- **THEN** `InfantryRouted` SHALL fire
+- **AND** the platoon SHALL retreat off-board and no longer participate in combat
+
+### Requirement: Field Gun Firing
+
+Field guns SHALL fire once per turn at the gun's mech-scale damage, consuming ammo.
+
+#### Scenario: AC/5 field gun fires
+
+- **GIVEN** a platoon crewing an AC/5 field gun with 10 rounds
+- **WHEN** the field gun fires
+- **THEN** damage to the target SHALL equal the AC/5 catalog damage
+- **AND** ammo SHALL decrement by 1
+- **AND** `FieldGunFired` SHALL fire
+
+#### Scenario: Field gun cannot fire when pinned
+
+- **GIVEN** a pinned platoon
+- **WHEN** the field gun firing option is evaluated
+- **THEN** firing SHALL be disallowed
+
+## MODIFIED Requirements
+
+### Requirement: Damage Distribution
+
+The system SHALL distribute damage across units based on battle intensity and outcome.
+
+#### Scenario: Victory results in light damage
+
+- **GIVEN** a battle with outcome VICTORY and 4 player units
+- **WHEN** distributeDamage is called
+- **THEN** units receive 0-30% damage on average
+
+#### Scenario: Defeat results in heavy damage
+
+- **GIVEN** a battle with outcome DEFEAT and 4 player units
+- **WHEN** distributeDamage is called
+- **THEN** units receive 40-80% damage on average
+
+#### Scenario: Draw results in moderate damage
+
+- **GIVEN** a battle with outcome DRAW and 4 player units
+- **WHEN** distributeDamage is called
+- **THEN** units receive 20-50% damage on average
+
+#### Scenario: Routed infantry surviving at 0 combat strength
+
+- **GIVEN** a battle where an infantry platoon routed off-board
+- **WHEN** distributeDamage is called
+- **THEN** the routed platoon SHALL count as surviving-but-withdrawn (not wrecked)
+- **AND** only actual casualties SHALL be recorded

--- a/openspec/changes/add-infantry-combat-behavior/specs/infantry-unit-system/spec.md
+++ b/openspec/changes/add-infantry-combat-behavior/specs/infantry-unit-system/spec.md
@@ -1,0 +1,41 @@
+# infantry-unit-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Infantry Platoon Combat State
+
+Each infantry platoon SHALL carry combat state tracked across the battle.
+
+#### Scenario: Combat state initialization
+
+- **GIVEN** a 28-trooper Foot platoon entering combat
+- **WHEN** combat state is initialized
+- **THEN** `unit.combatState.platoon.survivingTroopers` SHALL equal 28
+- **AND** `morale = "normal"`, `pinned = false`, `routed = false`
+- **AND** `fieldGunOperational` SHALL reflect whether the field gun is present and crewed
+- **AND** `antiMechCommitted` SHALL be `false`
+
+#### Scenario: State after casualties
+
+- **GIVEN** the same platoon after taking 15 casualties
+- **WHEN** combat state is read
+- **THEN** `survivingTroopers` SHALL equal 13
+- **AND** casualties past 75% SHALL have triggered a morale check
+
+### Requirement: Field Gun Crew Damage
+
+Field gun crew SHALL share in platoon damage; per 2 points of kit-adjusted damage, 1 crew is lost.
+
+#### Scenario: Field gun crew casualty
+
+- **GIVEN** an AC/5 field gun with 3 crew, operated by an otherwise-20-trooper platoon
+- **WHEN** 4 kit-adjusted damage hits the field gun hex
+- **THEN** 2 field gun crew SHALL die
+- **AND** field gun remains operational (1 crew left)
+
+#### Scenario: Field gun destroyed
+
+- **GIVEN** a 3-crew field gun where all 3 die
+- **WHEN** the final crew death event fires
+- **THEN** `FieldGunDestroyed` SHALL fire
+- **AND** the field gun SHALL no longer be a firing option

--- a/openspec/changes/add-infantry-combat-behavior/tasks.md
+++ b/openspec/changes/add-infantry-combat-behavior/tasks.md
@@ -1,0 +1,88 @@
+# Tasks: Add Infantry Combat Behavior
+
+## 1. Unit-Type Dispatch
+
+- [ ] 1.1 Route `resolveDamage()` to `infantryResolveDamage()` when target is `IInfantryUnit`
+- [ ] 1.2 Route attack declaration for infantry to use squad / field gun fire resolution
+- [ ] 1.3 No critical hits for infantry (skip `resolveCriticalHits` on infantry target)
+
+## 2. Platoon Combat State
+
+- [ ] 2.1 Initialize `unit.combatState.platoon.survivingTroopers = totalTroopers`
+- [ ] 2.2 `morale`, `pinned`, `routed`, `fieldGunOperational`, `antiMechCommitted`
+- [ ] 2.3 State updates on every damage event
+
+## 3. Damage Divisor Table
+
+- [ ] 3.1 Load per-weapon anti-infantry multiplier table (TW Chapter Infantry)
+- [ ] 3.2 Flamer × 2, MG × 2, Burst-Fire × 1.5 on infantry
+- [ ] 3.3 Standard Autocannon × 1, PPC × 1 (effective damage divided by infantry divisor tool)
+- [ ] 3.4 Large Laser × 1 standard, Small Laser × 1
+- [ ] 3.5 Explosion / Inferno rounds apply doubled damage
+
+## 4. Damage → Casualties Conversion
+
+- [ ] 4.1 For each incoming attack, compute effective damage = raw × weapon multiplier
+- [ ] 4.2 Subtract armor kit defense (Flak divides ballistic damage by 2 per TW)
+- [ ] 4.3 casualties = ceil(effective / trooperResilience)
+- [ ] 4.4 `survivingTroopers -= casualties` (clamped ≥ 0)
+- [ ] 4.5 Emit `InfantryCasualties` event with casualties count
+
+## 5. Morale Rule
+
+- [ ] 5.1 When survivingTroopers drops below 25% of starting, trigger morale check
+- [ ] 5.2 Roll 2d6 vs TN 8 + leader modifier
+- [ ] 5.3 Success: keep fighting
+- [ ] 5.4 Fail by 1: pinned (no firing next phase)
+- [ ] 5.5 Fail by 2+: routed (retreat off-board, no more firing)
+- [ ] 5.6 Emit `InfantryMoraleCheck` + `InfantryPinned` / `InfantryRouted` events
+
+## 6. Platoon Fire Resolution
+
+- [ ] 6.1 Effective firepower = primary + secondary scaled by surviving troopers
+- [ ] 6.2 Compute weapon damage using infantry firepower formula: `damage = troopers × weaponRating / divisor`
+- [ ] 6.3 Troopers firing field gun do NOT contribute personal weapons
+- [ ] 6.4 Apply to-hit modifiers for infantry cover (woods / building / hull-down)
+
+## 7. Field Gun Firing
+
+- [ ] 7.1 Field gun fires as a single mech-scale weapon at its listed BV/damage/range
+- [ ] 7.2 One shot per turn (field guns cannot continuous-fire without reloading)
+- [ ] 7.3 Ammo tracked; 0 ammo → cannot fire
+- [ ] 7.4 When platoon is pinned or routed, field gun cannot fire
+- [ ] 7.5 Emit `FieldGunFired` with target, damage, and range
+
+## 8. Field Gun Damage
+
+- [ ] 8.1 When the field gun's hex is attacked, crew take damage alongside platoon
+- [ ] 8.2 Every 2 damage past kit absorption kills 1 field gun crew
+- [ ] 8.3 If all field gun crew are dead, field gun is destroyed
+- [ ] 8.4 Emit `FieldGunDestroyed` event
+
+## 9. Anti-Mech Leg / Swarm (Simplified)
+
+- [ ] 9.1 Anti-mech trained platoons may declare Leg Attack at adjacency
+- [ ] 9.2 Roll 2d6 + platoon piloting vs mech piloting + 4
+- [ ] 9.3 Success: target leg takes damage = survivingTroopers × 2
+- [ ] 9.4 Failure: platoon takes 1d6 damage (distribute via casualties table)
+- [ ] 9.5 No full swarm rule for Phase 6 (BA handles swarm; infantry leg attack is lighter)
+
+## 10. Cover and Terrain Modifiers
+
+- [ ] 10.1 Woods: attacker +1 to-hit against infantry target
+- [ ] 10.2 Light building: attacker +2; heavy building: +3; hardened: +4
+- [ ] 10.3 Hull-down terrain: +1
+- [ ] 10.4 Pass modifiers through the `to-hit-resolution` layer
+
+## 11. AI Adaptations
+
+- [ ] 11.1 Bot avoids charging infantry with mechs (mechs may get legged)
+- [ ] 11.2 Bot pushes infantry into cover
+- [ ] 11.3 Bot avoids pinned units for target priority
+
+## 12. Validation
+
+- [ ] 12.1 `openspec validate add-infantry-combat-behavior --strict`
+- [ ] 12.2 Unit tests: damage divisor application, morale check, field gun firing, anti-mech leg attack
+- [ ] 12.3 Simulation: mech vs Foot platoon scenarios
+- [ ] 12.4 Build + lint clean

--- a/openspec/changes/add-infantry-construction/proposal.md
+++ b/openspec/changes/add-infantry-construction/proposal.md
@@ -1,0 +1,39 @@
+# Change: Add Infantry Construction
+
+## Why
+
+Conventional infantry platoons show up in virtually every ground engagement as objective holders, field-gun crews, and garrison units. The existing `infantry-unit-system` spec describes platoon composition and primary/secondary weapons, but the construction pipeline does not enforce platoon strength, motive type, armor kit, field gun integration, or per-trooper weapon table math. This change completes infantry construction so Phase 6 BV and combat have a legal platoon to work with.
+
+## What Changes
+
+- Add platoon composition: number of squads × troopers per squad per TW table
+- Add motive type: Foot / Jump / Motorized / Mechanized (Tracked/Wheeled/Hover/VTOL)
+- Add armor kit (Standard / Flak / Camo / Snow / Environmental Sealing) with mass per trooper
+- Add primary / secondary weapon selection from infantry weapon table; primary applies to all troopers, secondary applies to every N troopers per pattern
+- Add range multipliers (short/medium/long) from weapon table — consumed in combat
+- Add field gun integration: platoon may crew one field gun (deck-mounted large weapon) from the allowed list; mech-scale weapon mounted on a towed cart, crew penalty while operating
+- Add ammunition allocation: per-trooper rounds, plus field-gun ammo
+- Add anti-mech training flag: enables leg/swarm attacks at combat time
+- Add construction validation rule set `VAL-INF-*` covering platoon strength, motive compatibility, armor kit validity, primary weapon legality by motive, field gun rules, ammo availability
+- Wire into infantry store and customizer tabs
+
+## Non-goals
+
+- Infantry combat (damage, morale, field gun firing) — `add-infantry-combat-behavior`
+- BV calculation — `add-infantry-battle-value`
+- Support vehicle transport (carrying capacity) — future
+
+## Dependencies
+
+- **Requires**: existing `infantry-unit-system` spec stubs, `construction-services`, `equipment-database`
+- **Blocks**: `add-infantry-battle-value`, `add-infantry-combat-behavior`
+
+## Ordering in Phase 6
+
+Infantry is fourth after vehicles, aerospace, and battlearmor.
+
+## Impact
+
+- **Affected specs**: `infantry-unit-system` (ADDED — platoon / motive / armor / weapons / field gun / validation), `construction-rules-core` (MODIFIED — dispatch infantry path), `validation-rules-master` (MODIFIED)
+- **Affected code**: `src/stores/infantry/`, `src/utils/construction/infantry/`, `src/components/customizer/infantry/*`, `src/types/infantry/`
+- **New files**: infantry weapon table, armor kit table, field gun compatibility list, infantry motive table

--- a/openspec/changes/add-infantry-construction/specs/infantry-unit-system/spec.md
+++ b/openspec/changes/add-infantry-construction/specs/infantry-unit-system/spec.md
@@ -1,0 +1,148 @@
+# infantry-unit-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Platoon Composition Defaults
+
+The system SHALL initialize a platoon composition based on motive type with defaults drawn from TechManual.
+
+#### Scenario: Foot default
+
+- **GIVEN** a new Foot-motive infantry platoon
+- **WHEN** composition is initialized
+- **THEN** `platoonComposition.squads` SHALL equal 7
+- **AND** `platoonComposition.troopersPerSquad` SHALL equal 4
+- **AND** total troopers SHALL equal 28
+
+#### Scenario: Jump default
+
+- **GIVEN** a new Jump-motive platoon
+- **WHEN** composition is initialized
+- **THEN** total troopers SHALL equal 25 (5 × 5)
+
+#### Scenario: Mechanized default
+
+- **GIVEN** a new Mechanized-Tracked platoon
+- **WHEN** composition is initialized
+- **THEN** total troopers SHALL equal 20 (4 × 5)
+
+#### Scenario: Out-of-range platoon size
+
+- **GIVEN** a platoon with 35 troopers
+- **WHEN** validation runs
+- **THEN** `VAL-INF-PLATOON` SHALL emit "platoon size 35 exceeds maximum 30"
+
+### Requirement: Motive Type Movement Points
+
+The system SHALL assign movement points based on motive type.
+
+#### Scenario: Foot MP
+
+- **GIVEN** a Foot platoon
+- **WHEN** MP is computed
+- **THEN** ground MP SHALL equal 1 and jump MP SHALL equal 0
+
+#### Scenario: Jump MP
+
+- **GIVEN** a Jump platoon
+- **WHEN** MP is computed
+- **THEN** ground MP SHALL equal 3 and jump MP SHALL equal 3
+
+#### Scenario: Mechanized Hover MP
+
+- **GIVEN** a Mechanized-Hover platoon
+- **WHEN** MP is computed
+- **THEN** ground MP SHALL equal 5
+
+#### Scenario: VTOL troop cap
+
+- **GIVEN** a Mechanized-VTOL platoon
+- **WHEN** troopers exceed 10
+- **THEN** `VAL-INF-MOTIVE` SHALL emit "VTOL motive supports up to 10 troopers"
+
+### Requirement: Armor Kit Selection
+
+The system SHALL support armor kits that modify survival and combat without adding mech-scale armor points.
+
+#### Scenario: Flak kit modifier
+
+- **GIVEN** an infantry platoon wearing Flak armor
+- **WHEN** incoming damage is computed
+- **THEN** damage divisor SHALL be applied per TW flak rules (ballistic resistance)
+
+#### Scenario: Sneak suit motive restriction
+
+- **GIVEN** a Motorized platoon
+- **WHEN** armor kit is set to Sneak Camo
+- **THEN** `VAL-INF-ARMOR-KIT` SHALL emit "Sneak suits require Foot motive"
+
+#### Scenario: Environmental Sealing enables vacuum
+
+- **GIVEN** a platoon with Environmental Sealing kit
+- **WHEN** a vacuum / underwater scenario is started
+- **THEN** the platoon SHALL be allowed to deploy
+
+### Requirement: Primary and Secondary Weapon Selection
+
+The platoon SHALL select one primary weapon (carried by every trooper) and optionally a secondary (carried by 1 per N troopers).
+
+#### Scenario: Primary weapon applied uniformly
+
+- **GIVEN** a 28-trooper Foot platoon with primary weapon Laser Rifle
+- **WHEN** squad fire is computed
+- **THEN** all 28 troopers SHALL contribute Laser Rifle damage
+
+#### Scenario: Secondary weapon ratio
+
+- **GIVEN** a 28-trooper platoon with secondary SRM Launcher at ratio 1-per-4
+- **WHEN** secondary count is computed
+- **THEN** 7 troopers SHALL carry the secondary (28 / 4)
+
+#### Scenario: Heavy primary weapon on Foot
+
+- **GIVEN** a Foot platoon
+- **WHEN** primary weapon is set to Support Heavy MG (heavy weapon)
+- **THEN** `VAL-INF-WEAPON` SHALL emit an error — heavy primary requires Mechanized / Motorized motive
+
+### Requirement: Field Gun Integration
+
+The system SHALL allow a platoon to crew one field gun from the approved list.
+
+#### Scenario: Field gun crew
+
+- **GIVEN** a 20-trooper platoon crewing an AC/5 field gun (crew 3)
+- **WHEN** effective combat-ready trooper count is computed
+- **THEN** 17 troopers SHALL contribute personal weapons
+- **AND** 3 troopers SHALL operate the field gun
+
+#### Scenario: Over-crew field gun
+
+- **GIVEN** a 5-trooper platoon with an AC/20 field gun (crew 5)
+- **WHEN** validation runs
+- **THEN** `VAL-INF-FIELD-GUN` SHALL emit "field gun crew ≥ platoon size"
+
+### Requirement: Anti-Mech Training
+
+The system SHALL support an anti-mech training flag enabling leg / swarm attacks in combat.
+
+#### Scenario: Anti-mech enabled
+
+- **GIVEN** a Foot platoon with `antiMechTraining = true`
+- **WHEN** combat options are enumerated
+- **THEN** Leg Attack and Swarm Attack SHALL be available options
+- **AND** the BV multiplier for anti-mech training SHALL be recorded for the BV calculator
+
+#### Scenario: Motorized cannot train anti-mech
+
+- **GIVEN** a Motorized platoon with `antiMechTraining = true`
+- **WHEN** validation runs
+- **THEN** `VAL-INF-ANTI-MECH` SHALL emit "anti-mech training requires Foot, Jump, or Mechanized motive"
+
+### Requirement: Infantry Construction Validation Rule Set
+
+The validation registry SHALL include the `VAL-INF-*` rule group.
+
+#### Scenario: Rule ids registered
+
+- **WHEN** the validation registry initializes
+- **THEN** `VAL-INF-PLATOON`, `VAL-INF-MOTIVE`, `VAL-INF-ARMOR-KIT`, `VAL-INF-WEAPON`, `VAL-INF-FIELD-GUN`, and `VAL-INF-ANTI-MECH` SHALL be registered

--- a/openspec/changes/add-infantry-construction/tasks.md
+++ b/openspec/changes/add-infantry-construction/tasks.md
@@ -1,0 +1,81 @@
+# Tasks: Add Infantry Construction
+
+## 1. Types and Interfaces
+
+- [ ] 1.1 Extend `IInfantryUnit` with `motiveType`, `platoonComposition`, `armorKit`, `primaryWeapon`, `secondaryWeapon?`, `fieldGun?`, `antiMechTraining`
+- [ ] 1.2 Add `InfantryMotive` enum (Foot, Jump, Motorized, MechanizedTracked, MechanizedWheeled, MechanizedHover, MechanizedVTOL)
+- [ ] 1.3 Add `ArmorKit` enum (Standard, Flak, Camo, SnowCamo, EnvironmentalSealing, SneakCamo, SneakIR, SneakECM)
+- [ ] 1.4 Add `IPlatoonComposition` interface (squads, troopersPerSquad)
+- [ ] 1.5 Add `IFieldGun` interface (weaponId, ammoRounds, crewCount)
+
+## 2. Platoon Composition
+
+- [ ] 2.1 Default Foot: 7 squads × 4 troopers (28)
+- [ ] 2.2 Default Jump: 5 squads × 5 troopers (25)
+- [ ] 2.3 Default Motorized: 7 squads × 4 troopers (28)
+- [ ] 2.4 Default Mechanized: 4 squads × 5 troopers (20)
+- [ ] 2.5 Support 1–30 troopers with warning outside defaults
+- [ ] 2.6 Validation: min 5 troopers, max 30
+
+## 3. Motive Type
+
+- [ ] 3.1 Foot: MP 1 ground
+- [ ] 3.2 Jump: MP 3 ground + 3 jump (MP 3/3)
+- [ ] 3.3 Motorized: MP 3 ground (in trucks/APC shared with platoon)
+- [ ] 3.4 Mechanized Tracked: MP 3, adds armor
+- [ ] 3.5 Mechanized Wheeled: MP 4
+- [ ] 3.6 Mechanized Hover: MP 5
+- [ ] 3.7 Mechanized VTOL: MP 6 vertical
+- [ ] 3.8 Validation: motive × platoon size compatibility (e.g., VTOL max 10 troopers per TW)
+
+## 4. Armor Kit
+
+- [ ] 4.1 Per-trooper armor modifier from kit (Flak = +1 vs ballistic, Camo = -1 to be hit in woods, etc.)
+- [ ] 4.2 Environmental Sealing enables vacuum / underwater operations
+- [ ] 4.3 Armor kit mass counted per trooper (tracked for transport weight)
+- [ ] 4.4 Sneak suits require Foot motive
+
+## 5. Weapon Table
+
+- [ ] 5.1 Load infantry weapon table (Laser Rifle, Auto Rifle, SRM Launcher, LRM Launcher, MG, Flamer, etc.)
+- [ ] 5.2 Each entry: range (S/M/L), damage divisor (per TW), ammo type, heat, special
+- [ ] 5.3 Primary weapon: all troopers carry
+- [ ] 5.4 Secondary weapon: 1 per N troopers (N = 2/3/4 from table)
+- [ ] 5.5 Validation: weapon compatible with motive (heavy weapons not Foot)
+
+## 6. Field Guns
+
+- [ ] 6.1 Optional field gun: mech-scale weapon from approved list (AC/2, AC/5, LRM-5 through LRM-20, MG, Flamer, etc.)
+- [ ] 6.2 Crew size: derived from weapon type (AC/20 needs 5 crew, LRM-5 needs 2)
+- [ ] 6.3 When crewing the gun, that many troopers do NOT fire personal weapons
+- [ ] 6.4 Ammo count stored separately
+- [ ] 6.5 Field gun tonnage does not count against mech construction — it's a deployed weapon
+
+## 7. Anti-Mech Training
+
+- [ ] 7.1 Boolean flag: `antiMechTraining = true/false`
+- [ ] 7.2 Enables leg / swarm attacks in combat (similar to BA but simpler)
+- [ ] 7.3 Adds to training cost (BV multiplier at BV calc step)
+- [ ] 7.4 Validation: only Foot / Jump / Mechanized may learn anti-mech
+
+## 8. Construction Validation Rules
+
+- [ ] 8.1 `VAL-INF-PLATOON` — platoon size within 5-30 range
+- [ ] 8.2 `VAL-INF-MOTIVE` — motive compatible with platoon size
+- [ ] 8.3 `VAL-INF-ARMOR-KIT` — kit compatible with motive (sneak → Foot)
+- [ ] 8.4 `VAL-INF-WEAPON` — weapon legal for motive
+- [ ] 8.5 `VAL-INF-FIELD-GUN` — field gun crew ≤ platoon size − 1
+- [ ] 8.6 `VAL-INF-ANTI-MECH` — training legal for motive
+
+## 9. Store and UI Wiring
+
+- [ ] 9.1 Wire `infantryStore` to persist new state
+- [ ] 9.2 Enhance `InfantryBuildTab` to expose all fields
+- [ ] 9.3 Status bar displays platoon strength, effective MP, kit modifiers
+- [ ] 9.4 Field gun section adds/edits field gun
+
+## 10. Validation
+
+- [ ] 10.1 `openspec validate add-infantry-construction --strict`
+- [ ] 10.2 Fixtures: Foot Rifle Platoon, Jump SRM Platoon, Mechanized MG Platoon, Field Gun (AC/5) Platoon
+- [ ] 10.3 Build + lint clean

--- a/openspec/changes/add-interactive-combat-core-ui/proposal.md
+++ b/openspec/changes/add-interactive-combat-core-ui/proposal.md
@@ -1,0 +1,46 @@
+# Change: Add Interactive Combat Core UI
+
+## Why
+
+The game engine orchestrates the full BattleTech turn loop behind a headless
+`InteractiveSession`, and Zustand already wraps it via `useGameplayStore`,
+but there is no cohesive player-facing combat surface. Unit tokens render on
+the hex map, however selection does not bind to a right-hand action panel,
+and there is no phase/turn HUD or bottom event log tied to the session's
+event stream. This change makes the core combat screen usable: select a
+unit, see its armor, heat, weapons, SPAs, and pilot wounds; see the current
+phase and turn; watch events scroll by. Movement, attack, and damage-feedback
+UIs in later changes all plug into this surface.
+
+## What Changes
+
+- Bind token selection on `HexMapDisplay` to `useGameplayStore`'s selected
+  unit id, and route that id into the right-side action panel
+- Action panel (new) renders the selected unit's armor diagram, heat bar,
+  weapons list, SPA list, and pilot wound indicator
+- Add a top-of-screen phase tracker that shows the current phase, turn
+  number, and active side
+- Add a bottom-of-screen event log that streams `GameEvent` entries from
+  the session
+- Add facing indicator on all unit tokens (already in spec; wire it in)
+
+## Dependencies
+
+- **Requires**: `add-skirmish-setup-ui` (produces the live session rendered
+  here), `tactical-map-interface` (hex map), existing components
+  `HexMapDisplay`, `ActionBar`, `PhaseBanner`, `EventLogDisplay`,
+  `HeatTracker`, `ArmorPip`, `AmmoCounter`
+- **Required By**: `add-movement-phase-ui`, `add-attack-phase-ui`,
+  `add-damage-feedback-ui`
+
+## Impact
+
+- Affected specs: `tactical-map-interface` (ADDED — selection binding,
+  action panel contract, phase/turn HUD, event log panel)
+- Affected code: `src/pages/gameplay/games/[id].tsx` (compose the combat
+  surface), `src/components/gameplay/HexMapDisplay/` (selection state
+  binding), `src/stores/useGameplayStore.ts` (expose selected unit id + a
+  derived selected unit projection)
+- Non-goals: movement overlays (B3), weapon selector (B4), damage
+  animations (B5), victory screen (B6)
+- Database: none

--- a/openspec/changes/add-interactive-combat-core-ui/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-interactive-combat-core-ui/specs/tactical-map-interface/spec.md
@@ -1,0 +1,159 @@
+# tactical-map-interface Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Token Selection Binding
+
+The tactical map interface SHALL bind unit token selection to the gameplay
+store so that a single selected unit id drives all dependent UI surfaces
+(action panel, phase tracker, overlays).
+
+**Priority**: Critical
+
+#### Scenario: Click token selects unit
+
+- **GIVEN** a unit token on the map and no currently selected unit
+- **WHEN** the user clicks the token
+- **THEN** `useGameplayStore.selectedUnitId` SHALL equal that unit's id
+- **AND** the token SHALL render the selection ring
+- **AND** the action panel SHALL update to that unit
+
+#### Scenario: Click empty hex clears selection
+
+- **GIVEN** a currently selected unit
+- **WHEN** the user clicks an empty (non-token) hex
+- **THEN** `selectedUnitId` SHALL become `null`
+- **AND** the action panel SHALL show the empty placeholder
+
+#### Scenario: Click new token swaps selection
+
+- **GIVEN** unit A is selected
+- **WHEN** the user clicks unit B's token
+- **THEN** `selectedUnitId` SHALL equal B's id
+- **AND** exactly one token SHALL render a selection ring
+
+### Requirement: Action Panel Contract
+
+The tactical map interface SHALL expose an action panel region that, when a
+unit is selected, renders the unit's armor diagram, heat bar, weapons list,
+SPA list, and pilot wound track.
+
+**Priority**: Critical
+
+#### Scenario: Panel renders armor diagram
+
+- **GIVEN** a selected unit
+- **WHEN** the action panel renders
+- **THEN** the panel SHALL include armor pips for all eight locations
+- **AND** torso locations SHALL show both front and rear armor
+
+#### Scenario: Panel renders heat bar with thresholds
+
+- **GIVEN** a selected unit
+- **WHEN** the action panel renders
+- **THEN** the heat bar SHALL show current heat and dissipation capacity
+- **AND** tick marks SHALL label canonical thresholds 8, 13, 17, 24
+
+#### Scenario: Panel renders weapons, SPAs, pilot wounds
+
+- **GIVEN** a selected unit
+- **WHEN** the action panel renders
+- **THEN** the weapons list SHALL include every mounted weapon
+- **AND** the SPA list SHALL include every special pilot ability on the
+  assigned pilot
+- **AND** the pilot wound track SHALL show 6 pips and mark current wounds
+
+#### Scenario: Empty selection shows placeholder
+
+- **GIVEN** no unit is selected
+- **WHEN** the action panel renders
+- **THEN** the panel SHALL show the text `"Select a unit to view its status"`
+- **AND** SHALL NOT render armor, heat, weapons, SPAs, or wounds
+
+### Requirement: Phase and Turn HUD
+
+The tactical map interface SHALL render a phase-and-turn heads-up display at
+the top of the combat screen that updates reactively to session events.
+
+**Priority**: Critical
+
+#### Scenario: HUD shows current phase and turn
+
+- **GIVEN** a session in Turn 3, Weapon Attack phase, Player side active
+- **WHEN** the HUD renders
+- **THEN** it SHALL display `"Turn 3"` and `"Weapon Attack"` and
+  `"Player"`
+- **AND** the side label SHALL use the blue side color
+
+#### Scenario: HUD updates on phase_changed event
+
+- **GIVEN** the session emits `phase_changed` from Movement to Weapon Attack
+- **WHEN** the HUD re-renders
+- **THEN** the phase label SHALL change to `"Weapon Attack"`
+- **AND** the change SHALL take effect without a full page reload
+
+#### Scenario: HUD updates on turn_started event
+
+- **GIVEN** the session emits `turn_started` transitioning Turn 3 to Turn 4
+- **WHEN** the HUD re-renders
+- **THEN** the turn label SHALL change to `"Turn 4"`
+
+### Requirement: Event Log Panel
+
+The tactical map interface SHALL render an event log panel that streams
+`GameEvent` entries from the active session in reverse-chronological order.
+
+**Priority**: High
+
+#### Scenario: New event prepends to log
+
+- **GIVEN** the session appends an event of type `damage_applied`
+- **WHEN** the event log panel re-renders
+- **THEN** a new entry SHALL appear at the top of the list
+- **AND** the entry SHALL display the phase, the actor's designation, and a
+  one-line human summary
+
+#### Scenario: Log scroll anchors to newest
+
+- **GIVEN** the event log already has 50 entries and the user has not
+  scrolled
+- **WHEN** a new event is appended
+- **THEN** the scroll position SHALL snap to the top (newest)
+- **AND** the previous entry SHALL remain visible below
+
+#### Scenario: Log filters by phase (scaffolded)
+
+- **GIVEN** filter state `{phase: GamePhase.Movement}`
+- **WHEN** the event log panel renders
+- **THEN** entries from other phases SHALL be hidden
+- **AND** with filter state `null`, all entries SHALL be visible
+
+### Requirement: Unit Token Facing Indicator Binding
+
+Every unit token on the tactical map SHALL render a facing arrow that
+matches the unit's current `Facing` value and SHALL update whenever the
+session emits a `facing_changed` event.
+
+**Priority**: High
+
+#### Scenario: Facing arrow matches unit state
+
+- **GIVEN** a unit with `facing = Facing.NorthEast`
+- **WHEN** the token renders
+- **THEN** the arrow SHALL point Northeast (60°)
+
+#### Scenario: Facing arrow reacts to facing_changed
+
+- **GIVEN** the session emits `facing_changed` setting a unit's facing to
+  `Facing.South`
+- **WHEN** the token re-renders
+- **THEN** the arrow SHALL point downward (180°)
+
+#### Scenario: Destroyed units retain last facing
+
+- **GIVEN** a unit transitions to destroyed
+- **WHEN** the token re-renders
+- **THEN** the facing arrow SHALL continue to point to the last recorded
+  facing
+- **AND** the token SHALL display its destroyed visual treatment (gray +
+  red X)

--- a/openspec/changes/add-interactive-combat-core-ui/tasks.md
+++ b/openspec/changes/add-interactive-combat-core-ui/tasks.md
@@ -1,0 +1,101 @@
+# Tasks: Add Interactive Combat Core UI
+
+## 1. Combat Page Layout
+
+- [ ] 1.1 `/gameplay/games/[id]` renders a three-pane layout: top phase
+      tracker, center map, right action panel
+- [ ] 1.2 Bottom event log is its own pane below the map
+- [ ] 1.3 Layout is responsive: action panel collapses on widths < 1024px
+      into a drawer
+
+## 2. Selection State Wiring
+
+- [ ] 2.1 Clicking a unit token on `HexMapDisplay` sets
+      `useGameplayStore.selectedUnitId`
+- [ ] 2.2 Clicking an empty hex clears selection
+- [ ] 2.3 Selected token renders the existing yellow selection ring
+- [ ] 2.4 Store exposes a derived `selectedUnit` projection (full
+      `IGameUnit` record) so the action panel doesn't re-select by id
+
+## 3. Token Facing Indicator
+
+- [ ] 3.1 Every unit token renders its facing arrow per `Facing` enum
+- [ ] 3.2 Facing arrow updates reactively when the session emits a
+      `facing_changed` event
+- [ ] 3.3 Destroyed units still render their last-known facing
+
+## 4. Action Panel — Frame
+
+- [ ] 4.1 With no unit selected, panel shows placeholder
+      `"Select a unit to view its status"`
+- [ ] 4.2 With a unit selected, panel header shows designation, chassis,
+      tonnage, controlling side badge
+- [ ] 4.3 Panel scrolls independently of the map
+
+## 5. Action Panel — Armor Diagram
+
+- [ ] 5.1 Reuse existing `ArmorPip` to render per-location armor and
+      internal structure
+- [ ] 5.2 Diagram shows both front and rear armor for torso locations
+- [ ] 5.3 Destroyed locations render in gray with a strike-through
+
+## 6. Action Panel — Heat Bar
+
+- [ ] 6.1 Reuse existing `HeatTracker` to render current heat vs.
+      dissipation
+- [ ] 6.2 Heat thresholds (8/13/17/24) render as tick marks with labels
+- [ ] 6.3 Current heat bar color shifts red past 13 per canonical scale
+
+## 7. Action Panel — Weapons List
+
+- [ ] 7.1 List every weapon on the unit with name, location, short/med/long
+      range, damage, heat
+- [ ] 7.2 Reuse existing `AmmoCounter` inline for ammo-consuming weapons
+- [ ] 7.3 Destroyed or jammed weapons render disabled with status badge
+
+## 8. Action Panel — SPA List
+
+- [ ] 8.1 List the pilot's Special Pilot Abilities by name
+- [ ] 8.2 Each SPA shows a short description tooltip on hover
+- [ ] 8.3 Empty list renders `"No SPAs"` placeholder
+
+## 9. Action Panel — Pilot Wounds
+
+- [ ] 9.1 Show pilot name, gunnery, piloting, consciousness state
+- [ ] 9.2 Wound track renders 6 pips; filled pips indicate current wounds
+- [ ] 9.3 Unconscious pilots render a red banner over the wound track
+
+## 10. Phase Tracker
+
+- [ ] 10.1 Reuse `PhaseBanner` to show current phase name
+- [ ] 10.2 Banner shows turn number (`Turn N`) beside phase name
+- [ ] 10.3 Banner shows active side with the same side color used on tokens
+- [ ] 10.4 Banner updates when session emits `phase_changed` or
+      `turn_started`
+
+## 11. Event Log Panel
+
+- [ ] 11.1 Reuse `EventLogDisplay` bound to session's full event stream
+- [ ] 11.2 Newest event appears at the top; list auto-scrolls to top on
+      append
+- [ ] 11.3 Each entry shows phase, actor (unit designation when
+      applicable), one-line human summary
+- [ ] 11.4 Filters (future): entries can be filtered by phase — scaffold
+      the filter state but surface is not required this change
+
+## 12. Integration Tests
+
+- [ ] 12.1 Clicking two different tokens in sequence swaps the action
+      panel content
+- [ ] 12.2 Emitting a phase change from the session advances the phase
+      tracker
+- [ ] 12.3 Emitting a damage event adds an event log entry
+- [ ] 12.4 Resizing the viewport below 1024px collapses the action panel
+      into a drawer
+
+## 13. Spec Compliance
+
+- [ ] 13.1 Every requirement in the `tactical-map-interface` delta has at
+      least one GIVEN/WHEN/THEN scenario
+- [ ] 13.2 `openspec validate add-interactive-combat-core-ui --strict`
+      passes clean

--- a/openspec/changes/add-los-and-firing-arc-overlays/proposal.md
+++ b/openspec/changes/add-los-and-firing-arc-overlays/proposal.md
@@ -1,0 +1,54 @@
+# Change: Add LOS and Firing Arc Overlays
+
+## Why
+
+Players need two tactical answers constantly: "what can I shoot from
+here?" and "can I actually see that target?" The engine has both firing
+arcs and line-of-sight math, but the UI exposes neither. Players guess,
+click, get an unexpected to-hit modifier, and then backtrack. Phase 7
+surfaces this as visible overlays: when a unit is selected, the three
+firing arcs shade the map; when a target is hovered, a colored LOS line
+shows clear / partial / blocked.
+
+## What Changes
+
+- When a friendly unit is selected, render hex-shading for its firing
+  arcs: front 60 degrees green, left/right side 60 degrees yellow, rear
+  60 degrees red-pink
+- Arc shading only shows for hexes within weapon range + with any
+  eligible weapon
+- When hovering a target hex, draw an LOS line from selected unit to
+  target
+  - Solid green: clear LOS (no cover)
+  - Dashed yellow: partial cover (woods, hull-down target)
+  - Red: fully blocked (wall, height, heavy woods occlusion)
+- LOS line annotates the blocking hex(es) when partial or blocked
+- Arc / LOS overlays toggle off when no unit is selected or during an
+  animation
+
+## Dependencies
+
+- **Requires**: `add-interactive-combat-core-ui` (selection + phase
+  HUD), `firing-arc-calculation`, `tactical-map-interface`, existing
+  LOS logic in the engine
+- **Related**: `add-attack-phase-ui` (attacker selection consumes the
+  same arcs), `add-terrain-rendering` (LOS blocking logic depends on
+  terrain states)
+- **Required By**: none — Phase 7 presentation layer
+
+## Impact
+
+- Affected specs: `firing-arc-calculation` (MODIFIED — expose UI-ready
+  per-hex arc classification), `tactical-map-interface` (MODIFIED —
+  new arc shading + LOS line overlay), new `line-of-sight-visualization`
+  (ADDED — LOS line states, blocking annotations, color grammar)
+- Affected code: new
+  `src/components/gameplay/overlays/FiringArcOverlay.tsx`, new
+  `src/components/gameplay/overlays/LineOfSightOverlay.tsx`, new
+  `src/utils/overlays/arcClassifier.ts` that labels each hex as
+  front/side/rear for the selected unit, new `losClassifier.ts`
+  returning clear/partial/blocked with blocking hex refs
+- Non-goals: multi-target LOS preview (single hover at a time),
+  indirect-fire arcs (separate change in future), 3D LOS visualization
+  (shelved)
+- Database: none

--- a/openspec/changes/add-los-and-firing-arc-overlays/specs/firing-arc-calculation/spec.md
+++ b/openspec/changes/add-los-and-firing-arc-overlays/specs/firing-arc-calculation/spec.md
@@ -1,0 +1,34 @@
+# firing-arc-calculation Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: Per-Hex Arc Classification For UI
+
+The firing arc system SHALL expose a per-hex classifier that returns
+`front | left-side | right-side | rear | out-of-arc` so the UI can
+shade a unit's arcs without reimplementing the arc math.
+
+#### Scenario: Arc classifier returns front for forward wedge
+
+- **GIVEN** a unit at position (0,0) facing 0 (north)
+- **WHEN** classifying the hex directly in front
+- **THEN** the classifier SHALL return `front`
+
+#### Scenario: Arc classifier returns rear for opposite wedge
+
+- **GIVEN** a unit facing 0
+- **WHEN** classifying a hex in the rear 180-degree wedge
+- **THEN** the classifier SHALL return `rear`
+
+#### Scenario: Side arcs distinguish left from right
+
+- **GIVEN** a unit facing 0
+- **WHEN** classifying a hex to the unit's left side
+- **THEN** the classifier SHALL return `left-side`
+- **AND** a hex to the right SHALL return `right-side`
+
+#### Scenario: Out-of-map hex returns out-of-arc
+
+- **GIVEN** a target hex outside map bounds
+- **WHEN** classifying
+- **THEN** the classifier SHALL return `out-of-arc`

--- a/openspec/changes/add-los-and-firing-arc-overlays/specs/line-of-sight-visualization/spec.md
+++ b/openspec/changes/add-los-and-firing-arc-overlays/specs/line-of-sight-visualization/spec.md
@@ -1,0 +1,90 @@
+# line-of-sight-visualization Specification Delta
+
+## ADDED Requirements
+
+### Requirement: LOS Line State
+
+The LOS visualization SHALL render one of three states between an origin
+and target hex: clear, partial, or blocked.
+
+#### Scenario: Clear LOS renders solid green
+
+- **GIVEN** an origin and target with no intervening cover
+- **WHEN** the LOS overlay renders
+- **THEN** a solid green line SHALL render from origin to target
+- **AND** line thickness SHALL be 2px
+
+#### Scenario: Partial cover renders dashed yellow
+
+- **GIVEN** an origin and target with one light-woods hex between them
+- **WHEN** the LOS overlay renders
+- **THEN** a dashed yellow line SHALL render from origin to target
+- **AND** the partial-cover hex SHALL annotate with a cover icon
+
+#### Scenario: Blocked LOS renders red line to blocker
+
+- **GIVEN** an origin and target with a building fully occluding the
+  path
+- **WHEN** the LOS overlay renders
+- **THEN** a solid red line SHALL render from origin to the first
+  blocking hex
+- **AND** the blocker SHALL annotate with a wall icon
+- **AND** the line SHALL NOT extend past the blocker
+
+### Requirement: LOS Overlay Toggling
+
+The LOS overlay SHALL render only when a unit is selected and a hex is
+hovered, and SHALL hide when either condition no longer holds.
+
+#### Scenario: LOS line appears on hover
+
+- **GIVEN** a friendly unit is selected
+- **WHEN** the user hovers a hex within visual range
+- **THEN** an LOS line SHALL render
+- **AND** unhovering SHALL clear the line
+
+#### Scenario: LOS line hides during animation
+
+- **GIVEN** a movement animation is active
+- **WHEN** the user hovers a hex
+- **THEN** no LOS line SHALL render
+- **AND** hovering resumes after the animation completes
+
+#### Scenario: User toggle disables LOS line
+
+- **GIVEN** the user presses the LOS toggle hotkey (L)
+- **WHEN** toggled off
+- **THEN** no LOS line SHALL render regardless of hover
+- **AND** toggling back on SHALL restore hover behavior
+
+### Requirement: Blocker Annotations
+
+The LOS visualization SHALL annotate intervening hexes that provide
+partial cover or fully block the line.
+
+#### Scenario: Partial cover annotates with cover icon
+
+- **GIVEN** a partial LOS through a single light-woods hex
+- **WHEN** the overlay renders
+- **THEN** a cover icon SHALL render on that hex
+- **AND** the icon SHALL include a `<title>` for screen readers
+
+#### Scenario: Blocked LOS annotates with wall icon
+
+- **GIVEN** a blocked LOS through a building
+- **WHEN** the overlay renders
+- **THEN** a wall icon SHALL render on the blocker
+- **AND** the icon SHALL include a `<title>` for screen readers
+
+### Requirement: Accessibility Announcements
+
+LOS state transitions SHALL announce through an `aria-live` region so
+non-visual users can understand the line-of-sight resolution.
+
+#### Scenario: LOS change announces
+
+- **GIVEN** the user hovers a new hex
+- **WHEN** the LOS classifier settles
+- **THEN** an `aria-live: polite` announcement SHALL fire, e.g.,
+  "Line of sight clear" or "Partial cover through woods" or "Blocked
+  by wall"

--- a/openspec/changes/add-los-and-firing-arc-overlays/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-los-and-firing-arc-overlays/specs/tactical-map-interface/spec.md
@@ -1,0 +1,57 @@
+# tactical-map-interface Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Firing Arc Shading Overlay
+
+The tactical map interface SHALL render firing-arc shading for the
+selected unit's front, side, and rear arcs.
+
+#### Scenario: Arc colors by classification
+
+- **GIVEN** a friendly unit is selected
+- **WHEN** the arc overlay renders
+- **THEN** front-arc hexes SHALL shade green at ~25% alpha
+- **AND** left/right side hexes SHALL shade yellow at ~20% alpha
+- **AND** rear-arc hexes SHALL shade red-pink at ~25% alpha
+
+#### Scenario: Arc shading limited to weapon range
+
+- **GIVEN** a unit with maximum weapon range 12 hexes
+- **WHEN** the arc overlay renders
+- **THEN** only hexes within 12 range SHALL shade
+- **AND** hexes beyond range SHALL remain unshaded
+
+#### Scenario: Colorblind shape overlay
+
+- **GIVEN** a colorblind simulation mode
+- **WHEN** the arc overlay renders
+- **THEN** each arc SHALL include a shape overlay (up-chevron for front,
+  dot for side, minus for rear)
+- **AND** arcs SHALL remain distinguishable without color
+
+#### Scenario: Arcs hide during animation
+
+- **GIVEN** a movement animation is active
+- **WHEN** the overlay would render
+- **THEN** arc shading SHALL be suppressed
+- **AND** shading resumes after the animation completes
+
+#### Scenario: User hotkey toggles arcs
+
+- **GIVEN** the user presses the arc toggle hotkey (A)
+- **WHEN** toggled off
+- **THEN** arc shading SHALL hide regardless of selection
+- **AND** toggling back on SHALL restore arc rendering
+
+### Requirement: Line-Of-Sight Overlay Coexists With Arc Shading
+
+The tactical map interface SHALL render the LOS line on top of firing
+arc shading when both overlays are active.
+
+#### Scenario: LOS line renders above arc shading
+
+- **GIVEN** arc shading is visible and the user hovers a hex
+- **WHEN** the LOS overlay renders
+- **THEN** the LOS line SHALL render above the arc shading layer
+- **AND** the line SHALL remain legible against the shading

--- a/openspec/changes/add-los-and-firing-arc-overlays/tasks.md
+++ b/openspec/changes/add-los-and-firing-arc-overlays/tasks.md
@@ -1,0 +1,111 @@
+# Tasks: Add LOS and Firing Arc Overlays
+
+## 1. Arc Classifier Utility
+
+- [ ] 1.1 Create `src/utils/overlays/arcClassifier.ts`
+- [ ] 1.2 Given a unit (position + facing) and a hex, return
+      `front | left-side | right-side | rear | out-of-arc`
+- [ ] 1.3 Front is the 60-degree wedge centered on facing
+- [ ] 1.4 Sides are the adjacent 60-degree wedges
+- [ ] 1.5 Rear is the 180-degree wedge opposite front (TechManual p.109)
+- [ ] 1.6 Unit tests for every facing x target direction permutation
+
+## 2. LOS Classifier Utility
+
+- [ ] 2.1 Create `src/utils/overlays/losClassifier.ts`
+- [ ] 2.2 Given origin and target hexes, return
+      `{ state: 'clear' | 'partial' | 'blocked', blockers: HexCoord[] }`
+- [ ] 2.3 Use existing engine LOS logic (do not reimplement)
+- [ ] 2.4 Partial: at least one hex adds cover but does not fully occlude
+- [ ] 2.5 Blocked: at least one hex fully occludes
+- [ ] 2.6 Unit tests across clear / woods / building / elevation cases
+
+## 3. FiringArcOverlay Component
+
+- [ ] 3.1 Create
+      `src/components/gameplay/overlays/FiringArcOverlay.tsx`
+- [ ] 3.2 Subscribes to the selected unit ID from `useGameplayStore`
+- [ ] 3.3 For each hex in the unit's maximum weapon range, shade per
+      arc classifier output
+- [ ] 3.4 Colors: front = green 25% alpha, sides = yellow 20% alpha,
+      rear = red-pink 25% alpha
+- [ ] 3.5 Hexes out-of-arc render no shading
+- [ ] 3.6 Overlay renders beneath units, above terrain
+
+## 4. LineOfSightOverlay Component
+
+- [ ] 4.1 Create
+      `src/components/gameplay/overlays/LineOfSightOverlay.tsx`
+- [ ] 4.2 Subscribes to hover state (hovered hex ID)
+- [ ] 4.3 Draws a line from selected unit to hovered hex
+- [ ] 4.4 Clear state: solid green line, 2px
+- [ ] 4.5 Partial state: dashed yellow line, 2px
+- [ ] 4.6 Blocked state: solid red line, 2px, terminating at first
+      blocker
+- [ ] 4.7 Annotate blocking hexes with a small icon (cover / wall /
+      woods)
+- [ ] 4.8 Overlay renders above firing arc, below effect layers
+
+## 5. Overlay Toggles
+
+- [ ] 5.1 Arcs render only when a friendly unit is selected
+- [ ] 5.2 Arcs hide during movement interpolation animations
+- [ ] 5.3 LOS line renders only when a hex is hovered (not selected)
+- [ ] 5.4 LOS line hides on click (commits attack path elsewhere)
+- [ ] 5.5 User toggle in settings to disable arcs (hotkey: A)
+- [ ] 5.6 User toggle in settings to disable LOS (hotkey: L)
+
+## 6. Range Filtering
+
+- [ ] 6.1 Arcs shade only hexes within the unit's maximum weapon range
+- [ ] 6.2 Weapon list comes from the unit's configured equipment
+- [ ] 6.3 If the unit has zero operational weapons, only the rear-arc
+      shading renders (purely informational)
+- [ ] 6.4 Unit tests for range inclusion at the edge of short/medium/
+      long bands
+
+## 7. Blocker Annotations
+
+- [ ] 7.1 Partial-cover hexes annotate the blocker with a "cover" icon
+- [ ] 7.2 Blocked hexes annotate the first blocker with a "wall" icon
+- [ ] 7.3 Annotations use `<title>` SVG elements for screen readers
+- [ ] 7.4 Annotations fade in/out with the LOS line
+
+## 8. Accessibility
+
+- [ ] 8.1 Arc shading uses shape overlay (front = up-arrow chevron,
+      sides = dot, rear = minus) in addition to color for colorblind
+- [ ] 8.2 LOS states announce via `aria-live` on hex hover change
+- [ ] 8.3 Hotkeys (A, L) documented and announced on first use
+
+## 9. Performance
+
+- [ ] 9.1 Arc classification memoizes per (unit, facing)
+- [ ] 9.2 LOS classification memoizes per (unit, target) for the
+      current turn
+- [ ] 9.3 Overlay re-renders only on selection or hover change
+- [ ] 9.4 Budget: arc overlay paints within 4ms on a 30x30 map
+
+## 10. Tests
+
+- [ ] 10.1 Unit test: arc classifier returns `front` for hexes in the
+      front wedge across all six facings
+- [ ] 10.2 Unit test: LOS classifier correctly flags blocked through a
+      building
+- [ ] 10.3 Unit test: partial cover through light woods returns
+      `partial`
+- [ ] 10.4 Integration test: selecting a unit renders arc shading;
+      hovering an in-range hex renders a green LOS line
+- [ ] 10.5 Integration test: hovering a hex behind a wall renders a
+      red LOS line terminating at the wall
+
+## 11. Spec Compliance
+
+- [ ] 11.1 Every requirement in `line-of-sight-visualization` spec has a
+      GIVEN/WHEN/THEN scenario
+- [ ] 11.2 Every requirement in `firing-arc-calculation` delta has a
+      scenario
+- [ ] 11.3 Every requirement in `tactical-map-interface` delta has a
+      scenario
+- [ ] 11.4 `openspec validate add-los-and-firing-arc-overlays --strict`
+      passes clean

--- a/openspec/changes/add-mech-silhouette-sprite-set/proposal.md
+++ b/openspec/changes/add-mech-silhouette-sprite-set/proposal.md
@@ -1,0 +1,54 @@
+# Change: Add Mech Silhouette Sprite Set
+
+## Why
+
+Phase 1's combat MVP renders unit tokens as abstract hex markers — useful
+for hit-testing, useless for reading a battlefield at a glance. Phase 7
+demands a presentation layer where a stranger watching the screen can tell
+a light scout from an assault mech, whether it's humanoid or quad, which
+way it's facing, and which locations are beat up. This change ships a
+homemade (not licensed) 2D silhouette sprite set keyed off weight class
+and chassis archetype, with a facing indicator and an armor-pip damage
+overlay baked into every sprite.
+
+## What Changes
+
+- Add a homemade SVG silhouette sprite library covering four weight
+  classes (light, medium, heavy, assault) and three archetypes
+  (humanoid biped, quad, LAM)
+- Each sprite includes a built-in facing indicator (directional notch
+  or head rotation) that rotates in 60° increments with unit facing
+- Overlay armor-pip rings around each sprite that visualize hit-location
+  damage state (full / partial / structure / destroyed)
+- Replace the current abstract `UnitToken` marker with the sprite
+  renderer; selection ring and side color remain
+- Sprites scale to current hex size and stay crisp at zoom 0.5x–2.0x
+
+## Dependencies
+
+- **Requires**: `add-interactive-combat-core-ui` (Phase 1 MVP shipped —
+  this change upgrades its token rendering), `tactical-map-interface`
+  (hex map + token contract)
+- **Related**: `add-terrain-rendering`, `add-damage-feedback-effects`,
+  `add-heat-and-shutdown-visual-indicators` (these all layer visuals on
+  top of the sprite set; can parallelize)
+- **Required By**: none — Phase 7 is the final presentation phase
+
+## Impact
+
+- Affected specs: `tactical-map-interface` (MODIFIED — token rendering
+  contract now references sprites + pip overlays), new `unit-sprite-system`
+  (ADDED — sprite catalog, archetype/weight class keys, facing bake-in,
+  damage overlay)
+- Affected code: `src/components/gameplay/HexMapDisplay/UnitToken.tsx`
+  (swap abstract marker for sprite renderer), new
+  `src/components/gameplay/sprites/` directory housing SVG assets + the
+  `MechSprite` component, new `src/utils/sprites/spriteSelector.ts` for
+  weight-class/archetype lookup
+- Non-goals: 3D models (explicitly shelved — mech-IP licensing), licensed
+  BattleTech/MechWarrior art (homemade only), per-variant sprites (one
+  silhouette per weight-class × archetype bucket is sufficient),
+  animation of the sprite itself (that's `add-movement-interpolation-animations`)
+- Database: none
+- Assets: new SVG files under `public/sprites/mechs/` — all homemade,
+  version-controlled

--- a/openspec/changes/add-mech-silhouette-sprite-set/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-mech-silhouette-sprite-set/specs/tactical-map-interface/spec.md
@@ -1,0 +1,31 @@
+# tactical-map-interface Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Unit Token Rendering Uses Sprite System
+
+The tactical map interface SHALL render unit tokens via the sprite
+system, replacing the abstract marker used in the Phase 1 MVP.
+
+#### Scenario: Token uses MechSprite component
+
+- **GIVEN** a unit is placed on the hex map
+- **WHEN** the token renders
+- **THEN** a `MechSprite` component SHALL render the silhouette
+- **AND** an `ArmorPipRing` SHALL render the damage overlay
+- **AND** the outer `<g>` element SHALL remain the click target for
+  selection hit-testing
+
+#### Scenario: Selection binding preserved
+
+- **GIVEN** a user clicks a token
+- **WHEN** the click fires
+- **THEN** `useGameplayStore.setSelectedUnitId` SHALL be called with
+  the clicked unit's ID exactly as before the sprite swap
+
+#### Scenario: Side color preserved
+
+- **GIVEN** the Phase 1 MVP applied a side-color tint
+- **WHEN** the sprite renders
+- **THEN** the same side color SHALL drive the sprite's tint
+- **AND** existing accessibility overlays SHALL continue to apply

--- a/openspec/changes/add-mech-silhouette-sprite-set/specs/unit-sprite-system/spec.md
+++ b/openspec/changes/add-mech-silhouette-sprite-set/specs/unit-sprite-system/spec.md
@@ -1,0 +1,130 @@
+# unit-sprite-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Homemade Silhouette Sprite Catalog
+
+The unit sprite system SHALL provide a homemade (not licensed) 2D
+silhouette for every combination of weight class and chassis archetype,
+and SHALL never reference licensed BattleTech or MechWarrior visual
+assets.
+
+#### Scenario: Sprite exists for every weight x archetype combination
+
+- **GIVEN** a unit with weight class `light | medium | heavy | assault`
+- **WHEN** the sprite selector resolves the sprite
+- **THEN** exactly one SVG sprite SHALL be returned per combination
+- **AND** the sprite file SHALL live under `public/sprites/mechs/`
+- **AND** the sprite SHALL be homemade (no licensed art reference)
+
+#### Scenario: Archetype override for quads and LAMs
+
+- **GIVEN** a unit with `isQuad = true`
+- **WHEN** the sprite selector resolves the sprite
+- **THEN** the quad archetype sprite SHALL be returned
+- **AND** biped sprites SHALL NOT be returned for quad units
+
+#### Scenario: Missing archetype falls back to humanoid
+
+- **GIVEN** a unit with no archetype flags set
+- **WHEN** the sprite selector resolves the sprite
+- **THEN** the humanoid biped sprite for the unit's weight class SHALL
+  be returned
+
+### Requirement: Built-in Facing Indicator
+
+Every sprite SHALL include a facing indicator (directional notch or
+head-rotation cue) baked into the SVG so that rotation carries the
+indicator with it.
+
+#### Scenario: Facing rotates sprite and indicator together
+
+- **GIVEN** a unit facing direction 2 (120 degrees)
+- **WHEN** the sprite renders
+- **THEN** the sprite SHALL be rotated by `facing * 60deg` about its
+  center
+- **AND** the facing notch SHALL point in the same direction as the
+  rotated sprite's front
+
+#### Scenario: Facing change animates
+
+- **GIVEN** a unit rotates from facing 0 to facing 3
+- **WHEN** the new facing is committed
+- **THEN** the sprite SHALL animate over 150ms ease-out
+- **AND** `prefers-reduced-motion` users SHALL see an instant snap
+
+### Requirement: Armor Pip Damage Overlay
+
+Each sprite SHALL be accompanied by an armor-pip overlay ring that
+visualizes per-location damage state.
+
+#### Scenario: Pip color by location state
+
+- **GIVEN** a unit's right arm has full armor
+- **WHEN** the pip ring renders
+- **THEN** the RA pip group SHALL render green
+- **AND** a location with partial armor SHALL render yellow
+- **AND** a location with exposed internal structure SHALL render orange
+- **AND** a destroyed location SHALL render with a red outline and no fill
+
+#### Scenario: Quad pip layout differs from biped
+
+- **GIVEN** a quad unit's pip ring
+- **WHEN** the ring renders
+- **THEN** pip groups SHALL be positioned for Head, CT, Front-Left,
+  Front-Right, Rear-Left, Rear-Right legs
+- **AND** arm pip groups SHALL NOT render
+
+#### Scenario: Pip ring simplifies at low zoom
+
+- **GIVEN** the map zoom is below 0.6x
+- **WHEN** the pip ring renders
+- **THEN** each location SHALL collapse to a single aggregate dot
+- **AND** ring rendering SHALL be suppressed entirely below zoom 0.35x
+
+### Requirement: Sprite Scaling
+
+Sprites SHALL scale with hex size without losing legibility, and SHALL
+gracefully simplify at low zoom levels.
+
+#### Scenario: Default scale
+
+- **GIVEN** the map is at zoom 1.0
+- **WHEN** a sprite renders
+- **THEN** the sprite SHALL occupy approximately 80% of the hex diameter
+
+#### Scenario: Low-zoom simplification
+
+- **GIVEN** the map zoom is below 0.6x
+- **WHEN** the sprite renders
+- **THEN** the sprite SHALL collapse to an archetype glyph with side
+  tint only
+- **AND** the facing indicator SHALL still be visible
+
+### Requirement: Side Tint and Selection Ring
+
+The sprite renderer SHALL apply a side tint and render a selection ring
+when the unit is the currently selected unit.
+
+#### Scenario: Tint by side
+
+- **GIVEN** a unit on the Player side
+- **WHEN** the sprite renders
+- **THEN** the silhouette SHALL receive a blue tint via CSS filter or
+  feColorMatrix
+- **AND** an Opponent unit SHALL receive a red tint
+- **AND** a Neutral unit SHALL receive a gray tint
+
+#### Scenario: Colorblind-safe distinction
+
+- **GIVEN** a user with a colorblind simulation mode on
+- **WHEN** two sprites from opposing sides render next to each other
+- **THEN** the sprites SHALL remain distinguishable via a shape overlay
+  (e.g. triangle vs circle base marker) and not only by tint
+
+#### Scenario: Selection ring
+
+- **GIVEN** a unit is the selected unit in `useGameplayStore`
+- **WHEN** the sprite renders
+- **THEN** a selection ring SHALL render around the sprite
+- **AND** non-selected units SHALL NOT render a ring

--- a/openspec/changes/add-mech-silhouette-sprite-set/tasks.md
+++ b/openspec/changes/add-mech-silhouette-sprite-set/tasks.md
@@ -1,0 +1,97 @@
+# Tasks: Add Mech Silhouette Sprite Set
+
+## 1. Sprite Catalog Design
+
+- [ ] 1.1 Commission / draw 12 homemade silhouettes: 4 weight classes ×
+      3 archetypes (humanoid biped, quad, LAM)
+- [ ] 1.2 Confirm no asset resembles licensed BattleTech/MechWarrior art
+      (visual originality review)
+- [ ] 1.3 Export each as an SVG at a canonical 200×200 viewBox with
+      transparent background
+- [ ] 1.4 Place files under `public/sprites/mechs/<archetype>-<weight>.svg`
+
+## 2. Sprite Selector Utility
+
+- [ ] 2.1 Create `src/utils/sprites/spriteSelector.ts` exporting
+      `selectSprite(unit)`
+- [ ] 2.2 Map unit `weightClass` → `light | medium | heavy | assault`
+- [ ] 2.3 Derive archetype from unit data: `isQuad`, `isLAM`, else humanoid
+- [ ] 2.4 Return the resolved sprite URL + metadata (viewBox, anchor)
+- [ ] 2.5 Unit tests for every weight-class × archetype combination
+
+## 3. MechSprite Component
+
+- [ ] 3.1 Create `src/components/gameplay/sprites/MechSprite.tsx`
+- [ ] 3.2 Props: `unit`, `facing`, `scale`, `sideColor`, `isSelected`
+- [ ] 3.3 Load the silhouette via `<image>` or inline SVG symbol
+- [ ] 3.4 Apply side tint (Player=blue, Opponent=red, Neutral=gray) via
+      CSS filter or `<feColorMatrix>`
+- [ ] 3.5 Apply `transform: rotate(facing * 60deg)` about the sprite center
+- [ ] 3.6 Render selection ring when `isSelected` is true
+
+## 4. Facing Indicator
+
+- [ ] 4.1 Each silhouette SVG includes a directional notch element
+      identified by `id="facing-notch"`
+- [ ] 4.2 Notch orients along the sprite's "front" in its base SVG
+- [ ] 4.3 Sprite rotation carries the notch with it (no separate overlay)
+- [ ] 4.4 Facing changes animate over 150ms ease-out
+
+## 5. Armor Pip Overlay Ring
+
+- [ ] 5.1 Create `src/components/gameplay/sprites/ArmorPipRing.tsx`
+- [ ] 5.2 Render 8 pip groups around the sprite: Head, CT, LT, RT, LA,
+      RA, LL, RL (mechs) or Head, CT, FL, FR, RL, RR (quads)
+- [ ] 5.3 Each pip group colors by location state: full armor=green,
+      partial=yellow, structure exposed=orange, destroyed=red-outline
+- [ ] 5.4 Pip layout respects archetype (quads show legs in a cross,
+      LAMs show compact)
+- [ ] 5.5 Rings maintain legibility at 50% hex scale via simplified pip
+      aggregation (single dot per location when <50%)
+
+## 6. Swap UnitToken Renderer
+
+- [ ] 6.1 Replace abstract marker in `UnitToken.tsx` with `MechSprite` + `ArmorPipRing`
+- [ ] 6.2 Preserve existing hit-testing (the outer `<g>` remains the
+      click target)
+- [ ] 6.3 Preserve selection binding contract with `useGameplayStore`
+- [ ] 6.4 Preserve the side-color tint currently applied to the marker
+
+## 7. Zoom + Scale Behavior
+
+- [ ] 7.1 At zoom >= 1.0, sprites render at 80% of hex size
+- [ ] 7.2 At zoom < 0.6, sprites collapse to archetype glyph + class tint
+      only, pip ring hidden
+- [ ] 7.3 Pip ring never obscures neighboring hex content
+- [ ] 7.4 Text labels (unit name, call sign) scale with zoom but never
+      below 10px
+
+## 8. Accessibility + Colorblind
+
+- [ ] 8.1 Side tint uses shape-distinguishable overlays (not color-only)
+- [ ] 8.2 Armor pip states use both color and pattern (solid / striped /
+      empty)
+- [ ] 8.3 Sprites respect the existing `prefers-reduced-motion` setting
+      for facing animation
+
+## 9. Tests
+
+- [ ] 9.1 Unit test: `selectSprite` returns correct bundle for each
+      weight-class × archetype combination
+- [ ] 9.2 Unit test: `MechSprite` applies rotation matching
+      `facing * 60deg`
+- [ ] 9.3 Unit test: `ArmorPipRing` renders red-outline pip when a
+      location's structure is 0
+- [ ] 9.4 Visual regression snapshot for each of the 12 sprites at
+      default scale
+- [ ] 9.5 Integration test: selecting a quad unit renders quad layout
+      pips
+
+## 10. Spec Compliance
+
+- [ ] 10.1 Every requirement in `unit-sprite-system` spec has at least one
+      GIVEN/WHEN/THEN scenario
+- [ ] 10.2 Every requirement in `tactical-map-interface` delta has at
+      least one scenario
+- [ ] 10.3 `openspec validate add-mech-silhouette-sprite-set --strict`
+      passes clean

--- a/openspec/changes/add-minimap-and-camera-controls/proposal.md
+++ b/openspec/changes/add-minimap-and-camera-controls/proposal.md
@@ -1,0 +1,48 @@
+# Change: Add Minimap And Camera Controls
+
+## Why
+
+Large battlefields (30x30+ hex maps) already exceed the viewport, and
+Phase 1 ships a basic pan zoom hook but no overview. Players lose their
+orientation, have to zoom out to find their force, then zoom in again.
+Phase 7 adds a minimap in the corner with full-map context, proper
+camera controls (click-drag pan, wheel zoom, double-click unit focus)
+and documented keyboard shortcuts so experienced players can drive the
+map without reaching for the mouse.
+
+## What Changes
+
+- Minimap in the corner (top-right) showing the full map at a fixed
+  small scale with unit positions colored by side
+- Current camera viewport renders as a rectangle on the minimap
+- Click-drag on the minimap rectangle pans the main camera
+- Camera pan on the main map: click-drag on empty hex
+- Camera zoom: scroll wheel (zoom-to-cursor behavior)
+- Unit focus: double-click a unit token to center camera on it
+- Keyboard shortcuts: WASD / arrow pan, +/- zoom, Space = recenter on
+  selected unit, M = toggle minimap
+- Shortcuts surfaced in an in-app help overlay (hotkey: ?)
+
+## Dependencies
+
+- **Requires**: `add-interactive-combat-core-ui` (Phase 1 MVP),
+  `tactical-map-interface`, existing `useMapInteraction` hook
+- **Related**: `add-mech-silhouette-sprite-set` (sprite glyphs feed the
+  minimap dots), `add-terrain-rendering` (minimap renders a simplified
+  terrain color palette)
+- **Required By**: none — Phase 7 presentation layer
+
+## Impact
+
+- Affected specs: `tactical-map-interface` (MODIFIED — minimap panel,
+  unit-focus double-click, keyboard shortcut contract), new
+  `camera-controls` (ADDED — pan / zoom / focus behavior contract,
+  hotkey list, in-app help overlay)
+- Affected code: new `src/components/gameplay/minimap/Minimap.tsx`,
+  new `src/hooks/useCameraControls.ts` that extends the existing
+  `useMapInteraction` pan/zoom state, new
+  `src/components/gameplay/help/HotkeyHelpOverlay.tsx`, extensions to
+  `useMapInteraction.ts` for zoom-to-cursor and unit-focus actions
+- Non-goals: multi-viewport layouts, picture-in-picture of another
+  unit, cinematic camera paths, 3D perspective controls (shelved)
+- Database: none

--- a/openspec/changes/add-minimap-and-camera-controls/specs/camera-controls/spec.md
+++ b/openspec/changes/add-minimap-and-camera-controls/specs/camera-controls/spec.md
@@ -1,0 +1,116 @@
+# camera-controls Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Camera Pan
+
+The camera controls system SHALL support panning via mouse click-drag
+and keyboard shortcuts.
+
+#### Scenario: Click-drag pans camera
+
+- **GIVEN** the map is displayed at zoom 1.0
+- **WHEN** the user click-drags on an empty hex
+- **THEN** the camera SHALL pan by the drag delta in pixels
+- **AND** the unit selection SHALL NOT change
+
+#### Scenario: Arrow keys pan by one hex worth
+
+- **GIVEN** no modal overlay is active
+- **WHEN** the user presses an arrow key (or WASD equivalent)
+- **THEN** the camera SHALL pan by approximately one hex width in the
+  corresponding direction
+
+#### Scenario: Pan clamps to map bounds
+
+- **GIVEN** the camera is at the left edge of the map
+- **WHEN** the user pans further left
+- **THEN** the camera SHALL clamp at the map's left edge
+- **AND** no empty space beyond the map SHALL scroll into view
+
+### Requirement: Camera Zoom
+
+The camera controls system SHALL support zoom via scroll wheel and
+keyboard shortcuts, with zoom-to-cursor anchoring for the wheel.
+
+#### Scenario: Scroll wheel zooms with cursor anchor
+
+- **GIVEN** the cursor is over a specific hex
+- **WHEN** the user scrolls to zoom in
+- **THEN** the hex beneath the cursor SHALL remain beneath the cursor
+  after the zoom (within 1px tolerance)
+
+#### Scenario: Keyboard zoom
+
+- **GIVEN** no modal overlay is active
+- **WHEN** the user presses `+` or `-`
+- **THEN** zoom SHALL change by 10% per keystroke
+
+#### Scenario: Zoom clamps to bounds
+
+- **GIVEN** the zoom is at 2.0
+- **WHEN** the user scrolls to zoom in further
+- **THEN** zoom SHALL clamp at 2.0
+- **AND** zoom-out is clamped at 0.3
+
+### Requirement: Unit Focus
+
+The camera controls system SHALL support centering on a unit via
+double-click and keyboard shortcut.
+
+#### Scenario: Double-click centers on unit
+
+- **GIVEN** a unit token is on-screen
+- **WHEN** the user double-clicks the token
+- **THEN** the camera SHALL center on the unit's hex
+- **AND** the unit SHALL be selected
+- **AND** center animation SHALL ease over 200ms
+
+#### Scenario: Low-zoom focus bumps zoom
+
+- **GIVEN** the zoom is 0.4 when the user double-clicks a unit
+- **WHEN** the focus action runs
+- **THEN** zoom SHALL bump to 0.8 before centering
+
+#### Scenario: Space recenters on selected unit
+
+- **GIVEN** a unit is selected
+- **WHEN** the user presses Space
+- **THEN** the camera SHALL center on that unit
+
+### Requirement: Hotkey Help Overlay
+
+The camera controls system SHALL provide a hotkey help overlay
+triggered by the `?` key.
+
+#### Scenario: Help overlay opens
+
+- **GIVEN** no modal overlay is active
+- **WHEN** the user presses `?`
+- **THEN** the hotkey help overlay SHALL open
+- **AND** list camera, overlay, combat, and help hotkeys grouped
+
+#### Scenario: Esc closes help overlay
+
+- **GIVEN** the hotkey help overlay is open
+- **WHEN** the user presses Esc
+- **THEN** the overlay SHALL close
+
+#### Scenario: First-time prompt
+
+- **GIVEN** a user has never opened the hotkey help
+- **WHEN** their session starts
+- **THEN** a subtle "Press ? for shortcuts" prompt SHALL render briefly
+- **AND** the prompt SHALL NOT re-appear after first dismissal
+
+### Requirement: Reduced Motion Disables Camera Easing
+
+The camera controls system SHALL honor `prefers-reduced-motion` by
+disabling camera easing animations.
+
+#### Scenario: Reduced motion snaps focus
+
+- **GIVEN** `prefers-reduced-motion: reduce` is set
+- **WHEN** the user double-clicks a unit
+- **THEN** the camera SHALL snap to center instantly
+- **AND** no easing animation SHALL play

--- a/openspec/changes/add-minimap-and-camera-controls/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-minimap-and-camera-controls/specs/tactical-map-interface/spec.md
@@ -1,0 +1,90 @@
+# tactical-map-interface Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Minimap Panel
+
+The tactical map interface SHALL render a minimap panel in the top-right
+corner showing the full map, unit positions, and the current camera
+viewport.
+
+#### Scenario: Minimap dimensions and placement
+
+- **GIVEN** the combat surface is rendering
+- **WHEN** the minimap renders
+- **THEN** it SHALL be positioned in the top-right corner
+- **AND** it SHALL be 200x200 pixels with 12px margin
+- **AND** it SHALL include an opaque backdrop with a subtle drop shadow
+
+#### Scenario: Unit dots by side
+
+- **GIVEN** the minimap is visible
+- **WHEN** unit dots render
+- **THEN** each unit SHALL render as a dot colored by side (Player
+  blue, Opponent red, Neutral gray)
+- **AND** dot size SHALL scale with weight class
+
+#### Scenario: Camera viewport rectangle
+
+- **GIVEN** the main camera is zoomed in on part of the map
+- **WHEN** the minimap renders
+- **THEN** a bordered rectangle SHALL render on the minimap
+  representing the current camera viewport
+- **AND** the rectangle SHALL update live as the camera pans/zooms
+
+### Requirement: Minimap Interactions
+
+The tactical map interface SHALL accept click and drag interactions on
+the minimap to pan the main camera.
+
+#### Scenario: Click centers main camera
+
+- **GIVEN** the minimap is visible
+- **WHEN** the user clicks on a point within the minimap
+- **THEN** the main camera SHALL center on the corresponding map
+  location
+
+#### Scenario: Drag on viewport rectangle pans
+
+- **GIVEN** the user is dragging on the minimap's viewport rectangle
+- **WHEN** the drag moves
+- **THEN** the main camera SHALL pan continuously to match
+
+#### Scenario: Unit dot tooltip on hover
+
+- **GIVEN** the user hovers a unit dot on the minimap
+- **WHEN** the hover settles
+- **THEN** a tooltip SHALL render with the unit's name and side
+
+### Requirement: Minimap Toggle
+
+The tactical map interface SHALL allow the user to toggle minimap
+visibility.
+
+#### Scenario: M hotkey toggles minimap
+
+- **GIVEN** no modal overlay is active
+- **WHEN** the user presses M
+- **THEN** the minimap visibility SHALL toggle
+- **AND** the toggle state SHALL persist across the current session
+
+#### Scenario: Minimap accessibility role
+
+- **GIVEN** the minimap is visible
+- **WHEN** a screen reader traverses the page
+- **THEN** the minimap SHALL expose `role="region"` with an
+  `aria-label` describing it
+
+### Requirement: Double-Click Unit Focus
+
+The tactical map interface SHALL center the camera on a unit when the
+user double-clicks its token.
+
+#### Scenario: Double-click focuses and selects
+
+- **GIVEN** a unit token is on-screen
+- **WHEN** the user double-clicks the token
+- **THEN** the camera SHALL center on the unit
+- **AND** the unit SHALL become the selected unit
+- **AND** a single click SHALL still behave as selection-only (no
+  focus)

--- a/openspec/changes/add-minimap-and-camera-controls/tasks.md
+++ b/openspec/changes/add-minimap-and-camera-controls/tasks.md
@@ -1,0 +1,107 @@
+# Tasks: Add Minimap and Camera Controls
+
+## 1. Camera Controls Hook
+
+- [ ] 1.1 Extend `useMapInteraction.ts` with explicit pan / zoom / focus
+      actions: `panBy(dx, dy)`, `zoomTo(scale, cursorPoint)`,
+      `centerOn(hexCoord)`
+- [ ] 1.2 Zoom-to-cursor: anchor the zoom so the hex under the cursor
+      stays beneath the cursor
+- [ ] 1.3 Clamp zoom to [0.3, 2.0]
+- [ ] 1.4 Create a thin facade hook `src/hooks/useCameraControls.ts`
+      exposing the same surface with testable pure state
+
+## 2. Mouse Controls
+
+- [ ] 2.1 Click-drag on an empty (non-unit, non-minimap) hex pans the
+      camera
+- [ ] 2.2 Scroll wheel zooms with cursor anchor
+- [ ] 2.3 Double-click on a unit token calls `centerOn(unit.position)`
+      and selects the unit
+- [ ] 2.4 Middle-mouse drag also pans (alternate for laptop trackpads)
+
+## 3. Keyboard Shortcuts
+
+- [ ] 3.1 W/A/S/D (or arrow keys) pan by one hex worth of pixels
+- [ ] 3.2 `+` / `-` zoom in / out by 10% per keystroke
+- [ ] 3.3 Space recenters on the selected unit (no-op if none selected)
+- [ ] 3.4 M toggles minimap visibility
+- [ ] 3.5 A toggles firing arcs (defined in overlays change)
+- [ ] 3.6 L toggles LOS line (defined in overlays change)
+- [ ] 3.7 ? opens the hotkey help overlay
+- [ ] 3.8 Esc closes modal overlays and clears hover state
+
+## 4. Minimap Component
+
+- [ ] 4.1 Create `src/components/gameplay/minimap/Minimap.tsx`
+- [ ] 4.2 Fixed position top-right, 200x200 px with 12px margin
+- [ ] 4.3 Renders a simplified terrain color palette per hex
+- [ ] 4.4 Renders unit dots sized by weight class, colored by side
+- [ ] 4.5 Renders current camera viewport as a bordered rectangle
+- [ ] 4.6 Opaque backdrop with subtle drop shadow for legibility
+
+## 5. Minimap Interactions
+
+- [ ] 5.1 Click on the minimap centers the main camera on that point
+- [ ] 5.2 Drag on the minimap (on the viewport rectangle) pans the
+      main camera continuously
+- [ ] 5.3 Minimap does NOT zoom (minimap scale is fixed)
+- [ ] 5.4 Hovering a unit dot on the minimap shows a tooltip with the
+      unit name
+
+## 6. Hotkey Help Overlay
+
+- [ ] 6.1 Create `src/components/gameplay/help/HotkeyHelpOverlay.tsx`
+- [ ] 6.2 Opens on `?` keypress; closes on Esc or ? again
+- [ ] 6.3 Lists all hotkeys grouped: Camera (WASD, +/-, Space),
+      Overlays (A, L, M), Combat (1-5 weapon slots if defined
+      elsewhere), Help (?)
+- [ ] 6.4 First-time open flag is set once opened so new users see a
+      subtle prompt on session start
+
+## 7. Unit Focus
+
+- [ ] 7.1 Double-click on a unit token pans + zooms so the unit sits
+      in the viewport center
+- [ ] 7.2 If zoom is below 0.6, bump to 0.8 before centering (so the
+      unit is legible post-focus)
+- [ ] 7.3 Center animation eases over 200ms
+- [ ] 7.4 Selection state is set to the focused unit
+
+## 8. Accessibility
+
+- [ ] 8.1 All hotkeys documented in the help overlay
+- [ ] 8.2 Minimap has `role="region"` with an `aria-label` describing it
+- [ ] 8.3 Unit dots include `<title>` SVG elements for screen readers
+- [ ] 8.4 Hotkeys avoid collisions with screen-reader navigation keys
+- [ ] 8.5 Reduced motion disables the center-on-focus easing
+
+## 9. Performance
+
+- [ ] 9.1 Minimap renders at 15 FPS max (RAF-throttled)
+- [ ] 9.2 Dot positions re-read from state only on unit move events
+- [ ] 9.3 Viewport rectangle re-renders on camera change only
+- [ ] 9.4 Minimap terrain baked once per map load, cached
+
+## 10. Tests
+
+- [ ] 10.1 Unit test: `zoomTo(scale, cursorPoint)` keeps hex under
+      cursor stable within 1px
+- [ ] 10.2 Unit test: `centerOn(hex)` puts the hex at viewport center
+- [ ] 10.3 Unit test: pan clamps to map bounds (camera cannot leave the
+      map)
+- [ ] 10.4 Unit test: WASD keybinds each pan by the expected pixel
+      amount
+- [ ] 10.5 Integration test: double-click unit -> camera centers on
+      it, selection updates
+- [ ] 10.6 Integration test: minimap click -> camera pans
+- [ ] 10.7 Integration test: ? opens help overlay; Esc closes it
+
+## 11. Spec Compliance
+
+- [ ] 11.1 Every requirement in `camera-controls` spec has a
+      GIVEN/WHEN/THEN scenario
+- [ ] 11.2 Every requirement in `tactical-map-interface` delta has a
+      scenario
+- [ ] 11.3 `openspec validate add-minimap-and-camera-controls --strict`
+      passes clean

--- a/openspec/changes/add-movement-interpolation-animations/proposal.md
+++ b/openspec/changes/add-movement-interpolation-animations/proposal.md
@@ -1,0 +1,51 @@
+# Change: Add Movement Interpolation Animations
+
+## Why
+
+Today when a unit's movement resolves, the token snaps instantly from
+its start hex to its destination hex. The event log carries the real
+story, but a player watching the map never sees movement happen — they
+see teleportation. Phase 7's north star is "a stranger watching the
+screen understands what's happening without reading the log," so
+movement has to be animated: slide along the committed path, respect
+walk / run / jump speeds, and let jumps arc. The animation must block
+phase advancement until it completes so cause-and-effect is legible.
+
+## What Changes
+
+- When a movement is committed, the token interpolates from its start
+  hex to each hex along the A\* path in sequence
+- Walk speed: 300ms per hex; Run speed: 180ms per hex; Jump: single
+  ballistic arc from start to destination over 600ms
+- Facing rotates during the path at the same ease curve
+- The session's next-unit lock waits for the current animation to
+  complete before advancing
+- Users with `prefers-reduced-motion` see instant teleport (legacy
+  behavior) without breaking any logic
+
+## Dependencies
+
+- **Requires**: `add-interactive-combat-core-ui` (Phase 1 MVP),
+  `add-movement-phase-ui` (move commit UX), `movement-system`,
+  `tactical-map-interface`
+- **Related**: `add-mech-silhouette-sprite-set` (sprite rotation runs
+  alongside path tween)
+- **Required By**: none — Phase 7 presentation layer
+
+## Impact
+
+- Affected specs: `movement-system` (MODIFIED — movement events now
+  expose a serialized path and MP mode for playback; animation is a
+  UI concern but the path data must be present),
+  `tactical-map-interface` (ADDED — path-tween contract, phase
+  advancement gating, reduced-motion fallback)
+- Affected code: `src/components/gameplay/HexMapDisplay/UnitToken.tsx`
+  (consume animation props), new
+  `src/components/gameplay/animation/useMovementTween.ts` hook, new
+  `src/stores/useAnimationQueue.ts` to gate phase advancement on active
+  animations
+- Non-goals: non-path animations (rotation without movement, standing
+  up — separate effects in future phases), multiplayer animation sync
+  (Phase 4 owns that), sound effects (out of scope), cinematic camera
+  pulls (camera stays under user control per `add-minimap-and-camera-controls`)
+- Database: none

--- a/openspec/changes/add-movement-interpolation-animations/specs/movement-system/spec.md
+++ b/openspec/changes/add-movement-interpolation-animations/specs/movement-system/spec.md
@@ -1,0 +1,26 @@
+# movement-system Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: Movement Event Payload
+
+Movement-related events SHALL carry the full path and MP mode so that
+UI layers (animation, replay, indirect-fire tracking) can reconstruct
+the traversal without recomputing.
+
+#### Scenario: MovementCommitted embeds full path
+
+- **GIVEN** a player commits a movement
+- **WHEN** the `MovementCommitted` event is emitted
+- **THEN** the event payload SHALL contain the ordered array of axial
+  coordinates visited
+- **AND** the payload SHALL contain `mode: 'walk' | 'run' | 'jump'`
+- **AND** the payload SHALL contain the final committed facing
+
+#### Scenario: Backfill for legacy events
+
+- **GIVEN** a replay stream with older events that only store
+  destination
+- **WHEN** the animation layer plays them back
+- **THEN** the animation SHALL use an instant-snap fallback
+- **AND** no crash SHALL occur from missing path data

--- a/openspec/changes/add-movement-interpolation-animations/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-movement-interpolation-animations/specs/tactical-map-interface/spec.md
@@ -1,0 +1,97 @@
+# tactical-map-interface Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Movement Path Interpolation
+
+The tactical map interface SHALL animate unit tokens along their
+committed movement path, interpolating position from the start hex
+through each hex in sequence.
+
+#### Scenario: Walk animation at 300ms per hex
+
+- **GIVEN** a unit commits a 3-hex walking move
+- **WHEN** the animation plays
+- **THEN** the token SHALL traverse each hex segment in 300ms with
+  linear easing
+- **AND** total animation time SHALL be approximately 900ms
+- **AND** the token SHALL end at the destination hex
+
+#### Scenario: Run animation at 180ms per hex
+
+- **GIVEN** a unit commits a 5-hex running move
+- **WHEN** the animation plays
+- **THEN** the token SHALL traverse each hex in 180ms
+- **AND** total animation time SHALL be approximately 900ms
+
+#### Scenario: Facing rotates during path
+
+- **GIVEN** a walking move that ends facing 3 hexes away from start
+  facing
+- **WHEN** the animation plays
+- **THEN** the facing SHALL ease from start facing to commit facing
+- **AND** the final facing SHALL match the committed move
+
+### Requirement: Jump Arc Animation
+
+Jumps SHALL animate as a single parabolic arc from start to destination,
+rather than interpolating hex-by-hex.
+
+#### Scenario: Jump plays as a single arc
+
+- **GIVEN** a unit commits a jump move of any distance
+- **WHEN** the animation plays
+- **THEN** the token SHALL follow a parabolic arc from start to
+  destination over 600ms
+- **AND** the arc peak SHALL rise above the token's baseline by at
+  least 24px (scaled to zoom)
+
+#### Scenario: Jump arc indicator
+
+- **GIVEN** a jump animation is active
+- **WHEN** the arc plays
+- **THEN** a faint blue arc SHALL render from start to destination
+- **AND** the arc SHALL fade out after the animation completes
+
+### Requirement: Phase Advancement Gate On Active Animations
+
+The tactical map interface SHALL prevent phase advancement while any
+movement animation is active, and SHALL resume advancement once the
+animation queue drains.
+
+#### Scenario: Next unit waits for animation
+
+- **GIVEN** unit A is mid-animation along its movement path
+- **WHEN** the game engine tries to advance to unit B's lock
+- **THEN** advancement SHALL wait until unit A's animation completes
+- **AND** unit B's lock SHALL begin immediately after
+
+#### Scenario: Heat and PSR events flush after animation
+
+- **GIVEN** a committed move that generates heat and triggers a PSR
+- **WHEN** the animation plays
+- **THEN** heat and PSR events SHALL be buffered until the animation
+  completes
+- **AND** the event log SHALL render them after the token settles
+
+### Requirement: Reduced Motion Accessibility
+
+The tactical map interface SHALL respect the user's
+`prefers-reduced-motion` setting and fall back to instant position
+updates when enabled.
+
+#### Scenario: Reduced motion snaps to destination
+
+- **GIVEN** the user has `prefers-reduced-motion: reduce` set
+- **WHEN** a movement animation would play
+- **THEN** the token SHALL snap to its destination instantly
+- **AND** the phase advancement gate SHALL release on the same tick
+- **AND** no arc or path tween SHALL render
+
+#### Scenario: Game logic unaffected by reduced motion
+
+- **GIVEN** reduced motion is enabled
+- **WHEN** a player commits a move
+- **THEN** all game events, heat, PSR, and pilot rolls SHALL still
+  fire identically
+- **AND** only the visual interpolation SHALL be suppressed

--- a/openspec/changes/add-movement-interpolation-animations/tasks.md
+++ b/openspec/changes/add-movement-interpolation-animations/tasks.md
@@ -1,0 +1,104 @@
+# Tasks: Add Movement Interpolation Animations
+
+## 1. Movement Event Schema
+
+- [ ] 1.1 Ensure `MovementCommitted` event carries full path (array of
+      axial coordinates) plus MP mode (walk | run | jump)
+- [ ] 1.2 If event currently only stores destination, migrate: compute
+      path on commit and embed in payload
+- [ ] 1.3 Backfill logic for older event streams (replay uses instant
+      fallback)
+- [ ] 1.4 Unit tests for path serialization
+
+## 2. Animation Queue Store
+
+- [ ] 2.1 Create `src/stores/useAnimationQueue.ts`
+- [ ] 2.2 Methods: `enqueue(animation)`, `onComplete(callback)`,
+      `isActive`
+- [ ] 2.3 Session phase advancement reads `isActive` and waits until
+      queue drains
+- [ ] 2.4 Queue is FIFO per map; concurrent per-unit animations allowed
+      only when animations do not overlap hexes
+- [ ] 2.5 Unit tests for queue ordering
+
+## 3. Movement Tween Hook
+
+- [ ] 3.1 Create `useMovementTween(path, mode, onDone)` hook
+- [ ] 3.2 Walk: 300ms per hex segment, linear easing
+- [ ] 3.3 Run: 180ms per hex segment, linear easing
+- [ ] 3.4 Jump: single 600ms tween from start to destination with a
+      parabolic y offset (peak at 20% of jump distance, min 24px lift)
+- [ ] 3.5 Expose current interpolated `{x, y, facing, scale}` for the
+      token renderer
+- [ ] 3.6 Call `onDone` when the tween completes
+
+## 4. Token Renderer Integration
+
+- [ ] 4.1 `UnitToken.tsx` consumes tween output and renders the token
+      at the interpolated position
+- [ ] 4.2 Facing rotates over the path duration (ease-in-out) to the
+      final committed facing
+- [ ] 4.3 Token pulls itself to the top of the z-order while animating
+- [ ] 4.4 Animation cleanly removes itself on unmount
+
+## 5. Phase Advancement Gate
+
+- [ ] 5.1 Hook `useGameplayStore` phase advancement behind
+      `useAnimationQueue.isActive`
+- [ ] 5.2 When animations are pending, phase advancement is deferred
+- [ ] 5.3 On `prefers-reduced-motion`, the gate is bypassed (instant
+      teleport, instant advancement)
+- [ ] 5.4 Integration test: two units move sequentially; second move
+      waits for first animation to finish
+
+## 6. Reduced Motion Fallback
+
+- [ ] 6.1 Detect `window.matchMedia('(prefers-reduced-motion: reduce)')`
+- [ ] 6.2 When reduced motion is enabled, `useMovementTween` returns
+      the final position immediately and calls `onDone` synchronously
+- [ ] 6.3 Jump arc flattens to a straight snap
+- [ ] 6.4 Unit test: reduced-motion mode fires `onDone` within one tick
+
+## 7. Jump Arc Visual
+
+- [ ] 7.1 During a jump tween, draw a faint arc indicator from start
+      to destination for the duration of the animation
+- [ ] 7.2 Arc fades in during the first 100ms, fades out in the last
+      100ms
+- [ ] 7.3 Arc color uses the jump-MP color (blue) to reinforce mode
+- [ ] 7.4 Arc respects reduced motion (hidden when enabled)
+
+## 8. Event Log Sync
+
+- [ ] 8.1 Event log entries remain synchronized with animation
+      completion — a `MovementResolved` log line appears when the
+      tween calls `onDone`
+- [ ] 8.2 Heat / PSR events that fire from movement are held until
+      tween completes, then flushed
+- [ ] 8.3 Integration test: heat entry in log appears after animation
+      settles, not before
+
+## 9. Performance
+
+- [ ] 9.1 Tween uses `requestAnimationFrame`, not `setInterval`
+- [ ] 9.2 Tween cancellations on unmount are leak-free
+- [ ] 9.3 Profile: 4 simultaneous tweens should stay above 55 FPS on a
+      30x30 map
+
+## 10. Tests
+
+- [ ] 10.1 Unit test: `useMovementTween` walk covers 3 hexes in
+      ~900ms +/- frame tolerance
+- [ ] 10.2 Unit test: run mode completes in ~540ms for 3 hexes
+- [ ] 10.3 Unit test: jump tween y offset peaks near the midpoint
+- [ ] 10.4 Unit test: reduced-motion mode skips timing
+- [ ] 10.5 Integration test: committing a 4-hex walk produces a tween
+      that holds phase advancement, then releases
+
+## 11. Spec Compliance
+
+- [ ] 11.1 Every requirement in `tactical-map-interface` delta has a
+      GIVEN/WHEN/THEN scenario
+- [ ] 11.2 Every requirement in `movement-system` delta has a scenario
+- [ ] 11.3 `openspec validate add-movement-interpolation-animations
+    --strict` passes clean

--- a/openspec/changes/add-movement-interpolation-animations/tasks.md
+++ b/openspec/changes/add-movement-interpolation-animations/tasks.md
@@ -101,4 +101,4 @@
       GIVEN/WHEN/THEN scenario
 - [ ] 11.2 Every requirement in `movement-system` delta has a scenario
 - [ ] 11.3 `openspec validate add-movement-interpolation-animations
-    --strict` passes clean
+--strict` passes clean

--- a/openspec/changes/add-movement-phase-ui/proposal.md
+++ b/openspec/changes/add-movement-phase-ui/proposal.md
@@ -1,0 +1,47 @@
+# Change: Add Movement Phase UI
+
+## Why
+
+The movement phase in the engine alternates unit locks (Player → Opponent →
+Player → ...) but there's no way for a human player to execute a move. We
+have an A\* pathfinder in `src/utils/gameplay/movement/pathfinding.ts`,
+walk/run/jump MP derivation, and hex-cost logic — yet the active unit has
+no overlay showing reachable hexes, no path preview, no facing commit, and
+no way to lock movement. This change makes the movement phase playable: pick
+a destination hex, see the cumulative MP cost, rotate to your desired
+facing, commit.
+
+## What Changes
+
+- When a Player-side unit is selected during Movement phase, render a
+  reachable-hex overlay colored by MP type (walk=green, run=yellow,
+  jump=blue) with MP cost per hex
+- Hovering a reachable hex shows the A\* path preview with cumulative MP
+- Clicking a reachable hex commits the destination; facing picker appears
+- Facing picker lets the player rotate the unit in 60° increments
+- "Commit Move" button locks movement; the session advances to the next
+  unit's lock
+
+## Dependencies
+
+- **Requires**: `add-interactive-combat-core-ui` (selection + phase HUD
+  must be in place), `movement-system` (canonical spec),
+  `tactical-map-interface` (hex map + overlays), existing
+  `movement/pathfinding.ts` A\* implementation
+- **Related**: Lane A A5 `wire-heat-generation-and-effects` — this UI shows
+  a _preview_ of movement heat; actual application depends on A5
+- **Required By**: `add-attack-phase-ui` (must have a real post-movement
+  state to fire from)
+
+## Impact
+
+- Affected specs: `movement-system` (MODIFIED — add UI-facing
+  `plannedMovement` projection requirements), `tactical-map-interface`
+  (ADDED — reachable-hex overlay, path preview, facing picker)
+- Affected code: `src/components/gameplay/HexMapDisplay/` (overlay
+  rendering), `src/stores/useGameplayStore.ts` (movement planning state),
+  `src/pages/gameplay/games/[id].tsx` (wire the movement UI into the
+  combat surface when phase is Movement)
+- Non-goals: jumping over buildings (engine already handles it), climbing
+  elevation (engine already handles it), multiplayer synchronization of
+  planned moves (Phase 4)

--- a/openspec/changes/add-movement-phase-ui/specs/movement-system/spec.md
+++ b/openspec/changes/add-movement-phase-ui/specs/movement-system/spec.md
@@ -1,0 +1,88 @@
+# movement-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Planned Movement UI Projection
+
+The movement system SHALL expose a `plannedMovement` projection shape on the
+gameplay store that represents the player's in-progress (uncommitted)
+movement plan for a selected unit, so UI surfaces can render path previews
+and facing pickers without mutating session state.
+
+#### Scenario: Planned movement records destination, path, and facing
+
+- **GIVEN** a selected Player-side unit during Movement phase
+- **WHEN** the player hovers a reachable hex and commits it as destination
+- **THEN** `plannedMovement` SHALL contain `unitId`, `destination`, `path`,
+  `mpType`, and `facing`
+- **AND** `facing` SHALL default to the travel direction of the final path
+  segment
+
+#### Scenario: Planned movement cleared on phase exit
+
+- **GIVEN** `plannedMovement` is set for the current Movement phase
+- **WHEN** the phase transitions to Weapon Attack
+- **THEN** `plannedMovement` SHALL be cleared to `null`
+
+#### Scenario: Planned movement cleared on deselection
+
+- **GIVEN** `plannedMovement` is set for unit A
+- **WHEN** the player selects unit B
+- **THEN** `plannedMovement` for A SHALL be cleared
+- **AND** the store SHALL hold at most one `plannedMovement` at a time
+
+### Requirement: Reachable Hex Derivation by MP Type
+
+The movement system SHALL provide a `deriveReachableHexes(unit, mpType)`
+function that returns every hex reachable with the given movement type
+(Walk, Run, Jump), including the MP cost to each hex, using the existing A\*
+pathfinder.
+
+#### Scenario: Walk reachable hexes
+
+- **GIVEN** a BattleMech with 5 walk MP at hex {0,0}
+- **WHEN** `deriveReachableHexes(unit, MpType.Walk)` is called
+- **THEN** the result SHALL contain every hex whose cheapest path cost is
+  <= 5 MP
+- **AND** each entry SHALL contain `{hex, mpCost, mpType: MpType.Walk,
+reachable: true}`
+
+#### Scenario: Run reachable hexes extend walk reach
+
+- **GIVEN** a BattleMech with 5 walk MP, 8 run MP
+- **WHEN** `deriveReachableHexes(unit, MpType.Run)` is called
+- **THEN** the result SHALL contain every hex whose cheapest path cost is
+  <= 8 MP
+
+#### Scenario: Jump reachable hexes skip blocked terrain
+
+- **GIVEN** a BattleMech with 4 jump MP and a woods hex 3 hexes away
+- **WHEN** `deriveReachableHexes(unit, MpType.Jump)` is called
+- **THEN** the woods hex SHALL be marked reachable with `mpCost = 3`
+- **AND** intermediate hexes between origin and landing SHALL NOT be in
+  the result
+
+### Requirement: Movement Commit Event Emission
+
+The movement system SHALL, on player-confirmed movement commit, append a
+`MovementLocked` event to the session event stream whose payload contains
+the committed path, final facing, and declared MP type.
+
+#### Scenario: Commit path emits MovementLocked event
+
+- **GIVEN** a valid `plannedMovement` for a Player-side unit
+- **WHEN** the player clicks "Commit Move"
+- **THEN** a `MovementLocked` event SHALL be appended with
+  `{unitId, path, facing, mpType}`
+- **AND** the unit's position SHALL update to the path's terminal hex
+- **AND** the unit's facing SHALL update to the planned facing
+
+#### Scenario: Commit with invalid destination rejected
+
+- **GIVEN** a `plannedMovement` whose destination is now unreachable
+  because an intervening event blocked the path
+- **WHEN** the player clicks "Commit Move"
+- **THEN** the commit SHALL be rejected
+- **AND** no `MovementLocked` event SHALL be appended
+- **AND** an error toast `"Destination no longer reachable"` SHALL
+  display

--- a/openspec/changes/add-movement-phase-ui/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-movement-phase-ui/specs/tactical-map-interface/spec.md
@@ -1,0 +1,121 @@
+# tactical-map-interface Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Reachable Hex Overlay by MP Type
+
+The tactical map interface SHALL render a reachable-hex overlay during the
+Movement phase for the selected Player-side unit, coloring each tile by the
+movement type (Walk, Run, Jump) required to reach it.
+
+**Priority**: Critical
+
+#### Scenario: Walk-range tiles rendered green
+
+- **GIVEN** a selected unit has 5 walk MP and the player selects MP type
+  Walk
+- **WHEN** the overlay renders
+- **THEN** every hex with `mpCost <= 5` via walk SHALL be tinted green
+  (`#bbf7d0`)
+- **AND** each tile SHALL display its MP cost in small text
+
+#### Scenario: Run-range tiles rendered yellow
+
+- **GIVEN** the player selects MP type Run
+- **WHEN** the overlay renders
+- **THEN** tiles reachable only with run MP SHALL be tinted yellow
+  (`#fef08a`)
+- **AND** walk-reachable tiles SHALL retain their green tint under the
+  run set
+
+#### Scenario: Jump-range tiles rendered blue with pattern
+
+- **GIVEN** the player selects MP type Jump
+- **WHEN** the overlay renders
+- **THEN** landing hexes reachable with jump SHALL be tinted blue
+  (`#bfdbfe`) with a distinct diagonal pattern
+- **AND** tiles unreachable by any MP type SHALL have no overlay tint
+
+### Requirement: Path Preview on Hover
+
+The tactical map interface SHALL render a hover-driven path preview from the
+selected unit to the hovered reachable hex, using the existing A\*
+pathfinder.
+
+**Priority**: Critical
+
+#### Scenario: Hover reachable hex draws path
+
+- **GIVEN** a selected unit at {0,0} with the Walk overlay active
+- **WHEN** the user hovers a reachable hex at {3,0}
+- **THEN** every hex along the pathfinder's cheapest path SHALL be
+  highlighted yellow (`#fef9c3`)
+- **AND** the hovered hex SHALL display cumulative MP cost
+
+#### Scenario: Hover unreachable hex shows tooltip
+
+- **GIVEN** a hex not in the reachable set
+- **WHEN** the user hovers it
+- **THEN** no path SHALL be drawn
+- **AND** a tooltip SHALL display `"Unreachable"`
+
+#### Scenario: Clicking reachable hex commits destination
+
+- **GIVEN** a hover path is visible
+- **WHEN** the user clicks the hovered hex
+- **THEN** the path SHALL persist as the committed plan
+- **AND** the hover path SHALL lock until the plan is cleared
+
+### Requirement: Facing Picker Overlay
+
+The tactical map interface SHALL render a facing picker overlay at the
+committed destination hex, allowing the player to rotate the unit in 60°
+increments before locking movement.
+
+**Priority**: High
+
+#### Scenario: Picker appears on destination commit
+
+- **GIVEN** the player has committed a destination hex
+- **WHEN** the picker renders
+- **THEN** six arrow buttons SHALL be drawn radially around the
+  destination hex, one per `Facing` value
+- **AND** the default highlighted arrow SHALL match the travel direction
+  of the final path segment
+
+#### Scenario: Clicking arrow updates planned facing
+
+- **GIVEN** the picker is visible with default facing Northeast
+- **WHEN** the user clicks the South arrow
+- **THEN** `plannedMovement.facing` SHALL equal `Facing.South`
+- **AND** the ghost unit token on the destination hex SHALL rotate to
+  face South
+
+#### Scenario: Picker dismisses on commit or cancel
+
+- **GIVEN** the picker is visible
+- **WHEN** the user clicks "Commit Move" or clears the plan
+- **THEN** the picker SHALL dismiss
+- **AND** no residual arrow buttons SHALL remain on the map
+
+### Requirement: MP Type Indicator in Overlay Legend
+
+The tactical map interface SHALL include a visible legend adjacent to the
+map showing which MP type is currently driving the reachable overlay, and
+what the colors mean.
+
+**Priority**: Medium
+
+#### Scenario: Legend reflects current MP type
+
+- **GIVEN** the player has switched to Run
+- **WHEN** the legend renders
+- **THEN** the Run row SHALL be visually emphasized (bold + outline)
+- **AND** Walk and Jump rows SHALL be dimmed
+
+#### Scenario: Jump unavailable dims Jump row
+
+- **GIVEN** the selected unit has `jumpMP = 0`
+- **WHEN** the legend renders
+- **THEN** the Jump row SHALL be rendered at 40% opacity
+- **AND** hovering Jump SHALL show a tooltip `"No jump capability"`

--- a/openspec/changes/add-movement-phase-ui/tasks.md
+++ b/openspec/changes/add-movement-phase-ui/tasks.md
@@ -1,0 +1,98 @@
+# Tasks: Add Movement Phase UI
+
+## 1. Movement Planning State
+
+- [ ] 1.1 Extend `useGameplayStore` with `plannedMovement: {unitId,
+    destination, path, mpType, facing} | null`
+- [ ] 1.2 Add selector `getPlannedMovement(unitId)` returning the plan or
+      `null`
+- [ ] 1.3 Clearing plan on phase change or deselect
+
+## 2. Reachable Hex Derivation
+
+- [ ] 2.1 On Player-side selection during Movement phase, compute reachable
+      hexes for walk MP, run MP, and jump MP using existing pathfinder
+- [ ] 2.2 Memoize per selected unit; invalidate on unit facing or
+      destination change
+- [ ] 2.3 Expose as `IReachableHex[]` with `{hex, mpCost, mpType,
+    reachable}`
+
+## 3. Reachable Overlay Rendering
+
+- [ ] 3.1 Render overlay tiles over reachable hexes
+- [ ] 3.2 Walk-range tiles use green (`#bbf7d0`)
+- [ ] 3.3 Run-range tiles use yellow (`#fef08a`)
+- [ ] 3.4 Jump-range tiles use blue (`#bfdbfe`) with distinct pattern
+- [ ] 3.5 Each tile shows its MP cost as small text
+
+## 4. Path Preview on Hover
+
+- [ ] 4.1 Hovering a reachable hex triggers pathfind from current unit
+      position to that hex
+- [ ] 4.2 Path hexes highlighted with a yellow tint
+- [ ] 4.3 Cumulative MP cost displayed at the destination hex
+- [ ] 4.4 Hovering an unreachable hex shows a red "Unreachable" tooltip
+
+## 5. Destination Commit
+
+- [ ] 5.1 Clicking a reachable hex commits the destination in
+      `plannedMovement`
+- [ ] 5.2 Path preview becomes the locked-in path
+- [ ] 5.3 Clicking a different reachable hex replaces the plan
+
+## 6. Facing Picker
+
+- [ ] 6.1 Once a destination is committed, a facing picker appears over
+      the destination hex
+- [ ] 6.2 Picker shows six arrow buttons (one per `Facing` value)
+- [ ] 6.3 Clicking an arrow sets `plannedMovement.facing`
+- [ ] 6.4 Default facing is the travel direction of the last path segment
+
+## 7. MP Type Switcher
+
+- [ ] 7.1 Action panel shows MP type buttons: Walk, Run, Jump
+- [ ] 7.2 Switching MP type re-derives reachable hexes and clears the
+      current path if the destination is no longer reachable
+- [ ] 7.3 Units that can't jump have the Jump button disabled
+
+## 8. Move Commit Button
+
+- [ ] 8.1 "Commit Move" button appears in the action panel once a plan is
+      valid (destination + facing chosen)
+- [ ] 8.2 Clicking dispatches `MovementLocked` event via the session
+- [ ] 8.3 Unit token animates from origin to destination along the planned
+      path
+- [ ] 8.4 After animation, plan is cleared and selection moves to the next
+      unit owed a lock
+
+## 9. Movement Heat Preview
+
+- [ ] 9.1 Action panel shows "Heat this turn: +X" below the MP type
+      buttons
+- [ ] 9.2 Walk=+1, Run=+2, Jump=max(3, jumpMP) per canonical rules
+- [ ] 9.3 Value updates live as MP type changes
+
+## 10. Phase Boundary Behavior
+
+- [ ] 10.1 Movement UI only renders during `GamePhase.Movement`
+- [ ] 10.2 Opponent-controlled units never show a reachable overlay
+      (player can't plan opponent moves)
+- [ ] 10.3 When phase exits Movement, all planned-move state is cleared
+
+## 11. Tests
+
+- [ ] 11.1 Unit test: reachable hex derivation matches pathfinder output
+      for a standard mech with 5 walk MP
+- [ ] 11.2 Unit test: switching from walk to run expands the overlay
+- [ ] 11.3 Integration test: select → pick hex → pick facing → commit
+      appends a `MovementLocked` event
+- [ ] 11.4 Integration test: clicking unreachable hex does not commit a
+      plan
+
+## 12. Spec Compliance
+
+- [ ] 12.1 Every requirement in `movement-system` delta has at least one
+      scenario
+- [ ] 12.2 Every requirement in `tactical-map-interface` delta has at
+      least one scenario
+- [ ] 12.3 `openspec validate add-movement-phase-ui --strict` passes clean

--- a/openspec/changes/add-movement-phase-ui/tasks.md
+++ b/openspec/changes/add-movement-phase-ui/tasks.md
@@ -3,7 +3,7 @@
 ## 1. Movement Planning State
 
 - [ ] 1.1 Extend `useGameplayStore` with `plannedMovement: {unitId,
-    destination, path, mpType, facing} | null`
+destination, path, mpType, facing} | null`
 - [ ] 1.2 Add selector `getPlannedMovement(unitId)` returning the plan or
       `null`
 - [ ] 1.3 Clearing plan on phase change or deselect
@@ -15,7 +15,7 @@
 - [ ] 2.2 Memoize per selected unit; invalidate on unit facing or
       destination change
 - [ ] 2.3 Expose as `IReachableHex[]` with `{hex, mpCost, mpType,
-    reachable}`
+reachable}`
 
 ## 3. Reachable Overlay Rendering
 

--- a/openspec/changes/add-multiplayer-lobby-and-matchmaking-2-8/proposal.md
+++ b/openspec/changes/add-multiplayer-lobby-and-matchmaking-2-8/proposal.md
@@ -1,0 +1,53 @@
+# Change: Add Multiplayer Lobby and Matchmaking (2-8)
+
+## Why
+
+**Sub-phase 4b.** The 4a lobby handles 1v1 only, and the 4b server
+infrastructure is faceless — there's no way to form a 2v2, 3v3, 4v4,
+or free-for-all group. Phase 4b's checkpoint requires "third player
+joins the same side as co-op; AI fills remaining slots." This change
+delivers a server-authoritative lobby that supports 2–8 players across
+configurable team layouts, side assignment, AI slot filling, and a
+room-code invite flow that scales past two seats.
+
+## What Changes
+
+- Extend the `multiplayer-server` spec with team-layout primitives:
+  `'1v1'`, `'2v2'`, `'3v3'`, `'4v4'`, `'ffa-2'` through `'ffa-8'` (free-
+  for-all with N slots)
+- Host creates a match with a chosen layout; server derives the side
+  roster and seat count
+- Room code invitation: same 6-char convention as the vault
+  `p2p-sync-system`; joining a code navigates the player to the match's
+  lobby page
+- Each seat is a slot with `{slotId, side, seatNumber, occupant:
+IPlayerRef | null, kind: 'human' | 'ai'}`
+- Host can toggle any unoccupied human slot to AI (drives `BotPlayer`
+  behind the server engine) or back to human
+- Players can self-assign to any open human slot; host can reassign
+  players across sides until ready
+- Readiness gate: match launches when all human slots are filled and
+  ready, all AI slots are configured, and the host confirms
+- Spectator mode deferred; all human seats are players
+
+## Dependencies
+
+- **Requires**: `add-multiplayer-server-infrastructure` (server + match
+  store + WebSocket), `add-player-identity-and-auth` (players need a
+  stable identity to occupy seats)
+- **Required By**: `add-reconnection-and-session-rehydration` (must
+  know the seat → player binding to re-attach on reconnect),
+  `add-fog-of-war-event-filtering` (uses side assignments to filter
+  events per player)
+
+## Impact
+
+- Affected specs: `multiplayer-server` (MODIFIED — team layouts, seat
+  slots, AI-filled slots, readiness gate), `multiplayer-sync`
+  (MODIFIED — room-code invite flow, lobby replication for 2–8)
+- Affected code: new `src/server/multiplayer/lobby.ts`, new
+  `src/pages/gameplay/mp-lobby/[matchId].tsx`, extension of
+  `src/lib/multiplayer/client.ts` with lobby intent types, reuse of
+  `roomCodes.ts` for invite code generation
+- Non-goals: rated matchmaking (skill brackets), quick-match queue,
+  spectator slots, friend lists (depends on identity work)

--- a/openspec/changes/add-multiplayer-lobby-and-matchmaking-2-8/specs/multiplayer-server/spec.md
+++ b/openspec/changes/add-multiplayer-lobby-and-matchmaking-2-8/specs/multiplayer-server/spec.md
@@ -1,0 +1,149 @@
+# multiplayer-server Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Team Layouts
+
+The multiplayer server SHALL support configurable match team layouts
+for 2–8 players, covering symmetric team play (`1v1`, `2v2`, `3v3`,
+`4v4`) and free-for-all (`ffa-2` through `ffa-8`).
+
+#### Scenario: 2v2 produces two sides of two seats
+
+- **GIVEN** a host creates a match with `layout: '2v2'`
+- **WHEN** the server initializes the match
+- **THEN** the seat roster SHALL contain 4 seats
+- **AND** 2 seats SHALL be on side `'Alpha'`, 2 on side `'Bravo'`
+
+#### Scenario: ffa-5 produces five solo sides
+
+- **GIVEN** a host creates a match with `layout: 'ffa-5'`
+- **WHEN** the server initializes the match
+- **THEN** the seat roster SHALL contain 5 seats
+- **AND** each seat SHALL be on its own side (`'Alpha'` through
+  `'Echo'`)
+
+#### Scenario: 4v4 supports 8 total seats
+
+- **GIVEN** a host creates a match with `layout: '4v4'`
+- **WHEN** the server initializes the match
+- **THEN** the seat roster SHALL contain 8 seats
+- **AND** seats SHALL be evenly split between two sides
+
+### Requirement: Seat Slot Model
+
+The multiplayer server SHALL model each player slot as an explicit seat
+with a stable id, side assignment, occupant, kind (human or AI), and
+readiness flag.
+
+#### Scenario: Seat record shape
+
+- **GIVEN** a match with seats
+- **WHEN** the seat roster is inspected
+- **THEN** each seat SHALL have `slotId, side, seatNumber, occupant,
+kind, ready, aiProfile?`
+- **AND** `slotId` SHALL be of the form `{side-lowercase}-{seatNumber}`
+  (e.g. `alpha-1`, `bravo-2`)
+
+#### Scenario: Seat occupancy binding
+
+- **GIVEN** an unoccupied human seat `alpha-1`
+- **WHEN** player `pid_abc` sends `Intent {kind: 'OccupySeat',
+slotId: 'alpha-1'}`
+- **THEN** the server SHALL assign `occupant = {playerId: 'pid_abc'}`
+- **AND** other clients SHALL receive a lobby update reflecting the
+  new occupant
+
+#### Scenario: Cannot occupy AI seat
+
+- **GIVEN** a seat with `kind: 'ai'`
+- **WHEN** a player sends `OccupySeat` for that slot
+- **THEN** the server SHALL respond `Error {code: 'SEAT_IS_AI'}`
+- **AND** occupancy SHALL NOT change
+
+### Requirement: Room Code Invites for 2-8 Matches
+
+The multiplayer server SHALL issue a 6-character alphanumeric room code
+on match creation, usable as a shareable invite token that resolves to
+the internal match id.
+
+#### Scenario: Room code issued on create
+
+- **GIVEN** a host POSTs `/api/multiplayer/matches` with a valid body
+- **WHEN** the server creates the match
+- **THEN** the response SHALL include `roomCode: string` of 6 chars
+- **AND** the code SHALL use the same alphabet as the
+  `p2p-sync-system` (excluding I/O/0/1)
+
+#### Scenario: Resolve room code to match id
+
+- **GIVEN** a match with `roomCode: 'RX7KLM'` in `status: 'lobby'`
+- **WHEN** a joiner GETs `/api/multiplayer/invites/RX7KLM`
+- **THEN** the response SHALL be `{matchId, status: 'lobby'}`
+- **AND** the joiner SHALL use `matchId` to connect to the WebSocket
+
+#### Scenario: Code expires at launch
+
+- **GIVEN** a match whose `status` has transitioned to `'active'`
+- **WHEN** a newcomer GETs `/api/multiplayer/invites/{roomCode}`
+- **THEN** the response SHALL be `410 Gone`
+- **AND** the body SHALL indicate the match is no longer accepting
+  joiners
+
+### Requirement: AI-Filled Seats
+
+The system SHALL allow a host to mark any unoccupied human seat as AI,
+and the server SHALL spawn a `BotPlayer` instance in-process to occupy
+that seat at match launch.
+
+#### Scenario: Host toggles empty seat to AI
+
+- **GIVEN** an empty seat `bravo-2` with `kind: 'human'`
+- **WHEN** the host sends `Intent {kind: 'SetAiSlot', slotId: 'bravo-2',
+aiProfile: 'basic'}`
+- **THEN** the seat SHALL become `kind: 'ai', aiProfile: 'basic',
+ready: true`
+
+#### Scenario: AI seat auto-ready
+
+- **GIVEN** any seat with `kind: 'ai'`
+- **WHEN** readiness is evaluated
+- **THEN** the seat SHALL be considered ready without an explicit
+  toggle
+
+#### Scenario: Bot drives events at launch
+
+- **GIVEN** a match with one or more AI seats
+- **WHEN** the match launches
+- **THEN** the server SHALL instantiate a `BotPlayer` per AI seat
+- **AND** bot-generated intents SHALL NOT traverse the WebSocket layer
+  (in-process only)
+
+### Requirement: Readiness Gate
+
+The system SHALL require every seat to be ready AND every human seat to
+be occupied before the host may launch the match.
+
+#### Scenario: Cannot launch with empty seat
+
+- **GIVEN** a `'3v3'` match with 5 of 6 seats occupied and ready
+- **WHEN** the host sends `Intent {kind: 'LaunchMatch'}`
+- **THEN** the server SHALL respond `Error {code: 'NOT_READY',
+reason: 'empty-seat'}`
+
+#### Scenario: Cannot launch with unready human
+
+- **GIVEN** a match where all seats are occupied but one human has
+  `ready: false`
+- **WHEN** the host sends `LaunchMatch`
+- **THEN** the server SHALL respond `Error {code: 'NOT_READY',
+reason: 'unready-player'}`
+
+#### Scenario: Launch succeeds when fully ready
+
+- **GIVEN** a match where all seats are occupied, all humans are
+  ready, and all AI slots are configured
+- **WHEN** the host sends `LaunchMatch`
+- **THEN** the server SHALL emit `GameCreated` with the computed side
+  assignments
+- **AND** `IMatchMeta.status` SHALL become `'active'`

--- a/openspec/changes/add-multiplayer-lobby-and-matchmaking-2-8/specs/multiplayer-sync/spec.md
+++ b/openspec/changes/add-multiplayer-lobby-and-matchmaking-2-8/specs/multiplayer-sync/spec.md
@@ -1,0 +1,55 @@
+# multiplayer-sync Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Lobby Update Broadcast
+
+The server SHALL broadcast lobby state to all connected clients in the
+match whenever any seat or metadata changes during the lobby phase.
+
+#### Scenario: Seat change broadcasts update
+
+- **GIVEN** a match in `status: 'lobby'` with 4 connected clients
+- **WHEN** one player occupies seat `alpha-1`
+- **THEN** all 4 clients SHALL receive an `Event {type: 'lobby_
+updated', payload: {seats, meta}}` within 200ms
+- **AND** each client's local lobby view SHALL update to reflect the
+  new seat occupant
+
+#### Scenario: Occupant leaves broadcasts update
+
+- **GIVEN** a seated player who sends `LeaveSeat`
+- **WHEN** the server processes the intent
+- **THEN** the seat's occupant SHALL be cleared
+- **AND** a `lobby_updated` event SHALL be broadcast to the remaining
+  clients
+
+### Requirement: Room Code UI Contract
+
+The system SHALL expose the 6-character room code prominently in the
+lobby UI and support a one-click invite link that resolves to the
+lobby page via the code.
+
+#### Scenario: Lobby page shows code
+
+- **GIVEN** a client lands on `/gameplay/mp-lobby/[matchId]`
+- **WHEN** the page renders
+- **THEN** the current `roomCode` SHALL be visible in the header
+- **AND** a copy-to-clipboard button SHALL copy an absolute invite URL
+  of the form `<origin>/gameplay/mp-invite/{roomCode}`
+
+#### Scenario: Invite URL resolves and navigates
+
+- **GIVEN** a user visits `/gameplay/mp-invite/{roomCode}`
+- **WHEN** the page mounts
+- **THEN** the page SHALL call `/api/multiplayer/invites/{roomCode}`
+- **AND** on a valid response, SHALL navigate to
+  `/gameplay/mp-lobby/{matchId}`
+
+#### Scenario: Expired code renders error
+
+- **GIVEN** a room code whose match is already active
+- **WHEN** the user visits the invite URL
+- **THEN** the page SHALL render an error message
+  `"This match has already started"`
+- **AND** offer a link back to the landing page

--- a/openspec/changes/add-multiplayer-lobby-and-matchmaking-2-8/tasks.md
+++ b/openspec/changes/add-multiplayer-lobby-and-matchmaking-2-8/tasks.md
@@ -13,8 +13,8 @@
 ## 2. Seat Slot Data Model
 
 - [ ] 2.1 Define `IMatchSeat` with `{slotId, side, seatNumber,
-    occupant: IPlayerRef | null, kind: 'human' | 'ai', ready: boolean,
-    aiProfile?: string}`
+occupant: IPlayerRef | null, kind: 'human' | 'ai', ready: boolean,
+aiProfile?: string}`
 - [ ] 2.2 Seats live on `IMatchMeta` under `seats: IMatchSeat[]`
 - [ ] 2.3 Seat `slotId` format: `{side}-{seatNumber}` e.g. `alpha-1`,
       `bravo-2`
@@ -22,7 +22,7 @@
 ## 3. Match Creation Expansion
 
 - [ ] 3.1 `POST /api/multiplayer/matches` accepts `{config,
-    layout: TeamLayout, aiSlots?: string[]}`
+layout: TeamLayout, aiSlots?: string[]}`
 - [ ] 3.2 Server generates `matchId`, invite `roomCode` (6-char,
       reusing `roomCodes.ts`), and initializes seats
 - [ ] 3.3 If `aiSlots` is provided at creation, those slots are pre-
@@ -34,7 +34,7 @@
 - [ ] 4.1 Match meta stores both `matchId` (internal) and `roomCode`
       (shareable)
 - [ ] 4.2 `GET /api/multiplayer/invites/:roomCode` returns `{matchId,
-    status}` so a joiner can resolve code → match
+status}` so a joiner can resolve code → match
 - [ ] 4.3 Joining: client hits the resolve endpoint, then connects to
       the WebSocket with the resolved match id
 - [ ] 4.4 Invite codes expire when the match enters `status: 'active'`
@@ -121,4 +121,4 @@
 - [ ] 12.2 Every requirement in the `multiplayer-sync` MODIFIED delta
       has at least one GIVEN/WHEN/THEN scenario
 - [ ] 12.3 `openspec validate add-multiplayer-lobby-and-matchmaking-2-8
-    --strict` passes clean
+--strict` passes clean

--- a/openspec/changes/add-multiplayer-lobby-and-matchmaking-2-8/tasks.md
+++ b/openspec/changes/add-multiplayer-lobby-and-matchmaking-2-8/tasks.md
@@ -1,0 +1,124 @@
+# Tasks: Add Multiplayer Lobby and Matchmaking (2-8)
+
+## 1. Team Layout Primitives
+
+- [ ] 1.1 Define `TeamLayout` enum: `'1v1'`, `'2v2'`, `'3v3'`, `'4v4'`,
+      `'ffa-2'`, `'ffa-3'`, `'ffa-4'`, `'ffa-5'`, `'ffa-6'`, `'ffa-7'`,
+      `'ffa-8'`
+- [ ] 1.2 Derive seat count: team layouts → 2 sides × N seats; FFA
+      layouts → N sides × 1 seat
+- [ ] 1.3 Derive default side names: `'Alpha'`, `'Bravo'`, `'Charlie'`,
+      ... for each side
+
+## 2. Seat Slot Data Model
+
+- [ ] 2.1 Define `IMatchSeat` with `{slotId, side, seatNumber,
+    occupant: IPlayerRef | null, kind: 'human' | 'ai', ready: boolean,
+    aiProfile?: string}`
+- [ ] 2.2 Seats live on `IMatchMeta` under `seats: IMatchSeat[]`
+- [ ] 2.3 Seat `slotId` format: `{side}-{seatNumber}` e.g. `alpha-1`,
+      `bravo-2`
+
+## 3. Match Creation Expansion
+
+- [ ] 3.1 `POST /api/multiplayer/matches` accepts `{config,
+    layout: TeamLayout, aiSlots?: string[]}`
+- [ ] 3.2 Server generates `matchId`, invite `roomCode` (6-char,
+      reusing `roomCodes.ts`), and initializes seats
+- [ ] 3.3 If `aiSlots` is provided at creation, those slots are pre-
+      marked `kind: 'ai'`
+- [ ] 3.4 Host is auto-assigned to the first open human seat
+
+## 4. Room Code Invite Flow
+
+- [ ] 4.1 Match meta stores both `matchId` (internal) and `roomCode`
+      (shareable)
+- [ ] 4.2 `GET /api/multiplayer/invites/:roomCode` returns `{matchId,
+    status}` so a joiner can resolve code → match
+- [ ] 4.3 Joining: client hits the resolve endpoint, then connects to
+      the WebSocket with the resolved match id
+- [ ] 4.4 Invite codes expire when the match enters `status: 'active'`
+
+## 5. Seat Assignment Intents
+
+- [ ] 5.1 Intent `OccupySeat {slotId}`: a joining player occupies an
+      unoccupied human seat
+- [ ] 5.2 Intent `LeaveSeat {slotId}`: player leaves; seat becomes
+      unoccupied
+- [ ] 5.3 Intent `ReassignSeat {slotId, toSide, toSeat}` (host only):
+      moves an occupant to a different seat
+- [ ] 5.4 Intent `SetAiSlot {slotId, aiProfile}` (host only): toggles
+      a seat to AI
+- [ ] 5.5 Intent `SetHumanSlot {slotId}` (host only): toggles an AI
+      seat back to unoccupied-human
+
+## 6. Readiness Protocol
+
+- [ ] 6.1 Intent `ReadyToggle {slotId, ready: boolean}` for the slot
+      owner
+- [ ] 6.2 AI slots are always considered ready
+- [ ] 6.3 All seats must be ready AND no seat may be empty before
+      launch
+- [ ] 6.4 Host-only intent `LaunchMatch` flips the match from `'lobby'`
+      to `'active'` and emits `GameStarted`
+
+## 7. Lobby UI
+
+- [ ] 7.1 New page `/gameplay/mp-lobby/[matchId]`
+- [ ] 7.2 Renders seats grouped by side in a grid; each seat shows
+      occupant name / AI profile / "empty" / "you"
+- [ ] 7.3 Each seat has slot controls: self-occupy/leave for open
+      seats, host controls for AI toggle, ready toggle for occupied
+      seats
+- [ ] 7.4 Top banner shows room code with copy-to-clipboard and an
+      "invite link" (absolute URL)
+- [ ] 7.5 Launch button visible only to the host when readiness is
+      satisfied
+
+## 8. AI Slot Wiring
+
+- [ ] 8.1 Server spawns a `BotPlayer` per AI slot when the match
+      launches
+- [ ] 8.2 Bot players run inside the server process; they consume
+      events and produce intents through an in-process bus (not
+      WebSocket)
+- [ ] 8.3 Bot profiles: `'basic'`, `'aggressive'`, `'cautious'`
+      (existing `BotPlayer` flavors)
+
+## 9. Player Join/Leave Mid-Lobby
+
+- [ ] 9.1 Player disconnect during lobby auto-clears their seat after
+      60 seconds
+- [ ] 9.2 Auto-cleared seat becomes `null` occupant (still human kind);
+      host can invite a replacement or toggle to AI
+- [ ] 9.3 Host disconnect during lobby does NOT delete the match; it
+      pauses all lobby actions and shows `"Host reconnecting..."`
+
+## 10. Launching Into 2-8 Match
+
+- [ ] 10.1 On `LaunchMatch`, server emits `GameCreated` with side
+      assignments derived from seats
+- [ ] 10.2 Server persists the `seat → side` map on `IMatchMeta`
+- [ ] 10.3 All clients transition from lobby page to combat page
+      `/gameplay/games/[matchId]`
+
+## 11. Tests
+
+- [ ] 11.1 Integration test: create `'2v2'` match, 4 humans join via
+      room code, all ready, host launches, each client is on the
+      correct side
+- [ ] 11.2 Integration test: create `'ffa-4'` with 2 humans and 2 AI
+      slots; verify bots generate valid intents in-process
+- [ ] 11.3 Integration test: host toggles a human slot to AI after
+      one player joins that slot; player is kicked from the seat
+- [ ] 11.4 Integration test: sixth player tries to join a `'2v2'`
+      match; server responds `Error {code: 'MATCH_FULL'}`
+
+## 12. Spec Compliance
+
+- [ ] 12.1 Every requirement in the `multiplayer-server` MODIFIED
+      delta has at least one GIVEN/WHEN/THEN scenario
+- [ ] 12.2 Every requirement in the `multiplayer-sync` MODIFIED delta
+      has at least one GIVEN/WHEN/THEN scenario
+- [ ] 12.3 `openspec validate add-multiplayer-lobby-and-matchmaking-2-8
+    --strict` passes clean

--- a/openspec/changes/add-multiplayer-server-infrastructure/proposal.md
+++ b/openspec/changes/add-multiplayer-server-infrastructure/proposal.md
@@ -1,0 +1,56 @@
+# Change: Add Multiplayer Server Infrastructure
+
+## Why
+
+**Sub-phase 4b.** The 4a P2P model works for 1v1 but has structural
+limits: no cheat resistance beyond "both peers ran the same build", no
+support for 3+ players, and host-leaves = game over. Phase 4b steps up
+to a server-authoritative model: the canonical `GameSession` runs on a
+server, clients connect as observers that submit intents, and all random
+rolls and rule resolution happen server-side. This change is the
+foundation — a transport contract, a session persistence contract, and
+a scaffold for running the same `GameEngine` server-side — without
+committing to a specific hosting provider yet.
+
+## What Changes
+
+- Introduce `multiplayer-server` spec describing the WebSocket-based
+  client-server protocol and the session persistence contract
+- Define the transport: bi-directional WebSocket channel between client
+  and server, JSON-encoded messages, with typed envelopes:
+  `SessionJoin`, `Intent`, `Event`, `ReplayStream`, `Heartbeat`,
+  `Error`, `Close`
+- Define the session persistence contract: a pluggable `IMatchStore`
+  interface with `createMatch`, `appendEvent`, `getEvents`,
+  `getMatchMeta`, `closeMatch` — leaving the concrete implementation
+  (SQLite, Postgres, Redis, Fly Volumes, Supabase) deferred
+- Scaffold a Node.js server that runs `GameEngine` + `InteractiveSession`
+  server-side under the existing Next.js API route structure, with a
+  dev-mode in-memory `IMatchStore`
+- Keep the hosting decision open: proposal defines the protocol + the
+  store contract; production implementation is a later change
+
+## Dependencies
+
+- **Requires**: `add-p2p-game-session-sync` (validated the event-sync
+  model that the server now arbitrates), existing
+  `game-session-management`, `api-layer`, `event-store`,
+  `auto-save-persistence`
+- **Required By**: `add-authoritative-roll-arbitration`,
+  `add-multiplayer-lobby-and-matchmaking-2-8`,
+  `add-player-identity-and-auth`,
+  `add-reconnection-and-session-rehydration`,
+  `add-fog-of-war-event-filtering`
+
+## Impact
+
+- Affected specs: `multiplayer-server` (ADDED — WebSocket envelopes,
+  match store contract, server lifecycle), `api-layer` (MODIFIED —
+  documents the WebSocket path and thin REST surface for match
+  creation)
+- Affected code: new `src/server/multiplayer/` (transport, match store,
+  session host), new `src/pages/api/multiplayer/` WebSocket upgrade
+  endpoint, new `src/lib/multiplayer/client.ts` (typed client wrapper)
+- Non-goals: specific cloud vendor, identity/auth (separate change),
+  fog of war (separate change), load balancing, horizontal scaling,
+  encryption beyond TLS, voice chat

--- a/openspec/changes/add-multiplayer-server-infrastructure/specs/api-layer/spec.md
+++ b/openspec/changes/add-multiplayer-server-infrastructure/specs/api-layer/spec.md
@@ -1,0 +1,63 @@
+# api-layer Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Multiplayer REST Surface
+
+The api-layer SHALL expose a thin REST surface for multiplayer match
+lifecycle that complements the WebSocket event channel.
+
+#### Scenario: Create match
+
+- **GIVEN** an authenticated player wants to host a match
+- **WHEN** they POST `/api/multiplayer/matches` with body
+  `{config, players: IPlayerRef[]}`
+- **THEN** the response SHALL be `200 OK` with
+  `{matchId, wsUrl, hostPlayerId}`
+- **AND** the match SHALL be created in the `IMatchStore` with `status:
+'lobby'`
+
+#### Scenario: Fetch match meta
+
+- **GIVEN** a match id
+- **WHEN** GET `/api/multiplayer/matches/:id` is called
+- **THEN** the response SHALL return `IMatchMeta` with `matchId,
+hostPlayerId, playerIds, sideAssignments, status, createdAt,
+updatedAt`
+- **AND** the payload SHALL NOT include event-log content
+
+#### Scenario: Close match (host only)
+
+- **GIVEN** an authenticated host owns a match
+- **WHEN** they DELETE `/api/multiplayer/matches/:id`
+- **THEN** the server SHALL append `GameEnded {reason: 'host-closed'}`
+  to the match
+- **AND** the store SHALL mark the match `status: 'completed'`
+
+#### Scenario: Non-host cannot close
+
+- **GIVEN** an authenticated player who is NOT the match host
+- **WHEN** they DELETE `/api/multiplayer/matches/:id`
+- **THEN** the response SHALL be `403 Forbidden`
+
+### Requirement: WebSocket Endpoint Documentation
+
+The api-layer SHALL document the multiplayer WebSocket endpoint path,
+upgrade requirements, and envelope types alongside the REST surface.
+
+#### Scenario: Endpoint is documented
+
+- **GIVEN** the api-layer documentation set
+- **WHEN** inspected
+- **THEN** the path `/api/multiplayer/socket` SHALL be listed as a
+  WebSocket endpoint
+- **AND** the docs SHALL enumerate the envelope kinds
+
+#### Scenario: Upgrade auth
+
+- **GIVEN** a WebSocket upgrade request
+- **WHEN** the server handles it
+- **THEN** an `Authorization` header or `?token=...` query parameter
+  SHALL be present with a valid player token
+- **AND** if missing or invalid, the server SHALL respond `401
+Unauthorized` and NOT upgrade

--- a/openspec/changes/add-multiplayer-server-infrastructure/specs/multiplayer-server/spec.md
+++ b/openspec/changes/add-multiplayer-server-infrastructure/specs/multiplayer-server/spec.md
@@ -1,0 +1,173 @@
+# multiplayer-server Specification Delta
+
+## ADDED Requirements
+
+### Requirement: WebSocket Transport
+
+The system SHALL provide a bidirectional WebSocket channel for clients
+to exchange messages with the authoritative server during a networked
+match.
+
+#### Scenario: Client connects and joins
+
+- **GIVEN** a client wants to join match `sess_abc`
+- **WHEN** the client opens a WebSocket to the multiplayer endpoint and
+  sends `{kind: 'SessionJoin', matchId: 'sess_abc', playerId,
+lastSeq: 0}`
+- **THEN** the server SHALL validate the player's membership in the
+  match
+- **AND** the server SHALL stream the event log from `lastSeq+1` via
+  `ReplayStart`, one or more `ReplayChunk`, and `ReplayEnd`
+- **AND** after `ReplayEnd` the client SHALL receive live `Event`
+  messages as they are appended
+
+#### Scenario: Server rejects unknown match
+
+- **GIVEN** a client sends `SessionJoin` with an unknown `matchId`
+- **WHEN** the server handles the message
+- **THEN** the server SHALL reply `Error {code: 'UNKNOWN_MATCH'}`
+- **AND** the server SHALL close the socket
+
+#### Scenario: Heartbeat keeps connection alive
+
+- **GIVEN** a connected client
+- **WHEN** 20 seconds pass with no other traffic
+- **THEN** the server SHALL send a `Heartbeat`
+- **AND** the client SHALL reply with a `Heartbeat`
+- **AND** if either side misses three heartbeats in a row, the
+  connection SHALL be torn down
+
+### Requirement: Message Envelopes
+
+The system SHALL define a typed, validated set of message envelopes for
+all client-server communication.
+
+#### Scenario: Envelope kinds
+
+- **GIVEN** the protocol is inspected
+- **WHEN** listing envelope kinds
+- **THEN** the enumeration SHALL include `SessionJoin`, `Intent`,
+  `Event`, `ReplayStart`, `ReplayChunk`, `ReplayEnd`, `Heartbeat`,
+  `Error`, `Close`
+
+#### Scenario: Malformed envelope rejected
+
+- **GIVEN** a client sends a message missing required fields
+- **WHEN** the server validates the envelope
+- **THEN** the server SHALL respond `Error {code: 'BAD_ENVELOPE'}`
+- **AND** the connection SHALL remain open
+
+### Requirement: Match Store Contract
+
+The system SHALL define an `IMatchStore` interface that decouples
+session persistence from the in-memory server, allowing plug-in storage
+backends (SQLite, Postgres, Redis, cloud stores) without touching the
+server core.
+
+#### Scenario: Store interface methods
+
+- **GIVEN** an `IMatchStore` implementation
+- **WHEN** the type is inspected
+- **THEN** it SHALL expose `createMatch`, `appendEvent`, `getEvents`,
+  `getMatchMeta`, `updateMatchMeta`, `closeMatch`
+- **AND** every method SHALL return a `Promise`
+
+#### Scenario: Store append is transactional
+
+- **GIVEN** two concurrent `appendEvent` calls for the same match with
+  the same `sequence`
+- **WHEN** the store handles both
+- **THEN** exactly one SHALL succeed
+- **AND** the other SHALL reject with a `sequence-collision` error
+- **AND** the succeeding event SHALL be durably stored before the
+  promise resolves
+
+#### Scenario: Store preserves order on read
+
+- **GIVEN** a match with 50 events stored
+- **WHEN** `getEvents(matchId)` is called
+- **THEN** the returned array SHALL be ordered by ascending `sequence`
+- **AND** there SHALL be no gaps in sequence numbers
+
+### Requirement: Server-Authoritative Session Host
+
+The system SHALL run the canonical `GameSession` on the server for any
+networked match; clients send intents, receive events, and never mutate
+session state directly.
+
+#### Scenario: Intent translates to event
+
+- **GIVEN** a client sends `Intent {type: 'declareMovement', payload}`
+- **WHEN** the server's `ServerMatchHost` processes it
+- **THEN** the host SHALL run validation + engine resolution
+- **AND** on success, the host SHALL append the resulting event(s) to
+  the match store
+- **AND** the host SHALL broadcast `Event` messages to all connected
+  clients for that match
+
+#### Scenario: Invalid intent does not mutate state
+
+- **GIVEN** a client sends an intent for a unit not owned by their
+  player
+- **WHEN** the server processes it
+- **THEN** the server SHALL respond `Error {code: 'INVALID_INTENT',
+reason: 'unauthorized-unit'}`
+- **AND** no events SHALL be appended
+
+#### Scenario: Server restart resumes match
+
+- **GIVEN** a match `sess_abc` with 30 events persisted in the store
+- **WHEN** the server restarts and a client reconnects with `lastSeq:
+0`
+- **THEN** the server SHALL instantiate a fresh `ServerMatchHost` for
+  `sess_abc`, load the 30 events from the store, and replay them into
+  the client
+
+### Requirement: Dev-Mode In-Memory Store
+
+The system SHALL ship an in-memory `IMatchStore` implementation for
+development and testing, clearly labeled as non-production.
+
+#### Scenario: Dev store works for session
+
+- **GIVEN** the server is configured with `InMemoryMatchStore`
+- **WHEN** a client creates a match and appends events
+- **THEN** the events SHALL be retrievable via `getEvents`
+- **AND** the match SHALL behave identically to a persistent store for
+  the duration of the process
+
+#### Scenario: Dev store warns loudly
+
+- **GIVEN** the server starts with `InMemoryMatchStore`
+- **WHEN** the startup log is inspected
+- **THEN** a warning SHALL be present stating the store is dev-only
+- **AND** the warning SHALL include `"configure a persistent store for
+production"`
+
+### Requirement: Error Surface
+
+The system SHALL surface server-side errors to clients in a structured,
+typed shape so clients can react appropriately without string parsing.
+
+#### Scenario: Error envelope shape
+
+- **GIVEN** the server encounters an error condition
+- **WHEN** it emits an `Error` envelope
+- **THEN** the envelope SHALL contain `kind: 'Error'`, `code: string`,
+  `reason: string`, optional `intentId` for correlation
+
+#### Scenario: Intent-level errors keep connection open
+
+- **GIVEN** a client submits an invalid intent
+- **WHEN** the server replies with an `Error` envelope
+- **THEN** the WebSocket connection SHALL remain open
+- **AND** the client SHALL be able to send a corrected intent
+
+#### Scenario: Fatal errors close connection
+
+- **GIVEN** the match store fails during an append
+- **WHEN** the server emits `Error {code: 'STORE_FAILURE'}`
+- **THEN** the server SHALL subsequently send `Close` and disconnect
+  all clients on that match
+- **AND** the match SHALL be marked `'completed'` with cause
+  `'server-error'`

--- a/openspec/changes/add-multiplayer-server-infrastructure/tasks.md
+++ b/openspec/changes/add-multiplayer-server-infrastructure/tasks.md
@@ -1,0 +1,141 @@
+# Tasks: Add Multiplayer Server Infrastructure
+
+## 1. Transport Protocol
+
+- [ ] 1.1 Define `ServerMessage` and `ClientMessage` discriminated
+      unions covering: `SessionJoin`, `Intent`, `Event`, `ReplayStart`,
+      `ReplayChunk`, `ReplayEnd`, `Heartbeat`, `Error`, `Close`
+- [ ] 1.2 Each message carries `kind`, `matchId`, and a `ts` (ISO
+      timestamp)
+- [ ] 1.3 All messages are JSON-encoded
+- [ ] 1.4 Envelope schema validation via zod on both client and server
+- [ ] 1.5 Heartbeat every 20 seconds; missed heartbeat after 60s =
+      treat connection as dead
+
+## 2. Match Store Contract
+
+- [ ] 2.1 Define `IMatchStore` interface with methods:
+      `createMatch(meta): Promise<matchId>`,
+      `appendEvent(matchId, event): Promise<void>`,
+      `getEvents(matchId, fromSeq?): Promise<IGameEvent[]>`,
+      `getMatchMeta(matchId): Promise<IMatchMeta>`,
+      `updateMatchMeta(matchId, patch): Promise<void>`,
+      `closeMatch(matchId): Promise<void>`
+- [ ] 2.2 Define `IMatchMeta` shape: `{matchId, hostPlayerId,
+    playerIds, sideAssignments, status: 'lobby' | 'active' |
+    'completed', createdAt, updatedAt, config}`
+- [ ] 2.3 Store contract MUST be transactional: `appendEvent` is
+      all-or-nothing, sequence collisions SHALL reject
+- [ ] 2.4 Store MUST be async; synchronous implementations acceptable
+      via `Promise.resolve`
+
+## 3. In-Memory Match Store (Dev Mode)
+
+- [ ] 3.1 Implement `InMemoryMatchStore` satisfying `IMatchStore`
+- [ ] 3.2 Backs a `Map<matchId, {meta, events}>`
+- [ ] 3.3 Exposed via a factory so a production store can be swapped in
+      without touching call sites
+- [ ] 3.4 Warn prominently on server startup: `"InMemoryMatchStore is
+    dev-only; configure a persistent store for production"`
+
+## 4. WebSocket Upgrade Endpoint
+
+- [ ] 4.1 Add `src/pages/api/multiplayer/socket.ts` that handles the
+      WebSocket upgrade under Next.js's custom server path
+- [ ] 4.2 First message from a client MUST be `SessionJoin`; server
+      replies with either `ReplayStart` + log or `Error`
+- [ ] 4.3 Server maintains a `Set<WebSocket>` per match id for
+      broadcasting
+- [ ] 4.4 Disconnection removes the socket from the set but does NOT
+      end the match
+
+## 5. Server-Side Engine Host
+
+- [ ] 5.1 New `ServerMatchHost` class: wraps one `InteractiveSession`
+      per active match, owns its lifetime
+- [ ] 5.2 Hosts receive `Intent` messages, validate, run the engine,
+      append the resulting events to the `IMatchStore`, broadcast the
+      events to all connected clients for that match
+- [ ] 5.3 Host persists after every appended event (write-through)
+- [ ] 5.4 Host loads its session from the store on creation so a server
+      restart can resume
+
+## 6. Client Wrapper
+
+- [ ] 6.1 New `src/lib/multiplayer/client.ts` exporting `connect(url,
+    matchId, auth)` → `IMultiplayerClient`
+- [ ] 6.2 Client exposes `send(intent)`, `on(event, cb)`, `close()`
+- [ ] 6.3 Client handles replay on connect: accumulates events until a
+      `ReplayEnd`, then fires `ready`
+- [ ] 6.4 Client auto-reconnects with exponential backoff (capped at
+      30s)
+
+## 7. Match Creation REST
+
+- [ ] 7.1 `POST /api/multiplayer/matches` body: `{config, players:
+    IPlayerRef[]}` returns `{matchId, wsUrl}`
+- [ ] 7.2 `GET /api/multiplayer/matches/:id` returns match meta (for
+      the lobby)
+- [ ] 7.3 `DELETE /api/multiplayer/matches/:id` (host-only) closes a
+      match
+- [ ] 7.4 All endpoints require a valid `playerId` in a bearer token or
+      header (full auth is a separate change)
+
+## 8. Observability
+
+- [ ] 8.1 Each `ServerMatchHost` logs key events (session created,
+      event appended, player joined/left, match ended) via the
+      existing `logging-system`
+- [ ] 8.2 A metrics hook exposes active match count and connected
+      player count for future dashboards (no dashboard in this change)
+- [ ] 8.3 Correlate logs with `matchId` so a failing match can be
+      traced end-to-end
+
+## 9. Error Handling
+
+- [ ] 9.1 Malformed message → server responds `Error {code: 'BAD_
+    ENVELOPE'}` and keeps the connection open
+- [ ] 9.2 Invalid intent (e.g., out-of-phase) → server responds
+      `Error {code: 'INVALID_INTENT', reason}` without mutating state
+- [ ] 9.3 Store error during append → server closes affected match with
+      `{code: 'STORE_FAILURE'}` and broadcasts to all clients
+- [ ] 9.4 Client reconnect sends its `lastSeq`; server replays from
+      there
+
+## 10. Dev Server Scripts
+
+- [ ] 10.1 `npm run mp-dev` starts Next.js with the WebSocket handler
+      and an `InMemoryMatchStore`
+- [ ] 10.2 `npm run mp-smoke` runs a smoke test: 2 client wrappers
+      connect to the same match, fire a few intents, assert state
+      matches
+- [ ] 10.3 Scripts referenced in `package.json`
+
+## 11. Tests
+
+- [ ] 11.1 Unit test `InMemoryMatchStore` (create, append, get, close,
+      sequence collision)
+- [ ] 11.2 Unit test envelope validation (valid + malformed samples)
+- [ ] 11.3 Integration test: spin up the server in-process, connect two
+      clients, play a canned 10-event match, assert both receive
+      identical event streams
+- [ ] 11.4 Integration test: a server restart reloads the match from
+      `IMatchStore` and clients can resume
+- [ ] 11.5 Load test (smoke only): 8 clients, 500 intents, no dropped
+      events
+
+## 12. Documentation
+
+- [ ] 12.1 Update `docs/architecture.md` section for multiplayer
+      transport
+- [ ] 12.2 Document the `IMatchStore` interface in inline JSDoc and
+      reference it from the spec
+
+## 13. Spec Compliance
+
+- [ ] 13.1 Every requirement in the `multiplayer-server` ADDED delta
+      has at least one GIVEN/WHEN/THEN scenario
+- [ ] 13.2 Every requirement in the `api-layer` MODIFIED delta has at
+      least one GIVEN/WHEN/THEN scenario
+- [ ] 13.3 `openspec validate add-multiplayer-server-infrastructure
+    --strict` passes clean

--- a/openspec/changes/add-multiplayer-server-infrastructure/tasks.md
+++ b/openspec/changes/add-multiplayer-server-infrastructure/tasks.md
@@ -22,8 +22,8 @@
       `updateMatchMeta(matchId, patch): Promise<void>`,
       `closeMatch(matchId): Promise<void>`
 - [ ] 2.2 Define `IMatchMeta` shape: `{matchId, hostPlayerId,
-    playerIds, sideAssignments, status: 'lobby' | 'active' |
-    'completed', createdAt, updatedAt, config}`
+playerIds, sideAssignments, status: 'lobby' | 'active' |
+'completed', createdAt, updatedAt, config}`
 - [ ] 2.3 Store contract MUST be transactional: `appendEvent` is
       all-or-nothing, sequence collisions SHALL reject
 - [ ] 2.4 Store MUST be async; synchronous implementations acceptable
@@ -36,7 +36,7 @@
 - [ ] 3.3 Exposed via a factory so a production store can be swapped in
       without touching call sites
 - [ ] 3.4 Warn prominently on server startup: `"InMemoryMatchStore is
-    dev-only; configure a persistent store for production"`
+dev-only; configure a persistent store for production"`
 
 ## 4. WebSocket Upgrade Endpoint
 
@@ -63,7 +63,7 @@
 ## 6. Client Wrapper
 
 - [ ] 6.1 New `src/lib/multiplayer/client.ts` exporting `connect(url,
-    matchId, auth)` → `IMultiplayerClient`
+matchId, auth)` → `IMultiplayerClient`
 - [ ] 6.2 Client exposes `send(intent)`, `on(event, cb)`, `close()`
 - [ ] 6.3 Client handles replay on connect: accumulates events until a
       `ReplayEnd`, then fires `ready`
@@ -73,7 +73,7 @@
 ## 7. Match Creation REST
 
 - [ ] 7.1 `POST /api/multiplayer/matches` body: `{config, players:
-    IPlayerRef[]}` returns `{matchId, wsUrl}`
+IPlayerRef[]}` returns `{matchId, wsUrl}`
 - [ ] 7.2 `GET /api/multiplayer/matches/:id` returns match meta (for
       the lobby)
 - [ ] 7.3 `DELETE /api/multiplayer/matches/:id` (host-only) closes a
@@ -94,7 +94,7 @@
 ## 9. Error Handling
 
 - [ ] 9.1 Malformed message → server responds `Error {code: 'BAD_
-    ENVELOPE'}` and keeps the connection open
+ENVELOPE'}` and keeps the connection open
 - [ ] 9.2 Invalid intent (e.g., out-of-phase) → server responds
       `Error {code: 'INVALID_INTENT', reason}` without mutating state
 - [ ] 9.3 Store error during append → server closes affected match with
@@ -138,4 +138,4 @@
 - [ ] 13.2 Every requirement in the `api-layer` MODIFIED delta has at
       least one GIVEN/WHEN/THEN scenario
 - [ ] 13.3 `openspec validate add-multiplayer-server-infrastructure
-    --strict` passes clean
+--strict` passes clean

--- a/openspec/changes/add-p2p-game-session-sync/proposal.md
+++ b/openspec/changes/add-p2p-game-session-sync/proposal.md
@@ -1,0 +1,56 @@
+# Change: Add P2P Game Session Sync
+
+## Why
+
+**Sub-phase 4a.** Phase 4 targets 2–8 player multiplayer, but a
+server-authoritative backend is a multi-month lift. The existing Yjs /
+WebRTC infrastructure (`src/lib/p2p/`, `useSyncRoomStore`) already
+synchronizes vault items and customizer tabs between peers with a 6-char
+room code. Because `gameSessionCore.ts` is already event-sourced, the
+fastest path to a playable 1v1 networked match is to broadcast each
+appended `IGameEvent` to a single remote peer and apply it to their
+mirror session. This sub-phase delivers real two-machine play before the
+server architecture is even designed, and validates the event-sync model
+that 4b will formalize server-side.
+
+## What Changes
+
+- Introduce `multiplayer-sync` spec describing peer-event replication
+  semantics for `IGameSession`
+- Wire the existing Yjs room infrastructure to carry a new channel that
+  transmits `IGameEvent` deltas in arrival order
+- Local engine appends an event, channel broadcasts to peer, peer's
+  mirror session applies it via the existing `appendEvent` reducer
+- The peer who created the match is the "host": all random rolls
+  (initiative, to-hit, hit location, cluster, crit, consciousness) are
+  generated only on the host's engine; the guest's `DiceRoller` is
+  replaced by a deterministic replayer that consumes rolls received from
+  the host's events
+- Host disconnect ends the session with `reason: 'aborted'`; guest
+  disconnect produces a reconnect window (see
+  `add-game-session-persistence-for-reconnect`)
+- Add a "Networked 1v1" side to the skirmish setup screen that requires a
+  connected peer before launch
+
+## Dependencies
+
+- **Requires**: Phase 1 MVP changes (`add-skirmish-setup-ui`,
+  `add-interactive-combat-core-ui`, `wire-*` rule-accuracy changes),
+  existing `p2p-sync-system`, `game-session-management`, `api-layer`,
+  `dice-system`
+- **Required By**: `add-game-session-invite-and-lobby-1v1`,
+  `add-game-session-persistence-for-reconnect`,
+  `add-multiplayer-server-infrastructure` (4b validates this sync model)
+
+## Impact
+
+- Affected specs: `game-session-management` (MODIFIED — host-authoritative
+  roll semantics, peer-mirror sessions, abort condition),
+  `multiplayer-sync` (ADDED — peer event replication), `api-layer`
+  (ADDED — no new HTTP routes, but P2P channel contracts are documented)
+- Affected code: new `src/lib/p2p/gameSessionChannel.ts`, extension of
+  `src/engine/InteractiveSession.ts` with mirror-mode, extension of
+  `src/stores/useGameplayStore.ts` for peer-event intake, new
+  `src/utils/gameplay/replayDiceRoller.ts`
+- Non-goals: 3+ players, server persistence, fog of war, cheating
+  resistance beyond "both peers run the same engine build"

--- a/openspec/changes/add-p2p-game-session-sync/specs/api-layer/spec.md
+++ b/openspec/changes/add-p2p-game-session-sync/specs/api-layer/spec.md
@@ -1,0 +1,50 @@
+# api-layer Specification Delta
+
+## ADDED Requirements
+
+### Requirement: P2P Peer Channel Contracts
+
+The api-layer SHALL document the peer-to-peer channel contracts used by
+networked game sessions, since these contracts replace traditional HTTP
+endpoints for the 1v1 P2P multiplayer flow.
+
+#### Scenario: Event broadcast envelope
+
+- **GIVEN** a host peer appends an `IGameEvent`
+- **WHEN** the event is broadcast on the peer channel
+- **THEN** the wire shape SHALL be
+  `{ kind: 'game-event', event: IGameEvent, authorPeerId: string }`
+- **AND** the envelope SHALL be serialized as JSON inside the existing
+  Yjs `gameEvents` Y.Array
+
+#### Scenario: Intent envelope
+
+- **GIVEN** a guest peer submits an action
+- **WHEN** the intent is broadcast on the peer channel
+- **THEN** the wire shape SHALL be
+  `{ kind: 'game-intent', intent: IGameIntent, authorPeerId: string }`
+- **AND** the host SHALL acknowledge by appending the resolved event,
+  which naturally replicates back to the guest
+
+#### Scenario: Rejection envelope
+
+- **GIVEN** a host rejects a guest intent
+- **WHEN** the rejection is sent on the peer channel
+- **THEN** the wire shape SHALL be
+  `{ kind: 'peer-rejected', intentId: string, reason: string }`
+- **AND** the guest SHALL surface the reason as a toast
+
+### Requirement: No New HTTP Routes in 4a
+
+The system SHALL NOT introduce any server-side HTTP routes for the 1v1
+P2P sync flow, keeping the entire protocol peer-to-peer through the
+existing `p2p-sync-system` transport.
+
+#### Scenario: Zero HTTP surface added
+
+- **GIVEN** the api-layer is inspected after this change ships
+- **WHEN** the route manifest is listed
+- **THEN** the count of HTTP routes SHALL be unchanged from before the
+  change
+- **AND** all documented multiplayer flows SHALL go through the peer
+  channel envelopes defined above

--- a/openspec/changes/add-p2p-game-session-sync/specs/game-session-management/spec.md
+++ b/openspec/changes/add-p2p-game-session-sync/specs/game-session-management/spec.md
@@ -1,0 +1,69 @@
+# game-session-management Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Host-Authoritative Networked Sessions
+
+The system SHALL support a networked mode where exactly one peer hosts
+the authoritative session and other peers run mirror sessions that apply
+events received over a peer channel.
+
+#### Scenario: Host session owns the engine
+
+- **GIVEN** a networked match with `hostPeerId=P1` and `guestPeerId=P2`
+- **WHEN** events are appended
+- **THEN** only the peer whose `localPeerId === hostPeerId` SHALL invoke
+  phase resolvers, dice rolls, and damage pipelines
+- **AND** the guest peer's engine SHALL remain idle aside from applying
+  events received on the peer channel
+
+#### Scenario: Intent-mediated guest actions
+
+- **GIVEN** a guest wants their unit to move
+- **WHEN** the guest's UI commits the action
+- **THEN** the commit SHALL produce an `IGameIntent` on the peer channel
+  instead of appending a local event
+- **AND** the host SHALL validate the intent and, on success, append the
+  corresponding event
+
+### Requirement: Abort End Condition
+
+The system SHALL accept `'aborted'` as a valid `reason` on `GameEnded`
+events for sessions terminated by host disconnect or equivalent fatal
+transport failure in networked play.
+
+#### Scenario: Aborted reason accepted
+
+- **GIVEN** a networked match whose host has disconnected
+- **WHEN** the guest's client appends `GameEnded` with
+  `{winner: 'draw', reason: 'aborted'}`
+- **THEN** the event SHALL be accepted
+- **AND** `currentState.status` SHALL become `GameStatus.Completed`
+
+#### Scenario: Aborted session blocks further appends
+
+- **GIVEN** a session ended with `reason: 'aborted'`
+- **WHEN** any subsequent `appendEvent` call is attempted
+- **THEN** the call SHALL throw `"Game is not active"` per existing
+  lifecycle rules
+
+### Requirement: Peer Ownership on Session
+
+The system SHALL record peer ownership on networked sessions so rule
+engines and UI can distinguish authoritative vs. mirror participants.
+
+#### Scenario: Session carries host and guest peer ids
+
+- **GIVEN** a networked 1v1 match is created
+- **WHEN** the session is inspected
+- **THEN** it SHALL carry `hostPeerId: string` and
+  `guestPeerId: string | null` (null until guest joins)
+- **AND** it SHALL carry `sideOwners: Record<GameSide, string>`
+  mapping each side to the peer id that controls its units
+
+#### Scenario: Local session has no peer ownership
+
+- **GIVEN** a hot-seat (non-networked) match
+- **WHEN** the session is inspected
+- **THEN** `hostPeerId` and `guestPeerId` SHALL both be `null`
+- **AND** `sideOwners` SHALL be `null` or an empty object

--- a/openspec/changes/add-p2p-game-session-sync/specs/multiplayer-sync/spec.md
+++ b/openspec/changes/add-p2p-game-session-sync/specs/multiplayer-sync/spec.md
@@ -1,0 +1,154 @@
+# multiplayer-sync Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Peer Event Channel
+
+The system SHALL provide a peer-to-peer channel that transmits
+`IGameEvent` records between two peers in a shared sync room, in the
+order they are appended on the authoring peer.
+
+#### Scenario: Host-appended event reaches guest
+
+- **GIVEN** a host peer and a guest peer in the same sync room with an
+  active networked match
+- **WHEN** the host engine appends an event via `appendEvent`
+- **THEN** the event SHALL be broadcast on the peer channel
+- **AND** the guest SHALL receive the event within the next animation
+  frame
+- **AND** the guest's mirror session SHALL apply the event via its own
+  `appendEvent` reducer
+
+#### Scenario: Event ordering preserved
+
+- **GIVEN** the host appends events `E1`, `E2`, `E3` in that order
+- **WHEN** the events arrive on the guest
+- **THEN** they SHALL be applied to the guest's session in the same
+  order
+- **AND** the guest's `currentState` after `E3` SHALL match the host's
+  `currentState` after `E3`
+
+#### Scenario: Own events are not re-applied
+
+- **GIVEN** the host broadcasts an event `E1`
+- **WHEN** the host's own channel subscription receives `E1`
+- **THEN** the host SHALL detect that `E1.authorPeerId === localPeerId`
+- **AND** the host SHALL NOT append `E1` a second time
+
+### Requirement: Host-Authoritative RNG
+
+The system SHALL designate exactly one peer as the host in any networked
+match, and all random rolls SHALL originate on the host and be embedded
+in the event payload so the guest can replay them deterministically.
+
+#### Scenario: Host generates rolls via default DiceRoller
+
+- **GIVEN** a host engine resolving an initiative event
+- **WHEN** the host's `rollInitiative()` is called
+- **THEN** the default `DiceRoller` SHALL be used
+- **AND** the resulting dice values SHALL be stored on the emitted event
+  under `payload.rolls`
+
+#### Scenario: Guest replays rolls from event payload
+
+- **GIVEN** a guest receiving a peer event with `payload.rolls = [3, 5]`
+- **WHEN** the guest's mirror engine needs a dice result for the
+  corresponding action
+- **THEN** the guest's `replayDiceRoller` SHALL return those exact values
+- **AND** the guest SHALL NOT invoke any non-deterministic randomness
+
+#### Scenario: Two sessions converge under identical events
+
+- **GIVEN** a seeded host session and a guest mirror session, both
+  created from the same config
+- **WHEN** the host plays out 5 full turns and every emitted event is
+  replicated to the guest in order
+- **THEN** at every event boundary the host and guest `currentState`
+  SHALL be deep-equal
+
+### Requirement: Host Election and Role Assignment
+
+The system SHALL elect exactly one host per networked match and assign
+the other participant the role `guest`.
+
+#### Scenario: Room creator becomes host
+
+- **GIVEN** a peer creates a sync room and launches a networked match
+- **WHEN** the match session is created
+- **THEN** that peer's role SHALL be `host`
+- **AND** the peer id SHALL be recorded on the session under
+  `hostPeerId`
+
+#### Scenario: Second joiner becomes guest
+
+- **GIVEN** a host has created a networked match in a sync room
+- **WHEN** another peer joins the room and accepts the match
+- **THEN** that peer's role SHALL be `guest`
+- **AND** the peer id SHALL be recorded on the session under
+  `guestPeerId`
+
+#### Scenario: Third joiner is rejected
+
+- **GIVEN** a networked 1v1 match already has a host and a guest
+- **WHEN** a third peer joins the room and attempts to join the match
+- **THEN** the match SHALL refuse the join
+- **AND** the third peer's UI SHALL surface `"Match is full"`
+
+### Requirement: Side Ownership
+
+The system SHALL record which peer controls which game side, and SHALL
+forbid local event production for sides not owned by the local peer.
+
+#### Scenario: Peer cannot append for foreign side
+
+- **GIVEN** a guest peer whose side is `GameSide.Opponent`
+- **WHEN** the guest tries to append a MovementDeclared event for a unit
+  whose `side` is `GameSide.Player`
+- **THEN** the append SHALL be rejected
+- **AND** the UI SHALL surface a `peer-rejected` toast
+
+#### Scenario: Intent round-trip for owned side
+
+- **GIVEN** a guest peer whose side is `GameSide.Opponent`
+- **WHEN** the guest commits a movement for a unit they control
+- **THEN** the guest SHALL broadcast an `IGameIntent` with type
+  `declareMovement` to the host
+- **AND** the host SHALL validate the intent and append a corresponding
+  `MovementLocked` event
+- **AND** the resulting event SHALL replicate back to the guest
+
+### Requirement: Abort on Host Disconnect
+
+The system SHALL end a networked match with `reason: 'aborted'` if the
+host peer disconnects during an active session.
+
+#### Scenario: Host disconnect aborts the guest's session
+
+- **GIVEN** an active networked match
+- **WHEN** the host peer's Yjs awareness is lost for more than
+  5 seconds
+- **THEN** the guest's session SHALL append a local `GameEnded` event
+  with `reason: 'aborted'` and `winner: 'draw'`
+- **AND** the guest's UI SHALL route to the victory screen with
+  `"Match aborted — host disconnected"`
+
+### Requirement: Intent Protocol for Guest Actions
+
+The system SHALL define an `IGameIntent` contract that the guest uses to
+request actions the host must validate and execute.
+
+#### Scenario: Intent shape
+
+- **GIVEN** a guest wants to commit an action
+- **WHEN** the intent is constructed
+- **THEN** it SHALL include `type`, `payload`, and `authorPeerId`
+- **AND** `type` SHALL be one of `declareMovement`, `declareAttack`,
+  `declarePhysical`, `confirmHeat`, `endPhase`, `concede`
+
+#### Scenario: Host rejects intent for out-of-phase action
+
+- **GIVEN** the session is in the Movement phase
+- **WHEN** the host receives a `declareAttack` intent from the guest
+- **THEN** the host SHALL NOT append an event
+- **AND** the host SHALL broadcast a `peer-rejected` notification to the
+  guest indicating `reason: 'wrong-phase'`

--- a/openspec/changes/add-p2p-game-session-sync/tasks.md
+++ b/openspec/changes/add-p2p-game-session-sync/tasks.md
@@ -56,7 +56,7 @@
 ## 6. Side Ownership
 
 - [ ] 6.1 `IGameSession` gains an optional `sideOwners: Record<GameSide,
-    string>` field mapping side → peerId
+string>` field mapping side → peerId
 - [ ] 6.2 Skirmish setup screen with "Networked 1v1" lets host pick which
       side they control; the other side is auto-assigned to the guest
 - [ ] 6.3 UI disables any control that would modify a unit whose side is

--- a/openspec/changes/add-p2p-game-session-sync/tasks.md
+++ b/openspec/changes/add-p2p-game-session-sync/tasks.md
@@ -1,0 +1,99 @@
+# Tasks: Add P2P Game Session Sync
+
+## 1. Channel Primitives
+
+- [ ] 1.1 Add `gameSessionChannel.ts` in `src/lib/p2p/` that exposes
+      `broadcastEvent(event: IGameEvent)` and `onPeerEvent(cb)`
+- [ ] 1.2 Channel rides on the existing Yjs room; events go through a
+      dedicated `gameEvents` Y.Array so the customizer-tab sync is
+      unaffected
+- [ ] 1.3 Channel serializes/deserializes `IGameEvent` with the same
+      schema used by `event-store` persistence
+- [ ] 1.4 Channel rejects events authored by the local peer on arrival
+      (don't re-apply own events)
+
+## 2. Host Election
+
+- [ ] 2.1 Room creator is marked `role: 'host'` in Yjs awareness
+- [ ] 2.2 Room joiner is `role: 'guest'`; second joiner is rejected (1v1
+      only in this change)
+- [ ] 2.3 A `HostPromoted` / `GuestJoined` lifecycle event is logged
+      locally (not part of session event stream)
+
+## 3. Host-Authoritative RNG
+
+- [ ] 3.1 Host engine uses the existing default `DiceRoller`
+- [ ] 3.2 Guest engine uses a new `replayDiceRoller` that pops rolls off a
+      queue populated from incoming events' `payload.rolls`
+- [ ] 3.3 Every event the host generates that consumed dice includes the
+      rolled values in the event payload so the guest mirror can replay
+      them deterministically
+- [ ] 3.4 Unit test: a seeded host session and a guest session consuming
+      its events produce identical `currentState` at every step
+
+## 4. Mirror Session on Guest
+
+- [ ] 4.1 Guest creates a session object from the same config as the host
+- [ ] 4.2 Guest rejects any local event append; all state changes come
+      from the peer channel
+- [ ] 4.3 Guest's `InteractiveSession` exposes the same read API as host
+- [ ] 4.4 Guest's UI can still `selectedUnitId` / hover / inspect, but
+      the "Commit" buttons submit an intent event through the peer
+      channel instead of calling `appendEvent` directly
+
+## 5. Intent Events (Guest → Host)
+
+- [ ] 5.1 Define `IGameIntent` = `{type, payload, authorPeerId}` for
+      actions the guest wants the host to execute
+- [ ] 5.2 Guest UI produces intents for `declareMovement`,
+      `declareAttack`, `declarePhysical`, `confirmHeat`, `endPhase`,
+      `concede`
+- [ ] 5.3 Host consumes intents and translates them into appended events
+      after running the normal validation / rule engine
+- [ ] 5.4 Host rejects intents that would modify units the guest does not
+      control; rejection produces a `peer-rejected` local toast
+
+## 6. Side Ownership
+
+- [ ] 6.1 `IGameSession` gains an optional `sideOwners: Record<GameSide,
+    string>` field mapping side → peerId
+- [ ] 6.2 Skirmish setup screen with "Networked 1v1" lets host pick which
+      side they control; the other side is auto-assigned to the guest
+- [ ] 6.3 UI disables any control that would modify a unit whose side is
+      not owned by the local peer
+
+## 7. Disconnect Handling
+
+- [ ] 7.1 Host disconnect detected via Yjs awareness loss; guest's
+      session fires `GameEnded` with `reason: 'aborted'`
+- [ ] 7.2 Guest disconnect puts the session in a `PeerPending` local
+      status but does NOT end the game; host continues and buffers
+      events for reconnect (handled in
+      `add-game-session-persistence-for-reconnect`)
+
+## 8. Skirmish Setup Integration
+
+- [ ] 8.1 Setup screen adds a side option `Networked 1v1`
+- [ ] 8.2 Selecting it requires an active sync room; otherwise the
+      "Launch" button is disabled
+- [ ] 8.3 After launch, both peers render the combat surface without
+      either of them hot-seating
+
+## 9. Validation & Tests
+
+- [ ] 9.1 Integration test using the `MockSyncProvider` with two mirror
+      sessions: host fires initiative, attack, damage; guest mirror
+      produces identical state
+- [ ] 9.2 Integration test: guest intent to move produces a host-appended
+      MovementLocked event visible in both sessions
+- [ ] 9.3 Integration test: host disconnect ends the guest's session
+      with `reason: 'aborted'`
+
+## 10. Spec Compliance
+
+- [ ] 10.1 Every requirement in the `multiplayer-sync` ADDED delta has
+      at least one GIVEN/WHEN/THEN scenario
+- [ ] 10.2 Every requirement in the `game-session-management` MODIFIED
+      delta has at least one GIVEN/WHEN/THEN scenario
+- [ ] 10.3 `openspec validate add-p2p-game-session-sync --strict`
+      passes clean

--- a/openspec/changes/add-pilot-spa-editor-integration/proposal.md
+++ b/openspec/changes/add-pilot-spa-editor-integration/proposal.md
@@ -1,0 +1,57 @@
+# Change: Add Pilot SPA Editor Integration
+
+## Why
+
+The pilot detail page at `/gameplay/pilots/[id]` is where players manage a
+pilot's career state — skills, wounds, awards, career stats. Phase 5 calls
+for that same page to be the home of the "Abilities" editor: see current
+SPAs, purchase new ones with XP, remove ones granted during pilot creation,
+and see the XP impact of flaws. The `add-spa-picker-component` change
+builds the browsing surface; this change wires it to the pilot record with
+purchase semantics (XP deduction, origin-only gating, flaw XP grants, and
+the create-vs-post-create removal rule).
+
+Phase 5 runs in parallel with Phases 1, 2, and 3. This change touches only
+the pilot detail page and the pilot service, so it will not collide with
+Lane A engine wiring or Lane B combat UI.
+
+## What Changes
+
+- Add an "Abilities" section to the pilot detail page at
+  `/gameplay/pilots/[id]` listing every SPA the pilot currently owns,
+  with category color, displayName, designation (if any), source, and a
+  "Remove" affordance that is only enabled during pilot creation.
+- Add an "Add Ability" button that opens the `SPAPicker` in a modal,
+  configured with the pilot's current ability ids in `excludedIds` so the
+  player cannot select duplicates.
+- On picker confirm: deduct XP for purchasable entries, credit XP for
+  flaws, reject the action when the pilot's XP is insufficient, reject
+  origin-only entries outside the creation flow, and append the SPA with
+  its designation to the pilot record.
+- Extend `PilotService` with `purchaseSPA(pilotId, spaId, designation?)`
+  and `removeSPA(pilotId, spaId)` methods.
+
+## Dependencies
+
+- **Requires**: `add-spa-picker-component` (picker surface), existing
+  `PilotService` (`src/services/pilots/PilotService.ts`), existing pilot
+  types at `src/types/pilot/PilotInterfaces.ts`.
+- **Related**: can land in parallel with Phases 1/2/3.
+- **Required By**: `add-spa-display-on-pilot-sheet-and-unit-card`,
+  `add-spa-designation-persistence`.
+
+## Impact
+
+- Affected specs: `pilot-system` (MODIFIED — adds purchase, flaw, and
+  removal requirements), `spa-ui` (MODIFIED — adds editor embedding
+  contract).
+- Affected code: `src/pages/gameplay/pilots/[id].tsx` (abilities section),
+  new `src/components/pilots/PilotAbilitiesPanel.tsx` (owns the list +
+  add button + modal), `src/services/pilots/PilotService.ts` (new
+  purchase and removal methods).
+- Non-goals: SPA rendering on the record sheet / unit card (belongs to
+  the display change), combat-side use of designation (belongs to the
+  designation-persistence change), reworking existing pilot XP
+  progression rules (out of scope).
+- Database: no schema change — the existing `abilities` array on `IPilot`
+  already accommodates both id and designation.

--- a/openspec/changes/add-pilot-spa-editor-integration/specs/pilot-system/spec.md
+++ b/openspec/changes/add-pilot-spa-editor-integration/specs/pilot-system/spec.md
@@ -1,0 +1,123 @@
+# pilot-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: SPA Purchase from Pilot Detail
+
+The pilot system SHALL allow players to purchase SPAs from the pilot
+detail page by spending the pilot's XP.
+
+#### Scenario: Sufficient XP completes purchase
+
+- **GIVEN** a pilot with 150 XP and no ability with id `weapon_specialist`
+- **WHEN** the player selects `weapon_specialist` (xpCost 100) with a
+  `weapon_type` designation of "Medium Laser" and confirms
+- **THEN** `PilotService.purchaseSPA(pilotId, "weapon_specialist",
+{ type: "weapon_type", value: "Medium Laser" })` SHALL be called
+- **AND** the pilot's XP SHALL decrease from 150 to 50
+- **AND** the pilot's `abilities` array SHALL include the new reference
+
+#### Scenario: Insufficient XP rejects purchase
+
+- **GIVEN** a pilot with 50 XP
+- **WHEN** the player attempts to purchase an SPA with xpCost 100
+- **THEN** the purchase SHALL be rejected with error message
+  "Insufficient XP"
+- **AND** the pilot record SHALL remain unchanged
+
+#### Scenario: Duplicate purchase rejected
+
+- **GIVEN** a pilot that already owns `blood_stalker`
+- **WHEN** the player attempts to purchase `blood_stalker` again
+- **THEN** the SPA picker SHALL show the entry as disabled via
+  `excludedIds`
+- **AND** even if the purchase call bypasses the UI, the service SHALL
+  reject it with error message "Ability already owned"
+
+### Requirement: SPA Flaw XP Grant
+
+The pilot system SHALL treat entries with `isFlaw === true` as XP-granting
+during the creation flow and SHALL apply the negative `xpCost` as a credit.
+
+#### Scenario: Taking a flaw grants XP
+
+- **GIVEN** a pilot in the creation flow with 100 XP
+- **WHEN** the player takes a flaw with `isFlaw === true` and
+  `xpCost = -200`
+- **THEN** the pilot's XP SHALL increase from 100 to 300
+- **AND** the flaw SHALL be recorded in the pilot's `abilities` array
+
+#### Scenario: Flaws outside creation flow are rejected
+
+- **GIVEN** a pilot outside the creation flow
+- **WHEN** the player attempts to take a flaw
+- **THEN** the service SHALL reject the action with message "Flaws can
+  only be taken during pilot creation"
+
+### Requirement: Origin-Only Gating
+
+The pilot system SHALL restrict entries with `isOriginOnly === true` to
+the pilot creation flow.
+
+#### Scenario: Origin-only entry offered during creation
+
+- **GIVEN** a pilot in the creation flow
+- **WHEN** the player opens the SPA picker
+- **THEN** origin-only entries SHALL render enabled and purchasable at
+  their listed `xpCost` (typically 0)
+
+#### Scenario: Origin-only entry gated post-creation
+
+- **GIVEN** a pilot outside the creation flow
+- **WHEN** the player opens the SPA picker
+- **THEN** origin-only entries SHALL render disabled
+- **AND** if the `purchaseSPA` service method is called with an
+  origin-only id anyway, it SHALL reject with message "Origin-only
+  abilities cannot be acquired after creation"
+
+### Requirement: SPA Removal Allowed Only in Creation
+
+The pilot system SHALL allow SPA removal during pilot creation and SHALL
+reject removal after creation.
+
+#### Scenario: Remove ability during creation
+
+- **GIVEN** a pilot in the creation flow that owns `iron_man` (xpCost 100)
+- **WHEN** the player removes `iron_man`
+- **THEN** `PilotService.removeSPA(pilotId, "iron_man")` SHALL be called
+- **AND** the pilot's XP SHALL increase by 100 (refund)
+- **AND** the ability SHALL be removed from the pilot's `abilities`
+  array
+
+#### Scenario: Remove ability after creation is rejected
+
+- **GIVEN** a pilot outside the creation flow that owns `iron_man`
+- **WHEN** the player attempts to remove `iron_man`
+- **THEN** the Remove affordance SHALL render disabled
+- **AND** a tooltip SHALL explain "Abilities cannot be removed after
+  creation"
+- **AND** if the service is called anyway, it SHALL reject with message
+  "Abilities are permanent after creation"
+
+### Requirement: Abilities Section on Pilot Detail Page
+
+The pilot detail page SHALL expose the owned-abilities list and the
+add-ability affordance as a cohesive section.
+
+#### Scenario: Pilot with no abilities shows empty state
+
+- **GIVEN** a pilot whose `abilities` array is empty
+- **WHEN** the pilot detail page renders
+- **THEN** the Abilities section SHALL display an empty state prompting
+  "No special abilities — click Add Ability to purchase"
+- **AND** the Add Ability button SHALL remain enabled if the pilot has
+  XP or is in the creation flow
+
+#### Scenario: Owned abilities render with designation
+
+- **GIVEN** a pilot that owns `range_master` with designation
+  `{ type: "range_bracket", value: "Medium" }`
+- **WHEN** the Abilities section renders
+- **THEN** the row SHALL display "Range Master (Medium)"
+- **AND** the row SHALL show the Gunnery category color accent
+- **AND** the row SHALL show the CamOps source badge

--- a/openspec/changes/add-pilot-spa-editor-integration/specs/spa-ui/spec.md
+++ b/openspec/changes/add-pilot-spa-editor-integration/specs/spa-ui/spec.md
@@ -1,0 +1,56 @@
+# spa-ui Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Picker Embedding in Pilot Editor
+
+The SPA picker SHALL be embeddable inside the pilot detail page's
+Abilities section as a modal, configured with the pilot's current
+ability ids as `excludedIds`.
+
+#### Scenario: Modal opens with excluded ids set
+
+- **GIVEN** a pilot already owns `iron_man` and `weapon_specialist`
+- **WHEN** the Abilities section opens the add-ability modal
+- **THEN** the `SPAPicker` SHALL mount with `excludedIds = ["iron_man",
+"weapon_specialist"]`
+- **AND** those two entries SHALL render disabled with an "Already owned"
+  label
+
+#### Scenario: Picker filter mode respects creation flow
+
+- **GIVEN** a pilot is on the detail page outside the creation flow
+- **WHEN** the add-ability modal opens
+- **THEN** the `SPAPicker` SHALL mount with `filterMode =
+"purchase-only"`
+- **AND** origin-only entries SHALL render disabled
+
+#### Scenario: Picker filter mode in creation flow
+
+- **GIVEN** a pilot is on the creation page (`/gameplay/pilots/create`)
+- **WHEN** the add-ability modal opens
+- **THEN** the `SPAPicker` SHALL mount with `filterMode = "all"`
+- **AND** origin-only and flaw entries SHALL render enabled
+
+### Requirement: Editor Reacts to Picker Selection
+
+The Abilities editor SHALL receive picker selections and route them
+through the purchase or flaw-grant flow.
+
+#### Scenario: Picker selection triggers purchase
+
+- **GIVEN** the add-ability modal is open and the player confirms an
+  entry with a designation
+- **WHEN** the picker emits
+  `onSelect({ spa, designation })`
+- **THEN** the editor SHALL invoke `PilotService.purchaseSPA` (for
+  non-flaws) or the flaw-grant path (for flaws)
+- **AND** the modal SHALL close on success
+
+#### Scenario: Purchase failure keeps modal open
+
+- **GIVEN** the player selects an entry whose purchase fails (e.g.
+  insufficient XP)
+- **WHEN** `PilotService.purchaseSPA` rejects
+- **THEN** the modal SHALL remain open with the picker state intact
+- **AND** a toast SHALL surface the rejection message

--- a/openspec/changes/add-pilot-spa-editor-integration/tasks.md
+++ b/openspec/changes/add-pilot-spa-editor-integration/tasks.md
@@ -28,7 +28,7 @@
 - [ ] 3.2 If the resulting XP would be negative, abort with a toast
       "Insufficient XP" and leave the pilot unchanged
 - [ ] 3.3 If XP is sufficient, call `PilotService.purchaseSPA(id,
-    spaId, designation?)`
+spaId, designation?)`
 - [ ] 3.4 On success, refresh the panel with the updated pilot and
       close the modal
 
@@ -88,7 +88,7 @@
 - [ ] 9.3 Every new requirement has at least one GIVEN/WHEN/THEN
       scenario
 - [ ] 9.4 Run `openspec validate add-pilot-spa-editor-integration
-    --strict` clean
+--strict` clean
 
 ## 10. Tests
 

--- a/openspec/changes/add-pilot-spa-editor-integration/tasks.md
+++ b/openspec/changes/add-pilot-spa-editor-integration/tasks.md
@@ -1,0 +1,106 @@
+# Tasks: Add Pilot SPA Editor Integration
+
+## 1. Abilities Panel Component
+
+- [ ] 1.1 Create `src/components/pilots/PilotAbilitiesPanel.tsx` with an
+      `IPilotAbilitiesPanelProps` contract (pilot, isCreationFlow,
+      onPilotChange)
+- [ ] 1.2 Panel renders a section header with the pilot's current XP pool
+- [ ] 1.3 Panel renders the list of owned SPAs, resolved via
+      `getSPADefinition()` from `@/lib/spa`
+- [ ] 1.4 Each entry shows category color accent, displayName,
+      designation string (if present), source badge
+
+## 2. Add-Ability Modal
+
+- [ ] 2.1 Panel exposes an "Add Ability" button that opens a modal
+- [ ] 2.2 Modal hosts the `SPAPicker` with `excludedIds` set to the
+      pilot's current ability ids
+- [ ] 2.3 Modal sets `filterMode` to "purchase-only" outside pilot
+      creation, so origin-only entries render disabled
+- [ ] 2.4 Closing the modal without selection leaves pilot state
+      unchanged
+
+## 3. Purchase Flow
+
+- [ ] 3.1 On picker confirm with a purchasable (non-flaw) entry, compute
+      new XP as `pilot.career.xp - spa.xpCost`
+- [ ] 3.2 If the resulting XP would be negative, abort with a toast
+      "Insufficient XP" and leave the pilot unchanged
+- [ ] 3.3 If XP is sufficient, call `PilotService.purchaseSPA(id,
+    spaId, designation?)`
+- [ ] 3.4 On success, refresh the panel with the updated pilot and
+      close the modal
+
+## 4. Flaw Flow
+
+- [ ] 4.1 On picker confirm with a flaw entry (`isFlaw === true`,
+      negative `xpCost`), credit XP as `pilot.career.xp - spa.xpCost`
+      (subtracting a negative adds)
+- [ ] 4.2 Append the flaw to the pilot's abilities with the supplied
+      designation
+- [ ] 4.3 Flaws SHALL be accepted only during the creation flow unless
+      the future-designed campaign XP rules say otherwise (out of scope
+      here)
+
+## 5. Origin-Only Gating
+
+- [ ] 5.1 Outside the creation flow, origin-only entries MUST NOT be
+      purchasable — the picker renders them disabled and the purchase
+      method rejects them
+- [ ] 5.2 Inside the creation flow, origin-only entries are purchasable
+      with XP cost = 0 (catalog already encodes the zero cost)
+
+## 6. Removal Flow
+
+- [ ] 6.1 Each row in the owned-abilities list exposes a Remove button
+      that is enabled only when `isCreationFlow === true`
+- [ ] 6.2 Remove calls `PilotService.removeSPA(id, spaId)` and, on
+      success, refunds the XP paid at purchase
+- [ ] 6.3 Outside creation, the Remove button is disabled with a
+      tooltip "Abilities cannot be removed after creation"
+
+## 7. PilotService Extensions
+
+- [ ] 7.1 Add `purchaseSPA(pilotId, spaId, designation?)` to
+      `PilotService` — validates XP, appends the ability, returns the
+      updated pilot
+- [ ] 7.2 Add `removeSPA(pilotId, spaId)` to `PilotService` — removes
+      the ability, refunds XP, returns the updated pilot
+- [ ] 7.3 Both methods emit validation errors that the UI surfaces via
+      toast
+
+## 8. Page Wiring
+
+- [ ] 8.1 `src/pages/gameplay/pilots/[id].tsx` mounts the
+      `PilotAbilitiesPanel` below the existing skills section
+- [ ] 8.2 The creation page at `src/pages/gameplay/pilots/create.tsx`
+      mounts the panel with `isCreationFlow = true`
+- [ ] 8.3 The panel uses the page's existing data-fetch hook to refresh
+      pilot state after a purchase or removal
+
+## 9. Spec Compliance
+
+- [ ] 9.1 Add `pilot-system` spec delta for purchase, flaw, origin-only,
+      and removal requirements
+- [ ] 9.2 Add `spa-ui` spec delta for the editor's picker embedding
+      contract
+- [ ] 9.3 Every new requirement has at least one GIVEN/WHEN/THEN
+      scenario
+- [ ] 9.4 Run `openspec validate add-pilot-spa-editor-integration
+    --strict` clean
+
+## 10. Tests
+
+- [ ] 10.1 Unit test: purchasing a 100-XP SPA against a pilot with 150
+      XP reduces pool to 50 XP
+- [ ] 10.2 Unit test: purchasing a 200-XP SPA against a pilot with 100
+      XP fails with "Insufficient XP"
+- [ ] 10.3 Unit test: purchasing a flaw with `xpCost = -200` increases
+      the pilot's XP pool by 200
+- [ ] 10.4 Unit test: origin-only entry is rejected by
+      `purchaseSPA` outside creation flow
+- [ ] 10.5 Unit test: `removeSPA` outside creation flow is rejected
+- [ ] 10.6 Unit test: `removeSPA` inside creation flow refunds XP
+- [ ] 10.7 Integration test: full happy-path (open modal, select entry,
+      confirm, see new row, XP deducted)

--- a/openspec/changes/add-player-identity-and-auth/proposal.md
+++ b/openspec/changes/add-player-identity-and-auth/proposal.md
@@ -1,0 +1,57 @@
+# Change: Add Player Identity and Auth
+
+## Why
+
+**Sub-phase 4b.** The server needs to know which player occupies which
+seat, which player can close a match they host, and which player should
+receive fog-of-war filtered events for their side. The existing
+`user-identity` spec already covers vault sharing via Ed25519 keypairs
+and friend codes, but those identities are local-to-the-vault and never
+leave the device. Phase 4b needs an identity contract that is:
+(a) addressable over the network, (b) verifiable against a token, and
+(c) usable by the server to gate match operations. This change defines
+the contract without committing to a specific auth provider.
+
+## What Changes
+
+- Introduce `player-identity` spec: the server-side contract for a
+  multiplayer player
+- Define `IPlayerRef` = `{playerId, displayName, avatarUrl?}` —
+  everything the server needs to track a seat occupant
+- Define `IPlayerToken` = `{playerId, issuedAt, expiresAt, signature}`
+  — a bearer token the client sends on every REST/WebSocket call
+- Token issuance paths are pluggable:
+  - **Vault-identity path**: the existing `user-identity` Ed25519
+    keypair signs a self-issued token; server verifies via the public
+    key published in a vault profile
+  - **Future OAuth path**: reserved for a dedicated change; not
+    implemented here
+- Token contains no sensitive material; private key stays on device
+- Server maintains an `IPlayerStore` keyed by `playerId`, with opt-in
+  display names, match history list, last-seen timestamp
+- No password auth in this change; the identity model is public-key
+  based to match the existing vault design
+
+## Dependencies
+
+- **Requires**: existing `user-identity` (Ed25519 keypair + friend
+  codes on device), `add-multiplayer-server-infrastructure` (server
+  needs identities for matchmaking/seat binding)
+- **Required By**: `add-multiplayer-lobby-and-matchmaking-2-8`
+  (seats bind to `playerId`), `add-reconnection-and-session-
+rehydration` (reconnect verifies the same player is returning),
+  `add-fog-of-war-event-filtering` (per-player event filtering)
+
+## Impact
+
+- Affected specs: `player-identity` (ADDED — server identity model,
+  token verification, player store contract), `multiplayer-server`
+  (MODIFIED — every REST and WebSocket operation requires a valid
+  player token)
+- Affected code: new `src/server/multiplayer/auth.ts` (token verify),
+  new `src/server/multiplayer/playerStore.ts`, new
+  `src/lib/multiplayer/clientAuth.ts` (token issuance on the client
+  using the existing vault identity), extension of
+  `src/lib/multiplayer/client.ts` to attach tokens
+- Non-goals: OAuth/SSO integration, password reset, account recovery,
+  email/username account model, rate limiting, anti-abuse

--- a/openspec/changes/add-player-identity-and-auth/specs/multiplayer-server/spec.md
+++ b/openspec/changes/add-player-identity-and-auth/specs/multiplayer-server/spec.md
@@ -1,0 +1,84 @@
+# multiplayer-server Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Authenticated Multiplayer Endpoints
+
+The multiplayer server SHALL require a valid player token on every REST
+and WebSocket endpoint except the health check.
+
+#### Scenario: REST without token
+
+- **GIVEN** a client POSTs `/api/multiplayer/matches` without an
+  `Authorization` header
+- **WHEN** the server handles the request
+- **THEN** the response SHALL be `401 Unauthorized`
+
+#### Scenario: REST with invalid token
+
+- **GIVEN** a client POSTs with `Authorization: Bearer invalid`
+- **WHEN** the server verifies the token
+- **THEN** verification SHALL fail
+- **AND** the response SHALL be `401 Unauthorized`
+
+#### Scenario: WebSocket without token
+
+- **GIVEN** a WebSocket upgrade request missing a token in both
+  header and query string
+- **WHEN** the server handles the upgrade
+- **THEN** the server SHALL respond `401 Unauthorized`
+- **AND** SHALL NOT upgrade the connection
+
+### Requirement: Host Authority Gated by Identity
+
+Only the match's `hostPlayerId` SHALL be able to close or modify match
+configuration via privileged operations.
+
+#### Scenario: Non-host close rejected
+
+- **GIVEN** a player whose `playerId != hostPlayerId`
+- **WHEN** they DELETE `/api/multiplayer/matches/:id`
+- **THEN** the server SHALL respond `403 Forbidden`
+- **AND** the match SHALL remain active
+
+#### Scenario: Host close succeeds
+
+- **GIVEN** a player whose `playerId == hostPlayerId`
+- **WHEN** they DELETE `/api/multiplayer/matches/:id`
+- **THEN** the server SHALL mark the match completed
+- **AND** all connected clients SHALL receive a `Close` envelope
+
+### Requirement: Seat Binding Uses Authenticated Player
+
+The server SHALL bind seat occupancy to the `playerId` verified at
+WebSocket upgrade time and SHALL reject any `OccupySeat` intent that
+references a different `playerId`.
+
+#### Scenario: Seat binds to socket identity
+
+- **GIVEN** an authenticated WebSocket for `pid_abc`
+- **WHEN** the client sends `OccupySeat {slotId: 'alpha-1'}`
+- **THEN** the server SHALL assign `occupant = {playerId: 'pid_abc'}`
+- **AND** SHALL NOT let the client claim a different player id
+
+#### Scenario: Attempting to occupy on behalf of another player
+
+- **GIVEN** an authenticated WebSocket for `pid_abc`
+- **WHEN** the client sends `OccupySeat {slotId: 'alpha-1', claimed
+Player: 'pid_xyz'}`
+- **THEN** the server SHALL ignore `claimedPlayer` and bind the seat
+  to `pid_abc`
+- **AND** the server MAY respond with a warning envelope
+
+### Requirement: Match Participation Recorded Server-Side
+
+The server SHALL record each participant's match participation in the
+`IPlayerStore` when a match transitions from `'lobby'` to `'active'`.
+
+#### Scenario: Each human participant gets recorded
+
+- **GIVEN** a match launching with 4 human players
+- **WHEN** the server processes `LaunchMatch`
+- **THEN** `recordMatchParticipation(playerId, matchId)` SHALL be
+  called exactly once for each human participant
+- **AND** AI-occupied seats SHALL NOT produce participation records

--- a/openspec/changes/add-player-identity-and-auth/specs/player-identity/spec.md
+++ b/openspec/changes/add-player-identity-and-auth/specs/player-identity/spec.md
@@ -1,0 +1,135 @@
+# player-identity Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Player Reference Model
+
+The system SHALL represent a networked player with an `IPlayerRef`
+containing stable identifying fields sufficient for seat assignment,
+display, and match history.
+
+#### Scenario: Player ref shape
+
+- **GIVEN** a player connects to the multiplayer server
+- **WHEN** the server logs the player
+- **THEN** the reference SHALL contain `playerId: string`,
+  `displayName: string`, and optional `avatarUrl: string`
+- **AND** `playerId` SHALL be of the form `pid_{base58-derived-from-
+public-key}`
+
+#### Scenario: Player id is deterministic from public key
+
+- **GIVEN** a player with Ed25519 public key `K`
+- **WHEN** `playerId` is derived
+- **THEN** the result SHALL be identical for the same `K` across
+  sessions and machines
+- **AND** two different public keys SHALL produce different player ids
+
+### Requirement: Token-Based Authentication
+
+The system SHALL authenticate player connections via signed bearer
+tokens. A valid token SHALL be required on all multiplayer endpoints
+except the health check.
+
+#### Scenario: Token structure
+
+- **GIVEN** a player issues a token
+- **WHEN** the token is inspected
+- **THEN** it SHALL contain `playerId, issuedAt, expiresAt, publicKey,
+signature`
+- **AND** `signature` SHALL be an Ed25519 signature over the canonical
+  string representation of `{playerId, issuedAt, expiresAt}`
+
+#### Scenario: Server verifies token
+
+- **GIVEN** an authenticated REST request with `Authorization: Bearer
+<token>`
+- **WHEN** the server's auth middleware runs
+- **THEN** it SHALL verify the signature with the embedded public key
+- **AND** it SHALL verify `expiresAt > now`
+- **AND** it SHALL verify `playerId` is derived from `publicKey`
+
+#### Scenario: Tampered token rejected
+
+- **GIVEN** a token whose payload was altered after signing
+- **WHEN** the server verifies it
+- **THEN** signature verification SHALL fail
+- **AND** the server SHALL respond `401 Unauthorized`
+
+#### Scenario: Expired token rejected
+
+- **GIVEN** a token whose `expiresAt` is in the past
+- **WHEN** the server verifies it
+- **THEN** verification SHALL fail with `reason: 'expired'`
+- **AND** the server SHALL respond `401 Unauthorized`
+
+### Requirement: Player Store Contract
+
+The system SHALL provide a pluggable `IPlayerStore` interface that
+persists player profiles and match participation history.
+
+#### Scenario: Store interface
+
+- **GIVEN** an `IPlayerStore` implementation
+- **WHEN** the type is inspected
+- **THEN** it SHALL expose `getOrCreatePlayer`, `updateProfile`,
+  `recordMatchParticipation`
+- **AND** every method SHALL return a `Promise`
+
+#### Scenario: First-time connection bootstraps profile
+
+- **GIVEN** a player with `playerId: pid_new` connecting for the first
+  time
+- **WHEN** the server processes the `SessionJoin`
+- **THEN** `getOrCreatePlayer({playerId: 'pid_new', publicKey,
+displayName, avatarUrl?})` SHALL be called
+- **AND** the returned profile SHALL have `createdAt = now` and
+  `lastSeenAt = now`
+
+#### Scenario: Repeat connection updates lastSeenAt
+
+- **GIVEN** an existing profile for `pid_abc` with `lastSeenAt` in
+  the past
+- **WHEN** the player reconnects
+- **THEN** `lastSeenAt` SHALL be updated to the current timestamp
+- **AND** the existing profile SHALL otherwise be preserved
+
+### Requirement: Player Id Bound to WebSocket
+
+The system SHALL attach the verified `playerId` to each WebSocket
+connection at upgrade time and reject any subsequent message whose
+`playerId` differs from the socket's bound identity.
+
+#### Scenario: SessionJoin id must match socket
+
+- **GIVEN** a WebSocket authenticated as `playerId: pid_a`
+- **WHEN** the client sends `SessionJoin {playerId: 'pid_b', ...}`
+- **THEN** the server SHALL respond `Error {code: 'UNAUTHORIZED'}`
+- **AND** the socket SHALL be closed
+
+#### Scenario: Intent id must match socket
+
+- **GIVEN** an authenticated WebSocket for `pid_a`
+- **WHEN** a `Intent {playerId: 'pid_b', ...}` message arrives
+- **THEN** the server SHALL respond `Error {code: 'UNAUTHORIZED'}`
+- **AND** no state SHALL be mutated
+
+### Requirement: Token Rotation
+
+The system SHALL support client-side token rotation so live matches
+survive token expiry without losing the connection.
+
+#### Scenario: Rotation on near-expiry
+
+- **GIVEN** a client whose cached token expires in 4 minutes
+- **WHEN** the client next makes a request
+- **THEN** the client SHALL issue a new token before the request
+- **AND** the request SHALL carry the fresh token
+
+#### Scenario: Server accepts small clock drift
+
+- **GIVEN** a token whose `issuedAt` is 5 seconds in the future
+  (client clock ahead)
+- **WHEN** the server verifies it
+- **THEN** verification SHALL pass
+- **AND** the drift SHALL be tolerated up to 10 seconds

--- a/openspec/changes/add-player-identity-and-auth/tasks.md
+++ b/openspec/changes/add-player-identity-and-auth/tasks.md
@@ -3,11 +3,11 @@
 ## 1. Data Model
 
 - [ ] 1.1 Define `IPlayerRef` with `{playerId, displayName,
-    avatarUrl?}` — the server's minimum view of a player
+avatarUrl?}` — the server's minimum view of a player
 - [ ] 1.2 Define `IPlayerToken` with `{playerId, issuedAt, expiresAt,
-    publicKey, signature}`
+publicKey, signature}`
 - [ ] 1.3 Define `IPlayerProfile` with `{playerId, publicKey,
-    displayName, createdAt, lastSeenAt, matchHistory: string[]}`
+displayName, createdAt, lastSeenAt, matchHistory: string[]}`
 - [ ] 1.4 `playerId` format: `pid_{base58(firstBytes(publicKey))}`
       derived from the public key so the id and the verification key
       are inherently linked
@@ -15,7 +15,7 @@
 ## 2. Token Issuance (Client Side)
 
 - [ ] 2.1 Extend `user-identity` client API with `issuePlayerToken(ttl
-    = 1 hour): IPlayerToken`
+= 1 hour): IPlayerToken`
 - [ ] 2.2 Token is signed with the vault's Ed25519 private key over a
       canonical `{playerId, issuedAt, expiresAt}` payload
 - [ ] 2.3 Client caches the most recent unexpired token in memory;
@@ -24,7 +24,7 @@
 ## 3. Token Verification (Server Side)
 
 - [ ] 3.1 Add `auth.ts` with `verifyPlayerToken(token): {playerId} |
-    null`
+null`
 - [ ] 3.2 Verification: check `expiresAt > now`, derive `playerId`
       from `publicKey`, verify the Ed25519 signature over the
       canonical payload
@@ -64,7 +64,7 @@
 
 - [ ] 7.1 First time a client connects with a new `playerId`, the
       server calls `getOrCreatePlayer({playerId, publicKey,
-    displayName: ..., avatarUrl: ...})`
+displayName: ..., avatarUrl: ...})`
 - [ ] 7.2 Client provides `displayName` in the token request or
       separately in a profile-setup step
 - [ ] 7.3 Subsequent connections skip creation and use the existing

--- a/openspec/changes/add-player-identity-and-auth/tasks.md
+++ b/openspec/changes/add-player-identity-and-auth/tasks.md
@@ -1,0 +1,108 @@
+# Tasks: Add Player Identity and Auth
+
+## 1. Data Model
+
+- [ ] 1.1 Define `IPlayerRef` with `{playerId, displayName,
+    avatarUrl?}` — the server's minimum view of a player
+- [ ] 1.2 Define `IPlayerToken` with `{playerId, issuedAt, expiresAt,
+    publicKey, signature}`
+- [ ] 1.3 Define `IPlayerProfile` with `{playerId, publicKey,
+    displayName, createdAt, lastSeenAt, matchHistory: string[]}`
+- [ ] 1.4 `playerId` format: `pid_{base58(firstBytes(publicKey))}`
+      derived from the public key so the id and the verification key
+      are inherently linked
+
+## 2. Token Issuance (Client Side)
+
+- [ ] 2.1 Extend `user-identity` client API with `issuePlayerToken(ttl
+    = 1 hour): IPlayerToken`
+- [ ] 2.2 Token is signed with the vault's Ed25519 private key over a
+      canonical `{playerId, issuedAt, expiresAt}` payload
+- [ ] 2.3 Client caches the most recent unexpired token in memory;
+      refreshes with a new one when within 5 minutes of expiry
+
+## 3. Token Verification (Server Side)
+
+- [ ] 3.1 Add `auth.ts` with `verifyPlayerToken(token): {playerId} |
+    null`
+- [ ] 3.2 Verification: check `expiresAt > now`, derive `playerId`
+      from `publicKey`, verify the Ed25519 signature over the
+      canonical payload
+- [ ] 3.3 Invalid tokens result in `401 Unauthorized` on REST
+      endpoints and `Error {code: 'UNAUTHORIZED'}` then socket close
+      on WebSocket
+
+## 4. Player Store Contract
+
+- [ ] 4.1 Define `IPlayerStore` interface with:
+      `getOrCreatePlayer(profile): Promise<IPlayerProfile>`,
+      `updateProfile(playerId, patch): Promise<void>`,
+      `recordMatchParticipation(playerId, matchId): Promise<void>`
+- [ ] 4.2 Implementation MUST be pluggable (SQLite, Postgres, memory)
+- [ ] 4.3 In-memory implementation for dev mode, same pattern as
+      `InMemoryMatchStore`
+
+## 5. REST Endpoint Integration
+
+- [ ] 5.1 All `/api/multiplayer/*` REST endpoints require the
+      `Authorization: Bearer <token>` header
+- [ ] 5.2 Middleware extracts and verifies the token; on success,
+      attaches `{playerId}` to the request context
+- [ ] 5.3 Missing or invalid token → `401 Unauthorized`
+- [ ] 5.4 The existing health-check endpoint does NOT require auth
+
+## 6. WebSocket Endpoint Integration
+
+- [ ] 6.1 WebSocket upgrade requires a token either in the
+      `Authorization` header or the `?token=` query param
+- [ ] 6.2 Verified `playerId` is attached to the socket
+- [ ] 6.3 `SessionJoin` intent is cross-checked: the socket's
+      `playerId` must match the intent's `playerId`; mismatches are
+      rejected with `Error {code: 'UNAUTHORIZED'}`
+
+## 7. Profile Bootstrapping
+
+- [ ] 7.1 First time a client connects with a new `playerId`, the
+      server calls `getOrCreatePlayer({playerId, publicKey,
+    displayName: ..., avatarUrl: ...})`
+- [ ] 7.2 Client provides `displayName` in the token request or
+      separately in a profile-setup step
+- [ ] 7.3 Subsequent connections skip creation and use the existing
+      profile
+
+## 8. Match Membership
+
+- [ ] 8.1 `OccupySeat` intent verifies the requesting `playerId`
+      matches the socket's identity
+- [ ] 8.2 On successful lobby-ready → launch, the server records
+      `matchId` in each participant's `matchHistory` via
+      `recordMatchParticipation`
+- [ ] 8.3 Only the match's `hostPlayerId` may `DELETE` the match
+
+## 9. Token Rotation
+
+- [ ] 9.1 Tokens expire every hour
+- [ ] 9.2 Client detects `UNAUTHORIZED` on an active connection,
+      re-issues a token, reconnects
+- [ ] 9.3 Server accepts a token with `issuedAt` up to 10 seconds in
+      the future to tolerate clock drift
+
+## 10. Tests
+
+- [ ] 10.1 Unit test: token issuance and verification round-trip
+- [ ] 10.2 Unit test: tampered token (altered payload, same sig) is
+      rejected
+- [ ] 10.3 Unit test: expired token is rejected
+- [ ] 10.4 Integration test: unauthorized REST call returns 401
+- [ ] 10.5 Integration test: unauthorized WebSocket upgrade fails
+- [ ] 10.6 Integration test: two players with valid tokens can create
+      and join a match
+
+## 11. Spec Compliance
+
+- [ ] 11.1 Every requirement in the `player-identity` ADDED delta has
+      at least one GIVEN/WHEN/THEN scenario
+- [ ] 11.2 Every requirement in the `multiplayer-server` MODIFIED
+      delta has at least one GIVEN/WHEN/THEN scenario
+- [ ] 11.3 `openspec validate add-player-identity-and-auth --strict`
+      passes clean

--- a/openspec/changes/add-post-battle-processor/proposal.md
+++ b/openspec/changes/add-post-battle-processor/proposal.md
@@ -1,0 +1,60 @@
+# Change: Add Post-Battle Processor
+
+## Why
+
+When a battle ends, the `ICombatOutcome` is just data — nothing acts on it.
+Pilots don't gain XP, wounds don't get recorded, mechs heal nothing, contract
+status doesn't update. The campaign system has every ingredient already
+(day processors chain, `xpAwards.ts`, medical status helpers, contract
+progression) but no handler that converts a combat outcome into the series
+of campaign mutations those processors expect. This change builds that
+handler and registers it as a day-processor entry point.
+
+## What Changes
+
+- Add `PostBattleProcessor` — given an `ICombatOutcome`, applies every
+  campaign-visible consequence in a single atomic day-processor pass
+- Pilot XP awards — consume `IPilotOutcome.kills` / `.tasksCompleted` /
+  `.missionRole`, feed `xpAwards.ts` (`awardScenarioXP`, `awardKillXP`,
+  `awardTaskXP`, `awardMissionXP`), persist via `applyXPAward`
+- Pilot wound + status — increment medical `woundsTaken`, set personnel
+  status to `WOUNDED` / `UNCONSCIOUS` / `KIA` / `MIA` / `CAPTURED` per
+  `IPilotOutcome.finalStatus`, enqueue into medical queue
+- Unit damage persistence — the construction-state mech record gains a
+  sibling "current combat state" (`IUnitCombatState`): armor per location,
+  structure per location, destroyed components, ammo remaining. The
+  processor writes the `ICombatOutcome` deltas into that state so repair
+  and ammo-resupply downstream can see real damage
+- Contract mission completion — if `outcome.contractId` is set, update
+  contract progress (increment scenarios-played, set mission status to
+  `SUCCESS` / `FAILURE` / `PARTIAL` per scenario objective rules)
+- Registered as day-processor step: `postBattleProcessor` fires when an
+  `ICombatOutcome` is pending on the day being advanced, runs before
+  `contractProcessor` and `healingProcessor` so their inputs are current
+- Idempotent — same outcome applied twice has no additional effect
+
+## Dependencies
+
+- **Requires**: `add-combat-outcome-model` (consumes `ICombatOutcome`), Phase
+  1 A1–A7 (needs correct damage/crit/wound math in the outcome or effects
+  are wrong)
+- **Requires**: existing `src/lib/campaign/progression/xpAwards.ts`,
+  existing medical/personnel-status helpers, existing `contractProcessor`
+- **Required By**: `add-salvage-rules-engine` (runs after this),
+  `add-repair-queue-integration` (reads the persisted damage),
+  `wire-encounter-to-campaign-round-trip`
+
+## Impact
+
+- Affected specs: `personnel-management` (MODIFIED — adds post-battle
+  status application), `damage-system` (MODIFIED — adds `IUnitCombatState`
+  persistence alongside construction state), `mission-contracts` (MODIFIED —
+  mission completion applied from outcome), `game-session-management`
+  (MODIFIED — session-to-campaign handoff step)
+- Affected code: new `src/lib/campaign/processors/postBattleProcessor.ts`,
+  new `src/types/campaign/UnitCombatState.ts`, extends
+  `src/lib/campaign/dayPipeline.ts` registration, extends unit repository
+  with `getCombatState` / `setCombatState`
+- Non-goals: salvage math (that's `add-salvage-rules-engine`), repair
+  ticket creation (that's `add-repair-queue-integration`), UI (that's
+  `add-post-battle-review-ui`)

--- a/openspec/changes/add-post-battle-processor/specs/damage-system/spec.md
+++ b/openspec/changes/add-post-battle-processor/specs/damage-system/spec.md
@@ -1,0 +1,83 @@
+# damage-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Unit Combat State Persistence
+
+Each BattleMech in a campaign SHALL have a persistent `IUnitCombatState`
+stored alongside its immutable construction state. Combat damage SHALL be
+recorded in this state, never in the construction state itself.
+
+#### Scenario: Combat state distinct from construction state
+
+- **GIVEN** a unit with a fresh construction state
+- **WHEN** its combat state is first read
+- **THEN** `getCombatState(unitId)` SHALL return an object matching
+  `createInitialCombatState(unit)` (full armor, full structure, full ammo,
+  no destroyed components)
+- **AND** the construction state SHALL remain byte-identical
+
+#### Scenario: Combat state captures per-location armor
+
+- **GIVEN** a combat state `S` for a unit with 10 LT armor construction
+  points
+- **WHEN** a battle applies 6 armor damage to LT via `applyPostBattle`
+- **THEN** `S.currentArmorPerLocation[LT]` SHALL equal 4
+- **AND** the construction-state LT armor SHALL still equal 10
+
+#### Scenario: Combat state captures per-location structure
+
+- **GIVEN** a unit that suffered 3 structure damage in the right torso
+- **WHEN** combat state is updated
+- **THEN** `S.currentStructurePerLocation[RT]` SHALL equal
+  `construction.RT.structure - 3`
+
+#### Scenario: Combat state tracks destroyed components
+
+- **GIVEN** a unit whose LRM-15 in the right torso was destroyed during
+  battle
+- **WHEN** combat state is updated
+- **THEN** `S.destroyedComponents` SHALL contain an entry
+  `{ location: RT, slot: <n>, componentType: "weapon", name: "LRM 15",
+destroyedAt: matchId }`
+
+#### Scenario: Combat state tracks ammo remaining
+
+- **GIVEN** a unit that started with 16 LRM rounds and fired 8 in battle
+- **WHEN** combat state is updated
+- **THEN** `S.ammoRemaining["LRM 15 Ammo"]` SHALL equal 8
+- **AND** `S.ammoRemaining` values SHALL clamp at zero (never negative)
+
+### Requirement: Combat-Ready Classification
+
+A unit's combat readiness SHALL be derivable from its `IUnitCombatState`.
+
+#### Scenario: Unit with destroyed CT is not combat-ready
+
+- **GIVEN** a combat state where CT structure is 0
+- **WHEN** `isUnitCombatReady(state)` is called
+- **THEN** it SHALL return `false`
+
+#### Scenario: Unit with intact state is combat-ready
+
+- **GIVEN** a combat state with no location at zero structure and no
+  critical components destroyed
+- **WHEN** `isUnitCombatReady(state)` is called
+- **THEN** it SHALL return `true`
+
+### Requirement: Idempotent Damage Persistence
+
+Applying the same `ICombatOutcome` to combat state twice SHALL produce no
+additional damage beyond the first application.
+
+#### Scenario: Re-application does not double damage
+
+- **GIVEN** a unit whose combat state already reflects `outcome` with
+  `matchId = M`
+- **WHEN** `applyPostBattle(outcome, campaign)` is called again with the
+  same outcome
+- **THEN** `currentArmorPerLocation` SHALL remain unchanged
+- **AND** `currentStructurePerLocation` SHALL remain unchanged
+- **AND** `destroyedComponents` SHALL NOT gain duplicate entries (dedup by
+  `location + slot`)
+- **AND** `ammoRemaining` SHALL NOT decrease further

--- a/openspec/changes/add-post-battle-processor/specs/game-session-management/spec.md
+++ b/openspec/changes/add-post-battle-processor/specs/game-session-management/spec.md
@@ -1,0 +1,56 @@
+# game-session-management Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Pending Outcome Queue
+
+The campaign state SHALL maintain a `pendingBattleOutcomes: ICombatOutcome[]`
+queue. Completed sessions push their outcome onto this queue, and the
+`PostBattleProcessor` drains it during the next day-advancement.
+
+#### Scenario: Completed session pushes outcome to queue
+
+- **GIVEN** a campaign with an active contract and a session that just
+  emitted `GameEnded`
+- **WHEN** the session's `CombatOutcomeReady` event fires
+- **THEN** `outcome` SHALL be appended to `campaign.pendingBattleOutcomes`
+- **AND** the session SHALL NOT modify any other campaign state directly
+
+#### Scenario: Day advancement drains the queue
+
+- **GIVEN** a campaign with `pendingBattleOutcomes = [O1, O2]`
+- **WHEN** day advancement runs
+- **THEN** the `PostBattleProcessor` SHALL call `applyPostBattle(O1)` and
+  `applyPostBattle(O2)` in order
+- **AND** on success, both outcomes SHALL be removed from the queue and
+  added to `campaign.processedBattleIds`
+
+#### Scenario: Failed application keeps outcome in queue
+
+- **GIVEN** a campaign where `applyPostBattle(O1)` throws (e.g., corrupt
+  outcome data)
+- **WHEN** day advancement runs
+- **THEN** `O1` SHALL remain on `pendingBattleOutcomes`
+- **AND** a campaign-level error SHALL be recorded for surfacing in the UI
+- **AND** later outcomes in the queue MAY still be processed
+
+### Requirement: Processor Ordering In Day Pipeline
+
+The `postBattleProcessor` SHALL run at a well-defined position in the day
+pipeline so downstream processors see the updated state.
+
+#### Scenario: Runs before contract and healing processors
+
+- **GIVEN** a day advancement with pending outcomes, active contracts, and
+  wounded pilots
+- **WHEN** the pipeline executes
+- **THEN** `postBattleProcessor` SHALL run before `contractProcessor`
+- **AND** `postBattleProcessor` SHALL run before `healingProcessor`
+- **AND** the ordering SHALL be documented in `dayPipeline.ts`
+
+#### Scenario: Runs after income and acquisition processors
+
+- **GIVEN** a day advancement with pending outcomes and scheduled income
+- **WHEN** the pipeline executes
+- **THEN** income/financial processors SHALL have already run before
+  `postBattleProcessor` (battle results do not directly produce income)

--- a/openspec/changes/add-post-battle-processor/specs/mission-contracts/spec.md
+++ b/openspec/changes/add-post-battle-processor/specs/mission-contracts/spec.md
@@ -1,0 +1,54 @@
+# mission-contracts Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Contract Mission Progression From Combat Outcome
+
+The `PostBattleProcessor` SHALL update the referenced contract's mission progression (winner, end reason, scenario objective results) whenever an `ICombatOutcome` carries a `contractId`.
+
+#### Scenario: Player win counts as mission success
+
+- **GIVEN** an outcome with `winner = GameSide.Player`, `endReason = DESTRUCTION`,
+  and all scenario objectives met
+- **WHEN** `applyPostBattle(outcome, campaign)` is called
+- **THEN** the contract's `lastMissionResult` SHALL be set to `SUCCESS`
+- **AND** `scenariosPlayed` SHALL increment by 1
+- **AND** `missionsSuccessful` SHALL increment by 1
+
+#### Scenario: Player loss counts as mission failure
+
+- **GIVEN** an outcome with `winner = GameSide.Opponent` or player conceded
+- **WHEN** `applyPostBattle(outcome, campaign)` is called
+- **THEN** the contract's `lastMissionResult` SHALL be set to `FAILURE`
+- **AND** `scenariosPlayed` SHALL increment by 1
+- **AND** `missionsFailed` SHALL increment by 1
+
+#### Scenario: Turn-limit draw with partial objectives
+
+- **GIVEN** an outcome with `endReason = TURN_LIMIT`, `winner = "draw"`,
+  and some scenario objectives met
+- **WHEN** `applyPostBattle(outcome, campaign)` is called
+- **THEN** the contract's `lastMissionResult` SHALL be set to `PARTIAL`
+- **AND** `scenariosPlayed` SHALL increment by 1
+
+#### Scenario: Contract morale updates per AtB table
+
+- **GIVEN** a contract with current morale `NORMAL` and a FAILURE result
+- **WHEN** `applyPostBattle` is called
+- **THEN** the contract's morale SHALL be reduced toward `BROKEN` or
+  `WAVERING` per the AtB morale-update table for losses
+- **AND** the processor SHALL call the existing morale-update helper, not
+  re-implement the transition logic
+
+### Requirement: Fulfilled Contract Flagging
+
+The `PostBattleProcessor` SHALL flag a contract for final-payment processing by the existing `contractProcessor` once all scenarios required by the contract have been played.
+
+#### Scenario: Final scenario fulfills contract
+
+- **GIVEN** a contract requiring 5 scenarios with `scenariosPlayed = 4`
+- **WHEN** `applyPostBattle(outcome, campaign)` runs and increments
+  `scenariosPlayed` to 5
+- **THEN** the contract SHALL be marked `fulfilled = true`
+- **AND** the next `contractProcessor` run SHALL process final payment,
+  salvage rights, and closure

--- a/openspec/changes/add-post-battle-processor/specs/personnel-management/spec.md
+++ b/openspec/changes/add-post-battle-processor/specs/personnel-management/spec.md
@@ -1,0 +1,102 @@
+# personnel-management Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Post-Battle Pilot XP Application
+
+The `PostBattleProcessor` SHALL award XP to each participating pilot based on the pilot's `IPilotOutcome` data and the campaign's configured XP thresholds when an `ICombatOutcome` is applied.
+
+#### Scenario: Pilot receives scenario XP
+
+- **GIVEN** a pilot that participated in a completed battle
+- **WHEN** `applyPostBattle(outcome, campaign)` is called
+- **THEN** `awardScenarioXP(pilot, options)` SHALL be invoked
+- **AND** the resulting `IXPAwardEvent` SHALL be applied via
+  `applyXPAward`
+- **AND** the pilot's `xp` and `totalXpEarned` SHALL increase by
+  `options.scenarioXP`
+
+#### Scenario: Pilot receives kill XP above threshold
+
+- **GIVEN** a pilot with 3 kills in `outcome` and a `killXP` threshold of 2
+- **WHEN** `applyPostBattle(outcome, campaign)` is called
+- **THEN** `awardKillXP(pilot, 3, options)` SHALL award
+  `floor(3 / 2) * killXP` points
+- **AND** the event SHALL be applied to the pilot
+
+#### Scenario: Pilot receives mission XP based on winner side
+
+- **GIVEN** a pilot on the winning side of a SUCCESS mission
+- **WHEN** `applyPostBattle(outcome, campaign)` is called
+- **THEN** `awardMissionXP(pilot, "SUCCESS", options)` SHALL be called with
+  the mission-success XP amount
+- **AND** for a losing pilot, `awardMissionXP(pilot, "FAILURE", options)`
+  SHALL be called
+
+### Requirement: Post-Battle Pilot Status Application
+
+Each `IPilotOutcome.finalStatus` SHALL map to a deterministic personnel
+status change applied by the `PostBattleProcessor`.
+
+#### Scenario: Active pilot status unchanged
+
+- **GIVEN** a pilot with `finalStatus = ACTIVE`
+- **WHEN** `applyPostBattle` is called
+- **THEN** the pilot's personnel status SHALL remain unchanged
+- **AND** `medical.wounds` SHALL remain unchanged
+
+#### Scenario: Wounded pilot enters medical queue
+
+- **GIVEN** a pilot with `finalStatus = WOUNDED` and `woundsTaken = 2`
+- **WHEN** `applyPostBattle` is called
+- **THEN** `person.medical.wounds` SHALL increase by 2
+- **AND** the pilot SHALL be enqueued in the medical/healing queue
+- **AND** `person.personnelStatus` SHALL be set to `WOUNDED`
+
+#### Scenario: Unconscious pilot flagged for medical observation
+
+- **GIVEN** a pilot with `finalStatus = UNCONSCIOUS`
+- **WHEN** `applyPostBattle` is called
+- **THEN** `person.personnelStatus` SHALL be set to `WOUNDED`
+- **AND** the medical queue entry SHALL be flagged for immediate attention
+
+#### Scenario: KIA pilot removed from active roster
+
+- **GIVEN** a pilot with `finalStatus = KIA`
+- **WHEN** `applyPostBattle` is called
+- **THEN** `person.personnelStatus` SHALL be set to `KIA`
+- **AND** `person.dateOfDeath` SHALL be set to the campaign's current date
+- **AND** the pilot SHALL be removed from any assigned unit
+- **AND** a `PersonnelStatusChanged` campaign event SHALL fire
+
+#### Scenario: MIA pilot marked missing
+
+- **GIVEN** a pilot with `finalStatus = MIA`
+- **WHEN** `applyPostBattle` is called
+- **THEN** `person.personnelStatus` SHALL be set to `MIA`
+- **AND** the pilot SHALL remain on the roster (unlike KIA) but be
+  unassigned from active duty
+
+#### Scenario: Captured pilot goes into prisoner pool
+
+- **GIVEN** a pilot with `finalStatus = CAPTURED`
+- **WHEN** `applyPostBattle` is called
+- **THEN** `person.personnelStatus` SHALL be set to `CAPTURED`
+- **AND** the pilot SHALL be moved to the captured-personnel pool for
+  potential prisoner exchange or ransom handling
+
+### Requirement: Idempotent Post-Battle Application
+
+Applying the same `ICombatOutcome` twice SHALL produce no additional
+personnel changes beyond those made on the first application.
+
+#### Scenario: Re-application is a no-op
+
+- **GIVEN** a campaign that has already processed `outcome` with
+  `matchId = M`
+- **WHEN** `applyPostBattle(outcome, campaign)` is called again with the
+  same outcome
+- **THEN** no XP SHALL be awarded a second time
+- **AND** no personnel status changes SHALL occur a second time
+- **AND** the processor SHALL return a result marking the outcome as
+  already-processed

--- a/openspec/changes/add-post-battle-processor/tasks.md
+++ b/openspec/changes/add-post-battle-processor/tasks.md
@@ -1,0 +1,120 @@
+# Tasks: Add Post-Battle Processor
+
+## 1. Unit Combat State Model
+
+- [ ] 1.1 Create `src/types/campaign/UnitCombatState.ts`
+- [ ] 1.2 Define `IUnitCombatState` with `unitId`, `currentArmorPerLocation`,
+      `currentStructurePerLocation`, `destroyedComponents`, `ammoRemaining`,
+      `lastCombatOutcomeId`, `lastUpdated`
+- [ ] 1.3 Define `IDestroyedComponent` with `location`, `slot`, `componentType`,
+      `name`, `destroyedAt` (match id)
+- [ ] 1.4 Add `createInitialCombatState(unit)` — full armor, full structure,
+      full ammo, no destroyed components
+- [ ] 1.5 Add `isUnitCombatReady(state)` — true only if CT structure > 0 and
+      no critical component is fully destroyed
+
+## 2. Combat State Persistence
+
+- [ ] 2.1 Extend unit repository with `getCombatState(unitId)`
+- [ ] 2.2 Extend unit repository with `setCombatState(unitId, state)`
+- [ ] 2.3 Backfill existing units with `createInitialCombatState` on first
+      read
+- [ ] 2.4 Ensure construction-state is NEVER mutated (combat state lives
+      alongside, not inside)
+
+## 3. Post-Battle Processor Core
+
+- [ ] 3.1 Create `src/lib/campaign/processors/postBattleProcessor.ts`
+- [ ] 3.2 Export `applyPostBattle(outcome: ICombatOutcome, campaign): ICampaignChange[]`
+- [ ] 3.3 Implement idempotency — check if `outcome.matchId` is already in
+      `campaign.processedBattleIds`; skip if present
+- [ ] 3.4 On successful apply, append `matchId` to `processedBattleIds`
+
+## 4. Pilot XP Application
+
+- [ ] 4.1 For each `IPilotOutcome`, call `awardScenarioXP(pilot, options)`
+- [ ] 4.2 Call `awardKillXP(pilot, outcome.kills, options)` — returns null if
+      below threshold, otherwise increment
+- [ ] 4.3 Call `awardTaskXP(pilot, outcome.tasksCompleted, options)` when
+      threshold met
+- [ ] 4.4 Call `awardMissionXP(pilot, missionResult, options)` — where
+      `missionResult` is derived from `outcome.winner` and the pilot's side
+- [ ] 4.5 Collapse all four into a single `IXPAwardEvent[]` for this pilot
+- [ ] 4.6 Apply via `applyXPAward` per event
+
+## 5. Pilot Wound & Status Application
+
+- [ ] 5.1 Increment `person.medical.wounds` by `outcome.woundsTaken`
+- [ ] 5.2 Map `PilotFinalStatus` to personnel status:
+      ACTIVE → no change, WOUNDED → `WOUNDED`, UNCONSCIOUS → `WOUNDED` + in
+      medical queue, KIA → `KIA` + removed from active roster, MIA → `MIA`,
+      CAPTURED → `CAPTURED`
+- [ ] 5.3 On KIA, record `dateOfDeath` = campaign current date
+- [ ] 5.4 On WOUNDED, enqueue into medical/healing queue with expected
+      recovery days
+- [ ] 5.5 Fire `PersonnelStatusChanged` campaign event
+
+## 6. Unit Damage Persistence
+
+- [ ] 6.1 For each `IUnitCasualty`, load current `IUnitCombatState`
+- [ ] 6.2 Subtract `armorLostPerLocation` from current armor per location
+- [ ] 6.3 Subtract `structureLostPerLocation` from current structure per
+      location
+- [ ] 6.4 Append `destroyedComponents` from casualty to state (dedup by
+      location+slot)
+- [ ] 6.5 Subtract `ammoConsumed` from `ammoRemaining` per ammo type
+- [ ] 6.6 Clamp all values to ≥ 0
+- [ ] 6.7 Set `lastCombatOutcomeId = outcome.matchId`, `lastUpdated = now`
+- [ ] 6.8 Persist via `setCombatState`
+- [ ] 6.9 On `finalStatus = DESTROYED`, mark unit as unusable in roster
+      (combat-ready = false, awaiting total write-off or salvage)
+
+## 7. Contract Progression
+
+- [ ] 7.1 If `outcome.contractId` is set, load the contract
+- [ ] 7.2 Increment `contract.scenariosPlayed`
+- [ ] 7.3 Derive mission result: SUCCESS if player winner + objectives met,
+      FAILURE if player lost, PARTIAL if turn-limit/withdrawal with
+      partial objectives
+- [ ] 7.4 Update `contract.lastMissionResult` and `contract.morale` per AtB
+      morale tables
+- [ ] 7.5 Fire `ContractProgressChanged` event
+- [ ] 7.6 If contract is fulfilled (all required scenarios played), flag it
+      for `contractProcessor` final-payment run
+
+## 8. Day Pipeline Registration
+
+- [ ] 8.1 Register `postBattleProcessor` in `dayPipeline.ts`
+- [ ] 8.2 Runs BEFORE `contractProcessor` (so contract sees updated mission
+      result) and BEFORE `healingProcessor` (so healing sees new wounds)
+- [ ] 8.3 Runs AFTER any income processors (battle doesn't produce income
+      directly; salvage and contract payment come separately)
+- [ ] 8.4 Source of pending outcomes: a queue on the campaign state
+      `pendingBattleOutcomes: ICombatOutcome[]` populated by the wiring
+      change in `wire-encounter-to-campaign-round-trip`
+
+## 9. Tests
+
+- [ ] 9.1 Unit: XP application for a pilot with 2 kills + 1 task → correct
+      `IXPAwardEvent[]`
+- [ ] 9.2 Unit: KIA pilot gets status KIA, removed from active roster
+- [ ] 9.3 Unit: Wounded pilot enters medical queue with recovery days set
+- [ ] 9.4 Unit: Unit combat state reflects per-location armor/structure loss
+- [ ] 9.5 Unit: Destroyed component list dedupes on re-application of same
+      outcome (idempotency)
+- [ ] 9.6 Unit: Ammo consumption clamps at zero
+- [ ] 9.7 Unit: Contract progression increments `scenariosPlayed` once per
+      outcome
+- [ ] 9.8 Integration: Full outcome → processor → all downstream campaign
+      state updated correctly
+- [ ] 9.9 Regression: Replaying the same outcome twice produces zero net
+      change beyond the first application
+
+## 10. Error Handling
+
+- [ ] 10.1 Unknown pilot id in outcome → log warning, skip that pilot, keep
+      processing the rest
+- [ ] 10.2 Unknown unit id → same: warn, skip, continue
+- [ ] 10.3 Unknown contract id → warn, skip contract update
+- [ ] 10.4 Partial failure → any already-applied effects stay; processor
+      surfaces an `IPostBattleResult` with `appliedChanges` and `errors`

--- a/openspec/changes/add-post-battle-review-ui/proposal.md
+++ b/openspec/changes/add-post-battle-review-ui/proposal.md
@@ -1,0 +1,63 @@
+# Change: Add Post-Battle Review UI
+
+## Why
+
+Phase 1's `add-victory-and-post-battle-summary` (B6) produces a basic
+post-battle report from the event log, but it's raw numbers — damage dealt,
+damage received, kills. Phase 3 generates much richer data: per-unit
+casualties with per-location armor/structure loss, pilot XP awarded,
+pilot wounds and status transitions, salvage awarded split employer vs.
+mercenary, contract mission completion, repair queue updates with C-Bill
+estimates. Players need a single screen that surfaces all of this after a
+battle, so that "what just happened to my campaign?" is immediately
+legible. This change provides that screen.
+
+## What Changes
+
+- Add `/gameplay/games/[id]/review` route — the post-battle review page
+- New `post-battle-ui` capability (new spec)
+- Outcome summary header: winner, end reason, turn count, BV delta, MVP
+- Per-unit casualty panel with hoverable armor diagram — shows armor lost
+  per location, structure lost per location, destroyed components listed
+  by slot with visual damage overlay on the mech silhouette
+- Per-pilot outcome panel — XP earned (itemized: scenario + kill + task
+  - mission), wound count, consciousness rolls, final status badge
+    (ACTIVE / WOUNDED / UNCONSCIOUS / KIA / MIA / CAPTURED)
+- Salvage panel — two columns (employer award + mercenary award) showing
+  awarded units and parts with BV and estimated repair cost
+- Contract status panel — scenarios played, mission result, morale shift,
+  C-Bill earnings so far, remaining scenarios before fulfillment
+- Repair queue preview — ticket count, total C-Bill cost, longest expected
+  repair, parts shortage count
+- "Return to Campaign" CTA — commits the outcome to the pending queue (if
+  not already), closes the tactical session, returns player to campaign
+  dashboard with a toast confirming "X XP awarded, Y salvage secured"
+- Responsive (mobile column-stack, desktop side-by-side)
+- Re-openable from `/gameplay/matches/[id]` (persisted match log already
+  stores the outcome per `add-combat-outcome-model`)
+
+## Dependencies
+
+- **Requires**: `add-combat-outcome-model` (data shape),
+  `add-post-battle-processor` (pilot XP + status fields are populated in
+  the outcome), `add-salvage-rules-engine` (salvage allocation surfaces in
+  outcome), `add-repair-queue-integration` (repair preview)
+- **Requires (Phase 1 B6)**: `add-victory-and-post-battle-summary` —
+  extends B6's `/gameplay/matches/[id]` page rather than replacing it
+- **Required By**: `wire-encounter-to-campaign-round-trip` (this is the
+  user-visible hand-off point)
+
+## Impact
+
+- Affected specs: `after-combat-report` (MODIFIED — B6's report extended
+  with per-pilot XP + salvage + repair preview sections), new
+  `post-battle-ui` (ADDED — layout + interaction rules for the review
+  screen)
+- Affected code: new `src/app/gameplay/games/[id]/review/page.tsx`, new
+  `src/components/gameplay/post-battle/` directory
+  (CasualtyPanel, PilotOutcomePanel, SalvagePanel, ContractStatusPanel,
+  RepairPreviewPanel, ArmorDiagram, OutcomeSummaryHeader), extends
+  `src/stores/gameplayStore.ts` with `reviewReady` selector
+- Non-goals: applying effects (already done by processors via
+  `add-post-battle-processor`), editable ticket UI (use existing repair
+  UI), salvage rejection / custom splits (future change)

--- a/openspec/changes/add-post-battle-review-ui/specs/after-combat-report/spec.md
+++ b/openspec/changes/add-post-battle-review-ui/specs/after-combat-report/spec.md
@@ -1,0 +1,37 @@
+# after-combat-report Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: Post-Battle Report Screen
+
+The post-battle report screen SHALL now render from `ICombatOutcome`
+(superseding the original `IPostBattleReport`) and SHALL surface every
+campaign-relevant dimension of the battle in a single page layout.
+
+#### Scenario: Screen renders all required sections
+
+- **GIVEN** a user navigates to `/gameplay/games/[id]/review` for a
+  completed session
+- **WHEN** the page finishes loading
+- **THEN** the page SHALL contain an outcome summary header, one casualty
+  panel per participating unit, one pilot outcome panel per participating
+  pilot, a salvage panel (or empty-state), a contract status panel (when
+  contract linked), and a repair preview panel
+
+#### Scenario: Standalone skirmish omits contract panel
+
+- **GIVEN** a review for a standalone skirmish (no `contractId` on the
+  outcome)
+- **WHEN** the page renders
+- **THEN** the contract status panel SHALL NOT be rendered
+- **AND** the salvage panel SHALL render with an empty-state message
+
+#### Scenario: Return-to-campaign commits outcome
+
+- **GIVEN** a review page for an outcome not yet committed to the
+  campaign pending queue
+- **WHEN** the user clicks "Return to Campaign"
+- **THEN** the outcome SHALL be appended to
+  `campaign.pendingBattleOutcomes`
+- **AND** the session SHALL be marked reviewed in the session store
+- **AND** the router SHALL navigate to the campaign dashboard

--- a/openspec/changes/add-post-battle-review-ui/specs/post-battle-ui/spec.md
+++ b/openspec/changes/add-post-battle-review-ui/specs/post-battle-ui/spec.md
@@ -1,0 +1,156 @@
+# post-battle-ui Specification
+
+## ADDED Requirements
+
+### Requirement: Post-Battle Review Route
+
+The post-battle UI SHALL provide a `/gameplay/games/[id]/review` route
+accessible once a session has emitted `CombatOutcomeReady` and the
+associated `ICombatOutcome` has been persisted.
+
+#### Scenario: Route fetches outcome from persistence
+
+- **GIVEN** a session id `G` with a persisted outcome
+- **WHEN** the user navigates to `/gameplay/games/G/review`
+- **THEN** the page SHALL fetch `/api/matches/G/outcome`
+- **AND** the page SHALL render once the fetch resolves
+- **AND** loading and error states SHALL be handled with explicit UI
+
+#### Scenario: Route guards against incomplete sessions
+
+- **GIVEN** a session id `G` that is still `InProgress`
+- **WHEN** the user navigates to `/gameplay/games/G/review`
+- **THEN** the page SHALL redirect to `/gameplay/games/G` (the active
+  match view)
+
+### Requirement: Per-Unit Casualty Panel
+
+The UI SHALL render one `CasualtyPanel` per `IUnitCasualty` in the
+outcome, showing armor and structure loss per location, destroyed
+components, ammo consumption, maximum heat, shutdown count, and final
+status.
+
+#### Scenario: Panel reflects per-location armor loss
+
+- **GIVEN** a unit casualty with `armorLostPerLocation = { LT: 12, CT: 5 }`
+- **WHEN** the casualty panel renders
+- **THEN** the armor diagram SHALL visually indicate the LT lost 12
+  points and CT lost 5 points
+- **AND** hovering over the LT SHALL reveal a tooltip with before/after
+  values
+
+#### Scenario: Panel lists destroyed components
+
+- **GIVEN** a unit casualty with `destroyedComponents` containing a
+  Medium Laser in RA
+- **WHEN** the panel renders
+- **THEN** the destroyed-components section SHALL list
+  "Medium Laser — Right Arm (slot X)"
+- **AND** the armor diagram's RA SHALL visually indicate the component
+  slot as destroyed
+
+#### Scenario: Panel shows final status badge
+
+- **GIVEN** a unit casualty with `finalStatus = CRIPPLED`
+- **WHEN** the panel renders
+- **THEN** a badge labeled "CRIPPLED" SHALL be visible
+- **AND** the badge SHALL use a color consistent with the design system's
+  danger/warning palette
+
+### Requirement: Per-Pilot Outcome Panel
+
+The UI SHALL render one `PilotOutcomePanel` per `IPilotOutcome` showing
+XP awarded (itemized), wound count, consciousness roll failures, and
+final pilot status.
+
+#### Scenario: Panel itemizes XP sources
+
+- **GIVEN** a pilot outcome with 1 scenario XP, 2 kill XP, 1 task XP, 3
+  mission XP
+- **WHEN** the pilot panel renders
+- **THEN** the XP breakdown SHALL display
+  "Scenario +1, Kills +2, Tasks +1, Mission +3 = Total +7"
+- **AND** the total SHALL match the sum of the itemized values
+
+#### Scenario: Panel displays wound tracker
+
+- **GIVEN** a pilot outcome with 2 wounds taken
+- **WHEN** the panel renders
+- **THEN** a 6-slot wound tracker SHALL show 2 slots filled, 4 empty
+
+#### Scenario: KIA pilot has terminal status badge
+
+- **GIVEN** a pilot with `finalStatus = KIA`
+- **WHEN** the panel renders
+- **THEN** a prominent "KIA" badge SHALL be shown
+- **AND** no XP breakdown SHALL be displayed (KIA pilots do not receive
+  posthumous XP per campaign rules)
+
+### Requirement: Salvage Panel
+
+The UI SHALL render a `SalvagePanel` showing the employer and mercenary
+salvage awards side by side, with split-method label.
+
+#### Scenario: Contract split is labeled
+
+- **GIVEN** a salvage allocation with `splitMethod = "contract"` and
+  `salvageRights = 60`
+- **WHEN** the salvage panel renders
+- **THEN** the split-method label SHALL read "Contract 60/40 Mercenary"
+  (or equivalent)
+
+#### Scenario: Hostile withdrawal is labeled
+
+- **GIVEN** a salvage allocation with `splitMethod = "hostile_withdrawal"`
+- **WHEN** the panel renders
+- **THEN** the label SHALL read "Hostile Withdrawal (mercenary salvage
+  halved)"
+- **AND** the mercenary column's total value SHALL show the halved value
+
+#### Scenario: Empty pool shows empty-state
+
+- **GIVEN** an outcome whose salvage allocation has no candidates
+- **WHEN** the panel renders
+- **THEN** both columns SHALL show "No salvageable materiel"
+- **AND** the split-method label SHALL be suppressed
+
+### Requirement: Contract Status Panel
+
+The UI SHALL render a `ContractStatusPanel` when `outcome.contractId` is
+set, showing progress, mission result, morale shift, and earnings.
+
+#### Scenario: Panel hidden on standalone skirmish
+
+- **GIVEN** an outcome with `contractId = null`
+- **WHEN** the review page renders
+- **THEN** no contract status panel SHALL be rendered
+
+#### Scenario: Panel shows mission result
+
+- **GIVEN** an outcome with `contractId` set and the processor recorded a
+  SUCCESS mission result
+- **WHEN** the panel renders
+- **THEN** the result label SHALL read "SUCCESS" with a green icon
+- **AND** the scenarios-played progress SHALL increment to reflect this
+  mission
+
+### Requirement: Repair Preview Panel
+
+The UI SHALL render a `RepairPreviewPanel` summarizing tickets created
+by the repair queue builder for this battle.
+
+#### Scenario: Panel summarizes ticket counts by priority
+
+- **GIVEN** repair tickets generated for this battle: 1 CRITICAL, 2 HIGH,
+  5 NORMAL, 3 LOW
+- **WHEN** the panel renders
+- **THEN** the ticket-count summary SHALL read "1 critical, 2 high, 5
+  normal, 3 low"
+
+#### Scenario: Panel shows unmatched parts count
+
+- **GIVEN** tickets that collectively need 4 parts not in inventory
+- **WHEN** the panel renders
+- **THEN** an "unmatched parts" counter SHALL display 4
+- **AND** a link SHALL route the user to the acquisition UI filtered by
+  unmet demand

--- a/openspec/changes/add-post-battle-review-ui/tasks.md
+++ b/openspec/changes/add-post-battle-review-ui/tasks.md
@@ -1,0 +1,126 @@
+# Tasks: Add Post-Battle Review UI
+
+## 1. Route & Page Scaffolding
+
+- [ ] 1.1 Create `/gameplay/games/[id]/review` route
+- [ ] 1.2 Route component fetches `ICombatOutcome` from
+      `/api/matches/[id]/outcome`
+- [ ] 1.3 Guard against navigating to review before outcome is ready
+      (status check against session)
+- [ ] 1.4 Redirect from victory screen to review on "View Post-Battle
+      Report" action (update existing victory CTA wired in B6)
+- [ ] 1.5 Responsive layout — desktop 3-column, tablet 2-column, mobile
+      single-column stack
+
+## 2. Outcome Summary Header
+
+- [ ] 2.1 Component `OutcomeSummaryHeader`
+- [ ] 2.2 Displays winner side (large badge), end reason label, turn
+      count, total BV destroyed per side, MVP badge (pilot + unit)
+- [ ] 2.3 Visual treatment: green accent on winner, red on loser, gray on
+      draw
+- [ ] 2.4 Unit test for label derivation from end-reason enum
+
+## 3. Casualty Panel (per unit)
+
+- [ ] 3.1 Component `CasualtyPanel` rendered once per participating unit
+- [ ] 3.2 Includes a mini armor diagram (SVG) showing armor + structure
+      per location with damage overlay
+- [ ] 3.3 Hover over location shows tooltip: armor before → armor after,
+      structure before → structure after
+- [ ] 3.4 Destroyed components list (slot, component name) with
+      destroyed-component icon
+- [ ] 3.5 Ammo consumed summary (ammo type → rounds fired)
+- [ ] 3.6 Max heat reached + shutdown count
+- [ ] 3.7 Final status badge (INTACT / DAMAGED / CRIPPLED / DESTROYED /
+      EJECTED) with color coding
+- [ ] 3.8 Uses existing `src/components/gameplay/record-sheet/ArmorDiagram`
+      if available; otherwise build a minimal inline SVG reusing the
+      armor-diagram spec's schema
+
+## 4. Pilot Outcome Panel
+
+- [ ] 4.1 Component `PilotOutcomePanel` rendered once per pilot
+- [ ] 4.2 XP breakdown: scenario X + kills Y + tasks Z + mission M = total
+- [ ] 4.3 Pilot status badge: ACTIVE / WOUNDED / UNCONSCIOUS / KIA / MIA
+      / CAPTURED
+- [ ] 4.4 Wounds-taken counter with visual hit tracker (6 dots)
+- [ ] 4.5 Consciousness-rolls-failed counter
+- [ ] 4.6 "Captured" badge shows capturing faction when known
+
+## 5. Salvage Panel
+
+- [ ] 5.1 Component `SalvagePanel`
+- [ ] 5.2 Two-column layout: Employer Award / Mercenary Award
+- [ ] 5.3 Each column lists awarded units (with BV, damage level,
+      estimated repair cost) and awarded parts (name, quantity, market
+      value)
+- [ ] 5.4 Column totals at top — total value + total estimated repair
+- [ ] 5.5 Split method label: "Contract 60/40", "Auction Exchange",
+      "Hostile Withdrawal (halved)"
+- [ ] 5.6 Empty-state: "No salvageable materiel" when pool is empty
+
+## 6. Contract Status Panel
+
+- [ ] 6.1 Component `ContractStatusPanel`
+- [ ] 6.2 Shows contract name, employer
+- [ ] 6.3 Scenarios played (e.g., "3 of 5")
+- [ ] 6.4 Mission result label (SUCCESS / FAILURE / PARTIAL) with icon
+- [ ] 6.5 Morale shift indicator (arrow with before/after morale level)
+- [ ] 6.6 C-Bill earnings-to-date and final-payment estimate
+- [ ] 6.7 Hidden entirely when `outcome.contractId` is null (standalone
+      skirmish)
+
+## 7. Repair Preview Panel
+
+- [ ] 7.1 Component `RepairPreviewPanel`
+- [ ] 7.2 Ticket count summary (CRITICAL × N, HIGH × M, NORMAL × O, LOW ×
+      P)
+- [ ] 7.3 Total estimated C-Bill cost across all tickets
+- [ ] 7.4 Longest expected repair duration (from the longest-hours ticket)
+- [ ] 7.5 Unmatched-parts count with link to "Procurement plan" (routes
+      to existing acquisition UI filtered by unmet demand)
+
+## 8. Return-to-Campaign CTA
+
+- [ ] 8.1 Primary button "Return to Campaign" at the bottom of the page
+- [ ] 8.2 On click: commit outcome to `campaign.pendingBattleOutcomes` if
+      not already present
+- [ ] 8.3 Close the tactical session in session store (mark reviewed)
+- [ ] 8.4 Navigate to campaign dashboard
+- [ ] 8.5 Show toast: "Battle outcome recorded — advance day to apply
+      effects"
+
+## 9. Re-openable From Match Log
+
+- [ ] 9.1 Existing `/gameplay/matches/[id]` list route gains a "View
+      Review" link per match
+- [ ] 9.2 Review page also loads from this entry point using the same
+      outcome data
+
+## 10. Store Integration
+
+- [ ] 10.1 `useGameplayStore` selector `reviewReady(gameId)` returns true
+      once outcome exists
+- [ ] 10.2 `useGameplayStore` action `commitOutcomeToCampaign(outcome)` —
+      pushes to campaign pending queue via existing campaign store
+
+## 11. Tests
+
+- [ ] 11.1 Component test: `CasualtyPanel` renders destroyed components
+      correctly
+- [ ] 11.2 Component test: `PilotOutcomePanel` sums XP correctly
+- [ ] 11.3 Component test: `SalvagePanel` shows split method labels
+- [ ] 11.4 Component test: `ContractStatusPanel` hides when contractId is
+      null
+- [ ] 11.5 Component test: "Return to Campaign" CTA commits outcome
+- [ ] 11.6 Integration test: navigate review page with a mock completed
+      outcome → all panels render
+- [ ] 11.7 Accessibility test: all panels have proper ARIA labels, armor
+      diagram provides text alternative
+
+## 12. Documentation
+
+- [ ] 12.1 Add screenshots to `docs/gameplay/post-battle-review.md`
+- [ ] 12.2 Document the component composition (which panels read which
+      outcome fields)

--- a/openspec/changes/add-pre-battle-force-comparison/proposal.md
+++ b/openspec/changes/add-pre-battle-force-comparison/proposal.md
@@ -1,0 +1,64 @@
+# Change: Add Pre-Battle Force Comparison
+
+## Why
+
+Phase 1's pre-battle setup screen (`add-skirmish-setup-ui`) lets the
+player pick units, pilots, and map settings — then commits them to a
+match. But players have no snapshot of "is this a fair fight?" before
+pressing Launch. In BattleTech a 30% BV imbalance usually decides the
+match, a 50kg tonnage deficit is survivable, and a pilot-skill gap is
+often decisive. Phase 2's decision-support promise is "see the
+lopsided-ness before you commit". This change adds a force comparison
+panel to the pre-battle screen showing BV delta, tonnage delta, heat
+dissipation delta, average pilot skill delta, weapon DPT potential
+delta, and SPA modifier summary — all side-by-side, so the player can
+swap a mech before launching.
+
+## What Changes
+
+- Add `deriveForceSummary(side, force): IForceSummary` that aggregates
+  per-side statistics: `{totalBV, totalTonnage, heatDissipation,
+avgGunnery, avgPiloting, weaponDamagePerTurnPotential, spaSummary:
+Array<{spaId, unitIds}>}`
+- Add `compareForces(player, opponent): IForceComparison` returning
+  each metric's delta (signed, player minus opponent) plus a
+  normalized severity (low / moderate / high) based on documented
+  thresholds
+- Add a `ForceComparisonPanel` React component that renders the
+  comparison as a two-column layout with delta badges
+- Integrate the panel into the pre-battle page as a collapsible
+  sidebar; default open when the encounter has both sides configured
+- Add thresholds: BV ratio > 1.25 → high, 1.10–1.25 → moderate;
+  tonnage delta > 20% → high; pilot-skill gap ≥ 1.0 → high; DPT delta
+  > 25% → high
+- SPA summary groups pilots by their active SPAs so the player can
+  see "Opponent has Sniper × 2, Marksman × 1" at a glance
+
+## Dependencies
+
+- **Requires**: `add-skirmish-setup-ui` (pre-battle page where the
+  panel mounts), `after-combat-report` (reuses aggregation shapes),
+  `game-session-management` (force configuration input shape), Phase
+  1 wiring for SPA modifiers (from `improve-bot-basic-combat-competence`
+  and existing SPA catalog)
+- **Required By**: none in Phase 2 (leaf pre-battle surface). Phase 3
+  campaign integration will reuse this panel when accepting contracts.
+
+## Impact
+
+- Affected specs: `after-combat-report` (ADDED — `IForceSummary` and
+  `IForceComparison` shapes colocated with existing summary types
+  since they share aggregation patterns), `game-session-management`
+  (MODIFIED — pre-battle handshake exposes an optional
+  `onForcesChange` callback the panel subscribes to)
+- Affected code: new
+  `src/components/gameplay/ForceComparisonPanel.tsx`, new
+  `src/utils/gameplay/forceSummary.ts`, new
+  `src/utils/gameplay/forceComparison.ts`,
+  `src/pages/gameplay/encounters/[id]/pre-battle.tsx` (adds the panel
+  to the sidebar)
+- Non-goals: suggesting substitution units (future), showing heatmap
+  of terrain interactions (future), accounting for terrain pre-placed
+  hazards (future), running a quick Monte Carlo from the pre-battle
+  screen (that's the `add-quick-resolve-monte-carlo` button already
+  reachable from the encounter detail page)

--- a/openspec/changes/add-pre-battle-force-comparison/specs/after-combat-report/spec.md
+++ b/openspec/changes/add-pre-battle-force-comparison/specs/after-combat-report/spec.md
@@ -1,0 +1,197 @@
+# after-combat-report Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Force Summary Schema
+
+The after-combat-report system SHALL define an `IForceSummary` schema
+that aggregates per-side force statistics used by the pre-battle
+comparison panel and reusable elsewhere (post-battle reports, campaign
+contracts).
+
+#### Scenario: Force summary contains required fields
+
+- **GIVEN** a configured 2-mech force with assigned pilots
+- **WHEN** `deriveForceSummary(side, force)` is called
+- **THEN** the returned `IForceSummary` SHALL contain `{side,
+totalBV, totalTonnage, heatDissipation, avgGunnery, avgPiloting,
+weaponDamagePerTurnPotential, spaSummary}`
+- **AND** `side` SHALL be one of `GameSide.Player` or
+  `GameSide.Opponent`
+
+#### Scenario: BV aggregation
+
+- **GIVEN** a force with two mechs of BV `{1820, 2100}`
+- **WHEN** the summary is derived
+- **THEN** `totalBV` SHALL equal 3920
+
+#### Scenario: Tonnage aggregation
+
+- **GIVEN** a force with two mechs of tonnage `{45, 55}`
+- **WHEN** the summary is derived
+- **THEN** `totalTonnage` SHALL equal 100
+
+#### Scenario: Heat dissipation aggregation
+
+- **GIVEN** a force where mech A has 12 single heat sinks (10 integral
+  engine + 2 added) and mech B has 14 double heat sinks (10 engine +
+  4 added)
+- **WHEN** the summary is derived
+- **THEN** `heatDissipation` SHALL equal `12 + 28 = 40` (singles × 1 +
+  doubles × 2)
+
+#### Scenario: Pilot skill averaging
+
+- **GIVEN** two pilots with `{gunnery: 4, piloting: 5}` and `{gunnery:
+3, piloting: 4}`
+- **WHEN** the summary is derived
+- **THEN** `avgGunnery` SHALL equal 3.5
+- **AND** `avgPiloting` SHALL equal 4.5
+
+#### Scenario: DPT potential aggregation
+
+- **GIVEN** a force whose weapons sum to 45 damage per turn if every
+  weapon fires at medium range without misses
+- **WHEN** the summary is derived
+- **THEN** `weaponDamagePerTurnPotential` SHALL equal 45
+- **AND** no hit-probability factor SHALL be applied (this is
+  potential, not expected)
+
+#### Scenario: SPA summary aggregation
+
+- **GIVEN** a force where two pilots have `"Sniper"` and one pilot has
+  `"Marksman"`
+- **WHEN** the summary is derived
+- **THEN** `spaSummary` SHALL contain entries for both `"Sniper"` and
+  `"Marksman"`
+- **AND** the Sniper entry SHALL list both pilots' unit IDs
+- **AND** the Marksman entry SHALL list the single pilot's unit ID
+
+### Requirement: Force Comparison Schema
+
+The after-combat-report system SHALL define an `IForceComparison`
+schema wrapping two `IForceSummary` values with computed deltas,
+`bvRatio`, and per-metric severity tiers used to render visual
+warnings in the comparison panel.
+
+#### Scenario: Comparison contains deltas and severity
+
+- **GIVEN** two force summaries (player and opponent)
+- **WHEN** `compareForces(player, opponent)` is called
+- **THEN** the returned `IForceComparison` SHALL contain `{player,
+opponent, deltas, bvRatio}`
+- **AND** `deltas` SHALL contain entries for `totalBV`,
+  `totalTonnage`, `heatDissipation`, `avgGunnery`, `avgPiloting`,
+  `weaponDamagePerTurnPotential`
+- **AND** each delta entry SHALL be shaped `{value: number, severity:
+'low' | 'moderate' | 'high'}`
+
+#### Scenario: Delta value is player minus opponent
+
+- **GIVEN** `player.totalBV = 5325` and `opponent.totalBV = 5000`
+- **WHEN** the comparison is computed
+- **THEN** `deltas.totalBV.value` SHALL equal 325 (positive means
+  player advantage)
+
+#### Scenario: Gunnery delta inverts sign (lower is better)
+
+- **GIVEN** `player.avgGunnery = 3.5` and `opponent.avgGunnery = 4.0`
+- **WHEN** the comparison is computed
+- **THEN** `deltas.avgGunnery.value` SHALL equal `-0.5` in raw
+  arithmetic (player − opponent)
+- **AND** the severity SHALL be assessed on the absolute value
+- **AND** the rendered badge SHALL show the player side as having the
+  advantage (lower gunnery wins)
+
+#### Scenario: BV ratio calculation
+
+- **GIVEN** `player.totalBV = 5000` and `opponent.totalBV = 4000`
+- **WHEN** the comparison is computed
+- **THEN** `bvRatio` SHALL equal 1.25 (= 5000 / 4000)
+
+### Requirement: Severity Tier Thresholds
+
+The comparison SHALL assign each delta a severity tier using
+documented thresholds so the UI can render warning accents
+consistently.
+
+#### Scenario: BV severity tiers
+
+- **GIVEN** `bvRatio = 1.30`
+- **WHEN** severity is assigned
+- **THEN** `deltas.totalBV.severity` SHALL equal `"high"`
+
+- **GIVEN** `bvRatio = 1.15`
+- **WHEN** severity is assigned
+- **THEN** `deltas.totalBV.severity` SHALL equal `"moderate"`
+
+- **GIVEN** `bvRatio = 1.05`
+- **WHEN** severity is assigned
+- **THEN** `deltas.totalBV.severity` SHALL equal `"low"`
+
+#### Scenario: Tonnage severity based on percentage
+
+- **GIVEN** `player.totalTonnage = 100`, `opponent.totalTonnage = 125`
+  (25% delta vs max 125)
+- **WHEN** severity is assigned
+- **THEN** `deltas.totalTonnage.severity` SHALL equal `"high"` (> 20%)
+
+- **GIVEN** tonnage delta is 15% vs max
+- **WHEN** severity is assigned
+- **THEN** `deltas.totalTonnage.severity` SHALL equal `"moderate"`
+
+- **GIVEN** tonnage delta is 5% vs max
+- **WHEN** severity is assigned
+- **THEN** `deltas.totalTonnage.severity` SHALL equal `"low"`
+
+#### Scenario: Pilot skill severity
+
+- **GIVEN** `|avgGunnery delta| = 1.2`
+- **WHEN** severity is assigned
+- **THEN** `deltas.avgGunnery.severity` SHALL equal `"high"`
+
+- **GIVEN** `|avgPiloting delta| = 0.6`
+- **WHEN** severity is assigned
+- **THEN** `deltas.avgPiloting.severity` SHALL equal `"moderate"`
+
+#### Scenario: DPT severity thresholds
+
+- **GIVEN** DPT delta of 30% vs max
+- **WHEN** severity is assigned
+- **THEN** `deltas.weaponDamagePerTurnPotential.severity` SHALL equal
+  `"high"`
+
+- **GIVEN** DPT delta of 18% vs max
+- **WHEN** severity is assigned
+- **THEN** `deltas.weaponDamagePerTurnPotential.severity` SHALL equal
+  `"moderate"`
+
+### Requirement: Partial Force Summary Handling
+
+`deriveForceSummary` SHALL produce a best-effort summary when one side
+is only partially configured (e.g., missing pilots, invalid unit IDs),
+skipping invalid entries rather than throwing.
+
+#### Scenario: Invalid unit IDs skipped
+
+- **GIVEN** a force with two valid units and one unknown unit ID
+- **WHEN** the summary is derived
+- **THEN** the summary SHALL aggregate across the two valid units
+- **AND** `warnings` SHALL include `"Force contains unknown units"`
+- **AND** no exception SHALL be thrown
+
+#### Scenario: Missing pilot falls back to default skill
+
+- **GIVEN** a force with one pilotless unit
+- **WHEN** the summary is derived
+- **THEN** the pilotless unit SHALL contribute the default skill
+  values (`gunnery: 4`, `piloting: 5`) to the averages
+- **AND** `warnings` SHALL include `"Unit has no assigned pilot"`
+
+#### Scenario: Empty force returns zero summary
+
+- **GIVEN** an empty force (no units)
+- **WHEN** the summary is derived
+- **THEN** all numeric fields SHALL equal 0
+- **AND** `spaSummary` SHALL be an empty array
+- **AND** no exception SHALL be thrown

--- a/openspec/changes/add-pre-battle-force-comparison/specs/game-session-management/spec.md
+++ b/openspec/changes/add-pre-battle-force-comparison/specs/game-session-management/spec.md
@@ -1,0 +1,69 @@
+# game-session-management Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Pre-Battle Force Change Callback
+
+The game-session-management pre-battle configuration handshake SHALL
+accept an optional `onForcesChange` callback that fires whenever
+either side's force composition changes (add/remove unit, swap pilot,
+rename force), enabling the `ForceComparisonPanel` to re-derive its
+summary without polling.
+
+#### Scenario: Callback fires on unit addition
+
+- **GIVEN** a pre-battle session with `onForcesChange` subscribed and
+  the player side has one mech
+- **WHEN** the player adds a second mech to their force
+- **THEN** `onForcesChange` SHALL be invoked once with
+  `{player: IForceConfig, opponent: IForceConfig}`
+- **AND** the new player force config SHALL include both mechs
+
+#### Scenario: Callback fires on pilot swap
+
+- **GIVEN** a pre-battle session with `onForcesChange` subscribed
+- **WHEN** the player swaps the pilot assigned to mech A
+- **THEN** `onForcesChange` SHALL be invoked with the updated
+  `IForceConfig`
+
+#### Scenario: Callback fires on unit removal
+
+- **GIVEN** a pre-battle session with two mechs per side
+- **WHEN** the player removes one mech from their force
+- **THEN** `onForcesChange` SHALL be invoked with the reduced
+  `IForceConfig`
+
+#### Scenario: Callback not invoked for unrelated changes
+
+- **GIVEN** a pre-battle session with `onForcesChange` subscribed
+- **WHEN** the player changes the map radius (not a force change)
+- **THEN** `onForcesChange` SHALL NOT be invoked
+
+#### Scenario: Callback omission does not affect launch
+
+- **GIVEN** a pre-battle session with no `onForcesChange` supplied
+- **WHEN** the player configures forces and launches
+- **THEN** the session SHALL launch normally
+- **AND** no exception SHALL be thrown
+
+### Requirement: Force Config Stability
+
+The force configuration objects passed to `onForcesChange` SHALL be
+immutable snapshots — mutating them SHALL NOT affect the pre-battle
+session's internal state.
+
+#### Scenario: Mutation of snapshot does not affect session
+
+- **GIVEN** `onForcesChange` fires with a `player` force config
+- **WHEN** the consumer mutates the received config object
+- **THEN** the internal pre-battle session state SHALL remain
+  unchanged
+- **AND** a subsequent `onForcesChange` emission SHALL reflect the
+  true session state (not the mutated snapshot)
+
+#### Scenario: Deep-equal snapshots across emissions
+
+- **GIVEN** no force changes occurred between two callback
+  invocations (callback was triggered by a different subscriber path)
+- **WHEN** the two callbacks are compared
+- **THEN** the two snapshots SHALL be deeply equal

--- a/openspec/changes/add-pre-battle-force-comparison/tasks.md
+++ b/openspec/changes/add-pre-battle-force-comparison/tasks.md
@@ -1,0 +1,135 @@
+# Tasks: Add Pre-Battle Force Comparison
+
+## 1. Force Summary Shape
+
+- [ ] 1.1 Define `IForceSummary` with `{side, totalBV, totalTonnage,
+    heatDissipation, avgGunnery, avgPiloting,
+    weaponDamagePerTurnPotential, spaSummary:
+    Array<{spaId, name, unitIds: string[]}>}`
+- [ ] 1.2 Define `IForceComparison` with `{player: IForceSummary,
+    opponent: IForceSummary, deltas: Record<string, {value: number,
+    severity: 'low'|'moderate'|'high'}>, bvRatio: number}`
+
+## 2. Force Summary Derivation
+
+- [ ] 2.1 Create `deriveForceSummary(side, force): IForceSummary`
+- [ ] 2.2 `totalBV`: sum of `unit.battleValue` for every unit in the
+      force
+- [ ] 2.3 `totalTonnage`: sum of `unit.tonnage`
+- [ ] 2.4 `heatDissipation`: sum of per-unit dissipation (heat sinks
+      × 2 for doubles, × 1 for singles, + engine-integrated)
+- [ ] 2.5 `avgGunnery`: arithmetic mean of assigned pilots' gunnery
+- [ ] 2.6 `avgPiloting`: arithmetic mean of assigned pilots' piloting
+- [ ] 2.7 `weaponDamagePerTurnPotential`: sum of every weapon's max
+      damage per turn if fired at medium range (uses existing weapon
+      catalog damage values, no hit-probability factor — this is
+      potential, not expected)
+- [ ] 2.8 `spaSummary`: flat list of `{spaId, name, unitIds: string[]}`
+      (one entry per unique active SPA across all pilots; `unitIds`
+      lists the units whose pilots hold that SPA)
+
+## 3. Force Comparison
+
+- [ ] 3.1 Create `compareForces(player, opponent): IForceComparison`
+- [ ] 3.2 Compute deltas for: BV (player − opponent), tonnage,
+      heat dissipation, avg gunnery (inverted — lower gunnery is
+      better), avg piloting (inverted), DPT potential
+- [ ] 3.3 `bvRatio` = `max(player.totalBV, opponent.totalBV) /
+    min(player.totalBV, opponent.totalBV)`
+- [ ] 3.4 Severity thresholds: - BV: `bvRatio > 1.25` → high, `1.10–1.25` → moderate,
+      otherwise low - Tonnage: `|delta| / max_tonnage > 0.20` → high, `> 0.10` →
+      moderate, otherwise low - Pilot skill: `|avgGunnery delta| >= 1.0` OR `|avgPiloting
+      delta| >= 1.0` → high, `>= 0.5` → moderate, otherwise low - DPT: `|delta| / max_dpt > 0.25` → high, `> 0.15` → moderate,
+      otherwise low - Heat dissipation: `|delta| / max_heat > 0.30` → high, `> 0.15`
+      → moderate, otherwise low
+
+## 4. Comparison Panel Component
+
+- [ ] 4.1 Create `ForceComparisonPanel` that takes `{comparison:
+    IForceComparison}`
+- [ ] 4.2 Two-column layout: Player (left) / Opponent (right) with
+      the delta badge in the gap between columns
+- [ ] 4.3 Rows: Total BV, Total Tonnage, Heat Dissipation, Avg
+      Gunnery, Avg Piloting, Weapon DPT Potential
+- [ ] 4.4 Each row shows both side values and a signed delta with
+      severity color (low = neutral gray, moderate = amber, high =
+      red)
+- [ ] 4.5 SPA Summary sub-section: shows each side's active SPAs as a
+      list with count chips (e.g., "Sniper × 2", "Marksman × 1")
+
+## 5. Delta Badge Styling
+
+- [ ] 5.1 Delta value rendered with a signed prefix: `"+325 BV"` or
+      `"−4.2 tons"`
+- [ ] 5.2 "Player advantage" deltas use green accent, "Opponent
+      advantage" deltas use red accent; low-severity deltas use a
+      neutral accent regardless of sign
+- [ ] 5.3 `aria-label` on the badge explains the delta:
+      `"Player BV 5325, Opponent BV 5000, player advantage 325"`
+
+## 6. SPA Summary Sub-Section
+
+- [ ] 6.1 Show top-level counts per SPA ID (e.g., `"Sniper × 2"`) per
+      side
+- [ ] 6.2 Hover / tap reveals which unit designations hold that SPA
+- [ ] 6.3 When a side has zero SPAs, show `"No active SPAs"`
+
+## 7. Pre-Battle Page Integration
+
+- [ ] 7.1 Mount `ForceComparisonPanel` in the pre-battle page sidebar
+- [ ] 7.2 Panel is collapsible; defaults to expanded when both sides
+      have units assigned
+- [ ] 7.3 Panel subscribes to `onForcesChange` from
+      `game-session-management` so edits to either force (adding a
+      mech, swapping a pilot) re-derive the summary
+- [ ] 7.4 When a side has no units yet, show
+      `"Configure both sides to see comparison"`
+
+## 8. Decision Hints
+
+- [ ] 8.1 Above the comparison table, show a one-line hint derived
+      from the highest-severity delta: e.g., `"Opponent has a 28% BV
+    advantage"` or `"Forces look evenly matched"`
+- [ ] 8.2 If any delta is `high` severity, the panel header shows a
+      warning icon
+- [ ] 8.3 Hint text SHALL be neutral and descriptive — SHALL NOT
+      recommend swaps (that's a future scope)
+
+## 9. Empty / Partial State
+
+- [ ] 9.1 When only one side is configured, show per-side summary
+      but suppress the delta columns
+- [ ] 9.2 When no forces are configured, show `"Configure forces to
+    begin"` placeholder
+- [ ] 9.3 When a side is configured with invalid unit IDs, surface
+      `"Force contains unknown units"` and fall back to a best-effort
+      partial summary (skip invalid units)
+
+## 10. Tests
+
+- [ ] 10.1 Unit test: `deriveForceSummary` with a known 2-mech force
+      produces the expected totals
+- [ ] 10.2 Unit test: `compareForces` returns correct deltas and
+      severity tiers for a 25% BV advantage case
+- [ ] 10.3 Unit test: SPA summary aggregation groups duplicate SPAs
+      across pilots
+- [ ] 10.4 Component test: panel renders all rows for a sample
+      comparison
+- [ ] 10.5 Component test: Panel updates when `onForcesChange` fires
+- [ ] 10.6 Component test: Collapsed state hides the comparison table
+
+## 11. Accessibility
+
+- [ ] 11.1 Delta badges use both color and signed text so color-blind
+      users can read severity
+- [ ] 11.2 Comparison table uses `<table>` semantics with proper
+      `<th>` headers and `<caption>`
+- [ ] 11.3 SPA chips are keyboard-focusable with accessible tooltips
+
+## 12. Spec Compliance
+
+- [ ] 12.1 Every delta requirement across `after-combat-report` and
+      `game-session-management` has at least one GIVEN/WHEN/THEN
+      scenario
+- [ ] 12.2 `openspec validate add-pre-battle-force-comparison --strict`
+      passes clean

--- a/openspec/changes/add-pre-battle-force-comparison/tasks.md
+++ b/openspec/changes/add-pre-battle-force-comparison/tasks.md
@@ -3,12 +3,12 @@
 ## 1. Force Summary Shape
 
 - [ ] 1.1 Define `IForceSummary` with `{side, totalBV, totalTonnage,
-    heatDissipation, avgGunnery, avgPiloting,
-    weaponDamagePerTurnPotential, spaSummary:
-    Array<{spaId, name, unitIds: string[]}>}`
+heatDissipation, avgGunnery, avgPiloting,
+weaponDamagePerTurnPotential, spaSummary:
+Array<{spaId, name, unitIds: string[]}>}`
 - [ ] 1.2 Define `IForceComparison` with `{player: IForceSummary,
-    opponent: IForceSummary, deltas: Record<string, {value: number,
-    severity: 'low'|'moderate'|'high'}>, bvRatio: number}`
+opponent: IForceSummary, deltas: Record<string, {value: number,
+severity: 'low'|'moderate'|'high'}>, bvRatio: number}`
 
 ## 2. Force Summary Derivation
 
@@ -35,18 +35,18 @@
       heat dissipation, avg gunnery (inverted — lower gunnery is
       better), avg piloting (inverted), DPT potential
 - [ ] 3.3 `bvRatio` = `max(player.totalBV, opponent.totalBV) /
-    min(player.totalBV, opponent.totalBV)`
+min(player.totalBV, opponent.totalBV)`
 - [ ] 3.4 Severity thresholds: - BV: `bvRatio > 1.25` → high, `1.10–1.25` → moderate,
       otherwise low - Tonnage: `|delta| / max_tonnage > 0.20` → high, `> 0.10` →
       moderate, otherwise low - Pilot skill: `|avgGunnery delta| >= 1.0` OR `|avgPiloting
-      delta| >= 1.0` → high, `>= 0.5` → moderate, otherwise low - DPT: `|delta| / max_dpt > 0.25` → high, `> 0.15` → moderate,
+delta| >= 1.0` → high, `>= 0.5` → moderate, otherwise low - DPT: `|delta| / max_dpt > 0.25` → high, `> 0.15` → moderate,
       otherwise low - Heat dissipation: `|delta| / max_heat > 0.30` → high, `> 0.15`
       → moderate, otherwise low
 
 ## 4. Comparison Panel Component
 
 - [ ] 4.1 Create `ForceComparisonPanel` that takes `{comparison:
-    IForceComparison}`
+IForceComparison}`
 - [ ] 4.2 Two-column layout: Player (left) / Opponent (right) with
       the delta badge in the gap between columns
 - [ ] 4.3 Rows: Total BV, Total Tonnage, Heat Dissipation, Avg
@@ -89,7 +89,7 @@
 
 - [ ] 8.1 Above the comparison table, show a one-line hint derived
       from the highest-severity delta: e.g., `"Opponent has a 28% BV
-    advantage"` or `"Forces look evenly matched"`
+advantage"` or `"Forces look evenly matched"`
 - [ ] 8.2 If any delta is `high` severity, the panel header shows a
       warning icon
 - [ ] 8.3 Hint text SHALL be neutral and descriptive — SHALL NOT
@@ -100,7 +100,7 @@
 - [ ] 9.1 When only one side is configured, show per-side summary
       but suppress the delta columns
 - [ ] 9.2 When no forces are configured, show `"Configure forces to
-    begin"` placeholder
+begin"` placeholder
 - [ ] 9.3 When a side is configured with invalid unit IDs, surface
       `"Force contains unknown units"` and fall back to a best-effort
       partial summary (skip invalid units)

--- a/openspec/changes/add-protomech-battle-value/proposal.md
+++ b/openspec/changes/add-protomech-battle-value/proposal.md
@@ -1,0 +1,32 @@
+# Change: Add ProtoMech Battle Value
+
+## Why
+
+ProtoMechs are costed in forces by point (typically 5 units); getting BV right matters for scenario balance even at low play rates. Currently BV returns 0. This change adds ProtoMech BV 2.0 per TechManual using the mech formula adapted to proto scale. Existing spec flagged "detailed BV calculation beyond simplified formula" as out of scope — this change promotes it to full scope, consistent with BA.
+
+## What Changes
+
+- Add defensive BV = armor BV + structure BV + defensive equipment BV + speed factor
+- Add offensive BV = weapon BV + ammo BV + main gun BV + physical bonus
+- Add speed factor using `mp = walkMP + round(jumpMP / 2)` similar to mechs
+- Add proto-specific multipliers: Glider 0.9× (lower durability), Ultraheavy 1.15× (heavy)
+- Add main gun treated as full BV weapon, same multiplier as mech weapons
+- Add point-composition metadata: BV stored per proto and summed when part of a point
+- Add pilot skill multiplier from shared table
+- Expose breakdown on unit
+- Add parity harness vs canonical proto BV
+
+## Non-goals
+
+- Per-point combat BV aggregation (individual protos still fight as units; point is a command/admin construct)
+
+## Dependencies
+
+- **Requires**: `add-protomech-construction`, `battle-value-system`
+- **Blocks**: `add-protomech-combat-behavior`
+
+## Impact
+
+- **Affected specs**: `battle-value-system` (MODIFIED — proto path), `protomech-unit-system` (MODIFIED — remove simplified-BV scope exclusion; ADDED breakdown)
+- **Affected code**: `src/utils/construction/protomech/protoMechBV.ts` (new), dispatch in `battleValueCalculations.ts`
+- **Validation target**: ≥ 90% within 5% vs canonical protos

--- a/openspec/changes/add-protomech-battle-value/specs/battle-value-system/spec.md
+++ b/openspec/changes/add-protomech-battle-value/specs/battle-value-system/spec.md
@@ -1,0 +1,63 @@
+# battle-value-system (delta)
+
+## ADDED Requirements
+
+### Requirement: ProtoMech BV Dispatch
+
+The BV calculator SHALL route `IProtoMechUnit` inputs to a proto-specific calculation path.
+
+#### Scenario: Proto dispatch
+
+- **GIVEN** a ProtoMech
+- **WHEN** `calculateBattleValue` is called
+- **THEN** the proto calculator SHALL be invoked
+- **AND** the return SHALL include an `IProtoMechBVBreakdown`
+
+### Requirement: ProtoMech Defensive BV
+
+The proto defensive BV SHALL combine armor, structure, defensive equipment, explosive penalty, and a TMM-based factor.
+
+#### Scenario: Armor BV baseline
+
+- **GIVEN** a Medium proto with 20 armor points
+- **WHEN** armorBV is computed
+- **THEN** armorBV SHALL equal `20 × 2.5 × 1.0 = 50`
+
+#### Scenario: Structure BV baseline
+
+- **GIVEN** a Medium proto with 12 structure points
+- **WHEN** structureBV is computed
+- **THEN** structureBV SHALL equal `12 × 1.5 × 1.0 = 18`
+
+### Requirement: ProtoMech Offensive BV and Main Gun
+
+Proto offensive BV SHALL include arm weapons and a MainGun location weapon with the same BV as a mech-mounted instance.
+
+#### Scenario: Main gun BV at full value
+
+- **GIVEN** a proto with a main-gun PPC (catalog BV 176)
+- **WHEN** offensive BV is computed
+- **THEN** the main gun contribution SHALL equal 176 BV (no proto-specific modifier)
+
+#### Scenario: Proto speed factor
+
+- **GIVEN** a proto with walkMP 6 and jumpMP 4
+- **WHEN** speed factor is computed
+- **THEN** `mp = 6 + round(4 / 2) = 8`
+- **AND** `sf = round(pow(1 + (8 − 5) / 10, 1.2) × 100) / 100`
+
+### Requirement: ProtoMech Chassis Multiplier
+
+Proto final BV SHALL be adjusted by chassis type.
+
+#### Scenario: Glider multiplier
+
+- **GIVEN** a Glider proto with pre-multiplier BV 280
+- **WHEN** the chassis multiplier is applied
+- **THEN** BV SHALL equal `280 × 0.9 = 252`
+
+#### Scenario: Ultraheavy multiplier
+
+- **GIVEN** an Ultraheavy proto with pre-multiplier BV 600
+- **WHEN** the chassis multiplier is applied
+- **THEN** BV SHALL equal `600 × 1.15 = 690`

--- a/openspec/changes/add-protomech-battle-value/specs/protomech-unit-system/spec.md
+++ b/openspec/changes/add-protomech-battle-value/specs/protomech-unit-system/spec.md
@@ -1,0 +1,37 @@
+# protomech-unit-system (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Scope — Full BV Calculation Included
+
+ProtoMech construction SHALL include full BV 2.0 calculation (previously scoped as simplified only).
+
+#### Scenario: Full proto BV supported
+
+- **GIVEN** any legally constructed ProtoMech
+- **WHEN** `calculateBattleValue` runs
+- **THEN** the full BV 2.0 proto formula SHALL be applied (defensive + offensive, chassis multiplier, pilot adjustment)
+- **AND** the legacy simplified formula SHALL no longer be used
+
+## ADDED Requirements
+
+### Requirement: ProtoMech BV Breakdown on Unit State
+
+Every ProtoMech SHALL carry an `IProtoMechBVBreakdown` populated by the calculator.
+
+#### Scenario: Breakdown shape
+
+- **GIVEN** a ProtoMech after construction completes
+- **WHEN** BV is computed
+- **THEN** `unit.bvBreakdown` SHALL contain `defensive`, `offensive`, `chassisMultiplier`, `pilotMultiplier`, `final`
+
+### Requirement: Proto Point BV Aggregation
+
+The system SHALL support aggregating up to 5 proto BVs into a point BV for force-level reporting.
+
+#### Scenario: Point aggregation
+
+- **GIVEN** a point of 5 protos with BVs 250, 300, 275, 290, 310
+- **WHEN** point BV is computed
+- **THEN** point BV SHALL equal the sum = 1425
+- **AND** the aggregate SHALL be displayed in force-level tools (not used during combat dispatch)

--- a/openspec/changes/add-protomech-battle-value/tasks.md
+++ b/openspec/changes/add-protomech-battle-value/tasks.md
@@ -1,0 +1,56 @@
+# Tasks: Add ProtoMech Battle Value
+
+## 1. Calculator Scaffolding
+
+- [ ] 1.1 Create `src/utils/construction/protomech/protoMechBV.ts`
+- [ ] 1.2 Export `calculateProtoMechBV(unit: IProtoMechUnit): IProtoMechBVBreakdown`
+- [ ] 1.3 Wire dispatch in `battleValueCalculations.ts`
+- [ ] 1.4 Define `IProtoMechBVBreakdown`
+
+## 2. Defensive BV
+
+- [ ] 2.1 armorBV = armor × 2.5 (Standard armor only; mult 1.0)
+- [ ] 2.2 structureBV = structure × 1.5
+- [ ] 2.3 defEquipBV from resolver
+- [ ] 2.4 Explosive penalty
+- [ ] 2.5 defFactor = 1 + (maxTMM / 10) — TMM from walkMP
+- [ ] 2.6 defensiveBV = (armorBV + structureBV + defEquipBV − explosive) × defFactor
+
+## 3. Offensive BV
+
+- [ ] 3.1 weaponBV — arm + main gun weapons
+- [ ] 3.2 ammoBV
+- [ ] 3.3 Physical attack bonus (small — protos have lower punch damage)
+- [ ] 3.4 offEquipBV
+- [ ] 3.5 Speed factor with mp = walkMP + round(jumpMP / 2)
+
+## 4. Chassis Multipliers
+
+- [ ] 4.1 Glider: finalBV × 0.9 (fragile)
+- [ ] 4.2 Ultraheavy: finalBV × 1.15 (heavier armor/firepower)
+- [ ] 4.3 Standard Biped / Quad: 1.0 (no modifier)
+
+## 5. Pilot Skill Multiplier
+
+- [ ] 5.1 Reuse shared gunnery/piloting table
+
+## 6. Point Aggregation
+
+- [ ] 6.1 Support summing 5 proto BVs into point BV for reporting
+- [ ] 6.2 Point BV displayed in force tools (not combat — each proto fights individually)
+
+## 7. Parity Harness
+
+- [ ] 7.1 Load canonical protos (Minotaur, Satyr, Sprite, Ares, etc.)
+- [ ] 7.2 Compare against MegaMekLab proto BV values
+- [ ] 7.3 Emit `validation-output/protomech-bv-validation-report.json`
+
+## 8. Status Bar
+
+- [ ] 8.1 `ProtoMechStatusBar` (new or existing) shows BV and point-aggregate BV
+
+## 9. Validation
+
+- [ ] 9.1 `openspec validate add-protomech-battle-value --strict`
+- [ ] 9.2 Unit tests on 5 canonical protos
+- [ ] 9.3 Build + lint clean

--- a/openspec/changes/add-protomech-combat-behavior/proposal.md
+++ b/openspec/changes/add-protomech-combat-behavior/proposal.md
@@ -1,0 +1,36 @@
+# Change: Add ProtoMech Combat Behavior
+
+## Why
+
+ProtoMechs fight as 5-unit Clan Points but damage per-proto like tiny mechs: each has per-location armor / structure, takes locational damage, and applies physical attacks. However, their hit table is shorter (6 locations vs 11), they share a point-level squad interface for coordinated fire, and they have no pilot-damage / consciousness rule. The Phase 1 combat engine does not know about any of this. This change adds proto combat behavior, deliberately thinner than the other four unit-type combat changes (niche Clan-only asset).
+
+## What Changes
+
+- Add proto combat state: per-location armor/structure (Head, Torso, MainGun, LeftArm, RightArm, Legs), pilot wound track (proto-specific), destroyed flag
+- Add proto hit location tables: Front / Side / Rear → 2d6 → location outcome (shorter 6-entry table)
+- Add proto damage pipeline: armor → structure → location destroyed; no adjacent transfer (excess discarded if leg destroyed; MainGun destruction removes main gun weapon)
+- Add proto critical hits: simpler table — 2-7 no crit, 8-9 equipment (random), 10-11 engine, 12 pilot killed
+- Add proto physical attacks: kick (damage = tonnage / 2), punch (damage = tonnage / 5), main gun melee unavailable
+- Add point interface: 5-proto point fires as coordinated squad (optional — individual combat remains the default)
+- Add Glider rules: Glider flies like low-altitude unit, takes +1 TMM but takes fall damage on any structure hit
+- Emit events: `ProtoLocationDestroyed`, `ProtoPointAttack`, `GliderFall`
+
+## Non-goals
+
+- Full point-as-single-unit combat (simplifies to 5 independent protos for Phase 6)
+- ProtoMech infantry-style damage divisor (protos are full-scale targets)
+
+## Dependencies
+
+- **Requires**: `add-protomech-construction`, `add-protomech-battle-value`, `integrate-damage-pipeline`, `wire-heat-generation-and-effects`
+- **Blocks**: full combined-arms play
+
+## Ordering in Phase 6
+
+ProtoMech combat is the last of 15 Phase 6 changes.
+
+## Impact
+
+- **Affected specs**: `combat-resolution` (MODIFIED — proto path), `damage-system` (MODIFIED — proto transfer rule), `critical-hit-system` (MODIFIED — proto crit table), `hit-location-tables` (ADDED — proto front/side/rear), `protomech-unit-system` (ADDED — combat state)
+- **Affected code**: `src/utils/gameplay/protoMechDamage.ts` (new), `src/utils/gameplay/protoMechHitLocation.ts` (new), `src/utils/gameplay/protoMechCriticalHitResolution.ts` (new), `src/engine/GameEngine.ts` (dispatch)
+- **New events**: `ProtoLocationDestroyed`, `ProtoPointAttack`, `GliderFall`, `ProtoPilotKilled`

--- a/openspec/changes/add-protomech-combat-behavior/specs/combat-resolution/spec.md
+++ b/openspec/changes/add-protomech-combat-behavior/specs/combat-resolution/spec.md
@@ -1,0 +1,104 @@
+# combat-resolution (delta)
+
+## ADDED Requirements
+
+### Requirement: ProtoMech Combat Dispatch
+
+The combat resolution engine SHALL route ProtoMech targets to a proto-specific damage pipeline.
+
+#### Scenario: Proto target routing
+
+- **GIVEN** an attack whose target has `unitType === UnitType.PROTOMECH`
+- **WHEN** the engine resolves the hit
+- **THEN** `protoMechResolveDamage()` SHALL be invoked
+- **AND** proto-specific hit-location and crit tables SHALL be used
+
+### Requirement: ProtoMech Damage Chain
+
+The proto damage chain SHALL apply armor-then-structure per location with no cross-location transfer.
+
+#### Scenario: Damage contained to location
+
+- **GIVEN** a proto where the LeftArm has 3 armor and 3 structure
+- **WHEN** 15 damage hits the LeftArm
+- **THEN** armor and structure SHALL both be reduced to 0
+- **AND** the LeftArm SHALL be destroyed
+- **AND** the 9 excess damage SHALL be discarded (not transferred to Torso)
+
+#### Scenario: Torso destruction destroys proto
+
+- **GIVEN** a proto whose Torso armor and structure drop to 0
+- **WHEN** the destruction event fires
+- **THEN** the proto SHALL be flagged destroyed
+- **AND** a `UnitDestroyed` event SHALL fire
+
+#### Scenario: Main gun destruction
+
+- **GIVEN** a proto whose MainGun location is destroyed
+- **WHEN** the destruction event fires
+- **THEN** the main gun weapon SHALL be removed
+- **AND** a `ProtoLocationDestroyed` event SHALL specify MainGun
+- **AND** the proto SHALL continue operating (not destroyed)
+
+### Requirement: ProtoMech Critical Hit Table
+
+The system SHALL use a proto-specific crit table simpler than the mech table.
+
+#### Scenario: Proto crit outcomes
+
+- **WHEN** a proto critical hit is rolled (2d6)
+- **THEN** outcomes SHALL map:
+  - 2-7 = no critical
+  - 8-9 = random equipment destroyed at the hit location
+  - 10-11 = engine hit (1st = -1 MP, 2nd = engine destroyed → proto destroyed)
+  - 12 = pilot killed (proto abandoned, counts as destroyed)
+
+#### Scenario: Pilot killed ends participation
+
+- **GIVEN** a proto whose 12 crit fires
+- **WHEN** the event is applied
+- **THEN** a `ProtoPilotKilled` event SHALL fire
+- **AND** the proto SHALL be removed from active play
+
+### Requirement: Glider ProtoMech Fall Rule
+
+Glider protos SHALL make a fall roll on any structure-exposing damage while airborne.
+
+#### Scenario: Fall roll triggered
+
+- **GIVEN** an airborne Glider proto that takes damage exposing structure
+- **WHEN** the damage resolves
+- **THEN** a piloting roll vs TN 7 SHALL be made
+- **AND** on failure a `GliderFall` event SHALL fire
+- **AND** the proto SHALL take `10 × altitude` fall damage
+- **AND** altitude SHALL reset to 0
+
+## MODIFIED Requirements
+
+### Requirement: Damage Distribution
+
+The system SHALL distribute damage across units based on battle intensity and outcome.
+
+#### Scenario: Victory results in light damage
+
+- **GIVEN** a battle with outcome VICTORY and 4 player units
+- **WHEN** distributeDamage is called
+- **THEN** units receive 0-30% damage on average
+
+#### Scenario: Defeat results in heavy damage
+
+- **GIVEN** a battle with outcome DEFEAT and 4 player units
+- **WHEN** distributeDamage is called
+- **THEN** units receive 40-80% damage on average
+
+#### Scenario: Draw results in moderate damage
+
+- **GIVEN** a battle with outcome DRAW and 4 player units
+- **WHEN** distributeDamage is called
+- **THEN** units receive 20-50% damage on average
+
+#### Scenario: Abandoned proto counts as destroyed
+
+- **GIVEN** a battle where a proto was abandoned due to pilot kill
+- **WHEN** distributeDamage is called
+- **THEN** the proto SHALL be counted as destroyed for victory/salvage purposes

--- a/openspec/changes/add-protomech-combat-behavior/specs/protomech-unit-system/spec.md
+++ b/openspec/changes/add-protomech-combat-behavior/specs/protomech-unit-system/spec.md
@@ -1,0 +1,40 @@
+# protomech-unit-system (delta)
+
+## ADDED Requirements
+
+### Requirement: ProtoMech Combat State
+
+Each ProtoMech SHALL carry combat state covering per-location armor / structure and pilot status.
+
+#### Scenario: Combat state initialization
+
+- **GIVEN** a Medium Biped ProtoMech entering combat
+- **WHEN** combat state is initialized
+- **THEN** `unit.combatState.proto.armorByLocation` SHALL contain entries for Head, Torso, LeftArm, RightArm, Legs, and MainGun (if present)
+- **AND** `unit.combatState.proto.structureByLocation` SHALL mirror the armor keys
+- **AND** `unit.combatState.proto.pilotWounded` SHALL be `false`
+- **AND** `unit.combatState.proto.destroyed` SHALL be `false`
+
+#### Scenario: Quad proto legs layout
+
+- **GIVEN** a Quad ProtoMech
+- **WHEN** combat state is initialized
+- **THEN** the leg entries SHALL be `FrontLegs` and `RearLegs` instead of `Legs`
+- **AND** no Arm entries SHALL be present
+
+### Requirement: ProtoMech Heat Rules
+
+The system SHALL apply simplified proto heat rules separate from the mech heat table.
+
+#### Scenario: Proto shutdown threshold
+
+- **GIVEN** a proto whose heat reaches 4
+- **WHEN** heat effects are computed
+- **THEN** a shutdown check SHALL be triggered (lower threshold than mechs)
+
+#### Scenario: Proto heat sink baseline
+
+- **GIVEN** any proto
+- **WHEN** heat-sink count is read
+- **THEN** the base SHALL be 2 (engine-integrated)
+- **AND** extra heat sinks SHALL be the only configurable additions

--- a/openspec/changes/add-protomech-combat-behavior/tasks.md
+++ b/openspec/changes/add-protomech-combat-behavior/tasks.md
@@ -1,0 +1,80 @@
+# Tasks: Add ProtoMech Combat Behavior
+
+## 1. Unit-Type Dispatch
+
+- [ ] 1.1 Route `resolveDamage()` to `protoMechResolveDamage()` when target is `IProtoMechUnit`
+- [ ] 1.2 Route `resolveCriticalHits()` to proto-specific crit resolver
+- [ ] 1.3 Route `hitLocation.ts` to proto tables
+
+## 2. Proto Combat State
+
+- [ ] 2.1 `unit.combatState.proto.armorByLocation`, `structureByLocation`
+- [ ] 2.2 Locations: Head, Torso, MainGun (if present), LeftArm, RightArm, Legs (or FrontLegs/RearLegs for Quad)
+- [ ] 2.3 `pilotWounded` flag (proto pilot takes damage from head crits)
+- [ ] 2.4 `destroyed` flag
+
+## 3. Proto Hit Location Tables
+
+- [ ] 3.1 Front attack (2d6): 2=Torso(TAC), 3-4=RightArm, 5-7=Torso, 8-9=LeftArm, 10=Legs, 11=MainGun, 12=Head
+- [ ] 3.2 Side attack: 2=Side(TAC), 3-5=Legs, 6-8=Near Arm/Torso, 9-10=Torso, 11=MainGun, 12=Head
+- [ ] 3.3 Rear attack: 2=Torso(TAC), 3-5=Legs, 6-8=Torso, 9-10=Arms, 11=MainGun, 12=Head
+- [ ] 3.4 Glider bonus: +1 to attacker's to-hit (flying target)
+
+## 4. Proto Damage Chain
+
+- [ ] 4.1 Apply damage to hit-location armor first
+- [ ] 4.2 Excess reduces structure at same location
+- [ ] 4.3 No location-to-location transfer (proto structure damage stays local)
+- [ ] 4.4 Head / Torso destruction = proto destroyed
+- [ ] 4.5 MainGun destruction = main gun weapon removed
+- [ ] 4.6 Legs destruction = immobilized (still fires from other locations)
+- [ ] 4.7 Emit `ProtoLocationDestroyed` events
+
+## 5. Proto Critical Hits
+
+- [ ] 5.1 Trigger on TAC (roll 2) or structure-exposing damage
+- [ ] 5.2 Table: 2-7 no crit, 8-9 random equipment destroyed, 10-11 engine hit, 12 pilot killed
+- [ ] 5.3 Engine hit: 1 = -1 MP, 2 = destroyed
+- [ ] 5.4 Pilot killed: proto abandoned (counts as destroyed for victory)
+- [ ] 5.5 Emit `ProtoPilotKilled` or `ComponentDestroyed`
+
+## 6. Proto Physical Attacks
+
+- [ ] 6.1 Kick: damage = floor(tonnage / 2) — max 4 damage for 9-ton proto
+- [ ] 6.2 Punch: damage = floor(tonnage / 5) — max 3 damage for 15-ton ultraheavy
+- [ ] 6.3 No main-gun melee (main gun is fixed fire only)
+- [ ] 6.4 Quad protos cannot punch (no arms)
+
+## 7. Point-Level Fire (Optional)
+
+- [ ] 7.1 If 5-proto point is coordinated, declare a single attack pool covering all 5 protos
+- [ ] 7.2 Cluster-hits-style distribution across point members
+- [ ] 7.3 Emit `ProtoPointAttack` for audit
+- [ ] 7.4 Point fire is opt-in per scenario flag (off by default for MVP — individual protos fight on their own)
+
+## 8. Glider Proto Rules
+
+- [ ] 8.1 Glider treated as low-altitude flying unit (not full aerospace)
+- [ ] 8.2 Attacker +1 to-hit (flight TMM bonus)
+- [ ] 8.3 Any structure-exposing damage → GliderFall roll (piloting vs TN 7)
+- [ ] 8.4 Failed roll → fall; proto takes 10 × altitude damage, altitude reset to 0
+- [ ] 8.5 Emit `GliderFall` event
+
+## 9. Heat System for Protos
+
+- [ ] 9.1 Proto has 2 base heat sinks (built into engine)
+- [ ] 9.2 Heat levels: 4+ shutdown risk (lower than mech threshold due to proto fragility)
+- [ ] 9.3 Heat follows simplified proto table
+
+## 10. AI Adaptations
+
+- [ ] 10.1 Bot uses protos as fast flankers
+- [ ] 10.2 Bot keeps protos at medium range (avoid mech punch counterattack)
+- [ ] 10.3 Bot retreats protos below 50% armor
+
+## 11. Validation
+
+- [ ] 11.1 `openspec validate add-protomech-combat-behavior --strict`
+- [ ] 11.2 Unit tests: hit location per direction, damage chain, crit table, glider fall
+- [ ] 11.3 Simulation: point of 5 protos vs 1 mech
+- [ ] 11.4 Build + lint clean

--- a/openspec/changes/add-protomech-construction/proposal.md
+++ b/openspec/changes/add-protomech-construction/proposal.md
@@ -1,0 +1,39 @@
+# Change: Add ProtoMech Construction
+
+## Why
+
+ProtoMechs are Clan-only, rare, and the last priority in Phase 6, but they're canonical units that must build and cost correctly for Clan-era campaigns. The existing `protomech-unit-system` spec covers weight classes and main-gun slots but leaves construction enforcement thin. This change completes ProtoMech construction so Phase 6 BV and combat can operate on legal input. Scope is deliberately narrower than the other four unit types (~18 tasks) because ProtoMechs have fewer configuration axes.
+
+## What Changes
+
+- Add tonnage selection 2–15 tons (Ultraheavy 10–15, Standard 2–9) with weight class bucketing
+- Add chassis type: Biped / Quad / Glider / Ultraheavy
+- Add movement: walk / run / jump with MP caps by weight (Light max 8, Medium max 6, Heavy max 4, Ultraheavy max 3)
+- Add structure / armor per location (Head, Torso, MainGun, LeftArm, RightArm, Legs); Quad uses FrontLegs / RearLegs
+- Add per-location armor max from tonnage
+- Add main gun system: single heavy weapon in dedicated MainGun location; otherwise no large weapons
+- Add myomer booster (optional, +1 MP), glider wings (Glider chassis only)
+- Add engine — fusion only — with weight = rating × factor
+- Add construction validation rule set `VAL-PROTO-*` covering tonnage range, chassis compatibility, MP cap, main gun rules, tech-base lock (Clan only)
+- Wire into protomech store and customizer tabs
+
+## Non-goals
+
+- ProtoMech combat (point composition, damage) — `add-protomech-combat-behavior`
+- BV calculation — `add-protomech-battle-value`
+- Inner Sphere ProtoMechs (IS ProtoMechs do not exist in canon)
+
+## Dependencies
+
+- **Requires**: existing `protomech-unit-system` spec stubs, `construction-services`, `equipment-database`
+- **Blocks**: `add-protomech-battle-value`, `add-protomech-combat-behavior`
+
+## Ordering in Phase 6
+
+ProtoMech is fifth and last (niche, Clan-only, rare in campaigns).
+
+## Impact
+
+- **Affected specs**: `protomech-unit-system` (ADDED — tonnage / chassis / movement / main gun / validation)
+- **Affected code**: `src/stores/protomech/`, `src/utils/construction/protomech/`, `src/components/customizer/protomech/*`
+- **New files**: proto weight class table, chassis table, MP cap table, main gun approved weapon list

--- a/openspec/changes/add-protomech-construction/specs/protomech-unit-system/spec.md
+++ b/openspec/changes/add-protomech-construction/specs/protomech-unit-system/spec.md
@@ -1,0 +1,96 @@
+# protomech-unit-system (delta)
+
+## ADDED Requirements
+
+### Requirement: ProtoMech Chassis Types
+
+The system SHALL support four ProtoMech chassis types with per-chassis rules.
+
+#### Scenario: Biped default
+
+- **GIVEN** a new ProtoMech
+- **WHEN** chassis is initialized
+- **THEN** `chassisType` SHALL default to `Biped`
+
+#### Scenario: Glider Light-only
+
+- **GIVEN** a ProtoMech with tonnage 5
+- **WHEN** chassis is set to `Glider`
+- **THEN** `VAL-PROTO-CHASSIS` SHALL emit an error — Glider requires Light class (2-4 tons)
+
+#### Scenario: Ultraheavy class
+
+- **GIVEN** a ProtoMech with tonnage 12
+- **WHEN** chassis is set to `Ultraheavy`
+- **THEN** validation SHALL pass
+- **AND** jump MP SHALL be forced to 0
+
+### Requirement: ProtoMech Movement Caps
+
+The system SHALL enforce per-weight-class MP caps.
+
+#### Scenario: Medium walk cap
+
+- **GIVEN** a 6-ton (Medium) ProtoMech
+- **WHEN** walkMP is requested above 6
+- **THEN** `VAL-PROTO-MP` SHALL emit an error
+
+#### Scenario: Ultraheavy no jump
+
+- **GIVEN** an Ultraheavy 12-ton ProtoMech
+- **WHEN** jumpMP is requested as 1
+- **THEN** `VAL-PROTO-MP` SHALL emit "Ultraheavy cannot jump"
+
+#### Scenario: Myomer booster bonus
+
+- **GIVEN** a Medium-class ProtoMech with walkMP 5 and Myomer Booster
+- **WHEN** effective MP is computed
+- **THEN** walkMP SHALL be 6 (base 5 + 1 from booster)
+
+### Requirement: Main Gun System
+
+The system SHALL optionally configure a MainGun location with a single heavy weapon from an approved list.
+
+#### Scenario: Legal main gun
+
+- **GIVEN** a Medium ProtoMech with MainGun
+- **WHEN** a PPC is installed in MainGun
+- **THEN** installation SHALL succeed
+- **AND** MainGun location SHALL hold exactly one weapon
+
+#### Scenario: Illegal main gun weapon
+
+- **GIVEN** a Medium ProtoMech with MainGun
+- **WHEN** a Binary Laser Cannon is attempted in MainGun
+- **THEN** `VAL-PROTO-MAIN-GUN` SHALL emit "weapon not in approved main-gun list"
+
+#### Scenario: Heavy arm weapon requires main gun
+
+- **GIVEN** a Biped ProtoMech
+- **WHEN** a PPC is attempted in a LeftArm mount
+- **THEN** mounting SHALL fail — heavy weapons must be in MainGun
+
+### Requirement: Clan Tech Base Lock
+
+The system SHALL warn (not error) when tech base is not Clan.
+
+#### Scenario: Non-Clan tech base warning
+
+- **GIVEN** a ProtoMech with tech base Inner Sphere
+- **WHEN** validation runs
+- **THEN** `VAL-PROTO-TECH-BASE` SHALL emit a warning "ProtoMechs are Clan-only technology"
+
+#### Scenario: Clan tech base passes
+
+- **GIVEN** a ProtoMech with tech base Clan
+- **WHEN** validation runs
+- **THEN** no `VAL-PROTO-TECH-BASE` error or warning SHALL be emitted
+
+### Requirement: ProtoMech Construction Validation Rule Set
+
+The validation registry SHALL include the `VAL-PROTO-*` rule group.
+
+#### Scenario: Rule ids registered
+
+- **WHEN** the validation registry initializes
+- **THEN** `VAL-PROTO-TONNAGE`, `VAL-PROTO-CHASSIS`, `VAL-PROTO-MP`, `VAL-PROTO-MAIN-GUN`, and `VAL-PROTO-TECH-BASE` SHALL be registered

--- a/openspec/changes/add-protomech-construction/tasks.md
+++ b/openspec/changes/add-protomech-construction/tasks.md
@@ -1,0 +1,75 @@
+# Tasks: Add ProtoMech Construction
+
+## 1. Types and Interfaces
+
+- [ ] 1.1 Extend `IProtoMechUnit` with `chassisType`, `mainGunWeaponId?`, `glidingWings`, `myomerBooster`, `walkMP`, `jumpMP`
+- [ ] 1.2 Add `ProtoChassis` enum (Biped, Quad, Glider, Ultraheavy)
+- [ ] 1.3 Add `ProtoLocation` enum (Head, Torso, MainGun, LeftArm, RightArm, Legs, FrontLegs, RearLegs)
+- [ ] 1.4 Add `IProtoArmorByLocation` interface
+
+## 2. Tonnage Rules
+
+- [ ] 2.1 Standard ProtoMech: 2–9 tons
+- [ ] 2.2 Ultraheavy ProtoMech: 10–15 tons (Ultraheavy chassis only)
+- [ ] 2.3 Weight class: Light 2-4, Medium 5-7, Heavy 8-9, Ultraheavy 10-15
+- [ ] 2.4 Validation: reject Ultraheavy chassis + tonnage < 10
+
+## 3. Chassis Rules
+
+- [ ] 3.1 Biped: default; supports arm weapons
+- [ ] 3.2 Quad: no arms; all equipment on Torso or Legs
+- [ ] 3.3 Glider: Light only; adds Glider Wings (+2 jump MP); cannot have arms
+- [ ] 3.4 Ultraheavy: 10+ tons; no jump MP; increased armor
+
+## 4. Movement Caps
+
+- [ ] 4.1 Light: walk MP 8, jump MP 8
+- [ ] 4.2 Medium: walk MP 6, jump MP 6
+- [ ] 4.3 Heavy: walk MP 4, jump MP 4
+- [ ] 4.4 Ultraheavy: walk MP 3, jump 0
+- [ ] 4.5 Run MP = walkMP + 1 (Myomer Booster adds +1 walk, +1 run)
+
+## 5. Armor per Location
+
+- [ ] 5.1 Per-location armor max from tonnage table
+- [ ] 5.2 Total armor tonnage counted separately from equipment
+- [ ] 5.3 Armor type always Standard (ProtoMech ferro-fibrous variants not supported)
+
+## 6. Main Gun System
+
+- [ ] 6.1 Optional MainGun location holds one heavy weapon (approved list: LRM-5/10, AC/2, AC/5, Gauss Rifle, PPC, Medium Pulse Laser, ER Medium Laser)
+- [ ] 6.2 When no main gun, the location is not present on the record
+- [ ] 6.3 Main gun ammo stored in Torso
+- [ ] 6.4 Weapons larger than Medium-class cannot go in arms — must be main gun
+
+## 7. Engine
+
+- [ ] 7.1 Fusion only (Clan fusion)
+- [ ] 7.2 Engine rating = tonnage × walkMP
+- [ ] 7.3 Engine weight = engineRating × 0.025 (proto-specific factor)
+
+## 8. Myomer Booster and Glider Wings
+
+- [ ] 8.1 Myomer Booster: Light / Medium only, adds +1 MP, costs 1 ton
+- [ ] 8.2 Glider Wings: Glider chassis only; already factored into MP
+- [ ] 8.3 Reject illegal combos
+
+## 9. Construction Validation Rules
+
+- [ ] 9.1 `VAL-PROTO-TONNAGE` — in legal range
+- [ ] 9.2 `VAL-PROTO-CHASSIS` — chassis × tonnage × MP compatibility
+- [ ] 9.3 `VAL-PROTO-MP` — MP ≤ weight class cap
+- [ ] 9.4 `VAL-PROTO-MAIN-GUN` — main gun weapon in approved list
+- [ ] 9.5 `VAL-PROTO-TECH-BASE` — tech base = Clan (warning otherwise)
+
+## 10. Store and UI Wiring
+
+- [ ] 10.1 Wire `protoMechStore` to persist new state
+- [ ] 10.2 Enhance `ProtoMechStructureTab` to expose all fields
+- [ ] 10.3 Status bar displays tonnage, class, MP, main gun
+
+## 11. Validation
+
+- [ ] 11.1 `openspec validate add-protomech-construction --strict`
+- [ ] 11.2 Fixtures: Minotaur (Heavy), Sprite (Light), Satyr (Medium), Nuthatch (Glider), Ares (Ultraheavy)
+- [ ] 11.3 Build + lint clean

--- a/openspec/changes/add-quick-resolve-monte-carlo/proposal.md
+++ b/openspec/changes/add-quick-resolve-monte-carlo/proposal.md
@@ -1,0 +1,65 @@
+# Change: Add Quick Resolve Monte Carlo
+
+## Why
+
+Phase 1 delivers a playable tactical skirmish, but a single match is a
+sample size of 1. Players making campaign decisions, weighing force
+composition, or sizing up a scenario need to know "how often do I win
+this?" without sitting through 30 minutes of manual play. Phase 2's core
+promise is "run 100 auto-resolves and see the outcome distribution."
+This change wires a Quick Resolve batch runner on top of the existing
+`GameEngine.runToCompletion()` so any configured encounter can be fed to
+the engine N times with distinct seeds, aggregated, and reported as a
+distribution — win probability per side, turn-count percentiles,
+casualty distribution, heat-shutdown frequency, and mech-destroyed
+frequency.
+
+## What Changes
+
+- Add `QuickResolveService.runBatch(config, { runs, baseSeed })` that
+  executes `GameEngine.runToCompletion()` N times (default 100), varies
+  the seed deterministically (`baseSeed + runIndex`), and collects each
+  completed session into an `IBatchOutcome[]`
+- Add `aggregateBatchOutcomes(outcomes): IBatchResult` that reduces the
+  raw outcomes into win probabilities (player/opponent/draw), turn-count
+  mean/median/p25/p75/p90, heat-shutdown frequency per side,
+  mech-destroyed frequency per side, and per-unit survival rate
+- Extend the existing `after-combat-report` schema with a batch-level
+  summary shape (`IBatchResult`) that wraps the Phase 1
+  `IPostBattleReport` samples
+- Reuse the existing `SeededRandom` + injectable `DiceRoller` —
+  Monte Carlo must NOT introduce a second source of randomness
+- Add a React Query hook `useQuickResolve()` that wraps the batch runner
+  and exposes progress (`runsCompleted / totalRuns`) plus the aggregated
+  result once done
+- Add a "Quick Resolve" button on the encounter detail page; the button
+  opens a small run-size selector (25 / 100 / 500) and dispatches the
+  hook
+
+## Dependencies
+
+- **Requires**: Phase 1 A1–A5 (rule accuracy — otherwise aggregated
+  outcomes are garbage), `simulation-system` (existing `runToCompletion`),
+  `combat-resolution` (existing `CombatResolver`), `game-session-management`
+  (session lifecycle), `after-combat-report` (per-session report shape),
+  `add-victory-and-post-battle-summary` (defines `IPostBattleReport` that
+  batch aggregation consumes)
+- **Required By**: `add-quick-sim-result-display` (renders the
+  `IBatchResult` shape produced here)
+
+## Impact
+
+- Affected specs: `simulation-system` (ADDED — batch runner +
+  deterministic seed variation), `combat-resolution` (MODIFIED —
+  exposes batch aggregation helper), `after-combat-report` (MODIFIED —
+  adds `IBatchResult` schema wrapping N `IPostBattleReport` samples)
+- Affected code: new `src/simulation/QuickResolveService.ts`, new
+  `src/simulation/aggregateBatchOutcomes.ts`, new
+  `src/hooks/useQuickResolve.ts`, `src/pages/gameplay/encounters/[id]/index.tsx`
+  (adds button), existing `src/engine/GameEngine.ts` remains untouched
+  (read-only consumer)
+- Non-goals: surfacing the result UI (that is
+  `add-quick-sim-result-display`), persisting batch runs to disk (Phase
+  3 campaign integration), streaming partial results (future), running
+  batches concurrently via workers (future — MVP is sequential main
+  thread with yielding)

--- a/openspec/changes/add-quick-resolve-monte-carlo/specs/after-combat-report/spec.md
+++ b/openspec/changes/add-quick-resolve-monte-carlo/specs/after-combat-report/spec.md
@@ -1,0 +1,107 @@
+# after-combat-report Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Batch Result Schema
+
+The after-combat-report system SHALL define an `IBatchResult` schema
+that aggregates N `IPostBattleReport` samples produced by the Quick
+Resolve Monte Carlo runner, plus an `IBatchOutcome` per-run entry that
+retains per-run metadata alongside its report.
+
+#### Scenario: IBatchResult contains required top-level fields
+
+- **GIVEN** a completed Quick Resolve batch with 100 runs
+- **WHEN** `aggregateBatchOutcomes` derives the result
+- **THEN** the `IBatchResult` SHALL contain `{totalRuns, erroredRuns,
+baseSeed, winProbability, turnCount, heatShutdownFrequency,
+mechDestroyedFrequency, perUnitSurvival, mostLikelyOutcome}`
+- **AND** `winProbability` SHALL be shaped `{player: number, opponent:
+number, draw: number}` with values in `[0, 1]`
+- **AND** `turnCount` SHALL be shaped `{mean, median, p25, p75, p90,
+min, max}` (all numbers)
+
+#### Scenario: IBatchOutcome wraps one report
+
+- **GIVEN** one run inside a batch
+- **WHEN** the run completes
+- **THEN** the corresponding `IBatchOutcome` SHALL contain `{runIndex,
+seed, report: IPostBattleReport, durationMs}`
+- **AND** `runIndex` SHALL be the 0-based ordinal
+- **AND** `seed` SHALL equal `baseSeed + runIndex`
+
+#### Scenario: IBatchOutcome marks errored runs
+
+- **GIVEN** a run that throws during resolution
+- **WHEN** the batch runner captures the error
+- **THEN** the `IBatchOutcome` SHALL contain `{runIndex, seed, error:
+string, durationMs}` and SHALL NOT contain a `report` field
+- **AND** aggregation SHALL skip error entries when computing
+  probabilities
+
+### Requirement: Heat Shutdown Frequency
+
+The batch result SHALL expose `heatShutdownFrequency: {player: number,
+opponent: number}` expressing the fraction of successful runs in which
+any unit on that side shut down due to heat at least once during the
+match.
+
+#### Scenario: Frequency derived from per-unit heat problems
+
+- **GIVEN** a batch of 100 runs where 18 matches had at least one
+  Player heat shutdown
+- **WHEN** the batch aggregates
+- **THEN** `heatShutdownFrequency.player` SHALL equal 0.18
+
+#### Scenario: Multiple shutdowns in one match count once
+
+- **GIVEN** a single match where three Player units each shut down once
+- **WHEN** aggregation runs
+- **THEN** that match SHALL increment the shutdown counter by 1 (not 3)
+
+### Requirement: Mech Destroyed Frequency
+
+The batch result SHALL expose `mechDestroyedFrequency: {player: number,
+opponent: number}` expressing the fraction of successful runs in which
+at least one unit on that side was destroyed.
+
+#### Scenario: Any-unit-destroyed counts as 1
+
+- **GIVEN** 50 runs where exactly one Player mech was destroyed and 20
+  runs where two Player mechs were destroyed
+- **WHEN** aggregation runs across a 100-run batch
+- **THEN** `mechDestroyedFrequency.player` SHALL equal 0.70
+- **AND** the counter SHALL NOT double-count matches with multiple
+  destroyed units
+
+### Requirement: Per-Unit Survival Rate
+
+The batch result SHALL expose `perUnitSurvival: Record<string, number>`
+mapping each unit id in the original encounter to the fraction of
+successful runs in which that unit ended the match not destroyed.
+
+#### Scenario: Survival rate by unit id
+
+- **GIVEN** unit `"p1-atlas"` was not destroyed in 72 of 100 successful
+  runs
+- **WHEN** aggregation runs
+- **THEN** `perUnitSurvival["p1-atlas"]` SHALL equal 0.72
+
+#### Scenario: Destroyed unit always has zero survival
+
+- **GIVEN** unit `"op1-locust"` was destroyed in all 100 runs
+- **WHEN** aggregation runs
+- **THEN** `perUnitSurvival["op1-locust"]` SHALL equal 0.0
+
+### Requirement: Base Seed Reporting
+
+The batch result SHALL include `baseSeed: number` so the caller can
+reproduce the entire batch by re-invoking `runBatch` with the same seed
+and run count.
+
+#### Scenario: baseSeed round-trips
+
+- **GIVEN** a batch completed with `baseSeed = 9183`
+- **WHEN** `runBatch(config, { runs: 100, baseSeed: 9183 })` is invoked
+  a second time
+- **THEN** the second `IBatchResult` SHALL deep-equal the first

--- a/openspec/changes/add-quick-resolve-monte-carlo/specs/combat-resolution/spec.md
+++ b/openspec/changes/add-quick-resolve-monte-carlo/specs/combat-resolution/spec.md
@@ -1,0 +1,84 @@
+# combat-resolution Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Batch Outcome Aggregation
+
+The combat-resolution system SHALL expose
+`aggregateBatchOutcomes(outcomes: IBatchOutcome[]): IBatchResult` that
+reduces raw per-run outcomes into a single statistical summary used by
+the Quick Resolve UI.
+
+#### Scenario: Win probability computed from winner counts
+
+- **GIVEN** 100 outcomes with winner distribution
+  `{player: 62, opponent: 30, draw: 8}`
+- **WHEN** `aggregateBatchOutcomes(outcomes)` is called
+- **THEN** the returned `winProbability` SHALL be
+  `{player: 0.62, opponent: 0.30, draw: 0.08}`
+- **AND** the three probabilities SHALL sum to 1.0 (within floating
+  point tolerance)
+
+#### Scenario: Error outcomes excluded from probability denominator
+
+- **GIVEN** 100 outcomes where 10 errored and the remaining 90 resolved
+  to `{player: 45, opponent: 36, draw: 9}`
+- **WHEN** `aggregateBatchOutcomes(outcomes)` is called
+- **THEN** `winProbability` SHALL be computed over the 90 successful
+  runs (`player: 0.5, opponent: 0.4, draw: 0.1`)
+- **AND** `IBatchResult.erroredRuns` SHALL equal 10
+
+#### Scenario: Turn-count percentiles
+
+- **GIVEN** 100 outcomes with the turn counts distributed across
+  `[6..24]`
+- **WHEN** aggregation runs
+- **THEN** `turnCount.median` SHALL equal the 50th-percentile value
+- **AND** `turnCount.p25`, `turnCount.p75`, `turnCount.p90` SHALL equal
+  the respective percentile values
+- **AND** `turnCount.min` and `turnCount.max` SHALL bracket the range
+
+#### Scenario: Heat shutdown frequency
+
+- **GIVEN** 100 outcomes where Player units shut down in 18 matches and
+  Opponent units shut down in 9 matches
+- **WHEN** aggregation runs
+- **THEN** `heatShutdownFrequency` SHALL equal
+  `{player: 0.18, opponent: 0.09}`
+
+#### Scenario: Per-unit survival rate
+
+- **GIVEN** 100 outcomes where unit id `"p1-locust"` survived 81 matches
+- **WHEN** aggregation runs
+- **THEN** `perUnitSurvival["p1-locust"]` SHALL equal 0.81
+
+#### Scenario: Most likely outcome
+
+- **GIVEN** win probabilities `{player: 0.62, opponent: 0.30, draw:
+0.08}`
+- **WHEN** aggregation runs
+- **THEN** `mostLikelyOutcome` SHALL equal `"player"`
+
+#### Scenario: Draw when no clear winner
+
+- **GIVEN** win probabilities `{player: 0.49, opponent: 0.49, draw:
+0.02}`
+- **WHEN** aggregation runs
+- **THEN** `mostLikelyOutcome` SHALL equal `"draw"`
+- **AND** ties between player and opponent SHALL resolve to `"draw"`
+  regardless of the actual draw probability
+
+### Requirement: Empty Batch Handling
+
+`aggregateBatchOutcomes` SHALL return a well-formed empty `IBatchResult`
+when called with zero outcomes so the UI can render a "no data" state
+without a runtime error.
+
+#### Scenario: Empty input returns zeros
+
+- **GIVEN** an empty `outcomes` array
+- **WHEN** `aggregateBatchOutcomes([])` is called
+- **THEN** the result SHALL equal `{totalRuns: 0, winProbability:
+{player: 0, opponent: 0, draw: 0}, turnCount: {mean: 0, median: 0,
+...}, mostLikelyOutcome: "draw", perUnitSurvival: {}}`
+- **AND** no division-by-zero exception SHALL be thrown

--- a/openspec/changes/add-quick-resolve-monte-carlo/specs/simulation-system/spec.md
+++ b/openspec/changes/add-quick-resolve-monte-carlo/specs/simulation-system/spec.md
@@ -1,0 +1,155 @@
+# simulation-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Batch Monte Carlo Runner
+
+The simulation system SHALL expose a `QuickResolveService.runBatch(config,
+options)` that executes `GameEngine.runToCompletion()` N times with
+deterministic seed variation and collects the per-run outcomes into an
+`IBatchOutcome[]`.
+
+#### Scenario: Batch runs the requested number of sessions
+
+- **GIVEN** a valid `IGameConfig` and `options = { runs: 100, baseSeed:
+42 }`
+- **WHEN** `QuickResolveService.runBatch(config, options)` is invoked
+- **THEN** `GameEngine.runToCompletion` SHALL be called 100 times
+- **AND** the returned `IBatchOutcome[]` SHALL contain 100 entries
+  (including entries for runs that errored)
+
+#### Scenario: Seed variation produces distinct outcomes
+
+- **GIVEN** `options = { runs: 5, baseSeed: 42 }`
+- **WHEN** the batch runs
+- **THEN** run `i` SHALL use `seed = baseSeed + i` (so runs use seeds
+  42, 43, 44, 45, 46)
+- **AND** each run SHALL have its own fresh `DiceRoller` instance
+- **AND** no two runs SHALL share `SeededRandom` state
+
+#### Scenario: Batch reproducibility
+
+- **GIVEN** identical `config` and `options = { runs: 10, baseSeed: 42
+}` across two invocations
+- **WHEN** both batches complete
+- **THEN** the two resulting `IBatchResult` objects SHALL be deeply
+  equal
+- **AND** each `IBatchOutcome.report` SHALL match position-for-position
+
+#### Scenario: Default run count applied
+
+- **GIVEN** `options.runs` is omitted
+- **WHEN** `runBatch` is invoked
+- **THEN** the default `runs = 100` SHALL be used
+
+### Requirement: Batch Progress Reporting
+
+The batch runner SHALL expose an observable progress channel so the UI
+can render `runsCompleted / totalRuns` without busy-polling.
+
+#### Scenario: Progress increments per run
+
+- **GIVEN** a batch of 100 runs in progress
+- **WHEN** the 10th run completes
+- **THEN** the progress signal SHALL emit
+  `{runsCompleted: 10, totalRuns: 100}`
+
+#### Scenario: Progress reaches total on completion
+
+- **GIVEN** a batch of 100 runs has fully completed
+- **WHEN** the progress signal is observed
+- **THEN** the final emission SHALL be
+  `{runsCompleted: 100, totalRuns: 100}`
+
+### Requirement: Event Loop Yielding During Batch
+
+The batch runner SHALL yield control to the event loop at least every
+10 completed runs so that the main thread does not freeze during long
+batches.
+
+#### Scenario: Main thread stays responsive
+
+- **GIVEN** a 500-run batch is executing
+- **WHEN** the batch is halfway done
+- **THEN** the runner SHALL have performed at least 25 `await
+setTimeout(0)` yields (or equivalent)
+- **AND** a UI progress bar bound to the progress channel SHALL update
+  during the batch
+
+### Requirement: Batch Cancellation
+
+The batch runner SHALL accept an `AbortSignal` and produce a partial
+`IBatchResult` when cancellation fires mid-batch.
+
+#### Scenario: Cancellation returns partial aggregate
+
+- **GIVEN** a 100-run batch in progress, 37 runs completed
+- **WHEN** the caller aborts the signal
+- **THEN** the runner SHALL stop after the current run finishes
+- **AND** `aggregateBatchOutcomes` SHALL be called with the 37
+  completed outcomes
+- **AND** `IBatchResult.totalRuns` SHALL equal 37 (not 100)
+
+#### Scenario: Immediate cancellation before first run
+
+- **GIVEN** a batch is requested but the signal is already aborted
+- **WHEN** `runBatch` is invoked
+- **THEN** the runner SHALL return an empty `IBatchResult` with
+  `totalRuns: 0`
+- **AND** no `GameEngine` instances SHALL be created
+
+### Requirement: Per-Run Error Isolation
+
+A single run that throws SHALL NOT abort the entire batch; the error
+SHALL be captured in the corresponding `IBatchOutcome` and the batch
+SHALL continue.
+
+#### Scenario: Engine error captured as outcome
+
+- **GIVEN** a batch where run 3's `runToCompletion` throws `"Invalid
+weapon state"`
+- **WHEN** the batch completes
+- **THEN** `outcomes[3]` SHALL contain `{runIndex: 3, seed, error:
+"Invalid weapon state"}`
+- **AND** `outcomes.length` SHALL equal the configured run count
+
+#### Scenario: Batch aborts on systemic failure
+
+- **GIVEN** a batch where more than 20% of runs error out
+- **WHEN** the threshold is crossed
+- **THEN** the batch SHALL abort
+- **AND** the caller SHALL receive `"Quick Resolve failed: engine
+errors"` with the partial outcomes attached
+
+### Requirement: Invalid Run Count Rejection
+
+The batch runner SHALL reject run counts outside the inclusive range
+`[1, 5000]` before launching any sessions.
+
+#### Scenario: Zero runs rejected
+
+- **GIVEN** `options = { runs: 0 }`
+- **WHEN** `runBatch` is invoked
+- **THEN** the call SHALL throw `"Invalid run count"`
+- **AND** no `GameEngine` SHALL be created
+
+#### Scenario: Excessive runs rejected
+
+- **GIVEN** `options = { runs: 10000 }`
+- **WHEN** `runBatch` is invoked
+- **THEN** the call SHALL throw `"Invalid run count"`
+
+### Requirement: Auto-Generated Base Seed
+
+When the caller omits `baseSeed`, the batch runner SHALL generate a
+cryptographically random integer and include it in the returned
+`IBatchResult` so the batch can be replayed deterministically.
+
+#### Scenario: Omitted baseSeed is generated and reported
+
+- **GIVEN** `options = { runs: 10 }` with no `baseSeed`
+- **WHEN** `runBatch` completes
+- **THEN** `IBatchResult.baseSeed` SHALL be a non-null integer
+- **AND** calling `runBatch(config, { runs: 10, baseSeed:
+result.baseSeed })` again SHALL reproduce the same
+  `IBatchResult`

--- a/openspec/changes/add-quick-resolve-monte-carlo/tasks.md
+++ b/openspec/changes/add-quick-resolve-monte-carlo/tasks.md
@@ -1,0 +1,116 @@
+# Tasks: Add Quick Resolve Monte Carlo
+
+## 1. Batch Outcome Schema
+
+- [ ] 1.1 Define `IBatchOutcome` capturing `{runIndex, seed, report:
+    IPostBattleReport, durationMs}`
+- [ ] 1.2 Define `IBatchResult` with `{totalRuns, winProbability:
+    {player, opponent, draw}, turnCount: {mean, median, p25, p75, p90,
+    min, max}, heatShutdownFrequency: {player, opponent},
+    mechDestroyedFrequency: {player, opponent}, perUnitSurvival:
+    Record<unitId, number>, mostLikelyOutcome}`
+- [ ] 1.3 Add both shapes to `after-combat-report` spec's type exports
+
+## 2. Batch Runner
+
+- [ ] 2.1 Create `QuickResolveService.runBatch(config, options)` that
+      takes the same `IGameConfig` the interactive session accepts plus
+      `{runs: number, baseSeed: number}`
+- [ ] 2.2 For each run index `i`, instantiate a fresh `GameEngine` with
+      `seed = baseSeed + i` to guarantee reproducibility
+- [ ] 2.3 Call `engine.runToCompletion(...)` and derive
+      `IPostBattleReport` from the completed session's event log
+- [ ] 2.4 Collect results into `IBatchOutcome[]` and pass to
+      `aggregateBatchOutcomes`
+- [ ] 2.5 Yield to the event loop every 10 runs so the UI stays
+      responsive during a 500-run batch
+
+## 3. Aggregation
+
+- [ ] 3.1 Create `aggregateBatchOutcomes(outcomes): IBatchResult`
+- [ ] 3.2 Win probability: count `winner` values across reports,
+      normalize over `totalRuns`
+- [ ] 3.3 Turn-count stats: compute mean / median / p25 / p75 / p90 /
+      min / max from `report.turnCount`
+- [ ] 3.4 Heat-shutdown frequency: count reports where `units[].heatProblems`
+      contains a shutdown event, normalize per side
+- [ ] 3.5 Mech-destroyed frequency: count reports where a side has
+      units with `damageReceived >= structureMax`, normalize per side
+- [ ] 3.6 Per-unit survival: for each unit id, count reports where
+      `units[unitId].destroyed === false`, divide by totalRuns
+- [ ] 3.7 `mostLikelyOutcome`: select the winner with highest probability
+      (ties resolve to `"draw"`)
+
+## 4. Seed Management
+
+- [ ] 4.1 Document in the spec that `seed = baseSeed + runIndex` makes
+      each run independent yet reproducible as a whole
+- [ ] 4.2 If the caller omits `baseSeed`, generate a cryptographically
+      random integer once and include it in the returned `IBatchResult`
+      so the batch can be re-run deterministically
+- [ ] 4.3 Never reuse the interactive session's `SeededRandom` instance
+      across runs — each run gets a fresh `DiceRoller`
+
+## 5. React Query Hook
+
+- [ ] 5.1 Create `useQuickResolve()` that wraps `runBatch` in a
+      `useMutation`
+- [ ] 5.2 Expose `{runsCompleted, totalRuns, isRunning, result}` so the
+      UI can render progress
+- [ ] 5.3 Support cancellation via an `AbortSignal` — canceling mid-batch
+      returns the partial `IBatchResult` with `totalRuns` equal to the
+      number of completed runs
+- [ ] 5.4 Log the seed used on the completed result so users can
+      reproduce a run for debugging
+
+## 6. Encounter Page Entry Point
+
+- [ ] 6.1 Add "Quick Resolve" button to
+      `/gameplay/encounters/[id]/index.tsx` below the "Launch Match"
+      button
+- [ ] 6.2 Button opens a small modal with run-size options: 25, 100
+      (default), 500
+- [ ] 6.3 On confirm, dispatch `useQuickResolve()` and show a progress
+      bar `runsCompleted / totalRuns`
+- [ ] 6.4 On completion, navigate (or expand in place) to the result
+      surface owned by `add-quick-sim-result-display`
+
+## 7. Error Handling
+
+- [ ] 7.1 If a single run throws, catch it, include an error entry in
+      the `IBatchOutcome` list with `{runIndex, seed, error}`, and
+      continue the batch
+- [ ] 7.2 If >20% of runs error out, abort the batch and surface
+      `"Quick Resolve failed: engine errors"`
+- [ ] 7.3 If the caller provides an invalid `runs` (not 1..5000), throw
+      `"Invalid run count"` before starting
+
+## 8. Performance Targets
+
+- [ ] 8.1 A 100-run batch with the Phase 1 default encounter (2v2 light
+      mechs) SHALL complete in under 30 seconds on reference hardware
+- [ ] 8.2 Main thread SHALL NOT be blocked for more than 50ms at a time
+      (requires the event-loop yield from task 2.5)
+- [ ] 8.3 Memory: batch SHALL NOT retain the full event log of
+      completed sessions — only the derived `IPostBattleReport`
+
+## 9. Tests
+
+- [ ] 9.1 Unit test: `aggregateBatchOutcomes` with fixed input produces
+      expected win probabilities
+- [ ] 9.2 Unit test: `aggregateBatchOutcomes` with all-draws returns
+      `mostLikelyOutcome = "draw"`
+- [ ] 9.3 Determinism test: `runBatch(config, { runs: 10, baseSeed: 42
+    })` called twice produces deeply equal `IBatchResult`
+- [ ] 9.4 Integration test: running a small batch (10 runs) on the
+      Phase 1 default encounter completes without throwing
+- [ ] 9.5 Integration test: engine error in run 3 produces an error
+      entry but the batch continues to run 10
+
+## 10. Spec Compliance
+
+- [ ] 10.1 Every delta requirement across `simulation-system`,
+      `combat-resolution`, and `after-combat-report` has at least one
+      GIVEN/WHEN/THEN scenario
+- [ ] 10.2 `openspec validate add-quick-resolve-monte-carlo --strict`
+      passes clean

--- a/openspec/changes/add-quick-resolve-monte-carlo/tasks.md
+++ b/openspec/changes/add-quick-resolve-monte-carlo/tasks.md
@@ -3,12 +3,12 @@
 ## 1. Batch Outcome Schema
 
 - [ ] 1.1 Define `IBatchOutcome` capturing `{runIndex, seed, report:
-    IPostBattleReport, durationMs}`
+IPostBattleReport, durationMs}`
 - [ ] 1.2 Define `IBatchResult` with `{totalRuns, winProbability:
-    {player, opponent, draw}, turnCount: {mean, median, p25, p75, p90,
-    min, max}, heatShutdownFrequency: {player, opponent},
-    mechDestroyedFrequency: {player, opponent}, perUnitSurvival:
-    Record<unitId, number>, mostLikelyOutcome}`
+{player, opponent, draw}, turnCount: {mean, median, p25, p75, p90,
+min, max}, heatShutdownFrequency: {player, opponent},
+mechDestroyedFrequency: {player, opponent}, perUnitSurvival:
+Record<unitId, number>, mostLikelyOutcome}`
 - [ ] 1.3 Add both shapes to `after-combat-report` spec's type exports
 
 ## 2. Batch Runner
@@ -101,7 +101,7 @@
 - [ ] 9.2 Unit test: `aggregateBatchOutcomes` with all-draws returns
       `mostLikelyOutcome = "draw"`
 - [ ] 9.3 Determinism test: `runBatch(config, { runs: 10, baseSeed: 42
-    })` called twice produces deeply equal `IBatchResult`
+})` called twice produces deeply equal `IBatchResult`
 - [ ] 9.4 Integration test: running a small batch (10 runs) on the
       Phase 1 default encounter completes without throwing
 - [ ] 9.5 Integration test: engine error in run 3 produces an error

--- a/openspec/changes/add-quick-sim-result-display/proposal.md
+++ b/openspec/changes/add-quick-sim-result-display/proposal.md
@@ -1,0 +1,64 @@
+# Change: Add Quick Sim Result Display
+
+## Why
+
+The Quick Resolve batch runner (`add-quick-resolve-monte-carlo`)
+produces an `IBatchResult` that by itself is a blob of numbers. Players
+need a visual surface that answers "should I take this fight?" in under
+10 seconds — a stacked win-probability bar, a turn-count histogram,
+casualty expectations, and a one-line "most likely outcome" summary.
+Without this display the Monte Carlo data is invisible. This change
+adds the result surface that renders `IBatchResult` on the encounter
+detail page and (optionally) in a dedicated `/gameplay/encounters/[id]/sim`
+route for deep-linking.
+
+## What Changes
+
+- Add a `QuickSimResultPanel` React component that takes an
+  `IBatchResult` and renders:
+  - a stacked horizontal bar showing win probabilities (player /
+    opponent / draw), with inline percentages
+  - a turn-count histogram (bucketed by 2-turn bins) plus mean, median,
+    p25, p75, p90 annotations
+  - per-side expected-casualty breakdown (mechs destroyed, heat
+    shutdowns, per-unit survival rates shown as 0-100% bars)
+  - a "Most Likely Outcome" headline summarizing winner + confidence
+  - a collapsible "Raw Data" section showing `{totalRuns, erroredRuns,
+baseSeed}` for reproducibility
+- Add a `QuickSimResultSummary` compact variant for the encounter
+  detail page: single row with win-prob bar + headline + "Expand" link
+- Add route `/gameplay/encounters/[id]/sim` that runs
+  `useQuickResolve()` and renders the full panel on completion
+- Progress state: during the batch, render a progress bar + the current
+  `runsCompleted / totalRuns` count and a "Cancel" button that triggers
+  the `AbortSignal` defined in `add-quick-resolve-monte-carlo`
+- Empty-state rendering when `totalRuns === 0`: "Run a batch to see
+  outcome distribution" with a CTA button
+
+## Dependencies
+
+- **Requires**: `add-quick-resolve-monte-carlo` (produces the
+  `IBatchResult` this change consumes), `tactical-map-interface`
+  (existing spec that owns encounter-detail UI surfaces),
+  `simulation-system` (progress channel contract)
+- **Required By**: none in Phase 2 (this is a leaf display). Phase 3
+  campaign integration will reuse the panel when showing "expected
+  outcome before contract acceptance".
+
+## Impact
+
+- Affected specs: `tactical-map-interface` (ADDED — Quick Sim result
+  panel, summary variant, progress surface, empty state),
+  `simulation-system` (MODIFIED — consumer-side contract for the
+  progress channel and cancel signal — no new engine behavior, just
+  binding surface)
+- Affected code: new `src/components/gameplay/QuickSimResultPanel.tsx`,
+  new `src/components/gameplay/QuickSimResultSummary.tsx`, new
+  `src/components/gameplay/TurnCountHistogram.tsx`, new page
+  `src/pages/gameplay/encounters/[id]/sim.tsx`,
+  `src/pages/gameplay/encounters/[id]/index.tsx` (extended with summary
+  row)
+- Non-goals: exporting the result to CSV/PDF (future), persisting the
+  result to disk (Phase 3), showing comparative "what if I swap mech X
+  for mech Y" (future — would need the comparison surface from
+  `add-pre-battle-force-comparison`)

--- a/openspec/changes/add-quick-sim-result-display/specs/simulation-system/spec.md
+++ b/openspec/changes/add-quick-sim-result-display/specs/simulation-system/spec.md
@@ -1,0 +1,50 @@
+# simulation-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: UI Progress Channel Contract
+
+The simulation system SHALL expose the batch progress channel as a
+React-query-compatible observable that the `useQuickResolve` hook can
+subscribe to and surface to the `QuickSimResultPanel` progress bar
+without busy-polling.
+
+#### Scenario: Hook receives progress updates
+
+- **GIVEN** `useQuickResolve()` is invoked with `runs: 100`
+- **WHEN** a run completes
+- **THEN** the hook's `{runsCompleted, totalRuns}` state SHALL update
+  to reflect the new completion count
+- **AND** any subscribed React component SHALL re-render within one
+  animation frame
+
+#### Scenario: Progress snapshot survives renders
+
+- **GIVEN** a component subscribed to the progress channel mid-batch
+- **WHEN** the component unmounts and remounts during the batch
+- **THEN** the newly mounted component SHALL receive the current
+  `{runsCompleted, totalRuns}` value on first render (no reset to
+  zero)
+
+### Requirement: UI Abort Signal Binding
+
+The simulation system SHALL bind the `AbortSignal` exposed by
+`useQuickResolve()` to the batch runner's cancellation contract so the
+Cancel button in the result panel stops the batch after the current
+run finishes.
+
+#### Scenario: Cancel from UI halts batch
+
+- **GIVEN** a batch in progress dispatched via `useQuickResolve()`
+- **WHEN** the consumer calls the hook's `cancel()` method
+- **THEN** the underlying `AbortSignal` SHALL fire
+- **AND** the batch runner SHALL stop after the current run finishes
+- **AND** the hook SHALL transition to state
+  `{isRunning: false, result: <partial>}`
+
+#### Scenario: Cancel is idempotent
+
+- **GIVEN** a batch that has already been cancelled
+- **WHEN** the consumer calls `cancel()` again
+- **THEN** no error SHALL be thrown
+- **AND** no additional state change SHALL occur

--- a/openspec/changes/add-quick-sim-result-display/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-quick-sim-result-display/specs/tactical-map-interface/spec.md
@@ -1,0 +1,203 @@
+# tactical-map-interface Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Quick Sim Result Panel
+
+The tactical map interface SHALL provide a `QuickSimResultPanel`
+component that accepts an `IBatchResult` and renders four sections:
+win probability, turn count distribution, casualty breakdown, and a
+collapsible raw data block.
+
+#### Scenario: Panel renders all sections on completed batch
+
+- **GIVEN** a valid `IBatchResult` with `totalRuns = 100`
+- **WHEN** `QuickSimResultPanel` receives the result as props
+- **THEN** the rendered DOM SHALL contain sections labeled
+  `"Win Probability"`, `"Turn Count"`, `"Casualties"`, and a
+  collapsible `"Raw Data"` region
+- **AND** the header SHALL read `"Quick Resolve: 100 runs"`
+
+#### Scenario: Empty state rendered when totalRuns is zero
+
+- **GIVEN** an `IBatchResult` with `totalRuns = 0`
+- **WHEN** the panel renders
+- **THEN** the panel SHALL show `"Run a batch to see outcome
+distribution"` with a `"Run Batch"` CTA button
+- **AND** no win-probability bar SHALL be rendered
+
+### Requirement: Win Probability Bar
+
+The result panel SHALL render a horizontal stacked bar representing
+`winProbability.{player, opponent, draw}` with player-first ordering
+and inline percentage labels on segments wider than 10% of the bar.
+
+#### Scenario: Bar segments scale to probabilities
+
+- **GIVEN** `winProbability = {player: 0.62, opponent: 0.30, draw:
+0.08}`
+- **WHEN** the bar renders
+- **THEN** the player segment SHALL occupy 62% of the width
+- **AND** the opponent segment SHALL occupy 30%
+- **AND** the draw segment SHALL occupy 8%
+
+#### Scenario: Inline labels hidden for narrow segments
+
+- **GIVEN** `winProbability.draw = 0.08`
+- **WHEN** the bar renders
+- **THEN** the draw segment SHALL NOT render an inline percentage label
+  (below the 10% visibility threshold)
+
+#### Scenario: Bar uses accessible label
+
+- **GIVEN** `winProbability = {player: 0.62, opponent: 0.30, draw:
+0.08}`
+- **WHEN** the bar renders
+- **THEN** the bar SHALL have `role="img"`
+- **AND** `aria-label` SHALL equal `"Win probabilities: Player 62%,
+Opponent 30%, Draw 8%"`
+
+### Requirement: Most Likely Outcome Headline
+
+The result panel SHALL display a headline above the win-probability bar
+summarizing `mostLikelyOutcome` and a derived confidence qualifier.
+
+#### Scenario: High-confidence player victory
+
+- **GIVEN** `mostLikelyOutcome = "player"` and `winProbability.player =
+0.85`
+- **WHEN** the headline renders
+- **THEN** the headline text SHALL equal `"Most Likely Outcome: Player
+Victory (High)"`
+
+#### Scenario: Moderate-confidence opponent victory
+
+- **GIVEN** `mostLikelyOutcome = "opponent"` and
+  `winProbability.opponent = 0.67`
+- **WHEN** the headline renders
+- **THEN** the headline text SHALL equal `"Most Likely Outcome:
+Opponent Victory (Moderate)"`
+
+#### Scenario: Low-confidence outcome
+
+- **GIVEN** `mostLikelyOutcome = "player"` and `winProbability.player =
+0.52`
+- **WHEN** the headline renders
+- **THEN** the headline text SHALL equal `"Most Likely Outcome: Player
+Victory (Low)"`
+
+#### Scenario: Draw headline omits confidence
+
+- **GIVEN** `mostLikelyOutcome = "draw"` and `winProbability.draw =
+0.50`
+- **WHEN** the headline renders
+- **THEN** the headline text SHALL equal `"Most Likely Outcome: Draw"`
+  with no confidence qualifier
+
+### Requirement: Turn Count Histogram
+
+The result panel SHALL render a `TurnCountHistogram` chart bucketing
+turn counts into 2-turn bins across `[turnCount.min, turnCount.max]`,
+with mean (solid line), median (dashed line), p25/p75 (shaded band),
+and p90 (labeled marker) overlays.
+
+#### Scenario: Histogram renders when at least 2 runs succeeded
+
+- **GIVEN** a batch with `totalRuns = 100` successful runs
+- **WHEN** the histogram renders
+- **THEN** the chart SHALL display at least one 2-turn bucket per
+  sample point in the range
+- **AND** the mean indicator SHALL be drawn as a solid vertical line at
+  `turnCount.mean`
+- **AND** the median SHALL be drawn as a dashed vertical line at
+  `turnCount.median`
+
+#### Scenario: Insufficient data shows fallback text
+
+- **GIVEN** a batch with fewer than 2 successful runs
+- **WHEN** the histogram renders
+- **THEN** the histogram SHALL render the text `"Not enough data"`
+  instead of a chart
+
+#### Scenario: Screen-reader table fallback
+
+- **GIVEN** the histogram is rendered with 5 buckets
+- **WHEN** a screen reader inspects the component
+- **THEN** a visually hidden `<table>` SHALL list each bucket with its
+  count
+
+### Requirement: Casualty Breakdown
+
+The result panel SHALL render a two-column casualty section (Player /
+Opponent) showing mech-destroyed frequency, heat-shutdown frequency,
+and per-unit survival bars sorted by survival rate descending.
+
+#### Scenario: Per-side metrics visible
+
+- **GIVEN** `mechDestroyedFrequency = {player: 0.70, opponent: 0.45}`
+  and `heatShutdownFrequency = {player: 0.18, opponent: 0.09}`
+- **WHEN** the casualty section renders
+- **THEN** the Player column SHALL show `"Mech Destroyed: 70%"` and
+  `"Heat Shutdown: 18%"`
+- **AND** the Opponent column SHALL show `"Mech Destroyed: 45%"` and
+  `"Heat Shutdown: 9%"`
+
+#### Scenario: Per-unit survival sorted
+
+- **GIVEN** `perUnitSurvival = {"p1-atlas": 0.72, "p1-locust": 0.91,
+"p1-commando": 0.44}`
+- **WHEN** the Player column renders the per-unit rows
+- **THEN** rows SHALL be ordered: Locust (91%), Atlas (72%), Commando
+  (44%)
+- **AND** each row SHALL render a 0-100% bar labeled with the unit's
+  designation
+
+### Requirement: Compact Summary Variant
+
+The tactical map interface SHALL provide a compact
+`QuickSimResultSummary` component suitable for the encounter detail
+page, rendering a single row with a small win-prob bar, the outcome
+headline, and a "View Full Results" link.
+
+#### Scenario: Summary navigates to full panel
+
+- **GIVEN** `QuickSimResultSummary` rendered on
+  `/gameplay/encounters/[id]/index`
+- **WHEN** the user clicks "View Full Results"
+- **THEN** the browser SHALL navigate to
+  `/gameplay/encounters/[id]/sim`
+- **AND** the full-panel page SHALL render the same `IBatchResult`
+
+#### Scenario: Summary empty state
+
+- **GIVEN** no batch has been run yet for the encounter
+- **WHEN** the summary renders
+- **THEN** it SHALL display `"No quick resolve data yet"` with a `"Run
+Batch"` CTA button
+- **AND** the CTA SHALL dispatch `useQuickResolve()` with default
+  `runs: 100`
+
+### Requirement: Progress and Cancel Surface
+
+The result panel SHALL render a progress bar with `runsCompleted /
+totalRuns` during a running batch and a Cancel button that triggers
+the batch's `AbortSignal`.
+
+#### Scenario: Progress bar updates during batch
+
+- **GIVEN** a batch in progress with `runsCompleted = 37` of `totalRuns
+= 100`
+- **WHEN** the progress bar renders
+- **THEN** the bar SHALL display at 37% fill
+- **AND** the label SHALL read `"37 / 100"`
+- **AND** the bar SHALL have `role="progressbar"` with `aria-valuenow =
+37`, `aria-valuemin = 0`, `aria-valuemax = 100`
+
+#### Scenario: Cancel triggers abort and shows partial banner
+
+- **GIVEN** a batch in progress at 37 runs completed
+- **WHEN** the user clicks Cancel
+- **THEN** the batch's `AbortSignal` SHALL fire
+- **AND** once the current run finishes, the panel SHALL render a
+  banner `"Partial results (cancelled)"`
+- **AND** the underlying `IBatchResult.totalRuns` SHALL equal 37

--- a/openspec/changes/add-quick-sim-result-display/tasks.md
+++ b/openspec/changes/add-quick-sim-result-display/tasks.md
@@ -14,7 +14,7 @@
 - [ ] 2.1 Horizontal stacked bar with three segments (player / opponent
       / draw)
 - [ ] 2.2 Segment widths proportional to `winProbability.player /
-    opponent / draw`
+opponent / draw`
 - [ ] 2.3 Color scheme: player = theme primary, opponent = theme
       danger, draw = neutral gray
 - [ ] 2.4 Show percentage inline on each segment if its width exceeds
@@ -109,7 +109,7 @@
       `IBatchResult` fixture renders expected percentages
 - [ ] 12.2 Unit test: Empty-state renders when `totalRuns === 0`
 - [ ] 12.3 Unit test: Headline shows "Draw" when `mostLikelyOutcome ===
-    "draw"`
+"draw"`
 - [ ] 12.4 Integration test: Cancel button during a batch triggers the
       abort signal and renders the partial banner
 - [ ] 12.5 Visual snapshot test for the full panel + summary variant

--- a/openspec/changes/add-quick-sim-result-display/tasks.md
+++ b/openspec/changes/add-quick-sim-result-display/tasks.md
@@ -1,0 +1,122 @@
+# Tasks: Add Quick Sim Result Display
+
+## 1. Result Panel Component
+
+- [ ] 1.1 Create `QuickSimResultPanel` component that accepts
+      `{ result: IBatchResult, onRerun?: () => void }` props
+- [ ] 1.2 Render a header "Quick Resolve: N runs" reading `totalRuns`
+- [ ] 1.3 Render four sections: Win Probability, Turn Count, Casualties,
+      Raw Data (collapsible)
+- [ ] 1.4 Handle empty-state rendering when `totalRuns === 0`
+
+## 2. Win Probability Bar
+
+- [ ] 2.1 Horizontal stacked bar with three segments (player / opponent
+      / draw)
+- [ ] 2.2 Segment widths proportional to `winProbability.player /
+    opponent / draw`
+- [ ] 2.3 Color scheme: player = theme primary, opponent = theme
+      danger, draw = neutral gray
+- [ ] 2.4 Show percentage inline on each segment if its width exceeds
+      10% of the bar
+- [ ] 2.5 Accessible label: "Win probabilities: Player 62%, Opponent
+      30%, Draw 8%"
+
+## 3. Turn Count Histogram
+
+- [ ] 3.1 Create `TurnCountHistogram` component rendering a bar chart
+      with 2-turn buckets across `[turnCount.min, turnCount.max]`
+- [ ] 3.2 Show mean as a solid vertical line and median as a dashed
+      line
+- [ ] 3.3 Show p25/p75 as a shaded band
+- [ ] 3.4 Show p90 as a labeled marker
+- [ ] 3.5 Empty histogram when fewer than 2 successful runs — show text
+      "Not enough data"
+
+## 4. Casualty Breakdown
+
+- [ ] 4.1 Two-column layout (Player / Opponent)
+- [ ] 4.2 Each column shows: "Mech Destroyed Frequency" (%),
+      "Heat Shutdown Frequency" (%)
+- [ ] 4.3 Per-unit survival: one row per unit with designation + 0-100%
+      bar showing `perUnitSurvival[unitId]`
+- [ ] 4.4 Sort per-unit rows descending by survival rate
+
+## 5. Most Likely Outcome Headline
+
+- [ ] 5.1 Above the win-probability bar, render a large headline:
+      "Most Likely Outcome: <Side> Victory (<confidence>)"
+- [ ] 5.2 Confidence label derived from `winProbability`:
+      `> 0.8 → "High"`, `0.6–0.8 → "Moderate"`, `< 0.6 → "Low"`
+- [ ] 5.3 When `mostLikelyOutcome === "draw"`, render "Most Likely
+      Outcome: Draw" (no confidence qualifier)
+
+## 6. Raw Data Collapsible
+
+- [ ] 6.1 Collapsed by default
+- [ ] 6.2 Shows `totalRuns`, `erroredRuns`, `baseSeed`, and a "Copy
+      seed" button
+- [ ] 6.3 Button places `baseSeed` on the clipboard as plain text
+
+## 7. Compact Summary Variant
+
+- [ ] 7.1 `QuickSimResultSummary` component: single-row layout with
+      win-prob bar (small), headline, and "View Full Results" link
+- [ ] 7.2 Designed for the encounter detail page sidebar
+- [ ] 7.3 Link navigates to `/gameplay/encounters/[id]/sim`
+
+## 8. Progress + Cancel Surface
+
+- [ ] 8.1 During `isRunning`, render `QuickSimProgressBar` with
+      `runsCompleted / totalRuns`
+- [ ] 8.2 Cancel button triggers the `AbortSignal` returned by
+      `useQuickResolve()`
+- [ ] 8.3 After cancel, show partial `IBatchResult` with a "Partial
+      results (cancelled)" banner
+
+## 9. Dedicated Sim Route
+
+- [ ] 9.1 Create page `/gameplay/encounters/[id]/sim.tsx`
+- [ ] 9.2 Run-size selector (25/100/500) and "Start" button
+- [ ] 9.3 On start, dispatch `useQuickResolve()` and render the
+      progress surface
+- [ ] 9.4 On completion, render `QuickSimResultPanel` in-place
+- [ ] 9.5 "Rerun" button that invokes the mutation again with a fresh
+      `baseSeed`
+
+## 10. Empty State
+
+- [ ] 10.1 On the encounter detail page, before any batch runs, the
+      summary row shows "No quick resolve data yet" with a "Run Batch"
+      CTA button
+- [ ] 10.2 CTA dispatches the same `useQuickResolve()` hook with
+      default `runs: 100`
+
+## 11. Accessibility
+
+- [ ] 11.1 Win-prob bar is `role="img"` with a descriptive
+      `aria-label`
+- [ ] 11.2 Turn-count histogram includes a screen-reader-only table
+      fallback listing the bucket counts
+- [ ] 11.3 Progress bar uses `role="progressbar"` with
+      `aria-valuenow`, `aria-valuemin`, `aria-valuemax`
+- [ ] 11.4 All interactive controls (Cancel, Rerun, Copy Seed)
+      reachable by keyboard
+
+## 12. Tests
+
+- [ ] 12.1 Unit test: `QuickSimResultPanel` with a fixed
+      `IBatchResult` fixture renders expected percentages
+- [ ] 12.2 Unit test: Empty-state renders when `totalRuns === 0`
+- [ ] 12.3 Unit test: Headline shows "Draw" when `mostLikelyOutcome ===
+    "draw"`
+- [ ] 12.4 Integration test: Cancel button during a batch triggers the
+      abort signal and renders the partial banner
+- [ ] 12.5 Visual snapshot test for the full panel + summary variant
+
+## 13. Spec Compliance
+
+- [ ] 13.1 Every delta requirement across `tactical-map-interface` and
+      `simulation-system` has at least one GIVEN/WHEN/THEN scenario
+- [ ] 13.2 `openspec validate add-quick-sim-result-display --strict`
+      passes clean

--- a/openspec/changes/add-reconnection-and-session-rehydration/proposal.md
+++ b/openspec/changes/add-reconnection-and-session-rehydration/proposal.md
@@ -1,0 +1,58 @@
+# Change: Add Reconnection and Session Rehydration (Server)
+
+## Why
+
+**Sub-phase 4b.** 4a's reconnect protocol (`add-game-session-persistence-
+for-reconnect`) only covers 1v1 P2P, where the host's local log is the
+authoritative source. In 4b the authoritative log lives in the
+`IMatchStore` behind the server, which is both more robust (a player's
+wifi dying doesn't risk their local log being the last copy) and more
+flexible (a player can reconnect from a different device). This change
+formalizes the server-side side of reconnection: pause/unpause on peer
+loss, per-match grace windows, replay to reconnecting clients from the
+match store, identity-based reconnect (same `playerId` that left can
+rejoin their seat), and per-match replay limits.
+
+## What Changes
+
+- `multiplayer-server` spec adds a formal "player disconnection
+  lifecycle" section: `connected → pending → timed-out`
+- Grace window configurable per match; default 120 seconds for active
+  matches (2× the 4a default because now a server keeps humming)
+- Server pauses phase advancement while any human seat's occupant is
+  `pending`, unless the host explicitly marks them "leave as AI"
+- On reconnect, server verifies `playerId` matches the seat's
+  occupant, streams the replay from `IMatchStore` starting at the
+  client-provided `lastSeq`
+- Clients can reconnect from any device that holds a valid player
+  token for the same `playerId`
+- If grace times out, server offers the host two outcomes: forfeit
+  that seat's side (end match) OR replace the seat with a bot so the
+  other humans can continue
+- Persistent auto-save on the server ensures that a server restart
+  doesn't invalidate active matches; reconnecting clients pick back
+  up from the last appended event
+
+## Dependencies
+
+- **Requires**: `add-multiplayer-server-infrastructure` (server + match
+  store), `add-player-identity-and-auth` (authenticated reconnect),
+  `add-multiplayer-lobby-and-matchmaking-2-8` (seat model)
+- **Required By**: production readiness of 4b — without this, any
+  flaky connection ends a match
+
+## Impact
+
+- Affected specs: `multiplayer-server` (MODIFIED — disconnection
+  lifecycle, grace window, seat fallback), `game-session-management`
+  (MODIFIED — server-authored pause events), `auto-save-persistence`
+  (MODIFIED — server-side persistence hooks, mirror of 4a's client-
+  side contract)
+- Affected code: extension of `ServerMatchHost` with
+  connection-lifecycle tracking, new `src/server/multiplayer/
+reconnectManager.ts`, extension of `src/lib/multiplayer/client.ts`
+  with auto-reconnect + replay intake, extension of the lobby
+  `IMatchMeta` with seat connection status
+- Non-goals: cross-region server failover, hot-swap of the `IMatchStore`
+  backend mid-match, reconnect of multi-device split brain, voice/chat
+  session continuity

--- a/openspec/changes/add-reconnection-and-session-rehydration/specs/auto-save-persistence/spec.md
+++ b/openspec/changes/add-reconnection-and-session-rehydration/specs/auto-save-persistence/spec.md
@@ -1,0 +1,54 @@
+# auto-save-persistence Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Server-Side Persistence Contract
+
+The auto-save persistence system SHALL define server-side persistence
+behaviour in parallel to the client-side IndexedDB contract, so active
+matches survive server restarts without data loss.
+
+#### Scenario: Write-through on every append
+
+- **GIVEN** a `ServerMatchHost` receiving an appendable event
+- **WHEN** the host resolves the event
+- **THEN** the event SHALL be persisted via `IMatchStore.appendEvent`
+  BEFORE being broadcast to connected clients
+- **AND** a failed persist SHALL prevent the broadcast and emit
+  `Error {code: 'STORE_FAILURE'}`
+
+#### Scenario: Load on server startup
+
+- **GIVEN** the server has a set of matches with `status: 'active'` in
+  the store at process startup
+- **WHEN** the server initializes
+- **THEN** it SHALL call `getEvents(matchId)` for each active match
+- **AND** it SHALL instantiate `ServerMatchHost` instances pre-loaded
+  with the retrieved event logs
+
+#### Scenario: Match store API parity with client IndexedDB
+
+- **GIVEN** the 4a client-side IndexedDB contract and this server-side
+  `IMatchStore` contract
+- **WHEN** both are inspected
+- **THEN** both SHALL support ordered event retrieval by `(matchId,
+fromSeq)`
+- **AND** both SHALL enforce that a single match's events have no
+  sequence gaps and no duplicate sequences
+
+### Requirement: Cross-Device Reconnect Depends On Server Store
+
+The system SHALL rely on the server-side `IMatchStore` (not the
+client's IndexedDB) as the source of truth during reconnect for
+networked matches, so a player reconnecting from a different device
+receives the same authoritative log.
+
+#### Scenario: Cross-device reconnect delivers same state
+
+- **GIVEN** a player plays for 10 turns on Device A, then opens the
+  match on Device B with a fresh IndexedDB
+- **WHEN** Device B authenticates and sends `SessionJoin {lastSeq: 0}`
+- **THEN** the server SHALL stream the full event log from the
+  `IMatchStore`
+- **AND** Device B's `currentState` SHALL match Device A's state at
+  the last event

--- a/openspec/changes/add-reconnection-and-session-rehydration/specs/game-session-management/spec.md
+++ b/openspec/changes/add-reconnection-and-session-rehydration/specs/game-session-management/spec.md
@@ -1,0 +1,50 @@
+# game-session-management Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Match Pause Events
+
+The system SHALL emit `match_paused` and `match_resumed` events as
+part of the session event stream, authored by the server, to record
+pause intervals in networked matches.
+
+#### Scenario: Match paused event shape
+
+- **GIVEN** a networked match pausing due to a pending seat
+- **WHEN** the server emits the event
+- **THEN** the event type SHALL be `match_paused`
+- **AND** the payload SHALL contain `pendingSeats: string[]` (slot
+  ids) and `graceRemaining: number` (seconds)
+- **AND** the event SHALL be persisted to the match store and
+  broadcast to all connected clients
+
+#### Scenario: Match resumed event shape
+
+- **GIVEN** a paused match whose pending seats have all reconnected
+- **WHEN** the server emits the resume event
+- **THEN** the event type SHALL be `match_resumed`
+- **AND** the payload SHALL contain `pausedDurationMs: number`
+
+### Requirement: Seat Fallback Events
+
+The system SHALL record seat fallback decisions as session events so
+post-match reports and spectators can reconstruct the sequence of
+events that led to an AI replacement or forfeit.
+
+#### Scenario: Seat replaced-by-AI event
+
+- **GIVEN** the host chooses `'replace-with-ai'` for a timed-out seat
+- **WHEN** the server acts
+- **THEN** an `Event {type: 'seat_replaced_by_ai', payload: {slotId,
+originalPlayerId, aiProfile}}` SHALL be appended
+- **AND** the event SHALL be persisted before the bot starts producing
+  intents
+
+#### Scenario: Forfeit event
+
+- **GIVEN** the host chooses `'forfeit-side'`
+- **WHEN** the server acts
+- **THEN** a `Event {type: 'side_forfeited', payload: {slotId,
+originalPlayerId, forfeitedSide}}` SHALL be appended
+- **AND** it SHALL be immediately followed by `GameEnded {reason:
+'forfeit'}` in the same tick

--- a/openspec/changes/add-reconnection-and-session-rehydration/specs/multiplayer-server/spec.md
+++ b/openspec/changes/add-reconnection-and-session-rehydration/specs/multiplayer-server/spec.md
@@ -1,0 +1,154 @@
+# multiplayer-server Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Seat Connection Lifecycle
+
+The system SHALL track connection lifecycle for each match seat with
+the states `'connected'`, `'pending'`, `'timed-out'`, and
+`'replaced-by-ai'`, and SHALL broadcast changes to all connected
+clients.
+
+#### Scenario: Connect transitions
+
+- **GIVEN** a seat `alpha-1` in `'pending'` state
+- **WHEN** the owning player's WebSocket re-attaches and
+  authentication succeeds
+- **THEN** the seat SHALL transition to `'connected'`
+- **AND** all clients SHALL receive a `seat_status_changed` event
+
+#### Scenario: Disconnect transitions
+
+- **GIVEN** a seat `alpha-2` in `'connected'` state
+- **WHEN** the owning player's WebSocket closes
+- **THEN** the seat SHALL transition to `'pending'`
+- **AND** a per-seat grace timer SHALL start
+
+#### Scenario: Grace timeout
+
+- **GIVEN** a seat in `'pending'` whose grace timer expires
+- **WHEN** the timer fires
+- **THEN** the seat SHALL transition to `'timed-out'`
+- **AND** the host SHALL be prompted to choose a fallback action
+
+### Requirement: Pause on Pending Human Seat
+
+The system SHALL pause phase advancement and intent processing
+whenever any human seat is in `'pending'` state, unless the host has
+explicitly enabled `ProceedWithoutPending`.
+
+#### Scenario: Pause broadcasts to all clients
+
+- **GIVEN** a live match with 4 human seats
+- **WHEN** one human disconnects
+- **THEN** the server SHALL emit `Event {type: 'match_paused',
+payload: {pendingSeats: [...], graceRemaining}}`
+- **AND** no further phase transitions SHALL occur until either
+  reconnection or timeout resolution
+
+#### Scenario: Resume on reconnect
+
+- **GIVEN** a paused match with exactly one seat `'pending'`
+- **WHEN** that seat reconnects
+- **THEN** the server SHALL emit `Event {type: 'match_resumed'}`
+- **AND** intent processing SHALL resume
+
+#### Scenario: Host can proceed without pending
+
+- **GIVEN** a paused match
+- **WHEN** the host sends `Intent {kind: 'ProceedWithoutPending'}`
+- **THEN** the pause SHALL lift
+- **AND** the pending seat(s) SHALL remain in `'pending'` but phase
+  advancement SHALL continue (their owned units idle until reconnect)
+
+### Requirement: Reconnect Handshake
+
+The system SHALL define a reconnect handshake that authenticates the
+returning player against the disconnected seat and streams the
+missing events.
+
+#### Scenario: Reconnect to own seat
+
+- **GIVEN** seat `alpha-1` in `'pending'` whose prior occupant was
+  `playerId: pid_abc`
+- **WHEN** a WebSocket authenticates as `pid_abc` and sends
+  `SessionJoin {matchId, playerId: 'pid_abc', lastSeq}`
+- **THEN** the server SHALL bind the socket to seat `alpha-1`
+- **AND** the server SHALL stream events from `lastSeq+1` via
+  `ReplayStart` + chunks + `ReplayEnd`
+- **AND** the seat SHALL transition to `'connected'`
+
+#### Scenario: Rejoin with wrong identity rejected
+
+- **GIVEN** seat `alpha-1` whose prior occupant was `pid_abc`
+- **WHEN** a player with `playerId: pid_other` attempts to rejoin
+  that seat
+- **THEN** the server SHALL respond `Error {code: 'SEAT_OCCUPIED_BY_
+OTHER_PLAYER'}`
+- **AND** the seat binding SHALL remain unchanged
+
+### Requirement: Grace Timeout Fallback
+
+The system SHALL offer the host three fallback actions when a seat
+times out: forfeit that side, replace with AI, or extend the grace
+window.
+
+#### Scenario: Forfeit side fallback
+
+- **GIVEN** a timed-out seat
+- **WHEN** the host chooses `'forfeit-side'`
+- **THEN** the server SHALL append `GameEnded` with `winner = the
+opposite side`, `reason = 'forfeit'`
+- **AND** the match SHALL become `'completed'`
+
+#### Scenario: Replace with AI fallback
+
+- **GIVEN** a timed-out seat
+- **WHEN** the host chooses `'replace-with-ai'`
+- **THEN** the seat SHALL transition to `'replaced-by-ai'`
+- **AND** a `BotPlayer` SHALL be spawned in-process to occupy the
+  seat for the rest of the match
+
+#### Scenario: Extend grace fallback
+
+- **GIVEN** a timed-out seat
+- **WHEN** the host chooses `'wait-longer'`
+- **THEN** the grace timer SHALL restart at the current
+  `reconnectGraceSeconds` value
+- **AND** the seat SHALL return to `'pending'`
+
+#### Scenario: Host non-response defaults to AI
+
+- **GIVEN** a timed-out seat and no host response for 60 seconds
+- **WHEN** the default timer fires
+- **THEN** the server SHALL apply `'replace-with-ai'` automatically
+
+### Requirement: Supersede Stale Socket
+
+The server SHALL close an older open socket for a `playerId` whenever
+that same `playerId` authenticates a new socket, so the newest
+authenticated connection is always the active one.
+
+#### Scenario: New socket supersedes old
+
+- **GIVEN** a player with an open WebSocket connection
+- **WHEN** the same player authenticates from a second device and
+  sends `SessionJoin` for the same match
+- **THEN** the server SHALL accept the new socket
+- **AND** the server SHALL close the old socket with `Close {reason:
+'SUPERSEDED_BY_NEW_SESSION'}`
+
+### Requirement: Server Restart Survives Matches
+
+The system SHALL ensure that a server restart does not end active
+matches; the authoritative state SHALL be recoverable from the
+`IMatchStore`.
+
+#### Scenario: Server restart preserves match
+
+- **GIVEN** an active match `sess_abc` with 30 persisted events
+- **WHEN** the server process restarts
+- **THEN** on startup the server SHALL enumerate matches with `status:
+'active'` and re-instantiate `ServerMatchHost` for each
+- **AND** clients reconnecting after restart SHALL receive the full
+  replay starting from their `lastSeq`

--- a/openspec/changes/add-reconnection-and-session-rehydration/tasks.md
+++ b/openspec/changes/add-reconnection-and-session-rehydration/tasks.md
@@ -1,0 +1,127 @@
+# Tasks: Add Reconnection and Session Rehydration (Server)
+
+## 1. Connection Lifecycle Model
+
+- [ ] 1.1 Extend `IMatchSeat` with `connectionStatus: 'connected' |
+    'pending' | 'timed-out' | 'replaced-by-ai'`
+- [ ] 1.2 Transitions: on WebSocket attach → `connected`; on socket
+      close → `pending`; on grace timer expiry → `timed-out`;
+      post-fallback → `replaced-by-ai`
+- [ ] 1.3 `connected` seats appear in the UI with a green dot; `pending`
+      with a yellow pulse; `timed-out` with a red dot
+
+## 2. Grace Window Configuration
+
+- [ ] 2.1 `IMatchMeta.config.reconnectGraceSeconds` defaults to 120
+- [ ] 2.2 Grace timer starts per-seat on disconnect; resets on
+      reconnect
+- [ ] 2.3 Host may adjust the grace window via
+      `Intent {kind: 'SetGraceWindow', seconds}`, clamped to `[30,
+    600]`; can NOT be adjusted once a timer is already running for
+      that seat
+
+## 3. Server-Side Persistence Hooks
+
+- [ ] 3.1 `ServerMatchHost` persists every appended event through the
+      `IMatchStore.appendEvent` call before broadcasting
+- [ ] 3.2 On server restart, hosts load their session from the store
+      (via `IMatchStore.getEvents`) before accepting new connections
+- [ ] 3.3 A health check endpoint `/api/multiplayer/matches/:id/status`
+      returns `{status, seats, connectionStatuses, lastEventSeq}` for
+      monitoring dashboards
+
+## 4. Reconnect Handshake
+
+- [ ] 4.1 Client reconnect: opens a WebSocket with a valid token and
+      sends `SessionJoin {matchId, playerId, lastSeq}`
+- [ ] 4.2 Server verifies `playerId` matches a seat whose
+      `connectionStatus` is `'pending'`
+- [ ] 4.3 Server re-binds the socket to that seat and transitions the
+      seat to `'connected'`
+- [ ] 4.4 Server streams events from `lastSeq+1` via `ReplayStart` +
+      chunks + `ReplayEnd`
+
+## 5. Pause/Resume Mechanics
+
+- [ ] 5.1 If any human seat's `connectionStatus` is `'pending'`, the
+      server does NOT advance phases or process intents from other
+      clients
+- [ ] 5.2 Exception: host can override with `Intent {kind: 'ProceedWith
+    outPending'}` — matches the 4b checkpoint's "AI fills empty
+      slots" posture
+- [ ] 5.3 Paused matches broadcast an `Event {type: 'match_paused',
+    payload: {pendingSeats, graceRemaining}}`
+- [ ] 5.4 Resumed matches broadcast `Event {type: 'match_resumed'}`
+
+## 6. Grace Timeout Fallback
+
+- [ ] 6.1 When a seat's grace timer expires, server sets
+      `connectionStatus: 'timed-out'` and broadcasts a `match_seat_
+    timed_out` event
+- [ ] 6.2 Host receives an intent prompt offering three options: - `'forfeit-side'` → ends the match with the opposite side
+      winning - `'replace-with-ai'` → marks the seat `replaced-by-ai`, spawns
+      a bot, match resumes - `'wait-longer'` → extends the grace timer by another
+      `reconnectGraceSeconds`
+- [ ] 6.3 If the host does not respond within 60 seconds of the timeout
+      prompt, default behavior is `'replace-with-ai'`
+
+## 7. Identity-Gated Rejoin
+
+- [ ] 7.1 A reconnect with a `playerId` that does not match the
+      timed-out seat's last known occupant is rejected
+- [ ] 7.2 If the match has `replaced-by-ai` for that seat, the seat's
+      original `playerId` cannot reclaim it during the match
+- [ ] 7.3 The match meta retains the original `playerId` so
+      post-match summaries correctly attribute performance
+
+## 8. Multi-Device Reconnect
+
+- [ ] 8.1 If a player's old socket is still open and they reconnect
+      from a second device with the same `playerId`, the old socket
+      is closed first
+- [ ] 8.2 This supports "laptop → phone while afk" scenarios
+- [ ] 8.3 Close reason sent to old socket: `Close {reason: 'SUPERSEDED
+    _BY_NEW_SESSION'}`
+
+## 9. Client Auto-Reconnect
+
+- [ ] 9.1 `src/lib/multiplayer/client.ts` gains an auto-reconnect loop
+      with exponential backoff starting at 1s, cap 30s
+- [ ] 9.2 Client persists `lastSeq` in memory so reconnect resumes at
+      the right place
+- [ ] 9.3 Client emits `reconnecting` / `reconnected` / `reconnect-
+    failed` lifecycle events the UI can surface
+
+## 10. UI Indicators
+
+- [ ] 10.1 Combat page shows a banner when the match is paused:
+      `"Paused: waiting for <PlayerName> to reconnect (NN seconds
+    remaining)"`
+- [ ] 10.2 Seat pips in the scoreboard reflect `connectionStatus`
+      colors
+- [ ] 10.3 Host sees the grace-timeout prompt as a modal with the
+      three fallback options
+
+## 11. Tests
+
+- [ ] 11.1 Integration test: player disconnects mid-turn, match
+      pauses, player reconnects, match resumes at the same event
+- [ ] 11.2 Integration test: player times out; host selects `'replace-
+    with-ai'`, match resumes with a bot
+- [ ] 11.3 Integration test: player times out; host selects `'forfeit-
+    side'`, match ends cleanly
+- [ ] 11.4 Integration test: server restart with an active match;
+      client reconnects and receives the full log replay
+- [ ] 11.5 Integration test: multi-device reconnect closes the old
+      socket with `SUPERSEDED_BY_NEW_SESSION`
+
+## 12. Spec Compliance
+
+- [ ] 12.1 Every requirement in the `multiplayer-server` delta has at
+      least one GIVEN/WHEN/THEN scenario
+- [ ] 12.2 Every requirement in the `game-session-management` delta
+      has at least one GIVEN/WHEN/THEN scenario
+- [ ] 12.3 Every requirement in the `auto-save-persistence` delta has
+      at least one GIVEN/WHEN/THEN scenario
+- [ ] 12.4 `openspec validate add-reconnection-and-session-rehydration
+    --strict` passes clean

--- a/openspec/changes/add-reconnection-and-session-rehydration/tasks.md
+++ b/openspec/changes/add-reconnection-and-session-rehydration/tasks.md
@@ -3,7 +3,7 @@
 ## 1. Connection Lifecycle Model
 
 - [ ] 1.1 Extend `IMatchSeat` with `connectionStatus: 'connected' |
-    'pending' | 'timed-out' | 'replaced-by-ai'`
+'pending' | 'timed-out' | 'replaced-by-ai'`
 - [ ] 1.2 Transitions: on WebSocket attach → `connected`; on socket
       close → `pending`; on grace timer expiry → `timed-out`;
       post-fallback → `replaced-by-ai`
@@ -17,7 +17,7 @@
       reconnect
 - [ ] 2.3 Host may adjust the grace window via
       `Intent {kind: 'SetGraceWindow', seconds}`, clamped to `[30,
-    600]`; can NOT be adjusted once a timer is already running for
+600]`; can NOT be adjusted once a timer is already running for
       that seat
 
 ## 3. Server-Side Persistence Hooks
@@ -47,17 +47,17 @@
       server does NOT advance phases or process intents from other
       clients
 - [ ] 5.2 Exception: host can override with `Intent {kind: 'ProceedWith
-    outPending'}` — matches the 4b checkpoint's "AI fills empty
+outPending'}` — matches the 4b checkpoint's "AI fills empty
       slots" posture
 - [ ] 5.3 Paused matches broadcast an `Event {type: 'match_paused',
-    payload: {pendingSeats, graceRemaining}}`
+payload: {pendingSeats, graceRemaining}}`
 - [ ] 5.4 Resumed matches broadcast `Event {type: 'match_resumed'}`
 
 ## 6. Grace Timeout Fallback
 
 - [ ] 6.1 When a seat's grace timer expires, server sets
       `connectionStatus: 'timed-out'` and broadcasts a `match_seat_
-    timed_out` event
+timed_out` event
 - [ ] 6.2 Host receives an intent prompt offering three options: - `'forfeit-side'` → ends the match with the opposite side
       winning - `'replace-with-ai'` → marks the seat `replaced-by-ai`, spawns
       a bot, match resumes - `'wait-longer'` → extends the grace timer by another
@@ -81,7 +81,7 @@
       is closed first
 - [ ] 8.2 This supports "laptop → phone while afk" scenarios
 - [ ] 8.3 Close reason sent to old socket: `Close {reason: 'SUPERSEDED
-    _BY_NEW_SESSION'}`
+_BY_NEW_SESSION'}`
 
 ## 9. Client Auto-Reconnect
 
@@ -90,13 +90,13 @@
 - [ ] 9.2 Client persists `lastSeq` in memory so reconnect resumes at
       the right place
 - [ ] 9.3 Client emits `reconnecting` / `reconnected` / `reconnect-
-    failed` lifecycle events the UI can surface
+failed` lifecycle events the UI can surface
 
 ## 10. UI Indicators
 
 - [ ] 10.1 Combat page shows a banner when the match is paused:
       `"Paused: waiting for <PlayerName> to reconnect (NN seconds
-    remaining)"`
+remaining)"`
 - [ ] 10.2 Seat pips in the scoreboard reflect `connectionStatus`
       colors
 - [ ] 10.3 Host sees the grace-timeout prompt as a modal with the
@@ -107,9 +107,9 @@
 - [ ] 11.1 Integration test: player disconnects mid-turn, match
       pauses, player reconnects, match resumes at the same event
 - [ ] 11.2 Integration test: player times out; host selects `'replace-
-    with-ai'`, match resumes with a bot
+with-ai'`, match resumes with a bot
 - [ ] 11.3 Integration test: player times out; host selects `'forfeit-
-    side'`, match ends cleanly
+side'`, match ends cleanly
 - [ ] 11.4 Integration test: server restart with an active match;
       client reconnects and receives the full log replay
 - [ ] 11.5 Integration test: multi-device reconnect closes the old
@@ -124,4 +124,4 @@
 - [ ] 12.3 Every requirement in the `auto-save-persistence` delta has
       at least one GIVEN/WHEN/THEN scenario
 - [ ] 12.4 `openspec validate add-reconnection-and-session-rehydration
-    --strict` passes clean
+--strict` passes clean

--- a/openspec/changes/add-repair-queue-integration/proposal.md
+++ b/openspec/changes/add-repair-queue-integration/proposal.md
@@ -1,0 +1,60 @@
+# Change: Add Repair Queue Integration
+
+## Why
+
+After a battle, damaged mechs need to be repaired before they can deploy
+again. The campaign already has a repair/maintenance system (`repair/`,
+`repair-maintenance/` specs and the existing maintenance day-processor),
+and after Phase 3's earlier changes, units now have `IUnitCombatState`
+carrying real per-location damage and destroyed components. The missing
+link: no automatic hand-off from combat to repair. Currently, a player
+would have to manually create repair tickets per damaged location, per
+destroyed component — hundreds of items per battle. This change auto-enqueues
+all combat-sourced damage into the repair queue with expected duration
+and C-Bill cost estimates.
+
+## What Changes
+
+- Add `RepairQueueBuilder` — given a unit's `IUnitCombatState` and the
+  prior combat outcome, generate a full set of `IRepairTicket` entries
+  covering every armor-lost location, structure-lost location, destroyed
+  component, and ammo depletion
+- Each ticket carries: `unitId`, `location`, `workType` (armor / structure
+  / component / ammo), `cbillCost`, `expectedHours`, `techRatingRequired`,
+  `partsRequired`, `priority`, `source: "post_battle"`
+- Parts availability check — tickets that need parts (e.g., "replace
+  Medium Laser") integrate with the existing `acquisition-supply-chain`
+  system: if a salvage award or inventory entry satisfies the part, the
+  ticket's `partsRequired` is marked satisfied; otherwise the ticket blocks
+  on acquisition
+- Priority inference — CT-structure and engine-damage tickets get
+  `PRIORITY_CRITICAL`; head/cockpit tickets `PRIORITY_HIGH`; armor-only
+  tickets `PRIORITY_NORMAL`
+- Registered as new day-processor step: `repairQueueBuilderProcessor` fires
+  after `salvageProcessor` (so salvaged parts can satisfy repair ticket
+  parts requirements in the same day) and before `maintenanceProcessor`
+  (existing, handles ongoing repair ticks)
+
+## Dependencies
+
+- **Requires**: `add-combat-outcome-model`, `add-post-battle-processor`
+  (populates `IUnitCombatState`), `add-salvage-rules-engine` (parts pool)
+- **Requires (Phase 1 A1–A7)**: correct damage resolution so tickets match
+  actual damage
+- **Required By**: `add-post-battle-review-ui` (shows the queue summary),
+  `wire-encounter-to-campaign-round-trip`
+
+## Impact
+
+- Affected specs: `damage-system` (MODIFIED — damage state feeds repair
+  queue), `repair-maintenance` (MODIFIED — post-battle ticket source),
+  `acquisition-supply-chain` (MODIFIED — parts requirements surface from
+  tickets)
+- Affected code: new
+  `src/lib/campaign/repair/repairQueueBuilder.ts`, new
+  `src/lib/campaign/processors/repairQueueBuilderProcessor.ts`, extends
+  the existing repair ticket model with `source` and `expectedHours` fields
+  if absent
+- Non-goals: actual repair simulation (existing maintenance processor
+  handles that), BTech-accurate tech-rating distribution (existing repair
+  system), UI for manual ticket management (existing)

--- a/openspec/changes/add-repair-queue-integration/specs/acquisition-supply-chain/spec.md
+++ b/openspec/changes/add-repair-queue-integration/specs/acquisition-supply-chain/spec.md
@@ -1,0 +1,59 @@
+# acquisition-supply-chain Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Repair Tickets Declare Part Requirements
+
+Every `IRepairTicket` with `workType = "component"` or `workType = "armor"` SHALL declare a `partsRequired` list so the acquisition system can surface unmet demand.
+
+#### Scenario: Component ticket declares part
+
+- **GIVEN** a component ticket to reinstall a Medium Laser
+- **WHEN** the ticket is built
+- **THEN** `partsRequired` SHALL contain
+  `{ partName: "Medium Laser", quantity: 1, matched: false }`
+
+#### Scenario: Armor ticket declares armor tonnage
+
+- **GIVEN** an armor ticket for 10 points of standard IS armor
+- **WHEN** the ticket is built
+- **THEN** `partsRequired` SHALL contain
+  `{ partName: "Armor (Standard IS)", quantity: 10, matched: false }`
+
+### Requirement: Inventory Matching Prioritizes Salvage
+
+The queue builder SHALL attempt to satisfy each `partsRequired` entry from
+campaign inventory, prioritizing items tagged `source: "salvage"` before
+general inventory.
+
+#### Scenario: Salvage item satisfies requirement first
+
+- **GIVEN** a repair ticket requiring 1 Medium Laser and an inventory
+  containing 1 salvaged Medium Laser and 1 purchased Medium Laser
+- **WHEN** `matchPartsRequired(tickets, inventory)` runs
+- **THEN** the ticket SHALL be matched against the salvaged Medium Laser
+  first
+- **AND** `matchedFromInventoryId` SHALL reference the salvaged item
+- **AND** the purchased Medium Laser SHALL remain in inventory
+
+#### Scenario: Unmatched requirement surfaces to acquisition
+
+- **GIVEN** a ticket requiring a part with no matching inventory entry
+- **WHEN** `matchPartsRequired` runs
+- **THEN** the ticket's `partsRequired` entry SHALL retain
+  `matched = false`
+- **AND** the acquisition system SHALL be able to enumerate all
+  unmatched requirements across all open tickets for procurement
+  planning
+
+### Requirement: Matched Parts Consumed On Repair Start
+
+Matched inventory items SHALL be reserved (and unavailable to other tickets) when a repair ticket with fully-matched `partsRequired` begins work.
+
+#### Scenario: Reserved part is not reusable
+
+- **GIVEN** a ticket with a matched Medium Laser reserved from inventory
+- **WHEN** another ticket's `matchPartsRequired` pass runs
+- **THEN** the reserved Medium Laser SHALL NOT be available for matching
+- **AND** the other ticket SHALL show the unmatched Medium Laser
+  requirement until additional inventory arrives

--- a/openspec/changes/add-repair-queue-integration/specs/damage-system/spec.md
+++ b/openspec/changes/add-repair-queue-integration/specs/damage-system/spec.md
@@ -1,0 +1,89 @@
+# damage-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Damage State Drives Repair Ticket Generation
+
+The `IUnitCombatState` produced by the `PostBattleProcessor` SHALL be the
+canonical input to the repair queue builder, which SHALL produce one or
+more `IRepairTicket` entries covering every non-zero damage artifact on
+the unit.
+
+#### Scenario: Armor loss produces one armor ticket per location
+
+- **GIVEN** a combat state with `currentArmorPerLocation = { LT: -10 }`
+  (10 points lost)
+- **WHEN** `buildTickets(unit, state, outcome)` is called
+- **THEN** the result SHALL contain exactly one ticket with
+  `workType = "armor"`, `location = LT`, `partsRequired` reflecting 10
+  armor points of the unit's armor type
+
+#### Scenario: Structure loss produces one structure ticket per location
+
+- **GIVEN** a combat state with structure lost in RT and CT
+- **WHEN** `buildTickets` is called
+- **THEN** the result SHALL contain one `workType = "structure"` ticket
+  for RT and one for CT
+
+#### Scenario: Destroyed component produces one component ticket per entry
+
+- **GIVEN** a combat state with `destroyedComponents` containing a
+  Medium Laser in RA and a Heat Sink in LT
+- **WHEN** `buildTickets` is called
+- **THEN** the result SHALL contain two `workType = "component"` tickets
+
+#### Scenario: Ammo depletion produces one ammo ticket per ammo type
+
+- **GIVEN** a combat state with `ammoRemaining` showing 8 LRM rounds (max 16) and 12 AC/20 rounds (max 12)
+- **WHEN** `buildTickets` is called
+- **THEN** the result SHALL contain exactly one `workType = "ammo"`
+  ticket for LRM ammo (AC/20 is at full, no ticket)
+
+### Requirement: Repair Priority From Damage Severity
+
+Each repair ticket's priority SHALL be derived from the component and
+location affected.
+
+#### Scenario: CT structure is CRITICAL priority
+
+- **GIVEN** a ticket for structure loss in CT
+- **WHEN** priority is derived
+- **THEN** the ticket's priority SHALL be `CRITICAL`
+
+#### Scenario: Engine/gyro/life-support are CRITICAL
+
+- **GIVEN** a destroyed-component ticket for engine, gyro, or life support
+- **WHEN** priority is derived
+- **THEN** the ticket's priority SHALL be `CRITICAL`
+
+#### Scenario: Cockpit/sensors are HIGH
+
+- **GIVEN** a destroyed-component ticket for cockpit or sensors, or a
+  structure ticket for head
+- **WHEN** priority is derived
+- **THEN** the ticket's priority SHALL be `HIGH`
+
+#### Scenario: Armor tickets are NORMAL
+
+- **GIVEN** a ticket with `workType = "armor"`
+- **WHEN** priority is derived
+- **THEN** the ticket's priority SHALL be `NORMAL`
+
+#### Scenario: Ammo tickets are LOW
+
+- **GIVEN** a ticket with `workType = "ammo"`
+- **WHEN** priority is derived
+- **THEN** the ticket's priority SHALL be `LOW`
+
+### Requirement: Destroyed Units Produce No Tickets
+
+A unit with `finalStatus = DESTROYED` SHALL NOT produce any repair
+tickets; the unit is a write-off and a salvage-only candidate.
+
+#### Scenario: Destroyed unit is skipped
+
+- **GIVEN** a unit with `finalStatus = DESTROYED` in the outcome
+- **WHEN** the repair queue builder runs over the roster
+- **THEN** no tickets SHALL be generated for that unit
+- **AND** the unit SHALL be flagged `combatReady = false` permanently until
+  manual intervention or salvage

--- a/openspec/changes/add-repair-queue-integration/specs/repair-maintenance/spec.md
+++ b/openspec/changes/add-repair-queue-integration/specs/repair-maintenance/spec.md
@@ -1,0 +1,82 @@
+# repair-maintenance Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Post-Battle Ticket Source
+
+The `IRepairTicket` model SHALL carry a `source` field distinguishing
+`"post_battle"` tickets (created by the repair queue builder) from
+`"maintenance"` tickets (periodic wear-and-tear) and `"manual"` tickets
+(user-created).
+
+#### Scenario: Post-battle tickets are tagged
+
+- **GIVEN** a `repairQueueBuilderProcessor` run that creates tickets from
+  an outcome
+- **WHEN** the tickets are persisted
+- **THEN** each ticket's `source` SHALL be `"post_battle"`
+- **AND** each ticket's `sourceBattleId` SHALL equal the outcome's
+  `matchId`
+
+#### Scenario: Manual tickets are distinguishable
+
+- **GIVEN** a ticket the user created via the manual-repair UI
+- **WHEN** the ticket is persisted
+- **THEN** `source` SHALL be `"manual"`
+- **AND** `sourceBattleId` SHALL be `null`
+
+### Requirement: Idempotent Queue Building Per Battle
+
+The repair queue builder SHALL be idempotent per `{unitId, matchId}`.
+Rerunning after the tickets have already been created SHALL NOT produce
+duplicates.
+
+#### Scenario: Same unit, same battle yields no duplicate tickets
+
+- **GIVEN** a campaign where unit U has post-battle tickets from match M
+  already enqueued
+- **WHEN** `repairQueueBuilderProcessor` runs again for the same unit and
+  match
+- **THEN** no additional tickets SHALL be enqueued
+- **AND** the processor SHALL skip unit U for match M
+
+#### Scenario: Same unit, different battle yields new tickets
+
+- **GIVEN** a unit with post-battle tickets from match M1
+- **WHEN** the processor runs for a new match M2 on the same unit
+- **THEN** tickets for M2 SHALL be created
+- **AND** M1 tickets SHALL remain untouched
+
+### Requirement: Ticket Hour Estimation
+
+Each ticket SHALL include an `expectedHours` estimate computed from a
+repair-hours table per damage type.
+
+#### Scenario: Armor point hours
+
+- **GIVEN** a ticket to replace 10 armor points
+- **WHEN** the ticket is built
+- **THEN** `expectedHours` SHALL equal `10 × ARMOR_HOURS_PER_POINT`
+  from the repair-hours table
+
+#### Scenario: Component hours
+
+- **GIVEN** a ticket to reinstall a Medium Laser
+- **WHEN** the ticket is built
+- **THEN** `expectedHours` SHALL equal the Medium Laser's install-hours
+  value from the repair-hours table (or its weight-tier default when a
+  component-specific value is not defined)
+
+### Requirement: Runs Between Salvage And Maintenance
+
+The `repairQueueBuilderProcessor` SHALL run after the `salvageProcessor`
+and before the existing `maintenanceProcessor` in the day pipeline.
+
+#### Scenario: Ordering in day pipeline
+
+- **GIVEN** a day advancement that includes `salvageProcessor`,
+  `repairQueueBuilderProcessor`, and `maintenanceProcessor`
+- **WHEN** the pipeline executes
+- **THEN** the processors SHALL execute in the order
+  salvage → repair queue builder → maintenance
+- **AND** the ordering SHALL be documented in `dayPipeline.ts`

--- a/openspec/changes/add-repair-queue-integration/tasks.md
+++ b/openspec/changes/add-repair-queue-integration/tasks.md
@@ -1,0 +1,118 @@
+# Tasks: Add Repair Queue Integration
+
+## 1. Type Definitions
+
+- [ ] 1.1 Define/extend `IRepairTicket` with `source` (`"post_battle" |
+    "maintenance" | "manual"`), `workType` (`"armor" | "structure" |
+    "component" | "ammo"`), `expectedHours`, `priority`,
+      `partsRequired`, `sourceBattleId`
+- [ ] 1.2 Define `RepairPriority` enum: `CRITICAL`, `HIGH`, `NORMAL`, `LOW`
+- [ ] 1.3 Define `IRepairPartRequirement` with `partName`, `quantity`,
+      `matched` (`boolean`), `matchedFromInventoryId`
+
+## 2. Queue Builder Core
+
+- [ ] 2.1 Create `src/lib/campaign/repair/repairQueueBuilder.ts`
+- [ ] 2.2 Export `buildTickets(unit, combatState, outcome): IRepairTicket[]`
+- [ ] 2.3 Return tickets sorted by priority descending
+
+## 3. Armor Ticket Generation
+
+- [ ] 3.1 For each location with `armorLostPerLocation > 0`: create one
+      `workType: "armor"` ticket per location
+- [ ] 3.2 `cbillCost` = armor-lost × armor C-Bill cost per point (per tech
+      rating + armor type)
+- [ ] 3.3 `expectedHours` = armor-lost × hours-per-armor-point from repair
+      table
+- [ ] 3.4 Priority = `NORMAL`
+- [ ] 3.5 `partsRequired` = `[{ partName: "Armor (<type>)", quantity:
+    armor-lost, matched: false }]`
+
+## 4. Structure Ticket Generation
+
+- [ ] 4.1 For each location with `structureLostPerLocation > 0`: create
+      one `workType: "structure"` ticket
+- [ ] 4.2 `cbillCost` = structure-lost × structure C-Bill cost per point
+- [ ] 4.3 `expectedHours` = structure-lost × hours-per-structure-point
+- [ ] 4.4 Priority = `CRITICAL` if location is CT, `HIGH` if side torso,
+      else `NORMAL`
+
+## 5. Destroyed Component Ticket Generation
+
+- [ ] 5.1 For each entry in `destroyedComponents`: create one
+      `workType: "component"` ticket
+- [ ] 5.2 `cbillCost` = component market value × (0.5 for salvage-match
+      discount, else 1.0)
+- [ ] 5.3 `expectedHours` = component install hours from repair table
+- [ ] 5.4 Priority = `CRITICAL` for engine/gyro/life support, `HIGH` for
+      cockpit/sensors, `NORMAL` for weapons/heat sinks
+- [ ] 5.5 `partsRequired` = `[{ partName: component name, quantity: 1,
+    matched: false }]`
+
+## 6. Ammo Ticket Generation
+
+- [ ] 6.1 For each ammo type with `ammoRemaining < construction max`:
+      create one `workType: "ammo"` ticket per ammo type
+- [ ] 6.2 `cbillCost` = missing-rounds × market-price-per-round
+- [ ] 6.3 `expectedHours` = 1 hour per ton of ammo replaced (quick install)
+- [ ] 6.4 Priority = `LOW` (mech can still deploy with partial ammo)
+
+## 7. Parts Match Against Inventory
+
+- [ ] 7.1 `matchPartsRequired(tickets, inventory)` — scan each ticket's
+      `partsRequired`; if an inventory item with matching name and
+      sufficient quantity exists, mark `matched = true` and record source
+- [ ] 7.2 Salvage awards tagged `source: "salvage"` in inventory are
+      prioritized for matching (consumes salvage first)
+- [ ] 7.3 Return count of unmatched requirements per ticket
+
+## 8. Repair Queue Builder Processor
+
+- [ ] 8.1 Create `src/lib/campaign/processors/repairQueueBuilderProcessor.ts`
+- [ ] 8.2 Runs AFTER `salvageProcessor` (so salvage inventory is populated
+      before matching)
+- [ ] 8.3 Runs BEFORE `maintenanceProcessor` (so new tickets can be ticked
+      down on the same day)
+- [ ] 8.4 For each unit on the player's roster with `IUnitCombatState`
+      updated this turnover: call `buildTickets`, then `matchPartsRequired`,
+      then enqueue into the existing repair queue
+- [ ] 8.5 Fire `RepairTicketsCreated` event with ticket count and total
+      cost per unit
+- [ ] 8.6 Idempotency: compound key `{unitId, sourceBattleId}` — skip
+      unit/battle combinations already processed
+
+## 9. Integration with Existing Repair System
+
+- [ ] 9.1 Use existing repair ticket repository if present — do NOT create
+      a parallel store
+- [ ] 9.2 If the existing `IRepairTicket` lacks any new fields (e.g.,
+      `source`, `sourceBattleId`), extend the model and migrate existing
+      tickets with default `source: "manual"`
+- [ ] 9.3 Existing `maintenance` day processor ticks down `expectedHours`
+      on all tickets regardless of source
+
+## 10. Tests
+
+- [ ] 10.1 Unit: 10 armor lost → one armor ticket with cost = 10 × rate,
+      hours = 10 × hours-rate
+- [ ] 10.2 Unit: CT structure lost → priority CRITICAL ticket
+- [ ] 10.3 Unit: Destroyed engine → priority CRITICAL ticket, partsRequired
+      = `[{ partName: "Engine", quantity: 1 }]`
+- [ ] 10.4 Unit: Ammo depletion → LOW-priority ammo ticket per ammo type
+- [ ] 10.5 Unit: Parts match against salvage inventory first, then general
+      inventory
+- [ ] 10.6 Integration: Full outcome → postBattle → salvage → repairQueue
+      → matched tickets in queue
+- [ ] 10.7 Regression: Same outcome + same state → idempotent; second run
+      adds no new tickets
+
+## 11. Error Handling & Edge Cases
+
+- [ ] 11.1 Unit with `finalStatus: DESTROYED` → NO tickets (the unit is
+      written off; no repair possible)
+- [ ] 11.2 Missing market price for a salvageable part → fall back to
+      book value from equipment database; log warning if that's also
+      missing
+- [ ] 11.3 Extremely damaged unit (all locations crippled) → generate
+      tickets but flag the unit record with `writeOffRecommended: true`
+      for UI surfacing

--- a/openspec/changes/add-repair-queue-integration/tasks.md
+++ b/openspec/changes/add-repair-queue-integration/tasks.md
@@ -3,8 +3,8 @@
 ## 1. Type Definitions
 
 - [ ] 1.1 Define/extend `IRepairTicket` with `source` (`"post_battle" |
-    "maintenance" | "manual"`), `workType` (`"armor" | "structure" |
-    "component" | "ammo"`), `expectedHours`, `priority`,
+"maintenance" | "manual"`), `workType` (`"armor" | "structure" |
+"component" | "ammo"`), `expectedHours`, `priority`,
       `partsRequired`, `sourceBattleId`
 - [ ] 1.2 Define `RepairPriority` enum: `CRITICAL`, `HIGH`, `NORMAL`, `LOW`
 - [ ] 1.3 Define `IRepairPartRequirement` with `partName`, `quantity`,
@@ -26,7 +26,7 @@
       table
 - [ ] 3.4 Priority = `NORMAL`
 - [ ] 3.5 `partsRequired` = `[{ partName: "Armor (<type>)", quantity:
-    armor-lost, matched: false }]`
+armor-lost, matched: false }]`
 
 ## 4. Structure Ticket Generation
 
@@ -47,7 +47,7 @@
 - [ ] 5.4 Priority = `CRITICAL` for engine/gyro/life support, `HIGH` for
       cockpit/sensors, `NORMAL` for weapons/heat sinks
 - [ ] 5.5 `partsRequired` = `[{ partName: component name, quantity: 1,
-    matched: false }]`
+matched: false }]`
 
 ## 6. Ammo Ticket Generation
 

--- a/openspec/changes/add-salvage-rules-engine/proposal.md
+++ b/openspec/changes/add-salvage-rules-engine/proposal.md
@@ -1,0 +1,57 @@
+# Change: Add Salvage Rules Engine
+
+## Why
+
+Total Warfare and Campaign Operations define how a battle's wreckage is
+divided between employer and mercenary — salvage rights clauses in
+contracts, hostile-territory withdrawal modifiers, damaged-mech percentage
+values. Without this engine, a successful battle produces no downstream
+economic upside: no captured mechs, no parts for repair, no auction with
+the employer. The Phase 1 engine already produces `ICombatOutcome` with
+destroyed units and destroyed-component lists; this change turns that raw
+casualty data into a divided salvage pool with per-side awards.
+
+## What Changes
+
+- Add `salvage-rules` capability — new spec under `openspec/specs/`
+- Add `ISalvagePool` — aggregated from all enemy units with `finalStatus`
+  of `DAMAGED`, `CRIPPLED`, `DESTROYED`, or `EJECTED`; contains recoverable
+  units and recoverable parts (from destroyed-component lists)
+- Add `ISalvageAward` per side (employer + mercenary) — list of units and
+  parts awarded with estimated repair cost and market value
+- Add `computeSalvage(outcome, contract, terrain): ISalvageAllocation` —
+  applies Total Warfare salvage value tables (100% for intact, 75% for
+  damaged, 50% for crippled, 25% for destroyed), contract salvage split
+  (from `contract.salvageRights` — 0%-100%), and hostile-territory modifier
+  (salvage halved if player withdraws from hostile territory)
+- Add auction mechanic — when contract splits are not explicit (e.g., "50/50
+  exchange"), engine enters bid-exchange: employer picks first unit, mercenary
+  picks next, alternating until pool exhausted, weighted by BV
+- Add `salvageProcessor` — day-processor step that consumes
+  `ICombatOutcome.salvageAllocation` (populated by `PostBattleProcessor`)
+  and creates inventory entries for awarded units/parts via existing
+  `acquisitionProcessor` rails
+
+## Dependencies
+
+- **Requires**: `add-combat-outcome-model`, `add-post-battle-processor`
+- **Requires (Phase 1 A1–A7)**: correct damage/crit resolution in outcome so
+  unit final-status classification is trustworthy
+- **Required By**: `add-repair-queue-integration` (awarded damaged units
+  flow directly into repair queue), `add-post-battle-review-ui` (displays
+  salvage awarded), `wire-encounter-to-campaign-round-trip` (end-to-end)
+
+## Impact
+
+- Affected specs: new `salvage-rules` (ADDED — this is a new capability),
+  `mission-contracts` (MODIFIED — salvage rights clauses now drive
+  allocation)
+- Affected code: new `src/lib/campaign/salvage/salvageEngine.ts`, new
+  `src/types/campaign/Salvage.ts`, new
+  `src/lib/campaign/processors/salvageProcessor.ts`, extends
+  `contractMarket.ts` with `salvageRights` field on contract records if
+  not already present
+- Non-goals: repair queue entry creation (that's
+  `add-repair-queue-integration`), visual UI (that's
+  `add-post-battle-review-ui`), selling salvage on markets (existing
+  markets system handles that once inventory is populated)

--- a/openspec/changes/add-salvage-rules-engine/specs/mission-contracts/spec.md
+++ b/openspec/changes/add-salvage-rules-engine/specs/mission-contracts/spec.md
@@ -1,0 +1,46 @@
+# mission-contracts Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Contract Salvage Rights Clause
+
+Each contract SHALL carry a `salvageRights` field representing the
+mercenary percentage of salvage value (0–100).
+
+#### Scenario: Default salvage rights
+
+- **GIVEN** a newly generated contract without an overriding negotiation
+  result
+- **WHEN** its `salvageRights` field is inspected
+- **THEN** the field SHALL be a number in the range 0–100
+- **AND** typical default SHALL be between 0 (garrison) and 50 (objective
+  raid) per AtB defaults
+
+#### Scenario: Negotiated salvage rights
+
+- **GIVEN** a contract negotiation that succeeded on the salvage clause
+- **WHEN** the contract is created
+- **THEN** `salvageRights` SHALL reflect the negotiated percentage
+- **AND** the value SHALL remain clamped to the 0–100 range
+
+### Requirement: Contract Exchange Salvage Flag
+
+Each contract SHALL carry a boolean `exchangeSalvage` field indicating
+whether salvage uses the alternating-draft exchange rules instead of a
+straight percentage split.
+
+#### Scenario: Exchange salvage triggers auction split
+
+- **GIVEN** a contract with `exchangeSalvage = true`
+- **WHEN** `computeSalvage(outcome, contract, terrain)` is called
+- **THEN** the salvage engine SHALL use the auction-style draft split
+  instead of the contract-percentage split
+- **AND** `allocation.splitMethod` SHALL equal `"auction"`
+
+#### Scenario: Non-exchange contract uses percentage split
+
+- **GIVEN** a contract with `exchangeSalvage = false`
+- **WHEN** `computeSalvage` is called
+- **THEN** the salvage engine SHALL use the percentage-based contract
+  split
+- **AND** `allocation.splitMethod` SHALL equal `"contract"`

--- a/openspec/changes/add-salvage-rules-engine/specs/salvage-rules/spec.md
+++ b/openspec/changes/add-salvage-rules-engine/specs/salvage-rules/spec.md
@@ -1,0 +1,179 @@
+# salvage-rules Specification
+
+## ADDED Requirements
+
+### Requirement: Salvage Candidate Aggregation
+
+The salvage engine SHALL aggregate `ISalvageCandidate` entries from every
+enemy-side unit in a completed battle's `ICombatOutcome`, producing a single
+`ISalvagePool` per battle.
+
+#### Scenario: Non-INTACT enemy unit becomes a candidate
+
+- **GIVEN** an enemy unit with `finalStatus = DAMAGED` in the outcome
+- **WHEN** `aggregateSalvageCandidates(outcome)` is called
+- **THEN** the pool SHALL contain a candidate with `source = "unit"` and
+  `unitId` equal to the casualty's unitId
+- **AND** `recoveryPercentage` SHALL reflect the damage level per the
+  salvage table
+
+#### Scenario: Destroyed unit contributes salvageable parts
+
+- **GIVEN** an enemy unit with `finalStatus = DESTROYED` whose
+  `destroyedComponents` include a Medium Laser
+- **WHEN** `aggregateSalvageCandidates(outcome)` is called
+- **THEN** the pool SHALL contain a candidate for the Medium Laser with
+  `source = "part"`
+- **AND** a unit-level candidate SHALL exist with
+  `recoveryPercentage = 0` (unit cannot be recovered as a chassis)
+
+#### Scenario: Engine and gyro are not salvageable
+
+- **GIVEN** an enemy unit with destroyed engine and gyro components
+- **WHEN** `aggregateSalvageCandidates(outcome)` is called
+- **THEN** no part candidate SHALL be created for engine or gyro
+- **AND** no part candidate SHALL be created for internal-structure entries
+
+#### Scenario: INTACT enemy unit produces no candidate
+
+- **GIVEN** an enemy unit with `finalStatus = INTACT` (retreated
+  undamaged)
+- **WHEN** `aggregateSalvageCandidates(outcome)` is called
+- **THEN** the pool SHALL NOT contain a candidate for that unit
+
+### Requirement: Recovery Percentage By Damage Level
+
+The salvage engine SHALL apply canonical recovery percentages per Total
+Warfare and Campaign Operations damage tables.
+
+#### Scenario: Recovery percentage values
+
+- **GIVEN** a unit whose damage has been classified
+- **WHEN** `computeRecoveryPercentage(damageLevel)` is called
+- **THEN** INTACT SHALL return 1.00
+- **AND** LIGHT SHALL return 0.75
+- **AND** MODERATE SHALL return 0.50
+- **AND** HEAVY SHALL return 0.25
+- **AND** DESTROYED SHALL return 0.00
+
+#### Scenario: Damage level classification
+
+- **GIVEN** a casualty with known structure-lost percentage
+- **WHEN** `classifyDamageLevel(casualty)` is called
+- **THEN** no armor lost SHALL classify as INTACT
+- **AND** under 30% structure lost SHALL classify as LIGHT
+- **AND** 30%–60% structure lost SHALL classify as MODERATE
+- **AND** 60%–99% structure lost SHALL classify as HEAVY
+- **AND** 100% structure lost or CT destroyed SHALL classify as DESTROYED
+
+### Requirement: Contract-Driven Salvage Split
+
+The salvage engine SHALL split the pool between employer and mercenary
+using the contract's `salvageRights` clause (mercenary percentage 0–100)
+when the contract does not call for exchange.
+
+#### Scenario: 60% mercenary rights
+
+- **GIVEN** a pool with total value 1,000,000 C-Bills and a contract with
+  `salvageRights = 60`
+- **WHEN** `splitByContract(pool, 60)` is called
+- **THEN** the mercenary award total SHALL be within 10% of 600,000
+- **AND** the employer award total SHALL be within 10% of 400,000
+
+#### Scenario: Deterministic contract split
+
+- **GIVEN** the same pool and `salvageRights` value
+- **WHEN** `splitByContract` is called twice
+- **THEN** both allocations SHALL be deeply equal
+
+#### Scenario: Zero mercenary rights
+
+- **GIVEN** a contract with `salvageRights = 0`
+- **WHEN** `splitByContract` is called
+- **THEN** the mercenary award SHALL be empty
+- **AND** the employer award SHALL contain every candidate
+
+### Requirement: Auction-Style Exchange Split
+
+The salvage engine SHALL perform a seeded, alternating draft when the
+contract specifies `exchangeSalvage = true`.
+
+#### Scenario: Drafting order
+
+- **GIVEN** a pool of 6 candidates sorted by recovered value
+- **WHEN** `splitByAuction(pool, seed)` is called
+- **THEN** the employer SHALL pick the 1st, 3rd, and 5th
+- **AND** the mercenary SHALL pick the 2nd, 4th, and 6th
+- **AND** rerunning with the same pool and seed SHALL produce the same
+  allocation
+
+### Requirement: Hostile Territory Withdrawal Modifier
+
+The salvage engine SHALL halve the mercenary award when the player
+withdrew from hostile territory (`outcome.endReason = WITHDRAWAL` and
+`pool.hostileTerritory = true`).
+
+#### Scenario: Withdrawal from hostile territory
+
+- **GIVEN** an outcome with `endReason = WITHDRAWAL` and a pool marked
+  `hostileTerritory = true`
+- **WHEN** `computeSalvage(outcome, contract, terrain)` is called
+- **THEN** the mercenary award total value SHALL be no more than 50% of
+  what the contract split alone would produce
+- **AND** `allocation.splitMethod` SHALL equal `"hostile_withdrawal"`
+
+#### Scenario: No modifier when friendly territory
+
+- **GIVEN** an outcome with `endReason = WITHDRAWAL` and
+  `hostileTerritory = false`
+- **WHEN** `computeSalvage` is called
+- **THEN** no modifier SHALL be applied
+- **AND** the standard contract split SHALL produce the allocation
+
+### Requirement: Repair Cost Estimation Per Award
+
+The salvage engine SHALL compute an `estimatedRepairCost` on each
+`ISalvageAward` so campaign UIs can surface restoration cost without
+invoking the full repair system.
+
+#### Scenario: Repair cost for damaged unit
+
+- **GIVEN** an award containing one MODERATE-damaged 50-ton mech
+- **WHEN** `estimateRepairCost` is called on the award
+- **THEN** the returned cost SHALL equal `50 × MODERATE_CBILLS_PER_TON`
+  per the Campaign Ops table
+- **AND** the cost SHALL be a positive integer
+
+#### Scenario: Repair cost aggregates across candidates
+
+- **GIVEN** an award with 2 unit candidates and 3 part candidates
+- **WHEN** `estimateRepairCost` is called
+- **THEN** the returned value SHALL equal the sum of individual candidate
+  costs
+
+### Requirement: Standalone Skirmish Yields Empty Allocation
+
+A battle without a contract (standalone skirmish) SHALL produce an empty
+salvage allocation — the player keeps nothing and owes nothing.
+
+#### Scenario: No contractId in outcome
+
+- **GIVEN** an `ICombatOutcome` with `contractId = null`
+- **WHEN** `computeSalvage(outcome, null, terrain)` is called
+- **THEN** the returned allocation SHALL have an empty pool
+- **AND** both `employerAward.candidates` and `mercenaryAward.candidates`
+  SHALL be empty arrays
+
+### Requirement: Idempotent Salvage Processor
+
+The `salvageProcessor` SHALL be idempotent — reprocessing the same
+allocation in a subsequent day advancement SHALL NOT duplicate inventory
+entries.
+
+#### Scenario: Re-processing is a no-op
+
+- **GIVEN** a campaign where `salvageProcessor` has already converted a
+  mercenary award into inventory
+- **WHEN** the processor runs again with the same allocation
+- **THEN** no additional inventory entries SHALL be created
+- **AND** the allocation SHALL be marked `processed = true`

--- a/openspec/changes/add-salvage-rules-engine/tasks.md
+++ b/openspec/changes/add-salvage-rules-engine/tasks.md
@@ -1,0 +1,111 @@
+# Tasks: Add Salvage Rules Engine
+
+## 1. Type Definitions
+
+- [ ] 1.1 Create `src/types/campaign/Salvage.ts`
+- [ ] 1.2 Define `ISalvagePool` with `battleId`, `candidates: ISalvageCandidate[]`,
+      `totalEstimatedValue`, `hostileTerritory`
+- [ ] 1.3 Define `ISalvageCandidate` with `source` (`"unit" | "part"`),
+      `unitId`, `partId`, `originalValue`, `recoveredValue`,
+      `recoveryPercentage`, `location` (for part), `damageLevel`
+- [ ] 1.4 Define `ISalvageAllocation` with `pool`, `employerAward`,
+      `mercenaryAward`, `splitMethod` (`"contract" | "auction" |
+    "hostile_withdrawal"`)
+- [ ] 1.5 Define `ISalvageAward` with `candidates: ISalvageCandidate[]`,
+      `totalValue`, `estimatedRepairCost`
+- [ ] 1.6 Define `DamageLevel` enum: `INTACT`, `LIGHT`, `MODERATE`,
+      `HEAVY`, `DESTROYED`
+
+## 2. Candidate Aggregation
+
+- [ ] 2.1 `aggregateSalvageCandidates(outcome): ISalvageCandidate[]`
+- [ ] 2.2 For each enemy-side `IUnitCasualty` with `finalStatus !== INTACT`:
+      create a unit candidate with `recoveryPercentage` from damage table
+- [ ] 2.3 For each destroyed-component entry on enemy units: create a part
+      candidate (weapons, ammo bins, and heat sinks are salvageable; engine,
+      gyro, internal structure damage is NOT — these are destroyed outright)
+- [ ] 2.4 `computeRecoveryPercentage(damageLevel)`: INTACT→1.0,
+      LIGHT→0.75, MODERATE→0.5, HEAVY→0.25, DESTROYED→0 (unit is gone but
+      parts may remain)
+- [ ] 2.5 `classifyDamageLevel(casualty)`:
+      INTACT if no armor lost, LIGHT if <30% structure lost, MODERATE if
+      30–60%, HEAVY if 60–99%, DESTROYED if 100% or CT destroyed
+
+## 3. Contract-Driven Split
+
+- [ ] 3.1 `splitByContract(pool, salvageRights): ISalvageAllocation`
+- [ ] 3.2 `salvageRights` is 0–100 (mercenary percentage); employer gets the
+      remainder
+- [ ] 3.3 Greedy value-weighted split: sort candidates by `recoveredValue`
+      desc, distribute alternately starting with the higher-allocation side
+      while respecting total-value targets within 10%
+- [ ] 3.4 Deterministic — same pool + same rights SHALL produce deep-equal
+      allocation
+- [ ] 3.5 Fire `SalvageAllocated` event
+
+## 4. Auction / Exchange Split
+
+- [ ] 4.1 `splitByAuction(pool, seed): ISalvageAllocation`
+- [ ] 4.2 Used when contract specifies `exchangeSalvage: true` (50/50 by
+      value with drafting)
+- [ ] 4.3 Draft order — sort candidates by BV (unit) or market value
+      (parts), employer picks first (employer-priority in AtB), alternate
+- [ ] 4.4 Seeded RNG for tie-breaks (same pool + same seed = same result)
+
+## 5. Hostile Territory Modifier
+
+- [ ] 5.1 `applyHostileTerritoryModifier(allocation, outcome)`
+- [ ] 5.2 If player withdrew (`endReason: WITHDRAWAL`) from hostile
+      territory, mercenary salvage is halved (remaining half stays on the
+      battlefield — awarded to employer or lost)
+- [ ] 5.3 Flag allocation with `splitMethod: "hostile_withdrawal"`
+
+## 6. Repair Cost Estimation
+
+- [ ] 6.1 `estimateRepairCost(candidate, techRating)`: unit tons × damage
+      level × C-Bill per ton per damage-level table (per Campaign Ops)
+- [ ] 6.2 Part repair cost = (original price × (1 - recoveryPercentage))
+- [ ] 6.3 Aggregate per award to produce `estimatedRepairCost`
+
+## 7. Salvage Engine Entry Point
+
+- [ ] 7.1 Create `src/lib/campaign/salvage/salvageEngine.ts`
+- [ ] 7.2 Export `computeSalvage(outcome, contract, terrain): ISalvageAllocation`
+- [ ] 7.3 If `outcome.contractId` is null (standalone skirmish), return
+      empty allocation
+- [ ] 7.4 Dispatch to contract, auction, or hostile-withdrawal branch based
+      on contract clauses and outcome
+
+## 8. Salvage Processor (Day Pipeline)
+
+- [ ] 8.1 Create `src/lib/campaign/processors/salvageProcessor.ts`
+- [ ] 8.2 Runs AFTER `postBattleProcessor` (needs the outcome-derived data)
+- [ ] 8.3 For each processed outcome in the day's `processedBattleIds`,
+      look up the persisted `ISalvageAllocation`
+- [ ] 8.4 For each mercenary-award candidate: create a campaign inventory
+      entry via existing `acquisitionProcessor` rails (as if acquired) but
+      with `source: "salvage"` tag
+- [ ] 8.5 For damaged-unit candidates: create the unit in the roster with
+      its `IUnitCombatState` set to the damage snapshot from the outcome
+- [ ] 8.6 Fire `SalvageCollected` event with award summary
+
+## 9. Tests
+
+- [ ] 9.1 Unit: Contract-split 60% mercenary on a 4-unit pool → 60% of
+      total value allocated
+- [ ] 9.2 Unit: Auction split on a 6-unit pool, seeded → stable result
+- [ ] 9.3 Unit: Hostile withdrawal halves mercenary award
+- [ ] 9.4 Unit: Damage level classification across all five states
+- [ ] 9.5 Unit: Destroyed-but-crit-component list yields salvageable parts
+      even when unit is DESTROYED
+- [ ] 9.6 Unit: Engine/gyro/IS components are NOT salvageable
+- [ ] 9.7 Integration: Full outcome → computeSalvage → salvageProcessor →
+      inventory populated with expected items
+
+## 10. Validation & Error Handling
+
+- [ ] 10.1 Malformed `salvageRights` (e.g., > 100) → clamp and warn
+- [ ] 10.2 Empty pool (all enemy units INTACT) → return empty allocation,
+      no error
+- [ ] 10.3 Missing contract on a contractId-bearing outcome → warn, fall
+      back to 0% mercenary (employer keeps all)

--- a/openspec/changes/add-salvage-rules-engine/tasks.md
+++ b/openspec/changes/add-salvage-rules-engine/tasks.md
@@ -10,7 +10,7 @@
       `recoveryPercentage`, `location` (for part), `damageLevel`
 - [ ] 1.4 Define `ISalvageAllocation` with `pool`, `employerAward`,
       `mercenaryAward`, `splitMethod` (`"contract" | "auction" |
-    "hostile_withdrawal"`)
+"hostile_withdrawal"`)
 - [ ] 1.5 Define `ISalvageAward` with `candidates: ISalvageCandidate[]`,
       `totalValue`, `estimatedRepairCost`
 - [ ] 1.6 Define `DamageLevel` enum: `INTACT`, `LIGHT`, `MODERATE`,

--- a/openspec/changes/add-skirmish-setup-ui/proposal.md
+++ b/openspec/changes/add-skirmish-setup-ui/proposal.md
@@ -1,0 +1,48 @@
+# Change: Add Skirmish Setup UI
+
+## Why
+
+Phase 1 delivers a playable 4-mech skirmish, but the entry point is missing. The
+engine (`InteractiveSession`, `EncounterService`, `preBattleSessionBuilder`) can
+launch a session when handed a fully configured encounter, yet there is no
+interactive surface that lets a player assemble one. Players need a pre-battle
+screen where they can pick two mechs and two pilots per side, size the map,
+pick a terrain preset, confirm deployment zones, and launch the match. Without
+this, every Lane B combat UI change has no way to start a game.
+
+## What Changes
+
+- Add a pre-battle skirmish configuration surface at
+  `/gameplay/encounters/[id]/pre-battle` that collects per-side unit picks,
+  pilot assignments, map radius, terrain preset, and deployment zones.
+- Add `game-session-management` requirements for a `configureSkirmish` input
+  shape that captures player/opponent force composition and the launch
+  handshake into `InteractiveSession`.
+- Add `tactical-map-interface` requirements for map-setup visualization:
+  radius selection preview, terrain preset color legend, deployment zone
+  overlays for each side, and pre-battle viewport framing.
+
+## Dependencies
+
+- **Requires**: `game-session-management` (exists), `tactical-map-interface`
+  (exists), `terrain-system` (exists), `preBattleSessionBuilder` helper
+- **Related**: Lane A rule-accuracy changes (A1–A5) — not blocking for UI
+  scaffolding but outcomes from this screen will only be meaningful once the
+  engine side is wired.
+- **Required By**: `add-interactive-combat-core-ui` (the launched session
+  renders in the core combat surface), `add-movement-phase-ui`,
+  `add-attack-phase-ui`.
+
+## Impact
+
+- Affected specs: `game-session-management` (MODIFIED — adds skirmish launch
+  handshake), `tactical-map-interface` (ADDED — pre-battle preview
+  requirements).
+- Affected code: `src/pages/gameplay/encounters/[id]/pre-battle.tsx` (new
+  UI), `src/components/gameplay/pages/preBattleSessionBuilder.ts` (extended
+  to accept the richer config), `src/stores/useEncounterStore.ts` (read
+  existing encounter for pre-fill).
+- Non-goals: force builder (out — player re-uses saved forces), OpFor BV
+  generation (out — existing `encounter-system` archive covers it),
+  campaign-bound encounters (out — Phase 3 territory).
+- Database: no schema changes; encounter record already exists.

--- a/openspec/changes/add-skirmish-setup-ui/specs/game-session-management/spec.md
+++ b/openspec/changes/add-skirmish-setup-ui/specs/game-session-management/spec.md
@@ -1,0 +1,80 @@
+# game-session-management Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Skirmish Launch Configuration
+
+The system SHALL accept a `ISkirmishLaunchConfig` shape that fully describes a
+2v2 BattleMech skirmish and SHALL produce an `InteractiveSession` from it via
+the `preBattleSessionBuilder` helper.
+
+#### Scenario: Valid skirmish config launches a session
+
+- **GIVEN** an `ISkirmishLaunchConfig` with two pilot-assigned units per side,
+  a map radius in `{5, 8, 12, 17}`, and a terrain preset identifier
+- **WHEN** `preBattleSessionBuilder.buildFromSkirmishConfig(config)` is called
+- **THEN** the helper SHALL return an `InteractiveSession` in
+  `GameStatus.Setup`
+- **AND** the session's units SHALL match the four configured units with
+  assigned pilots
+- **AND** the session's map SHALL have radius and terrain matching the config
+
+#### Scenario: Missing pilot blocks launch
+
+- **GIVEN** an `ISkirmishLaunchConfig` where one unit has no pilot assigned
+- **WHEN** `preBattleSessionBuilder.buildFromSkirmishConfig(config)` is called
+- **THEN** the helper SHALL throw a validation error
+  `"Pilot required for unit <designation>"`
+- **AND** no session SHALL be created
+
+#### Scenario: Unsupported radius rejected
+
+- **GIVEN** an `ISkirmishLaunchConfig` with `mapRadius = 3`
+- **WHEN** the config is validated before launch
+- **THEN** validation SHALL fail with
+  `"Map radius 3 not in supported set {5, 8, 12, 17}"`
+
+### Requirement: Deployment Zone Derivation
+
+The system SHALL derive per-side deployment zones from the map radius and
+terrain preset at launch time, so the UI and the engine agree on starting
+hexes.
+
+#### Scenario: Opposing-edge deployment zones for Open preset
+
+- **GIVEN** a skirmish config with terrain preset `"Open"` and radius 8
+- **WHEN** deployment zones are derived
+- **THEN** the Player zone SHALL be a contiguous band of hexes along the
+  western edge
+- **AND** the Opponent zone SHALL be the mirrored band along the eastern
+  edge
+- **AND** no hex SHALL belong to both zones
+
+#### Scenario: Deployment zones scale with radius
+
+- **GIVEN** the same terrain preset applied at radius 5 versus radius 17
+- **WHEN** deployment zones are derived for each
+- **THEN** the absolute hex counts SHALL differ
+- **AND** the relative edge bands SHALL remain on the same facing edges
+
+### Requirement: Encounter Launch Status Transition
+
+The system SHALL transition an encounter record from `ready` to `launched`
+when a skirmish session is built from its config, and SHALL store the
+resulting session id on the encounter for round-trip navigation.
+
+#### Scenario: Successful launch updates encounter
+
+- **GIVEN** an encounter in status `ready` with a valid
+  `ISkirmishLaunchConfig` attached
+- **WHEN** the launch handshake succeeds
+- **THEN** the encounter SHALL transition to status `launched`
+- **AND** the encounter's `sessionId` SHALL equal the new session's id
+
+#### Scenario: Launch of already-launched encounter rejected
+
+- **GIVEN** an encounter already in status `launched`
+- **WHEN** the launch handshake runs again
+- **THEN** the handshake SHALL reject with
+  `"Encounter already launched"`
+- **AND** no new session SHALL be created

--- a/openspec/changes/add-skirmish-setup-ui/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-skirmish-setup-ui/specs/tactical-map-interface/spec.md
@@ -1,0 +1,88 @@
+# tactical-map-interface Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Pre-Battle Map Preview
+
+The tactical map interface SHALL render a non-interactive preview of the
+prospective skirmish map on the pre-battle setup screen, using the same hex
+grid, terrain, and viewport framing that will be used once combat begins.
+
+**Priority**: Critical
+
+#### Scenario: Preview reflects selected radius
+
+- **GIVEN** the user selects map radius 8 on the pre-battle screen
+- **WHEN** the preview renders
+- **THEN** the preview SHALL show `3 * 8^2 + 3 * 8 + 1 = 217` hexes
+- **AND** the preview viewport SHALL frame the entire hex grid with padding
+
+#### Scenario: Preview reflects selected terrain preset
+
+- **GIVEN** the user selects terrain preset `"Woods"`
+- **WHEN** the preview renders
+- **THEN** each hex SHALL be filled with the terrain color for the preset's
+  per-hex `TerrainType`
+- **AND** preview SHALL NOT respond to click or hover (non-interactive)
+
+#### Scenario: Preview updates live on config change
+
+- **GIVEN** the user changes radius from 8 to 12
+- **WHEN** the configuration value updates
+- **THEN** the preview SHALL re-render within the same frame with the new
+  radius
+- **AND** no stale hexes from the previous radius SHALL remain visible
+
+### Requirement: Deployment Zone Overlay
+
+The tactical map interface SHALL render per-side deployment zone overlays on
+the pre-battle preview, visually distinguishing Player and Opponent zones
+while preserving underlying terrain colors.
+
+**Priority**: High
+
+#### Scenario: Zones rendered with side colors
+
+- **GIVEN** deployment zones for Player (west) and Opponent (east)
+- **WHEN** the preview renders with zone overlays enabled
+- **THEN** Player zone hexes SHALL have a semi-transparent blue tint
+  (rgba(59,130,246,0.35))
+- **AND** Opponent zone hexes SHALL have a semi-transparent red tint
+  (rgba(239,68,68,0.35))
+- **AND** terrain color SHALL remain visible under the tint
+
+#### Scenario: Zone tooltip on hover
+
+- **GIVEN** zone overlays are visible
+- **WHEN** the user hovers a hex in the Player zone
+- **THEN** a tooltip SHALL display `"Player deployment"` and the zone's
+  hex count
+- **AND** moving to an Opponent hex SHALL switch the tooltip to
+  `"Opponent deployment"`
+
+#### Scenario: Empty zones handled
+
+- **GIVEN** a terrain preset that produces no valid deployment hexes for a
+  side
+- **WHEN** the preview renders
+- **THEN** a warning banner SHALL display
+  `"No valid deployment hexes for <side>"`
+- **AND** "Launch Skirmish" SHALL be disabled
+
+### Requirement: Terrain Preset Legend
+
+The tactical map interface SHALL render a legend adjacent to the pre-battle
+preview showing the colors and labels of terrain types present in the
+selected preset.
+
+**Priority**: Medium
+
+#### Scenario: Legend matches preview
+
+- **GIVEN** a preset that contains Clear, LightWoods, and HeavyWoods hexes
+- **WHEN** the legend renders
+- **THEN** exactly three entries SHALL be listed (no duplicates, no extras)
+- **AND** each entry's swatch color SHALL match the same terrain color used
+  in the preview
+- **AND** each entry's label SHALL use the canonical terrain name from
+  `terrain-system`

--- a/openspec/changes/add-skirmish-setup-ui/tasks.md
+++ b/openspec/changes/add-skirmish-setup-ui/tasks.md
@@ -1,0 +1,84 @@
+# Tasks: Add Skirmish Setup UI
+
+## 1. Pre-battle Page Scaffold
+
+- [ ] 1.1 Route `/gameplay/encounters/[id]/pre-battle` renders a dedicated
+      setup layout (not the combat layout)
+- [ ] 1.2 Load the existing encounter via `useEncounterStore.getEncounter`
+      and short-circuit with a 404 placeholder if not found
+- [ ] 1.3 Page has a single submit affordance "Launch Skirmish" that stays
+      disabled until config validates
+
+## 2. Per-side Unit Picker
+
+- [ ] 2.1 Each side (Player, Opponent) exposes exactly two unit slots
+- [ ] 2.2 Clicking a slot opens a searchable picker populated from the
+      active unit vault
+- [ ] 2.3 Picker filters duplicate selections within a side (no same mech
+      twice on one team)
+- [ ] 2.4 Selected unit displays designation, tonnage, BV, chassis silhouette
+
+## 3. Per-side Pilot Picker
+
+- [ ] 3.1 Each unit slot exposes a linked pilot slot
+- [ ] 3.2 Pilot picker lists saved pilots with Gunnery/Piloting shown
+- [ ] 3.3 Assigning a pilot already on another unit moves them, not
+      duplicates
+- [ ] 3.4 Launch is blocked until all four units have pilots
+
+## 4. Map Radius Selection
+
+- [ ] 4.1 Radius control presents discrete options (5, 8, 12, 17) with live
+      hex-count labels
+- [ ] 4.2 Changing radius updates the map preview immediately
+- [ ] 4.3 Default radius is 8 hexes (standard BattleTech battlefield)
+
+## 5. Terrain Preset Selection
+
+- [ ] 5.1 Preset selector lists at least four presets: Open, Woods, Urban,
+      Mountains
+- [ ] 5.2 Selecting a preset loads its terrain map into the preview
+- [ ] 5.3 Legend renders next to the preview showing each terrain color
+- [ ] 5.4 Custom terrain is explicitly marked out of scope and hidden
+
+## 6. Deployment Zones
+
+- [ ] 6.1 Each side has a deployment zone highlighted on the preview
+- [ ] 6.2 Zone overlays use side colors (blue=Player, red=Opponent) at
+      reduced opacity
+- [ ] 6.3 Zones are determined by preset + radius (no free placement yet)
+- [ ] 6.4 Hovering a zone shows a tooltip with hex count and side name
+
+## 7. Launch Handshake
+
+- [ ] 7.1 Clicking "Launch Skirmish" invokes the existing
+      `preBattleSessionBuilder` with the collected config
+- [ ] 7.2 The helper produces an `InteractiveSession` and a session id
+- [ ] 7.3 On success, navigate to `/gameplay/games/[id]`
+- [ ] 7.4 On failure, display a toast and leave the user on the setup
+      screen with their selections intact
+
+## 8. Validation Surface
+
+- [ ] 8.1 Validation errors surface inline next to the offending field
+- [ ] 8.2 "Launch Skirmish" tooltip explains why it's disabled when config
+      is incomplete
+- [ ] 8.3 Encounter already in `launched` or `completed` state prevents
+      re-launch with a friendly message
+
+## 9. Spec Compliance
+
+- [ ] 9.1 All new requirements in `game-session-management` spec delta have
+      at least one GIVEN/WHEN/THEN scenario
+- [ ] 9.2 All new requirements in `tactical-map-interface` spec delta have
+      at least one GIVEN/WHEN/THEN scenario
+- [ ] 9.3 Run `openspec validate add-skirmish-setup-ui --strict` clean
+
+## 10. Tests
+
+- [ ] 10.1 Unit test: launching with missing pilot blocks submission
+- [ ] 10.2 Unit test: radius change recalculates hex count in preview
+- [ ] 10.3 Unit test: same pilot assigned to two units moves rather than
+      duplicates
+- [ ] 10.4 Integration test: full happy-path (pick units, pilots, preset,
+      radius, launch) produces a live session id

--- a/openspec/changes/add-spa-designation-persistence/proposal.md
+++ b/openspec/changes/add-spa-designation-persistence/proposal.md
@@ -1,0 +1,71 @@
+# Change: Add SPA Designation Persistence
+
+## Why
+
+Several SPAs in the unified catalog require a player-supplied designation
+at purchase time: Weapon Specialist designates a weapon type, Blood
+Stalker designates a target, Range Master designates a range bracket,
+Gunnery Specialist designates a weapon category, and so on. The picker
+collects these designations and the editor persists them onto the pilot
+record. What is still missing is the formal contract for how that
+designation is stored, surfaced to the combat layer, and consumed by
+`spa-combat-integration` when attacks resolve. Without this contract, the
+combat layer cannot consistently tell _which_ weapon Weapon Specialist
+buffs or _which_ target Blood Stalker hunts.
+
+This change locks down the designation data shape, the pilot-side storage,
+and the hand-off into combat modifier resolution. It is the final Phase 5
+piece and is the prerequisite for any combat scenario that must honour
+designation-dependent SPAs.
+
+Phase 5 runs in parallel with Phases 1, 2, and 3. This change is contract
+work — it formalises storage and retrieval — and will not conflict with
+Lane A engine wiring or Lane B combat UI surfaces.
+
+## What Changes
+
+- Add `ISPADesignation` interface to the pilot types describing the
+  discriminated-union shape keyed on `designationType`
+  (weapon_type, weapon_category, target, range_bracket, skill, terrain).
+- Extend `IPilotAbilityRef` with an optional `designation?:
+ISPADesignation` field so the designation travels with the ability on
+  the pilot record.
+- Add `getPilotDesignation(pilot, spaId)` helper in
+  `src/services/pilots/PilotService.ts` so the combat layer can look up a
+  designation without reaching into the pilot structure directly.
+- Extend the `spa-combat-integration` spec so every designation-dependent
+  SPA (Weapon Specialist, Gunnery Specialist, Blood Stalker, Range
+  Master, Oblique Attacker, etc.) is specified to read its designation
+  from the pilot record via the new helper — replacing the current
+  placeholder language of "the designated target".
+
+## Dependencies
+
+- **Requires**: `add-spa-picker-component` (the surface that captures
+  designation), `add-pilot-spa-editor-integration` (the surface that
+  persists designation), existing pilot types, existing
+  `spa-combat-integration` spec (modified here).
+- **Related**: can land in parallel with Phases 1/2/3. The combat-layer
+  reads specified here align with changes already in progress for Lane A
+  (`fix-combat-rule-accuracy`).
+- **Required By**: any Phase 1 attack-resolution change that evaluates a
+  designation-dependent SPA (B4 `add-attack-phase-ui` indirectly
+  consumes this).
+
+## Impact
+
+- Affected specs: `pilot-system` (MODIFIED — adds designation shape and
+  persistence requirements), `spa-combat-integration` (MODIFIED — each
+  designation-dependent requirement now reads designation from the
+  pilot record).
+- Affected code: `src/types/pilot/PilotInterfaces.ts` (new
+  `ISPADesignation` + extension of `IPilotAbilityRef`),
+  `src/services/pilots/PilotService.ts` (new `getPilotDesignation`
+  helper and wiring through `purchaseSPA`),
+  `src/utils/gameplay/spaModifiers/` (reads designation via the helper,
+  not ad-hoc lookups).
+- Non-goals: changing the combat math for any SPA (the math is already
+  specced in `spa-combat-integration`), adding new designation types
+  beyond those already in `SPADesignationType`.
+- Database: no schema change; the pilot record is JSON so the extended
+  `IPilotAbilityRef` shape flows through existing storage.

--- a/openspec/changes/add-spa-designation-persistence/specs/pilot-system/spec.md
+++ b/openspec/changes/add-spa-designation-persistence/specs/pilot-system/spec.md
@@ -1,0 +1,127 @@
+# pilot-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: SPA Designation Data Shape
+
+The pilot system SHALL define a single `ISPADesignation` discriminated
+union that captures every designation supported by the SPA catalog.
+
+#### Scenario: Weapon-type designation
+
+- **GIVEN** an SPA with `designationType === "weapon_type"`
+- **WHEN** a designation is constructed for it
+- **THEN** the designation SHALL be `{ type: "weapon_type", value:
+string }` where `value` is a weapon type id from the weapon catalog
+
+#### Scenario: Target designation
+
+- **GIVEN** an SPA with `designationType === "target"`
+- **WHEN** a designation is constructed for it
+- **THEN** the designation SHALL be `{ type: "target", value: string }`
+  where `value` is a unit id
+
+#### Scenario: Range-bracket designation
+
+- **GIVEN** an SPA with `designationType === "range_bracket"`
+- **WHEN** a designation is constructed for it
+- **THEN** the designation SHALL be `{ type: "range_bracket", value:
+"short" | "medium" | "long" }`
+
+#### Scenario: Union covers every catalog designation type
+
+- **GIVEN** the canonical SPA catalog lists the following
+  `designationType` values: weapon_type, weapon_category, target,
+  range_bracket, skill, terrain
+- **WHEN** `ISPADesignation` is defined
+- **THEN** the union SHALL include a variant for every one of those
+  types
+- **AND** no catalog entry SHALL reference a type absent from the union
+
+### Requirement: Designation Persistence on Pilot Record
+
+The pilot system SHALL persist each ability's designation alongside the
+ability id on the pilot record.
+
+#### Scenario: Ability ref carries designation
+
+- **GIVEN** a pilot purchases `weapon_specialist` with designation
+  `{ type: "weapon_type", value: "medium_laser" }`
+- **WHEN** the purchase completes
+- **THEN** the pilot's `abilities` array SHALL contain an
+  `IPilotAbilityRef` whose `abilityId === "weapon_specialist"` and
+  whose `designation === { type: "weapon_type", value: "medium_laser"
+}`
+
+#### Scenario: Absent designation permitted for non-designating SPAs
+
+- **GIVEN** a pilot purchases `iron_man` (no designation required)
+- **WHEN** the purchase completes
+- **THEN** the stored ability ref SHALL have `designation === undefined`
+
+#### Scenario: Designation required when catalog says so
+
+- **GIVEN** a pilot attempts to purchase
+  `weapon_specialist` without supplying a designation
+- **WHEN** `PilotService.purchaseSPA` is called
+- **THEN** the service SHALL reject with error "Designation required
+  for Weapon Specialist"
+- **AND** the pilot record SHALL remain unchanged
+
+#### Scenario: Designation type must match SPA
+
+- **GIVEN** a pilot attempts to purchase `weapon_specialist` with a
+  designation of type `range_bracket`
+- **WHEN** `PilotService.purchaseSPA` is called
+- **THEN** the service SHALL reject with error "Designation type
+  mismatch"
+
+### Requirement: Designation Retrieval Helper
+
+The pilot system SHALL expose a pure `getPilotDesignation(pilot,
+spaId)` helper that the combat layer uses to resolve designations.
+
+#### Scenario: Helper returns stored designation
+
+- **GIVEN** a pilot that owns `range_master` with designation
+  `{ type: "range_bracket", value: "medium" }`
+- **WHEN** `getPilotDesignation(pilot, "range_master")` is called
+- **THEN** it SHALL return `{ type: "range_bracket", value: "medium" }`
+
+#### Scenario: Helper resolves legacy alias ids
+
+- **GIVEN** a pilot that owns `range_master` and the caller passes the
+  legacy alias id registered in `SPA_LEGACY_ALIASES`
+- **WHEN** `getPilotDesignation(pilot, legacyId)` is called
+- **THEN** the helper SHALL resolve the legacy id to the canonical id
+  first, then return the stored designation
+
+#### Scenario: Helper returns undefined when SPA not owned
+
+- **GIVEN** a pilot that does not own the requested SPA
+- **WHEN** `getPilotDesignation(pilot, spaId)` is called
+- **THEN** the helper SHALL return `undefined`
+
+#### Scenario: Helper returns undefined when designation absent
+
+- **GIVEN** a pilot that owns the SPA but whose stored ref has
+  `designation === undefined`
+- **WHEN** `getPilotDesignation(pilot, spaId)` is called
+- **THEN** the helper SHALL return `undefined`
+
+### Requirement: Backward Compatibility for Stored Pilots
+
+The pilot system SHALL treat existing stored pilots (written before this
+change) as valid, with missing designations interpreted as "not yet
+designated".
+
+#### Scenario: Legacy pilot loads without error
+
+- **GIVEN** a stored pilot JSON predating this change, where every
+  `IPilotAbilityRef` has no `designation` field
+- **WHEN** the pilot is loaded from persistence
+- **THEN** the load SHALL succeed
+- **AND** `getPilotDesignation(pilot, spaId)` SHALL return `undefined`
+  for each of those abilities
+- **AND** the combat layer SHALL fall back to its existing placeholder
+  behaviour for designation-dependent SPAs until a designation is set

--- a/openspec/changes/add-spa-designation-persistence/specs/spa-combat-integration/spec.md
+++ b/openspec/changes/add-spa-designation-persistence/specs/spa-combat-integration/spec.md
@@ -1,0 +1,126 @@
+# spa-combat-integration Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: Gunnery SPA — Weapon Specialist
+
+The Weapon Specialist SPA SHALL grant a -2 to-hit modifier when firing the
+weapon type stored as the pilot's Weapon Specialist designation on the
+pilot record. The combat layer SHALL obtain the designated weapon type
+via `getPilotDesignation(pilot, "weapon_specialist")`.
+
+#### Scenario: Weapon Specialist with stored weapon-type designation
+
+- **GIVEN** a pilot owns `weapon_specialist` with designation
+  `{ type: "weapon_type", value: "medium_laser" }`
+- **WHEN** the pilot fires a Medium Laser
+- **THEN** the combat layer SHALL call `getPilotDesignation` to resolve
+  the weapon type
+- **AND** the attack SHALL receive a -2 to-hit modifier
+
+#### Scenario: Weapon Specialist with non-matching weapon
+
+- **GIVEN** a pilot owns `weapon_specialist` with designation
+  `{ type: "weapon_type", value: "medium_laser" }`
+- **WHEN** the pilot fires an AC/10
+- **THEN** no Weapon Specialist modifier SHALL apply
+
+#### Scenario: Weapon Specialist without a designation recorded
+
+- **GIVEN** a pilot owns `weapon_specialist` but the pilot record has
+  no designation (legacy pilot)
+- **WHEN** the pilot fires any weapon
+- **THEN** the combat layer SHALL fall back to its placeholder
+  behaviour (no Weapon Specialist modifier applied) and SHALL NOT
+  throw
+
+### Requirement: Gunnery SPA — Gunnery Specialist
+
+The Gunnery Specialist SPA SHALL grant -1 to-hit for attacks with the
+weapon category stored as the pilot's Gunnery Specialist designation
+and +1 for all other categories. The combat layer SHALL obtain the
+designated category via `getPilotDesignation(pilot,
+"gunnery_specialist")`.
+
+#### Scenario: Gunnery Specialist with stored Energy designation
+
+- **GIVEN** a pilot owns `gunnery_specialist` with designation
+  `{ type: "weapon_category", value: "energy" }`
+- **WHEN** the pilot fires an energy weapon
+- **THEN** the attack SHALL receive -1 to-hit
+
+#### Scenario: Gunnery Specialist with stored Energy designation on ballistic weapon
+
+- **GIVEN** a pilot owns `gunnery_specialist` with designation
+  `{ type: "weapon_category", value: "energy" }`
+- **WHEN** the pilot fires a ballistic weapon
+- **THEN** the attack SHALL receive +1 to-hit
+
+### Requirement: Gunnery SPA — Blood Stalker
+
+The Blood Stalker SPA SHALL grant -1 to-hit against the target stored as
+the pilot's Blood Stalker designation and +2 against all other targets.
+The combat layer SHALL obtain the designated target id via
+`getPilotDesignation(pilot, "blood_stalker")`.
+
+#### Scenario: Blood Stalker against stored target
+
+- **GIVEN** a pilot owns `blood_stalker` with designation
+  `{ type: "target", value: "unit-abc-123" }`
+- **WHEN** the pilot attacks unit-abc-123
+- **THEN** the attack SHALL receive -1 to-hit
+
+#### Scenario: Blood Stalker against a different target
+
+- **GIVEN** a pilot owns `blood_stalker` with designation
+  `{ type: "target", value: "unit-abc-123" }`
+- **WHEN** the pilot attacks a unit other than unit-abc-123
+- **THEN** the attack SHALL receive +2 to-hit
+
+### Requirement: Gunnery SPA — Range Master
+
+The Range Master SPA SHALL zero the range modifier for the range bracket
+stored as the pilot's Range Master designation. The combat layer SHALL
+obtain the designated bracket via `getPilotDesignation(pilot,
+"range_master")`.
+
+#### Scenario: Range Master with stored medium designation
+
+- **GIVEN** a pilot owns `range_master` with designation
+  `{ type: "range_bracket", value: "medium" }`
+- **WHEN** the pilot fires at medium range
+- **THEN** the range to-hit modifier SHALL be 0 (instead of +2)
+
+#### Scenario: Range Master with stored medium designation at long range
+
+- **GIVEN** a pilot owns `range_master` with designation
+  `{ type: "range_bracket", value: "medium" }`
+- **WHEN** the pilot fires at long range
+- **THEN** the normal long range modifier SHALL apply
+
+## ADDED Requirements
+
+### Requirement: Designation Lookup Contract
+
+The combat modifier layer SHALL obtain every designation-dependent value
+by calling `getPilotDesignation(pilot, spaId)` and SHALL NOT reach into
+the pilot record directly.
+
+#### Scenario: Modifier layer uses the helper
+
+- **GIVEN** any designation-dependent SPA is being evaluated for an
+  attack
+- **WHEN** the modifier calculation needs the designated value
+- **THEN** the code SHALL read the designation only via
+  `getPilotDesignation(pilot, spaId)`
+- **AND** code reviews SHALL reject any direct traversal of
+  `pilot.abilities[].designation`
+
+#### Scenario: Missing designation produces neutral result
+
+- **GIVEN** a designation-dependent SPA is evaluated for a pilot where
+  `getPilotDesignation` returns `undefined`
+- **WHEN** the modifier calculation runs
+- **THEN** the modifier SHALL evaluate to zero (no-op) rather than
+  throwing
+- **AND** a debug-level log SHALL note the missing designation

--- a/openspec/changes/add-spa-designation-persistence/tasks.md
+++ b/openspec/changes/add-spa-designation-persistence/tasks.md
@@ -37,7 +37,7 @@
 ## 4. getPilotDesignation Helper
 
 - [ ] 4.1 Add `getPilotDesignation(pilot: IPilot, spaId: string):
-    ISPADesignation | undefined` to `PilotService`
+ISPADesignation | undefined` to `PilotService`
 - [ ] 4.2 Helper resolves the SPA id through `resolveSPAId()` so
       callers can pass canonical or legacy ids
 - [ ] 4.3 Helper returns `undefined` when the pilot does not own the
@@ -83,7 +83,7 @@
 - [ ] 7.3 Every new requirement has at least one GIVEN/WHEN/THEN
       scenario
 - [ ] 7.4 Run `openspec validate add-spa-designation-persistence
-    --strict` clean
+--strict` clean
 
 ## 8. Tests
 

--- a/openspec/changes/add-spa-designation-persistence/tasks.md
+++ b/openspec/changes/add-spa-designation-persistence/tasks.md
@@ -1,0 +1,107 @@
+# Tasks: Add SPA Designation Persistence
+
+## 1. ISPADesignation Type
+
+- [ ] 1.1 Add `ISPADesignation` to `src/types/pilot/PilotInterfaces.ts`
+      as a discriminated union keyed on
+      `type: SPADesignationType` and a `value` shape appropriate to
+      that type
+- [ ] 1.2 Export narrowing helpers: `isWeaponTypeDesignation`,
+      `isTargetDesignation`, `isRangeBracketDesignation`, etc.
+- [ ] 1.3 Ensure the union covers every `SPADesignationType` in the
+      canonical catalog (weapon_type, weapon_category, target,
+      range_bracket, skill, terrain)
+
+## 2. IPilotAbilityRef Extension
+
+- [ ] 2.1 Extend `IPilotAbilityRef` with an optional
+      `designation?: ISPADesignation` field
+- [ ] 2.2 Update the type guard `isPilot` if needed to tolerate the
+      new field (it should remain permissive — designation is
+      optional)
+- [ ] 2.3 Update JSDoc comments explaining when designation is required
+      versus omitted
+
+## 3. PilotService Wiring
+
+- [ ] 3.1 `PilotService.purchaseSPA` accepts an optional
+      `designation?: ISPADesignation` argument and persists it on the
+      pilot record
+- [ ] 3.2 `PilotService.purchaseSPA` rejects any purchase where the
+      SPA's `requiresDesignation === true` and no designation is
+      supplied — error "Designation required for <displayName>"
+- [ ] 3.3 `PilotService.purchaseSPA` rejects any purchase where
+      `designation.type !== spa.designationType` — error "Designation
+      type mismatch"
+
+## 4. getPilotDesignation Helper
+
+- [ ] 4.1 Add `getPilotDesignation(pilot: IPilot, spaId: string):
+    ISPADesignation | undefined` to `PilotService`
+- [ ] 4.2 Helper resolves the SPA id through `resolveSPAId()` so
+      callers can pass canonical or legacy ids
+- [ ] 4.3 Helper returns `undefined` when the pilot does not own the
+      SPA or the stored ref has no designation
+- [ ] 4.4 Helper is pure — it reads the pilot record, does not mutate
+
+## 5. Combat Layer Hand-off
+
+- [ ] 5.1 Update `src/utils/gameplay/spaModifiers/` to use
+      `getPilotDesignation` for every designation-dependent SPA read
+- [ ] 5.2 Remove any ad-hoc designation lookups that reach into the
+      pilot structure directly
+- [ ] 5.3 Confirm Weapon Specialist reads designated weapon type from
+      the pilot record
+- [ ] 5.4 Confirm Gunnery Specialist reads designated weapon category
+      from the pilot record
+- [ ] 5.5 Confirm Blood Stalker reads designated target from the pilot
+      record
+- [ ] 5.6 Confirm Range Master reads designated range bracket from the
+      pilot record
+- [ ] 5.7 Confirm Oblique Attacker reads designated terrain from the
+      pilot record
+
+## 6. Serialization Compatibility
+
+- [ ] 6.1 Verify that `IPilot` JSON round-trips with the new
+      designation field (existing pilots without designation remain
+      valid)
+- [ ] 6.2 Add a migration note in the spec for existing stored pilots:
+      absent designation means "none recorded" and the combat layer
+      SHALL fall back to the placeholder behaviour described in
+      `spa-combat-integration` until a designation is added
+- [ ] 6.3 Confirm the Yjs / p2p-sync layer tolerates the extended
+      shape (no new migration required — additive optional field)
+
+## 7. Spec Compliance
+
+- [ ] 7.1 Add `pilot-system` spec delta for the designation shape,
+      storage, and retrieval helper
+- [ ] 7.2 Add `spa-combat-integration` spec delta updating every
+      designation-dependent SPA to read its designation from the pilot
+      record via `getPilotDesignation`
+- [ ] 7.3 Every new requirement has at least one GIVEN/WHEN/THEN
+      scenario
+- [ ] 7.4 Run `openspec validate add-spa-designation-persistence
+    --strict` clean
+
+## 8. Tests
+
+- [ ] 8.1 Unit test: purchasing Weapon Specialist without a
+      designation is rejected
+- [ ] 8.2 Unit test: purchasing Weapon Specialist with a
+      `range_bracket` designation is rejected (type mismatch)
+- [ ] 8.3 Unit test: purchasing Weapon Specialist with a valid
+      `weapon_type` designation stores the designation on the ability
+      ref
+- [ ] 8.4 Unit test: `getPilotDesignation(pilot, "weapon_specialist")`
+      returns the persisted designation
+- [ ] 8.5 Unit test: `getPilotDesignation` returns undefined when the
+      pilot does not own the SPA
+- [ ] 8.6 Unit test: `getPilotDesignation` resolves legacy alias ids
+- [ ] 8.7 Integration test: attack resolution for a pilot with
+      Weapon Specialist (Medium Laser) firing a Medium Laser applies
+      the -2 to-hit modifier
+- [ ] 8.8 Integration test: attack resolution for a pilot with Blood
+      Stalker and a stored target id applies -1 against that target
+      and +2 against others

--- a/openspec/changes/add-spa-display-on-pilot-sheet-and-unit-card/proposal.md
+++ b/openspec/changes/add-spa-display-on-pilot-sheet-and-unit-card/proposal.md
@@ -1,0 +1,56 @@
+# Change: Add SPA Display on Pilot Sheet and Unit Card
+
+## Why
+
+Once a pilot owns SPAs (via the editor change), players expect to see them
+anywhere the pilot is surfaced: the in-game pilot-mech unit card shown on
+the tactical map, the pilot detail sheet, and the printable record sheet
+exported via the `RecordSheetService`. Right now, the SPA picker and
+editor drop abilities onto the pilot record, but nothing reads them back
+in the player-facing chrome. This change closes the loop by rendering
+SPA badges with category color, hover tooltips showing full descriptions,
+and a dedicated SPA section on the printed record sheet.
+
+Phase 5 runs in parallel with Phases 1, 2, and 3. This change is
+presentational — it reads the existing pilot record and extends the
+record-sheet export pipeline. It does not change engine behaviour and
+will not conflict with Lane A/B/C engine work.
+
+## What Changes
+
+- Add SPA badges to `PilotSection` in `PilotMechCard` — rendered as
+  compact pills with category color, displayName, designation (when
+  present), and a hover tooltip showing full description and source.
+- Add a "Special Abilities" section to the pilot detail page next to the
+  career stats — expanded form of the same badges, grouped by category.
+- Extend `RecordSheetService` so PDF output includes a Special Abilities
+  section below the pilot block, listing each SPA with displayName,
+  designation, and a truncated one-line description.
+- Add a shared `SPABadge` component under `src/components/spa/SPABadge/`
+  used by the unit card, the pilot sheet, and the record-sheet preview.
+
+## Dependencies
+
+- **Requires**: `add-spa-picker-component` (provides catalog lookup
+  utilities reused in the badge), `add-pilot-spa-editor-integration`
+  (populates the pilot's `abilities` array in the first place),
+  existing `RecordSheetService` at `src/services/printing/`.
+- **Related**: can land in parallel with Phases 1/2/3.
+- **Required By**: `add-spa-designation-persistence` (the display
+  surfaces here are what make persisted designation visible).
+
+## Impact
+
+- Affected specs: `spa-ui` (MODIFIED — adds badge and record-sheet
+  display requirements), `pilot-system` (MODIFIED — pilot sheet SHALL
+  render abilities), `record-sheet-export` (MODIFIED — PDF/SVG output
+  SHALL include the abilities section).
+- Affected code: `src/components/pilot-mech-card/PilotSection.tsx`
+  (adds badge row), `src/pages/gameplay/pilots/[id].tsx` (adds expanded
+  section alongside existing stats), `src/services/printing/
+RecordSheetService.ts` + `svgRecordSheetRenderer/` (render the new
+  section), new `src/components/spa/SPABadge/SPABadge.tsx`.
+- Non-goals: in-game gameplay use of SPAs (combat layer already wired
+  in Phase 0), persisted designation types beyond what the pilot record
+  currently carries (handled by `add-spa-designation-persistence`).
+- Database: no schema change.

--- a/openspec/changes/add-spa-display-on-pilot-sheet-and-unit-card/specs/pilot-system/spec.md
+++ b/openspec/changes/add-spa-display-on-pilot-sheet-and-unit-card/specs/pilot-system/spec.md
@@ -1,0 +1,42 @@
+# pilot-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Special Abilities Section on Pilot Detail Sheet
+
+The pilot detail sheet at `/gameplay/pilots/[id]` SHALL include a
+"Special Abilities" section that groups owned SPAs by category and
+renders them as expanded badges.
+
+#### Scenario: Section renders grouped by category
+
+- **GIVEN** a pilot that owns one Gunnery SPA and one Piloting SPA
+- **WHEN** the pilot detail sheet renders
+- **THEN** the Special Abilities section SHALL contain a "Gunnery"
+  subheader followed by the gunnery badge
+- **AND** a "Piloting" subheader followed by the piloting badge
+
+#### Scenario: Expanded badges render designation and description
+
+- **GIVEN** a pilot that owns `range_master` with designation
+  `{ type: "range_bracket", value: "Long" }`
+- **WHEN** the Special Abilities section renders the row
+- **THEN** the expanded badge SHALL display "Range Master (Long)"
+- **AND** the description from the catalog SHALL render inline below
+  the displayName
+
+#### Scenario: Empty pilot shows "No special abilities" text
+
+- **GIVEN** a pilot with no abilities
+- **WHEN** the pilot detail sheet renders
+- **THEN** the Special Abilities section SHALL display "No special
+  abilities." in place of the grouped list
+
+#### Scenario: Unknown ability id is skipped silently
+
+- **GIVEN** a pilot whose `abilities` array contains an id unknown to
+  the catalog
+- **WHEN** the Special Abilities section renders
+- **THEN** the unknown id SHALL be omitted from the output
+- **AND** remaining abilities SHALL render normally
+- **AND** no runtime error SHALL be thrown

--- a/openspec/changes/add-spa-display-on-pilot-sheet-and-unit-card/specs/record-sheet-export/spec.md
+++ b/openspec/changes/add-spa-display-on-pilot-sheet-and-unit-card/specs/record-sheet-export/spec.md
@@ -1,0 +1,64 @@
+# record-sheet-export Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Record Sheet Includes Special Abilities Block
+
+The record sheet export pipeline SHALL include a Special Abilities block
+on the printed record sheet when the assigned pilot owns one or more
+SPAs.
+
+#### Scenario: Pilot with abilities gets a Special Abilities block
+
+- **GIVEN** a record sheet is generated for a unit whose assigned pilot
+  owns `weapon_specialist` with designation "Medium Laser" and
+  `iron_man`
+- **WHEN** `RecordSheetService` renders the SVG template
+- **THEN** a block titled "Special Abilities" SHALL appear below the
+  pilot block
+- **AND** the block SHALL contain at least two lines — one per owned
+  SPA
+- **AND** each line SHALL include the displayName and the designation
+  in parentheses when present (e.g. "Weapon Specialist (Medium Laser)")
+- **AND** each line SHALL include a one-line truncated description from
+  the catalog
+
+#### Scenario: Pilot with zero abilities omits the block
+
+- **GIVEN** a record sheet is generated for a unit whose assigned pilot
+  has an empty `abilities` array
+- **WHEN** `RecordSheetService` renders the SVG template
+- **THEN** no Special Abilities block SHALL be emitted
+- **AND** the record sheet SHALL NOT reserve vertical space for an
+  empty block
+
+#### Scenario: Block never overflows the record sheet
+
+- **GIVEN** a pilot that owns the maximum plausible number of SPAs
+  (e.g. 8 abilities on a veteran pilot)
+- **WHEN** the record sheet renders
+- **THEN** the Special Abilities block SHALL wrap or truncate so that
+  no content is drawn past the record sheet's bottom border
+
+### Requirement: Data Extractor for Abilities
+
+The record-sheet data extraction layer SHALL expose an `extractAbilities`
+helper that resolves pilot ability ids to canonical definitions via the
+SPA catalog.
+
+#### Scenario: Extractor resolves known ids
+
+- **GIVEN** a pilot whose `abilities` array contains two canonical SPA
+  ids and one legacy-alias id
+- **WHEN** `extractAbilities(unit)` is called
+- **THEN** the helper SHALL return three resolved entries, each a
+  `{ spa: ISPADefinition, designation?: ISPADesignation }` tuple
+- **AND** entries SHALL be grouped by category in the returned list
+
+#### Scenario: Extractor skips unknown ids
+
+- **GIVEN** a pilot whose `abilities` array includes one id unknown to
+  the catalog
+- **WHEN** `extractAbilities(unit)` is called
+- **THEN** the unknown id SHALL be omitted from the returned list
+- **AND** no error SHALL be thrown

--- a/openspec/changes/add-spa-display-on-pilot-sheet-and-unit-card/specs/spa-ui/spec.md
+++ b/openspec/changes/add-spa-display-on-pilot-sheet-and-unit-card/specs/spa-ui/spec.md
@@ -1,0 +1,68 @@
+# spa-ui Specification Delta
+
+## ADDED Requirements
+
+### Requirement: SPA Badge Component
+
+The system SHALL provide a reusable `SPABadge` component that renders an
+SPA as a pill with category color accent, displayName, optional
+designation, and a tooltip.
+
+#### Scenario: Compact badge renders name and designation
+
+- **GIVEN** a badge is rendered with
+  `spa = weapon_specialist` and
+  `designation = { type: "weapon_type", value: "Medium Laser" }`
+- **WHEN** the badge mounts in `variant="compact"`
+- **THEN** the badge text SHALL read "Weapon Specialist (Medium Laser)"
+- **AND** the badge background SHALL use the Gunnery category color
+  token
+
+#### Scenario: Badge without designation renders name only
+
+- **GIVEN** a badge is rendered with `spa = iron_man` and
+  `designation = undefined`
+- **WHEN** the badge mounts
+- **THEN** the badge text SHALL read "Iron Man"
+
+#### Scenario: Tooltip exposes full description and source
+
+- **GIVEN** a badge is rendered for any SPA
+- **WHEN** the user hovers or focuses the badge
+- **THEN** a tooltip SHALL open containing the full `description`
+- **AND** the tooltip SHALL display the `source` rulebook label
+
+#### Scenario: Expanded variant shows multiline content
+
+- **GIVEN** a badge is rendered with `variant="expanded"`
+- **WHEN** the badge mounts
+- **THEN** the badge SHALL render displayName, designation, and
+  description inline (no tooltip needed)
+
+### Requirement: SPA Badge Row on Unit Card
+
+The system SHALL render a compact SPA badge row on the pilot-mech unit
+card, below the wounds indicator.
+
+#### Scenario: Pilot with abilities renders badge row
+
+- **GIVEN** a pilot-mech unit card for a pilot that owns two SPAs
+- **WHEN** the card renders
+- **THEN** a badge row SHALL render below the wounds indicator
+- **AND** each badge SHALL use the `variant="compact"` form
+
+#### Scenario: Pilot with zero abilities renders no row
+
+- **GIVEN** a pilot-mech unit card for a pilot with an empty
+  `abilities` array
+- **WHEN** the card renders
+- **THEN** no badge row SHALL render
+- **AND** no empty-state placeholder SHALL occupy vertical space
+
+#### Scenario: Unknown ability id is skipped silently
+
+- **GIVEN** a pilot whose `abilities` contains an id not in the
+  canonical catalog or its legacy alias table
+- **WHEN** the card renders
+- **THEN** the unknown id SHALL be skipped without error
+- **AND** remaining known abilities SHALL render normally

--- a/openspec/changes/add-spa-display-on-pilot-sheet-and-unit-card/tasks.md
+++ b/openspec/changes/add-spa-display-on-pilot-sheet-and-unit-card/tasks.md
@@ -1,0 +1,94 @@
+# Tasks: Add SPA Display on Pilot Sheet and Unit Card
+
+## 1. Shared Badge Component
+
+- [ ] 1.1 Create `src/components/spa/SPABadge/SPABadge.tsx` with props
+      `{ spa: ISPADefinition, designation?: ISPADesignation,
+    variant: "compact" | "expanded" }`
+- [ ] 1.2 Badge renders category color accent, displayName, optional
+      designation text
+- [ ] 1.3 Badge exposes a tooltip on hover/focus showing the full
+      `description`, source rulebook, and XP cost
+- [ ] 1.4 Create `index.ts` re-exporting the badge and props
+
+## 2. Pilot-Mech Unit Card Integration
+
+- [ ] 2.1 In `src/components/pilot-mech-card/PilotSection.tsx`, add a
+      compact SPA badge row below the wounds indicator
+- [ ] 2.2 Badges resolve each ability id via `getSPADefinition()`;
+      unknown ids SHALL be skipped silently
+- [ ] 2.3 Layout wraps badges to the next line when the pilot owns more
+      than fits a single row
+- [ ] 2.4 Cards for pilots with zero abilities render no badge row (no
+      empty container, no placeholder)
+
+## 3. Pilot Sheet Section
+
+- [ ] 3.1 Add a "Special Abilities" section to
+      `src/pages/gameplay/pilots/[id].tsx`, alongside the existing
+      career-stats block
+- [ ] 3.2 Abilities are grouped by category (Gunnery, Piloting, …)
+      with a section header per category
+- [ ] 3.3 Each ability renders as an expanded badge
+      (`variant="expanded"`) showing displayName, designation,
+      description, source
+- [ ] 3.4 Empty state: "No special abilities." when the pilot has none
+
+## 4. Record-Sheet PDF Export
+
+- [ ] 4.1 Extend `src/services/printing/svgRecordSheetRenderer/
+    template.ts` to emit a Special Abilities block below the pilot
+      block
+- [ ] 4.2 Block renders each ability as `displayName (designation)` on
+      its own line with a one-line truncated description
+- [ ] 4.3 Empty-case: omit the block entirely when the pilot has zero
+      abilities
+- [ ] 4.4 Block respects the page layout — no overflow past the record
+      sheet border
+
+## 5. Data Extraction for Print
+
+- [ ] 5.1 Extend `src/services/printing/recordsheet/dataExtractors.ts`
+      with a new `extractAbilities(unit)` helper that reads the
+      pilot's abilities and resolves each to an `ISPADefinition` plus
+      designation tuple
+- [ ] 5.2 Helper returns an ordered list grouped by category
+- [ ] 5.3 Helper skips unknown ids defensively (same rule as the
+      badge)
+
+## 6. Category Color Tokens
+
+- [ ] 6.1 Define a category-color map in
+      `src/components/spa/SPABadge/categoryColors.ts` — one accent per
+      category (gunnery, piloting, defensive, toughness, tactical,
+      infantry, bioware, edge, miscellaneous)
+- [ ] 6.2 Colors follow the existing app palette (pull tokens from the
+      theme rather than inventing new ones)
+- [ ] 6.3 Map is the single source of truth — the record sheet, unit
+      card, and pilot sheet all import it
+
+## 7. Spec Compliance
+
+- [ ] 7.1 Add `spa-ui` spec delta for badge layout, tooltip, and unit
+      card embedding
+- [ ] 7.2 Add `pilot-system` spec delta for the pilot sheet section
+- [ ] 7.3 Add `record-sheet-export` spec delta for the PDF abilities
+      block
+- [ ] 7.4 Every new requirement has at least one GIVEN/WHEN/THEN
+      scenario
+- [ ] 7.5 Run `openspec validate add-spa-display-on-pilot-sheet-and-
+    unit-card --strict` clean
+
+## 8. Tests
+
+- [ ] 8.1 Unit test: badge renders category color, displayName, and
+      designation
+- [ ] 8.2 Unit test: badge tooltip exposes full description and source
+- [ ] 8.3 Unit test: PilotSection renders zero badges when pilot has
+      no abilities (no empty container)
+- [ ] 8.4 Unit test: PilotSection skips unknown ability ids silently
+- [ ] 8.5 Unit test: extractAbilities groups by category
+- [ ] 8.6 Snapshot test: record sheet PDF contains the Special
+      Abilities block when pilot has abilities
+- [ ] 8.7 Snapshot test: record sheet PDF omits the block when pilot
+      has none

--- a/openspec/changes/add-spa-display-on-pilot-sheet-and-unit-card/tasks.md
+++ b/openspec/changes/add-spa-display-on-pilot-sheet-and-unit-card/tasks.md
@@ -4,7 +4,7 @@
 
 - [ ] 1.1 Create `src/components/spa/SPABadge/SPABadge.tsx` with props
       `{ spa: ISPADefinition, designation?: ISPADesignation,
-    variant: "compact" | "expanded" }`
+variant: "compact" | "expanded" }`
 - [ ] 1.2 Badge renders category color accent, displayName, optional
       designation text
 - [ ] 1.3 Badge exposes a tooltip on hover/focus showing the full
@@ -37,7 +37,7 @@
 ## 4. Record-Sheet PDF Export
 
 - [ ] 4.1 Extend `src/services/printing/svgRecordSheetRenderer/
-    template.ts` to emit a Special Abilities block below the pilot
+template.ts` to emit a Special Abilities block below the pilot
       block
 - [ ] 4.2 Block renders each ability as `displayName (designation)` on
       its own line with a one-line truncated description
@@ -77,7 +77,7 @@
 - [ ] 7.4 Every new requirement has at least one GIVEN/WHEN/THEN
       scenario
 - [ ] 7.5 Run `openspec validate add-spa-display-on-pilot-sheet-and-
-    unit-card --strict` clean
+unit-card --strict` clean
 
 ## 8. Tests
 

--- a/openspec/changes/add-spa-picker-component/proposal.md
+++ b/openspec/changes/add-spa-picker-component/proposal.md
@@ -1,0 +1,56 @@
+# Change: Add SPA Picker Component
+
+## Why
+
+Phase 5 (Pilot SPA UI) needs a shared, reusable surface for browsing the
+91-entry unified SPA catalog that already lives in `src/lib/spa/`. Every
+downstream Phase 5 change — pilot editor integration, pilot-sheet display,
+designation persistence — expects a single picker component so the browsing
+UX (tabs, search, filters, source badges, cost labels, designation prompts)
+is consistent everywhere. Without this component, each consumer would
+re-implement the same list rendering + filter logic and the UX would drift.
+
+Phase 5 can run in parallel with Phases 1, 2, and 3; the picker touches only
+UI and the existing catalog module, so it will not conflict with in-flight
+engine work in Lane A.
+
+## What Changes
+
+- Add `SPAPicker` React component under `src/components/spa/SPAPicker/`
+  that renders the 91-entry catalog with category tabs (Piloting, Gunnery,
+  Miscellaneous, Infantry, aToW, Manei Domini / Bioware, Unofficial, Edge).
+- Add search input that filters by `displayName`, `description`, and
+  `source` across all categories.
+- Add source-filter chips (`CamOps`, `MaxTech`, `ATOW`, `ManeiDomini`,
+  `Unofficial`, `Legacy`).
+- Each entry row shows `displayName`, `description`, XP cost badge (or
+  "Origin-Only" / "Flaw" badge when applicable), source badge, and category
+  color swatch.
+- Clicking a row emits a `(spa, designation?)` selection event; when the SPA
+  has `requiresDesignation = true`, the picker opens a secondary
+  designation prompt keyed on `designationType` (weapon type, weapon
+  category, target, range bracket, skill, terrain) before resolving the
+  selection.
+- Add new spec `spa-ui` to own every requirement for the picker surface.
+
+## Dependencies
+
+- **Requires**: unified SPA catalog at `src/lib/spa/` (exists), pilot types
+  at `src/types/spa/SPADefinition.ts` (exists), `spa-combat-integration`
+  spec (exists, unmodified here).
+- **Related**: can land in parallel with Phases 1/2/3 since it is pure UI.
+- **Required By**: `add-pilot-spa-editor-integration`,
+  `add-spa-display-on-pilot-sheet-and-unit-card`,
+  `add-spa-designation-persistence`.
+
+## Impact
+
+- Affected specs: new `spa-ui` spec (ADDED), `pilot-system` (MODIFIED —
+  adds a UI-layer picker contract for pilots to browse abilities).
+- Affected code: new `src/components/spa/SPAPicker/` module (component,
+  tab bar, filter bar, row renderer, designation prompt, tests). No
+  changes to the catalog or the existing combat modifier layer.
+- Non-goals: purchase flow (belongs to the editor change), pilot-sheet
+  rendering (belongs to the display change), persistence of designation
+  choices (belongs to the designation change).
+- Database: no changes.

--- a/openspec/changes/add-spa-picker-component/specs/pilot-system/spec.md
+++ b/openspec/changes/add-spa-picker-component/specs/pilot-system/spec.md
@@ -1,0 +1,27 @@
+# pilot-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Pilot-Facing SPA Browsing Surface
+
+The pilot system SHALL expose a single browsing surface — the `SPAPicker`
+component — for any pilot-facing flow that needs to present the SPA
+catalog (pilot creation, mid-campaign XP spend, designer previews).
+
+#### Scenario: Pilot flows import the picker, not the catalog directly
+
+- **GIVEN** a pilot flow needs to let the player browse SPAs
+- **WHEN** the flow is implemented
+- **THEN** it SHALL import `SPAPicker` from
+  `@/components/spa/SPAPicker`
+- **AND** it SHALL NOT render catalog entries with ad-hoc components
+- **AND** it SHALL NOT duplicate catalog list logic
+
+#### Scenario: Picker exposes the selection contract
+
+- **GIVEN** a pilot flow mounts the `SPAPicker`
+- **WHEN** the player selects an entry
+- **THEN** the flow SHALL receive the selection as
+  `{ spa: ISPADefinition, designation: ISPADesignation | undefined }`
+- **AND** the flow SHALL be responsible for purchase, XP deduction, and
+  persistence (the picker itself remains purely presentational)

--- a/openspec/changes/add-spa-picker-component/specs/spa-ui/spec.md
+++ b/openspec/changes/add-spa-picker-component/specs/spa-ui/spec.md
@@ -1,0 +1,171 @@
+# spa-ui Specification Delta
+
+## ADDED Requirements
+
+### Requirement: SPA Picker Layout
+
+The system SHALL provide a reusable `SPAPicker` component that renders the
+unified SPA catalog with category tabs, a search input, and source filter
+chips.
+
+#### Scenario: Picker renders full catalog on mount
+
+- **GIVEN** the `SPAPicker` is mounted with no filters and no excluded ids
+- **WHEN** the component first renders
+- **THEN** it SHALL display all 91 SPAs loaded from the canonical catalog
+- **AND** the "All" category tab SHALL be active by default
+- **AND** the search input SHALL be empty
+
+#### Scenario: Category tabs cover every catalog category
+
+- **GIVEN** the `SPAPicker` is mounted
+- **WHEN** the tab bar renders
+- **THEN** tabs SHALL exist for Piloting, Gunnery, Miscellaneous, Infantry,
+  aToW, Manei Domini, Unofficial, Edge, plus an "All" tab
+- **AND** each tab SHALL display a count of entries matching the active
+  search and source filters
+
+#### Scenario: Switching tab filters visible entries
+
+- **GIVEN** the picker is showing the "All" tab
+- **WHEN** the user selects the "Gunnery" tab
+- **THEN** only SPAs with `category === "gunnery"` SHALL be visible
+- **AND** the "Gunnery" tab SHALL be visually marked active
+
+### Requirement: Search and Source Filtering
+
+The system SHALL support text search and source-chip filtering over the
+catalog within the active category tab.
+
+#### Scenario: Text search matches displayName
+
+- **GIVEN** the picker is showing the "All" tab
+- **WHEN** the user types "weapon specialist" into the search input
+- **THEN** only entries whose `displayName` contains "weapon specialist"
+  (case-insensitive) SHALL be visible
+
+#### Scenario: Text search matches description
+
+- **GIVEN** the picker is showing the "All" tab
+- **WHEN** the user types a keyword that appears only in an entry's
+  `description`
+- **THEN** that entry SHALL be visible
+- **AND** entries without the keyword in `displayName`, `description`, or
+  `source` SHALL be hidden
+
+#### Scenario: Source chip filters by rulebook
+
+- **GIVEN** the picker is showing the "All" tab with no source chips
+  active
+- **WHEN** the user toggles the "Unofficial" source chip on
+- **THEN** only SPAs with `source === "Unofficial"` SHALL be visible
+- **AND** other source chips SHALL remain available to layer additional
+  sources
+
+#### Scenario: Combined filters return empty set
+
+- **GIVEN** the picker has search text and source chips that together
+  match zero entries
+- **WHEN** the filters are applied
+- **THEN** the picker SHALL render a "No abilities match these filters"
+  empty state
+
+### Requirement: Entry Row Content
+
+The system SHALL render each catalog entry as a row showing displayName,
+description, XP cost or flag badge, source badge, and category accent.
+
+#### Scenario: Purchasable entry renders cost badge
+
+- **GIVEN** a row for an entry with `xpCost = 100` and `isFlaw = false`
+- **WHEN** the row renders
+- **THEN** the cost badge SHALL display "100 XP"
+- **AND** the row SHALL be enabled
+
+#### Scenario: Flaw entry renders XP-gain label
+
+- **GIVEN** a row for an entry with `isFlaw === true` and a negative
+  `xpCost`
+- **WHEN** the row renders
+- **THEN** the badge SHALL indicate the XP granted (e.g. "+200 XP")
+- **AND** the entry SHALL be tagged as a Flaw
+
+#### Scenario: Origin-only entry is tagged
+
+- **GIVEN** a row for an entry with `isOriginOnly === true`
+- **WHEN** the row renders
+- **THEN** an "Origin-Only" tag SHALL be visible alongside the cost badge
+- **AND** when the picker's `filterMode === "purchase-only"`, the row
+  SHALL render disabled
+
+#### Scenario: Excluded entry renders disabled
+
+- **GIVEN** the picker is mounted with `excludedIds` containing a given
+  SPA id
+- **WHEN** that entry's row renders
+- **THEN** the row SHALL render disabled
+- **AND** an "Already owned" label SHALL be visible
+
+### Requirement: Designation Prompt
+
+The system SHALL, for any SPA with `requiresDesignation === true`, open a
+designation prompt keyed on `designationType` before emitting selection.
+
+#### Scenario: Weapon-type designation opens after row click
+
+- **GIVEN** the user clicks a row for Weapon Specialist
+  (`designationType === "weapon_type"`)
+- **WHEN** the selection is initiated
+- **THEN** the picker SHALL open a designation prompt listing weapon types
+  from the weapon catalog
+- **AND** no `onSelect` event SHALL fire yet
+
+#### Scenario: Designation confirm emits payload
+
+- **GIVEN** the designation prompt is open for Range Master
+  (`designationType === "range_bracket"`)
+- **WHEN** the user selects "Medium" and confirms
+- **THEN** the picker SHALL emit
+  `onSelect({ spa, designation: { type: "range_bracket", value: "Medium" } })`
+
+#### Scenario: Designation cancel returns to picker
+
+- **GIVEN** the designation prompt is open
+- **WHEN** the user cancels
+- **THEN** the prompt SHALL close
+- **AND** no `onSelect` event SHALL fire
+- **AND** the picker SHALL restore the prior tab and filters
+
+#### Scenario: Non-designation SPA emits immediately
+
+- **GIVEN** the user clicks a row for an entry with
+  `requiresDesignation === false`
+- **WHEN** the click resolves
+- **THEN** `onSelect({ spa, designation: undefined })` SHALL fire
+- **AND** no designation prompt SHALL open
+
+### Requirement: Accessibility
+
+The system SHALL expose the picker through keyboard and assistive-tech
+controls.
+
+#### Scenario: Keyboard tab navigation
+
+- **GIVEN** the tab bar has focus
+- **WHEN** the user presses ArrowRight
+- **THEN** focus SHALL advance to the next tab
+- **AND** pressing Enter SHALL activate the focused tab
+
+#### Scenario: Row keyboard activation
+
+- **GIVEN** an entry row has focus
+- **WHEN** the user presses Enter
+- **THEN** the picker SHALL trigger the same selection flow as a click
+  (including opening the designation prompt when required)
+
+#### Scenario: Designation prompt traps focus
+
+- **GIVEN** the designation prompt is open
+- **WHEN** the user presses Tab repeatedly
+- **THEN** focus SHALL cycle only through prompt-internal controls until
+  the prompt is closed

--- a/openspec/changes/add-spa-picker-component/tasks.md
+++ b/openspec/changes/add-spa-picker-component/tasks.md
@@ -1,0 +1,94 @@
+# Tasks: Add SPA Picker Component
+
+## 1. Component Scaffold
+
+- [ ] 1.1 Create `src/components/spa/SPAPicker/SPAPicker.tsx` with an
+      `ISPAPickerProps` contract (`onSelect`, `excludedIds`, `filterMode`)
+- [ ] 1.2 Create `src/components/spa/SPAPicker/index.ts` re-exporting the
+      component and its prop types
+- [ ] 1.3 Wire the component to load the catalog via `getAllSPAs()` from
+      `@/lib/spa` (do not duplicate the catalog)
+
+## 2. Category Tab Bar
+
+- [ ] 2.1 Render a tab bar with the eight UI categories (Piloting, Gunnery,
+      Miscellaneous, Infantry, aToW, Manei Domini, Unofficial, Edge)
+- [ ] 2.2 Each tab shows the count of entries that match the current
+      search and source filters
+- [ ] 2.3 An "All" tab SHALL render entries from every category
+- [ ] 2.4 Selected tab is visually distinct and persists across search
+      changes
+
+## 3. Search & Source Filters
+
+- [ ] 3.1 Text search filters by `displayName`, `description`, and
+      `source` (case-insensitive substring match)
+- [ ] 3.2 Source filter chips (`CamOps`, `MaxTech`, `ATOW`,
+      `ManeiDomini`, `Unofficial`, `Legacy`) toggle inclusion
+- [ ] 3.3 Clearing all filters restores the full catalog within the
+      active tab
+- [ ] 3.4 Empty result set shows a "No abilities match these filters"
+      empty state
+
+## 4. Entry Row Rendering
+
+- [ ] 4.1 Each row shows `displayName`, `description`, XP cost (or
+      "Origin-Only" / "Flaw" badge), source badge, category color
+      accent
+- [ ] 4.2 Flaws display with a negative XP value (e.g. "+200 XP")
+      since they grant XP rather than cost it
+- [ ] 4.3 Origin-only entries display an "Origin-Only" tag and a
+      disabled state when `filterMode === 'purchase-only'`
+- [ ] 4.4 Rows that appear in `excludedIds` render disabled with an
+      "Already owned" label
+
+## 5. Designation Prompt
+
+- [ ] 5.1 Clicking a row where `requiresDesignation === true` opens a
+      designation prompt, not an immediate selection
+- [ ] 5.2 Prompt content is driven by `designationType`:
+      `weapon_type` lists known weapon types from the weapon catalog;
+      `weapon_category` lists Energy / Ballistic / Missile / Melee;
+      `target` takes a free-text or target picker input;
+      `range_bracket` lists Short / Medium / Long;
+      `skill` lists Gunnery / Piloting;
+      `terrain` lists the terrain preset names
+- [ ] 5.3 Prompt has Confirm and Cancel actions; Cancel restores the
+      picker without selection; Confirm emits `{ spa, designation }`
+- [ ] 5.4 SPAs with `requiresDesignation === false` emit immediately on
+      click with `designation = undefined`
+
+## 6. Accessibility
+
+- [ ] 6.1 Tab bar is keyboard-navigable (ArrowLeft/ArrowRight,
+      Home/End)
+- [ ] 6.2 Each row has a visible focus ring and activates on Enter
+- [ ] 6.3 The designation prompt traps focus until Confirm or Cancel
+- [ ] 6.4 Source and category badges have `aria-label` text equivalents
+
+## 7. Spec Compliance
+
+- [ ] 7.1 Add new `spa-ui` spec delta with requirements for picker
+      layout, search, source filter, row content, and designation flow
+- [ ] 7.2 Add `pilot-system` spec delta for the picker's pilot-facing
+      selection contract
+- [ ] 7.3 Every new requirement has at least one GIVEN/WHEN/THEN
+      scenario
+- [ ] 7.4 Run `openspec validate add-spa-picker-component --strict`
+      clean
+
+## 8. Tests
+
+- [ ] 8.1 Unit test: default render shows all 91 entries when no
+      filters are applied
+- [ ] 8.2 Unit test: category tab switches filter the visible entries
+- [ ] 8.3 Unit test: search "weapon spec" narrows to Weapon Specialist
+- [ ] 8.4 Unit test: source filter "Unofficial" removes all non-Unofficial
+      rows
+- [ ] 8.5 Unit test: clicking a row with `requiresDesignation === true`
+      opens the designation prompt
+- [ ] 8.6 Unit test: designation Confirm emits the selected designation
+      payload
+- [ ] 8.7 Unit test: entry with id in `excludedIds` renders disabled
+- [ ] 8.8 Integration test: picker mounted inside a dialog emits
+      `onSelect` with the expected `{ spa, designation? }` payload

--- a/openspec/changes/add-terrain-rendering/proposal.md
+++ b/openspec/changes/add-terrain-rendering/proposal.md
@@ -1,0 +1,54 @@
+# Change: Add Terrain Rendering
+
+## Why
+
+The Phase 1 MVP draws hexes as flat colored polygons with a label. The
+terrain engine already models woods density, building hardness, water
+depth, rough/rubble/pavement, and elevation — but none of that shows on
+the map. A player currently has no visual cue that a hex is a heavy
+woods hex with +2 movement cost until they read the overlay tooltip. For
+a Civilization-grade presentation, each terrain type needs a recognizable
+illustrative style, and elevation needs gradient shading that the eye
+can read at a glance.
+
+## What Changes
+
+- Render illustrative terrain art per hex type: light woods, heavy woods,
+  light / medium / heavy / hardened buildings, shallow / deep water,
+  rough, rubble, pavement, clear
+- Shade hexes by elevation using a gradient (level 0 default, +N lighter,
+  -N darker) with a subtle contour edge at elevation transitions
+- Stack terrain: woods sit on top of a clear base; buildings sit on top
+  of pavement where present; depth shading applies beneath terrain art
+- All terrain art is homemade (not licensed) and consistent in style with
+  the mech silhouettes
+- Terrain tooltips and overlays continue to surface movement cost,
+  to-hit modifier, cover — layered over the new art
+
+## Dependencies
+
+- **Requires**: `add-interactive-combat-core-ui` (Phase 1 MVP shipped),
+  `tactical-map-interface`, `terrain-system` (terrain model), existing
+  `renderHelpers.ts` hex path generation
+- **Related**: `add-mech-silhouette-sprite-set` (same art style),
+  `add-los-and-firing-arc-overlays` (renders on top of terrain)
+- **Required By**: none — Phase 7 presentation layer
+
+## Impact
+
+- Affected specs: `terrain-system` (MODIFIED — add visual rendering
+  contract; terrain types now declare a visual style key),
+  `tactical-map-interface` (MODIFIED — hex render now composes a terrain
+  art layer + elevation shading layer beneath the token layer), new
+  `terrain-rendering` (ADDED — art catalog keys, elevation gradient
+  formula, layer stacking order)
+- Affected code: `src/components/gameplay/HexMapDisplay/HexCell.tsx`
+  (render terrain art under the hex polygon), new
+  `src/components/gameplay/terrain/` directory housing
+  `TerrainArtLayer.tsx` and SVG assets, new
+  `src/utils/terrain/elevationShading.ts` for the gradient formula
+- Non-goals: animated terrain (wind in trees, rippling water — future),
+  destructible building art (buildings change state through
+  existing damage overlays, not separate animations), weather overlays,
+  3D terrain height (explicitly shelved)
+- Assets: new SVG files under `public/sprites/terrain/` — homemade

--- a/openspec/changes/add-terrain-rendering/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-terrain-rendering/specs/tactical-map-interface/spec.md
@@ -1,0 +1,24 @@
+# tactical-map-interface Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: Hex Cell Composition
+
+Each hex cell SHALL compose a terrain art layer and an elevation
+shading layer beneath the existing interaction polygon.
+
+#### Scenario: Hex cell includes art layer
+
+- **GIVEN** a hex cell renders
+- **WHEN** its layers compose
+- **THEN** a `TerrainArtLayer` SHALL render beneath the hex polygon
+- **AND** the hex polygon SHALL remain the primary hit target
+- **AND** elevation shading SHALL apply to the fill beneath all art
+
+#### Scenario: Overlays still render above terrain
+
+- **GIVEN** a selected hex with movement-cost overlay visible
+- **WHEN** the hex renders
+- **THEN** terrain art SHALL render beneath the overlay
+- **AND** the overlay text SHALL remain legible
+- **AND** the unit token layer SHALL still render above everything

--- a/openspec/changes/add-terrain-rendering/specs/terrain-rendering/spec.md
+++ b/openspec/changes/add-terrain-rendering/specs/terrain-rendering/spec.md
@@ -1,0 +1,118 @@
+# terrain-rendering Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Homemade Terrain Art Catalog
+
+The terrain rendering system SHALL provide a homemade (not licensed)
+illustrative SVG asset for every terrain type supported by the terrain
+system.
+
+#### Scenario: Every terrain type has a visual key
+
+- **GIVEN** a terrain type among `clear`, `light woods`, `heavy woods`,
+  `light building`, `medium building`, `heavy building`, `hardened
+building`, `shallow water`, `deep water`, `rough`, `rubble`, `pavement`
+- **WHEN** the terrain visual map is queried
+- **THEN** exactly one SVG asset URL SHALL be returned
+- **AND** the asset SHALL live under `public/sprites/terrain/`
+- **AND** the asset SHALL be homemade (no licensed art reference)
+
+#### Scenario: Density variants resolve to different assets
+
+- **GIVEN** a woods hex with density `light`
+- **WHEN** the visual map resolves
+- **THEN** the light woods asset SHALL be returned
+- **AND** a `heavy` density SHALL resolve to the heavy woods asset
+
+### Requirement: Elevation Shading Gradient
+
+The terrain rendering system SHALL shade hexes by elevation using a
+monotonic lightness gradient centered on elevation 0.
+
+#### Scenario: Shading increases with elevation
+
+- **GIVEN** three hexes at elevations 0, 2, and -2
+- **WHEN** the elevation shading renders
+- **THEN** the +2 hex SHALL be lighter than the elevation-0 hex
+- **AND** the -2 hex SHALL be darker than the elevation-0 hex
+- **AND** the lightness step per level SHALL be ~6%
+
+#### Scenario: Clamping to BattleTech range
+
+- **GIVEN** an elevation of +8
+- **WHEN** the shading is computed
+- **THEN** the shading SHALL clamp at +6 (no additional lightening)
+- **AND** an elevation of -6 SHALL clamp at -4
+
+### Requirement: Contour Edges Between Elevation Changes
+
+The terrain rendering system SHALL render a contour line on each hex
+edge where adjacent hex elevations differ by 1 or more.
+
+#### Scenario: Contour line thickness scales with delta
+
+- **GIVEN** two adjacent hexes at elevations 1 and 3
+- **WHEN** the contour renders on their shared edge
+- **THEN** the contour line SHALL be ~2px thick (delta 2)
+- **AND** a delta of 1 SHALL produce a ~1px line
+- **AND** a delta of 0 SHALL produce no contour
+
+#### Scenario: Contour contrast against background
+
+- **GIVEN** a contour between a dark hex (elevation -2) and a light hex
+  (elevation +2)
+- **WHEN** the contour renders
+- **THEN** the contour color SHALL be chosen to contrast against both
+  neighboring fills
+
+### Requirement: Layer Stacking Order
+
+The terrain rendering system SHALL compose each hex from distinct visual
+layers in a fixed stacking order.
+
+#### Scenario: Layer order bottom to top
+
+- **GIVEN** a hex renders
+- **WHEN** its layers compose
+- **THEN** elevation shading SHALL render bottom
+- **AND** base terrain art (clear / pavement / water) SHALL render above
+- **AND** secondary terrain (woods, buildings) SHALL render above that
+- **AND** contour edges SHALL render above terrain art
+- **AND** tactical overlays (movement cost, selection) SHALL render
+  above contours
+- **AND** unit tokens SHALL render above all terrain layers
+
+#### Scenario: Rubble overrides destroyed buildings
+
+- **GIVEN** a building hex with `destroyed = true`
+- **WHEN** the hex renders
+- **THEN** the rubble asset SHALL render in place of the building asset
+- **AND** the pavement base (if any) SHALL remain
+
+### Requirement: Accessibility Shape Signatures
+
+Each terrain type SHALL carry a distinct shape signature so that
+colorblind users can identify terrain without relying on color alone.
+
+#### Scenario: Shape distinguishes terrain types
+
+- **GIVEN** a colorblind simulation mode
+- **WHEN** woods, buildings, water, rough, and pavement hexes render
+- **THEN** each SHALL carry a unique shape signature (triangular canopy
+  for woods, rectangular outline for buildings, wave pattern for water,
+  dotted pattern for rough, gridded for pavement)
+- **AND** terrain type SHALL be identifiable without color
+
+### Requirement: Fallback on Asset Load Failure
+
+If a terrain asset fails to load, the hex SHALL fall back to the flat
+color fill used in the Phase 1 MVP.
+
+#### Scenario: Missing asset falls back gracefully
+
+- **GIVEN** a terrain asset URL returns a 404
+- **WHEN** the hex renders
+- **THEN** the hex SHALL render with the Phase 1 MVP flat color
+- **AND** the error SHALL be logged (not thrown)
+- **AND** hit-testing SHALL remain functional

--- a/openspec/changes/add-terrain-rendering/specs/terrain-system/spec.md
+++ b/openspec/changes/add-terrain-rendering/specs/terrain-system/spec.md
@@ -1,0 +1,25 @@
+# terrain-system Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: Terrain Type Visual Metadata
+
+Each terrain type SHALL declare a `visualKey` that identifies the art
+asset used for rendering.
+
+#### Scenario: visualKey present on every terrain type
+
+- **GIVEN** the terrain registry
+- **WHEN** listing terrain types
+- **THEN** every type SHALL expose a `visualKey` string
+- **AND** the key SHALL match an entry in `terrainVisualMap`
+- **AND** the key SHALL be stable across persistence (saved games still
+  render correctly after art updates)
+
+#### Scenario: Density variants expose distinct visualKeys
+
+- **GIVEN** a terrain type with density variants (woods: light/heavy;
+  building: light/medium/heavy/hardened)
+- **WHEN** retrieving its `visualKey`
+- **THEN** each density variant SHALL map to its own key
+- **AND** the key SHALL NOT depend on runtime state

--- a/openspec/changes/add-terrain-rendering/tasks.md
+++ b/openspec/changes/add-terrain-rendering/tasks.md
@@ -1,0 +1,105 @@
+# Tasks: Add Terrain Rendering
+
+## 1. Terrain Art Catalog
+
+- [ ] 1.1 Draw homemade SVG art for each terrain type: clear, light woods,
+      heavy woods, light / medium / heavy / hardened buildings, shallow
+      water, deep water, rough, rubble, pavement
+- [ ] 1.2 Each asset sits inside a hex-shaped clip path at 200x200 viewBox
+- [ ] 1.3 Store under `public/sprites/terrain/<type>.svg`
+- [ ] 1.4 Confirm no asset resembles licensed BattleTech/MechWarrior art
+
+## 2. Terrain Visual Key Map
+
+- [ ] 2.1 Add `visualKey` property to each terrain type in
+      `terrain-system`
+- [ ] 2.2 Create `src/utils/terrain/terrainVisualMap.ts` mapping terrain
+      type + density -> asset URL
+- [ ] 2.3 Handle density variants (light vs heavy woods, light vs hardened
+      building) as separate keys
+- [ ] 2.4 Unit tests for every terrain type
+
+## 3. Elevation Gradient
+
+- [ ] 3.1 Create `src/utils/terrain/elevationShading.ts`
+- [ ] 3.2 `shadingFor(elevation)` returns a CSS color like
+      `hsl(base, sat, lightness)` where lightness scales with elevation
+- [ ] 3.3 Clamp elevation shading between -4 and +6 (BattleTech range)
+- [ ] 3.4 Base neutral lightness at elevation 0; +6% lightness per +1
+      level, -6% per -1 level
+- [ ] 3.5 Unit tests confirming monotonic lightness across the range
+
+## 4. TerrainArtLayer Component
+
+- [ ] 4.1 Create `src/components/gameplay/terrain/TerrainArtLayer.tsx`
+- [ ] 4.2 Render art via `<image href={visualKey}>` clipped to hex path
+- [ ] 4.3 Stack order: elevation shading (bottom), base terrain art,
+      secondary terrain (trees, buildings), contour edge (top of layer)
+- [ ] 4.4 Layer sits beneath the unit token layer
+
+## 5. HexCell Integration
+
+- [ ] 5.1 Extend `HexCell.tsx` to render the `TerrainArtLayer` beneath
+      the existing polygon
+- [ ] 5.2 Polygon stays for hit-testing and outline only
+- [ ] 5.3 Existing overlay (movement cost, selection highlight)
+      renders above the art layer
+- [ ] 5.4 Fallback: if art asset fails to load, render the current flat
+      color
+
+## 6. Elevation Contour Edges
+
+- [ ] 6.1 For each hex edge where adjacent hex elevation differs by >=1,
+      render a contour line
+- [ ] 6.2 Contour line thickness scales with elevation difference
+      (1 level = 1px, 2+ = 2px)
+- [ ] 6.3 Contour line color adapts to base hex lightness (dark on light,
+      light on dark) for contrast
+
+## 7. Terrain Stacking Rules
+
+- [ ] 7.1 Clear + woods: render clear base, woods on top at 75% opacity
+- [ ] 7.2 Pavement + building: render pavement base, building on top
+- [ ] 7.3 Water: single layer; shallow vs deep only differs in tint and
+      wave pattern density
+- [ ] 7.4 Rubble overrides building art when the building is destroyed
+
+## 8. Accessibility
+
+- [ ] 8.1 Each terrain type has a shape signature the eye can read
+      without color (trees = triangular canopy, buildings = rectangular
+      outline, water = wave pattern, rough = dotted, pavement = gridded)
+- [ ] 8.2 Colorblind-safe palette for the elevation gradient
+- [ ] 8.3 Respect `prefers-reduced-motion` (not strictly needed here, but
+      avoid any animated wave/grass)
+
+## 9. Performance
+
+- [ ] 9.1 Use `<use href="#symbol-id">` SVG symbol references so each
+      asset loads once and reuses across hexes
+- [ ] 9.2 Profile a 30x30 hex map render: terrain layer paint time
+      budget <= 16ms
+- [ ] 9.3 Skip art rendering for off-screen hexes (viewport culling)
+
+## 10. Tests
+
+- [ ] 10.1 Unit test: `terrainVisualMap` returns the right asset for
+      every terrain type + density
+- [ ] 10.2 Unit test: `shadingFor` produces monotonic lightness across
+      elevations -4 to +6
+- [ ] 10.3 Visual regression snapshot: one representative hex per
+      terrain type
+- [ ] 10.4 Integration test: placing a heavy-woods hex renders both
+      clear base and woods art
+- [ ] 10.5 Integration test: adjacent hexes at elevation 2 and 4 render
+      a contour between them
+
+## 11. Spec Compliance
+
+- [ ] 11.1 Every requirement in `terrain-rendering` spec has at least one
+      GIVEN/WHEN/THEN scenario
+- [ ] 11.2 Every requirement in `terrain-system` delta has at least one
+      scenario
+- [ ] 11.3 Every requirement in `tactical-map-interface` delta has at
+      least one scenario
+- [ ] 11.4 `openspec validate add-terrain-rendering --strict` passes clean

--- a/openspec/changes/add-vehicle-battle-value/proposal.md
+++ b/openspec/changes/add-vehicle-battle-value/proposal.md
@@ -1,0 +1,35 @@
+# Change: Add Vehicle Battle Value
+
+## Why
+
+The `battle-value-system` spec currently scopes BV to BattleMechs and reports BV=0 for every vehicle. Campaigns already list vehicles in forces, so undercosting them skews force-comparison, salvage payouts, and scenario balance. This change adds Vehicle BV 2.0 computation using TechManual rules for combat vehicles, VTOLs, and support vehicles. It depends on `add-vehicle-construction` so the calculator has legal inputs, and it blocks `add-vehicle-combat-behavior` which uses BV for AI target prioritization.
+
+## What Changes
+
+- Add vehicle-specific defensive BV: armor BV × armor multiplier + structure BV + defensive equipment BV − explosive penalties
+- Add vehicle defensive factor = 1 + ((maxMovement × 0.5) / 10) using ground speed (cruise × 0.5 for TMM) and flanking for VTOL / Hover / Hydrofoil bonus
+- Add vehicle offensive BV: weapon BV + ammo BV + offensive equipment BV, then × speed factor
+- Add vehicle speed factor using `runMP = flankMP` (no separate jump contribution for wheeled/tracked; VTOL includes altitude movement once combat spec lands)
+- Apply vehicle-specific multipliers: +5% for VTOL maneuverability, +5% per turret arc, motive-modifier penalty for fragile motive systems (hover/hydrofoil motive penalty already captured in offensive factor)
+- Apply crew skill multiplier identical to mech table (gunnery × piloting)
+- Support BAR armor scaling: support vehicles with BAR < 10 multiply armor BV by BAR / 10
+- Record vehicle BV breakdown on unit for display in customizer status bar
+
+## Non-goals
+
+- Motive-damage BV adjustments during combat (those are handled live, not at construction BV)
+- BV calculation for DropShips / naval warships
+- Battle Armor / Infantry / Protomech / Aerospace BV — each has its own Phase 6 change
+
+## Dependencies
+
+- **Requires**: `add-vehicle-construction` (legal unit state), `battle-value-system` (defines mech BV patterns reused here)
+- **Blocks**: `add-vehicle-combat-behavior` (AI uses BV for target pick)
+- **Phase 1 coupling**: none — BV is construction-time
+
+## Impact
+
+- **Affected specs**: `battle-value-system` (MODIFIED to reference vehicle path), `vehicle-unit-system` (ADDED BV requirements)
+- **Affected code**: `src/utils/construction/battleValueCalculations.ts` (new `calculateVehicleBV`), `src/utils/construction/vehicle/vehicleBV.ts`, `src/utils/construction/equipmentBVResolver.ts` (already applies to weapons; add vehicle-specific multipliers), `src/components/customizer/vehicle/VehicleStatusBar.tsx`
+- **New file**: `src/utils/construction/vehicle/vehicleBV.ts` with defensive/offensive decomposition
+- **Validation target**: BV parity against MegaMekLab canonical vehicles should reach ≥ 95% within 5% and ≥ 80% within 1% (bar is lower than mechs because catalogs have fewer canonical vehicles)

--- a/openspec/changes/add-vehicle-battle-value/specs/battle-value-system/spec.md
+++ b/openspec/changes/add-vehicle-battle-value/specs/battle-value-system/spec.md
@@ -1,0 +1,91 @@
+# battle-value-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Vehicle BV Dispatch
+
+The BV calculator SHALL route `IVehicleUnit` inputs to a vehicle-specific calculation path distinct from the BattleMech path.
+
+#### Scenario: Vehicle unit dispatch
+
+- **GIVEN** a combat vehicle with `unitType === UnitType.VEHICLE`
+- **WHEN** `calculateBattleValue(unit)` is called
+- **THEN** the vehicle calculator SHALL be invoked
+- **AND** the return SHALL include an `IVehicleBVBreakdown` object with `defensive`, `offensive`, `pilotMultiplier`, and `final` fields
+
+#### Scenario: Support vehicle dispatch
+
+- **GIVEN** a support vehicle with BAR rating 7
+- **WHEN** BV is calculated
+- **THEN** the vehicle calculator SHALL run with BAR-adjusted armor BV
+
+### Requirement: Vehicle Defensive BV
+
+Vehicle defensive BV SHALL combine armor, structure, defensive equipment, and motive-type TMM.
+
+#### Scenario: Defensive BV formula
+
+- **WHEN** computing vehicle defensive BV
+- **THEN** base defensive BV SHALL equal `armor × 2.5 × armorMult + structure × 1.5 × structureMult + defEquipBV − explosivePenalty`
+- **AND** defensive factor SHALL equal `1 + ((TMM × 0.5) / 10)`
+- **AND** final defensive BV SHALL equal `base × defensive factor`
+
+#### Scenario: VTOL TMM bonus
+
+- **GIVEN** a VTOL with flank MP 15
+- **WHEN** TMM is computed
+- **THEN** the TMM SHALL equal the 15-MP table value + 1 (altitude bonus)
+
+#### Scenario: BAR armor scaling
+
+- **GIVEN** a BAR-6 support vehicle with 40 armor points
+- **WHEN** armor BV is computed
+- **THEN** armor BV SHALL equal `40 × 2.5 × 1.0 × (6/10) = 60`
+
+### Requirement: Vehicle Offensive BV
+
+Vehicle offensive BV SHALL combine weapon BV, ammo BV, offensive equipment BV, turret multipliers, and speed factor.
+
+#### Scenario: Turret multiplier
+
+- **GIVEN** a vehicle with one Single turret containing 100 BV of weapons
+- **WHEN** offensive BV is computed
+- **THEN** the turret-mounted weapons SHALL receive a 1.05 multiplier (5% turret bonus)
+
+#### Scenario: Sponson pair multiplier
+
+- **GIVEN** a vehicle with a pair of Sponson turrets each holding 50 BV
+- **WHEN** offensive BV is computed
+- **THEN** each sponson SHALL receive a 1.025 multiplier (2.5% sponson bonus)
+
+#### Scenario: Rear-arc weapon penalty
+
+- **GIVEN** a combat vehicle with a rear-mounted AC/10 (no turret)
+- **WHEN** offensive BV is computed
+- **THEN** the rear-only weapon BV SHALL be multiplied by 0.5
+
+### Requirement: Vehicle Speed Factor
+
+Vehicle speed factor SHALL use flank MP with per-motion-type adjustments.
+
+#### Scenario: Tracked vehicle speed factor
+
+- **GIVEN** a tracked vehicle with flank MP 6
+- **WHEN** speed factor is computed
+- **THEN** `sf = round(pow(1 + (6 − 5) / 10, 1.2) × 100) / 100 = 1.12`
+
+#### Scenario: VTOL speed factor
+
+- **GIVEN** a VTOL with flank MP 15
+- **WHEN** speed factor is computed
+- **THEN** `sf = round(pow(1 + (15 − 5) / 10, 1.2) × 100) / 100 = 2.30`
+
+### Requirement: Vehicle Pilot Skill Adjustment
+
+Vehicle final BV SHALL apply the shared gunnery / piloting multiplier table identical to the mech calculator.
+
+#### Scenario: Standard crew
+
+- **GIVEN** a vehicle with gunnery 4 piloting 5
+- **WHEN** final BV is computed
+- **THEN** the pilot multiplier SHALL equal 1.00

--- a/openspec/changes/add-vehicle-battle-value/specs/vehicle-unit-system/spec.md
+++ b/openspec/changes/add-vehicle-battle-value/specs/vehicle-unit-system/spec.md
@@ -1,0 +1,30 @@
+# vehicle-unit-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Vehicle BV Breakdown on Unit State
+
+Every `IVehicleUnit` SHALL carry an `IVehicleBVBreakdown` populated by the calculator.
+
+#### Scenario: Breakdown shape
+
+- **GIVEN** a vehicle after construction completes
+- **WHEN** BV is computed
+- **THEN** `unit.bvBreakdown` SHALL contain at minimum: `defensive`, `offensive`, `pilotMultiplier`, `turretModifier`, `final`
+
+#### Scenario: Breakdown recomputed on construction edit
+
+- **GIVEN** an existing vehicle with BV 1100
+- **WHEN** the user adds 6 tons of weapons via the equipment tab
+- **THEN** `unit.bvBreakdown.offensive` SHALL increase
+- **AND** `unit.bvBreakdown.final` SHALL update live
+
+### Requirement: BV Parity Harness for Vehicles
+
+The validation tooling SHALL produce a vehicle BV parity report.
+
+#### Scenario: Vehicle validation report
+
+- **WHEN** the vehicle BV validator runs
+- **THEN** it SHALL emit `validation-output/vehicle-bv-validation-report.json`
+- **AND** the report SHALL include per-unit: `unitName`, `computedBV`, `mulBV`, `delta`, `deltaPct`

--- a/openspec/changes/add-vehicle-battle-value/tasks.md
+++ b/openspec/changes/add-vehicle-battle-value/tasks.md
@@ -1,0 +1,75 @@
+# Tasks: Add Vehicle Battle Value
+
+## 1. Calculator Scaffolding
+
+- [ ] 1.1 Create `src/utils/construction/vehicle/vehicleBV.ts`
+- [ ] 1.2 Export `calculateVehicleBV(unit: IVehicleUnit): IVehicleBVBreakdown`
+- [ ] 1.3 Wire dispatch in `battleValueCalculations.ts` so vehicle units route to the new calculator
+- [ ] 1.4 Define `IVehicleBVBreakdown` (defensive, offensive, modifiers, final)
+
+## 2. Defensive BV
+
+- [ ] 2.1 Compute armor BV = totalArmor × 2.5 × armorTypeMultiplier
+- [ ] 2.2 Compute structure BV = totalStructure × 1.5 × structureTypeMultiplier
+- [ ] 2.3 Sum defensive equipment BV (ECM, AMS, Guardian ECM, CASE, Chaff Pod, etc.) via resolver
+- [ ] 2.4 Subtract explosive-ammo penalties (same resolver rules as mech)
+- [ ] 2.5 Defensive factor = 1 + ((TMM × 0.5) / 10) using effective MP
+- [ ] 2.6 Apply defensive BV = (armor + structure + defEquip − explosive) × defensive factor
+
+## 3. TMM for Vehicle Motive Types
+
+- [ ] 3.1 Ground vehicle TMM: from flank MP (same table as mechs)
+- [ ] 3.2 VTOL: flank MP + 1 (+1 TMM bonus from altitude)
+- [ ] 3.3 Hover / Hydrofoil / WiGE: +1 TMM bonus when on appropriate terrain; BV uses the flat bonus
+- [ ] 3.4 Submarine: use depth movement
+
+## 4. Offensive BV
+
+- [ ] 4.1 Sum weapon BV via existing resolver (turret weapons use the same BV — no arc penalty at construction)
+- [ ] 4.2 Sum ammo BV
+- [ ] 4.3 Add offensive equipment BV (Targeting Computer, C3, ECM active role flags)
+- [ ] 4.4 Apply turret multiplier: +5% per rotating turret, +2.5% per sponson pair
+- [ ] 4.5 Apply rear-weapon penalty (0.5× BV) for rear-arc-only weapons on fixed-arc vehicles
+
+## 5. Speed Factor
+
+- [ ] 5.1 Use mp = flankMP (round jump bonus 0 for tracked/wheeled/naval/rail)
+- [ ] 5.2 VTOL: mp = flankMP + max(0, altitudeDelta/2) — altitude delta is 0 at construction
+- [ ] 5.3 sf = round(pow(1 + (mp − 5)/10, 1.2) × 100) / 100
+- [ ] 5.4 offensiveBV = offensive × sf
+
+## 6. BAR Armor Scaling for Support Vehicles
+
+- [ ] 6.1 When unit is support vehicle and BAR < 10, multiply armor BV by BAR/10
+- [ ] 6.2 When BAR = 10, no scaling
+- [ ] 6.3 Unit test: BAR 5 support truck with 20 armor → armor BV = 25
+
+## 7. Final Unit BV
+
+- [ ] 7.1 finalBV = (defensiveBV + offensiveBV) × pilotSkillMultiplier
+- [ ] 7.2 Pilot skill multiplier uses the shared gunnery/piloting table
+- [ ] 7.3 Store breakdown on `unit.bvBreakdown`
+
+## 8. Vehicle-Specific BV Modifiers
+
+- [ ] 8.1 Naval vehicles: +0.1 offensive multiplier when armed with naval gauss / naval laser
+- [ ] 8.2 VTOL maneuverability: already captured in TMM bonus; no extra factor
+- [ ] 8.3 Omni vehicle: BV is per pod configuration
+
+## 9. Status Bar
+
+- [ ] 9.1 `VehicleStatusBar.tsx` displays live BV, defensive/offensive split, and pilot-skill-adjusted final
+- [ ] 9.2 Breakdown dialog accessible from status bar
+
+## 10. Parity Harness
+
+- [ ] 10.1 Extend `scripts/validate-bv.ts` (or split a vehicle equivalent) to load vehicle canonical units
+- [ ] 10.2 Ingest MegaMekLab vehicle BV values and diff against computed BV
+- [ ] 10.3 Produce `validation-output/vehicle-bv-validation-report.json`
+- [ ] 10.4 Target ≥ 95% within 5%, ≥ 80% within 1% (report baseline, do not block)
+
+## 11. Validation
+
+- [ ] 11.1 `openspec validate add-vehicle-battle-value --strict`
+- [ ] 11.2 Unit tests: Demolisher, Manticore, Savannah Master, VTOL Warrior, LRM Carrier
+- [ ] 11.3 Build + lint clean

--- a/openspec/changes/add-vehicle-combat-behavior/proposal.md
+++ b/openspec/changes/add-vehicle-combat-behavior/proposal.md
@@ -1,0 +1,36 @@
+# Change: Add Vehicle Combat Behavior
+
+## Why
+
+Phase 1 combat is mech-centric — hit locations, heat tracking, and damage pipeline assume `IBattleMech`. Vehicles on the battlefield today either fall through the pipeline unchanged or silently fail. This change teaches the combat engine how a vehicle takes damage (motive hits, not critical slots), how its hit locations work (6-section vehicle table, not 11-section mech table), how its firing arcs are computed (per-side arcs, not based on torso twist), and how VTOL / Hover / Hydrofoil motion introduces its own damage effects.
+
+## What Changes
+
+- Add vehicle hit-location table per attack direction (Front / Side / Rear)
+- Add motive-damage table: damage to Front/Side/Rear with structure exposure triggers a Motive Damage roll per TW
+- Add motive-damage effects: minor (−1 cruise MP), moderate (−2), heavy (−3), immobilized
+- Add vehicle critical hit system (weapon / ammo / engine / crew / cargo / fuel / turret-lock)
+- Add vehicle-specific firing arcs: Front (60° front arc), Left/Right Side (120° each), Rear (60°); Turret ignores chassis facing
+- Add VTOL-specific rules: rotor hits reduce altitude / trigger crash, mast mount fixed arc
+- Add Hover / Hydrofoil motive-hit aggravation (bog-down / sinking on water terrain)
+- Wire `resolveDamage` and `resolveCriticalHits` to route to the vehicle variants when target is a vehicle
+- Emit vehicle-specific events: `MotiveDamage`, `TurretLocked`, `VehicleCrewStunned`, `VehicleImmobilized`
+- Extend game engine AI bot to understand vehicle movement legality (no reverse jump, no pivot in place for wheeled, etc.)
+
+## Non-goals
+
+- DropShip / warship combat — separate system
+- Motive-type terrain pathing (bogging down in swamp, etc.) — handled by `terrain-system` follow-up
+- Aerospace combat — covered by `add-aerospace-combat-behavior`
+- Infantry / BA combat — separate changes
+
+## Dependencies
+
+- **Requires**: `add-vehicle-construction` (legal unit with motive/turret data), `add-vehicle-battle-value` (AI prioritization), `integrate-damage-pipeline` (A4 damage pipeline), `wire-heat-generation-and-effects` (vehicles don't heat like mechs but must be exempt)
+- **Blocks**: full combined-arms play
+
+## Impact
+
+- **Affected specs**: `combat-resolution` (MODIFIED — route by unit type), `damage-system` (MODIFIED — vehicle transfer chain), `critical-hit-system` (MODIFIED — vehicle crit table), `hit-location-tables` (ADDED — vehicle front/side/rear tables), `firing-arc-calculation` (MODIFIED — vehicle arcs), `vehicle-unit-system` (ADDED — motive-damage state)
+- **Affected code**: `src/utils/gameplay/vehicleDamage.ts` (new), `src/utils/gameplay/vehicleHitLocation.ts` (new), `src/utils/gameplay/motiveDamage.ts` (new), `src/utils/gameplay/vehicleCriticalHitResolution.ts` (new), `src/utils/gameplay/firingArc.ts` (extend), `src/engine/GameEngine.ts` (type-dispatch damage/crit)
+- **New events**: `MotiveDamaged`, `MotivePenaltyApplied`, `VehicleImmobilized`, `TurretLocked`, `VehicleCrewStunned`

--- a/openspec/changes/add-vehicle-combat-behavior/specs/combat-resolution/spec.md
+++ b/openspec/changes/add-vehicle-combat-behavior/specs/combat-resolution/spec.md
@@ -1,0 +1,128 @@
+# combat-resolution (delta)
+
+## ADDED Requirements
+
+### Requirement: Vehicle Combat Dispatch
+
+The combat resolution engine SHALL route vehicle targets to a vehicle-specific damage pipeline distinct from the BattleMech path.
+
+#### Scenario: Vehicle target routing
+
+- **GIVEN** an attack whose target has `unitType === UnitType.VEHICLE`, `VTOL`, or `SUPPORT_VEHICLE`
+- **WHEN** the engine resolves the hit
+- **THEN** `vehicleResolveDamage()` SHALL be invoked (not the mech `resolveDamage`)
+- **AND** vehicle-specific hit-location and crit tables SHALL be used
+
+#### Scenario: Mech target unchanged
+
+- **GIVEN** an attack whose target is a BattleMech
+- **WHEN** the engine resolves the hit
+- **THEN** the existing BattleMech pipeline SHALL continue unchanged
+
+### Requirement: Vehicle Motive Damage Roll
+
+When damage exposes structure at a vehicle's Front, Side, or Rear location, the system SHALL roll for motive damage.
+
+#### Scenario: Motive roll on structure exposure
+
+- **GIVEN** a tracked vehicle whose Side location reaches internal structure
+- **WHEN** the hit is resolved
+- **THEN** the engine SHALL roll 2d6 against the motive-damage table
+- **AND** the resulting motive penalty SHALL be applied to the vehicle's cruise MP
+
+#### Scenario: Motive table outcomes
+
+- **WHEN** the 2d6 roll is evaluated
+- **THEN** 2-5 SHALL apply no effect
+- **AND** 6-7 SHALL apply -1 cruise MP (minor)
+- **AND** 8-9 SHALL apply -2 cruise MP (moderate)
+- **AND** 10-11 SHALL apply -3 cruise MP (heavy)
+- **AND** 12 SHALL immobilize the vehicle
+
+#### Scenario: Hover motive sensitivity
+
+- **GIVEN** a Hover vehicle
+- **WHEN** any damage is taken (structure exposure not required)
+- **THEN** a motive-damage roll SHALL be made
+
+### Requirement: Vehicle Hit Location Tables
+
+The system SHALL use vehicle-specific hit-location tables per attack direction.
+
+#### Scenario: Front attack table
+
+- **GIVEN** an attack from the Front arc
+- **WHEN** 2d6 is rolled
+- **THEN** 2 SHALL resolve to Front (TAC)
+- **AND** 3-4 SHALL resolve to Right Side
+- **AND** 5-7 SHALL resolve to Front
+- **AND** 8-9 SHALL resolve to Left Side
+- **AND** 10-11 SHALL resolve to Turret
+- **AND** 12 SHALL resolve to Front (TAC)
+
+#### Scenario: VTOL roll 12 hits Rotor
+
+- **GIVEN** a VTOL target
+- **WHEN** a Front or Rear hit location roll is 12
+- **THEN** the hit SHALL land on Rotor instead of Turret
+
+### Requirement: Vehicle Critical Hit Table
+
+The system SHALL use a vehicle-specific critical-hit table.
+
+#### Scenario: Crit table outcomes
+
+- **WHEN** a vehicle critical hit is rolled (2d6)
+- **THEN** outcomes SHALL map:
+  - 2-5 = no critical
+  - 6 = Crew Stunned
+  - 7 = Weapon Destroyed
+  - 8 = Cargo / Infantry Hit
+  - 9 = Driver Hit
+  - 10 = Fuel Tank Hit (ICE/FuelCell only; energy → reroll)
+  - 11 = Engine Hit
+  - 12 = Ammo Explosion (if ammo in crit slot)
+
+#### Scenario: Crew Stunned effect
+
+- **GIVEN** a vehicle that rolls Crew Stunned
+- **WHEN** the effect is applied
+- **THEN** a `VehicleCrewStunned` event SHALL fire
+- **AND** the vehicle SHALL skip its next movement phase and next weapon-attack phase
+
+#### Scenario: Engine Hit effect
+
+- **GIVEN** a vehicle that takes its first Engine Hit
+- **WHEN** the effect is applied
+- **THEN** the vehicle SHALL be disabled for the current turn
+- **AND** a second Engine Hit SHALL destroy the vehicle
+
+## MODIFIED Requirements
+
+### Requirement: Damage Distribution
+
+The system SHALL distribute damage across units based on battle intensity and outcome.
+
+#### Scenario: Victory results in light damage
+
+- **GIVEN** a battle with outcome VICTORY and 4 player units
+- **WHEN** distributeDamage is called
+- **THEN** units receive 0-30% damage on average
+
+#### Scenario: Defeat results in heavy damage
+
+- **GIVEN** a battle with outcome DEFEAT and 4 player units
+- **WHEN** distributeDamage is called
+- **THEN** units receive 40-80% damage on average
+
+#### Scenario: Draw results in moderate damage
+
+- **GIVEN** a battle with outcome DRAW and 4 player units
+- **WHEN** distributeDamage is called
+- **THEN** units receive 20-50% damage on average
+
+#### Scenario: Vehicle damage respects motive penalties
+
+- **GIVEN** a battle that destroys a vehicle by motive immobilization
+- **WHEN** damage is distributed
+- **THEN** the immobilized-but-intact vehicle SHALL count as combat-eligible salvage, not wreckage

--- a/openspec/changes/add-vehicle-combat-behavior/specs/firing-arc-calculation/spec.md
+++ b/openspec/changes/add-vehicle-combat-behavior/specs/firing-arc-calculation/spec.md
@@ -1,0 +1,38 @@
+# firing-arc-calculation (delta)
+
+## ADDED Requirements
+
+### Requirement: Vehicle Firing Arcs
+
+The firing-arc calculator SHALL compute vehicle arcs from facing and turret state.
+
+#### Scenario: Ground vehicle Front arc
+
+- **GIVEN** a tracked combat vehicle facing north
+- **WHEN** firing arc is computed for the Front location
+- **THEN** the arc SHALL be a 60° wedge centered on north
+
+#### Scenario: Ground vehicle Side arcs
+
+- **GIVEN** the same vehicle
+- **WHEN** firing arcs are computed for Left Side and Right Side
+- **THEN** each arc SHALL span 120°
+- **AND** together with Front (60°) and Rear (60°) SHALL cover the full 360°
+
+#### Scenario: Turret arc overrides chassis facing
+
+- **GIVEN** a vehicle with an unlocked Single turret
+- **WHEN** firing arc is computed for the Turret location
+- **THEN** the arc SHALL be 360° and independent of chassis facing
+
+#### Scenario: Locked turret reverts to Front arc
+
+- **GIVEN** a vehicle whose turret has taken a Turret Locked critical
+- **WHEN** firing arc is computed for turret weapons
+- **THEN** the arc SHALL be the chassis Front arc only
+
+#### Scenario: Sponson forward-side arc
+
+- **GIVEN** a vehicle with a left sponson turret
+- **WHEN** firing arc is computed for that sponson
+- **THEN** the arc SHALL be the 180° left-front hemisphere only

--- a/openspec/changes/add-vehicle-combat-behavior/specs/vehicle-unit-system/spec.md
+++ b/openspec/changes/add-vehicle-combat-behavior/specs/vehicle-unit-system/spec.md
@@ -1,0 +1,27 @@
+# vehicle-unit-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Motive Damage State Tracking
+
+Vehicle units SHALL carry a motive-damage state struct updated by combat resolution.
+
+#### Scenario: Motive damage counters
+
+- **GIVEN** any `IVehicleUnit`
+- **WHEN** the combat state is constructed
+- **THEN** `unit.combatState.motive` SHALL contain `originalCruiseMP`, `penaltyMP`, `immobilized`, `sinking`, `turretLocked`, `engineHits`, `driverHits`, `commanderHits`, `crewStunnedPhases`
+
+#### Scenario: Motive penalty applies to flank MP
+
+- **GIVEN** a vehicle with original cruise 5, flank 7 (floor(5×1.5)=7) and penalty 2
+- **WHEN** effective MP is computed
+- **THEN** effective cruise SHALL equal 3 (5 − 2)
+- **AND** effective flank SHALL equal 4 (floor(3 × 1.5))
+
+#### Scenario: Cumulative motive penalties
+
+- **GIVEN** a vehicle with cumulative motive penalty already at −3
+- **WHEN** another motive-damage roll applies −2
+- **THEN** penalty SHALL become −5
+- **AND** effective cruise MP SHALL not go below 0

--- a/openspec/changes/add-vehicle-combat-behavior/tasks.md
+++ b/openspec/changes/add-vehicle-combat-behavior/tasks.md
@@ -1,0 +1,90 @@
+# Tasks: Add Vehicle Combat Behavior
+
+## 1. Unit-Type Dispatch in Combat Engine
+
+- [ ] 1.1 Extend `resolveDamage()` dispatch to call `vehicleResolveDamage()` when target is `IVehicleUnit`
+- [ ] 1.2 Extend `resolveCriticalHits()` dispatch to call `vehicleResolveCriticalHits()`
+- [ ] 1.3 Extend `hitLocation.ts` dispatch to call `vehicleHitLocation()` when target is vehicle
+- [ ] 1.4 Extend `firingArc.ts` to compute vehicle arcs from facing + motion type
+
+## 2. Vehicle Hit Location Tables
+
+- [ ] 2.1 Front attack (2d6): 2=Front(TAC), 3-4=Right Side, 5-7=Front, 8-9=Left Side, 10-11=Turret, 12=Front(TAC)
+- [ ] 2.2 Side attack: 2=Side(TAC), 3-5=Rear, 6-8=Side, 9-10=Front, 11-12=Turret
+- [ ] 2.3 Rear attack: 2=Rear(TAC), 3-5=Left/Right Side, 6-8=Rear, 9-10=Turret, 11-12=Rear(TAC)
+- [ ] 2.4 VTOL extra: roll of 12 on Front/Rear attack hits Rotor instead of Turret
+- [ ] 2.5 Unit tests across every (direction × roll) combination
+
+## 3. Armor → Structure Transfer Chain (Vehicle)
+
+- [ ] 3.1 Apply damage to hit-location armor first
+- [ ] 3.2 Overflow into internal structure at that location
+- [ ] 3.3 No adjacent-location transfer (vehicles are single chassis)
+- [ ] 3.4 When any location's structure reaches 0, the vehicle is destroyed (except Turret → turret destroyed, Rotor → immobilized)
+- [ ] 3.5 Emit `LocationDestroyed` and `VehicleDestroyed` events
+
+## 4. Motive Damage Table
+
+- [ ] 4.1 Trigger motive-damage roll whenever damage exposes structure at Front/Side/Rear
+- [ ] 4.2 Roll 2d6: 2-5 = no effect, 6-7 = minor damage (-1 cruise MP), 8-9 = moderate (-2), 10-11 = heavy (-3), 12 = immobilized
+- [ ] 4.3 Apply `MotivePenaltyApplied` event with new cruise MP value
+- [ ] 4.4 Stack penalties (multiple rolls accumulate)
+- [ ] 4.5 Flank MP recomputed from reduced cruise MP
+- [ ] 4.6 Hover / Hydrofoil: motive-damage roll on any hit, not just structure-exposing
+
+## 5. Motive Crit Effects per Motion Type
+
+- [ ] 5.1 Tracked: reduced MP only; fully mobile at 1 MP minimum until immobilized
+- [ ] 5.2 Wheeled: immobilized on heavy motive damage (treat heavy = immobilized for wheeled)
+- [ ] 5.3 Hover: any heavy damage sinks (destroyed in water, bogged on land)
+- [ ] 5.4 VTOL: any rotor hit → crash (see §7)
+- [ ] 5.5 Naval: heavy → sinking begins (destroyed in N turns)
+
+## 6. Vehicle Critical Hit System
+
+- [ ] 6.1 Crit trigger: hit location rolls of 2 (TAC) or structure-exposing damage with crit roll ≥ 8
+- [ ] 6.2 Crit table: 1 = crew stunned (skip phase), 2 = weapon destroyed, 3 = cargo/infantry hit, 4 = driver/commander hit, 5 = fuel tank, 6 = engine, 7 = ammo explosion (if ammo in slot), 8 = crew killed
+- [ ] 6.3 Apply `VehicleCrewStunned` event — no firing / no movement next phase
+- [ ] 6.4 Engine crit: 1 hit = disabled this turn, 2 hits = engine destroyed → vehicle dead
+- [ ] 6.5 Ammo explosion: per standard ammo rules, vehicle destroyed
+- [ ] 6.6 Fuel tank: ICE/FuelCell only — fire onboard
+
+## 7. VTOL-Specific Rules
+
+- [ ] 7.1 Rotor location has its own armor/structure
+- [ ] 7.2 Any damage to Rotor structure → `VTOLCrashCheck` event
+- [ ] 7.3 Rotor destruction → vehicle falls, takes fall damage = 10 × altitude
+- [ ] 7.4 Altitude is tracked in combat state (0 at hover, 1-5 at flight)
+
+## 8. Turret-Specific Rules
+
+- [ ] 8.1 Turret Locked: crit #2 on turret location locks turret to current facing; turret weapons now fire in chassis Front arc only
+- [ ] 8.2 Emit `TurretLocked` event
+- [ ] 8.3 Dual turrets tracked independently
+
+## 9. Firing Arc Computation
+
+- [ ] 9.1 Ground vehicle arcs: Front = 60° front, Left/Right Side = 120° each, Rear = 60°
+- [ ] 9.2 Turret arc: 360° ignoring chassis facing (if not locked)
+- [ ] 9.3 Chin turret (VTOL): 360° horizontal with −1 to-hit penalty for pivots beyond 180°
+- [ ] 9.4 Sponson turrets: 180° forward-side arc only
+
+## 10. Heat Exemption
+
+- [ ] 10.1 Vehicles with Fusion/XL engines accumulate heat per TW combat-vehicle rules (1 heat per 3 heat-sink slots needed for weapons)
+- [ ] 10.2 ICE / Fuel Cell vehicles have no heat track at all
+- [ ] 10.3 Vehicle heat effects: at 6+ cap shutdown per Total Warfare; not identical to mech scale
+
+## 11. AI Adaptations
+
+- [ ] 11.1 Bot treats vehicle as no-reverse-jump, no pivot-in-place (wheeled)
+- [ ] 11.2 Bot prefers flanking arcs (Side) given motive-damage table
+- [ ] 11.3 Bot prioritizes turret-mounted high-BV weapons when scoring targets
+
+## 12. Validation
+
+- [ ] 12.1 `openspec validate add-vehicle-combat-behavior --strict`
+- [ ] 12.2 Simulation harness: 1 mech vs 1 tank produces legal outcomes
+- [ ] 12.3 Unit tests for motive damage table across directions + motion types
+- [ ] 12.4 Unit tests for turret-locked, crew-stunned, ammo-crit paths
+- [ ] 12.5 Build + lint clean

--- a/openspec/changes/add-vehicle-construction/proposal.md
+++ b/openspec/changes/add-vehicle-construction/proposal.md
@@ -1,0 +1,42 @@
+# Change: Add Vehicle Construction
+
+## Why
+
+Phase 6 brings combined arms to MekStation. Vehicles (combat vehicles, VTOLs, support vehicles) are the most common non-mech secondary unit and must move from skeleton UI to a full construction pipeline. Today `src/components/customizer/vehicle/` renders a chassis/armor/equipment shell but no construction rules enforce legal configurations, motive systems, turret allocation, engine tonnage, or crew. This change completes the construction side of the vehicle stack so later Phase 6 changes (BV, combat) have a valid unit to operate on.
+
+## What Changes
+
+- Add chassis configuration: motion type (Tracked/Wheeled/Hover/VTOL/Naval/Hydrofoil/Submarine/WiGE/Rail/Maglev) with per-type tonnage cap enforcement
+- Add engine selection with motive-modifier weight table (ICE/Fusion/XL/Light/Fuel Cell) and engine-rating validation against cruise MP
+- Add internal structure weight calculation (10% of tonnage, rounded to half-ton for combat vehicles)
+- Add armor allocation for the 6–8 vehicle locations (Front / Left Side / Right Side / Rear / Turret / (Rotor for VTOL) / (Chin Turret for VTOL) / (Body for support))
+- Add turret system: None / Single (360°) / Dual / Chin (VTOL only) / Sponson; enforce 10% of equipment weight rule
+- Add weapon and equipment mounting per location with ammo and power-amp weight calculation
+- Add crew size derivation from tonnage and motion type; enforce minimum crew per table
+- Add BAR rating selection for support vehicles; armor weight uses BAR-based points/ton
+- Add construction validation rule set (`VAL-VEHICLE-*`) covering tonnage/motion-type compatibility, engine legality, turret weight, armor max per location, crew, and power-amp requirements
+- Wire the construction pipeline into `vehicle-unit-system` store and customizer tabs (Structure/Armor/Equipment/Turret)
+
+## Non-goals
+
+- Combat behavior (damage, motive hits, hit tables) — covered by `add-vehicle-combat-behavior`
+- BV calculation — covered by `add-vehicle-battle-value`
+- DropShip / naval warship construction — out of scope
+- Record-sheet PDF layout for vehicles — follow-up work
+
+## Dependencies
+
+- **Requires**: existing `vehicle-unit-system` spec stubs (this change fills them), `construction-services`, `equipment-database`, `armor-system`
+- **Blocks**: `add-vehicle-battle-value`, `add-vehicle-combat-behavior`
+- **Phase 1 coupling**: uses the shared `construction-rules-core` pipeline; no dependency on A4 damage or A5 heat wiring (those are combat concerns)
+
+## Ordering in Phase 6
+
+Vehicle is the first of five unit types. Ordering: **vehicle → aerospace → battlearmor → infantry → protomech**. Vehicles ship first because they are the most common secondary unit in campaign forces.
+
+## Impact
+
+- **Affected specs**: `vehicle-unit-system` (ADDED requirements for motive/turret/crew/armor/validation), `construction-rules-core` (MODIFIED to route vehicle paths), `validation-rules-master` (MODIFIED to register `VAL-VEHICLE-*` rule IDs)
+- **Affected code**: `src/stores/vehicle/`, `src/utils/construction/vehicle/`, `src/components/customizer/vehicle/*`, `src/types/vehicle/`, `src/services/vehicleConstructionService.ts`
+- **New files**: vehicle chassis/turret/crew calculators, motive-type config table, BAR armor table for support vehicles
+- **No schema change**: existing vehicle records already carry the data; logic gap is the target

--- a/openspec/changes/add-vehicle-construction/specs/vehicle-unit-system/spec.md
+++ b/openspec/changes/add-vehicle-construction/specs/vehicle-unit-system/spec.md
@@ -1,0 +1,163 @@
+# vehicle-unit-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Engine Selection and Weight
+
+The system SHALL compute engine weight and validate engine rating against vehicle tonnage and motion type.
+
+#### Scenario: Fusion engine weight
+
+- **GIVEN** a 40-ton tracked vehicle with cruise MP 4
+- **WHEN** engine is set to Fusion
+- **THEN** engine rating SHALL equal 160 (tonnage × cruiseMP)
+- **AND** engine weight SHALL equal the Fusion rating-to-tons entry (5.5 t for 160)
+
+#### Scenario: XL engine half-weight
+
+- **GIVEN** the same 40-ton tracked vehicle
+- **WHEN** engine is set to XL
+- **THEN** engine weight SHALL equal Fusion weight × 0.5 (rounded to nearest half-ton)
+
+#### Scenario: Engine rating exceeds maximum
+
+- **WHEN** requested engine rating exceeds 400
+- **THEN** validation SHALL emit `VAL-VEHICLE-ENGINE` error "Engine rating 420 exceeds maximum 400"
+
+#### Scenario: Motion-type engine exclusions
+
+- **GIVEN** a Hover vehicle
+- **WHEN** engine type is set to Internal Combustion
+- **THEN** validation SHALL emit an error — Hover requires Fusion, XL, Light, or Fuel Cell engines
+
+### Requirement: Internal Structure Calculation
+
+The system SHALL compute vehicle internal structure weight as 10% of tonnage rounded to the nearest half-ton.
+
+#### Scenario: 40-ton vehicle structure weight
+
+- **GIVEN** a 40-ton combat vehicle with Standard structure
+- **WHEN** internal structure weight is computed
+- **THEN** the result SHALL equal 4.0 tons
+
+#### Scenario: Endo-Steel structure weight
+
+- **GIVEN** a 50-ton combat vehicle with Endo-Steel structure
+- **WHEN** internal structure weight is computed
+- **THEN** the result SHALL equal 2.5 tons (5.0 × 0.5)
+
+### Requirement: Armor Allocation with Per-Location Maximum
+
+The system SHALL enforce armor points per location ≤ 2 × internal structure at that location.
+
+#### Scenario: Armor cap on turret
+
+- **GIVEN** a vehicle with turret structure 5
+- **WHEN** user sets turret armor to 11
+- **THEN** validation SHALL emit `VAL-VEHICLE-ARMOR-LOC` error "Turret armor 11 exceeds maximum 10"
+
+#### Scenario: VTOL Rotor armor
+
+- **GIVEN** a VTOL with rotor structure 2
+- **WHEN** rotor armor is set above 4
+- **THEN** validation SHALL emit an armor-cap error
+
+#### Scenario: Support vehicle BAR armor
+
+- **GIVEN** a support vehicle with BAR rating 7
+- **WHEN** armor weight is computed
+- **THEN** points per ton SHALL follow the BAR-7 row of the support-armor table
+- **AND** the `barRating` SHALL be recorded on the unit
+
+### Requirement: Turret System Weight Rule
+
+The system SHALL compute turret weight as 10% of turret-mounted equipment weight, rounded up to the nearest half-ton.
+
+#### Scenario: Single turret weight
+
+- **GIVEN** a turret holding 6 tons of weapons + ammo
+- **WHEN** turret weight is computed
+- **THEN** turret weight SHALL equal 1.0 ton (0.6 rounded up to 1.0 — half-ton increments)
+
+#### Scenario: Dual turret tonnage gate
+
+- **GIVEN** a 45-ton combat vehicle
+- **WHEN** the user selects Dual turret
+- **THEN** validation SHALL emit an error — dual turrets require ≥ 50 tons
+
+#### Scenario: VTOL chin turret
+
+- **GIVEN** a VTOL
+- **WHEN** turret config is set to Chin
+- **THEN** turret weight SHALL equal 5% of chin-mounted equipment weight
+- **AND** Standard / Dual / Sponson turret options SHALL be disabled
+
+### Requirement: Crew Size Derivation
+
+The system SHALL derive minimum crew size from tonnage and motion type and reject understaffed configurations.
+
+#### Scenario: Tracked 40-ton crew
+
+- **GIVEN** a 40-ton tracked combat vehicle
+- **WHEN** minimum crew is computed
+- **THEN** the result SHALL equal 3 (driver + gunner + commander)
+
+#### Scenario: VTOL crew
+
+- **GIVEN** any VTOL
+- **WHEN** minimum crew is computed
+- **THEN** the result SHALL equal at least 2 (pilot + gunner)
+
+#### Scenario: Understaffed vehicle validation
+
+- **GIVEN** a vehicle with configured crew below its minimum
+- **WHEN** validation runs
+- **THEN** `VAL-VEHICLE-CREW` error SHALL fire
+
+### Requirement: Power Amplifier Requirement
+
+The system SHALL require power amplifiers for energy weapons when the engine is ICE or Fuel Cell.
+
+#### Scenario: Power amps required
+
+- **GIVEN** an ICE-powered vehicle with 4 tons of energy weapons
+- **WHEN** power-amp weight is computed
+- **THEN** the result SHALL equal 0.5 tons (10% rounded up to half-ton)
+- **AND** that weight SHALL be counted against total tonnage
+
+#### Scenario: No power amps for fusion
+
+- **GIVEN** a Fusion-engined vehicle with any energy weapons
+- **WHEN** power-amp requirement is evaluated
+- **THEN** power amps SHALL NOT be required
+
+### Requirement: Weapon and Equipment Mounting Arcs
+
+The system SHALL mount weapons and equipment to legal vehicle locations and reject arc violations.
+
+#### Scenario: Legal turret mount
+
+- **GIVEN** a combat vehicle with Single turret
+- **WHEN** a PPC is mounted in the Turret location
+- **THEN** mounting SHALL succeed
+
+#### Scenario: Rear-only sponson rejection
+
+- **GIVEN** a combat vehicle with Sponson turrets
+- **WHEN** equipment is mounted to a sponson in the Rear arc
+- **THEN** mounting SHALL fail — sponsons fire forward-side only
+
+### Requirement: Construction Validation Rule Set
+
+The system SHALL register the `VAL-VEHICLE-*` rule group covering tonnage, engine, turret, armor, crew, and power-amp validations.
+
+#### Scenario: Validation rule ids present
+
+- **WHEN** the validation registry initializes
+- **THEN** rule ids `VAL-VEHICLE-TONNAGE`, `VAL-VEHICLE-ENGINE`, `VAL-VEHICLE-TURRET`, `VAL-VEHICLE-ARMOR-LOC`, `VAL-VEHICLE-CREW`, and `VAL-VEHICLE-POWER-AMP` SHALL be registered
+
+#### Scenario: Legal vehicle passes all rules
+
+- **GIVEN** a legally constructed 40-ton Manticore
+- **WHEN** validation runs
+- **THEN** no `VAL-VEHICLE-*` errors SHALL be emitted

--- a/openspec/changes/add-vehicle-construction/tasks.md
+++ b/openspec/changes/add-vehicle-construction/tasks.md
@@ -1,0 +1,87 @@
+# Tasks: Add Vehicle Construction
+
+## 1. Types and Interfaces
+
+- [ ] 1.1 Extend `IVehicleUnit` with `motionType`, `engineType`, `engineRating`, `cruiseMP`, `turretConfig`, `crewSize`, `barRating?`
+- [ ] 1.2 Add `MotionType` enum (Tracked, Wheeled, Hover, VTOL, Naval, Hydrofoil, Submarine, WiGE, Rail, Maglev)
+- [ ] 1.3 Add `TurretConfig` enum (None, Single, Dual, Chin, Sponson)
+- [ ] 1.4 Add `VehicleLocation` enum (Front, LeftSide, RightSide, Rear, Turret, Body, Rotor, ChinTurret)
+- [ ] 1.5 Add `IVehicleArmor`, `IVehicleTurret`, `IVehicleCrew` interfaces per spec
+
+## 2. Motion Type + Tonnage Rules
+
+- [ ] 2.1 Implement per-motion-type max tonnage table per existing `vehicle-unit-system` spec
+- [ ] 2.2 Clamp tonnage when motion type changes (e.g., Hover → max 50t)
+- [ ] 2.3 On motion switch to VTOL, auto-add Rotor location and restrict turret to None/Chin
+- [ ] 2.4 On motion switch away from VTOL, remove Rotor and reset turret options
+- [ ] 2.5 Unit tests for every motion transition
+
+## 3. Engine Selection
+
+- [ ] 3.1 Compute engine rating from tonnage × cruiseMP
+- [ ] 3.2 Apply motive-modifier multiplier by motion type (Hover/VTOL/WiGE = 1.0, Tracked = 1.0, Wheeled = 1.0; Naval per table)
+- [ ] 3.3 Look up engine weight from rating × engine-type factor (Fusion 1.0, ICE 2.0, XL 0.5, Light 0.75, Fuel Cell 1.2)
+- [ ] 3.4 Validate engine rating does not exceed table max (400)
+- [ ] 3.5 Compute flank MP = floor(cruiseMP × 1.5)
+
+## 4. Internal Structure
+
+- [ ] 4.1 Compute structure weight = ceil(tonnage × 0.1 / 0.5) × 0.5 (combat vehicle)
+- [ ] 4.2 Apply structure-type multiplier (Standard 1.0, Endo-Steel 0.5, Composite 0.5)
+- [ ] 4.3 Compute internal structure points per location from tonnage table
+- [ ] 4.4 Unit tests for 20/40/60/80/100 ton vehicles
+
+## 5. Armor System
+
+- [ ] 5.1 Support all standard armor types (Standard, Ferro-Fibrous, Heavy FF, Light FF, Stealth, Reactive, Reflective, Hardened)
+- [ ] 5.2 Enforce per-location max armor = 2 × internal structure (location)
+- [ ] 5.3 Compute armor weight from points / points-per-ton by type
+- [ ] 5.4 Support BAR rating 1–10 for support vehicles with BAR-scaled armor tonnage
+- [ ] 5.5 Prevent armor allocation on Body (support) unless ≥ BAR 6
+- [ ] 5.6 Unit tests across combat, VTOL, and support armor paths
+
+## 6. Turret System
+
+- [ ] 6.1 Enforce turret weight = 10% of turret-mounted equipment weight (rounded up to half-ton)
+- [ ] 6.2 Single turret: 360° arc, mountable on combat vehicles, tonnage limited to tonnage – crew – other mounts
+- [ ] 6.3 Dual turret: each turret weighs 10% of its own equipment; only on vehicles ≥ 50t
+- [ ] 6.4 Chin turret: VTOL only, half weight of standard turret
+- [ ] 6.5 Sponson turret: per pair, 5% of equipment weight each, forward-side arc
+- [ ] 6.6 Validation: reject turret if motion type / tonnage is ineligible
+
+## 7. Crew Calculation
+
+- [ ] 7.1 Compute minimum crew from tonnage × motion-type table (e.g., Tracked 40t → 3 crew)
+- [ ] 7.2 Add passenger slots if configured
+- [ ] 7.3 Require commander crew slot on vehicles > 5t
+- [ ] 7.4 Validation error on understaffed vehicle
+
+## 8. Weapon and Equipment Mounting
+
+- [ ] 8.1 Mount weapons/equipment to legal locations (Front, sides, Rear, Turret(s), Body)
+- [ ] 8.2 Enforce arc legality (e.g., no Rear-mounted Sponson)
+- [ ] 8.3 Compute power amplifier weight: 10% of energy-weapon weight on ICE/Fuel Cell engines
+- [ ] 8.4 Reject equipment that requires slots the vehicle chassis cannot provide
+- [ ] 8.5 Support omni vehicles (pod-mounted equipment flag)
+
+## 9. Construction Validation Rules
+
+- [ ] 9.1 `VAL-VEHICLE-TONNAGE` — tonnage within legal range for motion type / unit sub-type
+- [ ] 9.2 `VAL-VEHICLE-ENGINE` — engine rating legal and engine weight + structure + armor + equipment ≤ tonnage
+- [ ] 9.3 `VAL-VEHICLE-TURRET` — turret mass 10% rule and motion-type eligibility
+- [ ] 9.4 `VAL-VEHICLE-ARMOR-LOC` — per-location armor ≤ 2× structure
+- [ ] 9.5 `VAL-VEHICLE-CREW` — at least minimum crew for tonnage / motion type
+- [ ] 9.6 `VAL-VEHICLE-POWER-AMP` — power amps present when required
+
+## 10. Store and UI Wiring
+
+- [ ] 10.1 Wire `vehicleStore` to persist all new construction state
+- [ ] 10.2 Update `VehicleStructureTab`, `VehicleArmorTab`, `VehicleEquipmentTab`, `VehicleTurretTab` to use the new calculators
+- [ ] 10.3 Status bar reflects live weight / tonnage ratio and validation errors
+- [ ] 10.4 Integration test: build a legal 40-ton tracked tank end-to-end
+
+## 11. Validation
+
+- [ ] 11.1 `openspec validate add-vehicle-construction --strict`
+- [ ] 11.2 Build + lint clean
+- [ ] 11.3 Fixture: Demolisher, Manticore, Savannah Master, VTOL Warrior, Support Truck round-trip through pipeline

--- a/openspec/changes/add-victory-and-post-battle-summary/proposal.md
+++ b/openspec/changes/add-victory-and-post-battle-summary/proposal.md
@@ -1,0 +1,52 @@
+# Change: Add Victory And Post-Battle Summary
+
+## Why
+
+Phase 1 defines "done" as a skirmish that reaches a decisive outcome with
+a readable summary. The engine can detect destruction-only end conditions
+today, but there's no way to concede, no turn-limit handling, no victory
+screen, and no post-battle report surface. Players need a moment of
+resolution — "I won/lost, here's what happened" — and a persistent log
+the fuzzer + future campaign integration can read from.
+
+## What Changes
+
+- Detect win conditions: last side standing (existing), opt-in concede,
+  turn-limit reached per `config.turnLimit`
+- Render a victory screen when a session transitions to `Completed`,
+  showing the winner, reason, and a short human summary
+- Render a post-battle report with per-unit damage received, kills, heat
+  problems, physical attacks, MVP determination (most damage dealt),
+  and an XP column marked `"pending campaign integration"` (Phase 3)
+- Persist the match log to `/api/matches` so it survives a page reload
+  and can be re-opened via `/gameplay/matches/[id]`
+- Concede affordance in the combat screen (small button under the phase
+  HUD) that appends `GameEnded` with `reason: 'concede'`
+
+## Dependencies
+
+- **Requires**: `add-interactive-combat-core-ui` (phase HUD for concede
+  button), `add-damage-feedback-ui` (post-battle report needs structured
+  damage events), `game-session-management` (session lifecycle),
+  `after-combat-report` (existing ACAR spec hosts casualty/damage
+  distribution shapes we re-use)
+- **Related**: Lane A A4 must be done or the post-battle report renders
+  zeroes
+- **Required By**: Phase 2 (Quick Sim reads the same post-battle report
+  schema)
+
+## Impact
+
+- Affected specs: `game-session-management` (MODIFIED — victory
+  detection rules for concede + turn limit + last-side-standing cleanup),
+  `after-combat-report` (MODIFIED — add `IPostBattleReport` schema),
+  `combat-resolution` (MODIFIED — tactical resolution path references
+  the same report schema)
+- Affected code: new `/gameplay/games/[id]/victory.tsx` page, new
+  `/gameplay/matches/[id].tsx` page, `useGameplayStore` gains an
+  `isGameCompleted` selector, new API route `/api/matches` for
+  persistence, `src/engine/InteractiveSession.ts` gains a
+  `concede(side)` method
+- Non-goals: XP calculation (Phase 3), contract-pay calculation (Phase
+  3), salvage generation (Phase 3), per-weapon hit-rate stats (Phase 2
+  Quick Sim)

--- a/openspec/changes/add-victory-and-post-battle-summary/specs/after-combat-report/spec.md
+++ b/openspec/changes/add-victory-and-post-battle-summary/specs/after-combat-report/spec.md
@@ -1,0 +1,83 @@
+# after-combat-report Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Post-Battle Report Schema
+
+The after-combat report system SHALL define an `IPostBattleReport`
+schema produced at the end of a tactical session, and `IUnitReport`
+per-unit entries, so the UI and the match log store can render and
+persist the outcome consistently.
+
+#### Scenario: Report contains required top-level fields
+
+- **GIVEN** a session that has completed via `GameEnded`
+- **WHEN** the report is derived
+- **THEN** the report SHALL contain `matchId`, `winner`, `reason`,
+  `turnCount`, `units`, `mvpUnitId`, `log`
+- **AND** `winner` SHALL be one of `GameSide.Player`, `GameSide.Opponent`,
+  or `"draw"`
+- **AND** `reason` SHALL be one of `"destruction"`, `"concede"`,
+  `"turn_limit"`
+
+#### Scenario: Unit report contains damage and kill accounting
+
+- **GIVEN** a unit that dealt 120 damage and took 80 damage and killed 1
+  enemy
+- **WHEN** the unit report is derived
+- **THEN** the `IUnitReport` SHALL contain `{unitId, side, designation,
+damageDealt: 120, damageReceived: 80, kills: 1, heatProblems,
+physicalAttacks, xpPending: true}`
+
+#### Scenario: XP always marked pending
+
+- **GIVEN** any derived unit report
+- **WHEN** inspecting its `xpPending` field
+- **THEN** the field SHALL be `true`
+- **AND** XP calculation SHALL NOT be performed in this change
+
+### Requirement: MVP Determination
+
+The after-combat report SHALL compute a single `mvpUnitId` selecting the
+winner-side unit with the greatest `damageDealt`, tie-broken first by
+lowest `damageReceived`, then by alphabetical designation.
+
+#### Scenario: Clear MVP by damage dealt
+
+- **GIVEN** winner side units with damage dealt {A: 200, B: 150, C: 100}
+- **WHEN** MVP is determined
+- **THEN** `mvpUnitId` SHALL equal unit A's id
+
+#### Scenario: Tie broken by damage received
+
+- **GIVEN** two units both dealt 200 damage; unit A took 50, unit B took
+  100
+- **WHEN** MVP is determined
+- **THEN** `mvpUnitId` SHALL equal unit A's id
+
+#### Scenario: No MVP for zero-damage winner
+
+- **GIVEN** a winner whose units dealt 0 total damage (e.g., a
+  turn-limit draw)
+- **WHEN** MVP is determined
+- **THEN** `mvpUnitId` SHALL be `null`
+
+### Requirement: Report Derivation From Event Log
+
+The after-combat report SHALL derive its fields purely from the session's
+`IGameEvent[]` log, with no session state mutation, ensuring the same
+log always produces the same report.
+
+#### Scenario: Deterministic derivation
+
+- **GIVEN** a fixed event log
+- **WHEN** `derivePostBattleReport(log)` is called twice
+- **THEN** both returned reports SHALL be deeply equal
+
+#### Scenario: Derivation counts kills from unit_destroyed events
+
+- **GIVEN** three `unit_destroyed` events in the log, each with
+  `killerId` set
+- **WHEN** the report is derived
+- **THEN** each killer's `IUnitReport.kills` SHALL increment once per
+  event where it is the killer

--- a/openspec/changes/add-victory-and-post-battle-summary/specs/combat-resolution/spec.md
+++ b/openspec/changes/add-victory-and-post-battle-summary/specs/combat-resolution/spec.md
@@ -1,0 +1,46 @@
+# combat-resolution Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Tactical Resolution References Post-Battle Report Schema
+
+The combat-resolution system SHALL, when invoked at the end of a tactical
+(interactive) session, return the same `IPostBattleReport` schema
+defined by `after-combat-report`, so the tactical and ACAR code paths
+converge on one downstream shape.
+
+#### Scenario: Tactical resolution returns IPostBattleReport
+
+- **GIVEN** an `InteractiveSession` that has transitioned to
+  `GameStatus.Completed`
+- **WHEN** `combatResolution.finalize(session)` is called
+- **THEN** the return value SHALL match the `IPostBattleReport` shape
+- **AND** the `reason` SHALL reflect how the session ended
+
+#### Scenario: ACAR resolution returns IPostBattleReport
+
+- **GIVEN** an ACAR auto-resolve call
+- **WHEN** the resolution completes
+- **THEN** the return value SHALL also match the `IPostBattleReport`
+  shape
+- **AND** tactical and ACAR reports SHALL be interchangeable downstream
+
+### Requirement: Post-Battle Report Persistence Is Optional For Quick Sims
+
+The combat-resolution system SHALL accept a `persist: boolean` option on
+`finalize`; when `persist = false`, the report SHALL NOT be written to
+`/api/matches`, so Quick Sim (Phase 2) can run thousands of matches
+without storage churn.
+
+#### Scenario: Tactical finalize persists by default
+
+- **GIVEN** `finalize(session)` called without an options argument
+- **WHEN** the call completes
+- **THEN** the derived report SHALL be POSTed to `/api/matches`
+
+#### Scenario: Quick Sim finalize skips persistence
+
+- **GIVEN** `finalize(session, {persist: false})`
+- **WHEN** the call completes
+- **THEN** no POST SHALL be made to `/api/matches`
+- **AND** the report SHALL still be returned to the caller

--- a/openspec/changes/add-victory-and-post-battle-summary/specs/game-session-management/spec.md
+++ b/openspec/changes/add-victory-and-post-battle-summary/specs/game-session-management/spec.md
@@ -1,0 +1,94 @@
+# game-session-management Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Concede End Condition
+
+The system SHALL allow a side to concede an active session, producing a
+`GameEnded` event whose winner is the opposite side and whose reason is
+`concede`.
+
+#### Scenario: Player concedes active game
+
+- **GIVEN** an active session with both sides still having units
+- **WHEN** `InteractiveSession.concede(GameSide.Player)` is called
+- **THEN** a `GameEnded` event SHALL be appended with
+  `{winner: GameSide.Opponent, reason: "concede"}`
+- **AND** `currentState.status` SHALL become `GameStatus.Completed`
+
+#### Scenario: Concede rejected after completion
+
+- **GIVEN** a session already in `GameStatus.Completed`
+- **WHEN** `InteractiveSession.concede(GameSide.Player)` is called
+- **THEN** the call SHALL throw an error `"Game is not active"`
+- **AND** no additional event SHALL be appended
+
+### Requirement: Turn Limit End Condition
+
+The system SHALL end an active session with `reason: "turn_limit"` when
+the End phase completes on a turn greater than `config.turnLimit`,
+evaluating the winner by total damage dealt (within a 5% tolerance for a
+draw).
+
+#### Scenario: Turn limit with clear damage winner
+
+- **GIVEN** `config.turnLimit = 20`, the session enters End phase on
+  turn 21, Player dealt 300 damage, Opponent dealt 200 damage
+- **WHEN** the victory check runs
+- **THEN** a `GameEnded` event SHALL be appended with
+  `{winner: GameSide.Player, reason: "turn_limit"}`
+
+#### Scenario: Turn limit with near-equal damage is draw
+
+- **GIVEN** Player dealt 310 damage, Opponent dealt 300 damage (within
+  5% of each other)
+- **WHEN** the turn-limit victory check runs
+- **THEN** the `GameEnded` event SHALL have `{winner: "draw", reason:
+"turn_limit"}`
+
+#### Scenario: Turn limit does not fire below threshold
+
+- **GIVEN** `config.turnLimit = 20` and the session enters End phase on
+  turn 15
+- **WHEN** the victory check runs
+- **THEN** no turn-limit `GameEnded` event SHALL be appended
+- **AND** the session SHALL continue to the next turn
+
+### Requirement: Game Completed Store Projection
+
+The system SHALL expose an `isGameCompleted` selector on
+`useGameplayStore` that the UI uses to trigger a redirect from the
+combat screen to the victory screen.
+
+#### Scenario: Selector true after GameEnded
+
+- **GIVEN** a session appended a `GameEnded` event
+- **WHEN** `isGameCompleted` is read
+- **THEN** it SHALL return `true`
+
+#### Scenario: Selector false while game active
+
+- **GIVEN** an active session with no `GameEnded` event
+- **WHEN** `isGameCompleted` is read
+- **THEN** it SHALL return `false`
+
+### Requirement: Match Log Persistence Handshake
+
+The system SHALL, on `GameEnded`, write a derived `IPostBattleReport`
+for the session to the match log store via POST `/api/matches` and SHALL
+expose GET `/api/matches/[id]` to retrieve it after reload.
+
+#### Scenario: GameEnded triggers persistence
+
+- **GIVEN** a `GameEnded` event is appended to the session
+- **WHEN** the persistence side-effect runs
+- **THEN** a POST SHALL be made to `/api/matches` with the derived
+  `IPostBattleReport` body
+- **AND** the response SHALL contain the new `matchId`
+
+#### Scenario: Reload reads persisted report
+
+- **GIVEN** a match previously persisted with id `"m-123"`
+- **WHEN** `/gameplay/matches/m-123` loads
+- **THEN** a GET SHALL be made to `/api/matches/m-123`
+- **AND** the response SHALL match the originally persisted report

--- a/openspec/changes/add-victory-and-post-battle-summary/tasks.md
+++ b/openspec/changes/add-victory-and-post-battle-summary/tasks.md
@@ -31,10 +31,10 @@
 ## 4. Post-Battle Report Schema
 
 - [ ] 4.1 Define `IPostBattleReport` with `{matchId, winner, reason,
-    turnCount, units: IUnitReport[], mvpUnitId, log: IGameEvent[]}`
+turnCount, units: IUnitReport[], mvpUnitId, log: IGameEvent[]}`
 - [ ] 4.2 Define `IUnitReport` with `{unitId, side, designation,
-    damageDealt, damageReceived, kills, heatProblems,
-    physicalAttacks, xpPending: true}`
+damageDealt, damageReceived, kills, heatProblems,
+physicalAttacks, xpPending: true}`
 - [ ] 4.3 Derive the report from the session's event log
 - [ ] 4.4 Unit tests for report derivation on known event streams
 
@@ -99,4 +99,4 @@
 - [ ] 11.3 Every requirement in `combat-resolution` delta has at least
       one scenario
 - [ ] 11.4 `openspec validate add-victory-and-post-battle-summary
-    --strict` passes clean
+--strict` passes clean

--- a/openspec/changes/add-victory-and-post-battle-summary/tasks.md
+++ b/openspec/changes/add-victory-and-post-battle-summary/tasks.md
@@ -1,0 +1,102 @@
+# Tasks: Add Victory And Post-Battle Summary
+
+## 1. Win Condition Detection
+
+- [ ] 1.1 Extend session End-phase victory check: last side standing
+      (already exists) + turn-limit reached + concede
+- [ ] 1.2 Turn-limit behavior: if `turn > config.turnLimit` with both
+      sides still active, `GameEnded` fires with `reason: 'turn_limit'`
+- [ ] 1.3 Concede: `InteractiveSession.concede(side)` appends `GameEnded`
+      with `reason: 'concede'` and the opposite side as winner
+- [ ] 1.4 Unit tests for each of the three end conditions
+
+## 2. Concede Button
+
+- [ ] 2.1 Phase HUD adds a small "Concede" button visible for the
+      Player-side only
+- [ ] 2.2 Clicking shows a confirm dialog `"End the match?"`
+- [ ] 2.3 Confirm invokes `concede(Player)` on the session
+
+## 3. Victory Screen
+
+- [ ] 3.1 New route `/gameplay/games/[id]/victory`
+- [ ] 3.2 Store selector `isGameCompleted` redirects from
+      `/gameplay/games/[id]` to `/victory` when the session's status
+      flips to `Completed`
+- [ ] 3.3 Victory screen shows winner side, reason (`destruction` |
+      `concede` | `turn_limit`), turn count, and a short summary line
+- [ ] 3.4 Screen has "View Post-Battle Report" and "Return to
+      Encounters" actions
+
+## 4. Post-Battle Report Schema
+
+- [ ] 4.1 Define `IPostBattleReport` with `{matchId, winner, reason,
+    turnCount, units: IUnitReport[], mvpUnitId, log: IGameEvent[]}`
+- [ ] 4.2 Define `IUnitReport` with `{unitId, side, designation,
+    damageDealt, damageReceived, kills, heatProblems,
+    physicalAttacks, xpPending: true}`
+- [ ] 4.3 Derive the report from the session's event log
+- [ ] 4.4 Unit tests for report derivation on known event streams
+
+## 5. Post-Battle Report Screen
+
+- [ ] 5.1 New route `/gameplay/matches/[id]`
+- [ ] 5.2 Screen renders one row per unit with the report columns
+- [ ] 5.3 MVP row has a highlighted background
+- [ ] 5.4 XP column shows "pending campaign integration" placeholder
+- [ ] 5.5 Collapsible event log below the unit rows (all events from the
+      match)
+
+## 6. Match Log Persistence
+
+- [ ] 6.1 On `GameEnded`, write the report to `/api/matches` with POST
+- [ ] 6.2 API route uses SQLite to persist the report
+- [ ] 6.3 GET `/api/matches/[id]` returns the stored report
+- [ ] 6.4 Page `/gameplay/matches/[id]` fetches from this route
+
+## 7. Victory Reason Labels
+
+- [ ] 7.1 `destruction` → "Last side standing"
+- [ ] 7.2 `concede` → "Opponent conceded" (or "You conceded" when
+      applicable)
+- [ ] 7.3 `turn_limit` → "Turn limit reached"
+- [ ] 7.4 Labels are externalized for future localization
+
+## 8. MVP Determination
+
+- [ ] 8.1 MVP is the unit with the highest `damageDealt` on the winning
+      side
+- [ ] 8.2 Ties broken by lowest `damageReceived`, then alphabetical
+      designation
+- [ ] 8.3 If no damage was dealt by the winner, MVP is null (e.g.,
+      turn-limit + zero-damage draw)
+
+## 9. Draw Handling
+
+- [ ] 9.1 Turn-limit outcome with both sides active evaluates total
+      damage — if tied within 5%, result is a draw; otherwise the side
+      dealing more damage wins
+- [ ] 9.2 Draw case renders a "Draw" variant of the victory screen
+- [ ] 9.3 Post-battle report shows both sides without an MVP highlight
+
+## 10. Integration Tests
+
+- [ ] 10.1 End-to-end: fire enough attacks to destroy all opponent
+      units; victory screen shows with `reason: destruction`
+- [ ] 10.2 End-to-end: concede from Player side; victory screen shows
+      Opponent winning with `reason: concede`
+- [ ] 10.3 End-to-end: simulate 20-turn match; at turn 21 victory screen
+      shows with `reason: turn_limit`
+- [ ] 10.4 End-to-end: post-battle report persisted and readable on
+      reload
+
+## 11. Spec Compliance
+
+- [ ] 11.1 Every requirement in `game-session-management` delta has at
+      least one GIVEN/WHEN/THEN scenario
+- [ ] 11.2 Every requirement in `after-combat-report` delta has at
+      least one scenario
+- [ ] 11.3 Every requirement in `combat-resolution` delta has at least
+      one scenario
+- [ ] 11.4 `openspec validate add-victory-and-post-battle-summary
+    --strict` passes clean

--- a/openspec/changes/add-what-if-to-hit-preview/proposal.md
+++ b/openspec/changes/add-what-if-to-hit-preview/proposal.md
@@ -1,0 +1,62 @@
+# Change: Add What-If To-Hit Preview
+
+## Why
+
+Phase 1's weapon-attack UI (`add-attack-phase-ui`) lets the player
+preview to-hit target numbers and hit probability before committing —
+but stops there. The player can't see expected damage, cluster-hit
+variance, or crit probability until they actually fire. Phase 2's
+decision-support promise is "see what the attack _will likely do_
+before you commit". This change adds a non-committing preview that
+plugs directly into the existing weapon-picker: toggle "Preview
+Damage", and every selected weapon row shows expected damage (mean),
+damage stddev, hit probability (already there from Phase 1), and crit
+probability — all purely informational, no events appended, no state
+mutated.
+
+## What Changes
+
+- Add `previewAttackOutcome(attack): IAttackPreview` to the to-hit
+  resolution system, returning `{hitProbability, expectedDamage,
+damageStddev, critProbability, clusterHitsMean, clusterHitsStddev}`
+  for a prospective attack, with no dice rolls and no state mutation
+- Extend the damage system with `expectedDamage(weapon, hitProbability)`
+  and `damageVariance(weapon, hitProbability)` helpers that integrate
+  the cluster-hit table expectation (for cluster weapons) with the
+  hit probability
+- Extend the weapon-resolution-system UI projection with
+  `preview: IAttackPreview | null` on `IUIWeaponState`, populated when
+  the Preview Damage toggle is enabled
+- Add a "Preview Damage" toggle in the weapon-picker header; when ON,
+  each weapon row shows preview columns (exp. damage, stddev, crit %)
+  next to the existing hit-probability column
+- Preview is purely read-only — no `AttackDeclared` event fires, no
+  ammo decrements, and toggling the switch SHALL NOT cost the player a
+  turn
+
+## Dependencies
+
+- **Requires**: `add-attack-phase-ui` (the weapon picker this extends),
+  `to-hit-resolution` (existing `forecastToHit` + `hitProbability`),
+  `damage-system` (cluster hit tables, crit probability derivation),
+  `weapon-resolution-system` (existing `IUIWeaponState` projection),
+  Phase 1 A4 (damage pipeline integration — otherwise expected damage
+  is wrong)
+- **Required By**: none (leaf informational surface)
+
+## Impact
+
+- Affected specs: `to-hit-resolution` (ADDED — `previewAttackOutcome`
+  - `critProbability` derivation), `damage-system` (ADDED — expected
+    damage + variance from cluster tables + hit probability),
+    `weapon-resolution-system` (MODIFIED — `IUIWeaponState` gains
+    optional `preview` field; the weapon-picker toggles population)
+- Affected code: new `src/utils/gameplay/toHit/preview.ts`, new
+  `src/utils/gameplay/damage/expectedDamage.ts`,
+  `src/components/gameplay/WeaponPicker.tsx` (adds toggle + preview
+  columns), `src/stores/useGameplayStore.ts` (gains `previewEnabled:
+boolean` UI flag)
+- Non-goals: predicting hit location (random), predicting specific
+  critical hit effects (too noisy), showing preview on non-weapon
+  actions (physical attacks are a separate future scope), persisting
+  preview state across page reloads (session-scoped toggle is enough)

--- a/openspec/changes/add-what-if-to-hit-preview/specs/damage-system/spec.md
+++ b/openspec/changes/add-what-if-to-hit-preview/specs/damage-system/spec.md
@@ -1,0 +1,105 @@
+# damage-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Expected Damage Helper
+
+The damage system SHALL expose `expectedDamage(weapon: IWeapon,
+hitProbability: number): number` that returns the statistical mean
+damage for a weapon given its hit probability, with cluster weapons
+integrating the cluster hit table expectation.
+
+#### Scenario: Single-shot weapon expected damage
+
+- **GIVEN** a Medium Laser (single-shot, 5 damage) and
+  `hitProbability = 0.72`
+- **WHEN** `expectedDamage(weapon, 0.72)` is called
+- **THEN** the result SHALL equal 3.6 (= 0.72 × 5)
+
+#### Scenario: Cluster weapon expected damage
+
+- **GIVEN** an LRM-10 (1 damage per missile, 10-rack) and
+  `hitProbability = 0.5`
+- **WHEN** `expectedDamage(weapon, 0.5)` is called
+- **THEN** the result SHALL equal 3.07 (= 0.5 × 6.14 × 1) within ±0.01
+- **AND** the expected cluster hits SHALL be 6.14 (standard 10-rack
+  cluster table expectation)
+
+#### Scenario: Streak weapon all-or-nothing
+
+- **GIVEN** a Streak SRM-4 (2 damage per missile, 4-rack) and
+  `hitProbability = 0.6`
+- **WHEN** `expectedDamage(weapon, 0.6)` is called
+- **THEN** the result SHALL equal 4.8 (= 0.6 × 4 × 2, Streak fires all
+  missiles on a successful lock-on)
+
+#### Scenario: Zero hit probability yields zero damage
+
+- **GIVEN** any weapon with `hitProbability = 0`
+- **WHEN** `expectedDamage(weapon, 0)` is called
+- **THEN** the result SHALL equal 0
+
+#### Scenario: One-shot weapon respects remaining shots
+
+- **GIVEN** a one-shot SRM-2 launcher that has already fired
+- **WHEN** `expectedDamage(weapon, 0.5)` is called
+- **THEN** the result SHALL equal 0 (no remaining shots)
+
+### Requirement: Damage Variance Helper
+
+The damage system SHALL expose `damageVariance(weapon: IWeapon,
+hitProbability: number): number` that returns the standard deviation
+(not raw variance) of damage so that the UI can display `±stddev`
+directly without additional math.
+
+#### Scenario: Single-shot weapon stddev
+
+- **GIVEN** a Medium Laser (5 damage) with `hitProbability = 0.5`
+- **WHEN** `damageVariance(weapon, 0.5)` is called
+- **THEN** the result SHALL equal 2.5 (= sqrt(0.5 × 0.5) × 5)
+
+#### Scenario: Stddev clamps to zero at extreme probabilities
+
+- **GIVEN** a Medium Laser with `hitProbability = 1.0`
+- **WHEN** `damageVariance(weapon, 1.0)` is called
+- **THEN** the result SHALL equal 0 (certain hit, no variance)
+
+- **GIVEN** the same weapon with `hitProbability = 0.0`
+- **WHEN** `damageVariance(weapon, 0.0)` is called
+- **THEN** the result SHALL equal 0 (certain miss, no variance)
+
+#### Scenario: Cluster weapon stddev includes cluster distribution
+
+- **GIVEN** an LRM-10 with `hitProbability = 0.5`
+- **WHEN** `damageVariance(weapon, 0.5)` is called
+- **THEN** the result SHALL combine the Bernoulli hit variance with
+  the cluster table variance (formula documented in implementation)
+- **AND** the result SHALL be strictly greater than the non-cluster
+  variance for the same expected damage
+
+### Requirement: Cluster Hit Table Expectations
+
+The damage system SHALL pre-compute and cache
+`expectedClusterHits[rackSize]` for each cluster rack size (2, 3, 4, 5,
+6, 7, 8, 9, 10, 12, 15, 20) as the dot product of the 2d6 probability
+mass and the cluster table row, avoiding re-computation during UI
+interaction.
+
+#### Scenario: Expected hits for 10-missile rack
+
+- **GIVEN** the standard TechManual cluster table
+- **WHEN** `expectedClusterHits[10]` is read
+- **THEN** the result SHALL equal 6.14 within ±0.01
+
+#### Scenario: Expected hits for 2-missile rack
+
+- **GIVEN** the standard TechManual cluster table
+- **WHEN** `expectedClusterHits[2]` is read
+- **THEN** the result SHALL equal 1.42 within ±0.01
+
+#### Scenario: Constant cached after first access
+
+- **GIVEN** `expectedClusterHits` has been accessed once
+- **WHEN** the same index is accessed 1000 more times
+- **THEN** the underlying computation SHALL run exactly once (cached
+  module-level constant)

--- a/openspec/changes/add-what-if-to-hit-preview/specs/to-hit-resolution/spec.md
+++ b/openspec/changes/add-what-if-to-hit-preview/specs/to-hit-resolution/spec.md
@@ -1,0 +1,112 @@
+# to-hit-resolution Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Attack Preview Projection
+
+The to-hit resolution system SHALL expose `previewAttackOutcome(attack):
+IAttackPreview` that composes the existing `forecastToHit` and
+`hitProbability` helpers with damage and crit probability derivations
+to produce a purely informational snapshot of what the attack would
+likely do if it were fired.
+
+#### Scenario: Preview combines hit, damage, and crit statistics
+
+- **GIVEN** an attacker with gunnery 4, a Medium Laser at medium range
+  vs. a stationary target, and a damage pipeline with standard armor
+  and structure
+- **WHEN** `previewAttackOutcome(attack)` is called
+- **THEN** the returned `IAttackPreview` SHALL contain non-null values
+  for all fields: `{hitProbability, expectedDamage, damageStddev,
+critProbability, clusterHitsMean, clusterHitsStddev}`
+- **AND** `hitProbability` SHALL equal the existing
+  `hitProbability(forecastToHit(attack).finalTn)` result
+
+#### Scenario: Preview is purely informational (no state mutation)
+
+- **GIVEN** a session with no `AttackDeclared` events yet appended
+- **WHEN** `previewAttackOutcome(attack)` is called 1000 times with
+  the same input
+- **THEN** `session.events.length` SHALL remain unchanged
+- **AND** all 1000 returned previews SHALL be deeply equal
+- **AND** no weapon ammo counters SHALL change
+
+#### Scenario: Out-of-range preview
+
+- **GIVEN** an attack where the weapon is beyond its Long range bracket
+- **WHEN** the preview is computed
+- **THEN** `hitProbability` SHALL equal 0
+- **AND** `expectedDamage` SHALL equal 0
+- **AND** `damageStddev` SHALL equal 0
+- **AND** `critProbability` SHALL equal 0
+
+#### Scenario: Cluster weapon preview includes cluster statistics
+
+- **GIVEN** an LRM-10 attack at medium range vs. gunnery 4 target
+- **WHEN** the preview is computed
+- **THEN** `clusterHitsMean` SHALL equal 6.14 (standard cluster table
+  expected value for a 10-missile rack)
+- **AND** `clusterHitsStddev` SHALL be a positive number (stddev of
+  the cluster hit distribution)
+- **AND** `expectedDamage` SHALL equal `hitProbability *
+clusterHitsMean * 1` (1 damage per missile)
+
+#### Scenario: Non-cluster weapon has zero cluster variance
+
+- **GIVEN** a Medium Laser attack (single-shot, not cluster)
+- **WHEN** the preview is computed
+- **THEN** `clusterHitsMean` SHALL equal 1
+- **AND** `clusterHitsStddev` SHALL equal 0
+
+### Requirement: Critical Hit Probability Derivation
+
+The to-hit resolution system SHALL expose `critProbability(attack):
+number` returning the probability that the attack produces at least
+one critical hit, usable as a standalone helper or internally by
+`previewAttackOutcome`.
+
+#### Scenario: Crit probability on full-armor target
+
+- **GIVEN** an attack on a target with full armor in all locations
+- **WHEN** `critProbability(attack)` is called
+- **THEN** the result SHALL equal the probability of a through-armor
+  critical (TAC): `P(hit) * P(hit location roll = 2) * P(crit on 2d6)`
+- **AND** the result SHALL be less than `P(hit)` (since TAC is strictly
+  rarer than a hit)
+
+#### Scenario: Crit probability with zero hit chance
+
+- **GIVEN** an attack with `hitProbability === 0`
+- **WHEN** `critProbability` is called
+- **THEN** the result SHALL equal 0
+
+#### Scenario: Crit probability aggregated across cluster hits
+
+- **GIVEN** an LRM-10 attack where each missile independently has a
+  chance to crit
+- **WHEN** `critProbability` is called
+- **THEN** the result SHALL aggregate expected crit occurrences across
+  the expected cluster hit count (per-missile probabilities summed
+  using the union-bound approximation documented in the implementation
+  note)
+
+### Requirement: Preview Determinism
+
+`previewAttackOutcome` SHALL be deterministic for a given input —
+calling it with the same attack descriptor SHALL always return the
+same `IAttackPreview`.
+
+#### Scenario: Repeated calls return identical results
+
+- **GIVEN** a fixed attack descriptor
+- **WHEN** `previewAttackOutcome(attack)` is called twice back-to-back
+- **THEN** the two returned `IAttackPreview` objects SHALL be deeply
+  equal
+
+#### Scenario: No DiceRoller consumption
+
+- **GIVEN** a session with a `DiceRoller` backed by `SeededRandom`
+- **WHEN** `previewAttackOutcome(attack)` is called
+- **THEN** the `DiceRoller`'s internal state SHALL NOT advance
+- **AND** the next real dice roll SHALL produce the same value it
+  would have produced without the preview call

--- a/openspec/changes/add-what-if-to-hit-preview/specs/weapon-resolution-system/spec.md
+++ b/openspec/changes/add-what-if-to-hit-preview/specs/weapon-resolution-system/spec.md
@@ -1,0 +1,97 @@
+# weapon-resolution-system Specification Delta
+
+## ADDED Requirements
+
+### Requirement: UI Weapon Preview Field
+
+The weapon resolution system SHALL extend the existing `IUIWeaponState`
+projection with an optional `preview: IAttackPreview | null` field
+populated when `useGameplayStore.previewEnabled === true`, allowing
+the weapon-picker UI to render expected damage, stddev, and crit
+probability alongside the existing hit-probability column.
+
+#### Scenario: Preview populated when toggle enabled
+
+- **GIVEN** `previewEnabled === true`, a locked target, and a Medium
+  Laser in range
+- **WHEN** the `IUIWeaponState` projection is requested
+- **THEN** the returned state SHALL contain `preview:
+{hitProbability, expectedDamage, damageStddev, critProbability,
+clusterHitsMean, clusterHitsStddev}`
+- **AND** `preview.hitProbability` SHALL equal the value returned by
+  the existing `hitProbability(forecastToHit(attack).finalTn)`
+
+#### Scenario: Preview null when toggle disabled
+
+- **GIVEN** `previewEnabled === false`
+- **WHEN** the projection is requested
+- **THEN** the returned `IUIWeaponState.preview` SHALL be `null`
+- **AND** no `previewAttackOutcome` computation SHALL occur
+
+#### Scenario: Preview null for out-of-range weapons
+
+- **GIVEN** `previewEnabled === true` and a weapon that is out of
+  range (`inRange === false`)
+- **WHEN** the projection is requested
+- **THEN** `preview` SHALL be `null` (not a zero-filled preview)
+- **AND** the weapon-picker UI SHALL render `"—"` in the preview
+  columns
+
+### Requirement: Preview Memoization
+
+The weapon resolution system SHALL memoize the `IUIWeaponState`
+projection on the tuple
+`{attackerId, targetId, weaponId, previewEnabled}` so that unrelated
+store updates (e.g., log scrolling, unrelated unit hover) do NOT
+trigger re-computation of the preview.
+
+#### Scenario: Memo hit when inputs unchanged
+
+- **GIVEN** `IUIWeaponState` has been computed for
+  `{attackerId: "u1", targetId: "u42", weaponId: "ml-1",
+previewEnabled: true}`
+- **WHEN** a store update fires that does not change any of those
+  four keys
+- **THEN** the cached projection SHALL be returned
+- **AND** `previewAttackOutcome` SHALL NOT be called again
+
+#### Scenario: Memo miss when target changes
+
+- **GIVEN** a cached projection for target `"u42"`
+- **WHEN** the target lock changes to `"u43"`
+- **THEN** the projection SHALL recompute
+- **AND** a fresh `previewAttackOutcome` call SHALL occur
+
+### Requirement: Preview Toggle UI Surface
+
+The weapon-picker UI SHALL expose a "Preview Damage" toggle bound to
+`useGameplayStore.previewEnabled`; toggling it SHALL NOT append events,
+mutate session state, or clear the attack plan.
+
+#### Scenario: Toggle does not fire weapons
+
+- **GIVEN** the Player has a locked target and one selected weapon
+- **WHEN** the "Preview Damage" toggle is flipped ON
+- **THEN** no `AttackDeclared` event SHALL be appended
+- **AND** `session.events.length` SHALL remain unchanged
+- **AND** the weapon's `ammoRemaining` SHALL remain unchanged
+
+#### Scenario: Toggle preserves attack plan
+
+- **GIVEN** an attack plan with `selectedWeapons =
+["ml-1", "sl-2"]` and `targetId = "u42"`
+- **WHEN** the toggle is flipped ON and OFF repeatedly
+- **THEN** `selectedWeapons` SHALL remain `["ml-1", "sl-2"]`
+- **AND** `targetId` SHALL remain `"u42"`
+
+#### Scenario: Preview columns only visible when enabled
+
+- **GIVEN** the weapon-picker is rendered with three weapons
+- **WHEN** `previewEnabled` is `false`
+- **THEN** each weapon row SHALL show only the Phase 1 columns (name,
+  location, damage, heat, range, ammo, hit probability)
+- **AND** the "Exp. Dmg", "± stddev", "Crit %" columns SHALL NOT be
+  visible
+
+- **WHEN** `previewEnabled` is flipped to `true`
+- **THEN** the three preview columns SHALL be visible on each row

--- a/openspec/changes/add-what-if-to-hit-preview/tasks.md
+++ b/openspec/changes/add-what-if-to-hit-preview/tasks.md
@@ -3,8 +3,8 @@
 ## 1. Attack Preview Shape
 
 - [ ] 1.1 Define `IAttackPreview` with `{hitProbability,
-    expectedDamage, damageStddev, critProbability, clusterHitsMean,
-    clusterHitsStddev}` (all numbers in `[0, +∞)`, probabilities in
+expectedDamage, damageStddev, critProbability, clusterHitsMean,
+clusterHitsStddev}` (all numbers in `[0, +∞)`, probabilities in
       `[0, 1]`)
 - [ ] 1.2 Document that all fields are purely informational — no dice
       rolls are performed to produce them
@@ -24,13 +24,13 @@
 - [ ] 3.1 Create `expectedDamage(weapon, hitProbability)` in the
       damage system
 - [ ] 3.2 For single-shot weapons: `expectedDamage = hitProbability *
-    weapon.damage`
+weapon.damage`
 - [ ] 3.3 For cluster weapons: `expectedDamage = hitProbability *
-    expectedClusterHits * damagePerCluster`, where
+expectedClusterHits * damagePerCluster`, where
       `expectedClusterHits` integrates the cluster hit table over all
       2d6 outcomes weighted by their 2d6 probability
 - [ ] 3.4 For Streak weapons: `expectedDamage = hitProbability *
-    rackSize * damagePerMissile` (Streak fires all-or-nothing)
+rackSize * damagePerMissile` (Streak fires all-or-nothing)
 - [ ] 3.5 For one-shot weapons: same as single-shot but capped at the
       one remaining shot
 
@@ -49,7 +49,7 @@
 - [ ] 5.1 Create `critProbability(attack)` returning the probability
       that the attack produces at least one critical hit
 - [ ] 5.2 Decompose into: `P(hit) * P(location with 0 armor) *
-    P(crit on 2d6 location roll)` for through-armor crits
+P(crit on 2d6 location roll)` for through-armor crits
 - [ ] 5.3 For cluster weapons, aggregate across expected cluster hits
 - [ ] 5.4 Simplification: the preview MAY use a closed-form
       approximation rather than full Monte Carlo; document the
@@ -67,7 +67,7 @@
 ## 7. UI Weapon State Projection Extension
 
 - [ ] 7.1 Extend `IUIWeaponState` with optional `preview: IAttackPreview
-    | null`
+| null`
 - [ ] 7.2 When `useGameplayStore.previewEnabled === false`, projection
       SHALL set `preview = null`
 - [ ] 7.3 When enabled, projection SHALL call `previewAttackOutcome`

--- a/openspec/changes/add-what-if-to-hit-preview/tasks.md
+++ b/openspec/changes/add-what-if-to-hit-preview/tasks.md
@@ -1,0 +1,130 @@
+# Tasks: Add What-If To-Hit Preview
+
+## 1. Attack Preview Shape
+
+- [ ] 1.1 Define `IAttackPreview` with `{hitProbability,
+    expectedDamage, damageStddev, critProbability, clusterHitsMean,
+    clusterHitsStddev}` (all numbers in `[0, +∞)`, probabilities in
+      `[0, 1]`)
+- [ ] 1.2 Document that all fields are purely informational — no dice
+      rolls are performed to produce them
+
+## 2. Preview Derivation
+
+- [ ] 2.1 Create `previewAttackOutcome(attack): IAttackPreview` that
+      composes `forecastToHit`, `hitProbability`, `expectedDamage`,
+      `damageVariance`, and `critProbability`
+- [ ] 2.2 Guarantee zero state mutation — function takes a read-only
+      attack descriptor and produces a pure result
+- [ ] 2.3 Unit test that 1000 consecutive calls with identical input
+      return identical output (proves no hidden randomness)
+
+## 3. Expected Damage Helper
+
+- [ ] 3.1 Create `expectedDamage(weapon, hitProbability)` in the
+      damage system
+- [ ] 3.2 For single-shot weapons: `expectedDamage = hitProbability *
+    weapon.damage`
+- [ ] 3.3 For cluster weapons: `expectedDamage = hitProbability *
+    expectedClusterHits * damagePerCluster`, where
+      `expectedClusterHits` integrates the cluster hit table over all
+      2d6 outcomes weighted by their 2d6 probability
+- [ ] 3.4 For Streak weapons: `expectedDamage = hitProbability *
+    rackSize * damagePerMissile` (Streak fires all-or-nothing)
+- [ ] 3.5 For one-shot weapons: same as single-shot but capped at the
+      one remaining shot
+
+## 4. Damage Variance Helper
+
+- [ ] 4.1 Create `damageVariance(weapon, hitProbability)` returning
+      stddev (not variance) so the UI can display it directly
+- [ ] 4.2 For single-shot weapons: stddev derived from Bernoulli
+      (`sqrt(p * (1-p)) * damage`)
+- [ ] 4.3 For cluster weapons: stddev derived from the cluster hit
+      distribution plus the Bernoulli hit factor
+- [ ] 4.4 Clamp stddev to 0 when hit probability is exactly 0 or 1
+
+## 5. Crit Probability Helper
+
+- [ ] 5.1 Create `critProbability(attack)` returning the probability
+      that the attack produces at least one critical hit
+- [ ] 5.2 Decompose into: `P(hit) * P(location with 0 armor) *
+    P(crit on 2d6 location roll)` for through-armor crits
+- [ ] 5.3 For cluster weapons, aggregate across expected cluster hits
+- [ ] 5.4 Simplification: the preview MAY use a closed-form
+      approximation rather than full Monte Carlo; document the
+      approximation in the spec
+
+## 6. Expected Cluster Hits Table
+
+- [ ] 6.1 Pre-compute `expectedClusterHits[rackSize]` for each cluster
+      rack size (2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 15, 20) as the dot
+      product of 2d6 probability mass × cluster table row
+- [ ] 6.2 Cache the result as a module-level constant so the preview
+      never re-computes during UI interaction
+- [ ] 6.3 Unit test expected values against TechManual cluster tables
+
+## 7. UI Weapon State Projection Extension
+
+- [ ] 7.1 Extend `IUIWeaponState` with optional `preview: IAttackPreview
+    | null`
+- [ ] 7.2 When `useGameplayStore.previewEnabled === false`, projection
+      SHALL set `preview = null`
+- [ ] 7.3 When enabled, projection SHALL call `previewAttackOutcome`
+      per weapon and populate `preview`
+- [ ] 7.4 Projection SHALL be memoized per
+      `{attackerId, targetId, weaponId, previewEnabled}` to avoid
+      recomputing on unrelated store changes
+
+## 8. Weapon Picker UI
+
+- [ ] 8.1 Add a "Preview Damage" toggle to the weapon-picker header
+- [ ] 8.2 Toggle state lives on `useGameplayStore.previewEnabled`
+- [ ] 8.3 When ON: each weapon row shows three additional columns —
+      "Exp. Dmg", "± stddev", "Crit %"
+- [ ] 8.4 When OFF: columns are hidden; existing hit-probability column
+      (from `add-attack-phase-ui`) remains
+- [ ] 8.5 Toggling SHALL NOT clear selected weapons or the target
+      lock
+- [ ] 8.6 Toggling SHALL NOT append any event or mutate session state
+
+## 9. Zero-Commit Guarantee
+
+- [ ] 9.1 Write an integration test that enables the preview toggle,
+      reads `preview` values for every weapon, then verifies
+      `session.events.length` is unchanged
+- [ ] 9.2 Verify that `session.units[*]` is deeply equal before and
+      after preview queries
+- [ ] 9.3 Document in the spec: "Preview SHALL NOT fire the weapon"
+
+## 10. Visual Formatting
+
+- [ ] 10.1 Expected damage formatted to 1 decimal (e.g., `"8.4"`)
+- [ ] 10.2 Stddev formatted as `"±2.1"` prefixed with the plus-minus
+      sign
+- [ ] 10.3 Crit probability formatted as percentage to 1 decimal
+      (e.g., `"3.2%"`)
+- [ ] 10.4 Out-of-range weapons show `"—"` in preview columns instead
+      of zeros (clarity: "not applicable" vs "0%")
+
+## 11. Tests
+
+- [ ] 11.1 Unit test: `previewAttackOutcome` for a Medium Laser at
+      medium range vs. gunnery 4 target produces the expected
+      `{hitProbability ≈ 0.72, expectedDamage ≈ 3.6, damageStddev, ...}`
+- [ ] 11.2 Unit test: Cluster weapon (LRM-10) expected damage matches
+      manually computed `hitProbability * 6.14 * 1`
+- [ ] 11.3 Unit test: Preview is zero across the board when
+      `inRange === false`
+- [ ] 11.4 Integration test: Toggling Preview Damage does not append
+      events
+- [ ] 11.5 Integration test: Preview stays accurate when the player
+      switches targets mid-phase
+
+## 12. Spec Compliance
+
+- [ ] 12.1 Every delta requirement across `to-hit-resolution`,
+      `damage-system`, and `weapon-resolution-system` has at least one
+      GIVEN/WHEN/THEN scenario
+- [ ] 12.2 `openspec validate add-what-if-to-hit-preview --strict`
+      passes clean

--- a/openspec/changes/fix-combat-rule-accuracy/proposal.md
+++ b/openspec/changes/fix-combat-rule-accuracy/proposal.md
@@ -1,0 +1,28 @@
+# Change: Fix Combat Rule Accuracy
+
+## Why
+
+MekStation's combat engine is ~90% correct, but 8 rule-accuracy bugs make the remaining 10% produce wrong outcomes. Prone targets are harder to hit from adjacent hexes than from range (reversed), the TMM formula scales linearly instead of using the canonical bracket table, three separate heat-threshold tables disagree with each other and with MegaMek, the consciousness check is off by one, two SPAs have wrong numeric values (Weapon Specialist, Sniper), one SPA targets the wrong roll (Jumping Jack), and life support destructs after a single hit instead of two. Until these bugs are fixed, every downstream wiring change (weapon data, damage pipeline, PSRs) propagates incorrect math. This is the foundational cleanup: pure bug-fix delta on already-shipped specs. See `openspec/changes/archive/2026-02-12-full-combat-parity/proposal.md` Phase 0 for the source bug list.
+
+## What Changes
+
+- **BREAKING**: Reverse the target prone modifier — adjacent attackers SHALL receive -2, attackers beyond 1 hex SHALL receive +1 (currently reversed)
+- **BREAKING**: Replace the `ceil(hexesMoved / 5)` TMM approximation with the canonical TechManual p.115 bracket table (0-2 hexes → +0, 3-4 → +1, 5-6 → +2, 7-9 → +3, 10-17 → +4, 18-24 → +5, 25+ → +6)
+- **BREAKING**: Consolidate the three contradicting heat-threshold tables (`toHit.ts`, `HeatManagement.ts`, `constants/heat.ts`) to a single MegaMek canonical source: +1 at heat 8, +2 at heat 13, +3 at heat 17, +4 at heat 24
+- Fix the consciousness check off-by-one in `damage.ts` (current `>` SHALL become `>=` so pilots at the threshold correctly roll)
+- Fix Weapon Specialist SPA to grant -2 (not -1) to the designated weapon type
+- Fix Sniper SPA to halve all range modifiers (floor division), not merely zero the medium-range penalty
+- Fix Jumping Jack SPA to modify the attacker's to-hit when jumping, not the target's piloting roll
+- Fix life support `hitsToDestroy` in `critical-hit-system` to 2 (currently 1)
+
+## Dependencies
+
+- **Requires**: None — this is a pure bug-fix delta on existing specs
+- **Blocks**: `wire-real-weapon-data`, `wire-firing-arc-resolution`, `integrate-damage-pipeline`, `wire-heat-generation-and-effects`, `wire-piloting-skill-rolls` (all downstream wiring depends on correct underlying math)
+
+## Impact
+
+- **Affected specs**: `to-hit-resolution` (prone, TMM, heat modifier), `heat-overflow-effects` (threshold table), `piloting-skill-rolls` (consciousness), `spa-combat-integration` (Weapon Specialist, Sniper, Jumping Jack), `critical-hit-system` (life support hitsToDestroy)
+- **Affected code**: `src/utils/gameplay/toHit/`, `src/utils/gameplay/damage.ts`, `src/utils/gameplay/spaModifiers/`, `src/lib/spa/catalog.ts`, `src/types/validation/CriticalHitSystem.ts`, `src/constants/heat.ts`
+- **No new files**. No new dependencies.
+- **Test fallout**: Existing tests that assert the wrong values will need updating; the authoritative MegaMek reference values replace them.

--- a/openspec/changes/fix-combat-rule-accuracy/specs/critical-hit-system/spec.md
+++ b/openspec/changes/fix-combat-rule-accuracy/specs/critical-hit-system/spec.md
@@ -1,0 +1,29 @@
+# critical-hit-system (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Critical Hit Effects
+
+Components SHALL have defined critical hit effects. The life-support component SHALL require 2 hits to destroy (`hitsToDestroy: 2`), not 1.
+
+#### Scenario: Single life-support hit does not destroy
+
+- **GIVEN** a BattleMech with intact life support
+- **WHEN** life support takes 1 critical hit
+- **THEN** the life support hit counter SHALL become 1
+- **AND** life support SHALL NOT be marked destroyed
+- **AND** environmental protection SHALL remain active
+
+#### Scenario: Two life-support hits destroy
+
+- **GIVEN** a BattleMech with life support hit counter = 1
+- **WHEN** life support takes a second critical hit
+- **THEN** the life support hit counter SHALL become 2
+- **AND** life support SHALL be marked destroyed
+- **AND** environmental damage SHALL begin applying to the pilot
+
+#### Scenario: Weapon critical still destroys on first hit
+
+- **GIVEN** an intact weapon component
+- **WHEN** the weapon takes a critical hit
+- **THEN** the weapon SHALL be destroyed on the first hit (unchanged, `hitsToDestroy: 1`)

--- a/openspec/changes/fix-combat-rule-accuracy/specs/heat-overflow-effects/spec.md
+++ b/openspec/changes/fix-combat-rule-accuracy/specs/heat-overflow-effects/spec.md
@@ -1,0 +1,33 @@
+# heat-overflow-effects (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Heat Scale Thresholds
+
+The system SHALL define heat scale effects at MegaMek canonical thresholds, sourced from a single authoritative constants module (`src/constants/heat.ts`).
+
+Duplicate or conflicting threshold tables in `src/utils/gameplay/toHit.ts` and `src/types/validation/HeatManagement.ts` SHALL be removed. The canonical to-hit thresholds are: heat ≥ 8 → +1, heat ≥ 13 → +2, heat ≥ 17 → +3, heat ≥ 24 → +4.
+
+#### Scenario: Canonical heat scale table
+
+- **GIVEN** a BattleMech with accumulated heat
+- **WHEN** heat effects are calculated
+- **THEN** the to-hit modifier SHALL be looked up from a single constants module
+- **AND** the thresholds SHALL be +1 at 8, +2 at 13, +3 at 17, +4 at 24
+- **AND** movement penalty SHALL be `floor(heat / 5)` MP reduction
+- **AND** shutdown TN SHALL be `4 + floor((heat - 14) / 4) * 2` for heat ≥ 14
+- **AND** ammo explosion TN SHALL be 4 at heat 19, 6 at heat 23, 8 at heat 28
+
+#### Scenario: Single source of truth enforced
+
+- **GIVEN** the heat thresholds are referenced from multiple call sites (toHit calculation, heat-phase shutdown check, movement penalty computation)
+- **WHEN** any consumer looks up a threshold value
+- **THEN** the value SHALL come from `src/constants/heat.ts`
+- **AND** no other module SHALL define conflicting threshold constants
+
+#### Scenario: Threshold boundary at heat 7 and 8
+
+- **GIVEN** two mechs with heat 7 and heat 8 respectively
+- **WHEN** the to-hit modifier is computed
+- **THEN** the heat 7 mech SHALL receive +0
+- **AND** the heat 8 mech SHALL receive +1

--- a/openspec/changes/fix-combat-rule-accuracy/specs/piloting-skill-rolls/spec.md
+++ b/openspec/changes/fix-combat-rule-accuracy/specs/piloting-skill-rolls/spec.md
@@ -1,0 +1,27 @@
+# piloting-skill-rolls (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Pilot Consciousness Check
+
+When a pilot takes sufficient damage to warrant a consciousness roll, the check SHALL use an inclusive `>=` comparison on the pilot-damage threshold, not the exclusive `>` previously used in `src/utils/gameplay/damage.ts` (~line 461).
+
+This corrects a one-off where a pilot at the exact boundary damage value previously avoided the roll. Per TechManual p.87, the roll fires when damage reaches (not exceeds) the threshold.
+
+#### Scenario: Pilot at threshold triggers consciousness roll
+
+- **GIVEN** a pilot whose accumulated damage has just reached the consciousness threshold
+- **WHEN** the consciousness check is evaluated
+- **THEN** the check SHALL fire (pilot rolls 2d6 vs consciousness TN)
+
+#### Scenario: Pilot below threshold does not trigger roll
+
+- **GIVEN** a pilot whose accumulated damage is 1 point below the consciousness threshold
+- **WHEN** the consciousness check is evaluated
+- **THEN** the check SHALL NOT fire
+
+#### Scenario: Pilot above threshold triggers roll
+
+- **GIVEN** a pilot whose accumulated damage is 1 point above the consciousness threshold
+- **WHEN** the consciousness check is evaluated
+- **THEN** the check SHALL fire

--- a/openspec/changes/fix-combat-rule-accuracy/specs/spa-combat-integration/spec.md
+++ b/openspec/changes/fix-combat-rule-accuracy/specs/spa-combat-integration/spec.md
@@ -1,0 +1,72 @@
+# spa-combat-integration (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Gunnery SPA — Weapon Specialist
+
+The Weapon Specialist SPA SHALL grant a -2 to-hit modifier (not -1) when firing the designated weapon type. This corrects the previous value which halved the intended benefit.
+
+#### Scenario: Weapon Specialist with designated weapon
+
+- **GIVEN** a pilot with Weapon Specialist (Medium Laser)
+- **WHEN** the pilot fires a Medium Laser
+- **THEN** the attack SHALL receive a -2 to-hit modifier
+
+#### Scenario: Weapon Specialist with non-designated weapon
+
+- **GIVEN** a pilot with Weapon Specialist (Medium Laser)
+- **WHEN** the pilot fires an AC/10
+- **THEN** no Weapon Specialist modifier SHALL apply
+
+### Requirement: Gunnery SPA — Sniper
+
+The Sniper SPA SHALL halve (floor-divide) every range modifier — short, medium, long, extreme — not merely zero the medium-range penalty.
+
+#### Scenario: Sniper at short range
+
+- **GIVEN** a pilot with Sniper firing at short range (base +0)
+- **WHEN** the range modifier is computed
+- **THEN** the range modifier SHALL be +0 (floor(0 / 2))
+
+#### Scenario: Sniper at medium range
+
+- **GIVEN** a pilot with Sniper firing at medium range (base +2)
+- **WHEN** the range modifier is computed
+- **THEN** the range modifier SHALL be +1 (floor(2 / 2))
+
+#### Scenario: Sniper at long range
+
+- **GIVEN** a pilot with Sniper firing at long range (base +4)
+- **WHEN** the range modifier is computed
+- **THEN** the range modifier SHALL be +2 (floor(4 / 2))
+
+#### Scenario: Sniper at extreme range
+
+- **GIVEN** a pilot with Sniper firing at extreme range (base +6)
+- **WHEN** the range modifier is computed
+- **THEN** the range modifier SHALL be +3 (floor(6 / 2))
+
+### Requirement: Movement SPA — Jumping Jack
+
+The Jumping Jack SPA SHALL modify the attacker's to-hit when the attacker jumped this turn, NOT the target's piloting roll.
+
+When an attacker with Jumping Jack jumped, the jump-movement to-hit penalty (normally +3) SHALL be reduced by 1 (net +2). The SPA SHALL NOT affect any piloting-skill-roll calculation.
+
+#### Scenario: Attacker with Jumping Jack jumps and fires
+
+- **GIVEN** an attacker with the Jumping Jack SPA who jumped this turn
+- **WHEN** the to-hit modifier is computed
+- **THEN** the jumping-attacker penalty SHALL be +2 (reduced from +3)
+
+#### Scenario: Attacker with Jumping Jack did not jump
+
+- **GIVEN** an attacker with the Jumping Jack SPA who walked this turn
+- **WHEN** the to-hit modifier is computed
+- **THEN** no Jumping Jack modifier SHALL apply
+- **AND** the standard walking penalty (+1) SHALL apply
+
+#### Scenario: Jumping Jack no longer affects PSRs
+
+- **GIVEN** an attacker with the Jumping Jack SPA who triggers a piloting-skill roll
+- **WHEN** the PSR modifiers are aggregated
+- **THEN** Jumping Jack SHALL NOT contribute any modifier to the PSR

--- a/openspec/changes/fix-combat-rule-accuracy/specs/to-hit-resolution/spec.md
+++ b/openspec/changes/fix-combat-rule-accuracy/specs/to-hit-resolution/spec.md
@@ -1,0 +1,122 @@
+# to-hit-resolution (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Target Prone Modifier
+
+The system SHALL apply the target-prone modifier based on the attacker's range to the prone target, per TechManual p.113.
+
+When the attacker is in a hex adjacent to the prone target (range ≤ 1 hex), the attacker SHALL receive a -2 to-hit modifier (the prone target is an easier target at melee range). When the attacker is more than 1 hex away, the attacker SHALL receive a +1 to-hit modifier (the prone target is harder to hit at range).
+
+#### Scenario: Adjacent attacker against prone target
+
+- **GIVEN** a target in prone state at hex distance 1 from the attacker
+- **WHEN** computing the target-prone modifier
+- **THEN** the modifier SHALL be -2
+
+#### Scenario: Attacker 2 hexes away from prone target
+
+- **GIVEN** a target in prone state at hex distance 2 from the attacker
+- **WHEN** computing the target-prone modifier
+- **THEN** the modifier SHALL be +1
+
+#### Scenario: Attacker at long range against prone target
+
+- **GIVEN** a target in prone state at hex distance 12 from the attacker
+- **WHEN** computing the target-prone modifier
+- **THEN** the modifier SHALL be +1
+
+#### Scenario: Standing target receives no prone modifier
+
+- **GIVEN** a target that is NOT in the prone state
+- **WHEN** computing the target-prone modifier
+- **THEN** the modifier SHALL be 0
+
+### Requirement: Target Movement Modifier (TMM)
+
+The system SHALL apply a target-movement modifier based on the number of hexes the target moved this turn, using the TechManual p.115 bracket table.
+
+The bracket table SHALL be: 0-2 hexes → +0, 3-4 → +1, 5-6 → +2, 7-9 → +3, 10-17 → +4, 18-24 → +5, 25 or more → +6.
+
+The previous approximation `ceil(hexesMoved / 5)` SHALL NOT be used.
+
+#### Scenario: Target moved 0 hexes
+
+- **GIVEN** a target that did not move this turn
+- **WHEN** computing the TMM
+- **THEN** the modifier SHALL be +0
+
+#### Scenario: Target moved 3 hexes
+
+- **GIVEN** a target that moved 3 hexes this turn
+- **WHEN** computing the TMM
+- **THEN** the modifier SHALL be +1 (from bracket 3-4)
+
+#### Scenario: Target moved 9 hexes
+
+- **GIVEN** a target that moved 9 hexes this turn
+- **WHEN** computing the TMM
+- **THEN** the modifier SHALL be +3 (from bracket 7-9)
+
+#### Scenario: Target moved 17 hexes
+
+- **GIVEN** a target that moved 17 hexes this turn
+- **WHEN** computing the TMM
+- **THEN** the modifier SHALL be +4 (from bracket 10-17)
+
+#### Scenario: Target moved 25 hexes
+
+- **GIVEN** a target that moved 25 hexes this turn
+- **WHEN** computing the TMM
+- **THEN** the modifier SHALL be +6 (from bracket 25+)
+
+#### Scenario: Bracket boundary transitions
+
+- **GIVEN** a target that moved 2 hexes (last value in +0 bracket)
+- **WHEN** computing the TMM
+- **THEN** the modifier SHALL be +0
+- **AND** a target that moved 3 hexes (first value in +1 bracket) SHALL yield +1
+
+### Requirement: Heat To-Hit Modifier
+
+The system SHALL apply a cumulative heat-based to-hit penalty using the MegaMek canonical thresholds as the single source of truth.
+
+Thresholds: heat ≥ 8 → +1, heat ≥ 13 → +2, heat ≥ 17 → +3, heat ≥ 24 → +4. Penalties are not additive across thresholds — the highest applicable threshold SHALL determine the modifier.
+
+The duplicate threshold tables previously defined in `src/utils/gameplay/toHit.ts` and `src/types/validation/HeatManagement.ts` SHALL be removed. `src/constants/heat.ts` SHALL be the single source of truth.
+
+#### Scenario: Heat 7 (below first threshold)
+
+- **GIVEN** an attacker with heat 7
+- **WHEN** computing the heat to-hit modifier
+- **THEN** the modifier SHALL be +0
+
+#### Scenario: Heat 8 (first threshold)
+
+- **GIVEN** an attacker with heat 8
+- **WHEN** computing the heat to-hit modifier
+- **THEN** the modifier SHALL be +1
+
+#### Scenario: Heat 13 (second threshold)
+
+- **GIVEN** an attacker with heat 13
+- **WHEN** computing the heat to-hit modifier
+- **THEN** the modifier SHALL be +2
+
+#### Scenario: Heat 17 (third threshold)
+
+- **GIVEN** an attacker with heat 17
+- **WHEN** computing the heat to-hit modifier
+- **THEN** the modifier SHALL be +3
+
+#### Scenario: Heat 24 (fourth threshold)
+
+- **GIVEN** an attacker with heat 24
+- **WHEN** computing the heat to-hit modifier
+- **THEN** the modifier SHALL be +4
+
+#### Scenario: Heat 40 (above all thresholds)
+
+- **GIVEN** an attacker with heat 40
+- **WHEN** computing the heat to-hit modifier
+- **THEN** the modifier SHALL be +4 (max bracket only, not cumulative)

--- a/openspec/changes/fix-combat-rule-accuracy/tasks.md
+++ b/openspec/changes/fix-combat-rule-accuracy/tasks.md
@@ -1,0 +1,69 @@
+# Tasks: Fix Combat Rule Accuracy
+
+## 1. Target Prone Modifier Fix
+
+- [ ] 1.1 Locate the prone-modifier branch in `src/utils/gameplay/toHit/` (damageModifiers or movementModifiers)
+- [ ] 1.2 Swap the constants — adjacent attacker SHALL yield -2, non-adjacent SHALL yield +1
+- [ ] 1.3 Add/update unit tests covering adjacent vs. 2-hex vs. 5-hex attackers against a prone target
+- [ ] 1.4 Update scenario in `to-hit-resolution` spec delta to encode the corrected direction
+
+## 2. TMM Bracket Table
+
+- [ ] 2.1 Delete `ceil(hexesMoved / 5)` formula usage
+- [ ] 2.2 Introduce a constant lookup array representing the canonical brackets [0-2:+0, 3-4:+1, 5-6:+2, 7-9:+3, 10-17:+4, 18-24:+5, 25+:+6]
+- [ ] 2.3 Wire the bracket lookup into `calculateToHit()` target-movement modifier
+- [ ] 2.4 Unit tests for each bracket boundary (0, 2, 3, 4, 6, 9, 10, 17, 18, 24, 25, 40)
+- [ ] 2.5 Update `to-hit-resolution` spec delta with new scenarios
+
+## 3. Heat Threshold Consolidation
+
+- [ ] 3.1 Identify the three heat-threshold definitions (`src/utils/gameplay/toHit.ts`, `src/types/validation/HeatManagement.ts`, `src/constants/heat.ts`)
+- [ ] 3.2 Designate `src/constants/heat.ts` as the single source of truth
+- [ ] 3.3 Set canonical thresholds: heat 8 → +1 to-hit, heat 13 → +2, heat 17 → +3, heat 24 → +4
+- [ ] 3.4 Remove the other two definitions; update imports to reference the constants module
+- [ ] 3.5 Confirm the threshold constants are used by `toHit/damageModifiers.ts` (heat mod)
+- [ ] 3.6 Unit tests across all four threshold boundaries plus interior values (0, 7, 8, 12, 13, 16, 17, 23, 24, 40)
+- [ ] 3.7 Update `heat-overflow-effects` spec delta
+
+## 4. Consciousness Off-By-One
+
+- [ ] 4.1 Locate the consciousness threshold comparison in `src/utils/gameplay/damage.ts` (~line 461)
+- [ ] 4.2 Change the `>` comparison to `>=` so the boundary case rolls (per TechManual p.87)
+- [ ] 4.3 Regression test: pilot at damage == threshold SHALL be required to make consciousness roll
+- [ ] 4.4 Update `piloting-skill-rolls` spec delta for consciousness scenarios
+
+## 5. Weapon Specialist SPA Value
+
+- [ ] 5.1 Find Weapon Specialist definition in `src/lib/spa/catalog.ts` or equivalent
+- [ ] 5.2 Change modifier from -1 to -2
+- [ ] 5.3 Update SPA combat integration tests
+- [ ] 5.4 Update `spa-combat-integration` spec delta (MODIFIED Requirement)
+
+## 6. Sniper SPA Mechanic
+
+- [ ] 6.1 Rewrite the Sniper SPA modifier logic so it halves (floor-div) every range modifier, not just zero medium
+- [ ] 6.2 Short +0 → +0, Medium +2 → +1, Long +4 → +2, Extreme +6 → +3
+- [ ] 6.3 Add unit tests for all four range brackets while Sniper is active
+- [ ] 6.4 Update `spa-combat-integration` spec delta (MODIFIED Requirement)
+
+## 7. Jumping Jack SPA Mechanic
+
+- [ ] 7.1 Rewrite the Jumping Jack SPA so it applies to the attacker's to-hit when the attacker jumped, not to the target's piloting roll
+- [ ] 7.2 Remove the incorrect wiring to `pilotingSkillRolls`
+- [ ] 7.3 Wire into `toHit/movementModifiers.ts` or `abilityModifiers.ts` as a -1 when attacker movement type is Jump
+- [ ] 7.4 Unit tests: jumping attacker with Jumping Jack receives -1 reduction on the +3 jump penalty
+- [ ] 7.5 Update `spa-combat-integration` spec delta (MODIFIED Requirement)
+
+## 8. Life Support HitsToDestroy
+
+- [ ] 8.1 Update `src/types/validation/CriticalHitSystem.ts` life-support entry to `hitsToDestroy: 2`
+- [ ] 8.2 Update any crit-resolution logic that assumes 1 hit destroys life support
+- [ ] 8.3 Unit test: 1 life-support crit SHALL NOT destroy life support; 2 crits SHALL destroy it
+- [ ] 8.4 Update `critical-hit-system` spec delta (MODIFIED Requirement)
+
+## 9. Validation
+
+- [ ] 9.1 Run full test suite; fix all downstream tests asserting the previously-wrong values
+- [ ] 9.2 Run `openspec validate fix-combat-rule-accuracy --strict` and clear any structural issues
+- [ ] 9.3 Confirm the autonomous-fuzzer invariants still pass (simulation-system harness)
+- [ ] 9.4 Verify build + lint clean

--- a/openspec/changes/implement-physical-attack-phase/proposal.md
+++ b/openspec/changes/implement-physical-attack-phase/proposal.md
@@ -1,0 +1,32 @@
+# Change: Implement Physical Attack Phase
+
+## Why
+
+The turn loop advances through `GamePhase.PhysicalAttack` but the phase body is empty — a single `advancePhase` call, no declarations, no resolution. The `physicalAttacks/` module family is already scaffolded (decision, resolution, restrictions, toHit, damage, types) but nothing invokes it. Punches, kicks, clubs, charges, DFAs, and pushes never occur. This change brings the physical-attack phase to life: a declaration step, a restriction check (arm that fired a weapon SHALL NOT punch; same limb SHALL NOT kick and punch in the same turn), a to-hit resolution step, a damage step that feeds into the existing damage pipeline, and PSR triggering hooks for both attacker and target. See `openspec/changes/archive/2026-02-12-full-combat-parity/proposal.md` Phase 7 for the canonical rules reference.
+
+## What Changes
+
+- Replace the empty `PhysicalAttack` phase body with a full resolution: declare → validate → to-hit → resolve → damage → PSR triggers
+- Implement **Punch**: to-hit = piloting + actuator mods + target-movement; damage = `ceil(weight / 10)` per arm; 1d6 punch hit-location table
+- Implement **Kick**: to-hit = piloting - 2 + actuator mods + target-movement; damage = `floor(weight / 5)`; 1d6 kick hit-location table; hit triggers PSR on target, miss triggers PSR on attacker
+- Implement **Charge**: to-hit = piloting + attacker-movement; damage to target = `ceil(weight / 10) × (hexesMoved - 1)`; damage to attacker = `ceil(targetWeight / 10)`; both sides take PSR
+- Implement **Death From Above (DFA)**: to-hit = piloting; target damage = `ceil(weight / 10) × 3`; attacker leg damage = `ceil(weight / 5)`; miss = attacker fall
+- Implement **Push**: to-hit = piloting - 1; no damage; target displaced 1 hex in attacker's facing
+- Implement **Club**: melee weapons (hatchet / sword / mace / lance) with weapon-specific damage and to-hit modifiers per `physical-weapons-system`
+- Enforce restrictions: arm that fired a weapon SHALL NOT punch; same limb SHALL NOT kick and punch; damaged actuators add to-hit modifiers; required actuators (lower arm + hand for punch; upper leg + foot for kick) SHALL be intact
+- Queue `PhysicalAttackTarget` PSR on every physical hit (delegated to `wire-piloting-skill-rolls`)
+- Queue `MissedDFA` / `MissedCharge` PSRs on misses (attacker falls on failure)
+- Feed damage into the damage pipeline via `integrate-damage-pipeline`
+- Emit `PhysicalAttackDeclared`, `PhysicalAttackResolved` events
+
+## Dependencies
+
+- **Requires**: `fix-combat-rule-accuracy` (correct base math), `integrate-damage-pipeline` (physical damage feeds the same pipeline), `wire-piloting-skill-rolls` (PSR triggers fire on hit and miss), `wire-firing-arc-resolution` (physical attacks need arc for hit-location table selection)
+- **Blocks**: None in Lane A. Opens the door for AI improvements (Lane C) and attack-phase UI (Lane B4)
+
+## Impact
+
+- **Affected specs**: `physical-attack-system` (phase resolution), `physical-weapons-system` (integrate melee weapons), `game-session-management` (physical phase is non-empty)
+- **Affected code**: `src/engine/GameEngine.phases.ts` (physical-phase branch), `src/utils/gameplay/physicalAttacks.ts`, `src/utils/gameplay/physicalAttacks/` (decision, resolution, restrictions, toHit, damage), `src/utils/gameplay/hitLocation.ts` (punch/kick tables), `src/simulation/ai/` (bot can declare physical attacks)
+- **New events**: `PhysicalAttackDeclared`, `PhysicalAttackResolved`
+- **No new modules required**; module files already exist and need filling in.

--- a/openspec/changes/implement-physical-attack-phase/specs/game-session-management/spec.md
+++ b/openspec/changes/implement-physical-attack-phase/specs/game-session-management/spec.md
@@ -1,0 +1,34 @@
+# game-session-management (delta)
+
+## ADDED Requirements
+
+### Requirement: Physical Attack Phase Runs Resolution
+
+The session turn loop SHALL execute a full physical-attack resolution when transitioning through `GamePhase.PhysicalAttack`: declaration → validation → to-hit → damage → PSR triggers → phase advance. The previous pass-through (empty branch that only advanced the phase) SHALL NOT remain.
+
+#### Scenario: Phase emits declaration and resolution events
+
+- **GIVEN** a session entering the physical-attack phase with at least one valid declaration
+- **WHEN** the phase runs
+- **THEN** a `PhysicalAttackDeclared` event SHALL be emitted for each declaration
+- **AND** a `PhysicalAttackResolved` event SHALL be emitted for each resolution
+
+#### Scenario: Phase produces damage events through pipeline
+
+- **GIVEN** a successful physical attack
+- **WHEN** resolution completes
+- **THEN** the damage SHALL flow through `resolveDamage` (same pipeline as weapon attacks)
+- **AND** `DamageApplied`, `LocationDestroyed`, `CriticalHit`, `PilotHit` events SHALL be emitted as applicable
+
+#### Scenario: Phase queues PSRs through PSR system
+
+- **GIVEN** a physical attack that hits or misses per rules
+- **WHEN** resolution completes
+- **THEN** the appropriate PSR trigger SHALL be queued on the PSR queue
+- **AND** those PSRs SHALL resolve per `wire-piloting-skill-rolls`
+
+#### Scenario: Phase advances after all attacks resolve
+
+- **GIVEN** all physical attacks this phase have resolved
+- **WHEN** the resolution step completes
+- **THEN** the phase SHALL advance to `GamePhase.Heat`

--- a/openspec/changes/implement-physical-attack-phase/specs/physical-attack-system/spec.md
+++ b/openspec/changes/implement-physical-attack-phase/specs/physical-attack-system/spec.md
@@ -1,0 +1,133 @@
+# physical-attack-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Physical Attack Phase Is Non-Empty
+
+The `GamePhase.PhysicalAttack` branch in the engine SHALL execute declaration, validation, to-hit resolution, damage resolution, and PSR triggering steps — not merely advance the phase.
+
+#### Scenario: Phase runs resolution when declarations exist
+
+- **GIVEN** two units with valid physical-attack declarations
+- **WHEN** the physical-attack phase runs
+- **THEN** both declarations SHALL be validated, to-hit rolled, and damage applied
+- **AND** `PhysicalAttackResolved` events SHALL be emitted for both
+
+#### Scenario: Phase advances cleanly with no declarations
+
+- **GIVEN** no declarations this phase
+- **WHEN** the physical-attack phase runs
+- **THEN** the phase SHALL advance without error
+
+### Requirement: Punch Resolution Per TechManual
+
+Punches SHALL use piloting skill + actuator modifiers + TMM, deal `ceil(weight / 10)` damage per arm, and use the 1d6 punch hit-location table.
+
+#### Scenario: 80-ton mech punch damage
+
+- **GIVEN** an 80-ton mech landing a punch
+- **WHEN** punch damage is computed
+- **THEN** damage SHALL be 8 per arm
+
+#### Scenario: Punch to-hit with actuator damage
+
+- **GIVEN** an attacker with piloting 4 and a damaged upper-arm actuator (+1)
+- **WHEN** punch to-hit is computed
+- **THEN** the base TN SHALL be 4 + 1 = 5 (before target movement modifier)
+
+#### Scenario: Arm that fired cannot punch
+
+- **GIVEN** an arm that fired a weapon this turn
+- **WHEN** the unit declares a punch with that arm
+- **THEN** the declaration SHALL be rejected with `PhysicalAttackInvalid` reason `ArmFired`
+
+### Requirement: Kick Resolution Per TechManual
+
+Kicks SHALL use piloting skill - 2 + actuator modifiers + TMM, deal `floor(weight / 5)` damage, and use the 1d6 kick hit-location table.
+
+#### Scenario: 80-ton mech kick damage
+
+- **GIVEN** an 80-ton mech landing a kick
+- **WHEN** kick damage is computed
+- **THEN** damage SHALL be 16
+
+#### Scenario: Kick miss triggers attacker PSR
+
+- **GIVEN** a kick that misses the target
+- **WHEN** resolution completes
+- **THEN** the attacker SHALL have a `KickMiss` PSR queued
+
+### Requirement: Charge Resolution
+
+Charges SHALL be available only when the attacker ran this turn. Damage to the target SHALL be `ceil(attacker.weight / 10) × (hexesMoved - 1)` in 5-point clusters. The attacker SHALL also take `ceil(target.weight / 10)` damage in 5-point clusters. Both units queue PSRs.
+
+#### Scenario: Charge damage calculation
+
+- **GIVEN** a 50-ton attacker running 5 hexes into a 70-ton target
+- **WHEN** charge damage is computed
+- **THEN** target damage SHALL be `ceil(50 / 10) × (5 - 1) = 5 × 4 = 20`
+- **AND** attacker damage SHALL be `ceil(70 / 10) = 7`
+
+#### Scenario: Charge miss queues PSR
+
+- **GIVEN** a charge that misses
+- **WHEN** resolution completes
+- **THEN** a `MissedCharge` PSR SHALL be queued on the attacker
+
+### Requirement: Death From Above (DFA) Resolution
+
+DFA SHALL be available only when the attacker jumped this turn. Target damage = `ceil(attacker.weight / 10) × 3`. Attacker leg damage = `ceil(attacker.weight / 5)`.
+
+#### Scenario: DFA damage
+
+- **GIVEN** a 60-ton mech performing DFA
+- **WHEN** damage is computed
+- **THEN** target damage SHALL be `ceil(60 / 10) × 3 = 18`
+- **AND** attacker leg damage SHALL be `ceil(60 / 5) = 12`
+
+#### Scenario: DFA miss triggers attacker fall
+
+- **GIVEN** a DFA that misses
+- **WHEN** resolution completes
+- **THEN** a `MissedDFA` PSR SHALL be queued on the attacker
+- **AND** on PSR failure the attacker SHALL fall (via fall-mechanics)
+
+### Requirement: Push Resolution
+
+Pushes SHALL use piloting skill - 1 for to-hit, apply no damage, and displace the target 1 hex in the attacker's facing direction on success.
+
+#### Scenario: Push hit displaces target
+
+- **GIVEN** a successful push
+- **WHEN** resolution completes
+- **THEN** the target SHALL move 1 hex in the attacker's facing
+- **AND** the target SHALL have a `PhysicalAttackTarget` PSR queued
+
+#### Scenario: Push into invalid hex
+
+- **GIVEN** a push where the destination hex is off-map or blocked
+- **WHEN** resolution completes
+- **THEN** the push SHALL fail
+- **AND** a fall SHALL be resolved per rules
+
+### Requirement: Restriction Validation
+
+Declarations that violate physical-attack restrictions SHALL be rejected before to-hit resolution.
+
+#### Scenario: Same limb kick + punch blocked
+
+- **GIVEN** a unit that punched with its right arm this turn
+- **WHEN** the unit declares a right-arm kick (impossible anatomy, but rule: same limb)
+- **THEN** the declaration SHALL be rejected
+
+#### Scenario: DFA without jump blocked
+
+- **GIVEN** a unit that walked this turn
+- **WHEN** the unit declares DFA
+- **THEN** the declaration SHALL be rejected with reason `NoJumpThisTurn`
+
+#### Scenario: Missing actuators block attack
+
+- **GIVEN** a unit whose right foot actuator is destroyed
+- **WHEN** the unit declares a right-leg kick
+- **THEN** the declaration SHALL be rejected with reason `MissingActuator`

--- a/openspec/changes/implement-physical-attack-phase/specs/physical-weapons-system/spec.md
+++ b/openspec/changes/implement-physical-attack-phase/specs/physical-weapons-system/spec.md
@@ -1,0 +1,41 @@
+# physical-weapons-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Melee Weapons Integrate With Physical Attack Phase
+
+Melee weapons (hatchet, sword, mace, lance) SHALL be declarable as physical attacks (`attackType: Club`) during the physical-attack phase, with their weapon-specific damage formulas and to-hit modifiers.
+
+#### Scenario: Hatchet attack
+
+- **GIVEN** a 60-ton mech with a hatchet
+- **WHEN** declaring a hatchet attack
+- **THEN** damage SHALL be `floor(60 / 5) = 12`
+- **AND** to-hit SHALL use piloting skill with hatchet-specific modifier
+
+#### Scenario: Sword attack
+
+- **GIVEN** a 55-ton mech with a sword
+- **WHEN** declaring a sword attack
+- **THEN** damage SHALL be `floor(55 / 10) + 1 = 6`
+- **AND** to-hit SHALL receive -2 modifier
+
+#### Scenario: Mace attack
+
+- **GIVEN** a 75-ton mech with a mace
+- **WHEN** declaring a mace attack
+- **THEN** damage SHALL be `floor(75 / 4) = 18`
+- **AND** to-hit SHALL receive +1 modifier
+
+#### Scenario: Lance charging
+
+- **GIVEN** a 50-ton mech with a lance, charging
+- **WHEN** declaring a charge-with-lance
+- **THEN** damage SHALL be doubled: `floor(50 / 5) × 2 = 20` per hit
+- **AND** the charge ruleset SHALL otherwise apply
+
+#### Scenario: Missing hand/lower-arm blocks club attack
+
+- **GIVEN** a mech with destroyed lower-arm or hand actuators on the club arm
+- **WHEN** declaring a club attack
+- **THEN** the declaration SHALL be rejected with reason `MissingActuator`

--- a/openspec/changes/implement-physical-attack-phase/tasks.md
+++ b/openspec/changes/implement-physical-attack-phase/tasks.md
@@ -1,0 +1,106 @@
+# Tasks: Implement Physical Attack Phase
+
+## 1. Phase Skeleton
+
+- [ ] 1.1 Replace the empty `GamePhase.PhysicalAttack` body in `GameEngine.phases.ts` with a full resolution function
+- [ ] 1.2 Add a declaration step where each eligible unit may declare a physical attack
+- [ ] 1.3 Add a restriction-validation step that rejects invalid declarations
+- [ ] 1.4 Add a to-hit resolution step
+- [ ] 1.5 Add a damage + PSR-trigger step
+- [ ] 1.6 Advance phase after all physical attacks resolve
+
+## 2. Declaration
+
+- [ ] 2.1 Define `IPhysicalAttackDeclaration { attackerId, targetId, attackType, limb? }`
+- [ ] 2.2 Support types: `Punch`, `Kick`, `Club`, `Charge`, `DFA`, `Push`
+- [ ] 2.3 `limb` is required for Punch and Kick (which arm/leg)
+- [ ] 2.4 Emit `PhysicalAttackDeclared` event
+
+## 3. Restriction Validation (`physicalAttacks/restrictions.ts`)
+
+- [ ] 3.1 An arm that fired a weapon this turn SHALL NOT punch
+- [ ] 3.2 A leg that took a hip crit SHALL NOT kick
+- [ ] 3.3 Punch requires lower arm + hand actuator intact (or at least one present)
+- [ ] 3.4 Kick requires upper leg + foot actuator intact
+- [ ] 3.5 Same limb SHALL NOT both kick and punch this turn
+- [ ] 3.6 DFA requires the attacker jumped this turn
+- [ ] 3.7 Charge requires the attacker ran this turn
+- [ ] 3.8 Reject with `PhysicalAttackInvalid` and reason enum
+
+## 4. Punch Resolution
+
+- [ ] 4.1 To-hit base = piloting skill
+- [ ] 4.2 Add actuator-damage modifiers (shoulder +4 if damaged; upper arm +1; lower arm +1)
+- [ ] 4.3 Add target-movement modifier (TMM)
+- [ ] 4.4 No range modifier (adjacent-only)
+- [ ] 4.5 Damage = `ceil(attacker.weight / 10)`
+- [ ] 4.6 Roll 1d6 on the punch hit-location table to select location
+- [ ] 4.7 Feed damage through `resolveDamage`
+- [ ] 4.8 Queue `PhysicalAttackTarget` PSR for the target (on hit)
+
+## 5. Kick Resolution
+
+- [ ] 5.1 To-hit base = piloting skill - 2
+- [ ] 5.2 Add leg actuator modifiers (upper leg +1; lower leg +1; foot +1)
+- [ ] 5.3 Add TMM
+- [ ] 5.4 Damage = `floor(attacker.weight / 5)`
+- [ ] 5.5 Roll 1d6 on the kick hit-location table
+- [ ] 5.6 On hit: queue PSR for target (`PhysicalAttackTarget`)
+- [ ] 5.7 On miss: queue PSR for attacker (`KickMiss`)
+
+## 6. Charge Resolution
+
+- [ ] 6.1 To-hit base = piloting skill + attacker-movement modifier
+- [ ] 6.2 Damage to target = `ceil(attacker.weight / 10) × (hexesMoved - 1)` (min 1 cluster of 5)
+- [ ] 6.3 Damage to attacker = `ceil(target.weight / 10)`
+- [ ] 6.4 Both damages split into 5-point clusters
+- [ ] 6.5 Roll hit-location for each cluster
+- [ ] 6.6 On hit: queue PSR for both attacker and target
+- [ ] 6.7 On miss: queue `MissedCharge` PSR for attacker
+
+## 7. DFA Resolution
+
+- [ ] 7.1 To-hit base = piloting skill
+- [ ] 7.2 Damage to target = `ceil(attacker.weight / 10) × 3`
+- [ ] 7.3 Damage to attacker legs = `ceil(attacker.weight / 5)` split among legs
+- [ ] 7.4 5-point clusters for both
+- [ ] 7.5 On hit: queue PSR for target; attacker fall roll per rules
+- [ ] 7.6 On miss: queue `MissedDFA` PSR for attacker; attacker falls via `fallMechanics`
+
+## 8. Push Resolution
+
+- [ ] 8.1 To-hit base = piloting skill - 1
+- [ ] 8.2 No damage
+- [ ] 8.3 On hit: displace target 1 hex in the attacker's facing direction
+- [ ] 8.4 Queue PSR for target (`PhysicalAttackTarget`)
+- [ ] 8.5 If destination hex is invalid (off map / blocked), push fails with fall per rules
+
+## 9. Club / Melee Weapons
+
+- [ ] 9.1 Hatchet: damage = `floor(weight / 5)`, to-hit modifier per `physical-weapons-system`
+- [ ] 9.2 Sword: damage = `floor(weight / 10) + 1`, to-hit -2
+- [ ] 9.3 Mace: damage = `floor(weight / 4)`, to-hit +1
+- [ ] 9.4 Lance: damage = `floor(weight / 5)`, doubled when charging
+- [ ] 9.5 Requires intact lower arm + hand actuators
+- [ ] 9.6 Feed through damage pipeline
+
+## 10. Hit Location Tables (1d6)
+
+- [ ] 10.1 Punch table (1d6): 1=LA, 2=LT, 3=CT, 4=RT, 5=RA, 6=Head (per TechManual)
+- [ ] 10.2 Kick table (1d6): 1=RL, 2=RL, 3=LL, 4=LL, 5=RL, 6=LL (legs only per TechManual)
+- [ ] 10.3 Tables in `hitLocation.ts` with seeded RNG
+
+## 11. Bot Integration (minimal)
+
+- [ ] 11.1 Bot SHOULD declare a kick when adjacent to a prone or lower-BV target
+- [ ] 11.2 Bot SHOULD NOT DFA or charge without heuristic justification (Lane C scope)
+- [ ] 11.3 Minimum: bot never crashes in the physical phase
+
+## 12. Validation
+
+- [ ] 12.1 `openspec validate implement-physical-attack-phase --strict`
+- [ ] 12.2 End-to-end test: punch from adjacent → hit → damage applied → target PSR queued
+- [ ] 12.3 Kick miss test: attacker queues PSR; resolution next step may cause attacker fall
+- [ ] 12.4 DFA hit test: attacker takes leg damage, target takes ×3 damage, both take PSR
+- [ ] 12.5 Restriction test: arm that fired weapon cannot punch (rejected)
+- [ ] 12.6 Build + lint clean

--- a/openspec/changes/improve-bot-basic-combat-competence/proposal.md
+++ b/openspec/changes/improve-bot-basic-combat-competence/proposal.md
@@ -1,0 +1,37 @@
+# Change: Improve Bot Basic Combat Competence
+
+## Why
+
+`BotPlayer` currently picks random moves and random targets, ignores firing arcs, never manages heat, and fires weapons out of range-bracket effectiveness order. For a Phase 1 solo skirmish to feel real, the AI opponent must make plausible baseline decisions: pick threatening targets, fire only weapons that can reach, avoid heat shutdown, and position to maintain line of sight. Tournament-level optimal play is explicitly not a goal — "feels like a real opponent" is the bar.
+
+## What Changes
+
+- Target prioritization by threat score × kill probability (replaces uniform-random target choice in `AttackAI.selectTarget`)
+- Firing-arc awareness: weapons that can't reach the target's current hex given the attacker's facing and torso twist state SHALL be excluded from the fire list
+- Heat management: if firing the candidate weapon set would push heat above a safe threshold (default 13), drop weapons one at a time in ascending damage-per-heat ratio until the candidate set is under threshold
+- Weapon selection order: fire highest damage-per-heat ratio weapons first, respect short/medium/long range-bracket effectiveness, and skip weapons at minimum-range penalty when better weapons are available
+- Movement positioning: prefer destination hexes that (a) keep at least one enemy in line of sight, and (b) maintain the highest-threat target in the attacker's forward firing arc after the move commits
+- Extend `IBotBehavior` with `safeHeatThreshold` (default 13) so scenario presets can tune aggression
+- Keep the existing `SeededRandom` discipline — every AI branch that introduces new randomness (tie-breaking, exploration) SHALL route through the injected random source
+
+## Dependencies
+
+- **Requires**: `wire-firing-arc-resolution` (A3) — firing-arc logic must return real arcs before the bot can respect them
+- **Requires**: `wire-heat-generation-and-effects` (A5) — safe heat calculation needs real per-weapon heat values
+- **Required By**: `add-bot-retreat-behavior` (C2) — retreat logic reuses the threat/firing/heat primitives introduced here
+
+## Impact
+
+- Affected specs: `simulation-system` (AI behavior requirements), `combat-resolution` (bot-driven weapon selection rules)
+- Affected code: `src/simulation/ai/BotPlayer.ts`, `src/simulation/ai/MoveAI.ts`, `src/simulation/ai/AttackAI.ts`, `src/simulation/ai/types.ts`
+- Engine helpers consumed: `src/utils/gameplay/firingArc.ts`, `src/utils/gameplay/range.ts`, `src/utils/gameplay/lineOfSight.ts`, `src/utils/gameplay/heat.ts`
+- No database changes, no UI changes, no event-schema changes — pure decision-layer improvement
+- Reproducibility preserved: identical seed + identical board state SHALL continue to produce identical bot actions
+
+## Non-Goals
+
+- Tournament-grade play (no minimax search, no multi-turn planning)
+- Coordinated multi-unit tactics (lance cohesion, focus-fire assignment across units)
+- Bluffing, feinting, or hidden-information play
+- Terrain preference beyond "must have line of sight" — cover-seeking, elevation hunting, and water-for-cooling are follow-up work
+- Physical-attack decisions (punch/kick/charge) — remains stubbed; covered by `implement-physical-attack-phase`

--- a/openspec/changes/improve-bot-basic-combat-competence/specs/combat-resolution/spec.md
+++ b/openspec/changes/improve-bot-basic-combat-competence/specs/combat-resolution/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Bot-Driven Weapon Selection Respects Combat Resolution Inputs
+
+When `BotPlayer` emits an `AttackDeclared` event, the weapon list SHALL already reflect the combat-resolution inputs that the resolver will check: valid firing arc, range within maximum, sufficient ammo, and weapon not destroyed. Downstream combat resolution SHALL therefore not reject bot-declared attacks for basic viability reasons.
+
+#### Scenario: Bot declares only weapons that pass resolver validation
+
+- **GIVEN** a bot attacker with a mix of destroyed, out-of-arc, and out-of-ammo weapons alongside viable weapons
+- **WHEN** `BotPlayer.playAttackPhase` emits an `AttackDeclared` event
+- **THEN** every weapon ID in the payload SHALL pass `CombatResolver`'s pre-attack validation (arc, range, ammo, destruction status)
+- **AND** the resolver SHALL NOT return a `WeaponUnavailable` rejection for any bot-declared weapon
+
+#### Scenario: Bot does not declare weapons at minimum range penalty when alternatives exist
+
+- **GIVEN** a bot attacker 2 hexes from target with both an LRM-10 (minRange 6) and a Medium Laser available
+- **WHEN** the resolver processes the declared attack
+- **THEN** only the Medium Laser SHALL appear in the declared weapon list
+- **AND** the resolver SHALL NOT be asked to apply a minimum-range penalty for this attack
+
+#### Scenario: Bot respects ammo depletion mid-phase
+
+- **GIVEN** a bot attacker with an AC/20 whose ammo reaches zero after a prior declaration in the same turn
+- **WHEN** the bot's next declaration considers the AC/20
+- **THEN** the weapon SHALL be excluded from the candidate list
+- **AND** the emitted event SHALL NOT reference the depleted weapon
+
+### Requirement: Bot Heat Declaration Matches Resolver Heat Accounting
+
+The projected heat used by bot heat management SHALL be computed using the same formula the `CombatResolver` uses when it applies heat at end of turn — namely `currentHeat + movementHeat + sum(firedWeaponHeat) - dissipation` — so that bot decisions and resolver outcomes agree.
+
+#### Scenario: Bot-projected heat matches post-attack heat in the resolver
+
+- **GIVEN** a bot declaration that includes Medium Laser (3 heat) and PPC (10 heat) with `movementHeat = 2` and `dissipation = 10`
+- **WHEN** the resolver completes the heat phase
+- **THEN** the resulting heat delta SHALL equal the value the bot used to decide whether to cull weapons
+- **AND** the bot SHALL NOT trigger unexpected shutdown because of a mismatched heat model
+
+#### Scenario: Bot accounts for already-dissipating heat
+
+- **GIVEN** a bot at current heat 8 with 10 dissipation
+- **WHEN** heat projection runs
+- **THEN** the projection SHALL subtract the per-turn dissipation before comparing to `safeHeatThreshold`
+- **AND** the bot SHALL be willing to fire slightly more aggressively than a naive additive projection would allow

--- a/openspec/changes/improve-bot-basic-combat-competence/specs/simulation-system/spec.md
+++ b/openspec/changes/improve-bot-basic-combat-competence/specs/simulation-system/spec.md
@@ -1,0 +1,197 @@
+## ADDED Requirements
+
+### Requirement: Bot Target Prioritization by Threat and Kill Probability
+
+`BotPlayer` SHALL select its attack target by evaluating each valid target with a composite score combining the target's offensive threat and the attacker's estimated kill probability, rather than picking uniformly at random.
+
+The score for each candidate target SHALL be computed as:
+
+```
+threatScore = totalWeaponDamagePerTurn * remainingHpFraction / max(gunneryModifier, 1)
+killProbability = clamp(1 - (toHitTN / 12), 0, 1)
+compositeScore = threatScore * killProbability
+```
+
+Where `toHitTN` is estimated from the attacker's gunnery skill, the range-bracket modifier, and the firing-arc modifier to the target's hex. The highest composite score SHALL win; ties SHALL be broken using the injected `SeededRandom` so the decision remains reproducible.
+
+#### Scenario: Bot picks high-damage target over crippled light mech
+
+- **GIVEN** a bot attacker with two valid targets: an undamaged Atlas AS7-D (15 damage/turn) and a light mech at 20% armor (4 damage/turn) at equal range
+- **WHEN** `BotPlayer.playAttackPhase` runs
+- **THEN** the emitted `AttackDeclared` event SHALL target the Atlas
+- **AND** the selection SHALL be reproducible across runs with the same seed
+
+#### Scenario: Bot favors easier kill when threats are comparable
+
+- **GIVEN** two targets with equivalent threat scores, but target A has a to-hit TN of 8 and target B has a to-hit TN of 11
+- **WHEN** target prioritization runs
+- **THEN** the bot SHALL select target A (higher kill probability)
+
+#### Scenario: Bot handles a single target without divide-by-zero
+
+- **GIVEN** exactly one valid target remains on the map
+- **WHEN** target prioritization runs
+- **THEN** the bot SHALL select that target without evaluating tie-breakers
+- **AND** the score computation SHALL NOT throw for zero-heat energy weapons
+
+#### Scenario: Bot returns null when no valid targets exist
+
+- **GIVEN** all enemy units are destroyed or out of maximum weapon range
+- **WHEN** `BotPlayer.playAttackPhase` runs
+- **THEN** the method SHALL return `null` without raising an exception
+
+### Requirement: Bot Firing-Arc Awareness
+
+`BotPlayer` SHALL exclude weapons that cannot fire into the target's current hex given the attacker's facing and torso-twist state. The arc calculation SHALL use the canonical `calculateFiringArc` helper from `src/utils/gameplay/firingArc.ts` and compare against each weapon's mounted arc.
+
+#### Scenario: Rear-mounted weapon fires when target is behind attacker
+
+- **GIVEN** a bot attacker with a rear-mounted medium laser and a target positioned in the rear arc
+- **WHEN** weapon selection runs
+- **THEN** the rear medium laser SHALL be included in the fire list
+- **AND** forward-mounted weapons in the same unit SHALL NOT be selected for that target
+
+#### Scenario: Torso twist shifts available forward weapons
+
+- **GIVEN** a bot attacker facing north with a target one hex-side to the east, and a pending torso twist to the right
+- **WHEN** firing-arc filtering runs
+- **THEN** forward-arc weapons SHALL be included because the twist brings the target into the forward arc
+- **AND** the emitted attack SHALL record the torso twist state
+
+#### Scenario: Target fully outside all weapon arcs yields empty fire list
+
+- **GIVEN** all of the attacker's weapons mount in the front arc and the target is directly behind the attacker with no torso twist available
+- **WHEN** weapon selection runs
+- **THEN** the candidate weapon list SHALL be empty
+- **AND** `BotPlayer.playAttackPhase` SHALL return `null`
+
+### Requirement: Bot Heat Management Weapon Culling
+
+`BotPlayer` SHALL project the attacker's post-attack heat (`currentHeat + movementHeat + sum(candidateWeaponHeat)`) and, if that value exceeds `IBotBehavior.safeHeatThreshold` (default 13), SHALL drop weapons one at a time from the candidate list — starting with the lowest damage-per-heat ratio — until the projected heat is at or below threshold or the list is empty.
+
+#### Scenario: Bot drops PPC when firing full loadout would shut down
+
+- **GIVEN** an attacker with current heat 10, heat dissipation 10, candidate weapons {PPC: 10 heat / 10 damage, Medium Laser: 3 heat / 5 damage, Small Laser: 1 heat / 3 damage}, and `safeHeatThreshold = 13`
+- **WHEN** heat management runs
+- **THEN** the PPC SHALL be removed from the candidate list (projected heat without PPC = 10 + 3 + 1 = 14; still over, drop next; final list = {Medium Laser, Small Laser} at projected heat 13)
+- **AND** the remaining weapons SHALL all fire
+
+#### Scenario: Bot fires full loadout when cool
+
+- **GIVEN** an attacker at current heat 3 with the same weapon set and threshold
+- **WHEN** heat management runs
+- **THEN** all three weapons SHALL remain in the candidate list (projected heat 3 + 10 + 3 + 1 = 17; well within dissipation-adjusted budget for this scenario with threshold 13 means PPC is dropped in a strict reading, so this scenario uses a higher threshold to illustrate the "fire everything" path)
+- **AND** the emitted attack SHALL fire the complete loadout
+
+#### Scenario: Bot fires nothing when no weapon subset fits budget
+
+- **GIVEN** an attacker at current heat 12 whose cheapest weapon generates 5 heat, with `safeHeatThreshold = 13`
+- **WHEN** heat management runs
+- **THEN** every weapon SHALL be culled
+- **AND** `BotPlayer.playAttackPhase` SHALL return `null` for that turn
+
+### Requirement: Bot Weapon Ordering by Damage-per-Heat and Range Bracket
+
+`BotPlayer` SHALL sort its candidate weapon list in descending order of `damage / max(heat, 1)` so that the most efficient weapons are retained first when heat culling trims the list. Within equal ratio buckets, weapons whose current range bracket is Short SHALL be preferred over Medium over Long. Weapons where the target is inside `minRange` SHALL be skipped when at least one other weapon can fire without minimum-range penalty.
+
+#### Scenario: Short-range efficient weapon beats long-range inefficient weapon
+
+- **GIVEN** candidate weapons {Medium Laser: 5 damage / 3 heat = 1.67, LRM-10: 6 damage / 4 heat = 1.5} and target at 5 hexes
+- **WHEN** weapon ordering runs
+- **THEN** the Medium Laser SHALL be placed ahead of the LRM-10 in the fire order
+- **AND** if heat culling removes one weapon, the LRM-10 SHALL be dropped first
+
+#### Scenario: LRM skipped at minimum range when alternative exists
+
+- **GIVEN** an attacker 2 hexes from target with candidate weapons {LRM-10 (minRange 6), Medium Laser}
+- **WHEN** weapon ordering runs
+- **THEN** the LRM-10 SHALL be excluded from the fire list
+- **AND** the Medium Laser SHALL fire
+
+#### Scenario: Energy weapon with zero heat does not divide by zero
+
+- **GIVEN** a candidate weapon with `heat = 0` (edge case for certain legacy weapon definitions)
+- **WHEN** the damage-per-heat score is computed
+- **THEN** the score SHALL use `damage / max(heat, 1)` to avoid division by zero
+- **AND** the weapon SHALL receive the same treatment as a 1-heat weapon of equivalent damage
+
+### Requirement: Bot Movement Positioning Maintains Line of Sight
+
+`MoveAI` SHALL score candidate movement destinations and pick the highest-scoring hex rather than choosing uniformly at random. The score SHALL favor destinations that maintain line of sight to at least one live enemy and that keep the highest-threat target in the attacker's forward firing arc at the move's resulting facing.
+
+Scoring SHALL use these component weights:
+
+- `+1000` if at least one non-destroyed enemy has line of sight to the destination hex (per `src/utils/gameplay/lineOfSight.ts`)
+- `+500` if the highest-threat target (per the Target Prioritization requirement) lies in the move's resulting forward arc
+- `-100 * hexDistance` to the nearest enemy (discourages retreating away from the fight)
+- `-1 * heatGenerated` (prefer cooler moves when all else is equal)
+
+Ties SHALL be broken using the injected `SeededRandom`.
+
+#### Scenario: Bot prefers hex with line of sight over blind hex
+
+- **GIVEN** two candidate moves: move A arrives at a hex with LoS to one enemy; move B arrives at a hex blocked by a building with no LoS to any enemy
+- **WHEN** `MoveAI.selectMove` runs
+- **THEN** move A SHALL be selected
+- **AND** the selection SHALL be reproducible for a given seed
+
+#### Scenario: Bot rotates to face highest-threat target
+
+- **GIVEN** two moves reaching the same hex with different ending facings, where facing 0 puts the highest-threat target in the forward arc and facing 3 puts it in the rear
+- **WHEN** move scoring runs
+- **THEN** the move ending at facing 0 SHALL score higher (+500 forward-arc bonus)
+- **AND** the bot SHALL commit that facing
+
+#### Scenario: Bot closes distance when all enemies are far away
+
+- **GIVEN** all enemies are beyond maximum weapon range at the start of movement
+- **WHEN** move scoring runs
+- **THEN** moves that reduce `hexDistance` to the nearest enemy SHALL score higher (smaller `-100 * distance` penalty)
+- **AND** the bot SHALL advance toward the enemy force
+
+#### Scenario: Jump move selected when it restores LoS around blocking terrain
+
+- **GIVEN** the bot is behind a hill that blocks LoS to all enemies; a walk move keeps it behind the hill; a jump move clears the hill
+- **WHEN** move scoring runs (jump MP available, movement type selection already chose Jump)
+- **THEN** the jump move SHALL score higher (+1000 LoS bonus offsets the heat penalty)
+- **AND** the bot SHALL commit the jump
+
+### Requirement: Bot Behavior Configuration Extension
+
+The `IBotBehavior` interface SHALL be extended with a `safeHeatThreshold: number` field (default `13`) so that scenario presets can tune bot aggression without code changes. Values outside `[0, 30]` SHALL be clamped at load time with a warning logged.
+
+#### Scenario: Default behavior uses canonical threshold
+
+- **GIVEN** a `BotPlayer` instantiated without a behavior override
+- **WHEN** heat management runs
+- **THEN** the threshold SHALL be `13` (matches the canonical +2 to-hit heat level)
+
+#### Scenario: Custom threshold overrides default
+
+- **GIVEN** a `BotPlayer` instantiated with `{ safeHeatThreshold: 8 }`
+- **WHEN** heat management runs
+- **THEN** the bot SHALL cull weapons aggressively, dropping any weapon that pushes projected heat above 8
+
+#### Scenario: Out-of-range threshold is clamped
+
+- **GIVEN** a behavior override with `safeHeatThreshold: 50`
+- **WHEN** the `BotPlayer` initializes
+- **THEN** the value SHALL be clamped to `30`
+- **AND** a warning SHALL be logged describing the clamp
+
+### Requirement: Bot Determinism Under SeededRandom
+
+All new AI decision branches (target tie-breaking, move tie-breaking, exploration fallbacks) SHALL route randomness through the injected `SeededRandom`. Direct calls to `Math.random()` SHALL NOT appear in any AI module.
+
+#### Scenario: Same seed produces identical decisions across runs
+
+- **GIVEN** two `BotPlayer` instances seeded identically and given identical inputs
+- **WHEN** `playMovementPhase` and `playAttackPhase` are called in sequence
+- **THEN** both instances SHALL emit byte-identical events
+- **AND** this SHALL hold across 100 consecutive turns of the same scenario
+
+#### Scenario: Lint enforcement catches Math.random usage
+
+- **GIVEN** a developer adds `Math.random()` to a file in `src/simulation/ai/`
+- **WHEN** the project lint rules run
+- **THEN** the existing `no-restricted-globals` rule SHALL flag the usage as an error

--- a/openspec/changes/improve-bot-basic-combat-competence/tasks.md
+++ b/openspec/changes/improve-bot-basic-combat-competence/tasks.md
@@ -1,0 +1,57 @@
+# Tasks: Improve Bot Basic Combat Competence
+
+## 1. Behavior Configuration
+
+- [ ] 1.1 Extend `IBotBehavior` in `src/simulation/ai/types.ts` with `safeHeatThreshold: number` (default 13)
+- [ ] 1.2 Update `DEFAULT_BEHAVIOR` constant with the new field
+- [ ] 1.3 Write unit tests that instantiate `BotPlayer` with overridden thresholds and confirm the value is honored
+
+## 2. Threat Scoring
+
+- [ ] 2.1 Add `scoreTarget(attacker, target)` helper in `AttackAI` that returns `threat * killProbability`
+- [ ] 2.2 Implement threat = `totalWeaponDamagePerTurn / gunneryMod * remainingHpFraction` (higher damage, better gunnery, healthier = more threatening)
+- [ ] 2.3 Implement killProbability = `1 - (toHitTN / 12)` clamped to `[0, 1]`; use the attacker's gunnery + range modifier + firing-arc modifier as the TN estimate
+- [ ] 2.4 Write unit tests: assault mech with intact armor scores higher than crippled light mech at equal range; target at +4 TN scores lower than target at +2 TN
+- [ ] 2.5 Update `AttackAI.selectTarget` to pick the highest-score target, using the injected `SeededRandom` only for tie-breaking
+
+## 3. Firing-Arc Awareness
+
+- [ ] 3.1 In `AttackAI.selectWeapons`, import `calculateFiringArc` from `src/utils/gameplay/firingArc.ts`
+- [ ] 3.2 For each weapon, compute the arc of the target hex relative to the attacker's facing and exclude weapons whose mounting arc does not include the target
+- [ ] 3.3 Write unit tests covering: front-arc weapon excluded when target is rear; rear-arc weapon included when target is rear; torso-twist shifts included-weapon set by one hex-side
+
+## 4. Range-Bracket Weapon Ordering
+
+- [ ] 4.1 Sort the candidate weapon list by `damage / max(heat, 1)` descending (energy weapons with zero heat use the damage value directly; add a guard for divide-by-zero)
+- [ ] 4.2 Within equal damage-per-heat buckets, prefer weapons whose current range bracket is short over medium over long
+- [ ] 4.3 Skip weapons where the target is inside `minRange` when an out-of-minimum-range alternative exists
+- [ ] 4.4 Write unit tests: PPC + medium laser at short range fires ML first when heat pressure is high; LRM-20 skipped when target is 2 hexes away and another weapon can fire
+
+## 5. Heat Management
+
+- [ ] 5.1 Compute projected heat = `currentHeat + movementHeat + sum(candidateWeaponHeat)` for the proposed fire list
+- [ ] 5.2 While `projectedHeat > behavior.safeHeatThreshold` and the candidate list is non-empty, remove the weapon with the lowest `damage / heat` ratio and recompute
+- [ ] 5.3 Preserve the ordering invariant (section 4) — removal SHALL come from the tail of the sorted list
+- [ ] 5.4 Write unit tests: candidate set of {PPC:10, ML:3, SL:1} with current heat 10 and threshold 13 drops PPC; same set with current heat 3 fires everything
+
+## 6. Line-of-Sight Movement Positioning
+
+- [ ] 6.1 In `MoveAI`, add a `scoreMove(move, attacker, allUnits, grid)` helper that returns a numeric score for candidate destinations
+- [ ] 6.2 Score +1000 if at least one non-destroyed enemy unit has line of sight to the destination (use `src/utils/gameplay/lineOfSight.ts`)
+- [ ] 6.3 Score +500 if the highest-threat target (from section 2) is in the move's resulting forward firing arc
+- [ ] 6.4 Score -100 per hex of distance from the nearest enemy (discourage backing off) and -1 per point of movement heat generated
+- [ ] 6.5 Write unit tests: given two moves where one maintains LoS and one does not, bot picks the LoS move; given equal-LoS moves, bot picks the one facing the threat
+
+## 7. Selection Integration
+
+- [ ] 7.1 Update `MoveAI.selectMove` to pick the highest-score move, using `SeededRandom` for tie-breaking only
+- [ ] 7.2 Update `BotPlayer.playMovementPhase` to supply `scoreMove` with the current enemy list
+- [ ] 7.3 Update `BotPlayer.playAttackPhase` to use the new `selectTarget` → `selectWeapons` (arc-aware, heat-managed) pipeline
+- [ ] 7.4 Write integration tests: two-bot skirmish with fixed seed reaches identical outcome across runs (determinism check)
+
+## 8. Edge-Case Tests
+
+- [ ] 8.1 Bot with no weapons in any arc SHALL return a null attack event (no-op), not crash
+- [ ] 8.2 Bot already above safe heat threshold SHALL still fire if a single weapon with positive damage brings net heat below threshold for next turn; otherwise fire nothing
+- [ ] 8.3 All targets out of maximum weapon range → bot returns null attack and movement phase SHALL prioritize closing distance
+- [ ] 8.4 All units destroyed except the bot → bot returns null for both phases without error

--- a/openspec/changes/integrate-damage-pipeline/proposal.md
+++ b/openspec/changes/integrate-damage-pipeline/proposal.md
@@ -1,0 +1,30 @@
+# Change: Integrate Damage Pipeline into Combat Resolution
+
+## Why
+
+The sophisticated `damage.ts` pipeline (armor → structure → transfer → adjacent location → pilot) and `criticalHitResolution.ts` (2d6 table → slot selection → effect application) both exist in the codebase but are never called by the combat loop. When an attack hits, the engine records "hit" and stops — it does not actually degrade the unit. Armor never decreases, structure never breaches, internal components never take critical hits, and side-torso destruction never cascades to the arm. This change connects those modules to the attack-resolution path so hits actually matter. It depends on `wire-real-weapon-data` (real damage numbers must arrive at the pipeline) and `wire-firing-arc-resolution` (hit location needs the real arc), and unblocks everything that reads unit state after an attack. See `openspec/changes/archive/2026-02-12-full-combat-parity/proposal.md` Phase 2 and Phase 3 for context.
+
+## What Changes
+
+- Call `resolveDamage()` from `damage.ts` when an attack hits, passing damage, hit location, arc, attacker state, target state, and a seeded RNG
+- Emit `DamageApplied`, `LocationDestroyed`, `TransferDamage`, and `PilotHit` events from the resolution result
+- Call `resolveCriticalHits()` from `criticalHitResolution.ts` whenever structure is exposed by a hit (and on TAC triggers from hit-location roll 2)
+- Select critical slots randomly from occupied non-destroyed slots in the affected location
+- Apply critical effects per component type: engine (+5 heat/hit, 3 hits destroys unit), gyro (+3 PSR/hit, 2 hits destroys), cockpit (pilot killed), sensors (+1/+2 to-hit), life support (2 hits per `fix-combat-rule-accuracy`), actuators with distinct types, weapons destroyed, heat sinks reduced, jump jets reduced, ammo explosion
+- Cascade side-torso destruction to the arm on that side
+- Apply head-damage cap (max 3 points from a single standard-weapon hit)
+- Apply 20+-phase-damage trigger (queues a PSR in the PSR queue for later firing by `wire-piloting-skill-rolls`)
+- Apply pilot damage from head-structure hits (1 point per penetrating hit)
+- Inject the seeded RNG so replay produces identical damage outcomes
+
+## Dependencies
+
+- **Requires**: `fix-combat-rule-accuracy` (life-support 2-hit rule, consciousness off-by-one), `wire-real-weapon-data` (real damage values), `wire-firing-arc-resolution` (real arc → correct hit location table)
+- **Blocks**: `wire-piloting-skill-rolls` (PSR triggers fire from damage events), `implement-physical-attack-phase` (physical attacks feed the same pipeline)
+
+## Impact
+
+- **Affected specs**: `damage-system` (connect resolveDamage to engine), `critical-hit-resolution` (invoke from attack path), `critical-hit-system` (slot selection and effect application integrated), `combat-resolution` (attack events produce damage events)
+- **Affected code**: `src/engine/GameEngine.ts`, `src/utils/gameplay/gameSession.ts`, `src/utils/gameplay/gameSessionAttackResolution.ts`, `src/utils/gameplay/damage.ts`, `src/utils/gameplay/criticalHitResolution.ts`, `src/utils/gameplay/hitLocation.ts`, `src/simulation/runner/SimulationRunner.ts`
+- **Event additions**: `DamageApplied`, `LocationDestroyed`, `TransferDamage`, `PilotHit`, `CriticalHit`, `ComponentDestroyed`, `AmmoExploded` (if not already present)
+- **No new top-level specs created**.

--- a/openspec/changes/integrate-damage-pipeline/specs/combat-resolution/spec.md
+++ b/openspec/changes/integrate-damage-pipeline/specs/combat-resolution/spec.md
@@ -1,0 +1,38 @@
+# combat-resolution (delta)
+
+## ADDED Requirements
+
+### Requirement: Attack Resolution Produces Damage Events
+
+When an attack hits, the combat resolution step SHALL emit the full chain of damage-related events derived from the damage pipeline output.
+
+Events that SHALL be emitted when applicable: `DamageApplied`, `LocationDestroyed`, `TransferDamage`, `PilotHit`, `CriticalHit`, `ComponentDestroyed`, `AmmoExploded`.
+
+#### Scenario: Simple damage emits DamageApplied
+
+- **GIVEN** an attack that hits and does not breach armor
+- **WHEN** the resolution completes
+- **THEN** a `DamageApplied` event SHALL be emitted with location, amount, and remaining armor
+
+#### Scenario: Structure breach emits critical chain
+
+- **GIVEN** an attack that reduces armor to 0 and damages structure
+- **WHEN** the resolution completes
+- **THEN** `DamageApplied` SHALL be emitted
+- **AND** `CriticalHit` SHALL be emitted if the crit roll yields ≥ 1 crit
+- **AND** `ComponentDestroyed` SHALL be emitted for each destroyed component
+
+#### Scenario: Location destruction emits transfer chain
+
+- **GIVEN** an attack that destroys a location
+- **WHEN** the resolution completes
+- **THEN** `LocationDestroyed` SHALL be emitted
+- **AND** `TransferDamage` SHALL be emitted for excess damage moving to the adjacent location
+- **AND** further events SHALL chain if the transfer also destroys the adjacent location
+
+#### Scenario: Side torso destruction cascades
+
+- **GIVEN** an attack destroys the left torso
+- **WHEN** the resolution completes
+- **THEN** `LocationDestroyed` SHALL be emitted for LT
+- **AND** `LocationDestroyed` SHALL also be emitted for LA (cascade)

--- a/openspec/changes/integrate-damage-pipeline/specs/critical-hit-resolution/spec.md
+++ b/openspec/changes/integrate-damage-pipeline/specs/critical-hit-resolution/spec.md
@@ -1,0 +1,39 @@
+# critical-hit-resolution (delta)
+
+## ADDED Requirements
+
+### Requirement: Critical Resolution Invoked From Damage Pipeline
+
+When damage exposes internal structure at a location, the system SHALL call `resolveCriticalHits()` on that location. TAC triggers (hit-location roll of 2) SHALL also call `resolveCriticalHits` regardless of remaining armor.
+
+#### Scenario: Exposed structure triggers crit roll
+
+- **GIVEN** an attack that reduces armor to 0 and damages structure at the target location
+- **WHEN** the damage pipeline processes the hit
+- **THEN** `resolveCriticalHits` SHALL be invoked for that location
+- **AND** the result SHALL be translated into `CriticalHit` and `ComponentDestroyed` events
+
+#### Scenario: TAC triggers crit regardless of armor
+
+- **GIVEN** a hit-location roll of 2
+- **WHEN** the damage pipeline processes the hit
+- **THEN** `resolveCriticalHits` SHALL be invoked for the TAC location (CT for front/rear, LT for left, RT for right)
+- **AND** the crit check SHALL occur even if the location still has armor
+
+### Requirement: Critical Slot Selection Via Seeded RNG
+
+Critical slot selection SHALL use the seeded `IDiceRoller`, not `Math.random`, so that replay is deterministic.
+
+#### Scenario: Replay reproduces same slot
+
+- **GIVEN** two identical replays of an event log with the same seed
+- **WHEN** a critical hit is resolved in both
+- **THEN** both replays SHALL select the same slot
+- **AND** both SHALL emit the same `ComponentDestroyed` event
+
+#### Scenario: No slot selectable
+
+- **GIVEN** a location where every occupied slot is already destroyed
+- **WHEN** `resolveCriticalHits` tries to select a slot
+- **THEN** the critical SHALL be discarded (no effect)
+- **AND** no `ComponentDestroyed` event SHALL be emitted

--- a/openspec/changes/integrate-damage-pipeline/specs/critical-hit-system/spec.md
+++ b/openspec/changes/integrate-damage-pipeline/specs/critical-hit-system/spec.md
@@ -1,0 +1,66 @@
+# critical-hit-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Critical Effects Applied Through Damage Pipeline
+
+Critical effects SHALL be applied via the damage pipeline integration, not through ad-hoc engine code. Each component type SHALL apply the canonical effect when a critical hit is resolved.
+
+#### Scenario: Engine hit applies +5 heat and counter increment
+
+- **GIVEN** an engine component takes 1 critical hit
+- **WHEN** the critical effect is applied
+- **THEN** the engine-hit counter SHALL increase by 1
+- **AND** subsequent heat phases SHALL add 5 per engine-hit counter to the unit's heat
+- **AND** 3 engine hits SHALL destroy the unit
+
+#### Scenario: Gyro hit adds +3 PSR modifier
+
+- **GIVEN** a gyro component takes 1 critical hit
+- **WHEN** the critical effect is applied
+- **THEN** all future PSR target numbers SHALL include +3 per gyro-hit counter
+- **AND** 2 gyro hits on a standard gyro SHALL destroy the gyro
+- **AND** an immediate PSR SHALL be queued
+
+#### Scenario: Cockpit hit kills pilot
+
+- **GIVEN** the cockpit takes a critical hit
+- **WHEN** the critical effect is applied
+- **THEN** the pilot SHALL be killed immediately
+- **AND** the unit SHALL be marked disabled
+
+#### Scenario: Sensor hit adds to-hit penalty
+
+- **GIVEN** sensors take a critical hit
+- **WHEN** the critical effect is applied
+- **THEN** 1 sensor hit SHALL add +1 to all of the unit's attack to-hit rolls
+- **AND** 2 sensor hits SHALL add +2 (and the second hit destroys sensors)
+
+#### Scenario: Actuator type determines effect
+
+- **GIVEN** a limb takes a critical hit
+- **WHEN** the slot manifest indicates which actuator was hit
+- **THEN** the effect SHALL depend on the actuator type (shoulder / upper arm / lower arm / hand / hip / upper leg / lower leg / foot)
+- **AND** a hip crit SHALL queue a PSR
+- **AND** a shoulder crit SHALL add +4 to-hit for attacks with weapons on that arm
+
+#### Scenario: Weapon crit destroys weapon
+
+- **GIVEN** a weapon takes a critical hit
+- **WHEN** the critical effect is applied
+- **THEN** the weapon SHALL be marked destroyed
+- **AND** the weapon SHALL NOT appear as fireable in subsequent turns
+
+#### Scenario: Heat sink crit reduces dissipation
+
+- **GIVEN** a heat sink takes a critical hit
+- **WHEN** the critical effect is applied
+- **THEN** the heat sink SHALL be marked destroyed
+- **AND** the unit's dissipation capacity SHALL decrease by the heat sink's rating (1 for single, 2 for double)
+
+#### Scenario: Ammo crit triggers explosion
+
+- **GIVEN** an ammo bin takes a critical hit
+- **WHEN** the critical effect is applied
+- **THEN** an ammo explosion SHALL be resolved (damage = remainingRounds × weapon damage)
+- **AND** CASE / CASE II protection SHALL be honored per their rules

--- a/openspec/changes/integrate-damage-pipeline/specs/damage-system/spec.md
+++ b/openspec/changes/integrate-damage-pipeline/specs/damage-system/spec.md
@@ -1,0 +1,104 @@
+# damage-system (delta)
+
+## ADDED Requirements
+
+### Requirement: resolveDamage Called From Attack Path
+
+When an attack hits, the engine SHALL call `resolveDamage()` from `src/utils/gameplay/damage.ts` to apply damage through the full armor → structure → transfer → pilot pipeline. The engine SHALL NOT apply damage directly or via `applySimpleDamage`.
+
+#### Scenario: Attack hit invokes resolveDamage
+
+- **GIVEN** an attack that hits
+- **WHEN** the attack resolver processes the hit
+- **THEN** `resolveDamage` SHALL be invoked with damage, hitLocation, arc, attackerState, targetState, and the seeded RNG
+- **AND** the returned `ILocationDamageResult` SHALL be translated into events
+
+#### Scenario: SimulationRunner uses resolveDamage
+
+- **GIVEN** an autonomous simulation match
+- **WHEN** an attack hits during the simulation
+- **THEN** `resolveDamage` SHALL be used (not `applySimpleDamage`)
+
+### Requirement: Full Damage Transfer Chain
+
+Damage SHALL cascade armor → structure → adjacent location per the canonical transfer diagram.
+
+#### Scenario: Damage exceeds armor transfers to structure
+
+- **GIVEN** a location with 10 armor and 8 structure
+- **WHEN** 15 damage is applied
+- **THEN** armor SHALL be reduced to 0
+- **AND** 5 damage SHALL apply to structure
+- **AND** structure SHALL become 3
+
+#### Scenario: Damage exceeds structure transfers to adjacent
+
+- **GIVEN** damage exceeds both armor and structure at a location
+- **WHEN** the transfer step runs
+- **THEN** the location SHALL be marked destroyed
+- **AND** excess damage SHALL transfer per the diagram (arm → side torso; leg → side torso; side torso → center torso; center torso destruction destroys the unit)
+- **AND** transferred damage SHALL apply to the adjacent location's armor first
+
+### Requirement: Side Torso Destruction Cascades to Arm
+
+When a side torso is destroyed, the arm on that side SHALL also be destroyed.
+
+#### Scenario: Left torso destroyed destroys left arm
+
+- **GIVEN** the left torso reaches structure 0
+- **WHEN** destruction is processed
+- **THEN** the left arm SHALL be marked destroyed
+- **AND** all equipment in the left arm SHALL be marked destroyed
+- **AND** a `LocationDestroyed` event SHALL be emitted for LA
+
+#### Scenario: Right torso cascade
+
+- **GIVEN** the right torso reaches structure 0
+- **WHEN** destruction is processed
+- **THEN** the right arm SHALL also be destroyed
+
+### Requirement: Head Damage Cap
+
+A single standard-weapon hit to the head SHALL deal a maximum of 3 damage, with excess discarded (not transferred).
+
+#### Scenario: AC/20 to head caps at 3
+
+- **GIVEN** an AC/20 (20 damage) hits the head
+- **WHEN** head damage is applied
+- **THEN** only 3 damage SHALL be applied to the head
+- **AND** the remaining 17 damage SHALL be discarded
+
+#### Scenario: Cluster hits cap per group
+
+- **GIVEN** an LRM volley producing multiple head hits
+- **WHEN** each cluster group is applied
+- **THEN** each group SHALL be independently capped at 3
+
+### Requirement: 20+ Phase Damage Queues PSR
+
+When a unit's accumulated damage in a single phase reaches 20 or more, a PSR SHALL be queued with trigger `TwentyPlusPhaseDamage`.
+
+#### Scenario: Accumulate 22 damage in weapon phase
+
+- **GIVEN** a unit takes 22 damage during the weapon attack phase
+- **WHEN** the 20-point boundary is crossed
+- **THEN** a PSR SHALL be queued with trigger `TwentyPlusPhaseDamage`
+- **AND** `damageThisPhase` SHALL reflect 22
+
+#### Scenario: Under 20 damage does not queue
+
+- **GIVEN** a unit takes 18 damage during the phase
+- **WHEN** the phase ends
+- **THEN** no `TwentyPlusPhaseDamage` PSR SHALL be queued
+
+### Requirement: Pilot Damage From Head Structure Hits
+
+Damage that reaches head internal structure SHALL inflict 1 point of pilot damage and queue a consciousness check.
+
+#### Scenario: Head structure exposed
+
+- **GIVEN** an attack that damages head structure (armor breached)
+- **WHEN** the damage is applied
+- **THEN** the pilot SHALL take 1 damage
+- **AND** a `PilotHit` event SHALL be emitted
+- **AND** a consciousness check SHALL be queued

--- a/openspec/changes/integrate-damage-pipeline/tasks.md
+++ b/openspec/changes/integrate-damage-pipeline/tasks.md
@@ -1,0 +1,97 @@
+# Tasks: Integrate Damage Pipeline
+
+## 1. Attack Path Hookup
+
+- [ ] 1.1 In `gameSessionAttackResolution.ts`, after a hit is confirmed, call `resolveDamage()` from `damage.ts`
+- [ ] 1.2 Pass: damage amount, hit location, arc, attacker state, target state, seeded RNG
+- [ ] 1.3 Receive the `ILocationDamageResult` (or equivalent) and translate to events
+- [ ] 1.4 Remove or deprecate `applySimpleDamage()` from the simulation runner path
+
+## 2. Hit Location Integration
+
+- [ ] 2.1 Use the computed firing arc (from `wire-firing-arc-resolution`) to pick the hit-location table
+- [ ] 2.2 Confirm `hitLocation.ts` accepts the seeded RNG parameter (not `Math.random`)
+- [ ] 2.3 Emit the hit-location roll result as part of the attack event chain
+
+## 3. Armor → Structure → Transfer Chain
+
+- [ ] 3.1 Reduce armor first; excess transfers to internal structure
+- [ ] 3.2 If structure reaches 0, mark the location destroyed and transfer excess per the canonical diagram (arms → side torso; legs → side torso; side torso → center torso; center torso destruction destroys the unit)
+- [ ] 3.3 Transferred damage applies to the adjacent location's armor first, then its structure, then further transfers
+- [ ] 3.4 Emit `TransferDamage` events for each transfer step
+- [ ] 3.5 Emit `LocationDestroyed` events when a location reaches 0 structure
+
+## 4. Side Torso Cascade
+
+- [ ] 4.1 When left torso is destroyed, mark the left arm destroyed too (and all equipment in the left arm)
+- [ ] 4.2 Same rule for right torso → right arm
+- [ ] 4.3 Test: destroying the left torso emits `LocationDestroyed` for LT then for LA
+
+## 5. Head Damage Cap
+
+- [ ] 5.1 Cap a single standard-weapon hit to the head at 3 damage applied
+- [ ] 5.2 Excess SHALL be discarded (not transferred)
+- [ ] 5.3 Cluster weapons SHALL cap per cluster group independently
+- [ ] 5.4 Unit tests: AC/20 to head applies 3, discards 17; LRM-20 with 6 hits caps each cluster at 3
+
+## 6. Pilot Damage From Head Hits
+
+- [ ] 6.1 When head damage penetrates armor and reaches structure, apply 1 pilot damage
+- [ ] 6.2 Queue a consciousness check (uses the corrected `>=` from `fix-combat-rule-accuracy`)
+- [ ] 6.3 Emit `PilotHit` event
+
+## 7. 20+ Phase Damage PSR Trigger
+
+- [ ] 7.1 Maintain per-unit `damageThisPhase` counter on `IUnitGameState`
+- [ ] 7.2 When `damageThisPhase` crosses 20, queue a PSR with trigger `TwentyPlusPhaseDamage`
+- [ ] 7.3 Reset `damageThisPhase` at phase boundary
+- [ ] 7.4 PSR firing itself is handled by `wire-piloting-skill-rolls`; this task only queues
+
+## 8. Critical Hit Resolution Hookup
+
+- [ ] 8.1 When structure is exposed at a location by damage, call `resolveCriticalHits()` on that location
+- [ ] 8.2 Pass the seeded RNG so replay reproduces the same slot selection
+- [ ] 8.3 Roll 2d6 per exposed-structure hit; the table is: 2-7 → 0 crits, 8-9 → 1 crit, 10-11 → 2 crits, 12 → location-specific (limb blown off / head destroyed / 3 torso crits)
+
+## 9. Critical Slot Selection
+
+- [ ] 9.1 Build the slot manifest from occupied non-destroyed slots in the hit location
+- [ ] 9.2 Select a slot uniformly at random via the seeded RNG
+- [ ] 9.3 If no slot is selectable (all destroyed), the critical is discarded
+
+## 10. Critical Effect Application
+
+- [ ] 10.1 Engine crit: engine-hit counter +1; +5 heat per turn per engine hit; 3 hits → unit destroyed
+- [ ] 10.2 Gyro crit: gyro-hit counter +1; +3 to all PSR TNs per hit; 2 hits → standard gyro destroyed → unit cannot stand
+- [ ] 10.3 Cockpit crit: pilot killed immediately
+- [ ] 10.4 Sensor crit: +1 to all attack to-hit at 1 hit, +2 at 2 hits
+- [ ] 10.5 Life support crit: `hitsToDestroy = 2` (from `fix-combat-rule-accuracy`)
+- [ ] 10.6 Heat sink crit: heat sink destroyed; dissipation capacity reduced
+- [ ] 10.7 Jump jet crit: jump jet destroyed; max jump MP -1
+- [ ] 10.8 Weapon crit: weapon destroyed; cannot fire
+- [ ] 10.9 Actuator crit: per actuator type (shoulder / upper arm / lower arm / hand / hip / upper leg / lower leg / foot) with distinct effects; hip crit queues a PSR
+- [ ] 10.10 Ammo crit: explosion of remaining rounds × weapon damage; CASE / CASE II protection honored
+
+## 11. TAC Processing
+
+- [ ] 11.1 When the hit-location roll is 2, call `resolveCriticalHits()` regardless of remaining armor
+- [ ] 11.2 TAC location: Front/Rear → CT, Left → LT, Right → RT
+
+## 12. Seeded RNG Plumbing
+
+- [ ] 12.1 Ensure `resolveDamage`, `hitLocation`, `resolveCriticalHits` all accept an injected `IDiceRoller` parameter
+- [ ] 12.2 Remove residual `Math.random()` from the damage/crit path
+- [ ] 12.3 Replay test: replaying the same event log with the same seed produces identical unit state
+
+## 13. Simulation Runner Parity
+
+- [ ] 13.1 Replace `applySimpleDamage()` in `SimulationRunner.ts` with a call to `resolveDamage`
+- [ ] 13.2 Ensure the autonomous fuzzer still passes invariants (no negative armor, no locations with > max armor, etc.)
+
+## 14. Validation
+
+- [ ] 14.1 `openspec validate integrate-damage-pipeline --strict`
+- [ ] 14.2 End-to-end test: fire 1 AC/20 to exposed CT structure → `DamageApplied` → `CriticalHit` → engine hit → `ComponentDestroyed` chain
+- [ ] 14.3 Side torso cascade test: destroy LT → LA also destroyed
+- [ ] 14.4 Head-cap test: single AC/20 to head applies only 3 damage
+- [ ] 14.5 Build + lint clean

--- a/openspec/changes/wire-encounter-to-campaign-round-trip/proposal.md
+++ b/openspec/changes/wire-encounter-to-campaign-round-trip/proposal.md
@@ -1,0 +1,69 @@
+# Change: Wire Encounter To Campaign Round Trip
+
+## Why
+
+Every Phase 3 piece (outcome model, post-battle processor, salvage, repair
+queue, review UI) is a component. This change is the integration glue that
+makes them a system. The end-to-end flow must work: player accepts a
+contract → campaign generates an encounter → player launches a game session
+→ Phase 1 engine plays out → `ICombatOutcome` emitted → outcome flows through
+review UI → pushed to `pendingBattleOutcomes` → next day-advance runs the
+post-battle, salvage, and repair processors → player sees the consequences
+on the campaign dashboard. Without this change, each Phase 3 piece works in
+isolation but the overall loop is broken.
+
+## What Changes
+
+- Extend `EncounterService.launchEncounter` so the returned `gameSessionId`
+  carries forward `encounterId`, `contractId`, and `scenarioId` onto the
+  `IGameSession` configuration (today it produces the session but linkage
+  is incomplete)
+- Extend the `InteractiveSession` completion handler: when `GameEnded`
+  fires, automatically derive `ICombatOutcome` and persist to
+  `/api/matches` (wired in `add-combat-outcome-model`), then emit a global
+  `CombatOutcomeReady` bus event the campaign store listens for
+- Extend campaign store: subscribing to `CombatOutcomeReady`, enqueue the
+  outcome into `campaign.pendingBattleOutcomes` (guard against double-push
+  by checking `matchId`)
+- Extend `wire-encounter-to-campaign-round-trip` flow: on `Return to
+Campaign` from the review UI, navigate to the campaign dashboard with a
+  query flag (`?pendingBattle=<matchId>`) so the dashboard shows a
+  "Pending battle outcomes — advance day to apply" banner
+- Extend the day-advancement flow: when the player clicks "Advance day",
+  run `postBattleProcessor` + `salvageProcessor` + `repairQueueBuilderProcessor`
+  as part of the pipeline before other processors; surface an audit card
+  on the dashboard summarizing applied effects (N XP, K pilots wounded, J
+  C-Bills salvage value, R tickets created)
+- Extend scenario generation: when `scenarioGenerationProcessor` creates a
+  scenario for a contract, tag the resulting encounter with the contract
+  id so the full linkage is preserved through the entire loop
+
+## Dependencies
+
+- **Requires**: `add-combat-outcome-model`, `add-post-battle-processor`,
+  `add-salvage-rules-engine`, `add-repair-queue-integration`,
+  `add-post-battle-review-ui`
+- **Requires (Phase 1 A1–A7, B6)**: correct combat math and post-battle
+  summary — this change assumes those land first
+- **Required By**: none — this is the terminal Phase 3 integration
+
+## Impact
+
+- Affected specs: `game-session-management` (MODIFIED — session carries
+  encounter/contract/scenario linkage, emits outcome bus event),
+  `contract-types` (MODIFIED — contract lifecycle event when a pending
+  outcome advances its state), `scenario-generation` (MODIFIED —
+  contract-generated encounters preserve full linkage)
+- Affected code: extends
+  `src/services/encounter/EncounterService.ts` (inject linkage into
+  session config), extends
+  `src/engine/InteractiveSession.ts` (emit outcome bus event on
+  completion), extends
+  `src/stores/campaign/campaignStore.ts` (subscribe to
+  `CombatOutcomeReady`), extends
+  `src/lib/campaign/dayAdvancement.ts` (registers the three new
+  processors in order), extends
+  `src/app/campaign/page.tsx` (pending-outcomes banner and audit card)
+- Non-goals: multiplayer sync of outcomes (Phase 4), contract negotiation
+  UI changes (already in contract-types spec), alternative paths for
+  abandoning outcomes (future — for now, outcomes are always applied)

--- a/openspec/changes/wire-encounter-to-campaign-round-trip/specs/contract-types/spec.md
+++ b/openspec/changes/wire-encounter-to-campaign-round-trip/specs/contract-types/spec.md
@@ -1,0 +1,44 @@
+# contract-types Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Contract Fulfillment Event
+
+The `PostBattleProcessor` SHALL publish a `ContractFulfilled` event when
+it processes the final outcome of a contract, allowing downstream
+processors to close the contract on their next run.
+
+#### Scenario: Final scenario triggers fulfillment event
+
+- **GIVEN** a contract requiring 5 scenarios with `scenariosPlayed = 4`
+- **WHEN** `postBattleProcessor` processes an outcome that increments
+  `scenariosPlayed` to 5
+- **THEN** a `ContractFulfilled` event SHALL be published with the
+  contract id
+- **AND** the contract's `fulfilled` flag SHALL be set to true
+
+#### Scenario: Non-final scenario does not publish event
+
+- **GIVEN** a contract requiring 5 scenarios with `scenariosPlayed = 2`
+- **WHEN** `postBattleProcessor` processes an outcome that increments
+  `scenariosPlayed` to 3
+- **THEN** no `ContractFulfilled` event SHALL be published
+- **AND** the contract's `fulfilled` flag SHALL remain false
+
+### Requirement: Contract Processor Listens For Fulfillment
+
+The existing `contractProcessor` SHALL listen for `ContractFulfilled`
+events and close the contract on its next invocation by processing final
+payment, faction standing, and removal from the active contract list.
+
+#### Scenario: Contract closure on next processor run
+
+- **GIVEN** a `ContractFulfilled` event was published today for contract C
+- **WHEN** `contractProcessor` runs (either later today or on the next
+  day advance)
+- **THEN** contract C SHALL have its final payment applied to the
+  campaign's finances
+- **AND** faction standing SHALL be updated per the contract's success
+  modifier
+- **AND** contract C SHALL be removed from the active contract list and
+  archived to completed contracts

--- a/openspec/changes/wire-encounter-to-campaign-round-trip/specs/game-session-management/spec.md
+++ b/openspec/changes/wire-encounter-to-campaign-round-trip/specs/game-session-management/spec.md
@@ -1,0 +1,91 @@
+# game-session-management Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Session Carries Campaign Linkage
+
+Every `IGameSession` launched from an encounter SHALL carry `encounterId`
+on its configuration, and when the encounter is generated from a contract
+the session SHALL additionally carry `contractId` and `scenarioId`.
+
+#### Scenario: Contract-launched session has full linkage
+
+- **GIVEN** a contract C with generated scenario S and encounter E
+- **WHEN** `EncounterService.launchEncounter(E)` returns a session id G
+- **THEN** session G's config SHALL include `encounterId = E.id`,
+  `contractId = C.id`, `scenarioId = S.id`
+
+#### Scenario: Standalone encounter has encounter id only
+
+- **GIVEN** a standalone encounter without a contract
+- **WHEN** `EncounterService.launchEncounter(E)` returns a session id G
+- **THEN** session G's config SHALL include `encounterId = E.id`
+- **AND** `contractId` and `scenarioId` SHALL be `null`
+
+### Requirement: Session Publishes Outcome Ready Event
+
+Upon session completion, the `InteractiveSession` SHALL publish a
+`CombatOutcomeReady` event on the global event bus carrying the session
+id, match id, and derived `ICombatOutcome`.
+
+#### Scenario: Event published on completion
+
+- **GIVEN** an active session that transitions to `Completed`
+- **WHEN** the completion handler runs
+- **THEN** `CombatOutcomeReady` SHALL be published on the session bus
+- **AND** the event payload SHALL include the full `ICombatOutcome`
+- **AND** the outcome SHALL also be POSTed to `/api/matches`
+
+#### Scenario: Event idempotent per session
+
+- **GIVEN** a session that has already published `CombatOutcomeReady`
+  once
+- **WHEN** any subsequent action on the session attempts another
+  publication
+- **THEN** no second `CombatOutcomeReady` SHALL be published for the
+  same match id
+
+### Requirement: Campaign Store Enqueues Outcomes
+
+The campaign store SHALL subscribe to `CombatOutcomeReady` and append the
+outcome to `campaign.pendingBattleOutcomes` when received, ignoring
+duplicates by `matchId`.
+
+#### Scenario: New outcome appended
+
+- **GIVEN** a campaign with an empty `pendingBattleOutcomes` queue
+- **WHEN** a `CombatOutcomeReady` event arrives carrying outcome O
+- **THEN** `pendingBattleOutcomes` SHALL equal `[O]`
+
+#### Scenario: Duplicate outcome ignored
+
+- **GIVEN** a campaign with `pendingBattleOutcomes` already containing
+  outcome O (by matchId)
+- **WHEN** another `CombatOutcomeReady` arrives carrying the same matchId
+- **THEN** the queue SHALL remain unchanged
+
+### Requirement: Day Advancement Applies Pending Outcomes
+
+When the player advances the day, the day pipeline SHALL drain
+`campaign.pendingBattleOutcomes` through the `postBattleProcessor`,
+`salvageProcessor`, and `repairQueueBuilderProcessor` in that order before
+any other day processors run.
+
+#### Scenario: Processors execute in required order
+
+- **GIVEN** a campaign with `pendingBattleOutcomes = [O1]` at the start
+  of day advancement
+- **WHEN** the pipeline executes
+- **THEN** `postBattleProcessor(O1)` SHALL run first
+- **AND** `salvageProcessor(O1)` SHALL run second
+- **AND** `repairQueueBuilderProcessor(O1)` SHALL run third
+- **AND** all three SHALL complete before `contractProcessor`,
+  `healingProcessor`, and `maintenanceProcessor` run
+
+#### Scenario: Drained outcomes move to processedBattleIds
+
+- **GIVEN** a successful run through the three battle-effects processors
+  for outcome O1 with matchId M
+- **WHEN** the pipeline finishes the battle-effects block
+- **THEN** O1 SHALL be removed from `pendingBattleOutcomes`
+- **AND** `M` SHALL be appended to `campaign.processedBattleIds`

--- a/openspec/changes/wire-encounter-to-campaign-round-trip/specs/scenario-generation/spec.md
+++ b/openspec/changes/wire-encounter-to-campaign-round-trip/specs/scenario-generation/spec.md
@@ -1,0 +1,45 @@
+# scenario-generation Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Contract-Generated Scenarios Preserve Linkage
+
+Every encounter produced by `scenarioGenerationProcessor` from a contract SHALL be tagged with both `contractId` and `scenarioId` so the linkage flows through to the `IGameSession` launched by `EncounterService`.
+
+#### Scenario: Encounter is tagged with contract id
+
+- **GIVEN** a contract C with combat role `MANEUVER` and a scheduled
+  weekly scenario
+- **WHEN** `scenarioGenerationProcessor` runs on a Monday and generates
+  scenario S and encounter E
+- **THEN** the persisted encounter E SHALL have `contractId = C.id`
+- **AND** E SHALL have `scenarioId = S.id`
+
+#### Scenario: Standalone scenarios have null contract id
+
+- **GIVEN** a manually-created scenario not attached to any contract
+- **WHEN** an encounter is created from it
+- **THEN** the encounter's `contractId` SHALL be `null`
+- **AND** the encounter's `scenarioId` SHALL reference the scenario
+
+### Requirement: Session Launch Forwards Linkage
+
+`EncounterService.launchEncounter(E)` SHALL forward any `contractId` and
+`scenarioId` on the encounter into the `IGameSession` config so the
+session inherits full linkage.
+
+#### Scenario: Launched session carries linkage
+
+- **GIVEN** an encounter E with `contractId = C` and `scenarioId = S`
+- **WHEN** `EncounterService.launchEncounter(E)` is called
+- **THEN** the returned session's config SHALL contain `contractId = C`
+- **AND** the session's config SHALL contain `scenarioId = S`
+
+#### Scenario: No linkage does not fail launch
+
+- **GIVEN** an encounter E with `contractId = null` and `scenarioId =
+null`
+- **WHEN** `EncounterService.launchEncounter(E)` is called
+- **THEN** the session SHALL launch successfully
+- **AND** the session's config SHALL carry `contractId = null` and
+  `scenarioId = null`

--- a/openspec/changes/wire-encounter-to-campaign-round-trip/tasks.md
+++ b/openspec/changes/wire-encounter-to-campaign-round-trip/tasks.md
@@ -1,0 +1,114 @@
+# Tasks: Wire Encounter To Campaign Round Trip
+
+## 1. Encounter → Session Linkage
+
+- [ ] 1.1 Extend `EncounterService.launchEncounter` signature: accept
+      `contractId?` and `scenarioId?` alongside the encounter
+- [ ] 1.2 Pass these into the `IGameSession` config as fields
+      `encounterId`, `contractId`, `scenarioId`
+- [ ] 1.3 Assert that launched sessions have these fields populated when
+      the source is a contract (fail fast if they're null)
+- [ ] 1.4 Update `encounterToGameSession.ts` tests to assert linkage
+
+## 2. Session Completion Emits Outcome Bus Event
+
+- [ ] 2.1 Add `CombatOutcomeReady` to the session-level event bus (in
+      `src/engine/InteractiveSession.ts`)
+- [ ] 2.2 On `GameEnded`, derive `ICombatOutcome` (per
+      `add-combat-outcome-model`) and publish `CombatOutcomeReady`
+- [ ] 2.3 POST outcome to `/api/matches` for persistence
+- [ ] 2.4 Include `matchId` in the bus payload
+
+## 3. Campaign Store Subscribes To Outcomes
+
+- [ ] 3.1 In `src/stores/campaign/campaignStore.ts`, subscribe to the
+      `CombatOutcomeReady` bus event
+- [ ] 3.2 On receipt, enqueue the outcome into
+      `campaign.pendingBattleOutcomes` if `matchId` is not already present
+      (idempotent push)
+- [ ] 3.3 Persist the queue alongside the campaign record
+- [ ] 3.4 Emit a campaign-level `PendingOutcomeAdded` event so the
+      dashboard can re-render
+
+## 4. Review UI → Campaign Handoff
+
+- [ ] 4.1 On the review page's "Return to Campaign" CTA, ensure the
+      outcome is in the pending queue (re-enqueue if not, matched by
+      matchId — still idempotent)
+- [ ] 4.2 Close the tactical session in session store
+- [ ] 4.3 Navigate to `/campaign?pendingBattle=<matchId>`
+
+## 5. Campaign Dashboard Pending-Outcomes Banner
+
+- [ ] 5.1 Add `PendingOutcomesBanner` component on the campaign dashboard
+- [ ] 5.2 Banner visible whenever `pendingBattleOutcomes.length > 0`
+- [ ] 5.3 Banner summary: "N pending battle outcomes — advance day to
+      apply"
+- [ ] 5.4 Banner lists match ids with links to each review page for
+      re-inspection
+- [ ] 5.5 Banner dismisses itself once queue is drained by the
+      post-battle processor
+
+## 6. Day Advancement Pipeline Order
+
+- [ ] 6.1 Register `postBattleProcessor` at the start of the "battle
+      effects" group
+- [ ] 6.2 Register `salvageProcessor` after `postBattleProcessor`
+- [ ] 6.3 Register `repairQueueBuilderProcessor` after `salvageProcessor`
+- [ ] 6.4 These three run before the existing `contractProcessor`,
+      `healingProcessor`, `maintenanceProcessor`
+- [ ] 6.5 Document the full order in `dayAdvancement.ts` header comment
+
+## 7. Day Advancement Audit Card
+
+- [ ] 7.1 Aggregate the effects applied by the three battle-effects
+      processors into a per-day `IDailyBattleAuditEntry`
+- [ ] 7.2 Entry fields: matches processed, total XP awarded, pilots
+      wounded/KIA/MIA, salvage value secured, repair tickets created
+- [ ] 7.3 Surface the entry in the campaign dashboard's audit feed
+- [ ] 7.4 Clicking the entry navigates to the relevant match review pages
+
+## 8. Scenario Generation Linkage
+
+- [ ] 8.1 Update `scenarioGenerationProcessor` so every generated scenario
+      produced from a contract records the `contractId` on the resulting
+      encounter record
+- [ ] 8.2 When `EncounterService.launchEncounter` is called, the
+      `contractId` flows through per task group 1
+
+## 9. Contract Lifecycle Events
+
+- [ ] 9.1 When `postBattleProcessor` flags a contract as fulfilled,
+      publish `ContractFulfilled` event
+- [ ] 9.2 `contractProcessor` listens and closes the contract (final
+      payment, faction standing, contract removal from active list) on its
+      next run
+- [ ] 9.3 Surface closure in the campaign dashboard as an audit entry
+
+## 10. End-to-End Test
+
+- [ ] 10.1 Integration test: mock contract → generated encounter →
+      launched session → simulated battle outcome → review → return to
+      campaign → day advance → assert state
+- [ ] 10.2 Assertions: pilots have XP, wounded pilots in medical queue,
+      units have combat state reflecting damage, salvage inventory has
+      awarded items, repair queue has expected tickets
+- [ ] 10.3 E2E test: full Playwright flow replicating a single-contract
+      play loop
+
+## 11. Error & Recovery Paths
+
+- [ ] 11.1 If the player quits mid-battle, no outcome is produced — queue
+      remains untouched; session marked abandoned
+- [ ] 11.2 If `postBattleProcessor` fails on an outcome, it stays in the
+      queue with an error flag; banner shows "1 outcome failed to apply —
+      see details" link
+- [ ] 11.3 Retry on next day advance or via manual "retry application"
+      button in the review page
+
+## 12. Documentation
+
+- [ ] 12.1 Add `docs/architecture/campaign-combat-loop.md` with a sequence
+      diagram covering: contract → encounter → session → outcome → queue →
+      processors → campaign state
+- [ ] 12.2 Cross-link the doc from the main architecture index

--- a/openspec/changes/wire-firing-arc-resolution/proposal.md
+++ b/openspec/changes/wire-firing-arc-resolution/proposal.md
@@ -1,0 +1,26 @@
+# Change: Wire Firing Arc Resolution
+
+## Why
+
+The engine currently uses `FiringArc.Front` for every attack regardless of attacker position or target facing. Side and rear attacks therefore never draw the correct hit-location tables and never apply rear-armor values. The math needed already exists in `src/utils/gameplay/firingArc.ts` and `firingArcs.ts` (arc from hex positions plus target facing), and the `firing-arc-calculation` spec is already archived. What's missing is the single wiring step: instead of hardcoding `FiringArc.Front` in the attack path, call the arc helper. Once wired, rear/side hit location tables become reachable, and rear armor starts being meaningful. See `openspec/changes/archive/2026-02-12-full-combat-parity/proposal.md` Phase 1 for context.
+
+## What Changes
+
+- Replace every hardcoded `FiringArc.Front` in the attack-resolution path with `computeFiringArc(attackerHex, targetHex, targetFacing)` from `firingArc.ts`
+- Thread the computed `FiringArc` through the attack event payload (`attackerArc` field) so hit-location resolution reads it
+- Update the `to-hit-resolution` hit-location scenarios to use the real arc (front / left / right / rear tables)
+- Apply the side-attack-during-movement boundary resolution consistently (front arc precedence on the front/side boundary, rear arc precedence on the rear/side boundary)
+- Emit a warning event when attacker and target are in the same hex (arc is undefined); reject the attack
+- Record the arc in the `AttackResolved` event so the UI can display it
+
+## Dependencies
+
+- **Requires**: `fix-combat-rule-accuracy` (to-hit math needs to be correct before arc changes which modifiers apply)
+- **Blocks**: `integrate-damage-pipeline` (hit location depends on real arc)
+
+## Impact
+
+- **Affected specs**: `firing-arc-calculation` (confirm computation wired into combat), `to-hit-resolution` (hit location uses computed arc), `combat-resolution` (attack events carry computed arc)
+- **Affected code**: `src/engine/GameEngine.ts`, `src/engine/GameEngine.phases.ts`, `src/utils/gameplay/gameSessionAttackResolution.ts`, `src/utils/gameplay/hitLocation.ts`, `src/utils/gameplay/firingArc.ts`, `src/utils/gameplay/firingArcs.ts`
+- **Test fallout**: tests that assert front-arc hit locations need variants for left/right/rear arcs
+- **No new modules required**. The helper already exists; this change wires it.

--- a/openspec/changes/wire-firing-arc-resolution/specs/combat-resolution/spec.md
+++ b/openspec/changes/wire-firing-arc-resolution/specs/combat-resolution/spec.md
@@ -1,0 +1,20 @@
+# combat-resolution (delta)
+
+## ADDED Requirements
+
+### Requirement: Attack Event Carries Computed Arc
+
+`AttackResolved` events SHALL include the computed firing arc. Downstream consumers (damage pipeline, event log, UI, replay) SHALL read the arc from the event, not recompute it.
+
+#### Scenario: Event payload includes arc
+
+- **GIVEN** an attack resolves from the right arc
+- **WHEN** the `AttackResolved` event is persisted
+- **THEN** the event payload SHALL include `attackerArc: FiringArc.Right`
+
+#### Scenario: Replay reconstructs arc from event
+
+- **GIVEN** an event log containing an `AttackResolved` event with `attackerArc: FiringArc.Rear`
+- **WHEN** the replay reducer processes the event
+- **THEN** the reconstructed game state SHALL show the attack was resolved from the rear arc
+- **AND** the damage application during replay SHALL use the rear hit-location table

--- a/openspec/changes/wire-firing-arc-resolution/specs/firing-arc-calculation/spec.md
+++ b/openspec/changes/wire-firing-arc-resolution/specs/firing-arc-calculation/spec.md
@@ -1,0 +1,50 @@
+# firing-arc-calculation (delta)
+
+## ADDED Requirements
+
+### Requirement: Arc Computation Invoked During Attack Resolution
+
+The firing-arc helper (`computeFiringArc(attackerHex, targetHex, targetFacing)`) SHALL be invoked for every attack during resolution. Hardcoded `FiringArc.Front` SHALL NOT appear in the attack-resolution path.
+
+#### Scenario: Direct call during attack resolution
+
+- **GIVEN** an attacker at hex (5, 3) and a target at hex (5, 5) facing direction 0
+- **WHEN** the attack is resolved
+- **THEN** `computeFiringArc` SHALL be invoked with those arguments
+- **AND** the returned arc SHALL propagate onto the `AttackResolved` event payload
+
+#### Scenario: Arc field on event payload
+
+- **GIVEN** an attack that resolves successfully
+- **WHEN** the `AttackResolved` event is emitted
+- **THEN** the payload SHALL include an `attackerArc: FiringArc` field
+
+#### Scenario: Same-hex arc undefined
+
+- **GIVEN** an attacker and target occupying the same hex
+- **WHEN** the arc helper is invoked
+- **THEN** the attack SHALL be rejected with `AttackInvalid` and reason `SameHex`
+
+### Requirement: Arc Boundary Resolution Is Deterministic
+
+When the attacker's hex is exactly on the boundary between two arcs, the system SHALL resolve the ambiguity deterministically and document the precedence rule.
+
+Precedence rule: front arc wins front/side boundaries; rear arc wins rear/side boundaries. The same position evaluated twice SHALL return the same arc.
+
+#### Scenario: Front/side boundary
+
+- **GIVEN** an attacker position that mathematically sits on the front-left boundary
+- **WHEN** the arc is computed
+- **THEN** the arc SHALL be `Front` (front precedence)
+
+#### Scenario: Rear/side boundary
+
+- **GIVEN** an attacker position that mathematically sits on the rear-left boundary
+- **WHEN** the arc is computed
+- **THEN** the arc SHALL be `Rear` (rear precedence)
+
+#### Scenario: Determinism property
+
+- **GIVEN** any attacker/target/facing triple
+- **WHEN** `computeFiringArc` is invoked twice with the same arguments
+- **THEN** both calls SHALL return the same `FiringArc` value

--- a/openspec/changes/wire-firing-arc-resolution/specs/to-hit-resolution/spec.md
+++ b/openspec/changes/wire-firing-arc-resolution/specs/to-hit-resolution/spec.md
@@ -1,0 +1,32 @@
+# to-hit-resolution (delta)
+
+## ADDED Requirements
+
+### Requirement: Hit Location Table Selected by Computed Arc
+
+The hit-location table used during damage resolution SHALL be selected by the arc computed at attack time, not a default front table.
+
+#### Scenario: Front-arc attack uses front table
+
+- **GIVEN** an attack resolved from the front arc
+- **WHEN** hit location is rolled
+- **THEN** the front 2d6 table SHALL be consulted (2=CT(TAC), 3-4=RA, 5=RL, 6=RT, 7=CT, 8=LT, 9=LL, 10-11=LA, 12=Head)
+
+#### Scenario: Left-arc attack uses left table
+
+- **GIVEN** an attack resolved from the left arc
+- **WHEN** hit location is rolled
+- **THEN** the left-side 2d6 table SHALL be consulted (per TechManual p.109)
+
+#### Scenario: Right-arc attack uses right table
+
+- **GIVEN** an attack resolved from the right arc
+- **WHEN** hit location is rolled
+- **THEN** the right-side 2d6 table SHALL be consulted
+
+#### Scenario: Rear-arc attack uses rear table
+
+- **GIVEN** an attack resolved from the rear arc
+- **WHEN** hit location is rolled
+- **THEN** the rear 2d6 table SHALL be consulted
+- **AND** hits SHALL apply to rear armor where applicable (CT rear, LT rear, RT rear)

--- a/openspec/changes/wire-firing-arc-resolution/tasks.md
+++ b/openspec/changes/wire-firing-arc-resolution/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: Wire Firing Arc Resolution
+
+## 1. Audit Hardcoded Arc Usage
+
+- [ ] 1.1 Grep every `FiringArc.Front` reference in the engine and gameSession paths
+- [ ] 1.2 Confirm which call sites are real combat path (not unit-test fixtures)
+- [ ] 1.3 Produce a worklist of replacement points
+
+## 2. Confirm Arc Helper API
+
+- [ ] 2.1 Review `firingArc.ts` / `firingArcs.ts` — confirm signature is `computeFiringArc(attackerHex, targetHex, targetFacing): FiringArc`
+- [ ] 2.2 Confirm boundary handling is consistent (front precedence on front/side boundary, rear precedence on rear/side boundary)
+- [ ] 2.3 If duplicate helpers exist across the two files, pick one and deprecate the other
+
+## 3. Wire Arc Computation Into Attack Path
+
+- [ ] 3.1 In `gameSessionAttackResolution.ts`, compute the arc per attacker/target pair instead of reading a constant
+- [ ] 3.2 Pass the computed arc through to `hitLocation.ts` so it picks the correct table (Front / Left / Right / Rear)
+- [ ] 3.3 Include the arc on the `AttackResolved` event payload as `attackerArc: FiringArc`
+- [ ] 3.4 Remove all `FiringArc.Front` literals from the attack-resolution path
+
+## 4. Hit Location Arc Propagation
+
+- [ ] 4.1 Confirm `hitLocation.ts` already supports arc parameter (per existing spec)
+- [ ] 4.2 If the game path was bypassing it, reconnect so arc determines the table used
+- [ ] 4.3 Unit tests: left-arc attack lands on the left-table locations (LA / LT / LL etc.)
+
+## 5. Edge Cases
+
+- [ ] 5.1 Handle same-hex attacker/target: reject the attack with an `AttackInvalid` / `SameHex` reason
+- [ ] 5.2 Handle attacker facing changes within the turn — use target facing at time of resolution
+- [ ] 5.3 Test rear-arc attack: target facing 0 (north), attacker directly south, arc SHALL be Rear
+
+## 6. Boundary Determinism
+
+- [ ] 6.1 Select a consistent convention for hex-side boundaries (front precedence over side; rear precedence over side)
+- [ ] 6.2 Document the convention in the arc helper
+- [ ] 6.3 Add a property-based test that sweeping attacker position around the target returns exactly one arc per position (no ambiguity)
+
+## 7. Bot Integration
+
+- [ ] 7.1 `AttackAI` SHOULD prefer arcs that expose rear armor (optional tactical heuristic)
+- [ ] 7.2 Minimum: `AttackAI` must not crash when target is in rear arc
+
+## 8. UI Consumers (non-blocking)
+
+- [ ] 8.1 Ensure the UI event log can display the arc string
+- [ ] 8.2 Optional: highlight arc on the hex map during attack preview
+
+## 9. Validation
+
+- [ ] 9.1 `openspec validate wire-firing-arc-resolution --strict`
+- [ ] 9.2 Autonomous fuzzer reports no new invariant violations related to arcs
+- [ ] 9.3 Build + lint clean

--- a/openspec/changes/wire-heat-generation-and-effects/proposal.md
+++ b/openspec/changes/wire-heat-generation-and-effects/proposal.md
@@ -1,0 +1,33 @@
+# Change: Wire Heat Generation and Effects
+
+## Why
+
+Heat is the defining tension of BattleTech combat — fire too much, overheat, shut down, maybe explode — but in MekStation the heat system is disconnected from almost everything. Movement heat uses `Jump ? 1 : 0` instead of walk=1 / run=2 / jump=max(3, jumpMP). Weapon heat is approximated as `weapons.length * 10` instead of reading per-weapon `heat` fields (this is addressed in `wire-real-weapon-data`). Heat sinks are hardcoded to `baseHeatSinks = 10` instead of reading actual unit heat-sink count. Shutdown checks never fire. Ammo-explosion heat checks never fire. Heat-induced to-hit and movement penalties aren't applied. Water cooling bonus exists but isn't consumed by the heat phase. This change wires the heat phase to operate on real values, triggering the full downstream chain (movement reduction, to-hit penalty, shutdown roll, ammo-explosion roll, engine-hit extra heat, pilot heat damage). See `openspec/changes/archive/2026-02-12-full-combat-parity/proposal.md` Phase 5 for the canonical heat-effects specification.
+
+## What Changes
+
+- Apply movement heat per phase: walking = 1, running = 2, jumping = max(3, jumpMP); add to unit heat during the movement resolution
+- Sum firing heat from real per-weapon heat (depends on `wire-real-weapon-data`)
+- Apply engine-hit heat: +5 per engine-hit counter (depends on `integrate-damage-pipeline`)
+- Compute dissipation from actual heat-sink count (engine-integrated + external, accounting for destroyed sinks)
+- Apply water-cooling bonus: +2 dissipation when standing in water depth 1, +4 when depth ≥ 2
+- Apply heat-induced to-hit penalty via the consolidated threshold table (from `fix-combat-rule-accuracy`)
+- Apply heat-induced movement penalty: `floor(heat / 5)` MP reduction to walk and run
+- Fire shutdown check at heat ≥ 14: roll 2d6 vs `4 + floor((heat - 14) / 4) * 2`
+- Automatic shutdown at heat ≥ 30
+- Fire ammo-explosion risk at heat ≥ 19 per bin: roll vs 4 (heat 19), 6 (heat 23), 8 (heat 28)
+- Apply pilot heat damage: 1 point at heat 15-24, 2 points at heat 25+ (plus life-support state)
+- Support startup rolls on subsequent turns for shut-down units
+- Emit `HeatGenerated`, `HeatDissipated`, `HeatShutdown`, `HeatStartup`, `PilotHit` (heat-sourced), `AmmoExploded` (heat-sourced) events
+
+## Dependencies
+
+- **Requires**: `fix-combat-rule-accuracy` (canonical heat thresholds), `wire-real-weapon-data` (real per-weapon heat), `integrate-damage-pipeline` (engine-hit heat contribution)
+- **Blocks**: `wire-piloting-skill-rolls` (shutdown from heat is a PSR trigger path)
+
+## Impact
+
+- **Affected specs**: `heat-management-system` (generation and dissipation wired), `heat-overflow-effects` (effects applied each heat phase), `heat-sink-system` (actual count consumed), `shutdown-startup-system` (shutdown/startup rolls fired), `movement-system` (movement heat + heat MP reduction)
+- **Affected code**: `src/utils/gameplay/gameSessionHeat.ts`, `src/utils/gameplay/heat.ts`, `src/utils/gameplay/movement.ts`, `src/engine/GameEngine.phases.ts`, `src/constants/heat.ts` (single source of truth)
+- **New events**: `HeatGenerated` (segmented by source: movement/firing/engine/environment), `HeatShutdown`, `HeatStartup`
+- **No new modules required**; module files already exist.

--- a/openspec/changes/wire-heat-generation-and-effects/specs/heat-management-system/spec.md
+++ b/openspec/changes/wire-heat-generation-and-effects/specs/heat-management-system/spec.md
@@ -1,0 +1,86 @@
+# heat-management-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Per-Turn Heat Generation
+
+The heat management system SHALL accumulate unit heat from all canonical sources each turn: movement, firing, engine damage, and environmental heat (e.g., fire/lava hexes).
+
+#### Scenario: Movement heat applied
+
+- **GIVEN** a unit that walked this turn
+- **WHEN** the heat phase runs
+- **THEN** the unit SHALL accumulate +1 heat from movement
+- **AND** a `HeatGenerated` event SHALL include source = `Movement`, amount = 1
+
+#### Scenario: Running heat
+
+- **GIVEN** a unit that ran this turn
+- **WHEN** the heat phase runs
+- **THEN** the unit SHALL accumulate +2 heat
+
+#### Scenario: Jump heat uses max(3, jumpMP)
+
+- **GIVEN** a unit with 5 jump MP that jumped 5 hexes
+- **WHEN** the heat phase runs
+- **THEN** the unit SHALL accumulate +5 heat from jump
+
+#### Scenario: Short jump still costs 3
+
+- **GIVEN** a unit with 2 jump MP that jumped 2 hexes
+- **WHEN** the heat phase runs
+- **THEN** the unit SHALL accumulate +3 heat (floor at 3)
+
+#### Scenario: Engine-hit contribution
+
+- **GIVEN** a unit with 2 engine hits
+- **WHEN** the heat phase runs
+- **THEN** the unit SHALL accumulate +10 heat from engine damage (5 × 2)
+
+### Requirement: Dissipation From Real Heat Sinks
+
+Dissipation SHALL be computed from the unit's actual heat-sink count (engine-integrated + external, minus destroyed sinks), not a fixed constant.
+
+#### Scenario: Standard mech with 10 single sinks
+
+- **GIVEN** a mech with 10 single heat sinks, none destroyed
+- **WHEN** dissipation is computed
+- **THEN** dissipation SHALL be 10
+
+#### Scenario: Double heat sinks
+
+- **GIVEN** a mech with 10 double heat sinks (IS), none destroyed
+- **WHEN** dissipation is computed
+- **THEN** dissipation SHALL be 20
+
+#### Scenario: Destroyed sinks excluded
+
+- **GIVEN** a mech with 10 single sinks, 3 destroyed by crits
+- **WHEN** dissipation is computed
+- **THEN** dissipation SHALL be 7
+
+### Requirement: Water Cooling Bonus Applied
+
+When a unit stands in water terrain, the water-cooling bonus SHALL be added to dissipation.
+
+#### Scenario: Water depth 1
+
+- **GIVEN** a mech standing in water depth 1
+- **WHEN** dissipation is computed
+- **THEN** +2 SHALL be added to dissipation
+
+#### Scenario: Water depth 2+
+
+- **GIVEN** a mech standing in water depth 2 or greater
+- **WHEN** dissipation is computed
+- **THEN** +4 SHALL be added to dissipation
+
+### Requirement: Heat Level Non-Negative
+
+The unit's heat level SHALL never be negative; dissipation that would reduce heat below 0 SHALL clamp to 0.
+
+#### Scenario: Overdissipation clamps
+
+- **GIVEN** a unit at heat 3 with dissipation 10
+- **WHEN** the heat phase ends
+- **THEN** the unit's heat SHALL be 0 (not -7)

--- a/openspec/changes/wire-heat-generation-and-effects/specs/heat-overflow-effects/spec.md
+++ b/openspec/changes/wire-heat-generation-and-effects/specs/heat-overflow-effects/spec.md
@@ -1,0 +1,38 @@
+# heat-overflow-effects (delta)
+
+## ADDED Requirements
+
+### Requirement: Heat Effects Applied Each Heat Phase
+
+Heat effects SHALL be evaluated every heat phase and at each relevant trigger point.
+
+#### Scenario: Movement penalty applied before next movement
+
+- **GIVEN** a unit at heat 15
+- **WHEN** the heat phase completes
+- **THEN** the unit's effective walk MP SHALL be reduced by `floor(15 / 5) = 3`
+
+#### Scenario: To-hit penalty applied on next attack
+
+- **GIVEN** a unit at heat 13 during the weapon attack phase
+- **WHEN** the attack to-hit is computed
+- **THEN** the heat-threshold modifier SHALL be +2
+
+#### Scenario: Ammo explosion risk rolled at heat 19
+
+- **GIVEN** a unit at heat 19 with explosive ammo bins
+- **WHEN** the heat phase runs the ammo-explosion check
+- **THEN** 2d6 SHALL be rolled vs TN 4 per bin
+- **AND** failure SHALL explode the bin
+
+#### Scenario: Pilot heat damage at heat 15
+
+- **GIVEN** a unit at heat 15
+- **WHEN** the heat phase runs pilot-damage check
+- **THEN** the pilot SHALL take 1 damage
+
+#### Scenario: Pilot heat damage at heat 25+
+
+- **GIVEN** a unit at heat 25
+- **WHEN** the heat phase runs pilot-damage check
+- **THEN** the pilot SHALL take 2 damage

--- a/openspec/changes/wire-heat-generation-and-effects/specs/heat-sink-system/spec.md
+++ b/openspec/changes/wire-heat-generation-and-effects/specs/heat-sink-system/spec.md
@@ -1,0 +1,26 @@
+# heat-sink-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Engine Reads Actual Heat Sink Count
+
+The heat phase SHALL query the unit's current heat-sink state (engine-integrated + external, minus destroyed) to compute dissipation. A fixed `baseHeatSinks = 10` constant SHALL NOT be used.
+
+#### Scenario: High-dissipation mech reads actual count
+
+- **GIVEN** a mech with 16 double heat sinks
+- **WHEN** the heat phase computes dissipation
+- **THEN** dissipation SHALL be 32 (not 10 or 20)
+
+#### Scenario: Destroyed sink removed from dissipation
+
+- **GIVEN** a mech with 10 single sinks, one destroyed by critical hit
+- **WHEN** the heat phase computes dissipation
+- **THEN** dissipation SHALL be 9
+
+#### Scenario: Unit state updated on destruction
+
+- **GIVEN** a heat sink takes a critical hit
+- **WHEN** the critical effect is applied
+- **THEN** the unit state SHALL mark that heat sink destroyed
+- **AND** the next heat phase SHALL compute dissipation excluding it

--- a/openspec/changes/wire-heat-generation-and-effects/specs/movement-system/spec.md
+++ b/openspec/changes/wire-heat-generation-and-effects/specs/movement-system/spec.md
@@ -1,0 +1,60 @@
+# movement-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Movement Generates Heat
+
+Movement SHALL generate heat per the canonical rules and add it to the unit's heat accumulator for the current turn.
+
+#### Scenario: Walking adds 1 heat
+
+- **GIVEN** a unit that walked any distance this turn
+- **WHEN** movement resolves
+- **THEN** +1 heat SHALL be added
+
+#### Scenario: Running adds 2 heat
+
+- **GIVEN** a unit that ran this turn
+- **WHEN** movement resolves
+- **THEN** +2 heat SHALL be added
+
+#### Scenario: Jump heat is max(3, jumpMP used)
+
+- **GIVEN** a unit that jumped using 5 jump MP
+- **WHEN** movement resolves
+- **THEN** +5 heat SHALL be added
+
+#### Scenario: Minimum jump heat of 3
+
+- **GIVEN** a unit that jumped using 2 jump MP
+- **WHEN** movement resolves
+- **THEN** +3 heat SHALL be added (clamped at 3)
+
+#### Scenario: Stationary unit generates no movement heat
+
+- **GIVEN** a unit that did not move
+- **WHEN** movement resolves
+- **THEN** no heat SHALL be added from movement
+
+### Requirement: Heat Reduces Effective Movement
+
+Effective walk and run MP SHALL be reduced by `floor(heat / 5)` each turn the unit has heat.
+
+#### Scenario: Heat 9 reduces MP by 1
+
+- **GIVEN** a unit with walk 5, run 8, heat 9
+- **WHEN** effective MP is computed
+- **THEN** effective walk SHALL be 4
+- **AND** effective run SHALL be 7
+
+#### Scenario: Heat 15 reduces MP by 3
+
+- **GIVEN** a unit with walk 5, heat 15
+- **WHEN** effective MP is computed
+- **THEN** effective walk SHALL be 2
+
+#### Scenario: TSM interaction
+
+- **GIVEN** a unit with walk 5 and TSM active at heat 9
+- **WHEN** effective MP is computed
+- **THEN** effective walk SHALL be 6 (5 base + 2 TSM - 1 heat)

--- a/openspec/changes/wire-heat-generation-and-effects/specs/shutdown-startup-system/spec.md
+++ b/openspec/changes/wire-heat-generation-and-effects/specs/shutdown-startup-system/spec.md
@@ -1,0 +1,55 @@
+# shutdown-startup-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Shutdown Check Fired During Heat Phase
+
+When a unit's heat is ≥ 14, the heat phase SHALL fire the shutdown check using TN `4 + floor((heat - 14) / 4) * 2` on a 2d6 roll.
+
+#### Scenario: Shutdown check at heat 14
+
+- **GIVEN** a unit with heat 14
+- **WHEN** the heat phase runs
+- **THEN** a shutdown check SHALL fire with TN 4
+
+#### Scenario: Shutdown check at heat 22
+
+- **GIVEN** a unit with heat 22
+- **WHEN** the heat phase runs
+- **THEN** the shutdown check TN SHALL be `4 + floor((22 - 14) / 4) * 2 = 8`
+
+#### Scenario: Failure marks unit shut down
+
+- **GIVEN** a unit with heat 18 rolling 5 on 2d6
+- **WHEN** the shutdown check resolves
+- **THEN** the unit SHALL be marked shut down
+- **AND** a `HeatShutdown` event SHALL be emitted
+
+### Requirement: Automatic Shutdown at Heat 30+
+
+At heat 30 or above, the unit SHALL shut down automatically without a roll.
+
+#### Scenario: Auto shutdown at heat 30
+
+- **GIVEN** a unit with heat 30
+- **WHEN** the heat phase runs
+- **THEN** the unit SHALL be marked shut down automatically
+- **AND** the `HeatShutdown` event SHALL have reason `Automatic`
+
+### Requirement: Startup Roll Offered on Subsequent Turn
+
+A shut-down unit SHALL get a startup roll at the start of each subsequent turn using the shutdown TN at its current heat (provided heat < 30).
+
+#### Scenario: Startup succeeds and unit re-activates
+
+- **GIVEN** a shut-down unit at heat 15
+- **WHEN** the startup step runs with 2d6 roll 10 vs TN 4
+- **THEN** the unit SHALL be marked active
+- **AND** a `HeatStartup` event SHALL be emitted
+
+#### Scenario: Startup still blocked at heat ≥ 30
+
+- **GIVEN** a shut-down unit at heat 30
+- **WHEN** the startup step runs
+- **THEN** no roll SHALL be offered
+- **AND** the unit SHALL remain shut down

--- a/openspec/changes/wire-heat-generation-and-effects/tasks.md
+++ b/openspec/changes/wire-heat-generation-and-effects/tasks.md
@@ -1,0 +1,90 @@
+# Tasks: Wire Heat Generation and Effects
+
+## 1. Movement Heat
+
+- [ ] 1.1 Replace `Jump ? 1 : 0` heat approximation in the movement path
+- [ ] 1.2 Add +1 heat for walking
+- [ ] 1.3 Add +2 heat for running
+- [ ] 1.4 Add +max(3, jumpMP) heat for jumping (per TechManual p.68)
+- [ ] 1.5 Apply heat at movement-resolution time so the heat phase sees it
+- [ ] 1.6 Unit tests: 3-hex walk adds 1 heat; 3-hex run adds 2 heat; 5 jump MP adds 5 heat
+
+## 2. Firing Heat
+
+- [ ] 2.1 Depends on `wire-real-weapon-data`: sum fired weapon heats
+- [ ] 2.2 Accumulate into the unit's heat during the weapon phase resolution
+- [ ] 2.3 Unit tests: firing PPC (10) + Medium Laser (3) produces +13 heat
+
+## 3. Engine-Hit Heat
+
+- [ ] 3.1 Depends on `integrate-damage-pipeline`: read engine-hit counter
+- [ ] 3.2 Add +5 heat per engine-hit counter during heat phase
+- [ ] 3.3 Unit test: 2 engine hits add +10 heat per turn
+
+## 4. Dissipation From Real Heat Sinks
+
+- [ ] 4.1 Replace `baseHeatSinks = 10` with actual count from unit state (engine-integrated + external, minus destroyed)
+- [ ] 4.2 Use rating per sink: 1 for singles, 2 for doubles
+- [ ] 4.3 Unit tests: 10 single HS dissipate 10; 10 double HS dissipate 20; 10 HS with 3 destroyed dissipate 7
+
+## 5. Water Cooling
+
+- [ ] 5.1 Read terrain under unit position
+- [ ] 5.2 Apply +2 dissipation if water depth = 1; +4 if depth ≥ 2
+- [ ] 5.3 Unit test: mech in depth-2 water gets +4 dissipation
+
+## 6. Heat To-Hit Penalty
+
+- [ ] 6.1 Read the unit's heat at attack-resolution time
+- [ ] 6.2 Apply the canonical threshold-based modifier (+1 at 8, +2 at 13, +3 at 17, +4 at 24)
+- [ ] 6.3 Use the single-source-of-truth constants module (`src/constants/heat.ts`)
+
+## 7. Heat Movement Penalty
+
+- [ ] 7.1 Reduce effective walk and run MP by `floor(heat / 5)` at movement time
+- [ ] 7.2 Ensure a mech with TSM active and heat 9 still walks the canonical MP (base + 2 TSM - 1 heat)
+- [ ] 7.3 Unit test: walk 5, run 8, heat 15 → effective walk 2, effective run 5
+
+## 8. Shutdown Check
+
+- [ ] 8.1 At heat phase, if heat ≥ 14, roll 2d6 vs `4 + floor((heat - 14) / 4) * 2`
+- [ ] 8.2 If failed, mark unit shut down (cannot act, heat dissipation continues)
+- [ ] 8.3 Emit `HeatShutdown` event with the TN, roll, and heat level
+- [ ] 8.4 Unit test: heat 14 TN 4; heat 18 TN 6; heat 22 TN 8; heat 26 TN 10
+
+## 9. Automatic Shutdown
+
+- [ ] 9.1 At heat ≥ 30, shut down automatically (no roll)
+- [ ] 9.2 Emit `HeatShutdown` with reason `Automatic`
+
+## 10. Startup Roll
+
+- [ ] 10.1 On a shut-down unit, at the start of its turn, offer a startup roll if heat ≤ 29
+- [ ] 10.2 Startup TN mirrors the shutdown TN at current heat
+- [ ] 10.3 Emit `HeatStartup` on success
+
+## 11. Ammo Explosion Risk
+
+- [ ] 11.1 At heat ≥ 19, for each explosive ammo bin, roll 2d6 vs threshold (4 at 19, 6 at 23, 8 at 28)
+- [ ] 11.2 On failure, explode the bin (damage = remainingRounds × weapon damage)
+- [ ] 11.3 CASE / CASE II protection honored (coordinate with `integrate-damage-pipeline`)
+- [ ] 11.4 Emit `AmmoExploded` event with the source = `HeatInduced`
+
+## 12. Pilot Heat Damage
+
+- [ ] 12.1 At heat 15-24: +1 pilot damage at heat-phase resolution
+- [ ] 12.2 At heat 25+: +2 pilot damage (combined with life-support state → more severe if LS destroyed)
+- [ ] 12.3 Emit `PilotHit` with source `Heat`
+
+## 13. Event Payload
+
+- [ ] 13.1 `HeatGenerated` event SHALL break down source contributions (movement, firing, engine, environment)
+- [ ] 13.2 `HeatDissipated` event SHALL include base dissipation and water bonus
+- [ ] 13.3 End-of-phase `unitState.heat` SHALL equal startHeat + generated - dissipated (clamped to 0 minimum)
+
+## 14. Validation
+
+- [ ] 14.1 `openspec validate wire-heat-generation-and-effects --strict`
+- [ ] 14.2 Autonomous fuzzer: no mech ever has negative heat; no mech silently skips a shutdown check
+- [ ] 14.3 End-to-end test: alpha-strike overheat sequence → shutdown at heat 20 → no-fire phase → cool-down startup
+- [ ] 14.4 Build + lint clean

--- a/openspec/changes/wire-piloting-skill-rolls/proposal.md
+++ b/openspec/changes/wire-piloting-skill-rolls/proposal.md
@@ -1,0 +1,29 @@
+# Change: Wire Piloting Skill Rolls
+
+## Why
+
+The `pilotingSkillRolls.ts` and `fallMechanics.ts` modules are fully implemented, the 26 PSR triggers are enumerated in the existing spec, and the fall-damage formulas are documented — but no trigger actually fires a PSR during gameplay. Damage hits don't queue PSRs, gyro crits don't queue PSRs, failed MASC rolls don't queue PSRs. The result: mechs never trip, never fall, never take fall damage. This change connects the trigger points (produced by earlier wiring work in `integrate-damage-pipeline`, `wire-heat-generation-and-effects`, and movement resolution) to the PSR queue, resolves queued PSRs in a dedicated resolution step, and invokes `fallMechanics.ts` on failure. See `openspec/changes/archive/2026-02-12-full-combat-parity/proposal.md` Phase 6 for the canonical PSR trigger list.
+
+## What Changes
+
+- Wire all 26 PSR triggers onto an in-state `psrQueue` on `IUnitGameState`: 20+ phase damage, leg damage (structure exposed), hip actuator crit, gyro crit, leg actuator crit, physical attack hit (kick / charge / DFA / push), physical attack miss (DFA miss, charge miss), terrain change (jump into water, skidding, fall), MASC failure, supercharger failure, attempting to stand, attempting to clear prone, heavy-enough damage to engine, etc. (full 26 per spec)
+- Each trigger adds an `IPsrQueuedEntry { triggerId, baseModifier, sourceEvent }` to the queue at the moment it fires
+- Resolve the queue during the end phase (or immediately, per trigger rule): for each entry, compute TN = pilotingSkill + sum(modifiers) and roll 2d6
+- On failure, call `applyFall` from `fallMechanics.ts` with the fall direction, height, and weight
+- Apply fall damage (`ceil(weight / 10) × (fallHeight + 1)`) in 5-point clusters using the fall-direction hit-location table
+- Apply pilot damage (1 per fall) and queue a consciousness check
+- Mark the unit prone; standing up in a subsequent turn costs walking MP and requires its own PSR
+- Emit `PsrTriggered`, `PsrResolved`, `UnitFell`, `UnitStood`, `PilotHit` events
+- Clear the queue at end of phase if any entry resolves to failure (remaining PSRs this phase are cancelled — the unit is already down)
+
+## Dependencies
+
+- **Requires**: `fix-combat-rule-accuracy` (consciousness off-by-one), `integrate-damage-pipeline` (damage events that trigger PSRs), `wire-heat-generation-and-effects` (shutdown-related triggers)
+- **Blocks**: `implement-physical-attack-phase` (physical attacks fire PSR triggers on hit and miss)
+
+## Impact
+
+- **Affected specs**: `piloting-skill-rolls` (wire triggers into queue, resolve), `fall-mechanics` (invoke from PSR failures)
+- **Affected code**: `src/utils/gameplay/pilotingSkillRolls.ts`, `src/utils/gameplay/pilotingSkillRolls/*.ts`, `src/utils/gameplay/fallMechanics.ts`, `src/utils/gameplay/gameSessionPSR.ts`, `src/engine/GameEngine.phases.ts`, `src/utils/gameplay/damage.ts` (queue triggers)
+- **New events**: `PsrTriggered`, `PsrResolved`, `UnitFell`, `UnitStood`
+- **No new modules required**.

--- a/openspec/changes/wire-piloting-skill-rolls/specs/fall-mechanics/spec.md
+++ b/openspec/changes/wire-piloting-skill-rolls/specs/fall-mechanics/spec.md
@@ -1,0 +1,73 @@
+# fall-mechanics (delta)
+
+## ADDED Requirements
+
+### Requirement: Fall Invoked From PSR Failure
+
+`applyFall` from `src/utils/gameplay/fallMechanics.ts` SHALL be invoked whenever a PSR resolution returns failure.
+
+#### Scenario: PSR failure calls applyFall
+
+- **GIVEN** a PSR that resolves to failure
+- **WHEN** the resolution step processes the entry
+- **THEN** `applyFall(unit, fallContext)` SHALL be invoked
+- **AND** a `UnitFell` event SHALL be emitted
+
+#### Scenario: Fall direction rolled via seeded RNG
+
+- **GIVEN** a falling mech
+- **WHEN** the fall direction is determined
+- **THEN** a 1d6 roll via the seeded RNG SHALL determine direction (forward / left side / backward / right side per canonical table)
+
+#### Scenario: Fall damage computed and applied in 5-point clusters
+
+- **GIVEN** an 80-ton mech falling from standing (height 0)
+- **WHEN** fall damage is computed
+- **THEN** the total SHALL be `ceil(80 / 10) × (0 + 1) = 8`
+- **AND** damage SHALL apply as one 5-point cluster and one 3-point cluster
+- **AND** each cluster SHALL roll the fall-direction hit-location table
+
+#### Scenario: Fall from elevation adds to damage
+
+- **GIVEN** a 60-ton mech falling from elevation 2
+- **WHEN** fall damage is computed
+- **THEN** the total SHALL be `ceil(60 / 10) × (2 + 1) = 18`
+- **AND** the damage SHALL apply as three 5-point clusters and one 3-point cluster
+
+### Requirement: Pilot Damage From Falling
+
+A fall SHALL inflict 1 point of pilot damage and queue a consciousness check.
+
+#### Scenario: Fall applies pilot damage
+
+- **GIVEN** a mech that fell this turn
+- **WHEN** the fall resolution completes
+- **THEN** the pilot SHALL take 1 damage
+- **AND** a consciousness check SHALL be queued
+- **AND** a `PilotHit` event with source `Fall` SHALL be emitted
+
+### Requirement: Prone State Tracking and Standing Up
+
+A fallen mech SHALL be marked prone. Standing up SHALL cost walking MP and require an `AttemptStand` PSR.
+
+#### Scenario: Unit marked prone after fall
+
+- **GIVEN** a mech that fell this turn
+- **WHEN** the fall resolution completes
+- **THEN** the unit state SHALL set `prone: true`
+
+#### Scenario: Successful stand-up
+
+- **GIVEN** a prone mech attempting to stand
+- **WHEN** the movement phase runs and the stand-up PSR resolves with success
+- **THEN** the unit state SHALL set `prone: false`
+- **AND** walk MP SHALL be consumed
+- **AND** a `UnitStood` event SHALL be emitted
+
+#### Scenario: Failed stand-up remains prone
+
+- **GIVEN** a prone mech attempting to stand
+- **WHEN** the stand-up PSR fails
+- **THEN** the unit SHALL remain prone
+- **AND** MP SHALL still be consumed (attempt cost)
+- **AND** no `UnitStood` event SHALL be emitted

--- a/openspec/changes/wire-piloting-skill-rolls/specs/piloting-skill-rolls/spec.md
+++ b/openspec/changes/wire-piloting-skill-rolls/specs/piloting-skill-rolls/spec.md
@@ -1,0 +1,83 @@
+# piloting-skill-rolls (delta)
+
+## ADDED Requirements
+
+### Requirement: PSR Queue on Unit State
+
+Each unit SHALL maintain a `psrQueue` on its game state. Trigger events SHALL enqueue an `IPsrQueuedEntry` at the moment they fire, and the resolution step SHALL drain the queue per the `resolveAt` policy.
+
+#### Scenario: Damage triggers enqueue
+
+- **GIVEN** a unit taking 22 damage during the weapon phase
+- **WHEN** the 20-point boundary is crossed
+- **THEN** the unit's `psrQueue` SHALL contain an entry with `triggerId: TwentyPlusPhaseDamage`
+
+#### Scenario: Multiple triggers queue independently
+
+- **GIVEN** a unit that suffers both a gyro crit and heavy damage in the same phase
+- **WHEN** both triggers fire
+- **THEN** the `psrQueue` SHALL contain both entries
+- **AND** the gyro-crit entry SHALL resolve immediately
+- **AND** the damage-based entry SHALL resolve at end of phase
+
+### Requirement: PSR Resolution Fires 2d6 vs Pilot + Modifiers
+
+For each queued PSR, the system SHALL roll 2d6 (via seeded RNG) against a target number equal to `pilotingSkill + sum(modifiers)`.
+
+#### Scenario: Successful roll
+
+- **GIVEN** a pilot with skill 4 and gyro-hit counter 1 (modifier +3), facing a 20+ damage trigger (base +0)
+- **WHEN** the PSR resolves with roll 8
+- **THEN** TN = 4 + 3 + 0 = 7
+- **AND** roll 8 ≥ 7 → success
+- **AND** a `PsrResolved { success: true, tn: 7, roll: 8 }` event SHALL be emitted
+
+#### Scenario: Failed roll triggers fall
+
+- **GIVEN** a pilot with skill 5 facing TN 7 with roll 6
+- **WHEN** the PSR resolves
+- **THEN** the PSR SHALL fail
+- **AND** `applyFall` SHALL be invoked
+- **AND** remaining queued PSRs for this unit this phase SHALL be cleared
+
+### Requirement: PSR Trigger Catalog
+
+The system SHALL implement the canonical PSR trigger set including (but not limited to): `TwentyPlusPhaseDamage`, `LegStructureDamage`, `HipActuatorCrit`, `GyroCrit`, `LegActuatorCrit`, `EngineHit`, `JumpIntoWater`, `Skid`, `MASCFailure`, `SuperchargerFailure`, `AttemptStand`, `PhysicalAttackTarget`, `MissedDFA`, `MissedCharge`, `HeatShutdown`, `HeadStructureDamage`.
+
+#### Scenario: Hip actuator crit fires PSR
+
+- **GIVEN** a hip actuator takes a critical hit
+- **WHEN** the crit effect is applied
+- **THEN** a `HipActuatorCrit` PSR SHALL be queued with `resolveAt: Immediate`
+
+#### Scenario: MASC failure queues PSR
+
+- **GIVEN** a unit uses MASC and the activation roll fails
+- **WHEN** the failure is processed
+- **THEN** a `MASCFailure` PSR SHALL be queued
+
+#### Scenario: Physical attack hit queues PSR
+
+- **GIVEN** a unit is hit by a kick / charge / DFA / push
+- **WHEN** the physical attack resolves
+- **THEN** a `PhysicalAttackTarget` PSR SHALL be queued for the target
+
+### Requirement: Gyro Modifier Stacking
+
+Each gyro-hit counter SHALL add +3 to every future PSR's TN until the gyro is destroyed.
+
+#### Scenario: Two gyro hits stack to +6
+
+- **GIVEN** a mech with gyro-hit counter = 2
+- **WHEN** a PSR resolves for any trigger
+- **THEN** the TN SHALL include +6 from gyro hits
+
+### Requirement: Pilot Wound Modifier
+
+Each pilot-damage point SHALL add +1 to every future PSR's TN.
+
+#### Scenario: Wounded pilot suffers PSR penalty
+
+- **GIVEN** a pilot with 2 wounds
+- **WHEN** a PSR resolves
+- **THEN** the TN SHALL include +2 from wounds

--- a/openspec/changes/wire-piloting-skill-rolls/tasks.md
+++ b/openspec/changes/wire-piloting-skill-rolls/tasks.md
@@ -1,0 +1,82 @@
+# Tasks: Wire Piloting Skill Rolls
+
+## 1. PSR Queue State
+
+- [ ] 1.1 Add `psrQueue: IPsrQueuedEntry[]` to `IUnitGameState`
+- [ ] 1.2 Define `IPsrQueuedEntry { triggerId, baseModifier, sourceEventId, resolveAt: "Immediate" | "EndOfPhase" | "StartOfTurn" }`
+- [ ] 1.3 Reset the queue at phase boundaries according to the rules
+
+## 2. Damage-Based Triggers
+
+- [ ] 2.1 When `damageThisPhase` ≥ 20, enqueue `TwentyPlusPhaseDamage`
+- [ ] 2.2 When a leg location's structure is exposed, enqueue `LegStructureDamage`
+- [ ] 2.3 When head structure is breached, apply pilot damage + enqueue `HeadStructureDamage`
+
+## 3. Critical-Based Triggers
+
+- [ ] 3.1 Gyro crit → enqueue `GyroCrit` (resolveAt: Immediate); subsequent PSRs include +3 per gyro-hit counter
+- [ ] 3.2 Hip actuator crit → enqueue `HipActuatorCrit` and require PSR per hex moved
+- [ ] 3.3 Leg actuator crit (upper / lower / foot) → enqueue `LegActuatorCrit`
+- [ ] 3.4 Engine crit heavy damage → enqueue `EngineHit` per rules
+- [ ] 3.5 Cockpit crit → pilot killed (no PSR; recorded as pilot death directly)
+
+## 4. Movement-Based Triggers
+
+- [ ] 4.1 Jump into water → enqueue `JumpIntoWater`
+- [ ] 4.2 Skidding (failed run in poor terrain) → enqueue `Skid`
+- [ ] 4.3 MASC failure → enqueue `MASCFailure`
+- [ ] 4.4 Supercharger failure → enqueue `SuperchargerFailure`
+- [ ] 4.5 Attempting to stand → enqueue `AttemptStand`
+- [ ] 4.6 Attempting to clear prone in same turn → enqueue per rules
+
+## 5. Physical-Attack Triggers
+
+- [ ] 5.1 Unit is hit by kick / charge / DFA / push → enqueue `PhysicalAttackTarget`
+- [ ] 5.2 Attacker misses a DFA → enqueue `MissedDFA`
+- [ ] 5.3 Attacker misses a charge → enqueue `MissedCharge`
+- [ ] 5.4 These are consumed by `implement-physical-attack-phase`; this change defines the trigger hooks
+
+## 6. Environmental / Heat Triggers
+
+- [ ] 6.1 Heat shutdown → enqueue `HeatShutdown` (result already rolled; this queue captures the consequences if rules require)
+- [ ] 6.2 Fall-from-damage on high-elevation hex → enqueue appropriate environmental trigger
+
+## 7. PSR Resolution Step
+
+- [ ] 7.1 Add a PSR-resolution step that iterates the queue for each unit
+- [ ] 7.2 Compute TN: pilotingSkill + sum of modifiers (gyro-hit counter × +3, pilot wounds × +1, base trigger modifier)
+- [ ] 7.3 Roll 2d6 via seeded RNG
+- [ ] 7.4 On success, mark the entry resolved successfully; emit `PsrResolved { success: true, tn, roll }`
+- [ ] 7.5 On failure, emit `PsrResolved { success: false, tn, roll }` and invoke `applyFall`
+
+## 8. Fall Resolution
+
+- [ ] 8.1 On PSR failure, call `applyFall(unit, { height, direction })` from `fallMechanics.ts`
+- [ ] 8.2 Roll 1d6 for fall direction (forward / left / backward / right per canonical table)
+- [ ] 8.3 Compute fall damage: `ceil(weight / 10) × (fallHeight + 1)`
+- [ ] 8.4 Apply damage in 5-point clusters to locations from the fall-direction hit-location table
+- [ ] 8.5 Apply 1 pilot damage; queue consciousness check
+- [ ] 8.6 Mark unit prone on `IUnitGameState`
+- [ ] 8.7 Clear any remaining queued PSRs for this unit this phase (already fell)
+- [ ] 8.8 Emit `UnitFell` event with direction, height, damage clusters, pilot damage
+
+## 9. Standing-Up Rules
+
+- [ ] 9.1 Attempting to stand costs walking MP
+- [ ] 9.2 Attempting to stand requires an `AttemptStand` PSR
+- [ ] 9.3 On success, unit is no longer prone; emit `UnitStood`
+- [ ] 9.4 On failure, unit remains prone for this turn
+
+## 10. Replay Fidelity
+
+- [ ] 10.1 All PSR rolls use the seeded RNG
+- [ ] 10.2 Replay test: reprocessing the event log produces identical fall outcomes
+
+## 11. Validation
+
+- [ ] 11.1 `openspec validate wire-piloting-skill-rolls --strict`
+- [ ] 11.2 End-to-end test: heavy damage → PSR queued → failure → fall → pilot hit → consciousness check
+- [ ] 11.3 Gyro crit test: crit triggers PSR; all subsequent PSRs include +3 modifier
+- [ ] 11.4 Stand-up test: prone unit costs MP + PSR; successful roll ends prone state
+- [ ] 11.5 Autonomous fuzzer: no mech fell without an emitted `UnitFell`; every `UnitFell` has a preceding `PsrResolved { success: false }`
+- [ ] 11.6 Build + lint clean

--- a/openspec/changes/wire-real-weapon-data/proposal.md
+++ b/openspec/changes/wire-real-weapon-data/proposal.md
@@ -1,0 +1,29 @@
+# Change: Wire Real Weapon Data into Combat Resolution
+
+## Why
+
+The MekStation combat engine currently hardcodes `damage = 5` and `heat = 3` for every weapon fired, uses a fixed `(3, 6, 9)` range bracket regardless of the weapon, assumes infinite ammo, and never consumes rounds from bins. As a result, an AC/20 hits for the same damage as a Small Laser, long-range LRMs fire at the same ranges as close-in SRMs, and an autocannon never runs dry. The full weapon catalog with correct damage, heat, and range values already exists in `IWeaponData`, and ammo bins are already tracked in the construction data — they just aren't consumed by the engine. This change replaces hardcoded values in the attack loop with reads from the catalog, wires real heat per firing weapon, and enforces ammo consumption from matching bins. Without this, downstream damage and heat wiring operate on fabricated numbers. See `openspec/changes/archive/2026-02-12-full-combat-parity/proposal.md` Phase 1 for the source of the hardcoded-values bug list.
+
+## What Changes
+
+- Replace every occurrence of `damage: 5` in the attack-resolution path with the weapon's actual `damage` field from `IWeaponData`
+- Replace every occurrence of `heat: 3` with the weapon's actual `heat` field
+- Replace the hardcoded range bracket `(3, 6, 9)` with the weapon's per-bracket ranges (`shortRange`, `mediumRange`, `longRange`, optional `extremeRange`)
+- Initialize per-unit ammo state from construction data at session start; each ton of ammo is a separate `IAmmoBin`
+- Consume 1 round per single-shot firing and 1 salvo per cluster firing from a matching bin
+- Prevent a weapon from firing when no matching non-empty bin exists; emit an `AttackInvalid` event with reason `OutOfAmmo`
+- Emit an `AmmoConsumed` event for every firing that draws from a bin
+- Accumulate real weapon heat per firing unit, replacing the `weapons.length * 10` approximation
+- Surface updated ammo counts in the event log so UI consumers can display them
+
+## Dependencies
+
+- **Requires**: `fix-combat-rule-accuracy` (underlying to-hit math must be correct before damage wiring is meaningful)
+- **Blocks**: `integrate-damage-pipeline` (damage pipeline can't apply real damage until real damage values arrive at it), `wire-heat-generation-and-effects` (heat generation reads per-weapon heat)
+
+## Impact
+
+- **Affected specs**: `weapon-resolution-system` (consume real weapon fields), `damage-system` (accept real damage values from attack resolution), `ammo-tracking` (consumption integrated with firing), `heat-management-system` (real per-weapon heat instead of approximation)
+- **Affected code**: `src/engine/GameEngine.ts`, `src/engine/GameEngine.phases.ts`, `src/utils/gameplay/gameSession.ts`, `src/utils/gameplay/gameSessionAttackResolution.ts`, `src/utils/gameplay/ammoTracking.ts`, `src/simulation/ai/AttackAI.ts`, test fixtures in `src/__tests__/unit/utils/gameplay/attackResolution.test.ts`
+- **Test fallout**: Several test fixtures intentionally use `damage: 5` as placeholders; these need to become real weapon fixtures from the catalog (or explicit mocks that document the hardcoding)
+- **No new specs created**. No new external dependencies.

--- a/openspec/changes/wire-real-weapon-data/specs/ammo-tracking/spec.md
+++ b/openspec/changes/wire-real-weapon-data/specs/ammo-tracking/spec.md
@@ -1,0 +1,49 @@
+# ammo-tracking (delta)
+
+## ADDED Requirements
+
+### Requirement: Ammo Consumption Wired Into Firing
+
+The ammo-tracking system SHALL be connected to the attack-resolution path so that each weapon firing consumes rounds from a matching bin and prevents firing when no matching non-empty bin exists.
+
+#### Scenario: Firing consumes 1 round from matching bin
+
+- **GIVEN** a unit with an AC/10 bin containing 10 rounds
+- **WHEN** the AC/10 fires
+- **THEN** the bin's `remainingRounds` SHALL decrement to 9
+- **AND** an `AmmoConsumed` event SHALL be emitted with binId and newCount
+
+#### Scenario: Firing with empty bin is invalid
+
+- **GIVEN** a unit whose AC/10 bins all have `remainingRounds = 0`
+- **WHEN** the AC/10 attempts to fire
+- **THEN** the attack SHALL be invalidated with reason `OutOfAmmo`
+- **AND** no damage SHALL be resolved
+- **AND** no `AmmoConsumed` event SHALL be emitted
+
+#### Scenario: Multi-bin selection consumes first non-empty
+
+- **GIVEN** a unit with two AC/10 bins, the first empty and the second full
+- **WHEN** the AC/10 fires
+- **THEN** consumption SHALL draw from the second bin
+- **AND** the second bin's `remainingRounds` SHALL decrement
+
+#### Scenario: Energy weapons do not consume ammo
+
+- **GIVEN** a unit firing a Medium Laser
+- **WHEN** the weapon fires
+- **THEN** no ammo bin SHALL be touched
+- **AND** no `AmmoConsumed` event SHALL be emitted
+
+#### Scenario: Session start populates ammo bins
+
+- **GIVEN** a mech construction that includes 2 tons of AC/10 ammo
+- **WHEN** the game session is created from the construction
+- **THEN** two separate `IAmmoBin` entries SHALL exist in unit state
+- **AND** each bin SHALL start with `remainingRounds = maxRounds` (10 for AC/10)
+
+#### Scenario: Cluster weapon consumes 1 salvo
+
+- **GIVEN** an LRM-20 with a full bin (6 salvos per ton)
+- **WHEN** the LRM-20 fires
+- **THEN** the bin's `remainingRounds` SHALL decrement by 1 (salvo count, not missile count)

--- a/openspec/changes/wire-real-weapon-data/specs/damage-system/spec.md
+++ b/openspec/changes/wire-real-weapon-data/specs/damage-system/spec.md
@@ -1,0 +1,25 @@
+# damage-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Damage Value Flows From Weapon Catalog
+
+The damage applied by the damage pipeline SHALL be the value sourced from the fired weapon's `IWeaponData.damage` field, not a placeholder constant.
+
+#### Scenario: Attack event carries real damage
+
+- **GIVEN** an AC/10 fires and hits
+- **WHEN** the damage pipeline receives the hit
+- **THEN** the damage amount entering the pipeline SHALL be 10
+
+#### Scenario: Small Laser does 3 damage
+
+- **GIVEN** a Small Laser fires and hits
+- **WHEN** the damage pipeline receives the hit
+- **THEN** the damage amount entering the pipeline SHALL be 3
+
+#### Scenario: Test placeholder removed from production path
+
+- **GIVEN** the production attack-resolution code path
+- **WHEN** the path is statically searched for `damage: 5`
+- **THEN** no occurrences SHALL remain outside of explicit test fixtures

--- a/openspec/changes/wire-real-weapon-data/specs/heat-management-system/spec.md
+++ b/openspec/changes/wire-real-weapon-data/specs/heat-management-system/spec.md
@@ -1,0 +1,25 @@
+# heat-management-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Real Weapon Heat Accumulation
+
+The heat-management system SHALL accumulate heat from fired weapons using each weapon's catalog `heat` value. The `weapons.length * 10` approximation SHALL be removed.
+
+#### Scenario: Firing multiple weapons sums real heats
+
+- **GIVEN** a unit that fires 1 PPC (heat 10) and 2 Medium Lasers (heat 3 each)
+- **WHEN** the firing heat is computed
+- **THEN** the firing heat SHALL be 10 + 3 + 3 = 16
+
+#### Scenario: No firing produces no heat
+
+- **GIVEN** a unit that fires no weapons this turn
+- **WHEN** the firing heat is computed
+- **THEN** the firing heat contribution SHALL be 0
+
+#### Scenario: Legacy approximation removed
+
+- **GIVEN** the heat generation code path
+- **WHEN** the path is statically searched for `weapons.length * 10`
+- **THEN** no occurrences SHALL remain in production code

--- a/openspec/changes/wire-real-weapon-data/specs/weapon-resolution-system/spec.md
+++ b/openspec/changes/wire-real-weapon-data/specs/weapon-resolution-system/spec.md
@@ -1,0 +1,56 @@
+# weapon-resolution-system (delta)
+
+## ADDED Requirements
+
+### Requirement: Resolve Weapon Stats from Catalog
+
+When an attack is resolved, the system SHALL read damage, heat, and range fields from the fired weapon's `IWeaponData` in the catalog. Hardcoded placeholders (`damage: 5`, `heat: 3`, range tuple `(3, 6, 9)`) SHALL NOT be used in the attack-resolution path.
+
+#### Scenario: AC/20 fires with real damage
+
+- **GIVEN** an AC/20 weapon with catalog damage = 20
+- **WHEN** the weapon fires and hits
+- **THEN** the attack-resolved event payload `damage` field SHALL be 20
+
+#### Scenario: PPC fires with real heat
+
+- **GIVEN** a PPC with catalog heat = 10
+- **WHEN** the weapon fires
+- **THEN** the firing unit's heat generated SHALL include +10 from this weapon
+
+#### Scenario: LRM-20 range brackets read from catalog
+
+- **GIVEN** an LRM-20 with catalog ranges short 7, medium 14, long 21
+- **WHEN** computing the range bracket for a target at 15 hexes
+- **THEN** the bracket SHALL be `LONG`
+- **AND** the range modifier SHALL be +4
+
+#### Scenario: Missing weapon data throws
+
+- **GIVEN** an attack references a weapon id that is not in the catalog
+- **WHEN** the attack resolver tries to read weapon stats
+- **THEN** an error SHALL be thrown (or a warning logged and the attack invalidated)
+- **AND** the attack SHALL NOT fall back to a silent default damage value
+
+### Requirement: Per-Weapon Range Bracket Resolution
+
+The system SHALL compute the range bracket using the fired weapon's catalog ranges, not a single global bracket tuple.
+
+#### Scenario: Short vs medium boundary
+
+- **GIVEN** a Medium Laser with catalog short 3, medium 6, long 9
+- **WHEN** the target is at 3 hexes
+- **THEN** the bracket SHALL be `SHORT` (+0)
+- **AND** a target at 4 hexes SHALL be `MEDIUM` (+2)
+
+#### Scenario: Extreme range when supported
+
+- **GIVEN** an ER PPC with catalog extreme range defined
+- **WHEN** the target is in the extreme bracket
+- **THEN** the bracket SHALL be `EXTREME` (+6)
+
+#### Scenario: Out of range rejects attack
+
+- **GIVEN** a Small Laser with long range 3
+- **WHEN** the target is at 10 hexes
+- **THEN** the attack SHALL be rejected with `OutOfRange`

--- a/openspec/changes/wire-real-weapon-data/tasks.md
+++ b/openspec/changes/wire-real-weapon-data/tasks.md
@@ -1,0 +1,81 @@
+# Tasks: Wire Real Weapon Data
+
+## 1. Audit Hardcoded Values
+
+- [ ] 1.1 Grep the engine and gameSession for `damage: 5`, `damage:5`, `damage = 5` and list every occurrence
+- [ ] 1.2 Grep for `heat: 3`, `heat:3`, `heat = 3` and list every occurrence
+- [ ] 1.3 Grep for the tuple `(3, 6, 9)` or range arrays `[3, 6, 9]` and list every occurrence
+- [ ] 1.4 Grep for `weapons.length * 10` heat approximation and list every occurrence
+- [ ] 1.5 Produce an audit list and check each call site against its fix
+
+## 2. Weapon Catalog Integration
+
+- [ ] 2.1 Confirm the weapon catalog exposes `IWeaponData` with damage, heat, shortRange, mediumRange, longRange, optional extremeRange, optional minimumRange
+- [ ] 2.2 Add a helper `getWeaponData(weaponId: string): IWeaponData` if one doesn't already exist
+- [ ] 2.3 Verify the helper resolves both IS and Clan weapon IDs via canonicalization
+
+## 3. Replace Hardcoded Damage
+
+- [ ] 3.1 In `gameSessionAttackResolution.ts`, read damage from the fired weapon's `IWeaponData` instead of using 5
+- [ ] 3.2 In `GameEngine.ts` / `GameEngine.phases.ts`, thread the real damage value into the attack-resolved event payload
+- [ ] 3.3 Update any default-damage fallbacks to throw / log a warning when a weapon has no data, instead of silently defaulting to 5
+- [ ] 3.4 Update unit tests to assert real damage values per weapon
+
+## 4. Replace Hardcoded Heat
+
+- [ ] 4.1 Read heat from the fired weapon's `IWeaponData` in the attack-resolution path
+- [ ] 4.2 Accumulate heat per firing unit for the current turn
+- [ ] 4.3 Remove the `weapons.length * 10` approximation
+- [ ] 4.4 Unit tests: firing 1 Medium Laser generates 3 heat; firing 1 PPC generates 10 heat; firing both generates 13
+
+## 5. Replace Hardcoded Range
+
+- [ ] 5.1 Remove the `(3, 6, 9)` constant from the to-hit path
+- [ ] 5.2 Use `IWeaponData.shortRange / mediumRange / longRange` to determine the bracket
+- [ ] 5.3 Apply `extremeRange` bracket when present and rules level allows
+- [ ] 5.4 Unit tests: AC/20 short=3, med=6, long=9; LRM-20 short=7, med=14, long=21
+
+## 6. Ammo State Initialization
+
+- [ ] 6.1 Audit `ammoTracking.ts` — confirm `IAmmoBin` state shape (binId, weaponType, location, remainingRounds, maxRounds, isExplosive)
+- [ ] 6.2 At session start, scan each unit's construction data for ammo components and produce one bin per ton
+- [ ] 6.3 Store the ammo bins on `IUnitGameState`
+- [ ] 6.4 Unit tests: a mech with 2 tons AC/10 ammo produces 2 bins of 10 rounds each
+
+## 7. Ammo Consumption
+
+- [ ] 7.1 On every weapon firing, locate the first non-empty bin matching the weapon's ammo type
+- [ ] 7.2 Decrement `remainingRounds` by 1 (salvo count for cluster weapons)
+- [ ] 7.3 Emit an `AmmoConsumed` event with the bin id and new remaining count
+- [ ] 7.4 If no matching non-empty bin exists, emit `AttackInvalid` with reason `OutOfAmmo` and do NOT resolve the attack
+- [ ] 7.5 Unit tests: firing an AC/10 with 1 bin of 10 rounds decrements to 9; firing 10 more times makes subsequent firings invalid
+
+## 8. Energy Weapon Bypass
+
+- [ ] 8.1 Energy weapons (lasers, PPCs, flamers) SHALL NOT consume ammo and SHALL NOT produce `AmmoConsumed` events
+- [ ] 8.2 Unit test: firing a Medium Laser does not touch any ammo bin
+
+## 9. Event Payload Updates
+
+- [ ] 9.1 Add `damage`, `heat`, `weaponId`, `ammoBinId` fields to the attack-resolved event payload
+- [ ] 9.2 Update the event-log UI consumer to display the new fields
+- [ ] 9.3 Add a replay-fidelity test: replaying the same event sequence produces the same unit state
+
+## 10. BotPlayer Integration
+
+- [ ] 10.1 Update `AttackAI.ts` to use real weapon damage when scoring target priority
+- [ ] 10.2 Update `AttackAI.ts` to respect ammo counts (don't pick a weapon with 0 rounds)
+- [ ] 10.3 Update `AttackAI.ts` to respect heat cost when scoring weapon usage
+- [ ] 10.4 Unit test: a dry AC/20 is never selected
+
+## 11. Test Fixture Cleanup
+
+- [ ] 11.1 Convert `src/__tests__/unit/utils/gameplay/attackResolution.test.ts` hardcoded fixtures to real weapon data or explicit mock
+- [ ] 11.2 Document the reason for any remaining `damage: 5` literal (unit test on attack-flow plumbing only, damage value arbitrary)
+- [ ] 11.3 Full test suite passes
+
+## 12. Validation
+
+- [ ] 12.1 Run `openspec validate wire-real-weapon-data --strict`
+- [ ] 12.2 Run the autonomous fuzzer and confirm no new invariant violations
+- [ ] 12.3 Build + lint clean


### PR DESCRIPTION
## Summary

- Drafts **61 OpenSpec change proposals** covering the Phase 0 → Phase 1 transition (Combat MVP) through Phase 7 (2D art & animation polish).
- Updates the platform roadmap to **remove Phase 8 (3D rendering)** — shelved due to IP licensing friction on mech art. Phase 7 is now the final presentation phase.
- Planning artifacts only — **no code changes**. All 61 proposals pass `openspec validate --strict`.

## Why now

Tier A polish cleanup shipped (PRs #291-298). The next horizon is a playable 2v2 mech skirmish so we can stress-test combat mechanics. This PR establishes the full OpenSpec plan before any code lands — so each change can be picked up, implemented, and verified against a written contract.

## Phase breakdown

| Phase | Guidepost | Changes |
|---|---|---|
| 1 — Combat MVP | 4-mech skirmish vs AI, all 6 phases, rules correct | **15** (7 engine + 6 UI + 2 AI) |
| 2 — Quick Sim | 100 auto-resolves + to-hit previews | 4 |
| 3 — Campaign ↔ Combat | Contracts → fight → salvage/XP/wounds persist | 6 |
| 4 — Multiplayer | 4a P2P 1v1 → 4b server 2-8 → 4c fog of war | 9 |
| 5 — Pilot SPA UI | Pick/purchase/designate SPAs on pilot records | 4 |
| 6 — Combined arms | Vehicle/Aero/BA/Infantry/ProtoMech parity | 15 (5 types × 3 concerns) |
| 7 — 2D art & polish | Silhouettes, terrain, animations, FX | 8 |

## Phase 1 dependency graph

```
A1 fix-rule-accuracy ────┐
A2 wire-weapon-data ─────┤
A3 wire-firing-arc ──────┼─▶ A4 damage-pipeline ──┬──▶ A6 psr ──▶ A7 physical-phase
A5 heat-wiring ──────────┘                         └──▶ B4 attack-ui

B1 skirmish-setup ───────▶ B2 combat-core-ui ──┬──▶ B3 movement-ui
                                                 ├──▶ B4 attack-ui
                                                 ├──▶ B5 damage-feedback-ui
                                                 └──▶ B6 victory-summary

C1 bot-competence (parallel)   C2 bot-retreat (after C1)
```

## First changes to implement

Suggested first round (independent, can be authored in parallel):

1. **`fix-combat-rule-accuracy`** — 8 known rule bugs (prone mod reversed, TMM formula, heat thresholds, etc.)
2. **`wire-real-weapon-data`** — replace hardcoded `damage = 5` with catalog stats
3. **`add-skirmish-setup-ui`** — pre-battle entry point (2 mechs + 2 pilots per side)

## Review approach

This PR is intentionally large (271 files, ~21k lines of markdown) but each change folder is self-contained and reviewable independently:

- `proposal.md` — why this change exists + non-goals
- `tasks.md` — atomic, testable work units (total 1500+ tasks across all 61)
- `specs/<capability>/spec.md` — delta spec with `## ADDED`/`## MODIFIED`/`## REMOVED` requirements

Reviewers can spot-check any 2-3 changes to sanity-check the proposal format; the validator already confirms structural correctness.

## Test plan

- [ ] `npx openspec list` shows all 61 changes
- [ ] `npx openspec validate <change> --strict` passes on every change (already verified locally)
- [ ] Phase 1 dependency graph matches what's in `proposal.md` files
- [ ] Roadmap doc reflects 3D-removed decision

## Out of scope

- Code implementation (each change gets its own implementation PR)
- Terrain rendering polish beyond flat hexes (Phase 7)
- Reverting to 3D (decision documented in roadmap)