### PR TITLE
chore(wave-cleanup): close 6 deferred cycles

### DIFF
--- a/src/components/award/awardIconComponents.tsx
+++ b/src/components/award/awardIconComponents.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import type { IconProps } from './awardIcons';
+import type { IconProps } from './awardIcons.types';
 
 type IconComponent = React.FC<IconProps>;
 

--- a/src/components/award/awardIcons.tsx
+++ b/src/components/award/awardIcons.tsx
@@ -11,6 +11,8 @@ import React from 'react';
 
 import { AwardCategory, AwardRarity } from '@/types/award/AwardInterfaces';
 
+import type { IconProps } from './awardIcons.types';
+
 import {
   SwordsIcon,
   TargetIcon,
@@ -55,11 +57,7 @@ export {
 // Types
 // =============================================================================
 
-export interface IconProps {
-  className?: string;
-  size?: number;
-  strokeWidth?: number;
-}
+export type { IconProps } from './awardIcons.types';
 
 type IconComponent = React.FC<IconProps>;
 

--- a/src/components/award/awardIcons.types.ts
+++ b/src/components/award/awardIcons.types.ts
@@ -1,0 +1,10 @@
+/**
+ * Award icon shared types — leaf module to break circular dependency
+ * between awardIcons.tsx and awardIconComponents.tsx.
+ */
+
+export interface IconProps {
+  className?: string;
+  size?: number;
+  strokeWidth?: number;
+}

--- a/src/components/campaign/ContextPanel.tsx
+++ b/src/components/campaign/ContextPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { ContextPanelMode, type ContextPanelProps } from './ContextPanel.types';
 import {
   EmptyPanel,
   SystemDetailsPanel,
@@ -8,53 +9,16 @@ import {
   PilotStatusPanel,
 } from './ContextPanelTabs';
 
-export enum ContextPanelMode {
-  Empty = 'empty',
-  SystemDetails = 'system',
-  ContractDetails = 'contract',
-  MechStatus = 'mech',
-  PilotStatus = 'pilot',
-}
-
-export interface SystemData {
-  name: string;
-  faction: string;
-  population?: number;
-  industrialRating?: string;
-}
-
-export interface ContractData {
-  name: string;
-  employer: string;
-  payment: number;
-  deadline: string;
-  type: string;
-}
-
-export interface MechData {
-  name: string;
-  variant: string;
-  tonnage: number;
-  armorPercent: number;
-  status: string;
-}
-
-export interface PilotData {
-  name: string;
-  callsign: string;
-  gunnery: number;
-  piloting: number;
-  wounds: number;
-}
-
-export interface ContextPanelProps {
-  mode: ContextPanelMode;
-  systemData?: SystemData;
-  contractData?: ContractData;
-  mechData?: MechData;
-  pilotData?: PilotData;
-  className?: string;
-}
+// Re-export leaf types so existing consumers (e.g. stories, tabs file)
+// keep their `from './ContextPanel'` import paths working.
+export { ContextPanelMode } from './ContextPanel.types';
+export type {
+  SystemData,
+  ContractData,
+  MechData,
+  PilotData,
+  ContextPanelProps,
+} from './ContextPanel.types';
 
 export function ContextPanel({
   mode,

--- a/src/components/campaign/ContextPanel.types.ts
+++ b/src/components/campaign/ContextPanel.types.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared types for ContextPanel — leaf module to break circular dependency
+ * between ContextPanel.tsx and ContextPanelTabs.tsx.
+ */
+
+export enum ContextPanelMode {
+  Empty = 'empty',
+  SystemDetails = 'system',
+  ContractDetails = 'contract',
+  MechStatus = 'mech',
+  PilotStatus = 'pilot',
+}
+
+export interface SystemData {
+  name: string;
+  faction: string;
+  population?: number;
+  industrialRating?: string;
+}
+
+export interface ContractData {
+  name: string;
+  employer: string;
+  payment: number;
+  deadline: string;
+  type: string;
+}
+
+export interface MechData {
+  name: string;
+  variant: string;
+  tonnage: number;
+  armorPercent: number;
+  status: string;
+}
+
+export interface PilotData {
+  name: string;
+  callsign: string;
+  gunnery: number;
+  piloting: number;
+  wounds: number;
+}
+
+export interface ContextPanelProps {
+  mode: ContextPanelMode;
+  systemData?: SystemData;
+  contractData?: ContractData;
+  mechData?: MechData;
+  pilotData?: PilotData;
+  className?: string;
+}

--- a/src/components/campaign/ContextPanelTabs.tsx
+++ b/src/components/campaign/ContextPanelTabs.tsx
@@ -5,7 +5,7 @@ import type {
   ContractData,
   MechData,
   PilotData,
-} from './ContextPanel';
+} from './ContextPanel.types';
 
 import {
   formatPopulation,

--- a/src/components/gameplay/pages/repair/bay/RepairBayPage.RepairWorkspace.tsx
+++ b/src/components/gameplay/pages/repair/bay/RepairBayPage.RepairWorkspace.tsx
@@ -6,7 +6,7 @@ import {
 } from '@/components/repair';
 import { Card } from '@/components/ui';
 
-import { UnitRepairCard } from './RepairBayPage.sections';
+import { UnitRepairCard } from './RepairBayPage.UnitRepairCard';
 
 interface RepairWorkspaceProps {
   filteredJobs: IRepairJob[];

--- a/src/components/unit-card/UnitCardExpanded.tsx
+++ b/src/components/unit-card/UnitCardExpanded.tsx
@@ -9,6 +9,12 @@ import React from 'react';
 import { getHeatDisplay } from '@/utils/heatCalculation';
 import { getTechBaseDisplay } from '@/utils/techBase';
 
+import type {
+  EquipmentEntry,
+  CriticalSlotSummary,
+  UnitCardExpandedProps,
+} from './UnitCardExpanded.types';
+
 import { Badge } from '../ui/Badge';
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
@@ -17,38 +23,14 @@ import {
   EquipmentList,
   CriticalSlotsSummary,
 } from './UnitCardExpandedSections';
-import { UnitCardStandardProps } from './UnitCardStandard';
 
-export interface EquipmentEntry {
-  name: string;
-  category: string;
-  weight: number;
-  slots: number;
-  location?: string;
-  count: number;
-}
-
-export interface CriticalSlotSummary {
-  location: string;
-  totalSlots: number;
-  usedSlots: number;
-  freeSlots: number;
-}
-
-export interface UnitCardExpandedProps extends UnitCardStandardProps {
-  // Additional equipment (non-weapon)
-  equipment: EquipmentEntry[];
-
-  // Critical slots per location
-  criticalSlots: CriticalSlotSummary[];
-
-  // Quirks
-  quirks: string[];
-
-  // Fluff
-  notes?: string;
-  overview?: string;
-}
+// Re-export leaf types so existing consumers keep their
+// `from './UnitCardExpanded'` import paths working (e.g. unit-card/index.ts).
+export type {
+  EquipmentEntry,
+  CriticalSlotSummary,
+  UnitCardExpandedProps,
+} from './UnitCardExpanded.types';
 
 /**
  * Expanded unit card with full equipment and fluff details

--- a/src/components/unit-card/UnitCardExpanded.types.ts
+++ b/src/components/unit-card/UnitCardExpanded.types.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared types for UnitCardExpanded — leaf module to break circular dependency
+ * between UnitCardExpanded.tsx and UnitCardExpandedSections.tsx.
+ */
+
+import type { UnitCardStandardProps } from './UnitCardStandard';
+
+export interface EquipmentEntry {
+  name: string;
+  category: string;
+  weight: number;
+  slots: number;
+  location?: string;
+  count: number;
+}
+
+export interface CriticalSlotSummary {
+  location: string;
+  totalSlots: number;
+  usedSlots: number;
+  freeSlots: number;
+}
+
+export interface UnitCardExpandedProps extends UnitCardStandardProps {
+  // Additional equipment (non-weapon)
+  equipment: EquipmentEntry[];
+
+  // Critical slots per location
+  criticalSlots: CriticalSlotSummary[];
+
+  // Quirks
+  quirks: string[];
+
+  // Fluff
+  notes?: string;
+  overview?: string;
+}

--- a/src/components/unit-card/UnitCardExpandedSections.tsx
+++ b/src/components/unit-card/UnitCardExpandedSections.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
-import type { EquipmentEntry, CriticalSlotSummary } from './UnitCardExpanded';
+import type {
+  EquipmentEntry,
+  CriticalSlotSummary,
+} from './UnitCardExpanded.types';
 
 import { Badge } from '../ui/Badge';
 

--- a/src/services/conversion/BlkExportServiceCore.exporters.ts
+++ b/src/services/conversion/BlkExportServiceCore.exporters.ts
@@ -7,7 +7,8 @@ import type { VehicleState } from '@/stores/vehicleState';
 import { UnitType } from '@/types/unit/BattleMechInterfaces';
 import { InfantryArmorKit } from '@/types/unit/PersonnelInterfaces';
 
-import { IBlkExportResult } from './BlkExportServiceCore';
+import type { IBlkExportResult } from './BlkExportServiceCore.types';
+
 import {
   formatMotionType,
   formatBAMotionType,

--- a/src/services/conversion/BlkExportServiceCore.ts
+++ b/src/services/conversion/BlkExportServiceCore.ts
@@ -20,6 +20,11 @@ import {
 } from '@/services/core/createSingleton';
 import { UnitType } from '@/types/unit/BattleMechInterfaces';
 
+import type {
+  ExportableUnitState,
+  IBlkExportResult,
+} from './BlkExportServiceCore.types';
+
 import {
   exportVehicle,
   exportAerospace,
@@ -28,24 +33,12 @@ import {
   exportProtoMech,
 } from './BlkExportServiceCore.exporters';
 
-/**
- * Result of exporting to BLK format
- */
-export interface IBlkExportResult {
-  readonly success: boolean;
-  readonly content?: string;
-  readonly errors: string[];
-}
-
-/**
- * Union type for all exportable unit states
- */
-export type ExportableUnitState =
-  | VehicleState
-  | AerospaceState
-  | BattleArmorState
-  | InfantryState
-  | ProtoMechState;
+// Re-export leaf types so existing consumers (BlkExportService.ts shim,
+// exporters.ts file, and downstream importers) keep working unchanged.
+export type {
+  ExportableUnitState,
+  IBlkExportResult,
+} from './BlkExportServiceCore.types';
 
 /**
  * BLK Export Service

--- a/src/services/conversion/BlkExportServiceCore.types.ts
+++ b/src/services/conversion/BlkExportServiceCore.types.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared types for BlkExportService — leaf module to break circular dependency
+ * between BlkExportServiceCore.ts and BlkExportServiceCore.exporters.ts.
+ */
+
+import type { AerospaceState } from '@/stores/aerospaceState';
+import type { BattleArmorState } from '@/stores/battleArmorState';
+import type { InfantryState } from '@/stores/infantryState';
+import type { ProtoMechState } from '@/stores/protoMechState';
+import type { VehicleState } from '@/stores/vehicleState';
+
+/**
+ * Result of exporting to BLK format
+ */
+export interface IBlkExportResult {
+  readonly success: boolean;
+  readonly content?: string;
+  readonly errors: string[];
+}
+
+/**
+ * Union type for all exportable unit states
+ */
+export type ExportableUnitState =
+  | VehicleState
+  | AerospaceState
+  | BattleArmorState
+  | InfantryState
+  | ProtoMechState;

--- a/src/utils/construction/aerospace/bombBays.ts
+++ b/src/utils/construction/aerospace/bombBays.ts
@@ -27,7 +27,7 @@
  * Requirement: Equipment Mounting per Arc
  */
 
-import type { AerospaceValidationError } from './validationRules';
+import type { AerospaceValidationError } from './validationRules.types';
 
 import { AerospaceSubType } from '../../../types/unit/AerospaceInterfaces';
 

--- a/src/utils/construction/aerospace/validationRules.ts
+++ b/src/utils/construction/aerospace/validationRules.ts
@@ -18,6 +18,10 @@
  * Requirement: Aerospace Construction Validation Rules
  */
 
+// AerospaceValidationError lives in `./validationRules.types` to break the
+// 3-way cycle with bombBays.ts and wingHeavyWeapons.ts. Re-exported below.
+import type { AerospaceValidationError } from './validationRules.types';
+
 import {
   AerospaceArc,
   AerospaceEngineType,
@@ -31,22 +35,14 @@ import {
   getMaxSafeThrust,
   isEngineLegalForSubType,
 } from './thrustCalculations';
+// ============================================================================
+// Validation Error Shape
+// ============================================================================
 import {
   validateWingHeavyWeapons,
   type WingMountInput,
 } from './wingHeavyWeapons';
-
-// ============================================================================
-// Validation Error Shape
-// ============================================================================
-
-/** A single construction validation failure. */
-export interface AerospaceValidationError {
-  /** Stable rule identifier, e.g. "VAL-AERO-TONNAGE" */
-  readonly ruleId: string;
-  /** Human-readable description of the violation */
-  readonly message: string;
-}
+export type { AerospaceValidationError };
 
 // ============================================================================
 // Tonnage Range Table

--- a/src/utils/construction/aerospace/validationRules.types.ts
+++ b/src/utils/construction/aerospace/validationRules.types.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared types for aerospace validation rules — leaf module to break the
+ * 3-way circular dependency between validationRules.ts, bombBays.ts, and
+ * wingHeavyWeapons.ts.
+ *
+ * @spec openspec/changes/add-aerospace-construction/specs/aerospace-unit-system/spec.md
+ */
+
+/** A single construction validation failure. */
+export interface AerospaceValidationError {
+  /** Stable rule identifier, e.g. "VAL-AERO-TONNAGE" */
+  readonly ruleId: string;
+  /** Human-readable description of the violation */
+  readonly message: string;
+}

--- a/src/utils/construction/aerospace/wingHeavyWeapons.ts
+++ b/src/utils/construction/aerospace/wingHeavyWeapons.ts
@@ -23,7 +23,7 @@
  * Requirement: Equipment Mounting per Arc
  */
 
-import type { AerospaceValidationError } from './validationRules';
+import type { AerospaceValidationError } from './validationRules.types';
 
 import {
   AerospaceArc,


### PR DESCRIPTION
## Summary

Closes the 6 Pattern 4 cycles that were deferred during the parallel cleanup wave. All via the `*.types.ts` leaf extraction pattern proven in PRs #419, #420, #422, #425.

**Repo-wide cycle count: 21 → 0** (all closed across the wave).

## Cycles closed

1. `components/award/awardIcons.tsx` ↔ `awardIconComponents.tsx`
2. `components/campaign/ContextPanel.tsx` ↔ `ContextPanelTabs.tsx`
3. `components/gameplay/pages/repair/bay/RepairBayPage.RepairWorkspace.tsx` ↔ `.sections.tsx`
4. `components/unit-card/UnitCardExpanded.tsx` ↔ `UnitCardExpandedSections.tsx`
5. `services/conversion/BlkExportServiceCore.ts` ↔ `.exporters.ts` (extracted `IBlkExportResult` + `ExportableUnitState` to `.types.ts`)
6. `utils/construction/aerospace/{validationRules, bombBays, wingHeavyWeapons}.ts` 3-way (extracted `AerospaceValidationError` to `validationRules.types.ts`)

## What deferred

The Tier 1 conversion-service tests (`MTFParserService`, `BlkParserService`, `ParityValidationService`) were originally scoped here but the agent budget was consumed by the cycle work. **These will be tracked as a follow-up** — the schema-bridge corpus validation already provides regression coverage at the data boundary.

## Verification

- `npx madge --circular --extensions ts,tsx src/` → **0 cycles** repo-wide
- `npx tsc --noEmit` clean
- `npx jest src/services/conversion src/utils/construction/aerospace` → 25 suites, 860/860 pass

## Commits

- `cc5f5f1c` chore(deps): break award + campaign-context-panel cycles
- `c795b6c4` chore(deps): break repair-bay + unit-card-expanded cycles
- `c241c83e` chore(deps): break BlkExportServiceCore <-> exporters cycle
- `dd5bbaaf` chore(deps): break aerospace validationRules 3-way cycle