### PR TITLE
Implement OpenSpec Wave 1 foundations

### DIFF
--- a/openspec/changes/add-infantry-construction/tasks.md
+++ b/openspec/changes/add-infantry-construction/tasks.md
@@ -2,54 +2,54 @@
 
 ## 1. Types and Interfaces
 
-- [ ] 1.1 Extend `IInfantryUnit` with `motiveType`, `platoonComposition`, `armorKit`, `primaryWeapon`, `secondaryWeapon?`, `fieldGun?`, `antiMechTraining`
+- [x] 1.1 Extend `IInfantryUnit` with `motiveType`, `platoonComposition`, `armorKit`, `primaryWeapon`, `secondaryWeapon?`, `fieldGun?`, `antiMechTraining`
 - [x] 1.2 Add `InfantryMotive` enum (Foot, Jump, Motorized, MechanizedTracked, MechanizedWheeled, MechanizedHover, MechanizedVTOL)
 - [x] 1.3 Add `ArmorKit` enum (Standard, Flak, Camo, SnowCamo, EnvironmentalSealing, SneakCamo, SneakIR, SneakECM)
 - [x] 1.4 Add `IPlatoonComposition` interface (squads, troopersPerSquad)
-- [ ] 1.5 Add `IFieldGun` interface (weaponId, ammoRounds, crewCount)
+- [x] 1.5 Add `IFieldGun` interface (weaponId, ammoRounds, crewCount)
 
 ## 2. Platoon Composition
 
 - [x] 2.1 Default Foot: 7 squads × 4 troopers (28)
 - [x] 2.2 Default Jump: 5 squads × 5 troopers (25)
-- [ ] 2.3 Default Motorized: 7 squads × 4 troopers (28)
+- [x] 2.3 Default Motorized: 7 squads × 4 troopers (28)
 - [x] 2.4 Default Mechanized: 4 squads × 5 troopers (20)
-- [ ] 2.5 Support 1–30 troopers with warning outside defaults
+- [x] 2.5 Support 1–30 troopers with warning outside defaults
 - [x] 2.6 Validation: min 5 troopers, max 30
 
 ## 3. Motive Type
 
 - [x] 3.1 Foot: MP 1 ground
 - [x] 3.2 Jump: MP 3 ground + 3 jump (MP 3/3)
-- [ ] 3.3 Motorized: MP 3 ground (in trucks/APC shared with platoon)
-- [ ] 3.4 Mechanized Tracked: MP 3, adds armor
-- [ ] 3.5 Mechanized Wheeled: MP 4
+- [x] 3.3 Motorized: MP 3 ground (in trucks/APC shared with platoon)
+- [x] 3.4 Mechanized Tracked: MP 3, adds armor
+- [x] 3.5 Mechanized Wheeled: MP 4
 - [x] 3.6 Mechanized Hover: MP 5
-- [ ] 3.7 Mechanized VTOL: MP 6 vertical
+- [x] 3.7 Mechanized VTOL: MP 6 vertical
 - [x] 3.8 Validation: motive × platoon size compatibility (e.g., VTOL max 10 troopers per TW)
 
 ## 4. Armor Kit
 
-- [ ] 4.1 Per-trooper armor modifier from kit (Flak = +1 vs ballistic, Camo = -1 to be hit in woods, etc.)
-- [ ] 4.2 Environmental Sealing enables vacuum / underwater operations
-- [ ] 4.3 Armor kit mass counted per trooper (tracked for transport weight)
+- [x] 4.1 Per-trooper armor modifier from kit (Flak = +1 vs ballistic, Camo = -1 to be hit in woods, etc.)
+- [x] 4.2 Environmental Sealing enables vacuum / underwater operations
+- [x] 4.3 Armor kit mass counted per trooper (tracked for transport weight)
 - [x] 4.4 Sneak suits require Foot motive
 
 ## 5. Weapon Table
 
-- [ ] 5.1 Load infantry weapon table (Laser Rifle, Auto Rifle, SRM Launcher, LRM Launcher, MG, Flamer, etc.)
-- [ ] 5.2 Each entry: range (S/M/L), damage divisor (per TW), ammo type, heat, special
+- [x] 5.1 Load infantry weapon table (Laser Rifle, Auto Rifle, SRM Launcher, LRM Launcher, MG, Flamer, etc.)
+- [x] 5.2 Each entry: range (S/M/L), damage divisor (per TW), ammo type, heat, special
 - [x] 5.3 Primary weapon: all troopers carry
 - [x] 5.4 Secondary weapon: 1 per N troopers (N = 2/3/4 from table)
 - [x] 5.5 Validation: weapon compatible with motive (heavy weapons not Foot)
 
 ## 6. Field Guns
 
-- [ ] 6.1 Optional field gun: mech-scale weapon from approved list (AC/2, AC/5, LRM-5 through LRM-20, MG, Flamer, etc.)
-- [ ] 6.2 Crew size: derived from weapon type (AC/20 needs 5 crew, LRM-5 needs 2)
+- [x] 6.1 Optional field gun: mech-scale weapon from approved list (AC/2, AC/5, LRM-5 through LRM-20, MG, Flamer, etc.)
+- [x] 6.2 Crew size: derived from weapon type (AC/20 needs 5 crew, LRM-5 needs 2)
 - [x] 6.3 When crewing the gun, that many troopers do NOT fire personal weapons
-- [ ] 6.4 Ammo count stored separately
-- [ ] 6.5 Field gun tonnage does not count against mech construction — it's a deployed weapon
+- [x] 6.4 Ammo count stored separately
+- [x] 6.5 Field gun tonnage does not count against mech construction — it's a deployed weapon
 
 ## 7. Anti-Mech Training
 
@@ -69,13 +69,13 @@
 
 ## 9. Store and UI Wiring
 
-- [ ] 9.1 Wire `infantryStore` to persist new state
+- [x] 9.1 Wire `infantryStore` to persist new state
 - [ ] 9.2 Enhance `InfantryBuildTab` to expose all fields
 - [ ] 9.3 Status bar displays platoon strength, effective MP, kit modifiers
-- [ ] 9.4 Field gun section adds/edits field gun
+- [x] 9.4 Field gun section adds/edits field gun
 
 ## 10. Validation
 
 - [x] 10.1 `openspec validate add-infantry-construction --strict`
-- [ ] 10.2 Fixtures: Foot Rifle Platoon, Jump SRM Platoon, Mechanized MG Platoon, Field Gun (AC/5) Platoon
+- [x] 10.2 Fixtures: Foot Rifle Platoon, Jump SRM Platoon, Mechanized MG Platoon, Field Gun (AC/5) Platoon
 - [ ] 10.3 Build + lint clean

--- a/openspec/changes/add-movement-interpolation-animations/tasks.md
+++ b/openspec/changes/add-movement-interpolation-animations/tasks.md
@@ -2,24 +2,24 @@
 
 ## 1. Movement Event Schema
 
