### PR TITLE
fix(openspec): close aerospace-construction spec/test gaps (verifier feedback)

### DIFF
--- a/openspec/changes/add-aerospace-construction/specs/aerospace-unit-system/spec.md
+++ b/openspec/changes/add-aerospace-construction/specs/aerospace-unit-system/spec.md
@@ -127,6 +127,38 @@ Small craft SHALL require crew and passenger quarters weight in construction.
 - **WHEN** validation runs
 - **THEN** `VAL-AERO-CREW` SHALL emit an error
 
+### Requirement: Wing-Mounted Heavy Weapon Cap
+
+The system SHALL cap the total tonnage of heavy weapons (PPC family, Gauss family, AC/20) mounted in any single wing arc of an ASF or CF at `floor(unitTonnage / 10)`. Small craft are exempt — `VAL-AERO-WING-HEAVY` SHALL NOT fire for sub-type Small Craft.
+
+#### Scenario: Wing cap exceeded on ASF
+
+- **GIVEN** a 65t ASF (cap = 6t per wing)
+- **WHEN** a 15t Gauss Rifle is mounted in the right wing
+- **THEN** `VAL-AERO-WING-HEAVY` SHALL emit an error
+
+#### Scenario: Small craft exempt
+
+- **GIVEN** a 100t small craft with 20t of PPCs in a side arc
+- **WHEN** validation runs
+- **THEN** `VAL-AERO-WING-HEAVY` SHALL NOT fire
+
+### Requirement: Small Craft Bomb Bay Configuration
+
+Small craft SHALL support multiple configurable bomb bays. Each bay SHALL cost `1 + capacityBombs` tons (1 ton structure + 1 ton per bomb of capacity). Total bomb-bay tonnage SHALL NOT exceed `floor(unitTonnage / 2)`. ASF and CF SHALL NOT declare configurable bomb bays — `VAL-AERO-BOMB-BAY` SHALL emit an error if they do.
+
+#### Scenario: Bomb bays exceed cap
+
+- **GIVEN** a 100t small craft (cap = 50t)
+- **WHEN** two bays totalling 56t are configured
+- **THEN** `VAL-AERO-BOMB-BAY` SHALL emit an error
+
+#### Scenario: ASF declares bomb bays
+
+- **GIVEN** a 65t ASF with a bomb bay declared
+- **WHEN** validation runs
+- **THEN** `VAL-AERO-BOMB-BAY` SHALL emit an error — only small craft may use configurable bays
+
 ### Requirement: Aerospace Construction Validation Rules
 
 The validation registry SHALL include the `VAL-AERO-*` rule group.
@@ -134,4 +166,4 @@ The validation registry SHALL include the `VAL-AERO-*` rule group.
 #### Scenario: Rule ids registered
 
 - **WHEN** the validation registry initializes
-- **THEN** `VAL-AERO-TONNAGE`, `VAL-AERO-THRUST`, `VAL-AERO-SI`, `VAL-AERO-FUEL`, `VAL-AERO-ARC-MAX`, and `VAL-AERO-CREW` SHALL be registered
+- **THEN** `VAL-AERO-TONNAGE`, `VAL-AERO-THRUST`, `VAL-AERO-SI`, `VAL-AERO-FUEL`, `VAL-AERO-ARC-MAX`, `VAL-AERO-CREW`, `VAL-AERO-WING-HEAVY`, and `VAL-AERO-BOMB-BAY` SHALL be registered

