### PR TITLE
Cluster E PR1 — Test fixture migration to (entry, pilot) bridge pattern (33 sites / 6 files)

### DIFF
--- a/src/__tests__/integration/phase3RoundTrip.test.ts
+++ b/src/__tests__/integration/phase3RoundTrip.test.ts
@@ -34,6 +34,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 
+import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
 import type { IPerson } from '@/types/campaign/Person';
 import type {
   IUnitCombatState,
@@ -43,6 +44,7 @@ import type {
   ICombatOutcome,
   IUnitCombatDelta,
 } from '@/types/combat/CombatOutcome';
+import type { IPilot } from '@/types/pilot/PilotInterfaces';
 import type { IPostBattleReport } from '@/utils/gameplay/postBattleReport';
 
 import {
@@ -51,13 +53,12 @@ import {
 } from '@/engine/combatOutcomeBus';
 import { _resetDayPipeline } from '@/lib/campaign/dayPipeline';
 import { _resetBuiltinRegistration } from '@/lib/campaign/processors';
+import { rosterEntryToPerson } from '@/lib/campaign/utils/rosterEntryToPerson';
 import {
   resetCampaignStore,
   useCampaignStore,
 } from '@/stores/campaign/useCampaignStore';
-import { createDefaultCampaignOptions } from '@/types/campaign/Campaign';
-import { CampaignType } from '@/types/campaign/CampaignType';
-import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
+import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
 import { MissionStatus } from '@/types/campaign/enums/MissionStatus';
 import { PersonnelStatus } from '@/types/campaign/enums/PersonnelStatus';
 import { createContract } from '@/types/campaign/Mission';
@@ -69,48 +70,52 @@ import {
   UnitFinalStatus,
 } from '@/types/combat/CombatOutcome';
 import { GameSide } from '@/types/gameplay/GameSessionInterfaces';
+import { PilotStatus, PilotType } from '@/types/pilot/PilotInterfaces';
 
 // ---------------------------------------------------------------------------
 // Test fixtures (kept local so this file is self-contained)
 // ---------------------------------------------------------------------------
 
 /**
- * Build a campaign-side `IPerson` with sane defaults. Tests pass a
- * partial override to flip status / pilot skills.
+ * Build a campaign-side `IPerson` with sane defaults.
+ *
+ * Cluster E PR1 — IPerson fixtures now route through the
+ * `(rosterEntry, vaultPilot) → rosterEntryToPerson()` bridge so the
+ * test substrate exercises the same shim production code uses to
+ * adapt the new roster-employment substrate to legacy `IPerson`-shaped
+ * helpers. Test-specific overrides (id, name, pilotSkills) still
+ * spread on top so individual cases drive their own scenarios.
  */
 function makePerson(overrides: Partial<IPerson> = {}): IPerson {
-  return {
-    id: 'pilot-1',
-    name: 'Test Pilot',
-    status: PersonnelStatus.ACTIVE,
-    primaryRole: CampaignPersonnelRole.PILOT,
-    rank: 'MechWarrior',
-    recruitmentDate: new Date('3024-01-01'),
-    missionsCompleted: 0,
-    totalKills: 0,
+  const id = overrides.id ?? 'pilot-1';
+  const name = overrides.name ?? 'Test Pilot';
+  const skills = overrides.pilotSkills ?? { gunnery: 4, piloting: 5 };
+  const entry: ICampaignRosterEntry = {
+    pilotId: id,
+    pilotName: name,
+    status: CampaignPilotStatus.Active,
+    wounds: 0,
+    recoveryTime: 0,
     xp: 0,
-    totalXpEarned: 0,
-    xpSpent: 0,
-    hits: 0,
-    injuries: [],
-    daysToWaitForHealing: 0,
-    skills: {},
-    attributes: {
-      STR: 5,
-      BOD: 5,
-      REF: 5,
-      DEX: 5,
-      INT: 5,
-      WIL: 5,
-      CHA: 5,
-      Edge: 0,
-    },
-    pilotSkills: { gunnery: 4, piloting: 5 },
+    campaignXpEarned: 0,
+    campaignKills: 0,
+    campaignMissions: 0,
+    hireDate: new Date('3024-01-01'),
+  };
+  const vault: IPilot = {
+    id,
+    name,
+    type: PilotType.Persistent,
+    status: PilotStatus.Active,
+    skills,
+    wounds: 0,
+    abilities: [],
+    awards: [],
     createdAt: '3024-01-01T00:00:00Z',
     updatedAt: '3025-01-01T00:00:00Z',
-    awards: [],
-    ...overrides,
   };
+  const base = rosterEntryToPerson(entry, vault);
+  return { ...base, ...overrides };
 }
 
 /**

--- a/src/__tests__/integration/phase4CampaignRoundTrip.test.ts
+++ b/src/__tests__/integration/phase4CampaignRoundTrip.test.ts
@@ -40,6 +40,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 
+import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
 import type { IDailyBattleAuditEntry } from '@/types/campaign/IDailyBattleAuditEntry';
 import type { IPerson } from '@/types/campaign/Person';
 import type {
@@ -50,6 +51,7 @@ import type {
   ICombatOutcome,
   IUnitCombatDelta,
 } from '@/types/combat/CombatOutcome';
+import type { IPilot } from '@/types/pilot/PilotInterfaces';
 import type { IPostBattleReport } from '@/utils/gameplay/postBattleReport';
 
 import {
@@ -64,11 +66,12 @@ import {
 } from '@/lib/campaign/contractFulfillmentBus';
 import { _resetDayPipeline } from '@/lib/campaign/dayPipeline';
 import { _resetBuiltinRegistration } from '@/lib/campaign/processors';
+import { rosterEntryToPerson } from '@/lib/campaign/utils/rosterEntryToPerson';
 import {
   resetCampaignStore,
   useCampaignStore,
 } from '@/stores/campaign/useCampaignStore';
-import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
+import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
 import { MissionStatus } from '@/types/campaign/enums/MissionStatus';
 import { PersonnelStatus } from '@/types/campaign/enums/PersonnelStatus';
 import { createContract } from '@/types/campaign/Mission';
@@ -80,48 +83,52 @@ import {
   UnitFinalStatus,
 } from '@/types/combat/CombatOutcome';
 import { GameSide } from '@/types/gameplay/GameSessionInterfaces';
+import { PilotStatus, PilotType } from '@/types/pilot/PilotInterfaces';
 
 // ---------------------------------------------------------------------------
 // Test fixtures (kept local so this file is self-contained)
 // ---------------------------------------------------------------------------
 
 /**
- * Build a campaign-side `IPerson` with sane defaults. Tests pass a
- * partial override to flip status / pilot skills.
+ * Build a campaign-side `IPerson` with sane defaults.
+ *
+ * Cluster E PR1 — IPerson fixtures now route through the
+ * `(rosterEntry, vaultPilot) → rosterEntryToPerson()` bridge so the
+ * test substrate exercises the same shim production code uses to
+ * adapt the new roster-employment substrate to legacy `IPerson`-shaped
+ * helpers. Test-specific overrides (id, name, pilotSkills) still
+ * spread on top so individual cases drive their own scenarios.
  */
 function makePerson(overrides: Partial<IPerson> = {}): IPerson {
-  return {
-    id: 'pilot-1',
-    name: 'Test Pilot',
-    status: PersonnelStatus.ACTIVE,
-    primaryRole: CampaignPersonnelRole.PILOT,
-    rank: 'MechWarrior',
-    recruitmentDate: new Date('3024-01-01'),
-    missionsCompleted: 0,
-    totalKills: 0,
+  const id = overrides.id ?? 'pilot-1';
+  const name = overrides.name ?? 'Test Pilot';
+  const skills = overrides.pilotSkills ?? { gunnery: 4, piloting: 5 };
+  const entry: ICampaignRosterEntry = {
+    pilotId: id,
+    pilotName: name,
+    status: CampaignPilotStatus.Active,
+    wounds: 0,
+    recoveryTime: 0,
     xp: 0,
-    totalXpEarned: 0,
-    xpSpent: 0,
-    hits: 0,
-    injuries: [],
-    daysToWaitForHealing: 0,
-    skills: {},
-    attributes: {
-      STR: 5,
-      BOD: 5,
-      REF: 5,
-      DEX: 5,
-      INT: 5,
-      WIL: 5,
-      CHA: 5,
-      Edge: 0,
-    },
-    pilotSkills: { gunnery: 4, piloting: 5 },
+    campaignXpEarned: 0,
+    campaignKills: 0,
+    campaignMissions: 0,
+    hireDate: new Date('3024-01-01'),
+  };
+  const vault: IPilot = {
+    id,
+    name,
+    type: PilotType.Persistent,
+    status: PilotStatus.Active,
+    skills,
+    wounds: 0,
+    abilities: [],
+    awards: [],
     createdAt: '3024-01-01T00:00:00Z',
     updatedAt: '3025-01-01T00:00:00Z',
-    awards: [],
-    ...overrides,
   };
+  const base = rosterEntryToPerson(entry, vault);
+  return { ...base, ...overrides };
 }
 
 /**

--- a/src/lib/campaign/__tests__/dailyBattleAuditBuilder.test.ts
+++ b/src/lib/campaign/__tests__/dailyBattleAuditBuilder.test.ts
@@ -9,17 +9,19 @@
 import { describe, it, expect } from '@jest/globals';
 
 import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
 import type { IPerson } from '@/types/campaign/Person';
 import type {
   ICombatOutcome,
   IUnitCombatDelta,
 } from '@/types/combat/CombatOutcome';
+import type { IPilot } from '@/types/pilot/PilotInterfaces';
 
+import { rosterEntryToPerson } from '@/lib/campaign/utils/rosterEntryToPerson';
 import { createDefaultCampaignOptions } from '@/types/campaign/Campaign';
+import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
 import { CampaignType } from '@/types/campaign/CampaignType';
-import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
 import { MissionStatus } from '@/types/campaign/enums/MissionStatus';
-import { PersonnelStatus } from '@/types/campaign/enums/PersonnelStatus';
 import { createContract } from '@/types/campaign/Mission';
 import { Money } from '@/types/campaign/Money';
 import {
@@ -29,6 +31,7 @@ import {
   UnitFinalStatus,
 } from '@/types/combat/CombatOutcome';
 import { GameSide } from '@/types/gameplay/GameSessionInterfaces';
+import { PilotStatus, PilotType } from '@/types/pilot/PilotInterfaces';
 
 import type { ICampaignWithBattleState } from '../processors/postBattleProcessor';
 
@@ -41,41 +44,47 @@ import {
 // Fixtures
 // ---------------------------------------------------------------------------
 
+/**
+ * Cluster E PR1 — IPerson fixtures are now synthesized via the
+ * `(rosterEntry, vaultPilot) → rosterEntryToPerson()` bridge so the
+ * test substrate exercises the same shim production code uses to
+ * adapt the new roster-employment substrate to legacy `IPerson`-shaped
+ * helpers. Test-specific overrides (xp, totalXpEarned, custom ids)
+ * still spread on top so individual cases drive their own scenarios.
+ */
 function makePerson(
   overrides: Partial<IPerson> & { totalXpEarned?: number } = {},
 ): IPerson {
-  return {
-    id: overrides.id ?? 'pilot-1',
-    name: overrides.name ?? 'Test Pilot',
-    status: PersonnelStatus.ACTIVE,
-    primaryRole: CampaignPersonnelRole.PILOT,
-    rank: 'MechWarrior',
-    recruitmentDate: new Date('3024-01-01'),
-    missionsCompleted: 0,
-    totalKills: 0,
-    xp: overrides.xp ?? 0,
-    totalXpEarned: overrides.totalXpEarned ?? 0,
-    xpSpent: 0,
-    hits: 0,
-    injuries: [],
-    daysToWaitForHealing: 0,
-    skills: {},
-    attributes: {
-      STR: 5,
-      BOD: 5,
-      REF: 5,
-      DEX: 5,
-      INT: 5,
-      WIL: 5,
-      CHA: 5,
-      Edge: 0,
-    },
-    pilotSkills: { gunnery: 4, piloting: 5 },
+  const id = overrides.id ?? 'pilot-1';
+  const name = overrides.name ?? 'Test Pilot';
+  const xp = overrides.xp ?? 0;
+  const totalXpEarned = overrides.totalXpEarned ?? 0;
+  const entry: ICampaignRosterEntry = {
+    pilotId: id,
+    pilotName: name,
+    status: CampaignPilotStatus.Active,
+    wounds: 0,
+    recoveryTime: 0,
+    xp,
+    campaignXpEarned: totalXpEarned,
+    campaignKills: 0,
+    campaignMissions: 0,
+    hireDate: new Date('3024-01-01'),
+  };
+  const vault: IPilot = {
+    id,
+    name,
+    type: PilotType.Persistent,
+    status: PilotStatus.Active,
+    skills: { gunnery: 4, piloting: 5 },
+    wounds: 0,
+    abilities: [],
+    awards: [],
     createdAt: '3024-01-01T00:00:00Z',
     updatedAt: '3025-01-01T00:00:00Z',
-    awards: [],
-    ...overrides,
   };
+  const base = rosterEntryToPerson(entry, vault);
+  return { ...base, ...overrides };
 }
 
 function makeCampaign(

--- a/src/lib/campaign/processors/__tests__/vocationalTrainingProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/vocationalTrainingProcessor.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
 
 import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
 import type { IPerson } from '@/types/campaign/Person';
+import type { IPilot } from '@/types/pilot/PilotInterfaces';
 
+import { rosterEntryToPerson } from '@/lib/campaign/utils/rosterEntryToPerson';
 import { createDefaultCampaignOptions } from '@/types/campaign/Campaign';
+import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
 import { CampaignType } from '@/types/campaign/CampaignType';
 import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
 import { PersonnelStatus } from '@/types/campaign/enums/PersonnelStatus';
 import { Money } from '@/types/campaign/Money';
+import { PilotStatus, PilotType } from '@/types/pilot/PilotInterfaces';
 
 import { DayPhase, _resetDayPipeline, getDayPipeline } from '../../dayPipeline';
 import {
@@ -18,38 +23,44 @@ import {
 
 type RandomFn = () => number;
 
+/**
+ * Cluster E PR1 — IPerson fixtures are now synthesized via the
+ * `(rosterEntry, vaultPilot) → rosterEntryToPerson()` bridge so the
+ * test substrate exercises the same shim production code uses. The
+ * bridge cannot directly express test-only states (RETIRED, POW,
+ * DEPENDENT role, birthDate, traits) — those still arrive via the
+ * `overrides` spread, which is exactly how production helpers receive
+ * non-bridge fields when seeded from saved campaigns.
+ */
 function createTestPerson(overrides: Partial<IPerson> = {}): IPerson {
-  return {
-    id: 'person-001',
-    name: 'Test Person',
-    status: PersonnelStatus.ACTIVE,
-    primaryRole: CampaignPersonnelRole.PILOT,
-    rank: 'MechWarrior',
-    recruitmentDate: new Date('3000-01-01'),
-    missionsCompleted: 5,
-    totalKills: 3,
+  const id = overrides.id ?? 'person-001';
+  const name = overrides.name ?? 'Test Person';
+  const entry: ICampaignRosterEntry = {
+    pilotId: id,
+    pilotName: name,
+    status: CampaignPilotStatus.Active,
+    wounds: 0,
+    recoveryTime: 0,
     xp: 100,
-    totalXpEarned: 200,
-    xpSpent: 100,
-    hits: 0,
-    injuries: [],
-    daysToWaitForHealing: 0,
-    skills: {},
-    attributes: {
-      STR: 5,
-      BOD: 5,
-      REF: 5,
-      DEX: 5,
-      INT: 5,
-      WIL: 5,
-      CHA: 5,
-      Edge: 0,
-    },
-    pilotSkills: { gunnery: 4, piloting: 5 },
+    campaignXpEarned: 200,
+    campaignKills: 3,
+    campaignMissions: 5,
+    hireDate: new Date('3000-01-01'),
+  };
+  const vault: IPilot = {
+    id,
+    name,
+    type: PilotType.Persistent,
+    status: PilotStatus.Active,
+    skills: { gunnery: 4, piloting: 5 },
+    wounds: 0,
+    abilities: [],
+    awards: [],
     createdAt: '3000-01-01T00:00:00Z',
     updatedAt: '3025-06-15T00:00:00Z',
-    ...overrides,
   };
+  const base = rosterEntryToPerson(entry, vault);
+  return { ...base, ...overrides };
 }
 
 function createTestCampaign(overrides: Partial<ICampaign> = {}): ICampaign {

--- a/src/lib/finances/__tests__/taxService.test.ts
+++ b/src/lib/finances/__tests__/taxService.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect } from '@jest/globals';
 
 import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
 import type { IPerson } from '@/types/campaign/Person';
+import type { IPilot } from '@/types/pilot/PilotInterfaces';
 
 import { MedicalSystem } from '@/lib/campaign/medical/medicalTypes';
+import { rosterEntryToPerson } from '@/lib/campaign/utils/rosterEntryToPerson';
+import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
 import { CampaignType } from '@/types/campaign/CampaignType';
 import { PersonnelStatus, CampaignPersonnelRole } from '@/types/campaign/enums';
 import { Money } from '@/types/campaign/Money';
+import { PilotStatus, PilotType } from '@/types/pilot/PilotInterfaces';
 
 import {
   calculateTaxes,
@@ -15,6 +20,47 @@ import {
   calculateFoodAndHousing,
   FOOD_AND_HOUSING_COSTS,
 } from '../taxService';
+
+/**
+ * Cluster E PR1 — IPerson fixtures are now synthesized via the
+ * `(rosterEntry, vaultPilot) → rosterEntryToPerson()` bridge so the
+ * test substrate exercises the same shim production code uses to
+ * adapt the new roster-employment substrate to legacy `IPerson`-shaped
+ * helpers. Tax-service tests need test-only states (POW, KIA) and
+ * roles (ADMIN_COMMAND) — those still arrive via the `overrides` spread
+ * because the bridge cannot synthesize them from the 5-value
+ * `CampaignPilotStatus` enum or the bridge's hardcoded PILOT role.
+ */
+function makePerson(overrides: Partial<IPerson> = {}): IPerson {
+  const id = overrides.id ?? 'person-1';
+  const name = overrides.name ?? 'Test Person';
+  const entry: ICampaignRosterEntry = {
+    pilotId: id,
+    pilotName: name,
+    status: CampaignPilotStatus.Active,
+    wounds: 0,
+    recoveryTime: 0,
+    xp: 0,
+    campaignXpEarned: overrides.totalXpEarned ?? 0,
+    campaignKills: 0,
+    campaignMissions: 0,
+    hireDate: new Date('3025-01-01'),
+  };
+  const vault: IPilot = {
+    id,
+    name,
+    type: PilotType.Persistent,
+    status: PilotStatus.Active,
+    skills: { gunnery: 4, piloting: 5 },
+    wounds: 0,
+    abilities: [],
+    awards: [],
+    createdAt: '3025-01-01T00:00:00Z',
+    updatedAt: '3025-01-01T00:00:00Z',
+  };
+  const base = rosterEntryToPerson(entry, vault);
+  return { ...base, ...overrides };
+}
 
 describe('taxService', () => {
   // Helper to create a minimal campaign
@@ -239,16 +285,13 @@ describe('taxService', () => {
         personnel: new Map([
           [
             'pilot-1',
-            {
+            makePerson({
               id: 'pilot-1',
               name: 'Test Pilot',
               primaryRole: CampaignPersonnelRole.PILOT,
               status: PersonnelStatus.ACTIVE,
               totalXpEarned: 500,
-              recruitmentDate: new Date('3025-01-01'),
-              missionsCompleted: 0,
-              totalKills: 0,
-            } as IPerson,
+            }),
           ],
         ]),
         options: {
@@ -270,16 +313,13 @@ describe('taxService', () => {
         personnel: new Map([
           [
             'pilot-1',
-            {
+            makePerson({
               id: 'pilot-1',
               name: 'Test Pilot',
               primaryRole: CampaignPersonnelRole.PILOT,
               status: PersonnelStatus.ACTIVE,
               totalXpEarned: 500,
-              recruitmentDate: new Date('3025-01-01'),
-              missionsCompleted: 0,
-              totalKills: 0,
-            } as IPerson,
+            }),
           ],
         ]),
         options: {
@@ -300,16 +340,13 @@ describe('taxService', () => {
         personnel: new Map([
           [
             'officer-1',
-            {
+            makePerson({
               id: 'officer-1',
               name: 'Commander',
               primaryRole: CampaignPersonnelRole.ADMIN_COMMAND,
               status: PersonnelStatus.ACTIVE,
               totalXpEarned: 500,
-              recruitmentDate: new Date('3025-01-01'),
-              missionsCompleted: 0,
-              totalKills: 0,
-            } as IPerson,
+            }),
           ],
         ]),
       });
@@ -323,16 +360,13 @@ describe('taxService', () => {
         personnel: new Map([
           [
             'pilot-1',
-            {
+            makePerson({
               id: 'pilot-1',
               name: 'Pilot',
               primaryRole: CampaignPersonnelRole.PILOT,
               status: PersonnelStatus.ACTIVE,
               totalXpEarned: 500,
-              recruitmentDate: new Date('3025-01-01'),
-              missionsCompleted: 0,
-              totalKills: 0,
-            } as IPerson,
+            }),
           ],
         ]),
       });
@@ -346,16 +380,13 @@ describe('taxService', () => {
         personnel: new Map([
           [
             'pow-1',
-            {
+            makePerson({
               id: 'pow-1',
               name: 'Prisoner',
               primaryRole: CampaignPersonnelRole.PILOT,
               status: PersonnelStatus.POW,
               totalXpEarned: 500,
-              recruitmentDate: new Date('3025-01-01'),
-              missionsCompleted: 0,
-              totalKills: 0,
-            } as IPerson,
+            }),
           ],
         ]),
       });
@@ -369,29 +400,23 @@ describe('taxService', () => {
         personnel: new Map([
           [
             'pilot-1',
-            {
+            makePerson({
               id: 'pilot-1',
               name: 'Alive Pilot',
               primaryRole: CampaignPersonnelRole.PILOT,
               status: PersonnelStatus.ACTIVE,
               totalXpEarned: 500,
-              recruitmentDate: new Date('3025-01-01'),
-              missionsCompleted: 0,
-              totalKills: 0,
-            } as IPerson,
+            }),
           ],
           [
             'kia-1',
-            {
+            makePerson({
               id: 'kia-1',
               name: 'Dead Pilot',
               primaryRole: CampaignPersonnelRole.PILOT,
               status: PersonnelStatus.KIA,
               totalXpEarned: 500,
-              recruitmentDate: new Date('3025-01-01'),
-              missionsCompleted: 0,
-              totalKills: 0,
-            } as IPerson,
+            }),
           ],
         ]),
       });
@@ -405,55 +430,43 @@ describe('taxService', () => {
         personnel: new Map([
           [
             'officer-1',
-            {
+            makePerson({
               id: 'officer-1',
               name: 'Commander',
               primaryRole: CampaignPersonnelRole.ADMIN_COMMAND,
               status: PersonnelStatus.ACTIVE,
               totalXpEarned: 500,
-              recruitmentDate: new Date('3025-01-01'),
-              missionsCompleted: 0,
-              totalKills: 0,
-            } as IPerson,
+            }),
           ],
           [
             'pilot-1',
-            {
+            makePerson({
               id: 'pilot-1',
               name: 'Pilot 1',
               primaryRole: CampaignPersonnelRole.PILOT,
               status: PersonnelStatus.ACTIVE,
               totalXpEarned: 500,
-              recruitmentDate: new Date('3025-01-01'),
-              missionsCompleted: 0,
-              totalKills: 0,
-            } as IPerson,
+            }),
           ],
           [
             'pilot-2',
-            {
+            makePerson({
               id: 'pilot-2',
               name: 'Pilot 2',
               primaryRole: CampaignPersonnelRole.PILOT,
               status: PersonnelStatus.ACTIVE,
               totalXpEarned: 500,
-              recruitmentDate: new Date('3025-01-01'),
-              missionsCompleted: 0,
-              totalKills: 0,
-            } as IPerson,
+            }),
           ],
           [
             'pow-1',
-            {
+            makePerson({
               id: 'pow-1',
               name: 'Prisoner',
               primaryRole: CampaignPersonnelRole.PILOT,
               status: PersonnelStatus.POW,
               totalXpEarned: 500,
-              recruitmentDate: new Date('3025-01-01'),
-              missionsCompleted: 0,
-              totalKills: 0,
-            } as IPerson,
+            }),
           ],
         ]),
       });

--- a/src/stores/campaign/__tests__/useCampaignStore.test.ts
+++ b/src/stores/campaign/__tests__/useCampaignStore.test.ts
@@ -5,17 +5,19 @@
  * sub-store composition, persistence, and day advancement coverage.
  */
 
+import { rosterEntryToPerson } from '@/lib/campaign/utils/rosterEntryToPerson';
 import { ICampaignOptions } from '@/types/campaign/Campaign';
 import { IMission } from '@/types/campaign/Campaign';
+import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
+import { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
 import {
-  PersonnelStatus,
-  CampaignPersonnelRole,
   ForceRole,
   FormationLevel,
   MissionStatus,
 } from '@/types/campaign/enums';
 import { IForce } from '@/types/campaign/Force';
-import { IPerson, createDefaultAttributes } from '@/types/campaign/Person';
+import { IPerson } from '@/types/campaign/Person';
+import { IPilot, PilotStatus, PilotType } from '@/types/pilot/PilotInterfaces';
 
 import {
   createCampaignStore,
@@ -31,32 +33,44 @@ let personIdCounter = 0;
 let forceIdCounter = 0;
 let missionIdCounter = 0;
 
+/**
+ * Cluster E PR1 — IPerson fixtures are now synthesized via the
+ * `(rosterEntry, vaultPilot) → rosterEntryToPerson()` bridge so the
+ * test substrate exercises the same shim production code uses to
+ * adapt the new roster-employment substrate to legacy `IPerson`-shaped
+ * helpers. Test-specific overrides (custom names, ids) still spread on
+ * top so individual cases drive their own scenarios.
+ */
 const createTestPerson = (overrides?: Partial<IPerson>): IPerson => {
-  const id = `person-${Date.now()}-${personIdCounter++}`;
+  const id = overrides?.id ?? `person-${Date.now()}-${personIdCounter++}`;
+  const name = overrides?.name ?? 'Test Person';
   const now = new Date().toISOString();
-
-  return {
+  const entry: ICampaignRosterEntry = {
+    pilotId: id,
+    pilotName: name,
+    status: CampaignPilotStatus.Active,
+    wounds: 0,
+    recoveryTime: 0,
+    xp: 0,
+    campaignXpEarned: 0,
+    campaignKills: 0,
+    campaignMissions: 0,
+    hireDate: new Date(),
+  };
+  const vault: IPilot = {
     id,
-    name: 'Test Person',
+    name,
+    type: PilotType.Persistent,
+    status: PilotStatus.Active,
+    skills: { gunnery: 4, piloting: 5 },
+    wounds: 0,
+    abilities: [],
+    awards: [],
     createdAt: now,
     updatedAt: now,
-    status: PersonnelStatus.ACTIVE,
-    primaryRole: CampaignPersonnelRole.PILOT,
-    rank: 'MechWarrior',
-    recruitmentDate: new Date(),
-    missionsCompleted: 0,
-    totalKills: 0,
-    xp: 0,
-    totalXpEarned: 0,
-    xpSpent: 0,
-    hits: 0,
-    injuries: [],
-    daysToWaitForHealing: 0,
-    skills: {},
-    attributes: createDefaultAttributes(),
-    pilotSkills: { gunnery: 4, piloting: 5 },
-    ...overrides,
   };
+  const base = rosterEntryToPerson(entry, vault);
+  return { ...base, ...overrides };
 };
 
 const createTestForce = (overrides?: Partial<IForce>): IForce => {


### PR DESCRIPTION
## Summary

This is **PR1 of 5** in the Cluster E IPerson hard-cutover (per Council #2 decision, see `openspec/council-decisions/2026-05-02-cluster-E-iperson-hard-cutover.md`).

**Scope: test fixture migration only — production code is NOT touched.**

Migrates 33 `personnel: new Map([...mockPerson])` construction sites across 6 test files to route through `rosterEntryToPerson(entry, vault)`, so the test substrate now exercises the same shim that production code uses to bridge the new `ICampaignRosterEntry` substrate to legacy `IPerson`-shaped helpers.

The bridge layer (`rosterEntryToPerson`, `derivePersonnelFromRoster`, `syncRosterFromPersonnel`) **STAYS ALIVE** — it gets removed in PR4 once helpers consume `ICampaignRosterEntry` directly.

## Files Migrated

| File | Sites |
|---|---|
| `src/lib/campaign/__tests__/dailyBattleAuditBuilder.test.ts` | 2 |
| `src/__tests__/integration/phase3RoundTrip.test.ts` | 2 |
| `src/__tests__/integration/phase4CampaignRoundTrip.test.ts` | 3 |
| `src/lib/campaign/processors/__tests__/vocationalTrainingProcessor.test.ts` | 12 |
| `src/stores/campaign/__tests__/useCampaignStore.test.ts` | 7 |
| `src/lib/finances/__tests__/taxService.test.ts` | 7 |
| **Total** | **33** |

## Migration Pattern

For factory-based files (5 of 6): the existing `createTestPerson` / `makePerson` factory body is rewritten to construct a synthetic `ICampaignRosterEntry` + `IPilot`, route through `rosterEntryToPerson`, then spread `...overrides` on top. Test-specific overrides (POW status, ADMIN_COMMAND role, DEPENDENT role, RETIRED status, traits, birthDate) still drive scenarios because the bridge cannot synthesize them from the 5-value `CampaignPilotStatus` enum or the bridge's hardcoded `PILOT` role — and that's the correct boundary, those non-bridge fields are exactly what helpers receive from saved campaigns.

For `taxService.test.ts` (the 7 inline `as IPerson` cast sites): a local `makePerson` helper that uses the bridge was added, and each inline cast was replaced with a `makePerson({...})` call.

## Verification

- `npx tsc --noEmit --skipLibCheck` — exit 0
- `npx jest --testPathPattern='(vocationalTrainingProcessor|useCampaignStore|taxService|phase4CampaignRoundTrip|dailyBattleAuditBuilder|phase3RoundTrip)'` — **111/111 tests pass across 9 suites**
- `npx oxfmt --check` on all 6 files — clean
- Pre-push hook (full project build) passed during commit
- Anti-contamination check: main repo working tree shows only pre-existing untracked files

## Out of Scope (Tracked for Other PRs)

- `src/lib/campaign/__tests__/dayAdvancement.test.ts`, `dayPipeline.test.ts`, `integration.test.ts` — these exercise `.injuries[]` access, deferred to **PR2 medical commit**
- Bridge helper signature changes — **PR2/PR3**
- Bridge function deletion — **PR4**

## Test Plan

- [x] All 6 migrated files compile
- [x] All 111 targeted tests pass locally
- [x] `oxfmt --check` clean on all 6 files
- [x] Pre-push project build passes
- [ ] CI green on PR