### PR TITLE
test(bv-core): add Tier 1 invariant tests for battleValue + aerospace construction

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,15 +23,20 @@ const customJestConfig = {
     '!**/*.d.ts',
   ],
   // Coverage thresholds - will fail if coverage drops below these levels
-  // Set based on coverage analysis from 2025-12-03
+  // Ratcheted on 2026-04-25 after Tier 1 BV-core invariant tests landed
+  // (PR-C1: ~110 new tests for battleValue*, aerospace, engine/gyro/heat-sink/
+  // armor/cost, equipmentBV, techBaseValidation). Pre-PR baseline reported
+  // 67.43% statements / 58.23% branches / 60.37% functions / 69.48% lines
+  // globally; new threshold sits well below the baseline to act as a true
+  // ratchet without flapping on small refactors.
   // Note: Directory-specific thresholds removed due to Jest path matching issues.
   // Global thresholds are sufficient for CI enforcement.
   coverageThreshold: {
     global: {
-      statements: 45,
-      branches: 35,
-      functions: 40,
-      lines: 45,
+      statements: 55,
+      branches: 45,
+      functions: 50,
+      lines: 55,
     },
   },
   // Report formats: text, lcov (for CI), html (for browsing)

--- a/src/utils/construction/__tests__/armorCalculations.test.ts
+++ b/src/utils/construction/__tests__/armorCalculations.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Armor calculation invariants.
+ *
+ * Standard armor: 16 points/ton, no slots, ×1 cost.
+ * Ferro-Fibrous: IS 17.92 pts/t (14 slots), Clan 19.2 pts/t (7 slots).
+ * Hardened: 16 pts/t but ×2 cost multiplier.
+ * Maximum head armor is 9 points; per-location max = 2× internal structure.
+ */
+
+import { ArmorTypeEnum } from '@/types/construction/ArmorType';
+import { MechConfiguration } from '@/types/unit/BattleMechInterfaces';
+
+import {
+  calculateArmorCost,
+  calculateArmorPoints,
+  calculateArmorWeight,
+  calculateOptimalArmorAllocation,
+  getArmorCriticalSlots,
+  getArmorFillPercent,
+  getMaxArmorForLocation,
+  getMaxTotalArmor,
+  MAX_HEAD_ARMOR,
+  validateLocationArmor,
+} from '../armorCalculations';
+
+describe('MAX_HEAD_ARMOR contract', () => {
+  it('is exactly 9 (BattleTech rule)', () => {
+    expect(MAX_HEAD_ARMOR).toBe(9);
+  });
+});
+
+describe('calculateArmorPoints / calculateArmorWeight', () => {
+  it('Standard armor: 16 pts per ton', () => {
+    expect(calculateArmorPoints(10, ArmorTypeEnum.STANDARD)).toBe(160);
+    expect(calculateArmorWeight(160, ArmorTypeEnum.STANDARD)).toBe(10);
+  });
+
+  it('Ferro-Fibrous IS: 17.92 pts/t (math truncates point count)', () => {
+    // 10 t × 17.92 = 179.2 → floor → 179
+    expect(calculateArmorPoints(10, ArmorTypeEnum.FERRO_FIBROUS_IS)).toBe(179);
+  });
+
+  it('Ferro-Fibrous Clan: 19.2 pts/t', () => {
+    // 5 t × 19.2 = 96 → floor → 96
+    expect(calculateArmorPoints(5, ArmorTypeEnum.FERRO_FIBROUS_CLAN)).toBe(96);
+  });
+
+  it('weight rounds UP to nearest 0.5 ton', () => {
+    // 161 / 16 = 10.0625 → ceil 0.5 → 10.5
+    expect(calculateArmorWeight(161, ArmorTypeEnum.STANDARD)).toBe(10.5);
+  });
+});
+
+describe('getArmorCriticalSlots', () => {
+  it('Standard armor consumes no critical slots', () => {
+    expect(getArmorCriticalSlots(ArmorTypeEnum.STANDARD)).toBe(0);
+  });
+
+  it('Ferro-Fibrous IS uses 14 critical slots', () => {
+    expect(getArmorCriticalSlots(ArmorTypeEnum.FERRO_FIBROUS_IS)).toBe(14);
+  });
+
+  it('Ferro-Fibrous Clan uses 7 critical slots', () => {
+    expect(getArmorCriticalSlots(ArmorTypeEnum.FERRO_FIBROUS_CLAN)).toBe(7);
+  });
+});
+
+describe('calculateArmorCost (10 000 cBills/pt × cost multiplier)', () => {
+  it('Standard armor: 10 000 cBills per point', () => {
+    expect(calculateArmorCost(100, ArmorTypeEnum.STANDARD)).toBe(1_000_000);
+  });
+
+  it('Hardened armor: ×2.5 cost multiplier (per ArmorType definitions)', () => {
+    expect(calculateArmorCost(100, ArmorTypeEnum.HARDENED)).toBe(2_500_000);
+  });
+});
+
+describe('getMaxArmorForLocation', () => {
+  it('Head is always 9 regardless of tonnage', () => {
+    expect(getMaxArmorForLocation(20, 'head')).toBe(9);
+    expect(getMaxArmorForLocation(100, 'Head')).toBe(9);
+  });
+
+  it('Other locations cap at 2× internal structure', () => {
+    // 50t CT internal = 16 → max armor 32
+    expect(getMaxArmorForLocation(50, 'centerTorso')).toBe(32);
+    // 50t arm internal = 8 → max 16
+    expect(getMaxArmorForLocation(50, 'leftArm')).toBe(16);
+  });
+});
+
+describe('validateLocationArmor', () => {
+  it('flags total exceeding location max', () => {
+    const r = validateLocationArmor(50, 'centerTorso', 30, 5);
+    expect(r.isValid).toBe(false);
+    expect(r.errors[0]).toMatch(/exceeds maximum/);
+  });
+
+  it('rejects negative armor values', () => {
+    const r = validateLocationArmor(50, 'centerTorso', -1, 0);
+    expect(r.isValid).toBe(false);
+  });
+
+  it('rejects rear armor on non-torso locations', () => {
+    const r = validateLocationArmor(50, 'leftArm', 10, 5);
+    expect(r.isValid).toBe(false);
+    expect(r.errors.some((e) => /rear armor/.test(e))).toBe(true);
+  });
+
+  it('allows rear armor on torso locations', () => {
+    const r = validateLocationArmor(50, 'centerTorso', 20, 5);
+    expect(r.isValid).toBe(true);
+  });
+});
+
+describe('getMaxTotalArmor', () => {
+  it('returns the sum across all biped locations', () => {
+    // 50 t biped: head 9, CT 32, LT 24, RT 24, LA 16, RA 16, LL 24, RL 24
+    // sum = 169
+    const total = getMaxTotalArmor(50, MechConfiguration.BIPED);
+    expect(total).toBe(169);
+  });
+
+  it('default configuration is biped', () => {
+    expect(getMaxTotalArmor(50)).toBe(
+      getMaxTotalArmor(50, MechConfiguration.BIPED),
+    );
+  });
+});
+
+describe('getArmorFillPercent', () => {
+  it('returns 0 for non-positive expectedMax', () => {
+    expect(getArmorFillPercent(10, 0)).toBe(0);
+    expect(getArmorFillPercent(10, -5)).toBe(0);
+  });
+
+  it('returns percentage of expected max (can exceed 100)', () => {
+    expect(getArmorFillPercent(50, 100)).toBe(50);
+    expect(getArmorFillPercent(120, 100)).toBe(120);
+  });
+});
+
+describe('calculateOptimalArmorAllocation (biped)', () => {
+  it('totalAllocated never exceeds availablePoints', () => {
+    const r = calculateOptimalArmorAllocation(100, 50);
+    expect(r.totalAllocated).toBeLessThanOrEqual(100);
+  });
+
+  it('respects head cap of 9', () => {
+    const r = calculateOptimalArmorAllocation(200, 50);
+    expect(r.head).toBeLessThanOrEqual(MAX_HEAD_ARMOR);
+  });
+
+  it('CT rear is 25% of CT total (rounded)', () => {
+    const r = calculateOptimalArmorAllocation(150, 50);
+    // ctRear = round(ct × 0.25); ctFront = ct - ctRear
+    expect(r.centerTorsoRear).toBe(
+      Math.round((r.centerTorsoFront + r.centerTorsoRear) * 0.25),
+    );
+  });
+
+  it('side torsos are symmetric (LT == RT, LA == RA, LL == RL)', () => {
+    const r = calculateOptimalArmorAllocation(120, 50);
+    expect(r.leftTorsoFront).toBe(r.rightTorsoFront);
+    expect(r.leftTorsoRear).toBe(r.rightTorsoRear);
+    expect(r.leftArm).toBe(r.rightArm);
+    expect(r.leftLeg).toBe(r.rightLeg);
+  });
+
+  it('clamps to maximum total armor for the chassis', () => {
+    // 50 t biped max = 169; ask for 500
+    const r = calculateOptimalArmorAllocation(500, 50);
+    expect(r.totalAllocated).toBeLessThanOrEqual(169);
+  });
+});
+
+describe('calculateOptimalArmorAllocation (quad)', () => {
+  it('uses front/rear leg locations for quads', () => {
+    const r = calculateOptimalArmorAllocation(100, 50, MechConfiguration.QUAD);
+    expect(r.frontLeftLeg).toBeGreaterThan(0);
+    expect(r.rearLeftLeg).toBeGreaterThan(0);
+    expect(r.frontLeftLeg).toBe(r.frontRightLeg);
+    expect(r.rearLeftLeg).toBe(r.rearRightLeg);
+  });
+});

--- a/src/utils/construction/__tests__/battleValueDefensive.test.ts
+++ b/src/utils/construction/__tests__/battleValueDefensive.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Defensive BV calculation invariants.
+ *
+ * Defensive BV = (armorBV + structureBV + gyroBV + defEquipBV - explosivePenalties)
+ *                × defensiveFactor
+ * where:
+ *   armorBV = round(armorPoints × 2.5 × armorMult × bar) / 10
+ *   structureBV = structurePoints × 1.5 × structureMult × engineMult
+ *   gyroBV = tonnage × gyroMult
+ *   defensiveFactor = 1 + maxTMM/10  (TMM may be boosted by ECM-style stealth)
+ *
+ * These tests cover the core formula path and each significant branch
+ * (stealth bonuses, void sig minimum, tunnage, blue shield).
+ */
+
+import { EngineType } from '@/types/construction/EngineType';
+
+import { calculateDefensiveBV } from '../battleValueDefensive';
+
+const baseConfig = {
+  totalArmorPoints: 100,
+  totalStructurePoints: 80,
+  tonnage: 50,
+  runMP: 6,
+  jumpMP: 0,
+};
+
+describe('calculateDefensiveBV — base formula', () => {
+  it('computes armor, structure, and gyro BV with standard multipliers', () => {
+    const result = calculateDefensiveBV({ ...baseConfig });
+    // armorBV = round(100 × 2.5 × 1.0 × 10) / 10 = 250
+    expect(result.armorBV).toBe(250);
+    // structureBV = 80 × 1.5 × 1.0 × 1.0 = 120
+    expect(result.structureBV).toBe(120);
+    // gyroBV = 50 × 0.5 = 25
+    expect(result.gyroBV).toBe(25);
+  });
+
+  it('applies the TMM-based defensive factor (1 + TMM/10)', () => {
+    // run 6 → TMM 2 → factor 1.2
+    const result = calculateDefensiveBV({ ...baseConfig });
+    expect(result.defensiveFactor).toBe(1.2);
+    expect(result.totalDefensiveBV).toBeCloseTo((250 + 120 + 25) * 1.2, 2);
+  });
+
+  it('subtracts explosive penalties from base defensive sum', () => {
+    const result = calculateDefensiveBV({
+      ...baseConfig,
+      explosivePenalties: 50,
+    });
+    // base = 250 + 120 + 25 - 50 = 345; ×1.2 = 414
+    expect(result.totalDefensiveBV).toBeCloseTo(345 * 1.2, 2);
+  });
+});
+
+describe('calculateDefensiveBV — armor type multipliers', () => {
+  it('doubles armor BV for hardened armor (mult 2.0)', () => {
+    const result = calculateDefensiveBV({
+      ...baseConfig,
+      armorType: 'hardened',
+    });
+    // 100 × 2.5 × 2.0 × 10 = 5000 → /10 = 500
+    expect(result.armorBV).toBe(500);
+  });
+
+  it('uses 1.5× for reactive/reflective/ballistic-reinforced', () => {
+    const reactive = calculateDefensiveBV({
+      ...baseConfig,
+      armorType: 'reactive',
+    });
+    expect(reactive.armorBV).toBe(375);
+  });
+});
+
+describe('calculateDefensiveBV — structure type & engine multipliers', () => {
+  it('halves structure BV for industrial structure (mult 0.5)', () => {
+    const result = calculateDefensiveBV({
+      ...baseConfig,
+      structureType: 'industrial',
+    });
+    // 80 × 1.5 × 0.5 × 1.0 = 60
+    expect(result.structureBV).toBe(60);
+  });
+
+  it('applies engine BV multiplier to structure (XL_IS = 0.5)', () => {
+    const result = calculateDefensiveBV({
+      ...baseConfig,
+      engineType: EngineType.XL_IS,
+    });
+    // 80 × 1.5 × 1.0 × 0.5 = 60
+    expect(result.structureBV).toBe(60);
+  });
+
+  it('uses superheavy engine multipliers when tonnage > 100', () => {
+    const result = calculateDefensiveBV({
+      ...baseConfig,
+      tonnage: 110, // superheavy
+      engineType: EngineType.XL_IS,
+    });
+    // Superheavy IS XL = 0.75 (was 0.5 below 100t)
+    expect(result.structureBV).toBe(80 * 1.5 * 1.0 * 0.75);
+  });
+
+  it('honors explicit engineMultiplier override', () => {
+    const result = calculateDefensiveBV({
+      ...baseConfig,
+      engineMultiplier: 0.25,
+    });
+    expect(result.structureBV).toBe(80 * 1.5 * 1.0 * 0.25);
+  });
+});
+
+describe('calculateDefensiveBV — stealth and signature bonuses', () => {
+  it('adds +2 TMM for stealth armor', () => {
+    // run 6 → TMM 2; stealth +2 = 4 → factor 1.4
+    const result = calculateDefensiveBV({
+      ...baseConfig,
+      hasStealthArmor: true,
+    });
+    expect(result.defensiveFactor).toBe(1.4);
+  });
+
+  it('adds +2 TMM for null sig system', () => {
+    const result = calculateDefensiveBV({ ...baseConfig, hasNullSig: true });
+    expect(result.defensiveFactor).toBe(1.4);
+  });
+
+  it('adds +2 TMM for chameleon LPS', () => {
+    const result = calculateDefensiveBV({
+      ...baseConfig,
+      hasChameleonLPS: true,
+    });
+    expect(result.defensiveFactor).toBe(1.4);
+  });
+
+  it('void sig clamps minimum TMM to 3 for slow units', () => {
+    // run 2 → TMM 0; void sig forces ≥3 → factor 1.3
+    const result = calculateDefensiveBV({
+      ...baseConfig,
+      runMP: 2,
+      hasVoidSig: true,
+    });
+    expect(result.defensiveFactor).toBe(1.3);
+  });
+
+  it('void sig increments when TMM is exactly 3', () => {
+    // run 7 → TMM 3, void sig should bump to 4 → factor 1.4
+    const result = calculateDefensiveBV({
+      ...baseConfig,
+      runMP: 7,
+      hasVoidSig: true,
+    });
+    expect(result.defensiveFactor).toBe(1.4);
+  });
+});
+
+describe('calculateDefensiveBV — Blue Shield bonus', () => {
+  it('adds +0.2 to both armor and structure multipliers when blue shield is set', () => {
+    const result = calculateDefensiveBV({
+      ...baseConfig,
+      hasBlueShield: true,
+    });
+    // armor mult = 1.0 + 0.2 = 1.2 → 100 × 2.5 × 1.2 × 10 = 3000 → /10 = 300
+    expect(result.armorBV).toBe(300);
+    // structure mult = 1.0 + 0.2 = 1.2 → 80 × 1.5 × 1.2 × 1.0 = 144
+    expect(result.structureBV).toBeCloseTo(144, 5);
+  });
+});
+
+describe('calculateDefensiveBV — UMU MP and BAR', () => {
+  it('uses max(jumpMP, umuMP) for TMM calculation', () => {
+    // run 4 → TMM 1; jump 0, umu 6 → jump TMM = 2+1 = 3 ⇒ factor 1.3
+    const result = calculateDefensiveBV({
+      ...baseConfig,
+      runMP: 4,
+      jumpMP: 0,
+      umuMP: 6,
+    });
+    expect(result.defensiveFactor).toBe(1.3);
+  });
+
+  it('honors a non-default BAR value (lower armor effectiveness)', () => {
+    const result = calculateDefensiveBV({ ...baseConfig, bar: 5 });
+    // armor BV scales linearly with bar: 100 × 2.5 × 1.0 × 5 = 1250 → /10 = 125
+    expect(result.armorBV).toBe(125);
+  });
+});

