### PR TITLE
feat(combat): integrate damage pipeline into attack-resolution event stream

### DIFF
--- a/src/__tests__/unit/utils/gameplay/integrateDamagePipeline.smoke.test.ts
+++ b/src/__tests__/unit/utils/gameplay/integrateDamagePipeline.smoke.test.ts
@@ -1,0 +1,542 @@
+/**
+ * Per-change smoke test for integrate-damage-pipeline.
+ *
+ * Asserts the full attack → damage pipeline now emits the ordered event
+ * chain `AttackResolved` → `DamageApplied` (per location) →
+ * `LocationDestroyed` (on structure == 0) → `TransferDamage` (when
+ * spill-over hits a transfer target) → `CriticalHit`/`CriticalHitResolved`
+ * → `ComponentDestroyed` (on component destruction), driven through
+ * `resolveDamagePipeline` — not the old `applySimpleDamage` shortcut.
+ *
+ * @spec openspec/changes/integrate-damage-pipeline/tasks.md § 14
+ */
+
+import { describe, it, expect } from '@jest/globals';
+
+import {
+  GameEventType,
+  GameSide,
+  IAttackResolvedPayload,
+  IDamageAppliedPayload,
+  IGameConfig,
+  IGameEvent,
+  IGameSession,
+  IGameUnit,
+  ILocationDestroyedPayload,
+  IPSRTriggeredPayload,
+  ITransferDamagePayload,
+  IUnitGameState,
+  MovementType,
+  RangeBracket,
+  WeaponCategory,
+} from '@/types/gameplay';
+import { Facing } from '@/types/gameplay';
+import {
+  advancePhase,
+  createGameSession,
+  declareAttack,
+  declareMovement,
+  DiceRoller,
+  lockMovement,
+  resolveAllAttacks,
+  startGame,
+} from '@/utils/gameplay/gameSession';
+
+const config: IGameConfig = {
+  mapRadius: 10,
+  turnLimit: 10,
+  victoryConditions: ['destruction'],
+  optionalRules: [],
+};
+
+const units: IGameUnit[] = [
+  {
+    id: 'attacker',
+    name: 'Attacker',
+    side: GameSide.Player,
+    unitRef: 'hbk-4g',
+    pilotRef: 'pilot-1',
+    gunnery: 4,
+    piloting: 5,
+    ammoConstruction: [
+      {
+        binId: 'bin-ac20-1',
+        weaponType: 'AC/20',
+        location: 'rt',
+        maxRounds: 10,
+        damagePerRound: 20,
+        isExplosive: true,
+      },
+    ],
+  },
+  {
+    id: 'target',
+    name: 'Target',
+    side: GameSide.Opponent,
+    unitRef: 'mad-3r',
+    pilotRef: 'pilot-2',
+    gunnery: 4,
+    piloting: 5,
+  },
+];
+
+const mediumLaser = [
+  {
+    weaponId: 'ml-1',
+    weaponName: 'Medium Laser',
+    damage: 5,
+    heat: 3,
+    category: WeaponCategory.ENERGY,
+    minRange: 0,
+    shortRange: 3,
+    mediumRange: 6,
+    longRange: 9,
+    isCluster: false,
+  },
+];
+
+const ac20 = [
+  {
+    weaponId: 'ac20-1',
+    weaponName: 'AC/20',
+    damage: 20,
+    heat: 7,
+    category: WeaponCategory.BALLISTIC,
+    minRange: 0,
+    shortRange: 3,
+    mediumRange: 6,
+    longRange: 9,
+    isCluster: false,
+  },
+];
+
+function mockDiceRoller(
+  rolls: Array<{ dice: [number, number]; total: number }>,
+): DiceRoller {
+  let i = 0;
+  return () => {
+    const r = rolls[i] ?? rolls[rolls.length - 1];
+    i++;
+    return {
+      dice: r.dice,
+      total: r.total,
+      isSnakeEyes: r.total === 2,
+      isBoxcars: r.total === 12,
+    };
+  };
+}
+
+/**
+ * Seed armor + structure by emitting zero-damage `DamageApplied` events
+ * (one per location). The reducer's `applyDamageApplied` unconditionally
+ * sets `newArmor[loc] = payload.armorRemaining` and
+ * `newStructure[loc] = payload.structureRemaining`, so passing
+ * damage=0 with the desired remaining values produces the intended
+ * starting state while staying on the event-sourced path (no direct
+ * currentState mutation that gets wiped on the next `appendEvent`).
+ */
+function seedArmorStructure(
+  session: IGameSession,
+  unitId: string,
+  armor: Record<string, number>,
+  structure: Record<string, number>,
+): IGameSession {
+  let current = session;
+  const locationSet: Record<string, true> = {};
+  for (const k of Object.keys(armor)) locationSet[k] = true;
+  for (const k of Object.keys(structure)) locationSet[k] = true;
+  const locations = Object.keys(locationSet);
+  for (const loc of locations) {
+    const sequence = current.events.length;
+    const { turn, phase } = current.currentState;
+    const event: IGameEvent = {
+      id: `seed-${unitId}-${loc}`,
+      gameId: current.id,
+      sequence,
+      timestamp: new Date().toISOString(),
+      type: GameEventType.DamageApplied,
+      turn,
+      phase,
+      actorId: unitId,
+      payload: {
+        unitId,
+        location: loc,
+        damage: 0,
+        armorRemaining: armor[loc] ?? 0,
+        structureRemaining: structure[loc] ?? 0,
+        locationDestroyed: false,
+      },
+    };
+    current = {
+      ...current,
+      events: [...current.events, event],
+      currentState: {
+        ...current.currentState,
+        units: {
+          ...current.currentState.units,
+          [unitId]: {
+            ...current.currentState.units[unitId],
+            armor: {
+              ...current.currentState.units[unitId].armor,
+              [loc]: armor[loc] ?? 0,
+            },
+            structure: {
+              ...current.currentState.units[unitId].structure,
+              [loc]: structure[loc] ?? 0,
+            },
+          },
+        },
+      },
+    };
+  }
+  return current;
+}
+
+function setupAttackPhase() {
+  let session = createGameSession(config, units);
+  session = startGame(session, GameSide.Player);
+  session = advancePhase(session); // movement
+
+  session = declareMovement(
+    session,
+    'attacker',
+    { q: 0, r: 0 },
+    { q: 0, r: 0 },
+    Facing.North,
+    MovementType.Stationary,
+    0,
+    0,
+  );
+  session = lockMovement(session, 'attacker');
+  session = declareMovement(
+    session,
+    'target',
+    { q: 0, r: -3 },
+    { q: 0, r: -3 },
+    Facing.South,
+    MovementType.Stationary,
+    0,
+    0,
+  );
+  session = lockMovement(session, 'target');
+
+  session = advancePhase(session); // weapon attack
+  return session;
+}
+
+// Filter helper: exclude the zero-damage seed events we injected to
+// populate armor/structure. Real pipeline events always carry a
+// positive `damage` value (or are LocationDestroyed / TransferDamage,
+// which are non-DamageApplied types).
+function realDamageEvents(session: IGameSession): IGameEvent[] {
+  return session.events.filter(
+    (e) =>
+      e.type === GameEventType.DamageApplied &&
+      (e.payload as IDamageAppliedPayload).damage > 0,
+  );
+}
+
+describe('integrate-damage-pipeline — smoke test', () => {
+  it('emits DamageApplied with real armor/structure absorption from the pipeline', () => {
+    // Target CT has 1 armor + 10 structure. A 5-damage ML front-hit
+    // should absorb 1 into armor, 4 into structure, leaving 6 structure.
+    let session = setupAttackPhase();
+    session = seedArmorStructure(
+      session,
+      'target',
+      {
+        head: 9,
+        center_torso: 1,
+        left_torso: 15,
+        right_torso: 15,
+        left_arm: 10,
+        right_arm: 10,
+        left_leg: 12,
+        right_leg: 12,
+      },
+      {
+        head: 3,
+        center_torso: 10,
+        left_torso: 12,
+        right_torso: 12,
+        left_arm: 8,
+        right_arm: 8,
+        left_leg: 12,
+        right_leg: 12,
+      },
+    );
+    session = declareAttack(
+      session,
+      'attacker',
+      'target',
+      mediumLaser,
+      4,
+      RangeBracket.Short,
+    );
+
+    // attack roll 10 (hit TN 4); hit location roll 7 → CT front
+    const roller = mockDiceRoller([
+      { dice: [5, 5], total: 10 },
+      { dice: [4, 3], total: 7 },
+    ]);
+    session = resolveAllAttacks(session, roller);
+
+    const damageEvents = realDamageEvents(session);
+    expect(damageEvents.length).toBeGreaterThan(0);
+    const first = damageEvents[0].payload as IDamageAppliedPayload;
+    expect(first.location).toBe('center_torso');
+    expect(first.damage).toBe(5);
+    // 1 armor + 4 structure absorbed; post-damage should be 0 armor / 6 structure
+    expect(first.armorRemaining).toBe(0);
+    expect(first.structureRemaining).toBe(6);
+    expect(first.locationDestroyed).toBe(false);
+  });
+
+  it('emits LocationDestroyed when structure hits zero, with TransferDamage spilling to CT', () => {
+    // Left arm: 0 armor, 2 structure. A 5-damage hit destroys the arm
+    // (absorbs 0 armor + 2 structure) and transfers 3 damage to LT.
+    // Front-arc roll 11 hits left_arm per FRONT_HIT_LOCATION_TABLE.
+    let session = setupAttackPhase();
+    session = seedArmorStructure(
+      session,
+      'target',
+      {
+        head: 9,
+        center_torso: 20,
+        left_torso: 15,
+        right_torso: 15,
+        left_arm: 0,
+        right_arm: 10,
+        left_leg: 12,
+        right_leg: 12,
+      },
+      {
+        head: 3,
+        center_torso: 16,
+        left_torso: 12,
+        right_torso: 12,
+        left_arm: 2,
+        right_arm: 8,
+        left_leg: 12,
+        right_leg: 12,
+      },
+    );
+    session = declareAttack(
+      session,
+      'attacker',
+      'target',
+      mediumLaser,
+      4,
+      RangeBracket.Short,
+    );
+
+    // attack roll 10, hit location 11 → left_arm (front table)
+    const roller = mockDiceRoller([
+      { dice: [5, 5], total: 10 },
+      { dice: [6, 5], total: 11 },
+    ]);
+    session = resolveAllAttacks(session, roller);
+
+    const types = session.events.map((e: IGameEvent) => e.type);
+    expect(types).toContain(GameEventType.LocationDestroyed);
+    expect(types).toContain(GameEventType.TransferDamage);
+
+    const destroyed = session.events.find(
+      (e: IGameEvent) => e.type === GameEventType.LocationDestroyed,
+    );
+    const destroyedPayload = destroyed!.payload as ILocationDestroyedPayload;
+    expect(destroyedPayload.location).toBe('left_arm');
+
+    const transfer = session.events.find(
+      (e: IGameEvent) => e.type === GameEventType.TransferDamage,
+    );
+    const transferPayload = transfer!.payload as ITransferDamagePayload;
+    expect(transferPayload.fromLocation).toBe('left_arm');
+    expect(transferPayload.toLocation).toBe('left_torso');
+    expect(transferPayload.damage).toBe(3);
+  });
+
+  it('side-torso destruction cascades to the arm (LT → LA) in a single event chain', () => {
+    // LT: 0 armor, 1 structure. A 5-damage hit destroys LT, cascades to
+    // LA, transfers remaining 4 damage to CT. Verify both locations fire
+    // `LocationDestroyed`, with the first carrying `cascadedTo: 'left_arm'`.
+    let session = setupAttackPhase();
+    session = seedArmorStructure(
+      session,
+      'target',
+      {
+        head: 9,
+        center_torso: 20,
+        left_torso: 0,
+        right_torso: 15,
+        left_arm: 10,
+        right_arm: 10,
+        left_leg: 12,
+        right_leg: 12,
+      },
+      {
+        head: 3,
+        center_torso: 16,
+        left_torso: 1,
+        right_torso: 12,
+        left_arm: 8,
+        right_arm: 8,
+        left_leg: 12,
+        right_leg: 12,
+      },
+    );
+    session = declareAttack(
+      session,
+      'attacker',
+      'target',
+      mediumLaser,
+      4,
+      RangeBracket.Short,
+    );
+
+    // attack roll 10, hit location 8 → left_torso (front table)
+    const roller = mockDiceRoller([
+      { dice: [5, 5], total: 10 },
+      { dice: [4, 4], total: 8 },
+    ]);
+    session = resolveAllAttacks(session, roller);
+
+    const destroyedEvents = session.events.filter(
+      (e: IGameEvent) => e.type === GameEventType.LocationDestroyed,
+    );
+    const destroyedPayloads = destroyedEvents.map(
+      (e) => e.payload as ILocationDestroyedPayload,
+    );
+    // First LT destruction carries cascadedTo=left_arm, second is the arm itself.
+    const ltDestroyed = destroyedPayloads.find(
+      (p) => p.location === 'left_torso',
+    );
+    expect(ltDestroyed).toBeDefined();
+    expect(ltDestroyed!.cascadedTo).toBe('left_arm');
+    const laDestroyed = destroyedPayloads.find(
+      (p) => p.location === 'left_arm',
+    );
+    expect(laDestroyed).toBeDefined();
+  });
+
+  it('AC/20 to head caps damage at 3 (head damage cap)', () => {
+    // Head: 9 armor, 3 structure. AC/20 (20 damage) capped at 3 applied.
+    let session = setupAttackPhase();
+    session = seedArmorStructure(
+      session,
+      'target',
+      {
+        head: 9,
+        center_torso: 20,
+        left_torso: 15,
+        right_torso: 15,
+        left_arm: 10,
+        right_arm: 10,
+        left_leg: 12,
+        right_leg: 12,
+      },
+      {
+        head: 3,
+        center_torso: 16,
+        left_torso: 12,
+        right_torso: 12,
+        left_arm: 8,
+        right_arm: 8,
+        left_leg: 12,
+        right_leg: 12,
+      },
+    );
+    session = declareAttack(
+      session,
+      'attacker',
+      'target',
+      ac20,
+      4,
+      RangeBracket.Short,
+    );
+
+    // attack roll 10 (hit); hit location 12 → head (front table)
+    const roller = mockDiceRoller([
+      { dice: [5, 5], total: 10 },
+      { dice: [6, 6], total: 12 },
+    ]);
+    session = resolveAllAttacks(session, roller);
+
+    const resolved = session.events.find(
+      (e: IGameEvent) => e.type === GameEventType.AttackResolved,
+    );
+    const resolvedPayload = resolved!.payload as IAttackResolvedPayload;
+    expect(resolvedPayload.location).toBe('head');
+    // Head cap: damage field on AttackResolved reflects the capped 3
+    expect(resolvedPayload.damage).toBe(3);
+
+    const damageEvents = realDamageEvents(session);
+    const damagePayload = damageEvents[0].payload as IDamageAppliedPayload;
+    expect(damagePayload.location).toBe('head');
+    expect(damagePayload.damage).toBe(3);
+  });
+
+  it('queues a 20+ damage PSR when a single AC/20 hit crosses the phase-damage threshold', () => {
+    // AC/20 to torso deals 20 damage, which alone crosses the 20-damage
+    // phase threshold. Expect a PSRTriggered event with triggerSource
+    // 'phase_damage_20_plus'.
+    let session = setupAttackPhase();
+    session = seedArmorStructure(
+      session,
+      'target',
+      {
+        head: 9,
+        center_torso: 20,
+        left_torso: 15,
+        right_torso: 15,
+        left_arm: 10,
+        right_arm: 10,
+        left_leg: 12,
+        right_leg: 12,
+      },
+      {
+        head: 3,
+        center_torso: 16,
+        left_torso: 12,
+        right_torso: 12,
+        left_arm: 8,
+        right_arm: 8,
+        left_leg: 12,
+        right_leg: 12,
+      },
+    );
+    session = declareAttack(
+      session,
+      'attacker',
+      'target',
+      ac20,
+      4,
+      RangeBracket.Short,
+    );
+
+    // attack roll 10; hit location 7 → CT front (not head, so full 20)
+    const roller = mockDiceRoller([
+      { dice: [5, 5], total: 10 },
+      { dice: [4, 3], total: 7 },
+    ]);
+    session = resolveAllAttacks(session, roller);
+
+    const psrEvents = session.events.filter(
+      (e: IGameEvent) => e.type === GameEventType.PSRTriggered,
+    );
+    const phaseDamagePSR = psrEvents.find(
+      (e) =>
+        (e.payload as IPSRTriggeredPayload).triggerSource ===
+        'phase_damage_20_plus',
+    );
+    expect(phaseDamagePSR).toBeDefined();
+  });
+
+  it('new enum values are wired: LocationDestroyed / TransferDamage / ComponentDestroyed', () => {
+    // Regression guard per task 0.5: assert the enum strings exist and
+    // match the documented wire values.
+    expect(GameEventType.LocationDestroyed).toBe('location_destroyed');
+    expect(GameEventType.TransferDamage).toBe('transfer_damage');
+    expect(GameEventType.ComponentDestroyed).toBe('component_destroyed');
+  });
+});

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -118,6 +118,26 @@ export enum GameEventType {
    * time; the union is future-extensible.
    */
   AttackInvalid = 'attack_invalid',
+  /**
+   * Per `integrate-damage-pipeline`: fired when a location's internal
+   * structure reaches zero. Also carries optional `cascadedTo` when the
+   * destruction triggers a linked-location destruction (e.g., side-torso
+   * → arm cascade).
+   */
+  LocationDestroyed = 'location_destroyed',
+  /**
+   * Per `integrate-damage-pipeline`: fired when damage transfers from one
+   * destroyed location to its canonical transfer target (arms → side
+   * torso; legs → side torso; side torso → center torso).
+   */
+  TransferDamage = 'transfer_damage',
+  /**
+   * Per `integrate-damage-pipeline`: fired when a critical-hit roll
+   * destroys a specific component (engine, gyro, weapon, heat sink, etc.)
+   * in a location. Provides the slot index so UI / replay consumers can
+   * highlight the destroyed slot on the record sheet.
+   */
+  ComponentDestroyed = 'component_destroyed',
 }
 
 /**
@@ -515,6 +535,45 @@ export interface IAmmoConsumedPayload {
 }
 
 /**
+ * Per `integrate-damage-pipeline`: a location's internal structure has
+ * reached zero. `cascadedTo` is set when the destruction triggered a
+ * linked-location destruction (e.g., LT destroyed → LA also destroyed).
+ */
+export interface ILocationDestroyedPayload {
+  readonly unitId: string;
+  readonly location: string;
+  readonly cascadedTo?: string;
+}
+
+/**
+ * Per `integrate-damage-pipeline`: damage has transferred from a
+ * destroyed `fromLocation` to its canonical `toLocation`. Multiple
+ * events may fire in sequence for a single shot (arm → side torso →
+ * center torso, etc.).
+ */
+export interface ITransferDamagePayload {
+  readonly unitId: string;
+  readonly fromLocation: string;
+  readonly toLocation: string;
+  readonly damage: number;
+}
+
+/**
+ * Per `integrate-damage-pipeline`: a critical-hit roll destroyed a
+ * specific component at `slotIndex` in `location`. `componentType`
+ * names the broad class (engine / gyro / weapon / heat sink / etc.)
+ * so UI consumers can pick the right icon without parsing
+ * `componentName`.
+ */
+export interface IComponentDestroyedPayload {
+  readonly unitId: string;
+  readonly location: string;
+  readonly componentType: string;
+  readonly slotIndex: number;
+  readonly componentName?: string;
+}
+
+/**
  * Union type for all event payloads.
  */
 export type GameEventPayload =
