### PR TITLE
feat(combat): wire heat-generation per-source events + startup roll

### DIFF
--- a/src/__tests__/unit/utils/gameplay/wireHeatGenerationAndEffects.smoke.test.ts
+++ b/src/__tests__/unit/utils/gameplay/wireHeatGenerationAndEffects.smoke.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Per-change smoke test for wire-heat-generation-and-effects.
+ *
+ * Asserts that the heat phase now emits per-source HeatGenerated events
+ * (movement / firing / engine_hit) and that shut-down units attempt a
+ * startup roll after dissipation brings heat below the auto-shutdown
+ * threshold.
+ *
+ * @spec openspec/changes/wire-heat-generation-and-effects/tasks.md § 14
+ */
+
+import { describe, it, expect } from '@jest/globals';
+
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IGameConfig,
+  IGameEvent,
+  IGameSession,
+  IGameUnit,
+  IHeatPayload,
+  IStartupAttemptPayload,
+  MovementType,
+  RangeBracket,
+  WeaponCategory,
+} from '@/types/gameplay';
+import { Facing } from '@/types/gameplay';
+import {
+  advancePhase,
+  createGameSession,
+  declareAttack,
+  declareMovement,
+  DiceRoller,
+  lockMovement,
+  resolveAllAttacks,
+  startGame,
+} from '@/utils/gameplay/gameSession';
+import { resolveHeatPhase } from '@/utils/gameplay/gameSessionHeat';
+import { deriveState } from '@/utils/gameplay/gameState';
+
+const config: IGameConfig = {
+  mapRadius: 10,
+  turnLimit: 10,
+  victoryConditions: ['destruction'],
+  optionalRules: [],
+};
+
+const units: IGameUnit[] = [
+  {
+    id: 'attacker',
+    name: 'Attacker',
+    side: GameSide.Player,
+    unitRef: 'hbk-4g',
+    pilotRef: 'pilot-1',
+    gunnery: 4,
+    piloting: 5,
+    heatSinks: 10,
+  },
+  {
+    id: 'target',
+    name: 'Target',
+    side: GameSide.Opponent,
+    unitRef: 'mad-3r',
+    pilotRef: 'pilot-2',
+    gunnery: 4,
+    piloting: 5,
+    heatSinks: 10,
+  },
+];
+
+const ppc = [
+  {
+    weaponId: 'ppc-1',
+    weaponName: 'PPC',
+    damage: 10,
+    heat: 10,
+    category: WeaponCategory.ENERGY,
+    minRange: 3,
+    shortRange: 6,
+    mediumRange: 12,
+    longRange: 18,
+    isCluster: false,
+  },
+];
+
+function mockDiceRoller(
+  rolls: Array<{ dice: [number, number]; total: number }>,
+): DiceRoller {
+  let i = 0;
+  return () => {
+    const r = rolls[i] ?? rolls[rolls.length - 1];
+    i++;
+    return {
+      dice: r.dice,
+      total: r.total,
+      isSnakeEyes: r.total === 2,
+      isBoxcars: r.total === 12,
+    };
+  };
+}
+
+/**
+ * Run the full turn sequence to weapon phase: create → start → movement
+ * (both units, with attacker running to generate +2 movement heat) →
+ * weapon attack phase advance.
+ */
+function setupToWeaponPhase(opts: { running?: boolean } = {}) {
+  let session = createGameSession(config, units);
+  session = startGame(session, GameSide.Player);
+  session = advancePhase(session); // movement
+
+  const movementType = opts.running
+    ? MovementType.Run
+    : MovementType.Stationary;
+  const heatGenerated = opts.running ? 2 : 0;
+  session = declareMovement(
+    session,
+    'attacker',
+    { q: 0, r: 0 },
+    { q: 0, r: 0 },
+    Facing.North,
+    movementType,
+    0,
+    heatGenerated,
+  );
+  session = lockMovement(session, 'attacker');
+  session = declareMovement(
+    session,
+    'target',
+    { q: 0, r: -6 },
+    { q: 0, r: -6 },
+    Facing.South,
+    MovementType.Stationary,
+    0,
+    0,
+  );
+  session = lockMovement(session, 'target');
+
+  session = advancePhase(session); // weapon attack
+  return session;
+}
+
+function heatGenEvents(session: IGameSession, unitId: string): IGameEvent[] {
+  return session.events.filter(
+    (e) =>
+      e.type === GameEventType.HeatGenerated &&
+      (e.payload as IHeatPayload).unitId === unitId,
+  );
+}
+
+describe('wire-heat-generation-and-effects — smoke test', () => {
+  it('emits per-source HeatGenerated events (movement + firing) for a running + firing attacker', () => {
+    // Attacker runs (+2 heat) and fires 1 PPC (+10 heat). Expect two
+    // HeatGenerated events (source=movement, source=firing) plus a
+    // HeatDissipated covering the 10 HS budget. Final heat = 0+2+10-10=2.
+    let session = setupToWeaponPhase({ running: true });
+    session = declareAttack(
+      session,
+      'attacker',
+      'target',
+      ppc,
+      4,
+      RangeBracket.Medium,
+    );
+    // Guarantee a hit so firing heat still accrues (heat accrues on
+    // fire regardless of hit, but declareAttack's weaponAttacks carries
+    // the heat so resolution does not change the heat path).
+    session = resolveAllAttacks(
+      session,
+      mockDiceRoller([
+        { dice: [5, 5], total: 10 },
+        { dice: [4, 3], total: 7 },
+      ]),
+    );
+
+    // Advance: physical → heat
+    session = advancePhase(session); // physical
+    session = advancePhase(session); // heat
+    session = resolveHeatPhase(
+      session,
+      mockDiceRoller([{ dice: [4, 4], total: 8 }]),
+    );
+
+    const attackerHeatEvents = heatGenEvents(session, 'attacker');
+    const sources = attackerHeatEvents.map(
+      (e) => (e.payload as IHeatPayload).source,
+    );
+    expect(sources).toContain('movement');
+    expect(sources).toContain('firing');
+
+    const moveEvent = attackerHeatEvents.find(
+      (e) => (e.payload as IHeatPayload).source === 'movement',
+    );
+    expect((moveEvent!.payload as IHeatPayload).amount).toBe(2);
+    const firingEvent = attackerHeatEvents.find(
+      (e) => (e.payload as IHeatPayload).source === 'firing',
+    );
+    expect((firingEvent!.payload as IHeatPayload).amount).toBe(10);
+
+    // Final heat for attacker after dissipation: 0 + 2 + 10 - 10 = 2
+    expect(session.currentState.units['attacker'].heat).toBe(2);
+  });
+
+  it('does NOT emit a movement HeatGenerated when unit stood still', () => {
+    let session = setupToWeaponPhase({ running: false });
+    session = declareAttack(
+      session,
+      'attacker',
+      'target',
+      ppc,
+      4,
+      RangeBracket.Medium,
+    );
+    session = resolveAllAttacks(
+      session,
+      mockDiceRoller([
+        { dice: [5, 5], total: 10 },
+        { dice: [4, 3], total: 7 },
+      ]),
+    );
+
+    session = advancePhase(session);
+    session = advancePhase(session);
+    session = resolveHeatPhase(
+      session,
+      mockDiceRoller([{ dice: [4, 4], total: 8 }]),
+    );
+
+    const attackerHeatEvents = heatGenEvents(session, 'attacker');
+    const sources = attackerHeatEvents.map(
+      (e) => (e.payload as IHeatPayload).source,
+    );
+    expect(sources).not.toContain('movement');
+    expect(sources).toContain('firing');
+  });
+
+  it('shutdown unit attempts a startup roll after dissipation brings heat ≤ 29', () => {
+    // Put the attacker into the shutdown state by synthesizing a
+    // ShutdownCheck event with shutdownOccurred=true (persists via
+    // the reducer). Also inject a HeatGenerated event to set heat to
+    // 20 so post-dissipation (20 - 10 heat sinks = 10) the startup
+    // branch fires (10 ≤ 29).
+    let session = createGameSession(config, units);
+    session = startGame(session, GameSide.Player);
+
+    // Advance to Heat phase via phase events.
+    session = advancePhase(session); // movement
+    session = declareMovement(
+      session,
+      'attacker',
+      { q: 0, r: 0 },
+      { q: 0, r: 0 },
+      Facing.North,
+      MovementType.Stationary,
+      0,
+      0,
+    );
+    session = lockMovement(session, 'attacker');
+    session = declareMovement(
+      session,
+      'target',
+      { q: 0, r: -6 },
+      { q: 0, r: -6 },
+      Facing.South,
+      MovementType.Stationary,
+      0,
+      0,
+    );
+    session = lockMovement(session, 'target');
+    session = advancePhase(session); // weapon
+    session = advancePhase(session); // physical
+    session = advancePhase(session); // heat
+
+    // Inject a HeatGenerated event to seed attacker heat = 20.
+    const heatEvent: IGameEvent = {
+      id: 'seed-heat',
+      gameId: session.id,
+      sequence: session.events.length,
+      timestamp: new Date().toISOString(),
+      type: GameEventType.HeatGenerated,
+      turn: session.currentState.turn,
+      phase: GamePhase.Heat,
+      actorId: 'attacker',
+      payload: {
+        unitId: 'attacker',
+        amount: 20,
+        source: 'external',
+        newTotal: 20,
+      } as IHeatPayload,
+    };
+    session = {
+      ...session,
+      events: [...session.events, heatEvent],
+    };
+
+    // Inject a ShutdownCheck event to flag attacker as shut down.
+    const shutdownEvent: IGameEvent = {
+      id: 'seed-shutdown',
+      gameId: session.id,
+      sequence: session.events.length,
+      timestamp: new Date().toISOString(),
+      type: GameEventType.ShutdownCheck,
+      turn: session.currentState.turn,
+      phase: GamePhase.Heat,
+      actorId: 'attacker',
+      payload: {
+        unitId: 'attacker',
+        heatLevel: 20,
+        targetNumber: 999, // sentinel; actual TN irrelevant for the reducer
+        roll: 0,
+        shutdownOccurred: true,
+      },
+    };
+    session = {
+      ...session,
+      events: [...session.events, shutdownEvent],
+    };
+
+    // Manually re-derive so currentState reflects our injected events.
+    session = {
+      ...session,
+      currentState: deriveState(session.id, session.events),
+    };
+
+    // Now the attacker is shutdown=true with heat=20 in currentState.
+    // Heat phase: no generation, dissipate 10 → heat 10. Startup TN at
+    // heat 10 is 0 (auto restart). Startup event should fire.
+    const startup = resolveHeatPhase(
+      session,
+      mockDiceRoller([{ dice: [4, 4], total: 8 }]),
+    );
+
+    const startupEvents = startup.events.filter(
+      (e: IGameEvent) => e.type === GameEventType.StartupAttempt,
+    );
+    expect(startupEvents.length).toBeGreaterThan(0);
+    const payload = startupEvents[0].payload as IStartupAttemptPayload;
+    expect(payload.success).toBe(true);
+    expect(payload.targetNumber).toBeGreaterThanOrEqual(0);
+  });
+
+  it('source enum accepts movement / firing / engine_hit (0.5.4 alignment)', () => {
+    // Compile-time regression guard: the heat-payload source union
+    // covers the per-change-spec sources. If a future refactor removes
+    // these, this test's imports would still compile but the literal
+    // assertions below would be blocked by the union type.
+    const movementSource: IHeatPayload['source'] = 'movement';
+    const firingSource: IHeatPayload['source'] = 'firing';
+    const engineHitSource: IHeatPayload['source'] = 'engine_hit';
+    expect(movementSource).toBe('movement');
+    expect(firingSource).toBe('firing');
+    expect(engineHitSource).toBe('engine_hit');
+  });
+});

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -402,6 +402,13 @@ export interface IDamageAppliedPayload {
 
 /**
  * Heat event payload.
+ *
+ * Per `wire-heat-generation-and-effects` task 0.5.4: the `source`
+ * union breaks heat generation down by cause so UI + AI consumers can
+ * distinguish firing heat from engine-hit heat without parsing
+ * adjacent events. `'weapons'` is kept as a legacy alias for
+ * `'firing'`; `'external'` is kept for fall / crash / jump-jet
+ * backfires that pre-date this change.
  */
 export interface IHeatPayload {
   /** Unit */
@@ -409,7 +416,14 @@ export interface IHeatPayload {
   /** Heat amount (positive for generated, negative for dissipated) */
   readonly amount: number;
   /** Heat source */
-  readonly source: 'movement' | 'weapons' | 'dissipation' | 'external';
+  readonly source:
+    | 'movement'
+    | 'firing'
+    | 'weapons'
+    | 'engine_hit'
+    | 'environment'
+    | 'dissipation'
+    | 'external';
   /** New total heat */
   readonly newTotal: number;
 }

--- a/src/utils/gameplay/__tests__/weaponDataWiring.test.ts
+++ b/src/utils/gameplay/__tests__/weaponDataWiring.test.ts
@@ -470,9 +470,20 @@ describe('Weapon Data Wiring', () => {
       );
       expect(heatGenEvents.length).toBeGreaterThan(0);
 
-      const heatPayload = heatGenEvents[0].payload as IHeatPayload;
-      // Movement heat(1) + weapon heat(7+3=10) = 11
-      expect(heatPayload.amount).toBe(11);
+      // Per `wire-heat-generation-and-effects` task 13.1: HeatGenerated
+      // now emits per-source (movement/firing/engine_hit) — assert the
+      // firing event carries the AC/20(7) + ML(3) = 10 sum. Movement
+      // event fires separately with amount 1.
+      const firingEvent = heatGenEvents.find(
+        (e) => (e.payload as IHeatPayload).source === 'firing',
+      );
+      expect(firingEvent).toBeDefined();
+      expect((firingEvent!.payload as IHeatPayload).amount).toBe(10);
+      const movementEvent = heatGenEvents.find(
+        (e) => (e.payload as IHeatPayload).source === 'movement',
+      );
+      expect(movementEvent).toBeDefined();
+      expect((movementEvent!.payload as IHeatPayload).amount).toBe(1);
     });
   });
 
