### PR TITLE
refactor(handlers): align JumpShip/SpaceStation imports with WarShip

### DIFF
--- a/src/services/units/handlers/JumpShipUnitHandler.calculations.ts
+++ b/src/services/units/handlers/JumpShipUnitHandler.calculations.ts
@@ -1,4 +1,4 @@
-import { IJumpShip } from './JumpShipUnitHandler';
+import type { IJumpShip } from './JumpShipUnitHandler.types';
 
 export function validateJumpShip(unit: IJumpShip): {
   errors: string[];

--- a/src/services/units/handlers/JumpShipUnitHandler.helpers.ts
+++ b/src/services/units/handlers/JumpShipUnitHandler.helpers.ts
@@ -9,7 +9,7 @@ import {
   CapitalArc,
 } from '@/types/unit/CapitalShipInterfaces';
 
-import { IJumpShip } from './JumpShipUnitHandler';
+import type { IJumpShip } from './JumpShipUnitHandler.types';
 
 const ARC_MAP: Record<string, CapitalArc> = {
   nose: CapitalArc.NOSE,

--- a/src/services/units/handlers/JumpShipUnitHandler.ts
+++ b/src/services/units/handlers/JumpShipUnitHandler.ts
@@ -14,16 +14,11 @@ import {
   AerospaceMotionType,
   IAerospaceMovement,
 } from '@/types/unit/BaseUnitInterfaces';
-import { IBaseUnit } from '@/types/unit/BaseUnitInterfaces';
 import { UnitType } from '@/types/unit/BattleMechInterfaces';
-import {
-  ICapitalMountedEquipment,
-  ITransportBay,
-  ICrewQuarters,
-  ICapitalCrewConfiguration,
-} from '@/types/unit/CapitalShipInterfaces';
 import { ISerializedUnit } from '@/types/unit/UnitSerialization';
 import { IUnitParseResult } from '@/types/unit/UnitTypeHandler';
+
+import type { IJumpShip } from './JumpShipUnitHandler.types';
 
 import {
   AbstractUnitTypeHandler,
@@ -45,49 +40,12 @@ import {
   getBooleanFromRaw,
 } from './JumpShipUnitHandler.helpers';
 
-// ============================================================================
-// JumpShip Interface
-// ============================================================================
-
-/**
- * JumpShip unit interface
- */
-export interface IJumpShip extends IBaseUnit {
-  readonly unitType: UnitType.JUMPSHIP;
-  readonly motionType: AerospaceMotionType;
-  readonly movement: IAerospaceMovement;
-  readonly fuel: number;
-  readonly structuralIntegrity: number;
-  readonly heatSinks: number;
-  readonly heatSinkType: number;
-  readonly engineType: number;
-  readonly armorType: number;
-  readonly armor: readonly number[];
-  readonly armorByArc: {
-    readonly nose: number;
-    readonly frontLeftSide: number;
-    readonly frontRightSide: number;
-    readonly aftLeftSide: number;
-    readonly aftRightSide: number;
-    readonly aft: number;
-  };
-  readonly totalArmorPoints: number;
-  readonly kfDrive: {
-    readonly rating: number;
-    readonly integrityPoints: number;
-    readonly hasDriveCore: boolean;
-    readonly hasLithiumFusion: boolean;
-  };
-  readonly dockingCollars: number;
-  readonly crewConfiguration: ICapitalCrewConfiguration;
-  readonly transportBays: readonly ITransportBay[];
-  readonly quarters: readonly ICrewQuarters[];
-  readonly equipment: readonly ICapitalMountedEquipment[];
-  readonly escapePods: number;
-  readonly lifeBoats: number;
-  readonly gravDecks: number;
-  readonly hpg?: boolean;
-}
+// Re-export the handler-local interface so existing consumers can
+// still `import { IJumpShip } from './JumpShipUnitHandler'` (or via
+// the barrel `index.ts`). The canonical definition now lives in
+// `./JumpShipUnitHandler.types` to break the orchestrator <->
+// leaf circular import.
+export type { IJumpShip };
 
 // ============================================================================
 // JumpShip Unit Handler

--- a/src/services/units/handlers/JumpShipUnitHandler.types.ts
+++ b/src/services/units/handlers/JumpShipUnitHandler.types.ts
@@ -1,0 +1,74 @@
+/**
+ * JumpShip Unit Handler - Types
+ *
+ * Type definitions for the JumpShip handler triplet. Lives as a leaf
+ * module so `.calculations.ts` and `.helpers.ts` can reference these
+ * types without back-importing from the orchestrator (which would
+ * create a circular dependency).
+ *
+ * Mirrors the WarShip handler's topology, where types live in
+ * `@/types/unit/CapitalShipInterfaces` and the leaves never import
+ * from the orchestrator.
+ *
+ * @see openspec/changes/add-multi-unit-type-support/tasks.md
+ */
+
+import {
+  AerospaceMotionType,
+  IAerospaceMovement,
+  IBaseUnit,
+} from '@/types/unit/BaseUnitInterfaces';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+import {
+  ICapitalMountedEquipment,
+  ITransportBay,
+  ICrewQuarters,
+  ICapitalCrewConfiguration,
+} from '@/types/unit/CapitalShipInterfaces';
+
+/**
+ * JumpShip unit interface used by the JumpShip handler triplet.
+ *
+ * NOTE: this is the handler-local shape, distinct from the canonical
+ * `IJumpShip` in `@/types/unit/CapitalShipInterfaces` which extends
+ * `IAerospaceUnit` and uses a different K-F drive shape. The two
+ * shapes have lived side-by-side; this file only relocates the
+ * handler-local definition to break a circular import — it does not
+ * unify the shapes.
+ */
+export interface IJumpShip extends IBaseUnit {
+  readonly unitType: UnitType.JUMPSHIP;
+  readonly motionType: AerospaceMotionType;
+  readonly movement: IAerospaceMovement;
+  readonly fuel: number;
+  readonly structuralIntegrity: number;
+  readonly heatSinks: number;
+  readonly heatSinkType: number;
+  readonly engineType: number;
+  readonly armorType: number;
+  readonly armor: readonly number[];
+  readonly armorByArc: {
+    readonly nose: number;
+    readonly frontLeftSide: number;
+    readonly frontRightSide: number;
+    readonly aftLeftSide: number;
+    readonly aftRightSide: number;
+    readonly aft: number;
+  };
+  readonly totalArmorPoints: number;
+  readonly kfDrive: {
+    readonly rating: number;
+    readonly integrityPoints: number;
+    readonly hasDriveCore: boolean;
+    readonly hasLithiumFusion: boolean;
+  };
+  readonly dockingCollars: number;
+  readonly crewConfiguration: ICapitalCrewConfiguration;
+  readonly transportBays: readonly ITransportBay[];
+  readonly quarters: readonly ICrewQuarters[];
+  readonly equipment: readonly ICapitalMountedEquipment[];
+  readonly escapePods: number;
+  readonly lifeBoats: number;
+  readonly gravDecks: number;
+  readonly hpg?: boolean;
+}

--- a/src/services/units/handlers/SpaceStationUnitHandler.calculations.ts
+++ b/src/services/units/handlers/SpaceStationUnitHandler.calculations.ts
@@ -4,7 +4,7 @@
  * BV and cost calculation methods.
  */
 
-import { ISpaceStation } from './SpaceStationUnitHandler';
+import type { ISpaceStation } from './SpaceStationUnitHandler.types';
 
 /**
  * Calculate Space Station BV

--- a/src/services/units/handlers/SpaceStationUnitHandler.helpers.ts
+++ b/src/services/units/handlers/SpaceStationUnitHandler.helpers.ts
@@ -15,7 +15,7 @@ import {
   CapitalArc,
 } from '@/types/unit/CapitalShipInterfaces';
 
-import { SpaceStationType } from './SpaceStationUnitHandler';
+import { SpaceStationType } from './SpaceStationUnitHandler.types';
 
 /**
  * Map location strings to CapitalArc enum

--- a/src/services/units/handlers/SpaceStationUnitHandler.ts
+++ b/src/services/units/handlers/SpaceStationUnitHandler.ts
@@ -14,16 +14,11 @@ import {
   AerospaceMotionType,
   IAerospaceMovement,
 } from '@/types/unit/BaseUnitInterfaces';
-import { IBaseUnit } from '@/types/unit/BaseUnitInterfaces';
 import { UnitType } from '@/types/unit/BattleMechInterfaces';
-import {
-  ICapitalMountedEquipment,
-  ITransportBay,
-  ICrewQuarters,
-  ICapitalCrewConfiguration,
-} from '@/types/unit/CapitalShipInterfaces';
 import { ISerializedUnit } from '@/types/unit/UnitSerialization';
 import { IUnitParseResult } from '@/types/unit/UnitTypeHandler';
+
+import type { ISpaceStation } from './SpaceStationUnitHandler.types';
 
 import {
   AbstractUnitTypeHandler,
@@ -44,58 +39,15 @@ import {
   parseNumericRaw,
   getBooleanFromRaw,
 } from './SpaceStationUnitHandler.helpers';
+import { SpaceStationType } from './SpaceStationUnitHandler.types';
 
-// ============================================================================
-// Space Station Interface
-// ============================================================================
-
-/**
- * Space station type
- */
-export enum SpaceStationType {
-  ORBITAL = 'Orbital',
-  DEEP_SPACE = 'Deep Space',
-  RECHARGE_STATION = 'Recharge Station',
-  SHIPYARD = 'Shipyard',
-  HABITAT = 'Habitat',
-  MILITARY = 'Military',
-}
-
-/**
- * Space Station unit interface
- */
-export interface ISpaceStation extends IBaseUnit {
-  readonly unitType: UnitType.SPACE_STATION;
-  readonly motionType: AerospaceMotionType.SPHEROID;
-  readonly stationType: SpaceStationType;
-  readonly movement: IAerospaceMovement;
-  readonly fuel: number;
-  readonly structuralIntegrity: number;
-  readonly heatSinks: number;
-  readonly heatSinkType: number;
-  readonly armorType: number;
-  readonly armor: readonly number[];
-  readonly armorByArc: {
-    readonly nose: number;
-    readonly frontLeftSide: number;
-    readonly frontRightSide: number;
-    readonly aftLeftSide: number;
-    readonly aftRightSide: number;
-    readonly aft: number;
-  };
-  readonly totalArmorPoints: number;
-  readonly dockingCollars: number;
-  readonly gravDecks: number;
-  readonly crewConfiguration: ICapitalCrewConfiguration;
-  readonly transportBays: readonly ITransportBay[];
-  readonly quarters: readonly ICrewQuarters[];
-  readonly equipment: readonly ICapitalMountedEquipment[];
-  readonly escapePods: number;
-  readonly lifeBoats: number;
-  readonly hasHPG: boolean;
-  readonly hasKFDrive: boolean;
-  readonly pressurizedModules: number;
-}
+// Re-export the handler-local interface and station-type enum so
+// existing consumers can still import them from this module (or via
+// the barrel `index.ts`). The canonical definitions now live in
+// `./SpaceStationUnitHandler.types` to break the orchestrator <->
+// leaf circular import.
+export { SpaceStationType };
+export type { ISpaceStation };
 
 // ============================================================================
 // Space Station Unit Handler

--- a/src/services/units/handlers/SpaceStationUnitHandler.types.ts
+++ b/src/services/units/handlers/SpaceStationUnitHandler.types.ts
@@ -1,0 +1,81 @@
+/**
+ * Space Station Unit Handler - Types
+ *
+ * Type definitions for the SpaceStation handler triplet. Lives as a
+ * leaf module so `.calculations.ts` and `.helpers.ts` can reference
+ * these types without back-importing from the orchestrator (which
+ * would create a circular dependency).
+ *
+ * Mirrors the WarShip handler's topology, where types live in
+ * `@/types/unit/CapitalShipInterfaces` and the leaves never import
+ * from the orchestrator.
+ *
+ * @see openspec/changes/add-multi-unit-type-support/tasks.md
+ */
+
+import {
+  AerospaceMotionType,
+  IAerospaceMovement,
+  IBaseUnit,
+} from '@/types/unit/BaseUnitInterfaces';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+import {
+  ICapitalMountedEquipment,
+  ITransportBay,
+  ICrewQuarters,
+  ICapitalCrewConfiguration,
+} from '@/types/unit/CapitalShipInterfaces';
+
+/**
+ * Space station type
+ */
+export enum SpaceStationType {
+  ORBITAL = 'Orbital',
+  DEEP_SPACE = 'Deep Space',
+  RECHARGE_STATION = 'Recharge Station',
+  SHIPYARD = 'Shipyard',
+  HABITAT = 'Habitat',
+  MILITARY = 'Military',
+}
+
+/**
+ * Space Station unit interface used by the SpaceStation handler triplet.
+ *
+ * NOTE: this is the handler-local shape, distinct from the canonical
+ * `ISpaceStation` in `@/types/unit/CapitalShipInterfaces` which extends
+ * `IAerospaceUnit`. The two shapes have lived side-by-side; this file
+ * only relocates the handler-local definition to break a circular
+ * import — it does not unify the shapes.
+ */
+export interface ISpaceStation extends IBaseUnit {
+  readonly unitType: UnitType.SPACE_STATION;
+  readonly motionType: AerospaceMotionType.SPHEROID;
+  readonly stationType: SpaceStationType;
+  readonly movement: IAerospaceMovement;
+  readonly fuel: number;
+  readonly structuralIntegrity: number;
+  readonly heatSinks: number;
+  readonly heatSinkType: number;
+  readonly armorType: number;
+  readonly armor: readonly number[];
+  readonly armorByArc: {
+    readonly nose: number;
+    readonly frontLeftSide: number;
+    readonly frontRightSide: number;
+    readonly aftLeftSide: number;
+    readonly aftRightSide: number;
+    readonly aft: number;
+  };
+  readonly totalArmorPoints: number;
+  readonly dockingCollars: number;
+  readonly gravDecks: number;
+  readonly crewConfiguration: ICapitalCrewConfiguration;
+  readonly transportBays: readonly ITransportBay[];
+  readonly quarters: readonly ICrewQuarters[];
+  readonly equipment: readonly ICapitalMountedEquipment[];
+  readonly escapePods: number;
+  readonly lifeBoats: number;
+  readonly hasHPG: boolean;
+  readonly hasKFDrive: boolean;
+  readonly pressurizedModules: number;
+}


### PR DESCRIPTION
## Summary

Closes 4 circular dependencies in `src/services/units/handlers/` by aligning the JumpShip and SpaceStation handler triplets with WarShip's import topology.

The 4 cycles closed (madge IDs #9-#12 from the maintenance sweep):

1. `JumpShipUnitHandler.calculations.ts` <-> `JumpShipUnitHandler.ts`
2. `JumpShipUnitHandler.helpers.ts` <-> `JumpShipUnitHandler.ts`
3. `SpaceStationUnitHandler.calculations.ts` <-> `SpaceStationUnitHandler.ts`
4. `SpaceStationUnitHandler.helpers.ts` <-> `SpaceStationUnitHandler.ts`

## WarShip is the reference topology

WarShip's `IWarShip` interface lives in `@/types/unit/CapitalShipInterfaces.ts`, so its `.calculations.ts` and `.helpers.ts` leaves never need to back-import the orchestrator. JumpShip and SpaceStation, however, defined their handler-local interfaces (`IJumpShip`, `ISpaceStation`, plus the `SpaceStationType` enum) inside the orchestrator file and the leaves imported them back, forming the cycle.

NOTE: The handler-local `IJumpShip` / `ISpaceStation` shapes differ from the canonical `IJumpShip` / `ISpaceStation` already in `CapitalShipInterfaces.ts` (canonical extends `IAerospaceUnit`; handler-local extends `IBaseUnit`, with a different K-F drive shape). To preserve behaviour exactly we did NOT unify with the canonical types — we only relocated the handler-local shapes to a new sibling leaf module:

- `src/services/units/handlers/JumpShipUnitHandler.types.ts` (new) — contains `IJumpShip`
- `src/services/units/handlers/SpaceStationUnitHandler.types.ts` (new) — contains `ISpaceStation` and `SpaceStationType`

## Before / after import topology

Before (cyclic):

```
JumpShipUnitHandler.ts ──defines IJumpShip──┐
       │   ▲                                 │
       │   │                                 ▼
       │   └─ imports IJumpShip ── JumpShipUnitHandler.calculations.ts
       │   ┌─ imports IJumpShip ── JumpShipUnitHandler.helpers.ts
       │   │
       └───┘
```

After (acyclic, mirrors WarShip):

```
JumpShipUnitHandler.types.ts ──defines IJumpShip
       ▲          ▲          ▲
       │          │          │
       │          │          └─ JumpShipUnitHandler.helpers.ts
       │          └─ JumpShipUnitHandler.calculations.ts
       └─ JumpShipUnitHandler.ts (also re-exports IJumpShip for back-compat)
```

(Same shape applied to SpaceStation triplet, with the additional move of the `SpaceStationType` enum.)

## Public API preserved

The orchestrator files `JumpShipUnitHandler.ts` and `SpaceStationUnitHandler.ts` re-export `IJumpShip`, `ISpaceStation`, and `SpaceStationType` so that existing consumers — including the `index.ts` barrel and the test files at `src/services/units/handlers/__tests__/SpaceStationUnitHandler.test.ts` — compile unchanged. No callsite outside this PR was modified.

## Madge before/after

```
Before:
$ npx madge --circular --extensions ts,tsx src/services/units/handlers/
Processed 75 files (1s) (20 warnings)
✖ Found 4 circular dependencies!

1) JumpShipUnitHandler.calculations.ts > JumpShipUnitHandler.ts
2) JumpShipUnitHandler.ts > JumpShipUnitHandler.helpers.ts
3) SpaceStationUnitHandler.calculations.ts > SpaceStationUnitHandler.ts
4) SpaceStationUnitHandler.ts > SpaceStationUnitHandler.helpers.ts

After:
$ npx madge --circular --extensions ts,tsx src/services/units/handlers/
Processed 77 files (907ms) (20 warnings)
✔ No circular dependency found!
```

## BV parity attestation

`scripts/validate-bv.ts` was run before and after the refactor. The per-unit BV result file `validation-output/bv-all-results.json` is **byte-identical** pre/post-refactor:

```
$ diff -q /tmp/bv-results-before.json /tmp/bv-results-after.json
(no output — files identical)
```

- 0 BV deltas across all units.
- All accuracy gates still pass (98.3% within 1%, 99.4% within 2%, 99.7% within 3% on the active validation set of 4225 units).

This refactor is a pure import topology change — no calculation, no parser, no mutation logic was modified.

## Verification

| Gate | Result |
|------|--------|
| `npx madge --circular` on `src/services/units/handlers/` | 0 cycles (was 4) |
| `npm run typecheck` | clean |
| `npx oxlint src/services/units/handlers/` | 0 warnings, 0 errors |
| `npm run format:check` | all files clean |
| `npx jest src/services/units/handlers` | 14 suites passed, 836 tests passed |
| `npx tsx scripts/validate-bv.ts` | identical to pre-refactor (0 deltas) |
| Pre-commit hook (full `next build`) | passed on both commits |

## Test plan

- [x] Madge shows 0 circular dependencies in `src/services/units/handlers/`
- [x] All 836 handler tests still pass
- [x] BV calculator output is byte-identical pre/post-refactor (0 unit deltas)
- [x] `IJumpShip`, `ISpaceStation`, `SpaceStationType` still importable from their original module paths
- [x] Build succeeds