### PR TITLE
Close 5 infantry-construction tasks (50/50; archive deferred for spec merge)

### DIFF
--- a/openspec/changes/add-infantry-construction/tasks.md
+++ b/openspec/changes/add-infantry-construction/tasks.md
@@ -54,8 +54,8 @@
 ## 7. Anti-Mech Training
 
 - [x] 7.1 Boolean flag: `antiMechTraining = true/false`
-- [ ] 7.2 Enables leg / swarm attacks in combat (similar to BA but simpler)
-- [ ] 7.3 Adds to training cost (BV multiplier at BV calc step)
+- [x] 7.2 Enables leg / swarm attacks in combat (similar to BA but simpler)
+- [x] 7.3 Adds to training cost (BV multiplier at BV calc step)
 - [x] 7.4 Validation: only Foot / Jump / Mechanized may learn anti-mech
 
 ## 8. Construction Validation Rules
@@ -70,12 +70,12 @@
 ## 9. Store and UI Wiring
 
 - [x] 9.1 Wire `infantryStore` to persist new state
-- [ ] 9.2 Enhance `InfantryBuildTab` to expose all fields
-- [ ] 9.3 Status bar displays platoon strength, effective MP, kit modifiers
+- [x] 9.2 Enhance `InfantryBuildTab` to expose all fields
+- [x] 9.3 Status bar displays platoon strength, effective MP, kit modifiers
 - [x] 9.4 Field gun section adds/edits field gun
 
 ## 10. Validation
 
 - [x] 10.1 `openspec validate add-infantry-construction --strict`
 - [x] 10.2 Fixtures: Foot Rifle Platoon, Jump SRM Platoon, Mechanized MG Platoon, Field Gun (AC/5) Platoon
-- [ ] 10.3 Build + lint clean
+- [x] 10.3 Build + lint clean


### PR DESCRIPTION
## Summary

Closes the last 5 unchecked tasks in `add-infantry-construction` (45/50 → 50/50). Wave 0 reconciliation missed these — they're proven in source as of `main@e4599563` but the change was authored against a sparse `infantry-unit-system` baseline before `add-infantry-battle-value` populated the source-of-truth spec with overlapping content.

## Task evidence

| Task | Evidence |
| --- | --- |
| 7.2 Anti-mech leg/swarm attacks | [legAttack.ts](src/utils/gameplay/infantry/legAttack.ts) with `IAntiMechLegAttackEvent` emission + 11 tests in `__tests__/legAttack.test.ts` |
| 7.3 BV multiplier at BV calc step | [infantryBV.ts:190,349-355](src/utils/construction/infantry/infantryBV.ts) `ANTI_MECH_MULTIPLIER = 1.1` applied at platoon BV step + `infantryBV.test.ts` coverage |
| 9.2 `InfantryBuildTab` exposes all fields | [InfantryBuildTab.tsx:88-115](src/components/customizer/infantry/InfantryBuildTab.tsx) wires `motiveType`, `platoonComposition`, `armorKit`, `primaryWeapon`, `secondaryWeapon`, `fieldGuns`, `hasAntiMechTraining` |
| 9.3 Status bar shows platoon strength + MP + kit | [InfantryStatusBar.tsx](src/components/customizer/infantry/InfantryStatusBar.tsx) — troopers, motive+MP, armor kit, anti-mech, field guns, BV |
| 10.3 Build + lint clean | `oxlint` clean (1 max-lines warning on 533-line tab, 0 errors), `tsc --noEmit` silent, 359/359 infantry tests pass |

## Why this isn't an archive PR

`npx openspec archive add-infantry-construction --yes` aborts because 7 of the change's `## ADDED Requirements` headers collide with already-merged content in `openspec/specs/infantry-unit-system/spec.md`:

- Anti-Mech Training (source line 224 — capability flags + default + swarm validation; delta adds Foot enables Leg/Swarm + BV multiplier recorded + Motorized validation message format)
- Platoon Composition Defaults vs source `Platoon Composition` (line 34)
- Motive Type Movement Points vs source `Motion Types` (line 62)
- Armor Kit Selection vs source `Armor Kits` (line 178)
- Primary and Secondary Weapon Selection vs source `Primary Weapon Types` + `Secondary Weapons` (lines 93, 120)
- Field Gun Integration vs source `Field Guns` (line 142)
- Infantry Construction Validation Rule Set vs source `Infantry Validation Rules` (line 420)

The scenarios in each are complementary, not contradictory — the merge is real spec work, not a one-line label flip. Deferred to a follow-up PR that converts overlapping `ADDED` → `MODIFIED` with merged scenarios.

## Test plan

- [x] `npx openspec validate add-infantry-construction --strict` passes
- [x] `npx oxlint src/utils/gameplay/infantry src/utils/construction/infantry src/components/customizer/infantry` clean
- [x] `npx tsc --noEmit --skipLibCheck` silent
- [x] `npx jest --testPathPattern="infantry"` 359/359 pass
- [ ] CI rollup green

## Husky bypass

`openspec/` is in `.prettierignore`. lint-staged calls `oxfmt --write` on the matching glob, but with all staged paths under `openspec/` oxfmt errors with `Expected at least one target file`. Documented bypass via `--no-verify` with full validation already run pre-commit.