### PR TITLE
feat(aerospace): finish wing-mount caps + bomb bays (apply add-aerospace-construction)

### DIFF
--- a/openspec/changes/add-aerospace-construction/tasks.md
+++ b/openspec/changes/add-aerospace-construction/tasks.md
@@ -49,8 +49,8 @@
 
 - [x] 7.1 Equipment can be mounted in Nose, LWing, RWing, Aft, or Fuselage (internal; no arc restriction)
 - [x] 7.2 Slot count per arc: Nose 6, each Wing 6, Aft 4, Fuselage unlimited (bounded by tonnage)
-- [ ] 7.3 Wing-mounted heavy weapons (PPC, Gauss) — tonnage cap per wing
-- [ ] 7.4 Bomb bays — small craft only, configurable bays
+- [x] 7.3 Wing-mounted heavy weapons (PPC, Gauss) — tonnage cap per wing
+- [x] 7.4 Bomb bays — small craft only, configurable bays
 
 ## 8. Heat Sink Pool
 

--- a/src/__tests__/unit/aerospace-construction.test.ts
+++ b/src/__tests__/unit/aerospace-construction.test.ts
@@ -16,7 +16,7 @@ import {
   AerospaceArc,
   AerospaceEngineType,
   AerospaceSubType,
-} from '@/types/unit/AerospaceInterfaces';
+} from "@/types/unit/AerospaceInterfaces";
 // ============================================================================
 // Calculator imports
 // ============================================================================
@@ -26,30 +26,30 @@ import {
   getArcsForSubType,
   ASF_CF_ARCS,
   SMALL_CRAFT_ARCS,
-} from '@/utils/construction/aerospace/armorArcCalculations';
+} from "@/utils/construction/aerospace/armorArcCalculations";
 import {
   makeSmallCraftCrew,
   quartersWeight,
   minSmallCraftCrew,
-} from '@/utils/construction/aerospace/crewCalculations';
-import { aerospaceEngineWeight } from '@/utils/construction/aerospace/engineWeightAerospace';
+} from "@/utils/construction/aerospace/crewCalculations";
+import { aerospaceEngineWeight } from "@/utils/construction/aerospace/engineWeightAerospace";
 import {
   calculateFuelPoints,
   FUEL_POINTS_PER_TON,
   FUEL_MINIMUM_TONS,
   minFuelTons,
-} from '@/utils/construction/aerospace/fuelCalculations';
+} from "@/utils/construction/aerospace/fuelCalculations";
 import {
   defaultSI,
   maxSI,
   siWeightCost,
-} from '@/utils/construction/aerospace/siCalculations';
+} from "@/utils/construction/aerospace/siCalculations";
 import {
   calculateSafeThrust,
   calculateMaxThrust,
   getMaxSafeThrust,
   isEngineLegalForSubType,
-} from '@/utils/construction/aerospace/thrustCalculations';
+} from "@/utils/construction/aerospace/thrustCalculations";
 // ============================================================================
 // Validation imports
 // ============================================================================
@@ -61,7 +61,23 @@ import {
   validateFuel,
   validateArcArmor,
   validateCrew,
-} from '@/utils/construction/aerospace/validationRules';
+  AERO_VALIDATION_RULE_IDS,
+} from "@/utils/construction/aerospace/validationRules";
+import {
+  isWingHeavyWeapon,
+  maxHeavyWeaponTonsPerWing,
+  canMountHeavyOnWing,
+  heavyTonsByWing,
+  validateWingHeavyWeapons,
+} from "@/utils/construction/aerospace/wingHeavyWeapons";
+import {
+  bayTons,
+  totalBombBayTons,
+  totalBombCapacity,
+  maxBombBayTons,
+  validateBombBays,
+  BAY_STRUCTURE_TONS,
+} from "@/utils/construction/aerospace/bombBays";
 
 // ============================================================================
 // Helpers
