### PR TITLE
fix(ci): gate build jobs at step level (fix paths-filter + branch protection)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -186,34 +186,46 @@ jobs:
       - name: All fan-out checks passed
         run: echo "All fan-out checks passed"
 
+  # prepare-build always runs (to satisfy branch-protection required check
+  # names), but its work is gated per-step on detect-changes.outputs.code.
+  # Docs/openspec-only PRs early-exit with a no-op step.
   prepare-build:
     name: Prepare Build Artifacts
     needs: detect-changes
-    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:
+      - name: Skip (no code changes)
+        if: needs.detect-changes.outputs.code != 'true'
+        run: echo "No code changes — skipping build."
+
       - name: Checkout code
+        if: needs.detect-changes.outputs.code == 'true'
         uses: actions/checkout@v6
 
       - name: Setup Node + caches + install deps
+        if: needs.detect-changes.outputs.code == 'true'
         uses: ./.github/actions/setup-node-and-install
         with:
           node-version: '20'
           fetch-assets: 'true'
 
       - name: Validate assets
+        if: needs.detect-changes.outputs.code == 'true'
         run: npm run validate:assets:strict
 
       - name: Build Next.js application
+        if: needs.detect-changes.outputs.code == 'true'
         run: npm run build
 
       - name: Build Electron TypeScript
+        if: needs.detect-changes.outputs.code == 'true'
         working-directory: desktop
         run: npm run build
 
       - name: Upload web build artifacts
+        if: needs.detect-changes.outputs.code == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: web-build
@@ -224,10 +236,12 @@ jobs:
             public/record-sheets
           retention-days: 1
 
+  # build-test always runs so the per-platform required checks
+  # ("Build Test / win", etc.) report SUCCESS on docs-only PRs.
+  # Work is gated per-step on detect-changes.outputs.code.
   build-test:
     name: Build Test / ${{ matrix.platform }}
     needs: [detect-changes, prepare-build]
-    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -243,21 +257,29 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: Skip (no code changes)
+        if: needs.detect-changes.outputs.code != 'true'
+        run: echo "No code changes — skipping build."
+
       - name: Checkout code
+        if: needs.detect-changes.outputs.code == 'true'
         uses: actions/checkout@v6
 
       - name: Setup Node + caches + install deps
+        if: needs.detect-changes.outputs.code == 'true'
         uses: ./.github/actions/setup-node-and-install
         with:
           node-version: '20'
           skip-nextjs-cache: 'true'
 
       - name: Download build artifacts
+        if: needs.detect-changes.outputs.code == 'true'
         uses: actions/download-artifact@v8
         with:
           name: web-build
 
       - name: Restore artifact structure
+        if: needs.detect-changes.outputs.code == 'true'
         shell: bash
         run: |
           # Move downloaded artifacts to their correct locations
@@ -269,11 +291,13 @@ jobs:
           test -d desktop/dist || { echo "Missing desktop/dist"; exit 1; }
 
       - name: Rebuild native modules for platform
+        if: needs.detect-changes.outputs.code == 'true'
         working-directory: desktop
         shell: bash
         run: npm run rebuild:next-standalone
 
       - name: Test Electron build (pack mode)
+        if: needs.detect-changes.outputs.code == 'true'
         working-directory: desktop
         shell: bash
         run: npx electron-builder --dir --publish never
@@ -283,6 +307,7 @@ jobs:
           ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/desktop/.electron-cache
 
       - name: Verify build output
+        if: needs.detect-changes.outputs.code == 'true'
         working-directory: desktop
         shell: bash
         run: |


### PR DESCRIPTION
## Problem
PR #367's \`if:\` gate at the **job level** caused \`prepare-build\` and \`build-test\` to be marked **SKIPPED** on docs-only PRs. Branch protection has \`strict: true\` and requires 'Build Test / win/mac/linux' to report SUCCESS, so skipped runs are treated as 'expected but missing' — blocking even admin merge.

Caught in the wild on PR #368 (gitignore-only change):
\`\`\`
GraphQL: 3 of 4 required status checks are expected. (mergePullRequest)
\`\`\`

## Fix
Convert job-level gates to step-level gates:
- \`prepare-build\` and \`build-test\` always run (required-check names register as SUCCESS).
- First step is a no-op \`echo\` that runs when \`code != 'true'\` (so runs have visible output).
- All real work steps are gated on \`needs.detect-changes.outputs.code == 'true'\`.

## Timing impact
| PR type | Before this fix | After | Notes |
|---|---|---|---|
| Docs / openspec only | 5 min (can't merge) | ~15-20 s per job (passes) | Fully merge-able |
| Code PRs | ~5 min | ~5 min | Unchanged |

## Test plan
- [x] YAML syntax validates locally
- [ ] CI on this PR (code change → all steps run)
- [ ] Follow-up: open a docs-only PR and verify the skipped-but-successful pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)