### PR TITLE
feat(combat): add InteractiveSession.concede + post-battle report derivation

### DIFF
--- a/src/__tests__/unit/gameplay/addVictoryAndPostBattleSummary.smoke.test.ts
+++ b/src/__tests__/unit/gameplay/addVictoryAndPostBattleSummary.smoke.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Per-change smoke test for add-victory-and-post-battle-summary.
+ *
+ * Asserts:
+ * - InteractiveSession.concede(side) emits GameEnded with the OPPOSITE
+ *   side as winner and reason='concede' (closes B3 from Phase 1 review)
+ * - derivePostBattleReport produces a versioned schema with per-unit
+ *   damage totals + MVP nomination + full event log
+ * - victoryReasonLabel produces human-readable labels for each reason
+ *
+ * @spec openspec/changes/add-victory-and-post-battle-summary/tasks.md § 1, § 4, § 7, § 8
+ */
+
+import { describe, it, expect } from '@jest/globals';
+
+import { GameEngine } from '@/engine/GameEngine';
+import {
+  GameEventType,
+  GameSide,
+  type IDamageAppliedPayload,
+  type IGameEndedPayload,
+  type IGameEvent,
+  type IGameSession,
+  type IGameUnit,
+  type IGameStartedPayload,
+} from '@/types/gameplay';
+import { createGameSession, startGame } from '@/utils/gameplay/gameSession';
+import { deriveState } from '@/utils/gameplay/gameState';
+import {
+  derivePostBattleReport,
+  victoryReasonLabel,
+} from '@/utils/gameplay/postBattleReport';
+
+const config = {
+  mapRadius: 10,
+  turnLimit: 10,
+  victoryConditions: ['destruction'],
+  optionalRules: [],
+};
+
+const units: IGameUnit[] = [
+  {
+    id: 'attacker',
+    name: 'Hunchback',
+    side: GameSide.Player,
+    unitRef: 'hbk-4g',
+    pilotRef: 'p1',
+    gunnery: 4,
+    piloting: 5,
+  },
+  {
+    id: 'target',
+    name: 'Marauder',
+    side: GameSide.Opponent,
+    unitRef: 'mad-3r',
+    pilotRef: 'p2',
+    gunnery: 4,
+    piloting: 5,
+  },
+];
+
+/**
+ * Inject a synthesized DamageApplied event so the report has data to
+ * derive from. Mirrors the pattern from the integrate-damage-pipeline
+ * smoke test.
+ */
+function injectDamageEvent(
+  session: IGameSession,
+  attackerId: string,
+  targetId: string,
+  damage: number,
+): IGameSession {
+  const baseSeq = session.events.length;
+  const turn = session.currentState.turn;
+  const phase = session.currentState.phase;
+
+  // Need an AttackResolved first so the report can attribute damage.
+  const resolvedEvent: IGameEvent = {
+    id: `seed-resolved-${baseSeq}`,
+    gameId: session.id,
+    sequence: baseSeq,
+    timestamp: new Date().toISOString(),
+    type: GameEventType.AttackResolved,
+    turn,
+    phase,
+    actorId: attackerId,
+    payload: {
+      attackerId,
+      targetId,
+      weaponId: 'ml-1',
+      roll: 10,
+      toHitNumber: 4,
+      hit: true,
+      location: 'center_torso',
+      damage,
+    },
+  };
+  const damageEvent: IGameEvent = {
+    id: `seed-damage-${baseSeq + 1}`,
+    gameId: session.id,
+    sequence: baseSeq + 1,
+    timestamp: new Date().toISOString(),
+    type: GameEventType.DamageApplied,
+    turn,
+    phase,
+    actorId: targetId,
+    payload: {
+      unitId: targetId,
+      location: 'center_torso',
+      damage,
+      armorRemaining: 10,
+      structureRemaining: 10,
+      locationDestroyed: false,
+    } as IDamageAppliedPayload,
+  };
+  const newEvents = [...session.events, resolvedEvent, damageEvent];
+  return {
+    ...session,
+    events: newEvents,
+    currentState: deriveState(session.id, newEvents),
+  };
+}
+
+describe('add-victory-and-post-battle-summary — smoke test', () => {
+  describe('InteractiveSession.concede (B3)', () => {
+    it('emits GameEnded with opposite side as winner + reason=concede', () => {
+      const engine = new GameEngine({ seed: 12345 });
+      const interactive = engine.createInteractiveSession([], [], units);
+      interactive.concede(GameSide.Player);
+
+      const session = interactive.getSession();
+      const ended = session.events.find(
+        (e: IGameEvent) => e.type === GameEventType.GameEnded,
+      );
+      expect(ended).toBeDefined();
+      const payload = ended!.payload as IGameEndedPayload;
+      expect(payload.winner).toBe(GameSide.Opponent);
+      expect(payload.reason).toBe('concede');
+    });
+
+    it('Opponent conceding makes Player the winner', () => {
+      const engine = new GameEngine({ seed: 67890 });
+      const interactive = engine.createInteractiveSession([], [], units);
+      interactive.concede(GameSide.Opponent);
+
+      const ended = interactive
+        .getSession()
+        .events.find((e: IGameEvent) => e.type === GameEventType.GameEnded);
+      const payload = ended!.payload as IGameEndedPayload;
+      expect(payload.winner).toBe(GameSide.Player);
+    });
+
+    it('is a no-op once the game is already over', () => {
+      const engine = new GameEngine({ seed: 11111 });
+      const interactive = engine.createInteractiveSession([], [], units);
+      interactive.concede(GameSide.Player);
+      // Calling again should not append a second GameEnded event.
+      interactive.concede(GameSide.Player);
+      interactive.concede(GameSide.Opponent);
+
+      const endedCount = interactive
+        .getSession()
+        .events.filter(
+          (e: IGameEvent) => e.type === GameEventType.GameEnded,
+        ).length;
+      expect(endedCount).toBe(1);
+    });
+  });
+
+  describe('derivePostBattleReport', () => {
+    it('produces a versioned schema with version=1 + matchId + log', () => {
+      const session = createGameSession(config, units);
+      const started = startGame(session, GameSide.Player);
+      const report = derivePostBattleReport(started);
+
+      expect(report.version).toBe(1);
+      expect(report.matchId).toBe(session.id);
+      expect(report.log).toBeInstanceOf(Array);
+      expect(report.units).toHaveLength(2);
+      // No GameEnded yet → defaults to draw / destruction
+      expect(report.winner).toBe('draw');
+      expect(report.mvpUnitId).toBeNull();
+    });
+
+    it('attributes damage to attacker and target via AttackResolved chain', () => {
+      let session = createGameSession(config, units);
+      session = startGame(session, GameSide.Player);
+      session = injectDamageEvent(session, 'attacker', 'target', 10);
+      session = injectDamageEvent(session, 'attacker', 'target', 5);
+
+      const report = derivePostBattleReport(session);
+      const attacker = report.units.find((u) => u.unitId === 'attacker');
+      const target = report.units.find((u) => u.unitId === 'target');
+
+      expect(attacker?.damageDealt).toBe(15);
+      expect(target?.damageReceived).toBe(15);
+      expect(target?.damageDealt).toBe(0);
+    });
+
+    it('picks MVP from the winning side using highest damageDealt', () => {
+      let session = createGameSession(config, units);
+      session = startGame(session, GameSide.Player);
+      session = injectDamageEvent(session, 'attacker', 'target', 20);
+
+      // Manually inject a GameEnded for the player side so MVP picks
+      // attacker (the only damage-dealing player unit).
+      const endedEvent: IGameEvent = {
+        id: 'seed-ended',
+        gameId: session.id,
+        sequence: session.events.length,
+        timestamp: new Date().toISOString(),
+        type: GameEventType.GameEnded,
+        turn: session.currentState.turn,
+        phase: session.currentState.phase,
+        payload: {
+          winner: GameSide.Player,
+          reason: 'destruction',
+        } as IGameEndedPayload,
+      };
+      session = {
+        ...session,
+        events: [...session.events, endedEvent],
+        currentState: deriveState(session.id, [...session.events, endedEvent]),
+      };
+
+      const report = derivePostBattleReport(session);
+      expect(report.winner).toBe(GameSide.Player);
+      expect(report.mvpUnitId).toBe('attacker');
+    });
+
+    it('returns mvpUnitId=null when winner side dealt no damage', () => {
+      let session = createGameSession(config, units);
+      session = startGame(session, GameSide.Player);
+      // Player wins via concede with zero damage on the field.
+      const endedEvent: IGameEvent = {
+        id: 'seed-ended',
+        gameId: session.id,
+        sequence: session.events.length,
+        timestamp: new Date().toISOString(),
+        type: GameEventType.GameEnded,
+        turn: session.currentState.turn,
+        phase: session.currentState.phase,
+        payload: {
+          winner: GameSide.Player,
+          reason: 'concede',
+        } as IGameEndedPayload,
+      };
+      session = {
+        ...session,
+        events: [...session.events, endedEvent],
+        currentState: deriveState(session.id, [...session.events, endedEvent]),
+      };
+
+      const report = derivePostBattleReport(session);
+      expect(report.mvpUnitId).toBeNull();
+    });
+  });
+
+  describe('victoryReasonLabel', () => {
+    it('returns human-readable labels for each reason', () => {
+      expect(victoryReasonLabel('destruction')).toBe('Last side standing');
+      expect(victoryReasonLabel('concede')).toBe('Opponent conceded');
+      expect(victoryReasonLabel('turn_limit')).toBe('Turn limit reached');
+      expect(victoryReasonLabel('objective')).toBe('Objective complete');
+    });
+
+    it('uses "You conceded" perspective when loser perspective requested', () => {
+      expect(victoryReasonLabel('concede', 'loser')).toBe('You conceded');
+    });
+  });
+
+  describe('startGame helper safety check', () => {
+    it('starts the game without errors (smoke check for IGameStartedPayload import)', () => {
+      const session = createGameSession(config, units);
+      const started = startGame(session, GameSide.Player);
+      const startedEvent = started.events.find(
+        (e: IGameEvent) => e.type === GameEventType.GameStarted,
+      );
+      const payload = startedEvent!.payload as IGameStartedPayload;
+      expect(payload.firstSide).toBe(GameSide.Player);
+    });
+  });
+});

