### PR TITLE
feat(phase-6): multi-type record sheet [WIP]

### DIFF
--- a/src/__tests__/service/printing/SVGRecordSheetRenderer.test.ts
+++ b/src/__tests__/service/printing/SVGRecordSheetRenderer.test.ts
@@ -10,8 +10,8 @@
  * - Pip group ID resolution for all configurations
  */
 
-import { SVGRecordSheetRenderer } from '@/services/printing/svgRecordSheetRenderer';
-import { IRecordSheetData } from '@/types/printing';
+import { SVGRecordSheetRenderer } from "@/services/printing/svgRecordSheetRenderer";
+import { IMechRecordSheetData } from "@/types/printing";
 
 // Mock fetch for SVG template loading
 global.fetch = jest.fn();
@@ -20,15 +20,15 @@ const createMockSVGResponse = (content: string) => {
   return Promise.resolve({
     ok: true,
     text: () => Promise.resolve(content),
-    headers: new Headers({ 'content-type': 'image/svg+xml' }),
+    headers: new Headers({ "content-type": "image/svg+xml" }),
   } as Response);
 };
 
 // Basic SVG template with pip groups for testing
-const createMockTemplate = (config: 'biped' | 'quad' | 'tripod') => {
-  let groups = '';
+const createMockTemplate = (config: "biped" | "quad" | "tripod") => {
+  let groups = "";
 
-  if (config === 'biped') {
+  if (config === "biped") {
     groups = `
       <g id="armorPipsHD"><rect x="0" y="0" width="50" height="10"/></g>
       <g id="armorPipsCT"><rect x="0" y="0" width="50" height="10"/></g>
@@ -50,7 +50,7 @@ const createMockTemplate = (config: 'biped' | 'quad' | 'tripod') => {
       <text id="textArmor_LL"></text>
       <text id="textArmor_RL"></text>
     `;
-  } else if (config === 'quad') {
+  } else if (config === "quad") {
     groups = `
       <g id="armorPipsHD"><rect x="0" y="0" width="50" height="10"/></g>
       <g id="armorPipsCT"><rect x="0" y="0" width="50" height="10"/></g>
@@ -72,7 +72,7 @@ const createMockTemplate = (config: 'biped' | 'quad' | 'tripod') => {
       <text id="textArmor_RLL"></text>
       <text id="textArmor_RRL"></text>
     `;
-  } else if (config === 'tripod') {
+  } else if (config === "tripod") {
     groups = `
       <g id="armorPipsHD"><rect x="0" y="0" width="50" height="10"/></g>
       <g id="armorPipsCT"><rect x="0" y="0" width="50" height="10"/></g>
@@ -114,89 +114,91 @@ const createMockTemplate = (config: 'biped' | 'quad' | 'tripod') => {
 };
 
 // Create mock armor data for testing
-const createMockArmorData = (mechType: string): IRecordSheetData['armor'] => {
+const createMockArmorData = (
+  mechType: string,
+): IMechRecordSheetData["armor"] => {
   const baseLocations = [
-    { location: 'Head', abbreviation: 'HD', current: 9, maximum: 9 },
+    { location: "Head", abbreviation: "HD", current: 9, maximum: 9 },
     {
-      location: 'Center Torso',
-      abbreviation: 'CT',
+      location: "Center Torso",
+      abbreviation: "CT",
       current: 20,
       maximum: 31,
       rear: 6,
     },
     {
-      location: 'Left Torso',
-      abbreviation: 'LT',
+      location: "Left Torso",
+      abbreviation: "LT",
       current: 17,
       maximum: 24,
       rear: 5,
     },
     {
-      location: 'Right Torso',
-      abbreviation: 'RT',
+      location: "Right Torso",
+      abbreviation: "RT",
       current: 17,
       maximum: 24,
       rear: 5,
     },
   ];
 
-  if (mechType === 'biped' || mechType === 'lam') {
+  if (mechType === "biped" || mechType === "lam") {
     return {
-      type: 'Standard',
+      type: "Standard",
       totalPoints: 168,
       locations: [
         ...baseLocations,
-        { location: 'Left Arm', abbreviation: 'LA', current: 13, maximum: 16 },
-        { location: 'Right Arm', abbreviation: 'RA', current: 13, maximum: 16 },
-        { location: 'Left Leg', abbreviation: 'LL', current: 20, maximum: 24 },
-        { location: 'Right Leg', abbreviation: 'RL', current: 20, maximum: 24 },
+        { location: "Left Arm", abbreviation: "LA", current: 13, maximum: 16 },
+        { location: "Right Arm", abbreviation: "RA", current: 13, maximum: 16 },
+        { location: "Left Leg", abbreviation: "LL", current: 20, maximum: 24 },
+        { location: "Right Leg", abbreviation: "RL", current: 20, maximum: 24 },
       ],
     };
-  } else if (mechType === 'quad' || mechType === 'quadvee') {
+  } else if (mechType === "quad" || mechType === "quadvee") {
     return {
-      type: 'Standard',
+      type: "Standard",
       totalPoints: 168,
       locations: [
         ...baseLocations,
         {
-          location: 'Front Left Leg',
-          abbreviation: 'FLL',
+          location: "Front Left Leg",
+          abbreviation: "FLL",
           current: 21,
           maximum: 24,
         },
         {
-          location: 'Front Right Leg',
-          abbreviation: 'FRL',
+          location: "Front Right Leg",
+          abbreviation: "FRL",
           current: 21,
           maximum: 24,
         },
         {
-          location: 'Rear Left Leg',
-          abbreviation: 'RLL',
+          location: "Rear Left Leg",
+          abbreviation: "RLL",
           current: 21,
           maximum: 24,
         },
         {
-          location: 'Rear Right Leg',
-          abbreviation: 'RRL',
+          location: "Rear Right Leg",
+          abbreviation: "RRL",
           current: 21,
           maximum: 24,
         },
       ],
     };
-  } else if (mechType === 'tripod') {
+  } else if (mechType === "tripod") {
     return {
-      type: 'Standard',
+      type: "Standard",
       totalPoints: 188,
       locations: [
         ...baseLocations,
-        { location: 'Left Arm', abbreviation: 'LA', current: 13, maximum: 16 },
-        { location: 'Right Arm', abbreviation: 'RA', current: 13, maximum: 16 },
-        { location: 'Left Leg', abbreviation: 'LL', current: 20, maximum: 24 },
-        { location: 'Right Leg', abbreviation: 'RL', current: 20, maximum: 24 },
+        { location: "Left Arm", abbreviation: "LA", current: 13, maximum: 16 },
+        { location: "Right Arm", abbreviation: "RA", current: 13, maximum: 16 },
+        { location: "Left Leg", abbreviation: "LL", current: 20, maximum: 24 },
+        { location: "Right Leg", abbreviation: "RL", current: 20, maximum: 24 },
         {
-          location: 'Center Leg',
-          abbreviation: 'CL',
+          location: "Center Leg",
+          abbreviation: "CL",
           current: 20,
           maximum: 24,
         },
@@ -204,10 +206,10 @@ const createMockArmorData = (mechType: string): IRecordSheetData['armor'] => {
     };
   }
 
-  return { type: 'Standard', totalPoints: 79, locations: baseLocations };
+  return { type: "Standard", totalPoints: 79, locations: baseLocations };
 };
 
-describe('SVGRecordSheetRenderer', () => {
+describe("SVGRecordSheetRenderer", () => {
   let renderer: SVGRecordSheetRenderer;
 
   beforeEach(() => {
@@ -215,85 +217,85 @@ describe('SVGRecordSheetRenderer', () => {
     renderer = new SVGRecordSheetRenderer();
   });
 
-  describe('loadTemplate', () => {
-    it('should load biped template for biped mech type', async () => {
-      const mockSvg = createMockTemplate('biped');
+  describe("loadTemplate", () => {
+    it("should load biped template for biped mech type", async () => {
+      const mockSvg = createMockTemplate("biped");
       (global.fetch as jest.Mock).mockImplementation(() =>
         createMockSVGResponse(mockSvg),
       );
 
       await renderer.loadTemplate(
-        '/record-sheets/templates_us/mek_biped_default.svg',
+        "/record-sheets/templates_us/mek_biped_default.svg",
       );
 
       // Verify fetch was called and template was loaded
       expect(global.fetch).toHaveBeenCalled();
     });
 
-    it('should load quad template for quad mech type', async () => {
-      const mockSvg = createMockTemplate('quad');
+    it("should load quad template for quad mech type", async () => {
+      const mockSvg = createMockTemplate("quad");
       (global.fetch as jest.Mock).mockImplementation(() =>
         createMockSVGResponse(mockSvg),
       );
 
       await renderer.loadTemplate(
-        '/record-sheets/templates_us/mek_quad_default.svg',
+        "/record-sheets/templates_us/mek_quad_default.svg",
       );
 
       // Verify fetch was called
       expect(global.fetch).toHaveBeenCalled();
     });
 
-    it('should load tripod template for tripod mech type', async () => {
-      const mockSvg = createMockTemplate('tripod');
+    it("should load tripod template for tripod mech type", async () => {
+      const mockSvg = createMockTemplate("tripod");
       (global.fetch as jest.Mock).mockImplementation(() =>
         createMockSVGResponse(mockSvg),
       );
 
       await renderer.loadTemplate(
-        '/record-sheets/templates_us/mek_tripod_default.svg',
+        "/record-sheets/templates_us/mek_tripod_default.svg",
       );
 
       // Verify fetch was called
       expect(global.fetch).toHaveBeenCalled();
     });
 
-    it('should load lam template for lam mech type', async () => {
-      const mockSvg = createMockTemplate('biped');
+    it("should load lam template for lam mech type", async () => {
+      const mockSvg = createMockTemplate("biped");
       (global.fetch as jest.Mock).mockImplementation(() =>
         createMockSVGResponse(mockSvg),
       );
 
       await renderer.loadTemplate(
-        '/record-sheets/templates_us/mek_lam_default.svg',
+        "/record-sheets/templates_us/mek_lam_default.svg",
       );
 
       // LAM template should be loaded (fetch was called)
       expect(global.fetch).toHaveBeenCalled();
     });
 
-    it('should load from templates_us for LETTER paper size', async () => {
-      const mockSvg = createMockTemplate('biped');
+    it("should load from templates_us for LETTER paper size", async () => {
+      const mockSvg = createMockTemplate("biped");
       (global.fetch as jest.Mock).mockImplementation(() =>
         createMockSVGResponse(mockSvg),
       );
 
       await renderer.loadTemplate(
-        '/record-sheets/templates_us/mek_biped_default.svg',
+        "/record-sheets/templates_us/mek_biped_default.svg",
       );
 
       // Just verify fetch was called with the letter paper size
       expect(global.fetch).toHaveBeenCalled();
     });
 
-    it('should load from templates_iso for A4 paper size', async () => {
-      const mockSvg = createMockTemplate('biped');
+    it("should load from templates_iso for A4 paper size", async () => {
+      const mockSvg = createMockTemplate("biped");
       (global.fetch as jest.Mock).mockImplementation(() =>
         createMockSVGResponse(mockSvg),
       );
 
       await renderer.loadTemplate(
-        '/record-sheets/templates_iso/mek_biped_default.svg',
+        "/record-sheets/templates_iso/mek_biped_default.svg",
       );
 
       // The implementation may use 'a4' directly or 'templates_iso'
@@ -301,43 +303,45 @@ describe('SVGRecordSheetRenderer', () => {
       expect(global.fetch).toHaveBeenCalled();
     });
 
-    it('should throw when template fetch fails', async () => {
+    it("should throw when template fetch fails", async () => {
       (global.fetch as jest.Mock).mockImplementation(() =>
         Promise.resolve({ ok: false, status: 404 }),
       );
 
       await expect(
         renderer.loadTemplate(
-          '/record-sheets/templates_us/mek_biped_default.svg',
+          "/record-sheets/templates_us/mek_biped_default.svg",
         ),
       ).rejects.toThrow();
     });
   });
 
-  describe('fillArmorPips', () => {
+  describe("fillArmorPips", () => {
     beforeEach(async () => {
-      const mockSvg = createMockTemplate('biped');
+      const mockSvg = createMockTemplate("biped");
       (global.fetch as jest.Mock).mockImplementation(() =>
         createMockSVGResponse(mockSvg),
       );
       await renderer.loadTemplate(
-        '/record-sheets/templates_us/mek_biped_default.svg',
+        "/record-sheets/templates_us/mek_biped_default.svg",
       );
     });
 
-    it('should fill armor pips for all biped locations', async () => {
-      const armorData: IRecordSheetData['armor'] = createMockArmorData('biped');
+    it("should fill armor pips for all biped locations", async () => {
+      const armorData: IMechRecordSheetData["armor"] =
+        createMockArmorData("biped");
 
-      await renderer.fillArmorPips(armorData, 'biped');
+      await renderer.fillArmorPips(armorData, "biped");
 
       // Verify method completes without error
       // Actual pip generation is tested in ArmorPipLayout.test.ts
     });
 
-    it('should set armor text values', async () => {
-      const armorData: IRecordSheetData['armor'] = createMockArmorData('biped');
+    it("should set armor text values", async () => {
+      const armorData: IMechRecordSheetData["armor"] =
+        createMockArmorData("biped");
 
-      await renderer.fillArmorPips(armorData, 'biped');
+      await renderer.fillArmorPips(armorData, "biped");
 
       const svgString = renderer.getSVGString();
       // Text values should be set in the template
@@ -345,61 +349,61 @@ describe('SVGRecordSheetRenderer', () => {
     });
   });
 
-  describe('fillStructurePips', () => {
+  describe("fillStructurePips", () => {
     beforeEach(async () => {
-      const mockSvg = createMockTemplate('biped');
+      const mockSvg = createMockTemplate("biped");
       (global.fetch as jest.Mock).mockImplementation(() =>
         createMockSVGResponse(mockSvg),
       );
       await renderer.loadTemplate(
-        '/record-sheets/templates_us/mek_biped_default.svg',
+        "/record-sheets/templates_us/mek_biped_default.svg",
       );
     });
 
-    it('should fill structure pips for all biped locations', async () => {
-      const structureData: IRecordSheetData['structure'] = {
-        type: 'Standard',
+    it("should fill structure pips for all biped locations", async () => {
+      const structureData: IMechRecordSheetData["structure"] = {
+        type: "Standard",
         totalPoints: 83,
         locations: [
-          { location: 'Head', abbreviation: 'HD', points: 3 },
-          { location: 'Center Torso', abbreviation: 'CT', points: 16 },
-          { location: 'Left Torso', abbreviation: 'LT', points: 12 },
-          { location: 'Right Torso', abbreviation: 'RT', points: 12 },
-          { location: 'Left Arm', abbreviation: 'LA', points: 8 },
-          { location: 'Right Arm', abbreviation: 'RA', points: 8 },
-          { location: 'Left Leg', abbreviation: 'LL', points: 12 },
-          { location: 'Right Leg', abbreviation: 'RL', points: 12 },
+          { location: "Head", abbreviation: "HD", points: 3 },
+          { location: "Center Torso", abbreviation: "CT", points: 16 },
+          { location: "Left Torso", abbreviation: "LT", points: 12 },
+          { location: "Right Torso", abbreviation: "RT", points: 12 },
+          { location: "Left Arm", abbreviation: "LA", points: 8 },
+          { location: "Right Arm", abbreviation: "RA", points: 8 },
+          { location: "Left Leg", abbreviation: "LL", points: 12 },
+          { location: "Right Leg", abbreviation: "RL", points: 12 },
         ],
       };
 
-      await renderer.fillStructurePips(structureData, 50, 'biped');
+      await renderer.fillStructurePips(structureData, 50, "biped");
 
       // Verify method completes without error
     });
   });
 
-  describe('fillTemplate', () => {
+  describe("fillTemplate", () => {
     beforeEach(async () => {
-      const mockSvg = createMockTemplate('biped');
+      const mockSvg = createMockTemplate("biped");
       (global.fetch as jest.Mock).mockImplementation(() =>
         createMockSVGResponse(mockSvg),
       );
       await renderer.loadTemplate(
-        '/record-sheets/templates_us/mek_biped_default.svg',
+        "/record-sheets/templates_us/mek_biped_default.svg",
       );
     });
 
-    it('should fill header data', () => {
-      const data: Partial<IRecordSheetData> = {
+    it("should fill header data", () => {
+      const data: Partial<IMechRecordSheetData> = {
         header: {
-          unitName: 'Atlas AS7-D',
-          chassis: 'Atlas',
-          model: 'AS7-D',
+          unitName: "Atlas AS7-D",
+          chassis: "Atlas",
+          model: "AS7-D",
           tonnage: 100,
-          techBase: 'Inner Sphere',
-          rulesLevel: 'Standard',
-          era: '3025',
-          role: 'Juggernaut',
+          techBase: "Inner Sphere",
+          rulesLevel: "Standard",
+          era: "3025",
+          role: "Juggernaut",
           battleValue: 1897,
           cost: 9626000,
         },
@@ -412,17 +416,17 @@ describe('SVGRecordSheetRenderer', () => {
           hasSupercharger: false,
         },
         armor: {
-          type: 'Standard',
+          type: "Standard",
           totalPoints: 0,
           locations: [],
         },
         structure: {
-          type: 'Standard',
+          type: "Standard",
           totalPoints: 0,
           locations: [],
         },
         heatSinks: {
-          type: 'Single',
+          type: "Single",
           count: 10,
           capacity: 10,
           integrated: 10,
@@ -430,141 +434,142 @@ describe('SVGRecordSheetRenderer', () => {
         },
         equipment: [],
         criticals: [],
-        mechType: 'biped',
+        mechType: "biped",
       };
 
-      renderer.fillTemplate(data as IRecordSheetData);
+      renderer.fillTemplate(data as IMechRecordSheetData);
 
       const svgString = renderer.getSVGString();
       expect(svgString).toBeDefined();
     });
 
-    it('should throw if template not loaded', () => {
+    it("should throw if template not loaded", () => {
       const freshRenderer = new SVGRecordSheetRenderer();
 
       expect(() => {
-        freshRenderer.fillTemplate({} as IRecordSheetData);
-      }).toThrow('Template not loaded');
+        freshRenderer.fillTemplate({} as IMechRecordSheetData);
+      }).toThrow("Template not loaded");
     });
   });
 
-  describe('getSVGString', () => {
-    it('should return serialized SVG document', async () => {
-      const mockSvg = createMockTemplate('biped');
+  describe("getSVGString", () => {
+    it("should return serialized SVG document", async () => {
+      const mockSvg = createMockTemplate("biped");
       (global.fetch as jest.Mock).mockImplementation(() =>
         createMockSVGResponse(mockSvg),
       );
       await renderer.loadTemplate(
-        '/record-sheets/templates_us/mek_biped_default.svg',
+        "/record-sheets/templates_us/mek_biped_default.svg",
       );
 
       const svgString = renderer.getSVGString();
 
-      expect(svgString).toContain('<svg');
-      expect(svgString).toContain('</svg>');
+      expect(svgString).toContain("<svg");
+      expect(svgString).toContain("</svg>");
     });
 
-    it('should throw if template not loaded', () => {
+    it("should throw if template not loaded", () => {
       const freshRenderer = new SVGRecordSheetRenderer();
 
-      expect(() => freshRenderer.getSVGString()).toThrow('Template not loaded');
+      expect(() => freshRenderer.getSVGString()).toThrow("Template not loaded");
     });
   });
 
-  describe('Multi-Configuration Support', () => {
-    describe('Quad Configuration', () => {
-      it('should use quad pip group IDs', async () => {
-        const mockSvg = createMockTemplate('quad');
+  describe("Multi-Configuration Support", () => {
+    describe("Quad Configuration", () => {
+      it("should use quad pip group IDs", async () => {
+        const mockSvg = createMockTemplate("quad");
         (global.fetch as jest.Mock).mockImplementation(() =>
           createMockSVGResponse(mockSvg),
         );
         await renderer.loadTemplate(
-          '/record-sheets/templates_us/mek_quad_default.svg',
+          "/record-sheets/templates_us/mek_quad_default.svg",
         );
 
-        const armorData: IRecordSheetData['armor'] =
-          createMockArmorData('quad');
-        await renderer.fillArmorPips(armorData, 'quad');
+        const armorData: IMechRecordSheetData["armor"] =
+          createMockArmorData("quad");
+        await renderer.fillArmorPips(armorData, "quad");
 
         // Verifies quad locations FLL, FRL, RLL, RRL are processed
       });
     });
 
-    describe('Tripod Configuration', () => {
-      it('should use tripod pip group IDs including center leg', async () => {
-        const mockSvg = createMockTemplate('tripod');
+    describe("Tripod Configuration", () => {
+      it("should use tripod pip group IDs including center leg", async () => {
+        const mockSvg = createMockTemplate("tripod");
         (global.fetch as jest.Mock).mockImplementation(() =>
           createMockSVGResponse(mockSvg),
         );
         await renderer.loadTemplate(
-          '/record-sheets/templates_us/mek_tripod_default.svg',
+          "/record-sheets/templates_us/mek_tripod_default.svg",
         );
 
-        const armorData: IRecordSheetData['armor'] =
-          createMockArmorData('tripod');
-        await renderer.fillArmorPips(armorData, 'tripod');
+        const armorData: IMechRecordSheetData["armor"] =
+          createMockArmorData("tripod");
+        await renderer.fillArmorPips(armorData, "tripod");
 
         // Verifies CL location is processed
       });
 
-      it('should generate pips for center leg when armor allocated', async () => {
-        const mockSvg = createMockTemplate('tripod');
+      it("should generate pips for center leg when armor allocated", async () => {
+        const mockSvg = createMockTemplate("tripod");
         (global.fetch as jest.Mock).mockImplementation(() =>
           createMockSVGResponse(mockSvg),
         );
         await renderer.loadTemplate(
-          '/record-sheets/templates_us/mek_tripod_default.svg',
+          "/record-sheets/templates_us/mek_tripod_default.svg",
         );
 
-        const armorData: IRecordSheetData['armor'] = {
-          type: 'Standard',
+        const armorData: IMechRecordSheetData["armor"] = {
+          type: "Standard",
           totalPoints: 20,
           locations: [
             {
-              location: 'Center Leg',
-              abbreviation: 'CL',
+              location: "Center Leg",
+              abbreviation: "CL",
               current: 20,
               maximum: 24,
             },
           ],
         };
 
-        await renderer.fillArmorPips(armorData, 'tripod');
+        await renderer.fillArmorPips(armorData, "tripod");
 
         // Should not throw when processing center leg
       });
     });
 
-    describe('LAM Configuration', () => {
-      it('should use biped locations for LAM', async () => {
-        const mockSvg = createMockTemplate('biped');
+    describe("LAM Configuration", () => {
+      it("should use biped locations for LAM", async () => {
+        const mockSvg = createMockTemplate("biped");
         (global.fetch as jest.Mock).mockImplementation(() =>
           createMockSVGResponse(mockSvg),
         );
         await renderer.loadTemplate(
-          '/record-sheets/templates_us/mek_lam_default.svg',
+          "/record-sheets/templates_us/mek_lam_default.svg",
         );
 
-        const armorData: IRecordSheetData['armor'] = createMockArmorData('lam');
-        await renderer.fillArmorPips(armorData, 'lam');
+        const armorData: IMechRecordSheetData["armor"] =
+          createMockArmorData("lam");
+        await renderer.fillArmorPips(armorData, "lam");
 
         // LAM uses biped pip group IDs
       });
     });
 
-    describe('QuadVee Configuration', () => {
-      it('should use quad locations for QuadVee', async () => {
-        const mockSvg = createMockTemplate('quad');
+    describe("QuadVee Configuration", () => {
+      it("should use quad locations for QuadVee", async () => {
+        const mockSvg = createMockTemplate("quad");
         (global.fetch as jest.Mock).mockImplementation(() =>
           createMockSVGResponse(mockSvg),
         );
         await renderer.loadTemplate(
-          '/record-sheets/templates_us/mek_quad_default.svg',
+          "/record-sheets/templates_us/mek_quad_default.svg",
         );
 
-        const armorData: IRecordSheetData['armor'] =
-          createMockArmorData('quadvee');
-        await renderer.fillArmorPips(armorData, 'quadvee');
+        const armorData: IMechRecordSheetData["armor"] =
+          createMockArmorData("quadvee");
+        await renderer.fillArmorPips(armorData, "quadvee");
 
         // QuadVee uses quad pip group IDs
       });

--- a/src/__tests__/service/printing/svgRecordSheetRenderer/structure.test.ts
+++ b/src/__tests__/service/printing/svgRecordSheetRenderer/structure.test.ts
@@ -15,15 +15,15 @@ import {
   TRIPOD_STRUCTURE_PIP_GROUP_IDS,
   PREMADE_PIP_TYPES,
   SVG_NS,
-} from '@/services/printing/svgRecordSheetRenderer/constants';
+} from "@/services/printing/svgRecordSheetRenderer/constants";
 import {
   fillStructurePips,
   generateStructurePipsForLocationFallback,
-} from '@/services/printing/svgRecordSheetRenderer/structure';
-import { IRecordSheetData, ILocationStructure } from '@/types/printing';
-import { logger } from '@/utils/logger';
+} from "@/services/printing/svgRecordSheetRenderer/structure";
+import { IMechRecordSheetData, ILocationStructure } from "@/types/printing";
+import { logger } from "@/utils/logger";
 
-jest.mock('@/utils/logger', () => ({
+jest.mock("@/utils/logger", () => ({
   logger: {
     debug: jest.fn(),
     info: jest.fn(),
@@ -33,19 +33,19 @@ jest.mock('@/utils/logger', () => ({
 }));
 
 // Mock the ArmorPipLayout module
-jest.mock('@/services/printing/ArmorPipLayout', () => ({
+jest.mock("@/services/printing/ArmorPipLayout", () => ({
   ArmorPipLayout: {
     addPips: jest.fn(),
   },
 }));
 
 // Mock the template module
-jest.mock('@/services/printing/svgRecordSheetRenderer/template', () => ({
+jest.mock("@/services/printing/svgRecordSheetRenderer/template", () => ({
   setTextContent: jest.fn(),
 }));
 
-import { ArmorPipLayout } from '@/services/printing/ArmorPipLayout';
-import { setTextContent } from '@/services/printing/svgRecordSheetRenderer/template';
+import { ArmorPipLayout } from "@/services/printing/ArmorPipLayout";
+import { setTextContent } from "@/services/printing/svgRecordSheetRenderer/template";
 
 // =============================================================================
 // Test Helpers
@@ -67,19 +67,19 @@ function getSvgRoot(doc: Document): SVGSVGElement {
  * @param includeDefaultGroups - Whether to include default structurePips/canonStructurePips groups
  */
 const createMockSVGDocument = (
-  additionalElements: string = '',
+  additionalElements: string = "",
   includeDefaultGroups: boolean = false,
 ): Document => {
   const parser = new DOMParser();
   const defaultGroups = includeDefaultGroups
     ? '<g id="structurePips"></g><g id="canonStructurePips"></g>'
-    : '';
+    : "";
   const doc = parser.parseFromString(
     `<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500">
       ${defaultGroups}
       ${additionalElements}
     </svg>`,
-    'image/svg+xml',
+    "image/svg+xml",
   );
   return doc;
 };
@@ -102,8 +102,8 @@ const createMockSVGResponse = (
  */
 const createMockStructure = (
   locations: Array<{ abbreviation: string; points: number }>,
-): IRecordSheetData['structure'] => ({
-  type: 'Standard',
+): IMechRecordSheetData["structure"] => ({
+  type: "Standard",
   totalPoints: locations.reduce((sum, loc) => sum + loc.points, 0),
   locations: locations.map(({ abbreviation, points }) => ({
     location: abbreviation, // simplified for tests
@@ -117,7 +117,7 @@ const createMockStructure = (
  */
 const createBipedStructure = (
   tonnage: number = 50,
-): IRecordSheetData['structure'] => {
+): IMechRecordSheetData["structure"] => {
   // Standard IS points vary by tonnage, using simplified values for tests
   const isPoints: Record<string, number> = {
     HD: 3,
@@ -141,16 +141,16 @@ const createBipedStructure = (
 /**
  * Creates quad mech structure data
  */
-const createQuadStructure = (): IRecordSheetData['structure'] => {
+const createQuadStructure = (): IMechRecordSheetData["structure"] => {
   return createMockStructure([
-    { abbreviation: 'HD', points: 3 },
-    { abbreviation: 'CT', points: 25 },
-    { abbreviation: 'LT', points: 17 },
-    { abbreviation: 'RT', points: 17 },
-    { abbreviation: 'FLL', points: 17 },
-    { abbreviation: 'FRL', points: 17 },
-    { abbreviation: 'RLL', points: 17 },
-    { abbreviation: 'RRL', points: 17 },
+    { abbreviation: "HD", points: 3 },
+    { abbreviation: "CT", points: 25 },
+    { abbreviation: "LT", points: 17 },
+    { abbreviation: "RT", points: 17 },
+    { abbreviation: "FLL", points: 17 },
+    { abbreviation: "FRL", points: 17 },
+    { abbreviation: "RLL", points: 17 },
+    { abbreviation: "RRL", points: 17 },
   ]);
 };
 
@@ -161,7 +161,7 @@ const createMockPipSVG = (pipCount: number): string => {
   const paths = Array.from(
     { length: pipCount },
     (_, i) => `<path id="pip${i}" d="M0,0 L10,0" fill="none" stroke="#000"/>`,
-  ).join('');
+  ).join("");
   return `<svg xmlns="http://www.w3.org/2000/svg">${paths}</svg>`;
 };
 
@@ -169,7 +169,7 @@ const createMockPipSVG = (pipCount: number): string => {
 // Tests
 // =============================================================================
 
-describe('structure.ts', () => {
+describe("structure.ts", () => {
   let mockFetch: jest.Mock;
   const consoleWarnSpy = logger.warn as jest.Mock;
 
@@ -179,9 +179,9 @@ describe('structure.ts', () => {
     global.fetch = mockFetch;
   });
 
-  describe('fillStructurePips', () => {
-    describe('Text Label Updates', () => {
-      it('should call setTextContent for each location with structure text ID', async () => {
+  describe("fillStructurePips", () => {
+    describe("Text Label Updates", () => {
+      it("should call setTextContent for each location with structure text ID", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createBipedStructure(50);
@@ -191,7 +191,7 @@ describe('structure.ts', () => {
           createMockSVGResponse(createMockPipSVG(5)),
         );
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "biped");
 
         // Should call setTextContent for locations that have STRUCTURE_TEXT_IDS
         structure.locations.forEach((loc) => {
@@ -206,51 +206,51 @@ describe('structure.ts', () => {
         });
       });
 
-      it('should format structure points with parentheses and spaces', async () => {
+      it("should format structure points with parentheses and spaces", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'CT', points: 31 },
+          { abbreviation: "CT", points: 31 },
         ]);
 
         mockFetch.mockImplementation(() =>
           createMockSVGResponse(createMockPipSVG(5)),
         );
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 100, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 100, "biped");
 
         expect(setTextContent).toHaveBeenCalledWith(
           svgDoc,
-          'textIS_CT',
-          '( 31 )',
+          "textIS_CT",
+          "( 31 )",
         );
       });
 
-      it('should skip locations without structure text IDs', async () => {
+      it("should skip locations without structure text IDs", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         // HD doesn't have a text element in the template
         const structure = createMockStructure([
-          { abbreviation: 'HD', points: 3 },
+          { abbreviation: "HD", points: 3 },
         ]);
 
         mockFetch.mockImplementation(() =>
           createMockSVGResponse(createMockPipSVG(3)),
         );
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "biped");
 
         // setTextContent should not be called for HD since STRUCTURE_TEXT_IDS['HD'] is undefined
         expect(setTextContent).not.toHaveBeenCalledWith(
           svgDoc,
           expect.anything(),
-          '( 3 )',
+          "( 3 )",
         );
       });
     });
 
-    describe('Biped Mech (Pre-made Pips)', () => {
-      it('should use pre-made pips for biped mech type', async () => {
+    describe("Biped Mech (Pre-made Pips)", () => {
+      it("should use pre-made pips for biped mech type", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createBipedStructure(50);
@@ -259,7 +259,7 @@ describe('structure.ts', () => {
           createMockSVGResponse(createMockPipSVG(5)),
         );
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "biped");
 
         // Should fetch pip files for each location
         expect(mockFetch).toHaveBeenCalled();
@@ -267,11 +267,11 @@ describe('structure.ts', () => {
         expect(ArmorPipLayout.addPips).not.toHaveBeenCalled();
       });
 
-      it('should default to biped when mechType is undefined', async () => {
+      it("should default to biped when mechType is undefined", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'CT', points: 25 },
+          { abbreviation: "CT", points: 25 },
         ]);
 
         mockFetch.mockImplementation(() =>
@@ -284,96 +284,96 @@ describe('structure.ts', () => {
         expect(mockFetch).toHaveBeenCalled();
       });
 
-      it('should hide template structurePips group and create new group when canonStructurePips absent', async () => {
+      it("should hide template structurePips group and create new group when canonStructurePips absent", async () => {
         // Create document with only structurePips (no canonStructurePips)
         const svgDoc = createMockSVGDocument(`<g id="structurePips"></g>`);
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'CT', points: 10 },
+          { abbreviation: "CT", points: 10 },
         ]);
 
         mockFetch.mockImplementation(() =>
           createMockSVGResponse(createMockPipSVG(3)),
         );
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "biped");
 
         // Template group should be hidden
-        const templatePips = svgDoc.getElementById('structurePips');
-        expect(templatePips?.getAttribute('visibility')).toBe('hidden');
+        const templatePips = svgDoc.getElementById("structurePips");
+        expect(templatePips?.getAttribute("visibility")).toBe("hidden");
 
         // New group should be created
-        const newGroup = svgDoc.getElementById('structure-pips-loaded');
+        const newGroup = svgDoc.getElementById("structure-pips-loaded");
         expect(newGroup).not.toBeNull();
-        expect(newGroup?.getAttribute('transform')).toBe(
-          'matrix(0.971,0,0,0.971,-378.511,-376.966)',
+        expect(newGroup?.getAttribute("transform")).toBe(
+          "matrix(0.971,0,0,0.971,-378.511,-376.966)",
         );
       });
 
-      it('should reuse existing canonStructurePips group if present', async () => {
+      it("should reuse existing canonStructurePips group if present", async () => {
         const svgDoc = createMockSVGDocument(`<g id="canonStructurePips"></g>`);
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'CT', points: 10 },
+          { abbreviation: "CT", points: 10 },
         ]);
 
         mockFetch.mockImplementation(() =>
           createMockSVGResponse(createMockPipSVG(3)),
         );
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "biped");
 
         // Should not create a new group
-        const newGroup = svgDoc.getElementById('structure-pips-loaded');
+        const newGroup = svgDoc.getElementById("structure-pips-loaded");
         expect(newGroup).toBeNull();
       });
 
-      it('should fetch correct pip file path for each location', async () => {
+      it("should fetch correct pip file path for each location", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'CT', points: 25 },
-          { abbreviation: 'HD', points: 3 },
+          { abbreviation: "CT", points: 25 },
+          { abbreviation: "HD", points: 3 },
         ]);
 
         mockFetch.mockImplementation(() =>
           createMockSVGResponse(createMockPipSVG(5)),
         );
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "biped");
 
         expect(mockFetch).toHaveBeenCalledWith(
-          '/record-sheets/biped_pips/BipedIS50_CT.svg',
+          "/record-sheets/biped_pips/BipedIS50_CT.svg",
         );
         expect(mockFetch).toHaveBeenCalledWith(
-          '/record-sheets/biped_pips/BipedIS50_HD.svg',
+          "/record-sheets/biped_pips/BipedIS50_HD.svg",
         );
       });
 
-      it('should create location groups with correct IDs and classes', async () => {
+      it("should create location groups with correct IDs and classes", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'LT', points: 15 },
+          { abbreviation: "LT", points: 15 },
         ]);
 
         mockFetch.mockImplementation(() =>
           createMockSVGResponse(createMockPipSVG(3)),
         );
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "biped");
 
         // Find the created location group
-        const locationGroup = svgDoc.getElementById('is_pips_LT');
+        const locationGroup = svgDoc.getElementById("is_pips_LT");
         expect(locationGroup).not.toBeNull();
-        expect(locationGroup?.getAttribute('class')).toBe('structure-pips');
+        expect(locationGroup?.getAttribute("class")).toBe("structure-pips");
       });
 
-      it('should clone paths with proper styling', async () => {
+      it("should clone paths with proper styling", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'RA', points: 10 },
+          { abbreviation: "RA", points: 10 },
         ]);
 
         // Pip SVG with paths that need styling
@@ -384,78 +384,78 @@ describe('structure.ts', () => {
 
         mockFetch.mockImplementation(() => createMockSVGResponse(pipSvg));
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "biped");
 
-        const locationGroup = svgDoc.getElementById('is_pips_RA');
-        const paths = locationGroup?.getElementsByTagName('path');
+        const locationGroup = svgDoc.getElementById("is_pips_RA");
+        const paths = locationGroup?.getElementsByTagName("path");
 
         if (paths && paths.length > 0) {
           // First path had fill="none", should get white fill
-          expect(paths[0].getAttribute('fill')).toBe('#FFFFFF');
-          expect(paths[0].getAttribute('stroke')).toBe('#000000');
+          expect(paths[0].getAttribute("fill")).toBe("#FFFFFF");
+          expect(paths[0].getAttribute("stroke")).toBe("#000000");
         }
       });
 
-      it('should handle missing pip file gracefully', async () => {
+      it("should handle missing pip file gracefully", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'CT', points: 25 },
+          { abbreviation: "CT", points: 25 },
         ]);
 
         mockFetch.mockImplementation(() =>
           Promise.resolve({
             ok: false,
-            text: () => Promise.resolve(''),
+            text: () => Promise.resolve(""),
           } as Response),
         );
 
         // Should not throw
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "biped");
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          expect.stringContaining('Structure pip file not found'),
+          expect.stringContaining("Structure pip file not found"),
         );
       });
 
-      it('should handle fetch error gracefully', async () => {
+      it("should handle fetch error gracefully", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'CT', points: 25 },
+          { abbreviation: "CT", points: 25 },
         ]);
 
         mockFetch.mockImplementation(() =>
-          Promise.reject(new Error('Network error')),
+          Promise.reject(new Error("Network error")),
         );
 
         // Should not throw
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "biped");
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          expect.stringContaining('Failed to load structure pip SVG'),
+          expect.stringContaining("Failed to load structure pip SVG"),
           expect.any(Error),
         );
       });
 
-      it('should skip pip file with no paths', async () => {
+      it("should skip pip file with no paths", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'HD', points: 3 },
+          { abbreviation: "HD", points: 3 },
         ]);
 
         const emptyPipSvg = `<svg xmlns="${SVG_NS}"></svg>`;
         mockFetch.mockImplementation(() => createMockSVGResponse(emptyPipSvg));
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "biped");
 
         // Should not create location group if no paths
-        const locationGroup = svgDoc.getElementById('is_pips_HD');
+        const locationGroup = svgDoc.getElementById("is_pips_HD");
         expect(locationGroup).toBeNull();
       });
 
-      it('should load pips for all locations in parallel', async () => {
+      it("should load pips for all locations in parallel", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createBipedStructure(50);
@@ -464,26 +464,26 @@ describe('structure.ts', () => {
           createMockSVGResponse(createMockPipSVG(5)),
         );
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "biped");
 
         // Should have called fetch for each location
         expect(mockFetch).toHaveBeenCalledTimes(structure.locations.length);
       });
     });
 
-    describe('Non-Biped Mechs (Dynamic Pips)', () => {
-      it('should use ArmorPipLayout for quad mechs', async () => {
+    describe("Non-Biped Mechs (Dynamic Pips)", () => {
+      it("should use ArmorPipLayout for quad mechs", async () => {
         const svgDoc = createMockSVGDocument(`
           <g id="isPipsFLL"></g>
           <g id="isPipsFRL"></g>
         `);
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'FLL', points: 17 },
-          { abbreviation: 'FRL', points: 17 },
+          { abbreviation: "FLL", points: 17 },
+          { abbreviation: "FRL", points: 17 },
         ]);
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'quad');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "quad");
 
         // Should not fetch pip files
         expect(mockFetch).not.toHaveBeenCalled();
@@ -491,7 +491,7 @@ describe('structure.ts', () => {
         expect(ArmorPipLayout.addPips).toHaveBeenCalledTimes(2);
       });
 
-      it('should use correct pip group IDs for quad mechs', async () => {
+      it("should use correct pip group IDs for quad mechs", async () => {
         const svgDoc = createMockSVGDocument(`
           <g id="isPipsFLL"></g>
           <g id="isPipsFRL"></g>
@@ -501,84 +501,84 @@ describe('structure.ts', () => {
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createQuadStructure();
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'quad');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "quad");
 
         // Check that ArmorPipLayout was called with correct elements
-        const fllGroup = svgDoc.getElementById('isPipsFLL');
+        const fllGroup = svgDoc.getElementById("isPipsFLL");
 
         expect(ArmorPipLayout.addPips).toHaveBeenCalledWith(
           svgDoc,
           fllGroup,
           17,
           expect.objectContaining({
-            fill: '#FFFFFF',
+            fill: "#FFFFFF",
             strokeWidth: 0.5,
-            className: 'pip structure',
+            className: "pip structure",
           }),
         );
       });
 
-      it('should use ArmorPipLayout for tripod mechs', async () => {
+      it("should use ArmorPipLayout for tripod mechs", async () => {
         const svgDoc = createMockSVGDocument(`
           <g id="isPipsCL"></g>
         `);
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'CL', points: 17 },
+          { abbreviation: "CL", points: 17 },
         ]);
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 80, 'tripod');
+        await fillStructurePips(svgDoc, svgRoot, structure, 80, "tripod");
 
         expect(ArmorPipLayout.addPips).toHaveBeenCalledWith(
           svgDoc,
           expect.anything(),
           17,
-          expect.objectContaining({ className: 'pip structure' }),
+          expect.objectContaining({ className: "pip structure" }),
         );
       });
 
