### PR TITLE
Advance Wave 4 multiplayer foundations

### DIFF
--- a/openspec/changes/add-fog-of-war-event-filtering/notepad/issues.md
+++ b/openspec/changes/add-fog-of-war-event-filtering/notepad/issues.md
@@ -1,0 +1,14 @@
+## [2026-04-30 00:00] Task: fog-broadcast-integration-map
+**Issue discovered**: `ServerMatchHost` has no event-specific `broadcastEvent` helper today. Generic `broadcast()` delegates to `ServerMatchBroadcaster.broadcast()`, which stringifies one payload and sends it to every socket.
+
+**Why it matters**: Fog integration needs a per-destination event fan-out path that can run `filterEventForPlayer(event, playerId, state)` before sending to each socket, while leaving generic lobby/error/status messages unchanged.
+
+## [2026-04-30 00:00] Task: fog-broadcast-integration-map
+**Issue discovered**: Socket player identity is stored in `ServerMatchSocketLifecycle`, but `ServerMatchBroadcaster.snapshot()` exposes sockets without player ids.
+
+**Why it matters**: Per-client fog filtering needs either a socket metadata snapshot or an explicit lifecycle fan-out method before live broadcast filtering can be wired.
+
+## [2026-04-30 00:00] Task: fog-broadcast-integration-map
+**Issue discovered**: Replay streams currently chunk raw events without historical visibility. If fog drops hidden events, client high-water tracking may need to advance on `ReplayEnd.toSeq`, not only received event sequences.
+
+**Why it matters**: Filtered reconnect replay must avoid leaking hidden history while still preventing repeated replay of the same hidden server events.

--- a/openspec/changes/add-fog-of-war-event-filtering/tasks.md
+++ b/openspec/changes/add-fog-of-war-event-filtering/tasks.md
@@ -2,14 +2,14 @@
 
 ## 1. Visibility Model
 
-- [ ] 1.1 Define `canPlayerSeeUnit(playerId, unitId, state): boolean`
+- [x] 1.1 Define `canPlayerSeeUnit(playerId, unitId, state): boolean`
       in `spatial-combat-system` as a shared helper
-- [ ] 1.2 Implementation: true if any unit owned by `playerId` has LOS
+- [x] 1.2 Implementation: true if any unit owned by `playerId` has LOS
       to `unitId` within its sensor range, OR the target is itself
       owned by `playerId`
-- [ ] 1.3 Add convenience `visibleUnitsForPlayer(playerId, state):
+- [x] 1.3 Add convenience `visibleUnitsForPlayer(playerId, state):
 UnitId[]` that returns the set
-- [ ] 1.4 Unit tests covering: adjacent LOS, LOS blocked by terrain,
+- [x] 1.4 Unit tests covering: adjacent LOS, LOS blocked by terrain,
       sensor range boundary, own units always visible
 
 ## 2. Event Visibility Classification

--- a/openspec/changes/add-fog-of-war-event-filtering/tasks.md
+++ b/openspec/changes/add-fog-of-war-event-filtering/tasks.md
@@ -16,7 +16,7 @@ UnitId[]` that returns the set
 
 - [ ] 2.1 Add `visibility` tag on every event type; values `'public' |
 'actor-only' | 'observer-visible' | 'target-visible'`
-- [ ] 2.2 Classify existing event types: - `GameCreated`, `PhaseChanged`, `TurnAdvanced`, `GameEnded`,
+- [x] 2.2 Classify existing event types: - `GameCreated`, `PhaseChanged`, `TurnAdvanced`, `GameEnded`,
       `match_paused`, `match_resumed` → `'public'` - `MovementDeclared` → `'actor-only'` (pre-commit) - `MovementLocked`, `FacingChanged` → `'observer-visible'` - `AttackDeclared` → `'actor-only'` - `AttackResolved`, `DamageApplied` → split:
       `'target-visible'` (target always knows they got hit) plus
       `'observer-visible'` for the full detail - `HeatGenerated`, `HeatDissipated` → `'observer-visible'` - `PilotHit`, `UnitDestroyed` → `'observer-visible'` - `InitiativeRolled` → `'public'` (initiative result itself);
@@ -24,13 +24,13 @@ UnitId[]` that returns the set
 
 ## 3. Server-Side Filter
 
-- [ ] 3.1 Add `fogOfWar.ts` with `filterEventForPlayer(event,
+- [x] 3.1 Add `fogOfWar.ts` with `filterEventForPlayer(event,
 playerId, state): IGameEvent | null`
-- [ ] 3.2 Returns `null` if the event must not be sent to this player
-- [ ] 3.3 Returns a potentially redacted copy if partial visibility
+- [x] 3.2 Returns `null` if the event must not be sent to this player
+- [x] 3.3 Returns a potentially redacted copy if partial visibility
       applies (e.g., target knows a hit was taken but not the shooter
       when the shooter is not in LOS)
-- [ ] 3.4 The filter is a no-op (returns original) when
+- [x] 3.4 The filter is a no-op (returns original) when
       `config.fogOfWar === false`
 
 ## 4. Broadcast Integration
@@ -44,22 +44,22 @@ playerId, state): IGameEvent | null`
 
 ## 5. Redaction Rules
 
-- [ ] 5.1 `AttackResolved` when shooter is not visible to target
+- [x] 5.1 `AttackResolved` when shooter is not visible to target
       owner: redact `attackerId`, keep `targetId`, `damage`,
       `hitLocation`, `rolls` for target's own damage display
-- [ ] 5.2 `MovementLocked` when the moving unit is not in the
+- [x] 5.2 `MovementLocked` when the moving unit is not in the
       observer's LOS: skip the event entirely
-- [ ] 5.3 `HeatGenerated` for an enemy unit outside LOS: skip entirely
-- [ ] 5.4 `UnitDestroyed` for an enemy unit outside LOS: send a
+- [x] 5.3 `HeatGenerated` for an enemy unit outside LOS: skip entirely
+- [x] 5.4 `UnitDestroyed` for an enemy unit outside LOS: send a
       reduced form `{type: 'unit_destroyed', payload: {unitId}}`
       without damage/crit detail
 
 ## 6. Fog-Enable Configuration
 
-- [ ] 6.1 `IMatchMeta.config.fogOfWar: boolean` defaults to `false`
-- [ ] 6.2 Host sets fog on at match creation; cannot be toggled mid-
+- [x] 6.1 `IMatchMeta.config.fogOfWar: boolean` defaults to `false`
+- [x] 6.2 Host sets fog on at match creation; cannot be toggled mid-
       match
-- [ ] 6.3 Lobby UI surfaces a `"Double-blind (fog of war)"` checkbox
+- [x] 6.3 Lobby UI surfaces a `"Double-blind (fog of war)"` checkbox
 
 ## 7. Client Rendering With Fog
 
@@ -94,7 +94,7 @@ playerId, state): IGameEvent | null`
 
 ## 10. Performance
 
-- [ ] 10.1 LOS checks are cached per-turn per-(observer, target)
+- [x] 10.1 LOS checks are cached per-turn per-(observer, target)
       pair; invalidated on movement events
 - [ ] 10.2 `canPlayerSeeUnit` target: sub-millisecond per check on
       8-player, 32-unit maps

--- a/openspec/changes/add-game-session-persistence-for-reconnect/notepad/issues.md
+++ b/openspec/changes/add-game-session-persistence-for-reconnect/notepad/issues.md
@@ -1,0 +1,14 @@
+## [2026-04-30 00:00] Task: reconnect-integration-map
+**Issue discovered**: The reconnect tasks say `IGameSession.matchId` is already present, but current source only exposes `IGameSession.id`. P2P lobby sessions already set `session.id` to the lobby `matchId`, while server-hosted matches keep an external server `matchId` that can differ from the engine session id.
+
+**Why it matters**: Event-log persistence needs a single stable match identifier before `InteractiveSession` hydration and replay can be wired safely.
+
+## [2026-04-30 00:00] Task: reconnect-integration-map
+**Issue discovered**: Reconnect timing is inconsistent across artifacts and code. The proposal mentions 30 seconds, tasks/specs require a 60-second grace window, and the current multiplayer protocol constant is 120 seconds.
+
+**Why it matters**: Wave 4 should implement the spec/task value of 60 seconds and update tests/constants together rather than preserving the old server default.
+
+## [2026-04-30 00:00] Task: reconnect-integration-map
+**Issue discovered**: Current server replay chunking uses 50-event chunks, while the reconnect tasks require chunks of at most 64 events.
+
+**Why it matters**: Reconnect protocol changes must update the shared protocol constant and replay tests together.

--- a/openspec/changes/add-game-session-persistence-for-reconnect/tasks.md
+++ b/openspec/changes/add-game-session-persistence-for-reconnect/tasks.md
@@ -42,18 +42,18 @@ IGameEvent[]}` containing all events with `seq > lastLocalSeq`
 
 ## 5. Peer Pending Local Status
 
-- [ ] 5.1 Add `localMatchStatus: 'live' | 'guestPending' | 'hostPending'
+- [x] 5.1 Add `localMatchStatus: 'live' | 'guestPending' | 'hostPending'
 | 'aborted'` to `useGameplayStore`
 - [ ] 5.2 Host sets `guestPending` when the guest's Yjs awareness is
       lost and the match is mid-play
 - [ ] 5.3 Guest sets `hostPending` when the host's Yjs awareness is lost
       but the local log is preserved
-- [ ] 5.4 `localMatchStatus` is a local UI concern; it is NOT written
+- [x] 5.4 `localMatchStatus` is a local UI concern; it is NOT written
       to the session event log
 
 ## 6. Grace Window
 
-- [ ] 6.1 Grace window defaults to 60 seconds (configurable per match)
+- [x] 6.1 Grace window defaults to 60 seconds (configurable per match)
 - [ ] 6.2 During the grace window, the host pauses phase advancement
       and shows a banner: `"Waiting for opponent to reconnect
 (NN seconds remaining)..."`
@@ -64,9 +64,9 @@ Status` returns to `'live'` and play resumes
 
 ## 7. Host-Side Replay API
 
-- [ ] 7.1 Host exposes `getEventsFromSeq(seq: number): IGameEvent[]`
+- [x] 7.1 Host exposes `getEventsFromSeq(seq: number): IGameEvent[]`
       from its in-memory log
-- [ ] 7.2 Replay response is streamed in chunks of 64 events max per
+- [x] 7.2 Replay response is streamed in chunks of 64 events max per
       message to avoid large single messages
 - [ ] 7.3 Host rejects `reconnect-request` if `matchId` doesn't match
       the host's current session

--- a/openspec/changes/add-game-session-persistence-for-reconnect/tasks.md
+++ b/openspec/changes/add-game-session-persistence-for-reconnect/tasks.md
@@ -15,17 +15,17 @@ IGameEvent, savedAt: ISO8601}`; primary key `[matchId, sequence]`
 
 - [ ] 2.1 `InteractiveSession.appendEvent` on both host and guest writes
       to IndexedDB after the in-memory append succeeds
