### PR TITLE
chore(deps): break ArmorPipLayout 3-way cycle

### DIFF
--- a/src/services/printing/ArmorPipLayout.grouped.ts
+++ b/src/services/printing/ArmorPipLayout.grouped.ts
@@ -1,6 +1,6 @@
 import type { ProcessLayoutParams } from './ArmorPipLayout.types';
 
-import { Bounds } from './ArmorPipLayout';
+import { Bounds } from './ArmorPipLayout.types';
 
 export function processGroupedByFiveLayout(
   params: ProcessLayoutParams,

--- a/src/services/printing/ArmorPipLayout.processing.ts
+++ b/src/services/printing/ArmorPipLayout.processing.ts
@@ -1,6 +1,6 @@
 import type { ProcessLayoutParams } from './ArmorPipLayout.types';
 
-import { Bounds } from './ArmorPipLayout';
+import { Bounds } from './ArmorPipLayout.types';
 
 const PRECISION = 0.01;
 const DEFAULT_PIP_SIZE = 0.4;

--- a/src/services/printing/ArmorPipLayout.ts
+++ b/src/services/printing/ArmorPipLayout.ts
@@ -1,5 +1,10 @@
 import { processGroupedByFiveLayout } from './ArmorPipLayout.grouped';
 import { processStandardLayout } from './ArmorPipLayout.processing';
+import { Bounds } from './ArmorPipLayout.types';
+
+// Re-export Bounds for backward compatibility — historical consumers
+// imported it from './ArmorPipLayout' before the leaf-extraction refactor.
+export { Bounds };
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 const PRECISION = 0.01;
@@ -15,43 +20,6 @@ export interface PipOptions {
   className?: string;
   staggered?: boolean;
   groupByFive?: boolean;
-}
-
-export class Bounds {
-  constructor(
-    public readonly left: number,
-    public readonly top: number,
-    public readonly right: number,
-    public readonly bottom: number,
-  ) {}
-
-  get width(): number {
-    return this.right - this.left;
-  }
-
-  get height(): number {
-    return this.bottom - this.top;
-  }
-
-  get centerX(): number {
-    return this.left + this.width / 2;
-  }
-
-  get centerY(): number {
-    return this.top + this.height / 2;
-  }
-
-  static fromRect(rect: Element): Bounds {
-    const x = parseFloat(rect.getAttribute('x') || '0');
-    const y = parseFloat(rect.getAttribute('y') || '0');
-    const width = parseFloat(rect.getAttribute('width') || '0');
-    const height = parseFloat(rect.getAttribute('height') || '0');
-    return new Bounds(x, y, x + width, y + height);
-  }
-
-  static empty(): Bounds {
-    return new Bounds(0, 0, 0, 0);
-  }
 }
 
 export class ArmorPipLayout {

--- a/src/services/printing/ArmorPipLayout.types.ts
+++ b/src/services/printing/ArmorPipLayout.types.ts
@@ -1,4 +1,43 @@
-import { Bounds } from './ArmorPipLayout';
+// Leaf module: pure types/classes shared across ArmorPipLayout siblings.
+// Must NOT import from ./ArmorPipLayout, ./ArmorPipLayout.grouped, or
+// ./ArmorPipLayout.processing — keeps the printing dependency graph acyclic.
+
+export class Bounds {
+  constructor(
+    public readonly left: number,
+    public readonly top: number,
+    public readonly right: number,
+    public readonly bottom: number,
+  ) {}
+
+  get width(): number {
+    return this.right - this.left;
+  }
+
+  get height(): number {
+    return this.bottom - this.top;
+  }
+
+  get centerX(): number {
+    return this.left + this.width / 2;
+  }
+
+  get centerY(): number {
+    return this.top + this.height / 2;
+  }
+
+  static fromRect(rect: Element): Bounds {
+    const x = parseFloat(rect.getAttribute('x') || '0');
+    const y = parseFloat(rect.getAttribute('y') || '0');
+    const width = parseFloat(rect.getAttribute('width') || '0');
+    const height = parseFloat(rect.getAttribute('height') || '0');
+    return new Bounds(x, y, x + width, y + height);
+  }
+
+  static empty(): Bounds {
+    return new Bounds(0, 0, 0, 0);
+  }
+}
 
 export interface ProcessLayoutParams {
   pipCount: number;


### PR DESCRIPTION
## Summary

Breaks the 3-way circular dependency in `src/services/printing/ArmorPipLayout*.ts` by promoting `ArmorPipLayout.types.ts` to a true leaf module. Plan reference: Phase B / PR-B5 of the repo-wide cycle-break sweep.

## Strategy

`ArmorPipLayout.types.ts` previously imported `Bounds` from `ArmorPipLayout.ts`, which created the seed of the 3-way cycle (orchestrator depends on both helpers and the types module that depended back on the orchestrator). The fix:

- **Move `Bounds` class into `ArmorPipLayout.types.ts`** — the leaf now declares both `Bounds` and `ProcessLayoutParams` and imports nothing from its siblings.
- **Re-export `Bounds` from `ArmorPipLayout.ts`** for backward compat (no external consumer breakage; only sibling files used `Bounds` directly).
- **Update `.grouped.ts` and `.processing.ts`** to import `Bounds` from `.types.ts` directly instead of routing through `.ts`.

Final dependency shape (unidirectional):
```
ArmorPipLayout.types.ts          (leaf — no sibling imports)
        ▲      ▲         ▲
        │      │         │
        │      │         │
.grouped.ts   .processing.ts    ArmorPipLayout.ts
                                       │
                                       ├──→ .grouped.ts
                                       └──→ .processing.ts
```

## Cycles closed

Before (`npx madge --circular --extensions ts,tsx src/services/printing/`):
```
✖ Found 3 circular dependencies!

1) ArmorPipLayout.grouped.ts > ArmorPipLayout.ts
2) ArmorPipLayout.ts > ArmorPipLayout.processing.ts
3) ArmorPipLayout.ts > ArmorPipLayout.processing.ts > ArmorPipLayout.types.ts
```

After:
```
✔ No circular dependency found!
```

Repo-wide cycle count dropped from 18 → 15 (the remaining 15 are unrelated targets owned by parallel PRs and pre-existing work).

## What moved where

| File | Change |
|---|---|
| `ArmorPipLayout.types.ts` | Now declares `Bounds` (was: only `ProcessLayoutParams`). No sibling imports. |
| `ArmorPipLayout.ts` | Removed local `Bounds` class. Imports `Bounds` from `.types.ts`. Re-exports `Bounds` for backward compat. |
| `ArmorPipLayout.grouped.ts` | Switched `Bounds` import source from `./ArmorPipLayout` → `./ArmorPipLayout.types`. |
| `ArmorPipLayout.processing.ts` | Switched `Bounds` import source from `./ArmorPipLayout` → `./ArmorPipLayout.types`. |

Net diff: 4 files, +47 / −40 lines.

## Behavior

Zero behavior change. `Bounds` is a pure value class (no side effects, no module-init coupling); moving the declaration only changes which file owns the `class` keyword.

## Verification

- `npx tsc --noEmit --skipLibCheck` → 0 errors
- `npx oxlint src/services/printing/ArmorPipLayout*.ts` → 0 warnings, 0 errors
- `npx oxfmt --check` → format-clean
- `npx jest src/services/printing src/__tests__/service/printing` → **285 / 285 pass** (8 suites: ArmorPipLayout, RecordSheetService, SVGRecordSheetRenderer, structure, equipment, criticals, equipmentUtils, spaSection)
- `npx madge --circular --extensions ts,tsx src/services/printing/` → 0 cycles
- Pre-commit hook (oxlint --fix → oxfmt --write → tsc --noEmit → next build) → green

## Test plan

- [ ] CI green on `chore/break-armorpiplayout-cycle`
- [ ] Visual smoke check: open a record sheet for any BattleMech and confirm armor/structure pip rendering matches main (no missing pips, no positional drift)
- [ ] Confirm no other branch in flight expected `Bounds` to live in `ArmorPipLayout.ts` only (re-export covers this)