### PR TITLE
feat(salvage): finish or defer remaining salvage tasks (apply add-salvage-rules-engine)

### DIFF
--- a/openspec/changes/add-salvage-rules-engine/notepad/decisions.md
+++ b/openspec/changes/add-salvage-rules-engine/notepad/decisions.md
@@ -1,0 +1,68 @@
+# Decisions — add-salvage-rules-engine
+
+## [2026-04-24] Tasks 8.4 + 8.5 + 11.1–11.4 — DEFERRED to Wave 4
+
+**Choice**: Mark salvage-to-inventory conversion (8.4), damaged-unit
+roster creation (8.5), and the four Wave 4 UI handoff items (11.1–11.4)
+as `**DEFERRED**` in `tasks.md` rather than implementing them in this
+change.
+
+**Rationale**:
+
+1. **No `acquisitionProcessor` salvage rail exists.** The existing
+   `acquisitionProcessor` (`src/lib/campaign/processors/acquisitionProcessor.ts`)
+   only services `IAcquisitionRequest` records on `IShoppingList` —
+   `processPendingAcquisitions` and `processInTransitAcquisitions` walk
+   pending / in-transit purchase orders and roll for delivery. There is
+   no salvage-to-inventory conversion path on the campaign, no `source:
+   'salvage'` tag recognised by the inventory side, and no
+   `addUnitToRoster` / `createRosterUnit` helper. Implementing 8.4 here
+   would require inventing the rail AND the inventory schema extension,
+   which is the scope of the Wave 4 / `add-repair-queue-integration`
+   change. Out of scope for the rules-engine change.
+
+2. **No roster mutation surface for damaged-unit ingestion.** Same
+   shape: nothing in `src/lib/campaign/` mutates the campaign's force /
+   roster to inject a freshly-acquired damaged mech with a seeded
+   `IUnitCombatState`. The Phase 3 force-management change owns this
+   surface; baking it into the salvage engine here would couple two
+   changes and leak Wave 4 work into the Wave 3 archive.
+
+3. **The Wave 3 engine already preserves everything Wave 4 needs.** The
+   persisted `ISalvageAllocation` carries every field the Wave 4 UI
+   layer will consume:
+   - `damageLevel` + `recoveryPercentage` per candidate → Wave 4 can
+     reconstruct `IUnitCombatState` without replaying the battle.
+   - `splitMethod: 'auction' | 'contract' | 'hostile_withdrawal' |
+     'standalone'` → drives Wave 4 routing logic (auction draft UI vs.
+     direct award screen).
+   - `mercenaryAward.candidates` + `employerAward.candidates` are fully
+     classified, value-weighted, and deterministic — the auction draft
+     order is already stable.
+   - `campaign.salvageReports` is keyed by `matchId` so the Wave 4
+     after-action UI can render directly without further engine
+     changes.
+
+4. **Tasks 11.1–11.4 are explicitly tagged "Wave 4" in `tasks.md`.**
+   The §11 "Wave 3 → Wave 4 Handoff" section is a forward-pointer, not
+   a Wave 3 deliverable. They were never implementation targets for
+   this change; deferral simply makes that explicit at archive time.
+
+5. **The salvage processor's module docstring already documents this.**
+   `src/lib/campaign/processors/salvageProcessor.ts` line 14 states
+   "Phase 3 Wave 3 — `add-salvage-rules-engine`. Wave 4 will surface
+   inventory conversion + auction UI; this processor only owns the
+   compute-and-persist half." The deferral is consistent with the
+   existing implementation intent — no code-vs-spec drift.
+
+**Spec impact**: Zero. The `salvage-rules` spec deltas describe engine
+behaviour (aggregation, splitting, repair-cost estimation, hostile
+territory modifier, idempotent processor), not inventory / roster
+mutation. `openspec validate add-salvage-rules-engine --strict` passes.
+
+**Cross-reference**: identical pattern to
+`openspec/changes/wire-heat-generation-and-effects/notepad/decisions.md`
+entry for §11.3 (CASE/CASE II) and §15.2 / §15.3 (autonomous fuzzer +
+multi-turn E2E) — work that belongs to a parallel or downstream change
+is deferred with rationale rather than half-implemented in the current
+archive.

--- a/openspec/changes/add-salvage-rules-engine/tasks.md
+++ b/openspec/changes/add-salvage-rules-engine/tasks.md
@@ -85,10 +85,26 @@
       and compute the `ISalvageAllocation`; persist by matchId
 - [ ] 8.4 For each mercenary-award candidate: create a campaign inventory
       entry via existing `acquisitionProcessor` rails (as if acquired) but
-      with `source: "salvage"` tag — DEFERRED to Wave 4 (UI surfaces)
+      with `source: "salvage"` tag — **DEFERRED**: the existing
+      `acquisitionProcessor` only services the shopping-list / delivery
+      pipeline (`processPendingAcquisitions` over `IAcquisitionRequest`).
+      No salvage-to-inventory rail exists yet, and no `source: 'salvage'`
+      tag is recognised by the campaign inventory side. Wiring this here
+      would require inventing both the rail and the inventory schema
+      extension, which is the Wave 4 / `add-repair-queue-integration`
+      scope. The Wave 3 engine already produces the canonical
+      `ISalvageAllocation` + `ISalvageReport` records the Wave 4 surface
+      will consume. See `openspec/changes/add-salvage-rules-engine/notepad/decisions.md`.
 - [ ] 8.5 For damaged-unit candidates: create the unit in the roster with
       its `IUnitCombatState` set to the damage snapshot from the outcome —
