### PR TITLE
chore(test+build): unflake balance + cryptodice tests, fix lint-staged yaml glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
       "oxlint --fix",
       "oxfmt --write"
     ],
-    "*.{json,md,yml,yaml,css}": [
+    "*.{json,md,css}": [
       "oxfmt --write"
     ]
   }

--- a/src/lib/multiplayer/server/__tests__/CryptoDiceRoller.test.ts
+++ b/src/lib/multiplayer/server/__tests__/CryptoDiceRoller.test.ts
@@ -4,9 +4,11 @@
  * Two assertions matter:
  *   1. Range: every roll lands in [1, 6]. Anything else means the
  *      rejection-sampling cutoff is wrong.
- *   2. Distribution: across 100k rolls, each face is within ~1% of the
- *      expected 1/6 frequency. The rejection-sampling path eliminates
- *      modulo bias so the tolerance can stay tight.
+ *   2. Distribution: across 100k rolls, each face is within 3% of the
+ *      expected 1/6 frequency (~4.2σ). The rejection-sampling path
+ *      eliminates modulo bias; the 3% tolerance is wide enough to be
+ *      effectively flake-free in CI while still catching a broken
+ *      sampler (which would skew at least one face by 16%+).
  *
  * @spec openspec/changes/add-authoritative-roll-arbitration/specs/multiplayer-server/spec.md
  */
@@ -24,8 +26,11 @@ describe('CryptoDiceRoller', () => {
     }
   });
 
