### PR TITLE
feat(ui): add mech silhouette sprite set

### DIFF
--- a/openspec/.sessions/add-mech-silhouette-sprite-set.json
+++ b/openspec/.sessions/add-mech-silhouette-sprite-set.json
@@ -1,0 +1,26 @@
+{
+  "active_change": "add-mech-silhouette-sprite-set",
+  "status": "completed",
+  "started_at": "2026-04-22T00:00:00Z",
+  "completed_at": "2026-04-23T00:00:00Z",
+  "completed_tasks": [
+    "1.1", "1.2", "1.3", "1.4",
+    "2.1", "2.2", "2.3", "2.4", "2.5",
+    "3.1", "3.2", "3.3", "3.4", "3.5", "3.6",
+    "4.1", "4.2", "4.3", "4.4",
+    "5.1", "5.2", "5.3", "5.4", "5.5",
+    "6.1", "6.2", "6.3", "6.4",
+    "7.1", "7.2", "7.3", "7.4",
+    "8.1", "8.2", "8.3",
+    "9.1", "9.2", "9.3", "9.4", "9.5",
+    "10.1", "10.2", "10.3"
+  ],
+  "in_progress_tasks": [],
+  "verification": {
+    "typecheck": "pass",
+    "format": "pass",
+    "jest_full_suite": "21639 passed, 44 skipped",
+    "spec_coverage": "all SHALL/MUST covered by passing tests"
+  },
+  "notes": "Deltas merged into openspec/specs/unit-sprite-system (new) and openspec/specs/tactical-map-interface (appended). Change folder retained pending user 'archive it' command."
+}

--- a/openspec/changes/add-mech-silhouette-sprite-set/notepad/decisions.md
+++ b/openspec/changes/add-mech-silhouette-sprite-set/notepad/decisions.md
@@ -1,0 +1,86 @@
+# Decisions — add-mech-silhouette-sprite-set
+
+## Decision: Inline SVG sprites, not `<image href>` assets
+
+**Choice**: Ship the 12 silhouettes as a TypeScript module exporting inline
+JSX/SVG strings, not as separate `.svg` files referenced via `<image href>`.
+
+**Rationale**:
+- Tests run in jsdom which does not load external resources — `<image href>`
+  wouldn't render in snapshots.
+- Inline SVG lets us apply `currentColor` + CSS filter tints and swap stroke
+  widths via props.
+- Bundle impact is negligible — 12 silhouettes under 200 LOC each → ~2 KB
+  gzipped total. Avoids a network round-trip per token.
+- Hot-reloadable: changing a sprite rebuilds the component, no asset cache
+  invalidation.
+
+**Spec-compliance**: The spec says sprites live "under `public/sprites/mechs/`"
+(Scenario "Sprite exists for every weight x archetype combination"). We will
+ALSO write the same SVGs to `public/sprites/mechs/<archetype>-<weight>.svg`
+so the file-based contract is satisfied, but the runtime renderer reads the
+inline TS module. `spriteSelector` exposes both URL and inline content —
+callers choose. This keeps the spec scenario satisfied while keeping tests
+deterministic.
+
+**Discovered during**: Task 2.1 scoping.
+
+## Decision: Sprite selector takes IUnitToken, not a raw unit record
+
+**Choice**: `selectSprite(token: Pick<IUnitToken, 'weightClass' |
+'chassisArchetype'>)` — operates on token-surface fields, not on the full
+construction-domain unit record.
+
+**Rationale**:
+- Token-rendering components already receive `IUnitToken`. Passing the same
+  type keeps the surface small and avoids pulling the construction/unit
+  domain into the render layer.
+- `IUnitToken` gains two new OPTIONAL fields: `weightClass?: WeightClass`
+  and `chassisArchetype?: ChassisArchetype`. Callers (interactive session →
+  token projection) populate them when known; selector defaults to
+  `MEDIUM × humanoid` when absent (Scenario: Missing archetype falls back
+  to humanoid).
+
+**Discovered during**: Task 2.1 design.
+
+## Decision: Archetype enum uses `humanoid | quad | lam`
+
+**Choice**: New enum `ChassisArchetype = 'humanoid' | 'quad' | 'lam'` in
+`src/types/gameplay/GameplayUIInterfaces.ts`.
+
+**Rationale**: Spec lists exactly three archetypes. Discriminated-union-
+friendly string literals, easy to switch on, serializes cleanly.
+
+**Discovered during**: Task 1.1 scoping.
+
+## Decision: Armor pip aggregation — one pip per location, intensity by state
+
+**Choice**: Each of the 8 biped (or 6 quad) locations renders as ONE pip
+dot — not 3–4 sub-pips per location. State maps to fill/outline:
+- `full`     → solid green fill
+- `partial`  → solid yellow fill
+- `structure`→ solid orange fill + diagonal stripes (pattern for colorblind)
+- `destroyed`→ red outline only, no fill
+- `missing`  → no pip rendered (location not applicable to archetype)
+
+**Rationale**:
+- Legibility at 80% hex diameter is the overriding constraint.
+- Colorblind scenario requires shape distinction — stripes on the
+  `structure` state satisfy this without adding a separate icon.
+- Aggregate-dot-per-location satisfies the "simplified pip aggregation"
+  clause of the spec at low zoom.
+
+**Discovered during**: Task 5.3 design.
+
+## Decision: Low-zoom collapse uses a single glyph SVG per archetype
+
+**Choice**: Below zoom 0.6, render a tiny archetype glyph (humanoid ▲ / quad
+■ / LAM ◆) with side tint only, no pip ring. Below zoom 0.35, no glyph
+either — just a colored dot. Parent (HexMapDisplay) passes `zoom` down; if
+absent, MechSprite defaults to 1.0 (full detail).
+
+**Rationale**: Spec requires graceful simplification at low zoom. A single
+glyph keeps the scale-invariant silhouette readable without stroke-width
+juggling.
+
+**Discovered during**: Task 7 design.

--- a/openspec/changes/add-mech-silhouette-sprite-set/notepad/issues.md
+++ b/openspec/changes/add-mech-silhouette-sprite-set/notepad/issues.md
@@ -1,0 +1,3 @@
+# Issues — add-mech-silhouette-sprite-set
+
+(populated as implementation surfaces gotchas)

--- a/openspec/changes/add-mech-silhouette-sprite-set/notepad/learnings.md
+++ b/openspec/changes/add-mech-silhouette-sprite-set/notepad/learnings.md
@@ -1,0 +1,64 @@
+# Learnings — add-mech-silhouette-sprite-set
+
+## Repo conventions
+
+- Testing is **Jest**, not vitest. Test suites live under `__tests__/` beside the file.
+- Test helper: wrap SVG children in `<svg>` — jsdom requires SVG root. See
+  `src/components/gameplay/UnitToken/__tests__/UnitTokenForType.test.tsx` for
+  the `renderInSvg(ui)` helper pattern.
+- Lint is **oxlint**; formatter is **oxfmt**. Scripts:
+  `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run test`.
+- Husky pre-commit is broken on Windows — use `git commit --no-verify`.
+
+## Token rendering architecture
+
+- Token dispatcher: `src/components/gameplay/UnitToken/UnitTokenForType.tsx`
+  routes by `token.unitType` to per-type renderers. Dispatcher also projects
+  events via `projectEvents()` once and passes `eventState` down.
+- Per-type renderers are **children of a `<g>`** — the dispatcher provides
+  the outer `<g transform="translate(x,y)" onClick=…>` wrapper, and each
+  renderer returns token-local SVG children only (no outer group).
+- `MechToken` currently paints: selection/target ring, optional active-target
+  pulse (SVG `<animate>`), circular body fill, facing arrow path, designation
+  label, destroyed cross, pilot/crit/damage overlays.
+- Legacy `UnitToken.tsx` is marked TODO-deprecated and kept only for a smoke
+  test. Do NOT touch — the real swap target is `MechToken.tsx`.
+
+## Accessibility
+
+- `useAccessibilityStore` (zustand + persist) exposes `reduceMotion: boolean`
+  and `highContrast: boolean`. Read via `useAccessibilityStore((s) => s.reduceMotion)`.
+- No `prefers-reduced-motion` CSS media query is used today — the store flag
+  is the single source of truth.
+
+## IUnitToken shape
+
+- Already extended with optional per-type fields (vehicle, aerospace, BA,
+  infantry, proto). Adding new **optional** fields for sprite-system (weight
+  class, chassis archetype, per-location armor state) is safe and does not
+  break Phase-1 callers.
+- Backwards-compat rule for this surface: new fields MUST be optional, and
+  callers that don't set them MUST still get a sensible silhouette (default
+  → humanoid-medium).
+
+## Constants + math
+
+- `HEX_SIZE = 40` (center to vertex). Sprites should occupy ~80% of the hex
+  diameter at zoom 1.0 → radius ~32 → fits inside 64×64 — use a 200×200
+  viewBox internally for crisp scaling.
+- `getFacingRotation(facing)` returns 0/60/120/180/240/300 degrees.
+- The facing arrow in MechToken was drawn with a `rotate(rotation - 90)`
+  offset because the path points "up" (−y). Our sprite convention: the SVG
+  is drawn facing "north" by default, and we apply `rotate(facing * 60)`
+  about the center — no additional −90 needed.
+
+## Weight class enum
+
+`src/types/enums/WeightClass.ts` has `ULTRALIGHT / LIGHT / MEDIUM / HEAVY /
+ASSAULT / SUPERHEAVY`. Sprite catalog buckets ULTRALIGHT with LIGHT, and
+SUPERHEAVY with ASSAULT (only 4 buckets per spec).
+
+## Snapshot tests
+
+Jest snapshot tests exist in `src/components/gameplay/__tests__/__snapshots__/`.
+For sprite visual regression, use Jest snapshot on the rendered SVG output.

--- a/openspec/changes/add-mech-silhouette-sprite-set/notepad/problems.md
+++ b/openspec/changes/add-mech-silhouette-sprite-set/notepad/problems.md
@@ -1,0 +1,3 @@
+# Problems — add-mech-silhouette-sprite-set
+
+(unresolved blockers only — empty unless escalated)

--- a/openspec/changes/add-mech-silhouette-sprite-set/tasks.md
+++ b/openspec/changes/add-mech-silhouette-sprite-set/tasks.md
@@ -2,96 +2,96 @@
 
 ## 1. Sprite Catalog Design
 
-- [ ] 1.1 Commission / draw 12 homemade silhouettes: 4 weight classes ×
+- [x] 1.1 Commission / draw 12 homemade silhouettes: 4 weight classes ×
       3 archetypes (humanoid biped, quad, LAM)
-- [ ] 1.2 Confirm no asset resembles licensed BattleTech/MechWarrior art
+- [x] 1.2 Confirm no asset resembles licensed BattleTech/MechWarrior art
       (visual originality review)
-- [ ] 1.3 Export each as an SVG at a canonical 200×200 viewBox with
+- [x] 1.3 Export each as an SVG at a canonical 200×200 viewBox with
       transparent background
-- [ ] 1.4 Place files under `public/sprites/mechs/<archetype>-<weight>.svg`
+- [x] 1.4 Place files under `public/sprites/mechs/<archetype>-<weight>.svg`
 
 ## 2. Sprite Selector Utility
 
-- [ ] 2.1 Create `src/utils/sprites/spriteSelector.ts` exporting
+- [x] 2.1 Create `src/utils/sprites/spriteSelector.ts` exporting
       `selectSprite(unit)`
-- [ ] 2.2 Map unit `weightClass` → `light | medium | heavy | assault`
-- [ ] 2.3 Derive archetype from unit data: `isQuad`, `isLAM`, else humanoid
-- [ ] 2.4 Return the resolved sprite URL + metadata (viewBox, anchor)
-- [ ] 2.5 Unit tests for every weight-class × archetype combination
+- [x] 2.2 Map unit `weightClass` → `light | medium | heavy | assault`
+- [x] 2.3 Derive archetype from unit data: `isQuad`, `isLAM`, else humanoid
+- [x] 2.4 Return the resolved sprite URL + metadata (viewBox, anchor)
+- [x] 2.5 Unit tests for every weight-class × archetype combination
 
 ## 3. MechSprite Component
 
-- [ ] 3.1 Create `src/components/gameplay/sprites/MechSprite.tsx`
-- [ ] 3.2 Props: `unit`, `facing`, `scale`, `sideColor`, `isSelected`
-- [ ] 3.3 Load the silhouette via `<image>` or inline SVG symbol
-- [ ] 3.4 Apply side tint (Player=blue, Opponent=red, Neutral=gray) via
+- [x] 3.1 Create `src/components/gameplay/sprites/MechSprite.tsx`
+- [x] 3.2 Props: `unit`, `facing`, `scale`, `sideColor`, `isSelected`
+- [x] 3.3 Load the silhouette via `<image>` or inline SVG symbol
+- [x] 3.4 Apply side tint (Player=blue, Opponent=red, Neutral=gray) via
       CSS filter or `<feColorMatrix>`
-- [ ] 3.5 Apply `transform: rotate(facing * 60deg)` about the sprite center
-- [ ] 3.6 Render selection ring when `isSelected` is true
+- [x] 3.5 Apply `transform: rotate(facing * 60deg)` about the sprite center
+- [x] 3.6 Render selection ring when `isSelected` is true
 
 ## 4. Facing Indicator
 
-- [ ] 4.1 Each silhouette SVG includes a directional notch element
+- [x] 4.1 Each silhouette SVG includes a directional notch element
       identified by `id="facing-notch"`
-- [ ] 4.2 Notch orients along the sprite's "front" in its base SVG
-- [ ] 4.3 Sprite rotation carries the notch with it (no separate overlay)
-- [ ] 4.4 Facing changes animate over 150ms ease-out
+- [x] 4.2 Notch orients along the sprite's "front" in its base SVG
+- [x] 4.3 Sprite rotation carries the notch with it (no separate overlay)
+- [x] 4.4 Facing changes animate over 150ms ease-out
 
 ## 5. Armor Pip Overlay Ring
 
-- [ ] 5.1 Create `src/components/gameplay/sprites/ArmorPipRing.tsx`
-- [ ] 5.2 Render 8 pip groups around the sprite: Head, CT, LT, RT, LA,
+- [x] 5.1 Create `src/components/gameplay/sprites/ArmorPipRing.tsx`
+- [x] 5.2 Render 8 pip groups around the sprite: Head, CT, LT, RT, LA,
       RA, LL, RL (mechs) or Head, CT, FL, FR, RL, RR (quads)
-- [ ] 5.3 Each pip group colors by location state: full armor=green,
+- [x] 5.3 Each pip group colors by location state: full armor=green,
       partial=yellow, structure exposed=orange, destroyed=red-outline
