### PR TITLE
Implement OpenSpec Wave 3 tactical visuals

### DIFF
--- a/openspec/changes/add-attack-visual-effects/tasks.md
+++ b/openspec/changes/add-attack-visual-effects/tasks.md
@@ -2,97 +2,97 @@
 
 ## 1. Weapon Visual Map
 
-- [ ] 1.1 Create `src/utils/effects/weaponEffectMap.ts`
-- [ ] 1.2 Map weapon types to categories: `laser | missile | ballistic
+- [x] 1.1 Create `src/utils/effects/weaponEffectMap.ts`
+- [x] 1.2 Map weapon types to categories: `laser | missile | ballistic
 | physical`
-- [ ] 1.3 Map subtypes to colors (small/med pulse -> IR tint; med/large
+- [x] 1.3 Map subtypes to colors (small/med pulse -> IR tint; med/large
       laser -> green; ER variants -> red-orange; missiles -> yellow
       trail; ballistic -> cyan tracer; physical -> white shockwave)
-- [ ] 1.4 Unit tests covering every weapon type represented in the
+- [x] 1.4 Unit tests covering every weapon type represented in the
       catalog
 
 ## 2. Effect Primitives
 
-- [ ] 2.1 Create `LaserBeam.tsx`: solid line with glow filter from
+- [x] 2.1 Create `LaserBeam.tsx`: solid line with glow filter from
       origin to target, 400ms duration
-- [ ] 2.2 Create `MissileTrail.tsx`: dashed line animating from origin
+- [x] 2.2 Create `MissileTrail.tsx`: dashed line animating from origin
       to target with an arrowhead, 600ms duration
-- [ ] 2.3 Create `Tracer.tsx`: short bright dashes moving along the
+- [x] 2.3 Create `Tracer.tsx`: short bright dashes moving along the
       line, 300ms duration
-- [ ] 2.4 Create `Shockwave.tsx`: expanding ring at target hex, 400ms
+- [x] 2.4 Create `Shockwave.tsx`: expanding ring at target hex, 400ms
       duration
-- [ ] 2.5 Create `ImpactFlash.tsx`: white burst at impact hex, 150ms
+- [x] 2.5 Create `ImpactFlash.tsx`: white burst at impact hex, 150ms
       duration
 
 ## 3. Attack Effects Layer
 
-- [ ] 3.1 Create `src/components/gameplay/effects/AttackEffectsLayer.tsx`
-- [ ] 3.2 Subscribes to `AttackResolved` events
-- [ ] 3.3 For each hit, emits the appropriate primitive + impact flash
-- [ ] 3.4 For each miss, emits a faded primitive that terminates past
+- [x] 3.1 Create `src/components/gameplay/effects/AttackEffectsLayer.tsx`
+- [x] 3.2 Subscribes to `AttackResolved` events
+- [x] 3.3 For each hit, emits the appropriate primitive + impact flash
+- [x] 3.4 For each miss, emits a faded primitive that terminates past
       the target hex
-- [ ] 3.5 Layer sits above the token layer, `pointer-events: none` so
+- [x] 3.5 Layer sits above the token layer, `pointer-events: none` so
       click-through is preserved
 
 ## 4. Miss vs Hit Differentiation
 
-- [ ] 4.1 Hit: full opacity primitive ending at target center; impact
+- [x] 4.1 Hit: full opacity primitive ending at target center; impact
       flash at target
-- [ ] 4.2 Miss: 40% opacity primitive overshooting the target by 1 hex
+- [x] 4.2 Miss: 40% opacity primitive overshooting the target by 1 hex
       in the attack direction; no impact flash
-- [ ] 4.3 Partial (cluster half-hit) renders split dashes: solid hit
+- [x] 4.3 Partial (cluster half-hit) renders split dashes: solid hit
       portion, faded miss portion
-- [ ] 4.4 Unit tests for each variant
+- [x] 4.4 Unit tests for each variant
 
 ## 5. Cluster Weapon Staggering
 
-- [ ] 5.1 Multi-missile launchers (LRM/SRM) stagger trails with 30ms
+- [x] 5.1 Multi-missile launchers (LRM/SRM) stagger trails with 30ms
       offset so a salvo reads as multiple missiles
-- [ ] 5.2 Ultra AC double-tap staggers two tracers at 80ms offset
-- [ ] 5.3 Rotary AC burst fires five tracers at 40ms offset
-- [ ] 5.4 Visual stagger does not affect damage math (pure presentation)
+- [x] 5.2 Ultra AC double-tap staggers two tracers at 80ms offset
+- [x] 5.3 Rotary AC burst fires five tracers at 40ms offset
+- [x] 5.4 Visual stagger does not affect damage math (pure presentation)
 
 ## 6. Physical Attack Effects
 
-- [ ] 6.1 Punch: shockwave at target hex, thin ring
-- [ ] 6.2 Kick: shockwave at target hex, thicker ring
-- [ ] 6.3 Club / hatchet / sword: shockwave plus faint arc from attacker
+- [x] 6.1 Punch: shockwave at target hex, thin ring
+- [x] 6.2 Kick: shockwave at target hex, thicker ring
+- [x] 6.3 Club / hatchet / sword: shockwave plus faint arc from attacker
       to target hex
-- [ ] 6.4 Charge / DFA: shockwave at both attacker and target hexes
-- [ ] 6.5 Physical impact flashes use a red tint (distinct from
+- [x] 6.4 Charge / DFA: shockwave at both attacker and target hexes
+- [x] 6.5 Physical impact flashes use a red tint (distinct from
       ballistic white)
 
 ## 7. Event Timing
 
 - [ ] 7.1 Effects queue alongside damage animations in
       `useAnimationQueue`
-- [ ] 7.2 Beam/tracer/trail plays 300-600ms, then impact flash fires
+- [x] 7.2 Beam/tracer/trail plays 300-600ms, then impact flash fires
 - [ ] 7.3 Damage-pip decay fires on impact flash (coordinate with
       `add-damage-feedback-effects`)
 - [ ] 7.4 Phase advancement waits for all queued effects to drain
 
 ## 8. Reduced Motion Fallback
 
-- [ ] 8.1 On `prefers-reduced-motion: reduce`, render a single 300ms
+- [x] 8.1 On `prefers-reduced-motion: reduce`, render a single 300ms
       fading connecting line from origin to target
-- [ ] 8.2 Impact flash is still shown but dimmed to 50% opacity and
+- [x] 8.2 Impact flash is still shown but dimmed to 50% opacity and
       shortened to 80ms
-- [ ] 8.3 Arcs and shockwaves collapse to a static line
-- [ ] 8.4 Unit test: reduced motion path emits only the simplified line
+- [x] 8.3 Arcs and shockwaves collapse to a static line
+- [x] 8.4 Unit test: reduced motion path emits only the simplified line
 
 ## 9. Performance
 
-- [ ] 9.1 Use CSS transforms + opacity animations (no layout thrash)
-- [ ] 9.2 Reuse `<defs>` for glow filters across all beams
+- [x] 9.1 Use CSS transforms + opacity animations (no layout thrash)
+- [x] 9.2 Reuse `<defs>` for glow filters across all beams
 - [ ] 9.3 Budget: 30 concurrent effects at 60 FPS on a 30x30 map
 - [ ] 9.4 Profile regression checked in CI
 
 ## 10. Tests
 
-- [ ] 10.1 Unit test: `weaponEffectMap` returns correct category for
+- [x] 10.1 Unit test: `weaponEffectMap` returns correct category for
       each weapon type
-- [ ] 10.2 Unit test: hit renders full-opacity primitive + flash
-- [ ] 10.3 Unit test: miss renders faded primitive with no flash
+- [x] 10.2 Unit test: hit renders full-opacity primitive + flash
+- [x] 10.3 Unit test: miss renders faded primitive with no flash
 - [ ] 10.4 Integration test: resolving a PPC hit produces a green beam
       and impact flash within 600ms
 - [ ] 10.5 Integration test: LRM-20 hit produces 20 staggered trails

--- a/openspec/changes/add-damage-feedback-effects/tasks.md
+++ b/openspec/changes/add-damage-feedback-effects/tasks.md
@@ -2,108 +2,108 @@
 
 ## 1. Screen Shake Hook
 
-- [ ] 1.1 Create `src/hooks/useScreenShake.ts`
-- [ ] 1.2 Exposes `shake(intensity, duration)` which offsets the map
+- [x] 1.1 Create `src/hooks/useScreenShake.ts`
+- [x] 1.2 Exposes `shake(intensity, duration)` which offsets the map
       root by pseudo-random x/y within the intensity radius
-- [ ] 1.3 Subscribes to `DamageApplied` events, fires shake when hit
+- [x] 1.3 Subscribes to `DamageApplied` events, fires shake when hit
       damage >= 10
-- [ ] 1.4 Intensity scales linearly with damage, clamped at 8px
-- [ ] 1.5 Duration fixed at 300ms
-- [ ] 1.6 Reduced motion halves amplitude and skips if intensity < 2px
+- [x] 1.4 Intensity scales linearly with damage, clamped at 8px
+- [x] 1.5 Duration fixed at 300ms
+- [x] 1.6 Reduced motion halves amplitude and skips if intensity < 2px
 
 ## 2. Hit Location Flash
 
-- [ ] 2.1 Create `src/components/gameplay/effects/HitLocationFlash.tsx`
-- [ ] 2.2 On `DamageApplied`, flash the specific pip group white at
+- [x] 2.1 Create `src/components/gameplay/effects/HitLocationFlash.tsx`
+- [x] 2.2 On `DamageApplied`, flash the specific pip group white at
       60% opacity for 250ms
-- [ ] 2.3 Works for both attached location (RA, LT, etc.) and
+- [x] 2.3 Works for both attached location (RA, LT, etc.) and
       transferred locations
-- [ ] 2.4 Stacks with armor-pip decay already defined in
+- [x] 2.4 Stacks with armor-pip decay already defined in
       `add-damage-feedback-ui`
 
 ## 3. Smoke Puff
 
-- [ ] 3.1 Create `src/components/gameplay/effects/SmokePuff.tsx`
-- [ ] 3.2 Renders a looping animated smoke sprite near the location's
+- [x] 3.1 Create `src/components/gameplay/effects/SmokePuff.tsx`
+- [x] 3.2 Renders a looping animated smoke sprite near the location's
       pip group
-- [ ] 3.3 Activates when a location is destroyed (structure = 0 or
+- [x] 3.3 Activates when a location is destroyed (structure = 0 or
       location marked destroyed)
-- [ ] 3.4 Persists until the unit dies or is removed
-- [ ] 3.5 Supports multiple concurrent smoke streams per unit (one per
+- [x] 3.4 Persists until the unit dies or is removed
+- [x] 3.5 Supports multiple concurrent smoke streams per unit (one per
       destroyed location)
 
 ## 4. Engine Fire
 
-- [ ] 4.1 Create `src/components/gameplay/effects/EngineFire.tsx`
-- [ ] 4.2 Triggered on engine critical hit events
-- [ ] 4.3 Renders a small animated flame at the unit's torso anchor
-- [ ] 4.4 Persists until the unit dies
-- [ ] 4.5 Second engine crit intensifies the flame (larger, brighter)
+- [x] 4.1 Create `src/components/gameplay/effects/EngineFire.tsx`
+- [x] 4.2 Triggered on engine critical hit events
+- [x] 4.3 Renders a small animated flame at the unit's torso anchor
+- [x] 4.4 Persists until the unit dies
+- [x] 4.5 Second engine crit intensifies the flame (larger, brighter)
 
 ## 5. Debris Cloud + Wreck Sprite
 
-- [ ] 5.1 Create `src/components/gameplay/effects/DebrisCloud.tsx`
-- [ ] 5.2 Triggered on `UnitDestroyed` event
-- [ ] 5.3 Plays 800ms debris burst centered on the token
-- [ ] 5.4 Token transitions to a wreck sprite variant (homemade, per
+- [x] 5.1 Create `src/components/gameplay/effects/DebrisCloud.tsx`
+- [x] 5.2 Triggered on `UnitDestroyed` event
+- [x] 5.3 Plays 800ms debris burst centered on the token
+- [x] 5.4 Token transitions to a wreck sprite variant (homemade, per
       archetype) with ~50% opacity
 - [ ] 5.5 Wreck remains on the hex blocking LOS per existing rules
-- [ ] 5.6 Persistent smoke / fire from this unit clear when it becomes
+- [x] 5.6 Persistent smoke / fire from this unit clear when it becomes
       a wreck (replaced by a single quieter smoke stream)
 
 ## 6. Event Subscriptions
 
-- [ ] 6.1 `HitLocationFlash` subscribes to `DamageApplied`
-- [ ] 6.2 `SmokePuff` subscribes to `LocationDestroyed`
-- [ ] 6.3 `EngineFire` subscribes to `CriticalHit` events where slot =
+- [x] 6.1 `HitLocationFlash` subscribes to `DamageApplied`
+- [x] 6.2 `SmokePuff` subscribes to `LocationDestroyed`
+- [x] 6.3 `EngineFire` subscribes to `CriticalHit` events where slot =
       ENGINE
-- [ ] 6.4 `DebrisCloud` subscribes to `UnitDestroyed`
-- [ ] 6.5 Screen shake subscribes to `DamageApplied`
-- [ ] 6.6 All subscriptions tear down on unmount
+- [x] 6.4 `DebrisCloud` subscribes to `UnitDestroyed`
+- [x] 6.5 Screen shake subscribes to `DamageApplied`
+- [x] 6.6 All subscriptions tear down on unmount
 
 ## 7. Persistent Effect Layer
 
-- [ ] 7.1 Create `PersistentEffectsLayer.tsx` rendering smoke and fire
+- [x] 7.1 Create `PersistentEffectsLayer.tsx` rendering smoke and fire
       across every live unit with destroyed parts / engine damage
-- [ ] 7.2 Layer reads derived state (not events) so persistent effects
+- [x] 7.2 Layer reads derived state (not events) so persistent effects
       survive page reload / replay
 - [ ] 7.3 Layer sits between sprite-ring and selection ring
 
 ## 8. Reduced Motion
 
-- [ ] 8.1 Screen shake halves amplitude and skips tiny shakes
-- [ ] 8.2 Smoke and fire reduce to a static icon (no animation)
-- [ ] 8.3 Debris cloud collapses to a single frame puff
-- [ ] 8.4 Hit location flash becomes an instant color change for 80ms
+- [x] 8.1 Screen shake halves amplitude and skips tiny shakes
+- [x] 8.2 Smoke and fire reduce to a static icon (no animation)
+- [x] 8.3 Debris cloud collapses to a single frame puff
+- [x] 8.4 Hit location flash becomes an instant color change for 80ms
 
 ## 9. Accessibility
 
-- [ ] 9.1 Screen shake announces via `aria-live` "heavy hit" when
+- [x] 9.1 Screen shake announces via `aria-live` "heavy hit" when
       triggered
-- [ ] 9.2 Persistent smoke / fire include `<title>` SVG elements for
+- [x] 9.2 Persistent smoke / fire include `<title>` SVG elements for
       screen readers
-- [ ] 9.3 Destroyed units render a textual "WRECK" badge on the token
+- [x] 9.3 Destroyed units render a textual "WRECK" badge on the token
       for colorblind-safe legibility
 
 ## 10. Performance
 
-- [ ] 10.1 Smoke and fire use a single shared SVG animation definition
+- [x] 10.1 Smoke and fire use a single shared SVG animation definition
       referenced via `<use>`
-- [ ] 10.2 Screen shake uses CSS transform only on the map root
+- [x] 10.2 Screen shake uses CSS transform only on the map root
       (doesn't invalidate children)
-- [ ] 10.3 Wreck sprite replaces live sprite — no double render
+- [x] 10.3 Wreck sprite replaces live sprite — no double render
 - [ ] 10.4 Budget: 20 concurrent persistent effects at 60 FPS
 
 ## 11. Tests
 
-- [ ] 11.1 Unit test: screen shake intensity scales with damage
-- [ ] 11.2 Unit test: hit location flash targets correct pip group
-- [ ] 11.3 Unit test: smoke activates on LocationDestroyed
-- [ ] 11.4 Unit test: engine fire activates on engine crit
-- [ ] 11.5 Unit test: debris cloud + wreck transition on UnitDestroyed
+- [x] 11.1 Unit test: screen shake intensity scales with damage
+- [x] 11.2 Unit test: hit location flash targets correct pip group
+- [x] 11.3 Unit test: smoke activates on LocationDestroyed
+- [x] 11.4 Unit test: engine fire activates on engine crit
+- [x] 11.5 Unit test: debris cloud + wreck transition on UnitDestroyed
 - [ ] 11.6 Integration test: unit takes 25-damage CT hit — shake
       triggers, pip flashes, no destruction events fire
-- [ ] 11.7 Integration test: unit destroyed — cloud plays, wreck sprite
+- [x] 11.7 Integration test: unit destroyed — cloud plays, wreck sprite
       appears, prior smoke streams collapse
 
 ## 12. Spec Compliance

--- a/openspec/changes/add-heat-and-shutdown-visual-indicators/tasks.md
+++ b/openspec/changes/add-heat-and-shutdown-visual-indicators/tasks.md
@@ -2,92 +2,92 @@
 
 ## 1. Heat Visual Map
 
-- [ ] 1.1 Create `src/utils/effects/heatVisualMap.ts`
-- [ ] 1.2 Thresholds: 0-4 neutral, 5-9 amber glow, 10-14 orange glow,
+- [x] 1.1 Create `src/utils/effects/heatVisualMap.ts`
+- [x] 1.2 Thresholds: 0-4 neutral, 5-9 amber glow, 10-14 orange glow,
       15-19 red glow, 20+ red-white glow with subtle pulse
-- [ ] 1.3 Map heat level to `{color, intensity, pulse}` tuple
-- [ ] 1.4 Unit tests for every threshold boundary
+- [x] 1.3 Map heat level to `{color, intensity, pulse}` tuple
+- [x] 1.4 Unit tests for every threshold boundary
 
 ## 2. HeatGlow Component
 
-- [ ] 2.1 Create `src/components/gameplay/effects/HeatGlow.tsx`
-- [ ] 2.2 Renders a radial glow around the sprite using SVG filter
-- [ ] 2.3 Smoothly transitions between thresholds over 300ms
-- [ ] 2.4 Pulse animation only above heat 20 (1.5s period, subtle)
-- [ ] 2.5 Layer sits above sprite + armor pips, below selection ring
+- [x] 2.1 Create `src/components/gameplay/effects/HeatGlow.tsx`
+- [x] 2.2 Renders a radial glow around the sprite using SVG filter
+- [x] 2.3 Smoothly transitions between thresholds over 300ms
+- [x] 2.4 Pulse animation only above heat 20 (1.5s period, subtle)
+- [x] 2.5 Layer sits above sprite + armor pips, below selection ring
 
 ## 3. Shutdown Overlay
 
-- [ ] 3.1 Create `src/components/gameplay/effects/ShutdownOverlay.tsx`
-- [ ] 3.2 Desaturates the sprite via `<feColorMatrix>` filter
-- [ ] 3.3 Adds a dim "POWERED DOWN" label beneath the token
-- [ ] 3.4 Subtle flicker (~3s period) hints at failed restart attempts
-- [ ] 3.5 Layer overrides HeatGlow while active (shutdown is definitive)
+- [x] 3.1 Create `src/components/gameplay/effects/ShutdownOverlay.tsx`
+- [x] 3.2 Desaturates the sprite via `<feColorMatrix>` filter
+- [x] 3.3 Adds a dim "POWERED DOWN" label beneath the token
+- [x] 3.4 Subtle flicker (~3s period) hints at failed restart attempts
+- [x] 3.5 Layer overrides HeatGlow while active (shutdown is definitive)
 
 ## 4. Startup Pulse
 
-- [ ] 4.1 Create `src/components/gameplay/effects/StartupPulse.tsx`
-- [ ] 4.2 Triggered on the frame a unit leaves shutdown state
-- [ ] 4.3 Success branch: radial pulse 0 -> 1.2x scale, amber fading
+- [x] 4.1 Create `src/components/gameplay/effects/StartupPulse.tsx`
+- [x] 4.2 Triggered on the frame a unit leaves shutdown state
+- [x] 4.3 Success branch: radial pulse 0 -> 1.2x scale, amber fading
       to neutral over 800ms
-- [ ] 4.4 Failure branch: shorter pulse (400ms) fading to gray,
+- [x] 4.4 Failure branch: shorter pulse (400ms) fading to gray,
       shutdown overlay remains
-- [ ] 4.5 Plays exactly once per restart attempt
+- [x] 4.5 Plays exactly once per restart attempt
 
 ## 5. Ammo Explosion Warning Aura
 
-- [ ] 5.1 Create `src/components/gameplay/effects/AmmoExplosionAura.tsx`
-- [ ] 5.2 Triggered when heat level would risk ammo cookoff per
+- [x] 5.1 Create `src/components/gameplay/effects/AmmoExplosionAura.tsx`
+- [x] 5.2 Triggered when heat level would risk ammo cookoff per
       `heat-overflow-effects` rules
-- [ ] 5.3 Red-purple halo pulsing at 1s period
-- [ ] 5.4 Renders beneath HeatGlow and above sprite
-- [ ] 5.5 Auto-dismisses when heat drops out of danger range
+- [x] 5.3 Red-purple halo pulsing at 1s period
+- [x] 5.4 Renders beneath HeatGlow and above sprite
+- [x] 5.5 Auto-dismisses when heat drops out of danger range
 
 ## 6. Event Subscription
 
-- [ ] 6.1 Token wrappers subscribe to `HeatChanged`, `Shutdown`,
+- [x] 6.1 Token wrappers subscribe to `HeatChanged`, `Shutdown`,
       `Startup`, `AmmoExplosionRiskEntered`, `AmmoExplosionRiskExited`
-- [ ] 6.2 Effects update per subscription, not per tick
-- [ ] 6.3 Subscriptions tear down on unmount
+- [x] 6.2 Effects update per subscription, not per tick
+- [x] 6.3 Subscriptions tear down on unmount
 
 ## 7. Layering Rules
 
-- [ ] 7.1 Sprite (bottom)
-- [ ] 7.2 Armor pip ring (above sprite)
-- [ ] 7.3 Ammo explosion aura (above pips)
-- [ ] 7.4 Heat glow (above aura, unless shutdown)
-- [ ] 7.5 Shutdown overlay (overrides heat glow entirely)
-- [ ] 7.6 Startup pulse (transient, above shutdown overlay)
-- [ ] 7.7 Selection ring (always top)
+- [x] 7.1 Sprite (bottom)
+- [x] 7.2 Armor pip ring (above sprite)
+- [x] 7.3 Ammo explosion aura (above pips)
+- [x] 7.4 Heat glow (above aura, unless shutdown)
+- [x] 7.5 Shutdown overlay (overrides heat glow entirely)
+- [x] 7.6 Startup pulse (transient, above shutdown overlay)
+- [x] 7.7 Selection ring (always top)
 
 ## 8. Reduced Motion
 
-- [ ] 8.1 Detect `prefers-reduced-motion: reduce`
-- [ ] 8.2 HeatGlow collapses to a static colored outline matching the
+- [x] 8.1 Detect `prefers-reduced-motion: reduce`
+- [x] 8.2 HeatGlow collapses to a static colored outline matching the
       current threshold (no pulse)
-- [ ] 8.3 Shutdown overlay removes flicker
-- [ ] 8.4 Startup pulse becomes a single color snap
-- [ ] 8.5 Ammo explosion aura becomes a static ring
+- [x] 8.3 Shutdown overlay removes flicker
+- [x] 8.4 Startup pulse becomes a single color snap
+- [x] 8.5 Ammo explosion aura becomes a static ring
 
 ## 9. Accessibility
 
-- [ ] 9.1 Heat thresholds use both color and a textual badge ("HOT",
+- [x] 9.1 Heat thresholds use both color and a textual badge ("HOT",
       "OVERHEAT", "CRITICAL") on the token when heat >= 15
-- [ ] 9.2 Shutdown state announces via `aria-live` region
-- [ ] 9.3 Colorblind palette uses amber -> orange -> red per heat ramp
+- [x] 9.2 Shutdown state announces via `aria-live` region
+- [x] 9.3 Colorblind palette uses amber -> orange -> red per heat ramp
       (distinguishable without red-green)
 
 ## 10. Tests
 
-- [ ] 10.1 Unit test: `heatVisualMap` resolves correctly at each
+- [x] 10.1 Unit test: `heatVisualMap` resolves correctly at each
       threshold
-- [ ] 10.2 Unit test: HeatGlow transitions between thresholds over
+- [x] 10.2 Unit test: HeatGlow transitions between thresholds over
       300ms
-- [ ] 10.3 Unit test: shutdown overlay desaturates the sprite
-- [ ] 10.4 Unit test: startup pulse plays once per restart
-- [ ] 10.5 Integration test: heat climbs from 0 to 22; glow progresses
+- [x] 10.3 Unit test: shutdown overlay desaturates the sprite
+- [x] 10.4 Unit test: startup pulse plays once per restart
+- [x] 10.5 Integration test: heat climbs from 0 to 22; glow progresses
       through thresholds; at 22, ammo explosion aura activates
-- [ ] 10.6 Integration test: reduced-motion mode renders static
+- [x] 10.6 Integration test: reduced-motion mode renders static
       outlines only
 
 ## 11. Spec Compliance

--- a/openspec/changes/add-los-and-firing-arc-overlays/tasks.md
+++ b/openspec/changes/add-los-and-firing-arc-overlays/tasks.md
@@ -2,62 +2,62 @@
 
 ## 1. Arc Classifier Utility
 
-- [ ] 1.1 Create `src/utils/overlays/arcClassifier.ts`
-- [ ] 1.2 Given a unit (position + facing) and a hex, return
+- [x] 1.1 Create `src/utils/overlays/arcClassifier.ts`
+- [x] 1.2 Given a unit (position + facing) and a hex, return
       `front | left-side | right-side | rear | out-of-arc`
-- [ ] 1.3 Front is the 60-degree wedge centered on facing
-- [ ] 1.4 Sides are the adjacent 60-degree wedges
-- [ ] 1.5 Rear is the 180-degree wedge opposite front (TechManual p.109)
-- [ ] 1.6 Unit tests for every facing x target direction permutation
+- [x] 1.3 Front is the 60-degree wedge centered on facing
+- [x] 1.4 Sides are the adjacent 60-degree wedges
+- [x] 1.5 Rear is the 180-degree wedge opposite front (TechManual p.109)
+- [x] 1.6 Unit tests for every facing x target direction permutation
 
 ## 2. LOS Classifier Utility
 
-- [ ] 2.1 Create `src/utils/overlays/losClassifier.ts`
-- [ ] 2.2 Given origin and target hexes, return
+- [x] 2.1 Create `src/utils/overlays/losClassifier.ts`
+- [x] 2.2 Given origin and target hexes, return
       `{ state: 'clear' | 'partial' | 'blocked', blockers: HexCoord[] }`
-- [ ] 2.3 Use existing engine LOS logic (do not reimplement)
-- [ ] 2.4 Partial: at least one hex adds cover but does not fully occlude
-- [ ] 2.5 Blocked: at least one hex fully occludes
-- [ ] 2.6 Unit tests across clear / woods / building / elevation cases
+- [x] 2.3 Use existing engine LOS logic (do not reimplement)
+- [x] 2.4 Partial: at least one hex adds cover but does not fully occlude
+- [x] 2.5 Blocked: at least one hex fully occludes
+- [x] 2.6 Unit tests across clear / woods / building / elevation cases
 
 ## 3. FiringArcOverlay Component
 
-- [ ] 3.1 Create
+- [x] 3.1 Create
       `src/components/gameplay/overlays/FiringArcOverlay.tsx`
 - [ ] 3.2 Subscribes to the selected unit ID from `useGameplayStore`
-- [ ] 3.3 For each hex in the unit's maximum weapon range, shade per
+- [x] 3.3 For each hex in the unit's maximum weapon range, shade per
       arc classifier output
-- [ ] 3.4 Colors: front = green 25% alpha, sides = yellow 20% alpha,
+- [x] 3.4 Colors: front = green 25% alpha, sides = yellow 20% alpha,
       rear = red-pink 25% alpha
-- [ ] 3.5 Hexes out-of-arc render no shading
-- [ ] 3.6 Overlay renders beneath units, above terrain
+- [x] 3.5 Hexes out-of-arc render no shading
+- [x] 3.6 Overlay renders beneath units, above terrain
 
 ## 4. LineOfSightOverlay Component
 
-- [ ] 4.1 Create
+- [x] 4.1 Create
       `src/components/gameplay/overlays/LineOfSightOverlay.tsx`
 - [ ] 4.2 Subscribes to hover state (hovered hex ID)
-- [ ] 4.3 Draws a line from selected unit to hovered hex
-- [ ] 4.4 Clear state: solid green line, 2px
-- [ ] 4.5 Partial state: dashed yellow line, 2px
-- [ ] 4.6 Blocked state: solid red line, 2px, terminating at first
+- [x] 4.3 Draws a line from selected unit to hovered hex
+- [x] 4.4 Clear state: solid green line, 2px
+- [x] 4.5 Partial state: dashed yellow line, 2px
+- [x] 4.6 Blocked state: solid red line, 2px, terminating at first
       blocker
-- [ ] 4.7 Annotate blocking hexes with a small icon (cover / wall /
+- [x] 4.7 Annotate blocking hexes with a small icon (cover / wall /
       woods)
-- [ ] 4.8 Overlay renders above firing arc, below effect layers
+- [x] 4.8 Overlay renders above firing arc, below effect layers
 
 ## 5. Overlay Toggles
 
 - [ ] 5.1 Arcs render only when a friendly unit is selected
-- [ ] 5.2 Arcs hide during movement interpolation animations
-- [ ] 5.3 LOS line renders only when a hex is hovered (not selected)
+- [x] 5.2 Arcs hide during movement interpolation animations
+- [x] 5.3 LOS line renders only when a hex is hovered (not selected)
 - [ ] 5.4 LOS line hides on click (commits attack path elsewhere)
 - [ ] 5.5 User toggle in settings to disable arcs (hotkey: A)
 - [ ] 5.6 User toggle in settings to disable LOS (hotkey: L)
 
 ## 6. Range Filtering
 
-- [ ] 6.1 Arcs shade only hexes within the unit's maximum weapon range
+- [x] 6.1 Arcs shade only hexes within the unit's maximum weapon range
 - [ ] 6.2 Weapon list comes from the unit's configured equipment
 - [ ] 6.3 If the unit has zero operational weapons, only the rear-arc
       shading renders (purely informational)
@@ -66,35 +66,35 @@
 
 ## 7. Blocker Annotations
 
-- [ ] 7.1 Partial-cover hexes annotate the blocker with a "cover" icon
-- [ ] 7.2 Blocked hexes annotate the first blocker with a "wall" icon
-- [ ] 7.3 Annotations use `<title>` SVG elements for screen readers
+- [x] 7.1 Partial-cover hexes annotate the blocker with a "cover" icon
+- [x] 7.2 Blocked hexes annotate the first blocker with a "wall" icon
+- [x] 7.3 Annotations use `<title>` SVG elements for screen readers
 - [ ] 7.4 Annotations fade in/out with the LOS line
 
 ## 8. Accessibility
 
-- [ ] 8.1 Arc shading uses shape overlay (front = up-arrow chevron,
+- [x] 8.1 Arc shading uses shape overlay (front = up-arrow chevron,
       sides = dot, rear = minus) in addition to color for colorblind
-- [ ] 8.2 LOS states announce via `aria-live` on hex hover change
+- [x] 8.2 LOS states announce via `aria-live` on hex hover change
 - [ ] 8.3 Hotkeys (A, L) documented and announced on first use
 
 ## 9. Performance
 
-- [ ] 9.1 Arc classification memoizes per (unit, facing)
-- [ ] 9.2 LOS classification memoizes per (unit, target) for the
+- [x] 9.1 Arc classification memoizes per (unit, facing)
+- [x] 9.2 LOS classification memoizes per (unit, target) for the
       current turn
-- [ ] 9.3 Overlay re-renders only on selection or hover change
+- [x] 9.3 Overlay re-renders only on selection or hover change
 - [ ] 9.4 Budget: arc overlay paints within 4ms on a 30x30 map
 
 ## 10. Tests
 
-- [ ] 10.1 Unit test: arc classifier returns `front` for hexes in the
+- [x] 10.1 Unit test: arc classifier returns `front` for hexes in the
       front wedge across all six facings
-- [ ] 10.2 Unit test: LOS classifier correctly flags blocked through a
+- [x] 10.2 Unit test: LOS classifier correctly flags blocked through a
       building
-- [ ] 10.3 Unit test: partial cover through light woods returns
+- [x] 10.3 Unit test: partial cover through light woods returns
       `partial`
-- [ ] 10.4 Integration test: selecting a unit renders arc shading;
+- [x] 10.4 Integration test: selecting a unit renders arc shading;
       hovering an in-range hex renders a green LOS line
 - [ ] 10.5 Integration test: hovering a hex behind a wall renders a
       red LOS line terminating at the wall

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.tsx
@@ -10,18 +10,20 @@ import type {
   IGameEvent,
 } from '@/types/gameplay';
 
+import { AttackEffectsLayer } from '@/components/gameplay/effects/AttackEffectsLayer';
+import { PersistentEffectsLayer } from '@/components/gameplay/effects/PersistentEffectsLayer';
+import { FiringArcOverlay } from '@/components/gameplay/overlays/FiringArcOverlay';
+import { LineOfSightOverlay } from '@/components/gameplay/overlays/LineOfSightOverlay';
 import { TerrainSymbolDefs } from '@/components/gameplay/terrain/TerrainSymbolDefs';
 import { UnitTokenForType } from '@/components/gameplay/UnitToken/UnitTokenForType';
 import { useAnimationQueue } from '@/stores/useAnimationQueue';
 import { TerrainType } from '@/types/gameplay';
-import { coordToKey } from '@/utils/gameplay/hexMath';
-import { calculateLOS } from '@/utils/gameplay/lineOfSight';
+import { coordToKey, hexDistance } from '@/utils/gameplay/hexMath';
 
 import { HexCell } from './HexCell';
 import {
   MovementCostOverlay,
   CoverOverlay,
-  LOSLine,
   TerrainPatternDefs,
 } from './Overlays';
 import { generateHexesInRadius, hexEquals, hexInList } from './renderHelpers';
@@ -163,23 +165,12 @@ export function HexMapDisplay({
     return { config: { radius }, hexes: hexMap };
   }, [hexTerrain, hexes, radius]);
 
-  const selectedUnitPosition = useMemo(() => {
-    const selectedToken = tokens.find((t) => t.isSelected);
-    return selectedToken?.position ?? null;
-  }, [tokens]);
+  const selectedToken = useMemo(
+    () => tokens.find((t) => t.isSelected) ?? null,
+    [tokens],
+  );
 
-  const losResults = useMemo(() => {
-    if (!interaction.showLOSOverlay || !selectedUnitPosition)
-      return new Map<string, boolean>();
-    const results = new Map<string, boolean>();
-    for (const hex of hexes) {
-      if (hex.q === selectedUnitPosition.q && hex.r === selectedUnitPosition.r)
-        continue;
-      const los = calculateLOS(selectedUnitPosition, hex, hexGrid);
-      results.set(coordToKey(hex), los.hasLOS);
-    }
-    return results;
-  }, [interaction.showLOSOverlay, selectedUnitPosition, hexes, hexGrid]);
+  const selectedUnitPosition = selectedToken?.position ?? null;
 
   const movementAnimationsByUnit = useMemo(() => {
     const lookup = new Map<string, (typeof activeAnimations)[number]>();
@@ -203,6 +194,23 @@ export function HexMapDisplay({
       return aAnimating ? 1 : -1;
     });
   }, [movementAnimationsByUnit, tokens]);
+
+  const hasActiveMovementAnimation = useMemo(
+    () =>
+      activeAnimations.some(
+        (animation) =>
+          animation.mapId === mapId && animation.kind === 'movement',
+      ),
+    [activeAnimations, mapId],
+  );
+
+  const selectedWeaponMaxRange = useMemo(() => {
+    if (!selectedUnitPosition || attackRange.length === 0) return radius;
+    return Math.max(
+      0,
+      ...attackRange.map((hex) => hexDistance(selectedUnitPosition, hex)),
+    );
+  }, [attackRange, radius, selectedUnitPosition]);
 
   const handleHexClick = useCallback(
     (hex: IHexCoordinate) => {
@@ -313,6 +321,34 @@ export function HexMapDisplay({
           })}
         </g>
 
+        {interaction.showLOSOverlay &&
+          selectedToken &&
+          !hasActiveMovementAnimation && (
+            <FiringArcOverlay
+              unit={{
+                coord: selectedToken.position,
+                facing: selectedToken.facing,
+                unitId: selectedToken.unitId,
+              }}
+              hexes={hexes}
+              maxRange={selectedWeaponMaxRange}
+              enabled
+              testId="firing-arc-overlay"
+            />
+          )}
+
+        {interaction.showLOSOverlay &&
+          selectedUnitPosition &&
+          hoveredHex &&
+          !hasActiveMovementAnimation && (
+            <LineOfSightOverlay
+              origin={selectedUnitPosition}
+              target={hoveredHex}
+              grid={hexGrid}
+              testId="los-overlay"
+            />
+          )}
+
         <g>
           {orderedTokens.map((token) => (
             <UnitTokenForType
@@ -327,27 +363,8 @@ export function HexMapDisplay({
           ))}
         </g>
 
-        {interaction.showLOSOverlay && selectedUnitPosition && (
-          <g data-testid="los-overlay">
-            {hexes.map((hex) => {
-              const key = coordToKey(hex);
-              if (
-                hex.q === selectedUnitPosition.q &&
-                hex.r === selectedUnitPosition.r
-              )
-                return null;
-              const hasLOS = losResults.get(key) ?? true;
-              return (
-                <LOSLine
-                  key={`los-${key}`}
-                  from={selectedUnitPosition}
-                  to={hex}
-                  hasLOS={hasLOS}
-                />
-              );
-            })}
-          </g>
-        )}
+        <PersistentEffectsLayer tokens={tokens} events={events} />
+        <AttackEffectsLayer events={events} tokens={tokens} mapId={mapId} />
 
         {interaction.showMovementOverlay && (
           <g data-testid="movement-overlay">

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
@@ -1,10 +1,12 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
-import type { IUnitToken } from '@/types/gameplay';
+import type { IGameEvent, IUnitToken } from '@/types/gameplay';
 
 import { useAnimationQueue } from '@/stores/useAnimationQueue';
 import {
   Facing,
+  GameEventType,
+  GamePhase,
   GameSide,
   MovementType,
   TokenUnitType,
@@ -28,13 +30,34 @@ function makeToken(overrides: Partial<IUnitToken>): IUnitToken {
   };
 }
 
+function makeEvent(
+  type: GameEventType,
+  payload: IGameEvent['payload'],
+  sequence = 1,
+): IGameEvent {
+  return {
+    id: `${type}-${sequence}`,
+    gameId: 'game',
+    sequence,
+    timestamp: `2026-04-29T00:00:0${sequence}.000Z`,
+    type,
+    turn: 1,
+    phase: GamePhase.WeaponAttack,
+    payload,
+  };
+}
+
 describe('HexMapDisplay movement animation ordering', () => {
   beforeEach(() => {
-    useAnimationQueue.getState().reset();
+    act(() => {
+      useAnimationQueue.getState().reset();
+    });
   });
 
   afterEach(() => {
-    useAnimationQueue.getState().reset();
+    act(() => {
+      useAnimationQueue.getState().reset();
+    });
   });
 
   it('renders moving tokens after static tokens so they appear on top', () => {
@@ -75,5 +98,147 @@ describe('HexMapDisplay movement animation ordering', () => {
     act(() => {
       unmount();
     });
+  });
+});
+
+describe('HexMapDisplay tactical visual layers', () => {
+  beforeEach(() => {
+    act(() => {
+      useAnimationQueue.getState().reset();
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      useAnimationQueue.getState().reset();
+    });
+  });
+
+  it('renders hover line-of-sight and firing arc overlays from the LOS toggle', () => {
+    const selected = makeToken({
+      unitId: 'selected',
+      isSelected: true,
+      position: { q: 0, r: 0 },
+      facing: Facing.North,
+    });
+
+    const { unmount } = render(
+      <HexMapDisplay
+        mapId="map-1"
+        radius={1}
+        tokens={[selected]}
+        selectedHex={null}
+        attackRange={[{ q: 1, r: 0 }]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('overlay-toggle-los'));
+    fireEvent.mouseEnter(screen.getByTestId('hex-1-0'));
+
+    expect(screen.getByTestId('firing-arc-overlay')).toBeInTheDocument();
+    expect(screen.getByTestId('los-overlay')).toBeInTheDocument();
+    expect(screen.getByTestId('los-line')).toBeInTheDocument();
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it('suppresses LOS and arc overlays while movement animations are active', () => {
+    const selected = makeToken({
+      unitId: 'selected',
+      isSelected: true,
+      position: { q: 0, r: 0 },
+    });
+    act(() => {
+      useAnimationQueue.getState().enqueue({
+        id: 'move-selected',
+        mapId: 'map-1',
+        unitId: selected.unitId,
+        kind: 'movement',
+        path: [
+          { q: 0, r: 0 },
+          { q: 1, r: 0 },
+        ],
+        mode: MovementType.Walk,
+      });
+    });
+
+    const { unmount } = render(
+      <HexMapDisplay
+        mapId="map-1"
+        radius={1}
+        tokens={[selected]}
+        selectedHex={null}
+        attackRange={[{ q: 1, r: 0 }]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('overlay-toggle-los'));
+    fireEvent.mouseEnter(screen.getByTestId('hex-1-0'));
+
+    expect(screen.queryByTestId('firing-arc-overlay')).toBeNull();
+    expect(screen.queryByTestId('los-overlay')).toBeNull();
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it('mounts attack and persistent damage effect layers from event history', () => {
+    const attacker = makeToken({
+      unitId: 'attacker',
+      position: { q: 0, r: 0 },
+    });
+    const target = makeToken({
+      unitId: 'target',
+      side: GameSide.Opponent,
+      position: { q: 1, r: 0 },
+    });
+    const events = [
+      makeEvent(
+        GameEventType.AttackResolved,
+        {
+          attackerId: 'attacker',
+          targetId: 'target',
+          weaponId: 'medium-laser',
+          roll: 9,
+          toHitNumber: 7,
+          hit: true,
+          damage: 5,
+          location: 'centerTorso',
+          visualCategory: 'laser',
+          visualSubtype: 'medium-laser',
+          projectileCount: 1,
+        },
+        1,
+      ),
+      makeEvent(
+        GameEventType.UnitDestroyed,
+        {
+          unitId: 'target',
+          cause: 'damage',
+          killerUnitId: 'attacker',
+        },
+        2,
+      ),
+    ];
+
+    render(
+      <HexMapDisplay
+        mapId="map-1"
+        radius={1}
+        tokens={[attacker, target]}
+        events={events}
+        selectedHex={null}
+      />,
+    );
+
+    expect(screen.getByTestId('attack-effects-layer')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('attack-effect-event-attack_resolved-1'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('persistent-effects-layer')).toBeInTheDocument();
+    expect(screen.getByTestId('wreck-marker-target')).toBeInTheDocument();
   });
 });

--- a/src/components/gameplay/UnitToken/UnitTokenForType.tsx
+++ b/src/components/gameplay/UnitToken/UnitTokenForType.tsx
@@ -21,18 +21,28 @@ import type { MovementTweenFrame } from '@/components/gameplay/animation/useMove
 import type { DamageFloaterEntry } from '@/components/gameplay/DamageFloater';
 import type { TacticalAnimation } from '@/stores/useAnimationQueue';
 import type {
+  IAmmoExplosionPayload,
   ICriticalHitResolvedPayload,
   IDamageAppliedPayload,
   IGameEvent,
+  IHeatPayload,
   IPilotHitPayload,
+  IShutdownCheckPayload,
+  IStartupAttemptPayload,
   IUnitDestroyedPayload,
   IUnitToken,
 } from '@/types/gameplay';
 
 import { useMovementTween } from '@/components/gameplay/animation/useMovementTween';
+import { AmmoExplosionAura } from '@/components/gameplay/effects/AmmoExplosionAura';
+import { HeatGlow } from '@/components/gameplay/effects/HeatGlow';
+import { HitLocationFlash } from '@/components/gameplay/effects/HitLocationFlash';
+import { ShutdownOverlay } from '@/components/gameplay/effects/ShutdownOverlay';
+import { StartupPulse } from '@/components/gameplay/effects/StartupPulse';
 import { hexToPixel } from '@/components/gameplay/HexMapDisplay/renderHelpers';
 import { useAnimationQueue } from '@/stores/useAnimationQueue';
 import { GameEventType, MovementType, TokenUnitType } from '@/types/gameplay';
+import { getHeatTransitionFromPayload } from '@/utils/effects/heatVisualMap';
 
 import type { IUnitEventState } from './tokenTypes';
 
@@ -144,6 +154,84 @@ function projectEvents(
   };
 }
 
+interface UnitThermalVisualState {
+  readonly heat: number;
+  readonly hasHeatEvent: boolean;
+  readonly isShutdown: boolean;
+  readonly startupAttemptId: number | string | null;
+  readonly startupSucceeded: boolean;
+  readonly ammoExplosionRisk: boolean;
+}
+
+const EMPTY_THERMAL_VISUAL_STATE: UnitThermalVisualState = {
+  heat: 0,
+  hasHeatEvent: false,
+  isShutdown: false,
+  startupAttemptId: null,
+  startupSucceeded: false,
+  ammoExplosionRisk: false,
+};
+
+function projectThermalVisualState(
+  unitId: string,
+  events: readonly IGameEvent[] | undefined,
+): UnitThermalVisualState {
+  if (!events || events.length === 0) return EMPTY_THERMAL_VISUAL_STATE;
+
+  let heat = 0;
+  let hasHeatEvent = false;
+  let isShutdown = false;
+  let startupAttemptId: number | string | null = null;
+  let startupSucceeded = false;
+  let ammoExplosionRisk = false;
+
+  for (const event of events) {
+    switch (event.type) {
+      case GameEventType.HeatGenerated:
+      case GameEventType.HeatDissipated: {
+        const payload = event.payload as IHeatPayload;
+        if (payload.unitId !== unitId) break;
+        const transition = getHeatTransitionFromPayload(payload);
+        heat = transition.currentHeat;
+        hasHeatEvent = true;
+        ammoExplosionRisk = transition.ammoExplosionRisk;
+        break;
+      }
+      case GameEventType.ShutdownCheck: {
+        const payload = event.payload as IShutdownCheckPayload;
+        if (payload.unitId !== unitId) break;
+        if (payload.shutdownOccurred) isShutdown = true;
+        break;
+      }
+      case GameEventType.StartupAttempt: {
+        const payload = event.payload as IStartupAttemptPayload;
+        if (payload.unitId !== unitId) break;
+        startupAttemptId = event.id || event.sequence;
+        startupSucceeded = payload.success;
+        if (payload.success) isShutdown = false;
+        break;
+      }
+      case GameEventType.AmmoExplosion: {
+        const payload = event.payload as IAmmoExplosionPayload;
+        if (payload.unitId !== unitId) break;
+        ammoExplosionRisk = true;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return {
+    heat,
+    hasHeatEvent,
+    isShutdown,
+    startupAttemptId,
+    startupSucceeded,
+    ammoExplosionRisk,
+  };
+}
+
 // =============================================================================
 // Dispatcher Component
 // =============================================================================
@@ -158,6 +246,10 @@ export const UnitTokenForType = React.memo(function UnitTokenForType({
 }: UnitTokenForTypeProps): React.ReactElement | null {
   const eventState = useMemo(
     () => projectEvents(token.unitId, events),
+    [token.unitId, events],
+  );
+  const thermalVisualState = useMemo(
+    () => projectThermalVisualState(token.unitId, events),
     [token.unitId, events],
   );
   const movementAnimationId = movementAnimation?.id;
@@ -251,7 +343,15 @@ export const UnitTokenForType = React.memo(function UnitTokenForType({
   const wrap = (children: React.ReactElement): React.ReactElement => (
     <>
       {jumpArc}
-      <g {...wrapperProps}>{children}</g>
+      <g {...wrapperProps}>
+        <TokenVisualEffects
+          token={token}
+          events={events}
+          thermalVisualState={thermalVisualState}
+        >
+          {children}
+        </TokenVisualEffects>
+      </g>
     </>
   );
 
@@ -287,6 +387,48 @@ export const UnitTokenForType = React.memo(function UnitTokenForType({
       return wrap(<MechToken token={renderToken} eventState={eventState} />);
   }
 });
+
+function TokenVisualEffects({
+  token,
+  events,
+  thermalVisualState,
+  children,
+}: {
+  readonly token: IUnitToken;
+  readonly events?: readonly IGameEvent[];
+  readonly thermalVisualState: UnitThermalVisualState;
+  readonly children: React.ReactElement;
+}): React.ReactElement {
+  const idSuffix = token.unitId;
+
+  return (
+    <>
+      <AmmoExplosionAura
+        active={thermalVisualState.ammoExplosionRisk}
+        heat={thermalVisualState.heat}
+        idSuffix={idSuffix}
+      />
+      {thermalVisualState.hasHeatEvent && (
+        <HeatGlow
+          heat={thermalVisualState.heat}
+          idSuffix={idSuffix}
+          isShutdown={thermalVisualState.isShutdown}
+        />
+      )}
+      {children}
+      <ShutdownOverlay
+        active={thermalVisualState.isShutdown}
+        idSuffix={idSuffix}
+        unitName={token.name}
+      />
+      <StartupPulse
+        attemptId={thermalVisualState.startupAttemptId}
+        success={thermalVisualState.startupSucceeded}
+      />
+      <HitLocationFlash unitId={token.unitId} events={events} />
+    </>
+  );
+}
 
 function renderJumpArc(
   unitId: string,

--- a/src/components/gameplay/UnitToken/__tests__/UnitTokenForType.test.tsx
+++ b/src/components/gameplay/UnitToken/__tests__/UnitTokenForType.test.tsx
@@ -16,7 +16,7 @@
 import { act, render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
-import type { IUnitToken } from '@/types/gameplay';
+import type { IGameEvent, IUnitToken } from '@/types/gameplay';
 
 import { useAnimationQueue } from '@/stores/useAnimationQueue';
 import {
@@ -24,6 +24,8 @@ import {
   TokenUnitType,
   Facing,
   MovementType,
+  GameEventType,
+  GamePhase,
 } from '@/types/gameplay';
 
 import { UnitTokenForType } from '../UnitTokenForType';
@@ -54,6 +56,23 @@ function makeToken(overrides: Partial<IUnitToken> = {}): IUnitToken {
   };
 }
 
+function makeEvent(
+  type: GameEventType,
+  payload: IGameEvent['payload'],
+  sequence = 1,
+): IGameEvent {
+  return {
+    id: `${type}-${sequence}`,
+    gameId: 'game',
+    sequence,
+    timestamp: `2026-04-29T00:00:0${sequence}.000Z`,
+    type,
+    turn: 1,
+    phase: GamePhase.Heat,
+    payload,
+  };
+}
+
 // =============================================================================
 // Dispatcher routing — each unitType → correct wrapper data-testid
 // =============================================================================
@@ -63,11 +82,15 @@ describe('UnitTokenForType dispatcher routing', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    useAnimationQueue.getState().reset();
+    act(() => {
+      useAnimationQueue.getState().reset();
+    });
   });
 
   afterEach(() => {
-    useAnimationQueue.getState().reset();
+    act(() => {
+      useAnimationQueue.getState().reset();
+    });
   });
 
   it('renders a <g> with data-testid="unit-token-unit-1" for any token', () => {
@@ -286,15 +309,126 @@ describe('UnitTokenForType event projection', () => {
     // MechToken renders data-testid="unit-destroyed-overlay" when destroyed.
     expect(screen.getByTestId('unit-destroyed-overlay')).toBeInTheDocument();
   });
+
+  it('projects heat events into token heat and ammo-risk visuals', () => {
+    const token = makeToken({ unitId: 'hot-mech' });
+    renderInSvg(
+      <UnitTokenForType
+        token={token}
+        onClick={jest.fn()}
+        events={[
+          makeEvent(GameEventType.HeatGenerated, {
+            unitId: 'hot-mech',
+            amount: 10,
+            source: 'firing',
+            previousTotal: 8,
+            newTotal: 19,
+            ammoExplosionRisk: true,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('heat-glow')).toHaveAttribute(
+      'data-heat-threshold',
+      'overheat',
+    );
+    expect(screen.getByTestId('ammo-explosion-aura')).toHaveAttribute(
+      'data-risk-heat',
+      '19',
+    );
+  });
+
+  it('keeps shutdown visible after a failed startup attempt', () => {
+    const token = makeToken({ unitId: 'shutdown-mech' });
+    renderInSvg(
+      <UnitTokenForType
+        token={token}
+        onClick={jest.fn()}
+        events={[
+          makeEvent(
+            GameEventType.ShutdownCheck,
+            {
+              unitId: 'shutdown-mech',
+              heatLevel: 18,
+              targetNumber: 6,
+              roll: 4,
+              shutdownOccurred: true,
+            },
+            1,
+          ),
+          makeEvent(
+            GameEventType.StartupAttempt,
+            {
+              unitId: 'shutdown-mech',
+              targetNumber: 6,
+              roll: 5,
+              success: false,
+            },
+            2,
+          ),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('shutdown-overlay')).toBeInTheDocument();
+    expect(screen.getByTestId('startup-pulse')).toHaveAttribute(
+      'data-outcome',
+      'failure',
+    );
+  });
+
+  it('clears shutdown after a successful startup attempt', () => {
+    const token = makeToken({ unitId: 'restarted-mech' });
+    renderInSvg(
+      <UnitTokenForType
+        token={token}
+        onClick={jest.fn()}
+        events={[
+          makeEvent(
+            GameEventType.ShutdownCheck,
+            {
+              unitId: 'restarted-mech',
+              heatLevel: 18,
+              targetNumber: 6,
+              roll: 4,
+              shutdownOccurred: true,
+            },
+            1,
+          ),
+          makeEvent(
+            GameEventType.StartupAttempt,
+            {
+              unitId: 'restarted-mech',
+              targetNumber: 6,
+              roll: 8,
+              success: true,
+            },
+            2,
+          ),
+        ]}
+      />,
+    );
+
+    expect(screen.queryByTestId('shutdown-overlay')).toBeNull();
+    expect(screen.getByTestId('startup-pulse')).toHaveAttribute(
+      'data-outcome',
+      'success',
+    );
+  });
 });
 
 describe('UnitTokenForType movement animation integration', () => {
   beforeEach(() => {
-    useAnimationQueue.getState().reset();
+    act(() => {
+      useAnimationQueue.getState().reset();
+    });
   });
 
   afterEach(() => {
-    useAnimationQueue.getState().reset();
+    act(() => {
+      useAnimationQueue.getState().reset();
+    });
   });
 
   it('renders an active movement at the tween start and completes it on unmount', () => {

--- a/src/components/gameplay/effects/AmmoExplosionAura.tsx
+++ b/src/components/gameplay/effects/AmmoExplosionAura.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+import { isAmmoExplosionDangerHeat } from '@/utils/effects/heatVisualMap';
+
+export interface AmmoExplosionAuraProps {
+  readonly active?: boolean;
+  readonly heat?: number;
+  readonly idSuffix?: string;
+  readonly radius?: number;
+}
+
+const DEFAULT_RADIUS = 39;
+const AURA_RED = '#dc2626';
+const AURA_PURPLE = '#a21caf';
+
+export function AmmoExplosionAura({
+  active,
+  heat = 0,
+  idSuffix = 'unit',
+  radius = DEFAULT_RADIUS,
+}: AmmoExplosionAuraProps): React.ReactElement | null {
+  const reducedMotion = usePrefersReducedMotion();
+  const isActive = active ?? isAmmoExplosionDangerHeat(heat);
+
+  if (!isActive) return null;
+
+  const filterId = `ammo-explosion-aura-${toSvgIdSuffix(idSuffix)}`;
+  const shouldPulse = !reducedMotion;
+
+  return (
+    <g
+      data-testid="ammo-explosion-aura"
+      data-layer-order="ammo-explosion-aura"
+      data-dismiss-transition-ms="300"
+      data-pulse={shouldPulse ? 'true' : 'false'}
+      data-reduced-motion={reducedMotion ? 'true' : 'false'}
+      data-risk-heat={String(heat)}
+      pointerEvents="none"
+      role="img"
+      aria-label={`Ammo explosion risk at heat ${heat}`}
+    >
+      <defs>
+        <filter
+          id={filterId}
+          data-testid="ammo-explosion-aura-filter"
+          x="-80%"
+          y="-80%"
+          width="260%"
+          height="260%"
+        >
+          <feGaussianBlur
+            in="SourceGraphic"
+            stdDeviation={reducedMotion ? 2 : 4}
+            result="ammoAuraBlur"
+          />
+          <feMerge>
+            <feMergeNode in="ammoAuraBlur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+      </defs>
+
+      <circle
+        data-testid="ammo-explosion-aura-halo"
+        cx="0"
+        cy="0"
+        r={radius}
+        fill="none"
+        stroke={AURA_PURPLE}
+        strokeWidth="5"
+        opacity={reducedMotion ? 0.82 : 0.58}
+        filter={`url(#${filterId})`}
+        style={{
+          transition: reducedMotion
+            ? 'none'
+            : 'opacity 300ms ease, stroke 300ms ease',
+        }}
+        pointerEvents="none"
+      >
+        {shouldPulse && (
+          <animate
+            data-testid="ammo-explosion-aura-pulse"
+            attributeName="opacity"
+            values="0.45;0.84;0.45"
+            dur="1s"
+            repeatCount="indefinite"
+          />
+        )}
+      </circle>
+
+      <circle
+        data-testid="ammo-explosion-aura-red-ring"
+        cx="0"
+        cy="0"
+        r={round(radius * 0.86)}
+        fill="none"
+        stroke={AURA_RED}
+        strokeWidth="2"
+        opacity="0.82"
+        pointerEvents="none"
+      />
+    </g>
+  );
+}
+
+function toSvgIdSuffix(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '-');
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/src/components/gameplay/effects/AttackEffectsLayer.tsx
+++ b/src/components/gameplay/effects/AttackEffectsLayer.tsx
@@ -1,0 +1,468 @@
+import React, { useMemo } from 'react';
+
+import type { IGameEvent, IHexCoordinate, IUnitToken } from '@/types/gameplay';
+
+import { hexToPixel } from '@/components/gameplay/HexMapDisplay/renderHelpers';
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+import {
+  GameEventType,
+  type IAttackResolvedPayload,
+  type IPhysicalAttackResolvedPayload,
+} from '@/types/gameplay';
+import {
+  resolveAttackEventEffect,
+  type AttackEffectPayloadHints,
+  type PhysicalAttackEffectPayload,
+  type WeaponEffectDescriptor,
+} from '@/utils/effects/weaponEffectMap';
+
+import {
+  AttackEffectDefs,
+  AttackEffectStyles,
+  ImpactFlash,
+  LaserBeam,
+  MissileTrail,
+  ReducedMotionLine,
+  Shockwave,
+  Tracer,
+  type EffectPoint,
+} from './primitives';
+
+export interface AttackEffectsLayerProps {
+  readonly events: readonly IGameEvent[];
+  readonly tokens: readonly IUnitToken[];
+  readonly mapId: string;
+  readonly testId?: string;
+}
+
+interface AttackGeometryHints {
+  readonly from?: IHexCoordinate;
+  readonly to?: IHexCoordinate;
+  readonly origin?: IHexCoordinate;
+  readonly target?: IHexCoordinate;
+}
+
+interface ClusterVisualHints {
+  readonly hitProjectiles?: number;
+  readonly projectilesHit?: number;
+  readonly missilesHit?: number;
+  readonly clusterHitCount?: number;
+  readonly missedProjectiles?: number;
+  readonly projectilesMissed?: number;
+  readonly missilesMissed?: number;
+  readonly clusterMissCount?: number;
+}
+
+type AttackLayerPayload = IAttackResolvedPayload &
+  AttackEffectPayloadHints &
+  AttackGeometryHints &
+  ClusterVisualHints;
+
+type PhysicalLayerPayload = IPhysicalAttackResolvedPayload &
+  PhysicalAttackEffectPayload &
+  AttackGeometryHints &
+  ClusterVisualHints;
+
+type SupportedAttackEvent =
+  | {
+      readonly event: IGameEvent;
+      readonly payload: AttackLayerPayload;
+      readonly physical: false;
+    }
+  | {
+      readonly event: IGameEvent;
+      readonly payload: PhysicalLayerPayload;
+      readonly physical: true;
+    };
+
+interface AttackGeometry {
+  readonly fromHex: IHexCoordinate;
+  readonly toHex: IHexCoordinate;
+  readonly start: EffectPoint;
+  readonly target: EffectPoint;
+  readonly overshoot: EffectPoint;
+}
+
+interface ProjectileBreakdown {
+  readonly hitCount: number;
+  readonly missCount: number;
+}
+
+const MISS_OPACITY = 0.4;
+const HEX_DIRECTIONS: readonly IHexCoordinate[] = [
+  { q: 1, r: 0 },
+  { q: 1, r: -1 },
+  { q: 0, r: -1 },
+  { q: -1, r: 0 },
+  { q: -1, r: 1 },
+  { q: 0, r: 1 },
+];
+
+export function AttackEffectsLayer({
+  events,
+  tokens,
+  mapId,
+  testId = 'attack-effects-layer',
+}: AttackEffectsLayerProps): React.ReactElement {
+  const reducedMotion = usePrefersReducedMotion();
+  const tokenById = useMemo(() => {
+    const byId = new Map<string, IUnitToken>();
+    for (const token of tokens) byId.set(token.unitId, token);
+    return byId;
+  }, [tokens]);
+
+  const effectEvents = useMemo(
+    () =>
+      events
+        .map(toSupportedAttackEvent)
+        .filter((event): event is SupportedAttackEvent => event !== null),
+    [events],
+  );
+
+  return (
+    <g
+      pointerEvents="none"
+      style={{ pointerEvents: 'none' }}
+      data-testid={testId}
+      data-map-id={mapId}
+    >
+      <AttackEffectStyles />
+      <AttackEffectDefs />
+      {effectEvents.map((entry) =>
+        renderAttackEvent(entry, tokenById, reducedMotion),
+      )}
+    </g>
+  );
+}
+
+function toSupportedAttackEvent(
+  event: IGameEvent,
+): SupportedAttackEvent | null {
+  if (event.type === GameEventType.AttackResolved) {
+    return {
+      event,
+      payload: event.payload as AttackLayerPayload,
+      physical: false,
+    };
+  }
+  if (event.type === GameEventType.PhysicalAttackResolved) {
+    return {
+      event,
+      payload: event.payload as PhysicalLayerPayload,
+      physical: true,
+    };
+  }
+  return null;
+}
+
+function renderAttackEvent(
+  entry: SupportedAttackEvent,
+  tokenById: ReadonlyMap<string, IUnitToken>,
+  reducedMotion: boolean,
+): React.ReactElement | null {
+  const effect = resolveAttackEventEffect(entry.event);
+  if (!effect) return null;
+
+  const geometry = resolveGeometry(entry.payload, tokenById);
+  if (!geometry) return null;
+
+  const breakdown = projectileBreakdown(entry.payload, effect.projectileCount);
+  const eventId = entry.event.id;
+  const flashDelay = reducedMotion ? 0 : effect.durationMs;
+  const hasImpact = breakdown.hitCount > 0;
+
+  return (
+    <g
+      key={eventId}
+      pointerEvents="none"
+      data-testid={`attack-effect-event-${eventId}`}
+      data-event-id={eventId}
+      data-category={effect.category}
+      data-primitive={effect.primitive}
+      data-visual-subtype={effect.visualSubtype}
+      data-projectile-count={effect.projectileCount}
+      data-hit-projectiles={breakdown.hitCount}
+      data-miss-projectiles={breakdown.missCount}
+      data-stagger-ms={effect.staggerMs}
+    >
+      {reducedMotion ? (
+        <ReducedMotionLine
+          start={geometry.start}
+          end={geometry.target}
+          color={effect.color}
+          opacity={entry.payload.hit ? 0.7 : MISS_OPACITY}
+          testId={`attack-effect-reduced-line-${eventId}`}
+        />
+      ) : (
+        <>
+          {renderPrimaryEffects({
+            eventId,
+            effect,
+            geometry,
+            hitCount: breakdown.hitCount,
+            missCount: breakdown.missCount,
+          })}
+        </>
+      )}
+      {hasImpact && (
+        <ImpactFlash
+          center={geometry.target}
+          color={effect.impactColor}
+          delayMs={flashDelay}
+          reducedMotion={reducedMotion}
+          testId={`attack-effect-impact-flash-${eventId}`}
+        />
+      )}
+    </g>
+  );
+}
+
+function renderPrimaryEffects(params: {
+  readonly eventId: string;
+  readonly effect: WeaponEffectDescriptor;
+  readonly geometry: AttackGeometry;
+  readonly hitCount: number;
+  readonly missCount: number;
+}): readonly React.ReactElement[] {
+  const elements: React.ReactElement[] = [];
+  if (params.effect.category === 'physical') {
+    elements.push(
+      ...renderPhysicalEffects({
+        eventId: params.eventId,
+        effect: params.effect,
+        geometry: params.geometry,
+        hitCount: params.hitCount,
+        missCount: params.missCount,
+      }),
+    );
+    return elements;
+  }
+
+  for (let index = 0; index < params.hitCount; index++) {
+    elements.push(
+      renderPrimitiveInstance({
+        eventId: params.eventId,
+        effect: params.effect,
+        geometry: params.geometry,
+        end: params.geometry.target,
+        opacity: 1,
+        outcome: 'hit',
+        projectileIndex: index,
+      }),
+    );
+  }
+
+  for (let index = 0; index < params.missCount; index++) {
+    const projectileIndex = params.hitCount + index;
+    elements.push(
+      renderPrimitiveInstance({
+        eventId: params.eventId,
+        effect: params.effect,
+        geometry: params.geometry,
+        end: params.geometry.overshoot,
+        opacity: MISS_OPACITY,
+        outcome: 'miss',
+        projectileIndex,
+      }),
+    );
+  }
+
+  return elements;
+}
+
+function renderPhysicalEffects(params: {
+  readonly eventId: string;
+  readonly effect: WeaponEffectDescriptor;
+  readonly geometry: AttackGeometry;
+  readonly hitCount: number;
+  readonly missCount: number;
+}): readonly React.ReactElement[] {
+  const elements: React.ReactElement[] = [];
+  const targetCenter =
+    params.hitCount > 0 ? params.geometry.target : params.geometry.overshoot;
+  const outcome = params.hitCount > 0 ? 'hit' : 'miss';
+  const opacity = params.hitCount > 0 ? 1 : MISS_OPACITY;
+
+  if (params.effect.originShockwave) {
+    elements.push(
+      <Shockwave
+        key={`${params.eventId}-physical-origin`}
+        center={params.geometry.start}
+        color={params.effect.color}
+        opacity={opacity}
+        durationMs={params.effect.durationMs}
+        strokeWidth={params.effect.ringStrokeWidth}
+        testId={`attack-effect-shockwave-${params.eventId}-origin`}
+      />,
+    );
+  }
+
+  elements.push(
+    <Shockwave
+      key={`${params.eventId}-physical-${outcome}`}
+      center={targetCenter}
+      color={params.effect.color}
+      opacity={opacity}
+      durationMs={params.effect.durationMs}
+      strokeWidth={params.effect.ringStrokeWidth}
+      testId={`attack-effect-shockwave-${params.eventId}-${outcome}`}
+    />,
+  );
+
+  if (params.effect.showArc) {
+    elements.push(
+      <LaserBeam
+        key={`${params.eventId}-physical-arc`}
+        start={params.geometry.start}
+        end={targetCenter}
+        color={params.effect.color}
+        opacity={opacity * 0.28}
+        durationMs={params.effect.durationMs}
+        testId={`attack-effect-physical-arc-${params.eventId}-${outcome}`}
+      />,
+    );
+  }
+
+  return elements;
+}
+
+function renderPrimitiveInstance(params: {
+  readonly eventId: string;
+  readonly effect: WeaponEffectDescriptor;
+  readonly geometry: AttackGeometry;
+  readonly end: EffectPoint;
+  readonly opacity: number;
+  readonly outcome: 'hit' | 'miss';
+  readonly projectileIndex: number;
+}): React.ReactElement {
+  const testId = `attack-effect-${params.effect.primitive}-${params.eventId}-${params.outcome}-${params.projectileIndex}`;
+  const key = `${params.eventId}-${params.outcome}-${params.projectileIndex}`;
+  const common = {
+    start: params.geometry.start,
+    end: params.end,
+    color: params.effect.color,
+    opacity: params.opacity,
+    durationMs: params.effect.durationMs,
+    projectileIndex: params.projectileIndex,
+    projectileCount: params.effect.projectileCount,
+    staggerMs: params.effect.staggerMs,
+    testId,
+    reducedMotion: false,
+  } as const;
+
+  return (
+    <g
+      key={key}
+      pointerEvents="none"
+      data-testid={`attack-effect-instance-${params.eventId}-${params.outcome}-${params.projectileIndex}`}
+      data-outcome={params.outcome}
+      data-category={params.effect.category}
+      data-primitive={params.effect.primitive}
+      data-start-x={params.geometry.start.x}
+      data-start-y={params.geometry.start.y}
+      data-end-x={params.end.x}
+      data-end-y={params.end.y}
+    >
+      {params.effect.primitive === 'missile' && <MissileTrail {...common} />}
+      {params.effect.primitive === 'tracer' && <Tracer {...common} />}
+      {params.effect.primitive === 'laser' && <LaserBeam {...common} />}
+    </g>
+  );
+}
+
+function resolveGeometry(
+  payload: AttackLayerPayload | PhysicalLayerPayload,
+  tokenById: ReadonlyMap<string, IUnitToken>,
+): AttackGeometry | null {
+  const fromHex =
+    payload.from ??
+    payload.origin ??
+    tokenById.get(payload.attackerId)?.position;
+  const toHex =
+    payload.to ?? payload.target ?? tokenById.get(payload.targetId)?.position;
+  if (!fromHex || !toHex) return null;
+
+  const overshootHexCoord = overshootHex(fromHex, toHex);
+  return {
+    fromHex,
+    toHex,
+    start: hexToPixel(fromHex),
+    target: hexToPixel(toHex),
+    overshoot: hexToPixel(overshootHexCoord),
+  };
+}
+
+function overshootHex(
+  from: IHexCoordinate,
+  to: IHexCoordinate,
+): IHexCoordinate {
+  if (from.q === to.q && from.r === to.r) return to;
+  const start = hexToPixel(from);
+  const target = hexToPixel(to);
+  const dx = target.x - start.x;
+  const dy = target.y - start.y;
+  let bestDirection = HEX_DIRECTIONS[0];
+  let bestDot = Number.NEGATIVE_INFINITY;
+
+  for (const direction of HEX_DIRECTIONS) {
+    const point = hexToPixel(direction);
+    const dot = point.x * dx + point.y * dy;
+    if (dot > bestDot) {
+      bestDot = dot;
+      bestDirection = direction;
+    }
+  }
+
+  return {
+    q: to.q + bestDirection.q,
+    r: to.r + bestDirection.r,
+  };
+}
+
+function projectileBreakdown(
+  payload: AttackLayerPayload | PhysicalLayerPayload,
+  projectileCount: number,
+): ProjectileBreakdown {
+  if (!payload.hit) return { hitCount: 0, missCount: projectileCount };
+
+  const explicitHitCount = firstIntegerInRange(
+    [
+      payload.hitProjectiles,
+      payload.projectilesHit,
+      payload.missilesHit,
+      payload.clusterHitCount,
+    ],
+    projectileCount,
+  );
+  const hitCount = explicitHitCount ?? projectileCount;
+  const explicitMissCount = firstIntegerInRange(
+    [
+      payload.missedProjectiles,
+      payload.projectilesMissed,
+      payload.missilesMissed,
+      payload.clusterMissCount,
+    ],
+    projectileCount,
+  );
+  const missCount =
+    explicitMissCount ?? Math.max(0, projectileCount - hitCount);
+
+  return {
+    hitCount,
+    missCount,
+  };
+}
+
+function firstIntegerInRange(
+  values: readonly (number | undefined)[],
+  max: number,
+): number | null {
+  for (const value of values) {
+    if (value === undefined) continue;
+    if (!Number.isFinite(value)) continue;
+    return Math.max(0, Math.min(max, Math.floor(value)));
+  }
+  return null;
+}
+
+export default AttackEffectsLayer;

