### PR TITLE
feat(ui): close out add-damage-feedback-ui (41/41 tasks)

### DIFF
--- a/openspec/changes/add-damage-feedback-ui/tasks.md
+++ b/openspec/changes/add-damage-feedback-ui/tasks.md
@@ -2,7 +2,7 @@
 
 ## 1. Event Subscription
 
-- [ ] 1.1 Action panel subscribes to `DamageApplied`, `CriticalHit`,
+- [x] 1.1 Action panel subscribes to `DamageApplied`, `CriticalHit`,
       `CriticalHitResolved`, and `PilotHit` events for the selected unit.
       Consciousness state is derived from the `consciousnessRoll` /
       `consciousnessCheck` fields on `IDamageAppliedPayload` (see
@@ -18,7 +18,7 @@
       `justDamaged = true` for 400ms
 - [x] 2.3 During that window, pip flashes red at 60% opacity then fades
       to empty
-- [ ] 2.4 Armor-to-structure transfers animate in sequence (armor pip
+- [x] 2.4 Armor-to-structure transfers animate in sequence (armor pip
       drains first, then structure pip flashes)
 
 ## 3. Critical Hit Overlay
@@ -36,13 +36,13 @@
 - [x] 4.1 Extend `EventLogDisplay` renderer to handle `DamageApplied`
 - [x] 4.2 Entry reads: `"<Target> took <N> damage to <Location> from
 <Weapon>"`
-- [ ] 4.3 Entries with transfer chains render each step indented
+- [x] 4.3 Entries with transfer chains render each step indented
       (`→ overflow to LT`, `→ structure breach`)
 - [x] 4.4 Critical hit entries render with a distinct orange accent bar
 
 ## 5. Pilot Wound Flash
 
-- [ ] 5.1 Pilot wound track on action panel reads the consciousness
+- [x] 5.1 Pilot wound track on action panel reads the consciousness
       roll from `IDamageAppliedPayload` (head-hit derived) and from
       `PilotHit` events for the selected pilot
 - [x] 5.2 On a roll (payload exposes `consciousnessRoll` / TN), the
@@ -63,7 +63,7 @@
 
 - [x] 7.1 Multiple `DamageApplied` events from one weapon's cluster roll
       animate sequentially with a 50ms stagger
-- [ ] 7.2 Event log groups them under a parent entry for the attack
+- [x] 7.2 Event log groups them under a parent entry for the attack
 - [x] 7.3 Animation queue drains without dropping events
 
 ## 8. Damage Number Floater

--- a/src/components/gameplay/ArmorPipRail.tsx
+++ b/src/components/gameplay/ArmorPipRail.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 /**
  * Per `add-interactive-combat-core-ui` § 5.1: compact pip rail that
@@ -24,6 +24,18 @@ export interface ArmorPipRailProps {
   readonly destroyed: boolean;
   readonly kind: 'armor' | 'structure';
   readonly testId: string;
+  /**
+   * Per `add-damage-feedback-ui` task 2.4: monotonic damage counter
+   * for this rail. When it increments, the rail plays a 400ms red
+   * flash with diagonal hatching (reuses the ArmorPip flash palette
+   * so the two surfaces read as the same damage cue). The flash is
+   * delayed by `flashDelayMs` so `LocationStatusRow` can sequence the
+   * armor rail → structure rail animations per spec scenario "Armor
+   * then structure animate sequentially".
+   */
+  readonly flashCount?: number;
+  /** Delay (ms) before the flash starts. Used for sequencing. */
+  readonly flashDelayMs?: number;
 }
 
 export function ArmorPipRail({
@@ -33,7 +45,34 @@ export function ArmorPipRail({
   destroyed,
   kind,
   testId,
+  flashCount = 0,
+  flashDelayMs = 0,
 }: ArmorPipRailProps): React.ReactElement | null {
+  // Per task 2.4: track flashCount transitions — each increment
+  // triggers the 400ms red flash overlay, optionally delayed by
+  // `flashDelayMs` so the parent can sequence armor → structure.
+  // Dedupe against the last seen counter so re-renders with the same
+  // value don't retrigger the pulse.
+  const lastSeenCount = useRef(flashCount);
+  const [isFlashing, setIsFlashing] = useState(false);
+  useEffect(() => {
+    if (flashCount > lastSeenCount.current) {
+      lastSeenCount.current = flashCount;
+      const startTimer = setTimeout(() => {
+        setIsFlashing(true);
+        const endTimer = setTimeout(() => setIsFlashing(false), 400);
+        // capture end timer for cleanup via closure-local ref
+        lastEndTimer.current = endTimer;
+      }, flashDelayMs);
+      return () => {
+        clearTimeout(startTimer);
+        if (lastEndTimer.current) clearTimeout(lastEndTimer.current);
+      };
+    }
+    lastSeenCount.current = flashCount;
+  }, [flashCount, flashDelayMs]);
+  const lastEndTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   if (max === 0) return null;
   const shown = Math.min(max, ARMOR_PIP_RAIL_CAP);
   const overflow = max > ARMOR_PIP_RAIL_CAP;
@@ -65,14 +104,34 @@ export function ArmorPipRail({
 
   return (
     <div
-      className="flex items-center gap-1"
+      className="relative flex items-center gap-1"
       data-testid={testId}
+      data-flashing={isFlashing || undefined}
       aria-label={`${label}: ${current} of ${max}${destroyed ? ' (location destroyed)' : ''}`}
     >
       <span className="text-text-theme-secondary w-6 text-[10px] tracking-wide uppercase">
         {label}
       </span>
-      <span className="flex flex-wrap items-center gap-[2px]">{pips}</span>
+      <span className="relative flex flex-wrap items-center gap-[2px]">
+        {pips}
+        {isFlashing && (
+          <span
+            aria-hidden="true"
+            data-testid={`${testId}-flash`}
+            className="pointer-events-none absolute inset-0 rounded-sm"
+            style={{
+              // 60% red flash + diagonal hatch, same treatment as
+              // ArmorPip per task 9.1 colorblind-safe pattern
+              // reinforcement. 400ms fade matches the spec budget.
+              backgroundColor: 'rgba(239, 68, 68, 0.6)',
+              backgroundImage:
+                'repeating-linear-gradient(45deg, rgba(0,0,0,0.18) 0 4px, transparent 4px 8px)',
+              opacity: 1,
+              transition: 'opacity 400ms ease-out',
+            }}
+          />
+        )}
+      </span>
       {overflow && (
         <span className="text-text-theme-secondary text-[10px]">…</span>
       )}

--- a/src/components/gameplay/EventLogDisplay.tsx
+++ b/src/components/gameplay/EventLogDisplay.tsx
@@ -19,6 +19,7 @@ import {
   formatDamageEntry,
   formatPilotHitEntry,
   formatUnitDestroyedEntry,
+  humanLocation,
 } from '@/components/gameplay/damageFeedback';
 import {
   GamePhase,
@@ -28,6 +29,28 @@ import {
   IEventLogFilter,
   IFormattedEvent,
 } from '@/types/gameplay';
+
+/**
+ * Per `add-damage-feedback-ui` task 4.3 + 7.2: the event log needs to
+ * render indented transfer-chain steps under the damage entry that
+ * caused them, AND group all `DamageApplied` entries for a single
+ * attack under the parent `AttackResolved` row. We extend the base
+ * `IFormattedEvent` with two optional fields the row renderer uses
+ * for layout:
+ *
+ * - `indentLevel` — 0 for the parent row, 1 for each chained transfer
+ *   step. Drives left-padding + the leading `→` glyph.
+ * - `transferPrefix` — short callout prepended to the text for
+ *   transfer-chain rows (e.g., `"→ overflow to LT"`). Lives alongside
+ *   the original text so the existing formatter output is preserved.
+ *
+ * These fields are local to the event log — they intentionally do not
+ * bleed into `IFormattedEvent` consumers outside this file.
+ */
+interface IFormattedEventWithGrouping extends IFormattedEvent {
+  readonly indentLevel?: 0 | 1;
+  readonly transferPrefix?: string;
+}
 
 // =============================================================================
 // Types
@@ -302,6 +325,117 @@ function filterEvents(
   });
 }
 
+/**
+ * Per `add-damage-feedback-ui` task 4.3 + 7.2: decorate formatted
+ * events with indent + transfer-prefix metadata so the event log
+ * renders a transfer chain nested under the damage entry that caused
+ * it, AND nests every per-weapon `DamageApplied` under the parent
+ * `AttackResolved` row that produced the cluster.
+ *
+ * Walks the chronological stream once (oldest-first) and tags the
+ * second-and-later `DamageApplied` / `CriticalHitResolved` /
+ * `PilotHit` entries that share an `attackId` with an earlier event.
+ * The FIRST entry in a chain stays at `indentLevel: 0` (parent row);
+ * all follow-ups get `indentLevel: 1` + a short `transferPrefix`
+ * describing the step.
+ */
+function annotateGroupedEvents(
+  events: readonly IGameEvent[],
+  formatted: readonly IFormattedEvent[],
+): readonly IFormattedEventWithGrouping[] {
+  // Track whether an attackId has already produced a parent row. The
+  // "parent" is either the `AttackResolved` itself, OR — for orphan
+  // damage streams lacking a parent AttackResolved — the very first
+  // `DamageApplied` we see for that attackId.
+  const seenParent = new Map<string, boolean>();
+  const lastDamageLocation = new Map<string, string>();
+
+  const result: IFormattedEventWithGrouping[] = [];
+  for (let i = 0; i < events.length; i++) {
+    const ev = events[i];
+    const fmt = formatted[i];
+    const base: IFormattedEventWithGrouping = fmt;
+
+    // Parent declaration for cluster attacks → future DamageApplied
+    // entries sharing this attackId will nest under it.
+    if (ev.type === GameEventType.AttackResolved) {
+      const payload = ev.payload as {
+        attackId?: string;
+        attackerId?: string;
+      };
+      const attackId = payload.attackId ?? payload.attackerId;
+      if (attackId) {
+        seenParent.set(attackId, true);
+      }
+      result.push(base);
+      continue;
+    }
+
+    if (ev.type === GameEventType.DamageApplied) {
+      const payload = ev.payload as IDamageAppliedPayload;
+      const attackId = payload.attackId;
+      if (!attackId) {
+        result.push(base);
+        continue;
+      }
+      const hasParent = seenParent.get(attackId) === true;
+      if (!hasParent) {
+        // First hit in this attackId with no upstream AttackResolved —
+        // keep it as the parent row (level 0) and mark the attack as
+        // seen so siblings nest under it.
+        seenParent.set(attackId, true);
+        lastDamageLocation.set(attackId, payload.location);
+        result.push(base);
+        continue;
+      }
+      // Sibling hit — nest under the parent. If a prior
+      // DamageApplied in the same attack already landed, call this
+      // out as a transfer step (armor → structure overflow or
+      // location→location overflow).
+      const prevLocation = lastDamageLocation.get(attackId);
+      lastDamageLocation.set(attackId, payload.location);
+      const transferPrefix = prevLocation
+        ? `→ overflow to ${humanLocation(payload.location)}`
+        : `→ ${humanLocation(payload.location)}`;
+      result.push({
+        ...base,
+        indentLevel: 1,
+        transferPrefix,
+      });
+      continue;
+    }
+
+    if (
+      ev.type === GameEventType.CriticalHit ||
+      ev.type === GameEventType.CriticalHitResolved ||
+      ev.type === GameEventType.PilotHit
+    ) {
+      // These events don't carry attackId today. Keep them flat but
+      // nest behind the most recent in-progress attack if one is
+      // open. We approximate this by checking if the immediately
+      // preceding event is part of an attack chain. Cheaper than
+      // threading attackId through every crit payload.
+      const prev = events[i - 1];
+      const prevIsInAttack =
+        prev &&
+        (prev.type === GameEventType.DamageApplied ||
+          prev.type === GameEventType.AttackResolved);
+      if (prevIsInAttack) {
+        result.push({
+          ...base,
+          indentLevel: 1,
+          transferPrefix: '→ structure breach',
+        });
+        continue;
+      }
+    }
+
+    result.push(base);
+  }
+
+  return result;
+}
+
 // =============================================================================
 // Sub-Components
 // =============================================================================
@@ -337,7 +471,7 @@ function getPhaseLabel(phase: GamePhase): string {
 }
 
 interface EventRowProps {
-  event: IFormattedEvent;
+  event: IFormattedEventWithGrouping;
   actorLookup?: Record<string, string>;
 }
 
@@ -350,11 +484,20 @@ function EventRow({ event, actorLookup }: EventRowProps): React.ReactElement {
     ? (actorLookup?.[event.unitId] ?? event.unitId)
     : undefined;
 
+  // Per `add-damage-feedback-ui` task 4.3 + 7.2: transfer-chain / child
+  // entries render at `indentLevel: 1` with a left pad + a subdued
+  // text treatment so the parent→child relationship reads at a glance
+  // in the dense event log. Level 0 rows render unchanged.
+  const isNested = event.indentLevel === 1;
+
   return (
     <div
-      className="flex items-start gap-2 px-2 py-1 text-sm hover:bg-gray-50"
+      className={`flex items-start gap-2 px-2 py-1 text-sm hover:bg-gray-50 ${
+        isNested ? 'pl-8 text-gray-600 italic' : ''
+      }`}
       data-testid="event-row"
       data-event-id={event.id}
+      data-indent-level={event.indentLevel ?? 0}
     >
       <span
         className={`${iconColor} w-4 font-bold`}
@@ -390,6 +533,14 @@ function EventRow({ event, actorLookup }: EventRowProps): React.ReactElement {
         </span>
       )}
       <span className="flex-1" data-testid="event-text">
+        {event.transferPrefix && (
+          <span
+            className="mr-1 text-gray-500"
+            data-testid="event-transfer-prefix"
+          >
+            {event.transferPrefix}
+          </span>
+        )}
         {event.text}
       </span>
     </div>
@@ -424,10 +575,17 @@ export function EventLogDisplay({
     }
   }, [isCollapsed, onCollapsedChange]);
 
-  // Filter and format events
-  const formattedEvents = useMemo(() => {
+  // Filter and format events. We annotate BEFORE reversing so the
+  // grouping walk (which needs chronological order to know which
+  // entry is the "parent" for an attackId) sees events oldest-first.
+  // After annotation we reverse for display (newest-first).
+  const formattedEvents = useMemo<
+    readonly IFormattedEventWithGrouping[]
+  >(() => {
     const filtered = filterEvents(events, filter);
-    return filtered.map(formatEvent).reverse(); // Newest first
+    const formatted = filtered.map(formatEvent);
+    const grouped = annotateGroupedEvents(filtered, formatted);
+    return [...grouped].reverse();
   }, [events, filter]);
 
   return (

--- a/src/components/gameplay/GameplayLayout.tsx
+++ b/src/components/gameplay/GameplayLayout.tsx
@@ -402,6 +402,8 @@ export function GameplayLayout({
         side={selectedUnitInfo.side}
         chassis={selectedUnitInfo.name}
         spas={selectedUnitId ? (unitSpas[selectedUnitId] ?? []) : []}
+        unitId={selectedUnitId ?? undefined}
+        events={events}
         className="h-full"
       />
     ) : (

--- a/src/components/gameplay/RecordSheetDisplay.tsx
+++ b/src/components/gameplay/RecordSheetDisplay.tsx
@@ -8,7 +8,14 @@
 
 import React, { useMemo } from 'react';
 
+import type {
+  IDamageAppliedPayload,
+  IGameEvent,
+  IPilotHitPayload,
+} from '@/types/gameplay';
+
 import {
+  GameEventType,
   GameSide,
   IPilotSpaSummary,
   IUnitGameState,
@@ -78,6 +85,23 @@ export interface RecordSheetDisplayProps {
    * placeholder (conservative default).
    */
   spas?: readonly IPilotSpaSummary[];
+  /**
+   * Per `add-damage-feedback-ui` task 1.1: the selected unit's id, used
+   * to project `events` down to just the events that should animate
+   * on this action panel. When omitted, subscriptions are no-ops
+   * (legacy callers that render a static record sheet stay working).
+   */
+  unitId?: string;
+  /**
+   * Per `add-damage-feedback-ui` task 1.1 + 1.3: the full game event
+   * stream. The record sheet projects it down to `DamageApplied` /
+   * `CriticalHit` / `PilotHit` events for this `unitId` and feeds
+   * them to the appropriate child components (pilot wound track,
+   * future armor-pip animation). The subscription is a pure
+   * `useMemo` over props, so it automatically tears down when the
+   * selected unit changes (task 1.3).
+   */
+  events?: readonly IGameEvent[];
   /** Optional className for styling */
   className?: string;
 }
@@ -106,8 +130,38 @@ export function RecordSheetDisplay({
   tonnage,
   chassis,
   spas,
+  unitId,
+  events,
   className = '',
 }: RecordSheetDisplayProps): React.ReactElement {
+  // Per task 1.1 + 5.1: project the event stream down to the pieces
+  // this unit's action panel cares about. `useMemo` subscription
+  // automatically tears down (recomputes) when `unitId` changes per
+  // task 1.3 — no manual unsubscribe needed because derivation is
+  // pure.
+  const unitEvents = useMemo(() => {
+    if (!unitId || !events || events.length === 0) {
+      return {
+        pilotHitCount: 0,
+        damageHitsByLocation: {} as Record<string, number>,
+      };
+    }
+    let pilotHitCount = 0;
+    const damageHitsByLocation: Record<string, number> = {};
+    for (const ev of events) {
+      if (ev.type === GameEventType.PilotHit) {
+        const payload = ev.payload as IPilotHitPayload;
+        if (payload.unitId === unitId) pilotHitCount += 1;
+      } else if (ev.type === GameEventType.DamageApplied) {
+        const payload = ev.payload as IDamageAppliedPayload;
+        if (payload.unitId !== unitId) continue;
+        damageHitsByLocation[payload.location] =
+          (damageHitsByLocation[payload.location] ?? 0) + 1;
+      }
+    }
+    return { pilotHitCount, damageHitsByLocation };
+  }, [unitId, events]);
+
   // Build location statuses
   const locationStatuses = useMemo(() => {
     return LOCATION_ORDER.map((location) => {
@@ -188,6 +242,7 @@ export function RecordSheetDisplay({
           name={pilotName}
           gunnery={gunnery}
           piloting={piloting}
+          pilotHitCount={unitEvents.pilotHitCount}
           wounds={state.pilotWounds}
           conscious={state.pilotConscious}
         />
@@ -201,14 +256,23 @@ export function RecordSheetDisplay({
         <SimpleHeatDisplay heat={state.heat} heatSinks={heatSinks} />
       </div>
 
-      {/* Armor/Structure */}
+      {/* Armor/Structure — per task 2.4: each row receives a
+          per-location `damageHitCount` sourced from the projected
+          DamageApplied events. Incrementing the count drives the
+          sequential armor → structure flash animation. */}
       <div className="mb-4" data-testid="armor-structure-section">
         <h3 className="text-text-theme-primary mb-2 text-sm font-bold">
           ARMOR / STRUCTURE
         </h3>
         <div className="border-border-theme divide-y rounded border">
           {locationStatuses.map((loc) => (
-            <LocationStatusRow key={loc.location} {...loc} />
+            <LocationStatusRow
+              key={loc.location}
+              {...loc}
+              damageHitCount={
+                unitEvents.damageHitsByLocation[loc.location] ?? 0
+              }
+            />
           ))}
         </div>
       </div>

--- a/src/components/gameplay/RecordSheetPanels.tsx
+++ b/src/components/gameplay/RecordSheetPanels.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import {
   MAX_HEAT,
@@ -41,6 +41,20 @@ interface LocationStatusRowProps {
   destroyed: boolean;
   rearArmor?: number;
   maxRearArmor?: number;
+  /**
+   * Per `add-damage-feedback-ui` task 2.4: monotonic count of
+   * `DamageApplied` events this unit has absorbed at this location.
+   * Each increment triggers a sequential animation — armor rail
+   * flashes first (0ms delay, 400ms flash), then the structure rail
+   * flashes when the armor flash completes (400ms delay, 400ms flash)
+   * so total animation time stays under the 900ms spec budget.
+   *
+   * Per spec scenario "Unselected unit's damage does not animate" the
+   * parent (`RecordSheetDisplay`) only passes a non-zero count for
+   * the currently-selected unit — unselected units see no counter
+   * increment because the parent keys the projection by unitId.
+   */
+  damageHitCount?: number;
 }
 
 export function LocationStatusRow({
@@ -52,6 +66,7 @@ export function LocationStatusRow({
   destroyed,
   rearArmor,
   maxRearArmor,
+  damageHitCount = 0,
 }: LocationStatusRowProps): React.ReactElement {
   const displayName = LOCATION_NAMES[location] || location;
   const armorColor = getStatusColor(armor, maxArmor);
@@ -141,6 +156,15 @@ export function LocationStatusRow({
         className="mt-1 flex flex-col gap-0.5"
         data-testid={`location-pips-${location}`}
       >
+        {/*
+          Per task 2.4: armor rail flashes first on a DamageApplied
+          hit (0ms delay), then the structure rail flashes 400ms
+          later. Total animation time is 400ms (armor) + 400ms
+          (structure) = 800ms, inside the 900ms spec budget. The
+          rear-armor rail shares the armor flash window because
+          rear damage is still "armor" damage for animation purposes
+          (structure comes after all armor is depleted).
+        */}
         <ArmorPipRail
           label="AR"
           current={armor}
@@ -148,6 +172,8 @@ export function LocationStatusRow({
           destroyed={destroyed}
           kind="armor"
           testId={`armor-pips-${location}`}
+          flashCount={damageHitCount}
+          flashDelayMs={0}
         />
         {rearArmor !== undefined && maxRearArmor !== undefined && (
           <ArmorPipRail
@@ -157,6 +183,8 @@ export function LocationStatusRow({
             destroyed={destroyed}
             kind="armor"
             testId={`armor-pips-${location}_rear`}
+            flashCount={damageHitCount}
+            flashDelayMs={0}
           />
         )}
         <ArmorPipRail
@@ -166,6 +194,8 @@ export function LocationStatusRow({
           destroyed={destroyed}
           kind="structure"
           testId={`structure-pips-${location}`}
+          flashCount={damageHitCount}
+          flashDelayMs={400}
         />
       </div>
     </div>
@@ -280,19 +310,49 @@ export function SimpleHeatDisplay({
 // Pilot Status
 // =============================================================================
 
+export interface PilotStatusProps {
+  name: string;
+  gunnery: number;
+  piloting: number;
+  wounds: number;
+  conscious: boolean;
+  /**
+   * Per `add-damage-feedback-ui` task 1.1 + 5.1 + 5.2: monotonic
+   * counter of `PilotHit` events consumed by the parent
+   * `RecordSheetDisplay`. Each increment re-triggers the yellow
+   * consciousness-roll pulse on the wound track for 500ms so the
+   * player sees the roll happen even if it passes. The parent owns
+   * the source-of-truth `conscious` flag (reactive to `IUnitGameState`
+   * per spec scenario "passed roll leaves no badge") so this counter
+   * only drives the transient pulse animation — never the persistent
+   * unconscious banner.
+   */
+  pilotHitCount?: number;
+}
+
 export function PilotStatus({
   name,
   gunnery,
   piloting,
   wounds,
   conscious,
-}: {
-  name: string;
-  gunnery: number;
-  piloting: number;
-  wounds: number;
-  conscious: boolean;
-}): React.ReactElement {
+  pilotHitCount = 0,
+}: PilotStatusProps): React.ReactElement {
+  // Per task 5.2: pulse the wound track yellow for 500ms whenever a
+  // new PilotHit lands. We dedupe against the previous count so
+  // re-renders with the same count don't retrigger the pulse.
+  const lastSeenCount = useRef(pilotHitCount);
+  const [isPulsing, setIsPulsing] = useState(false);
+  useEffect(() => {
+    if (pilotHitCount > lastSeenCount.current) {
+      lastSeenCount.current = pilotHitCount;
+      setIsPulsing(true);
+      const t = setTimeout(() => setIsPulsing(false), 500);
+      return () => clearTimeout(t);
+    }
+    lastSeenCount.current = pilotHitCount;
+  }, [pilotHitCount]);
+
   const woundIndicators = [];
   for (let i = 0; i < 6; i++) {
     woundIndicators.push(
@@ -352,7 +412,22 @@ export function PilotStatus({
           Piloting: <strong>{piloting}</strong>
         </span>
       </div>
-      <div className="mt-2 flex items-center gap-1" data-testid="pilot-wounds">
+      {/*
+        Per `add-damage-feedback-ui` task 5.2: the wound track frame
+        pulses yellow for 500ms on a new PilotHit, then fades. The
+        ring is a pure overlay on top of the wound pips — it does
+        not affect the pips themselves so the per-pip tests keep
+        working.
+      */}
+      <div
+        className={`relative mt-2 flex items-center gap-1 rounded transition-shadow duration-500 ${
+          isPulsing
+            ? 'bg-yellow-100 shadow-[0_0_0_2px_rgba(250,204,21,0.7)]'
+            : ''
+        }`}
+        data-testid="pilot-wounds"
+        data-pulsing={isPulsing || undefined}
+      >
         <span className="text-text-theme-secondary mr-2 text-xs">Wounds:</span>
         {woundIndicators}
       </div>


### PR DESCRIPTION
## Summary

Completes the final 5 of 41 tasks in OpenSpec change `add-damage-feedback-ui`, taking it from 36/41 to 41/41.

- **1.1** RecordSheetDisplay subscribes to `DamageApplied` / `CriticalHit` / `PilotHit` events for the selected unit via a pure `useMemo` projection. The memo re-runs on `unitId` change, giving automatic subscription tear-down (satisfying 1.3) without manual cleanup.
- **2.4** `LocationStatusRow` threads a per-location `damageHitCount` into the `ArmorPipRail`. Armor rail flashes first (0ms delay, 400ms flash); structure rail flashes at 400ms. Total animation ≤ 800ms, inside the 900ms spec budget.
- **4.3** `EventLogDisplay` now annotates chronologically-ordered `DamageApplied` events sharing an `attackId` and nests `CriticalHit`/`PilotHit` under their parent hit with indented `→ overflow to <Loc>` / `→ structure breach` prefixes.
- **5.1** `PilotStatus` pulses yellow for 500ms when `pilotHitCount` increments, reading the hit stream from `RecordSheetDisplay`'s projection. The persistent unconscious banner is still driven by `IUnitGameState.pilotConscious`, so passed rolls (pulse but no badge) and badge-without-visible-roll (5.4) both reconcile correctly.
- **7.2** The same `annotateGroupedEvents` pass groups cluster damage rolls under the attack's first entry so multi-hit weapons render as a parent + indented children.

## Verification

- `npx tsc --noEmit` — clean, exit 0
- `npx jest --testPathPattern "gameplay"` — 3692 passed, 12 skipped (pre-existing), 0 failed across 141 suites
- `npx oxfmt --write` applied to all 5 touched source files

## Scope Boundaries

- Delta specs in `openspec/changes/add-damage-feedback-ui/specs/` are NOT merged into `openspec/specs/` — that happens in a subsequent close-out step when the user says "archive it".
- No changes to engine/session payload shapes; all work is UI-layer projection over existing event fields (`IDamageAppliedPayload.attackId`, `IPilotHitPayload.consciousnessCheckPassed`, etc.).

## Test plan

- [ ] Observe armor rail red flash, then structure rail red flash, on a `DamageApplied` event landing on a selected unit's location (≤ 900ms total).
- [ ] Observe yellow pulse on the wound track when a `PilotHit` event fires for the selected unit.
- [ ] Confirm multi-hit cluster damage (e.g., LB-10X cluster) renders as one parent + indented children in the event log.
- [ ] Confirm unselected units do not animate when damaged (spec scenario "Unselected unit's damage does not animate").