### PR TITLE
feat(schema-bridge): finalize follow-ups + migrate type casts to contract adapters

### DIFF
--- a/scripts/megameklab-conversion/README.md
+++ b/scripts/megameklab-conversion/README.md
@@ -48,10 +48,11 @@ cross-language schema bridge introduced by PR-A1:
   `run_schema_validation_only.py`.
 
 - `blk_common.py` — adds `write_weapon_json` / `write_unit_json` /
-  `write_equipment_json` choke points. Validation runs only when
-  `MEKSTATION_VALIDATE_WRITES=1` is set in the environment. PR-A1
-  ships this opt-in; PR-A2 will flip it on by default once corpus
-  drift is patched.
+  `write_equipment_json` choke points. Validation is **enabled by
+  default**: every write checks the JSON Schema and raises `ValueError`
+  on drift. Set `MEKSTATION_VALIDATE_WRITES=0` (or `false`/`no`/`off`)
+  to disable for legacy data-regeneration runs that need to tolerate
+  pre-bridge drift.
 
 - `run_schema_validation_only.py` — corpus harness used by the
   `schema-bridge` CI job. Walks
@@ -88,18 +89,29 @@ print(validate_weapon({'id': 'x'}))
 "
 ```
 
-### Opt-in write-time validation
+### Write-time validation (default ON)
 
-Run any BLK / equipment writer with `MEKSTATION_VALIDATE_WRITES=1` to
-have `blk_common.write_*_json` raise `ValueError` on any drift before
-serialising:
+`blk_common.write_*_json` validates by default — every write through
+the helpers raises `ValueError` on drift before serialising. Normal
+conversion runs need no env flag:
 
 ```bash
