### PR TITLE
feat(ui): add MapConfigEditor to pre-battle page (radius + terrain)

### DIFF
--- a/src/components/gameplay/pages/PreBattlePage.sections.tsx
+++ b/src/components/gameplay/pages/PreBattlePage.sections.tsx
@@ -6,6 +6,7 @@ import type {
 import type { IForce } from '@/types/force';
 
 import { Badge, Card } from '@/components/ui';
+import { TerrainPreset } from '@/types/encounter';
 
 interface ForceCardProps {
   title: string;
@@ -166,6 +167,93 @@ export function BattlefieldCard({
               {mapConfig.playerDeploymentZone} vs{' '}
               {mapConfig.opponentDeploymentZone}
             </p>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+/**
+ * Per `add-skirmish-setup-ui` tasks 4 + 5: interactive editor for the
+ * battlefield's hex radius and terrain preset. Surfaces the existing
+ * encounter `mapConfig` as a controlled form and emits changes via
+ * `onChange` so the parent can persist via `useEncounterStore.updateEncounter`.
+ *
+ * Discrete radius options are 5 / 8 / 12 / 17 (canonical sizes per the
+ * roadmap; default 8 = 17×17 hex grid). Terrain presets are loaded
+ * from the `TerrainPreset` enum so adding a new preset there
+ * automatically surfaces here.
+ */
+interface MapConfigEditorProps {
+  mapConfig: IMapConfiguration;
+  onChange: (next: Partial<IMapConfiguration>) => void;
+  disabled?: boolean;
+}
+
+export const MAP_RADIUS_OPTIONS = [5, 8, 12, 17] as const;
+
+export function MapConfigEditor({
+  mapConfig,
+  onChange,
+  disabled = false,
+}: MapConfigEditorProps): React.ReactElement {
+  const hexCount = (radius: number) => 1 + 3 * radius * (radius + 1);
+
+  return (
+    <Card className="mb-6" data-testid="map-config-editor">
+      <div className="p-4">
+        <h3 className="text-text-theme-secondary mb-3 text-sm font-medium">
+          Battlefield Configuration
+        </h3>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div>
+            <label
+              htmlFor="map-radius-select"
+              className="text-text-theme-muted mb-1 block text-xs"
+            >
+              Hex Radius
+            </label>
+            <select
+              id="map-radius-select"
+              data-testid="map-radius-select"
+              className="bg-surface-theme text-text-theme-primary border-border-theme w-full rounded border px-2 py-1 text-sm"
+              value={mapConfig.radius}
+              disabled={disabled}
+              onChange={(e) => onChange({ radius: Number(e.target.value) })}
+            >
+              {MAP_RADIUS_OPTIONS.map((r) => (
+                <option key={r} value={r}>
+                  {r} ({hexCount(r)} hexes)
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label
+              htmlFor="terrain-preset-select"
+              className="text-text-theme-muted mb-1 block text-xs"
+            >
+              Terrain Preset
+            </label>
+            <select
+              id="terrain-preset-select"
+              data-testid="terrain-preset-select"
+              className="bg-surface-theme text-text-theme-primary border-border-theme w-full rounded border px-2 py-1 text-sm"
+              value={mapConfig.terrain}
+              disabled={disabled}
+              onChange={(e) =>
+                onChange({ terrain: e.target.value as TerrainPreset })
+              }
+            >
+              {Object.values(TerrainPreset).map((preset) => (
+                <option key={preset} value={preset}>
+                  {preset
+                    .replace('_', ' ')
+                    .replace(/\b\w/g, (c) => c.toUpperCase())}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
       </div>

--- a/src/components/gameplay/pages/__tests__/addSkirmishSetupUI.smoke.test.tsx
+++ b/src/components/gameplay/pages/__tests__/addSkirmishSetupUI.smoke.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Per-change smoke test for add-skirmish-setup-ui.
+ *
+ * Asserts the MapConfigEditor surfaces radius + terrain controls,
+ * exposes the canonical 4 radius options + all TerrainPreset values,
+ * and emits change events with partial-config diffs.
+ *
+ * @spec openspec/changes/add-skirmish-setup-ui/tasks.md § 4-5
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import {
+  MAP_RADIUS_OPTIONS,
+  MapConfigEditor,
+} from '@/components/gameplay/pages/PreBattlePage.sections';
+import { TerrainPreset, type IMapConfiguration } from '@/types/encounter';
+
+const baseConfig: IMapConfiguration = {
+  radius: 8,
+  terrain: TerrainPreset.Clear,
+  playerDeploymentZone: 'south',
+  opponentDeploymentZone: 'north',
+};
+
+describe('add-skirmish-setup-ui — MapConfigEditor smoke test', () => {
+  it('renders canonical radius options (5 / 8 / 12 / 17) with hex counts', () => {
+    const onChange = jest.fn();
+    render(<MapConfigEditor mapConfig={baseConfig} onChange={onChange} />);
+
+    const radiusSelect = screen.getByTestId(
+      'map-radius-select',
+    ) as HTMLSelectElement;
+    expect(radiusSelect).toBeInTheDocument();
+
+    // All 4 canonical radius values are present
+    for (const r of MAP_RADIUS_OPTIONS) {
+      expect(radiusSelect.querySelector(`option[value="${r}"]`)).not.toBeNull();
+    }
+
+    // Default selection matches the input mapConfig.radius
+    expect(radiusSelect.value).toBe('8');
+
+    // Hex count is rendered next to the radius (formula: 1 + 3r(r+1))
+    // For r=8: 1 + 3*8*9 = 217 hexes
+    expect(radiusSelect.textContent).toContain('217');
+  });
+
+  it('renders every TerrainPreset value in the terrain selector', () => {
+    const onChange = jest.fn();
+    render(<MapConfigEditor mapConfig={baseConfig} onChange={onChange} />);
+
+    const terrainSelect = screen.getByTestId(
+      'terrain-preset-select',
+    ) as HTMLSelectElement;
+    for (const preset of Object.values(TerrainPreset)) {
+      expect(
+        terrainSelect.querySelector(`option[value="${preset}"]`),
+      ).not.toBeNull();
+    }
+    expect(terrainSelect.value).toBe(TerrainPreset.Clear);
+  });
+
+  it('emits onChange with { radius } when radius is changed', () => {
+    const onChange = jest.fn();
+    render(<MapConfigEditor mapConfig={baseConfig} onChange={onChange} />);
+
+    fireEvent.change(screen.getByTestId('map-radius-select'), {
+      target: { value: '12' },
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({ radius: 12 });
+  });
+
+  it('emits onChange with { terrain } when terrain preset is changed', () => {
+    const onChange = jest.fn();
+    render(<MapConfigEditor mapConfig={baseConfig} onChange={onChange} />);
+
+    fireEvent.change(screen.getByTestId('terrain-preset-select'), {
+      target: { value: TerrainPreset.Urban },
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({ terrain: TerrainPreset.Urban });
+  });
+
+  it('disables both controls when disabled prop is true', () => {
+    const onChange = jest.fn();
+    render(
+      <MapConfigEditor mapConfig={baseConfig} onChange={onChange} disabled />,
+    );
+    expect(
+      (screen.getByTestId('map-radius-select') as HTMLSelectElement).disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByTestId('terrain-preset-select') as HTMLSelectElement)
+        .disabled,
+    ).toBe(true);
+  });
+});

--- a/src/pages/gameplay/encounters/[id]/pre-battle.tsx
+++ b/src/pages/gameplay/encounters/[id]/pre-battle.tsx
@@ -14,6 +14,7 @@ import {
   BattlefieldCard,
   BVComparison,
   ForceCard,
+  MapConfigEditor,
   ModeSelection,
   ScenarioTemplateCard,
 } from '@/components/gameplay/pages/PreBattlePage.sections';
@@ -67,6 +68,7 @@ export default function PreBattlePage(): React.ReactElement {
   const {
     getEncounter,
     loadEncounters,
+    updateEncounter,
     isLoading: encountersLoading,
   } = useEncounterStore();
   const { forces, loadForces } = useForceStore();
@@ -347,6 +349,16 @@ export default function PreBattlePage(): React.ReactElement {
         </div>
 
         <BattlefieldCard mapConfig={encounter.mapConfig} />
+
+        <MapConfigEditor
+          mapConfig={encounter.mapConfig}
+          disabled={isResolving}
+          onChange={(next) => {
+            void updateEncounter(encounter.id, {
+              mapConfig: { ...encounter.mapConfig, ...next },
+            });
+          }}
+        />
 
         <div className="mb-6">
           <ModeSelection


### PR DESCRIPTION
## Summary

The pre-battle screen previously rendered map config (radius, terrain, deployment) as read-only text. This change adds an interactive `MapConfigEditor` with the canonical 4 hex radii (5/8/12/17) and all `TerrainPreset` enum values, persisting changes through `useEncounterStore.updateEncounter`.

- `MapConfigEditor` component with radius + terrain dropdowns; radius shows hex count per option (1 + 3r(r+1)); terrain dropdown is data-driven from `TerrainPreset`
- Wired into pre-battle.tsx between `BattlefieldCard` and `ModeSelection`
- Disabled while launch is resolving so users can't change config mid-launch
- Exported `MAP_RADIUS_OPTIONS` for reuse + test assertions

Spec gap notes: tasks 1-3 (per-side unit/pilot pickers) already implemented via the existing `ForceCard` system; task 6 (deployment-zone overlay on a hex preview) deferred — needs hex-map renderer that's a separate Phase 7 polish concern; task 7 (launch handshake) already wired via `buildPreparedBattleData` + `GameEngine.createInteractiveSession`.

## Test plan

- [x] 610 test suites pass (19508 tests, 12 skipped, 0 fail)
- [x] `npx tsc --noEmit` clean
- [x] `npx oxlint` 0 errors (2 pre-existing max-lines warnings)
- [x] `npx next build` passes
- [x] Per-change smoke test \`addSkirmishSetupUI.smoke.test.tsx\` (5 tests, all pass)

Spec: \`openspec/changes/add-skirmish-setup-ui/tasks.md\`

🚀 First Lane B PR. Lane A complete (#301-#308).