### PR TITLE
ci: Swervebox k8s manifest lint (self-hosted ARC)

### DIFF
--- a/.github/workflows/swervebox-k8s-lint.yml
+++ b/.github/workflows/swervebox-k8s-lint.yml
@@ -1,9 +1,9 @@
-# Runs yamllint + kubeconform on kubernetes/ via the org reusable workflow.
-# Uses self-hosted ARC runners (label: swervebox-arc), not GitHub-hosted minutes.
-#
-# Prerequisite: swervebox-ci repo Settings → Actions → General must allow this
-# repo to use its workflows (org access or explicit allowlist).
+# Runs yamllint + kubeconform on kubernetes/ via SwiggitySwerve/swervebox-ci.
+# Jobs execute on self-hosted ARC runners (label: swervebox-arc).
 name: Swervebox — Kubernetes lint
+
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/swervebox-k8s-lint.yml
+++ b/.github/workflows/swervebox-k8s-lint.yml
@@ -1,0 +1,28 @@
+# Runs yamllint + kubeconform on kubernetes/ via the org reusable workflow.
+# Uses self-hosted ARC runners (label: swervebox-arc), not GitHub-hosted minutes.
+#
+# Prerequisite: swervebox-ci repo Settings → Actions → General must allow this
+# repo to use its workflows (org access or explicit allowlist).
+name: Swervebox — Kubernetes lint
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "kubernetes/**"
+      - ".github/workflows/swervebox-k8s-lint.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "kubernetes/**"
+      - ".github/workflows/swervebox-k8s-lint.yml"
+  workflow_dispatch:
+
+jobs:
+  lint:
+    uses: SwiggitySwerve/swervebox-ci/.github/workflows/k8s-lint.yaml@main
+    with:
+      manifests-path: kubernetes
+      kubernetes-version: "1.30.0"

--- a/kubernetes/namespace-mekstation.yaml
+++ b/kubernetes/namespace-mekstation.yaml
@@ -1,0 +1,6 @@
+# Minimal manifests for local kubeconform / yamllint smoke checks in CI.
+# Extend this directory with real MekStation deployment resources as needed.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mekstation


### PR DESCRIPTION
## Summary
Adds a thin caller workflow that runs the org reusable **k8s-lint** pipeline from [`SwiggitySwerve/swervebox-ci`](https://github.com/SwiggitySwerve/swervebox-ci) (yamllint + kubeconform) on self-hosted runners labeled `swervebox-arc` — **not** GitHub-hosted `ubuntu-latest`, so it should not consume monthly Actions minutes for hosted runners.

## Changes
- `.github/workflows/swervebox-k8s-lint.yml` — calls `k8s-lint.yaml@main` with `manifests-path: kubernetes`, `kubernetes-version: 1.30.0`; triggers on PR/push to `main` when `kubernetes/**` or this workflow changes, plus `workflow_dispatch`.
- `kubernetes/namespace-mekstation.yaml` — minimal valid manifest so CI has something to validate.

## How to verify after merge
1. **Actions** → **Swervebox — Kubernetes lint** → **Run workflow** (manual) on `main`, or
2. Open a follow-up PR that touches `kubernetes/**`.

## Notes
- Reusable workflow access for this repo should already be allowed on **swervebox-ci** (org settings).
- If jobs stay queued, check ARC runners / `swervebox-arc` availability on the cluster.


Made with [Cursor](https://cursor.com)