### PR TITLE
ci: skip build jobs on docs-only PRs (paths-filter)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,6 +11,41 @@ env:
 
 jobs:
   # ---------------------------------------------------------------
+  # detect-changes gates the expensive build jobs. Docs/openspec-only
+  # PRs skip prepare-build and the 3-platform build-test matrix.
+  # ---------------------------------------------------------------
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'public/**'
+              - 'desktop/**'
+              - 'scripts/**'
+              - 'config/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'next.config.*'
+              - 'tsconfig.json'
+              - 'jest.config.*'
+              - 'jest.setup.*'
+              - '.babelrc*'
+              - '.github/workflows/**'
+              - '.github/actions/**'
+
+  # ---------------------------------------------------------------
   # install-deps runs first so the other lint/test/type/build jobs
   # can reuse a single `npm ci`. It populates the node_modules cache
   # keyed on (OS, node version, lockfile hash); fan-out jobs restore
@@ -153,6 +188,8 @@ jobs:
 
   prepare-build:
     name: Prepare Build Artifacts
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -189,7 +226,8 @@ jobs:
 
   build-test:
     name: Build Test / ${{ matrix.platform }}
-    needs: prepare-build
+    needs: [detect-changes, prepare-build]
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Add a lightweight \`detect-changes\` gate job using \`dorny/paths-filter@v3\`.
- Skip \`prepare-build\` and the 3-platform \`build-test\` matrix when a PR only touches docs, openspec, \`.claude/\`, or other non-build paths.
- Lint / format / typecheck / test / validate-bv / storybook continue to run for every PR.

## Impact
| PR type              | Before | After     | Savings |
|----------------------|-------:|----------:|--------:|
| Docs / openspec only | ~5 min | ~20-30 s  | ~4.5 min |
| Code changes         | ~5 min | ~5 min    | 0 (10-15 s overhead) |

## Build-triggering paths
Any change to the following triggers the full build matrix:
- \`src/**\`, \`public/**\`, \`desktop/**\`, \`scripts/**\`, \`config/**\`
- \`package.json\`, \`package-lock.json\`
- \`next.config.*\`, \`tsconfig.json\`, \`jest.config.*\`, \`jest.setup.*\`, \`.babelrc*\`
- \`.github/workflows/**\`, \`.github/actions/**\` (so CI changes verify themselves)

## Branch protection note
If 'Prepare Build Artifacts' or any 'Build Test / *' check is marked as a required status, the required-checks UI needs to be updated so a skipped status counts as success. Admin merges continue to work either way. (Worst case: add a small aggregator 'CI Success' job later.)

## Stacking
- Independent of #365 (fan-out) and #366 (swc/jest). All three compose cleanly: fan-out improves granularity, swc/jest cuts test wall-clock ~60%, this PR skips the expensive matrix on docs PRs.

## Test plan
- [ ] CI passes on this PR (which touches \`.github/workflows/\`, so build MUST run — good test of the \`.github/workflows/**\` inclusion rule)
- [ ] Follow-up test: open a docs-only PR and confirm build jobs are skipped
- [x] YAML syntax validated locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)