--- a/src/utils/construction/__tests__/battleValueExplosivePenalties.test.ts
+++ b/src/utils/construction/__tests__/battleValueExplosivePenalties.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Explosive penalty invariants.
+ *
+ * Per MegaMek BV rules:
+ *  - 'standard' explosives (ammo, gauss-ammo) cost 15 BV per slot
+ *  - gauss/HVAC/reduced cost 1 BV per slot (HVAC counts as 1 effective slot)
+ *  - Arm-mounted explosives transfer to the side torso for CASE checks
+ *  - CASE protects the location for non-XL/XXL engines (sideTorsoSlots < 3)
+ *  - CASE-II always protects the location
+ *
+ * The explosive-equipment-in-CT/HD path always penalizes regardless of CASE.
+ */
+
+import { EngineType } from '@/types/construction/EngineType';
+
+import { calculateExplosivePenalties } from '../battleValueExplosivePenalties';
+
+describe('calculateExplosivePenalties — base behaviour', () => {
+  it('returns 0 penalty for an empty equipment list', () => {
+    const result = calculateExplosivePenalties({
+      equipment: [],
+      caseLocations: [],
+      caseIILocations: [],
+    });
+    expect(result.totalPenalty).toBe(0);
+    expect(Object.keys(result.locationPenalties)).toHaveLength(0);
+  });
+
+  it('charges 15 BV per slot for standard explosives in CT', () => {
+    const result = calculateExplosivePenalties({
+      equipment: [{ location: 'CT', slots: 2, penaltyCategory: 'standard' }],
+      caseLocations: [],
+      caseIILocations: [],
+    });
+    expect(result.totalPenalty).toBe(30);
+    expect(result.locationPenalties.CT).toBe(30);
+  });
+
+  it('charges 1 BV per slot for gauss-category explosives', () => {
+    const result = calculateExplosivePenalties({
+      equipment: [{ location: 'RT', slots: 7, penaltyCategory: 'gauss' }],
+      caseLocations: [],
+      caseIILocations: [],
+    });
+    // 1 × 7 = 7
+    expect(result.totalPenalty).toBe(7);
+  });
+
+  it('treats HVAC as 1 effective slot regardless of declared slot count', () => {
+    const result = calculateExplosivePenalties({
+      equipment: [{ location: 'RT', slots: 6, penaltyCategory: 'hvac' }],
+      caseLocations: [],
+      caseIILocations: [],
+    });
+    expect(result.totalPenalty).toBe(1);
+  });
+});
+
+describe('calculateExplosivePenalties — CASE handling (side torsos)', () => {
+  it('CASE in side torso protects against penalty for standard engines (sideTorsoSlots < 3)', () => {
+    const result = calculateExplosivePenalties({
+      equipment: [{ location: 'LT', slots: 1, penaltyCategory: 'standard' }],
+      caseLocations: ['LT'],
+      caseIILocations: [],
+      engineType: EngineType.STANDARD, // 0 side torso slots
+    });
+    expect(result.totalPenalty).toBe(0);
+  });
+
+  it('CASE does NOT protect when XL_IS engine claims ≥3 side torso slots', () => {
+    const result = calculateExplosivePenalties({
+      equipment: [{ location: 'LT', slots: 1, penaltyCategory: 'standard' }],
+      caseLocations: ['LT'],
+      caseIILocations: [],
+      engineType: EngineType.XL_IS, // 3 side torso slots
+    });
+    // CASE bypassed at sideTorsoSlots >= 3 → 15 BV
+    expect(result.totalPenalty).toBe(15);
+  });
+
+  it('CASE-II always protects the location regardless of engine', () => {
+    const result = calculateExplosivePenalties({
+      equipment: [{ location: 'LT', slots: 1, penaltyCategory: 'standard' }],
+      caseLocations: [],
+      caseIILocations: ['LT'],
+      engineType: EngineType.XL_IS,
+    });
+    expect(result.totalPenalty).toBe(0);
+  });
+});
+
+describe('calculateExplosivePenalties — arm transfer (biped only)', () => {
+  it('arm explosive transfers to LT/RT for CASE evaluation in biped mechs', () => {
+    // Arm has no CASE, but LT does → arm transfers, LT-CASE protects
+    const result = calculateExplosivePenalties({
+      equipment: [{ location: 'LA', slots: 1, penaltyCategory: 'standard' }],
+      caseLocations: ['LT'],
+      caseIILocations: [],
+      engineType: EngineType.STANDARD,
+    });
+    // Arm → LT → LT has CASE & 0 side torso slots → no penalty
+    expect(result.totalPenalty).toBe(0);
+  });
+
+  it('arm CASE alone protects the arm location (no transfer)', () => {
+    const result = calculateExplosivePenalties({
+      equipment: [{ location: 'RA', slots: 2, penaltyCategory: 'standard' }],
+      caseLocations: ['RA'],
+      caseIILocations: [],
+    });
+    expect(result.totalPenalty).toBe(0);
+  });
+
+  it('quad mechs do NOT transfer arm explosives (arms are legs)', () => {
+    const result = calculateExplosivePenalties({
+      equipment: [{ location: 'LA', slots: 1, penaltyCategory: 'standard' }],
+      caseLocations: ['LT'],
+      caseIILocations: [],
+      isQuad: true,
+    });
+    // No arm-to-torso transfer for quads ⇒ LA penalty applies in full
+    expect(result.totalPenalty).toBe(15);
+  });
+});
+
+describe('calculateExplosivePenalties — multi-location aggregation', () => {
+  it('sums penalties across multiple locations', () => {
+    const result = calculateExplosivePenalties({
+      equipment: [
+        { location: 'CT', slots: 1, penaltyCategory: 'standard' },
+        { location: 'HD', slots: 2, penaltyCategory: 'standard' },
+        { location: 'RT', slots: 7, penaltyCategory: 'gauss' },
+      ],
+      caseLocations: [],
+      caseIILocations: [],
+    });
+    // CT 15 + HD 30 + RT 7 = 52
+    expect(result.totalPenalty).toBe(52);
+    expect(result.locationPenalties.CT).toBe(15);
+    expect(result.locationPenalties.HD).toBe(30);
+    expect(result.locationPenalties.RT).toBe(7);
+  });
+});

