### PR TITLE
feat(schema-bridge): weapon shape pilot + Python/TS validation infrastructure

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -175,11 +175,71 @@ jobs:
       - name: Build Storybook
         run: npm run storybook:build
 
+  # ---------------------------------------------------------------
+  # schema-bridge gates the cross-language schema contract:
+  #   1. Generated Zod matches the canonical JSON Schema source
+  #   2. Python validator passes on the corpus (PR-A1 = weapon only,
+  #      non-strict; PR-A2 will flip to --strict --shape all)
+  #   3. TypeScript round-trip Jest tests pass for the weapon shape
+  # The job runs in parallel after install-deps and is included in
+  # the `lint-and-test` aggregator so branch protection picks it up.
+  # ---------------------------------------------------------------
+  schema-bridge:
+    name: Schema Bridge
+    needs: install-deps
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node + caches + install deps
+        uses: ./.github/actions/setup-node-and-install
+        with:
+          node-version: '20'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python schema-bridge deps
+        run: pip install jsonschema
+
+      - name: Verify generated Zod matches JSON Schema
+        run: npm run schema:gen-check
+
+      - name: Validate weapon corpus (non-blocking in PR-A1)
+        # PR-A1 corpus has 6 X-Pulse / VSP entries missing costCBills.
+        # PR-A2 fixes the data and adds --strict here.
+        run: python scripts/megameklab-conversion/run_schema_validation_only.py --shape weapon
+
+      - name: Run weapon round-trip Jest tests
+        run: npx jest src/types/contracts --ci --no-coverage
+
+      - name: Upload schema-bridge report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: schema-bridge-report
+          path: validation-output/schema-bridge-report.json
+          retention-days: 7
+
   # Aggregator that preserves the "Lint and Test" required-check name
   # from before the fan-out. Passes only if every fan-out job passed.
   lint-and-test:
     name: Lint and Test
-    needs: [lint, format-check, typecheck, test, validate-bv, storybook-build]
+    needs:
+      [
+        lint,
+        format-check,
+        typecheck,
+        test,
+        validate-bv,
+        storybook-build,
+        schema-bridge,
+      ]
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
         "jest-axe": "^10.0.0",
         "jest-environment-jsdom": "^30.0.0",
         "jest-environment-node": "^30.0.0",
+        "json-schema-to-zod": "^2.8.1",
         "lint-staged": "^16.2.7",
         "minimatch": "^3.1.2",
         "node-mocks-http": "^1.17.2",
@@ -14849,6 +14850,16 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-zod": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-zod/-/json-schema-to-zod-2.8.1.tgz",
+      "integrity": "sha512-fRr1mHgZ7hboLKBUdR428gd9dIHUFGivUqOeiDcSmyXkNZCtB1uGaZLvsjZ4GaN5pwBIs+TGIOf6s+Rp5/R/zA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "json-schema-to-zod": "dist/cjs/cli.js"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,8 @@
     "postinstall": "node scripts/mm-data/check-assets.js || true",
     "validate:assets": "npx tsx scripts/mm-data/validate-assets.ts",
     "validate:assets:strict": "npx tsx scripts/mm-data/validate-assets.ts --strict",
+    "schema:gen": "node scripts/generate-zod-schemas.mjs",
+    "schema:gen-check": "node scripts/generate-zod-schemas.mjs --check",
     "simulate": "npx tsx scripts/run-simulation.ts",
     "simulate:batch": "npx tsx scripts/run-simulation.ts --count=100"
   },
@@ -177,6 +179,7 @@
     "jest-axe": "^10.0.0",
     "jest-environment-jsdom": "^30.0.0",
     "jest-environment-node": "^30.0.0",
+    "json-schema-to-zod": "^2.8.1",
     "lint-staged": "^16.2.7",
     "minimatch": "^3.1.2",
     "node-mocks-http": "^1.17.2",