-  // FLAKY: 2% tolerance is ~2.8σ — fires once every few hundred CI runs in practice. Sibling to balance.test.ts flake (PR #421). Unskip after raising tolerance to 3σ or pinning seed.
-  it.skip('100k rolls show uniform distribution within 2% of expected', () => {
+  // De-flaked 2026-04-25: tolerance widened from 2% (~2.8σ) to 3% (~4.2σ)
+  // per face. The original tolerance fired once every few hundred CI runs.
+  // 3% still detects a broken rejection-sampling path (which would skew at
+  // least one face by 16%+) but pushes the flake rate to effectively zero.
+  it('100k rolls show uniform distribution within 3% of expected', () => {
     const roller = new CryptoDiceRoller();
     const SAMPLES = 100_000;
     const counts = [0, 0, 0, 0, 0, 0];
@@ -33,12 +38,12 @@ describe('CryptoDiceRoller', () => {
       counts[roller.d6() - 1] += 1;
     }
     const expected = SAMPLES / 6;
-    // 2% tolerance per face. Multinomial std dev for one face at this
-    // sample size is sqrt(N * p * (1-p)) ≈ 117.85, so 2% (≈333) is
-    // ~2.8 standard deviations — flake-resistant under CI noise but
-    // still tight enough to catch a broken rejection-sampling path
-    // (which would skew at least one face by 16%+).
-    const tolerance = expected * 0.02;
+    // 3% tolerance per face. Multinomial std dev for one face at this
+    // sample size is sqrt(N * p * (1-p)) ≈ 117.85, so 3% (≈500) is
+    // ~4.2 standard deviations — effectively zero false-positive rate
+    // under CI noise while still tight enough to catch a broken
+    // rejection-sampling path (which would skew at least one face by 16%+).
+    const tolerance = expected * 0.03;
     for (let face = 0; face < 6; face += 1) {
       expect(Math.abs(counts[face] - expected)).toBeLessThan(tolerance);
     }

--- a/src/services/generators/__tests__/balance.test.ts
+++ b/src/services/generators/__tests__/balance.test.ts
@@ -109,8 +109,11 @@ describe('Balance Testing', () => {
   describe('Difficulty Scaling', () => {
     const difficulties = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0];
 
-    // FLAKY: seeded-random tolerance window edge case. See MEMORY.md "Husky Pre-Commit Gotchas" / handoff. Unskip after balance generator is reworked.
-    it.skip('should scale OpFor BV proportionally with difficulty', () => {
+    // De-flaked 2026-04-25: pin a seeded RNG per difficulty step so the
+    // `hardBV > easyBV` and `extremeBV > normalBV * 0.8` comparisons are
+    // deterministic. Previously this used Math.random and tripped the
+    // tolerance window in ~1/few-hundred CI runs.
+    it('should scale OpFor BV proportionally with difficulty', () => {
       const playerBV = 10000;
       const results: { difficulty: number; bv: number }[] = [];
 
@@ -123,7 +126,14 @@ describe('Balance Testing', () => {
           ),
           difficultyMultiplier: difficulty,
         };
-        const result = opForGenerator.generate(config);
+        // Use a fixed seed per-step for deterministic comparison across
+        // difficulty levels. Same seed each step removes Math.random jitter
+        // that caused the original flake while preserving the relative
+        // ordering produced by the difficultyMultiplier scaling.
+        const seededRandom = new SeededRandom(42);
+        const result = opForGenerator.generate(config, () =>
+          seededRandom.next(),
+        );
         results.push({ difficulty, bv: result.totalBV });
       }
 


### PR DESCRIPTION
## Summary

Sub-PR for the **wave-cleanup-followups** integration branch (Wrap-C scope). Two real fixes for previously-quarantined flaky tests + one lint-staged config fix discovered during PR #429.

### Part 1 — Unflake balance.test difficulty scaling
- File: `src/services/generators/__tests__/balance.test.ts`
- Test: `should scale OpFor BV proportionally with difficulty` (was `it.skip` from PR #421).
- **Root cause**: test used `Math.random` indirectly via `OpForGeneratorService.generate(config)` (no `randomFn` arg). Across 6 difficulty steps the random unit selection occasionally produced `hardBV <= easyBV` or `extremeBV < normalBV * 0.8`.
- **Fix**: pin a fresh `SeededRandom(42)` per difficulty step — same pattern already used by sibling tests in this file (`OpFor BV Accuracy`, `Force Composition`).
- **20-run pass rate**: 30/30 when running the de-flaked test in isolation (`npx jest -t '...should scale OpFor BV...'`).

### Part 2 — Unflake CryptoDiceRoller distribution test
- File: `src/lib/multiplayer/server/__tests__/CryptoDiceRoller.test.ts`
- Test: `100k rolls show uniform distribution within 2% of expected` (was `it.skip` from PR #426).
- **Before**: 2% tolerance per face (~2.8σ).
- **After**: 3% tolerance per face (~4.2σ). Test name + inline math comment + file-level docstring updated.
- **Why this is still a real test**: a broken rejection-sampling path (e.g. naive 32-bit mod 6 with default cutoff) skews at least one face by 16%+, far beyond 3%. Per-run flake rate is now ~6 × 3e-5 ≈ 1.8e-4 (one false positive every ~5500 runs).
- **20-run pass rate**: 20/20 locally.

### Part 3 — Fix lint-staged YAML glob bug
- File: `package.json` (lint-staged section only)
- **Root cause**: oxfmt 0.28 doesn't actually format YAML. When YAML was the only staged file kind, oxfmt errored with "Expected at least one target file" and rejected the commit. Surfaced during PR #429.
- **Fix**: `*.{json,md,yml,yaml,css}` → `*.{json,md,css}` (drop yml/yaml from the glob entirely). YAML files now skip lint-staged formatting; commits succeed gracefully.
- **Smoke test**: a YAML-only `git commit` on `.github/workflows/pr-checks.yml` succeeded with `lint-staged could not find any staged files matching configured tasks` (graceful skip), then reverted via `git reset --hard HEAD~1`.
- Note: oxfmt 0.28-specific. If oxfmt adds YAML support later, this glob can be restored.

## Test plan
- [x] `npx jest src/services/generators/__tests__/balance.test.ts -t 'should scale OpFor BV proportionally with difficulty'` — 30/30 pass
- [x] `npx jest src/lib/multiplayer/server/__tests__/CryptoDiceRoller.test.ts` — 20/20 pass
- [x] YAML-only commit smoke test passes (verified locally, reverted)
- [x] `npx tsc --noEmit --skipLibCheck` — clean
- [x] `npm run lint` — 0 errors (32 pre-existing warnings)
- [x] Build passes via husky pre-commit hook (verified twice via Part 1 and Part 2 commits)

## Notes for reviewer

The full balance.test.ts suite has a *separate* pre-existing flake at line 105 (`expect(maxDeviation).toBeLessThan(0.3)` in 'should consistently hit BV targets') — observed 1/30 failure during full-suite runs (Received: 0.3997). That assertion is **not** part of this PR's scope (sibling Wrap-A or Wrap-B may pick it up; otherwise it can be quarantined with another `it.skip` if it becomes a CI problem).