### PR TITLE
fix(blk-import): add bv: null field to manifest entries

### DIFF
--- a/openspec/changes/archive/2026-04-25-add-blk-import-per-type/notepad/decisions.md
+++ b/openspec/changes/archive/2026-04-25-add-blk-import-per-type/notepad/decisions.md
@@ -41,7 +41,7 @@
 
 - **Task 8.2** (`App loads manifest first`): outside this change scope. The build-time manifest is in place; UI integration belongs to the per-type customizer change. Pickup: `src/components/units/UnitCatalogService.ts` once that proposal lands.
 - **Spec: Parity Validation BV column**: deferred to wave 5 once `validate-bv` covers non-mech types. Tonnage / equipment-count parity is implemented today.
-- **Spec: Per-Type Unit Manifest BV field**: same deferral — manifest entries currently have `bv: null` for all non-mech units.
+- **Spec: Per-Type Unit Manifest BV field**: same deferral — manifest entries explicitly carry `bv: null` for all non-mech units (added to every `build_manifest_entry()` return on 2026-04-25 as an audit follow-up; the prior wording suggested it was already populated as `null`, but the key was actually absent from the dicts. Now it's present, which closes the spec/code contract gap and lets consumers `entry["bv"]` without a `KeyError`). Wave 5 swaps `None` for the calculated value once per-type calculators are callable.
 
 ### Files touched
 

--- a/openspec/changes/archive/2026-04-25-add-blk-import-per-type/tasks.md
+++ b/openspec/changes/archive/2026-04-25-add-blk-import-per-type/tasks.md
@@ -66,7 +66,7 @@
 
 ## 8. Data Manifest
 
-- [x] 8.1 One `units-manifest.json` per type listing all unit ids and basic metadata (chassis, model, tonnage, BV)
+- [x] 8.1 One `units-manifest.json` per type listing all unit ids and basic metadata (chassis, model, tonnage, BV) — `bv: null` field added to all 5 `build_manifest_entry()` returns per audit follow-up; per-type BV calculator wires the value in Wave 5
 - [x] 8.2 App loads manifest first, then fetches individual unit files on demand — DEFERRED: this is frontend wiring outside the BLK-import scope. The build-time manifest is in place; UI integration belongs to the per-type customizer change (pickup: `src/components/units/UnitCatalogService.ts` once the proposal lands).
 - [x] 8.3 Size budget check: manifests < 5MB each — enforced in every converter at write time (largest current manifest: infantry at 836 KB, well under the 5 MB budget)
 

--- a/scripts/megameklab-conversion/blk_aerospace_converter.py
+++ b/scripts/megameklab-conversion/blk_aerospace_converter.py
@@ -549,6 +549,7 @@ def build_manifest_entry(unit: Dict[str, Any]) -> Dict[str, Any]:
         "era": unit["era"],
         "year": unit["year"],
         "tonnage": unit["tonnage"],
+        "bv": None,
         "motionType": unit.get("motionType", "AERODYNE"),
         "role": unit.get("role"),
         "source": unit.get("source"),

--- a/scripts/megameklab-conversion/blk_battlearmor_converter.py
+++ b/scripts/megameklab-conversion/blk_battlearmor_converter.py
@@ -496,6 +496,7 @@ def build_manifest_entry(unit: Dict[str, Any]) -> Dict[str, Any]:
         "year": unit["year"],
         "weightClass": unit["weightClass"],
         "squadSize": unit["squadSize"],
+        "bv": None,
         "motionType": unit["motionType"],
         "role": unit.get("role"),
         "source": unit.get("source"),

--- a/scripts/megameklab-conversion/blk_infantry_converter.py
+++ b/scripts/megameklab-conversion/blk_infantry_converter.py
@@ -394,6 +394,7 @@ def build_manifest_entry(unit: Dict[str, Any]) -> Dict[str, Any]:
         "squadSize": platoon.get("squadSize"),
         "squadCount": platoon.get("squadCount"),
         "totalTroopers": platoon.get("totalTroopers"),
+        "bv": None,
         "specialization": unit.get("specialization"),
         "role": unit.get("role"),
         "source": unit.get("source"),

--- a/scripts/megameklab-conversion/blk_protomech_converter.py
+++ b/scripts/megameklab-conversion/blk_protomech_converter.py
@@ -439,6 +439,7 @@ def build_manifest_entry(unit: Dict[str, Any]) -> Dict[str, Any]:
         "era": unit["era"],
         "year": unit["year"],
         "tonnage": unit["tonnage"],
+        "bv": None,
         "weightClass": unit["weightClass"],
         "motionType": unit["motionType"],
         "isGlider": unit.get("isGlider", False),

--- a/scripts/megameklab-conversion/blk_vehicle_converter.py
+++ b/scripts/megameklab-conversion/blk_vehicle_converter.py
@@ -568,6 +568,7 @@ def build_manifest_entry(unit: Dict[str, Any]) -> Dict[str, Any]:
         "era": unit["era"],
         "year": unit["year"],
         "tonnage": unit["tonnage"],
+        "bv": None,
         "motionType": unit.get("motionType", "Tracked"),
         "role": unit.get("role"),
         "source": unit.get("source"),


### PR DESCRIPTION
## Summary

Tier 4 audit follow-up: closes the spec/code mismatch in `add-blk-import-per-type` so it's archive-ready.

The `Per-Type Unit Manifest` SHALL block in the unit-data-import spec delta requires every entry to expose a `bv` field (with the actual value DEFERRED to Wave 5 per-type BV calculators). The decisions log claimed manifest entries already carried `bv: null`, but in fact all 5 converters' `build_manifest_entry()` were omitting the key entirely. Consumers reading `entry["bv"]` (Python) or `entry.bv` (TS) would have hit `KeyError` / `undefined`.

This adds `bv: None` to all 5 returns:

- `scripts/megameklab-conversion/blk_vehicle_converter.py`
- `scripts/megameklab-conversion/blk_aerospace_converter.py`
- `scripts/megameklab-conversion/blk_battlearmor_converter.py`
- `scripts/megameklab-conversion/blk_infantry_converter.py`
- `scripts/megameklab-conversion/blk_protomech_converter.py`

Plus a tasks.md note (8.1) and a corrected line in `notepad/decisions.md` so the change folder reflects reality.

## Verification

Re-ran every converter end-to-end:

| Type        | Converted | Parity Failures |
|-------------|----------:|----------------:|
| vehicle     |     1412  |             0/10 |
| aerospace   |      612  |             0/10 |
| battlearmor |     1188  |             0/10 |
| infantry    |     1792  |             0/10 |
| protomech   |       86  |             0/10 |
| **Total**   | **5090**  |        **0/50** |

Verified each `units-manifest.json` post-regeneration: every entry of every manifest has `bv: null` (5090/5090). No tonnage / squadSize parity regression. Existing Jest test suite (776 suites, 22045 tests) passes when `e2e/` is excluded; only failures are pre-existing Playwright/TransformStream issues unrelated to this PR.

## Test plan

- [x] All 5 converters return non-zero on parity regression (existing behavior preserved)
- [x] Each manifest contains `"bv": null` on every entry (5090/5090)
- [x] Per-type parity reports still pass 10/10 each
- [x] Jest test suite passes for non-e2e suites (22045/22045)
- [ ] CI pipeline green on PR