-      DEFERRED to Wave 4 (roster integration)
+      **DEFERRED**: roster mutation surface for damaged-unit ingestion
+      does not exist on the campaign yet (no `addUnitToRoster` /
+      `createRosterUnit` helpers, no salvage→roster path in any
+      processor). The damage snapshot is preserved on each candidate's
+      `damageLevel` + `recoveryPercentage` so Wave 4 can rebuild the
+      `IUnitCombatState` from the persisted `ISalvageAllocation` without
+      replaying the battle. See
+      `openspec/changes/add-salvage-rules-engine/notepad/decisions.md`.
 - [x] 8.6 Fire `salvage_allocated` event with award summary
 
 ## 9. Tests
@@ -114,9 +130,28 @@
 
 ## 11. Wave 3 → Wave 4 Handoff
 
-- [ ] 11.1 Wave 4: surface `ISalvageReport` on the after-action UI
+All four sub-tasks here are explicitly UI / roster surfaces planned for
+Phase 3 Wave 4. They are out of scope for the salvage **rules engine**
+delivered by this change. Carrying them forward as DEFERRED preserves
+the handoff contract without leaking Wave 4 work into a Wave 3 archive.
+
+- [ ] 11.1 Wave 4: surface `ISalvageReport` on the after-action UI —
+      **DEFERRED**: after-action review UI is owned by
+      `add-post-battle-review-ui` (Wave 4). The salvage processor already
+      persists `ISalvageReport` per matchId in
+      `campaign.salvageReports` so the Wave 4 component can render
+      directly without further engine changes.
 - [ ] 11.2 Wave 4: convert mercenary-award candidates into roster /
-      inventory entries via `acquisitionProcessor` rails (8.4)
+      inventory entries via `acquisitionProcessor` rails (8.4) —
+      **DEFERRED**: see 8.4 above. Same rationale — the rails and
+      inventory schema extension are Wave 4 work.
 - [ ] 11.3 Wave 4: damaged-unit roster creation with `IUnitCombatState`
-      seeded from the outcome (8.5)
-- [ ] 11.4 Wave 4: auction draft UI for `splitMethod: 'auction'`
+      seeded from the outcome (8.5) — **DEFERRED**: see 8.5 above. The
+      Wave 3 allocation already preserves damage classification and
+      recovery percentage, so Wave 4 can hydrate `IUnitCombatState`
+      without any additional engine changes.
+- [ ] 11.4 Wave 4: auction draft UI for `splitMethod: 'auction'` —
+      **DEFERRED**: the engine already classifies allocations with
+      `splitMethod: 'auction'` and runs the seeded draft deterministically
+      (§4.1–4.4 + tests 9.2). The Wave 4 UI is a presentation concern over
+      the persisted allocation; no engine work remains.


### PR DESCRIPTION
## Summary

Final apply pass for `add-salvage-rules-engine` (44/50 → 50/50 resolved). The remaining 6 tasks are all Wave 4 surfaces (UI, roster mutation, salvage→inventory rails) — explicitly tagged "Wave 4" in `tasks.md` §11 and noted in the salvage processor's module docstring.

This PR marks them `**DEFERRED**` inline (matching the format used by `wire-heat-generation-and-effects/tasks.md`) and adds a `notepad/decisions.md` capturing the rationale per task. **No source code changes** — the Wave 3 engine already persists every field Wave 4 needs.

## Per-task resolution

| Task | Resolution | Rationale |
| --- | --- | --- |
| 8.4 inventory entry via acquisitionProcessor rails | DEFERRED | `acquisitionProcessor` only services `IShoppingList` / `IAcquisitionRequest` — no salvage→inventory rail exists, no `source: 'salvage'` tag in inventory schema. Wave 4 / `add-repair-queue-integration` scope. |
| 8.5 damaged-unit roster creation | DEFERRED | No roster-mutation surface (`addUnitToRoster` / `createRosterUnit`) exists. Wave 3 allocation preserves `damageLevel` + `recoveryPercentage` so Wave 4 can hydrate `IUnitCombatState` without replaying. |
| 11.1 ISalvageReport on after-action UI | DEFERRED | UI owned by `add-post-battle-review-ui`. Reports are already persisted on `campaign.salvageReports` by matchId. |
| 11.2 mercenary award → roster/inventory (8.4) | DEFERRED | Cross-references 8.4. |
| 11.3 damaged-unit roster (8.5) | DEFERRED | Cross-references 8.5. |
| 11.4 auction draft UI | DEFERRED | Engine already classifies `splitMethod: 'auction'` and runs the seeded draft deterministically (§4 + tests 9.2). UI is presentation only. |

## Verification

- `openspec validate add-salvage-rules-engine --strict` passes
- `npm run typecheck` clean
- `npm run lint` 0 errors (32 pre-existing max-lines warnings, unrelated)
- `npx jest --watchAll=false` 21813 passed / 44 skipped / 767 suites
- Salvage-targeted suites: 39/39 pass (`salvageEngine.test.ts` + `salvageProcessor.test.ts`)

## Files changed

- `openspec/changes/add-salvage-rules-engine/tasks.md` — DEFERRED markers + rationale
- `openspec/changes/add-salvage-rules-engine/notepad/decisions.md` — new

## Test plan

- [x] OpenSpec validation passes strict
- [x] Typecheck / lint / full test suite all clean
- [x] All 6 remaining tasks have explicit DEFER rationale + notepad entry
- [x] Format mirrors `wire-heat-generation-and-effects/tasks.md`
- [ ] Merging deferred until orchestrator review (per opsx:apply contract — do NOT merge)