### PR TITLE
ci: fan out Lint and Test into parallel jobs

### DIFF
--- a/.github/actions/setup-node-and-install/action.yml
+++ b/.github/actions/setup-node-and-install/action.yml
@@ -15,6 +15,11 @@ inputs:
     required: false
     default: 'false'
 
+outputs:
+  node-modules-cache-hit:
+    description: Whether node_modules cache was restored (true means npm ci was skipped)
+    value: ${{ steps.node-modules-cache.outputs.cache-hit }}
+
 runs:
   using: composite
   steps:
@@ -26,6 +31,15 @@ runs:
         cache-dependency-path: |
           package-lock.json
           desktop/package-lock.json
+
+    - name: Cache node_modules
+      id: node-modules-cache
+      uses: actions/cache@v5
+      with:
+        path: |
+          node_modules
+          desktop/node_modules
+        key: ${{ runner.os }}-node${{ inputs.node-version }}-modules-${{ hashFiles('package-lock.json', 'desktop/package-lock.json') }}
 
     - name: Cache Next.js build cache (.next/cache)
       if: inputs.skip-nextjs-cache != 'true'
@@ -63,10 +77,12 @@ runs:
           mm-data-assets-
 
     - name: Install root dependencies
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
       shell: bash
       run: npm ci
 
     - name: Install desktop dependencies
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: desktop
       run: npm ci

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,10 +10,16 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  lint-and-test:
-    name: Lint and Test
+  # ---------------------------------------------------------------
+  # install-deps runs first so the other lint/test/type/build jobs
+  # can reuse a single `npm ci`. It populates the node_modules cache
+  # keyed on (OS, node version, lockfile hash); fan-out jobs restore
+  # from that cache and skip `npm ci` entirely on a hit.
+  # ---------------------------------------------------------------
+  install-deps:
+    name: Install Dependencies
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
 
     steps:
       - name: Checkout code
@@ -25,20 +31,111 @@ jobs:
           node-version: '20'
           fetch-assets: 'true'
 
+  lint:
+    name: Lint
+    needs: install-deps
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node + caches + install deps
+        uses: ./.github/actions/setup-node-and-install
+        with:
+          node-version: '20'
+
       - name: Run linter
         run: npm run lint
+
+  format-check:
+    name: Format Check
+    needs: install-deps
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node + caches + install deps
+        uses: ./.github/actions/setup-node-and-install
+        with:
+          node-version: '20'
 
       - name: Check formatting
         run: npm run format:check
 
+  typecheck:
+    name: Type Check
+    needs: install-deps
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node + caches + install deps
+        uses: ./.github/actions/setup-node-and-install
+        with:
+          node-version: '20'
+
       - name: Run type check
         run: npx tsc --noEmit
+
+  test:
+    name: Test
+    needs: install-deps
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node + caches + install deps
+        uses: ./.github/actions/setup-node-and-install
+        with:
+          node-version: '20'
 
       - name: Run tests
         run: npm test -- --ci
 
+  validate-bv:
+    name: Validate BV Parity
+    needs: install-deps
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node + caches + install deps
+        uses: ./.github/actions/setup-node-and-install
+        with:
+          node-version: '20'
+          fetch-assets: 'true'
+
       - name: Validate BV parity
         run: npm run validate:bv
+
+  storybook-build:
+    name: Build Storybook
+    needs: install-deps
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node + caches + install deps
+        uses: ./.github/actions/setup-node-and-install
+        with:
+          node-version: '20'
 
       - name: Build Storybook
         run: npm run storybook:build

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -140,6 +140,17 @@ jobs:
       - name: Build Storybook
         run: npm run storybook:build
 
+  # Aggregator that preserves the "Lint and Test" required-check name
+  # from before the fan-out. Passes only if every fan-out job passed.
+  lint-and-test:
+    name: Lint and Test
+    needs: [lint, format-check, typecheck, test, validate-bv, storybook-build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: All fan-out checks passed
+        run: echo "All fan-out checks passed"
+
   prepare-build:
     name: Prepare Build Artifacts
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Split the monolithic `Lint and Test` job into 6 parallel jobs that share a single `npm ci` via a `node_modules` cache. Granular per-check status in PRs, shorter feedback loop on lint/tsc failures, and reduced Lint+Test wall-clock on the critical path.

## Changes

- **`node_modules` cache** in `setup-node-and-install` keyed on (os, node-version, lockfile hash). Skips `npm ci` on cache hit.
- **New `install-deps` gate job** populates the cache once per run.
- **Fan-out jobs** (`needs: install-deps`): `lint`, `format-check`, `typecheck`, `test`, `validate-bv`, `storybook-build`.
- **`prepare-build` stays independent** (parallel from t=0) — it's the other critical path and would only slow down if serialized behind `install-deps`.

## Expected timing

| Metric | Before | After |
|---|---|---|
| Lint+Test critical path | ~3:48 | ~2:47 (jest-bound) |
| Per-check failure feedback | 3:48 | ~30s (lint) / ~1:30 (tsc) |
| Total PR wall-clock | ~4:54 | ~4:54 (prepare-build still dominant) |

Total wall-clock is unchanged because `prepare-build + build-test` (~4:48) is still the bottleneck. Follow-ups will target that: (1) `@swc/jest` swap to cut the test step further, (2) `paths-filter` to skip the 3-platform matrix on openspec/docs-only PRs.

## Test plan

- [ ] First run (cold cache): verify `install-deps` populates cache
- [ ] Subsequent run (warm cache): verify `install-deps` skips `npm ci`
- [ ] All 6 fan-out jobs pass
- [ ] `prepare-build` + `build-test / {linux,win,mac}` unaffected