### PR TITLE
chore(deps): break services repository + sync cycles

### DIFF
--- a/src/services/forces/ForceRepository.operations.ts
+++ b/src/services/forces/ForceRepository.operations.ts
@@ -10,11 +10,14 @@ import {
 } from '@/types/force';
 
 import { getSQLiteService } from '../persistence/SQLiteService';
-import { ForceErrorCode, type IForceOperationResult } from './ForceRepository';
 import {
   wouldCreateCycle,
   type AssignmentRow,
 } from './ForceRepository.helpers';
+import {
+  ForceErrorCode,
+  type IForceOperationResult,
+} from './ForceRepository.types';
 
 export function createForceOperation(
   request: ICreateForceRequest,

--- a/src/services/forces/ForceRepository.ts
+++ b/src/services/forces/ForceRepository.ts
@@ -26,25 +26,19 @@ import {
   updateAssignmentOperation,
   swapAssignmentsOperation,
 } from './ForceRepository.operations';
+import {
+  ForceErrorCode,
+  type IForceOperationResult,
+} from './ForceRepository.types';
 
 // =============================================================================
 // Result Types
 // =============================================================================
 
-export enum ForceErrorCode {
-  NotFound = 'NOT_FOUND',
-  DuplicateName = 'DUPLICATE_NAME',
-  ValidationError = 'VALIDATION_ERROR',
-  DatabaseError = 'DATABASE_ERROR',
-  CircularHierarchy = 'CIRCULAR_HIERARCHY',
-}
-
-export interface IForceOperationResult {
-  readonly success: boolean;
-  readonly id?: string;
-  readonly error?: string;
-  readonly errorCode?: ForceErrorCode;
-}
+// Re-exported from ForceRepository.types so existing consumers that import
+// these from `@/services/forces/ForceRepository` keep working unchanged.
+export { ForceErrorCode };
+export type { IForceOperationResult };
 
 // =============================================================================
 // Repository Interface

--- a/src/services/forces/ForceRepository.types.ts
+++ b/src/services/forces/ForceRepository.types.ts
@@ -1,0 +1,23 @@
+/**
+ * Force Repository — shared types
+ *
+ * Leaf module that holds the result types shared between ForceRepository
+ * and its operation helpers. Extracting these breaks the ForceRepository ↔
+ * ForceRepository.operations circular import without changing the public
+ * API (both names continue to be re-exported from ForceRepository.ts).
+ */
+
+export enum ForceErrorCode {
+  NotFound = 'NOT_FOUND',
+  DuplicateName = 'DUPLICATE_NAME',
+  ValidationError = 'VALIDATION_ERROR',
+  DatabaseError = 'DATABASE_ERROR',
+  CircularHierarchy = 'CIRCULAR_HIERARCHY',
+}
+
+export interface IForceOperationResult {
+  readonly success: boolean;
+  readonly id?: string;
+  readonly error?: string;
+  readonly errorCode?: ForceErrorCode;
+}

--- a/src/services/pilots/PilotRepository.career.ts
+++ b/src/services/pilots/PilotRepository.career.ts
@@ -3,7 +3,10 @@ import { v4 as uuidv4 } from 'uuid';
 import type { IKillRecord, IMissionRecord, IPilot } from '@/types/pilot';
 
 import { getSQLiteService } from '../persistence/SQLiteService';
-import { PilotErrorCode, type IPilotOperationResult } from './PilotRepository';
+import {
+  PilotErrorCode,
+  type IPilotOperationResult,
+} from './PilotRepository.types';
 
 export function recordKill(
   pilotId: string,
@@ -22,10 +25,12 @@ export function recordKill(
   }
 
   try {
-    db.prepare(`
+    db.prepare(
+      `
       INSERT INTO pilot_kills (id, pilot_id, target_id, target_name, weapon_used, kill_date, game_id)
       VALUES (?, ?, ?, ?, ?, ?, ?)
-    `).run(
+    `,
+    ).run(
       uuidv4(),
       pilotId,
       kill.targetId,
@@ -35,9 +40,11 @@ export function recordKill(
       kill.gameId,
     );
 
-    db.prepare(`
+    db.prepare(
+      `
       UPDATE pilots SET total_kills = total_kills + 1, updated_at = ? WHERE id = ?
-    `).run(now, pilotId);
+    `,
+    ).run(now, pilotId);
 
     return { success: true, id: pilotId };
   } catch (error) {
@@ -67,10 +74,12 @@ export function recordMission(
   }
 
   try {
-    db.prepare(`
+    db.prepare(
+      `
       INSERT INTO pilot_missions (id, pilot_id, game_id, mission_name, mission_date, outcome, xp_earned, kills)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
+    `,
+    ).run(
       uuidv4(),
       pilotId,
       mission.gameId,
@@ -88,7 +97,8 @@ export function recordMission(
           ? 'defeats'
           : 'draws';
 
-    db.prepare(`
+    db.prepare(
+      `
       UPDATE pilots SET 
         missions_completed = missions_completed + 1,
         ${outcomeField} = ${outcomeField} + 1,
@@ -96,7 +106,8 @@ export function recordMission(
         total_xp_earned = total_xp_earned + ?,
         updated_at = ?
       WHERE id = ?
-    `).run(mission.xpEarned, mission.xpEarned, now, pilotId);
+    `,
+    ).run(mission.xpEarned, mission.xpEarned, now, pilotId);
 
     return { success: true, id: pilotId };
   } catch (error) {
@@ -126,13 +137,15 @@ export function addXp(
   }
 
   try {
-    db.prepare(`
+    db.prepare(
+      `
       UPDATE pilots SET 
         xp = xp + ?,
         total_xp_earned = total_xp_earned + ?,
         updated_at = ?
       WHERE id = ?
-    `).run(amount, amount, now, pilotId);
+    `,
+    ).run(amount, amount, now, pilotId);
 
     return { success: true, id: pilotId };
   } catch (error) {
@@ -171,9 +184,11 @@ export function spendXp(
   }
 
   try {
-    db.prepare(`
+    db.prepare(
+      `
       UPDATE pilots SET xp = xp - ?, updated_at = ? WHERE id = ?
-    `).run(amount, now, pilotId);
+    `,
+    ).run(amount, now, pilotId);
 
     return { success: true, id: pilotId };
   } catch (error) {

--- a/src/services/pilots/PilotRepository.ts
+++ b/src/services/pilots/PilotRepository.ts
@@ -31,25 +31,20 @@ import {
   type PilotRow,
 } from './PilotRepository.helpers';
 import { buildUpdateQuery } from './PilotRepository.queries';
+import {
+  PilotErrorCode,
+  type IPilotOperationResult,
+} from './PilotRepository.types';
 
 // =============================================================================
 // Result Types
 // =============================================================================
 
-export enum PilotErrorCode {
-  NotFound = 'NOT_FOUND',
-  DuplicateName = 'DUPLICATE_NAME',
-  ValidationError = 'VALIDATION_ERROR',
-  DatabaseError = 'DATABASE_ERROR',
-  InsufficientXp = 'INSUFFICIENT_XP',
-}
-
-export interface IPilotOperationResult {
-  readonly success: boolean;
-  readonly id?: string;
-  readonly error?: string;
-  readonly errorCode?: PilotErrorCode;
-}
+// Re-exported from PilotRepository.types so existing consumers that import
+// these from `@/services/pilots/PilotRepository` (or via the pilots barrel
+// index) keep working unchanged.
+export { PilotErrorCode };
+export type { IPilotOperationResult };
 
 // =============================================================================
 // Repository Interface

--- a/src/services/pilots/PilotRepository.types.ts
+++ b/src/services/pilots/PilotRepository.types.ts
@@ -1,0 +1,24 @@
+/**
+ * Pilot Repository — shared types
+ *
+ * Leaf module that holds the result types shared between PilotRepository
+ * and its career-operation helpers. Extracting these breaks the
+ * PilotRepository ↔ PilotRepository.career circular import without
+ * changing the public API (both names continue to be re-exported from
+ * PilotRepository.ts and from the pilots barrel index).
+ */
+
+export enum PilotErrorCode {
+  NotFound = 'NOT_FOUND',
+  DuplicateName = 'DUPLICATE_NAME',
+  ValidationError = 'VALIDATION_ERROR',
+  DatabaseError = 'DATABASE_ERROR',
+  InsufficientXp = 'INSUFFICIENT_XP',
+}
+
+export interface IPilotOperationResult {
+  readonly success: boolean;
+  readonly id?: string;
+  readonly error?: string;
+  readonly errorCode?: PilotErrorCode;
+}

--- a/src/services/vault/SyncEngine.conflictResolution.ts
+++ b/src/services/vault/SyncEngine.conflictResolution.ts
@@ -9,7 +9,7 @@
 import type { IChangeLogEntry, ISyncConflict } from '@/types/vault';
 
 import type { ChangeLogRepository } from './ChangeLogRepository';
-import type { ContentApplyFn } from './SyncEngine';
+import type { ContentApplyFn } from './SyncEngine.types';
 
 /**
  * Shape returned by the pending-conflict lookup on ChangeLogRepository.

--- a/src/services/vault/SyncEngine.ts
+++ b/src/services/vault/SyncEngine.ts
@@ -15,6 +15,13 @@ import type {
   ChangeType,
 } from '@/types/vault';
 
+import type {
+  ContentApplyFn,
+  ContentDataFn,
+  ContentHashFn,
+  ItemNameFn,
+} from './SyncEngine.types';
+
 import {
   createSingleton,
   type SingletonFactory,
@@ -61,41 +68,10 @@ export interface IReconciliationResult {
   skipped: IChangeLogEntry[];
 }
 
-/**
- * Content hash function type
- */
-export type ContentHashFn = (
-  itemId: string,
-  contentType: ShareableContentType | 'folder',
-) => Promise<string | null>;
-
-/**
- * Content data function type
- */
-export type ContentDataFn = (
-  itemId: string,
-  contentType: ShareableContentType | 'folder',
-) => Promise<string | null>;
-
-/**
- * Item name resolver — returns a human-readable display name for a
- * conflicting item so conflict records aren't labelled with raw ids.
- */
-export type ItemNameFn = (
-  itemId: string,
-  contentType: ShareableContentType | 'folder',
-) => Promise<string | null>;
-
-/**
- * Content apply function — writes remote content back to local storage.
- * Registered by the caller that owns persistence (e.g. a vault store)
- * so the sync engine stays storage-agnostic.
- */
-export type ContentApplyFn = (
-  itemId: string,
-  contentType: ShareableContentType | 'folder',
-  data: string,
-) => Promise<void>;
+// Re-exported from SyncEngine.types so existing consumers that import these
+// callback types from `@/services/vault/SyncEngine` (or via the vault barrel
+// index) keep working unchanged.
+export type { ContentHashFn, ContentDataFn, ItemNameFn, ContentApplyFn };
 
 // =============================================================================
 // Service

--- a/src/services/vault/SyncEngine.types.ts
+++ b/src/services/vault/SyncEngine.types.ts
@@ -1,0 +1,46 @@
+/**
+ * SyncEngine — shared callback types
+ *
+ * Leaf module that holds the storage-agnostic callback types the
+ * SyncEngine class accepts. Extracting them breaks the
+ * SyncEngine ↔ SyncEngine.conflictResolution circular import without
+ * changing the public API (every name is re-exported from SyncEngine.ts).
+ */
+
+import type { ShareableContentType } from '@/types/vault';
+
+/**
+ * Content hash function type
+ */
+export type ContentHashFn = (
+  itemId: string,
+  contentType: ShareableContentType | 'folder',
+) => Promise<string | null>;
+
+/**
+ * Content data function type
+ */
+export type ContentDataFn = (
+  itemId: string,
+  contentType: ShareableContentType | 'folder',
+) => Promise<string | null>;
+
+/**
+ * Item name resolver — returns a human-readable display name for a
+ * conflicting item so conflict records aren't labelled with raw ids.
+ */
+export type ItemNameFn = (
+  itemId: string,
+  contentType: ShareableContentType | 'folder',
+) => Promise<string | null>;
+
+/**
+ * Content apply function — writes remote content back to local storage.
+ * Registered by the caller that owns persistence (e.g. a vault store)
+ * so the sync engine stays storage-agnostic.
+ */
+export type ContentApplyFn = (
+  itemId: string,
+  contentType: ShareableContentType | 'folder',
+  data: string,
+) => Promise<void>;


### PR DESCRIPTION
## Summary

PR-B2 of the 5-PR circular-dependency cleanup wave. Breaks 3 over-decomposed import cycles inside `src/services/` by extracting shared result/callback types into leaf `*.types.ts` modules. All three are mechanical Pattern-1 fixes — no behavior change, public APIs preserved via re-exports.

| Cycle | Before | After |
| --- | --- | --- |
| `forces/ForceRepository.ts` ↔ `forces/ForceRepository.operations.ts` | circular | leaf `ForceRepository.types.ts` |
| `pilots/PilotRepository.ts` ↔ `pilots/PilotRepository.career.ts` | circular | leaf `PilotRepository.types.ts` |
| `vault/SyncEngine.conflictResolution.ts` ↔ `vault/SyncEngine.ts` | circular | leaf `SyncEngine.types.ts` |

## What moved where

- `ForceErrorCode` enum + `IForceOperationResult` interface → new `src/services/forces/ForceRepository.types.ts`. Re-exported from `ForceRepository.ts` so `@/services/forces/ForceRepository` keeps working for `EncounterService`, the `api/forces/*` handlers, and existing tests.
- `PilotErrorCode` enum + `IPilotOperationResult` interface → new `src/services/pilots/PilotRepository.types.ts`. Re-exported from `PilotRepository.ts` so `@/services/pilots` (barrel index), the `api/pilots/*` handlers, `PilotService`, and existing tests keep working.
- `ContentHashFn`, `ContentDataFn`, `ItemNameFn`, `ContentApplyFn` (the four storage-agnostic SyncEngine callback types) → new `src/services/vault/SyncEngine.types.ts`. `SyncEngine.conflictResolution.ts` now imports `ContentApplyFn` from the leaf instead of from `SyncEngine.ts`, breaking the cycle. `SyncEngine.ts` re-exports all four so `@/services/vault/SyncEngine` consumers, the vault barrel index, and existing tests keep working.

## madge before / after

```
$ npx madge --circular --extensions ts,tsx src/services/   # before
✖ Found 12 circular dependencies!
 ...
3) forces/ForceRepository.ts > forces/ForceRepository.operations.ts
4) pilots/PilotRepository.ts > pilots/PilotRepository.career.ts
 ...
12) vault/SyncEngine.conflictResolution.ts > vault/SyncEngine.ts
```

```
$ npx madge --circular --extensions ts,tsx src/services/   # after
✖ Found 9 circular dependencies!
1) conversion/BlkExportServiceCore.ts > conversion/BlkExportServiceCore.exporters.ts
2) conversion/MTFParser.components.ts > conversion/MTFParserHelpers.ts        # PR-B3
3) units/handlers/JumpShipUnitHandler.ts > ...calculations.ts                  # PR-B4
4) units/handlers/JumpShipUnitHandler.ts > ...helpers.ts                       # PR-B4
5) units/handlers/SpaceStationUnitHandler.ts > ...calculations.ts              # PR-B4
6) units/handlers/SpaceStationUnitHandler.ts > ...helpers.ts                   # PR-B4
7) printing/ArmorPipLayout.grouped.ts > printing/ArmorPipLayout.ts
8) printing/ArmorPipLayout.ts > printing/ArmorPipLayout.processing.ts
9) printing/ArmorPipLayout.ts > ...processing.ts > ...types.ts
```

12 → 9 (the 3 target cycles closed; remaining cycles are scoped to other PRs in the wave).

## Verification

- `npx tsc --noEmit` — exit 0 (run after each commit; pre-commit hook also ran `npx tsc --noEmit --skipLibCheck` + full `next build` for every commit and all three passed)
- `npm run lint` — 0 errors, 31 warnings (all pre-existing `max-lines` warnings on store files; none touched by this PR)
- `npx jest src/services/forces src/services/pilots src/services/vault` — 24 suites, 1041 tests, all passing
- `npx madge --circular --extensions ts,tsx src/services/` — 12 → 9 cycles, all 3 target cycles confirmed gone

## Test plan

- [x] tsc clean
- [x] lint clean (zero errors; pre-existing warnings unrelated to this change)
- [x] All forces / pilots / vault unit tests pass (1041/1041)
- [x] madge confirms 3 target cycles closed
- [x] Public API unchanged (every name still importable from the original module path via re-export)
- [ ] Remote CI green on push