-- [ ] 2.2 `IGameSession` carries a `matchId` (already present after
+- [x] 2.2 `IGameSession` carries a `matchId` (already present after
       `add-game-session-invite-and-lobby-1v1`)
 - [ ] 2.3 Persistence is fire-and-forget but errors are logged; state
       mismatch between disk and memory is surfaced as a toast
 
 ## 3. Hydration From Log
 
-- [ ] 3.1 `InteractiveSession.fromMatchLog(matchId)` reads all events
+- [x] 3.1 `InteractiveSession.fromMatchLog(matchId)` reads all events
       from IndexedDB and rebuilds the session
-- [ ] 3.2 Hydration replays events into `deriveState` in sequence
-- [ ] 3.3 Unit test: a session saved then hydrated produces an
+- [x] 3.2 Hydration replays events into `deriveState` in sequence
+- [x] 3.3 Unit test: a session saved then hydrated produces an
       identical `currentState`
 
 ## 4. Reconnect Protocol (Guest → Host)
@@ -89,7 +89,7 @@ Status` returns to `'live'` and play resumes
 
 ## 10. Tests
 
-- [ ] 10.1 Unit test: save 20 events, hydrate, verify `currentState`
+- [x] 10.1 Unit test: save 20 events, hydrate, verify `currentState`
 - [ ] 10.2 Integration test using mock sync: guest drops after turn 3
       event 5, reconnects, catches up to turn 4 event 9
 - [ ] 10.3 Integration test: guest drops, grace window expires, host

--- a/openspec/changes/add-game-session-persistence-for-reconnect/tasks.md
+++ b/openspec/changes/add-game-session-persistence-for-reconnect/tasks.md
@@ -2,14 +2,14 @@
 
 ## 1. IndexedDB Schema
 
-- [ ] 1.1 Add `matchLogStorage.ts` in `src/lib/p2p/` wrapping IndexedDB
+- [x] 1.1 Add `matchLogStorage.ts` in `src/lib/p2p/` wrapping IndexedDB
       with an object store `matchEvents`
-- [ ] 1.2 Record shape: `{matchId: string, sequence: number, event:
+- [x] 1.2 Record shape: `{matchId: string, sequence: number, event:
 IGameEvent, savedAt: ISO8601}`; primary key `[matchId, sequence]`
-- [ ] 1.3 Add a `matches` object store for metadata:
+- [x] 1.3 Add a `matches` object store for metadata:
       `{matchId, hostPeerId, guestPeerId, status, lastActivity}`
-- [ ] 1.4 Writes SHALL be batched (single txn per animation frame)
-- [ ] 1.5 Add migration path for existing IndexedDB schema
+- [x] 1.4 Writes SHALL be batched (single txn per animation frame)
+- [x] 1.5 Add migration path for existing IndexedDB schema
 
 ## 2. Persistence Wiring
 

--- a/openspec/planning/ACTIVE-CHANGES-ROADMAP.md
+++ b/openspec/planning/ACTIVE-CHANGES-ROADMAP.md
@@ -12,24 +12,26 @@ where merge conflicts are likely.
 
 ## Current Active Queue
 
-All active changes remain `in-progress`. Wave 0 reconciliation marked already
-proven source, test, and spec-admin tasks complete; the remaining unchecked
-tasks are implementation work or intentionally unproven partials.
+The active queue currently has one complete change and eleven in-progress
+changes. Wave 0 reconciliation marked already proven source, test, and
+spec-admin tasks complete; later wave work has advanced several changes, but
+the remaining unchecked tasks are implementation work or intentionally
+unproven partials.
 
 | Change | Tasks | Lane |
 | --- | ---: | --- |
-| `wire-encounter-to-campaign-round-trip` | 9/42 | Campaign closure |
-| `add-infantry-construction` | 25/50 | Phase 6 construction |
-| `add-multi-type-record-sheet-export` | 2/54 | Phase 6 export |
-| `add-p2p-game-session-sync` | 3/33 | Phase 4 multiplayer |
-| `add-game-session-invite-and-lobby-1v1` | 6/39 | Phase 4 multiplayer |
-| `add-game-session-persistence-for-reconnect` | 4/39 | Phase 4 multiplayer |
-| `add-fog-of-war-event-filtering` | 5/39 | Phase 4/4.5 multiplayer |
-| `add-movement-interpolation-animations` | 3/45 | Phase 7 tactical visuals |
-| `add-los-and-firing-arc-overlays` | 4/56 | Phase 7 tactical visuals |
-| `add-attack-visual-effects` | 4/48 | Phase 7 tactical visuals |
-| `add-damage-feedback-effects` | 3/56 | Phase 7 tactical visuals |
-| `add-heat-and-shutdown-visual-indicators` | 3/51 | Phase 7 tactical visuals |
+| `wire-encounter-to-campaign-round-trip` | 15/42 | Campaign closure |
+| `add-infantry-construction` | 45/50 | Phase 6 construction |
+| `add-multi-type-record-sheet-export` | 46/54 | Phase 6 export |
+| `add-p2p-game-session-sync` | 12/33 | Phase 4 multiplayer |
+| `add-game-session-invite-and-lobby-1v1` | 29/39 | Phase 4 multiplayer |
+| `add-game-session-persistence-for-reconnect` | 19/39 | Phase 4 multiplayer |
+| `add-fog-of-war-event-filtering` | 22/39 | Phase 4/4.5 multiplayer |
+| `add-movement-interpolation-animations` | 44/45 | Phase 7 tactical visuals |
+| `add-los-and-firing-arc-overlays` | 43/56 | Phase 7 tactical visuals |
+| `add-attack-visual-effects` | 41/48 | Phase 7 tactical visuals |
+| `add-damage-feedback-effects` | 52/56 | Phase 7 tactical visuals |
+| `add-heat-and-shutdown-visual-indicators` | 51/51 | Phase 7 tactical visuals |
 
 ## Lane Model
 
@@ -175,6 +177,23 @@ After Wave 1 contracts land:
      shutdown, heat glow, smoke, and fire.
 
 ### Wave 4: Multiplayer Hardening
+
+Current status after the 2026-04-30 Wave 4 foundation slice:
+
+- `add-game-session-persistence-for-reconnect` is at 19/39. Completed
+  foundations include IndexedDB match logs, session hydration, 60s replay/grace
+  constants, host `getEventsFromSeq`, 64-event replay chunks, P2P replay helper
+  envelopes, local-only pending status fields, and focused unit tests. Remaining
+  work includes page-load reconnect wiring, Yjs awareness pending hooks,
+  grace-window pause/abort behavior, late-join rejection, cleanup/purge, and
+  integration tests.
+- `add-fog-of-war-event-filtering` is at 22/39. Completed foundations include
+  visibility helpers, standalone event classification/filtering, redaction
+  rules, fog match creation config, lobby checkbox, cache invalidation, and
+  focused unit tests. Remaining work includes literal event visibility tags or
+  an artifact decision to keep helper classification, server broadcast
+  integration, filtered replay, client rendering, integration tests, and
+  performance benchmarks.
 
 1. `add-game-session-persistence-for-reconnect`
    - Storage and `InteractiveSession.fromMatchLog` can start early.

--- a/src/__tests__/unit/api/multiplayerMatchesFog.test.ts
+++ b/src/__tests__/unit/api/multiplayerMatchesFog.test.ts
@@ -1,0 +1,121 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import type { IMatchMeta } from '@/lib/multiplayer/server/IMatchStore';
+
+import { _resetDefaultMatchStore } from '@/lib/multiplayer/server/InMemoryMatchStore';
+import handler from '@/pages/api/multiplayer/matches';
+
+jest.mock('@/lib/multiplayer/server/auth', () => ({
+  authenticateRequest: jest.fn().mockResolvedValue({
+    ok: true,
+    playerId: 'pid_host',
+    publicKey: 'host-public-key',
+    token: {
+      playerId: 'pid_host',
+      issuedAt: '2026-04-30T00:00:00.000Z',
+      expiresAt: '2026-04-30T01:00:00.000Z',
+      publicKey: 'host-public-key',
+      signature: 'host-signature',
+    },
+  }),
+}));
+
+interface ICreateMatchResponse {
+  readonly matchId: string;
+  readonly wsUrl: string;
+  readonly roomCode?: string;
+  readonly meta: IMatchMeta;
+}
+
+interface IErrorResponse {
+  readonly error: string;
+}
+
+interface MockResponse<T> {
+  statusCode: number;
+  body: T | undefined;
+  headers: Record<string, string | readonly string[]>;
+}
+
+function mockReqRes(body: unknown): {
+  req: NextApiRequest;
+  res: NextApiResponse<ICreateMatchResponse | IErrorResponse>;
+  result: MockResponse<ICreateMatchResponse | IErrorResponse>;
+} {
+  const result: MockResponse<ICreateMatchResponse | IErrorResponse> = {
+    statusCode: 0,
+    body: undefined,
+    headers: {},
+  };
+  const req = {
+    method: 'POST',
+    headers: { host: 'test.local' },
+    query: {},
+    body,
+  } as unknown as NextApiRequest;
+  const res = {
+    status(code: number) {
+      result.statusCode = code;
+      return this;
+    },
+    json(payload: ICreateMatchResponse | IErrorResponse) {
+      result.body = payload;
+      return this;
+    },
+    setHeader(name: string, value: string | readonly string[]) {
+      result.headers[name] = value;
+      return this;
+    },
+  } as unknown as NextApiResponse<ICreateMatchResponse | IErrorResponse>;
+  return { req, res, result };
+}
+
+function createdMeta(
+  result: MockResponse<ICreateMatchResponse | IErrorResponse>,
+): IMatchMeta {
+  expect(result.statusCode).toBe(201);
+  expect(result.body).toBeDefined();
+  const body = result.body;
+  if (!body || 'error' in body) {
+    throw new Error('Expected create-match response');
+  }
+  return body.meta;
+}
+
+describe('POST /api/multiplayer/matches fog config', () => {
+  beforeEach(() => {
+    _resetDefaultMatchStore();
+  });
+
+  it('defaults omitted fog config to false in match metadata', async () => {
+    const { req, res, result } = mockReqRes({
+      config: { mapRadius: 8, turnLimit: 20 },
+      layout: '1v1',
+      displayName: 'Host',
+    });
+
+    await handler(req, res);
+
+    expect(createdMeta(result).config).toMatchObject({
+      mapRadius: 8,
+      turnLimit: 20,
+      fogOfWar: false,
+    });
+  });
+
+  it('preserves selected fog config in match metadata', async () => {
+    const { req, res, result } = mockReqRes({
+      config: { mapRadius: 8, turnLimit: 20, fogOfWar: true },
+      layout: '1v1',
+      displayName: 'Host',
+    });
+
+    await handler(req, res);
+
+    expect(createdMeta(result).config).toMatchObject({
+      mapRadius: 8,
+      turnLimit: 20,
+      fogOfWar: true,
+    });
+  });
+});

--- a/src/components/multiplayer/CreateMatchForm.tsx
+++ b/src/components/multiplayer/CreateMatchForm.tsx
@@ -23,6 +23,7 @@ export interface ICreateMatchFormValue {
   readonly displayName: string;
   readonly mapRadius: number;
   readonly turnLimit: number;
+  readonly fogOfWar: boolean;
 }
 
 export interface ICreateMatchFormProps {
@@ -64,12 +65,19 @@ export function CreateMatchForm(
   const [displayName, setDisplayName] = useState<string>('MechWarrior');
   const [mapRadius, setMapRadius] = useState<number>(8);
   const [turnLimit, setTurnLimit] = useState<number>(20);
+  const [fogOfWar, setFogOfWar] = useState<boolean>(false);
 
   return (
     <form
       onSubmit={(e) => {
         e.preventDefault();
-        void props.onSubmit({ layout, displayName, mapRadius, turnLimit });
+        void props.onSubmit({
+          layout,
+          displayName,
+          mapRadius,
+          turnLimit,
+          fogOfWar,
+        });
       }}
       className="space-y-4"
     >
@@ -146,6 +154,15 @@ export function CreateMatchForm(
           />
         </div>
       </div>
+      <label className="flex items-start gap-3 rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100">
+        <input
+          type="checkbox"
+          checked={fogOfWar}
+          onChange={(e) => setFogOfWar(e.target.checked)}
+          className="mt-0.5 h-4 w-4 rounded border-slate-600 bg-slate-950 text-emerald-600 focus:ring-emerald-500"
+        />
+        <span>Double-blind (fog of war)</span>
+      </label>
       <button
         type="submit"
         disabled={props.busy}

--- a/src/components/multiplayer/__tests__/CreateMatchForm.test.tsx
+++ b/src/components/multiplayer/__tests__/CreateMatchForm.test.tsx
@@ -1,0 +1,39 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { CreateMatchForm } from '../CreateMatchForm';
+
+describe('CreateMatchForm', () => {
+  it('submits fog disabled by default', async () => {
+    const onSubmit = jest.fn();
+    render(<CreateMatchForm onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create match' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith({
+      layout: '1v1',
+      displayName: 'MechWarrior',
+      mapRadius: 8,
+      turnLimit: 20,
+      fogOfWar: false,
+    });
+  });
+
+  it('submits fog enabled when double-blind is selected', async () => {
+    const onSubmit = jest.fn();
+    render(<CreateMatchForm onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByLabelText('Double-blind (fog of war)'));
+    fireEvent.click(screen.getByRole('button', { name: 'Create match' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith({
+      layout: '1v1',
+      displayName: 'MechWarrior',
+      mapRadius: 8,
+      turnLimit: 20,
+      fogOfWar: true,
+    });
+  });
+});

--- a/src/engine/InteractiveSession.ts
+++ b/src/engine/InteractiveSession.ts
@@ -15,6 +15,10 @@ import {
   type IDeriveCombatOutcomeOptions,
 } from '@/lib/combat/outcome/combatOutcome';
 import {
+  matchLogStorage,
+  type MatchLogStorage,
+} from '@/lib/p2p/matchLogStorage';
+import {
   calculateGameOutcome,
   isGameEnded,
   type IGameOutcome,
@@ -55,6 +59,7 @@ import {
 } from '@/utils/gameplay/gameEvents';
 import {
   createGameSession,
+  hydrateGameSessionFromEvents,
   startGame,
   advancePhase,
   appendEvent,
@@ -185,6 +190,14 @@ export class InteractiveSession {
 
     this.session = createGameSession(this.gameConfig, gameUnits);
     this.session = startGame(this.session, GameSide.Player);
+  }
+
+  static async fromMatchLog(
+    matchId: string,
+    storage: Pick<MatchLogStorage, 'getEventsForMatch'> = matchLogStorage,
+  ): Promise<IGameSession> {
+    const events = await storage.getEventsForMatch(matchId);
+    return hydrateGameSessionFromEvents(matchId, events);
   }
 
   getState(): IGameState {

--- a/src/engine/__tests__/InteractiveSession.matchLog.test.ts
+++ b/src/engine/__tests__/InteractiveSession.matchLog.test.ts
@@ -1,0 +1,122 @@
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
+
+if (typeof globalThis.structuredClone === 'undefined') {
+  Object.defineProperty(globalThis, 'structuredClone', {
+    value: <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T,
+    writable: true,
+    configurable: true,
+  });
+}
+
+import { MatchLogStorage } from '@/lib/p2p/matchLogStorage';
+import {
+  GameSide,
+  type IGameConfig,
+  type IGameSession,
+  type IGameUnit,
+} from '@/types/gameplay/GameSessionInterfaces';
+import {
+  advancePhase,
+  createGameSession,
+  startGame,
+} from '@/utils/gameplay/gameSession';
+
+import { InteractiveSession } from '../InteractiveSession';
+
+const MATCH_ID = 'sess_rehydrate';
+
+function installFreshIndexedDB(): void {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: new IDBFactory(),
+    writable: true,
+    configurable: true,
+  });
+}
+
+function makeConfig(): IGameConfig {
+  return {
+    mapRadius: 7,
+    turnLimit: 30,
+    victoryConditions: ['elimination'],
+    optionalRules: [],
+  };
+}
+
+function makeUnits(): readonly IGameUnit[] {
+  return [
+    {
+      id: 'unit-player',
+      name: 'Atlas',
+      side: GameSide.Player,
+      unitRef: 'atlas-as7-d',
+      pilotRef: 'pilot-player',
+      gunnery: 4,
+      piloting: 5,
+    },
+    {
+      id: 'unit-opponent',
+      name: 'Marauder',
+      side: GameSide.Opponent,
+      unitRef: 'marauder-mad-3r',
+      pilotRef: 'pilot-opponent',
+      gunnery: 4,
+      piloting: 5,
+    },
+  ];
+}
+
+function buildTwentyEventSession(): IGameSession {
+  let session = createGameSession(makeConfig(), makeUnits(), {
+    id: MATCH_ID,
+    createdAt: '2026-04-30T00:00:00.000Z',
+  });
+  session = startGame(session, GameSide.Player);
+
+  while (session.events.length < 20) {
+    session = advancePhase(session);
+  }
+
+  return session;
+}
+
+describe('InteractiveSession.fromMatchLog', () => {
+  beforeEach(() => {
+    installFreshIndexedDB();
+  });
+
+  it('hydrates a persisted match log into an equivalent game session', async () => {
+    const storage = new MatchLogStorage({
+      dbName: 'interactive-session-match-log-test',
+      now: () => '2026-04-30T00:00:00.000Z',
+    });
+    const original = buildTwentyEventSession();
+
+    await Promise.all(
+      original.events.map((event) => storage.appendEvent(MATCH_ID, event)),
+    );
+
+    const hydrated = await InteractiveSession.fromMatchLog(MATCH_ID, storage);
+
+    expect(hydrated.id).toBe(MATCH_ID);
+    expect(hydrated.matchId).toBe(MATCH_ID);
+    expect(hydrated.events).toHaveLength(20);
+    expect(hydrated.events.map((event) => event.sequence)).toEqual(
+      Array.from({ length: 20 }, (_, sequence) => sequence),
+    );
+    expect(hydrated.currentState).toEqual(original.currentState);
+    storage.close();
+  });
+
+  it('throws a clear error for an unknown match id', async () => {
+    const storage = new MatchLogStorage({
+      dbName: 'interactive-session-missing-log-test',
+      now: () => '2026-04-30T00:00:00.000Z',
+    });
+
+    await expect(
+      InteractiveSession.fromMatchLog('sess_missing', storage),
+    ).rejects.toThrow('Match log not found');
+    storage.close();
+  });
+});

--- a/src/lib/multiplayer/server/IMatchStore.ts
+++ b/src/lib/multiplayer/server/IMatchStore.ts
@@ -52,6 +52,7 @@ export interface ISideAssignment {
 export interface IMatchConfig {
   readonly mapRadius: number;
   readonly turnLimit: number;
+  readonly fogOfWar?: boolean;
   readonly optionalRules?: readonly string[];
   readonly contractId?: string | null;
   readonly scenarioId?: string | null;

--- a/src/lib/multiplayer/server/ServerMatchHost.ts
+++ b/src/lib/multiplayer/server/ServerMatchHost.ts
@@ -449,13 +449,23 @@ export class ServerMatchHost {
    * `broadcast()`.
    */
   async sendReplay(socket: IMatchSocket, fromSeq = 0): Promise<void> {
-    const events = await this.store.getEvents(this.matchId, fromSeq);
+    const events = await this.getEventsFromSeq(fromSeq);
     const frames = streamReplay(this.matchId, events, fromSeq);
     this.safeSend(socket, frames.start);
     for (const chunk of frames.chunks) {
       this.safeSend(socket, chunk);
     }
     this.safeSend(socket, frames.end);
+  }
+
+  /**
+   * Wave 4 reconnect API: expose this host's authoritative in-memory
+   * event log slice through the store abstraction. `seq` is inclusive,
+   * matching `IMatchStore.getEvents(matchId, fromSeq?)` so callers that
+   * track a high-water mark should pass `lastSeq + 1`.
+   */
+  async getEventsFromSeq(seq: number): Promise<readonly IGameEvent[]> {
+    return this.store.getEvents(this.matchId, seq);
   }
 
   /**
@@ -478,7 +488,19 @@ export class ServerMatchHost {
     socket: IMatchSocket,
     playerId: string,
     lastSeq?: number,
+    requestedMatchId = this.matchId,
   ): Promise<void> {
+    if (requestedMatchId !== this.matchId) {
+      this.safeSend(socket, {
+        kind: 'Error',
+        matchId: this.matchId,
+        ts: nowIso(),
+        code: 'UNKNOWN_MATCH',
+        reason: 'wrong-match',
+      });
+      return;
+    }
+
     // `lastSeq` is the highest seq the client has SEEN. We stream
     // strictly newer events, so request `lastSeq + 1`. The store's
     // `getEvents(fromSeq)` returns sequence >= fromSeq, which combined

--- a/src/lib/multiplayer/server/ServerMatchHost.ts
+++ b/src/lib/multiplayer/server/ServerMatchHost.ts
@@ -442,7 +442,7 @@ export class ServerMatchHost {
   /**
    * Send the event history >= `fromSeq` to one socket as a
    * `ReplayStart` → 0+ `ReplayChunk` → `ReplayEnd` triple. Wave 4
-   * paginates via `streamReplay` (default 50 events per chunk).
+   * paginates via `streamReplay` (default 64 events per chunk).
    *
    * Replay envelopes go ONLY to the requesting socket — they are NOT
    * broadcast. Live events still go to every attached socket via

--- a/src/lib/multiplayer/server/__tests__/PendingPeerTracker.test.ts
+++ b/src/lib/multiplayer/server/__tests__/PendingPeerTracker.test.ts
@@ -6,6 +6,8 @@
  * the suite.
  */
 
+import { RECONNECT_GRACE_MS } from '@/types/multiplayer/Protocol';
+
 import {
   PendingPeerTracker,
   type IPendingPeerEntry,
@@ -55,6 +57,27 @@ function makeManualScheduler(graceMs: number) {
 // =============================================================================
 
 describe('PendingPeerTracker', () => {
+  it('uses a 60-second grace window by default', () => {
+    const sched = makeManualScheduler(RECONNECT_GRACE_MS);
+    const tracker = new PendingPeerTracker(
+      undefined,
+      sched.schedule,
+      sched.cancel,
+    );
+    let fired = false;
+
+    tracker.markPending('p1', 'alpha-1', () => {
+      fired = true;
+    });
+    sched.advance(59_999);
+
+    expect(RECONNECT_GRACE_MS).toBe(60_000);
+    expect(fired).toBe(false);
+
+    sched.advance(1);
+    expect(fired).toBe(true);
+  });
+
   it('markPending registers an entry visible via isPending', () => {
     const sched = makeManualScheduler(100);
     const tracker = new PendingPeerTracker(

--- a/src/lib/multiplayer/server/__tests__/ServerMatchHost.test.ts
+++ b/src/lib/multiplayer/server/__tests__/ServerMatchHost.test.ts
@@ -114,6 +114,34 @@ describe('ServerMatchHost', () => {
     expect(kinds).toContain('ReplayChunk');
   });
 
+  it('getEventsFromSeq returns this host match history from an inclusive sequence', async () => {
+    const { host } = await makeHost();
+
+    const allEvents = await host.getEventsFromSeq(0);
+    const tailEvents = await host.getEventsFromSeq(1);
+
+    expect(allEvents.length).toBeGreaterThan(0);
+    expect(tailEvents.every((event) => event.sequence >= 1)).toBe(true);
+    expect(tailEvents.length).toBeLessThanOrEqual(allEvents.length);
+  });
+
+  it('handleSessionJoin rejects a reconnect request for a different match', async () => {
+    const { host } = await makeHost();
+    const socket = makeMockSocket();
+
+    await host.handleSessionJoin(socket, 'p1', undefined, 'other-match');
+
+    expect(socket.sent.length).toBe(1);
+    const parsed = JSON.parse(socket.sent[0].payload) as {
+      kind: string;
+      code?: string;
+      reason?: string;
+    };
+    expect(parsed.kind).toBe('Error');
+    expect(parsed.code).toBe('UNKNOWN_MATCH');
+    expect(parsed.reason).toBe('wrong-match');
+  });
+
   it('handleIntent broadcasts new events to all sockets', async () => {
     const { host, store } = await makeHost();
     const a = makeMockSocket();

--- a/src/lib/multiplayer/server/__tests__/fogOfWar.test.ts
+++ b/src/lib/multiplayer/server/__tests__/fogOfWar.test.ts
@@ -1,0 +1,366 @@
+import {
+  Facing,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  GameStatus,
+  LockState,
+  MovementType,
+  type GameEventPayload,
+  type IAttackResolvedPayload,
+  type IGameEvent,
+  type IGameState,
+  type IUnitGameState,
+} from '@/types/gameplay';
+
+import {
+  filterEventForPlayer,
+  FogOfWarVisibilityCache,
+  classifyEventVisibility,
+} from '../fogOfWar';
+
+const PLAYER_A = 'pid_a';
+const PLAYER_B = 'pid_b';
+
+type TestCanSeeUnit = (
+  playerId: string,
+  unitId: string,
+  state: IGameState,
+) => boolean;
+
+type TestState = IGameState & {
+  readonly sideOwners: Partial<Record<GameSide, string>>;
+};
+
+function makeUnit(
+  id: string,
+  side: GameSide,
+  position = { q: 0, r: 0 },
+): IUnitGameState {
+  return {
+    id,
+    side,
+    position,
+    facing: Facing.North,
+    heat: 0,
+    movementThisTurn: MovementType.Stationary,
+    hexesMovedThisTurn: 0,
+    armor: {},
+    structure: {},
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {},
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+  };
+}
+
+function makeState(): TestState {
+  return {
+    gameId: 'game-fog',
+    status: GameStatus.Active,
+    turn: 4,
+    phase: GamePhase.WeaponAttack,
+    activationIndex: 0,
+    units: {
+      attacker: makeUnit('attacker', GameSide.Player),
+      target: makeUnit('target', GameSide.Opponent, { q: 6, r: 0 }),
+      scout: makeUnit('scout', GameSide.Opponent, { q: 2, r: 0 }),
+    },
+    turnEvents: [],
+    sideOwners: {
+      [GameSide.Player]: PLAYER_A,
+      [GameSide.Opponent]: PLAYER_B,
+    },
+  };
+}
+
+function makeEvent(
+  type: GameEventType,
+  payload: GameEventPayload,
+  actorId?: string,
+): IGameEvent {
+  return {
+    id: `evt-${type}`,
+    gameId: 'game-fog',
+    sequence: 10,
+    timestamp: '2026-04-30T00:00:00.000Z',
+    type,
+    turn: 4,
+    phase: GamePhase.WeaponAttack,
+    actorId,
+    payload,
+  };
+}
+
+function movementDeclaredEvent(unitId: string): IGameEvent {
+  return makeEvent(
+    GameEventType.MovementDeclared,
+    {
+      unitId,
+      from: { q: 0, r: 0 },
+      to: { q: 1, r: 0 },
+      facing: Facing.North,
+      movementType: MovementType.Walk,
+      mpUsed: 1,
+      heatGenerated: 0,
+    },
+    unitId,
+  );
+}
+
+function movementLockedEvent(unitId: string): IGameEvent {
+  return makeEvent(GameEventType.MovementLocked, { unitId }, unitId);
+}
+
+function heatGeneratedEvent(unitId: string): IGameEvent {
+  return makeEvent(
+    GameEventType.HeatGenerated,
+    {
+      unitId,
+      amount: 4,
+      source: 'movement',
+      newTotal: 4,
+    },
+    unitId,
+  );
+}
+
+function attackResolvedEvent(
+  payload: Partial<IAttackResolvedPayload> = {},
+): IGameEvent {
+  return makeEvent(
+    GameEventType.AttackResolved,
+    {
+      attackerId: 'attacker',
+      targetId: 'target',
+      weaponId: 'medium-laser-1',
+      roll: 8,
+      toHitNumber: 7,
+      hit: true,
+      location: 'center_torso',
+      damage: 5,
+      heat: 3,
+      attackerArc: 'front',
+      ammoBinId: null,
+      rolls: [3, 5, 2, 6],
+      ...payload,
+    },
+    payload.attackerId ?? 'attacker',
+  );
+}
+
+function unitDestroyedEvent(unitId: string): IGameEvent {
+  return makeEvent(
+    GameEventType.UnitDestroyed,
+    {
+      unitId,
+      cause: 'damage',
+      killerUnitId: 'attacker',
+    },
+    unitId,
+  );
+}
+
+function assertDelivered(
+  event: ReturnType<typeof filterEventForPlayer>,
+): asserts event is NonNullable<ReturnType<typeof filterEventForPlayer>> {
+  expect(event).not.toBeNull();
+}
+
+describe('fog-of-war event filtering', () => {
+  it('classifies representative existing event types', () => {
+    expect(classifyEventVisibility({ type: GameEventType.PhaseChanged })).toBe(
+      'public',
+    );
+    expect(
+      classifyEventVisibility({ type: GameEventType.MovementDeclared }),
+    ).toBe('actor-only');
+    expect(
+      classifyEventVisibility({ type: GameEventType.MovementLocked }),
+    ).toBe('observer-visible');
+    expect(
+      classifyEventVisibility({ type: GameEventType.AttackResolved }),
+    ).toBe('target-visible');
+  });
+
+  it('returns the original event when fog is disabled', () => {
+    const state = makeState();
+    const event = movementLockedEvent('attacker');
+    const canSeeUnit: TestCanSeeUnit = () => false;
+
+    const filtered = filterEventForPlayer(event, PLAYER_B, state, {
+      fogOfWar: false,
+      canSeeUnit,
+    });
+
+    expect(filtered).toBe(event);
+  });
+
+  it('delivers actor-only events to the actor owner and skips observers', () => {
+    const state = makeState();
+    const event = movementDeclaredEvent('attacker');
+
+    expect(
+      filterEventForPlayer(event, PLAYER_A, state, { fogOfWar: true }),
+    ).toBe(event);
+    expect(
+      filterEventForPlayer(event, PLAYER_B, state, { fogOfWar: true }),
+    ).toBeNull();
+  });
+
+  it('delivers observer-visible movement when LOS exists and skips when hidden', () => {
+    const state = makeState();
+    const event = movementLockedEvent('attacker');
+    const canSeeUnit: TestCanSeeUnit = (_playerId, unitId) => {
+      return unitId === 'attacker';
+    };
+
+    expect(
+      filterEventForPlayer(event, PLAYER_B, state, {
+        fogOfWar: true,
+        canSeeUnit,
+      }),
+    ).toBe(event);
+
+    const hiddenCanSeeUnit: TestCanSeeUnit = () => false;
+
+    expect(
+      filterEventForPlayer(event, PLAYER_B, state, {
+        fogOfWar: true,
+        canSeeUnit: hiddenCanSeeUnit,
+      }),
+    ).toBeNull();
+  });
+
+  it('skips hidden enemy heat events', () => {
+    const state = makeState();
+    const event = heatGeneratedEvent('attacker');
+    const canSeeUnit: TestCanSeeUnit = () => false;
+
+    expect(
+      filterEventForPlayer(event, PLAYER_B, state, {
+        fogOfWar: true,
+        canSeeUnit,
+      }),
+    ).toBeNull();
+  });
+
+  it('redacts a hidden attacker from the target owner attack resolution', () => {
+    const state = makeState();
+    const event = attackResolvedEvent();
+    const canSeeUnit: TestCanSeeUnit = (_playerId, unitId) => {
+      return unitId === 'target';
+    };
+
+    const filtered = filterEventForPlayer(event, PLAYER_B, state, {
+      fogOfWar: true,
+      canSeeUnit,
+    });
+
+    assertDelivered(filtered);
+    expect(filtered).not.toBe(event);
+    expect(filtered.actorId).toBeUndefined();
+    expect(filtered.payload).toEqual({
+      targetId: 'target',
+      roll: 8,
+      toHitNumber: 7,
+      hit: true,
+      location: 'center_torso',
+      damage: 5,
+      rolls: [3, 5, 2, 6],
+    });
+    expect('attackerId' in filtered.payload).toBe(false);
+    expect('weaponId' in filtered.payload).toBe(false);
+  });
+
+  it('delivers full attack detail to the attacker owner', () => {
+    const state = makeState();
+    const event = attackResolvedEvent();
+    const canSeeUnit: TestCanSeeUnit = () => false;
+
+    expect(
+      filterEventForPlayer(event, PLAYER_A, state, {
+        fogOfWar: true,
+        canSeeUnit,
+      }),
+    ).toBe(event);
+  });
+
+  it('redacts hidden unit destruction to unitId only', () => {
+    const state = makeState();
+    const event = unitDestroyedEvent('attacker');
+    const canSeeUnit: TestCanSeeUnit = () => false;
+
+    const filtered = filterEventForPlayer(event, PLAYER_B, state, {
+      fogOfWar: true,
+      canSeeUnit,
+    });
+
+    assertDelivered(filtered);
+    expect(filtered).not.toBe(event);
+    expect(filtered.type).toBe(GameEventType.UnitDestroyed);
+    expect(filtered.payload).toEqual({ unitId: 'attacker' });
+  });
+
+  it('caches repeated LOS checks for the same player/unit/state turn', () => {
+    const state = makeState();
+    const cache = new FogOfWarVisibilityCache();
+    const event = heatGeneratedEvent('attacker');
+    let checks = 0;
+    const canSeeUnit: TestCanSeeUnit = () => {
+      checks += 1;
+      return true;
+    };
+
+    expect(
+      filterEventForPlayer(event, PLAYER_B, state, {
+        fogOfWar: true,
+        cache,
+        canSeeUnit,
+      }),
+    ).toBe(event);
+    expect(
+      filterEventForPlayer(event, PLAYER_B, state, {
+        fogOfWar: true,
+        cache,
+        canSeeUnit,
+      }),
+    ).toBe(event);
+
+    expect(checks).toBe(1);
+    expect(cache.size).toBe(1);
+  });
+
+  it('invalidates cached LOS for a unit when movement is filtered', () => {
+    const state = makeState();
+    const cache = new FogOfWarVisibilityCache();
+    let visible = true;
+    let checks = 0;
+    const canSeeUnit: TestCanSeeUnit = () => {
+      checks += 1;
+      return visible;
+    };
+
+    expect(
+      filterEventForPlayer(heatGeneratedEvent('attacker'), PLAYER_B, state, {
+        fogOfWar: true,
+        cache,
+        canSeeUnit,
+      }),
+    ).not.toBeNull();
+
+    visible = false;
+
+    expect(
+      filterEventForPlayer(movementLockedEvent('attacker'), PLAYER_B, state, {
+        fogOfWar: true,
+        cache,
+        canSeeUnit,
+      }),
+    ).toBeNull();
+    expect(checks).toBe(2);
+  });
+});

--- a/src/lib/multiplayer/server/__tests__/replayStream.test.ts
+++ b/src/lib/multiplayer/server/__tests__/replayStream.test.ts
@@ -9,6 +9,7 @@ import {
   GameEventType,
   type IGameEvent,
 } from '@/types/gameplay/GameSessionInterfaces';
+import { REPLAY_CHUNK_SIZE } from '@/types/multiplayer/Protocol';
 
 import { streamReplay } from '../reconnection/replayStream';
 
@@ -73,6 +74,19 @@ describe('streamReplay', () => {
     if (frames.end.kind === 'ReplayEnd') {
       expect(frames.end.toSeq).toBe(14); // last event sequence
     }
+  });
+
+  it('uses the protocol default of 64 events per replay chunk', () => {
+    const events = Array.from({ length: REPLAY_CHUNK_SIZE + 1 }, (_, i) =>
+      fakeEvent(i + 1),
+    );
+    const frames = streamReplay('match-x', events, 0);
+    const sizes = frames.chunks.map((chunk) =>
+      chunk.kind === 'ReplayChunk' ? chunk.events.length : -1,
+    );
+
+    expect(REPLAY_CHUNK_SIZE).toBe(64);
+    expect(sizes).toEqual([64, 1]);
   });
 
   it('preserves event ordering across chunks', () => {

--- a/src/lib/multiplayer/server/fogOfWar.ts
+++ b/src/lib/multiplayer/server/fogOfWar.ts
@@ -1,0 +1,435 @@
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  type GameEventPayload,
+  type IAttackResolvedPayload,
+  type IDamageAppliedPayload,
+  type IGameEvent,
+  type IGameState,
+  type IRedactedAttackResolvedPayload,
+  type IUnitGameState,
+} from '@/types/gameplay';
+import { canPlayerSeeUnit } from '@/utils/gameplay/visibility';
+
+export type FogEventVisibility =
+  | 'public'
+  | 'actor-only'
+  | 'observer-visible'
+  | 'target-visible';
+
+export interface IFogOfWarConfig {
+  readonly fogOfWar?: boolean;
+}
+
+export interface IFogOfWarFilterOptions {
+  readonly fogOfWar?: boolean;
+  readonly config?: IFogOfWarConfig;
+  readonly cache?: FogOfWarVisibilityCache;
+  readonly canSeeUnit?: (
+    playerId: string,
+    unitId: string,
+    state: IGameState,
+  ) => boolean;
+}
+
+interface IVisibilitySideAssignment {
+  readonly playerId: string;
+  readonly side: string;
+}
+
+type FogState = IGameState & {
+  readonly sideOwners?: Partial<Record<GameSide, string>> | null;
+  readonly sideAssignments?: readonly IVisibilitySideAssignment[] | null;
+};
+
+interface ICacheEntry {
+  readonly state: IGameState;
+  readonly stateTurn: number;
+  readonly statePhase: GamePhase;
+  readonly value: boolean;
+}
+
+export class FogOfWarVisibilityCache {
+  private readonly entries = new Map<string, ICacheEntry>();
+
+  get(
+    playerId: string,
+    unitId: string,
+    state: IGameState,
+  ): boolean | undefined {
+    const entry = this.entries.get(cacheKey(playerId, unitId));
+
+    if (
+      entry &&
+      entry.state === state &&
+      entry.stateTurn === state.turn &&
+      entry.statePhase === state.phase
+    ) {
+      return entry.value;
+    }
+
+    return undefined;
+  }
+
+  set(
+    playerId: string,
+    unitId: string,
+    state: IGameState,
+    value: boolean,
+  ): void {
+    this.entries.set(cacheKey(playerId, unitId), {
+      state,
+      stateTurn: state.turn,
+      statePhase: state.phase,
+      value,
+    });
+  }
+
+  invalidateUnit(unitId: string): void {
+    for (const key of Array.from(this.entries.keys())) {
+      if (key.endsWith(`\u0000${unitId}`)) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+}
+
+const stateCaches = new WeakMap<IGameState, FogOfWarVisibilityCache>();
+
+const PUBLIC_EVENTS = new Set<GameEventType>([
+  GameEventType.GameCreated,
+  GameEventType.GameStarted,
+  GameEventType.GameEnded,
+  GameEventType.TurnStarted,
+  GameEventType.TurnEnded,
+  GameEventType.PhaseChanged,
+  GameEventType.InitiativeRolled,
+  GameEventType.InitiativeOrderSet,
+]);
+
+const ACTOR_ONLY_EVENTS = new Set<GameEventType>([
+  GameEventType.MovementDeclared,
+  GameEventType.AttackDeclared,
+  GameEventType.AttackLocked,
+  GameEventType.PhysicalAttackDeclared,
+]);
+
+const TARGET_VISIBLE_EVENTS = new Set<GameEventType>([
+  GameEventType.AttackResolved,
+  GameEventType.DamageApplied,
+  GameEventType.PhysicalAttackResolved,
+]);
+
+export function classifyEventVisibility(
+  event: Pick<IGameEvent, 'type'>,
+): FogEventVisibility {
+  if (PUBLIC_EVENTS.has(event.type)) {
+    return 'public';
+  }
+
+  if (ACTOR_ONLY_EVENTS.has(event.type)) {
+    return 'actor-only';
+  }
+
+  if (TARGET_VISIBLE_EVENTS.has(event.type)) {
+    return 'target-visible';
+  }
+
+  return 'observer-visible';
+}
+
+export function filterEventForPlayer(
+  event: IGameEvent,
+  playerId: string,
+  state: IGameState,
+  options: IFogOfWarFilterOptions = {},
+): IGameEvent | null {
+  if (!isFogEnabled(options)) {
+    return event;
+  }
+
+  const cache = options.cache ?? getStateCache(state);
+  invalidateCacheForEvent(event, cache);
+
+  const context: IFilterContext = {
+    playerId,
+    state,
+    cache,
+    canSeeUnit: options.canSeeUnit ?? canPlayerSeeUnit,
+  };
+
+  switch (classifyEventVisibility(event)) {
+    case 'public':
+      return event;
+    case 'actor-only':
+      return isEventActorOwnedByPlayer(event, context) ? event : null;
+    case 'observer-visible':
+      return filterObserverVisibleEvent(event, context);
+    case 'target-visible':
+      return filterTargetVisibleEvent(event, context);
+  }
+}
+
+interface IFilterContext {
+  readonly playerId: string;
+  readonly state: IGameState;
+  readonly cache: FogOfWarVisibilityCache;
+  readonly canSeeUnit: (
+    playerId: string,
+    unitId: string,
+    state: IGameState,
+  ) => boolean;
+}
+
+function filterObserverVisibleEvent(
+  event: IGameEvent,
+  context: IFilterContext,
+): IGameEvent | null {
+  const unitId = getPrimaryUnitId(event);
+
+  if (!unitId) {
+    return event;
+  }
+
+  if (event.type === GameEventType.UnitDestroyed) {
+    if (isUnitOwnedByPlayer(context.playerId, unitId, context.state)) {
+      return event;
+    }
+
+    if (canSeeUnitCached(context, unitId)) {
+      return event;
+    }
+
+    return {
+      ...event,
+      payload: { unitId },
+    };
+  }
+
+  return canSeeUnitCached(context, unitId) ? event : null;
+}
+
+function filterTargetVisibleEvent(
+  event: IGameEvent,
+  context: IFilterContext,
+): IGameEvent | null {
+  if (event.type === GameEventType.AttackResolved) {
+    return filterAttackResolvedEvent(event, context);
+  }
+
+  if (event.type === GameEventType.DamageApplied) {
+    return filterDamageAppliedEvent(event, context);
+  }
+
+  const unitId = getPrimaryUnitId(event);
+
+  if (!unitId) {
+    return event;
+  }
+
+  return canSeeUnitCached(context, unitId) ? event : null;
+}
+
+function filterAttackResolvedEvent(
+  event: IGameEvent,
+  context: IFilterContext,
+): IGameEvent | null {
+  const payload = event.payload as IAttackResolvedPayload;
+  const targetOwnerCanReceive = isUnitOwnedByPlayer(
+    context.playerId,
+    payload.targetId,
+    context.state,
+  );
+
+  if (
+    isUnitOwnedByPlayer(context.playerId, payload.attackerId, context.state)
+  ) {
+    return event;
+  }
+
+  const attackerVisible = canSeeUnitCached(context, payload.attackerId);
+  const targetVisible = canSeeUnitCached(context, payload.targetId);
+
+  if (targetOwnerCanReceive && !attackerVisible) {
+    return {
+      ...event,
+      actorId: undefined,
+      payload: redactAttackResolvedPayload(payload),
+    };
+  }
+
+  if (attackerVisible || targetVisible) {
+    return event;
+  }
+
+  return null;
+}
+
+function filterDamageAppliedEvent(
+  event: IGameEvent,
+  context: IFilterContext,
+): IGameEvent | null {
+  const payload = event.payload as IDamageAppliedPayload;
+
+  if (isUnitOwnedByPlayer(context.playerId, payload.unitId, context.state)) {
+    return event;
+  }
+
+  if (canSeeUnitCached(context, payload.unitId)) {
+    return event;
+  }
+
+  if (payload.sourceUnitId && canSeeUnitCached(context, payload.sourceUnitId)) {
+    return event;
+  }
+
+  return null;
+}
+
+function redactAttackResolvedPayload(
+  payload: IAttackResolvedPayload,
+): IRedactedAttackResolvedPayload {
+  return {
+    targetId: payload.targetId,
+    roll: payload.roll,
+    toHitNumber: payload.toHitNumber,
+    hit: payload.hit,
+    ...(payload.location !== undefined ? { location: payload.location } : {}),
+    ...(payload.damage !== undefined ? { damage: payload.damage } : {}),
+    ...(payload.rolls !== undefined ? { rolls: payload.rolls } : {}),
+  };
+}
+
+function invalidateCacheForEvent(
+  event: IGameEvent,
+  cache: FogOfWarVisibilityCache,
+): void {
+  if (
+    event.type === GameEventType.MovementDeclared ||
+    event.type === GameEventType.MovementLocked
+  ) {
+    const unitId = getUnitIdFromPayload(event.payload);
+    if (unitId) {
+      cache.invalidateUnit(unitId);
+    }
+  }
+}
+
+function canSeeUnitCached(context: IFilterContext, unitId: string): boolean {
+  const cached = context.cache.get(context.playerId, unitId, context.state);
+
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const value = context.canSeeUnit(context.playerId, unitId, context.state);
+  context.cache.set(context.playerId, unitId, context.state, value);
+
+  return value;
+}
+
+function isEventActorOwnedByPlayer(
+  event: IGameEvent,
+  context: IFilterContext,
+): boolean {
+  const actorId = event.actorId ?? getPrimaryUnitId(event);
+
+  if (!actorId) {
+    return false;
+  }
+
+  return isUnitOwnedByPlayer(context.playerId, actorId, context.state);
+}
+
+function getPrimaryUnitId(event: IGameEvent): string | null {
+  if (event.actorId) {
+    return event.actorId;
+  }
+
+  return getCombatUnitIdFromPayload(event.payload);
+}
+
+function getUnitIdFromPayload(payload: GameEventPayload): string | null {
+  if (isPayloadWithStringField(payload, 'unitId')) {
+    return payload.unitId;
+  }
+
+  return null;
+}
+
+function getCombatUnitIdFromPayload(payload: GameEventPayload): string | null {
+  if (isPayloadWithStringField(payload, 'attackerId')) {
+    return payload.attackerId;
+  }
+
+  if (isPayloadWithStringField(payload, 'unitId')) {
+    return payload.unitId;
+  }
+
+  return null;
+}
+
+function isPayloadWithStringField<TField extends string>(
+  payload: GameEventPayload,
+  field: TField,
+): payload is GameEventPayload & Record<TField, string> {
+  const record = payload as Readonly<Record<string, unknown>>;
+  return field in record && typeof record[field] === 'string';
+}
+
+function isUnitOwnedByPlayer(
+  playerId: string,
+  unitId: string,
+  state: IGameState,
+): boolean {
+  const unit = state.units[unitId];
+
+  if (!unit) {
+    return false;
+  }
+
+  return ownerIdForUnit(unit, state as FogState) === playerId;
+}
+
+function ownerIdForUnit(unit: IUnitGameState, state: FogState): string {
+  const ownerFromSideMap = state.sideOwners?.[unit.side];
+
+  if (ownerFromSideMap !== undefined) {
+    return ownerFromSideMap;
+  }
+
+  const assignment = state.sideAssignments?.find((candidate) => {
+    return candidate.side === unit.side;
+  });
+
+  return assignment?.playerId ?? unit.side;
+}
+
+function isFogEnabled(options: IFogOfWarFilterOptions): boolean {
+  return options.fogOfWar ?? options.config?.fogOfWar ?? false;
+}
+
+function getStateCache(state: IGameState): FogOfWarVisibilityCache {
+  const existing = stateCaches.get(state);
+
+  if (existing) {
+    return existing;
+  }
+
+  const cache = new FogOfWarVisibilityCache();
+  stateCaches.set(state, cache);
+  return cache;
+}
+
+function cacheKey(playerId: string, unitId: string): string {
+  return `${playerId}\u0000${unitId}`;
+}

--- a/src/lib/multiplayer/server/reconnection/PendingPeerTracker.ts
+++ b/src/lib/multiplayer/server/reconnection/PendingPeerTracker.ts
@@ -2,7 +2,7 @@
  * PendingPeerTracker — owns the per-pending-player grace timers.
  *
  * Wave 4 of Phase 4. When a socket closes, the host marks the player's
- * seat as `pending` and asks this tracker to start a 120s grace timer.
+ * seat as `pending` and asks this tracker to start a 60s grace timer.
  * If the player reconnects before the timer fires, `clearPending`
  * cancels it. If the timer expires, the registered `onTimeout`
  * callback fires (the host then broadcasts `SeatTimedOut`).

--- a/src/lib/multiplayer/server/reconnection/replayStream.ts
+++ b/src/lib/multiplayer/server/reconnection/replayStream.ts
@@ -48,7 +48,7 @@ export interface IReplayStreamFrames {
  *
  * Behaviour:
  *   - Always emits exactly ONE `ReplayStart` and ONE `ReplayEnd`.
- *   - Chunks the events into `chunkSize` slices (default 50). An empty
+ *   - Chunks the events into `chunkSize` slices (default 64). An empty
  *     event list still emits one zero-length chunk so the client's
  *     `ReplayStart → ReplayChunk → ReplayEnd` invariant holds without a
  *     special-case.
@@ -64,7 +64,7 @@ export interface IReplayStreamFrames {
  * @param fromSeq  The client's high-water mark (`lastSeq + 1`). Echoed
  *                 in `ReplayStart.fromSeq` so the client can sanity-check.
  * @param chunkSize Override for the default chunk size; tests use this
- *                 to drive multi-chunk behaviour without 50+ events.
+ *                 to drive multi-chunk behaviour without 64+ events.
  */
 export function streamReplay(
   matchId: string,

--- a/src/lib/p2p/__tests__/gameSessionChannel.test.ts
+++ b/src/lib/p2p/__tests__/gameSessionChannel.test.ts
@@ -9,14 +9,19 @@ import {
   type IGameIntent,
   type IGameSession,
 } from '@/types/gameplay/GameSessionInterfaces';
+import { REPLAY_CHUNK_SIZE } from '@/types/multiplayer/Protocol';
 
 import {
   GAME_SESSION_EVENTS_ARRAY,
+  createReconnectRequestEnvelope,
   createGameSessionChannel,
+  createReplayStreamEnvelopes,
   deserializeGameSessionEnvelope,
+  getReplayEventsAfterSeq,
   isGameIntent,
   serializeGameSessionEnvelope,
   type IGameEventEnvelope,
+  type MatchLogPersistence,
 } from '../gameSessionChannel';
 import {
   GAME_SESSION_AWARENESS_FIELD,
@@ -109,6 +114,34 @@ describe('gameSessionChannel', () => {
     expect(customizerTabs.toArray()).toEqual(['tab-a']);
   });
 
+  it('persists locally broadcast events after the Yjs append succeeds', async () => {
+    const persisted: Array<{ matchId: string; event: IGameEvent }> = [];
+    const matchLog: MatchLogPersistence = {
+      appendEvent: jest.fn((matchId, event) => {
+        persisted.push({ matchId, event });
+        return Promise.resolve({
+          matchId,
+          sequence: event.sequence,
+          event,
+          savedAt: '2026-04-30T00:00:00.000Z',
+        });
+      }),
+    };
+    const channel = createGameSessionChannel({
+      localPeerId: 'host-peer',
+      eventArray,
+      matchId: 'match-1',
+      matchLog,
+    });
+    const event = makeEvent('event-1', 1);
+
+    channel.broadcastEvent(event);
+    await Promise.resolve();
+
+    expect(eventArray).toHaveLength(1);
+    expect(persisted).toEqual([{ matchId: 'match-1', event }]);
+  });
+
   it('delivers peer-authored events in arrival order', () => {
     const channel = createGameSessionChannel({
       localPeerId: 'guest-peer',
@@ -134,6 +167,72 @@ describe('gameSessionChannel', () => {
 
     unsubscribe();
     expect(received).toEqual(['event-1', 'event-2']);
+  });
+
+  it('persists peer-received events without blocking peer delivery', async () => {
+    const matchLog: MatchLogPersistence = {
+      appendEvent: jest.fn((matchId, event) =>
+        Promise.resolve({
+          matchId,
+          sequence: event.sequence,
+          event,
+          savedAt: '2026-04-30T00:00:00.000Z',
+        }),
+      ),
+    };
+    const channel = createGameSessionChannel({
+      localPeerId: 'guest-peer',
+      eventArray,
+      matchId: 'match-1',
+      matchLog,
+    });
+    const received: string[] = [];
+    const unsubscribe = channel.onPeerEvent((event) => {
+      received.push(event.id);
+    });
+    const event = makeEvent('event-1', 1);
+
+    eventArray.push([
+      serializeGameSessionEnvelope({
+        kind: 'game-event',
+        event,
+        authorPeerId: 'host-peer',
+      }),
+    ]);
+    await Promise.resolve();
+
+    unsubscribe();
+    expect(received).toEqual(['event-1']);
+    expect(matchLog.appendEvent).toHaveBeenCalledWith('match-1', event);
+  });
+
+  it('logs persistence failures without breaking local broadcast sync', async () => {
+    const error = new Error('indexeddb write failed');
+    const logger = { error: jest.fn() };
+    const matchLog: MatchLogPersistence = {
+      appendEvent: jest.fn(() => Promise.reject(error)),
+    };
+    const channel = createGameSessionChannel({
+      localPeerId: 'host-peer',
+      eventArray,
+      matchId: 'match-1',
+      matchLog,
+      logger,
+    });
+
+    channel.broadcastEvent(makeEvent('event-1', 1));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(eventArray).toHaveLength(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to persist P2P match event',
+      {
+        matchId: 'match-1',
+        sequence: 1,
+        error,
+      },
+    );
   });
 
   it('rejects local-authored event arrivals', () => {
@@ -181,6 +280,62 @@ describe('gameSessionChannel', () => {
         authorPeerId: 'guest-peer',
       },
     ]);
+  });
+
+  it('builds reconnect requests with the expected wire shape', () => {
+    const request = createReconnectRequestEnvelope({
+      matchId: 'match-1',
+      lastLocalSeq: 25,
+      authorPeerId: 'guest-peer',
+    });
+
+    expect(request).toEqual({
+      kind: 'reconnect-request',
+      matchId: 'match-1',
+      lastLocalSeq: 25,
+      authorPeerId: 'guest-peer',
+    });
+    expect(
+      deserializeGameSessionEnvelope(serializeGameSessionEnvelope(request)),
+    ).toEqual(request);
+  });
+
+  it('chunks replay streams at the protocol chunk size and marks only the final chunk done', () => {
+    const events = Array.from({ length: REPLAY_CHUNK_SIZE + 1 }, (_, index) =>
+      makeEvent(`event-${index}`, index),
+    );
+
+    const chunks = createReplayStreamEnvelopes('match-1', events);
+
+    expect(REPLAY_CHUNK_SIZE).toBe(64);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toMatchObject({
+      kind: 'replay-stream',
+      matchId: 'match-1',
+      done: false,
+    });
+    expect(chunks[0].events).toHaveLength(REPLAY_CHUNK_SIZE);
+    expect(chunks[1]).toMatchObject({
+      kind: 'replay-stream',
+      matchId: 'match-1',
+      done: true,
+    });
+    expect(chunks[1].events).toHaveLength(1);
+    expect(
+      deserializeGameSessionEnvelope(serializeGameSessionEnvelope(chunks[0])),
+    ).toEqual(chunks[0]);
+  });
+
+  it('selects replay events newer than the reconnecting peer sequence in order', () => {
+    const events = [
+      makeEvent('event-3', 3),
+      makeEvent('event-1', 1),
+      makeEvent('event-2', 2),
+    ];
+
+    expect(
+      getReplayEventsAfterSeq(events, 1).map((event) => event.sequence),
+    ).toEqual([2, 3]);
   });
 });
 

--- a/src/lib/p2p/__tests__/matchLogStorage.test.ts
+++ b/src/lib/p2p/__tests__/matchLogStorage.test.ts
@@ -1,0 +1,328 @@
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
+
+if (typeof globalThis.structuredClone === 'undefined') {
+  Object.defineProperty(globalThis, 'structuredClone', {
+    value: <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T,
+    writable: true,
+    configurable: true,
+  });
+}
+
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  type IGameEvent,
+} from '@/types/gameplay/GameSessionInterfaces';
+
+import {
+  MATCH_LOG_DB_NAME,
+  MATCH_LOG_DB_VERSION,
+  MATCH_LOG_RETENTION_MS,
+  MATCH_LOG_STORES,
+  MatchLogStorage,
+  MatchLogStorageUnavailableError,
+  type IMatchEventRecord,
+} from '../matchLogStorage';
+
+const BASE_TIME = '2026-04-30T00:00:00.000Z';
+
+let dbCounter = 0;
+
+function nextDbName(): string {
+  dbCounter += 1;
+  return `${MATCH_LOG_DB_NAME}-test-${dbCounter}`;
+}
+
+function installFreshIndexedDB(): void {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: new IDBFactory(),
+    writable: true,
+    configurable: true,
+  });
+}
+
+function makeEvent(matchId: string, sequence: number): IGameEvent {
+  return {
+    id: `${matchId}-${sequence}`,
+    gameId: matchId,
+    sequence,
+    timestamp: BASE_TIME,
+    type: GameEventType.GameStarted,
+    turn: 1,
+    phase: GamePhase.Initiative,
+    payload: {
+      firstSide: GameSide.Player,
+    },
+  };
+}
+
+function openRawDatabase(
+  dbName: string,
+  version: number,
+  upgrade?: (db: IDBDatabase) => void,
+): Promise<IDBDatabase> {
+  return new Promise<IDBDatabase>((resolve, reject) => {
+    const request = globalThis.indexedDB.open(dbName, version);
+    request.onupgradeneeded = () => {
+      upgrade?.(request.result);
+    };
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+    request.onerror = () => {
+      reject(request.error ?? new Error('Failed to open raw database'));
+    };
+  });
+}
+
+function getRawRecord<T>(dbName: string, storeName: string, key: IDBValidKey) {
+  return openRawDatabase(dbName, MATCH_LOG_DB_VERSION).then(
+    (db) =>
+      new Promise<T | undefined>((resolve, reject) => {
+        const request = db
+          .transaction(storeName, 'readonly')
+          .objectStore(storeName)
+          .get(key);
+        request.onsuccess = () => {
+          db.close();
+          resolve(request.result as T | undefined);
+        };
+        request.onerror = () => {
+          db.close();
+          reject(request.error ?? new Error('Failed to read raw record'));
+        };
+      }),
+  );
+}
+
+describe('MatchLogStorage', () => {
+  beforeEach(() => {
+    installFreshIndexedDB();
+  });
+
+  it('creates matchEvents and matches stores with the compound event key during migration', async () => {
+    const dbName = nextDbName();
+    const legacyDb = await openRawDatabase(dbName, 1, (db) => {
+      db.createObjectStore('legacy');
+    });
+    legacyDb.close();
+
+    const storage = new MatchLogStorage({ dbName, now: () => BASE_TIME });
+    await storage.initialize();
+    storage.close();
+
+    const db = await openRawDatabase(dbName, MATCH_LOG_DB_VERSION);
+    expect(db.objectStoreNames.contains(MATCH_LOG_STORES.MATCH_EVENTS)).toBe(
+      true,
+    );
+    expect(db.objectStoreNames.contains(MATCH_LOG_STORES.MATCHES)).toBe(true);
+
+    const transaction = db.transaction(
+      [MATCH_LOG_STORES.MATCH_EVENTS, MATCH_LOG_STORES.MATCHES],
+      'readonly',
+    );
+    expect(
+      transaction.objectStore(MATCH_LOG_STORES.MATCH_EVENTS).keyPath,
+    ).toEqual(['matchId', 'sequence']);
+    expect(transaction.objectStore(MATCH_LOG_STORES.MATCHES).keyPath).toBe(
+      'matchId',
+    );
+    expect(
+      transaction
+        .objectStore(MATCH_LOG_STORES.MATCH_EVENTS)
+        .indexNames.contains('byMatchId'),
+    ).toBe(true);
+    expect(
+      transaction
+        .objectStore(MATCH_LOG_STORES.MATCHES)
+        .indexNames.contains('byStatus'),
+    ).toBe(true);
+    db.close();
+  });
+
+  it('stores the required record shape and queries each match in ascending sequence order', async () => {
+    const dbName = nextDbName();
+    const storage = new MatchLogStorage({
+      dbName,
+      now: () => BASE_TIME,
+      scheduleFrame: (callback) => callback(),
+    });
+
+    await storage.appendEvent('sess_abc', makeEvent('sess_abc', 2));
+    await storage.appendEvent('sess_xyz', makeEvent('sess_xyz', 0));
+    await storage.appendEvent('sess_abc', makeEvent('sess_abc', 0));
+    await storage.appendEvent('sess_abc', makeEvent('sess_abc', 1));
+
+    const events = await storage.getEventsForMatch('sess_abc');
+    expect(events.map((event) => event.sequence)).toEqual([0, 1, 2]);
+    expect(events.every((event) => event.gameId === 'sess_abc')).toBe(true);
+    expect(await storage.getLastSequence('sess_abc')).toBe(2);
+    expect(await storage.getLastSequence('missing')).toBeNull();
+
+    const rawRecord = await getRawRecord<IMatchEventRecord>(
+      dbName,
+      MATCH_LOG_STORES.MATCH_EVENTS,
+      ['sess_abc', 0],
+    );
+    expect(rawRecord).toEqual({
+      matchId: 'sess_abc',
+      sequence: 0,
+      event: makeEvent('sess_abc', 0),
+      savedAt: BASE_TIME,
+    });
+    storage.close();
+  });
+
+  it('batches a burst of appends into one animation-frame transaction', async () => {
+    const dbName = nextDbName();
+    const scheduler: { callback?: () => void } = {};
+    const flushes: number[] = [];
+    const storage = new MatchLogStorage({
+      dbName,
+      now: () => BASE_TIME,
+      scheduleFrame: (callback) => {
+        scheduler.callback = callback;
+      },
+      onFlushTransaction: ({ recordCount }) => {
+        flushes.push(recordCount);
+      },
+    });
+
+    const writes = Array.from({ length: 20 }, (_, sequence) =>
+      storage.appendEvent('burst-match', makeEvent('burst-match', sequence)),
+    );
+
+    expect(flushes).toEqual([]);
+    if (!scheduler.callback) {
+      throw new Error('Expected match log flush to be scheduled');
+    }
+    scheduler.callback();
+    await Promise.all(writes);
+
+    expect(flushes).toEqual([20]);
+    expect(await storage.getLastSequence('burst-match')).toBe(19);
+    expect(await storage.getEventsForMatch('burst-match')).toHaveLength(20);
+    storage.close();
+  });
+
+  it('upserts metadata while preserving peer ids across activity updates', async () => {
+    const dbName = nextDbName();
+    let now = BASE_TIME;
+    const storage = new MatchLogStorage({
+      dbName,
+      now: () => now,
+      scheduleFrame: (callback) => callback(),
+    });
+
+    await storage.upsertMatchMetadata({
+      matchId: 'meta-match',
+      hostPeerId: 'host-peer',
+      guestPeerId: 'guest-peer',
+    });
+
+    now = '2026-04-30T00:01:00.000Z';
+    await storage.appendEvent('meta-match', makeEvent('meta-match', 0));
+
+    expect(await storage.getMatchMetadata('meta-match')).toEqual({
+      matchId: 'meta-match',
+      hostPeerId: 'host-peer',
+      guestPeerId: 'guest-peer',
+      status: 'active',
+      lastActivity: '2026-04-30T00:01:00.000Z',
+    });
+    storage.close();
+  });
+
+  it('marks completed matches without dropping metadata fields', async () => {
+    const dbName = nextDbName();
+    const storage = new MatchLogStorage({
+      dbName,
+      now: () => BASE_TIME,
+      scheduleFrame: (callback) => callback(),
+    });
+
+    await storage.upsertMatchMetadata({
+      matchId: 'completed-match',
+      hostPeerId: 'host-peer',
+      guestPeerId: null,
+    });
+
+    const completed = await storage.markMatchCompleted(
+      'completed-match',
+      '2026-04-30T00:02:00.000Z',
+    );
+
+    expect(completed).toEqual({
+      matchId: 'completed-match',
+      hostPeerId: 'host-peer',
+      guestPeerId: null,
+      status: 'completed',
+      lastActivity: '2026-04-30T00:02:00.000Z',
+    });
+    expect(await storage.getMatchMetadata('completed-match')).toEqual(
+      completed,
+    );
+    storage.close();
+  });
+
+  it('purges only completed match logs older than the retention window', async () => {
+    const dbName = nextDbName();
+    const storage = new MatchLogStorage({
+      dbName,
+      now: () => '2026-04-30T00:00:00.000Z',
+      scheduleFrame: (callback) => callback(),
+    });
+
+    await storage.appendEvent('old-completed', makeEvent('old-completed', 0));
+    await storage.appendEvent(
+      'recent-completed',
+      makeEvent('recent-completed', 0),
+    );
+    await storage.appendEvent('old-active', makeEvent('old-active', 0));
+    await storage.upsertMatchMetadata({
+      matchId: 'old-completed',
+      status: 'completed',
+      lastActivity: '2026-04-21T23:59:59.000Z',
+    });
+    await storage.upsertMatchMetadata({
+      matchId: 'recent-completed',
+      status: 'completed',
+      lastActivity: '2026-04-29T00:00:00.000Z',
+    });
+    await storage.upsertMatchMetadata({
+      matchId: 'old-active',
+      status: 'active',
+      lastActivity: '2026-04-01T00:00:00.000Z',
+    });
+
+    const result = await storage.purgeOldMatches(MATCH_LOG_RETENTION_MS);
+
+    expect(result).toEqual({
+      purgedMatchIds: ['old-completed'],
+      purgedEventCount: 1,
+    });
+    expect(await storage.getEventsForMatch('old-completed')).toEqual([]);
+    expect(await storage.getMatchMetadata('old-completed')).toBeUndefined();
+    expect(await storage.getEventsForMatch('recent-completed')).toHaveLength(1);
+    expect(await storage.getEventsForMatch('old-active')).toHaveLength(1);
+    storage.close();
+  });
+
+  it('rejects with an explicit unavailable error when IndexedDB is absent', async () => {
+    Object.defineProperty(globalThis, 'indexedDB', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+    const storage = new MatchLogStorage({
+      dbName: nextDbName(),
+      now: () => BASE_TIME,
+    });
+
+    await expect(
+      storage.appendEvent('offline-match', makeEvent('offline-match', 0)),
+    ).rejects.toThrow(MatchLogStorageUnavailableError);
+  });
+});

--- a/src/lib/p2p/gameSessionChannel.ts
+++ b/src/lib/p2p/gameSessionChannel.ts
@@ -7,11 +7,13 @@ import {
   type IGameEvent,
   type IGameIntent,
 } from '@/types/gameplay/GameSessionInterfaces';
+import { REPLAY_CHUNK_SIZE } from '@/types/multiplayer/Protocol';
 import {
   deserializeEvent,
   serializeEvent,
 } from '@/utils/gameplay/gameEvents/serialization';
 
+import { matchLogStorage, type MatchLogStorage } from './matchLogStorage';
 import { getLocalPeerId, getYArray } from './SyncProvider';
 
 export const GAME_SESSION_EVENTS_ARRAY = 'gameEvents';
@@ -30,14 +32,30 @@ export interface IGameIntentEnvelope {
 
 export interface IPeerRejectedEnvelope {
   readonly kind: 'peer-rejected';
-  readonly intentId: string;
+  readonly intentId?: string;
   readonly reason: string;
+}
+
+export interface IReconnectRequestEnvelope {
+  readonly kind: 'reconnect-request';
+  readonly matchId: string;
+  readonly lastLocalSeq: number;
+  readonly authorPeerId: string;
+}
+
+export interface IReplayStreamEnvelope {
+  readonly kind: 'replay-stream';
+  readonly matchId: string;
+  readonly events: readonly IGameEvent[];
+  readonly done: boolean;
 }
 
 export type GameSessionChannelEnvelope =
   | IGameEventEnvelope
   | IGameIntentEnvelope
-  | IPeerRejectedEnvelope;
+  | IPeerRejectedEnvelope
+  | IReconnectRequestEnvelope
+  | IReplayStreamEnvelope;
 
 export type PeerEventCallback = (
   event: IGameEvent,
@@ -50,6 +68,14 @@ export type PeerIntentCallback = (
 ) => void;
 
 export type PeerRejectedCallback = (envelope: IPeerRejectedEnvelope) => void;
+export type ReconnectRequestCallback = (
+  envelope: IReconnectRequestEnvelope,
+) => void;
+export type ReplayStreamCallback = (envelope: IReplayStreamEnvelope) => void;
+
+export type MatchLogPersistence = Pick<MatchLogStorage, 'appendEvent'>;
+
+export type GameSessionChannelLogger = Pick<Console, 'error'>;
 
 export interface IGameSessionChannel {
   readonly broadcastEvent: (event: IGameEvent) => void;
@@ -60,12 +86,26 @@ export interface IGameSessionChannel {
     rejection: Omit<IPeerRejectedEnvelope, 'kind'>,
   ) => void;
   readonly onPeerRejection: (callback: PeerRejectedCallback) => () => void;
+  readonly broadcastReconnectRequest: (
+    request: Omit<IReconnectRequestEnvelope, 'kind' | 'authorPeerId'>,
+  ) => void;
+  readonly onReconnectRequest: (
+    callback: ReconnectRequestCallback,
+  ) => () => void;
+  readonly broadcastReplayStream: (
+    stream: Omit<IReplayStreamEnvelope, 'kind'>,
+  ) => void;
+  readonly onReplayStream: (callback: ReplayStreamCallback) => () => void;
 }
 
 export interface IGameSessionChannelOptions {
   readonly localPeerId?: string;
   readonly eventArray?: Y.Array<string>;
   readonly getEventArray?: () => Y.Array<string> | null;
+  readonly matchId?: string;
+  readonly getMatchId?: () => string | null | undefined;
+  readonly matchLog?: MatchLogPersistence;
+  readonly logger?: GameSessionChannelLogger;
 }
 
 export function serializeGameSessionEnvelope(
@@ -77,6 +117,18 @@ export function serializeGameSessionEnvelope(
       kind: envelope.kind,
       event,
       authorPeerId: envelope.authorPeerId,
+    });
+  }
+
+  if (envelope.kind === 'replay-stream') {
+    const events = envelope.events.map((event) =>
+      JSON.parse(serializeEvent(event)),
+    );
+    return JSON.stringify({
+      kind: envelope.kind,
+      matchId: envelope.matchId,
+      events,
+      done: envelope.done,
     });
   }
 
@@ -121,16 +173,57 @@ export function deserializeGameSessionEnvelope(
   }
 
   if (parsed.kind === 'peer-rejected') {
+    const intentId = parsed.intentId;
     if (
-      typeof parsed.intentId !== 'string' ||
+      (intentId !== undefined && typeof intentId !== 'string') ||
       typeof parsed.reason !== 'string'
     ) {
       throw new Error('Invalid peer rejection envelope payload');
     }
     return {
       kind: 'peer-rejected',
-      intentId: parsed.intentId,
+      intentId,
       reason: parsed.reason,
+    };
+  }
+
+  if (parsed.kind === 'reconnect-request') {
+    if (
+      typeof parsed.matchId !== 'string' ||
+      typeof parsed.lastLocalSeq !== 'number' ||
+      !Number.isInteger(parsed.lastLocalSeq) ||
+      parsed.lastLocalSeq < 0 ||
+      typeof parsed.authorPeerId !== 'string'
+    ) {
+      throw new Error('Invalid reconnect request envelope payload');
+    }
+    return {
+      kind: 'reconnect-request',
+      matchId: parsed.matchId,
+      lastLocalSeq: parsed.lastLocalSeq,
+      authorPeerId: parsed.authorPeerId,
+    };
+  }
+
+  if (parsed.kind === 'replay-stream') {
+    if (
+      typeof parsed.matchId !== 'string' ||
+      !Array.isArray(parsed.events) ||
+      typeof parsed.done !== 'boolean'
+    ) {
+      throw new Error('Invalid replay stream envelope payload');
+    }
+    const events = parsed.events.map((event) =>
+      deserializeEvent(JSON.stringify(event)),
+    );
+    if (!events.every(isGameEvent)) {
+      throw new Error('Invalid replay stream event payload');
+    }
+    return {
+      kind: 'replay-stream',
+      matchId: parsed.matchId,
+      events,
+      done: parsed.done,
     };
   }
 
@@ -153,6 +246,21 @@ export function createGameSessionChannel(
   const appendEnvelope = (envelope: GameSessionChannelEnvelope): void => {
     const eventArray = requireGameEventsArray(options);
     eventArray.push([serializeGameSessionEnvelope(envelope)]);
+  };
+
+  const persistEvent = (event: IGameEvent): void => {
+    const matchId = getPersistenceMatchId(options);
+    if (!matchId) return;
+
+    const storage = options.matchLog ?? matchLogStorage;
+    void storage.appendEvent(matchId, event).catch((error: unknown) => {
+      const logger = options.logger ?? console;
+      logger.error('Failed to persist P2P match event', {
+        matchId,
+        sequence: event.sequence,
+        error,
+      });
+    });
   };
 
   const observeEnvelopes = (
@@ -184,11 +292,13 @@ export function createGameSessionChannel(
         event,
         authorPeerId: requireLocalPeerId(options),
       });
+      persistEvent(event);
     },
     onPeerEvent: (callback: PeerEventCallback): (() => void) => {
       return observeEnvelopes((envelope) => {
         if (envelope.kind !== 'game-event') return;
         if (isLocalAuthor(envelope.authorPeerId)) return;
+        persistEvent(envelope.event);
         callback(envelope.event, envelope);
       });
     },
@@ -222,6 +332,39 @@ export function createGameSessionChannel(
         callback(envelope);
       });
     },
+    broadcastReconnectRequest: (
+      request: Omit<IReconnectRequestEnvelope, 'kind' | 'authorPeerId'>,
+    ): void => {
+      appendEnvelope(
+        createReconnectRequestEnvelope({
+          ...request,
+          authorPeerId: requireLocalPeerId(options),
+        }),
+      );
+    },
+    onReconnectRequest: (callback: ReconnectRequestCallback): (() => void) => {
+      return observeEnvelopes((envelope) => {
+        if (envelope.kind !== 'reconnect-request') return;
+        if (isLocalAuthor(envelope.authorPeerId)) return;
+        callback(envelope);
+      });
+    },
+    broadcastReplayStream: (
+      stream: Omit<IReplayStreamEnvelope, 'kind'>,
+    ): void => {
+      appendEnvelope({
+        kind: 'replay-stream',
+        matchId: stream.matchId,
+        events: stream.events,
+        done: stream.done,
+      });
+    },
+    onReplayStream: (callback: ReplayStreamCallback): (() => void) => {
+      return observeEnvelopes((envelope) => {
+        if (envelope.kind !== 'replay-stream') return;
+        callback(envelope);
+      });
+    },
   };
 }
 
@@ -249,6 +392,73 @@ export function broadcastRejection(
 
 export function onPeerRejection(callback: PeerRejectedCallback): () => void {
   return createGameSessionChannel().onPeerRejection(callback);
+}
+
+export function createReconnectRequestEnvelope(input: {
+  readonly matchId: string;
+  readonly lastLocalSeq: number;
+  readonly authorPeerId: string;
+}): IReconnectRequestEnvelope {
+  return {
+    kind: 'reconnect-request',
+    matchId: input.matchId,
+    lastLocalSeq: input.lastLocalSeq,
+    authorPeerId: input.authorPeerId,
+  };
+}
+
+export function createReplayStreamEnvelopes(
+  matchId: string,
+  events: readonly IGameEvent[],
+  chunkSize: number = REPLAY_CHUNK_SIZE,
+): IReplayStreamEnvelope[] {
+  if (!Number.isInteger(chunkSize) || chunkSize < 1) {
+    throw new Error('Replay chunk size must be a positive integer');
+  }
+
+  if (events.length === 0) {
+    return [
+      {
+        kind: 'replay-stream',
+        matchId,
+        events: [],
+        done: true,
+      },
+    ];
+  }
+
+  const envelopes: IReplayStreamEnvelope[] = [];
+  for (let index = 0; index < events.length; index += chunkSize) {
+    const chunk = events.slice(index, index + chunkSize);
+    envelopes.push({
+      kind: 'replay-stream',
+      matchId,
+      events: chunk,
+      done: index + chunkSize >= events.length,
+    });
+  }
+  return envelopes;
+}
+
+export function getReplayEventsAfterSeq(
+  events: readonly IGameEvent[],
+  lastLocalSeq: number,
+): IGameEvent[] {
+  return events
+    .filter((event) => event.sequence > lastLocalSeq)
+    .sort((left, right) => left.sequence - right.sequence);
+}
+
+export function applyReplayStreamEvents(
+  streams: readonly IReplayStreamEnvelope[],
+  appendEvent: (event: IGameEvent) => void,
+): void {
+  const events = streams.flatMap((stream) => stream.events);
+  for (const event of events.sort(
+    (left, right) => left.sequence - right.sequence,
+  )) {
+    appendEvent(event);
+  }
 }
 
 export function isGameIntent(value: unknown): value is IGameIntent {
@@ -288,6 +498,12 @@ function requireLocalPeerId(options: IGameSessionChannelOptions): string {
     throw new Error('No local peer id available');
   }
   return peerId;
+}
+
+function getPersistenceMatchId(
+  options: IGameSessionChannelOptions,
+): string | null {
+  return options.matchId ?? options.getMatchId?.() ?? null;
 }
 
 function insertedValues(event: Y.YArrayEvent<string>): readonly string[] {

--- a/src/lib/p2p/index.ts
+++ b/src/lib/p2p/index.ts
@@ -92,11 +92,15 @@ export {
 
 export {
   GAME_SESSION_EVENTS_ARRAY,
+  applyReplayStreamEvents,
   broadcastEvent,
   broadcastIntent,
   broadcastRejection,
+  createReconnectRequestEnvelope,
   createGameSessionChannel,
+  createReplayStreamEnvelopes,
   deserializeGameSessionEnvelope,
+  getReplayEventsAfterSeq,
   isGameIntent,
   onPeerEvent,
   onPeerIntent,
@@ -104,14 +108,20 @@ export {
   serializeGameSessionEnvelope,
   tryDeserializeGameSessionEnvelope,
   type GameSessionChannelEnvelope,
+  type GameSessionChannelLogger,
   type IGameEventEnvelope,
   type IGameIntentEnvelope,
   type IGameSessionChannel,
   type IGameSessionChannelOptions,
   type IPeerRejectedEnvelope,
+  type IReconnectRequestEnvelope,
+  type IReplayStreamEnvelope,
+  type MatchLogPersistence,
   type PeerEventCallback,
   type PeerIntentCallback,
   type PeerRejectedCallback,
+  type ReconnectRequestCallback,
+  type ReplayStreamCallback,
 } from './gameSessionChannel';
 
 export {

--- a/src/lib/p2p/index.ts
+++ b/src/lib/p2p/index.ts
@@ -140,5 +140,33 @@ export {
   type LobbyStateCallback,
 } from './lobbyChannel';
 
+export {
+  MATCH_LOG_DB_NAME,
+  MATCH_LOG_DB_VERSION,
+  MATCH_LOG_RETENTION_MS,
+  MATCH_LOG_STORES,
+  MatchLogStorage,
+  MatchLogStorageError,
+  MatchLogStorageUnavailableError,
+  appendMatchEvent,
+  flushMatchLogWrites,
+  getEventsForMatch,
+  getLastSequence,
+  getMatchMetadata,
+  markMatchCompleted,
+  matchLogStorage,
+  migrateMatchLogDatabase,
+  purgeOldMatches,
+  upsertMatchMetadata,
+  type IMatchEventRecord,
+  type IMatchLogFlushInfo,
+  type IMatchLogStorageOptions,
+  type IMatchMetadataRecord,
+  type IMatchMetadataUpsert,
+  type IPurgeOldMatchesResult,
+  type MatchLogStatus,
+  type MatchLogStoreName,
+} from './matchLogStorage';
+
 // Hooks
 export { useSyncRoom, type UseSyncRoomReturn } from './useSyncRoom';

--- a/src/lib/p2p/matchLogStorage.ts
+++ b/src/lib/p2p/matchLogStorage.ts
@@ -1,0 +1,677 @@
+/**
+ * Match log storage
+ *
+ * P2P-specific IndexedDB wrapper for locally persisted game event logs.
+ * Kept separate from the generic IndexedDBService so match-log schema
+ * upgrades do not force unrelated app stores through a version bump.
+ *
+ * @spec openspec/changes/add-game-session-persistence-for-reconnect/specs/auto-save-persistence/spec.md
+ * @spec openspec/changes/add-game-session-persistence-for-reconnect/specs/multiplayer-sync/spec.md
+ */
+
+import type { IGameEvent } from '@/types/gameplay/GameSessionInterfaces';
+
+export const MATCH_LOG_DB_NAME = 'mekstation-match-log';
+export const MATCH_LOG_DB_VERSION = 2;
+export const MATCH_LOG_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+export const MATCH_LOG_STORES = {
+  MATCH_EVENTS: 'matchEvents',
+  MATCHES: 'matches',
+} as const;
+
+export type MatchLogStoreName =
+  (typeof MATCH_LOG_STORES)[keyof typeof MATCH_LOG_STORES];
+
+export type MatchLogStatus = 'active' | 'completed' | 'abandoned';
+
+export interface IMatchEventRecord {
+  readonly matchId: string;
+  readonly sequence: number;
+  readonly event: IGameEvent;
+  readonly savedAt: string;
+}
+
+export interface IMatchMetadataRecord {
+  readonly matchId: string;
+  readonly hostPeerId: string | null;
+  readonly guestPeerId: string | null;
+  readonly status: MatchLogStatus;
+  readonly lastActivity: string;
+}
+
+export interface IMatchMetadataUpsert {
+  readonly matchId: string;
+  readonly hostPeerId?: string | null;
+  readonly guestPeerId?: string | null;
+  readonly status?: MatchLogStatus;
+  readonly lastActivity?: string;
+}
+
+export interface IPurgeOldMatchesResult {
+  readonly purgedMatchIds: readonly string[];
+  readonly purgedEventCount: number;
+}
+
+export interface IMatchLogFlushInfo {
+  readonly recordCount: number;
+  readonly matchIds: readonly string[];
+}
+
+export interface IMatchLogStorageOptions {
+  readonly dbName?: string;
+  readonly dbVersion?: number;
+  readonly indexedDB?: IDBFactory;
+  readonly now?: () => string;
+  readonly scheduleFrame?: (callback: () => void) => void;
+  readonly onFlushTransaction?: (info: IMatchLogFlushInfo) => void;
+}
+
+interface IPendingEventWrite {
+  readonly record: IMatchEventRecord;
+  readonly resolve: (record: IMatchEventRecord) => void;
+  readonly reject: (error: Error) => void;
+}
+
+export class MatchLogStorageUnavailableError extends Error {
+  constructor() {
+    super('IndexedDB is unavailable in this environment');
+    this.name = 'MatchLogStorageUnavailableError';
+  }
+}
+
+export class MatchLogStorageError extends Error {
+  readonly originalError?: unknown;
+
+  constructor(message: string, originalError?: unknown) {
+    super(message);
+    this.name = 'MatchLogStorageError';
+    this.originalError = originalError;
+  }
+}
+
+export class MatchLogStorage {
+  private readonly dbName: string;
+  private readonly dbVersion: number;
+  private readonly indexedDBOverride?: IDBFactory;
+  private readonly now: () => string;
+  private readonly scheduleFrame: (callback: () => void) => void;
+  private readonly onFlushTransaction?: (info: IMatchLogFlushInfo) => void;
+
+  private db: IDBDatabase | null = null;
+  private openPromise: Promise<IDBDatabase> | null = null;
+  private pendingEventWrites: IPendingEventWrite[] = [];
+  private flushScheduled = false;
+  private flushPromise: Promise<void> | null = null;
+
+  constructor(options: IMatchLogStorageOptions = {}) {
+    this.dbName = options.dbName ?? MATCH_LOG_DB_NAME;
+    this.dbVersion = options.dbVersion ?? MATCH_LOG_DB_VERSION;
+    this.indexedDBOverride = options.indexedDB;
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.scheduleFrame = options.scheduleFrame ?? scheduleNextFrame;
+    this.onFlushTransaction = options.onFlushTransaction;
+  }
+
+  async initialize(): Promise<void> {
+    await this.openDatabase();
+  }
+
+  close(): void {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+    }
+    this.openPromise = null;
+  }
+
+  appendEvent(matchId: string, event: IGameEvent): Promise<IMatchEventRecord> {
+    const record: IMatchEventRecord = {
+      matchId,
+      sequence: event.sequence,
+      event,
+      savedAt: this.now(),
+    };
+
+    const promise = new Promise<IMatchEventRecord>((resolve, reject) => {
+      this.pendingEventWrites.push({ record, resolve, reject });
+    });
+
+    this.schedulePendingFlush();
+    return promise;
+  }
+
+  async flushPendingWrites(): Promise<void> {
+    if (this.pendingEventWrites.length === 0) {
+      return this.flushPromise ?? Promise.resolve();
+    }
+
+    this.flushScheduled = false;
+    const batch = this.pendingEventWrites.splice(0);
+    const flush = this.persistEventBatch(batch).finally(() => {
+      if (this.flushPromise === flush) {
+        this.flushPromise = null;
+      }
+      if (this.pendingEventWrites.length > 0) {
+        this.schedulePendingFlush();
+      }
+    });
+    this.flushPromise = flush;
+    return flush;
+  }
+
+  async getEventsForMatch(matchId: string): Promise<IGameEvent[]> {
+    const records = await this.getEventRecordsForMatch(matchId);
+    return records.map((record) => record.event);
+  }
+
+  async getEventRecordsForMatch(matchId: string): Promise<IMatchEventRecord[]> {
+    const db = await this.openDatabase();
+
+    return new Promise<IMatchEventRecord[]>((resolve, reject) => {
+      const transaction = db.transaction(
+        MATCH_LOG_STORES.MATCH_EVENTS,
+        'readonly',
+      );
+      const store = transaction.objectStore(MATCH_LOG_STORES.MATCH_EVENTS);
+      const records: IMatchEventRecord[] = [];
+      const request = store.openCursor(matchSequenceRange(matchId));
+
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (!cursor) {
+          return;
+        }
+        records.push(cursor.value as IMatchEventRecord);
+        cursor.continue();
+      };
+
+      transaction.oncomplete = () => {
+        resolve(records);
+      };
+      transaction.onerror = () => {
+        reject(
+          toStorageError('Failed to read match events', transaction.error),
+        );
+      };
+      transaction.onabort = () => {
+        reject(toStorageError('Match events read aborted', transaction.error));
+      };
+    });
+  }
+
+  async getLastSequence(matchId: string): Promise<number | null> {
+    const db = await this.openDatabase();
+
+    return new Promise<number | null>((resolve, reject) => {
+      const transaction = db.transaction(
+        MATCH_LOG_STORES.MATCH_EVENTS,
+        'readonly',
+      );
+      const store = transaction.objectStore(MATCH_LOG_STORES.MATCH_EVENTS);
+      const request = store.openCursor(matchSequenceRange(matchId), 'prev');
+      let lastSequence: number | null = null;
+
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (!cursor) {
+          return;
+        }
+        lastSequence = (cursor.value as IMatchEventRecord).sequence;
+      };
+
+      transaction.oncomplete = () => {
+        resolve(lastSequence);
+      };
+      transaction.onerror = () => {
+        reject(
+          toStorageError(
+            'Failed to read last match sequence',
+            transaction.error,
+          ),
+        );
+      };
+      transaction.onabort = () => {
+        reject(
+          toStorageError('Last match sequence read aborted', transaction.error),
+        );
+      };
+    });
+  }
+
+  async upsertMatchMetadata(
+    metadata: IMatchMetadataUpsert,
+  ): Promise<IMatchMetadataRecord> {
+    const db = await this.openDatabase();
+    const lastActivity = metadata.lastActivity ?? this.now();
+
+    return new Promise<IMatchMetadataRecord>((resolve, reject) => {
+      const transaction = db.transaction(MATCH_LOG_STORES.MATCHES, 'readwrite');
+      const store = transaction.objectStore(MATCH_LOG_STORES.MATCHES);
+      const request = store.get(metadata.matchId);
+      let saved: IMatchMetadataRecord | null = null;
+
+      request.onsuccess = () => {
+        const existing = request.result as IMatchMetadataRecord | undefined;
+        saved = mergeMatchMetadata(existing, metadata, lastActivity);
+        store.put(saved);
+      };
+
+      transaction.oncomplete = () => {
+        if (!saved) {
+          reject(new MatchLogStorageError('Match metadata was not saved'));
+          return;
+        }
+        resolve(saved);
+      };
+      transaction.onerror = () => {
+        reject(
+          toStorageError('Failed to upsert match metadata', transaction.error),
+        );
+      };
+      transaction.onabort = () => {
+        reject(
+          toStorageError('Match metadata upsert aborted', transaction.error),
+        );
+      };
+    });
+  }
+
+  async getMatchMetadata(
+    matchId: string,
+  ): Promise<IMatchMetadataRecord | undefined> {
+    const db = await this.openDatabase();
+    const result = await requestToPromise(
+      db
+        .transaction(MATCH_LOG_STORES.MATCHES, 'readonly')
+        .objectStore(MATCH_LOG_STORES.MATCHES)
+        .get(matchId),
+      'Failed to read match metadata',
+    );
+    return result as IMatchMetadataRecord | undefined;
+  }
+
+  async markMatchCompleted(
+    matchId: string,
+    completedAt = this.now(),
+  ): Promise<IMatchMetadataRecord> {
+    return this.upsertMatchMetadata({
+      matchId,
+      status: 'completed',
+      lastActivity: completedAt,
+    });
+  }
+
+  async purgeOldMatches(
+    retentionMs = MATCH_LOG_RETENTION_MS,
+  ): Promise<IPurgeOldMatchesResult> {
+    const db = await this.openDatabase();
+    const nowMs = Date.parse(this.now());
+    const cutoff = (Number.isFinite(nowMs) ? nowMs : Date.now()) - retentionMs;
+
+    return new Promise<IPurgeOldMatchesResult>((resolve, reject) => {
+      const transaction = db.transaction(
+        [MATCH_LOG_STORES.MATCHES, MATCH_LOG_STORES.MATCH_EVENTS],
+        'readwrite',
+      );
+      const matchesStore = transaction.objectStore(MATCH_LOG_STORES.MATCHES);
+      const eventsStore = transaction.objectStore(
+        MATCH_LOG_STORES.MATCH_EVENTS,
+      );
+      const purgedMatchIds: string[] = [];
+      let purgedEventCount = 0;
+
+      const cursorRequest = matchesStore.openCursor();
+      cursorRequest.onsuccess = () => {
+        const cursor = cursorRequest.result;
+        if (!cursor) {
+          return;
+        }
+
+        const metadata = cursor.value as IMatchMetadataRecord;
+        if (shouldPurgeMatch(metadata, cutoff)) {
+          const range = matchSequenceRange(metadata.matchId);
+          purgedMatchIds.push(metadata.matchId);
+
+          const countRequest = eventsStore.count(range);
+          countRequest.onsuccess = () => {
+            purgedEventCount += countRequest.result;
+            eventsStore.delete(range);
+          };
+
+          cursor.delete();
+        }
+
+        cursor.continue();
+      };
+
+      transaction.oncomplete = () => {
+        resolve({ purgedMatchIds, purgedEventCount });
+      };
+      transaction.onerror = () => {
+        reject(
+          toStorageError('Failed to purge old matches', transaction.error),
+        );
+      };
+      transaction.onabort = () => {
+        reject(toStorageError('Old match purge aborted', transaction.error));
+      };
+    });
+  }
+
+  private async persistEventBatch(batch: IPendingEventWrite[]): Promise<void> {
+    try {
+      const db = await this.openDatabase();
+      await persistBatchInTransaction(db, batch, this.onFlushTransaction);
+      for (const write of batch) {
+        write.resolve(write.record);
+      }
+    } catch (error) {
+      const storageError = toStorageError(
+        'Failed to persist match events',
+        error,
+      );
+      for (const write of batch) {
+        write.reject(storageError);
+      }
+      throw storageError;
+    }
+  }
+
+  private schedulePendingFlush(): void {
+    if (this.flushScheduled) {
+      return;
+    }
+
+    this.flushScheduled = true;
+    this.scheduleFrame(() => {
+      void this.flushPendingWrites().catch(() => undefined);
+    });
+  }
+
+  private async openDatabase(): Promise<IDBDatabase> {
+    if (this.db) {
+      return this.db;
+    }
+    if (this.openPromise) {
+      return this.openPromise;
+    }
+
+    const indexedDBFactory = this.getIndexedDBFactory();
+    if (!indexedDBFactory) {
+      return Promise.reject(new MatchLogStorageUnavailableError());
+    }
+
+    this.openPromise = new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDBFactory.open(this.dbName, this.dbVersion);
+
+      request.onupgradeneeded = () => {
+        migrateMatchLogDatabase(request.result, request.transaction);
+      };
+
+      request.onsuccess = () => {
+        this.db = request.result;
+        this.db.onversionchange = () => {
+          this.close();
+        };
+        resolve(this.db);
+      };
+
+      request.onerror = () => {
+        this.openPromise = null;
+        reject(
+          toStorageError('Failed to open match log database', request.error),
+        );
+      };
+
+      request.onblocked = () => {
+        reject(new MatchLogStorageError('Match log database upgrade blocked'));
+      };
+    });
+
+    return this.openPromise;
+  }
+
+  private getIndexedDBFactory(): IDBFactory | null {
+    if (this.indexedDBOverride) {
+      return this.indexedDBOverride;
+    }
+    if (typeof globalThis === 'undefined') {
+      return null;
+    }
+    return globalThis.indexedDB ?? null;
+  }
+}
+
+export function migrateMatchLogDatabase(
+  db: IDBDatabase,
+  transaction: IDBTransaction | null,
+): void {
+  const eventStore = ensureObjectStore(
+    db,
+    transaction,
+    MATCH_LOG_STORES.MATCH_EVENTS,
+    {
+      keyPath: ['matchId', 'sequence'],
+    },
+  );
+  ensureIndex(eventStore, 'byMatchId', 'matchId');
+  ensureIndex(eventStore, 'bySavedAt', 'savedAt');
+
+  const matchStore = ensureObjectStore(
+    db,
+    transaction,
+    MATCH_LOG_STORES.MATCHES,
+    {
+      keyPath: 'matchId',
+    },
+  );
+  ensureIndex(matchStore, 'byStatus', 'status');
+  ensureIndex(matchStore, 'byLastActivity', 'lastActivity');
+}
+
+const defaultMatchLogStorage = new MatchLogStorage();
+
+export const matchLogStorage = defaultMatchLogStorage;
+
+export function appendMatchEvent(
+  matchId: string,
+  event: IGameEvent,
+): Promise<IMatchEventRecord> {
+  return defaultMatchLogStorage.appendEvent(matchId, event);
+}
+
+export function flushMatchLogWrites(): Promise<void> {
+  return defaultMatchLogStorage.flushPendingWrites();
+}
+
+export function getEventsForMatch(matchId: string): Promise<IGameEvent[]> {
+  return defaultMatchLogStorage.getEventsForMatch(matchId);
+}
+
+export function getLastSequence(matchId: string): Promise<number | null> {
+  return defaultMatchLogStorage.getLastSequence(matchId);
+}
+
+export function upsertMatchMetadata(
+  metadata: IMatchMetadataUpsert,
+): Promise<IMatchMetadataRecord> {
+  return defaultMatchLogStorage.upsertMatchMetadata(metadata);
+}
+
+export function getMatchMetadata(
+  matchId: string,
+): Promise<IMatchMetadataRecord | undefined> {
+  return defaultMatchLogStorage.getMatchMetadata(matchId);
+}
+
+export function markMatchCompleted(
+  matchId: string,
+  completedAt?: string,
+): Promise<IMatchMetadataRecord> {
+  return defaultMatchLogStorage.markMatchCompleted(matchId, completedAt);
+}
+
+export function purgeOldMatches(
+  retentionMs?: number,
+): Promise<IPurgeOldMatchesResult> {
+  return defaultMatchLogStorage.purgeOldMatches(retentionMs);
+}
+
+function persistBatchInTransaction(
+  db: IDBDatabase,
+  batch: readonly IPendingEventWrite[],
+  onFlushTransaction?: (info: IMatchLogFlushInfo) => void,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(
+      [MATCH_LOG_STORES.MATCH_EVENTS, MATCH_LOG_STORES.MATCHES],
+      'readwrite',
+    );
+    const eventStore = transaction.objectStore(MATCH_LOG_STORES.MATCH_EVENTS);
+    const matchStore = transaction.objectStore(MATCH_LOG_STORES.MATCHES);
+    const latestSavedAtByMatch = new Map<string, string>();
+
+    for (const write of batch) {
+      eventStore.put(write.record);
+      const current = latestSavedAtByMatch.get(write.record.matchId);
+      if (!current || write.record.savedAt > current) {
+        latestSavedAtByMatch.set(write.record.matchId, write.record.savedAt);
+      }
+    }
+
+    for (const [matchId, lastActivity] of Array.from(
+      latestSavedAtByMatch.entries(),
+    )) {
+      const request = matchStore.get(matchId);
+      request.onsuccess = () => {
+        const existing = request.result as IMatchMetadataRecord | undefined;
+        matchStore.put(
+          mergeMatchMetadata(
+            existing,
+            {
+              matchId,
+            },
+            lastActivity,
+          ),
+        );
+      };
+    }
+
+    onFlushTransaction?.({
+      recordCount: batch.length,
+      matchIds: Array.from(latestSavedAtByMatch.keys()),
+    });
+
+    transaction.oncomplete = () => {
+      resolve();
+    };
+    transaction.onerror = () => {
+      reject(
+        toStorageError('Match event transaction failed', transaction.error),
+      );
+    };
+    transaction.onabort = () => {
+      reject(
+        toStorageError('Match event transaction aborted', transaction.error),
+      );
+    };
+  });
+}
+
+function ensureObjectStore(
+  db: IDBDatabase,
+  transaction: IDBTransaction | null,
+  storeName: MatchLogStoreName,
+  options: IDBObjectStoreParameters,
+): IDBObjectStore {
+  if (!db.objectStoreNames.contains(storeName)) {
+    return db.createObjectStore(storeName, options);
+  }
+  if (!transaction) {
+    throw new MatchLogStorageError(
+      `Cannot migrate existing object store without an upgrade transaction: ${storeName}`,
+    );
+  }
+  return transaction.objectStore(storeName);
+}
+
+function ensureIndex(
+  store: IDBObjectStore,
+  indexName: string,
+  keyPath: string,
+): void {
+  if (!store.indexNames.contains(indexName)) {
+    store.createIndex(indexName, keyPath);
+  }
+}
+
+function mergeMatchMetadata(
+  existing: IMatchMetadataRecord | undefined,
+  patch: IMatchMetadataUpsert,
+  lastActivity: string,
+): IMatchMetadataRecord {
+  return {
+    matchId: patch.matchId,
+    hostPeerId:
+      patch.hostPeerId === undefined
+        ? (existing?.hostPeerId ?? null)
+        : patch.hostPeerId,
+    guestPeerId:
+      patch.guestPeerId === undefined
+        ? (existing?.guestPeerId ?? null)
+        : patch.guestPeerId,
+    status: patch.status ?? existing?.status ?? 'active',
+    lastActivity,
+  };
+}
+
+function matchSequenceRange(matchId: string): IDBKeyRange {
+  return IDBKeyRange.bound(
+    [matchId, Number.NEGATIVE_INFINITY],
+    [matchId, Number.POSITIVE_INFINITY],
+  );
+}
+
+function shouldPurgeMatch(
+  metadata: IMatchMetadataRecord,
+  cutoff: number,
+): boolean {
+  if (metadata.status !== 'completed') {
+    return false;
+  }
+  const lastActivityMs = Date.parse(metadata.lastActivity);
+  return Number.isFinite(lastActivityMs) && lastActivityMs < cutoff;
+}
+
+function requestToPromise<T>(
+  request: IDBRequest<T>,
+  errorMessage: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+    request.onerror = () => {
+      reject(toStorageError(errorMessage, request.error));
+    };
+  });
+}
+
+function scheduleNextFrame(callback: () => void): void {
+  if (typeof globalThis.requestAnimationFrame === 'function') {
+    globalThis.requestAnimationFrame(() => callback());
+    return;
+  }
+  globalThis.setTimeout(callback, 0);
+}
+
+function toStorageError(message: string, cause: unknown): Error {
+  if (cause instanceof MatchLogStorageUnavailableError) {
+    return cause;
+  }
+  if (cause instanceof MatchLogStorageError) {
+    return cause;
+  }
+  return new MatchLogStorageError(message, cause);
+}

--- a/src/pages/api/multiplayer/matches/index.ts
+++ b/src/pages/api/multiplayer/matches/index.ts
@@ -112,6 +112,9 @@ function isValidBody(body: unknown): body is ICreateMatchBody {
   if (typeof cfg.mapRadius !== 'number' || typeof cfg.turnLimit !== 'number') {
     return false;
   }
+  if (cfg.fogOfWar !== undefined && typeof cfg.fogOfWar !== 'boolean') {
+    return false;
+  }
   if (
     b.displayName !== undefined &&
     (typeof b.displayName !== 'string' || b.displayName.length === 0)
@@ -219,6 +222,10 @@ export default async function handler(
 
   const matchId = randomUUID();
   const now = new Date().toISOString();
+  const config: IMatchConfig = {
+    ...body.config,
+    fogOfWar: body.config.fogOfWar ?? false,
+  };
   const meta: IMatchMeta = {
     matchId,
     hostPlayerId,
@@ -232,7 +239,7 @@ export default async function handler(
     status: 'lobby',
     createdAt: now,
     updatedAt: now,
-    config: body.config,
+    config,
     layout: body.layout,
     seats,
     roomCode,

--- a/src/pages/multiplayer/index.tsx
+++ b/src/pages/multiplayer/index.tsx
@@ -134,11 +134,13 @@ export default function MultiplayerHubPage(): React.ReactElement {
     displayName: string;
     mapRadius: number;
     turnLimit: number;
+    fogOfWar: boolean;
   }): Promise<void> {
     await withAuth('create', async (auth) => {
       const config: IMatchConfig = {
         mapRadius: value.mapRadius,
         turnLimit: value.turnLimit,
+        fogOfWar: value.fogOfWar,
       };
       const res = await fetch('/api/multiplayer/matches', {
         method: 'POST',

--- a/src/stores/__tests__/useGameplayStore.localMatchStatus.test.ts
+++ b/src/stores/__tests__/useGameplayStore.localMatchStatus.test.ts
@@ -1,0 +1,137 @@
+import {
+  selectLocalMatchGraceRemainingMs,
+  selectLocalMatchStatus,
+  useGameplayStore,
+} from '@/stores/useGameplayStore';
+import {
+  GamePhase,
+  GameStatus,
+  type IGameEvent,
+  type IGameSession,
+} from '@/types/gameplay';
+import { RECONNECT_GRACE_MS } from '@/types/multiplayer/Protocol';
+
+function buildSessionWithEvents(events: readonly IGameEvent[]): IGameSession {
+  return {
+    id: 'local-status-session',
+    createdAt: '2026-04-29T00:00:00.000Z',
+    updatedAt: '2026-04-29T00:00:00.000Z',
+    config: {
+      mapRadius: 5,
+      turnLimit: 0,
+      victoryConditions: [],
+      optionalRules: [],
+    },
+    units: [],
+    events,
+    currentState: {
+      gameId: 'local-status-session',
+      status: GameStatus.Active,
+      turn: 1,
+      phase: GamePhase.Movement,
+      activationIndex: 0,
+      units: {},
+      turnEvents: [],
+    },
+  };
+}
+
+describe('useGameplayStore local reconnect match status', () => {
+  beforeEach(() => {
+    useGameplayStore.getState().reset();
+  });
+
+  afterEach(() => {
+    useGameplayStore.getState().reset();
+  });
+
+  it('defaults to live with the protocol reconnect grace window', () => {
+    const state = useGameplayStore.getState();
+
+    expect(state.localMatchStatus).toBe('live');
+    expect(state.localMatchGraceDeadlineMs).toBeNull();
+    expect(state.localMatchGraceRemainingMs).toBeNull();
+    expect(state.reconnectGraceMs).toBe(RECONNECT_GRACE_MS);
+  });
+
+  it('sets guest pending with the default grace deadline and remaining time', () => {
+    useGameplayStore
+      .getState()
+      .setLocalMatchStatus('guestPending', { nowMs: 1_000 });
+
+    const state = useGameplayStore.getState();
+    expect(selectLocalMatchStatus(state)).toBe('guestPending');
+    expect(state.localMatchGraceDeadlineMs).toBe(1_000 + RECONNECT_GRACE_MS);
+    expect(selectLocalMatchGraceRemainingMs(state)).toBe(RECONNECT_GRACE_MS);
+    expect(state.reconnectGraceMs).toBe(RECONNECT_GRACE_MS);
+  });
+
+  it('supports a per-match grace override for host pending', () => {
+    useGameplayStore.getState().setLocalMatchStatus('hostPending', {
+      graceMs: 15_000,
+      nowMs: 5_000,
+    });
+
+    const state = useGameplayStore.getState();
+    expect(state.localMatchStatus).toBe('hostPending');
+    expect(state.localMatchGraceDeadlineMs).toBe(20_000);
+    expect(state.localMatchGraceRemainingMs).toBe(15_000);
+    expect(state.reconnectGraceMs).toBe(15_000);
+  });
+
+  it('updates deadline or remaining countdown state for UI consumers', () => {
+    const store = useGameplayStore.getState();
+
+    store.setLocalMatchGraceDeadline(11_000, 1_000);
+    expect(useGameplayStore.getState().localMatchGraceRemainingMs).toBe(10_000);
+
+    store.setLocalMatchGraceRemaining(3_500, 2_000);
+    expect(useGameplayStore.getState().localMatchGraceDeadlineMs).toBe(5_500);
+    expect(useGameplayStore.getState().localMatchGraceRemainingMs).toBe(3_500);
+
+    store.setLocalMatchGraceDeadline(1_000, 2_000);
+    expect(useGameplayStore.getState().localMatchGraceRemainingMs).toBe(0);
+  });
+
+  it('returns to live and clears pending grace state without appending events', () => {
+    const events: readonly IGameEvent[] = [];
+    const session = buildSessionWithEvents(events);
+    useGameplayStore.getState().setSession(session);
+
+    useGameplayStore
+      .getState()
+      .setLocalMatchStatus('guestPending', { nowMs: 1_000 });
+    expect(useGameplayStore.getState().session?.events).toBe(events);
+    expect(useGameplayStore.getState().session?.events).toHaveLength(0);
+    expect(useGameplayStore.getState().session?.currentState.status).toBe(
+      GameStatus.Active,
+    );
+
+    useGameplayStore.getState().setLocalMatchStatus('live');
+    const state = useGameplayStore.getState();
+    expect(state.localMatchStatus).toBe('live');
+    expect(state.localMatchGraceDeadlineMs).toBeNull();
+    expect(state.localMatchGraceRemainingMs).toBeNull();
+    expect(state.session?.events).toBe(events);
+    expect(state.session?.events).toHaveLength(0);
+    expect(state.session?.currentState.status).toBe(GameStatus.Active);
+  });
+
+  it('can mark the local match aborted without mutating the session log', () => {
+    const events: readonly IGameEvent[] = [];
+    const session = buildSessionWithEvents(events);
+    useGameplayStore.getState().setSession(session);
+
+    useGameplayStore
+      .getState()
+      .setLocalMatchStatus('aborted', { nowMs: 9_000 });
+
+    const state = useGameplayStore.getState();
+    expect(state.localMatchStatus).toBe('aborted');
+    expect(state.localMatchGraceDeadlineMs).toBe(9_000);
+    expect(state.localMatchGraceRemainingMs).toBe(0);
+    expect(state.session?.events).toBe(events);
+    expect(state.session?.events).toHaveLength(0);
+    expect(state.session?.currentState.status).toBe(GameStatus.Active);
+  });
+});

--- a/src/stores/useGameplayStore.selectors.ts
+++ b/src/stores/useGameplayStore.selectors.ts
@@ -42,6 +42,15 @@ export const selectIsGameCompleted = (state: {
   session: IGameSession | null;
 }): boolean => state.session?.currentState.status === GameStatus.Completed;
 
+export const selectLocalMatchStatus = (state: {
+  localMatchStatus: 'live' | 'guestPending' | 'hostPending' | 'aborted';
+}): 'live' | 'guestPending' | 'hostPending' | 'aborted' =>
+  state.localMatchStatus;
+
+export const selectLocalMatchGraceRemainingMs = (state: {
+  localMatchGraceRemainingMs: number | null;
+}): number | null => state.localMatchGraceRemainingMs;
+
 /**
  * Project the currently-selected unit (or `null`) from the relevant
  * store fields. Pure helper so the hook wrapper can compose the three

--- a/src/stores/useGameplayStore.ts
+++ b/src/stores/useGameplayStore.ts
@@ -30,6 +30,7 @@ import {
   IPilotSpaSummary,
   IWeaponStatus,
 } from '@/types/gameplay';
+import { RECONNECT_GRACE_MS } from '@/types/multiplayer/Protocol';
 import { logger } from '@/utils/logger';
 
 import {
@@ -67,6 +68,8 @@ import {
 import {
   projectSelectedUnit,
   selectIsGameCompleted,
+  selectLocalMatchGraceRemainingMs,
+  selectLocalMatchStatus,
   type ISelectedUnitProjection,
 } from './useGameplayStore.selectors';
 import {
@@ -78,6 +81,7 @@ import {
 } from './useGameplayStore.session';
 
 export { InteractivePhase, selectIsGameCompleted };
+export { selectLocalMatchGraceRemainingMs, selectLocalMatchStatus };
 export type {
   IAttackPlan,
   IPlannedMovement,
@@ -89,9 +93,19 @@ export type {
 // Types
 // =============================================================================
 
+export type LocalMatchStatus =
+  | 'live'
+  | 'guestPending'
+  | 'hostPending'
+  | 'aborted';
+
 interface GameplayState {
   session: IGameSession | null;
   interactiveSession: InteractiveSession | null;
+  localMatchStatus: LocalMatchStatus;
+  localMatchGraceDeadlineMs: number | null;
+  localMatchGraceRemainingMs: number | null;
+  reconnectGraceMs: number;
   interactivePhase: InteractivePhase;
   spectatorMode: SpectatorMode | null;
   validMovementHexes: readonly { q: number; r: number }[];
@@ -146,6 +160,19 @@ interface GameplayActions {
   setSpectatorMode: (
     interactiveSession: InteractiveSession,
     spectatorMode: SpectatorMode,
+  ) => void;
+  setLocalMatchStatus: (
+    status: LocalMatchStatus,
+    options?: { graceMs?: number; nowMs?: number },
+  ) => void;
+  resetLocalMatchStatus: () => void;
+  setLocalMatchGraceDeadline: (
+    deadlineMs: number | null,
+    nowMs?: number,
+  ) => void;
+  setLocalMatchGraceRemaining: (
+    remainingMs: number | null,
+    nowMs?: number,
   ) => void;
   selectUnit: (unitId: string | null) => void;
   setTarget: (unitId: string | null) => void;
@@ -214,6 +241,10 @@ type GameplayStore = GameplayState & GameplayActions;
 const initialState: GameplayState = {
   session: null,
   interactiveSession: null,
+  localMatchStatus: 'live',
+  localMatchGraceDeadlineMs: null,
+  localMatchGraceRemainingMs: null,
+  reconnectGraceMs: RECONNECT_GRACE_MS,
   interactivePhase: InteractivePhase.None,
   spectatorMode: null,
   validMovementHexes: [],
@@ -253,6 +284,58 @@ export const useGameplayStore = create<GameplayStore>((set, get) => ({
     setInteractiveSessionLogic(interactiveSession, set),
   setSpectatorMode: (interactiveSession, spectatorMode) =>
     setSpectatorModeLogic(interactiveSession, spectatorMode, set),
+  setLocalMatchStatus: (status, options) => {
+    if (status === 'live') {
+      set({
+        localMatchStatus: 'live',
+        localMatchGraceDeadlineMs: null,
+        localMatchGraceRemainingMs: null,
+      });
+      return;
+    }
+
+    const nowMs = options?.nowMs ?? Date.now();
+    if (status === 'aborted') {
+      set({
+        localMatchStatus: 'aborted',
+        localMatchGraceDeadlineMs: nowMs,
+        localMatchGraceRemainingMs: 0,
+      });
+      return;
+    }
+
+    const graceMs = options?.graceMs ?? get().reconnectGraceMs;
+    const deadlineMs = nowMs + graceMs;
+    set({
+      localMatchStatus: status,
+      reconnectGraceMs: graceMs,
+      localMatchGraceDeadlineMs: deadlineMs,
+      localMatchGraceRemainingMs: graceMs,
+    });
+  },
+  resetLocalMatchStatus: () => {
+    set({
+      localMatchStatus: 'live',
+      localMatchGraceDeadlineMs: null,
+      localMatchGraceRemainingMs: null,
+      reconnectGraceMs: RECONNECT_GRACE_MS,
+    });
+  },
+  setLocalMatchGraceDeadline: (deadlineMs, nowMs = Date.now()) => {
+    set({
+      localMatchGraceDeadlineMs: deadlineMs,
+      localMatchGraceRemainingMs:
+        deadlineMs === null ? null : Math.max(0, deadlineMs - nowMs),
+    });
+  },
+  setLocalMatchGraceRemaining: (remainingMs, nowMs = Date.now()) => {
+    set({
+      localMatchGraceDeadlineMs:
+        remainingMs === null ? null : nowMs + Math.max(0, remainingMs),
+      localMatchGraceRemainingMs:
+        remainingMs === null ? null : Math.max(0, remainingMs),
+    });
+  },
   clearError: () => {
     set({ error: null });
   },

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -1403,6 +1403,8 @@ export interface IGameState {
 export interface IGameSession {
   /** Session ID */
   readonly id: string;
+  /** Stable match ID used by multiplayer persistence/reconnect. */
+  readonly matchId?: string;
   /** Creation timestamp */
   readonly createdAt: string;
   /** Last update timestamp */

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -569,6 +569,20 @@ export interface IAttackResolvedPayload {
 }
 
 /**
+ * Fog-of-war redacted attack resolution. Sent to the target owner when the
+ * attacker is hidden; weapon and attacker identifiers are intentionally absent.
+ */
+export interface IRedactedAttackResolvedPayload {
+  readonly targetId: string;
+  readonly roll: number;
+  readonly toHitNumber: number;
+  readonly hit: boolean;
+  readonly location?: string;
+  readonly damage?: number;
+  readonly rolls?: readonly number[];
+}
+
+/**
  * Attack-invalid event payload — emitted when an attack attempt is
  * rejected BEFORE any damage, heat, or `AttackResolved` event fires.
  * Reasons are future-extensible; initial users are `wire-ammo-consumption`
@@ -733,6 +747,14 @@ export interface IUnitDestroyedPayload {
   readonly cause: 'damage' | 'ammo_explosion' | 'pilot_death' | 'shutdown';
   /** Unit that killed this unit (undefined for self-destruction: ammo explosions, pilot death, etc.) */
   readonly killerUnitId?: string;
+}
+
+/**
+ * Fog-of-war redacted destruction notice. Sent when a hidden enemy is destroyed
+ * without leaking cause, damage, crit, pilot, or killer detail.
+ */
+export interface IRedactedUnitDestroyedPayload {
+  readonly unitId: string;
 }
 
 /**
@@ -1061,11 +1083,13 @@ export type GameEventPayload =
   | IAttackDeclaredPayload
   | IAttackLockedPayload
   | IAttackResolvedPayload
+  | IRedactedAttackResolvedPayload
   | IDamageAppliedPayload
   | IHeatPayload
   | IPilotHitPayload
   | IAmmoExplosionPayload
   | IUnitDestroyedPayload
+  | IRedactedUnitDestroyedPayload
   | ICriticalHitResolvedPayload
   | IPSRTriggeredPayload
   | IPSRResolvedPayload

--- a/src/types/multiplayer/Protocol.ts
+++ b/src/types/multiplayer/Protocol.ts
@@ -483,17 +483,17 @@ export const RECONNECT_MULTIPLIER = 2;
  * the host gets the SeatTimedOut prompt. Configurable per-match in a
  * follow-up; for now this is the constant the server uses.
  *
- * 120s = 2x the heartbeat dead-connection window; long enough for a
- * mobile-data hop or a wifi roam, short enough that a hung match
- * doesn't waste the other players' evening.
+ * 60s = the reconnect-persistence OpenSpec default; long enough for a
+ * browser refresh or wifi roam, short enough that a hung match doesn't
+ * waste the other players' evening.
  */
-export const RECONNECT_GRACE_MS = 120_000;
+export const RECONNECT_GRACE_MS = 60_000;
 
 /**
  * Wave 4 — replay chunk size. Long matches can accrue thousands of
  * events; chunking the replay payload avoids one huge socket frame.
  */
-export const REPLAY_CHUNK_SIZE = 50;
+export const REPLAY_CHUNK_SIZE = 64;
 
 // =============================================================================
 // Helper builders

--- a/src/utils/gameplay/__tests__/visibility.test.ts
+++ b/src/utils/gameplay/__tests__/visibility.test.ts
@@ -1,0 +1,197 @@
+import {
+  Facing,
+  MovementType,
+  type IHex,
+  type IHexCoordinate,
+  type IHexGrid,
+} from '@/types/gameplay';
+import {
+  GamePhase,
+  GameSide,
+  GameStatus,
+  LockState,
+  type IGameState,
+  type IUnitGameState,
+} from '@/types/gameplay/GameSessionInterfaces';
+import { TerrainType } from '@/types/gameplay/TerrainTypes';
+import { coordToKey } from '@/utils/gameplay/hexMath';
+import {
+  canPlayerSeeUnit,
+  visibleUnitsForPlayer,
+} from '@/utils/gameplay/visibility';
+
+type VisibilityTestState = IGameState & {
+  readonly grid: IHexGrid;
+  readonly sideOwners: Partial<Record<GameSide, string>>;
+};
+
+type VisibilityTestUnit = IUnitGameState & {
+  readonly sensorRange?: number;
+};
+
+const PLAYER_ID = 'pid_a';
+const OPPONENT_ID = 'pid_b';
+
+function makeUnit(
+  id: string,
+  side: GameSide,
+  position: IHexCoordinate,
+  overrides: Partial<VisibilityTestUnit> = {},
+): VisibilityTestUnit {
+  return {
+    id,
+    side,
+    position,
+    facing: Facing.North,
+    heat: 0,
+    movementThisTurn: MovementType.Stationary,
+    hexesMovedThisTurn: 0,
+    armor: {},
+    structure: {},
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {},
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+    ...overrides,
+  };
+}
+
+function makeHex(
+  q: number,
+  r: number,
+  terrain: string = TerrainType.Clear,
+  elevation: number = 0,
+): IHex {
+  return {
+    coord: { q, r },
+    occupantId: null,
+    terrain,
+    elevation,
+  };
+}
+
+function makeGrid(hexes: readonly IHex[]): IHexGrid {
+  const hexMap = new Map<string, IHex>();
+
+  for (const hex of hexes) {
+    hexMap.set(coordToKey(hex.coord), hex);
+  }
+
+  return {
+    config: { radius: 12 },
+    hexes: hexMap,
+  };
+}
+
+function makeClearLineGrid(qMin: number, qMax: number): IHexGrid {
+  const hexes: IHex[] = [];
+
+  for (let q = qMin; q <= qMax; q++) {
+    hexes.push(makeHex(q, 0));
+  }
+
+  return makeGrid(hexes);
+}
+
+function makeState(
+  units: readonly VisibilityTestUnit[],
+  grid: IHexGrid = makeClearLineGrid(0, 12),
+): VisibilityTestState {
+  const unitMap: Record<string, IUnitGameState> = {};
+
+  for (const unit of units) {
+    unitMap[unit.id] = unit;
+  }
+
+  return {
+    gameId: 'game-visibility',
+    status: GameStatus.Active,
+    turn: 1,
+    phase: GamePhase.Movement,
+    activationIndex: 0,
+    units: unitMap,
+    turnEvents: [],
+    grid,
+    sideOwners: {
+      [GameSide.Player]: PLAYER_ID,
+      [GameSide.Opponent]: OPPONENT_ID,
+    },
+  };
+}
+
+describe('fog-of-war unit visibility helpers', () => {
+  it('returns true for adjacent enemy units with clear LOS', () => {
+    const state = makeState([
+      makeUnit('player-scout', GameSide.Player, { q: 0, r: 0 }),
+      makeUnit('enemy-adjacent', GameSide.Opponent, { q: 1, r: 0 }),
+    ]);
+
+    expect(canPlayerSeeUnit(PLAYER_ID, 'enemy-adjacent', state)).toBe(true);
+  });
+
+  it('returns false when blocking terrain interrupts LOS', () => {
+    const grid = makeGrid([
+      makeHex(0, 0),
+      makeHex(1, 0, TerrainType.HeavyWoods),
+      makeHex(2, 0),
+      makeHex(3, 0),
+    ]);
+    const state = makeState(
+      [
+        makeUnit('player-scout', GameSide.Player, { q: 0, r: 0 }),
+        makeUnit('enemy-hidden', GameSide.Opponent, { q: 3, r: 0 }),
+      ],
+      grid,
+    );
+
+    expect(canPlayerSeeUnit(PLAYER_ID, 'enemy-hidden', state)).toBe(false);
+  });
+
+  it('honors the default sensor range boundary', () => {
+    const state = makeState([
+      makeUnit('player-scout', GameSide.Player, { q: 0, r: 0 }),
+      makeUnit('enemy-at-boundary', GameSide.Opponent, { q: 10, r: 0 }),
+      makeUnit('enemy-beyond-boundary', GameSide.Opponent, { q: 11, r: 0 }),
+    ]);
+
+    expect(canPlayerSeeUnit(PLAYER_ID, 'enemy-at-boundary', state)).toBe(true);
+    expect(canPlayerSeeUnit(PLAYER_ID, 'enemy-beyond-boundary', state)).toBe(
+      false,
+    );
+  });
+
+  it('always returns true for own units regardless of combat state', () => {
+    const state = makeState([
+      makeUnit(
+        'own-disabled',
+        GameSide.Player,
+        { q: 11, r: 0 },
+        {
+          destroyed: true,
+          prone: true,
+          shutdown: true,
+        },
+      ),
+    ]);
+
+    expect(canPlayerSeeUnit(PLAYER_ID, 'own-disabled', state)).toBe(true);
+  });
+
+  it('returns sorted unique aggregate visible unit ids', () => {
+    const state = makeState([
+      makeUnit('zeta-own', GameSide.Player, { q: 0, r: 0 }),
+      makeUnit('alpha-own', GameSide.Player, { q: 0, r: 1 }),
+      makeUnit('beta-enemy', GameSide.Opponent, { q: 1, r: 0 }),
+      makeUnit('omega-hidden', GameSide.Opponent, { q: 11, r: 0 }),
+    ]);
+
+    expect(visibleUnitsForPlayer(PLAYER_ID, state)).toEqual([
+      'alpha-own',
+      'beta-enemy',
+      'zeta-own',
+    ]);
+  });
+});

--- a/src/utils/gameplay/gameSession.ts
+++ b/src/utils/gameplay/gameSession.ts
@@ -1,5 +1,6 @@
 export {
   createGameSession,
+  hydrateGameSessionFromEvents,
   startGame,
   endGame,
   appendEvent,

--- a/src/utils/gameplay/gameSessionCore.ts
+++ b/src/utils/gameplay/gameSessionCore.ts
@@ -2,10 +2,12 @@ import { v4 as uuidv4 } from 'uuid';
 
 import {
   Facing,
+  GameEventType,
   GamePhase,
   GameSide,
   GameStatus,
   IGameConfig,
+  IGameCreatedPayload,
   IGameEvent,
   IGameSession,
   IGameUnit,
@@ -86,6 +88,7 @@ export function createGameSession(
 
   return {
     id,
+    matchId: id,
     createdAt: now,
     updatedAt: now,
     config,
@@ -95,6 +98,35 @@ export function createGameSession(
     hostPeerId: options.hostPeerId,
     guestPeerId: options.guestPeerId,
     sideOwners: options.sideOwners,
+  };
+}
+
+export function hydrateGameSessionFromEvents(
+  matchId: string,
+  events: readonly IGameEvent[],
+): IGameSession {
+  if (events.length === 0) {
+    throw new Error('Match log not found');
+  }
+
+  const orderedEvents = [...events].sort((a, b) => a.sequence - b.sequence);
+  const createdEvent = orderedEvents[0];
+  if (createdEvent.type !== GameEventType.GameCreated) {
+    throw new Error('Match log not found');
+  }
+
+  const payload = createdEvent.payload as IGameCreatedPayload;
+  const lastEvent = orderedEvents[orderedEvents.length - 1];
+
+  return {
+    id: matchId,
+    matchId,
+    createdAt: createdEvent.timestamp,
+    updatedAt: lastEvent.timestamp,
+    config: payload.config,
+    units: payload.units,
+    events: orderedEvents,
+    currentState: deriveState(matchId, orderedEvents),
   };
 }
 

--- a/src/utils/gameplay/index.ts
+++ b/src/utils/gameplay/index.ts
@@ -119,6 +119,9 @@ export * from './indirectFire';
 // Line of Sight - LOS calculations and terrain blocking
 export * from './lineOfSight';
 
+// Visibility - Per-player LOS and sensor visibility helpers
+export * from './visibility';
+
 // Physical Attacks - Melee combat resolution
 export * from './physicalAttacks';
 

--- a/src/utils/gameplay/visibility.ts
+++ b/src/utils/gameplay/visibility.ts
@@ -1,0 +1,138 @@
+/**
+ * Per-player unit visibility helpers for fog-of-war filtering.
+ *
+ * @spec openspec/changes/add-fog-of-war-event-filtering/specs/spatial-combat-system/spec.md
+ */
+
+import type { IHexGrid } from '@/types/gameplay/HexGridInterfaces';
+
+import {
+  GameSide,
+  type IGameState,
+  type IUnitGameState,
+} from '@/types/gameplay/GameSessionInterfaces';
+
+import { hexDistance } from './hexMath';
+import { calculateLOS } from './lineOfSight';
+
+// IUnitGameState has no canonical sensor-range field today, so use the
+// fog-of-war spec baseline until a state field is introduced.
+const DEFAULT_SENSOR_RANGE = 10;
+
+const EMPTY_CLEAR_GRID: IHexGrid = {
+  config: { radius: 0 },
+  hexes: new Map(),
+};
+
+interface IVisibilitySideAssignment {
+  readonly playerId: string;
+  readonly side: string;
+}
+
+interface IVisibilityStateAugments {
+  readonly grid?: IHexGrid;
+  readonly sideOwners?: Partial<Record<GameSide, string>> | null;
+  readonly sideAssignments?: readonly IVisibilitySideAssignment[] | null;
+}
+
+type VisibilityState = IGameState & IVisibilityStateAugments;
+
+type UnitWithSensorRange = IUnitGameState & {
+  readonly sensorRange?: number;
+};
+
+/**
+ * Return true when the player owns the target unit or any owned unit has
+ * line of sight to it within sensor range.
+ */
+export function canPlayerSeeUnit(
+  playerId: string,
+  unitId: string,
+  state: IGameState,
+): boolean {
+  const visibilityState = state as VisibilityState;
+  const target = visibilityState.units[unitId];
+
+  if (!target) {
+    return false;
+  }
+
+  if (isUnitOwnedByPlayer(playerId, target, visibilityState)) {
+    return true;
+  }
+
+  const grid = visibilityState.grid ?? EMPTY_CLEAR_GRID;
+
+  return getUnitsOwnedByPlayer(playerId, visibilityState).some((observer) => {
+    if (
+      hexDistance(observer.position, target.position) > getSensorRange(observer)
+    ) {
+      return false;
+    }
+
+    return calculateLOS(observer.position, target.position, grid).hasLOS;
+  });
+}
+
+/**
+ * Return all unit ids currently visible to a player, sorted for deterministic
+ * cache keys and replay/filter comparisons.
+ */
+export function visibleUnitsForPlayer(
+  playerId: string,
+  state: IGameState,
+): string[] {
+  const visibleIds = new Set<string>();
+
+  for (const unitId of Object.keys(state.units)) {
+    if (canPlayerSeeUnit(playerId, unitId, state)) {
+      visibleIds.add(unitId);
+    }
+  }
+
+  return Array.from(visibleIds).sort((a, b) => a.localeCompare(b));
+}
+
+function getUnitsOwnedByPlayer(
+  playerId: string,
+  state: VisibilityState,
+): readonly IUnitGameState[] {
+  return Object.values(state.units).filter((unit) =>
+    isUnitOwnedByPlayer(playerId, unit, state),
+  );
+}
+
+function isUnitOwnedByPlayer(
+  playerId: string,
+  unit: IUnitGameState,
+  state: VisibilityState,
+): boolean {
+  return getOwnerIdForSide(unit.side, state) === playerId;
+}
+
+function getOwnerIdForSide(side: GameSide, state: VisibilityState): string {
+  const ownerFromSideMap = state.sideOwners?.[side];
+  if (ownerFromSideMap !== undefined) {
+    return ownerFromSideMap;
+  }
+
+  const assignment = state.sideAssignments?.find((candidate) => {
+    return candidate.side === side;
+  });
+
+  return assignment?.playerId ?? side;
+}
+
+function getSensorRange(unit: IUnitGameState): number {
+  const { sensorRange } = unit as UnitWithSensorRange;
+
+  if (
+    typeof sensorRange === 'number' &&
+    Number.isFinite(sensorRange) &&
+    sensorRange >= 0
+  ) {
+    return sensorRange;
+  }
+
+  return DEFAULT_SENSOR_RANGE;
+}


### PR DESCRIPTION
## Summary\n- add reconnect persistence/replay foundations: match log storage, session hydration, P2P replay helpers, local pending status, host getEventsFromSeq\n- add fog-of-war foundations: match creation config, lobby checkbox, event classification/filtering, redaction rules, LOS cache\n- update OpenSpec task status and roadmap stats; Wave 4 remains in-progress\n\n## Tests\n- npx.cmd jest --selectProjects unit --runTestsByPath src\\lib\\p2p\\__tests__\\gameSessionChannel.test.ts src\\stores\\__tests__\\useGameplayStore.localMatchStatus.test.ts src\\lib\\multiplayer\\server\\__tests__\\ServerMatchHost.test.ts src\\lib\\multiplayer\\server\\__tests__\\fogOfWar.test.ts src\\components\\multiplayer\\__tests__\\CreateMatchForm.test.tsx src\\__tests__\\unit\\api\\multiplayerMatchesFog.test.ts --runInBand --watchAll=false\n- npx.cmd tsx scripts\\validate-bv.ts\n- npx.cmd madge --circular --extensions ts,tsx src\\\n- npx.cmd openspec validate --all --strict\n- npx.cmd oxfmt --check src --no-error-on-unmatched-pattern\n- npx.cmd oxlint\n- npm.cmd run typecheck -- --pretty false\n\n## Notes\n- Full unscoped npx.cmd oxfmt --check still scans local untracked .agents/.omx state files and exits nonzero outside this branch diff.\n- Remaining Wave 4 work: page-load reconnect, awareness pending hooks, host broadcast filtering, filtered replay, client fog rendering, integration/perf coverage.