--- a/src/components/gameplay/effects/DebrisCloud.tsx
+++ b/src/components/gameplay/effects/DebrisCloud.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import type { IGameEvent } from '@/types/gameplay';
+
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+
+import { isUnitDestroyedEvent, toDomToken } from './damageEffectHelpers';
+
+export const DEBRIS_CLOUD_DURATION_MS = 800;
+const REDUCED_MOTION_DEBRIS_MS = 80;
+
+interface ActiveDebrisCloud {
+  readonly id: string;
+  readonly cause: string;
+}
+
+export interface DebrisCloudProps {
+  readonly unitId: string;
+  readonly events?: readonly IGameEvent[];
+  readonly x?: number;
+  readonly y?: number;
+  readonly prefersReducedMotion?: boolean;
+}
+
+export function DebrisCloud({
+  unitId,
+  events,
+  x = 0,
+  y = 0,
+  prefersReducedMotion,
+}: DebrisCloudProps): React.ReactElement | null {
+  const systemPrefersReducedMotion = usePrefersReducedMotion();
+  const reducedMotion = prefersReducedMotion ?? systemPrefersReducedMotion;
+  const durationMs = reducedMotion
+    ? REDUCED_MOTION_DEBRIS_MS
+    : DEBRIS_CLOUD_DURATION_MS;
+  const seenEventIdsRef = useRef<Set<string>>(new Set());
+  const [activeClouds, setActiveClouds] = useState<
+    readonly ActiveDebrisCloud[]
+  >([]);
+
+  useEffect(() => {
+    if (!events) return undefined;
+
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    for (const event of events) {
+      if (seenEventIdsRef.current.has(event.id)) continue;
+      seenEventIdsRef.current.add(event.id);
+      if (!isUnitDestroyedEvent(event)) continue;
+      if (event.payload.unitId !== unitId) continue;
+
+      const cloud: ActiveDebrisCloud = {
+        id: event.id,
+        cause: event.payload.cause,
+      };
+      setActiveClouds((current) => [...current, cloud]);
+      const clearTimer = setTimeout(() => {
+        setActiveClouds((current) =>
+          current.filter((candidate) => candidate.id !== cloud.id),
+        );
+      }, durationMs);
+      timers.push(clearTimer);
+    }
+
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+    };
+  }, [durationMs, events, unitId]);
+
+  if (activeClouds.length === 0) return null;
+
+  const unitToken = toDomToken(unitId);
+
+  return (
+    <g
+      data-testid={`debris-cloud-${unitToken}`}
+      data-cloud-count={activeClouds.length}
+      data-reduced-motion={reducedMotion ? 'true' : 'false'}
+      data-duration-ms={durationMs}
+      transform={`translate(${x}, ${y})`}
+      pointerEvents="none"
+      aria-hidden="true"
+    >
+      {activeClouds.map((cloud, index) => (
+        <g
+          key={cloud.id}
+          data-testid="debris-cloud-burst"
+          data-cause={cloud.cause}
+          transform={`rotate(${index * 19})`}
+          pointerEvents="none"
+        >
+          <circle r={reducedMotion ? 22 : 12} fill="#6b7280" opacity={0.42}>
+            {!reducedMotion && (
+              <>
+                <animate
+                  attributeName="r"
+                  values="10;34"
+                  dur={`${DEBRIS_CLOUD_DURATION_MS}ms`}
+                  fill="freeze"
+                />
+                <animate
+                  attributeName="opacity"
+                  values="0.55;0"
+                  dur={`${DEBRIS_CLOUD_DURATION_MS}ms`}
+                  fill="freeze"
+                />
+              </>
+            )}
+          </circle>
+          <path
+            d="M -22 -5 L -8 -14 L 4 -6 L 17 -18 L 24 -4 L 7 8 L -12 14 Z"
+            fill="#374151"
+            opacity={0.5}
+          >
+            {!reducedMotion && (
+              <animate
+                attributeName="opacity"
+                values="0.65;0"
+                dur={`${DEBRIS_CLOUD_DURATION_MS}ms`}
+                fill="freeze"
+              />
+            )}
+          </path>
+        </g>
+      ))}
+    </g>
+  );
+}
+
+export default DebrisCloud;