-      it('should skip locations with zero points', async () => {
+      it("should skip locations with zero points", async () => {
         const svgDoc = createMockSVGDocument(`<g id="isPipsFLL"></g>`);
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'FLL', points: 0 },
+          { abbreviation: "FLL", points: 0 },
         ]);
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'quad');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "quad");
 
         // Should not call ArmorPipLayout for 0 points
         expect(ArmorPipLayout.addPips).not.toHaveBeenCalled();
       });
 
-      it('should warn when pip area element is not found', async () => {
+      it("should warn when pip area element is not found", async () => {
         const svgDoc = createMockSVGDocument(); // No pip groups
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'FLL', points: 17 },
+          { abbreviation: "FLL", points: 17 },
         ]);
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'quad');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "quad");
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          expect.stringContaining('Structure pip area not found'),
+          expect.stringContaining("Structure pip area not found"),
         );
       });
 
-      it('should warn when location has no group ID mapping', async () => {
+      it("should warn when location has no group ID mapping", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'UNKNOWN', points: 10 },
+          { abbreviation: "UNKNOWN", points: 10 },
         ]);
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'quad');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "quad");
 
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          expect.stringContaining('No structure pip group ID for location'),
+          expect.stringContaining("No structure pip group ID for location"),
         );
       });
 
-      it('should default non-premade types to quad pip generation', async () => {
+      it("should default non-premade types to quad pip generation", async () => {
         // quadvee uses quad pip group IDs, so use quad locations
         const svgDoc = createMockSVGDocument(`
           <g id="isPipsFLL"></g>
@@ -586,80 +586,80 @@ describe('structure.ts', () => {
         `);
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'FLL', points: 10 },
-          { abbreviation: 'FRL', points: 10 },
+          { abbreviation: "FLL", points: 10 },
+          { abbreviation: "FRL", points: 10 },
         ]);
 
         // quadvee is not in PREMADE_PIP_TYPES, so should use dynamic generation
         // Note: quadvee doesn't have its own pip group mapping, so it falls back to biped
         // which doesn't have FLL/FRL, but the code will warn and skip
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'quadvee');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "quadvee");
 
         // Since quadvee falls back to biped pip group IDs (which don't have FLL/FRL),
         // warnings should be logged but ArmorPipLayout won't be called
         expect(consoleWarnSpy).toHaveBeenCalledWith(
-          expect.stringContaining('No structure pip group ID for location'),
+          expect.stringContaining("No structure pip group ID for location"),
         );
       });
     });
 