--- a/src/utils/construction/__tests__/battleValueMovement.test.ts
+++ b/src/utils/construction/__tests__/battleValueMovement.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Battle Value movement helpers — TMM and speed factor invariants.
+ *
+ * The TMM table is the authoritative MegaMek mapping for run/jump MP buckets;
+ * the offensive speed factor is the BV-2.0 formula
+ *   sf = round(pow(1 + (mp - 5)/10, 1.2) × 100) / 100
+ * with mp = runMP + round(max(jumpMP, umuMP) / 2). These invariants protect
+ * BV parity for every mech we calculate.
+ */
+
+import {
+  calculateOffensiveSpeedFactor,
+  calculateSpeedFactor,
+  calculateTMM,
+  SPEED_FACTORS,
+} from '../battleValueMovement';
+
+describe('calculateTMM (run/jump bucket table)', () => {
+  it('returns 0 for very slow units (run MP ≤ 2)', () => {
+    expect(calculateTMM(0)).toBe(0);
+    expect(calculateTMM(2)).toBe(0);
+  });
+
+  it('uses the canonical MegaMek run-bucket boundaries', () => {
+    // mp ≤ 4 → 1, ≤ 6 → 2, ≤ 9 → 3, ≤ 17 → 4, ≤ 24 → 5, > 24 → 6
+    expect(calculateTMM(3)).toBe(1);
+    expect(calculateTMM(4)).toBe(1);
+    expect(calculateTMM(5)).toBe(2);
+    expect(calculateTMM(6)).toBe(2);
+    expect(calculateTMM(7)).toBe(3);
+    expect(calculateTMM(9)).toBe(3);
+    expect(calculateTMM(10)).toBe(4);
+    expect(calculateTMM(17)).toBe(4);
+    expect(calculateTMM(18)).toBe(5);
+    expect(calculateTMM(24)).toBe(5);
+    expect(calculateTMM(25)).toBe(6);
+  });
+
+  it('grants jump bonus of +1 over the jump bucket when jumping', () => {
+    // Run = 2 → bucket 0, jump = 3 → bucket 1, +1 = 2; max(0, 2) = 2
+    expect(calculateTMM(2, 3)).toBe(2);
+    // Run = 6 → bucket 2, jump = 4 → bucket 1, +1 = 2; max(2, 2) = 2
+    expect(calculateTMM(6, 4)).toBe(2);
+    // Run = 4 → bucket 1, jump = 6 → bucket 2 +1 = 3; max(1, 3) = 3
+    expect(calculateTMM(4, 6)).toBe(3);
+  });
+
+  it('zero jump MP contributes no jump TMM', () => {
+    expect(calculateTMM(6, 0)).toBe(2);
+  });
+});
+
+describe('calculateSpeedFactor (defensive TMM-based factor)', () => {
+  it('returns 1.0 for stationary units (TMM 0)', () => {
+    expect(calculateSpeedFactor(0, 0)).toBe(1.0);
+    expect(calculateSpeedFactor(1, 1)).toBe(1.0); // mp ≤ 2 → bucket 0
+  });
+
+  it('uses the SPEED_FACTORS lookup for each TMM bucket', () => {
+    // Run 4 → bucket 1 → 1.1
+    expect(calculateSpeedFactor(2, 4)).toBe(1.1);
+    // Run 6 → bucket 2 → 1.2
+    expect(calculateSpeedFactor(4, 6)).toBe(1.2);
+    // Run 9 → bucket 3 → 1.3
+    expect(calculateSpeedFactor(6, 9)).toBe(1.3);
+    // Run 17 → bucket 4 → 1.4
+    expect(calculateSpeedFactor(11, 17)).toBe(1.4);
+  });
+
+  it('applies a jump bonus when jumpMP > walkMP', () => {
+    // walk 4, jump 5: bonus = min(0.5, (5-4)*0.1) = 0.1
+    // run 6 → bucket 2 → 1.2; jump 5 → bucket 2+1 = 3 → bigger ⇒ baseFactor uses jump TMM
+    // result floor: 1.3 + 0.1 = 1.4 (capped at 2.24)
+    const sf = calculateSpeedFactor(4, 6, 5);
+    expect(sf).toBeGreaterThan(1.2);
+    expect(sf).toBeLessThanOrEqual(2.24);
+  });
+
+  it('caps the speed factor at 2.24', () => {
+    // Massive jump (e.g. jump 30, walk 1) should never break the cap
+    const sf = calculateSpeedFactor(1, 1, 30);
+    expect(sf).toBeLessThanOrEqual(2.24);
+  });
+
+  it('exposes the SPEED_FACTORS table as a stable contract', () => {
+    expect(SPEED_FACTORS[0]).toBe(1.0);
+    expect(SPEED_FACTORS[5]).toBe(1.5);
+    expect(SPEED_FACTORS[10]).toBe(2.0);
+  });
+});
+
+describe('calculateOffensiveSpeedFactor (BV-2.0 formula)', () => {
+  it('matches the canonical sf at run=5, no jump (baseline)', () => {
+    // mp = 5 + round(0/2) = 5, sf = round(pow(1 + 0, 1.2) * 100) / 100 = 1.0
+    expect(calculateOffensiveSpeedFactor(5, 0, 0)).toBe(1.0);
+  });
+
+  it('uses ceil-style round on max(jump,umu)/2 (round-half-up)', () => {
+    // run=6, jump=3 → mp = 6 + round(1.5) = 6 + 2 = 8
+    // sf = round(pow(1 + 3/10, 1.2) * 100) / 100 = round(1.3^1.2 * 100)/100
+    // 1.3^1.2 ≈ 1.3724 → 1.37
+    const sf = calculateOffensiveSpeedFactor(6, 3, 0);
+    expect(sf).toBeCloseTo(1.37, 2);
+  });
+
+  it('rounds the speed factor to two decimal places', () => {
+    const sf = calculateOffensiveSpeedFactor(7, 5, 0);
+    // mp = 7 + round(2.5) = 7 + 3 = 10
+    // sf = round(pow(1 + 5/10, 1.2) * 100)/100 = round(1.5^1.2 * 100)/100
+    // 1.5^1.2 ≈ 1.62657 → ×100 = 162.657 → round = 163 → /100 = 1.63
+    expect(sf).toBe(1.63);
+    // Always 2 decimal places
+    expect(Math.round(sf * 100) / 100).toBe(sf);
+  });
+
+  it('uses max(jumpMP, umuMP) for movement contribution', () => {
+    // run=4, jump=0, umu=4 → mp = 4 + round(2) = 6
+    const withUmu = calculateOffensiveSpeedFactor(4, 0, 4);
+    // run=4, jump=4, umu=0 → mp = 4 + round(2) = 6 (same)
+    const withJump = calculateOffensiveSpeedFactor(4, 4, 0);
+    expect(withUmu).toBe(withJump);
+  });
+
+  it('produces sf < 1 for slow units (mp < 5)', () => {
+    // mp = 3, sf = round(pow(1 - 2/10, 1.2) * 100)/100 = round(0.8^1.2*100)/100 ≈ 0.77
+    const sf = calculateOffensiveSpeedFactor(3, 0, 0);
+    expect(sf).toBeLessThan(1.0);
+    expect(sf).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/construction/__tests__/battleValueOffensive.test.ts
+++ b/src/utils/construction/__tests__/battleValueOffensive.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Offensive BV calculation invariants.
+ *
+ * Offensive BV = (weaponBV + ammoBV + physicalWeaponBV + weightBonus +
+ *                 offensiveEquipmentBV) × speedFactor × typeModifier
+ *
+ * Heat tracking is the load-bearing piece: weapons that exceed heat
+ * efficiency are halved. Speed factor uses the BV-2.0 formula.
+ *
+ * These tests cover the modifier chain (rear, AES, Artemis, TC),
+ * ammo cap, heat efficiency, weight bonus (TSM/iTSM/AES), and
+ * the IndustrialMech 0.9× type modifier.
+ */
+
+import { EngineType } from '@/types/construction/EngineType';
+
+import {
+  calculateAmmoBVWithExcessiveCap,
+  calculateOffensiveBV,
+  calculateOffensiveBVWithHeatTracking,
+  type OffensiveBVConfig,
+} from '../battleValueOffensive';
+
+const baseConfig: OffensiveBVConfig = {
+  weapons: [],
+  tonnage: 50,
+  walkMP: 4,
+  runMP: 6,
+  jumpMP: 0,
+  heatDissipation: 10,
+};
+
+describe('calculateOffensiveBVWithHeatTracking — base flow', () => {
+  it('handles a weapons-free configuration (only weight bonus)', () => {
+    const result = calculateOffensiveBVWithHeatTracking({ ...baseConfig });
+    expect(result.weaponBV).toBe(0);
+    expect(result.ammoBV).toBe(0);
+    expect(result.weightBonus).toBe(50); // tonnage × 1.0 (no TSM, no AES)
+  });
+
+  it('sums non-heat weapons without heat penalty', () => {
+    const result = calculateOffensiveBVWithHeatTracking({
+      ...baseConfig,
+      weapons: [
+        { id: 'mg', name: 'machine-gun', heat: 0, bv: 5 },
+        { id: 'mg2', name: 'machine-gun', heat: 0, bv: 5 },
+      ],
+      heatDissipation: 0,
+    });
+    // 0-heat weapons sort first and never push heatSum past efficiency
+    expect(result.weaponBV).toBe(10);
+    expect(result.halvedWeaponCount).toBe(0);
+  });
+});
+
+describe('calculateOffensiveBVWithHeatTracking — weapon modifiers', () => {
+  it('halves rear-mounted weapon BV', () => {
+    const result = calculateOffensiveBVWithHeatTracking({
+      ...baseConfig,
+      weapons: [
+        { id: 'ml', name: 'medium-laser', heat: 3, bv: 46, rear: true },
+      ],
+      heatDissipation: 30,
+    });
+    expect(result.weaponBV).toBe(23);
+  });
+
+  it('multiplies AES-arm-mounted weapons by 1.25', () => {
+    const result = calculateOffensiveBVWithHeatTracking({
+      ...baseConfig,
+      weapons: [
+        { id: 'ml', name: 'medium-laser', heat: 3, bv: 46, hasAES: true },
+      ],
+      heatDissipation: 30,
+    });
+    expect(result.weaponBV).toBe(46 * 1.25);
+  });
+
+  it('multiplies Artemis IV weapons by 1.2', () => {
+    const result = calculateOffensiveBVWithHeatTracking({
+      ...baseConfig,
+      weapons: [
+        { id: 'lrm', name: 'lrm-15', heat: 5, bv: 136, artemisType: 'iv' },
+      ],
+      heatDissipation: 30,
+    });
+    expect(result.weaponBV).toBeCloseTo(136 * 1.2, 5);
+  });
+
+  it('applies TC bonus only to direct-fire weapons', () => {
+    const result = calculateOffensiveBVWithHeatTracking({
+      ...baseConfig,
+      hasTargetingComputer: true,
+      weapons: [
+        {
+          id: 'ml',
+          name: 'medium-laser',
+          heat: 3,
+          bv: 46,
+          isDirectFire: true,
+        },
+        { id: 'mg', name: 'machine-gun', heat: 0, bv: 5, isDirectFire: false },
+      ],
+      heatDissipation: 30,
+    });
+    // ml: 46 × 1.25 = 57.5; mg: 5 (unchanged)
+    expect(result.weaponBV).toBeCloseTo(46 * 1.25 + 5, 5);
+  });
+});
+
+describe('calculateOffensiveBVWithHeatTracking — heat efficiency', () => {
+  it('halves the BV of weapons that push past heat efficiency', () => {
+    // heatDissipation = 5 → heatEfficiency = 6 + 5 - 2(running heat) = 9
+    // Two 10-heat weapons of 100 BV each:
+    //  weapon1: heatSum 10 ≥ 9 → next weapon halved
+    //  weapon2: halved (50 BV)
+    const result = calculateOffensiveBVWithHeatTracking({
+      ...baseConfig,
+      weapons: [
+        { id: 'w1', name: 'w', heat: 10, bv: 100 },
+        { id: 'w2', name: 'w', heat: 10, bv: 100 },
+      ],
+      heatDissipation: 5,
+    });
+    expect(result.heatEfficiency).toBe(9);
+    expect(result.halvedWeaponCount).toBe(1);
+    expect(result.weaponBV).toBeCloseTo(150, 5);
+  });
+
+  it('uses jump heat when greater than running heat', () => {
+    // jumpMP = 4 → jumpHeat = max(3, 4) = 4 ⇒ moveHeat = max(2, 4) = 4
+    const result = calculateOffensiveBVWithHeatTracking({
+      ...baseConfig,
+      jumpMP: 4,
+      weapons: [{ id: 'w', name: 'w', heat: 0, bv: 10 }],
+      heatDissipation: 10,
+    });
+    // heatEfficiency = 6 + 10 - 4 = 12
+    expect(result.moveHeat).toBe(4);
+    expect(result.heatEfficiency).toBe(12);
+  });
+
+  it('zeroes running heat for ICE / FuelCell engines', () => {
+    const result = calculateOffensiveBVWithHeatTracking({
+      ...baseConfig,
+      engineType: EngineType.ICE,
+      weapons: [{ id: 'w', name: 'w', heat: 0, bv: 10 }],
+      heatDissipation: 10,
+    });
+    expect(result.moveHeat).toBe(0);
+    expect(result.heatEfficiency).toBe(16);
+  });
+
+  it('uses 6 running heat for XXL engines', () => {
+    const result = calculateOffensiveBVWithHeatTracking({
+      ...baseConfig,
+      engineType: EngineType.XXL,
+      weapons: [{ id: 'w', name: 'w', heat: 0, bv: 10 }],
+      heatDissipation: 10,
+    });
+    expect(result.moveHeat).toBe(6);
+    expect(result.heatEfficiency).toBe(10);
+  });
+
+  it('subtracts 10 from heat efficiency for stealth armor', () => {
+    const result = calculateOffensiveBVWithHeatTracking({
+      ...baseConfig,
+      hasStealthArmor: true,
+      weapons: [{ id: 'w', name: 'w', heat: 0, bv: 10 }],
+      heatDissipation: 10,
+    });
+    // 6 + 10 - 2 - 10 = 4
+    expect(result.heatEfficiency).toBe(4);
+  });
+});
+
+describe('calculateOffensiveBVWithHeatTracking — weight bonus', () => {
+  it('uses tonnage as the default weight bonus', () => {
+    const result = calculateOffensiveBVWithHeatTracking({ ...baseConfig });
+    expect(result.weightBonus).toBe(50);
+  });
+
+  it('multiplies weight bonus by 1.5 for TSM mechs', () => {
+    const result = calculateOffensiveBVWithHeatTracking({
+      ...baseConfig,
+      hasTSM: true,
+    });
+    expect(result.weightBonus).toBe(75);
+  });
+
+  it('multiplies weight bonus by 1.15 for Industrial TSM', () => {
+    const result = calculateOffensiveBVWithHeatTracking({
+      ...baseConfig,
+      hasIndustrialTSM: true,
+    });
+    expect(result.weightBonus).toBeCloseTo(57.5, 5);
+  });
+
+  it('adds 10% per AES arm to the weight bonus', () => {
+    const result = calculateOffensiveBVWithHeatTracking({
+      ...baseConfig,
+      aesArms: 2,
+    });
+    // 50 × (1.0 + 0.2) = 60
+    expect(result.weightBonus).toBe(60);
+  });
+});
+
+describe('calculateOffensiveBVWithHeatTracking — type modifier', () => {
+  it('multiplies offensive BV by 0.9 for IndustrialMechs', () => {
+    const baseline = calculateOffensiveBVWithHeatTracking({
+      ...baseConfig,
+      weapons: [{ id: 'ml', name: 'medium-laser', heat: 3, bv: 46 }],
+      heatDissipation: 30,
+    });
+    const industrial = calculateOffensiveBVWithHeatTracking({
+      ...baseConfig,
+      weapons: [{ id: 'ml', name: 'medium-laser', heat: 3, bv: 46 }],
+      heatDissipation: 30,
+      isIndustrialMech: true,
+    });
+    expect(industrial.totalOffensiveBV).toBeCloseTo(
+      baseline.totalOffensiveBV * 0.9,
+      2,
+    );
+  });
+});
+
+describe('calculateAmmoBVWithExcessiveCap', () => {
+  it('returns 0 when no ammo provided', () => {
+    expect(calculateAmmoBVWithExcessiveCap([], [])).toBe(0);
+  });
+
+  it('caps ammo BV at the matching weapon BV (excessive ammo rule)', () => {
+    // Weapon ac-10 with BV 100; ammo bv 200 (way too much)
+    // Expected: ammoBV = min(200, 100) = 100
+    const total = calculateAmmoBVWithExcessiveCap(
+      [{ id: 'isac10', bv: 100 }],
+      [{ id: 'isac10ammo', bv: 200, weaponType: 'ac-10' }],
+    );
+    expect(total).toBe(100);
+  });
+
+  it('returns 0 for ammo with no matching weapon', () => {
+    const total = calculateAmmoBVWithExcessiveCap(
+      [{ id: 'ml', bv: 46 }],
+      [{ id: 'ammo-ac-10', bv: 30, weaponType: 'ac-10' }],
+    );
+    expect(total).toBe(0);
+  });
+});
+
+describe('calculateOffensiveBV (legacy, no heat tracking)', () => {
+  it('returns 0 for empty weapons', () => {
+    expect(calculateOffensiveBV([])).toBe(0);
+  });
+
+  it('halves rear-mounted weapon BV in legacy path', () => {
+    const result = calculateOffensiveBV([
+      { id: 'medium-laser', rear: true },
+      { id: 'medium-laser' },
+    ]);
+    // Catalog lookup: medium-laser BV = 46 → 23 + 46 = 69
+    expect(result).toBe(69);
+  });
+});

--- a/src/utils/construction/__tests__/battleValueTotals.test.ts
+++ b/src/utils/construction/__tests__/battleValueTotals.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Total BV calculation invariants — the public {@link calculateTotalBV}
+ * entry point that combines defensive + offensive BV and applies a cockpit
+ * modifier. These tests pin down the cockpit modifier table and the round
+ * applied to the final composite figure.
+ */
+
+import {
+  calculateTotalBV,
+  getBVBreakdown,
+  getCockpitModifier,
+  type BVCalculationConfig,
+} from '../battleValueTotals';
+
+const baseConfig: BVCalculationConfig = {
+  totalArmorPoints: 100,
+  totalStructurePoints: 80,
+  tonnage: 50,
+  heatSinkCapacity: 10,
+  walkMP: 4,
+  runMP: 6,
+  jumpMP: 0,
+  weapons: [], // No weapons → no offensive BV from weapons
+};
+
+describe('getCockpitModifier (load-bearing constants)', () => {
+  it('returns 1.0 for standard cockpit (default)', () => {
+    expect(getCockpitModifier()).toBe(1.0);
+    expect(getCockpitModifier('standard')).toBe(1.0);
+  });
+
+  it('returns 0.95 for small / torso-mounted / drone-OS / SCC', () => {
+    // Per MegaMek BVCalculator: these all share the 0.95 modifier.
+    expect(getCockpitModifier('small')).toBe(0.95);
+    expect(getCockpitModifier('torso-mounted')).toBe(0.95);
+    expect(getCockpitModifier('drone-operating-system')).toBe(0.95);
+    expect(getCockpitModifier('small-command-console')).toBe(0.95);
+  });
+
+  it('returns 1.3 for interface cockpit', () => {
+    expect(getCockpitModifier('interface')).toBe(1.3);
+  });
+
+  it('returns 1.0 for unknown / command-console (no MegaMek BV penalty)', () => {
+    expect(getCockpitModifier('command-console')).toBe(1.0);
+  });
+});
+
+describe('calculateTotalBV — composition + rounding', () => {
+  it('returns an integer (rounded composite figure)', () => {
+    const total = calculateTotalBV(baseConfig);
+    expect(Number.isInteger(total)).toBe(true);
+  });
+
+  it('applies cockpit modifier to the combined defensive+offensive base', () => {
+    const standard = calculateTotalBV(baseConfig);
+    const small = calculateTotalBV({ ...baseConfig, cockpitType: 'small' });
+    // Small = 0.95 × standard (after rounding)
+    expect(small).toBe(Math.round(standard * 0.95));
+  });
+
+  it('higher armor → higher BV (monotonic in armor points)', () => {
+    const lowArmor = calculateTotalBV({
+      ...baseConfig,
+      totalArmorPoints: 50,
+    });
+    const highArmor = calculateTotalBV({
+      ...baseConfig,
+      totalArmorPoints: 200,
+    });
+    expect(highArmor).toBeGreaterThan(lowArmor);
+  });
+
+  it('higher run MP increases defensive factor and offensive speed factor', () => {
+    const slow = calculateTotalBV({ ...baseConfig, runMP: 4, walkMP: 3 });
+    const fast = calculateTotalBV({ ...baseConfig, runMP: 9, walkMP: 6 });
+    expect(fast).toBeGreaterThan(slow);
+  });
+
+  it('explosive penalties reduce defensive base BV', () => {
+    const noPenalty = calculateTotalBV(baseConfig);
+    const withPenalty = calculateTotalBV({
+      ...baseConfig,
+      explosivePenalties: 50,
+    });
+    expect(withPenalty).toBeLessThan(noPenalty);
+  });
+});
+
+describe('getBVBreakdown — exposes the defensive/offensive split', () => {
+  it('returns separate defensive and offensive sub-totals', () => {
+    const bd = getBVBreakdown(baseConfig);
+    expect(bd.defensiveBV).toBeGreaterThan(0);
+    // No weapons supplied → offensive BV is just the weight bonus × speedFactor
+    expect(bd.offensiveBV).toBeGreaterThan(0);
+    // Total ≈ round((defensiveBV + offensiveBV) × cockpitModifier)
+    expect(bd.totalBV).toBe(
+      Math.round((bd.defensiveBV + bd.offensiveBV) * 1.0),
+    );
+  });
+
+  it('exposes the offensive speed factor', () => {
+    const bd = getBVBreakdown({ ...baseConfig, runMP: 5, walkMP: 4 });
+    // run 5 → mp = 5 + 0 = 5 → sf = 1.0
+    expect(bd.speedFactor).toBe(1.0);
+  });
+});

--- a/src/utils/construction/__tests__/costCalculations.test.ts
+++ b/src/utils/construction/__tests__/costCalculations.test.ts
@@ -1,0 +1,186 @@
+/**
+ * cBill cost calculation invariants.
+ *
+ * Per TechManual:
+ *   chassis        = tonnage × 10 000
+ *   engine         = rating² × 5000 × type-multiplier
+ *   gyro           = ceil(rating/100) × 300 000 × type-multiplier
+ *   structure      = tonnage × cost/ton
+ *   armor          = points × 10 000 × cost-multiplier
+ *   cockpit        = flat per type
+ *   heat sink      = external × cost-each (integral free)
+ */
+
+import { ArmorTypeEnum } from '@/types/construction/ArmorType';
+import { CockpitType } from '@/types/construction/CockpitType';
+import { EngineType } from '@/types/construction/EngineType';
+import { GyroType } from '@/types/construction/GyroType';
+import { HeatSinkType } from '@/types/construction/HeatSinkType';
+import { InternalStructureType } from '@/types/construction/InternalStructureType';
+
+import {
+  calculateChassisCost,
+  calculateCockpitCost,
+  calculateEngineCost,
+  calculateGyroCost,
+  calculateHeatSinkCost,
+  calculateStructureCost,
+  calculateTotalCost,
+  COCKPIT_COSTS,
+  ENGINE_COST_MULTIPLIERS,
+  getCostBreakdown,
+  GYRO_COST_MULTIPLIERS,
+  HEAT_SINK_COSTS,
+  STRUCTURE_COST_PER_TON,
+} from '../costCalculations';
+
+describe('cost multiplier tables', () => {
+  it('engine multipliers match TechManual ratios', () => {
+    expect(ENGINE_COST_MULTIPLIERS[EngineType.STANDARD]).toBe(1.0);
+    expect(ENGINE_COST_MULTIPLIERS[EngineType.XL_IS]).toBe(2.0);
+    expect(ENGINE_COST_MULTIPLIERS[EngineType.XL_CLAN]).toBe(2.0);
+    expect(ENGINE_COST_MULTIPLIERS[EngineType.LIGHT]).toBe(1.5);
+    expect(ENGINE_COST_MULTIPLIERS[EngineType.XXL]).toBe(3.0);
+    expect(ENGINE_COST_MULTIPLIERS[EngineType.ICE]).toBe(0.3);
+  });
+
+  it('gyro multipliers (XL gyro is half-cost; heavy-duty is double)', () => {
+    expect(GYRO_COST_MULTIPLIERS[GyroType.STANDARD]).toBe(1.0);
+    expect(GYRO_COST_MULTIPLIERS[GyroType.XL]).toBe(0.5);
+    expect(GYRO_COST_MULTIPLIERS[GyroType.HEAVY_DUTY]).toBe(2.0);
+  });
+
+  it('structure cost-per-ton (standard 400, endo-steel 1600, reinforced 6400)', () => {
+    expect(STRUCTURE_COST_PER_TON[InternalStructureType.STANDARD]).toBe(400);
+    expect(STRUCTURE_COST_PER_TON[InternalStructureType.ENDO_STEEL_IS]).toBe(
+      1600,
+    );
+    expect(STRUCTURE_COST_PER_TON[InternalStructureType.REINFORCED]).toBe(6400);
+  });
+
+  it('cockpit costs (standard 200k, small 175k, torso 750k)', () => {
+    expect(COCKPIT_COSTS[CockpitType.STANDARD]).toBe(200_000);
+    expect(COCKPIT_COSTS[CockpitType.SMALL]).toBe(175_000);
+    expect(COCKPIT_COSTS[CockpitType.TORSO_MOUNTED]).toBe(750_000);
+  });
+
+  it('heat sink costs (single 2000, double 6000)', () => {
+    expect(HEAT_SINK_COSTS[HeatSinkType.SINGLE]).toBe(2000);
+    expect(HEAT_SINK_COSTS[HeatSinkType.DOUBLE_IS]).toBe(6000);
+    expect(HEAT_SINK_COSTS[HeatSinkType.DOUBLE_CLAN]).toBe(6000);
+  });
+});
+
+describe('calculateChassisCost', () => {
+  it('returns tonnage × 10 000', () => {
+    expect(calculateChassisCost(50)).toBe(500_000);
+    expect(calculateChassisCost(100)).toBe(1_000_000);
+  });
+});
+
+describe('calculateEngineCost (rating² × 5000 × multiplier)', () => {
+  it('standard fusion: rating² × 5000', () => {
+    expect(calculateEngineCost(200, EngineType.STANDARD)).toBe(
+      200 * 200 * 5000,
+    );
+  });
+
+  it('XL doubles the standard fusion cost', () => {
+    expect(calculateEngineCost(200, EngineType.XL_IS)).toBe(
+      200 * 200 * 5000 * 2,
+    );
+  });
+
+  it('ICE is 30% of standard cost', () => {
+    expect(calculateEngineCost(200, EngineType.ICE)).toBe(
+      200 * 200 * 5000 * 0.3,
+    );
+  });
+});
+
+describe('calculateGyroCost', () => {
+  it('rating 200 → ceil(200/100) = 2 t → 2 × 300 000 × 1.0 = 600 000', () => {
+    expect(calculateGyroCost(200, GyroType.STANDARD)).toBe(600_000);
+  });
+
+  it('XL gyro halves the standard cost', () => {
+    expect(calculateGyroCost(200, GyroType.XL)).toBe(300_000);
+  });
+
+  it('rounds up the rating/100 (rating 201 → 3 t)', () => {
+    expect(calculateGyroCost(201, GyroType.STANDARD)).toBe(900_000);
+  });
+});
+
+describe('calculateStructureCost', () => {
+  it('Standard structure: tonnage × 400', () => {
+    expect(calculateStructureCost(50, InternalStructureType.STANDARD)).toBe(
+      20_000,
+    );
+  });
+
+  it('Endo-Steel IS: tonnage × 1600', () => {
+    expect(
+      calculateStructureCost(50, InternalStructureType.ENDO_STEEL_IS),
+    ).toBe(80_000);
+  });
+});
+
+describe('calculateCockpitCost', () => {
+  it('returns the per-type cost', () => {
+    expect(calculateCockpitCost(CockpitType.STANDARD)).toBe(200_000);
+    expect(calculateCockpitCost(CockpitType.TORSO_MOUNTED)).toBe(750_000);
+  });
+});
+
+describe('calculateHeatSinkCost (external only — integral are free)', () => {
+  it('returns externalCount × per-sink cost', () => {
+    expect(calculateHeatSinkCost(5, HeatSinkType.SINGLE)).toBe(10_000);
+    expect(calculateHeatSinkCost(5, HeatSinkType.DOUBLE_IS)).toBe(30_000);
+  });
+
+  it('returns 0 for zero externals', () => {
+    expect(calculateHeatSinkCost(0, HeatSinkType.SINGLE)).toBe(0);
+  });
+});
+
+describe('calculateTotalCost / getCostBreakdown', () => {
+  const config = {
+    tonnage: 50,
+    engineRating: 200,
+    engineType: EngineType.STANDARD,
+    gyroType: GyroType.STANDARD,
+    structureType: InternalStructureType.STANDARD,
+    armorType: ArmorTypeEnum.STANDARD,
+    totalArmorPoints: 100,
+    cockpitType: CockpitType.STANDARD,
+    heatSinkType: HeatSinkType.SINGLE,
+    externalHeatSinks: 4,
+    equipmentCost: 0,
+  };
+
+  it('total = sum of all components', () => {
+    const total = calculateTotalCost(config);
+    const bd = getCostBreakdown(config);
+    expect(total).toBe(bd.total);
+    expect(bd.total).toBe(
+      bd.chassis +
+        bd.engine +
+        bd.gyro +
+        bd.structure +
+        bd.armor +
+        bd.cockpit +
+        bd.heatSinks +
+        bd.equipment,
+    );
+  });
+
+  it('chassis cost = 500 000 for 50-ton', () => {
+    expect(getCostBreakdown(config).chassis).toBe(500_000);
+  });
+
+  it('equipment cost flows through unchanged', () => {
+    const withEquip = { ...config, equipmentCost: 250_000 };
+    expect(getCostBreakdown(withEquip).equipment).toBe(250_000);
+  });
+});

--- a/src/utils/construction/__tests__/engineCalculations.test.ts
+++ b/src/utils/construction/__tests__/engineCalculations.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Engine calculation invariants.
+ *
+ * Engine rating is constrained to multiples of 5 in [10..500].
+ * Standard fusion table from TechManual p.49 governs base weight;
+ * each engine type applies its own weight multiplier.
+ * Walk MP = floor(rating / tonnage). Integral HS = floor(rating / 25).
+ * Side-torso crit slots come from the engine definition (0 for std, 3 for IS XL, etc.).
+ */
+
+import { EngineType } from '@/types/construction/EngineType';
+
+import {
+  calculateEngineRating,
+  calculateEngineWeight,
+  calculateIntegralHeatSinks,
+  calculateWalkMP,
+  getAllValidEngineRatings,
+  getBaseEngineWeight,
+  getEngineCTSlots,
+  getEngineSideTorsoSlots,
+  getTotalEngineSlots,
+  isFusionEngine,
+  validateEngineForTonnage,
+  validateEngineRating,
+} from '../engineCalculations';
+
+describe('validateEngineRating', () => {
+  it('accepts valid multiples of 5 in [10..500]', () => {
+    expect(validateEngineRating(10).isValid).toBe(true);
+    expect(validateEngineRating(200).isValid).toBe(true);
+    expect(validateEngineRating(500).isValid).toBe(true);
+  });
+
+  it('rejects non-multiples of 5', () => {
+    const r = validateEngineRating(201);
+    expect(r.isValid).toBe(false);
+    expect(r.errors.some((e) => /multiple of 5/.test(e))).toBe(true);
+  });
+
+  it('rejects out-of-range ratings', () => {
+    expect(validateEngineRating(5).isValid).toBe(false);
+    expect(validateEngineRating(505).isValid).toBe(false);
+  });
+
+  it('rejects non-integer ratings', () => {
+    const r = validateEngineRating(50.5);
+    expect(r.isValid).toBe(false);
+  });
+});
+
+describe('getBaseEngineWeight (TechManual table)', () => {
+  it('matches the canonical table at common ratings', () => {
+    expect(getBaseEngineWeight(200)).toBe(8.5);
+    expect(getBaseEngineWeight(300)).toBe(19.0);
+    expect(getBaseEngineWeight(100)).toBe(3.0);
+    expect(getBaseEngineWeight(400)).toBe(52.5);
+  });
+
+  it('returns 0 for invalid ratings', () => {
+    expect(getBaseEngineWeight(7)).toBe(0);
+    expect(getBaseEngineWeight(0)).toBe(0);
+  });
+});
+
+describe('calculateEngineWeight (with type multiplier)', () => {
+  it('matches base weight for standard fusion', () => {
+    expect(calculateEngineWeight(200, EngineType.STANDARD)).toBe(8.5);
+  });
+
+  it('halves weight for XL engines (mult 0.5, rounded UP to 0.5 t)', () => {
+    // 8.5 × 0.5 = 4.25 → ceil 0.5 → 4.5
+    expect(calculateEngineWeight(200, EngineType.XL_IS)).toBe(4.5);
+    expect(calculateEngineWeight(200, EngineType.XL_CLAN)).toBe(4.5);
+  });
+});
+
+describe('calculateEngineRating + calculateWalkMP', () => {
+  it('rating = tonnage × walkMP, snapped to nearest 5', () => {
+    expect(calculateEngineRating(50, 4)).toBe(200);
+    expect(calculateEngineRating(75, 4)).toBe(300);
+    // 50×7 = 350 (multiple of 5)
+    expect(calculateEngineRating(50, 7)).toBe(350);
+  });
+
+  it('walkMP = floor(rating / tonnage)', () => {
+    expect(calculateWalkMP(200, 50)).toBe(4);
+    expect(calculateWalkMP(300, 75)).toBe(4);
+    expect(calculateWalkMP(199, 50)).toBe(3); // floor 3.98 → 3
+  });
+
+  it('returns 0 walk MP for non-positive inputs', () => {
+    expect(calculateWalkMP(0, 50)).toBe(0);
+    expect(calculateWalkMP(200, 0)).toBe(0);
+  });
+});
+
+describe('engine slot accounting', () => {
+  it('Standard CT slots = 6, side-torso = 0', () => {
+    expect(getEngineCTSlots(200, EngineType.STANDARD)).toBe(6);
+    expect(getEngineSideTorsoSlots(EngineType.STANDARD)).toBe(0);
+    expect(getTotalEngineSlots(200, EngineType.STANDARD)).toBe(6);
+  });
+
+  it('IS XL: 6 CT + 3 per side = 12 total', () => {
+    expect(getEngineSideTorsoSlots(EngineType.XL_IS)).toBe(3);
+    expect(getTotalEngineSlots(200, EngineType.XL_IS)).toBe(12);
+  });
+
+  it('Clan XL: 6 CT + 2 per side = 10 total', () => {
+    expect(getEngineSideTorsoSlots(EngineType.XL_CLAN)).toBe(2);
+    expect(getTotalEngineSlots(200, EngineType.XL_CLAN)).toBe(10);
+  });
+
+  it('Compact engines use 3 CT slots and 0 side', () => {
+    expect(getEngineCTSlots(200, EngineType.COMPACT)).toBe(3);
+    expect(getEngineSideTorsoSlots(EngineType.COMPACT)).toBe(0);
+  });
+});
+
+describe('calculateIntegralHeatSinks (floor(rating/25) for fusion)', () => {
+  it('returns floor(rating / 25) for fusion engines', () => {
+    expect(calculateIntegralHeatSinks(250, EngineType.STANDARD)).toBe(10);
+    expect(calculateIntegralHeatSinks(400, EngineType.STANDARD)).toBe(16);
+    expect(calculateIntegralHeatSinks(99, EngineType.STANDARD)).toBe(3);
+  });
+
+  it('returns 0 for non-fusion engines (ICE)', () => {
+    expect(calculateIntegralHeatSinks(200, EngineType.ICE)).toBe(0);
+  });
+});
+
+describe('validateEngineForTonnage', () => {
+  it('flags engine too small (walk < 1)', () => {
+    // 100 t with rating 50 → walkMP 0 → invalid
+    const r = validateEngineForTonnage(50, 100);
+    expect(r.isValid).toBe(false);
+  });
+
+  it('flags engine too large (walk > 20)', () => {
+    // 5 t with rating 500 → walkMP = floor(500/5) = 100 → invalid
+    const r = validateEngineForTonnage(500, 5);
+    expect(r.isValid).toBe(false);
+    expect(r.errors.some((e) => /too high/.test(e))).toBe(true);
+  });
+
+  it('passes for legal engine/tonnage combinations', () => {
+    expect(validateEngineForTonnage(200, 50).isValid).toBe(true);
+  });
+});
+
+describe('isFusionEngine', () => {
+  it('returns true for fusion family', () => {
+    expect(isFusionEngine(EngineType.STANDARD)).toBe(true);
+    expect(isFusionEngine(EngineType.XL_IS)).toBe(true);
+  });
+
+  it('returns false for ICE / fuel cell / fission', () => {
+    expect(isFusionEngine(EngineType.ICE)).toBe(false);
+    expect(isFusionEngine(EngineType.FUEL_CELL)).toBe(false);
+    expect(isFusionEngine(EngineType.FISSION)).toBe(false);
+  });
+});
+
+describe('getAllValidEngineRatings', () => {
+  it('returns a sorted ascending list of multiples of 5 from 10 to 500', () => {
+    const ratings = getAllValidEngineRatings();
+    expect(ratings[0]).toBe(10);
+    expect(ratings[ratings.length - 1]).toBe(500);
+    // Sorted ascending
+    for (let i = 1; i < ratings.length; i++) {
+      expect(ratings[i]).toBeGreaterThan(ratings[i - 1]);
+    }
+    // All multiples of 5
+    expect(ratings.every((r) => r % 5 === 0)).toBe(true);
+  });
+});

--- a/src/utils/construction/__tests__/equipmentBVResolver.test.ts
+++ b/src/utils/construction/__tests__/equipmentBVResolver.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Equipment BV resolver invariants.
+ *
+ * The resolver canonicalizes equipment IDs from MegaMek/unit-JSON formats,
+ * looks them up in the catalog, and applies BV-context heat overrides
+ * (Ultra AC ×2, Rotary AC ×6, Streak/IATM ×0.5) to weapon heat values.
+ *
+ * Heat overrides are tested at the resolver layer because they're load-bearing
+ * for offensive heat tracking.
+ */
+
+import {
+  getCatalogSize,
+  getEquipmentEntry,
+  isResolvable,
+  normalizeEquipmentId,
+  resolveAmmoBV,
+  resolveEquipmentBV,
+} from '../equipmentBVResolver';
+
+describe('normalizeEquipmentId — canonical lookup paths', () => {
+  it('returns lowercased id when already canonical', () => {
+    expect(normalizeEquipmentId('medium-laser')).toBe('medium-laser');
+  });
+
+  it('strips numeric prefixes ("0-medium-laser") and re-resolves', () => {
+    expect(normalizeEquipmentId('0-medium-laser')).toBe('medium-laser');
+  });
+
+  it('normalises MegaMek ID conventions: isac10 → ac-10', () => {
+    expect(normalizeEquipmentId('isac10')).toBe('ac-10');
+    expect(normalizeEquipmentId('clac10')).toBe('ac-10');
+    expect(normalizeEquipmentId('islrm5')).toBe('lrm-5');
+    expect(normalizeEquipmentId('issrm6')).toBe('srm-6');
+  });
+
+  it('handles laser families (smalllaser → small-laser)', () => {
+    expect(normalizeEquipmentId('smalllaser')).toBe('small-laser');
+    expect(normalizeEquipmentId('mediumlaser')).toBe('medium-laser');
+    expect(normalizeEquipmentId('largelaser')).toBe('large-laser');
+  });
+
+  it('handles ER laser families', () => {
+    expect(normalizeEquipmentId('iserlarge')).toBe('er-large-laser');
+    expect(normalizeEquipmentId('clerlarge')).toBe('clan-er-large-laser');
+  });
+});
+
+describe('resolveEquipmentBV — base lookups', () => {
+  it('returns resolved=true for known catalog entries', () => {
+    const r = resolveEquipmentBV('medium-laser');
+    expect(r.resolved).toBe(true);
+    expect(r.battleValue).toBeGreaterThan(0);
+  });
+
+  it('returns resolved=false with zero BV for unknown ids', () => {
+    const r = resolveEquipmentBV('not-a-real-weapon-12345');
+    expect(r.resolved).toBe(false);
+    expect(r.battleValue).toBe(0);
+  });
+
+  it('returns identical BV for equivalent ID forms', () => {
+    const a = resolveEquipmentBV('medium-laser');
+    const b = resolveEquipmentBV('IS Medium Laser');
+    expect(b.battleValue).toBe(a.battleValue);
+  });
+});
+
+describe('resolveEquipmentBV — heat overrides (BV context)', () => {
+  it('Ultra AC heat is doubled', () => {
+    // Catalog "Ultra AC/5" base heat 1; BV override → 2
+    const r = resolveEquipmentBV('uac-5');
+    if (r.resolved) {
+      const entry = getEquipmentEntry('uac-5');
+      if (entry && typeof entry.heat === 'number') {
+        expect(r.heat).toBe(entry.heat * 2);
+      }
+    }
+  });
+
+  it('Rotary AC heat is multiplied by 6', () => {
+    const entry = getEquipmentEntry('rac-5');
+    const r = resolveEquipmentBV('rac-5');
+    if (r.resolved && entry && typeof entry.heat === 'number') {
+      expect(r.heat).toBe(entry.heat * 6);
+    }
+  });
+
+  it('Streak SRM heat is halved (×0.5)', () => {
+    // Look at IS Streak SRM-2; heat 2 → BV-context heat 1
+    const r = resolveEquipmentBV('streak-srm-2');
+    const entry = getEquipmentEntry('streak-srm-2');
+    if (r.resolved && entry && typeof entry.heat === 'number') {
+      expect(r.heat).toBe(entry.heat * 0.5);
+    }
+  });
+});
+
+describe('isResolvable', () => {
+  it('returns true for canonical IDs', () => {
+    expect(isResolvable('medium-laser')).toBe(true);
+  });
+
+  it('returns false for fake IDs', () => {
+    expect(isResolvable('definitely-not-a-real-weapon-99')).toBe(false);
+  });
+});
+
+describe('resolveAmmoBV', () => {
+  it('returns the weaponType derived from the ammo id', () => {
+    const r = resolveAmmoBV('ac-5-ammo');
+    if (r.resolved) {
+      // Strip suffix → weaponType = 'ac-5'
+      expect(r.weaponType).toBe('ac-5');
+    }
+  });
+
+  it('returns resolved=false for unknown ammo', () => {
+    const r = resolveAmmoBV('not-a-real-ammo');
+    expect(r.resolved).toBe(false);
+    expect(r.battleValue).toBe(0);
+  });
+});
+
+describe('getCatalogSize', () => {
+  it('returns a positive integer (catalog is non-empty)', () => {
+    expect(getCatalogSize()).toBeGreaterThan(0);
+    expect(Number.isInteger(getCatalogSize())).toBe(true);
+  });
+});

--- a/src/utils/construction/__tests__/gyroCalculations.test.ts
+++ b/src/utils/construction/__tests__/gyroCalculations.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Gyro calculation invariants.
+ *
+ * Base weight = ceil(engineRating / 100).
+ * Final weight = ceil(base × type-multiplier × 2) / 2 (ceil to half-ton).
+ *
+ * Standard gyro = 4 critical slots (mult 1.0).
+ * XL gyro mult 0.5 (lighter), Compact mult 1.5, Heavy-Duty mult 2.0.
+ */
+
+import { GyroType } from '@/types/construction/GyroType';
+
+import {
+  calculateGyroWeight,
+  getGyroCriticalSlots,
+  isGyroCompatibleWithCockpit,
+  validateGyro,
+} from '../gyroCalculations';
+
+describe('calculateGyroWeight (base = ceil(rating/100))', () => {
+  it('matches base weight for standard gyro at exact 100s', () => {
+    // rating 200 → base 2; mult 1.0 → 2 t
+    expect(calculateGyroWeight(200, GyroType.STANDARD)).toBe(2);
+    // rating 100 → 1 t
+    expect(calculateGyroWeight(100, GyroType.STANDARD)).toBe(1);
+    // rating 400 → 4 t
+    expect(calculateGyroWeight(400, GyroType.STANDARD)).toBe(4);
+  });
+
+  it('rounds base UP when engine rating exceeds a multiple of 100', () => {
+    // rating 201 → ceil(2.01) = 3 → 3 t standard
+    expect(calculateGyroWeight(201, GyroType.STANDARD)).toBe(3);
+    // rating 105 → ceil(1.05) = 2 → 2 t
+    expect(calculateGyroWeight(105, GyroType.STANDARD)).toBe(2);
+  });
+
+  it('handles XL gyro (mult 0.5, ceil to 0.5 t)', () => {
+    // rating 200 → base 2 × 0.5 = 1 → 1 t
+    expect(calculateGyroWeight(200, GyroType.XL)).toBe(1);
+    // rating 100 → base 1 × 0.5 = 0.5 → 0.5 t
+    expect(calculateGyroWeight(100, GyroType.XL)).toBe(0.5);
+  });
+
+  it('handles Compact gyro (mult 1.5)', () => {
+    // rating 200 → base 2 × 1.5 = 3 → 3 t
+    expect(calculateGyroWeight(200, GyroType.COMPACT)).toBe(3);
+  });
+
+  it('handles Heavy-Duty gyro (mult 2.0)', () => {
+    // rating 200 → base 2 × 2.0 = 4 → 4 t
+    expect(calculateGyroWeight(200, GyroType.HEAVY_DUTY)).toBe(4);
+  });
+
+  it('returns 0 for non-positive engine rating', () => {
+    expect(calculateGyroWeight(0, GyroType.STANDARD)).toBe(0);
+    expect(calculateGyroWeight(-1, GyroType.STANDARD)).toBe(0);
+  });
+});
+
+describe('getGyroCriticalSlots', () => {
+  it('Standard / XL / Heavy-Duty / Compact use canonical slot counts', () => {
+    expect(getGyroCriticalSlots(GyroType.STANDARD)).toBe(4);
+    expect(getGyroCriticalSlots(GyroType.XL)).toBe(6);
+    expect(getGyroCriticalSlots(GyroType.HEAVY_DUTY)).toBe(4);
+    expect(getGyroCriticalSlots(GyroType.COMPACT)).toBe(2);
+  });
+});
+
+describe('validateGyro', () => {
+  it('flags non-positive engine rating', () => {
+    const r = validateGyro(GyroType.STANDARD, 0);
+    expect(r.isValid).toBe(false);
+    expect(r.errors.some((e) => /greater than 0/.test(e))).toBe(true);
+  });
+
+  it('passes for valid combinations', () => {
+    expect(validateGyro(GyroType.STANDARD, 200).isValid).toBe(true);
+  });
+});
+
+describe('isGyroCompatibleWithCockpit', () => {
+  it('returns true for compact gyro + standard cockpit (compatible per simplified rules)', () => {
+    expect(isGyroCompatibleWithCockpit(GyroType.COMPACT, 'Standard')).toBe(
+      true,
+    );
+  });
+
+  it('returns true for arbitrary gyro/cockpit pairings (no incompatibilities encoded)', () => {
+    expect(isGyroCompatibleWithCockpit(GyroType.XL, 'Torso-Mounted')).toBe(
+      true,
+    );
+  });
+});

--- a/src/utils/construction/__tests__/heatSinkCalculations.test.ts
+++ b/src/utils/construction/__tests__/heatSinkCalculations.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Heat sink calculation invariants.
+ *
+ * Per BattleTech rules:
+ *  - Single HS: 1 dissipation/ton; Double HS: 2 dissipation/ton, same weight.
+ *  - First 10 heat sinks are weight-free (paid for by chassis).
+ *  - "External" = above engine-integral; consumes critical slots.
+ *  - Engine-integral count = floor(rating/25) for fusion engines, 0 otherwise.
+ *  - Minimum 10 heat sinks per mech.
+ */
+
+import { EngineType } from '@/types/construction/EngineType';
+import { HeatSinkType } from '@/types/construction/HeatSinkType';
+
+import {
+  calculateExternalHeatSinks,
+  calculateExternalHeatSinkSlots,
+  calculateExternalHeatSinkWeight,
+  calculateHeatDissipation,
+  calculateHeatSinkWeight,
+  getHeatSinkSummary,
+  MINIMUM_HEAT_SINKS,
+  validateHeatSinks,
+} from '../heatSinkCalculations';
+
+describe('MINIMUM_HEAT_SINKS contract', () => {
+  it('is exactly 10', () => {
+    expect(MINIMUM_HEAT_SINKS).toBe(10);
+  });
+});
+
+describe('calculateHeatDissipation', () => {
+  it('Single HS: 1 dissipation per sink', () => {
+    expect(calculateHeatDissipation(HeatSinkType.SINGLE, 10)).toBe(10);
+    expect(calculateHeatDissipation(HeatSinkType.SINGLE, 18)).toBe(18);
+  });
+
+  it('Double HS: 2 dissipation per sink', () => {
+    expect(calculateHeatDissipation(HeatSinkType.DOUBLE_IS, 10)).toBe(20);
+    expect(calculateHeatDissipation(HeatSinkType.DOUBLE_CLAN, 12)).toBe(24);
+  });
+});
+
+describe('calculateExternalHeatSinks', () => {
+  it('subtracts engine-integral count from total', () => {
+    // 250 fusion → 10 integral; 12 total → 2 external
+    expect(calculateExternalHeatSinks(12, 250, EngineType.STANDARD)).toBe(2);
+  });
+
+  it('clamps to 0 when integral exceeds total', () => {
+    // 400 fusion → 16 integral; 10 total → 0 external (clamped)
+    expect(calculateExternalHeatSinks(10, 400, EngineType.STANDARD)).toBe(0);
+  });
+
+  it('returns total for non-fusion engines (no integral capacity)', () => {
+    expect(calculateExternalHeatSinks(15, 250, EngineType.ICE)).toBe(15);
+  });
+});
+
+describe('calculateHeatSinkWeight (canonical: first 10 free)', () => {
+  it('returns 0 t for 10 or fewer heat sinks', () => {
+    expect(calculateHeatSinkWeight(10, HeatSinkType.SINGLE)).toBe(0);
+    expect(calculateHeatSinkWeight(5, HeatSinkType.SINGLE)).toBe(0);
+  });
+
+  it('charges 1 t per sink above 10 for Single HS', () => {
+    expect(calculateHeatSinkWeight(15, HeatSinkType.SINGLE)).toBe(5);
+    expect(calculateHeatSinkWeight(20, HeatSinkType.SINGLE)).toBe(10);
+  });
+
+  it('charges 1 t per sink above 10 for Double HS (same weight as singles)', () => {
+    expect(calculateHeatSinkWeight(15, HeatSinkType.DOUBLE_IS)).toBe(5);
+    expect(calculateHeatSinkWeight(15, HeatSinkType.DOUBLE_CLAN)).toBe(5);
+  });
+});
+
+describe('calculateExternalHeatSinkWeight (legacy/incorrect path)', () => {
+  it('returns externalCount × per-sink weight (does NOT apply free-10 rule)', () => {
+    // This is the legacy path; documented as deprecated in source.
+    expect(calculateExternalHeatSinkWeight(5, HeatSinkType.SINGLE)).toBe(5);
+  });
+});
+
+describe('calculateExternalHeatSinkSlots (slot count for external sinks)', () => {
+  it('Single HS: 1 slot each', () => {
+    expect(calculateExternalHeatSinkSlots(5, HeatSinkType.SINGLE)).toBe(5);
+  });
+
+  it('Double IS HS: 3 slots each', () => {
+    expect(calculateExternalHeatSinkSlots(2, HeatSinkType.DOUBLE_IS)).toBe(6);
+  });
+
+  it('Double Clan HS: 2 slots each', () => {
+    expect(calculateExternalHeatSinkSlots(3, HeatSinkType.DOUBLE_CLAN)).toBe(6);
+  });
+});
+
+describe('validateHeatSinks', () => {
+  it('flags fewer than 10 heat sinks', () => {
+    const r = validateHeatSinks(
+      5,
+      HeatSinkType.SINGLE,
+      200,
+      EngineType.STANDARD,
+    );
+    expect(r.isValid).toBe(false);
+    expect(r.errors.some((e) => /Minimum 10/.test(e))).toBe(true);
+  });
+
+  it('passes for 10+ heat sinks', () => {
+    const r = validateHeatSinks(
+      10,
+      HeatSinkType.SINGLE,
+      250,
+      EngineType.STANDARD,
+    );
+    expect(r.isValid).toBe(true);
+  });
+
+  it('warns about excessive externals (>20)', () => {
+    // 250 fusion = 10 integral; 35 total = 25 external → warning
+    const r = validateHeatSinks(
+      35,
+      HeatSinkType.SINGLE,
+      250,
+      EngineType.STANDARD,
+    );
+    expect(r.warnings.length).toBeGreaterThan(0);
+  });
+});
+
+describe('getHeatSinkSummary', () => {
+  it('returns the full configuration breakdown', () => {
+    // 250 fusion → 10 integral; 14 total → 4 external; first-10 free → 4 t weight
+    const s = getHeatSinkSummary(
+      14,
+      HeatSinkType.SINGLE,
+      250,
+      EngineType.STANDARD,
+    );
+    expect(s.integrated).toBe(10);
+    expect(s.external).toBe(4);
+    expect(s.weight).toBe(4); // 14 - 10 = 4 paid sinks × 1 t
+    expect(s.dissipation).toBe(14); // single, total 14
+    expect(s.weightFree).toBe(10);
+  });
+
+  it('handles double heat sinks with proper dissipation', () => {
+    const s = getHeatSinkSummary(
+      12,
+      HeatSinkType.DOUBLE_IS,
+      250,
+      EngineType.STANDARD,
+    );
+    expect(s.dissipation).toBe(24); // 12 × 2
+  });
+});

--- a/src/utils/construction/__tests__/techBaseValidation.test.ts
+++ b/src/utils/construction/__tests__/techBaseValidation.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tech base compatibility invariants.
+ *
+ * Per construction rules:
+ *  - Same tech base components are always compatible.
+ *  - Mixed-tech construction explicitly allows cross-base components.
+ *  - IS components on a Clan unit are allowed even without mixed-tech (inferior tech).
+ *  - Clan components on an IS unit require mixed-tech.
+ *  - Highest rules level among components dictates the unit's required level.
+ */
+
+import { ArmorTypeEnum } from '@/types/construction/ArmorType';
+import { EngineType } from '@/types/construction/EngineType';
+import { GyroType } from '@/types/construction/GyroType';
+import { HeatSinkType } from '@/types/construction/HeatSinkType';
+import { InternalStructureType } from '@/types/construction/InternalStructureType';
+import { RulesLevel } from '@/types/enums/RulesLevel';
+import { TechBase } from '@/types/enums/TechBase';
+
+import {
+  getAvailableArmorTypes,
+  getAvailableEngineTypes,
+  getAvailableGyroTypes,
+  getAvailableHeatSinkTypes,
+  getAvailableStructureTypes,
+  getEngineTechBase,
+  getHighestRulesLevel,
+  isComponentCompatible,
+  validateTechBaseCompatibility,
+} from '../techBaseValidation';
+
+describe('isComponentCompatible — same tech base', () => {
+  it('IS-on-IS always compatible', () => {
+    expect(
+      isComponentCompatible(
+        TechBase.INNER_SPHERE,
+        TechBase.INNER_SPHERE,
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it('Clan-on-Clan always compatible', () => {
+    expect(isComponentCompatible(TechBase.CLAN, TechBase.CLAN, false)).toBe(
+      true,
+    );
+  });
+});
+
+describe('isComponentCompatible — cross tech base', () => {
+  it('IS components ALLOWED on Clan units (inferior tech rule)', () => {
+    expect(
+      isComponentCompatible(TechBase.INNER_SPHERE, TechBase.CLAN, false),
+    ).toBe(true);
+  });
+
+  it('Clan components REJECTED on IS units without mixed-tech', () => {
+    expect(
+      isComponentCompatible(TechBase.CLAN, TechBase.INNER_SPHERE, false),
+    ).toBe(false);
+  });
+
+  it('Mixed-tech permits any cross-base combination', () => {
+    expect(
+      isComponentCompatible(TechBase.CLAN, TechBase.INNER_SPHERE, true),
+    ).toBe(true);
+  });
+});
+
+describe('getEngineTechBase', () => {
+  it('returns INNER_SPHERE for IS XL engine', () => {
+    expect(getEngineTechBase(EngineType.XL_IS)).toBe(TechBase.INNER_SPHERE);
+  });
+
+  it('returns CLAN for Clan XL engine', () => {
+    expect(getEngineTechBase(EngineType.XL_CLAN)).toBe(TechBase.CLAN);
+  });
+});
+
+describe('validateTechBaseCompatibility', () => {
+  it('passes when all components match unit tech base', () => {
+    const r = validateTechBaseCompatibility(TechBase.INNER_SPHERE, {
+      engineType: EngineType.STANDARD,
+      gyroType: GyroType.STANDARD,
+      structureType: InternalStructureType.STANDARD,
+    });
+    expect(r.isValid).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('flags Clan engine on IS unit without mixed-tech', () => {
+    const r = validateTechBaseCompatibility(
+      TechBase.INNER_SPHERE,
+      { engineType: EngineType.XL_CLAN },
+      false,
+    );
+    expect(r.isValid).toBe(false);
+    expect(r.errors[0]).toMatch(/Engine/);
+  });
+
+  it('passes when mixed-tech is enabled', () => {
+    const r = validateTechBaseCompatibility(
+      TechBase.INNER_SPHERE,
+      { engineType: EngineType.XL_CLAN },
+      true,
+    );
+    expect(r.isValid).toBe(true);
+    // Mixed-tech warning when multiple tech bases are present
+    expect(r.warnings.length).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('getHighestRulesLevel', () => {
+  it('returns INTRODUCTORY when no components are supplied', () => {
+    expect(getHighestRulesLevel({})).toBe(RulesLevel.INTRODUCTORY);
+  });
+
+  it('escalates to STANDARD when an XL engine is present', () => {
+    // XL_IS is STANDARD per ENGINE_DEFINITIONS
+    const level = getHighestRulesLevel({ engineType: EngineType.XL_IS });
+    expect(level).toBe(RulesLevel.STANDARD);
+  });
+
+  it('takes the highest level across all components', () => {
+    // Hardened armor is EXPERIMENTAL in this codebase → final level is EXPERIMENTAL
+    const level = getHighestRulesLevel({
+      engineType: EngineType.STANDARD, // INTRO
+      armorType: ArmorTypeEnum.HARDENED, // EXPERIMENTAL
+    });
+    expect(level).toBe(RulesLevel.EXPERIMENTAL);
+  });
+});
+
+describe('getAvailable* (filtering by tech base)', () => {
+  it('IS unit (no mixed-tech) returns only IS-compatible engines + IS components on Clan', () => {
+    const engines = getAvailableEngineTypes(TechBase.INNER_SPHERE, false);
+    // STANDARD is IS-base → must be available
+    expect(engines).toContain(EngineType.STANDARD);
+    // XL_IS is IS-base → available
+    expect(engines).toContain(EngineType.XL_IS);
+    // XL_CLAN is Clan-only → NOT available
+    expect(engines).not.toContain(EngineType.XL_CLAN);
+  });
+
+  it('Clan unit (no mixed-tech) returns Clan + IS-as-inferior engines', () => {
+    const engines = getAvailableEngineTypes(TechBase.CLAN, false);
+    expect(engines).toContain(EngineType.XL_CLAN);
+    // IS XL is inferior → still allowed on Clan
+    expect(engines).toContain(EngineType.XL_IS);
+  });
+
+  it('Mixed-tech expands the available set', () => {
+    const standard = getAvailableEngineTypes(TechBase.INNER_SPHERE, false);
+    const mixed = getAvailableEngineTypes(TechBase.INNER_SPHERE, true);
+    expect(mixed.length).toBeGreaterThanOrEqual(standard.length);
+  });
+
+  it('getAvailableGyroTypes / Structure / HeatSink / Armor return non-empty arrays', () => {
+    expect(
+      getAvailableGyroTypes(TechBase.INNER_SPHERE, false).length,
+    ).toBeGreaterThan(0);
+    expect(
+      getAvailableStructureTypes(TechBase.INNER_SPHERE, false).length,
+    ).toBeGreaterThan(0);
+    expect(
+      getAvailableHeatSinkTypes(TechBase.INNER_SPHERE, false).length,
+    ).toBeGreaterThan(0);
+    expect(
+      getAvailableArmorTypes(TechBase.INNER_SPHERE, false).length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/construction/aerospace/__tests__/armorArcCalculations.test.ts
+++ b/src/utils/construction/aerospace/__tests__/armorArcCalculations.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Aerospace per-arc armor allocation invariants.
+ *
+ * Each arc has a tonnage-multiplier:
+ *   ASF/CF: Nose 0.28, LWing/RWing 0.20, Aft 0.12, Sides 0
+ *   SmallCraft: Nose 0.28, LSide/RSide 0.20, Aft 0.12, Wings 0
+ * maxArcArmorPoints = floor(tonnage × factor).
+ */
+
+import {
+  AerospaceArc,
+  AerospaceSubType,
+} from '@/types/unit/AerospaceInterfaces';
+
+import {
+  arcMaxMap,
+  ASF_CF_ARCS,
+  getArcsForSubType,
+  maxArcArmorPoints,
+  maxTotalArmorPoints,
+  SMALL_CRAFT_ARCS,
+} from '../armorArcCalculations';
+
+describe('getArcsForSubType', () => {
+  it('returns wing arcs for ASF and CF', () => {
+    expect(getArcsForSubType(AerospaceSubType.AEROSPACE_FIGHTER)).toBe(
+      ASF_CF_ARCS,
+    );
+    expect(getArcsForSubType(AerospaceSubType.CONVENTIONAL_FIGHTER)).toBe(
+      ASF_CF_ARCS,
+    );
+  });
+
+  it('returns side arcs for small craft (no wings)', () => {
+    expect(getArcsForSubType(AerospaceSubType.SMALL_CRAFT)).toBe(
+      SMALL_CRAFT_ARCS,
+    );
+  });
+
+  it('exposes the canonical 4-arc set for ASF/CF (Nose, LWing, RWing, Aft)', () => {
+    expect(ASF_CF_ARCS).toEqual([
+      AerospaceArc.NOSE,
+      AerospaceArc.LEFT_WING,
+      AerospaceArc.RIGHT_WING,
+      AerospaceArc.AFT,
+    ]);
+  });
+});
+
+describe('maxArcArmorPoints — ASF/CF', () => {
+  const subType = AerospaceSubType.AEROSPACE_FIGHTER;
+
+  it('Nose = floor(tonnage × 0.28)', () => {
+    expect(maxArcArmorPoints(AerospaceArc.NOSE, 50, subType)).toBe(14); // 14.0
+    expect(maxArcArmorPoints(AerospaceArc.NOSE, 100, subType)).toBe(28);
+  });
+
+  it('Wings = floor(tonnage × 0.20)', () => {
+    expect(maxArcArmorPoints(AerospaceArc.LEFT_WING, 50, subType)).toBe(10);
+    expect(maxArcArmorPoints(AerospaceArc.RIGHT_WING, 75, subType)).toBe(15);
+  });
+
+  it('Aft = floor(tonnage × 0.12)', () => {
+    expect(maxArcArmorPoints(AerospaceArc.AFT, 50, subType)).toBe(6); // 6.0
+    expect(maxArcArmorPoints(AerospaceArc.AFT, 100, subType)).toBe(12);
+  });
+
+  it('returns 0 for sides on ASF (sides are small-craft only)', () => {
+    expect(maxArcArmorPoints(AerospaceArc.LEFT_SIDE, 50, subType)).toBe(0);
+    expect(maxArcArmorPoints(AerospaceArc.RIGHT_SIDE, 50, subType)).toBe(0);
+  });
+});
+
+describe('maxArcArmorPoints — small craft', () => {
+  const subType = AerospaceSubType.SMALL_CRAFT;
+
+  it('uses sides instead of wings (0.20 factor)', () => {
+    expect(maxArcArmorPoints(AerospaceArc.LEFT_SIDE, 200, subType)).toBe(40);
+    expect(maxArcArmorPoints(AerospaceArc.RIGHT_SIDE, 200, subType)).toBe(40);
+  });
+
+  it('returns 0 for wings on small craft', () => {
+    expect(maxArcArmorPoints(AerospaceArc.LEFT_WING, 200, subType)).toBe(0);
+    expect(maxArcArmorPoints(AerospaceArc.RIGHT_WING, 200, subType)).toBe(0);
+  });
+});
+
+describe('maxTotalArmorPoints', () => {
+  it('sums all arcs for ASF (Nose + LWing + RWing + Aft)', () => {
+    // 100 t ASF: 28 + 20 + 20 + 12 = 80
+    expect(maxTotalArmorPoints(100, AerospaceSubType.AEROSPACE_FIGHTER)).toBe(
+      80,
+    );
+  });
+
+  it('sums all arcs for small craft (Nose + LSide + RSide + Aft)', () => {
+    // 200 t SC: 56 + 40 + 40 + 24 = 160
+    expect(maxTotalArmorPoints(200, AerospaceSubType.SMALL_CRAFT)).toBe(160);
+  });
+});
+
+describe('arcMaxMap', () => {
+  it('returns a per-arc map matching maxArcArmorPoints', () => {
+    const map = arcMaxMap(50, AerospaceSubType.AEROSPACE_FIGHTER);
+    expect(map[AerospaceArc.NOSE]).toBe(14);
+    expect(map[AerospaceArc.LEFT_WING]).toBe(10);
+    expect(map[AerospaceArc.RIGHT_WING]).toBe(10);
+    expect(map[AerospaceArc.AFT]).toBe(6);
+  });
+});

--- a/src/utils/construction/aerospace/__tests__/bombBays.test.ts
+++ b/src/utils/construction/aerospace/__tests__/bombBays.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Aerospace small-craft bomb bay invariants.
+ *
+ * Per bay tonnage = capacityBombs + 1 t structure.
+ * Aggregate cap = floor(unitTonnage / 2).
+ * Bays are legal only on small craft.
+ */
+
+import { AerospaceSubType } from '@/types/unit/AerospaceInterfaces';
+
+import {
+  BAY_STRUCTURE_TONS,
+  bayTons,
+  BOMB_BAY_TONNAGE_FRACTION,
+  maxBombBayTons,
+  totalBombBayTons,
+  totalBombCapacity,
+  validateBombBays,
+  type IBombBay,
+} from '../bombBays';
+
+describe('bomb bay constants', () => {
+  it('charges 1 ton structure per bay', () => {
+    expect(BAY_STRUCTURE_TONS).toBe(1);
+  });
+  it('caps aggregate bay tonnage at half of unit tonnage', () => {
+    expect(BOMB_BAY_TONNAGE_FRACTION).toBe(0.5);
+  });
+});
+
+describe('bayTons (single bay)', () => {
+  it('returns capacityBombs + 1 t structure', () => {
+    expect(bayTons({ id: 'a', capacityBombs: 5 })).toBe(6);
+    expect(bayTons({ id: 'b', capacityBombs: 0 })).toBe(1);
+  });
+
+  it('clamps negative capacity to zero (bay still costs 1 t)', () => {
+    expect(bayTons({ id: 'c', capacityBombs: -3 })).toBe(1);
+  });
+});
+
+describe('totalBombBayTons / totalBombCapacity', () => {
+  const bays: IBombBay[] = [
+    { id: 'a', capacityBombs: 5 },
+    { id: 'b', capacityBombs: 3 },
+  ];
+
+  it('sums per-bay tonnage', () => {
+    // 6 + 4 = 10 t
+    expect(totalBombBayTons(bays)).toBe(10);
+  });
+
+  it('sums per-bay bomb capacity (excluding structure overhead)', () => {
+    expect(totalBombCapacity(bays)).toBe(8);
+  });
+});
+
+describe('maxBombBayTons (aggregate cap)', () => {
+  it('returns floor(tonnage / 2) for small craft', () => {
+    expect(maxBombBayTons(200, AerospaceSubType.SMALL_CRAFT)).toBe(100);
+    expect(maxBombBayTons(101, AerospaceSubType.SMALL_CRAFT)).toBe(50);
+  });
+
+  it('returns 0 for non-small-craft sub-types', () => {
+    expect(maxBombBayTons(200, AerospaceSubType.AEROSPACE_FIGHTER)).toBe(0);
+    expect(maxBombBayTons(50, AerospaceSubType.CONVENTIONAL_FIGHTER)).toBe(0);
+  });
+});
+
+describe('validateBombBays (VAL-AERO-BOMB-BAY)', () => {
+  it('allows zero bays on any sub-type', () => {
+    expect(
+      validateBombBays([], 50, AerospaceSubType.AEROSPACE_FIGHTER),
+    ).toEqual([]);
+    expect(validateBombBays([], 200, AerospaceSubType.SMALL_CRAFT)).toEqual([]);
+  });
+
+  it('rejects bays on ASF / CF (only SC may declare bays)', () => {
+    const errs = validateBombBays(
+      [{ id: 'a', capacityBombs: 5 }],
+      50,
+      AerospaceSubType.AEROSPACE_FIGHTER,
+    );
+    expect(errs).toHaveLength(1);
+    expect(errs[0].ruleId).toBe('VAL-AERO-BOMB-BAY');
+  });
+
+  it('flags negative or non-integer capacities', () => {
+    const errs = validateBombBays(
+      [{ id: 'a', capacityBombs: -1 }],
+      200,
+      AerospaceSubType.SMALL_CRAFT,
+    );
+    expect(errs).toHaveLength(1);
+    expect(errs[0].message).toMatch(/non-negative integer/);
+  });
+
+  it('flags aggregate tonnage that exceeds floor(tonnage/2)', () => {
+    const errs = validateBombBays(
+      [{ id: 'a', capacityBombs: 60 }], // 60 + 1 = 61 t
+      100, // cap = 50 t
+      AerospaceSubType.SMALL_CRAFT,
+    );
+    expect(errs.some((e) => /exceeds cap/.test(e.message))).toBe(true);
+  });
+
+  it('returns empty array when bays fit within the cap', () => {
+    const errs = validateBombBays(
+      [{ id: 'a', capacityBombs: 5 }], // 6 t
+      200, // cap = 100 t
+      AerospaceSubType.SMALL_CRAFT,
+    );
+    expect(errs).toEqual([]);
+  });
+});

--- a/src/utils/construction/aerospace/__tests__/crewCalculations.test.ts
+++ b/src/utils/construction/aerospace/__tests__/crewCalculations.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Aerospace small-craft crew quarters invariants.
+ *
+ * Standard quarters: 5 t/crew. Steerage: 3 t/passenger or marine.
+ * Minimum crew per tonnage bracket: ≤100 t = 3, ≤150 t = 4, ≤200 t = 6.
+ */
+
+import {
+  makeSmallCraftCrew,
+  minSmallCraftCrew,
+  quartersWeight,
+  STANDARD_QUARTERS_TONS_PER_CREW,
+  STEERAGE_QUARTERS_TONS_PER_PERSON,
+} from '../crewCalculations';
+
+describe('quarters constants', () => {
+  it('exposes the canonical 5/3 tonnage rates', () => {
+    expect(STANDARD_QUARTERS_TONS_PER_CREW).toBe(5);
+    expect(STEERAGE_QUARTERS_TONS_PER_PERSON).toBe(3);
+  });
+});
+
+describe('minSmallCraftCrew (tonnage bracket → min crew)', () => {
+  it('returns 3 for ≤100 t small craft', () => {
+    expect(minSmallCraftCrew(100)).toBe(3);
+    expect(minSmallCraftCrew(50)).toBe(3);
+  });
+
+  it('returns 4 for >100 t up to 150 t', () => {
+    expect(minSmallCraftCrew(101)).toBe(4);
+    expect(minSmallCraftCrew(150)).toBe(4);
+  });
+
+  it('returns 6 for >150 t up to 200 t', () => {
+    expect(minSmallCraftCrew(151)).toBe(6);
+    expect(minSmallCraftCrew(200)).toBe(6);
+  });
+
+  it('returns 6 (safe fallback) for >200 t', () => {
+    expect(minSmallCraftCrew(300)).toBe(6);
+  });
+});
+
+describe('quartersWeight (crew × 5 + passengers × 3 + marines × 3)', () => {
+  it('charges 5 t per crew member', () => {
+    const w = quartersWeight({
+      crew: 4,
+      passengers: 0,
+      marines: 0,
+      quartersTons: 0,
+    });
+    expect(w).toBe(20);
+  });
+
+  it('charges 3 t per passenger and marine (steerage shares the rate)', () => {
+    const w = quartersWeight({
+      crew: 0,
+      passengers: 4,
+      marines: 4,
+      quartersTons: 0,
+    });
+    expect(w).toBe(24);
+  });
+
+  it('sums all categories', () => {
+    const w = quartersWeight({
+      crew: 3,
+      passengers: 5,
+      marines: 2,
+      quartersTons: 0,
+    });
+    // 3×5 + 5×3 + 2×3 = 15 + 15 + 6 = 36
+    expect(w).toBe(36);
+  });
+});
+
+describe('makeSmallCraftCrew', () => {
+  it('returns an ISmallCraftCrew with computed quartersTons', () => {
+    const c = makeSmallCraftCrew(3, 4, 1);
+    // 3×5 + 4×3 + 1×3 = 15 + 12 + 3 = 30
+    expect(c.quartersTons).toBe(30);
+    expect(c.crew).toBe(3);
+    expect(c.passengers).toBe(4);
+    expect(c.marines).toBe(1);
+  });
+});

--- a/src/utils/construction/aerospace/__tests__/engineWeightAerospace.test.ts
+++ b/src/utils/construction/aerospace/__tests__/engineWeightAerospace.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Aerospace engine weight invariants.
+ *
+ * Base fusion weight comes from the TechManual table; per-engine multipliers
+ * scale the base. ICE doubles, XL halves, FuelCell ×1.2, CompactFusion ×1.5.
+ * Final weight is rounded UP to the nearest 0.5 t.
+ */
+
+import { AerospaceEngineType } from '@/types/unit/AerospaceInterfaces';
+
+import { aerospaceEngineWeight } from '../engineWeightAerospace';
+
+describe('aerospaceEngineWeight — fusion baseline', () => {
+  it('matches the table value at common ratings', () => {
+    expect(aerospaceEngineWeight(200, AerospaceEngineType.FUSION)).toBe(8.5);
+    expect(aerospaceEngineWeight(300, AerospaceEngineType.FUSION)).toBe(17.5);
+    expect(aerospaceEngineWeight(100, AerospaceEngineType.FUSION)).toBe(3.0);
+  });
+
+  it('handles small fighter ratings', () => {
+    expect(aerospaceEngineWeight(50, AerospaceEngineType.FUSION)).toBe(1.5);
+    expect(aerospaceEngineWeight(20, AerospaceEngineType.FUSION)).toBe(0.5);
+  });
+});
+
+describe('aerospaceEngineWeight — engine-type multipliers', () => {
+  it('XL halves fusion weight (rounded UP to 0.5)', () => {
+    // Fusion 200 = 8.5 → ×0.5 = 4.25 → ceil 0.5 → 4.5
+    expect(aerospaceEngineWeight(200, AerospaceEngineType.XL)).toBe(4.5);
+  });
+
+  it('ICE doubles fusion weight', () => {
+    // Fusion 200 = 8.5 → ×2 = 17.0
+    expect(aerospaceEngineWeight(200, AerospaceEngineType.ICE)).toBe(17.0);
+  });
+
+  it('Compact Fusion ×1.5', () => {
+    // Fusion 100 = 3.0 → ×1.5 = 4.5
+    expect(aerospaceEngineWeight(100, AerospaceEngineType.COMPACT_FUSION)).toBe(
+      4.5,
+    );
+  });
+
+  it('Fuel Cell ×1.2 rounds up to next 0.5', () => {
+    // Fusion 100 = 3.0 → ×1.2 = 3.6 → ceil 0.5 → 4.0
+    expect(aerospaceEngineWeight(100, AerospaceEngineType.FUEL_CELL)).toBe(4.0);
+  });
+});
+
+describe('aerospaceEngineWeight — half-ton rounding rule', () => {
+  it('always rounds UP to the nearest 0.5 t', () => {
+    // Pick a rating that produces a non-half-ton multiplied weight.
+    // Fusion 215 = 9.0 → XL ×0.5 = 4.5 (already half-ton)
+    expect(aerospaceEngineWeight(215, AerospaceEngineType.XL)).toBe(4.5);
+    // Fusion 210 = 9.0 → ICE ×2 = 18 (whole)
+    expect(aerospaceEngineWeight(210, AerospaceEngineType.ICE)).toBe(18.0);
+    // Fusion 50 = 1.5 → FuelCell ×1.2 = 1.8 → 2.0
+    expect(aerospaceEngineWeight(50, AerospaceEngineType.FUEL_CELL)).toBe(2.0);
+  });
+});
+
+describe('aerospaceEngineWeight — out-of-table fallback', () => {
+  it('uses ceil(rating/25)×0.5 for very large ratings beyond the table', () => {
+    // 405 isn't in the table → fallback ceil(405/25)*0.5 = ceil(16.2)*0.5 = 17*0.5 = 8.5
+    // FUSION ×1.0 = 8.5
+    expect(aerospaceEngineWeight(405, AerospaceEngineType.FUSION)).toBe(8.5);
+  });
+});

--- a/src/utils/construction/aerospace/__tests__/equipmentSlots.test.ts
+++ b/src/utils/construction/aerospace/__tests__/equipmentSlots.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Aerospace per-arc slot-limit invariants.
+ *
+ * Slot limits per arc:
+ *   Nose:        6
+ *   LWing/RWing: 6
+ *   LSide/RSide: 6
+ *   Aft:         4
+ *   Fuselage:    unlimited (null)
+ */
+
+import { AerospaceArc } from '@/types/unit/AerospaceInterfaces';
+
+import {
+  arcSlotAvailable,
+  arcSlotLimit,
+  countItemsPerArc,
+  overLimitArcs,
+} from '../equipmentSlots';
+
+describe('arcSlotLimit', () => {
+  it('returns 6 for Nose, Wings, and Sides', () => {
+    expect(arcSlotLimit(AerospaceArc.NOSE)).toBe(6);
+    expect(arcSlotLimit(AerospaceArc.LEFT_WING)).toBe(6);
+    expect(arcSlotLimit(AerospaceArc.RIGHT_WING)).toBe(6);
+    expect(arcSlotLimit(AerospaceArc.LEFT_SIDE)).toBe(6);
+    expect(arcSlotLimit(AerospaceArc.RIGHT_SIDE)).toBe(6);
+  });
+
+  it('returns 4 for Aft (canonical aerospace rule)', () => {
+    expect(arcSlotLimit(AerospaceArc.AFT)).toBe(4);
+  });
+
+  it('returns null for Fuselage (unlimited)', () => {
+    expect(arcSlotLimit(AerospaceArc.FUSELAGE)).toBeNull();
+  });
+});
+
+describe('arcSlotAvailable', () => {
+  it('allows mounting up to but not past the cap', () => {
+    expect(arcSlotAvailable(AerospaceArc.AFT, 0)).toBe(true);
+    expect(arcSlotAvailable(AerospaceArc.AFT, 3)).toBe(true);
+    expect(arcSlotAvailable(AerospaceArc.AFT, 4)).toBe(false);
+    expect(arcSlotAvailable(AerospaceArc.AFT, 100)).toBe(false);
+  });
+
+  it('always returns true for fuselage (no slot cap)', () => {
+    expect(arcSlotAvailable(AerospaceArc.FUSELAGE, 0)).toBe(true);
+    expect(arcSlotAvailable(AerospaceArc.FUSELAGE, 999)).toBe(true);
+  });
+});
+
+describe('countItemsPerArc', () => {
+  it('aggregates equipment counts by location', () => {
+    const counts = countItemsPerArc([
+      { location: AerospaceArc.NOSE },
+      { location: AerospaceArc.NOSE },
+      { location: AerospaceArc.NOSE },
+      { location: AerospaceArc.AFT },
+    ]);
+    expect(counts.get(AerospaceArc.NOSE)).toBe(3);
+    expect(counts.get(AerospaceArc.AFT)).toBe(1);
+  });
+
+  it('returns an empty map for no equipment', () => {
+    expect(countItemsPerArc([]).size).toBe(0);
+  });
+});
+
+describe('overLimitArcs', () => {
+  it('flags the Aft arc when 5+ items are mounted (cap is 4)', () => {
+    const equipment = Array.from({ length: 5 }, () => ({
+      location: AerospaceArc.AFT,
+    }));
+    expect(overLimitArcs(equipment)).toEqual([AerospaceArc.AFT]);
+  });
+
+  it('returns no violations when caps are respected', () => {
+    const equipment = [
+      ...Array.from({ length: 4 }, () => ({ location: AerospaceArc.AFT })),
+      ...Array.from({ length: 6 }, () => ({ location: AerospaceArc.NOSE })),
+    ];
+    expect(overLimitArcs(equipment)).toEqual([]);
+  });
+
+  it('does not flag fuselage even with massive item counts', () => {
+    const equipment = Array.from({ length: 100 }, () => ({
+      location: AerospaceArc.FUSELAGE,
+    }));
+    expect(overLimitArcs(equipment)).toEqual([]);
+  });
+});

--- a/src/utils/construction/aerospace/__tests__/fuelCalculations.test.ts
+++ b/src/utils/construction/aerospace/__tests__/fuelCalculations.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Aerospace fuel-related invariants.
+ *
+ * Per-subtype minimum fuel: ASF 5, CF 2, Small Craft 20 tons.
+ * Per-engine fuel-points-per-ton: Fusion/XL/CompactFusion 80, ICE 40, FuelCell 60.
+ */
+
+import {
+  AerospaceEngineType,
+  AerospaceSubType,
+} from '@/types/unit/AerospaceInterfaces';
+
+import {
+  calculateFuelPoints,
+  FUEL_BURN_PER_THRUST_POINT,
+  FUEL_MINIMUM_TONS,
+  FUEL_POINTS_PER_TON,
+  minFuelTons,
+} from '../fuelCalculations';
+
+describe('FUEL_MINIMUM_TONS (subtype contract)', () => {
+  it('matches the published per-subtype minima', () => {
+    expect(FUEL_MINIMUM_TONS[AerospaceSubType.AEROSPACE_FIGHTER]).toBe(5);
+    expect(FUEL_MINIMUM_TONS[AerospaceSubType.CONVENTIONAL_FIGHTER]).toBe(2);
+    expect(FUEL_MINIMUM_TONS[AerospaceSubType.SMALL_CRAFT]).toBe(20);
+  });
+});
+
+describe('FUEL_POINTS_PER_TON (engine contract)', () => {
+  it('uses 80 pts/ton for Fusion family (Fusion, XL, CompactFusion)', () => {
+    expect(FUEL_POINTS_PER_TON[AerospaceEngineType.FUSION]).toBe(80);
+    expect(FUEL_POINTS_PER_TON[AerospaceEngineType.XL]).toBe(80);
+    expect(FUEL_POINTS_PER_TON[AerospaceEngineType.COMPACT_FUSION]).toBe(80);
+  });
+
+  it('uses 40 pts/ton for ICE and 60 for fuel cell', () => {
+    expect(FUEL_POINTS_PER_TON[AerospaceEngineType.ICE]).toBe(40);
+    expect(FUEL_POINTS_PER_TON[AerospaceEngineType.FUEL_CELL]).toBe(60);
+  });
+});
+
+describe('FUEL_BURN_PER_THRUST_POINT', () => {
+  it('exposes the canonical 1-fuel-per-thrust constant', () => {
+    expect(FUEL_BURN_PER_THRUST_POINT).toBe(1);
+  });
+});
+
+describe('minFuelTons (subtype lookup)', () => {
+  it('returns 5 for ASF, 2 for CF, 20 for small craft', () => {
+    expect(minFuelTons(AerospaceSubType.AEROSPACE_FIGHTER)).toBe(5);
+    expect(minFuelTons(AerospaceSubType.CONVENTIONAL_FIGHTER)).toBe(2);
+    expect(minFuelTons(AerospaceSubType.SMALL_CRAFT)).toBe(20);
+  });
+});
+
+describe('calculateFuelPoints (tons × pts-per-ton, floored)', () => {
+  it('multiplies fuel tons by engine rate and floors', () => {
+    expect(calculateFuelPoints(5, AerospaceEngineType.FUSION)).toBe(400);
+    expect(calculateFuelPoints(2, AerospaceEngineType.ICE)).toBe(80);
+    expect(calculateFuelPoints(20, AerospaceEngineType.FUEL_CELL)).toBe(1200);
+  });
+
+  it('floors fractional fuel tonnage results', () => {
+    // 0.5 × 80 = 40 (exact, no flooring)
+    expect(calculateFuelPoints(0.5, AerospaceEngineType.FUSION)).toBe(40);
+    // 0.51 × 80 = 40.8 → floor → 40
+    expect(calculateFuelPoints(0.51, AerospaceEngineType.FUSION)).toBe(40);
+  });
+
+  it('returns 0 for zero fuel tonnage', () => {
+    expect(calculateFuelPoints(0, AerospaceEngineType.FUSION)).toBe(0);
+  });
+});

--- a/src/utils/construction/aerospace/__tests__/siCalculations.test.ts
+++ b/src/utils/construction/aerospace/__tests__/siCalculations.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Aerospace Structural Integrity invariants.
+ *
+ * Default SI = ceil(tonnage / 10).
+ * Per-class hard maximum: ASF 20, CF 15, Small Craft 30.
+ * Each SI point above default costs floor(tonnage/10)×0.5 tons; default is free.
+ */
+
+import { AerospaceSubType } from '@/types/unit/AerospaceInterfaces';
+
+import {
+  defaultSI,
+  maxSI,
+  siExtraWeightTons,
+  siWeightCost,
+} from '../siCalculations';
+
+describe('defaultSI (ceil(tonnage / 10))', () => {
+  it('returns 1 for the smallest fighters (≤10 t)', () => {
+    expect(defaultSI(10)).toBe(1);
+    expect(defaultSI(5)).toBe(1);
+  });
+
+  it('rounds up to the next 10-t bucket', () => {
+    expect(defaultSI(45)).toBe(5);
+    expect(defaultSI(50)).toBe(5);
+    expect(defaultSI(51)).toBe(6);
+    expect(defaultSI(100)).toBe(10);
+  });
+
+  it('handles small craft tonnage range', () => {
+    expect(defaultSI(150)).toBe(15);
+    expect(defaultSI(200)).toBe(20);
+  });
+});
+
+describe('maxSI (per-subtype hard cap)', () => {
+  it('returns 20 for aerospace fighters', () => {
+    expect(maxSI(AerospaceSubType.AEROSPACE_FIGHTER)).toBe(20);
+  });
+
+  it('returns 15 for conventional fighters', () => {
+    expect(maxSI(AerospaceSubType.CONVENTIONAL_FIGHTER)).toBe(15);
+  });
+
+  it('returns 30 for small craft', () => {
+    expect(maxSI(AerospaceSubType.SMALL_CRAFT)).toBe(30);
+  });
+});
+
+describe('siWeightCost (extra-only formula)', () => {
+  it('returns 0 when SI equals the default for that tonnage', () => {
+    // 50 t default = 5; SI = 5 → 0 t cost
+    expect(siWeightCost(5, 50)).toBe(0);
+    expect(siWeightCost(10, 100)).toBe(0);
+  });
+
+  it('returns 0 when SI is below default (treats negative extra as zero)', () => {
+    expect(siWeightCost(2, 100)).toBe(0);
+  });
+
+  it('costs (tonnage/10) × 0.5 per extra SI point', () => {
+    // 100 t default 10; +2 SI = 12; cost = 2 × (100/10) × 0.5 = 10 t
+    expect(siWeightCost(12, 100)).toBe(10);
+    // 50 t default 5; +1 SI = 6; cost = 1 × 5 × 0.5 = 2.5 t
+    expect(siWeightCost(6, 50)).toBe(2.5);
+  });
+
+  it('siExtraWeightTons mirrors siWeightCost (only the extra portion is charged)', () => {
+    expect(siExtraWeightTons(12, 100)).toBe(siWeightCost(12, 100));
+    expect(siExtraWeightTons(5, 50)).toBe(0);
+  });
+});

--- a/src/utils/construction/aerospace/__tests__/thrustCalculations.test.ts
+++ b/src/utils/construction/aerospace/__tests__/thrustCalculations.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Aerospace thrust derivation invariants.
+ *
+ * safeThrust = floor(rating / tonnage), clamped to per-subtype cap.
+ * maxThrust = floor(safeThrust × 1.5).
+ * Engine legality is restricted per sub-type (CF: ICE/FuelCell only).
+ */
+
+import {
+  AerospaceEngineType,
+  AerospaceSubType,
+} from '@/types/unit/AerospaceInterfaces';
+
+import {
+  calculateMaxThrust,
+  calculateSafeThrust,
+  getMaxSafeThrust,
+  isEngineLegalForSubType,
+  ratingFromThrust,
+} from '../thrustCalculations';
+
+describe('calculateSafeThrust', () => {
+  it('returns floor(rating/tonnage) within cap', () => {
+    // 250 / 50 = 5
+    expect(
+      calculateSafeThrust(250, 50, AerospaceSubType.AEROSPACE_FIGHTER),
+    ).toBe(5);
+    // 300 / 100 = 3
+    expect(calculateSafeThrust(300, 100, AerospaceSubType.SMALL_CRAFT)).toBe(3);
+  });
+
+  it('clamps to ASF/CF cap of 12', () => {
+    // 600/50 = 12 (at cap)
+    expect(
+      calculateSafeThrust(600, 50, AerospaceSubType.AEROSPACE_FIGHTER),
+    ).toBe(12);
+    // 1000/50 = 20 → clamped to 12
+    expect(
+      calculateSafeThrust(1000, 50, AerospaceSubType.AEROSPACE_FIGHTER),
+    ).toBe(12);
+  });
+
+  it('clamps small craft to a cap of 6', () => {
+    expect(calculateSafeThrust(2000, 100, AerospaceSubType.SMALL_CRAFT)).toBe(
+      6,
+    );
+  });
+
+  it('returns 0 for non-positive tonnage (guard)', () => {
+    expect(
+      calculateSafeThrust(200, 0, AerospaceSubType.AEROSPACE_FIGHTER),
+    ).toBe(0);
+  });
+
+  it('floors fractional thrust', () => {
+    // 251 / 50 = 5.02 → floor → 5
+    expect(
+      calculateSafeThrust(251, 50, AerospaceSubType.AEROSPACE_FIGHTER),
+    ).toBe(5);
+  });
+});
+
+describe('calculateMaxThrust (safeThrust × 1.5, floored)', () => {
+  it('returns floor(safeThrust × 1.5)', () => {
+    expect(calculateMaxThrust(4)).toBe(6); // 4×1.5 = 6
+    expect(calculateMaxThrust(5)).toBe(7); // 7.5 → floor → 7
+    expect(calculateMaxThrust(6)).toBe(9);
+    expect(calculateMaxThrust(8)).toBe(12);
+  });
+
+  it('returns 0 for zero safe thrust', () => {
+    expect(calculateMaxThrust(0)).toBe(0);
+  });
+});
+
+describe('ratingFromThrust (engine rating needed for a thrust target)', () => {
+  it('multiplies safeThrust × tonnage', () => {
+    expect(ratingFromThrust(6, 50)).toBe(300);
+    expect(ratingFromThrust(4, 100)).toBe(400);
+  });
+});
+
+describe('isEngineLegalForSubType (sub-type → engine restrictions)', () => {
+  it('allows fusion engines on ASF and small craft, but not CF', () => {
+    expect(
+      isEngineLegalForSubType(
+        AerospaceEngineType.FUSION,
+        AerospaceSubType.AEROSPACE_FIGHTER,
+      ),
+    ).toBe(true);
+    expect(
+      isEngineLegalForSubType(
+        AerospaceEngineType.FUSION,
+        AerospaceSubType.SMALL_CRAFT,
+      ),
+    ).toBe(true);
+    expect(
+      isEngineLegalForSubType(
+        AerospaceEngineType.FUSION,
+        AerospaceSubType.CONVENTIONAL_FIGHTER,
+      ),
+    ).toBe(false);
+  });
+
+  it('restricts conventional fighters to ICE and fuel cell only', () => {
+    expect(
+      isEngineLegalForSubType(
+        AerospaceEngineType.ICE,
+        AerospaceSubType.CONVENTIONAL_FIGHTER,
+      ),
+    ).toBe(true);
+    expect(
+      isEngineLegalForSubType(
+        AerospaceEngineType.FUEL_CELL,
+        AerospaceSubType.CONVENTIONAL_FIGHTER,
+      ),
+    ).toBe(true);
+    expect(
+      isEngineLegalForSubType(
+        AerospaceEngineType.XL,
+        AerospaceSubType.CONVENTIONAL_FIGHTER,
+      ),
+    ).toBe(false);
+  });
+
+  it('forbids ICE on aerospace fighters', () => {
+    expect(
+      isEngineLegalForSubType(
+        AerospaceEngineType.ICE,
+        AerospaceSubType.AEROSPACE_FIGHTER,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('getMaxSafeThrust (per-subtype cap)', () => {
+  it('returns 12 for ASF and CF, 6 for small craft', () => {
+    expect(getMaxSafeThrust(AerospaceSubType.AEROSPACE_FIGHTER)).toBe(12);
+    expect(getMaxSafeThrust(AerospaceSubType.CONVENTIONAL_FIGHTER)).toBe(12);
+    expect(getMaxSafeThrust(AerospaceSubType.SMALL_CRAFT)).toBe(6);
+  });
+});

--- a/src/utils/construction/aerospace/__tests__/validationRules.test.ts
+++ b/src/utils/construction/aerospace/__tests__/validationRules.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Aerospace VAL-AERO-* validation rule invariants.
+ *
+ * Each rule is responsible for one construction constraint:
+ *   VAL-AERO-TONNAGE      tonnage range per sub-type
+ *   VAL-AERO-THRUST       engine legality + safe thrust cap
+ *   VAL-AERO-SI           SI ≤ class max
+ *   VAL-AERO-FUEL         fuel ≥ class minimum
+ *   VAL-AERO-ARC-MAX      per-arc armor ≤ arc max
+ *   VAL-AERO-CREW         small craft must allocate quarters
+ */
+
+import {
+  AerospaceArc,
+  AerospaceEngineType,
+  AerospaceSubType,
+} from '@/types/unit/AerospaceInterfaces';
+
+import {
+  AERO_VALIDATION_RULE_IDS,
+  validateAerospaceUnit,
+  validateArcArmor,
+  validateCrew,
+  validateFuel,
+  validateSI,
+  validateThrust,
+  validateTonnage,
+} from '../validationRules';
+
+describe('validateTonnage (VAL-AERO-TONNAGE)', () => {
+  it('passes for ASF in 5-100 t range', () => {
+    expect(validateTonnage(50, AerospaceSubType.AEROSPACE_FIGHTER)).toEqual([]);
+    expect(validateTonnage(5, AerospaceSubType.AEROSPACE_FIGHTER)).toEqual([]);
+    expect(validateTonnage(100, AerospaceSubType.AEROSPACE_FIGHTER)).toEqual(
+      [],
+    );
+  });
+
+  it('flags ASF tonnage outside 5-100', () => {
+    expect(validateTonnage(4, AerospaceSubType.AEROSPACE_FIGHTER)).toHaveLength(
+      1,
+    );
+    expect(
+      validateTonnage(101, AerospaceSubType.AEROSPACE_FIGHTER),
+    ).toHaveLength(1);
+  });
+
+  it('uses CF range 5-50', () => {
+    expect(validateTonnage(50, AerospaceSubType.CONVENTIONAL_FIGHTER)).toEqual(
+      [],
+    );
+    expect(
+      validateTonnage(51, AerospaceSubType.CONVENTIONAL_FIGHTER),
+    ).toHaveLength(1);
+  });
+
+  it('uses small-craft range 100-200', () => {
+    expect(validateTonnage(100, AerospaceSubType.SMALL_CRAFT)).toEqual([]);
+    expect(validateTonnage(99, AerospaceSubType.SMALL_CRAFT)).toHaveLength(1);
+    expect(validateTonnage(201, AerospaceSubType.SMALL_CRAFT)).toHaveLength(1);
+  });
+});
+
+describe('validateThrust (VAL-AERO-THRUST)', () => {
+  it('flags illegal engine type for sub-type', () => {
+    const errs = validateThrust(
+      AerospaceEngineType.FUSION,
+      6,
+      AerospaceSubType.CONVENTIONAL_FIGHTER,
+    );
+    expect(errs).toHaveLength(1);
+    expect(errs[0].ruleId).toBe('VAL-AERO-THRUST');
+  });
+
+  it('flags safeThrust above class cap', () => {
+    const errs = validateThrust(
+      AerospaceEngineType.FUSION,
+      13, // ASF cap = 12
+      AerospaceSubType.AEROSPACE_FIGHTER,
+    );
+    expect(errs).toHaveLength(1);
+  });
+
+  it('returns empty when both checks pass', () => {
+    const errs = validateThrust(
+      AerospaceEngineType.FUSION,
+      8,
+      AerospaceSubType.AEROSPACE_FIGHTER,
+    );
+    expect(errs).toEqual([]);
+  });
+});
+
+describe('validateSI (VAL-AERO-SI)', () => {
+  it('flags SI above class max', () => {
+    expect(validateSI(21, AerospaceSubType.AEROSPACE_FIGHTER)).toHaveLength(1); // max 20
+    expect(validateSI(16, AerospaceSubType.CONVENTIONAL_FIGHTER)).toHaveLength(
+      1,
+    ); // max 15
+  });
+
+  it('passes when SI is at or below max', () => {
+    expect(validateSI(20, AerospaceSubType.AEROSPACE_FIGHTER)).toEqual([]);
+    expect(validateSI(30, AerospaceSubType.SMALL_CRAFT)).toEqual([]);
+  });
+});
+
+describe('validateFuel (VAL-AERO-FUEL)', () => {
+  it('flags fuel tonnage below sub-type minimum', () => {
+    expect(validateFuel(4, AerospaceSubType.AEROSPACE_FIGHTER)).toHaveLength(1);
+    expect(validateFuel(1, AerospaceSubType.CONVENTIONAL_FIGHTER)).toHaveLength(
+      1,
+    );
+    expect(validateFuel(19, AerospaceSubType.SMALL_CRAFT)).toHaveLength(1);
+  });
+
+  it('passes at or above minimum', () => {
+    expect(validateFuel(5, AerospaceSubType.AEROSPACE_FIGHTER)).toEqual([]);
+    expect(validateFuel(20, AerospaceSubType.SMALL_CRAFT)).toEqual([]);
+  });
+});
+
+describe('validateArcArmor (VAL-AERO-ARC-MAX)', () => {
+  const subType = AerospaceSubType.AEROSPACE_FIGHTER;
+  it('passes when each arc is within its max', () => {
+    // 50 t ASF: Nose 14, Wings 10, Aft 6
+    const errs = validateArcArmor(
+      {
+        [AerospaceArc.NOSE]: 14,
+        [AerospaceArc.LEFT_WING]: 10,
+        [AerospaceArc.RIGHT_WING]: 10,
+        [AerospaceArc.AFT]: 6,
+      },
+      50,
+      subType,
+    );
+    expect(errs).toEqual([]);
+  });
+
+  it('flags arcs that exceed their max', () => {
+    const errs = validateArcArmor(
+      {
+        [AerospaceArc.NOSE]: 99, // way over
+      },
+      50,
+      subType,
+    );
+    expect(errs).toHaveLength(1);
+    expect(errs[0].ruleId).toBe('VAL-AERO-ARC-MAX');
+  });
+
+  it('ignores arcs that are not applicable to the sub-type (max=0)', () => {
+    // ASF has no LEFT_SIDE; supplying points there is silently fine
+    const errs = validateArcArmor(
+      {
+        [AerospaceArc.LEFT_SIDE]: 5,
+      },
+      50,
+      subType,
+    );
+    expect(errs).toEqual([]);
+  });
+});
+
+describe('validateCrew (VAL-AERO-CREW)', () => {
+  it('is a no-op for ASF and CF', () => {
+    expect(validateCrew(AerospaceSubType.AEROSPACE_FIGHTER, 0, 0)).toEqual([]);
+    expect(validateCrew(AerospaceSubType.CONVENTIONAL_FIGHTER, 0, 0)).toEqual(
+      [],
+    );
+  });
+
+  it('flags small craft missing quarters', () => {
+    const errs = validateCrew(AerospaceSubType.SMALL_CRAFT, 0, 3);
+    expect(errs.some((e) => /quarters/.test(e.message))).toBe(true);
+  });
+
+  it('flags small craft missing crew', () => {
+    const errs = validateCrew(AerospaceSubType.SMALL_CRAFT, 20, 0);
+    expect(errs.some((e) => /at least 1 crew/.test(e.message))).toBe(true);
+  });
+});
+
+describe('validateAerospaceUnit (full runner)', () => {
+  it('returns no errors for a legal ASF', () => {
+    const errs = validateAerospaceUnit({
+      tonnage: 50,
+      subType: AerospaceSubType.AEROSPACE_FIGHTER,
+      engineType: AerospaceEngineType.FUSION,
+      safeThrust: 6,
+      structuralIntegrity: 5,
+      fuelTons: 5,
+      arcArmor: {
+        [AerospaceArc.NOSE]: 10,
+        [AerospaceArc.LEFT_WING]: 8,
+        [AerospaceArc.RIGHT_WING]: 8,
+        [AerospaceArc.AFT]: 4,
+      },
+      quartersTons: 0,
+      crewCount: 0,
+    });
+    expect(errs).toEqual([]);
+  });
+
+  it('aggregates errors across all rules', () => {
+    const errs = validateAerospaceUnit({
+      tonnage: 1000, // VAL-AERO-TONNAGE
+      subType: AerospaceSubType.AEROSPACE_FIGHTER,
+      engineType: AerospaceEngineType.ICE, // illegal for ASF → VAL-AERO-THRUST
+      safeThrust: 99, // > cap → VAL-AERO-THRUST
+      structuralIntegrity: 99, // > class max → VAL-AERO-SI
+      fuelTons: 0, // < min → VAL-AERO-FUEL
+      arcArmor: {},
+      quartersTons: 0,
+      crewCount: 0,
+    });
+    expect(errs.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe('AERO_VALIDATION_RULE_IDS', () => {
+  it('exposes the canonical 8 rule ids', () => {
+    expect(AERO_VALIDATION_RULE_IDS).toEqual([
+      'VAL-AERO-TONNAGE',
+      'VAL-AERO-THRUST',
+      'VAL-AERO-SI',
+      'VAL-AERO-FUEL',
+      'VAL-AERO-ARC-MAX',
+      'VAL-AERO-CREW',
+      'VAL-AERO-WING-HEAVY',
+      'VAL-AERO-BOMB-BAY',
+    ]);
+  });
+});

--- a/src/utils/construction/aerospace/__tests__/weightBreakdown.test.ts
+++ b/src/utils/construction/aerospace/__tests__/weightBreakdown.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Aerospace weight-breakdown invariants.
+ *
+ * Total used = engine + extra-SI + fuel + armor + extra-heat-sinks + cockpit
+ *            + (small-craft quarters) + equipment.
+ * The first 10 heat sinks are engine-integral (free).
+ * Standard cockpit = 3 t, small = 2 t, primitive = 5 t, command-console = 6 t.
+ */
+
+import {
+  AerospaceEngineType,
+  AerospaceSubType,
+} from '@/types/unit/AerospaceInterfaces';
+
+import {
+  cockpitTons,
+  computeWeightBreakdown,
+  heatSinkExtraTons,
+} from '../weightBreakdown';
+
+describe('cockpitTons', () => {
+  it('uses 3 t for the standard cockpit (default)', () => {
+    expect(cockpitTons('Standard')).toBe(3);
+    expect(cockpitTons('UnknownCockpit')).toBe(3); // default fallback
+  });
+
+  it('matches per-type tonnage table', () => {
+    expect(cockpitTons('Small')).toBe(2);
+    expect(cockpitTons('Primitive')).toBe(5);
+    expect(cockpitTons('Command Console')).toBe(6);
+  });
+});
+
+describe('heatSinkExtraTons (engine-free baseline)', () => {
+  it('returns 0 when ≤10 heat sinks (all engine-integral)', () => {
+    expect(heatSinkExtraTons(10)).toBe(0);
+    expect(heatSinkExtraTons(5)).toBe(0);
+  });
+
+  it('charges 1 t per sink above 10', () => {
+    expect(heatSinkExtraTons(11)).toBe(1);
+    expect(heatSinkExtraTons(20)).toBe(10);
+  });
+});
+
+describe('computeWeightBreakdown', () => {
+  it('aggregates all components and computes remaining tonnage', () => {
+    const bd = computeWeightBreakdown({
+      tonnage: 50,
+      subType: AerospaceSubType.AEROSPACE_FIGHTER,
+      engineRating: 200, // table = 8.5 t fusion
+      engineType: AerospaceEngineType.FUSION,
+      structuralIntegrity: 5, // default for 50 t = 5 → no extra cost
+      fuelTons: 5,
+      armorTons: 4,
+      totalHeatSinks: 12, // 2 t extra
+      cockpitType: 'Standard', // 3 t
+      equipmentTons: 8,
+      crew: null,
+    });
+
+    expect(bd.engineTons).toBe(8.5);
+    expect(bd.siTons).toBe(0); // SI 5 = default for 50 t
+    expect(bd.fuelTons).toBe(5);
+    expect(bd.armorTons).toBe(4);
+    expect(bd.heatSinkTons).toBe(2);
+    expect(bd.cockpitTons).toBe(3);
+    expect(bd.quartersTons).toBe(0);
+    expect(bd.equipmentTons).toBe(8);
+    expect(bd.totalUsed).toBeCloseTo(8.5 + 0 + 5 + 4 + 2 + 3 + 0 + 8, 5);
+    expect(bd.remaining).toBeCloseTo(50 - bd.totalUsed, 5);
+  });
+
+  it('charges extra SI tonnage when above default', () => {
+    const bd = computeWeightBreakdown({
+      tonnage: 100,
+      subType: AerospaceSubType.AEROSPACE_FIGHTER,
+      engineRating: 300, // 17.5 t fusion
+      engineType: AerospaceEngineType.FUSION,
+      structuralIntegrity: 12, // default 10 → +2 → 2 × (100/10) × 0.5 = 10 t
+      fuelTons: 5,
+      armorTons: 0,
+      totalHeatSinks: 10,
+      cockpitType: 'Standard',
+      equipmentTons: 0,
+      crew: null,
+    });
+    expect(bd.siTons).toBe(10);
+  });
+
+  it('includes small-craft quarters tonnage', () => {
+    const bd = computeWeightBreakdown({
+      tonnage: 200,
+      subType: AerospaceSubType.SMALL_CRAFT,
+      engineRating: 300,
+      engineType: AerospaceEngineType.FUSION,
+      structuralIntegrity: 20,
+      fuelTons: 20,
+      armorTons: 5,
+      totalHeatSinks: 15,
+      cockpitType: 'Standard',
+      equipmentTons: 0,
+      crew: { crew: 4, passengers: 0, marines: 0, quartersTons: 20 },
+    });
+    expect(bd.quartersTons).toBe(20);
+    // totalUsed must include the 20-t quarters
+    expect(bd.totalUsed).toBeGreaterThanOrEqual(20);
+  });
+
+  it('produces negative remaining when over-budget', () => {
+    const bd = computeWeightBreakdown({
+      tonnage: 30,
+      subType: AerospaceSubType.AEROSPACE_FIGHTER,
+      engineRating: 200,
+      engineType: AerospaceEngineType.FUSION,
+      structuralIntegrity: 3,
+      fuelTons: 5,
+      armorTons: 5,
+      totalHeatSinks: 10,
+      cockpitType: 'Standard',
+      equipmentTons: 50, // way too much
+      crew: null,
+    });
+    expect(bd.remaining).toBeLessThan(0);
+  });
+});

--- a/src/utils/construction/aerospace/__tests__/wingHeavyWeapons.test.ts
+++ b/src/utils/construction/aerospace/__tests__/wingHeavyWeapons.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Aerospace wing heavy-weapon cap invariants.
+ *
+ * Cap rule: floor(tonnage / 10) heavy weapon tons per wing arc on ASF/CF.
+ * Heavy weapons: PPC family, all Gauss flavors, AC/20.
+ * Small craft are exempt.
+ */
+
+import {
+  AerospaceArc,
+  AerospaceSubType,
+} from '@/types/unit/AerospaceInterfaces';
+
+import {
+  canMountHeavyOnWing,
+  heavyTonsByWing,
+  isWingHeavyWeapon,
+  maxHeavyWeaponTonsPerWing,
+  validateWingHeavyWeapons,
+} from '../wingHeavyWeapons';
+
+describe('isWingHeavyWeapon', () => {
+  it('matches PPC family case-insensitively', () => {
+    expect(isWingHeavyWeapon('PPC')).toBe(true);
+    expect(isWingHeavyWeapon('isppc')).toBe(true);
+    expect(isWingHeavyWeapon('clerppc')).toBe(true);
+  });
+
+  it('matches gauss family', () => {
+    expect(isWingHeavyWeapon('gauss-rifle')).toBe(true);
+    expect(isWingHeavyWeapon('Heavy Gauss')).toBe(true);
+    expect(isWingHeavyWeapon('Light Gauss Rifle')).toBe(true);
+  });
+
+  it('matches AC/20 by id and display name', () => {
+    expect(isWingHeavyWeapon('isac20')).toBe(true);
+    expect(isWingHeavyWeapon('AC/20')).toBe(true);
+    expect(isWingHeavyWeapon('Autocannon/20')).toBe(true);
+  });
+
+  it('rejects light weapons', () => {
+    expect(isWingHeavyWeapon('medium-laser')).toBe(false);
+    expect(isWingHeavyWeapon('LRM-5')).toBe(false);
+    expect(isWingHeavyWeapon('AC/2')).toBe(false);
+    expect(isWingHeavyWeapon('AC/5')).toBe(false);
+  });
+});
+
+describe('maxHeavyWeaponTonsPerWing', () => {
+  it('returns floor(tonnage/10) for ASF and CF', () => {
+    expect(
+      maxHeavyWeaponTonsPerWing(50, AerospaceSubType.AEROSPACE_FIGHTER),
+    ).toBe(5);
+    expect(
+      maxHeavyWeaponTonsPerWing(75, AerospaceSubType.CONVENTIONAL_FIGHTER),
+    ).toBe(7);
+  });
+
+  it('returns 0 for small craft (exempt)', () => {
+    expect(maxHeavyWeaponTonsPerWing(200, AerospaceSubType.SMALL_CRAFT)).toBe(
+      0,
+    );
+  });
+});
+
+describe('heavyTonsByWing', () => {
+  it('aggregates heavy tonnage per wing arc only', () => {
+    const items = [
+      { arc: AerospaceArc.LEFT_WING, idOrName: 'PPC', tons: 7 },
+      { arc: AerospaceArc.LEFT_WING, idOrName: 'medium-laser', tons: 1 }, // not heavy
+      { arc: AerospaceArc.RIGHT_WING, idOrName: 'gauss-rifle', tons: 15 },
+      { arc: AerospaceArc.NOSE, idOrName: 'PPC', tons: 7 }, // not a wing
+    ];
+    const tons = heavyTonsByWing(items);
+    expect(tons.get(AerospaceArc.LEFT_WING)).toBe(7);
+    expect(tons.get(AerospaceArc.RIGHT_WING)).toBe(15);
+  });
+
+  it('always includes both wing entries (zeros where empty)', () => {
+    const tons = heavyTonsByWing([]);
+    expect(tons.get(AerospaceArc.LEFT_WING)).toBe(0);
+    expect(tons.get(AerospaceArc.RIGHT_WING)).toBe(0);
+  });
+});
+
+describe('canMountHeavyOnWing', () => {
+  it('allows mounting up to but not over the cap', () => {
+    // 50 t ASF cap = 5 t per wing
+    expect(
+      canMountHeavyOnWing(
+        AerospaceArc.LEFT_WING,
+        0,
+        5,
+        50,
+        AerospaceSubType.AEROSPACE_FIGHTER,
+      ),
+    ).toBe(true);
+    expect(
+      canMountHeavyOnWing(
+        AerospaceArc.LEFT_WING,
+        3,
+        3,
+        50,
+        AerospaceSubType.AEROSPACE_FIGHTER,
+      ),
+    ).toBe(false); // would be 6t > 5
+  });
+
+  it('returns true unconditionally for non-wing arcs', () => {
+    expect(
+      canMountHeavyOnWing(
+        AerospaceArc.NOSE,
+        100,
+        100,
+        50,
+        AerospaceSubType.AEROSPACE_FIGHTER,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('validateWingHeavyWeapons (VAL-AERO-WING-HEAVY)', () => {
+  it('returns no errors when small craft mount heavy weapons (rule does not apply)', () => {
+    const errs = validateWingHeavyWeapons(
+      [
+        {
+          arc: AerospaceArc.LEFT_WING,
+          idOrName: 'gauss-rifle',
+          tons: 15,
+        },
+      ],
+      200,
+      AerospaceSubType.SMALL_CRAFT,
+    );
+    expect(errs).toEqual([]);
+  });
+
+  it('flags an over-cap wing on an ASF', () => {
+    const errs = validateWingHeavyWeapons(
+      [{ arc: AerospaceArc.LEFT_WING, idOrName: 'gauss-rifle', tons: 15 }],
+      50, // cap = 5 t
+      AerospaceSubType.AEROSPACE_FIGHTER,
+    );
+    expect(errs).toHaveLength(1);
+    expect(errs[0].ruleId).toBe('VAL-AERO-WING-HEAVY');
+  });
+
+  it('returns no errors when both wings are within the cap', () => {
+    const errs = validateWingHeavyWeapons(
+      [
+        { arc: AerospaceArc.LEFT_WING, idOrName: 'PPC', tons: 7 },
+        { arc: AerospaceArc.RIGHT_WING, idOrName: 'PPC', tons: 7 },
+      ],
+      80, // cap = 8 t
+      AerospaceSubType.AEROSPACE_FIGHTER,
+    );
+    expect(errs).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes ~25 of the highest-value untested files in `src/utils/construction/` with **~110 new tests** structured as **invariant assertions from rules text**, not internal call shape. Targets the load-bearing math files for BV parity.

This is **PR-C1** of the test coverage wave. Runs in parallel with #420, #421, #423, #424, #425 (cleanup PRs) and the now-merged #426 (cryptodice flake).

## What's tested (file-by-file)

### Core BV calculation modules (`src/utils/construction/__tests__/`)
- [x] `battleValueMovement.test.ts` — TMM run/jump bucket table; defensive speed factor SPEED_FACTORS lookup; offensive BV-2.0 formula `sf = round(pow(1+(mp-5)/10, 1.2)×100)/100` with mp = runMP + round(max(jump,umu)/2); 2-dp rounding pin
- [x] `battleValueDefensive.test.ts` — armor/structure/gyro multipliers (hardened ×2, industrial ×0.5, IS XL 0.5, Clan XL 0.75); stealth/null-sig/chameleon/void-sig TMM bonuses; Blue Shield +0.2 to both; UMU MP TMM contribution; superheavy engine table (>100t)
- [x] `battleValueOffensive.test.ts` — weapon modifier chain (rear ×0.5, AES ×1.25, Artemis IV ×1.2, TC direct-fire ×1.25); heat efficiency tracking + halve-past-cap; engine running heat (XXL=6, ICE=0); TSM/iTSM weight bonus; 0.9× IndustrialMech type modifier; ammo excessive cap
- [x] `battleValueExplosivePenalties.test.ts` — 15 BV/slot standard, 1 BV/slot gauss, HVAC=1-effective-slot; CASE protects only when sideTorsoSlots<3; CASE-II always protects; biped arm→torso transfer; quad NO transfer (arms are legs)
- [x] `battleValueTotals.test.ts` — cockpit modifier table (small/torso/dronOS=0.95, interface=1.3); composite int rounding; defensive/offensive split via `getBVBreakdown`

### Aerospace construction (`src/utils/construction/aerospace/__tests__/`)
- [x] `siCalculations.test.ts` — default SI=ceil(t/10), per-class max (ASF 20/CF 15/SC 30), extra-only weight cost
- [x] `fuelCalculations.test.ts` — per-subtype minima (5/2/20), per-engine pts/ton (Fusion 80, ICE 40, FuelCell 60), floor on points, FUEL_BURN_PER_THRUST_POINT=1
- [x] `thrustCalculations.test.ts` — safe = floor(rating/t) clamped to subtype cap; max = floor(safe×1.5); CF restricted to ICE/FuelCell engines
- [x] `armorArcCalculations.test.ts` — per-arc factors (Nose 0.28, Wings/Sides 0.20, Aft 0.12); ASF/CF wings vs SC sides; sum = max total armor
- [x] `equipmentSlots.test.ts` — caps (nose/wings/sides=6, aft=4, fuselage=unlimited)
- [x] `engineWeightAerospace.test.ts` — TechManual baseline + per-type multipliers (XL 0.5, ICE 2.0, CompactFusion 1.5, FuelCell 1.2), half-ton ceil
- [x] `crewCalculations.test.ts` — 5 t/crew, 3 t/passenger or marine; tonnage→min-crew brackets (3/4/6)
- [x] `bombBays.test.ts` — per-bay = capacity + 1 t structure, aggregate cap = floor(t/2), SC-only validation
- [x] `wingHeavyWeapons.test.ts` — heavy classifier (PPC/gauss/AC20), per-wing cap = floor(t/10), small craft exempt
- [x] `weightBreakdown.test.ts` — full aggregation, free-10 heat sinks, cockpit table, SC quarters
- [x] `validationRules.test.ts` — all 8 VAL-AERO-* rules + full runner (TONNAGE/THRUST/SI/FUEL/ARC-MAX/CREW/WING-HEAVY/BOMB-BAY)

### Component calculations (`src/utils/construction/__tests__/`)
- [x] `engineCalculations.test.ts` — TechManual weight table; multiples-of-5 validation; walk MP = floor(rating/tonnage); integral HS = floor(rating/25); side-torso slot table (IS XL 3, Clan XL 2, Compact 0)
- [x] `gyroCalculations.test.ts` — base = ceil(rating/100), per-type multipliers, slot table (Std 4, XL 6, Compact 2, HD 4)
- [x] `heatSinkCalculations.test.ts` — first 10 free, single 1pt / double 2pt dissipation, fusion-only integrals, Double-IS uses 3 slots, Double-Clan uses 2
- [x] `armorCalculations.test.ts` — pts/ton tables (Std 16, FF-IS 17.92, FF-Clan 19.2), head cap = 9, 2× IS max, symmetric biped/quad allocation, 25% rear ratio
- [x] `costCalculations.test.ts` — engine = rating² × 5000 × mult; gyro = ceil(rating/100) × 300k × mult; full breakdown sum invariant

### Equipment + tech base (`src/utils/construction/__tests__/`)
- [x] `equipmentBVResolver.test.ts` — catalog lookups, MegaMek ID normalization (isac10→ac-10, smalllaser→small-laser), Ultra AC ×2 / Rotary AC ×6 / Streak ×0.5 BV-context heat overrides, ammo weaponType derivation
- [x] `techBaseValidation.test.ts` — IS-on-Clan inferior-tech rule, mixed-tech bypass, cross-base rejection, highest-rules-level escalation, getAvailable* filtering

## Test count summary

| Suite | Tests | Suites |
|---|---|---|
| New tests added | ~110 | 23 files |
| Total construction tests post-PR | **502** | 29 |
| Construction tests pre-PR | 392 | 6 |

## Coverage delta

Coverage was already above the previous floors. This PR makes existing high coverage **enforced** rather than incidental.

| Metric | Before (45/35/40/45) | After (PR + ratchet 55/45/50/55) |
|---|---|---|
| Statements | 67.43% (above floor by +22%) | 67.42% (above new floor by +12%) |
| Branches | 58.23% | 58.21% |
| Functions | 60.37% | 60.36% |
| Lines | 69.48% | 69.46% |

**Construction directory specifically**: 46.64% statements, 41.25% branches, 48.61% functions, 47.39% lines (1556 lines covered of 3283).

## Threshold ratchet

`jest.config.js` global threshold raised:
- statements: **45 → 55**
- branches: **35 → 45**
- functions: **40 → 50**
- lines: **45 → 55**

New thresholds sit ~12 points below the actual baseline so they catch regressions without flapping on small refactors.

## BV parity attestation

Ran `npm run validate:bv` before and after the new tests:

| Metric | Before | After |
|---|---|---|
| Validated units | 3454 | 3454 |
| Calculated | 3454 | 3454 |
| Exact match | 3199 | **3199** |
| Within 1% | 3395 (98.3%) | **3395 (98.3%)** |
| Within 2% | 3433 (99.4%) | **3433 (99.4%)** |
| Within 3% | 3445 (99.7%) | **3445 (99.7%)** |
| Over 3% | 9 | 9 |

**No parity regression. Byte-identical results.**

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` — zero errors
- [x] `npm run lint` — 0 errors, 31 pre-existing warnings (LOC limits in unrelated files)
- [x] `npx jest src/utils/construction/` — 502 / 502 pass (29 suites)
- [x] `npx jest --coverage` (full repo) — 22477 / 22477 pass, threshold check green
- [x] `npm run validate:bv` — parity unchanged