### PR TITLE
docs: Phase 6 scope corrections (5 gap-filler OpenSpec changes + master execution plan)

### DIFF
--- a/openspec/changes/PHASE-6-EXECUTION-PLAN.md
+++ b/openspec/changes/PHASE-6-EXECUTION-PLAN.md
@@ -1,0 +1,102 @@
+# Phase 6 Execution Plan — Non-Mech Unit Types (Combined Arms)
+
+**Branch (future):** `feat/phase-6-combined-arms`
+**Roadmap reference:** [docs/plans/2026-04-17-combat-and-multiplayer-roadmap.md](../../docs/plans/2026-04-17-combat-and-multiplayer-roadmap.md) §Phase 6 (lines 224-246)
+**Phase 1-5 status:** ✅ COMPLETE (PRs #301-#324)
+
+---
+
+## Context
+
+Phase 6 brings vehicles, aerospace, BattleArmor, infantry, and ProtoMechs to full parity with the existing mech pipeline. The roadmap specifies: "Each is effectively a mini-phase mirroring the mech work: construction specs → validation → BV → combat behavior → display."
+
+**The pre-authored 15 proposals cover**: construction (5) + BV (5) + combat behavior (5).
+
+**This plan adds 5 gap-filler proposals** to close the UI / rendering / data-import surface the roadmap explicitly called for with "→ display" and that construction proposals explicitly deferred with "Record-sheet PDF layout for vehicles — follow-up work":
+
+| Gap-filler (authored 2026-04-18)              | Covers                                                 |
+| --------------------------------------------- | ------------------------------------------------------ |
+| `add-per-type-customizer-tabs`                | Canonical tab set per type + dispatcher                |
+| `add-per-type-armor-diagrams`                 | Per-type armor diagram components + shared primitive   |
+| `add-multi-type-record-sheet-export`          | Per-type SVG record sheet rendering + extractors       |
+| `add-per-type-hex-tokens`                     | Per-type combat-map tokens (shape/facing/stacking)     |
+| `add-blk-import-per-type`                     | BLK → per-type JSON catalog generation                 |
+
+**Total Phase 6 scope: 20 OpenSpec changes. Rough size: 25 PRs, 4–6 months sequential (can be parallelized per unit type after foundation lands).**
+
+---
+
+## Full change inventory (20 changes)
+
+### Foundation (horizontal, apply to all types)
+1. `add-per-type-customizer-tabs` — tab architecture
+2. `add-per-type-armor-diagrams` — armor diagram per type
+3. `add-multi-type-record-sheet-export` — PDF/SVG export per type
+4. `add-per-type-hex-tokens` — combat map tokens per type
+5. `add-blk-import-per-type` — catalog generation per type
+
+### Vertical per unit type (5 types × 3 changes = 15)
+6. `add-vehicle-construction` + `add-vehicle-battle-value` + `add-vehicle-combat-behavior`
+7. `add-aerospace-construction` + `add-aerospace-battle-value` + `add-aerospace-combat-behavior`
+8. `add-battlearmor-construction` + `add-battlearmor-battle-value` + `add-battlearmor-combat-behavior`
+9. `add-infantry-construction` + `add-infantry-battle-value` + `add-infantry-combat-behavior`
+10. `add-protomech-construction` + `add-protomech-battle-value` + `add-protomech-combat-behavior`
+
+---
+
+## Dependency graph
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Wave 0: Foundation (blocks per-type work)                        │
+│   - add-per-type-customizer-tabs        (locks tab set)          │
+│   - add-per-type-armor-diagrams         (blocks armor tabs)      │
+│   - add-per-type-hex-tokens             (blocks combat UI)       │
+└──────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+    ┌───────────────────────────┬───────────────────────────┐
+    │                           │                           │
+Wave 1-5 (sequential OR parallel per type):
+    │  Each type = 3-change ladder:                         │
+    │    construction → battle-value → combat-behavior      │
+    │                                                       │
+    │  Then consume foundation:                             │
+    │    record-sheet-export (per-type renderer)            │
+    │    blk-import (per-type converter)                    │
+    │                                                       │
+    ▼                                                       │
+  vehicle ──► aerospace ──► battlearmor ──► infantry ──► protomech
+  (priority order per roadmap: most common secondary unit first)
+```
+
+**Recommended sequencing**: Foundation first, then vehicles ship end-to-end (construction → BV → combat → record sheet → BLK import → hex token). Then aerospace the same way. Then BA, infantry, protos. Each type's full stack is one PR or a small PR train.
+
+**Parallelism**: After Foundation, different types can proceed on different agents in parallel IF scoped carefully (the only shared files are the foundation files, which are locked by Wave 0).
+
+---
+
+## Sub-branch execution plan (recommended)
+
+| Wave | Sub-branch                                              | Changes merged                                                                                                                              | Notes                              |
+| ---- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| 0    | `feat/phase-6--foundation`                              | `add-per-type-customizer-tabs`, `add-per-type-armor-diagrams`, `add-per-type-hex-tokens`                                                    | Blocks all per-type work           |
+| 1    | `feat/phase-6--vehicles`                                | `add-vehicle-construction`, `add-vehicle-battle-value`, `add-vehicle-combat-behavior`, vehicle record sheet + vehicle BLK import (per-type deltas of the multi-type changes) | Most common secondary unit         |
+| 2    | `feat/phase-6--aerospace`                               | `add-aerospace-construction`, `add-aerospace-battle-value`, `add-aerospace-combat-behavior`, aerospace record sheet + aerospace BLK import  | Air-to-ground campaigns            |
+| 3    | `feat/phase-6--battlearmor`                             | `add-battlearmor-*` stack + BA record sheet + BA BLK import                                                                                 | Common hostile infantry in contracts |
+| 4    | `feat/phase-6--infantry`                                | `add-infantry-*` stack + infantry record sheet + infantry BLK import                                                                        | Occupy-ground role                 |
+| 5    | `feat/phase-6--protomech`                               | `add-protomech-*` stack + proto record sheet + proto BLK import                                                                             | Niche, Clan-only                   |
+
+Each wave merges to `feat/phase-6-combined-arms` before the next spawns. Waves 1–5 can partially overlap after Foundation provided agents scope file edits tightly.
+
+---
+
+## Done definition
+
+- [ ] All 20 OpenSpec changes' tasks.md fully checked or explicitly deferred
+- [ ] One squashed PR `feat/phase-6-combined-arms` → `main` merged (OR 5 PRs per type)
+- [ ] All 20 changes archived
+- [ ] Roadmap §Phase 6 section marked complete
+- [ ] E2E smoke: build a vehicle, aerospace, BA point, infantry platoon, and ProtoMech point in the customizer; print record sheets; place them all on the combat map and resolve a mixed-forces battle
+- [ ] BLK import populates `public/data/units/{vehicles,aerospace,battlearmor,infantry,protomechs}/` with ≥100 canonical units per type
+- [ ] No regression in existing jest tests

--- a/openspec/changes/PHASE-6-EXECUTION-PLAN.md
+++ b/openspec/changes/PHASE-6-EXECUTION-PLAN.md
@@ -14,13 +14,13 @@ Phase 6 brings vehicles, aerospace, BattleArmor, infantry, and ProtoMechs to ful
 
 **This plan adds 5 gap-filler proposals** to close the UI / rendering / data-import surface the roadmap explicitly called for with "→ display" and that construction proposals explicitly deferred with "Record-sheet PDF layout for vehicles — follow-up work":
 
-| Gap-filler (authored 2026-04-18)              | Covers                                                 |
-| --------------------------------------------- | ------------------------------------------------------ |
-| `add-per-type-customizer-tabs`                | Canonical tab set per type + dispatcher                |
-| `add-per-type-armor-diagrams`                 | Per-type armor diagram components + shared primitive   |
-| `add-multi-type-record-sheet-export`          | Per-type SVG record sheet rendering + extractors       |
-| `add-per-type-hex-tokens`                     | Per-type combat-map tokens (shape/facing/stacking)     |
-| `add-blk-import-per-type`                     | BLK → per-type JSON catalog generation                 |
+| Gap-filler (authored 2026-04-18)     | Covers                                               |
+| ------------------------------------ | ---------------------------------------------------- |
+| `add-per-type-customizer-tabs`       | Canonical tab set per type + dispatcher              |
+| `add-per-type-armor-diagrams`        | Per-type armor diagram components + shared primitive |
+| `add-multi-type-record-sheet-export` | Per-type SVG record sheet rendering + extractors     |
+| `add-per-type-hex-tokens`            | Per-type combat-map tokens (shape/facing/stacking)   |
+| `add-blk-import-per-type`            | BLK → per-type JSON catalog generation               |
 
 **Total Phase 6 scope: 20 OpenSpec changes. Rough size: 25 PRs, 4–6 months sequential (can be parallelized per unit type after foundation lands).**
 
@@ -29,6 +29,7 @@ Phase 6 brings vehicles, aerospace, BattleArmor, infantry, and ProtoMechs to ful
 ## Full change inventory (20 changes)
 
 ### Foundation (horizontal, apply to all types)
+
 1. `add-per-type-customizer-tabs` — tab architecture
 2. `add-per-type-armor-diagrams` — armor diagram per type
 3. `add-multi-type-record-sheet-export` — PDF/SVG export per type
@@ -36,6 +37,7 @@ Phase 6 brings vehicles, aerospace, BattleArmor, infantry, and ProtoMechs to ful
 5. `add-blk-import-per-type` — catalog generation per type
 
 ### Vertical per unit type (5 types × 3 changes = 15)
+
 6. `add-vehicle-construction` + `add-vehicle-battle-value` + `add-vehicle-combat-behavior`
 7. `add-aerospace-construction` + `add-aerospace-battle-value` + `add-aerospace-combat-behavior`
 8. `add-battlearmor-construction` + `add-battlearmor-battle-value` + `add-battlearmor-combat-behavior`
@@ -78,14 +80,14 @@ Wave 1-5 (sequential OR parallel per type):
 
 ## Sub-branch execution plan (recommended)
 
-| Wave | Sub-branch                                              | Changes merged                                                                                                                              | Notes                              |
-| ---- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| 0    | `feat/phase-6--foundation`                              | `add-per-type-customizer-tabs`, `add-per-type-armor-diagrams`, `add-per-type-hex-tokens`                                                    | Blocks all per-type work           |
-| 1    | `feat/phase-6--vehicles`                                | `add-vehicle-construction`, `add-vehicle-battle-value`, `add-vehicle-combat-behavior`, vehicle record sheet + vehicle BLK import (per-type deltas of the multi-type changes) | Most common secondary unit         |
-| 2    | `feat/phase-6--aerospace`                               | `add-aerospace-construction`, `add-aerospace-battle-value`, `add-aerospace-combat-behavior`, aerospace record sheet + aerospace BLK import  | Air-to-ground campaigns            |
-| 3    | `feat/phase-6--battlearmor`                             | `add-battlearmor-*` stack + BA record sheet + BA BLK import                                                                                 | Common hostile infantry in contracts |
-| 4    | `feat/phase-6--infantry`                                | `add-infantry-*` stack + infantry record sheet + infantry BLK import                                                                        | Occupy-ground role                 |
-| 5    | `feat/phase-6--protomech`                               | `add-protomech-*` stack + proto record sheet + proto BLK import                                                                             | Niche, Clan-only                   |
+| Wave | Sub-branch                  | Changes merged                                                                                                                                                               | Notes                                |
+| ---- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| 0    | `feat/phase-6--foundation`  | `add-per-type-customizer-tabs`, `add-per-type-armor-diagrams`, `add-per-type-hex-tokens`                                                                                     | Blocks all per-type work             |
+| 1    | `feat/phase-6--vehicles`    | `add-vehicle-construction`, `add-vehicle-battle-value`, `add-vehicle-combat-behavior`, vehicle record sheet + vehicle BLK import (per-type deltas of the multi-type changes) | Most common secondary unit           |
+| 2    | `feat/phase-6--aerospace`   | `add-aerospace-construction`, `add-aerospace-battle-value`, `add-aerospace-combat-behavior`, aerospace record sheet + aerospace BLK import                                   | Air-to-ground campaigns              |
+| 3    | `feat/phase-6--battlearmor` | `add-battlearmor-*` stack + BA record sheet + BA BLK import                                                                                                                  | Common hostile infantry in contracts |
+| 4    | `feat/phase-6--infantry`    | `add-infantry-*` stack + infantry record sheet + infantry BLK import                                                                                                         | Occupy-ground role                   |
+| 5    | `feat/phase-6--protomech`   | `add-protomech-*` stack + proto record sheet + proto BLK import                                                                                                              | Niche, Clan-only                     |
 
 Each wave merges to `feat/phase-6-combined-arms` before the next spawns. Waves 1–5 can partially overlap after Foundation provided agents scope file edits tightly.
 

--- a/openspec/changes/add-blk-import-per-type/proposal.md
+++ b/openspec/changes/add-blk-import-per-type/proposal.md
@@ -1,0 +1,59 @@
+# Change: Add BLK Import Per Unit Type
+
+## Why
+
+MegaMek's canonical dataset (`mm-data`) ships ~13,000 non-mech unit definitions as `.blk` files (vehicles, aerospace, BattleArmor, infantry, ProtoMechs). MekStation's `src/services/conversion/BlkParserService.ts` can read the raw BLK format but the parsed output is NOT wired into per-type catalogs — today only mechs (`.mtf`) populate `public/data/units/battlemechs/` via the `convert:mtf` pipeline. Without a matching BLK import pipeline, Phase 6 proposals will ship with empty catalogs for each non-mech type, forcing users to hand-build every unit. This change wires BLK parsing into per-type catalog generation so the Phase 6 customizers open with real data.
+
+## What Changes
+
+- Extend `BlkParserService` to dispatch to per-type extractors based on BLK `<UnitType>` tag (CombatVehicle / AeroSpaceFighter / ConventionalFighter / SmallCraft / BattleArmor / Infantry / ProtoMech)
+- Add per-type BLK → JSON converters under `scripts/megameklab-conversion/`:
+  - `blk_vehicle_converter.py`
+  - `blk_aerospace_converter.py`
+  - `blk_battlearmor_converter.py`
+  - `blk_infantry_converter.py`
+  - `blk_protomech_converter.py`
+- Each converter produces unit JSON conforming to the corresponding `I<Type>Unit` shape from the matching construction proposal
+- Extend the main `convert:mtf` npm script (or add `convert:blk`) to run all 5 per-type converters on `E:\Projects\mm-data\data\` and write outputs to `public/data/units/<type>/`
+- Add unit-data index files per type (mirrors existing `public/data/units/battlemechs/units-manifest.json`)
+- Add BLK parity validation (mirrors `mtf-parity-validation` spec): compare key fields (tonnage, BV, equipment) against expected MegaMek values for a sample fixture per type
+- Handle BLK-specific quirks:
+  - BLK equipment lines use different naming than MTF (`IS ER Medium Laser` vs `ISERLargeLaser`) — reuse existing `EquipmentNameMapper` aliases
+  - BLK locations differ per unit type (Front/Rear/LS/RS for vehicles vs Nose/LW/RW/Aft for aerospace)
+  - Some BLK files have configuration blocks that the mech pipeline doesn't understand
+- Log + report unsupported BLK variants (DropShips, JumpShips, WarShips, LAMs, QuadVees are Phase 6 non-goals and SHOULD be skipped with a warning)
+
+## Non-goals
+
+- Support vehicle BAR tables beyond what `add-vehicle-construction` defines
+- DropShip / JumpShip / WarShip / LAM / QuadVee import — explicitly skipped with log
+- Runtime editing of catalog files from the app — catalog is build-time generated; UI imports from `public/data/`
+- Python → TypeScript rewrite of the converters — keep the existing Python pipeline pattern
+
+## Dependencies
+
+- **Requires**: `add-vehicle-construction`, `add-aerospace-construction`, `add-battlearmor-construction`, `add-infantry-construction`, `add-protomech-construction` (each defines the target data shape), existing `BlkParserService`, existing Python MTF converter as a reference
+- **Required by**: none directly — users benefit from populated catalogs immediately after each type lands
+- **Phase coupling**: none
+
+## Ordering in Phase 6
+
+Ship one converter per unit type, AFTER that type's construction proposal has stabilized the target shape:
+
+```
+add-vehicle-construction        → blk_vehicle_converter + 4000 vehicles
+add-aerospace-construction      → blk_aerospace_converter + 2000 aerospace
+add-battlearmor-construction    → blk_battlearmor_converter + 800 BA
+add-infantry-construction       → blk_infantry_converter + 500 infantry
+add-protomech-construction      → blk_protomech_converter + 150 protos
+```
+
+Each sub-task ships an empty JSON for unsupported variants and a parity report.
+
+## Impact
+
+- **Affected specs**: a new `unit-data-import` capability spec is created (or an existing conversion/import spec is extended — authorship discretion)
+- **Affected code**: `src/services/conversion/BlkParserService.ts`, `scripts/megameklab-conversion/*.py` (new converters), `package.json` scripts
+- **New files**: 5 Python converter scripts, parity validation reports, per-type `units-manifest.json`, populated `public/data/units/vehicles/`, `aerospace/`, `battlearmor/`, `infantry/`, `protomechs/`
+- **Data delta**: ~13,000 new JSON unit files (expect ~50–200 MB of new data; committed selectively — canonicals only; variants fetched on demand)
+- **No runtime behavior change for mechs**

--- a/openspec/changes/add-blk-import-per-type/specs/unit-data-import/spec.md
+++ b/openspec/changes/add-blk-import-per-type/specs/unit-data-import/spec.md
@@ -1,0 +1,117 @@
+# unit-data-import (delta — NEW CAPABILITY)
+
+## ADDED Requirements
+
+### Requirement: BLK Parser Dispatches By Unit Type
+
+`BlkParserService.parseByUnitType(doc)` SHALL dispatch on the BLK document's `<UnitType>` tag and return a discriminated union typed to the specific unit kind.
+
+**Rationale**: MegaMek's BLK format covers 6+ unit kinds with substantially different schemas. A single parse output loses type safety.
+
+**Priority**: Critical
+
+#### Scenario: CombatVehicle dispatched
+
+- **GIVEN** a BLK document with `<UnitType>Tank</UnitType>`
+- **WHEN** `parseByUnitType` runs
+- **THEN** it SHALL return `{ kind: 'vehicle', data: IVehicleBlkResult }`
+
+#### Scenario: AeroSpaceFighter dispatched
+
+- **GIVEN** a BLK document with `<UnitType>Aero</UnitType>`
+- **WHEN** `parseByUnitType` runs
+- **THEN** it SHALL return `{ kind: 'aerospace', data: IAerospaceBlkResult }`
+
+#### Scenario: Unsupported WarShip logged + skipped
+
+- **GIVEN** a BLK document with `<UnitType>Warship</UnitType>`
+- **WHEN** `parseByUnitType` runs
+- **THEN** it SHALL return `{ kind: 'unsupported', reason: 'warship' }` and log a warning
+
+---
+
+### Requirement: Per-Type JSON Output Conforming To Construction Types
+
+Each per-type converter SHALL emit JSON files conforming to the `I<Type>Unit` interface defined by the corresponding construction spec, validated against the zod schema before writing.
+
+**Priority**: Critical
+
+#### Scenario: Vehicle output validates against IVehicleUnit
+
+- **GIVEN** a parsed BLK for a 50-ton Manticore tank
+- **WHEN** the vehicle converter runs
+- **THEN** the output JSON SHALL be parseable by the `IVehicleUnit` zod schema defined in `add-vehicle-construction` with no validation errors
+
+#### Scenario: Aerospace output validates against IAerospaceUnit
+
+- **GIVEN** a parsed BLK for a Shilone aerospace fighter
+- **WHEN** the aerospace converter runs
+- **THEN** the output JSON SHALL be parseable by the `IAerospaceUnit` zod schema and include `structuralIntegrity`, `safeThrust`, `maxThrust`, `fuelPoints`
+
+---
+
+### Requirement: Parity Validation Against MegaMek Expected Values
+
+Each converter SHALL emit a parity report comparing key fields (tonnage, BV, equipment list length) against expected MegaMek/MUL values for a sample set of 10 canonical units per type.
+
+**Priority**: High
+
+#### Scenario: Parity report generated
+
+- **GIVEN** the vehicle converter run on the mm-data source directory
+- **WHEN** the convert:blk script completes
+- **THEN** a `validation-output/blk-vehicle-parity.json` report SHALL exist containing per-unit tonnage/BV/equipment-count comparison
+
+#### Scenario: Parity regression fails build
+
+- **GIVEN** an intentional regression in the vehicle converter
+- **WHEN** convert:blk is run
+- **THEN** the script SHALL exit with a non-zero status if any canonical unit's BV differs from expected by > 2%
+
+---
+
+### Requirement: Equipment Name Alias Reuse
+
+The BLK converters SHALL reuse the existing `EquipmentNameMapper` aliases so BLK equipment names resolve to the same internal equipment IDs used by the MTF pipeline.
+
+**Priority**: High
+
+#### Scenario: BLK name maps to canonical id
+
+- **GIVEN** a BLK equipment line reading `IS ER Medium Laser`
+- **WHEN** the converter resolves the equipment
+- **THEN** it SHALL produce the same equipment id as the MTF pipeline produces for `ISERMediumLaser`
+
+---
+
+### Requirement: Per-Type Unit Manifest
+
+Each type's converter SHALL write a `units-manifest.json` at `public/data/units/<type>/units-manifest.json` listing every converted unit with id, chassis, model, tonnage, BV — used by the app for manifest-driven lazy loading.
+
+**Priority**: High
+
+#### Scenario: Manifest lists all converted vehicles
+
+- **GIVEN** a successful vehicle converter run producing 4000 vehicle JSON files
+- **WHEN** the manifest is inspected
+- **THEN** it SHALL contain 4000 entries, each with id, chassis, model, tonnage, BV
+
+#### Scenario: Manifest size budget
+
+- **GIVEN** any per-type manifest
+- **WHEN** serialized to disk
+- **THEN** its size SHALL be under 5 MB (enforces concise per-entry metadata)
+
+---
+
+### Requirement: Unsupported Chassis Logged And Counted
+
+The converters SHALL log and skip unsupported chassis (WarShip, DropShip, JumpShip, LAM, QuadVee, Mobile Structure) and emit a post-run summary with counts per unsupported type.
+
+**Priority**: Medium
+
+#### Scenario: Unsupported summary
+
+- **GIVEN** the convert:blk run encounters 120 DropShip BLK files and 30 LAMs
+- **WHEN** the run completes
+- **THEN** a summary line SHALL report "Skipped: 120 dropship, 30 lam" — without failing the build

--- a/openspec/changes/add-blk-import-per-type/tasks.md
+++ b/openspec/changes/add-blk-import-per-type/tasks.md
@@ -1,0 +1,82 @@
+# Tasks: Add BLK Import Per Unit Type
+
+## 1. Parser Extension
+
+- [ ] 1.1 Extend `BlkParserService` with `parseByUnitType(doc): Discriminated<I{Type}BlkParseResult>` dispatcher
+- [ ] 1.2 Per-type result types (VehicleBlkResult, AerospaceBlkResult, etc.) tagged on unit type
+- [ ] 1.3 Unit tests: each type's representative BLK fixture parses into the correct shape
+- [ ] 1.4 Document BLK quirks per type in a `BLK_QUIRKS.md` README
+
+## 2. Vehicle Converter
+
+- [ ] 2.1 Create `scripts/megameklab-conversion/blk_vehicle_converter.py`
+- [ ] 2.2 Parse BLK and emit `public/data/units/vehicles/<name>.json` conforming to `IVehicleUnit` from `add-vehicle-construction`
+- [ ] 2.3 Handle motion-type mapping (MegaMek's `TANK` / `VTOL` / `HOVER` / etc. → our `MotionType` enum)
+- [ ] 2.4 Map equipment names via existing aliases
+- [ ] 2.5 Skip unsupported chassis (WarShip/DropShip/JumpShip) with a warning log
+- [ ] 2.6 Generate `units-manifest.json` for vehicles
+- [ ] 2.7 Parity check: pick 10 canonical vehicles (Demolisher, Manticore, LRM Carrier, etc.) and assert BV + tonnage match MUL data within 2%
+
+## 3. Aerospace Converter
+
+- [ ] 3.1 Create `blk_aerospace_converter.py`
+- [ ] 3.2 Parse BLK and emit `public/data/units/aerospace/<name>.json` conforming to `IAerospaceUnit`
+- [ ] 3.3 Handle chassis type split: AeroSpaceFighter / ConventionalFighter / SmallCraft
+- [ ] 3.4 Map arc-based locations (Nose/LW/RW/Aft) from BLK's location tags
+- [ ] 3.5 SI (Structural Integrity) extraction
+- [ ] 3.6 Bomb bay slot extraction
+- [ ] 3.7 Parity check on 10 canonical aerospace (Shilone, Stuka, etc.)
+
+## 4. BattleArmor Converter
+
+- [ ] 4.1 Create `blk_battlearmor_converter.py`
+- [ ] 4.2 Parse BLK and emit `public/data/units/battlearmor/<name>.json` conforming to `IBattleArmorUnit`
+- [ ] 4.3 Extract manipulator types per arm
+- [ ] 4.4 Extract modular weapon mount configuration
+- [ ] 4.5 Extract AP weapon per trooper
+- [ ] 4.6 Handle squad size (4 for IS, 5 for Clan, 6 for Star League)
+- [ ] 4.7 Parity check on 10 canonical BA (Elemental, Kage, Gnome, Marauder BA, etc.)
+
+## 5. Infantry Converter
+
+- [ ] 5.1 Create `blk_infantry_converter.py`
+- [ ] 5.2 Parse BLK and emit `public/data/units/infantry/<name>.json` conforming to `IInfantryUnit`
+- [ ] 5.3 Extract platoon composition (squads × troopers per squad)
+- [ ] 5.4 Extract motive type
+- [ ] 5.5 Extract primary + secondary weapon references
+- [ ] 5.6 Extract field gun assignments
+- [ ] 5.7 Extract specialization
+- [ ] 5.8 Parity check on 10 canonical infantry (foot rifle, motorized jump, marine, mountain, etc.)
+
+## 6. ProtoMech Converter
+
+- [ ] 6.1 Create `blk_protomech_converter.py`
+- [ ] 6.2 Parse BLK and emit `public/data/units/protomechs/<name>.json` conforming to `IProtoMechUnit`
+- [ ] 6.3 Extract 5-location armor + optional main gun
+- [ ] 6.4 Extract glider-mode flag
+- [ ] 6.5 Extract UMU / jump
+- [ ] 6.6 Parity check on 10 canonical protos (Roc, Minotaur, Siren, etc.)
+
+## 7. NPM Script Integration
+
+- [ ] 7.1 Add `convert:blk` npm script that runs all 5 converters in sequence
+- [ ] 7.2 Accept `--type=<type>` flag to run a single converter
+- [ ] 7.3 Write a converter log file with skip/error counts
+- [ ] 7.4 Exit non-zero on parity regression vs baseline
+
+## 8. Data Manifest
+
+- [ ] 8.1 One `units-manifest.json` per type listing all unit ids and basic metadata (chassis, model, tonnage, BV)
+- [ ] 8.2 App loads manifest first, then fetches individual unit files on demand
+- [ ] 8.3 Size budget check: manifests < 5MB each
+
+## 9. Unsupported Variants
+
+- [ ] 9.1 Enumerate Phase-6-unsupported chassis: WarShip, DropShip, JumpShip, LAM, QuadVee, Mobile Structure
+- [ ] 9.2 Converters log + skip + count these
+- [ ] 9.3 Post-run summary reports counts per unsupported type
+
+## 10. Spec Compliance
+
+- [ ] 10.1 Every `### Requirement:` in the `unit-data-import` spec delta has a `#### Scenario:`
+- [ ] 10.2 `openspec validate add-blk-import-per-type --strict` passes

--- a/openspec/changes/add-multi-type-record-sheet-export/proposal.md
+++ b/openspec/changes/add-multi-type-record-sheet-export/proposal.md
@@ -1,0 +1,54 @@
+# Change: Add Multi-Type Record Sheet Export
+
+## Why
+
+The `RecordSheetService` + SVG renderer pipeline shipped for BattleMechs and handles nothing else today. Every Phase 6 unit-construction proposal explicitly defers its record-sheet layout (vehicle construction's Non-goals: "Record-sheet PDF layout for vehicles — follow-up work"), and the four sibling types (aerospace, BattleArmor, infantry, ProtoMech) inherit the same deferral by pattern. Without per-type layouts, a player who builds a vehicle in the customizer cannot print or PDF it — breaking feature parity with mechs and preventing Phase 6 from meeting its "each type mirrors the mech work" roadmap goal.
+
+This change extends the record-sheet export pipeline to all 5 non-mech unit types so Phase 6 construction work lands with a printable artifact, not a half-built surface.
+
+## What Changes
+
+- Extend `IRecordSheetData` with a discriminated `unitType` tag and per-type payload variants: `IMechRecordSheetData` (existing, renamed), `IVehicleRecordSheetData`, `IAerospaceRecordSheetData`, `IBattleArmorRecordSheetData`, `IInfantryRecordSheetData`, `IProtoMechRecordSheetData`
+- Add per-type SVG renderers under `src/services/printing/svgRecordSheetRenderer/` — one module per type (`vehicleRenderer.ts`, `aerospaceRenderer.ts`, `battleArmorRenderer.ts`, `infantryRenderer.ts`, `protoMechRenderer.ts`) — with layouts matching the canonical Total Warfare / TechManual record sheets
+- Extend `RecordSheetService.extractData(unit)` to dispatch on `unit.type` and delegate to type-specific extractors
+- Add per-type SVG templates (6–8 vehicle locations, 4 aerospace arcs, BA squad pip grid, infantry platoon block, ProtoMech 5-location compact sheet) — fetched from mm-data CDN where available, falling back to generated layouts
+- Add per-type armor pip layout helpers (mirrors mech's `armor.ts` renderer but with per-type geometry)
+- Add per-type equipment list renderer (vehicles show Front/Side/Rear/Turret columns; aerospace shows Nose/L-Wing/R-Wing/Aft; BA shows per-trooper; infantry shows platoon weapons + field gun)
+- Add per-type crew/pilot block (vehicles: driver + gunner + commander; aerospace: pilot; BA: per-suit troopers; infantry: platoon morale + training; ProtoMech: point pilots)
+- Extend `recordsheet/spaSection.ts` (Phase 5) to render correctly against each type's pilot block
+- Add Jest snapshot tests for each renderer with representative fixtures
+
+## Non-goals
+
+- Printing/export UI changes — existing `/print` page routes all types through one dispatcher
+- PDF engine swap — we keep the current SVG → PDF pipeline, only add per-type SVG output
+- Record sheet for DropShips, JumpShips, WarShips, LAMs, QuadVees — out of Phase 6 scope
+- Fluff / biography section changes — unchanged from mech layout pattern
+- Printed Special Abilities block — Phase 5 already shipped; per-type work just ensures it fits the per-type pilot area
+
+## Dependencies
+
+- **Requires**: `add-vehicle-construction`, `add-aerospace-construction`, `add-battlearmor-construction`, `add-infantry-construction`, `add-protomech-construction` (each needs valid type-specific data flowing into `extractData`)
+- **Required by**: none — terminal change in Phase 6 per unit type
+- **Phase 5 coupling**: Special Abilities section (shipped) must continue to work across all 5 new layouts
+
+## Ordering in Phase 6
+
+Ship one type's layout immediately after its construction change lands:
+
+```
+vehicle-construction    → vehicle-record-sheet    (sub-task of this change)
+aerospace-construction  → aerospace-record-sheet
+battlearmor-construction → battlearmor-record-sheet
+infantry-construction   → infantry-record-sheet
+protomech-construction  → protomech-record-sheet
+```
+
+Each sub-task is self-contained; agents can parallelize per type once their construction dependency is merged.
+
+## Impact
+
+- **Affected specs**: `record-sheet-export` (ADDED: per-type data model, per-type renderer contracts, per-type snapshot tests)
+- **Affected code**: `src/services/printing/RecordSheetService.ts`, `src/services/printing/svgRecordSheetRenderer/*`, `src/types/printing/RecordSheetTypes.ts`
+- **New files**: 5 new per-type renderer modules, 5 new per-type extractor modules, 5 fixture sets
+- **No schema change**: per-type unit records already exist from their construction changes; this change only reads them

--- a/openspec/changes/add-multi-type-record-sheet-export/specs/record-sheet-export/spec.md
+++ b/openspec/changes/add-multi-type-record-sheet-export/specs/record-sheet-export/spec.md
@@ -1,0 +1,139 @@
+# record-sheet-export (delta)
+
+## ADDED Requirements
+
+### Requirement: Discriminated Per-Type Record Sheet Data Model
+
+The `IRecordSheetData` type SHALL be a discriminated union tagged on `unitType`, with one variant per supported unit type: `mech`, `vehicle`, `aerospace`, `battlearmor`, `infantry`, `protomech`.
+
+**Rationale**: Each unit type has fundamentally different armor geometry, movement profile, crew model, and equipment layout. A single flat payload cannot represent all 6 shapes safely. Discriminated unions preserve type safety at the extractor → renderer boundary.
+
+**Priority**: Critical
+
+#### Scenario: Mech variant preserves existing shape
+
+- **GIVEN** an `IBattleMech` passed to `RecordSheetService.extractData`
+- **WHEN** the extractor runs
+- **THEN** the return value SHALL have `unitType: 'mech'` and the existing mech record-sheet fields (identity, movement, armor per mech location, critical slots, heat sinks)
+
+#### Scenario: Vehicle variant includes motive data
+
+- **GIVEN** an `IVehicleUnit` with motion type Tracked, turret Single
+- **WHEN** extracted
+- **THEN** the return value SHALL have `unitType: 'vehicle'`, `motionType: 'Tracked'`, armor payload covering 5 locations (Front/LSide/RSide/Rear/Turret), and crew payload with driver + gunner
+
+#### Scenario: Aerospace variant includes SI and fuel
+
+- **GIVEN** an `IAerospaceUnit` (aerospace fighter, 50t)
+- **WHEN** extracted
+- **THEN** the return value SHALL have `unitType: 'aerospace'`, armor per 4 arcs, `structuralIntegrity`, `fuelPoints`, `safeThrust`, `maxThrust`, and pilot payload
+
+#### Scenario: Unknown unit type rejected
+
+- **GIVEN** a unit with `type: 'warship'`
+- **WHEN** extraction is attempted
+- **THEN** the service SHALL throw `UnsupportedUnitTypeError` with the unsupported type in the message
+
+---
+
+### Requirement: Per-Type SVG Renderers
+
+The system SHALL provide a dedicated SVG renderer module per unit type, each consuming its matching `IRecordSheetData` variant and producing an SVG string conforming to the canonical Total Warfare record-sheet layout for that type.
+
+**Priority**: Critical
+
+#### Scenario: Renderer dispatch by variant tag
+
+- **GIVEN** an `IVehicleRecordSheetData` payload
+- **WHEN** the top-level `renderer.ts` dispatcher is called
+- **THEN** it SHALL delegate to `vehicleRenderer.render(data)` and return the resulting SVG
+
+#### Scenario: Vehicle armor diagram geometry
+
+- **GIVEN** a VTOL unit with Rotor location
+- **WHEN** the vehicle renderer runs
+- **THEN** the output SVG SHALL include both a standard 4-side armor diagram AND a separate Rotor location block
+
+#### Scenario: Aerospace 4-arc diagram
+
+- **GIVEN** any aerospace unit
+- **WHEN** the aerospace renderer runs
+- **THEN** the output SVG SHALL show armor pips for Nose, Left Wing, Right Wing, Aft arcs — no front/rear as mechs use
+
+#### Scenario: BattleArmor per-trooper grid
+
+- **GIVEN** a 5-trooper Elemental point
+- **WHEN** the battlearmor renderer runs
+- **THEN** the output SVG SHALL show 5 distinct trooper columns, each with its own armor pip grid and loadout section
+
+#### Scenario: Infantry platoon counter (no per-location armor)
+
+- **GIVEN** a 28-trooper foot rifle platoon
+- **WHEN** the infantry renderer runs
+- **THEN** the output SVG SHALL show a platoon-size counter rather than per-location armor pips, plus primary + secondary weapon blocks
+
+#### Scenario: ProtoMech 5-location compact sheet
+
+- **GIVEN** a 5-proto point
+- **WHEN** the protomech renderer runs
+- **THEN** the output SVG SHALL render 5 compact per-proto sheets on one page, each with the 5-location (Head/Torso/LA/RA/Legs/±MainGun) diagram
+
+---
+
+### Requirement: Per-Type Extractors
+
+The `RecordSheetService` SHALL route `extractData(unit)` to a type-specific extractor by `unit.type`, each producing the matching variant of `IRecordSheetData`.
+
+**Priority**: Critical
+
+#### Scenario: Vehicle extractor populates crew
+
+- **GIVEN** a 40-ton Hover vehicle with crew configured (driver + gunner)
+- **WHEN** `extractVehicleData(unit)` runs
+- **THEN** the result's `crew` field SHALL list the driver and gunner with their skills, and the commander field SHALL be absent (no commander on 40t)
+
+#### Scenario: BattleArmor extractor populates per-suit
+
+- **GIVEN** a 5-trooper point with modular weapon mounts
+- **WHEN** `extractBattleArmorData(unit)` runs
+- **THEN** the result SHALL contain 5 entries in `troopers`, each with the currently-selected modular weapon and AP sidearm
+
+#### Scenario: Infantry extractor populates field gun
+
+- **GIVEN** a 28-trooper platoon with 4 field guns
+- **WHEN** `extractInfantryData(unit)` runs
+- **THEN** the result SHALL contain a `fieldGun` block with 4 guns, reflecting the 1-gun-per-7-troopers rule
+
+---
+
+### Requirement: SPA Block Positioning Per Type
+
+The Special Abilities SVG section (shipped in Phase 5) SHALL be anchored within each per-type renderer's pilot area, not at a mech-only coordinate.
+
+**Priority**: High
+
+#### Scenario: Vehicle SPA block anchored in crew area
+
+- **GIVEN** a vehicle with a driver who has the Melee Specialist SPA
+- **WHEN** the vehicle renderer runs
+- **THEN** the Special Abilities block SHALL render within the crew section of the vehicle sheet, not at the mech pilot coordinate (360, 690)
+
+#### Scenario: BattleArmor SPA block per-trooper
+
+- **GIVEN** a point where trooper 1 has Marksman SPA
+- **WHEN** the battlearmor renderer runs
+- **THEN** the SPA SHALL display next to trooper 1's pilot block, not on a shared sheet footer
+
+---
+
+### Requirement: Snapshot Test Coverage
+
+Every per-type renderer SHALL have at least one Jest snapshot test with a representative fixture, and the snapshot SHALL be committed alongside the renderer.
+
+**Priority**: High
+
+#### Scenario: Snapshot captures geometry regression
+
+- **GIVEN** the vehicle renderer's snapshot test running on a 50t tracked tank fixture
+- **WHEN** the armor location geometry changes (e.g., a location is accidentally removed)
+- **THEN** the snapshot assertion SHALL fail with a diff showing the missing location

--- a/openspec/changes/add-multi-type-record-sheet-export/tasks.md
+++ b/openspec/changes/add-multi-type-record-sheet-export/tasks.md
@@ -1,0 +1,82 @@
+# Tasks: Add Multi-Type Record Sheet Export
+
+## 1. Data Model
+
+- [ ] 1.1 Extend `IRecordSheetData` as a discriminated union tagged on `unitType: 'mech' | 'vehicle' | 'aerospace' | 'battlearmor' | 'infantry' | 'protomech'`
+- [ ] 1.2 Rename the existing mech payload to `IMechRecordSheetData`
+- [ ] 1.3 Add `IVehicleRecordSheetData` with: motionType, crew, turretConfig, armor per location (6–8 locations), equipment per location, BAR rating (optional)
+- [ ] 1.4 Add `IAerospaceRecordSheetData` with: SI (structural integrity), fuel, thrust/velocity caps, heat sinks, armor per arc (Nose/LW/RW/Aft), equipment per arc, bomb bay
+- [ ] 1.5 Add `IBattleArmorRecordSheetData` with: squad size, per-trooper armor pips, manipulators, modular weapon mounts, AP weapons, UMU/jump/VTOL
+- [ ] 1.6 Add `IInfantryRecordSheetData` with: platoon size, motive type, primary weapon, secondary weapons (AP ratio), field gun block (if any), specialization
+- [ ] 1.7 Add `IProtoMechRecordSheetData` with: 5 locations (Head/Torso/LeftArm/RightArm/Legs/MainGun), main gun designation, point composition (1–5 protos per point), UMU/glider flags
+- [ ] 1.8 Zod schemas for each variant
+
+## 2. Service Dispatch
+
+- [ ] 2.1 `RecordSheetService.extractData(unit)` dispatches on `unit.type` to type-specific `extract<Type>Data(unit)` extractors
+- [ ] 2.2 Each extractor lives in its own module under `src/services/printing/recordsheet/` (co-located with existing mech extractor)
+- [ ] 2.3 Unknown unit types throw `UnsupportedUnitTypeError`
+
+## 3. Vehicle Record Sheet
+
+- [ ] 3.1 Add `vehicleRenderer.ts` in `svgRecordSheetRenderer/`
+- [ ] 3.2 Render 6–8 armor locations (Front/LSide/RSide/Rear/Turret/(Rotor)/(Chin)/(Body)) with correct geometry
+- [ ] 3.3 Render motive table (cruise/flank MP) + motion type badge
+- [ ] 3.4 Render crew block: driver, gunner, commander (as applicable)
+- [ ] 3.5 Render turret weapons separately from hull weapons
+- [ ] 3.6 Render BAR rating for support vehicles
+- [ ] 3.7 Snapshot test with a representative 50t tracked tank fixture
+
+## 4. Aerospace Record Sheet
+
+- [ ] 4.1 Add `aerospaceRenderer.ts`
+- [ ] 4.2 Render 4-arc armor diagram (Nose/LW/RW/Aft) + SI bar
+- [ ] 4.3 Render heat chart (aerospace uses different thresholds than mechs)
+- [ ] 4.4 Render thrust/velocity table
+- [ ] 4.5 Render fuel track
+- [ ] 4.6 Render bomb bay slots if present
+- [ ] 4.7 Render pilot block (gunnery + piloting, edge)
+- [ ] 4.8 Snapshot test with a Shilone and a Stuka fixture
+
+## 5. BattleArmor Record Sheet
+
+- [ ] 5.1 Add `battleArmorRenderer.ts`
+- [ ] 5.2 Render per-trooper armor pip grid (4–6 troopers × per-suit pips)
+- [ ] 5.3 Render modular weapon mounts (selected weapon shown)
+- [ ] 5.4 Render AP (anti-personnel) weapons
+- [ ] 5.5 Render manipulator type per arm
+- [ ] 5.6 Render jump/UMU/VTOL jets
+- [ ] 5.7 Render per-suit pilot block (gunnery + anti-mech skill)
+- [ ] 5.8 Snapshot test with an Elemental and a Kage fixture
+
+## 6. Infantry Record Sheet
+
+- [ ] 6.1 Add `infantryRenderer.ts`
+- [ ] 6.2 Render platoon size counter (troopers alive / max)
+- [ ] 6.3 Render primary weapon stats (damage, range, ammo if applicable)
+- [ ] 6.4 Render secondary weapons block (AP weapons, ratio)
+- [ ] 6.5 Render field gun block (if present — 1 gun per 7 men rule)
+- [ ] 6.6 Render motive type (Foot / Motorized / Jump / Mechanized / Beast)
+- [ ] 6.7 Render specialization badge (anti-mech / marine / scuba / mountain / xct)
+- [ ] 6.8 Snapshot test with a foot rifle platoon and a marine jump platoon fixture
+
+## 7. ProtoMech Record Sheet
+
+- [ ] 7.1 Add `protoMechRenderer.ts`
+- [ ] 7.2 Render 5-location armor diagram (Head/Torso/LA/RA/Legs/(MainGun))
+- [ ] 7.3 Render main gun designation and ammo
+- [ ] 7.4 Render point composition (up to 5 protos in one sheet)
+- [ ] 7.5 Render UMU/glider flags
+- [ ] 7.6 Render point pilot block
+- [ ] 7.7 Snapshot test with a Roc and a Minotaur point fixture
+
+## 8. Integration
+
+- [ ] 8.1 Existing `/print/[id]` page routes all unit types through the extended `RecordSheetService`
+- [ ] 8.2 Existing `recordsheet/spaSection.ts` (Phase 5) is called from every per-type renderer at the appropriate pilot-area coordinate
+- [ ] 8.3 `renderer.ts` top-level dispatch picks the per-type renderer by `data.unitType`
+
+## 9. Spec Compliance
+
+- [ ] 9.1 Every `### Requirement:` in the `record-sheet-export` spec delta has a `#### Scenario:`
+- [ ] 9.2 `openspec validate add-multi-type-record-sheet-export --strict` passes

--- a/openspec/changes/add-per-type-armor-diagrams/proposal.md
+++ b/openspec/changes/add-per-type-armor-diagrams/proposal.md
@@ -1,0 +1,74 @@
+# Change: Add Per-Type Armor Diagrams
+
+## Why
+
+The armor diagram is the centerpiece of the customizer's Armor tab. Mechs have an established 8-front-location + 3-rear-location diagram under `src/components/customizer/armor/ArmorDiagram.tsx`. Each non-mech type has fundamentally different armor geometry:
+
+- **Vehicle**: 4 cardinal sides + optional Turret + optional Rotor (VTOL) + optional Chin Turret (VTOL) + optional Body (support)
+- **Aerospace**: 4 arcs — Nose, Left Wing, Right Wing, Aft — no front/rear distinction
+- **BattleArmor**: per-trooper armor pips (each of 4–6 troopers has its own armor pool)
+- **Infantry**: NO per-location armor; a platoon-size counter replaces the diagram
+- **ProtoMech**: 5 locations — Head, Torso, Left Arm, Right Arm, Legs + optional Main Gun
+
+The scaffolds `VehicleDiagram.tsx`, `AerospaceDiagram.tsx`, `BattleArmorDiagram.tsx` exist but are placeholders. Without a real per-type diagram, the Armor tab can't render correctly for non-mechs, the validation UI can't highlight which location is over-allocated, and the auto-allocate button can't distribute points. This change delivers the diagrams.
+
+## What Changes
+
+- Add `src/components/customizer/armor/VehicleArmorDiagram.tsx` (or replace the existing placeholder) with:
+  - 4-side SVG geometry + optional Turret / Rotor / Chin / Body locations
+  - Conditional rendering based on `vehicle.motionType` (VTOL shows Rotor; support shows Body; etc.)
+  - Per-location armor input with current/max indicators
+  - Auto-allocate button honoring TechManual distribution tables
+- Add `src/components/customizer/armor/AerospaceArmorDiagram.tsx`:
+  - 4-arc SVG (Nose/LW/RW/Aft) with capital-ship–style arc labels
+  - SI (Structural Integrity) bar separate from armor
+  - Per-arc capacity enforced from aerospace-unit-system rules
+- Add `src/components/customizer/armor/BattleArmorPipGrid.tsx`:
+  - Per-trooper armor pip display (suit pips × N troopers)
+  - Damage tracking model (pips clear as damage is taken — consumed by combat UI)
+  - Modular weapon indicator alongside the pip grid
+- Add `src/components/customizer/armor/InfantryPlatoonCounter.tsx`:
+  - Large counter showing remaining/max troopers
+  - Color-coded thresholds (green >75%, yellow >25%, red ≤25%)
+  - "No per-location armor" label for clarity
+- Add `src/components/customizer/armor/ProtoMechArmorDiagram.tsx`:
+  - 5-location compact SVG (Head/Torso/LA/RA/Legs + optional Main Gun)
+  - Compact layout to allow 1–5 protos on one screen when showing a point
+- Extract a shared `<ArmorPipRow>` primitive so every diagram reuses the same pip rendering primitive
+- Add a diagram-selector in the Armor tab that picks the correct component by `unit.type`
+- Storybook stories per diagram + Jest snapshot tests per diagram
+
+## Non-goals
+
+- Armor allocation business logic (max points per location, distribution rules) — that lives in each `add-<type>-construction` proposal
+- Animation / damage effects on the diagram during combat — Phase 7 art polish
+- Printed record sheet armor rendering — `add-multi-type-record-sheet-export` territory
+- Color theme customization — reuses existing theme tokens
+
+## Dependencies
+
+- **Requires**: `add-per-type-customizer-tabs` (needs the Armor tab to exist per type), each `add-<type>-construction` change (needs the per-location data model)
+- **Required by**: `add-multi-type-record-sheet-export` (share armor geometry helpers where possible)
+- **Phase 1 coupling**: none (customizer UI only)
+
+## Ordering in Phase 6
+
+Ship after customizer-tabs lands and in parallel with or after each type's construction proposal:
+
+```
+add-per-type-customizer-tabs       (Wave 0)
+         │
+         ├──► add-<type>-construction  (Wave 1+, one per type)
+         │           │
+         │           ▼
+         └──► add-per-type-armor-diagrams  (can ship alongside or after each construction)
+```
+
+Agents can ship one diagram at a time (vehicle first, then aerospace, etc.) or all 5 in a single PR.
+
+## Impact
+
+- **Affected specs**: `armor-diagram` (ADDED: per-type diagram requirements, per-type geometry, shared primitives, diagram-selector)
+- **Affected code**: `src/components/customizer/armor/*`, existing `Diagram.tsx` stubs in each per-type folder
+- **New files**: 5 per-type diagram components, shared `ArmorPipRow`, diagram-selector, 5 Storybook stories, 5 test files
+- **No schema change**

--- a/openspec/changes/add-per-type-armor-diagrams/specs/armor-diagram/spec.md
+++ b/openspec/changes/add-per-type-armor-diagrams/specs/armor-diagram/spec.md
@@ -1,0 +1,163 @@
+# armor-diagram (delta)
+
+## ADDED Requirements
+
+### Requirement: Per-Type Diagram Selection
+
+The customizer's Armor tab SHALL render a diagram component appropriate to the unit's type, selected at render time by `unit.type`.
+
+**Rationale**: Each unit type has fundamentally different armor geometry. A single universal diagram cannot represent all shapes.
+
+**Priority**: Critical
+
+#### Scenario: Vehicle routes to vehicle diagram
+
+- **GIVEN** a vehicle loaded in the customizer
+- **WHEN** the Armor tab renders
+- **THEN** it SHALL render `VehicleArmorDiagram`, not the mech diagram
+
+#### Scenario: Aerospace routes to aerospace diagram
+
+- **GIVEN** an aerospace unit loaded
+- **WHEN** the Armor tab renders
+- **THEN** it SHALL render `AerospaceArmorDiagram` with 4 arc labels (Nose/LW/RW/Aft) and the SI bar
+
+#### Scenario: Infantry shows platoon counter, not diagram
+
+- **GIVEN** an infantry unit loaded
+- **WHEN** the Armor tab renders
+- **THEN** it SHALL render `InfantryPlatoonCounter` — a trooper counter, NOT a per-location diagram
+
+---
+
+### Requirement: Vehicle Diagram Geometry
+
+The vehicle armor diagram SHALL render 4 base locations (Front, Left Side, Right Side, Rear) plus conditional additional locations based on vehicle configuration.
+
+**Priority**: Critical
+
+#### Scenario: VTOL adds Rotor location
+
+- **GIVEN** a VTOL vehicle
+- **WHEN** the vehicle diagram renders
+- **THEN** a Rotor armor location SHALL appear alongside the 4 base sides
+
+#### Scenario: Support vehicle adds Body location
+
+- **GIVEN** a Support vehicle chassis
+- **WHEN** the diagram renders
+- **THEN** a Body armor location SHALL appear
+
+#### Scenario: Turret configured shows Turret location
+
+- **GIVEN** a vehicle with `turretConfig: 'Single'`
+- **WHEN** the diagram renders
+- **THEN** a Turret armor location SHALL appear
+
+#### Scenario: Auto-allocate distributes per TechManual
+
+- **GIVEN** a 50-ton tracked vehicle with armor tonnage 5
+- **WHEN** the Auto-allocate button is clicked
+- **THEN** points SHALL be distributed: 40% Front, 20% each Side, 10% Rear, remainder Turret — matching TechManual pp.86–87
+
+---
+
+### Requirement: Aerospace Diagram Geometry
+
+The aerospace armor diagram SHALL render 4 arcs (Nose, Left Wing, Right Wing, Aft) plus a separate Structural Integrity bar.
+
+**Priority**: Critical
+
+#### Scenario: Arcs match aerospace-unit-system
+
+- **GIVEN** any aerospace unit
+- **WHEN** the aerospace diagram renders
+- **THEN** the 4 arcs SHALL be labeled Nose, Left Wing, Right Wing, Aft — matching the `aerospace-unit-system` spec's arc names
+
+#### Scenario: SI bar rendered separately
+
+- **GIVEN** an aerospace fighter with SI 5
+- **WHEN** the diagram renders
+- **THEN** a horizontal bar above the arcs SHALL show `5 / max` for SI
+
+---
+
+### Requirement: BattleArmor Per-Trooper Grid
+
+The BattleArmor armor diagram SHALL render a per-trooper pip grid with one column per trooper (4–6 troopers) and rows corresponding to the suit's max armor pips per chassis weight class.
+
+**Priority**: Critical
+
+#### Scenario: Elemental point shows 5 columns
+
+- **GIVEN** a 5-trooper Elemental point (medium chassis, 7 pips per suit)
+- **WHEN** the diagram renders
+- **THEN** exactly 5 trooper columns SHALL appear, each with 7 pip slots
+
+#### Scenario: Damage decrements pips
+
+- **GIVEN** a point where trooper 2 has taken 3 points of damage
+- **WHEN** the diagram renders
+- **THEN** 3 of trooper 2's pips SHALL render as consumed (filled or crossed-out per theme)
+
+---
+
+### Requirement: Infantry Platoon Counter
+
+An infantry unit's "armor" surface SHALL render a platoon-size counter instead of per-location armor, because infantry damage reduces trooper count (TechManual §infantry damage).
+
+**Priority**: Critical
+
+#### Scenario: Counter reflects trooper count
+
+- **GIVEN** a 28-trooper foot rifle platoon at full strength
+- **WHEN** the Armor tab renders
+- **THEN** the counter SHALL show `28 / 28` in green styling
+
+#### Scenario: Threshold color changes on damage
+
+- **GIVEN** a platoon reduced to 6 troopers out of 28
+- **WHEN** the counter renders
+- **THEN** the counter styling SHALL use the red threshold (≤25%)
+
+---
+
+### Requirement: ProtoMech 5-Location Compact Diagram
+
+The ProtoMech armor diagram SHALL render 5 locations (Head, Torso, Left Arm, Right Arm, Legs) plus an optional Main Gun location when the unit has a main gun designated.
+
+**Priority**: Critical
+
+#### Scenario: Standard ProtoMech shows 5 locations
+
+- **GIVEN** a standard ProtoMech with no main gun
+- **WHEN** the diagram renders
+- **THEN** exactly 5 armor locations SHALL appear (Head, Torso, LA, RA, Legs)
+
+#### Scenario: Main-gun ProtoMech shows 6 locations
+
+- **GIVEN** a ProtoMech with a designated Main Gun
+- **WHEN** the diagram renders
+- **THEN** a 6th Main Gun armor location SHALL appear
+
+#### Scenario: Compact layout fits 5 protos
+
+- **GIVEN** a point of 5 ProtoMechs displayed together
+- **WHEN** the layout renders
+- **THEN** all 5 diagrams SHALL be visible without horizontal scroll on a standard desktop viewport
+
+---
+
+### Requirement: Shared Armor Pip Primitive
+
+All per-type diagrams SHALL use the shared `<ArmorPipRow>` primitive for rendering individual armor pips. Unit-type-specific layouts compose from this primitive.
+
+**Rationale**: Ensures visual consistency and centralizes damage-state rendering logic.
+
+**Priority**: Medium
+
+#### Scenario: Pip primitive used across types
+
+- **GIVEN** the vehicle, aerospace, BA, and protomech diagrams
+- **WHEN** any one renders armor pips
+- **THEN** it SHALL delegate to `<ArmorPipRow>` for the pip strip — no per-type pip implementations

--- a/openspec/changes/add-per-type-armor-diagrams/tasks.md
+++ b/openspec/changes/add-per-type-armor-diagrams/tasks.md
@@ -1,0 +1,77 @@
+# Tasks: Add Per-Type Armor Diagrams
+
+## 1. Shared Primitive
+
+- [ ] 1.1 Extract `ArmorPipRow` component from existing mech diagram (single row of N pips, filled/empty state)
+- [ ] 1.2 `ArmorLocationBlock` wrapper: label + current/max counter + pip row
+- [ ] 1.3 Extract `<ArmorAllocationInput>` primitive (number input + spinner + max)
+- [ ] 1.4 Unit tests for the primitives
+
+## 2. Diagram Selector
+
+- [ ] 2.1 Add `ArmorDiagramForType.tsx` that switches on `unit.type` and renders the correct per-type diagram
+- [ ] 2.2 Used by each per-type Armor tab component
+
+## 3. Vehicle Armor Diagram
+
+- [ ] 3.1 Create `VehicleArmorDiagram.tsx` (replace existing scaffold if present)
+- [ ] 3.2 Render 4 base locations (Front, LeftSide, RightSide, Rear)
+- [ ] 3.3 Add Turret location when `vehicle.turretConfig !== 'None'`
+- [ ] 3.4 Add Rotor location when `motionType === 'VTOL'`
+- [ ] 3.5 Add Chin Turret when `turretConfig === 'Chin'`
+- [ ] 3.6 Add Body location for support vehicles
+- [ ] 3.7 Per-location input wired to the vehicle store
+- [ ] 3.8 Auto-allocate button: distribute armor points per TM Table (40% front, 20% each side, 10% rear, remainder to turret)
+- [ ] 3.9 Storybook story + snapshot test
+
+## 4. Aerospace Armor Diagram
+
+- [ ] 4.1 Create `AerospaceArmorDiagram.tsx`
+- [ ] 4.2 Render 4 arcs: Nose, Left Wing, Right Wing, Aft
+- [ ] 4.3 Render SI (Structural Integrity) as a separate horizontal bar above the arcs
+- [ ] 4.4 Per-arc capacity cap derived from tonnage × armor-per-ton
+- [ ] 4.5 Auto-allocate: distribute evenly by default, respecting fighter vs small-craft caps
+- [ ] 4.6 Storybook story + snapshot test
+
+## 5. BattleArmor Pip Grid
+
+- [ ] 5.1 Create `BattleArmorPipGrid.tsx`
+- [ ] 5.2 Render N columns (one per trooper) × M pip rows
+- [ ] 5.3 Suit max armor pips derived from BA chassis (Light: 3, Medium: 7, Heavy: 11, Assault: 15 — TechManual)
+- [ ] 5.4 Per-trooper damage tracking stub (filled pips decrement on damage)
+- [ ] 5.5 Indicate which trooper is the squad leader if the chassis rule applies
+- [ ] 5.6 Storybook story + snapshot test
+
+## 6. Infantry Platoon Counter
+
+- [ ] 6.1 Create `InfantryPlatoonCounter.tsx`
+- [ ] 6.2 Show `trooperCount / maxTrooperCount` with large typography
+- [ ] 6.3 Color thresholds: green (>75%), yellow (25–75%), red (≤25%)
+- [ ] 6.4 Below counter: "No per-location armor" label + per-TM rule citation
+- [ ] 6.5 Show platoon XP / morale if tracked by the infantry record
+- [ ] 6.6 Storybook story + snapshot test
+
+## 7. ProtoMech Armor Diagram
+
+- [ ] 7.1 Create `ProtoMechArmorDiagram.tsx`
+- [ ] 7.2 Render 5 locations (Head, Torso, LA, RA, Legs) — compact
+- [ ] 7.3 Add Main Gun location when main-gun designation is set
+- [ ] 7.4 Compact layout — sized to show 5 protos on one screen when displaying a full point
+- [ ] 7.5 Armor per-location capped per ProtoMech weight table
+- [ ] 7.6 Storybook story + snapshot test
+
+## 8. Wiring
+
+- [ ] 8.1 Each per-type `<Type>ArmorTab.tsx` consumes `<ArmorDiagramForType>` instead of scaffold
+- [ ] 8.2 Remove placeholder diagrams (`VehicleDiagram.tsx`, `AerospaceDiagram.tsx`, `BattleArmorDiagram.tsx`) or convert them to re-export from new files
+
+## 9. Accessibility
+
+- [ ] 9.1 Every location has an accessible label including location name + current/max
+- [ ] 9.2 Keyboard navigation: arrows move between location inputs
+- [ ] 9.3 Auto-allocate button has a confirm step if armor is currently non-default
+
+## 10. Spec Compliance
+
+- [ ] 10.1 Every `### Requirement:` in the `armor-diagram` spec delta has a `#### Scenario:`
+- [ ] 10.2 `openspec validate add-per-type-armor-diagrams --strict` passes

--- a/openspec/changes/add-per-type-customizer-tabs/proposal.md
+++ b/openspec/changes/add-per-type-customizer-tabs/proposal.md
@@ -1,0 +1,59 @@
+# Change: Add Per-Type Customizer Tabs
+
+## Why
+
+Current customizer scaffolding under `src/components/customizer/` has sub-folders for every unit type (`vehicle/`, `aerospace/`, `battlearmor/`, `infantry/`, `protomech/`) but the tab sets are uneven and incomplete:
+
+- **Vehicle**: has Structure / Armor / Turret / Equipment — reasonable, needs wiring to construction rules
+- **Aerospace**: has Structure / Armor / Equipment — missing Velocity/Thrust, Fuel, Bomb Bay tabs
+- **BattleArmor**: has Squad + Structure — missing Manipulators, Modular weapons, AP weapons, per-trooper armor
+- **Infantry**: has Build only — missing Platoon composition, Primary/Secondary weapons, Field Gun, Specialization
+- **ProtoMech**: has Structure only — missing Armor, Equipment, Main Gun, Glider mode
+
+The construction proposals (`add-vehicle-construction` et al.) mention "wire into customizer tabs" but don't enumerate which tabs. Agents implementing those proposals will invent the tab sets ad-hoc, producing inconsistent UX. This change locks the tab architecture per type so every construction proposal has a clear UI contract.
+
+## What Changes
+
+- Lock the canonical tab set per unit type:
+  - **Mech** (reference, unchanged): Overview / Structure / Armor / Equipment / Critical Slots / Preview / Fluff
+  - **Vehicle**: Overview / Structure / Armor / Turret / Equipment / Preview / Fluff
+  - **Aerospace**: Overview / Structure / Armor / Equipment / Velocity / Bombs / Preview / Fluff
+  - **BattleArmor**: Overview / Chassis / Squad / Manipulators / Modular Weapons / AP Weapons / Jump/UMU / Preview / Fluff
+  - **Infantry**: Overview / Platoon / Primary Weapon / Secondary Weapons / Field Guns / Specialization / Preview / Fluff
+  - **ProtoMech**: Overview / Structure / Armor / Main Gun / Equipment / Glider / Preview / Fluff
+- Add missing tab components for each type (see tasks)
+- Extend `CustomizerTabs.tsx` / `UnitTypeRouter.tsx` to render the correct tab set based on `unit.type`
+- Extract shared tab behaviors (tab state, routing, dirty tracking) into a `useCustomizerTabs` hook so per-type implementations stay thin
+- Keep `Overview`, `Preview`, `Fluff` tabs SHARED across all types — only the middle tabs vary
+- Add tab visibility predicates (e.g., Bomb Bay tab hidden on Conventional Fighter; Glider tab hidden on ProtoMechs that don't support glider rule)
+
+## Non-goals
+
+- The construction business logic inside each tab — that's each `add-<type>-construction` change's territory
+- Armor diagram artwork (separate `add-per-type-armor-diagrams` change)
+- Record sheet layout (separate `add-multi-type-record-sheet-export` change)
+- Visual theming of tabs — reuses existing customizer tab styling
+
+## Dependencies
+
+- **Requires**: existing `multi-unit-tabs` spec and `UnitTypeRouter.tsx` scaffolding
+- **Required by**: `add-vehicle-construction`, `add-aerospace-construction`, `add-battlearmor-construction`, `add-infantry-construction`, `add-protomech-construction` — each of those proposals assumes a set of tabs to wire into; this change defines them
+- **Phase 5 coupling**: none; Phase 5 pilot SPA UI is on the pilot detail page, not the customizer
+
+## Ordering in Phase 6
+
+Ship BEFORE any construction proposal so the tab architecture exists when agents wire data flow. Specifically:
+
+```
+Wave 0: add-per-type-customizer-tabs        (THIS CHANGE — lands first)
+Wave 1: add-vehicle-construction             (uses tabs)
+Wave 2: add-aerospace-construction           (uses tabs)
+... etc.
+```
+
+## Impact
+
+- **Affected specs**: `multi-unit-tabs` (ADDED: canonical tab set per type, tab visibility rules, shared tab components)
+- **Affected code**: `src/components/customizer/CustomizerWithRouter.tsx`, `UnitTypeRouter.tsx`, `UnitEditorWithRouting.tsx`, `tabs/CustomizerTabs.tsx`, `vehicle/`, `aerospace/`, `battlearmor/`, `infantry/`, `protomech/` sub-folders
+- **New files** (per type, ~20 new `*Tab.tsx` placeholder components with signed contract that construction proposals will fill in): aerospace Velocity/Bombs, BA Manipulators/Modular/AP/JumpUMU, Infantry Platoon/Primary/Secondary/FieldGuns/Specialization, ProtoMech Armor/Equipment/MainGun/Glider
+- **No schema change** — pure UI scaffolding

--- a/openspec/changes/add-per-type-customizer-tabs/specs/multi-unit-tabs/spec.md
+++ b/openspec/changes/add-per-type-customizer-tabs/specs/multi-unit-tabs/spec.md
@@ -1,0 +1,121 @@
+# multi-unit-tabs (delta)
+
+## ADDED Requirements
+
+### Requirement: Canonical Per-Type Tab Sets
+
+The customizer SHALL render a locked, canonical set of tabs for each supported unit type. Tab sets differ by type and are defined in a `TabSpec` registry keyed by `UnitType`.
+
+**Rationale**: Without a locked tab set, each construction proposal will invent its own UI, producing inconsistent UX across types and making later changes (armor diagrams, record sheet) impossible to align.
+
+**Priority**: Critical
+
+#### Scenario: Mech unit shows mech tab set
+
+- **GIVEN** a BattleMech loaded in the customizer
+- **WHEN** the customizer renders
+- **THEN** the tab bar SHALL show exactly: Overview, Structure, Armor, Equipment, Critical Slots, Preview, Fluff
+
+#### Scenario: Vehicle unit shows vehicle tab set
+
+- **GIVEN** a combat vehicle loaded in the customizer
+- **WHEN** the customizer renders
+- **THEN** the tab bar SHALL show exactly: Overview, Structure, Armor, Turret, Equipment, Preview, Fluff
+
+#### Scenario: Aerospace unit shows aerospace tab set
+
+- **GIVEN** an aerospace fighter loaded
+- **WHEN** the customizer renders
+- **THEN** the tab bar SHALL show: Overview, Structure, Armor, Equipment, Velocity, Bombs, Preview, Fluff
+
+#### Scenario: BattleArmor unit shows BA tab set
+
+- **GIVEN** a BattleArmor squad loaded
+- **WHEN** the customizer renders
+- **THEN** the tab bar SHALL show: Overview, Chassis, Squad, Manipulators, Modular Weapons, AP Weapons, Jump/UMU, Preview, Fluff
+
+#### Scenario: Infantry unit shows infantry tab set
+
+- **GIVEN** an infantry platoon loaded
+- **WHEN** the customizer renders
+- **THEN** the tab bar SHALL show: Overview, Platoon, Primary Weapon, Secondary Weapons, Field Guns, Specialization, Preview, Fluff
+
+#### Scenario: ProtoMech unit shows ProtoMech tab set
+
+- **GIVEN** a ProtoMech point loaded
+- **WHEN** the customizer renders
+- **THEN** the tab bar SHALL show: Overview, Structure, Armor, Main Gun, Equipment, Glider, Preview, Fluff
+
+---
+
+### Requirement: Conditional Tab Visibility
+
+A `TabSpec` MAY declare a `visibleWhen` predicate. The customizer SHALL hide tabs whose predicate returns `false` for the current unit state.
+
+**Priority**: High
+
+#### Scenario: Conventional fighter hides Bombs tab
+
+- **GIVEN** an aerospace unit with `chassisType: 'conventional-fighter'`
+- **WHEN** the tab bar renders
+- **THEN** the Bombs tab SHALL NOT appear
+
+#### Scenario: Jump infantry hides Field Guns tab
+
+- **GIVEN** an infantry platoon with `motiveType: 'Jump'`
+- **WHEN** the tab bar renders
+- **THEN** the Field Guns tab SHALL NOT appear
+
+#### Scenario: Ultraheavy ProtoMech hides Glider tab
+
+- **GIVEN** a ProtoMech in the Ultraheavy weight class (10–15t)
+- **WHEN** the tab bar renders
+- **THEN** the Glider tab SHALL NOT appear
+
+---
+
+### Requirement: Shared Tab Implementations
+
+The Overview, Preview, and Fluff tabs SHALL be shared implementations usable across all unit types; their component modules live outside any per-type folder.
+
+**Priority**: High
+
+#### Scenario: Fluff data uniform across types
+
+- **GIVEN** any unit type
+- **WHEN** the Fluff tab renders
+- **THEN** it SHALL present the same fluff fields (description, history, capabilities) regardless of unit type
+
+---
+
+### Requirement: Tab Dirty Tracking
+
+The `useCustomizerTabs` hook SHALL track which tabs have pending (un-saved) field changes, expose this via a `dirtyTabs: Set<string>` selector, and display a visual marker on dirty tabs.
+
+**Priority**: High
+
+#### Scenario: Dirty marker appears on edit
+
+- **GIVEN** a user editing the Armor tab
+- **WHEN** any armor field is changed but not yet saved
+- **THEN** the Armor tab label SHALL display a dirty marker (e.g., bullet or asterisk)
+
+#### Scenario: Dirty marker clears on save
+
+- **GIVEN** a dirty Armor tab
+- **WHEN** the unit is saved
+- **THEN** the dirty marker SHALL clear
+
+---
+
+### Requirement: Validation Error Markers
+
+Tabs whose fields currently fail construction validation SHALL display an error marker distinguishable from the dirty marker.
+
+**Priority**: Medium
+
+#### Scenario: Error marker on validation failure
+
+- **GIVEN** a vehicle where armor on Front location exceeds max
+- **WHEN** the tab bar renders
+- **THEN** the Armor tab label SHALL display a red dot or equivalent error indicator with an ARIA label naming the failing rule (`VAL-VEHICLE-ARMOR-MAX`)

--- a/openspec/changes/add-per-type-customizer-tabs/tasks.md
+++ b/openspec/changes/add-per-type-customizer-tabs/tasks.md
@@ -1,0 +1,74 @@
+# Tasks: Add Per-Type Customizer Tabs
+
+## 1. Shared Infrastructure
+
+- [ ] 1.1 Create `useCustomizerTabs(unitType, sections)` hook that returns `{activeTab, setActiveTab, dirtyTabs, isActive}`
+- [ ] 1.2 Create `TabSpec` type: `{id, label, visibleWhen?: (unit) => boolean, component: ComponentType}`
+- [ ] 1.3 Create `getTabSpec(unitType): TabSpec[]` registry — one array per unit type
+- [ ] 1.4 Refactor `CustomizerTabs.tsx` to consume `TabSpec[]` rather than hardcoded tab list
+- [ ] 1.5 Extend `UnitTypeRouter.tsx` to route based on `unit.type` and render the correct tab set
+
+## 2. Mech Tab Set (Reference — No Change)
+
+- [ ] 2.1 Verify mech tab set: Overview / Structure / Armor / Equipment / Critical Slots / Preview / Fluff is correctly sourced from the new `TabSpec` registry
+- [ ] 2.2 Verify no regression in mech customizer behavior after refactor
+
+## 3. Vehicle Tab Set
+
+- [ ] 3.1 Canonical tabs: Overview / Structure / Armor / Turret / Equipment / Preview / Fluff
+- [ ] 3.2 Hide Turret tab when `motionType === 'VTOL'` (use chin-turret UI within Structure instead) OR allow it but restrict turret config options
+- [ ] 3.3 Wire existing `VehicleStructureTab`, `VehicleArmorTab`, `VehicleTurretTab`, `VehicleEquipmentTab` into the TabSpec registry
+- [ ] 3.4 Integration test: rendering `/customizer/<vehicle-id>` shows exactly these tabs
+
+## 4. Aerospace Tab Set
+
+- [ ] 4.1 Canonical tabs: Overview / Structure / Armor / Equipment / Velocity / Bombs / Preview / Fluff
+- [ ] 4.2 Add placeholder `AerospaceVelocityTab.tsx` — construction proposal fills in fields (safeThrust, maxThrust, SI, fuel)
+- [ ] 4.3 Add placeholder `AerospaceBombTab.tsx` — construction proposal fills bomb-bay slot allocation
+- [ ] 4.4 Hide Bombs tab on conventional fighters that can't carry bombs
+- [ ] 4.5 Wire existing `AerospaceStructureTab`, `AerospaceArmorTab`, `AerospaceEquipmentTab` + new placeholders
+
+## 5. BattleArmor Tab Set
+
+- [ ] 5.1 Canonical tabs: Overview / Chassis / Squad / Manipulators / Modular Weapons / AP Weapons / Jump/UMU / Preview / Fluff
+- [ ] 5.2 Rename existing `BattleArmorStructureTab` → `BattleArmorChassisTab` (or alias)
+- [ ] 5.3 Keep existing `BattleArmorSquadTab`
+- [ ] 5.4 Add `BattleArmorManipulatorsTab.tsx` placeholder — construction proposal fills left-arm / right-arm manipulator type (Battle Claw / Cargo Lifter / Basic Manipulator / etc.)
+- [ ] 5.5 Add `BattleArmorModularWeaponsTab.tsx` placeholder — modular mount per suit with weapon-selector dropdown
+- [ ] 5.6 Add `BattleArmorAPWeaponsTab.tsx` placeholder — one AP weapon per suit
+- [ ] 5.7 Add `BattleArmorJumpUMUTab.tsx` placeholder — jump jets / UMU / VTOL selection
+
+## 6. Infantry Tab Set
+
+- [ ] 6.1 Canonical tabs: Overview / Platoon / Primary Weapon / Secondary Weapons / Field Guns / Specialization / Preview / Fluff
+- [ ] 6.2 Rename existing `InfantryBuildTab` → `InfantryPlatoonTab` (or alias) — handles platoon size, motive type, squads × troopers per squad
+- [ ] 6.3 Add `InfantryPrimaryWeaponTab.tsx` placeholder — pick one primary weapon from infantry-weapons catalog
+- [ ] 6.4 Add `InfantrySecondaryWeaponsTab.tsx` placeholder — AP weapons, ratio per 4 troopers
+- [ ] 6.5 Add `InfantryFieldGunsTab.tsx` placeholder — 1 field gun per 7 men rule; hide if motive type doesn't support field guns
+- [ ] 6.6 Add `InfantrySpecializationTab.tsx` placeholder — anti-mech / marine / scuba / mountain / xct / paratroop / tunnel
+- [ ] 6.7 Hide Field Guns tab when `motiveType === 'Jump' | 'Mechanized'` (no field guns)
+
+## 7. ProtoMech Tab Set
+
+- [ ] 7.1 Canonical tabs: Overview / Structure / Armor / Main Gun / Equipment / Glider / Preview / Fluff
+- [ ] 7.2 Keep existing `ProtoMechStructureTab`
+- [ ] 7.3 Add `ProtoMechArmorTab.tsx` placeholder — 5-location armor allocation
+- [ ] 7.4 Add `ProtoMechMainGunTab.tsx` placeholder — main gun weapon selector; unique ProtoMech concept
+- [ ] 7.5 Add `ProtoMechEquipmentTab.tsx` placeholder — weapon/equipment mounts in arms/torso
+- [ ] 7.6 Add `ProtoMechGliderTab.tsx` placeholder — glider mode toggle; hide if ultraheavy
+
+## 8. Preview + Fluff Shared
+
+- [ ] 8.1 Verify `PreviewTab` works for every unit type (may need per-type preview widgets)
+- [ ] 8.2 Verify `FluffTab` works for every unit type (fluff fields are universal)
+
+## 9. Validation + Dirty Tracking
+
+- [ ] 9.1 `dirtyTabs` state correctly flags a tab when its fields have pending changes
+- [ ] 9.2 Navigation warning: leaving a dirty tab prompts confirm
+- [ ] 9.3 Validation errors on a tab surface a red dot on the tab label
+
+## 10. Spec Compliance
+
+- [ ] 10.1 Every `### Requirement:` in the `multi-unit-tabs` spec delta has a `#### Scenario:`
+- [ ] 10.2 `openspec validate add-per-type-customizer-tabs --strict` passes

--- a/openspec/changes/add-per-type-hex-tokens/proposal.md
+++ b/openspec/changes/add-per-type-hex-tokens/proposal.md
@@ -1,0 +1,57 @@
+# Change: Add Per-Type Hex Map Tokens
+
+## Why
+
+Phase 1 shipped the interactive combat UI with mech-only hex tokens. `src/components/gameplay/HexMapDisplay/` contains no `unitType` branching — every placed unit renders as a mech silhouette with the mech movement/facing conventions. When Phase 6 adds vehicles, aerospace, BA, infantry, and ProtoMech to the combat loop, the map needs:
+
+- **Per-type token shapes** (a tank silhouette ≠ a mech silhouette; an infantry stack ≠ a ProtoMech point)
+- **Per-type facing rules** (vehicles face a cardinal direction; aerospace vector with velocity arrows; infantry has no facing)
+- **Per-type stacking rules** (mechs occupy one hex; infantry stack multiple platoons per hex; BA rides on mechs)
+- **Per-type movement markers** (aerospace shows velocity vectors, VTOLs show altitude, infantry show move modes)
+
+Without these, a Phase 6 unit is technically constructible but cannot appear on the combat map in any meaningful way. The `add-<type>-combat-behavior` proposals cover rules (damage, motive hits, morale) but not token rendering. This change closes that gap.
+
+## What Changes
+
+- Introduce `UnitTokenForType` component that dispatches on `unit.type` to the per-type token renderer
+- Add `MechToken.tsx` (extract existing behavior into a named component — minimal refactor)
+- Add `VehicleToken.tsx` — rectangular base, motion-type icon (tracked/wheeled/hover/VTOL/naval), cardinal-direction facing indicator
+- Add `AerospaceToken.tsx` — triangular wing silhouette, velocity vector arrow showing current speed + direction, altitude badge
+- Add `BattleArmorToken.tsx` — grouped pip representing N troopers (4–6 dots), can render as a passenger badge overlaid on a mech token when mounted
+- Add `InfantryToken.tsx` — stack icon with trooper count, motive-type badge (foot/motorized/jump/mechanized), specialization icon
+- Add `ProtoMechToken.tsx` — compact silhouette, point grouping (up to 5 protos displayed as a cluster)
+- Extend `IGameUnit` with `tokenType` discriminator (or derive from `unit.type`) so the renderer can dispatch
+- Add per-type facing / altitude / stacking rules to the map's placement logic
+- Update Phase 1's mech-only selection ring + range brackets to be aware of token dimensions per type
+
+## Non-goals
+
+- Final artwork (silhouettes, icons) — Phase 7 polish. This change ships with placeholder geometric shapes + text labels; Phase 7 replaces with art.
+- Animation (movement interpolation, impact visuals) — Phase 7
+- Atmospheric combat (aerospace dogfights on a separate map) — future Phase
+- Fog-of-war tokens (hidden unit rendering) — deferred to Phase 4.5
+
+## Dependencies
+
+- **Requires**: Phase 1 `tactical-map-interface` spec and existing `HexMapDisplay` components; each `add-<type>-combat-behavior` change (needs the per-type combat rules to interpret facing / stacking)
+- **Required by**: none (terminal for combat UI per type)
+- **Phase 4 coupling**: multiplayer sends token updates via server events; token shape is client-side rendering only, so no protocol change
+
+## Ordering in Phase 6
+
+Ship after each type's combat-behavior proposal lands:
+
+```
+add-<type>-construction      → (tabs, diagrams, record sheet) → type buildable
+add-<type>-combat-behavior   → rules of engagement defined
+add-per-type-hex-tokens      → type RENDERS on the map correctly
+```
+
+Tokens can ship one type at a time; the dispatcher returns to a generic placeholder for unimplemented types.
+
+## Impact
+
+- **Affected specs**: `tactical-map-interface` (ADDED: per-type token rendering, per-type facing, per-type stacking, velocity vectors for aerospace)
+- **Affected code**: `src/components/gameplay/HexMapDisplay/*`, `src/components/gameplay/UnitToken/` (new folder)
+- **New files**: 6 token components (Mech + 5 new types), dispatcher, per-type facing helpers
+- **Minor type extension**: `IGameUnit.type: UnitType` (already present on source data; may need to be threaded through `IAdaptedUnit`)

--- a/openspec/changes/add-per-type-hex-tokens/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-per-type-hex-tokens/specs/tactical-map-interface/spec.md
@@ -1,0 +1,153 @@
+# tactical-map-interface (delta)
+
+## ADDED Requirements
+
+### Requirement: Per-Type Token Rendering
+
+The `HexMapDisplay` SHALL render a unit token whose shape, indicators, and overlays are determined by `unit.type`. A central dispatcher component SHALL route to the correct per-type token renderer.
+
+**Rationale**: Phase 1's mech-only rendering cannot represent vehicles, aerospace, BA, infantry, or ProtoMechs correctly. Different unit types have different silhouettes, facing rules, and stacking.
+
+**Priority**: Critical
+
+#### Scenario: Mech unit renders mech token
+
+- **GIVEN** a BattleMech placed on the map
+- **WHEN** the hex renders
+- **THEN** `MechToken` SHALL render at the hex position with the mech silhouette and 6-hex facing indicator
+
+#### Scenario: Vehicle renders vehicle token
+
+- **GIVEN** a tracked vehicle placed on the map
+- **WHEN** the hex renders
+- **THEN** `VehicleToken` SHALL render with a rectangular base and a Tracked motion-type icon
+
+#### Scenario: Aerospace renders aerospace token
+
+- **GIVEN** an aerospace fighter airborne at altitude 3, velocity 5
+- **WHEN** the hex renders
+- **THEN** `AerospaceToken` SHALL render with a wedge silhouette, an altitude badge reading "3", and a velocity vector arrow whose length is proportional to 5
+
+#### Scenario: BattleArmor mounted renders as badge
+
+- **GIVEN** a BA point mounted on a mech (via `mountedOn`)
+- **WHEN** the hex renders
+- **THEN** the BA token SHALL render as a small badge overlaid on the host mech token, NOT as a separate token
+
+#### Scenario: Infantry renders stack icon with count
+
+- **GIVEN** a 28-trooper platoon
+- **WHEN** the hex renders
+- **THEN** `InfantryToken` SHALL render with a stack icon and a "28" label
+
+#### Scenario: ProtoMech point clusters in one hex
+
+- **GIVEN** a 5-proto point placed on one hex
+- **WHEN** the hex renders
+- **THEN** all 5 ProtoMech silhouettes SHALL appear in a tight cluster within the single hex
+
+---
+
+### Requirement: Per-Type Facing Rules
+
+The map SHALL apply per-type facing conventions when displaying and rotating units.
+
+**Priority**: Critical
+
+#### Scenario: Mech uses 6-hex facing
+
+- **GIVEN** a mech
+- **WHEN** the facing arrow is rendered
+- **THEN** it SHALL point to one of the 6 hex edges
+
+#### Scenario: Vehicle uses 8-direction facing
+
+- **GIVEN** a ground vehicle
+- **WHEN** the facing arrow is rendered
+- **THEN** it SHALL point to one of 8 directions (N/NE/E/SE/S/SW/W/NW)
+
+#### Scenario: Aerospace uses velocity vector
+
+- **GIVEN** an aerospace unit
+- **WHEN** its heading is rendered
+- **THEN** the token SHALL display a velocity vector arrow instead of a fixed facing arrow
+
+#### Scenario: Infantry has no facing
+
+- **GIVEN** an infantry platoon
+- **WHEN** the token renders
+- **THEN** no facing indicator SHALL appear (infantry do not have facing in Total Warfare)
+
+---
+
+### Requirement: Per-Type Stacking Rules
+
+Multiple units SHARING a hex SHALL obey type-specific stacking rules. Attempts to violate stacking SHALL be rejected or aggregated visually.
+
+**Priority**: Critical
+
+#### Scenario: Mechs cannot share hex
+
+- **GIVEN** a hex already occupied by one mech
+- **WHEN** another mech is placed on the same hex
+- **THEN** placement SHALL fail with an error message
+
+#### Scenario: Infantry platoons stack to 4
+
+- **GIVEN** a hex with 3 infantry platoons
+- **WHEN** a 4th platoon is placed on the same hex
+- **THEN** placement SHALL succeed
+- **AND** the hex SHALL display a stack indicator "×4"
+
+#### Scenario: BA mounts on mech
+
+- **GIVEN** a mech occupying a hex
+- **WHEN** a BA point is placed on the same hex with the "Mount" action
+- **THEN** the BA's `mountedOn` SHALL be set to the mech's ID
+- **AND** only the mech+BA-badge SHALL render on the hex, not two separate tokens
+
+---
+
+### Requirement: Aerospace Velocity + Altitude Indicators
+
+Aerospace tokens SHALL display current velocity (as a vector arrow) and altitude (as a badge) alongside the token.
+
+**Priority**: High
+
+#### Scenario: Velocity vector length
+
+- **GIVEN** an aerospace unit at velocity 8
+- **WHEN** the token renders
+- **THEN** the velocity vector length SHALL be proportional to 8 (e.g., 8 × pixel-per-velocity-unit) and oriented along the unit's heading
+
+#### Scenario: Altitude badge
+
+- **GIVEN** an aerospace unit at altitude 5
+- **WHEN** the token renders
+- **THEN** an altitude badge reading "5" SHALL render in a stable corner of the token
+
+#### Scenario: Landed aerospace visual distinction
+
+- **GIVEN** an aerospace unit at altitude 0 (landed)
+- **WHEN** the token renders
+- **THEN** the velocity vector SHALL be omitted and the token SHALL render in a "landed" visual state
+
+---
+
+### Requirement: Selection + Range Scaling
+
+The selection ring around a unit and the range-bracket overlays SHALL scale proportionally to the token size so small tokens (BA, ProtoMech) remain legible.
+
+**Priority**: Medium
+
+#### Scenario: BA selection ring scales down
+
+- **GIVEN** a BA point selected on the map
+- **WHEN** the selection ring renders
+- **THEN** the ring radius SHALL be proportional to the BA token size (smaller than the mech ring)
+
+#### Scenario: Aerospace range brackets use aerospace ranges
+
+- **GIVEN** an aerospace unit with a weapon whose aerospace ranges are 6/12/18/24
+- **WHEN** the range-bracket overlay renders
+- **THEN** the brackets SHALL use aerospace range bands, NOT ground-unit range bands

--- a/openspec/changes/add-per-type-hex-tokens/tasks.md
+++ b/openspec/changes/add-per-type-hex-tokens/tasks.md
@@ -1,0 +1,72 @@
+# Tasks: Add Per-Type Hex Map Tokens
+
+## 1. Token Dispatcher
+
+- [ ] 1.1 Create `src/components/gameplay/UnitToken/UnitTokenForType.tsx` that takes `{ unit, selected, showRange }` and dispatches on `unit.type`
+- [ ] 1.2 Update `HexMapDisplay.tsx` to render `<UnitTokenForType>` instead of the inline mech rendering
+- [ ] 1.3 Unit test: each unit type routes to the correct token component
+
+## 2. Mech Token (Refactor)
+
+- [ ] 2.1 Extract existing mech rendering into `MechToken.tsx` with a clean props interface
+- [ ] 2.2 Preserve existing selection ring + facing arrow + destroyed overlay behavior
+- [ ] 2.3 No visual regression from Phase 1
+
+## 3. Vehicle Token
+
+- [ ] 3.1 Create `VehicleToken.tsx` — rectangular base shape
+- [ ] 3.2 Motion-type icon overlay: Tracked / Wheeled / Hover / VTOL / Naval / WiGE
+- [ ] 3.3 Cardinal-direction facing indicator (N/NE/E/SE/S/SW/W/NW — 8-hex facing matches vehicle rules)
+- [ ] 3.4 Turret indicator (if vehicle has a turret, show a small rotated weapon arrow separate from body facing)
+- [ ] 3.5 Destroyed state: burned-out chassis overlay
+- [ ] 3.6 Tests + Storybook story
+
+## 4. Aerospace Token
+
+- [ ] 4.1 Create `AerospaceToken.tsx` — triangular / wedge silhouette
+- [ ] 4.2 Velocity vector arrow: length proportional to current velocity, direction = current heading
+- [ ] 4.3 Altitude badge (1–10 map levels)
+- [ ] 4.4 Landed vs airborne visual distinction
+- [ ] 4.5 Tests + Storybook story
+
+## 5. BattleArmor Token
+
+- [ ] 5.1 Create `BattleArmorToken.tsx` — cluster of N dots (4–6) representing troopers
+- [ ] 5.2 Squad leader dot distinguishable (slightly larger)
+- [ ] 5.3 Mounted on mech rendering: when BA is riding a mech (`mountedOn` set), render as a small badge overlaid on the host mech token
+- [ ] 5.4 Jump/UMU active indicator
+- [ ] 5.5 Tests + Storybook story
+
+## 6. Infantry Token
+
+- [ ] 6.1 Create `InfantryToken.tsx` — stack icon with trooper-count label
+- [ ] 6.2 Motive-type badge (Foot / Motorized / Jump / Mechanized / Beast)
+- [ ] 6.3 Specialization icon (anti-mech / marine / scuba / mountain / xct)
+- [ ] 6.4 Counter decrements visibly as troopers are lost
+- [ ] 6.5 Multiple platoons per hex: stack indicator (e.g., "×3 platoons")
+- [ ] 6.6 Tests + Storybook story
+
+## 7. ProtoMech Token
+
+- [ ] 7.1 Create `ProtoMechToken.tsx` — compact silhouette
+- [ ] 7.2 Point grouping: render up to 5 protos as a tight cluster within one hex
+- [ ] 7.3 Glider mode visual distinction (extended wings)
+- [ ] 7.4 Main-gun indicator (weapon symbol overlay)
+- [ ] 7.5 Tests + Storybook story
+
+## 8. Facing + Stacking Rules
+
+- [ ] 8.1 `getFacingRules(unitType)` returns canonical facing behavior (6-hex for mechs/proto, 8-direction for vehicles, vector for aerospace, none for infantry/BA)
+- [ ] 8.2 `getStackingRules(unitType, hexContents)` — mechs can't share hex with mechs; infantry platoons stack up to 4 per hex; BA rides on mechs
+- [ ] 8.3 `HexMapDisplay` consults `getStackingRules` before placing a unit
+- [ ] 8.4 Stack overflow shows aggregated badge (e.g., "×4" on the hex)
+
+## 9. Selection + Range Visuals
+
+- [ ] 9.1 Selection ring scales with token size — smaller tokens (BA, ProtoMech) get proportional rings
+- [ ] 9.2 Range bracket overlays account for per-type ranges (aerospace has different bracket sizes)
+
+## 10. Spec Compliance
+
+- [ ] 10.1 Every `### Requirement:` in the `tactical-map-interface` spec delta has a `#### Scenario:`
+- [ ] 10.2 `openspec validate add-per-type-hex-tokens --strict` passes


### PR DESCRIPTION
## Summary

Audit revealed the 15 pre-authored Phase 6 proposals (construction + BV + combat-behavior per unit type) do NOT cover the display / UI / data-import surface the roadmap explicitly calls out as \"→ display\" per unit type. Construction proposals explicitly defer: \"Record-sheet PDF layout for vehicles — follow-up work.\" This PR authors 5 gap-filler OpenSpec changes that close that gap + a master execution plan.

## Why

Without these 5, Phase 6 would ship:
- ❌ Units you can build but can't print (no per-type record sheets)
- ❌ Customizer tabs invented ad-hoc per construction proposal (inconsistent UX)
- ❌ Mech-shaped armor diagrams on non-mechs
- ❌ Mech silhouettes on tanks / aerospace / infantry in combat
- ❌ Empty catalogs (BLK files in mm-data unwired)

## 5 new OpenSpec changes (all validate \`--strict\`)

1. **\`add-multi-type-record-sheet-export\`** — discriminated \`IRecordSheetData\` union, 5 per-type SVG renderers (vehicle 6-8 locations, aerospace 4 arcs + SI, BA per-trooper grid, infantry platoon counter, ProtoMech 5-location compact), Phase 5 SPA block anchored per-type
2. **\`add-per-type-customizer-tabs\`** — canonical tab set locked per type (Vehicle adds Turret, Aerospace adds Velocity+Bombs, BA adds Manipulators+Modular+AP+Jump, Infantry adds Platoon+Primary+Secondary+FieldGuns+Spec, ProtoMech adds MainGun+Glider), dispatcher via \`useCustomizerTabs\`
3. **\`add-per-type-armor-diagrams\`** — 5 per-type diagram components + shared \`<ArmorPipRow>\` primitive + diagram selector; correct geometry per type (no more mech-shaped vehicle armor)
4. **\`add-per-type-hex-tokens\`** — \`UnitTokenForType\` dispatcher + 5 per-type tokens (vehicle rectangle + motion icon, aerospace wedge + velocity vector + altitude, BA cluster, infantry stack + count, ProtoMech cluster), per-type facing rules (6-hex mech vs 8-direction vehicle vs velocity-vector aerospace), stacking rules (mechs alone, infantry stack to 4, BA mounts on mech)
5. **\`add-blk-import-per-type\`** — extends \`BlkParserService\` to dispatch per type, adds 5 Python BLK converters (\`blk_vehicle_converter.py\` etc.), emits per-type JSON into \`public/data/units/{type}/\` with per-type manifests + parity reports against MegaMek/MUL values

## Phase 6 master execution plan

\`openspec/changes/PHASE-6-EXECUTION-PLAN.md\` documents the full 20-change scope:

- **Wave 0 (Foundation)**: 3 horizontal changes (customizer tabs, armor diagrams, hex tokens) — blocks per-type work
- **Waves 1–5 (per type)**: vehicle → aerospace → battlearmor → infantry → protomech; each a 3-change ladder (construction → BV → combat) + per-type slice of record-sheet + BLK import
- Sub-branch plan, dependency graph, done definition

## Stats

- 5 new \`proposal.md\` + 5 \`tasks.md\` + 5 spec delta files
- 15 files / ~1800 lines of spec authoring
- All 5 run \`openspec validate --strict\` clean
- Zero code changes — pure spec / planning

## Test plan

- [x] \`openspec validate --strict\` on each of 5 new changes — pass
- [ ] CI green (docs-only PR should be clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)