@@ -543,7 +602,10 @@ export type GameEventPayload =
   | IShutdownCheckPayload
   | IStartupAttemptPayload
   | IAmmoConsumedPayload
-  | IAttackInvalidPayload;
+  | IAttackInvalidPayload
+  | ILocationDestroyedPayload
+  | ITransferDamagePayload
+  | IComponentDestroyedPayload;
 
 /**
  * Complete game event with payload.

--- a/src/utils/gameplay/gameEvents/combat.ts
+++ b/src/utils/gameplay/gameEvents/combat.ts
@@ -5,9 +5,12 @@ import {
   IAttackInvalidPayload,
   IAttackLockedPayload,
   IAttackResolvedPayload,
+  IComponentDestroyedPayload,
   IDamageAppliedPayload,
   IGameEvent,
+  ILocationDestroyedPayload,
   IToHitModifier,
+  ITransferDamagePayload,
   IWeaponAttackData,
 } from '@/types/gameplay';
 
@@ -167,6 +170,108 @@ export function createDamageAppliedEvent(
       gameId,
       sequence,
       GameEventType.DamageApplied,
+      turn,
+      GamePhase.WeaponAttack,
+      unitId,
+    ),
+    payload,
+  };
+}
+
+/**
+ * Per `integrate-damage-pipeline`: location's internal structure reached
+ * zero. Optionally carries `cascadedTo` when destruction triggered a
+ * linked-location destruction (side torso → arm cascade).
+ */
+export function createLocationDestroyedEvent(
+  gameId: string,
+  sequence: number,
+  turn: number,
+  unitId: string,
+  location: string,
+  cascadedTo?: string,
+): IGameEvent {
+  const payload: ILocationDestroyedPayload = {
+    unitId,
+    location,
+    cascadedTo,
+  };
+
+  return {
+    ...createEventBase(
+      gameId,
+      sequence,
+      GameEventType.LocationDestroyed,
+      turn,
+      GamePhase.WeaponAttack,
+      unitId,
+    ),
+    payload,
+  };
+}
+
+/**
+ * Per `integrate-damage-pipeline`: damage transferred from a destroyed
+ * `fromLocation` to its canonical `toLocation`. Multiple events may
+ * fire in sequence for a single shot (arm → side torso → center torso).
+ */
+export function createTransferDamageEvent(
+  gameId: string,
+  sequence: number,
+  turn: number,
+  unitId: string,
+  fromLocation: string,
+  toLocation: string,
+  damage: number,
+): IGameEvent {
+  const payload: ITransferDamagePayload = {
+    unitId,
+    fromLocation,
+    toLocation,
+    damage,
+  };
+
+  return {
+    ...createEventBase(
+      gameId,
+      sequence,
+      GameEventType.TransferDamage,
+      turn,
+      GamePhase.WeaponAttack,
+      unitId,
+    ),
+    payload,
+  };
+}
+
+/**
+ * Per `integrate-damage-pipeline`: a specific component has been
+ * destroyed by a critical-hit roll. Provides slot index for UI highlight
+ * and `componentType` for icon selection.
+ */
+export function createComponentDestroyedEvent(
+  gameId: string,
+  sequence: number,
+  turn: number,
+  unitId: string,
+  location: string,
+  componentType: string,
+  slotIndex: number,
+  componentName?: string,
+): IGameEvent {
+  const payload: IComponentDestroyedPayload = {
+    unitId,
+    location,
+    componentType,
+    slotIndex,
+    componentName,
+  };
+
+  return {
+    ...createEventBase(
+      gameId,
+      sequence,
+      GameEventType.ComponentDestroyed,
       turn,
       GamePhase.WeaponAttack,
       unitId,

--- a/src/utils/gameplay/gameSessionAttackResolution.ts
+++ b/src/utils/gameplay/gameSessionAttackResolution.ts
@@ -24,8 +24,10 @@ import {
   createAttackInvalidEvent,
   createAttackResolvedEvent,
   createDamageAppliedEvent,
+  createLocationDestroyedEvent,
   createPilotHitEvent,
   createPSRTriggeredEvent,
+  createTransferDamageEvent,
   createUnitDestroyedEvent,
 } from './gameEvents';
 import {
@@ -202,12 +204,40 @@ export function resolveAttack(
       );
       currentSession = appendEvent(currentSession, resolvedEvent);
 
+      // Per `integrate-damage-pipeline` task 7: capture the target's
+      // pre-attack `damageThisPhase` so we can detect the 20+ crossing
+      // and queue a PSR once per crossing (not per-damage-event).
+      const preAttackDamageThisPhase =
+        currentSession.currentState.units[targetId]?.damageThisPhase ?? 0;
+
       const damageState = buildDamageStateFromUnit(targetState);
       const damageResult = resolveDamagePipeline(
         damageState,
         location as CombatLocation,
         damage,
       );
+
+      // Per `integrate-damage-pipeline` tasks 3-5: emit the ordered event
+      // chain `DamageApplied` → (`LocationDestroyed` on structure == 0)
+      // → (`TransferDamage` when damage spills to the transfer target).
+      // `damageResult.result.locationDamages` is already ordered along
+      // the canonical transfer path (original → adjacent → center torso),
+      // so walking it in order preserves the replay-visible sequence.
+      //
+      // Side-torso → arm cascade: `applyDamageToLocation` also zeroes
+      // the corresponding arm's armor/structure and pushes it onto
+      // `destroyedLocations`. We detect that cascade by diffing the
+      // pre- and post-state `destroyedLocations` arrays so the
+      // `LocationDestroyed` event carries the `cascadedTo` arm id.
+      const preDestroyedSet = new Set<CombatLocation>(
+        damageState.destroyedLocations,
+      );
+      const newlyDestroyed: CombatLocation[] = [];
+      for (const loc of damageResult.state.destroyedLocations) {
+        if (!preDestroyedSet.has(loc)) {
+          newlyDestroyed.push(loc);
+        }
+      }
 
       for (const locationDamage of damageResult.result.locationDamages) {
         const damageSequence = currentSession.events.length;
@@ -223,6 +253,74 @@ export function resolveAttack(
           locationDamage.destroyed,
         );
         currentSession = appendEvent(currentSession, damageEvent);
+
+        if (locationDamage.destroyed) {
+          // The arm cascade (LT → LA, RT → RA) is set by
+          // `applyDamageToLocation` but not surfaced on the
+          // `ILocationDamage.transferredDamage` field (it's a marker,
+          // not a real damage transfer). Detect it via the set diff
+          // and attach as `cascadedTo`.
+          let cascadedArm: string | undefined;
+          if (
+            locationDamage.location === 'left_torso' &&
+            newlyDestroyed.includes('left_arm' as CombatLocation)
+          ) {
+            cascadedArm = 'left_arm';
+          } else if (
+            locationDamage.location === 'right_torso' &&
+            newlyDestroyed.includes('right_arm' as CombatLocation)
+          ) {
+            cascadedArm = 'right_arm';
+          }
+          const destroyedSequence = currentSession.events.length;
+          currentSession = appendEvent(
+            currentSession,
+            createLocationDestroyedEvent(
+              currentSession.id,
+              destroyedSequence,
+              turn,
+              targetId,
+              locationDamage.location,
+              cascadedArm,
+            ),
+          );
+
+          // If the arm cascaded, emit a second `LocationDestroyed`
+          // event for the arm itself so downstream consumers (UI,
+          // replay) don't have to dedupe off the parent event.
+          if (cascadedArm) {
+            const cascadeSequence = currentSession.events.length;
+            currentSession = appendEvent(
+              currentSession,
+              createLocationDestroyedEvent(
+                currentSession.id,
+                cascadeSequence,
+                turn,
+                targetId,
+                cascadedArm,
+              ),
+            );
+          }
+        }
+
+        if (
+          locationDamage.transferredDamage > 0 &&
+          locationDamage.transferLocation
+        ) {
+          const transferSequence = currentSession.events.length;
+          currentSession = appendEvent(
+            currentSession,
+            createTransferDamageEvent(
+              currentSession.id,
+              transferSequence,
+              turn,
+              targetId,
+              locationDamage.location,
+              locationDamage.transferLocation,
+              locationDamage.transferredDamage,
+            ),
+          );
+        }
       }
 
       const d6Roller = () => {
@@ -302,6 +400,32 @@ export function resolveAttack(
           );
           break;
         }
+      }
+
+      // Per `integrate-damage-pipeline` task 7: queue a PSR when
+      // `damageThisPhase` crosses 20 as a result of this weapon hit.
+      // The reducer (`applyDamageApplied`) has already accumulated the
+      // `DamageApplied.damage` values into `damageThisPhase`, so we
+      // read post-attack state and emit exactly once per crossing
+      // (pre < 20 && post >= 20). `wire-piloting-skill-rolls` resolves
+      // the queued PSR; this task only queues.
+      const postAttackDamageThisPhase =
+        currentSession.currentState.units[targetId]?.damageThisPhase ?? 0;
+      if (preAttackDamageThisPhase < 20 && postAttackDamageThisPhase >= 20) {
+        const phaseDamagePSRSequence = currentSession.events.length;
+        currentSession = appendEvent(
+          currentSession,
+          createPSRTriggeredEvent(
+            currentSession.id,
+            phaseDamagePSRSequence,
+            turn,
+            GamePhase.WeaponAttack,
+            targetId,
+            '20+ damage this phase',
+            0,
+            'phase_damage_20_plus',
+          ),
+        );
       }
 
       if (damageResult.result.pilotDamage) {

--- a/src/utils/gameplay/gameSessionAttackResolutionHelpers.ts
+++ b/src/utils/gameplay/gameSessionAttackResolutionHelpers.ts
@@ -9,6 +9,7 @@ import {
 import { type CriticalHitEvent } from './criticalHitResolution';
 import { type IUnitDamageState } from './damage';
 import {
+  createComponentDestroyedEvent,
   createCriticalHitResolvedEvent,
   createPilotHitEvent,
   createPSRTriggeredEvent,
@@ -62,6 +63,27 @@ export function emitCriticalEvents(
           payload.destroyed,
         ),
       );
+      // Per `integrate-damage-pipeline` task 8 + 0.5.4: when a
+      // `CriticalHitResolved` flags the component as destroyed, also
+      // emit a `ComponentDestroyed` event so UI + replay consumers
+      // can render the slot-specific destruction without re-parsing
+      // the `effect` string.
+      if (payload.destroyed) {
+        const componentSequence = currentSession.events.length;
+        currentSession = appendEvent(
+          currentSession,
+          createComponentDestroyedEvent(
+            currentSession.id,
+            componentSequence,
+            turn,
+            payload.unitId,
+            payload.location,
+            payload.componentType,
+            payload.slotIndex,
+            payload.componentName,
+          ),
+        );
+      }
       continue;
     }
 


### PR DESCRIPTION
## Summary

Wires `resolveDamagePipeline` into the attack path so hits drive the full armor → structure → transfer chain through a first-class event stream (not state diffing). Adds three new events — `LocationDestroyed`, `TransferDamage`, `ComponentDestroyed` — so UI + replay consumers get a structured record of every destruction step.

- Emits ordered `DamageApplied` → `LocationDestroyed` (on structure == 0, with optional `cascadedTo`) → `TransferDamage` (on spill-over) chain per hit
- Side-torso → arm cascade (LT → LA, RT → RA) surfaces via `cascadedTo` on the parent event AND a second `LocationDestroyed` event for the arm
- Queues a `PSRTriggered { phase_damage_20_plus }` exactly once when `damageThisPhase` crosses 20
- Every `CriticalHitResolved { destroyed: true }` now fires a matching `ComponentDestroyed` event with `slotIndex` for UI highlighting
- 6-case per-change smoke test covers the full event chain, head cap, cascade, and 20+ PSR

## Test plan

- [x] 607 test suites pass (19494 tests, 12 skipped, 0 fail)
- [x] `npx tsc --noEmit` clean
- [x] `npx oxlint` 0 errors (2 pre-existing max-lines warnings)
- [x] `npx next build` passes
- [x] Per-change smoke test `integrateDamagePipeline.smoke.test.ts` (6 tests, all pass)

Spec: `openspec/changes/integrate-damage-pipeline/tasks.md`