### PR TITLE
chore(openspec): tier5-audit-cleanup — Tier 1-4 audit follow-ups (MED + LOW)

### DIFF
--- a/openspec/changes/tier5-audit-cleanup/.openspec.yaml
+++ b/openspec/changes/tier5-audit-cleanup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-25

--- a/openspec/changes/tier5-audit-cleanup/design.md
+++ b/openspec/changes/tier5-audit-cleanup/design.md
@@ -1,0 +1,124 @@
+## Context
+
+The Tier 1–4 close-out wave (PRs #381–#403) shipped 14 OpenSpec changes between April 24–25, 2026. A retrospective audit (full plan at `~/.claude/plans/look-at-tiers-1-eventual-seahorse.md`) found 12 follow-ups: 3 HIGH-severity items already in flight, plus 9 MEDIUM/LOW items collected here.
+
+This change is intentionally **multi-spec but single-purpose**: each item touches a different existing spec via a small delta, but they all share the audit context and the goal of leaving the post-Tier-4 baseline cleanly closed (no orphaned deferrals, no test gaps, no silent bugs).
+
+A design.md is justified because Phase C contains three decisions where "implement" vs. "de-scope" is non-trivial and the chosen path has downstream consequences. Phase A and B are mechanical; Phase C is the deliberation surface.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Close the audit-identified MED/LOW items in one focused change.
+- Make every Phase C decision explicit (no ambiguous deferrals).
+- Use minimal-surface spec deltas — touch only the requirements the audit flagged.
+- Land tests BEFORE documentation BEFORE code-impacting decisions, so each phase is independently mergeable if scope must shrink.
+- Keep the change archive-ready when execution finishes (zero deferrals at archive time).
+
+**Non-Goals:**
+- New combat features, new unit types, new construction rules.
+- Refactoring outside the audit findings.
+- Coordination with the in-flight HIGH-severity workers (BLK manifest, review-flag, PSR-wiring change). Those are tracked by the `tier4-followups` team independently.
+- Cross-tier MekHQ-feature parity beyond what each item already calls out.
+- Re-verifying the entire Tier 1–4 baseline — this is targeted cleanup, not a full re-audit.
+
+## Decisions
+
+### D1 — Phase ordering: Tests → Docs → Decisions
+
+Rationale: Tests verify existing behavior at zero risk. Documentation is low-risk and unblocks future contributors. Code-impacting decisions go last so an unexpected snag in Phase C doesn't block Phase A/B from merging as a separate PR if needed.
+
+**Alternative considered:** Group items by affected spec (e.g., heat work together, vehicle work together). Rejected because spec-grouping mixes risk levels and would force a single mega-PR; phase-grouping allows graceful scope reduction.
+
+### D2 — Vehicle 9.3 chin turret −1 pivot penalty: IMPLEMENT (not de-scope)
+
+The penalty is small (one extra modifier slot in the to-hit pipeline), MegaMek's `Tank.java` carries the canonical rule, and de-scoping would leave a half-implemented requirement in the archived `vehicle-combat-behavior` spec which is exactly the kind of drift this cleanup wave is supposed to prevent.
+
+**Implementation sketch:** Extend the to-hit modifier accumulator to detect `attacker.unitType === IGroundUnit && weapon.location === ChinTurret && weapon.firedThisTurn === true` and add a `+1 to-hit` (which is the same as `−1 effective skill`, framing depends on existing pipeline convention).
+
+**Alternative considered:** Formal de-scope. Rejected — the requirement was never legitimately out of scope; it just got deferred without a pickup task.
+
+### D3 — `pendingPSRs` turn-boundary clear: ALREADY IMPLEMENTED → ADD REGRESSION TEST ONLY
+
+**Audit correction:** The Tier 1–4 audit flagged `applyPhaseChanged` as the missing clear-point. Direct verification against current main showed the audit picked the wrong function — the live behavior is correctly attached to the `TurnStarted` event handler at `src/utils/gameplay/gameState/phaseManagement.ts::applyTurnStarted` (line 60: `pendingPSRs: []`). This was a deliberate decision in the archived `wire-piloting-skill-rolls` change (task 1.3): "PSRs within a turn are deliberately NOT cleared at phase change — they accumulate and resolve in the End phase." The clear-on-turn-start semantics match TW p.52.
+
+The PSR worker (`psr-queue-wiring`) caught this during pre-authoring verification, before any speculative spec or code was written. The same misreading affected the parallel `wire-interactive-psr-integration` change proposal — that worker correctly halted instead of authoring a no-op change.
+
+**What this change does instead:** A regression test asserting `applyTurnStarted` clears `pendingPSRs` for every unit, since no such test exists today (verified by Grep across `src/**/*.test.ts`). This locks in existing behavior as a refactor guard.
+
+**Alternative considered:** Document-only spec note with no test. Rejected — the implementation works but is currently unprotected by an explicit test, which is a real (if smaller) gap worth closing.
+
+**Alternative considered (original audit's IMPLEMENT path):** Edit `applyPhaseChanged`. Rejected — that would duplicate the existing clear at the wrong layer and contradict the deliberate task-1.3 decision.
+
+### D4 — HeadStructureDamage PSR (archived task 2.3): DE-SCOPE from spec
+
+Canonical TW treats head hits as wound + consciousness check, not stability PSR. The original task 2.3 in `wire-piloting-skill-rolls` conflated two separate mechanics. Pilot-damage and consciousness-roll already live in the damage pipeline (audit confirmed `applyPilotDamage` is wired); only the redundant "stability PSR on head hit" reference needs to come out.
+
+**Implementation sketch:** Edit the archived spec at `archive/2026-04-25-wire-piloting-skill-rolls/specs/piloting-skill-rolls/spec.md` to remove the head-PSR scenario. Add a `## REMOVED Requirements` delta in this change's spec delta with **Reason** and **Migration** lines. Update the historical task entry to `[x] DE-SCOPED — see tier5-audit-cleanup`.
+
+**Alternative considered:** Implement a head-PSR. Rejected — it duplicates pilot-damage and would be a spec invention not present in TechManual.
+
+### D5 — Vehicle Body BAR≥6: EXPLICIT COMMENT (not interim VAL guard)
+
+The Body location only matters for support vehicles (combat vehicles legitimately can't allocate to Body). Adding a `VAL-VEHICLE-BODY-DISALLOWED` rule for combat vehicles would fire on data that's already correctly clamped to 0 — i.e., a no-op rule. The Wave 5 support-vehicle customizer surface owns the real rule.
+
+**Implementation sketch:** Replace the bare `Body: 0` placeholder with a one-line comment block citing the Wave-5 owner change. No spec delta needed (the existing aerospace-construction spec already DEFERRED this).
+
+**Alternative considered:** Interim VAL guard. Rejected — would add a no-op rule and complicate the validation registry without behavioral change.
+
+### D6 — KIA-via-outcome JSDoc: WARNING ONLY (no spec delta required)
+
+The `combat-resolution` spec correctly marks the KIA path as DEFERRED in the archived `add-combat-outcome-model` change. The audit gap is purely a consumer-awareness issue. A JSDoc on the `pilotState` field in `ICombatOutcome` is sufficient.
+
+**Implementation sketch:** Add `@remarks` block on the `pilotState` field documenting that `'KIA'` is reachable only when Wave-5 pilot-event wiring lands. Cite `src/lib/combat/outcome/combatOutcome.ts:128-133` and the related Wave-5 change name.
+
+**Alternative considered:** Add a `MODIFIED Requirements` delta to `combat-resolution` documenting the same. Rejected — the spec already says it; over-specifying would mean future Wave-5 work has to MODIFY again to remove the warning.
+
+### D7 — Aerospace decisions.md backfill: WRITE-THROUGH to archive directory
+
+The aerospace change is already archived at `archive/2026-04-25-add-aerospace-construction/`. Backfilling `notepad/decisions.md` there is unusual (archive directories are typically frozen) but is the only way to preserve accountability for the PR #388 retroactive spec additions. The audit found NO notepad entry exists for this change at all (unique among Tier 2).
+
+**Implementation sketch:** Write the new file directly to the archive path. Add a comment at the top: "Backfilled by `tier5-audit-cleanup` (Tier 1–4 audit follow-up). Original close-out lacked a decisions log." Reference the verifier feedback that triggered the additions.
+
+**Alternative considered:** Write the backfill to a sibling note in this change's directory instead. Rejected — that would orphan the historical context from its real change.
+
+### D8 — TSM+heat-9 test placement
+
+Spec scenario lives in `heat-management-system` (the spec that owns heat-effects rules). Test file co-locates with movement tests since walk-MP computation is a movement concern. **Path: `src/utils/gameplay/movement/__tests__/tsmHeatInteraction.test.ts`** (new file). Justification: TSM is a heat-triggered effect but the assertion is about MP, and movement tests already verify other MP modifiers.
+
+### D9 — Vehicle armor 40/20/20/10/10 assertions: store test, NOT component test
+
+The auto-allocate logic lives in the vehicle store (`useVehicleStore.autoAllocateArmor`). Component test (`VehicleArmorDiagram.test.tsx`) currently checks UI binding only. The ratio is a data-layer concern, so the assertion belongs at the store level (likely an existing test like `useVehicleStore.autoAllocate.test.ts`). Component test stays unchanged.
+
+## Risks / Trade-offs
+
+- **Risk:** Phase C decisions (D2, D3, D4) cause unexpected test failures elsewhere. → **Mitigation:** Each Phase C item is a separate task with its own test-suite gate; if one breaks something we don't expect, that task can be split into its own PR without holding up Phase A/B.
+- **Risk:** Backfilling an archived `notepad/decisions.md` (D7) sets a precedent for editing archived changes. → **Mitigation:** Document this as a one-off audit artifact in the file itself; the broader rule "archives are immutable" still stands.
+- **Risk:** Extending `applyPhaseChanged` (D3) interacts subtly with the in-flight `wire-interactive-psr-integration` change being authored by the parallel worker. → **Mitigation:** Tier 5 lands AFTER the HIGHs merge; coordinate at execution time by re-reading the PSR-wiring change before touching `applyPhaseChanged`.
+- **Trade-off:** Bundling 9 items into one change creates a larger PR. → Acceptable because phase-grouping allows graceful split if reviewer pushback warrants it.
+
+## Migration Plan
+
+1. Land this change AFTER all three Tier 4 HIGH-severity PRs merge to main.
+2. Execute Phase A (tests) first — green CI proves nothing regressed before touching code.
+3. Execute Phase B (docs) next — atomic doc commits.
+4. Execute Phase C (decisions) last, one task per PR-internal commit so each can be reverted independently if needed.
+5. After all phases: re-run `npx openspec validate tier5-audit-cleanup --strict`, archive the change with `npx openspec archive tier5-audit-cleanup`.
+
+No rollback strategy needed beyond standard `git revert` per commit — none of these items touches data persistence or external integrations.
+
+## Open Questions
+
+- (resolved by D2) Should chin turret penalty land or de-scope? → Land.
+- (resolved by D3) Should `pendingPSRs` clear at turn boundary? → **Already implemented** in `applyTurnStarted` per archived `wire-piloting-skill-rolls` task 1.3. Add regression test only.
+- (resolved by D4) Implement head-PSR or de-scope? → De-scope.
+- Should the historical `archive/2026-04-25-wire-piloting-skill-rolls/tasks.md` be edited to mark task 2.3 `[x] DE-SCOPED`, or do we leave the archive frozen and rely on this change's REMOVED Requirements delta as the audit trail? → **Open** — proposal: edit the archived tasks.md with a backreference (consistent with D7 precedent), but flag for review during execution.
+
+## Audit Corrections (lessons learned mid-authoring)
+
+The Tier 1–4 audit (plan at `~/.claude/plans/look-at-tiers-1-eventual-seahorse.md`) contained two false positives that were caught during pre-authoring verification of this change and the parallel `wire-interactive-psr-integration` work:
+
+1. **PSR queue interactive-combat integration** — flagged as HIGH-severity missing wiring. Direct verification showed `GameEngine.phases.ts:384/391/417`, `InteractiveSession.ts:327/342/361-363` all carry the integration with explicit `wire-piloting-skill-rolls` task citations in comments. The audit conflated the archived `notepad/learnings.md` "key integration gaps" snapshot (which was the gap-discovery moment that the change was AUTHORED to close) with current state. → Killed the speculative `wire-interactive-psr-integration` change before any artifacts were written.
+2. **`pendingPSRs` turn-boundary clear** — flagged as missing in `applyPhaseChanged`. Direct verification showed the clear lives in `applyTurnStarted:60` (correct per the archived change's deliberate task-1.3 decision). → Demoted from D3 IMPLEMENT to D3 REGRESSION-TEST-ONLY (above).
+
+Process takeaway: when an audit cites `notepad/learnings.md` as evidence of an unresolved gap, the auditor MUST cross-check `tasks.md` for the same items being marked `[x]` complete. The notepad is a snapshot of discovery; the tasks file is the authoritative state-as-of-archive.

--- a/openspec/changes/tier5-audit-cleanup/proposal.md
+++ b/openspec/changes/tier5-audit-cleanup/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+The Tier 1–4 close-out audit (April 2026, plan at `~/.claude/plans/look-at-tiers-1-eventual-seahorse.md`) identified 12 follow-up items across 4 archived OpenSpec waves. Three HIGH-severity items are already in flight via parallel worktrees (BLK manifest `bv: null` fix, post-battle reviewed-flag, and the new `wire-interactive-psr-integration` change). This change bundles the remaining 9 MEDIUM and LOW severity items — test-coverage gaps, documentation backfills, and small spec/code decisions — into a single Tier 5 cleanup wave so they don't drift unnoticed.
+
+## What Changes
+
+Three execution phases, ordered by risk (zero-risk tests first, deliberate decisions last):
+
+### Phase A — Test additions (zero behavioral risk)
+- Add TSM + heat-9 walk-MP combined integration test (closes verifier PARTIAL on archived `wire-heat-generation-and-effects` task 7.2)
+- Add ProtoMech Quad location-remap test (RightArm→FrontLegs and mirror, per `archive/2026-04-24-add-protomech-combat-behavior/notepad/learnings.md`)
+- Add explicit 40/20/20/10/10 ratio assertions to vehicle armor diagram tests (TechManual pp.86-87 distribution; current tests check location *presence* only)
+
+### Phase B — Documentation backfills (low risk, accountability work)
+- Backfill `archive/2026-04-25-add-aerospace-construction/notepad/decisions.md` documenting the PR #388 retroactive spec additions (`VAL-AERO-WING-HEAVY`, `VAL-AERO-BOMB-BAY`)
+- Add JSDoc warning on `ICombatOutcome.pilotState` documenting that `'KIA'` is unreachable in Wave 4 (no engine event flips `pilotConscious=false`)
+- Replace `armor.ts:164` bare `Body: 0` placeholder with explicit policy comment OR add interim `VAL-VEHICLE-BODY-DISALLOWED` rule
+
+### Phase C — Spec/code decisions (require deliberate calls)
+- Resolve vehicle 9.3 chin turret −1 pivot penalty (currently half-implemented): land the penalty OR formally de-scope from `firing-arc-calculation` spec
+- Resolve archived `wire-piloting-skill-rolls` task 2.3 HeadStructureDamage PSR (deferred with thin rationale): implement head-breach pilot damage + consciousness check OR delete from spec
+
+(Originally proposed: `pendingPSRs` turn-boundary clear. Pre-authoring verification showed the clear is already implemented in `applyTurnStarted:60` per archived `wire-piloting-skill-rolls` task 1.3 — see design **D3** Audit Correction. Demoted to a Phase A regression test.)
+
+## Capabilities
+
+### New Capabilities
+
+(none — this is a cleanup wave; all changes are deltas against existing specs)
+
+### Modified Capabilities
+
+- `heat-management-system`: Add explicit TSM + heat-9 walk-MP test scenario closing the verifier PARTIAL on the archived `wire-heat-generation-and-effects` change.
+- `protomech-unit-system`: Add Quad ProtoMech location-remap requirement with test scenario (RightArm→FrontLegs and mirror).
+- `armor-diagram`: Add scenario asserting vehicle auto-allocate distributes armor at the canonical 40/20/20/10/10 ratio (TechManual pp.86-87).
+- `firing-arc-calculation`: Resolve vehicle chin-turret pivot rule — either add SHALL block enforcing the −1 penalty OR remove the deferred-penalty reference if formally de-scoped.
+- `piloting-skill-rolls`: (1) Add `pendingPSRs` turn-boundary clear semantics to the queue lifecycle requirement; (2) Resolve HeadStructureDamage PSR — add SHALL block for head-breach pilot damage + consciousness PSR OR remove the orphaned task reference from the historical spec.
+- `combat-resolution`: Document `ICombatOutcome.pilotState === 'KIA'` Wave-4 unreachability so consumers (post-battle-review, repair-queue, roster processors) plan around it.
+
+## Impact
+
+- **Code touched (Phase A + B):**
+  - `src/utils/gameplay/movement/__tests__/` (new TSM+heat test file)
+  - `src/utils/gameplay/protomech/__tests__/` (new Quad location-remap test file)
+  - `src/components/customizer/vehicle/__tests__/VehicleArmorDiagram.test.tsx` and/or `src/stores/__tests__/useVehicleStore.autoAllocate.test.ts` (ratio assertions)
+  - `src/types/combat/CombatOutcome.ts` (JSDoc on `pilotState`)
+  - `src/utils/construction/vehicle/armor.ts:164` (Body BAR placeholder cleanup)
+
+- **Code touched (Phase C, depends on per-item decision):**
+  - Vehicle chin turret penalty: potentially `src/utils/gameplay/firingArc/` and `src/utils/gameplay/toHit/` (if landing) OR spec-only delta (if de-scoping)
+  - `pendingPSRs` clear: potentially `src/engine/applyPhaseChanged*` (if implementing) OR spec-only policy note (if documenting)
+  - Head-breach PSR: potentially `src/utils/gameplay/psr/` + `src/utils/gameplay/damage/` (if landing) OR spec-only removal (if de-scoping)
+
+- **Documentation:**
+  - `openspec/changes/archive/2026-04-25-add-aerospace-construction/notepad/decisions.md` (new file in archived change directory — write through to archive)
+
+- **Out of scope (handled by parallel `tier4-followups` team workers):**
+  - BLK manifest `bv: null` field
+  - Post-battle review-UI reviewed-flag
+  - Interactive-combat PSR queue integration (`wire-interactive-psr-integration` is a separate authored change)
+
+- **Dependencies:** This change should LAND AFTER the three Tier 4 HIGH-severity PRs merge, so that any spec updates here build on the post-Tier-4 baseline.
+
+## Non-goals
+
+- No new combat features, no new unit types, no new construction rules.
+- No refactoring outside the audit findings — single-purpose cleanup wave.
+- No coordination with the in-flight HIGH-severity workers — those are tracked separately.

--- a/openspec/changes/tier5-audit-cleanup/specs/armor-diagram/spec.md
+++ b/openspec/changes/tier5-audit-cleanup/specs/armor-diagram/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Vehicle Auto-Allocate Canonical Distribution Ratio
+
+The vehicle armor auto-allocate function SHALL distribute total armor points across locations using the canonical TechManual pp.86-87 ratio: 40% Front, 20% Left Side, 20% Right Side, 10% Rear, 10% Turret (or normalized across remaining locations when the vehicle has no turret or has VTOL rotors).
+
+This requirement makes the existing implementation testable. The store function `useVehicleStore.autoAllocateArmor` already applies these ratios; this scenario adds explicit numeric assertions that were absent from the existing component-level tests (which checked location *presence* only).
+
+#### Scenario: 100-point vehicle armor pool distributes 40/20/20/10/10
+
+- **WHEN** `autoAllocateArmor(totalArmorPoints = 100)` runs on a turreted ground vehicle
+- **THEN** the resulting allocation is `{ Front: 40, LeftSide: 20, RightSide: 20, Rear: 10, Turret: 10 }`
+
+#### Scenario: Turretless vehicle redistributes turret share proportionally
+
+- **WHEN** `autoAllocateArmor(totalArmorPoints = 100)` runs on a vehicle with no turret
+- **THEN** the resulting allocation preserves the 40/20/20/10 ratio across `{ Front, LeftSide, RightSide, Rear }`
+- **AND** the turret share is redistributed proportionally (or zeroed) per the implementation's normalization rule
+- **AND** the sum of allocated points equals the input total
+
+#### Scenario: VTOL replaces turret with rotor allocation
+
+- **WHEN** `autoAllocateArmor(totalArmorPoints = 100)` runs on a VTOL
+- **THEN** the rotor location receives the equivalent of the turret share (10% baseline)
+- **AND** the front/side/rear ratios remain `40/20/20/10`

--- a/openspec/changes/tier5-audit-cleanup/specs/combat-resolution/spec.md
+++ b/openspec/changes/tier5-audit-cleanup/specs/combat-resolution/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Combat Outcome Pilot KIA Path Documented As Wave-5 Gated
+
+The `ICombatOutcome.pilotState` field documentation (TypeScript JSDoc on the type definition in `src/types/combat/CombatOutcome.ts`) SHALL include a remarks block stating that the `'KIA'` value is unreachable in Wave 4 because no engine event flips `pilotConscious=false`, and pointing consumers to the Wave-5 pilot-event wiring change as the unblock dependency.
+
+This requirement is documentation-only (no spec scenario test); it ensures downstream consumers (post-battle-review-ui, repair-queue-integration, roster processors) plan around the limitation rather than discovering it in production.
+
+This requirement closes a Tier 4 audit finding on the keystone `ICombatOutcome` interface introduced by archived `add-combat-outcome-model`.
+
+#### Scenario: ICombatOutcome JSDoc surfaces KIA limitation
+
+- **WHEN** a contributor reads the `ICombatOutcome.pilotState` field in `src/types/combat/CombatOutcome.ts`
+- **THEN** the JSDoc `@remarks` block states that `'KIA'` is currently unreachable
+- **AND** the remarks cite `src/lib/combat/outcome/combatOutcome.ts:128-133` as the derivation site
+- **AND** the remarks reference the Wave-5 pilot-event wiring change name (or the `wire-interactive-psr-integration` change if pilot consciousness events are folded into that work) as the unblock dependency

--- a/openspec/changes/tier5-audit-cleanup/specs/firing-arc-calculation/spec.md
+++ b/openspec/changes/tier5-audit-cleanup/specs/firing-arc-calculation/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Vehicle Chin Turret Pivot Penalty
+
+When a ground vehicle fires a weapon mounted in a chin turret, and the turret has pivoted from its previous facing during the same turn, the to-hit calculation SHALL apply a +1 to-hit modifier (equivalent to a −1 effective gunnery skill) to that weapon attack.
+
+This requirement closes a half-implemented item from archived `add-vehicle-combat-behavior` task 9.3. The 360° chin-turret arc shipped in that change; the pivot-penalty modifier was deferred without a pickup task. Per the Tier 5 audit, the penalty is small in scope and the rule is canonical (mirrors MegaMek `Tank.java` chin-turret handling), so it is being landed rather than de-scoped.
+
+#### Scenario: Chin-turret weapon fires after pivoting in same turn
+
+- **WHEN** a ground vehicle's chin turret pivoted from facing N to facing N+1 during the current turn
+- **AND** a weapon mounted in that chin turret fires at a target within the (now-current) firing arc
+- **THEN** the to-hit calculation includes a `+1` modifier with attribution `chin-turret-pivot`
+- **AND** the resulting modified to-hit number reflects the penalty in the modifier breakdown
+
+#### Scenario: Chin-turret weapon fires without pivoting
+
+- **WHEN** a ground vehicle's chin turret has not pivoted during the current turn
+- **AND** a weapon mounted in that chin turret fires at a target within the firing arc
+- **THEN** the to-hit calculation does NOT include the chin-turret-pivot modifier
+
+#### Scenario: Non-chin-turret weapon unaffected by chin-turret pivot
+
+- **WHEN** a ground vehicle's chin turret pivoted during the current turn
+- **AND** a weapon mounted in a body or sponson location fires
+- **THEN** the to-hit calculation for the body/sponson weapon does NOT include the chin-turret-pivot modifier

--- a/openspec/changes/tier5-audit-cleanup/specs/heat-management-system/spec.md
+++ b/openspec/changes/tier5-audit-cleanup/specs/heat-management-system/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: TSM Walk-MP Combined With Heat Penalty
+
+The system SHALL preserve canonical Total Warfare walk-MP arithmetic when Triple Strength Myomer (TSM) is active and the unit is at or above heat 9. The TSM bonus (+2 walk MP) and the heat-based movement penalty (−1 walk MP at heat 5+, −2 at heat 7+, etc.) SHALL be combined additively against the unit's base walk MP.
+
+This requirement closes the verifier PARTIAL on archived `wire-heat-generation-and-effects` task 7.2.
+
+#### Scenario: TSM-active mech at heat 9 walks base + 2 − heat penalty
+
+- **WHEN** a BattleMech with TSM equipment installed has current heat = 9 (TSM activation threshold)
+- **AND** the mech's base walk MP is 4
+- **THEN** `getEffectiveWalkMP(unit)` returns `4 + 2 (TSM bonus) − 1 (heat 5+ penalty) = 5`
+- **AND** the run MP derived from walk MP reflects the same composition
+
+#### Scenario: TSM-active mech at heat 0 receives only TSM bonus
+
+- **WHEN** a BattleMech with TSM equipment installed has current heat = 0 (TSM dormant)
+- **THEN** `getEffectiveWalkMP(unit)` returns base walk MP unchanged (TSM bonus does not apply below heat 9)
+
+#### Scenario: Non-TSM mech at heat 9 receives only heat penalty
+
+- **WHEN** a BattleMech without TSM has current heat = 9
+- **AND** base walk MP is 4
+- **THEN** `getEffectiveWalkMP(unit)` returns `4 − 2 (heat 7+ penalty) = 2`

--- a/openspec/changes/tier5-audit-cleanup/specs/piloting-skill-rolls/spec.md
+++ b/openspec/changes/tier5-audit-cleanup/specs/piloting-skill-rolls/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Pending PSR Queue Cleared At Turn Boundary (Regression Protection)
+
+The `pendingPSRs` queue SHALL be cleared when the game state transitions from the End phase of one turn into the first phase of the next turn. PSRs that have not been resolved by the end of their turn of origin do NOT carry over into subsequent turns.
+
+This behavior is **already implemented** in `src/utils/gameplay/gameState/phaseManagement.ts::applyTurnStarted` (lines 45-72; clear at line 60), citing `wire-piloting-skill-rolls` task 1.3 and TW p.52. The original audit incorrectly flagged `applyPhaseChanged` as the implementation site — the live behavior is correctly attached to `TurnStarted` events, NOT phase transitions (per the archived change's deliberate task-1.3 decision: "PSRs within a turn are deliberately NOT cleared at phase change — they accumulate and resolve in the End phase").
+
+This requirement is therefore **regression-protection-only**: it adds an explicit test scenario that locks in the existing `applyTurnStarted` clear behavior so a future refactor cannot silently drop it. No production code change is required.
+
+#### Scenario: applyTurnStarted clears pending PSRs at turn-N+1 start
+
+- **WHEN** a unit's `pendingPSRs` array contains one or more entries at the moment a `TurnStarted` event arrives for turn N+1
+- **AND** `applyTurnStarted(state, event)` runs against that state
+- **THEN** every unit in the resulting state has `pendingPSRs: []`
+- **AND** the unit's other per-turn flags (`weaponsFiredThisTurn`) are also reset
+
+#### Scenario: applyPhaseChanged within a turn does NOT clear pending PSRs
+
+- **WHEN** a PSR is queued during the Weapon Attack phase of turn N
+- **AND** the phase transitions from Weapon Attack to Physical Attack within the same turn (via `applyPhaseChanged`)
+- **THEN** `state.pendingPSRs` retains the queued PSR (intended for resolution at turn N's End phase per archived `wire-piloting-skill-rolls` task 1.3 decision)
+
+## REMOVED Requirements
+
+### Requirement: HeadStructureDamage PSR
+
+**Reason:** Canonical Total Warfare treats head hits as a wound + consciousness check (handled by the damage pipeline via `applyPilotDamage` and the consciousness-roll system), not as a stability PSR. The original task in archived `wire-piloting-skill-rolls` (task 2.3) conflated two separate mechanics. The pilot-damage and consciousness-roll paths are already wired; the redundant "stability PSR on head hit" reference is being removed to prevent future contributors from re-implementing a mechanic that does not exist in TW.
+
+**Migration:** Consumers requiring head-breach pilot effects SHALL use `applyPilotDamage` (cluster damage when head front + rear armor is breached) and the existing pilot consciousness-roll path. No replacement PSR factory or queue entry is required. The `archive/2026-04-25-wire-piloting-skill-rolls/tasks.md` task 2.3 SHALL be annotated `[x] DE-SCOPED — see tier5-audit-cleanup` for audit-trail integrity.

--- a/openspec/changes/tier5-audit-cleanup/specs/protomech-unit-system/spec.md
+++ b/openspec/changes/tier5-audit-cleanup/specs/protomech-unit-system/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Quad ProtoMech Hit-Location Remapping
+
+The system SHALL remap arm hit-location rolls on Quad ProtoMechs (chassis configuration with four legs and no arms) to leg locations: rolls that would resolve to `RightArm` resolve to `FrontLegs`, and rolls that would resolve to `LeftArm` resolve to `RearLegs` (or the equivalent quad-leg locations defined in the protomech location enum).
+
+This requirement makes explicit a remapping noted in archived `wire-piloting-skill-rolls` and `add-protomech-combat-behavior` learnings but never covered by an end-to-end test.
+
+#### Scenario: Quad ProtoMech right-arm roll resolves to front-legs
+
+- **WHEN** a hit-location roll on a Quad ProtoMech yields a value that maps to `RightArm` on a biped ProtoMech
+- **THEN** the resolver returns `FrontLegs` (or the canonical quad-leg-front location)
+- **AND** damage applies to the front-leg armor/structure pool
+
+#### Scenario: Quad ProtoMech left-arm roll resolves to rear-legs
+
+- **WHEN** a hit-location roll on a Quad ProtoMech yields a value that maps to `LeftArm` on a biped ProtoMech
+- **THEN** the resolver returns `RearLegs` (or the canonical quad-leg-rear location)
+- **AND** damage applies to the rear-leg armor/structure pool
+
+#### Scenario: Biped ProtoMech location resolution unchanged
+
+- **WHEN** a hit-location roll on a biped ProtoMech resolves to `RightArm` or `LeftArm`
+- **THEN** the resolver returns the same arm location with no remapping

--- a/openspec/changes/tier5-audit-cleanup/tasks.md
+++ b/openspec/changes/tier5-audit-cleanup/tasks.md
@@ -1,0 +1,76 @@
+# Tasks — tier5-audit-cleanup
+
+Tasks are grouped into three phases following design decision **D1**: Tests → Docs → Decisions. Each phase is independently shippable; if Phase C is blocked at execution, Phase A + B can ship as a stand-alone PR.
+
+Implementation should land AFTER all three Tier 4 HIGH-severity PRs merge (BLK manifest `bv: null`, post-battle reviewed-flag, `wire-interactive-psr-integration`).
+
+---
+
+## 1. Phase A — Test additions (zero behavioral risk)
+
+- [ ] 1.1 Add TSM + heat-9 walk-MP combined integration test at `src/utils/gameplay/movement/__tests__/tsmHeatInteraction.test.ts` (per design **D8**). Cover the three scenarios in `specs/heat-management-system/spec.md::Requirement: TSM Walk-MP Combined With Heat Penalty`: TSM-active at heat 9, TSM-active at heat 0 (dormant), and non-TSM at heat 9. Use existing `getEffectiveWalkMP` (Grep for the function — likely in `src/utils/gameplay/movement/modifiers.ts`).
+- [ ] 1.2 Add Quad ProtoMech location-remap test at `src/utils/gameplay/protomech/__tests__/quadLocationMapping.test.ts`. Cover the three scenarios in `specs/protomech-unit-system/spec.md::Requirement: Quad ProtoMech Hit-Location Remapping`: RightArm→FrontLegs, LeftArm→RearLegs, biped unchanged. Use the existing protomech location resolver (Grep for `resolveProtomechLocation` or similar in `src/utils/gameplay/protomech/`).
+- [ ] 1.3 Add 40/20/20/10/10 ratio assertions to the vehicle-store auto-allocate test (per design **D9**). Locate `src/stores/__tests__/useVehicleStore.autoAllocate.test.ts` (or whichever existing test owns `autoAllocateArmor`). Add the three scenarios from `specs/armor-diagram/spec.md::Requirement: Vehicle Auto-Allocate Canonical Distribution Ratio`: turreted 40/20/20/10/10, turretless redistribution, VTOL rotor substitution.
+- [ ] 1.4 Add `applyTurnStarted` PSR-clear regression test (per design **D3** correction). Add `src/utils/gameplay/gameState/__tests__/phaseManagement.turnStarted.test.ts` (or extend an existing phaseManagement test if one exists). Cover the two scenarios in `specs/piloting-skill-rolls/spec.md::Requirement: Pending PSR Queue Cleared At Turn Boundary (Regression Protection)`: (a) `applyTurnStarted` clears every unit's `pendingPSRs` array; (b) `applyPhaseChanged` (within the same turn) does NOT clear `pendingPSRs`. Cite `phaseManagement.ts:60` as the implementation site under test.
+- [ ] 1.5 Run `npx jest --testPathPattern="tsmHeatInteraction|quadLocationMapping|useVehicleStore.autoAllocate|phaseManagement.turnStarted"` — all new tests pass; no regressions in adjacent suites.
+- [ ] 1.6 Commit Phase A as a single conventional-commits commit: `test(audit): add TSM+heat-9, quad-protomech, vehicle-armor-ratio, applyTurnStarted-PSR-clear coverage`.
+
+---
+
+## 2. Phase B — Documentation backfills (low risk, accountability work)
+
+- [ ] 2.1 Backfill `openspec/changes/archive/2026-04-25-add-aerospace-construction/notepad/decisions.md` (per design **D7**) — file does not currently exist. Open with the line: "Backfilled by `tier5-audit-cleanup` (Tier 1–4 audit follow-up). Original close-out lacked a decisions log." Document the PR #388 retroactive spec additions (`VAL-AERO-WING-HEAVY` and `VAL-AERO-BOMB-BAY`) — what triggered them (verifier feedback), what was fixed, file:line refs to the new SHALL blocks in `specs/aerospace-unit-system/spec.md`.
+- [ ] 2.2 Add JSDoc `@remarks` block to `src/types/combat/CombatOutcome.ts` `ICombatOutcome.pilotState` field (per design **D6** + spec `combat-resolution`). Cite `src/lib/combat/outcome/combatOutcome.ts:128-133` as the derivation site and reference the Wave-5 pilot-event wiring change (or `wire-interactive-psr-integration` if pilot consciousness events are folded there) as the unblock dependency. Verify the JSDoc renders cleanly: `npx tsc --noEmit --skipLibCheck`.
+- [ ] 2.3 Replace the bare `Body: 0` placeholder at `src/utils/construction/vehicle/armor.ts:164` with an explicit code-comment block (per design **D5**) — one-line comment citing the Wave 5 owner change (the support-vehicle customizer surface). No spec delta needed; the existing `aerospace-construction` spec already DEFERRED this.
+- [ ] 2.4 Run `npx tsc --noEmit --skipLibCheck` and `npx oxlint <touched files>` — clean.
+- [ ] 2.5 Commit Phase B: `docs(audit): backfill aerospace decisions, KIA JSDoc warning, body-armor placeholder cleanup`.
+
+---
+
+## 3. Phase C — Spec/code decisions (deliberate calls)
+
+### 3.A — Vehicle 9.3 chin turret −1 pivot penalty: IMPLEMENT (per design **D2**)
+
+- [ ] 3.A.1 Locate the vehicle to-hit modifier accumulator. Grep for `chinTurret` and existing vehicle-specific to-hit modifiers (likely in `src/utils/gameplay/toHit/` or `src/utils/gameplay/firingArc/`).
+- [ ] 3.A.2 Detect chin-turret pivot during the current turn. Grep for an existing turret-facing tracker on `IVehicleUnit` or its game-state companion. If absent, add a `turretPivotedThisTurn: boolean` flag and clear it at end-of-turn alongside other per-turn flags.
+- [ ] 3.A.3 Add `+1 to-hit` modifier with attribution `chin-turret-pivot` when `weapon.location === ChinTurret && unit.turretPivotedThisTurn`. Do NOT apply to body- or sponson-mounted weapons.
+- [ ] 3.A.4 Add three Jest tests covering the scenarios in `specs/firing-arc-calculation/spec.md::Requirement: Vehicle Chin Turret Pivot Penalty` (pivot+chin+penalty applies, no-pivot=no-penalty, body-weapon unaffected).
+- [ ] 3.A.5 Run `npx jest --testPathPattern="toHit|firingArc|chinTurret"` — green.
+- [ ] 3.A.6 Commit: `feat(combat): apply -1 to-hit penalty for vehicle chin-turret pivot`.
+
+### 3.B — ~~`pendingPSRs` turn-boundary clear~~ — REMOVED FROM PHASE C
+
+**Status:** Originally proposed as IMPLEMENT in `applyPhaseChanged`. Pre-authoring verification revealed the clear is already implemented in `applyTurnStarted:60` per archived `wire-piloting-skill-rolls` task 1.3 (deliberate decision to attach to `TurnStarted` events rather than phase transitions). The audit picked the wrong function. See design **D3** "Audit correction".
+
+The regression test is now task **1.4** in Phase A. No production code change is needed.
+
+### 3.C — HeadStructureDamage PSR: DE-SCOPE from spec (per design **D4**)
+
+- [ ] 3.C.1 Edit `openspec/changes/archive/2026-04-25-wire-piloting-skill-rolls/specs/piloting-skill-rolls/spec.md` — remove the head-PSR scenario/requirement (whichever block originally encoded the deferred head-PSR concept).
+- [ ] 3.C.2 Edit `openspec/changes/archive/2026-04-25-wire-piloting-skill-rolls/tasks.md` — flip task 2.3 from `[x] DEFERRED — pickup: <ref>` to `[x] DE-SCOPED — see tier5-audit-cleanup`. Acknowledge the design **D7** precedent that we are intentionally editing an archived change for audit-trail integrity (one-off, not a new norm).
+- [ ] 3.C.3 Verify no production code currently emits head-PSR factories or queue entries (Grep `head_psr`, `HeadStructureDamage`, `headPsr` across `src/`). If found, delete it.
+- [ ] 3.C.4 Confirm the `applyPilotDamage` + consciousness-roll path is intact (Grep for `applyPilotDamage` — should already be wired per audit). No code change needed if intact.
+- [ ] 3.C.5 Commit: `chore(spec): de-scope head-PSR from piloting-skill-rolls (Tier 5 cleanup, design D4)`.
+
+### 3.D — Phase C verification
+
+- [ ] 3.D.1 Run full Jest sweep on touched paths: `npx jest --testPathPattern="movement|protomech|vehicle|toHit|firingArc|psr|phase|engine"` — green.
+- [ ] 3.D.2 Run `npx tsc --noEmit --skipLibCheck` — clean.
+- [ ] 3.D.3 Run `npx oxlint` on all touched files — 0 errors.
+- [ ] 3.D.4 Run `npx oxfmt --write` on all touched files; verify `npx oxfmt --check` passes.
+
+---
+
+## 4. Spec validation + change archive prep
+
+- [ ] 4.1 Run `npx openspec validate tier5-audit-cleanup --strict` — must pass with no errors.
+- [ ] 4.2 Verify each spec delta in `specs/` references a real existing capability under `openspec/specs/` (heat-management-system, protomech-unit-system, armor-diagram, firing-arc-calculation, piloting-skill-rolls, combat-resolution — all confirmed present).
+- [ ] 4.3 Re-confirm every task above is `[x]` checked. If any `[ ]` remains at archive time, it MUST be either resolved or explicitly DE-SCOPED with rationale (no `DEFERRED` markers in this cleanup wave — this is the last-mile change).
+
+---
+
+## 5. PR + archive
+
+- [ ] 5.1 Push branch `spec/tier5-audit-cleanup` and open PR via `gh pr create`. Title: `chore(openspec): tier5-audit-cleanup — Tier 1–4 audit follow-ups (MED + LOW severity)`. Body should call out the three phases, link the audit plan, and note the change MUST land after the three Tier 4 HIGH PRs merge.
+- [ ] 5.2 After PR merges to main, run `npx openspec archive tier5-audit-cleanup` — this moves the change to `openspec/changes/archive/<YYYY-MM-DD>-tier5-audit-cleanup/` and merges deltas into source-of-truth specs.
+- [ ] 5.3 Post-archive sanity check: `npx openspec validate --strict` (whole repo) — clean.


### PR DESCRIPTION
## Summary

Authors a new OpenSpec change `tier5-audit-cleanup` that bundles 9 MEDIUM/LOW severity follow-ups from the Tier 1–4 close-out audit. The 3 HIGH-severity items are tracked separately:
- BLK manifest `bv: null` — PR #405
- Post-battle reviewed-flag — PR #406
- Interactive PSR queue wiring — DROPPED as false positive (verified already shipped)

This PR is **authoring only** — no production code changes. Branch was hard-reset from a stale baseline that bundled pre-archive Tier 5 history; the diff now reflects only the actual 10-file authoring delta. Phase A/B/C task execution happens in a follow-up apply-PR.

## Phases

- **A — Tests** (zero behavioral risk): TSM+heat-9 walk-MP, Quad ProtoMech location-remap, vehicle armor 40/20/20/10/10 ratio assertions, `pendingPSRs` turn-boundary clear regression
- **B — Docs** (low risk): aerospace `notepad/decisions.md` backfill, `ICombatOutcome.pilotState` KIA JSDoc warning, vehicle Body BAR placeholder cleanup
- **C — Decisions**: chin turret −1 pivot penalty (IMPLEMENT), head-PSR (DE-SCOPE)

## Spec deltas (6 capabilities)

- `heat-management-system` — TSM walk-MP combined-with-heat scenario
- `protomech-unit-system` — Quad hit-location remap
- `armor-diagram` — vehicle 40/20/20/10/10 distribution scenario
- `firing-arc-calculation` — chin turret pivot penalty
- `piloting-skill-rolls` — pendingPSRs turn-boundary clear (regression test) + head-PSR (REMOVED)
- `combat-resolution` — KIA-via-outcome JSDoc warning requirement

## Validation

- `npx openspec validate tier5-audit-cleanup --strict` — passes
- 4/4 artifacts complete: proposal, design, tasks, specs

## Test plan

- [ ] Reviewer reads `proposal.md` for the why
- [ ] Reviewer reads `design.md` for the 9 deliberate decisions (D1–D9)
- [ ] Reviewer skims `tasks.md` for the Phase A/B/C ordering
- [ ] Reviewer confirms each `specs/*/spec.md` delta references an existing capability under `openspec/specs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)