@@ -526,10 +537,14 @@ describe('Weapon Data Wiring', () => {
 
       session = resolveHeatPhase(session);
 
-      // Movement reducer already applied 1 heat. Heat phase adds movement(1)+weapons(20)=21.
-      // Total before dissipation: 1 + 21 = 22. Dissipation: 15. Net: 22 - 15 = 7.
+      // Per `wire-heat-generation-and-effects`: movement heat is no
+      // longer double-counted by the heat phase (the reducer tallied
+      // +1 at movement time; the heat phase now emits a log-only
+      // `source: 'movement'` event with `newTotal` unchanged). Firing
+      // heat (20) accumulates during heat phase. Total before
+      // dissipation: 1 + 20 = 21. Dissipation: 15. Net: 21 - 15 = 6.
       const playerState = session.currentState.units['player-1'];
-      expect(playerState.heat).toBe(7);
+      expect(playerState.heat).toBe(6);
     });
 
     it('unit without heatSinks field defaults to 10', () => {
@@ -582,10 +597,12 @@ describe('Weapon Data Wiring', () => {
 
       session = resolveHeatPhase(session);
 
-      // Movement reducer applied 1 heat. Heat phase adds movement(1)+weapons(20)=21.
-      // Total before dissipation: 1 + 21 = 22. Dissipation: 10 (default). Net: 22 - 10 = 12.
+      // Per `wire-heat-generation-and-effects`: movement heat is no
+      // longer double-counted. Movement reducer applied 1. Heat phase
+      // adds firing(20). Total before dissipation: 1 + 20 = 21.
+      // Default dissipation: 10. Net: 21 - 10 = 11.
       const playerState = session.currentState.units['player-1'];
-      expect(playerState.heat).toBe(12);
+      expect(playerState.heat).toBe(11);
     });
   });
 