-    describe('Edge Cases', () => {
-      it('should handle empty structure locations array', async () => {
+    describe("Edge Cases", () => {
+      it("should handle empty structure locations array", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([]);
 
         // Should not throw
-        await fillStructurePips(svgDoc, svgRoot, structure, 50, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 50, "biped");
 
         expect(mockFetch).not.toHaveBeenCalled();
       });
 
-      it('should handle very large tonnage values', async () => {
+      it("should handle very large tonnage values", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'CT', points: 62 },
+          { abbreviation: "CT", points: 62 },
         ]);
 
         mockFetch.mockImplementation(() =>
           createMockSVGResponse(createMockPipSVG(10)),
         );
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 100, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 100, "biped");
 
         expect(mockFetch).toHaveBeenCalledWith(
-          '/record-sheets/biped_pips/BipedIS100_CT.svg',
+          "/record-sheets/biped_pips/BipedIS100_CT.svg",
         );
       });
 
-      it('should handle small tonnage values', async () => {
+      it("should handle small tonnage values", async () => {
         const svgDoc = createMockSVGDocument();
         const svgRoot = getSvgRoot(svgDoc);
         const structure = createMockStructure([
-          { abbreviation: 'CT', points: 8 },
+          { abbreviation: "CT", points: 8 },
         ]);
 
         mockFetch.mockImplementation(() =>
           createMockSVGResponse(createMockPipSVG(3)),
         );
 
-        await fillStructurePips(svgDoc, svgRoot, structure, 20, 'biped');
+        await fillStructurePips(svgDoc, svgRoot, structure, 20, "biped");
 
         expect(mockFetch).toHaveBeenCalledWith(
-          '/record-sheets/biped_pips/BipedIS20_CT.svg',
+          "/record-sheets/biped_pips/BipedIS20_CT.svg",
         );
       });
     });
   });
 
