### PR TITLE
chore(deps): break utils/colors + utils/techBaseValidation cycles

### DIFF
--- a/src/utils/colors/equipmentColors.ammo.ts
+++ b/src/utils/colors/equipmentColors.ammo.ts
@@ -8,7 +8,7 @@ import { EquipmentCategory } from '@/types/equipment';
 import {
   EQUIPMENT_CATEGORY_COLORS,
   type CategoryColorDefinition,
-} from './equipmentColors';
+} from './equipmentColors.types';
 
 // =============================================================================
 // Ammunition Sub-Types

--- a/src/utils/colors/equipmentColors.legacy.ts
+++ b/src/utils/colors/equipmentColors.legacy.ts
@@ -6,8 +6,8 @@
 
 import { EquipmentCategory } from '@/types/equipment';
 
-import { EQUIPMENT_CATEGORY_COLORS } from './equipmentColors';
 import { classifyEquipmentByName } from './equipmentColors.classification';
+import { EQUIPMENT_CATEGORY_COLORS } from './equipmentColors.types';
 
 // =============================================================================
 // Legacy Types

--- a/src/utils/colors/equipmentColors.ts
+++ b/src/utils/colors/equipmentColors.ts
@@ -1,8 +1,14 @@
 /**
- * Equipment Category Color System - SINGLE SOURCE OF TRUTH
+ * Equipment Category Color System - Public Aggregator
  *
- * All equipment category colors for the entire application.
- * Used by: Equipment Browser, Critical Slots Display, Customizer, etc.
+ * Re-exports the full equipment color API from the leaf modules and
+ * provides the high-level `getCategory*` helpers used across the UI.
+ *
+ * The shared types and the SINGLE SOURCE OF TRUTH category color map
+ * live in `equipmentColors.types.ts` (a leaf module). The legacy
+ * compatibility layer lives in `equipmentColors.legacy.ts`. The ammo
+ * sub-type detection lives in `equipmentColors.ammo.ts`. None of those
+ * may import from this file — that would re-introduce the cycle.
  *
  * RESERVED COLORS (used by system components in slotColors.ts):
  *   - Orange: Engine
@@ -16,6 +22,16 @@
 import { EquipmentCategory } from '@/types/equipment';
 
 import { classifyEquipmentByName } from './equipmentColors.classification';
+import {
+  EQUIPMENT_CATEGORY_COLORS,
+  type CategoryColorDefinition,
+} from './equipmentColors.types';
+
+// Re-export the shared type + map so existing consumers keep working.
+export {
+  EQUIPMENT_CATEGORY_COLORS,
+  type CategoryColorDefinition,
+} from './equipmentColors.types';
 
 export { classifyEquipmentByName };
 export {
@@ -36,160 +52,6 @@ export {
   type EquipmentColorType,
   type EquipmentColorDefinition,
 } from './equipmentColors.legacy';
-
-// =============================================================================
-// Types
-// =============================================================================
-
-export interface CategoryColorDefinition {
-  readonly label: string;
-  readonly badgeVariant: string;
-  readonly slotBg: string;
-  readonly slotBorder: string;
-  readonly slotText: string;
-  readonly slotHoverBg: string;
-  readonly indicatorBg: string;
-}
-
-// =============================================================================
-// SINGLE SOURCE OF TRUTH: Equipment Category Colors
-// =============================================================================
-
-/**
- * Color definitions for each equipment category.
- *
- * Color assignments avoid conflicts with system components:
- * - Engine uses Orange → Ballistic uses Amber instead
- * - Gyro uses Purple → Structural uses Lime instead
- * - Actuator uses Blue → Electronics uses Teal instead
- * - Cockpit uses Yellow-600 → Ammo uses Yellow-400 (different shade)
- */
-export const EQUIPMENT_CATEGORY_COLORS: Record<
-  EquipmentCategory,
-  CategoryColorDefinition
-> = {
-  // -------------------------------------------------------------------------
-  // WEAPON CATEGORIES - Each has a distinct color
-  // -------------------------------------------------------------------------
-
-  [EquipmentCategory.ENERGY_WEAPON]: {
-    label: 'Energy',
-    badgeVariant: 'yellow',
-    slotBg: 'bg-yellow-600',
-    slotBorder: 'border-yellow-700',
-    slotText: 'text-black',
-    slotHoverBg: 'hover:bg-yellow-500',
-    indicatorBg: 'bg-yellow-500',
-  },
-
-  [EquipmentCategory.BALLISTIC_WEAPON]: {
-    label: 'Ballistic',
-    badgeVariant: 'red',
-    slotBg: 'bg-red-700',
-    slotBorder: 'border-red-800',
-    slotText: 'text-white',
-    slotHoverBg: 'hover:bg-red-600',
-    indicatorBg: 'bg-red-500',
-  },
-
-  [EquipmentCategory.MISSILE_WEAPON]: {
-    label: 'Missile',
-    badgeVariant: 'teal',
-    slotBg: 'bg-teal-700',
-    slotBorder: 'border-teal-800',
-    slotText: 'text-white',
-    slotHoverBg: 'hover:bg-teal-600',
-    indicatorBg: 'bg-teal-500',
-  },
-
-  [EquipmentCategory.ARTILLERY]: {
-    label: 'Artillery',
-    badgeVariant: 'violet',
-    slotBg: 'bg-violet-700',
-    slotBorder: 'border-violet-800',
-    slotText: 'text-white',
-    slotHoverBg: 'hover:bg-violet-600',
-    indicatorBg: 'bg-violet-500',
-  },
-
-  [EquipmentCategory.CAPITAL_WEAPON]: {
-    label: 'Capital',
-    badgeVariant: 'fuchsia',
-    slotBg: 'bg-fuchsia-700',
-    slotBorder: 'border-fuchsia-800',
-    slotText: 'text-white',
-    slotHoverBg: 'hover:bg-fuchsia-600',
-    indicatorBg: 'bg-fuchsia-500',
-  },
-
-  [EquipmentCategory.PHYSICAL_WEAPON]: {
-    label: 'Physical',
-    badgeVariant: 'rose',
-    slotBg: 'bg-rose-700',
-    slotBorder: 'border-rose-800',
-    slotText: 'text-white',
-    slotHoverBg: 'hover:bg-rose-600',
-    indicatorBg: 'bg-rose-500',
-  },
-
-  // -------------------------------------------------------------------------
-  // AMMUNITION - Yellow (different shade than cockpit's yellow-600)
-  // -------------------------------------------------------------------------
-
-  [EquipmentCategory.AMMUNITION]: {
-    label: 'Ammo',
-    badgeVariant: 'amber',
-    slotBg: 'bg-amber-600',
-    slotBorder: 'border-amber-700',
-    slotText: 'text-white',
-    slotHoverBg: 'hover:bg-amber-500',
-    indicatorBg: 'bg-amber-400',
-  },
-
-  // -------------------------------------------------------------------------
-  // OTHER EQUIPMENT - Avoiding reserved system component colors
-  // -------------------------------------------------------------------------
-
-  [EquipmentCategory.ELECTRONICS]: {
-    label: 'Electronics',
-    badgeVariant: 'cyan',
-    slotBg: 'bg-cyan-700',
-    slotBorder: 'border-cyan-800',
-    slotText: 'text-white',
-    slotHoverBg: 'hover:bg-cyan-600',
-    indicatorBg: 'bg-cyan-500',
-  },
-
-  [EquipmentCategory.MOVEMENT]: {
-    label: 'Movement',
-    badgeVariant: 'emerald',
-    slotBg: 'bg-emerald-700',
-    slotBorder: 'border-emerald-800',
-    slotText: 'text-white',
-    slotHoverBg: 'hover:bg-emerald-600',
-    indicatorBg: 'bg-emerald-500',
-  },
-
-  [EquipmentCategory.STRUCTURAL]: {
-    label: 'Structural',
-    badgeVariant: 'lime',
-    slotBg: 'bg-lime-700',
-    slotBorder: 'border-lime-800',
-    slotText: 'text-white',
-    slotHoverBg: 'hover:bg-lime-600',
-    indicatorBg: 'bg-lime-500',
-  },
-
-  [EquipmentCategory.MISC_EQUIPMENT]: {
-    label: 'Misc',
-    badgeVariant: 'slate',
-    slotBg: 'bg-slate-700',
-    slotBorder: 'border-slate-800',
-    slotText: 'text-white',
-    slotHoverBg: 'hover:bg-slate-600',
-    indicatorBg: 'bg-slate-500',
-  },
-};
 
 export const HEATSINK_COLORS: CategoryColorDefinition = {
   label: 'Heat Sink',

--- a/src/utils/colors/equipmentColors.types.ts
+++ b/src/utils/colors/equipmentColors.types.ts
@@ -1,0 +1,170 @@
+/**
+ * Equipment Color Types & Category Color Map
+ *
+ * Leaf module containing the shared type definition and the
+ * single-source-of-truth color map. Both `equipmentColors.ammo.ts`
+ * and `equipmentColors.legacy.ts` import from here to avoid creating
+ * a circular dependency through `equipmentColors.ts` (the orchestrator
+ * that re-exports both halves).
+ *
+ * Do not import from `./equipmentColors`, `./equipmentColors.ammo`,
+ * or `./equipmentColors.legacy` from this file — it must remain a leaf.
+ *
+ * @spec openspec/specs/color-system/spec.md
+ */
+
+import { EquipmentCategory } from '@/types/equipment';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface CategoryColorDefinition {
+  readonly label: string;
+  readonly badgeVariant: string;
+  readonly slotBg: string;
+  readonly slotBorder: string;
+  readonly slotText: string;
+  readonly slotHoverBg: string;
+  readonly indicatorBg: string;
+}
+
+// =============================================================================
+// SINGLE SOURCE OF TRUTH: Equipment Category Colors
+// =============================================================================
+
+/**
+ * Color definitions for each equipment category.
+ *
+ * Color assignments avoid conflicts with system components:
+ * - Engine uses Orange → Ballistic uses Amber instead
+ * - Gyro uses Purple → Structural uses Lime instead
+ * - Actuator uses Blue → Electronics uses Teal instead
+ * - Cockpit uses Yellow-600 → Ammo uses Yellow-400 (different shade)
+ */
+export const EQUIPMENT_CATEGORY_COLORS: Record<
+  EquipmentCategory,
+  CategoryColorDefinition
+> = {
+  // -------------------------------------------------------------------------
+  // WEAPON CATEGORIES - Each has a distinct color
+  // -------------------------------------------------------------------------
+
+  [EquipmentCategory.ENERGY_WEAPON]: {
+    label: 'Energy',
+    badgeVariant: 'yellow',
+    slotBg: 'bg-yellow-600',
+    slotBorder: 'border-yellow-700',
+    slotText: 'text-black',
+    slotHoverBg: 'hover:bg-yellow-500',
+    indicatorBg: 'bg-yellow-500',
+  },
+
+  [EquipmentCategory.BALLISTIC_WEAPON]: {
+    label: 'Ballistic',
+    badgeVariant: 'red',
+    slotBg: 'bg-red-700',
+    slotBorder: 'border-red-800',
+    slotText: 'text-white',
+    slotHoverBg: 'hover:bg-red-600',
+    indicatorBg: 'bg-red-500',
+  },
+
+  [EquipmentCategory.MISSILE_WEAPON]: {
+    label: 'Missile',
+    badgeVariant: 'teal',
+    slotBg: 'bg-teal-700',
+    slotBorder: 'border-teal-800',
+    slotText: 'text-white',
+    slotHoverBg: 'hover:bg-teal-600',
+    indicatorBg: 'bg-teal-500',
+  },
+
+  [EquipmentCategory.ARTILLERY]: {
+    label: 'Artillery',
+    badgeVariant: 'violet',
+    slotBg: 'bg-violet-700',
+    slotBorder: 'border-violet-800',
+    slotText: 'text-white',
+    slotHoverBg: 'hover:bg-violet-600',
+    indicatorBg: 'bg-violet-500',
+  },
+
+  [EquipmentCategory.CAPITAL_WEAPON]: {
+    label: 'Capital',
+    badgeVariant: 'fuchsia',
+    slotBg: 'bg-fuchsia-700',
+    slotBorder: 'border-fuchsia-800',
+    slotText: 'text-white',
+    slotHoverBg: 'hover:bg-fuchsia-600',
+    indicatorBg: 'bg-fuchsia-500',
+  },
+
+  [EquipmentCategory.PHYSICAL_WEAPON]: {
+    label: 'Physical',
+    badgeVariant: 'rose',
+    slotBg: 'bg-rose-700',
+    slotBorder: 'border-rose-800',
+    slotText: 'text-white',
+    slotHoverBg: 'hover:bg-rose-600',
+    indicatorBg: 'bg-rose-500',
+  },
+
+  // -------------------------------------------------------------------------
+  // AMMUNITION - Yellow (different shade than cockpit's yellow-600)
+  // -------------------------------------------------------------------------
+
+  [EquipmentCategory.AMMUNITION]: {
+    label: 'Ammo',
+    badgeVariant: 'amber',
+    slotBg: 'bg-amber-600',
+    slotBorder: 'border-amber-700',
+    slotText: 'text-white',
+    slotHoverBg: 'hover:bg-amber-500',
+    indicatorBg: 'bg-amber-400',
+  },
+
+  // -------------------------------------------------------------------------
+  // OTHER EQUIPMENT - Avoiding reserved system component colors
+  // -------------------------------------------------------------------------
+
+  [EquipmentCategory.ELECTRONICS]: {
+    label: 'Electronics',
+    badgeVariant: 'cyan',
+    slotBg: 'bg-cyan-700',
+    slotBorder: 'border-cyan-800',
+    slotText: 'text-white',
+    slotHoverBg: 'hover:bg-cyan-600',
+    indicatorBg: 'bg-cyan-500',
+  },
+
+  [EquipmentCategory.MOVEMENT]: {
+    label: 'Movement',
+    badgeVariant: 'emerald',
+    slotBg: 'bg-emerald-700',
+    slotBorder: 'border-emerald-800',
+    slotText: 'text-white',
+    slotHoverBg: 'hover:bg-emerald-600',
+    indicatorBg: 'bg-emerald-500',
+  },
+
+  [EquipmentCategory.STRUCTURAL]: {
+    label: 'Structural',
+    badgeVariant: 'lime',
+    slotBg: 'bg-lime-700',
+    slotBorder: 'border-lime-800',
+    slotText: 'text-white',
+    slotHoverBg: 'hover:bg-lime-600',
+    indicatorBg: 'bg-lime-500',
+  },
+
+  [EquipmentCategory.MISC_EQUIPMENT]: {
+    label: 'Misc',
+    badgeVariant: 'slate',
+    slotBg: 'bg-slate-700',
+    slotBorder: 'border-slate-800',
+    slotText: 'text-white',
+    slotHoverBg: 'hover:bg-slate-600',
+    indicatorBg: 'bg-slate-500',
+  },
+};

--- a/src/utils/techBaseValidation.helpers.ts
+++ b/src/utils/techBaseValidation.helpers.ts
@@ -2,13 +2,12 @@ import { ISelectionMemory } from '@/stores/unitState';
 import { TechBaseComponent } from '@/types/construction/TechBaseConfiguration';
 import { TechBase } from '@/types/enums/TechBase';
 
-import type {
-  ComponentSelections,
-  ComponentValidator,
-} from './techBaseValidation';
-
-import { COMPONENT_VALIDATORS } from './techBaseValidation';
 import { COMPONENT_AFFECTED_SELECTIONS } from './techBaseValidation.mapping';
+import {
+  COMPONENT_VALIDATORS,
+  type ComponentSelections,
+  type ComponentValidator,
+} from './techBaseValidation.types';
 
 export function getValueWithMemory<T>(
   validator: ComponentValidator<T>,

--- a/src/utils/techBaseValidation.mapping.ts
+++ b/src/utils/techBaseValidation.mapping.ts
@@ -1,6 +1,6 @@
 import { TechBaseComponent } from '@/types/construction/TechBaseConfiguration';
 
-import type { ComponentSelections } from './techBaseValidation';
+import type { ComponentSelections } from './techBaseValidation.types';
 
 export const COMPONENT_AFFECTED_SELECTIONS: Record<
   TechBaseComponent,

--- a/src/utils/techBaseValidation.ts
+++ b/src/utils/techBaseValidation.ts
@@ -1,98 +1,42 @@
 /**
- * Tech Base Validation Utilities
+ * Tech Base Validation Utilities - Public Aggregator
  *
- * Abstracted validation system for component selections based on tech base.
- * Uses a registry pattern to make it easy to add new component types.
+ * High-level entry point used by stores and UI code. Re-exports the
+ * shared types, the validator registry, and the helper functions, and
+ * provides the orchestrating `getFullyValidatedSelections` function
+ * plus the per-component getValidTypes/isValid/getDefault aliases.
+ *
+ * The shared interfaces and the COMPONENT_VALIDATORS registry live in
+ * `techBaseValidation.types.ts`. The selection-update helpers live in
+ * `techBaseValidation.helpers.ts`. The component-to-affected-selection
+ * mapping lives in `techBaseValidation.mapping.ts`. None of those may
+ * import from this file or a 3-way cycle returns.
  *
  * @spec openspec/specs/component-configuration/spec.md
  * @spec openspec/specs/tech-base-integration/spec.md
  */
 
 import { ISelectionMemory } from '@/stores/unitState';
-import { ArmorTypeEnum } from '@/types/construction/ArmorType';
-import { CockpitType } from '@/types/construction/CockpitType';
-import { EngineType } from '@/types/construction/EngineType';
-import { GyroType } from '@/types/construction/GyroType';
-import { HeatSinkType } from '@/types/construction/HeatSinkType';
-import { InternalStructureType } from '@/types/construction/InternalStructureType';
 import { IComponentTechBases } from '@/types/construction/TechBaseConfiguration';
 import { TechBase } from '@/types/enums/TechBase';
 
-import {
-  filterEngineTypes,
-  filterGyroTypes,
-  filterStructureTypes,
-  filterCockpitTypes,
-  filterHeatSinkTypes,
-  filterArmorTypes,
-} from './techBaseValidation.filters';
 import { getValueWithMemory } from './techBaseValidation.helpers';
+import {
+  COMPONENT_VALIDATORS,
+  type ComponentSelections,
+} from './techBaseValidation.types';
+
+// Re-export shared types/registry so existing consumers keep working.
+export {
+  COMPONENT_VALIDATORS,
+  type ComponentSelections,
+  type ComponentValidator,
+} from './techBaseValidation.types';
 
 export {
   getValidatedSelectionUpdates,
   getSelectionWithMemory,
 } from './techBaseValidation.helpers';
-
-// =============================================================================
-// Component Selections Interface
-// =============================================================================
-
-export interface ComponentSelections {
-  engineType: EngineType;
-  gyroType: GyroType;
-  internalStructureType: InternalStructureType;
-  cockpitType: CockpitType;
-  heatSinkType: HeatSinkType;
-  armorType: ArmorTypeEnum;
-}
-
-// =============================================================================
-// Component Validator Interface
-// =============================================================================
-
-export interface ComponentValidator<T> {
-  getValidTypes: (techBase: TechBase) => T[];
-  isValid: (value: T, techBase: TechBase) => boolean;
-  getDefault: (techBase: TechBase) => T;
-  fallbackDefault: T;
-}
-
-/**
- * Create a validator for a component type
- */
-function createValidator<T>(
-  filterFn: (techBase: TechBase) => T[],
-  fallbackDefault: T,
-): ComponentValidator<T> {
-  return {
-    getValidTypes: filterFn,
-    isValid: (value: T, techBase: TechBase) =>
-      filterFn(techBase).includes(value),
-    getDefault: (techBase: TechBase) =>
-      filterFn(techBase)[0] ?? fallbackDefault,
-    fallbackDefault,
-  };
-}
-
-// =============================================================================
-// Component Validators Registry
-// =============================================================================
-
-/**
- * Registry of all component validators
- * Add new component types here to integrate them into the validation system
- */
-export const COMPONENT_VALIDATORS = {
-  engine: createValidator(filterEngineTypes, EngineType.STANDARD),
-  gyro: createValidator(filterGyroTypes, GyroType.STANDARD),
-  structure: createValidator(
-    filterStructureTypes,
-    InternalStructureType.STANDARD,
-  ),
-  cockpit: createValidator(filterCockpitTypes, CockpitType.STANDARD),
-  heatSink: createValidator(filterHeatSinkTypes, HeatSinkType.SINGLE),
-  armor: createValidator(filterArmorTypes, ArmorTypeEnum.STANDARD),
-} as const;
 
 // =============================================================================
 // Public API - Generic Functions

--- a/src/utils/techBaseValidation.types.ts
+++ b/src/utils/techBaseValidation.types.ts
@@ -1,0 +1,95 @@
+/**
+ * Tech Base Validation - Shared Types & Validator Registry
+ *
+ * Leaf module that defines the public selection shape, the
+ * `ComponentValidator<T>` contract, the `createValidator` factory,
+ * and the `COMPONENT_VALIDATORS` registry. Both `techBaseValidation.helpers.ts`
+ * and `techBaseValidation.mapping.ts` depend on this module instead of
+ * the orchestrator (`techBaseValidation.ts`), which previously formed
+ * a 3-way cycle: orchestrator <-> helpers <-> mapping <-> orchestrator.
+ *
+ * This file must not import from `./techBaseValidation`,
+ * `./techBaseValidation.helpers`, or `./techBaseValidation.mapping` —
+ * it is a leaf.
+ *
+ * @spec openspec/specs/component-configuration/spec.md
+ * @spec openspec/specs/tech-base-integration/spec.md
+ */
+
+import { ArmorTypeEnum } from '@/types/construction/ArmorType';
+import { CockpitType } from '@/types/construction/CockpitType';
+import { EngineType } from '@/types/construction/EngineType';
+import { GyroType } from '@/types/construction/GyroType';
+import { HeatSinkType } from '@/types/construction/HeatSinkType';
+import { InternalStructureType } from '@/types/construction/InternalStructureType';
+import { TechBase } from '@/types/enums/TechBase';
+
+import {
+  filterArmorTypes,
+  filterCockpitTypes,
+  filterEngineTypes,
+  filterGyroTypes,
+  filterHeatSinkTypes,
+  filterStructureTypes,
+} from './techBaseValidation.filters';
+
+// =============================================================================
+// Component Selections Interface
+// =============================================================================
+
+export interface ComponentSelections {
+  engineType: EngineType;
+  gyroType: GyroType;
+  internalStructureType: InternalStructureType;
+  cockpitType: CockpitType;
+  heatSinkType: HeatSinkType;
+  armorType: ArmorTypeEnum;
+}
+
+// =============================================================================
+// Component Validator Interface
+// =============================================================================
+
+export interface ComponentValidator<T> {
+  getValidTypes: (techBase: TechBase) => T[];
+  isValid: (value: T, techBase: TechBase) => boolean;
+  getDefault: (techBase: TechBase) => T;
+  fallbackDefault: T;
+}
+
+/**
+ * Create a validator for a component type
+ */
+function createValidator<T>(
+  filterFn: (techBase: TechBase) => T[],
+  fallbackDefault: T,
+): ComponentValidator<T> {
+  return {
+    getValidTypes: filterFn,
+    isValid: (value: T, techBase: TechBase) =>
+      filterFn(techBase).includes(value),
+    getDefault: (techBase: TechBase) =>
+      filterFn(techBase)[0] ?? fallbackDefault,
+    fallbackDefault,
+  };
+}
+
+// =============================================================================
+// Component Validators Registry
+// =============================================================================
+
+/**
+ * Registry of all component validators
+ * Add new component types here to integrate them into the validation system
+ */
+export const COMPONENT_VALIDATORS = {
+  engine: createValidator(filterEngineTypes, EngineType.STANDARD),
+  gyro: createValidator(filterGyroTypes, GyroType.STANDARD),
+  structure: createValidator(
+    filterStructureTypes,
+    InternalStructureType.STANDARD,
+  ),
+  cockpit: createValidator(filterCockpitTypes, CockpitType.STANDARD),
+  heatSink: createValidator(filterHeatSinkTypes, HeatSinkType.SINGLE),
+  armor: createValidator(filterArmorTypes, ArmorTypeEnum.STANDARD),
+} as const;


### PR DESCRIPTION
## Summary

PR-B1 of the circular-dependency cleanup wave. Closes 3 over-decomposed-split cycles in `src/utils/` by extracting shared types and registries into leaf modules. No behavior change, no public API change.

## Cycles closed

| # | Cycle | Strategy |
|---|-------|----------|
| 1 | `equipmentColors.ammo.ts` ↔ `equipmentColors.ts` | Extract `EQUIPMENT_CATEGORY_COLORS` + `CategoryColorDefinition` into new leaf `equipmentColors.types.ts` |
| 2 | `equipmentColors.ts` ↔ `equipmentColors.legacy.ts` | Same leaf extraction (one-shot fix for #1 + #2) |
| 3 | 3-way: `techBaseValidation.helpers.ts` ↔ `techBaseValidation.mapping.ts` ↔ `techBaseValidation.ts` | Extract `ComponentSelections`, `ComponentValidator`, `createValidator`, `COMPONENT_VALIDATORS` into new leaf `techBaseValidation.types.ts` |

In each case the orchestrator (`equipmentColors.ts`, `techBaseValidation.ts`) re-exports the moved symbols for backward compatibility, so external consumers (other utils, components, stores, tests) compile unchanged.

## madge before / after (cycles in `src/utils/`)

**Before** (`npx madge --circular --extensions ts,tsx src/utils/`):
```
✖ Found 5 circular dependencies!

1) colors/equipmentColors.ammo.ts > colors/equipmentColors.ts
2) colors/equipmentColors.ts > colors/equipmentColors.legacy.ts
3) construction/aerospace/bombBays.ts > construction/aerospace/validationRules.ts
4) construction/aerospace/validationRules.ts > construction/aerospace/wingHeavyWeapons.ts
5) techBaseValidation.helpers.ts > techBaseValidation.mapping.ts > techBaseValidation.ts
```

**After**:
```
✖ Found 2 circular dependencies!

1) construction/aerospace/bombBays.ts > construction/aerospace/validationRules.ts
2) construction/aerospace/validationRules.ts > construction/aerospace/wingHeavyWeapons.ts
```

The 3 cycles in scope (1, 2, 5 in the baseline list) are gone. The 2 remaining aerospace cycles are pre-existing and out of scope for this PR (separate cleanup).

## Files

- New: `src/utils/colors/equipmentColors.types.ts` (leaf — type + category map)
- New: `src/utils/techBaseValidation.types.ts` (leaf — selections interface, validator interface, factory, registry)
- Modified: `src/utils/colors/equipmentColors.ts`, `equipmentColors.ammo.ts`, `equipmentColors.legacy.ts`
- Modified: `src/utils/techBaseValidation.ts`, `techBaseValidation.helpers.ts`, `techBaseValidation.mapping.ts`

Naming: chose `.types.ts` because the codebase already uses that suffix in 15 places (e.g. `MechSilhouette.types.ts`, `useForceStore.types.ts`); no `.shared.ts` files exist.

## Verification (local)

| Check | Result |
|-------|--------|
| `npx madge --circular --extensions ts,tsx src/utils/` | 5 -> 2 cycles (3 target cycles closed) |
| `npx tsc --noEmit --skipLibCheck` | 0 errors |
| `npx oxlint` | 0 errors, 31 pre-existing warnings |
| `npx oxfmt --check src/utils/` | clean |
| `npx jest src/__tests__/{unit,}/utils/{colors,techBaseValidation,construction/techBaseValidation}` | 208/208 pass (8 suites) |
| Pre-commit Husky hook (build + lint-staged) | passed on both commits |

## Behavior change

Zero. Public exports from `@/utils/colors/equipmentColors` and `@/utils/techBaseValidation` are byte-identical to before. Imports in tests, stores, and components are untouched.

## Test plan

- [x] `npx madge --circular --extensions ts,tsx src/utils/` shows 2 cycles only (both pre-existing aerospace)
- [x] `npx tsc --noEmit --skipLibCheck` exits 0
- [x] `npx oxlint` clean
- [x] `npx oxfmt --check` clean
- [x] All `colors/*` + `techBaseValidation*` tests pass (208/208)
- [x] Husky pre-commit (build + lint-staged) passes on both commits
- [ ] CI green