### PR TITLE
chore(cleanup): unflake 2nd balance test + remove unitLoader IRawSerializedUnit cast

### DIFF
--- a/src/services/generators/__tests__/balance.test.ts
+++ b/src/services/generators/__tests__/balance.test.ts
@@ -80,6 +80,14 @@ describe('Balance Testing', () => {
       expect(result.totalBV).toBeGreaterThan(12000);
     });
 
+    // De-flaked 2026-04-25: pin a seeded RNG per iteration so the
+    // `avgDeviation < 0.2` and `maxDeviation < 0.3` assertions are
+    // deterministic. WrapC's 30-run verification of #421 surfaced a
+    // 1/30 failure here (`maxDeviation = 0.3997 >= 0.3`) under
+    // full-suite Math.random jitter. Same fix pattern as the sibling
+    // "scale OpFor BV proportionally with difficulty" test below —
+    // a per-iteration seed (1..10) preserves the multi-sample shape
+    // (10 distinct generations) while removing global RNG variance.
     it('should consistently hit BV targets across multiple generations', () => {
       const playerBV = 10000;
       const config = getDefaultOpForConfig(
@@ -90,7 +98,13 @@ describe('Balance Testing', () => {
 
       const deviations: number[] = [];
       for (let i = 0; i < 10; i++) {
-        const result = opForGenerator.generate(config);
+        // Distinct seed per iteration so we still sample 10 different
+        // generator outputs (vs. the single-seed difficulty test which
+        // intentionally re-uses one seed across difficulty steps).
+        const seededRandom = new SeededRandom(100 + i);
+        const result = opForGenerator.generate(config, () =>
+          seededRandom.next(),
+        );
         deviations.push(result.bvDeviation);
       }
 
@@ -99,7 +113,6 @@ describe('Balance Testing', () => {
       const maxDeviation = Math.max(...deviations.map(Math.abs));
 
       // Average deviation should be reasonable (within 20%)
-      // Note: stochastic test — tolerance accounts for random generation variance
       expect(Math.abs(avgDeviation)).toBeLessThan(0.2);
       // No single generation should be wildly off (within 30%)
       expect(maxDeviation).toBeLessThan(0.3);

--- a/src/services/units/unitLoaderService/unitContractAdapter.ts
+++ b/src/services/units/unitLoaderService/unitContractAdapter.ts
@@ -124,3 +124,40 @@ export function safeParseUnit(
     throw err;
   }
 }
+
+/**
+ * Resolve a `safeParseUnit` result back into the boundary
+ * `IRawSerializedUnit` shape, falling back to the original JSON when
+ * parsing produced drift warnings. Drift is dev-only-warned upstream
+ * (the corpus contract test owns strict failure), so the loader keeps
+ * loading even when the contract trips — but it must still hand
+ * `mapToUnitState` an `IRawSerializedUnit`-shaped value.
+ *
+ * Centralising the fallback coercion here removes the duplicated
+ * `(parseResult.success ? parseResult.unit : fullUnit) as IRawSerializedUnit`
+ * pattern from each loader call site. The single coercion is justified
+ * because:
+ *   - upstream services type their cached JSON as `IFullUnit` /
+ *     `IUnitWithVersion`, both of which carry `[key: string]: unknown`
+ *     index signatures wide enough to accept the structurally-richer
+ *     `IRawSerializedUnit`,
+ *   - `hasSerializedUnitStructure` already runs ahead of this in the
+ *     custom-unit branch to confirm the shape is the serialized variant
+ *     (chassis/tonnage/techBase present),
+ *   - the contract adapter has already validated the parse on the
+ *     happy path, and the corpus test guarantees no canonical fixture
+ *     can stay drifted.
+ *
+ * If the wire shape ever needs a structural transform (e.g. armor
+ * allocation reshaping), this helper is the single place to do it
+ * without re-fanning the cast across loader entry points.
+ */
+export function resolveRawUnit(
+  parseResult: ReturnType<typeof safeParseUnit>,
+  fallback: unknown,
+): IRawSerializedUnit {
+  if (parseResult.success) {
+    return parseResult.unit;
+  }
+  return fallback as IRawSerializedUnit;
+}

--- a/src/services/units/unitLoaderService/unitLoader.ts
+++ b/src/services/units/unitLoaderService/unitLoader.ts
@@ -45,7 +45,7 @@ import {
 import { mapEquipment } from './equipmentMapping';
 import { hasSerializedUnitStructure } from './typeGuards';
 import { IRawSerializedUnit, UnitSource, ILoadUnitResult } from './types';
-import { safeParseUnit } from './unitContractAdapter';
+import { resolveRawUnit, safeParseUnit } from './unitContractAdapter';
 
 /**
  * Unit Loader Service
@@ -89,9 +89,7 @@ export class UnitLoaderService {
         );
       }
       const state = this.mapToUnitState(
-        (parseResult.success
-          ? parseResult.unit
-          : fullUnit) as IRawSerializedUnit,
+        resolveRawUnit(parseResult, fullUnit),
         true,
       );
       return { success: true, state };
@@ -142,9 +140,7 @@ export class UnitLoaderService {
         );
       }
       const state = this.mapToUnitState(
-        (parseResult.success
-          ? parseResult.unit
-          : fullUnit) as IRawSerializedUnit,
+        resolveRawUnit(parseResult, fullUnit),
         false,
       );
       return { success: true, state };


### PR DESCRIPTION
## Summary

Closes two real-tech-debt items surfaced during the 2026-04-25 wrap-up wave:

1. **De-flake** the second `balance.test.ts` test (`should consistently hit BV targets`) by replacing `Math.random` with a per-iteration `SeededRandom`. Same fix pattern as #421 used for the sibling difficulty-scaling test.
2. **Remove the duplicated `as IRawSerializedUnit` casts** from `unitLoader.ts` introduced in PR #433 commit `794c4c9b`, by centralising the parse-or-fallback decision in a new `resolveRawUnit` helper colocated with `safeParseUnit` in `unitContractAdapter.ts`.

Runs in parallel with PR-C3 (conversion tests) — scopes are disjoint.

## Part 1 — `balance.test.ts` flake fix

- **File**: `src/services/generators/__tests__/balance.test.ts`
- **Test**: `'should consistently hit BV targets across multiple generations'` (lines ~91-119)
- **Mechanism**: WrapC's 30-run verification of #421 saw a 1/30 full-suite-mode failure (`maxDeviation = 0.3997 >= 0.3`) under `Math.random` jitter.
- **Fix**: Per-iteration `SeededRandom(100 + i)` so each of the 10 generations is deterministic. Distinct seeds preserve the 10-sample shape (vs. the difficulty test which intentionally re-uses a single seed across difficulty steps).
- **30-run result**: `PASS: 30 / 30, FAIL: 0 / 30` (full-suite mode).

## Part 2 — `unitLoader.ts` cast cleanup

### Type comparison performed

| Field | `IUnitContract` (Zod-inferred) | `IRawSerializedUnit` |
|---|---|---|
| `chassis` | `string` (optional) | `string` (required) |
| `tonnage` | `number` (optional) | `number` (required) |
| `techBase` | `enum` (optional) | `string` (required) |
| `unitType` | enum-required | `string` (optional) |
| catchall | `.catchall(z.any())` | `[key: string]: unknown` |

The contract also ends with `.and(z.intersection(z.any(), z.any()))` which produces an over-wide inferred type.

### Chosen path: **B (centralised helper)**

Path A (`type IRawSerializedUnit = IUnitContract`) was rejected because it would weaken the required-field guarantees `mapToUnitState` relies on (`serialized.tonnage` being a number, not `number | undefined`).

Path B introduces `resolveRawUnit(parseResult, fallback): IRawSerializedUnit` in `unitContractAdapter.ts`. Both loader call sites (`loadCanonicalUnit`, `loadCustomUnit`) now use it, replacing the duplicated inline `(parseResult.success ? parseResult.unit : fullUnit) as IRawSerializedUnit` pattern.

The single remaining `fallback as IRawSerializedUnit` lives inside `resolveRawUnit` and is justified by:
- canonical: `IFullUnit` carries `[key: string]: unknown`,
- custom: pre-checked by `hasSerializedUnitStructure` to confirm chassis/tonnage/techBase presence,
- the corpus contract test (`unit.contract.test.ts`) owns strict drift detection; runtime-loader behaviour stays dev-only-warned.

If the wire shape ever needs a structural transform (e.g. armor allocation reshaping), the helper is the single place to do it without re-fanning the cast across loader entry points.

### Grep verification

No `as IRawSerializedUnit` remains in `unitLoader.ts`. The only surviving casts are:
- `unitContractAdapter.ts:104` — pre-existing inside `parseUnit` (validating the Zod parse result at the boundary)
- `unitContractAdapter.ts:162` — the new centralized fallback inside `resolveRawUnit`

## Verification

- 30-run flake retest: **30/30 PASS** in full balance.test.ts suite mode
- `npx tsc --noEmit --skipLibCheck`: **clean**
- `npx jest src/services/generators src/__tests__/service/units src/services/units`: **1245/1245 passing** across 31 suites
- `npx jest src/__tests__/service/units/UnitLoaderService.test.ts src/services/units/unitLoaderService`: **47/47 passing**
- `npm run lint`: **0 errors** (33 pre-existing warnings unchanged)
- `npx tsx scripts/validate-bv.ts`: **ALL ACCURACY GATES PASSED** — BV parity unchanged
- `npm run build` (via husky pre-commit): **succeeded** for both commits

## Commits

1. `f20aeb96` chore(test): de-flake 'should consistently hit BV targets' balance test
2. `a543ff63` refactor(unit-loader): centralize parse-or-fallback coercion in resolveRawUnit