### PR TITLE
Collapse IUnitWithVersion into IFullUnit (descoped from PR6)

### DIFF
--- a/src/services/units/CanonicalUnitService.ts
+++ b/src/services/units/CanonicalUnitService.ts
@@ -99,6 +99,13 @@ function mapRawToIndexEntry(raw: RawUnitIndexEntry): IUnitIndexEntry {
 
 /**
  * Full unit data structure (placeholder - will be defined in types)
+ *
+ * Optional temporal fields (`currentVersion`, `createdAt`, `updatedAt`) carry
+ * version metadata for custom units that have been persisted via the
+ * `CustomUnitApiService` versioning endpoints. They are absent on canonical
+ * (bundled) units and on unsaved drafts. Collapsed in here from the former
+ * `IUnitWithVersion` extension — the wrapper added no architectural value
+ * and forced ad-hoc casts at the API boundary.
  */
 export interface IFullUnit {
   readonly id: string;
@@ -112,6 +119,10 @@ export interface IFullUnit {
   readonly equipment?: unknown[];
   readonly armor?: Record<string, number>;
   readonly structure?: Record<string, number>;
+  // Optional version metadata — present only on persisted custom units.
+  readonly currentVersion?: number;
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
   [key: string]: unknown;
 }
 

--- a/src/services/units/CustomUnitApiService.ts
+++ b/src/services/units/CustomUnitApiService.ts
@@ -19,15 +19,6 @@ import { IFullUnit } from './CanonicalUnitService';
 import { getCanonicalUnitService } from './CanonicalUnitService';
 
 /**
- * Unit with version info
- */
-export interface IUnitWithVersion extends IFullUnit {
-  readonly currentVersion: number;
-  readonly createdAt: string;
-  readonly updatedAt: string;
-}
-
-/**
  * API Response types
  */
 interface IUnitListResponse {
@@ -36,7 +27,7 @@ interface IUnitListResponse {
 
 interface IUnitDetailsResponse {
   readonly success: boolean;
-  readonly data?: IUnitWithVersion;
+  readonly data?: IFullUnit;
   readonly error?: string;
 }
 
@@ -74,7 +65,7 @@ export interface IVersionWithData {
 export interface ICustomUnitApiService {
   // CRUD
   list(): Promise<readonly ICustomUnitIndexEntry[]>;
-  getById(id: string): Promise<IUnitWithVersion | null>;
+  getById(id: string): Promise<IFullUnit | null>;
   create(
     unit: IFullUnit,
     chassis: string,
@@ -134,7 +125,7 @@ export class CustomUnitApiService implements ICustomUnitApiService {
   /**
    * Get a custom unit by ID
    */
-  async getById(id: string): Promise<IUnitWithVersion | null> {
+  async getById(id: string): Promise<IFullUnit | null> {
     const response = await fetch(
       `${API_BASE}/custom/${encodeURIComponent(id)}`,
     );
@@ -162,7 +153,7 @@ export class CustomUnitApiService implements ICustomUnitApiService {
       currentVersion: data.data.currentVersion,
       createdAt: data.data.createdAt,
       updatedAt: data.data.updatedAt,
-    } as IUnitWithVersion;
+    } as IFullUnit;
   }
 
   /**

--- a/src/services/units/index.ts
+++ b/src/services/units/index.ts
@@ -59,7 +59,6 @@ export {
   CustomUnitApiService,
   customUnitApiService,
   type ICustomUnitApiService,
-  type IUnitWithVersion,
   type ISaveResult,
   type IVersionWithData,
 } from './CustomUnitApiService';

--- a/src/services/units/unitLoaderService/unitContractAdapter.ts
+++ b/src/services/units/unitLoaderService/unitContractAdapter.ts
@@ -137,10 +137,10 @@ export function safeParseUnit(
  * `(parseResult.success ? parseResult.unit : fullUnit) as IRawSerializedUnit`
  * pattern from each loader call site. The single coercion is justified
  * because:
- *   - upstream services type their cached JSON as `IFullUnit` /
- *     `IUnitWithVersion`, both of which carry `[key: string]: unknown`
- *     index signatures wide enough to accept the structurally-richer
- *     `IRawSerializedUnit`,
+ *   - upstream services type their cached JSON as `IFullUnit`, which
+ *     carries optional version metadata (currentVersion/createdAt/
+ *     updatedAt) plus a `[key: string]: unknown` index signature wide
+ *     enough to accept the structurally-richer `IRawSerializedUnit`,
  *   - `hasSerializedUnitStructure` already runs ahead of this in the
  *     custom-unit branch to confirm the shape is the serialized variant
  *     (chassis/tonnage/techBase present),


### PR DESCRIPTION
## Summary

Descoped follow-up from PR #479 (which collapsed 3 of 4 type pairs). This change collapses the final `IUnitWithVersion extends IFullUnit` wrapper interface — which only added 3 temporal fields (`currentVersion`, `createdAt`, `updatedAt`) — directly into `IFullUnit` as **optional** fields.

The wrapper added no architectural value as a separate type; it forced ad-hoc casts at the API boundary and split otherwise-equivalent unit shapes across two type names. The 3 temporal fields are now optional on `IFullUnit` (absent on canonical/bundled units, present on persisted custom units).

## Changes

- `src/services/units/CanonicalUnitService.ts` — added `currentVersion?`, `createdAt?`, `updatedAt?` to `IFullUnit` with explanatory JSDoc.
- `src/services/units/CustomUnitApiService.ts` — deleted `IUnitWithVersion` interface declaration; replaced 3 callsites (interface return type, method signature, return cast) with `IFullUnit`.
- `src/services/units/index.ts` — removed `type IUnitWithVersion` from barrel re-export.
- `src/services/units/unitLoaderService/unitContractAdapter.ts` — updated docstring reference to remove the `/ IUnitWithVersion` mention.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` — exit 0 (no errors)
- [x] `npx jest --testPathPattern='services/units'` — 17 suites / 913 tests pass
- [x] `npx oxfmt --check` on the 4 changed files — clean

## Origin

Descoped from #479 (PR6 — collapsed 3 of 4 type pairs). This finishes the type-pair collapse work.