--- a/src/__tests__/unit/aerospace-construction.test.ts
+++ b/src/__tests__/unit/aerospace-construction.test.ts
@@ -42,6 +42,11 @@ import {
 } from '@/utils/construction/aerospace/crewCalculations';
 import { aerospaceEngineWeight } from '@/utils/construction/aerospace/engineWeightAerospace';
 import {
+  arcSlotAvailable,
+  arcSlotLimit,
+  overLimitArcs,
+} from '@/utils/construction/aerospace/equipmentSlots';
+import {
   calculateFuelPoints,
   FUEL_POINTS_PER_TON,
   FUEL_MINIMUM_TONS,
@@ -1326,5 +1331,97 @@ describe('AERO_VALIDATION_RULE_IDS includes new rules', () => {
 
   it('includes VAL-AERO-BOMB-BAY', () => {
     expect(AERO_VALIDATION_RULE_IDS).toContain('VAL-AERO-BOMB-BAY');
+  });
+});
+
+// ============================================================================
+// Arc slot capacity (Equipment Mounting per Arc — slot count rules)
+// ============================================================================
+
+describe('arc slot capacity', () => {
+  describe('arcSlotLimit', () => {
+    it('Nose arc → 6', () => {
+      expect(arcSlotLimit(AerospaceArc.NOSE)).toBe(6);
+    });
+
+    it('LeftWing arc → 6', () => {
+      expect(arcSlotLimit(AerospaceArc.LEFT_WING)).toBe(6);
+    });
+
+    it('RightWing arc → 6', () => {
+      expect(arcSlotLimit(AerospaceArc.RIGHT_WING)).toBe(6);
+    });
+
+    it('Aft arc → 4', () => {
+      expect(arcSlotLimit(AerospaceArc.AFT)).toBe(4);
+    });
+
+    it('Fuselage arc → null (unlimited)', () => {
+      expect(arcSlotLimit(AerospaceArc.FUSELAGE)).toBeNull();
+    });
+  });
+
+  describe('arcSlotAvailable', () => {
+    it('Nose with 5 items: slot 6 still available → true', () => {
+      expect(arcSlotAvailable(AerospaceArc.NOSE, 5)).toBe(true);
+    });
+
+    it('Nose with 6 items: 7th slot rejected → false', () => {
+      // Mounting a 7th weapon in the Nose violates the cap of 6.
+      expect(arcSlotAvailable(AerospaceArc.NOSE, 6)).toBe(false);
+    });
+
+    it('Aft with 3 items: slot 4 still available → true', () => {
+      expect(arcSlotAvailable(AerospaceArc.AFT, 3)).toBe(true);
+    });
+
+    it('Aft with 4 items: 5th slot rejected → false', () => {
+      expect(arcSlotAvailable(AerospaceArc.AFT, 4)).toBe(false);
+    });
+
+    it('Fuselage with 999 items still allowed → true (unlimited)', () => {
+      expect(arcSlotAvailable(AerospaceArc.FUSELAGE, 999)).toBe(true);
+    });
+  });
+
+  describe('overLimitArcs', () => {
+    it('Nose with 7 items → returns [NOSE]', () => {
+      // 7 > limit of 6 → over-limit
+      const equipment = Array.from({ length: 7 }, () => ({
+        location: AerospaceArc.NOSE,
+      }));
+      expect(overLimitArcs(equipment)).toEqual([AerospaceArc.NOSE]);
+    });
+
+    it('all arcs within limits → returns []', () => {
+      const equipment = [
+        { location: AerospaceArc.NOSE },
+        { location: AerospaceArc.NOSE },
+        { location: AerospaceArc.LEFT_WING },
+        { location: AerospaceArc.LEFT_WING },
+        { location: AerospaceArc.RIGHT_WING },
+        { location: AerospaceArc.AFT },
+        { location: AerospaceArc.AFT },
+      ];
+      expect(overLimitArcs(equipment)).toEqual([]);
+    });
+
+    it('empty equipment list → returns []', () => {
+      expect(overLimitArcs([])).toEqual([]);
+    });
+
+    it('Fuselage with 50 items is never over-limit (unlimited)', () => {
+      const equipment = Array.from({ length: 50 }, () => ({
+        location: AerospaceArc.FUSELAGE,
+      }));
+      expect(overLimitArcs(equipment)).toEqual([]);
+    });
+
+    it('Aft with 5 items → returns [AFT] (cap is 4)', () => {
+      const equipment = Array.from({ length: 5 }, () => ({
+        location: AerospaceArc.AFT,
+      }));
+      expect(overLimitArcs(equipment)).toEqual([AerospaceArc.AFT]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes 4 gaps flagged by `openspec verify` against `add-aerospace-construction`. The implementation in `src/utils/construction/aerospace/` and the bulk of `src/__tests__/unit/aerospace-construction.test.ts` are already on main and approved (#386). Only the spec delta and arc-slot tests were missing.

## Gaps closed

1. **VAL-AERO-WING-HEAVY requirement block missing** — added `### Requirement: Wing-Mounted Heavy Weapon Cap` to `openspec/changes/add-aerospace-construction/specs/aerospace-unit-system/spec.md` under `## ADDED Requirements`, with two scenarios (wing cap exceeded on ASF; small craft exempt).
2. **VAL-AERO-BOMB-BAY requirement block missing** — added `### Requirement: Small Craft Bomb Bay Configuration` block in the same file, with two scenarios (bomb bays exceed cap; ASF declares bomb bays).
3. **Registration scenario lists only 6 rules** — updated the `Aerospace Construction Validation Rules` scenario to list all 8 rule ids: `VAL-AERO-TONNAGE`, `VAL-AERO-THRUST`, `VAL-AERO-SI`, `VAL-AERO-FUEL`, `VAL-AERO-ARC-MAX`, `VAL-AERO-CREW`, `VAL-AERO-WING-HEAVY`, `VAL-AERO-BOMB-BAY`.
4. **Arc slot helpers untested** — added a new `describe('arc slot capacity', ...)` block in `src/__tests__/unit/aerospace-construction.test.ts` exercising `arcSlotAvailable`, `arcSlotLimit`, and `overLimitArcs` from `src/utils/construction/aerospace/equipmentSlots.ts` (covers Nose=6, Wing=6, Aft=4, Fuselage=null and the 7-weapon Nose / unlimited Fuselage scenarios from the spec).

No production code was modified — only the spec delta and existing test file. Spec edits stay scoped to `aerospace-unit-system/spec.md` per the proposal.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — only pre-existing warnings (no new ones)
- [x] `npm run format:check` — all files conform to oxfmt
- [x] `npm test -- src/__tests__/unit/aerospace-construction.test.ts` — 162/162 pass (was 147; +15 from the new arc-slot describe)
- [x] `npx openspec validate add-aerospace-construction --strict` — change is valid

Do **NOT** merge — spec change stays open until the parent change is archived.