### PR TITLE
fix(aerospace): close add-aerospace-combat-behavior spec gaps

### DIFF
--- a/src/lib/combat/__tests__/acar.test.ts
+++ b/src/lib/combat/__tests__/acar.test.ts
@@ -5,6 +5,7 @@ import {
   distributeDamage,
   determineCasualties,
   resolveScenario,
+  type IUnitDamageState,
 } from '../acar';
 
 describe('calculateVictoryProbability', () => {
@@ -152,6 +153,89 @@ describe('distributeDamage', () => {
     const result = distributeDamage(['unit1'], 0, seededRandom);
     expect(result.size).toBe(1);
     expect(result.get('unit1')).toBe(0); // 0 * (0.5 + 1.0 * 0.5) * 100 = 0
+  });
+});
+
+// Spec: combat-resolution — "Aerospace fly-off counts as surviving"
+// (openspec/changes/add-aerospace-combat-behavior/specs/combat-resolution/spec.md)
+describe('distributeDamage — aerospace fly-off survival', () => {
+  it('treats an off-map aerospace unit as surviving, not wrecked', () => {
+    // Off-map + not destroyed → record only the actual SI/arc damage,
+    // bypass the severity roll entirely. RNG must not be consumed.
+    const seededRandom = jest.fn(() => 0.5);
+    const unitStates = new Map<string, IUnitDamageState>([
+      ['asf-1', { offMap: true, destroyed: false, actualDamagePercent: 22 }],
+    ]);
+    const result = distributeDamage(['asf-1'], 0.8, seededRandom, unitStates);
+
+    expect(result.size).toBe(1);
+    expect(result.get('asf-1')).toBe(22);
+    // Survivor must NOT be at 100% (not wrecked).
+    expect(result.get('asf-1')).toBeLessThan(100);
+    // No RNG roll for the off-map survivor.
+    expect(seededRandom).not.toHaveBeenCalled();
+  });
+
+  it('still classifies a destroyed off-map aerospace unit as wrecked (100%)', () => {
+    const seededRandom = jest.fn(() => 0.5);
+    const unitStates = new Map<string, IUnitDamageState>([
+      ['asf-1', { offMap: true, destroyed: true }],
+    ]);
+    const result = distributeDamage(['asf-1'], 0.3, seededRandom, unitStates);
+
+    expect(result.get('asf-1')).toBe(100);
+    expect(seededRandom).not.toHaveBeenCalled();
+  });
+
+  it('defaults actualDamagePercent to 0 when omitted for an off-map survivor', () => {
+    const seededRandom = jest.fn(() => 0.5);
+    const unitStates = new Map<string, IUnitDamageState>([
+      ['asf-1', { offMap: true, destroyed: false }],
+    ]);
+    const result = distributeDamage(['asf-1'], 0.8, seededRandom, unitStates);
+
+    expect(result.get('asf-1')).toBe(0);
+  });
+
+  it('clamps actualDamagePercent into [0, 100] for off-map survivors', () => {
+    const unitStates = new Map<string, IUnitDamageState>([
+      ['hi', { offMap: true, destroyed: false, actualDamagePercent: 250 }],
+      ['lo', { offMap: true, destroyed: false, actualDamagePercent: -10 }],
+    ]);
+    const result = distributeDamage(['hi', 'lo'], 0.5, () => 0.5, unitStates);
+
+    expect(result.get('hi')).toBe(100);
+    expect(result.get('lo')).toBe(0);
+  });
+
+  it('mixes survivors and on-field units in a single distribution', () => {
+    // Two on-field units roll normally, one off-map survivor records 15.
+    let call = 0;
+    const seededRandom = () => {
+      call += 1;
+      // 0.0 then 1.0 → on-field units get min then max severity damage.
+      return call === 1 ? 0.0 : 1.0;
+    };
+    const unitStates = new Map<string, IUnitDamageState>([
+      ['asf-1', { offMap: true, destroyed: false, actualDamagePercent: 15 }],
+    ]);
+    const result = distributeDamage(
+      ['mech-1', 'asf-1', 'mech-2'],
+      0.8,
+      seededRandom,
+      unitStates,
+    );
+
+    expect(result.get('mech-1')).toBeCloseTo(40, 5); // 0.8 * (0.5 + 0.0 * 0.5) * 100
+    expect(result.get('asf-1')).toBe(15); // survivor — actual damage only
+    expect(result.get('mech-2')).toBeCloseTo(80, 5); // 0.8 * (0.5 + 1.0 * 0.5) * 100
+  });
+
+  it('falls back to legacy distribution when unitStates is omitted', () => {
+    // Existing call sites (no unitStates) must keep current behavior.
+    const seededRandom = () => 0.5;
+    const result = distributeDamage(['unit1'], 0.5, seededRandom);
+    expect(result.get('unit1')).toBeCloseTo(37.5, 5);
   });
 });
 