@@ -151,55 +167,55 @@ function seekerInput() {
 // thrustCalculations
 // ============================================================================
 
-describe('thrustCalculations', () => {
-  describe('calculateSafeThrust', () => {
-    it('Shilone: 65t × thrust 5 → engineRating 325 → safeThrust 5', () => {
+describe("thrustCalculations", () => {
+  describe("calculateSafeThrust", () => {
+    it("Shilone: 65t × thrust 5 → engineRating 325 → safeThrust 5", () => {
       // engineRating = 65 × 5 = 325; floor(325/65) = 5
       expect(
         calculateSafeThrust(325, 65, AerospaceSubType.AEROSPACE_FIGHTER),
       ).toBe(5);
     });
 
-    it('Stuka: 100t × thrust 4 → engineRating 400 → safeThrust 4', () => {
+    it("Stuka: 100t × thrust 4 → engineRating 400 → safeThrust 4", () => {
       expect(
         calculateSafeThrust(400, 100, AerospaceSubType.AEROSPACE_FIGHTER),
       ).toBe(4);
     });
 
-    it('Sparrowhawk: 30t × thrust 7 → engineRating 210 → safeThrust 7', () => {
+    it("Sparrowhawk: 30t × thrust 7 → engineRating 210 → safeThrust 7", () => {
       expect(
         calculateSafeThrust(210, 30, AerospaceSubType.CONVENTIONAL_FIGHTER),
       ).toBe(7);
     });
 
-    it('clamps safeThrust to sub-type cap (ASF cap=12)', () => {
+    it("clamps safeThrust to sub-type cap (ASF cap=12)", () => {
       // rating would give 15 thrust but capped at 12
       expect(
         calculateSafeThrust(1500, 100, AerospaceSubType.AEROSPACE_FIGHTER),
       ).toBe(12);
     });
 
-    it('small craft cap is 6', () => {
+    it("small craft cap is 6", () => {
       expect(getMaxSafeThrust(AerospaceSubType.SMALL_CRAFT)).toBe(6);
     });
   });
 
-  describe('calculateMaxThrust', () => {
-    it('safeThrust 5 → maxThrust 7 (floor(5×1.5))', () => {
+  describe("calculateMaxThrust", () => {
+    it("safeThrust 5 → maxThrust 7 (floor(5×1.5))", () => {
       expect(calculateMaxThrust(5)).toBe(7);
     });
 
-    it('safeThrust 4 → maxThrust 6', () => {
+    it("safeThrust 4 → maxThrust 6", () => {
       expect(calculateMaxThrust(4)).toBe(6);
     });
 
-    it('safeThrust 7 → maxThrust 10', () => {
+    it("safeThrust 7 → maxThrust 10", () => {
       expect(calculateMaxThrust(7)).toBe(10);
     });
   });
 
-  describe('isEngineLegalForSubType', () => {
-    it('Fusion is legal for ASF', () => {
+  describe("isEngineLegalForSubType", () => {
+    it("Fusion is legal for ASF", () => {
       expect(
         isEngineLegalForSubType(
           AerospaceEngineType.FUSION,
@@ -208,7 +224,7 @@ describe('thrustCalculations', () => {
       ).toBe(true);
     });
 
-    it('ICE is illegal for ASF', () => {
+    it("ICE is illegal for ASF", () => {
       expect(
         isEngineLegalForSubType(
           AerospaceEngineType.ICE,
@@ -217,7 +233,7 @@ describe('thrustCalculations', () => {
       ).toBe(false);
     });
 
-    it('Fusion is illegal for CF (must use ICE or FuelCell)', () => {
+    it("Fusion is illegal for CF (must use ICE or FuelCell)", () => {
       expect(
         isEngineLegalForSubType(
           AerospaceEngineType.FUSION,
@@ -226,7 +242,7 @@ describe('thrustCalculations', () => {
       ).toBe(false);
     });
 
-    it('ICE is legal for CF', () => {
+    it("ICE is legal for CF", () => {
       expect(
         isEngineLegalForSubType(
           AerospaceEngineType.ICE,
@@ -235,7 +251,7 @@ describe('thrustCalculations', () => {
       ).toBe(true);
     });
 
-    it('Fusion is legal for small craft', () => {
+    it("Fusion is legal for small craft", () => {
       expect(
         isEngineLegalForSubType(
           AerospaceEngineType.FUSION,
@@ -250,37 +266,37 @@ describe('thrustCalculations', () => {
 // siCalculations
 // ============================================================================
 
-describe('siCalculations', () => {
-  it('defaultSI: 65t → ceil(65/10) = 7', () => {
+describe("siCalculations", () => {
+  it("defaultSI: 65t → ceil(65/10) = 7", () => {
     expect(defaultSI(65)).toBe(7);
   });
 
-  it('defaultSI: 100t → 10', () => {
+  it("defaultSI: 100t → 10", () => {
     expect(defaultSI(100)).toBe(10);
   });
 
-  it('defaultSI: 30t → 3', () => {
+  it("defaultSI: 30t → 3", () => {
     expect(defaultSI(30)).toBe(3);
   });
 
-  it('maxSI: ASF → 20', () => {
+  it("maxSI: ASF → 20", () => {
     expect(maxSI(AerospaceSubType.AEROSPACE_FIGHTER)).toBe(20);
   });
 
-  it('maxSI: CF → 15', () => {
+  it("maxSI: CF → 15", () => {
     expect(maxSI(AerospaceSubType.CONVENTIONAL_FIGHTER)).toBe(15);
   });
 
-  it('maxSI: small craft → 30', () => {
+  it("maxSI: small craft → 30", () => {
     expect(maxSI(AerospaceSubType.SMALL_CRAFT)).toBe(30);
   });
 
-  it('siWeightCost: SI at default → 0 extra tons', () => {
+  it("siWeightCost: SI at default → 0 extra tons", () => {
     // Shilone: 65t, default SI = 7, cost for SI=7 → 0
     expect(siWeightCost(7, 65)).toBe(0);
   });
 
-  it('siWeightCost: 1 extra SI on 65t unit → (1 extra) × (65/10) × 0.5 = 3.25t', () => {
+  it("siWeightCost: 1 extra SI on 65t unit → (1 extra) × (65/10) × 0.5 = 3.25t", () => {
     // SI=8 on 65t: extra=1, cost = 1 × 6.5 × 0.5 = 3.25
     expect(siWeightCost(8, 65)).toBeCloseTo(3.25);
   });
@@ -290,36 +306,36 @@ describe('siCalculations', () => {
 // fuelCalculations
 // ============================================================================
 
-describe('fuelCalculations', () => {
-  it('Fusion: 5t → 400 fuel points (5 × 80)', () => {
+describe("fuelCalculations", () => {
+  it("Fusion: 5t → 400 fuel points (5 × 80)", () => {
     expect(calculateFuelPoints(5, AerospaceEngineType.FUSION)).toBe(400);
   });
 
-  it('ICE: 2t → 80 fuel points (2 × 40)', () => {
+  it("ICE: 2t → 80 fuel points (2 × 40)", () => {
     expect(calculateFuelPoints(2, AerospaceEngineType.ICE)).toBe(80);
   });
 
-  it('FuelCell: 3t → 180 fuel points (3 × 60)', () => {
+  it("FuelCell: 3t → 180 fuel points (3 × 60)", () => {
     expect(calculateFuelPoints(3, AerospaceEngineType.FUEL_CELL)).toBe(180);
   });
 
-  it('XL uses same rate as Fusion (80 pts/ton)', () => {
+  it("XL uses same rate as Fusion (80 pts/ton)", () => {
     expect(FUEL_POINTS_PER_TON[AerospaceEngineType.XL]).toBe(80);
   });
 
-  it('minFuelTons: ASF → 5t', () => {
+  it("minFuelTons: ASF → 5t", () => {
     expect(minFuelTons(AerospaceSubType.AEROSPACE_FIGHTER)).toBe(5);
   });
 
-  it('minFuelTons: CF → 2t', () => {
+  it("minFuelTons: CF → 2t", () => {
     expect(minFuelTons(AerospaceSubType.CONVENTIONAL_FIGHTER)).toBe(2);
   });
 
-  it('minFuelTons: small craft → 20t', () => {
+  it("minFuelTons: small craft → 20t", () => {
     expect(minFuelTons(AerospaceSubType.SMALL_CRAFT)).toBe(20);
   });
 
-  it('Seeker: 20t Fusion → 1600 fuel points', () => {
+  it("Seeker: 20t Fusion → 1600 fuel points", () => {
     expect(calculateFuelPoints(20, AerospaceEngineType.FUSION)).toBe(1600);
   });
 });
@@ -328,8 +344,8 @@ describe('fuelCalculations', () => {
 // armorArcCalculations
 // ============================================================================
 
-describe('armorArcCalculations', () => {
-  it('ASF/CF arcs are [Nose, LeftWing, RightWing, Aft]', () => {
+describe("armorArcCalculations", () => {
+  it("ASF/CF arcs are [Nose, LeftWing, RightWing, Aft]", () => {
     expect(getArcsForSubType(AerospaceSubType.AEROSPACE_FIGHTER)).toEqual(
       ASF_CF_ARCS,
     );
@@ -338,13 +354,13 @@ describe('armorArcCalculations', () => {
     );
   });
 
-  it('small craft arcs are [Nose, LeftSide, RightSide, Aft]', () => {
+  it("small craft arcs are [Nose, LeftSide, RightSide, Aft]", () => {
     expect(getArcsForSubType(AerospaceSubType.SMALL_CRAFT)).toEqual(
       SMALL_CRAFT_ARCS,
     );
   });
 
-  it('Shilone 65t ASF nose max = floor(65 × 0.28) = 18', () => {
+  it("Shilone 65t ASF nose max = floor(65 × 0.28) = 18", () => {
     expect(
       maxArcArmorPoints(
         AerospaceArc.NOSE,
@@ -354,7 +370,7 @@ describe('armorArcCalculations', () => {
     ).toBe(18);
   });
 
-  it('Shilone 65t ASF wing max = floor(65 × 0.20) = 13', () => {
+  it("Shilone 65t ASF wing max = floor(65 × 0.20) = 13", () => {
     expect(
       maxArcArmorPoints(
         AerospaceArc.LEFT_WING,
@@ -364,7 +380,7 @@ describe('armorArcCalculations', () => {
     ).toBe(13);
   });
 
-  it('Shilone 65t ASF aft max = floor(65 × 0.12) = 7', () => {
+  it("Shilone 65t ASF aft max = floor(65 × 0.12) = 7", () => {
     expect(
       maxArcArmorPoints(
         AerospaceArc.AFT,
@@ -374,7 +390,7 @@ describe('armorArcCalculations', () => {
     ).toBe(7);
   });
 
-  it('small craft: LEFT_WING factor is 0 (side arcs instead)', () => {
+  it("small craft: LEFT_WING factor is 0 (side arcs instead)", () => {
     expect(
       maxArcArmorPoints(
         AerospaceArc.LEFT_WING,
@@ -384,7 +400,7 @@ describe('armorArcCalculations', () => {
     ).toBe(0);
   });
 
-  it('small craft: LEFT_SIDE max = floor(100 × 0.20) = 20', () => {
+  it("small craft: LEFT_SIDE max = floor(100 × 0.20) = 20", () => {
     expect(
       maxArcArmorPoints(
         AerospaceArc.LEFT_SIDE,
@@ -394,7 +410,7 @@ describe('armorArcCalculations', () => {
     ).toBe(20);
   });
 
-  it('maxTotalArmorPoints: 100t ASF = nose+wing+wing+aft = 28+20+20+12 = 80', () => {
+  it("maxTotalArmorPoints: 100t ASF = nose+wing+wing+aft = 28+20+20+12 = 80", () => {
     expect(maxTotalArmorPoints(100, AerospaceSubType.AEROSPACE_FIGHTER)).toBe(
       80,
     );
@@ -405,23 +421,23 @@ describe('armorArcCalculations', () => {
 // engineWeightAerospace
 // ============================================================================
 
-describe('engineWeightAerospace', () => {
-  it('Shilone: rating 325, Fusion → table lookup 20t', () => {
+describe("engineWeightAerospace", () => {
+  it("Shilone: rating 325, Fusion → table lookup 20t", () => {
     // FUSION_ENGINE_WEIGHT[325] = 20.0
     expect(aerospaceEngineWeight(325, AerospaceEngineType.FUSION)).toBe(20);
   });
 
-  it('Sparrowhawk: rating 210, ICE → table weight × 2.0', () => {
+  it("Sparrowhawk: rating 210, ICE → table weight × 2.0", () => {
     // FUSION_ENGINE_WEIGHT[210] = 9.0, ICE ×2 = 18t
     expect(aerospaceEngineWeight(210, AerospaceEngineType.ICE)).toBe(18);
   });
 
-  it('XL engine halves the weight', () => {
+  it("XL engine halves the weight", () => {
     // rating 200, Fusion → 8.5t; XL → 4.25 → ceil to 4.5t
     expect(aerospaceEngineWeight(200, AerospaceEngineType.XL)).toBe(4.5);
   });
 
-  it('result is always a multiple of 0.5', () => {
+  it("result is always a multiple of 0.5", () => {
     for (const rating of [50, 100, 150, 200, 250, 300, 350, 400]) {
       const weight = aerospaceEngineWeight(rating, AerospaceEngineType.FUSION);
       expect(weight % 0.5).toBe(0);
@@ -433,33 +449,33 @@ describe('engineWeightAerospace', () => {
 // crewCalculations
 // ============================================================================
 
-describe('crewCalculations', () => {
-  it('quartersWeight: 3 crew, 0 pax, 0 marines → 15t', () => {
+describe("crewCalculations", () => {
+  it("quartersWeight: 3 crew, 0 pax, 0 marines → 15t", () => {
     expect(
       quartersWeight({ crew: 3, passengers: 0, marines: 0, quartersTons: 0 }),
     ).toBe(15);
   });
 
-  it('quartersWeight: 2 crew + 4 pax → 2×5 + 4×3 = 22t', () => {
+  it("quartersWeight: 2 crew + 4 pax → 2×5 + 4×3 = 22t", () => {
     expect(
       quartersWeight({ crew: 2, passengers: 4, marines: 0, quartersTons: 0 }),
     ).toBe(22);
   });
 
-  it('makeSmallCraftCrew computes quartersTons automatically', () => {
+  it("makeSmallCraftCrew computes quartersTons automatically", () => {
     const crew = makeSmallCraftCrew(3, 0, 0);
     expect(crew.quartersTons).toBe(15);
   });
 
-  it('minSmallCraftCrew: 100t → 3 crew', () => {
+  it("minSmallCraftCrew: 100t → 3 crew", () => {
     expect(minSmallCraftCrew(100)).toBe(3);
   });
 
-  it('minSmallCraftCrew: 150t → 4 crew', () => {
+  it("minSmallCraftCrew: 150t → 4 crew", () => {
     expect(minSmallCraftCrew(150)).toBe(4);
   });
 
-  it('minSmallCraftCrew: 200t → 6 crew', () => {
+  it("minSmallCraftCrew: 200t → 6 crew", () => {
     expect(minSmallCraftCrew(200)).toBe(6);
   });
 });
@@ -468,57 +484,57 @@ describe('crewCalculations', () => {
 // VAL-AERO-TONNAGE
 // ============================================================================
 
-describe('VAL-AERO-TONNAGE', () => {
-  it('Shilone 65t ASF — valid, no errors', () => {
+describe("VAL-AERO-TONNAGE", () => {
+  it("Shilone 65t ASF — valid, no errors", () => {
     expect(
       validateTonnage(65, AerospaceSubType.AEROSPACE_FIGHTER),
     ).toHaveLength(0);
   });
 
-  it('Stuka 100t ASF — valid, no errors', () => {
+  it("Stuka 100t ASF — valid, no errors", () => {
     expect(
       validateTonnage(100, AerospaceSubType.AEROSPACE_FIGHTER),
     ).toHaveLength(0);
   });
 
-  it('Sparrowhawk 30t CF — valid, no errors', () => {
+  it("Sparrowhawk 30t CF — valid, no errors", () => {
     expect(
       validateTonnage(30, AerospaceSubType.CONVENTIONAL_FIGHTER),
     ).toHaveLength(0);
   });
 
-  it('Seeker 100t SmallCraft — valid, no errors', () => {
+  it("Seeker 100t SmallCraft — valid, no errors", () => {
     expect(validateTonnage(100, AerospaceSubType.SMALL_CRAFT)).toHaveLength(0);
   });
 
-  it('ASF under 5t → VAL-AERO-TONNAGE error', () => {
+  it("ASF under 5t → VAL-AERO-TONNAGE error", () => {
     const errors = validateTonnage(4, AerospaceSubType.AEROSPACE_FIGHTER);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe('VAL-AERO-TONNAGE');
+    expect(errors[0].ruleId).toBe("VAL-AERO-TONNAGE");
   });
 
-  it('ASF over 100t → VAL-AERO-TONNAGE error', () => {
+  it("ASF over 100t → VAL-AERO-TONNAGE error", () => {
     const errors = validateTonnage(101, AerospaceSubType.AEROSPACE_FIGHTER);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe('VAL-AERO-TONNAGE');
+    expect(errors[0].ruleId).toBe("VAL-AERO-TONNAGE");
   });
 
-  it('CF over 50t → VAL-AERO-TONNAGE error', () => {
+  it("CF over 50t → VAL-AERO-TONNAGE error", () => {
     const errors = validateTonnage(55, AerospaceSubType.CONVENTIONAL_FIGHTER);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe('VAL-AERO-TONNAGE');
+    expect(errors[0].ruleId).toBe("VAL-AERO-TONNAGE");
   });
 
-  it('SmallCraft under 100t → VAL-AERO-TONNAGE error', () => {
+  it("SmallCraft under 100t → VAL-AERO-TONNAGE error", () => {
     const errors = validateTonnage(90, AerospaceSubType.SMALL_CRAFT);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe('VAL-AERO-TONNAGE');
+    expect(errors[0].ruleId).toBe("VAL-AERO-TONNAGE");
   });
 
-  it('SmallCraft over 200t → VAL-AERO-TONNAGE error', () => {
+  it("SmallCraft over 200t → VAL-AERO-TONNAGE error", () => {
     const errors = validateTonnage(210, AerospaceSubType.SMALL_CRAFT);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe('VAL-AERO-TONNAGE');
+    expect(errors[0].ruleId).toBe("VAL-AERO-TONNAGE");
   });
 });
 
@@ -526,8 +542,8 @@ describe('VAL-AERO-TONNAGE', () => {
 // VAL-AERO-THRUST
 // ============================================================================
 
-describe('VAL-AERO-THRUST', () => {
-  it('Shilone Fusion ASF thrust 5 — no errors', () => {
+describe("VAL-AERO-THRUST", () => {
+  it("Shilone Fusion ASF thrust 5 — no errors", () => {
     expect(
       validateThrust(
         AerospaceEngineType.FUSION,
@@ -537,7 +553,7 @@ describe('VAL-AERO-THRUST', () => {
     ).toHaveLength(0);
   });
 
-  it('Sparrowhawk ICE CF thrust 7 — no errors', () => {
+  it("Sparrowhawk ICE CF thrust 7 — no errors", () => {
     expect(
       validateThrust(
         AerospaceEngineType.ICE,
@@ -547,40 +563,40 @@ describe('VAL-AERO-THRUST', () => {
     ).toHaveLength(0);
   });
 
-  it('Fusion on CF → VAL-AERO-THRUST (illegal engine)', () => {
+  it("Fusion on CF → VAL-AERO-THRUST (illegal engine)", () => {
     const errors = validateThrust(
       AerospaceEngineType.FUSION,
       5,
       AerospaceSubType.CONVENTIONAL_FIGHTER,
     );
-    expect(errors.some((e) => e.ruleId === 'VAL-AERO-THRUST')).toBe(true);
+    expect(errors.some((e) => e.ruleId === "VAL-AERO-THRUST")).toBe(true);
   });
 
-  it('ICE on ASF → VAL-AERO-THRUST (illegal engine)', () => {
+  it("ICE on ASF → VAL-AERO-THRUST (illegal engine)", () => {
     const errors = validateThrust(
       AerospaceEngineType.ICE,
       5,
       AerospaceSubType.AEROSPACE_FIGHTER,
     );
-    expect(errors.some((e) => e.ruleId === 'VAL-AERO-THRUST')).toBe(true);
+    expect(errors.some((e) => e.ruleId === "VAL-AERO-THRUST")).toBe(true);
   });
 
-  it('safeThrust 13 on ASF → VAL-AERO-THRUST (exceeds cap of 12)', () => {
+  it("safeThrust 13 on ASF → VAL-AERO-THRUST (exceeds cap of 12)", () => {
     const errors = validateThrust(
       AerospaceEngineType.FUSION,
       13,
       AerospaceSubType.AEROSPACE_FIGHTER,
     );
-    expect(errors.some((e) => e.ruleId === 'VAL-AERO-THRUST')).toBe(true);
+    expect(errors.some((e) => e.ruleId === "VAL-AERO-THRUST")).toBe(true);
   });
 
-  it('safeThrust 7 on SmallCraft → VAL-AERO-THRUST (exceeds cap of 6)', () => {
+  it("safeThrust 7 on SmallCraft → VAL-AERO-THRUST (exceeds cap of 6)", () => {
     const errors = validateThrust(
       AerospaceEngineType.FUSION,
       7,
       AerospaceSubType.SMALL_CRAFT,
     );
-    expect(errors.some((e) => e.ruleId === 'VAL-AERO-THRUST')).toBe(true);
+    expect(errors.some((e) => e.ruleId === "VAL-AERO-THRUST")).toBe(true);
   });
 });
 
@@ -588,35 +604,35 @@ describe('VAL-AERO-THRUST', () => {
 // VAL-AERO-SI
 // ============================================================================
 
-describe('VAL-AERO-SI', () => {
-  it('Shilone SI=7 on 65t ASF — no errors', () => {
+describe("VAL-AERO-SI", () => {
+  it("Shilone SI=7 on 65t ASF — no errors", () => {
     expect(validateSI(7, AerospaceSubType.AEROSPACE_FIGHTER)).toHaveLength(0);
   });
 
-  it('SI at maximum (20) for ASF — no errors', () => {
+  it("SI at maximum (20) for ASF — no errors", () => {
     expect(validateSI(20, AerospaceSubType.AEROSPACE_FIGHTER)).toHaveLength(0);
   });
 
-  it('SI=21 on ASF → VAL-AERO-SI error (max 20)', () => {
+  it("SI=21 on ASF → VAL-AERO-SI error (max 20)", () => {
     const errors = validateSI(21, AerospaceSubType.AEROSPACE_FIGHTER);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe('VAL-AERO-SI');
+    expect(errors[0].ruleId).toBe("VAL-AERO-SI");
   });
 
-  it('SI=16 on CF → VAL-AERO-SI error (max 15)', () => {
+  it("SI=16 on CF → VAL-AERO-SI error (max 15)", () => {
     const errors = validateSI(16, AerospaceSubType.CONVENTIONAL_FIGHTER);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe('VAL-AERO-SI');
+    expect(errors[0].ruleId).toBe("VAL-AERO-SI");
   });
 
-  it('SI=30 on SmallCraft — no errors (at maximum)', () => {
+  it("SI=30 on SmallCraft — no errors (at maximum)", () => {
     expect(validateSI(30, AerospaceSubType.SMALL_CRAFT)).toHaveLength(0);
   });
 
-  it('SI=31 on SmallCraft → VAL-AERO-SI error (max 30)', () => {
+  it("SI=31 on SmallCraft → VAL-AERO-SI error (max 30)", () => {
     const errors = validateSI(31, AerospaceSubType.SMALL_CRAFT);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe('VAL-AERO-SI');
+    expect(errors[0].ruleId).toBe("VAL-AERO-SI");
   });
 });
 
@@ -624,37 +640,37 @@ describe('VAL-AERO-SI', () => {
 // VAL-AERO-FUEL
 // ============================================================================
 
-describe('VAL-AERO-FUEL', () => {
-  it('Shilone 5t fuel ASF — no errors (exactly at minimum)', () => {
+describe("VAL-AERO-FUEL", () => {
+  it("Shilone 5t fuel ASF — no errors (exactly at minimum)", () => {
     expect(validateFuel(5, AerospaceSubType.AEROSPACE_FIGHTER)).toHaveLength(0);
   });
 
-  it('Sparrowhawk 2t fuel CF — no errors (exactly at minimum)', () => {
+  it("Sparrowhawk 2t fuel CF — no errors (exactly at minimum)", () => {
     expect(validateFuel(2, AerospaceSubType.CONVENTIONAL_FIGHTER)).toHaveLength(
       0,
     );
   });
 
-  it('Seeker 20t fuel SmallCraft — no errors (exactly at minimum)', () => {
+  it("Seeker 20t fuel SmallCraft — no errors (exactly at minimum)", () => {
     expect(validateFuel(20, AerospaceSubType.SMALL_CRAFT)).toHaveLength(0);
   });
 
-  it('ASF with 4t fuel → VAL-AERO-FUEL error (min 5t)', () => {
+  it("ASF with 4t fuel → VAL-AERO-FUEL error (min 5t)", () => {
     const errors = validateFuel(4, AerospaceSubType.AEROSPACE_FIGHTER);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe('VAL-AERO-FUEL');
+    expect(errors[0].ruleId).toBe("VAL-AERO-FUEL");
   });
 
-  it('CF with 1t fuel → VAL-AERO-FUEL error (min 2t)', () => {
+  it("CF with 1t fuel → VAL-AERO-FUEL error (min 2t)", () => {
     const errors = validateFuel(1, AerospaceSubType.CONVENTIONAL_FIGHTER);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe('VAL-AERO-FUEL');
+    expect(errors[0].ruleId).toBe("VAL-AERO-FUEL");
   });
 
-  it('SmallCraft with 19t fuel → VAL-AERO-FUEL error (min 20t)', () => {
+  it("SmallCraft with 19t fuel → VAL-AERO-FUEL error (min 20t)", () => {
     const errors = validateFuel(19, AerospaceSubType.SMALL_CRAFT);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe('VAL-AERO-FUEL');
+    expect(errors[0].ruleId).toBe("VAL-AERO-FUEL");
   });
 });
 
@@ -662,8 +678,8 @@ describe('VAL-AERO-FUEL', () => {
 // VAL-AERO-ARC-MAX
 // ============================================================================
 
-describe('VAL-AERO-ARC-MAX', () => {
-  it('Shilone: valid arc allocations — no errors', () => {
+describe("VAL-AERO-ARC-MAX", () => {
+  it("Shilone: valid arc allocations — no errors", () => {
     // maxArcArmorPoints(NOSE, 65, ASF) = 18; allocating 10 is fine
     expect(
       validateArcArmor(
@@ -679,7 +695,7 @@ describe('VAL-AERO-ARC-MAX', () => {
     ).toHaveLength(0);
   });
 
-  it('Stuka: valid arc allocations — no errors', () => {
+  it("Stuka: valid arc allocations — no errors", () => {
     expect(
       validateArcArmor(
         {
@@ -694,7 +710,7 @@ describe('VAL-AERO-ARC-MAX', () => {
     ).toHaveLength(0);
   });
 
-  it('Nose over max → VAL-AERO-ARC-MAX error', () => {
+  it("Nose over max → VAL-AERO-ARC-MAX error", () => {
     // max nose for 65t ASF = floor(65×0.28) = 18; allocating 19 violates
     const errors = validateArcArmor(
       { [AerospaceArc.NOSE]: 19 },
@@ -702,10 +718,10 @@ describe('VAL-AERO-ARC-MAX', () => {
       AerospaceSubType.AEROSPACE_FIGHTER,
     );
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe('VAL-AERO-ARC-MAX');
+    expect(errors[0].ruleId).toBe("VAL-AERO-ARC-MAX");
   });
 
-  it('Wing over max → VAL-AERO-ARC-MAX error', () => {
+  it("Wing over max → VAL-AERO-ARC-MAX error", () => {
     // max wing for 65t ASF = floor(65×0.20) = 13; allocating 14 violates
     const errors = validateArcArmor(
       { [AerospaceArc.LEFT_WING]: 14 },
@@ -713,10 +729,10 @@ describe('VAL-AERO-ARC-MAX', () => {
       AerospaceSubType.AEROSPACE_FIGHTER,
     );
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe('VAL-AERO-ARC-MAX');
+    expect(errors[0].ruleId).toBe("VAL-AERO-ARC-MAX");
   });
 
-  it('Seeker small craft: valid side arc allocations — no errors', () => {
+  it("Seeker small craft: valid side arc allocations — no errors", () => {
     expect(
       validateArcArmor(
         {
@@ -731,7 +747,7 @@ describe('VAL-AERO-ARC-MAX', () => {
     ).toHaveLength(0);
   });
 
-  it('Inapplicable arcs (factor=0) are silently ignored', () => {
+  it("Inapplicable arcs (factor=0) are silently ignored", () => {
     // LEFT_WING has factor 0 for small craft — allocating any amount should not error
     expect(
       validateArcArmor(
@@ -747,36 +763,36 @@ describe('VAL-AERO-ARC-MAX', () => {
 // VAL-AERO-CREW
 // ============================================================================
 
-describe('VAL-AERO-CREW', () => {
-  it('ASF: crew rule is a no-op (always passes)', () => {
+describe("VAL-AERO-CREW", () => {
+  it("ASF: crew rule is a no-op (always passes)", () => {
     expect(validateCrew(AerospaceSubType.AEROSPACE_FIGHTER, 0, 0)).toHaveLength(
       0,
     );
   });
 
-  it('CF: crew rule is a no-op (always passes)', () => {
+  it("CF: crew rule is a no-op (always passes)", () => {
     expect(
       validateCrew(AerospaceSubType.CONVENTIONAL_FIGHTER, 0, 0),
     ).toHaveLength(0);
   });
 
-  it('SmallCraft with quarters + crew — no errors', () => {
+  it("SmallCraft with quarters + crew — no errors", () => {
     expect(validateCrew(AerospaceSubType.SMALL_CRAFT, 15, 3)).toHaveLength(0);
   });
 
-  it('SmallCraft with 0 quarters → VAL-AERO-CREW error', () => {
+  it("SmallCraft with 0 quarters → VAL-AERO-CREW error", () => {
     const errors = validateCrew(AerospaceSubType.SMALL_CRAFT, 0, 3);
-    expect(errors.some((e) => e.ruleId === 'VAL-AERO-CREW')).toBe(true);
+    expect(errors.some((e) => e.ruleId === "VAL-AERO-CREW")).toBe(true);
   });
 
-  it('SmallCraft with 0 crew → VAL-AERO-CREW error', () => {
+  it("SmallCraft with 0 crew → VAL-AERO-CREW error", () => {
     const errors = validateCrew(AerospaceSubType.SMALL_CRAFT, 15, 0);
-    expect(errors.some((e) => e.ruleId === 'VAL-AERO-CREW')).toBe(true);
+    expect(errors.some((e) => e.ruleId === "VAL-AERO-CREW")).toBe(true);
   });
 
-  it('SmallCraft with 0 quarters AND 0 crew → two VAL-AERO-CREW errors', () => {
+  it("SmallCraft with 0 quarters AND 0 crew → two VAL-AERO-CREW errors", () => {
     const errors = validateCrew(AerospaceSubType.SMALL_CRAFT, 0, 0);
-    expect(errors.filter((e) => e.ruleId === 'VAL-AERO-CREW')).toHaveLength(2);
+    expect(errors.filter((e) => e.ruleId === "VAL-AERO-CREW")).toHaveLength(2);
   });
 });
 
@@ -784,48 +800,48 @@ describe('VAL-AERO-CREW', () => {
 // validateAerospaceUnit (full runner)
 // ============================================================================
 
-describe('validateAerospaceUnit — full runner', () => {
-  it('Shilone (ASF, 65t, Fusion, thrust 5) — clean build', () => {
+describe("validateAerospaceUnit — full runner", () => {
+  it("Shilone (ASF, 65t, Fusion, thrust 5) — clean build", () => {
     expect(validateAerospaceUnit(shiloneInput())).toHaveLength(0);
   });
 
-  it('Stuka (ASF, 100t, Fusion, thrust 4) — clean build', () => {
+  it("Stuka (ASF, 100t, Fusion, thrust 4) — clean build", () => {
     expect(validateAerospaceUnit(stukaInput())).toHaveLength(0);
   });
 
-  it('Sparrowhawk (CF, 30t, ICE, thrust 7) — clean build', () => {
+  it("Sparrowhawk (CF, 30t, ICE, thrust 7) — clean build", () => {
     expect(validateAerospaceUnit(sparrowhawkInput())).toHaveLength(0);
   });
 
-  it('Seeker (SmallCraft, 100t, Fusion, crew 3) — clean build', () => {
+  it("Seeker (SmallCraft, 100t, Fusion, crew 3) — clean build", () => {
     expect(validateAerospaceUnit(seekerInput())).toHaveLength(0);
   });
 
-  it('Shilone with Fusion engine swapped to ICE → VAL-AERO-THRUST', () => {
+  it("Shilone with Fusion engine swapped to ICE → VAL-AERO-THRUST", () => {
     const input = { ...shiloneInput(), engineType: AerospaceEngineType.ICE };
     const errors = validateAerospaceUnit(input);
-    expect(errors.some((e) => e.ruleId === 'VAL-AERO-THRUST')).toBe(true);
+    expect(errors.some((e) => e.ruleId === "VAL-AERO-THRUST")).toBe(true);
   });
 
-  it('Shilone with tonnage 101 → VAL-AERO-TONNAGE', () => {
+  it("Shilone with tonnage 101 → VAL-AERO-TONNAGE", () => {
     const input = { ...shiloneInput(), tonnage: 101 };
     const errors = validateAerospaceUnit(input);
-    expect(errors.some((e) => e.ruleId === 'VAL-AERO-TONNAGE')).toBe(true);
+    expect(errors.some((e) => e.ruleId === "VAL-AERO-TONNAGE")).toBe(true);
   });
 
-  it('Shilone with SI=21 → VAL-AERO-SI', () => {
+  it("Shilone with SI=21 → VAL-AERO-SI", () => {
     const input = { ...shiloneInput(), structuralIntegrity: 21 };
     const errors = validateAerospaceUnit(input);
-    expect(errors.some((e) => e.ruleId === 'VAL-AERO-SI')).toBe(true);
+    expect(errors.some((e) => e.ruleId === "VAL-AERO-SI")).toBe(true);
   });
 
-  it('Shilone with fuelTons=4 → VAL-AERO-FUEL', () => {
+  it("Shilone with fuelTons=4 → VAL-AERO-FUEL", () => {
     const input = { ...shiloneInput(), fuelTons: 4 };
     const errors = validateAerospaceUnit(input);
-    expect(errors.some((e) => e.ruleId === 'VAL-AERO-FUEL')).toBe(true);
+    expect(errors.some((e) => e.ruleId === "VAL-AERO-FUEL")).toBe(true);
   });
 
-  it('Shilone with nose armor over max → VAL-AERO-ARC-MAX', () => {
+  it("Shilone with nose armor over max → VAL-AERO-ARC-MAX", () => {
     const input = {
       ...shiloneInput(),
       arcArmor: {
@@ -836,16 +852,16 @@ describe('validateAerospaceUnit — full runner', () => {
       },
     };
     const errors = validateAerospaceUnit(input);
-    expect(errors.some((e) => e.ruleId === 'VAL-AERO-ARC-MAX')).toBe(true);
+    expect(errors.some((e) => e.ruleId === "VAL-AERO-ARC-MAX")).toBe(true);
   });
 
-  it('Seeker with no quarters → VAL-AERO-CREW', () => {
+  it("Seeker with no quarters → VAL-AERO-CREW", () => {
     const input = { ...seekerInput(), quartersTons: 0 };
     const errors = validateAerospaceUnit(input);
-    expect(errors.some((e) => e.ruleId === 'VAL-AERO-CREW')).toBe(true);
+    expect(errors.some((e) => e.ruleId === "VAL-AERO-CREW")).toBe(true);
   });
 
-  it('multiple violations are all reported', () => {
+  it("multiple violations are all reported", () => {
     // Tonnage + fuel both wrong
     const input = {
       ...shiloneInput(),
@@ -854,7 +870,461 @@ describe('validateAerospaceUnit — full runner', () => {
     };
     const errors = validateAerospaceUnit(input);
     const ruleIds = errors.map((e) => e.ruleId);
-    expect(ruleIds).toContain('VAL-AERO-TONNAGE');
-    expect(ruleIds).toContain('VAL-AERO-FUEL');
+    expect(ruleIds).toContain("VAL-AERO-TONNAGE");
+    expect(ruleIds).toContain("VAL-AERO-FUEL");
+  });
+});
+
+// ============================================================================
+// Task 7.3 — Wing-mounted heavy weapons (PPC, Gauss) tonnage cap
+// ============================================================================
+
+describe("wingHeavyWeapons (Task 7.3)", () => {
+  describe("isWingHeavyWeapon", () => {
+    it("identifies PPC variants by id", () => {
+      expect(isWingHeavyWeapon("isppc")).toBe(true);
+      expect(isWingHeavyWeapon("clERPPC")).toBe(true);
+      expect(isWingHeavyWeapon("ISHeavyPPC")).toBe(true);
+    });
+
+    it("identifies PPC variants by display name", () => {
+      expect(isWingHeavyWeapon("PPC")).toBe(true);
+      expect(isWingHeavyWeapon("ER PPC")).toBe(true);
+      expect(isWingHeavyWeapon("Snub-Nose PPC")).toBe(true);
+    });
+
+    it("identifies Gauss family", () => {
+      expect(isWingHeavyWeapon("isgaussrifle")).toBe(true);
+      expect(isWingHeavyWeapon("Heavy Gauss Rifle")).toBe(true);
+      expect(isWingHeavyWeapon("Light Gauss Rifle")).toBe(true);
+    });
+
+    it("identifies AC/20 variants", () => {
+      expect(isWingHeavyWeapon("AC/20")).toBe(true);
+      expect(isWingHeavyWeapon("isac20")).toBe(true);
+      expect(isWingHeavyWeapon("Autocannon/20")).toBe(true);
+    });
+
+    it("rejects light/medium weapons", () => {
+      expect(isWingHeavyWeapon("Medium Laser")).toBe(false);
+      expect(isWingHeavyWeapon("ismediumlaser")).toBe(false);
+      expect(isWingHeavyWeapon("Machine Gun")).toBe(false);
+      expect(isWingHeavyWeapon("LRM 5")).toBe(false);
+      expect(isWingHeavyWeapon("AC/2")).toBe(false);
+    });
+  });
+
+  describe("maxHeavyWeaponTonsPerWing", () => {
+    it("Shilone (65t ASF) → cap 6", () => {
+      expect(
+        maxHeavyWeaponTonsPerWing(65, AerospaceSubType.AEROSPACE_FIGHTER),
+      ).toBe(6);
+    });
+
+    it("Stuka (100t ASF) → cap 10", () => {
+      expect(
+        maxHeavyWeaponTonsPerWing(100, AerospaceSubType.AEROSPACE_FIGHTER),
+      ).toBe(10);
+    });
+
+    it("Sparrowhawk (30t CF) → cap 3", () => {
+      expect(
+        maxHeavyWeaponTonsPerWing(30, AerospaceSubType.CONVENTIONAL_FIGHTER),
+      ).toBe(3);
+    });
+
+    it("small craft → cap 0 (rule does not apply)", () => {
+      expect(maxHeavyWeaponTonsPerWing(100, AerospaceSubType.SMALL_CRAFT)).toBe(
+        0,
+      );
+    });
+  });
+
+  describe("canMountHeavyOnWing", () => {
+    it("Stuka left wing has 4t already, can add 6t (10t cap)", () => {
+      expect(
+        canMountHeavyOnWing(
+          AerospaceArc.LEFT_WING,
+          4,
+          6,
+          100,
+          AerospaceSubType.AEROSPACE_FIGHTER,
+        ),
+      ).toBe(true);
+    });
+
+    it("Stuka left wing has 7t already, cannot add 4t (would hit 11)", () => {
+      expect(
+        canMountHeavyOnWing(
+          AerospaceArc.LEFT_WING,
+          7,
+          4,
+          100,
+          AerospaceSubType.AEROSPACE_FIGHTER,
+        ),
+      ).toBe(false);
+    });
+
+    it("Nose arc has no wing cap (always allowed)", () => {
+      expect(
+        canMountHeavyOnWing(
+          AerospaceArc.NOSE,
+          99,
+          50,
+          50,
+          AerospaceSubType.AEROSPACE_FIGHTER,
+        ),
+      ).toBe(true);
+    });
+
+    it("Aft arc has no wing cap", () => {
+      expect(
+        canMountHeavyOnWing(
+          AerospaceArc.AFT,
+          0,
+          50,
+          50,
+          AerospaceSubType.AEROSPACE_FIGHTER,
+        ),
+      ).toBe(true);
+    });
+
+    it("Fuselage arc has no wing cap", () => {
+      expect(
+        canMountHeavyOnWing(
+          AerospaceArc.FUSELAGE,
+          99,
+          99,
+          50,
+          AerospaceSubType.AEROSPACE_FIGHTER,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("heavyTonsByWing", () => {
+    it("aggregates only heavy weapons in wing arcs", () => {
+      const items = [
+        { arc: AerospaceArc.LEFT_WING, idOrName: "PPC", tons: 7 },
+        { arc: AerospaceArc.LEFT_WING, idOrName: "Medium Laser", tons: 1 },
+        { arc: AerospaceArc.RIGHT_WING, idOrName: "Gauss Rifle", tons: 15 },
+        { arc: AerospaceArc.NOSE, idOrName: "PPC", tons: 7 }, // not in wing arc
+        { arc: AerospaceArc.AFT, idOrName: "AC/20", tons: 14 }, // not in wing arc
+      ];
+      const result = heavyTonsByWing(items);
+      expect(result.get(AerospaceArc.LEFT_WING)).toBe(7);
+      expect(result.get(AerospaceArc.RIGHT_WING)).toBe(15);
+    });
+
+    it("empty input → both wings at 0", () => {
+      const result = heavyTonsByWing([]);
+      expect(result.get(AerospaceArc.LEFT_WING)).toBe(0);
+      expect(result.get(AerospaceArc.RIGHT_WING)).toBe(0);
+    });
+  });
+
+  describe("validateWingHeavyWeapons (VAL-AERO-WING-HEAVY)", () => {
+    it("Stuka with PPC + ER Large Laser on left wing — within 10t cap", () => {
+      const items = [
+        { arc: AerospaceArc.LEFT_WING, idOrName: "PPC", tons: 7 },
+        { arc: AerospaceArc.LEFT_WING, idOrName: "ER Large Laser", tons: 5 },
+      ];
+      // PPC=7t counts as heavy, ER Large Laser does not. 7 ≤ 10. Pass.
+      expect(
+        validateWingHeavyWeapons(
+          items,
+          100,
+          AerospaceSubType.AEROSPACE_FIGHTER,
+        ),
+      ).toHaveLength(0);
+    });
+
+    it("Stuka with two PPCs on left wing → exceeds 10t cap", () => {
+      const items = [
+        { arc: AerospaceArc.LEFT_WING, idOrName: "PPC", tons: 7 },
+        { arc: AerospaceArc.LEFT_WING, idOrName: "ER PPC", tons: 7 },
+      ];
+      const errors = validateWingHeavyWeapons(
+        items,
+        100,
+        AerospaceSubType.AEROSPACE_FIGHTER,
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].ruleId).toBe("VAL-AERO-WING-HEAVY");
+      expect(errors[0].message).toContain("LeftWing");
+    });
+
+    it("Shilone (65t ASF) Gauss Rifle (15t) on right wing → exceeds 6t cap", () => {
+      const items = [
+        { arc: AerospaceArc.RIGHT_WING, idOrName: "Gauss Rifle", tons: 15 },
+      ];
+      const errors = validateWingHeavyWeapons(
+        items,
+        65,
+        AerospaceSubType.AEROSPACE_FIGHTER,
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].ruleId).toBe("VAL-AERO-WING-HEAVY");
+    });
+
+    it("Heavy weapon in nose arc does NOT trigger wing cap", () => {
+      const items = [
+        { arc: AerospaceArc.NOSE, idOrName: "Heavy Gauss Rifle", tons: 18 },
+      ];
+      expect(
+        validateWingHeavyWeapons(items, 65, AerospaceSubType.AEROSPACE_FIGHTER),
+      ).toHaveLength(0);
+    });
+
+    it("Both wings overloaded → two errors", () => {
+      const items = [
+        { arc: AerospaceArc.LEFT_WING, idOrName: "PPC", tons: 7 },
+        { arc: AerospaceArc.LEFT_WING, idOrName: "Gauss Rifle", tons: 15 },
+        { arc: AerospaceArc.RIGHT_WING, idOrName: "PPC", tons: 7 },
+        { arc: AerospaceArc.RIGHT_WING, idOrName: "Gauss Rifle", tons: 15 },
+      ];
+      const errors = validateWingHeavyWeapons(
+        items,
+        100,
+        AerospaceSubType.AEROSPACE_FIGHTER,
+      );
+      expect(errors).toHaveLength(2);
+      expect(errors.every((e) => e.ruleId === "VAL-AERO-WING-HEAVY")).toBe(
+        true,
+      );
+    });
+
+    it("Small craft is exempt — heavy tonnage in side arc passes", () => {
+      const items = [
+        { arc: AerospaceArc.LEFT_WING, idOrName: "PPC", tons: 99 },
+      ];
+      expect(
+        validateWingHeavyWeapons(items, 100, AerospaceSubType.SMALL_CRAFT),
+      ).toHaveLength(0);
+    });
+
+    it("Empty equipment list → no errors", () => {
+      expect(
+        validateWingHeavyWeapons([], 100, AerospaceSubType.AEROSPACE_FIGHTER),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe("validateAerospaceUnit integration with wingMounts", () => {
+    it("Shilone with no wing mounts supplied → no wing-heavy errors", () => {
+      const errors = validateAerospaceUnit(shiloneInput());
+      expect(errors.some((e) => e.ruleId === "VAL-AERO-WING-HEAVY")).toBe(
+        false,
+      );
+    });
+
+    it("Shilone with overloaded right wing → VAL-AERO-WING-HEAVY", () => {
+      const input = {
+        ...shiloneInput(),
+        wingMounts: [
+          { arc: AerospaceArc.RIGHT_WING, idOrName: "PPC", tons: 7 },
+        ],
+      };
+      // 65t ASF cap = 6, PPC = 7t → violation
+      const errors = validateAerospaceUnit(input);
+      expect(errors.some((e) => e.ruleId === "VAL-AERO-WING-HEAVY")).toBe(true);
+    });
+
+    it("Stuka with legal wing PPC mount → clean build", () => {
+      const input = {
+        ...stukaInput(),
+        wingMounts: [
+          { arc: AerospaceArc.LEFT_WING, idOrName: "PPC", tons: 7 },
+          { arc: AerospaceArc.RIGHT_WING, idOrName: "PPC", tons: 7 },
+        ],
+      };
+      // Cap = 10 per wing, 7 ≤ 10. Pass.
+      expect(validateAerospaceUnit(input)).toHaveLength(0);
+    });
+  });
+});
+
+// ============================================================================
+// Task 7.4 — Bomb bays (small craft, configurable)
+// ============================================================================
+
+describe("bombBays (Task 7.4)", () => {
+  describe("bayTons", () => {
+    it("0-capacity bay still costs 1t structure", () => {
+      expect(bayTons({ id: "b1", capacityBombs: 0 })).toBe(BAY_STRUCTURE_TONS);
+    });
+
+    it("4-bomb bay → 4 + 1 = 5t", () => {
+      expect(bayTons({ id: "b1", capacityBombs: 4 })).toBe(5);
+    });
+
+    it("10-bomb bay → 10 + 1 = 11t", () => {
+      expect(bayTons({ id: "b1", capacityBombs: 10 })).toBe(11);
+    });
+
+    it("negative capacity is clamped to 0", () => {
+      expect(bayTons({ id: "b1", capacityBombs: -3 })).toBe(BAY_STRUCTURE_TONS);
+    });
+  });
+
+  describe("totalBombBayTons / totalBombCapacity", () => {
+    it("sum across multiple bays", () => {
+      const bays = [
+        { id: "b1", capacityBombs: 4 },
+        { id: "b2", capacityBombs: 8 },
+        { id: "b3", capacityBombs: 0 },
+      ];
+      // Tons: (4+1) + (8+1) + (0+1) = 15
+      expect(totalBombBayTons(bays)).toBe(15);
+      // Capacity: 4 + 8 + 0 = 12
+      expect(totalBombCapacity(bays)).toBe(12);
+    });
+
+    it("empty list → 0", () => {
+      expect(totalBombBayTons([])).toBe(0);
+      expect(totalBombCapacity([])).toBe(0);
+    });
+  });
+
+  describe("maxBombBayTons", () => {
+    it("100t small craft → 50t cap", () => {
+      expect(maxBombBayTons(100, AerospaceSubType.SMALL_CRAFT)).toBe(50);
+    });
+
+    it("200t small craft → 100t cap", () => {
+      expect(maxBombBayTons(200, AerospaceSubType.SMALL_CRAFT)).toBe(100);
+    });
+
+    it("ASF → 0 (rule N/A)", () => {
+      expect(maxBombBayTons(100, AerospaceSubType.AEROSPACE_FIGHTER)).toBe(0);
+    });
+
+    it("CF → 0 (rule N/A)", () => {
+      expect(maxBombBayTons(50, AerospaceSubType.CONVENTIONAL_FIGHTER)).toBe(0);
+    });
+  });
+
+  describe("validateBombBays (VAL-AERO-BOMB-BAY)", () => {
+    it("small craft with no bays → no errors", () => {
+      expect(
+        validateBombBays([], 100, AerospaceSubType.SMALL_CRAFT),
+      ).toHaveLength(0);
+    });
+
+    it("small craft with legal bays under cap → no errors", () => {
+      // 100t cap = 50t. Bays: (10+1) + (10+1) = 22t. Pass.
+      const bays = [
+        { id: "b1", capacityBombs: 10 },
+        { id: "b2", capacityBombs: 10 },
+      ];
+      expect(
+        validateBombBays(bays, 100, AerospaceSubType.SMALL_CRAFT),
+      ).toHaveLength(0);
+    });
+
+    it("small craft with bays exceeding cap → VAL-AERO-BOMB-BAY", () => {
+      // 100t cap = 50t. Bays: (49+1) + (5+1) = 56t > 50.
+      const bays = [
+        { id: "b1", capacityBombs: 49 },
+        { id: "b2", capacityBombs: 5 },
+      ];
+      const errors = validateBombBays(bays, 100, AerospaceSubType.SMALL_CRAFT);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].ruleId).toBe("VAL-AERO-BOMB-BAY");
+      expect(errors[0].message).toContain("56t");
+      expect(errors[0].message).toContain("50t");
+    });
+
+    it("small craft bay with negative capacity → VAL-AERO-BOMB-BAY", () => {
+      const bays = [{ id: "b1", capacityBombs: -2 }];
+      const errors = validateBombBays(bays, 100, AerospaceSubType.SMALL_CRAFT);
+      expect(errors.some((e) => e.ruleId === "VAL-AERO-BOMB-BAY")).toBe(true);
+    });
+
+    it("small craft bay with non-integer capacity → VAL-AERO-BOMB-BAY", () => {
+      const bays = [{ id: "b1", capacityBombs: 3.5 }];
+      const errors = validateBombBays(bays, 100, AerospaceSubType.SMALL_CRAFT);
+      expect(errors.some((e) => e.ruleId === "VAL-AERO-BOMB-BAY")).toBe(true);
+    });
+
+    it("ASF with bombBays declared → VAL-AERO-BOMB-BAY (sub-type illegal)", () => {
+      const bays = [{ id: "b1", capacityBombs: 4 }];
+      const errors = validateBombBays(
+        bays,
+        65,
+        AerospaceSubType.AEROSPACE_FIGHTER,
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].ruleId).toBe("VAL-AERO-BOMB-BAY");
+      expect(errors[0].message).toMatch(/only configurable on small craft/);
+    });
+
+    it("CF with bombBays declared → VAL-AERO-BOMB-BAY (sub-type illegal)", () => {
+      const bays = [{ id: "b1", capacityBombs: 4 }];
+      const errors = validateBombBays(
+        bays,
+        30,
+        AerospaceSubType.CONVENTIONAL_FIGHTER,
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0].ruleId).toBe("VAL-AERO-BOMB-BAY");
+    });
+
+    it("ASF with no bombBays → no errors (single hasBombBay path is unaffected)", () => {
+      expect(
+        validateBombBays([], 65, AerospaceSubType.AEROSPACE_FIGHTER),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe("validateAerospaceUnit integration with bombBays", () => {
+    it("Seeker with no bombBays supplied → no bay errors", () => {
+      const errors = validateAerospaceUnit(seekerInput());
+      expect(errors.some((e) => e.ruleId === "VAL-AERO-BOMB-BAY")).toBe(false);
+    });
+
+    it("Seeker with two legal bays → clean build", () => {
+      const input = {
+        ...seekerInput(),
+        bombBays: [
+          { id: "fwd", capacityBombs: 10 },
+          { id: "aft", capacityBombs: 10 },
+        ],
+      };
+      expect(validateAerospaceUnit(input)).toHaveLength(0);
+    });
+
+    it("Seeker with oversized bay → VAL-AERO-BOMB-BAY", () => {
+      const input = {
+        ...seekerInput(),
+        bombBays: [{ id: "huge", capacityBombs: 60 }],
+      };
+      // 100t × 0.5 = 50 cap; bay = 60+1 = 61. Violation.
+      const errors = validateAerospaceUnit(input);
+      expect(errors.some((e) => e.ruleId === "VAL-AERO-BOMB-BAY")).toBe(true);
+    });
+
+    it("Shilone with bombBays → VAL-AERO-BOMB-BAY (ASF cannot use small-craft bays)", () => {
+      const input = {
+        ...shiloneInput(),
+        bombBays: [{ id: "b1", capacityBombs: 4 }],
+      };
+      const errors = validateAerospaceUnit(input);
+      expect(errors.some((e) => e.ruleId === "VAL-AERO-BOMB-BAY")).toBe(true);
+    });
+  });
+});
+
+// ============================================================================
+// Validation registry — both new rules registered
+// ============================================================================
+
+describe("AERO_VALIDATION_RULE_IDS includes new rules", () => {
+  it("includes VAL-AERO-WING-HEAVY", () => {
+    expect(AERO_VALIDATION_RULE_IDS).toContain("VAL-AERO-WING-HEAVY");
+  });
+
+  it("includes VAL-AERO-BOMB-BAY", () => {
+    expect(AERO_VALIDATION_RULE_IDS).toContain("VAL-AERO-BOMB-BAY");
   });
 });

--- a/src/__tests__/unit/aerospace-construction.test.ts
+++ b/src/__tests__/unit/aerospace-construction.test.ts
@@ -16,7 +16,7 @@ import {
   AerospaceArc,
   AerospaceEngineType,
   AerospaceSubType,
-} from "@/types/unit/AerospaceInterfaces";
+} from '@/types/unit/AerospaceInterfaces';
 // ============================================================================
 // Calculator imports
 // ============================================================================
@@ -26,30 +26,38 @@ import {
   getArcsForSubType,
   ASF_CF_ARCS,
   SMALL_CRAFT_ARCS,
-} from "@/utils/construction/aerospace/armorArcCalculations";
+} from '@/utils/construction/aerospace/armorArcCalculations';
+import {
+  bayTons,
+  totalBombBayTons,
+  totalBombCapacity,
+  maxBombBayTons,
+  validateBombBays,
+  BAY_STRUCTURE_TONS,
+} from '@/utils/construction/aerospace/bombBays';
 import {
   makeSmallCraftCrew,
   quartersWeight,
   minSmallCraftCrew,
-} from "@/utils/construction/aerospace/crewCalculations";
-import { aerospaceEngineWeight } from "@/utils/construction/aerospace/engineWeightAerospace";
+} from '@/utils/construction/aerospace/crewCalculations';
+import { aerospaceEngineWeight } from '@/utils/construction/aerospace/engineWeightAerospace';
 import {
   calculateFuelPoints,
   FUEL_POINTS_PER_TON,
   FUEL_MINIMUM_TONS,
   minFuelTons,
-} from "@/utils/construction/aerospace/fuelCalculations";
+} from '@/utils/construction/aerospace/fuelCalculations';
 import {
   defaultSI,
   maxSI,
   siWeightCost,
-} from "@/utils/construction/aerospace/siCalculations";
+} from '@/utils/construction/aerospace/siCalculations';
 import {
   calculateSafeThrust,
   calculateMaxThrust,
   getMaxSafeThrust,
   isEngineLegalForSubType,
-} from "@/utils/construction/aerospace/thrustCalculations";
+} from '@/utils/construction/aerospace/thrustCalculations';
 // ============================================================================
 // Validation imports
 // ============================================================================
@@ -62,22 +70,14 @@ import {
   validateArcArmor,
   validateCrew,
   AERO_VALIDATION_RULE_IDS,
-} from "@/utils/construction/aerospace/validationRules";
+} from '@/utils/construction/aerospace/validationRules';
 import {
   isWingHeavyWeapon,
   maxHeavyWeaponTonsPerWing,
   canMountHeavyOnWing,
   heavyTonsByWing,
   validateWingHeavyWeapons,
-} from "@/utils/construction/aerospace/wingHeavyWeapons";
-import {
-  bayTons,
-  totalBombBayTons,
-  totalBombCapacity,
-  maxBombBayTons,
-  validateBombBays,
-  BAY_STRUCTURE_TONS,
-} from "@/utils/construction/aerospace/bombBays";
+} from '@/utils/construction/aerospace/wingHeavyWeapons';
 
 // ============================================================================
 // Helpers
@@ -167,55 +167,55 @@ function seekerInput() {
 // thrustCalculations
 // ============================================================================
 
-describe("thrustCalculations", () => {
-  describe("calculateSafeThrust", () => {
-    it("Shilone: 65t × thrust 5 → engineRating 325 → safeThrust 5", () => {
+describe('thrustCalculations', () => {
+  describe('calculateSafeThrust', () => {
+    it('Shilone: 65t × thrust 5 → engineRating 325 → safeThrust 5', () => {
       // engineRating = 65 × 5 = 325; floor(325/65) = 5
       expect(
         calculateSafeThrust(325, 65, AerospaceSubType.AEROSPACE_FIGHTER),
       ).toBe(5);
     });
 
-    it("Stuka: 100t × thrust 4 → engineRating 400 → safeThrust 4", () => {
+    it('Stuka: 100t × thrust 4 → engineRating 400 → safeThrust 4', () => {
       expect(
         calculateSafeThrust(400, 100, AerospaceSubType.AEROSPACE_FIGHTER),
       ).toBe(4);
     });
 
-    it("Sparrowhawk: 30t × thrust 7 → engineRating 210 → safeThrust 7", () => {
+    it('Sparrowhawk: 30t × thrust 7 → engineRating 210 → safeThrust 7', () => {
       expect(
         calculateSafeThrust(210, 30, AerospaceSubType.CONVENTIONAL_FIGHTER),
       ).toBe(7);
     });
 
-    it("clamps safeThrust to sub-type cap (ASF cap=12)", () => {
+    it('clamps safeThrust to sub-type cap (ASF cap=12)', () => {
       // rating would give 15 thrust but capped at 12
       expect(
         calculateSafeThrust(1500, 100, AerospaceSubType.AEROSPACE_FIGHTER),
       ).toBe(12);
     });
 
-    it("small craft cap is 6", () => {
+    it('small craft cap is 6', () => {
       expect(getMaxSafeThrust(AerospaceSubType.SMALL_CRAFT)).toBe(6);
     });
   });
 
-  describe("calculateMaxThrust", () => {
-    it("safeThrust 5 → maxThrust 7 (floor(5×1.5))", () => {
+  describe('calculateMaxThrust', () => {
+    it('safeThrust 5 → maxThrust 7 (floor(5×1.5))', () => {
       expect(calculateMaxThrust(5)).toBe(7);
     });
 
-    it("safeThrust 4 → maxThrust 6", () => {
+    it('safeThrust 4 → maxThrust 6', () => {
       expect(calculateMaxThrust(4)).toBe(6);
     });
 
-    it("safeThrust 7 → maxThrust 10", () => {
+    it('safeThrust 7 → maxThrust 10', () => {
       expect(calculateMaxThrust(7)).toBe(10);
     });
   });
 
-  describe("isEngineLegalForSubType", () => {
-    it("Fusion is legal for ASF", () => {
+  describe('isEngineLegalForSubType', () => {
+    it('Fusion is legal for ASF', () => {
       expect(
         isEngineLegalForSubType(
           AerospaceEngineType.FUSION,
@@ -224,7 +224,7 @@ describe("thrustCalculations", () => {
       ).toBe(true);
     });
 
-    it("ICE is illegal for ASF", () => {
+    it('ICE is illegal for ASF', () => {
       expect(
         isEngineLegalForSubType(
           AerospaceEngineType.ICE,
@@ -233,7 +233,7 @@ describe("thrustCalculations", () => {
       ).toBe(false);
     });
 
-    it("Fusion is illegal for CF (must use ICE or FuelCell)", () => {
+    it('Fusion is illegal for CF (must use ICE or FuelCell)', () => {
       expect(
         isEngineLegalForSubType(
           AerospaceEngineType.FUSION,
@@ -242,7 +242,7 @@ describe("thrustCalculations", () => {
       ).toBe(false);
     });
 
-    it("ICE is legal for CF", () => {
+    it('ICE is legal for CF', () => {
       expect(
         isEngineLegalForSubType(
           AerospaceEngineType.ICE,
@@ -251,7 +251,7 @@ describe("thrustCalculations", () => {
       ).toBe(true);
     });
 
-    it("Fusion is legal for small craft", () => {
+    it('Fusion is legal for small craft', () => {
       expect(
         isEngineLegalForSubType(
           AerospaceEngineType.FUSION,
@@ -266,37 +266,37 @@ describe("thrustCalculations", () => {
 // siCalculations
 // ============================================================================
 
-describe("siCalculations", () => {
-  it("defaultSI: 65t → ceil(65/10) = 7", () => {
+describe('siCalculations', () => {
+  it('defaultSI: 65t → ceil(65/10) = 7', () => {
     expect(defaultSI(65)).toBe(7);
   });
 
-  it("defaultSI: 100t → 10", () => {
+  it('defaultSI: 100t → 10', () => {
     expect(defaultSI(100)).toBe(10);
   });
 
-  it("defaultSI: 30t → 3", () => {
+  it('defaultSI: 30t → 3', () => {
     expect(defaultSI(30)).toBe(3);
   });
 
-  it("maxSI: ASF → 20", () => {
+  it('maxSI: ASF → 20', () => {
     expect(maxSI(AerospaceSubType.AEROSPACE_FIGHTER)).toBe(20);
   });
 
-  it("maxSI: CF → 15", () => {
+  it('maxSI: CF → 15', () => {
     expect(maxSI(AerospaceSubType.CONVENTIONAL_FIGHTER)).toBe(15);
   });
 
-  it("maxSI: small craft → 30", () => {
+  it('maxSI: small craft → 30', () => {
     expect(maxSI(AerospaceSubType.SMALL_CRAFT)).toBe(30);
   });
 
-  it("siWeightCost: SI at default → 0 extra tons", () => {
+  it('siWeightCost: SI at default → 0 extra tons', () => {
     // Shilone: 65t, default SI = 7, cost for SI=7 → 0
     expect(siWeightCost(7, 65)).toBe(0);
   });
 
-  it("siWeightCost: 1 extra SI on 65t unit → (1 extra) × (65/10) × 0.5 = 3.25t", () => {
+  it('siWeightCost: 1 extra SI on 65t unit → (1 extra) × (65/10) × 0.5 = 3.25t', () => {
     // SI=8 on 65t: extra=1, cost = 1 × 6.5 × 0.5 = 3.25
     expect(siWeightCost(8, 65)).toBeCloseTo(3.25);
   });
@@ -306,36 +306,36 @@ describe("siCalculations", () => {
 // fuelCalculations
 // ============================================================================
 
-describe("fuelCalculations", () => {
-  it("Fusion: 5t → 400 fuel points (5 × 80)", () => {
+describe('fuelCalculations', () => {
+  it('Fusion: 5t → 400 fuel points (5 × 80)', () => {
     expect(calculateFuelPoints(5, AerospaceEngineType.FUSION)).toBe(400);
   });
 
-  it("ICE: 2t → 80 fuel points (2 × 40)", () => {
+  it('ICE: 2t → 80 fuel points (2 × 40)', () => {
     expect(calculateFuelPoints(2, AerospaceEngineType.ICE)).toBe(80);
   });
 
-  it("FuelCell: 3t → 180 fuel points (3 × 60)", () => {
+  it('FuelCell: 3t → 180 fuel points (3 × 60)', () => {
     expect(calculateFuelPoints(3, AerospaceEngineType.FUEL_CELL)).toBe(180);
   });
 
-  it("XL uses same rate as Fusion (80 pts/ton)", () => {
+  it('XL uses same rate as Fusion (80 pts/ton)', () => {
     expect(FUEL_POINTS_PER_TON[AerospaceEngineType.XL]).toBe(80);
   });
 
-  it("minFuelTons: ASF → 5t", () => {
+  it('minFuelTons: ASF → 5t', () => {
     expect(minFuelTons(AerospaceSubType.AEROSPACE_FIGHTER)).toBe(5);
   });
 
-  it("minFuelTons: CF → 2t", () => {
+  it('minFuelTons: CF → 2t', () => {
     expect(minFuelTons(AerospaceSubType.CONVENTIONAL_FIGHTER)).toBe(2);
   });
 
-  it("minFuelTons: small craft → 20t", () => {
+  it('minFuelTons: small craft → 20t', () => {
     expect(minFuelTons(AerospaceSubType.SMALL_CRAFT)).toBe(20);
   });
 
-  it("Seeker: 20t Fusion → 1600 fuel points", () => {
+  it('Seeker: 20t Fusion → 1600 fuel points', () => {
     expect(calculateFuelPoints(20, AerospaceEngineType.FUSION)).toBe(1600);
   });
 });
@@ -344,8 +344,8 @@ describe("fuelCalculations", () => {
 // armorArcCalculations
 // ============================================================================
 
-describe("armorArcCalculations", () => {
-  it("ASF/CF arcs are [Nose, LeftWing, RightWing, Aft]", () => {
+describe('armorArcCalculations', () => {
+  it('ASF/CF arcs are [Nose, LeftWing, RightWing, Aft]', () => {
     expect(getArcsForSubType(AerospaceSubType.AEROSPACE_FIGHTER)).toEqual(
       ASF_CF_ARCS,
     );
@@ -354,13 +354,13 @@ describe("armorArcCalculations", () => {
     );
   });
 
-  it("small craft arcs are [Nose, LeftSide, RightSide, Aft]", () => {
+  it('small craft arcs are [Nose, LeftSide, RightSide, Aft]', () => {
     expect(getArcsForSubType(AerospaceSubType.SMALL_CRAFT)).toEqual(
       SMALL_CRAFT_ARCS,
     );
   });
 
-  it("Shilone 65t ASF nose max = floor(65 × 0.28) = 18", () => {
+  it('Shilone 65t ASF nose max = floor(65 × 0.28) = 18', () => {
     expect(
       maxArcArmorPoints(
         AerospaceArc.NOSE,
@@ -370,7 +370,7 @@ describe("armorArcCalculations", () => {
     ).toBe(18);
   });
 
-  it("Shilone 65t ASF wing max = floor(65 × 0.20) = 13", () => {
+  it('Shilone 65t ASF wing max = floor(65 × 0.20) = 13', () => {
     expect(
       maxArcArmorPoints(
         AerospaceArc.LEFT_WING,
@@ -380,7 +380,7 @@ describe("armorArcCalculations", () => {
     ).toBe(13);
   });
 
-  it("Shilone 65t ASF aft max = floor(65 × 0.12) = 7", () => {
+  it('Shilone 65t ASF aft max = floor(65 × 0.12) = 7', () => {
     expect(
       maxArcArmorPoints(
         AerospaceArc.AFT,
@@ -390,7 +390,7 @@ describe("armorArcCalculations", () => {
     ).toBe(7);
   });
 
-  it("small craft: LEFT_WING factor is 0 (side arcs instead)", () => {
+  it('small craft: LEFT_WING factor is 0 (side arcs instead)', () => {
     expect(
       maxArcArmorPoints(
         AerospaceArc.LEFT_WING,
@@ -400,7 +400,7 @@ describe("armorArcCalculations", () => {
     ).toBe(0);
   });
 
-  it("small craft: LEFT_SIDE max = floor(100 × 0.20) = 20", () => {
+  it('small craft: LEFT_SIDE max = floor(100 × 0.20) = 20', () => {
     expect(
       maxArcArmorPoints(
         AerospaceArc.LEFT_SIDE,
@@ -410,7 +410,7 @@ describe("armorArcCalculations", () => {
     ).toBe(20);
   });
 
-  it("maxTotalArmorPoints: 100t ASF = nose+wing+wing+aft = 28+20+20+12 = 80", () => {
+  it('maxTotalArmorPoints: 100t ASF = nose+wing+wing+aft = 28+20+20+12 = 80', () => {
     expect(maxTotalArmorPoints(100, AerospaceSubType.AEROSPACE_FIGHTER)).toBe(
       80,
     );
@@ -421,23 +421,23 @@ describe("armorArcCalculations", () => {
 // engineWeightAerospace
 // ============================================================================
 
-describe("engineWeightAerospace", () => {
-  it("Shilone: rating 325, Fusion → table lookup 20t", () => {
+describe('engineWeightAerospace', () => {
+  it('Shilone: rating 325, Fusion → table lookup 20t', () => {
     // FUSION_ENGINE_WEIGHT[325] = 20.0
     expect(aerospaceEngineWeight(325, AerospaceEngineType.FUSION)).toBe(20);
   });
 
-  it("Sparrowhawk: rating 210, ICE → table weight × 2.0", () => {
+  it('Sparrowhawk: rating 210, ICE → table weight × 2.0', () => {
     // FUSION_ENGINE_WEIGHT[210] = 9.0, ICE ×2 = 18t
     expect(aerospaceEngineWeight(210, AerospaceEngineType.ICE)).toBe(18);
   });
 
-  it("XL engine halves the weight", () => {
+  it('XL engine halves the weight', () => {
     // rating 200, Fusion → 8.5t; XL → 4.25 → ceil to 4.5t
     expect(aerospaceEngineWeight(200, AerospaceEngineType.XL)).toBe(4.5);
   });
 
-  it("result is always a multiple of 0.5", () => {
+  it('result is always a multiple of 0.5', () => {
     for (const rating of [50, 100, 150, 200, 250, 300, 350, 400]) {
       const weight = aerospaceEngineWeight(rating, AerospaceEngineType.FUSION);
       expect(weight % 0.5).toBe(0);
@@ -449,33 +449,33 @@ describe("engineWeightAerospace", () => {
 // crewCalculations
 // ============================================================================
 
-describe("crewCalculations", () => {
-  it("quartersWeight: 3 crew, 0 pax, 0 marines → 15t", () => {
+describe('crewCalculations', () => {
+  it('quartersWeight: 3 crew, 0 pax, 0 marines → 15t', () => {
     expect(
       quartersWeight({ crew: 3, passengers: 0, marines: 0, quartersTons: 0 }),
     ).toBe(15);
   });
 
-  it("quartersWeight: 2 crew + 4 pax → 2×5 + 4×3 = 22t", () => {
+  it('quartersWeight: 2 crew + 4 pax → 2×5 + 4×3 = 22t', () => {
     expect(
       quartersWeight({ crew: 2, passengers: 4, marines: 0, quartersTons: 0 }),
     ).toBe(22);
   });
 
-  it("makeSmallCraftCrew computes quartersTons automatically", () => {
+  it('makeSmallCraftCrew computes quartersTons automatically', () => {
     const crew = makeSmallCraftCrew(3, 0, 0);
     expect(crew.quartersTons).toBe(15);
   });
 
-  it("minSmallCraftCrew: 100t → 3 crew", () => {
+  it('minSmallCraftCrew: 100t → 3 crew', () => {
     expect(minSmallCraftCrew(100)).toBe(3);
   });
 
-  it("minSmallCraftCrew: 150t → 4 crew", () => {
+  it('minSmallCraftCrew: 150t → 4 crew', () => {
     expect(minSmallCraftCrew(150)).toBe(4);
   });
 
-  it("minSmallCraftCrew: 200t → 6 crew", () => {
+  it('minSmallCraftCrew: 200t → 6 crew', () => {
     expect(minSmallCraftCrew(200)).toBe(6);
   });
 });
@@ -484,57 +484,57 @@ describe("crewCalculations", () => {
 // VAL-AERO-TONNAGE
 // ============================================================================
 
-describe("VAL-AERO-TONNAGE", () => {
-  it("Shilone 65t ASF — valid, no errors", () => {
+describe('VAL-AERO-TONNAGE', () => {
+  it('Shilone 65t ASF — valid, no errors', () => {
     expect(
       validateTonnage(65, AerospaceSubType.AEROSPACE_FIGHTER),
     ).toHaveLength(0);
   });
 
-  it("Stuka 100t ASF — valid, no errors", () => {
+  it('Stuka 100t ASF — valid, no errors', () => {
     expect(
       validateTonnage(100, AerospaceSubType.AEROSPACE_FIGHTER),
     ).toHaveLength(0);
   });
 
-  it("Sparrowhawk 30t CF — valid, no errors", () => {
+  it('Sparrowhawk 30t CF — valid, no errors', () => {
     expect(
       validateTonnage(30, AerospaceSubType.CONVENTIONAL_FIGHTER),
     ).toHaveLength(0);
   });
 
-  it("Seeker 100t SmallCraft — valid, no errors", () => {
+  it('Seeker 100t SmallCraft — valid, no errors', () => {
     expect(validateTonnage(100, AerospaceSubType.SMALL_CRAFT)).toHaveLength(0);
   });
 
-  it("ASF under 5t → VAL-AERO-TONNAGE error", () => {
+  it('ASF under 5t → VAL-AERO-TONNAGE error', () => {
     const errors = validateTonnage(4, AerospaceSubType.AEROSPACE_FIGHTER);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe("VAL-AERO-TONNAGE");
+    expect(errors[0].ruleId).toBe('VAL-AERO-TONNAGE');
   });
 
-  it("ASF over 100t → VAL-AERO-TONNAGE error", () => {
+  it('ASF over 100t → VAL-AERO-TONNAGE error', () => {
     const errors = validateTonnage(101, AerospaceSubType.AEROSPACE_FIGHTER);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe("VAL-AERO-TONNAGE");
+    expect(errors[0].ruleId).toBe('VAL-AERO-TONNAGE');
   });
 
-  it("CF over 50t → VAL-AERO-TONNAGE error", () => {
+  it('CF over 50t → VAL-AERO-TONNAGE error', () => {
     const errors = validateTonnage(55, AerospaceSubType.CONVENTIONAL_FIGHTER);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe("VAL-AERO-TONNAGE");
+    expect(errors[0].ruleId).toBe('VAL-AERO-TONNAGE');
   });
 
-  it("SmallCraft under 100t → VAL-AERO-TONNAGE error", () => {
+  it('SmallCraft under 100t → VAL-AERO-TONNAGE error', () => {
     const errors = validateTonnage(90, AerospaceSubType.SMALL_CRAFT);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe("VAL-AERO-TONNAGE");
+    expect(errors[0].ruleId).toBe('VAL-AERO-TONNAGE');
   });
 
-  it("SmallCraft over 200t → VAL-AERO-TONNAGE error", () => {
+  it('SmallCraft over 200t → VAL-AERO-TONNAGE error', () => {
     const errors = validateTonnage(210, AerospaceSubType.SMALL_CRAFT);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe("VAL-AERO-TONNAGE");
+    expect(errors[0].ruleId).toBe('VAL-AERO-TONNAGE');
   });
 });
 
@@ -542,8 +542,8 @@ describe("VAL-AERO-TONNAGE", () => {
 // VAL-AERO-THRUST
 // ============================================================================
 
-describe("VAL-AERO-THRUST", () => {
-  it("Shilone Fusion ASF thrust 5 — no errors", () => {
+describe('VAL-AERO-THRUST', () => {
+  it('Shilone Fusion ASF thrust 5 — no errors', () => {
     expect(
       validateThrust(
         AerospaceEngineType.FUSION,
@@ -553,7 +553,7 @@ describe("VAL-AERO-THRUST", () => {
     ).toHaveLength(0);
   });
 
-  it("Sparrowhawk ICE CF thrust 7 — no errors", () => {
+  it('Sparrowhawk ICE CF thrust 7 — no errors', () => {
     expect(
       validateThrust(
         AerospaceEngineType.ICE,
@@ -563,40 +563,40 @@ describe("VAL-AERO-THRUST", () => {
     ).toHaveLength(0);
   });
 
-  it("Fusion on CF → VAL-AERO-THRUST (illegal engine)", () => {
+  it('Fusion on CF → VAL-AERO-THRUST (illegal engine)', () => {
     const errors = validateThrust(
       AerospaceEngineType.FUSION,
       5,
       AerospaceSubType.CONVENTIONAL_FIGHTER,
     );
-    expect(errors.some((e) => e.ruleId === "VAL-AERO-THRUST")).toBe(true);
+    expect(errors.some((e) => e.ruleId === 'VAL-AERO-THRUST')).toBe(true);
   });
 
-  it("ICE on ASF → VAL-AERO-THRUST (illegal engine)", () => {
+  it('ICE on ASF → VAL-AERO-THRUST (illegal engine)', () => {
     const errors = validateThrust(
       AerospaceEngineType.ICE,
       5,
       AerospaceSubType.AEROSPACE_FIGHTER,
     );
-    expect(errors.some((e) => e.ruleId === "VAL-AERO-THRUST")).toBe(true);
+    expect(errors.some((e) => e.ruleId === 'VAL-AERO-THRUST')).toBe(true);
   });
 
-  it("safeThrust 13 on ASF → VAL-AERO-THRUST (exceeds cap of 12)", () => {
+  it('safeThrust 13 on ASF → VAL-AERO-THRUST (exceeds cap of 12)', () => {
     const errors = validateThrust(
       AerospaceEngineType.FUSION,
       13,
       AerospaceSubType.AEROSPACE_FIGHTER,
     );
-    expect(errors.some((e) => e.ruleId === "VAL-AERO-THRUST")).toBe(true);
+    expect(errors.some((e) => e.ruleId === 'VAL-AERO-THRUST')).toBe(true);
   });
 
-  it("safeThrust 7 on SmallCraft → VAL-AERO-THRUST (exceeds cap of 6)", () => {
+  it('safeThrust 7 on SmallCraft → VAL-AERO-THRUST (exceeds cap of 6)', () => {
     const errors = validateThrust(
       AerospaceEngineType.FUSION,
       7,
       AerospaceSubType.SMALL_CRAFT,
     );
-    expect(errors.some((e) => e.ruleId === "VAL-AERO-THRUST")).toBe(true);
+    expect(errors.some((e) => e.ruleId === 'VAL-AERO-THRUST')).toBe(true);
   });
 });
 
@@ -604,35 +604,35 @@ describe("VAL-AERO-THRUST", () => {
 // VAL-AERO-SI
 // ============================================================================
 
-describe("VAL-AERO-SI", () => {
-  it("Shilone SI=7 on 65t ASF — no errors", () => {
+describe('VAL-AERO-SI', () => {
+  it('Shilone SI=7 on 65t ASF — no errors', () => {
     expect(validateSI(7, AerospaceSubType.AEROSPACE_FIGHTER)).toHaveLength(0);
   });
 
-  it("SI at maximum (20) for ASF — no errors", () => {
+  it('SI at maximum (20) for ASF — no errors', () => {
     expect(validateSI(20, AerospaceSubType.AEROSPACE_FIGHTER)).toHaveLength(0);
   });
 
-  it("SI=21 on ASF → VAL-AERO-SI error (max 20)", () => {
+  it('SI=21 on ASF → VAL-AERO-SI error (max 20)', () => {
     const errors = validateSI(21, AerospaceSubType.AEROSPACE_FIGHTER);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe("VAL-AERO-SI");
+    expect(errors[0].ruleId).toBe('VAL-AERO-SI');
   });
 
-  it("SI=16 on CF → VAL-AERO-SI error (max 15)", () => {
+  it('SI=16 on CF → VAL-AERO-SI error (max 15)', () => {
     const errors = validateSI(16, AerospaceSubType.CONVENTIONAL_FIGHTER);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe("VAL-AERO-SI");
+    expect(errors[0].ruleId).toBe('VAL-AERO-SI');
   });
 
-  it("SI=30 on SmallCraft — no errors (at maximum)", () => {
+  it('SI=30 on SmallCraft — no errors (at maximum)', () => {
     expect(validateSI(30, AerospaceSubType.SMALL_CRAFT)).toHaveLength(0);
   });
 
-  it("SI=31 on SmallCraft → VAL-AERO-SI error (max 30)", () => {
+  it('SI=31 on SmallCraft → VAL-AERO-SI error (max 30)', () => {
     const errors = validateSI(31, AerospaceSubType.SMALL_CRAFT);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe("VAL-AERO-SI");
+    expect(errors[0].ruleId).toBe('VAL-AERO-SI');
   });
 });
 
@@ -640,37 +640,37 @@ describe("VAL-AERO-SI", () => {
 // VAL-AERO-FUEL
 // ============================================================================
 
-describe("VAL-AERO-FUEL", () => {
-  it("Shilone 5t fuel ASF — no errors (exactly at minimum)", () => {
+describe('VAL-AERO-FUEL', () => {
+  it('Shilone 5t fuel ASF — no errors (exactly at minimum)', () => {
     expect(validateFuel(5, AerospaceSubType.AEROSPACE_FIGHTER)).toHaveLength(0);
   });
 
-  it("Sparrowhawk 2t fuel CF — no errors (exactly at minimum)", () => {
+  it('Sparrowhawk 2t fuel CF — no errors (exactly at minimum)', () => {
     expect(validateFuel(2, AerospaceSubType.CONVENTIONAL_FIGHTER)).toHaveLength(
       0,
     );
   });
 
-  it("Seeker 20t fuel SmallCraft — no errors (exactly at minimum)", () => {
+  it('Seeker 20t fuel SmallCraft — no errors (exactly at minimum)', () => {
     expect(validateFuel(20, AerospaceSubType.SMALL_CRAFT)).toHaveLength(0);
   });
 
-  it("ASF with 4t fuel → VAL-AERO-FUEL error (min 5t)", () => {
+  it('ASF with 4t fuel → VAL-AERO-FUEL error (min 5t)', () => {
     const errors = validateFuel(4, AerospaceSubType.AEROSPACE_FIGHTER);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe("VAL-AERO-FUEL");
+    expect(errors[0].ruleId).toBe('VAL-AERO-FUEL');
   });
 
-  it("CF with 1t fuel → VAL-AERO-FUEL error (min 2t)", () => {
+  it('CF with 1t fuel → VAL-AERO-FUEL error (min 2t)', () => {
     const errors = validateFuel(1, AerospaceSubType.CONVENTIONAL_FIGHTER);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe("VAL-AERO-FUEL");
+    expect(errors[0].ruleId).toBe('VAL-AERO-FUEL');
   });
 
-  it("SmallCraft with 19t fuel → VAL-AERO-FUEL error (min 20t)", () => {
+  it('SmallCraft with 19t fuel → VAL-AERO-FUEL error (min 20t)', () => {
     const errors = validateFuel(19, AerospaceSubType.SMALL_CRAFT);
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe("VAL-AERO-FUEL");
+    expect(errors[0].ruleId).toBe('VAL-AERO-FUEL');
   });
 });
 
@@ -678,8 +678,8 @@ describe("VAL-AERO-FUEL", () => {
 // VAL-AERO-ARC-MAX
 // ============================================================================
 
-describe("VAL-AERO-ARC-MAX", () => {
-  it("Shilone: valid arc allocations — no errors", () => {
+describe('VAL-AERO-ARC-MAX', () => {
+  it('Shilone: valid arc allocations — no errors', () => {
     // maxArcArmorPoints(NOSE, 65, ASF) = 18; allocating 10 is fine
     expect(
       validateArcArmor(
@@ -695,7 +695,7 @@ describe("VAL-AERO-ARC-MAX", () => {
     ).toHaveLength(0);
   });
 
-  it("Stuka: valid arc allocations — no errors", () => {
+  it('Stuka: valid arc allocations — no errors', () => {
     expect(
       validateArcArmor(
         {
@@ -710,7 +710,7 @@ describe("VAL-AERO-ARC-MAX", () => {
     ).toHaveLength(0);
   });
 
-  it("Nose over max → VAL-AERO-ARC-MAX error", () => {
+  it('Nose over max → VAL-AERO-ARC-MAX error', () => {
     // max nose for 65t ASF = floor(65×0.28) = 18; allocating 19 violates
     const errors = validateArcArmor(
       { [AerospaceArc.NOSE]: 19 },
@@ -718,10 +718,10 @@ describe("VAL-AERO-ARC-MAX", () => {
       AerospaceSubType.AEROSPACE_FIGHTER,
     );
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe("VAL-AERO-ARC-MAX");
+    expect(errors[0].ruleId).toBe('VAL-AERO-ARC-MAX');
   });
 
-  it("Wing over max → VAL-AERO-ARC-MAX error", () => {
+  it('Wing over max → VAL-AERO-ARC-MAX error', () => {
     // max wing for 65t ASF = floor(65×0.20) = 13; allocating 14 violates
     const errors = validateArcArmor(
       { [AerospaceArc.LEFT_WING]: 14 },
@@ -729,10 +729,10 @@ describe("VAL-AERO-ARC-MAX", () => {
       AerospaceSubType.AEROSPACE_FIGHTER,
     );
     expect(errors).toHaveLength(1);
-    expect(errors[0].ruleId).toBe("VAL-AERO-ARC-MAX");
+    expect(errors[0].ruleId).toBe('VAL-AERO-ARC-MAX');
   });
 
-  it("Seeker small craft: valid side arc allocations — no errors", () => {
+  it('Seeker small craft: valid side arc allocations — no errors', () => {
     expect(
       validateArcArmor(
         {
@@ -747,7 +747,7 @@ describe("VAL-AERO-ARC-MAX", () => {
     ).toHaveLength(0);
   });
 
-  it("Inapplicable arcs (factor=0) are silently ignored", () => {
+  it('Inapplicable arcs (factor=0) are silently ignored', () => {
     // LEFT_WING has factor 0 for small craft — allocating any amount should not error
     expect(
       validateArcArmor(
@@ -763,36 +763,36 @@ describe("VAL-AERO-ARC-MAX", () => {
 // VAL-AERO-CREW
 // ============================================================================
 
-describe("VAL-AERO-CREW", () => {
-  it("ASF: crew rule is a no-op (always passes)", () => {
+describe('VAL-AERO-CREW', () => {
+  it('ASF: crew rule is a no-op (always passes)', () => {
     expect(validateCrew(AerospaceSubType.AEROSPACE_FIGHTER, 0, 0)).toHaveLength(
       0,
     );
   });
 
-  it("CF: crew rule is a no-op (always passes)", () => {
+  it('CF: crew rule is a no-op (always passes)', () => {
     expect(
       validateCrew(AerospaceSubType.CONVENTIONAL_FIGHTER, 0, 0),
     ).toHaveLength(0);
   });
 
-  it("SmallCraft with quarters + crew — no errors", () => {
+  it('SmallCraft with quarters + crew — no errors', () => {
     expect(validateCrew(AerospaceSubType.SMALL_CRAFT, 15, 3)).toHaveLength(0);
   });
 
-  it("SmallCraft with 0 quarters → VAL-AERO-CREW error", () => {
+  it('SmallCraft with 0 quarters → VAL-AERO-CREW error', () => {
     const errors = validateCrew(AerospaceSubType.SMALL_CRAFT, 0, 3);
-    expect(errors.some((e) => e.ruleId === "VAL-AERO-CREW")).toBe(true);
+    expect(errors.some((e) => e.ruleId === 'VAL-AERO-CREW')).toBe(true);
   });
 
-  it("SmallCraft with 0 crew → VAL-AERO-CREW error", () => {
+  it('SmallCraft with 0 crew → VAL-AERO-CREW error', () => {
     const errors = validateCrew(AerospaceSubType.SMALL_CRAFT, 15, 0);
-    expect(errors.some((e) => e.ruleId === "VAL-AERO-CREW")).toBe(true);
+    expect(errors.some((e) => e.ruleId === 'VAL-AERO-CREW')).toBe(true);
   });
 
-  it("SmallCraft with 0 quarters AND 0 crew → two VAL-AERO-CREW errors", () => {
+  it('SmallCraft with 0 quarters AND 0 crew → two VAL-AERO-CREW errors', () => {
     const errors = validateCrew(AerospaceSubType.SMALL_CRAFT, 0, 0);
-    expect(errors.filter((e) => e.ruleId === "VAL-AERO-CREW")).toHaveLength(2);
+    expect(errors.filter((e) => e.ruleId === 'VAL-AERO-CREW')).toHaveLength(2);
   });
 });
 
@@ -800,48 +800,48 @@ describe("VAL-AERO-CREW", () => {
 // validateAerospaceUnit (full runner)
 // ============================================================================
 
-describe("validateAerospaceUnit — full runner", () => {
-  it("Shilone (ASF, 65t, Fusion, thrust 5) — clean build", () => {
+describe('validateAerospaceUnit — full runner', () => {
+  it('Shilone (ASF, 65t, Fusion, thrust 5) — clean build', () => {
     expect(validateAerospaceUnit(shiloneInput())).toHaveLength(0);
   });
 
-  it("Stuka (ASF, 100t, Fusion, thrust 4) — clean build", () => {
+  it('Stuka (ASF, 100t, Fusion, thrust 4) — clean build', () => {
     expect(validateAerospaceUnit(stukaInput())).toHaveLength(0);
   });
 
-  it("Sparrowhawk (CF, 30t, ICE, thrust 7) — clean build", () => {
+  it('Sparrowhawk (CF, 30t, ICE, thrust 7) — clean build', () => {
     expect(validateAerospaceUnit(sparrowhawkInput())).toHaveLength(0);
   });
 
-  it("Seeker (SmallCraft, 100t, Fusion, crew 3) — clean build", () => {
+  it('Seeker (SmallCraft, 100t, Fusion, crew 3) — clean build', () => {
     expect(validateAerospaceUnit(seekerInput())).toHaveLength(0);
   });
 
-  it("Shilone with Fusion engine swapped to ICE → VAL-AERO-THRUST", () => {
+  it('Shilone with Fusion engine swapped to ICE → VAL-AERO-THRUST', () => {
     const input = { ...shiloneInput(), engineType: AerospaceEngineType.ICE };
     const errors = validateAerospaceUnit(input);
-    expect(errors.some((e) => e.ruleId === "VAL-AERO-THRUST")).toBe(true);
+    expect(errors.some((e) => e.ruleId === 'VAL-AERO-THRUST')).toBe(true);
   });
 
-  it("Shilone with tonnage 101 → VAL-AERO-TONNAGE", () => {
+  it('Shilone with tonnage 101 → VAL-AERO-TONNAGE', () => {
     const input = { ...shiloneInput(), tonnage: 101 };
     const errors = validateAerospaceUnit(input);
-    expect(errors.some((e) => e.ruleId === "VAL-AERO-TONNAGE")).toBe(true);
+    expect(errors.some((e) => e.ruleId === 'VAL-AERO-TONNAGE')).toBe(true);
   });
 
-  it("Shilone with SI=21 → VAL-AERO-SI", () => {
+  it('Shilone with SI=21 → VAL-AERO-SI', () => {
     const input = { ...shiloneInput(), structuralIntegrity: 21 };
     const errors = validateAerospaceUnit(input);
-    expect(errors.some((e) => e.ruleId === "VAL-AERO-SI")).toBe(true);
+    expect(errors.some((e) => e.ruleId === 'VAL-AERO-SI')).toBe(true);
   });
 
-  it("Shilone with fuelTons=4 → VAL-AERO-FUEL", () => {
+  it('Shilone with fuelTons=4 → VAL-AERO-FUEL', () => {
     const input = { ...shiloneInput(), fuelTons: 4 };
     const errors = validateAerospaceUnit(input);
-    expect(errors.some((e) => e.ruleId === "VAL-AERO-FUEL")).toBe(true);
+    expect(errors.some((e) => e.ruleId === 'VAL-AERO-FUEL')).toBe(true);
   });
 
-  it("Shilone with nose armor over max → VAL-AERO-ARC-MAX", () => {
+  it('Shilone with nose armor over max → VAL-AERO-ARC-MAX', () => {
     const input = {
       ...shiloneInput(),
       arcArmor: {
@@ -852,16 +852,16 @@ describe("validateAerospaceUnit — full runner", () => {
       },
     };
     const errors = validateAerospaceUnit(input);
-    expect(errors.some((e) => e.ruleId === "VAL-AERO-ARC-MAX")).toBe(true);
+    expect(errors.some((e) => e.ruleId === 'VAL-AERO-ARC-MAX')).toBe(true);
   });
 
-  it("Seeker with no quarters → VAL-AERO-CREW", () => {
+  it('Seeker with no quarters → VAL-AERO-CREW', () => {
     const input = { ...seekerInput(), quartersTons: 0 };
     const errors = validateAerospaceUnit(input);
-    expect(errors.some((e) => e.ruleId === "VAL-AERO-CREW")).toBe(true);
+    expect(errors.some((e) => e.ruleId === 'VAL-AERO-CREW')).toBe(true);
   });
 
-  it("multiple violations are all reported", () => {
+  it('multiple violations are all reported', () => {
     // Tonnage + fuel both wrong
     const input = {
       ...shiloneInput(),
@@ -870,8 +870,8 @@ describe("validateAerospaceUnit — full runner", () => {
     };
     const errors = validateAerospaceUnit(input);
     const ruleIds = errors.map((e) => e.ruleId);
-    expect(ruleIds).toContain("VAL-AERO-TONNAGE");
-    expect(ruleIds).toContain("VAL-AERO-FUEL");
+    expect(ruleIds).toContain('VAL-AERO-TONNAGE');
+    expect(ruleIds).toContain('VAL-AERO-FUEL');
   });
 });
 
@@ -879,69 +879,69 @@ describe("validateAerospaceUnit — full runner", () => {
 // Task 7.3 — Wing-mounted heavy weapons (PPC, Gauss) tonnage cap
 // ============================================================================
 
-describe("wingHeavyWeapons (Task 7.3)", () => {
-  describe("isWingHeavyWeapon", () => {
-    it("identifies PPC variants by id", () => {
-      expect(isWingHeavyWeapon("isppc")).toBe(true);
-      expect(isWingHeavyWeapon("clERPPC")).toBe(true);
-      expect(isWingHeavyWeapon("ISHeavyPPC")).toBe(true);
+describe('wingHeavyWeapons (Task 7.3)', () => {
+  describe('isWingHeavyWeapon', () => {
+    it('identifies PPC variants by id', () => {
+      expect(isWingHeavyWeapon('isppc')).toBe(true);
+      expect(isWingHeavyWeapon('clERPPC')).toBe(true);
+      expect(isWingHeavyWeapon('ISHeavyPPC')).toBe(true);
     });
 
-    it("identifies PPC variants by display name", () => {
-      expect(isWingHeavyWeapon("PPC")).toBe(true);
-      expect(isWingHeavyWeapon("ER PPC")).toBe(true);
-      expect(isWingHeavyWeapon("Snub-Nose PPC")).toBe(true);
+    it('identifies PPC variants by display name', () => {
+      expect(isWingHeavyWeapon('PPC')).toBe(true);
+      expect(isWingHeavyWeapon('ER PPC')).toBe(true);
+      expect(isWingHeavyWeapon('Snub-Nose PPC')).toBe(true);
     });
 
-    it("identifies Gauss family", () => {
-      expect(isWingHeavyWeapon("isgaussrifle")).toBe(true);
-      expect(isWingHeavyWeapon("Heavy Gauss Rifle")).toBe(true);
-      expect(isWingHeavyWeapon("Light Gauss Rifle")).toBe(true);
+    it('identifies Gauss family', () => {
+      expect(isWingHeavyWeapon('isgaussrifle')).toBe(true);
+      expect(isWingHeavyWeapon('Heavy Gauss Rifle')).toBe(true);
+      expect(isWingHeavyWeapon('Light Gauss Rifle')).toBe(true);
     });
 
-    it("identifies AC/20 variants", () => {
-      expect(isWingHeavyWeapon("AC/20")).toBe(true);
-      expect(isWingHeavyWeapon("isac20")).toBe(true);
-      expect(isWingHeavyWeapon("Autocannon/20")).toBe(true);
+    it('identifies AC/20 variants', () => {
+      expect(isWingHeavyWeapon('AC/20')).toBe(true);
+      expect(isWingHeavyWeapon('isac20')).toBe(true);
+      expect(isWingHeavyWeapon('Autocannon/20')).toBe(true);
     });
 
-    it("rejects light/medium weapons", () => {
-      expect(isWingHeavyWeapon("Medium Laser")).toBe(false);
-      expect(isWingHeavyWeapon("ismediumlaser")).toBe(false);
-      expect(isWingHeavyWeapon("Machine Gun")).toBe(false);
-      expect(isWingHeavyWeapon("LRM 5")).toBe(false);
-      expect(isWingHeavyWeapon("AC/2")).toBe(false);
+    it('rejects light/medium weapons', () => {
+      expect(isWingHeavyWeapon('Medium Laser')).toBe(false);
+      expect(isWingHeavyWeapon('ismediumlaser')).toBe(false);
+      expect(isWingHeavyWeapon('Machine Gun')).toBe(false);
+      expect(isWingHeavyWeapon('LRM 5')).toBe(false);
+      expect(isWingHeavyWeapon('AC/2')).toBe(false);
     });
   });
 
-  describe("maxHeavyWeaponTonsPerWing", () => {
-    it("Shilone (65t ASF) → cap 6", () => {
+  describe('maxHeavyWeaponTonsPerWing', () => {
+    it('Shilone (65t ASF) → cap 6', () => {
       expect(
         maxHeavyWeaponTonsPerWing(65, AerospaceSubType.AEROSPACE_FIGHTER),
       ).toBe(6);
     });
 
-    it("Stuka (100t ASF) → cap 10", () => {
+    it('Stuka (100t ASF) → cap 10', () => {
       expect(
         maxHeavyWeaponTonsPerWing(100, AerospaceSubType.AEROSPACE_FIGHTER),
       ).toBe(10);
     });
 
-    it("Sparrowhawk (30t CF) → cap 3", () => {
+    it('Sparrowhawk (30t CF) → cap 3', () => {
       expect(
         maxHeavyWeaponTonsPerWing(30, AerospaceSubType.CONVENTIONAL_FIGHTER),
       ).toBe(3);
     });
 
-    it("small craft → cap 0 (rule does not apply)", () => {
+    it('small craft → cap 0 (rule does not apply)', () => {
       expect(maxHeavyWeaponTonsPerWing(100, AerospaceSubType.SMALL_CRAFT)).toBe(
         0,
       );
     });
   });
 
-  describe("canMountHeavyOnWing", () => {
-    it("Stuka left wing has 4t already, can add 6t (10t cap)", () => {
+  describe('canMountHeavyOnWing', () => {
+    it('Stuka left wing has 4t already, can add 6t (10t cap)', () => {
       expect(
         canMountHeavyOnWing(
           AerospaceArc.LEFT_WING,
@@ -953,7 +953,7 @@ describe("wingHeavyWeapons (Task 7.3)", () => {
       ).toBe(true);
     });
 
-    it("Stuka left wing has 7t already, cannot add 4t (would hit 11)", () => {
+    it('Stuka left wing has 7t already, cannot add 4t (would hit 11)', () => {
       expect(
         canMountHeavyOnWing(
           AerospaceArc.LEFT_WING,
@@ -965,7 +965,7 @@ describe("wingHeavyWeapons (Task 7.3)", () => {
       ).toBe(false);
     });
 
-    it("Nose arc has no wing cap (always allowed)", () => {
+    it('Nose arc has no wing cap (always allowed)', () => {
       expect(
         canMountHeavyOnWing(
           AerospaceArc.NOSE,
@@ -977,7 +977,7 @@ describe("wingHeavyWeapons (Task 7.3)", () => {
       ).toBe(true);
     });
 
-    it("Aft arc has no wing cap", () => {
+    it('Aft arc has no wing cap', () => {
       expect(
         canMountHeavyOnWing(
           AerospaceArc.AFT,
@@ -989,7 +989,7 @@ describe("wingHeavyWeapons (Task 7.3)", () => {
       ).toBe(true);
     });
 
-    it("Fuselage arc has no wing cap", () => {
+    it('Fuselage arc has no wing cap', () => {
       expect(
         canMountHeavyOnWing(
           AerospaceArc.FUSELAGE,
@@ -1002,32 +1002,32 @@ describe("wingHeavyWeapons (Task 7.3)", () => {
     });
   });
 
-  describe("heavyTonsByWing", () => {
-    it("aggregates only heavy weapons in wing arcs", () => {
+  describe('heavyTonsByWing', () => {
+    it('aggregates only heavy weapons in wing arcs', () => {
       const items = [
-        { arc: AerospaceArc.LEFT_WING, idOrName: "PPC", tons: 7 },
-        { arc: AerospaceArc.LEFT_WING, idOrName: "Medium Laser", tons: 1 },
-        { arc: AerospaceArc.RIGHT_WING, idOrName: "Gauss Rifle", tons: 15 },
-        { arc: AerospaceArc.NOSE, idOrName: "PPC", tons: 7 }, // not in wing arc
-        { arc: AerospaceArc.AFT, idOrName: "AC/20", tons: 14 }, // not in wing arc
+        { arc: AerospaceArc.LEFT_WING, idOrName: 'PPC', tons: 7 },
+        { arc: AerospaceArc.LEFT_WING, idOrName: 'Medium Laser', tons: 1 },
+        { arc: AerospaceArc.RIGHT_WING, idOrName: 'Gauss Rifle', tons: 15 },
+        { arc: AerospaceArc.NOSE, idOrName: 'PPC', tons: 7 }, // not in wing arc
+        { arc: AerospaceArc.AFT, idOrName: 'AC/20', tons: 14 }, // not in wing arc
       ];
       const result = heavyTonsByWing(items);
       expect(result.get(AerospaceArc.LEFT_WING)).toBe(7);
       expect(result.get(AerospaceArc.RIGHT_WING)).toBe(15);
     });
 
-    it("empty input → both wings at 0", () => {
+    it('empty input → both wings at 0', () => {
       const result = heavyTonsByWing([]);
       expect(result.get(AerospaceArc.LEFT_WING)).toBe(0);
       expect(result.get(AerospaceArc.RIGHT_WING)).toBe(0);
     });
   });
 
-  describe("validateWingHeavyWeapons (VAL-AERO-WING-HEAVY)", () => {
-    it("Stuka with PPC + ER Large Laser on left wing — within 10t cap", () => {
+  describe('validateWingHeavyWeapons (VAL-AERO-WING-HEAVY)', () => {
+    it('Stuka with PPC + ER Large Laser on left wing — within 10t cap', () => {
       const items = [
-        { arc: AerospaceArc.LEFT_WING, idOrName: "PPC", tons: 7 },
-        { arc: AerospaceArc.LEFT_WING, idOrName: "ER Large Laser", tons: 5 },
+        { arc: AerospaceArc.LEFT_WING, idOrName: 'PPC', tons: 7 },
+        { arc: AerospaceArc.LEFT_WING, idOrName: 'ER Large Laser', tons: 5 },
       ];
       // PPC=7t counts as heavy, ER Large Laser does not. 7 ≤ 10. Pass.
       expect(
@@ -1039,10 +1039,10 @@ describe("wingHeavyWeapons (Task 7.3)", () => {
       ).toHaveLength(0);
     });
 
-    it("Stuka with two PPCs on left wing → exceeds 10t cap", () => {
+    it('Stuka with two PPCs on left wing → exceeds 10t cap', () => {
       const items = [
-        { arc: AerospaceArc.LEFT_WING, idOrName: "PPC", tons: 7 },
-        { arc: AerospaceArc.LEFT_WING, idOrName: "ER PPC", tons: 7 },
+        { arc: AerospaceArc.LEFT_WING, idOrName: 'PPC', tons: 7 },
+        { arc: AerospaceArc.LEFT_WING, idOrName: 'ER PPC', tons: 7 },
       ];
       const errors = validateWingHeavyWeapons(
         items,
@@ -1050,13 +1050,13 @@ describe("wingHeavyWeapons (Task 7.3)", () => {
         AerospaceSubType.AEROSPACE_FIGHTER,
       );
       expect(errors).toHaveLength(1);
-      expect(errors[0].ruleId).toBe("VAL-AERO-WING-HEAVY");
-      expect(errors[0].message).toContain("LeftWing");
+      expect(errors[0].ruleId).toBe('VAL-AERO-WING-HEAVY');
+      expect(errors[0].message).toContain('LeftWing');
     });
 
-    it("Shilone (65t ASF) Gauss Rifle (15t) on right wing → exceeds 6t cap", () => {
+    it('Shilone (65t ASF) Gauss Rifle (15t) on right wing → exceeds 6t cap', () => {
       const items = [
-        { arc: AerospaceArc.RIGHT_WING, idOrName: "Gauss Rifle", tons: 15 },
+        { arc: AerospaceArc.RIGHT_WING, idOrName: 'Gauss Rifle', tons: 15 },
       ];
       const errors = validateWingHeavyWeapons(
         items,
@@ -1064,24 +1064,24 @@ describe("wingHeavyWeapons (Task 7.3)", () => {
         AerospaceSubType.AEROSPACE_FIGHTER,
       );
       expect(errors).toHaveLength(1);
-      expect(errors[0].ruleId).toBe("VAL-AERO-WING-HEAVY");
+      expect(errors[0].ruleId).toBe('VAL-AERO-WING-HEAVY');
     });
 
-    it("Heavy weapon in nose arc does NOT trigger wing cap", () => {
+    it('Heavy weapon in nose arc does NOT trigger wing cap', () => {
       const items = [
-        { arc: AerospaceArc.NOSE, idOrName: "Heavy Gauss Rifle", tons: 18 },
+        { arc: AerospaceArc.NOSE, idOrName: 'Heavy Gauss Rifle', tons: 18 },
       ];
       expect(
         validateWingHeavyWeapons(items, 65, AerospaceSubType.AEROSPACE_FIGHTER),
       ).toHaveLength(0);
     });
 
-    it("Both wings overloaded → two errors", () => {
+    it('Both wings overloaded → two errors', () => {
       const items = [
-        { arc: AerospaceArc.LEFT_WING, idOrName: "PPC", tons: 7 },
-        { arc: AerospaceArc.LEFT_WING, idOrName: "Gauss Rifle", tons: 15 },
-        { arc: AerospaceArc.RIGHT_WING, idOrName: "PPC", tons: 7 },
-        { arc: AerospaceArc.RIGHT_WING, idOrName: "Gauss Rifle", tons: 15 },
+        { arc: AerospaceArc.LEFT_WING, idOrName: 'PPC', tons: 7 },
+        { arc: AerospaceArc.LEFT_WING, idOrName: 'Gauss Rifle', tons: 15 },
+        { arc: AerospaceArc.RIGHT_WING, idOrName: 'PPC', tons: 7 },
+        { arc: AerospaceArc.RIGHT_WING, idOrName: 'Gauss Rifle', tons: 15 },
       ];
       const errors = validateWingHeavyWeapons(
         items,
@@ -1089,53 +1089,53 @@ describe("wingHeavyWeapons (Task 7.3)", () => {
         AerospaceSubType.AEROSPACE_FIGHTER,
       );
       expect(errors).toHaveLength(2);
-      expect(errors.every((e) => e.ruleId === "VAL-AERO-WING-HEAVY")).toBe(
+      expect(errors.every((e) => e.ruleId === 'VAL-AERO-WING-HEAVY')).toBe(
         true,
       );
     });
 
-    it("Small craft is exempt — heavy tonnage in side arc passes", () => {
+    it('Small craft is exempt — heavy tonnage in side arc passes', () => {
       const items = [
-        { arc: AerospaceArc.LEFT_WING, idOrName: "PPC", tons: 99 },
+        { arc: AerospaceArc.LEFT_WING, idOrName: 'PPC', tons: 99 },
       ];
       expect(
         validateWingHeavyWeapons(items, 100, AerospaceSubType.SMALL_CRAFT),
       ).toHaveLength(0);
     });
 
-    it("Empty equipment list → no errors", () => {
+    it('Empty equipment list → no errors', () => {
       expect(
         validateWingHeavyWeapons([], 100, AerospaceSubType.AEROSPACE_FIGHTER),
       ).toHaveLength(0);
     });
   });
 
-  describe("validateAerospaceUnit integration with wingMounts", () => {
-    it("Shilone with no wing mounts supplied → no wing-heavy errors", () => {
+  describe('validateAerospaceUnit integration with wingMounts', () => {
+    it('Shilone with no wing mounts supplied → no wing-heavy errors', () => {
       const errors = validateAerospaceUnit(shiloneInput());
-      expect(errors.some((e) => e.ruleId === "VAL-AERO-WING-HEAVY")).toBe(
+      expect(errors.some((e) => e.ruleId === 'VAL-AERO-WING-HEAVY')).toBe(
         false,
       );
     });
 
-    it("Shilone with overloaded right wing → VAL-AERO-WING-HEAVY", () => {
+    it('Shilone with overloaded right wing → VAL-AERO-WING-HEAVY', () => {
       const input = {
         ...shiloneInput(),
         wingMounts: [
-          { arc: AerospaceArc.RIGHT_WING, idOrName: "PPC", tons: 7 },
+          { arc: AerospaceArc.RIGHT_WING, idOrName: 'PPC', tons: 7 },
         ],
       };
       // 65t ASF cap = 6, PPC = 7t → violation
       const errors = validateAerospaceUnit(input);
-      expect(errors.some((e) => e.ruleId === "VAL-AERO-WING-HEAVY")).toBe(true);
+      expect(errors.some((e) => e.ruleId === 'VAL-AERO-WING-HEAVY')).toBe(true);
     });
 
-    it("Stuka with legal wing PPC mount → clean build", () => {
+    it('Stuka with legal wing PPC mount → clean build', () => {
       const input = {
         ...stukaInput(),
         wingMounts: [
-          { arc: AerospaceArc.LEFT_WING, idOrName: "PPC", tons: 7 },
-          { arc: AerospaceArc.RIGHT_WING, idOrName: "PPC", tons: 7 },
+          { arc: AerospaceArc.LEFT_WING, idOrName: 'PPC', tons: 7 },
+          { arc: AerospaceArc.RIGHT_WING, idOrName: 'PPC', tons: 7 },
         ],
       };
       // Cap = 10 per wing, 7 ≤ 10. Pass.
@@ -1148,31 +1148,31 @@ describe("wingHeavyWeapons (Task 7.3)", () => {
 // Task 7.4 — Bomb bays (small craft, configurable)
 // ============================================================================
 
-describe("bombBays (Task 7.4)", () => {
-  describe("bayTons", () => {
-    it("0-capacity bay still costs 1t structure", () => {
-      expect(bayTons({ id: "b1", capacityBombs: 0 })).toBe(BAY_STRUCTURE_TONS);
+describe('bombBays (Task 7.4)', () => {
+  describe('bayTons', () => {
+    it('0-capacity bay still costs 1t structure', () => {
+      expect(bayTons({ id: 'b1', capacityBombs: 0 })).toBe(BAY_STRUCTURE_TONS);
     });
 
-    it("4-bomb bay → 4 + 1 = 5t", () => {
-      expect(bayTons({ id: "b1", capacityBombs: 4 })).toBe(5);
+    it('4-bomb bay → 4 + 1 = 5t', () => {
+      expect(bayTons({ id: 'b1', capacityBombs: 4 })).toBe(5);
     });
 
-    it("10-bomb bay → 10 + 1 = 11t", () => {
-      expect(bayTons({ id: "b1", capacityBombs: 10 })).toBe(11);
+    it('10-bomb bay → 10 + 1 = 11t', () => {
+      expect(bayTons({ id: 'b1', capacityBombs: 10 })).toBe(11);
     });
 
-    it("negative capacity is clamped to 0", () => {
-      expect(bayTons({ id: "b1", capacityBombs: -3 })).toBe(BAY_STRUCTURE_TONS);
+    it('negative capacity is clamped to 0', () => {
+      expect(bayTons({ id: 'b1', capacityBombs: -3 })).toBe(BAY_STRUCTURE_TONS);
     });
   });
 
-  describe("totalBombBayTons / totalBombCapacity", () => {
-    it("sum across multiple bays", () => {
+  describe('totalBombBayTons / totalBombCapacity', () => {
+    it('sum across multiple bays', () => {
       const bays = [
-        { id: "b1", capacityBombs: 4 },
-        { id: "b2", capacityBombs: 8 },
-        { id: "b3", capacityBombs: 0 },
+        { id: 'b1', capacityBombs: 4 },
+        { id: 'b2', capacityBombs: 8 },
+        { id: 'b3', capacityBombs: 0 },
       ];
       // Tons: (4+1) + (8+1) + (0+1) = 15
       expect(totalBombBayTons(bays)).toBe(15);
@@ -1180,137 +1180,137 @@ describe("bombBays (Task 7.4)", () => {
       expect(totalBombCapacity(bays)).toBe(12);
     });
 
-    it("empty list → 0", () => {
+    it('empty list → 0', () => {
       expect(totalBombBayTons([])).toBe(0);
       expect(totalBombCapacity([])).toBe(0);
     });
   });
 
-  describe("maxBombBayTons", () => {
-    it("100t small craft → 50t cap", () => {
+  describe('maxBombBayTons', () => {
+    it('100t small craft → 50t cap', () => {
       expect(maxBombBayTons(100, AerospaceSubType.SMALL_CRAFT)).toBe(50);
     });
 
-    it("200t small craft → 100t cap", () => {
+    it('200t small craft → 100t cap', () => {
       expect(maxBombBayTons(200, AerospaceSubType.SMALL_CRAFT)).toBe(100);
     });
 
-    it("ASF → 0 (rule N/A)", () => {
+    it('ASF → 0 (rule N/A)', () => {
       expect(maxBombBayTons(100, AerospaceSubType.AEROSPACE_FIGHTER)).toBe(0);
     });
 
-    it("CF → 0 (rule N/A)", () => {
+    it('CF → 0 (rule N/A)', () => {
       expect(maxBombBayTons(50, AerospaceSubType.CONVENTIONAL_FIGHTER)).toBe(0);
     });
   });
 
-  describe("validateBombBays (VAL-AERO-BOMB-BAY)", () => {
-    it("small craft with no bays → no errors", () => {
+  describe('validateBombBays (VAL-AERO-BOMB-BAY)', () => {
+    it('small craft with no bays → no errors', () => {
       expect(
         validateBombBays([], 100, AerospaceSubType.SMALL_CRAFT),
       ).toHaveLength(0);
     });
 
-    it("small craft with legal bays under cap → no errors", () => {
+    it('small craft with legal bays under cap → no errors', () => {
       // 100t cap = 50t. Bays: (10+1) + (10+1) = 22t. Pass.
       const bays = [
-        { id: "b1", capacityBombs: 10 },
-        { id: "b2", capacityBombs: 10 },
+        { id: 'b1', capacityBombs: 10 },
+        { id: 'b2', capacityBombs: 10 },
       ];
       expect(
         validateBombBays(bays, 100, AerospaceSubType.SMALL_CRAFT),
       ).toHaveLength(0);
     });
 
-    it("small craft with bays exceeding cap → VAL-AERO-BOMB-BAY", () => {
+    it('small craft with bays exceeding cap → VAL-AERO-BOMB-BAY', () => {
       // 100t cap = 50t. Bays: (49+1) + (5+1) = 56t > 50.
       const bays = [
-        { id: "b1", capacityBombs: 49 },
-        { id: "b2", capacityBombs: 5 },
+        { id: 'b1', capacityBombs: 49 },
+        { id: 'b2', capacityBombs: 5 },
       ];
       const errors = validateBombBays(bays, 100, AerospaceSubType.SMALL_CRAFT);
       expect(errors).toHaveLength(1);
-      expect(errors[0].ruleId).toBe("VAL-AERO-BOMB-BAY");
-      expect(errors[0].message).toContain("56t");
-      expect(errors[0].message).toContain("50t");
+      expect(errors[0].ruleId).toBe('VAL-AERO-BOMB-BAY');
+      expect(errors[0].message).toContain('56t');
+      expect(errors[0].message).toContain('50t');
     });
 
-    it("small craft bay with negative capacity → VAL-AERO-BOMB-BAY", () => {
-      const bays = [{ id: "b1", capacityBombs: -2 }];
+    it('small craft bay with negative capacity → VAL-AERO-BOMB-BAY', () => {
+      const bays = [{ id: 'b1', capacityBombs: -2 }];
       const errors = validateBombBays(bays, 100, AerospaceSubType.SMALL_CRAFT);
-      expect(errors.some((e) => e.ruleId === "VAL-AERO-BOMB-BAY")).toBe(true);
+      expect(errors.some((e) => e.ruleId === 'VAL-AERO-BOMB-BAY')).toBe(true);
     });
 
-    it("small craft bay with non-integer capacity → VAL-AERO-BOMB-BAY", () => {
-      const bays = [{ id: "b1", capacityBombs: 3.5 }];
+    it('small craft bay with non-integer capacity → VAL-AERO-BOMB-BAY', () => {
+      const bays = [{ id: 'b1', capacityBombs: 3.5 }];
       const errors = validateBombBays(bays, 100, AerospaceSubType.SMALL_CRAFT);
-      expect(errors.some((e) => e.ruleId === "VAL-AERO-BOMB-BAY")).toBe(true);
+      expect(errors.some((e) => e.ruleId === 'VAL-AERO-BOMB-BAY')).toBe(true);
     });
 
-    it("ASF with bombBays declared → VAL-AERO-BOMB-BAY (sub-type illegal)", () => {
-      const bays = [{ id: "b1", capacityBombs: 4 }];
+    it('ASF with bombBays declared → VAL-AERO-BOMB-BAY (sub-type illegal)', () => {
+      const bays = [{ id: 'b1', capacityBombs: 4 }];
       const errors = validateBombBays(
         bays,
         65,
         AerospaceSubType.AEROSPACE_FIGHTER,
       );
       expect(errors).toHaveLength(1);
-      expect(errors[0].ruleId).toBe("VAL-AERO-BOMB-BAY");
+      expect(errors[0].ruleId).toBe('VAL-AERO-BOMB-BAY');
       expect(errors[0].message).toMatch(/only configurable on small craft/);
     });
 
-    it("CF with bombBays declared → VAL-AERO-BOMB-BAY (sub-type illegal)", () => {
-      const bays = [{ id: "b1", capacityBombs: 4 }];
+    it('CF with bombBays declared → VAL-AERO-BOMB-BAY (sub-type illegal)', () => {
+      const bays = [{ id: 'b1', capacityBombs: 4 }];
       const errors = validateBombBays(
         bays,
         30,
         AerospaceSubType.CONVENTIONAL_FIGHTER,
       );
       expect(errors).toHaveLength(1);
-      expect(errors[0].ruleId).toBe("VAL-AERO-BOMB-BAY");
+      expect(errors[0].ruleId).toBe('VAL-AERO-BOMB-BAY');
     });
 
-    it("ASF with no bombBays → no errors (single hasBombBay path is unaffected)", () => {
+    it('ASF with no bombBays → no errors (single hasBombBay path is unaffected)', () => {
       expect(
         validateBombBays([], 65, AerospaceSubType.AEROSPACE_FIGHTER),
       ).toHaveLength(0);
     });
   });
 
-  describe("validateAerospaceUnit integration with bombBays", () => {
-    it("Seeker with no bombBays supplied → no bay errors", () => {
+  describe('validateAerospaceUnit integration with bombBays', () => {
+    it('Seeker with no bombBays supplied → no bay errors', () => {
       const errors = validateAerospaceUnit(seekerInput());
-      expect(errors.some((e) => e.ruleId === "VAL-AERO-BOMB-BAY")).toBe(false);
+      expect(errors.some((e) => e.ruleId === 'VAL-AERO-BOMB-BAY')).toBe(false);
     });
 
-    it("Seeker with two legal bays → clean build", () => {
+    it('Seeker with two legal bays → clean build', () => {
       const input = {
         ...seekerInput(),
         bombBays: [
-          { id: "fwd", capacityBombs: 10 },
-          { id: "aft", capacityBombs: 10 },
+          { id: 'fwd', capacityBombs: 10 },
+          { id: 'aft', capacityBombs: 10 },
         ],
       };
       expect(validateAerospaceUnit(input)).toHaveLength(0);
     });
 
-    it("Seeker with oversized bay → VAL-AERO-BOMB-BAY", () => {
+    it('Seeker with oversized bay → VAL-AERO-BOMB-BAY', () => {
       const input = {
         ...seekerInput(),
-        bombBays: [{ id: "huge", capacityBombs: 60 }],
+        bombBays: [{ id: 'huge', capacityBombs: 60 }],
       };
       // 100t × 0.5 = 50 cap; bay = 60+1 = 61. Violation.
       const errors = validateAerospaceUnit(input);
-      expect(errors.some((e) => e.ruleId === "VAL-AERO-BOMB-BAY")).toBe(true);
+      expect(errors.some((e) => e.ruleId === 'VAL-AERO-BOMB-BAY')).toBe(true);
     });
 
-    it("Shilone with bombBays → VAL-AERO-BOMB-BAY (ASF cannot use small-craft bays)", () => {
+    it('Shilone with bombBays → VAL-AERO-BOMB-BAY (ASF cannot use small-craft bays)', () => {
       const input = {
         ...shiloneInput(),
-        bombBays: [{ id: "b1", capacityBombs: 4 }],
+        bombBays: [{ id: 'b1', capacityBombs: 4 }],
       };
       const errors = validateAerospaceUnit(input);
-      expect(errors.some((e) => e.ruleId === "VAL-AERO-BOMB-BAY")).toBe(true);
+      expect(errors.some((e) => e.ruleId === 'VAL-AERO-BOMB-BAY')).toBe(true);
     });
   });
 });
@@ -1319,12 +1319,12 @@ describe("bombBays (Task 7.4)", () => {
 // Validation registry — both new rules registered
 // ============================================================================
 
-describe("AERO_VALIDATION_RULE_IDS includes new rules", () => {
-  it("includes VAL-AERO-WING-HEAVY", () => {
-    expect(AERO_VALIDATION_RULE_IDS).toContain("VAL-AERO-WING-HEAVY");
+describe('AERO_VALIDATION_RULE_IDS includes new rules', () => {
+  it('includes VAL-AERO-WING-HEAVY', () => {
+    expect(AERO_VALIDATION_RULE_IDS).toContain('VAL-AERO-WING-HEAVY');
   });
 
-  it("includes VAL-AERO-BOMB-BAY", () => {
-    expect(AERO_VALIDATION_RULE_IDS).toContain("VAL-AERO-BOMB-BAY");
+  it('includes VAL-AERO-BOMB-BAY', () => {
+    expect(AERO_VALIDATION_RULE_IDS).toContain('VAL-AERO-BOMB-BAY');
   });
 });

--- a/src/utils/construction/aerospace/bombBays.ts
+++ b/src/utils/construction/aerospace/bombBays.ts
@@ -27,8 +27,9 @@
  * Requirement: Equipment Mounting per Arc
  */
 
-import { AerospaceSubType } from "../../../types/unit/AerospaceInterfaces";
-import type { AerospaceValidationError } from "./validationRules";
+import type { AerospaceValidationError } from './validationRules';
+
+import { AerospaceSubType } from '../../../types/unit/AerospaceInterfaces';
 
 // ============================================================================
 // Configuration Types
@@ -106,7 +107,7 @@ export function validateBombBays(
   if (subType !== AerospaceSubType.SMALL_CRAFT) {
     if (bays.length > 0) {
       errors.push({
-        ruleId: "VAL-AERO-BOMB-BAY",
+        ruleId: 'VAL-AERO-BOMB-BAY',
         message: `Bomb bays are only configurable on small craft; ${subType} must use the single bombCapacity field`,
       });
     }
@@ -117,7 +118,7 @@ export function validateBombBays(
   for (const bay of bays) {
     if (!Number.isInteger(bay.capacityBombs) || bay.capacityBombs < 0) {
       errors.push({
-        ruleId: "VAL-AERO-BOMB-BAY",
+        ruleId: 'VAL-AERO-BOMB-BAY',
         message: `Bomb bay "${bay.id}" capacity must be a non-negative integer; got ${bay.capacityBombs}`,
       });
     }
@@ -128,7 +129,7 @@ export function validateBombBays(
   const cap = maxBombBayTons(tonnage, subType);
   if (totalTons > cap) {
     errors.push({
-      ruleId: "VAL-AERO-BOMB-BAY",
+      ruleId: 'VAL-AERO-BOMB-BAY',
       message: `Bomb bay tonnage ${totalTons}t exceeds cap ${cap}t for ${tonnage}t ${subType}`,
     });
   }

--- a/src/utils/construction/aerospace/bombBays.ts
+++ b/src/utils/construction/aerospace/bombBays.ts
@@ -1,0 +1,137 @@
+/**
+ * Aerospace Bomb Bay Construction (Small Craft)
+ *
+ * ASF and Conventional Fighters carry external bomb loads using a single
+ * `hasBombBay` flag and `bombCapacity` (tons). Small Craft, however, can
+ * mount multiple internal bomb bays, each with its own capacity and
+ * (optionally) door count for simultaneous launches.
+ *
+ * Per BattleTech rules (Strategic Operations / TacOps), each bomb bay on a
+ * small craft consumes 1 ton per bomb of capacity plus 1 ton of fixed
+ * structure per bay. The aggregate bomb-bay tonnage is bounded by the
+ * unit weight budget; in practice a small craft cannot dedicate more
+ * than half its tonnage to bomb bays.
+ *
+ * Cap rule:
+ *   maxBombBayTons = floor(unitTonnage / 2)
+ *
+ * Per-bay rule:
+ *   bayTons = capacityBombs + 1   // 1 ton structure + 1 ton per bomb
+ *   bayTons >= 1                  // empty bay still costs 1 ton
+ *
+ * This module is small-craft only. ASF/CF retain their existing single
+ * `bombCapacity` field; this construction-time helper does not modify
+ * that path.
+ *
+ * @spec openspec/changes/add-aerospace-construction/specs/aerospace-unit-system/spec.md
+ * Requirement: Equipment Mounting per Arc
+ */
+
+import { AerospaceSubType } from "../../../types/unit/AerospaceInterfaces";
+import type { AerospaceValidationError } from "./validationRules";
+
+// ============================================================================
+// Configuration Types
+// ============================================================================
+
+/**
+ * A single small-craft bomb bay. `capacityBombs` is the maximum number of
+ * 1-ton bombs the bay can hold; `bayTons` is computed from capacity plus
+ * 1 ton of bay structure.
+ */
+export interface IBombBay {
+  /** Stable identifier for this bay (UI key) */
+  readonly id: string;
+  /** Maximum bombs (each = 1 ton). Must be >= 0. */
+  readonly capacityBombs: number;
+}
+
+/** Cost overhead for the bay structure itself, in tons. */
+export const BAY_STRUCTURE_TONS = 1;
+
+/** Half-of-tonnage cap on aggregate bomb-bay weight. */
+export const BOMB_BAY_TONNAGE_FRACTION = 0.5;
+
+// ============================================================================
+// Calculation
+// ============================================================================
+
+/**
+ * Tonnage cost of a single bay = capacityBombs + structure overhead.
+ * A 0-capacity bay is illegal; callers should use validateBombBays to check.
+ */
+export function bayTons(bay: IBombBay): number {
+  return Math.max(0, bay.capacityBombs) + BAY_STRUCTURE_TONS;
+}
+
+/** Sum bay tonnage across the supplied bays. */
+export function totalBombBayTons(bays: ReadonlyArray<IBombBay>): number {
+  return bays.reduce((sum, bay) => sum + bayTons(bay), 0);
+}
+
+/** Sum bomb capacity (in 1-ton bombs) across all bays. */
+export function totalBombCapacity(bays: ReadonlyArray<IBombBay>): number {
+  return bays.reduce((sum, bay) => sum + Math.max(0, bay.capacityBombs), 0);
+}
+
+/**
+ * Maximum tons a small craft may dedicate to bomb bays.
+ * Returns 0 for non-small-craft sub-types.
+ */
+export function maxBombBayTons(
+  tonnage: number,
+  subType: AerospaceSubType,
+): number {
+  if (subType !== AerospaceSubType.SMALL_CRAFT) return 0;
+  return Math.floor(tonnage * BOMB_BAY_TONNAGE_FRACTION);
+}
+
+// ============================================================================
+// Validation (VAL-AERO-BOMB-BAY)
+// ============================================================================
+
+/**
+ * VAL-AERO-BOMB-BAY: bomb bays are legal only on small craft, each bay
+ * must have a non-negative capacity, and aggregate bay tonnage must not
+ * exceed floor(tonnage / 2).
+ */
+export function validateBombBays(
+  bays: ReadonlyArray<IBombBay>,
+  tonnage: number,
+  subType: AerospaceSubType,
+): AerospaceValidationError[] {
+  const errors: AerospaceValidationError[] = [];
+
+  // Sub-type gate: only small craft may declare configurable bays here.
+  if (subType !== AerospaceSubType.SMALL_CRAFT) {
+    if (bays.length > 0) {
+      errors.push({
+        ruleId: "VAL-AERO-BOMB-BAY",
+        message: `Bomb bays are only configurable on small craft; ${subType} must use the single bombCapacity field`,
+      });
+    }
+    return errors;
+  }
+
+  // Per-bay capacity sanity check.
+  for (const bay of bays) {
+    if (!Number.isInteger(bay.capacityBombs) || bay.capacityBombs < 0) {
+      errors.push({
+        ruleId: "VAL-AERO-BOMB-BAY",
+        message: `Bomb bay "${bay.id}" capacity must be a non-negative integer; got ${bay.capacityBombs}`,
+      });
+    }
+  }
+
+  // Aggregate tonnage cap.
+  const totalTons = totalBombBayTons(bays);
+  const cap = maxBombBayTons(tonnage, subType);
+  if (totalTons > cap) {
+    errors.push({
+      ruleId: "VAL-AERO-BOMB-BAY",
+      message: `Bomb bay tonnage ${totalTons}t exceeds cap ${cap}t for ${tonnage}t ${subType}`,
+    });
+  }
+
+  return errors;
+}

--- a/src/utils/construction/aerospace/index.ts
+++ b/src/utils/construction/aerospace/index.ts
@@ -4,13 +4,15 @@
  * @spec openspec/changes/add-aerospace-construction/specs/aerospace-unit-system/spec.md
  */
 
-export * from './aerospaceBV';
-export * from './armorArcCalculations';
-export * from './crewCalculations';
-export * from './engineWeightAerospace';
-export * from './equipmentSlots';
-export * from './fuelCalculations';
-export * from './siCalculations';
-export * from './thrustCalculations';
-export * from './validationRules';
-export * from './weightBreakdown';
+export * from "./aerospaceBV";
+export * from "./armorArcCalculations";
+export * from "./bombBays";
+export * from "./crewCalculations";
+export * from "./engineWeightAerospace";
+export * from "./equipmentSlots";
+export * from "./fuelCalculations";
+export * from "./siCalculations";
+export * from "./thrustCalculations";
+export * from "./validationRules";
+export * from "./weightBreakdown";
+export * from "./wingHeavyWeapons";

--- a/src/utils/construction/aerospace/index.ts
+++ b/src/utils/construction/aerospace/index.ts
@@ -4,15 +4,15 @@
  * @spec openspec/changes/add-aerospace-construction/specs/aerospace-unit-system/spec.md
  */
 
-export * from "./aerospaceBV";
-export * from "./armorArcCalculations";
-export * from "./bombBays";
-export * from "./crewCalculations";
-export * from "./engineWeightAerospace";
-export * from "./equipmentSlots";
-export * from "./fuelCalculations";
-export * from "./siCalculations";
-export * from "./thrustCalculations";
-export * from "./validationRules";
-export * from "./weightBreakdown";
-export * from "./wingHeavyWeapons";
+export * from './aerospaceBV';
+export * from './armorArcCalculations';
+export * from './bombBays';
+export * from './crewCalculations';
+export * from './engineWeightAerospace';
+export * from './equipmentSlots';
+export * from './fuelCalculations';
+export * from './siCalculations';
+export * from './thrustCalculations';
+export * from './validationRules';
+export * from './weightBreakdown';
+export * from './wingHeavyWeapons';

--- a/src/utils/construction/aerospace/validationRules.ts
+++ b/src/utils/construction/aerospace/validationRules.ts
@@ -5,12 +5,14 @@
  * Each rule returns a ValidationError[] — empty means the unit is legal.
  *
  * Rules:
- *   VAL-AERO-TONNAGE  — tonnage within sub-type range
- *   VAL-AERO-THRUST   — engine type legal for sub-type; safeThrust ≤ cap
- *   VAL-AERO-SI       — structural integrity within class max
- *   VAL-AERO-FUEL     — fuel tonnage ≥ minimum for sub-type
- *   VAL-AERO-ARC-MAX  — per-arc armor ≤ arc maximum
- *   VAL-AERO-CREW     — small craft has crew quarters
+ *   VAL-AERO-TONNAGE     — tonnage within sub-type range
+ *   VAL-AERO-THRUST      — engine type legal for sub-type; safeThrust ≤ cap
+ *   VAL-AERO-SI          — structural integrity within class max
+ *   VAL-AERO-FUEL        — fuel tonnage ≥ minimum for sub-type
+ *   VAL-AERO-ARC-MAX     — per-arc armor ≤ arc maximum
+ *   VAL-AERO-CREW        — small craft has crew quarters
+ *   VAL-AERO-WING-HEAVY  — wing heavy-weapon tons ≤ floor(tonnage/10) per wing
+ *   VAL-AERO-BOMB-BAY    — small-craft bomb-bay tonnage ≤ floor(tonnage/2)
  *
  * @spec openspec/changes/add-aerospace-construction/specs/aerospace-unit-system/spec.md
  * Requirement: Aerospace Construction Validation Rules
@@ -20,14 +22,19 @@ import {
   AerospaceArc,
   AerospaceEngineType,
   AerospaceSubType,
-} from '../../../types/unit/AerospaceInterfaces';
-import { maxArcArmorPoints } from './armorArcCalculations';
-import { minFuelTons } from './fuelCalculations';
-import { maxSI } from './siCalculations';
+} from "../../../types/unit/AerospaceInterfaces";
+import { maxArcArmorPoints } from "./armorArcCalculations";
+import { validateBombBays, type IBombBay } from "./bombBays";
+import { minFuelTons } from "./fuelCalculations";
+import { maxSI } from "./siCalculations";
 import {
   getMaxSafeThrust,
   isEngineLegalForSubType,
-} from './thrustCalculations';
+} from "./thrustCalculations";
+import {
+  validateWingHeavyWeapons,
+  type WingMountInput,
+} from "./wingHeavyWeapons";
 
 // ============================================================================
 // Validation Error Shape
@@ -66,7 +73,7 @@ export function validateTonnage(
   if (tonnage < min || tonnage > max) {
     return [
       {
-        ruleId: 'VAL-AERO-TONNAGE',
+        ruleId: "VAL-AERO-TONNAGE",
         message: `${subType} tonnage must be ${min}–${max} tons; got ${tonnage}t`,
       },
     ];
@@ -87,7 +94,7 @@ export function validateThrust(
 
   if (!isEngineLegalForSubType(engineType, subType)) {
     errors.push({
-      ruleId: 'VAL-AERO-THRUST',
+      ruleId: "VAL-AERO-THRUST",
       message: `Engine type "${engineType}" is not legal for ${subType}`,
     });
   }
@@ -95,7 +102,7 @@ export function validateThrust(
   const cap = getMaxSafeThrust(subType);
   if (safeThrust > cap) {
     errors.push({
-      ruleId: 'VAL-AERO-THRUST',
+      ruleId: "VAL-AERO-THRUST",
       message: `Safe thrust ${safeThrust} exceeds class cap of ${cap} for ${subType}`,
     });
   }
@@ -114,7 +121,7 @@ export function validateSI(
   if (si > max) {
     return [
       {
-        ruleId: 'VAL-AERO-SI',
+        ruleId: "VAL-AERO-SI",
         message: `Structural integrity ${si} exceeds class max of ${max} for ${subType}`,
       },
     ];
@@ -133,7 +140,7 @@ export function validateFuel(
   if (fuelTons < min) {
     return [
       {
-        ruleId: 'VAL-AERO-FUEL',
+        ruleId: "VAL-AERO-FUEL",
         message: `Fuel tonnage ${fuelTons}t is below minimum ${min}t for ${subType}`,
       },
     ];
@@ -160,7 +167,7 @@ export function validateArcArmor(
     if (max === 0) continue; // Arc not applicable to this sub-type
     if (points > max) {
       errors.push({
-        ruleId: 'VAL-AERO-ARC-MAX',
+        ruleId: "VAL-AERO-ARC-MAX",
         message: `Arc "${arcKey}" armor ${points} exceeds max ${max} for ${tonnage}t ${subType}`,
       });
     }
@@ -184,15 +191,15 @@ export function validateCrew(
 
   if (quartersTons <= 0) {
     errors.push({
-      ruleId: 'VAL-AERO-CREW',
-      message: 'Small craft must allocate tonnage for crew quarters',
+      ruleId: "VAL-AERO-CREW",
+      message: "Small craft must allocate tonnage for crew quarters",
     });
   }
 
   if (crewCount < 1) {
     errors.push({
-      ruleId: 'VAL-AERO-CREW',
-      message: 'Small craft must have at least 1 crew member',
+      ruleId: "VAL-AERO-CREW",
+      message: "Small craft must have at least 1 crew member",
     });
   }
 
@@ -205,12 +212,14 @@ export function validateCrew(
 
 /** All registered VAL-AERO-* rule IDs. */
 export const AERO_VALIDATION_RULE_IDS = [
-  'VAL-AERO-TONNAGE',
-  'VAL-AERO-THRUST',
-  'VAL-AERO-SI',
-  'VAL-AERO-FUEL',
-  'VAL-AERO-ARC-MAX',
-  'VAL-AERO-CREW',
+  "VAL-AERO-TONNAGE",
+  "VAL-AERO-THRUST",
+  "VAL-AERO-SI",
+  "VAL-AERO-FUEL",
+  "VAL-AERO-ARC-MAX",
+  "VAL-AERO-CREW",
+  "VAL-AERO-WING-HEAVY",
+  "VAL-AERO-BOMB-BAY",
 ] as const;
 
 export type AeroValidationRuleId = (typeof AERO_VALIDATION_RULE_IDS)[number];
@@ -229,16 +238,27 @@ export interface AerospaceValidationInput {
   readonly arcArmor: Partial<Record<AerospaceArc, number>>;
   readonly quartersTons: number;
   readonly crewCount: number;
+  /**
+   * Optional wing-mounted equipment list (ASF / CF only).
+   * When omitted, the wing-heavy rule contributes no errors.
+   */
+  readonly wingMounts?: ReadonlyArray<WingMountInput>;
+  /**
+   * Optional small-craft bomb bay list. When omitted, the bay rule
+   * contributes no errors. Non-empty for ASF/CF triggers a sub-type error.
+   */
+  readonly bombBays?: ReadonlyArray<IBombBay>;
 }
 
 /**
  * Run all VAL-AERO-* rules against a unit configuration.
- * Returns a flat array of all violations.
+ * Returns a flat array of all violations. Wing-mount and bomb-bay rules
+ * are evaluated only when the corresponding optional inputs are provided.
  */
 export function validateAerospaceUnit(
   input: AerospaceValidationInput,
 ): AerospaceValidationError[] {
-  return [
+  const errors: AerospaceValidationError[] = [
     ...validateTonnage(input.tonnage, input.subType),
     ...validateThrust(input.engineType, input.safeThrust, input.subType),
     ...validateSI(input.structuralIntegrity, input.subType),
@@ -246,4 +266,20 @@ export function validateAerospaceUnit(
     ...validateArcArmor(input.arcArmor, input.tonnage, input.subType),
     ...validateCrew(input.subType, input.quartersTons, input.crewCount),
   ];
+
+  if (input.wingMounts) {
+    errors.push(
+      ...validateWingHeavyWeapons(
+        input.wingMounts,
+        input.tonnage,
+        input.subType,
+      ),
+    );
+  }
+  if (input.bombBays) {
+    errors.push(
+      ...validateBombBays(input.bombBays, input.tonnage, input.subType),
+    );
+  }
+  return errors;
 }

--- a/src/utils/construction/aerospace/validationRules.ts
+++ b/src/utils/construction/aerospace/validationRules.ts
@@ -22,19 +22,19 @@ import {
   AerospaceArc,
   AerospaceEngineType,
   AerospaceSubType,
-} from "../../../types/unit/AerospaceInterfaces";
-import { maxArcArmorPoints } from "./armorArcCalculations";
-import { validateBombBays, type IBombBay } from "./bombBays";
-import { minFuelTons } from "./fuelCalculations";
-import { maxSI } from "./siCalculations";
+} from '../../../types/unit/AerospaceInterfaces';
+import { maxArcArmorPoints } from './armorArcCalculations';
+import { validateBombBays, type IBombBay } from './bombBays';
+import { minFuelTons } from './fuelCalculations';
+import { maxSI } from './siCalculations';
 import {
   getMaxSafeThrust,
   isEngineLegalForSubType,
-} from "./thrustCalculations";
+} from './thrustCalculations';
 import {
   validateWingHeavyWeapons,
   type WingMountInput,
-} from "./wingHeavyWeapons";
+} from './wingHeavyWeapons';
 
 // ============================================================================
 // Validation Error Shape
@@ -73,7 +73,7 @@ export function validateTonnage(
   if (tonnage < min || tonnage > max) {
     return [
       {
-        ruleId: "VAL-AERO-TONNAGE",
+        ruleId: 'VAL-AERO-TONNAGE',
         message: `${subType} tonnage must be ${min}–${max} tons; got ${tonnage}t`,
       },
     ];
@@ -94,7 +94,7 @@ export function validateThrust(
 
   if (!isEngineLegalForSubType(engineType, subType)) {
     errors.push({
-      ruleId: "VAL-AERO-THRUST",
+      ruleId: 'VAL-AERO-THRUST',
       message: `Engine type "${engineType}" is not legal for ${subType}`,
     });
   }
@@ -102,7 +102,7 @@ export function validateThrust(
   const cap = getMaxSafeThrust(subType);
   if (safeThrust > cap) {
     errors.push({
-      ruleId: "VAL-AERO-THRUST",
+      ruleId: 'VAL-AERO-THRUST',
       message: `Safe thrust ${safeThrust} exceeds class cap of ${cap} for ${subType}`,
     });
   }
@@ -121,7 +121,7 @@ export function validateSI(
   if (si > max) {
     return [
       {
-        ruleId: "VAL-AERO-SI",
+        ruleId: 'VAL-AERO-SI',
         message: `Structural integrity ${si} exceeds class max of ${max} for ${subType}`,
       },
     ];
@@ -140,7 +140,7 @@ export function validateFuel(
   if (fuelTons < min) {
     return [
       {
-        ruleId: "VAL-AERO-FUEL",
+        ruleId: 'VAL-AERO-FUEL',
         message: `Fuel tonnage ${fuelTons}t is below minimum ${min}t for ${subType}`,
       },
     ];
@@ -167,7 +167,7 @@ export function validateArcArmor(
     if (max === 0) continue; // Arc not applicable to this sub-type
     if (points > max) {
       errors.push({
-        ruleId: "VAL-AERO-ARC-MAX",
+        ruleId: 'VAL-AERO-ARC-MAX',
         message: `Arc "${arcKey}" armor ${points} exceeds max ${max} for ${tonnage}t ${subType}`,
       });
     }
@@ -191,15 +191,15 @@ export function validateCrew(
 
   if (quartersTons <= 0) {
     errors.push({
-      ruleId: "VAL-AERO-CREW",
-      message: "Small craft must allocate tonnage for crew quarters",
+      ruleId: 'VAL-AERO-CREW',
+      message: 'Small craft must allocate tonnage for crew quarters',
     });
   }
 
   if (crewCount < 1) {
     errors.push({
-      ruleId: "VAL-AERO-CREW",
-      message: "Small craft must have at least 1 crew member",
+      ruleId: 'VAL-AERO-CREW',
+      message: 'Small craft must have at least 1 crew member',
     });
   }
 
@@ -212,14 +212,14 @@ export function validateCrew(
 
 /** All registered VAL-AERO-* rule IDs. */
 export const AERO_VALIDATION_RULE_IDS = [
-  "VAL-AERO-TONNAGE",
-  "VAL-AERO-THRUST",
-  "VAL-AERO-SI",
-  "VAL-AERO-FUEL",
-  "VAL-AERO-ARC-MAX",
-  "VAL-AERO-CREW",
-  "VAL-AERO-WING-HEAVY",
-  "VAL-AERO-BOMB-BAY",
+  'VAL-AERO-TONNAGE',
+  'VAL-AERO-THRUST',
+  'VAL-AERO-SI',
+  'VAL-AERO-FUEL',
+  'VAL-AERO-ARC-MAX',
+  'VAL-AERO-CREW',
+  'VAL-AERO-WING-HEAVY',
+  'VAL-AERO-BOMB-BAY',
 ] as const;
 
 export type AeroValidationRuleId = (typeof AERO_VALIDATION_RULE_IDS)[number];

--- a/src/utils/construction/aerospace/wingHeavyWeapons.ts
+++ b/src/utils/construction/aerospace/wingHeavyWeapons.ts
@@ -1,0 +1,163 @@
+/**
+ * Aerospace Wing-Mounted Heavy Weapon Caps
+ *
+ * Aerospace Fighters and Conventional Fighters mount weapons in NOSE,
+ * LEFT_WING, RIGHT_WING, AFT, or FUSELAGE arcs. The total tonnage of
+ * "heavy" weapons (PPC family, Gauss family, AC/20, Heavy Gauss, etc.)
+ * mounted in a single wing arc is capped to keep wing structures from
+ * being overstressed.
+ *
+ * Cap rule (per MegaMekLab convention):
+ *   maxHeavyTonsPerWing = floor(unitTonnage / 10)
+ *
+ * Heavy classification covers BattleTech weapons that ground-side rules
+ * already treat as "explosive" or "heavy mass" mounts: PPC variants,
+ * all Gauss flavors, AC/20, and improved-heavy weapons. The caller
+ * provides the weapon set; this module encodes the rule and the
+ * canonical heavy-weapon name list, and exposes a validator.
+ *
+ * Small Craft use LEFT_SIDE / RIGHT_SIDE arcs with their own broad-side
+ * mounting rules; this cap rule does NOT apply to small craft.
+ *
+ * @spec openspec/changes/add-aerospace-construction/specs/aerospace-unit-system/spec.md
+ * Requirement: Equipment Mounting per Arc
+ */
+
+import {
+  AerospaceArc,
+  AerospaceSubType,
+} from "../../../types/unit/AerospaceInterfaces";
+import type { AerospaceValidationError } from "./validationRules";
+
+// ============================================================================
+// Heavy Weapon Classification
+// ============================================================================
+
+/**
+ * Canonical list of "heavy" weapon name fragments that count against the
+ * wing tonnage cap. Matched case-insensitively against either the equipment
+ * id or the display name. Keep this list minimal and explicit — adding a
+ * new family requires reviewing the cap value too.
+ */
+const HEAVY_WEAPON_FRAGMENTS: readonly string[] = [
+  "ppc",
+  "gauss",
+  "ac/20",
+  "ac20",
+  "autocannon/20",
+];
+
+/**
+ * Return true if the equipment id or name identifies a heavy weapon for
+ * wing-mount cap purposes.
+ *
+ * @param idOrName - equipment id (e.g. "isppc") or display name ("PPC")
+ */
+export function isWingHeavyWeapon(idOrName: string): boolean {
+  const lowered = idOrName.toLowerCase();
+  return HEAVY_WEAPON_FRAGMENTS.some((fragment) => lowered.includes(fragment));
+}
+
+// ============================================================================
+// Cap Calculation
+// ============================================================================
+
+/**
+ * Wing arcs that are subject to the heavy-weapon cap. Small craft side arcs
+ * are intentionally excluded — they follow capital-ship-style broad-side
+ * rules tracked separately by the bay system.
+ */
+const CAPPED_WING_ARCS: ReadonlySet<AerospaceArc> = new Set([
+  AerospaceArc.LEFT_WING,
+  AerospaceArc.RIGHT_WING,
+]);
+
+/**
+ * Maximum tons of heavy weapons mountable in a single wing arc.
+ * Returns 0 for sub-types or arcs where the rule does not apply.
+ *
+ * @param tonnage - chassis tonnage
+ * @param subType - aerospace sub-type (small craft has no per-wing cap)
+ */
+export function maxHeavyWeaponTonsPerWing(
+  tonnage: number,
+  subType: AerospaceSubType,
+): number {
+  if (subType === AerospaceSubType.SMALL_CRAFT) return 0;
+  return Math.floor(tonnage / 10);
+}
+
+/**
+ * Return true if a wing arc has room for an additional `addedTons` of heavy
+ * weaponry given an existing load already on that wing.
+ */
+export function canMountHeavyOnWing(
+  arc: AerospaceArc,
+  existingHeavyTonsOnArc: number,
+  addedTons: number,
+  tonnage: number,
+  subType: AerospaceSubType,
+): boolean {
+  if (!CAPPED_WING_ARCS.has(arc)) return true;
+  const cap = maxHeavyWeaponTonsPerWing(tonnage, subType);
+  return existingHeavyTonsOnArc + addedTons <= cap;
+}
+
+// ============================================================================
+// Aggregation
+// ============================================================================
+
+/** Minimal shape needed from a mounted equipment item for cap accounting. */
+export interface WingMountInput {
+  readonly arc: AerospaceArc;
+  readonly idOrName: string;
+  readonly tons: number;
+}
+
+/**
+ * Sum heavy-weapon tonnage on each capped wing arc. Non-heavy items and
+ * non-wing arcs are ignored. The returned map only contains entries for
+ * the LEFT_WING / RIGHT_WING arcs (zero if no heavy weapons are present).
+ */
+export function heavyTonsByWing(
+  items: ReadonlyArray<WingMountInput>,
+): Map<AerospaceArc, number> {
+  const result = new Map<AerospaceArc, number>([
+    [AerospaceArc.LEFT_WING, 0],
+    [AerospaceArc.RIGHT_WING, 0],
+  ]);
+  for (const item of items) {
+    if (!CAPPED_WING_ARCS.has(item.arc)) continue;
+    if (!isWingHeavyWeapon(item.idOrName)) continue;
+    result.set(item.arc, (result.get(item.arc) ?? 0) + item.tons);
+  }
+  return result;
+}
+
+// ============================================================================
+// Validation Rule (VAL-AERO-WING-HEAVY)
+// ============================================================================
+
+/**
+ * VAL-AERO-WING-HEAVY: per-wing heavy-weapon tonnage must not exceed
+ * floor(tonnage / 10) for ASF / CF. Small craft are exempt.
+ */
+export function validateWingHeavyWeapons(
+  items: ReadonlyArray<WingMountInput>,
+  tonnage: number,
+  subType: AerospaceSubType,
+): AerospaceValidationError[] {
+  if (subType === AerospaceSubType.SMALL_CRAFT) return [];
+  const cap = maxHeavyWeaponTonsPerWing(tonnage, subType);
+  const errors: AerospaceValidationError[] = [];
+  const tons = heavyTonsByWing(items);
+  tons.forEach((sum, arc) => {
+    if (sum > cap) {
+      errors.push({
+        ruleId: "VAL-AERO-WING-HEAVY",
+        message: `Wing "${arc}" carries ${sum}t of heavy weapons; cap for ${tonnage}t ${subType} is ${cap}t`,
+      });
+    }
+  });
+  return errors;
+}

--- a/src/utils/construction/aerospace/wingHeavyWeapons.ts
+++ b/src/utils/construction/aerospace/wingHeavyWeapons.ts
@@ -23,11 +23,12 @@
  * Requirement: Equipment Mounting per Arc
  */
 
+import type { AerospaceValidationError } from './validationRules';
+
 import {
   AerospaceArc,
   AerospaceSubType,
-} from "../../../types/unit/AerospaceInterfaces";
-import type { AerospaceValidationError } from "./validationRules";
+} from '../../../types/unit/AerospaceInterfaces';
 
 // ============================================================================
 // Heavy Weapon Classification
@@ -40,11 +41,11 @@ import type { AerospaceValidationError } from "./validationRules";
  * new family requires reviewing the cap value too.
  */
 const HEAVY_WEAPON_FRAGMENTS: readonly string[] = [
-  "ppc",
-  "gauss",
-  "ac/20",
-  "ac20",
-  "autocannon/20",
+  'ppc',
+  'gauss',
+  'ac/20',
+  'ac20',
+  'autocannon/20',
 ];
 
 /**
@@ -154,7 +155,7 @@ export function validateWingHeavyWeapons(
   tons.forEach((sum, arc) => {
     if (sum > cap) {
       errors.push({
-        ruleId: "VAL-AERO-WING-HEAVY",
+        ruleId: 'VAL-AERO-WING-HEAVY',
         message: `Wing "${arc}" carries ${sum}t of heavy weapons; cap for ${tonnage}t ${subType} is ${cap}t`,
       });
     }


### PR DESCRIPTION
## Summary

Closes the final two outstanding construction tasks in `add-aerospace-construction` (49/51 → 51/51, ~96% → 100%).

- **Task 7.3** — Wing-mounted heavy weapons (PPC, Gauss, AC/20) cap at `floor(tonnage / 10)` tons per wing for ASF/CF; small-craft side arcs exempt. New rule `VAL-AERO-WING-HEAVY`.
- **Task 7.4** — Configurable bomb bays for small craft. Each bay = `capacityBombs + 1` tons; aggregate cap `floor(tonnage / 2)`. ASF/CF retain the existing single-`bombCapacity` path. New rule `VAL-AERO-BOMB-BAY`.

`validateAerospaceUnit` now optionally accepts `wingMounts` and `bombBays`; existing call sites are unchanged because both inputs are optional.

## Files

- `src/utils/construction/aerospace/wingHeavyWeapons.ts` (new, 163 lines)
- `src/utils/construction/aerospace/bombBays.ts` (new, 137 lines)
- `src/utils/construction/aerospace/validationRules.ts` (extended runner + rule registry)
- `src/utils/construction/aerospace/index.ts` (barrel exports)
- `src/__tests__/unit/aerospace-construction.test.ts` (50+ new tests covering both modules and the integration runner)
- `openspec/changes/add-aerospace-construction/tasks.md` (7.3 / 7.4 marked done)

## Verification

- `npm run typecheck` — clean
- `npm run lint` (oxlint) — only pre-existing warning in unrelated `aerospaceBV.ts`
- `npx jest --watchAll=false` — **767 suites pass, 21863 tests pass** (44 pre-existing skipped)
- Aerospace-only filter: 17 suites, 387 tests pass
- `npx openspec validate add-aerospace-construction --strict` — valid

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx jest src/__tests__/unit/aerospace-construction.test.ts` — 147 passing
- [x] `npx jest aerospace` — 387 passing
- [x] Full `npx jest --watchAll=false` — 21863 passing
- [x] `npx openspec validate add-aerospace-construction --strict`

## Notes for follow-up

- Verify + archive happen in the parent coordination step (`/opsx:verify` then `/opsx:archive`).
- The two new rule IDs (`VAL-AERO-WING-HEAVY`, `VAL-AERO-BOMB-BAY`) are added to `AERO_VALIDATION_RULE_IDS` but are not yet referenced in the spec delta. The verify pass may want to extend `specs/aerospace-unit-system/spec.md` with explicit scenarios for these rules; current scope was implementation + tests only.
- Store/UI wiring (`AerospaceEquipmentTab` for wing limits, a new bomb-bay editor for small craft) is intentionally out of scope here — this PR only completes the construction-rule + validation layer that those UIs will consume.