### PR TITLE
feat(ui): close out what-if to-hit preview

### DIFF
--- a/openspec/changes/add-what-if-to-hit-preview/tasks.md
+++ b/openspec/changes/add-what-if-to-hit-preview/tasks.md
@@ -130,12 +130,17 @@ P(crit on 2d6 location roll)` for through-armor crits
       `inRange === false`
 - [x] 11.4 Integration test: Toggling Preview Damage does not append
       events
-- [ ] 11.5 Integration test: Preview stays accurate when the player
-      switches targets mid-phase (deferred — the memoization keys
-      include the `target` reference so the recompute is structurally
-      guaranteed; full E2E coverage will land with the Phase 2
-      capstone test that walks the gameplay page through a real
-      target switch)
+- [x] 11.5 Integration test: Preview stays accurate when the player
+      switches targets mid-phase (covered in
+      `addWhatIfToHitPreview.smoke.test.tsx` under the "Preview
+      recomputes on target switch (§ 11.5)" suite — two cases: swap
+      `target` reference with a new movement profile, and swap
+      `rangeToTarget` against a locked target. Both verify the
+      Exp. Dmg / stddev / crit values actually change between renders
+      AND that `onToggle` / `onTogglePreview` stay untouched, wiring
+      the target-switch path to both the recompute guarantee from
+      weapon-resolution-system/spec.md "Memo miss when target changes"
+      and the zero-commit guarantee from § 9)
 
 ## 12. Spec Compliance
 

--- a/src/components/gameplay/__tests__/addWhatIfToHitPreview.smoke.test.tsx
+++ b/src/components/gameplay/__tests__/addWhatIfToHitPreview.smoke.test.tsx
@@ -299,7 +299,155 @@ describe('Zero-commit guarantee (add-what-if-to-hit-preview § 9)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 3. ToHitForecastModal — preview sub-rows (§ 8 / § 10)
+// 3. Target switch recompute (§ 11.5 / spec scenario "Memo miss when target
+// changes")
+// ---------------------------------------------------------------------------
+
+describe('Preview recomputes on target switch (§ 11.5)', () => {
+  it('updates Exp. Dmg / stddev / crit when the parent swaps target mid-phase', () => {
+    // Spec scenario: "Memo miss when target changes" —
+    // weapon-resolution-system/spec.md. A new `target` reference
+    // passed into the memoization key MUST force
+    // `previewAttackOutcome` to re-run and produce different output.
+    //
+    // We make the two targets meaningfully different (stationary vs.
+    // fast-mover with 5 hexes of movement) so the to-hit modifier
+    // pipeline produces different `finalTn` values — which guarantees
+    // the downstream Exp. Dmg / stddev / crit all change. If the
+    // memoization were broken (e.g., the component cached by weapon
+    // id alone), the second render would reuse the first target's
+    // numbers and this test would fail.
+    const onToggle = jest.fn();
+    const onTogglePreview = jest.fn();
+
+    const fastMover: ITargetState = {
+      movementType: MovementType.Run,
+      hexesMoved: 5, // +2 movement modifier under standard TM
+      prone: false,
+      immobile: false,
+      partialCover: false,
+    };
+
+    const { rerender } = render(
+      <WeaponSelector
+        weapons={[mediumLaser]}
+        rangeToTarget={3}
+        selectedWeaponIds={['med-laser-1']}
+        ammo={{}}
+        onToggle={onToggle}
+        attacker={baseAttacker}
+        target={baseTarget}
+        previewEnabled={true}
+        onTogglePreview={onTogglePreview}
+      />,
+    );
+
+    const initialExpDmg = screen.getByTestId(
+      'weapon-preview-expdmg-med-laser-1',
+    ).textContent;
+    const initialStddev = screen.getByTestId(
+      'weapon-preview-stddev-med-laser-1',
+    ).textContent;
+    const initialCrit = screen.getByTestId(
+      'weapon-preview-crit-med-laser-1',
+    ).textContent;
+    // Sanity: the baseline target should produce real numbers, not
+    // "—". Otherwise the post-switch comparison below is vacuous.
+    expect(initialExpDmg).toMatch(/^\d+\.\d$/);
+    expect(initialStddev).toMatch(/^±\d+\.\d$/);
+    expect(initialCrit).toMatch(/^\d+\.\d%$/);
+
+    // Simulate the Player switching to a new target lock. The parent
+    // (TargetLockHUD → useGameplayStore) replaces the `target` prop
+    // with a new object identity; nothing else changes — same
+    // weapons, same selection, same preview toggle.
+    rerender(
+      <WeaponSelector
+        weapons={[mediumLaser]}
+        rangeToTarget={3}
+        selectedWeaponIds={['med-laser-1']}
+        ammo={{}}
+        onToggle={onToggle}
+        attacker={baseAttacker}
+        target={fastMover}
+        previewEnabled={true}
+        onTogglePreview={onTogglePreview}
+      />,
+    );
+
+    const switchedExpDmg = screen.getByTestId(
+      'weapon-preview-expdmg-med-laser-1',
+    ).textContent;
+    const switchedStddev = screen.getByTestId(
+      'weapon-preview-stddev-med-laser-1',
+    ).textContent;
+    const switchedCrit = screen.getByTestId(
+      'weapon-preview-crit-med-laser-1',
+    ).textContent;
+
+    // All three preview stats MUST differ — the fast-mover is harder
+    // to hit, so expected damage and crit probability both drop.
+    // Stddev follows the Bernoulli shape so it also changes.
+    expect(switchedExpDmg).not.toBe(initialExpDmg);
+    expect(switchedCrit).not.toBe(initialCrit);
+    expect(switchedStddev).not.toBe(initialStddev);
+    // Zero-commit guarantee (§ 9) also holds across target switches:
+    // the recompute MUST NOT mutate the attack plan.
+    expect(onToggle).not.toHaveBeenCalled();
+    expect(onTogglePreview).not.toHaveBeenCalled();
+  });
+
+  it('updates preview when the parent swaps rangeToTarget (same target object)', () => {
+    // Companion to the target-switch case: the memoization key
+    // includes `rangeToTarget`, so changing only the range (e.g.,
+    // the attacker moved closer on the same turn) must also force a
+    // recompute. Guarantees no stale-range bug when the target stays
+    // locked but distance changes.
+    const onToggle = jest.fn();
+
+    const { rerender } = render(
+      <WeaponSelector
+        weapons={[mediumLaser]}
+        rangeToTarget={3}
+        selectedWeaponIds={['med-laser-1']}
+        ammo={{}}
+        onToggle={onToggle}
+        attacker={baseAttacker}
+        target={baseTarget}
+        previewEnabled={true}
+        onTogglePreview={jest.fn()}
+      />,
+    );
+    const shortRangeExpDmg = screen.getByTestId(
+      'weapon-preview-expdmg-med-laser-1',
+    ).textContent;
+
+    // Same target reference, new range → still should recompute.
+    rerender(
+      <WeaponSelector
+        weapons={[mediumLaser]}
+        rangeToTarget={8} // long bracket for Medium Laser (short=3, med=6, long=9)
+        selectedWeaponIds={['med-laser-1']}
+        ammo={{}}
+        onToggle={onToggle}
+        attacker={baseAttacker}
+        target={baseTarget}
+        previewEnabled={true}
+        onTogglePreview={jest.fn()}
+      />,
+    );
+    const longRangeExpDmg = screen.getByTestId(
+      'weapon-preview-expdmg-med-laser-1',
+    ).textContent;
+
+    // Long bracket is harder to hit → expected damage must drop.
+    expect(longRangeExpDmg).not.toBe(shortRangeExpDmg);
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. ToHitForecastModal — preview sub-rows (§ 8 / § 10)
 // ---------------------------------------------------------------------------
 
 describe('ToHitForecastModal preview sub-rows', () => {


### PR DESCRIPTION
## Summary

Closes out the final remaining task (11.5) of the `add-what-if-to-hit-preview` OpenSpec change — the change is now 45/45 complete.

- Adds an integration test that mounts `WeaponSelector` with preview ON, swaps the `target` prop for a fast-mover, and asserts the Exp. Dmg / stddev / crit % values all change — proving the memo key's target recompute path actually runs.
- Adds a companion test that keeps the target reference stable and only varies `rangeToTarget`, covering the "same target, closer distance" case the memoization key also depends on.
- Both tests re-assert the § 9 zero-commit guarantee across the re-render (no `onToggle` / `onTogglePreview` calls).
- Updates `tasks.md` to mark 11.5 complete and replace the deferral note with a pointer to the two new cases.

## Spec anchors

- `weapon-resolution-system/spec.md` — scenario "Memo miss when target changes"
- `add-what-if-to-hit-preview/tasks.md` § 11.5

## Test plan

- [x] `npx jest src/components/gameplay/__tests__/addWhatIfToHitPreview.smoke.test.tsx` — 13/13 passing, including the two new § 11.5 cases
- [x] `npx jest src/components/gameplay/__tests__/ src/utils/gameplay/toHit/ src/utils/gameplay/damage/` — 348/348 passing (22 suites)
- [x] `npx tsc --noEmit --skipLibCheck` — clean
- [x] `npx oxfmt --check .` — clean
- [x] `openspec validate add-what-if-to-hit-preview --strict` — valid