--- a/src/lib/combat/acar.ts
+++ b/src/lib/combat/acar.ts
@@ -18,6 +18,39 @@ export interface ISalvageItem {
 }
 
 /**
+ * Per-unit combat state hint for damage distribution.
+ *
+ * The default `distributeDamage(unitIds, severity, random)` path treats every
+ * unit as a participant on the field — its damage is rolled by severity.
+ * For aerospace units that fled the map before the battle ended, the spec
+ * (combat-resolution: "Aerospace fly-off counts as surviving") says we
+ * MUST NOT treat them as wrecked. They are surviving units, and only the
+ * actual SI/arc damage they took should be recorded.
+ *
+ * Callers that have access to per-unit combat state can pass a map of
+ * `unitId → IUnitDamageState` to `distributeDamage` to opt into this
+ * behavior. Existing callers that pass nothing keep the legacy distribution.
+ *
+ * @spec openspec/changes/add-aerospace-combat-behavior/specs/combat-resolution/spec.md
+ */
+export interface IUnitDamageState {
+  /**
+   * True when the unit flew off the map before the battle ended (aerospace).
+   * Off-map + not-destroyed → surviving, with `actualDamagePercent` recorded.
+   * Off-map + destroyed → still wrecked (caller should set destroyed=true).
+   */
+  offMap?: boolean;
+  /** True when the unit was destroyed during the battle. */
+  destroyed?: boolean;
+  /**
+   * Actual damage taken during the battle as a percentage (0-100).
+   * Used when `offMap` is true and `destroyed` is false. Defaults to 0
+   * if omitted.
+   */
+  actualDamagePercent?: number;
+}
+
+/**
  * Result of resolving a combat scenario
  */
 export interface ResolveScenarioResult {
@@ -58,27 +91,67 @@ export function calculateVictoryProbability(
 }
 
 /**
- * Distributes damage across multiple units based on severity
- * Each unit receives damage calculated as: severity * (0.5 + random() * 0.5) * 100, capped at 100%
+ * Distributes damage across multiple units based on severity.
+ *
+ * Each unit receives damage calculated as
+ * `severity * (0.5 + random() * 0.5) * 100`, capped at 100%.
+ *
+ * When the optional `unitStates` map is provided, units flagged with
+ * `offMap=true` and `destroyed=false` are treated as having survived (per
+ * the aerospace fly-off spec scenario): their reported damage equals the
+ * unit's `actualDamagePercent` (defaulting to 0) — NOT a severity-driven
+ * roll — and no random number is consumed for them. Units with
+ * `destroyed=true` get a flat 100% damage and skip the RNG. This keeps
+ * fly-off survivors out of the wrecked bucket while preserving exact
+ * legacy behavior for every caller that omits the map.
  *
  * @param unitIds - Array of unit identifiers to distribute damage to
  * @param severity - Damage severity multiplier between 0 and 1
  * @param random - Optional random number generator function (defaults to Math.random)
+ * @param unitStates - Optional per-unit combat-state hints. When supplied,
+ *                     off-map / destroyed units are handled deterministically.
  * @returns Map of unitId to damage percentage (0-100)
  *
  * @example
  * distributeDamage(['unit1', 'unit2'], 0.8)
  * // Returns Map { 'unit1' => 65.3, 'unit2' => 72.1 }
+ *
+ * @example
+ * distributeDamage(['asf-1'], 0.8, rng, new Map([
+ *   ['asf-1', { offMap: true, destroyed: false, actualDamagePercent: 22 }],
+ * ]))
+ * // Returns Map { 'asf-1' => 22 } — survivor, only actual damage recorded.
+ *
+ * @spec openspec/changes/add-aerospace-combat-behavior/specs/combat-resolution/spec.md
  */
 export function distributeDamage(
   unitIds: string[],
   severity: number,
   random: () => number = Math.random,
+  unitStates?: Map<string, IUnitDamageState>,
 ): Map<string, number> {
   const damageMap = new Map<string, number>();
 
   for (const unitId of unitIds) {
-    // Formula: severity * (0.5 + random() * 0.5) * 100, capped at 100
+    const state = unitStates?.get(unitId);
+
+    if (state?.destroyed === true) {
+      // Destroyed units (including off-map ones that died during fly-off)
+      // are wrecked: 100% damage. RNG is not consumed.
+      damageMap.set(unitId, 100);
+      continue;
+    }
+
+    if (state?.offMap === true) {
+      // Aerospace fly-off survivor: NOT wrecked. Record only the actual
+      // SI/arc damage taken before exiting the map. RNG is not consumed
+      // so deterministic callers stay deterministic.
+      const actual = state.actualDamagePercent ?? 0;
+      damageMap.set(unitId, Math.max(0, Math.min(actual, 100)));
+      continue;
+    }
+
+    // Default path: severity * (0.5 + random() * 0.5) * 100, capped at 100
     const damage = Math.min(severity * (0.5 + random() * 0.5) * 100, 100);
     damageMap.set(unitId, damage);
   }

--- a/src/utils/gameplay/aerospace/__tests__/state.test.ts
+++ b/src/utils/gameplay/aerospace/__tests__/state.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Aerospace combat-state helper tests.
+ *
+ * Covers `clampSI` per the aerospace-unit-system spec requirement that
+ * `currentSI` is capped at `maxSI` after a repair / bonus event.
+ *
+ * @spec openspec/changes/add-aerospace-combat-behavior/specs/aerospace-unit-system/spec.md
+ */
+
+import { clampSI, createAerospaceCombatState } from '../state';
+
+/**
+ * Build a minimal but realistic aerospace combat state. Mirrors the fixture
+ * shape used in `damage.test.ts` so the two suites stay in lock-step.
+ */
+function makeState() {
+  return createAerospaceCombatState({
+    maxSI: 6,
+    armorByArc: {
+      nose: 20,
+      leftWing: 15,
+      rightWing: 15,
+      aft: 10,
+    },
+    heatSinks: 10,
+    fuelPoints: 20,
+    safeThrust: 6,
+    maxThrust: 9,
+  });
+}
+
+describe('clampSI', () => {
+  it('caps currentSI at maxSI when exceeded', () => {
+    const base = makeState();
+    const inflated = { ...base, currentSI: 99 };
+    const clamped = clampSI(inflated);
+    expect(clamped.currentSI).toBe(base.maxSI);
+  });
+
+  it('is a no-op when currentSI is already at maxSI', () => {
+    const state = makeState();
+    // currentSI === maxSI by construction; clampSI must return the same ref.
+    expect(clampSI(state)).toBe(state);
+  });
+
+  it('is a no-op when currentSI is below maxSI', () => {
+    const damaged = { ...makeState(), currentSI: 3 };
+    expect(clampSI(damaged)).toBe(damaged);
+  });
+
+  it('does not mutate the input when clamping', () => {
+    const inflated = { ...makeState(), currentSI: 999 };
+    const before = inflated.currentSI;
+    clampSI(inflated);
+    // Source state must be untouched — clampSI returns a new object.
+    expect(inflated.currentSI).toBe(before);
+  });
+
+  it('returns a new object reference when clamping is needed', () => {
+    const inflated = { ...makeState(), currentSI: 7 };
+    const clamped = clampSI(inflated);
+    expect(clamped).not.toBe(inflated);
+    expect(clamped.currentSI).toBe(inflated.maxSI);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the two REJECT items flagged by the spec-verifier for the `add-aerospace-combat-behavior` OpenSpec change.

### Gap 1 — `clampSI` direct unit tests
- New file: `src/utils/gameplay/aerospace/__tests__/state.test.ts`.
- Covers cap-at-maxSI, no-op below/at maxSI, input immutability, and new-reference semantics.

### Gap 2 — Aerospace fly-off "counts as surviving" in `distributeDamage`
- `distributeDamage(unitIds, severity, random, unitStates?)` now accepts an optional `Map<string, IUnitDamageState>`.
- Off-map + not-destroyed units record only their actual SI/arc damage and skip the severity roll (no RNG consumed).
- Off-map + destroyed units stay wrecked at 100%.
- Existing call sites (no map) keep their legacy severity-based behavior — fully backward compatible.
- New `IUnitDamageState` interface exported from `src/lib/combat/acar.ts` for callers that thread aerospace combat state into the distribution step.

### Test additions
- `clampSI` suite: 5 tests.
- `distributeDamage — aerospace fly-off survival` suite: 6 tests covering survivor recording, RNG non-consumption, destroyed-off-map wreckage, default `actualDamagePercent`, percentage clamping, mixed survivor/on-field distribution, and legacy fallback.

### Out of scope
- Task 13.2 (1 ASF vs 2 mechs simulation harness) remains explicitly deferred per `tasks.md` — not part of the verifier's REJECT verdict.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (31 pre-existing warnings on untouched files)
- [x] `npx jest --testPathPattern='aerospace|acar'` — 18 suites / 398 tests green
- [x] `npm run build` — clean
- [x] `npx openspec validate add-aerospace-combat-behavior --strict` — valid
- [ ] Full CI green on PR