-- [ ] 5.4 Pip layout respects archetype (quads show legs in a cross,
+- [x] 5.4 Pip layout respects archetype (quads show legs in a cross,
       LAMs show compact)
-- [ ] 5.5 Rings maintain legibility at 50% hex scale via simplified pip
+- [x] 5.5 Rings maintain legibility at 50% hex scale via simplified pip
       aggregation (single dot per location when <50%)
 
 ## 6. Swap UnitToken Renderer
 
-- [ ] 6.1 Replace abstract marker in `UnitToken.tsx` with `MechSprite` + `ArmorPipRing`
-- [ ] 6.2 Preserve existing hit-testing (the outer `<g>` remains the
+- [x] 6.1 Replace abstract marker in `UnitToken.tsx` with `MechSprite` + `ArmorPipRing`
+- [x] 6.2 Preserve existing hit-testing (the outer `<g>` remains the
       click target)
-- [ ] 6.3 Preserve selection binding contract with `useGameplayStore`
-- [ ] 6.4 Preserve the side-color tint currently applied to the marker
+- [x] 6.3 Preserve selection binding contract with `useGameplayStore`
+- [x] 6.4 Preserve the side-color tint currently applied to the marker
 
 ## 7. Zoom + Scale Behavior
 
-- [ ] 7.1 At zoom >= 1.0, sprites render at 80% of hex size
-- [ ] 7.2 At zoom < 0.6, sprites collapse to archetype glyph + class tint
+- [x] 7.1 At zoom >= 1.0, sprites render at 80% of hex size
+- [x] 7.2 At zoom < 0.6, sprites collapse to archetype glyph + class tint
       only, pip ring hidden
-- [ ] 7.3 Pip ring never obscures neighboring hex content
-- [ ] 7.4 Text labels (unit name, call sign) scale with zoom but never
+- [x] 7.3 Pip ring never obscures neighboring hex content
+- [x] 7.4 Text labels (unit name, call sign) scale with zoom but never
       below 10px
 
 ## 8. Accessibility + Colorblind
 
-- [ ] 8.1 Side tint uses shape-distinguishable overlays (not color-only)
-- [ ] 8.2 Armor pip states use both color and pattern (solid / striped /
+- [x] 8.1 Side tint uses shape-distinguishable overlays (not color-only)
+- [x] 8.2 Armor pip states use both color and pattern (solid / striped /
       empty)
-- [ ] 8.3 Sprites respect the existing `prefers-reduced-motion` setting
+- [x] 8.3 Sprites respect the existing `prefers-reduced-motion` setting
       for facing animation
 
 ## 9. Tests
 
-- [ ] 9.1 Unit test: `selectSprite` returns correct bundle for each
+- [x] 9.1 Unit test: `selectSprite` returns correct bundle for each
       weight-class × archetype combination
-- [ ] 9.2 Unit test: `MechSprite` applies rotation matching
+- [x] 9.2 Unit test: `MechSprite` applies rotation matching
       `facing * 60deg`
-- [ ] 9.3 Unit test: `ArmorPipRing` renders red-outline pip when a
+- [x] 9.3 Unit test: `ArmorPipRing` renders red-outline pip when a
       location's structure is 0
-- [ ] 9.4 Visual regression snapshot for each of the 12 sprites at
+- [x] 9.4 Visual regression snapshot for each of the 12 sprites at
       default scale
-- [ ] 9.5 Integration test: selecting a quad unit renders quad layout
+- [x] 9.5 Integration test: selecting a quad unit renders quad layout
       pips
 
 ## 10. Spec Compliance
 
-- [ ] 10.1 Every requirement in `unit-sprite-system` spec has at least one
+- [x] 10.1 Every requirement in `unit-sprite-system` spec has at least one
       GIVEN/WHEN/THEN scenario
-- [ ] 10.2 Every requirement in `tactical-map-interface` delta has at
+- [x] 10.2 Every requirement in `tactical-map-interface` delta has at
       least one scenario
-- [ ] 10.3 `openspec validate add-mech-silhouette-sprite-set --strict`
+- [x] 10.3 `openspec validate add-mech-silhouette-sprite-set --strict`
       passes clean

--- a/openspec/specs/tactical-map-interface/spec.md
+++ b/openspec/specs/tactical-map-interface/spec.md
@@ -1048,6 +1048,33 @@ what the colors mean.
 - **THEN** the Jump row SHALL be rendered at 40% opacity
 - **AND** hovering Jump SHALL show a tooltip `"No jump capability"`
 
+---
+
+### Requirement: Unit Token Rendering Uses Sprite System
+
+The tactical map interface SHALL render unit tokens via the sprite system, replacing the abstract marker used in the Phase 1 MVP.
+
+#### Scenario: Token uses MechSprite component
+
+- **GIVEN** a unit is placed on the hex map
+- **WHEN** the token renders
+- **THEN** a `MechSprite` component SHALL render the silhouette
+- **AND** an `ArmorPipRing` SHALL render the damage overlay
+- **AND** the outer `<g>` element SHALL remain the click target for selection hit-testing
+
+#### Scenario: Selection binding preserved
+
+- **GIVEN** a user clicks a token
+- **WHEN** the click fires
+- **THEN** `useGameplayStore.setSelectedUnitId` SHALL be called with the clicked unit's ID exactly as before the sprite swap
+
+#### Scenario: Side color preserved
+
+- **GIVEN** the Phase 1 MVP applied a side-color tint
+- **WHEN** the sprite renders
+- **THEN** the same side color SHALL drive the sprite's tint
+- **AND** existing accessibility overlays SHALL continue to apply
+
 ## Data Model Requirements
 
 ### Required Interfaces
@@ -1556,3 +1583,9 @@ const props: IHexMapDisplayProps = {
 - Initial specification based on existing HexMapDisplay implementation
 - Covers SVG rendering, pan/zoom, terrain visualization, overlays, unit tokens
 - Defines interaction patterns and visual feedback requirements
+
+### Version 1.1 (2026-04-23)
+
+- Added `Requirement: Unit Token Rendering Uses Sprite System` via change `add-mech-silhouette-sprite-set`
+- Unit tokens now render through `MechSprite` + `ArmorPipRing` instead of the flat disc marker
+- Selection binding and side tint contracts preserved from Phase 1 MVP

--- a/openspec/specs/unit-sprite-system/spec.md
+++ b/openspec/specs/unit-sprite-system/spec.md
@@ -1,0 +1,194 @@
+# Unit Sprite System Specification
+
+**Status**: Draft
+**Version**: 1.0
+**Last Updated**: 2026-04-23
+**Dependencies**: [tactical-map-interface, unit-entity-model, accessibility-system]
+**Affects**: [tactical-map-interface]
+
+---
+
+## Overview
+
+### Purpose
+
+Defines the homemade 2D silhouette sprite system used by the tactical map to render BattleMech unit tokens. The sprite system replaces the Phase-1 MVP abstract coloured-disc marker with per-weight-class × archetype silhouettes that carry a built-in facing indicator, an armor-pip damage overlay, and zoom-aware simplifications.
+
+### Scope
+
+**In Scope:**
+
+- Inline SVG silhouette catalog keyed by weight class × chassis archetype (humanoid biped, quad, LAM)
+- Built-in facing indicator (notch / head cue) baked into each SVG so rotation carries it
+- Side tint (Player blue, Opponent red, Neutral gray) applied via CSS `currentColor` / `color`
+- Selection ring rendered when the unit is the selected unit
+- Armor-pip overlay ring with per-location state (full / partial / structure / destroyed / missing)
+- Zoom-aware level-of-detail: full silhouette ≥ 0.6×, archetype glyph < 0.6×, pip ring hidden < 0.35×
+- Colorblind-safe shape overlay (triangle / square / circle) layered on top of the tint
+- Homemade-only asset constraint: no licensed BattleTech or MechWarrior art references
+
+**Out of Scope:**
+
+- Vehicle, infantry, battle armor, protomech, and aerospace sprites (handled by their own unit-system specs)
+- Terrain rendering (see terrain-system spec)
+- Token click / selection binding (see tactical-map-interface spec — this spec only specifies the renderer)
+- Animation of facing changes beyond the 150ms ease-out transition contract
+
+### Key Concepts
+
+- **Archetype**: Chassis layout — humanoid biped, quad, or LAM. Drives sprite id and pip-ring layout.
+- **Weight class**: Light / Medium / Heavy / Assault — drives silhouette size and bulk within the chosen archetype.
+- **Facing**: One of six hex directions (North, NE, SE, South, SW, NW), each a multiple of 60°.
+- **Side tint**: Colour used to distinguish Player vs Opponent vs Neutral; applied via `currentColor` so inline SVGs inherit.
+- **Pip location state**: `full | partial | structure | destroyed | missing` — drives pip fill / outline / pattern.
+- **Low-zoom glyph**: An abstract archetype-specific shape rendered in place of the silhouette below the zoom threshold.
+
+---
+
+## Requirements
+
+### Requirement: Homemade Silhouette Sprite Catalog
+
+The unit sprite system SHALL provide a homemade (not licensed) 2D silhouette for every combination of weight class and chassis archetype, and SHALL never reference licensed BattleTech or MechWarrior visual assets.
+
+#### Scenario: Sprite exists for every weight x archetype combination
+
+- **GIVEN** a unit with weight class `light | medium | heavy | assault`
+- **WHEN** the sprite selector resolves the sprite
+- **THEN** exactly one SVG sprite SHALL be returned per combination
+- **AND** the sprite file SHALL live under `public/sprites/mechs/`
+- **AND** the sprite SHALL be homemade (no licensed art reference)
+
+#### Scenario: Archetype override for quads and LAMs
+
+- **GIVEN** a unit with `isQuad = true`
+- **WHEN** the sprite selector resolves the sprite
+- **THEN** the quad archetype sprite SHALL be returned
+- **AND** biped sprites SHALL NOT be returned for quad units
+
+#### Scenario: Missing archetype falls back to humanoid
+
+- **GIVEN** a unit with no archetype flags set
+- **WHEN** the sprite selector resolves the sprite
+- **THEN** the humanoid biped sprite for the unit's weight class SHALL be returned
+
+---
+
+### Requirement: Built-in Facing Indicator
+
+Every sprite SHALL include a facing indicator (directional notch or head-rotation cue) baked into the SVG so that rotation carries the indicator with it.
+
+#### Scenario: Facing rotates sprite and indicator together
+
+- **GIVEN** a unit facing direction 2 (120 degrees)
+- **WHEN** the sprite renders
+- **THEN** the sprite SHALL be rotated by `facing * 60deg` about its center
+- **AND** the facing notch SHALL point in the same direction as the rotated sprite's front
+
+#### Scenario: Facing change animates
+
+- **GIVEN** a unit rotates from facing 0 to facing 3
+- **WHEN** the new facing is committed
+- **THEN** the sprite SHALL animate over 150ms ease-out
+- **AND** `prefers-reduced-motion` users SHALL see an instant snap
+
+---
+
+### Requirement: Armor Pip Damage Overlay
+
+Each sprite SHALL be accompanied by an armor-pip overlay ring that visualizes per-location damage state.
+
+#### Scenario: Pip color by location state
+
+- **GIVEN** a unit's right arm has full armor
+- **WHEN** the pip ring renders
+- **THEN** the RA pip group SHALL render green
+- **AND** a location with partial armor SHALL render yellow
+- **AND** a location with exposed internal structure SHALL render orange
+- **AND** a destroyed location SHALL render with a red outline and no fill
+
+#### Scenario: Quad pip layout differs from biped
+
+- **GIVEN** a quad unit's pip ring
+- **WHEN** the ring renders
+- **THEN** pip groups SHALL be positioned for Head, CT, Front-Left, Front-Right, Rear-Left, Rear-Right legs
+- **AND** arm pip groups SHALL NOT render
+
+#### Scenario: Pip ring simplifies at low zoom
+
+- **GIVEN** the map zoom is below 0.6x
+- **WHEN** the pip ring renders
+- **THEN** each location SHALL collapse to a single aggregate dot
+- **AND** ring rendering SHALL be suppressed entirely below zoom 0.35x
+
+---
+
+### Requirement: Sprite Scaling
+
+Sprites SHALL scale with hex size without losing legibility, and SHALL gracefully simplify at low zoom levels.
+
+#### Scenario: Default scale
+
+- **GIVEN** the map is at zoom 1.0
+- **WHEN** a sprite renders
+- **THEN** the sprite SHALL occupy approximately 80% of the hex diameter
+
+#### Scenario: Low-zoom simplification
+
+- **GIVEN** the map zoom is below 0.6x
+- **WHEN** the sprite renders
+- **THEN** the sprite SHALL collapse to an archetype glyph with side tint only
+- **AND** the facing indicator SHALL still be visible
+
+---
+
+### Requirement: Side Tint and Selection Ring
+
+The sprite renderer SHALL apply a side tint and render a selection ring when the unit is the currently selected unit.
+
+#### Scenario: Tint by side
+
+- **GIVEN** a unit on the Player side
+- **WHEN** the sprite renders
+- **THEN** the silhouette SHALL receive a blue tint via CSS filter or feColorMatrix
+- **AND** an Opponent unit SHALL receive a red tint
+- **AND** a Neutral unit SHALL receive a gray tint
+
+#### Scenario: Colorblind-safe distinction
+
+- **GIVEN** a user with a colorblind simulation mode on
+- **WHEN** two sprites from opposing sides render next to each other
+- **THEN** the sprites SHALL remain distinguishable via a shape overlay (e.g. triangle vs circle base marker) and not only by tint
+
+#### Scenario: Selection ring
+
+- **GIVEN** a unit is the selected unit in `useGameplayStore`
+- **WHEN** the sprite renders
+- **THEN** a selection ring SHALL render around the sprite
+- **AND** non-selected units SHALL NOT render a ring
+
+---
+
+## Relationships
+
+### Dependencies
+
+- **tactical-map-interface**: Hosts the sprite renderer inside the unit token layer.
+- **unit-entity-model**: Supplies `weightClass`, `isQuad`, `isLAM`, `facing`, `side`, `isDestroyed`, and `armorPipState` to the sprite.
+- **accessibility-system**: Supplies `prefers-reduced-motion` and colorblind simulation flags consumed by the renderer.
+
+### Implementation Reference
+
+- **MechSprite component**: `src/components/gameplay/sprites/MechSprite.tsx`
+- **Armor pip ring**: `src/components/gameplay/sprites/ArmorPipRing.tsx`
+- **Mech token integration**: `src/components/gameplay/UnitToken/MechToken.tsx`
+- **Sprite catalog**: `public/sprites/mechs/`
+
+---
+
+## Changelog
+
+### Version 1.0 (2026-04-23)
+
+- Initial specification introduced by change `add-mech-silhouette-sprite-set`.
+- Defines homemade silhouette catalog, facing indicator, armor pip overlay, side tint, selection ring, and zoom-aware level-of-detail.

--- a/public/sprites/mechs/README.md
+++ b/public/sprites/mechs/README.md
@@ -1,0 +1,33 @@
+# Mech Silhouette Sprites
+
+Homemade 2D silhouettes for the tactical map token renderer.
+
+## Originality attestation
+
+These SVGs are entirely homemade. They are composed of geometric
+primitives (rect, polygon, circle) and do **not** reference or derive from
+any licensed BattleTech, MechWarrior, or other third-party mech art. No
+published unit is named, traced, or rendered here.
+
+## Catalog
+
+4 weight classes × 3 archetypes = 12 sprites:
+
+- `humanoid-{light,medium,heavy,assault}.svg` — standard biped 'Mechs
+- `quad-{light,medium,heavy,assault}.svg` — four-legged 'Mechs (no arms)
+- `lam-{light,medium,heavy,assault}.svg` — Land-Air 'Mechs (humanoid + wings)
+
+## Conventions
+
+- viewBox `0 0 200 200` — anchor at center (100, 100).
+- Every sprite includes a `<polygon id="facing-notch">` near the top
+  (north). Rotation in the renderer carries the notch with the body.
+- Fills use `currentColor` so the parent can tint via CSS `color`.
+- The runtime renderer consumes **inline** versions of these sprites from
+  `src/components/gameplay/sprites/spriteCatalog.ts` (the same geometry).
+  The files here satisfy the spec's file-path contract and provide an
+  out-of-band reference for future asset pipelines.
+
+## Spec
+
+`openspec/changes/add-mech-silhouette-sprite-set/specs/unit-sprite-system/spec.md`

--- a/public/sprites/mechs/humanoid-assault.svg
+++ b/public/sprites/mechs/humanoid-assault.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" data-archetype="humanoid" data-weight="assault">
+  <polygon id="facing-notch" points="100,10 92,28 108,28" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="84" y="24" width="32" height="24" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="46" y="52" width="28" height="34" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="126" y="52" width="28" height="34" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="64" y="50" width="72" height="62" rx="6" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="46" y="86" width="22" height="38" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="132" y="86" width="22" height="38" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="74" y="114" width="24" height="56" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="114" width="24" height="56" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="66" y="170" width="36" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="170" width="36" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>

--- a/public/sprites/mechs/humanoid-heavy.svg
+++ b/public/sprites/mechs/humanoid-heavy.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" data-archetype="humanoid" data-weight="heavy">
+  <polygon id="facing-notch" points="100,10 92,28 108,28" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="86" y="26" width="28" height="22" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="54,62 80,50 80,78 54,82" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="146,62 120,50 120,78 146,82" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="70" y="50" width="60" height="58" rx="6" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="54" y="62" width="18" height="50" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="128" y="62" width="18" height="50" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="78" y="110" width="20" height="60" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="110" width="20" height="60" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="70" y="170" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="170" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>

--- a/public/sprites/mechs/humanoid-light.svg
+++ b/public/sprites/mechs/humanoid-light.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" data-archetype="humanoid" data-weight="light">
+  <polygon id="facing-notch" points="100,10 92,28 108,28" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="90" y="28" width="20" height="18" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="82" y="48" width="36" height="52" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="68" y="52" width="12" height="46" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="120" y="52" width="12" height="46" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="84" y="102" width="14" height="64" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="102" width="14" height="64" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="80" y="166" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="166" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>

--- a/public/sprites/mechs/humanoid-medium.svg
+++ b/public/sprites/mechs/humanoid-medium.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" data-archetype="humanoid" data-weight="medium">
+  <polygon id="facing-notch" points="100,10 92,28 108,28" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="88" y="26" width="24" height="22" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="76" y="50" width="48" height="56" rx="5" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="58" y="54" width="16" height="52" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="126" y="54" width="16" height="52" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="80" y="108" width="18" height="64" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="108" width="18" height="64" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="74" y="172" width="28" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="172" width="28" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>

--- a/public/sprites/mechs/lam-assault.svg
+++ b/public/sprites/mechs/lam-assault.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" data-archetype="lam" data-weight="assault">
+  <polygon id="facing-notch" points="100,10 92,28 108,28" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="20,76 64,58 64,110 20,104" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="180,76 136,58 136,110 180,104" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="84" y="24" width="32" height="24" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="64" y="50" width="72" height="62" rx="6" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="46" y="86" width="22" height="38" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="132" y="86" width="22" height="38" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="74" y="114" width="24" height="56" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="114" width="24" height="56" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="66" y="170" width="36" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="170" width="36" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>

--- a/public/sprites/mechs/lam-heavy.svg
+++ b/public/sprites/mechs/lam-heavy.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" data-archetype="lam" data-weight="heavy">
+  <polygon id="facing-notch" points="100,10 92,28 108,28" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="26,74 70,60 70,106 26,100" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="174,74 130,60 130,106 174,100" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="86" y="26" width="28" height="22" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="70" y="50" width="60" height="58" rx="6" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="54" y="62" width="18" height="50" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="128" y="62" width="18" height="50" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="78" y="110" width="20" height="60" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="110" width="20" height="60" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="70" y="170" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="170" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>

--- a/public/sprites/mechs/lam-light.svg
+++ b/public/sprites/mechs/lam-light.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" data-archetype="lam" data-weight="light">
+  <polygon id="facing-notch" points="100,10 92,28 108,28" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="40,70 82,60 82,96 40,90" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="160,70 118,60 118,96 160,90" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="90" y="28" width="20" height="18" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="82" y="48" width="36" height="52" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="68" y="52" width="12" height="46" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="120" y="52" width="12" height="46" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="84" y="102" width="14" height="64" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="102" width="14" height="64" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="80" y="166" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="166" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>

--- a/public/sprites/mechs/lam-medium.svg
+++ b/public/sprites/mechs/lam-medium.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" data-archetype="lam" data-weight="medium">
+  <polygon id="facing-notch" points="100,10 92,28 108,28" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="32,72 76,60 76,102 32,96" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="168,72 124,60 124,102 168,96" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="88" y="26" width="24" height="22" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="76" y="50" width="48" height="56" rx="5" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="58" y="54" width="16" height="52" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="126" y="54" width="16" height="52" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="80" y="108" width="18" height="64" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="108" width="18" height="64" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="74" y="172" width="28" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="172" width="28" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>

--- a/public/sprites/mechs/quad-assault.svg
+++ b/public/sprites/mechs/quad-assault.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" data-archetype="quad" data-weight="assault">
+  <polygon id="facing-notch" points="100,10 92,28 108,28" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="84,26 116,26 100,52" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="44" y="48" width="112" height="64" rx="10" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="40" y="62" width="14" height="44" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="146" y="62" width="14" height="44" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="34" y="102" width="26" height="60" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="140" y="102" width="26" height="60" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="62" y="108" width="26" height="66" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="112" y="108" width="26" height="66" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="28" y="160" width="38" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="134" y="160" width="38" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="56" y="172" width="38" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="106" y="172" width="38" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>

--- a/public/sprites/mechs/quad-heavy.svg
+++ b/public/sprites/mechs/quad-heavy.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" data-archetype="quad" data-weight="heavy">
+  <polygon id="facing-notch" points="100,10 92,28 108,28" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="86,28 114,28 100,50" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="50" y="48" width="100" height="58" rx="8" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="40" y="96" width="22" height="62" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="138" y="96" width="22" height="62" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="64" y="104" width="22" height="66" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="114" y="104" width="22" height="66" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="34" y="156" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="134" y="156" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="58" y="168" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="110" y="168" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>

--- a/public/sprites/mechs/quad-light.svg
+++ b/public/sprites/mechs/quad-light.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" data-archetype="quad" data-weight="light">
+  <polygon id="facing-notch" points="100,10 92,28 108,28" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="90,32 110,32 100,46" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="64" y="46" width="72" height="48" rx="6" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="54" y="88" width="14" height="56" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="132" y="88" width="14" height="56" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="72" y="94" width="14" height="64" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="114" y="94" width="14" height="64" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="50" y="142" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="128" y="142" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="68" y="156" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="110" y="156" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>

--- a/public/sprites/mechs/quad-medium.svg
+++ b/public/sprites/mechs/quad-medium.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" data-archetype="quad" data-weight="medium">
+  <polygon id="facing-notch" points="100,10 92,28 108,28" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="88,30 112,30 100,48" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="58" y="48" width="84" height="52" rx="8" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="48" y="94" width="18" height="58" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="134" y="94" width="18" height="58" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="68" y="100" width="18" height="64" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="114" y="100" width="18" height="64" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="42" y="150" width="26" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="132" y="150" width="26" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="62" y="162" width="26" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="112" y="162" width="26" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>

--- a/src/components/gameplay/UnitToken/MechToken.tsx
+++ b/src/components/gameplay/UnitToken/MechToken.tsx
@@ -1,12 +1,30 @@
 /**
- * MechToken — renders a BattleMech on the hex map.
+ * MechToken — renders a BattleMech on the hex map using the Phase-7 homemade
+ * silhouette sprite set.
  *
- * Extracted from the original `UnitToken.tsx` (Phase 1) with a clean props
- * interface. Visual behavior is unchanged: circular body, 6-hex facing arrow,
- * selection / target ring, destroyed overlay, and damage-feedback overlays.
+ * This file used to emit a flat coloured disc plus an arrow; the Wave-5 UI
+ * polish swaps that for:
+ *   - `MechSprite` — resolves the right archetype × weight silhouette,
+ *     rotates it to match `token.facing`, applies side tint + selection ring
+ *     + colorblind-safe shape overlay, and collapses to an archetype glyph
+ *     at low zoom.
+ *   - `ArmorPipRing` — draws 6 or 8 pip dots around the sprite that encode
+ *     per-location armor / structure state.
  *
- * @spec openspec/changes/add-per-type-hex-tokens/specs/tactical-map-interface/spec.md
- *        §Per-Type Token Rendering — Mech unit renders mech token
+ * We preserve the existing Phase-1 contract: this component emits
+ * token-local SVG children inside the parent `<g transform="translate(x,y)">`,
+ * the outer `<g>` (provided by `UnitTokenForType`) remains the click target,
+ * the selection ring lives under the sprite, the active-target pulse still
+ * runs via `<animate>`, the destroyed cross renders over the top, and
+ * damage-feedback overlays (CritHit, PilotWound, DamageFloater) compose in
+ * the same order.
+ *
+ * @spec openspec/changes/add-mech-silhouette-sprite-set/specs/unit-sprite-system/spec.md
+ *        §Side Tint and Selection Ring
+ *        §Armor Pip Damage Overlay
+ *        §Sprite Scaling
+ * @spec openspec/changes/add-mech-silhouette-sprite-set/specs/tactical-map-interface/spec.md
+ *        §Mech silhouette replaces flat disc marker
  */
 
 import React from 'react';
@@ -15,66 +33,58 @@ import type { IUnitToken } from '@/types/gameplay';
 
 import { CritHitOverlay } from '@/components/gameplay/CritHitOverlay';
 import { DamageFloater } from '@/components/gameplay/DamageFloater';
-import { getFacingRotation } from '@/components/gameplay/HexMapDisplay/renderHelpers';
 import { PilotWoundFlash } from '@/components/gameplay/PilotWoundFlash';
-import { HEX_SIZE, HEX_COLORS } from '@/constants/hexMap';
-import { GameSide } from '@/types/gameplay';
+import { ArmorPipRing } from '@/components/gameplay/sprites/ArmorPipRing';
+import { MechSprite } from '@/components/gameplay/sprites/MechSprite';
+import { HEX_SIZE } from '@/constants/hexMap';
 
 import type { ITokenSharedProps } from './tokenTypes';
 
-// Token radius constants — exported so UnitTokenForType can scale the selection ring.
+// =============================================================================
+// Token radius constants — re-exported so callers (dispatcher, tests) can
+// place effects relative to the token body without re-deriving the math.
+// =============================================================================
+
+/**
+ * Approximate body radius for overlay placement. The new sprite is 80% of
+ * hex diameter (= HEX_SIZE * 0.8); keeping the same constant name lets
+ * existing consumers (CritHitOverlay, PilotWoundFlash) place their effects
+ * without code changes.
+ */
 export const MECH_TOKEN_RADIUS = HEX_SIZE * 0.5;
+
+/**
+ * Outer ring radius for selection / active-target highlights. Matches the
+ * previous Phase-1 value so the active-target pulse in this file and the
+ * selection halo in `MechSprite` sit at visually compatible radii.
+ */
 export const MECH_RING_RADIUS = HEX_SIZE * 0.7;
 
 export interface MechTokenProps extends ITokenSharedProps {
   token: IUnitToken;
+  /**
+   * Current map zoom factor (1.0 = 100%). Forwarded to the sprite + pip
+   * ring so they can collapse at low zoom. Defaults to 1 so callers that
+   * don't pipe zoom through continue to get the full-fidelity render.
+   */
+  zoom?: number;
 }
 
 /**
- * Pure SVG mech token. Rendered inside a `<g transform="translate(x,y)">` by
- * the parent — this component only outputs the token-local SVG children.
- * The `<g>` wrapper with click handler is provided by the parent so the
- * overlay pipeline (CritHit, Pilot, Damage) composees cleanly.
+ * Pure SVG mech token. Renders inside a parent `<g transform="translate"/>`.
  */
 export const MechToken = React.memo(function MechToken({
   token,
   eventState,
+  zoom = 1,
 }: MechTokenProps): React.ReactElement {
-  const rotation = getFacingRotation(token.facing);
   const isDestroyed = token.isDestroyed || eventState.destroyed;
-
-  let color =
-    token.side === GameSide.Player
-      ? HEX_COLORS.playerToken
-      : HEX_COLORS.opponentToken;
-  if (isDestroyed) {
-    color = HEX_COLORS.destroyedToken;
-  }
-
-  // Active target takes precedence over generic valid-target tone; the
-  // selection (yellow) ring still wins for the controlled attacker.
-  const ringColor = token.isSelected
-    ? '#fbbf24'
-    : token.isActiveTarget
-      ? '#dc2626'
-      : token.isValidTarget
-        ? '#f87171'
-        : 'transparent';
 
   return (
     <>
-      {/* Selection / target ring — radius scales with token size */}
-      <circle
-        r={MECH_RING_RADIUS}
-        fill="none"
-        stroke={ringColor}
-        strokeWidth={3}
-      />
-
-      {/* Pulsing ring overlay — only painted when this unit is the
-          attacker's active target (spec: tactical-map-interface §Target
-          Lock Visualization). Uses SVG <animate> so the effect works
-          inside static SVG snapshots / JSDOM tests. */}
+      {/* Active-target pulsing ring — painted BEHIND the sprite so the
+          silhouette reads on top. Uses SVG <animate> so the effect renders
+          inside static snapshots / JSDOM. */}
       {token.isActiveTarget && !isDestroyed && (
         <circle
           data-testid="unit-active-target-pulse"
@@ -100,31 +110,45 @@ export const MechToken = React.memo(function MechToken({
         </circle>
       )}
 
-      {/* Circular mech body */}
-      <circle
-        r={MECH_TOKEN_RADIUS}
-        fill={color}
-        stroke="#1e293b"
-        strokeWidth={2}
+      {/* Valid-target halo (static — red) stays a flat ring. The selection
+          ring (yellow) is emitted by `MechSprite` itself when isSelected. */}
+      {token.isValidTarget && !token.isSelected && !token.isActiveTarget && (
+        <circle
+          data-testid="unit-valid-target-ring"
+          r={MECH_RING_RADIUS}
+          fill="none"
+          stroke="#f87171"
+          strokeWidth={3}
+          pointerEvents="none"
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Armor pip ring — painted under the sprite so the silhouette sits
+          above the dots at the ring radius. Passes through zoom so the
+          ring simplifies / disappears at low zoom per spec. */}
+      <ArmorPipRing
+        state={token.armorPipState}
+        zoom={zoom}
+        patternKey={token.unitId}
       />
 
-      {/* 6-hex facing arrow — rotated to the current Facing value */}
-      <g transform={`rotate(${rotation - 90})`}>
-        <path
-          d="M0,-20 L8,-8 L0,-12 L-8,-8 Z"
-          fill="white"
-          stroke="#1e293b"
-          strokeWidth={1}
-        />
-      </g>
+      {/* Main silhouette (+ selection ring + colorblind shape overlay). */}
+      <MechSprite token={token} zoom={zoom} isSelected={token.isSelected} />
 
-      {/* Designation label */}
+      {/* Designation label — sits just below the sprite. Font size floors
+          at 10px per spec scenario "text labels scale with zoom but never
+          below 10px"; we compute once at the current zoom and clamp. */}
       <text
-        y={4}
+        y={MECH_TOKEN_RADIUS + 14}
         textAnchor="middle"
-        fontSize={10}
+        fontSize={Math.max(10, 10 * Math.min(1.4, Math.max(zoom, 0.5)))}
         fontWeight="bold"
-        fill="white"
+        fill="#f8fafc"
+        stroke="#0f172a"
+        strokeWidth={0.6}
+        paintOrder="stroke fill"
+        pointerEvents="none"
       >
         {token.designation}
       </text>

--- a/src/components/gameplay/sprites/ArmorPipRing.tsx
+++ b/src/components/gameplay/sprites/ArmorPipRing.tsx
@@ -1,0 +1,289 @@
+/**
+ * ArmorPipRing — renders the 6/8 armor-pip dots around a mech sprite.
+ *
+ * Layout choice by archetype:
+ *   - humanoid / lam: 8 pip groups → Head, CT, LT, RT, LA, RA, LL, RL
+ *     arranged clockwise from 12 o'clock (head) around the silhouette.
+ *   - quad:           6 pip groups → Head, CT, Front-Left, Front-Right,
+ *                      Rear-Left, Rear-Right.
+ *
+ * Each pip group is ONE dot; state controls fill/outline/pattern. This
+ * keeps the ring legible at 80% hex diameter (~64px total) where 3 sub-
+ * pips per location would smear into a blur.
+ *
+ * Colorblind rule: `structure` state adds a diagonal stripe pattern so
+ * it is distinguishable from `partial` (yellow) by shape as well as hue,
+ * matching the accessibility requirement.
+ *
+ * @spec openspec/changes/add-mech-silhouette-sprite-set/specs/unit-sprite-system/spec.md
+ *        §Armor Pip Damage Overlay
+ */
+
+import React from 'react';
+
+import type {
+  ArmorPipState,
+  BipedPipLocation,
+  PipLocationState,
+  QuadPipLocation,
+} from '@/types/gameplay';
+
+// =============================================================================
+// Geometry — pip positions (in viewBox units, centered on sprite)
+// =============================================================================
+
+/**
+ * Radius of the pip ring in sprite-viewBox units (viewBox = 200).
+ * @why 108 sits just outside the 200×200 silhouette, which is already padded
+ *      inward to ~180 max extent — gives clean separation from the body.
+ */
+const RING_RADIUS = 108;
+
+/** Pip dot radius — two-ish pixels at hex scale, readable at zoom 1.0. */
+const PIP_RADIUS = 7;
+
+/**
+ * Biped pip positions around the silhouette. Clock-face layout starting at
+ * 12 o'clock (head) and marching clockwise. Coordinates are viewBox-centered:
+ * (0,0) is the sprite center; the enclosing <g> translates by +100,+100.
+ */
+const BIPED_POSITIONS: Readonly<
+  Record<BipedPipLocation, { x: number; y: number }>
+> = {
+  head: { x: 0, y: -RING_RADIUS }, // 12
+  rightArm: { x: RING_RADIUS * 0.72, y: -RING_RADIUS * 0.66 }, // 1-2
+  rightTorso: { x: RING_RADIUS * 0.95, y: 0 }, // 3
+  rightLeg: { x: RING_RADIUS * 0.72, y: RING_RADIUS * 0.66 }, // 4-5
+  centerTorso: { x: 0, y: RING_RADIUS }, // 6
+  leftLeg: { x: -RING_RADIUS * 0.72, y: RING_RADIUS * 0.66 }, // 7-8
+  leftTorso: { x: -RING_RADIUS * 0.95, y: 0 }, // 9
+  leftArm: { x: -RING_RADIUS * 0.72, y: -RING_RADIUS * 0.66 }, // 10-11
+};
+
+/**
+ * Quad pip positions. Head at 12, CT at 6, four legs at the cardinal-ish
+ * corners (front pair near 2/10, rear pair near 4/8).
+ */
+const QUAD_POSITIONS: Readonly<
+  Record<QuadPipLocation, { x: number; y: number }>
+> = {
+  head: { x: 0, y: -RING_RADIUS }, // 12
+  frontRightLeg: { x: RING_RADIUS * 0.85, y: -RING_RADIUS * 0.4 }, // 2
+  rearRightLeg: { x: RING_RADIUS * 0.85, y: RING_RADIUS * 0.4 }, // 4
+  centerTorso: { x: 0, y: RING_RADIUS }, // 6
+  rearLeftLeg: { x: -RING_RADIUS * 0.85, y: RING_RADIUS * 0.4 }, // 8
+  frontLeftLeg: { x: -RING_RADIUS * 0.85, y: -RING_RADIUS * 0.4 }, // 10
+};
+
+// =============================================================================
+// State → visual mapping
+// =============================================================================
+
+/**
+ * Pip fill color by state. Colors are accessibility-considered:
+ *   full      → green  (damage-free)
+ *   partial   → yellow (armor breached but holding)
+ *   structure → orange (internals exposed)
+ *   destroyed → red outline only, no fill
+ *   missing   → not rendered
+ *
+ * Colors intentionally chosen for contrast against a grey-tinted sprite
+ * background; the stripe pattern on `structure` adds a shape cue.
+ */
+const PIP_FILL: Record<
+  Exclude<PipLocationState, 'destroyed' | 'missing'>,
+  string
+> = {
+  full: '#16a34a',
+  partial: '#facc15',
+  structure: '#f97316',
+};
+
+/**
+ * Shared stable ID for the stripe pattern. We expose it as a function so
+ * callers with multiple rings on the same map each get a uniquely-scoped
+ * pattern and SVG <defs> stacking never collides.
+ */
+function stripePatternId(keySuffix: string): string {
+  return `armor-pip-stripe-${keySuffix}`;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export interface ArmorPipRingProps {
+  /**
+   * Per-location armor state for this unit. When omitted the ring assumes
+   * every location is `full` — useful before the gameplay store wires
+   * real armor projection in.
+   */
+  readonly state?: ArmorPipState;
+  /**
+   * Current map zoom level. Below 0.6 the ring simplifies (still shows a
+   * single dot per location but suppresses stripes). Below 0.35 the ring
+   * is hidden entirely (too small to read).
+   */
+  readonly zoom?: number;
+  /**
+   * Unique suffix for the SVG pattern def — typically the unit id. Keeps
+   * multiple rings on the same map from stomping each other's <pattern>.
+   */
+  readonly patternKey: string;
+}
+
+/**
+ * Render a ring of small pip dots, one per hit location.
+ *
+ * Returns `null` when `zoom < 0.35` — the ring is too small to read, and
+ * the spec says "ring rendering SHALL be suppressed entirely below zoom
+ * 0.35x".
+ */
+export const ArmorPipRing = React.memo(function ArmorPipRing({
+  state,
+  zoom = 1,
+  patternKey,
+}: ArmorPipRingProps): React.ReactElement | null {
+  if (zoom < 0.35) return null;
+
+  // Low-zoom simplification: hide the stripe pattern since it won't read.
+  // We still render the dots themselves per spec "each location SHALL
+  // collapse to a single aggregate dot" — our layout is already one dot
+  // per location, so the only simplification is dropping the stripe.
+  const simplified = zoom < 0.6;
+
+  const locations = resolveLocations(state);
+  const stripeId = stripePatternId(patternKey);
+
+  return (
+    <g data-testid="armor-pip-ring" aria-hidden="true" pointerEvents="none">
+      {/* <defs> scope is local to this <g> — pattern fill resolves via url(#id). */}
+      {!simplified && (
+        <defs>
+          <pattern
+            id={stripeId}
+            patternUnits="userSpaceOnUse"
+            width="4"
+            height="4"
+            patternTransform="rotate(45)"
+          >
+            <rect width="4" height="4" fill={PIP_FILL.structure} />
+            <line
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="4"
+              stroke="#7c2d12"
+              strokeWidth="2"
+            />
+          </pattern>
+        </defs>
+      )}
+
+      {locations.map(({ name, pos, pipState }) => (
+        <PipDot
+          key={name}
+          cx={pos.x}
+          cy={pos.y}
+          state={pipState}
+          stripeId={stripeId}
+          simplified={simplified}
+        />
+      ))}
+    </g>
+  );
+});
+
+// =============================================================================
+// Internals — location resolution + single pip primitive
+// =============================================================================
+
+interface ResolvedPip {
+  readonly name: string;
+  readonly pos: { x: number; y: number };
+  readonly pipState: PipLocationState;
+}
+
+/**
+ * Project the optional `ArmorPipState` into an ordered list of pips. When
+ * no state is provided, every biped location renders as `full`.
+ */
+function resolveLocations(state: ArmorPipState | undefined): ResolvedPip[] {
+  if (!state) {
+    return Object.entries(BIPED_POSITIONS).map(([name, pos]) => ({
+      name,
+      pos,
+      pipState: 'full' as const,
+    }));
+  }
+  if (state.archetype === 'quad') {
+    return Object.entries(QUAD_POSITIONS)
+      .map(([name, pos]) => {
+        const s = state.locations[name as QuadPipLocation];
+        return { name, pos, pipState: s };
+      })
+      .filter((p) => p.pipState !== 'missing');
+  }
+  // humanoid + lam both use the biped layout.
+  return Object.entries(BIPED_POSITIONS)
+    .map(([name, pos]) => {
+      const s = state.locations[name as BipedPipLocation];
+      return { name, pos, pipState: s };
+    })
+    .filter((p) => p.pipState !== 'missing');
+}
+
+interface PipDotProps {
+  readonly cx: number;
+  readonly cy: number;
+  readonly state: PipLocationState;
+  readonly stripeId: string;
+  readonly simplified: boolean;
+}
+
+/**
+ * One pip dot. `destroyed` renders as an outline-only circle with a red
+ * stroke — no fill — so the location reads as "gone" even at small sizes.
+ */
+function PipDot({
+  cx,
+  cy,
+  state,
+  stripeId,
+  simplified,
+}: PipDotProps): React.ReactElement | null {
+  if (state === 'missing') return null;
+
+  if (state === 'destroyed') {
+    return (
+      <circle
+        cx={cx}
+        cy={cy}
+        r={PIP_RADIUS}
+        fill="none"
+        stroke="#dc2626"
+        strokeWidth={2.5}
+        data-pip-state="destroyed"
+      />
+    );
+  }
+
+  // `structure` uses a stripe pattern for colorblind distinction — unless
+  // we're in simplified (low-zoom) mode, where we just use the flat orange.
+  const fill =
+    state === 'structure' && !simplified
+      ? `url(#${stripeId})`
+      : PIP_FILL[state as 'full' | 'partial' | 'structure'];
+
+  return (
+    <circle
+      cx={cx}
+      cy={cy}
+      r={PIP_RADIUS}
+      fill={fill}
+      stroke="#1e293b"
+      strokeWidth={1}
+      data-pip-state={state}
+    />
+  );
+}

--- a/src/components/gameplay/sprites/MechSprite.tsx
+++ b/src/components/gameplay/sprites/MechSprite.tsx
@@ -1,0 +1,367 @@
+/**
+ * MechSprite — renders a homemade mech silhouette for a unit token.
+ *
+ * Responsibilities (per tasks 3, 4, 7, 8 of add-mech-silhouette-sprite-set):
+ *   - Resolve the correct archetype × weight silhouette from `spriteCatalog`
+ *   - Apply a side-derived tint via CSS `color` (silhouettes fill with
+ *     `currentColor`)
+ *   - Rotate the sprite by `facing * 60deg` about its center
+ *   - Smoothly animate facing changes over 150ms ease-out, snapping instantly
+ *     when `prefers-reduced-motion` (OS) or the AccessibilityStore opts in
+ *   - Render a selection ring when the unit is selected
+ *   - Collapse to a tiny archetype glyph below zoom 0.6 so the hex stays
+ *     legible (pip ring is hidden by `ArmorPipRing` at the same threshold)
+ *   - Overlay a colorblind-safe shape marker (circle/triangle/square) keyed
+ *     by side so adjacent opponents are distinguishable without color
+ *
+ * Shape of rendered output: this component emits SVG children (a `<g>` with
+ * the silhouette plus optional selection ring and shape overlay). It is
+ * meant to be composed inside the parent hex-cell `<g transform="translate"/>`
+ * just like the original `MechToken`.
+ *
+ * @spec openspec/changes/add-mech-silhouette-sprite-set/specs/unit-sprite-system/spec.md
+ *        §Homemade Silhouette Sprite Catalog
+ *        §Built-in Facing Indicator
+ *        §Sprite Scaling
+ *        §Side Tint and Selection Ring
+ */
+
+import React from 'react';
+
+import type { IUnitToken } from '@/types/gameplay';
+
+import {
+  ARCHETYPE_GLYPHS,
+  SPRITE_ANCHOR_X,
+  SPRITE_ANCHOR_Y,
+  SPRITE_VIEWBOX_SIZE,
+  getSpriteSvg,
+} from '@/components/gameplay/sprites/spriteCatalog';
+import { HEX_SIZE } from '@/constants/hexMap';
+import { useAccessibilityStore } from '@/stores/useAccessibilityStore';
+import { Facing, GameSide } from '@/types/gameplay';
+import { selectSprite } from '@/utils/sprites/spriteSelector';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * Rendered sprite diameter at zoom 1.0 — 80% of hex diameter per spec
+ * Scenario "Default scale".
+ *
+ * @why `HEX_SIZE` is a flat-top radius; diameter = 2 × radius. 80% of that
+ *      lands the sprite inside the hex with visible margin for the pip ring
+ *      and the selection halo.
+ */
+const SPRITE_DIAMETER = HEX_SIZE * 2 * 0.8;
+
+/**
+ * Threshold below which the full silhouette is replaced by the archetype
+ * glyph. Matches the pip ring's simplification threshold, so both visual
+ * layers transition together.
+ */
+const LOW_ZOOM_GLYPH_THRESHOLD = 0.6;
+
+/**
+ * Ring radius when the sprite is selected. A bit larger than the sprite
+ * half-diameter so the ring sits clear of the silhouette's outline.
+ */
+const SELECTION_RING_RADIUS = SPRITE_DIAMETER * 0.62;
+
+/** Shape-overlay marker size (diameter in SVG user units). */
+const SHAPE_OVERLAY_SIZE = 10;
+
+/**
+ * Side → tint color. Tinted via CSS `color` → `currentColor` fills in SVG.
+ * Matches HEX_COLORS but kept local so the sprite palette can diverge
+ * from the original flat-disc marker palette without forcing other callers
+ * to re-theme.
+ *
+ * @why The game currently only models two sides (Player, Opponent) via the
+ *      `GameSide` enum. The spec references a "Neutral" tint for future-
+ *      neutral chassis, so we expose a grey fallback (`NEUTRAL_TINT`) that
+ *      callers can pass via `tintOverride` when a unit is not on either
+ *      side of the active engagement (e.g. eject pilots, turrets).
+ */
+const SIDE_TINT: Record<GameSide, string> = {
+  [GameSide.Player]: '#3b82f6', // blue
+  [GameSide.Opponent]: '#ef4444', // red
+};
+
+/** Grey fallback exposed for callers that need a "neutral" tint. */
+export const NEUTRAL_TINT = '#9ca3af';
+
+// =============================================================================
+// Facing helpers
+// =============================================================================
+
+/**
+ * Map the `Facing` enum to rotation degrees (0/60/120/180/240/300).
+ * Kept local to avoid pulling in `renderHelpers` — this function is pure
+ * and trivial and we want `MechSprite` to have zero hex-math dependency.
+ */
+function facingToDegrees(facing: Facing): number {
+  switch (facing) {
+    case Facing.North:
+      return 0;
+    case Facing.Northeast:
+      return 60;
+    case Facing.Southeast:
+      return 120;
+    case Facing.South:
+      return 180;
+    case Facing.Southwest:
+      return 240;
+    case Facing.Northwest:
+      return 300;
+    default:
+      return 0;
+  }
+}
+
+// =============================================================================
+// Side shape overlay (colorblind safety)
+// =============================================================================
+
+interface SideShapeProps {
+  readonly side: GameSide;
+  readonly tint: string;
+}
+
+/**
+ * Colorblind-safe shape overlay. Small marker drawn at the top of the
+ * sprite — triangle for Player, square for Opponent, circle for Neutral.
+ * Combined with the facing notch this gives two independent shape cues.
+ *
+ * @spec openspec/changes/add-mech-silhouette-sprite-set/specs/unit-sprite-system/spec.md
+ *        §Side Tint and Selection Ring → Scenario: Colorblind-safe distinction
+ */
+function SideShape({ side, tint }: SideShapeProps): React.ReactElement | null {
+  // Place the shape above the sprite center (just above the sprite)
+  const cy = -SPRITE_DIAMETER * 0.46;
+  const commonProps = {
+    fill: tint,
+    stroke: '#0f172a',
+    strokeWidth: 1,
+    'data-testid': `sprite-side-shape-${side}`,
+    'aria-hidden': true,
+    pointerEvents: 'none' as const,
+  };
+  switch (side) {
+    case GameSide.Player:
+      // Upward triangle
+      return (
+        <polygon
+          points={`0,${cy - SHAPE_OVERLAY_SIZE / 2} ${SHAPE_OVERLAY_SIZE / 2},${cy + SHAPE_OVERLAY_SIZE / 2} ${-SHAPE_OVERLAY_SIZE / 2},${cy + SHAPE_OVERLAY_SIZE / 2}`}
+          {...commonProps}
+        />
+      );
+    case GameSide.Opponent:
+      // Square
+      return (
+        <rect
+          x={-SHAPE_OVERLAY_SIZE / 2}
+          y={cy - SHAPE_OVERLAY_SIZE / 2}
+          width={SHAPE_OVERLAY_SIZE}
+          height={SHAPE_OVERLAY_SIZE}
+          {...commonProps}
+        />
+      );
+    default:
+      // Any future side falls back to a neutral circle.
+      return (
+        <circle cx={0} cy={cy} r={SHAPE_OVERLAY_SIZE / 2} {...commonProps} />
+      );
+  }
+}
+
+// =============================================================================
+// Reduced-motion detection
+// =============================================================================
+
+/**
+ * Return true when the user has explicitly requested reduced motion, either
+ * via the OS media query or the in-app accessibility store.
+ *
+ * @why Wrapped in a hook so the component re-renders when the setting flips
+ *      at runtime (e.g. the user toggles it in AccessibilitySettings).
+ */
+function useReducedMotion(): boolean {
+  const storeReduceMotion = useAccessibilityStore((s) => s.reduceMotion);
+  const [mediaReduce, setMediaReduce] = React.useState<boolean>(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handler = (e: MediaQueryListEvent): void => setMediaReduce(e.matches);
+    // `addEventListener` is the modern API; jsdom supports it.
+    mql.addEventListener?.('change', handler);
+    return () => mql.removeEventListener?.('change', handler);
+  }, []);
+
+  return storeReduceMotion || mediaReduce;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export interface MechSpriteProps {
+  /**
+   * The token being rendered. `weightClass`, `chassisArchetype`, `isQuad`,
+   * and `isLAM` feed the sprite selector; absent values default to
+   * humanoid-medium.
+   */
+  readonly token: Pick<
+    IUnitToken,
+    | 'weightClass'
+    | 'chassisArchetype'
+    | 'isQuad'
+    | 'isLAM'
+    | 'facing'
+    | 'side'
+    | 'isDestroyed'
+  >;
+  /** Current map zoom level (1.0 = 100%). Drives low-zoom glyph collapse. */
+  readonly zoom?: number;
+  /** Whether the unit is currently selected — drives the ring. */
+  readonly isSelected?: boolean;
+  /**
+   * Optional tint override. Normally the tint is derived from `token.side`;
+   * callers may pass an explicit value for dead/destroyed/bot states.
+   */
+  readonly tintOverride?: string;
+}
+
+/**
+ * Render a mech silhouette token with facing rotation, side tint, selection
+ * ring, and low-zoom glyph collapse.
+ *
+ * Layout contract: emits an SVG fragment assuming the parent has already
+ * translated to the hex center. All internal coordinates are viewBox-local
+ * and centered at (0, 0).
+ */
+export const MechSprite = React.memo(function MechSprite({
+  token,
+  zoom = 1,
+  isSelected = false,
+  tintOverride,
+}: MechSpriteProps): React.ReactElement {
+  const bundle = selectSprite({
+    weightClass: token.weightClass,
+    chassisArchetype: token.chassisArchetype,
+    isQuad: token.isQuad,
+    isLAM: token.isLAM,
+  });
+
+  const rotationDeg = facingToDegrees(token.facing);
+  const reducedMotion = useReducedMotion();
+
+  // CSS transition — the <g> that holds the silhouette rotates; animation
+  // is disabled when reduced motion is requested (spec scenario "Facing
+  // change animates" + "prefers-reduced-motion users SHALL see an instant
+  // snap").
+  const rotateTransform = `rotate(${rotationDeg})`;
+  const rotateStyle: React.CSSProperties = {
+    transformBox: 'fill-box',
+    transformOrigin: 'center',
+    transition: reducedMotion ? 'none' : 'transform 150ms ease-out',
+  };
+
+  const tint =
+    tintOverride ?? (token.isDestroyed ? '#6b7280' : SIDE_TINT[token.side]);
+
+  const lowZoom = zoom < LOW_ZOOM_GLYPH_THRESHOLD;
+  const glyphSvg = ARCHETYPE_GLYPHS[bundle.archetype];
+  const fullSvg = getSpriteSvg(bundle.archetype, bundle.weight);
+
+  // Render either the full silhouette or the tiny archetype glyph. In both
+  // cases the outer transform handles position + facing rotation.
+  const spriteBody = lowZoom ? (
+    <g
+      data-testid="mech-sprite-glyph"
+      data-archetype={bundle.archetype}
+      // Glyph is 24×24; scale it to ~50% of sprite diameter and center.
+      transform={`translate(${-SPRITE_DIAMETER * 0.25}, ${-SPRITE_DIAMETER * 0.25}) scale(${SPRITE_DIAMETER * 0.5 * (1 / 24)})`}
+      style={{ color: tint }}
+      dangerouslySetInnerHTML={{ __html: stripOuterSvg(glyphSvg) }}
+    />
+  ) : (
+    <g
+      data-testid="mech-sprite-body"
+      data-archetype={bundle.archetype}
+      data-weight={bundle.weight}
+      // Silhouettes live in a 200×200 viewBox with center at (100,100).
+      // Translate so center is at (0,0), then scale to target diameter.
+      transform={`translate(${-SPRITE_DIAMETER / 2}, ${-SPRITE_DIAMETER / 2}) scale(${SPRITE_DIAMETER / SPRITE_VIEWBOX_SIZE})`}
+      style={{ color: tint }}
+      dangerouslySetInnerHTML={{ __html: stripOuterSvg(fullSvg) }}
+    />
+  );
+
+  return (
+    <g
+      data-testid="mech-sprite"
+      data-sprite-id={bundle.spriteId}
+      data-facing={token.facing}
+      data-zoom-mode={lowZoom ? 'glyph' : 'full'}
+    >
+      {/* Selection ring — painted BEHIND the silhouette so it reads as a halo. */}
+      {isSelected && (
+        <circle
+          data-testid="mech-sprite-selection-ring"
+          r={SELECTION_RING_RADIUS}
+          fill="none"
+          stroke="#fbbf24"
+          strokeWidth={3}
+          pointerEvents="none"
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Rotating silhouette group. Anchor is sprite center (0,0). */}
+      <g
+        data-testid="mech-sprite-rotator"
+        data-rotation-deg={rotationDeg}
+        data-reduced-motion={reducedMotion ? 'true' : 'false'}
+        transform={rotateTransform}
+        style={rotateStyle}
+      >
+        {spriteBody}
+      </g>
+
+      {/* Colorblind-safe shape overlay. Lives ABOVE the rotator so it does
+          NOT rotate with the sprite — it is a side cue, not a facing cue. */}
+      <SideShape side={token.side} tint={tint} />
+    </g>
+  );
+});
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Extract the inner SVG markup from a top-level `<svg ...>...</svg>` string.
+ *
+ * @why We inject the silhouette geometry into an existing `<g>` inside a
+ *      larger SVG scene. Keeping the outer `<svg>` tag would nest root
+ *      namespaces; stripping it gives us just the children (polygons,
+ *      rects, etc.) to embed cleanly.
+ */
+function stripOuterSvg(svg: string): string {
+  const openEnd = svg.indexOf('>');
+  const closeStart = svg.lastIndexOf('</svg>');
+  if (openEnd < 0 || closeStart < 0) return svg;
+  return svg.slice(openEnd + 1, closeStart);
+}
+
+// Reference the anchor constants so callers that destructure this file
+// (e.g., snapshot generators) can verify the hex center alignment matches
+// the catalog. Re-exports are avoided to keep the public API tight.
+void SPRITE_ANCHOR_X;
+void SPRITE_ANCHOR_Y;

--- a/src/components/gameplay/sprites/__tests__/ArmorPipRing.test.tsx
+++ b/src/components/gameplay/sprites/__tests__/ArmorPipRing.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * Tests for ArmorPipRing — the damage-overlay pip ring that sits around a
+ * mech silhouette.
+ *
+ * Covers:
+ *   - Default (no state): renders 8 biped dots
+ *   - Quad state: renders 6 dots in the quad layout, no arm pips
+ *   - Per-location color coding (full=green, partial=yellow, structure=orange
+ *     as stripe pattern, destroyed=red outline no fill)
+ *   - Missing locations are omitted
+ *   - Low-zoom simplification (no stripes) and cutoff below 0.35 (no ring)
+ *
+ * @spec openspec/changes/add-mech-silhouette-sprite-set/specs/unit-sprite-system/spec.md
+ *        §Armor Pip Damage Overlay
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import type {
+  ArmorPipState,
+  BipedPipLocation,
+  PipLocationState,
+  QuadPipLocation,
+} from '@/types/gameplay';
+
+import { ArmorPipRing } from '../ArmorPipRing';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Wrap the ring in an <svg> root so jsdom handles SVG children correctly. */
+function renderInSvg(ui: React.ReactElement): { svg: SVGSVGElement } {
+  const { container } = render(<svg>{ui}</svg>);
+  return { svg: container.querySelector('svg')! };
+}
+
+/** Build a biped location record where every location has the same state. */
+function uniformBipedLocations(
+  state: PipLocationState,
+): Record<BipedPipLocation, PipLocationState> {
+  return {
+    head: state,
+    centerTorso: state,
+    leftTorso: state,
+    rightTorso: state,
+    leftArm: state,
+    rightArm: state,
+    leftLeg: state,
+    rightLeg: state,
+  };
+}
+
+/** Build a biped `ArmorPipState` filled with one uniform state. */
+function uniformBiped(state: PipLocationState): ArmorPipState {
+  return { archetype: 'humanoid', locations: uniformBipedLocations(state) };
+}
+
+/** Biped state with one location overridden. */
+function bipedWithOverride(
+  location: BipedPipLocation,
+  overrideState: PipLocationState,
+): ArmorPipState {
+  const base = uniformBipedLocations('full');
+  return {
+    archetype: 'humanoid',
+    locations: { ...base, [location]: overrideState },
+  };
+}
+
+/** LAM state (same shape as biped, different archetype tag). */
+function lamState(state: PipLocationState): ArmorPipState {
+  return { archetype: 'lam', locations: uniformBipedLocations(state) };
+}
+
+/** Build a quad location record where every location has the same state. */
+function uniformQuadLocations(
+  state: PipLocationState,
+): Record<QuadPipLocation, PipLocationState> {
+  return {
+    head: state,
+    centerTorso: state,
+    frontLeftLeg: state,
+    frontRightLeg: state,
+    rearLeftLeg: state,
+    rearRightLeg: state,
+  };
+}
+
+/** Build a quad `ArmorPipState` filled with one uniform state. */
+function uniformQuad(state: PipLocationState): ArmorPipState {
+  return { archetype: 'quad', locations: uniformQuadLocations(state) };
+}
+
+// =============================================================================
+// Default (no state)
+// =============================================================================
+
+describe('ArmorPipRing — default state', () => {
+  it('renders 8 pip dots when no state is supplied (biped default)', () => {
+    const { svg } = renderInSvg(<ArmorPipRing patternKey="test" />);
+    const dots = svg.querySelectorAll('[data-pip-state]');
+    expect(dots.length).toBe(8);
+    dots.forEach((d) => expect(d.getAttribute('data-pip-state')).toBe('full'));
+  });
+
+  it('applies the green fill to full-armor pips', () => {
+    const { svg } = renderInSvg(<ArmorPipRing patternKey="test" />);
+    const dots = svg.querySelectorAll("[data-pip-state='full']");
+    expect(dots.length).toBe(8);
+    expect(dots[0].getAttribute('fill')).toBe('#16a34a');
+  });
+});
+
+// =============================================================================
+// Archetype layouts
+// =============================================================================
+
+describe('ArmorPipRing — archetype layouts', () => {
+  it('renders 6 pips for a quad unit (no arm pips)', () => {
+    const { svg } = renderInSvg(
+      <ArmorPipRing patternKey="q" state={uniformQuad('full')} />,
+    );
+    const dots = svg.querySelectorAll('[data-pip-state]');
+    expect(dots.length).toBe(6);
+  });
+
+  it('renders 8 pips for a biped unit', () => {
+    const { svg } = renderInSvg(
+      <ArmorPipRing patternKey="b" state={uniformBiped('full')} />,
+    );
+    const dots = svg.querySelectorAll('[data-pip-state]');
+    expect(dots.length).toBe(8);
+  });
+
+  it('renders 8 pips for a LAM unit (biped layout)', () => {
+    const { svg } = renderInSvg(
+      <ArmorPipRing patternKey="l" state={lamState('full')} />,
+    );
+    const dots = svg.querySelectorAll('[data-pip-state]');
+    expect(dots.length).toBe(8);
+  });
+});
+
+// =============================================================================
+// Per-location state colors / shape
+// =============================================================================
+
+describe('ArmorPipRing — per-location state', () => {
+  it('partial state paints yellow', () => {
+    const { svg } = renderInSvg(
+      <ArmorPipRing
+        patternKey="p"
+        state={bipedWithOverride('rightArm', 'partial')}
+      />,
+    );
+    const partialDots = svg.querySelectorAll("[data-pip-state='partial']");
+    expect(partialDots.length).toBe(1);
+    expect(partialDots[0].getAttribute('fill')).toBe('#facc15');
+  });
+
+  it('structure state uses the stripe pattern fill', () => {
+    const { svg } = renderInSvg(
+      <ArmorPipRing
+        patternKey="s"
+        state={bipedWithOverride('centerTorso', 'structure')}
+      />,
+    );
+    const structureDots = svg.querySelectorAll("[data-pip-state='structure']");
+    expect(structureDots.length).toBe(1);
+    expect(structureDots[0].getAttribute('fill')).toBe(
+      'url(#armor-pip-stripe-s)',
+    );
+  });
+
+  it('destroyed state renders a red outline with no fill', () => {
+    const { svg } = renderInSvg(
+      <ArmorPipRing
+        patternKey="d"
+        state={bipedWithOverride('leftLeg', 'destroyed')}
+      />,
+    );
+    const destroyedDots = svg.querySelectorAll("[data-pip-state='destroyed']");
+    expect(destroyedDots.length).toBe(1);
+    expect(destroyedDots[0].getAttribute('fill')).toBe('none');
+    expect(destroyedDots[0].getAttribute('stroke')).toBe('#dc2626');
+  });
+
+  it('missing locations are omitted from the ring', () => {
+    const base = uniformBipedLocations('full');
+    const state: ArmorPipState = {
+      archetype: 'humanoid',
+      locations: {
+        ...base,
+        rightArm: 'missing',
+        leftArm: 'missing',
+      },
+    };
+    const { svg } = renderInSvg(<ArmorPipRing patternKey="m" state={state} />);
+    const dots = svg.querySelectorAll('[data-pip-state]');
+    expect(dots.length).toBe(6);
+  });
+});
+
+// =============================================================================
+// Zoom behaviour
+// =============================================================================
+
+describe('ArmorPipRing — zoom behaviour', () => {
+  it('hides the ring entirely below zoom 0.35', () => {
+    const { container } = render(
+      <svg>
+        <ArmorPipRing patternKey="low" zoom={0.3} />
+      </svg>,
+    );
+    expect(
+      container.querySelector("[data-testid='armor-pip-ring']"),
+    ).toBeNull();
+  });
+
+  it('suppresses the stripe pattern below zoom 0.6', () => {
+    const { svg } = renderInSvg(
+      <ArmorPipRing
+        patternKey="simplify"
+        state={bipedWithOverride('centerTorso', 'structure')}
+        zoom={0.5}
+      />,
+    );
+    expect(svg.querySelector('pattern')).toBeNull();
+    const structureDots = svg.querySelectorAll("[data-pip-state='structure']");
+    expect(structureDots[0].getAttribute('fill')).toBe('#f97316');
+  });
+
+  it('emits the stripe pattern at zoom >= 0.6', () => {
+    const { svg } = renderInSvg(
+      <ArmorPipRing
+        patternKey="full-zoom"
+        state={bipedWithOverride('centerTorso', 'structure')}
+        zoom={1}
+      />,
+    );
+    expect(
+      svg.querySelector('pattern#armor-pip-stripe-full-zoom'),
+    ).not.toBeNull();
+  });
+});

--- a/src/components/gameplay/sprites/__tests__/MechSprite.test.tsx
+++ b/src/components/gameplay/sprites/__tests__/MechSprite.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * Tests for MechSprite — the silhouette renderer that sits at a hex.
+ *
+ * Covers:
+ *   - Rotation matches `facing * 60deg` (spec: Built-in Facing Indicator,
+ *     Scenario "Facing rotates sprite and indicator together")
+ *   - Selection ring renders only when `isSelected === true`
+ *   - Side tint applied to both the sprite body and the shape overlay
+ *   - Low-zoom glyph collapse (< 0.6) swaps in the archetype glyph
+ *   - Destroyed units render with the destroyed tint, not the side tint
+ *   - Sprite id resolves to the right archetype × weight
+ *
+ * @spec openspec/changes/add-mech-silhouette-sprite-set/specs/unit-sprite-system/spec.md
+ *        §Built-in Facing Indicator
+ *        §Sprite Scaling
+ *        §Side Tint and Selection Ring
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { WeightClass } from '@/types/enums/WeightClass';
+import { Facing, GameSide } from '@/types/gameplay';
+
+import { MechSprite } from '../MechSprite';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Wrap the sprite in an <svg> so jsdom treats its children correctly. */
+function renderInSvg(ui: React.ReactElement): { svg: SVGSVGElement } {
+  const { container } = render(<svg>{ui}</svg>);
+  return { svg: container.querySelector('svg')! };
+}
+
+type TokenShape = React.ComponentProps<typeof MechSprite>['token'];
+
+function makeToken(overrides: Partial<TokenShape> = {}): TokenShape {
+  return {
+    weightClass: WeightClass.MEDIUM,
+    facing: Facing.North,
+    side: GameSide.Player,
+    isDestroyed: false,
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// Facing rotation
+// =============================================================================
+
+describe('MechSprite — facing rotation', () => {
+  const cases: Array<{ facing: Facing; expected: number }> = [
+    { facing: Facing.North, expected: 0 },
+    { facing: Facing.Northeast, expected: 60 },
+    { facing: Facing.Southeast, expected: 120 },
+    { facing: Facing.South, expected: 180 },
+    { facing: Facing.Southwest, expected: 240 },
+    { facing: Facing.Northwest, expected: 300 },
+  ];
+
+  it.each(cases)(
+    'facing $facing → rotate($expected)',
+    ({ facing, expected }) => {
+      const { svg } = renderInSvg(<MechSprite token={makeToken({ facing })} />);
+      const rotator = svg.querySelector("[data-testid='mech-sprite-rotator']");
+      expect(rotator).not.toBeNull();
+      expect(rotator!.getAttribute('data-rotation-deg')).toBe(String(expected));
+      expect(rotator!.getAttribute('transform')).toBe(`rotate(${expected})`);
+    },
+  );
+});
+
+// =============================================================================
+// Selection ring
+// =============================================================================
+
+describe('MechSprite — selection ring', () => {
+  it('renders the selection ring when isSelected=true', () => {
+    const { svg } = renderInSvg(<MechSprite token={makeToken()} isSelected />);
+    expect(
+      svg.querySelector("[data-testid='mech-sprite-selection-ring']"),
+    ).not.toBeNull();
+  });
+
+  it('does not render the selection ring by default', () => {
+    const { svg } = renderInSvg(<MechSprite token={makeToken()} />);
+    expect(
+      svg.querySelector("[data-testid='mech-sprite-selection-ring']"),
+    ).toBeNull();
+  });
+});
+
+// =============================================================================
+// Side tint
+// =============================================================================
+
+describe('MechSprite — side tint', () => {
+  it('applies blue for Player', () => {
+    const { svg } = renderInSvg(
+      <MechSprite token={makeToken({ side: GameSide.Player })} />,
+    );
+    const body = svg.querySelector(
+      "[data-testid='mech-sprite-body']",
+    ) as SVGGElement | null;
+    expect(body).not.toBeNull();
+    expect(body!.getAttribute('style')).toContain('color: rgb(59, 130, 246)');
+  });
+
+  it('applies red for Opponent', () => {
+    const { svg } = renderInSvg(
+      <MechSprite token={makeToken({ side: GameSide.Opponent })} />,
+    );
+    const body = svg.querySelector(
+      "[data-testid='mech-sprite-body']",
+    ) as SVGGElement | null;
+    expect(body!.getAttribute('style')).toContain('color: rgb(239, 68, 68)');
+  });
+
+  it('honors tintOverride for neutral-like units', () => {
+    const { svg } = renderInSvg(
+      <MechSprite token={makeToken()} tintOverride="#9ca3af" />,
+    );
+    const body = svg.querySelector(
+      "[data-testid='mech-sprite-body']",
+    ) as SVGGElement | null;
+    expect(body!.getAttribute('style')).toContain('color: rgb(156, 163, 175)');
+  });
+
+  it('applies gray when destroyed regardless of side', () => {
+    const { svg } = renderInSvg(
+      <MechSprite
+        token={makeToken({ side: GameSide.Player, isDestroyed: true })}
+      />,
+    );
+    const body = svg.querySelector(
+      "[data-testid='mech-sprite-body']",
+    ) as SVGGElement | null;
+    expect(body!.getAttribute('style')).toContain('color: rgb(107, 114, 128)');
+  });
+});
+
+// =============================================================================
+// Colorblind-safe shape overlay
+// =============================================================================
+
+describe('MechSprite — colorblind shape overlay', () => {
+  it('renders a Player shape marker (triangle)', () => {
+    const { svg } = renderInSvg(
+      <MechSprite token={makeToken({ side: GameSide.Player })} />,
+    );
+    expect(
+      svg.querySelector(`[data-testid='sprite-side-shape-${GameSide.Player}']`),
+    ).not.toBeNull();
+  });
+
+  it('renders an Opponent shape marker (square)', () => {
+    const { svg } = renderInSvg(
+      <MechSprite token={makeToken({ side: GameSide.Opponent })} />,
+    );
+    expect(
+      svg.querySelector(
+        `[data-testid='sprite-side-shape-${GameSide.Opponent}']`,
+      ),
+    ).not.toBeNull();
+  });
+});
+
+// =============================================================================
+// Sprite id resolution (archetype × weight)
+// =============================================================================
+
+describe('MechSprite — sprite id resolution', () => {
+  it('picks humanoid-medium by default', () => {
+    const { svg } = renderInSvg(<MechSprite token={makeToken()} />);
+    const sprite = svg.querySelector("[data-testid='mech-sprite']");
+    expect(sprite!.getAttribute('data-sprite-id')).toBe('humanoid-medium');
+  });
+
+  it('picks quad-heavy for a heavy quad', () => {
+    const { svg } = renderInSvg(
+      <MechSprite
+        token={makeToken({ weightClass: WeightClass.HEAVY, isQuad: true })}
+      />,
+    );
+    const sprite = svg.querySelector("[data-testid='mech-sprite']");
+    expect(sprite!.getAttribute('data-sprite-id')).toBe('quad-heavy');
+  });
+
+  it('picks lam-assault for an assault LAM', () => {
+    const { svg } = renderInSvg(
+      <MechSprite
+        token={makeToken({ weightClass: WeightClass.ASSAULT, isLAM: true })}
+      />,
+    );
+    const sprite = svg.querySelector("[data-testid='mech-sprite']");
+    expect(sprite!.getAttribute('data-sprite-id')).toBe('lam-assault');
+  });
+});
+
+// =============================================================================
+// Zoom behaviour
+// =============================================================================
+
+describe('MechSprite — zoom behaviour', () => {
+  it('renders the full silhouette at zoom >= 0.6', () => {
+    const { svg } = renderInSvg(<MechSprite token={makeToken()} zoom={0.8} />);
+    expect(
+      svg.querySelector("[data-testid='mech-sprite-body']"),
+    ).not.toBeNull();
+    expect(svg.querySelector("[data-testid='mech-sprite-glyph']")).toBeNull();
+  });
+
+  it('collapses to the archetype glyph at zoom < 0.6', () => {
+    const { svg } = renderInSvg(<MechSprite token={makeToken()} zoom={0.4} />);
+    expect(svg.querySelector("[data-testid='mech-sprite-body']")).toBeNull();
+    expect(
+      svg.querySelector("[data-testid='mech-sprite-glyph']"),
+    ).not.toBeNull();
+  });
+
+  it('reports zoom mode via data-zoom-mode attribute', () => {
+    const { svg: fullSvg } = renderInSvg(
+      <MechSprite token={makeToken()} zoom={1} />,
+    );
+    expect(
+      fullSvg
+        .querySelector("[data-testid='mech-sprite']")!
+        .getAttribute('data-zoom-mode'),
+    ).toBe('full');
+
+    const { svg: glyphSvg } = renderInSvg(
+      <MechSprite token={makeToken()} zoom={0.3} />,
+    );
+    expect(
+      glyphSvg
+        .querySelector("[data-testid='mech-sprite']")!
+        .getAttribute('data-zoom-mode'),
+    ).toBe('glyph');
+  });
+});

--- a/src/components/gameplay/sprites/spriteCatalog.ts
+++ b/src/components/gameplay/sprites/spriteCatalog.ts
@@ -1,0 +1,347 @@
+/**
+ * Sprite catalog — inline SVG strings for the 12 homemade mech silhouettes.
+ *
+ * Why inline (not <image href>): jsdom tests cannot load external SVGs, and
+ * inline sprites let callers retint via `currentColor` + CSS filter without
+ * an extra network round-trip. The file-based assets under
+ * `public/sprites/mechs/*.svg` mirror these exactly and exist to satisfy
+ * the spec's "file SHALL live under public/sprites/mechs/" scenario plus
+ * any caller that prefers URL-based loading.
+ *
+ * Design notes:
+ *   - viewBox is 200×200 for all sprites. Anchor is center (100,100).
+ *   - Sprites face "north" (up) by default; the `MechSprite` component
+ *     applies `rotate(facing*60)` about the center.
+ *   - Every silhouette carries a `<polygon id="facing-notch">` at the top
+ *     (north side) so the facing cue rotates with the sprite — no separate
+ *     overlay.
+ *   - Fills use `currentColor` so parent `color` CSS drives the tint. Side
+ *     color is delivered via the wrapper's `color` style, not baked in.
+ *   - Every silhouette is HOMEMADE — geometric primitives only (rect,
+ *     polygon, circle, path). No reference to licensed BattleTech art.
+ *   - Weight classes are expressed via chassis girth and head/torso bulk:
+ *       light   — slim limbs, small head, narrow torso
+ *       medium  — balanced proportions
+ *       heavy   — broader torso, chunkier limbs, larger shoulders
+ *       assault — widest silhouette, pauldron blocks, squared-off legs
+ *   - Archetypes:
+ *       humanoid — biped with two arms, two legs, centered head
+ *       quad     — four legs (front/rear pairs), no arms, wider centered body
+ *       lam      — humanoid plus symmetric wing stubs flanking the torso
+ *
+ * @spec openspec/changes/add-mech-silhouette-sprite-set/specs/unit-sprite-system/spec.md
+ *        §Homemade Silhouette Sprite Catalog
+ */
+
+import type { ChassisArchetype, SpriteWeightBucket } from '@/types/gameplay';
+
+// =============================================================================
+// Shared constants
+// =============================================================================
+
+/** Standard viewBox for every sprite. */
+export const SPRITE_VIEWBOX = '0 0 200 200';
+export const SPRITE_VIEWBOX_SIZE = 200;
+export const SPRITE_ANCHOR_X = 100;
+export const SPRITE_ANCHOR_Y = 100;
+
+/**
+ * Facing-notch polygon, drawn near the top of the viewBox. This exact
+ * marker appears in every silhouette so test assertions can locate it by
+ * `id="facing-notch"`.
+ *
+ * @why A 14×16 triangular notch sits well above the head even on the
+ *      lightest silhouette, so rotating the sprite visually sells the
+ *      unit's facing direction.
+ */
+const FACING_NOTCH = `<polygon id="facing-notch" points="100,10 92,28 108,28" fill="currentColor" stroke="black" stroke-width="1.5" />`;
+
+// =============================================================================
+// Humanoid (biped) silhouettes — light / medium / heavy / assault
+// =============================================================================
+
+const HUMANOID_LIGHT = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="${SPRITE_VIEWBOX}" data-archetype="humanoid" data-weight="light">
+  ${FACING_NOTCH}
+  <!-- head -->
+  <rect x="90" y="28" width="20" height="18" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- narrow torso -->
+  <rect x="82" y="48" width="36" height="52" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- slim arms -->
+  <rect x="68" y="52" width="12" height="46" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="120" y="52" width="12" height="46" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- slim legs -->
+  <rect x="84" y="102" width="14" height="64" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="102" width="14" height="64" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- feet -->
+  <rect x="80" y="166" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="166" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>`.trim();
+
+const HUMANOID_MEDIUM = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="${SPRITE_VIEWBOX}" data-archetype="humanoid" data-weight="medium">
+  ${FACING_NOTCH}
+  <!-- head -->
+  <rect x="88" y="26" width="24" height="22" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- torso -->
+  <rect x="76" y="50" width="48" height="56" rx="5" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- arms -->
+  <rect x="58" y="54" width="16" height="52" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="126" y="54" width="16" height="52" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- legs -->
+  <rect x="80" y="108" width="18" height="64" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="108" width="18" height="64" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- feet -->
+  <rect x="74" y="172" width="28" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="172" width="28" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>`.trim();
+
+const HUMANOID_HEAVY = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="${SPRITE_VIEWBOX}" data-archetype="humanoid" data-weight="heavy">
+  ${FACING_NOTCH}
+  <!-- head -->
+  <rect x="86" y="26" width="28" height="22" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- pauldrons (big shoulders) -->
+  <polygon points="54,62 80,50 80,78 54,82" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="146,62 120,50 120,78 146,82" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- broad torso -->
+  <rect x="70" y="50" width="60" height="58" rx="6" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- chunky arms -->
+  <rect x="54" y="62" width="18" height="50" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="128" y="62" width="18" height="50" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- legs -->
+  <rect x="78" y="110" width="20" height="60" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="110" width="20" height="60" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- broad feet -->
+  <rect x="70" y="170" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="170" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>`.trim();
+
+const HUMANOID_ASSAULT = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="${SPRITE_VIEWBOX}" data-archetype="humanoid" data-weight="assault">
+  ${FACING_NOTCH}
+  <!-- head -->
+  <rect x="84" y="24" width="32" height="24" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- big block pauldrons -->
+  <rect x="46" y="52" width="28" height="34" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="126" y="52" width="28" height="34" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- massive torso -->
+  <rect x="64" y="50" width="72" height="62" rx="6" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- arm stubs -->
+  <rect x="46" y="86" width="22" height="38" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="132" y="86" width="22" height="38" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- thick legs -->
+  <rect x="74" y="114" width="24" height="56" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="114" width="24" height="56" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- wide feet -->
+  <rect x="66" y="170" width="36" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="170" width="36" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>`.trim();
+
+// =============================================================================
+// Quad silhouettes — light / medium / heavy / assault (no arms, 4 legs)
+// =============================================================================
+
+const QUAD_LIGHT = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="${SPRITE_VIEWBOX}" data-archetype="quad" data-weight="light">
+  ${FACING_NOTCH}
+  <!-- small head -->
+  <polygon points="90,32 110,32 100,46" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- narrow body -->
+  <rect x="64" y="46" width="72" height="48" rx="6" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- front-left / front-right legs -->
+  <rect x="54" y="88" width="14" height="56" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="132" y="88" width="14" height="56" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- rear-left / rear-right legs -->
+  <rect x="72" y="94" width="14" height="64" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="114" y="94" width="14" height="64" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- feet -->
+  <rect x="50" y="142" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="128" y="142" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="68" y="156" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="110" y="156" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>`.trim();
+
+const QUAD_MEDIUM = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="${SPRITE_VIEWBOX}" data-archetype="quad" data-weight="medium">
+  ${FACING_NOTCH}
+  <polygon points="88,30 112,30 100,48" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="58" y="48" width="84" height="52" rx="8" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="48" y="94" width="18" height="58" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="134" y="94" width="18" height="58" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="68" y="100" width="18" height="64" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="114" y="100" width="18" height="64" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="42" y="150" width="26" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="132" y="150" width="26" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="62" y="162" width="26" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="112" y="162" width="26" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>`.trim();
+
+const QUAD_HEAVY = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="${SPRITE_VIEWBOX}" data-archetype="quad" data-weight="heavy">
+  ${FACING_NOTCH}
+  <polygon points="86,28 114,28 100,50" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="50" y="48" width="100" height="58" rx="8" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="40" y="96" width="22" height="62" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="138" y="96" width="22" height="62" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="64" y="104" width="22" height="66" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="114" y="104" width="22" height="66" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="34" y="156" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="134" y="156" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="58" y="168" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="110" y="168" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>`.trim();
+
+const QUAD_ASSAULT = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="${SPRITE_VIEWBOX}" data-archetype="quad" data-weight="assault">
+  ${FACING_NOTCH}
+  <polygon points="84,26 116,26 100,52" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="44" y="48" width="112" height="64" rx="10" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- armored flank plates -->
+  <rect x="40" y="62" width="14" height="44" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="146" y="62" width="14" height="44" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="34" y="102" width="26" height="60" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="140" y="102" width="26" height="60" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="62" y="108" width="26" height="66" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="112" y="108" width="26" height="66" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="28" y="160" width="38" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="134" y="160" width="38" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="56" y="172" width="38" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="106" y="172" width="38" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>`.trim();
+
+// =============================================================================
+// LAM silhouettes — humanoid + wing stubs
+// =============================================================================
+
+const LAM_LIGHT = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="${SPRITE_VIEWBOX}" data-archetype="lam" data-weight="light">
+  ${FACING_NOTCH}
+  <!-- angled wing stubs -->
+  <polygon points="40,70 82,60 82,96 40,90" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="160,70 118,60 118,96 160,90" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- head -->
+  <rect x="90" y="28" width="20" height="18" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- torso -->
+  <rect x="82" y="48" width="36" height="52" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- arms -->
+  <rect x="68" y="52" width="12" height="46" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="120" y="52" width="12" height="46" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <!-- legs -->
+  <rect x="84" y="102" width="14" height="64" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="102" width="14" height="64" rx="3" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="80" y="166" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="166" width="22" height="8" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>`.trim();
+
+const LAM_MEDIUM = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="${SPRITE_VIEWBOX}" data-archetype="lam" data-weight="medium">
+  ${FACING_NOTCH}
+  <polygon points="32,72 76,60 76,102 32,96" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="168,72 124,60 124,102 168,96" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="88" y="26" width="24" height="22" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="76" y="50" width="48" height="56" rx="5" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="58" y="54" width="16" height="52" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="126" y="54" width="16" height="52" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="80" y="108" width="18" height="64" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="108" width="18" height="64" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="74" y="172" width="28" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="172" width="28" height="10" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>`.trim();
+
+const LAM_HEAVY = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="${SPRITE_VIEWBOX}" data-archetype="lam" data-weight="heavy">
+  ${FACING_NOTCH}
+  <polygon points="26,74 70,60 70,106 26,100" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="174,74 130,60 130,106 174,100" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="86" y="26" width="28" height="22" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="70" y="50" width="60" height="58" rx="6" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="54" y="62" width="18" height="50" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="128" y="62" width="18" height="50" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="78" y="110" width="20" height="60" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="110" width="20" height="60" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="70" y="170" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="170" width="32" height="12" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>`.trim();
+
+const LAM_ASSAULT = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="${SPRITE_VIEWBOX}" data-archetype="lam" data-weight="assault">
+  ${FACING_NOTCH}
+  <polygon points="20,76 64,58 64,110 20,104" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <polygon points="180,76 136,58 136,110 180,104" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="84" y="24" width="32" height="24" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="64" y="50" width="72" height="62" rx="6" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="46" y="86" width="22" height="38" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="132" y="86" width="22" height="38" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="74" y="114" width="24" height="56" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="102" y="114" width="24" height="56" rx="4" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="66" y="170" width="36" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+  <rect x="98" y="170" width="36" height="14" rx="2" fill="currentColor" stroke="black" stroke-width="1.5" />
+</svg>`.trim();
+
+// =============================================================================
+// Catalog map — (archetype, weight) -> inline SVG string
+// =============================================================================
+
+/**
+ * All 12 homemade silhouettes, keyed by `${archetype}-${weight}`.
+ *
+ * @why One flat map keeps lookups O(1) and makes "every combo" test
+ *      enumeration trivial — the test iterates catalog keys and asserts
+ *      each one decodes to a valid bundle.
+ */
+export const SPRITE_CATALOG: Readonly<Record<string, string>> = {
+  'humanoid-light': HUMANOID_LIGHT,
+  'humanoid-medium': HUMANOID_MEDIUM,
+  'humanoid-heavy': HUMANOID_HEAVY,
+  'humanoid-assault': HUMANOID_ASSAULT,
+  'quad-light': QUAD_LIGHT,
+  'quad-medium': QUAD_MEDIUM,
+  'quad-heavy': QUAD_HEAVY,
+  'quad-assault': QUAD_ASSAULT,
+  'lam-light': LAM_LIGHT,
+  'lam-medium': LAM_MEDIUM,
+  'lam-heavy': LAM_HEAVY,
+  'lam-assault': LAM_ASSAULT,
+};
+
+/**
+ * Compose the catalog key for a given archetype × weight combination.
+ *
+ * @why Having a single function for this guarantees the selector and the
+ *      renderer agree on key formatting.
+ */
+export function spriteId(
+  archetype: ChassisArchetype,
+  weight: SpriteWeightBucket,
+): string {
+  return `${archetype}-${weight}`;
+}
+
+/**
+ * Pull the raw inline SVG string for a given archetype × weight.
+ *
+ * @throws never — falls back to `humanoid-medium` if a key is missing, so
+ *         the renderer never crashes on bad input.
+ */
+export function getSpriteSvg(
+  archetype: ChassisArchetype,
+  weight: SpriteWeightBucket,
+): string {
+  const id = spriteId(archetype, weight);
+  return SPRITE_CATALOG[id] ?? SPRITE_CATALOG['humanoid-medium'];
+}
+
+/**
+ * Tiny archetype glyph shown at low zoom. Three small SVG primitives,
+ * each 24×24 with the side color applied via `currentColor`.
+ *
+ * @why Below zoom 0.6 the full silhouette is illegible — the glyph keeps
+ *      archetype recognisable without stroke-width hacks.
+ */
+export const ARCHETYPE_GLYPHS: Readonly<Record<ChassisArchetype, string>> = {
+  humanoid:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><polygon points="12,3 21,21 3,21" fill="currentColor" stroke="black" stroke-width="1" /></svg>',
+  quad: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" fill="currentColor" stroke="black" stroke-width="1" /></svg>',
+  lam: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><polygon points="12,2 22,12 12,22 2,12" fill="currentColor" stroke="black" stroke-width="1" /></svg>',
+};

--- a/src/types/gameplay/GameplayUIInterfaces.ts
+++ b/src/types/gameplay/GameplayUIInterfaces.ts
@@ -5,6 +5,10 @@
  * @spec openspec/changes/add-gameplay-ui/specs/gameplay-ui/spec.md
  */
 
+import { WeightClass } from '@/types/enums/WeightClass';
+
+import type { ArmorPipState, ChassisArchetype } from './UnitSpriteTypes';
+
 import { GamePhase, GameSide, IToHitModifier } from './GameSessionInterfaces';
 import { IHexCoordinate, Facing, MovementType } from './HexGridInterfaces';
 
@@ -206,6 +210,30 @@ export interface IUnitToken {
   readonly isGlider?: boolean;
   /** Has main gun equipped. */
   readonly hasMainGun?: boolean;
+
+  // -------------------------------------------------------------------------
+  // Mech-sprite-system fields (optional — consumed by `MechSprite` +
+  // `ArmorPipRing`; see add-mech-silhouette-sprite-set/specs/unit-sprite-system).
+  // When any of these is absent, the renderer falls back to the
+  // "medium humanoid, undamaged" silhouette so Phase-1 callers keep
+  // rendering cleanly.
+  // -------------------------------------------------------------------------
+  /** Tonnage-class bucket used to pick the sprite's weight silhouette. */
+  readonly weightClass?: WeightClass;
+  /**
+   * Silhouette archetype override. When absent, a biped with `isQuad ||
+   * isLAM` flags drives selection; otherwise the humanoid sprite is used.
+   */
+  readonly chassisArchetype?: ChassisArchetype;
+  /** Is this a quadruped 'Mech chassis? Feeds sprite selection. */
+  readonly isQuad?: boolean;
+  /** Is this a Land-Air 'Mech? Feeds sprite selection. */
+  readonly isLAM?: boolean;
+  /**
+   * Per-location armor+structure state for the damage pip ring. When
+   * absent, the ring renders every location as `full` (fresh-off-the-lot).
+   */
+  readonly armorPipState?: ArmorPipState;
 }
 
 // =============================================================================

--- a/src/types/gameplay/UnitSpriteTypes.ts
+++ b/src/types/gameplay/UnitSpriteTypes.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit Sprite Types — shared types for the mech silhouette sprite system.
+ *
+ * Why a dedicated file: the sprite layer adds a few enums and a small set
+ * of interfaces that are consumed by three different modules (the sprite
+ * selector, the MechSprite component, and the armor-pip ring). Grouping
+ * them here keeps `GameplayUIInterfaces.ts` from ballooning while still
+ * re-exporting through `@/types/gameplay`.
+ *
+ * @spec openspec/changes/add-mech-silhouette-sprite-set/specs/unit-sprite-system/spec.md
+ */
+
+import { WeightClass } from '@/types/enums/WeightClass';
+
+// =============================================================================
+// Chassis archetype
+// =============================================================================
+
+/**
+ * Three silhouette archetypes covered by the sprite set.
+ *
+ * Why a discriminated string literal (not a class hierarchy): we only ever
+ * branch on this value in the selector and the pip-ring layout — an enum
+ * plus `switch` is smaller and friendlier to exhaustiveness checking.
+ *
+ * - `humanoid` — standard biped BattleMech
+ * - `quad`     — four-legged mech (no arm locations, two front + two rear legs)
+ * - `lam`      — Land-Air 'Mech (humanoid on the ground, extends wings in air)
+ */
+export type ChassisArchetype = 'humanoid' | 'quad' | 'lam';
+
+// =============================================================================
+// Sprite-facing weight-class bucket
+// =============================================================================
+
+/**
+ * Four weight buckets the sprite catalog ships silhouettes for.
+ *
+ * Why not reuse `WeightClass` directly: the game's `WeightClass` enum has
+ * six values (Ultralight/Light/Medium/Heavy/Assault/Superheavy), but the
+ * spec only demands four silhouettes. We collapse Ultralight → light and
+ * Superheavy → assault at the selector boundary so the catalog stays small.
+ */
+export type SpriteWeightBucket = 'light' | 'medium' | 'heavy' | 'assault';
+
+/**
+ * Collapse the full `WeightClass` enum into the 4-bucket sprite space.
+ *
+ * @why Callers typically hold a `WeightClass` (from the unit's tonnage) —
+ *      this keeps the downshift logic in one place.
+ */
+export function weightClassToBucket(
+  weightClass: WeightClass | undefined,
+): SpriteWeightBucket {
+  switch (weightClass) {
+    case WeightClass.ULTRALIGHT:
+    case WeightClass.LIGHT:
+      return 'light';
+    case WeightClass.MEDIUM:
+      return 'medium';
+    case WeightClass.HEAVY:
+      return 'heavy';
+    case WeightClass.ASSAULT:
+    case WeightClass.SUPERHEAVY:
+      return 'assault';
+    default:
+      // Missing weightClass → default to medium (Scenario: Missing archetype
+      // falls back to humanoid is for archetype; weight gets medium as the
+      // neutral middle-of-the-road silhouette).
+      return 'medium';
+  }
+}
+
+// =============================================================================
+// Armor-pip location state
+// =============================================================================
+
+/**
+ * Per-location armor + structure state rendered by `ArmorPipRing`.
+ *
+ * Why five discrete states (not raw numbers): the pip ring only needs to
+ * pick a color / pattern, not render exact pip counts. Discretising here
+ * lets callers project arbitrary armor/structure math (or receive stub
+ * data during development) without the ring re-implementing it.
+ */
+export type PipLocationState =
+  | 'full' // armor ≥ max (no damage)
+  | 'partial' // 0 < armor < max (some armor remains)
+  | 'structure' // armor === 0, internal structure exposed
+  | 'destroyed' // structure === 0, location lost
+  | 'missing'; // location does not exist on this archetype
+
+/**
+ * Biped location keys — eight pip groups around the silhouette.
+ * Matches standard BattleMech hit-location labels.
+ */
+export type BipedPipLocation =
+  | 'head'
+  | 'centerTorso'
+  | 'leftTorso'
+  | 'rightTorso'
+  | 'leftArm'
+  | 'rightArm'
+  | 'leftLeg'
+  | 'rightLeg';
+
+/**
+ * Quad location keys — six pip groups (no arms, legs split front/rear).
+ */
+export type QuadPipLocation =
+  | 'head'
+  | 'centerTorso'
+  | 'frontLeftLeg'
+  | 'frontRightLeg'
+  | 'rearLeftLeg'
+  | 'rearRightLeg';
+
+/**
+ * Discriminated per-archetype armor state. Callers pass whichever shape
+ * matches the unit; the ring switches on `archetype` to pick the layout.
+ */
+export type ArmorPipState =
+  | {
+      readonly archetype: 'humanoid';
+      readonly locations: Record<BipedPipLocation, PipLocationState>;
+    }
+  | {
+      readonly archetype: 'quad';
+      readonly locations: Record<QuadPipLocation, PipLocationState>;
+    }
+  | {
+      readonly archetype: 'lam';
+      readonly locations: Record<BipedPipLocation, PipLocationState>;
+    };
+
+// =============================================================================
+// Sprite metadata (returned by the selector)
+// =============================================================================
+
+/**
+ * Resolved sprite bundle — the selector returns this so the renderer has
+ * everything needed to paint without re-running selection logic.
+ *
+ * - `assetUrl`   — path under `public/sprites/mechs/` (satisfies the
+ *                  "file SHALL live under public/sprites/mechs" scenario).
+ * - `viewBox`    — source SVG viewBox string (e.g. "0 0 200 200").
+ * - `anchor`     — center-of-mass offset in viewBox units (for precise hex
+ *                  centering; most sprites anchor at 100,100).
+ * - `weight`     — resolved bucket.
+ * - `archetype`  — resolved archetype.
+ * - `spriteId`   — stable id, e.g. `humanoid-heavy`.
+ */
+export interface ISpriteBundle {
+  readonly spriteId: string;
+  readonly assetUrl: string;
+  readonly viewBox: string;
+  readonly anchor: { readonly x: number; readonly y: number };
+  readonly weight: SpriteWeightBucket;
+  readonly archetype: ChassisArchetype;
+}

--- a/src/types/gameplay/index.ts
+++ b/src/types/gameplay/index.ts
@@ -25,6 +25,9 @@ export * from './CombatInterfaces';
 // Gameplay UI
 export * from './GameplayUIInterfaces';
 
+// Unit Sprite System (Phase 7 visual layer — mech silhouettes + pip ring)
+export * from './UnitSpriteTypes';
+
 // Vehicle Combat Behavior
 export * from './VehicleCombatInterfaces';
 

--- a/src/utils/sprites/__tests__/spriteSelector.test.ts
+++ b/src/utils/sprites/__tests__/spriteSelector.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for spriteSelector — resolution for every weight × archetype combo.
+ *
+ * Covers:
+ *   - Every (4 weight × 3 archetype) combination returns a unique bundle.
+ *   - `isQuad` forces quad archetype; `isLAM` forces lam archetype.
+ *   - No archetype flags → humanoid (spec scenario "Missing archetype falls
+ *     back to humanoid").
+ *   - Explicit `chassisArchetype` wins over flags.
+ *   - Weight collapse: ULTRALIGHT → light, SUPERHEAVY → assault.
+ *   - Missing weightClass → medium default.
+ *   - `assetUrl` always points under `/sprites/mechs/`.
+ *
+ * @spec openspec/changes/add-mech-silhouette-sprite-set/specs/unit-sprite-system/spec.md
+ */
+
+import type { ChassisArchetype, SpriteWeightBucket } from '@/types/gameplay';
+
+import { WeightClass } from '@/types/enums/WeightClass';
+
+import { ALL_SPRITE_COMBOS, selectSprite } from '../spriteSelector';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const WEIGHT_BY_BUCKET: Record<SpriteWeightBucket, WeightClass> = {
+  light: WeightClass.LIGHT,
+  medium: WeightClass.MEDIUM,
+  heavy: WeightClass.HEAVY,
+  assault: WeightClass.ASSAULT,
+};
+
+function inputFor(archetype: ChassisArchetype, bucket: SpriteWeightBucket) {
+  return {
+    weightClass: WEIGHT_BY_BUCKET[bucket],
+    isQuad: archetype === 'quad',
+    isLAM: archetype === 'lam',
+  };
+}
+
+// =============================================================================
+// Complete coverage — every weight × archetype combo
+// =============================================================================
+
+describe('selectSprite — full catalog coverage', () => {
+  it('returns exactly one bundle per combination with correct spriteId', () => {
+    for (const { archetype, weight } of ALL_SPRITE_COMBOS) {
+      const bundle = selectSprite(inputFor(archetype, weight));
+      expect(bundle.archetype).toBe(archetype);
+      expect(bundle.weight).toBe(weight);
+      expect(bundle.spriteId).toBe(`${archetype}-${weight}`);
+    }
+  });
+
+  it('returns a unique spriteId for every combo (no collisions)', () => {
+    const ids = ALL_SPRITE_COMBOS.map(
+      ({ archetype, weight }) =>
+        selectSprite(inputFor(archetype, weight)).spriteId,
+    );
+    expect(new Set(ids).size).toBe(12);
+  });
+
+  it('assetUrl lives under /sprites/mechs/ and matches spriteId', () => {
+    for (const { archetype, weight } of ALL_SPRITE_COMBOS) {
+      const bundle = selectSprite(inputFor(archetype, weight));
+      expect(bundle.assetUrl).toBe(`/sprites/mechs/${bundle.spriteId}.svg`);
+    }
+  });
+});
+
+// =============================================================================
+// Archetype override + fallback behavior
+// =============================================================================
+
+describe('selectSprite — archetype resolution', () => {
+  it('isQuad → quad archetype', () => {
+    const bundle = selectSprite({
+      weightClass: WeightClass.MEDIUM,
+      isQuad: true,
+    });
+    expect(bundle.archetype).toBe('quad');
+  });
+
+  it('isLAM → lam archetype', () => {
+    const bundle = selectSprite({
+      weightClass: WeightClass.HEAVY,
+      isLAM: true,
+    });
+    expect(bundle.archetype).toBe('lam');
+  });
+
+  it('no archetype flags → humanoid fallback', () => {
+    const bundle = selectSprite({ weightClass: WeightClass.LIGHT });
+    expect(bundle.archetype).toBe('humanoid');
+  });
+
+  it('explicit chassisArchetype wins over flags', () => {
+    const bundle = selectSprite({
+      weightClass: WeightClass.MEDIUM,
+      chassisArchetype: 'humanoid',
+      isQuad: true,
+      isLAM: true,
+    });
+    expect(bundle.archetype).toBe('humanoid');
+  });
+
+  it('LAM flag wins over quad when both are set (no archetype override)', () => {
+    const bundle = selectSprite({
+      weightClass: WeightClass.MEDIUM,
+      isQuad: true,
+      isLAM: true,
+    });
+    expect(bundle.archetype).toBe('lam');
+  });
+});
+
+// =============================================================================
+// Weight bucket collapse
+// =============================================================================
+
+describe('selectSprite — weight bucket collapse', () => {
+  it('ULTRALIGHT → light bucket', () => {
+    const bundle = selectSprite({ weightClass: WeightClass.ULTRALIGHT });
+    expect(bundle.weight).toBe('light');
+  });
+
+  it('SUPERHEAVY → assault bucket', () => {
+    const bundle = selectSprite({ weightClass: WeightClass.SUPERHEAVY });
+    expect(bundle.weight).toBe('assault');
+  });
+
+  it('undefined weightClass → medium default', () => {
+    const bundle = selectSprite({});
+    expect(bundle.weight).toBe('medium');
+    expect(bundle.archetype).toBe('humanoid');
+    expect(bundle.spriteId).toBe('humanoid-medium');
+  });
+});
+
+// =============================================================================
+// Viewbox / anchor contract
+// =============================================================================
+
+describe('selectSprite — metadata contract', () => {
+  it('viewBox is "0 0 200 200" for every sprite', () => {
+    for (const { archetype, weight } of ALL_SPRITE_COMBOS) {
+      const bundle = selectSprite(inputFor(archetype, weight));
+      expect(bundle.viewBox).toBe('0 0 200 200');
+    }
+  });
+
+  it('anchor is centered at (100, 100)', () => {
+    const bundle = selectSprite({ weightClass: WeightClass.MEDIUM });
+    expect(bundle.anchor).toEqual({ x: 100, y: 100 });
+  });
+});

--- a/src/utils/sprites/spriteSelector.ts
+++ b/src/utils/sprites/spriteSelector.ts
@@ -1,0 +1,107 @@
+/**
+ * Sprite selector — resolves the correct silhouette for a given unit.
+ *
+ * Decision flow:
+ *   1. Archetype comes from (in priority order):
+ *        explicit `token.chassisArchetype`
+ *        →  `token.isLAM` → 'lam'
+ *        →  `token.isQuad` → 'quad'
+ *        →  default 'humanoid' (Scenario: Missing archetype falls back to humanoid)
+ *   2. Weight bucket comes from `token.weightClass` via `weightClassToBucket`.
+ *   3. Sprite bundle is assembled from the (archetype, weight) key and returned.
+ *
+ * Why on a token-shaped input: the render layer already works off `IUnitToken`,
+ * so threading a full construction-domain `Unit` through would pull unrelated
+ * types into the presentation layer. This keeps the sprite selector dependency
+ * set tiny.
+ *
+ * @spec openspec/changes/add-mech-silhouette-sprite-set/specs/unit-sprite-system/spec.md
+ *        §Homemade Silhouette Sprite Catalog
+ */
+
+import type { IUnitToken } from '@/types/gameplay';
+import type {
+  ChassisArchetype,
+  ISpriteBundle,
+  SpriteWeightBucket,
+} from '@/types/gameplay';
+
+import { spriteId } from '@/components/gameplay/sprites/spriteCatalog';
+import {
+  SPRITE_ANCHOR_X,
+  SPRITE_ANCHOR_Y,
+  SPRITE_VIEWBOX,
+} from '@/components/gameplay/sprites/spriteCatalog';
+import { weightClassToBucket } from '@/types/gameplay';
+
+/**
+ * Token-shape subset that feeds the selector. Accepting a wide `Pick`
+ * (instead of the full `IUnitToken`) keeps tests lightweight — callers
+ * only need to construct the four fields that matter here.
+ */
+export type SpriteSelectorInput = Pick<
+  IUnitToken,
+  'weightClass' | 'chassisArchetype' | 'isQuad' | 'isLAM'
+>;
+
+/**
+ * Derive the archetype, honouring explicit override first, then LAM, then
+ * quad, then humanoid.
+ *
+ * @why Explicit override wins so callers that already know the archetype
+ *      can skip the `isQuad`/`isLAM` plumbing. The LAM-before-quad order
+ *      matters because a hypothetical quad-LAM isn't in the spec — but if
+ *      both flags land truthy we treat LAM as the stronger signal (LAMs
+ *      transform; quadhood rarely co-exists with it in canon anyway).
+ */
+function resolveArchetype(input: SpriteSelectorInput): ChassisArchetype {
+  if (input.chassisArchetype) return input.chassisArchetype;
+  if (input.isLAM) return 'lam';
+  if (input.isQuad) return 'quad';
+  return 'humanoid';
+}
+
+/**
+ * Resolve the sprite bundle for a token.
+ *
+ * The returned `assetUrl` points to the real file under
+ * `public/sprites/mechs/` so URL-based consumers (future Storybook art
+ * reviews, CDN workflows) keep working. The runtime React renderer uses
+ * the inline SVG from `spriteCatalog`, but the URL is stable contract.
+ */
+export function selectSprite(input: SpriteSelectorInput): ISpriteBundle {
+  const archetype = resolveArchetype(input);
+  const weight: SpriteWeightBucket = weightClassToBucket(input.weightClass);
+  const id = spriteId(archetype, weight);
+  return {
+    spriteId: id,
+    assetUrl: `/sprites/mechs/${id}.svg`,
+    viewBox: SPRITE_VIEWBOX,
+    anchor: { x: SPRITE_ANCHOR_X, y: SPRITE_ANCHOR_Y },
+    weight,
+    archetype,
+  };
+}
+
+/**
+ * Enumerate every (archetype × weight) combination the catalog covers.
+ * Used by tests to assert 100% coverage and by Storybook art reviews to
+ * render the full matrix.
+ */
+export const ALL_SPRITE_COMBOS: ReadonlyArray<{
+  archetype: ChassisArchetype;
+  weight: SpriteWeightBucket;
+}> = Object.freeze([
+  { archetype: 'humanoid', weight: 'light' },
+  { archetype: 'humanoid', weight: 'medium' },
+  { archetype: 'humanoid', weight: 'heavy' },
+  { archetype: 'humanoid', weight: 'assault' },
+  { archetype: 'quad', weight: 'light' },
+  { archetype: 'quad', weight: 'medium' },
+  { archetype: 'quad', weight: 'heavy' },
+  { archetype: 'quad', weight: 'assault' },
+  { archetype: 'lam', weight: 'light' },
+  { archetype: 'lam', weight: 'medium' },
+  { archetype: 'lam', weight: 'heavy' },
+  { archetype: 'lam', weight: 'assault' },
+]);


### PR DESCRIPTION
## Summary

- Replaces the Phase-1 abstract disc marker with a homemade mech silhouette sprite system: 12 handcrafted SVGs keyed by weight class (light/medium/heavy/assault) x archetype (humanoid biped, quad, LAM), each with a baked-in facing notch so rotation carries the indicator.
- Adds `MechSprite` (rotation, side tint, selection ring, colorblind-safe shape overlay, low-zoom archetype-glyph collapse) and `ArmorPipRing` (6/8 location pips, state-driven colour + stripe pattern for structure, simplification + cutoff at low zoom).
- Rewires `MechToken` to compose the new sprite + pip ring while preserving hit-testing, selection binding, active-target pulse, destroyed cross, designation label (10px floor), and damage-feedback overlays. Respects `prefers-reduced-motion`.

## Spec

Delta merged:
- New `openspec/specs/unit-sprite-system/spec.md`
- New requirement `Unit Token Rendering Uses Sprite System` in `openspec/specs/tactical-map-interface/spec.md`

Change folder `openspec/changes/add-mech-silhouette-sprite-set/` retained per instructions (not archived).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx oxfmt --check .` clean
- [x] New unit tests: `MechSprite` rotation for all 6 facings, selection ring visibility, side tint, colorblind-shape overlay, sprite id resolution, zoom mode
- [x] New unit tests: `ArmorPipRing` default/biped/quad/LAM layouts, per-location colours, stripe pattern for structure, destroyed outline, missing omitted, zoom cutoffs
- [x] Full Jest suite: 21,639 passed / 44 skipped / 0 failed
- [ ] Visual sanity check in dev server (reviewer)