### PR TITLE
chore(deps): break MTFParser components/helpers cycle

### DIFF
--- a/src/services/conversion/MTFParser.components.ts
+++ b/src/services/conversion/MTFParser.components.ts
@@ -1,4 +1,4 @@
-import { parseField } from './MTFParserHelpers';
+import { parseField } from './MTFParser.types';
 
 export function parseEngine(lines: string[]): { type: string; rating: number } {
   const engineLine = parseField(lines, 'engine');

--- a/src/services/conversion/MTFParser.types.ts
+++ b/src/services/conversion/MTFParser.types.ts
@@ -1,0 +1,32 @@
+/**
+ * MTF Parser - Shared Leaf Module
+ *
+ * Leaf module that hosts the low-level `parseField` primitive consumed by
+ * both `MTFParser.components.ts` and `MTFParserHelpers.ts`. Previously
+ * `MTFParser.components.ts` imported `parseField` from
+ * `MTFParserHelpers.ts`, which re-exported the components from
+ * `MTFParser.components.ts` — a 2-way cycle.
+ *
+ * This file must not import from `./MTFParser.components` or
+ * `./MTFParserHelpers` — it is a leaf.
+ */
+
+/**
+ * Parse a field by its case-insensitive name from a list of MTF lines.
+ *
+ * Matches the `^<fieldName>:(.*)$` pattern and returns the trimmed value,
+ * or `undefined` if the field is absent.
+ */
+export function parseField(
+  lines: string[],
+  fieldName: string,
+): string | undefined {
+  const pattern = new RegExp(`^${fieldName}:(.*)$`, 'i');
+  for (const line of lines) {
+    const match = line.match(pattern);
+    if (match) {
+      return match[1].trim();
+    }
+  }
+  return undefined;
+}

--- a/src/services/conversion/MTFParserHelpers.ts
+++ b/src/services/conversion/MTFParserHelpers.ts
@@ -1,6 +1,7 @@
 import { ISerializedFluff } from '@/types/unit/UnitSerialization';
 
 import { normalizeEquipmentId, normalizeLocation } from './MTFParser.mapping';
+import { parseField } from './MTFParser.types';
 
 export {
   parseEngine,
@@ -18,6 +19,7 @@ export {
   normalizeLocation,
   generateUnitId,
 } from './MTFParser.mapping';
+export { parseField } from './MTFParser.types';
 
 const LOCATION_HEADERS: Record<string, string> = {
   'Left Arm:': 'LEFT_ARM',
@@ -64,20 +66,6 @@ export interface ParsedMTFHeader {
   clanname?: string;
   isOmni: boolean;
   baseChassisHeatSinks?: number;
-}
-
-export function parseField(
-  lines: string[],
-  fieldName: string,
-): string | undefined {
-  const pattern = new RegExp(`^${fieldName}:(.*)$`, 'i');
-  for (const line of lines) {
-    const match = line.match(pattern);
-    if (match) {
-      return match[1].trim();
-    }
-  }
-  return undefined;
 }
 
 export function parseHeader(lines: string[]): ParsedMTFHeader {


### PR DESCRIPTION
## Summary

Closes circular dependency #6 (`MTFParser.components.ts` <-> `MTFParserHelpers.ts`) by extracting the shared `parseField` primitive to a new leaf module `MTFParser.types.ts` that both halves import.

Pattern: over-decomposed split (Pattern 1 in the cleanup plan). Same mechanical fix that landed in #420 (utils/colors, techBaseValidation) and #419 (services repos).

## Why

Unblocks the schema-bridge effort (PR-A1) which will edit adjacent conversion files. Cleans up one of 21 cycles surfaced by `/maintain`.

## What changed

- **New leaf**: `src/services/conversion/MTFParser.types.ts` — exports `parseField`. No imports from sibling files.
- **MTFParser.components.ts**: removed local `parseField`, now imports from `./MTFParser.types`.
- **MTFParserHelpers.ts**: removed local `parseField`, now imports from `./MTFParser.types`. Re-exports `parseField` for backward compat with any external callers.

Public API unchanged — anything that previously imported `parseField` from `MTFParserHelpers` still works.

## Madge cycle count

| | Before | After |
|---|---|---|
| Cycles in `src/services/conversion/` | 2 | 1 |
| MTFParser cycle (#6) | yes | **closed** |
| BlkExportServiceCore cycle (#5) | yes | yes (deferred to PR-B6 — overlaps schema bridge surface) |

## Test plan

- [x] `npx madge --circular --extensions ts,tsx src/services/conversion/` — only #5 remains
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest src/services/conversion` — 13 suites, 715/715 pass
- [x] Husky pre-commit (full Next build + lint-staged + tsc) — passed without `--no-verify`