### PR TITLE
Close remaining session debt

### DIFF
--- a/src/__tests__/components/mobile/BottomNavBar.test.tsx
+++ b/src/__tests__/components/mobile/BottomNavBar.test.tsx
@@ -3,7 +3,11 @@ import React from 'react';
 
 import { BottomNavBar, Tab } from '@/components/mobile/BottomNavBar';
 import { useDeviceType } from '@/hooks/useDeviceType';
-import { useNavigationStore, PanelId } from '@/stores/useNavigationStore';
+import {
+  useNavigationStore,
+  useNavigationSelector,
+  PanelId,
+} from '@/stores/useNavigationStore';
 
 // Mock dependencies
 jest.mock('../../../stores/useNavigationStore');
@@ -14,6 +18,8 @@ describe('BottomNavBar', () => {
   const mockUseNavigationStore = useNavigationStore as jest.MockedFunction<
     typeof useNavigationStore
   >;
+  const mockUseNavigationSelector =
+    useNavigationSelector as jest.MockedFunction<typeof useNavigationSelector>;
   const mockUseDeviceType = useDeviceType as jest.MockedFunction<
     typeof useDeviceType
   >;
@@ -63,6 +69,10 @@ describe('BottomNavBar', () => {
       resetNavigation: jest.fn(),
       replacePanel: jest.fn(),
     });
+
+    mockUseNavigationSelector.mockImplementation((selector) =>
+      selector(mockUseNavigationStore()),
+    );
   });
 
   afterEach(() => {

--- a/src/__tests__/components/mobile/PanelStack.test.tsx
+++ b/src/__tests__/components/mobile/PanelStack.test.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 
 import { PanelStack, Panel } from '@/components/mobile/PanelStack';
 import { useDeviceType } from '@/hooks/useDeviceType';
-import { useNavigationStore } from '@/stores/useNavigationStore';
+import {
+  useNavigationStore,
+  useNavigationSelector,
+} from '@/stores/useNavigationStore';
 
 // Mock dependencies
 jest.mock('../../../stores/useNavigationStore');
@@ -13,6 +16,8 @@ describe('PanelStack', () => {
   const mockUseNavigationStore = useNavigationStore as jest.MockedFunction<
     typeof useNavigationStore
   >;
+  const mockUseNavigationSelector =
+    useNavigationSelector as jest.MockedFunction<typeof useNavigationSelector>;
   const mockUseDeviceType = useDeviceType as jest.MockedFunction<
     typeof useDeviceType
   >;
@@ -41,6 +46,10 @@ describe('PanelStack', () => {
       resetNavigation: jest.fn(),
       replacePanel: jest.fn(),
     });
+
+    mockUseNavigationSelector.mockImplementation((selector) =>
+      selector(mockUseNavigationStore()),
+    );
   });
 
   afterEach(() => {

--- a/src/__tests__/hooks/useEquipmentBrowser.test.ts
+++ b/src/__tests__/hooks/useEquipmentBrowser.test.ts
@@ -7,13 +7,18 @@
 import { renderHook, act } from '@testing-library/react';
 
 import { useEquipmentBrowser } from '@/hooks/useEquipmentBrowser';
-import { useEquipmentStore, SortColumn } from '@/stores/useEquipmentStore';
+import {
+  useEquipmentStore,
+  useEquipmentSelector,
+  SortColumn,
+} from '@/stores/useEquipmentStore';
 import { TechBase } from '@/types/enums/TechBase';
 import { EquipmentCategory } from '@/types/equipment';
 
 // Mock the equipment store
 jest.mock('@/stores/useEquipmentStore', () => ({
   useEquipmentStore: jest.fn(),
+  useEquipmentSelector: jest.fn(),
   SortColumn: {
     NAME: 'name',
     DAMAGE: 'damage',
@@ -39,6 +44,9 @@ jest.mock('@/types/equipment', () => {
 describe('useEquipmentBrowser Hook', () => {
   const mockUseEquipmentStore = useEquipmentStore as jest.MockedFunction<
     typeof useEquipmentStore
+  >;
+  const mockUseEquipmentSelector = useEquipmentSelector as jest.MockedFunction<
+    typeof useEquipmentSelector
   >;
   const mockEquipment = [
     { id: 'eq-1', name: 'Medium Laser', category: 'Energy' },
@@ -94,6 +102,9 @@ describe('useEquipmentBrowser Hook', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseEquipmentStore.mockReturnValue(createMockStore());
+    mockUseEquipmentSelector.mockImplementation((selector) =>
+      selector(mockUseEquipmentStore()),
+    );
   });
 
   describe('Data Loading', () => {

--- a/src/__tests__/hooks/useUnit.test.ts
+++ b/src/__tests__/hooks/useUnit.test.ts
@@ -7,14 +7,21 @@
 import { renderHook, act } from '@testing-library/react';
 
 import { useUnit, useSelection, useUnitEditor } from '@/hooks/useUnit';
-import { useCustomizerStore } from '@/stores/useCustomizerStore';
-import { useMultiUnitStore } from '@/stores/useMultiUnitStore';
+import {
+  useCustomizerStore,
+  useCustomizerSelector,
+} from '@/stores/useCustomizerStore';
+import {
+  useMultiUnitStore,
+  useMultiUnitSelector,
+} from '@/stores/useMultiUnitStore';
 import { MechLocation } from '@/types/construction';
 import { TechBase } from '@/types/enums/TechBase';
 
 // Mock the stores
 jest.mock('@/stores/useMultiUnitStore', () => ({
   useMultiUnitStore: jest.fn(),
+  useMultiUnitSelector: jest.fn(),
   UNIT_TEMPLATES: [
     { tonnage: 20, name: 'Light' },
     { tonnage: 50, name: 'Medium' },
@@ -25,11 +32,15 @@ jest.mock('@/stores/useMultiUnitStore', () => ({
 
 jest.mock('@/stores/useCustomizerStore', () => ({
   useCustomizerStore: jest.fn(),
+  useCustomizerSelector: jest.fn(),
 }));
 
 describe('useUnit Hook', () => {
   const mockUseMultiUnitStore = useMultiUnitStore as jest.MockedFunction<
     typeof useMultiUnitStore
+  >;
+  const mockUseMultiUnitSelector = useMultiUnitSelector as jest.MockedFunction<
+    typeof useMultiUnitSelector
   >;
 
   const mockMultiUnitStore = {
@@ -53,6 +64,9 @@ describe('useUnit Hook', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseMultiUnitStore.mockReturnValue(mockMultiUnitStore);
+    mockUseMultiUnitSelector.mockImplementation((selector) =>
+      selector(mockUseMultiUnitStore()),
+    );
   });
 
   it('should return current tab', () => {
@@ -229,6 +243,8 @@ describe('useSelection Hook', () => {
   const mockUseCustomizerStore = useCustomizerStore as jest.MockedFunction<
     typeof useCustomizerStore
   >;
+  const mockUseCustomizerSelector =
+    useCustomizerSelector as jest.MockedFunction<typeof useCustomizerSelector>;
 
   const mockCustomizerStore = {
     selectedEquipment: {
@@ -248,6 +264,9 @@ describe('useSelection Hook', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseCustomizerStore.mockReturnValue(mockCustomizerStore);
+    mockUseCustomizerSelector.mockImplementation((selector) =>
+      selector(mockUseCustomizerStore()),
+    );
   });
 
   it('should return selected equipment', () => {
@@ -319,6 +338,11 @@ describe('useUnitEditor Hook', () => {
   const mockUseCustomizerStore = useCustomizerStore as jest.MockedFunction<
     typeof useCustomizerStore
   >;
+  const mockUseMultiUnitSelector = useMultiUnitSelector as jest.MockedFunction<
+    typeof useMultiUnitSelector
+  >;
+  const mockUseCustomizerSelector =
+    useCustomizerSelector as jest.MockedFunction<typeof useCustomizerSelector>;
 
   const mockMultiUnitStore = {
     tabs: [{ id: 'tab-1', name: 'Atlas', isModified: false, tonnage: 100 }],
@@ -348,6 +372,12 @@ describe('useUnitEditor Hook', () => {
     jest.clearAllMocks();
     mockUseMultiUnitStore.mockReturnValue(mockMultiUnitStore);
     mockUseCustomizerStore.mockReturnValue(mockCustomizerStore);
+    mockUseMultiUnitSelector.mockImplementation((selector) =>
+      selector(mockUseMultiUnitStore()),
+    );
+    mockUseCustomizerSelector.mockImplementation((selector) =>
+      selector(mockUseCustomizerStore()),
+    );
   });
 
   it('should return combined unit and selection context', () => {

--- a/src/__tests__/pages/settings.test.tsx
+++ b/src/__tests__/pages/settings.test.tsx
@@ -97,6 +97,28 @@ jest.mock('@/lib/p2p/useSyncRoomStore', () => ({
     error: null,
     clearError: jest.fn(),
   }),
+  useSyncRoomSelector: (
+    selector: (state: {
+      localPeerName: string;
+      localPeerId: string;
+      setLocalPeerName: jest.Mock;
+      createRoom: jest.Mock;
+      joinRoom: jest.Mock;
+      leaveRoom: jest.Mock;
+      error: string | null;
+      clearError: jest.Mock;
+    }) => unknown,
+  ) =>
+    selector({
+      localPeerName: 'TestPeer',
+      localPeerId: 'test-peer-id',
+      setLocalPeerName: jest.fn(),
+      createRoom: jest.fn(),
+      joinRoom: jest.fn(),
+      leaveRoom: jest.fn(),
+      error: null,
+      clearError: jest.fn(),
+    }),
   useConnectionState: () => 'disconnected',
   usePeers: () => [],
   useRoomCode: () => null,

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { useThemeStore } from '@/stores/useThemeStore';
+import { useThemeSelector } from '@/stores/useThemeStore';
 
 const SunIcon: React.FC<{ className?: string }> = ({ className }) => (
   <svg
@@ -49,7 +49,9 @@ export interface IThemeToggleProps {
 export const ThemeToggle: React.FC<IThemeToggleProps> = ({
   className = '',
 }) => {
-  const { theme, toggleTheme, applyTheme } = useThemeStore();
+  const theme = useThemeSelector((state) => state.theme);
+  const toggleTheme = useThemeSelector((state) => state.toggleTheme);
+  const applyTheme = useThemeSelector((state) => state.applyTheme);
 
   useEffect(() => {
     applyTheme();

--- a/src/components/armor/ArmorDiagramModeSwitch.tsx
+++ b/src/components/armor/ArmorDiagramModeSwitch.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {
-  useAppSettingsStore,
+  useAppSettingsSelector,
   ArmorDiagramMode,
 } from '@/stores/useAppSettingsStore';
 
@@ -9,7 +9,12 @@ import {
  * Toggle switch for armor diagram mode (Schematic vs Silhouette)
  */
 export function ArmorDiagramModeSwitch(): React.ReactElement {
-  const { armorDiagramMode, setArmorDiagramMode } = useAppSettingsStore();
+  const armorDiagramMode = useAppSettingsSelector(
+    (state) => state.armorDiagramMode,
+  );
+  const setArmorDiagramMode = useAppSettingsSelector(
+    (state) => state.setArmorDiagramMode,
+  );
 
   const modes: { id: ArmorDiagramMode; label: string }[] = [
     { id: 'schematic', label: 'Schematic' },

--- a/src/components/armor/__tests__/ArmorDiagramModeSwitch.test.tsx
+++ b/src/components/armor/__tests__/ArmorDiagramModeSwitch.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
-import { useAppSettingsStore } from '@/stores/useAppSettingsStore';
+import {
+  useAppSettingsStore,
+  useAppSettingsSelector,
+} from '@/stores/useAppSettingsStore';
 
 import { ArmorDiagramModeSwitch } from '../ArmorDiagramModeSwitch';
 
@@ -10,6 +13,8 @@ jest.mock('@/stores/useAppSettingsStore');
 const mockUseAppSettingsStore = useAppSettingsStore as jest.MockedFunction<
   typeof useAppSettingsStore
 >;
+const mockUseAppSettingsSelector =
+  useAppSettingsSelector as jest.MockedFunction<typeof useAppSettingsSelector>;
 
 describe('ArmorDiagramModeSwitch', () => {
   const mockSetArmorDiagramMode = jest.fn();
@@ -20,6 +25,9 @@ describe('ArmorDiagramModeSwitch', () => {
       armorDiagramMode: 'silhouette',
       setArmorDiagramMode: mockSetArmorDiagramMode,
     } as ReturnType<typeof useAppSettingsStore>);
+    mockUseAppSettingsSelector.mockImplementation((selector) =>
+      selector(mockUseAppSettingsStore()),
+    );
   });
 
   it('should render mode options', () => {

--- a/src/components/common/TopBar.tsx
+++ b/src/components/common/TopBar.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router';
  */
 import React, { useState, useEffect } from 'react';
 
-import { useMobileSidebarStore } from '@/stores/useNavigationStore';
+import { useMobileSidebarSelector } from '@/stores/useNavigationStore';
 
 import {
   MekStationIcon,
@@ -34,11 +34,9 @@ type DropdownId = 'browse' | 'tools' | 'gameplay' | null;
 
 const TopBar: React.FC = () => {
   const router = useRouter();
-  const {
-    isOpen: isMobileOpen,
-    open: openMobile,
-    close: closeMobile,
-  } = useMobileSidebarStore();
+  const isMobileOpen = useMobileSidebarSelector((state) => state.isOpen);
+  const openMobile = useMobileSidebarSelector((state) => state.open);
+  const closeMobile = useMobileSidebarSelector((state) => state.close);
 
   // Single state to track which dropdown is open (only one at a time)
   const [openDropdown, setOpenDropdown] = useState<DropdownId>(null);

--- a/src/components/customizer/armor/ArmorDiagram.tsx
+++ b/src/components/customizer/armor/ArmorDiagram.tsx
@@ -12,7 +12,7 @@ import React, { useState } from 'react';
 import type { LocationArmorData } from '@/types/construction/LocationArmorData';
 
 import { SchematicDiagram } from '@/components/armor/schematic';
-import { useAppSettingsStore } from '@/stores/useAppSettingsStore';
+import { useAppSettingsSelector } from '@/stores/useAppSettingsStore';
 import { MechLocation } from '@/types/construction';
 
 import { ArmorLegend } from './ArmorLegend';
@@ -44,7 +44,9 @@ export function ArmorDiagram({
   const [hoveredLocation, setHoveredLocation] = useState<MechLocation | null>(
     null,
   );
-  const { armorDiagramMode } = useAppSettingsStore();
+  const armorDiagramMode = useAppSettingsSelector(
+    (state) => state.armorDiagramMode,
+  );
 
   const getArmorData = (
     location: MechLocation,

--- a/src/components/customizer/armor/__tests__/ArmorDiagram.test.tsx
+++ b/src/components/customizer/armor/__tests__/ArmorDiagram.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { useAppSettingsStore } from '@/stores/useAppSettingsStore';
+import {
+  useAppSettingsStore,
+  useAppSettingsSelector,
+} from '@/stores/useAppSettingsStore';
 import { MechLocation } from '@/types/construction';
 
 import { ArmorDiagram } from '../ArmorDiagram';
@@ -11,6 +14,8 @@ jest.mock('@/stores/useAppSettingsStore');
 const mockUseAppSettingsStore = useAppSettingsStore as jest.MockedFunction<
   typeof useAppSettingsStore
 >;
+const mockUseAppSettingsSelector =
+  useAppSettingsSelector as jest.MockedFunction<typeof useAppSettingsSelector>;
 
 describe('ArmorDiagram', () => {
   const mockArmorData = [
@@ -51,6 +56,9 @@ describe('ArmorDiagram', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseAppSettingsSelector.mockImplementation((selector) =>
+      selector(mockUseAppSettingsStore()),
+    );
   });
 
   describe('mode switching', () => {

--- a/src/components/gameplay/CombatPlanningPanel.stories.tsx
+++ b/src/components/gameplay/CombatPlanningPanel.stories.tsx
@@ -1,0 +1,275 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+
+import { fn } from '@storybook/test';
+import { useEffect } from 'react';
+
+import type { IWeapon } from '@/simulation/ai/types';
+
+import { useGameplayStore } from '@/stores/useGameplayStore';
+import {
+  DEFAULT_UI_STATE,
+  Facing,
+  GamePhase,
+  GameSide,
+  GameStatus,
+  LockState,
+  MovementType,
+  type IGameSession,
+  type IGameUnit,
+  type IUnitGameState,
+} from '@/types/gameplay';
+
+import { CombatPlanningPanel } from './CombatPlanningPanel';
+
+const weapons: readonly IWeapon[] = [
+  {
+    id: 'ac20',
+    name: 'AC/20',
+    shortRange: 3,
+    mediumRange: 6,
+    longRange: 9,
+    damage: 20,
+    heat: 7,
+    minRange: 0,
+    ammoPerTon: 5,
+    destroyed: false,
+  },
+  {
+    id: 'medium-laser',
+    name: 'Medium Laser',
+    shortRange: 3,
+    mediumRange: 6,
+    longRange: 9,
+    damage: 5,
+    heat: 3,
+    minRange: 0,
+    ammoPerTon: -1,
+    destroyed: false,
+  },
+  {
+    id: 'lrm20',
+    name: 'LRM 20',
+    shortRange: 7,
+    mediumRange: 14,
+    longRange: 21,
+    damage: 20,
+    heat: 6,
+    minRange: 6,
+    ammoPerTon: 6,
+    destroyed: false,
+  },
+];
+
+const units: readonly IGameUnit[] = [
+  {
+    id: 'atlas',
+    name: 'Atlas AS7-D',
+    side: GameSide.Player,
+    unitRef: 'atlas-as7-d',
+    pilotRef: 'major-vale',
+    gunnery: 3,
+    piloting: 4,
+    heatSinks: 20,
+    heatSinkType: 'double',
+  },
+  {
+    id: 'hunchback',
+    name: 'Hunchback HBK-4G',
+    side: GameSide.Opponent,
+    unitRef: 'hunchback-hbk-4g',
+    pilotRef: 'captain-rhee',
+    gunnery: 4,
+    piloting: 5,
+    heatSinks: 10,
+  },
+];
+
+function createUnitState(
+  id: string,
+  side: GameSide,
+  position: { q: number; r: number },
+  lockState: LockState,
+): IUnitGameState {
+  return {
+    id,
+    side,
+    position,
+    facing: side === GameSide.Player ? Facing.North : Facing.South,
+    heat: side === GameSide.Player ? 7 : 2,
+    movementThisTurn: MovementType.Walk,
+    hexesMovedThisTurn: side === GameSide.Player ? 2 : 0,
+    armor: {
+      head: 9,
+      center_torso: 47,
+      center_torso_rear: 14,
+      left_torso: 32,
+      left_torso_rear: 10,
+      right_torso: 32,
+      right_torso_rear: 10,
+      left_arm: 34,
+      right_arm: 34,
+      left_leg: 42,
+      right_leg: 42,
+    },
+    structure: {
+      head: 3,
+      center_torso: 31,
+      left_torso: 21,
+      right_torso: 21,
+      left_arm: 17,
+      right_arm: 17,
+      left_leg: 21,
+      right_leg: 21,
+    },
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {
+      ac20: 4,
+      lrm20: 8,
+    },
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState,
+  };
+}
+
+function createSession(
+  phase: GamePhase,
+  attackerLocked: boolean,
+): IGameSession {
+  const playerLockState = attackerLocked
+    ? LockState.Locked
+    : LockState.Planning;
+  return {
+    id: 'storybook-combat-session',
+    createdAt: '2026-04-29T03:00:00.000Z',
+    updatedAt: '2026-04-29T03:14:00.000Z',
+    config: {
+      mapRadius: 5,
+      turnLimit: 12,
+      victoryConditions: ['destroy_opponent'],
+      optionalRules: [],
+    },
+    units,
+    events: [],
+    currentState: {
+      gameId: 'storybook-combat-session',
+      status: GameStatus.Active,
+      turn: 2,
+      phase,
+      activationIndex: 0,
+      initiativeWinner: GameSide.Player,
+      firstMover: GameSide.Opponent,
+      units: {
+        atlas: createUnitState(
+          'atlas',
+          GameSide.Player,
+          { q: 0, r: 0 },
+          playerLockState,
+        ),
+        hunchback: createUnitState(
+          'hunchback',
+          GameSide.Opponent,
+          { q: 3, r: -1 },
+          LockState.Pending,
+        ),
+      },
+      turnEvents: [],
+    },
+  };
+}
+
+const GameplayStoreDecorator: Decorator = (Story, context) => {
+  const phase =
+    context.parameters.gameplayPhase === GamePhase.WeaponAttack
+      ? GamePhase.WeaponAttack
+      : context.parameters.gameplayPhase === GamePhase.PhysicalAttack
+        ? GamePhase.PhysicalAttack
+        : GamePhase.Movement;
+  const attackerLocked = context.parameters.attackerLocked === true;
+
+  useEffect(() => {
+    useGameplayStore.getState().reset();
+    useGameplayStore.setState({
+      session: createSession(phase, attackerLocked),
+      ui: {
+        ...DEFAULT_UI_STATE,
+        selectedUnitId: 'atlas',
+        targetUnitId: phase === GamePhase.Movement ? null : 'hunchback',
+      },
+      plannedMovement:
+        phase === GamePhase.Movement
+          ? {
+              destination: { q: 1, r: 0 },
+              facing: Facing.Northeast,
+              movementType: MovementType.Walk,
+              path: [
+                { q: 0, r: 0 },
+                { q: 1, r: 0 },
+              ],
+            }
+          : null,
+      attackPlan:
+        phase === GamePhase.Movement
+          ? { targetUnitId: null, selectedWeapons: [] }
+          : { targetUnitId: 'hunchback', selectedWeapons: ['ac20'] },
+      previewEnabled: true,
+    });
+
+    return () => {
+      useGameplayStore.getState().reset();
+    };
+  }, [attackerLocked, phase]);
+
+  return <Story />;
+};
+
+const meta: Meta<typeof CombatPlanningPanel> = {
+  title: 'Gameplay/CombatPlanningPanel',
+  component: CombatPlanningPanel,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    gameplayPhase: GamePhase.Movement,
+  },
+  decorators: [
+    GameplayStoreDecorator,
+    (Story) => (
+      <div className="w-[520px] max-w-full rounded-lg border border-gray-300 bg-white">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    walkMP: 3,
+    jumpMP: 0,
+    weapons,
+    attackerTonnage: 100,
+    onPhysicalAttackIntentChange: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CombatPlanningPanel>;
+
+export const MovementPlanning: Story = {};
+
+export const WeaponAttackPlanning: Story = {
+  parameters: {
+    gameplayPhase: GamePhase.WeaponAttack,
+  },
+};
+
+export const LockedWeaponAttack: Story = {
+  parameters: {
+    gameplayPhase: GamePhase.WeaponAttack,
+    attackerLocked: true,
+  },
+};
+
+export const PhysicalAttackPlanning: Story = {
+  parameters: {
+    gameplayPhase: GamePhase.PhysicalAttack,
+  },
+};

--- a/src/components/gameplay/EventLogDisplay.stories.tsx
+++ b/src/components/gameplay/EventLogDisplay.stories.tsx
@@ -1,0 +1,172 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { fn } from '@storybook/test';
+
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  Facing,
+  MovementType,
+  type IGameEvent,
+} from '@/types/gameplay';
+
+import { EventLogDisplay } from './EventLogDisplay';
+
+const events: readonly IGameEvent[] = [
+  {
+    id: 'event-1',
+    gameId: 'story-game',
+    sequence: 1,
+    timestamp: '2026-04-29T03:00:00.000Z',
+    type: GameEventType.TurnStarted,
+    turn: 1,
+    phase: GamePhase.Initiative,
+    payload: {},
+  },
+  {
+    id: 'event-2',
+    gameId: 'story-game',
+    sequence: 2,
+    timestamp: '2026-04-29T03:01:00.000Z',
+    type: GameEventType.PhaseChanged,
+    turn: 1,
+    phase: GamePhase.Movement,
+    payload: {
+      fromPhase: GamePhase.Initiative,
+      toPhase: GamePhase.Movement,
+    },
+  },
+  {
+    id: 'event-3',
+    gameId: 'story-game',
+    sequence: 3,
+    timestamp: '2026-04-29T03:03:00.000Z',
+    type: GameEventType.MovementDeclared,
+    turn: 1,
+    phase: GamePhase.Movement,
+    actorId: 'atlas',
+    payload: {
+      unitId: 'atlas',
+      from: { q: 0, r: 0 },
+      to: { q: 1, r: 0 },
+      facing: Facing.Northeast,
+      movementType: MovementType.Walk,
+      mpUsed: 2,
+      heatGenerated: 0,
+    },
+  },
+  {
+    id: 'event-4',
+    gameId: 'story-game',
+    sequence: 4,
+    timestamp: '2026-04-29T03:06:00.000Z',
+    type: GameEventType.AttackResolved,
+    turn: 1,
+    phase: GamePhase.WeaponAttack,
+    actorId: 'atlas',
+    payload: {
+      attackerId: 'atlas',
+      targetId: 'hunchback',
+      weaponId: 'ac20',
+      roll: 9,
+      toHitNumber: 7,
+      hit: true,
+      location: 'center_torso',
+      damage: 20,
+      heat: 7,
+      attackerArc: 'front',
+      ammoBinId: 'ac20-bin-1',
+    },
+  },
+  {
+    id: 'event-5',
+    gameId: 'story-game',
+    sequence: 5,
+    timestamp: '2026-04-29T03:06:05.000Z',
+    type: GameEventType.DamageApplied,
+    turn: 1,
+    phase: GamePhase.WeaponAttack,
+    actorId: 'atlas',
+    payload: {
+      unitId: 'hunchback',
+      location: 'center_torso',
+      damage: 20,
+      armorRemaining: 0,
+      structureRemaining: 8,
+      locationDestroyed: false,
+      sourceUnitId: 'atlas',
+      attackId: 'atlas',
+    },
+  },
+  {
+    id: 'event-6',
+    gameId: 'story-game',
+    sequence: 6,
+    timestamp: '2026-04-29T03:08:00.000Z',
+    type: GameEventType.HeatGenerated,
+    turn: 1,
+    phase: GamePhase.Heat,
+    actorId: 'atlas',
+    payload: {
+      unitId: 'atlas',
+      amount: 7,
+      source: 'firing',
+      newTotal: 7,
+    },
+  },
+];
+
+const meta: Meta<typeof EventLogDisplay> = {
+  title: 'Gameplay/EventLogDisplay',
+  component: EventLogDisplay,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[780px] max-w-full rounded-lg border border-gray-300 bg-white">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    events,
+    actorLookup: {
+      atlas: 'AS7-D',
+      hunchback: 'HBK-4G',
+    },
+    weaponLookup: {
+      ac20: 'AC/20',
+    },
+    maxHeight: 280,
+    onFilterChange: fn(),
+    onCollapsedChange: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EventLogDisplay>;
+
+export const CombatSequence: Story = {};
+
+export const Collapsed: Story = {
+  args: {
+    collapsed: true,
+  },
+};
+
+export const FilteredToAttackPhase: Story = {
+  args: {
+    filter: {
+      eventTypes: [GameEventType.AttackResolved, GameEventType.DamageApplied],
+    },
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    events: [],
+  },
+};

--- a/src/components/gameplay/HexMapDisplay.stories.tsx
+++ b/src/components/gameplay/HexMapDisplay.stories.tsx
@@ -389,3 +389,119 @@ export const WithOverlays: Story = {
     },
   },
 };
+
+const movementOverlayToken: IUnitToken = {
+  ...overlayToken,
+  unitId: 'griffin-move',
+  name: 'Griffin GRF-1N',
+  designation: 'G1',
+  position: { q: -1, r: 0 },
+  facing: Facing.Northeast,
+};
+
+const attackOverlayTokens: IUnitToken[] = [
+  {
+    ...overlayToken,
+    unitId: 'warhammer-attacker',
+    name: 'Warhammer WHM-6R',
+    designation: 'W6',
+    position: { q: 0, r: 0 },
+    facing: Facing.Northeast,
+    isSelected: true,
+  },
+  {
+    ...overlayToken,
+    unitId: 'hunchback-target',
+    name: 'Hunchback HBK-4G',
+    designation: 'H4',
+    position: { q: 3, r: -1 },
+    facing: Facing.Southwest,
+    side: GameSide.Opponent,
+    isSelected: false,
+    isValidTarget: true,
+    isActiveTarget: true,
+  },
+  {
+    ...overlayToken,
+    unitId: 'locust-target',
+    name: 'Locust LCT-1V',
+    designation: 'L1',
+    position: { q: 2, r: 1 },
+    facing: Facing.Northwest,
+    side: GameSide.Opponent,
+    isSelected: false,
+    isValidTarget: true,
+  },
+];
+
+export const MovementAndPathOverlay: Story = {
+  args: {
+    radius: 4,
+    tokens: [movementOverlayToken],
+    selectedHex: { q: -1, r: 0 },
+    hexTerrain: overlayTerrain,
+    showCoordinates: true,
+    movementRange: [
+      {
+        hex: { q: 0, r: 0 },
+        mpCost: 1,
+        reachable: true,
+        movementType: MovementType.Walk,
+      },
+      {
+        hex: { q: 1, r: 0 },
+        mpCost: 2,
+        reachable: true,
+        movementType: MovementType.Walk,
+      },
+      {
+        hex: { q: 2, r: 0 },
+        mpCost: 4,
+        reachable: true,
+        movementType: MovementType.Run,
+      },
+      {
+        hex: { q: 2, r: -1 },
+        mpCost: 5,
+        reachable: false,
+        movementType: MovementType.Run,
+      },
+      {
+        hex: { q: 0, r: 2 },
+        mpCost: 3,
+        reachable: true,
+        movementType: MovementType.Jump,
+      },
+    ],
+    highlightPath: [
+      { q: -1, r: 0 },
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+      { q: 2, r: 0 },
+    ],
+    hoverMpCost: 4,
+    mpLegend: {
+      active: 'run',
+      jumpAvailable: true,
+    },
+  },
+};
+
+export const AttackTargetOverlay: Story = {
+  args: {
+    radius: 4,
+    tokens: attackOverlayTokens,
+    selectedHex: { q: 0, r: 0 },
+    hexTerrain: overlayTerrain,
+    showCoordinates: true,
+    attackRange: [
+      { q: 1, r: 0 },
+      { q: 2, r: 0 },
+      { q: 3, r: -1 },
+      { q: 2, r: 1 },
+      { q: 1, r: -1 },
+      { q: 0, r: 1 },
+      { q: -1, r: 1 },
+    ],
+  },
+};

--- a/src/components/gameplay/RecordSheetDisplay.stories.tsx
+++ b/src/components/gameplay/RecordSheetDisplay.stories.tsx
@@ -1,0 +1,232 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { fn } from '@storybook/test';
+
+import {
+  Facing,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  LockState,
+  MovementType,
+  type IGameEvent,
+  type IUnitGameState,
+  type IWeaponStatus,
+} from '@/types/gameplay';
+
+import { RecordSheetDisplay } from './RecordSheetDisplay';
+
+const maxArmor: Record<string, number> = {
+  head: 9,
+  center_torso: 47,
+  center_torso_rear: 14,
+  left_torso: 32,
+  left_torso_rear: 10,
+  right_torso: 32,
+  right_torso_rear: 10,
+  left_arm: 34,
+  right_arm: 34,
+  left_leg: 42,
+  right_leg: 42,
+};
+
+const maxStructure: Record<string, number> = {
+  head: 3,
+  center_torso: 31,
+  left_torso: 21,
+  right_torso: 21,
+  left_arm: 17,
+  right_arm: 17,
+  left_leg: 21,
+  right_leg: 21,
+};
+
+const atlasState: IUnitGameState = {
+  id: 'atlas',
+  side: GameSide.Player,
+  position: { q: 0, r: 0 },
+  facing: Facing.North,
+  heat: 7,
+  movementThisTurn: MovementType.Walk,
+  hexesMovedThisTurn: 2,
+  armor: {
+    ...maxArmor,
+    center_torso: 31,
+    right_torso: 18,
+    right_arm: 12,
+  },
+  structure: {
+    ...maxStructure,
+    right_arm: 9,
+  },
+  destroyedLocations: [],
+  destroyedEquipment: ['small-laser-ra'],
+  ammo: {
+    ac20: 4,
+    lrm20: 8,
+    srm6: 10,
+  },
+  pilotWounds: 1,
+  pilotConscious: true,
+  destroyed: false,
+  lockState: LockState.Planning,
+};
+
+const weapons: readonly IWeaponStatus[] = [
+  {
+    id: 'ac20',
+    name: 'AC/20',
+    location: 'right_torso',
+    destroyed: false,
+    firedThisTurn: true,
+    ammoRemaining: 4,
+    ammoMax: 10,
+    heat: 7,
+    damage: 20,
+    ranges: { short: 3, medium: 6, long: 9 },
+  },
+  {
+    id: 'lrm20',
+    name: 'LRM 20',
+    location: 'left_torso',
+    destroyed: false,
+    firedThisTurn: false,
+    ammoRemaining: 8,
+    ammoMax: 12,
+    heat: 6,
+    damage: '20 clusters',
+    ranges: { minimum: 6, short: 7, medium: 14, long: 21 },
+  },
+  {
+    id: 'mlas-ct',
+    name: 'Medium Laser',
+    location: 'center_torso',
+    destroyed: false,
+    firedThisTurn: false,
+    heat: 3,
+    damage: 5,
+    ranges: { short: 3, medium: 6, long: 9 },
+  },
+  {
+    id: 'small-laser-ra',
+    name: 'Small Laser',
+    location: 'right_arm',
+    destroyed: true,
+    firedThisTurn: false,
+    heat: 1,
+    damage: 3,
+    ranges: { short: 1, medium: 2, long: 3 },
+  },
+];
+
+const recentEvents: readonly IGameEvent[] = [
+  {
+    id: 'damage-atlas-ra',
+    gameId: 'story-game',
+    sequence: 11,
+    timestamp: '2026-04-29T03:08:00.000Z',
+    type: GameEventType.DamageApplied,
+    turn: 2,
+    phase: GamePhase.WeaponAttack,
+    payload: {
+      unitId: 'atlas',
+      location: 'right_arm',
+      damage: 14,
+      armorRemaining: 12,
+      structureRemaining: 9,
+      locationDestroyed: false,
+      sourceUnitId: 'hunchback',
+      attackId: 'hunchback-ac20',
+    },
+  },
+  {
+    id: 'pilot-atlas',
+    gameId: 'story-game',
+    sequence: 12,
+    timestamp: '2026-04-29T03:08:05.000Z',
+    type: GameEventType.PilotHit,
+    turn: 2,
+    phase: GamePhase.WeaponAttack,
+    payload: {
+      unitId: 'atlas',
+      wounds: 1,
+      totalWounds: 1,
+      source: 'head_hit',
+      consciousnessCheckRequired: true,
+      consciousnessCheckPassed: true,
+    },
+  },
+];
+
+const meta: Meta<typeof RecordSheetDisplay> = {
+  title: 'Gameplay/RecordSheetDisplay',
+  component: RecordSheetDisplay,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[760px] w-[520px] max-w-full overflow-hidden rounded-lg border border-gray-700">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    unitName: 'Atlas AS7-D',
+    designation: 'AS7-D',
+    state: atlasState,
+    maxArmor,
+    maxStructure,
+    weapons,
+    pilotName: 'Major Tamsin Vale',
+    gunnery: 3,
+    piloting: 4,
+    heatSinks: 20,
+    selectedWeaponIds: ['ac20'],
+    onWeaponToggle: fn(),
+    side: GameSide.Player,
+    tonnage: 100,
+    chassis: 'Atlas',
+    unitId: 'atlas',
+    events: recentEvents,
+    spas: [
+      {
+        id: 'weapon-specialist-ac20',
+        displayLabel: 'Weapon Specialist (AC/20)',
+        description: 'Improves accuracy with the selected weapon family.',
+      },
+    ],
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RecordSheetDisplay>;
+
+export const DamagedAssaultMech: Story = {};
+
+export const DestroyedUnit: Story = {
+  args: {
+    state: {
+      ...atlasState,
+      armor: Object.fromEntries(
+        Object.keys(maxArmor).map((location) => [location, 0]),
+      ),
+      structure: Object.fromEntries(
+        Object.keys(maxStructure).map((location) => [location, 0]),
+      ),
+      destroyedLocations: [
+        'head',
+        'center_torso',
+        'left_torso',
+        'right_torso',
+        'left_arm',
+        'right_arm',
+        'left_leg',
+        'right_leg',
+      ],
+      destroyed: true,
+      pilotConscious: false,
+    },
+  },
+};

--- a/src/components/gameplay/ScenarioGenerator.stories.tsx
+++ b/src/components/gameplay/ScenarioGenerator.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { fn } from '@storybook/test';
+
+import { ScenarioObjectiveType } from '@/types/scenario';
+
+import { ScenarioGenerator } from './ScenarioGenerator';
+
+const meta: Meta<typeof ScenarioGenerator> = {
+  title: 'Gameplay/ScenarioGenerator',
+  component: ScenarioGenerator,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[760px] max-w-full">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    playerBV: 6450,
+    playerUnitCount: 4,
+    defaultScenarioType: ScenarioObjectiveType.Breakthrough,
+    onGenerate: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ScenarioGenerator>;
+
+export const Panel: Story = {};
+
+export const ModalLayout: Story = {
+  args: {
+    variant: 'modal',
+    playerBV: 9200,
+    playerUnitCount: 6,
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[980px] max-w-full">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const LowBVForce: Story = {
+  args: {
+    playerBV: 1800,
+    playerUnitCount: 1,
+  },
+};

--- a/src/components/gameplay/UnitToken/UnitTokenForType.stories.tsx
+++ b/src/components/gameplay/UnitToken/UnitTokenForType.stories.tsx
@@ -1,0 +1,213 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { ReactElement } from 'react';
+
+import { fn } from '@storybook/test';
+
+import {
+  Facing,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  InfantryMotiveType,
+  InfantryTokenSpecialization,
+  TokenUnitType,
+  VehicleMotionType,
+  type IGameEvent,
+  type IUnitToken,
+} from '@/types/gameplay';
+
+import { UnitTokenForType } from './UnitTokenForType';
+
+const tokenEvents: readonly IGameEvent[] = [
+  {
+    id: 'floater-damage',
+    gameId: 'story-game',
+    sequence: 21,
+    timestamp: '2026-04-29T03:11:00.000Z',
+    type: GameEventType.DamageApplied,
+    turn: 2,
+    phase: GamePhase.WeaponAttack,
+    payload: {
+      unitId: 'token-mech',
+      location: 'center_torso',
+      damage: 12,
+      armorRemaining: 9,
+      structureRemaining: 31,
+      locationDestroyed: false,
+      sourceUnitId: 'token-vehicle',
+      attackId: 'story-attack',
+    },
+  },
+  {
+    id: 'floater-crit',
+    gameId: 'story-game',
+    sequence: 22,
+    timestamp: '2026-04-29T03:11:05.000Z',
+    type: GameEventType.CriticalHitResolved,
+    turn: 2,
+    phase: GamePhase.WeaponAttack,
+    payload: {
+      unitId: 'token-mech',
+      location: 'center_torso',
+      slotIndex: 4,
+      componentType: 'engine',
+      componentName: 'Fusion Engine',
+      effect: 'Engine hit',
+      destroyed: false,
+    },
+  },
+];
+
+const tokens: readonly IUnitToken[] = [
+  {
+    unitId: 'token-mech',
+    name: 'Atlas AS7-D',
+    designation: 'AS7',
+    side: GameSide.Player,
+    position: { q: 0, r: 0 },
+    facing: Facing.North,
+    isSelected: true,
+    isValidTarget: false,
+    isDestroyed: false,
+    unitType: TokenUnitType.Mech,
+  },
+  {
+    unitId: 'token-vehicle',
+    name: 'Schrek PPC Carrier',
+    designation: 'SRK',
+    side: GameSide.Opponent,
+    position: { q: 1, r: -1 },
+    facing: Facing.South,
+    isSelected: false,
+    isValidTarget: true,
+    isActiveTarget: true,
+    isDestroyed: false,
+    unitType: TokenUnitType.Vehicle,
+    vehicleMotionType: VehicleMotionType.Tracked,
+    turretFacing: Facing.South,
+  },
+  {
+    unitId: 'token-aero',
+    name: 'Seydlitz SYD-21',
+    designation: 'SYD',
+    side: GameSide.Player,
+    position: { q: -1, r: 0 },
+    facing: Facing.Northeast,
+    isSelected: false,
+    isValidTarget: false,
+    isDestroyed: false,
+    unitType: TokenUnitType.Aerospace,
+    altitude: 5,
+    velocity: 8,
+  },
+  {
+    unitId: 'token-ba',
+    name: 'Elemental Point',
+    designation: 'BA',
+    side: GameSide.Player,
+    position: { q: 0, r: 1 },
+    facing: Facing.North,
+    isSelected: false,
+    isValidTarget: false,
+    isDestroyed: false,
+    unitType: TokenUnitType.BattleArmor,
+    trooperCount: 4,
+    jumpActive: true,
+    mountedOn: 'token-mech',
+  },
+  {
+    unitId: 'token-infantry',
+    name: 'Rifle Platoon',
+    designation: 'INF',
+    side: GameSide.Opponent,
+    position: { q: -1, r: 1 },
+    facing: Facing.Northwest,
+    isSelected: false,
+    isValidTarget: true,
+    isDestroyed: false,
+    unitType: TokenUnitType.Infantry,
+    infantryCount: 21,
+    platoonCount: 2,
+    infantryMotiveType: InfantryMotiveType.Jump,
+    infantrySpecialization: InfantryTokenSpecialization.AntiMech,
+  },
+  {
+    unitId: 'token-proto',
+    name: 'Roc Point',
+    designation: 'ROC',
+    side: GameSide.Player,
+    position: { q: 1, r: 0 },
+    facing: Facing.Southeast,
+    isSelected: false,
+    isValidTarget: false,
+    isDestroyed: false,
+    unitType: TokenUnitType.ProtoMech,
+    protoCount: 3,
+    isGlider: true,
+    hasMainGun: true,
+  },
+];
+
+const TokenCanvas = ({
+  visibleTokens,
+}: {
+  visibleTokens: readonly IUnitToken[];
+}): ReactElement => (
+  <svg
+    width="520"
+    height="420"
+    viewBox="-180 -150 360 300"
+    role="img"
+    aria-label="Unit token variants"
+    className="rounded-lg bg-slate-950"
+  >
+    <g>
+      {visibleTokens.map((token) => (
+        <UnitTokenForType
+          key={token.unitId}
+          token={token}
+          onClick={fn()}
+          onDoubleClick={fn()}
+          events={tokenEvents}
+          allTokens={visibleTokens}
+        />
+      ))}
+    </g>
+  </svg>
+);
+
+const meta: Meta<typeof UnitTokenForType> = {
+  title: 'Gameplay/UnitTokenForType',
+  component: UnitTokenForType,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof UnitTokenForType>;
+
+export const AllUnitTypes: Story = {
+  render: () => <TokenCanvas visibleTokens={tokens} />,
+};
+
+export const DestroyedVehicle: Story = {
+  render: () => (
+    <TokenCanvas
+      visibleTokens={[
+        {
+          ...tokens[1],
+          unitId: 'token-destroyed-vehicle',
+          isDestroyed: true,
+          isValidTarget: false,
+          isActiveTarget: false,
+        },
+      ]}
+    />
+  ),
+};
+
+export const MountedBattleArmor: Story = {
+  render: () => <TokenCanvas visibleTokens={[tokens[0], tokens[3]]} />,
+};

--- a/src/components/gameplay/__tests__/GameplayPhase2.a11y.test.tsx
+++ b/src/components/gameplay/__tests__/GameplayPhase2.a11y.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import React from 'react';
+
+import { RepairStatsOverview } from '@/components/gameplay/pages/repair/bay/RepairBayPage.sections';
+import { ScenarioGenerator } from '@/components/gameplay/ScenarioGenerator';
+import { ScenarioObjectiveType } from '@/types/scenario';
+
+describe('Gameplay Phase 2 a11y', () => {
+  it('has no axe violations for the scenario generator panel', async () => {
+    const { container } = render(
+      <ScenarioGenerator
+        playerBV={6450}
+        playerUnitCount={4}
+        defaultScenarioType={ScenarioObjectiveType.Breakthrough}
+        onGenerate={() => undefined}
+      />,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no axe violations for the repair stats overview', async () => {
+    const { container } = render(
+      <RepairStatsOverview
+        stats={{
+          active: 1,
+          pending: 3,
+          complete: 2,
+          totalCost: 58800,
+        }}
+      />,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/gameplay/pages/forces/detail/ForceDetailPage.tsx
+++ b/src/components/gameplay/pages/forces/detail/ForceDetailPage.tsx
@@ -10,8 +10,8 @@ import {
 import { useToast } from '@/components/shared/Toast';
 import { PageLayout, PageError } from '@/components/ui';
 import { unitSearchService } from '@/services/units/UnitSearchService';
-import { useForceStore } from '@/stores/useForceStore';
-import { usePilotStore } from '@/stores/usePilotStore';
+import { useForceSelector } from '@/stores/useForceStore';
+import { usePilotSelector } from '@/stores/usePilotStore';
 import { IForce, IForceValidation, getForceTypeName } from '@/types/force';
 import { IPilot, PilotStatus } from '@/types/pilot';
 import { IUnitIndexEntry } from '@/types/unit/UnitIndex';
@@ -31,22 +31,21 @@ export default function ForceDetailPage(): React.ReactElement {
   const forceId = typeof id === 'string' ? id : null;
   const { showToast } = useToast();
 
-  const {
-    loadForces,
-    getForce,
-    updateForce,
-    deleteForce,
-    validateForce,
-    assignPilot,
-    assignUnit,
-    clearAssignment,
-    swapAssignments,
-    isLoading: forceLoading,
-    error: forceError,
-    clearError: clearForceError,
-  } = useForceStore();
+  const loadForces = useForceSelector((state) => state.loadForces);
+  const getForce = useForceSelector((state) => state.getForce);
+  const updateForce = useForceSelector((state) => state.updateForce);
+  const deleteForce = useForceSelector((state) => state.deleteForce);
+  const validateForce = useForceSelector((state) => state.validateForce);
+  const assignPilot = useForceSelector((state) => state.assignPilot);
+  const assignUnit = useForceSelector((state) => state.assignUnit);
+  const clearAssignment = useForceSelector((state) => state.clearAssignment);
+  const swapAssignments = useForceSelector((state) => state.swapAssignments);
+  const forceLoading = useForceSelector((state) => state.isLoading);
+  const forceError = useForceSelector((state) => state.error);
+  const clearForceError = useForceSelector((state) => state.clearError);
 
-  const { loadPilots, pilots } = usePilotStore();
+  const loadPilots = usePilotSelector((state) => state.loadPilots);
+  const pilots = usePilotSelector((state) => state.pilots);
 
   const [isInitialized, setIsInitialized] = useState(false);
   const [allUnits, setAllUnits] = useState<IUnitIndexEntry[]>([]);

--- a/src/components/gameplay/pages/repair/bay/RepairBayPage.stories.tsx
+++ b/src/components/gameplay/pages/repair/bay/RepairBayPage.stories.tsx
@@ -1,0 +1,199 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+
+import { useEffect } from 'react';
+
+import { useRepairStore } from '@/stores/useRepairStore';
+import { PartQuality } from '@/types/campaign/quality';
+import {
+  DEFAULT_REPAIR_BAY,
+  RepairJobStatus,
+  RepairType,
+  UnitLocation,
+  type IRepairJob,
+} from '@/types/repair';
+
+import RepairBayPage from './RepairBayPage';
+
+const campaignId = 'story-campaign';
+
+const repairJobs: IRepairJob[] = [
+  {
+    id: 'repair-atlas-armor',
+    unitId: 'unit-atlas-as7-d',
+    unitName: 'Atlas AS7-D',
+    campaignId,
+    status: RepairJobStatus.Pending,
+    priority: 1,
+    createdAt: '2026-04-28T18:00:00.000Z',
+    totalCost: 14500,
+    totalTimeHours: 16,
+    timeRemainingHours: 16,
+    unitQuality: PartQuality.E,
+    items: [
+      {
+        id: 'repair-ct-armor',
+        type: RepairType.Armor,
+        location: UnitLocation.CenterTorso,
+        pointsToRestore: 22,
+        cost: 2200,
+        timeHours: 3,
+        selected: true,
+      },
+      {
+        id: 'repair-ra-structure',
+        type: RepairType.Structure,
+        location: UnitLocation.RightArm,
+        pointsToRestore: 8,
+        cost: 4000,
+        timeHours: 8,
+        selected: true,
+      },
+      {
+        id: 'repair-small-laser',
+        type: RepairType.ComponentReplace,
+        location: UnitLocation.RightArm,
+        componentName: 'Small Laser',
+        cost: 8300,
+        timeHours: 5,
+        selected: false,
+      },
+    ],
+  },
+  {
+    id: 'repair-centurion-engine',
+    unitId: 'unit-centurion-cn9-a',
+    unitName: 'Centurion CN9-A',
+    campaignId,
+    status: RepairJobStatus.InProgress,
+    priority: 2,
+    createdAt: '2026-04-27T15:00:00.000Z',
+    startedAt: '2026-04-29T01:00:00.000Z',
+    assignedTechId: 'tech-mara',
+    totalCost: 37500,
+    totalTimeHours: 42,
+    timeRemainingHours: 18,
+    unitQuality: PartQuality.D,
+    items: [
+      {
+        id: 'repair-engine-hit',
+        type: RepairType.ComponentRepair,
+        location: UnitLocation.CenterTorso,
+        componentName: 'Fusion Engine',
+        cost: 30000,
+        timeHours: 36,
+        selected: true,
+      },
+      {
+        id: 'repair-lt-structure',
+        type: RepairType.Structure,
+        location: UnitLocation.LeftTorso,
+        pointsToRestore: 5,
+        cost: 7500,
+        timeHours: 6,
+        selected: true,
+      },
+    ],
+  },
+  {
+    id: 'repair-shadow-hawk',
+    unitId: 'unit-shadow-hawk-shd-2h',
+    unitName: 'Shadow Hawk SHD-2H',
+    campaignId,
+    status: RepairJobStatus.Completed,
+    priority: 3,
+    createdAt: '2026-04-26T14:00:00.000Z',
+    startedAt: '2026-04-27T09:00:00.000Z',
+    completedAt: '2026-04-28T12:00:00.000Z',
+    totalCost: 6800,
+    totalTimeHours: 9,
+    timeRemainingHours: 0,
+    unitQuality: PartQuality.D,
+    items: [
+      {
+        id: 'repair-lrm-reload',
+        type: RepairType.ComponentRepair,
+        location: UnitLocation.LeftTorso,
+        componentName: 'LRM 5 feed mechanism',
+        cost: 6800,
+        timeHours: 9,
+        selected: true,
+      },
+    ],
+  },
+];
+
+const RepairStoreDecorator: Decorator = (Story) => {
+  useEffect(() => {
+    useRepairStore.setState({
+      jobsByCampaign: {
+        [campaignId]: repairJobs,
+      },
+      baysByCampaign: {
+        [campaignId]: {
+          ...DEFAULT_REPAIR_BAY,
+          activeJobs: ['repair-centurion-engine'],
+          queuedJobs: ['repair-atlas-armor'],
+        },
+      },
+      salvageByCampaign: {
+        [campaignId]: { parts: [], totalValue: 0 },
+      },
+      selectedJobId: 'repair-atlas-armor',
+      isLoading: false,
+      error: null,
+    });
+
+    return () => {
+      useRepairStore.setState({
+        jobsByCampaign: {},
+        baysByCampaign: {},
+        salvageByCampaign: {},
+        selectedJobId: null,
+        isLoading: false,
+        error: null,
+      });
+    };
+  }, []);
+
+  return <Story />;
+};
+
+const meta: Meta<typeof RepairBayPage> = {
+  title: 'Gameplay/RepairBayPage',
+  component: RepairBayPage,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    nextRouter: {
+      pathname: '/gameplay/repair',
+      query: { campaignId },
+    },
+  },
+  decorators: [RepairStoreDecorator],
+};
+
+export default meta;
+type Story = StoryObj<typeof RepairBayPage>;
+
+export const PopulatedRepairBay: Story = {};
+
+export const EmptyRepairBay: Story = {
+  decorators: [
+    (Story) => {
+      useEffect(() => {
+        useRepairStore.setState({
+          jobsByCampaign: { [campaignId]: [] },
+          baysByCampaign: { [campaignId]: { ...DEFAULT_REPAIR_BAY } },
+          salvageByCampaign: {
+            [campaignId]: { parts: [], totalValue: 0 },
+          },
+          selectedJobId: null,
+          isLoading: false,
+          error: null,
+        });
+      }, []);
+
+      return <Story />;
+    },
+  ],
+};

--- a/src/components/gameplay/pages/repair/bay/RepairBayPage.tsx
+++ b/src/components/gameplay/pages/repair/bay/RepairBayPage.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import { useCallback, useMemo } from 'react';
 
 import { PageLayout, PageLoading } from '@/components/ui';
-import { useRepairStore } from '@/stores/useRepairStore';
+import { useRepairSelector } from '@/stores/useRepairStore';
 import { RepairJobStatus, type IRepairJob } from '@/types/repair';
 import { logger } from '@/utils/logger';
 
@@ -33,22 +33,22 @@ export default function RepairBayPage(): React.ReactElement {
 
   const activeCampaignId = (campaignId as string) || 'demo-campaign';
 
-  const {
-    isLoading,
-    error,
-    selectedJobId,
-    getJobs,
-    getJob,
-    selectJob,
-    startJob,
-    cancelJob,
-    toggleRepairItem,
-    selectAllItems,
-    deselectAllItems,
-    reorderJobs,
-    initializeCampaign,
-    clearError,
-  } = useRepairStore();
+  const isLoading = useRepairSelector((state) => state.isLoading);
+  const error = useRepairSelector((state) => state.error);
+  const selectedJobId = useRepairSelector((state) => state.selectedJobId);
+  const getJobs = useRepairSelector((state) => state.getJobs);
+  const getJob = useRepairSelector((state) => state.getJob);
+  const selectJob = useRepairSelector((state) => state.selectJob);
+  const startJob = useRepairSelector((state) => state.startJob);
+  const cancelJob = useRepairSelector((state) => state.cancelJob);
+  const toggleRepairItem = useRepairSelector((state) => state.toggleRepairItem);
+  const selectAllItems = useRepairSelector((state) => state.selectAllItems);
+  const deselectAllItems = useRepairSelector((state) => state.deselectAllItems);
+  const reorderJobs = useRepairSelector((state) => state.reorderJobs);
+  const initializeCampaign = useRepairSelector(
+    (state) => state.initializeCampaign,
+  );
+  const clearError = useRepairSelector((state) => state.clearError);
 
   const {
     searchQuery,

--- a/src/components/mobile/BottomNavBar.tsx
+++ b/src/components/mobile/BottomNavBar.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 
 import { useDeviceType } from '@/hooks/useDeviceType';
-import { PanelId, useNavigationStore } from '@/stores/useNavigationStore';
+import { PanelId, useNavigationSelector } from '@/stores/useNavigationStore';
 
 export interface Tab {
   id: string;
@@ -42,7 +42,8 @@ export function BottomNavBar({
   className = '',
 }: BottomNavBarProps): React.ReactElement | null {
   const { isMobile } = useDeviceType();
-  const { currentPanel, pushPanel } = useNavigationStore();
+  const currentPanel = useNavigationSelector((state) => state.currentPanel);
+  const pushPanel = useNavigationSelector((state) => state.pushPanel);
 
   // Don't render on desktop
   if (!isMobile) {

--- a/src/components/mobile/PanelStack.tsx
+++ b/src/components/mobile/PanelStack.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useRef, useEffect, useState } from 'react';
 
 import { useDeviceType } from '@/hooks/useDeviceType';
-import { useNavigationStore } from '@/stores/useNavigationStore';
+import { useNavigationSelector } from '@/stores/useNavigationStore';
 
 interface PanelProps {
   id: string;
@@ -143,7 +143,9 @@ export function PanelStack({
   className = '',
 }: PanelStackProps): React.ReactElement | null {
   const { isMobile } = useDeviceType();
-  const { currentPanel, history, currentIndex } = useNavigationStore();
+  const currentPanel = useNavigationSelector((state) => state.currentPanel);
+  const history = useNavigationSelector((state) => state.history);
+  const currentIndex = useNavigationSelector((state) => state.currentIndex);
   const [direction, setDirection] = useState<'forward' | 'backward' | null>(
     null,
   );

--- a/src/components/pilots/PilotAbilitiesPanel.tsx
+++ b/src/components/pilots/PilotAbilitiesPanel.tsx
@@ -36,7 +36,7 @@ import {
 import { SPAPickerModal } from '@/components/spa/SPAPickerModal';
 import { Badge, Button, Card, CardSection } from '@/components/ui';
 import { getSPADefinition } from '@/lib/spa';
-import { usePilotStore } from '@/stores/usePilotStore';
+import { usePilotSelector } from '@/stores/usePilotStore';
 
 // =============================================================================
 // Props
@@ -181,7 +181,9 @@ export function PilotAbilitiesPanel({
   isCreationFlow = false,
   onPilotChange,
 }: IPilotAbilitiesPanelProps): React.ReactElement {
-  const { purchaseSPA, removeSPA, error } = usePilotStore();
+  const purchaseSPA = usePilotSelector((state) => state.purchaseSPA);
+  const removeSPA = usePilotSelector((state) => state.removeSPA);
+  const error = usePilotSelector((state) => state.error);
   const { showToast } = useToast();
 
   const [isModalOpen, setModalOpen] = useState(false);

--- a/src/components/pilots/PilotCreationWizard.tsx
+++ b/src/components/pilots/PilotCreationWizard.tsx
@@ -15,7 +15,7 @@ import React, { useState, useCallback, useMemo } from 'react';
 import { ModalOverlay } from '@/components/customizer/dialogs/ModalOverlay';
 import { useToast } from '@/components/shared/Toast';
 import { Button } from '@/components/ui';
-import { usePilotStore } from '@/stores/usePilotStore';
+import { usePilotSelector } from '@/stores/usePilotStore';
 import {
   PilotExperienceLevel,
   IPilotIdentity,
@@ -45,13 +45,13 @@ export function PilotCreationWizard({
   onClose,
   onCreated,
 }: PilotCreationWizardProps): React.ReactElement | null {
-  const {
-    createFromTemplate,
-    createRandom,
-    createPilot,
-    createStatblock,
-    isLoading,
-  } = usePilotStore();
+  const createFromTemplate = usePilotSelector(
+    (state) => state.createFromTemplate,
+  );
+  const createRandom = usePilotSelector((state) => state.createRandom);
+  const createPilot = usePilotSelector((state) => state.createPilot);
+  const createStatblock = usePilotSelector((state) => state.createStatblock);
+  const isLoading = usePilotSelector((state) => state.isLoading);
   const { showToast } = useToast();
 
   const [state, setState] = useState<WizardState>(INITIAL_STATE);

--- a/src/components/pilots/PilotProgressionPanel.tsx
+++ b/src/components/pilots/PilotProgressionPanel.tsx
@@ -12,7 +12,7 @@
 import React, { useState } from 'react';
 
 import { Badge, Button, Card } from '@/components/ui';
-import { usePilotStore } from '@/stores/usePilotStore';
+import { usePilotSelector } from '@/stores/usePilotStore';
 import {
   IPilot,
   MIN_SKILL_VALUE,
@@ -164,7 +164,9 @@ export function PilotProgressionPanel({
   pilot,
   onUpdate,
 }: PilotProgressionPanelProps): React.ReactElement {
-  const { improveGunnery, improvePiloting, error } = usePilotStore();
+  const improveGunnery = usePilotSelector((state) => state.improveGunnery);
+  const improvePiloting = usePilotSelector((state) => state.improvePiloting);
+  const error = usePilotSelector((state) => state.error);
   const [isUpgradingGunnery, setIsUpgradingGunnery] = useState(false);
   const [isUpgradingPiloting, setIsUpgradingPiloting] = useState(false);
 

--- a/src/components/pilots/__tests__/PilotAbilitiesPanel.test.tsx
+++ b/src/components/pilots/__tests__/PilotAbilitiesPanel.test.tsx
@@ -30,6 +30,18 @@ jest.mock('@/stores/usePilotStore', () => ({
     removeSPA: mockRemoveSPA,
     error: null,
   }),
+  usePilotSelector: (
+    selector: (state: {
+      purchaseSPA: typeof mockPurchaseSPA;
+      removeSPA: typeof mockRemoveSPA;
+      error: string | null;
+    }) => unknown,
+  ) =>
+    selector({
+      purchaseSPA: mockPurchaseSPA,
+      removeSPA: mockRemoveSPA,
+      error: null,
+    }),
 }));
 
 jest.mock('@/components/shared/Toast', () => ({

--- a/src/components/pilots/__tests__/PilotCreationWizard.test.tsx
+++ b/src/components/pilots/__tests__/PilotCreationWizard.test.tsx
@@ -21,6 +21,14 @@ jest.mock('@/stores/usePilotStore', () => ({
     createStatblock: mockCreateStatblock,
     isLoading: false,
   }),
+  usePilotSelector: (selector: (state: unknown) => unknown) =>
+    selector({
+      createFromTemplate: mockCreateFromTemplate,
+      createRandom: mockCreateRandom,
+      createPilot: mockCreatePilot,
+      createStatblock: mockCreateStatblock,
+      isLoading: false,
+    }),
 }));
 
 jest.mock('@/components/shared/Toast', () => ({

--- a/src/components/quickgame/QuickGamePlay.tsx
+++ b/src/components/quickgame/QuickGamePlay.tsx
@@ -9,7 +9,7 @@
 import { useEffect, useRef } from 'react';
 
 import { Card } from '@/components/ui';
-import { useQuickGameStore } from '@/stores/useQuickGameStore';
+import { useQuickGameSelector } from '@/stores/useQuickGameStore';
 import { GameStatus } from '@/types/gameplay';
 
 // =============================================================================
@@ -91,7 +91,10 @@ function UnitCard({ unit, isPlayer }: UnitCardProps): React.ReactElement {
 // =============================================================================
 
 export function QuickGamePlay(): React.ReactElement {
-  const { game, isLoading, error, startBattle } = useQuickGameStore();
+  const game = useQuickGameSelector((state) => state.game);
+  const isLoading = useQuickGameSelector((state) => state.isLoading);
+  const error = useQuickGameSelector((state) => state.error);
+  const startBattle = useQuickGameSelector((state) => state.startBattle);
   const battleStarted = useRef(false);
 
   useEffect(() => {

--- a/src/components/quickgame/QuickGameResults.tsx
+++ b/src/components/quickgame/QuickGameResults.tsx
@@ -21,8 +21,8 @@ import {
   calculateCombatStats,
   assessUnitDamage,
 } from '@/services/game-resolution';
-import { useGameplayStore } from '@/stores/useGameplayStore';
-import { useQuickGameStore } from '@/stores/useQuickGameStore';
+import { useGameplaySelector } from '@/stores/useGameplayStore';
+import { useQuickGameSelector } from '@/stores/useQuickGameStore';
 import { GameSide } from '@/types/gameplay';
 
 import type { ResultsTab } from './quickGameResults.helpers';
@@ -38,8 +38,10 @@ import {
 
 export function QuickGameResults(): React.ReactElement {
   const router = useRouter();
-  const { game, playAgain, clearGame } = useQuickGameStore();
-  const session = useGameplayStore((s) => s.session);
+  const game = useQuickGameSelector((state) => state.game);
+  const playAgain = useQuickGameSelector((state) => state.playAgain);
+  const clearGame = useQuickGameSelector((state) => state.clearGame);
+  const session = useGameplaySelector((state) => state.session);
   const [activeTab, setActiveTab] = useState<ResultsTab>('summary');
   const tabListRef = useRef<HTMLDivElement>(null);
 

--- a/src/components/quickgame/QuickGameResultsSections.tsx
+++ b/src/components/quickgame/QuickGameResultsSections.tsx
@@ -11,7 +11,7 @@ import type { IQuickGameUnit } from '@/types/quickgame/QuickGameInterfaces';
 import type { IKeyMoment } from '@/types/simulation-viewer/IKeyMoment';
 
 import { Card } from '@/components/ui';
-import { useQuickGameStore } from '@/stores/useQuickGameStore';
+import { useQuickGameSelector } from '@/stores/useQuickGameStore';
 import { GamePhase } from '@/types/gameplay';
 import { projectUnitPerformance } from '@/utils/gameplay/combatStatistics';
 
@@ -123,7 +123,7 @@ export function BattleSummary({
   combatStats,
   keyMoments,
 }: BattleSummaryProps): React.ReactElement {
-  const { game } = useQuickGameStore();
+  const game = useQuickGameSelector((state) => state.game);
   const [showLowerTiers, setShowLowerTiers] = useState(false);
 
   if (!game) return <></>;

--- a/src/components/quickgame/QuickGameReview.tsx
+++ b/src/components/quickgame/QuickGameReview.tsx
@@ -10,7 +10,7 @@ import { useRouter } from 'next/router';
 import { Button, Card } from '@/components/ui';
 import { FACTION_NAMES, Faction } from '@/constants/scenario/rats';
 import { useGameplayStore } from '@/stores/useGameplayStore';
-import { useQuickGameStore } from '@/stores/useQuickGameStore';
+import { useQuickGameSelector } from '@/stores/useQuickGameStore';
 
 // =============================================================================
 // Force Display Component
@@ -93,7 +93,7 @@ function ForceDisplay({
 // =============================================================================
 
 function ModifierDisplay(): React.ReactElement {
-  const { game } = useQuickGameStore();
+  const game = useQuickGameSelector((state) => state.game);
   const modifiers = game?.scenario?.modifiers ?? [];
 
   if (modifiers.length === 0) {
@@ -199,8 +199,13 @@ function ModifierDisplay(): React.ReactElement {
 
 export function QuickGameReview(): React.ReactElement {
   const router = useRouter();
-  const { game, previousStep, startGame, startSpectatorMode, isLoading } =
-    useQuickGameStore();
+  const game = useQuickGameSelector((state) => state.game);
+  const previousStep = useQuickGameSelector((state) => state.previousStep);
+  const startGame = useQuickGameSelector((state) => state.startGame);
+  const startSpectatorMode = useQuickGameSelector(
+    (state) => state.startSpectatorMode,
+  );
+  const isLoading = useQuickGameSelector((state) => state.isLoading);
 
   const handleWatchAIBattle = async () => {
     await startSpectatorMode();

--- a/src/components/quickgame/QuickGameSetup.tsx
+++ b/src/components/quickgame/QuickGameSetup.tsx
@@ -5,14 +5,14 @@
  * @spec openspec/changes/add-quick-session-mode/proposal.md
  */
 
-import { useQuickGameStore } from '@/stores/useQuickGameStore';
+import { useQuickGameSelector } from '@/stores/useQuickGameStore';
 import { QuickGameStep } from '@/types/quickgame';
 
 import { ScenarioConfigStep } from './QuickGameSetupScenarioConfig';
 import { UnitSelectionStep } from './QuickGameSetupUnitSelection';
 
 export function QuickGameSetup(): React.ReactElement {
-  const { game } = useQuickGameStore();
+  const game = useQuickGameSelector((state) => state.game);
 
   if (!game) {
     return (

--- a/src/components/quickgame/QuickGameSetupScenarioConfig.tsx
+++ b/src/components/quickgame/QuickGameSetupScenarioConfig.tsx
@@ -2,18 +2,20 @@ import { useEffect, useRef } from 'react';
 
 import { Button, Card, Select } from '@/components/ui';
 import { Faction, FACTION_NAMES } from '@/constants/scenario/rats';
-import { useQuickGameStore } from '@/stores/useQuickGameStore';
+import { useQuickGameSelector } from '@/stores/useQuickGameStore';
 import { BiomeType } from '@/types/scenario';
 
 export function ScenarioConfigStep(): React.ReactElement {
-  const {
-    game,
-    setScenarioConfig,
-    generateScenario,
-    previousStep,
-    nextStep,
-    isLoading,
-  } = useQuickGameStore();
+  const game = useQuickGameSelector((state) => state.game);
+  const setScenarioConfig = useQuickGameSelector(
+    (state) => state.setScenarioConfig,
+  );
+  const generateScenario = useQuickGameSelector(
+    (state) => state.generateScenario,
+  );
+  const previousStep = useQuickGameSelector((state) => state.previousStep);
+  const nextStep = useQuickGameSelector((state) => state.nextStep);
+  const isLoading = useQuickGameSelector((state) => state.isLoading);
   const wasLoadingRef = useRef(false);
 
   useEffect(() => {

--- a/src/components/quickgame/QuickGameSetupUnitSelection.tsx
+++ b/src/components/quickgame/QuickGameSetupUnitSelection.tsx
@@ -1,13 +1,18 @@
 import type { IQuickGameUnitRequest } from '@/types/quickgame';
 
 import { Button, Card } from '@/components/ui';
-import { useQuickGameStore } from '@/stores/useQuickGameStore';
+import { useQuickGameSelector } from '@/stores/useQuickGameStore';
 
 import { DEMO_UNITS } from './quickGameSetup.helpers';
 
 export function UnitSelectionStep(): React.ReactElement {
-  const { game, addUnit, removeUnit, updateUnitSkills, nextStep } =
-    useQuickGameStore();
+  const game = useQuickGameSelector((state) => state.game);
+  const addUnit = useQuickGameSelector((state) => state.addUnit);
+  const removeUnit = useQuickGameSelector((state) => state.removeUnit);
+  const updateUnitSkills = useQuickGameSelector(
+    (state) => state.updateUnitSkills,
+  );
+  const nextStep = useQuickGameSelector((state) => state.nextStep);
 
   const handleAddUnit = (unit: IQuickGameUnitRequest) => {
     addUnit(unit);

--- a/src/components/quickgame/QuickGameTimeline.tsx
+++ b/src/components/quickgame/QuickGameTimeline.tsx
@@ -6,7 +6,7 @@
  */
 
 import { Card } from '@/components/ui';
-import { useQuickGameStore } from '@/stores/useQuickGameStore';
+import { useQuickGameSelector } from '@/stores/useQuickGameStore';
 import { GameEventType, GamePhase } from '@/types/gameplay';
 
 // =============================================================================
@@ -72,7 +72,7 @@ function formatTime(timestamp: string): string {
 // =============================================================================
 
 export function QuickGameTimeline(): React.ReactElement {
-  const { game } = useQuickGameStore();
+  const game = useQuickGameSelector((state) => state.game);
 
   if (!game) {
     return (

--- a/src/components/settings/P2PSyncSettings.tsx
+++ b/src/components/settings/P2PSyncSettings.tsx
@@ -8,7 +8,7 @@ import {
 import { Input } from '@/components/ui';
 import { ConnectionState } from '@/lib/p2p';
 import {
-  useSyncRoomStore,
+  useSyncRoomSelector,
   useConnectionState,
   usePeers,
   useRoomCode,
@@ -24,16 +24,16 @@ export function P2PSyncSettings({
   const connectionState = useConnectionState();
   const peers = usePeers();
   const roomCode = useRoomCode();
-  const {
-    localPeerName,
-    localPeerId,
-    setLocalPeerName,
-    createRoom,
-    joinRoom,
-    leaveRoom,
-    error,
-    clearError,
-  } = useSyncRoomStore();
+  const localPeerName = useSyncRoomSelector((state) => state.localPeerName);
+  const localPeerId = useSyncRoomSelector((state) => state.localPeerId);
+  const setLocalPeerName = useSyncRoomSelector(
+    (state) => state.setLocalPeerName,
+  );
+  const createRoom = useSyncRoomSelector((state) => state.createRoom);
+  const joinRoom = useSyncRoomSelector((state) => state.joinRoom);
+  const leaveRoom = useSyncRoomSelector((state) => state.leaveRoom);
+  const error = useSyncRoomSelector((state) => state.error);
+  const clearError = useSyncRoomSelector((state) => state.clearError);
 
   const [showRoomDialog, setShowRoomDialog] = React.useState(false);
   const [peerNameInput, setPeerNameInput] = React.useState(localPeerName);

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -35,7 +35,8 @@ export function Input({
   id,
   ...props
 }: InputProps): React.ReactElement {
-  const inputId = id || props.name;
+  const generatedId = React.useId();
+  const inputId = id || props.name || (label ? generatedId : undefined);
   const baseClasses =
     'w-full bg-surface-raised/50 border border-border-theme text-text-theme-primary placeholder-text-theme-secondary focus:outline-none transition-colors';
 
@@ -76,7 +77,8 @@ export function Select({
   id,
   ...props
 }: SelectProps): React.ReactElement {
-  const selectId = id || props.name;
+  const generatedId = React.useId();
+  const selectId = id || props.name || (label ? generatedId : undefined);
   const baseClasses =
     'w-full bg-surface-raised/50 border border-border-theme rounded-lg px-4 py-2 text-text-theme-primary focus:outline-none transition-colors min-h-[44px]';
 
@@ -121,7 +123,8 @@ export function Textarea({
   id,
   ...props
 }: TextareaProps): React.ReactElement {
-  const textareaId = id || props.name;
+  const generatedId = React.useId();
+  const textareaId = id || props.name || (label ? generatedId : undefined);
   const baseClasses =
     'w-full bg-surface-raised/50 border border-border-theme text-text-theme-primary placeholder-text-theme-secondary focus:outline-none transition-colors rounded-lg px-4 py-2.5 resize-none min-h-[44px]';
 

--- a/src/components/vault/ExportDialog.tsx
+++ b/src/components/vault/ExportDialog.tsx
@@ -17,7 +17,7 @@ import type {
 
 import { DialogTemplate } from '@/components/ui/DialogTemplate';
 import { useVaultExport, type ExportOptions } from '@/hooks/useVaultExport';
-import { useIdentityStore } from '@/stores/useIdentityStore';
+import { useIdentitySelector } from '@/stores/useIdentityStore';
 
 // =============================================================================
 // Types
@@ -69,7 +69,8 @@ export function ExportDialog({
   const [password, setPassword] = useState('');
   const [copied, setCopied] = useState(false);
 
-  const { publicIdentity, isUnlocked } = useIdentityStore();
+  const publicIdentity = useIdentitySelector((state) => state.publicIdentity);
+  const isUnlocked = useIdentitySelector((state) => state.isUnlocked);
   const {
     exporting,
     result,

--- a/src/components/vault/FolderManager.stories.tsx
+++ b/src/components/vault/FolderManager.stories.tsx
@@ -1,0 +1,211 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { fn } from '@storybook/test';
+
+import type {
+  IContact,
+  IFolderItem,
+  IPermissionGrant,
+  IVaultFolder,
+} from '@/types/vault';
+
+import {
+  FolderCreateDialog,
+  FolderEditDialog,
+  FolderItemsPanel,
+  FolderList,
+  FolderSharePanel,
+} from './FolderManager';
+
+const folders: IVaultFolder[] = [
+  {
+    id: 'folder-command',
+    name: 'Command Lance',
+    description: 'Front-line machines and veteran pilots',
+    parentId: null,
+    createdAt: '2026-04-24T17:00:00.000Z',
+    updatedAt: '2026-04-29T02:00:00.000Z',
+    itemCount: 8,
+    isShared: true,
+  },
+  {
+    id: 'folder-command-mechs',
+    name: 'BattleMechs',
+    description: 'Current deployment roster',
+    parentId: 'folder-command',
+    createdAt: '2026-04-25T17:00:00.000Z',
+    updatedAt: '2026-04-29T02:00:00.000Z',
+    itemCount: 4,
+    isShared: true,
+  },
+  {
+    id: 'folder-command-pilots',
+    name: 'Pilots',
+    description: 'Gunnery and SPA notes',
+    parentId: 'folder-command',
+    createdAt: '2026-04-25T18:00:00.000Z',
+    updatedAt: '2026-04-28T23:00:00.000Z',
+    itemCount: 4,
+    isShared: false,
+  },
+  {
+    id: 'folder-contracts',
+    name: 'Contract Prep',
+    description: 'Forces staged for the next sortie',
+    parentId: null,
+    createdAt: '2026-04-26T15:00:00.000Z',
+    updatedAt: '2026-04-28T14:00:00.000Z',
+    itemCount: 5,
+    isShared: false,
+  },
+];
+
+const contacts: IContact[] = [
+  {
+    id: 'contact-1',
+    friendCode: 'KSTL-713F-VAULT-01',
+    publicKey: 'kestrel-public-key',
+    nickname: 'Kestrel',
+    displayName: 'Kestrel Lance',
+    avatar: null,
+    addedAt: '2026-04-20T15:00:00.000Z',
+    lastSeenAt: '2026-04-29T03:45:00.000Z',
+    isTrusted: true,
+    notes: 'Campaign co-op partner',
+  },
+  {
+    id: 'contact-2',
+    friendCode: 'NOVA-422B-VAULT-09',
+    publicKey: 'nova-public-key',
+    nickname: null,
+    displayName: 'Nova Relay',
+    avatar: null,
+    addedAt: '2026-04-21T15:00:00.000Z',
+    lastSeenAt: '2026-04-28T22:12:00.000Z',
+    isTrusted: false,
+    notes: null,
+  },
+];
+
+const shares: IPermissionGrant[] = [
+  {
+    id: 'grant-1',
+    granteeId: 'KSTL-713F-VAULT-01',
+    scopeType: 'folder',
+    scopeId: 'folder-command',
+    scopeCategory: null,
+    level: 'write',
+    expiresAt: null,
+    createdAt: '2026-04-27T13:00:00.000Z',
+    granteeName: 'Kestrel Lance',
+  },
+];
+
+const items: IFolderItem[] = [
+  {
+    folderId: 'folder-command',
+    itemId: 'Atlas AS7-D',
+    itemType: 'unit',
+    assignedAt: '2026-04-29T01:00:00.000Z',
+  },
+  {
+    folderId: 'folder-command',
+    itemId: 'Major Tamsin Vale',
+    itemType: 'pilot',
+    assignedAt: '2026-04-29T01:05:00.000Z',
+  },
+  {
+    folderId: 'folder-command',
+    itemId: 'First Crucis Lancers',
+    itemType: 'force',
+    assignedAt: '2026-04-29T01:10:00.000Z',
+  },
+];
+
+const meta: Meta<typeof FolderList> = {
+  title: 'Vault/FolderManager',
+  component: FolderList,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[720px] max-w-full rounded-lg bg-gray-900 p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    folders,
+    selectedFolderId: 'folder-command',
+    expandedFolderIds: new Set(['folder-command']),
+    onSelectFolder: fn(),
+    onToggleExpand: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FolderList>;
+
+export const FolderTree: Story = {};
+
+export const Loading: Story = {
+  args: {
+    folders: [],
+    isLoading: true,
+  },
+};
+
+export const CreateDialog: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: () => (
+    <div className="min-h-[520px] bg-gray-950">
+      <FolderCreateDialog
+        isOpen
+        onClose={fn()}
+        parentFolders={folders}
+        onCreated={fn()}
+      />
+    </div>
+  ),
+};
+
+export const EditDialog: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: () => (
+    <div className="min-h-[540px] bg-gray-950">
+      <FolderEditDialog
+        isOpen
+        onClose={fn()}
+        folder={folders[0]}
+        onUpdated={fn()}
+        onDeleted={fn()}
+      />
+    </div>
+  ),
+};
+
+export const SharingAndContents: Story = {
+  render: () => (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <FolderSharePanel
+        folder={folders[0]}
+        shares={shares}
+        contacts={contacts}
+        onAddShare={fn()}
+        onRemoveShare={fn()}
+      />
+      <FolderItemsPanel
+        folder={folders[0]}
+        items={items}
+        onAddItem={fn()}
+        onRemoveItem={fn()}
+      />
+    </div>
+  ),
+};

--- a/src/components/vault/SyncStatus.stories.tsx
+++ b/src/components/vault/SyncStatus.stories.tsx
@@ -1,0 +1,132 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { fn } from '@storybook/test';
+
+import type { IPeerQueueSummary, IQueueStats } from '@/types/vault';
+
+import {
+  PeerSyncRow,
+  SyncStatusIndicator,
+  SyncStatusPanel,
+} from './SyncStatus';
+
+const queueStats: IQueueStats = {
+  totalMessages: 19,
+  byStatus: {
+    pending: 11,
+    sending: 2,
+    sent: 3,
+    failed: 2,
+    expired: 1,
+  },
+  totalSizeBytes: 148872,
+  targetPeerCount: 3,
+  expiringSoon: 4,
+};
+
+const peerSummaries: IPeerQueueSummary[] = [
+  {
+    peerId: 'KSTL-713F-VAULT-01',
+    pendingCount: 5,
+    pendingSizeBytes: 48216,
+    oldestPending: '2026-04-29T02:12:00.000Z',
+    failedCount: 0,
+    lastSuccessAt: '2026-04-29T04:18:00.000Z',
+  },
+  {
+    peerId: 'NOVA-422B-VAULT-09',
+    pendingCount: 6,
+    pendingSizeBytes: 100656,
+    oldestPending: '2026-04-29T01:03:00.000Z',
+    failedCount: 2,
+    lastSuccessAt: '2026-04-28T21:41:00.000Z',
+  },
+];
+
+const meta: Meta<typeof SyncStatusPanel> = {
+  title: 'Vault/SyncStatus',
+  component: SyncStatusPanel,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    isOpen: true,
+    onClose: fn(),
+    stats: queueStats,
+    peerSummaries,
+    peerStates: {
+      'KSTL-713F-VAULT-01': 'connected',
+      'NOVA-422B-VAULT-09': 'failed',
+    },
+    peerNames: {
+      'KSTL-713F-VAULT-01': 'Kestrel Lance',
+      'NOVA-422B-VAULT-09': 'Nova Relay',
+    },
+    onFlushAll: fn(async () => undefined),
+    onClearExpired: fn(async () => undefined),
+    onFlushPeer: fn(async () => undefined),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SyncStatusPanel>;
+
+export const PanelWithPeers: Story = {};
+
+export const LoadingPanel: Story = {
+  args: {
+    isLoading: true,
+    stats: null,
+    peerSummaries: [],
+  },
+};
+
+export const ErrorPanel: Story = {
+  args: {
+    error: 'Signaling relay timed out while loading queue state.',
+    peerSummaries: [],
+  },
+};
+
+export const Indicators: Story = {
+  parameters: {
+    layout: 'centered',
+  },
+  render: () => (
+    <div className="flex items-center gap-4 rounded-lg bg-gray-900 p-6">
+      <SyncStatusIndicator state="online" showLabel />
+      <SyncStatusIndicator state="syncing" pendingCount={3} showLabel />
+      <SyncStatusIndicator state="offline" showLabel />
+      <SyncStatusIndicator state="error" pendingCount={12} showLabel />
+    </div>
+  ),
+};
+
+export const PeerRows: Story = {
+  parameters: {
+    layout: 'centered',
+  },
+  render: () => (
+    <div className="w-[520px] divide-y divide-gray-700 rounded-lg bg-gray-800">
+      <PeerSyncRow
+        peerId="KSTL-713F-VAULT-01"
+        peerName="Kestrel Lance"
+        connectionState="connected"
+        pendingCount={5}
+        pendingSizeBytes={48216}
+        lastSuccessAt="2026-04-29T04:18:00.000Z"
+        onFlush={fn(async () => undefined)}
+      />
+      <PeerSyncRow
+        peerId="NOVA-422B-VAULT-09"
+        peerName="Nova Relay"
+        connectionState="connecting"
+        pendingCount={0}
+        isSyncing
+        syncProgress={63}
+        lastSuccessAt="2026-04-29T03:44:00.000Z"
+      />
+    </div>
+  ),
+};

--- a/src/components/vault/SyncStatus.tsx
+++ b/src/components/vault/SyncStatus.tsx
@@ -130,6 +130,7 @@ export function SyncStatusPanel({
               </div>
               <button
                 onClick={onClose}
+                aria-label="Close sync status"
                 className="rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-700/50 hover:text-white"
               >
                 <XMarkIcon className="h-5 w-5" />

--- a/src/components/vault/VaultDialogs.stories.tsx
+++ b/src/components/vault/VaultDialogs.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { ReactElement, ReactNode } from 'react';
+
+import { fn } from '@storybook/test';
+
+import type {
+  IExportableUnit,
+  IImportHandlers,
+  ISyncConflict,
+} from '@/types/vault';
+
+import { ConflictResolutionDialog } from './ConflictResolutionDialog';
+import { ExportDialog } from './ExportDialog';
+import { ImportDialog } from './ImportDialog';
+import { ShareDialog } from './ShareDialog';
+
+const sampleUnit: IExportableUnit = {
+  id: 'unit-atlas-as7-d',
+  name: 'Atlas AS7-D',
+  chassis: 'Atlas',
+  model: 'AS7-D',
+  data: {
+    tonnage: 100,
+    battleValue: 1897,
+    techBase: 'Inner Sphere',
+  },
+  source: 'storybook',
+};
+
+const conflict: ISyncConflict = {
+  id: 'conflict-unit-atlas',
+  contentType: 'unit',
+  itemId: 'unit-atlas-as7-d',
+  itemName: 'Atlas AS7-D',
+  localVersion: 12,
+  localHash: 'local-a06a44e8b8fb4c6f9fca76f9ed67b422',
+  remoteVersion: 13,
+  remoteHash: 'remote-f2d624d5e1a44f60b99ceef24c6272a8',
+  remotePeerId: 'KSTL-713F-VAULT-01',
+  detectedAt: '2026-04-29T04:22:00.000Z',
+  resolution: 'pending',
+};
+
+const importHandlers: IImportHandlers<IExportableUnit> = {
+  checkExists: fn(async () => false),
+  checkNameConflict: fn(async () => null),
+  save: fn(async (item) => item.id),
+};
+
+const DialogStoryHost = ({
+  children,
+}: {
+  children: ReactNode;
+}): ReactElement => (
+  <div className="min-h-[620px] bg-gray-950 p-8">{children}</div>
+);
+
+const meta: Meta<typeof ShareDialog> = {
+  title: 'Vault/Dialogs',
+  component: ShareDialog,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ShareDialog>;
+
+export const ShareUnitDialog: Story = {
+  render: () => (
+    <DialogStoryHost>
+      <ShareDialog
+        isOpen
+        onClose={fn()}
+        scopeType="item"
+        scopeId="unit-atlas-as7-d"
+        itemName="Atlas AS7-D"
+        onShareCreated={fn()}
+      />
+    </DialogStoryHost>
+  ),
+};
+
+export const ConflictResolution: Story = {
+  render: () => (
+    <DialogStoryHost>
+      <ConflictResolutionDialog
+        isOpen
+        onClose={fn()}
+        conflict={conflict}
+        onResolved={fn()}
+      />
+    </DialogStoryHost>
+  ),
+};
+
+export const ExportLocked: Story = {
+  render: () => (
+    <DialogStoryHost>
+      <ExportDialog
+        isOpen
+        onClose={fn()}
+        contentType="unit"
+        content={sampleUnit}
+        onExportComplete={fn()}
+      />
+    </DialogStoryHost>
+  ),
+};
+
+export const ImportBundle: Story = {
+  render: () => (
+    <DialogStoryHost>
+      <ImportDialog
+        isOpen
+        onClose={fn()}
+        handlers={importHandlers}
+        onImportComplete={fn()}
+      />
+    </DialogStoryHost>
+  ),
+};

--- a/src/components/vault/VaultIdentitySection.tsx
+++ b/src/components/vault/VaultIdentitySection.tsx
@@ -9,7 +9,10 @@
 
 import React, { useEffect, useState, useCallback } from 'react';
 
-import { useIdentityStore, selectFriendCode } from '@/stores/useIdentityStore';
+import {
+  useIdentitySelector,
+  selectFriendCode,
+} from '@/stores/useIdentityStore';
 
 // =============================================================================
 // Sub-components
@@ -28,7 +31,10 @@ function CreateIdentityForm({
   const [confirmPassword, setConfirmPassword] = useState('');
   const [localError, setLocalError] = useState<string | null>(null);
 
-  const { createIdentity, loading, error, clearError } = useIdentityStore();
+  const createIdentity = useIdentitySelector((state) => state.createIdentity);
+  const loading = useIdentitySelector((state) => state.loading);
+  const error = useIdentitySelector((state) => state.error);
+  const clearError = useIdentitySelector((state) => state.clearError);
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -154,7 +160,10 @@ function UnlockIdentityForm({
   onSuccess: () => void;
 }): React.ReactElement {
   const [password, setPassword] = useState('');
-  const { unlockIdentity, loading, error, clearError } = useIdentityStore();
+  const unlockIdentity = useIdentitySelector((state) => state.unlockIdentity);
+  const loading = useIdentitySelector((state) => state.loading);
+  const error = useIdentitySelector((state) => state.error);
+  const clearError = useIdentitySelector((state) => state.clearError);
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -215,8 +224,9 @@ function UnlockIdentityForm({
  * Unlocked identity display
  */
 function UnlockedIdentityDisplay(): React.ReactElement {
-  const { publicIdentity, lockIdentity } = useIdentityStore();
-  const friendCode = useIdentityStore(selectFriendCode);
+  const publicIdentity = useIdentitySelector((state) => state.publicIdentity);
+  const lockIdentity = useIdentitySelector((state) => state.lockIdentity);
+  const friendCode = useIdentitySelector(selectFriendCode);
   const [copied, setCopied] = useState(false);
 
   const handleCopyFriendCode = useCallback(async () => {
@@ -288,14 +298,12 @@ function UnlockedIdentityDisplay(): React.ReactElement {
 // =============================================================================
 
 export function VaultIdentitySection(): React.ReactElement {
-  const {
-    initialized,
-    hasIdentity,
-    publicIdentity,
-    isUnlocked,
-    checkIdentity,
-    loading,
-  } = useIdentityStore();
+  const initialized = useIdentitySelector((state) => state.initialized);
+  const hasIdentity = useIdentitySelector((state) => state.hasIdentity);
+  const publicIdentity = useIdentitySelector((state) => state.publicIdentity);
+  const isUnlocked = useIdentitySelector((state) => state.isUnlocked);
+  const checkIdentity = useIdentitySelector((state) => state.checkIdentity);
+  const loading = useIdentitySelector((state) => state.loading);
 
   // Check identity status on mount
   useEffect(() => {

--- a/src/components/vault/VersionHistory.stories.tsx
+++ b/src/components/vault/VersionHistory.stories.tsx
@@ -1,0 +1,229 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+
+import { fn } from '@storybook/test';
+import { useEffect } from 'react';
+
+import type {
+  IVersionDiff,
+  IVersionHistorySummary,
+  IVersionSnapshot,
+  ShareableContentType,
+} from '@/types/vault';
+
+import {
+  VersionDiffView,
+  VersionHistoryPanel,
+  VersionPreview,
+  VersionRollbackDialog,
+} from './VersionHistory';
+
+const itemId = 'unit-atlas-as7-d';
+const contentType: ShareableContentType = 'unit';
+
+const versions: IVersionSnapshot[] = [
+  {
+    id: 'version-3',
+    contentType,
+    itemId,
+    version: 3,
+    contentHash: 'f2d624d5e1a44f60b99ceef24c6272a8',
+    content: JSON.stringify(
+      {
+        name: 'Atlas AS7-D',
+        battleValue: 1897,
+        armor: { head: 9, centerTorso: 47, leftTorso: 32, rightTorso: 32 },
+        weapons: ['AC/20', 'LRM 20', 'Medium Laser', 'SRM 6'],
+      },
+      null,
+      2,
+    ),
+    createdAt: '2026-04-29T04:30:00.000Z',
+    createdBy: 'local',
+    message: 'Rebalanced torso armor after refit',
+    sizeBytes: 2846,
+  },
+  {
+    id: 'version-2',
+    contentType,
+    itemId,
+    version: 2,
+    contentHash: 'a06a44e8b8fb4c6f9fca76f9ed67b422',
+    content: JSON.stringify(
+      {
+        name: 'Atlas AS7-D',
+        battleValue: 1884,
+        armor: { head: 9, centerTorso: 45, leftTorso: 31, rightTorso: 31 },
+        weapons: ['AC/20', 'LRM 20', 'Medium Laser', 'SRM 6'],
+      },
+      null,
+      2,
+    ),
+    createdAt: '2026-04-28T21:15:00.000Z',
+    createdBy: 'peer-kestrel-713f',
+    message: 'Imported campaign refit',
+    sizeBytes: 2798,
+  },
+  {
+    id: 'version-1',
+    contentType,
+    itemId,
+    version: 1,
+    contentHash: '6e1ec2f23dc64a7ca31f8fe18f9d34af',
+    content: JSON.stringify(
+      {
+        name: 'Atlas AS7-D',
+        battleValue: 1872,
+        armor: { head: 9, centerTorso: 44, leftTorso: 30, rightTorso: 30 },
+        weapons: ['AC/20', 'LRM 20', 'Medium Laser', 'SRM 6'],
+      },
+      null,
+      2,
+    ),
+    createdAt: '2026-04-27T18:00:00.000Z',
+    createdBy: 'local',
+    message: 'Initial vault save',
+    sizeBytes: 2719,
+  },
+];
+
+const summary: IVersionHistorySummary = {
+  itemId,
+  contentType,
+  currentVersion: 3,
+  totalVersions: versions.length,
+  oldestVersion: versions[versions.length - 1].createdAt,
+  newestVersion: versions[0].createdAt,
+  totalSizeBytes: versions.reduce(
+    (total, version) => total + version.sizeBytes,
+    0,
+  ),
+};
+
+const diff: IVersionDiff = {
+  fromVersion: 2,
+  toVersion: 3,
+  contentType,
+  itemId,
+  changedFields: ['battleValue', 'armor.centerTorso', 'armor.leftTorso'],
+  additions: {
+    tags: ['campaign-ready'],
+  },
+  deletions: {},
+  modifications: {
+    battleValue: { from: 1884, to: 1897 },
+    'armor.centerTorso': { from: 45, to: 47 },
+    'armor.leftTorso': { from: 31, to: 32 },
+  },
+};
+
+function createJsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const VersionFetchDecorator: Decorator = (Story) => {
+  useEffect(() => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const url = String(input);
+
+      if (url.includes('/api/vault/versions/diff')) {
+        return createJsonResponse(diff);
+      }
+
+      if (url.includes('/api/vault/versions/rollback')) {
+        return createJsonResponse({ ok: true });
+      }
+
+      if (url.includes('/api/vault/versions')) {
+        return createJsonResponse({ versions, summary });
+      }
+
+      return originalFetch.call(globalThis, input, init);
+    };
+
+    return () => {
+      globalThis.fetch = originalFetch;
+    };
+  }, []);
+
+  return <Story />;
+};
+
+const meta: Meta<typeof VersionHistoryPanel> = {
+  title: 'Vault/VersionHistory',
+  component: VersionHistoryPanel,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    VersionFetchDecorator,
+    (Story) => (
+      <div className="w-[760px] max-w-full">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    itemId,
+    contentType,
+    onVersionSelect: fn(),
+    onRollback: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VersionHistoryPanel>;
+
+export const HistoryPanel: Story = {};
+
+export const DiffView: Story = {
+  render: () => (
+    <VersionDiffView
+      itemId={itemId}
+      contentType={contentType}
+      versions={versions}
+      initialFromVersion={2}
+      initialToVersion={3}
+    />
+  ),
+};
+
+export const PreviewModal: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: () => (
+    <div className="min-h-[640px] bg-gray-950">
+      <VersionPreview
+        isOpen
+        onClose={fn()}
+        version={versions[0]}
+        onRollback={fn()}
+      />
+    </div>
+  ),
+};
+
+export const RollbackDialog: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: () => (
+    <div className="min-h-[540px] bg-gray-950">
+      <VersionRollbackDialog
+        isOpen
+        onClose={fn()}
+        version={versions[1]}
+        currentVersion={3}
+        onConfirm={fn()}
+      />
+    </div>
+  ),
+};

--- a/src/components/vault/VersionPreviewModal.tsx
+++ b/src/components/vault/VersionPreviewModal.tsx
@@ -102,6 +102,7 @@ export function VersionPreview({
               </div>
               <button
                 onClick={handleClose}
+                aria-label="Close version preview"
                 className="rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-700/50 hover:text-white"
               >
                 <XMarkIcon className="h-6 w-6" />

--- a/src/components/vault/__tests__/VaultPhase2.a11y.test.tsx
+++ b/src/components/vault/__tests__/VaultPhase2.a11y.test.tsx
@@ -1,0 +1,128 @@
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import React from 'react';
+
+import type {
+  IPeerQueueSummary,
+  IQueueStats,
+  ISyncConflict,
+  IVaultFolder,
+} from '@/types/vault';
+
+import { ConflictResolutionDialog } from '@/components/vault/ConflictResolutionDialog';
+import { FolderList } from '@/components/vault/FolderManager';
+import { SyncStatusPanel } from '@/components/vault/SyncStatus';
+
+const queueStats: IQueueStats = {
+  totalMessages: 9,
+  byStatus: {
+    pending: 5,
+    sending: 1,
+    sent: 1,
+    failed: 1,
+    expired: 1,
+  },
+  totalSizeBytes: 64000,
+  targetPeerCount: 2,
+  expiringSoon: 2,
+};
+
+const peerSummaries: IPeerQueueSummary[] = [
+  {
+    peerId: 'KSTL-713F-VAULT-01',
+    pendingCount: 5,
+    pendingSizeBytes: 64000,
+    oldestPending: '2026-04-29T02:12:00.000Z',
+    failedCount: 1,
+    lastSuccessAt: '2026-04-29T04:18:00.000Z',
+  },
+];
+
+const folders: IVaultFolder[] = [
+  {
+    id: 'folder-command',
+    name: 'Command Lance',
+    description: 'Front-line roster',
+    parentId: null,
+    createdAt: '2026-04-24T17:00:00.000Z',
+    updatedAt: '2026-04-29T02:00:00.000Z',
+    itemCount: 4,
+    isShared: true,
+  },
+  {
+    id: 'folder-command-pilots',
+    name: 'Pilots',
+    description: 'Pilot notes',
+    parentId: 'folder-command',
+    createdAt: '2026-04-25T17:00:00.000Z',
+    updatedAt: '2026-04-29T02:00:00.000Z',
+    itemCount: 4,
+    isShared: false,
+  },
+];
+
+const conflict: ISyncConflict = {
+  id: 'conflict-unit-atlas',
+  contentType: 'unit',
+  itemId: 'unit-atlas-as7-d',
+  itemName: 'Atlas AS7-D',
+  localVersion: 12,
+  localHash: 'local-a06a44e8b8fb4c6f9fca76f9ed67b422',
+  remoteVersion: 13,
+  remoteHash: 'remote-f2d624d5e1a44f60b99ceef24c6272a8',
+  remotePeerId: 'KSTL-713F-VAULT-01',
+  detectedAt: '2026-04-29T04:22:00.000Z',
+  resolution: 'pending',
+};
+
+describe('Vault Phase 2 a11y', () => {
+  it('has no axe violations for the sync status panel', async () => {
+    const { container } = render(
+      <SyncStatusPanel
+        isOpen
+        onClose={() => undefined}
+        stats={queueStats}
+        peerSummaries={peerSummaries}
+        peerStates={{ 'KSTL-713F-VAULT-01': 'connected' }}
+        peerNames={{ 'KSTL-713F-VAULT-01': 'Kestrel Lance' }}
+        onFlushAll={async () => undefined}
+        onClearExpired={async () => undefined}
+        onFlushPeer={async () => undefined}
+      />,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no axe violations for the folder tree', async () => {
+    const { container } = render(
+      <div className="bg-gray-900 p-4">
+        <FolderList
+          folders={folders}
+          selectedFolderId="folder-command"
+          expandedFolderIds={new Set(['folder-command'])}
+          onSelectFolder={() => undefined}
+          onToggleExpand={() => undefined}
+        />
+      </div>,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no axe violations for the conflict resolution modal', async () => {
+    const { container } = render(
+      <ConflictResolutionDialog
+        isOpen
+        onClose={() => undefined}
+        conflict={conflict}
+        onResolved={() => undefined}
+      />,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/vault/folder-manager/FolderDialogs.tsx
+++ b/src/components/vault/folder-manager/FolderDialogs.tsx
@@ -110,6 +110,7 @@ export function FolderCreateDialog({
           </div>
           <button
             onClick={handleClose}
+            aria-label="Close folder create dialog"
             className="rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-700/50 hover:text-white"
           >
             <XMarkIcon className="h-5 w-5" />
@@ -300,6 +301,7 @@ export function FolderEditDialog({
           </div>
           <button
             onClick={handleClose}
+            aria-label="Close folder edit dialog"
             className="rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-700/50 hover:text-white"
           >
             <XMarkIcon className="h-5 w-5" />

--- a/src/components/vault/folder-manager/FolderList.tsx
+++ b/src/components/vault/folder-manager/FolderList.tsx
@@ -76,6 +76,7 @@ function FolderTreeItem({
           e.stopPropagation();
           onToggleExpand();
         }}
+        aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${folder.name}`}
         className={`flex h-5 w-5 flex-shrink-0 items-center justify-center rounded transition-all duration-200 ${
           hasChildren
             ? 'text-gray-400 hover:bg-gray-600/50 hover:text-white'

--- a/src/hooks/__tests__/useEquipmentBrowser.test.ts
+++ b/src/hooks/__tests__/useEquipmentBrowser.test.ts
@@ -9,7 +9,10 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import * as React from 'react';
 
 import { equipmentLookupService } from '@/services/equipment/EquipmentLookupService';
-import { useEquipmentStore } from '@/stores/useEquipmentStore';
+import {
+  useEquipmentStore,
+  useEquipmentSelector,
+} from '@/stores/useEquipmentStore';
 import { RulesLevel } from '@/types/enums/RulesLevel';
 import { TechBase } from '@/types/enums/TechBase';
 import { EquipmentCategory, IEquipmentItem } from '@/types/equipment';
@@ -31,6 +34,9 @@ jest.mock('react', () => {
 
 const mockUseEquipmentStore = useEquipmentStore as jest.MockedFunction<
   typeof useEquipmentStore
+>;
+const mockUseEquipmentSelector = useEquipmentSelector as jest.MockedFunction<
+  typeof useEquipmentSelector
 >;
 const mockEquipmentLookupService = equipmentLookupService as jest.Mocked<
   typeof equipmentLookupService
@@ -152,6 +158,9 @@ describe('useEquipmentBrowser', () => {
     jest.clearAllMocks();
     mockStoreState = createMockStoreState();
     mockUseEquipmentStore.mockReturnValue(mockStoreState);
+    mockUseEquipmentSelector.mockImplementation((selector) =>
+      selector(mockUseEquipmentStore()),
+    );
     mockEquipmentLookupService.initialize = jest
       .fn()
       .mockResolvedValue(undefined);

--- a/src/hooks/__tests__/useVaultExport.test.ts
+++ b/src/hooks/__tests__/useVaultExport.test.ts
@@ -15,7 +15,10 @@ import type {
 } from '@/types/vault';
 
 import { serializeBundle } from '@/services/vault/BundleService';
-import { useIdentityStore } from '@/stores/useIdentityStore';
+import {
+  useIdentityStore,
+  useIdentitySelector,
+} from '@/stores/useIdentityStore';
 
 import { useVaultExport, ExportOptions } from '../useVaultExport';
 
@@ -25,6 +28,9 @@ jest.mock('@/services/vault/BundleService');
 
 const mockUseIdentityStore = useIdentityStore as jest.MockedFunction<
   typeof useIdentityStore
+>;
+const mockUseIdentitySelector = useIdentitySelector as jest.MockedFunction<
+  typeof useIdentitySelector
 >;
 const mockSerializeBundle = serializeBundle as jest.MockedFunction<
   typeof serializeBundle
@@ -126,6 +132,9 @@ describe('useVaultExport', () => {
       updateDisplayName: jest.fn(),
       clearError: jest.fn(),
     });
+    mockUseIdentitySelector.mockImplementation((selector) =>
+      selector(mockUseIdentityStore()),
+    );
 
     // Default fetch mock - success
     mockFetch.mockResolvedValue({

--- a/src/hooks/useEquipmentBrowser.ts
+++ b/src/hooks/useEquipmentBrowser.ts
@@ -15,7 +15,7 @@
 import { useEffect, useMemo, useCallback, useContext, useState } from 'react';
 
 import { equipmentLookupService } from '@/services/equipment/EquipmentLookupService';
-import { useEquipmentStore, SortColumn } from '@/stores/useEquipmentStore';
+import { useEquipmentSelector, SortColumn } from '@/stores/useEquipmentStore';
 import { UnitStoreContext, type UnitStore } from '@/stores/useUnitStore';
 import {
   VehicleStoreContext,
@@ -168,33 +168,49 @@ function useUnitContextValues(): {
  * Hook for equipment browser functionality
  */
 export function useEquipmentBrowser(): EquipmentBrowserState {
-  const {
-    equipment,
-    isLoading,
-    error,
-    filters,
-    pagination,
-    sort,
-    setEquipment,
-    setLoading,
-    setError,
-    setUnitContext,
-    setSearch,
-    setTechBaseFilter,
-    setCategoryFilter,
-    selectCategory,
-    showAllCategories,
-    toggleHidePrototype,
-    toggleHideOneShot,
-    toggleHideUnavailable,
-    toggleHideAmmoWithoutWeapon,
-    clearFilters,
-    setPage,
-    setPageSize,
-    setSort,
-    getFilteredEquipment,
-    getPaginatedEquipment,
-  } = useEquipmentStore();
+  const equipment = useEquipmentSelector((state) => state.equipment);
+  const isLoading = useEquipmentSelector((state) => state.isLoading);
+  const error = useEquipmentSelector((state) => state.error);
+  const filters = useEquipmentSelector((state) => state.filters);
+  const pagination = useEquipmentSelector((state) => state.pagination);
+  const sort = useEquipmentSelector((state) => state.sort);
+  const setEquipment = useEquipmentSelector((state) => state.setEquipment);
+  const setLoading = useEquipmentSelector((state) => state.setLoading);
+  const setError = useEquipmentSelector((state) => state.setError);
+  const setUnitContext = useEquipmentSelector((state) => state.setUnitContext);
+  const setSearch = useEquipmentSelector((state) => state.setSearch);
+  const setTechBaseFilter = useEquipmentSelector(
+    (state) => state.setTechBaseFilter,
+  );
+  const setCategoryFilter = useEquipmentSelector(
+    (state) => state.setCategoryFilter,
+  );
+  const selectCategory = useEquipmentSelector((state) => state.selectCategory);
+  const showAllCategories = useEquipmentSelector(
+    (state) => state.showAllCategories,
+  );
+  const toggleHidePrototype = useEquipmentSelector(
+    (state) => state.toggleHidePrototype,
+  );
+  const toggleHideOneShot = useEquipmentSelector(
+    (state) => state.toggleHideOneShot,
+  );
+  const toggleHideUnavailable = useEquipmentSelector(
+    (state) => state.toggleHideUnavailable,
+  );
+  const toggleHideAmmoWithoutWeapon = useEquipmentSelector(
+    (state) => state.toggleHideAmmoWithoutWeapon,
+  );
+  const clearFilters = useEquipmentSelector((state) => state.clearFilters);
+  const setPage = useEquipmentSelector((state) => state.setPage);
+  const setPageSize = useEquipmentSelector((state) => state.setPageSize);
+  const setSort = useEquipmentSelector((state) => state.setSort);
+  const getFilteredEquipment = useEquipmentSelector(
+    (state) => state.getFilteredEquipment,
+  );
+  const getPaginatedEquipment = useEquipmentSelector(
+    (state) => state.getPaginatedEquipment,
+  );
 
   // Get unit year, tech base, and weapon IDs from unit store context (if available)
   const {

--- a/src/hooks/useUnit.ts
+++ b/src/hooks/useUnit.ts
@@ -10,11 +10,11 @@
 import { useMemo, useCallback } from 'react';
 
 import {
-  useCustomizerStore,
+  useCustomizerSelector,
   EquipmentSelection,
 } from '@/stores/useCustomizerStore';
 import {
-  useMultiUnitStore,
+  useMultiUnitSelector,
   UnitTab,
   UNIT_TEMPLATES,
 } from '@/stores/useMultiUnitStore';
@@ -66,20 +66,24 @@ export interface SelectionContext {
  * Hook to access the current unit context
  */
 export function useUnit(): UnitContext {
-  const {
-    tabs,
-    activeTabId,
-    isLoading,
-    selectTab,
-    createTab,
-    duplicateTab,
-    closeTab,
-    renameTab,
-    markModified,
-    isNewTabModalOpen,
-    openNewTabModal,
-    closeNewTabModal,
-  } = useMultiUnitStore();
+  const tabs = useMultiUnitSelector((state) => state.tabs);
+  const activeTabId = useMultiUnitSelector((state) => state.activeTabId);
+  const isLoading = useMultiUnitSelector((state) => state.isLoading);
+  const selectTab = useMultiUnitSelector((state) => state.selectTab);
+  const createTab = useMultiUnitSelector((state) => state.createTab);
+  const duplicateTab = useMultiUnitSelector((state) => state.duplicateTab);
+  const closeTab = useMultiUnitSelector((state) => state.closeTab);
+  const renameTab = useMultiUnitSelector((state) => state.renameTab);
+  const markModified = useMultiUnitSelector((state) => state.markModified);
+  const isNewTabModalOpen = useMultiUnitSelector(
+    (state) => state.isNewTabModalOpen,
+  );
+  const openNewTabModal = useMultiUnitSelector(
+    (state) => state.openNewTabModal,
+  );
+  const closeNewTabModal = useMultiUnitSelector(
+    (state) => state.closeNewTabModal,
+  );
 
   const activeTab = useMemo(
     () => tabs.find((t) => t.id === activeTabId) || null,
@@ -146,14 +150,18 @@ export function useUnit(): UnitContext {
  * Hook to access selection state (equipment and location selection)
  */
 export function useSelection(): SelectionContext {
-  const {
-    selectedEquipment,
-    selectedLocation,
-    selectionMode,
-    selectEquipment,
-    selectLocation,
-    clearSelection,
-  } = useCustomizerStore();
+  const selectedEquipment = useCustomizerSelector(
+    (state) => state.selectedEquipment,
+  );
+  const selectedLocation = useCustomizerSelector(
+    (state) => state.selectedLocation,
+  );
+  const selectionMode = useCustomizerSelector((state) => state.selectionMode);
+  const selectEquipment = useCustomizerSelector(
+    (state) => state.selectEquipment,
+  );
+  const selectLocation = useCustomizerSelector((state) => state.selectLocation);
+  const clearSelection = useCustomizerSelector((state) => state.clearSelection);
 
   return {
     selectedEquipment,

--- a/src/hooks/useVaultExport.ts
+++ b/src/hooks/useVaultExport.ts
@@ -19,7 +19,7 @@ import type {
 } from '@/types/vault';
 
 import { serializeBundle } from '@/services/vault/BundleService';
-import { useIdentityStore } from '@/stores/useIdentityStore';
+import { useIdentitySelector } from '@/stores/useIdentityStore';
 
 // =============================================================================
 // API Response Types
@@ -96,7 +96,7 @@ export function useVaultExport(): UseVaultExportState & UseVaultExportActions {
   const [result, setResult] = useState<IExportResult | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const { isUnlocked } = useIdentityStore();
+  const isUnlocked = useIdentitySelector((state) => state.isUnlocked);
 
   /**
    * Export content via server-side signing

--- a/src/lib/multiplayer/server/ServerMatchHost.ts
+++ b/src/lib/multiplayer/server/ServerMatchHost.ts
@@ -57,8 +57,6 @@ import {
 } from '@/types/gameplay/GameSessionInterfaces';
 import { Facing, MovementType } from '@/types/gameplay/HexGridInterfaces';
 import {
-  HEARTBEAT_INTERVAL_MS,
-  HEARTBEAT_TIMEOUT_MS,
   intentHasForbiddenDiceField,
   type IIntent,
   type ILobbyUpdated,
@@ -86,6 +84,8 @@ import {
 } from './reconnection/PendingPeerTracker';
 import { streamReplay } from './reconnection/replayStream';
 import { RollCapture, SeededDiceRoller } from './RollCapture';
+import { ServerMatchBroadcaster } from './ServerMatchBroadcaster';
+import { ServerMatchSocketLifecycle } from './ServerMatchSocketLifecycle';
 
 // =============================================================================
 // Socket abstraction
@@ -94,18 +94,6 @@ import { RollCapture, SeededDiceRoller } from './RollCapture';
 // Re-exported for external consumers (e.g. websocket upgrade handler) so the
 // canonical home (`ServerMatchSocketTypes`) doesn't force a path change.
 export type { IMatchSocket } from './ServerMatchSocketTypes';
-
-/**
- * Per-socket bookkeeping kept in a side-Map. We don't subclass the
- * socket itself because the `ws` library's WebSocket type is not
- * trivially extendable across versions.
- */
-interface ISocketState {
-  socket: IMatchSocket;
-  playerId: string;
-  lastInboundAt: number;
-  heartbeatTimer: NodeJS.Timeout;
-}
 
 // =============================================================================
 // Engine bootstrap input — Wave 1 keeps it minimal
@@ -141,7 +129,8 @@ export interface IMatchHostBootstrap {
 // =============================================================================
 
 export class ServerMatchHost {
-  private readonly sockets = new Map<IMatchSocket, ISocketState>();
+  private readonly broadcaster = new ServerMatchBroadcaster();
+  private readonly lifecycle: ServerMatchSocketLifecycle;
   private readonly session: InteractiveSession;
   private lastBroadcastSeq: number;
   private closed = false;
@@ -222,6 +211,17 @@ export class ServerMatchHost {
     this.session = session;
     this.sourceRoller = sourceRoller ?? new CryptoDiceRoller();
     this.currentCapture = new RollCapture(this.sourceRoller);
+    this.lifecycle = new ServerMatchSocketLifecycle({
+      matchId: this.matchId,
+      broadcaster: this.broadcaster,
+      onLastSocketDropped: (playerId) => {
+        if (this.closed) return;
+        // Fire-and-forget — meta lookup is async but socket close is
+        // sync. Failures here just skip the pause path; the match keeps
+        // running in degraded mode rather than crashing.
+        void this.maybeMarkPlayerPending(playerId);
+      },
+    });
     // Stable callback identity — engine holds this reference for the
     // lifetime of the match. Routes every d6 through whatever
     // `currentCapture` points at right now.
@@ -338,36 +338,7 @@ export class ServerMatchHost {
     // so the order matches the proposal: replay → LobbyUpdated →
     // MatchResumed.
     this.pendingPeers.clearPending(playerId);
-    const heartbeatTimer = setInterval(() => {
-      const state = this.sockets.get(socket);
-      if (!state) return;
-      const idleFor = Date.now() - state.lastInboundAt;
-      if (idleFor > HEARTBEAT_TIMEOUT_MS) {
-        // Treat as dead — close + detach. Caller's `on('close')`
-        // listener is what actually removes from the set.
-        this.detachSocket(socket);
-        return;
-      }
-      this.safeSend(socket, {
-        kind: 'Heartbeat',
-        matchId: this.matchId,
-        ts: nowIso(),
-      });
-    }, HEARTBEAT_INTERVAL_MS);
-
-    // `unref` so a dangling timer doesn't keep Node alive in tests; it
-    // exists only on `NodeJS.Timeout`, never on the browser-style
-    // `Timer`. We're always in Node here, but the cast keeps TS happy.
-    if (typeof (heartbeatTimer as NodeJS.Timeout).unref === 'function') {
-      (heartbeatTimer as NodeJS.Timeout).unref();
-    }
-
-    this.sockets.set(socket, {
-      socket,
-      playerId,
-      lastInboundAt: Date.now(),
-      heartbeatTimer,
-    });
+    this.lifecycle.attach(socket, playerId);
   }
 
   /**
@@ -375,33 +346,7 @@ export class ServerMatchHost {
    * path (client bye, heartbeat timeout, host shutdown).
    */
   detachSocket(socket: IMatchSocket): void {
-    const state = this.sockets.get(socket);
-    if (!state) return;
-    clearInterval(state.heartbeatTimer);
-    this.sockets.delete(socket);
-    // Wave 4: if the dropping socket held a human seat in an active
-    // match, mark the seat pending and start the grace timer. Lobby
-    // status drops are NOT paused (no engine to pause yet) — pre-
-    // active reconnect just uses the seat ledger.
-    //
-    // Also guarded: the same player might still have ANOTHER socket
-    // attached (multi-tab same-account) — only mark pending when this
-    // was their last socket.
-    const playerId = state.playerId;
-    const stillHasSocket = Array.from(this.sockets.values()).some(
-      (s) => s.playerId === playerId,
-    );
-    if (!stillHasSocket && !this.closed) {
-      // Fire-and-forget — meta lookup is async but socket close is
-      // sync. Failures here just skip the pause path; the match keeps
-      // running in degraded mode rather than crashing.
-      void this.maybeMarkPlayerPending(playerId);
-    }
-    try {
-      socket.close();
-    } catch {
-      // already closed — ignore
-    }
+    this.lifecycle.detach(socket);
   }
 
   /**
@@ -487,9 +432,7 @@ export class ServerMatchHost {
    * comes in for this socket. Resets the dead-connection timer.
    */
   noteInbound(socket: IMatchSocket): void {
-    const state = this.sockets.get(socket);
-    if (!state) return;
-    state.lastInboundAt = Date.now();
+    this.lifecycle.noteInbound(socket);
   }
 
   // ---------------------------------------------------------------------------
@@ -728,7 +671,7 @@ export class ServerMatchHost {
     // If the match was force-closed mid-fight (host crash, admin kill)
     // and the win-condition predicate happens to trip, this catches it.
     this.tryPublishOutcome();
-    const socketList = Array.from(this.sockets.keys());
+    const socketList = this.lifecycle.snapshot();
     for (const socket of socketList) {
       this.safeSend(socket, {
         kind: 'Close',
@@ -798,7 +741,7 @@ export class ServerMatchHost {
 
   /** Test/observability: number of currently-connected sockets. */
   socketCount(): number {
-    return this.sockets.size;
+    return this.lifecycle.count();
   }
 
   /** Test/observability: most recent broadcast sequence (or -1). */
@@ -1028,14 +971,7 @@ export class ServerMatchHost {
    * swallowed — the heartbeat timer will reap dead sockets.
    */
   private broadcast(message: IServerMessage): void {
-    const payload = JSON.stringify(message);
-    this.sockets.forEach((_state, socket) => {
-      try {
-        socket.send(payload);
-      } catch {
-        // Socket is dead — let the heartbeat / close handler clean up.
-      }
-    });
+    this.broadcaster.broadcast(message);
   }
 
   /**
@@ -1044,11 +980,7 @@ export class ServerMatchHost {
    * of the upgrade handler.
    */
   private safeSend(socket: IMatchSocket, message: IServerMessage): void {
-    try {
-      socket.send(JSON.stringify(message));
-    } catch {
-      // ignore
-    }
+    this.broadcaster.safeSend(socket, message);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/lib/multiplayer/server/__tests__/ServerMatchHost.test.ts
+++ b/src/lib/multiplayer/server/__tests__/ServerMatchHost.test.ts
@@ -176,6 +176,7 @@ describe('ServerMatchHost', () => {
     expect(host.isClosed()).toBe(true);
     const meta = await store.getMatchMeta(host.matchId);
     expect(meta.status).toBe('completed');
+    expect(host.socketCount()).toBe(0);
     // The socket should have received a Close envelope.
     const kinds = socket.sent.map((s) => s.parsed.kind);
     expect(kinds).toContain('Close');

--- a/src/lib/multiplayer/server/__tests__/ServerMatchSocketLifecycle.test.ts
+++ b/src/lib/multiplayer/server/__tests__/ServerMatchSocketLifecycle.test.ts
@@ -1,0 +1,158 @@
+import {
+  HEARTBEAT_INTERVAL_MS,
+  HEARTBEAT_TIMEOUT_MS,
+  type IServerMessage,
+} from '@/types/multiplayer/Protocol';
+
+import type { IMatchSocket } from '../ServerMatchSocketTypes';
+
+import { ServerMatchBroadcaster } from '../ServerMatchBroadcaster';
+import { ServerMatchSocketLifecycle } from '../ServerMatchSocketLifecycle';
+
+interface IRecordedSend {
+  payload: string;
+  parsed: IServerMessage;
+}
+
+function makeMockSocket(): IMatchSocket & {
+  sent: IRecordedSend[];
+  closeCount: number;
+} {
+  const sent: IRecordedSend[] = [];
+  let closeCount = 0;
+
+  return {
+    send(data: string) {
+      sent.push({
+        payload: data,
+        parsed: JSON.parse(data) as IServerMessage,
+      });
+    },
+    close() {
+      closeCount += 1;
+    },
+    get readyState() {
+      return closeCount > 0 ? 3 : 1;
+    },
+    sent,
+    get closeCount() {
+      return closeCount;
+    },
+  };
+}
+
+function makeLifecycle(onLastSocketDropped = jest.fn()): {
+  broadcaster: ServerMatchBroadcaster;
+  lifecycle: ServerMatchSocketLifecycle;
+  onLastSocketDropped: jest.Mock;
+} {
+  const broadcaster = new ServerMatchBroadcaster();
+  return {
+    broadcaster,
+    lifecycle: new ServerMatchSocketLifecycle({
+      matchId: 'match-lifecycle',
+      broadcaster,
+      onLastSocketDropped,
+    }),
+    onLastSocketDropped,
+  };
+}
+
+describe('ServerMatchSocketLifecycle', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('attaches sockets, registers them for broadcast, and reattach does not leak heartbeat timers', () => {
+    const { broadcaster, lifecycle } = makeLifecycle();
+    const socket = makeMockSocket();
+
+    lifecycle.attach(socket, 'p1');
+    lifecycle.attach(socket, 'p1');
+
+    expect(lifecycle.count()).toBe(1);
+    broadcaster.broadcast({
+      kind: 'MatchResumed',
+      matchId: 'match-lifecycle',
+      ts: '2026-04-29T00:00:00.000Z',
+    });
+
+    jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+
+    expect(socket.sent.map((send) => send.parsed.kind)).toEqual([
+      'MatchResumed',
+      'Heartbeat',
+    ]);
+  });
+
+  it('detaches idempotently and removes the socket from broadcaster fan-out', () => {
+    const { broadcaster, lifecycle, onLastSocketDropped } = makeLifecycle();
+    const socket = makeMockSocket();
+
+    lifecycle.attach(socket, 'p1');
+    lifecycle.detach(socket);
+    lifecycle.detach(socket);
+
+    broadcaster.broadcast({
+      kind: 'MatchResumed',
+      matchId: 'match-lifecycle',
+      ts: '2026-04-29T00:00:00.000Z',
+    });
+
+    expect(lifecycle.count()).toBe(0);
+    expect(socket.closeCount).toBe(1);
+    expect(socket.sent).toHaveLength(0);
+    expect(onLastSocketDropped).toHaveBeenCalledTimes(1);
+    expect(onLastSocketDropped).toHaveBeenCalledWith('p1');
+  });
+
+  it('fires the drop callback only when the last socket for a player detaches', () => {
+    const { lifecycle, onLastSocketDropped } = makeLifecycle();
+    const first = makeMockSocket();
+    const second = makeMockSocket();
+
+    lifecycle.attach(first, 'p1');
+    lifecycle.attach(second, 'p1');
+
+    lifecycle.detach(first);
+    expect(onLastSocketDropped).not.toHaveBeenCalled();
+    expect(lifecycle.count()).toBe(1);
+
+    lifecycle.detach(second);
+    expect(onLastSocketDropped).toHaveBeenCalledTimes(1);
+    expect(onLastSocketDropped).toHaveBeenCalledWith('p1');
+    expect(lifecycle.count()).toBe(0);
+  });
+
+  it('detaches idle sockets after the heartbeat timeout window', () => {
+    const { lifecycle, onLastSocketDropped } = makeLifecycle();
+    const socket = makeMockSocket();
+
+    lifecycle.attach(socket, 'p1');
+
+    jest.advanceTimersByTime(HEARTBEAT_TIMEOUT_MS + HEARTBEAT_INTERVAL_MS + 1);
+
+    expect(lifecycle.count()).toBe(0);
+    expect(socket.closeCount).toBe(1);
+    expect(onLastSocketDropped).toHaveBeenCalledWith('p1');
+  });
+
+  it('noteInbound refreshes the idle timer so active sockets are not detached', () => {
+    const { lifecycle, onLastSocketDropped } = makeLifecycle();
+    const socket = makeMockSocket();
+
+    lifecycle.attach(socket, 'p1');
+
+    jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS * 2);
+    lifecycle.noteInbound(socket);
+    jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS * 2);
+
+    expect(lifecycle.count()).toBe(1);
+    expect(socket.closeCount).toBe(0);
+    expect(onLastSocketDropped).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/p2p/useSyncRoom.ts
+++ b/src/lib/p2p/useSyncRoom.ts
@@ -12,7 +12,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { formatRoomCode } from './roomCodes';
 import { getConnectedPeerCount } from './SyncProvider';
 import { ConnectionState, IPeer } from './types';
-import { useSyncRoomStore } from './useSyncRoomStore';
+import { useSyncRoomSelector } from './useSyncRoomStore';
 
 // =============================================================================
 // Hook Return Type
@@ -88,12 +88,25 @@ export interface UseSyncRoomReturn {
  * ```
  */
 export function useSyncRoom(): UseSyncRoomReturn {
-  const store = useSyncRoomStore();
+  const activeRoom = useSyncRoomSelector((state) => state.activeRoom);
+  const connectionState = useSyncRoomSelector((state) => state.connectionState);
+  const peers = useSyncRoomSelector((state) => state.peers);
+  const error = useSyncRoomSelector((state) => state.error);
+  const localPeerNameValue = useSyncRoomSelector(
+    (state) => state.localPeerName,
+  );
+  const createSyncRoom = useSyncRoomSelector((state) => state.createRoom);
+  const joinSyncRoom = useSyncRoomSelector((state) => state.joinRoom);
+  const leaveSyncRoom = useSyncRoomSelector((state) => state.leaveRoom);
+  const setLocalPeerNameAction = useSyncRoomSelector(
+    (state) => state.setLocalPeerName,
+  );
+  const clearSyncError = useSyncRoomSelector((state) => state.clearError);
   const [peerCount, setPeerCount] = useState(0);
 
   // Poll peer count (awareness updates don't always trigger store updates)
   useEffect(() => {
-    if (!store.activeRoom) {
+    if (!activeRoom) {
       setPeerCount(0);
       return;
     }
@@ -109,50 +122,48 @@ export function useSyncRoom(): UseSyncRoomReturn {
     const interval = setInterval(updatePeerCount, 1000);
 
     return () => clearInterval(interval);
-  }, [store.activeRoom]);
+  }, [activeRoom]);
 
   const createRoom = useCallback(
     async (password?: string) => {
-      const code = await store.createRoom({ password });
+      const code = await createSyncRoom({ password });
       return formatRoomCode(code);
     },
-    [store],
+    [createSyncRoom],
   );
 
   const joinRoom = useCallback(
     async (roomCode: string, password?: string) => {
-      await store.joinRoom(roomCode, password);
+      await joinSyncRoom(roomCode, password);
     },
-    [store],
+    [joinSyncRoom],
   );
 
   const leaveRoom = useCallback(() => {
-    store.leaveRoom();
-  }, [store]);
+    leaveSyncRoom();
+  }, [leaveSyncRoom]);
 
   const setLocalPeerName = useCallback(
     (name: string) => {
-      store.setLocalPeerName(name);
+      setLocalPeerNameAction(name);
     },
-    [store],
+    [setLocalPeerNameAction],
   );
 
   const clearError = useCallback(() => {
-    store.clearError();
-  }, [store]);
+    clearSyncError();
+  }, [clearSyncError]);
 
   return {
-    roomCode: store.activeRoom
-      ? formatRoomCode(store.activeRoom.roomCode)
-      : null,
-    rawRoomCode: store.activeRoom?.roomCode ?? null,
-    connectionState: store.connectionState,
-    isConnected: store.connectionState === ConnectionState.Connected,
-    isConnecting: store.connectionState === ConnectionState.Connecting,
+    roomCode: activeRoom ? formatRoomCode(activeRoom.roomCode) : null,
+    rawRoomCode: activeRoom?.roomCode ?? null,
+    connectionState,
+    isConnected: connectionState === ConnectionState.Connected,
+    isConnecting: connectionState === ConnectionState.Connecting,
     peerCount,
-    peers: store.peers,
-    error: store.error,
-    localPeerName: store.localPeerName,
+    peers,
+    error,
+    localPeerName: localPeerNameValue,
     createRoom,
     joinRoom,
     leaveRoom,

--- a/src/lib/p2p/useSyncRoomStore.ts
+++ b/src/lib/p2p/useSyncRoomStore.ts
@@ -182,39 +182,45 @@ export const useSyncRoomStore = create<SyncRoomStore>()(
 // Selector Hooks
 // =============================================================================
 
+export function useSyncRoomSelector<T>(
+  selector: (state: SyncRoomStore) => T,
+): T {
+  return useSyncRoomStore(selector);
+}
+
 /**
  * Get the current room code.
  */
 export function useRoomCode(): string | null {
-  return useSyncRoomStore((state) => state.activeRoom?.roomCode ?? null);
+  return useSyncRoomSelector((state) => state.activeRoom?.roomCode ?? null);
 }
 
 /**
  * Get the connection state.
  */
 export function useConnectionState(): ConnectionState {
-  return useSyncRoomStore((state) => state.connectionState);
+  return useSyncRoomSelector((state) => state.connectionState);
 }
 
 /**
  * Get the connected peers.
  */
 export function usePeers(): readonly IPeer[] {
-  return useSyncRoomStore((state) => state.peers);
+  return useSyncRoomSelector((state) => state.peers);
 }
 
 /**
  * Get the peer count.
  */
 export function usePeerCount(): number {
-  return useSyncRoomStore((state) => state.peers.length);
+  return useSyncRoomSelector((state) => state.peers.length);
 }
 
 /**
  * Check if connected to a room.
  */
 export function useIsConnected(): boolean {
-  return useSyncRoomStore(
+  return useSyncRoomSelector(
     (state) => state.connectionState === ConnectionState.Connected,
   );
 }
@@ -223,5 +229,5 @@ export function useIsConnected(): boolean {
  * Get the local peer name.
  */
 export function useLocalPeerName(): string {
-  return useSyncRoomStore((state) => state.localPeerName);
+  return useSyncRoomSelector((state) => state.localPeerName);
 }

--- a/src/pages/gameplay/encounters/[id].tsx
+++ b/src/pages/gameplay/encounters/[id].tsx
@@ -32,9 +32,9 @@ import { buildPreparedBattleData } from '@/components/gameplay/pages/preBattleSe
 import { QuickResolveLauncher } from '@/components/gameplay/quickResolve/QuickResolveLauncher';
 import { useToast } from '@/components/shared/Toast';
 import { Badge, Button, PageLayout } from '@/components/ui';
-import { useEncounterStore } from '@/stores/useEncounterStore';
-import { useForceStore } from '@/stores/useForceStore';
-import { usePilotStore } from '@/stores/usePilotStore';
+import { useEncounterSelector } from '@/stores/useEncounterStore';
+import { useForceSelector } from '@/stores/useForceStore';
+import { usePilotSelector } from '@/stores/usePilotStore';
 import { EncounterStatus, SCENARIO_TEMPLATES } from '@/types/encounter';
 import { getStatusColor, getStatusLabel } from '@/utils/encounterStatus';
 import { logger } from '@/utils/logger';
@@ -44,19 +44,23 @@ export default function EncounterDetailPage(): React.ReactElement {
   const { id } = router.query;
   const { showToast } = useToast();
 
-  const {
-    getEncounter,
-    loadEncounters,
-    deleteEncounter,
-    validateEncounter,
-    validations,
-    isLoading,
-    error,
-    clearError,
-  } = useEncounterStore();
+  const getEncounter = useEncounterSelector((state) => state.getEncounter);
+  const loadEncounters = useEncounterSelector((state) => state.loadEncounters);
+  const deleteEncounter = useEncounterSelector(
+    (state) => state.deleteEncounter,
+  );
+  const validateEncounter = useEncounterSelector(
+    (state) => state.validateEncounter,
+  );
+  const validations = useEncounterSelector((state) => state.validations);
+  const isLoading = useEncounterSelector((state) => state.isLoading);
+  const error = useEncounterSelector((state) => state.error);
+  const clearError = useEncounterSelector((state) => state.clearError);
 
-  const { forces, loadForces } = useForceStore();
-  const { pilots, loadPilots } = usePilotStore();
+  const forces = useForceSelector((state) => state.forces);
+  const loadForces = useForceSelector((state) => state.loadForces);
+  const pilots = usePilotSelector((state) => state.pilots);
+  const loadPilots = usePilotSelector((state) => state.loadPilots);
 
   const [isInitialized, setIsInitialized] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);

--- a/src/pages/gameplay/encounters/[id]/pre-battle.tsx
+++ b/src/pages/gameplay/encounters/[id]/pre-battle.tsx
@@ -36,10 +36,10 @@ import { useToast } from '@/components/shared/Toast';
 import { Card, PageLayout } from '@/components/ui';
 import { adaptUnit } from '@/engine/adapters/CompendiumAdapter';
 import { GameEngine } from '@/engine/GameEngine';
-import { useEncounterStore } from '@/stores/useEncounterStore';
-import { useForceStore } from '@/stores/useForceStore';
+import { useEncounterSelector } from '@/stores/useEncounterStore';
+import { useForceSelector } from '@/stores/useForceStore';
 import { useGameplaySelector } from '@/stores/useGameplayStore';
-import { usePilotStore } from '@/stores/usePilotStore';
+import { usePilotSelector } from '@/stores/usePilotStore';
 import {
   EncounterStatus,
   SCENARIO_TEMPLATES,
@@ -83,14 +83,16 @@ export default function PreBattlePage(): React.ReactElement {
   const { id } = router.query;
   const { showToast } = useToast();
 
-  const {
-    getEncounter,
-    loadEncounters,
-    updateEncounter,
-    isLoading: encountersLoading,
-  } = useEncounterStore();
-  const { forces, loadForces } = useForceStore();
-  const { pilots, loadPilots } = usePilotStore();
+  const getEncounter = useEncounterSelector((state) => state.getEncounter);
+  const loadEncounters = useEncounterSelector((state) => state.loadEncounters);
+  const updateEncounter = useEncounterSelector(
+    (state) => state.updateEncounter,
+  );
+  const encountersLoading = useEncounterSelector((state) => state.isLoading);
+  const forces = useForceSelector((state) => state.forces);
+  const loadForces = useForceSelector((state) => state.loadForces);
+  const pilots = usePilotSelector((state) => state.pilots);
+  const loadPilots = usePilotSelector((state) => state.loadPilots);
   // Per-field selectors (useGameplaySelector POC). All three are stable
   // action references, so each subscription is effectively static —
   // we still pull them individually to keep the convention uniform

--- a/src/pages/gameplay/encounters/[id]/sim.tsx
+++ b/src/pages/gameplay/encounters/[id]/sim.tsx
@@ -27,9 +27,9 @@ import { QuickSimResultPanel } from '@/components/gameplay/QuickSimResultPanel';
 import { useToast } from '@/components/shared/Toast';
 import { Button, PageLayout } from '@/components/ui';
 import { useQuickResolve } from '@/hooks/useQuickResolve';
-import { useEncounterStore } from '@/stores/useEncounterStore';
-import { useForceStore } from '@/stores/useForceStore';
-import { usePilotStore } from '@/stores/usePilotStore';
+import { useEncounterSelector } from '@/stores/useEncounterStore';
+import { useForceSelector } from '@/stores/useForceStore';
+import { usePilotSelector } from '@/stores/usePilotStore';
 import { logger } from '@/utils/logger';
 
 const DEFAULT_RUN_COUNT = 100;
@@ -47,13 +47,13 @@ export default function QuickSimResultPage(): React.ReactElement {
   const encounterId = typeof id === 'string' ? id : '';
 
   // Encounter / force / pilot data (mirrors encounter detail page).
-  const {
-    getEncounter,
-    loadEncounters,
-    isLoading: encountersLoading,
-  } = useEncounterStore();
-  const { forces, loadForces } = useForceStore();
-  const { pilots, loadPilots } = usePilotStore();
+  const getEncounter = useEncounterSelector((state) => state.getEncounter);
+  const loadEncounters = useEncounterSelector((state) => state.loadEncounters);
+  const encountersLoading = useEncounterSelector((state) => state.isLoading);
+  const forces = useForceSelector((state) => state.forces);
+  const loadForces = useForceSelector((state) => state.loadForces);
+  const pilots = usePilotSelector((state) => state.pilots);
+  const loadPilots = usePilotSelector((state) => state.loadPilots);
 
   const [isInitialized, setIsInitialized] = useState(false);
   const [runCount, setRunCount] = useState<number>(DEFAULT_RUN_COUNT);

--- a/src/pages/gameplay/encounters/create.tsx
+++ b/src/pages/gameplay/encounters/create.tsx
@@ -9,7 +9,7 @@ import { useState, useCallback } from 'react';
 
 import { useToast } from '@/components/shared/Toast';
 import { PageLayout, Card, Input, Textarea, Button } from '@/components/ui';
-import { useEncounterStore } from '@/stores/useEncounterStore';
+import { useEncounterSelector } from '@/stores/useEncounterStore';
 import { SCENARIO_TEMPLATES, ScenarioTemplateType } from '@/types/encounter';
 
 // =============================================================================
@@ -61,7 +61,12 @@ function TemplateCard({
 
 export default function CreateEncounterPage(): React.ReactElement {
   const router = useRouter();
-  const { createEncounter, isLoading, error, clearError } = useEncounterStore();
+  const createEncounter = useEncounterSelector(
+    (state) => state.createEncounter,
+  );
+  const isLoading = useEncounterSelector((state) => state.isLoading);
+  const error = useEncounterSelector((state) => state.error);
+  const clearError = useEncounterSelector((state) => state.clearError);
   const { showToast } = useToast();
 
   const [name, setName] = useState('');

--- a/src/pages/gameplay/encounters/index.tsx
+++ b/src/pages/gameplay/encounters/index.tsx
@@ -16,7 +16,7 @@ import {
   EmptyState,
   Badge,
 } from '@/components/ui';
-import { useEncounterStore } from '@/stores/useEncounterStore';
+import { useEncounterSelector } from '@/stores/useEncounterStore';
 import {
   IEncounter,
   EncounterStatus,
@@ -113,17 +113,21 @@ function EncounterCard({
 
 export default function EncountersListPage(): React.ReactElement {
   const router = useRouter();
-  const {
-    isLoading,
-    error,
-    loadEncounters,
-    searchQuery,
-    setSearchQuery,
-    statusFilter,
-    setStatusFilter,
-    getFilteredEncounters,
-    selectEncounter,
-  } = useEncounterStore();
+  const isLoading = useEncounterSelector((state) => state.isLoading);
+  const error = useEncounterSelector((state) => state.error);
+  const loadEncounters = useEncounterSelector((state) => state.loadEncounters);
+  const searchQuery = useEncounterSelector((state) => state.searchQuery);
+  const setSearchQuery = useEncounterSelector((state) => state.setSearchQuery);
+  const statusFilter = useEncounterSelector((state) => state.statusFilter);
+  const setStatusFilter = useEncounterSelector(
+    (state) => state.setStatusFilter,
+  );
+  const getFilteredEncounters = useEncounterSelector(
+    (state) => state.getFilteredEncounters,
+  );
+  const selectEncounter = useEncounterSelector(
+    (state) => state.selectEncounter,
+  );
 
   const filteredEncounters = getFilteredEncounters();
   const [isInitialized, setIsInitialized] = useState(false);

--- a/src/pages/gameplay/forces/create.tsx
+++ b/src/pages/gameplay/forces/create.tsx
@@ -17,7 +17,7 @@ import {
   Textarea,
   Badge,
 } from '@/components/ui';
-import { useForceStore } from '@/stores/useForceStore';
+import { useForceSelector } from '@/stores/useForceStore';
 import { ForceType } from '@/types/force';
 
 // =============================================================================
@@ -123,7 +123,10 @@ function ForceTypeCard({
 
 export default function CreateForcePage(): React.ReactElement {
   const router = useRouter();
-  const { createForce, isLoading, error, clearError } = useForceStore();
+  const createForce = useForceSelector((state) => state.createForce);
+  const isLoading = useForceSelector((state) => state.isLoading);
+  const error = useForceSelector((state) => state.error);
+  const clearError = useForceSelector((state) => state.clearError);
   const { showToast } = useToast();
 
   // Form state

--- a/src/pages/gameplay/forces/index.tsx
+++ b/src/pages/gameplay/forces/index.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/common/SkeletonLoader';
 import { ForceCard } from '@/components/force';
 import { PageLayout, Card, Input, Button, EmptyState } from '@/components/ui';
-import { useForceStore } from '@/stores/useForceStore';
+import { useForceSelector } from '@/stores/useForceStore';
 import { IForce } from '@/types/force';
 
 // =============================================================================
@@ -23,15 +23,15 @@ import { IForce } from '@/types/force';
 
 export default function ForceRosterPage(): React.ReactElement {
   const router = useRouter();
-  const {
-    isLoading,
-    error,
-    loadForces,
-    searchQuery,
-    setSearchQuery,
-    getFilteredForces,
-    selectForce,
-  } = useForceStore();
+  const isLoading = useForceSelector((state) => state.isLoading);
+  const error = useForceSelector((state) => state.error);
+  const loadForces = useForceSelector((state) => state.loadForces);
+  const searchQuery = useForceSelector((state) => state.searchQuery);
+  const setSearchQuery = useForceSelector((state) => state.setSearchQuery);
+  const getFilteredForces = useForceSelector(
+    (state) => state.getFilteredForces,
+  );
+  const selectForce = useForceSelector((state) => state.selectForce);
 
   const filteredForces = getFilteredForces();
   const [isInitialized, setIsInitialized] = useState(false);

--- a/src/pages/gameplay/games/[id].tsx
+++ b/src/pages/gameplay/games/[id].tsx
@@ -21,7 +21,10 @@ import {
   GameError,
   GameLoading,
 } from '@/components/gameplay/pages/GameSessionPage.states';
-import { useGameplayStore, InteractivePhase } from '@/stores/useGameplayStore';
+import {
+  useGameplaySelector,
+  InteractivePhase,
+} from '@/stores/useGameplayStore';
 import {
   Facing,
   GamePhase,
@@ -68,47 +71,52 @@ export default function GameSessionPage(): React.ReactElement {
   const campaignIdStr = typeof campaignId === 'string' ? campaignId : undefined;
   const missionIdStr = typeof missionId === 'string' ? missionId : undefined;
 
-  // INTENTIONAL FULL-STORE DESTRUCTURE (useGameplaySelector POC opt-out):
-  // this page consumes 30+ fields from the gameplay store. Splitting
-  // each into its own per-field selector would add dozens of
-  // subscription objects and the page already re-renders on most
-  // gameplay mutations anyway (it owns the active session view), so
-  // the per-field overhead would outweigh the re-render savings.
-  // Smaller consumers (SpectatorView, pre-battle) DO use the
-  // `useGameplaySelector` helper — see `useGameplayStore.ts` selector
-  // helper docs for the heuristic.
-  const {
-    session,
-    isLoading,
-    error,
-    loadSession,
-    createDemoSession,
-    ui,
-    selectUnit,
-    handleAction,
-    unitWeapons,
-    maxArmor,
-    maxStructure,
-    pilotNames,
-    heatSinks,
-    unitSpas,
-    clearError,
-    interactiveSession,
-    interactivePhase,
-    spectatorMode,
-    validTargetIds,
-    hitChance,
-    handleInteractiveHexClick,
-    handleInteractiveTokenClick,
-    advanceInteractivePhase,
-    fireWeapons,
-    runAITurn,
-    skipPhase,
-    checkGameOver,
-    plannedMovement,
-    setPlannedMovement,
-    clearPlannedMovement,
-  } = useGameplayStore();
+  const session = useGameplaySelector((state) => state.session);
+  const isLoading = useGameplaySelector((state) => state.isLoading);
+  const error = useGameplaySelector((state) => state.error);
+  const loadSession = useGameplaySelector((state) => state.loadSession);
+  const createDemoSession = useGameplaySelector(
+    (state) => state.createDemoSession,
+  );
+  const ui = useGameplaySelector((state) => state.ui);
+  const selectUnit = useGameplaySelector((state) => state.selectUnit);
+  const handleAction = useGameplaySelector((state) => state.handleAction);
+  const unitWeapons = useGameplaySelector((state) => state.unitWeapons);
+  const maxArmor = useGameplaySelector((state) => state.maxArmor);
+  const maxStructure = useGameplaySelector((state) => state.maxStructure);
+  const pilotNames = useGameplaySelector((state) => state.pilotNames);
+  const heatSinks = useGameplaySelector((state) => state.heatSinks);
+  const unitSpas = useGameplaySelector((state) => state.unitSpas);
+  const clearError = useGameplaySelector((state) => state.clearError);
+  const interactiveSession = useGameplaySelector(
+    (state) => state.interactiveSession,
+  );
+  const interactivePhase = useGameplaySelector(
+    (state) => state.interactivePhase,
+  );
+  const spectatorMode = useGameplaySelector((state) => state.spectatorMode);
+  const validTargetIds = useGameplaySelector((state) => state.validTargetIds);
+  const hitChance = useGameplaySelector((state) => state.hitChance);
+  const handleInteractiveHexClick = useGameplaySelector(
+    (state) => state.handleInteractiveHexClick,
+  );
+  const handleInteractiveTokenClick = useGameplaySelector(
+    (state) => state.handleInteractiveTokenClick,
+  );
+  const advanceInteractivePhase = useGameplaySelector(
+    (state) => state.advanceInteractivePhase,
+  );
+  const fireWeapons = useGameplaySelector((state) => state.fireWeapons);
+  const runAITurn = useGameplaySelector((state) => state.runAITurn);
+  const skipPhase = useGameplaySelector((state) => state.skipPhase);
+  const checkGameOver = useGameplaySelector((state) => state.checkGameOver);
+  const plannedMovement = useGameplaySelector((state) => state.plannedMovement);
+  const setPlannedMovement = useGameplaySelector(
+    (state) => state.setPlannedMovement,
+  );
+  const clearPlannedMovement = useGameplaySelector(
+    (state) => state.clearPlannedMovement,
+  );
 
   useEffect(() => {
     if (id === 'demo') {

--- a/src/pages/gameplay/pilots/[id].tsx
+++ b/src/pages/gameplay/pilots/[id].tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/pilots';
 import { useToast } from '@/components/shared/Toast';
 import { PageLayout, PageError, Button } from '@/components/ui';
-import { usePilotStore, usePilotById } from '@/stores/usePilotStore';
+import { usePilotSelector, usePilotById } from '@/stores/usePilotStore';
 
 type PilotTab = 'overview' | 'career';
 
@@ -20,8 +20,11 @@ export default function PilotDetailPage(): React.ReactElement {
   const pilotId = typeof id === 'string' ? id : null;
   const { showToast } = useToast();
 
-  const { loadPilots, updatePilot, deletePilot, isLoading, error } =
-    usePilotStore();
+  const loadPilots = usePilotSelector((state) => state.loadPilots);
+  const updatePilot = usePilotSelector((state) => state.updatePilot);
+  const deletePilot = usePilotSelector((state) => state.deletePilot);
+  const isLoading = usePilotSelector((state) => state.isLoading);
+  const error = usePilotSelector((state) => state.error);
   const pilot = usePilotById(pilotId);
 
   const [isInitialized, setIsInitialized] = useState(false);

--- a/src/pages/gameplay/pilots/index.tsx
+++ b/src/pages/gameplay/pilots/index.tsx
@@ -18,7 +18,7 @@ import {
   Badge,
   EmptyState,
 } from '@/components/ui';
-import { usePilotStore, useFilteredPilots } from '@/stores/usePilotStore';
+import { usePilotSelector, useFilteredPilots } from '@/stores/usePilotStore';
 import { IPilot, PilotStatus, getPilotRating } from '@/types/pilot';
 
 // =============================================================================
@@ -176,15 +176,15 @@ function PilotCard({ pilot }: PilotCardProps): React.ReactElement {
 
 export default function PilotRosterPage(): React.ReactElement {
   const router = useRouter();
-  const {
-    isLoading,
-    error,
-    loadPilots,
-    showActiveOnly,
-    setShowActiveOnly,
-    searchQuery,
-    setSearchQuery,
-  } = usePilotStore();
+  const isLoading = usePilotSelector((state) => state.isLoading);
+  const error = usePilotSelector((state) => state.error);
+  const loadPilots = usePilotSelector((state) => state.loadPilots);
+  const showActiveOnly = usePilotSelector((state) => state.showActiveOnly);
+  const setShowActiveOnly = usePilotSelector(
+    (state) => state.setShowActiveOnly,
+  );
+  const searchQuery = usePilotSelector((state) => state.searchQuery);
+  const setSearchQuery = usePilotSelector((state) => state.setSearchQuery);
 
   const filteredPilots = useFilteredPilots();
   const [isInitialized, setIsInitialized] = useState(false);

--- a/src/pages/gameplay/quick/index.tsx
+++ b/src/pages/gameplay/quick/index.tsx
@@ -16,7 +16,7 @@ import {
   QuickGameResults,
 } from '@/components/quickgame';
 import { Button, Card } from '@/components/ui';
-import { useQuickGameStore } from '@/stores/useQuickGameStore';
+import { useQuickGameSelector } from '@/stores/useQuickGameStore';
 import { QuickGameStep } from '@/types/quickgame';
 
 // =============================================================================
@@ -232,7 +232,10 @@ function WelcomeScreen({ onStart }: WelcomeScreenProps): React.ReactElement {
 
 export default function QuickGamePage(): React.ReactElement {
   const router = useRouter();
-  const { game, startNewGame, error, clearError } = useQuickGameStore();
+  const game = useQuickGameSelector((state) => state.game);
+  const startNewGame = useQuickGameSelector((state) => state.startNewGame);
+  const error = useQuickGameSelector((state) => state.error);
+  const clearError = useQuickGameSelector((state) => state.clearError);
 
   // Restore from session storage on mount
   useEffect(() => {

--- a/src/stores/useAppSettingsStore.ts
+++ b/src/stores/useAppSettingsStore.ts
@@ -247,3 +247,9 @@ export const useAppSettingsStore = create<AppSettingsState>()(
     },
   ),
 );
+
+export function useAppSettingsSelector<T>(
+  selector: (state: AppSettingsState) => T,
+): T {
+  return useAppSettingsStore(selector);
+}

--- a/src/stores/useCustomizerStore.ts
+++ b/src/stores/useCustomizerStore.ts
@@ -173,3 +173,9 @@ export const useCustomizerStore = create<CustomizerState>((set) => ({
       colorLegendExpanded: false,
     }),
 }));
+
+export function useCustomizerSelector<T>(
+  selector: (state: CustomizerState) => T,
+): T {
+  return useCustomizerStore(selector);
+}

--- a/src/stores/useEncounterStore.ts
+++ b/src/stores/useEncounterStore.ts
@@ -458,3 +458,9 @@ export const useEncounterStore = create<EncounterStore>((set, get) => ({
     set({ error: null });
   },
 }));
+
+export function useEncounterSelector<T>(
+  selector: (state: EncounterStore) => T,
+): T {
+  return useEncounterStore(selector);
+}

--- a/src/stores/useEquipmentStore.ts
+++ b/src/stores/useEquipmentStore.ts
@@ -581,3 +581,9 @@ export const useEquipmentStore = create<EquipmentStoreState>((set, get) => ({
     return filtered.slice(startIndex, endIndex);
   },
 }));
+
+export function useEquipmentSelector<T>(
+  selector: (state: EquipmentStoreState) => T,
+): T {
+  return useEquipmentStore(selector);
+}

--- a/src/stores/useForceStore.ts
+++ b/src/stores/useForceStore.ts
@@ -398,3 +398,7 @@ export const useForceStore = create<ForceStore>((set, get) => ({
     set({ error: null });
   },
 }));
+
+export function useForceSelector<T>(selector: (state: ForceStore) => T): T {
+  return useForceStore(selector);
+}

--- a/src/stores/useIdentityStore.ts
+++ b/src/stores/useIdentityStore.ts
@@ -261,6 +261,12 @@ export const useIdentityStore = create<IdentityStore>((set, get) => ({
 // Selectors
 // =============================================================================
 
+export function useIdentitySelector<T>(
+  selector: (state: IdentityStore) => T,
+): T {
+  return useIdentityStore(selector);
+}
+
 /** Select if identity is ready for sharing operations */
 export const selectCanShare = (state: IdentityStore): boolean =>
   state.isUnlocked && state.publicIdentity !== null;

--- a/src/stores/useMultiUnitStore.ts
+++ b/src/stores/useMultiUnitStore.ts
@@ -109,3 +109,9 @@ export const useMultiUnitStore = create<MultiUnitState>()(
     },
   ),
 );
+
+export function useMultiUnitSelector<T>(
+  selector: (state: MultiUnitState) => T,
+): T {
+  return useMultiUnitStore(selector);
+}

--- a/src/stores/useNavigationStore.ts
+++ b/src/stores/useNavigationStore.ts
@@ -29,6 +29,12 @@ export const useMobileSidebarStore = create<MobileSidebarState>((set) => ({
   toggle: () => set((state) => ({ isOpen: !state.isOpen })),
 }));
 
+export function useMobileSidebarSelector<T>(
+  selector: (state: MobileSidebarState) => T,
+): T {
+  return useMobileSidebarStore(selector);
+}
+
 // =============================================================================
 // Panel Navigation Store
 // =============================================================================
@@ -191,3 +197,9 @@ export const useNavigationStore = create<NavigationStore>((set, get) => ({
     });
   },
 }));
+
+export function useNavigationSelector<T>(
+  selector: (state: NavigationStore) => T,
+): T {
+  return useNavigationStore(selector);
+}

--- a/src/stores/usePilotStore.ts
+++ b/src/stores/usePilotStore.ts
@@ -128,13 +128,17 @@ export const usePilotStore = create<PilotStore>((set, get) => ({
 // Live in this file (instead of usePilotStore.selectors.ts) to avoid a
 // store <-> selectors circular import. Same pattern as useGameplayStore.
 
+export function usePilotSelector<T>(selector: (state: PilotStore) => T): T {
+  return usePilotStore(selector);
+}
+
 /**
  * Get filtered pilots based on current filters (status + search query).
- * Subscribes to the full store rather than a fine-grained selector
- * because the three filter inputs change together in practice.
  */
 export function useFilteredPilots(): IPilot[] {
-  const { pilots, showActiveOnly, searchQuery } = usePilotStore();
+  const pilots = usePilotSelector((state) => state.pilots);
+  const showActiveOnly = usePilotSelector((state) => state.showActiveOnly);
+  const searchQuery = usePilotSelector((state) => state.searchQuery);
 
   let filtered = pilots;
   if (showActiveOnly) {
@@ -157,7 +161,7 @@ export function useFilteredPilots(): IPilot[] {
  * callers can pass an optional id straight from URL params.
  */
 export function usePilotById(id: string | null): IPilot | null {
-  const pilots = usePilotStore((state) => state.pilots);
+  const pilots = usePilotSelector((state) => state.pilots);
   if (!id) return null;
   return pilots.find((p) => p.id === id) || null;
 }

--- a/src/stores/useQuickGameStore.ts
+++ b/src/stores/useQuickGameStore.ts
@@ -327,3 +327,9 @@ export const useQuickGameStore = create<QuickGameStore>()(
     },
   ),
 );
+
+export function useQuickGameSelector<T>(
+  selector: (state: QuickGameStore) => T,
+): T {
+  return useQuickGameStore(selector);
+}

--- a/src/stores/useRepairStore.ts
+++ b/src/stores/useRepairStore.ts
@@ -466,3 +466,7 @@ export const useRepairStore = create<RepairStore>()(
     },
   ),
 );
+
+export function useRepairSelector<T>(selector: (state: RepairStore) => T): T {
+  return useRepairStore(selector);
+}

--- a/src/stores/useThemeStore.ts
+++ b/src/stores/useThemeStore.ts
@@ -44,3 +44,7 @@ export const useThemeStore = create<IThemeState>()(
     },
   ),
 );
+
+export function useThemeSelector<T>(selector: (state: IThemeState) => T): T {
+  return useThemeStore(selector);
+}


### PR DESCRIPTION
## Summary
- wires ServerMatchHost through ServerMatchBroadcaster and ServerMatchSocketLifecycle while keeping the public host API unchanged
- adds Phase 2 Storybook coverage for vault and gameplay surfaces plus high-risk axe checks
- rolls out use<StoreName>Selector helpers across hook-based Zustand stores and migrates production full-store subscriptions

## Verification
- npm run test -- --watchAll=false
- npm run typecheck
- npx oxlint
- npx oxfmt --check src
- npm run schema:gen-check
- npx openspec validate --all --strict
- npx madge --circular --extensions ts,tsx src/
- npx jest src/lib/multiplayer/server --selectProjects unit --watchAll=false
- npx jest --selectProjects a11y --watchAll=false
- npx tsx scripts/validate-bv.ts
- npm run storybook:build

## Notes
- The exact root `npx oxfmt --check` still reports only the pre-existing untracked `.agents/skills/**/SKILL.md` files, which this branch intentionally leaves untouched per handoff.
- `npm run build` also ran during pre-commit and completed with the known Windows traced-file copy warning for a `node:crypto` chunk.