### PR TITLE
feat(combat): wire piloting-skill-roll resolution + stand-up flow

### DIFF
--- a/src/__tests__/unit/utils/gameplay/wirePilotingSkillRolls.smoke.test.ts
+++ b/src/__tests__/unit/utils/gameplay/wirePilotingSkillRolls.smoke.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Per-change smoke test for wire-piloting-skill-rolls.
+ *
+ * Asserts the full PSR queue → resolution → fall flow:
+ * - PSRTriggered event pushes onto unit.pendingPSRs
+ * - resolvePendingPSRs rolls 2d6 vs TN, emits PSRResolved
+ * - Failure → UnitFell + PilotHit chain
+ * - attemptStandUp: prone unit success → UnitStood; failure → still prone
+ *
+ * @spec openspec/changes/wire-piloting-skill-rolls/tasks.md § 11
+ */
+
+import { describe, it, expect } from '@jest/globals';
+
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IGameConfig,
+  IGameEvent,
+  IGameSession,
+  IGameUnit,
+  IPSRResolvedPayload,
+  IPSRTriggeredPayload,
+  IUnitStoodPayload,
+  MovementType,
+} from '@/types/gameplay';
+import { Facing } from '@/types/gameplay';
+import {
+  advancePhase,
+  attemptStandUp,
+  checkAndQueueDamagePSRs,
+  createGameSession,
+  declareMovement,
+  DiceRoller,
+  lockMovement,
+  resolvePendingPSRs,
+  startGame,
+} from '@/utils/gameplay/gameSession';
+import { deriveState } from '@/utils/gameplay/gameState';
+
+const config: IGameConfig = {
+  mapRadius: 10,
+  turnLimit: 10,
+  victoryConditions: ['destruction'],
+  optionalRules: [],
+};
+
+const units: IGameUnit[] = [
+  {
+    id: 'attacker',
+    name: 'Attacker',
+    side: GameSide.Player,
+    unitRef: 'hbk-4g',
+    pilotRef: 'pilot-1',
+    gunnery: 4,
+    piloting: 5, // PSR base TN
+    heatSinks: 10,
+  },
+  {
+    id: 'target',
+    name: 'Target',
+    side: GameSide.Opponent,
+    unitRef: 'mad-3r',
+    pilotRef: 'pilot-2',
+    gunnery: 4,
+    piloting: 5,
+    heatSinks: 10,
+  },
+];
+
+function mockDiceRoller(
+  rolls: Array<{ dice: [number, number]; total: number }>,
+): DiceRoller {
+  let i = 0;
+  return () => {
+    const r = rolls[i] ?? rolls[rolls.length - 1];
+    i++;
+    return {
+      dice: r.dice,
+      total: r.total,
+      isSnakeEyes: r.total === 2,
+      isBoxcars: r.total === 12,
+    };
+  };
+}
+
+/** Inject a synthesized DamageApplied event with N damage to set
+ *  damageThisPhase via the reducer, so checkAndQueueDamagePSRs picks
+ *  up the 20+ trigger. */
+function seedDamageThisPhase(
+  session: IGameSession,
+  unitId: string,
+  damage: number,
+): IGameSession {
+  const event: IGameEvent = {
+    id: `seed-dmg-${unitId}`,
+    gameId: session.id,
+    sequence: session.events.length,
+    timestamp: new Date().toISOString(),
+    type: GameEventType.DamageApplied,
+    turn: session.currentState.turn,
+    phase: session.currentState.phase,
+    actorId: unitId,
+    payload: {
+      unitId,
+      location: 'center_torso',
+      damage,
+      armorRemaining: 10,
+      structureRemaining: 10,
+      locationDestroyed: false,
+    },
+  };
+  const newEvents = [...session.events, event];
+  return {
+    ...session,
+    events: newEvents,
+    currentState: deriveState(session.id, newEvents),
+  };
+}
+
+function setupActiveSession(): IGameSession {
+  let session = createGameSession(config, units);
+  session = startGame(session, GameSide.Player);
+  session = advancePhase(session); // movement
+  session = declareMovement(
+    session,
+    'attacker',
+    { q: 0, r: 0 },
+    { q: 0, r: 0 },
+    Facing.North,
+    MovementType.Stationary,
+    0,
+    0,
+  );
+  session = lockMovement(session, 'attacker');
+  session = declareMovement(
+    session,
+    'target',
+    { q: 0, r: -3 },
+    { q: 0, r: -3 },
+    Facing.South,
+    MovementType.Stationary,
+    0,
+    0,
+  );
+  session = lockMovement(session, 'target');
+  session = advancePhase(session); // weapon
+  return session;
+}
+
+describe('wire-piloting-skill-rolls — smoke test', () => {
+  it('20+ phase damage queues a PSR that resolvePendingPSRs consumes', () => {
+    let session = setupActiveSession();
+    // Seed 20+ damage on attacker → triggers TwentyPlusPhaseDamage PSR
+    session = seedDamageThisPhase(session, 'attacker', 20);
+    session = checkAndQueueDamagePSRs(session);
+
+    // After checkAndQueue, attacker should have a PSRTriggered event
+    // and pendingPSRs should be non-empty.
+    const triggered = session.events.filter(
+      (e: IGameEvent) =>
+        e.type === GameEventType.PSRTriggered &&
+        (e.payload as IPSRTriggeredPayload).triggerSource === '20+_damage',
+    );
+    expect(triggered.length).toBe(1);
+    expect(session.currentState.units['attacker'].pendingPSRs?.length).toBe(1);
+
+    // Roll 9 — passes TN 5 (piloting). resolveAllPSRs internally calls
+    // d6Roller twice (taking dice[0] each time), so the mock must
+    // return two rolls whose dice[0] values sum to the desired total.
+    // 4 + 5 = 9.
+    session = resolvePendingPSRs(
+      session,
+      mockDiceRoller([
+        { dice: [4, 0], total: 4 },
+        { dice: [5, 0], total: 5 },
+      ]),
+    );
+
+    const resolved = session.events.find(
+      (e: IGameEvent) => e.type === GameEventType.PSRResolved,
+    );
+    expect(resolved).toBeDefined();
+    const payload = resolved!.payload as IPSRResolvedPayload;
+    expect(payload.passed).toBe(true);
+    expect(payload.roll).toBe(9);
+
+    const fellEvents = session.events.filter(
+      (e: IGameEvent) => e.type === GameEventType.UnitFell,
+    );
+    expect(fellEvents).toHaveLength(0);
+  });
+
+  it('PSR failure triggers UnitFell + PilotHit chain', () => {
+    let session = setupActiveSession();
+    session = seedDamageThisPhase(session, 'attacker', 20);
+    session = checkAndQueueDamagePSRs(session);
+
+    // Roll 2 (snake eyes) — fails TN 5. Expect PSRResolved failure +
+    // UnitFell + PilotHit. The fall direction roll uses dice[0] of the
+    // next dice; we feed extra rolls to cover the fall path.
+    session = resolvePendingPSRs(
+      session,
+      mockDiceRoller([
+        { dice: [1, 1], total: 2 }, // PSR roll → fail
+        { dice: [3, 0], total: 3 }, // fall direction (uses dice[0] = 3)
+      ]),
+    );
+
+    const resolved = session.events.find(
+      (e: IGameEvent) => e.type === GameEventType.PSRResolved,
+    );
+    const psrPayload = resolved!.payload as IPSRResolvedPayload;
+    expect(psrPayload.passed).toBe(false);
+
+    const fellEvents = session.events.filter(
+      (e: IGameEvent) => e.type === GameEventType.UnitFell,
+    );
+    expect(fellEvents).toHaveLength(1);
+
+    const pilotHits = session.events.filter(
+      (e: IGameEvent) => e.type === GameEventType.PilotHit,
+    );
+    expect(pilotHits.length).toBeGreaterThan(0);
+
+    // Reducer should have set prone=true.
+    expect(session.currentState.units['attacker'].prone).toBe(true);
+  });
+
+  it('attemptStandUp succeeds → emits UnitStood and clears prone', () => {
+    let session = setupActiveSession();
+    // Get attacker into prone state via the failure flow above.
+    session = seedDamageThisPhase(session, 'attacker', 20);
+    session = checkAndQueueDamagePSRs(session);
+    session = resolvePendingPSRs(
+      session,
+      mockDiceRoller([
+        { dice: [1, 1], total: 2 },
+        { dice: [3, 0], total: 3 },
+      ]),
+    );
+    expect(session.currentState.units['attacker'].prone).toBe(true);
+
+    // Now attempt to stand up with a passing roll (10 vs piloting TN 5).
+    session = attemptStandUp(
+      session,
+      'attacker',
+      mockDiceRoller([{ dice: [5, 5], total: 10 }]),
+    );
+
+    const stood = session.events.find(
+      (e: IGameEvent) => e.type === GameEventType.UnitStood,
+    );
+    expect(stood).toBeDefined();
+    const payload = stood!.payload as IUnitStoodPayload;
+    expect(payload.unitId).toBe('attacker');
+    expect(payload.roll).toBe(10);
+
+    expect(session.currentState.units['attacker'].prone).toBe(false);
+  });
+
+  it('attemptStandUp failure leaves the unit prone (no UnitStood)', () => {
+    let session = setupActiveSession();
+    session = seedDamageThisPhase(session, 'attacker', 20);
+    session = checkAndQueueDamagePSRs(session);
+    session = resolvePendingPSRs(
+      session,
+      mockDiceRoller([
+        { dice: [1, 1], total: 2 },
+        { dice: [3, 0], total: 3 },
+      ]),
+    );
+
+    // Roll 2 — fails the stand-up TN 5. Expect PSRResolved failure but
+    // NO UnitStood event, and unit remains prone.
+    session = attemptStandUp(
+      session,
+      'attacker',
+      mockDiceRoller([{ dice: [1, 1], total: 2 }]),
+    );
+
+    const stoodEvents = session.events.filter(
+      (e: IGameEvent) => e.type === GameEventType.UnitStood,
+    );
+    expect(stoodEvents).toHaveLength(0);
+    expect(session.currentState.units['attacker'].prone).toBe(true);
+  });
+
+  it('UnitStood enum value is wired (0.5.2 alignment)', () => {
+    expect(GameEventType.UnitStood).toBe('unit_stood');
+  });
+});

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -107,6 +107,14 @@ export enum GameEventType {
   PSRTriggered = 'psr_triggered',
   PSRResolved = 'psr_resolved',
   UnitFell = 'unit_fell',
+  /**
+   * Per `wire-piloting-skill-rolls` task 0.5.2: emitted when a prone
+   * unit successfully passes an `AttemptStand` PSR and returns to its
+   * upright state. Carries the roll + TN so UI / replay consumers can
+   * show the stand-up attempt without re-computing it from the
+   * preceding `PSRResolved` event.
+   */
+  UnitStood = 'unit_stood',
   PhysicalAttackDeclared = 'physical_attack_declared',
   PhysicalAttackResolved = 'physical_attack_resolved',
   ShutdownCheck = 'shutdown_check',
@@ -507,6 +515,17 @@ export interface IUnitFellPayload {
   readonly pilotDamage: number;
 }
 
+/**
+ * Per `wire-piloting-skill-rolls` task 0.5.4: emitted when a prone
+ * unit passes an `AttemptStand` PSR and returns to upright state.
+ */
+export interface IUnitStoodPayload {
+  readonly unitId: string;
+  readonly turn: number;
+  readonly roll: number;
+  readonly targetNumber: number;
+}
+
 export interface IPhysicalAttackDeclaredPayload {
   readonly attackerId: string;
   readonly targetId: string;
@@ -611,6 +630,7 @@ export type GameEventPayload =
   | IPSRTriggeredPayload
   | IPSRResolvedPayload
   | IUnitFellPayload
+  | IUnitStoodPayload
   | IPhysicalAttackDeclaredPayload
   | IPhysicalAttackResolvedPayload
   | IShutdownCheckPayload

--- a/src/utils/gameplay/gameEvents/status.ts
+++ b/src/utils/gameplay/gameEvents/status.ts
@@ -12,6 +12,7 @@ import {
   IStartupAttemptPayload,
   IUnitDestroyedPayload,
   IUnitFellPayload,
+  IUnitStoodPayload,
   IAmmoConsumedPayload,
 } from '@/types/gameplay';
 
@@ -248,6 +249,38 @@ export function createUnitFellEvent(
       gameId,
       sequence,
       GameEventType.UnitFell,
+      turn,
+      phase,
+      unitId,
+    ),
+    payload,
+  };
+}
+
+/**
+ * Per `wire-piloting-skill-rolls` task 9.3: fired when a prone unit
+ * successfully passes an `AttemptStand` PSR and returns upright.
+ */
+export function createUnitStoodEvent(
+  gameId: string,
+  sequence: number,
+  turn: number,
+  phase: GamePhase,
+  unitId: string,
+  roll: number,
+  targetNumber: number,
+): IGameEvent {
+  const payload: IUnitStoodPayload = {
+    unitId,
+    turn,
+    roll,
+    targetNumber,
+  };
+  return {
+    ...createEventBase(
+      gameId,
+      sequence,
+      GameEventType.UnitStood,
       turn,
       phase,
       unitId,

--- a/src/utils/gameplay/gameSession.ts
+++ b/src/utils/gameplay/gameSession.ts
@@ -21,7 +21,11 @@ export {
   resolveAllAttacks,
 } from './gameSessionAttackResolution';
 
-export { checkAndQueueDamagePSRs, resolvePendingPSRs } from './gameSessionPSR';
+export {
+  attemptStandUp,
+  checkAndQueueDamagePSRs,
+  resolvePendingPSRs,
+} from './gameSessionPSR';
 
 export { resolveHeatPhase } from './gameSessionHeat';
 

--- a/src/utils/gameplay/gameSessionPSR.ts
+++ b/src/utils/gameplay/gameSessionPSR.ts
@@ -7,11 +7,13 @@ import {
   createPSRResolvedEvent,
   createPSRTriggeredEvent,
   createUnitFellEvent,
+  createUnitStoodEvent,
 } from './gameEvents';
 import { appendEvent } from './gameSessionCore';
 import { roll2d6 as rollDice } from './hitLocation';
 import {
   checkPhaseDamagePSR,
+  createStandingUpPSR,
   isGyroDestroyed,
   resolveAllPSRs,
 } from './pilotingSkillRolls';
@@ -228,6 +230,98 @@ export function resolvePendingPSRs(
         ),
       );
     }
+  }
+
+  return currentSession;
+}
+
+/**
+ * Per `wire-piloting-skill-rolls` task 9: prone unit attempts to stand.
+ * Enqueues an `AttemptStand` PSR trigger, immediately rolls, and on
+ * success emits `UnitStood` (clears prone). On failure the unit remains
+ * prone. Fall damage is NOT applied — failing a stand-up attempt doesn't
+ * cause additional damage; the unit just fails to rise this turn.
+ *
+ * Caller decides when (movement phase) and pays the MP cost before
+ * invoking. This helper only emits the event chain.
+ */
+export function attemptStandUp(
+  session: IGameSession,
+  unitId: string,
+  diceRoller: DiceRoller = rollDice,
+): IGameSession {
+  const { turn } = session.currentState;
+  const phase = session.currentState.phase;
+  const unitState = session.currentState.units[unitId];
+  if (!unitState || !unitState.prone || unitState.destroyed) {
+    return session;
+  }
+  const unit = session.units.find((u) => u.id === unitId);
+  if (!unit) return session;
+
+  let currentSession = session;
+
+  // 1. Emit PSRTriggered so the reducer pushes the PSR onto the queue.
+  const psr = createStandingUpPSR(unitId);
+  const triggeredSeq = currentSession.events.length;
+  currentSession = appendEvent(
+    currentSession,
+    createPSRTriggeredEvent(
+      currentSession.id,
+      triggeredSeq,
+      turn,
+      phase,
+      unitId,
+      psr.reason,
+      psr.additionalModifier,
+      psr.triggerSource,
+    ),
+  );
+
+  // 2. Roll the PSR: piloting skill + gyro-hit modifier + wound
+  //    modifier + trigger-specific modifier. Canonical stand-up TN is
+  //    piloting + 0 (plus any active modifiers).
+  const componentDamage = unitState.componentDamage;
+  const gyroModifier = (componentDamage?.gyroHits ?? 0) * 3;
+  const woundModifier = unitState.pilotWounds;
+  const tn =
+    unit.piloting + gyroModifier + woundModifier + psr.additionalModifier;
+  const roll = diceRoller();
+  const passed = roll.total >= tn;
+
+  const resolvedSeq = currentSession.events.length;
+  currentSession = appendEvent(
+    currentSession,
+    createPSRResolvedEvent(
+      currentSession.id,
+      resolvedSeq,
+      turn,
+      phase,
+      unitId,
+      tn,
+      roll.total,
+      gyroModifier + woundModifier,
+      passed,
+      psr.reason,
+    ),
+  );
+
+  // 3. On success, emit UnitStood. On failure the unit stays prone;
+  //    no additional damage (per canonical standing-up rules).
+  if (passed) {
+    const stoodSeq = currentSession.events.length;
+    currentSession = appendEvent(
+      currentSession,
+      createUnitStoodEvent(
+        currentSession.id,
+        stoodSeq,
+        turn,
+        phase,
+        unitId,
+        roll.total,
+        tn,
+      ),
+    );
   }
 
   return currentSession;

--- a/src/utils/gameplay/gameState/extendedCombat.ts
+++ b/src/utils/gameplay/gameState/extendedCombat.ts
@@ -8,6 +8,7 @@ import {
   IShutdownCheckPayload,
   IStartupAttemptPayload,
   IUnitFellPayload,
+  IUnitStoodPayload,
   LockState,
 } from '@/types/gameplay';
 
@@ -84,6 +85,32 @@ export function applyUnitFell(
         prone: true,
         facing: payload.newFacing,
         pendingPSRs: [],
+      },
+    },
+  };
+}
+
+/**
+ * Per `wire-piloting-skill-rolls` task 9.3: prone unit has passed an
+ * `AttemptStand` PSR and returns upright. Clears prone flag;
+ * pendingPSRs have already been resolved by the preceding
+ * `PSRResolved` event.
+ */
+export function applyUnitStood(
+  state: IGameState,
+  payload: IUnitStoodPayload,
+): IGameState {
+  const unit = state.units[payload.unitId];
+  if (!unit) {
+    return state;
+  }
+  return {
+    ...state,
+    units: {
+      ...state.units,
+      [payload.unitId]: {
+        ...unit,
+        prone: false,
       },
     },
   };

--- a/src/utils/gameplay/gameState/gameStateReducer.ts
+++ b/src/utils/gameplay/gameState/gameStateReducer.ts
@@ -24,6 +24,7 @@ import {
   IStartupAttemptPayload,
   IUnitDestroyedPayload,
   IUnitFellPayload,
+  IUnitStoodPayload,
   IUnitGameState,
   IGameStartedPayload,
   LockState,
@@ -51,6 +52,7 @@ import {
   applyShutdownCheck,
   applyStartupAttempt,
   applyUnitFell,
+  applyUnitStood,
 } from './extendedCombat';
 import {
   createInitialGameState,
@@ -139,6 +141,9 @@ export function applyEvent(state: IGameState, event: IGameEvent): IGameState {
 
     case GameEventType.UnitFell:
       return applyUnitFell(state, event.payload as IUnitFellPayload);
+
+    case GameEventType.UnitStood:
+      return applyUnitStood(state, event.payload as IUnitStoodPayload);
 
     case GameEventType.PhysicalAttackDeclared:
       return applyPhysicalAttackDeclared(


### PR DESCRIPTION
## Summary

The PSR queue / resolution / fall infrastructure already existed in `gameSessionPSR.ts` + `pilotingSkillRolls/`, but nothing closed the loop on standing back up after falling. This change adds the missing `UnitStood` event + `attemptStandUp(session, unitId)` helper.

- `GameEventType.UnitStood` + `IUnitStoodPayload { unitId, turn, roll, targetNumber }` in the event union
- `createUnitStoodEvent` factory in `gameEvents/status.ts`
- `applyUnitStood` reducer flips `prone: false`
- `attemptStandUp` helper: enqueues `AttemptStand` PSR, rolls 2d6 vs piloting + gyro/wound mods, emits `PSRResolved` and (on success) `UnitStood`
- Re-exported through `gameSession.ts`

Pre-existing PSR pipeline left intact: `PSRTriggered` reducer pushes onto `pendingPSRs`, `resolvePendingPSRs` rolls + emits `PSRResolved`, gyro auto-fall + fall damage via `resolveFall`, `checkAndQueueDamagePSRs` for 20+ damage trigger.

## Test plan

- [x] 609 test suites pass (19503 tests, 12 skipped, 0 fail)
- [x] `npx tsc --noEmit` clean
- [x] `npx oxlint` 0 errors (2 pre-existing max-lines warnings)
- [x] `npx next build` passes
- [x] Per-change smoke test `wirePilotingSkillRolls.smoke.test.ts` (5 tests, all pass)

Spec: `openspec/changes/wire-piloting-skill-rolls/tasks.md`