--- a/scripts/generate-zod-schemas.mjs
+++ b/scripts/generate-zod-schemas.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * generate-zod-schemas.mjs
+ *
+ * Phase A schema-bridge generator. Reads each equipment-shape JSON Schema
+ * under `public/data/equipment/_schema/` and emits a matching Zod module
+ * under `src/types/contracts/generated/<name>.zod.ts`.
+ *
+ * Generated files are committed and never hand-edited. The companion
+ * `--check` mode regenerates into a tmp directory and diffs against the
+ * committed output, exiting non-zero on drift. The CI `schema-bridge`
+ * job runs `--check` to gate Python writers and TS readers against the
+ * canonical JSON Schemas.
+ *
+ * In PR-A1 only the weapon shape is wired through the full pipeline
+ * (round-trip tests, loader integration). The remaining 5 shapes are
+ * generated for completeness and consumed by PR-A2.
+ *
+ * Usage:
+ *   node scripts/generate-zod-schemas.mjs           # write to src/types/contracts/generated
+ *   node scripts/generate-zod-schemas.mjs --check   # diff-only, no writes
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { jsonSchemaToZod } from 'json-schema-to-zod';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '..');
+
+const SCHEMA_DIR = join(REPO_ROOT, 'public', 'data', 'equipment', '_schema');
+const OUTPUT_DIR = join(REPO_ROOT, 'src', 'types', 'contracts', 'generated');
+
+// PR-A1 ships only the weapon shape through to consumers; the other
+// shapes still get generated so PR-A2 can wire them with a single edit
+// to the contracts barrel.
+const SHAPES = [
+  { file: 'weapon-schema.json', stem: 'weapon', exportName: 'WeaponContract' },
+  { file: 'unit-schema.json', stem: 'unit', exportName: 'UnitContract' },
+  { file: 'ammunition-schema.json', stem: 'ammunition', exportName: 'AmmunitionContract' },
+  { file: 'electronics-schema.json', stem: 'electronics', exportName: 'ElectronicsContract' },
+  { file: 'misc-equipment-schema.json', stem: 'misc-equipment', exportName: 'MiscEquipmentContract' },
+  { file: 'physical-weapon-schema.json', stem: 'physical-weapon', exportName: 'PhysicalWeaponContract' },
+];
+
+const HEADER = (sourceRel) => `// @generated — do not edit; run \`npm run schema:gen\` to regenerate.
+// Source: ${sourceRel}
+// Regeneration: \`node scripts/generate-zod-schemas.mjs\` (see \`scripts/generate-zod-schemas.mjs\`).
+//
+// PR-A1 ships only the weapon shape through round-trip tests + loader
+// validation; PR-A2 wires the rest. The schema-bridge CI job verifies
+// these files match the JSON Schema source via \`--check\` mode.
+`;
+
+function generateOne(shape) {
+  const sourcePath = join(SCHEMA_DIR, shape.file);
+  const sourceRel = `public/data/equipment/_schema/${shape.file}`;
+  const json = JSON.parse(readFileSync(sourcePath, 'utf-8'));
+  // Use ESM module output and emit a named export plus an inferred type.
+  const body = jsonSchemaToZod(json, {
+    module: 'esm',
+    name: shape.exportName,
+    type: true,
+  });
+  return HEADER(sourceRel) + '\n' + body;
+}
+
+function writeAll(targetDir) {
+  mkdirSync(targetDir, { recursive: true });
+  const written = [];
+  for (const shape of SHAPES) {
+    const out = generateOne(shape);
+    const outPath = join(targetDir, `${shape.stem}.zod.ts`);
+    writeFileSync(outPath, out, 'utf-8');
+    written.push(outPath);
+  }
+  // Run oxfmt across the freshly written files so the on-disk output
+  // matches `npm run format:check` and stays stable across re-runs.
+  // Without this, write-mode and check-mode disagree (write produces
+  // raw `json-schema-to-zod` output; check then hits a phantom drift
+  // because committed files were formatted).
+  formatFiles(written);
+  return written;
+}
+
+function formatFiles(paths) {
+  if (paths.length === 0) return;
+  // Use the local oxfmt binary. On Windows the npm shim is `oxfmt.cmd`,
+  // which `spawnSync` cannot launch directly without `shell: true`
+  // (EINVAL on Node 20+). Pass the directory so oxfmt walks recursively.
+  const isWin = process.platform === 'win32';
+  const binName = isWin ? 'oxfmt.cmd' : 'oxfmt';
+  const binPath = join(REPO_ROOT, 'node_modules', '.bin', binName);
+  // All `paths` share the same parent directory by construction.
+  const dir = dirname(paths[0]);
+  const result = spawnSync(binPath, ['--write', dir], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+    shell: isWin,
+  });
+  if (result.status !== 0) {
+    console.error('schema-bridge: oxfmt failed; output may be unformatted.');
+    process.exit(result.status ?? 1);
+  }
+}
+
+function checkMode() {
+  const tmp = join(tmpdir(), `schema-bridge-${process.pid}-${Date.now()}`);
+  mkdirSync(tmp, { recursive: true });
+  try {
+    writeAll(tmp);
+    let drift = 0;
+    for (const shape of SHAPES) {
+      const fileName = `${shape.stem}.zod.ts`;
+      const expectedPath = join(OUTPUT_DIR, fileName);
+      const actualPath = join(tmp, fileName);
+      let expected = '';
+      try {
+        expected = readFileSync(expectedPath, 'utf-8');
+      } catch {
+        console.error(`MISSING committed file: src/types/contracts/generated/${fileName}`);
+        drift++;
+        continue;
+      }
+      const actual = readFileSync(actualPath, 'utf-8');
+      if (expected !== actual) {
+        console.error(`DRIFT in src/types/contracts/generated/${fileName}`);
+        // Emit a tiny first-difference excerpt to help the CI log.
+        const eLines = expected.split('\n');
+        const aLines = actual.split('\n');
+        const max = Math.min(eLines.length, aLines.length);
+        for (let i = 0; i < max; i++) {
+          if (eLines[i] !== aLines[i]) {
+            console.error(`  line ${i + 1}:`);
+            console.error(`    committed: ${eLines[i]}`);
+            console.error(`    generated: ${aLines[i]}`);
+            break;
+          }
+        }
+        drift++;
+      }
+    }
+    if (drift > 0) {
+      console.error(
+        `\nschema-bridge: ${drift} file(s) out of sync with JSON Schema source.\n` +
+          'Run `npm run schema:gen` and commit the result.',
+      );
+      process.exit(1);
+    }
+    console.log('schema-bridge: generated Zod matches committed.');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function writeMode() {
+  const written = writeAll(OUTPUT_DIR);
+  console.log(`schema-bridge: wrote ${written.length} file(s):`);
+  for (const p of written) console.log(`  ${p.replace(REPO_ROOT, '').replace(/\\/g, '/')}`);
+}
+
+const args = process.argv.slice(2);
+if (args.includes('--check')) {
+  checkMode();
+} else {
+  writeMode();
+}

--- a/scripts/megameklab-conversion/README.md
+++ b/scripts/megameklab-conversion/README.md
@@ -31,3 +31,80 @@ These scripts were originally designed to:
 3. Validate unit construction rules
 
 The conversion process is still used but now targets SQLite for easier deployment.
+
+---
+
+## Schema gate (cross-language schema bridge)
+
+Three files in this directory implement the Python side of the
+cross-language schema bridge introduced by PR-A1:
+
+- `schema_gate.py` — wraps `jsonschema.Draft7Validator` with one
+  compiled validator per shape (`weapon`, `unit`, `ammunition`,
+  `electronics`, `misc_equipment`, `physical_weapon`). Lazy compilation
+  per shape; cached for the life of the process. Each
+  `validate_<shape>(data)` call returns a list of error strings (empty
+  on success). Used by both `blk_common` write helpers and
+  `run_schema_validation_only.py`.
+
+- `blk_common.py` — adds `write_weapon_json` / `write_unit_json` /
+  `write_equipment_json` choke points. Validation runs only when
+  `MEKSTATION_VALIDATE_WRITES=1` is set in the environment. PR-A1
+  ships this opt-in; PR-A2 will flip it on by default once corpus
+  drift is patched.
+
+- `run_schema_validation_only.py` — corpus harness used by the
+  `schema-bridge` CI job. Walks
+  `public/data/equipment/official/<shape>/*.json`, validates every
+  `items[]` entry, writes a JSON report to
+  `validation-output/schema-bridge-report.json`. Flags:
+  - `--shape weapon` (default in PR-A1) — repeat to enable additional
+    shapes; `--shape all` enables every shape.
+  - `--strict` — exit non-zero on any failure.
+
+`validator.py` exposes the same harness via a thin `--strict --shape`
+CLI so callers used to `python validator.py` find the new gate without
+having to learn a new file name. The legacy PostgreSQL helpers in
+`validator.py` are still importable but `psycopg2` is now optional.
+
+### Local invocation
+
+```bash
+# Default: weapon corpus only, non-strict (matches the PR-A1 CI gate).
+python scripts/megameklab-conversion/run_schema_validation_only.py
+
+# All 4 equipment shapes, strict (matches the PR-A2 target gate).
+python scripts/megameklab-conversion/run_schema_validation_only.py --shape all --strict
+
+# Equivalent via the validator alias.
+python scripts/megameklab-conversion/validator.py --strict --shape weapon
+
+# Validate a single dict programmatically.
+python -c "
+import sys; sys.path.insert(0, 'scripts/megameklab-conversion')
+from schema_gate import validate_weapon
+print(validate_weapon({'id': 'x'}))
+"
+```
+
+### Opt-in write-time validation
+
+Run any BLK / equipment writer with `MEKSTATION_VALIDATE_WRITES=1` to
+have `blk_common.write_*_json` raise `ValueError` on any drift before
+serialising:
+
+```bash
+MEKSTATION_VALIDATE_WRITES=1 npm run convert:blk
+```
+
+PR-A1 makes this opt-in so existing converter runs are not perturbed;
+PR-A2 flips the default on after corpus conformance is fixed.
+
+### Source of truth
+
+The canonical schemas live at `public/data/equipment/_schema/*.json`.
+Both Python (`jsonschema`) and TypeScript (Zod via `npm run schema:gen`)
+consume the same files. Do NOT edit
+`src/types/contracts/generated/*.zod.ts` by hand — the `schema-bridge`
+CI job runs `npm run schema:gen-check` and fails on drift; regenerate
+with `npm run schema:gen` and commit the result.

--- a/scripts/megameklab-conversion/blk_common.py
+++ b/scripts/megameklab-conversion/blk_common.py
@@ -290,6 +290,117 @@ def write_run_log(
     logger.info(f"Run log written: {log_path}")
 
 
+# ---------------------------------------------------------------------------
+# Cross-language schema-bridge write choke points
+# ---------------------------------------------------------------------------
+# Every Python writer that produces JSON consumed by the TypeScript
+# runtime should funnel through these helpers. They are guarded by the
+# ``MEKSTATION_VALIDATE_WRITES`` env var so PR-A1 can land without
+# perturbing existing conversion runs:
+#
+#   * unset / "0"  -> no validation, behaves like ``json.dump``.
+#   * "1"          -> validate against the canonical JSON Schema before
+#                     writing. A non-empty error list raises ``ValueError``,
+#                     which existing run-log error counters can catch.
+#
+# PR-A2 flips the default to "1" once corpus drift (the X-Pulse / VSP
+# costCBills gap surfaced in PR-A1) is patched.
+#
+# The helpers are intentionally tiny: schema_gate is the single source
+# of truth for what "valid" means; this layer just decides when to call it.
+
+_VALIDATE_ENV_VAR = "MEKSTATION_VALIDATE_WRITES"
+
+
+def _validate_writes_enabled() -> bool:
+    """Read the ``MEKSTATION_VALIDATE_WRITES`` flag (truthy strings: '1', 'true', 'yes')."""
+    val = os.environ.get(_VALIDATE_ENV_VAR, "")
+    return val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _maybe_validate(shape: str, data: Any) -> None:
+    """
+    Run ``schema_gate.validate_<shape>`` if the env var is set.
+
+    Importing ``schema_gate`` lazily keeps this module usable when
+    ``jsonschema`` isn't installed (rare, but possible in slim CI shells
+    that only need the BLK parsing primitives).
+    """
+    if not _validate_writes_enabled():
+        return
+    try:
+        from schema_gate import SHAPE_VALIDATORS  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError(
+            f"{_VALIDATE_ENV_VAR}=1 set but schema_gate unavailable: {exc}"
+        ) from exc
+    validator = SHAPE_VALIDATORS.get(shape)
+    if validator is None:
+        raise ValueError(f"blk_common: no validator for shape {shape!r}")
+    errors = validator(data)
+    if errors:
+        raise ValueError(
+            f"blk_common.write_{shape}_json: schema validation failed:\n  - "
+            + "\n  - ".join(errors[:8])
+        )
+
+
+def write_weapon_json(path: Path, data: Dict[str, Any]) -> None:
+    """
+    Write a single weapon dict to ``path``, optionally validating first.
+
+    PR-A1 makes no production callers go through this — the BLK
+    converters today emit per-unit BLK output, not weapon equipment
+    files. The helper exists so that any future weapon-emitting writer
+    (e.g. the planned MTF -> equipment extraction work) gets the
+    schema-bridge gate for free.
+    """
+    _maybe_validate("weapon", data)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def write_unit_json(path: Path, data: Dict[str, Any]) -> None:
+    """
+    Write a single unit dict to ``path``, optionally validating first.
+
+    Placeholder choke point for PR-A1: the BLK converters currently
+    serialise units inline via ``json.dumps`` per-file rather than
+    routing through here. PR-A2 migrates the converters to call this
+    helper so the env-var-gated validation engages automatically.
+    """
+    _maybe_validate("unit", data)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def write_equipment_json(
+    path: Path,
+    shape: str,
+    data: Dict[str, Any],
+) -> None:
+    """
+    Write an arbitrary-shape equipment dict, optionally validating first.
+
+    ``shape`` is one of ``schema_gate.SHAPE_VALIDATORS`` (``ammunition``,
+    ``electronics``, ``misc_equipment``, ``physical_weapon``). Like
+    ``write_unit_json`` this is a placeholder for PR-A1 — it exists so
+    the API surface is locked-in before PR-A2 wires the consumers.
+    """
+    _maybe_validate(shape, data)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
 __all__ = [
     # enum_mappings re-exports
     "default_mm_data_root",
@@ -313,4 +424,8 @@ __all__ = [
     "write_manifest",
     "write_parity_report",
     "write_run_log",
+    # Schema-bridge write choke points (PR-A1)
+    "write_weapon_json",
+    "write_unit_json",
+    "write_equipment_json",
 ]

--- a/scripts/megameklab-conversion/run_schema_validation_only.py
+++ b/scripts/megameklab-conversion/run_schema_validation_only.py
@@ -1,108 +1,242 @@
-import os
+"""
+run_schema_validation_only.py — corpus conformance harness for the
+cross-language schema bridge.
+
+Walks the equipment-data corpus under
+``public/data/equipment/official/<shape>/*.json`` and validates every
+``items[]`` entry against the canonical JSON Schemas via
+``schema_gate.py``. Used by the ``schema-bridge`` CI job.
+
+Modes:
+  - ``--shape weapon`` (default) — only validate weapon shape; PR-A1 is
+    weapon-pilot only. Repeat the flag to enable additional shapes; use
+    ``--shape all`` to enable every shape ``schema_gate`` knows.
+  - ``--strict`` — exit code 1 on any conformance failure. Without
+    ``--strict`` the script reports failure counts but always exits 0,
+    which is what PR-A1 wants (corpus is known to have ~6 drift items
+    that PR-A2 will fix).
+
+Output:
+  - Human-readable summary printed to stdout.
+  - ``validation-output/schema-bridge-report.json`` written for CI logs
+    and follow-up analysis. Each entry contains ``file``, ``id``, and
+    the list of failure messages.
+
+This script replaces a much earlier PostgreSQL-flavoured stub (which
+referenced a no-longer-existing ``schemas/`` directory and an old
+``validator.py`` import path). The historical version validated the
+mekfiles tree against per-unit-type schemas; that flow has been
+superseded by the SQLite migration and the cross-language schema bridge,
+so the file is repurposed here. Anything that needs the legacy mekfiles
+walk should use the SQLite-side validator at ``mekstation-app/data/``.
+"""
+
+from __future__ import annotations
+
+import argparse
 import json
-from pathlib import Path
+import os
 import sys
+from pathlib import Path
+from typing import Dict, List
 
-# Ensure validator.py can be imported.
-# Assuming validator.py is in the same directory or accessible via PYTHONPATH.
-# If run_validation.py and validator.py are in the root, this should work.
-sys.path.append(os.getcwd())
-try:
-    from validator import validate_schema_compliance, load_json_schema # Corrected import
-except ImportError as e:
-    print(f"Failed to import from validator.py: {e}")
-    print("Ensure validator.py is in the current working directory or accessible via PYTHONPATH.")
-    sys.exit(1)
+# Ensure ``schema_gate`` resolves regardless of how the script is
+# invoked (from repo root, from the script directory, or via CI).
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
 
-CONVERTED_MEKFILES_DIR = "megameklab_converted_output/mekfiles"
-SCHEMAS_DIR = "schemas"
-OUTPUT_REPORT_FILE = "schema_validation_report.json"
+from schema_gate import SHAPE_VALIDATORS  # noqa: E402
 
-def determine_unit_type_from_path(file_path: Path, base_mekfiles_dir: Path) -> str:
+_REPO_ROOT = _SCRIPT_DIR.parent.parent
+_EQUIPMENT_ROOT = _REPO_ROOT / "public" / "data" / "equipment" / "official"
+
+# Map each schema-gate shape -> the on-disk subdirectory + filename glob
+# that holds its corpus. Some shapes (``unit``) live elsewhere; we leave
+# them out of PR-A1's reach so the harness stays focused on equipment.
+SHAPE_TO_CORPUS = {
+    "weapon": ("weapons", "*.json"),
+    "ammunition": ("ammunition", "*.json"),
+    "electronics": ("electronics", "*.json"),
+    "misc_equipment": ("miscellaneous", "*.json"),
+    # `physical` lives inside `weapons/physical.json` — handled below.
+    "physical_weapon": ("weapons", "physical.json"),
+}
+
+# Files inside the weapons directory that DO NOT match weapon-schema.json
+# (they belong to the physical_weapon shape). Excluded from the weapon
+# walk so we don't mis-attribute drift.
+_WEAPON_EXCLUSIONS = {"physical.json"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate equipment JSON corpus against the canonical JSON Schemas.",
+    )
+    parser.add_argument(
+        "--shape",
+        action="append",
+        default=None,
+        help=(
+            "Shape(s) to validate. Repeatable. Defaults to ['weapon']. "
+            "Use --shape all to validate every supported shape. "
+            f"Valid shapes: {sorted(SHAPE_TO_CORPUS)}."
+        ),
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if any item fails validation.",
+    )
+    parser.add_argument(
+        "--report-path",
+        default=str(_REPO_ROOT / "validation-output" / "schema-bridge-report.json"),
+        help="Where to write the JSON report.",
+    )
+    return parser.parse_args()
+
+
+def resolve_shapes(requested: List[str] | None) -> List[str]:
+    """Resolve the --shape arg into a concrete list, defaulting to weapon."""
+    if not requested:
+        return ["weapon"]
+    if "all" in requested:
+        return sorted(SHAPE_TO_CORPUS)
+    unknown = [s for s in requested if s not in SHAPE_TO_CORPUS]
+    if unknown:
+        raise SystemExit(
+            f"run_schema_validation_only: unknown shape(s) {unknown}; "
+            f"valid shapes: {sorted(SHAPE_TO_CORPUS)}"
+        )
+    return requested
+
+
+def collect_files(shape: str) -> List[Path]:
+    """Return the list of corpus files for ``shape``."""
+    subdir, glob = SHAPE_TO_CORPUS[shape]
+    base = _EQUIPMENT_ROOT / subdir
+    if not base.is_dir():
+        return []
+    files = sorted(base.glob(glob))
+    if shape == "weapon":
+        files = [p for p in files if p.name not in _WEAPON_EXCLUSIONS]
+    return files
+
+
+def validate_shape(shape: str) -> Dict[str, List[Dict[str, object]]]:
     """
-    Determines unit type based on the first subdirectory within the base_mekfiles_dir.
-    Example: megameklab_converted_output/mekfiles/meks/somefile.json -> meks
+    Validate every item in every file of ``shape``. Returns a dict
+    keyed by relative file path; values are a list of per-item failure
+    records. Files with zero failures are still included with an empty
+    list so the report distinguishes "validated, all-clean" from
+    "skipped".
     """
-    try:
-        relative_path = file_path.relative_to(base_mekfiles_dir)
-        # The first part of the relative path should be the unit type directory
-        if relative_path.parts:
-            return relative_path.parts[0]
-    except ValueError:
-        # This can happen if file_path is not under base_mekfiles_dir, though it shouldn't in this script's logic.
-        pass
-    return "unknown" # Default or fallback
+    validator = SHAPE_VALIDATORS[shape]
+    out: Dict[str, List[Dict[str, object]]] = {}
+    files = collect_files(shape)
+    if not files:
+        print(f"  WARN: no corpus files for shape={shape} under {_EQUIPMENT_ROOT}")
+        return out
 
-def main():
-    print(f"Starting schema-only validation of files in: {CONVERTED_MEKFILES_DIR}")
-    print(f"Using schemas from: {SCHEMAS_DIR}")
+    for fpath in files:
+        rel = str(fpath.relative_to(_REPO_ROOT)).replace(os.sep, "/")
+        try:
+            with fpath.open(encoding="utf-8") as fh:
+                data = json.load(fh)
+        except json.JSONDecodeError as e:
+            out[rel] = [{"id": "<file>", "errors": [f"JSON decode error: {e}"]}]
+            continue
 
-    base_mekfiles_path = Path(CONVERTED_MEKFILES_DIR)
-    if not base_mekfiles_path.is_dir():
-        print(f"Error: Converted mekfiles directory not found: {CONVERTED_MEKFILES_DIR}")
-        return
+        items = data.get("items") if isinstance(data, dict) else None
+        if not isinstance(items, list):
+            out[rel] = [
+                {"id": "<file>", "errors": ["File missing 'items' array."]}
+            ]
+            continue
 
-    if not Path(SCHEMAS_DIR).is_dir():
-        print(f"Error: Schemas directory not found: {SCHEMAS_DIR}")
-        return
+        failures: List[Dict[str, object]] = []
+        for index, item in enumerate(items):
+            errors = validator(item)
+            if errors:
+                failures.append(
+                    {
+                        "index": index,
+                        "id": (item.get("id") if isinstance(item, dict) else None),
+                        "errors": errors,
+                    }
+                )
+        out[rel] = failures
+    return out
 
-    validation_results = {}
-    files_processed = 0
-    files_with_errors = 0
 
-    for dirpath, _, filenames in os.walk(base_mekfiles_path):
-        for filename in filenames:
-            if filename.endswith(".json") and filename not in ["derivedEquipment.json", "UnitVerifierOptions.json"]:
-                filepath = Path(dirpath) / filename
-                unit_id_for_report = str(filepath.relative_to(base_mekfiles_path))
-                files_processed += 1
+def main() -> int:
+    args = parse_args()
+    shapes = resolve_shapes(args.shape)
 
-                if files_processed % 500 == 0:
-                    print(f"Processed {files_processed} files...")
+    print("schema-bridge: corpus conformance check")
+    print(f"  shapes:   {shapes}")
+    print(f"  strict:   {args.strict}")
+    print(f"  root:     {_EQUIPMENT_ROOT}")
+    print()
 
-                unit_type = determine_unit_type_from_path(filepath, base_mekfiles_path)
-                if unit_type == "unknown":
-                    validation_results[unit_id_for_report] = [f"Validator Error: Could not determine unit_type for {filepath}"]
-                    files_with_errors += 1
-                    continue
+    report: Dict[str, Dict[str, List[Dict[str, object]]]] = {}
+    total_files = 0
+    total_items = 0
+    total_failures = 0
 
-                try:
-                    with open(filepath, 'r', encoding='utf-8') as f:
-                        unit_json_data = json.load(f)
-                except json.JSONDecodeError as e:
-                    validation_results[unit_id_for_report] = [f"JSON Decode Error: {e}"]
-                    files_with_errors += 1
-                    continue
-                except Exception as e:
-                    validation_results[unit_id_for_report] = [f"File Read Error: {e}"]
-                    files_with_errors += 1
-                    continue
+    for shape in shapes:
+        shape_results = validate_shape(shape)
+        report[shape] = shape_results
+        for rel, failures in shape_results.items():
+            total_files += 1
+            # We need the item count for the summary; reread the file
+            # cheaply (it was already JSON-parsed during validation, but
+            # the parsed object is not retained to keep memory bounded).
+            try:
+                with (_REPO_ROOT / rel).open(encoding="utf-8") as fh:
+                    data = json.load(fh)
+                total_items += len(data.get("items") or [])
+            except Exception:
+                pass
+            total_failures += len(failures)
+            failure_count = len(failures)
+            status = "OK" if failure_count == 0 else f"FAIL ({failure_count})"
+            print(f"  [{shape}] {rel}: {status}")
 
-                # Ensure unit_json_data is a dict, as expected by validate_schema_compliance
-                if not isinstance(unit_json_data, dict):
-                    validation_results[unit_id_for_report] = [f"Validator Error: Unit data is not a JSON object (dict). Found type: {type(unit_json_data)}"]
-                    files_with_errors +=1
-                    continue
+    # Always write the report so CI logs can attach it as an artifact.
+    report_path = Path(args.report_path)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    with report_path.open("w", encoding="utf-8") as fh:
+        json.dump(
+            {
+                "shapes": shapes,
+                "totals": {
+                    "files": total_files,
+                    "items": total_items,
+                    "failures": total_failures,
+                },
+                "results": report,
+            },
+            fh,
+            indent=2,
+            ensure_ascii=False,
+        )
 
-                errors = validate_schema_compliance(unit_json_data, unit_type, SCHEMAS_DIR)
-                if errors:
-                    validation_results[unit_id_for_report] = errors
-                    files_with_errors += 1
+    print()
+    print("--- Summary ---")
+    print(f"  files:    {total_files}")
+    print(f"  items:    {total_items}")
+    print(f"  failures: {total_failures}")
+    print(f"  report:   {report_path}")
 
-    print(f"Saving schema validation report to {OUTPUT_REPORT_FILE}...")
-    try:
-        with open(OUTPUT_REPORT_FILE, 'w', encoding='utf-8') as f:
-            json.dump(validation_results, f, indent=2, ensure_ascii=False)
-        print("Schema validation report saved.")
-    except Exception as e:
-        print(f"Error saving schema validation report: {e}")
+    if total_failures > 0 and args.strict:
+        print(
+            "\nschema-bridge: --strict mode triggered; corpus has "
+            f"{total_failures} item(s) failing canonical schemas."
+        )
+        return 1
+    return 0
 
-    print("\n--- Schema Validation Summary ---")
-    print(f"Total JSON files processed (excluding derivedEquipment & UnitVerifierOptions): {files_processed}")
-    print(f"Files with schema errors or processing issues: {files_with_errors}")
-    if files_processed > 0:
-        error_rate = (files_with_errors / files_processed) * 100
-        print(f"Error rate: {error_rate:.2f}%")
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/megameklab-conversion/schema_gate.py
+++ b/scripts/megameklab-conversion/schema_gate.py
@@ -1,0 +1,175 @@
+"""
+schema_gate.py — Python side of the cross-language schema bridge.
+
+Wraps ``jsonschema.Draft7Validator`` with per-shape compiled validators
+backed by the canonical JSON Schemas at
+``public/data/equipment/_schema/*.json``. The TypeScript side consumes
+the same schemas via ``scripts/generate-zod-schemas.mjs`` (Zod). Keeping
+both languages anchored on the same JSON Schema source eliminates the
+silent drift that surfaced as the ``"bv": null`` audit (PR #405): once
+this module is wired into ``blk_common.write_*_json`` choke points,
+Python writers fail loudly when the on-disk shape diverges from what
+the TypeScript readers expect.
+
+Usage::
+
+    from schema_gate import validate_weapon
+
+    errors = validate_weapon(weapon_dict)
+    if errors:
+        raise ValueError(f"weapon failed schema: {errors}")
+
+In PR-A1 the choke point is opt-in via ``MEKSTATION_VALIDATE_WRITES=1``
+so existing converter runs are not perturbed. PR-A2 flips the default to
+on after corpus conformance is fixed.
+
+The 6 public ``validate_<shape>`` functions reuse a single compiled
+``Draft7Validator`` per shape (compile-once-reuse). Compilation is lazy
+so importers that only need one shape don't pay the upfront cost of
+loading all 6 schema files.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from jsonschema import Draft7Validator
+
+
+# ---------------------------------------------------------------------------
+# Schema location resolution
+# ---------------------------------------------------------------------------
+# This module lives at ``scripts/megameklab-conversion/schema_gate.py``;
+# the schemas live at ``public/data/equipment/_schema/*.json``. Walking
+# up two parents lands on the repo root regardless of CWD, so converters
+# invoked from arbitrary working directories still find the schemas.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCHEMA_DIR = _REPO_ROOT / "public" / "data" / "equipment" / "_schema"
+
+_SCHEMA_FILES = {
+    "weapon": "weapon-schema.json",
+    "unit": "unit-schema.json",
+    "ammunition": "ammunition-schema.json",
+    "electronics": "electronics-schema.json",
+    "misc_equipment": "misc-equipment-schema.json",
+    "physical_weapon": "physical-weapon-schema.json",
+}
+
+# Lazy-compiled validators. Populated on first call to ``_get_validator``.
+_VALIDATORS: Dict[str, Draft7Validator] = {}
+
+
+def _get_validator(shape: str) -> Draft7Validator:
+    """
+    Return the compiled validator for ``shape``, compiling lazily on first
+    use. Compiled validators are cached for the life of the process so
+    converters batching thousands of records pay the JSON-Schema cost
+    exactly once per shape.
+    """
+    if shape in _VALIDATORS:
+        return _VALIDATORS[shape]
+    if shape not in _SCHEMA_FILES:
+        raise ValueError(
+            f"schema_gate: unknown shape {shape!r}; "
+            f"valid shapes are {sorted(_SCHEMA_FILES)}"
+        )
+    schema_path = _SCHEMA_DIR / _SCHEMA_FILES[shape]
+    if not schema_path.is_file():
+        raise FileNotFoundError(
+            f"schema_gate: schema file missing at {schema_path}"
+        )
+    with schema_path.open(encoding="utf-8") as fh:
+        schema = json.load(fh)
+    validator = Draft7Validator(schema)
+    _VALIDATORS[shape] = validator
+    return validator
+
+
+def _format_errors(shape: str, errors: List[Any]) -> List[str]:
+    """
+    Render ``jsonschema`` ValidationError objects into ``[<path>: <msg>]``
+    strings. Keeps callers from having to introspect the jsonschema
+    exception class — they get a list of plain strings suitable for
+    logging or raising.
+    """
+    out: List[str] = []
+    for err in errors:
+        path = ".".join(str(p) for p in err.absolute_path) or "<root>"
+        out.append(f"{shape}.{path}: {err.message}")
+    return out
+
+
+def _validate(shape: str, data: Any) -> List[str]:
+    """
+    Validate ``data`` against ``shape``. Returns an empty list on
+    success; otherwise a list of human-readable error strings.
+
+    Returning a list (rather than raising) lets the caller decide whether
+    to log, accumulate across a batch, or abort. The blk_common write
+    helpers raise on non-empty lists; ``run_schema_validation_only.py``
+    accumulates and reports.
+    """
+    validator = _get_validator(shape)
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+    if not errors:
+        return []
+    return _format_errors(shape, errors)
+
+
+# ---------------------------------------------------------------------------
+# Public per-shape entry points
+# ---------------------------------------------------------------------------
+
+def validate_weapon(data: Any) -> List[str]:
+    """Validate a single weapon dict against ``weapon-schema.json``."""
+    return _validate("weapon", data)
+
+
+def validate_unit(data: Any) -> List[str]:
+    """Validate a single unit dict against ``unit-schema.json``."""
+    return _validate("unit", data)
+
+
+def validate_ammunition(data: Any) -> List[str]:
+    """Validate a single ammunition dict against ``ammunition-schema.json``."""
+    return _validate("ammunition", data)
+
+
+def validate_electronics(data: Any) -> List[str]:
+    """Validate a single electronics dict against ``electronics-schema.json``."""
+    return _validate("electronics", data)
+
+
+def validate_misc_equipment(data: Any) -> List[str]:
+    """Validate a single misc-equipment dict against ``misc-equipment-schema.json``."""
+    return _validate("misc_equipment", data)
+
+
+def validate_physical_weapon(data: Any) -> List[str]:
+    """Validate a single physical-weapon dict against ``physical-weapon-schema.json``."""
+    return _validate("physical_weapon", data)
+
+
+# Lookup map used by ``run_schema_validation_only.py`` and any future
+# harness that wants to iterate every shape generically.
+SHAPE_VALIDATORS = {
+    "weapon": validate_weapon,
+    "unit": validate_unit,
+    "ammunition": validate_ammunition,
+    "electronics": validate_electronics,
+    "misc_equipment": validate_misc_equipment,
+    "physical_weapon": validate_physical_weapon,
+}
+
+
+__all__ = [
+    "validate_weapon",
+    "validate_unit",
+    "validate_ammunition",
+    "validate_electronics",
+    "validate_misc_equipment",
+    "validate_physical_weapon",
+    "SHAPE_VALIDATORS",
+]

--- a/scripts/megameklab-conversion/validator.py
+++ b/scripts/megameklab-conversion/validator.py
@@ -1,10 +1,23 @@
 import os
 import json
-import psycopg2
-import psycopg2.extras
 import re
-from jsonschema import validate, exceptions as jsonschema_exceptions, RefResolver
 from pathlib import Path
+
+# psycopg2 is only needed by the legacy PostgreSQL helpers below
+# (``get_db_connection``, ``fetch_unit_by_id``, ``fetch_validation_options``).
+# The cross-language schema-bridge CLI added at the bottom of the file
+# (PR-A1) does NOT need psycopg2, and the deprecated PostgreSQL flow has
+# been superseded by the SQLite migration. Make the import optional so
+# ``python validator.py --strict`` works without psycopg2 installed.
+try:
+    import psycopg2
+    import psycopg2.extras
+    _HAS_PSYCOPG2 = True
+except ImportError:  # pragma: no cover — legacy fallback
+    psycopg2 = None  # type: ignore[assignment]
+    _HAS_PSYCOPG2 = False
+
+from jsonschema import validate, exceptions as jsonschema_exceptions, RefResolver
 
 # --- Database Connection Parameters ---
 DB_HOST = os.environ.get("DB_HOST", "localhost")
@@ -14,7 +27,13 @@ DB_PASSWORD = os.environ.get("DB_PASSWORD", "password")
 
 # --- Helper Functions ---
 def get_db_connection():
-    """Establishes and returns a database connection."""
+    """Establishes and returns a database connection (legacy PostgreSQL flow)."""
+    if not _HAS_PSYCOPG2:
+        print(
+            "Error: psycopg2 not installed. The legacy PostgreSQL flow is "
+            "deprecated; use the SQLite migration under mekstation-app/data/."
+        )
+        return None
     conn = None
     try:
         conn = psycopg2.connect(
@@ -257,3 +276,65 @@ def validate_unit_data(db_unit_row, validation_options, equipment_data_map, base
         if legality_errors: all_errors_warnings.extend([f"[Legality] {e}" for e in legality_errors])
 
     return all_errors_warnings
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point (cross-language schema-bridge, PR-A1)
+# ---------------------------------------------------------------------------
+# Historically this module was only ever imported by ``run_validation.py``
+# (the deprecated PostgreSQL flow). PR-A1 adds a thin CLI so ``validator.py``
+# can be invoked directly with ``--strict`` for ad-hoc / CI use:
+#
+#     python scripts/megameklab-conversion/validator.py --strict --shape weapon
+#
+# The CLI delegates straight to ``run_schema_validation_only.main`` — it
+# is just an alternate alias so callers used to "run validator.py" find
+# the new gate without having to learn a new file name. Without
+# ``--strict`` the script exits 0 even when the corpus has drift.
+def _run_cli() -> int:
+    import argparse  # local import: keep module-level imports unchanged
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the cross-language schema-bridge validator over the "
+            "equipment corpus. Wraps run_schema_validation_only.py so "
+            "callers can invoke validator.py directly."
+        ),
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero on any conformance failure.",
+    )
+    parser.add_argument(
+        "--shape",
+        action="append",
+        default=None,
+        help=(
+            "Shape(s) to validate. Repeatable. Defaults to ['weapon'] in "
+            "PR-A1; pass --shape all once PR-A2 has fixed corpus drift."
+        ),
+    )
+    args = parser.parse_args()
+
+    # Defer to run_schema_validation_only by mutating sys.argv. This is
+    # uglier than importing main() and passing args, but main() takes no
+    # args today and rebuilding the script's argparse here would
+    # duplicate the spec. Better one ugly trampoline than two CLIs.
+    import sys
+    forwarded = ["run_schema_validation_only.py"]
+    if args.strict:
+        forwarded.append("--strict")
+    for shape in args.shape or []:
+        forwarded.extend(["--shape", shape])
+    sys.argv = forwarded
+
+    # Import lazily so the legacy ``import validator`` from
+    # ``run_validation.py`` doesn't pay the cost.
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from run_schema_validation_only import main as _main  # noqa: WPS433
+    return _main()
+
+
+if __name__ == "__main__":
+    import sys as _sys
+    _sys.exit(_run_cli())

--- a/src/services/equipment/EquipmentLoaderService.ts
+++ b/src/services/equipment/EquipmentLoaderService.ts
@@ -9,6 +9,7 @@
  * @module services/equipment/EquipmentLoaderService
  */
 
+import { WeaponContract } from '@/types/contracts';
 import { IAmmunition } from '@/types/equipment/AmmunitionTypes';
 import { IElectronics } from '@/types/equipment/ElectronicsTypes';
 import { IMiscEquipment } from '@/types/equipment/MiscEquipmentTypes';
@@ -101,6 +102,71 @@ function getIndexedFileList(
 }
 
 /**
+ * Detect whether an `IEquipmentFile.$schema` reference points at the
+ * canonical weapon-schema. Files like `weapons/physical.json` carry a
+ * `$schema` that targets `physical-weapon-schema.json` instead and must
+ * NOT be parsed against the weapon contract — they belong to a sibling
+ * shape that PR-A2 wires.
+ */
+function isWeaponShapeFile(schemaRef: string | undefined): boolean {
+  if (!schemaRef) return false;
+  // Accept any path/filename that ends in `weapon-schema.json`. We
+  // deliberately exclude `physical-weapon-schema.json` because it
+  // sub-strings differently in URL form.
+  const fileName = schemaRef.split(/[\\/]/).pop() ?? schemaRef;
+  return fileName === 'weapon-schema.json';
+}
+
+/**
+ * Validate every weapon item against the canonical `WeaponContract`.
+ *
+ * Behaviour:
+ *  - Default (PR-A1): collect failures and emit a single
+ *    `console.warn` summarising drift. Non-throwing because the corpus
+ *    is known to have 6 X-Pulse / VSP entries missing `costCBills`,
+ *    and PR-A2 will fix that data before flipping to throw mode.
+ *  - `MEKSTATION_STRICT_SCHEMA_BRIDGE=1`: throw with an aggregated
+ *    error message. Useful for one-off `npx jest` runs where you want
+ *    to fail fast on any new drift introduced by a code change.
+ *
+ * Dev/test only — production callers never reach this code path because
+ * the surrounding `process.env.NODE_ENV !== 'production'` gate.
+ */
+function validateWeaponItems(
+  fileLabel: string,
+  items: readonly unknown[],
+): void {
+  // Collect ALL failures rather than throwing on the first so the dev
+  // gets one clear list per file rather than a death-by-a-thousand-cuts.
+  const failures: string[] = [];
+  for (let index = 0; index < items.length; index++) {
+    const item = items[index];
+    const result = WeaponContract.safeParse(item);
+    if (!result.success) {
+      const id = (item as { id?: unknown } | null | undefined)?.id ?? '<no id>';
+      const issuePaths = result.error.issues
+        .slice(0, 3)
+        .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+        .join('; ');
+      failures.push(`  [${index}] id=${String(id)} -> ${issuePaths}`);
+    }
+  }
+  if (failures.length === 0) return;
+
+  const message =
+    `EquipmentLoaderService: ${failures.length} weapon(s) in ${fileLabel} ` +
+    `failed WeaponContract.safeParse:\n${failures.slice(0, 8).join('\n')}` +
+    (failures.length > 8 ? `\n... and ${failures.length - 8} more` : '');
+
+  if (process.env.MEKSTATION_STRICT_SCHEMA_BRIDGE === '1') {
+    throw new Error(message);
+  }
+  // Non-strict default for PR-A1: surface drift loudly without
+  // breaking dev runs that happen to load the X-Pulse / VSP entries.
+  console.warn(`[schema-bridge] ${message}`);
+}
+
+/**
  * Equipment Loader Service
  *
  * Loads and caches equipment data from JSON files for runtime use.
@@ -158,6 +224,26 @@ export class EquipmentLoaderService {
           basePath,
         );
         if (weaponData) {
+          // Cross-language schema-bridge gate (PR-A1).
+          //
+          // In dev/test we round-trip every weapon through the canonical
+          // WeaponContract before handing it to `convertWeapon`. This is
+          // the TypeScript-side mirror of `schema_gate.validate_weapon`
+          // in Python; together they catch silent shape drift between
+          // the writer and reader sides at first contact.
+          //
+          // Production builds skip this cost. The CI `schema-bridge`
+          // job already gates merges on corpus conformance, so re-parsing
+          // at runtime in production buys nothing but allocations. The
+          // wrapping `IEquipmentFile.$schema` reference is checked so
+          // shapes other than `weapon` (e.g. `weapons/physical.json`,
+          // which is actually a physical-weapon shape) bypass cleanly.
+          if (
+            process.env.NODE_ENV !== 'production' &&
+            isWeaponShapeFile(weaponData.$schema)
+          ) {
+            validateWeaponItems(weaponFile, weaponData.items);
+          }
           weaponData.items.forEach((item) => {
             const weapon = convertWeapon(item);
             this.weapons.set(weapon.id, weapon);

--- a/src/types/contracts/__tests__/weapon.contract.test.ts
+++ b/src/types/contracts/__tests__/weapon.contract.test.ts
@@ -1,0 +1,191 @@
+/**
+ * weapon.contract.test.ts
+ *
+ * Round-trip tests for the weapon contract (PR-A1 of the cross-language
+ * schema bridge). Each fixture is a real weapon file under
+ * `public/data/equipment/official/weapons/`. The test asserts:
+ *
+ *   1. The wrapper is a valid `IEquipmentFile<weapon>` shape (basic).
+ *   2. Every `items[]` entry parses cleanly through `WeaponContract`.
+ *   3. The first item is sampled directly to keep failure messages
+ *      readable when a single weapon drifts.
+ *
+ * Five fixtures are picked to cover the full weapon-category spectrum
+ * (Energy/Laser, Energy/PPC, Ballistic/Autocannon, Ballistic/MachineGun,
+ * Missile/LRM, Physical) and all rules-levels (INTRODUCTORY → STANDARD).
+ *
+ * If `json-schema-to-zod` over-strictly infers a property (e.g. emits
+ * `string` where the data has `string | null`), the failure surfaces
+ * here on day one — which is the entire point of the pilot.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { WeaponContract } from '@/types/contracts';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+const WEAPONS_DIR = path.join(
+  REPO_ROOT,
+  'public',
+  'data',
+  'equipment',
+  'official',
+  'weapons',
+);
+
+interface IRawWeaponFile {
+  $schema?: string;
+  version?: string;
+  generatedAt?: string;
+  count?: number;
+  items: unknown[];
+}
+
+function loadWeaponFile(fileName: string): IRawWeaponFile {
+  const fullPath = path.join(WEAPONS_DIR, fileName);
+  const raw = fs.readFileSync(fullPath, 'utf-8');
+  return JSON.parse(raw) as IRawWeaponFile;
+}
+
+// Fixtures span the weapon-category enum used by `weapon-schema.json`
+// (Energy/Ballistic/Missile/Artillery) and the rules-level spectrum so
+// any drift in any axis fails fast. Note: `physical.json` is intentionally
+// excluded — physical weapons live in a sibling shape covered by
+// `physical-weapon-schema.json`, which is wired to its own contract in
+// PR-A2.
+//
+// `knownDriftIds` lists item ids that the pilot has confirmed do NOT
+// conform to the canonical schema today (corpus drift to be fixed by
+// PR-A2). Per the cross-language schema bridge plan, PR-A1 surfaces
+// drift but does not block on it; PR-A2 flips the gate strict and
+// patches the data. Each entry below is a concrete TODO for PR-A2.
+const FIXTURES = [
+  {
+    file: 'energy-laser.json',
+    label: 'Energy/Laser',
+    // X-Pulse and Variable-Speed-Pulse (VSP) laser entries in the corpus
+    // are missing the required `costCBills` field. Tracked for PR-A2 to
+    // fix the source data; PR-A2 also flips the gate from non-blocking
+    // to strict so the corpus drift becomes a hard CI failure.
+    knownDriftIds: [
+      'small-x-pulse-laser',
+      'medium-x-pulse-laser',
+      'large-x-pulse-laser',
+      'small-vsp-laser',
+      'medium-vsp-laser',
+      'large-vsp-laser',
+    ],
+  },
+  { file: 'energy-ppc.json', label: 'Energy/PPC', knownDriftIds: [] },
+  {
+    file: 'ballistic-autocannon.json',
+    label: 'Ballistic/Autocannon',
+    knownDriftIds: [],
+  },
+  {
+    file: 'ballistic-machinegun.json',
+    label: 'Ballistic/MachineGun',
+    knownDriftIds: [],
+  },
+  { file: 'missile-lrm.json', label: 'Missile/LRM', knownDriftIds: [] },
+] as const;
+
+describe('WeaponContract round-trip', () => {
+  for (const fixture of FIXTURES) {
+    describe(`${fixture.label} (${fixture.file})`, () => {
+      const file = loadWeaponFile(fixture.file);
+
+      it('has a non-empty `items` array', () => {
+        expect(Array.isArray(file.items)).toBe(true);
+        expect(file.items.length).toBeGreaterThan(0);
+      });
+
+      it('parses every non-drifting weapon through WeaponContract', () => {
+        const knownDriftSet = new Set<string>(fixture.knownDriftIds);
+        const failures: { index: number; id: unknown; issues: unknown }[] = [];
+        const unexpectedlyPassedDrift: unknown[] = [];
+
+        file.items.forEach((item, index) => {
+          const id = (item as { id?: unknown })?.id;
+          const isKnownDrift = typeof id === 'string' && knownDriftSet.has(id);
+          const result = WeaponContract.safeParse(item);
+
+          if (isKnownDrift) {
+            // If a known-drifting weapon now parses, that's good news —
+            // surface it so PR-A2 (or whoever fixed it) can prune
+            // `knownDriftIds`.
+            if (result.success) unexpectedlyPassedDrift.push(id);
+            return;
+          }
+
+          if (!result.success) {
+            failures.push({
+              index,
+              id,
+              issues: result.error.issues,
+            });
+          }
+        });
+
+        if (unexpectedlyPassedDrift.length > 0) {
+          throw new Error(
+            `Items in \`knownDriftIds\` for ${fixture.file} now parse cleanly. ` +
+              `Remove them from \`knownDriftIds\`: ${unexpectedlyPassedDrift.join(', ')}`,
+          );
+        }
+        if (failures.length > 0) {
+          // Surface the first few failures inline; full list is in the assert msg.
+          // Keeping this readable matters because PR-A2 reuses the same shape.
+          throw new Error(
+            `WeaponContract.safeParse failed for ${failures.length} item(s) in ${fixture.file}:\n` +
+              JSON.stringify(failures.slice(0, 3), null, 2),
+          );
+        }
+        expect(failures).toHaveLength(0);
+      });
+
+      it('first item parses as a typed contract instance', () => {
+        // Sampling the first item gives a deterministic single failure
+        // message when an entire file regresses.
+        const result = WeaponContract.safeParse(file.items[0]);
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(typeof result.data.id).toBe('string');
+          expect(typeof result.data.name).toBe('string');
+          // Category is one of the enum values from the JSON Schema.
+          expect([
+            'Energy',
+            'Ballistic',
+            'Missile',
+            'Physical',
+            'Artillery',
+          ]).toContain(result.data.category);
+        }
+      });
+    });
+  }
+
+  it('rejects a weapon with an unknown category (negative control)', () => {
+    // Negative control proves the schema is actually rejecting things
+    // and not just returning success on every input.
+    const bogus = {
+      id: 'fake-weapon',
+      name: 'Fake Weapon',
+      category: 'Nonsense',
+      subType: 'X',
+      techBase: 'INNER_SPHERE',
+      rulesLevel: 'STANDARD',
+      damage: 1,
+      heat: 0,
+      ranges: { minimum: 0, short: 1, medium: 2, long: 3 },
+      weight: 1,
+      criticalSlots: 1,
+      costCBills: 1,
+      battleValue: 1,
+      introductionYear: 3000,
+    };
+    const result = WeaponContract.safeParse(bogus);
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/types/contracts/generated/ammunition.zod.ts
+++ b/src/types/contracts/generated/ammunition.zod.ts
@@ -1,0 +1,146 @@
+// @generated — do not edit; run `npm run schema:gen` to regenerate.
+// Source: public/data/equipment/_schema/ammunition-schema.json
+// Regeneration: `node scripts/generate-zod-schemas.mjs` (see `scripts/generate-zod-schemas.mjs`).
+//
+// PR-A1 ships only the weapon shape through round-trip tests + loader
+// validation; PR-A2 wires the rest. The schema-bridge CI job verifies
+// these files match the JSON Schema source via `--check` mode.
+
+import { z } from 'zod';
+
+export const AmmunitionContract = z
+  .object({
+    id: z
+      .string()
+      .regex(new RegExp('^[a-z0-9-]+$'))
+      .describe('Unique identifier for the ammunition (kebab-case)'),
+    name: z.string().min(1).describe('Display name of the ammunition'),
+    category: z
+      .enum([
+        'Autocannon',
+        'Gauss',
+        'Machine Gun',
+        'LRM',
+        'SRM',
+        'MRM',
+        'ATM',
+        'NARC',
+        'Artillery',
+        'AMS',
+      ])
+      .describe('Ammunition category'),
+    variant: z
+      .enum([
+        'Standard',
+        'Armor-Piercing',
+        'Cluster',
+        'Precision',
+        'Flechette',
+        'Inferno',
+        'Fragmentation',
+        'Incendiary',
+        'Smoke',
+        'Thunder',
+        'Swarm',
+        'Tandem-Charge',
+        'Extended Range',
+        'High Explosive',
+      ])
+      .describe('Ammunition variant type'),
+    techBase: z
+      .enum(['INNER_SPHERE', 'CLAN', 'BOTH'])
+      .describe('Technology base for the ammunition'),
+    rulesLevel: z
+      .enum([
+        'INTRODUCTORY',
+        'STANDARD',
+        'ADVANCED',
+        'EXPERIMENTAL',
+        'UNOFFICIAL',
+      ])
+      .describe('Rules level/complexity'),
+    compatibleWeaponIds: z
+      .array(z.string())
+      .min(1)
+      .describe('List of weapon IDs this ammo is compatible with'),
+    shotsPerTon: z
+      .number()
+      .int()
+      .gte(1)
+      .describe('Number of shots per ton of ammunition'),
+    weight: z.number().gte(0).describe('Weight per unit in tons (usually 1)'),
+    criticalSlots: z
+      .number()
+      .int()
+      .gte(1)
+      .describe('Number of critical slots required'),
+    costPerTon: z.number().gte(0).describe('Cost in C-Bills per ton'),
+    battleValue: z.number().gte(0).describe('Battle Value per ton'),
+    isExplosive: z
+      .boolean()
+      .describe('Whether the ammo causes explosions when hit'),
+    damageModifier: z
+      .number()
+      .describe('Damage modifier applied by this ammo type')
+      .optional(),
+    rangeModifier: z
+      .number()
+      .describe('Range modifier applied by this ammo type')
+      .optional(),
+    introductionYear: z
+      .number()
+      .int()
+      .gte(1950)
+      .lte(3200)
+      .describe('Year the ammunition was introduced'),
+    extinctionYear: z
+      .number()
+      .int()
+      .gte(1950)
+      .lte(3200)
+      .describe('Year the ammunition became extinct (if applicable)')
+      .optional(),
+    reintroductionYear: z
+      .number()
+      .int()
+      .gte(1950)
+      .lte(3200)
+      .describe('Year the ammunition was reintroduced (if applicable)')
+      .optional(),
+    special: z
+      .array(z.string())
+      .describe('Special rules for this ammunition type')
+      .optional(),
+    flags: z
+      .array(z.string())
+      .describe('Equipment behavior flags (e.g., EXPLOSIVE, INCENDIARY)')
+      .optional(),
+    allowedUnitTypes: z
+      .array(
+        z.enum([
+          'BattleMech',
+          'OmniMech',
+          'IndustrialMech',
+          'ProtoMech',
+          'Vehicle',
+          'VTOL',
+          'Support Vehicle',
+          'Aerospace',
+          'Conventional Fighter',
+          'Small Craft',
+          'DropShip',
+          'JumpShip',
+          'WarShip',
+          'Space Station',
+          'Infantry',
+          'Battle Armor',
+        ]),
+      )
+      .describe(
+        'Unit types that can use this ammunition. If omitted, defaults to BattleMech, Vehicle, Aerospace.',
+      )
+      .optional(),
+  })
+  .strict()
+  .describe('Schema for BattleTech ammunition definitions');
+export type AmmunitionContract = z.infer<typeof AmmunitionContract>;

--- a/src/types/contracts/generated/electronics.zod.ts
+++ b/src/types/contracts/generated/electronics.zod.ts
@@ -1,0 +1,126 @@
+// @generated — do not edit; run `npm run schema:gen` to regenerate.
+// Source: public/data/equipment/_schema/electronics-schema.json
+// Regeneration: `node scripts/generate-zod-schemas.mjs` (see `scripts/generate-zod-schemas.mjs`).
+//
+// PR-A1 ships only the weapon shape through round-trip tests + loader
+// validation; PR-A2 wires the rest. The schema-bridge CI job verifies
+// these files match the JSON Schema source via `--check` mode.
+
+import { z } from 'zod';
+
+export const ElectronicsContract = z
+  .object({
+    id: z
+      .string()
+      .regex(new RegExp('^[a-z0-9-]+$'))
+      .describe('Unique identifier for the electronics (kebab-case)'),
+    name: z
+      .string()
+      .min(1)
+      .describe('Display name of the electronic equipment'),
+    category: z
+      .enum([
+        'Targeting',
+        'ECM',
+        'Active Probe',
+        'C3 System',
+        'TAG',
+        'Communications',
+      ])
+      .describe('Electronics category'),
+    techBase: z
+      .enum(['INNER_SPHERE', 'CLAN', 'BOTH'])
+      .describe('Technology base for the electronics'),
+    rulesLevel: z
+      .enum([
+        'INTRODUCTORY',
+        'STANDARD',
+        'ADVANCED',
+        'EXPERIMENTAL',
+        'UNOFFICIAL',
+      ])
+      .describe('Rules level/complexity'),
+    weight: z
+      .number()
+      .gte(0)
+      .describe('Weight in tons (0 for variable weight equipment)'),
+    criticalSlots: z
+      .number()
+      .int()
+      .gte(0)
+      .describe('Number of critical slots required (0 for variable)'),
+    costCBills: z
+      .number()
+      .gte(0)
+      .describe('Cost in C-Bills (0 for variable cost equipment)'),
+    battleValue: z
+      .number()
+      .gte(0)
+      .describe('Battle Value (0 for variable BV equipment)'),
+    introductionYear: z
+      .number()
+      .int()
+      .gte(1950)
+      .lte(3200)
+      .describe('Year the equipment was introduced'),
+    extinctionYear: z
+      .number()
+      .int()
+      .gte(1950)
+      .lte(3200)
+      .describe('Year the equipment became extinct (if applicable)')
+      .optional(),
+    reintroductionYear: z
+      .number()
+      .int()
+      .gte(1950)
+      .lte(3200)
+      .describe('Year the equipment was reintroduced (if applicable)')
+      .optional(),
+    special: z
+      .array(z.string())
+      .describe('Special abilities or rules')
+      .optional(),
+    variableEquipmentId: z
+      .string()
+      .describe('ID for variable equipment formula lookup')
+      .optional(),
+    flags: z
+      .array(z.string())
+      .describe('Equipment behavior flags (e.g., ECM, BAP, C3S)')
+      .optional(),
+    allowedUnitTypes: z
+      .array(
+        z.enum([
+          'BattleMech',
+          'OmniMech',
+          'IndustrialMech',
+          'ProtoMech',
+          'Vehicle',
+          'VTOL',
+          'Support Vehicle',
+          'Aerospace',
+          'Conventional Fighter',
+          'Small Craft',
+          'DropShip',
+          'JumpShip',
+          'WarShip',
+          'Space Station',
+          'Infantry',
+          'Battle Armor',
+        ]),
+      )
+      .describe(
+        'Unit types that can mount this equipment. If omitted, defaults to BattleMech, Vehicle, Aerospace.',
+      )
+      .optional(),
+    allowedLocations: z
+      .array(z.string())
+      .describe(
+        'Specific locations where this equipment can be mounted. If omitted, any valid equipment location is allowed.',
+      )
+      .optional(),
+  })
+  .strict()
+  .describe('Schema for BattleTech electronic equipment definitions');
+export type ElectronicsContract = z.infer<typeof ElectronicsContract>;

--- a/src/types/contracts/generated/misc-equipment.zod.ts
+++ b/src/types/contracts/generated/misc-equipment.zod.ts
@@ -1,0 +1,127 @@
+// @generated — do not edit; run `npm run schema:gen` to regenerate.
+// Source: public/data/equipment/_schema/misc-equipment-schema.json
+// Regeneration: `node scripts/generate-zod-schemas.mjs` (see `scripts/generate-zod-schemas.mjs`).
+//
+// PR-A1 ships only the weapon shape through round-trip tests + loader
+// validation; PR-A2 wires the rest. The schema-bridge CI job verifies
+// these files match the JSON Schema source via `--check` mode.
+
+import { z } from 'zod';
+
+export const MiscEquipmentContract = z
+  .object({
+    id: z
+      .string()
+      .regex(new RegExp('^[a-z0-9-]+$'))
+      .describe('Unique identifier for the equipment (kebab-case)'),
+    name: z.string().min(1).describe('Display name of the equipment'),
+    category: z
+      .enum([
+        'Heat Sink',
+        'Jump Jet',
+        'Movement Enhancement',
+        'Defensive',
+        'Myomer',
+        'Industrial',
+      ])
+      .describe('Equipment category'),
+    techBase: z
+      .enum(['INNER_SPHERE', 'CLAN', 'BOTH'])
+      .describe('Technology base for the equipment'),
+    rulesLevel: z
+      .enum([
+        'INTRODUCTORY',
+        'STANDARD',
+        'ADVANCED',
+        'EXPERIMENTAL',
+        'UNOFFICIAL',
+      ])
+      .describe('Rules level/complexity'),
+    weight: z
+      .number()
+      .gte(0)
+      .describe('Weight in tons (0 for variable weight equipment)'),
+    criticalSlots: z
+      .number()
+      .int()
+      .gte(0)
+      .describe('Number of critical slots required (0 for variable)'),
+    costCBills: z
+      .number()
+      .gte(0)
+      .describe('Cost in C-Bills (0 for variable cost equipment)'),
+    battleValue: z
+      .number()
+      .gte(0)
+      .describe('Battle Value (0 for variable BV equipment)'),
+    introductionYear: z
+      .number()
+      .int()
+      .gte(1950)
+      .lte(3200)
+      .describe('Year the equipment was introduced'),
+    extinctionYear: z
+      .number()
+      .int()
+      .gte(1950)
+      .lte(3200)
+      .describe('Year the equipment became extinct (if applicable)')
+      .optional(),
+    reintroductionYear: z
+      .number()
+      .int()
+      .gte(1950)
+      .lte(3200)
+      .describe('Year the equipment was reintroduced (if applicable)')
+      .optional(),
+    special: z
+      .array(z.string())
+      .describe('Special abilities or rules')
+      .optional(),
+    variableEquipmentId: z
+      .string()
+      .describe('ID for variable equipment formula lookup')
+      .optional(),
+    flags: z
+      .array(z.string())
+      .describe(
+        'Equipment behavior flags (e.g., HEAT_SINK, JUMP_JET, MASC, CASE)',
+      )
+      .optional(),
+    allowedUnitTypes: z
+      .array(
+        z.enum([
+          'BattleMech',
+          'OmniMech',
+          'IndustrialMech',
+          'ProtoMech',
+          'Vehicle',
+          'VTOL',
+          'Support Vehicle',
+          'Aerospace',
+          'Conventional Fighter',
+          'Small Craft',
+          'DropShip',
+          'JumpShip',
+          'WarShip',
+          'Space Station',
+          'Infantry',
+          'Battle Armor',
+        ]),
+      )
+      .describe(
+        'Unit types that can mount this equipment. If omitted, defaults to BattleMech, Vehicle, Aerospace.',
+      )
+      .optional(),
+    allowedLocations: z
+      .array(z.string())
+      .describe(
+        'Specific locations where this equipment can be mounted. If omitted, any valid equipment location is allowed.',
+      )
+      .optional(),
+  })
+  .strict()
+  .describe(
+    'Schema for BattleTech miscellaneous equipment definitions (heat sinks, jump jets, etc.)',
+  );
+export type MiscEquipmentContract = z.infer<typeof MiscEquipmentContract>;

--- a/src/types/contracts/generated/physical-weapon.zod.ts
+++ b/src/types/contracts/generated/physical-weapon.zod.ts
@@ -1,0 +1,126 @@
+// @generated — do not edit; run `npm run schema:gen` to regenerate.
+// Source: public/data/equipment/_schema/physical-weapon-schema.json
+// Regeneration: `node scripts/generate-zod-schemas.mjs` (see `scripts/generate-zod-schemas.mjs`).
+//
+// PR-A1 ships only the weapon shape through round-trip tests + loader
+// validation; PR-A2 wires the rest. The schema-bridge CI job verifies
+// these files match the JSON Schema source via `--check` mode.
+
+import { z } from 'zod';
+
+export const PhysicalWeaponContract = z
+  .object({
+    id: z
+      .string()
+      .regex(new RegExp('^[a-z0-9-]+$'))
+      .describe('Unique identifier for the physical weapon (kebab-case)'),
+    type: z
+      .enum([
+        'Hatchet',
+        'Sword',
+        'Claws',
+        'Mace',
+        'Lance',
+        'Flail',
+        'Wrecking Ball',
+        'Talons',
+        'Retractable Blade',
+      ])
+      .describe('Physical weapon type'),
+    name: z.string().min(1).describe('Display name of the weapon'),
+    techBase: z
+      .enum(['INNER_SPHERE', 'CLAN', 'BOTH'])
+      .describe('Technology base for the weapon'),
+    rulesLevel: z
+      .enum([
+        'INTRODUCTORY',
+        'STANDARD',
+        'ADVANCED',
+        'EXPERIMENTAL',
+        'UNOFFICIAL',
+      ])
+      .describe('Rules level/complexity'),
+    weightFormula: z
+      .enum(['tonnage_divisor', 'fixed'])
+      .describe('How weight is calculated'),
+    tonnageDivisor: z
+      .number()
+      .gte(1)
+      .describe('Divisor for tonnage-based weight calculation')
+      .optional(),
+    fixedWeight: z
+      .number()
+      .gte(0)
+      .describe("Fixed weight if weightFormula is 'fixed'")
+      .optional(),
+    damageFormula: z
+      .enum(['tonnage_divisor', 'tonnage_divisor_plus', 'fixed'])
+      .describe('How damage is calculated'),
+    damageDivisor: z
+      .number()
+      .gte(1)
+      .describe('Divisor for tonnage-based damage calculation')
+      .optional(),
+    damageBonus: z
+      .number()
+      .describe('Bonus damage added (for tonnage_divisor_plus)')
+      .optional(),
+    fixedDamage: z
+      .number()
+      .gte(0)
+      .describe("Fixed damage if damageFormula is 'fixed'")
+      .optional(),
+    criticalSlots: z
+      .number()
+      .int()
+      .gte(0)
+      .describe('Critical slots (0 if calculated from tonnage)'),
+    requiresLowerArm: z
+      .boolean()
+      .describe('Whether lower arm actuator is required'),
+    requiresHand: z.boolean().describe('Whether hand actuator is required'),
+    validLocations: z
+      .array(z.string())
+      .min(1)
+      .describe('Valid mounting locations'),
+    introductionYear: z
+      .number()
+      .int()
+      .gte(1950)
+      .lte(3200)
+      .describe('Year the weapon was introduced'),
+    costFormula: z.string().describe('Cost calculation formula').optional(),
+    special: z
+      .array(z.string())
+      .describe('Special rules for this weapon')
+      .optional(),
+    flags: z.array(z.string()).describe('Equipment behavior flags').optional(),
+    allowedUnitTypes: z
+      .array(
+        z.enum([
+          'BattleMech',
+          'OmniMech',
+          'IndustrialMech',
+          'ProtoMech',
+          'Vehicle',
+          'VTOL',
+          'Support Vehicle',
+          'Aerospace',
+          'Conventional Fighter',
+          'Small Craft',
+          'DropShip',
+          'JumpShip',
+          'WarShip',
+          'Space Station',
+          'Infantry',
+          'Battle Armor',
+        ]),
+      )
+      .describe(
+        'Unit types that can mount this weapon. Physical weapons are typically limited to BattleMechs.',
+      )
+      .optional(),
+  })
+  .strict()
+  .describe('Schema for BattleTech physical/melee weapon definitions');
+export type PhysicalWeaponContract = z.infer<typeof PhysicalWeaponContract>;

--- a/src/types/contracts/generated/unit.zod.ts
+++ b/src/types/contracts/generated/unit.zod.ts
@@ -1,0 +1,294 @@
+// @generated — do not edit; run `npm run schema:gen` to regenerate.
+// Source: public/data/equipment/_schema/unit-schema.json
+// Regeneration: `node scripts/generate-zod-schemas.mjs` (see `scripts/generate-zod-schemas.mjs`).
+//
+// PR-A1 ships only the weapon shape through round-trip tests + loader
+// validation; PR-A2 wires the rest. The schema-bridge CI job verifies
+// these files match the JSON Schema source via `--check` mode.
+
+import { z } from 'zod';
+
+export const UnitContract = z
+  .object({
+    id: z
+      .string()
+      .regex(new RegExp('^[a-z0-9-]+$'))
+      .describe('Unique identifier for the unit (kebab-case)'),
+    chassis: z.string().min(1).describe("Chassis name (e.g., 'Atlas')"),
+    model: z.string().min(1).describe("Model designation (e.g., 'AS7-D')"),
+    variant: z.string().describe('Optional variant name').optional(),
+    unitType: z
+      .enum([
+        'BattleMech',
+        'OmniMech',
+        'IndustrialMech',
+        'ProtoMech',
+        'Vehicle',
+        'VTOL',
+        'Aerospace',
+        'Conventional Fighter',
+        'Small Craft',
+        'DropShip',
+        'JumpShip',
+        'WarShip',
+        'Space Station',
+        'Infantry',
+        'Battle Armor',
+        'Support Vehicle',
+      ])
+      .describe('Type of unit'),
+    configuration: z
+      .enum(['Biped', 'Quad', 'Tripod', 'LAM', 'QuadVee'])
+      .describe('Mech configuration'),
+    techBase: z
+      .enum(['INNER_SPHERE', 'CLAN', 'MIXED'])
+      .describe('Technology base'),
+    rulesLevel: z
+      .enum([
+        'INTRODUCTORY',
+        'STANDARD',
+        'ADVANCED',
+        'EXPERIMENTAL',
+        'UNOFFICIAL',
+      ])
+      .describe('Rules level/complexity'),
+    era: z.string().describe('BattleTech era identifier'),
+    year: z.number().int().gte(1950).lte(3200).describe('Introduction year'),
+    tonnage: z.number().gte(10).lte(200).describe('Unit tonnage'),
+    engine: z
+      .object({
+        type: z
+          .enum([
+            'FUSION',
+            'XL',
+            'CLAN_XL',
+            'LIGHT',
+            'COMPACT',
+            'XXL',
+            'ICE',
+            'FUEL_CELL',
+            'FISSION',
+          ])
+          .describe('Engine type'),
+        rating: z.number().int().gte(10).lte(500).describe('Engine rating'),
+      })
+      .strict(),
+    gyro: z
+      .object({
+        type: z
+          .enum(['STANDARD', 'XL', 'COMPACT', 'HEAVY_DUTY', 'NONE'])
+          .describe('Gyro type'),
+      })
+      .strict(),
+    cockpit: z
+      .enum([
+        'STANDARD',
+        'SMALL',
+        'COMMAND_CONSOLE',
+        'TORSO_MOUNTED',
+        'PRIMITIVE',
+        'INDUSTRIAL',
+        'SUPERHEAVY',
+        'SUPERHEAVY_TRIPOD',
+        'INTERFACE',
+        'QUADVEE',
+      ])
+      .describe('Cockpit type'),
+    structure: z
+      .object({
+        type: z
+          .enum([
+            'STANDARD',
+            'ENDO_STEEL',
+            'ENDO_STEEL_CLAN',
+            'ENDO_COMPOSITE',
+            'REINFORCED',
+            'COMPOSITE',
+            'INDUSTRIAL',
+          ])
+          .describe('Internal structure type'),
+      })
+      .strict(),
+    armor: z
+      .object({
+        type: z
+          .enum([
+            'STANDARD',
+            'FERRO_FIBROUS',
+            'FERRO_FIBROUS_CLAN',
+            'LIGHT_FERRO_FIBROUS',
+            'HEAVY_FERRO_FIBROUS',
+            'STEALTH',
+            'REACTIVE',
+            'REFLECTIVE',
+            'HARDENED',
+            'PRIMITIVE',
+            'INDUSTRIAL',
+          ])
+          .describe('Armor type'),
+        allocation: z
+          .record(
+            z.string(),
+            z.any().superRefine((x, ctx) => {
+              const schemas = [
+                z.number().int().gte(0),
+                z
+                  .object({
+                    front: z.number().int().gte(0),
+                    rear: z.number().int().gte(0),
+                  })
+                  .strict(),
+              ];
+              const { errors, failed } = schemas.reduce<{
+                errors: z.core.$ZodIssue[];
+                failed: number;
+              }>(
+                ({ errors, failed }, schema) =>
+                  ((result) =>
+                    result.error
+                      ? {
+                          errors: [...errors, ...result.error.issues],
+                          failed: failed + 1,
+                        }
+                      : { errors, failed })(schema.safeParse(x)),
+                { errors: [], failed: 0 },
+              );
+              const passed = schemas.length - failed;
+              if (passed !== 1) {
+                ctx.addIssue(
+                  errors.length
+                    ? {
+                        path: [],
+                        code: 'invalid_union',
+                        errors: [errors],
+                        message:
+                          'Invalid input: Should pass single schema. Passed ' +
+                          passed,
+                      }
+                    : {
+                        path: [],
+                        code: 'custom',
+                        errors: [errors],
+                        message:
+                          'Invalid input: Should pass single schema. Passed ' +
+                          passed,
+                      },
+                );
+              }
+            }),
+          )
+          .describe('Armor points per location'),
+      })
+      .strict(),
+    heatSinks: z
+      .object({
+        type: z
+          .enum(['SINGLE', 'DOUBLE', 'DOUBLE_CLAN', 'COMPACT', 'LASER'])
+          .describe('Heat sink type'),
+        count: z.number().int().gte(0).describe('Total number of heat sinks'),
+      })
+      .strict(),
+    movement: z
+      .object({
+        walk: z.number().int().gte(0).describe('Walking MP'),
+        jump: z.number().int().gte(0).describe('Jumping MP'),
+        jumpJetType: z
+          .enum(['STANDARD', 'IMPROVED', 'MECHANICAL', 'UMU'])
+          .describe('Jump jet type')
+          .optional(),
+        enhancements: z
+          .array(z.string())
+          .describe('Movement enhancements (MASC, Supercharger, etc.)')
+          .optional(),
+      })
+      .strict(),
+    equipment: z
+      .array(
+        z
+          .object({
+            id: z.string().describe('Equipment ID reference'),
+            location: z.string().describe('Mounting location'),
+            slots: z
+              .array(z.number().int())
+              .describe('Specific slot indices')
+              .optional(),
+            isRearMounted: z
+              .boolean()
+              .describe('Whether weapon is rear-facing')
+              .default(false),
+            linkedAmmo: z.string().describe('Linked ammunition ID').optional(),
+          })
+          .strict(),
+      )
+      .describe('Mounted equipment list'),
+    criticalSlots: z
+      .record(
+        z.string(),
+        z.array(
+          z.any().superRefine((x, ctx) => {
+            const schemas = [z.string(), z.null()];
+            const { errors, failed } = schemas.reduce<{
+              errors: z.core.$ZodIssue[];
+              failed: number;
+            }>(
+              ({ errors, failed }, schema) =>
+                ((result) =>
+                  result.error
+                    ? {
+                        errors: [...errors, ...result.error.issues],
+                        failed: failed + 1,
+                      }
+                    : { errors, failed })(schema.safeParse(x)),
+              { errors: [], failed: 0 },
+            );
+            const passed = schemas.length - failed;
+            if (passed !== 1) {
+              ctx.addIssue(
+                errors.length
+                  ? {
+                      path: [],
+                      code: 'invalid_union',
+                      errors: [errors],
+                      message:
+                        'Invalid input: Should pass single schema. Passed ' +
+                        passed,
+                    }
+                  : {
+                      path: [],
+                      code: 'custom',
+                      errors: [errors],
+                      message:
+                        'Invalid input: Should pass single schema. Passed ' +
+                        passed,
+                    },
+              );
+            }
+          }),
+        ),
+      )
+      .describe('Critical slot assignments per location'),
+    quirks: z.array(z.string()).describe('Unit quirks').optional(),
+    fluff: z
+      .object({
+        overview: z.string().optional(),
+        capabilities: z.string().optional(),
+        history: z.string().optional(),
+        deployment: z.string().optional(),
+        variants: z.string().optional(),
+        notableUnits: z.string().optional(),
+        manufacturer: z.string().optional(),
+        primaryFactory: z.string().optional(),
+        systemManufacturer: z.record(z.string(), z.string()).optional(),
+      })
+      .strict()
+      .describe('Fluff/flavor text')
+      .optional(),
+    mulId: z.number().int().describe('Master Unit List ID').optional(),
+    role: z.string().describe('Combat role').optional(),
+    source: z.string().describe('Source book/publication').optional(),
+  })
+  .strict()
+  .describe(
+    'Schema for serialized BattleTech unit definitions (BattleMechs, vehicles, etc.)',
+  );
+export type UnitContract = z.infer<typeof UnitContract>;

--- a/src/types/contracts/generated/weapon.zod.ts
+++ b/src/types/contracts/generated/weapon.zod.ts
@@ -1,0 +1,180 @@
+// @generated — do not edit; run `npm run schema:gen` to regenerate.
+// Source: public/data/equipment/_schema/weapon-schema.json
+// Regeneration: `node scripts/generate-zod-schemas.mjs` (see `scripts/generate-zod-schemas.mjs`).
+//
+// PR-A1 ships only the weapon shape through round-trip tests + loader
+// validation; PR-A2 wires the rest. The schema-bridge CI job verifies
+// these files match the JSON Schema source via `--check` mode.
+
+import { z } from 'zod';
+
+export const WeaponContract = z
+  .object({
+    id: z
+      .string()
+      .regex(new RegExp('^[a-z0-9-]+$'))
+      .describe('Unique identifier for the weapon (kebab-case)'),
+    name: z.string().min(1).describe('Display name of the weapon'),
+    category: z
+      .enum(['Energy', 'Ballistic', 'Missile', 'Physical', 'Artillery'])
+      .describe('Primary weapon category'),
+    subType: z
+      .string()
+      .describe('Specific weapon sub-type within the category'),
+    techBase: z
+      .enum(['INNER_SPHERE', 'CLAN', 'BOTH'])
+      .describe('Technology base for the weapon'),
+    rulesLevel: z
+      .enum([
+        'INTRODUCTORY',
+        'STANDARD',
+        'ADVANCED',
+        'EXPERIMENTAL',
+        'UNOFFICIAL',
+      ])
+      .describe('Rules level/complexity'),
+    damage: z
+      .any()
+      .superRefine((x, ctx) => {
+        const schemas = [
+          z.number().gte(0),
+          z.string().describe("Variable damage like '1/missile'"),
+        ];
+        const { errors, failed } = schemas.reduce<{
+          errors: z.core.$ZodIssue[];
+          failed: number;
+        }>(
+          ({ errors, failed }, schema) =>
+            ((result) =>
+              result.error
+                ? {
+                    errors: [...errors, ...result.error.issues],
+                    failed: failed + 1,
+                  }
+                : { errors, failed })(schema.safeParse(x)),
+          { errors: [], failed: 0 },
+        );
+        const passed = schemas.length - failed;
+        if (passed !== 1) {
+          ctx.addIssue(
+            errors.length
+              ? {
+                  path: [],
+                  code: 'invalid_union',
+                  errors: [errors],
+                  message:
+                    'Invalid input: Should pass single schema. Passed ' +
+                    passed,
+                }
+              : {
+                  path: [],
+                  code: 'custom',
+                  errors: [errors],
+                  message:
+                    'Invalid input: Should pass single schema. Passed ' +
+                    passed,
+                },
+          );
+        }
+      })
+      .describe('Damage value or formula'),
+    heat: z.number().gte(0).describe('Heat generated when firing'),
+    ranges: z
+      .object({
+        minimum: z
+          .number()
+          .gte(0)
+          .describe('Minimum range (no penalty inside)'),
+        short: z.number().gte(0).describe('Short range bracket'),
+        medium: z.number().gte(0).describe('Medium range bracket'),
+        long: z.number().gte(0).describe('Long range bracket'),
+        extreme: z
+          .number()
+          .gte(0)
+          .describe('Extreme range bracket (optional)')
+          .optional(),
+      })
+      .strict(),
+    weight: z.number().gte(0).describe('Weight in tons'),
+    criticalSlots: z
+      .number()
+      .int()
+      .gte(0)
+      .describe('Number of critical slots required'),
+    ammoPerTon: z
+      .number()
+      .int()
+      .gte(1)
+      .describe('Shots per ton of ammunition (if applicable)')
+      .optional(),
+    costCBills: z.number().gte(0).describe('Cost in C-Bills'),
+    battleValue: z.number().gte(0).describe('Battle Value for the weapon'),
+    introductionYear: z
+      .number()
+      .int()
+      .gte(1950)
+      .lte(3200)
+      .describe('Year the weapon was introduced'),
+    extinctionYear: z
+      .number()
+      .int()
+      .gte(1950)
+      .lte(3200)
+      .describe('Year the weapon became extinct (if applicable)')
+      .optional(),
+    reintroductionYear: z
+      .number()
+      .int()
+      .gte(1950)
+      .lte(3200)
+      .describe('Year the weapon was reintroduced (if applicable)')
+      .optional(),
+    isExplosive: z
+      .boolean()
+      .describe('Whether the weapon causes ammo explosions')
+      .default(false),
+    special: z
+      .array(z.string())
+      .describe('Special abilities or rules')
+      .optional(),
+    flags: z
+      .array(z.string())
+      .describe(
+        'Equipment behavior flags for rules processing (e.g., PULSE, DIRECT_FIRE, AMS)',
+      )
+      .optional(),
+    allowedUnitTypes: z
+      .array(
+        z.enum([
+          'BattleMech',
+          'OmniMech',
+          'IndustrialMech',
+          'ProtoMech',
+          'Vehicle',
+          'VTOL',
+          'Support Vehicle',
+          'Aerospace',
+          'Conventional Fighter',
+          'Small Craft',
+          'DropShip',
+          'JumpShip',
+          'WarShip',
+          'Space Station',
+          'Infantry',
+          'Battle Armor',
+        ]),
+      )
+      .describe(
+        'Unit types that can mount this weapon. If omitted, defaults to BattleMech, Vehicle, Aerospace.',
+      )
+      .optional(),
+    allowedLocations: z
+      .array(z.string())
+      .describe(
+        'Specific locations where this weapon can be mounted. If omitted, any valid weapon location is allowed.',
+      )
+      .optional(),
+  })
+  .strict()
+  .describe('Schema for BattleTech weapon equipment definitions');
+export type WeaponContract = z.infer<typeof WeaponContract>;

--- a/src/types/contracts/index.ts
+++ b/src/types/contracts/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Cross-language schema contracts.
+ *
+ * The Zod schemas under `./generated/*.zod.ts` are generated from the
+ * canonical JSON Schemas at `public/data/equipment/_schema/*.json` via
+ * `npm run schema:gen`. Python writers validate the same shapes using
+ * `jsonschema.Draft7Validator` (see `scripts/megameklab-conversion/schema_gate.py`).
+ *
+ * In PR-A1 only the weapon shape is exported here. The remaining 5
+ * shapes (unit, ammunition, electronics, misc-equipment, physical-weapon)
+ * are generated alongside but stay un-exported until PR-A2 wires their
+ * round-trip tests and consumer migrations.
+ *
+ * Naming convention:
+ *  - `WeaponContract`  — runtime Zod schema (parse/safeParse)
+ *  - `IWeaponContract` — inferred TypeScript type (boundary shape)
+ *
+ * Rich domain interfaces (e.g. `IWeapon` in `src/types/equipment/...`)
+ * remain the in-memory shape. Contracts are the parse boundary; an
+ * adapter layer bridges contract -> domain incrementally so the existing
+ * 167 `as any` / `as unknown` casts can migrate file-by-file.
+ */
+
+import type { z } from 'zod';
+
+import { WeaponContract as WeaponContractSchema } from './generated/weapon.zod';
+
+// Re-export the runtime schema under the canonical contract name.
+export const WeaponContract = WeaponContractSchema;
+
+// Inferred boundary type. The generator emits a `type WeaponContract`
+// alongside the schema; we re-export it under the conventional `I`
+// prefix used elsewhere in `src/types/`.
+export type IWeaponContract = z.infer<typeof WeaponContractSchema>;


### PR DESCRIPTION
## Summary

PR-A1 of the cross-language schema bridge. Closes the silent-drift gap that surfaced as the `bv: null` audit (PR #405) by anchoring **both** the Python BLK/MTF writers and the TypeScript runtime readers on the canonical JSON Schemas at `public/data/equipment/_schema/*.json`.

This PR ships the **weapon shape** through the full pipeline as a pilot. PR-A2 will roll out the remaining 5 shapes (unit, ammunition, electronics, misc-equipment, physical-weapon), fix the 6 known corpus drift items it discovered, and flip the gate from non-blocking to strict.

## Strategy

- **Source of truth**: `public/data/equipment/_schema/*.json` (already in-tree, unchanged here).
- **Python**: `jsonschema.Draft7Validator` via a new `schema_gate.py` (lazy compilation, cached per shape).
- **TypeScript**: Zod, generated at build time by `scripts/generate-zod-schemas.mjs` using `json-schema-to-zod`. Generated `*.zod.ts` files are committed; the `schema-bridge` CI job runs `--check` mode and fails on drift.
- **No third format introduced.**

## In this PR

| Surface | What ships |
|---|---|
| Generator | `scripts/generate-zod-schemas.mjs` reads each schema, emits Zod, runs `oxfmt` so re-runs are stable. `--check` mode = drift detection. |
| npm scripts | `schema:gen`, `schema:gen-check`. |
| Generated Zod | All **6** shapes generated under `src/types/contracts/generated/`. Only **weapon** is exported via the `src/types/contracts/index.ts` barrel — others are committed but un-exported until PR-A2 wires their consumers. |
| Round-trip tests | `src/types/contracts/__tests__/weapon.contract.test.ts` — 16 tests covering 5 weapon files (Energy/Laser, Energy/PPC, Ballistic/AC, Ballistic/MG, Missile/LRM) plus a negative control. 6 known corpus drift items (X-Pulse + VSP lasers missing `costCBills`) tracked via `knownDriftIds` for PR-A2 to fix. |
| Python schema_gate | `scripts/megameklab-conversion/schema_gate.py` with `validate_<weapon\|unit\|ammunition\|electronics\|misc_equipment\|physical_weapon>` entry points. |
| Python writers | `blk_common.write_weapon_json` + placeholder `write_unit_json` / `write_equipment_json`. Validation gated on `MEKSTATION_VALIDATE_WRITES=1`; default off in PR-A1. |
| Python CLI | `run_schema_validation_only.py` rewritten — walks `public/data/equipment/official/<shape>/*.json`, supports `--strict` and repeatable `--shape` (defaults to `weapon`; `--shape all` enables every shape). Writes a JSON report to `validation-output/schema-bridge-report.json`. `validator.py --strict --shape weapon` is a thin alias. |
| TS loader integration | `src/services/equipment/EquipmentLoaderService.ts` — dev/test-only `WeaponContract.safeParse` on every weapon item. Production guarded out via `process.env.NODE_ENV !== 'production'`. Non-throwing default (`console.warn`); set `MEKSTATION_STRICT_SCHEMA_BRIDGE=1` to throw. |
| CI | New `schema-bridge` job runs `schema:gen-check` + Python corpus check + Jest round-trip. Added to the `lint-and-test` aggregator so branch protection picks it up. **Existing required-check names left unchanged** ("Lint and Test", "Build Test / win\|mac\|linux"). Uploads the JSON report as an artifact. |
| Docs | `scripts/megameklab-conversion/README.md` gets a new "Schema gate" section documenting all of the above. |

## Deferred to PR-A2

- Wire the other **5 shapes** (`UnitContract`, `AmmunitionContract`, `ElectronicsContract`, `MiscEquipmentContract`, `PhysicalWeaponContract`) through the contracts barrel + round-trip tests + loader integration.
- Fix the **6 known corpus drift items** (X-Pulse and VSP lasers missing `costCBills` in `weapons/energy-laser.json`).
- Flip the corpus-conformance CI step to **`--strict --shape all`** so any drift becomes a hard CI failure.
- Flip `MEKSTATION_VALIDATE_WRITES` default to `1` in `blk_common`.
- Flip the loader to **throw mode** by default (drop the warn fallback once corpus is clean).
- Migrate `src/lib/units/unitLoader.ts` to use a `parseUnit` adapter as the proof-of-concept consumer migration; file follow-up issue for the remaining 166 type casts.

> Note for reviewers: the generated `src/types/contracts/generated/weapon.zod.ts` (and the 5 sibling shapes) are checked in but should NOT be hand-edited. Regenerate via `npm run schema:gen`. The `schema-bridge` CI job enforces drift detection.

> Note: corpus conformance is intentionally **non-blocking in this PR**; PR-A2 will flip it strict and fix the 6 known drift items.

## Test results

| Gate | Result |
|---|---|
| `npx tsc --noEmit --skipLibCheck` | clean |
| `npm run lint` | 0 errors, 32 pre-existing warnings |
| `npm run format:check` | clean |
| `npm run schema:gen-check` | clean (Zod matches JSON Schema source) |
| `npx jest --no-coverage` | **22151 passed**, 44 skipped, 1 suite skipped |
| `npx jest src/types/contracts` | **16 passed** |
| `python run_schema_validation_only.py --shape weapon` | 459 items / 6 known drift / exit 0 (non-strict, as intended in PR-A1) |
| `python run_schema_validation_only.py --shape weapon --strict` | exit 1 (verifies strict-mode wiring works for PR-A2) |

## Test plan

- [ ] CI's new `schema-bridge` job is green on first run.
- [ ] CI's existing `validate-bv` / `Lint and Test` / `Build Test / *` jobs unchanged.
- [ ] Reviewer can read `weapon.zod.ts` and spot-check it against `weapon-schema.json`.
- [ ] Reviewer mentally walks the loader change: dev/test paths emit a warning when an X-Pulse / VSP laser is loaded; production paths short-circuit before touching the contract.