--- a/src/components/gameplay/effects/EngineFire.tsx
+++ b/src/components/gameplay/effects/EngineFire.tsx
@@ -1,0 +1,81 @@
+import React, { useMemo } from 'react';
+
+import type { IGameEvent } from '@/types/gameplay';
+
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+
+import {
+  DAMAGE_EFFECT_FIRE_SYMBOL_ID,
+  effectAnchorForLocation,
+  isEngineCriticalEvent,
+  toDomToken,
+} from './damageEffectHelpers';
+
+export interface EngineFireProps {
+  readonly unitId: string;
+  readonly events?: readonly IGameEvent[];
+  readonly engineCritCount?: number;
+  readonly x?: number;
+  readonly y?: number;
+  readonly prefersReducedMotion?: boolean;
+  readonly symbolId?: string;
+}
+
+export function EngineFire({
+  unitId,
+  events,
+  engineCritCount,
+  x = 0,
+  y = 0,
+  prefersReducedMotion,
+  symbolId = DAMAGE_EFFECT_FIRE_SYMBOL_ID,
+}: EngineFireProps): React.ReactElement | null {
+  const systemPrefersReducedMotion = usePrefersReducedMotion();
+  const reducedMotion = prefersReducedMotion ?? systemPrefersReducedMotion;
+  const projectedCritCount = useMemo(
+    () => engineCritCount ?? countEngineCrits(unitId, events),
+    [engineCritCount, events, unitId],
+  );
+
+  if (projectedCritCount <= 0) return null;
+
+  const intensity = Math.min(3, projectedCritCount);
+  const scale = 0.78 + intensity * 0.2;
+  const anchor = effectAnchorForLocation('centerTorso');
+  const unitToken = toDomToken(unitId);
+  const titleId = `engine-fire-title-${unitToken}`;
+
+  return (
+    <g
+      data-testid={`engine-fire-${unitToken}`}
+      data-intensity={intensity}
+      data-engine-crit-count={projectedCritCount}
+      data-reduced-motion={reducedMotion ? 'true' : 'false'}
+      role="img"
+      aria-labelledby={titleId}
+      pointerEvents="none"
+      transform={`translate(${x + anchor.x}, ${y + anchor.y}) scale(${scale})`}
+    >
+      <title id={titleId}>
+        {`Engine fire on ${unitId}, intensity ${intensity}`}
+      </title>
+      <use href={`#${symbolId}`} />
+    </g>
+  );
+}
+
+function countEngineCrits(
+  unitId: string,
+  events: readonly IGameEvent[] | undefined,
+): number {
+  if (!events) return 0;
+
+  let count = 0;
+  for (const event of events) {
+    if (!isEngineCriticalEvent(event)) continue;
+    if (event.payload.unitId === unitId) count += 1;
+  }
+  return count;
+}
+
+export default EngineFire;

--- a/src/components/gameplay/effects/HeatGlow.tsx
+++ b/src/components/gameplay/effects/HeatGlow.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+import { getHeatVisualMap } from '@/utils/effects/heatVisualMap';
+
+export interface HeatGlowProps {
+  readonly heat: number;
+  readonly idSuffix?: string;
+  readonly isShutdown?: boolean;
+  readonly radius?: number;
+}
+
+const DEFAULT_RADIUS = 36;
+const BADGE_MIN_HEAT = 15;
+const CRITICAL_CORE_COLOR = '#dc2626';
+
+export function HeatGlow({
+  heat,
+  idSuffix = 'unit',
+  isShutdown = false,
+  radius = DEFAULT_RADIUS,
+}: HeatGlowProps): React.ReactElement | null {
+  const reducedMotion = usePrefersReducedMotion();
+  const heatVisual = getHeatVisualMap(heat);
+
+  if (isShutdown) return null;
+
+  const filterId = `heat-glow-filter-${toSvgIdSuffix(idSuffix)}`;
+  const opacity = round(0.18 + heatVisual.intensity * 0.64);
+  const strokeWidth = round(2 + heatVisual.intensity * 5);
+  const shouldPulse = heatVisual.pulse && !reducedMotion;
+  const badge = heat >= BADGE_MIN_HEAT ? heatVisual.badge : null;
+  const transition = reducedMotion
+    ? 'none'
+    : 'opacity 300ms ease, stroke 300ms ease, stroke-width 300ms ease';
+
+  return (
+    <g
+      data-testid="heat-glow"
+      data-heat-threshold={heatVisual.threshold}
+      data-layer-order="heat-glow"
+      data-transition-ms="300"
+      data-pulse={shouldPulse ? 'true' : 'false'}
+      data-reduced-motion={reducedMotion ? 'true' : 'false'}
+      pointerEvents="none"
+      role="img"
+      aria-label={`Heat ${heat}: ${heatVisual.threshold}`}
+    >
+      <title>{`Heat ${heat}: ${heatVisual.threshold}`}</title>
+      <defs>
+        <filter
+          id={filterId}
+          data-testid="heat-glow-filter"
+          x="-80%"
+          y="-80%"
+          width="260%"
+          height="260%"
+        >
+          <feGaussianBlur
+            in="SourceGraphic"
+            stdDeviation={round(3 + heatVisual.intensity * 5)}
+            result="heatGlowBlur"
+          />
+          <feMerge>
+            <feMergeNode in="heatGlowBlur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+      </defs>
+
+      <circle
+        data-testid="heat-glow-halo"
+        cx="0"
+        cy="0"
+        r={radius}
+        fill="none"
+        stroke={heatVisual.color}
+        strokeWidth={strokeWidth}
+        opacity={opacity}
+        filter={`url(#${filterId})`}
+        style={{ transition }}
+        pointerEvents="none"
+      >
+        {shouldPulse && (
+          <animate
+            data-testid="heat-glow-pulse"
+            attributeName="opacity"
+            values={`${opacity};${round(Math.min(1, opacity + 0.16))};${opacity}`}
+            dur="1.5s"
+            repeatCount="indefinite"
+          />
+        )}
+      </circle>
+
+      {heatVisual.threshold === 'critical' && (
+        <circle
+          data-testid="heat-glow-critical-core"
+          cx="0"
+          cy="0"
+          r={round(radius * 0.82)}
+          fill="none"
+          stroke={CRITICAL_CORE_COLOR}
+          strokeWidth={round(strokeWidth * 0.48)}
+          opacity={round(opacity * 0.8)}
+          style={{ transition }}
+          pointerEvents="none"
+        />
+      )}
+
+      {reducedMotion && (
+        <circle
+          data-testid="heat-glow-reduced-outline"
+          cx="0"
+          cy="0"
+          r={round(radius + 1)}
+          fill="none"
+          stroke={heatVisual.color}
+          strokeWidth="2"
+          opacity="0.9"
+          pointerEvents="none"
+        />
+      )}
+
+      {badge && (
+        <g data-testid="heat-glow-badge" pointerEvents="none">
+          <rect
+            x="-25"
+            y="-48"
+            width="50"
+            height="14"
+            rx="2"
+            fill="#111827"
+            opacity="0.86"
+          />
+          <text
+            x="0"
+            y="-38"
+            textAnchor="middle"
+            fontSize="8"
+            fontWeight="700"
+            fill="#f8fafc"
+            letterSpacing="0"
+          >
+            {badge}
+          </text>
+        </g>
+      )}
+    </g>
+  );
+}
+
+function toSvgIdSuffix(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '-');
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/src/components/gameplay/effects/HitLocationFlash.tsx
+++ b/src/components/gameplay/effects/HitLocationFlash.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import type { IGameEvent } from '@/types/gameplay';
+
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+
+import {
+  damageFlashLocations,
+  effectAnchorForLocation,
+  isDamageAppliedEvent,
+  toDomToken,
+  type EffectLocation,
+} from './damageEffectHelpers';
+
+const FLASH_DURATION_MS = 250;
+const REDUCED_MOTION_FLASH_MS = 80;
+
+interface ActiveFlash {
+  readonly id: string;
+  readonly location: EffectLocation;
+}
+
+export interface HitLocationFlashProps {
+  readonly unitId: string;
+  readonly events?: readonly IGameEvent[];
+  readonly prefersReducedMotion?: boolean;
+}
+
+export function HitLocationFlash({
+  unitId,
+  events,
+  prefersReducedMotion,
+}: HitLocationFlashProps): React.ReactElement | null {
+  const systemPrefersReducedMotion = usePrefersReducedMotion();
+  const reducedMotion = prefersReducedMotion ?? systemPrefersReducedMotion;
+  const durationMs = reducedMotion
+    ? REDUCED_MOTION_FLASH_MS
+    : FLASH_DURATION_MS;
+  const seenEventIdsRef = useRef<Set<string>>(new Set());
+  const [activeFlashes, setActiveFlashes] = useState<readonly ActiveFlash[]>(
+    [],
+  );
+
+  useEffect(() => {
+    if (!events) return undefined;
+
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    for (const event of events) {
+      if (seenEventIdsRef.current.has(event.id)) continue;
+      seenEventIdsRef.current.add(event.id);
+      if (!isDamageAppliedEvent(event)) continue;
+      if (event.payload.unitId !== unitId) continue;
+
+      const locations = damageFlashLocations(event.payload);
+      locations.forEach((location, index) => {
+        const flashId = `${event.id}-${location}-${index}`;
+        const startTimer = setTimeout(() => {
+          setActiveFlashes((current) => [
+            ...current,
+            { id: flashId, location },
+          ]);
+
+          const clearTimer = setTimeout(() => {
+            setActiveFlashes((current) =>
+              current.filter((flash) => flash.id !== flashId),
+            );
+          }, durationMs);
+          timers.push(clearTimer);
+        }, index * durationMs);
+        timers.push(startTimer);
+      });
+    }
+
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+    };
+  }, [durationMs, events, unitId]);
+
+  if (activeFlashes.length === 0) return null;
+
+  return (
+    <g
+      data-testid={`hit-location-flashes-${toDomToken(unitId)}`}
+      pointerEvents="none"
+      aria-hidden="true"
+    >
+      {activeFlashes.map((flash) => {
+        const anchor = effectAnchorForLocation(flash.location);
+        return (
+          <g
+            key={flash.id}
+            data-testid={`hit-location-flash-${toDomToken(unitId)}-${flash.location}`}
+            data-location={flash.location}
+            data-duration-ms={durationMs}
+            transform={`translate(${anchor.x}, ${anchor.y})`}
+            pointerEvents="none"
+          >
+            <ellipse
+              rx={16}
+              ry={11}
+              fill="#ffffff"
+              opacity={0.6}
+              stroke="#dbeafe"
+              strokeWidth={1}
+            >
+              {!reducedMotion && (
+                <animate
+                  attributeName="opacity"
+                  values="0.6;0"
+                  dur={`${durationMs}ms`}
+                  fill="freeze"
+                />
+              )}
+            </ellipse>
+          </g>
+        );
+      })}
+    </g>
+  );
+}
+
+export default HitLocationFlash;

--- a/src/components/gameplay/effects/PersistentEffectsLayer.tsx
+++ b/src/components/gameplay/effects/PersistentEffectsLayer.tsx
@@ -1,0 +1,311 @@
+import React, { useMemo } from 'react';
+
+import type { IGameEvent, IUnitToken } from '@/types/gameplay';
+
+import { hexToPixel } from '@/components/gameplay/HexMapDisplay/renderHelpers';
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+
+import {
+  DAMAGE_EFFECT_FIRE_SYMBOL_ID,
+  DAMAGE_EFFECT_SMOKE_SYMBOL_ID,
+  destroyedLocationsFromArmorState,
+  destroyedLocationsFromEvent,
+  effectAnchorForLocation,
+  isEngineCriticalEvent,
+  isLocationDestroyedEvent,
+  isUnitDestroyedEvent,
+  toDomToken,
+  uniqueEffectLocations,
+  type EffectLocation,
+} from './damageEffectHelpers';
+import { DebrisCloud } from './DebrisCloud';
+import { EngineFire } from './EngineFire';
+import { SmokePuff } from './SmokePuff';
+
+export interface PersistentEffectsLayerProps {
+  readonly tokens: readonly IUnitToken[];
+  readonly events?: readonly IGameEvent[];
+  readonly prefersReducedMotion?: boolean;
+}
+
+interface UnitPersistentEffectState {
+  readonly token: IUnitToken;
+  readonly x: number;
+  readonly y: number;
+  readonly destroyed: boolean;
+  readonly smokeLocations: readonly EffectLocation[];
+  readonly engineCritCount: number;
+}
+
+export function PersistentEffectsLayer({
+  tokens,
+  events = [],
+  prefersReducedMotion,
+}: PersistentEffectsLayerProps): React.ReactElement | null {
+  const systemPrefersReducedMotion = usePrefersReducedMotion();
+  const reducedMotion = prefersReducedMotion ?? systemPrefersReducedMotion;
+  const effectStates = useMemo(
+    () => projectPersistentEffects(tokens, events),
+    [events, tokens],
+  );
+
+  if (effectStates.length === 0) return null;
+
+  return (
+    <g
+      data-testid="persistent-effects-layer"
+      data-layer-position="between-sprite-ring-and-selection-ring"
+      pointerEvents="none"
+    >
+      <DamageEffectDefinitions prefersReducedMotion={reducedMotion} />
+      {effectStates.map((state) =>
+        state.destroyed ? (
+          <React.Fragment key={state.token.unitId}>
+            <WreckMarker token={state.token} x={state.x} y={state.y} />
+            <SmokePuff
+              unitId={state.token.unitId}
+              location="wreck"
+              variant="wreck"
+              x={state.x}
+              y={state.y}
+              prefersReducedMotion={reducedMotion}
+            />
+            <DebrisCloud
+              unitId={state.token.unitId}
+              events={events}
+              x={state.x}
+              y={state.y}
+              prefersReducedMotion={reducedMotion}
+            />
+          </React.Fragment>
+        ) : (
+          <React.Fragment key={state.token.unitId}>
+            {state.smokeLocations.map((location) => (
+              <SmokePuff
+                key={`${state.token.unitId}-${location}`}
+                unitId={state.token.unitId}
+                location={location}
+                x={state.x}
+                y={state.y}
+                prefersReducedMotion={reducedMotion}
+              />
+            ))}
+            <EngineFire
+              unitId={state.token.unitId}
+              engineCritCount={state.engineCritCount}
+              x={state.x}
+              y={state.y}
+              prefersReducedMotion={reducedMotion}
+            />
+          </React.Fragment>
+        ),
+      )}
+    </g>
+  );
+}
+
+export function projectPersistentEffects(
+  tokens: readonly IUnitToken[],
+  events: readonly IGameEvent[],
+): readonly UnitPersistentEffectState[] {
+  const destroyedUnitIds = new Set<string>();
+  const smokeLocationsByUnit = new Map<string, EffectLocation[]>();
+  const engineCritCountsByUnit = new Map<string, number>();
+
+  for (const event of events) {
+    if (isUnitDestroyedEvent(event)) {
+      destroyedUnitIds.add(event.payload.unitId);
+      continue;
+    }
+
+    if (isLocationDestroyedEvent(event)) {
+      const existing = smokeLocationsByUnit.get(event.payload.unitId) ?? [];
+      smokeLocationsByUnit.set(event.payload.unitId, [
+        ...existing,
+        ...destroyedLocationsFromEvent(event.payload),
+      ]);
+      continue;
+    }
+
+    if (isEngineCriticalEvent(event)) {
+      engineCritCountsByUnit.set(
+        event.payload.unitId,
+        (engineCritCountsByUnit.get(event.payload.unitId) ?? 0) + 1,
+      );
+    }
+  }
+
+  return tokens
+    .map((token) => {
+      const { x, y } = hexToPixel(token.position);
+      const destroyed = token.isDestroyed || destroyedUnitIds.has(token.unitId);
+      const smokeLocations = destroyed
+        ? []
+        : uniqueEffectLocations([
+            ...destroyedLocationsFromArmorState(token.armorPipState),
+            ...(smokeLocationsByUnit.get(token.unitId) ?? []),
+          ]);
+      const engineCritCount = destroyed
+        ? 0
+        : (engineCritCountsByUnit.get(token.unitId) ?? 0);
+
+      return {
+        token,
+        x,
+        y,
+        destroyed,
+        smokeLocations,
+        engineCritCount,
+      };
+    })
+    .filter(
+      (state) =>
+        state.destroyed ||
+        state.smokeLocations.length > 0 ||
+        state.engineCritCount > 0,
+    );
+}
+
+export interface DamageEffectDefinitionsProps {
+  readonly prefersReducedMotion?: boolean;
+}
+
+export function DamageEffectDefinitions({
+  prefersReducedMotion = false,
+}: DamageEffectDefinitionsProps): React.ReactElement {
+  return (
+    <defs data-testid="damage-effect-definitions">
+      <g id={DAMAGE_EFFECT_SMOKE_SYMBOL_ID}>
+        <circle cx={-5} cy={2} r={6} fill="#9ca3af" opacity={0.58}>
+          {!prefersReducedMotion && (
+            <>
+              <animate
+                attributeName="cy"
+                values="6;-8"
+                dur="1200ms"
+                repeatCount="indefinite"
+              />
+              <animate
+                attributeName="opacity"
+                values="0.3;0.68;0"
+                dur="1200ms"
+                repeatCount="indefinite"
+              />
+            </>
+          )}
+        </circle>
+        <circle cx={5} cy={-2} r={8} fill="#6b7280" opacity={0.42}>
+          {!prefersReducedMotion && (
+            <>
+              <animate
+                attributeName="cy"
+                values="4;-12"
+                dur="1450ms"
+                repeatCount="indefinite"
+              />
+              <animate
+                attributeName="opacity"
+                values="0.24;0.55;0"
+                dur="1450ms"
+                repeatCount="indefinite"
+              />
+            </>
+          )}
+        </circle>
+      </g>
+      <g id={DAMAGE_EFFECT_FIRE_SYMBOL_ID}>
+        <path
+          d="M 0 -18 C 10 -8 12 4 0 16 C -12 5 -9 -8 0 -18 Z"
+          fill="#f97316"
+          opacity={0.95}
+        >
+          {!prefersReducedMotion && (
+            <animate
+              attributeName="fill"
+              values="#f97316;#facc15;#ef4444;#f97316"
+              dur="760ms"
+              repeatCount="indefinite"
+            />
+          )}
+        </path>
+        <path
+          d="M 0 -8 C 5 -2 5 6 0 12 C -5 6 -4 -2 0 -8 Z"
+          fill="#fef3c7"
+          opacity={0.86}
+        />
+      </g>
+    </defs>
+  );
+}
+
+function WreckMarker({
+  token,
+  x,
+  y,
+}: {
+  readonly token: IUnitToken;
+  readonly x: number;
+  readonly y: number;
+}): React.ReactElement {
+  const unitToken = toDomToken(token.unitId);
+  const wreckAnchor = effectAnchorForLocation('wreck');
+  const archetype = resolveWreckArchetype(token);
+
+  return (
+    <g
+      data-testid={`wreck-marker-${unitToken}`}
+      data-archetype={archetype}
+      transform={`translate(${x}, ${y})`}
+      pointerEvents="none"
+      role="img"
+      aria-label={`${token.name} wreck`}
+    >
+      <path
+        data-testid={`wreck-silhouette-${unitToken}`}
+        d={wreckPathForArchetype(archetype)}
+        fill="#4b5563"
+        stroke="#111827"
+        strokeWidth={2}
+        opacity={0.5}
+      />
+      <text
+        data-testid={`wreck-badge-${unitToken}`}
+        x={wreckAnchor.x}
+        y={wreckAnchor.y + 7}
+        textAnchor="middle"
+        fontSize={9}
+        fontWeight="bold"
+        fill="#ffffff"
+        stroke="#111827"
+        strokeWidth={0.8}
+        paintOrder="stroke fill"
+        pointerEvents="none"
+      >
+        WRECK
+      </text>
+    </g>
+  );
+}
+
+type WreckArchetype = 'humanoid' | 'quad' | 'lam';
+
+function resolveWreckArchetype(token: IUnitToken): WreckArchetype {
+  if (token.chassisArchetype) return token.chassisArchetype;
+  if (token.isQuad) return 'quad';
+  if (token.isLAM) return 'lam';
+  return 'humanoid';
+}
+
+function wreckPathForArchetype(archetype: WreckArchetype): string {
+  switch (archetype) {
+    case 'quad':
+      return 'M -28 -8 L -12 -18 L 10 -16 L 28 -6 L 20 10 L 8 18 L -10 16 L -24 8 Z';
+    case 'lam':
+      return 'M -30 -6 L -12 -22 L 0 -12 L 13 -23 L 31 -5 L 13 16 L -2 12 L -17 17 Z';
+    case 'humanoid':
+    default:
+      return 'M -24 -10 L -10 -24 L 6 -18 L 21 -8 L 18 14 L 2 22 L -18 16 Z';
+  }
+}
+
+export default PersistentEffectsLayer;

