### PR TITLE
feat(storybook): add Phase 1 stories for high-leverage shared components

### DIFF
--- a/src/components/armor/ArmorDiagram.stories.tsx
+++ b/src/components/armor/ArmorDiagram.stories.tsx
@@ -1,0 +1,186 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { fn } from "@storybook/test";
+import { useState } from "react";
+
+import { MechLocation } from "@/types/construction/CriticalSlotAllocation";
+
+import {
+  ArmorDiagram,
+  type ArmorAllocationType,
+  type ArmorData,
+} from "./ArmorDiagram";
+
+/**
+ * The armor/ArmorDiagram component is a self-contained front/rear armor
+ * editor used outside of the heavyweight customizer pipeline. It accepts a
+ * structured ArmorData object and emits per-location armor edits along with
+ * optional auto-allocation requests.
+ */
+const meta: Meta<typeof ArmorDiagram> = {
+  title: "Armor/ArmorDiagram",
+  component: ArmorDiagram,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Standalone armor diagram with front/rear toggle and optional auto-allocate dropdown. Renders a CSS-grid silhouette layout on desktop and a vertical stack on mobile.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-surface-deep w-[640px] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    onArmorChange: fn(),
+    onAutoAllocate: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ArmorDiagram>;
+
+const fullArmor: ArmorData = {
+  front: {
+    [MechLocation.HEAD]: 9,
+    [MechLocation.CENTER_TORSO]: 31,
+    [MechLocation.LEFT_TORSO]: 22,
+    [MechLocation.RIGHT_TORSO]: 22,
+    [MechLocation.LEFT_ARM]: 17,
+    [MechLocation.RIGHT_ARM]: 17,
+    [MechLocation.LEFT_LEG]: 26,
+    [MechLocation.RIGHT_LEG]: 26,
+  },
+  rear: {
+    [MechLocation.CENTER_TORSO]: 14,
+    [MechLocation.LEFT_TORSO]: 10,
+    [MechLocation.RIGHT_TORSO]: 10,
+  },
+  max: {
+    [MechLocation.HEAD]: 9,
+    [MechLocation.CENTER_TORSO]: 47,
+    [MechLocation.LEFT_TORSO]: 32,
+    [MechLocation.RIGHT_TORSO]: 32,
+    [MechLocation.LEFT_ARM]: 34,
+    [MechLocation.RIGHT_ARM]: 34,
+    [MechLocation.LEFT_LEG]: 42,
+    [MechLocation.RIGHT_LEG]: 42,
+  },
+};
+
+const partialArmor: ArmorData = {
+  front: {
+    [MechLocation.HEAD]: 5,
+    [MechLocation.CENTER_TORSO]: 18,
+    [MechLocation.LEFT_TORSO]: 14,
+    [MechLocation.RIGHT_TORSO]: 14,
+    [MechLocation.LEFT_ARM]: 10,
+    [MechLocation.RIGHT_ARM]: 10,
+    [MechLocation.LEFT_LEG]: 18,
+    [MechLocation.RIGHT_LEG]: 18,
+  },
+  rear: {
+    [MechLocation.CENTER_TORSO]: 5,
+    [MechLocation.LEFT_TORSO]: 0,
+    [MechLocation.RIGHT_TORSO]: 0,
+  },
+  max: fullArmor.max,
+};
+
+const emptyArmor: ArmorData = {
+  front: {
+    [MechLocation.HEAD]: 0,
+    [MechLocation.CENTER_TORSO]: 0,
+    [MechLocation.LEFT_TORSO]: 0,
+    [MechLocation.RIGHT_TORSO]: 0,
+    [MechLocation.LEFT_ARM]: 0,
+    [MechLocation.RIGHT_ARM]: 0,
+    [MechLocation.LEFT_LEG]: 0,
+    [MechLocation.RIGHT_LEG]: 0,
+  },
+  rear: {
+    [MechLocation.CENTER_TORSO]: 0,
+    [MechLocation.LEFT_TORSO]: 0,
+    [MechLocation.RIGHT_TORSO]: 0,
+  },
+  max: fullArmor.max,
+};
+
+export const FullArmor: Story = {
+  args: {
+    armor: fullArmor,
+  },
+};
+
+export const PartialArmor: Story = {
+  args: {
+    armor: partialArmor,
+  },
+};
+
+export const EmptyArmor: Story = {
+  args: {
+    armor: emptyArmor,
+  },
+};
+
+export const WithAutoAllocate: Story = {
+  args: {
+    armor: partialArmor,
+    onAutoAllocate: fn(),
+  },
+};
+
+export const WithoutAutoAllocate: Story = {
+  args: {
+    armor: partialArmor,
+    onAutoAllocate: undefined,
+  },
+};
+
+/**
+ * Stateful story that lets you walk through allocation by clicking on
+ * locations. Demonstrates the front/rear toggle and auto-allocate flow.
+ */
+export const Interactive: Story = {
+  render: (args) => {
+    const [armor, setArmor] = useState<ArmorData>(partialArmor);
+
+    const handleArmorChange = (
+      location: MechLocation,
+      value: number,
+      facing: "front" | "rear",
+    ) => {
+      setArmor((prev) => ({
+        ...prev,
+        [facing]: { ...prev[facing], [location]: value },
+      }));
+    };
+
+    const handleAutoAllocate = (type: ArmorAllocationType) => {
+      // Naive demo: distribute max armor evenly across the front face
+      // (front-weighted/rear-weighted variants left as stub).
+      if (type === "even") {
+        setArmor((prev) => ({
+          ...prev,
+          front: { ...prev.max },
+        }));
+      }
+    };
+
+    return (
+      <ArmorDiagram
+        {...args}
+        armor={armor}
+        onArmorChange={handleArmorChange}
+        onAutoAllocate={handleAutoAllocate}
+      />
+    );
+  },
+};

--- a/src/components/customizer/armor/shared/ArmorFills.stories.tsx
+++ b/src/components/customizer/armor/shared/ArmorFills.stories.tsx
@@ -1,0 +1,309 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import React from "react";
+
+import {
+  FRONT_ARMOR_COLOR,
+  GradientDefs,
+  REAR_ARMOR_COLOR,
+  SELECTED_COLOR,
+  TankFillClipPath,
+  darkenColor,
+  getArmorGradientId,
+  getArmorStatusColor,
+  getMegaMekStatusColor,
+  lightenColor,
+} from "./ArmorFills";
+
+/**
+ * ArmorFills exports SVG gradient definitions, helper colour utilities, and
+ * tank-style clip paths used by the armor diagrams. These stories surface the
+ * visual fragments so designers can review palette and gradient changes
+ * without spinning up a full mech configurator.
+ */
+const meta: Meta = {
+  title: "Customizer/Armor/ArmorFills",
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "SVG fill primitives for armor diagrams: gradient defs, tank-style clip paths, and palette helpers.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+const GRADIENT_IDS: Array<{ id: string; label: string }> = [
+  { id: "armor-gradient-healthy", label: "Healthy" },
+  { id: "armor-gradient-moderate", label: "Moderate" },
+  { id: "armor-gradient-low", label: "Low" },
+  { id: "armor-gradient-critical", label: "Critical" },
+  { id: "armor-gradient-selected", label: "Selected" },
+  { id: "armor-gradient-front", label: "Front" },
+  { id: "armor-gradient-rear", label: "Rear" },
+];
+
+export const GradientGallery: Story = {
+  render: () => (
+    <svg viewBox="0 0 560 200" style={{ width: 560, height: 200 }}>
+      <GradientDefs />
+      {GRADIENT_IDS.map(({ id, label }, index) => {
+        const x = 10 + index * 78;
+        return (
+          <g key={id}>
+            <rect
+              x={x}
+              y={20}
+              width={64}
+              height={120}
+              fill={`url(#${id})`}
+              stroke="#1e293b"
+              strokeWidth={1}
+            />
+            <text
+              x={x + 32}
+              y={160}
+              textAnchor="middle"
+              fontSize={11}
+              fill="#f8fafc"
+            >
+              {label}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  ),
+};
+
+const STATUS_RATIOS: Array<{ label: string; current: number; max: number }> = [
+  { label: "Full (100%)", current: 30, max: 30 },
+  { label: "Healthy (80%)", current: 24, max: 30 },
+  { label: "Moderate (55%)", current: 17, max: 30 },
+  { label: "Low (30%)", current: 9, max: 30 },
+  { label: "Critical (10%)", current: 3, max: 30 },
+  { label: "Destroyed (0%)", current: 0, max: 30 },
+];
+
+export const StatusColorScale: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <div className="text-text-theme-primary text-sm font-semibold">
+        getArmorStatusColor
+      </div>
+      <div className="flex gap-2">
+        {STATUS_RATIOS.map(({ label, current, max }) => (
+          <div
+            key={label}
+            className="flex flex-col items-center"
+            style={{ width: 88 }}
+          >
+            <div
+              style={{
+                background: getArmorStatusColor(current, max),
+                width: 64,
+                height: 80,
+                borderRadius: 4,
+                border: "1px solid #1e293b",
+              }}
+            />
+            <span className="text-text-theme-secondary mt-1 text-center text-xs">
+              {label}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="text-text-theme-primary mt-4 text-sm font-semibold">
+        getMegaMekStatusColor (beige record-sheet palette)
+      </div>
+      <div className="flex gap-2">
+        {STATUS_RATIOS.map(({ label, current, max }) => (
+          <div
+            key={`mm-${label}`}
+            className="flex flex-col items-center"
+            style={{ width: 88 }}
+          >
+            <div
+              style={{
+                background: getMegaMekStatusColor(current, max),
+                width: 64,
+                height: 80,
+                borderRadius: 4,
+                border: "1px solid #1e293b",
+              }}
+            />
+            <span className="text-text-theme-secondary mt-1 text-center text-xs">
+              {label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  ),
+};
+
+const FILL_PERCENTS = [0, 25, 50, 75, 100];
+
+export const TankFillProgression: Story = {
+  render: () => (
+    <svg viewBox="0 0 420 180" style={{ width: 420, height: 180 }}>
+      <GradientDefs />
+      {FILL_PERCENTS.map((percent, idx) => {
+        const x = 20 + idx * 80;
+        const y = 20;
+        const width = 64;
+        const height = 120;
+        const clipId = `tank-fill-${percent}`;
+        return (
+          <g key={percent}>
+            <TankFillClipPath
+              id={clipId}
+              fillPercent={percent}
+              x={x}
+              y={y}
+              width={width}
+              height={height}
+            />
+            <rect
+              x={x}
+              y={y}
+              width={width}
+              height={height}
+              fill="#1e293b"
+              stroke="#475569"
+              strokeWidth={1}
+            />
+            <rect
+              x={x}
+              y={y}
+              width={width}
+              height={height}
+              fill={getArmorGradientId(percent, 100, false)}
+              clipPath={`url(#${clipId})`}
+            />
+            <text
+              x={x + width / 2}
+              y={160}
+              textAnchor="middle"
+              fontSize={11}
+              fill="#f8fafc"
+            >
+              {percent}%
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  ),
+};
+
+const FACING_PALETTE: Array<{ label: string; color: string }> = [
+  { label: "FRONT", color: FRONT_ARMOR_COLOR },
+  { label: "REAR", color: REAR_ARMOR_COLOR },
+  { label: "SELECTED", color: SELECTED_COLOR },
+];
+
+export const FacingPalette: Story = {
+  render: () => (
+    <div className="flex gap-3">
+      {FACING_PALETTE.map(({ label, color }) => (
+        <div
+          key={label}
+          className="flex flex-col items-center"
+          style={{ width: 96 }}
+        >
+          <div
+            style={{
+              background: color,
+              width: 80,
+              height: 80,
+              borderRadius: 4,
+            }}
+          />
+          <span className="text-text-theme-primary mt-2 text-xs font-semibold">
+            {label}
+          </span>
+          <code className="text-text-theme-secondary text-xs">{color}</code>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+const LIGHTEN_AMOUNTS = [0, 0.1, 0.2, 0.3, 0.4];
+const DARKEN_AMOUNTS = [0, 0.1, 0.2, 0.3, 0.4];
+
+export const ColorTransforms: Story = {
+  render: () => {
+    const baseColor = FRONT_ARMOR_COLOR;
+    return (
+      <div className="flex flex-col gap-3">
+        <div>
+          <div className="text-text-theme-primary text-sm font-semibold">
+            lightenColor (base: {baseColor})
+          </div>
+          <div className="mt-2 flex gap-2">
+            {LIGHTEN_AMOUNTS.map((amount) => {
+              const transformed = lightenColor(baseColor, amount);
+              return (
+                <div
+                  key={`l-${amount}`}
+                  className="flex flex-col items-center"
+                  style={{ width: 80 }}
+                >
+                  <div
+                    style={{
+                      background: transformed,
+                      width: 64,
+                      height: 64,
+                      borderRadius: 4,
+                      border: "1px solid #1e293b",
+                    }}
+                  />
+                  <span className="text-text-theme-secondary mt-1 text-xs">
+                    +{Math.round(amount * 100)}%
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+        <div>
+          <div className="text-text-theme-primary text-sm font-semibold">
+            darkenColor (base: {baseColor})
+          </div>
+          <div className="mt-2 flex gap-2">
+            {DARKEN_AMOUNTS.map((amount) => {
+              const transformed = darkenColor(baseColor, amount);
+              return (
+                <div
+                  key={`d-${amount}`}
+                  className="flex flex-col items-center"
+                  style={{ width: 80 }}
+                >
+                  <div
+                    style={{
+                      background: transformed,
+                      width: 64,
+                      height: 64,
+                      borderRadius: 4,
+                      border: "1px solid #1e293b",
+                    }}
+                  />
+                  <span className="text-text-theme-secondary mt-1 text-xs">
+                    -{Math.round(amount * 100)}%
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    );
+  },
+};

--- a/src/components/customizer/armor/shared/MechSilhouette.stories.tsx
+++ b/src/components/customizer/armor/shared/MechSilhouette.stories.tsx
@@ -1,0 +1,209 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import React from "react";
+
+import { MechLocation } from "@/types/construction";
+
+import {
+  BATTLEMECH_SILHOUETTE,
+  FIGHTER_LOCATION_LABELS,
+  FIGHTER_SILHOUETTE,
+  GEOMETRIC_SILHOUETTE,
+  getLocationLabel,
+  MEGAMEK_SILHOUETTE,
+  QUAD_SILHOUETTE,
+  REALISTIC_SILHOUETTE,
+  type SilhouetteConfig,
+  TRIPOD_SILHOUETTE,
+} from "./MechSilhouette";
+
+type SilhouetteVariant = "biped" | "quad" | "tripod" | "fighter";
+
+function resolveLocationLabel(
+  location: MechLocation,
+  variant: SilhouetteVariant,
+): string {
+  if (variant === "fighter") {
+    return FIGHTER_LOCATION_LABELS[location] ?? location;
+  }
+  return getLocationLabel(location, variant);
+}
+
+/**
+ * The MechSilhouette module is a facade that re-exports SVG path data and
+ * helper utilities for the various silhouette styles consumed by armor
+ * diagrams. These stories visualize each exported config so the SVG geometry
+ * can be reviewed in isolation without the rest of the armor pipeline.
+ */
+const meta: Meta = {
+  title: "Customizer/Armor/MechSilhouette",
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Visual reference for the silhouette path data exported from MechSilhouette. Each story renders the configured viewBox and per-location SVG paths.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+interface SilhouettePreviewProps {
+  config: SilhouetteConfig;
+  height?: number;
+  variant?: SilhouetteVariant;
+}
+
+/**
+ * Render a SilhouetteConfig as a centered SVG with each location filled and
+ * labelled. Used by every story below to keep the rendered output consistent.
+ */
+function SilhouettePreview({
+  config,
+  height = 360,
+  variant = "biped",
+}: SilhouettePreviewProps): React.ReactElement {
+  const entries = Object.entries(config.locations) as Array<
+    [MechLocation, NonNullable<SilhouetteConfig["locations"][MechLocation]>]
+  >;
+
+  return (
+    <svg
+      viewBox={config.viewBox}
+      style={{ height, width: "auto", display: "block" }}
+      role="img"
+      aria-label="Mech silhouette preview"
+    >
+      <rect x={0} y={0} width="100%" height="100%" fill="#0f172a" opacity={0} />
+      {config.outlinePath && (
+        <path
+          d={config.outlinePath}
+          fill="none"
+          stroke="#475569"
+          strokeWidth={1}
+        />
+      )}
+      {entries.map(([location, position]) => {
+        const label = resolveLocationLabel(location, variant);
+        return (
+          <g key={location}>
+            {position.path ? (
+              <path
+                d={position.path}
+                fill="#3b82f6"
+                fillOpacity={0.35}
+                stroke="#60a5fa"
+                strokeWidth={1.5}
+              />
+            ) : (
+              <rect
+                x={position.x}
+                y={position.y}
+                width={position.width}
+                height={position.height}
+                fill="#3b82f6"
+                fillOpacity={0.35}
+                stroke="#60a5fa"
+                strokeWidth={1.5}
+              />
+            )}
+            <text
+              x={position.x + position.width / 2}
+              y={position.y + position.height / 2}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontSize={10}
+              fill="#f8fafc"
+              style={{ pointerEvents: "none", fontWeight: 600 }}
+            >
+              {label}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+export const RealisticBiped: Story = {
+  render: () => <SilhouettePreview config={REALISTIC_SILHOUETTE} />,
+};
+
+export const BattleMechBiped: Story = {
+  render: () => <SilhouettePreview config={BATTLEMECH_SILHOUETTE} />,
+};
+
+export const MegaMekBiped: Story = {
+  render: () => <SilhouettePreview config={MEGAMEK_SILHOUETTE} />,
+};
+
+export const GeometricBiped: Story = {
+  render: () => <SilhouettePreview config={GEOMETRIC_SILHOUETTE} />,
+};
+
+export const Quad: Story = {
+  render: () => <SilhouettePreview config={QUAD_SILHOUETTE} variant="quad" />,
+};
+
+export const Tripod: Story = {
+  render: () => (
+    <SilhouettePreview config={TRIPOD_SILHOUETTE} variant="tripod" />
+  ),
+};
+
+export const Fighter: Story = {
+  render: () => (
+    <SilhouettePreview config={FIGHTER_SILHOUETTE} variant="fighter" />
+  ),
+};
+
+export const VariantGallery: Story = {
+  render: () => (
+    <div className="grid grid-cols-2 gap-6 lg:grid-cols-4">
+      {(
+        [
+          {
+            label: "Realistic",
+            config: REALISTIC_SILHOUETTE,
+            variant: "biped",
+          },
+          {
+            label: "BattleMech",
+            config: BATTLEMECH_SILHOUETTE,
+            variant: "biped",
+          },
+          { label: "MegaMek", config: MEGAMEK_SILHOUETTE, variant: "biped" },
+          {
+            label: "Geometric",
+            config: GEOMETRIC_SILHOUETTE,
+            variant: "biped",
+          },
+        ] as const
+      ).map(({ label, config, variant }) => (
+        <div
+          key={label}
+          className="bg-surface-base border-border-theme flex flex-col items-center gap-2 rounded border p-3"
+        >
+          <SilhouettePreview config={config} variant={variant} height={220} />
+          <span className="text-text-theme-primary text-xs font-medium">
+            {label}
+          </span>
+        </div>
+      ))}
+    </div>
+  ),
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-surface-deep p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/src/components/customizer/equipment/GlobalLoadoutTray.stories.tsx
+++ b/src/components/customizer/equipment/GlobalLoadoutTray.stories.tsx
@@ -1,0 +1,254 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { fn } from "@storybook/test";
+import { useState } from "react";
+
+import { MechLocation } from "@/types/construction";
+import { EquipmentCategory } from "@/types/equipment";
+
+import type {
+  AvailableLocation,
+  LoadoutEquipmentItem,
+} from "./GlobalLoadoutTray.types";
+
+import { GlobalLoadoutTray } from "./GlobalLoadoutTray";
+
+const meta: Meta<typeof GlobalLoadoutTray> = {
+  title: "Customizer/Equipment/GlobalLoadoutTray",
+  component: GlobalLoadoutTray,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Global loadout tray showing unallocated and allocated equipment with category filters, drag-and-drop, quick assign, and remove confirmation. Uses react-dnd HTML5 backend (provided globally by the Storybook DndDecorator).",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-surface-deep flex h-[600px] justify-end">
+        <div className="bg-surface-base flex-1" />
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    onRemoveEquipment: fn(),
+    onRemoveAllEquipment: fn(),
+    onToggleExpand: fn(),
+    onSelectEquipment: fn(),
+    onUnassignEquipment: fn(),
+    onQuickAssign: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof GlobalLoadoutTray>;
+
+/**
+ * Build a LoadoutEquipmentItem fixture with sensible defaults that mirror
+ * the unit-test factory in GlobalLoadoutTray.test.tsx.
+ */
+function makeItem(
+  overrides: Partial<LoadoutEquipmentItem> &
+    Pick<LoadoutEquipmentItem, "instanceId" | "name" | "category">,
+): LoadoutEquipmentItem {
+  return {
+    equipmentId: overrides.name.toLowerCase().replace(/\s+/g, "-"),
+    weight: 1,
+    criticalSlots: 1,
+    isAllocated: false,
+    isRemovable: true,
+    ...overrides,
+  };
+}
+
+const sampleEquipment: LoadoutEquipmentItem[] = [
+  makeItem({
+    instanceId: "eq-1",
+    name: "Medium Laser",
+    category: EquipmentCategory.ENERGY_WEAPON,
+    heat: 3,
+    damage: 5,
+  }),
+  makeItem({
+    instanceId: "eq-2",
+    name: "Large Laser",
+    category: EquipmentCategory.ENERGY_WEAPON,
+    heat: 8,
+    damage: 8,
+    weight: 5,
+    criticalSlots: 2,
+  }),
+  makeItem({
+    instanceId: "eq-3",
+    name: "AC/10",
+    category: EquipmentCategory.BALLISTIC_WEAPON,
+    weight: 12,
+    criticalSlots: 7,
+    heat: 3,
+    damage: 10,
+    isAllocated: true,
+    location: "Right Torso",
+  }),
+  makeItem({
+    instanceId: "eq-4",
+    name: "AC/10 Ammo",
+    category: EquipmentCategory.AMMUNITION,
+    weight: 1,
+  }),
+  makeItem({
+    instanceId: "eq-5",
+    name: "LRM 15",
+    category: EquipmentCategory.MISSILE_WEAPON,
+    weight: 7,
+    criticalSlots: 3,
+    heat: 5,
+    damage: "1/missile",
+    isAllocated: true,
+    location: "Left Torso",
+  }),
+  makeItem({
+    instanceId: "eq-6",
+    name: "LRM Ammo",
+    category: EquipmentCategory.AMMUNITION,
+    weight: 1,
+  }),
+  makeItem({
+    instanceId: "eq-7",
+    name: "CASE",
+    category: EquipmentCategory.MISC_EQUIPMENT,
+    weight: 0.5,
+    isRemovable: false,
+  }),
+];
+
+const omniEquipment: LoadoutEquipmentItem[] = sampleEquipment.map((item) => ({
+  ...item,
+  isOmniPodMounted: item.category !== EquipmentCategory.STRUCTURAL,
+}));
+
+const sampleAvailableLocations: AvailableLocation[] = [
+  {
+    location: MechLocation.LEFT_ARM,
+    label: "Left Arm",
+    availableSlots: 4,
+    canFit: true,
+  },
+  {
+    location: MechLocation.RIGHT_ARM,
+    label: "Right Arm",
+    availableSlots: 4,
+    canFit: true,
+  },
+  {
+    location: MechLocation.LEFT_TORSO,
+    label: "Left Torso",
+    availableSlots: 8,
+    canFit: true,
+  },
+  {
+    location: MechLocation.CENTER_TORSO,
+    label: "Center Torso",
+    availableSlots: 2,
+    canFit: false,
+  },
+  {
+    location: MechLocation.RIGHT_TORSO,
+    label: "Right Torso",
+    availableSlots: 6,
+    canFit: true,
+  },
+];
+
+export const Default: Story = {
+  args: {
+    equipment: sampleEquipment,
+    equipmentCount: sampleEquipment.length,
+    isExpanded: true,
+    selectedEquipmentId: null,
+    availableLocations: sampleAvailableLocations,
+    isOmni: false,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    equipment: [],
+    equipmentCount: 0,
+    isExpanded: true,
+    selectedEquipmentId: null,
+    availableLocations: sampleAvailableLocations,
+    isOmni: false,
+  },
+};
+
+export const Collapsed: Story = {
+  args: {
+    equipment: sampleEquipment,
+    equipmentCount: sampleEquipment.length,
+    isExpanded: false,
+    selectedEquipmentId: null,
+    availableLocations: sampleAvailableLocations,
+    isOmni: false,
+  },
+};
+
+export const SelectedItem: Story = {
+  args: {
+    equipment: sampleEquipment,
+    equipmentCount: sampleEquipment.length,
+    isExpanded: true,
+    selectedEquipmentId: "eq-1",
+    availableLocations: sampleAvailableLocations,
+    isOmni: false,
+  },
+};
+
+export const OmniPodMounted: Story = {
+  args: {
+    equipment: omniEquipment,
+    equipmentCount: omniEquipment.length,
+    isExpanded: true,
+    selectedEquipmentId: null,
+    availableLocations: sampleAvailableLocations,
+    isOmni: true,
+  },
+};
+
+export const FullyAllocated: Story = {
+  args: {
+    equipment: sampleEquipment.map((item) => ({
+      ...item,
+      isAllocated: true,
+      location: item.location ?? "Right Torso",
+    })),
+    equipmentCount: sampleEquipment.length,
+    isExpanded: true,
+    selectedEquipmentId: null,
+    availableLocations: sampleAvailableLocations,
+    isOmni: false,
+  },
+};
+
+export const Interactive: Story = {
+  render: (args) => {
+    const [isExpanded, setIsExpanded] = useState(true);
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+
+    return (
+      <GlobalLoadoutTray
+        {...args}
+        equipment={sampleEquipment}
+        equipmentCount={sampleEquipment.length}
+        isExpanded={isExpanded}
+        onToggleExpand={() => setIsExpanded((prev) => !prev)}
+        selectedEquipmentId={selectedId}
+        onSelectEquipment={setSelectedId}
+        availableLocations={sampleAvailableLocations}
+      />
+    );
+  },
+};

--- a/src/components/customizer/shared/TechBaseConfiguration.stories.tsx
+++ b/src/components/customizer/shared/TechBaseConfiguration.stories.tsx
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { fn } from "@storybook/test";
+import { useState } from "react";
+
+import {
+  TechBaseComponent,
+  TechBaseMode,
+  createDefaultComponentTechBases,
+  type IComponentTechBases,
+} from "@/types/construction/TechBaseConfiguration";
+import { TechBase } from "@/types/enums/TechBase";
+
+import { TechBaseConfiguration } from "./TechBaseConfiguration";
+
+const meta: Meta<typeof TechBaseConfiguration> = {
+  title: "Customizer/Shared/TechBaseConfiguration",
+  component: TechBaseConfiguration,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Combined panel showing component selections and tech base toggles. Supports Inner Sphere, Clan, and Mixed Tech modes per BattleTech TechManual mixed tech rules.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[640px]">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    onModeChange: fn(),
+    onComponentChange: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TechBaseConfiguration>;
+
+const innerSphereComponents: IComponentTechBases =
+  createDefaultComponentTechBases(TechBase.INNER_SPHERE);
+const clanComponents: IComponentTechBases = createDefaultComponentTechBases(
+  TechBase.CLAN,
+);
+const mixedComponents: IComponentTechBases = {
+  [TechBaseComponent.CHASSIS]: TechBase.INNER_SPHERE,
+  [TechBaseComponent.GYRO]: TechBase.INNER_SPHERE,
+  [TechBaseComponent.ENGINE]: TechBase.CLAN,
+  [TechBaseComponent.HEATSINK]: TechBase.CLAN,
+  [TechBaseComponent.TARGETING]: TechBase.INNER_SPHERE,
+  [TechBaseComponent.MYOMER]: TechBase.INNER_SPHERE,
+  [TechBaseComponent.MOVEMENT]: TechBase.CLAN,
+  [TechBaseComponent.ARMOR]: TechBase.CLAN,
+};
+
+const sampleComponentValues = {
+  chassis: "Endo Steel",
+  gyro: "XL",
+  engine: "XL Fusion 300",
+  heatsink: "Double",
+  targeting: "Standard",
+  myomer: "TSM",
+  movement: "Jump Jets",
+  armor: "Ferro-Fibrous",
+};
+
+export const InnerSphereMode: Story = {
+  args: {
+    mode: TechBaseMode.INNER_SPHERE,
+    components: innerSphereComponents,
+    componentValues: sampleComponentValues,
+    readOnly: false,
+  },
+};
+
+export const ClanMode: Story = {
+  args: {
+    mode: TechBaseMode.CLAN,
+    components: clanComponents,
+    componentValues: {
+      ...sampleComponentValues,
+      armor: "Ferro-Fibrous (Clan)",
+    },
+    readOnly: false,
+  },
+};
+
+export const MixedTechMode: Story = {
+  args: {
+    mode: TechBaseMode.MIXED,
+    components: mixedComponents,
+    componentValues: sampleComponentValues,
+    readOnly: false,
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    mode: TechBaseMode.INNER_SPHERE,
+    components: innerSphereComponents,
+    componentValues: sampleComponentValues,
+    readOnly: true,
+  },
+};
+
+export const DefaultPlaceholders: Story = {
+  args: {
+    mode: TechBaseMode.INNER_SPHERE,
+    components: innerSphereComponents,
+    readOnly: false,
+  },
+};
+
+export const Interactive: Story = {
+  render: (args) => {
+    const [mode, setMode] = useState<TechBaseMode>(TechBaseMode.MIXED);
+    const [components, setComponents] =
+      useState<IComponentTechBases>(mixedComponents);
+
+    return (
+      <TechBaseConfiguration
+        {...args}
+        mode={mode}
+        components={components}
+        componentValues={sampleComponentValues}
+        onModeChange={(next) => {
+          setMode(next);
+          if (next === TechBaseMode.INNER_SPHERE) {
+            setComponents(
+              createDefaultComponentTechBases(TechBase.INNER_SPHERE),
+            );
+          } else if (next === TechBaseMode.CLAN) {
+            setComponents(createDefaultComponentTechBases(TechBase.CLAN));
+          }
+        }}
+        onComponentChange={(component, techBase) => {
+          setComponents((prev) => ({ ...prev, [component]: techBase }));
+        }}
+      />
+    );
+  },
+};


### PR DESCRIPTION
## Summary

Adds Phase 1 Storybook coverage for 5 high-leverage shared components and documents the Toast story situation.

## New stories (5 files, 32 stories total)

| Component | LOC | Story file | Variants |
|---|---:|---|---:|
| TechBaseConfiguration | 331 | `src/components/customizer/shared/TechBaseConfiguration.stories.tsx` | 6 |
| MechSilhouette (facade) | 39 | `src/components/customizer/armor/shared/MechSilhouette.stories.tsx` | 8 |
| ArmorFills (utilities + GradientDefs) | 430 | `src/components/customizer/armor/shared/ArmorFills.stories.tsx` | 5 |
| GlobalLoadoutTray | 343 | `src/components/customizer/equipment/GlobalLoadoutTray.stories.tsx` | 7 |
| armor/ArmorDiagram (standalone) | 298 | `src/components/armor/ArmorDiagram.stories.tsx` | 6 |

Each file has a `Default`/typical-usage story plus variant stories covering empty/populated, read-only, multi-mode (Inner Sphere/Clan/Mixed), and stateful `Interactive` flows where relevant.

## Toast story relocation: not needed

The task brief asked to relocate `Toast.stories.tsx` from the customizer tree to live next to `src/components/ui/Toast.tsx`. Investigation found:

- `src/components/shared/Toast.stories.tsx` already lives co-located with `src/components/shared/Toast.tsx` (it imports from `'./Toast'` and uses the canonical `showToast`/`dismissAll` API).
- `src/components/shared/Toast.tsx` is the canonical implementation — 20+ consumers across pages, hooks, and components.
- `src/components/ui/Toast.tsx` is a separate, parallel implementation with only one consumer (`useSyncToasts` via `useToastSafe`).

No relocation was performed — the existing story is correctly placed. Consolidating the two Toast implementations is a separate refactor and out of scope for a Phase 1 stories PR.

## Verification

- `npm run typecheck` clean
- `npm run lint` 0 errors (30 pre-existing warnings in unrelated files, no new warnings from these stories)
- `npm run storybook:build` succeeds in ~14s; all 5 new story bundles emitted to `storybook-static/assets/`:
  - `TechBaseConfiguration.stories-CNDCk4RK.js`
  - `MechSilhouette.stories-BJ4-t954.js` (22.09 kB)
  - `ArmorFills.stories-B269-zwe.js` (16.72 kB)
  - `GlobalLoadoutTray.stories-CAeeqc9V.js` (27.58 kB)
  - `ArmorDiagram.stories-BC7ASXx8.js` (19.95 kB)

## Notes

- All stories are additive — no underlying components were modified.
- DnD/Theme/Zustand/Router/Electron decorators are wired globally in `.storybook/preview.ts`, so per-story decoration is minimal.
- One commit per story file (5 commits) for clean review.

## Test plan

- [ ] CI typecheck passes
- [ ] CI lint passes
- [ ] CI storybook build passes
- [ ] Manual review of each story renders correctly (Storybook UI)