### PR TITLE
feat(gameplay): wire combat-behavior dispatch via IUnitGameState.combatState slot (cluster F PR7)

### DIFF
--- a/openspec/changes/wire-combat-behavior-dispatch/design.md
+++ b/openspec/changes/wire-combat-behavior-dispatch/design.md
@@ -1,0 +1,236 @@
+# Design: Wire Combat-Behavior Dispatch
+
+## Technical Approach
+
+The four archived combat-behavior changes each delivered a per-type combat-state struct (`IAerospaceCombatState`, `IProtoMechCombatState`, `IInfantryCombatState`, `IBattleArmorCombatState`) plus a factory (`create{Type}CombatState{,FromUnit}`) — but stopped short of wiring those structs into `IUnitGameState`, the canonical envelope that the reducer and renderer share. As a result, `unitStateToToken` has no source for per-type fields and the four token components carry inline `?? <default>` fallbacks at:
+
+- `src/components/gameplay/UnitToken/AerospaceToken.tsx:45` (`token.altitude ?? 1`, `token.velocity ?? 0`)
+- `src/components/gameplay/UnitToken/InfantryToken.tsx:83` (`token.infantryCount ?? 28`)
+- `src/components/gameplay/UnitToken/BattleArmorToken.tsx:75` (`token.trooperCount ?? 4`)
+- `src/components/gameplay/UnitToken/ProtoMechToken.tsx:60` (`token.protoCount ?? 5`, `token.isGlider ?? false`, `token.hasMainGun ?? false`)
+
+This change closes the gap with one envelope on the state side, one projection adapter on the rendering side, and one redaction branch on the fog side. Future per-type variants (vehicle in PR9+) become additive type-checker-driven changes.
+
+## Architecture Decisions
+
+### Decision: Envelope per-type combat data inside `IUnitGameState`, not as a parallel map
+
+**Choice**: Add an optional `combatState` field directly on `IUnitGameState` carrying a discriminated union keyed by `kind`.
+
+**Rationale**: The Oracle ruling in Council #1 was specific: per-type combat data must travel inside the existing single-message multiplayer-sync envelope (one `IUnitGameState` blob per unit per turn). Side-channels (parallel `Record<unitId, IInfantryCombatState>` maps on `IGameState`) would force every reducer, replay, and sync layer to learn about a second channel, and would break event-sourced replay determinism the moment the two channels could disagree.
+
+**Alternatives considered**:
+- **Parallel map on `IGameState`** (`infantryStates: Record<string, IInfantryCombatState>`) — rejected. Two channels = two sources of truth for the same unit; replay determinism leaks.
+- **Type-narrowed `IUnitGameState` union** (`IMechUnitGameState | IInfantryUnitGameState | ...`) — rejected for PR7. That is the PR8 token-side flip Hephaestus pushed back on; doing it on the state side first would force every existing reducer call-site to update simultaneously. Slot-first keeps PR7 small.
+- **Make `combatState` non-optional** — rejected. The legacy mech-only init path and ~80 fixtures would all need to be touched in this PR; optional+assertion confines blast radius to the four supported per-type unit types.
+
+### Decision: Single shared `unitStateToToken` adapter
+
+**Choice**: Extract one `unitStateToToken` function (currently duplicated at `GameplayLayout.tsx:181` and `SpectatorViewPanels.tsx:19`) into a shared module under `src/lib/gameplay/` and have both call-sites import it. The adapter is the *only* place that narrows on `combatState.kind`.
+
+**Rationale**: Two divergent copies were the immediate cause of the per-type fields never reaching the renderer — the spectator copy at `SpectatorViewPanels.tsx:19` doesn't even take a `fogProjection` parameter. Unifying now (a) eliminates that drift, (b) makes the projection rule discoverable in one place for the future `kind: 'vehicle'` variant, (c) lets the fog-redaction branch live in exactly one switch arm.
+
+**Alternatives considered**:
+- **Per-token-component projection** (each `<{Type}Token>` reads `combatState` itself) — rejected. Would push narrowing into the renderer, recreate the duplication problem one level lower, and break the fog-redaction one-liner.
+- **Reducer enriches the token at state-construction time** — rejected. Tokens are a render-time projection, not state. Storing them in state would require keeping `IUnitToken` and `IUnitGameState` synchronized through every reducer.
+
+### Decision: Init-time discriminated assertion (throw, do not warn)
+
+**Choice**: `createInitialUnitState` throws when an `IGameUnit` whose `unitType` is one of the four supported per-type discriminants arrives without the construction inputs needed to seed `combatState`.
+
+**Rationale**: Soft warnings would let session creation succeed with a partially-wired unit, then surface as silent renders or null-deref crashes mid-battle. Hard throws at session-init keep the failure adjacent to the cause (compendium adapter, lobby builder, test fixture). Replay-from-events is unaffected because event replay rebuilds state from `createInitialUnitState`'s output, which by definition will have already passed the assertion.
+
+**Alternatives considered**:
+- **Console warn + use defaults** — rejected. Defaults silently wrong-render and never get cleaned up.
+- **Type-only narrowing (no runtime check)** — rejected. `IGameUnit` arrives from JSON loaders; the type system can't catch missing fields at the boundary.
+
+### Decision: Fog redaction in the projection adapter, not in the renderer
+
+**Choice**: The `unitStateToToken` adapter takes the existing `fogProjection` parameter, and when the unit is hidden it explicitly omits per-type fields from the returned `IUnitToken`.
+
+**Rationale**: Renderer-level redaction would have to repeat itself across four token components, and could only redact what the renderer happens to read — easy to miss. Adapter-level redaction stops the leak at the type boundary; the renderer never sees the values. One line, one test, one place to add the next redacted field.
+
+### Decision: Defer `IAerospaceCombatState.velocity`; add `altitude` now
+
+**Choice**: Add `altitude` to `IAerospaceCombatState` (Oracle open question #1; verified absent during Phase-4.5). Leave `velocity` unwired with a `// TODO: wire from movement slice 2` comment; the projection adapter passes `velocity: undefined` for now.
+
+**Rationale**: `altitude` is the field that drives the `isLanded` visual branch in `AerospaceToken` and is trivially seedable at battle start (default `1` matches today's hard-coded fallback). `velocity` is a movement-tick-derived value and properly belongs to "movement slice 2" in the aerospace roadmap; faking it here would entrench the wrong owner.
+
+## Per-type slot shape (verbatim TS)
+
+The discriminated-union slot added to `IUnitGameState` (in `src/types/gameplay/GameSessionInterfaces.ts`, after line 1396 and before the closing `}` on line 1397):
+
+```ts
+import type { IAerospaceCombatState } from '@/utils/gameplay/aerospace/state';
+import type { IBattleArmorCombatState } from '@/types/gameplay';
+import type { IInfantryCombatState } from '@/utils/gameplay/infantry/state';
+import type { IProtoMechCombatState } from '@/utils/gameplay/protomech/state';
+
+// Inside `interface IUnitGameState { ... }`:
+/**
+ * Per-type combat-behavior envelope.
+ *
+ * Per Council #1 (`openspec/council-decisions/2026-05-02-cluster-F-combat-
+ * behavior-wiring.md`), aerospace / protomech / infantry / BA units carry
+ * their per-type combat struct here so renderers and fog redaction read a
+ * single channel. Mech and vehicle units leave this `undefined` until the
+ * `kind: 'vehicle'` variant lands in PR9+.
+ *
+ * Producers: `createInitialUnitState` (initial seed); per-type reducers
+ * (combat events update the inner `state` and replace the envelope).
+ *
+ * Consumers: `unitStateToToken` (projection); fog-of-war redaction.
+ */
+readonly combatState?:
+  | { readonly kind: 'aero'; readonly state: IAerospaceCombatState }
+  | { readonly kind: 'proto'; readonly state: IProtoMechCombatState }
+  | { readonly kind: 'platoon'; readonly state: IInfantryCombatState }
+  | { readonly kind: 'squad'; readonly state: IBattleArmorCombatState };
+```
+
+`altitude` added to `IAerospaceCombatState` (in `src/utils/gameplay/aerospace/state.ts`, after line 100):
+
+```ts
+/** Current altitude band (0 = landed; 1+ = airborne). Defaults to 1. */
+altitude: number;
+```
+
+And in `createAerospaceCombatState` (lines 171-198):
+
+```ts
+export function createAerospaceCombatState(params: {
+  // ... existing fields ...
+  readonly altitude?: number;          // NEW (defaults to 1)
+}): IAerospaceCombatState {
+  return {
+    // ... existing fields ...
+    altitude: params.altitude ?? 1,    // NEW
+  };
+}
+```
+
+## Projection adapter sketch
+
+A new file `src/lib/gameplay/unitStateToToken.ts` exporting the unified function. The two existing copies become thin re-exports.
+
+```ts
+import type { GameSide, IUnitGameState, IUnitToken } from '@/types/gameplay';
+import { TokenUnitType } from '@/types/gameplay';
+import { getSurvivingTroopers as baSurvivors } from '@/utils/gameplay/battlearmor/state';
+import { ProtoChassis } from '@/types/unit/ProtoMechInterfaces';
+
+export interface IFogProjection {
+  fogStatus?: 'lastKnown';
+  lastKnownPosition?: { q: number; r: number };
+  sensorRange?: number;
+}
+
+export function unitStateToToken(
+  unitId: string,
+  state: IUnitGameState,
+  unitInfo: { name: string; side: GameSide },
+  flags: {
+    isSelected?: boolean;
+    isValidTarget?: boolean;
+    isActiveTarget?: boolean;
+  } = {},
+  fog: IFogProjection = {},
+  isHidden = false,                                  // NEW: drives redaction
+): IUnitToken {
+  const designation = unitInfo.name
+    .split(/[\s-]+/)
+    .map((w) => w[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 4);
+
+  const base: IUnitToken = {
+    unitId,
+    name: unitInfo.name,
+    side: unitInfo.side,
+    position: state.position,
+    facing: state.facing,
+    isSelected: flags.isSelected ?? false,
+    isValidTarget: flags.isValidTarget ?? false,
+    isActiveTarget: flags.isActiveTarget ?? false,
+    isDestroyed: state.destroyed,
+    designation,
+    ...fog,
+  };
+
+  // Fog redaction: never project per-type combat data for hidden enemies.
+  if (isHidden) {
+    return base;
+  }
+
+  const cs = state.combatState;
+  if (!cs) {
+    return base; // mech / vehicle path — no per-type fields populated.
+  }
+  switch (cs.kind) {
+    case 'aero':
+      return {
+        ...base,
+        unitType: TokenUnitType.Aerospace,
+        altitude: cs.state.altitude,
+        // velocity intentionally omitted: TODO movement slice 2.
+      };
+    case 'platoon':
+      return {
+        ...base,
+        unitType: TokenUnitType.Infantry,
+        infantryCount: cs.state.survivingTroopers,
+        platoonCount: 1,
+      };
+    case 'squad':
+      return {
+        ...base,
+        unitType: TokenUnitType.BattleArmor,
+        trooperCount: baSurvivors(cs.state),
+      };
+    case 'proto':
+      return {
+        ...base,
+        unitType: TokenUnitType.ProtoMech,
+        protoCount: 1, // single proto per IUnitGameState; point=multiple states.
+        isGlider: cs.state.chassisType === ProtoChassis.GLIDER,
+        hasMainGun: cs.state.hasMainGun,
+      };
+  }
+}
+```
+
+## Multiplayer sync interaction
+
+Per Oracle's gating ruling, all per-unit data flows in a single envelope (`IUnitGameState`) per turn. The `combatState` slot rides inside that same envelope — no parallel sync channel, no out-of-band update path. The reducer creates a new `IUnitGameState` (with a new `combatState` object when the inner per-type state changes); the multiplayer layer ships the diff per its existing JSON-patch / event-sourced strategy. Replay determinism is preserved because `createInitialUnitState` always produces the same seed for the same `IGameUnit`.
+
+## Fog redaction interaction (one-line branch + test)
+
+The redaction is a single `if (isHidden) return base;` early-return at the top of `unitStateToToken` (after constructing `base`, before the `combatState` switch). The accompanying test in `src/lib/gameplay/__tests__/unitStateToToken.test.ts` asserts:
+
+```ts
+it('redacts combatState-derived fields when isHidden=true', () => {
+  const state = makeInfantryState({ survivingTroopers: 22 });
+  const token = unitStateToToken('u1', state, info, {}, {}, /* isHidden */ true);
+  expect(token.infantryCount).toBeUndefined();
+  expect(token.platoonCount).toBeUndefined();
+});
+```
+
+Caller wiring in `GameplayLayout.tsx` derives `isHidden` from the existing fog visibility branch (the `else` arm of `canPlayerSeeUnit` at lines 421-427) and passes it through to the adapter.
+
+## File Changes
+
+- **New**: `src/lib/gameplay/unitStateToToken.ts` — unified projection adapter + re-exports.
+- **New**: `src/lib/gameplay/__tests__/unitStateToToken.test.ts` — adapter unit tests (per-type projection + fog redaction + missing-combatState mech path).
+- **New**: `src/utils/gameplay/gameState/__tests__/initialization.combatState.test.ts` — seeding tests + assertion-throws tests for each of the four per-type unit kinds.
+- **Modified**: `src/types/gameplay/GameSessionInterfaces.ts` — add `combatState?` discriminated-union slot at line 1397.
+- **Modified**: `src/utils/gameplay/aerospace/state.ts` — add `altitude` field to `IAerospaceCombatState` and `altitude?` parameter (default 1) to `createAerospaceCombatState`.
+- **Modified**: `src/utils/gameplay/gameState/initialization.ts` — branch on `unit.unitType` to seed `combatState` via the matching factory; throw on missing inputs.
+- **Modified**: `src/components/gameplay/GameplayLayout.tsx` — replace local `unitStateToToken` (line 181) with shared import; pass `isHidden` to adapter.
+- **Modified**: `src/components/gameplay/SpectatorViewPanels.tsx` — replace local `unitStateToToken` (line 19) with shared import.
+- **Modified**: `src/components/gameplay/UnitToken/AerospaceToken.tsx` — remove `?? 1` and `?? 0` defaults (lines 45-46).
+- **Modified**: `src/components/gameplay/UnitToken/InfantryToken.tsx` — remove `?? 28` default (line 83); also remove `?? 1` from `platoonCount` (line 84).
+- **Modified**: `src/components/gameplay/UnitToken/BattleArmorToken.tsx` — remove `?? 4` default (line 75).
+- **Modified**: `src/components/gameplay/UnitToken/ProtoMechToken.tsx` — remove `?? 5`, `?? false`, `?? false` defaults (lines 60-62).
+- **Modified**: existing test fixtures and Storybook stories that build `IUnitGameState` for non-mech types — add the matching `combatState` slot OR add `unitType: 'BATTLEMECH'` to the stub `IGameUnit` so the mech path is taken. Specific files surfaced in tasks §8.

--- a/openspec/changes/wire-combat-behavior-dispatch/proposal.md
+++ b/openspec/changes/wire-combat-behavior-dispatch/proposal.md
@@ -1,0 +1,44 @@
+# Wire Combat-Behavior Dispatch
+
+## Intent
+
+The four archived per-type combat-behavior changes (`add-aerospace-combat-behavior`, `add-protomech-combat-behavior`, `add-infantry-combat-behavior`, `add-battlearmor-combat-behavior`) each declare per-unit combat state at `unit.combatState.{aero|proto|platoon|squad}` — yet `IUnitGameState` carries no such slot today. As a result, four token components (`AerospaceToken`, `InfantryToken`, `BattleArmorToken`, `ProtoMechToken`) silently fall back to hard-coded defaults (altitude=1, troopers=28, troopers=4, protos=5) for every render. Council #1 (`openspec/council-decisions/2026-05-02-cluster-F-combat-behavior-wiring.md`) ruled "wire it via Oracle's discriminated-union slot" so the existing per-type combat factories actually reach the renderer.
+
+This change ships the missing dispatch wiring as PR7 of two: it (a) introduces the `IUnitGameState.combatState?` discriminated-union slot, (b) seeds it from the existing `create{Type}CombatState` factories at session-init time, (c) projects it into `IUnitToken` via a single shared adapter, and (d) removes the four `?? <default>` fallbacks. PR8 (out of scope here) will follow with the discriminated-union flip of `IUnitToken` itself.
+
+## Scope
+
+### In
+
+- Add `IUnitGameState.combatState?` discriminated-union slot in `src/types/gameplay/GameSessionInterfaces.ts` (kinds: `aero` / `proto` / `platoon` / `squad`).
+- Verify `IAerospaceCombatState.altitude` field existence; add it when absent (Oracle-flagged open question #1).
+- Seed `combatState` in `createInitialUnitState` (`src/utils/gameplay/gameState/initialization.ts`) using existing factories: `createAerospaceCombatState`, `createInfantryCombatStateFromUnit`, `createProtoMechCombatState`, `createBattleArmorCombatState`.
+- Add type-discriminated assertion in init: throw when an aerospace / proto / infantry / BA `IGameUnit` arrives without the inputs needed to seed `combatState`.
+- Write a single `unitStateToToken` projection adapter that narrows on `combatState.kind` and populates per-type token fields (`altitude`, `velocity`, `infantryCount`, `trooperCount`, `protoCount`, `isGlider`, `hasMainGun`).
+- Unify the two divergent `unitStateToToken` copies (`src/components/gameplay/GameplayLayout.tsx:181`, `src/components/gameplay/SpectatorViewPanels.tsx:19`) onto the new shared adapter.
+- Remove the four token-component `?? <default>` fallbacks (`AerospaceToken.tsx:45-46`, `InfantryToken.tsx:83-84`, `BattleArmorToken.tsx:75`, `ProtoMechToken.tsx:60-62`).
+- Add fog-of-war redaction branch: explicitly strip `combatState` (and the projected per-type fields) for hidden-enemy tokens so structure / trooper counts cannot leak through `lastKnown` projections.
+- Update unit-test fixtures and Storybook stories that build `IUnitGameState` or `IUnitToken` for non-mech types so the new slot is present and the renderers receive concrete values.
+
+### Out
+
+- **Customizer TODOs** (`BattleArmorPipGrid.tsx:52`, `InfantryPlatoonCounter.tsx:33`) — design-time customizer components with misattributed comments (council ruling). Separate cleanup.
+- **Re-authoring the 4 archived specs** — the missing artefact is one new dispatch spec, not four reruns (council ruling).
+- **Vehicle combat-state migration** — `IVehicleCombatState` lives in a parallel structure; plan for a fifth `kind: 'vehicle'` variant in PR9+ (council ruling).
+- **Discriminated-union flip of `IUnitToken`** — PR8 follow-up (~1.5 days, type-checker driven). Closes Momus's god-type concern; out of scope here.
+- **`IAerospaceCombatState.velocity`** — genuinely missing. Defer with a TODO pointing at "movement slice 2" (Oracle open question #2).
+
+## Approach
+
+Domains touched:
+- `game-state-management` (`IUnitGameState.combatState` slot + `createInitialUnitState` seeding + discriminated-union assertion).
+- `tactical-map-interface` (single shared `unitStateToToken` projection adapter; removal of four token-default fallbacks).
+- `fog-of-war` (redaction branch that strips `combatState` and per-type token fields for hidden enemies).
+
+Pattern: a typed *envelope* on the game-state side (immutable per-unit slot keyed by `kind`) plus a *projection adapter* on the rendering side. The envelope keeps Oracle's single-message multiplayer sync model intact (one `IUnitGameState` blob per unit per turn — no parallel side-channels). The projection adapter is the only place that ever narrows on `combatState.kind`, so adding the future `kind: 'vehicle'` variant becomes an additive type-checker-driven change.
+
+## Test Strategy
+
+- Infrastructure: exists (Jest + ts-jest + storybook, see `MEMORY.md` "CI Infrastructure (2026-04-24)").
+- Tests: tests-after — implementation tasks land first; unit-test additions in §8 of tasks.md cover (a) `createInitialUnitState` seeds the right `kind` per `IGameUnit.unitType`, (b) `unitStateToToken` populates per-type fields from the envelope, (c) fog redaction strips `combatState` and projected per-type fields for hidden enemies, (d) the init-time assertion throws on missing inputs.
+- Agent QA: `npx tsc --noEmit` clean, `npm test` clean, `npm run validate-bv` parity = 0 deltas (BV calc untouched), `npm run lint` + `oxfmt --check` clean. Storybook fixtures for each per-type token render visibly identical to pre-change snapshots when the envelope provides values that match the old defaults.

--- a/openspec/changes/wire-combat-behavior-dispatch/specs/fog-of-war/spec.md
+++ b/openspec/changes/wire-combat-behavior-dispatch/specs/fog-of-war/spec.md
@@ -1,0 +1,55 @@
+# fog-of-war (delta)
+
+## ADDED Requirements
+
+### Requirement: Combat-State Redaction for Hidden Units
+
+When fog-of-war is enabled and a unit is NOT visible to the local player (no LOS, no `lastKnown` exposure granting full state), the projected `IUnitToken` for that unit SHALL NOT include `combatState`-derived per-type fields. Specifically the projection adapter SHALL strip `altitude`, `velocity`, `infantryCount`, `platoonCount`, `trooperCount`, `protoCount`, `isGlider`, and `hasMainGun` from the redacted token.
+
+This prevents the new `IUnitGameState.combatState` envelope (introduced in `game-state-management`) from leaking trooper counts, structural integrity, altitude, or chassis flags through the rendering pipeline to a player who has no sensor-grade reason to see them. `lastKnownPosition` and `fogStatus = 'lastKnown'` MAY still be set per the existing fog model.
+
+#### Scenario: Hidden enemy infantry leaks no troopers
+
+- **GIVEN** fog-of-war is enabled
+- **AND** an enemy infantry platoon is NOT visible to the local player
+- **WHEN** `unitStateToToken(...)` projects the platoon's `IUnitGameState` for rendering
+- **THEN** the returned `IUnitToken.infantryCount` SHALL be `undefined`
+- **AND** `IUnitToken.platoonCount` SHALL be `undefined`
+
+#### Scenario: Hidden enemy aerospace leaks no altitude
+
+- **GIVEN** fog-of-war is enabled
+- **AND** an enemy aerospace fighter is NOT visible to the local player
+- **WHEN** `unitStateToToken(...)` projects the fighter's `IUnitGameState`
+- **THEN** the returned `IUnitToken.altitude` SHALL be `undefined`
+- **AND** `IUnitToken.velocity` SHALL be `undefined`
+
+#### Scenario: Hidden enemy battle armor leaks no troopers
+
+- **GIVEN** fog-of-war is enabled
+- **AND** an enemy battle armor squad is NOT visible to the local player
+- **WHEN** `unitStateToToken(...)` projects the squad's `IUnitGameState`
+- **THEN** the returned `IUnitToken.trooperCount` SHALL be `undefined`
+
+#### Scenario: Hidden enemy protomech leaks no chassis flags
+
+- **GIVEN** fog-of-war is enabled
+- **AND** an enemy proto point is NOT visible to the local player
+- **WHEN** `unitStateToToken(...)` projects the proto's `IUnitGameState`
+- **THEN** the returned `IUnitToken.protoCount` SHALL be `undefined`
+- **AND** `IUnitToken.isGlider` SHALL be `undefined`
+- **AND** `IUnitToken.hasMainGun` SHALL be `undefined`
+
+#### Scenario: Owned units are not redacted
+
+- **GIVEN** fog-of-war is enabled
+- **AND** the local player owns an infantry platoon with `combatState.kind === 'platoon'` and `survivingTroopers === 22`
+- **WHEN** `unitStateToToken(...)` projects the platoon's `IUnitGameState`
+- **THEN** the returned `IUnitToken.infantryCount` SHALL equal `22`
+
+#### Scenario: Visible enemies (in-LOS) are not redacted
+
+- **GIVEN** fog-of-war is enabled
+- **AND** an enemy infantry platoon IS visible to the local player via owned-unit LOS
+- **WHEN** `unitStateToToken(...)` projects the platoon's `IUnitGameState`
+- **THEN** `IUnitToken.infantryCount` SHALL reflect the live `survivingTroopers` value

--- a/openspec/changes/wire-combat-behavior-dispatch/specs/game-state-management/spec.md
+++ b/openspec/changes/wire-combat-behavior-dispatch/specs/game-state-management/spec.md
@@ -1,0 +1,102 @@
+# game-state-management (delta)
+
+## ADDED Requirements
+
+### Requirement: Per-Unit Combat-Behavior Envelope
+
+`IUnitGameState` SHALL carry an optional `combatState` slot whose shape is a discriminated union keyed by `kind`. The slot envelopes the per-type combat-behavior structs that the four archived combat-behavior changes (`add-aerospace-combat-behavior`, `add-protomech-combat-behavior`, `add-infantry-combat-behavior`, `add-battlearmor-combat-behavior`) each declared at `unit.combatState.{aero|proto|platoon|squad}`.
+
+The envelope MUST be the single channel through which per-type combat data flows from the game state to consumers (renderers, fog redaction, multiplayer sync). Per-type side-channels are PROHIBITED.
+
+The envelope MUST be immutable from the consumer's perspective: producers (reducers, init helpers) construct a new `combatState` object when the per-type struct changes; consumers never mutate it in place.
+
+#### Scenario: Envelope shape
+
+- **GIVEN** an `IUnitGameState` for any unit
+- **WHEN** the type is inspected
+- **THEN** `combatState` SHALL be one of `{ kind: 'aero'; state: IAerospaceCombatState }`, `{ kind: 'proto'; state: IProtoMechCombatState }`, `{ kind: 'platoon'; state: IInfantryCombatState }`, or `{ kind: 'squad'; state: IBattleArmorCombatState }`
+- **AND** the slot SHALL be optional (legacy mech-only callers continue to omit it without breakage)
+
+#### Scenario: Single-channel rule
+
+- **GIVEN** a renderer or sync consumer needs per-type combat data
+- **WHEN** it reads `IUnitGameState`
+- **THEN** it SHALL obtain that data ONLY through `combatState`
+- **AND** it SHALL NOT consult parallel per-type maps, side-channels, or out-of-band lookups
+
+### Requirement: Combat-State Seeding at Initialization
+
+`createInitialUnitState` SHALL seed `combatState` whenever the input `IGameUnit.unitType` is one of the four supported per-type discriminants (aerospace fighter / conventional fighter / small craft → `aero`; protomech → `proto`; infantry → `platoon`; battle armor → `squad`). The seeded `state` MUST be the return value of the matching existing factory: `createAerospaceCombatState`, `createProtoMechCombatState`, `createInfantryCombatStateFromUnit`, or `createBattleArmorCombatState`.
+
+Mech and vehicle units MUST leave `combatState` unset (until vehicle support lands as a future `kind: 'vehicle'` variant).
+
+#### Scenario: Aerospace seeding
+
+- **GIVEN** an `IGameUnit` whose `unitType` is `AEROSPACE_FIGHTER`, `CONVENTIONAL_FIGHTER`, or `SMALL_CRAFT`
+- **WHEN** `createInitialUnitState(unit, position)` runs
+- **THEN** the returned `IUnitGameState` SHALL have `combatState.kind === 'aero'`
+- **AND** `combatState.state` SHALL equal `createAerospaceCombatState({...})` invoked with the unit's construction-time `maxSI`, `armorByArc`, `heatSinks`, `fuelPoints`, `safeThrust`, `maxThrust`
+
+#### Scenario: Infantry seeding
+
+- **GIVEN** an `IGameUnit` whose `unitType` is `INFANTRY`
+- **WHEN** `createInitialUnitState(unit, position)` runs
+- **THEN** `combatState.kind` SHALL be `'platoon'`
+- **AND** `combatState.state` SHALL equal `createInfantryCombatStateFromUnit(unit)`
+
+#### Scenario: Protomech seeding
+
+- **GIVEN** an `IGameUnit` whose `unitType` is `PROTOMECH`
+- **WHEN** `createInitialUnitState(unit, position)` runs
+- **THEN** `combatState.kind` SHALL be `'proto'`
+- **AND** `combatState.state` SHALL equal `createProtoMechCombatState({...})` invoked with the unit's `chassisType`, `hasMainGun`, per-location armor / structure maps
+
+#### Scenario: Battle armor seeding
+
+- **GIVEN** an `IGameUnit` whose `unitType` is `BATTLE_ARMOR`
+- **WHEN** `createInitialUnitState(unit, position)` runs
+- **THEN** `combatState.kind` SHALL be `'squad'`
+- **AND** `combatState.state` SHALL equal `createBattleArmorCombatState({...})` invoked with the unit's `squadSize`, per-trooper armor, stealth kind, magnetic-clamp / vibroclaw flags
+
+#### Scenario: Mech and vehicle units leave the slot unset
+
+- **GIVEN** an `IGameUnit` whose `unitType` is `BATTLEMECH` or any vehicle motive type
+- **WHEN** `createInitialUnitState(unit, position)` runs
+- **THEN** the returned `IUnitGameState.combatState` SHALL be `undefined`
+
+### Requirement: Discriminated Initialization Assertion
+
+`createInitialUnitState` SHALL throw a typed error when an `IGameUnit` whose `unitType` is one of the four supported per-type discriminants arrives without the construction inputs needed to seed its `combatState`. This rejects silent fall-back to defaults at the entry point and surfaces compendium / lobby gaps loudly during session creation.
+
+#### Scenario: Missing aerospace inputs
+
+- **GIVEN** an `IGameUnit` with `unitType === AEROSPACE_FIGHTER` whose construction blob lacks `maxSI`, `armorByArc`, or `heatSinks`
+- **WHEN** `createInitialUnitState(unit, position)` runs
+- **THEN** an error SHALL be thrown
+- **AND** the error message SHALL identify the unit id and the missing field(s)
+
+#### Scenario: Aerospace inputs present
+
+- **GIVEN** the same `IGameUnit` after the missing fields are populated
+- **WHEN** `createInitialUnitState(unit, position)` runs
+- **THEN** the returned `IUnitGameState.combatState.kind` SHALL be `'aero'`
+- **AND** no error SHALL be thrown
+
+### Requirement: Aerospace Altitude Field
+
+`IAerospaceCombatState` SHALL carry an `altitude` field expressing the unit's current altitude band (0 = landed; positive integers = airborne in standard altitude bands per BattleTech aerospace rules). The factory `createAerospaceCombatState` SHALL accept an optional `altitude` parameter and SHALL default to `1` (airborne) when the parameter is omitted, matching the prior render-time fallback in `AerospaceToken`.
+
+`velocity` is intentionally NOT added in this change; consumers that need velocity SHALL fall back to `0` and a TODO marker SHALL point at "movement slice 2".
+
+#### Scenario: Default altitude on construction
+
+- **GIVEN** `createAerospaceCombatState({...})` is called without `altitude`
+- **WHEN** the resulting state is inspected
+- **THEN** `altitude` SHALL equal `1`
+
+#### Scenario: Explicit landed altitude
+
+- **GIVEN** `createAerospaceCombatState({..., altitude: 0})` is called
+- **WHEN** the resulting state is inspected
+- **THEN** `altitude` SHALL equal `0`
+- **AND** downstream renderers SHALL treat the unit as landed

--- a/openspec/changes/wire-combat-behavior-dispatch/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/wire-combat-behavior-dispatch/specs/tactical-map-interface/spec.md
@@ -1,0 +1,86 @@
+# tactical-map-interface (delta)
+
+## ADDED Requirements
+
+### Requirement: Unified Combat-State Token Projection Adapter
+
+The system SHALL provide a single shared `unitStateToToken` projection adapter that converts an `IUnitGameState` into an `IUnitToken` for tactical-map rendering. The adapter MUST narrow on `IUnitGameState.combatState.kind` and SHALL populate per-type token fields (`altitude`, `infantryCount`, `trooperCount`, `protoCount`, `isGlider`, `hasMainGun`) from the envelope.
+
+The adapter SHALL be the only call-site in the codebase that reads `IUnitGameState.combatState` to populate `IUnitToken` per-type fields. Per-component or per-screen reimplementations of this projection are PROHIBITED.
+
+#### Scenario: Aerospace projection
+
+- **GIVEN** an `IUnitGameState` with `combatState.kind === 'aero'` and `state.altitude === 0`
+- **WHEN** `unitStateToToken(...)` is called
+- **THEN** the returned `IUnitToken.altitude` SHALL equal `0`
+- **AND** `unitType` SHALL be `TokenUnitType.Aerospace`
+
+#### Scenario: Infantry projection
+
+- **GIVEN** an `IUnitGameState` with `combatState.kind === 'platoon'` and `state.survivingTroopers === 22`
+- **WHEN** `unitStateToToken(...)` is called
+- **THEN** the returned `IUnitToken.infantryCount` SHALL equal `22`
+- **AND** `unitType` SHALL be `TokenUnitType.Infantry`
+
+#### Scenario: Battle armor projection
+
+- **GIVEN** an `IUnitGameState` with `combatState.kind === 'squad'` and 3 surviving troopers
+- **WHEN** `unitStateToToken(...)` is called
+- **THEN** the returned `IUnitToken.trooperCount` SHALL equal `3`
+- **AND** `unitType` SHALL be `TokenUnitType.BattleArmor`
+
+#### Scenario: Protomech projection
+
+- **GIVEN** an `IUnitGameState` with `combatState.kind === 'proto'`, `state.chassisType === ProtoChassis.GLIDER`, and `state.hasMainGun === true`
+- **WHEN** `unitStateToToken(...)` is called
+- **THEN** the returned `IUnitToken.protoCount` SHALL reflect surviving proto count
+- **AND** `IUnitToken.isGlider` SHALL be `true`
+- **AND** `IUnitToken.hasMainGun` SHALL be `true`
+- **AND** `unitType` SHALL be `TokenUnitType.ProtoMech`
+
+#### Scenario: Mech projection (legacy path)
+
+- **GIVEN** an `IUnitGameState` whose `combatState` is `undefined`
+- **WHEN** `unitStateToToken(...)` is called
+- **THEN** the returned `IUnitToken` SHALL omit per-type fields
+- **AND** `unitType` SHALL default per current `TokenUnitType.Mech` rules
+
+## MODIFIED Requirements
+
+### Requirement: Per-Type Token Renders SHALL Read Envelope Values
+
+The four per-type token components (`AerospaceToken`, `InfantryToken`, `BattleArmorToken`, `ProtoMechToken`) SHALL read per-type fields (`altitude`, `infantryCount`, `platoonCount`, `trooperCount`, `protoCount`, `isGlider`, `hasMainGun`) directly from the `IUnitToken` props with NO inline `?? <default>` fall-back expression.
+
+Producers (the unified `unitStateToToken` projection adapter) are responsible for populating concrete values from `IUnitGameState.combatState`. When `combatState` is absent for a unit whose `unitType` is in the four supported per-type discriminants, that is a producer-side bug (caught by the init-time assertion in `game-state-management`), NOT a render-side concern.
+
+(`velocity` is exempt from this rule until "movement slice 2" lands; an `?? 0` fallback MAY remain in `AerospaceToken` with a TODO comment.)
+
+The previous behaviour — each token component carrying inline `?? <default>` fall-backs (`altitude ?? 1`, `infantryCount ?? 28`, `trooperCount ?? 4`, `protoCount ?? 5`) so they would render visibly even when no producer wired the field — is REMOVED.
+
+#### Scenario: Aerospace token renders envelope altitude
+
+- **GIVEN** an `IUnitToken` with `unitType === TokenUnitType.Aerospace` and `altitude === 0`
+- **WHEN** `<AerospaceToken token={token} ... />` renders
+- **THEN** the rendered output SHALL reflect the landed visual state
+- **AND** the source code SHALL NOT contain any `altitude ?? <default>` expression
+
+#### Scenario: Infantry token renders envelope troopers
+
+- **GIVEN** an `IUnitToken` with `unitType === TokenUnitType.Infantry` and `infantryCount === 22`
+- **WHEN** `<InfantryToken token={token} ... />` renders
+- **THEN** the rendered output SHALL reflect 22 troopers
+- **AND** the source code SHALL NOT contain any `infantryCount ?? <default>` expression
+
+#### Scenario: Battle armor token renders envelope troopers
+
+- **GIVEN** an `IUnitToken` with `unitType === TokenUnitType.BattleArmor` and `trooperCount === 3`
+- **WHEN** `<BattleArmorToken token={token} ... />` renders
+- **THEN** the rendered output SHALL reflect 3 trooper dots
+- **AND** the source code SHALL NOT contain any `trooperCount ?? <default>` expression
+
+#### Scenario: Protomech token renders envelope flags
+
+- **GIVEN** an `IUnitToken` with `unitType === TokenUnitType.ProtoMech`, `protoCount === 4`, `isGlider === true`, `hasMainGun === false`
+- **WHEN** `<ProtoMechToken token={token} ... />` renders
+- **THEN** the rendered output SHALL reflect 4 protos, glider variant, no main gun
+- **AND** the source code SHALL NOT contain `protoCount ?? <default>`, `isGlider ?? false`, or `hasMainGun ?? false` expressions

--- a/openspec/changes/wire-combat-behavior-dispatch/tasks.md
+++ b/openspec/changes/wire-combat-behavior-dispatch/tasks.md
@@ -1,0 +1,138 @@
+# Tasks: Wire Combat-Behavior Dispatch
+
+> Council #1 ruling: ship as PR7 (`wire-combat-behavior-dispatch`). PR8 (token discriminated-union flip) is a follow-up, NOT part of this change.
+
+## 1. Foundation: factory verification + altitude field
+
+- [ ] 1.1 Verify the four combat-state factories are exported as documented:
+  - `createAerospaceCombatState` at `src/utils/gameplay/aerospace/state.ts:171`
+  - `createInfantryCombatStateFromUnit` at `src/utils/gameplay/infantry/state.ts:130`
+  - `createProtoMechCombatState` at `src/utils/gameplay/protomech/state.ts:139`
+  - `createBattleArmorCombatState` at `src/utils/gameplay/battlearmor/state.ts:39`
+  - Acceptance: all four import-resolve from `@/utils/gameplay/{aerospace,infantry,protomech,battlearmor}/state`.
+  - QA: `npx tsc --noEmit` clean before any other change.
+
+- [ ] 1.2 Add `altitude: number` field to `IAerospaceCombatState` (`src/utils/gameplay/aerospace/state.ts:60`).
+  - Position: after `destroyed: boolean;` on line 96, before the readonly thrust fields.
+  - Acceptance: type compiles; no existing consumer breaks (the field is new, not narrowed).
+  - QA: `npx tsc --noEmit` clean.
+
+- [ ] 1.3 Extend `createAerospaceCombatState` (`src/utils/gameplay/aerospace/state.ts:171`) to accept `altitude?: number` and default to `1`.
+  - Acceptance: existing 3 call-sites still compile (param is optional); new field appears in returned state.
+  - QA: `npm test -- aerospace/state` clean.
+
+## 2. State envelope: discriminated-union slot
+
+- [ ] 2.1 Add the `combatState?` discriminated-union slot to `IUnitGameState` in `src/types/gameplay/GameSessionInterfaces.ts:1397` (insert before the closing `}` of the interface, after `hasRetreated?: boolean;`).
+  - Use the verbatim TS shape from `design.md` § "Per-type slot shape".
+  - Add the four required `import type` statements at the top of the file. If `IBattleArmorCombatState` is already re-exported from `@/types/gameplay`, import from there; otherwise import from `@/utils/gameplay/battlearmor/state` (verify before authoring).
+  - Acceptance: type-only addition, all existing call-sites continue to compile (slot is optional).
+  - QA: `npx tsc --noEmit` clean.
+
+- [ ] 2.2 Re-export the four per-type combat-state interfaces (`IAerospaceCombatState`, `IInfantryCombatState`, `IProtoMechCombatState`, `IBattleArmorCombatState`) from `src/types/gameplay/index.ts` if not already exported.
+  - Acceptance: `import type { IAerospaceCombatState } from '@/types/gameplay'` works.
+  - QA: `npx tsc --noEmit` clean.
+
+## 3. Initialization: seeding + discriminated assertion
+
+- [ ] 3.1 In `src/utils/gameplay/gameState/initialization.ts:30` (`createInitialUnitState`), branch on `unit.unitType` to construct the per-type `combatState` envelope and assign it to the returned object.
+  - Aerospace branch (`AEROSPACE_FIGHTER` / `CONVENTIONAL_FIGHTER` / `SMALL_CRAFT`): call `createAerospaceCombatState({ maxSI, armorByArc, heatSinks, fuelPoints, safeThrust, maxThrust, altitude: 1 })` using construction fields off the unit blob.
+  - Infantry branch (`INFANTRY`): call `createInfantryCombatStateFromUnit(unit as IInfantry)`.
+  - Protomech branch (`PROTOMECH`): call `createProtoMechCombatState({ unitId, chassisType, hasMainGun, armorByLocation, structureByLocation, altitude: chassis === GLIDER ? 0 : undefined })`.
+  - Battle armor branch (`BATTLE_ARMOR`): call `createBattleArmorCombatState({ unitId, squadSize, armorPointsPerTrooper, stealthKind, hasMagneticClamp, hasVibroClaws, vibroClawCount })`.
+  - Mech / vehicle branches: leave `combatState` undefined.
+  - Acceptance: returned `IUnitGameState` has `combatState.kind` matching `unitType` for the four per-type kinds; mech/vehicle paths have `combatState === undefined`.
+  - QA: `npm test -- initialization` clean.
+
+- [ ] 3.2 In the same file, add a discriminated assertion: when `unitType` is one of the four supported per-type kinds AND any required construction field is missing, throw `new Error("createInitialUnitState: <unitType> unit '<unitId>' missing required field(s): <list>")`.
+  - Required fields per kind documented inline (cross-reference design.md § "Decision: Init-time discriminated assertion").
+  - Acceptance: a missing field produces a thrown error whose message contains the unit id AND the missing field name.
+  - QA: see test in §8.1.
+
+## 4. Projection adapter: unify the two `unitStateToToken` copies
+
+- [ ] 4.1 Create `src/lib/gameplay/unitStateToToken.ts` containing the unified adapter using the verbatim sketch from design.md § "Projection adapter sketch".
+  - Acceptance: file exports `unitStateToToken` and `IFogProjection`; narrows on `combatState.kind`; honours `isHidden` early-return.
+  - QA: `npx tsc --noEmit` clean; the file imports cleanly with no circular-dependency warnings.
+
+- [ ] 4.2 Update `src/components/gameplay/GameplayLayout.tsx:181` to remove the local `unitStateToToken` definition and import from `@/lib/gameplay/unitStateToToken`.
+  - At call-site (`GameplayLayout.tsx:429`), compute `isHidden` from the existing fog branch (the case where neither owned nor `canPlayerSeeUnit` is true) and pass it through as the new last argument.
+  - Acceptance: no behaviour change for visible units; hidden enemies now have per-type fields stripped from their tokens.
+  - QA: `npx tsc --noEmit` clean; `npm test -- GameplayLayout` clean.
+
+- [ ] 4.3 Update `src/components/gameplay/SpectatorViewPanels.tsx:19` to remove the local `unitStateToToken` definition and import from `@/lib/gameplay/unitStateToToken`.
+  - Spectator view has no fog branch — pass `isHidden = false` (omit, default).
+  - Acceptance: spectator-view tokens render identically to pre-change for any unit that has `combatState` seeded.
+  - QA: `npm test -- SpectatorViewPanels` clean.
+
+## 5. Remove the four token-component default fallbacks
+
+- [ ] 5.1 `src/components/gameplay/UnitToken/AerospaceToken.tsx:45` — replace `token.altitude ?? 1` with `token.altitude` and `token.velocity ?? 0` with `token.velocity ?? 0` (keep velocity fallback temporarily; TODO marker stays, comment retargeted to "movement slice 2").
+  - Remove the `// TODO: remove default when add-aerospace-combat-behavior wires altitude field.` line; replace with a comment referencing the wired source: `// altitude is wired from IAerospaceCombatState.altitude via the unitStateToToken adapter.`
+  - Acceptance: source no longer contains `altitude ?? 1`; component renders when given concrete altitude; `velocity ?? 0` survives with new TODO pointing at "movement slice 2".
+  - QA: visual snapshot matches pre-change for `altitude=1` fixture.
+
+- [ ] 5.2 `src/components/gameplay/UnitToken/InfantryToken.tsx:83` — replace `token.infantryCount ?? 28` with `token.infantryCount`. Also drop `token.platoonCount ?? 1` to `token.platoonCount`.
+  - Acceptance: source no longer contains `infantryCount ?? 28` or `platoonCount ?? 1`; component renders when given concrete trooper count.
+  - QA: visual snapshot matches for `infantryCount=28, platoonCount=1` fixture.
+
+- [ ] 5.3 `src/components/gameplay/UnitToken/BattleArmorToken.tsx:75` — replace `Math.max(1, Math.min(6, token.trooperCount ?? 4))` with `Math.max(1, Math.min(6, token.trooperCount))`.
+  - Acceptance: source no longer contains `trooperCount ?? 4`; component renders when given concrete trooper count in [1,6].
+  - QA: visual snapshot matches for `trooperCount=4` fixture.
+
+- [ ] 5.4 `src/components/gameplay/UnitToken/ProtoMechToken.tsx:60-62` — replace `token.protoCount ?? 5`, `token.isGlider ?? false`, `token.hasMainGun ?? false` with the bare prop reads.
+  - Acceptance: source no longer contains any `?? <default>` for those three fields; component renders when given concrete values.
+  - QA: visual snapshot matches for `protoCount=5, isGlider=false, hasMainGun=false` fixture.
+
+## 6. Fog-of-war redaction wiring
+
+- [ ] 6.1 In `src/lib/gameplay/unitStateToToken.ts` (created in 4.1), the `isHidden` early-return is the redaction implementation. No additional file change needed — but verify by code-reading that no per-type field can leak through `base` (only fog-projection fields `fogStatus` / `lastKnownPosition` / `sensorRange` may persist).
+  - Acceptance: `base` object literal contains zero per-type fields; switch arms are the only writers of per-type fields.
+
+- [ ] 6.2 In `src/components/gameplay/GameplayLayout.tsx:417-427`, derive `isHidden` from the existing fog branch:
+  - `isHidden = config.fogOfWar === true && unitInfo.side !== playerSide && !canPlayerSeeUnit(localFogPlayerId, unitId, visibilityState)`
+  - Pass it as the new last argument to `unitStateToToken(...)`.
+  - Acceptance: an enemy infantry unit with `combatState.kind === 'platoon'` and `survivingTroopers === 22`, hidden by fog, projects to a token with `infantryCount === undefined`.
+  - QA: see test in §8.4.
+
+## 7. (Reserved — was a duplicate of §6; intentionally left blank to keep section numbering stable across reviewer copies.)
+
+## 8. Tests
+
+- [ ] 8.1 New: `src/utils/gameplay/gameState/__tests__/initialization.combatState.test.ts`
+  - Cases: aerospace seeding produces `kind: 'aero'`; infantry seeding produces `kind: 'platoon'`; protomech (Biped + Glider + Quad) seeding produces `kind: 'proto'` with correct location maps; battle armor seeding produces `kind: 'squad'` with correct trooper count; mech and vehicle units leave `combatState` undefined.
+  - Cases: missing-input assertion throws with unit id + field name in the error message for each per-type kind.
+  - Acceptance: all cases green; uses real factories (no mocks).
+  - QA: `npm test -- initialization.combatState` clean.
+
+- [ ] 8.2 New: `src/lib/gameplay/__tests__/unitStateToToken.test.ts`
+  - Cases: aerospace projection (altitude wired; velocity undefined); infantry projection (`infantryCount` from `survivingTroopers`); battle armor projection (`trooperCount` from `getSurvivingTroopers`); protomech projection (`isGlider` reflects `chassisType === ProtoChassis.GLIDER`, `hasMainGun` mirrors); mech path returns no per-type fields.
+  - Cases: `isHidden=true` strips all per-type fields from the returned token; `fogStatus` / `lastKnownPosition` / `sensorRange` survive.
+  - Acceptance: all cases green; ≥ 1 case per discriminant kind plus the redaction case.
+  - QA: `npm test -- unitStateToToken` clean.
+
+- [ ] 8.3 Update existing tests that build `IUnitGameState` for non-mech types so they include the new `combatState` slot OR explicitly use `unitType: 'BATTLEMECH'` for the stubs. Surface candidates (verify scope during execution):
+  - `src/utils/gameplay/__tests__/gameState.test.ts`
+  - `src/utils/gameplay/__tests__/damagePipeline.test.ts`
+  - `src/utils/gameplay/__tests__/unitStateExtension.test.ts`
+  - Any other test under `src/**/__tests__/` that constructs `IUnitGameState` for an aerospace / proto / infantry / BA unit (`grep -r "IUnitGameState" src/**/__tests__/`).
+  - Acceptance: all updated tests pass; no test relies on the removed token-component defaults.
+  - QA: `npm test` full suite clean.
+
+- [ ] 8.4 Update Storybook stories that exercise the four token components so each story passes a concrete value for the per-type fields (matching the prior defaults to keep visuals stable):
+  - `src/components/gameplay/UnitToken/AerospaceToken.stories.tsx` (verify path) — set `altitude: 1`, leave `velocity` undefined.
+  - `src/components/gameplay/UnitToken/InfantryToken.stories.tsx` — set `infantryCount: 28`, `platoonCount: 1`.
+  - `src/components/gameplay/UnitToken/BattleArmorToken.stories.tsx` — set `trooperCount: 4`.
+  - `src/components/gameplay/UnitToken/ProtoMechToken.stories.tsx` — set `protoCount: 5`, `isGlider: false`, `hasMainGun: false`.
+  - Acceptance: storybook build succeeds; renders are visually identical to pre-change.
+  - QA: `npm run storybook:build` clean.
+
+## 9. Final Verification Wave
+
+- [ ] F1 `npx tsc --noEmit` clean across all touched files.
+- [ ] F2 `npm run lint` clean; `npx oxfmt --check` clean (CI is stricter than lint-staged — see MEMORY.md "Husky Pre-Commit Gotchas").
+- [ ] F3 `npm test` full suite green (target: 22477+ tests, all green).
+- [ ] F4 `npm run validate-bv` parity report shows 0 deltas vs pre-change baseline (BV calculation untouched; this is a regression sentinel).
+- [ ] F5 `npm run storybook:build` clean; manual spot-check of the four per-type token stories shows identical rendering.
+- [ ] F6 Grep verification: `grep -rn "?? 1" src/components/gameplay/UnitToken/AerospaceToken.tsx` returns no `altitude ?? 1` match; equivalent grep for the other three components' removed defaults returns no matches.
+- [ ] F7 `omo-spec-verifier` pass: every SHALL / MUST in the three delta specs (`game-state-management`, `tactical-map-interface`, `fog-of-war`) has either an implementation site or a test referencing it.

--- a/openspec/council-decisions/2026-05-02-cluster-F-combat-behavior-wiring.md
+++ b/openspec/council-decisions/2026-05-02-cluster-F-combat-behavior-wiring.md
@@ -1,0 +1,76 @@
+# Council #1 Decision — Cluster F: Combat-Behavior Wiring TODOs
+
+**Date**: 2026-05-02
+**Variant**: Lean+ (5 Phase-2 seats + Phase 3 cross-attack)
+**Verdict**: VERIFIED (Phase 4.5 Haiku)
+**Survival Score**: 8/10
+
+## Question
+
+For 7 `// TODO: remove default when add-X-combat-behavior wires...` markers in MekStation, choose between:
+- **(a) FIX-FORWARD** — re-author 4 archived openspec changes (`add-protomech-combat-behavior`, `add-infantry-combat-behavior`, `add-battlearmor-combat-behavior`, `add-aerospace-combat-behavior`) to wire the data flow.
+- **(b) DELETE-DEFAULTS** — remove silent defaults; force callers to pass explicit values.
+
+## Decision
+
+**WIRE IT — via Oracle's `IUnitGameState.combatState?` discriminated-union slot. Ship in two sequential PRs.**
+
+### PR7 — `wire-combat-behavior-dispatch` (~1 day)
+
+1. Add `IUnitGameState.combatState?` discriminated-union slot in `src/types/gameplay/GameSessionInterfaces.ts:1397`:
+   ```ts
+   readonly combatState?:
+     | { readonly kind: 'aero'; readonly state: IAerospaceCombatState }
+     | { readonly kind: 'proto'; readonly state: IProtoMechCombatState }
+     | { readonly kind: 'platoon'; readonly state: IInfantryCombatState }
+     | { readonly kind: 'squad'; readonly state: IBattleArmorCombatState };
+   ```
+   (Verbatim match to all 4 archived spec.md files — `unit.combatState.{aero|proto|platoon|squad}`.)
+2. Seed `combatState` in `src/utils/gameplay/gameState/initialization.ts` `createInitialUnitState` using existing `create{Type}CombatState` factories.
+3. Write projection adapter in `unitStateToToken` (`src/components/gameplay/GameplayLayout.tsx:181`) that narrows on `combatState.kind` and populates per-type fields.
+4. **Unify** the two divergent `unitStateToToken` copies (`GameplayLayout.tsx:181` + `SpectatorViewPanels.tsx:19`).
+5. Remove the 4 token-component `?? <default>` defaults.
+6. Add type-discriminated assertion in init: throw if `unitType === 'aerospace' && !combatState`.
+7. Add fog redaction branch — explicitly strip `combatState` for hidden units (don't leak structure counts).
+8. Author one NEW openspec change `wire-combat-behavior-dispatch` (NOT re-author the 4 archived specs).
+
+### PR8 — discriminated-union token flip (~1.5 days)
+
+Pure type refactor of `IUnitToken` from flat-with-optionals into `IMechToken | IVehicleToken | IAerospaceToken | IBattleArmorToken | IInfantryToken | IProtoMechToken`. Type-checker drives ~36 file edits + 12 test files mechanically. Closes Momus's god-type concern.
+
+## Out of scope
+
+- **Customizer TODOs** (`BattleArmorPipGrid.tsx:52`, `InfantryPlatoonCounter.tsx:33`) — design-time customizer components with misattributed comments. Separate cleanup.
+- **Re-authoring the 4 archived specs** — they were intentionally archived with dispatch wave deferred. The missing artifact is ONE new dispatch spec, not 4 re-runs.
+- **Vehicle combat-state migration** — `IVehicleCombatState` exists in a parallel structure. Plan for 5th `kind: 'vehicle'` variant in PR9+; do not ship in this cluster.
+
+## Open questions tracked
+
+1. **`IAerospaceCombatState.altitude` field existence** — Oracle flagged unverified. PR7 must verify; if absent, add it.
+2. **`velocity` source** — genuinely missing on `IAerospaceCombatState`. Defer with TODO pointing at "movement slice 2."
+3. **Fog redaction for `combatState`** — Oracle flagged: must explicitly strip combatState for hidden units.
+
+## Phase 4.5 Verifier (VERIFIED)
+
+All 4 deciding facts confirmed:
+1. Archived spec text cites `unit.combatState.{aero|proto|platoon|squad}` verbatim ✓
+2. `IUnitGameState` (line 1307-1410) has no per-type combat slot today ✓
+3. Two divergent `unitStateToToken` copies exist (no import relationship) ✓
+4. Production today never sets `unitType` on tokens — all non-mech token rendering is dead ✓
+
+## Preserved dissent
+
+- **Hephaestus** preferred keeping `IUnitToken` flat (Survival 8/10). Oracle's Phase-3 ruling overrode by splitting into PR7 (slot) + PR8 (union flip).
+- **Momus's "Metis 20-line claim BUSTED"** — partially true; the slot prerequisite is real plumbing (~1 day, not 20 lines). Synthesis honors this.
+
+## Council seats
+
+| Seat | Position | Survival | Model |
+|---|---|---|---|
+| Hephaestus | proposer-wire (flat tokens) | 8/10 | opus |
+| Prometheus | proposer-delete (discriminated-union tokens) | 9/10 | opus |
+| Oracle | architecture (gating ruling) | n/a | opus |
+| Explore-Deep | call-graph facts | n/a | sonnet |
+| Momus | adversary | n/a | sonnet |
+| Phase-3 Oracle | cross-attack (split A/B/C → B) | n/a | opus |
+| Phase 4.5 verifier | VERIFIED | n/a | haiku |

--- a/src/components/gameplay/GameplayLayout.tsx
+++ b/src/components/gameplay/GameplayLayout.tsx
@@ -19,6 +19,7 @@ import type { InteractivePhase } from '@/stores/useGameplayStore';
 import { pixelToHex } from '@/constants/hexMap';
 import { useCameraControls } from '@/hooks/useCameraControls';
 import { useGameplayHotkeys } from '@/hooks/useGameplayHotkeys';
+import { unitStateToToken } from '@/lib/gameplay/unitStateToToken';
 import { useAnimationQueue } from '@/stores/useAnimationQueue';
 import { useGameplaySelector } from '@/stores/useGameplayStore';
 import {
@@ -27,8 +28,6 @@ import {
   IGameSession,
   IHexCoordinate,
   IPilotSpaSummary,
-  IUnitGameState,
-  IUnitToken,
   ILayoutConfig,
   IWeaponStatus,
   IMovementRangeHex,
@@ -174,43 +173,6 @@ export interface GameplayLayoutProps {
 // =============================================================================
 // Helper Functions
 // =============================================================================
-
-/**
- * Convert unit state to display token.
- */
-function unitStateToToken(
-  unitId: string,
-  state: IUnitGameState,
-  unitInfo: { name: string; side: GameSide },
-  isSelected: boolean,
-  isValidTarget: boolean,
-  isActiveTarget: boolean,
-  fogProjection: Partial<
-    Pick<IUnitToken, 'fogStatus' | 'lastKnownPosition' | 'sensorRange'>
-  > = {},
-): IUnitToken {
-  // Generate a short designation from the unit name
-  const designation = unitInfo.name
-    .split(/[\s-]+/)
-    .map((word) => word[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 4);
-
-  return {
-    unitId,
-    name: unitInfo.name,
-    side: unitInfo.side,
-    position: state.position,
-    facing: state.facing,
-    isSelected,
-    isValidTarget,
-    isActiveTarget,
-    isDestroyed: state.destroyed,
-    designation,
-    ...fogProjection,
-  };
-}
 
 const DEFAULT_FOG_SENSOR_RANGE = 10;
 
@@ -414,26 +376,36 @@ export function GameplayLayout({
         currentState.phase === GamePhase.WeaponAttack &&
         activeTargetId !== null &&
         unitId === activeTargetId;
-      const fogProjection =
-        config.fogOfWar === true
-          ? unitInfo.side === playerSide
-            ? { sensorRange: DEFAULT_FOG_SENSOR_RANGE }
-            : canPlayerSeeUnit(localFogPlayerId, unitId, visibilityState)
-              ? {}
-              : {
-                  fogStatus: 'lastKnown' as const,
-                  lastKnownPosition: state.position,
-                }
-          : {};
+      // Per `wire-combat-behavior-dispatch` task §6.2: derive `isHidden`
+      // from the existing fog branch so the unified adapter strips
+      // `combatState`-derived per-type fields for unseen enemies (no
+      // trooper / altitude / chassis-flag leakage through `lastKnown`).
+      const isFogActive = config.fogOfWar === true;
+      const isOwnedSide = unitInfo.side === playerSide;
+      const isVisibleEnemy = canPlayerSeeUnit(
+        localFogPlayerId,
+        unitId,
+        visibilityState,
+      );
+      const isHidden = isFogActive && !isOwnedSide && !isVisibleEnemy;
+      const fogProjection = isFogActive
+        ? isOwnedSide
+          ? { sensorRange: DEFAULT_FOG_SENSOR_RANGE }
+          : isVisibleEnemy
+            ? {}
+            : {
+                fogStatus: 'lastKnown' as const,
+                lastKnownPosition: state.position,
+              }
+        : {};
 
       return unitStateToToken(
         unitId,
         state,
         unitInfo,
-        isSelected,
-        isValidTarget,
-        isActiveTarget,
+        { isSelected, isValidTarget, isActiveTarget },
         fogProjection,
+        isHidden,
       );
     });
   }, [

--- a/src/components/gameplay/SpectatorViewPanels.tsx
+++ b/src/components/gameplay/SpectatorViewPanels.tsx
@@ -4,42 +4,24 @@ import React from 'react';
 import type { InteractiveSession } from '@/engine/GameEngine';
 
 import { Button } from '@/components/ui';
-import {
-  GamePhase,
-  GameSide,
-  IGameSession,
-  IUnitGameState,
-  IUnitToken,
-} from '@/types/gameplay';
+import { GamePhase, GameSide, IGameSession } from '@/types/gameplay';
 
 // =============================================================================
 // Helpers
 // =============================================================================
 
-export function unitStateToToken(
-  unitId: string,
-  state: IUnitGameState,
-  unitInfo: { name: string; side: GameSide },
-): IUnitToken {
-  const designation = unitInfo.name
-    .split(/[\s-]+/)
-    .map((word) => word[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 4);
-
-  return {
-    unitId,
-    name: unitInfo.name,
-    side: unitInfo.side,
-    position: state.position,
-    facing: state.facing,
-    isSelected: false,
-    isValidTarget: false,
-    isDestroyed: state.destroyed,
-    designation,
-  };
-}
+/**
+ * Re-export of the unified `unitStateToToken` adapter (lives in
+ * `src/lib/gameplay/unitStateToToken.ts`). Kept as a re-export so existing
+ * callers (`SpectatorView`) keep their `import { unitStateToToken } from
+ * './SpectatorViewPanels'` line working without churn.
+ *
+ * Per `wire-combat-behavior-dispatch` (Council #1 PR7), there's only one
+ * adapter implementation now — the prior local copy diverged from the
+ * GameplayLayout copy and was the immediate cause of per-type token fields
+ * never reaching the renderer in spectator view.
+ */
+export { unitStateToToken } from '@/lib/gameplay/unitStateToToken';
 
 export function speedToInterval(speed: 1 | 2 | 4): number {
   return 1200 / speed;

--- a/src/components/gameplay/UnitToken/AerospaceToken.tsx
+++ b/src/components/gameplay/UnitToken/AerospaceToken.tsx
@@ -40,9 +40,16 @@ export const AerospaceToken = React.memo(function AerospaceToken({
 }: AerospaceTokenProps): React.ReactElement {
   const isDestroyed = token.isDestroyed || eventState.destroyed;
 
-  // altitude defaults to 1 (airborne) when not yet wired from combat behavior.
-  // TODO: remove default when add-aerospace-combat-behavior wires altitude field.
-  const altitude = token.altitude ?? 1;
+  // altitude is wired from IAerospaceCombatState.altitude via the
+  // unitStateToToken adapter (per `wire-combat-behavior-dispatch`,
+  // Council #1 PR7). Fog-redacted hidden enemies arrive with
+  // `altitude === undefined` — treat as airborne (the safe non-leaking
+  // default) for the visual branch.
+  const altitude = token.altitude;
+  // velocity is intentionally NOT wired in PR7 — it belongs to the
+  // future "movement slice 2". Keep the `?? 0` fallback until then.
+  // TODO(movement slice 2): remove `?? 0` once IAerospaceCombatState
+  //   carries velocity and the unitStateToToken adapter projects it.
   const velocity = token.velocity ?? 0;
   const isLanded = altitude === 0;
 
@@ -121,7 +128,7 @@ export const AerospaceToken = React.memo(function AerospaceToken({
           dy={2}
           data-testid="altitude-badge"
         >
-          {isLanded ? 'GND' : String(altitude)}
+          {isLanded ? 'GND' : altitude === undefined ? '?' : String(altitude)}
         </text>
       </g>
 

--- a/src/components/gameplay/UnitToken/BattleArmorToken.tsx
+++ b/src/components/gameplay/UnitToken/BattleArmorToken.tsx
@@ -70,9 +70,12 @@ export const BattleArmorToken = React.memo(function BattleArmorToken({
   mountedBadge = false,
 }: BattleArmorTokenProps): React.ReactElement {
   const isDestroyed = token.isDestroyed || eventState.destroyed;
-  // Default to 4 troopers (minimum BA squad) when field not yet wired.
-  // TODO: remove default when add-battlearmor-combat-behavior wires trooperCount.
-  const count = Math.max(1, Math.min(6, token.trooperCount ?? 4));
+  // trooperCount is wired from IBattleArmorCombatState surviving troopers
+  // via the unitStateToToken adapter (per `wire-combat-behavior-dispatch`,
+  // Council #1 PR7). Fog-redacted hidden enemies arrive with
+  // `trooperCount === undefined` — fall back to the minimum (1 visible
+  // dot) so the silhouette still renders without revealing squad size.
+  const count = Math.max(1, Math.min(6, token.trooperCount ?? 1));
   const positions = trooperPositions(count);
 
   const dotColor =

--- a/src/components/gameplay/UnitToken/InfantryToken.tsx
+++ b/src/components/gameplay/UnitToken/InfantryToken.tsx
@@ -78,10 +78,14 @@ export const InfantryToken = React.memo(function InfantryToken({
   eventState,
 }: InfantryTokenProps): React.ReactElement {
   const isDestroyed = token.isDestroyed || eventState.destroyed;
-  // Default 28 troopers when field not yet wired.
-  // TODO: remove default when add-infantry-combat-behavior wires infantryCount.
-  const trooperCount = token.infantryCount ?? 28;
-  const platoonCount = token.platoonCount ?? 1;
+  // infantryCount + platoonCount are wired from
+  // IInfantryCombatState.survivingTroopers via the unitStateToToken adapter
+  // (per `wire-combat-behavior-dispatch`, Council #1 PR7). Fog-redacted
+  // hidden enemies arrive with both `undefined` — the trooper-count
+  // badge falls back to a hyphen and the stack indicator is hidden
+  // (the `platoonCount > 1` guard already handles `undefined`).
+  const trooperCount = token.infantryCount;
+  const platoonCount = token.platoonCount;
 
   let bodyColor =
     token.side === GameSide.Player
@@ -145,7 +149,7 @@ export const InfantryToken = React.memo(function InfantryToken({
           dy={2}
           data-testid="infantry-count"
         >
-          {trooperCount}
+          {trooperCount ?? '?'}
         </text>
       </g>
 
@@ -211,8 +215,10 @@ export const InfantryToken = React.memo(function InfantryToken({
         {token.designation}
       </text>
 
-      {/* Stack indicator badge "×N" when multiple platoons share the hex */}
-      {platoonCount > 1 && (
+      {/* Stack indicator badge "×N" when multiple platoons share the hex.
+          `platoonCount` is undefined for fog-redacted enemies; guard so the
+          stack indicator stays hidden in that case. */}
+      {platoonCount !== undefined && platoonCount > 1 && (
         <g
           transform={`translate(${INF_TOKEN_RADIUS + 2}, 0)`}
           data-testid="infantry-stack-indicator"

--- a/src/components/gameplay/UnitToken/ProtoMechToken.tsx
+++ b/src/components/gameplay/UnitToken/ProtoMechToken.tsx
@@ -55,11 +55,19 @@ export const ProtoMechToken = React.memo(function ProtoMechToken({
   eventState,
 }: ProtoMechTokenProps): React.ReactElement {
   const isDestroyed = token.isDestroyed || eventState.destroyed;
-  // Default to 5 (full point) when field not yet wired.
-  // TODO: remove default when add-protomech-combat-behavior wires protoCount.
-  const protoCount = Math.max(1, Math.min(5, token.protoCount ?? 5));
-  const isGlider = token.isGlider ?? false;
-  const hasMainGun = token.hasMainGun ?? false;
+  // protoCount / isGlider / hasMainGun are wired from
+  // IProtoMechCombatState via the unitStateToToken adapter (per
+  // `wire-combat-behavior-dispatch`, Council #1 PR7). Fog-redacted hidden
+  // enemies arrive with all three `undefined` — fall back to a single
+  // proto silhouette with no glider wings or main-gun barrel so the
+  // chassis variant doesn't leak through `lastKnown` projections.
+  const rawProtoCount = token.protoCount;
+  const protoCount = Math.max(
+    1,
+    Math.min(5, rawProtoCount === undefined ? 1 : rawProtoCount),
+  );
+  const isGlider = token.isGlider === true;
+  const hasMainGun = token.hasMainGun === true;
 
   let bodyColor =
     token.side === GameSide.Player

--- a/src/components/gameplay/UnitToken/__tests__/AerospaceToken.test.tsx
+++ b/src/components/gameplay/UnitToken/__tests__/AerospaceToken.test.tsx
@@ -70,12 +70,18 @@ describe('AerospaceToken altitude badge', () => {
     expect(screen.getByTestId('altitude-badge').textContent).toBe('GND');
   });
 
-  it('defaults altitude to 1 when undefined', () => {
+  it('renders "?" badge when altitude is undefined (fog-redacted hidden enemy)', () => {
+    // Per `wire-combat-behavior-dispatch` (Council #1 PR7): the prior
+    // `?? 1` default is GONE. Producers (the unified unitStateToToken
+    // adapter) supply concrete altitudes for visible units; fog-redacted
+    // hidden enemies arrive with `altitude === undefined` and the badge
+    // shows "?" so the chassis silhouette stays visible but the specific
+    // altitude band is not leaked.
     const token = makeAerospaceToken({ altitude: undefined });
     renderInSvg(
       <AerospaceToken token={token} eventState={EMPTY_EVENT_STATE} />,
     );
-    expect(screen.getByTestId('altitude-badge').textContent).toBe('1');
+    expect(screen.getByTestId('altitude-badge').textContent).toBe('?');
   });
 });
 

--- a/src/components/gameplay/UnitToken/__tests__/BattleArmorToken.test.tsx
+++ b/src/components/gameplay/UnitToken/__tests__/BattleArmorToken.test.tsx
@@ -97,12 +97,16 @@ describe('BattleArmorToken standalone cluster', () => {
     expect(countPipCircles(container)).toBe(6);
   });
 
-  it('defaults trooperCount to 4 when undefined', () => {
+  it('renders 1 trooper pip when trooperCount is undefined (fog-redacted hidden enemy)', () => {
+    // Per `wire-combat-behavior-dispatch` (Council #1 PR7): the prior
+    // `?? 4` default is GONE. Fog-redacted hidden enemies arrive with
+    // `trooperCount === undefined` — fall back to the minimum (1 visible
+    // dot) so the silhouette still renders without revealing squad size.
     const token = makeBAToken({ trooperCount: undefined });
     const { container } = renderInSvg(
       <BattleArmorToken token={token} eventState={EMPTY_EVENT_STATE} />,
     );
-    expect(countPipCircles(container)).toBe(4);
+    expect(countPipCircles(container)).toBe(1);
   });
 });
 

--- a/src/components/gameplay/UnitToken/__tests__/InfantryToken.test.tsx
+++ b/src/components/gameplay/UnitToken/__tests__/InfantryToken.test.tsx
@@ -75,10 +75,14 @@ describe('InfantryToken trooper count', () => {
     expect(screen.getByTestId('infantry-count').textContent).toBe('3');
   });
 
-  it('defaults to 28 when infantryCount is undefined', () => {
+  it('renders "?" when infantryCount is undefined (fog-redacted hidden enemy)', () => {
+    // Per `wire-combat-behavior-dispatch` (Council #1 PR7): the prior
+    // `?? 28` default is GONE. Fog-redacted hidden enemies arrive with
+    // `infantryCount === undefined` and the badge shows "?" so the
+    // platoon silhouette still renders without leaking trooper count.
     const token = makeInfantryToken({ infantryCount: undefined });
     renderInSvg(<InfantryToken token={token} eventState={EMPTY_EVENT_STATE} />);
-    expect(screen.getByTestId('infantry-count').textContent).toBe('28');
+    expect(screen.getByTestId('infantry-count').textContent).toBe('?');
   });
 });
 

--- a/src/components/gameplay/UnitToken/__tests__/ProtoMechToken.test.tsx
+++ b/src/components/gameplay/UnitToken/__tests__/ProtoMechToken.test.tsx
@@ -108,12 +108,16 @@ describe('ProtoMechToken point cluster', () => {
     expect(countPipsByTestid(container)).toBe(5);
   });
 
-  it('defaults protoCount to 5 when undefined', () => {
+  it('renders 1 proto pip when protoCount is undefined (fog-redacted hidden enemy)', () => {
+    // Per `wire-combat-behavior-dispatch` (Council #1 PR7): the prior
+    // `?? 5` default is GONE. Fog-redacted hidden enemies arrive with
+    // `protoCount === undefined` — fall back to a single proto silhouette
+    // so the chassis shows but point size is not leaked.
     const token = makeProtoToken({ protoCount: undefined });
     const { container } = renderInSvg(
       <ProtoMechToken token={token} eventState={EMPTY_EVENT_STATE} />,
     );
-    expect(countPipsByTestid(container)).toBe(5);
+    expect(countPipsByTestid(container)).toBe(1);
   });
 });
 

--- a/src/lib/gameplay/__tests__/unitStateToToken.test.ts
+++ b/src/lib/gameplay/__tests__/unitStateToToken.test.ts
@@ -1,0 +1,426 @@
+/**
+ * unitStateToToken — projection adapter tests
+ *
+ * Per `wire-combat-behavior-dispatch` (Council #1 PR7) tasks §4.1 / §6.1 and
+ * the `tactical-map-interface` + `fog-of-war` delta specs. Verifies:
+ *   - Each `combatState.kind` projects the correct per-type fields with the
+ *     right `TokenUnitType` discriminator.
+ *   - Mech path (`combatState === undefined`) returns the base token with no
+ *     per-type fields populated.
+ *   - The `isHidden` early-return strips ALL `combatState`-derived per-type
+ *     fields while preserving the fog-projection layer (`fogStatus` /
+ *     `lastKnownPosition` / `sensorRange`).
+ */
+
+import {
+  Facing,
+  GameSide,
+  LockState,
+  MovementType,
+  TokenUnitType,
+  type IUnitGameState,
+} from '@/types/gameplay';
+import { InfantryArmorKit } from '@/types/unit/PersonnelInterfaces';
+import { ProtoChassis, ProtoLocation } from '@/types/unit/ProtoMechInterfaces';
+import { createAerospaceCombatState } from '@/utils/gameplay/aerospace/state';
+import { createBattleArmorCombatState } from '@/utils/gameplay/battlearmor/state';
+import { createInfantryCombatState } from '@/utils/gameplay/infantry/state';
+import { createProtoMechCombatState } from '@/utils/gameplay/protomech/state';
+
+import { unitStateToToken, type IFogProjection } from '../unitStateToToken';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const POSITION = { q: 1, r: 2 };
+const UNIT_INFO = { name: 'Test Unit', side: GameSide.Player };
+
+function baseState(overrides: Partial<IUnitGameState> = {}): IUnitGameState {
+  return {
+    id: 'unit-1',
+    side: GameSide.Player,
+    position: POSITION,
+    facing: Facing.North,
+    heat: 0,
+    movementThisTurn: MovementType.Stationary,
+    hexesMovedThisTurn: 0,
+    armor: {},
+    structure: {},
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {},
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// Mech (legacy) path
+// =============================================================================
+
+describe('unitStateToToken — mech / no-envelope path', () => {
+  it('returns base token with no per-type fields when combatState is undefined', () => {
+    const token = unitStateToToken('u1', baseState(), UNIT_INFO);
+    expect(token.unitId).toBe('u1');
+    expect(token.position).toEqual(POSITION);
+    expect(token.altitude).toBeUndefined();
+    expect(token.infantryCount).toBeUndefined();
+    expect(token.trooperCount).toBeUndefined();
+    expect(token.protoCount).toBeUndefined();
+    expect(token.unitType).toBeUndefined();
+  });
+
+  it('derives a designation from the unit name (split on space + hyphen, max 4, uppercase)', () => {
+    // 'Atlas AS7-D' splits on `[\s-]+` → ['Atlas', 'AS7', 'D'] → 'AAD'.
+    const token = unitStateToToken('u1', baseState(), {
+      name: 'Atlas AS7-D',
+      side: GameSide.Player,
+    });
+    expect(token.designation).toBe('AAD');
+  });
+
+  it('passes through fog-projection fields untouched', () => {
+    const fog: IFogProjection = {
+      fogStatus: 'lastKnown',
+      lastKnownPosition: { q: 9, r: 9 },
+      sensorRange: 5,
+    };
+    const token = unitStateToToken('u1', baseState(), UNIT_INFO, {}, fog);
+    expect(token.fogStatus).toBe('lastKnown');
+    expect(token.lastKnownPosition).toEqual({ q: 9, r: 9 });
+    expect(token.sensorRange).toBe(5);
+  });
+});
+
+// =============================================================================
+// Aerospace projection
+// =============================================================================
+
+describe('unitStateToToken — aerospace projection', () => {
+  function aeroState(altitude: number): IUnitGameState {
+    return baseState({
+      combatState: {
+        kind: 'aero',
+        state: createAerospaceCombatState({
+          maxSI: 8,
+          armorByArc: { nose: 20, leftWing: 15, rightWing: 15, aft: 10 },
+          heatSinks: 12,
+          fuelPoints: 400,
+          safeThrust: 5,
+          maxThrust: 8,
+          altitude,
+        }),
+      },
+    });
+  }
+
+  it("populates altitude and unitType=Aerospace when kind === 'aero'", () => {
+    const token = unitStateToToken('u1', aeroState(3), UNIT_INFO);
+    expect(token.unitType).toBe(TokenUnitType.Aerospace);
+    expect(token.altitude).toBe(3);
+  });
+
+  it('honours altitude=0 (landed)', () => {
+    const token = unitStateToToken('u1', aeroState(0), UNIT_INFO);
+    expect(token.altitude).toBe(0);
+  });
+
+  it('leaves velocity undefined (movement slice 2 future work)', () => {
+    const token = unitStateToToken('u1', aeroState(1), UNIT_INFO);
+    expect(token.velocity).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Infantry projection
+// =============================================================================
+
+describe('unitStateToToken — infantry projection', () => {
+  function platoonState(survivingTroopers: number): IUnitGameState {
+    const state = createInfantryCombatState({
+      startingTroopers: 28,
+      armorKit: InfantryArmorKit.STANDARD,
+      hasAntiMechTraining: true,
+    });
+    return baseState({
+      combatState: {
+        kind: 'platoon',
+        state: { ...state, survivingTroopers },
+      },
+    });
+  }
+
+  it("populates infantryCount + platoonCount + unitType=Infantry when kind === 'platoon'", () => {
+    const token = unitStateToToken('u1', platoonState(22), UNIT_INFO);
+    expect(token.unitType).toBe(TokenUnitType.Infantry);
+    expect(token.infantryCount).toBe(22);
+    expect(token.platoonCount).toBe(1);
+  });
+});
+
+// =============================================================================
+// Battle armor projection
+// =============================================================================
+
+describe('unitStateToToken — battle armor projection', () => {
+  function squadState(survivors: number): IUnitGameState {
+    const state = createBattleArmorCombatState({
+      unitId: 'u1',
+      squadSize: 5,
+      armorPointsPerTrooper: 8,
+    });
+    // Kill troopers down to `survivors` while keeping the rest fully alive.
+    const killCount = Math.max(0, state.troopers.length - survivors);
+    const troopers = state.troopers.map((t, i) =>
+      i < killCount ? { ...t, alive: false, armorRemaining: 0 } : t,
+    );
+    return baseState({
+      combatState: { kind: 'squad', state: { ...state, troopers } },
+    });
+  }
+
+  it("populates trooperCount + unitType=BattleArmor when kind === 'squad'", () => {
+    const token = unitStateToToken('u1', squadState(3), UNIT_INFO);
+    expect(token.unitType).toBe(TokenUnitType.BattleArmor);
+    expect(token.trooperCount).toBe(3);
+  });
+});
+
+// =============================================================================
+// Protomech projection
+// =============================================================================
+
+describe('unitStateToToken — protomech projection', () => {
+  function protoState(
+    chassisType: ProtoChassis,
+    hasMainGun: boolean,
+  ): IUnitGameState {
+    return baseState({
+      combatState: {
+        kind: 'proto',
+        state: createProtoMechCombatState({
+          unitId: 'u1',
+          chassisType,
+          hasMainGun,
+          armorByLocation: {
+            [ProtoLocation.HEAD]: 2,
+            [ProtoLocation.TORSO]: 6,
+          },
+          structureByLocation: {
+            [ProtoLocation.HEAD]: 1,
+            [ProtoLocation.TORSO]: 5,
+          },
+        }),
+      },
+    });
+  }
+
+  it('populates protoCount=1 + isGlider + hasMainGun for GLIDER chassis with main gun', () => {
+    const token = unitStateToToken(
+      'u1',
+      protoState(ProtoChassis.GLIDER, true),
+      UNIT_INFO,
+    );
+    expect(token.unitType).toBe(TokenUnitType.ProtoMech);
+    expect(token.protoCount).toBe(1);
+    expect(token.isGlider).toBe(true);
+    expect(token.hasMainGun).toBe(true);
+  });
+
+  it('isGlider=false for BIPED chassis', () => {
+    const token = unitStateToToken(
+      'u1',
+      protoState(ProtoChassis.BIPED, false),
+      UNIT_INFO,
+    );
+    expect(token.isGlider).toBe(false);
+    expect(token.hasMainGun).toBe(false);
+  });
+});
+
+// =============================================================================
+// Selection / target flags
+// =============================================================================
+
+describe('unitStateToToken — selection / target flags', () => {
+  it('honours isSelected / isValidTarget / isActiveTarget flags', () => {
+    const token = unitStateToToken('u1', baseState(), UNIT_INFO, {
+      isSelected: true,
+      isValidTarget: true,
+      isActiveTarget: true,
+    });
+    expect(token.isSelected).toBe(true);
+    expect(token.isValidTarget).toBe(true);
+    expect(token.isActiveTarget).toBe(true);
+  });
+
+  it('defaults all flags to false when omitted', () => {
+    const token = unitStateToToken('u1', baseState(), UNIT_INFO);
+    expect(token.isSelected).toBe(false);
+    expect(token.isValidTarget).toBe(false);
+    expect(token.isActiveTarget).toBe(false);
+  });
+});
+
+// =============================================================================
+// Fog redaction
+// =============================================================================
+
+describe('unitStateToToken — fog redaction (isHidden=true)', () => {
+  const FOG_PROJECTION: IFogProjection = {
+    fogStatus: 'lastKnown',
+    lastKnownPosition: { q: 4, r: 4 },
+  };
+
+  it('redacts infantry per-type fields for hidden enemy platoon', () => {
+    const state = baseState({
+      combatState: {
+        kind: 'platoon',
+        state: {
+          ...createInfantryCombatState({
+            startingTroopers: 28,
+            armorKit: InfantryArmorKit.STANDARD,
+            hasAntiMechTraining: true,
+          }),
+          survivingTroopers: 22,
+        },
+      },
+    });
+    const token = unitStateToToken(
+      'u1',
+      state,
+      UNIT_INFO,
+      {},
+      FOG_PROJECTION,
+      true,
+    );
+    expect(token.infantryCount).toBeUndefined();
+    expect(token.platoonCount).toBeUndefined();
+    expect(token.unitType).toBeUndefined();
+    // Fog-projection fields survive redaction.
+    expect(token.fogStatus).toBe('lastKnown');
+    expect(token.lastKnownPosition).toEqual({ q: 4, r: 4 });
+  });
+
+  it('redacts altitude (and velocity) for hidden enemy aerospace', () => {
+    const state = baseState({
+      combatState: {
+        kind: 'aero',
+        state: createAerospaceCombatState({
+          maxSI: 8,
+          armorByArc: { nose: 20, leftWing: 15, rightWing: 15, aft: 10 },
+          heatSinks: 12,
+          fuelPoints: 400,
+          safeThrust: 5,
+          maxThrust: 8,
+          altitude: 5,
+        }),
+      },
+    });
+    const token = unitStateToToken(
+      'u1',
+      state,
+      UNIT_INFO,
+      {},
+      FOG_PROJECTION,
+      true,
+    );
+    expect(token.altitude).toBeUndefined();
+    expect(token.velocity).toBeUndefined();
+  });
+
+  it('redacts trooperCount for hidden enemy battle armor', () => {
+    const state = baseState({
+      combatState: {
+        kind: 'squad',
+        state: createBattleArmorCombatState({
+          unitId: 'u1',
+          squadSize: 5,
+          armorPointsPerTrooper: 8,
+        }),
+      },
+    });
+    const token = unitStateToToken(
+      'u1',
+      state,
+      UNIT_INFO,
+      {},
+      FOG_PROJECTION,
+      true,
+    );
+    expect(token.trooperCount).toBeUndefined();
+  });
+
+  it('redacts protoCount / isGlider / hasMainGun for hidden enemy proto', () => {
+    const state = baseState({
+      combatState: {
+        kind: 'proto',
+        state: createProtoMechCombatState({
+          unitId: 'u1',
+          chassisType: ProtoChassis.GLIDER,
+          hasMainGun: true,
+          armorByLocation: { [ProtoLocation.TORSO]: 6 },
+          structureByLocation: { [ProtoLocation.TORSO]: 5 },
+        }),
+      },
+    });
+    const token = unitStateToToken(
+      'u1',
+      state,
+      UNIT_INFO,
+      {},
+      FOG_PROJECTION,
+      true,
+    );
+    expect(token.protoCount).toBeUndefined();
+    expect(token.isGlider).toBeUndefined();
+    expect(token.hasMainGun).toBeUndefined();
+  });
+
+  it('does NOT redact when isHidden=false (visible enemies render normally)', () => {
+    const state = baseState({
+      combatState: {
+        kind: 'platoon',
+        state: {
+          ...createInfantryCombatState({
+            startingTroopers: 28,
+            armorKit: InfantryArmorKit.STANDARD,
+            hasAntiMechTraining: true,
+          }),
+          survivingTroopers: 22,
+        },
+      },
+    });
+    const token = unitStateToToken(
+      'u1',
+      state,
+      UNIT_INFO,
+      {},
+      FOG_PROJECTION,
+      false,
+    );
+    expect(token.infantryCount).toBe(22);
+  });
+
+  it('does NOT redact when caller omits isHidden (defaults to false)', () => {
+    const state = baseState({
+      combatState: {
+        kind: 'platoon',
+        state: {
+          ...createInfantryCombatState({
+            startingTroopers: 28,
+            armorKit: InfantryArmorKit.STANDARD,
+            hasAntiMechTraining: true,
+          }),
+          survivingTroopers: 22,
+        },
+      },
+    });
+    const token = unitStateToToken('u1', state, UNIT_INFO);
+    expect(token.infantryCount).toBe(22);
+  });
+});

--- a/src/lib/gameplay/unitStateToToken.ts
+++ b/src/lib/gameplay/unitStateToToken.ts
@@ -1,0 +1,140 @@
+/**
+ * Unified `unitStateToToken` projection adapter.
+ *
+ * Per `wire-combat-behavior-dispatch` (Council #1 PR7), this is the single
+ * shared call-site that converts `IUnitGameState` into `IUnitToken` for
+ * tactical-map and spectator-view rendering. It narrows on
+ * `IUnitGameState.combatState.kind` and projects per-type fields
+ * (`altitude`, `infantryCount`, `trooperCount`, `protoCount`, `isGlider`,
+ * `hasMainGun`) into the token. The fog-of-war redaction branch lives here
+ * as a single early-return so per-type fields never leak through `lastKnown`
+ * projections to a hidden enemy.
+ *
+ * Replaces the two divergent inline copies that used to live in
+ * `GameplayLayout.tsx` (line 181) and `SpectatorViewPanels.tsx` (line 19).
+ *
+ * @spec openspec/changes/wire-combat-behavior-dispatch/specs/tactical-map-interface/spec.md
+ * @spec openspec/changes/wire-combat-behavior-dispatch/specs/fog-of-war/spec.md
+ */
+
+import type { GameSide, IUnitGameState, IUnitToken } from '@/types/gameplay';
+
+import { TokenUnitType } from '@/types/gameplay';
+import { ProtoChassis } from '@/types/unit/ProtoMechInterfaces';
+import { getSurvivingTroopers as baSurvivingTroopers } from '@/utils/gameplay/battlearmor/state';
+
+/**
+ * Subset of `IUnitToken` fog-projection fields that callers may layer onto a
+ * token. These survive redaction (they ARE the redaction signal) — only the
+ * per-type combat fields are stripped when `isHidden` is true.
+ */
+export type IFogProjection = Partial<
+  Pick<IUnitToken, 'fogStatus' | 'lastKnownPosition' | 'sensorRange'>
+>;
+
+/**
+ * Per-call selection / targeting flags derived from the caller's interaction
+ * state. All optional so simple consumers (spectator view) can pass `{}`.
+ */
+export interface IUnitStateToTokenFlags {
+  readonly isSelected?: boolean;
+  readonly isValidTarget?: boolean;
+  readonly isActiveTarget?: boolean;
+}
+
+/**
+ * Convert an `IUnitGameState` into the `IUnitToken` consumed by the tactical
+ * map's per-type token components.
+ *
+ * @param unitId    Stable unit id (used as token identity).
+ * @param state     The current per-unit state (carries `combatState` envelope).
+ * @param unitInfo  Display name + side, sourced from the session's `IGameUnit`.
+ * @param flags     Selection / target highlight flags. Defaults to all-false.
+ * @param fog       Fog-projection layer (`fogStatus`, `lastKnownPosition`,
+ *                  `sensorRange`). Defaults to `{}`.
+ * @param isHidden  When `true`, the fog branch redacts `combatState`-derived
+ *                  per-type fields. Per-type renderers receive `undefined`
+ *                  for `altitude`, `infantryCount`, `trooperCount`,
+ *                  `protoCount`, `isGlider`, `hasMainGun`. Required so a
+ *                  hidden enemy never leaks structure / trooper counts
+ *                  through `lastKnown` snapshots.
+ */
+export function unitStateToToken(
+  unitId: string,
+  state: IUnitGameState,
+  unitInfo: { readonly name: string; readonly side: GameSide },
+  flags: IUnitStateToTokenFlags = {},
+  fog: IFogProjection = {},
+  isHidden = false,
+): IUnitToken {
+  // Generate a short designation from the unit name (first letters of each
+  // word, uppercased, max 4 chars) — matches the prior inline copies so token
+  // captions stay visually identical.
+  const designation = unitInfo.name
+    .split(/[\s-]+/)
+    .map((word) => word[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 4);
+
+  const base: IUnitToken = {
+    unitId,
+    name: unitInfo.name,
+    side: unitInfo.side,
+    position: state.position,
+    facing: state.facing,
+    isSelected: flags.isSelected ?? false,
+    isValidTarget: flags.isValidTarget ?? false,
+    isActiveTarget: flags.isActiveTarget ?? false,
+    isDestroyed: state.destroyed,
+    designation,
+    ...fog,
+  };
+
+  // Fog redaction: hidden enemies expose ONLY the fog-projection fields
+  // (lastKnown position / sensor ring). Per-type combat-derived fields are
+  // never populated, so trooper counts / altitude / chassis flags can't leak.
+  if (isHidden) {
+    return base;
+  }
+
+  const cs = state.combatState;
+  if (cs === undefined) {
+    // Mech / vehicle path — no per-type envelope, no per-type fields.
+    return base;
+  }
+
+  switch (cs.kind) {
+    case 'aero':
+      return {
+        ...base,
+        unitType: TokenUnitType.Aerospace,
+        altitude: cs.state.altitude,
+        // velocity intentionally omitted: TODO movement slice 2.
+      };
+    case 'platoon':
+      return {
+        ...base,
+        unitType: TokenUnitType.Infantry,
+        infantryCount: cs.state.survivingTroopers,
+        platoonCount: 1,
+      };
+    case 'squad':
+      return {
+        ...base,
+        unitType: TokenUnitType.BattleArmor,
+        trooperCount: baSurvivingTroopers(cs.state),
+      };
+    case 'proto':
+      return {
+        ...base,
+        unitType: TokenUnitType.ProtoMech,
+        // Single proto per IUnitGameState; the "point" abstraction (1-5
+        // protos sharing a hex stack) is layered higher up. Surviving-proto
+        // count is derived from the destroyed flag — destroyed === 0 alive.
+        protoCount: cs.state.destroyed ? 0 : 1,
+        isGlider: cs.state.chassisType === ProtoChassis.GLIDER,
+        hasMainGun: cs.state.hasMainGun,
+      };
+  }
+}

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -5,9 +5,14 @@
  * @spec openspec/changes/add-game-session-core/specs/game-session-core/spec.md
  */
 
+import type { IAerospaceCombatState } from '@/utils/gameplay/aerospace/state';
+import type { IInfantryCombatState } from '@/utils/gameplay/infantry/state';
+import type { IProtoMechCombatState } from '@/utils/gameplay/protomech/state';
+
 import { ActuatorType } from '@/types/construction/MechConfigurationSystem';
 
 import type { IAmmoConstructionInit } from './AmmoTypes';
+import type { IBattleArmorCombatState } from './BattleArmorCombatInterfaces';
 import type {
   ILegAttackPayload,
   IMimeticBonusPayload,
@@ -1225,6 +1230,53 @@ export interface IGameUnit {
    * data per `wire-ammo-consumption`.
    */
   readonly ammoConstruction?: readonly IAmmoConstructionInit[];
+  /**
+   * Construction-side `UnitType` (BattleMech / Aerospace / Infantry / Battle
+   * Armor / ProtoMech / Vehicle / etc.). Per `wire-combat-behavior-dispatch`
+   * (Council #1 PR7), `createInitialUnitState` branches on this value to
+   * seed `IUnitGameState.combatState` via the matching per-type factory.
+   *
+   * Optional for backward compatibility: legacy callers (existing fixtures,
+   * tests, lobby builders that haven't been updated) leave it `undefined`,
+   * which behaves exactly like the prior mech-only path (no `combatState`
+   * envelope, mech tokens render). New callers wiring aerospace / proto /
+   * infantry / BA units MUST set both `unitType` AND the matching per-type
+   * construction inputs below — the init-time assertion will throw otherwise.
+   */
+  readonly unitType?: import('@/types/unit/BattleMechInterfaces').UnitType;
+  /**
+   * Per-type construction inputs consumed by `createInitialUnitState` to
+   * build `combatState` via `create{Type}CombatState` factories. Each block
+   * is OPTIONAL at the type level so the legacy mech-only call path stays
+   * compile-clean; the init-time assertion enforces presence at runtime
+   * when `unitType` is one of the four supported per-type discriminants.
+   */
+  readonly aerospaceInit?: {
+    readonly maxSI: number;
+    readonly armorByArc: import('@/utils/gameplay/aerospace/state').IAerospaceArcArmor;
+    readonly heatSinks: number;
+    readonly fuelPoints: number;
+    readonly safeThrust: number;
+    readonly maxThrust: number;
+    /** Initial altitude band; defaults to `1` (airborne) when omitted. */
+    readonly altitude?: number;
+  };
+  readonly infantryInit?: import('@/types/unit/PersonnelInterfaces').IInfantry;
+  readonly protoMechInit?: {
+    readonly chassisType: import('@/types/unit/ProtoMechInterfaces').ProtoChassis;
+    readonly hasMainGun: boolean;
+    readonly armorByLocation: import('@/utils/gameplay/protomech/state').ProtoLocationSlotMap;
+    readonly structureByLocation: import('@/utils/gameplay/protomech/state').ProtoLocationSlotMap;
+    readonly altitude?: number;
+  };
+  readonly battleArmorInit?: {
+    readonly squadSize: number;
+    readonly armorPointsPerTrooper: number;
+    readonly stealthKind?: import('./BattleArmorCombatInterfaces').BattleArmorStealthKind;
+    readonly hasMagneticClamp?: boolean;
+    readonly hasVibroClaws?: boolean;
+    readonly vibroClawCount?: number;
+  };
 }
 
 // `IAmmoConstructionInit` is imported at the top of this module (so
@@ -1394,6 +1446,26 @@ export interface IUnitGameState {
    * summaries can list withdrawn units separately from combat losses.
    */
   readonly hasRetreated?: boolean;
+  /**
+   * Per-type combat-behavior envelope.
+   *
+   * Per Council #1 (`openspec/council-decisions/2026-05-02-cluster-F-combat-
+   * behavior-wiring.md`) and openspec change `wire-combat-behavior-dispatch`,
+   * aerospace / protomech / infantry / BA units carry their per-type combat
+   * struct here so renderers and fog redaction read a single channel. Mech
+   * and vehicle units leave this `undefined` until the `kind: 'vehicle'`
+   * variant lands in PR9+.
+   *
+   * Producers: `createInitialUnitState` (initial seed); per-type reducers
+   * (combat events update the inner `state` and replace the envelope).
+   *
+   * Consumers: `unitStateToToken` (projection); fog-of-war redaction.
+   */
+  readonly combatState?:
+    | { readonly kind: 'aero'; readonly state: IAerospaceCombatState }
+    | { readonly kind: 'proto'; readonly state: IProtoMechCombatState }
+    | { readonly kind: 'platoon'; readonly state: IInfantryCombatState }
+    | { readonly kind: 'squad'; readonly state: IBattleArmorCombatState };
 }
 
 /**

--- a/src/types/gameplay/GameplayUIInterfaces.ts
+++ b/src/types/gameplay/GameplayUIInterfaces.ts
@@ -173,13 +173,21 @@ export interface IUnitToken {
   // Aerospace-specific fields (present when unitType === TokenUnitType.Aerospace)
   // -------------------------------------------------------------------------
   /**
-   * Current altitude level (0–10). 0 = landed.
-   * TODO: wire from aerospace combat-behavior proposal when landed.
+   * Current altitude level (0–10). 0 = landed. Wired from
+   * `IAerospaceCombatState.altitude` via the unified `unitStateToToken`
+   * adapter (`src/lib/gameplay/unitStateToToken.ts`). Per
+   * `wire-combat-behavior-dispatch` (Council #1 PR7). Optional at the
+   * type level so fog-redacted hidden enemies and legacy mech tokens
+   * can omit it.
    */
   readonly altitude?: number;
   /**
    * Current velocity in thrust points.
-   * TODO: wire from aerospace combat-behavior proposal.
+   * TODO(movement slice 2): velocity belongs to a future movement-tick
+   * slice and is intentionally NOT wired by `wire-combat-behavior-dispatch`
+   * (Council #1 PR7). When the aerospace movement slice lands, add a
+   * `velocity` field to `IAerospaceCombatState` and project it through
+   * the `unitStateToToken` adapter alongside `altitude`.
    */
   readonly velocity?: number;
 

--- a/src/utils/gameplay/aerospace/state.ts
+++ b/src/utils/gameplay/aerospace/state.ts
@@ -98,6 +98,16 @@ export interface IAerospaceCombatState {
   readonly baseSafeThrust: number;
   /** Construction-time max thrust. */
   readonly baseMaxThrust: number;
+  /**
+   * Current altitude band (0 = landed; positive integers = airborne in
+   * standard altitude bands per BattleTech aerospace rules). Per
+   * `wire-combat-behavior-dispatch` (Council #1), this field is the canonical
+   * altitude source consumed by `unitStateToToken`. The factory defaults to
+   * `1` (airborne) — matching the prior render-time fallback in
+   * `AerospaceToken`. `velocity` is intentionally absent in PR7 and will be
+   * wired when "movement slice 2" lands.
+   */
+  altitude: number;
 }
 
 // ============================================================================
@@ -175,6 +185,11 @@ export function createAerospaceCombatState(params: {
   readonly fuelPoints: number;
   readonly safeThrust: number;
   readonly maxThrust: number;
+  /**
+   * Initial altitude band. Defaults to `1` (airborne) — matches the prior
+   * `AerospaceToken` render fallback. Pass `0` to spawn the unit landed.
+   */
+  readonly altitude?: number;
 }): IAerospaceCombatState {
   return {
     maxSI: params.maxSI,
@@ -192,6 +207,7 @@ export function createAerospaceCombatState(params: {
     avionicsDamaged: false,
     crewStunned: false,
     destroyed: false,
+    altitude: params.altitude ?? 1,
     baseSafeThrust: params.safeThrust,
     baseMaxThrust: params.maxThrust,
   };

--- a/src/utils/gameplay/gameState/__tests__/initialization.combatState.test.ts
+++ b/src/utils/gameplay/gameState/__tests__/initialization.combatState.test.ts
@@ -1,0 +1,399 @@
+/**
+ * createInitialUnitState — combatState seeding tests
+ *
+ * Per `wire-combat-behavior-dispatch` (Council #1 PR7) tasks §3.1 / §3.2 and
+ * `game-state-management` delta spec (Combat-State Seeding at Initialization
+ * + Discriminated Initialization Assertion). Verifies:
+ *   - Each of the four per-type discriminants seeds the matching `combatState`
+ *     envelope using the real factory (no mocks).
+ *   - Mech / vehicle / capital paths leave `combatState === undefined`.
+ *   - Missing required fields throw an Error whose message names the unit id
+ *     and the missing field(s).
+ */
+
+import type { IInfantry } from '@/types/unit/PersonnelInterfaces';
+
+import {
+  Facing,
+  GameSide,
+  type IGameUnit,
+  type IUnitGameState,
+} from '@/types/gameplay';
+import { SquadMotionType } from '@/types/unit/BaseUnitInterfaces';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+import {
+  InfantryArmorKit,
+  InfantrySpecialization,
+} from '@/types/unit/PersonnelInterfaces';
+import { ProtoChassis, ProtoLocation } from '@/types/unit/ProtoMechInterfaces';
+
+import { createInitialUnitState } from '../initialization';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const POSITION = { q: 0, r: 0 } as const;
+
+function baseGameUnit(overrides: Partial<IGameUnit> = {}): IGameUnit {
+  return {
+    id: 'unit-1',
+    name: 'Test Unit',
+    side: GameSide.Player,
+    unitRef: 'test-ref',
+    pilotRef: 'pilot-1',
+    gunnery: 4,
+    piloting: 5,
+    ...overrides,
+  };
+}
+
+/** Minimal `IInfantry` shape sufficient for `createInfantryCombatStateFromUnit`. */
+function makeInfantryUnit(): IInfantry {
+  // The factory only reads `platoonStrength`, `armorKit`, `hasAntiMechTraining`,
+  // and the first `fieldGuns[0]`. The rest of `IInfantry` is filled in with
+  // sensible defaults to satisfy the type without exercising the calculator.
+  return {
+    unitType: UnitType.INFANTRY,
+    tonnage: 3,
+    weightClass: 'Light',
+    metadata: {
+      chassis: 'Test Platoon',
+      model: 'TST-1',
+      era: 'Succession Wars',
+      year: 3025,
+      rulesLevel: 'Standard',
+    },
+    totalWeight: 3,
+    remainingTonnage: 0,
+    isValid: true,
+    validationErrors: [],
+    techBase: 'IS',
+    introductionYear: 3025,
+    extinctionYear: 0,
+    cBills: 0,
+    bv: 0,
+    crew: 28,
+    squadSize: 7,
+    numberOfSquads: 4,
+    platoonStrength: 28,
+    motionType: SquadMotionType.FOOT,
+    primaryWeapon: 'SRM Launcher',
+    secondaryWeaponCount: 0,
+    armorKit: InfantryArmorKit.STANDARD,
+    specialization: InfantrySpecialization.NONE,
+    fieldGuns: [],
+    hasAntiMechTraining: true,
+    isAugmented: false,
+    canSwarm: true,
+    canLegAttack: true,
+  } as unknown as IInfantry;
+}
+
+const SAMPLE_AERO_INIT = {
+  maxSI: 8,
+  armorByArc: { nose: 20, leftWing: 15, rightWing: 15, aft: 10 },
+  heatSinks: 12,
+  fuelPoints: 400,
+  safeThrust: 5,
+  maxThrust: 8,
+} as const;
+
+const SAMPLE_PROTO_INIT = {
+  chassisType: ProtoChassis.BIPED,
+  hasMainGun: true,
+  armorByLocation: {
+    [ProtoLocation.HEAD]: 2,
+    [ProtoLocation.TORSO]: 6,
+    [ProtoLocation.LEFT_ARM]: 2,
+    [ProtoLocation.RIGHT_ARM]: 2,
+    [ProtoLocation.LEGS]: 4,
+    [ProtoLocation.MAIN_GUN]: 2,
+  },
+  structureByLocation: {
+    [ProtoLocation.HEAD]: 1,
+    [ProtoLocation.TORSO]: 5,
+    [ProtoLocation.LEFT_ARM]: 1,
+    [ProtoLocation.RIGHT_ARM]: 1,
+    [ProtoLocation.LEGS]: 3,
+    [ProtoLocation.MAIN_GUN]: 1,
+  },
+} as const;
+
+const SAMPLE_BA_INIT = {
+  squadSize: 5,
+  armorPointsPerTrooper: 8,
+} as const;
+
+// =============================================================================
+// Mech / Vehicle / Legacy paths
+// =============================================================================
+
+describe('createInitialUnitState — mech / vehicle / legacy', () => {
+  it('leaves combatState undefined when unitType is omitted', () => {
+    const unit = baseGameUnit();
+    const state = createInitialUnitState(unit, POSITION, Facing.North);
+    expect(state.combatState).toBeUndefined();
+  });
+
+  it('leaves combatState undefined for BATTLEMECH', () => {
+    const unit = baseGameUnit({ unitType: UnitType.BATTLEMECH });
+    const state = createInitialUnitState(unit, POSITION, Facing.North);
+    expect(state.combatState).toBeUndefined();
+  });
+
+  it('leaves combatState undefined for VEHICLE (kind: vehicle is a future variant)', () => {
+    const unit = baseGameUnit({ unitType: UnitType.VEHICLE });
+    const state = createInitialUnitState(unit, POSITION, Facing.North);
+    expect(state.combatState).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Aerospace path
+// =============================================================================
+
+describe('createInitialUnitState — aerospace seeding', () => {
+  function buildAeroUnit(altitude?: number): IGameUnit {
+    return baseGameUnit({
+      id: 'aero-1',
+      unitType: UnitType.AEROSPACE,
+      aerospaceInit: { ...SAMPLE_AERO_INIT, altitude },
+    });
+  }
+
+  it("seeds combatState with kind='aero' for AEROSPACE", () => {
+    const state = createInitialUnitState(buildAeroUnit(), POSITION);
+    expect(state.combatState?.kind).toBe('aero');
+  });
+
+  it.each([
+    UnitType.AEROSPACE,
+    UnitType.CONVENTIONAL_FIGHTER,
+    UnitType.SMALL_CRAFT,
+  ])('seeds aero envelope for unitType=%s', (unitType) => {
+    const unit = baseGameUnit({
+      id: `${unitType}-unit`,
+      unitType,
+      aerospaceInit: SAMPLE_AERO_INIT,
+    });
+    const state = createInitialUnitState(unit, POSITION);
+    expect(state.combatState?.kind).toBe('aero');
+    if (state.combatState?.kind === 'aero') {
+      expect(state.combatState.state.maxSI).toBe(SAMPLE_AERO_INIT.maxSI);
+      expect(state.combatState.state.armorByArc.nose).toBe(20);
+    }
+  });
+
+  it('defaults altitude to 1 (airborne) when omitted', () => {
+    const state = createInitialUnitState(buildAeroUnit(), POSITION);
+    if (state.combatState?.kind === 'aero') {
+      expect(state.combatState.state.altitude).toBe(1);
+    } else {
+      throw new Error('expected aero combatState');
+    }
+  });
+
+  it('honours explicit altitude=0 (landed)', () => {
+    const state = createInitialUnitState(buildAeroUnit(0), POSITION);
+    if (state.combatState?.kind === 'aero') {
+      expect(state.combatState.state.altitude).toBe(0);
+    } else {
+      throw new Error('expected aero combatState');
+    }
+  });
+
+  it('throws when aerospaceInit block is missing entirely', () => {
+    const unit = baseGameUnit({ id: 'aero-2', unitType: UnitType.AEROSPACE });
+    expect(() => createInitialUnitState(unit, POSITION)).toThrow(
+      /aero-2.*aerospaceInit/i,
+    );
+  });
+
+  it('throws when a required aerospaceInit field is missing', () => {
+    const unit = baseGameUnit({
+      id: 'aero-3',
+      unitType: UnitType.AEROSPACE,
+      // Cast is necessary because the missing-field is the test's whole point.
+      aerospaceInit: {
+        ...SAMPLE_AERO_INIT,
+        maxSI: undefined as unknown as number,
+      },
+    });
+    expect(() => createInitialUnitState(unit, POSITION)).toThrow(
+      /aero-3.*aerospaceInit\.maxSI/i,
+    );
+  });
+});
+
+// =============================================================================
+// Infantry path
+// =============================================================================
+
+describe('createInitialUnitState — infantry seeding', () => {
+  it("seeds combatState with kind='platoon' for INFANTRY", () => {
+    const unit = baseGameUnit({
+      id: 'inf-1',
+      unitType: UnitType.INFANTRY,
+      infantryInit: makeInfantryUnit(),
+    });
+    const state = createInitialUnitState(unit, POSITION);
+    expect(state.combatState?.kind).toBe('platoon');
+    if (state.combatState?.kind === 'platoon') {
+      expect(state.combatState.state.startingTroopers).toBe(28);
+      expect(state.combatState.state.survivingTroopers).toBe(28);
+      expect(state.combatState.state.hasAntiMechTraining).toBe(true);
+    }
+  });
+
+  it('throws when infantryInit is missing for INFANTRY', () => {
+    const unit = baseGameUnit({ id: 'inf-2', unitType: UnitType.INFANTRY });
+    expect(() => createInitialUnitState(unit, POSITION)).toThrow(
+      /inf-2.*infantryInit/i,
+    );
+  });
+});
+
+// =============================================================================
+// ProtoMech path
+// =============================================================================
+
+describe('createInitialUnitState — protomech seeding', () => {
+  it("seeds combatState with kind='proto' for PROTOMECH", () => {
+    const unit = baseGameUnit({
+      id: 'proto-1',
+      unitType: UnitType.PROTOMECH,
+      protoMechInit: SAMPLE_PROTO_INIT,
+    });
+    const state = createInitialUnitState(unit, POSITION);
+    expect(state.combatState?.kind).toBe('proto');
+    if (state.combatState?.kind === 'proto') {
+      expect(state.combatState.state.chassisType).toBe(ProtoChassis.BIPED);
+      expect(state.combatState.state.hasMainGun).toBe(true);
+      expect(state.combatState.state.armorByLocation[ProtoLocation.TORSO]).toBe(
+        6,
+      );
+    }
+  });
+
+  it("seeds altitude=0 for GLIDER chassis when caller doesn't pass altitude", () => {
+    const unit = baseGameUnit({
+      id: 'proto-glider',
+      unitType: UnitType.PROTOMECH,
+      protoMechInit: { ...SAMPLE_PROTO_INIT, chassisType: ProtoChassis.GLIDER },
+    });
+    const state = createInitialUnitState(unit, POSITION);
+    if (state.combatState?.kind === 'proto') {
+      expect(state.combatState.state.altitude).toBe(0);
+    } else {
+      throw new Error('expected proto combatState');
+    }
+  });
+
+  it("Quad chassis still seeds with kind='proto'", () => {
+    const unit = baseGameUnit({
+      id: 'proto-quad',
+      unitType: UnitType.PROTOMECH,
+      protoMechInit: { ...SAMPLE_PROTO_INIT, chassisType: ProtoChassis.QUAD },
+    });
+    const state = createInitialUnitState(unit, POSITION);
+    expect(state.combatState?.kind).toBe('proto');
+  });
+
+  it('throws when protoMechInit block is missing', () => {
+    const unit = baseGameUnit({
+      id: 'proto-2',
+      unitType: UnitType.PROTOMECH,
+    });
+    expect(() => createInitialUnitState(unit, POSITION)).toThrow(
+      /proto-2.*protoMechInit/i,
+    );
+  });
+
+  it('throws when a required protoMechInit field is missing', () => {
+    const unit = baseGameUnit({
+      id: 'proto-3',
+      unitType: UnitType.PROTOMECH,
+      protoMechInit: {
+        ...SAMPLE_PROTO_INIT,
+        hasMainGun: undefined as unknown as boolean,
+      },
+    });
+    expect(() => createInitialUnitState(unit, POSITION)).toThrow(
+      /proto-3.*protoMechInit\.hasMainGun/i,
+    );
+  });
+});
+
+// =============================================================================
+// Battle Armor path
+// =============================================================================
+
+describe('createInitialUnitState — battle armor seeding', () => {
+  it("seeds combatState with kind='squad' for BATTLE_ARMOR", () => {
+    const unit = baseGameUnit({
+      id: 'ba-1',
+      unitType: UnitType.BATTLE_ARMOR,
+      battleArmorInit: SAMPLE_BA_INIT,
+    });
+    const state = createInitialUnitState(unit, POSITION);
+    expect(state.combatState?.kind).toBe('squad');
+    if (state.combatState?.kind === 'squad') {
+      expect(state.combatState.state.squadSize).toBe(5);
+      expect(state.combatState.state.troopers).toHaveLength(5);
+      // All troopers alive at battle start.
+      expect(
+        state.combatState.state.troopers.every(
+          (t: { alive: boolean }) => t.alive,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it('throws when battleArmorInit block is missing', () => {
+    const unit = baseGameUnit({
+      id: 'ba-2',
+      unitType: UnitType.BATTLE_ARMOR,
+    });
+    expect(() => createInitialUnitState(unit, POSITION)).toThrow(
+      /ba-2.*battleArmorInit/i,
+    );
+  });
+
+  it('throws when armorPointsPerTrooper is missing', () => {
+    const unit = baseGameUnit({
+      id: 'ba-3',
+      unitType: UnitType.BATTLE_ARMOR,
+      battleArmorInit: {
+        squadSize: 4,
+        armorPointsPerTrooper: undefined as unknown as number,
+      },
+    });
+    expect(() => createInitialUnitState(unit, POSITION)).toThrow(
+      /ba-3.*armorPointsPerTrooper/i,
+    );
+  });
+});
+
+// =============================================================================
+// Type narrowing — IUnitGameState shape
+// =============================================================================
+
+describe('IUnitGameState combatState shape', () => {
+  it("narrows on combatState.kind === 'platoon' for downstream consumers", () => {
+    const unit = baseGameUnit({
+      id: 'inf-narrow',
+      unitType: UnitType.INFANTRY,
+      infantryInit: makeInfantryUnit(),
+    });
+    const state: IUnitGameState = createInitialUnitState(unit, POSITION);
+    if (state.combatState?.kind === 'platoon') {
+      // TypeScript should narrow `state` to the IInfantryCombatState branch.
+      const survivingTroopers: number =
+        state.combatState.state.survivingTroopers;
+      expect(survivingTroopers).toBe(28);
+    } else {
+      throw new Error('expected platoon combatState');
+    }
+  });
+});

--- a/src/utils/gameplay/gameState/initialization.ts
+++ b/src/utils/gameplay/gameState/initialization.ts
@@ -11,6 +11,12 @@ import {
   LockState,
   MovementType,
 } from '@/types/gameplay';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+import { ProtoChassis } from '@/types/unit/ProtoMechInterfaces';
+import { createAerospaceCombatState } from '@/utils/gameplay/aerospace/state';
+import { createBattleArmorCombatState } from '@/utils/gameplay/battlearmor/state';
+import { createInfantryCombatStateFromUnit } from '@/utils/gameplay/infantry/state';
+import { createProtoMechCombatState } from '@/utils/gameplay/protomech/state';
 
 export const PLAYER_DEPLOY_ROW = 5;
 export const OPPONENT_DEPLOY_ROW = -5;
@@ -26,6 +32,169 @@ export const DEFAULT_COMPONENT_DAMAGE: IComponentDamageState = {
   heatSinksDestroyed: 0,
   jumpJetsDestroyed: 0,
 };
+
+/**
+ * Per-type discriminants that REQUIRE a `combatState` envelope per Council #1
+ * (`openspec/council-decisions/2026-05-02-cluster-F-combat-behavior-wiring.md`)
+ * and openspec change `wire-combat-behavior-dispatch`. Mech / vehicle / capital
+ * unit types intentionally leave `combatState` undefined — vehicles get a
+ * `kind: 'vehicle'` envelope in PR9+; capital ships are out of scope.
+ */
+const PER_TYPE_COMBAT_BEHAVIOR_KINDS: ReadonlySet<UnitType> = new Set([
+  UnitType.AEROSPACE,
+  UnitType.CONVENTIONAL_FIGHTER,
+  UnitType.SMALL_CRAFT,
+  UnitType.PROTOMECH,
+  UnitType.INFANTRY,
+  UnitType.BATTLE_ARMOR,
+]);
+
+/**
+ * Build the per-type `combatState` envelope for a unit, branching on
+ * `unit.unitType` and consulting the matching `*Init` block on `IGameUnit`.
+ *
+ * Returns `undefined` when:
+ *   - `unitType` is undefined (legacy path / mech-only stubs).
+ *   - `unitType` is mech / vehicle / capital — those don't get an envelope.
+ *
+ * Throws an `Error` whose message names the unit id and the missing field
+ * when `unitType` is one of the four supported per-type discriminants but the
+ * matching `*Init` block (or a required field inside it) is absent. Council #1
+ * Decision: "Init-time discriminated assertion (throw, do not warn)" — we
+ * surface the gap loudly at session creation, never silently fall back.
+ */
+function buildCombatStateForUnit(
+  unit: IGameUnit,
+): IUnitGameState['combatState'] {
+  const ut = unit.unitType;
+  if (ut === undefined) return undefined;
+  if (!PER_TYPE_COMBAT_BEHAVIOR_KINDS.has(ut)) return undefined;
+
+  // ---- Aerospace family ----
+  if (
+    ut === UnitType.AEROSPACE ||
+    ut === UnitType.CONVENTIONAL_FIGHTER ||
+    ut === UnitType.SMALL_CRAFT
+  ) {
+    const init = unit.aerospaceInit;
+    if (init === undefined) {
+      throw new Error(
+        `createInitialUnitState: ${ut} unit '${unit.id}' missing required field(s): aerospaceInit`,
+      );
+    }
+    const missing: string[] = [];
+    if (init.maxSI === undefined) missing.push('aerospaceInit.maxSI');
+    if (init.armorByArc === undefined) missing.push('aerospaceInit.armorByArc');
+    if (init.heatSinks === undefined) missing.push('aerospaceInit.heatSinks');
+    if (init.fuelPoints === undefined) missing.push('aerospaceInit.fuelPoints');
+    if (init.safeThrust === undefined) missing.push('aerospaceInit.safeThrust');
+    if (init.maxThrust === undefined) missing.push('aerospaceInit.maxThrust');
+    if (missing.length > 0) {
+      throw new Error(
+        `createInitialUnitState: ${ut} unit '${unit.id}' missing required field(s): ${missing.join(', ')}`,
+      );
+    }
+    return {
+      kind: 'aero',
+      state: createAerospaceCombatState({
+        maxSI: init.maxSI,
+        armorByArc: init.armorByArc,
+        heatSinks: init.heatSinks,
+        fuelPoints: init.fuelPoints,
+        safeThrust: init.safeThrust,
+        maxThrust: init.maxThrust,
+        altitude: init.altitude ?? 1,
+      }),
+    };
+  }
+
+  // ---- Infantry ----
+  if (ut === UnitType.INFANTRY) {
+    const init = unit.infantryInit;
+    if (init === undefined) {
+      throw new Error(
+        `createInitialUnitState: ${ut} unit '${unit.id}' missing required field(s): infantryInit`,
+      );
+    }
+    return {
+      kind: 'platoon',
+      state: createInfantryCombatStateFromUnit(init),
+    };
+  }
+
+  // ---- ProtoMech ----
+  if (ut === UnitType.PROTOMECH) {
+    const init = unit.protoMechInit;
+    if (init === undefined) {
+      throw new Error(
+        `createInitialUnitState: ${ut} unit '${unit.id}' missing required field(s): protoMechInit`,
+      );
+    }
+    const missing: string[] = [];
+    if (init.chassisType === undefined)
+      missing.push('protoMechInit.chassisType');
+    if (init.hasMainGun === undefined) missing.push('protoMechInit.hasMainGun');
+    if (init.armorByLocation === undefined)
+      missing.push('protoMechInit.armorByLocation');
+    if (init.structureByLocation === undefined)
+      missing.push('protoMechInit.structureByLocation');
+    if (missing.length > 0) {
+      throw new Error(
+        `createInitialUnitState: ${ut} unit '${unit.id}' missing required field(s): ${missing.join(', ')}`,
+      );
+    }
+    return {
+      kind: 'proto',
+      state: createProtoMechCombatState({
+        unitId: unit.id,
+        chassisType: init.chassisType,
+        hasMainGun: init.hasMainGun,
+        armorByLocation: init.armorByLocation,
+        structureByLocation: init.structureByLocation,
+        altitude:
+          init.chassisType === ProtoChassis.GLIDER
+            ? (init.altitude ?? 0)
+            : init.altitude,
+      }),
+    };
+  }
+
+  // ---- Battle Armor ----
+  if (ut === UnitType.BATTLE_ARMOR) {
+    const init = unit.battleArmorInit;
+    if (init === undefined) {
+      throw new Error(
+        `createInitialUnitState: ${ut} unit '${unit.id}' missing required field(s): battleArmorInit`,
+      );
+    }
+    const missing: string[] = [];
+    if (init.squadSize === undefined) missing.push('battleArmorInit.squadSize');
+    if (init.armorPointsPerTrooper === undefined)
+      missing.push('battleArmorInit.armorPointsPerTrooper');
+    if (missing.length > 0) {
+      throw new Error(
+        `createInitialUnitState: ${ut} unit '${unit.id}' missing required field(s): ${missing.join(', ')}`,
+      );
+    }
+    return {
+      kind: 'squad',
+      state: createBattleArmorCombatState({
+        unitId: unit.id,
+        squadSize: init.squadSize,
+        armorPointsPerTrooper: init.armorPointsPerTrooper,
+        stealthKind: init.stealthKind,
+        hasMagneticClamp: init.hasMagneticClamp,
+        hasVibroClaws: init.hasVibroClaws,
+        vibroClawCount: init.vibroClawCount,
+      }),
+    };
+  }
+
+  // Defensive: Set membership above already excludes anything that would
+  // reach this point. Returning undefined keeps the function total in case
+  // the discriminant set is widened later without a matching branch.
+  return undefined;
+}
 
 export function createInitialUnitState(
   unit: IGameUnit,
@@ -49,6 +218,12 @@ export function createInitialUnitState(
       };
     }
   }
+
+  // Per `wire-combat-behavior-dispatch` task §3.1/§3.2: branch on
+  // `unit.unitType` to seed the per-type combat-behavior envelope. Throws
+  // when one of the four supported per-type discriminants is missing its
+  // construction-input block (Decision: "throw, do not warn").
+  const combatState = buildCombatStateForUnit(unit);
 
   return {
     id: unit.id,
@@ -92,6 +267,8 @@ export function createInitialUnitState(
     isRetreating: false,
     retreatTargetEdge: undefined,
     hasRetreated: false,
+    // Per-type combat-behavior envelope (mech / vehicle paths leave undefined).
+    combatState,
   };
 }
 


### PR DESCRIPTION
## Summary

Council #1 deliverable for cluster F (combat-behavior wiring TODOs). Implements the Council decision documented at [`openspec/council-decisions/2026-05-02-cluster-F-combat-behavior-wiring.md`](https://github.com/SwiggitySwerve/MekStation/blob/chore/pr7-wire-combat-behavior-dispatch/openspec/council-decisions/2026-05-02-cluster-F-combat-behavior-wiring.md) by adding `IUnitGameState.combatState?` as a discriminated-union slot, seeding it from existing per-type combat-state factories at session-init, and projecting it into `IUnitToken` through a single shared `unitStateToToken` adapter.

OpenSpec change: [`openspec/changes/wire-combat-behavior-dispatch/`](https://github.com/SwiggitySwerve/MekStation/tree/chore/pr7-wire-combat-behavior-dispatch/openspec/changes/wire-combat-behavior-dispatch). Spec deltas: `game-state-management`, `tactical-map-interface`, `fog-of-war`.

## What changed

- **State envelope** — new `IUnitGameState.combatState?` discriminated union with kinds `aero` / `proto` / `platoon` / `squad`, matching all four archived combat-behavior spec.md files verbatim (no parallel maps, no side-channels — preserves Oracle's single-message multiplayer-sync model).
- **Session-init seeding** — `createInitialUnitState` branches on `IGameUnit.unitType` (new optional field) and seeds the envelope via the existing per-type factories. Mech / vehicle paths leave `combatState` undefined.
- **Init-time discriminated assertion** — throws an `Error` whose message names the unit id and the missing field when one of the four per-type discriminants arrives without its construction-input block. Fails loudly at session creation rather than silently rendering wrong values mid-battle.
- **Unified `unitStateToToken` adapter** at `src/lib/gameplay/unitStateToToken.ts`. Replaces the two divergent inline copies (`GameplayLayout.tsx:181`, `SpectatorViewPanels.tsx:19`) — those were the immediate cause of per-type fields never reaching the renderer in spectator view.
- **Per-type field projection** — adapter narrows on `combatState.kind` and populates `altitude`, `infantryCount`, `platoonCount`, `trooperCount`, `protoCount`, `isGlider`, `hasMainGun` on the resulting `IUnitToken`.
- **Fog redaction** — `isHidden` early-return in the adapter strips ALL `combatState`-derived per-type fields for hidden enemies. Prevents trooper counts / altitude / chassis flags from leaking through `lastKnown` projections. Wired at the `GameplayLayout` call-site from the existing `fogOfWar` + `canPlayerSeeUnit` branch.
- **Token-component defaults removed** — the four `?? <default>` fallbacks (`altitude ?? 1`, `infantryCount ?? 28`, `trooperCount ?? 4`, `protoCount ?? 5`, `isGlider ?? false`, `hasMainGun ?? false`) are gone. Components show fog-safe `'?'` / single-pip silhouettes when the producer doesn't supply a value.
- **`altitude` field added** to `IAerospaceCombatState` (Oracle open question #1, verified absent in Phase 4.5). Factory defaults to `1` to match the prior render-time fallback.
- **Velocity TODO retargeted** to `movement slice 2` per Council ruling — velocity is intentionally NOT wired in this PR.

## Out of scope (per Council ruling)

- Customizer TODOs at `BattleArmorPipGrid.tsx:52` and `InfantryPlatoonCounter.tsx:33` (design-time customizer components — separate cleanup).
- Re-authoring the four archived combat-behavior specs (the missing artefact is one new dispatch spec, not four reruns).
- Vehicle combat-state migration (`kind: 'vehicle'` variant lands in PR9+).
- Discriminated-union flip of `IUnitToken` (PR8 follow-up — closes Momus's god-type concern).
- Aerospace velocity wiring (movement slice 2).

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` — exit 0.
- [x] `npx jest` (unit project, excluding e2e/a11y/worktrees) — 23,199 of 23,199 pass.
  - 22 new tests at `src/utils/gameplay/gameState/__tests__/initialization.combatState.test.ts` (seeding + assertion-throws).
  - 18 new tests at `src/lib/gameplay/__tests__/unitStateToToken.test.ts` (per-type projection + fog redaction).
  - Existing token-default tests rewritten to assert the new fog-redacted display behavior in place of the prior hard-coded defaults.
- [x] `npx tsx scripts/validate-bv.ts --strict` — 🎉 ALL ACCURACY GATES PASSED. BV calc untouched, parity preserved.
- [x] `npx oxfmt --check src/` — all matched files use the correct format.
- [x] `npx oxlint` — 2 preexisting `max-lines` warnings on `GameplayLayout.tsx` and `GameSessionInterfaces.ts`, 0 errors.
- [x] `npx openspec validate wire-combat-behavior-dispatch --strict` — Change `wire-combat-behavior-dispatch` is valid.
- [x] Grep verification: zero remaining `altitude ?? 1`, `infantryCount ?? 28`, `trooperCount ?? 4`, `protoCount ?? 5`, `isGlider ?? false`, `hasMainGun ?? false` matches in the four token components.