### PR TITLE
refactor(protomech): replace isQuad/isGlider booleans with ProtoChassis enum (cluster L)

### DIFF
--- a/src/services/conversion/BlkParserService.ts
+++ b/src/services/conversion/BlkParserService.ts
@@ -615,6 +615,9 @@ export class BlkParserService {
    * Glider protos have motionType "Glider".
    */
   private extractProtoMech(doc: IBlkDocument): IProtoMechBlkResult {
+    // motionType is the canonical chassis discriminant at the BLK boundary;
+    // downstream consumers derive `glider`/`quad` flags from it instead of
+    // carrying a redundant boolean field on the parsed result.
     const motionType = doc.motionType ?? 'Biped';
     return {
       name: doc.name,
@@ -626,7 +629,6 @@ export class BlkParserService {
       motionType,
       cruiseMP: doc.cruiseMP ?? 0,
       jumpMP: doc.jumpingMP ?? 0,
-      isGlider: motionType.toLowerCase() === 'glider',
       armor: doc.armor,
       equipmentByLocation: doc.equipmentByLocation,
       role: doc.role,

--- a/src/services/conversion/__tests__/BlkExportService.test.ts
+++ b/src/services/conversion/__tests__/BlkExportService.test.ts
@@ -295,8 +295,6 @@ describe('BlkExportService', () => {
     weightClass: ProtoWeightClass.MEDIUM,
     chassisType: ProtoChassis.BIPED,
     pointSize: 5,
-    isQuad: false,
-    isGlider: false,
     engineRating: 25,
     walkMP: 5,
     cruiseMP: 5,

--- a/src/services/conversion/__tests__/BlkParserServiceDispatch.test.ts
+++ b/src/services/conversion/__tests__/BlkParserServiceDispatch.test.ts
@@ -550,7 +550,9 @@ describe('BlkParserService.parseByUnitType', () => {
     expect(proto.tonnage).toBe(7);
     expect(proto.cruiseMP).toBe(5);
     expect(proto.jumpMP).toBe(5);
-    expect(proto.isGlider).toBe(false);
+    // motionType is the SoT for chassis configuration at the BLK boundary;
+    // a non-Glider Roc parses with motionType "Biped".
+    expect(proto.motionType.toLowerCase()).not.toBe('glider');
     expect(proto.techBase).toBe('CLAN');
     // armor array: Head, Torso, L Arm, R Arm, Legs
     expect(proto.armor).toHaveLength(5);

--- a/src/services/units/handlers/ProtoMechUnitHandler.ts
+++ b/src/services/units/handlers/ProtoMechUnitHandler.ts
@@ -136,8 +136,20 @@ export class ProtoMechUnitHandler extends AbstractUnitTypeHandler<IProtoMech> {
 
     // Special features from raw tags
     const rawTags = document.rawTags || {};
-    const isGlider = this.getBooleanFromRaw(rawTags, 'glider');
-    const isQuad = this.getBooleanFromRaw(rawTags, 'quad');
+    // Resolve chassis configuration to the canonical `ProtoChassis` enum.
+    // Glider takes priority over Quad because Glider is a Light-class chassis
+    // that excludes arms (matching the previous `isGlider ? GLIDER : isQuad
+    // ? QUAD : BIPED` precedence). Ultraheavy is selected on tonnage when no
+    // explicit tag is present.
+    const isGliderTag = this.getBooleanFromRaw(rawTags, 'glider');
+    const isQuadTag = this.getBooleanFromRaw(rawTags, 'quad');
+    const chassisType: ProtoChassis = isGliderTag
+      ? ProtoChassis.GLIDER
+      : isQuadTag
+        ? ProtoChassis.QUAD
+        : weightPerUnit >= 10
+          ? ProtoChassis.ULTRAHEAVY
+          : ProtoChassis.BIPED;
     const hasMyomerBooster = this.getBooleanFromRaw(rawTags, 'myomerbooster');
     const hasMagneticClamps = this.getBooleanFromRaw(rawTags, 'magneticclamps');
     const hasExtendedTorsoTwist = this.getBooleanFromRaw(
@@ -160,8 +172,7 @@ export class ProtoMechUnitHandler extends AbstractUnitTypeHandler<IProtoMech> {
       armorByLocation,
       structureByLocation,
       equipment,
-      isGlider,
-      isQuad,
+      chassisType,
       hasMyomerBooster,
       hasMagneticClamps,
       hasExtendedTorsoTwist,
@@ -343,8 +354,12 @@ export class ProtoMechUnitHandler extends AbstractUnitTypeHandler<IProtoMech> {
   protected serializeTypeSpecificFields(
     unit: IProtoMech,
   ): Partial<ISerializedUnit> {
+    // Project the canonical chassisType discriminant onto the legacy
+    // serialized "configuration" string. Only QUAD vs everything-else is
+    // observable at this boundary; Glider and Ultraheavy are stored on the
+    // chassisType field itself.
     return {
-      configuration: unit.isQuad ? 'Quad' : 'Biped',
+      configuration: unit.chassisType === ProtoChassis.QUAD ? 'Quad' : 'Biped',
       rulesLevel: String(unit.rulesLevel),
     };
   }
@@ -389,12 +404,12 @@ export class ProtoMechUnitHandler extends AbstractUnitTypeHandler<IProtoMech> {
     }
 
     // Main gun validation
-    if (unit.hasMainGun && unit.isQuad) {
+    if (unit.hasMainGun && unit.chassisType === ProtoChassis.QUAD) {
       errors.push('Quad ProtoMechs cannot have main guns');
     }
 
     // Glider validation
-    if (unit.isGlider && unit.jumpMP < 2) {
+    if (unit.chassisType === ProtoChassis.GLIDER && unit.jumpMP < 2) {
       errors.push('Glider ProtoMechs require at least 2 jump MP');
     }
 
@@ -445,13 +460,9 @@ export class ProtoMechUnitHandler extends AbstractUnitTypeHandler<IProtoMech> {
    * calculator does not inspect but TypeScript still requires.
    */
   private toProtoMechUnit(unit: IProtoMech): IProtoMechUnit {
-    const chassisType: ProtoChassis = unit.isGlider
-      ? ProtoChassis.GLIDER
-      : unit.isQuad
-        ? ProtoChassis.QUAD
-        : unit.weightPerUnit >= 10
-          ? ProtoChassis.ULTRAHEAVY
-          : ProtoChassis.BIPED;
+    // chassisType is the canonical discriminant on IProtoMech; the BV-shape
+    // unit reuses it directly so the two layers cannot drift.
+    const chassisType: ProtoChassis = unit.chassisType;
 
     const weightClass: ProtoWeightClass =
       unit.weightPerUnit <= 4
@@ -527,7 +538,9 @@ export class ProtoMechUnitHandler extends AbstractUnitTypeHandler<IProtoMech> {
       engineRating: unit.engineRating,
       engineWeight: unit.engineRating * 0.025,
       myomerBooster: unit.hasMyomerBooster,
-      glidingWings: unit.isGlider,
+      // Glider Wings is a passive special equipment of the Glider chassis;
+      // derive from the discriminant so the projection always matches.
+      glidingWings: unit.chassisType === ProtoChassis.GLIDER,
       armorType: 'Standard',
       armorByLocation,
       structureByLocation,
@@ -576,7 +589,7 @@ export class ProtoMechUnitHandler extends AbstractUnitTypeHandler<IProtoMech> {
     costPerUnit += unit.engineRating * 1000;
 
     // Special equipment
-    if (unit.isGlider) costPerUnit += 50000;
+    if (unit.chassisType === ProtoChassis.GLIDER) costPerUnit += 50000;
     if (unit.hasMyomerBooster) costPerUnit += 100000;
     if (unit.hasMagneticClamps) costPerUnit += 75000;
 

--- a/src/services/units/handlers/__tests__/ProtoMechUnitHandler.test.ts
+++ b/src/services/units/handlers/__tests__/ProtoMechUnitHandler.test.ts
@@ -7,6 +7,7 @@
 import { TechBase } from '@/types/enums';
 import { IBlkDocument } from '@/types/formats/BlkFormat';
 import { UnitType } from '@/types/unit/BattleMechInterfaces';
+import { ProtoChassis } from '@/types/unit/ProtoMechInterfaces';
 
 import {
   ProtoMechUnitHandler,
@@ -177,7 +178,7 @@ describe('ProtoMechUnitHandler', () => {
       const result = handler.parse(doc);
 
       expect(result.success).toBe(true);
-      expect(result.data?.unit?.isGlider).toBe(true);
+      expect(result.data?.unit?.chassisType).toBe(ProtoChassis.GLIDER);
       expect(result.data?.unit?.jumpMP).toBe(4);
     });
 
@@ -186,7 +187,7 @@ describe('ProtoMechUnitHandler', () => {
       const result = handler.parse(doc);
 
       expect(result.success).toBe(true);
-      expect(result.data?.unit?.isQuad).toBe(true);
+      expect(result.data?.unit?.chassisType).toBe(ProtoChassis.QUAD);
     });
 
     it('should always be Clan tech base', () => {

--- a/src/stores/protoMechState.ts
+++ b/src/stores/protoMechState.ts
@@ -158,12 +158,6 @@ export interface ProtoMechState {
   /** Point size (typically 5 ProtoMechs per point) */
   pointSize: number;
 
-  /** @deprecated Use chassisType === ProtoChassis.QUAD. Kept for backward compat. */
-  isQuad: boolean;
-
-  /** @deprecated Use chassisType === ProtoChassis.GLIDER. Kept for backward compat. */
-  isGlider: boolean;
-
   // =========================================================================
   // Movement
   // =========================================================================
@@ -289,11 +283,13 @@ export interface ProtoMechStoreActions {
   // Classification Actions
   setTonnage: (tonnage: number) => void;
   setPointSize: (size: number) => void;
-  setQuad: (isQuad: boolean) => void;
-  setGlider: (isGlider: boolean) => void;
   /**
    * Set the chassis type. Re-derives weight class + MP caps; resets glidingWings
    * if the new chassis is not Glider, and clears jump MP for Ultraheavy.
+   *
+   * Replaces the legacy `setQuad` / `setGlider` setters which used to mutate a
+   * pair of redundant booleans alongside `chassisType`; the discriminant is
+   * now the only source of truth.
    */
   setChassisType: (chassis: ProtoChassis) => void;
 
@@ -384,7 +380,12 @@ export interface CreateProtoMechOptions {
   chassis?: string;
   model?: string;
   tonnage?: number;
-  isQuad?: boolean;
+  /**
+   * Initial chassis type. Replaces the legacy `isQuad?: boolean` option so
+   * callers can pick BIPED / QUAD / GLIDER / ULTRAHEAVY directly. Defaults
+   * to BIPED.
+   */
+  chassisType?: ProtoChassis;
 }
 
 /**
@@ -416,7 +417,7 @@ export function createDefaultProtoMechState(
   const chassis = options.chassis ?? 'New ProtoMech';
   const model = options.model ?? '';
   const tonnage = options.tonnage ?? 5;
-  const chassisType = options.isQuad ? ProtoChassis.QUAD : ProtoChassis.BIPED;
+  const chassisType = options.chassisType ?? ProtoChassis.BIPED;
   const weightClass = getProtoWeightClass(tonnage);
 
   // Default walk MP to the minimum 1 — the user sets it via setWalkMP
@@ -444,8 +445,6 @@ export function createDefaultProtoMechState(
     weightClass,
     chassisType,
     pointSize: 5,
-    isQuad: options.isQuad ?? false,
-    isGlider: false,
 
     // Movement
     engineRating: tonnage * walkMP,

--- a/src/stores/protoMechStoreRegistry.ts
+++ b/src/stores/protoMechStoreRegistry.ts
@@ -166,7 +166,7 @@ export function duplicateProtoMech(
   const newState = createDefaultProtoMechState({
     name: newName ?? `${sourceState.name} (Copy)`,
     tonnage: sourceState.tonnage,
-    isQuad: sourceState.isQuad,
+    chassisType: sourceState.chassisType,
   });
 
   const mergedState: ProtoMechState = {

--- a/src/stores/useProtoMechStore.ts
+++ b/src/stores/useProtoMechStore.ts
@@ -198,20 +198,6 @@ export function createProtoMechStore(
               lastModifiedAt: Date.now(),
             }),
 
-          setQuad: (isQuad) =>
-            set({
-              isQuad,
-              isModified: true,
-              lastModifiedAt: Date.now(),
-            }),
-
-          setGlider: (isGlider) =>
-            set({
-              isGlider,
-              isModified: true,
-              lastModifiedAt: Date.now(),
-            }),
-
           setChassisType: (chassisType) =>
             set((state) => {
               const weightClass = getProtoWeightClass(state.tonnage);
@@ -229,8 +215,6 @@ export function createProtoMechStore(
                   : false;
               return {
                 chassisType,
-                isQuad: chassisType === ProtoChassis.QUAD,
-                isGlider: chassisType === ProtoChassis.GLIDER,
                 walkMP,
                 cruiseMP: walkMP,
                 flankMP: effWalk + 1,
@@ -515,8 +499,6 @@ export function createProtoMechStore(
           weightClass: state.weightClass,
           chassisType: state.chassisType,
           pointSize: state.pointSize,
-          isQuad: state.isQuad,
-          isGlider: state.isGlider,
           engineRating: state.engineRating,
           walkMP: state.walkMP,
           cruiseMP: state.cruiseMP,

--- a/src/types/formats/BlkFormat.ts
+++ b/src/types/formats/BlkFormat.ts
@@ -342,14 +342,17 @@ export interface IProtoMechBlkResult {
   readonly year: number;
   readonly tonnage: number;
   readonly techBase: string;
-  /** Motion type (Biped | Quad | Glider | UMU) */
+  /**
+   * Motion type (Biped | Quad | Glider | UMU). Single source of truth for
+   * chassis configuration at the BLK boundary — consumers derive `glider`,
+   * `quad`, etc. from `motionType.toLowerCase()` rather than carrying a
+   * second redundant flag that could drift.
+   */
   readonly motionType: string;
   /** Cruise MP */
   readonly cruiseMP: number;
   /** Jump MP */
   readonly jumpMP: number;
-  /** Is glider proto */
-  readonly isGlider: boolean;
   /** Armor values: [Head, Torso, L Arm, R Arm, Legs, Main Gun?] — order matches BLK armor tag */
   readonly armor: readonly number[];
   /** Equipment by location */

--- a/src/types/unit/PersonnelInterfaces.ts
+++ b/src/types/unit/PersonnelInterfaces.ts
@@ -16,6 +16,7 @@ import {
 } from '../construction/UnitLocation';
 import { ISquadUnit, SquadMotionType } from './BaseUnitInterfaces';
 import { UnitType } from './BattleMechInterfaces';
+import { ProtoChassis } from './ProtoMechInterfaces';
 
 // ============================================================================
 // Battle Armor Types
@@ -368,11 +369,12 @@ export interface IProtoMech extends ISquadUnit {
 
   // ===== ProtoMech-Specific Options =====
 
-  /** Is this a glider (has extended jump) */
-  readonly isGlider: boolean;
-
-  /** Is this a quad ProtoMech */
-  readonly isQuad: boolean;
+  /**
+   * Chassis configuration. Single source of truth for biped vs quad vs
+   * glider vs ultraheavy variants — replaces the previous redundant
+   * `isQuad`/`isGlider` boolean pair so the discriminant cannot drift.
+   */
+  readonly chassisType: ProtoChassis;
 
   /** Has myomer booster */
   readonly hasMyomerBooster: boolean;


### PR DESCRIPTION
## Summary

Cluster L from the hard-cutover triage. Per pre-council audit, the discriminant ALREADY EXISTS — `ProtoChassis` enum at `src/types/unit/ProtoMechInterfaces.ts:29` (`BIPED | QUAD | GLIDER | ULTRAHEAVY`). The redundant `isQuad`/`isGlider` boolean fields were a second source-of-truth that could drift from the enum. This PR is a pure mechanical codemod that removes the booleans and routes everything through the discriminant.

## Migration scope

**Removed boolean fields, promoted `chassisType: ProtoChassis` as single source of truth:**
- `IProtoMech` (`src/types/unit/PersonnelInterfaces.ts`) — added `chassisType` field, dropped `isQuad`/`isGlider`
- `ProtoMechState` (`src/stores/protoMechState.ts`) — dropped deprecated `isQuad`/`isGlider`, removed `setQuad`/`setGlider` actions, replaced `CreateProtoMechOptions.isQuad?: boolean` with `chassisType?: ProtoChassis`
- `IProtoMechBlkResult` (`src/types/formats/BlkFormat.ts`) — dropped `isGlider` (motionType is the canonical raw discriminant at the BLK boundary)

**Refactored consumers to read from `chassisType`:**
- `ProtoMechUnitHandler.parseTypeSpecificFields` — produces `chassisType` directly from raw tags + tonnage
- `ProtoMechUnitHandler.validateTypeSpecificRules` — quad/glider validation reads `chassisType === ProtoChassis.QUAD/GLIDER`
- `ProtoMechUnitHandler.serializeTypeSpecificFields` — `configuration: chassisType === QUAD ? "Quad" : "Biped"`
- `ProtoMechUnitHandler.toProtoMechUnit` (BV adapter) — passes `chassisType` through unchanged; `glidingWings` now derived from `chassisType === GLIDER`
- `ProtoMechUnitHandler.calculateTypeSpecificCost` — Glider cost bonus reads `chassisType === GLIDER`
- `useProtoMechStore.setChassisType` — no longer mirrors to redundant booleans
- `useProtoMechStore` partialize — drops `isQuad`/`isGlider` from persisted shape
- `protoMechStoreRegistry.duplicateProtoMech` — passes `chassisType` to factory
- `BlkParserService.extractProtoMech` — drops the redundant `isGlider` projection on parsed result

**Tests updated:**
- `ProtoMechUnitHandler.test.ts` — `result.data?.unit?.isGlider/isQuad` → `result.data?.unit?.chassisType === ProtoChassis.GLIDER/QUAD`
- `BlkParserServiceDispatch.test.ts` — checks `proto.motionType.toLowerCase()` instead of removed `proto.isGlider`
- `BlkExportService.test.ts` — drops `isQuad`/`isGlider` from `ProtoMechState` mock fixture

## Out of scope (preserved per spec)

- **Token-layer projection fields** (`IProtoMechToken.isGlider`, `IMechToken.isQuad`) — UI flags computed from `chassisType` at projection time; renderer reads them directly. Single-source preserved at the source.
- **Renderer-layer projection fields** (`IProtoMechRecordSheetData.isGlider`, `IProtoMechUnitConfig.isGlider`) — input/output edge flags for the SVG renderer pipeline.
- **Mech `isQuad`** — no cluster L migration target; the `MechConfiguration` registry already has a working enum + `isQuadConfiguration()` predicate.
- **BattleArmor `BAChassisType`** — already a separate enum.
- **`battleValueExplosivePenalties.ts isQuad`** — mech locations LA/RA/LL/RL; mech-side, not protomech.
- **Local consts derived from `chassisType`** — already correct pattern in `hitLocation.ts`, `damage.ts`, `ProtoMechStructureTab.tsx`.

## Verification

- `npx tsc --noEmit --skipLibCheck` — exit 0
- `npx jest --selectProjects unit` — **23166/23166 pass** (1 skipped, 0 failed)
- `npx tsx scripts/validate-bv.ts --strict` — **byte-identical to baseline** (`diff` exit 0; zero deltas across all units; `battleValueExplosivePenalties.ts` is mech-only and unchanged)
- `npx oxfmt --check .` — clean
- `npx oxlint` — 33 baseline warnings (preexisting), 0 errors
- Husky pre-commit (build + lint + tsc) passed at commit time without `--no-verify`

## Test plan

- [ ] CI gate: lint, format, typecheck, test, validate-bv, storybook-build all green
- [ ] Smoke: open the customizer Structure tab on an existing Glider proto fixture; toggling chassis type via `setChassisType` updates the chassis configuration without persisting stale boolean state
- [ ] Smoke: BLK import of a Glider proto (e.g. Roc) lands `chassisType === ProtoChassis.GLIDER` and serializes back via `serializeTypeSpecificFields` with the right `configuration` string