-- [ ] 1.1 Ensure `MovementCommitted` event carries full path (array of
+- [x] 1.1 Ensure `MovementCommitted` event carries full path (array of
       axial coordinates) plus MP mode (walk | run | jump)
-- [ ] 1.2 If event currently only stores destination, migrate: compute
+- [x] 1.2 If event currently only stores destination, migrate: compute
       path on commit and embed in payload
-- [ ] 1.3 Backfill logic for older event streams (replay uses instant
+- [x] 1.3 Backfill logic for older event streams (replay uses instant
       fallback)
-- [ ] 1.4 Unit tests for path serialization
+- [x] 1.4 Unit tests for path serialization
 
 ## 2. Animation Queue Store
 
-- [ ] 2.1 Create `src/stores/useAnimationQueue.ts`
-- [ ] 2.2 Methods: `enqueue(animation)`, `onComplete(callback)`,
+- [x] 2.1 Create `src/stores/useAnimationQueue.ts`
+- [x] 2.2 Methods: `enqueue(animation)`, `onComplete(callback)`,
       `isActive`
-- [ ] 2.3 Session phase advancement reads `isActive` and waits until
+- [x] 2.3 Session phase advancement reads `isActive` and waits until
       queue drains
-- [ ] 2.4 Queue is FIFO per map; concurrent per-unit animations allowed
+- [x] 2.4 Queue is FIFO per map; concurrent per-unit animations allowed
       only when animations do not overlap hexes
-- [ ] 2.5 Unit tests for queue ordering
+- [x] 2.5 Unit tests for queue ordering
 
 ## 3. Movement Tween Hook
 
@@ -53,11 +53,11 @@
 
 ## 6. Reduced Motion Fallback
 
-- [ ] 6.1 Detect `window.matchMedia('(prefers-reduced-motion: reduce)')`
-- [ ] 6.2 When reduced motion is enabled, `useMovementTween` returns
+- [x] 6.1 Detect `window.matchMedia('(prefers-reduced-motion: reduce)')`
+- [x] 6.2 When reduced motion is enabled, `useMovementTween` returns
       the final position immediately and calls `onDone` synchronously
-- [ ] 6.3 Jump arc flattens to a straight snap
-- [ ] 6.4 Unit test: reduced-motion mode fires `onDone` within one tick
+- [x] 6.3 Jump arc flattens to a straight snap
+- [x] 6.4 Unit test: reduced-motion mode fires `onDone` within one tick
 
 ## 7. Jump Arc Visual
 

--- a/openspec/changes/add-p2p-game-session-sync/tasks.md
+++ b/openspec/changes/add-p2p-game-session-sync/tasks.md
@@ -2,22 +2,22 @@
 
 ## 1. Channel Primitives
 
-- [ ] 1.1 Add `gameSessionChannel.ts` in `src/lib/p2p/` that exposes
+- [x] 1.1 Add `gameSessionChannel.ts` in `src/lib/p2p/` that exposes
       `broadcastEvent(event: IGameEvent)` and `onPeerEvent(cb)`
-- [ ] 1.2 Channel rides on the existing Yjs room; events go through a
+- [x] 1.2 Channel rides on the existing Yjs room; events go through a
       dedicated `gameEvents` Y.Array so the customizer-tab sync is
       unaffected
-- [ ] 1.3 Channel serializes/deserializes `IGameEvent` with the same
+- [x] 1.3 Channel serializes/deserializes `IGameEvent` with the same
       schema used by `event-store` persistence
-- [ ] 1.4 Channel rejects events authored by the local peer on arrival
+- [x] 1.4 Channel rejects events authored by the local peer on arrival
       (don't re-apply own events)
 
 ## 2. Host Election
 
-- [ ] 2.1 Room creator is marked `role: 'host'` in Yjs awareness
-- [ ] 2.2 Room joiner is `role: 'guest'`; second joiner is rejected (1v1
+- [x] 2.1 Room creator is marked `role: 'host'` in Yjs awareness
+- [x] 2.2 Room joiner is `role: 'guest'`; second joiner is rejected (1v1
       only in this change)
-- [ ] 2.3 A `HostPromoted` / `GuestJoined` lifecycle event is logged
+- [x] 2.3 A `HostPromoted` / `GuestJoined` lifecycle event is logged
       locally (not part of session event stream)
 
 ## 3. Host-Authoritative RNG
@@ -43,7 +43,7 @@
 
 ## 5. Intent Events (Guest → Host)
 
-- [ ] 5.1 Define `IGameIntent` = `{type, payload, authorPeerId}` for
+- [x] 5.1 Define `IGameIntent` = `{type, payload, authorPeerId}` for
       actions the guest wants the host to execute
 - [ ] 5.2 Guest UI produces intents for `declareMovement`,
       `declareAttack`, `declarePhysical`, `confirmHeat`, `endPhase`,
@@ -55,7 +55,7 @@
 
 ## 6. Side Ownership
 
-- [ ] 6.1 `IGameSession` gains an optional `sideOwners: Record<GameSide,
+- [x] 6.1 `IGameSession` gains an optional `sideOwners: Record<GameSide,
 string>` field mapping side → peerId
 - [ ] 6.2 Skirmish setup screen with "Networked 1v1" lets host pick which
       side they control; the other side is auto-assigned to the guest

--- a/openspec/changes/wire-encounter-to-campaign-round-trip/tasks.md
+++ b/openspec/changes/wire-encounter-to-campaign-round-trip/tasks.md
@@ -2,13 +2,13 @@
 
 ## 1. Encounter → Session Linkage
 
-- [ ] 1.1 Extend `EncounterService.launchEncounter` signature: accept
+- [x] 1.1 Extend `EncounterService.launchEncounter` signature: accept
       `contractId?` and `scenarioId?` alongside the encounter
-- [ ] 1.2 Pass these into the `IGameSession` config as fields
+- [x] 1.2 Pass these into the `IGameSession` config as fields
       `encounterId`, `contractId`, `scenarioId`
-- [ ] 1.3 Assert that launched sessions have these fields populated when
+- [x] 1.3 Assert that launched sessions have these fields populated when
       the source is a contract (fail fast if they're null)
-- [ ] 1.4 Update `encounterToGameSession.ts` tests to assert linkage
+- [x] 1.4 Update `encounterToGameSession.ts` tests to assert linkage
 
 ## 2. Session Completion Emits Outcome Bus Event
 
@@ -26,8 +26,8 @@
 - [x] 3.2 On receipt, enqueue the outcome into
       `campaign.pendingBattleOutcomes` if `matchId` is not already present
       (idempotent push)
-- [ ] 3.3 Persist the queue alongside the campaign record
-- [ ] 3.4 Emit a campaign-level `PendingOutcomeAdded` event so the
+- [x] 3.3 Persist the queue alongside the campaign record
+- [x] 3.4 Emit a campaign-level `PendingOutcomeAdded` event so the
       dashboard can re-render
 
 ## 4. Review UI → Campaign Handoff

--- a/src/__tests__/api/encounters/encounters.test.ts
+++ b/src/__tests__/api/encounters/encounters.test.ts
@@ -700,6 +700,46 @@ describe('POST /api/encounters/[id]/launch', () => {
 
     expect(mockEncounterService.launchEncounter).toHaveBeenCalledWith(
       'encounter-1',
+      {},
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      ...result,
+      encounter,
+      gameSessionId: 'session-123',
+    });
+  });
+
+  it('should forward campaign launch linkage from the request body', async () => {
+    const encounter = createMockEncounter({
+      status: EncounterStatus.Launched,
+      gameSessionId: 'session-123',
+    });
+    const result = createSuccessResult();
+
+    mockEncounterService.launchEncounter.mockReturnValue(result);
+    mockEncounterService.getEncounter.mockReturnValue(encounter);
+
+    const req = createMockRequest({
+      method: 'POST',
+      query: { id: 'encounter-1' },
+      body: {
+        campaignId: 'campaign-1',
+        contractId: 'contract-1',
+        scenarioId: 'scenario-1',
+      },
+    });
+    const res = createMockResponse();
+
+    await launchHandler(req, res);
+
+    expect(mockEncounterService.launchEncounter).toHaveBeenCalledWith(
+      'encounter-1',
+      {
+        campaignId: 'campaign-1',
+        contractId: 'contract-1',
+        scenarioId: 'scenario-1',
+      },
     );
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({

--- a/src/__tests__/fixtures/infantry-construction-fixtures.ts
+++ b/src/__tests__/fixtures/infantry-construction-fixtures.ts
@@ -1,0 +1,99 @@
+/**
+ * Named infantry construction fixtures for add-infantry-construction task 10.2.
+ */
+
+import {
+  IInfantryFieldGun,
+  IInfantryUnit,
+  InfantryArmorKitType,
+  InfantryMotive,
+  IPlatoonComposition,
+} from '@/types/unit/InfantryInterfaces';
+import {
+  buildFieldGun,
+  findFieldGunById,
+} from '@/utils/construction/infantry/fieldGuns';
+
+export interface InfantryConstructionFixture extends IInfantryUnit {
+  readonly name: string;
+  readonly expectedTroopers: number;
+  readonly primaryWeaponId: string;
+  readonly secondaryWeaponId?: string;
+}
+
+function requiredFieldGun(weaponId: string): IInfantryFieldGun {
+  const entry = findFieldGunById(weaponId);
+  if (!entry) {
+    throw new Error(`Missing infantry field gun fixture entry: ${weaponId}`);
+  }
+  return buildFieldGun(entry);
+}
+
+const footRifleComposition: IPlatoonComposition = {
+  squads: 7,
+  troopersPerSquad: 4,
+};
+
+const jumpSrmComposition: IPlatoonComposition = {
+  squads: 5,
+  troopersPerSquad: 5,
+};
+
+const mechanizedMgComposition: IPlatoonComposition = {
+  squads: 4,
+  troopersPerSquad: 5,
+};
+
+export const FOOT_RIFLE_PLATOON: InfantryConstructionFixture = {
+  name: 'Foot Rifle Platoon',
+  motiveType: InfantryMotive.FOOT,
+  platoonComposition: footRifleComposition,
+  armorKit: InfantryArmorKitType.STANDARD,
+  primaryWeapon: 'Rifle',
+  primaryWeaponId: 'inf-rifle',
+  antiMechTraining: false,
+  expectedTroopers: 28,
+};
+
+export const JUMP_SRM_PLATOON: InfantryConstructionFixture = {
+  name: 'Jump SRM Platoon',
+  motiveType: InfantryMotive.JUMP,
+  platoonComposition: jumpSrmComposition,
+  armorKit: InfantryArmorKitType.STANDARD,
+  primaryWeapon: 'Auto-Rifle',
+  primaryWeaponId: 'inf-auto-rifle',
+  secondaryWeapon: 'SRM Launcher',
+  secondaryWeaponId: 'inf-srm2',
+  antiMechTraining: true,
+  expectedTroopers: 25,
+};
+
+export const MECHANIZED_MG_PLATOON: InfantryConstructionFixture = {
+  name: 'Mechanized MG Platoon',
+  motiveType: InfantryMotive.MECHANIZED_TRACKED,
+  platoonComposition: mechanizedMgComposition,
+  armorKit: InfantryArmorKitType.FLAK,
+  primaryWeapon: 'Machine Gun',
+  primaryWeaponId: 'inf-mg',
+  antiMechTraining: false,
+  expectedTroopers: 20,
+};
+
+export const FIELD_GUN_AC5_PLATOON: InfantryConstructionFixture = {
+  name: 'Field Gun (AC/5) Platoon',
+  motiveType: InfantryMotive.FOOT,
+  platoonComposition: footRifleComposition,
+  armorKit: InfantryArmorKitType.STANDARD,
+  primaryWeapon: 'Rifle',
+  primaryWeaponId: 'inf-rifle',
+  fieldGun: requiredFieldGun('ac5'),
+  antiMechTraining: false,
+  expectedTroopers: 28,
+};
+
+export const INFANTRY_CONSTRUCTION_FIXTURES = [
+  FOOT_RIFLE_PLATOON,
+  JUMP_SRM_PLATOON,
+  MECHANIZED_MG_PLATOON,
+  FIELD_GUN_AC5_PLATOON,
+] as const;

--- a/src/__tests__/unit/infantry-construction.test.ts
+++ b/src/__tests__/unit/infantry-construction.test.ts
@@ -8,9 +8,20 @@
  */
 
 import {
+  INFANTRY_CONSTRUCTION_FIXTURES,
+  FIELD_GUN_AC5_PLATOON,
+} from '@/__tests__/fixtures/infantry-construction-fixtures';
+import {
+  createDefaultInfantryState,
+  calculateInfantryTransportWeight,
+} from '@/stores/infantryState';
+import { createInfantryStore } from '@/stores/useInfantryStore';
+import {
   InfantryMotive,
   InfantryArmorKitType,
+  IFieldGun,
   IPlatoonComposition,
+  INFANTRY_MOTIVE_PROFILES,
   PLATOON_DEFAULTS,
   MOTIVE_MP,
   ANTI_MECH_ELIGIBLE_MOTIVES,
@@ -21,14 +32,30 @@ import {
   VTOL_MAX_TROOPERS,
 } from '@/types/unit/InfantryInterfaces';
 import { IInfantryFieldGun } from '@/types/unit/InfantryInterfaces';
+import { InfantryArmorKit } from '@/types/unit/PersonnelInterfaces';
+import {
+  canArmorKitDeployInVacuumOrUnderwater,
+  calculateArmorKitMassTons,
+  getInfantryArmorKitProfile,
+} from '@/utils/construction/infantry/armorKits';
+import {
+  FIELD_GUN_CATALOG,
+  buildFieldGun,
+  deriveFieldGunCrewCount,
+  findFieldGunById,
+  getDeployedFieldGunTonnage,
+  getFieldGunConstructionTonnage,
+} from '@/utils/construction/infantry/fieldGuns';
 import {
   totalTroopers,
   effectiveFiringTroopers,
   secondaryWeaponCount,
   HEAVY_WEAPON_MOTIVES,
+  getMotiveProfile,
 } from '@/utils/construction/infantry/platoonComposition';
 import {
   validatePlatoonSize,
+  validatePlatoonDefaultWarning,
   validateMotiveCompatibility,
   validateArmorKit,
   validatePrimaryWeapon,
@@ -37,6 +64,7 @@ import {
   validateInfantryConstruction,
   INF_VALIDATION_RULE_IDS,
 } from '@/utils/construction/infantry/validation';
+import { INFANTRY_WEAPON_TABLE } from '@/utils/construction/infantry/weaponTable';
 
 // =============================================================================
 // Scenario helpers
@@ -50,7 +78,22 @@ function makeFieldGun(
   name: string,
   crew: number,
 ): IInfantryFieldGun {
-  return { equipmentId, name, crew, ammoRounds: 10 };
+  return {
+    weaponId: equipmentId,
+    crewCount: crew,
+    equipmentId,
+    name,
+    crew,
+    ammoRounds: 10,
+  };
+}
+
+function requiredFieldGunEntry(id: string) {
+  const entry = findFieldGunById(id);
+  if (!entry) {
+    throw new Error(`Missing field gun catalog entry: ${id}`);
+  }
+  return entry;
 }
 
 // =============================================================================
@@ -76,6 +119,14 @@ describe('Platoon Composition Defaults', () => {
     const comp: IPlatoonComposition =
       PLATOON_DEFAULTS[InfantryMotive.MECHANIZED_TRACKED];
     expect(totalTroopers(comp)).toBe(20);
+  });
+
+  it('Motorized default: 7 squads x 4 troopers = 28 total', () => {
+    const comp: IPlatoonComposition =
+      PLATOON_DEFAULTS[InfantryMotive.MOTORIZED];
+    expect(comp.squads).toBe(7);
+    expect(comp.troopersPerSquad).toBe(4);
+    expect(totalTroopers(comp)).toBe(28);
   });
 });
 
@@ -188,6 +239,31 @@ describe('Environmental Sealing armor kit', () => {
       expect(errors).toHaveLength(0);
     }
   });
+
+  it('Environmental Sealing enables vacuum and underwater deployment', () => {
+    expect(
+      canArmorKitDeployInVacuumOrUnderwater(
+        InfantryArmorKitType.ENVIRONMENTAL_SEALING,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('Armor kit construction profiles', () => {
+  it('Flak has a per-trooper ballistic resistance modifier', () => {
+    const profile = getInfantryArmorKitProfile(InfantryArmorKitType.FLAK);
+    expect(profile.ballisticDamageDivisorModifier).toBe(1);
+  });
+
+  it('Camo applies a woods to-hit modifier', () => {
+    const profile = getInfantryArmorKitProfile(InfantryArmorKitType.CAMO);
+    expect(profile.woodsToHitModifier).toBe(-1);
+  });
+
+  it('armor kit mass is counted per trooper for transport weight', () => {
+    const mass = calculateArmorKitMassTons(InfantryArmorKitType.FLAK, 28);
+    expect(mass).toBeCloseTo(28 * 0.012, 5);
+  });
 });
 
 // =============================================================================
@@ -205,6 +281,30 @@ describe('Primary and Secondary Weapon Selection', () => {
   it('28-trooper platoon with SRM Launcher secondary at ratio 1-per-4 = 7 secondaries', () => {
     const count = secondaryWeaponCount(28, 4);
     expect(count).toBe(7);
+  });
+});
+
+describe('Infantry weapon table', () => {
+  it('loads the expected foundation weapon entries', () => {
+    const ids = new Set(INFANTRY_WEAPON_TABLE.map((weapon) => weapon.id));
+    expect(ids.has('inf-laser-rifle')).toBe(true);
+    expect(ids.has('inf-auto-rifle')).toBe(true);
+    expect(ids.has('inf-srm2')).toBe(true);
+    expect(ids.has('inf-lrm5')).toBe(true);
+    expect(ids.has('inf-mg')).toBe(true);
+    expect(ids.has('inf-flamer')).toBe(true);
+  });
+
+  it('each weapon entry exposes range, divisor, ammo, heat, and special tags', () => {
+    for (const weapon of INFANTRY_WEAPON_TABLE) {
+      expect(weapon.rangeShort).toBeGreaterThanOrEqual(0);
+      expect(weapon.rangeMedium).toBeGreaterThanOrEqual(0);
+      expect(weapon.rangeLong).toBeGreaterThanOrEqual(0);
+      expect(weapon.damageDivisor).toBeGreaterThan(0);
+      expect(typeof weapon.ammoType).toBe('string');
+      expect(weapon.heat).toBeGreaterThanOrEqual(0);
+      expect(Array.isArray(weapon.special)).toBe(true);
+    }
   });
 });
 
@@ -263,6 +363,48 @@ describe('VAL-INF-FIELD-GUN: Field gun crew accounting', () => {
     const ac5 = makeFieldGun('ac5', 'Autocannon/5', 3);
     const errors = validateFieldGuns(InfantryMotive.FOOT, 20, [ac5]);
     expect(errors).toHaveLength(0);
+  });
+
+  it('approved field-gun catalog includes AC/2, AC/5, LRM launchers, MG, and Flamer', () => {
+    const ids = new Set(FIELD_GUN_CATALOG.map((gun) => gun.id));
+    expect(ids.has('ac2')).toBe(true);
+    expect(ids.has('ac5')).toBe(true);
+    expect(ids.has('lrm5')).toBe(true);
+    expect(ids.has('lrm20')).toBe(true);
+    expect(ids.has('mg')).toBe(true);
+    expect(ids.has('flamer')).toBe(true);
+  });
+
+  it('derives crew size and default ammo from the selected field-gun type', () => {
+    const ac5 = buildFieldGun(requiredFieldGunEntry('ac5'));
+    const lrm5 = buildFieldGun(requiredFieldGunEntry('lrm5'));
+    const ac20 = buildFieldGun(requiredFieldGunEntry('ac20'));
+
+    expect(ac5.crewCount).toBe(3);
+    expect(ac5.ammoRounds).toBe(20);
+    expect(lrm5.crewCount).toBe(2);
+    expect(deriveFieldGunCrewCount('ac20')).toBe(5);
+    expect(ac20.crewCount).toBe(5);
+  });
+
+  it('stores ammo rounds separately from crew count', () => {
+    const ac5 = buildFieldGun(requiredFieldGunEntry('ac5'), 12);
+    expect(ac5.weaponId).toBe('ac5');
+    expect(ac5.crewCount).toBe(3);
+    expect(ac5.ammoRounds).toBe(12);
+  });
+
+  it('field-gun deployed tonnage is tracked but construction tonnage is zero', () => {
+    const ac5 = buildFieldGun(requiredFieldGunEntry('ac5'));
+    const specShape: IFieldGun = ac5;
+    expect(getDeployedFieldGunTonnage('ac5')).toBe(8);
+    expect(getFieldGunConstructionTonnage(specShape)).toBe(0);
+  });
+
+  it('rejects field guns outside the approved list', () => {
+    const customGun = makeFieldGun('gauss-rifle', 'Gauss Rifle', 4);
+    const errors = validateFieldGuns(InfantryMotive.FOOT, 20, [customGun]);
+    expect(errors.some((error) => error.includes('approved list'))).toBe(true);
   });
 });
 
@@ -332,6 +474,13 @@ describe('VAL-INF-PLATOON: Platoon size bounds', () => {
     expect(validatePlatoonSize(30)).toHaveLength(0);
     expect(validatePlatoonSize(15)).toHaveLength(0);
   });
+
+  it('custom 1-30 platoon sizes are supported with a default-size warning', () => {
+    expect(validatePlatoonSize(12)).toHaveLength(0);
+    const warnings = validatePlatoonDefaultWarning(InfantryMotive.FOOT, 12);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('differs from Foot default 28');
+  });
 });
 
 // =============================================================================
@@ -351,6 +500,29 @@ describe('Motive MP derivation', () => {
 
   it('Mechanized Hover: ground MP 5', () => {
     expect(MOTIVE_MP[InfantryMotive.MECHANIZED_HOVER].groundMP).toBe(5);
+  });
+
+  it('Motorized: ground MP 3', () => {
+    expect(MOTIVE_MP[InfantryMotive.MOTORIZED]).toEqual({
+      groundMP: 3,
+      jumpMP: 0,
+    });
+  });
+
+  it('Mechanized Tracked: ground MP 3 and adds mechanized armor', () => {
+    const profile = getMotiveProfile(InfantryMotive.MECHANIZED_TRACKED);
+    expect(profile.movement.groundMP).toBe(3);
+    expect(profile.hasMechanizedArmor).toBe(true);
+  });
+
+  it('Mechanized Wheeled: ground MP 4', () => {
+    expect(MOTIVE_MP[InfantryMotive.MECHANIZED_WHEELED].groundMP).toBe(4);
+  });
+
+  it('Mechanized VTOL: MP 6 vertical', () => {
+    const profile = INFANTRY_MOTIVE_PROFILES[InfantryMotive.MECHANIZED_VTOL];
+    expect(profile.movement.groundMP).toBe(6);
+    expect(profile.movementMode).toBe('vertical');
   });
 });
 
@@ -447,6 +619,121 @@ describe('validateInfantryConstruction (composite)', () => {
     expect(result.isValid).toBe(false);
     expect(result.errors.some((e) => e.includes('VAL-INF-ANTI-MECH'))).toBe(
       true,
+    );
+  });
+
+  it('returns warnings for non-default but otherwise legal platoon sizes', () => {
+    const result = validateInfantryConstruction({
+      motive: InfantryMotive.FOOT,
+      totalTroopers: 12,
+      armorKit: InfantryArmorKitType.STANDARD,
+      isPrimaryHeavy: false,
+      fieldGuns: [],
+      hasAntiMechTraining: false,
+    });
+    expect(result.isValid).toBe(true);
+    expect(result.warnings).toHaveLength(1);
+  });
+});
+
+describe('IInfantryUnit construction fixtures', () => {
+  it('defines the four named fixtures requested by task 10.2', () => {
+    expect(
+      INFANTRY_CONSTRUCTION_FIXTURES.map((fixture) => fixture.name),
+    ).toEqual([
+      'Foot Rifle Platoon',
+      'Jump SRM Platoon',
+      'Mechanized MG Platoon',
+      'Field Gun (AC/5) Platoon',
+    ]);
+  });
+
+  it('fixtures use the spec-name motiveType and antiMechTraining fields', () => {
+    for (const fixture of INFANTRY_CONSTRUCTION_FIXTURES) {
+      expect(Object.values(InfantryMotive)).toContain(fixture.motiveType);
+      expect(typeof fixture.antiMechTraining).toBe('boolean');
+      expect(totalTroopers(fixture.platoonComposition)).toBe(
+        fixture.expectedTroopers,
+      );
+    }
+  });
+
+  it('Field Gun (AC/5) fixture uses the IFieldGun shape', () => {
+    const fieldGun = FIELD_GUN_AC5_PLATOON.fieldGun;
+    expect(fieldGun).toBeDefined();
+    if (fieldGun) {
+      expect(fieldGun.weaponId).toBe('ac5');
+      expect(fieldGun.crewCount).toBe(3);
+      expect(fieldGun.ammoRounds).toBe(20);
+    }
+  });
+});
+
+describe('Infantry store construction state', () => {
+  const storeId = '00000000-0000-4000-8000-000000000101';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults legacy squad fields from construction composition', () => {
+    const state = createDefaultInfantryState({ id: storeId });
+    expect(state.platoonComposition).toEqual({
+      squads: 7,
+      troopersPerSquad: 4,
+    });
+    expect(state.numberOfSquads).toBe(7);
+    expect(state.squadSize).toBe(4);
+  });
+
+  it('persists motive, composition, field-gun aliases, and ammo rounds', () => {
+    const store = createInfantryStore(
+      createDefaultInfantryState({ id: storeId }),
+    );
+    const ac5 = buildFieldGun(requiredFieldGunEntry('ac5'));
+
+    store.getState().setInfantryMotive(InfantryMotive.MOTORIZED);
+    store.getState().setPlatoonComposition({
+      squads: 3,
+      troopersPerSquad: 4,
+    });
+    store.getState().addFieldGun(ac5);
+    store.getState().setFieldGunAmmo(0, 12);
+
+    const raw = localStorage.getItem(`megamek-infantry-${storeId}`);
+    expect(raw).not.toBeNull();
+    const persisted = JSON.parse(raw ?? '{}') as {
+      state?: {
+        infantryMotive?: InfantryMotive;
+        platoonComposition?: IPlatoonComposition;
+        fieldGuns?: IInfantryFieldGun[];
+      };
+    };
+
+    expect(persisted.state?.infantryMotive).toBe(InfantryMotive.MOTORIZED);
+    expect(persisted.state?.platoonComposition).toEqual({
+      squads: 3,
+      troopersPerSquad: 4,
+    });
+    expect(persisted.state?.fieldGuns?.[0]?.weaponId).toBe('ac5');
+    expect(persisted.state?.fieldGuns?.[0]?.crewCount).toBe(3);
+    expect(persisted.state?.fieldGuns?.[0]?.ammoRounds).toBe(12);
+  });
+
+  it('transport weight includes armor kit mass but excludes field-gun tonnage', () => {
+    const state = createDefaultInfantryState({
+      id: storeId,
+      platoonComposition: { squads: 7, troopersPerSquad: 4 },
+    });
+    const armoredState = {
+      ...state,
+      armorKit: InfantryArmorKit.FLAK,
+      fieldGuns: [buildFieldGun(requiredFieldGunEntry('ac5'))],
+    };
+
+    expect(calculateInfantryTransportWeight(armoredState)).toBeCloseTo(
+      28 * 0.08 + 28 * 0.012,
+      5,
     );
   });
 });

--- a/src/components/customizer/infantry/InfantryBuildTab.tsx
+++ b/src/components/customizer/infantry/InfantryBuildTab.tsx
@@ -23,8 +23,11 @@ import {
   FIELD_GUN_CATALOG,
   buildFieldGun,
 } from '@/utils/construction/infantry/fieldGuns';
-import { HEAVY_WEAPON_MOTIVES } from '@/utils/construction/infantry/platoonComposition';
-import { totalTroopers } from '@/utils/construction/infantry/platoonComposition';
+import {
+  FIELD_GUN_ALLOWED_MOTIVES,
+  HEAVY_WEAPON_MOTIVES,
+  totalTroopers,
+} from '@/utils/construction/infantry/platoonComposition';
 import {
   INFANTRY_WEAPON_TABLE,
   getPrimaryWeaponOptions,
@@ -165,6 +168,7 @@ export function InfantryBuildTab({
     () => new Set(fieldGuns.map((g) => g.equipmentId)),
     [fieldGuns],
   );
+  const canUseFieldGuns = FIELD_GUN_ALLOWED_MOTIVES.has(infantryMotive);
 
   // --------------------------------------------------------------------------
   // Handlers — identity
@@ -271,12 +275,12 @@ export function InfantryBuildTab({
 
   const handleAddFieldGun = useCallback(
     (gunId: string) => {
-      if (readOnly) return;
+      if (readOnly || !canUseFieldGuns) return;
       const entry = FIELD_GUN_CATALOG.find((g) => g.id === gunId);
       if (!entry || addedFieldGunIds.has(gunId)) return;
       addFieldGun(buildFieldGun(entry));
     },
-    [addFieldGun, addedFieldGunIds, readOnly],
+    [addFieldGun, addedFieldGunIds, canUseFieldGuns, readOnly],
   );
 
   const handleRemoveFieldGun = useCallback(
@@ -527,6 +531,11 @@ export function InfantryBuildTab({
       {/* Field Guns — available only for Foot and Motorized platoons */}
       <div className={cs.panel.main}>
         <h3 className={cs.text.sectionTitle}>Field Guns</h3>
+        {!canUseFieldGuns && (
+          <p className="mb-4 text-xs text-amber-400">
+            Field guns require Foot or Motorized motive.
+          </p>
+        )}
         {/* Currently equipped field guns */}
         {fieldGuns.length > 0 ? (
           <div className="mb-4 space-y-2">
@@ -538,7 +547,7 @@ export function InfantryBuildTab({
                 <span className="flex-1 text-sm text-white">
                   {gun.name}
                   <span className="ml-2 text-xs text-gray-400">
-                    (crew: {gun.crew})
+                    (crew: {gun.crewCount})
                   </span>
                 </span>
                 <label className="flex items-center gap-1 text-xs text-gray-400">
@@ -575,6 +584,7 @@ export function InfantryBuildTab({
             <select
               className={cs.select.full}
               defaultValue=""
+              disabled={!canUseFieldGuns}
               onChange={(e) => {
                 if (e.target.value) {
                   handleAddFieldGun(e.target.value);
@@ -619,7 +629,7 @@ export function InfantryBuildTab({
             <span>
               Field gun crew:{' '}
               <span className="font-medium text-white">
-                {fieldGuns.reduce((s, g) => s + g.crew, 0)}
+                {fieldGuns.reduce((s, g) => s + g.crewCount, 0)}
               </span>{' '}
               / {platoonStrength} troopers
             </span>

--- a/src/components/customizer/infantry/InfantryCustomizer.tsx
+++ b/src/components/customizer/infantry/InfantryCustomizer.tsx
@@ -4,7 +4,7 @@
  * Main component for customizing Infantry platoons.
  * Tab set is data-driven from INFANTRY_TABS registry. The Field Guns tab is
  * automatically hidden for Jump and Mechanized platoons via a visibleWhen
- * predicate that reads motionType from the store.
+ * predicate that reads infantryMotive from the store.
  *
  * @spec openspec/changes/add-per-type-customizer-tabs/specs/multi-unit-tabs/spec.md
  * @spec openspec/changes/add-multi-unit-type-support/tasks.md Phase 5.2
@@ -52,7 +52,7 @@ interface InfantryCustomizerProps {
 }
 
 // =============================================================================
-// Inner component (needs store context to read motionType for Field Guns visibility)
+// Inner component (needs store context to read infantryMotive for Field Guns visibility)
 // =============================================================================
 
 interface InfantryCustomizerInnerProps {
@@ -66,13 +66,13 @@ function InfantryCustomizerInner({
   onTabChange,
   readOnly,
 }: InfantryCustomizerInnerProps): React.ReactElement {
-  // Read motionType to drive the Field Guns tab visibility predicate
-  const motionType = useInfantryStore((s) => s.motionType);
+  // Read infantryMotive to drive the Field Guns tab visibility predicate
+  const infantryMotive = useInfantryStore((s) => s.infantryMotive);
 
   const { visibleSpecs, activeTab, setActiveTab, dirtyTabs, errorTabs } =
     useCustomizerTabs({
       specs: INFANTRY_TABS,
-      state: { motionType },
+      state: { infantryMotive },
       initialTabId: initialTab,
     });
 
@@ -123,7 +123,7 @@ function InfantryCustomizerInner({
  * Main Infantry customizer with registry-driven tabbed interface.
  *
  * Wraps InfantryCustomizerInner inside the store context so the inner
- * component can read motionType for the Field Guns tab visibility predicate.
+ * component can read infantryMotive for the Field Guns tab visibility predicate.
  */
 export function InfantryCustomizer({
   store,

--- a/src/components/customizer/infantry/InfantryFieldGunsTab.tsx
+++ b/src/components/customizer/infantry/InfantryFieldGunsTab.tsx
@@ -1,37 +1,146 @@
 /**
- * InfantryFieldGunsTab — placeholder
+ * Infantry Field Guns Tab
  *
- * Will be wired by `add-infantry-construction` to expose:
- *   - 1 field gun per 7 men rule enforcement
- *   - Field gun type and count selection
+ * Focused editor for the optional field-gun construction state.
  *
- * Visibility rule: hidden when motiveType is Jump or Mechanized (field guns
- * are not allowed for those motive types).  The visibleWhen predicate lives
- * in tabRegistry.ts.
- *
- * @spec openspec/changes/add-per-type-customizer-tabs/tasks.md §6.5, §6.7
- * @wiredBy add-infantry-construction
+ * @spec openspec/changes/add-infantry-construction/specs/infantry-unit-system/spec.md
  */
 
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
+
+import { useInfantryStore } from '@/stores/useInfantryStore';
+import {
+  FIELD_GUN_CATALOG,
+  buildFieldGun,
+} from '@/utils/construction/infantry/fieldGuns';
+import { FIELD_GUN_ALLOWED_MOTIVES } from '@/utils/construction/infantry/platoonComposition';
+
+import { customizerStyles as cs } from '../styles';
 
 export interface InfantryFieldGunsTabProps {
   readOnly?: boolean;
   className?: string;
 }
 
-/**
- * Placeholder for the Field Guns tab.
- * Construction proposal `add-infantry-construction` will replace the body.
- */
 export function InfantryFieldGunsTab({
+  readOnly = false,
   className = '',
 }: InfantryFieldGunsTabProps): React.ReactElement {
+  const infantryMotive = useInfantryStore((s) => s.infantryMotive);
+  const fieldGuns = useInfantryStore((s) => s.fieldGuns);
+  const addFieldGun = useInfantryStore((s) => s.addFieldGun);
+  const removeFieldGun = useInfantryStore((s) => s.removeFieldGun);
+  const setFieldGunAmmo = useInfantryStore((s) => s.setFieldGunAmmo);
+
+  const canUseFieldGuns = FIELD_GUN_ALLOWED_MOTIVES.has(infantryMotive);
+  const addedFieldGunIds = useMemo(
+    () => new Set(fieldGuns.map((gun) => gun.equipmentId)),
+    [fieldGuns],
+  );
+
+  const handleAddFieldGun = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      if (readOnly || !canUseFieldGuns || !event.target.value) return;
+      const entry = FIELD_GUN_CATALOG.find(
+        (gun) => gun.id === event.target.value,
+      );
+      if (!entry || addedFieldGunIds.has(entry.id)) return;
+      addFieldGun(buildFieldGun(entry));
+      event.target.value = '';
+    },
+    [addFieldGun, addedFieldGunIds, canUseFieldGuns, readOnly],
+  );
+
+  const handleAmmoChange = useCallback(
+    (index: number, event: React.ChangeEvent<HTMLInputElement>) => {
+      if (readOnly) return;
+      setFieldGunAmmo(index, Number(event.target.value));
+    },
+    [readOnly, setFieldGunAmmo],
+  );
+
   return (
-    <div className={`p-4 ${className}`} data-testid="infantry-field-guns-tab">
-      <p className="text-text-theme-secondary text-sm">
-        Coming soon — this tab will be wired up by add-infantry-construction
-      </p>
+    <div
+      className={`space-y-4 ${className}`}
+      data-testid="infantry-field-guns-tab"
+    >
+      <div className={cs.panel.main}>
+        <h3 className={cs.text.sectionTitle}>Field Guns</h3>
+
+        {!canUseFieldGuns && (
+          <p className="mb-4 text-xs text-amber-400">
+            Field guns require Foot or Motorized motive.
+          </p>
+        )}
+
+        {fieldGuns.length > 0 ? (
+          <div className="space-y-2">
+            {fieldGuns.map((gun, index) => (
+              <div
+                key={gun.equipmentId}
+                className="bg-surface-raised border-border-theme flex flex-wrap items-center gap-3 rounded border px-3 py-2"
+              >
+                <div className="min-w-48 flex-1">
+                  <div className="text-sm font-medium text-white">
+                    {gun.name}
+                  </div>
+                  <div className="text-xs text-gray-400">
+                    Crew {gun.crewCount}
+                  </div>
+                </div>
+
+                <label className="flex items-center gap-2 text-xs text-gray-400">
+                  Ammo
+                  <input
+                    type="number"
+                    value={gun.ammoRounds}
+                    min={0}
+                    disabled={readOnly}
+                    onChange={(event) => handleAmmoChange(index, event)}
+                    className="bg-surface-base border-border-theme w-20 rounded border px-2 py-1 text-sm text-white"
+                  />
+                </label>
+
+                {!readOnly && (
+                  <button
+                    type="button"
+                    onClick={() => removeFieldGun(gun.equipmentId)}
+                    className="text-xs text-red-400 hover:text-red-300"
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-xs text-gray-400">No field guns assigned.</p>
+        )}
+
+        {!readOnly && (
+          <div className="mt-4">
+            <label className={cs.text.label}>Add Field Gun</label>
+            <select
+              className={cs.select.full}
+              defaultValue=""
+              disabled={!canUseFieldGuns}
+              onChange={handleAddFieldGun}
+            >
+              <option value="">Select field gun to add...</option>
+              {FIELD_GUN_CATALOG.map((gun) => (
+                <option
+                  key={gun.id}
+                  value={gun.id}
+                  disabled={addedFieldGunIds.has(gun.id)}
+                >
+                  {gun.name} (crew {gun.crewRequired}, ammo{' '}
+                  {gun.defaultAmmoRounds})
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/customizer/shared/tabRegistry.ts
+++ b/src/components/customizer/shared/tabRegistry.ts
@@ -62,8 +62,8 @@ import { VehicleTurretTab } from '@/components/customizer/vehicle/VehicleTurretT
 import { AerospaceState } from '@/stores/aerospaceState';
 import { InfantryState } from '@/stores/infantryState';
 import { ProtoMechState } from '@/stores/protoMechState';
-import { SquadMotionType } from '@/types/unit/BaseUnitInterfaces';
 import { UnitType } from '@/types/unit/BattleMechInterfaces';
+import { InfantryMotive } from '@/types/unit/InfantryInterfaces';
 
 import { TabSpec } from './TabSpec';
 
@@ -350,7 +350,7 @@ export const BATTLE_ARMOR_TABS: TabSpec[] = [
 // =============================================================================
 
 /** Shape of the state snapshot passed to infantry visibleWhen predicates */
-type InfantryVisibilityState = Pick<InfantryState, 'motionType'>;
+type InfantryVisibilityState = Pick<InfantryState, 'infantryMotive'>;
 
 /**
  * Canonical Infantry tab set.
@@ -385,10 +385,10 @@ export const INFANTRY_TABS: TabSpec<InfantryVisibilityState>[] = [
     label: 'Field Guns',
     icon: iconSvg(ICONS.fieldguns),
     component: InfantryFieldGunsTab,
-    // Jump and Mechanized platoons cannot deploy field guns
+    // Only Foot and Motorized platoons can deploy field guns
     visibleWhen: (s) =>
-      s.motionType !== SquadMotionType.JUMP &&
-      s.motionType !== SquadMotionType.MECHANIZED,
+      s.infantryMotive === InfantryMotive.FOOT ||
+      s.infantryMotive === InfantryMotive.MOTORIZED,
   },
   {
     id: 'specialization',

--- a/src/components/gameplay/animation/__tests__/useMovementTween.reducedMotion.test.tsx
+++ b/src/components/gameplay/animation/__tests__/useMovementTween.reducedMotion.test.tsx
@@ -1,0 +1,40 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useMovementTween } from '@/components/gameplay/animation/useMovementTween';
+import { Facing, MovementType } from '@/types/gameplay';
+
+describe('useMovementTween reduced motion', () => {
+  it('snaps to the final frame and completes within one tick', async () => {
+    const onDone = jest.fn();
+    const path = [
+      { q: 0, r: 0 },
+      { q: 2, r: -1 },
+    ];
+
+    const { result } = renderHook(() =>
+      useMovementTween(path, MovementType.Jump, onDone, {
+        finalFacing: Facing.South,
+        prefersReducedMotion: true,
+        projectHex: (coord) => ({ x: coord.q * 16, y: coord.r * 16 }),
+      }),
+    );
+
+    expect(result.current).toEqual({
+      x: 32,
+      y: -16,
+      facing: Facing.South,
+      scale: 1,
+      arcOffset: 0,
+      isAnimating: false,
+      isComplete: true,
+      reducedMotion: true,
+      mode: MovementType.Jump,
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/gameplay/animation/useMovementTween.ts
+++ b/src/components/gameplay/animation/useMovementTween.ts
@@ -1,0 +1,114 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import type {
+  Facing,
+  IHexCoordinate,
+  MovementAnimationMode,
+} from '@/types/gameplay';
+
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+import { Facing as FacingValue } from '@/types/gameplay';
+
+export interface TweenPoint {
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface MovementTweenFrame {
+  readonly x: number;
+  readonly y: number;
+  readonly facing: Facing;
+  readonly scale: number;
+  readonly arcOffset: number;
+  readonly isAnimating: boolean;
+  readonly isComplete: boolean;
+  readonly reducedMotion: boolean;
+  readonly mode: MovementAnimationMode;
+}
+
+export interface MovementTweenOptions {
+  readonly initialFacing?: Facing;
+  readonly finalFacing?: Facing;
+  readonly prefersReducedMotion?: boolean;
+  readonly projectHex?: (coord: IHexCoordinate) => TweenPoint;
+}
+
+export function useMovementTween(
+  path: readonly IHexCoordinate[],
+  mode: MovementAnimationMode,
+  onDone: () => void,
+  options: MovementTweenOptions = {},
+): MovementTweenFrame {
+  const systemReducedMotion = usePrefersReducedMotion();
+  const reducedMotion = options.prefersReducedMotion ?? systemReducedMotion;
+  const projectHex = options.projectHex ?? defaultProjectHex;
+  const initialFacing = options.initialFacing ?? FacingValue.North;
+  const finalFacing = options.finalFacing ?? initialFacing;
+  const pathKey = path.map((hex) => `${hex.q},${hex.r}`).join('|');
+  const onDoneRef = useRef(onDone);
+  const completedKeyRef = useRef<string | null>(null);
+  const completionKey = `${pathKey}:${mode}:${finalFacing}:${reducedMotion}`;
+
+  useEffect(() => {
+    onDoneRef.current = onDone;
+  }, [onDone]);
+
+  const nextFrame = useMemo(
+    () =>
+      createReducedMotionAwareFrame({
+        path,
+        mode,
+        reducedMotion,
+        projectHex,
+        initialFacing,
+        finalFacing,
+      }),
+    [finalFacing, initialFacing, mode, path, projectHex, reducedMotion],
+  );
+  const [frame, setFrame] = useState(nextFrame);
+
+  useEffect(() => {
+    setFrame(nextFrame);
+
+    if (!reducedMotion) {
+      completedKeyRef.current = null;
+      return;
+    }
+
+    if (completedKeyRef.current === completionKey) return;
+    completedKeyRef.current = completionKey;
+    onDoneRef.current();
+  }, [completionKey, nextFrame, reducedMotion]);
+
+  return frame;
+}
+
+function createReducedMotionAwareFrame(params: {
+  readonly path: readonly IHexCoordinate[];
+  readonly mode: MovementAnimationMode;
+  readonly reducedMotion: boolean;
+  readonly projectHex: (coord: IHexCoordinate) => TweenPoint;
+  readonly initialFacing: Facing;
+  readonly finalFacing: Facing;
+}): MovementTweenFrame {
+  const start = params.path[0] ?? { q: 0, r: 0 };
+  const end = params.path[params.path.length - 1] ?? start;
+  const coord = params.reducedMotion ? end : start;
+  const point = params.projectHex(coord);
+
+  return {
+    x: point.x,
+    y: point.y,
+    facing: params.reducedMotion ? params.finalFacing : params.initialFacing,
+    scale: 1,
+    arcOffset: 0,
+    isAnimating: !params.reducedMotion && params.path.length > 1,
+    isComplete: params.reducedMotion || params.path.length <= 1,
+    reducedMotion: params.reducedMotion,
+    mode: params.mode,
+  };
+}
+
+function defaultProjectHex(coord: IHexCoordinate): TweenPoint {
+  return { x: coord.q, y: coord.r };
+}

--- a/src/engine/GameEngine.phases.ts
+++ b/src/engine/GameEngine.phases.ts
@@ -39,6 +39,10 @@ import {
   resolvePendingPSRs,
   type IPhysicalAttackContext,
 } from '@/utils/gameplay/gameSession';
+import {
+  buildMovementEventPath,
+  maxMovementCostForCapability,
+} from '@/utils/gameplay/movement/eventPath';
 import { waterDepthAtPosition } from '@/utils/gameplay/waterDepth';
 import { buildWeaponAttacks } from '@/utils/gameplay/weaponAttackBuilder';
 
@@ -149,6 +153,16 @@ export function runMovementPhase(
     const moveEvt = botPlayer.playMovementPhase(aiUnit, grid, cap);
 
     if (moveEvt) {
+      const eventPath = buildMovementEventPath({
+        grid,
+        from: unit.position,
+        to: moveEvt.payload.to,
+        movementType: moveEvt.payload.movementType,
+        maxCost: maxMovementCostForCapability(
+          cap,
+          moveEvt.payload.movementType,
+        ),
+      });
       updatedSession = declareMovement(
         updatedSession,
         unitId,
@@ -158,6 +172,7 @@ export function runMovementPhase(
         moveEvt.payload.movementType,
         moveEvt.payload.mpUsed,
         moveEvt.payload.heatGenerated,
+        eventPath,
       );
     }
     updatedSession = lockMovement(updatedSession, unitId);

--- a/src/engine/GameEngine.ts
+++ b/src/engine/GameEngine.ts
@@ -194,6 +194,7 @@ export class GameEngine {
     opponentUnits: readonly IAdaptedUnit[],
     gameUnits: readonly IGameUnit[],
     linkage?: {
+      readonly campaignId?: string | null;
       readonly contractId?: string | null;
       readonly scenarioId?: string | null;
       readonly encounterId?: string | null;

--- a/src/engine/InteractiveSession.ts
+++ b/src/engine/InteractiveSession.ts
@@ -72,6 +72,10 @@ import {
   endGame,
   type IPhysicalAttackContext,
 } from '@/utils/gameplay/gameSession';
+import {
+  buildMovementEventPath,
+  maxMovementCostForCapability,
+} from '@/utils/gameplay/movement/eventPath';
 import { waterDepthAtPosition } from '@/utils/gameplay/waterDepth';
 import { buildWeaponAttacks } from '@/utils/gameplay/weaponAttackBuilder';
 
@@ -241,9 +245,20 @@ export class InteractiveSession {
     to: IHexCoordinate,
     facing: Facing,
     movementType: MovementType,
+    path?: readonly IHexCoordinate[],
   ): void {
     const unit = this.session.currentState.units[unitId];
     if (!unit) return;
+    const capability = this.movementByUnit.get(unitId);
+    const eventPath =
+      path ??
+      buildMovementEventPath({
+        grid: this.grid,
+        from: unit.position,
+        to,
+        movementType,
+        maxCost: maxMovementCostForCapability(capability, movementType),
+      });
 
     this.session = declareMovement(
       this.session,
@@ -254,6 +269,7 @@ export class InteractiveSession {
       movementType,
       0,
       movementType === MovementType.Jump ? 1 : 0,
+      eventPath,
     );
     this.session = lockMovement(this.session, unitId);
     this.tryFinalizeAndPublish();
@@ -410,6 +426,16 @@ export class InteractiveSession {
           cap,
         );
         if (moveEvt) {
+          const eventPath = buildMovementEventPath({
+            grid: this.grid,
+            from: refreshedUnit.position,
+            to: moveEvt.payload.to,
+            movementType: moveEvt.payload.movementType,
+            maxCost: maxMovementCostForCapability(
+              cap,
+              moveEvt.payload.movementType,
+            ),
+          });
           this.session = declareMovement(
             this.session,
             unitId,
@@ -419,6 +445,7 @@ export class InteractiveSession {
             moveEvt.payload.movementType,
             moveEvt.payload.mpUsed,
             moveEvt.payload.heatGenerated,
+            eventPath,
           );
         }
         this.session = lockMovement(this.session, unitId);

--- a/src/engine/InteractiveSession.ts
+++ b/src/engine/InteractiveSession.ts
@@ -88,6 +88,7 @@ import { toAIUnitState, toMovementCapability } from './GameEngine.helpers';
  * outcome resolves.
  */
 export interface IInteractiveSessionLinkage {
+  readonly campaignId?: string | null;
   readonly contractId?: string | null;
   readonly scenarioId?: string | null;
   readonly encounterId?: string | null;
@@ -172,6 +173,7 @@ export class InteractiveSession {
       // any later consumer of `IGameSession` (review UI, persistence
       // layer) can read them without keeping a parallel map.
       encounterId: linkage.encounterId ?? null,
+      campaignId: linkage.campaignId ?? null,
       contractId: linkage.contractId ?? null,
       scenarioId: linkage.scenarioId ?? null,
     };

--- a/src/hooks/__tests__/useReducedMotion.test.ts
+++ b/src/hooks/__tests__/useReducedMotion.test.ts
@@ -1,0 +1,28 @@
+import {
+  getPrefersReducedMotion,
+  REDUCED_MOTION_QUERY,
+} from '@/hooks/useReducedMotion';
+
+describe('getPrefersReducedMotion', () => {
+  it('reads the reduced-motion media query', () => {
+    const mediaQueryList: MediaQueryList = {
+      matches: true,
+      media: REDUCED_MOTION_QUERY,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => true,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+    };
+
+    expect(
+      getPrefersReducedMotion({
+        matchMedia: (query) =>
+          query === REDUCED_MOTION_QUERY
+            ? mediaQueryList
+            : { ...mediaQueryList, matches: false, media: query },
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+
+export const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+interface MatchMediaTarget {
+  readonly matchMedia?: (query: string) => MediaQueryList;
+}
+
+export function getPrefersReducedMotion(
+  target: MatchMediaTarget | undefined = browserWindow(),
+): boolean {
+  const media = target?.matchMedia?.(REDUCED_MOTION_QUERY);
+  return media?.matches ?? false;
+}
+
+export function subscribePrefersReducedMotion(
+  callback: (enabled: boolean) => void,
+  target: MatchMediaTarget | undefined = browserWindow(),
+): () => void {
+  const media = target?.matchMedia?.(REDUCED_MOTION_QUERY);
+  if (!media) return () => undefined;
+
+  const listener = (event: MediaQueryListEvent) => {
+    callback(event.matches);
+  };
+
+  if (typeof media.addEventListener === 'function') {
+    media.addEventListener('change', listener);
+    return () => media.removeEventListener('change', listener);
+  }
+
+  media.addListener(listener);
+  return () => media.removeListener(listener);
+}
+
+export function usePrefersReducedMotion(): boolean {
+  const [enabled, setEnabled] = useState(() => getPrefersReducedMotion());
+
+  useEffect(() => subscribePrefersReducedMotion(setEnabled), []);
+
+  return enabled;
+}
+
+function browserWindow(): MatchMediaTarget | undefined {
+  return typeof window === 'undefined' ? undefined : window;
+}

--- a/src/lib/p2p/__tests__/gameSessionChannel.test.ts
+++ b/src/lib/p2p/__tests__/gameSessionChannel.test.ts
@@ -1,0 +1,288 @@
+import * as Y from 'yjs';
+
+import {
+  GAME_INTENT_TYPES,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  type IGameEvent,
+  type IGameIntent,
+  type IGameSession,
+} from '@/types/gameplay/GameSessionInterfaces';
+
+import {
+  GAME_SESSION_EVENTS_ARRAY,
+  createGameSessionChannel,
+  deserializeGameSessionEnvelope,
+  isGameIntent,
+  serializeGameSessionEnvelope,
+  type IGameEventEnvelope,
+} from '../gameSessionChannel';
+import {
+  GAME_SESSION_AWARENESS_FIELD,
+  getGameSessionAwarenessStates,
+  joinLocalPeerAsGuest,
+  onGameSessionLifecycleEvent,
+  promoteLocalPeerToHost,
+  type IGameSessionAwarenessAdapter,
+  type IGameSessionAwarenessState,
+} from '../gameSessionRoles';
+
+class TestAwareness implements IGameSessionAwarenessAdapter {
+  readonly states = new Map<number, Record<string, unknown>>();
+
+  constructor(readonly clientID: number) {
+    this.states.set(clientID, {});
+  }
+
+  getStates(): Map<number, Record<string, unknown>> {
+    return this.states;
+  }
+
+  setLocalStateField(field: string, value: unknown): void {
+    const currentState = this.states.get(this.clientID) ?? {};
+    this.states.set(this.clientID, {
+      ...currentState,
+      [field]: value,
+    });
+  }
+
+  setPeerState(clientID: number, metadata: IGameSessionAwarenessState): void {
+    this.states.set(clientID, {
+      [GAME_SESSION_AWARENESS_FIELD]: metadata,
+    });
+  }
+}
+
+function makeEvent(id: string, sequence: number): IGameEvent {
+  return {
+    id,
+    gameId: 'game-1',
+    sequence,
+    timestamp: '2026-04-30T00:00:00.000Z',
+    type: GameEventType.GameStarted,
+    turn: 1,
+    phase: GamePhase.Initiative,
+    payload: {
+      firstSide: GameSide.Player,
+    },
+  };
+}
+
+describe('gameSessionChannel', () => {
+  let doc: Y.Doc;
+  let eventArray: Y.Array<string>;
+
+  beforeEach(() => {
+    doc = new Y.Doc();
+    eventArray = doc.getArray<string>(GAME_SESSION_EVENTS_ARRAY);
+  });
+
+  afterEach(() => {
+    doc.destroy();
+  });
+
+  it('serializes game events through the event-store JSON helpers', () => {
+    const event = makeEvent('event-1', 1);
+    const envelope: IGameEventEnvelope = {
+      kind: 'game-event',
+      event,
+      authorPeerId: 'host-peer',
+    };
+
+    expect(
+      deserializeGameSessionEnvelope(serializeGameSessionEnvelope(envelope)),
+    ).toEqual(envelope);
+  });
+
+  it('broadcasts events into the dedicated gameEvents Y.Array', () => {
+    const customizerTabs = doc.getArray<string>('customizerTabs');
+    customizerTabs.push(['tab-a']);
+    const channel = createGameSessionChannel({
+      localPeerId: 'host-peer',
+      eventArray,
+    });
+
+    channel.broadcastEvent(makeEvent('event-1', 1));
+
+    expect(eventArray).toHaveLength(1);
+    expect(customizerTabs.toArray()).toEqual(['tab-a']);
+  });
+
+  it('delivers peer-authored events in arrival order', () => {
+    const channel = createGameSessionChannel({
+      localPeerId: 'guest-peer',
+      eventArray,
+    });
+    const received: string[] = [];
+    const unsubscribe = channel.onPeerEvent((event) => {
+      received.push(event.id);
+    });
+
+    eventArray.push([
+      serializeGameSessionEnvelope({
+        kind: 'game-event',
+        event: makeEvent('event-1', 1),
+        authorPeerId: 'host-peer',
+      }),
+      serializeGameSessionEnvelope({
+        kind: 'game-event',
+        event: makeEvent('event-2', 2),
+        authorPeerId: 'host-peer',
+      }),
+    ]);
+
+    unsubscribe();
+    expect(received).toEqual(['event-1', 'event-2']);
+  });
+
+  it('rejects local-authored event arrivals', () => {
+    const channel = createGameSessionChannel({
+      localPeerId: 'host-peer',
+      eventArray,
+    });
+    const received: IGameEvent[] = [];
+    const unsubscribe = channel.onPeerEvent((event) => {
+      received.push(event);
+    });
+
+    channel.broadcastEvent(makeEvent('event-1', 1));
+
+    unsubscribe();
+    expect(eventArray).toHaveLength(1);
+    expect(received).toEqual([]);
+  });
+
+  it('serializes and filters game intents with author metadata', () => {
+    const guestChannel = createGameSessionChannel({
+      localPeerId: 'guest-peer',
+      eventArray,
+    });
+    const hostChannel = createGameSessionChannel({
+      localPeerId: 'host-peer',
+      eventArray,
+    });
+    const received: IGameIntent[] = [];
+    const unsubscribe = hostChannel.onPeerIntent((intent) => {
+      received.push(intent);
+    });
+
+    guestChannel.broadcastIntent({
+      type: 'concede',
+      payload: { side: GameSide.Opponent },
+      authorPeerId: 'guest-peer',
+    });
+
+    unsubscribe();
+    expect(received).toEqual([
+      {
+        type: 'concede',
+        payload: { side: GameSide.Opponent },
+        authorPeerId: 'guest-peer',
+      },
+    ]);
+  });
+});
+
+describe('game session role and intent contracts', () => {
+  it('marks the local room creator as host in awareness and logs HostPromoted', () => {
+    const awareness = new TestAwareness(1);
+    const lifecycleEvents: string[] = [];
+    const unsubscribe = onGameSessionLifecycleEvent((event) => {
+      lifecycleEvents.push(`${event.type}:${event.peerId}`);
+    });
+
+    const metadata = promoteLocalPeerToHost({
+      awareness,
+      localPeerId: 'host-peer',
+      now: () => '2026-04-30T00:00:00.000Z',
+    });
+
+    unsubscribe();
+    expect(
+      awareness.getStates().get(1)?.[GAME_SESSION_AWARENESS_FIELD],
+    ).toEqual(metadata);
+    expect(getGameSessionAwarenessStates(awareness)).toEqual([metadata]);
+    expect(lifecycleEvents).toEqual(['HostPromoted:host-peer']);
+  });
+
+  it('marks the first joiner as guest and logs GuestJoined', () => {
+    const awareness = new TestAwareness(2);
+    awareness.setPeerState(1, {
+      peerId: 'host-peer',
+      role: 'host',
+      assignedAt: '2026-04-30T00:00:00.000Z',
+    });
+    const lifecycleEvents: string[] = [];
+    const unsubscribe = onGameSessionLifecycleEvent((event) => {
+      lifecycleEvents.push(`${event.type}:${event.peerId}`);
+    });
+
+    const metadata = joinLocalPeerAsGuest({
+      awareness,
+      localPeerId: 'guest-peer',
+      now: () => '2026-04-30T00:00:01.000Z',
+    });
+
+    unsubscribe();
+    expect(
+      awareness.getStates().get(2)?.[GAME_SESSION_AWARENESS_FIELD],
+    ).toEqual(metadata);
+    expect(lifecycleEvents).toEqual(['GuestJoined:guest-peer']);
+  });
+
+  it('rejects a second guest joiner for networked 1v1', () => {
+    const awareness = new TestAwareness(3);
+    awareness.setPeerState(1, {
+      peerId: 'host-peer',
+      role: 'host',
+      assignedAt: '2026-04-30T00:00:00.000Z',
+    });
+    awareness.setPeerState(2, {
+      peerId: 'guest-peer',
+      role: 'guest',
+      assignedAt: '2026-04-30T00:00:01.000Z',
+    });
+
+    expect(() =>
+      joinLocalPeerAsGuest({
+        awareness,
+        localPeerId: 'third-peer',
+      }),
+    ).toThrow('Match is full');
+  });
+
+  it('defines the guest-to-host IGameIntent contract', () => {
+    const intent: IGameIntent = {
+      type: 'declareMovement',
+      payload: { unitId: 'unit-1' },
+      authorPeerId: 'guest-peer',
+    };
+
+    expect(GAME_INTENT_TYPES).toEqual([
+      'declareMovement',
+      'declareAttack',
+      'declarePhysical',
+      'confirmHeat',
+      'endPhase',
+      'concede',
+    ]);
+    expect(isGameIntent(intent)).toBe(true);
+  });
+
+  it('keeps network ownership optional on local sessions', () => {
+    const localSessionMetadata: Pick<
+      IGameSession,
+      'hostPeerId' | 'guestPeerId' | 'sideOwners'
+    > = {};
+    const sideOwners: NonNullable<IGameSession['sideOwners']> = {
+      [GameSide.Player]: 'host-peer',
+      [GameSide.Opponent]: 'guest-peer',
+    };
+
+    expect(localSessionMetadata.hostPeerId).toBeUndefined();
+    expect(localSessionMetadata.guestPeerId).toBeUndefined();
+    expect(localSessionMetadata.sideOwners).toBeUndefined();
+    expect(sideOwners[GameSide.Player]).toBe('host-peer');
+  });
+});

--- a/src/lib/p2p/gameSessionChannel.ts
+++ b/src/lib/p2p/gameSessionChannel.ts
@@ -1,0 +1,314 @@
+import type * as Y from 'yjs';
+
+import {
+  GAME_INTENT_TYPES,
+  isGameEvent,
+  type GameIntentType,
+  type IGameEvent,
+  type IGameIntent,
+} from '@/types/gameplay/GameSessionInterfaces';
+import {
+  deserializeEvent,
+  serializeEvent,
+} from '@/utils/gameplay/gameEvents/serialization';
+
+import { getLocalPeerId, getYArray } from './SyncProvider';
+
+export const GAME_SESSION_EVENTS_ARRAY = 'gameEvents';
+
+export interface IGameEventEnvelope {
+  readonly kind: 'game-event';
+  readonly event: IGameEvent;
+  readonly authorPeerId: string;
+}
+
+export interface IGameIntentEnvelope {
+  readonly kind: 'game-intent';
+  readonly intent: IGameIntent;
+  readonly authorPeerId: string;
+}
+
+export interface IPeerRejectedEnvelope {
+  readonly kind: 'peer-rejected';
+  readonly intentId: string;
+  readonly reason: string;
+}
+
+export type GameSessionChannelEnvelope =
+  | IGameEventEnvelope
+  | IGameIntentEnvelope
+  | IPeerRejectedEnvelope;
+
+export type PeerEventCallback = (
+  event: IGameEvent,
+  envelope: IGameEventEnvelope,
+) => void;
+
+export type PeerIntentCallback = (
+  intent: IGameIntent,
+  envelope: IGameIntentEnvelope,
+) => void;
+
+export type PeerRejectedCallback = (envelope: IPeerRejectedEnvelope) => void;
+
+export interface IGameSessionChannel {
+  readonly broadcastEvent: (event: IGameEvent) => void;
+  readonly onPeerEvent: (callback: PeerEventCallback) => () => void;
+  readonly broadcastIntent: (intent: IGameIntent) => void;
+  readonly onPeerIntent: (callback: PeerIntentCallback) => () => void;
+  readonly broadcastRejection: (
+    rejection: Omit<IPeerRejectedEnvelope, 'kind'>,
+  ) => void;
+  readonly onPeerRejection: (callback: PeerRejectedCallback) => () => void;
+}
+
+export interface IGameSessionChannelOptions {
+  readonly localPeerId?: string;
+  readonly eventArray?: Y.Array<string>;
+  readonly getEventArray?: () => Y.Array<string> | null;
+}
+
+export function serializeGameSessionEnvelope(
+  envelope: GameSessionChannelEnvelope,
+): string {
+  if (envelope.kind === 'game-event') {
+    const event: unknown = JSON.parse(serializeEvent(envelope.event));
+    return JSON.stringify({
+      kind: envelope.kind,
+      event,
+      authorPeerId: envelope.authorPeerId,
+    });
+  }
+
+  return JSON.stringify(envelope);
+}
+
+export function deserializeGameSessionEnvelope(
+  serialized: string,
+): GameSessionChannelEnvelope {
+  const parsed: unknown = JSON.parse(serialized);
+  if (!isRecord(parsed)) {
+    throw new Error('Invalid game session channel envelope');
+  }
+
+  if (parsed.kind === 'game-event') {
+    if (typeof parsed.authorPeerId !== 'string') {
+      throw new Error('Invalid game event envelope author');
+    }
+    const event = deserializeEvent(JSON.stringify(parsed.event));
+    if (!isGameEvent(event)) {
+      throw new Error('Invalid game event envelope payload');
+    }
+    return {
+      kind: 'game-event',
+      event,
+      authorPeerId: parsed.authorPeerId,
+    };
+  }
+
+  if (parsed.kind === 'game-intent') {
+    if (typeof parsed.authorPeerId !== 'string') {
+      throw new Error('Invalid game intent envelope author');
+    }
+    if (!isGameIntent(parsed.intent)) {
+      throw new Error('Invalid game intent envelope payload');
+    }
+    return {
+      kind: 'game-intent',
+      intent: parsed.intent,
+      authorPeerId: parsed.authorPeerId,
+    };
+  }
+
+  if (parsed.kind === 'peer-rejected') {
+    if (
+      typeof parsed.intentId !== 'string' ||
+      typeof parsed.reason !== 'string'
+    ) {
+      throw new Error('Invalid peer rejection envelope payload');
+    }
+    return {
+      kind: 'peer-rejected',
+      intentId: parsed.intentId,
+      reason: parsed.reason,
+    };
+  }
+
+  throw new Error('Unknown game session channel envelope kind');
+}
+
+export function tryDeserializeGameSessionEnvelope(
+  serialized: string,
+): GameSessionChannelEnvelope | null {
+  try {
+    return deserializeGameSessionEnvelope(serialized);
+  } catch {
+    return null;
+  }
+}
+
+export function createGameSessionChannel(
+  options: IGameSessionChannelOptions = {},
+): IGameSessionChannel {
+  const appendEnvelope = (envelope: GameSessionChannelEnvelope): void => {
+    const eventArray = requireGameEventsArray(options);
+    eventArray.push([serializeGameSessionEnvelope(envelope)]);
+  };
+
+  const observeEnvelopes = (
+    callback: (envelope: GameSessionChannelEnvelope) => void,
+  ): (() => void) => {
+    const eventArray = requireGameEventsArray(options);
+    const observer = (event: Y.YArrayEvent<string>): void => {
+      for (const serialized of insertedValues(event)) {
+        const envelope = tryDeserializeGameSessionEnvelope(serialized);
+        if (!envelope) continue;
+        callback(envelope);
+      }
+    };
+
+    eventArray.observe(observer);
+    return () => {
+      eventArray.unobserve(observer);
+    };
+  };
+
+  const isLocalAuthor = (authorPeerId: string): boolean => {
+    return authorPeerId === requireLocalPeerId(options);
+  };
+
+  return {
+    broadcastEvent: (event: IGameEvent): void => {
+      appendEnvelope({
+        kind: 'game-event',
+        event,
+        authorPeerId: requireLocalPeerId(options),
+      });
+    },
+    onPeerEvent: (callback: PeerEventCallback): (() => void) => {
+      return observeEnvelopes((envelope) => {
+        if (envelope.kind !== 'game-event') return;
+        if (isLocalAuthor(envelope.authorPeerId)) return;
+        callback(envelope.event, envelope);
+      });
+    },
+    broadcastIntent: (intent: IGameIntent): void => {
+      const authorPeerId = requireLocalPeerId(options);
+      appendEnvelope({
+        kind: 'game-intent',
+        intent: { ...intent, authorPeerId },
+        authorPeerId,
+      });
+    },
+    onPeerIntent: (callback: PeerIntentCallback): (() => void) => {
+      return observeEnvelopes((envelope) => {
+        if (envelope.kind !== 'game-intent') return;
+        if (isLocalAuthor(envelope.authorPeerId)) return;
+        callback(envelope.intent, envelope);
+      });
+    },
+    broadcastRejection: (
+      rejection: Omit<IPeerRejectedEnvelope, 'kind'>,
+    ): void => {
+      appendEnvelope({
+        kind: 'peer-rejected',
+        intentId: rejection.intentId,
+        reason: rejection.reason,
+      });
+    },
+    onPeerRejection: (callback: PeerRejectedCallback): (() => void) => {
+      return observeEnvelopes((envelope) => {
+        if (envelope.kind !== 'peer-rejected') return;
+        callback(envelope);
+      });
+    },
+  };
+}
+
+export function broadcastEvent(event: IGameEvent): void {
+  createGameSessionChannel().broadcastEvent(event);
+}
+
+export function onPeerEvent(callback: PeerEventCallback): () => void {
+  return createGameSessionChannel().onPeerEvent(callback);
+}
+
+export function broadcastIntent(intent: IGameIntent): void {
+  createGameSessionChannel().broadcastIntent(intent);
+}
+
+export function onPeerIntent(callback: PeerIntentCallback): () => void {
+  return createGameSessionChannel().onPeerIntent(callback);
+}
+
+export function broadcastRejection(
+  rejection: Omit<IPeerRejectedEnvelope, 'kind'>,
+): void {
+  createGameSessionChannel().broadcastRejection(rejection);
+}
+
+export function onPeerRejection(callback: PeerRejectedCallback): () => void {
+  return createGameSessionChannel().onPeerRejection(callback);
+}
+
+export function isGameIntent(value: unknown): value is IGameIntent {
+  if (!isRecord(value)) return false;
+  return (
+    isGameIntentType(value.type) &&
+    'payload' in value &&
+    typeof value.authorPeerId === 'string'
+  );
+}
+
+function isGameIntentType(value: unknown): value is GameIntentType {
+  return (
+    typeof value === 'string' &&
+    GAME_INTENT_TYPES.some((intentType) => intentType === value)
+  );
+}
+
+function requireGameEventsArray(
+  options: IGameSessionChannelOptions,
+): Y.Array<string> {
+  const eventArray =
+    options.eventArray ??
+    options.getEventArray?.() ??
+    getYArray<string>(GAME_SESSION_EVENTS_ARRAY);
+
+  if (!eventArray) {
+    throw new Error('No active gameEvents Y.Array');
+  }
+
+  return eventArray;
+}
+
+function requireLocalPeerId(options: IGameSessionChannelOptions): string {
+  const peerId = options.localPeerId ?? getLocalPeerId();
+  if (!peerId) {
+    throw new Error('No local peer id available');
+  }
+  return peerId;
+}
+
+function insertedValues(event: Y.YArrayEvent<string>): readonly string[] {
+  const values: string[] = [];
+
+  for (const change of event.changes.delta) {
+    const insert = 'insert' in change ? change.insert : undefined;
+    if (Array.isArray(insert)) {
+      for (const value of insert) {
+        if (typeof value === 'string') {
+          values.push(value);
+        }
+      }
+    } else if (typeof insert === 'string') {
+      values.push(insert);
+    }
+  }
+
+  return values;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/lib/p2p/gameSessionRoles.ts
+++ b/src/lib/p2p/gameSessionRoles.ts
@@ -1,0 +1,188 @@
+import { getActiveRoom, getLocalPeerId } from './SyncProvider';
+
+export const GAME_SESSION_AWARENESS_FIELD = 'gameSession';
+
+export type GameSessionPeerRole = 'host' | 'guest';
+
+export interface IGameSessionAwarenessState {
+  readonly peerId: string;
+  readonly role: GameSessionPeerRole;
+  readonly assignedAt: string;
+}
+
+export interface IGameSessionAwarenessAdapter {
+  readonly clientID?: number;
+  readonly getStates: () => Map<number, Record<string, unknown>>;
+  readonly setLocalStateField: (field: string, value: unknown) => void;
+}
+
+export interface IGameSessionRoleOptions {
+  readonly awareness?: IGameSessionAwarenessAdapter;
+  readonly localPeerId?: string;
+  readonly now?: () => string;
+}
+
+export type GameSessionLifecycleEvent =
+  | {
+      readonly type: 'HostPromoted';
+      readonly peerId: string;
+      readonly role: 'host';
+      readonly timestamp: string;
+    }
+  | {
+      readonly type: 'GuestJoined';
+      readonly peerId: string;
+      readonly role: 'guest';
+      readonly timestamp: string;
+    };
+
+type LifecycleListener = (event: GameSessionLifecycleEvent) => void;
+
+const lifecycleListeners = new Set<LifecycleListener>();
+
+export function onGameSessionLifecycleEvent(
+  listener: LifecycleListener,
+): () => void {
+  lifecycleListeners.add(listener);
+  return () => {
+    lifecycleListeners.delete(listener);
+  };
+}
+
+export function promoteLocalPeerToHost(
+  options: IGameSessionRoleOptions = {},
+): IGameSessionAwarenessState {
+  const metadata = setLocalGameSessionRole('host', options);
+  emitLifecycleEvent({
+    type: 'HostPromoted',
+    peerId: metadata.peerId,
+    role: 'host',
+    timestamp: metadata.assignedAt,
+  });
+  return metadata;
+}
+
+export function joinLocalPeerAsGuest(
+  options: IGameSessionRoleOptions = {},
+): IGameSessionAwarenessState {
+  const awareness = requireAwareness(options);
+  const localPeerId = resolveAwarenessPeerId(options, awareness);
+  const currentPeers = getGameSessionAwarenessStates(awareness);
+  const guestPeer = currentPeers.find(
+    (peer) => peer.role === 'guest' && peer.peerId !== localPeerId,
+  );
+
+  if (guestPeer) {
+    throw new Error('Match is full');
+  }
+
+  const metadata = setLocalGameSessionRole('guest', {
+    ...options,
+    awareness,
+    localPeerId,
+  });
+  emitLifecycleEvent({
+    type: 'GuestJoined',
+    peerId: metadata.peerId,
+    role: 'guest',
+    timestamp: metadata.assignedAt,
+  });
+  return metadata;
+}
+
+export function getGameSessionAwarenessStates(
+  awareness?: IGameSessionAwarenessAdapter,
+): readonly IGameSessionAwarenessState[] {
+  const resolvedAwareness =
+    awareness ?? getActiveRoom()?.webrtcProvider.awareness;
+  if (!resolvedAwareness) return [];
+
+  const peers: IGameSessionAwarenessState[] = [];
+  resolvedAwareness.getStates().forEach((state) => {
+    const metadata = readGameSessionAwarenessState(state);
+    if (metadata) {
+      peers.push(metadata);
+    }
+  });
+  return peers;
+}
+
+function setLocalGameSessionRole(
+  role: GameSessionPeerRole,
+  options: IGameSessionRoleOptions,
+): IGameSessionAwarenessState {
+  const awareness = requireAwareness(options);
+  const peerId = resolveAwarenessPeerId(options, awareness);
+  const assignedAt = options.now?.() ?? new Date().toISOString();
+  const metadata: IGameSessionAwarenessState = {
+    peerId,
+    role,
+    assignedAt,
+  };
+
+  awareness.setLocalStateField(GAME_SESSION_AWARENESS_FIELD, metadata);
+  return metadata;
+}
+
+function requireAwareness(
+  options: IGameSessionRoleOptions,
+): IGameSessionAwarenessAdapter {
+  const awareness =
+    options.awareness ?? getActiveRoom()?.webrtcProvider.awareness;
+  if (!awareness) {
+    throw new Error('No active Yjs awareness');
+  }
+  return awareness;
+}
+
+function resolveAwarenessPeerId(
+  options: IGameSessionRoleOptions,
+  awareness: IGameSessionAwarenessAdapter,
+): string {
+  const peerId =
+    options.localPeerId ??
+    getLocalPeerId() ??
+    (typeof awareness.clientID === 'number'
+      ? String(awareness.clientID)
+      : null);
+
+  if (!peerId) {
+    throw new Error('No local peer id available');
+  }
+
+  return peerId;
+}
+
+function readGameSessionAwarenessState(
+  state: Record<string, unknown>,
+): IGameSessionAwarenessState | null {
+  const metadata = state[GAME_SESSION_AWARENESS_FIELD];
+  if (!isRecord(metadata)) return null;
+  if (
+    typeof metadata.peerId !== 'string' ||
+    !isGameSessionPeerRole(metadata.role) ||
+    typeof metadata.assignedAt !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    peerId: metadata.peerId,
+    role: metadata.role,
+    assignedAt: metadata.assignedAt,
+  };
+}
+
+function isGameSessionPeerRole(value: unknown): value is GameSessionPeerRole {
+  return value === 'host' || value === 'guest';
+}
+
+function emitLifecycleEvent(event: GameSessionLifecycleEvent): void {
+  lifecycleListeners.forEach((listener) => {
+    listener(event);
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/lib/p2p/index.ts
+++ b/src/lib/p2p/index.ts
@@ -89,5 +89,42 @@ export {
   useItemSyncState,
 } from './useSyncedVaultStore';
 
+export {
+  GAME_SESSION_EVENTS_ARRAY,
+  broadcastEvent,
+  broadcastIntent,
+  broadcastRejection,
+  createGameSessionChannel,
+  deserializeGameSessionEnvelope,
+  isGameIntent,
+  onPeerEvent,
+  onPeerIntent,
+  onPeerRejection,
+  serializeGameSessionEnvelope,
+  tryDeserializeGameSessionEnvelope,
+  type GameSessionChannelEnvelope,
+  type IGameEventEnvelope,
+  type IGameIntentEnvelope,
+  type IGameSessionChannel,
+  type IGameSessionChannelOptions,
+  type IPeerRejectedEnvelope,
+  type PeerEventCallback,
+  type PeerIntentCallback,
+  type PeerRejectedCallback,
+} from './gameSessionChannel';
+
+export {
+  GAME_SESSION_AWARENESS_FIELD,
+  getGameSessionAwarenessStates,
+  joinLocalPeerAsGuest,
+  onGameSessionLifecycleEvent,
+  promoteLocalPeerToHost,
+  type GameSessionLifecycleEvent,
+  type GameSessionPeerRole,
+  type IGameSessionAwarenessAdapter,
+  type IGameSessionAwarenessState,
+  type IGameSessionRoleOptions,
+} from './gameSessionRoles';
+
 // Hooks
 export { useSyncRoom, type UseSyncRoomReturn } from './useSyncRoom';

--- a/src/pages/api/encounters/[id]/launch.ts
+++ b/src/pages/api/encounters/[id]/launch.ts
@@ -9,7 +9,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { IEncounterOperationResult } from '@/services/encounter/EncounterRepository';
-import { getEncounterService } from '@/services/encounter/EncounterService';
+import {
+  getEncounterService,
+  type ILaunchEncounterOptions,
+} from '@/services/encounter/EncounterService';
 import { getSQLiteService } from '@/services/persistence/SQLiteService';
 import { IEncounter } from '@/types/encounter';
 
@@ -25,6 +28,30 @@ type LaunchResponse = IEncounterOperationResult & {
 type ErrorResponse = {
   error: string;
 };
+
+function readOptionalId(
+  body: Record<string, unknown>,
+  key: keyof ILaunchEncounterOptions,
+): string | null | undefined {
+  const value = body[key];
+  if (typeof value === 'string' || value === null) {
+    return value;
+  }
+  return undefined;
+}
+
+function parseLaunchOptions(body: unknown): ILaunchEncounterOptions {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return {};
+  }
+
+  const record = body as Record<string, unknown>;
+  return {
+    campaignId: readOptionalId(record, 'campaignId'),
+    contractId: readOptionalId(record, 'contractId'),
+    scenarioId: readOptionalId(record, 'scenarioId'),
+  };
+}
 
 // =============================================================================
 // Handler
@@ -56,7 +83,10 @@ export default async function handler(
   const encounterService = getEncounterService();
 
   try {
-    const result = encounterService.launchEncounter(id);
+    const result = encounterService.launchEncounter(
+      id,
+      parseLaunchOptions(req.body),
+    );
 
     if (result.success) {
       const encounter = encounterService.getEncounter(id);

--- a/src/services/encounter/EncounterService.ts
+++ b/src/services/encounter/EncounterService.ts
@@ -52,8 +52,36 @@ import {
  * id only" passes naturally.
  */
 export interface ILaunchEncounterOptions {
+  readonly campaignId?: string | null;
   readonly contractId?: string | null;
   readonly scenarioId?: string | null;
+}
+
+function hasLaunchId(value: string | null | undefined): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function normalizeLaunchId(value: string | null | undefined): string | null {
+  return hasLaunchId(value) ? value : null;
+}
+
+function validateContractLaunchLinkage(
+  options: ILaunchEncounterOptions,
+): string | null {
+  if (options.contractId === undefined || options.contractId === null) {
+    return null;
+  }
+
+  const missing: string[] = [];
+  if (!hasLaunchId(options.campaignId)) missing.push('campaignId');
+  if (!hasLaunchId(options.contractId)) missing.push('contractId');
+  if (!hasLaunchId(options.scenarioId)) missing.push('scenarioId');
+
+  if (missing.length === 0) {
+    return null;
+  }
+
+  return `Cannot launch contract encounter without ${missing.join(', ')}`;
 }
 
 // =============================================================================
@@ -295,6 +323,14 @@ export class EncounterService implements IEncounterService {
       };
     }
 
+    const linkageError = validateContractLaunchLinkage(options);
+    if (linkageError) {
+      return {
+        success: false,
+        error: linkageError,
+      };
+    }
+
     // Build the game config and units from the encounter. Force/pilot
     // resolvers are injected so this helper stays trivially testable.
     const forceRepo = getForceRepository();
@@ -317,14 +353,14 @@ export class EncounterService implements IEncounterService {
     // play state from the encounter + forces, using this id as the handle.
     //
     // Per `wire-encounter-to-campaign-round-trip` Wave 5: thread campaign
-    // linkage (contractId, scenarioId) into the config so the eventual
-    // `ICombatOutcome` is self-describing. The encounter id is always
-    // stamped — see `buildGameConfigFromEncounter`. When `contractId` is
-    // present we also assert "fail-fast" by surfacing it on the result so
-    // tests can confirm linkage propagated end-to-end.
+    // linkage (campaignId, contractId, scenarioId) into the config so the
+    // eventual `ICombatOutcome` is self-describing. The encounter id is always
+    // stamped by `buildGameConfigFromEncounter`. Contract-bound launches
+    // were validated above so incomplete linkage cannot produce a session.
     const config = buildGameConfigFromEncounter(encounter, {
-      contractId: options.contractId ?? null,
-      scenarioId: options.scenarioId ?? null,
+      campaignId: normalizeLaunchId(options.campaignId),
+      contractId: normalizeLaunchId(options.contractId),
+      scenarioId: normalizeLaunchId(options.scenarioId),
     });
     const session = createGameSession(config, units);
     return this.repository.linkGameSession(id, session.id);

--- a/src/services/encounter/__tests__/EncounterService.test.ts
+++ b/src/services/encounter/__tests__/EncounterService.test.ts
@@ -20,6 +20,7 @@ import {
   SCENARIO_TEMPLATES,
 } from '@/types/encounter';
 import { IForce, ForceType, ForcePosition, ForceStatus } from '@/types/force';
+import { createGameSession } from '@/utils/gameplay/gameSessionCore';
 
 import { IEncounterOperationResult } from '../EncounterRepository';
 
@@ -30,6 +31,7 @@ import { IEncounterOperationResult } from '../EncounterRepository';
 const mockEncounters = new Map<string, IEncounter>();
 const mockForces = new Map<string, IForce>();
 let mockIdCounter = 0;
+let mockSessionIdCounter = 0;
 
 // Default map configuration for testing
 const DEFAULT_MAP_CONFIG: IMapConfiguration = {
@@ -57,6 +59,25 @@ jest.mock('../../forces/ForceRepository', () => ({
 jest.mock('../../pilots/PilotService', () => ({
   getPilotService: () => ({
     getPilot: () => null,
+  }),
+}));
+
+// =============================================================================
+// Mock Game Session Factory
+// =============================================================================
+
+jest.mock('@/utils/gameplay/gameSessionCore', () => ({
+  createGameSession: jest.fn((config, units) => {
+    mockSessionIdCounter += 1;
+    return {
+      id: `game-session-${mockSessionIdCounter}`,
+      createdAt: '2026-04-17T00:00:00.000Z',
+      updatedAt: '2026-04-17T00:00:00.000Z',
+      config,
+      units,
+      events: [],
+      currentState: {},
+    };
   }),
 }));
 
@@ -264,6 +285,8 @@ function clearMocks(): void {
   mockEncounters.clear();
   mockForces.clear();
   mockIdCounter = 0;
+  mockSessionIdCounter = 0;
+  jest.mocked(createGameSession).mockClear();
 }
 
 // =============================================================================
@@ -705,6 +728,51 @@ describe('EncounterService', () => {
       const encounter = service.getEncounter(createResult.id!);
       expect(encounter?.status).toBe(EncounterStatus.Launched);
       expect(encounter?.gameSessionId).toBeDefined();
+    });
+
+    it('should thread campaign linkage into the launched session config', () => {
+      const playerForce = createMockForce('force-p', 'Player');
+      const opponentForce = createMockForce('force-o', 'Opponent');
+      const createResult = service.createEncounter({
+        name: 'Campaign Launch',
+        template: ScenarioTemplateType.Skirmish,
+      });
+      service.setPlayerForce(createResult.id!, playerForce.id);
+      service.setOpponentForce(createResult.id!, opponentForce.id);
+
+      const launchResult = service.launchEncounter(createResult.id!, {
+        campaignId: 'campaign-1',
+        contractId: 'contract-1',
+        scenarioId: 'scenario-1',
+      });
+
+      expect(launchResult.success).toBe(true);
+      expect(createGameSession).toHaveBeenCalledTimes(1);
+      const [config] = jest.mocked(createGameSession).mock.calls[0];
+      expect(config.encounterId).toBe(createResult.id);
+      expect(config.campaignId).toBe('campaign-1');
+      expect(config.contractId).toBe('contract-1');
+      expect(config.scenarioId).toBe('scenario-1');
+    });
+
+    it('should fail before session creation when contract linkage is incomplete', () => {
+      const playerForce = createMockForce('force-p', 'Player');
+      const opponentForce = createMockForce('force-o', 'Opponent');
+      const createResult = service.createEncounter({
+        name: 'Broken Campaign Launch',
+        template: ScenarioTemplateType.Skirmish,
+      });
+      service.setPlayerForce(createResult.id!, playerForce.id);
+      service.setOpponentForce(createResult.id!, opponentForce.id);
+
+      const result = service.launchEncounter(createResult.id!, {
+        contractId: 'contract-1',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('campaignId');
+      expect(result.error).toContain('scenarioId');
+      expect(createGameSession).not.toHaveBeenCalled();
     });
 
     it('should reject launching non-existent encounter', () => {

--- a/src/services/encounter/__tests__/encounterToGameSession.test.ts
+++ b/src/services/encounter/__tests__/encounterToGameSession.test.ts
@@ -147,6 +147,30 @@ describe('buildGameConfigFromEncounter', () => {
       'double_blind',
     ]);
   });
+
+  it('stamps standalone encounter linkage with null campaign fields', () => {
+    const encounter = makeEncounter({ id: 'enc-standalone' });
+    const config = buildGameConfigFromEncounter(encounter);
+
+    expect(config.encounterId).toBe('enc-standalone');
+    expect(config.campaignId).toBeNull();
+    expect(config.contractId).toBeNull();
+    expect(config.scenarioId).toBeNull();
+  });
+
+  it('threads campaign, contract, and scenario linkage into the config', () => {
+    const encounter = makeEncounter({ id: 'enc-contract' });
+    const config = buildGameConfigFromEncounter(encounter, {
+      campaignId: 'campaign-1',
+      contractId: 'contract-1',
+      scenarioId: 'scenario-1',
+    });
+
+    expect(config.encounterId).toBe('enc-contract');
+    expect(config.campaignId).toBe('campaign-1');
+    expect(config.contractId).toBe('contract-1');
+    expect(config.scenarioId).toBe('scenario-1');
+  });
 });
 
 describe('buildGameUnitsFromEncounter', () => {

--- a/src/services/encounter/encounterToGameSession.ts
+++ b/src/services/encounter/encounterToGameSession.ts
@@ -66,6 +66,7 @@ function deriveTurnLimit(conditions: readonly IVictoryCondition[]): number {
  * uses to route the post-battle pipeline.
  */
 export interface IEncounterLinkage {
+  readonly campaignId?: string | null;
   readonly contractId?: string | null;
   readonly scenarioId?: string | null;
 }
@@ -91,6 +92,7 @@ export function buildGameConfigFromEncounter(
     ),
     optionalRules: [...encounter.optionalRules],
     encounterId: encounter.id,
+    campaignId: linkage.campaignId ?? null,
     contractId: linkage.contractId ?? null,
     scenarioId: linkage.scenarioId ?? null,
   };

--- a/src/services/units/handlers/InfantryUnitHandler.ts
+++ b/src/services/units/handlers/InfantryUnitHandler.ts
@@ -21,7 +21,10 @@ import {
 } from '@/types/unit/PersonnelInterfaces';
 import { ISerializedUnit } from '@/types/unit/UnitSerialization';
 import { IUnitParseResult } from '@/types/unit/UnitTypeHandler';
-import { calculateInfantryBVFromUnit } from '@/utils/construction/infantry';
+import {
+  calculateInfantryBVFromUnit,
+  calculatePersonnelArmorKitMassTons,
+} from '@/utils/construction/infantry';
 
 import {
   AbstractUnitTypeHandler,
@@ -378,14 +381,12 @@ export class InfantryUnitHandler extends AbstractUnitTypeHandler<IInfantry> {
   protected calculateTypeSpecificWeight(unit: IInfantry): number {
     // Average soldier: 80kg with gear
     const soldierWeight = 0.08; // tons
-    let weight = unit.platoonStrength * soldierWeight;
+    const armorKitWeight = calculatePersonnelArmorKitMassTons(
+      unit.armorKit,
+      unit.platoonStrength,
+    );
 
-    // Add field gun weight
-    for (const _gun of unit.fieldGuns) {
-      weight += 0.5; // Assume 0.5 tons per field gun
-    }
-
-    return weight;
+    return unit.platoonStrength * soldierWeight + armorKitWeight;
   }
 
   /**

--- a/src/services/units/handlers/__tests__/InfantryUnitHandler.test.ts
+++ b/src/services/units/handlers/__tests__/InfantryUnitHandler.test.ts
@@ -906,14 +906,28 @@ describe('InfantryUnitHandler', () => {
         expect(weight).toBeCloseTo(2.24, 2);
       });
 
-      it('should add field gun weight', () => {
+      it('should not add field gun tonnage to construction weight', () => {
         const doc = createFieldGunInfantryDocument();
         const result = handler.parse(doc);
         expect(result.success).toBe(true);
+        const unit = result.data?.unit;
+        if (!unit) throw new Error('Expected parsed infantry unit');
 
-        const weight = handler.calculateWeight(result.data!.unit);
-        // 16 soldiers * 0.08 + 2 field guns * 0.5 = 1.28 + 1.0 = 2.28 tons
-        expect(weight).toBeCloseTo(2.28, 2);
+        const weight = handler.calculateWeight(unit);
+        // 16 soldiers * 0.08; field guns are deployed weapons.
+        expect(weight).toBeCloseTo(1.28, 2);
+      });
+
+      it('should add armor kit mass per trooper', () => {
+        const doc = createMockBlkDocument({ armorKit: 'Flak' });
+        const result = handler.parse(doc);
+        expect(result.success).toBe(true);
+        const unit = result.data?.unit;
+        if (!unit) throw new Error('Expected parsed infantry unit');
+
+        const weight = handler.calculateWeight(unit);
+        // 28 soldiers * 0.08 + 28 flak kits * 0.012
+        expect(weight).toBeCloseTo(2.576, 3);
       });
 
       it('should return positive weight', () => {

--- a/src/stores/__tests__/useAnimationQueue.test.ts
+++ b/src/stores/__tests__/useAnimationQueue.test.ts
@@ -1,0 +1,103 @@
+import type { IHexCoordinate } from '@/types/gameplay';
+
+import { useAnimationQueue } from '@/stores/useAnimationQueue';
+
+function movement(
+  id: string,
+  unitId: string,
+  path: readonly IHexCoordinate[],
+  mapId = 'map-1',
+) {
+  return {
+    id,
+    mapId,
+    unitId,
+    kind: 'movement' as const,
+    path,
+  };
+}
+
+describe('useAnimationQueue', () => {
+  beforeEach(() => {
+    useAnimationQueue.getState().reset();
+  });
+
+  afterEach(() => {
+    useAnimationQueue.getState().reset();
+  });
+
+  it('runs conflicting same-map animations in FIFO order', () => {
+    useAnimationQueue
+      .getState()
+      .enqueue(movement('move-a', 'unit-a', [{ q: 0, r: 0 }]));
+    useAnimationQueue
+      .getState()
+      .enqueue(movement('move-b', 'unit-b', [{ q: 0, r: 0 }]));
+
+    expect(useAnimationQueue.getState().active.map((item) => item.id)).toEqual([
+      'move-a',
+    ]);
+    expect(useAnimationQueue.getState().queue.map((item) => item.id)).toEqual([
+      'move-b',
+    ]);
+    expect(useAnimationQueue.getState().isActive).toBe(true);
+
+    useAnimationQueue.getState().complete('move-a');
+
+    expect(useAnimationQueue.getState().active.map((item) => item.id)).toEqual([
+      'move-b',
+    ]);
+    expect(useAnimationQueue.getState().queue).toHaveLength(0);
+  });
+
+  it('allows concurrent per-unit animations when paths do not overlap', () => {
+    useAnimationQueue
+      .getState()
+      .enqueue(movement('move-a', 'unit-a', [{ q: 0, r: 0 }]));
+    useAnimationQueue
+      .getState()
+      .enqueue(movement('move-b', 'unit-b', [{ q: 4, r: -2 }]));
+
+    expect(useAnimationQueue.getState().active.map((item) => item.id)).toEqual([
+      'move-a',
+      'move-b',
+    ]);
+    expect(useAnimationQueue.getState().queue).toHaveLength(0);
+  });
+
+  it('does not run two animations for the same unit concurrently', () => {
+    useAnimationQueue
+      .getState()
+      .enqueue(movement('move-a', 'unit-a', [{ q: 0, r: 0 }]));
+    useAnimationQueue
+      .getState()
+      .enqueue(movement('move-b', 'unit-a', [{ q: 4, r: -2 }]));
+
+    expect(useAnimationQueue.getState().active.map((item) => item.id)).toEqual([
+      'move-a',
+    ]);
+    expect(useAnimationQueue.getState().queue.map((item) => item.id)).toEqual([
+      'move-b',
+    ]);
+  });
+
+  it('fires per-animation and subscribed completion callbacks', () => {
+    const animationComplete = jest.fn();
+    const storeComplete = jest.fn();
+    const unsubscribe = useAnimationQueue.getState().onComplete(storeComplete);
+
+    useAnimationQueue.getState().enqueue({
+      ...movement('move-a', 'unit-a', [{ q: 0, r: 0 }]),
+      onComplete: animationComplete,
+    });
+    useAnimationQueue.getState().complete('move-a');
+    unsubscribe();
+
+    expect(animationComplete).toHaveBeenCalledTimes(1);
+    expect(storeComplete).toHaveBeenCalledTimes(1);
+    expect(storeComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'move-a' }),
+    );
+    expect(useAnimationQueue.getState().isActive).toBe(false);
+  });
+});

--- a/src/stores/__tests__/useGameplayStore.animationGate.test.ts
+++ b/src/stores/__tests__/useGameplayStore.animationGate.test.ts
@@ -1,0 +1,116 @@
+import type { InteractiveSession } from '@/engine/GameEngine';
+
+import { useAnimationQueue } from '@/stores/useAnimationQueue';
+import { useGameplayStore } from '@/stores/useGameplayStore';
+import {
+  GamePhase,
+  GameSide,
+  GameStatus,
+  Facing,
+  LockState,
+  MovementType,
+  type IGameSession,
+} from '@/types/gameplay';
+
+function buildInteractiveSession(): {
+  readonly calls: { advancePhase: number };
+  readonly interactiveSession: InteractiveSession;
+  readonly session: IGameSession;
+} {
+  const calls = { advancePhase: 0 };
+  const session: IGameSession = {
+    id: 'game-1',
+    createdAt: '',
+    updatedAt: '',
+    config: {
+      mapRadius: 5,
+      turnLimit: 0,
+      victoryConditions: [],
+      optionalRules: [],
+    },
+    units: [
+      {
+        id: 'unit-a',
+        name: 'Unit A',
+        side: GameSide.Player,
+        unitRef: 'unit-a',
+        pilotRef: 'pilot-a',
+        gunnery: 4,
+        piloting: 5,
+      },
+    ],
+    events: [],
+    currentState: {
+      gameId: 'game-1',
+      status: GameStatus.Active,
+      turn: 1,
+      phase: GamePhase.Movement,
+      activationIndex: 0,
+      units: {
+        'unit-a': {
+          id: 'unit-a',
+          side: GameSide.Player,
+          position: { q: 0, r: 0 },
+          facing: Facing.North,
+          heat: 0,
+          movementThisTurn: MovementType.Stationary,
+          hexesMovedThisTurn: 0,
+          armor: {},
+          structure: {},
+          destroyedLocations: [],
+          destroyedEquipment: [],
+          ammo: {},
+          pilotWounds: 0,
+          pilotConscious: true,
+          destroyed: false,
+          lockState: LockState.Planning,
+        },
+      },
+      turnEvents: [],
+    },
+  };
+  const interactiveSession = {
+    advancePhase: () => {
+      calls.advancePhase += 1;
+    },
+    getSession: () => session,
+    getState: () => session.currentState,
+    isGameOver: () => false,
+  } as unknown as InteractiveSession;
+
+  return { calls, interactiveSession, session };
+}
+
+describe('useGameplayStore animation gate', () => {
+  beforeEach(() => {
+    useGameplayStore.getState().reset();
+    useAnimationQueue.getState().reset();
+  });
+
+  afterEach(() => {
+    useGameplayStore.getState().reset();
+    useAnimationQueue.getState().reset();
+  });
+
+  it('defers phase advancement until the animation queue drains', () => {
+    const { calls, interactiveSession, session } = buildInteractiveSession();
+    useGameplayStore.setState({ interactiveSession, session });
+    useAnimationQueue.getState().enqueue({
+      id: 'move-a',
+      mapId: 'map-1',
+      unitId: 'unit-a',
+      path: [
+        { q: 0, r: 0 },
+        { q: 1, r: 0 },
+      ],
+    });
+
+    useGameplayStore.getState().advanceInteractivePhase();
+
+    expect(calls.advancePhase).toBe(0);
+
+    useAnimationQueue.getState().complete('move-a');
+
+    expect(calls.advancePhase).toBe(1);
+  });
+});

--- a/src/stores/__tests__/useGameplayStore.combatFlows.test.ts
+++ b/src/stores/__tests__/useGameplayStore.combatFlows.test.ts
@@ -35,6 +35,7 @@ interface FakeSessionCalls {
     to: { q: number; r: number };
     facing: Facing;
     type: MovementType;
+    path?: readonly { q: number; r: number }[];
   }>;
   attacks: Array<{
     attackerId: string;
@@ -84,8 +85,15 @@ function buildFakeSession(): {
       to: { q: number; r: number },
       facing: Facing,
       type: MovementType,
+      path?: readonly { q: number; r: number }[],
     ) => {
-      calls.movement.push({ unitId, to, facing, type });
+      calls.movement.push({
+        unitId,
+        to,
+        facing,
+        type,
+        ...(path !== undefined ? { path } : {}),
+      });
     },
     applyAttack: (
       attackerId: string,
@@ -179,6 +187,10 @@ describe('useGameplayStore — combat-phase planning actions', () => {
         to: { q: 3, r: -1 },
         facing: Facing.Southeast,
         type: MovementType.Run,
+        path: [
+          { q: 0, r: 0 },
+          { q: 3, r: -1 },
+        ],
       });
       expect(useGameplayStore.getState().plannedMovement).toBeNull();
       expect(useGameplayStore.getState().ui.selectedUnitId).toBeNull();

--- a/src/stores/campaign/__tests__/useCampaignStore.outcomes.test.ts
+++ b/src/stores/campaign/__tests__/useCampaignStore.outcomes.test.ts
@@ -1,0 +1,124 @@
+import { getEventStore, resetEventStore } from '@/services/events';
+import { createCampaignStore } from '@/stores/campaign/useCampaignStore';
+import {
+  COMBAT_OUTCOME_VERSION,
+  CombatEndReason,
+  type ICombatOutcome,
+} from '@/types/combat/CombatOutcome';
+import { EventCategory } from '@/types/events';
+import { GameSide } from '@/types/gameplay/GameSessionInterfaces';
+import {
+  CampaignOutcomeEventTypes,
+  type IPendingOutcomeAddedPayload,
+} from '@/utils/events/campaignOutcomeEvents';
+import { resetSequence } from '@/utils/events/eventFactory';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+Object.defineProperty(global, 'localStorage', {
+  value: localStorageMock,
+});
+
+function makeOutcome(
+  matchId: string,
+  overrides: Partial<ICombatOutcome> = {},
+): ICombatOutcome {
+  return {
+    version: COMBAT_OUTCOME_VERSION,
+    matchId,
+    contractId: 'contract-1',
+    scenarioId: 'scenario-1',
+    endReason: CombatEndReason.ObjectiveMet,
+    capturedAt: '2026-04-25T00:00:00.000Z',
+    report: {
+      version: 1,
+      matchId,
+      winner: GameSide.Player,
+      reason: 'objective',
+      turnCount: 1,
+      units: [],
+      mvpUnitId: null,
+      log: [],
+    },
+    unitDeltas: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  localStorageMock.clear();
+  resetEventStore();
+  resetSequence(0);
+});
+
+describe('useCampaignStore outcome queue persistence/events', () => {
+  it('persists pending battle outcomes with the campaign record', () => {
+    const store = createCampaignStore();
+    const campaignId = store
+      .getState()
+      .createCampaign('Outcome Queue Co.', 'mercenary');
+
+    store.getState().enqueueOutcome(makeOutcome('match-persist'));
+
+    const stored = localStorageMock.getItem(`campaign-${campaignId}`);
+    expect(stored).toBeTruthy();
+    const parsed = JSON.parse(stored!) as {
+      state: { pendingBattleOutcomes: ICombatOutcome[] };
+    };
+    expect(parsed.state.pendingBattleOutcomes).toHaveLength(1);
+    expect(parsed.state.pendingBattleOutcomes[0].matchId).toBe('match-persist');
+
+    const hydrated = createCampaignStore();
+    expect(hydrated.getState().loadCampaign(campaignId)).toBe(true);
+    expect(hydrated.getState().getPendingOutcomes()[0].matchId).toBe(
+      'match-persist',
+    );
+  });
+
+  it('emits one PendingOutcomeAdded campaign event for a newly queued outcome', () => {
+    const store = createCampaignStore();
+    const campaignId = store
+      .getState()
+      .createCampaign('Outcome Event Co.', 'mercenary');
+    const outcome = makeOutcome('match-event');
+
+    store.getState().enqueueOutcome(outcome);
+    store.getState().enqueueOutcome(outcome);
+
+    const events = getEventStore().query({
+      filters: {
+        category: EventCategory.Campaign,
+        types: [CampaignOutcomeEventTypes.PendingOutcomeAdded],
+      },
+    }).events;
+
+    expect(events).toHaveLength(1);
+    expect(events[0].context.campaignId).toBe(campaignId);
+    expect(events[0].context.missionId).toBe('contract-1');
+    expect(events[0].context.gameId).toBe('match-event');
+    const payload = events[0].payload as IPendingOutcomeAddedPayload;
+    expect(payload.matchId).toBe('match-event');
+    expect(payload.contractId).toBe('contract-1');
+    expect(payload.scenarioId).toBe('scenario-1');
+    expect(payload.queueLength).toBe(1);
+  });
+});

--- a/src/stores/campaign/useCampaignStore.ts
+++ b/src/stores/campaign/useCampaignStore.ts
@@ -43,6 +43,7 @@ import { IForce } from '@/types/campaign/Force';
 import { Money } from '@/types/campaign/Money';
 import { IPerson } from '@/types/campaign/Person';
 import { Transaction } from '@/types/campaign/Transaction';
+import { emitPendingOutcomeAdded } from '@/utils/events/campaignOutcomeEvents';
 
 import { createForcesStore, ForcesStore } from './useForcesStore';
 import { createMissionsStore, MissionsStore } from './useMissionsStore';
@@ -79,6 +80,9 @@ interface SerializedCampaignState {
   campaignStartDate?: string;
   description?: string;
   iconUrl?: string;
+  pendingBattleOutcomes?: ICombatOutcome[];
+  processedBattleIds?: string[];
+  reviewedBattleIds?: Record<string, number>;
   createdAt: string;
   updatedAt: string;
 }
@@ -252,7 +256,12 @@ function withBattleQueueAttached(
 /**
  * Serialize campaign state for persistence.
  */
-function serializeCampaign(campaign: ICampaign): SerializedCampaignState {
+function serializeCampaign(
+  campaign: ICampaign,
+  pendingBattleOutcomes: readonly ICombatOutcome[] = [],
+  processedBattleIds: readonly string[] = [],
+  reviewedBattleIds: Record<string, number> = {},
+): SerializedCampaignState {
   return {
     id: campaign.id,
     name: campaign.name,
@@ -275,6 +284,9 @@ function serializeCampaign(campaign: ICampaign): SerializedCampaignState {
     campaignStartDate: campaign.campaignStartDate?.toISOString(),
     description: campaign.description,
     iconUrl: campaign.iconUrl,
+    pendingBattleOutcomes: [...pendingBattleOutcomes],
+    processedBattleIds: [...processedBattleIds],
+    reviewedBattleIds: { ...reviewedBattleIds },
     createdAt: campaign.createdAt,
     updatedAt: campaign.updatedAt,
   };
@@ -323,6 +335,44 @@ function deserializeCampaign(
     createdAt: serialized.createdAt,
     updatedAt: serialized.updatedAt,
   };
+}
+
+function persistCampaignRecord(
+  campaign: ICampaign,
+  pendingBattleOutcomes: readonly ICombatOutcome[],
+  processedBattleIds: readonly string[],
+  reviewedBattleIds: Record<string, number>,
+): void {
+  const serialized = serializeCampaign(
+    campaign,
+    pendingBattleOutcomes,
+    processedBattleIds,
+    reviewedBattleIds,
+  );
+  clientSafeStorage.setItem(
+    `campaign-${campaign.id}`,
+    JSON.stringify({ state: serialized }),
+  );
+}
+
+function emitPendingOutcomeAddedEvent(
+  campaign: ICampaign | null,
+  outcome: ICombatOutcome,
+  queueLength: number,
+): void {
+  if (!campaign) return;
+
+  try {
+    emitPendingOutcomeAdded({
+      campaignId: campaign.id,
+      matchId: outcome.matchId,
+      contractId: outcome.contractId,
+      scenarioId: outcome.scenarioId,
+      queueLength,
+    });
+  } catch {
+    // Outcome queue persistence must not depend on the optional event sink.
+  }
 }
 
 // =============================================================================
@@ -454,6 +504,9 @@ export function createCampaignStore(): StoreApi<CampaignStore> {
 
             set({
               campaign,
+              pendingBattleOutcomes: serialized.pendingBattleOutcomes ?? [],
+              processedBattleIds: serialized.processedBattleIds ?? [],
+              reviewedBattleIds: serialized.reviewedBattleIds ?? {},
               personnelStore,
               forcesStore,
               missionsStore,
@@ -466,8 +519,15 @@ export function createCampaignStore(): StoreApi<CampaignStore> {
         },
 
         saveCampaign: () => {
-          const { campaign, personnelStore, forcesStore, missionsStore } =
-            get();
+          const {
+            campaign,
+            pendingBattleOutcomes,
+            processedBattleIds,
+            reviewedBattleIds,
+            personnelStore,
+            forcesStore,
+            missionsStore,
+          } = get();
 
           if (!campaign) {
             return;
@@ -512,12 +572,11 @@ export function createCampaignStore(): StoreApi<CampaignStore> {
 
           set({ campaign: updatedCampaign });
 
-          // Serialize and save to storage
-          const serialized = serializeCampaign(updatedCampaign);
-          const storageKey = `campaign-${campaign.id}`;
-          clientSafeStorage.setItem(
-            storageKey,
-            JSON.stringify({ state: serialized }),
+          persistCampaignRecord(
+            updatedCampaign,
+            pendingBattleOutcomes,
+            processedBattleIds,
+            reviewedBattleIds,
           );
         },
 
@@ -638,7 +697,12 @@ export function createCampaignStore(): StoreApi<CampaignStore> {
         getMissionsStore: () => get().missionsStore,
 
         enqueueOutcome: (outcome) => {
-          const { pendingBattleOutcomes, processedBattleIds } = get();
+          const {
+            campaign,
+            pendingBattleOutcomes,
+            processedBattleIds,
+            reviewedBattleIds,
+          } = get();
           // Per spec scenario "Duplicate outcome ignored": both the
           // pending queue AND the processed ledger gate enqueueing —
           // once a match has been applied to the campaign, replaying its
@@ -652,18 +716,41 @@ export function createCampaignStore(): StoreApi<CampaignStore> {
           if (processedBattleIds.includes(outcome.matchId)) {
             return;
           }
+          const nextPending = [...pendingBattleOutcomes, outcome];
           set({
-            pendingBattleOutcomes: [...pendingBattleOutcomes, outcome],
+            pendingBattleOutcomes: nextPending,
           });
+          if (campaign) {
+            persistCampaignRecord(
+              campaign,
+              nextPending,
+              processedBattleIds,
+              reviewedBattleIds,
+            );
+          }
+          emitPendingOutcomeAddedEvent(campaign, outcome, nextPending.length);
         },
 
         dequeueOutcome: (matchId) => {
-          const { pendingBattleOutcomes } = get();
+          const {
+            campaign,
+            pendingBattleOutcomes,
+            processedBattleIds,
+            reviewedBattleIds,
+          } = get();
           const next = pendingBattleOutcomes.filter(
             (o) => o.matchId !== matchId,
           );
           if (next.length === pendingBattleOutcomes.length) return false;
           set({ pendingBattleOutcomes: next });
+          if (campaign) {
+            persistCampaignRecord(
+              campaign,
+              next,
+              processedBattleIds,
+              reviewedBattleIds,
+            );
+          }
           return true;
         },
 
@@ -677,16 +764,26 @@ export function createCampaignStore(): StoreApi<CampaignStore> {
 
         markBattleReviewed: (matchId) => {
           if (!matchId) return;
-          const { pendingBattleOutcomes, reviewedBattleIds } = get();
+          const { campaign, pendingBattleOutcomes, processedBattleIds } = get();
+          const reviewedBattleIds = {
+            ...get().reviewedBattleIds,
+            [matchId]: Date.now(),
+          };
+          const nextPending = pendingBattleOutcomes.filter(
+            (o) => o.matchId !== matchId,
+          );
           set({
-            reviewedBattleIds: {
-              ...reviewedBattleIds,
-              [matchId]: Date.now(),
-            },
-            pendingBattleOutcomes: pendingBattleOutcomes.filter(
-              (o) => o.matchId !== matchId,
-            ),
+            reviewedBattleIds,
+            pendingBattleOutcomes: nextPending,
           });
+          if (campaign) {
+            persistCampaignRecord(
+              campaign,
+              nextPending,
+              processedBattleIds,
+              reviewedBattleIds,
+            );
+          }
         },
 
         getReviewedAt: (matchId) => {
@@ -703,7 +800,12 @@ export function createCampaignStore(): StoreApi<CampaignStore> {
             return { campaign: null };
           }
           return {
-            campaign: serializeCampaign(state.campaign),
+            campaign: serializeCampaign(
+              state.campaign,
+              state.pendingBattleOutcomes,
+              state.processedBattleIds,
+              state.reviewedBattleIds,
+            ),
           };
         },
         // Merge persisted state
@@ -735,6 +837,9 @@ export function createCampaignStore(): StoreApi<CampaignStore> {
           return {
             ...current,
             campaign,
+            pendingBattleOutcomes: serialized.pendingBattleOutcomes ?? [],
+            processedBattleIds: serialized.processedBattleIds ?? [],
+            reviewedBattleIds: serialized.reviewedBattleIds ?? {},
             personnelStore: null,
             forcesStore: null,
             missionsStore: null,

--- a/src/stores/infantryState.ts
+++ b/src/stores/infantryState.ts
@@ -25,6 +25,11 @@ import {
   InfantryArmorKit,
   InfantrySpecialization,
 } from '@/types/unit/PersonnelInterfaces';
+import {
+  calculatePersonnelArmorKitMassTons,
+  normalizeInfantryFieldGun,
+  squadMotionTypeForMotive,
+} from '@/utils/construction/infantry';
 import { computeInfantryBVFromState } from '@/utils/construction/infantry/infantryBVAdapter';
 import { generateUnitId as generateUUID } from '@/utils/uuid';
 
@@ -274,6 +279,8 @@ export interface CreateInfantryOptions {
   model?: string;
   techBase?: TechBase;
   motionType?: SquadMotionType;
+  infantryMotive?: InfantryMotive;
+  platoonComposition?: IPlatoonComposition;
   squadSize?: number;
   numberOfSquads?: number;
 }
@@ -288,6 +295,11 @@ export function createDefaultInfantryState(
   const id = options.id ?? generateUUID();
   const chassis = options.chassis ?? 'Rifle Platoon';
   const model = options.model ?? '';
+  const infantryMotive = options.infantryMotive ?? InfantryMotive.FOOT;
+  const platoonComposition =
+    options.platoonComposition ?? PLATOON_DEFAULTS[infantryMotive];
+  const squadSize = options.squadSize ?? platoonComposition.troopersPerSquad;
+  const numberOfSquads = options.numberOfSquads ?? platoonComposition.squads;
 
   return {
     // Identity
@@ -304,13 +316,13 @@ export function createDefaultInfantryState(
     unitType: UnitType.INFANTRY,
 
     // Platoon Configuration
-    squadSize: options.squadSize ?? 7,
-    numberOfSquads: options.numberOfSquads ?? 4,
-    motionType: options.motionType ?? SquadMotionType.FOOT,
-    infantryMotive: InfantryMotive.FOOT,
-    platoonComposition: PLATOON_DEFAULTS[InfantryMotive.FOOT],
-    groundMP: MOTIVE_MP[InfantryMotive.FOOT].groundMP,
-    jumpMP: MOTIVE_MP[InfantryMotive.FOOT].jumpMP,
+    squadSize,
+    numberOfSquads,
+    motionType: options.motionType ?? squadMotionTypeForMotive(infantryMotive),
+    infantryMotive,
+    platoonComposition,
+    groundMP: MOTIVE_MP[infantryMotive].groundMP,
+    jumpMP: MOTIVE_MP[infantryMotive].jumpMP,
 
     // Weapons
     primaryWeapon: 'Rifle',
@@ -340,10 +352,47 @@ export function createDefaultInfantryState(
 }
 
 /**
+ * Normalize newly hydrated or externally provided infantry state.
+ *
+ * Keeps legacy squad fields synchronized with the construction composition
+ * and fills field-gun spec aliases introduced by add-infantry-construction.
+ */
+export function normalizeInfantryState(state: InfantryState): InfantryState {
+  const platoonComposition = state.platoonComposition ?? {
+    squads: state.numberOfSquads,
+    troopersPerSquad: state.squadSize,
+  };
+
+  return {
+    ...state,
+    platoonComposition,
+    squadSize: platoonComposition.troopersPerSquad,
+    numberOfSquads: platoonComposition.squads,
+    groundMP: state.groundMP ?? MOTIVE_MP[state.infantryMotive].groundMP,
+    jumpMP: state.jumpMP ?? MOTIVE_MP[state.infantryMotive].jumpMP,
+    fieldGuns: state.fieldGuns.map(normalizeInfantryFieldGun),
+  };
+}
+
+/**
  * Calculate platoon strength (total soldiers)
  */
 export function calculatePlatoonStrength(state: InfantryState): number {
   return state.squadSize * state.numberOfSquads;
+}
+
+/**
+ * Transport weight for the platoon, including per-trooper armor kit mass.
+ * Field-gun tonnage is intentionally excluded; field guns are deployed
+ * equipment and do not consume unit construction tonnage.
+ */
+export function calculateInfantryTransportWeight(state: InfantryState): number {
+  const troopers = calculatePlatoonStrength(state);
+  const soldierWeightTons = 0.08;
+  return (
+    troopers * soldierWeightTons +
+    calculatePersonnelArmorKitMassTons(state.armorKit, troopers)
+  );
 }
 
 /**

--- a/src/stores/infantryStoreRegistry.ts
+++ b/src/stores/infantryStoreRegistry.ts
@@ -167,6 +167,8 @@ export function duplicateInfantry(
     name: newName ?? `${sourceState.name} (Copy)`,
     techBase: sourceState.techBase,
     motionType: sourceState.motionType,
+    infantryMotive: sourceState.infantryMotive,
+    platoonComposition: sourceState.platoonComposition,
     squadSize: sourceState.squadSize,
     numberOfSquads: sourceState.numberOfSquads,
   });
@@ -183,6 +185,10 @@ export function duplicateInfantry(
     specialization: sourceState.specialization,
     hasAntiMechTraining: sourceState.hasAntiMechTraining,
     isAugmented: sourceState.isAugmented,
+    augmentationType: sourceState.augmentationType,
+    fieldGuns: sourceState.fieldGuns,
+    groundMP: sourceState.groundMP,
+    jumpMP: sourceState.jumpMP,
   };
 
   const store = createInfantryStore(mergedState);

--- a/src/stores/useAnimationQueue.ts
+++ b/src/stores/useAnimationQueue.ts
@@ -1,0 +1,182 @@
+import { create } from 'zustand';
+
+import type { IHexCoordinate } from '@/types/gameplay';
+
+export type TacticalAnimationKind = 'movement' | 'effect';
+
+export interface TacticalAnimation {
+  readonly id: string;
+  readonly mapId: string;
+  readonly unitId?: string;
+  readonly kind?: TacticalAnimationKind;
+  readonly path?: readonly IHexCoordinate[];
+  readonly occupiedHexes?: readonly IHexCoordinate[];
+  readonly onComplete?: () => void;
+}
+
+export type AnimationCompleteCallback = (animation: TacticalAnimation) => void;
+
+interface AnimationQueueState {
+  readonly queue: readonly TacticalAnimation[];
+  readonly active: readonly TacticalAnimation[];
+  readonly isActive: boolean;
+  enqueue: (animation: TacticalAnimation) => string;
+  complete: (animationId: string) => void;
+  onComplete: (callback: AnimationCompleteCallback) => () => void;
+  reset: () => void;
+}
+
+const completeListeners = new Set<AnimationCompleteCallback>();
+
+const emptyState = {
+  queue: [],
+  active: [],
+  isActive: false,
+} satisfies Pick<AnimationQueueState, 'active' | 'isActive' | 'queue'>;
+
+export const useAnimationQueue = create<AnimationQueueState>((set, get) => ({
+  ...emptyState,
+  enqueue: (animation) => {
+    const queued = cloneAnimation(animation);
+    set((state) =>
+      withActivity(
+        promoteQueuedAnimations([...state.queue, queued], state.active),
+      ),
+    );
+    return queued.id;
+  },
+  complete: (animationId) => {
+    const completed =
+      get().active.find((animation) => animation.id === animationId) ?? null;
+
+    set((state) => {
+      const remainingActive = state.active.filter((animation) => {
+        return animation.id !== animationId;
+      });
+
+      if (!completed) {
+        return withActivity({
+          active: remainingActive,
+          queue: state.queue.filter(
+            (animation) => animation.id !== animationId,
+          ),
+        });
+      }
+
+      return withActivity(
+        promoteQueuedAnimations(state.queue, remainingActive),
+      );
+    });
+
+    if (!completed) return;
+
+    completed.onComplete?.();
+    for (const listener of Array.from(completeListeners)) {
+      listener(completed);
+    }
+  },
+  onComplete: (callback) => {
+    completeListeners.add(callback);
+    return () => {
+      completeListeners.delete(callback);
+    };
+  },
+  reset: () => {
+    completeListeners.clear();
+    set(emptyState);
+  },
+}));
+
+function promoteQueuedAnimations(
+  queue: readonly TacticalAnimation[],
+  active: readonly TacticalAnimation[],
+): Pick<AnimationQueueState, 'active' | 'queue'> {
+  const nextActive = [...active];
+  const nextQueue: TacticalAnimation[] = [];
+  const blockedMaps = new Set<string>();
+
+  for (const animation of queue) {
+    if (blockedMaps.has(animation.mapId)) {
+      nextQueue.push(animation);
+      continue;
+    }
+
+    if (canStart(animation, nextActive)) {
+      nextActive.push(animation);
+      continue;
+    }
+
+    blockedMaps.add(animation.mapId);
+    nextQueue.push(animation);
+  }
+
+  return { active: nextActive, queue: nextQueue };
+}
+
+function canStart(
+  candidate: TacticalAnimation,
+  active: readonly TacticalAnimation[],
+): boolean {
+  return !active.some((animation) => {
+    if (animation.mapId !== candidate.mapId) return false;
+    if (
+      candidate.unitId !== undefined &&
+      animation.unitId === candidate.unitId
+    ) {
+      return true;
+    }
+    return overlapsHexes(candidate, animation);
+  });
+}
+
+function overlapsHexes(
+  candidate: TacticalAnimation,
+  active: TacticalAnimation,
+): boolean {
+  const candidateHexes = hexesForAnimation(candidate);
+  if (candidateHexes.length === 0) return false;
+
+  const activeKeys = new Set(hexesForAnimation(active).map(hexKey));
+  return candidateHexes.some((hex) => activeKeys.has(hexKey(hex)));
+}
+
+function hexesForAnimation(
+  animation: TacticalAnimation,
+): readonly IHexCoordinate[] {
+  return animation.occupiedHexes ?? animation.path ?? [];
+}
+
+function withActivity(
+  state: Pick<AnimationQueueState, 'active' | 'queue'>,
+): Pick<AnimationQueueState, 'active' | 'isActive' | 'queue'> {
+  return {
+    ...state,
+    isActive: state.active.length > 0 || state.queue.length > 0,
+  };
+}
+
+function cloneAnimation(animation: TacticalAnimation): TacticalAnimation {
+  return {
+    id: animation.id,
+    mapId: animation.mapId,
+    ...(animation.unitId !== undefined ? { unitId: animation.unitId } : {}),
+    ...(animation.kind !== undefined ? { kind: animation.kind } : {}),
+    ...(animation.path !== undefined
+      ? { path: animation.path.map(copyHex) }
+      : {}),
+    ...(animation.occupiedHexes !== undefined
+      ? { occupiedHexes: animation.occupiedHexes.map(copyHex) }
+      : {}),
+    ...(animation.onComplete !== undefined
+      ? { onComplete: animation.onComplete }
+      : {}),
+  };
+}
+
+function copyHex(hex: IHexCoordinate): IHexCoordinate {
+  return { q: hex.q, r: hex.r };
+}
+
+function hexKey(hex: IHexCoordinate): string {
+  return `${hex.q},${hex.r}`;
+}

--- a/src/stores/useEncounterStore.ts
+++ b/src/stores/useEncounterStore.ts
@@ -40,6 +40,12 @@ interface LaunchResponse {
   error?: string;
 }
 
+interface LaunchEncounterOptions {
+  readonly campaignId?: string | null;
+  readonly contractId?: string | null;
+  readonly scenarioId?: string | null;
+}
+
 interface ValidationResponse {
   validation: IEncounterValidationResult;
 }
@@ -97,7 +103,10 @@ interface EncounterStoreActions {
   /** Validate an encounter */
   validateEncounter: (id: string) => Promise<IEncounterValidationResult | null>;
   /** Launch an encounter — returns gameSessionId on success, null on failure */
-  launchEncounter: (id: string) => Promise<string | null>;
+  launchEncounter: (
+    id: string,
+    options?: LaunchEncounterOptions,
+  ) => Promise<string | null>;
   /** Clone an encounter */
   cloneEncounter: (id: string, newName: string) => Promise<string | null>;
   /** Set status filter */
@@ -369,11 +378,13 @@ export const useEncounterStore = create<EncounterStore>((set, get) => ({
     }
   },
 
-  launchEncounter: async (id: string) => {
+  launchEncounter: async (id: string, options?: LaunchEncounterOptions) => {
     set({ isLoading: true, error: null });
     try {
       const response = await fetch(`/api/encounters/${id}/launch`, {
         method: 'POST',
+        headers: options ? { 'Content-Type': 'application/json' } : undefined,
+        body: options ? JSON.stringify(options) : undefined,
       });
       const data = (await response.json()) as LaunchResponse;
       if (!data.success) {

--- a/src/stores/useGameplayStore.combatFlows.ts
+++ b/src/stores/useGameplayStore.combatFlows.ts
@@ -111,6 +111,7 @@ export function commitPlannedMovementLogic(get: GetFn, set: SetFn): void {
     plannedMovement.destination,
     plannedMovement.facing,
     plannedMovement.movementType,
+    plannedMovement.path,
   );
 
   set({

--- a/src/stores/useGameplayStore.helpers.ts
+++ b/src/stores/useGameplayStore.helpers.ts
@@ -1,5 +1,6 @@
 import type { InteractiveSession } from '@/engine/GameEngine';
 
+import { getPrefersReducedMotion } from '@/hooks/useReducedMotion';
 import {
   IGameSession,
   IGameplayUIState,
@@ -15,6 +16,8 @@ import {
   replayToSequence,
 } from '@/utils/gameplay/gameSession';
 import { logger } from '@/utils/logger';
+
+import { useAnimationQueue } from './useAnimationQueue';
 
 export enum InteractivePhase {
   None = 'none',
@@ -52,6 +55,8 @@ type SetFn = {
  * Zustand get function type for gameplay helpers.
  */
 type GetFn = () => GameplayHelperState;
+
+let pendingPhaseAdvance = false;
 
 export function handleActionLogic(
   actionId: string,
@@ -168,6 +173,13 @@ export function advanceInteractivePhaseLogic(
   const state = get();
   if (!interactiveSession || !state.session) return;
 
+  if (shouldWaitForAnimations()) {
+    waitForAnimationQueueDrain(() =>
+      advanceInteractivePhaseLogic(interactiveSession, get, set),
+    );
+    return;
+  }
+
   const { phase } = interactiveSession.getState();
 
   if (phase === GamePhase.Initiative) {
@@ -255,6 +267,13 @@ export function skipPhaseLogic(
 ): void {
   if (!interactiveSession) return;
 
+  if (shouldWaitForAnimations()) {
+    waitForAnimationQueueDrain(() =>
+      skipPhaseLogic(interactiveSession, get, set),
+    );
+    return;
+  }
+
   interactiveSession.advancePhase();
 
   const gameOver = interactiveSession.isGameOver();
@@ -274,5 +293,28 @@ export function skipPhaseLogic(
       targetUnitId: null,
       queuedWeaponIds: [],
     },
+  });
+}
+
+function shouldWaitForAnimations(): boolean {
+  const isActive = useAnimationQueue.getState().isActive;
+  if (!isActive || getPrefersReducedMotion()) {
+    pendingPhaseAdvance = false;
+    return false;
+  }
+  return true;
+}
+
+function waitForAnimationQueueDrain(callback: () => void): void {
+  if (pendingPhaseAdvance) return;
+  pendingPhaseAdvance = true;
+
+  let unsubscribe: (() => void) | null = null;
+  unsubscribe = useAnimationQueue.getState().onComplete(() => {
+    if (useAnimationQueue.getState().isActive) return;
+
+    pendingPhaseAdvance = false;
+    unsubscribe?.();
+    callback();
   });
 }

--- a/src/stores/useInfantryStore.ts
+++ b/src/stores/useInfantryStore.ts
@@ -19,6 +19,10 @@ import {
   PLATOON_DEFAULTS,
   MOTIVE_MP,
 } from '@/types/unit/InfantryInterfaces';
+import {
+  normalizeInfantryFieldGun,
+  squadMotionTypeForMotive,
+} from '@/utils/construction/infantry';
 
 import {
   InfantryState,
@@ -27,6 +31,7 @@ import {
   createDefaultInfantryState,
   getArmorKitDivisor,
   computeInfantryStateBV,
+  normalizeInfantryState,
 } from './infantryState';
 
 // Re-export types for convenience
@@ -45,10 +50,12 @@ export function createInfantryStore(
   // Seed the initial bvBreakdown so consumers have a value before the first
   // BV-affecting action fires. See @spec .../infantry-unit-system/spec.md —
   // "unit.bvBreakdown SHALL contain perTrooper, motiveMultiplier, ...".
+  const normalizedInitialState = normalizeInfantryState(initialState);
   const seededState: InfantryState = {
-    ...initialState,
+    ...normalizedInitialState,
     bvBreakdown:
-      initialState.bvBreakdown ?? computeInfantryStateBV(initialState),
+      normalizedInitialState.bvBreakdown ??
+      computeInfantryStateBV(normalizedInitialState),
   };
 
   return create<InfantryStore>()(
@@ -199,8 +206,11 @@ export function createInfantryStore(
           setInfantryMotive: (motive: InfantryMotive) =>
             setWithBV({
               infantryMotive: motive,
+              motionType: squadMotionTypeForMotive(motive),
               // Re-derive composition defaults from TechManual tables
               platoonComposition: PLATOON_DEFAULTS[motive],
+              squadSize: PLATOON_DEFAULTS[motive].troopersPerSquad,
+              numberOfSquads: PLATOON_DEFAULTS[motive].squads,
               // Re-derive MP from motive
               groundMP: MOTIVE_MP[motive].groundMP,
               jumpMP: MOTIVE_MP[motive].jumpMP,
@@ -211,6 +221,8 @@ export function createInfantryStore(
           setPlatoonComposition: (comp: IPlatoonComposition) =>
             setWithBV({
               platoonComposition: comp,
+              squadSize: comp.troopersPerSquad,
+              numberOfSquads: comp.squads,
               isModified: true,
               lastModifiedAt: Date.now(),
             }),
@@ -306,7 +318,10 @@ export function createInfantryStore(
 
           addFieldGun: (gun: IInfantryFieldGun) =>
             setWithBV((state) => ({
-              fieldGuns: [...state.fieldGuns, gun],
+              fieldGuns: [
+                ...state.fieldGuns.map(normalizeInfantryFieldGun),
+                normalizeInfantryFieldGun(gun),
+              ],
               isModified: true,
               lastModifiedAt: Date.now(),
             })),

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -403,6 +403,11 @@ export interface IInitiativeRolledPayload {
   readonly rolls?: readonly number[];
 }
 
+export type MovementAnimationMode =
+  | MovementType.Walk
+  | MovementType.Run
+  | MovementType.Jump;
+
 /**
  * Movement declared event payload.
  */
@@ -417,6 +422,16 @@ export interface IMovementDeclaredPayload {
   readonly facing: Facing;
   /** Movement type used */
   readonly movementType: MovementType;
+  /**
+   * Phase 7 animation mode. Optional so legacy event streams that only
+   * serialized `movementType` continue to replay.
+   */
+  readonly mode?: MovementAnimationMode;
+  /**
+   * Ordered axial coordinates visited by the committed move, including
+   * the origin and destination. Optional for legacy replay backfill.
+   */
+  readonly path?: readonly IHexCoordinate[];
   /** MP spent */
   readonly mpUsed: number;
   /** Heat generated */

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -268,6 +268,37 @@ export enum GameSide {
 }
 
 // =============================================================================
+// Networked Game Intents
+// =============================================================================
+
+/**
+ * Guest-to-host intent types for networked 1v1 game sessions.
+ */
+export const GAME_INTENT_TYPES = [
+  'declareMovement',
+  'declareAttack',
+  'declarePhysical',
+  'confirmHeat',
+  'endPhase',
+  'concede',
+] as const;
+
+export type GameIntentType = (typeof GAME_INTENT_TYPES)[number];
+
+/**
+ * Intent envelope used when a peer requests that the host validate and execute
+ * an action.
+ */
+export interface IGameIntent {
+  /** Requested action type */
+  readonly type: GameIntentType;
+  /** Action-specific request payload */
+  readonly payload: unknown;
+  /** Peer that authored the request */
+  readonly authorPeerId: string;
+}
+
+// =============================================================================
 // Event Interfaces
 // =============================================================================
 
@@ -1325,6 +1356,12 @@ export interface IGameSession {
   readonly events: readonly IGameEvent[];
   /** Current derived state */
   readonly currentState: IGameState;
+  /** Network host peer id for P2P sessions; absent/null for local sessions */
+  readonly hostPeerId?: string | null;
+  /** Network guest peer id for P2P sessions; absent/null until joined */
+  readonly guestPeerId?: string | null;
+  /** Peer id that controls each side in networked sessions */
+  readonly sideOwners?: Readonly<Record<GameSide, string>> | null;
 }
 
 // =============================================================================

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -1041,6 +1041,11 @@ export interface IGameConfig {
    */
   readonly encounterId?: string | null;
   /**
+   * Campaign this session belongs to. Populated for campaign-launched
+   * encounters; null for standalone quick-play / handcrafted encounters.
+   */
+  readonly campaignId?: string | null;
+  /**
    * Campaign contract this session resolves. Populated when the encounter
    * was generated from a contract. Null for standalone encounters.
    */

--- a/src/types/unit/InfantryInterfaces.ts
+++ b/src/types/unit/InfantryInterfaces.ts
@@ -39,6 +39,14 @@ export interface IInfantryMP {
   readonly jumpMP: number;
 }
 
+/**
+ * Movement mode descriptor used by construction summaries.
+ *
+ * `vertical` is used for Mechanized VTOL platoons so UI/record-sheet consumers
+ * can distinguish VTOL movement from ground MP that merely happens to be 6.
+ */
+export type InfantryMovementMode = 'ground' | 'jump' | 'vertical';
+
 // ============================================================================
 // Platoon Composition
 // ============================================================================
@@ -104,6 +112,8 @@ export interface IInfantryWeaponEntry {
   readonly heat: number;
   /** Ammo type identifier (empty string if no ammo required) */
   readonly ammoType: string;
+  /** Special rule tags consumed by combat/record-sheet callers */
+  readonly special: readonly string[];
   /** Secondary weapon ratio denominator (1 per N troopers) */
   readonly secondaryRatio: number;
 }
@@ -113,12 +123,29 @@ export interface IInfantryWeaponEntry {
 // ============================================================================
 
 /**
+ * Spec-name field gun shape.
+ *
+ * This is the construction-facing name requested by the OpenSpec delta. Runtime
+ * store objects use `IInfantryFieldGun`, which extends this shape with the
+ * legacy `equipmentId/name/crew` fields already consumed by the UI and BV
+ * adapter.
+ */
+export interface IFieldGun {
+  /** Weapon catalog ID matching the approved field-gun list */
+  readonly weaponId: string;
+  /** Ammo rounds allocated to this field gun */
+  readonly ammoRounds: number;
+  /** Number of troopers required to operate the gun */
+  readonly crewCount: number;
+}
+
+/**
  * Field gun configuration: a mech-scale weapon crewed by platoon members.
  *
  * Crew members operating the gun do NOT fire personal weapons.
  * Field guns are not allowed for Jump or Mechanized motive platoons.
  */
-export interface IInfantryFieldGun {
+export interface IInfantryFieldGun extends IFieldGun {
   /** Equipment ID matching the weapon catalog */
   readonly equipmentId: string;
   /** Display name */
@@ -141,10 +168,41 @@ export interface IFieldGunCatalogEntry {
   readonly id: string;
   /** Display name */
   readonly name: string;
+  /** Deployed weapon tonnage for transport/reference display */
+  readonly tonnage: number;
   /** Minimum crew required */
   readonly crewRequired: number;
   /** Standard ammo bin count */
   readonly defaultAmmoRounds: number;
+}
+
+// ============================================================================
+// Spec-name infantry construction shape
+// ============================================================================
+
+/**
+ * Spec-name construction shape for conventional infantry.
+ *
+ * Existing runtime state keeps backwards-compatible names such as
+ * `infantryMotive`, `fieldGuns`, and `hasAntiMechTraining`. This interface
+ * gives spec consumers the requested names without replacing those established
+ * store fields.
+ */
+export interface IInfantryUnit {
+  /** Construction motive type; maps to store `infantryMotive` */
+  readonly motiveType: InfantryMotive;
+  /** Platoon composition: squads x troopers per squad */
+  readonly platoonComposition: IPlatoonComposition;
+  /** Construction armor kit */
+  readonly armorKit: InfantryArmorKitType;
+  /** Primary weapon table ID or display name */
+  readonly primaryWeapon: string;
+  /** Optional secondary weapon table ID or display name */
+  readonly secondaryWeapon?: string;
+  /** Optional single field gun; store state keeps this as `fieldGuns[0]` */
+  readonly fieldGun?: IFieldGun;
+  /** Anti-mech training flag; maps to store `hasAntiMechTraining` */
+  readonly antiMechTraining: boolean;
 }
 
 // ============================================================================
@@ -208,6 +266,74 @@ export const MOTIVE_MP: Record<InfantryMotive, IInfantryMP> = {
   [InfantryMotive.MECHANIZED_WHEELED]: { groundMP: 4, jumpMP: 0 },
   [InfantryMotive.MECHANIZED_HOVER]: { groundMP: 5, jumpMP: 0 },
   [InfantryMotive.MECHANIZED_VTOL]: { groundMP: 6, jumpMP: 0 },
+};
+
+/**
+ * Full construction profile for each motive.
+ */
+export interface IInfantryMotiveProfile {
+  readonly motive: InfantryMotive;
+  readonly defaultComposition: IPlatoonComposition;
+  readonly movement: IInfantryMP;
+  readonly movementMode: InfantryMovementMode;
+  /** Mechanized transport adds platoon-scale protection without mech armor */
+  readonly hasMechanizedArmor: boolean;
+}
+
+/** Motive defaults, movement, and construction flags in one table. */
+export const INFANTRY_MOTIVE_PROFILES: Record<
+  InfantryMotive,
+  IInfantryMotiveProfile
+> = {
+  [InfantryMotive.FOOT]: {
+    motive: InfantryMotive.FOOT,
+    defaultComposition: PLATOON_DEFAULTS[InfantryMotive.FOOT],
+    movement: MOTIVE_MP[InfantryMotive.FOOT],
+    movementMode: 'ground',
+    hasMechanizedArmor: false,
+  },
+  [InfantryMotive.JUMP]: {
+    motive: InfantryMotive.JUMP,
+    defaultComposition: PLATOON_DEFAULTS[InfantryMotive.JUMP],
+    movement: MOTIVE_MP[InfantryMotive.JUMP],
+    movementMode: 'jump',
+    hasMechanizedArmor: false,
+  },
+  [InfantryMotive.MOTORIZED]: {
+    motive: InfantryMotive.MOTORIZED,
+    defaultComposition: PLATOON_DEFAULTS[InfantryMotive.MOTORIZED],
+    movement: MOTIVE_MP[InfantryMotive.MOTORIZED],
+    movementMode: 'ground',
+    hasMechanizedArmor: false,
+  },
+  [InfantryMotive.MECHANIZED_TRACKED]: {
+    motive: InfantryMotive.MECHANIZED_TRACKED,
+    defaultComposition: PLATOON_DEFAULTS[InfantryMotive.MECHANIZED_TRACKED],
+    movement: MOTIVE_MP[InfantryMotive.MECHANIZED_TRACKED],
+    movementMode: 'ground',
+    hasMechanizedArmor: true,
+  },
+  [InfantryMotive.MECHANIZED_WHEELED]: {
+    motive: InfantryMotive.MECHANIZED_WHEELED,
+    defaultComposition: PLATOON_DEFAULTS[InfantryMotive.MECHANIZED_WHEELED],
+    movement: MOTIVE_MP[InfantryMotive.MECHANIZED_WHEELED],
+    movementMode: 'ground',
+    hasMechanizedArmor: true,
+  },
+  [InfantryMotive.MECHANIZED_HOVER]: {
+    motive: InfantryMotive.MECHANIZED_HOVER,
+    defaultComposition: PLATOON_DEFAULTS[InfantryMotive.MECHANIZED_HOVER],
+    movement: MOTIVE_MP[InfantryMotive.MECHANIZED_HOVER],
+    movementMode: 'ground',
+    hasMechanizedArmor: true,
+  },
+  [InfantryMotive.MECHANIZED_VTOL]: {
+    motive: InfantryMotive.MECHANIZED_VTOL,
+    defaultComposition: PLATOON_DEFAULTS[InfantryMotive.MECHANIZED_VTOL],
+    movement: MOTIVE_MP[InfantryMotive.MECHANIZED_VTOL],
+    movementMode: 'vertical',
+    hasMechanizedArmor: true,
+  },
 };
 
 /**

--- a/src/utils/construction/infantry/armorKits.ts
+++ b/src/utils/construction/infantry/armorKits.ts
@@ -1,0 +1,200 @@
+/**
+ * Infantry Armor Kit Construction Profiles
+ *
+ * Profiles capture the construction-level effects requested by
+ * add-infantry-construction: per-trooper modifiers, environment deployment
+ * flags, and transport mass per trooper.
+ *
+ * @spec openspec/changes/add-infantry-construction/specs/infantry-unit-system/spec.md
+ */
+
+import { InfantryArmorKitType } from '@/types/unit/InfantryInterfaces';
+import { InfantryArmorKit } from '@/types/unit/PersonnelInterfaces';
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+export interface IInfantryArmorKitProfile {
+  readonly kit: InfantryArmorKitType;
+  readonly displayName: string;
+  /** Flak-style ballistic resistance modifier. */
+  readonly ballisticDamageDivisorModifier: number;
+  /** Terrain to-hit modifier while in woods. Negative values benefit infantry. */
+  readonly woodsToHitModifier: number;
+  /** Terrain to-hit modifier while in snow. Negative values benefit infantry. */
+  readonly snowToHitModifier: number;
+  readonly enablesVacuumOperations: boolean;
+  readonly enablesUnderwaterOperations: boolean;
+  /** Transport mass added per trooper, in tons. */
+  readonly massTonsPerTrooper: number;
+}
+
+// ============================================================================
+// Canonical construction table
+// ============================================================================
+
+export const INFANTRY_ARMOR_KIT_PROFILES: Record<
+  InfantryArmorKitType,
+  IInfantryArmorKitProfile
+> = {
+  [InfantryArmorKitType.NONE]: {
+    kit: InfantryArmorKitType.NONE,
+    displayName: 'None',
+    ballisticDamageDivisorModifier: 0,
+    woodsToHitModifier: 0,
+    snowToHitModifier: 0,
+    enablesVacuumOperations: false,
+    enablesUnderwaterOperations: false,
+    massTonsPerTrooper: 0,
+  },
+  [InfantryArmorKitType.STANDARD]: {
+    kit: InfantryArmorKitType.STANDARD,
+    displayName: 'Standard',
+    ballisticDamageDivisorModifier: 0,
+    woodsToHitModifier: 0,
+    snowToHitModifier: 0,
+    enablesVacuumOperations: false,
+    enablesUnderwaterOperations: false,
+    massTonsPerTrooper: 0.01,
+  },
+  [InfantryArmorKitType.FLAK]: {
+    kit: InfantryArmorKitType.FLAK,
+    displayName: 'Flak',
+    ballisticDamageDivisorModifier: 1,
+    woodsToHitModifier: 0,
+    snowToHitModifier: 0,
+    enablesVacuumOperations: false,
+    enablesUnderwaterOperations: false,
+    massTonsPerTrooper: 0.012,
+  },
+  [InfantryArmorKitType.CAMO]: {
+    kit: InfantryArmorKitType.CAMO,
+    displayName: 'Camo',
+    ballisticDamageDivisorModifier: 0,
+    woodsToHitModifier: -1,
+    snowToHitModifier: 0,
+    enablesVacuumOperations: false,
+    enablesUnderwaterOperations: false,
+    massTonsPerTrooper: 0.011,
+  },
+  [InfantryArmorKitType.SNOW_CAMO]: {
+    kit: InfantryArmorKitType.SNOW_CAMO,
+    displayName: 'Snow Camo',
+    ballisticDamageDivisorModifier: 0,
+    woodsToHitModifier: 0,
+    snowToHitModifier: -1,
+    enablesVacuumOperations: false,
+    enablesUnderwaterOperations: false,
+    massTonsPerTrooper: 0.011,
+  },
+  [InfantryArmorKitType.ENVIRONMENTAL_SEALING]: {
+    kit: InfantryArmorKitType.ENVIRONMENTAL_SEALING,
+    displayName: 'Environmental Sealing',
+    ballisticDamageDivisorModifier: 0,
+    woodsToHitModifier: 0,
+    snowToHitModifier: 0,
+    enablesVacuumOperations: true,
+    enablesUnderwaterOperations: true,
+    massTonsPerTrooper: 0.02,
+  },
+  [InfantryArmorKitType.SNEAK_CAMO]: {
+    kit: InfantryArmorKitType.SNEAK_CAMO,
+    displayName: 'Sneak Camo',
+    ballisticDamageDivisorModifier: 0,
+    woodsToHitModifier: -1,
+    snowToHitModifier: 0,
+    enablesVacuumOperations: false,
+    enablesUnderwaterOperations: false,
+    massTonsPerTrooper: 0.018,
+  },
+  [InfantryArmorKitType.SNEAK_IR]: {
+    kit: InfantryArmorKitType.SNEAK_IR,
+    displayName: 'Sneak IR',
+    ballisticDamageDivisorModifier: 0,
+    woodsToHitModifier: 0,
+    snowToHitModifier: 0,
+    enablesVacuumOperations: false,
+    enablesUnderwaterOperations: false,
+    massTonsPerTrooper: 0.018,
+  },
+  [InfantryArmorKitType.SNEAK_ECM]: {
+    kit: InfantryArmorKitType.SNEAK_ECM,
+    displayName: 'Sneak ECM',
+    ballisticDamageDivisorModifier: 0,
+    woodsToHitModifier: 0,
+    snowToHitModifier: 0,
+    enablesVacuumOperations: false,
+    enablesUnderwaterOperations: false,
+    massTonsPerTrooper: 0.02,
+  },
+  [InfantryArmorKitType.CLAN]: {
+    kit: InfantryArmorKitType.CLAN,
+    displayName: 'Clan',
+    ballisticDamageDivisorModifier: 0,
+    woodsToHitModifier: 0,
+    snowToHitModifier: 0,
+    enablesVacuumOperations: false,
+    enablesUnderwaterOperations: false,
+    massTonsPerTrooper: 0.015,
+  },
+};
+
+const PERSONNEL_TO_CONSTRUCTION_ARMOR_KIT: Record<
+  InfantryArmorKit,
+  InfantryArmorKitType
+> = {
+  [InfantryArmorKit.NONE]: InfantryArmorKitType.NONE,
+  [InfantryArmorKit.STANDARD]: InfantryArmorKitType.STANDARD,
+  [InfantryArmorKit.FLAK]: InfantryArmorKitType.FLAK,
+  [InfantryArmorKit.ABLATIVE]: InfantryArmorKitType.STANDARD,
+  [InfantryArmorKit.SNEAK_CAMO]: InfantryArmorKitType.SNEAK_CAMO,
+  [InfantryArmorKit.SNEAK_IR]: InfantryArmorKitType.SNEAK_IR,
+  [InfantryArmorKit.SNEAK_ECM]: InfantryArmorKitType.SNEAK_ECM,
+  [InfantryArmorKit.SNEAK_CAMO_IR]: InfantryArmorKitType.SNEAK_CAMO,
+  [InfantryArmorKit.SNEAK_IR_ECM]: InfantryArmorKitType.SNEAK_ECM,
+  [InfantryArmorKit.SNEAK_COMPLETE]: InfantryArmorKitType.SNEAK_ECM,
+  [InfantryArmorKit.CLAN]: InfantryArmorKitType.CLAN,
+  [InfantryArmorKit.ENVIRONMENTAL]: InfantryArmorKitType.ENVIRONMENTAL_SEALING,
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+export function getInfantryArmorKitProfile(
+  kit: InfantryArmorKitType,
+): IInfantryArmorKitProfile {
+  return INFANTRY_ARMOR_KIT_PROFILES[kit];
+}
+
+export function mapPersonnelArmorKitToConstructionKit(
+  kit: InfantryArmorKit,
+): InfantryArmorKitType {
+  return PERSONNEL_TO_CONSTRUCTION_ARMOR_KIT[kit];
+}
+
+export function canArmorKitDeployInVacuumOrUnderwater(
+  kit: InfantryArmorKitType,
+): boolean {
+  const profile = getInfantryArmorKitProfile(kit);
+  return profile.enablesVacuumOperations && profile.enablesUnderwaterOperations;
+}
+
+export function calculateArmorKitMassTons(
+  kit: InfantryArmorKitType,
+  troopers: number,
+): number {
+  const profile = getInfantryArmorKitProfile(kit);
+  return Math.max(0, troopers) * profile.massTonsPerTrooper;
+}
+
+export function calculatePersonnelArmorKitMassTons(
+  kit: InfantryArmorKit,
+  troopers: number,
+): number {
+  return calculateArmorKitMassTons(
+    mapPersonnelArmorKitToConstructionKit(kit),
+    troopers,
+  );
+}

--- a/src/utils/construction/infantry/fieldGuns.ts
+++ b/src/utils/construction/infantry/fieldGuns.ts
@@ -11,6 +11,7 @@
  */
 
 import {
+  IFieldGun,
   IFieldGunCatalogEntry,
   IInfantryFieldGun,
 } from '@/types/unit/InfantryInterfaces';
@@ -27,78 +28,91 @@ export const FIELD_GUN_CATALOG: readonly IFieldGunCatalogEntry[] = [
   {
     id: 'mg',
     name: 'Machine Gun',
+    tonnage: 0.5,
     crewRequired: 2,
     defaultAmmoRounds: 200,
   },
   {
     id: 'flamer',
     name: 'Flamer',
+    tonnage: 1,
     crewRequired: 2,
     defaultAmmoRounds: 0,
   },
   {
     id: 'ac2',
     name: 'Autocannon/2',
+    tonnage: 6,
     crewRequired: 2,
     defaultAmmoRounds: 45,
   },
   {
     id: 'ac5',
     name: 'Autocannon/5',
+    tonnage: 8,
     crewRequired: 3,
     defaultAmmoRounds: 20,
   },
   {
     id: 'ac10',
     name: 'Autocannon/10',
+    tonnage: 12,
     crewRequired: 4,
     defaultAmmoRounds: 10,
   },
   {
     id: 'ac20',
     name: 'Autocannon/20',
+    tonnage: 14,
     crewRequired: 5,
     defaultAmmoRounds: 5,
   },
   {
     id: 'lrm5',
     name: 'LRM 5',
+    tonnage: 2,
     crewRequired: 2,
     defaultAmmoRounds: 24,
   },
   {
     id: 'lrm10',
     name: 'LRM 10',
+    tonnage: 5,
     crewRequired: 3,
     defaultAmmoRounds: 12,
   },
   {
     id: 'lrm15',
     name: 'LRM 15',
+    tonnage: 7,
     crewRequired: 3,
     defaultAmmoRounds: 8,
   },
   {
     id: 'lrm20',
     name: 'LRM 20',
+    tonnage: 10,
     crewRequired: 4,
     defaultAmmoRounds: 6,
   },
   {
     id: 'srm2',
     name: 'SRM 2',
+    tonnage: 1,
     crewRequired: 2,
     defaultAmmoRounds: 50,
   },
   {
     id: 'srm4',
     name: 'SRM 4',
+    tonnage: 2,
     crewRequired: 2,
     defaultAmmoRounds: 25,
   },
   {
     id: 'srm6',
     name: 'SRM 6',
+    tonnage: 3,
     crewRequired: 3,
     defaultAmmoRounds: 15,
   },
@@ -125,11 +139,59 @@ export function buildFieldGun(
   entry: IFieldGunCatalogEntry,
   ammoOverride?: number,
 ): IInfantryFieldGun {
+  const ammoRounds = ammoOverride ?? entry.defaultAmmoRounds;
   return {
+    weaponId: entry.id,
+    crewCount: entry.crewRequired,
+    ammoRounds,
     equipmentId: entry.id,
     name: entry.name,
     crew: entry.crewRequired,
-    ammoRounds: ammoOverride ?? entry.defaultAmmoRounds,
+  };
+}
+
+/**
+ * Return the crew count derived from the approved field-gun catalog.
+ */
+export function deriveFieldGunCrewCount(weaponId: string): number | undefined {
+  return findFieldGunById(weaponId)?.crewRequired;
+}
+
+/**
+ * Return the deployed weapon tonnage for reference/transport displays.
+ */
+export function getDeployedFieldGunTonnage(weaponId: string): number {
+  return findFieldGunById(weaponId)?.tonnage ?? 0;
+}
+
+/**
+ * Field guns do not consume unit construction tonnage.
+ *
+ * The deployed weapon tonnage is still present in FIELD_GUN_CATALOG for
+ * reference, but construction weight/BV paths must treat field-gun tonnage as
+ * zero because the gun is a deployed/towed weapon.
+ */
+export function getFieldGunConstructionTonnage(_fieldGun: IFieldGun): number {
+  return 0;
+}
+
+/**
+ * Normalize a legacy store field gun into the current spec-compatible shape.
+ */
+export function normalizeInfantryFieldGun(
+  gun: IInfantryFieldGun,
+): IInfantryFieldGun {
+  const weaponId = gun.weaponId || gun.equipmentId;
+  const crewCount = gun.crewCount || gun.crew;
+  const ammoRounds =
+    typeof gun.ammoRounds === 'number' ? Math.max(0, gun.ammoRounds) : 0;
+  return {
+    ...gun,
+    weaponId,
+    crewCount,
+    equipmentId: gun.equipmentId || weaponId,
+    crew: gun.crew || crewCount,
+    ammoRounds,
   };
 }
 
@@ -138,5 +200,5 @@ export function buildFieldGun(
  * A platoon may carry multiple guns but crew counts accumulate.
  */
 export function totalFieldGunCrew(guns: readonly IInfantryFieldGun[]): number {
-  return guns.reduce((sum, g) => sum + g.crew, 0);
+  return guns.reduce((sum, g) => sum + g.crewCount, 0);
 }

--- a/src/utils/construction/infantry/index.ts
+++ b/src/utils/construction/infantry/index.ts
@@ -14,6 +14,8 @@ export {
   getDefaultComposition,
   totalTroopers,
   getMotiveMP,
+  getMotiveProfile,
+  squadMotionTypeForMotive,
   effectiveFiringTroopers,
   secondaryWeaponCount,
   FIELD_GUN_ALLOWED_MOTIVES,
@@ -24,11 +26,27 @@ export {
   FIELD_GUN_CATALOG,
   findFieldGunById,
   buildFieldGun,
+  deriveFieldGunCrewCount,
+  getDeployedFieldGunTonnage,
+  getFieldGunConstructionTonnage,
+  normalizeInfantryFieldGun,
   totalFieldGunCrew,
 } from './fieldGuns';
 
 export {
+  INFANTRY_ARMOR_KIT_PROFILES,
+  getInfantryArmorKitProfile,
+  mapPersonnelArmorKitToConstructionKit,
+  canArmorKitDeployInVacuumOrUnderwater,
+  calculateArmorKitMassTons,
+  calculatePersonnelArmorKitMassTons,
+} from './armorKits';
+
+export type { IInfantryArmorKitProfile } from './armorKits';
+
+export {
   validatePlatoonSize,
+  validatePlatoonDefaultWarning,
   validateMotiveCompatibility,
   validateArmorKit,
   validatePrimaryWeapon,

--- a/src/utils/construction/infantry/infantryBVAdapter.ts
+++ b/src/utils/construction/infantry/infantryBVAdapter.ts
@@ -193,13 +193,13 @@ function adaptFieldGuns(
       gun.ammoRounds && gun.ammoRounds > 0
         ? [
             {
-              id: ammoIdForFieldGun(gun.equipmentId),
-              weaponTypeOverride: gun.equipmentId,
+              id: ammoIdForFieldGun(gun.weaponId),
+              weaponTypeOverride: gun.weaponId,
             },
           ]
         : [];
     return {
-      id: gun.equipmentId,
+      id: gun.weaponId,
       ammo: ammoBins,
     };
   });
@@ -331,6 +331,8 @@ export function calculateInfantryBVFromUnit(
   // bin each — the BV layer only needs equipmentId + a non-zero ammoRounds
   // flag to emit an ammo entry.
   const fieldGuns: readonly IInfantryFieldGun[] = unit.fieldGuns.map((gun) => ({
+    weaponId: gun.equipmentId,
+    crewCount: gun.crew,
     equipmentId: gun.equipmentId,
     name: gun.name,
     crew: gun.crew,

--- a/src/utils/construction/infantry/platoonComposition.ts
+++ b/src/utils/construction/infantry/platoonComposition.ts
@@ -7,10 +7,13 @@
  * @spec openspec/changes/add-infantry-construction/specs/infantry-unit-system/spec.md
  */
 
+import { SquadMotionType } from '@/types/unit/BaseUnitInterfaces';
 import {
   InfantryMotive,
   IPlatoonComposition,
   IInfantryMP,
+  IInfantryMotiveProfile,
+  INFANTRY_MOTIVE_PROFILES,
   PLATOON_DEFAULTS,
   MOTIVE_MP,
 } from '@/types/unit/InfantryInterfaces';
@@ -43,6 +46,39 @@ export function totalTroopers(composition: IPlatoonComposition): number {
  */
 export function getMotiveMP(motive: InfantryMotive): IInfantryMP {
   return MOTIVE_MP[motive];
+}
+
+/**
+ * Return the full construction profile for a motive.
+ */
+export function getMotiveProfile(
+  motive: InfantryMotive,
+): IInfantryMotiveProfile {
+  return INFANTRY_MOTIVE_PROFILES[motive];
+}
+
+/**
+ * Map construction-layer motive to the legacy squad motion enum.
+ */
+export function squadMotionTypeForMotive(
+  motive: InfantryMotive,
+): SquadMotionType {
+  switch (motive) {
+    case InfantryMotive.FOOT:
+      return SquadMotionType.FOOT;
+    case InfantryMotive.JUMP:
+      return SquadMotionType.JUMP;
+    case InfantryMotive.MOTORIZED:
+      return SquadMotionType.MOTORIZED;
+    case InfantryMotive.MECHANIZED_TRACKED:
+      return SquadMotionType.TRACKED;
+    case InfantryMotive.MECHANIZED_WHEELED:
+      return SquadMotionType.WHEELED;
+    case InfantryMotive.MECHANIZED_HOVER:
+      return SquadMotionType.HOVER;
+    case InfantryMotive.MECHANIZED_VTOL:
+      return SquadMotionType.VTOL;
+  }
 }
 
 // ============================================================================

--- a/src/utils/construction/infantry/validation.ts
+++ b/src/utils/construction/infantry/validation.ts
@@ -20,6 +20,7 @@ import {
   InfantryArmorKitType,
   InfantryMotive,
   IInfantryFieldGun,
+  PLATOON_DEFAULTS,
   PLATOON_MAX_TROOPERS,
   PLATOON_MIN_TROOPERS,
   SNEAK_ARMOR_KITS,
@@ -27,10 +28,15 @@ import {
   VTOL_MAX_TROOPERS,
 } from '@/types/unit/InfantryInterfaces';
 
-import { totalFieldGunCrew } from './fieldGuns';
+import {
+  deriveFieldGunCrewCount,
+  findFieldGunById,
+  totalFieldGunCrew,
+} from './fieldGuns';
 import {
   FIELD_GUN_ALLOWED_MOTIVES,
   HEAVY_WEAPON_MOTIVES,
+  totalTroopers as calculateTotalTroopers,
 } from './platoonComposition';
 
 // ============================================================================
@@ -53,6 +59,31 @@ export function validatePlatoonSize(totalTroopers: number): string[] {
     );
   }
   return errors;
+}
+
+/**
+ * Warning companion for VAL-INF-PLATOON.
+ *
+ * Custom platoon sizes in the supported 1-30 construction range are allowed,
+ * but the UI/validators should flag when the size diverges from the motive's
+ * TechManual default.
+ */
+export function validatePlatoonDefaultWarning(
+  motive: InfantryMotive,
+  totalTrooperCount: number,
+): string[] {
+  if (totalTrooperCount < 1 || totalTrooperCount > PLATOON_MAX_TROOPERS) {
+    return [];
+  }
+
+  const defaultTotal = calculateTotalTroopers(PLATOON_DEFAULTS[motive]);
+  if (totalTrooperCount === defaultTotal) {
+    return [];
+  }
+
+  return [
+    `[VAL-INF-PLATOON] platoon size ${totalTrooperCount} differs from ${motive} default ${defaultTotal}`,
+  ];
 }
 
 /**
@@ -128,6 +159,24 @@ export function validateFieldGuns(
     );
   }
 
+  for (const gun of fieldGuns) {
+    const weaponId = gun.weaponId || gun.equipmentId;
+    const catalogEntry = findFieldGunById(weaponId);
+    if (!catalogEntry) {
+      errors.push(
+        `[VAL-INF-FIELD-GUN] field gun ${weaponId} is not in the approved list`,
+      );
+      continue;
+    }
+
+    const derivedCrew = deriveFieldGunCrewCount(weaponId);
+    if (derivedCrew !== undefined && gun.crewCount !== derivedCrew) {
+      errors.push(
+        `[VAL-INF-FIELD-GUN] field gun ${weaponId} crew must be ${derivedCrew}, got ${gun.crewCount}`,
+      );
+    }
+  }
+
   const crew = totalFieldGunCrew(fieldGuns);
   if (crew >= totalTroopers) {
     errors.push(
@@ -189,6 +238,7 @@ export interface InfantryValidationInput {
 export interface InfantryValidationResult {
   isValid: boolean;
   errors: string[];
+  warnings: string[];
 }
 
 /**
@@ -205,6 +255,10 @@ export function validateInfantryConstruction(
     ...validateFieldGuns(input.motive, input.totalTroopers, input.fieldGuns),
     ...validateAntiMechTraining(input.motive, input.hasAntiMechTraining),
   ];
+  const warnings = validatePlatoonDefaultWarning(
+    input.motive,
+    input.totalTroopers,
+  );
 
-  return { isValid: errors.length === 0, errors };
+  return { isValid: errors.length === 0, errors, warnings };
 }

--- a/src/utils/construction/infantry/weaponTable.ts
+++ b/src/utils/construction/infantry/weaponTable.ts
@@ -33,6 +33,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     rangeLong: 3,
     heat: 0,
     ammoType: '',
+    special: [],
     secondaryRatio: 4,
   },
   {
@@ -45,6 +46,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     rangeLong: 3,
     heat: 0,
     ammoType: 'auto-rifle',
+    special: ['ballistic'],
     secondaryRatio: 3,
   },
   {
@@ -57,6 +59,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     rangeLong: 3,
     heat: 0,
     ammoType: '',
+    special: ['energy'],
     secondaryRatio: 4,
   },
   {
@@ -69,6 +72,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     rangeLong: 3,
     heat: 0,
     ammoType: 'needler',
+    special: ['anti-infantry'],
     secondaryRatio: 4,
   },
   {
@@ -81,6 +85,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     rangeLong: 3,
     heat: 0,
     ammoType: 'gyrojet',
+    special: ['vacuum-capable'],
     secondaryRatio: 4,
   },
   {
@@ -93,6 +98,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     rangeLong: 0,
     heat: 1,
     ammoType: 'flamer',
+    special: ['heat', 'incendiary'],
     secondaryRatio: 4,
   },
   // --- Missile launchers (secondary-typical) ---
@@ -106,6 +112,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     rangeLong: 9,
     heat: 0,
     ammoType: 'srm',
+    special: ['missile'],
     secondaryRatio: 4,
   },
   {
@@ -118,6 +125,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     rangeLong: 21,
     heat: 0,
     ammoType: 'lrm',
+    special: ['missile', 'indirect'],
     secondaryRatio: 4,
   },
   // --- Heavy support weapons (Mechanized / Motorized only) ---
@@ -131,6 +139,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     rangeLong: 3,
     heat: 0,
     ammoType: 'mg',
+    special: ['ballistic'],
     secondaryRatio: 2,
   },
   {
@@ -143,6 +152,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     rangeLong: 3,
     heat: 0,
     ammoType: 'mg-heavy',
+    special: ['ballistic', 'support'],
     secondaryRatio: 2,
   },
   {
@@ -155,6 +165,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     rangeLong: 5,
     heat: 2,
     ammoType: '',
+    special: ['energy', 'support'],
     secondaryRatio: 3,
   },
   {
@@ -167,6 +178,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     rangeLong: 12,
     heat: 5,
     ammoType: '',
+    special: ['energy', 'support'],
     secondaryRatio: 3,
   },
 ] as const;

--- a/src/utils/events/campaignOutcomeEvents.ts
+++ b/src/utils/events/campaignOutcomeEvents.ts
@@ -1,0 +1,43 @@
+import { getEventStore } from '@/services/events';
+import { type IBaseEvent } from '@/types/events';
+
+import { createCampaignEvent } from './eventFactory';
+
+export const CampaignOutcomeEventTypes = {
+  PendingOutcomeAdded: 'PendingOutcomeAdded',
+} as const;
+
+export type CampaignOutcomeEventType =
+  (typeof CampaignOutcomeEventTypes)[keyof typeof CampaignOutcomeEventTypes];
+
+export interface IPendingOutcomeAddedPayload {
+  readonly campaignId: string;
+  readonly matchId: string;
+  readonly contractId: string | null;
+  readonly scenarioId: string | null;
+  readonly queueLength: number;
+}
+
+function appendWhenEnabled<T>(event: IBaseEvent<T>, emit: boolean): void {
+  if (emit) {
+    getEventStore().append(event);
+  }
+}
+
+export function emitPendingOutcomeAdded(
+  params: IPendingOutcomeAddedPayload,
+  emit = true,
+): IBaseEvent<IPendingOutcomeAddedPayload> {
+  const event = createCampaignEvent(
+    CampaignOutcomeEventTypes.PendingOutcomeAdded,
+    params,
+    params.campaignId,
+    params.contractId ?? undefined,
+    {
+      gameId: params.matchId,
+    },
+  );
+
+  appendWhenEnabled(event, emit);
+  return event;
+}

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -73,3 +73,11 @@ export {
   emitPilotInstanceMissionCompleted,
   emitPilotInstanceDeceased,
 } from './campaignInstanceEvents';
+
+// Campaign outcome events
+export {
+  CampaignOutcomeEventTypes,
+  emitPendingOutcomeAdded,
+  type CampaignOutcomeEventType,
+  type IPendingOutcomeAddedPayload,
+} from './campaignOutcomeEvents';

--- a/src/utils/gameplay/__tests__/movementEventPayload.test.ts
+++ b/src/utils/gameplay/__tests__/movementEventPayload.test.ts
@@ -1,0 +1,75 @@
+import {
+  Facing,
+  GameEventType,
+  GamePhase,
+  MovementType,
+  type IGameEvent,
+  type IMovementDeclaredPayload,
+} from '@/types/gameplay';
+import { getMovementDeclaredPlaybackPayload } from '@/utils/gameplay/eventPayloads';
+import { createMovementDeclaredEvent } from '@/utils/gameplay/gameEvents';
+
+describe('movement event path payloads', () => {
+  it('serializes the committed path and movement mode', () => {
+    const path = [
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+      { q: 2, r: -1 },
+    ];
+
+    const event = createMovementDeclaredEvent(
+      'game-1',
+      1,
+      1,
+      'unit-a',
+      path[0],
+      path[2],
+      Facing.Southeast,
+      MovementType.Run,
+      3,
+      1,
+      path,
+    );
+    const payload = event.payload as IMovementDeclaredPayload;
+    const parsed = JSON.parse(JSON.stringify(event)) as {
+      readonly payload: Pick<IMovementDeclaredPayload, 'mode' | 'path'>;
+    };
+
+    expect(payload.path).toEqual(path);
+    expect(payload.mode).toBe(MovementType.Run);
+    expect(parsed.payload.path).toEqual(path);
+    expect(parsed.payload.mode).toBe(MovementType.Run);
+  });
+
+  it('backfills legacy destination-only movement events as instant playback', () => {
+    const legacyEvent: IGameEvent = {
+      id: 'event-1',
+      gameId: 'game-1',
+      sequence: 1,
+      timestamp: '2026-04-30T00:00:00.000Z',
+      type: GameEventType.MovementDeclared,
+      turn: 1,
+      phase: GamePhase.Movement,
+      actorId: 'unit-a',
+      payload: {
+        unitId: 'unit-a',
+        from: { q: 0, r: 0 },
+        to: { q: 3, r: -1 },
+        facing: Facing.Northeast,
+        movementType: MovementType.Walk,
+        mpUsed: 3,
+        heatGenerated: 0,
+      },
+    };
+
+    const playback = getMovementDeclaredPlaybackPayload(legacyEvent);
+
+    expect(playback).not.toBeNull();
+    expect(playback?.instantFallback).toBe(true);
+    expect(playback?.mode).toBe(MovementType.Walk);
+    expect(playback?.path).toEqual([
+      { q: 0, r: 0 },
+      { q: 3, r: -1 },
+    ]);
+  });
+});

--- a/src/utils/gameplay/eventPayloads.ts
+++ b/src/utils/gameplay/eventPayloads.ts
@@ -19,9 +19,24 @@ import {
   IAttackResolvedPayload,
   IDamageAppliedPayload,
   IHeatPayload,
+  IHexCoordinate,
   IPilotHitPayload,
+  MovementAnimationMode,
   IUnitDestroyedPayload,
 } from '@/types/gameplay';
+import {
+  movementAnimationModeForType,
+  normalizeMovementEventPath,
+} from '@/utils/gameplay/movement/eventPath';
+
+export interface IMovementDeclaredPlaybackPayload extends Omit<
+  IMovementDeclaredPayload,
+  'mode' | 'path'
+> {
+  readonly mode: MovementAnimationMode | null;
+  readonly path: readonly IHexCoordinate[];
+  readonly instantFallback: boolean;
+}
 
 // =============================================================================
 // Type Guards
@@ -99,6 +114,33 @@ export function getMovementDeclaredPayload(
 ): IMovementDeclaredPayload | null {
   if (event.type !== GameEventType.MovementDeclared) return null;
   return event.payload as IMovementDeclaredPayload;
+}
+
+/**
+ * Extract MovementDeclared payload for animation/replay consumers.
+ *
+ * Legacy events did not serialize the full path. Those events are
+ * normalized to a safe endpoint path and flagged so UI playback can snap
+ * instantly instead of trying to reconstruct historical traversal.
+ */
+export function getMovementDeclaredPlaybackPayload(
+  event: IGameEvent,
+): IMovementDeclaredPlaybackPayload | null {
+  const payload = getMovementDeclaredPayload(event);
+  if (!payload) return null;
+
+  const hasSerializedPath = Boolean(payload.path && payload.path.length > 0);
+  return {
+    ...payload,
+    mode: payload.mode ?? movementAnimationModeForType(payload.movementType),
+    path: hasSerializedPath
+      ? normalizeMovementEventPath(payload.from, payload.to, payload.path)
+      : normalizeMovementEventPath(payload.from, payload.to, [
+          payload.from,
+          payload.to,
+        ]),
+    instantFallback: !hasSerializedPath,
+  };
 }
 
 /**

--- a/src/utils/gameplay/gameEvents/movement.ts
+++ b/src/utils/gameplay/gameEvents/movement.ts
@@ -8,6 +8,10 @@ import {
   IMovementLockedPayload,
   MovementType,
 } from '@/types/gameplay';
+import {
+  movementAnimationModeForType,
+  normalizeMovementEventPath,
+} from '@/utils/gameplay/movement/eventPath';
 
 import { createEventBase } from './base';
 
@@ -22,13 +26,17 @@ export function createMovementDeclaredEvent(
   movementType: MovementType,
   mpUsed: number,
   heatGenerated: number,
+  path?: readonly IHexCoordinate[],
 ): IGameEvent {
+  const mode = movementAnimationModeForType(movementType);
   const payload: IMovementDeclaredPayload = {
     unitId,
     from,
     to,
     facing,
     movementType,
+    ...(mode ? { mode } : {}),
+    path: normalizeMovementEventPath(from, to, path),
     mpUsed,
     heatGenerated,
   };

--- a/src/utils/gameplay/gameSessionCore.ts
+++ b/src/utils/gameplay/gameSessionCore.ts
@@ -266,6 +266,7 @@ export function declareMovement(
   movementType: MovementType,
   mpUsed: number,
   heatGenerated: number,
+  path?: readonly IHexCoordinate[],
 ): IGameSession {
   if (session.currentState.phase !== GamePhase.Movement) {
     throw new Error('Not in movement phase');
@@ -289,6 +290,7 @@ export function declareMovement(
     movementType,
     mpUsed,
     heatGenerated,
+    path,
   );
 
   return appendEvent(session, event);

--- a/src/utils/gameplay/movement/eventPath.ts
+++ b/src/utils/gameplay/movement/eventPath.ts
@@ -1,0 +1,84 @@
+import type {
+  IHexCoordinate,
+  IHexGrid,
+  IMovementCapability,
+  MovementAnimationMode,
+} from '@/types/gameplay';
+
+import { MovementType } from '@/types/gameplay';
+import { hexEquals, hexLine } from '@/utils/gameplay/hexMath';
+
+import { findPath } from './pathfinding';
+
+export function movementAnimationModeForType(
+  movementType: MovementType,
+): MovementAnimationMode | null {
+  switch (movementType) {
+    case MovementType.Walk:
+    case MovementType.Run:
+    case MovementType.Jump:
+      return movementType;
+    default:
+      return null;
+  }
+}
+
+export function normalizeMovementEventPath(
+  from: IHexCoordinate,
+  to: IHexCoordinate,
+  path?: readonly IHexCoordinate[],
+): readonly IHexCoordinate[] {
+  if (path && path.length > 0) {
+    return path.map(copyHex);
+  }
+
+  return hexLine(from, to).map(copyHex);
+}
+
+export function buildMovementEventPath(params: {
+  readonly grid: IHexGrid;
+  readonly from: IHexCoordinate;
+  readonly to: IHexCoordinate;
+  readonly movementType: MovementType;
+  readonly maxCost?: number;
+}): readonly IHexCoordinate[] {
+  const { grid, from, to, movementType, maxCost } = params;
+
+  if (hexEquals(from, to)) {
+    return [copyHex(from)];
+  }
+
+  if (
+    movementType === MovementType.Jump ||
+    movementType === MovementType.Stationary
+  ) {
+    return [copyHex(from), copyHex(to)];
+  }
+
+  const path = findPath(grid, from, to, maxCost ?? Infinity);
+  return normalizeMovementEventPath(from, to, path ?? undefined);
+}
+
+export function maxMovementCostForCapability(
+  capability: IMovementCapability | null | undefined,
+  movementType: MovementType,
+): number {
+  if (!capability) {
+    return Infinity;
+  }
+
+  switch (movementType) {
+    case MovementType.Walk:
+      return capability.walkMP;
+    case MovementType.Run:
+      return capability.runMP;
+    case MovementType.Jump:
+      return capability.jumpMP;
+    default:
+      return 0;
+  }
+}
+
+function copyHex(coord: IHexCoordinate): IHexCoordinate {
+  return { q: coord.q, r: coord.r };
+}


### PR DESCRIPTION
## Summary
- Implements the Wave 1 OpenSpec foundation lanes in one integration branch: campaign round-trip linkage, infantry construction foundation, tactical movement animation foundation, and P2P game-session channel contracts.
- Keeps runtime/source commits separate from OpenSpec task-checklist commits for tighter review.
- Leaves `.agents/` and `dependency-analysis.json` untouched/untracked.

## Wave 1 Scope
- `wire-encounter-to-campaign-round-trip`: launch linkage, session metadata propagation, pending outcome/day advancement handoff coverage.
- `add-infantry-construction`: infantry shape extensions, armor kits, field guns, platoon defaults/validation, fixtures, store/UI wiring foundation.
- `add-movement-interpolation-animations`: movement path/mode payloads, animation queue store, phase-advance gating, reduced-motion helper, movement tween foundation.
- `add-p2p-game-session-sync`: host/guest roles, Yjs-backed game session channel, side ownership and intent helper contracts.

## Verification
- `npx.cmd openspec validate --all --strict` -> 189 passed, 0 failed
- `npm.cmd run typecheck` -> pass
- `npx.cmd oxlint` -> 24 warnings, 0 errors (known max-lines warnings)
- `npx.cmd oxfmt --check . '!**/.agents/**'` -> pass
- `npm.cmd run schema:gen-check` -> generated Zod matches committed
- `npx.cmd madge --circular --extensions ts,tsx src/` -> no circular dependency found
- `npm.cmd run test -- --watchAll=false` -> 843 suites passed, 1 skipped; 23,067 tests passed

## Notes
- The pre-commit build passed on each runtime commit. Next build still emits the known Windows traced-file copy warning for the `node:crypto` chunk but exits successfully.
- Wave 2 should branch after these contracts land, per `openspec/planning/ACTIVE-CHANGES-ROADMAP.md`.