--- a/src/components/gameplay/effects/ShutdownOverlay.tsx
+++ b/src/components/gameplay/effects/ShutdownOverlay.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+
+export interface ShutdownOverlayProps {
+  readonly active: boolean;
+  readonly children?: React.ReactNode;
+  readonly idSuffix?: string;
+  readonly radius?: number;
+  readonly unitName?: string;
+}
+
+const DEFAULT_RADIUS = 34;
+const DESATURATION_MATRIX =
+  '0.33 0.33 0.33 0 0 0.33 0.33 0.33 0 0 0.33 0.33 0.33 0 0 0 0 0 1 0';
+
+export function ShutdownOverlay({
+  active,
+  children,
+  idSuffix = 'unit',
+  radius = DEFAULT_RADIUS,
+  unitName,
+}: ShutdownOverlayProps): React.ReactElement | null {
+  const reducedMotion = usePrefersReducedMotion();
+
+  if (!active) return null;
+
+  const filterId = `shutdown-desaturation-${toSvgIdSuffix(idSuffix)}`;
+  const announcement = unitName
+    ? `${unitName} powered down`
+    : 'Unit powered down';
+
+  return (
+    <g
+      data-testid="shutdown-overlay"
+      data-layer-order="shutdown-overlay"
+      data-suppresses-heat-glow="true"
+      data-flicker={reducedMotion ? 'false' : 'true'}
+      data-reduced-motion={reducedMotion ? 'true' : 'false'}
+      pointerEvents="none"
+      role="img"
+      aria-label={announcement}
+    >
+      <defs>
+        <filter id={filterId} data-testid="shutdown-desaturation-filter">
+          <feColorMatrix type="matrix" values={DESATURATION_MATRIX} />
+        </filter>
+      </defs>
+
+      {children && (
+        <g
+          data-testid="shutdown-desaturated-content"
+          filter={`url(#${filterId})`}
+          pointerEvents="none"
+        >
+          {children}
+        </g>
+      )}
+
+      <circle
+        data-testid="shutdown-dim-disc"
+        cx="0"
+        cy="0"
+        r={radius}
+        fill="#0f172a"
+        opacity="0.58"
+        filter={`url(#${filterId})`}
+        pointerEvents="none"
+      >
+        {!reducedMotion && (
+          <animate
+            data-testid="shutdown-flicker"
+            attributeName="opacity"
+            values="0.52;0.68;0.52"
+            dur="3s"
+            repeatCount="indefinite"
+          />
+        )}
+      </circle>
+
+      <g data-testid="shutdown-label" pointerEvents="none">
+        <rect
+          x="-34"
+          y="40"
+          width="68"
+          height="14"
+          rx="2"
+          fill="#020617"
+          opacity="0.78"
+        />
+        <text
+          x="0"
+          y="50"
+          textAnchor="middle"
+          fontSize="7"
+          fontWeight="700"
+          fill="#cbd5e1"
+          letterSpacing="0"
+        >
+          POWERED DOWN
+        </text>
+      </g>
+
+      <text
+        data-testid="shutdown-live-region"
+        aria-live="polite"
+        role="status"
+        opacity="0"
+      >
+        {announcement}
+      </text>
+    </g>
+  );
+}
+
+function toSvgIdSuffix(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '-');
+}

--- a/src/components/gameplay/effects/SmokePuff.tsx
+++ b/src/components/gameplay/effects/SmokePuff.tsx
@@ -1,0 +1,137 @@
+import React, { useMemo } from 'react';
+
+import type { IGameEvent } from '@/types/gameplay';
+
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+
+import {
+  DAMAGE_EFFECT_SMOKE_SYMBOL_ID,
+  destroyedLocationsFromEvent,
+  effectAnchorForLocation,
+  effectLocationLabel,
+  isLocationDestroyedEvent,
+  normalizeDamageLocation,
+  toDomToken,
+  uniqueEffectLocations,
+  type EffectLocation,
+  type SmokeLocation,
+} from './damageEffectHelpers';
+
+export interface SmokePuffProps {
+  readonly unitId: string;
+  readonly location?: string;
+  readonly events?: readonly IGameEvent[];
+  readonly x?: number;
+  readonly y?: number;
+  readonly variant?: 'live' | 'wreck';
+  readonly prefersReducedMotion?: boolean;
+  readonly symbolId?: string;
+}
+
+export function SmokePuff({
+  unitId,
+  location,
+  events,
+  x = 0,
+  y = 0,
+  variant = 'live',
+  prefersReducedMotion,
+  symbolId = DAMAGE_EFFECT_SMOKE_SYMBOL_ID,
+}: SmokePuffProps): React.ReactElement | null {
+  const systemPrefersReducedMotion = usePrefersReducedMotion();
+  const reducedMotion = prefersReducedMotion ?? systemPrefersReducedMotion;
+  const smokeLocations = useMemo(
+    () => resolveSmokeLocations(unitId, location, events, variant),
+    [events, location, unitId, variant],
+  );
+
+  if (smokeLocations.length === 0) return null;
+
+  return (
+    <>
+      {smokeLocations.map((smokeLocation) => (
+        <SmokePuffVisual
+          key={`${unitId}-${smokeLocation}`}
+          unitId={unitId}
+          smokeLocation={smokeLocation}
+          x={x}
+          y={y}
+          variant={variant}
+          reducedMotion={reducedMotion}
+          symbolId={symbolId}
+        />
+      ))}
+    </>
+  );
+}
+
+function SmokePuffVisual({
+  unitId,
+  smokeLocation,
+  x,
+  y,
+  variant,
+  reducedMotion,
+  symbolId,
+}: {
+  readonly unitId: string;
+  readonly smokeLocation: SmokeLocation;
+  readonly x: number;
+  readonly y: number;
+  readonly variant: 'live' | 'wreck';
+  readonly reducedMotion: boolean;
+  readonly symbolId: string;
+}): React.ReactElement {
+  const anchor = effectAnchorForLocation(smokeLocation);
+  const label = effectLocationLabel(smokeLocation);
+  const unitToken = toDomToken(unitId);
+  const locationToken = toDomToken(smokeLocation);
+  const titleId = `smoke-title-${unitToken}-${locationToken}`;
+  const scale = variant === 'wreck' ? 0.72 : 1;
+  const opacity = variant === 'wreck' ? 0.42 : 0.72;
+
+  return (
+    <g
+      data-testid={
+        variant === 'wreck'
+          ? `wreck-smoke-${unitToken}`
+          : `smoke-puff-${unitToken}-${smokeLocation}`
+      }
+      data-location={smokeLocation}
+      data-variant={variant}
+      data-reduced-motion={reducedMotion ? 'true' : 'false'}
+      role="img"
+      aria-labelledby={titleId}
+      pointerEvents="none"
+      transform={`translate(${x + anchor.x}, ${y + anchor.y}) scale(${scale})`}
+    >
+      <title id={titleId}>
+        {variant === 'wreck'
+          ? `Wreck smoke from ${unitId}`
+          : `Smoke venting from ${label} on ${unitId}`}
+      </title>
+      <use href={`#${symbolId}`} opacity={opacity} />
+    </g>
+  );
+}
+
+function resolveSmokeLocations(
+  unitId: string,
+  location: string | undefined,
+  events: readonly IGameEvent[] | undefined,
+  variant: 'live' | 'wreck',
+): readonly SmokeLocation[] {
+  if (variant === 'wreck') return ['wreck'];
+  if (location) return [normalizeDamageLocation(location)];
+  if (!events) return [];
+
+  const locations: EffectLocation[] = [];
+  for (const event of events) {
+    if (!isLocationDestroyedEvent(event)) continue;
+    if (event.payload.unitId !== unitId) continue;
+    locations.push(...destroyedLocationsFromEvent(event.payload));
+  }
+  return uniqueEffectLocations(locations);
+}
+
+export default SmokePuff;