--- a/src/engine/InteractiveSession.ts
+++ b/src/engine/InteractiveSession.ts
@@ -16,6 +16,7 @@ import { SeededRandom } from '@/simulation/core/SeededRandom';
 import {
   GameSide,
   GamePhase,
+  GameStatus,
   LockState,
   type IGameSession,
   type IGameConfig,
@@ -41,6 +42,7 @@ import {
   lockAttack,
   resolveAllAttacks,
   resolveHeatPhase,
+  endGame,
 } from '@/utils/gameplay/gameSession';
 import { buildWeaponAttacks } from '@/utils/gameplay/weaponAttackBuilder';
 
@@ -291,6 +293,20 @@ export class InteractiveSession {
         this.session = lockAttack(this.session, unitId);
       }
     }
+  }
+
+  /**
+   * Per `add-victory-and-post-battle-summary` task 1.3 + B3 from the
+   * Phase 1 review: end the match by surrender from `side`. Appends a
+   * `GameEnded` event with `reason: 'concede'` and the OPPOSITE side
+   * as winner. No-op if the game is already over (or in setup).
+   */
+  concede(side: GameSide): void {
+    if (this.isGameOver()) return;
+    if (this.session.currentState.status !== GameStatus.Active) return;
+    const winner =
+      side === GameSide.Player ? GameSide.Opponent : GameSide.Player;
+    this.session = endGame(this.session, winner, 'concede');
   }
 
   isGameOver(): boolean {

--- a/src/utils/gameplay/postBattleReport.ts
+++ b/src/utils/gameplay/postBattleReport.ts
@@ -1,0 +1,225 @@
+/**
+ * Post-Battle Report Derivation
+ *
+ * Pure function that walks the session's event log and derives the
+ * after-action report (per-unit damage dealt/received, kills, heat
+ * problems, MVP nomination). Schema is versioned so Phase 3 campaign
+ * integration can extend it without losing stored Phase 1 records.
+ *
+ * @spec openspec/changes/add-victory-and-post-battle-summary/tasks.md § 4, § 8
+ */
+
+import type {
+  GameSide,
+  IDamageAppliedPayload,
+  IGameEndedPayload,
+  IGameEvent,
+  IGameSession,
+  IHeatPayload,
+  IPhysicalAttackResolvedPayload,
+  IUnitDestroyedPayload,
+} from '@/types/gameplay';
+
+import { GameEventType } from '@/types/gameplay';
+
+/** Schema version literal — bump on breaking changes to the report. */
+export type PostBattleReportVersion = 1;
+
+/**
+ * Per-unit summary captured in the after-action report. Damage totals
+ * include both player and opponent units; presentation layer filters
+ * by side.
+ */
+export interface IUnitReport {
+  readonly unitId: string;
+  readonly side: GameSide;
+  readonly designation: string;
+  readonly damageDealt: number;
+  readonly damageReceived: number;
+  readonly kills: number;
+  /** Number of heat-generation events that pushed the unit ≥ 14. */
+  readonly heatProblems: number;
+  /** Count of physical attacks declared by this unit. */
+  readonly physicalAttacks: number;
+  /** XP integration is Phase 3 — placeholder flag for the UI. */
+  readonly xpPending: true;
+}
+
+export interface IPostBattleReport {
+  readonly version: PostBattleReportVersion;
+  readonly matchId: string;
+  readonly winner: GameSide | 'draw';
+  readonly reason: 'destruction' | 'concede' | 'turn_limit' | 'objective';
+  readonly turnCount: number;
+  readonly units: readonly IUnitReport[];
+  /** MVP unit id; null when no damage was dealt by the winner. */
+  readonly mvpUnitId: string | null;
+  /** Full event log so the screen can render a collapsible feed. */
+  readonly log: readonly IGameEvent[];
+}
+
+const HEAT_PROBLEM_THRESHOLD = 14;
+
+/**
+ * Per task 8: MVP is the unit with highest `damageDealt` on the
+ * winning side. Ties broken by lowest `damageReceived`, then
+ * alphabetical designation. Returns null when no winner-side unit
+ * dealt damage (e.g., turn-limit + zero-damage draw).
+ */
+function pickMvp(
+  units: readonly IUnitReport[],
+  winner: GameSide | 'draw',
+): string | null {
+  if (winner === 'draw') return null;
+  const candidates = units
+    .filter((u) => u.side === winner && u.damageDealt > 0)
+    .slice()
+    .sort((a, b) => {
+      if (b.damageDealt !== a.damageDealt) return b.damageDealt - a.damageDealt;
+      if (a.damageReceived !== b.damageReceived) {
+        return a.damageReceived - b.damageReceived;
+      }
+      return a.designation.localeCompare(b.designation);
+    });
+  return candidates[0]?.unitId ?? null;
+}
+
+/**
+ * Derive the post-battle report from a session. The session SHOULD be
+ * Completed (have a `GameEnded` event) but the function works on
+ * mid-match sessions for testing / preview — `winner`/`reason` come
+ * from the GameEnded event when present, otherwise default to 'draw' /
+ * 'destruction'.
+ */
+export function derivePostBattleReport(
+  session: IGameSession,
+): IPostBattleReport {
+  // 1. Build per-unit zeroed reports keyed by id.
+  const reports = new Map<string, IUnitReport>();
+  for (const unit of session.units) {
+    reports.set(unit.id, {
+      unitId: unit.id,
+      side: unit.side,
+      designation: unit.name,
+      damageDealt: 0,
+      damageReceived: 0,
+      kills: 0,
+      heatProblems: 0,
+      physicalAttacks: 0,
+      xpPending: true,
+    });
+  }
+
+  // 2. Walk the log to accumulate per-unit stats.
+  // Track each AttackResolved's attackerId + targetId so we can credit
+  // the subsequent DamageApplied to the right attacker.
+  const damageAttribution = new Map<string, string>(); // targetId → attackerId for last unattributed attack
+  for (const event of session.events) {
+    if (event.type === GameEventType.AttackResolved) {
+      const p = event.payload as { attackerId: string; targetId: string };
+      damageAttribution.set(p.targetId, p.attackerId);
+      continue;
+    }
+    if (event.type === GameEventType.DamageApplied) {
+      const p = event.payload as IDamageAppliedPayload;
+      const target = reports.get(p.unitId);
+      if (target) {
+        reports.set(p.unitId, {
+          ...target,
+          damageReceived: target.damageReceived + p.damage,
+        });
+      }
+      const attackerId = damageAttribution.get(p.unitId);
+      if (attackerId) {
+        const attacker = reports.get(attackerId);
+        if (attacker) {
+          reports.set(attackerId, {
+            ...attacker,
+            damageDealt: attacker.damageDealt + p.damage,
+          });
+        }
+      }
+      continue;
+    }
+    if (event.type === GameEventType.UnitDestroyed) {
+      const p = event.payload as IUnitDestroyedPayload;
+      const attackerId = damageAttribution.get(p.unitId);
+      if (attackerId) {
+        const attacker = reports.get(attackerId);
+        if (attacker) {
+          reports.set(attackerId, {
+            ...attacker,
+            kills: attacker.kills + 1,
+          });
+        }
+      }
+      continue;
+    }
+    if (event.type === GameEventType.HeatGenerated) {
+      const p = event.payload as IHeatPayload;
+      if (p.newTotal >= HEAT_PROBLEM_THRESHOLD) {
+        const unit = reports.get(p.unitId);
+        if (unit) {
+          reports.set(p.unitId, {
+            ...unit,
+            heatProblems: unit.heatProblems + 1,
+          });
+        }
+      }
+      continue;
+    }
+    if (event.type === GameEventType.PhysicalAttackResolved) {
+      const p = event.payload as IPhysicalAttackResolvedPayload;
+      const attacker = reports.get(p.attackerId);
+      if (attacker) {
+        reports.set(p.attackerId, {
+          ...attacker,
+          physicalAttacks: attacker.physicalAttacks + 1,
+        });
+      }
+      continue;
+    }
+  }
+
+  // 3. Extract winner / reason from GameEnded event.
+  const ended = session.events.find((e) => e.type === GameEventType.GameEnded);
+  const endedPayload = ended?.payload as IGameEndedPayload | undefined;
+  const winner = endedPayload?.winner ?? 'draw';
+  const reason = endedPayload?.reason ?? 'destruction';
+
+  const unitReports = Array.from(reports.values());
+  const mvpUnitId = pickMvp(unitReports, winner);
+
+  return {
+    version: 1,
+    matchId: session.id,
+    winner,
+    reason,
+    turnCount: session.currentState.turn,
+    units: unitReports,
+    mvpUnitId,
+    log: session.events,
+  };
+}
+
+/**
+ * Per task 7: human-readable label for a victory reason. Externalized
+ * here so future localization can swap the table.
+ */
+export function victoryReasonLabel(
+  reason: IPostBattleReport['reason'],
+  perspective: 'winner' | 'loser' = 'winner',
+): string {
+  switch (reason) {
+    case 'destruction':
+      return 'Last side standing';
+    case 'concede':
+      return perspective === 'loser' ? 'You conceded' : 'Opponent conceded';
+    case 'turn_limit':
+      return 'Turn limit reached';
+    case 'objective':
+      return 'Objective complete';
+    default:
+      return reason;
+  }
+}


### PR DESCRIPTION
## Summary

Closes the final Lane B engine gap (B3 from the Phase 1 review) and ships the after-action report schema + derivation that the post-battle screen consumes.

**InteractiveSession.concede(side)** (task 1.3 + B3): emits `GameEnded { winner: opposite, reason: 'concede' }`. No-op when game over; idempotent.

**derivePostBattleReport(session)** (task 4 + 8): walks the event log to produce versioned `IPostBattleReport` (`version: 1`) with per-unit damageDealt/damageReceived/kills/heatProblems/physicalAttacks, MVP nomination (winning side, highest damage dealt, ties broken by lowest received then alphabetical), and the full event log. Schema versioning protects against Phase 3 campaign integration breaking stored Phase 1 records.

**victoryReasonLabel(reason, perspective)** (task 7): externalized human-readable labels with winner/loser perspective for the concede case.

Spec gap notes (deferred): concede button UI (task 2 — wiring), victory screen route (task 3), post-battle screen route (task 5), `/api/matches` persistence (task 6 — DB integration), capstone E2E test (task 10.5).

🎉 **Lane B complete**: 6 of 6 UI changes shipped/queued (#309-#314).

## Test plan

- [x] 613 test suites pass (19533 tests, 12 skipped, 0 fail)
- [x] `npx tsc --noEmit` clean
- [x] `npx oxlint` 0 errors (3 pre-existing max-lines warnings)
- [x] `npx next build` passes
- [x] Per-change smoke test \`addVictoryAndPostBattleSummary.smoke.test.ts\` (10 tests, all pass)

Spec: \`openspec/changes/add-victory-and-post-battle-summary/tasks.md\`