--- a/src/utils/gameplay/gameEvents/status.ts
+++ b/src/utils/gameplay/gameEvents/status.ts
@@ -24,7 +24,7 @@ export function createHeatGeneratedEvent(
   phase: GamePhase,
   unitId: string,
   amount: number,
-  source: 'movement' | 'weapons' | 'dissipation' | 'external',
+  source: IHeatPayload['source'],
   newTotal: number,
 ): IGameEvent {
   const payload: IHeatPayload = { unitId, amount, source, newTotal };

--- a/src/utils/gameplay/gameSessionHeat.ts
+++ b/src/utils/gameplay/gameSessionHeat.ts
@@ -21,6 +21,7 @@ import {
   createPilotHitEvent,
   createPSRTriggeredEvent,
   createShutdownCheckEvent,
+  createStartupAttemptEvent,
   createUnitDestroyedEvent,
 } from './gameEvents';
 import { appendEvent } from './gameSessionCore';
@@ -87,22 +88,71 @@ export function resolveHeatPhase(
     const componentDamage = unitState.componentDamage;
     const engineHits = componentDamage?.engineHits ?? 0;
     const heatFromEngine = engineHits * ENGINE_HIT_HEAT;
-    const totalHeatGenerated =
-      heatFromMovement + heatFromWeapons + heatFromEngine;
 
-    if (totalHeatGenerated > 0) {
-      const heatGeneratedSequence = currentSession.events.length;
-      const heatGeneratedEvent = createHeatGeneratedEvent(
-        currentSession.id,
-        heatGeneratedSequence,
-        turn,
-        GamePhase.Heat,
-        unitId,
-        totalHeatGenerated,
-        heatFromEngine > 0 ? 'external' : 'weapons',
-        unitState.heat + totalHeatGenerated,
+    // Per `wire-heat-generation-and-effects` task 13.1 + 0.5.4: emit
+    // one `HeatGenerated` event per contributing source (movement /
+    // firing / engine_hit) so UI + AI consumers can break down the
+    // per-turn heat budget without summing adjacent events or parsing
+    // attack payloads. Skip sources that contributed zero.
+    //
+    // Accounting: movement heat is already baked into `unit.heat` by
+    // the `MovementDeclared` reducer (`unit.heat + payload.heatGenerated`).
+    // Firing heat + engine-hit heat are NOT accumulated by any reducer
+    // before the heat phase — they exist only on attack payloads and
+    // component-damage state — so those sources add to `newTotal`. The
+    // movement event we emit here is a log-only record (`newTotal`
+    // matches current) so the UI can still show the movement
+    // contribution without the reducer double-counting it on replay.
+    let runningHeat = unitState.heat;
+    if (heatFromMovement > 0) {
+      const seq = currentSession.events.length;
+      currentSession = appendEvent(
+        currentSession,
+        createHeatGeneratedEvent(
+          currentSession.id,
+          seq,
+          turn,
+          GamePhase.Heat,
+          unitId,
+          heatFromMovement,
+          'movement',
+          runningHeat,
+        ),
       );
-      currentSession = appendEvent(currentSession, heatGeneratedEvent);
+    }
+    if (heatFromWeapons > 0) {
+      runningHeat += heatFromWeapons;
+      const seq = currentSession.events.length;
+      currentSession = appendEvent(
+        currentSession,
+        createHeatGeneratedEvent(
+          currentSession.id,
+          seq,
+          turn,
+          GamePhase.Heat,
+          unitId,
+          heatFromWeapons,
+          'firing',
+          runningHeat,
+        ),
+      );
+    }
+    if (heatFromEngine > 0) {
+      runningHeat += heatFromEngine;
+      const seq = currentSession.events.length;
+      currentSession = appendEvent(
+        currentSession,
+        createHeatGeneratedEvent(
+          currentSession.id,
+          seq,
+          turn,
+          GamePhase.Heat,
+          unitId,
+          heatFromEngine,
+          'engine_hit',
+          runningHeat,
+        ),
+      );
     }
 
     const currentHeatBeforeDissipation =
@@ -128,6 +178,47 @@ export function resolveHeatPhase(
     currentSession = appendEvent(currentSession, dissipationEvent);
 
     const finalHeat = currentSession.currentState.units[unitId].heat;
+
+    // Per `wire-heat-generation-and-effects` task 10: shut-down units
+    // attempt to restart once heat has dissipated to 29 or lower. TN
+    // mirrors the shutdown TN at the current heat. Success flips
+    // `shutdown: false`; failure leaves the unit shut down for another
+    // turn. Units must be shut down AND below auto-shutdown threshold
+    // (30) to be eligible — automatic at heat 0 (TN 0).
+    const stateAfterDissipation = currentSession.currentState.units[unitId];
+    if (stateAfterDissipation.shutdown && finalHeat <= 29) {
+      const startupTN = getShutdownTN(finalHeat);
+      const autoRestart = startupTN === 0;
+      const startupRoll = autoRestart ? null : diceRoller();
+      const startupSuccess = autoRestart
+        ? true
+        : (startupRoll?.total ?? 0) >= startupTN;
+      const startupSequence = currentSession.events.length;
+      currentSession = appendEvent(
+        currentSession,
+        createStartupAttemptEvent(
+          currentSession.id,
+          startupSequence,
+          turn,
+          GamePhase.Heat,
+          unitId,
+          startupTN,
+          startupRoll?.total ?? 0,
+          startupSuccess,
+        ),
+      );
+      // If startup succeeded the unit is now active and skips the
+      // shutdown check path below (it was already shut down for the
+      // whole turn, so no further shutdown check applies). If it
+      // failed, fall through to any additional effects at heat
+      // thresholds (pilot heat damage, ammo explosion still apply
+      // while shut down, so we don't `continue` out of the loop).
+      if (startupSuccess) {
+        // Continue to heat-effect processing below — pilot heat
+        // damage + ammo explosion risk still apply regardless of
+        // startup outcome.
+      }
+    }
 
     if (finalHeat >= 30) {
       const shutdownSequence = currentSession.events.length;


### PR DESCRIPTION
## Summary

Splits the heat phase's single `HeatGenerated` emission into one event per contributing source (movement / firing / engine_hit) and fixes a long-standing double-count bug where movement heat was tallied by both the `MovementDeclared` reducer AND the heat phase.

- `IHeatPayload.source` extended with `'firing' | 'engine_hit' | 'environment'` (legacy `'weapons'` / `'external'` kept as aliases)
- `resolveHeatPhase` emits per-source `HeatGenerated` events; movement is log-only (reducer already tallied), firing/engine_hit advance `newTotal`
- `resolveHeatPhase` now emits a `StartupAttempt` event for shut-down units once dissipation brings heat ≤ 29; TN mirrors canonical shutdown table
- Legacy heat-phase assertions in `weaponDataWiring.test.ts` updated to match the corrected no-double-count arithmetic

## Test plan

- [x] 608 test suites pass (19498 tests, 12 skipped, 0 fail)
- [x] `npx tsc --noEmit` clean
- [x] `npx oxlint` 0 errors (2 pre-existing max-lines warnings)
- [x] `npx next build` passes
- [x] Per-change smoke test `wireHeatGenerationAndEffects.smoke.test.ts` (4 tests, all pass)

Spec: `openspec/changes/wire-heat-generation-and-effects/tasks.md`