-MEKSTATION_VALIDATE_WRITES=1 npm run convert:blk
+npm run convert:blk
 ```
 
-PR-A1 makes this opt-in so existing converter runs are not perturbed;
-PR-A2 flips the default on after corpus conformance is fixed.
+The historical opt-out is still available for legacy data-regeneration
+runs that need to bypass the gate (e.g. importing a known-bad corpus
+for diff inspection):
+
+```bash
+MEKSTATION_VALIDATE_WRITES=0 npm run convert:blk
+```
+
+Accepted disable values: `0`, `false`, `no`, `off` (case-insensitive).
+Anything else — including unset, empty, `1`, `true`, `yes`, `on` — keeps
+validation enabled. The default flipped after PR #429 verified the
+entire 5-shape corpus rounds-trip clean and the `--strict` CI gate
+turned green.
 
 ### Source of truth
 

--- a/scripts/megameklab-conversion/blk_common.py
+++ b/scripts/megameklab-conversion/blk_common.py
@@ -295,27 +295,46 @@ def write_run_log(
 # ---------------------------------------------------------------------------
 # Every Python writer that produces JSON consumed by the TypeScript
 # runtime should funnel through these helpers. They are guarded by the
-# ``MEKSTATION_VALIDATE_WRITES`` env var so PR-A1 can land without
-# perturbing existing conversion runs:
+# ``MEKSTATION_VALIDATE_WRITES`` env var:
 #
-#   * unset / "0"  -> no validation, behaves like ``json.dump``.
-#   * "1"          -> validate against the canonical JSON Schema before
-#                     writing. A non-empty error list raises ``ValueError``,
-#                     which existing run-log error counters can catch.
+#   * unset / "1" / "true" / "yes" / "on"  -> validation ENABLED (default).
+#                                              Validates against the canonical
+#                                              JSON Schema before writing. A
+#                                              non-empty error list raises
+#                                              ``ValueError`` so existing
+#                                              run-log error counters catch it.
+#   * "0" / "false" / "no" / "off"          -> validation DISABLED. Writer
+#                                              behaves like a plain
+#                                              ``json.dump``. Use only as an
+#                                              escape hatch for legacy data
+#                                              regeneration runs that need to
+#                                              tolerate pre-bridge corpus
+#                                              drift.
 #
-# PR-A2 flips the default to "1" once corpus drift (the X-Pulse / VSP
-# costCBills gap surfaced in PR-A1) is patched.
+# Default-on was flipped after PR #429 verified the entire 5-shape corpus
+# round-trips clean and the ``--strict`` CI gate flipped green. Treating
+# validation as the default means new writers can never silently drift
+# again — they fail loudly during local dev instead.
 #
 # The helpers are intentionally tiny: schema_gate is the single source
 # of truth for what "valid" means; this layer just decides when to call it.
 
 _VALIDATE_ENV_VAR = "MEKSTATION_VALIDATE_WRITES"
 
+# Explicit opt-out values. Anything else (including unset) leaves validation on.
+_DISABLE_VALUES = frozenset({"0", "false", "no", "off"})
+
 
 def _validate_writes_enabled() -> bool:
-    """Read the ``MEKSTATION_VALIDATE_WRITES`` flag (truthy strings: '1', 'true', 'yes')."""
-    val = os.environ.get(_VALIDATE_ENV_VAR, "")
-    return val.strip().lower() in {"1", "true", "yes", "on"}
+    """
+    Return whether schema validation should run before writing.
+
+    Default is ENABLED. Validation is only skipped when the env var is set
+    to one of ``_DISABLE_VALUES`` (``0`` / ``false`` / ``no`` / ``off``).
+    Unset, empty, and any truthy spelling all keep validation on.
+    """
+    val = os.environ.get(_VALIDATE_ENV_VAR, "").strip().lower()
+    return val not in _DISABLE_VALUES
 
 
 def _maybe_validate(shape: str, data: Any) -> None:

--- a/scripts/megameklab-conversion/schema_gate.py
+++ b/scripts/megameklab-conversion/schema_gate.py
@@ -19,9 +19,10 @@ Usage::
     if errors:
         raise ValueError(f"weapon failed schema: {errors}")
 
-In PR-A1 the choke point is opt-in via ``MEKSTATION_VALIDATE_WRITES=1``
-so existing converter runs are not perturbed. PR-A2 flips the default to
-on after corpus conformance is fixed.
+The choke point is **default-on**: ``blk_common.write_*_json`` calls run
+this validator unless ``MEKSTATION_VALIDATE_WRITES`` is explicitly set
+to ``0`` / ``false`` / ``no`` / ``off``. Default flipped after PR #429
+verified corpus conformance and the strict CI gate turned green.
 
 The 6 public ``validate_<shape>`` functions reuse a single compiled
 ``Draft7Validator`` per shape (compile-once-reuse). Compilation is lazy

--- a/src/lib/campaign/processors/postBattleProcessor.ts
+++ b/src/lib/campaign/processors/postBattleProcessor.ts
@@ -282,14 +282,11 @@ function applyUnitDelta(
  * richer player-side check (multi-player teams, etc.).
  */
 function playerWon(outcome: ICombatOutcome): boolean {
-  // The composed report contains the original session winner. Defensive
-  // optional access keeps the processor working with stub reports too.
-  const winner = (
-    outcome.report as unknown as {
-      readonly winner?: GameSide | 'draw';
-    }
-  ).winner;
-  return winner === GameSide.Player;
+  // The composed report contains the original session winner.
+  // `IPostBattleReport.winner` is required + already typed as
+  // `GameSide | 'draw'` — the previous double-cast was a no-op
+  // defensive shim from before the report shape was tightened.
+  return outcome.report.winner === GameSide.Player;
 }
 
 /**

--- a/src/services/equipment/EquipmentLoaderService.ts
+++ b/src/services/equipment/EquipmentLoaderService.ts
@@ -9,7 +9,13 @@
  * @module services/equipment/EquipmentLoaderService
  */
 
-import { WeaponContract } from '@/types/contracts';
+import {
+  AmmunitionContract,
+  ElectronicsContract,
+  MiscEquipmentContract,
+  PhysicalWeaponContract,
+  WeaponContract,
+} from '@/types/contracts';
 import { IAmmunition } from '@/types/equipment/AmmunitionTypes';
 import { IElectronics } from '@/types/equipment/ElectronicsTypes';
 import { IMiscEquipment } from '@/types/equipment/MiscEquipmentTypes';
@@ -102,37 +108,99 @@ function getIndexedFileList(
 }
 
 /**
- * Detect whether an `IEquipmentFile.$schema` reference points at the
- * canonical weapon-schema. Files like `weapons/physical.json` carry a
- * `$schema` that targets `physical-weapon-schema.json` instead and must
- * NOT be parsed against the weapon contract — they belong to a sibling
- * shape that PR-A2 wires.
+ * One-line summary of a Zod schema for use in dev-loader log lines.
+ *
+ * The `safeParse` API is structural so we treat each contract as an
+ * opaque parser keyed by a human-readable label.
  */
-function isWeaponShapeFile(schemaRef: string | undefined): boolean {
-  if (!schemaRef) return false;
-  // Accept any path/filename that ends in `weapon-schema.json`. We
-  // deliberately exclude `physical-weapon-schema.json` because it
-  // sub-strings differently in URL form.
-  const fileName = schemaRef.split(/[\\/]/).pop() ?? schemaRef;
-  return fileName === 'weapon-schema.json';
+interface IShapeValidator {
+  readonly label: string;
+  readonly safeParse: (item: unknown) => {
+    success: boolean;
+    error?: {
+      issues: readonly {
+        path: ReadonlyArray<string | number>;
+        message: string;
+      }[];
+    };
+  };
 }
 
 /**
- * Validate every weapon item against the canonical `WeaponContract`.
+ * Map per-shape `$schema`-filename suffix to the matching contract.
+ *
+ * Used by `detectShapeValidator` to pick the right Zod schema for an
+ * equipment file. Ammunition files in the corpus today don't carry a
+ * `$schema` reference, so the loader falls back to the per-loop default
+ * (see `validateShapeFromFile`). New shapes only need an entry here
+ * plus a default-fallback in the call site.
+ */
+const SHAPE_VALIDATORS_BY_SCHEMA_FILE: Record<string, IShapeValidator> = {
+  'weapon-schema.json': {
+    label: 'WeaponContract',
+    safeParse: WeaponContract.safeParse.bind(
+      WeaponContract,
+    ) as IShapeValidator['safeParse'],
+  },
+  'physical-weapon-schema.json': {
+    label: 'PhysicalWeaponContract',
+    safeParse: PhysicalWeaponContract.safeParse.bind(
+      PhysicalWeaponContract,
+    ) as IShapeValidator['safeParse'],
+  },
+  'ammunition-schema.json': {
+    label: 'AmmunitionContract',
+    safeParse: AmmunitionContract.safeParse.bind(
+      AmmunitionContract,
+    ) as IShapeValidator['safeParse'],
+  },
+  'electronics-schema.json': {
+    label: 'ElectronicsContract',
+    safeParse: ElectronicsContract.safeParse.bind(
+      ElectronicsContract,
+    ) as IShapeValidator['safeParse'],
+  },
+  'misc-equipment-schema.json': {
+    label: 'MiscEquipmentContract',
+    safeParse: MiscEquipmentContract.safeParse.bind(
+      MiscEquipmentContract,
+    ) as IShapeValidator['safeParse'],
+  },
+};
+
+/**
+ * Resolve a contract validator from an `IEquipmentFile.$schema` reference.
+ *
+ * Returns `undefined` when the file has no `$schema` or the suffix isn't
+ * mapped — callers can pass an explicit `fallback` validator (typical
+ * for ammunition files which omit the header) so the gate still runs.
+ */
+function detectShapeValidator(
+  schemaRef: string | undefined,
+): IShapeValidator | undefined {
+  if (!schemaRef) return undefined;
+  const fileName = schemaRef.split(/[\\/]/).pop() ?? schemaRef;
+  return SHAPE_VALIDATORS_BY_SCHEMA_FILE[fileName];
+}
+
+/**
+ * Validate every item in an equipment file against a contract.
  *
  * Behaviour:
- *  - Default (PR-A1): collect failures and emit a single
- *    `console.warn` summarising drift. Non-throwing because the corpus
- *    is known to have 6 X-Pulse / VSP entries missing `costCBills`,
- *    and PR-A2 will fix that data before flipping to throw mode.
+ *  - Default: collect failures and emit a single `console.warn`
+ *    summarising drift. Non-throwing because the corpus may still have
+ *    minor known gaps (e.g. 6 X-Pulse / VSP entries pre-PR-A2 missed
+ *    `costCBills`). The `--strict` schema-bridge CI gate is the
+ *    enforcement layer; this dev-loader gate is just an early signal.
  *  - `MEKSTATION_STRICT_SCHEMA_BRIDGE=1`: throw with an aggregated
  *    error message. Useful for one-off `npx jest` runs where you want
  *    to fail fast on any new drift introduced by a code change.
  *
  * Dev/test only — production callers never reach this code path because
- * the surrounding `process.env.NODE_ENV !== 'production'` gate.
+ * every consumer wraps the call in `process.env.NODE_ENV !== 'production'`.
  */
-function validateWeaponItems(
+function validateShape(
+  validator: IShapeValidator,
   fileLabel: string,
   items: readonly unknown[],
 ): void {
@@ -141,12 +209,15 @@ function validateWeaponItems(
   const failures: string[] = [];
   for (let index = 0; index < items.length; index++) {
     const item = items[index];
-    const result = WeaponContract.safeParse(item);
+    const result = validator.safeParse(item);
     if (!result.success) {
       const id = (item as { id?: unknown } | null | undefined)?.id ?? '<no id>';
-      const issuePaths = result.error.issues
+      const issuePaths = (result.error?.issues ?? [])
         .slice(0, 3)
-        .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+        .map(
+          (issue) =>
+            `${issue.path.map(String).join('.') || '<root>'}: ${issue.message}`,
+        )
         .join('; ');
       failures.push(`  [${index}] id=${String(id)} -> ${issuePaths}`);
     }
@@ -154,17 +225,48 @@ function validateWeaponItems(
   if (failures.length === 0) return;
 
   const message =
-    `EquipmentLoaderService: ${failures.length} weapon(s) in ${fileLabel} ` +
-    `failed WeaponContract.safeParse:\n${failures.slice(0, 8).join('\n')}` +
+    `EquipmentLoaderService: ${failures.length} item(s) in ${fileLabel} ` +
+    `failed ${validator.label}.safeParse:\n${failures.slice(0, 8).join('\n')}` +
     (failures.length > 8 ? `\n... and ${failures.length - 8} more` : '');
 
   if (process.env.MEKSTATION_STRICT_SCHEMA_BRIDGE === '1') {
     throw new Error(message);
   }
-  // Non-strict default for PR-A1: surface drift loudly without
-  // breaking dev runs that happen to load the X-Pulse / VSP entries.
+  // Non-strict default: surface drift loudly without breaking dev runs.
   console.warn(`[schema-bridge] ${message}`);
 }
+
+/**
+ * Run the dev-loader schema gate for a single equipment file.
+ *
+ * Resolves the contract from the file's `$schema` header and falls back
+ * to `defaultValidator` when the header is missing (ammunition today)
+ * or points at an unknown shape. No-ops in production builds.
+ */
+function validateShapeFromFile(
+  fileLabel: string,
+  fileSchemaRef: string | undefined,
+  items: readonly unknown[],
+  defaultValidator: IShapeValidator,
+): void {
+  if (process.env.NODE_ENV === 'production') return;
+  const validator = detectShapeValidator(fileSchemaRef) ?? defaultValidator;
+  validateShape(validator, fileLabel, items);
+}
+
+// Pre-bound shape validators reused by the loader loops. Defined once so
+// every call site lands on the same `IShapeValidator` object identity
+// (cheap value, but clearer in profiles than ad-hoc literals). The
+// physical-weapon shape is reachable via `detectShapeValidator` for
+// files in the weapons/ directory carrying `physical-weapon-schema.json`,
+// so it doesn't need its own pre-bound constant.
+const WEAPON_SHAPE = SHAPE_VALIDATORS_BY_SCHEMA_FILE['weapon-schema.json'];
+const AMMUNITION_SHAPE =
+  SHAPE_VALIDATORS_BY_SCHEMA_FILE['ammunition-schema.json'];
+const ELECTRONICS_SHAPE =
+  SHAPE_VALIDATORS_BY_SCHEMA_FILE['electronics-schema.json'];
+const MISC_EQUIPMENT_SHAPE =
+  SHAPE_VALIDATORS_BY_SCHEMA_FILE['misc-equipment-schema.json'];
 
 /**
  * Equipment Loader Service
@@ -224,26 +326,30 @@ export class EquipmentLoaderService {
           basePath,
         );
         if (weaponData) {
-          // Cross-language schema-bridge gate (PR-A1).
+          // Cross-language schema-bridge gate.
           //
-          // In dev/test we round-trip every weapon through the canonical
-          // WeaponContract before handing it to `convertWeapon`. This is
-          // the TypeScript-side mirror of `schema_gate.validate_weapon`
-          // in Python; together they catch silent shape drift between
-          // the writer and reader sides at first contact.
+          // In dev/test we round-trip every item through the canonical
+          // contract before handing it to the per-shape converter. This
+          // is the TypeScript-side mirror of `schema_gate.validate_*` in
+          // Python; together they catch silent shape drift between the
+          // writer and reader sides at first contact.
           //
           // Production builds skip this cost. The CI `schema-bridge`
-          // job already gates merges on corpus conformance, so re-parsing
-          // at runtime in production buys nothing but allocations. The
-          // wrapping `IEquipmentFile.$schema` reference is checked so
-          // shapes other than `weapon` (e.g. `weapons/physical.json`,
-          // which is actually a physical-weapon shape) bypass cleanly.
-          if (
-            process.env.NODE_ENV !== 'production' &&
-            isWeaponShapeFile(weaponData.$schema)
-          ) {
-            validateWeaponItems(weaponFile, weaponData.items);
-          }
+          // job already gates merges on corpus conformance via the
+          // `--shape all --strict` Python harness, so re-parsing at
+          // runtime in production buys nothing but allocations.
+          //
+          // The weapons/ directory holds two shapes: WeaponContract for
+          // ranged weapons (energy-laser.json etc.) and
+          // PhysicalWeaponContract for physical.json. The default-
+          // validator argument matches the directory's "primary" shape;
+          // file-level `$schema` headers re-route per-file when present.
+          validateShapeFromFile(
+            weaponFile,
+            weaponData.$schema,
+            weaponData.items,
+            WEAPON_SHAPE,
+          );
           weaponData.items.forEach((item) => {
             const weapon = convertWeapon(item);
             this.weapons.set(weapon.id, weapon);
@@ -263,6 +369,15 @@ export class EquipmentLoaderService {
           basePath,
         );
         if (ammoData) {
+          // Schema-bridge gate. Ammunition files in the corpus today don't
+          // carry `$schema` headers, so the default validator
+          // (`AmmunitionContract`) handles the entire directory.
+          validateShapeFromFile(
+            ammoFile,
+            ammoData.$schema,
+            ammoData.items,
+            AMMUNITION_SHAPE,
+          );
           ammoData.items.forEach((item) => {
             const ammo = convertAmmunition(item);
             this.ammunition.set(ammo.id, ammo);
@@ -284,6 +399,16 @@ export class EquipmentLoaderService {
           IEquipmentFile<IRawElectronicsData>
         >(elecFile, basePath);
         if (electronicsData) {
+          // Schema-bridge gate. Electronics files all carry
+          // `$schema: ../../_schema/electronics-schema.json` so the
+          // default-validator argument is more of a safety net than a
+          // primary code path.
+          validateShapeFromFile(
+            elecFile,
+            electronicsData.$schema,
+            electronicsData.items,
+            ELECTRONICS_SHAPE,
+          );
           electronicsData.items.forEach((item) => {
             const electronics = convertElectronics(item);
             this.electronics.set(electronics.id, electronics);
@@ -302,6 +427,14 @@ export class EquipmentLoaderService {
           IEquipmentFile<IRawMiscEquipmentData>
         >(miscFile, basePath);
         if (miscData) {
+          // Schema-bridge gate. Misc files all carry
+          // `$schema: ../../_schema/misc-equipment-schema.json`.
+          validateShapeFromFile(
+            miscFile,
+            miscData.$schema,
+            miscData.items,
+            MISC_EQUIPMENT_SHAPE,
+          );
           miscData.items.forEach((item) => {
             const equipment = convertMiscEquipment(item);
             this.miscEquipment.set(equipment.id, equipment);

--- a/src/services/equipment/__tests__/EquipmentLoaderService.schemaBridge.test.ts
+++ b/src/services/equipment/__tests__/EquipmentLoaderService.schemaBridge.test.ts
@@ -1,0 +1,224 @@
+/**
+ * EquipmentLoaderService.schemaBridge.test.ts
+ *
+ * Smoke tests for the cross-language schema-bridge dev-loader gate.
+ *
+ * The loader's responsibility under the bridge is:
+ *  1. In dev/test, run every loaded item through its shape's contract.
+ *  2. Production builds skip the gate (no NODE_ENV check inside the
+ *     loader test fixtures here — Jest runs as `test` so the gate is
+ *     active).
+ *  3. With `MEKSTATION_STRICT_SCHEMA_BRIDGE=1`, drift throws.
+ *  4. Without the strict flag, drift hits `console.warn` so dev runs
+ *     don't break on minor / known gaps.
+ *
+ * We exercise the gate by feeding a known-bad item to `loadCustomEquipment`
+ * (which routes ammunition/electronics/misc/weapon items into the same
+ * convert-and-cache path used by `loadOfficialEquipment`). The dev-gate
+ * lives in `loadOfficialEquipment` only — we test it indirectly by
+ * priming the loader with a fake `readJsonFile` for one shape at a time.
+ *
+ * Mocking the I/O instead of writing to a temp directory avoids
+ * polluting the corpus and keeps the test deterministic across CI
+ * checkouts that may not have the full `public/data/equipment/official/`
+ * tree (slim CI sandboxes, etc).
+ */
+
+import {
+  EquipmentLoaderService,
+  resetEquipmentLoader,
+} from '../EquipmentLoaderService';
+
+jest.mock('../EquipmentFileReader', () => ({
+  readJsonFile: jest.fn(),
+}));
+
+import { readJsonFile } from '../EquipmentFileReader';
+
+const mockedReadJsonFile = readJsonFile as jest.MockedFunction<
+  typeof readJsonFile
+>;
+
+/**
+ * Build a minimal index.json so the loader knows which files to walk.
+ *
+ * The loader keys off `indexData?.files?.<category>` for each shape;
+ * any category we want exercised must appear here.
+ */
+function buildIndex(category: string, files: string[]) {
+  const filesObj: Record<string, string> = {};
+  files.forEach((f, i) => {
+    filesObj[`f${i}`] = f;
+  });
+  return {
+    files: { [category]: filesObj },
+  };
+}
+
+beforeEach(() => {
+  resetEquipmentLoader();
+  jest.resetAllMocks();
+});
+
+describe('EquipmentLoaderService schema-bridge gate', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    delete process.env.MEKSTATION_STRICT_SCHEMA_BRIDGE;
+  });
+
+  it('warns (does not throw) on weapon drift in non-strict mode', async () => {
+    // Index advertises one weapon file. The file's `$schema` points at
+    // weapon-schema.json so the gate runs WeaponContract.
+    mockedReadJsonFile.mockImplementation(async (relPath: string) => {
+      if (relPath === 'index.json') {
+        return buildIndex('weapons', ['weapons/fake.json']);
+      }
+      if (relPath === 'weapons/fake.json') {
+        return {
+          $schema: '../../_schema/weapon-schema.json',
+          version: '1.0.0',
+          generatedAt: '2026-04-25',
+          count: 1,
+          items: [
+            {
+              // Missing required fields like `name`, `tonnage`, etc.
+              id: 'broken-weapon',
+            },
+          ],
+        };
+      }
+      return null;
+    });
+
+    const loader = new EquipmentLoaderService();
+    await loader.loadOfficialEquipment();
+
+    expect(warnSpy).toHaveBeenCalled();
+    const messages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(
+      messages.some((m) => m.includes('failed WeaponContract.safeParse')),
+    ).toBe(true);
+  });
+
+  it('warns on ammunition drift when no $schema header is present', async () => {
+    // Ammunition files in the real corpus omit `$schema`; the gate
+    // falls back to the AmmunitionContract default validator. Verifies
+    // the default-validator path actually fires.
+    mockedReadJsonFile.mockImplementation(async (relPath: string) => {
+      if (relPath === 'index.json') {
+        return buildIndex('ammunition', ['ammunition/fake.json']);
+      }
+      if (relPath === 'ammunition/fake.json') {
+        return {
+          // No `$schema` field.
+          version: '1.0.0',
+          generatedAt: '2026-04-25',
+          count: 1,
+          items: [
+            {
+              // Missing required ammunition fields.
+              id: 'broken-ammo',
+            },
+          ],
+        };
+      }
+      return null;
+    });
+
+    const loader = new EquipmentLoaderService();
+    await loader.loadOfficialEquipment();
+
+    const messages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(
+      messages.some((m) => m.includes('failed AmmunitionContract.safeParse')),
+    ).toBe(true);
+  });
+
+  it('warns on electronics drift', async () => {
+    mockedReadJsonFile.mockImplementation(async (relPath: string) => {
+      if (relPath === 'index.json') {
+        return buildIndex('electronics', ['electronics/fake.json']);
+      }
+      if (relPath === 'electronics/fake.json') {
+        return {
+          $schema: '../../_schema/electronics-schema.json',
+          version: '1.0.0',
+          generatedAt: '2026-04-25',
+          count: 1,
+          items: [{ id: 'broken-electronics' }],
+        };
+      }
+      return null;
+    });
+
+    const loader = new EquipmentLoaderService();
+    await loader.loadOfficialEquipment();
+
+    const messages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(
+      messages.some((m) => m.includes('failed ElectronicsContract.safeParse')),
+    ).toBe(true);
+  });
+
+  it('warns on misc-equipment drift', async () => {
+    mockedReadJsonFile.mockImplementation(async (relPath: string) => {
+      if (relPath === 'index.json') {
+        return buildIndex('miscellaneous', ['miscellaneous/fake.json']);
+      }
+      if (relPath === 'miscellaneous/fake.json') {
+        return {
+          $schema: '../../_schema/misc-equipment-schema.json',
+          version: '1.0.0',
+          generatedAt: '2026-04-25',
+          count: 1,
+          items: [{ id: 'broken-misc' }],
+        };
+      }
+      return null;
+    });
+
+    const loader = new EquipmentLoaderService();
+    await loader.loadOfficialEquipment();
+
+    const messages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(
+      messages.some((m) =>
+        m.includes('failed MiscEquipmentContract.safeParse'),
+      ),
+    ).toBe(true);
+  });
+
+  it('routes weapons/physical.json through PhysicalWeaponContract', async () => {
+    mockedReadJsonFile.mockImplementation(async (relPath: string) => {
+      if (relPath === 'index.json') {
+        return buildIndex('weapons', ['weapons/physical.json']);
+      }
+      if (relPath === 'weapons/physical.json') {
+        return {
+          $schema: '../_schema/physical-weapon-schema.json',
+          version: '1.0.0',
+          generatedAt: '2026-04-25',
+          count: 1,
+          items: [{ id: 'broken-physical' }],
+        };
+      }
+      return null;
+    });
+
+    const loader = new EquipmentLoaderService();
+    await loader.loadOfficialEquipment();
+
+    const messages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(
+      messages.some((m) =>
+        m.includes('failed PhysicalWeaponContract.safeParse'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/services/units/unitLoaderService/__tests__/unitContractAdapter.test.ts
+++ b/src/services/units/unitLoaderService/__tests__/unitContractAdapter.test.ts
@@ -1,0 +1,134 @@
+/**
+ * unitContractAdapter.test.ts
+ *
+ * Round-trip tests for `parseUnit` and `safeParseUnit`. The adapter is
+ * the parse-boundary choke-point that PR-A2 introduces between raw JSON
+ * (canonical fetches, custom-unit API responses, file imports) and the
+ * `IRawSerializedUnit` shape consumed by `UnitLoaderService.mapToUnitState`.
+ *
+ * The "happy path" reads a real BattleMech JSON file from the corpus
+ * because mocking the full UnitContract shape would just re-encode what
+ * the contract already documents. Negative-path tests use minimal hand-
+ * crafted bogus inputs.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  parseUnit,
+  safeParseUnit,
+  UnitContractParseError,
+} from '../unitContractAdapter';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..', '..');
+const FIXTURE_PATH = path.join(
+  REPO_ROOT,
+  'public',
+  'data',
+  'units',
+  'battlemechs',
+  '3-succession-wars',
+  'advanced',
+  'Annihilator ANH-1G.json',
+);
+
+describe('parseUnit', () => {
+  it('round-trips a real BattleMech corpus entry', () => {
+    const raw = JSON.parse(fs.readFileSync(FIXTURE_PATH, 'utf-8'));
+    const unit = parseUnit(raw, 'Annihilator ANH-1G.json');
+
+    // Spot-check that core fields survive the adapter — both required
+    // (id, chassis, tonnage, techBase) and optional rich fields
+    // (engine, equipment) flow through unchanged.
+    expect(typeof unit.id).toBe('string');
+    expect(unit.chassis).toBe('Annihilator');
+    expect(unit.tonnage).toBe(100);
+    expect(unit.techBase).toBe('INNER_SPHERE');
+    expect(unit.engine?.rating).toBeGreaterThan(0);
+    expect(Array.isArray(unit.equipment)).toBe(true);
+    expect(unit.equipment?.length).toBeGreaterThan(0);
+  });
+
+  it('throws UnitContractParseError on missing required fields', () => {
+    // No id, no unitType — UnitContract requires both.
+    const bogus = { chassis: 'Phantom' };
+    expect(() => parseUnit(bogus, 'bogus.json')).toThrow(
+      UnitContractParseError,
+    );
+  });
+
+  it('throws UnitContractParseError on invalid enum value', () => {
+    const bogus = {
+      id: 'fake-unit',
+      unitType: 'NotARealUnitType',
+    };
+    expect(() => parseUnit(bogus)).toThrow(UnitContractParseError);
+  });
+
+  it('preserves Zod issue paths in the thrown error', () => {
+    const bogus = { id: 'fake', unitType: 'BattleMech', tonnage: -50 };
+    try {
+      parseUnit(bogus, 'tonnage-bad.json');
+      fail('Expected UnitContractParseError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(UnitContractParseError);
+      const issues = (err as UnitContractParseError).issues;
+      // At least one issue should mention 'tonnage' (negative value
+      // violates the .gte(0) constraint in the schema).
+      expect(issues.some((i) => i.path === 'tonnage')).toBe(true);
+    }
+  });
+
+  it('forwards extra fields via the index signature passthrough', () => {
+    const raw = JSON.parse(fs.readFileSync(FIXTURE_PATH, 'utf-8'));
+    const unit = parseUnit(raw);
+    // mulId is a real field on canonical entries that downstream
+    // consumers (mapToUnitState) read via the index signature.
+    expect(unit.mulId).toBeDefined();
+  });
+
+  it('uses default sourceLabel when none provided', () => {
+    const bogus = {};
+    try {
+      parseUnit(bogus);
+      fail('Expected throw');
+    } catch (err) {
+      expect((err as Error).message).toContain('<json input>');
+    }
+  });
+});
+
+describe('safeParseUnit', () => {
+  it('returns success result for valid input', () => {
+    const raw = JSON.parse(fs.readFileSync(FIXTURE_PATH, 'utf-8'));
+    const result = safeParseUnit(raw);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.unit.chassis).toBe('Annihilator');
+    }
+  });
+
+  it('returns failure result without throwing on invalid input', () => {
+    const result = safeParseUnit({ chassis: 'Phantom' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(UnitContractParseError);
+      expect(result.error.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('rethrows non-contract errors unchanged', () => {
+    // Pass something that makes JSON.parse-style mishandling pop. We
+    // can't easily force a non-contract throw from inside parseUnit
+    // today, so this test documents the rethrow contract via a manual
+    // trigger: pass a value that Zod's safeParse handles fine but
+    // would fail downstream. Currently Zod swallows everything into
+    // its issue list, so this test asserts the happy-path contract
+    // shape; if a future refactor adds a real throw site this becomes
+    // a regression catcher.
+    const result = safeParseUnit(null);
+    // null fails Zod schema validation rather than throwing.
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/services/units/unitLoaderService/index.ts
+++ b/src/services/units/unitLoaderService/index.ts
@@ -44,3 +44,12 @@ export { calculateArmorTonnage } from './armorCalculations';
 
 // Main service class
 export { UnitLoaderService, unitLoaderService } from './unitLoader';
+
+// Schema-bridge contract adapter (PR-A2). Use `parseUnit` / `safeParseUnit`
+// at any new JSON-parse boundary instead of casting `as IRawSerializedUnit`
+// — drift fails loudly with a Zod issue path.
+export {
+  parseUnit,
+  safeParseUnit,
+  UnitContractParseError,
+} from './unitContractAdapter';

--- a/src/services/units/unitLoaderService/unitContractAdapter.ts
+++ b/src/services/units/unitLoaderService/unitContractAdapter.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit Contract Adapter
+ *
+ * Bridges the cross-language `UnitContract` (boundary shape parsed from
+ * JSON via Zod) to the in-memory `IRawSerializedUnit` shape consumed by
+ * `UnitLoaderService.mapToUnitState`. This is the parse-boundary
+ * choke-point referenced from `src/types/contracts/index.ts` — every
+ * place that previously cast raw JSON `as unknown as IRawSerializedUnit`
+ * (or similar) routes through here so a future wire-format drift fails
+ * loudly with a Zod issue path instead of silently producing a
+ * malformed `UnitState`.
+ *
+ * Design notes:
+ *  - `parseUnit(json)` returns `IRawSerializedUnit` because the loader
+ *    is the only consumer today; the rich `IUnit` domain interface is
+ *    constructed downstream by `mapToUnitState`. We deliberately don't
+ *    materialise the rich type here — it would force every adapter call
+ *    site to run the full mapper, which has equipment-registry side
+ *    effects.
+ *  - The adapter is intentionally permissive: `IRawSerializedUnit` has
+ *    an `[key: string]: unknown` catchall, so we forward extra fields
+ *    that aren't yet in the contract (e.g. `mulId`, `era`,
+ *    `baseChassisHeatSinks`) without dropping data. The Zod schema
+ *    accepts unknown keys at the unit root via `.passthrough()` upstream.
+ *  - On failure we throw with the first 3 Zod issue paths so the caller
+ *    sees a CI-friendly, actionable error instead of "type assertion
+ *    failed" deep inside the mapper.
+ *
+ * Error type: `UnitContractParseError` is exported so callers can
+ * differentiate schema drift from other I/O errors without resorting to
+ * string matching.
+ *
+ * @see src/types/contracts/index.ts — UnitContract source of truth
+ * @see src/services/units/unitLoaderService/unitLoader.ts — main consumer
+ */
+
+import { UnitContract } from '@/types/contracts';
+
+import { IRawSerializedUnit } from './types';
+
+/**
+ * Thrown when `parseUnit` cannot validate input against `UnitContract`.
+ *
+ * Carries the Zod issue list (first 5) so test output and CI logs can
+ * pinpoint the offending field without re-running the parse.
+ */
+export class UnitContractParseError extends Error {
+  /** First 5 Zod issues, preserved verbatim for debugging. */
+  readonly issues: ReadonlyArray<{
+    readonly path: string;
+    readonly message: string;
+  }>;
+
+  constructor(
+    issues: ReadonlyArray<{
+      readonly path: string;
+      readonly message: string;
+    }>,
+    sourceLabel: string,
+  ) {
+    const summary = issues
+      .slice(0, 5)
+      .map((issue) => `  ${issue.path || '<root>'}: ${issue.message}`)
+      .join('\n');
+    super(
+      `parseUnit: UnitContract.safeParse failed for ${sourceLabel}:\n${summary}`,
+    );
+    this.name = 'UnitContractParseError';
+    this.issues = issues;
+  }
+}
+
+/**
+ * Parse arbitrary JSON through `UnitContract` and return the
+ * boundary-shape unit usable by `UnitLoaderService.mapToUnitState`.
+ *
+ * Throws `UnitContractParseError` on validation failure. Successful
+ * parses produce a value compatible with `IRawSerializedUnit`: the
+ * Zod-inferred shape is a structural subset (every required field plus
+ * permissive optionals), and the `[key: string]: unknown` catchall on
+ * `IRawSerializedUnit` accepts any extra fields the schema allows.
+ *
+ * @param json    Untyped input — typically `JSON.parse(...)` output, a
+ *                fetched response body, or imported JSON.
+ * @param sourceLabel Human-readable label used in error messages
+ *                    ("Atlas AS7-D.json", "POST /api/custom-units/123",
+ *                    etc.). Defaults to "<json input>".
+ */
+export function parseUnit(
+  json: unknown,
+  sourceLabel = '<json input>',
+): IRawSerializedUnit {
+  const result = UnitContract.safeParse(json);
+  if (!result.success) {
+    const issues = result.error.issues.map((issue) => ({
+      path: issue.path.join('.'),
+      message: issue.message,
+    }));
+    throw new UnitContractParseError(issues, sourceLabel);
+  }
+  // Zod's inferred type is a permissive structural subset of
+  // IRawSerializedUnit; the index signature makes the cast safe at this
+  // boundary because we've just proven the runtime shape conforms.
+  return result.data as unknown as IRawSerializedUnit;
+}
+
+/**
+ * Safe variant: returns either the parsed unit or a structured failure
+ * record. Use when the caller wants to handle drift without try/catch
+ * (e.g. batch-import flows that need to surface per-file errors).
+ */
+export function safeParseUnit(
+  json: unknown,
+):
+  | { success: true; unit: IRawSerializedUnit }
+  | { success: false; error: UnitContractParseError } {
+  try {
+    const unit = parseUnit(json);
+    return { success: true, unit };
+  } catch (err) {
+    if (err instanceof UnitContractParseError) {
+      return { success: false, error: err };
+    }
+    throw err;
+  }
+}

--- a/src/services/units/unitLoaderService/unitLoader.ts
+++ b/src/services/units/unitLoaderService/unitLoader.ts
@@ -45,6 +45,7 @@ import {
 import { mapEquipment } from './equipmentMapping';
 import { hasSerializedUnitStructure } from './typeGuards';
 import { IRawSerializedUnit, UnitSource, ILoadUnitResult } from './types';
+import { parseUnit, UnitContractParseError } from './unitContractAdapter';
 
 /**
  * Unit Loader Service
@@ -76,9 +77,20 @@ export class UnitLoaderService {
         return { success: false, error: `Canonical unit "${id}" not found` };
       }
 
-      const state = this.mapToUnitState(fullUnit as IRawSerializedUnit, true);
+      // Schema-bridge boundary: route the fetched JSON through `parseUnit`
+      // so any drift between the on-disk shape and `UnitContract` surfaces
+      // here with a Zod issue path instead of silently producing a
+      // malformed `UnitState` deep inside the mapper. The full BattleMech
+      // corpus is verified by `unit.contract.test.ts` so this should be
+      // a no-op for canonical data; if a hand-edited unit JSON regresses
+      // we want to know loudly.
+      const validated = parseUnit(fullUnit, `canonical:${id}`);
+      const state = this.mapToUnitState(validated, true);
       return { success: true, state };
     } catch (error) {
+      if (error instanceof UnitContractParseError) {
+        return { success: false, error: error.message };
+      }
       const message =
         error instanceof Error
           ? error.message
@@ -102,19 +114,29 @@ export class UnitLoaderService {
       }
 
       // Custom units may already be in UnitState format (saved from customizer)
-      // or in serialized format (imported)
-      // IFullUnit has [key: string]: unknown, so we can use it as ISerializedUnit if it has the right structure
+      // or in serialized format (imported). The structural pre-check stays
+      // because UnitState has a different shape (no top-level `tonnage`/
+      // `techBase` etc.) and `parseUnit` would reject it — that's the wrong
+      // failure mode for already-customizer-saved units which the loader
+      // currently silently passes through. Once UnitState gets its own
+      // contract this branch can collapse into a single parse.
       if (!hasSerializedUnitStructure(fullUnit)) {
         return {
           success: false,
           error: 'Custom unit data is not in serialized format',
         };
       }
-      // Type assertion is safe here because we've verified the structure matches IRawSerializedUnit
-      // and IFullUnit's index signature [key: string]: unknown makes it compatible
-      const state = this.mapToUnitState(fullUnit as IRawSerializedUnit, false);
+      // Schema-bridge boundary for serialized-format custom units (the
+      // shape we just structurally narrowed to). Same drift-catch guarantee
+      // as the canonical path: any field that doesn't conform to
+      // `UnitContract` fails here with a Zod issue path.
+      const validated = parseUnit(fullUnit, `custom:${id}`);
+      const state = this.mapToUnitState(validated, false);
       return { success: true, state };
     } catch (error) {
+      if (error instanceof UnitContractParseError) {
+        return { success: false, error: error.message };
+      }
       const message =
         error instanceof Error ? error.message : 'Failed to load custom unit';
       return { success: false, error: message };

--- a/src/simulation/detectors/KeyMomentDetector/KeyMomentDetector.ts
+++ b/src/simulation/detectors/KeyMomentDetector/KeyMomentDetector.ts
@@ -173,7 +173,11 @@ export class KeyMomentDetector {
     metadata?: Record<string, unknown>,
   ): IKeyMoment {
     const id = `km-${type}-${event.turn}-${state.momentCounter++}`;
-    const momentType = type as unknown as keyof typeof TIER_MAP;
+    // `type` is the caller-supplied string discriminator that we already
+    // hand-constructed from `keyof typeof TIER_MAP` upstream — narrow
+    // with a single cast since `string` is the supertype of `keyof
+    // typeof TIER_MAP` here, so the double-cast was redundant.
+    const momentType = type as keyof typeof TIER_MAP;
 
     return {
       id,

--- a/src/utils/construction/equipmentBVCatalogData.ts
+++ b/src/utils/construction/equipmentBVCatalogData.ts
@@ -87,4 +87,13 @@ export const AMMUNITION_CATALOG_FILES: readonly CatalogDataFile[] = [
   ammunitionSrm,
 ] as const;
 
+// FIXME(schema-bridge): name-mappings.json doesn't yet have a Zod
+// contract (no `_schema/name-mappings-schema.json` Zod generation).
+// Once authored, replace this double-cast with a `parseNameMappings`
+// adapter call in line with the `parseUnit` pattern from
+// `services/units/unitLoaderService/unitContractAdapter.ts`. The cast
+// is safe today because the JSON is committed verbatim and validated
+// statically — runtime drift would be caught at the next BV regression
+// run rather than at parse-time, which is the only thing the contract
+// adapter would buy us here.
 export const NAME_MAPPINGS_DATA = nameMappings as unknown as NameMappingsData;

--- a/src/utils/gameplay/forceSummaryBuilder.ts
+++ b/src/utils/gameplay/forceSummaryBuilder.ts
@@ -77,9 +77,11 @@ function extractHeatSinks(unit: IFullUnit): {
   count: number;
   kind: HeatSinkKind;
 } {
-  const raw = (unit as unknown as Record<string, unknown>).heatSinks as
-    | { count?: number; type?: string }
-    | undefined;
+  // `IFullUnit` already has a `[key: string]: unknown` index signature,
+  // so reading `.heatSinks` directly yields `unknown`. The previous
+  // double-cast through `Record<string, unknown>` was a no-op — narrow
+  // straight to the optional shape we want.
+  const raw = unit.heatSinks as { count?: number; type?: string } | undefined;
   return {
     count: raw?.count ?? 10,
     kind: toHeatSinkKind(raw?.type),
@@ -88,7 +90,9 @@ function extractHeatSinks(unit: IFullUnit): {
 
 /** Pull BV from a full-unit record (sometimes present, often null). */
 function extractBattleValue(unit: IFullUnit): number {
-  const bv = (unit as unknown as Record<string, unknown>).bv;
+  // Same as above — `unit.bv` already type-narrows from the index
+  // signature without the double-cast.
+  const bv = unit.bv;
   if (typeof bv === 'number') return bv;
   return 0;
 }


### PR DESCRIPTION
## Summary

Closes the schema-bridge follow-up trifecta from PR #424 + PR #429:

- **Part A** — Flip `MEKSTATION_VALIDATE_WRITES` default to ON. Every `blk_common.write_*_json` call now validates by default; only `0`/`false`/`no`/`off` disables. Safe because PR #429 verified `--shape all --strict` clean across 5,348 corpus items.
- **Part B** — Add `parseUnit` / `safeParseUnit` / `UnitContractParseError` adapter at `src/services/units/unitLoaderService/unitContractAdapter.ts`. Migrates `UnitLoaderService.loadCanonicalUnit` and `loadCustomUnit` from `as IRawSerializedUnit` casts to schema-bridge calls. Drift now surfaces with a Zod issue path instead of producing a malformed `UnitState` deep inside the mapper. Barrel-exported from `unitLoaderService/index.ts`.
- **Part C** — Generalise the dev-loader schema gate from weapon-only (PR #424) to all 5 equipment shapes. Replaced `isWeaponShapeFile` + `validateWeaponItems` with a `SHAPE_VALIDATORS_BY_SCHEMA_FILE` table + generic `validateShape` runner. Each loader loop (weapons / ammo / electronics / misc) now routes its items through the matching contract.
- **Part D** — Reduce production `as unknown as` casts where the migration is type-safety hygiene rather than schema-bridging:
  - `forceSummaryBuilder.ts` × 2 dropped (redundant against `IFullUnit`'s index signature).
  - `postBattleProcessor.ts` × 1 dropped (`IPostBattleReport.winner` is required + typed).
  - `KeyMomentDetector.ts` × 1 collapsed double-cast → single cast.
  - `equipmentBVCatalogData.ts` FIXME-tagged (no Zod contract for `name-mappings.json` yet).

## Cast inventory (production, excluding tests)

| Category | Before | After |
| --- | ---: | ---: |
| `as unknown as` (real) | 22 | **18** |
| `as any` (real) | 0 | 0 |

The 18 remaining break down as:

| Bucket | Count | Notes |
| --- | ---: | --- |
| `dispatchTarget.ts` discriminated-union narrowing | 5 | Documented architecture, not boundary casts |
| `unitContractAdapter.ts:104` post-Zod cast | 1 | Intended schema-bridge target — runtime shape was just proven |
| `MockSyncProvider.ts` | 2 | `@internal For testing only` infrastructure |
| `src/components/customizer/` | 2 | Out of scope (Wrap-A territory) |
| Internal type-system gaps | 8 | Enum-keyed→string-keyed records, fixed-length tuples, stale `IFullUnit` field types — not boundary casts |

A clean drop below 10 needs domain-type refactoring (widening `IFullUnit`, simplifying tuple constraints in `pointFire.ts`, relocating `dispatchTarget` to a true tagged-union) — out of schema-bridge scope.

## New adapter surface

- `parseUnit(json: unknown, sourceLabel?: string): IRawSerializedUnit`
- `safeParseUnit(json: unknown): { success: true; unit: IRawSerializedUnit } | { success: false; error: UnitContractParseError }`
- `class UnitContractParseError extends Error` — carries `issues: { path; message }[]`
- `validateShape(validator, fileLabel, items)` and `validateShapeFromFile(...)` (private to `EquipmentLoaderService`, generic over `IShapeValidator`)

## BV parity attestation

```
Within 1%: 3395 (98.3%) ✅ PASS  (matches baseline)
Within 2%: 3433 (99.4%) ✅ PASS  (matches baseline)
Within 3%: 3445 (99.7%) ✅ PASS  (matches baseline)
🎉 ALL ACCURACY GATES PASSED!
```

Identical to `origin/chore/wave-cleanup-followups` baseline — zero runtime delta from the cast migrations.

## FIXME-tagged casts NOT migrated

- `src/utils/construction/equipmentBVCatalogData.ts:99` — `nameMappings as unknown as NameMappingsData`. Tagged with a `FIXME(schema-bridge)` block referencing the `parseUnit` pattern; needs a Zod schema for `name-mappings.json` first (no contract authored today).

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 33 warnings (all pre-existing `max-lines`), 0 errors
- `python scripts/megameklab-conversion/run_schema_validation_only.py --shape all --strict` — 5,348 items / 0 failures
- `npx jest src/types/contracts src/services/units/unitLoaderService src/services/equipment` — 103/103 pass across 8 suites
- `npx tsx scripts/validate-bv.ts` — all accuracy gates pass, identical to baseline
- 14 new tests added (9 in `unitContractAdapter.test.ts`, 5 in `EquipmentLoaderService.schemaBridge.test.ts`)

## Commit cadence

4 atomic commits, one per part:

1. `feat(schema-bridge): flip MEKSTATION_VALIDATE_WRITES default to ON`
2. `feat(schema-bridge): add parseUnit adapter and migrate unitLoader`
3. `feat(schema-bridge): extend dev-loader gate to all 5 equipment shapes`
4. `refactor(types): drop redundant double-casts + barrel-export parseUnit`

## Test plan

- [x] Targeted contract + loader tests pass
- [x] BV parity unchanged
- [x] Schema-bridge corpus passes `--strict`
- [x] Typecheck + lint clean