### PR TITLE
feat(ui): add MovementHeatPreview + per-type tile colors for movement phase

### DIFF
--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -7,6 +7,26 @@ import type {
 } from '@/types/gameplay';
 
 import { HEX_COLORS } from '@/constants/hexMap';
+import { MovementType } from '@/types/gameplay';
+
+/**
+ * Per `add-movement-phase-ui` task 3.2-3.4: pick the per-type tile
+ * color (green = walk, yellow = run, blue = jump). Falls back to the
+ * uniform `movementRange` color for legacy callers that don't set a
+ * type or use Stationary.
+ */
+function colorForMovementType(type: MovementType): string {
+  switch (type) {
+    case MovementType.Walk:
+      return HEX_COLORS.movementRangeWalk;
+    case MovementType.Run:
+      return HEX_COLORS.movementRangeRun;
+    case MovementType.Jump:
+      return HEX_COLORS.movementRangeJump;
+    default:
+      return HEX_COLORS.movementRange;
+  }
+}
 
 import {
   hexToPixel,
@@ -62,7 +82,7 @@ export const HexCell = React.memo(function HexCell({
     overlayOpacity = 0.6;
   } else if (movementInfo) {
     overlayFill = movementInfo.reachable
-      ? HEX_COLORS.movementRange
+      ? colorForMovementType(movementInfo.movementType)
       : HEX_COLORS.movementRangeUnreachable;
     overlayOpacity = 0.5;
   } else if (isInAttackRange) {

--- a/src/components/gameplay/MovementHeatPreview.tsx
+++ b/src/components/gameplay/MovementHeatPreview.tsx
@@ -1,0 +1,72 @@
+/**
+ * MovementHeatPreview
+ *
+ * Per `add-movement-phase-ui` task 9: a small preview chip the action
+ * panel shows below the MP-type buttons during the Movement phase. It
+ * surfaces the heat the unit will accumulate this turn for the chosen
+ * movement type (Walk = +1, Run = +2, Jump = max(3, jumpMP)) so the
+ * player can plan around heat limits before committing the move.
+ *
+ * Heat math is delegated to `calculateMovementHeat` from
+ * `utils/gameplay/movement` so this component can never drift from the
+ * canonical rules.
+ *
+ * @spec openspec/changes/add-movement-phase-ui/tasks.md § 9
+ */
+
+import React from 'react';
+
+import { MovementType } from '@/types/gameplay';
+import { calculateMovementHeat } from '@/utils/gameplay/movement';
+
+export interface MovementHeatPreviewProps {
+  /** The movement type the player is currently planning. */
+  movementType: MovementType;
+  /**
+   * Number of hexes the unit will jump (only used when
+   * `movementType === MovementType.Jump`). Walk and Run heat are
+   * fixed at 1/2 regardless of distance per canonical rules.
+   */
+  jumpHexes?: number;
+  /** Optional className for layout overrides. */
+  className?: string;
+}
+
+const MOVEMENT_TYPE_LABEL: Record<MovementType, string> = {
+  [MovementType.Stationary]: 'Stationary',
+  [MovementType.Walk]: 'Walk',
+  [MovementType.Run]: 'Run',
+  [MovementType.Jump]: 'Jump',
+};
+
+export function MovementHeatPreview({
+  movementType,
+  jumpHexes = 0,
+  className = '',
+}: MovementHeatPreviewProps): React.ReactElement {
+  const heat = calculateMovementHeat(movementType, jumpHexes);
+  const label = MOVEMENT_TYPE_LABEL[movementType] ?? 'Move';
+
+  return (
+    <div
+      className={`flex items-center gap-2 text-sm ${className}`}
+      data-testid="movement-heat-preview"
+      data-heat={heat}
+      data-movement-type={movementType}
+    >
+      <span className="text-text-theme-muted">Heat this turn:</span>
+      <span
+        className={
+          heat >= 8
+            ? 'font-semibold text-amber-500'
+            : heat > 0
+              ? 'text-text-theme-primary font-semibold'
+              : 'text-text-theme-muted'
+        }
+      >
+        {heat > 0 ? `+${heat}` : '0'}
+      </span>
+      <span className="text-text-theme-muted text-xs">({label})</span>
+    </div>
+  );
+}

--- a/src/components/gameplay/__tests__/addMovementPhaseUI.smoke.test.tsx
+++ b/src/components/gameplay/__tests__/addMovementPhaseUI.smoke.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Per-change smoke test for add-movement-phase-ui.
+ *
+ * Asserts:
+ * - MovementHeatPreview renders the canonical per-type heat values
+ *   (Walk=+1, Run=+2, Jump=max(3,jumpMP), Stationary=0)
+ * - HEX_COLORS exposes per-movement-type tile colors (walk/run/jump)
+ *
+ * @spec openspec/changes/add-movement-phase-ui/tasks.md § 3, § 9
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { MovementHeatPreview } from '@/components/gameplay/MovementHeatPreview';
+import { HEX_COLORS } from '@/constants/hexMap';
+import { MovementType } from '@/types/gameplay';
+
+describe('add-movement-phase-ui — smoke test', () => {
+  describe('MovementHeatPreview', () => {
+    it('renders +1 heat for Walk', () => {
+      render(<MovementHeatPreview movementType={MovementType.Walk} />);
+      const preview = screen.getByTestId('movement-heat-preview');
+      expect(preview.dataset.heat).toBe('1');
+      expect(preview.textContent).toContain('+1');
+      expect(preview.textContent).toContain('Walk');
+    });
+
+    it('renders +2 heat for Run', () => {
+      render(<MovementHeatPreview movementType={MovementType.Run} />);
+      const preview = screen.getByTestId('movement-heat-preview');
+      expect(preview.dataset.heat).toBe('2');
+      expect(preview.textContent).toContain('+2');
+      expect(preview.textContent).toContain('Run');
+    });
+
+    it('renders +3 heat for Jump with 0 jumpHexes (min floor of 3)', () => {
+      render(
+        <MovementHeatPreview movementType={MovementType.Jump} jumpHexes={0} />,
+      );
+      const preview = screen.getByTestId('movement-heat-preview');
+      expect(preview.dataset.heat).toBe('3');
+      expect(preview.textContent).toContain('+3');
+    });
+
+    it('renders +max(jumpMP) heat for Jump beyond 3 hexes', () => {
+      render(
+        <MovementHeatPreview movementType={MovementType.Jump} jumpHexes={5} />,
+      );
+      const preview = screen.getByTestId('movement-heat-preview');
+      expect(preview.dataset.heat).toBe('5');
+      expect(preview.textContent).toContain('+5');
+    });
+
+    it('renders 0 heat for Stationary', () => {
+      render(<MovementHeatPreview movementType={MovementType.Stationary} />);
+      const preview = screen.getByTestId('movement-heat-preview');
+      expect(preview.dataset.heat).toBe('0');
+      // No "+" prefix when heat is 0
+      expect(preview.textContent).toContain('0');
+      expect(preview.textContent).not.toContain('+0');
+    });
+  });
+
+  describe('HEX_COLORS movement-type palette (task 3.2-3.4)', () => {
+    it('exposes per-movement-type tile colors', () => {
+      // Per spec: green=Walk, yellow=Run, blue=Jump
+      expect(HEX_COLORS.movementRangeWalk).toBe('#bbf7d0');
+      expect(HEX_COLORS.movementRangeRun).toBe('#fef08a');
+      expect(HEX_COLORS.movementRangeJump).toBe('#bfdbfe');
+      // Legacy uniform color preserved for backwards compat
+      expect(HEX_COLORS.movementRange).toBeDefined();
+    });
+  });
+});

--- a/src/constants/hexMap.ts
+++ b/src/constants/hexMap.ts
@@ -43,8 +43,16 @@ export const HEX_COLORS: Record<string, string> = {
   hexHover: '#e2e8f0',
   /** Selected hex */
   hexSelected: '#bfdbfe',
-  /** Reachable movement range */
+  /** Reachable movement range (legacy uniform color; per
+   *  add-movement-phase-ui task 3.2-3.4 use the per-type colors below
+   *  when movement type is known). */
   movementRange: '#86efac',
+  /** Walk-range tile (green per spec) */
+  movementRangeWalk: '#bbf7d0',
+  /** Run-range tile (yellow per spec) */
+  movementRangeRun: '#fef08a',
+  /** Jump-range tile (blue per spec) */
+  movementRangeJump: '#bfdbfe',
   /** Unreachable/blocked movement */
   movementRangeUnreachable: '#fca5a5',
   /** Attack range highlight */


### PR DESCRIPTION
## Summary

Closes the two highest-impact gaps from `add-movement-phase-ui`:

1. **Per-movement-type tile colors** (task 3.2-3.4): reachable-hex overlay now picks color from `movementInfo.movementType` — green for Walk, yellow for Run, blue for Jump. Legacy uniform color preserved for backwards compat.

2. **MovementHeatPreview component** (task 9): action-panel chip showing heat the unit will accumulate this turn. Delegates to canonical `calculateMovementHeat` (Walk=+1, Run=+2, Jump=max(3,jumpMP)). Heat ≥ 8 renders amber to flag the shutdown threshold.

Pre-existing: `validMovementHexes` already populated by store, `HexMapDisplay` already accepts `movementRange[]`, `IMovementRangeHex` already shaped per spec.

Spec gap notes (deferred): path-preview-on-hover (task 4), facing picker (task 6), move animation (task 8.3) — separate concerns.

## Test plan

- [x] 611 test suites pass (19514 tests, 12 skipped, 0 fail)
- [x] `npx tsc --noEmit` clean
- [x] `npx oxlint` 0 errors (3 pre-existing max-lines warnings)
- [x] `npx next build` passes
- [x] Per-change smoke test \`addMovementPhaseUI.smoke.test.tsx\` (6 tests, all pass)

Spec: \`openspec/changes/add-movement-phase-ui/tasks.md\`