### PR TITLE
feat(audit): close 5 integration gaps from Tier 5 audit-cleanup

### DIFF
--- a/src/components/customizer/tabs/StructureTabMovementSection.tsx
+++ b/src/components/customizer/tabs/StructureTabMovementSection.tsx
@@ -7,6 +7,10 @@ import {
   JumpJetType,
   JUMP_JET_DEFINITIONS,
 } from '@/utils/construction/movementCalculations';
+import {
+  calculateRunMP,
+  getEffectiveWalkMP,
+} from '@/utils/gameplay/movement/calculations';
 
 import type {
   StructureConfigurationOption,
@@ -65,6 +69,16 @@ export function StructureTabMovementSection({
   handleEnhancementChange,
   handleConfigurationChange,
 }: StructureTabMovementSectionProps): React.ReactElement {
+  // Compute the canonical TSM-active walk / run preview for the tooltip.
+  // `getEffectiveWalkMP` is the single source of truth for the combined
+  // TSM bonus + heat-induced movement penalty (per the heat-management
+  // spec's "TSM Walk-MP Combined With Heat Penalty" requirement). Sample
+  // at heat 9 — the TSM activation threshold — so the tooltip surfaces
+  // the canonical "TSM active" walk MP rather than embedding the
+  // arithmetic inline.
+  const tsmEffectiveWalkMP = getEffectiveWalkMP(walkMP, 9, true);
+  const tsmEffectiveRunMP = calculateRunMP(tsmEffectiveWalkMP);
+
   return (
     <div className={cs.panel.main}>
       <h3 className={cs.text.sectionTitle}>Movement</h3>
@@ -134,7 +148,7 @@ export function StructureTabMovementSection({
                   enhancement === MovementEnhancementType.MASC
                     ? `MASC Sprint: Walk ${walkMP} × 2 = ${maxRunMP}`
                     : enhancement === MovementEnhancementType.TSM
-                      ? `TSM at 9+ heat: Base Run ${runMP} + 1 = ${maxRunMP} (net +1 from +2 Walk, -1 heat penalty)`
+                      ? `TSM at 9+ heat: effective Walk ${tsmEffectiveWalkMP} (base ${walkMP} + 2 TSM − 1 heat), Run ${tsmEffectiveRunMP}`
                       : enhancement === MovementEnhancementType.SUPERCHARGER
                         ? `Supercharger Sprint: Walk ${walkMP} × 2 = ${maxRunMP}`
                         : `Enhanced max: ${maxRunMP}`

--- a/src/types/combat/CombatOutcome.ts
+++ b/src/types/combat/CombatOutcome.ts
@@ -123,7 +123,7 @@ export interface IUnitCombatDelta {
    * `@remarks` block should be removed and the KIA path documented as
    * fully reachable.
    *
-   * @see openspec/changes/tier5-audit-cleanup/specs/combat-resolution/spec.md
+   * @see openspec/changes/archive/2026-04-25-tier5-audit-cleanup/specs/combat-resolution/spec.md
    */
   readonly pilotState: {
     readonly conscious: boolean;

--- a/src/types/gameplay/CombatInterfaces.ts
+++ b/src/types/gameplay/CombatInterfaces.ts
@@ -7,8 +7,10 @@
 
 // Re-export from construction for backwards compatibility
 import { MechLocation } from '../construction/CriticalSlotAllocation';
+import { VehicleLocation, VTOLLocation } from '../construction/UnitLocation';
 // Re-export from equipment for backwards compatibility
 import { WeaponCategory } from '../equipment/weapons/interfaces';
+import { TurretType } from '../unit/VehicleInterfaces';
 import { IToHitModifier } from './GameSessionInterfaces';
 import { FiringArc, RangeBracket, MovementType } from './HexGridInterfaces';
 
@@ -600,6 +602,18 @@ export interface IAttackerState {
   readonly designatedRangeBracket?: RangeBracket;
   readonly unitQuirks?: readonly string[];
   readonly weaponQuirks?: Readonly<Record<string, readonly string[]>>;
+  /**
+   * Vehicle-only context fields. Populated when the attacker is a ground or
+   * VTOL combat vehicle so the to-hit pipeline can apply vehicle-scoped
+   * modifiers (e.g. chin-turret pivot penalty). Mech / aerospace / battle
+   * armor callers leave these undefined and incur no vehicle penalty paths.
+   *
+   * @see calculateChinTurretPivotModifier (utils/gameplay/toHit/vehicleModifiers.ts)
+   */
+  readonly vehicleTurretType?: TurretType;
+  readonly vehicleTurretPivotedThisTurn?: boolean;
+  readonly vehicleWeaponMountLocation?: VehicleLocation | VTOLLocation;
+  readonly vehicleWeaponIsTurretMounted?: boolean;
 }
 
 /**

--- a/src/utils/gameplay/__tests__/pilotingSkillRolls.test.ts
+++ b/src/utils/gameplay/__tests__/pilotingSkillRolls.test.ts
@@ -21,6 +21,7 @@ import {
   createLegDamagePSR,
   createHipActuatorPSR,
   createGyroPSR,
+  createEngineHitPSR,
   createUpperLegActuatorPSR,
   createLowerLegActuatorPSR,
   createFootActuatorPSR,
@@ -312,7 +313,7 @@ describe('Piloting Skill Rolls', () => {
     });
   });
 
-  describe('PSR Trigger Generators — all 26 triggers', () => {
+  describe('PSR Trigger Generators — all 27 triggers', () => {
     const triggerTests: Array<{
       fn: (id: string) => IPendingPSR;
       expectedSource: PSRTrigger;
@@ -334,6 +335,11 @@ describe('Piloting Skill Rolls', () => {
         expectedMod: 0,
       },
       { fn: createGyroPSR, expectedSource: PSRTrigger.GyroHit, expectedMod: 0 },
+      {
+        fn: createEngineHitPSR,
+        expectedSource: PSRTrigger.EngineHit,
+        expectedMod: 0,
+      },
       {
         fn: createUpperLegActuatorPSR,
         expectedSource: PSRTrigger.UpperLegActuatorHit,
@@ -462,8 +468,8 @@ describe('Piloting Skill Rolls', () => {
       },
     );
 
-    it('should have exactly 27 trigger types (26 + standing up)', () => {
-      expect(triggerTests).toHaveLength(27);
+    it('should have exactly 28 trigger types (27 catalog entries + standing up)', () => {
+      expect(triggerTests).toHaveLength(28);
     });
   });
 

--- a/src/utils/gameplay/__tests__/vehicleTurretLifecycle.test.ts
+++ b/src/utils/gameplay/__tests__/vehicleTurretLifecycle.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for the vehicle turret-pivot lifecycle helpers.
+ *
+ * Locks in the SET / CLEAR semantics for `turretPivotedThisTurn` on
+ * `IVehicleCombatState`. The flag drives the +1 chin-turret pivot to-hit
+ * penalty (see `calculateChinTurretPivotModifier`), and the spec
+ * requires it to be cleared at the start of each turn.
+ *
+ * @spec openspec/specs/firing-arc-calculation/spec.md
+ *   Requirement: Vehicle Chin Turret Pivot Penalty
+ */
+
+import { describe, expect, it } from '@jest/globals';
+
+import type { IVehicleCombatState } from '@/types/gameplay';
+
+import { GroundMotionType } from '@/types/unit/BaseUnitInterfaces';
+
+import {
+  clearAllTurretPivotedFlags,
+  clearTurretPivotedFlag,
+  markTurretPivoted,
+} from '../vehicleTurretLifecycle';
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+function makeVehicleState(
+  overrides: Partial<IVehicleCombatState> = {},
+): IVehicleCombatState {
+  return {
+    unitId: 'tank-1',
+    motionType: GroundMotionType.TRACKED,
+    armor: {},
+    structure: {},
+    destroyedLocations: [],
+    motive: {
+      originalCruiseMP: 4,
+      penaltyMP: 0,
+      immobilized: false,
+      sinking: false,
+      turretLocked: false,
+      engineHits: 0,
+      driverHits: 0,
+      commanderHits: 0,
+      crewStunnedPhases: 0,
+    },
+    turretLock: { primaryLocked: false, secondaryLocked: false },
+    destroyed: false,
+    ...overrides,
+  };
+}
+
+describe('markTurretPivoted', () => {
+  it('sets turretPivotedThisTurn = true on a state without the flag', () => {
+    const state = makeVehicleState();
+    expect(state.turretPivotedThisTurn).toBeUndefined();
+
+    const result = markTurretPivoted(state);
+
+    expect(result.turretPivotedThisTurn).toBe(true);
+    // New object identity (immutable update).
+    expect(result).not.toBe(state);
+  });
+
+  it('sets the flag when previously explicitly false', () => {
+    const state = makeVehicleState({ turretPivotedThisTurn: false });
+
+    const result = markTurretPivoted(state);
+
+    expect(result.turretPivotedThisTurn).toBe(true);
+    expect(result).not.toBe(state);
+  });
+
+  it('is idempotent — returns the same reference when already pivoted', () => {
+    const state = makeVehicleState({ turretPivotedThisTurn: true });
+
+    const result = markTurretPivoted(state);
+
+    expect(result).toBe(state); // Same reference, no-op.
+    expect(result.turretPivotedThisTurn).toBe(true);
+  });
+});
+
+describe('clearTurretPivotedFlag', () => {
+  it('clears the flag when set', () => {
+    const state = makeVehicleState({ turretPivotedThisTurn: true });
+
+    const result = clearTurretPivotedFlag(state);
+
+    expect(result.turretPivotedThisTurn).toBe(false);
+    expect(result).not.toBe(state);
+  });
+
+  it('is idempotent — returns same reference when flag is absent', () => {
+    const state = makeVehicleState();
+
+    const result = clearTurretPivotedFlag(state);
+
+    expect(result).toBe(state);
+    // Flag remains undefined; clearing absence yields absence.
+    expect(result.turretPivotedThisTurn).toBeUndefined();
+  });
+
+  it('is idempotent — returns same reference when flag is explicitly false', () => {
+    const state = makeVehicleState({ turretPivotedThisTurn: false });
+
+    const result = clearTurretPivotedFlag(state);
+
+    expect(result).toBe(state);
+  });
+});
+
+describe('clearAllTurretPivotedFlags', () => {
+  it('clears the flag across a mixed batch of vehicle states', () => {
+    const states: Record<string, IVehicleCombatState> = {
+      'tank-pivoted': makeVehicleState({
+        unitId: 'tank-pivoted',
+        turretPivotedThisTurn: true,
+      }),
+      'tank-static': makeVehicleState({ unitId: 'tank-static' }),
+      'tank-also-pivoted': makeVehicleState({
+        unitId: 'tank-also-pivoted',
+        turretPivotedThisTurn: true,
+      }),
+    };
+
+    const result = clearAllTurretPivotedFlags(states);
+
+    expect(result['tank-pivoted'].turretPivotedThisTurn).toBe(false);
+    expect(result['tank-also-pivoted'].turretPivotedThisTurn).toBe(false);
+    // Untouched state preserves identity.
+    expect(result['tank-static']).toBe(states['tank-static']);
+    // Mutated states get new references.
+    expect(result['tank-pivoted']).not.toBe(states['tank-pivoted']);
+  });
+
+  it('returns the same map reference when no state needed updating', () => {
+    // None of these states have the flag set, so nothing changes — the
+    // helper short-circuits and preserves selector / memo identity.
+    const states: Record<string, IVehicleCombatState> = {
+      'tank-1': makeVehicleState({ unitId: 'tank-1' }),
+      'tank-2': makeVehicleState({
+        unitId: 'tank-2',
+        turretPivotedThisTurn: false,
+      }),
+    };
+
+    const result = clearAllTurretPivotedFlags(states);
+
+    expect(result).toBe(states);
+  });
+
+  it('handles an empty input map without erroring', () => {
+    const states: Record<string, IVehicleCombatState> = {};
+
+    const result = clearAllTurretPivotedFlags(states);
+
+    expect(result).toBe(states);
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+});
+
+describe('SET → CLEAR end-to-end lifecycle', () => {
+  it('marks then clears returns to a flag-clean state', () => {
+    // Models the canonical turn lifecycle: turret rotates mid-turn (SET),
+    // turn ends and TurnStarted handler runs (CLEAR), next turn begins
+    // with the flag back to false.
+    const initial = makeVehicleState();
+
+    const afterPivot = markTurretPivoted(initial);
+    expect(afterPivot.turretPivotedThisTurn).toBe(true);
+
+    const afterTurnStart = clearTurretPivotedFlag(afterPivot);
+    expect(afterTurnStart.turretPivotedThisTurn).toBe(false);
+  });
+});

--- a/src/utils/gameplay/pilotingSkillRolls/damageFactories.ts
+++ b/src/utils/gameplay/pilotingSkillRolls/damageFactories.ts
@@ -56,6 +56,29 @@ export function createGyroPSR(entityId: string): IPendingPSR {
 }
 
 /**
+ * Create a pending PSR for an engine critical hit.
+ *
+ * Per the piloting-skill-rolls spec ("PSR Trigger Catalog") and MegaMek's
+ * canonical engine-crit handling, an engine hit triggers a PSR for the
+ * affected mech. The factory produces the catalog entry; the actual
+ * dispatch from `CriticalEffectType.EngineHit` into the pending PSR queue
+ * is wired by the critical-hit pipeline in a future change. Shipping the
+ * factory here keeps the trigger catalog complete and gives the future
+ * dispatcher a canonical entry point.
+ *
+ * @spec openspec/specs/piloting-skill-rolls/spec.md
+ *   Requirement: PSR Trigger Catalog
+ */
+export function createEngineHitPSR(entityId: string): IPendingPSR {
+  return {
+    entityId,
+    reason: 'Engine hit',
+    additionalModifier: 0,
+    triggerSource: PSRTrigger.EngineHit,
+  };
+}
+
+/**
  * Create a pending PSR for upper leg actuator critical hit.
  */
 export function createUpperLegActuatorPSR(entityId: string): IPendingPSR {

--- a/src/utils/gameplay/pilotingSkillRolls/index.ts
+++ b/src/utils/gameplay/pilotingSkillRolls/index.ts
@@ -19,6 +19,7 @@ export {
   createLegDamagePSR,
   createHipActuatorPSR,
   createGyroPSR,
+  createEngineHitPSR,
   createUpperLegActuatorPSR,
   createLowerLegActuatorPSR,
   createFootActuatorPSR,

--- a/src/utils/gameplay/pilotingSkillRolls/types.ts
+++ b/src/utils/gameplay/pilotingSkillRolls/types.ts
@@ -45,7 +45,9 @@ export interface IPSRBatchResult {
 }
 
 /**
- * PSR trigger types — all 26 canonical trigger sources.
+ * PSR trigger types — all 27 canonical trigger sources, including the
+ * `EngineHit` entry required by the piloting-skill-rolls spec
+ * ("PSR Trigger Catalog") and consistent with MegaMek's engine-crit PSR.
  */
 export enum PSRTrigger {
   // Damage triggers
@@ -55,6 +57,7 @@ export enum PSRTrigger {
   // Component damage triggers
   HipActuatorDestroyed = 'hip_actuator_destroyed',
   GyroHit = 'gyro_hit',
+  EngineHit = 'engine_hit',
   UpperLegActuatorHit = 'upper_leg_actuator_hit',
   LowerLegActuatorHit = 'lower_leg_actuator_hit',
   FootActuatorHit = 'foot_actuator_hit',

--- a/src/utils/gameplay/toHit/__tests__/calculateChinTurretIntegration.test.ts
+++ b/src/utils/gameplay/toHit/__tests__/calculateChinTurretIntegration.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Integration tests for `calculateToHit` + chin-turret pivot wiring.
+ *
+ * Closes the integration gap left by the Tier 5 audit-cleanup wave: the
+ * `calculateChinTurretPivotModifier` utility was tested in isolation
+ * (`vehicleModifiers.test.ts`) but never composed into the to-hit
+ * accumulator. These tests assert that, when the attacker state carries
+ * the vehicle-only chin-turret context fields, the +1 modifier appears
+ * in the final modifier breakdown and the final to-hit reflects it.
+ *
+ * @spec openspec/specs/firing-arc-calculation/spec.md
+ *   Requirement: Vehicle Chin Turret Pivot Penalty
+ */
+
+import { describe, expect, it } from '@jest/globals';
+
+import { VehicleLocation } from '@/types/construction/UnitLocation';
+import {
+  MovementType,
+  RangeBracket,
+  type IAttackerState,
+  type ITargetState,
+} from '@/types/gameplay';
+import { TurretType } from '@/types/unit/VehicleInterfaces';
+
+import { calculateToHit } from '../calculate';
+
+// ---------------------------------------------------------------------------
+// Fixtures — minimal stationary attacker / target so the chin-turret penalty
+// is the only optional modifier in play.
+// ---------------------------------------------------------------------------
+
+const baseTarget: ITargetState = {
+  movementType: MovementType.Stationary,
+  hexesMoved: 0,
+  prone: false,
+  immobile: false,
+  partialCover: false,
+};
+
+function vehicleAttacker(
+  overrides: Partial<IAttackerState> = {},
+): IAttackerState {
+  return {
+    gunnery: 4,
+    movementType: MovementType.Stationary,
+    heat: 0,
+    damageModifiers: [],
+    ...overrides,
+  };
+}
+
+describe('calculateToHit — chin-turret pivot integration', () => {
+  it('includes the +1 chin-turret modifier when a chin-turret weapon fires after pivoting', () => {
+    const attacker = vehicleAttacker({
+      vehicleTurretType: TurretType.CHIN,
+      vehicleTurretPivotedThisTurn: true,
+      vehicleWeaponMountLocation: VehicleLocation.TURRET,
+      vehicleWeaponIsTurretMounted: true,
+    });
+
+    const result = calculateToHit(attacker, baseTarget, RangeBracket.Short, 3);
+
+    const chinMod = result.modifiers.find(
+      (m) => m.name === 'Chin Turret Pivot',
+    );
+    expect(chinMod).toBeDefined();
+    expect(chinMod?.value).toBe(1);
+
+    // Sanity: stationary 4-gunnery, short range, stationary target, no other
+    // modifiers fire — base 4 + short-range 0 + attacker movement 0 + TMM 0
+    // + heat 0 + chin-turret +1 = 5. Confirms the modifier was actually
+    // summed into the final to-hit, not just present in the list.
+    expect(result.finalToHit).toBe(5);
+  });
+
+  it('omits the chin-turret modifier when the chin turret did NOT pivot this turn', () => {
+    const attacker = vehicleAttacker({
+      vehicleTurretType: TurretType.CHIN,
+      vehicleTurretPivotedThisTurn: false,
+      vehicleWeaponMountLocation: VehicleLocation.TURRET,
+      vehicleWeaponIsTurretMounted: true,
+    });
+
+    const result = calculateToHit(attacker, baseTarget, RangeBracket.Short, 3);
+
+    expect(
+      result.modifiers.find((m) => m.name === 'Chin Turret Pivot'),
+    ).toBeUndefined();
+    // Without the chin-turret penalty: 4 + 0 + 0 + 0 + 0 = 4.
+    expect(result.finalToHit).toBe(4);
+  });
+
+  it('omits the chin-turret modifier for body-mounted weapons even when the chin turret pivoted', () => {
+    const attacker = vehicleAttacker({
+      vehicleTurretType: TurretType.CHIN,
+      vehicleTurretPivotedThisTurn: true,
+      vehicleWeaponMountLocation: VehicleLocation.FRONT,
+      vehicleWeaponIsTurretMounted: false,
+    });
+
+    const result = calculateToHit(attacker, baseTarget, RangeBracket.Short, 3);
+
+    expect(
+      result.modifiers.find((m) => m.name === 'Chin Turret Pivot'),
+    ).toBeUndefined();
+    expect(result.finalToHit).toBe(4);
+  });
+
+  it('omits the chin-turret modifier for non-CHIN turret types (Single, Dual)', () => {
+    const single = calculateToHit(
+      vehicleAttacker({
+        vehicleTurretType: TurretType.SINGLE,
+        vehicleTurretPivotedThisTurn: true,
+        vehicleWeaponMountLocation: VehicleLocation.TURRET,
+        vehicleWeaponIsTurretMounted: true,
+      }),
+      baseTarget,
+      RangeBracket.Short,
+      3,
+    );
+    expect(
+      single.modifiers.find((m) => m.name === 'Chin Turret Pivot'),
+    ).toBeUndefined();
+    expect(single.finalToHit).toBe(4);
+
+    const dual = calculateToHit(
+      vehicleAttacker({
+        vehicleTurretType: TurretType.DUAL,
+        vehicleTurretPivotedThisTurn: true,
+        vehicleWeaponMountLocation: VehicleLocation.TURRET,
+        vehicleWeaponIsTurretMounted: true,
+      }),
+      baseTarget,
+      RangeBracket.Short,
+      3,
+    );
+    expect(
+      dual.modifiers.find((m) => m.name === 'Chin Turret Pivot'),
+    ).toBeUndefined();
+    expect(dual.finalToHit).toBe(4);
+  });
+
+  it('does not fire the chin-turret modifier for a mech attacker (no vehicle fields supplied)', () => {
+    // A bare mech attacker has none of the vehicle-* fields. The whole
+    // chin-turret branch should be skipped, leaving the to-hit unchanged.
+    const mech = vehicleAttacker();
+    const result = calculateToHit(mech, baseTarget, RangeBracket.Short, 3);
+
+    expect(
+      result.modifiers.find((m) => m.name === 'Chin Turret Pivot'),
+    ).toBeUndefined();
+    expect(result.finalToHit).toBe(4);
+  });
+});

--- a/src/utils/gameplay/toHit/calculate.ts
+++ b/src/utils/gameplay/toHit/calculate.ts
@@ -41,6 +41,7 @@ import {
   getRangeModifierForBracket,
   getRangeBracket,
 } from './rangeModifiers';
+import { calculateChinTurretPivotModifier } from './vehicleModifiers';
 
 export function calculateToHit(
   attacker: IAttackerState,
@@ -128,6 +129,27 @@ export function calculateToHit(
       attacker.abilities,
     );
     if (calledMod) modifiers.push(calledMod);
+  }
+
+  // Vehicle-only chin-turret pivot penalty. Per archived
+  // `tier5-audit-cleanup` Phase C 1.A and the firing-arc-calculation spec
+  // ("Vehicle Chin Turret Pivot Penalty"), a ground vehicle that pivots its
+  // chin turret during the current turn incurs +1 to-hit on every weapon
+  // attack from that turret. The fields below are populated only when the
+  // attacker is a vehicle; mech callers leave them undefined and the
+  // modifier returns null.
+  if (
+    attacker.vehicleTurretType !== undefined &&
+    attacker.vehicleWeaponMountLocation !== undefined &&
+    attacker.vehicleWeaponIsTurretMounted !== undefined
+  ) {
+    const chinPivotMod = calculateChinTurretPivotModifier({
+      turretType: attacker.vehicleTurretType,
+      turretPivotedThisTurn: attacker.vehicleTurretPivotedThisTurn ?? false,
+      weaponMountLocation: attacker.vehicleWeaponMountLocation,
+      weaponIsTurretMounted: attacker.vehicleWeaponIsTurretMounted,
+    });
+    if (chinPivotMod) modifiers.push(chinPivotMod);
   }
 
   const rangeModValue = RANGE_MODIFIERS[rangeBracket] ?? 0;

--- a/src/utils/gameplay/vehicleTurretLifecycle.ts
+++ b/src/utils/gameplay/vehicleTurretLifecycle.ts
@@ -1,0 +1,89 @@
+/**
+ * Vehicle Turret Lifecycle Helpers
+ *
+ * Pure-state helpers for the per-turn `turretPivotedThisTurn` flag on
+ * `IVehicleCombatState`. The flag drives the `+1` chin-turret pivot to-hit
+ * penalty (see `calculateChinTurretPivotModifier` in
+ * `toHit/vehicleModifiers.ts`). Per the firing-arc-calculation spec
+ * ("Vehicle Chin Turret Pivot Penalty"), callers SHALL set the flag when
+ * the turret rotates from its previous facing and SHALL clear it at
+ * turn-start alongside other per-turn flags.
+ *
+ * **Wave 4 limitation — SET path is not yet wired into a vehicle facing /
+ * rotation reducer.** The vehicle combat state currently lives outside
+ * the main `IGameState` reducer (separate `IVehicleCombatState` shape
+ * routed through `damageDispatch`), and no `VehicleTurretRotated` event
+ * is authored yet. `markTurretPivoted` is shipped as the canonical entry
+ * point so the future facing-change reducer can call it without
+ * re-deriving the immutable-update pattern. The CLEAR path
+ * (`clearTurretPivotedFlag`, `clearAllTurretPivotedFlags`) IS production-
+ * ready: any vehicle turn-start handler can call it today to reset the
+ * flag at the canonical boundary.
+ *
+ * @spec openspec/specs/firing-arc-calculation/spec.md
+ *   Requirement: Vehicle Chin Turret Pivot Penalty
+ */
+
+import { IVehicleCombatState } from '@/types/gameplay';
+
+/**
+ * Set `turretPivotedThisTurn = true` on a vehicle combat state. Called when
+ * the vehicle's primary turret rotates from its previous facing during the
+ * current turn. Idempotent — calling it on a state that is already
+ * pivoted is a no-op (returns the same reference where possible to keep
+ * downstream selector identity stable).
+ *
+ * The flag is cleared at the next turn-start boundary by
+ * `clearTurretPivotedFlag`. While set, the chin-turret weapon attacks
+ * routed through `calculateToHit` will pick up the +1 modifier via
+ * `calculateChinTurretPivotModifier`.
+ *
+ * **Caller note:** the rotation event handler is not yet authored in
+ * production (per the architecture comment above). Once a future change
+ * authors the facing-change reducer, it should call this helper as part
+ * of the rotation effect.
+ */
+export function markTurretPivoted(
+  state: IVehicleCombatState,
+): IVehicleCombatState {
+  if (state.turretPivotedThisTurn === true) return state;
+  return { ...state, turretPivotedThisTurn: true };
+}
+
+/**
+ * Clear `turretPivotedThisTurn` on a single vehicle combat state. Idempotent.
+ * Per the spec, the flag SHALL be cleared at the start of each turn so the
+ * next turn's pivot tracking starts from a clean slate.
+ *
+ * Returns the same reference when the flag is already absent / false to
+ * preserve selector identity.
+ */
+export function clearTurretPivotedFlag(
+  state: IVehicleCombatState,
+): IVehicleCombatState {
+  if (!state.turretPivotedThisTurn) return state;
+  return { ...state, turretPivotedThisTurn: false };
+}
+
+/**
+ * Clear `turretPivotedThisTurn` across a batch of vehicle combat states —
+ * the canonical end-of-turn / start-of-turn reset for the per-turn flag.
+ *
+ * Returns the same input map reference when no state needs updating, so
+ * unchanged turns don't trigger downstream re-renders.
+ *
+ * @param states - Map keyed by `unitId` (matches the existing
+ *   `IVehicleCombatState.unitId` convention).
+ */
+export function clearAllTurretPivotedFlags(
+  states: Readonly<Record<string, IVehicleCombatState>>,
+): Readonly<Record<string, IVehicleCombatState>> {
+  let mutated = false;
+  const next: Record<string, IVehicleCombatState> = {};
+  for (const [unitId, state] of Object.entries(states)) {
+    const cleared = clearTurretPivotedFlag(state);
+    if (cleared !== state) mutated = true;
+    next[unitId] = cleared;
+  }
+  return mutated ? next : states;
+}


### PR DESCRIPTION
## Summary

Closes the 5 integration gaps identified by the post-Tier-5 audit. The audit-cleanup wave (PRs #405/#408/#412/#413) shipped specs and tests but left utilities orphaned — they existed and passed unit tests in isolation, but were never called from production pipelines. This PR wires them in.

## What's in the box

Five surgical commits, one per gap:

1. `8c9f79f8` **feat(toHit)** — `calculateChinTurretPivotModifier` is now composed into `calculateToHit`. Extends `IAttackerState` with optional vehicle-only fields (`vehicleTurretType`, `vehicleTurretPivotedThisTurn`, `vehicleWeaponMountLocation`, `vehicleWeaponIsTurretMounted`). Mech / aerospace / battle-armor callers leave them undefined and the chin-turret branch is skipped. Adds `calculateChinTurretIntegration.test.ts` — 5 integration tests covering the four spec scenarios end-to-end through the accumulator.
2. `1b79df26` **feat(vehicle)** — adds `vehicleTurretLifecycle.ts` with three pure helpers: `markTurretPivoted` (SET), `clearTurretPivotedFlag` (CLEAR), `clearAllTurretPivotedFlags` (batch CLEAR for end-of-turn). Idempotent immutable updates with reference identity preserved when nothing changes. 10 lifecycle tests including SET → CLEAR end-to-end.
3. `85d05b6a` **feat(piloting)** — adds `PSRTrigger.EngineHit = 'engine_hit'` to the catalog (was missing despite being listed in the spec). Adds `createEngineHitPSR` factory matching nearby damage-factory pattern. Re-exports from the barrel. Extends parameterized "all triggers" test (count 27 → 28).
4. `fa156258` **feat(movement)** — wires `getEffectiveWalkMP` into the customizer's TSM tooltip, replacing hardcoded inline arithmetic ("net +1 from +2 Walk, -1 heat penalty") with a call to the canonical helper. Single source of truth for the TSM-bonus + heat-penalty combined formula per the heat-management spec.
5. `2be2196e` **docs(combat-outcome)** — fixes the stale `@see` link in `CombatOutcome.ts` to point to the archived `tier5-audit-cleanup` path.

## Integration vs unit test distinction

The Tier 5 audit-cleanup wave shipped **unit tests** for the 5 utilities. This PR adds the missing **integration**: production callers that exercise the utilities end-to-end. Specifically:

- Chin-turret modifier: was tested via `vehicleModifiers.test.ts` (unit, modifier in isolation). Now also tested via `calculateChinTurretIntegration.test.ts` (integration, modifier composed through the accumulator into `finalToHit`).
- Lifecycle helpers: were absent. Now exist as standalone helpers with their own test suite.
- `EngineHit` PSR: was absent. Now in the catalog and exercised by the parameterized factory test table.

## Trade-offs / acknowledged gaps

- **Task 2 SET path** is shipped as the canonical entry point for future facing-change reducers but has no production caller yet — the vehicle combat state currently flows through `damageDispatch` outside the main `IGameState` reducer, and no `VehicleTurretRotated` event is authored. The CLEAR path IS production-ready for any future vehicle turn-start handler. JSDoc explicitly documents this.
- **Task 3 EngineHit dispatch** — the factory + enum are in the catalog. The actual dispatch from `CriticalEffectType.EngineHit` into the pending PSR queue is wired by the critical-hit pipeline in a future change. Spec compliance: catalog has the trigger.
- **Task 4 customizer scope** — the construction-time customizer has no runtime heat. The tooltip samples at heat 9 (TSM activation threshold) to surface the canonical "TSM active" preview, which is what the inline arithmetic was approximating.

## Tier 5 audit-cleanup status

**The Tier 5 audit-cleanup wave is COMPLETE for the original audit's enumerated scope** (PRs #405/#408/#412/#413 + archive #413). This PR closes apply-phase-introduced wiring debt — utilities that shipped without production callers. The archived change at `openspec/changes/archive/2026-04-25-tier5-audit-cleanup/` remains the spec-of-record.

## Verification

All 5 verification gates passed locally:

- `npx tsc --noEmit --skipLibCheck` — clean
- `npx oxfmt --check .` — all 3031 files correctly formatted
- `npx oxlint <touched files>` — 0 warnings, 0 errors
- Targeted tests (`toHit|vehicleModifiers|phaseManagement|pilotingSkillRolls|tsmHeat|vehicleTurretLifecycle|StructureTab|calculateChinTurret`): 471/471 green
- Full Jest suite: 22167 passed, 12 skipped, 0 failed (789/790 suites; 1 skipped). Known flake `balance.test.ts` did not flake.
- Husky pre-push gate (oxlint --fix + oxfmt --write + tsc --noEmit + next build) passed for every commit during local commit.

## Test plan

- [x] All 5 commits land cleanly with husky verification
- [x] Full `npx jest` green
- [x] CI gate (lint / format / typecheck / test / validate-bv / storybook-build) on this PR