--- a/src/components/gameplay/effects/StartupPulse.tsx
+++ b/src/components/gameplay/effects/StartupPulse.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+
+export interface StartupPulseProps {
+  readonly attemptId: number | string | null;
+  readonly success: boolean;
+  readonly active?: boolean;
+  readonly radius?: number;
+}
+
+const DEFAULT_RADIUS = 34;
+const SUCCESS_COLOR = '#f59e0b';
+const SUCCESS_SETTLE_COLOR = '#e5e7eb';
+const FAILURE_COLOR = '#94a3b8';
+const FAILURE_SETTLE_COLOR = '#475569';
+
+export function StartupPulse({
+  attemptId,
+  success,
+  active = true,
+  radius = DEFAULT_RADIUS,
+}: StartupPulseProps): React.ReactElement | null {
+  const reducedMotion = usePrefersReducedMotion();
+
+  if (!active || attemptId === null) return null;
+
+  const outcome = success ? 'success' : 'failure';
+  const durationMs = success ? 800 : 400;
+  const startColor = success ? SUCCESS_COLOR : FAILURE_COLOR;
+  const endColor = success ? SUCCESS_SETTLE_COLOR : FAILURE_SETTLE_COLOR;
+  const targetRadius = round(radius * 1.2);
+
+  return (
+    <g
+      key={`${attemptId}-${outcome}`}
+      data-testid="startup-pulse"
+      data-attempt-id={String(attemptId)}
+      data-replay-key={`${attemptId}-${outcome}`}
+      data-outcome={outcome}
+      data-duration-ms={String(durationMs)}
+      data-layer-order="startup-pulse"
+      data-shutdown-remains={success ? 'false' : 'true'}
+      data-reduced-motion={reducedMotion ? 'true' : 'false'}
+      pointerEvents="none"
+      role="img"
+      aria-label={`Startup ${outcome}`}
+    >
+      <circle
+        data-testid="startup-pulse-ring"
+        cx="0"
+        cy="0"
+        r={reducedMotion ? targetRadius : 0}
+        fill="none"
+        stroke={reducedMotion ? endColor : startColor}
+        strokeWidth="3"
+        opacity={reducedMotion ? 0.78 : 0.88}
+        pointerEvents="none"
+      >
+        {!reducedMotion && (
+          <>
+            <animate
+              data-testid="startup-pulse-scale"
+              attributeName="r"
+              values={`0;${targetRadius}`}
+              dur={`${durationMs}ms`}
+              fill="freeze"
+              repeatCount="1"
+            />
+            <animate
+              data-testid="startup-pulse-fade"
+              attributeName="opacity"
+              values="0.88;0"
+              dur={`${durationMs}ms`}
+              fill="freeze"
+              repeatCount="1"
+            />
+            <animate
+              data-testid="startup-pulse-color"
+              attributeName="stroke"
+              values={`${startColor};${endColor}`}
+              dur={`${durationMs}ms`}
+              fill="freeze"
+              repeatCount="1"
+            />
+          </>
+        )}
+      </circle>
+
+      {reducedMotion && (
+        <circle
+          data-testid="startup-pulse-static-snap"
+          cx="0"
+          cy="0"
+          r={targetRadius}
+          fill="none"
+          stroke={endColor}
+          strokeWidth="2"
+          opacity="0.72"
+          pointerEvents="none"
+        />
+      )}
+    </g>
+  );
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/src/components/gameplay/effects/__tests__/AttackEffectsLayer.test.tsx
+++ b/src/components/gameplay/effects/__tests__/AttackEffectsLayer.test.tsx
@@ -1,0 +1,276 @@
+import { render, screen } from '@testing-library/react';
+
+import type { IGameEvent, IHexCoordinate, IUnitToken } from '@/types/gameplay';
+
+import { hexToPixel } from '@/components/gameplay/HexMapDisplay/renderHelpers';
+import { REDUCED_MOTION_QUERY } from '@/hooks/useReducedMotion';
+import {
+  Facing,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  TokenUnitType,
+} from '@/types/gameplay';
+import {
+  ATTACK_EFFECT_COLORS,
+  type AttackWeaponEffectPayload,
+} from '@/utils/effects/weaponEffectMap';
+
+import { AttackEffectsLayer } from '../AttackEffectsLayer';
+import {
+  AttackEffectDefs,
+  AttackEffectStyles,
+  ImpactFlash,
+  LaserBeam,
+  MissileTrail,
+  Shockwave,
+  Tracer,
+} from '../primitives';
+
+type AttackLayerTestPayload = AttackWeaponEffectPayload & {
+  readonly from?: IHexCoordinate;
+  readonly to?: IHexCoordinate;
+  readonly projectilesHit?: number;
+  readonly projectilesMissed?: number;
+};
+
+function setReducedMotion(matches: boolean): void {
+  const matchMedia = window.matchMedia as jest.MockedFunction<
+    typeof window.matchMedia
+  >;
+  matchMedia.mockImplementation(
+    (query: string): MediaQueryList => ({
+      matches: query === REDUCED_MOTION_QUERY ? matches : false,
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => true,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+    }),
+  );
+}
+
+function makeToken(
+  unitId: string,
+  position: IHexCoordinate,
+  overrides: Partial<IUnitToken> = {},
+): IUnitToken {
+  return {
+    unitId,
+    name: unitId,
+    side: GameSide.Player,
+    position,
+    facing: Facing.North,
+    isSelected: false,
+    isValidTarget: false,
+    isDestroyed: false,
+    designation: unitId.toUpperCase(),
+    unitType: TokenUnitType.Mech,
+    ...overrides,
+  };
+}
+
+function makeAttackEvent(
+  id: string,
+  overrides: Partial<AttackLayerTestPayload>,
+): IGameEvent {
+  const payload: AttackLayerTestPayload = {
+    attackerId: 'attacker',
+    targetId: 'target',
+    weaponId: 'weapon',
+    roll: 8,
+    toHitNumber: 7,
+    hit: true,
+    ...overrides,
+  };
+
+  return {
+    id,
+    gameId: 'game',
+    sequence: 1,
+    timestamp: '2026-04-30T00:00:00.000Z',
+    type: GameEventType.AttackResolved,
+    turn: 1,
+    phase: GamePhase.WeaponAttack,
+    actorId: payload.attackerId,
+    payload,
+  };
+}
+
+function renderLayer(event: IGameEvent): void {
+  render(
+    <svg>
+      <AttackEffectsLayer
+        mapId="map-1"
+        events={[event]}
+        tokens={[
+          makeToken('attacker', { q: 0, r: 0 }),
+          makeToken('target', { q: 1, r: 0 }, { side: GameSide.Opponent }),
+        ]}
+      />
+    </svg>,
+  );
+}
+
+function attributeNumber(element: Element, name: string): number {
+  const value = element.getAttribute(name);
+  if (value === null) throw new Error(`Missing attribute ${name}`);
+  return Number(value);
+}
+
+describe('attack effect primitives', () => {
+  beforeEach(() => setReducedMotion(false));
+
+  it('render stable SVG test ids with pointer-events disabled and transform/opacity animations', () => {
+    render(
+      <svg>
+        <AttackEffectStyles />
+        <AttackEffectDefs />
+        <LaserBeam
+          start={{ x: 0, y: 0 }}
+          end={{ x: 80, y: 0 }}
+          color="#22c55e"
+          testId="primitive-laser"
+          reducedMotion={false}
+        />
+        <MissileTrail
+          start={{ x: 0, y: 10 }}
+          end={{ x: 80, y: 10 }}
+          color="#facc15"
+          testId="primitive-missile"
+          reducedMotion={false}
+        />
+        <Tracer
+          start={{ x: 0, y: 20 }}
+          end={{ x: 80, y: 20 }}
+          color="#22d3ee"
+          testId="primitive-tracer"
+          reducedMotion={false}
+        />
+        <Shockwave
+          center={{ x: 40, y: 40 }}
+          color="#ffffff"
+          testId="primitive-shockwave"
+          reducedMotion={false}
+        />
+        <ImpactFlash
+          center={{ x: 60, y: 60 }}
+          color="#ffffff"
+          testId="primitive-impact"
+          reducedMotion={false}
+        />
+      </svg>,
+    );
+
+    for (const testId of [
+      'primitive-laser',
+      'primitive-missile',
+      'primitive-tracer',
+      'primitive-shockwave',
+      'primitive-impact',
+    ]) {
+      const primitive = screen.getByTestId(testId);
+      expect(primitive).toHaveAttribute('pointer-events', 'none');
+      const animated = primitive.querySelector('g[style]');
+      if (!animated) throw new Error(`Missing animated group for ${testId}`);
+      const style = animated.getAttribute('style') ?? '';
+      expect(style).toContain('animation-name:');
+      expect(style).not.toMatch(/stroke-dashoffset|left|top|width|height/i);
+    }
+  });
+});
+
+describe('AttackEffectsLayer', () => {
+  beforeEach(() => setReducedMotion(false));
+
+  it('renders a hit as a full-opacity beam ending at the target plus an impact flash', () => {
+    renderLayer(makeAttackEvent('hit', { weaponName: 'PPC', hit: true }));
+
+    const eventGroup = screen.getByTestId('attack-effect-event-hit');
+    expect(eventGroup).toHaveAttribute('data-category', 'energy');
+    expect(eventGroup).toHaveAttribute('data-primitive', 'laser');
+
+    const beam = screen.getByTestId('attack-effect-laser-hit-hit-0');
+    expect(beam).toHaveAttribute('opacity', '1');
+    expect(beam).toHaveAttribute(
+      'data-color',
+      ATTACK_EFFECT_COLORS.energyGreen,
+    );
+
+    const target = hexToPixel({ q: 1, r: 0 });
+    const instance = screen.getByTestId('attack-effect-instance-hit-hit-0');
+    expect(attributeNumber(instance, 'data-end-x')).toBeCloseTo(target.x);
+    expect(attributeNumber(instance, 'data-end-y')).toBeCloseTo(target.y);
+    expect(
+      screen.getByTestId('attack-effect-impact-flash-hit'),
+    ).toHaveAttribute('data-duration-ms', '150');
+  });
+
+  it('renders a miss faded past the target and suppresses the impact flash', () => {
+    renderLayer(
+      makeAttackEvent('miss', {
+        weaponName: 'Medium Laser',
+        hit: false,
+      }),
+    );
+
+    const beam = screen.getByTestId('attack-effect-laser-miss-miss-0');
+    expect(beam).toHaveAttribute('opacity', '0.4');
+    expect(screen.queryByTestId('attack-effect-impact-flash-miss')).toBeNull();
+
+    const overshoot = hexToPixel({ q: 2, r: 0 });
+    const instance = screen.getByTestId('attack-effect-instance-miss-miss-0');
+    expect(attributeNumber(instance, 'data-end-x')).toBeCloseTo(overshoot.x);
+    expect(attributeNumber(instance, 'data-end-y')).toBeCloseTo(overshoot.y);
+  });
+
+  it('renders partial cluster hits as solid hit trails and faded miss trails', () => {
+    renderLayer(
+      makeAttackEvent('cluster', {
+        weaponName: 'LRM-20',
+        hit: true,
+        projectilesHit: 8,
+      }),
+    );
+
+    expect(
+      screen.getAllByTestId(/^attack-effect-missile-cluster-hit-/),
+    ).toHaveLength(8);
+    expect(
+      screen.getAllByTestId(/^attack-effect-missile-cluster-miss-/),
+    ).toHaveLength(12);
+
+    const firstMiss = screen.getByTestId(
+      'attack-effect-missile-cluster-miss-8',
+    );
+    expect(firstMiss).toHaveAttribute('opacity', '0.4');
+    expect(firstMiss).toHaveAttribute('data-projectile-count', '20');
+    expect(firstMiss).toHaveAttribute('data-stagger-ms', '30');
+    expect(firstMiss).toHaveAttribute('data-delay-ms', '240');
+    expect(
+      screen.getByTestId('attack-effect-impact-flash-cluster'),
+    ).toBeInTheDocument();
+  });
+
+  it('collapses reduced motion to one connecting line and a dimmed flash', () => {
+    setReducedMotion(true);
+
+    renderLayer(
+      makeAttackEvent('reduced', {
+        weaponName: 'LRM-20',
+        hit: true,
+      }),
+    );
+
+    expect(
+      screen.getByTestId('attack-effect-reduced-line-reduced'),
+    ).toHaveAttribute('data-duration-ms', '300');
+    expect(screen.queryByTestId(/^attack-effect-missile-reduced-/)).toBeNull();
+
+    const flash = screen.getByTestId('attack-effect-impact-flash-reduced');
+    expect(flash).toHaveAttribute('data-duration-ms', '80');
+    expect(flash).toHaveAttribute('opacity', '0.5');
+  });
+});

--- a/src/components/gameplay/effects/__tests__/damageFeedbackEffects.test.tsx
+++ b/src/components/gameplay/effects/__tests__/damageFeedbackEffects.test.tsx
@@ -1,0 +1,499 @@
+import { act, render, screen, within } from '@testing-library/react';
+import React from 'react';
+
+import type {
+  ArmorPipState,
+  BipedPipLocation,
+  ICriticalHitResolvedPayload,
+  IDamageAppliedPayload,
+  IGameEvent,
+  ILocationDestroyedPayload,
+  IUnitDestroyedPayload,
+  IUnitToken,
+  PipLocationState,
+} from '@/types/gameplay';
+
+import {
+  effectAnchorForLocation,
+  type EffectLocation,
+} from '@/components/gameplay/effects/damageEffectHelpers';
+import { DebrisCloud } from '@/components/gameplay/effects/DebrisCloud';
+import { EngineFire } from '@/components/gameplay/effects/EngineFire';
+import { HitLocationFlash } from '@/components/gameplay/effects/HitLocationFlash';
+import {
+  DamageEffectDefinitions,
+  PersistentEffectsLayer,
+} from '@/components/gameplay/effects/PersistentEffectsLayer';
+import { SmokePuff } from '@/components/gameplay/effects/SmokePuff';
+import { hexToPixel } from '@/components/gameplay/HexMapDisplay/renderHelpers';
+import { Facing, GameEventType, GamePhase, GameSide } from '@/types/gameplay';
+
+interface DamageAppliedPayloadWithTransfer extends IDamageAppliedPayload {
+  readonly fromLocation: string;
+  readonly toLocation: string;
+}
+
+function svgRender(ui: React.ReactElement): ReturnType<typeof render> {
+  return render(<svg>{ui}</svg>);
+}
+
+function buildEvent(
+  id: string,
+  type: GameEventType,
+  payload: IGameEvent['payload'],
+  sequence = 1,
+): IGameEvent {
+  return {
+    id,
+    gameId: 'g1',
+    sequence,
+    timestamp: `2026-01-01T00:00:0${sequence}.000Z`,
+    type,
+    turn: 1,
+    phase: GamePhase.WeaponAttack,
+    payload,
+  };
+}
+
+function damagePayload(
+  overrides: Partial<IDamageAppliedPayload> = {},
+): IDamageAppliedPayload {
+  return {
+    unitId: 'u1',
+    location: 'right_arm',
+    damage: 7,
+    armorRemaining: 3,
+    structureRemaining: 8,
+    locationDestroyed: false,
+    ...overrides,
+  };
+}
+
+function locationDestroyedPayload(
+  overrides: Partial<ILocationDestroyedPayload> = {},
+): ILocationDestroyedPayload {
+  return {
+    unitId: 'u1',
+    location: 'left_arm',
+    ...overrides,
+  };
+}
+
+function engineCritPayload(
+  overrides: Partial<ICriticalHitResolvedPayload> = {},
+): ICriticalHitResolvedPayload {
+  return {
+    unitId: 'u1',
+    location: 'center_torso',
+    slotIndex: 3,
+    componentType: 'engine',
+    componentName: 'Fusion Engine',
+    effect: 'engine_hit',
+    destroyed: false,
+    ...overrides,
+  };
+}
+
+function unitDestroyedPayload(
+  overrides: Partial<IUnitDestroyedPayload> = {},
+): IUnitDestroyedPayload {
+  return {
+    unitId: 'u1',
+    cause: 'damage',
+    ...overrides,
+  };
+}
+
+function token(overrides: Partial<IUnitToken> = {}): IUnitToken {
+  return {
+    unitId: 'u1',
+    name: 'Atlas',
+    side: GameSide.Player,
+    position: { q: 0, r: 0 },
+    facing: Facing.North,
+    isSelected: false,
+    isValidTarget: false,
+    isDestroyed: false,
+    designation: 'ATL',
+    ...overrides,
+  };
+}
+
+function uniformBipedLocations(
+  state: PipLocationState,
+): Record<BipedPipLocation, PipLocationState> {
+  return {
+    head: state,
+    centerTorso: state,
+    leftTorso: state,
+    rightTorso: state,
+    leftArm: state,
+    rightArm: state,
+    leftLeg: state,
+    rightLeg: state,
+  };
+}
+
+function armorStateWithDestroyed(location: BipedPipLocation): ArmorPipState {
+  return {
+    archetype: 'humanoid',
+    locations: {
+      ...uniformBipedLocations('full'),
+      [location]: 'destroyed',
+    },
+  };
+}
+
+function expectedSmokeTransform(
+  position: IUnitToken['position'],
+  location: EffectLocation,
+): string {
+  const pixel = hexToPixel(position);
+  const anchor = effectAnchorForLocation(location);
+  return `translate(${pixel.x + anchor.x}, ${pixel.y + anchor.y}) scale(1)`;
+}
+
+describe('damage feedback effects primitives', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('HitLocationFlash targets only the damaged pip group', () => {
+    const events: readonly IGameEvent[] = [
+      buildEvent(
+        'damage-right-arm',
+        GameEventType.DamageApplied,
+        damagePayload({ location: 'RA' }),
+      ),
+    ];
+
+    svgRender(
+      <HitLocationFlash
+        unitId="u1"
+        events={events}
+        prefersReducedMotion={false}
+      />,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(0);
+    });
+
+    const flash = screen.getByTestId('hit-location-flash-u1-rightArm');
+    expect(flash).toHaveAttribute('data-location', 'rightArm');
+    expect(flash).toHaveAttribute('pointer-events', 'none');
+    expect(
+      screen.queryByTestId('hit-location-flash-u1-leftArm'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('HitLocationFlash sequences transferred damage from source to destination', () => {
+    const payload: DamageAppliedPayloadWithTransfer = {
+      ...damagePayload({ location: 'right_torso' }),
+      fromLocation: 'left_arm',
+      toLocation: 'right_torso',
+    };
+    const events: readonly IGameEvent[] = [
+      buildEvent('transfer-hit', GameEventType.DamageApplied, payload),
+    ];
+
+    svgRender(
+      <HitLocationFlash
+        unitId="u1"
+        events={events}
+        prefersReducedMotion={false}
+      />,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(0);
+    });
+    expect(screen.getByTestId('hit-location-flash-u1-leftArm')).toBeVisible();
+    expect(
+      screen.queryByTestId('hit-location-flash-u1-rightTorso'),
+    ).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(
+      screen.getByTestId('hit-location-flash-u1-rightTorso'),
+    ).toBeVisible();
+  });
+
+  it('SmokePuff is pointer-safe and exposes an accessibility title', () => {
+    const { container } = svgRender(
+      <>
+        <DamageEffectDefinitions />
+        <SmokePuff unitId="u1" location="left_arm" prefersReducedMotion />
+      </>,
+    );
+
+    const smoke = screen.getByTestId('smoke-puff-u1-leftArm');
+    expect(smoke).toHaveAttribute('pointer-events', 'none');
+    expect(smoke).toHaveAttribute('data-reduced-motion', 'true');
+    expect(container.querySelector('title')?.textContent).toBe(
+      'Smoke venting from Left Arm on u1',
+    );
+  });
+
+  it('SmokePuff can project LocationDestroyed events without global state', () => {
+    const events: readonly IGameEvent[] = [
+      buildEvent(
+        'right-leg-destroyed',
+        GameEventType.LocationDestroyed,
+        locationDestroyedPayload({ location: 'right_leg' }),
+      ),
+    ];
+
+    svgRender(
+      <>
+        <DamageEffectDefinitions />
+        <SmokePuff unitId="u1" events={events} prefersReducedMotion />
+      </>,
+    );
+
+    expect(screen.getByTestId('smoke-puff-u1-rightLeg')).toBeInTheDocument();
+  });
+
+  it('EngineFire counts engine CriticalHitResolved events for intensity', () => {
+    const events: readonly IGameEvent[] = [
+      buildEvent('engine-type', GameEventType.CriticalHitResolved, {
+        ...engineCritPayload({ componentType: 'ENGINE' }),
+      }),
+      buildEvent(
+        'engine-name',
+        GameEventType.CriticalHitResolved,
+        engineCritPayload({
+          componentType: 'weapon',
+          componentName: 'Fusion Engine Slot',
+        }),
+        2,
+      ),
+      buildEvent(
+        'gyro',
+        GameEventType.CriticalHitResolved,
+        engineCritPayload({
+          componentType: 'gyro',
+          componentName: 'Gyro',
+        }),
+        3,
+      ),
+    ];
+
+    const { container } = svgRender(
+      <>
+        <DamageEffectDefinitions />
+        <EngineFire unitId="u1" events={events} prefersReducedMotion />
+      </>,
+    );
+
+    const fire = screen.getByTestId('engine-fire-u1');
+    expect(fire).toHaveAttribute('data-intensity', '2');
+    expect(fire).toHaveAttribute('pointer-events', 'none');
+    expect(container.querySelector('title')?.textContent).toBe(
+      'Engine fire on u1, intensity 2',
+    );
+  });
+
+  it('DebrisCloud plays for UnitDestroyed and clears after 800ms', () => {
+    const events: readonly IGameEvent[] = [
+      buildEvent(
+        'destroyed',
+        GameEventType.UnitDestroyed,
+        unitDestroyedPayload(),
+      ),
+    ];
+
+    svgRender(
+      <DebrisCloud unitId="u1" events={events} prefersReducedMotion={false} />,
+    );
+
+    expect(screen.getByTestId('debris-cloud-u1')).toHaveAttribute(
+      'data-duration-ms',
+      '800',
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(800);
+    });
+
+    expect(screen.queryByTestId('debris-cloud-u1')).not.toBeInTheDocument();
+  });
+
+  it('reduced-motion debris collapses to a static frame', () => {
+    const events: readonly IGameEvent[] = [
+      buildEvent(
+        'destroyed',
+        GameEventType.UnitDestroyed,
+        unitDestroyedPayload(),
+      ),
+    ];
+
+    const { container } = svgRender(
+      <DebrisCloud unitId="u1" events={events} prefersReducedMotion />,
+    );
+
+    expect(screen.getByTestId('debris-cloud-u1')).toHaveAttribute(
+      'data-duration-ms',
+      '80',
+    );
+    expect(container.querySelector('animate')).toBeNull();
+  });
+});
+
+describe('PersistentEffectsLayer', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('projects smoke and engine fire from supplied tokens and events', () => {
+    const mapToken = token({
+      position: { q: 1, r: 0 },
+      armorPipState: armorStateWithDestroyed('rightLeg'),
+    });
+    const events: readonly IGameEvent[] = [
+      buildEvent(
+        'left-arm-destroyed',
+        GameEventType.LocationDestroyed,
+        locationDestroyedPayload({ location: 'left_arm' }),
+      ),
+      buildEvent(
+        'engine',
+        GameEventType.CriticalHitResolved,
+        engineCritPayload(),
+        2,
+      ),
+    ];
+
+    svgRender(
+      <PersistentEffectsLayer
+        tokens={[mapToken]}
+        events={events}
+        prefersReducedMotion={false}
+      />,
+    );
+
+    const leftArmSmoke = screen.getByTestId('smoke-puff-u1-leftArm');
+    expect(leftArmSmoke).toHaveAttribute(
+      'transform',
+      expectedSmokeTransform(mapToken.position, 'leftArm'),
+    );
+    expect(screen.getByTestId('smoke-puff-u1-rightLeg')).toBeInTheDocument();
+    expect(screen.getByTestId('engine-fire-u1')).toHaveAttribute(
+      'data-intensity',
+      '1',
+    );
+  });
+
+  it('renders wreck badge and replaces live smoke/fire with one wreck smoke stream', () => {
+    const events: readonly IGameEvent[] = [
+      buildEvent(
+        'left-arm-destroyed',
+        GameEventType.LocationDestroyed,
+        locationDestroyedPayload({ location: 'left_arm' }),
+      ),
+      buildEvent(
+        'engine',
+        GameEventType.CriticalHitResolved,
+        engineCritPayload(),
+        2,
+      ),
+      buildEvent(
+        'destroyed',
+        GameEventType.UnitDestroyed,
+        unitDestroyedPayload(),
+        3,
+      ),
+    ];
+
+    svgRender(
+      <PersistentEffectsLayer
+        tokens={[token()]}
+        events={events}
+        prefersReducedMotion={false}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId('smoke-puff-u1-leftArm'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('engine-fire-u1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('wreck-smoke-u1')).toBeInTheDocument();
+    expect(screen.getByTestId('wreck-silhouette-u1')).toHaveAttribute(
+      'opacity',
+      '0.5',
+    );
+    expect(screen.getByTestId('wreck-badge-u1')).toHaveTextContent('WRECK');
+    expect(screen.getByTestId('debris-cloud-u1')).toBeInTheDocument();
+  });
+
+  it('reduced motion removes smoke and fire animation definitions', () => {
+    const events: readonly IGameEvent[] = [
+      buildEvent(
+        'left-arm-destroyed',
+        GameEventType.LocationDestroyed,
+        locationDestroyedPayload({ location: 'left_arm' }),
+      ),
+      buildEvent(
+        'engine',
+        GameEventType.CriticalHitResolved,
+        engineCritPayload(),
+        2,
+      ),
+    ];
+
+    const { container } = svgRender(
+      <PersistentEffectsLayer
+        tokens={[token()]}
+        events={events}
+        prefersReducedMotion
+      />,
+    );
+
+    expect(container.querySelector('animate')).toBeNull();
+  });
+
+  it('smoke and fire titles are available inside the layer', () => {
+    const events: readonly IGameEvent[] = [
+      buildEvent(
+        'left-arm-destroyed',
+        GameEventType.LocationDestroyed,
+        locationDestroyedPayload({ location: 'left_arm' }),
+      ),
+      buildEvent(
+        'engine',
+        GameEventType.CriticalHitResolved,
+        engineCritPayload(),
+        2,
+      ),
+    ];
+
+    const { container } = svgRender(
+      <PersistentEffectsLayer
+        tokens={[token()]}
+        events={events}
+        prefersReducedMotion
+      />,
+    );
+    const titles = Array.from(container.querySelectorAll('title')).map(
+      (title) => title.textContent,
+    );
+
+    expect(titles).toContain('Smoke venting from Left Arm on u1');
+    expect(titles).toContain('Engine fire on u1, intensity 1');
+    expect(
+      within(screen.getByTestId('persistent-effects-layer')).getByTestId(
+        'damage-effect-definitions',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/gameplay/effects/__tests__/heatAndShutdownEffects.test.tsx
+++ b/src/components/gameplay/effects/__tests__/heatAndShutdownEffects.test.tsx
@@ -1,0 +1,357 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+
+import { AmmoExplosionAura } from '../AmmoExplosionAura';
+import { HeatGlow } from '../HeatGlow';
+import { ShutdownOverlay } from '../ShutdownOverlay';
+import { StartupPulse } from '../StartupPulse';
+
+jest.mock('@/hooks/useReducedMotion', () => ({
+  usePrefersReducedMotion: jest.fn(),
+}));
+
+const mockUsePrefersReducedMotion =
+  usePrefersReducedMotion as jest.MockedFunction<
+    typeof usePrefersReducedMotion
+  >;
+
+function renderInSvg(ui: React.ReactElement): SVGSVGElement {
+  const { container } = render(<svg>{ui}</svg>);
+  const svg = container.querySelector('svg');
+  if (!svg) throw new Error('Expected svg root');
+  return svg;
+}
+
+function getByTestId(root: ParentNode, testId: string): Element {
+  const element = root.querySelector(`[data-testid='${testId}']`);
+  if (!element) throw new Error(`Expected ${testId}`);
+  return element;
+}
+
+describe('HeatGlow', () => {
+  beforeEach(() => {
+    mockUsePrefersReducedMotion.mockReturnValue(false);
+  });
+
+  it('renders a filtered SVG glow with the 300ms threshold transition contract', () => {
+    const svg = renderInSvg(<HeatGlow heat={15} idSuffix="unit-a" />);
+
+    const root = getByTestId(svg, 'heat-glow');
+    const halo = getByTestId(svg, 'heat-glow-halo');
+
+    expect(root).toHaveAttribute('pointer-events', 'none');
+    expect(root).toHaveAttribute('data-heat-threshold', 'overheat');
+    expect(root).toHaveAttribute('data-layer-order', 'heat-glow');
+    expect(root).toHaveAttribute('data-transition-ms', '300');
+    expect(getByTestId(svg, 'heat-glow-filter')).toBeInTheDocument();
+    expect(halo).toHaveAttribute('filter', 'url(#heat-glow-filter-unit-a)');
+    expect(halo.getAttribute('style')).toContain('300ms');
+  });
+
+  it('pulses only at critical heat', () => {
+    const hotSvg = renderInSvg(<HeatGlow heat={19} />);
+    expect(hotSvg.querySelector("[data-testid='heat-glow-pulse']")).toBeNull();
+
+    const criticalSvg = renderInSvg(<HeatGlow heat={20} />);
+    expect(getByTestId(criticalSvg, 'heat-glow-pulse')).toHaveAttribute(
+      'dur',
+      '1.5s',
+    );
+    expect(
+      getByTestId(criticalSvg, 'heat-glow-critical-core'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders textual heat badges where color alone is not enough', () => {
+    const belowBadgeSvg = renderInSvg(<HeatGlow heat={14} />);
+    expect(
+      belowBadgeSvg.querySelector("[data-testid='heat-glow-badge']"),
+    ).toBeNull();
+
+    const overheatSvg = renderInSvg(<HeatGlow heat={15} />);
+    expect(getByTestId(overheatSvg, 'heat-glow-badge')).toHaveTextContent(
+      'OVERHEAT',
+    );
+
+    const criticalSvg = renderInSvg(<HeatGlow heat={22} />);
+    expect(getByTestId(criticalSvg, 'heat-glow-badge')).toHaveTextContent(
+      'CRITICAL',
+    );
+  });
+
+  it('collapses to a static outline under reduced motion', () => {
+    mockUsePrefersReducedMotion.mockReturnValue(true);
+
+    const svg = renderInSvg(<HeatGlow heat={22} />);
+
+    expect(getByTestId(svg, 'heat-glow')).toHaveAttribute(
+      'data-reduced-motion',
+      'true',
+    );
+    expect(svg.querySelector("[data-testid='heat-glow-pulse']")).toBeNull();
+    expect(getByTestId(svg, 'heat-glow-reduced-outline')).toBeInTheDocument();
+  });
+
+  it('is suppressed when shutdown is definitive', () => {
+    const svg = renderInSvg(<HeatGlow heat={22} isShutdown />);
+
+    expect(svg.querySelector("[data-testid='heat-glow']")).toBeNull();
+  });
+});
+
+describe('ShutdownOverlay', () => {
+  beforeEach(() => {
+    mockUsePrefersReducedMotion.mockReturnValue(false);
+  });
+
+  it('desaturates child token content and labels the powered-down state', () => {
+    const svg = renderInSvg(
+      <ShutdownOverlay active idSuffix="atlas" unitName="Atlas">
+        <circle data-testid="token-body" r="20" />
+      </ShutdownOverlay>,
+    );
+
+    const root = getByTestId(svg, 'shutdown-overlay');
+    const filteredContent = getByTestId(svg, 'shutdown-desaturated-content');
+
+    expect(root).toHaveAttribute('pointer-events', 'none');
+    expect(root).toHaveAttribute('data-suppresses-heat-glow', 'true');
+    expect(root).toHaveAttribute('data-layer-order', 'shutdown-overlay');
+    expect(filteredContent).toHaveAttribute(
+      'filter',
+      'url(#shutdown-desaturation-atlas)',
+    );
+    expect(getByTestId(svg, 'shutdown-desaturation-filter')).toContainHTML(
+      'feColorMatrix',
+    );
+    expect(getByTestId(svg, 'shutdown-label')).toHaveTextContent(
+      'POWERED DOWN',
+    );
+  });
+
+  it('announces shutdown through an aria-live status region', () => {
+    const svg = renderInSvg(
+      <ShutdownOverlay active idSuffix="unit-a" unitName="Hunchback" />,
+    );
+
+    const liveRegion = getByTestId(svg, 'shutdown-live-region');
+    expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    expect(liveRegion).toHaveAttribute('role', 'status');
+    expect(liveRegion).toHaveTextContent('Hunchback powered down');
+  });
+
+  it('removes flicker under reduced motion', () => {
+    mockUsePrefersReducedMotion.mockReturnValue(true);
+
+    const svg = renderInSvg(<ShutdownOverlay active />);
+
+    expect(getByTestId(svg, 'shutdown-overlay')).toHaveAttribute(
+      'data-flicker',
+      'false',
+    );
+    expect(svg.querySelector("[data-testid='shutdown-flicker']")).toBeNull();
+  });
+});
+
+describe('StartupPulse', () => {
+  beforeEach(() => {
+    mockUsePrefersReducedMotion.mockReturnValue(false);
+  });
+
+  it('plays the success branch once for a restart attempt', () => {
+    const svg = renderInSvg(<StartupPulse attemptId="turn-7" success />);
+    const root = getByTestId(svg, 'startup-pulse');
+
+    expect(root).toHaveAttribute('pointer-events', 'none');
+    expect(root).toHaveAttribute('data-attempt-id', 'turn-7');
+    expect(root).toHaveAttribute('data-replay-key', 'turn-7-success');
+    expect(root).toHaveAttribute('data-outcome', 'success');
+    expect(root).toHaveAttribute('data-duration-ms', '800');
+    expect(root).toHaveAttribute('data-shutdown-remains', 'false');
+    expect(getByTestId(svg, 'startup-pulse-scale')).toHaveAttribute(
+      'repeatCount',
+      '1',
+    );
+  });
+
+  it('uses a shorter gray failure branch that leaves shutdown in place', () => {
+    const svg = renderInSvg(
+      <StartupPulse attemptId="turn-8" success={false} />,
+    );
+    const root = getByTestId(svg, 'startup-pulse');
+
+    expect(root).toHaveAttribute('data-outcome', 'failure');
+    expect(root).toHaveAttribute('data-duration-ms', '400');
+    expect(root).toHaveAttribute('data-shutdown-remains', 'true');
+    expect(getByTestId(svg, 'startup-pulse-color')).toHaveAttribute(
+      'dur',
+      '400ms',
+    );
+  });
+
+  it('collapses to a single static snap under reduced motion', () => {
+    mockUsePrefersReducedMotion.mockReturnValue(true);
+
+    const svg = renderInSvg(<StartupPulse attemptId={3} success />);
+
+    expect(getByTestId(svg, 'startup-pulse')).toHaveAttribute(
+      'data-reduced-motion',
+      'true',
+    );
+    expect(svg.querySelector("[data-testid='startup-pulse-scale']")).toBeNull();
+    expect(getByTestId(svg, 'startup-pulse-static-snap')).toBeInTheDocument();
+  });
+});
+
+describe('AmmoExplosionAura', () => {
+  beforeEach(() => {
+    mockUsePrefersReducedMotion.mockReturnValue(false);
+  });
+
+  it('activates in ammo danger heat and renders below HeatGlow by contract', () => {
+    const svg = renderInSvg(<AmmoExplosionAura heat={19} idSuffix="risk-a" />);
+    const root = getByTestId(svg, 'ammo-explosion-aura');
+
+    expect(root).toHaveAttribute('pointer-events', 'none');
+    expect(root).toHaveAttribute('data-layer-order', 'ammo-explosion-aura');
+    expect(root).toHaveAttribute('data-dismiss-transition-ms', '300');
+    expect(getByTestId(svg, 'ammo-explosion-aura-pulse')).toHaveAttribute(
+      'dur',
+      '1s',
+    );
+    expect(getByTestId(svg, 'ammo-explosion-aura-halo')).toHaveAttribute(
+      'filter',
+      'url(#ammo-explosion-aura-risk-a)',
+    );
+  });
+
+  it('auto-dismisses when heat leaves the danger range', () => {
+    const safeSvg = renderInSvg(<AmmoExplosionAura heat={18} />);
+    expect(
+      safeSvg.querySelector("[data-testid='ammo-explosion-aura']"),
+    ).toBeNull();
+
+    const dangerSvg = renderInSvg(<AmmoExplosionAura heat={22} />);
+    expect(getByTestId(dangerSvg, 'ammo-explosion-aura')).toBeInTheDocument();
+  });
+
+  it('uses a static ring under reduced motion', () => {
+    mockUsePrefersReducedMotion.mockReturnValue(true);
+
+    const svg = renderInSvg(<AmmoExplosionAura heat={22} />);
+
+    expect(getByTestId(svg, 'ammo-explosion-aura')).toHaveAttribute(
+      'data-pulse',
+      'false',
+    );
+    expect(
+      svg.querySelector("[data-testid='ammo-explosion-aura-pulse']"),
+    ).toBeNull();
+    expect(
+      getByTestId(svg, 'ammo-explosion-aura-red-ring'),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('heat and shutdown visual indicator lane', () => {
+  beforeEach(() => {
+    mockUsePrefersReducedMotion.mockReturnValue(false);
+  });
+
+  function HeatIndicatorLane({ heat }: { readonly heat: number }) {
+    return (
+      <>
+        <AmmoExplosionAura heat={heat} />
+        <HeatGlow heat={heat} />
+      </>
+    );
+  }
+
+  it('progresses from neutral heat to critical heat and activates ammo aura at 22', () => {
+    const { container, rerender } = render(
+      <svg>
+        <HeatIndicatorLane heat={0} />
+      </svg>,
+    );
+
+    expect(getByTestId(container, 'heat-glow')).toHaveAttribute(
+      'data-heat-threshold',
+      'normal',
+    );
+    expect(
+      container.querySelector("[data-testid='ammo-explosion-aura']"),
+    ).toBeNull();
+
+    rerender(
+      <svg>
+        <HeatIndicatorLane heat={5} />
+      </svg>,
+    );
+    expect(getByTestId(container, 'heat-glow')).toHaveAttribute(
+      'data-heat-threshold',
+      'warm',
+    );
+
+    rerender(
+      <svg>
+        <HeatIndicatorLane heat={10} />
+      </svg>,
+    );
+    expect(getByTestId(container, 'heat-glow')).toHaveAttribute(
+      'data-heat-threshold',
+      'hot',
+    );
+
+    rerender(
+      <svg>
+        <HeatIndicatorLane heat={15} />
+      </svg>,
+    );
+    expect(getByTestId(container, 'heat-glow')).toHaveAttribute(
+      'data-heat-threshold',
+      'overheat',
+    );
+
+    rerender(
+      <svg>
+        <HeatIndicatorLane heat={22} />
+      </svg>,
+    );
+    expect(getByTestId(container, 'heat-glow')).toHaveAttribute(
+      'data-heat-threshold',
+      'critical',
+    );
+    expect(getByTestId(container, 'ammo-explosion-aura')).toBeInTheDocument();
+    expect(
+      Array.from(container.querySelectorAll('[data-layer-order]')).map((node) =>
+        node.getAttribute('data-layer-order'),
+      ),
+    ).toEqual(['ammo-explosion-aura', 'heat-glow']);
+  });
+
+  it('renders static visual forms only in reduced-motion mode', () => {
+    mockUsePrefersReducedMotion.mockReturnValue(true);
+
+    const svg = renderInSvg(
+      <>
+        <AmmoExplosionAura heat={22} />
+        <HeatGlow heat={22} />
+        <ShutdownOverlay active />
+        <StartupPulse attemptId="restart-1" success={false} />
+      </>,
+    );
+
+    expect(svg.querySelector('animate')).toBeNull();
+    expect(
+      getByTestId(svg, 'ammo-explosion-aura-red-ring'),
+    ).toBeInTheDocument();
+    expect(getByTestId(svg, 'heat-glow-reduced-outline')).toBeInTheDocument();
+    expect(getByTestId(svg, 'shutdown-overlay')).toHaveAttribute(
+      'data-flicker',
+      'false',
+    );
+    expect(getByTestId(svg, 'startup-pulse-static-snap')).toBeInTheDocument();
+  });
+});

--- a/src/components/gameplay/effects/damageEffectHelpers.ts
+++ b/src/components/gameplay/effects/damageEffectHelpers.ts
@@ -1,0 +1,325 @@
+import type {
+  ArmorPipState,
+  BipedPipLocation,
+  ICriticalHitResolvedPayload,
+  IDamageAppliedPayload,
+  IGameEvent,
+  ILocationDestroyedPayload,
+  IUnitDestroyedPayload,
+  QuadPipLocation,
+} from '@/types/gameplay';
+
+import { GameEventType } from '@/types/gameplay';
+
+export const DAMAGE_EFFECT_SMOKE_SYMBOL_ID = 'damage-effect-smoke-symbol';
+export const DAMAGE_EFFECT_FIRE_SYMBOL_ID = 'damage-effect-fire-symbol';
+
+export const EFFECT_LOCATION_ORDER = [
+  'head',
+  'leftArm',
+  'rightArm',
+  'leftTorso',
+  'rightTorso',
+  'centerTorso',
+  'leftLeg',
+  'rightLeg',
+  'frontLeftLeg',
+  'frontRightLeg',
+  'rearLeftLeg',
+  'rearRightLeg',
+] as const;
+
+export type EffectLocation = (typeof EFFECT_LOCATION_ORDER)[number];
+export type SmokeLocation = EffectLocation | 'wreck';
+
+export interface EffectPoint {
+  readonly x: number;
+  readonly y: number;
+}
+
+type TypedGameEvent<TType extends GameEventType, TPayload> = IGameEvent & {
+  readonly type: TType;
+  readonly payload: TPayload;
+};
+
+export type DamageAppliedEvent = TypedGameEvent<
+  GameEventType.DamageApplied,
+  IDamageAppliedPayload
+>;
+
+export type LocationDestroyedEvent = TypedGameEvent<
+  GameEventType.LocationDestroyed,
+  ILocationDestroyedPayload
+>;
+
+export type CriticalHitResolvedEvent = TypedGameEvent<
+  GameEventType.CriticalHitResolved,
+  ICriticalHitResolvedPayload
+>;
+
+export type UnitDestroyedEvent = TypedGameEvent<
+  GameEventType.UnitDestroyed,
+  IUnitDestroyedPayload
+>;
+
+const LOCATION_ALIASES: Readonly<Record<string, EffectLocation>> = {
+  h: 'head',
+  hd: 'head',
+  head: 'head',
+
+  c: 'centerTorso',
+  ct: 'centerTorso',
+  ctr: 'centerTorso',
+  center: 'centerTorso',
+  centre: 'centerTorso',
+  centertorso: 'centerTorso',
+  centretorso: 'centerTorso',
+  centertorsorear: 'centerTorso',
+  centretorsorear: 'centerTorso',
+
+  ltorso: 'leftTorso',
+  lt: 'leftTorso',
+  ltr: 'leftTorso',
+  lefttorso: 'leftTorso',
+  lefttorsorear: 'leftTorso',
+
+  rtorso: 'rightTorso',
+  rt: 'rightTorso',
+  rtr: 'rightTorso',
+  righttorso: 'rightTorso',
+  righttorsorear: 'rightTorso',
+
+  la: 'leftArm',
+  larm: 'leftArm',
+  leftarm: 'leftArm',
+
+  ra: 'rightArm',
+  rarm: 'rightArm',
+  rightarm: 'rightArm',
+
+  ll: 'leftLeg',
+  lleg: 'leftLeg',
+  leftleg: 'leftLeg',
+
+  rl: 'rightLeg',
+  rleg: 'rightLeg',
+  rightleg: 'rightLeg',
+
+  fll: 'frontLeftLeg',
+  frontleftleg: 'frontLeftLeg',
+  flleg: 'frontLeftLeg',
+
+  frl: 'frontRightLeg',
+  frontrightleg: 'frontRightLeg',
+  frleg: 'frontRightLeg',
+
+  rll: 'rearLeftLeg',
+  rearleftleg: 'rearLeftLeg',
+  rlleg: 'rearLeftLeg',
+
+  rrl: 'rearRightLeg',
+  rearrightleg: 'rearRightLeg',
+  rrleg: 'rearRightLeg',
+};
+
+const LOCATION_LABELS: Readonly<Record<SmokeLocation, string>> = {
+  head: 'Head',
+  centerTorso: 'Center Torso',
+  leftTorso: 'Left Torso',
+  rightTorso: 'Right Torso',
+  leftArm: 'Left Arm',
+  rightArm: 'Right Arm',
+  leftLeg: 'Left Leg',
+  rightLeg: 'Right Leg',
+  frontLeftLeg: 'Front Left Leg',
+  frontRightLeg: 'Front Right Leg',
+  rearLeftLeg: 'Rear Left Leg',
+  rearRightLeg: 'Rear Right Leg',
+  wreck: 'Wreck',
+};
+
+const LOCATION_ANCHORS: Readonly<Record<SmokeLocation, EffectPoint>> = {
+  head: { x: 0, y: -48 },
+  leftArm: { x: -44, y: -24 },
+  rightArm: { x: 44, y: -24 },
+  leftTorso: { x: -34, y: -4 },
+  rightTorso: { x: 34, y: -4 },
+  centerTorso: { x: 0, y: 16 },
+  leftLeg: { x: -24, y: 34 },
+  rightLeg: { x: 24, y: 34 },
+  frontLeftLeg: { x: -34, y: -18 },
+  frontRightLeg: { x: 34, y: -18 },
+  rearLeftLeg: { x: -30, y: 28 },
+  rearRightLeg: { x: 30, y: 28 },
+  wreck: { x: 0, y: -10 },
+};
+
+const LOCATION_ORDER_INDEX: Readonly<Record<EffectLocation, number>> =
+  EFFECT_LOCATION_ORDER.reduce(
+    (acc, location, index) => ({ ...acc, [location]: index }),
+    {} as Record<EffectLocation, number>,
+  );
+
+const BIPED_LOCATION_MAP: Readonly<Record<BipedPipLocation, EffectLocation>> = {
+  head: 'head',
+  centerTorso: 'centerTorso',
+  leftTorso: 'leftTorso',
+  rightTorso: 'rightTorso',
+  leftArm: 'leftArm',
+  rightArm: 'rightArm',
+  leftLeg: 'leftLeg',
+  rightLeg: 'rightLeg',
+};
+
+const QUAD_LOCATION_MAP: Readonly<Record<QuadPipLocation, EffectLocation>> = {
+  head: 'head',
+  centerTorso: 'centerTorso',
+  frontLeftLeg: 'frontLeftLeg',
+  frontRightLeg: 'frontRightLeg',
+  rearLeftLeg: 'rearLeftLeg',
+  rearRightLeg: 'rearRightLeg',
+};
+
+export function isDamageAppliedEvent(
+  event: IGameEvent,
+): event is DamageAppliedEvent {
+  return event.type === GameEventType.DamageApplied;
+}
+
+export function isLocationDestroyedEvent(
+  event: IGameEvent,
+): event is LocationDestroyedEvent {
+  return event.type === GameEventType.LocationDestroyed;
+}
+
+export function isCriticalHitResolvedEvent(
+  event: IGameEvent,
+): event is CriticalHitResolvedEvent {
+  return event.type === GameEventType.CriticalHitResolved;
+}
+
+export function isUnitDestroyedEvent(
+  event: IGameEvent,
+): event is UnitDestroyedEvent {
+  return event.type === GameEventType.UnitDestroyed;
+}
+
+export function isEngineCriticalEvent(
+  event: IGameEvent,
+): event is CriticalHitResolvedEvent {
+  if (!isCriticalHitResolvedEvent(event)) return false;
+
+  const componentType = event.payload.componentType.trim().toLowerCase();
+  const componentName = event.payload.componentName.trim().toLowerCase();
+
+  return componentType.includes('engine') || componentName.includes('engine');
+}
+
+export function normalizeDamageLocation(
+  location: string | undefined,
+): EffectLocation {
+  const key = toLocationKey(location);
+  return LOCATION_ALIASES[key] ?? 'centerTorso';
+}
+
+export function effectAnchorForLocation(location: SmokeLocation): EffectPoint {
+  return LOCATION_ANCHORS[location];
+}
+
+export function effectLocationLabel(location: SmokeLocation): string {
+  return LOCATION_LABELS[location];
+}
+
+export function compareEffectLocations(
+  left: EffectLocation,
+  right: EffectLocation,
+): number {
+  return LOCATION_ORDER_INDEX[left] - LOCATION_ORDER_INDEX[right];
+}
+
+export function damageFlashLocations(
+  payload: IDamageAppliedPayload,
+): readonly EffectLocation[] {
+  const sourceLocation =
+    readStringField(payload, 'fromLocation') ??
+    readStringField(payload, 'sourceLocation') ??
+    readStringField(payload, 'transferredFromLocation') ??
+    readStringField(payload, 'originalLocation');
+  const targetLocation =
+    readStringField(payload, 'toLocation') ??
+    readStringField(payload, 'transferredToLocation') ??
+    payload.location;
+
+  const locations: EffectLocation[] = [];
+  if (sourceLocation) {
+    locations.push(normalizeDamageLocation(sourceLocation));
+  }
+  locations.push(normalizeDamageLocation(targetLocation));
+
+  return uniqueEffectLocations(locations);
+}
+
+export function destroyedLocationsFromEvent(
+  payload: ILocationDestroyedPayload,
+): readonly EffectLocation[] {
+  const locations = [normalizeDamageLocation(payload.location)];
+  if (payload.cascadedTo) {
+    locations.push(normalizeDamageLocation(payload.cascadedTo));
+  }
+  return uniqueEffectLocations(locations);
+}
+
+export function destroyedLocationsFromArmorState(
+  state: ArmorPipState | undefined,
+): readonly EffectLocation[] {
+  if (!state) return [];
+
+  const destroyed: EffectLocation[] = [];
+  if (state.archetype === 'quad') {
+    const entries = Object.entries(state.locations) as readonly [
+      QuadPipLocation,
+      string,
+    ][];
+    for (const [location, value] of entries) {
+      if (value === 'destroyed') destroyed.push(QUAD_LOCATION_MAP[location]);
+    }
+    return uniqueEffectLocations(destroyed);
+  }
+
+  const entries = Object.entries(state.locations) as readonly [
+    BipedPipLocation,
+    string,
+  ][];
+  for (const [location, value] of entries) {
+    if (value === 'destroyed') destroyed.push(BIPED_LOCATION_MAP[location]);
+  }
+  return uniqueEffectLocations(destroyed);
+}
+
+export function uniqueEffectLocations(
+  locations: readonly EffectLocation[],
+): readonly EffectLocation[] {
+  return Array.from(new Set(locations)).sort(compareEffectLocations);
+}
+
+export function toDomToken(value: string): string {
+  const token = value.trim().replace(/[^A-Za-z0-9_-]+/g, '-');
+  return token.length > 0 ? token : 'effect';
+}
+
+function toLocationKey(location: string | undefined): string {
+  return (location ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+function readStringField<TField extends string>(
+  payload: IDamageAppliedPayload,
+  field: TField,
+): string | undefined {
+  const value = (
+    payload as IDamageAppliedPayload & Partial<Record<TField, unknown>>
+  )[field];
+  return typeof value === 'string' ? value : undefined;
+}

--- a/src/components/gameplay/effects/primitives/ImpactFlash.tsx
+++ b/src/components/gameplay/effects/primitives/ImpactFlash.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+
+import {
+  attackAnimationStyle,
+  type PointEffectProps,
+  useEffectiveReducedMotion,
+} from './shared';
+
+export interface ImpactFlashProps extends PointEffectProps {
+  readonly radius?: number;
+}
+
+export function ImpactFlash({
+  center,
+  color,
+  opacity = 1,
+  durationMs = 150,
+  delayMs = 0,
+  testId = 'attack-effect-impact-flash',
+  reducedMotion,
+  radius = 12,
+}: ImpactFlashProps): React.ReactElement {
+  const prefersReducedMotion = useEffectiveReducedMotion(reducedMotion);
+  const effectiveDuration = prefersReducedMotion ? 80 : durationMs;
+  const effectiveOpacity = prefersReducedMotion ? opacity * 0.5 : opacity;
+
+  return (
+    <g
+      pointerEvents="none"
+      opacity={effectiveOpacity}
+      transform={`translate(${center.x} ${center.y})`}
+      data-testid={testId}
+      data-effect="impact-flash"
+      data-color={color}
+      data-duration-ms={effectiveDuration}
+      data-delay-ms={delayMs}
+    >
+      <g
+        style={attackAnimationStyle(
+          prefersReducedMotion
+            ? 'attack-effect-reduced-fade'
+            : 'attack-effect-impact',
+          effectiveDuration,
+          delayMs,
+          { transformOrigin: 'center', transformBox: 'fill-box' },
+        )}
+      >
+        <circle
+          cx={0}
+          cy={0}
+          r={radius}
+          fill={color}
+          fillOpacity={0.38}
+          stroke={color}
+          strokeWidth={2}
+        />
+        <line
+          x1={-radius}
+          y1={0}
+          x2={radius}
+          y2={0}
+          stroke={color}
+          strokeWidth={2}
+          strokeLinecap="round"
+        />
+        <line
+          x1={0}
+          y1={-radius}
+          x2={0}
+          y2={radius}
+          stroke={color}
+          strokeWidth={2}
+          strokeLinecap="round"
+        />
+      </g>
+    </g>
+  );
+}
+
+export default ImpactFlash;

--- a/src/components/gameplay/effects/primitives/LaserBeam.tsx
+++ b/src/components/gameplay/effects/primitives/LaserBeam.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+import {
+  attackAnimationStyle,
+  lineGeometry,
+  ReducedMotionLine,
+  type LineEffectProps,
+  useEffectiveReducedMotion,
+} from './shared';
+
+export interface LaserBeamProps extends LineEffectProps {
+  readonly glowFilterId?: string;
+}
+
+export function LaserBeam({
+  start,
+  end,
+  color,
+  opacity = 1,
+  durationMs = 400,
+  delayMs = 0,
+  projectileIndex = 0,
+  projectileCount = 1,
+  staggerMs = 0,
+  testId = 'attack-effect-laser',
+  reducedMotion,
+  glowFilterId = 'attack-effect-glow',
+}: LaserBeamProps): React.ReactElement {
+  const prefersReducedMotion = useEffectiveReducedMotion(reducedMotion);
+  const delay = delayMs + projectileIndex * staggerMs;
+
+  if (prefersReducedMotion) {
+    return (
+      <ReducedMotionLine
+        start={start}
+        end={end}
+        color={color}
+        opacity={opacity}
+        delayMs={delay}
+        testId={testId}
+      />
+    );
+  }
+
+  const geometry = lineGeometry(start, end);
+  return (
+    <g
+      pointerEvents="none"
+      opacity={opacity}
+      transform={geometry.transform}
+      data-testid={testId}
+      data-effect="laser"
+      data-color={color}
+      data-duration-ms={durationMs}
+      data-delay-ms={delay}
+      data-projectile-index={projectileIndex}
+      data-projectile-count={projectileCount}
+      data-stagger-ms={staggerMs}
+    >
+      <g
+        style={attackAnimationStyle('attack-effect-beam', durationMs, delay, {
+          transformBox: 'view-box',
+        })}
+      >
+        <line
+          x1={0}
+          y1={0}
+          x2={geometry.length}
+          y2={0}
+          stroke={color}
+          strokeWidth={8}
+          strokeLinecap="round"
+          strokeOpacity={0.35}
+          filter={`url(#${glowFilterId})`}
+        />
+        <line
+          x1={0}
+          y1={0}
+          x2={geometry.length}
+          y2={0}
+          stroke={color}
+          strokeWidth={3}
+          strokeLinecap="round"
+          strokeOpacity={0.95}
+        />
+      </g>
+    </g>
+  );
+}
+
+export default LaserBeam;

--- a/src/components/gameplay/effects/primitives/MissileTrail.tsx
+++ b/src/components/gameplay/effects/primitives/MissileTrail.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+
+import {
+  attackAnimationStyle,
+  lineGeometry,
+  ReducedMotionLine,
+  stableSvgId,
+  type LineEffectProps,
+  useEffectiveReducedMotion,
+} from './shared';
+
+export function MissileTrail({
+  start,
+  end,
+  color,
+  opacity = 1,
+  durationMs = 600,
+  delayMs = 0,
+  projectileIndex = 0,
+  projectileCount = 1,
+  staggerMs = 30,
+  testId = 'attack-effect-missile',
+  reducedMotion,
+}: LineEffectProps): React.ReactElement {
+  const prefersReducedMotion = useEffectiveReducedMotion(reducedMotion);
+  const delay = delayMs + projectileIndex * staggerMs;
+
+  if (prefersReducedMotion) {
+    return (
+      <ReducedMotionLine
+        start={start}
+        end={end}
+        color={color}
+        opacity={opacity}
+        delayMs={delay}
+        testId={testId}
+      />
+    );
+  }
+
+  const geometry = lineGeometry(start, end);
+  const markerId = stableSvgId(`${testId}-arrow-${projectileIndex}`);
+  return (
+    <g
+      pointerEvents="none"
+      opacity={opacity}
+      data-testid={testId}
+      data-effect="missile"
+      data-color={color}
+      data-duration-ms={durationMs}
+      data-delay-ms={delay}
+      data-projectile-index={projectileIndex}
+      data-projectile-count={projectileCount}
+      data-stagger-ms={staggerMs}
+    >
+      <defs>
+        <marker
+          id={markerId}
+          viewBox="0 0 12 12"
+          refX={10}
+          refY={6}
+          markerWidth={7}
+          markerHeight={7}
+          orient="auto"
+        >
+          <path d="M0,0 L12,6 L0,12 L3,6 Z" fill={color} />
+        </marker>
+      </defs>
+      <g transform={geometry.transform}>
+        <g
+          style={attackAnimationStyle(
+            'attack-effect-missile',
+            durationMs,
+            delay,
+            { transformBox: 'view-box' },
+          )}
+        >
+          <line
+            x1={0}
+            y1={0}
+            x2={geometry.length}
+            y2={0}
+            stroke={color}
+            strokeWidth={3}
+            strokeLinecap="round"
+            strokeDasharray="8 7"
+            markerEnd={`url(#${markerId})`}
+          />
+        </g>
+      </g>
+    </g>
+  );
+}
+
+export default MissileTrail;

--- a/src/components/gameplay/effects/primitives/Shockwave.tsx
+++ b/src/components/gameplay/effects/primitives/Shockwave.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+import {
+  attackAnimationStyle,
+  ReducedMotionLine,
+  type EffectPoint,
+  type PointEffectProps,
+  useEffectiveReducedMotion,
+} from './shared';
+
+export interface ShockwaveProps extends PointEffectProps {
+  readonly radius?: number;
+  readonly strokeWidth?: number;
+  readonly fallbackStart?: EffectPoint;
+  readonly fallbackEnd?: EffectPoint;
+}
+
+export function Shockwave({
+  center,
+  color,
+  opacity = 1,
+  durationMs = 400,
+  delayMs = 0,
+  testId = 'attack-effect-shockwave',
+  reducedMotion,
+  radius = 18,
+  strokeWidth = 2,
+  fallbackStart,
+  fallbackEnd,
+}: ShockwaveProps): React.ReactElement {
+  const prefersReducedMotion = useEffectiveReducedMotion(reducedMotion);
+
+  if (prefersReducedMotion && fallbackStart && fallbackEnd) {
+    return (
+      <ReducedMotionLine
+        start={fallbackStart}
+        end={fallbackEnd}
+        color={color}
+        opacity={opacity}
+        delayMs={delayMs}
+        testId={testId}
+      />
+    );
+  }
+
+  return (
+    <g
+      pointerEvents="none"
+      opacity={opacity}
+      transform={`translate(${center.x} ${center.y})`}
+      data-testid={testId}
+      data-effect="shockwave"
+      data-color={color}
+      data-duration-ms={durationMs}
+      data-delay-ms={delayMs}
+      data-stroke-width={strokeWidth}
+    >
+      <g
+        style={attackAnimationStyle(
+          prefersReducedMotion
+            ? 'attack-effect-reduced-fade'
+            : 'attack-effect-shockwave',
+          prefersReducedMotion ? 300 : durationMs,
+          delayMs,
+          { transformOrigin: 'center', transformBox: 'fill-box' },
+        )}
+      >
+        <circle
+          cx={0}
+          cy={0}
+          r={radius}
+          fill="none"
+          stroke={color}
+          strokeWidth={strokeWidth}
+        />
+      </g>
+    </g>
+  );
+}
+
+export default Shockwave;

--- a/src/components/gameplay/effects/primitives/Tracer.tsx
+++ b/src/components/gameplay/effects/primitives/Tracer.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+
+import {
+  attackAnimationStyle,
+  lineGeometry,
+  ReducedMotionLine,
+  type LineEffectProps,
+  useEffectiveReducedMotion,
+} from './shared';
+
+export function Tracer({
+  start,
+  end,
+  color,
+  opacity = 1,
+  durationMs = 300,
+  delayMs = 0,
+  projectileIndex = 0,
+  projectileCount = 1,
+  staggerMs = 0,
+  testId = 'attack-effect-tracer',
+  reducedMotion,
+}: LineEffectProps): React.ReactElement {
+  const prefersReducedMotion = useEffectiveReducedMotion(reducedMotion);
+  const delay = delayMs + projectileIndex * staggerMs;
+
+  if (prefersReducedMotion) {
+    return (
+      <ReducedMotionLine
+        start={start}
+        end={end}
+        color={color}
+        opacity={opacity}
+        delayMs={delay}
+        testId={testId}
+      />
+    );
+  }
+
+  const geometry = lineGeometry(start, end);
+  const dashLength = Math.min(28, Math.max(12, geometry.length * 0.18));
+  const travelX = Math.max(0, geometry.length - dashLength);
+  return (
+    <g
+      pointerEvents="none"
+      opacity={opacity}
+      transform={geometry.transform}
+      data-testid={testId}
+      data-effect="tracer"
+      data-color={color}
+      data-duration-ms={durationMs}
+      data-delay-ms={delay}
+      data-projectile-index={projectileIndex}
+      data-projectile-count={projectileCount}
+      data-stagger-ms={staggerMs}
+    >
+      <g
+        style={attackAnimationStyle('attack-effect-tracer', durationMs, delay, {
+          transformBox: 'view-box',
+          travelX,
+        })}
+      >
+        <line
+          x1={0}
+          y1={0}
+          x2={dashLength}
+          y2={0}
+          stroke={color}
+          strokeWidth={4}
+          strokeLinecap="round"
+        />
+        <line
+          x1={-18}
+          y1={0}
+          x2={-8}
+          y2={0}
+          stroke={color}
+          strokeWidth={3}
+          strokeLinecap="round"
+          strokeOpacity={0.75}
+        />
+        <line
+          x1={-32}
+          y1={0}
+          x2={-26}
+          y2={0}
+          stroke={color}
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeOpacity={0.45}
+        />
+      </g>
+    </g>
+  );
+}
+
+export default Tracer;

--- a/src/components/gameplay/effects/primitives/index.ts
+++ b/src/components/gameplay/effects/primitives/index.ts
@@ -1,0 +1,11 @@
+export { LaserBeam, type LaserBeamProps } from './LaserBeam';
+export { MissileTrail } from './MissileTrail';
+export { Tracer } from './Tracer';
+export { Shockwave, type ShockwaveProps } from './Shockwave';
+export { ImpactFlash, type ImpactFlashProps } from './ImpactFlash';
+export {
+  AttackEffectDefs,
+  AttackEffectStyles,
+  ReducedMotionLine,
+  type EffectPoint,
+} from './shared';

--- a/src/components/gameplay/effects/primitives/shared.tsx
+++ b/src/components/gameplay/effects/primitives/shared.tsx
@@ -1,0 +1,208 @@
+import React from 'react';
+
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+
+export interface EffectPoint {
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface BaseEffectProps {
+  readonly color: string;
+  readonly opacity?: number;
+  readonly durationMs?: number;
+  readonly delayMs?: number;
+  readonly testId?: string;
+  readonly reducedMotion?: boolean;
+}
+
+export interface LineEffectProps extends BaseEffectProps {
+  readonly start: EffectPoint;
+  readonly end: EffectPoint;
+  readonly projectileIndex?: number;
+  readonly projectileCount?: number;
+  readonly staggerMs?: number;
+}
+
+export interface PointEffectProps extends BaseEffectProps {
+  readonly center: EffectPoint;
+}
+
+export type AttackEffectAnimationName =
+  | 'attack-effect-beam'
+  | 'attack-effect-missile'
+  | 'attack-effect-tracer'
+  | 'attack-effect-shockwave'
+  | 'attack-effect-impact'
+  | 'attack-effect-reduced-fade';
+
+export type AttackEffectStyle = React.CSSProperties & {
+  readonly transformBox?: 'fill-box' | 'view-box';
+  readonly '--attack-effect-travel-x'?: string;
+};
+
+export const DEFAULT_REDUCED_MOTION_DURATION_MS = 300;
+
+export function useEffectiveReducedMotion(
+  override: boolean | undefined,
+): boolean {
+  const systemReducedMotion = usePrefersReducedMotion();
+  return override ?? systemReducedMotion;
+}
+
+export function lineGeometry(
+  start: EffectPoint,
+  end: EffectPoint,
+): {
+  readonly length: number;
+  readonly angleDeg: number;
+  readonly transform: string;
+} {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const length = Math.max(0.01, Math.hypot(dx, dy));
+  const angleDeg = (Math.atan2(dy, dx) * 180) / Math.PI;
+  return {
+    length,
+    angleDeg,
+    transform: `translate(${start.x} ${start.y}) rotate(${angleDeg})`,
+  };
+}
+
+export function attackAnimationStyle(
+  animationName: AttackEffectAnimationName,
+  durationMs: number,
+  delayMs: number,
+  options: {
+    readonly transformOrigin?: string;
+    readonly transformBox?: 'fill-box' | 'view-box';
+    readonly travelX?: number;
+  } = {},
+): AttackEffectStyle {
+  return {
+    animationName,
+    animationDuration: `${durationMs}ms`,
+    animationDelay: `${delayMs}ms`,
+    animationFillMode: 'both',
+    animationTimingFunction: 'ease-out',
+    transformOrigin: options.transformOrigin ?? '0 0',
+    transformBox: options.transformBox ?? 'fill-box',
+    '--attack-effect-travel-x':
+      options.travelX === undefined ? undefined : `${options.travelX}px`,
+  };
+}
+
+export function stableSvgId(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '-');
+}
+
+export function AttackEffectStyles(): React.ReactElement {
+  return (
+    <style>{`
+      @keyframes attack-effect-beam {
+        0% { opacity: 0; transform: scaleX(0.18); }
+        14% { opacity: 1; transform: scaleX(1); }
+        82% { opacity: 1; transform: scaleX(1); }
+        100% { opacity: 0; transform: scaleX(1); }
+      }
+
+      @keyframes attack-effect-missile {
+        0% { opacity: 0; transform: scaleX(0.12); }
+        18% { opacity: 1; transform: scaleX(0.72); }
+        74% { opacity: 1; transform: scaleX(1); }
+        100% { opacity: 0; transform: scaleX(1); }
+      }
+
+      @keyframes attack-effect-tracer {
+        0% { opacity: 0; transform: translateX(0) scaleX(0.85); }
+        18% { opacity: 1; transform: translateX(0) scaleX(1); }
+        82% { opacity: 1; transform: translateX(var(--attack-effect-travel-x, 0px)) scaleX(1); }
+        100% { opacity: 0; transform: translateX(var(--attack-effect-travel-x, 0px)) scaleX(0.9); }
+      }
+
+      @keyframes attack-effect-shockwave {
+        0% { opacity: 0; transform: scale(0.18); }
+        18% { opacity: 1; transform: scale(0.7); }
+        100% { opacity: 0; transform: scale(1.7); }
+      }
+
+      @keyframes attack-effect-impact {
+        0% { opacity: 0; transform: scale(0.25); }
+        35% { opacity: 1; transform: scale(1); }
+        100% { opacity: 0; transform: scale(1.35); }
+      }
+
+      @keyframes attack-effect-reduced-fade {
+        0% { opacity: 0.75; transform: scaleX(1); }
+        100% { opacity: 0; transform: scaleX(1); }
+      }
+    `}</style>
+  );
+}
+
+export function AttackEffectDefs({
+  glowFilterId = 'attack-effect-glow',
+}: {
+  readonly glowFilterId?: string;
+}): React.ReactElement {
+  return (
+    <defs>
+      <filter
+        id={glowFilterId}
+        x="-35%"
+        y="-120%"
+        width="170%"
+        height="340%"
+        colorInterpolationFilters="sRGB"
+      >
+        <feGaussianBlur stdDeviation="3" result="blur" />
+        <feMerge>
+          <feMergeNode in="blur" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+    </defs>
+  );
+}
+
+export function ReducedMotionLine({
+  start,
+  end,
+  color,
+  opacity = 0.65,
+  durationMs = DEFAULT_REDUCED_MOTION_DURATION_MS,
+  delayMs = 0,
+  testId = 'attack-effect-reduced-line',
+}: LineEffectProps): React.ReactElement {
+  const geometry = lineGeometry(start, end);
+  return (
+    <g
+      pointerEvents="none"
+      opacity={opacity}
+      transform={geometry.transform}
+      data-testid={testId}
+      data-effect="reduced"
+      data-duration-ms={durationMs}
+      data-delay-ms={delayMs}
+    >
+      <g
+        style={attackAnimationStyle(
+          'attack-effect-reduced-fade',
+          durationMs,
+          delayMs,
+          { transformBox: 'view-box' },
+        )}
+      >
+        <line
+          x1={0}
+          y1={0}
+          x2={geometry.length}
+          y2={0}
+          stroke={color}
+          strokeWidth={3}
+          strokeLinecap="round"
+        />
+      </g>
+    </g>
+  );
+}

--- a/src/components/gameplay/overlays/FiringArcOverlay.tsx
+++ b/src/components/gameplay/overlays/FiringArcOverlay.tsx
@@ -1,0 +1,262 @@
+import React, { useMemo } from 'react';
+
+import type { IHexCoordinate } from '@/types/gameplay';
+import type {
+  ArcClassifierUnit,
+  ArcMapBounds,
+  UiFiringArc,
+} from '@/utils/overlays/arcClassifier';
+
+import {
+  hexPath,
+  hexToPixel,
+} from '@/components/gameplay/HexMapDisplay/renderHelpers';
+import { coordToKey, hexEquals } from '@/utils/gameplay/hexMath';
+import { classifyFiringArcHexes } from '@/utils/overlays/arcClassifier';
+
+export interface FiringArcOverlayProps {
+  readonly unit: ArcClassifierUnit | null;
+  readonly hexes: readonly IHexCoordinate[];
+  readonly maxRange: number;
+  readonly mapHexes?: ArcMapBounds;
+  readonly enabled?: boolean;
+  readonly visibleArcs?: readonly UiFiringArc[];
+  readonly testId?: string;
+}
+
+interface ArcStyle {
+  readonly fill: string;
+  readonly fillOpacity: number;
+  readonly stroke: string;
+  readonly label: string;
+}
+
+const ARC_STYLES: Record<Exclude<UiFiringArc, 'out-of-arc'>, ArcStyle> = {
+  front: {
+    fill: '#22c55e',
+    fillOpacity: 0.25,
+    stroke: '#15803d',
+    label: 'Front arc',
+  },
+  'left-side': {
+    fill: '#eab308',
+    fillOpacity: 0.2,
+    stroke: '#a16207',
+    label: 'Left side arc',
+  },
+  'right-side': {
+    fill: '#eab308',
+    fillOpacity: 0.2,
+    stroke: '#a16207',
+    label: 'Right side arc',
+  },
+  rear: {
+    fill: '#f43f5e',
+    fillOpacity: 0.25,
+    stroke: '#be123c',
+    label: 'Rear arc',
+  },
+};
+
+function coordsEqual(
+  left: IHexCoordinate | null | undefined,
+  right: IHexCoordinate | null | undefined,
+): boolean {
+  if (!left || !right) return left === right;
+  return hexEquals(left, right);
+}
+
+function coordListEqual(
+  left: readonly IHexCoordinate[],
+  right: readonly IHexCoordinate[],
+): boolean {
+  if (left === right) return true;
+  if (left.length !== right.length) return false;
+  return left.every((coord, index) => hexEquals(coord, right[index]));
+}
+
+function arcListEqual(
+  left: readonly UiFiringArc[] | undefined,
+  right: readonly UiFiringArc[] | undefined,
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return left === right;
+  if (left.length !== right.length) return false;
+  return left.every((arc, index) => arc === right[index]);
+}
+
+function isCoordinateBounds(
+  bounds: ArcMapBounds,
+): bounds is readonly IHexCoordinate[] {
+  return Array.isArray(bounds);
+}
+
+function mapBoundsKeys(bounds: ArcMapBounds): readonly string[] {
+  if (isCoordinateBounds(bounds)) {
+    return bounds.map(coordToKey);
+  }
+  return Array.from(bounds);
+}
+
+function mapBoundsEqual(
+  left: ArcMapBounds | undefined,
+  right: ArcMapBounds | undefined,
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return left === right;
+
+  const leftKeys = mapBoundsKeys(left);
+  const rightKeys = mapBoundsKeys(right);
+
+  if (leftKeys.length !== rightKeys.length) return false;
+  return leftKeys.every((key, index) => key === rightKeys[index]);
+}
+
+function unitsEqual(
+  left: ArcClassifierUnit | null,
+  right: ArcClassifierUnit | null,
+): boolean {
+  if (!left || !right) return left === right;
+  return (
+    coordsEqual(left.coord, right.coord) &&
+    left.facing === right.facing &&
+    left.unitId === right.unitId &&
+    left.prone === right.prone
+  );
+}
+
+export function areFiringArcOverlayPropsEqual(
+  previous: FiringArcOverlayProps,
+  next: FiringArcOverlayProps,
+): boolean {
+  return (
+    unitsEqual(previous.unit, next.unit) &&
+    coordListEqual(previous.hexes, next.hexes) &&
+    previous.maxRange === next.maxRange &&
+    previous.enabled === next.enabled &&
+    previous.testId === next.testId &&
+    mapBoundsEqual(previous.mapHexes, next.mapHexes) &&
+    arcListEqual(previous.visibleArcs, next.visibleArcs)
+  );
+}
+
+function ArcShape({
+  arc,
+  hex,
+  testId,
+}: {
+  readonly arc: Exclude<UiFiringArc, 'out-of-arc'>;
+  readonly hex: IHexCoordinate;
+  readonly testId: string;
+}): React.ReactElement {
+  const { x, y } = hexToPixel(hex);
+
+  if (arc === 'front') {
+    return (
+      <path
+        d={`M ${x - 8} ${y + 4} L ${x} ${y - 6} L ${x + 8} ${y + 4}`}
+        fill="none"
+        stroke="#14532d"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        data-testid={testId}
+      />
+    );
+  }
+
+  if (arc === 'rear') {
+    return (
+      <line
+        x1={x - 8}
+        y1={y}
+        x2={x + 8}
+        y2={y}
+        stroke="#881337"
+        strokeWidth={2.5}
+        strokeLinecap="round"
+        data-testid={testId}
+      />
+    );
+  }
+
+  return (
+    <circle
+      cx={x}
+      cy={y}
+      r={3.5}
+      fill="#713f12"
+      fillOpacity={0.9}
+      data-testid={testId}
+    />
+  );
+}
+
+function FiringArcOverlayComponent({
+  unit,
+  hexes,
+  maxRange,
+  mapHexes,
+  enabled = true,
+  visibleArcs,
+  testId = 'firing-arc-overlay',
+}: FiringArcOverlayProps): React.ReactElement {
+  const arcHexes = useMemo(() => {
+    if (!enabled || !unit) return [];
+
+    return classifyFiringArcHexes(unit, hexes, {
+      mapHexes,
+      maxRange,
+      includeOrigin: false,
+      visibleArcs,
+    }).filter((classification) => classification.arc !== 'out-of-arc');
+  }, [enabled, hexes, mapHexes, maxRange, unit, visibleArcs]);
+
+  return (
+    <g
+      pointerEvents="none"
+      data-testid={testId}
+      aria-label="Firing arc overlay"
+    >
+      {arcHexes.map(({ hex, arc }) => {
+        const typedArc = arc as Exclude<UiFiringArc, 'out-of-arc'>;
+        const style = ARC_STYLES[typedArc];
+        const key = coordToKey(hex);
+        const title = `${style.label} at (${hex.q}, ${hex.r})`;
+        const { x, y } = hexToPixel(hex);
+
+        return (
+          <g
+            key={key}
+            data-testid={`firing-arc-hex-${key}`}
+            data-arc={typedArc}
+            aria-label={title}
+          >
+            <title>{title}</title>
+            <path
+              d={hexPath(x, y)}
+              fill={style.fill}
+              fillOpacity={style.fillOpacity}
+              stroke={style.stroke}
+              strokeOpacity={0.35}
+              strokeWidth={1}
+              data-testid={`firing-arc-fill-${key}`}
+            />
+            <ArcShape
+              arc={typedArc}
+              hex={hex}
+              testId={`firing-arc-shape-${typedArc}-${key}`}
+            />
+          </g>
+        );
+      })}
+    </g>
+  );
+}
+
+export const FiringArcOverlay = React.memo(
+  FiringArcOverlayComponent,
+  areFiringArcOverlayPropsEqual,
+);
+
+export default FiringArcOverlay;

--- a/src/components/gameplay/overlays/LineOfSightOverlay.tsx
+++ b/src/components/gameplay/overlays/LineOfSightOverlay.tsx
@@ -1,0 +1,223 @@
+import React, { useMemo } from 'react';
+
+import type {
+  IHexCoordinate,
+  IHexGrid,
+} from '@/types/gameplay/HexGridInterfaces';
+import type {
+  LOSBlockerMetadata,
+  LOSClassification,
+  LOSOverlayState,
+} from '@/utils/overlays/losClassifier';
+
+import { hexToPixel } from '@/components/gameplay/HexMapDisplay/renderHelpers';
+import { hexEquals } from '@/utils/gameplay/hexMath';
+import { classifyLOS } from '@/utils/overlays/losClassifier';
+
+export interface LineOfSightOverlayProps {
+  readonly origin: IHexCoordinate | null;
+  readonly target: IHexCoordinate | null;
+  readonly grid: IHexGrid | null;
+  readonly enabled?: boolean;
+  readonly fromElevation?: number;
+  readonly toElevation?: number;
+  readonly testId?: string;
+}
+
+interface LOSStyle {
+  readonly stroke: string;
+  readonly dash?: string;
+}
+
+const LOS_STYLES: Record<LOSOverlayState, LOSStyle> = {
+  clear: { stroke: '#16a34a' },
+  partial: { stroke: '#ca8a04', dash: '6,4' },
+  blocked: { stroke: '#dc2626' },
+};
+
+function coordsEqual(
+  left: IHexCoordinate | null | undefined,
+  right: IHexCoordinate | null | undefined,
+): boolean {
+  if (!left || !right) return left === right;
+  return hexEquals(left, right);
+}
+
+export function areLineOfSightOverlayPropsEqual(
+  previous: LineOfSightOverlayProps,
+  next: LineOfSightOverlayProps,
+): boolean {
+  return (
+    coordsEqual(previous.origin, next.origin) &&
+    coordsEqual(previous.target, next.target) &&
+    previous.grid === next.grid &&
+    previous.enabled === next.enabled &&
+    previous.fromElevation === next.fromElevation &&
+    previous.toElevation === next.toElevation &&
+    previous.testId === next.testId
+  );
+}
+
+function announcementFor(classification: LOSClassification): string {
+  if (classification.state === 'clear') {
+    return 'Line of sight clear';
+  }
+
+  const firstAnnotation = classification.blockerAnnotations[0];
+  if (classification.state === 'partial') {
+    return firstAnnotation
+      ? `Line of sight partial: ${firstAnnotation.title}`
+      : 'Line of sight partial';
+  }
+
+  return firstAnnotation
+    ? `Line of sight blocked: ${firstAnnotation.title}`
+    : 'Line of sight blocked';
+}
+
+function CoverIcon({
+  annotation,
+}: {
+  readonly annotation: LOSBlockerMetadata;
+}): React.ReactElement {
+  const { x, y } = hexToPixel(annotation.coord);
+  const key = `${annotation.coord.q},${annotation.coord.r}`;
+
+  return (
+    <g
+      data-testid={`los-annotation-cover-${key}`}
+      data-icon="cover"
+      aria-label={annotation.title}
+    >
+      <title>{annotation.title}</title>
+      <path
+        d={`M ${x} ${y - 12} L ${x - 10} ${y - 5} L ${x - 8} ${y + 8} Q ${x} ${y + 14} ${x + 8} ${y + 8} L ${x + 10} ${y - 5} Z`}
+        fill="#fef3c7"
+        stroke="#92400e"
+        strokeWidth={1.5}
+      />
+      <line
+        x1={x - 6}
+        y1={y}
+        x2={x + 6}
+        y2={y}
+        stroke="#92400e"
+        strokeWidth={2}
+        strokeLinecap="round"
+      />
+    </g>
+  );
+}
+
+function WallIcon({
+  annotation,
+}: {
+  readonly annotation: LOSBlockerMetadata;
+}): React.ReactElement {
+  const { x, y } = hexToPixel(annotation.coord);
+  const key = `${annotation.coord.q},${annotation.coord.r}`;
+
+  return (
+    <g
+      data-testid={`los-annotation-wall-${key}`}
+      data-icon="wall"
+      aria-label={annotation.title}
+    >
+      <title>{annotation.title}</title>
+      <rect
+        x={x - 11}
+        y={y - 10}
+        width={22}
+        height={20}
+        rx={2}
+        fill="#fee2e2"
+        stroke="#991b1b"
+        strokeWidth={1.5}
+      />
+      <line x1={x - 11} y1={y - 3} x2={x + 11} y2={y - 3} stroke="#991b1b" />
+      <line x1={x - 11} y1={y + 4} x2={x + 11} y2={y + 4} stroke="#991b1b" />
+      <line x1={x - 3} y1={y - 10} x2={x - 3} y2={y - 3} stroke="#991b1b" />
+      <line x1={x + 5} y1={y - 3} x2={x + 5} y2={y + 4} stroke="#991b1b" />
+      <line x1={x - 4} y1={y + 4} x2={x - 4} y2={y + 10} stroke="#991b1b" />
+    </g>
+  );
+}
+
+function BlockerAnnotation({
+  annotation,
+}: {
+  readonly annotation: LOSBlockerMetadata;
+}): React.ReactElement {
+  if (annotation.icon === 'wall') {
+    return <WallIcon annotation={annotation} />;
+  }
+
+  return <CoverIcon annotation={annotation} />;
+}
+
+function LineOfSightOverlayComponent({
+  origin,
+  target,
+  grid,
+  enabled = true,
+  fromElevation,
+  toElevation,
+  testId = 'line-of-sight-overlay',
+}: LineOfSightOverlayProps): React.ReactElement {
+  const classification = useMemo(() => {
+    if (!enabled || !origin || !target || !grid) return null;
+    return classifyLOS(origin, target, grid, { fromElevation, toElevation });
+  }, [enabled, fromElevation, grid, origin, target, toElevation]);
+
+  if (!classification || !origin || !target) {
+    return (
+      <g
+        pointerEvents="none"
+        data-testid={testId}
+        aria-label="Line of sight overlay"
+        aria-live="polite"
+      />
+    );
+  }
+
+  const style = LOS_STYLES[classification.state];
+  const start = hexToPixel(origin);
+  const end = hexToPixel(classification.lineEnd);
+  const announcement = announcementFor(classification);
+
+  return (
+    <g
+      pointerEvents="none"
+      data-testid={testId}
+      aria-label={announcement}
+      aria-live="polite"
+    >
+      <title>{announcement}</title>
+      <line
+        data-testid="los-line"
+        data-state={classification.state}
+        x1={start.x}
+        y1={start.y}
+        x2={end.x}
+        y2={end.y}
+        stroke={style.stroke}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeDasharray={style.dash}
+      />
+      {classification.blockerAnnotations.map((annotation) => (
+        <BlockerAnnotation
+          key={`${annotation.icon}-${annotation.coord.q},${annotation.coord.r}`}
+          annotation={annotation}
+        />
+      ))}
+    </g>
+  );
+}
+
+export const LineOfSightOverlay = React.memo(
+  LineOfSightOverlayComponent,
+  areLineOfSightOverlayPropsEqual,
+);
+
+export default LineOfSightOverlay;

--- a/src/components/gameplay/overlays/__tests__/FiringArcOverlay.test.tsx
+++ b/src/components/gameplay/overlays/__tests__/FiringArcOverlay.test.tsx
@@ -1,0 +1,127 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import { Facing, type IHexCoordinate } from '@/types/gameplay';
+import { hexNeighbor } from '@/utils/gameplay/hexMath';
+
+import {
+  FiringArcOverlay,
+  areFiringArcOverlayPropsEqual,
+  type FiringArcOverlayProps,
+} from '../FiringArcOverlay';
+
+const origin: IHexCoordinate = { q: 0, r: 0 };
+const unit = {
+  unitId: 'atlas',
+  coord: origin,
+  facing: Facing.North,
+  prone: false,
+};
+
+const radiusOneHexes: readonly IHexCoordinate[] = [
+  origin,
+  hexNeighbor(origin, Facing.North),
+  hexNeighbor(origin, Facing.Northeast),
+  hexNeighbor(origin, Facing.Southeast),
+  hexNeighbor(origin, Facing.South),
+  hexNeighbor(origin, Facing.Southwest),
+  hexNeighbor(origin, Facing.Northwest),
+];
+
+function renderOverlay(props: Partial<FiringArcOverlayProps> = {}) {
+  return render(
+    <svg>
+      <FiringArcOverlay
+        unit={unit}
+        hexes={radiusOneHexes}
+        maxRange={1}
+        {...props}
+      />
+    </svg>,
+  );
+}
+
+describe('FiringArcOverlay', () => {
+  it('renders SVG-only arc shading with pointer events disabled and labels', () => {
+    const { container } = renderOverlay();
+
+    const overlay = screen.getByTestId('firing-arc-overlay');
+    expect(overlay).toHaveAttribute('pointer-events', 'none');
+    expect(overlay).toHaveAttribute('aria-label', 'Firing arc overlay');
+
+    const frontHex = screen.getByTestId('firing-arc-hex-0,-1');
+    expect(frontHex).toHaveAttribute('data-arc', 'front');
+    expect(frontHex).toHaveAttribute('aria-label', 'Front arc at (0, -1)');
+
+    const frontFill = screen.getByTestId('firing-arc-fill-0,-1');
+    expect(frontFill).toHaveAttribute('fill', '#22c55e');
+    expect(frontFill).toHaveAttribute('fill-opacity', '0.25');
+    expect(
+      screen.getByTestId('firing-arc-shape-front-0,-1'),
+    ).toBeInTheDocument();
+
+    expect(container.querySelectorAll('title').length).toBeGreaterThan(0);
+  });
+
+  it('renders side and rear style distinctions without shading the unit origin', () => {
+    renderOverlay();
+
+    expect(screen.queryByTestId('firing-arc-hex-0,0')).not.toBeInTheDocument();
+
+    const rightSideHex = screen.getByTestId('firing-arc-hex-1,0');
+    expect(rightSideHex).toHaveAttribute('data-arc', 'right-side');
+    expect(screen.getByTestId('firing-arc-fill-1,0')).toHaveAttribute(
+      'fill-opacity',
+      '0.2',
+    );
+    expect(
+      screen.getByTestId('firing-arc-shape-right-side-1,0'),
+    ).toBeInTheDocument();
+
+    const rearHex = screen.getByTestId('firing-arc-hex-0,1');
+    expect(rearHex).toHaveAttribute('data-arc', 'rear');
+    expect(screen.getByTestId('firing-arc-fill-0,1')).toHaveAttribute(
+      'fill',
+      '#f43f5e',
+    );
+    expect(screen.getByTestId('firing-arc-shape-rear-0,1')).toBeInTheDocument();
+  });
+
+  it('keeps out-of-range and hidden arcs unrendered', () => {
+    renderOverlay({
+      hexes: [...radiusOneHexes, { q: 0, r: -2 }],
+      maxRange: 1,
+      visibleArcs: ['rear'],
+    });
+
+    expect(screen.queryByTestId('firing-arc-hex-0,-2')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('firing-arc-hex-0,-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('firing-arc-hex-0,1')).toHaveAttribute(
+      'data-arc',
+      'rear',
+    );
+  });
+
+  it('exposes a memo comparator to avoid rerendering for semantically identical map props', () => {
+    const previous: FiringArcOverlayProps = {
+      unit,
+      hexes: radiusOneHexes,
+      maxRange: 1,
+      enabled: true,
+    };
+    const next: FiringArcOverlayProps = {
+      unit: { ...unit, coord: { ...unit.coord } },
+      hexes: radiusOneHexes.map((hex) => ({ ...hex })),
+      maxRange: 1,
+      enabled: true,
+    };
+
+    expect(areFiringArcOverlayPropsEqual(previous, next)).toBe(true);
+    expect(
+      areFiringArcOverlayPropsEqual(previous, {
+        ...next,
+        unit: { ...unit, facing: Facing.South },
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/components/gameplay/overlays/__tests__/LineOfSightOverlay.test.tsx
+++ b/src/components/gameplay/overlays/__tests__/LineOfSightOverlay.test.tsx
@@ -1,0 +1,179 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import type {
+  IHex,
+  IHexCoordinate,
+  IHexGrid,
+} from '@/types/gameplay/HexGridInterfaces';
+
+import { hexToPixel } from '@/components/gameplay/HexMapDisplay/renderHelpers';
+import { TerrainType } from '@/types/gameplay/TerrainTypes';
+import { coordToKey } from '@/utils/gameplay/hexMath';
+
+import {
+  LineOfSightOverlay,
+  areLineOfSightOverlayPropsEqual,
+  type LineOfSightOverlayProps,
+} from '../LineOfSightOverlay';
+
+const origin: IHexCoordinate = { q: 0, r: 0 };
+const target: IHexCoordinate = { q: 2, r: 0 };
+
+function createHex(
+  q: number,
+  r: number,
+  terrain: TerrainType = TerrainType.Clear,
+  elevation = 0,
+): IHex {
+  return {
+    coord: { q, r },
+    occupantId: null,
+    terrain,
+    elevation,
+  };
+}
+
+function createGrid(hexes: readonly IHex[]): IHexGrid {
+  const map = new Map<string, IHex>();
+  for (const hex of hexes) {
+    map.set(coordToKey(hex.coord), hex);
+  }
+
+  return {
+    config: { radius: 10 },
+    hexes: map,
+  };
+}
+
+function renderOverlay(
+  grid: IHexGrid,
+  props: Partial<LineOfSightOverlayProps> = {},
+) {
+  return render(
+    <svg>
+      <LineOfSightOverlay
+        origin={origin}
+        target={target}
+        grid={grid}
+        {...props}
+      />
+    </svg>,
+  );
+}
+
+describe('LineOfSightOverlay', () => {
+  it('renders clear LOS as a solid green SVG line with pointer events disabled', () => {
+    const grid = createGrid([
+      createHex(0, 0),
+      createHex(1, 0),
+      createHex(2, 0),
+    ]);
+
+    renderOverlay(grid);
+
+    const overlay = screen.getByTestId('line-of-sight-overlay');
+    expect(overlay).toHaveAttribute('pointer-events', 'none');
+    expect(overlay).toHaveAttribute('aria-live', 'polite');
+    expect(overlay).toHaveAttribute('aria-label', 'Line of sight clear');
+
+    const line = screen.getByTestId('los-line');
+    expect(line).toHaveAttribute('data-state', 'clear');
+    expect(line).toHaveAttribute('stroke', '#16a34a');
+    expect(line).toHaveAttribute('stroke-width', '2');
+    expect(line).not.toHaveAttribute('stroke-dasharray');
+  });
+
+  it('renders partial cover as a dashed yellow line with a titled cover annotation', () => {
+    const grid = createGrid([
+      createHex(0, 0),
+      createHex(1, 0, TerrainType.LightWoods),
+      createHex(2, 0),
+    ]);
+    const { container } = renderOverlay(grid);
+
+    const line = screen.getByTestId('los-line');
+    expect(line).toHaveAttribute('data-state', 'partial');
+    expect(line).toHaveAttribute('stroke', '#ca8a04');
+    expect(line).toHaveAttribute('stroke-dasharray', '6,4');
+
+    const annotation = screen.getByTestId('los-annotation-cover-1,0');
+    expect(annotation).toHaveAttribute('data-icon', 'cover');
+    expect(annotation).toHaveAttribute(
+      'aria-label',
+      'Partial cover through light woods at (1, 0)',
+    );
+    expect(container.querySelector('title')?.textContent).toContain(
+      'Line of sight partial',
+    );
+    expect(annotation.querySelector('title')?.textContent).toContain(
+      'Partial cover through light woods',
+    );
+  });
+
+  it('renders blocked LOS as a solid red line ending at the first blocker', () => {
+    const grid = createGrid([
+      createHex(0, 0),
+      createHex(1, 0, TerrainType.Building),
+      createHex(2, 0),
+    ]);
+    const blockerPixel = hexToPixel({ q: 1, r: 0 });
+    const targetPixel = hexToPixel(target);
+
+    renderOverlay(grid);
+
+    const line = screen.getByTestId('los-line');
+    expect(line).toHaveAttribute('data-state', 'blocked');
+    expect(line).toHaveAttribute('stroke', '#dc2626');
+    expect(line).not.toHaveAttribute('stroke-dasharray');
+    expect(line).toHaveAttribute('x2', String(blockerPixel.x));
+    expect(line).not.toHaveAttribute('x2', String(targetPixel.x));
+
+    const annotation = screen.getByTestId('los-annotation-wall-1,0');
+    expect(annotation).toHaveAttribute('data-icon', 'wall');
+    expect(annotation.querySelector('title')?.textContent).toContain(
+      'Blocked by building',
+    );
+  });
+
+  it('renders an empty labelled group when origin, target, or grid is unavailable', () => {
+    render(
+      <svg>
+        <LineOfSightOverlay origin={origin} target={null} grid={null} />
+      </svg>,
+    );
+
+    const overlay = screen.getByTestId('line-of-sight-overlay');
+    expect(overlay).toHaveAttribute('pointer-events', 'none');
+    expect(overlay).toHaveAttribute('aria-label', 'Line of sight overlay');
+    expect(screen.queryByTestId('los-line')).not.toBeInTheDocument();
+  });
+
+  it('exposes a memo comparator scoped to hover/origin/grid changes', () => {
+    const grid = createGrid([
+      createHex(0, 0),
+      createHex(1, 0),
+      createHex(2, 0),
+    ]);
+    const previous: LineOfSightOverlayProps = {
+      origin,
+      target,
+      grid,
+      enabled: true,
+    };
+    const next: LineOfSightOverlayProps = {
+      origin: { ...origin },
+      target: { ...target },
+      grid,
+      enabled: true,
+    };
+
+    expect(areLineOfSightOverlayPropsEqual(previous, next)).toBe(true);
+    expect(
+      areLineOfSightOverlayPropsEqual(previous, {
+        ...next,
+        target: { q: 3, r: 0 },
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/useScreenShake.test.tsx
+++ b/src/hooks/__tests__/useScreenShake.test.tsx
@@ -1,0 +1,126 @@
+import { act, renderHook } from '@testing-library/react';
+
+import type { IDamageAppliedPayload, IGameEvent } from '@/types/gameplay';
+
+import {
+  SCREEN_SHAKE_DURATION_MS,
+  screenShakeIntensityForDamage,
+  useScreenShake,
+} from '@/hooks/useScreenShake';
+import { GameEventType, GamePhase } from '@/types/gameplay';
+
+function buildDamageEvent(
+  id: string,
+  payload: IDamageAppliedPayload,
+  sequence = 1,
+): IGameEvent {
+  return {
+    id,
+    gameId: 'g1',
+    sequence,
+    timestamp: `2026-01-01T00:00:0${sequence}.000Z`,
+    type: GameEventType.DamageApplied,
+    turn: 1,
+    phase: GamePhase.WeaponAttack,
+    payload,
+  };
+}
+
+function damagePayload(
+  overrides: Partial<IDamageAppliedPayload> = {},
+): IDamageAppliedPayload {
+  return {
+    unitId: 'u1',
+    location: 'center_torso',
+    damage: 12,
+    armorRemaining: 8,
+    structureRemaining: 12,
+    locationDestroyed: false,
+    ...overrides,
+  };
+}
+
+describe('useScreenShake', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('scales heavy-hit damage linearly and clamps at 8px', () => {
+    expect(screenShakeIntensityForDamage(9)).toBe(0);
+    expect(screenShakeIntensityForDamage(10)).toBe(4);
+    expect(screenShakeIntensityForDamage(15)).toBe(6);
+    expect(screenShakeIntensityForDamage(20)).toBe(8);
+    expect(screenShakeIntensityForDamage(25)).toBe(8);
+  });
+
+  it('subscribes to explicit DamageApplied event arrays', () => {
+    const events: readonly IGameEvent[] = [
+      buildDamageEvent('d1', damagePayload({ damage: 20 })),
+    ];
+
+    const { result } = renderHook(() =>
+      useScreenShake({
+        events,
+        prefersReducedMotion: false,
+        random: () => 1,
+      }),
+    );
+
+    expect(result.current.transform).toBe('translate3d(8px, 8px, 0)');
+    expect(result.current.style.transform).toBe('translate3d(8px, 8px, 0)');
+    expect(result.current.liveMessage).toBe('heavy hit');
+    expect(result.current.isShaking).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(SCREEN_SHAKE_DURATION_MS);
+    });
+
+    expect(result.current.transform).toBe('translate3d(0px, 0px, 0)');
+    expect(result.current.liveMessage).toBe('');
+    expect(result.current.isShaking).toBe(false);
+  });
+
+  it('ignores DamageApplied events below the heavy-hit threshold', () => {
+    const events: readonly IGameEvent[] = [
+      buildDamageEvent('d-small', damagePayload({ damage: 6 })),
+    ];
+
+    const { result } = renderHook(() =>
+      useScreenShake({
+        events,
+        prefersReducedMotion: false,
+        random: () => 1,
+      }),
+    );
+
+    expect(result.current.transform).toBe('translate3d(0px, 0px, 0)');
+    expect(result.current.liveMessage).toBe('');
+  });
+
+  it('halves reduced-motion shakes and skips tiny manual shakes', () => {
+    const { result } = renderHook(() =>
+      useScreenShake({
+        prefersReducedMotion: true,
+        random: () => 1,
+      }),
+    );
+
+    act(() => {
+      result.current.shake(3, SCREEN_SHAKE_DURATION_MS);
+    });
+
+    expect(result.current.transform).toBe('translate3d(0px, 0px, 0)');
+    expect(result.current.liveMessage).toBe('');
+
+    act(() => {
+      result.current.shake(8, SCREEN_SHAKE_DURATION_MS);
+    });
+
+    expect(result.current.transform).toBe('translate3d(4px, 4px, 0)');
+    expect(result.current.liveMessage).toBe('heavy hit');
+  });
+});

--- a/src/hooks/useScreenShake.ts
+++ b/src/hooks/useScreenShake.ts
@@ -1,0 +1,159 @@
+import type { CSSProperties } from 'react';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import type { IGameEvent } from '@/types/gameplay';
+
+import { isDamageAppliedEvent } from '@/components/gameplay/effects/damageEffectHelpers';
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+
+export const SCREEN_SHAKE_DAMAGE_THRESHOLD = 10;
+export const SCREEN_SHAKE_MAX_INTENSITY = 8;
+export const SCREEN_SHAKE_DURATION_MS = 300;
+
+const DAMAGE_TO_INTENSITY_SCALE =
+  SCREEN_SHAKE_MAX_INTENSITY / (SCREEN_SHAKE_DAMAGE_THRESHOLD * 2);
+const ZERO_OFFSET: ShakeOffset = { x: 0, y: 0 };
+const ZERO_TRANSFORM = 'translate3d(0px, 0px, 0)';
+
+interface ShakeOffset {
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface UseScreenShakeOptions {
+  readonly events?: readonly IGameEvent[];
+  readonly prefersReducedMotion?: boolean;
+  readonly random?: () => number;
+}
+
+export interface UseScreenShakeResult {
+  readonly shake: (intensity: number, durationMs?: number) => void;
+  readonly transform: string;
+  readonly style: CSSProperties;
+  readonly liveMessage: string;
+  readonly isShaking: boolean;
+}
+
+export function screenShakeIntensityForDamage(damage: number): number {
+  if (damage < SCREEN_SHAKE_DAMAGE_THRESHOLD) return 0;
+  return Math.min(
+    SCREEN_SHAKE_MAX_INTENSITY,
+    Math.max(0, damage * DAMAGE_TO_INTENSITY_SCALE),
+  );
+}
+
+export function useScreenShake(
+  options: UseScreenShakeOptions = {},
+): UseScreenShakeResult {
+  const systemPrefersReducedMotion = usePrefersReducedMotion();
+  const prefersReducedMotion =
+    options.prefersReducedMotion ?? systemPrefersReducedMotion;
+  const randomRef = useRef(options.random ?? Math.random);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const seenEventIdsRef = useRef<Set<string>>(new Set());
+
+  const [offset, setOffset] = useState<ShakeOffset>(ZERO_OFFSET);
+  const [isShaking, setIsShaking] = useState(false);
+  const [liveMessage, setLiveMessage] = useState('');
+
+  useEffect(() => {
+    randomRef.current = options.random ?? Math.random;
+  }, [options.random]);
+
+  const clearShakeTimer = useCallback((): void => {
+    if (!timerRef.current) return;
+    clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }, []);
+
+  const shake = useCallback(
+    (intensity: number, durationMs = SCREEN_SHAKE_DURATION_MS): void => {
+      const dampenedIntensity = prefersReducedMotion
+        ? intensity / 2
+        : intensity;
+      const effectiveIntensity = Math.min(
+        SCREEN_SHAKE_MAX_INTENSITY,
+        Math.max(0, dampenedIntensity),
+      );
+
+      if (prefersReducedMotion && effectiveIntensity < 2) return;
+      if (effectiveIntensity <= 0) return;
+
+      clearShakeTimer();
+
+      setOffset({
+        x: randomOffset(effectiveIntensity, randomRef.current),
+        y: randomOffset(effectiveIntensity, randomRef.current),
+      });
+      setIsShaking(true);
+      setLiveMessage('heavy hit');
+
+      timerRef.current = setTimeout(() => {
+        setOffset(ZERO_OFFSET);
+        setIsShaking(false);
+        setLiveMessage('');
+        timerRef.current = null;
+      }, durationMs);
+    },
+    [clearShakeTimer, prefersReducedMotion],
+  );
+
+  useEffect(() => {
+    const events = options.events;
+    if (!events) return;
+
+    for (const event of events) {
+      if (seenEventIdsRef.current.has(event.id)) continue;
+      seenEventIdsRef.current.add(event.id);
+      if (!isDamageAppliedEvent(event)) continue;
+
+      const intensity = screenShakeIntensityForDamage(event.payload.damage);
+      if (intensity > 0) {
+        shake(intensity, SCREEN_SHAKE_DURATION_MS);
+      }
+    }
+  }, [options.events, shake]);
+
+  useEffect(
+    () => () => {
+      clearShakeTimer();
+    },
+    [clearShakeTimer],
+  );
+
+  const transform = useMemo(
+    () =>
+      offset.x === 0 && offset.y === 0
+        ? ZERO_TRANSFORM
+        : `translate3d(${offset.x}px, ${offset.y}px, 0)`,
+    [offset.x, offset.y],
+  );
+
+  const style = useMemo<CSSProperties>(
+    () => ({
+      transform,
+      transition: prefersReducedMotion
+        ? 'transform 80ms ease-out'
+        : 'transform 40ms linear',
+      willChange: isShaking ? 'transform' : undefined,
+    }),
+    [isShaking, prefersReducedMotion, transform],
+  );
+
+  return {
+    shake,
+    transform,
+    style,
+    liveMessage,
+    isShaking,
+  };
+}
+
+function randomOffset(intensity: number, random: () => number): number {
+  return roundToTenth((random() * 2 - 1) * intensity);
+}
+
+function roundToTenth(value: number): number {
+  return Math.round(value * 10) / 10;
+}

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -408,6 +408,20 @@ export type MovementAnimationMode =
   | MovementType.Run
   | MovementType.Jump;
 
+export type AttackVisualCategory =
+  | 'laser'
+  | 'missile'
+  | 'ballistic'
+  | 'physical'
+  | 'energy';
+
+export type HeatVisualThreshold =
+  | 'normal'
+  | 'warm'
+  | 'hot'
+  | 'overheat'
+  | 'critical';
+
 /**
  * Movement declared event payload.
  */
@@ -530,6 +544,22 @@ export interface IAttackResolvedPayload {
    */
   readonly ammoBinId?: string | null;
   /**
+   * Phase 7 tactical visual hint. Optional so existing event streams and
+   * combat resolvers remain replay-compatible; UI layers may derive a
+   * category from weapon metadata when this is absent.
+   */
+  readonly visualCategory?: AttackVisualCategory;
+  /**
+   * Stable subtype key for visual color/stagger maps, such as
+   * `medium-laser`, `lrm-20`, or `kick`. Optional for legacy streams.
+   */
+  readonly visualSubtype?: string;
+  /**
+   * Projectile/tracer count for cluster and multi-shot weapons. Optional
+   * because non-cluster weapons can render a single primitive by default.
+   */
+  readonly projectileCount?: number;
+  /**
    * Per `add-authoritative-roll-arbitration` (Wave 3a): every individual
    * d6 the server consumed for this event, in consumption order
    * (typically the to-hit 2d6 + the location 2d6 on hit). OPTIONAL so
@@ -607,6 +637,20 @@ export interface IHeatPayload {
     | 'external';
   /** New total heat */
   readonly newTotal: number;
+  /**
+   * Previous total heat when known. Optional because legacy event creators
+   * only carried the post-event total.
+   */
+  readonly previousTotal?: number;
+  /**
+   * UI threshold transition metadata for Phase 7 heat indicators. Optional
+   * so renderers can derive it from `previousTotal`/`newTotal` or fall back
+   * to `newTotal` alone for old replays.
+   */
+  readonly previousThreshold?: HeatVisualThreshold;
+  readonly currentThreshold?: HeatVisualThreshold;
+  /** Whether the new heat total is in the ammo-explosion warning band. */
+  readonly ammoExplosionRisk?: boolean;
   /**
    * Per `wire-heat-generation-and-effects` task 13.2: optional
    * dissipation breakdown. Populated only on `HeatDissipated` events

--- a/src/utils/effects/__tests__/heatVisualMap.test.ts
+++ b/src/utils/effects/__tests__/heatVisualMap.test.ts
@@ -1,0 +1,75 @@
+import {
+  getHeatThresholdTransition,
+  getHeatTransitionFromPayload,
+  getHeatVisualMap,
+  isAmmoExplosionDangerHeat,
+} from '../heatVisualMap';
+
+describe('heatVisualMap', () => {
+  it.each([
+    [0, 'normal', '#94a3b8', false, null],
+    [4, 'normal', '#94a3b8', false, null],
+    [5, 'warm', '#f59e0b', false, null],
+    [9, 'warm', '#f59e0b', false, null],
+    [10, 'hot', '#f97316', false, 'HOT'],
+    [14, 'hot', '#f97316', false, 'HOT'],
+    [15, 'overheat', '#dc2626', false, 'OVERHEAT'],
+    [19, 'overheat', '#dc2626', false, 'OVERHEAT'],
+    [20, 'critical', '#fff1f2', true, 'CRITICAL'],
+    [30, 'critical', '#fff1f2', true, 'CRITICAL'],
+  ] as const)('maps heat %i to %s', (heat, threshold, color, pulse, badge) => {
+    expect(getHeatVisualMap(heat)).toMatchObject({
+      threshold,
+      color,
+      pulse,
+      badge,
+    });
+  });
+
+  it('keeps intensity monotonic across threshold starts', () => {
+    const intensities = [0, 5, 10, 15, 20].map(
+      (heat) => getHeatVisualMap(heat).intensity,
+    );
+
+    expect(intensities).toEqual([...intensities].sort((a, b) => a - b));
+  });
+
+  it('normalizes invalid or negative heat to neutral', () => {
+    expect(getHeatVisualMap(-3).threshold).toBe('normal');
+    expect(getHeatVisualMap(Number.NaN).threshold).toBe('normal');
+  });
+
+  it('marks ammo explosion danger heat from existing heat rules', () => {
+    expect(isAmmoExplosionDangerHeat(18)).toBe(false);
+    expect(isAmmoExplosionDangerHeat(19)).toBe(true);
+    expect(isAmmoExplosionDangerHeat(30)).toBe(true);
+  });
+
+  it('derives threshold transitions from heat totals', () => {
+    expect(getHeatThresholdTransition(9, 20)).toEqual({
+      previousHeat: 9,
+      currentHeat: 20,
+      previousThreshold: 'warm',
+      currentThreshold: 'critical',
+      ammoExplosionRisk: true,
+    });
+  });
+
+  it('honors threshold metadata already present on heat events', () => {
+    expect(
+      getHeatTransitionFromPayload({
+        previousTotal: 4,
+        newTotal: 16,
+        previousThreshold: 'normal',
+        currentThreshold: 'overheat',
+        ammoExplosionRisk: false,
+      }),
+    ).toEqual({
+      previousHeat: 4,
+      currentHeat: 16,
+      previousThreshold: 'normal',
+      currentThreshold: 'overheat',
+      ammoExplosionRisk: false,
+    });
+  });
+});

--- a/src/utils/effects/__tests__/weaponEffectMap.test.ts
+++ b/src/utils/effects/__tests__/weaponEffectMap.test.ts
@@ -1,0 +1,110 @@
+import {
+  ATTACK_EFFECT_COLORS,
+  resolvePhysicalAttackEffect,
+  resolveWeaponEffect,
+  WEAPON_EFFECT_FALLBACK_CASES,
+  type AttackWeaponEffectPayload,
+  type PhysicalAttackEffectPayload,
+} from '../weaponEffectMap';
+
+function attackPayload(
+  overrides: Partial<AttackWeaponEffectPayload>,
+): AttackWeaponEffectPayload {
+  return {
+    attackerId: 'attacker',
+    targetId: 'target',
+    weaponId: 'weapon',
+    roll: 8,
+    toHitNumber: 7,
+    hit: true,
+    ...overrides,
+  };
+}
+
+function physicalPayload(
+  overrides: Partial<PhysicalAttackEffectPayload>,
+): PhysicalAttackEffectPayload {
+  return {
+    attackerId: 'attacker',
+    targetId: 'target',
+    attackType: 'punch',
+    roll: 8,
+    toHitNumber: 7,
+    hit: true,
+    ...overrides,
+  };
+}
+
+describe('weaponEffectMap', () => {
+  it('prefers visual metadata carried on the event payload', () => {
+    const effect = resolveWeaponEffect(
+      attackPayload({
+        weaponId: 'ambiguous-weapon',
+        visualCategory: 'laser',
+        visualSubtype: 'er-large-laser',
+        projectileCount: 3,
+        projectileStaggerMs: 15,
+      }),
+    );
+
+    expect(effect).toMatchObject({
+      category: 'laser',
+      primitive: 'laser',
+      visualSubtype: 'er-large-laser',
+      color: ATTACK_EFFECT_COLORS.laserErRedOrange,
+      projectileCount: 3,
+      staggerMs: 15,
+      metadataSource: {
+        category: 'event',
+        color: 'event',
+        projectiles: 'event',
+        stagger: 'event',
+      },
+    });
+  });
+
+  it.each(WEAPON_EFFECT_FALLBACK_CASES)(
+    'derives fallback metadata for $weaponName',
+    (testCase) => {
+      const effect = resolveWeaponEffect(
+        attackPayload({ weaponName: testCase.weaponName }),
+      );
+
+      expect(effect.category).toBe(testCase.expectedCategory);
+      expect(effect.color).toBe(testCase.expectedColor);
+      expect(effect.projectileCount).toBe(
+        'expectedProjectiles' in testCase ? testCase.expectedProjectiles : 1,
+      );
+      expect(effect.staggerMs).toBe(
+        'expectedStaggerMs' in testCase ? testCase.expectedStaggerMs : 0,
+      );
+    },
+  );
+
+  it('maps physical variants to ring and arc metadata', () => {
+    expect(
+      resolvePhysicalAttackEffect(physicalPayload({ attackType: 'kick' })),
+    ).toMatchObject({
+      category: 'physical',
+      primitive: 'shockwave',
+      ringStrokeWidth: 4,
+      showArc: false,
+      impactColor: ATTACK_EFFECT_COLORS.physicalImpactRed,
+    });
+
+    expect(
+      resolvePhysicalAttackEffect(physicalPayload({ attackType: 'hatchet' })),
+    ).toMatchObject({
+      ringStrokeWidth: 3,
+      showArc: true,
+      originShockwave: false,
+    });
+
+    expect(
+      resolvePhysicalAttackEffect(physicalPayload({ attackType: 'charge' })),
+    ).toMatchObject({
+      ringStrokeWidth: 5,
+      originShockwave: true,
+    });
+  });
+});

--- a/src/utils/effects/heatVisualMap.ts
+++ b/src/utils/effects/heatVisualMap.ts
@@ -1,0 +1,130 @@
+import type { HeatVisualThreshold, IHeatPayload } from '@/types/gameplay';
+
+import { getAmmoExplosionTN } from '@/constants/heat';
+
+export type HeatVisualBadge = 'HOT' | 'OVERHEAT' | 'CRITICAL';
+
+export interface HeatVisualState {
+  readonly threshold: HeatVisualThreshold;
+  readonly color: string;
+  readonly intensity: number;
+  readonly pulse: boolean;
+  readonly badge: HeatVisualBadge | null;
+}
+
+export interface HeatThresholdTransition {
+  readonly previousHeat: number;
+  readonly currentHeat: number;
+  readonly previousThreshold: HeatVisualThreshold;
+  readonly currentThreshold: HeatVisualThreshold;
+  readonly ammoExplosionRisk: boolean;
+}
+
+const NEUTRAL_HEAT: HeatVisualState = {
+  threshold: 'normal',
+  color: '#94a3b8',
+  intensity: 0.12,
+  pulse: false,
+  badge: null,
+};
+
+const WARM_HEAT: HeatVisualState = {
+  threshold: 'warm',
+  color: '#f59e0b',
+  intensity: 0.32,
+  pulse: false,
+  badge: null,
+};
+
+const HOT_HEAT: HeatVisualState = {
+  threshold: 'hot',
+  color: '#f97316',
+  intensity: 0.52,
+  pulse: false,
+  badge: 'HOT',
+};
+
+const OVERHEAT: HeatVisualState = {
+  threshold: 'overheat',
+  color: '#dc2626',
+  intensity: 0.74,
+  pulse: false,
+  badge: 'OVERHEAT',
+};
+
+const CRITICAL_HEAT: HeatVisualState = {
+  threshold: 'critical',
+  color: '#fff1f2',
+  intensity: 0.95,
+  pulse: true,
+  badge: 'CRITICAL',
+};
+
+function normalizeHeat(heat: number): number {
+  if (!Number.isFinite(heat)) return 0;
+  return Math.max(0, Math.floor(heat));
+}
+
+export function getHeatVisualMap(heat: number): HeatVisualState {
+  const normalizedHeat = normalizeHeat(heat);
+
+  if (normalizedHeat >= 20) return CRITICAL_HEAT;
+  if (normalizedHeat >= 15) return OVERHEAT;
+  if (normalizedHeat >= 10) return HOT_HEAT;
+  if (normalizedHeat >= 5) return WARM_HEAT;
+  return NEUTRAL_HEAT;
+}
+
+export const mapHeatToVisualState = getHeatVisualMap;
+export const resolveHeatVisualState = getHeatVisualMap;
+
+export function getHeatVisualThreshold(heat: number): HeatVisualThreshold {
+  return getHeatVisualMap(heat).threshold;
+}
+
+export function isAmmoExplosionDangerHeat(heat: number): boolean {
+  return getAmmoExplosionTN(normalizeHeat(heat)) > 0;
+}
+
+export function getHeatThresholdTransition(
+  previousHeat: number,
+  currentHeat: number,
+): HeatThresholdTransition {
+  const normalizedPreviousHeat = normalizeHeat(previousHeat);
+  const normalizedCurrentHeat = normalizeHeat(currentHeat);
+
+  return {
+    previousHeat: normalizedPreviousHeat,
+    currentHeat: normalizedCurrentHeat,
+    previousThreshold: getHeatVisualThreshold(normalizedPreviousHeat),
+    currentThreshold: getHeatVisualThreshold(normalizedCurrentHeat),
+    ammoExplosionRisk: isAmmoExplosionDangerHeat(normalizedCurrentHeat),
+  };
+}
+
+export function getHeatTransitionFromPayload(
+  payload: Pick<
+    IHeatPayload,
+    | 'newTotal'
+    | 'previousTotal'
+    | 'previousThreshold'
+    | 'currentThreshold'
+    | 'ammoExplosionRisk'
+  >,
+): HeatThresholdTransition {
+  const previousHeat = normalizeHeat(payload.previousTotal ?? payload.newTotal);
+  const currentHeat = normalizeHeat(payload.newTotal);
+
+  return {
+    previousHeat,
+    currentHeat,
+    previousThreshold:
+      payload.previousThreshold ?? getHeatVisualThreshold(previousHeat),
+    currentThreshold:
+      payload.currentThreshold ?? getHeatVisualThreshold(currentHeat),
+    ammoExplosionRisk:
+      payload.ammoExplosionRisk ?? isAmmoExplosionDangerHeat(currentHeat),
+  };
+}
+
+export default getHeatVisualMap;

--- a/src/utils/effects/weaponEffectMap.ts
+++ b/src/utils/effects/weaponEffectMap.ts
@@ -1,0 +1,584 @@
+import {
+  GameEventType,
+  type AttackVisualCategory,
+  type IAttackResolvedPayload,
+  type IGameEvent,
+  type IPhysicalAttackResolvedPayload,
+} from '@/types/gameplay';
+
+export type AttackEffectPrimitiveKind =
+  | 'laser'
+  | 'missile'
+  | 'tracer'
+  | 'shockwave';
+
+export type AttackEffectMetadataSource = 'event' | 'fallback';
+
+export interface AttackEffectPayloadHints {
+  readonly weaponName?: string;
+  readonly weaponType?: string;
+  readonly weaponCategory?: string;
+  readonly category?: string;
+  readonly visualColor?: string;
+  readonly totalProjectiles?: number;
+  readonly projectilesFired?: number;
+  readonly salvoSize?: number;
+  readonly burstCount?: number;
+  readonly staggerMs?: number;
+  readonly visualStaggerMs?: number;
+  readonly projectileStaggerMs?: number;
+}
+
+export type AttackWeaponEffectPayload = IAttackResolvedPayload &
+  AttackEffectPayloadHints;
+
+export type PhysicalAttackEffectPayload = IPhysicalAttackResolvedPayload &
+  AttackEffectPayloadHints & {
+    readonly visualCategory?: AttackVisualCategory;
+    readonly visualSubtype?: string;
+    readonly projectileCount?: number;
+  };
+
+export interface WeaponEffectDescriptor {
+  readonly category: AttackVisualCategory;
+  readonly primitive: AttackEffectPrimitiveKind;
+  readonly visualSubtype: string;
+  readonly color: string;
+  readonly impactColor: string;
+  readonly projectileCount: number;
+  readonly staggerMs: number;
+  readonly durationMs: number;
+  readonly ringStrokeWidth: number;
+  readonly showArc: boolean;
+  readonly originShockwave: boolean;
+  readonly metadataSource: {
+    readonly category: AttackEffectMetadataSource;
+    readonly color: AttackEffectMetadataSource;
+    readonly projectiles: AttackEffectMetadataSource;
+    readonly stagger: AttackEffectMetadataSource;
+  };
+}
+
+export const ATTACK_EFFECT_COLORS = {
+  laserGreen: '#22c55e',
+  laserErRedOrange: '#f97316',
+  laserPulseIr: '#f43f5e',
+  missileYellow: '#facc15',
+  ballisticCyan: '#22d3ee',
+  physicalWhite: '#ffffff',
+  physicalImpactRed: '#f87171',
+  energyGreen: '#22c55e',
+  impactWhite: '#ffffff',
+} as const;
+
+export const ATTACK_EFFECT_DURATIONS_MS = {
+  laser: 400,
+  energy: 400,
+  missile: 600,
+  ballistic: 300,
+  physical: 400,
+} as const satisfies Record<AttackVisualCategory, number>;
+
+export const WEAPON_EFFECT_FALLBACK_CASES = [
+  {
+    weaponName: 'Small Laser',
+    expectedCategory: 'laser',
+    expectedColor: ATTACK_EFFECT_COLORS.laserGreen,
+  },
+  {
+    weaponName: 'Medium Laser',
+    expectedCategory: 'laser',
+    expectedColor: ATTACK_EFFECT_COLORS.laserGreen,
+  },
+  {
+    weaponName: 'Large Laser',
+    expectedCategory: 'laser',
+    expectedColor: ATTACK_EFFECT_COLORS.laserGreen,
+  },
+  {
+    weaponName: 'ER Large Laser',
+    expectedCategory: 'laser',
+    expectedColor: ATTACK_EFFECT_COLORS.laserErRedOrange,
+  },
+  {
+    weaponName: 'Medium Pulse Laser',
+    expectedCategory: 'laser',
+    expectedColor: ATTACK_EFFECT_COLORS.laserPulseIr,
+  },
+  {
+    weaponName: 'PPC',
+    expectedCategory: 'energy',
+    expectedColor: ATTACK_EFFECT_COLORS.energyGreen,
+  },
+  {
+    weaponName: 'ER PPC',
+    expectedCategory: 'energy',
+    expectedColor: ATTACK_EFFECT_COLORS.laserErRedOrange,
+  },
+  {
+    weaponName: 'Flamer',
+    expectedCategory: 'energy',
+    expectedColor: ATTACK_EFFECT_COLORS.energyGreen,
+  },
+  {
+    weaponName: 'AC/10',
+    expectedCategory: 'ballistic',
+    expectedColor: ATTACK_EFFECT_COLORS.ballisticCyan,
+  },
+  {
+    weaponName: 'Ultra AC/10',
+    expectedCategory: 'ballistic',
+    expectedColor: ATTACK_EFFECT_COLORS.ballisticCyan,
+    expectedProjectiles: 2,
+    expectedStaggerMs: 80,
+  },
+  {
+    weaponName: 'Rotary AC/5',
+    expectedCategory: 'ballistic',
+    expectedColor: ATTACK_EFFECT_COLORS.ballisticCyan,
+    expectedProjectiles: 5,
+    expectedStaggerMs: 40,
+  },
+  {
+    weaponName: 'Gauss Rifle',
+    expectedCategory: 'ballistic',
+    expectedColor: ATTACK_EFFECT_COLORS.ballisticCyan,
+  },
+  {
+    weaponName: 'Machine Gun',
+    expectedCategory: 'ballistic',
+    expectedColor: ATTACK_EFFECT_COLORS.ballisticCyan,
+  },
+  {
+    weaponName: 'LRM-20',
+    expectedCategory: 'missile',
+    expectedColor: ATTACK_EFFECT_COLORS.missileYellow,
+    expectedProjectiles: 20,
+    expectedStaggerMs: 30,
+  },
+  {
+    weaponName: 'SRM 6',
+    expectedCategory: 'missile',
+    expectedColor: ATTACK_EFFECT_COLORS.missileYellow,
+    expectedProjectiles: 6,
+    expectedStaggerMs: 30,
+  },
+  {
+    weaponName: 'Streak SRM 4',
+    expectedCategory: 'missile',
+    expectedColor: ATTACK_EFFECT_COLORS.missileYellow,
+    expectedProjectiles: 4,
+    expectedStaggerMs: 30,
+  },
+  {
+    weaponName: 'Punch',
+    expectedCategory: 'physical',
+    expectedColor: ATTACK_EFFECT_COLORS.physicalWhite,
+  },
+  {
+    weaponName: 'Kick',
+    expectedCategory: 'physical',
+    expectedColor: ATTACK_EFFECT_COLORS.physicalWhite,
+  },
+  {
+    weaponName: 'Hatchet',
+    expectedCategory: 'physical',
+    expectedColor: ATTACK_EFFECT_COLORS.physicalWhite,
+  },
+] as const satisfies readonly {
+  readonly weaponName: string;
+  readonly expectedCategory: AttackVisualCategory;
+  readonly expectedColor: string;
+  readonly expectedProjectiles?: number;
+  readonly expectedStaggerMs?: number;
+}[];
+
+export function resolveWeaponEffect(
+  payload: AttackWeaponEffectPayload,
+): WeaponEffectDescriptor {
+  const fallbackKey = fallbackWeaponKey(payload);
+  const subtype = normalizeWeaponKey(payload.visualSubtype ?? fallbackKey);
+  const explicitCategory = normalizeCategory(
+    payload.visualCategory ?? payload.weaponCategory ?? payload.category,
+  );
+  const category = explicitCategory ?? categoryFromWeaponKey(fallbackKey);
+  const projectileResult = projectileCountFor(payload, subtype, category);
+  const staggerResult = staggerMsFor(
+    payload,
+    subtype,
+    category,
+    projectileResult.value,
+  );
+  const colorResult = colorFor(payload, subtype, category);
+
+  return buildDescriptor({
+    category,
+    subtype,
+    color: colorResult.value,
+    projectileCount: projectileResult.value,
+    staggerMs: staggerResult.value,
+    metadataSource: {
+      category: explicitCategory ? 'event' : 'fallback',
+      color: colorResult.source,
+      projectiles: projectileResult.source,
+      stagger: staggerResult.source,
+    },
+  });
+}
+
+export function resolvePhysicalAttackEffect(
+  payload: PhysicalAttackEffectPayload,
+): WeaponEffectDescriptor {
+  const subtype = normalizeWeaponKey(
+    payload.visualSubtype ??
+      payload.weaponName ??
+      payload.weaponType ??
+      payload.attackType,
+  );
+  const explicitCategory = normalizeCategory(
+    payload.visualCategory ?? payload.weaponCategory ?? payload.category,
+  );
+  const category = explicitCategory ?? 'physical';
+  const projectileResult = projectileCountFor(payload, subtype, category);
+  const staggerResult = staggerMsFor(
+    payload,
+    subtype,
+    category,
+    projectileResult.value,
+  );
+  const colorResult = colorFor(payload, subtype, category);
+
+  return buildDescriptor({
+    category,
+    subtype,
+    color: colorResult.value,
+    projectileCount: projectileResult.value,
+    staggerMs: staggerResult.value,
+    metadataSource: {
+      category: explicitCategory ? 'event' : 'fallback',
+      color: colorResult.source,
+      projectiles: projectileResult.source,
+      stagger: staggerResult.source,
+    },
+  });
+}
+
+export function resolveAttackEventEffect(
+  event: IGameEvent,
+): WeaponEffectDescriptor | null {
+  if (event.type === GameEventType.AttackResolved) {
+    return resolveWeaponEffect(event.payload as AttackWeaponEffectPayload);
+  }
+
+  if (event.type === GameEventType.PhysicalAttackResolved) {
+    return resolvePhysicalAttackEffect(
+      event.payload as PhysicalAttackEffectPayload,
+    );
+  }
+
+  return null;
+}
+
+export function normalizeWeaponKey(value: string | undefined): string {
+  if (!value) return '';
+  return value
+    .toLowerCase()
+    .replace(/\s*\((?:r|rear|clan|is|omnipod)\)\s*/g, ' ')
+    .replace(/\//g, '-')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+}
+
+function buildDescriptor(params: {
+  readonly category: AttackVisualCategory;
+  readonly subtype: string;
+  readonly color: string;
+  readonly projectileCount: number;
+  readonly staggerMs: number;
+  readonly metadataSource: WeaponEffectDescriptor['metadataSource'];
+}): WeaponEffectDescriptor {
+  const physical = physicalMetadata(params.subtype);
+  const primitive = primitiveForCategory(params.category);
+  return {
+    category: params.category,
+    primitive,
+    visualSubtype: params.subtype || params.category,
+    color: params.color,
+    impactColor:
+      params.category === 'physical'
+        ? ATTACK_EFFECT_COLORS.physicalImpactRed
+        : ATTACK_EFFECT_COLORS.impactWhite,
+    projectileCount: params.projectileCount,
+    staggerMs: params.staggerMs,
+    durationMs: ATTACK_EFFECT_DURATIONS_MS[params.category],
+    ringStrokeWidth: physical.ringStrokeWidth,
+    showArc: physical.showArc,
+    originShockwave: physical.originShockwave,
+    metadataSource: params.metadataSource,
+  };
+}
+
+function fallbackWeaponKey(payload: AttackWeaponEffectPayload): string {
+  return normalizeWeaponKey(
+    payload.weaponName ?? payload.weaponType ?? payload.weaponId,
+  );
+}
+
+function normalizeCategory(
+  value: AttackVisualCategory | string | undefined,
+): AttackVisualCategory | null {
+  const normalized = normalizeWeaponKey(value);
+  if (normalized === 'laser') return 'laser';
+  if (normalized === 'missile') return 'missile';
+  if (normalized === 'ballistic') return 'ballistic';
+  if (normalized === 'physical') return 'physical';
+  if (normalized === 'energy') return 'energy';
+
+  if (normalized.includes('energy')) return 'energy';
+  if (normalized.includes('missile')) return 'missile';
+  if (normalized.includes('ballistic')) return 'ballistic';
+  if (normalized.includes('physical')) return 'physical';
+
+  return null;
+}
+
+function categoryFromWeaponKey(key: string): AttackVisualCategory {
+  if (isPhysicalKey(key)) return 'physical';
+  if (isMissileKey(key)) return 'missile';
+  if (isBallisticKey(key)) return 'ballistic';
+  if (isLaserKey(key)) return 'laser';
+  if (isEnergyKey(key)) return 'energy';
+  return 'energy';
+}
+
+function primitiveForCategory(
+  category: AttackVisualCategory,
+): AttackEffectPrimitiveKind {
+  switch (category) {
+    case 'missile':
+      return 'missile';
+    case 'ballistic':
+      return 'tracer';
+    case 'physical':
+      return 'shockwave';
+    case 'laser':
+    case 'energy':
+      return 'laser';
+  }
+}
+
+function colorFor(
+  payload: AttackEffectPayloadHints,
+  key: string,
+  category: AttackVisualCategory,
+): { readonly value: string; readonly source: AttackEffectMetadataSource } {
+  if (payload.visualColor) {
+    return { value: payload.visualColor, source: 'event' };
+  }
+
+  if (category === 'missile') {
+    return { value: ATTACK_EFFECT_COLORS.missileYellow, source: 'fallback' };
+  }
+  if (category === 'ballistic') {
+    return { value: ATTACK_EFFECT_COLORS.ballisticCyan, source: 'fallback' };
+  }
+  if (category === 'physical') {
+    return { value: ATTACK_EFFECT_COLORS.physicalWhite, source: 'fallback' };
+  }
+  if (isErKey(key)) {
+    return {
+      value: ATTACK_EFFECT_COLORS.laserErRedOrange,
+      source: payloadHasVisualSubtype(payload) ? 'event' : 'fallback',
+    };
+  }
+  if (isPulseKey(key)) {
+    return {
+      value: ATTACK_EFFECT_COLORS.laserPulseIr,
+      source: payloadHasVisualSubtype(payload) ? 'event' : 'fallback',
+    };
+  }
+  if (category === 'energy') {
+    return {
+      value: ATTACK_EFFECT_COLORS.energyGreen,
+      source: payloadHasVisualSubtype(payload) ? 'event' : 'fallback',
+    };
+  }
+
+  return {
+    value: ATTACK_EFFECT_COLORS.laserGreen,
+    source: payloadHasVisualSubtype(payload) ? 'event' : 'fallback',
+  };
+}
+
+function projectileCountFor(
+  payload: AttackEffectPayloadHints & { readonly projectileCount?: number },
+  key: string,
+  category: AttackVisualCategory,
+): { readonly value: number; readonly source: AttackEffectMetadataSource } {
+  const eventCount = firstPositiveInteger([
+    payload.projectileCount,
+    payload.totalProjectiles,
+    payload.projectilesFired,
+    payload.salvoSize,
+    payload.burstCount,
+  ]);
+  if (eventCount !== null) return { value: eventCount, source: 'event' };
+
+  if (category === 'missile') {
+    return { value: missileTubeCount(key), source: 'fallback' };
+  }
+  if (category === 'ballistic') {
+    if (isRotaryKey(key)) return { value: 5, source: 'fallback' };
+    if (isUltraKey(key)) return { value: 2, source: 'fallback' };
+  }
+  return { value: 1, source: 'fallback' };
+}
+
+function staggerMsFor(
+  payload: AttackEffectPayloadHints,
+  key: string,
+  category: AttackVisualCategory,
+  projectileCount: number,
+): { readonly value: number; readonly source: AttackEffectMetadataSource } {
+  const eventStagger = firstPositiveInteger([
+    payload.staggerMs,
+    payload.visualStaggerMs,
+    payload.projectileStaggerMs,
+  ]);
+  if (eventStagger !== null) return { value: eventStagger, source: 'event' };
+
+  if (projectileCount <= 1) return { value: 0, source: 'fallback' };
+  if (category === 'missile') return { value: 30, source: 'fallback' };
+  if (category === 'ballistic') {
+    if (isUltraKey(key)) return { value: 80, source: 'fallback' };
+    if (isRotaryKey(key)) return { value: 40, source: 'fallback' };
+  }
+
+  return { value: 0, source: 'fallback' };
+}
+
+function physicalMetadata(key: string): {
+  readonly ringStrokeWidth: number;
+  readonly showArc: boolean;
+  readonly originShockwave: boolean;
+} {
+  if (key.includes('kick')) {
+    return { ringStrokeWidth: 4, showArc: false, originShockwave: false };
+  }
+  if (key.includes('charge') || key.includes('dfa')) {
+    return { ringStrokeWidth: 5, showArc: false, originShockwave: true };
+  }
+  if (
+    key.includes('club') ||
+    key.includes('hatchet') ||
+    key.includes('sword') ||
+    key.includes('mace') ||
+    key.includes('lance')
+  ) {
+    return { ringStrokeWidth: 3, showArc: true, originShockwave: false };
+  }
+  return { ringStrokeWidth: 2, showArc: false, originShockwave: false };
+}
+
+function missileTubeCount(key: string): number {
+  const match = key.match(
+    /(?:^|-)(?:clan-)?(?:streak-)?(?:lrm|srm|mrm|atm|mml|thunderbolt)-?(\d{1,2})(?:-|$)/,
+  );
+  const parsed = match?.[1] ? Number(match[1]) : 1;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+}
+
+function firstPositiveInteger(
+  values: readonly (number | undefined)[],
+): number | null {
+  for (const value of values) {
+    if (value === undefined) continue;
+    const rounded = Math.floor(value);
+    if (Number.isFinite(rounded) && rounded > 0) return rounded;
+  }
+  return null;
+}
+
+function payloadHasVisualSubtype(payload: AttackEffectPayloadHints): boolean {
+  return (
+    'visualSubtype' in payload && typeof payload.visualSubtype === 'string'
+  );
+}
+
+function isLaserKey(key: string): boolean {
+  return key.includes('laser');
+}
+
+function isEnergyKey(key: string): boolean {
+  return (
+    key.includes('ppc') ||
+    key.includes('flamer') ||
+    key.includes('plasma') ||
+    key.includes('particle-cannon')
+  );
+}
+
+function isErKey(key: string): boolean {
+  return (
+    key.startsWith('er-') ||
+    key.includes('-er-') ||
+    key.includes('extended-range')
+  );
+}
+
+function isPulseKey(key: string): boolean {
+  return key.includes('pulse');
+}
+
+function isMissileKey(key: string): boolean {
+  return (
+    key.includes('lrm') ||
+    key.includes('srm') ||
+    key.includes('mrm') ||
+    key.includes('atm') ||
+    key.includes('mml') ||
+    key.includes('narc') ||
+    key.includes('missile') ||
+    key.includes('thunderbolt')
+  );
+}
+
+function isBallisticKey(key: string): boolean {
+  return (
+    key.includes('ac-') ||
+    key.includes('autocannon') ||
+    key.includes('uac-') ||
+    key.includes('ultra-ac') ||
+    key.includes('rac-') ||
+    key.includes('rotary-ac') ||
+    key.includes('gauss') ||
+    key.includes('machine-gun') ||
+    key === 'mg' ||
+    key.includes('lb-') ||
+    key.includes('hvac')
+  );
+}
+
+function isUltraKey(key: string): boolean {
+  return key.includes('uac-') || key.includes('ultra-ac');
+}
+
+function isRotaryKey(key: string): boolean {
+  return key.includes('rac-') || key.includes('rotary-ac');
+}
+
+function isPhysicalKey(key: string): boolean {
+  return (
+    key.includes('punch') ||
+    key.includes('kick') ||
+    key.includes('club') ||
+    key.includes('hatchet') ||
+    key.includes('sword') ||
+    key.includes('charge') ||
+    key.includes('dfa') ||
+    key.includes('death-from-above') ||
+    key.includes('mace') ||
+    key.includes('lance')
+  );
+}

--- a/src/utils/overlays/__tests__/arcClassifier.test.ts
+++ b/src/utils/overlays/__tests__/arcClassifier.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  AXIAL_DIRECTION_DELTAS,
+  Facing,
+  type IHexCoordinate,
+  type IUnitPosition,
+} from '@/types/gameplay';
+import { determineArc } from '@/utils/gameplay/firingArcs';
+import { hexNeighbor } from '@/utils/gameplay/hexMath';
+import {
+  classifyFiringArc,
+  createFiringArcClassifier,
+  firingArcToUiArc,
+  type UiFiringArc,
+} from '@/utils/overlays/arcClassifier';
+
+const FACINGS: readonly Facing[] = [
+  Facing.North,
+  Facing.Northeast,
+  Facing.Southeast,
+  Facing.South,
+  Facing.Southwest,
+  Facing.Northwest,
+];
+
+function unit(facing: Facing): IUnitPosition {
+  return {
+    unitId: `unit-${facing}`,
+    coord: { q: 0, r: 0 },
+    facing,
+    prone: false,
+  };
+}
+
+function expectedArc(facing: Facing, target: IHexCoordinate): UiFiringArc {
+  return firingArcToUiArc(determineArc(unit(facing), target).arc);
+}
+
+describe('arcClassifier', () => {
+  it('returns front for the hex directly in front across all facings', () => {
+    for (const facing of FACINGS) {
+      expect(
+        classifyFiringArc(unit(facing), hexNeighbor({ q: 0, r: 0 }, facing)),
+      ).toBe('front');
+    }
+  });
+
+  it('matches existing determineArc conventions for every facing and adjacent target direction', () => {
+    for (const facing of FACINGS) {
+      for (const targetDirection of FACINGS) {
+        const target = hexNeighbor({ q: 0, r: 0 }, targetDirection);
+        expect(classifyFiringArc(unit(facing), target)).toBe(
+          expectedArc(facing, target),
+        );
+      }
+    }
+  });
+
+  it('distinguishes left-side and right-side labels using the engine arc result', () => {
+    const north = unit(Facing.North);
+
+    expect(classifyFiringArc(north, { q: -1, r: 0 })).toBe('left-side');
+    expect(classifyFiringArc(north, { q: 1, r: 0 })).toBe('right-side');
+    expect(classifyFiringArc(north, { q: 0, r: 1 })).toBe('rear');
+  });
+
+  it('returns out-of-arc for map-excluded hexes and range-excluded hexes', () => {
+    const north = unit(Facing.North);
+    const mapHexes = new Set(['0,0', '0,-1']);
+
+    expect(
+      classifyFiringArc(north, { q: 1, r: 0 }, { mapHexes, maxRange: 5 }),
+    ).toBe('out-of-arc');
+    expect(classifyFiringArc(north, { q: 0, r: -2 }, { maxRange: 1 })).toBe(
+      'out-of-arc',
+    );
+  });
+
+  it('supports visible arc filtering for informational rear-only overlays', () => {
+    const north = unit(Facing.North);
+
+    expect(
+      classifyFiringArc(north, { q: 0, r: 1 }, { visibleArcs: ['rear'] }),
+    ).toBe('rear');
+    expect(
+      classifyFiringArc(north, { q: 0, r: -1 }, { visibleArcs: ['rear'] }),
+    ).toBe('out-of-arc');
+  });
+
+  it('creates a reusable classifier scoped to one unit and option set', () => {
+    const classifier = createFiringArcClassifier(unit(Facing.North), {
+      mapHexes: AXIAL_DIRECTION_DELTAS,
+      includeOrigin: false,
+      maxRange: 1,
+    });
+
+    expect(classifier({ q: 0, r: -1 })).toBe('front');
+    expect(classifier({ q: 0, r: -1 })).toBe('front');
+    expect(classifier({ q: 0, r: 0 })).toBe('out-of-arc');
+  });
+});

--- a/src/utils/overlays/__tests__/losClassifier.test.ts
+++ b/src/utils/overlays/__tests__/losClassifier.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type {
+  IHex,
+  IHexCoordinate,
+  IHexGrid,
+} from '@/types/gameplay/HexGridInterfaces';
+
+import { TerrainType } from '@/types/gameplay/TerrainTypes';
+import { coordToKey } from '@/utils/gameplay/hexMath';
+import {
+  classifyLOS,
+  createLOSClassifier,
+} from '@/utils/overlays/losClassifier';
+
+function createHex(
+  q: number,
+  r: number,
+  terrain: TerrainType = TerrainType.Clear,
+  elevation = 0,
+): IHex {
+  return {
+    coord: { q, r },
+    occupantId: null,
+    terrain,
+    elevation,
+  };
+}
+
+function createGrid(hexes: readonly IHex[]): IHexGrid {
+  const map = new Map<string, IHex>();
+  for (const hex of hexes) {
+    map.set(coordToKey(hex.coord), hex);
+  }
+
+  return {
+    config: { radius: 10 },
+    hexes: map,
+  };
+}
+
+const origin: IHexCoordinate = { q: 0, r: 0 };
+const target: IHexCoordinate = { q: 2, r: 0 };
+
+describe('losClassifier', () => {
+  it('classifies clear LOS with no blockers', () => {
+    const grid = createGrid([
+      createHex(0, 0),
+      createHex(1, 0),
+      createHex(2, 0),
+    ]);
+
+    const result = classifyLOS(origin, target, grid);
+
+    expect(result.state).toBe('clear');
+    expect(result.blockers).toEqual([]);
+    expect(result.blockerAnnotations).toEqual([]);
+    expect(result.lineEnd).toEqual(target);
+    expect(result.engineResult.hasLOS).toBe(true);
+  });
+
+  it('classifies light woods as partial cover when LOS exists', () => {
+    const grid = createGrid([
+      createHex(0, 0),
+      createHex(1, 0, TerrainType.LightWoods),
+      createHex(2, 0),
+    ]);
+
+    const result = classifyLOS(origin, target, grid);
+
+    expect(result.state).toBe('partial');
+    expect(result.blockers).toEqual([{ q: 1, r: 0 }]);
+    expect(result.blockerAnnotations).toEqual([
+      expect.objectContaining({
+        coord: { q: 1, r: 0 },
+        terrain: TerrainType.LightWoods,
+        icon: 'cover',
+      }),
+    ]);
+    expect(result.blockerAnnotations[0].title).toContain('light woods');
+    expect(result.engineResult.hasLOS).toBe(true);
+  });
+
+  it('classifies heavy woods as partial cover when elevation lets LOS pass over it', () => {
+    const grid = createGrid([
+      createHex(0, 0, TerrainType.Clear, 3),
+      createHex(1, 0, TerrainType.HeavyWoods, 0),
+      createHex(2, 0, TerrainType.Clear, 3),
+    ]);
+
+    const result = classifyLOS(origin, target, grid);
+
+    expect(result.state).toBe('partial');
+    expect(result.blockerAnnotations[0]).toEqual(
+      expect.objectContaining({
+        coord: { q: 1, r: 0 },
+        terrain: TerrainType.HeavyWoods,
+        icon: 'cover',
+      }),
+    );
+    expect(result.engineResult.hasLOS).toBe(true);
+  });
+
+  it('classifies a blocking building through the existing LOS result', () => {
+    const grid = createGrid([
+      createHex(0, 0),
+      createHex(1, 0, TerrainType.Building),
+      createHex(2, 0),
+    ]);
+
+    const result = classifyLOS(origin, target, grid);
+
+    expect(result.state).toBe('blocked');
+    expect(result.blockers).toEqual([{ q: 1, r: 0 }]);
+    expect(result.blockerAnnotations).toEqual([
+      expect.objectContaining({
+        coord: { q: 1, r: 0 },
+        terrain: TerrainType.Building,
+        icon: 'wall',
+      }),
+    ]);
+    expect(result.lineEnd).toEqual({ q: 1, r: 0 });
+    expect(result.engineResult.hasLOS).toBe(false);
+  });
+
+  it('keeps LOS clear when elevation lets the engine see over blocking terrain', () => {
+    const grid = createGrid([
+      createHex(0, 0, TerrainType.Clear, 3),
+      createHex(1, 0, TerrainType.Building, 0),
+      createHex(2, 0, TerrainType.Clear, 3),
+    ]);
+
+    const result = classifyLOS(origin, target, grid);
+
+    expect(result.state).toBe('clear');
+    expect(result.blockers).toEqual([]);
+    expect(result.engineResult.hasLOS).toBe(true);
+  });
+
+  it('creates a reusable classifier scoped to the current grid and elevations', () => {
+    const grid = createGrid([
+      createHex(0, 0),
+      createHex(1, 0, TerrainType.LightWoods),
+      createHex(2, 0),
+    ]);
+    const classifier = createLOSClassifier(grid);
+
+    const first = classifier(origin, target);
+    const second = classifier({ ...origin }, { ...target });
+
+    expect(first).toBe(second);
+    expect(first.state).toBe('partial');
+  });
+});

--- a/src/utils/overlays/arcClassifier.ts
+++ b/src/utils/overlays/arcClassifier.ts
@@ -1,0 +1,128 @@
+import type { IHexCoordinate, IUnitPosition } from '@/types/gameplay';
+
+import { FiringArc } from '@/types/gameplay';
+import { determineArc } from '@/utils/gameplay/firingArcs';
+import { coordToKey, hexDistance, hexEquals } from '@/utils/gameplay/hexMath';
+
+export type UiFiringArc =
+  | 'front'
+  | 'left-side'
+  | 'right-side'
+  | 'rear'
+  | 'out-of-arc';
+
+export interface ArcClassifierUnit {
+  readonly coord: IHexCoordinate;
+  readonly facing: IUnitPosition['facing'];
+  readonly unitId?: string;
+  readonly prone?: boolean;
+}
+
+export type ArcMapBounds = ReadonlySet<string> | readonly IHexCoordinate[];
+
+export interface ArcClassifierOptions {
+  readonly mapHexes?: ArcMapBounds;
+  readonly maxRange?: number;
+  readonly includeOrigin?: boolean;
+  readonly visibleArcs?: readonly UiFiringArc[];
+}
+
+export interface ArcHexClassification {
+  readonly hex: IHexCoordinate;
+  readonly arc: UiFiringArc;
+  readonly distance: number;
+}
+
+function isCoordinateList(
+  mapHexes: ArcMapBounds,
+): mapHexes is readonly IHexCoordinate[] {
+  return Array.isArray(mapHexes);
+}
+
+function mapContainsHex(
+  mapHexes: ArcMapBounds | undefined,
+  hex: IHexCoordinate,
+): boolean {
+  if (!mapHexes) return true;
+  if (isCoordinateList(mapHexes)) {
+    return mapHexes.some((candidate) => hexEquals(candidate, hex));
+  }
+  return mapHexes.has(coordToKey(hex));
+}
+
+function toUnitPosition(unit: ArcClassifierUnit): IUnitPosition {
+  return {
+    unitId: unit.unitId ?? 'overlay-unit',
+    coord: unit.coord,
+    facing: unit.facing,
+    prone: unit.prone ?? false,
+  };
+}
+
+export function firingArcToUiArc(arc: FiringArc): UiFiringArc {
+  switch (arc) {
+    case FiringArc.Front:
+      return 'front';
+    case FiringArc.Left:
+      return 'left-side';
+    case FiringArc.Right:
+      return 'right-side';
+    case FiringArc.Rear:
+      return 'rear';
+  }
+}
+
+export function classifyFiringArc(
+  unit: ArcClassifierUnit,
+  target: IHexCoordinate,
+  options: ArcClassifierOptions = {},
+): UiFiringArc {
+  if (!mapContainsHex(options.mapHexes, target)) {
+    return 'out-of-arc';
+  }
+
+  if (options.includeOrigin === false && hexEquals(unit.coord, target)) {
+    return 'out-of-arc';
+  }
+
+  const distance = hexDistance(unit.coord, target);
+  if (options.maxRange !== undefined && distance > options.maxRange) {
+    return 'out-of-arc';
+  }
+
+  const arc = firingArcToUiArc(determineArc(toUnitPosition(unit), target).arc);
+  if (options.visibleArcs && !options.visibleArcs.includes(arc)) {
+    return 'out-of-arc';
+  }
+
+  return arc;
+}
+
+export function classifyFiringArcHexes(
+  unit: ArcClassifierUnit,
+  hexes: readonly IHexCoordinate[],
+  options: ArcClassifierOptions = {},
+): readonly ArcHexClassification[] {
+  return hexes.map((hex) => ({
+    hex,
+    arc: classifyFiringArc(unit, hex, options),
+    distance: hexDistance(unit.coord, hex),
+  }));
+}
+
+export function createFiringArcClassifier(
+  unit: ArcClassifierUnit,
+  options: ArcClassifierOptions = {},
+): (target: IHexCoordinate) => UiFiringArc {
+  const cache = new Map<string, UiFiringArc>();
+
+  return (target: IHexCoordinate): UiFiringArc => {
+    const key = coordToKey(target);
+    const cached = cache.get(key);
+    if (cached) return cached;
+
+    const arc = classifyFiringArc(unit, target, options);
+    cache.set(key, arc);
+    return arc;
+  };
+}

--- a/src/utils/overlays/losClassifier.ts
+++ b/src/utils/overlays/losClassifier.ts
@@ -1,0 +1,178 @@
+import type {
+  IHexCoordinate,
+  IHexGrid,
+} from '@/types/gameplay/HexGridInterfaces';
+import type { ILOSResult } from '@/utils/gameplay/lineOfSight';
+
+import { TerrainType } from '@/types/gameplay/TerrainTypes';
+import { coordToKey } from '@/utils/gameplay/hexMath';
+import {
+  calculateLOS,
+  parseTerrainFeatures,
+} from '@/utils/gameplay/lineOfSight';
+
+export type LOSOverlayState = 'clear' | 'partial' | 'blocked';
+export type LOSBlockerIcon = 'cover' | 'wall';
+
+export interface LOSBlockerMetadata {
+  readonly coord: IHexCoordinate;
+  readonly terrain: TerrainType;
+  readonly icon: LOSBlockerIcon;
+  readonly title: string;
+}
+
+export interface LOSClassification {
+  readonly state: LOSOverlayState;
+  readonly blockers: readonly IHexCoordinate[];
+  readonly blockerAnnotations: readonly LOSBlockerMetadata[];
+  readonly lineEnd: IHexCoordinate;
+  readonly engineResult: ILOSResult;
+}
+
+export interface LOSClassifierOptions {
+  readonly fromElevation?: number;
+  readonly toElevation?: number;
+}
+
+const PARTIAL_COVER_TERRAINS: readonly TerrainType[] = [
+  TerrainType.LightWoods,
+  TerrainType.HeavyWoods,
+];
+
+function terrainLabel(terrain: TerrainType): string {
+  return terrain.replace(/_/g, ' ');
+}
+
+function hexLabel(hex: IHexCoordinate): string {
+  return `(${hex.q}, ${hex.r})`;
+}
+
+function terrainAt(
+  grid: IHexGrid,
+  hex: IHexCoordinate,
+): TerrainType | undefined {
+  const hexData = grid.hexes.get(coordToKey(hex));
+  if (!hexData) return undefined;
+
+  return parseTerrainFeatures(hexData.terrain)[0]?.type;
+}
+
+function partialCoverTerrainAt(
+  grid: IHexGrid,
+  hex: IHexCoordinate,
+): TerrainType | undefined {
+  const hexData = grid.hexes.get(coordToKey(hex));
+  if (!hexData) return undefined;
+
+  const features = parseTerrainFeatures(hexData.terrain);
+  return features.find((feature) =>
+    PARTIAL_COVER_TERRAINS.includes(feature.type),
+  )?.type;
+}
+
+function partialCoverAnnotation(
+  coord: IHexCoordinate,
+  terrain: TerrainType,
+): LOSBlockerMetadata {
+  return {
+    coord,
+    terrain,
+    icon: 'cover',
+    title: `Partial cover through ${terrainLabel(terrain)} at ${hexLabel(coord)}`,
+  };
+}
+
+function blockedAnnotation(
+  coord: IHexCoordinate,
+  terrain: TerrainType,
+): LOSBlockerMetadata {
+  return {
+    coord,
+    terrain,
+    icon: 'wall',
+    title: `Blocked by ${terrainLabel(terrain)} at ${hexLabel(coord)}`,
+  };
+}
+
+export function classifyLOS(
+  from: IHexCoordinate,
+  to: IHexCoordinate,
+  grid: IHexGrid,
+  options: LOSClassifierOptions = {},
+): LOSClassification {
+  const engineResult = calculateLOS(
+    from,
+    to,
+    grid,
+    options.fromElevation,
+    options.toElevation,
+  );
+
+  if (!engineResult.hasLOS) {
+    const blockedBy = engineResult.blockedBy;
+    const terrain =
+      engineResult.blockingTerrain ??
+      (blockedBy ? terrainAt(grid, blockedBy) : undefined) ??
+      TerrainType.Building;
+    const blockerAnnotations = blockedBy
+      ? [blockedAnnotation(blockedBy, terrain)]
+      : [];
+
+    return {
+      state: 'blocked',
+      blockers: blockedBy ? [blockedBy] : [],
+      blockerAnnotations,
+      lineEnd: blockedBy ?? to,
+      engineResult,
+    };
+  }
+
+  const blockerAnnotations = engineResult.interveningHexes
+    .map((hex) => {
+      const terrain = partialCoverTerrainAt(grid, hex);
+      return terrain ? partialCoverAnnotation(hex, terrain) : null;
+    })
+    .filter(
+      (annotation): annotation is LOSBlockerMetadata => annotation !== null,
+    );
+
+  if (blockerAnnotations.length > 0) {
+    return {
+      state: 'partial',
+      blockers: blockerAnnotations.map((annotation) => annotation.coord),
+      blockerAnnotations,
+      lineEnd: to,
+      engineResult,
+    };
+  }
+
+  return {
+    state: 'clear',
+    blockers: [],
+    blockerAnnotations: [],
+    lineEnd: to,
+    engineResult,
+  };
+}
+
+export function createLOSClassifier(
+  grid: IHexGrid,
+  options: LOSClassifierOptions = {},
+): (from: IHexCoordinate, to: IHexCoordinate) => LOSClassification {
+  const cache = new Map<string, LOSClassification>();
+
+  return (from: IHexCoordinate, to: IHexCoordinate): LOSClassification => {
+    const key = [
+      coordToKey(from),
+      coordToKey(to),
+      options.fromElevation ?? 'auto',
+      options.toElevation ?? 'auto',
+    ].join('|');
+    const cached = cache.get(key);
+    if (cached) return cached;
+
+    const classification = classifyLOS(from, to, grid, options);
+    cache.set(key, classification);
+    return classification;
+  };
+}


### PR DESCRIPTION
## Summary
- adds Wave 3 tactical visual primitives for LOS/firing arcs, attack effects, damage feedback, and heat/shutdown indicators
- wires map/token surfaces to render hover LOS, firing arcs, attack trails, persistent damage, heat glow, shutdown, startup, and ammo-risk visuals from event history
- updates Wave 3 OpenSpec task progress; heat/shutdown is all-done, the other tactical visual specs remain valid with explicit follow-up tasks open

## Verification
- `npm run typecheck -- --pretty false`
- `npx jest --selectProjects unit --runTestsByPath src\utils\overlays\__tests__\arcClassifier.test.ts src\utils\overlays\__tests__\losClassifier.test.ts src\components\gameplay\overlays\__tests__\FiringArcOverlay.test.tsx src\components\gameplay\overlays\__tests__\LineOfSightOverlay.test.tsx src\utils\effects\__tests__\weaponEffectMap.test.ts src\components\gameplay\effects\__tests__\AttackEffectsLayer.test.tsx src\hooks\__tests__\useScreenShake.test.tsx src\components\gameplay\effects\__tests__\damageFeedbackEffects.test.tsx src\utils\effects\__tests__\heatVisualMap.test.ts src\components\gameplay\effects\__tests__\heatAndShutdownEffects.test.tsx src\components\gameplay\HexMapDisplay\__tests__\HexMapDisplay.movementAnimation.test.tsx src\components\gameplay\UnitToken\__tests__\UnitTokenForType.test.tsx --runInBand`
- `npx oxlint ...` (0 errors; 3 max-lines warnings on known large Wave 3/HexMap files)
- `npx oxfmt --check ...`
- `npx openspec validate --all --strict`
- `npm run schema:gen-check`
- `npx madge --circular --extensions ts,tsx src/`
- pre-commit full Next builds passed on all runtime commits; Windows emitted the known traced-file copy warning for `[externals]_node:crypto...` with exit 0