### PR TITLE
chore: ignore .cursor/ IDE state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ yarn-error.log*
 
 # AI/Assistant files
 .claude/
+.cursor/
 
 # OS files
 .DS_Store


### PR DESCRIPTION
One-line gitignore addition. Cursor IDE writes `.cursor/hooks/state/*.json` similar to `.claude/`, so it fits the same pattern.