-  describe('generateStructurePipsForLocationFallback', () => {
-    it('should return early if location has no pip group ID', () => {
+  describe("generateStructurePipsForLocationFallback", () => {
+    it("should return early if location has no pip group ID", () => {
       const svgDoc = createMockSVGDocument();
-      const parentGroup = svgDoc.createElementNS(SVG_NS, 'g');
+      const parentGroup = svgDoc.createElementNS(SVG_NS, "g");
       const location: ILocationStructure = {
-        location: 'Unknown',
-        abbreviation: 'UNK',
+        location: "Unknown",
+        abbreviation: "UNK",
         points: 10,
       };
 
@@ -669,24 +669,24 @@ describe('structure.ts', () => {
       expect(parentGroup.children.length).toBe(0);
     });
 
-    it('should warn when existing pip group not found', () => {
+    it("should warn when existing pip group not found", () => {
       const svgDoc = createMockSVGDocument();
-      const parentGroup = svgDoc.createElementNS(SVG_NS, 'g');
+      const parentGroup = svgDoc.createElementNS(SVG_NS, "g");
       const location: ILocationStructure = {
-        location: 'Center Torso',
-        abbreviation: 'CT',
+        location: "Center Torso",
+        abbreviation: "CT",
         points: 25,
       };
 
       generateStructurePipsForLocationFallback(svgDoc, parentGroup, location);
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Structure pip group not found'),
+        expect.stringContaining("Structure pip group not found"),
       );
     });
 
-    describe('With Existing Pips', () => {
-      it('should show correct number of pips and hide excess', () => {
+    describe("With Existing Pips", () => {
+      it("should show correct number of pips and hide excess", () => {
         // Create document with pip group containing existing pips
         const svgDoc = createMockSVGDocument(`
           <g id="isPipsCT">
@@ -697,65 +697,65 @@ describe('structure.ts', () => {
             <path class="pip structure" fill="#FFFFFF" visibility="visible"/>
           </g>
         `);
-        const parentGroup = svgDoc.createElementNS(SVG_NS, 'g');
+        const parentGroup = svgDoc.createElementNS(SVG_NS, "g");
         const location: ILocationStructure = {
-          location: 'Center Torso',
-          abbreviation: 'CT',
+          location: "Center Torso",
+          abbreviation: "CT",
           points: 3, // Only need 3 of 5
         };
 
         generateStructurePipsForLocationFallback(svgDoc, parentGroup, location);
 
-        const pipGroup = svgDoc.getElementById('isPipsCT');
-        const pips = pipGroup?.querySelectorAll('path.pip.structure');
+        const pipGroup = svgDoc.getElementById("isPipsCT");
+        const pips = pipGroup?.querySelectorAll("path.pip.structure");
 
         if (pips) {
           // First 3 should be visible
-          expect((pips[0] as SVGElement).getAttribute('visibility')).toBe(
-            'visible',
+          expect((pips[0] as SVGElement).getAttribute("visibility")).toBe(
+            "visible",
           );
-          expect((pips[1] as SVGElement).getAttribute('visibility')).toBe(
-            'visible',
+          expect((pips[1] as SVGElement).getAttribute("visibility")).toBe(
+            "visible",
           );
-          expect((pips[2] as SVGElement).getAttribute('visibility')).toBe(
-            'visible',
+          expect((pips[2] as SVGElement).getAttribute("visibility")).toBe(
+            "visible",
           );
           // Last 2 should be hidden
-          expect((pips[3] as SVGElement).getAttribute('visibility')).toBe(
-            'hidden',
+          expect((pips[3] as SVGElement).getAttribute("visibility")).toBe(
+            "hidden",
           );
-          expect((pips[4] as SVGElement).getAttribute('visibility')).toBe(
-            'hidden',
+          expect((pips[4] as SVGElement).getAttribute("visibility")).toBe(
+            "hidden",
           );
         }
       });
 
-      it('should apply white fill to visible pips', () => {
+      it("should apply white fill to visible pips", () => {
         const svgDoc = createMockSVGDocument(`
           <g id="isPipsLA">
             <circle class="pip structure" cx="0" cy="0" r="2"/>
             <circle class="pip structure" cx="5" cy="0" r="2"/>
           </g>
         `);
-        const parentGroup = svgDoc.createElementNS(SVG_NS, 'g');
+        const parentGroup = svgDoc.createElementNS(SVG_NS, "g");
         const location: ILocationStructure = {
-          location: 'Left Arm',
-          abbreviation: 'LA',
+          location: "Left Arm",
+          abbreviation: "LA",
           points: 2,
         };
 
         generateStructurePipsForLocationFallback(svgDoc, parentGroup, location);
 
-        const pipGroup = svgDoc.getElementById('isPipsLA');
-        const pips = pipGroup?.querySelectorAll('circle.pip.structure');
+        const pipGroup = svgDoc.getElementById("isPipsLA");
+        const pips = pipGroup?.querySelectorAll("circle.pip.structure");
 
         if (pips) {
-          expect((pips[0] as SVGElement).getAttribute('fill')).toBe('#FFFFFF');
-          expect((pips[1] as SVGElement).getAttribute('fill')).toBe('#FFFFFF');
+          expect((pips[0] as SVGElement).getAttribute("fill")).toBe("#FFFFFF");
+          expect((pips[1] as SVGElement).getAttribute("fill")).toBe("#FFFFFF");
         }
       });
 
-      it('should generate additional pips when needed', () => {
+      it("should generate additional pips when needed", () => {
         // Create with nested structure similar to MegaMek templates
         const svgDoc = createMockSVGDocument(`
           <g id="isPipsLL">
@@ -764,19 +764,19 @@ describe('structure.ts', () => {
             </g>
           </g>
         `);
-        const parentGroup = svgDoc.createElementNS(SVG_NS, 'g');
+        const parentGroup = svgDoc.createElementNS(SVG_NS, "g");
         const location: ILocationStructure = {
-          location: 'Left Leg',
-          abbreviation: 'LL',
+          location: "Left Leg",
+          abbreviation: "LL",
           points: 5, // Need more than exists
         };
 
         generateStructurePipsForLocationFallback(svgDoc, parentGroup, location);
 
         // Additional pips should be created (4 more)
-        const pipGroup = svgDoc.getElementById('isPipsLL');
+        const pipGroup = svgDoc.getElementById("isPipsLL");
         const allPips = pipGroup?.querySelectorAll(
-          'circle.pip.structure, path.pip.structure',
+          "circle.pip.structure, path.pip.structure",
         );
 
         // Should have generated additional pips
@@ -784,161 +784,161 @@ describe('structure.ts', () => {
       });
     });
 
-    describe('Without Existing Pips (Grid Generation)', () => {
-      it('should generate pip grid when no template pips exist', () => {
+    describe("Without Existing Pips (Grid Generation)", () => {
+      it("should generate pip grid when no template pips exist", () => {
         const svgDoc = createMockSVGDocument(`<g id="isPipsRT"></g>`);
-        const parentGroup = svgDoc.createElementNS(SVG_NS, 'g');
+        const parentGroup = svgDoc.createElementNS(SVG_NS, "g");
         const location: ILocationStructure = {
-          location: 'Right Torso',
-          abbreviation: 'RT',
+          location: "Right Torso",
+          abbreviation: "RT",
           points: 8,
         };
 
         generateStructurePipsForLocationFallback(svgDoc, parentGroup, location);
 
-        const pipGroup = svgDoc.getElementById('isPipsRT');
+        const pipGroup = svgDoc.getElementById("isPipsRT");
         const generatedGroup = pipGroup?.querySelector('g[id^="gen_is_pips_"]');
 
         expect(generatedGroup).not.toBeNull();
-        expect(generatedGroup?.getAttribute('class')).toBe(
-          'structure-pips-generated',
+        expect(generatedGroup?.getAttribute("class")).toBe(
+          "structure-pips-generated",
         );
       });
 
-      it('should create circles with correct attributes in grid', () => {
+      it("should create circles with correct attributes in grid", () => {
         const svgDoc = createMockSVGDocument(`<g id="isPipsHD"></g>`);
-        const parentGroup = svgDoc.createElementNS(SVG_NS, 'g');
+        const parentGroup = svgDoc.createElementNS(SVG_NS, "g");
         const location: ILocationStructure = {
-          location: 'Head',
-          abbreviation: 'HD',
+          location: "Head",
+          abbreviation: "HD",
           points: 3,
         };
 
         generateStructurePipsForLocationFallback(svgDoc, parentGroup, location);
 
-        const pipGroup = svgDoc.getElementById('isPipsHD');
-        const circles = pipGroup?.getElementsByTagName('circle');
+        const pipGroup = svgDoc.getElementById("isPipsHD");
+        const circles = pipGroup?.getElementsByTagName("circle");
 
         expect(circles?.length).toBe(3);
 
         if (circles && circles.length > 0) {
           const firstCircle = circles[0];
-          expect(firstCircle.getAttribute('fill')).toBe('#FFFFFF');
-          expect(firstCircle.getAttribute('stroke')).toBe('#000000');
-          expect(firstCircle.getAttribute('stroke-width')).toBe('0.5');
-          expect(firstCircle.getAttribute('class')).toBe('pip structure');
-          expect(firstCircle.getAttribute('r')).toBe('1.75');
+          expect(firstCircle.getAttribute("fill")).toBe("#FFFFFF");
+          expect(firstCircle.getAttribute("stroke")).toBe("#000000");
+          expect(firstCircle.getAttribute("stroke-width")).toBe("0.5");
+          expect(firstCircle.getAttribute("class")).toBe("pip structure");
+          expect(firstCircle.getAttribute("r")).toBe("1.75");
         }
       });
 
-      it('should arrange pips in rows based on location-specific column count', () => {
+      it("should arrange pips in rows based on location-specific column count", () => {
         const svgDoc = createMockSVGDocument(`<g id="isPipsCT"></g>`);
-        const parentGroup = svgDoc.createElementNS(SVG_NS, 'g');
+        const parentGroup = svgDoc.createElementNS(SVG_NS, "g");
         const location: ILocationStructure = {
-          location: 'Center Torso',
-          abbreviation: 'CT',
+          location: "Center Torso",
+          abbreviation: "CT",
           points: 12, // Should be 5 cols (CT layout), so 3 rows
         };
 
         generateStructurePipsForLocationFallback(svgDoc, parentGroup, location);
 
-        const pipGroup = svgDoc.getElementById('isPipsCT');
-        const circles = pipGroup?.getElementsByTagName('circle');
+        const pipGroup = svgDoc.getElementById("isPipsCT");
+        const circles = pipGroup?.getElementsByTagName("circle");
 
         expect(circles?.length).toBe(12);
 
         // Check that circles have varying y values (multiple rows)
         if (circles) {
           const yValues = Array.from(circles).map((c) =>
-            parseFloat(c.getAttribute('cy') || '0'),
+            parseFloat(c.getAttribute("cy") || "0"),
           );
           const uniqueY = new Set(yValues);
           expect(uniqueY.size).toBeGreaterThan(1);
         }
       });
 
-      it('should use location-specific column layout for known locations', () => {
+      it("should use location-specific column layout for known locations", () => {
         // HD has cols: 3 in the layout config
         const svgDoc = createMockSVGDocument(`<g id="isPipsHD"></g>`);
-        const parentGroup = svgDoc.createElementNS(SVG_NS, 'g');
+        const parentGroup = svgDoc.createElementNS(SVG_NS, "g");
         const location: ILocationStructure = {
-          location: 'Head',
-          abbreviation: 'HD',
+          location: "Head",
+          abbreviation: "HD",
           points: 6, // 6 pips with 3 cols = 2 rows
         };
 
         generateStructurePipsForLocationFallback(svgDoc, parentGroup, location);
 
-        const pipGroup = svgDoc.getElementById('isPipsHD');
-        const circles = pipGroup?.getElementsByTagName('circle');
+        const pipGroup = svgDoc.getElementById("isPipsHD");
+        const circles = pipGroup?.getElementsByTagName("circle");
 
         expect(circles?.length).toBe(6);
 
         // Verify row distribution - with 3 cols, should have y values at 0 and 4.5
         if (circles) {
           const yValues = Array.from(circles).map((c) =>
-            parseFloat(c.getAttribute('cy') || '0'),
+            parseFloat(c.getAttribute("cy") || "0"),
           );
           const uniqueY = new Set(yValues.map((y) => Math.round(y * 10) / 10)); // Round to 1 decimal
           expect(uniqueY.size).toBe(2); // 2 rows
         }
       });
 
-      it('should not generate pips for zero or negative count', () => {
+      it("should not generate pips for zero or negative count", () => {
         const svgDoc = createMockSVGDocument(`<g id="isPipsRA"></g>`);
-        const parentGroup = svgDoc.createElementNS(SVG_NS, 'g');
+        const parentGroup = svgDoc.createElementNS(SVG_NS, "g");
         const location: ILocationStructure = {
-          location: 'Right Arm',
-          abbreviation: 'RA',
+          location: "Right Arm",
+          abbreviation: "RA",
           points: 0,
         };
 
         generateStructurePipsForLocationFallback(svgDoc, parentGroup, location);
 
-        const pipGroup = svgDoc.getElementById('isPipsRA');
-        const circles = pipGroup?.getElementsByTagName('circle');
+        const pipGroup = svgDoc.getElementById("isPipsRA");
+        const circles = pipGroup?.getElementsByTagName("circle");
 
         expect(circles?.length).toBe(0);
       });
     });
   });
 
-  describe('Constants Integration', () => {
-    it('should use SVG_NS for element creation', () => {
-      expect(SVG_NS).toBe('http://www.w3.org/2000/svg');
+  describe("Constants Integration", () => {
+    it("should use SVG_NS for element creation", () => {
+      expect(SVG_NS).toBe("http://www.w3.org/2000/svg");
     });
 
-    it('should have PREMADE_PIP_TYPES include biped', () => {
-      expect(PREMADE_PIP_TYPES).toContain('biped');
+    it("should have PREMADE_PIP_TYPES include biped", () => {
+      expect(PREMADE_PIP_TYPES).toContain("biped");
     });
 
-    it('should have matching structure pip group IDs for biped locations', () => {
+    it("should have matching structure pip group IDs for biped locations", () => {
       expect(BIPED_STRUCTURE_PIP_GROUP_IDS).toMatchObject({
-        HD: 'isPipsHD',
-        CT: 'isPipsCT',
-        LT: 'isPipsLT',
-        RT: 'isPipsRT',
-        LA: 'isPipsLA',
-        RA: 'isPipsRA',
-        LL: 'isPipsLL',
-        RL: 'isPipsRL',
+        HD: "isPipsHD",
+        CT: "isPipsCT",
+        LT: "isPipsLT",
+        RT: "isPipsRT",
+        LA: "isPipsLA",
+        RA: "isPipsRA",
+        LL: "isPipsLL",
+        RL: "isPipsRL",
       });
     });
 
-    it('should have quad-specific leg locations', () => {
+    it("should have quad-specific leg locations", () => {
       expect(QUAD_STRUCTURE_PIP_GROUP_IDS).toMatchObject({
-        FLL: 'isPipsFLL',
-        FRL: 'isPipsFRL',
-        RLL: 'isPipsRLL',
-        RRL: 'isPipsRRL',
+        FLL: "isPipsFLL",
+        FRL: "isPipsFRL",
+        RLL: "isPipsRLL",
+        RRL: "isPipsRRL",
       });
     });
 
-    it('should have tripod center leg location', () => {
-      expect(TRIPOD_STRUCTURE_PIP_GROUP_IDS.CL).toBe('isPipsCL');
+    it("should have tripod center leg location", () => {
+      expect(TRIPOD_STRUCTURE_PIP_GROUP_IDS.CL).toBe("isPipsCL");
     });
 
-    it('should have STRUCTURE_PIP_GROUP_IDS alias biped IDs', () => {
+    it("should have STRUCTURE_PIP_GROUP_IDS alias biped IDs", () => {
       expect(STRUCTURE_PIP_GROUP_IDS).toEqual(BIPED_STRUCTURE_PIP_GROUP_IDS);
     });
   });

--- a/src/services/printing/RecordSheetService.ts
+++ b/src/services/printing/RecordSheetService.ts
@@ -2,6 +2,8 @@
  * Record Sheet Service
  *
  * Orchestrates record sheet generation, preview rendering, and PDF export.
+ * Dispatches on `unit.type` / `data.unitType` to per-type extractors and
+ * renderers for all six supported unit classes.
  *
  * @spec openspec/specs/record-sheet-export/spec.md
  */
@@ -34,33 +36,68 @@ import {
   extractHeatSinks,
   extractCriticals,
 } from "./recordsheet/dataExtractors";
+import {
+  extractVehicleData,
+  type IVehicleUnitConfig,
+} from "./recordsheet/dataExtractors.vehicle";
+import {
+  extractAerospaceData,
+  type IAerospaceUnitConfig,
+} from "./recordsheet/dataExtractors.aerospace";
+import {
+  extractBattleArmorData,
+  type IBattleArmorUnitConfig,
+} from "./recordsheet/dataExtractors.battleArmor";
+import {
+  extractInfantryData,
+  type IInfantryUnitConfig,
+} from "./recordsheet/dataExtractors.infantry";
+import {
+  extractProtoMechData,
+  type IProtoMechUnitConfig,
+} from "./recordsheet/dataExtractors.protoMech";
 import { getMechType } from "./recordsheet/mechTypeUtils";
 import { buildSPASection } from "./recordsheet/spaSection";
 import { IUnitConfig } from "./recordsheet/types";
 import { SVGRecordSheetRenderer } from "./svgRecordSheetRenderer";
+import { renderVehicleSVG } from "./svgRecordSheetRenderer/vehicleRenderer";
+import { renderAerospaceSVG } from "./svgRecordSheetRenderer/aerospaceRenderer";
+import { renderBattleArmorSVG } from "./svgRecordSheetRenderer/battleArmorRenderer";
+import { renderInfantrySVG } from "./svgRecordSheetRenderer/infantryRenderer";
+import { renderProtoMechSVG } from "./svgRecordSheetRenderer/protoMechRenderer";
+import { renderToCanvasHighDPI } from "./svgRecordSheetRenderer/canvas";
 
 export type { IUnitConfig };
 
 /**
+ * Render a non-mech SVG string to a canvas using the shared high-DPI helper.
+ */
+async function renderSVGStringToCanvas(
+  svgString: string,
+  canvas: HTMLCanvasElement,
+  dpiMultiplier: number,
+): Promise<void> {
+  await renderToCanvasHighDPI(svgString, canvas, dpiMultiplier);
+}
+
+/**
  * Record Sheet Service class
+ *
+ * All public methods accept the discriminated-union `IRecordSheetData` so
+ * callers work with the narrowed type they already have. Methods that
+ * previously accepted `IMechRecordSheetData` retain that overload for
+ * backward compatibility.
  */
 export class RecordSheetService {
-  /**
-   * Extract record sheet data from unit configuration.
-   *
-   * Phase 5 Wave 3: when `pilotAbilities` is supplied, the printable
-   * Special Abilities block is built and included on the output. Omit
-   * to render a sheet without the SPA section (legacy behaviour).
-   */
+  // ── Data extraction ──────────────────────────────────────────────────────
+
   /**
    * Extract mech record sheet data from a mech unit configuration.
    *
-   * Routes to `extractMechData` under the hood. For non-mech units, see
-   * `extractDataByType` which dispatches on `unit.type`.
+   * Legacy entry-point — always returns `IMechRecordSheetData`. For multi-type
+   * dispatch use `extractDataByType`.
    *
-   * Phase 5 Wave 3: when `pilotAbilities` is supplied, the printable
-   * Special Abilities block is built and included on the output. Omit
-   * to render a sheet without the SPA section (legacy behaviour).
+   * Phase 5 Wave 3: supply `pilotAbilities` to include the SPA block.
    */
   extractData(
     unit: IUnitConfig,
@@ -73,17 +110,28 @@ export class RecordSheetService {
    * Extract record sheet data dispatching on `unit.type`.
    *
    * Returns the appropriate `IRecordSheetData` variant. Throws
-   * `UnsupportedUnitTypeError` for unit types not yet supported.
+   * `UnsupportedUnitTypeError` for unknown unit types.
    */
   extractDataByType(
     unit: IUnitConfig & { type?: string },
     pilotAbilities?: readonly IPilotAbilityRef[],
   ): IRecordSheetData {
-    const unitType = (unit as { type?: string }).type ?? "mech";
+    const unitType = unit.type ?? "mech";
     switch (unitType) {
       case "mech":
-      case undefined:
         return this.extractMechData(unit, pilotAbilities);
+      case "vehicle":
+        return extractVehicleData(unit as unknown as IVehicleUnitConfig);
+      case "aerospace":
+        return extractAerospaceData(unit as unknown as IAerospaceUnitConfig);
+      case "battlearmor":
+        return extractBattleArmorData(
+          unit as unknown as IBattleArmorUnitConfig,
+        );
+      case "infantry":
+        return extractInfantryData(unit as unknown as IInfantryUnitConfig);
+      case "protomech":
+        return extractProtoMechData(unit as unknown as IProtoMechUnitConfig);
       default:
         throw new UnsupportedUnitTypeError(unitType);
     }
@@ -115,13 +163,95 @@ export class RecordSheetService {
     };
   }
 
+  // ── Rendering ────────────────────────────────────────────────────────────
+
   /**
-   * Render preview using SVG template (MegaMekLab-style)
+   * Render a preview of any unit type to a canvas.
+   *
+   * Mechs use the MegaMek SVG template pipeline; all other types use the
+   * per-type string-based SVG renderer rendered via the canvas helper.
    */
   async renderPreview(
     canvas: HTMLCanvasElement,
-    data: IMechRecordSheetData,
+    data: IRecordSheetData,
     paperSize: PaperSize = PaperSize.LETTER,
+  ): Promise<void> {
+    if (data.unitType === "mech") {
+      await this.renderMechPreview(canvas, data, paperSize);
+      return;
+    }
+    const svgString = this.buildNonMechSVG(data);
+    await renderSVGStringToCanvas(svgString, canvas, 1);
+  }
+
+  /**
+   * Return the SVG string for any unit type.
+   *
+   * Mechs go through the MegaMek template pipeline; others use the per-type
+   * string renderers.
+   */
+  async getSVGString(
+    data: IRecordSheetData,
+    paperSize: PaperSize = PaperSize.LETTER,
+  ): Promise<string> {
+    if (data.unitType === "mech") {
+      return this.getMechSVGString(data, paperSize);
+    }
+    return this.buildNonMechSVG(data);
+  }
+
+  /**
+   * Export to PDF and trigger a browser download.
+   *
+   * For non-mech units the per-type SVG is rasterised to canvas then embedded
+   * in the PDF at letter / A4 dimensions.
+   */
+  async exportPDF(
+    data: IRecordSheetData,
+    options: IPDFExportOptions = {
+      paperSize: PaperSize.LETTER,
+      includePilotData: false,
+    },
+  ): Promise<void> {
+    const { paperSize, filename } = options;
+    const { width, height } = PAPER_DIMENSIONS[paperSize];
+
+    if (data.unitType === "mech") {
+      await this.exportMechPDF(data, options);
+      return;
+    }
+
+    // Non-mech: render SVG string → canvas → PDF
+    const canvas = document.createElement("canvas");
+    const scaledWidth = width * PDF_DPI_MULTIPLIER;
+    const scaledHeight = height * PDF_DPI_MULTIPLIER;
+    canvas.width = scaledWidth;
+    canvas.height = scaledHeight;
+
+    const svgString = this.buildNonMechSVG(data);
+    await renderSVGStringToCanvas(svgString, canvas, PDF_DPI_MULTIPLIER);
+
+    const pdf = new jsPDF({
+      orientation: "portrait",
+      unit: "pt",
+      format: paperSize === PaperSize.A4 ? "a4" : "letter",
+    });
+
+    const imgData = canvas.toDataURL("image/jpeg", 0.95);
+    pdf.addImage(imgData, "JPEG", 0, 0, width, height);
+
+    const pdfFilename =
+      filename ||
+      `${data.header.chassis}-${data.header.model}.pdf`.replace(/\s+/g, "-");
+    pdf.save(pdfFilename);
+  }
+
+  // ── Internal mech helpers (preserve existing behaviour exactly) ───────────
+
+  private async renderMechPreview(
+    canvas: HTMLCanvasElement,
+    data: IMechRecordSheetData,
+    paperSize: PaperSize,
   ): Promise<void> {
     const templates =
       paperSize === PaperSize.A4 ? SVG_TEMPLATES_A4 : SVG_TEMPLATES;
@@ -139,9 +269,9 @@ export class RecordSheetService {
     await renderer.renderToCanvas(canvas);
   }
 
-  async getSVGString(
+  private async getMechSVGString(
     data: IMechRecordSheetData,
-    paperSize: PaperSize = PaperSize.LETTER,
+    paperSize: PaperSize,
   ): Promise<string> {
     const templates =
       paperSize === PaperSize.A4 ? SVG_TEMPLATES_A4 : SVG_TEMPLATES;
@@ -159,16 +289,9 @@ export class RecordSheetService {
     return renderer.getSVGString();
   }
 
-  /**
-   * Export to PDF and trigger download
-   * Uses SVG template rendering with high-DPI (3x) for crisp text and graphics.
-   */
-  async exportPDF(
+  private async exportMechPDF(
     data: IMechRecordSheetData,
-    options: IPDFExportOptions = {
-      paperSize: PaperSize.LETTER,
-      includePilotData: false,
-    },
+    options: IPDFExportOptions,
   ): Promise<void> {
     const { paperSize, filename } = options;
     const { width, height } = PAPER_DIMENSIONS[paperSize];
@@ -210,7 +333,38 @@ export class RecordSheetService {
   }
 
   /**
-   * Print record sheet using browser print dialog
+   * Build an SVG string for any non-mech unit type by calling the matching
+   * per-type renderer. Throws `UnsupportedUnitTypeError` for the 'mech' case
+   * (callers should use the mech pipeline) and unknown types.
+   */
+  private buildNonMechSVG(data: IRecordSheetData): string {
+    switch (data.unitType) {
+      case "vehicle":
+        return renderVehicleSVG(data);
+      case "aerospace":
+        return renderAerospaceSVG(data);
+      case "battlearmor":
+        return renderBattleArmorSVG(data);
+      case "infantry":
+        return renderInfantrySVG(data);
+      case "protomech":
+        return renderProtoMechSVG(data);
+      case "mech":
+        throw new UnsupportedUnitTypeError("mech (use mech pipeline)");
+      default: {
+        // TypeScript exhaustiveness guard
+        const _exhaustive: never = data;
+        throw new UnsupportedUnitTypeError(
+          (_exhaustive as { unitType: string }).unitType,
+        );
+      }
+    }
+  }
+
+  // ── Print helper (unchanged) ─────────────────────────────────────────────
+
+  /**
+   * Print record sheet using browser print dialog.
    */
   print(canvas: HTMLCanvasElement): void {
     const dataUrl = canvas.toDataURL("image/png");

--- a/src/services/printing/RecordSheetService.ts
+++ b/src/services/printing/RecordSheetService.ts
@@ -6,23 +6,25 @@
  * @spec openspec/specs/record-sheet-export/spec.md
  */
 
-import { jsPDF } from 'jspdf';
+import { jsPDF } from "jspdf";
 
-import type { IPilotAbilityRef } from '@/types/pilot';
+import type { IPilotAbilityRef } from "@/types/pilot";
 
 import {
   createSingleton,
   type SingletonFactory,
-} from '@/services/core/createSingleton';
+} from "@/services/core/createSingleton";
 import {
   IRecordSheetData,
+  IMechRecordSheetData,
+  UnsupportedUnitTypeError,
   PaperSize,
   PAPER_DIMENSIONS,
   PDF_DPI_MULTIPLIER,
   IPDFExportOptions,
-} from '@/types/printing';
+} from "@/types/printing";
 
-import { SVG_TEMPLATES, SVG_TEMPLATES_A4 } from './recordsheet/constants';
+import { SVG_TEMPLATES, SVG_TEMPLATES_A4 } from "./recordsheet/constants";
 import {
   extractHeader,
   extractMovement,
@@ -31,11 +33,11 @@ import {
   extractEquipment,
   extractHeatSinks,
   extractCriticals,
-} from './recordsheet/dataExtractors';
-import { getMechType } from './recordsheet/mechTypeUtils';
-import { buildSPASection } from './recordsheet/spaSection';
-import { IUnitConfig } from './recordsheet/types';
-import { SVGRecordSheetRenderer } from './svgRecordSheetRenderer';
+} from "./recordsheet/dataExtractors";
+import { getMechType } from "./recordsheet/mechTypeUtils";
+import { buildSPASection } from "./recordsheet/spaSection";
+import { IUnitConfig } from "./recordsheet/types";
+import { SVGRecordSheetRenderer } from "./svgRecordSheetRenderer";
 
 export type { IUnitConfig };
 
@@ -50,15 +52,56 @@ export class RecordSheetService {
    * Special Abilities block is built and included on the output. Omit
    * to render a sheet without the SPA section (legacy behaviour).
    */
+  /**
+   * Extract mech record sheet data from a mech unit configuration.
+   *
+   * Routes to `extractMechData` under the hood. For non-mech units, see
+   * `extractDataByType` which dispatches on `unit.type`.
+   *
+   * Phase 5 Wave 3: when `pilotAbilities` is supplied, the printable
+   * Special Abilities block is built and included on the output. Omit
+   * to render a sheet without the SPA section (legacy behaviour).
+   */
   extractData(
     unit: IUnitConfig,
     pilotAbilities?: readonly IPilotAbilityRef[],
+  ): IMechRecordSheetData {
+    return this.extractMechData(unit, pilotAbilities);
+  }
+
+  /**
+   * Extract record sheet data dispatching on `unit.type`.
+   *
+   * Returns the appropriate `IRecordSheetData` variant. Throws
+   * `UnsupportedUnitTypeError` for unit types not yet supported.
+   */
+  extractDataByType(
+    unit: IUnitConfig & { type?: string },
+    pilotAbilities?: readonly IPilotAbilityRef[],
   ): IRecordSheetData {
+    const unitType = (unit as { type?: string }).type ?? "mech";
+    switch (unitType) {
+      case "mech":
+      case undefined:
+        return this.extractMechData(unit, pilotAbilities);
+      default:
+        throw new UnsupportedUnitTypeError(unitType);
+    }
+  }
+
+  /**
+   * Extract mech-specific record sheet data.
+   */
+  private extractMechData(
+    unit: IUnitConfig,
+    pilotAbilities?: readonly IPilotAbilityRef[],
+  ): IMechRecordSheetData {
     const spaBlock = pilotAbilities
       ? buildSPASection(pilotAbilities)
       : { entries: [], hasContent: false };
 
     return {
+      unitType: "mech",
       header: extractHeader(unit),
       movement: extractMovement(unit),
       armor: extractArmor(unit),
@@ -77,7 +120,7 @@ export class RecordSheetService {
    */
   async renderPreview(
     canvas: HTMLCanvasElement,
-    data: IRecordSheetData,
+    data: IMechRecordSheetData,
     paperSize: PaperSize = PaperSize.LETTER,
   ): Promise<void> {
     const templates =
@@ -97,7 +140,7 @@ export class RecordSheetService {
   }
 
   async getSVGString(
-    data: IRecordSheetData,
+    data: IMechRecordSheetData,
     paperSize: PaperSize = PaperSize.LETTER,
   ): Promise<string> {
     const templates =
@@ -121,7 +164,7 @@ export class RecordSheetService {
    * Uses SVG template rendering with high-DPI (3x) for crisp text and graphics.
    */
   async exportPDF(
-    data: IRecordSheetData,
+    data: IMechRecordSheetData,
     options: IPDFExportOptions = {
       paperSize: PaperSize.LETTER,
       includePilotData: false,
@@ -130,7 +173,7 @@ export class RecordSheetService {
     const { paperSize, filename } = options;
     const { width, height } = PAPER_DIMENSIONS[paperSize];
 
-    const canvas = document.createElement('canvas');
+    const canvas = document.createElement("canvas");
     const scaledWidth = width * PDF_DPI_MULTIPLIER;
     const scaledHeight = height * PDF_DPI_MULTIPLIER;
     canvas.width = scaledWidth;
@@ -152,17 +195,17 @@ export class RecordSheetService {
     await renderer.renderToCanvasHighDPI(canvas, PDF_DPI_MULTIPLIER);
 
     const pdf = new jsPDF({
-      orientation: 'portrait',
-      unit: 'pt',
-      format: paperSize === PaperSize.A4 ? 'a4' : 'letter',
+      orientation: "portrait",
+      unit: "pt",
+      format: paperSize === PaperSize.A4 ? "a4" : "letter",
     });
 
-    const imgData = canvas.toDataURL('image/jpeg', 0.95);
-    pdf.addImage(imgData, 'JPEG', 0, 0, width, height);
+    const imgData = canvas.toDataURL("image/jpeg", 0.95);
+    pdf.addImage(imgData, "JPEG", 0, 0, width, height);
 
     const pdfFilename =
       filename ||
-      `${data.header.chassis}-${data.header.model}.pdf`.replace(/\s+/g, '-');
+      `${data.header.chassis}-${data.header.model}.pdf`.replace(/\s+/g, "-");
     pdf.save(pdfFilename);
   }
 
@@ -170,18 +213,18 @@ export class RecordSheetService {
    * Print record sheet using browser print dialog
    */
   print(canvas: HTMLCanvasElement): void {
-    const dataUrl = canvas.toDataURL('image/png');
+    const dataUrl = canvas.toDataURL("image/png");
 
-    const printWindow = window.open('', '_blank');
+    const printWindow = window.open("", "_blank");
     if (!printWindow) {
       throw new Error(
-        'Could not open print window. Check popup blocker settings.',
+        "Could not open print window. Check popup blocker settings.",
       );
     }
 
     const windowDoc = (printWindow as { document?: Document }).document;
     if (!windowDoc) {
-      throw new Error('Print window does not have document access');
+      throw new Error("Print window does not have document access");
     }
 
     windowDoc.write(`

--- a/src/services/printing/recordsheet/dataExtractors.aerospace.ts
+++ b/src/services/printing/recordsheet/dataExtractors.aerospace.ts
@@ -1,0 +1,124 @@
+/**
+ * Aerospace Record Sheet Data Extractor
+ *
+ * Produces `IAerospaceRecordSheetData` from an aerospace fighter / conventional
+ * fighter unit configuration.
+ */
+
+import {
+  IAerospaceRecordSheetData,
+  IAerospaceArcArmor,
+  IRecordSheetEquipment,
+  IRecordSheetHeatSinks,
+} from "@/types/printing";
+
+import { extractHeader } from "./dataExtractors";
+
+/** Aerospace-specific unit config fields. */
+export interface IAerospaceUnitConfig {
+  id: string;
+  name: string;
+  chassis: string;
+  model: string;
+  tonnage: number;
+  techBase: string;
+  rulesLevel: string;
+  era: string;
+  battleValue?: number;
+  cost?: number;
+  /** Structural Integrity points. */
+  structuralIntegrity?: number;
+  /** Total fuel points (standard aerospace: 400). */
+  fuelPoints?: number;
+  /** Safe Thrust rating (2/3 of max, rounded up). */
+  safeThrust?: number;
+  /** Maximum Thrust rating. */
+  maxThrust?: number;
+  heatSinks?: { type: string; count: number };
+  armorType?: string;
+  /** Armor per arc. Missing arcs default to 0/0. */
+  armorArcs?: Partial<
+    Record<IAerospaceArcArmor["arc"], { current: number; maximum: number }>
+  >;
+  equipment?: Array<{
+    id: string;
+    name: string;
+    location: string;
+    heat?: number;
+    damage?: number | string;
+    ranges?: { minimum: number; short: number; medium: number; long: number };
+    isWeapon?: boolean;
+    isAmmo?: boolean;
+    ammoCount?: number;
+  }>;
+  /** Number of bomb bay slots (0 or absent when none). */
+  bombBaySlots?: number;
+}
+
+/** Canonical arc order for the 4-arc armor diagram. */
+const ARC_ORDER: IAerospaceArcArmor["arc"][] = [
+  "Nose",
+  "Left Wing",
+  "Right Wing",
+  "Aft",
+];
+
+/**
+ * Extract aerospace record sheet data from a unit configuration.
+ */
+export function extractAerospaceData(
+  unit: IAerospaceUnitConfig,
+): IAerospaceRecordSheetData {
+  const arcAlloc = unit.armorArcs ?? {};
+  const armorArcs: IAerospaceArcArmor[] = ARC_ORDER.map((arc) => ({
+    arc,
+    current: arcAlloc[arc]?.current ?? 0,
+    maximum: arcAlloc[arc]?.maximum ?? 0,
+  }));
+
+  const hsRaw = unit.heatSinks ?? { type: "Single", count: 10 };
+  const isDouble = hsRaw.type.toLowerCase().includes("double");
+  const heatSinks: IRecordSheetHeatSinks = {
+    type: hsRaw.type,
+    count: hsRaw.count,
+    capacity: hsRaw.count * (isDouble ? 2 : 1),
+    integrated: Math.min(hsRaw.count, 10),
+    external: Math.max(0, hsRaw.count - 10),
+  };
+
+  const equipment: IRecordSheetEquipment[] = (unit.equipment ?? []).map(
+    (eq, idx) => ({
+      id: eq.id ?? String(idx),
+      name: eq.name,
+      location: eq.location,
+      locationAbbr: eq.location.substring(0, 3).toUpperCase(),
+      heat: eq.heat ?? "-",
+      damage: eq.damage ?? "-",
+      damageCode: undefined,
+      minimum: eq.ranges?.minimum ?? "-",
+      short: eq.ranges?.short ?? "-",
+      medium: eq.ranges?.medium ?? "-",
+      long: eq.ranges?.long ?? "-",
+      quantity: 1,
+      isWeapon: eq.isWeapon ?? false,
+      isAmmo: eq.isAmmo ?? false,
+      ammoCount: eq.ammoCount,
+    }),
+  );
+
+  return {
+    unitType: "aerospace",
+    header: extractHeader(unit as Parameters<typeof extractHeader>[0]),
+    structuralIntegrity: unit.structuralIntegrity ?? 0,
+    fuelPoints: unit.fuelPoints ?? 400,
+    safeThrust: unit.safeThrust ?? 0,
+    maxThrust: unit.maxThrust ?? 0,
+    heatSinks,
+    armorType: unit.armorType ?? "Aerospace Standard",
+    armorArcs,
+    equipment,
+    bombBaySlots: unit.bombBaySlots ?? 0,
+    pilot: undefined,
+    specialAbilities: undefined,
+  };
+}

--- a/src/services/printing/recordsheet/dataExtractors.battleArmor.ts
+++ b/src/services/printing/recordsheet/dataExtractors.battleArmor.ts
@@ -1,0 +1,85 @@
+/**
+ * BattleArmor Record Sheet Data Extractor
+ *
+ * Produces `IBattleArmorRecordSheetData` from a BattleArmor unit configuration.
+ */
+
+import {
+  IBattleArmorRecordSheetData,
+  IBattleArmorTrooper,
+} from "@/types/printing";
+
+import { extractHeader } from "./dataExtractors";
+
+/** BattleArmor-specific unit config fields. */
+export interface IBattleArmorUnitConfig {
+  id: string;
+  name: string;
+  chassis: string;
+  model: string;
+  tonnage: number;
+  techBase: string;
+  rulesLevel: string;
+  era: string;
+  battleValue?: number;
+  cost?: number;
+  /** Number of troopers in the squad (2–6 IS, 2–5 Clan). */
+  squadSize?: number;
+  /** Per-trooper armor pip data. Length should equal squadSize. */
+  troopers?: Array<{
+    index: number;
+    armorPips: number;
+    maximumArmorPips: number;
+    modularWeapon?: string;
+    apWeapon?: string;
+    gunnery?: number;
+    antiMech?: number;
+  }>;
+  manipulators?: { left: string; right: string };
+  walkMP?: number;
+  jumpMP?: number;
+  umuMP?: number;
+  vtolMP?: number;
+}
+
+/**
+ * Extract BattleArmor record sheet data.
+ *
+ * Generates synthetic trooper entries when `troopers` is absent so the
+ * renderer always has something to display.
+ */
+export function extractBattleArmorData(
+  unit: IBattleArmorUnitConfig,
+): IBattleArmorRecordSheetData {
+  const squadSize = unit.squadSize ?? 4;
+
+  // Build trooper list — fill missing entries with defaults
+  const rawTroopers = unit.troopers ?? [];
+  const troopers: IBattleArmorTrooper[] = Array.from(
+    { length: squadSize },
+    (_, i) => {
+      const raw = rawTroopers[i];
+      return {
+        index: i + 1,
+        armorPips: raw?.armorPips ?? 4,
+        maximumArmorPips: raw?.maximumArmorPips ?? 4,
+        modularWeapon: raw?.modularWeapon,
+        apWeapon: raw?.apWeapon,
+        gunnery: raw?.gunnery ?? 4,
+        antiMech: raw?.antiMech ?? 5,
+      };
+    },
+  );
+
+  return {
+    unitType: "battlearmor",
+    header: extractHeader(unit as Parameters<typeof extractHeader>[0]),
+    squadSize,
+    troopers,
+    manipulators: unit.manipulators ?? { left: "None", right: "None" },
+    walkMP: unit.walkMP ?? 0,
+    jumpMP: unit.jumpMP ?? 0,
+    umuMP: unit.umuMP ?? 0,
+    vtolMP: unit.vtolMP ?? 0,
+  };
+}

--- a/src/services/printing/recordsheet/dataExtractors.infantry.ts
+++ b/src/services/printing/recordsheet/dataExtractors.infantry.ts
@@ -1,0 +1,82 @@
+/**
+ * Infantry Record Sheet Data Extractor
+ *
+ * Produces `IInfantryRecordSheetData` from an infantry platoon unit configuration.
+ */
+
+import {
+  IInfantryRecordSheetData,
+  IInfantryFieldGunSheet,
+} from "@/types/printing";
+
+import { extractHeader } from "./dataExtractors";
+
+/** Infantry-specific unit config fields. */
+export interface IInfantryUnitConfig {
+  id: string;
+  name: string;
+  chassis: string;
+  model: string;
+  tonnage: number;
+  techBase: string;
+  rulesLevel: string;
+  era: string;
+  battleValue?: number;
+  cost?: number;
+  /** Total troopers in the platoon. */
+  platoonSize?: number;
+  /** Movement mode. */
+  motiveType?: IInfantryRecordSheetData["motiveType"];
+  /** Primary weapon name. */
+  primaryWeapon?: string;
+  /** Secondary weapons with anti-personnel ratio. */
+  secondaryWeapons?: Array<{ name: string; perTrooperRatio: number }>;
+  /** Field gun block — 1 gun per 7 men. */
+  fieldGun?: {
+    name: string;
+    count: number;
+    damage: number | string;
+    minimumRange: number;
+    shortRange: number;
+    mediumRange: number;
+    longRange: number;
+  };
+  /** Specialization badge string (anti-mech, marine, scuba, mountain, xct). */
+  specialization?: string;
+  /** Gunnery skill (default 5). */
+  gunnery?: number;
+  /** Anti-mech skill (default 6). */
+  antiMech?: number;
+}
+
+/**
+ * Extract infantry record sheet data.
+ */
+export function extractInfantryData(
+  unit: IInfantryUnitConfig,
+): IInfantryRecordSheetData {
+  const fieldGun: IInfantryFieldGunSheet | undefined = unit.fieldGun
+    ? {
+        name: unit.fieldGun.name,
+        count: unit.fieldGun.count,
+        damage: unit.fieldGun.damage,
+        minimumRange: unit.fieldGun.minimumRange,
+        shortRange: unit.fieldGun.shortRange,
+        mediumRange: unit.fieldGun.mediumRange,
+        longRange: unit.fieldGun.longRange,
+      }
+    : undefined;
+
+  return {
+    unitType: "infantry",
+    header: extractHeader(unit as Parameters<typeof extractHeader>[0]),
+    platoonSize: unit.platoonSize ?? 28,
+    motiveType: unit.motiveType ?? "Foot",
+    primaryWeapon: unit.primaryWeapon ?? "Auto Rifle",
+    secondaryWeapons: unit.secondaryWeapons ?? [],
+    fieldGun,
+    specialization: unit.specialization,
+    gunnery: unit.gunnery ?? 5,
+    antiMech: unit.antiMech ?? 6,
+  };
+}

--- a/src/services/printing/recordsheet/dataExtractors.protoMech.ts
+++ b/src/services/printing/recordsheet/dataExtractors.protoMech.ts
@@ -1,0 +1,151 @@
+/**
+ * ProtoMech Record Sheet Data Extractor
+ *
+ * Produces `IProtoMechRecordSheetData` from a ProtoMech point unit configuration.
+ */
+
+import {
+  IProtoMechRecordSheetData,
+  IProtoMechUnit,
+  IRecordSheetEquipment,
+} from "@/types/printing";
+
+import { extractHeader } from "./dataExtractors";
+
+/** ProtoMech location keys. */
+type ProtoLoc =
+  | "Head"
+  | "Torso"
+  | "Left Arm"
+  | "Right Arm"
+  | "Legs"
+  | "Main Gun";
+
+/** ProtoMech-specific unit config fields. */
+export interface IProtoMechUnitConfig {
+  id: string;
+  name: string;
+  chassis: string;
+  model: string;
+  /** Tonnage per individual ProtoMech (2–9t). */
+  tonnage: number;
+  techBase: string;
+  rulesLevel: string;
+  era: string;
+  battleValue?: number;
+  cost?: number;
+  /** Number of ProtoMechs in this point (1–5). */
+  pointSize?: number;
+  /** Per-proto armor data. Missing entries get synthetic defaults. */
+  protos?: Array<{
+    index: number;
+    armorByLocation: Partial<
+      Record<ProtoLoc, { current: number; maximum: number }>
+    >;
+  }>;
+  /** Main gun designation (weapon name). */
+  mainGun?: string;
+  /** Remaining main gun ammo shots. */
+  mainGunAmmo?: number;
+  hasUMU?: boolean;
+  isGlider?: boolean;
+  walkMP?: number;
+  jumpMP?: number;
+  equipment?: Array<{
+    id: string;
+    name: string;
+    location: string;
+    heat?: number;
+    damage?: number | string;
+    ranges?: { minimum: number; short: number; medium: number; long: number };
+    isWeapon?: boolean;
+    isAmmo?: boolean;
+    ammoCount?: number;
+  }>;
+}
+
+/** Default armor values per location when absent from config. */
+const DEFAULT_ARMOR: Record<ProtoLoc, { current: number; maximum: number }> = {
+  Head: { current: 0, maximum: 0 },
+  Torso: { current: 0, maximum: 0 },
+  "Left Arm": { current: 0, maximum: 0 },
+  "Right Arm": { current: 0, maximum: 0 },
+  Legs: { current: 0, maximum: 0 },
+  "Main Gun": { current: 0, maximum: 0 },
+};
+
+/**
+ * Build a fully-specified armor map for one proto, filling missing locations
+ * with zero values so the renderer always has all 6 keys available.
+ */
+function buildArmorMap(
+  raw?: Partial<Record<ProtoLoc, { current: number; maximum: number }>>,
+): Record<ProtoLoc, { current: number; maximum: number }> {
+  const locs: ProtoLoc[] = [
+    "Head",
+    "Torso",
+    "Left Arm",
+    "Right Arm",
+    "Legs",
+    "Main Gun",
+  ];
+  const result = {} as Record<ProtoLoc, { current: number; maximum: number }>;
+  for (const loc of locs) {
+    result[loc] = raw?.[loc] ?? DEFAULT_ARMOR[loc];
+  }
+  return result;
+}
+
+/**
+ * Extract ProtoMech record sheet data from a point configuration.
+ */
+export function extractProtoMechData(
+  unit: IProtoMechUnitConfig,
+): IProtoMechRecordSheetData {
+  const pointSize = Math.min(Math.max(unit.pointSize ?? 1, 1), 5);
+
+  // Build proto entries — synthesise missing ones
+  const rawProtos = unit.protos ?? [];
+  const protos: IProtoMechUnit[] = Array.from({ length: pointSize }, (_, i) => {
+    const raw = rawProtos[i];
+    return {
+      index: i + 1,
+      armorByLocation: buildArmorMap(raw?.armorByLocation),
+    };
+  });
+
+  const equipment: IRecordSheetEquipment[] = (unit.equipment ?? []).map(
+    (eq, idx) => ({
+      id: eq.id ?? String(idx),
+      name: eq.name,
+      location: eq.location,
+      locationAbbr: eq.location.substring(0, 3).toUpperCase(),
+      heat: eq.heat ?? "-",
+      damage: eq.damage ?? "-",
+      damageCode: undefined,
+      minimum: eq.ranges?.minimum ?? "-",
+      short: eq.ranges?.short ?? "-",
+      medium: eq.ranges?.medium ?? "-",
+      long: eq.ranges?.long ?? "-",
+      quantity: 1,
+      isWeapon: eq.isWeapon ?? false,
+      isAmmo: eq.isAmmo ?? false,
+      ammoCount: eq.ammoCount,
+    }),
+  );
+
+  return {
+    unitType: "protomech",
+    header: extractHeader(unit as Parameters<typeof extractHeader>[0]),
+    pointSize,
+    protos,
+    mainGun: unit.mainGun,
+    mainGunAmmo: unit.mainGunAmmo,
+    hasUMU: unit.hasUMU ?? false,
+    isGlider: unit.isGlider ?? false,
+    walkMP: unit.walkMP ?? 0,
+    jumpMP: unit.jumpMP ?? 0,
+    equipment,
+    pilot: undefined,
+  };
+}

--- a/src/services/printing/recordsheet/dataExtractors.vehicle.ts
+++ b/src/services/printing/recordsheet/dataExtractors.vehicle.ts
@@ -1,0 +1,145 @@
+/**
+ * Vehicle Record Sheet Data Extractor
+ *
+ * Produces `IVehicleRecordSheetData` from a vehicle unit configuration.
+ * The unit config shape is the same `IUnitConfig` used by the mech extractor,
+ * extended with vehicle-specific optional fields that callers populate.
+ */
+
+import {
+  IVehicleRecordSheetData,
+  IVehicleCrewMember,
+  IVehicleLocationArmor,
+  IRecordSheetEquipment,
+} from "@/types/printing";
+
+import { extractHeader } from "./dataExtractors";
+
+/**
+ * Vehicle-specific fields augmenting the base `IUnitConfig`.
+ * Callers cast their unit object to this before calling the extractor.
+ */
+export interface IVehicleUnitConfig {
+  id: string;
+  name: string;
+  chassis: string;
+  model: string;
+  tonnage: number;
+  techBase: string;
+  rulesLevel: string;
+  era: string;
+  battleValue?: number;
+  cost?: number;
+  /** Combat vehicle motion type — defaults to 'Tracked' when absent. */
+  motionType?: string;
+  /** Cruise MP (walk equivalent). */
+  cruiseMP?: number;
+  /** Flank MP (run equivalent). */
+  flankMP?: number;
+  armorType?: string;
+  /** Armor allocation keyed by location string. */
+  armorAllocation?: Record<
+    string,
+    { current: number; maximum: number; bar?: number }
+  >;
+  crew?: Array<{
+    role: "driver" | "gunner" | "commander";
+    gunnery: number;
+    piloting: number;
+  }>;
+  equipment?: Array<{
+    id: string;
+    name: string;
+    location: string;
+    heat?: number;
+    damage?: number | string;
+    ranges?: { minimum: number; short: number; medium: number; long: number };
+    isWeapon?: boolean;
+    isAmmo?: boolean;
+    ammoCount?: number;
+  }>;
+  barRating?: number;
+}
+
+/** Standard vehicle armor location order for consistent rendering. */
+const VEHICLE_LOCATION_ORDER: IVehicleLocationArmor["location"][] = [
+  "Front",
+  "Left Side",
+  "Right Side",
+  "Rear",
+  "Turret",
+  "Rotor",
+  "Chin",
+  "Body",
+];
+
+/**
+ * Extract vehicle record sheet data from a vehicle unit configuration.
+ *
+ * All fields have safe defaults so a partially-populated config still
+ * produces a renderable sheet (with zeros where data is missing).
+ */
+export function extractVehicleData(
+  unit: IVehicleUnitConfig,
+): IVehicleRecordSheetData {
+  // Build armor locations in canonical order, skipping absent locations
+  const armorAlloc = unit.armorAllocation ?? {};
+  const armorLocations: IVehicleLocationArmor[] = VEHICLE_LOCATION_ORDER.filter(
+    (loc) => armorAlloc[loc] !== undefined,
+  ).map((loc) => ({
+    location: loc,
+    current: armorAlloc[loc]?.current ?? 0,
+    maximum: armorAlloc[loc]?.maximum ?? 0,
+    bar: armorAlloc[loc]?.bar,
+  }));
+
+  // If no allocation provided, emit a placeholder Front location so the
+  // renderer always has at least one bar to draw.
+  if (armorLocations.length === 0) {
+    armorLocations.push({ location: "Front", current: 0, maximum: 0 });
+  }
+
+  // Crew — default to a single driver when not specified
+  const crew: IVehicleCrewMember[] = (
+    unit.crew ?? [{ role: "driver", gunnery: 4, piloting: 5 }]
+  ).map((c) => ({ role: c.role, gunnery: c.gunnery, piloting: c.piloting }));
+
+  // Equipment — map to the shared IRecordSheetEquipment shape
+  const equipment: IRecordSheetEquipment[] = (unit.equipment ?? []).map(
+    (eq, idx) => ({
+      id: eq.id ?? String(idx),
+      name: eq.name,
+      location: eq.location,
+      locationAbbr: eq.location.substring(0, 3).toUpperCase(),
+      heat: eq.heat ?? "-",
+      damage: eq.damage ?? "-",
+      damageCode: undefined,
+      minimum: eq.ranges?.minimum ?? "-",
+      short: eq.ranges?.short ?? "-",
+      medium: eq.ranges?.medium ?? "-",
+      long: eq.ranges?.long ?? "-",
+      quantity: 1,
+      isWeapon: eq.isWeapon ?? false,
+      isAmmo: eq.isAmmo ?? false,
+      ammoCount: eq.ammoCount,
+    }),
+  );
+
+  const motionType = (unit.motionType ??
+    "Tracked") as IVehicleRecordSheetData["motionType"];
+
+  return {
+    unitType: "vehicle",
+    header: extractHeader(unit as Parameters<typeof extractHeader>[0]),
+    motionType,
+    cruiseMP: unit.cruiseMP ?? 0,
+    flankMP: unit.flankMP ?? 0,
+    armorType: unit.armorType ?? "Standard",
+    armorLocations,
+    crew,
+    equipment,
+    barRating: unit.barRating,
+    pilot: undefined,
+    specialAbilities: undefined,
+  };
+}

--- a/src/services/printing/svgRecordSheetRenderer/aerospaceRenderer.ts
+++ b/src/services/printing/svgRecordSheetRenderer/aerospaceRenderer.ts
@@ -1,0 +1,184 @@
+/**
+ * Aerospace Record Sheet SVG Renderer
+ *
+ * Generates an SVG string for an aerospace fighter or conventional fighter
+ * record sheet. Skeleton: title block + thrust table + SI bar + 4-arc armor
+ * bars + fuel track + equipment list.
+ *
+ * Dimensions: 612 × 792 pts (US Letter) to match the mech sheet canvas.
+ */
+
+import { IAerospaceRecordSheetData } from "@/types/printing";
+
+const SVG_W = 612;
+const SVG_H = 792;
+const MARGIN = 18;
+const FONT = "Eurostile, Arial, sans-serif";
+
+/** Escape text for safe SVG embedding. */
+function esc(s: string | number): string {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Horizontal pip bar for SI / fuel. */
+function pipBar(
+  x: number,
+  y: number,
+  w: number,
+  current: number,
+  maximum: number,
+  label: string,
+): string {
+  const fillW = maximum > 0 ? Math.round((current / maximum) * w) : 0;
+  return `
+    <text x="${x}" y="${y - 2}" font-family="${FONT}" font-size="7" fill="#000">${esc(label)} ${esc(current)}/${esc(maximum)}</text>
+    <rect x="${x}" y="${y}" width="${w}" height="8" fill="#e0e0e0" stroke="#000" stroke-width="0.5"/>
+    <rect x="${x}" y="${y}" width="${fillW}" height="8" fill="#2d4a6e"/>`;
+}
+
+/**
+ * Render an aerospace fighter record sheet as an SVG string.
+ */
+export function renderAerospaceSVG(data: IAerospaceRecordSheetData): string {
+  const {
+    header,
+    structuralIntegrity,
+    fuelPoints,
+    safeThrust,
+    maxThrust,
+    heatSinks,
+    armorType,
+    armorArcs,
+    equipment,
+    bombBaySlots,
+  } = data;
+
+  // ── Title block ──────────────────────────────────────────────────────────
+  let body = `
+  <!-- Title block -->
+  <rect x="${MARGIN}" y="${MARGIN}" width="${SVG_W - MARGIN * 2}" height="36" fill="#1a2e3a" rx="3"/>
+  <text x="${SVG_W / 2}" y="${MARGIN + 14}" font-family="${FONT}" font-size="13" font-weight="bold" fill="#fff" text-anchor="middle">${esc(header.chassis)} ${esc(header.model)}</text>
+  <text x="${SVG_W / 2}" y="${MARGIN + 28}" font-family="${FONT}" font-size="8" fill="#ccc" text-anchor="middle">${esc(header.tonnage)}t · ${esc(header.techBase)} · BV ${esc(header.battleValue.toLocaleString())}</text>`;
+
+  // ── Thrust / velocity table ──────────────────────────────────────────────
+  const thrustY = MARGIN + 46;
+  body += `
+  <!-- Thrust table -->
+  <text x="${MARGIN}" y="${thrustY}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">THRUST</text>
+  <text x="${MARGIN + 4}" y="${thrustY + 13}" font-family="${FONT}" font-size="7" fill="#000">Safe Thrust (Thrust Points): ${esc(safeThrust)}</text>
+  <text x="${MARGIN + 4}" y="${thrustY + 24}" font-family="${FONT}" font-size="7" fill="#000">Maximum Thrust: ${esc(maxThrust)}</text>`;
+
+  // ── Heat sinks ───────────────────────────────────────────────────────────
+  const hsY = thrustY + 36;
+  body += `
+  <!-- Heat sinks -->
+  <text x="${MARGIN}" y="${hsY}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">HEAT SINKS: ${esc(heatSinks.count)} (${esc(heatSinks.type)})  Capacity: ${esc(heatSinks.capacity)}</text>`;
+
+  // ── Structural Integrity bar ─────────────────────────────────────────────
+  const siY = hsY + 14;
+  const barW = SVG_W - MARGIN * 2 - 10;
+  body += pipBar(
+    MARGIN + 5,
+    siY,
+    barW,
+    structuralIntegrity,
+    structuralIntegrity,
+    "Structural Integrity",
+  );
+
+  // ── Fuel track ───────────────────────────────────────────────────────────
+  const fuelY = siY + 22;
+  body += pipBar(MARGIN + 5, fuelY, barW, fuelPoints, fuelPoints, "Fuel");
+
+  // ── Bomb bay slots ───────────────────────────────────────────────────────
+  const bombY = fuelY + 22;
+  if (bombBaySlots > 0) {
+    body += `
+  <!-- Bomb bays -->
+  <text x="${MARGIN}" y="${bombY}" font-family="${FONT}" font-size="7" fill="#000">Bomb Bay Slots: ${esc(bombBaySlots)}</text>`;
+  }
+
+  // ── 4-arc armor bars ─────────────────────────────────────────────────────
+  const armorStartY = bombBaySlots > 0 ? bombY + 14 : bombY;
+  body += `
+  <!-- Armor (${esc(armorType)}) -->
+  <text x="${MARGIN}" y="${armorStartY}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">ARMOR (${esc(armorType)})</text>`;
+
+  armorArcs.forEach((arc, i) => {
+    const ly = armorStartY + 10 + i * 20;
+    const fillW =
+      arc.maximum > 0 ? Math.round((arc.current / arc.maximum) * barW) : 0;
+    body += `
+  <text x="${MARGIN + 5}" y="${ly - 2}" font-family="${FONT}" font-size="7" fill="#000">${esc(arc.arc)} ${esc(arc.current)}/${esc(arc.maximum)}</text>
+  <rect x="${MARGIN + 5}" y="${ly}" width="${barW}" height="8" fill="#e0e0e0" stroke="#000" stroke-width="0.5"/>
+  <rect x="${MARGIN + 5}" y="${ly}" width="${fillW}" height="8" fill="#2d4a6e"/>`;
+  });
+
+  // ── Equipment list ───────────────────────────────────────────────────────
+  const equipStartY = armorStartY + 14 + armorArcs.length * 20 + 14;
+  body += `
+  <!-- Equipment -->
+  <text x="${MARGIN}" y="${equipStartY}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">WEAPONS &amp; EQUIPMENT</text>
+  <line x1="${MARGIN}" y1="${equipStartY + 2}" x2="${SVG_W - MARGIN}" y2="${equipStartY + 2}" stroke="#000" stroke-width="0.5"/>`;
+
+  const cols = {
+    qty: MARGIN + 2,
+    name: MARGIN + 18,
+    loc: MARGIN + 160,
+    dmg: MARGIN + 195,
+    sht: MARGIN + 230,
+    med: MARGIN + 260,
+    lng: MARGIN + 290,
+  };
+  const hdrY = equipStartY + 12;
+  body += `
+  <text x="${cols.qty}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Qty</text>
+  <text x="${cols.name}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Type</text>
+  <text x="${cols.loc}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Loc</text>
+  <text x="${cols.dmg}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Dmg</text>
+  <text x="${cols.sht}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Sht</text>
+  <text x="${cols.med}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Med</text>
+  <text x="${cols.lng}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Lng</text>`;
+
+  const maxEqRows = Math.floor((SVG_H - equipStartY - 30) / 9);
+  equipment.slice(0, maxEqRows).forEach((eq, i) => {
+    const ry = hdrY + 10 + i * 9;
+    const name =
+      eq.name.length > 22 ? eq.name.substring(0, 20) + ".." : eq.name;
+    body += `
+  <text x="${cols.qty}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.quantity)}</text>
+  <text x="${cols.name}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(name)}</text>
+  <text x="${cols.loc}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.locationAbbr)}</text>`;
+    if (eq.isWeapon) {
+      body += `
+  <text x="${cols.dmg}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.damage ?? "-")}</text>
+  <text x="${cols.sht}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.short || "-")}</text>
+  <text x="${cols.med}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.medium || "-")}</text>
+  <text x="${cols.lng}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.long || "-")}</text>`;
+    } else if (eq.isAmmo) {
+      body += `<text x="${cols.dmg}" y="${ry}" font-family="${FONT}" font-size="6" fill="#555">(${esc(eq.ammoCount ?? 0)} shots)</text>`;
+    }
+  });
+
+  // ── Pilot block ───────────────────────────────────────────────────────────
+  if (data.pilot) {
+    const pilotY = SVG_H - 40;
+    body += `
+  <!-- Pilot block -->
+  <rect x="${MARGIN}" y="${pilotY}" width="200" height="28" fill="#f5f5f5" stroke="#000" stroke-width="0.5" rx="2"/>
+  <text x="${MARGIN + 4}" y="${pilotY + 10}" font-family="${FONT}" font-size="7" font-weight="bold" fill="#000">PILOT: ${esc(data.pilot.name)}</text>
+  <text x="${MARGIN + 4}" y="${pilotY + 22}" font-family="${FONT}" font-size="7" fill="#000">Gunnery: ${esc(data.pilot.gunnery)}   Piloting: ${esc(data.pilot.piloting)}</text>`;
+  }
+
+  body += `
+  <text x="${SVG_W / 2}" y="${SVG_H - 6}" font-family="${FONT}" font-size="5.5" fill="#888" text-anchor="middle">MekStation · Aerospace Record Sheet</text>`;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${SVG_W}" height="${SVG_H}" viewBox="0 0 ${SVG_W} ${SVG_H}">
+  <rect width="${SVG_W}" height="${SVG_H}" fill="#fff"/>
+  ${body}
+</svg>`;
+}

--- a/src/services/printing/svgRecordSheetRenderer/armor.ts
+++ b/src/services/printing/svgRecordSheetRenderer/armor.ts
@@ -3,10 +3,10 @@
  * Handles loading pre-made armor pip SVGs and generating dynamic pips for non-biped mechs
  */
 
-import { IRecordSheetData } from '@/types/printing';
-import { logger } from '@/utils/logger';
+import { IMechRecordSheetData } from "@/types/printing";
+import { logger } from "@/utils/logger";
 
-import { ArmorPipLayout } from '../ArmorPipLayout';
+import { ArmorPipLayout } from "../ArmorPipLayout";
 import {
   SVG_NS,
   PIPS_BASE_PATH,
@@ -18,8 +18,8 @@ import {
   BIPED_PIP_GROUP_IDS,
   QUAD_PIP_GROUP_IDS,
   TRIPOD_PIP_GROUP_IDS,
-} from './constants';
-import { setTextContent } from './template';
+} from "./constants";
+import { setTextContent } from "./template";
 
 /**
  * Fill template with armor pips and text values (async - fetches pip SVGs)
@@ -27,7 +27,7 @@ import { setTextContent } from './template';
 export async function fillArmorPips(
   svgDoc: Document,
   svgRoot: SVGSVGElement,
-  armor: IRecordSheetData['armor'],
+  armor: IMechRecordSheetData["armor"],
   mechType?: string,
 ): Promise<void> {
   // Fill armor text labels with armor point values
@@ -48,7 +48,7 @@ export async function fillArmorPips(
   });
 
   // Check if this mech type uses pre-made pip files
-  const usePremadePips = PREMADE_PIP_TYPES.includes(mechType || 'biped');
+  const usePremadePips = PREMADE_PIP_TYPES.includes(mechType || "biped");
 
   if (usePremadePips) {
     // Biped: Load pre-made pip SVG files
@@ -59,13 +59,13 @@ export async function fillArmorPips(
     }
     if (!armorPipsGroup) {
       logger.warn(
-        'Could not find canonArmorPips or armorPips group in template',
+        "Could not find canonArmorPips or armorPips group in template",
       );
-      const rootGroup = svgDoc.createElementNS(SVG_NS, 'g');
-      rootGroup.setAttribute('id', 'armor-pips-generated');
+      const rootGroup = svgDoc.createElementNS(SVG_NS, "g");
+      rootGroup.setAttribute("id", "armor-pips-generated");
       rootGroup.setAttribute(
-        'transform',
-        'matrix(0.975,0,0,0.975,-390.621,-44.241)',
+        "transform",
+        "matrix(0.975,0,0,0.975,-390.621,-44.241)",
       );
       svgRoot.appendChild(rootGroup);
       await loadAllArmorPips(svgDoc, rootGroup, armor);
@@ -75,7 +75,7 @@ export async function fillArmorPips(
     await loadAllArmorPips(svgDoc, armorPipsGroup, armor);
   } else {
     // Non-biped (quad, tripod, etc.): Generate pips dynamically using template rects
-    await generateDynamicArmorPips(svgDoc, armor, mechType || 'quad');
+    await generateDynamicArmorPips(svgDoc, armor, mechType || "quad");
   }
 }
 
@@ -85,7 +85,7 @@ export async function fillArmorPips(
 async function loadAllArmorPips(
   svgDoc: Document,
   parentGroup: Element,
-  armor: IRecordSheetData['armor'],
+  armor: IMechRecordSheetData["armor"],
 ): Promise<void> {
   // Load pips for each armor location
   const pipPromises = armor.locations.map(async (loc) => {
@@ -125,7 +125,7 @@ async function loadAndInsertPips(
 ): Promise<void> {
   // Build the pip file path
   // Format: Armor_<Location>_<Count>_Humanoid.svg or Armor_<Location>_R_<Count>_Humanoid.svg
-  const rearSuffix = isRear ? '_R' : '';
+  const rearSuffix = isRear ? "_R" : "";
   const pipFileName = `Armor_${locationName}${rearSuffix}_${pipCount}_Humanoid.svg`;
   const pipPath = `${PIPS_BASE_PATH}/${pipFileName}`;
 
@@ -138,30 +138,30 @@ async function loadAndInsertPips(
 
     const pipSvgText = await response.text();
     const parser = new DOMParser();
-    const pipDoc = parser.parseFromString(pipSvgText, 'image/svg+xml');
+    const pipDoc = parser.parseFromString(pipSvgText, "image/svg+xml");
 
     // Extract the path elements from the pip SVG
     // Pip files have paths inside <switch><g>...</g></switch>
-    const paths = pipDoc.querySelectorAll('path');
+    const paths = pipDoc.querySelectorAll("path");
 
     if (paths.length === 0) return;
 
     // Create a group for this location's pips
     // MegaMekLab imports pip paths directly - the parent's transform handles positioning
     // NO additional transform needed on location groups
-    const locationGroup = svgDoc.createElementNS(SVG_NS, 'g');
-    locationGroup.setAttribute('id', `pips_${locationName}${rearSuffix}`);
-    locationGroup.setAttribute('class', 'armor-pips');
+    const locationGroup = svgDoc.createElementNS(SVG_NS, "g");
+    locationGroup.setAttribute("id", `pips_${locationName}${rearSuffix}`);
+    locationGroup.setAttribute("class", "armor-pips");
 
     // Clone each path into our template
     paths.forEach((path) => {
       const clonedPath = svgDoc.importNode(path, true) as SVGPathElement;
       // Ensure the path styling is preserved
-      if (!clonedPath.getAttribute('fill')) {
-        clonedPath.setAttribute('fill', '#FFFFFF');
+      if (!clonedPath.getAttribute("fill")) {
+        clonedPath.setAttribute("fill", "#FFFFFF");
       }
-      if (!clonedPath.getAttribute('stroke')) {
-        clonedPath.setAttribute('stroke', '#000000');
+      if (!clonedPath.getAttribute("stroke")) {
+        clonedPath.setAttribute("stroke", "#000000");
       }
       locationGroup.appendChild(clonedPath);
     });
@@ -178,7 +178,7 @@ async function loadAndInsertPips(
  */
 async function generateDynamicArmorPips(
   svgDoc: Document,
-  armor: IRecordSheetData['armor'],
+  armor: IMechRecordSheetData["armor"],
   mechType: string,
 ): Promise<void> {
   // Get the pip group IDs based on mech type
@@ -202,9 +202,9 @@ async function generateDynamicArmorPips(
     // Use ArmorPipLayout to generate pips within the bounding rects
     if (loc.current > 0) {
       ArmorPipLayout.addPips(svgDoc, pipArea, loc.current, {
-        fill: '#FFFFFF',
+        fill: "#FFFFFF",
         strokeWidth: 0.5,
-        className: 'pip armor',
+        className: "pip armor",
       });
     }
   });
@@ -221,9 +221,9 @@ async function generateDynamicArmorPips(
         const pipArea = svgDoc.getElementById(rearGroupId);
         if (pipArea && loc.rear > 0) {
           ArmorPipLayout.addPips(svgDoc, pipArea, loc.rear, {
-            fill: '#FFFFFF',
+            fill: "#FFFFFF",
             strokeWidth: 0.5,
-            className: 'pip armor rear',
+            className: "pip armor rear",
           });
         }
       }
@@ -236,11 +236,11 @@ async function generateDynamicArmorPips(
  */
 function getPipGroupIdsForMechType(mechType: string): Record<string, string> {
   switch (mechType) {
-    case 'quad':
+    case "quad":
       return QUAD_PIP_GROUP_IDS;
-    case 'tripod':
+    case "tripod":
       return TRIPOD_PIP_GROUP_IDS;
-    case 'biped':
+    case "biped":
     default:
       return BIPED_PIP_GROUP_IDS;
   }

--- a/src/services/printing/svgRecordSheetRenderer/battleArmorRenderer.ts
+++ b/src/services/printing/svgRecordSheetRenderer/battleArmorRenderer.ts
@@ -1,0 +1,149 @@
+/**
+ * BattleArmor Record Sheet SVG Renderer
+ *
+ * Generates an SVG string for a BattleArmor point (squad) record sheet.
+ * Skeleton: title block + per-trooper armor pip columns + manipulator block
+ * + movement block + equipment list.
+ *
+ * Dimensions: 612 × 792 pts (US Letter) to match the mech sheet canvas.
+ */
+
+import { IBattleArmorRecordSheetData } from "@/types/printing";
+
+const SVG_W = 612;
+const SVG_H = 792;
+const MARGIN = 18;
+const FONT = "Eurostile, Arial, sans-serif";
+
+/** Escape text for safe SVG embedding. */
+function esc(s: string | number): string {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Render a column of armor pips for one trooper.
+ *
+ * Each pip is a small circle: filled for remaining armor, open for damage.
+ */
+function trooperColumn(
+  x: number,
+  y: number,
+  trooperIndex: number,
+  armorPips: number,
+  maximumPips: number,
+  gunnery: number,
+  antiMech: number,
+  modularWeapon?: string,
+  apWeapon?: string,
+): string {
+  const PIP_R = 4;
+  const PIP_GAP = 11;
+  const COLS_PER_ROW = 2;
+
+  let out = `
+  <!-- Trooper ${trooperIndex} -->
+  <text x="${x + 11}" y="${y}" font-family="${FONT}" font-size="7" font-weight="bold" fill="#000" text-anchor="middle">#${trooperIndex}</text>
+  <text x="${x}" y="${y + 10}" font-family="${FONT}" font-size="6" fill="#000">G:${gunnery} AM:${antiMech}</text>`;
+
+  for (let p = 0; p < maximumPips; p++) {
+    const col = p % COLS_PER_ROW;
+    const row = Math.floor(p / COLS_PER_ROW);
+    const cx = x + PIP_R + col * PIP_GAP;
+    const cy = y + 18 + row * PIP_GAP;
+    const filled = p < armorPips;
+    out += `
+  <circle cx="${cx}" cy="${cy}" r="${PIP_R}" fill="${filled ? "#333" : "#fff"}" stroke="#000" stroke-width="0.6"/>`;
+  }
+
+  const labY = y + 18 + Math.ceil(maximumPips / COLS_PER_ROW) * PIP_GAP + 8;
+  if (modularWeapon) {
+    out += `<text x="${x}" y="${labY}" font-family="${FONT}" font-size="5.5" fill="#333">${esc(modularWeapon)}</text>`;
+  }
+  if (apWeapon) {
+    out += `<text x="${x}" y="${labY + 8}" font-family="${FONT}" font-size="5.5" fill="#333">AP: ${esc(apWeapon)}</text>`;
+  }
+  return out;
+}
+
+/**
+ * Render a BattleArmor record sheet as an SVG string.
+ */
+export function renderBattleArmorSVG(
+  data: IBattleArmorRecordSheetData,
+): string {
+  const {
+    header,
+    squadSize,
+    troopers,
+    manipulators,
+    walkMP,
+    jumpMP,
+    umuMP,
+    vtolMP,
+  } = data;
+
+  // ── Title block ──────────────────────────────────────────────────────────
+  let body = `
+  <!-- Title block -->
+  <rect x="${MARGIN}" y="${MARGIN}" width="${SVG_W - MARGIN * 2}" height="36" fill="#2e1a1a" rx="3"/>
+  <text x="${SVG_W / 2}" y="${MARGIN + 14}" font-family="${FONT}" font-size="13" font-weight="bold" fill="#fff" text-anchor="middle">${esc(header.chassis)} ${esc(header.model)}</text>
+  <text x="${SVG_W / 2}" y="${MARGIN + 28}" font-family="${FONT}" font-size="8" fill="#ccc" text-anchor="middle">BattleArmor · Squad Size: ${esc(squadSize)} · ${esc(header.techBase)} · BV ${esc(header.battleValue.toLocaleString())}</text>`;
+
+  // ── Movement block ───────────────────────────────────────────────────────
+  const moveY = MARGIN + 46;
+  body += `
+  <!-- Movement -->
+  <text x="${MARGIN}" y="${moveY}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">MOVEMENT</text>
+  <text x="${MARGIN + 4}" y="${moveY + 12}" font-family="${FONT}" font-size="7" fill="#000">Walk: ${esc(walkMP)}  Jump: ${esc(jumpMP)}  UMU: ${esc(umuMP)}  VTOL: ${esc(vtolMP)}</text>`;
+
+  // ── Manipulators block ───────────────────────────────────────────────────
+  const manipY = moveY + 26;
+  body += `
+  <!-- Manipulators -->
+  <text x="${MARGIN}" y="${manipY}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">MANIPULATORS</text>
+  <text x="${MARGIN + 4}" y="${manipY + 12}" font-family="${FONT}" font-size="7" fill="#000">Left: ${esc(manipulators.left)}   Right: ${esc(manipulators.right)}</text>`;
+
+  // ── Per-trooper columns ──────────────────────────────────────────────────
+  const trooperStartY = manipY + 28;
+  body += `
+  <!-- Per-trooper armor pips -->
+  <text x="${MARGIN}" y="${trooperStartY}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">ARMOR PIPS (per trooper)</text>`;
+
+  const colW = Math.floor((SVG_W - MARGIN * 2) / Math.max(squadSize, 1));
+  troopers.forEach((t, i) => {
+    const tx = MARGIN + i * colW;
+    body += trooperColumn(
+      tx,
+      trooperStartY + 12,
+      t.index,
+      t.armorPips,
+      t.maximumArmorPips,
+      t.gunnery,
+      t.antiMech,
+      t.modularWeapon,
+      t.apWeapon,
+    );
+  });
+
+  // Estimate where trooper columns end (max pips determines height)
+  const maxPips = Math.max(...troopers.map((t) => t.maximumArmorPips), 1);
+  const COLS_PER_ROW = 2;
+  const trooperColH = 18 + Math.ceil(maxPips / COLS_PER_ROW) * 11 + 20;
+  const afterTroopers = trooperStartY + 14 + trooperColH + 10;
+
+  // ── Footer ───────────────────────────────────────────────────────────────
+  body += `
+  <text x="${SVG_W / 2}" y="${SVG_H - 6}" font-family="${FONT}" font-size="5.5" fill="#888" text-anchor="middle">MekStation · BattleArmor Record Sheet</text>`;
+
+  // ── Suppress unused variable lint ────────────────────────────────────────
+  void afterTroopers;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${SVG_W}" height="${SVG_H}" viewBox="0 0 ${SVG_W} ${SVG_H}">
+  <rect width="${SVG_W}" height="${SVG_H}" fill="#fff"/>
+  ${body}
+</svg>`;
+}

--- a/src/services/printing/svgRecordSheetRenderer/infantryRenderer.ts
+++ b/src/services/printing/svgRecordSheetRenderer/infantryRenderer.ts
@@ -1,0 +1,130 @@
+/**
+ * Infantry Record Sheet SVG Renderer
+ *
+ * Generates an SVG string for an infantry platoon record sheet.
+ * Skeleton: title block + platoon size counter + motive type badge
+ * + primary/secondary weapons + field gun block + specialization badge.
+ *
+ * Dimensions: 612 × 792 pts (US Letter) to match the mech sheet canvas.
+ */
+
+import { IInfantryRecordSheetData } from "@/types/printing";
+
+const SVG_W = 612;
+const SVG_H = 792;
+const MARGIN = 18;
+const FONT = "Eurostile, Arial, sans-serif";
+
+/** Escape text for safe SVG embedding. */
+function esc(s: string | number): string {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Draw a row of trooper pip circles (10 per row). */
+function trooperPips(x: number, y: number, count: number): string {
+  const PIP_R = 4;
+  const PIP_GAP = 10;
+  const PIPS_PER_ROW = 10;
+  let out = "";
+  for (let i = 0; i < count; i++) {
+    const col = i % PIPS_PER_ROW;
+    const row = Math.floor(i / PIPS_PER_ROW);
+    const cx = x + PIP_R + col * PIP_GAP;
+    const cy = y + PIP_R + row * PIP_GAP;
+    out += `<circle cx="${cx}" cy="${cy}" r="${PIP_R}" fill="#333" stroke="#000" stroke-width="0.6"/>`;
+  }
+  return out;
+}
+
+/**
+ * Render an infantry platoon record sheet as an SVG string.
+ */
+export function renderInfantrySVG(data: IInfantryRecordSheetData): string {
+  const {
+    header,
+    platoonSize,
+    motiveType,
+    primaryWeapon,
+    secondaryWeapons,
+    fieldGun,
+    specialization,
+    gunnery,
+    antiMech,
+  } = data;
+
+  // ── Title block ──────────────────────────────────────────────────────────
+  let body = `
+  <!-- Title block -->
+  <rect x="${MARGIN}" y="${MARGIN}" width="${SVG_W - MARGIN * 2}" height="36" fill="#1a3a1a" rx="3"/>
+  <text x="${SVG_W / 2}" y="${MARGIN + 14}" font-family="${FONT}" font-size="13" font-weight="bold" fill="#fff" text-anchor="middle">${esc(header.chassis)} ${esc(header.model)}</text>
+  <text x="${SVG_W / 2}" y="${MARGIN + 28}" font-family="${FONT}" font-size="8" fill="#ccc" text-anchor="middle">Infantry · ${esc(header.techBase)} · BV ${esc(header.battleValue.toLocaleString())}</text>`;
+
+  // ── Motive type badge + skills ───────────────────────────────────────────
+  const badgeY = MARGIN + 46;
+  body += `
+  <!-- Motive type + skills -->
+  <rect x="${MARGIN}" y="${badgeY}" width="110" height="22" fill="#2d5a2d" rx="2"/>
+  <text x="${MARGIN + 55}" y="${badgeY + 14}" font-family="${FONT}" font-size="9" font-weight="bold" fill="#fff" text-anchor="middle">${esc(motiveType)}</text>
+  <text x="${MARGIN + 120}" y="${badgeY + 10}" font-family="${FONT}" font-size="7" fill="#000">Gunnery: ${esc(gunnery)}</text>
+  <text x="${MARGIN + 120}" y="${badgeY + 20}" font-family="${FONT}" font-size="7" fill="#000">Anti-Mech: ${esc(antiMech)}</text>`;
+
+  // ── Specialization badge ─────────────────────────────────────────────────
+  if (specialization) {
+    body += `
+  <!-- Specialization -->
+  <rect x="${SVG_W - MARGIN - 100}" y="${badgeY}" width="100" height="22" fill="#5a4a1a" rx="2"/>
+  <text x="${SVG_W - MARGIN - 50}" y="${badgeY + 14}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#fff" text-anchor="middle">${esc(specialization.toUpperCase())}</text>`;
+  }
+
+  // ── Platoon size counter (pip grid) ──────────────────────────────────────
+  const pipsY = badgeY + 34;
+  body += `
+  <!-- Platoon size: ${platoonSize} troopers -->
+  <text x="${MARGIN}" y="${pipsY}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">PLATOON (${esc(platoonSize)} troopers)</text>
+  ${trooperPips(MARGIN + 4, pipsY + 6, platoonSize)}`;
+
+  const pipRows = Math.ceil(platoonSize / 10);
+  const afterPips = pipsY + 10 + pipRows * 10 + 14;
+
+  // ── Primary weapon ───────────────────────────────────────────────────────
+  body += `
+  <!-- Primary weapon -->
+  <text x="${MARGIN}" y="${afterPips}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">PRIMARY WEAPON</text>
+  <text x="${MARGIN + 4}" y="${afterPips + 13}" font-family="${FONT}" font-size="8" fill="#000">${esc(primaryWeapon)}</text>`;
+
+  // ── Secondary weapons ─────────────────────────────────────────────────────
+  let secY = afterPips + 28;
+  if (secondaryWeapons.length > 0) {
+    body += `
+  <!-- Secondary weapons -->
+  <text x="${MARGIN}" y="${secY}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">SECONDARY WEAPONS</text>`;
+    secondaryWeapons.forEach((sw, i) => {
+      body += `
+  <text x="${MARGIN + 4}" y="${secY + 13 + i * 12}" font-family="${FONT}" font-size="7" fill="#000">${esc(sw.name)}  (${esc(sw.perTrooperRatio)} per trooper)</text>`;
+    });
+    secY += 14 + secondaryWeapons.length * 12;
+  }
+
+  // ── Field gun block ───────────────────────────────────────────────────────
+  if (fieldGun) {
+    body += `
+  <!-- Field gun -->
+  <text x="${MARGIN}" y="${secY + 4}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">FIELD GUN</text>
+  <rect x="${MARGIN}" y="${secY + 8}" width="${SVG_W - MARGIN * 2}" height="30" fill="#f0f0f0" stroke="#000" stroke-width="0.5" rx="2"/>
+  <text x="${MARGIN + 4}" y="${secY + 20}" font-family="${FONT}" font-size="7" fill="#000">${esc(fieldGun.name)} × ${esc(fieldGun.count)}</text>
+  <text x="${MARGIN + 4}" y="${secY + 32}" font-family="${FONT}" font-size="7" fill="#000">Dmg: ${esc(fieldGun.damage)}  Min: ${esc(fieldGun.minimumRange)}  Sht: ${esc(fieldGun.shortRange)}  Med: ${esc(fieldGun.mediumRange)}  Lng: ${esc(fieldGun.longRange)}</text>`;
+  }
+
+  // ── Footer ───────────────────────────────────────────────────────────────
+  body += `
+  <text x="${SVG_W / 2}" y="${SVG_H - 6}" font-family="${FONT}" font-size="5.5" fill="#888" text-anchor="middle">MekStation · Infantry Record Sheet</text>`;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${SVG_W}" height="${SVG_H}" viewBox="0 0 ${SVG_W} ${SVG_H}">
+  <rect width="${SVG_W}" height="${SVG_H}" fill="#fff"/>
+  ${body}
+</svg>`;
+}

--- a/src/services/printing/svgRecordSheetRenderer/protoMechRenderer.ts
+++ b/src/services/printing/svgRecordSheetRenderer/protoMechRenderer.ts
@@ -1,0 +1,194 @@
+/**
+ * ProtoMech Record Sheet SVG Renderer
+ *
+ * Generates an SVG string for a ProtoMech point (1–5 units) record sheet.
+ * Skeleton: title block + per-proto 5-location armor pips + main gun block
+ * + movement + equipment list.
+ *
+ * Dimensions: 612 × 792 pts (US Letter) to match the mech sheet canvas.
+ */
+
+import { IProtoMechRecordSheetData } from "@/types/printing";
+
+const SVG_W = 612;
+const SVG_H = 792;
+const MARGIN = 18;
+const FONT = "Eurostile, Arial, sans-serif";
+
+/** Escape text for safe SVG embedding. */
+function esc(s: string | number): string {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Ordered list of proto armor locations to render. */
+const PROTO_LOCATIONS = [
+  "Head",
+  "Torso",
+  "Left Arm",
+  "Right Arm",
+  "Legs",
+  "Main Gun",
+] as const;
+
+type ProtoLoc = (typeof PROTO_LOCATIONS)[number];
+
+/** Armor bar for a single proto location. */
+function locBar(
+  x: number,
+  y: number,
+  w: number,
+  label: string,
+  current: number,
+  maximum: number,
+): string {
+  const fillW = maximum > 0 ? Math.round((current / maximum) * w) : 0;
+  return `
+  <text x="${x}" y="${y - 1}" font-family="${FONT}" font-size="6" fill="#000">${esc(label)} ${esc(current)}/${esc(maximum)}</text>
+  <rect x="${x}" y="${y}" width="${w}" height="6" fill="#e0e0e0" stroke="#000" stroke-width="0.5"/>
+  <rect x="${x}" y="${y}" width="${fillW}" height="6" fill="#4a3070"/>`;
+}
+
+/**
+ * Render a ProtoMech point record sheet as an SVG string.
+ */
+export function renderProtoMechSVG(data: IProtoMechRecordSheetData): string {
+  const {
+    header,
+    pointSize,
+    protos,
+    mainGun,
+    mainGunAmmo,
+    hasUMU,
+    isGlider,
+    walkMP,
+    jumpMP,
+    equipment,
+  } = data;
+
+  // ── Title block ──────────────────────────────────────────────────────────
+  let body = `
+  <!-- Title block -->
+  <rect x="${MARGIN}" y="${MARGIN}" width="${SVG_W - MARGIN * 2}" height="36" fill="#2e1a3e" rx="3"/>
+  <text x="${SVG_W / 2}" y="${MARGIN + 14}" font-family="${FONT}" font-size="13" font-weight="bold" fill="#fff" text-anchor="middle">${esc(header.chassis)} ${esc(header.model)}</text>
+  <text x="${SVG_W / 2}" y="${MARGIN + 28}" font-family="${FONT}" font-size="8" fill="#ccc" text-anchor="middle">ProtoMech · Point Size: ${esc(pointSize)} · ${esc(header.techBase)} · BV ${esc(header.battleValue.toLocaleString())}</text>`;
+
+  // ── Movement + flags ─────────────────────────────────────────────────────
+  const moveY = MARGIN + 46;
+  const flags = [hasUMU && "UMU", isGlider && "Glider"]
+    .filter(Boolean)
+    .join(", ");
+  body += `
+  <!-- Movement -->
+  <text x="${MARGIN}" y="${moveY}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">MOVEMENT</text>
+  <text x="${MARGIN + 4}" y="${moveY + 13}" font-family="${FONT}" font-size="7" fill="#000">Walk: ${esc(walkMP)}  Jump: ${esc(jumpMP)}${flags ? `  [${esc(flags)}]` : ""}</text>`;
+
+  // ── Main gun block ───────────────────────────────────────────────────────
+  const gunY = moveY + 28;
+  if (mainGun) {
+    body += `
+  <!-- Main gun -->
+  <text x="${MARGIN}" y="${gunY}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">MAIN GUN: ${esc(mainGun)}${mainGunAmmo !== undefined ? `  (${esc(mainGunAmmo)} shots)` : ""}</text>`;
+  }
+
+  // ── Per-proto armor columns ──────────────────────────────────────────────
+  const armorStartY = mainGun ? gunY + 16 : gunY;
+  body += `
+  <!-- Per-proto armor (${esc(pointSize)} unit${pointSize !== 1 ? "s" : ""}) -->
+  <text x="${MARGIN}" y="${armorStartY}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">ARMOR BY LOCATION</text>`;
+
+  const colW = Math.floor((SVG_W - MARGIN * 2) / Math.max(pointSize, 1));
+  const barW = colW - 8;
+  const LOC_ROW_H = 16;
+
+  protos.forEach((proto, pi) => {
+    const colX = MARGIN + pi * colW;
+    body += `
+  <!-- Proto #${proto.index} -->
+  <text x="${colX + colW / 2}" y="${armorStartY + 13}" font-family="${FONT}" font-size="7" font-weight="bold" fill="#000" text-anchor="middle">#${esc(proto.index)}</text>`;
+
+    PROTO_LOCATIONS.forEach((loc, li) => {
+      const locData = proto.armorByLocation[loc as ProtoLoc];
+      if (!locData) return;
+      const ly = armorStartY + 16 + li * LOC_ROW_H;
+      body += locBar(
+        colX + 2,
+        ly + 8,
+        barW,
+        loc,
+        locData.current,
+        locData.maximum,
+      );
+    });
+  });
+
+  const afterArmor = armorStartY + 18 + PROTO_LOCATIONS.length * LOC_ROW_H + 14;
+
+  // ── Equipment list ───────────────────────────────────────────────────────
+  if (equipment.length > 0) {
+    body += `
+  <!-- Equipment -->
+  <text x="${MARGIN}" y="${afterArmor}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">WEAPONS &amp; EQUIPMENT</text>
+  <line x1="${MARGIN}" y1="${afterArmor + 2}" x2="${SVG_W - MARGIN}" y2="${afterArmor + 2}" stroke="#000" stroke-width="0.5"/>`;
+
+    const cols = {
+      qty: MARGIN + 2,
+      name: MARGIN + 18,
+      loc: MARGIN + 160,
+      dmg: MARGIN + 200,
+      sht: MARGIN + 240,
+      med: MARGIN + 270,
+      lng: MARGIN + 300,
+    };
+    const hdrY = afterArmor + 12;
+    body += `
+  <text x="${cols.qty}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Qty</text>
+  <text x="${cols.name}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Type</text>
+  <text x="${cols.loc}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Loc</text>
+  <text x="${cols.dmg}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Dmg</text>
+  <text x="${cols.sht}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Sht</text>
+  <text x="${cols.med}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Med</text>
+  <text x="${cols.lng}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Lng</text>`;
+
+    const maxEqRows = Math.floor((SVG_H - afterArmor - 40) / 9);
+    equipment.slice(0, maxEqRows).forEach((eq, i) => {
+      const ry = hdrY + 10 + i * 9;
+      const name =
+        eq.name.length > 22 ? eq.name.substring(0, 20) + ".." : eq.name;
+      body += `
+  <text x="${cols.qty}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.quantity)}</text>
+  <text x="${cols.name}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(name)}</text>
+  <text x="${cols.loc}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.locationAbbr)}</text>`;
+      if (eq.isWeapon) {
+        body += `
+  <text x="${cols.dmg}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.damage ?? "-")}</text>
+  <text x="${cols.sht}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.short || "-")}</text>
+  <text x="${cols.med}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.medium || "-")}</text>
+  <text x="${cols.lng}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.long || "-")}</text>`;
+      } else if (eq.isAmmo) {
+        body += `<text x="${cols.dmg}" y="${ry}" font-family="${FONT}" font-size="6" fill="#555">(${esc(eq.ammoCount ?? 0)} shots)</text>`;
+      }
+    });
+  }
+
+  // ── Pilot block ───────────────────────────────────────────────────────────
+  if (data.pilot) {
+    const pilotY = SVG_H - 40;
+    body += `
+  <!-- Pilot block -->
+  <rect x="${MARGIN}" y="${pilotY}" width="200" height="28" fill="#f5f5f5" stroke="#000" stroke-width="0.5" rx="2"/>
+  <text x="${MARGIN + 4}" y="${pilotY + 10}" font-family="${FONT}" font-size="7" font-weight="bold" fill="#000">POINT PILOT: ${esc(data.pilot.name)}</text>
+  <text x="${MARGIN + 4}" y="${pilotY + 22}" font-family="${FONT}" font-size="7" fill="#000">Gunnery: ${esc(data.pilot.gunnery)}   Piloting: ${esc(data.pilot.piloting)}</text>`;
+  }
+
+  body += `
+  <text x="${SVG_W / 2}" y="${SVG_H - 6}" font-family="${FONT}" font-size="5.5" fill="#888" text-anchor="middle">MekStation · ProtoMech Record Sheet</text>`;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${SVG_W}" height="${SVG_H}" viewBox="0 0 ${SVG_W} ${SVG_H}">
+  <rect width="${SVG_W}" height="${SVG_H}" fill="#fff"/>
+  ${body}
+</svg>`;
+}

--- a/src/services/printing/svgRecordSheetRenderer/renderer.ts
+++ b/src/services/printing/svgRecordSheetRenderer/renderer.ts
@@ -7,22 +7,22 @@
  * @spec openspec/specs/record-sheet-export/spec.md
  */
 
-import { IRecordSheetData, PREVIEW_DPI_MULTIPLIER } from '@/types/printing';
+import { IMechRecordSheetData, PREVIEW_DPI_MULTIPLIER } from "@/types/printing";
 
-import { fillArmorPips } from './armor';
-import { renderToCanvasHighDPI } from './canvas';
-import { ELEMENT_IDS } from './constants';
-import { renderCriticalSlots } from './criticals';
-import { renderEquipmentTable } from './equipment';
-import { renderSPASection } from './spaSection';
-import { fillStructurePips } from './structure';
+import { fillArmorPips } from "./armor";
+import { renderToCanvasHighDPI } from "./canvas";
+import { ELEMENT_IDS } from "./constants";
+import { renderCriticalSlots } from "./criticals";
+import { renderEquipmentTable } from "./equipment";
+import { renderSPASection } from "./spaSection";
+import { fillStructurePips } from "./structure";
 import {
   loadSVGTemplate,
   addDocumentMargins,
   hideSecondCrewPanel,
   fixCopyrightYear,
   setTextContent,
-} from './template';
+} from "./template";
 
 export class SVGRecordSheetRenderer {
   private svgDoc: Document | null = null;
@@ -35,9 +35,9 @@ export class SVGRecordSheetRenderer {
     addDocumentMargins(this.svgRoot);
   }
 
-  fillTemplate(data: IRecordSheetData): void {
+  fillTemplate(data: IMechRecordSheetData): void {
     if (!this.svgDoc || !this.svgRoot) {
-      throw new Error('Template not loaded. Call loadTemplate first.');
+      throw new Error("Template not loaded. Call loadTemplate first.");
     }
 
     setTextContent(
@@ -56,7 +56,7 @@ export class SVGRecordSheetRenderer {
       ELEMENT_IDS.RULES_LEVEL,
       data.header.rulesLevel,
     );
-    setTextContent(this.svgDoc, ELEMENT_IDS.ROLE, 'Juggernaut');
+    setTextContent(this.svgDoc, ELEMENT_IDS.ROLE, "Juggernaut");
 
     const engineRating = data.header.tonnage * data.movement.walkMP;
     setTextContent(this.svgDoc, ELEMENT_IDS.ENGINE_TYPE, `${engineRating} XL`);
@@ -101,9 +101,9 @@ export class SVGRecordSheetRenderer {
       `${data.heatSinks.count}`,
     );
 
-    setTextContent(this.svgDoc, ELEMENT_IDS.PILOT_NAME, '');
-    setTextContent(this.svgDoc, ELEMENT_IDS.GUNNERY_SKILL, '');
-    setTextContent(this.svgDoc, ELEMENT_IDS.PILOTING_SKILL, '');
+    setTextContent(this.svgDoc, ELEMENT_IDS.PILOT_NAME, "");
+    setTextContent(this.svgDoc, ELEMENT_IDS.GUNNERY_SKILL, "");
+    setTextContent(this.svgDoc, ELEMENT_IDS.PILOTING_SKILL, "");
 
     fixCopyrightYear(this.svgDoc);
     hideSecondCrewPanel(this.svgDoc);
@@ -122,22 +122,22 @@ export class SVGRecordSheetRenderer {
   }
 
   async fillArmorPips(
-    armor: IRecordSheetData['armor'],
+    armor: IMechRecordSheetData["armor"],
     mechType?: string,
   ): Promise<void> {
     if (!this.svgDoc || !this.svgRoot) {
-      throw new Error('Template not loaded');
+      throw new Error("Template not loaded");
     }
     await fillArmorPips(this.svgDoc, this.svgRoot, armor, mechType);
   }
 
   async fillStructurePips(
-    structure: IRecordSheetData['structure'],
+    structure: IMechRecordSheetData["structure"],
     tonnage: number,
     mechType?: string,
   ): Promise<void> {
     if (!this.svgDoc || !this.svgRoot) {
-      throw new Error('Template not loaded');
+      throw new Error("Template not loaded");
     }
     await fillStructurePips(
       this.svgDoc,
@@ -150,7 +150,7 @@ export class SVGRecordSheetRenderer {
 
   getSVGString(): string {
     if (!this.svgDoc) {
-      throw new Error('Template not loaded');
+      throw new Error("Template not loaded");
     }
     const serializer = new XMLSerializer();
     return serializer.serializeToString(this.svgDoc);

--- a/src/services/printing/svgRecordSheetRenderer/structure.ts
+++ b/src/services/printing/svgRecordSheetRenderer/structure.ts
@@ -3,10 +3,10 @@
  * Handles loading pre-made structure pip SVGs and generating dynamic pips for non-biped mechs
  */
 
-import { IRecordSheetData, ILocationStructure } from '@/types/printing';
-import { logger } from '@/utils/logger';
+import { IMechRecordSheetData, ILocationStructure } from "@/types/printing";
+import { logger } from "@/utils/logger";
 
-import { ArmorPipLayout } from '../ArmorPipLayout';
+import { ArmorPipLayout } from "../ArmorPipLayout";
 import {
   SVG_NS,
   PIPS_BASE_PATH,
@@ -17,8 +17,8 @@ import {
   BIPED_STRUCTURE_PIP_GROUP_IDS,
   QUAD_STRUCTURE_PIP_GROUP_IDS,
   TRIPOD_STRUCTURE_PIP_GROUP_IDS,
-} from './constants';
-import { setTextContent } from './template';
+} from "./constants";
+import { setTextContent } from "./template";
 
 /**
  * Fill template with structure pips and text values
@@ -28,7 +28,7 @@ import { setTextContent } from './template';
 export async function fillStructurePips(
   svgDoc: Document,
   svgRoot: SVGSVGElement,
-  structure: IRecordSheetData['structure'],
+  structure: IMechRecordSheetData["structure"],
   tonnage: number,
   mechType?: string,
 ): Promise<void> {
@@ -41,7 +41,7 @@ export async function fillStructurePips(
   });
 
   // Check if this mech type uses pre-made pip files
-  const usePremadePips = PREMADE_PIP_TYPES.includes(mechType || 'biped');
+  const usePremadePips = PREMADE_PIP_TYPES.includes(mechType || "biped");
 
   if (usePremadePips) {
     // Biped: Load pre-made structure pip SVG files
@@ -52,14 +52,14 @@ export async function fillStructurePips(
     if (!structurePipsGroup) {
       const templatePips = svgDoc.getElementById(ELEMENT_IDS.STRUCTURE_PIPS);
       if (templatePips) {
-        templatePips.setAttribute('visibility', 'hidden');
+        templatePips.setAttribute("visibility", "hidden");
       }
 
-      const newGroup = svgDoc.createElementNS(SVG_NS, 'g');
-      newGroup.setAttribute('id', 'structure-pips-loaded');
+      const newGroup = svgDoc.createElementNS(SVG_NS, "g");
+      newGroup.setAttribute("id", "structure-pips-loaded");
       newGroup.setAttribute(
-        'transform',
-        'matrix(0.971,0,0,0.971,-378.511,-376.966)',
+        "transform",
+        "matrix(0.971,0,0,0.971,-378.511,-376.966)",
       );
       svgRoot.appendChild(newGroup);
       structurePipsGroup = newGroup;
@@ -73,7 +73,7 @@ export async function fillStructurePips(
     );
   } else {
     // Non-biped (quad, tripod, etc.): Generate pips dynamically using template rects
-    generateDynamicStructurePips(svgDoc, structure, mechType || 'quad');
+    generateDynamicStructurePips(svgDoc, structure, mechType || "quad");
   }
 }
 
@@ -121,30 +121,30 @@ async function loadAndInsertStructurePips(
 
     const pipSvgText = await response.text();
     const parser = new DOMParser();
-    const pipDoc = parser.parseFromString(pipSvgText, 'image/svg+xml');
+    const pipDoc = parser.parseFromString(pipSvgText, "image/svg+xml");
 
     // Extract the path elements from the pip SVG
-    const paths = pipDoc.querySelectorAll('path');
+    const paths = pipDoc.querySelectorAll("path");
 
     if (paths.length === 0) return;
 
     // Create a group for this location's structure pips
-    const locationGroup = svgDoc.createElementNS(SVG_NS, 'g');
-    locationGroup.setAttribute('id', `is_pips_${locationAbbr}`);
-    locationGroup.setAttribute('class', 'structure-pips');
+    const locationGroup = svgDoc.createElementNS(SVG_NS, "g");
+    locationGroup.setAttribute("id", `is_pips_${locationAbbr}`);
+    locationGroup.setAttribute("class", "structure-pips");
 
     // Clone each path into our template
     paths.forEach((path) => {
       const clonedPath = svgDoc.importNode(path, true) as SVGPathElement;
       // Ensure proper styling for structure pips (white fill with black stroke)
       if (
-        !clonedPath.getAttribute('fill') ||
-        clonedPath.getAttribute('fill') === 'none'
+        !clonedPath.getAttribute("fill") ||
+        clonedPath.getAttribute("fill") === "none"
       ) {
-        clonedPath.setAttribute('fill', '#FFFFFF');
+        clonedPath.setAttribute("fill", "#FFFFFF");
       }
-      if (!clonedPath.getAttribute('stroke')) {
-        clonedPath.setAttribute('stroke', '#000000');
+      if (!clonedPath.getAttribute("stroke")) {
+        clonedPath.setAttribute("stroke", "#000000");
       }
       locationGroup.appendChild(clonedPath);
     });
@@ -176,7 +176,7 @@ export function generateStructurePipsForLocationFallback(
 
   // Get all existing pip paths in this group to determine positions
   const existingPips = existingPipGroup.querySelectorAll(
-    'path.pip.structure, circle.pip.structure',
+    "path.pip.structure, circle.pip.structure",
   );
 
   // If there are existing pips, we can use them as templates
@@ -191,11 +191,11 @@ export function generateStructurePipsForLocationFallback(
       const pip = existingPips[i] as SVGElement;
       if (i < pipsToShow) {
         // Show this pip with proper styling
-        pip.setAttribute('fill', '#FFFFFF');
-        pip.setAttribute('visibility', 'visible');
+        pip.setAttribute("fill", "#FFFFFF");
+        pip.setAttribute("visibility", "visible");
       } else {
         // Hide excess pips
-        pip.setAttribute('visibility', 'hidden');
+        pip.setAttribute("visibility", "hidden");
       }
     }
 
@@ -235,7 +235,7 @@ function generateAdditionalStructurePips(
   const parentG = referencePip.parentElement;
   if (!parentG) return;
 
-  const transform = parentG.getAttribute('transform') || '';
+  const transform = parentG.getAttribute("transform") || "";
   const translateMatch = transform.match(/translate\(([\d.-]+),([\d.-]+)\)/);
 
   if (!translateMatch) return;
@@ -249,20 +249,20 @@ function generateAdditionalStructurePips(
 
   // Generate additional pips in a row/column pattern
   for (let i = 0; i < count; i++) {
-    const pipGroup = svgDoc.createElementNS(SVG_NS, 'g');
+    const pipGroup = svgDoc.createElementNS(SVG_NS, "g");
     pipGroup.setAttribute(
-      'transform',
+      "transform",
       `translate(${baseX + (i + 1) * spacing},${baseY})`,
     );
 
-    const pip = svgDoc.createElementNS(SVG_NS, 'circle');
-    pip.setAttribute('cx', '0');
-    pip.setAttribute('cy', '0');
-    pip.setAttribute('r', String(radius));
-    pip.setAttribute('fill', '#FFFFFF');
-    pip.setAttribute('stroke', '#000000');
-    pip.setAttribute('stroke-width', '0.5');
-    pip.setAttribute('class', 'pip structure');
+    const pip = svgDoc.createElementNS(SVG_NS, "circle");
+    pip.setAttribute("cx", "0");
+    pip.setAttribute("cy", "0");
+    pip.setAttribute("r", String(radius));
+    pip.setAttribute("fill", "#FFFFFF");
+    pip.setAttribute("stroke", "#000000");
+    pip.setAttribute("stroke-width", "0.5");
+    pip.setAttribute("class", "pip structure");
 
     pipGroup.appendChild(pip);
     parentGroup.appendChild(pipGroup);
@@ -299,22 +299,22 @@ function generateStructurePipGrid(
   const radius = 1.75;
   const spacing = 4.5;
 
-  const group = svgDoc.createElementNS(SVG_NS, 'g');
-  group.setAttribute('id', `gen_is_pips_${locationAbbr}`);
-  group.setAttribute('class', 'structure-pips-generated');
+  const group = svgDoc.createElementNS(SVG_NS, "g");
+  group.setAttribute("id", `gen_is_pips_${locationAbbr}`);
+  group.setAttribute("class", "structure-pips-generated");
 
   for (let i = 0; i < count; i++) {
     const col = i % layout.cols;
     const row = Math.floor(i / layout.cols);
 
-    const pip = svgDoc.createElementNS(SVG_NS, 'circle');
-    pip.setAttribute('cx', String(layout.startX + col * spacing));
-    pip.setAttribute('cy', String(layout.startY + row * spacing));
-    pip.setAttribute('r', String(radius));
-    pip.setAttribute('fill', '#FFFFFF');
-    pip.setAttribute('stroke', '#000000');
-    pip.setAttribute('stroke-width', '0.5');
-    pip.setAttribute('class', 'pip structure');
+    const pip = svgDoc.createElementNS(SVG_NS, "circle");
+    pip.setAttribute("cx", String(layout.startX + col * spacing));
+    pip.setAttribute("cy", String(layout.startY + row * spacing));
+    pip.setAttribute("r", String(radius));
+    pip.setAttribute("fill", "#FFFFFF");
+    pip.setAttribute("stroke", "#000000");
+    pip.setAttribute("stroke-width", "0.5");
+    pip.setAttribute("class", "pip structure");
 
     group.appendChild(pip);
   }
@@ -328,7 +328,7 @@ function generateStructurePipGrid(
  */
 function generateDynamicStructurePips(
   svgDoc: Document,
-  structure: IRecordSheetData['structure'],
+  structure: IMechRecordSheetData["structure"],
   mechType: string,
 ): void {
   // Get the structure pip group IDs based on mech type
@@ -354,9 +354,9 @@ function generateDynamicStructurePips(
     // Use ArmorPipLayout to generate pips within the bounding rects
     if (loc.points > 0) {
       ArmorPipLayout.addPips(svgDoc, pipArea, loc.points, {
-        fill: '#FFFFFF',
+        fill: "#FFFFFF",
         strokeWidth: 0.5,
-        className: 'pip structure',
+        className: "pip structure",
       });
     }
   });
@@ -369,11 +369,11 @@ function getStructurePipGroupIdsForMechType(
   mechType: string,
 ): Record<string, string> {
   switch (mechType) {
-    case 'quad':
+    case "quad":
       return QUAD_STRUCTURE_PIP_GROUP_IDS;
-    case 'tripod':
+    case "tripod":
       return TRIPOD_STRUCTURE_PIP_GROUP_IDS;
-    case 'biped':
+    case "biped":
     default:
       return BIPED_STRUCTURE_PIP_GROUP_IDS;
   }

--- a/src/services/printing/svgRecordSheetRenderer/vehicleRenderer.ts
+++ b/src/services/printing/svgRecordSheetRenderer/vehicleRenderer.ts
@@ -1,0 +1,162 @@
+/**
+ * Vehicle Record Sheet SVG Renderer
+ *
+ * Generates an SVG string for a vehicle (tracked/wheeled/hover/VTOL/WiGE/naval)
+ * record sheet. Skeleton implementation: title block + motion badge + armor bars
+ * + equipment list. Sufficient for screen preview and PDF export.
+ *
+ * Dimensions match the mech sheet canvas: 612 × 792 pts (US Letter).
+ */
+
+import { IVehicleRecordSheetData } from "@/types/printing";
+
+const SVG_W = 612;
+const SVG_H = 792;
+const MARGIN = 18;
+const FONT = "Eurostile, Arial, sans-serif";
+
+/** Escape text for safe SVG embedding. */
+function esc(s: string | number): string {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Render a simple horizontal armor bar (filled rect + outline). */
+function armorBar(
+  x: number,
+  y: number,
+  w: number,
+  current: number,
+  maximum: number,
+  label: string,
+): string {
+  const fillW = maximum > 0 ? Math.round((current / maximum) * w) : 0;
+  return `
+    <text x="${x}" y="${y - 2}" font-family="${FONT}" font-size="7" fill="#000">${esc(label)} ${esc(current)}/${esc(maximum)}</text>
+    <rect x="${x}" y="${y}" width="${w}" height="8" fill="#e0e0e0" stroke="#000" stroke-width="0.5"/>
+    <rect x="${x}" y="${y}" width="${fillW}" height="8" fill="#555"/>`;
+}
+
+/**
+ * Render a vehicle record sheet as an SVG string.
+ *
+ * Returns a complete `<svg>` document at 612×792 pts.
+ */
+export function renderVehicleSVG(data: IVehicleRecordSheetData): string {
+  const {
+    header,
+    motionType,
+    cruiseMP,
+    flankMP,
+    armorLocations,
+    equipment,
+    crew,
+  } = data;
+
+  // ── Title block ──────────────────────────────────────────────────────────
+  let body = `
+  <!-- Title block -->
+  <rect x="${MARGIN}" y="${MARGIN}" width="${SVG_W - MARGIN * 2}" height="36" fill="#1a1a2e" rx="3"/>
+  <text x="${SVG_W / 2}" y="${MARGIN + 14}" font-family="${FONT}" font-size="13" font-weight="bold" fill="#fff" text-anchor="middle">${esc(header.chassis)} ${esc(header.model)}</text>
+  <text x="${SVG_W / 2}" y="${MARGIN + 28}" font-family="${FONT}" font-size="8" fill="#ccc" text-anchor="middle">${esc(header.tonnage)}t · ${esc(header.techBase)} · BV ${esc(header.battleValue.toLocaleString())}</text>`;
+
+  // ── Motion type badge + MP ───────────────────────────────────────────────
+  const motionY = MARGIN + 46;
+  body += `
+  <!-- Motion type -->
+  <rect x="${MARGIN}" y="${motionY}" width="120" height="22" fill="#2d4a6e" rx="2"/>
+  <text x="${MARGIN + 60}" y="${motionY + 14}" font-family="${FONT}" font-size="9" font-weight="bold" fill="#fff" text-anchor="middle">${esc(motionType)}</text>
+  <text x="${MARGIN + 130}" y="${motionY + 8}" font-family="${FONT}" font-size="7" fill="#000">Cruise MP: ${esc(cruiseMP)}</text>
+  <text x="${MARGIN + 130}" y="${motionY + 18}" font-family="${FONT}" font-size="7" fill="#000">Flank MP: ${esc(flankMP)}</text>`;
+
+  // ── Crew block ───────────────────────────────────────────────────────────
+  const crewY = motionY + 32;
+  body += `
+  <!-- Crew -->
+  <text x="${MARGIN}" y="${crewY}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">CREW</text>`;
+  crew.forEach((member, i) => {
+    const ly = crewY + 12 + i * 12;
+    body += `
+  <text x="${MARGIN + 4}" y="${ly}" font-family="${FONT}" font-size="7" fill="#000">${esc(member.role.charAt(0).toUpperCase() + member.role.slice(1))}  Gun:${esc(member.gunnery)}  Pil:${esc(member.piloting)}</text>`;
+  });
+
+  // ── Armor locations ──────────────────────────────────────────────────────
+  const armorStartY = crewY + 16 + crew.length * 12 + 10;
+  body += `
+  <!-- Armor locations -->
+  <text x="${MARGIN}" y="${armorStartY}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">ARMOR (${esc(data.armorType)})</text>`;
+  const barW = SVG_W - MARGIN * 2 - 10;
+  armorLocations.forEach((loc, i) => {
+    const ly = armorStartY + 10 + i * 20;
+    body += armorBar(
+      MARGIN + 5,
+      ly,
+      barW,
+      loc.current,
+      loc.maximum,
+      loc.location,
+    );
+    if (loc.bar !== undefined) {
+      body += `<text x="${MARGIN + barW + 6}" y="${ly + 7}" font-family="${FONT}" font-size="6" fill="#000">BAR ${esc(loc.bar)}</text>`;
+    }
+  });
+
+  // ── Equipment list ───────────────────────────────────────────────────────
+  const equipStartY = armorStartY + 14 + armorLocations.length * 20 + 14;
+  body += `
+  <!-- Equipment -->
+  <text x="${MARGIN}" y="${equipStartY}" font-family="${FONT}" font-size="8" font-weight="bold" fill="#000">WEAPONS &amp; EQUIPMENT</text>
+  <line x1="${MARGIN}" y1="${equipStartY + 2}" x2="${SVG_W - MARGIN}" y2="${equipStartY + 2}" stroke="#000" stroke-width="0.5"/>`;
+
+  // Column headers
+  const cols = {
+    qty: MARGIN + 2,
+    name: MARGIN + 18,
+    loc: MARGIN + 160,
+    dmg: MARGIN + 195,
+    sht: MARGIN + 230,
+    med: MARGIN + 260,
+    lng: MARGIN + 290,
+  };
+  const hdrY = equipStartY + 12;
+  body += `
+  <text x="${cols.qty}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Qty</text>
+  <text x="${cols.name}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Type</text>
+  <text x="${cols.loc}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Loc</text>
+  <text x="${cols.dmg}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Dmg</text>
+  <text x="${cols.sht}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Sht</text>
+  <text x="${cols.med}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Med</text>
+  <text x="${cols.lng}" y="${hdrY}" font-family="${FONT}" font-size="6" font-weight="bold" fill="#000">Lng</text>`;
+
+  const maxEqRows = Math.floor((SVG_H - equipStartY - 30) / 9);
+  equipment.slice(0, maxEqRows).forEach((eq, i) => {
+    const ry = hdrY + 10 + i * 9;
+    const name =
+      eq.name.length > 22 ? eq.name.substring(0, 20) + ".." : eq.name;
+    body += `
+  <text x="${cols.qty}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.quantity)}</text>
+  <text x="${cols.name}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(name)}</text>
+  <text x="${cols.loc}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.locationAbbr)}</text>`;
+    if (eq.isWeapon) {
+      body += `
+  <text x="${cols.dmg}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.damage ?? "-")}</text>
+  <text x="${cols.sht}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.short || "-")}</text>
+  <text x="${cols.med}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.medium || "-")}</text>
+  <text x="${cols.lng}" y="${ry}" font-family="${FONT}" font-size="6" fill="#000">${esc(eq.long || "-")}</text>`;
+    } else if (eq.isAmmo) {
+      body += `<text x="${cols.dmg}" y="${ry}" font-family="${FONT}" font-size="6" fill="#555">(${esc(eq.ammoCount ?? 0)} shots)</text>`;
+    }
+  });
+
+  // ── Footer ───────────────────────────────────────────────────────────────
+  body += `
+  <text x="${SVG_W / 2}" y="${SVG_H - 6}" font-family="${FONT}" font-size="5.5" fill="#888" text-anchor="middle">MekStation · Vehicle Record Sheet</text>`;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${SVG_W}" height="${SVG_H}" viewBox="0 0 ${SVG_W} ${SVG_H}">
+  <rect width="${SVG_W}" height="${SVG_H}" fill="#fff"/>
+  ${body}
+</svg>`;
+}

--- a/src/types/printing/RecordSheetTypes.ts
+++ b/src/types/printing/RecordSheetTypes.ts
@@ -6,15 +6,15 @@
  * @spec openspec/specs/record-sheet-export/spec.md
  */
 
-import { MechLocation } from '../construction/CriticalSlotAllocation';
-import { LOCATION_ABBREVIATION_MAP } from '../construction/MechConfigurationSystem';
+import { MechLocation } from "../construction/CriticalSlotAllocation";
+import { LOCATION_ABBREVIATION_MAP } from "../construction/MechConfigurationSystem";
 
 /**
  * Paper size options for PDF generation
  */
 export enum PaperSize {
-  LETTER = 'letter',
-  A4 = 'a4',
+  LETTER = "letter",
+  A4 = "a4",
 }
 
 /**
@@ -189,10 +189,22 @@ export interface IRecordSheetSPAEntry {
   readonly xpSpent?: number;
 }
 
+// =============================================================================
+// Discriminated union — per-type record sheet data
+// =============================================================================
+
 /**
- * Complete record sheet data extracted from unit
+ * Mech sub-type string used for template selection.
  */
-export interface IRecordSheetData {
+export type MechSubType = "biped" | "quad" | "tripod" | "lam" | "quadvee";
+
+/**
+ * Mech record sheet data (existing shape, preserved for regression safety).
+ *
+ * `unitType: 'mech'` is the discriminant used by the renderer dispatcher.
+ */
+export interface IMechRecordSheetData {
+  readonly unitType: "mech";
   readonly header: IRecordSheetHeader;
   readonly movement: IRecordSheetMovement;
   readonly armor: IRecordSheetArmor;
@@ -201,11 +213,237 @@ export interface IRecordSheetData {
   readonly heatSinks: IRecordSheetHeatSinks;
   readonly criticals: readonly ILocationCriticals[];
   readonly pilot?: IRecordSheetPilot;
-  /** Phase 5 Wave 3 — printable Special Abilities block. Empty when the
-   *  pilot has no resolvable SPAs; renderer skips the section then. */
+  /** Phase 5 Wave 3 — printable Special Abilities block. */
   readonly specialAbilities?: readonly IRecordSheetSPAEntry[];
-  readonly mechType: 'biped' | 'quad' | 'tripod' | 'lam' | 'quadvee';
+  readonly mechType: MechSubType;
 }
+
+/**
+ * Crew member on a vehicle (driver, gunner, commander).
+ */
+export interface IVehicleCrewMember {
+  readonly role: "driver" | "gunner" | "commander";
+  readonly gunnery: number;
+  readonly piloting: number;
+}
+
+/**
+ * Armor for a single vehicle location.
+ */
+export interface IVehicleLocationArmor {
+  readonly location:
+    | "Front"
+    | "Left Side"
+    | "Right Side"
+    | "Rear"
+    | "Turret"
+    | "Rotor"
+    | "Chin"
+    | "Body";
+  readonly current: number;
+  readonly maximum: number;
+  /** BAR (Barrier Armor Rating) for support vehicles — omitted for standard tanks. */
+  readonly bar?: number;
+}
+
+/**
+ * Vehicle record sheet data.
+ *
+ * Covers tracked, wheeled, hover, VTOL, and WiGE combat/support vehicles.
+ */
+export interface IVehicleRecordSheetData {
+  readonly unitType: "vehicle";
+  readonly header: IRecordSheetHeader;
+  /** Motion type governs movement rules and record-sheet layout variant. */
+  readonly motionType:
+    | "Tracked"
+    | "Wheeled"
+    | "Hover"
+    | "VTOL"
+    | "WiGE"
+    | "Naval"
+    | "Submarine"
+    | "Rail";
+  readonly cruiseMP: number;
+  readonly flankMP: number;
+  readonly armorType: string;
+  readonly armorLocations: readonly IVehicleLocationArmor[];
+  readonly crew: readonly IVehicleCrewMember[];
+  /** Equipment keyed by location string for turret / hull split. */
+  readonly equipment: readonly IRecordSheetEquipment[];
+  /** BAR rating for the vehicle as a whole — present for support vehicles. */
+  readonly barRating?: number;
+  readonly pilot?: IRecordSheetPilot;
+  readonly specialAbilities?: readonly IRecordSheetSPAEntry[];
+}
+
+/**
+ * Aerospace armor per standard 4-arc layout.
+ */
+export interface IAerospaceArcArmor {
+  readonly arc: "Nose" | "Left Wing" | "Right Wing" | "Aft";
+  readonly current: number;
+  readonly maximum: number;
+}
+
+/**
+ * Aerospace record sheet data (aerospace fighters and conventional fighters).
+ */
+export interface IAerospaceRecordSheetData {
+  readonly unitType: "aerospace";
+  readonly header: IRecordSheetHeader;
+  /** Structural Integrity — the aerospace equivalent of internal structure. */
+  readonly structuralIntegrity: number;
+  readonly fuelPoints: number;
+  /** Safe Thrust (2/3 of max thrust, rounded up). */
+  readonly safeThrust: number;
+  /** Maximum Thrust (full engine output). */
+  readonly maxThrust: number;
+  readonly heatSinks: IRecordSheetHeatSinks;
+  readonly armorType: string;
+  readonly armorArcs: readonly IAerospaceArcArmor[];
+  readonly equipment: readonly IRecordSheetEquipment[];
+  /** Number of bomb bay slots (0 when no bomb bay). */
+  readonly bombBaySlots: number;
+  readonly pilot?: IRecordSheetPilot;
+  readonly specialAbilities?: readonly IRecordSheetSPAEntry[];
+}
+
+/**
+ * Per-trooper data within a BattleArmor point.
+ */
+export interface IBattleArmorTrooper {
+  /** 1-based trooper index within the point. */
+  readonly index: number;
+  readonly armorPips: number;
+  readonly maximumArmorPips: number;
+  /** Currently-selected modular weapon, if any. */
+  readonly modularWeapon?: string;
+  /** Anti-personnel weapon mounted on this suit. */
+  readonly apWeapon?: string;
+  readonly gunnery: number;
+  /** Anti-mech skill (replaces piloting for BA). */
+  readonly antiMech: number;
+  readonly specialAbilities?: readonly IRecordSheetSPAEntry[];
+}
+
+/**
+ * BattleArmor record sheet data.
+ */
+export interface IBattleArmorRecordSheetData {
+  readonly unitType: "battlearmor";
+  readonly header: IRecordSheetHeader;
+  readonly squadSize: number;
+  readonly troopers: readonly IBattleArmorTrooper[];
+  /** Manipulator types (left, right). */
+  readonly manipulators: { readonly left: string; readonly right: string };
+  /** Movement mode and points. */
+  readonly jumpMP: number;
+  readonly walkMP: number;
+  readonly umuMP: number;
+  readonly vtolMP: number;
+}
+
+/**
+ * Field gun entry for infantry platoons (1 gun per 7 troopers).
+ *
+ * Named `IInfantryFieldGunSheet` to avoid collision with the construction-
+ * domain `IInfantryFieldGun` in `src/types/unit/PersonnelInterfaces.ts`.
+ */
+export interface IInfantryFieldGunSheet {
+  readonly name: string;
+  readonly count: number;
+  readonly damage: number | string;
+  readonly minimumRange: number;
+  readonly shortRange: number;
+  readonly mediumRange: number;
+  readonly longRange: number;
+}
+
+/**
+ * Infantry record sheet data.
+ */
+export interface IInfantryRecordSheetData {
+  readonly unitType: "infantry";
+  readonly header: IRecordSheetHeader;
+  readonly platoonSize: number;
+  readonly motiveType: "Foot" | "Motorized" | "Jump" | "Mechanized" | "Beast";
+  readonly primaryWeapon: string;
+  /** Secondary weapons with anti-personnel ratio. */
+  readonly secondaryWeapons: readonly {
+    readonly name: string;
+    readonly perTrooperRatio: number;
+  }[];
+  /** Field gun block — present when the platoon fields crew-served weapons. */
+  readonly fieldGun?: IInfantryFieldGunSheet;
+  /** Specialization badge (anti-mech, marine, scuba, mountain, XCT). */
+  readonly specialization?: string;
+  readonly gunnery: number;
+  readonly antiMech: number;
+}
+
+/**
+ * Per-proto data within a ProtoMech point.
+ */
+export interface IProtoMechUnit {
+  /** 1-based index within the point (1–5). */
+  readonly index: number;
+  readonly armorByLocation: Record<
+    "Head" | "Torso" | "Left Arm" | "Right Arm" | "Legs" | "Main Gun",
+    { readonly current: number; readonly maximum: number }
+  >;
+}
+
+/**
+ * ProtoMech record sheet data.
+ */
+export interface IProtoMechRecordSheetData {
+  readonly unitType: "protomech";
+  readonly header: IRecordSheetHeader;
+  /** Point composition (1–5 ProtoMechs per point). */
+  readonly pointSize: number;
+  readonly protos: readonly IProtoMechUnit[];
+  /** Main gun designation (name), if equipped. */
+  readonly mainGun?: string;
+  readonly mainGunAmmo?: number;
+  readonly hasUMU: boolean;
+  readonly isGlider: boolean;
+  readonly walkMP: number;
+  readonly jumpMP: number;
+  readonly equipment: readonly IRecordSheetEquipment[];
+  readonly pilot?: IRecordSheetPilot;
+}
+
+/**
+ * Discriminated union of all supported record sheet data variants.
+ *
+ * Consumers narrow to the correct variant via `data.unitType`:
+ *   if (data.unitType === 'vehicle') { ... IVehicleRecordSheetData ... }
+ */
+export type IRecordSheetData =
+  | IMechRecordSheetData
+  | IVehicleRecordSheetData
+  | IAerospaceRecordSheetData
+  | IBattleArmorRecordSheetData
+  | IInfantryRecordSheetData
+  | IProtoMechRecordSheetData;
+
+/**
+ * Error thrown when `RecordSheetService.extractData` receives an unsupported unit type.
+ */
+export class UnsupportedUnitTypeError extends Error {
+  constructor(readonly unitType: string) {
+    super(`Unsupported unit type for record sheet extraction: '${unitType}'`);
+    this.name = "UnsupportedUnitTypeError";
+  }
+}
+
+/**
+ * @deprecated Use `IMechRecordSheetData` directly. This alias exists for
+ * call-sites that used the old flat `IRecordSheetData` interface which was
+ * mech-only. Will be removed once all callers are narrowed.
+ */
+export type ILegacyMechRecordSheetData = IMechRecordSheetData;
 
 /**
  * Render context for drawing record sheet elements


### PR DESCRIPTION
## Summary

Completes the multi-type record sheet export — discriminated union + all 6 unit renderers + dispatcher.

### What landed in this PR

**Priority 1 — 5 skeleton SVG renderers** (`src/services/printing/svgRecordSheetRenderer/`)
- `vehicleRenderer.ts` — title bar + motion type badge + cruise/flank MP + per-location armor bars + equipment table
- `aerospaceRenderer.ts` — title bar + thrust table + SI bar + 4-arc armor bars + fuel track + bomb bay slot count + pilot block
- `battleArmorRenderer.ts` — per-trooper armor pip columns + manipulator block + movement block
- `infantryRenderer.ts` — platoon pip grid + motive type badge + specialization badge + primary/secondary weapons + field gun block
- `protoMechRenderer.ts` — per-proto 5-location armor bars + main gun block + movement flags (UMU/glider) + equipment table

Each renderer: takes narrowed per-type data, returns a complete 612×792 SVG string. Title block, dimensions, and font stack match the mech sheet aesthetic.

**Priority 2 — 5 per-type extractors** (`src/services/printing/recordsheet/`)
- `dataExtractors.vehicle.ts` → `IVehicleRecordSheetData`
- `dataExtractors.aerospace.ts` → `IAerospaceRecordSheetData`
- `dataExtractors.battleArmor.ts` → `IBattleArmorRecordSheetData`
- `dataExtractors.infantry.ts` → `IInfantryRecordSheetData`
- `dataExtractors.protoMech.ts` → `IProtoMechRecordSheetData`

All extractors have safe defaults so partially-populated configs still produce renderable sheets.

**Priority 3 — Top-level dispatch** (`RecordSheetService.ts`)
- `extractDataByType` now dispatches all 6 unit types to their extractors
- `renderPreview`, `getSVGString`, `exportPDF` accept full `IRecordSheetData` union
- Non-mech units route through `buildNonMechSVG` dispatcher; mech pipeline (MegaMek template) preserved exactly
- TypeScript exhaustiveness guard in `buildNonMechSVG` ensures compile-time safety for future variants

### Verification
- `tsc --noEmit` — clean (0 errors)
- 308 existing printing/recordsheet tests — all pass

### Remaining (P4 — optional)
- Zod schemas per variant (`RecordSheetSchemas.ts`)
- Snapshot tests per renderer
- `openspec validate add-multi-type-record-sheet-export --strict`