### PR TITLE
Council #3 — Author campaign-unit-combat-state spec + decision doc

### DIFF
--- a/openspec/changes/canonicalize-unit-combat-state/.openspec.yaml
+++ b/openspec/changes/canonicalize-unit-combat-state/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-02

--- a/openspec/changes/canonicalize-unit-combat-state/design.md
+++ b/openspec/changes/canonicalize-unit-combat-state/design.md
@@ -1,0 +1,133 @@
+# Design: Canonicalize Unit Combat State
+
+> Source-of-truth references: Council #3 decision at `openspec/council-decisions/2026-05-02-cluster-H5-unit-combat-state.md` and canonical spec at `openspec/specs/campaign-unit-combat-state/spec.md`. This document covers implementation-level design decisions only.
+
+## Decision: Type promotion shape
+
+`ICampaign` gains a single new field. The `Record<string, IUnitCombatState>` shape (rather than `Map`) keeps serialization free for free under the existing JSON-friendly campaign persistence pipeline.
+
+```ts
+// src/types/campaign/Campaign.ts
+export interface ICampaign {
+  // ... existing fields ...
+
+  /**
+   * Canonical post-deploy combat state per unit, keyed by unitId.
+   * Populated by createInitialCombatState at first deploy, updated by
+   * postBattleProcessor, reset by repair completion. Absent entry means
+   * unit not yet deployed (or combat state was reset post-repair).
+   *
+   * See openspec/specs/campaign-unit-combat-state/spec.md for the
+   * canonical shape contract and idempotency rules.
+   */
+  readonly unitCombatStates: Readonly<Record<string, IUnitCombatState>>;
+}
+```
+
+Rationale:
+- `Record` (not `Map`) — matches existing `ICampaign` field serialization patterns (`forces`, `personnel` are exceptions on the way out via Cluster E).
+- `Readonly` wrapper — consistent with the rest of `ICampaign` immutability conventions.
+- Required field (not `?`) — pre-release / hard-cutover policy. Initialize empty `{}` for fresh campaigns; serialization always emits the field.
+
+## Decision: Roster projection type shape and naming
+
+Name: `IRosterUnitProjection` (NOT `IUnitDamageState` — collides with definitions in `lib/combat/acar.ts`, `utils/gameplay/damage/types.ts`, current roster store).
+
+```ts
+// src/stores/campaign/useCampaignRosterStore.ts (or new file src/types/campaign/RosterUnitProjection.ts)
+export interface IRosterUnitProjection {
+  readonly unitId: string;
+  readonly unitName: string;
+  readonly pilotId?: string;
+  readonly chassisVariant: string;
+  readonly readiness: 'Ready' | 'Damaged' | 'Destroyed';
+}
+
+// Derive readiness from canonical state — does NOT belong on the projection itself
+// (the projection caches it for selector stability, but the source-of-truth derivation
+// lives in a helper that takes IUnitCombatState).
+export function deriveRosterReadiness(state: IUnitCombatState | undefined): 'Ready' | 'Damaged' | 'Destroyed' {
+  if (!state || !state.combatReady) return 'Destroyed';
+  // Unit-deployed-but-clean = Ready; deployed-with-damage = Damaged
+  const hasDamage =
+    Object.values(state.currentArmorPerLocation).some((a, i, arr) => /* compare against max */ false) ||
+    state.destroyedComponents.length > 0;
+  return hasDamage ? 'Damaged' : 'Ready';
+}
+```
+
+Rationale for the projection:
+- 5 fields, all display-only — no damage state, no repair cost, no ammo.
+- `readiness` is derived but cached on the projection so Zustand subscribers don't re-render on unrelated combat-state changes.
+- Selector contract: components subscribe to `useCampaignRosterStore((s) => s.units)` (shallow-stable) for the projection list, then look up `IUnitCombatState` separately when needed (e.g., damage bar).
+
+## Decision: Selector memoization for damage bar
+
+`RosterStateCards.tsx` damage bar reads from canonical state. To avoid re-renders on every unrelated campaign-store write:
+
+```tsx
+// In RosterStateCards.tsx
+const damageBarData = useCampaignStore(
+  useShallow((state) => {
+    const combatState = state.campaign.unitCombatStates[unitId];
+    const maxState = state.campaign.unitMaxStates?.[unitId];
+    if (!combatState || !maxState) return null;
+    return {
+      armorRatio: computeArmorRatio(combatState, maxState),
+      structureRatio: computeStructureRatio(combatState, maxState),
+      destroyedCount: combatState.destroyedComponents.length,
+    };
+  })
+);
+```
+
+`useShallow` from Zustand prevents re-render unless the computed object's fields actually change. Per-frame stability for the most common case (no damage change between renders).
+
+## Decision: Init-time campaign creation
+
+Fresh campaigns start with `unitCombatStates: {}`. Units are added via `createInitialCombatState` at deploy time (existing factory at `src/types/campaign/UnitCombatState.ts:84`). The campaign creation flow at `src/components/gameplay/pages/campaigns/create/CreateCampaignPage.tsx` does NOT seed combat states — that happens later in the deploy flow.
+
+## Decision: Migration of `IRecordMissionOutcomeInput.unitUpdates`
+
+Current: `unitUpdates: readonly Partial<ICampaignUnitState>[]` (line 335 of `CampaignInterfaces.types.ts`).
+
+Replacement options considered:
+1. `unitUpdates: readonly Partial<IUnitCombatState>[]` keyed implicitly by entry order — REJECTED, fragile.
+2. `unitUpdates: Readonly<Record<string, Partial<IUnitCombatState>>>` keyed by unitId — CHOSEN. Explicit, lookup-friendly, matches `unitCombatStates` map shape.
+3. Delete the field if no consumer reads it — INVESTIGATE first; might be the case.
+
+PR-C task includes a grep for `unitUpdates` consumers before committing to option 2 vs option 3.
+
+## Decision: No persist migration callback
+
+Pre-release product (`package.json: "version": "0.1.1", "private": true`). Zero released users. Zustand `persist` middleware will rehydrate localStorage with the deleted shape on first load post-PR-C. The load will silently produce undefined fields, the store will reset to defaults, the user sees an empty roster.
+
+This is acceptable because:
+1. No production users affected.
+2. Hard-cutover policy explicitly endorsed by user.
+3. Adding a `version` bump + `migrate` callback would be carrying compat code for zero users.
+
+If post-release this becomes an issue, the conventional Zustand `version` + `migrate` pattern is well-documented and trivially additive.
+
+## Decision: Test coverage strategy
+
+PR-B is the riskiest. Tests required:
+- **Snapshot regression**: `RosterStateCards` storybook snapshot at full health, 50% armor, full damage. Catches projection-shape errors.
+- **Selector memoization test**: render `RosterStateCards` once, dispatch unrelated campaign-store action (e.g., `addPersonnel`), assert no re-render. Use `@testing-library/react` `renderHook` with a render counter.
+- **Round-trip integration**: `phase3RoundTrip.test.ts` and `phase4CampaignRoundTrip.test.ts` continue passing with both cast removal (PR-A) and roster store migration (PR-B).
+
+## Decision: PR-A blocking on PR-B
+
+PR-A (type promotion) does NOT block on PR-B. PR-A removes 5 sites total: 3 test casts + 2 local `ICampaignInput` interfaces. PR-B touches the roster store + UI which still type-check independently (the cast hack stays in roster store land until PR-B addresses it directly).
+
+PR-B DOES block on PR-A: the new `RosterStateCards` damage bar reads `campaign.unitCombatStates[unitId]` directly, which only type-checks after PR-A promotes the field.
+
+PR-C blocks on PR-B: `ICampaignUnitState` cannot be deleted until the roster store has been migrated off it.
+
+## Open questions (to verify during PR-A)
+
+1. Does `ICampaign` already use any field that conflicts with `unitCombatStates` naming? (Unlikely, but grep.)
+2. Does `phase3RoundTrip.test.ts:320` cast pattern leak into other test files we missed in the Phase 2 scan?
+3. Is `IRecordMissionOutcomeInput.unitUpdates` actually consumed anywhere or is it dead?
+
+PR-A author should grep these BEFORE committing the type promotion.

--- a/openspec/changes/canonicalize-unit-combat-state/proposal.md
+++ b/openspec/changes/canonicalize-unit-combat-state/proposal.md
@@ -1,0 +1,64 @@
+# Canonicalize Unit Combat State
+
+## Intent
+
+Two parallel state representations exist for unit state in the gameplay/campaign domain. `ICampaignUnitState` (in `src/types/campaign/CampaignInterfaces.types.ts:113-136`) stores damage deltas plus orphan display fields (`status`, `repairCost`, `repairTime`, `pilotId`, `unitName`). `IUnitCombatState` (in `src/types/campaign/UnitCombatState.ts:47`) stores current remaining values and is wired into 9 production + test files. The two types serve orthogonal layers — UI store vs processor pipeline — but consumers reach across the boundary via cast-through hacks (`campaign as typeof campaign & { unitCombatStates?: ... }` at three test sites and via local `ICampaignInput` interfaces in two processors).
+
+Council #3 (Lean++ thin variant, decision at `openspec/council-decisions/2026-05-02-cluster-H5-unit-combat-state.md`) ruled: keep `IUnitCombatState` as canonical (matches MegaMek `Entity`'s "current remaining values" convention); promote `unitCombatStates` onto `ICampaign`; delete `ICampaignUnitState` entirely; replace the roster store's unit shape with a thin display projection (NOT named `IUnitDamageState` — collides with three existing definitions).
+
+This change ships the implementation in three sequential PRs (PR-A → PR-B → PR-C), eliminating the cast-through hack and the conflated UI-store-as-state-store anti-pattern. The new canonical spec at `openspec/specs/campaign-unit-combat-state/spec.md` (authored alongside the council decision) is the source-of-truth this change implements.
+
+## Scope
+
+### In
+
+- Promote `unitCombatStates: Record<string, IUnitCombatState>` onto `ICampaign` (`src/types/campaign/Campaign.ts`).
+- Remove the three cast-through sites in `phase3RoundTrip.test.ts:320`, `phase4CampaignRoundTrip.test.ts:385`, `phase4CampaignRoundTrip.test.ts:392`.
+- Remove the local `ICampaignInput` interfaces in `postBattleProcessor.ts` (~line 68-80) and `repairQueueBuilderProcessor.ts` (~line 60-70). Both processors accept `ICampaign` directly post-promotion.
+- Author `IRosterUnitProjection` type carrying only roster-identity + derived display fields: `unitId`, `unitName`, `pilotId`, `chassisVariant`, derived `readiness`. Name MUST avoid `IUnitDamageState` collision.
+- Migrate `useCampaignRosterStore.units: ICampaignUnitState[]` → `units: IRosterUnitProjection[]` (`src/stores/campaign/useCampaignRosterStore.ts`).
+- Migrate `RosterStateCards.tsx` damage bar to read `currentArmorPerLocation` from `campaign.unitCombatStates[unitId]` against `IUnitMaxState.maxArmorPerLocation` denominator.
+- Migrate `RosterStateDisplay.tsx` to consume the projection type.
+- Migrate `CreateCampaignPage.tsx` construct site to build the projection (not the deleted state shape).
+- Add `useMemo` / `zustand/shallow` selector contract for damage-bar derivation to avoid full re-renders on unrelated campaign-store writes.
+- Delete `ICampaignUnitState` from `CampaignInterfaces.types.ts:113-136` (and `ICampaignRoster.units` field if unused after PR-B).
+- Delete or repoint `IRecordMissionOutcomeInput.unitUpdates: Partial<ICampaignUnitState>[]` (replace with `Partial<IUnitCombatState>[]` keyed by unit id).
+- Delete or migrate `getOperationalUnits()` in `CampaignInterfaces.runtime.ts` if it returned the old shape.
+- Update `useCampaignRosterStore.test.ts` (~30 references) to use the projection type.
+
+### Out
+
+- Per-Part hit-count escalation (engine 1/2/3 → MP penalty escalation, gyro 1/2 → +3 PSR mod / destroyed). Spec carve-out tracked under "Deferred extensions" in `openspec/specs/campaign-unit-combat-state/spec.md`. Future change.
+- Pilot consciousness on `ICampaignRosterEntry` (combat-resolution Wave 5 gate). Spec already records the ownership decision.
+- Zustand `persist` migration callback (pre-release product, zero released users — `package.json: "version": "0.1.1", "private": true`). First load post-PR-C rebuilds localStorage from defaults.
+- Salvage inventory (owned by `repair` spec).
+- Damage application math (owned by `combat-resolution` spec).
+
+## Approach
+
+Domains touched:
+- `campaign-management` (`ICampaign.unitCombatStates` slot promotion).
+- `campaign-roster` (`useCampaignRosterStore` projection-type migration).
+- `repair` (no change — already consumes `IUnitCombatState`).
+- `after-combat-report` (no change — already produces outcomes the post-battle processor merges).
+
+Pattern: a single canonical state type (`IUnitCombatState`) lives on `ICampaign.unitCombatStates`; UI consumes it directly via shallow selectors; the roster store holds only display projection. Mirrors MekHQ's `Unit.entity` ownership: one state object is the truth, displays derive from it, repair tickets diff against `IUnitMaxState`. No transient bridge type because we're a single TS process (MekHQ has `ResolveScenarioTracker` only because of MegaMek's IPC boundary).
+
+PR sequencing:
+- **PR-A** (S, ~1h): Type promotion + cast removal. Type-only change; integration round-trip tests verify shape.
+- **PR-B** (M, ~2-3h): Roster store + UI consumer migration. Largest PR — touches stores, components, test fixtures.
+- **PR-C** (S, ~30m): Final deletion. After PR-B lands, `ICampaignUnitState` has zero remaining production references.
+
+Each PR is independently shippable and testable. PR-B should not start until PR-A merges (PR-B's UI changes assume `campaign.unitCombatStates` is the readable source).
+
+## Test Strategy
+
+- **PR-A verification**: `phase3RoundTrip.test.ts` and `phase4CampaignRoundTrip.test.ts` continue to pass with cast hacks removed. Type-checker (`npx tsc --noEmit --skipLibCheck`) confirms `unitCombatStates` is on `ICampaign`. Unit tests for `postBattleProcessor` and `repairQueueBuilderProcessor` continue to pass.
+- **PR-B verification**: `useCampaignRosterStore.test.ts` (30+ references) updated to projection type, all passing. `RosterStateCards.tsx` damage bar renders correctly for: unit at full health, unit at 50% armor, unit with destroyed location. Storybook stories for both `RosterStateCards` and `RosterStateDisplay` render without errors. Manual verification: open dashboard, confirm no excess re-renders on day-advance / XP-gain (selector memoization works).
+- **PR-C verification**: `grep -r "ICampaignUnitState" src/` returns zero hits. Full test suite passes (~22.5k tests). Type-check clean.
+
+## References
+
+- Council #3 decision: `openspec/council-decisions/2026-05-02-cluster-H5-unit-combat-state.md`
+- Canonical spec: `openspec/specs/campaign-unit-combat-state/spec.md`
+- Reference pattern: MegaMek `Entity` (`E:/Projects/megamek/megamek/src/megamek/common/units/Entity.java:455-461`) + MekHQ `Unit.setEntity()` (`E:/Projects/mekhq/MekHQ/src/mekhq/campaign/unit/Unit.java:527-540`)

--- a/openspec/changes/canonicalize-unit-combat-state/specs/campaign-unit-combat-state/spec.md
+++ b/openspec/changes/canonicalize-unit-combat-state/specs/campaign-unit-combat-state/spec.md
@@ -1,0 +1,114 @@
+# Delta Spec: campaign-unit-combat-state
+
+> Adds the `campaign-unit-combat-state` capability to the source-of-truth spec at `openspec/specs/campaign-unit-combat-state/spec.md`. This delta is a NEW spec — no MODIFIED or REMOVED requirements (the capability did not exist before).
+
+## ADDED Requirements
+
+### Requirement: ICampaign owns the canonical unit combat state map
+
+`ICampaign` SHALL declare `unitCombatStates: Readonly<Record<string, IUnitCombatState>>` as a first-class field. All callers SHALL access the map directly. Cast-through patterns SHALL be removed.
+
+#### Scenario: Reading current armor for a deployed unit
+
+- **WHEN** a consumer needs current armor for unit `u-42`
+- **THEN** it reads `campaign.unitCombatStates['u-42']?.currentArmorPerLocation['LT']`
+- **AND** it SHALL NOT read `campaign.roster.units[*].armorDamage` (deleted shape).
+
+#### Scenario: Missing entry indicates undeployed unit
+
+- **WHEN** `campaign.unitCombatStates['u-42']` is `undefined`
+- **THEN** the unit has not yet been deployed
+- **AND** `createInitialCombatState` SHALL run on first deploy to populate the entry.
+
+#### Scenario: ICampaignUnitState is removed from the type system
+
+- **WHEN** searching `src/` for `ICampaignUnitState` references
+- **THEN** the count SHALL be 0.
+
+### Requirement: Combat state shape is normative and positive-space
+
+`IUnitCombatState` SHALL store current remaining values, not damage-taken deltas. Numeric maps keyed by location SHALL hold the post-damage current value. Destroyed components SHALL be deduped by `(location, slot)`. Ammo SHALL be keyed by ammo bin id, not weapon name.
+
+#### Scenario: Armor encoding
+
+- **WHEN** a location loses 4 of 12 armor in battle
+- **THEN** `currentArmorPerLocation['RT']` is `8` (remaining)
+- **AND** the value `4` (damage taken) SHALL NOT appear anywhere in combat state.
+
+#### Scenario: Destroyed component dedup
+
+- **WHEN** the same critical slot is reported destroyed by multiple match outcomes
+- **THEN** `destroyedComponents` contains exactly one entry for that `(location, slot)` pair.
+
+### Requirement: Initial combat state is derived from construction at deploy time
+
+`createInitialCombatState` SHALL accept full-health values from the construction layer and SHALL NOT introspect `unit-entity-model` types directly.
+
+#### Scenario: Construction layer is the source of max values
+
+- **WHEN** `createInitialCombatState` is called
+- **THEN** the caller SHALL pass armor / structure / ammo from construction
+- **AND** combat state SHALL NOT call into construction services itself.
+
+### Requirement: Post-battle merge is idempotent
+
+`postBattleProcessor` SHALL track `lastCombatOutcomeId` on each `IUnitCombatState`. Re-applying an outcome with the same `matchId` SHALL produce a structurally equal state.
+
+#### Scenario: Same matchId applied twice
+
+- **WHEN** an outcome with `matchId='m-7'` is applied to a unit, then applied again
+- **THEN** `destroyedComponents` length is unchanged after the second application.
+
+### Requirement: Deploy gate predicate is centralized
+
+`isUnitCombatReady(state: IUnitCombatState): boolean` SHALL be the only place encoding deploy eligibility.
+
+#### Scenario: Combat-ready flag false
+
+- **WHEN** `state.combatReady` is `false`
+- **THEN** `isUnitCombatReady` returns `false`.
+
+#### Scenario: CT destroyed
+
+- **WHEN** `state.currentStructurePerLocation['CT']` is `0`
+- **THEN** `isUnitCombatReady` returns `false` regardless of `combatReady`.
+
+#### Scenario: Non-mech unit with absent CT entry
+
+- **WHEN** `state.currentStructurePerLocation['CT']` is `undefined` AND `state.combatReady` is `true`
+- **THEN** `isUnitCombatReady` returns `true`.
+
+### Requirement: Combat state SHALL NOT carry display, cost, or roster fields
+
+`IUnitCombatState` SHALL NOT contain `unitName`, `pilotId`, `repairCost`, `repairTime`, or a `status` enum.
+
+#### Scenario: No display name field
+
+- **WHEN** searching `IUnitCombatState` for `unitName`
+- **THEN** the field is absent (display name is cached on `ICampaignRosterEntry`).
+
+#### Scenario: No repair cost field
+
+- **WHEN** searching `IUnitCombatState` for `repairCost` or `repairTime`
+- **THEN** both fields are absent (computed on demand by `repair` spec).
+
+#### Scenario: No status enum field
+
+- **WHEN** searching `IUnitCombatState` for `status` or `CampaignUnitStatus`
+- **THEN** both are absent.
+
+### Requirement: Roster store consumes combat state via thin projection type
+
+`useCampaignRosterStore` SHALL expose a thin display projection (named `IRosterUnitProjection`) carrying only roster-identity and derived display fields. Components needing damage values SHALL read from `campaign.unitCombatStates[unitId]` directly.
+
+#### Scenario: Damage bar rendering
+
+- **WHEN** `RosterStateCards.tsx` renders a damage bar
+- **THEN** it reads `currentArmorPerLocation` from `IUnitCombatState`
+- **AND** computes the bar percentage against `IUnitMaxState.maxArmorPerLocation`
+- **AND** does not read `armorDamage` from a roster projection (deleted field).
+
+#### Scenario: Projection name does not collide
+
+- **WHEN** the projection type is named
+- **THEN** it SHALL NOT be `IUnitDamageState`.

--- a/openspec/changes/canonicalize-unit-combat-state/tasks.md
+++ b/openspec/changes/canonicalize-unit-combat-state/tasks.md
@@ -1,0 +1,179 @@
+# Tasks: Canonicalize Unit Combat State
+
+> Council #3 ruling: ship as 3 sequential PRs (PR-A → PR-B → PR-C). PR-A is a type-only promotion. PR-B is the largest (roster store + UI consumers). PR-C is final cleanup.
+>
+> **Sequencing**: PR-A blocks PR-B. PR-B blocks PR-C. Each PR is independently shippable and CI-verifiable.
+
+## PR-A — Promote unitCombatStates to ICampaign
+
+### 1. Type promotion + open question verification
+
+- [ ] 1.1 Grep `src/types/campaign/Campaign.ts` for any field named `unitCombatStates` (open question #1 from design.md).
+  - Acceptance: zero pre-existing references.
+  - QA: `npx tsc --noEmit --skipLibCheck` clean before any change.
+
+- [ ] 1.2 Add `unitCombatStates: Readonly<Record<string, IUnitCombatState>>` field to `ICampaign` interface in `src/types/campaign/Campaign.ts`.
+  - Required field (not optional). Initialize empty `{}` in fresh-campaign factories.
+  - Add `import type { IUnitCombatState } from './UnitCombatState';` at top of file.
+  - Acceptance: type-only addition, integration tests still type-check.
+  - QA: `npx tsc --noEmit --skipLibCheck` clean.
+
+- [ ] 1.3 Update fresh-campaign factories to initialize `unitCombatStates: {}`.
+  - Locations: `src/stores/campaign/useCampaignStore.ts` (deserialize / loadCampaign / merge paths), any `createCampaign(...)` helpers.
+  - Acceptance: typecheck clean; existing campaign-creation tests pass.
+  - QA: `npx jest --testPathPattern='useCampaignStore'`.
+
+### 2. Cast-through removal
+
+- [ ] 2.1 Remove cast-through pattern in `src/__tests__/integration/phase3RoundTrip.test.ts:320`.
+  - Replace `(campaign as typeof campaign & { readonly unitCombatStates?: ... })` with direct `campaign.unitCombatStates?.['unit-A']`.
+  - Acceptance: test passes; no `as` cast remains in this file targeting `unitCombatStates`.
+  - QA: `npx jest src/__tests__/integration/phase3RoundTrip.test.ts`.
+
+- [ ] 2.2 Remove cast-through patterns in `src/__tests__/integration/phase4CampaignRoundTrip.test.ts:385` and `:392`.
+  - Same pattern as 2.1.
+  - Acceptance: test passes; no `as` cast remains targeting `unitCombatStates`.
+  - QA: `npx jest src/__tests__/integration/phase4CampaignRoundTrip.test.ts`.
+
+### 3. Local interface removal in processors
+
+- [ ] 3.1 Delete local `ICampaignInput` interface in `src/lib/campaign/processors/postBattleProcessor.ts` (~lines 68-80).
+  - Update function signature to accept `ICampaign` directly.
+  - Acceptance: typecheck clean; postBattleProcessor unit tests pass.
+  - QA: `npx jest src/lib/campaign/processors/__tests__/postBattleProcessor.test.ts`.
+
+- [ ] 3.2 Delete local `ICampaignInput` interface in `src/lib/campaign/processors/repairQueueBuilderProcessor.ts` (~lines 60-70).
+  - Update function signature to accept `ICampaign` directly.
+  - Acceptance: typecheck clean; processor unit tests pass.
+  - QA: `npx jest src/lib/campaign/processors/__tests__/repairQueueBuilderProcessor.test.ts`.
+
+### 4. PR-A verification
+
+- [ ] 4.1 `npx tsc --noEmit --skipLibCheck` exit 0.
+- [ ] 4.2 `npx jest --testPathPattern='(phase3RoundTrip|phase4CampaignRoundTrip|postBattleProcessor|repairQueueBuilderProcessor|useCampaignStore)'` all pass.
+- [ ] 4.3 `npx oxfmt --check` clean on all changed files.
+- [ ] 4.4 PR opened, CI green, merged to main.
+
+---
+
+## PR-B — Roster store projection type + UI consumer migration
+
+### 5. Open questions (verify before authoring)
+
+- [ ] 5.1 Grep `src/` for consumers of `IRecordMissionOutcomeInput.unitUpdates` (open question #3 from design.md).
+  - If zero non-test consumers: delete the field entirely in PR-C.
+  - If one or more consumers: replace with `Readonly<Record<string, Partial<IUnitCombatState>>>` shape per design.md decision.
+  - Acceptance: decision documented inline; PR-C task plan updated.
+
+### 6. Author IRosterUnitProjection type
+
+- [ ] 6.1 Create `src/types/campaign/RosterUnitProjection.ts` exporting `IRosterUnitProjection` interface and `deriveRosterReadiness(state: IUnitCombatState | undefined)` helper per design.md shape.
+  - Field set: `unitId`, `unitName`, `pilotId?`, `chassisVariant`, `readiness`.
+  - Add `IUnitMaxState` lookup helper if not already exported.
+  - Acceptance: typecheck clean; new exports importable from `@/types/campaign`.
+  - QA: `npx tsc --noEmit --skipLibCheck`.
+
+### 7. Migrate useCampaignRosterStore
+
+- [ ] 7.1 Change `useCampaignRosterStore` state from `units: ICampaignUnitState[]` to `units: IRosterUnitProjection[]` in `src/stores/campaign/useCampaignRosterStore.ts:68`.
+  - Update `addUnit(unit: IRosterUnitProjection)` (line 88).
+  - Update `getUnitsWithReadiness()` return type (line 107).
+  - Update `getDeployableUnits()` return type (line 111).
+  - Update `unitReadiness(unit: IRosterUnitProjection)` to derive from canonical state via `deriveRosterReadiness`.
+  - Acceptance: typecheck clean within store; downstream callers temporarily broken (fixed in tasks 8-9).
+
+- [ ] 7.2 Migrate `applyDamageCarryForward` (line 316-318): instead of spreading `armorDamage`, `structureDamage`, `destroyedComponents` from `ICampaignUnitState`, the function should be deleted or repointed to write into `campaign.unitCombatStates[unitId]` directly.
+  - This may move out of the roster store entirely (it's a damage-state operation, not a roster operation).
+  - Decision: relocate to `useCampaignStore` or a new `useUnitCombatStateStore` helper.
+  - Acceptance: damage carry-forward integration test still passes.
+  - QA: `npx jest --testPathPattern='applyDamageCarryForward'`.
+
+### 8. Migrate UI components
+
+- [ ] 8.1 Migrate `src/components/campaign/RosterStateDisplay.tsx` to consume `IRosterUnitProjection`.
+  - Change prop type `units: readonly ICampaignUnitState[]` to `units: readonly IRosterUnitProjection[]`.
+  - Update `unit.status` reads (lines 47-48, 148) to `unit.readiness`.
+  - Acceptance: component renders; storybook story still works.
+  - QA: `npx jest src/components/campaign/__tests__/RosterStateDisplay.test.tsx` (if exists); manual storybook check.
+
+- [ ] 8.2 Migrate `src/components/campaign/RosterStateCards.tsx` damage bar to read `currentArmorPerLocation` from canonical state.
+  - Add `useShallow` selector per design.md (selector memoization).
+  - Subscribe to `useCampaignStore((s) => s.campaign.unitCombatStates[unit.unitId])`.
+  - Compute `armorRatio` against `IUnitMaxState.maxArmorPerLocation`.
+  - Drop reads of `unit.armorDamage`, `unit.structureDamage`, `unit.destroyedComponents` from projection.
+  - Acceptance: damage bar renders correctly at 100%, 50%, 0% for each location; no excess re-renders on unrelated store writes.
+  - QA: render-counter test per design.md test strategy; manual visual check.
+
+- [ ] 8.3 Migrate `src/components/gameplay/pages/campaigns/create/CreateCampaignPage.tsx` construct site (lines 14, 135-147) to build `IRosterUnitProjection` instead of full `ICampaignUnitState`.
+  - Combat state initialization moves to deploy flow (not campaign-creation flow).
+  - Acceptance: campaign-creation flow still produces a valid campaign that can deploy units.
+  - QA: `npx jest --testPathPattern='CreateCampaignPage'`.
+
+### 9. Migrate test fixtures
+
+- [ ] 9.1 Update `src/types/campaign/__tests__/CampaignInterfaces.test.ts` `makeUnitState` factory to build `IRosterUnitProjection` (line 11, 36-37).
+  - Acceptance: tests pass.
+  - QA: `npx jest src/types/campaign/__tests__/CampaignInterfaces.test.ts`.
+
+- [ ] 9.2 Audit any other test fixture files using `ICampaignUnitState` (grep `src/__tests__/` and `src/**/__tests__/` for the type name).
+  - Migrate each to `IRosterUnitProjection` or canonical `IUnitCombatState` as appropriate.
+  - Acceptance: full test suite passes.
+  - QA: `npx jest`.
+
+### 10. PR-B verification
+
+- [ ] 10.1 `npx tsc --noEmit --skipLibCheck` exit 0.
+- [ ] 10.2 Full test suite passes (~22.5k tests).
+- [ ] 10.3 Storybook builds without errors (`npm run build-storybook`).
+- [ ] 10.4 Selector memoization render-counter test passes (no excess re-renders on unrelated store writes).
+- [ ] 10.5 `npx oxfmt --check` clean on all changed files.
+- [ ] 10.6 PR opened, CI green, merged to main.
+
+---
+
+## PR-C — Delete ICampaignUnitState
+
+### 11. Pre-deletion grep
+
+- [ ] 11.1 `grep -rn "ICampaignUnitState" src/` — record count.
+  - Expected: only the type definition site + dead references (if any).
+  - Acceptance: count is documented in PR description.
+
+- [ ] 11.2 Re-grep after each task in this PR section.
+
+### 12. Delete the type
+
+- [ ] 12.1 Delete `ICampaignUnitState` interface from `src/types/campaign/CampaignInterfaces.types.ts:113-136`.
+  - Acceptance: typecheck clean (any remaining references will surface).
+  - QA: `npx tsc --noEmit --skipLibCheck`.
+
+- [ ] 12.2 Delete `ICampaignRoster.units` field from `CampaignInterfaces.types.ts:147` if unused after PR-B.
+  - Verify with grep first.
+  - Acceptance: typecheck clean.
+
+- [ ] 12.3 Address `IRecordMissionOutcomeInput.unitUpdates` field per task 5.1 decision:
+  - If unused: delete the field.
+  - If used: replace `Partial<ICampaignUnitState>[]` with `Readonly<Record<string, Partial<IUnitCombatState>>>`.
+  - Acceptance: typecheck clean; consumers migrated.
+
+- [ ] 12.4 Delete `getOperationalUnits()` in `src/types/campaign/CampaignInterfaces.runtime.ts:5,162` if it returned the old shape and is unused after PR-B.
+  - Verify with grep.
+  - Acceptance: typecheck clean.
+
+### 13. Final verification
+
+- [ ] 13.1 `grep -rn "ICampaignUnitState" src/` returns ZERO hits.
+- [ ] 13.2 `npx tsc --noEmit --skipLibCheck` exit 0.
+- [ ] 13.3 Full test suite passes.
+- [ ] 13.4 `npx oxfmt --check` clean.
+- [ ] 13.5 PR opened, CI green, merged to main.
+
+### 14. Spec sync
+
+- [ ] 14.1 On change archive (post-merge of PR-C), the delta spec at `openspec/changes/canonicalize-unit-combat-state/specs/campaign-unit-combat-state/spec.md` syncs into `openspec/specs/campaign-unit-combat-state/spec.md`.
+  - The source-of-truth spec already exists (authored alongside the council decision).
+  - Sync should be a no-op or near-no-op.
+  - Acceptance: `openspec sync` reports no diff or expected diff only.
+
+- [ ] 14.2 Archive change to `openspec/changes/archive/YYYY-MM-DD-canonicalize-unit-combat-state/`.
+  - Acceptance: `openspec list` no longer shows this change as active.

--- a/openspec/council-decisions/2026-05-02-cluster-E-iperson-hard-cutover.md
+++ b/openspec/council-decisions/2026-05-02-cluster-E-iperson-hard-cutover.md
@@ -1,0 +1,99 @@
+# Council #2 Decision — Cluster E: IPerson Hard-Cutover (Flagship)
+
+**Date**: 2026-05-02
+**Variant**: Lean++ thin (3 Phase-2 seats: Hephaestus + Explore-Deep + Momus)
+**Verdict**: VERIFIED (after recount of test fixture site count to 69)
+**Survival Score**: 7/10
+
+## Question
+
+This is the deferred Phase 8.2 of `migrate-personnel-to-roster-employment` (PRs #472/#473/#474). Under hard-cutover policy, the `IPerson` shim + 72 helper signatures must come down. Original brief asked 4 questions:
+
+1. Wave structure (mega-PR vs N domain waves)?
+2. Replacement signature (two-arg vs `IPersonnelView`)?
+3. `ICampaign.personnel` field (drop entirely vs derived getter)?
+4. Sequencing dependency on bridge functions?
+
+## Decision
+
+**STAGED CUTOVER — 5 sequential PRs. Bridge functions stay alive through PR1-PR2; Map drops in PR3.**
+
+Both proposers and adversary converged on:
+- Two-arg `(entry: ICampaignRosterEntry, pilot: IPilot | null)` signature (NOT `IPersonnelView` god-type rename)
+- 5 sequential PRs (NOT 6 parallel domain waves — processor pipeline atomicity blocks parallelism)
+- Drop `ICampaign.personnel` entirely (NOT derived getter — keeps `isCampaign()` coupled)
+- Delete bridge functions (`derivePersonnelFromRoster`, `syncRosterFromPersonnel`) in PR4 — kills the lossy Critical→Wounded round-trip bug
+
+## Critical findings
+
+1. **Metis's "Map is dead" was WRONG**. Momus + Explore-Deep verified ~10+ production readers of `campaign.personnel`:
+   - 5 processors (`healingProcessor`, `autoAwardsProcessor`, `vocationalTrainingProcessor`, `turnoverProcessor`, `randomEventsProcessor`, `postBattleProcessor`)
+   - 3 finance services (`salaryService`, `taxService`, `FinanceService` in `src/lib/finances/`)
+   - `dayAdvancement.ts:329,429`
+   - `autoAwardEngine.ts:55`, `turnoverCheck.ts:257`
+   - 4 type-layer helpers in `Campaign.ts:147,163,180,300`
+   - 2 UI `.size` reads (`campaigns/index.tsx:46`, `CampaignDashboardPage.sections.tsx:157`)
+
+2. **Test fixture surface ~69 sites** across 20+ test files (verified). NOT 2 (Metis's initial count). This drives PR1 sequencing.
+
+3. **Processor pipeline is NOT splittable**. `dayAdvancement.ts:425-452` chains 6 processors via immutable `ICampaign` spreads. PR3 must repoint atomically.
+
+4. **84 helper files in `src/lib/campaign/`** (not 61 — Metis Glob truncation).
+
+## What ships
+
+### PR1 — Test fixture migration (~69 sites)
+Migrate `personnel: new Map([...])` test fixtures to `useCampaignRosterStore.setPilots([entry])` + `usePilotStore.addPilot(vaultPilot)`. Bridge layer untouched.
+
+### PR2 — Helper signature migration (~72 helpers, 84 files, per-domain commits in ONE PR)
+Two-arg signature `(entry, pilot | null)`. Per-domain commits:
+1. medical (7 files)
+2. turnover (5 files) + ranks/rankService.isOfficer cross-call
+3. finances/statusRules + 3 finance services in `src/lib/finances/`
+4. progression (4 files) + skills (3 files)
+5. awards (2 files, ~18 checker functions)
+6. ranks + maintenance + events
+7. type-layer helpers in `Campaign.ts`
+
+Pre-join template: `Map<pilotId, IPilot>` from vault to avoid N² `find()` calls.
+
+### PR3 — Processor + dayAdvancement repointing (atomic)
+Update `dayAdvancement.ts` + 6 processors + 4 `Campaign.ts` helpers + 2 UI `.size` readers. Bridge functions still alive but no production code reads `campaign.personnel`.
+
+### PR4 — Map drop + lossy bug fix
+Delete `ICampaign.personnel`, `derivePersonnelFromRoster`, `syncRosterFromPersonnel`, `isCampaign()` guard, legacy preservation merge at `useCampaignStore.ts:743-750`.
+
+### PR5 — Cleanup
+Delete `IPerson` interface, `rosterEntryToPerson.ts` shim + tests. Final grep: `IPerson` count = 0 in src/.
+
+## Out of scope (REFUSED)
+
+- `IPersonnelView` (renamed god type)
+- 6 parallel domain waves (processor pipeline atomicity)
+- Memoization (premature)
+- `IAttributes` aspirational fields
+- `PersonnelStatus` 37-value vs `CampaignPilotStatus` 5-value reconciliation
+- Vault/roster store split architecture
+
+## Open questions tracked
+
+1. **`IInjury[]` migration**: lives on `IPerson.injuries`; verify `ICampaignRosterEntry.injuries` exists in PR2 medical commit; add if absent.
+2. **NPC domain matrix**: turnover/vocational training/awards produce noise on NPC entries; PR2 helpers must document which domains skip NPCs explicitly.
+3. **Delta-return contract for cross-store mutations**: PR2 progression returns delta objects; PR3 processors commit deltas to right store.
+
+## Council seats
+
+| Seat | Position | Survival | Model |
+|---|---|---|---|
+| Hephaestus | proposer (9 waves, 6 parallel domains) | 8/10 | opus |
+| Explore-Deep | call-graph (84 files; 10+ Map readers) | n/a | sonnet |
+| Momus | adversary (overruled Metis "Map is dead"; 69 test sites) | n/a | sonnet |
+| Phase 4.5 verifier | VERIFIED after recount | n/a | haiku |
+
+## Effort estimate
+
+5 PRs over **3-4 weeks** of focused work. PR1 (test fixtures) and PR2 (helpers) are the bulk. PR3-PR5 are smaller but coupled.
+
+## Phase 6 status
+
+**Not started in this session.** Council #2 deliverable is the openspec change `wire-iperson-hard-cutover` (to be authored by Prometheus) and the 5 PRs that follow. Implementation is multi-week — picks up in subsequent sessions.

--- a/openspec/council-decisions/2026-05-02-cluster-H5-unit-combat-state.md
+++ b/openspec/council-decisions/2026-05-02-cluster-H5-unit-combat-state.md
@@ -1,0 +1,142 @@
+# Council #3 Decision — Cluster H pair #5: Unit Combat State Canonicalization
+
+**Date**: 2026-05-02
+**Variant**: Lean++ thin (Phase 0 Metis + 3 Phase-2 seats: Explore-Deep + Oracle-as-adversary + general-purpose for spec scoping)
+**Verdict**: VERIFIED (Phase 4.5 Haiku — all 4 deciding facts confirmed)
+**Survival Score**: 8/10
+**Execution status**: Decision + spec authoring complete this session. Implementation deferred to next session per ULTRAWORK loop scope cap.
+
+---
+
+## Question
+
+The original triage plan asked: "ICampaignUnitState (delta-based) vs IUnitCombatState (absolute-based) — which representation wins, and what's the migration?"
+
+Phase 0 Metis reframed the question. The "delta vs absolute" framing was wrong — the two types track orthogonal concerns:
+
+- `IUnitCombatState` (`src/types/campaign/UnitCombatState.ts`) — processor/engine layer. Stores current remaining values. Already wired into 9 files including `postBattleProcessor`, `repairQueueBuilderProcessor`, `repairQueueBuilder`, and round-trip integration tests.
+- `ICampaignUnitState` (`src/types/campaign/CampaignInterfaces.types.ts:113-136`) — Zustand UI store type. Stores damage deltas (`armorDamage`, `structureDamage`) plus orphan display fields (`status`, `repairCost`, `repairTime`, `pilotId`, `unitName`).
+
+The real question became: how do we collapse to one canonical state shape, where does the display projection live, and what spec crystallizes it?
+
+## Reference pattern: MegaMek + MekHQ
+
+Phase 0 research grounded the determination in the canonical Java reference implementation at `E:/Projects/megamek` and `E:/Projects/mekhq`:
+
+| Layer | Type | What it owns |
+|---|---|---|
+| Combat engine (MegaMek) | `Entity` (inside `Game`) | Current remaining values: `armor[loc]`, `internal[loc]`, `shotsLeft` per ammo bin |
+| Transient bridge (MekHQ) | `ResolveScenarioTracker` + `UnitStatus` | Lives ~5 min during the resolve wizard, then garbage-collected |
+| Persistent campaign (MekHQ) | `Unit` wraps a single `Entity`; `Part` collection per unit | The Entity IS the persistent state. Damage absorbed via `unit.setEntity(en)`. Per-Part deltas computed on demand by `runDiagnostic()`. |
+
+**Three load-bearing observations:**
+
+1. **One canonical state type.** MekHQ doesn't keep two parallel representations. `Entity` is the truth, full stop.
+2. **Current remaining values, not deltas.** Deltas are computed on demand by `Part.updateConditionFromEntity()`.
+3. **Transient bridge exists only because of an IPC boundary.** MegaMek runs in a separate JVM and hands MekHQ an `Entity` via `IGameListener.gameVictory(PostGameResolution)`. Without that boundary, MekHQ would update Unit directly. We're a single TS process; the post-battle handoff is an in-process function call.
+
+## Decision
+
+**KEEP `IUnitCombatState`. DELETE `ICampaignUnitState`. PROMOTE `unitCombatStates` onto `ICampaign`. REPLACE the roster store's unit shape with a thin projection type. AUTHOR a canonical spec.**
+
+Specifically:
+
+1. **`IUnitCombatState` is canonical** — matches MegaMek `Entity`'s "current remaining values" convention. `IDestroyedComponent` already carries `slot: number` (verified at `UnitCombatState.ts:31`), enabling per-slot repair targeting.
+2. **`unitCombatStates: Record<string, IUnitCombatState>` is promoted to `ICampaign`** — eliminates the cast-through pattern (`campaign as typeof campaign & { unitCombatStates?: ... }`) used in 3 test sites and the local `ICampaignInput` interfaces in 2 processor files.
+3. **`ICampaignUnitState` is deleted entirely** — it stores deltas (anti-pattern) AND it conflates damage state with display caches.
+4. **`useCampaignRosterStore` gets a thin projection type** carrying only `unitId`, `unitName`, `pilotId`, `chassisVariant`, derived `readiness`. **The projection type SHALL NOT be named `IUnitDamageState`** — that name has 3 independent definitions in the repo (`lib/combat/acar.ts`, `utils/gameplay/damage/types.ts`, current roster store). Suggested name: `IRosterUnitProjection`.
+5. **`repairCost` / `repairTime` are computed on demand by `repair`** — they are not stored on combat state. Mirrors MekHQ's `Part.updateConditionFromEntity()` pattern.
+6. **No transient bridge type** — single TS process, in-process function calls.
+7. **No Zustand `persist` migration needed** — pre-release product, zero released users (verified via `package.json: "version": "0.1.1", "private": true`). First load post-deletion rebuilds localStorage from defaults.
+
+## Critical Phase 2 findings
+
+### Explore-Deep call-graph verification
+
+- **9 files for `IUnitCombatState`**: 3 production (`UnitCombatState.ts` def, `postBattleProcessor`, `repairQueueBuilderProcessor`, `repairQueueBuilder`) + 6 test files. Metis claim VERIFIED.
+- **7 files for `ICampaignUnitState`**: definition, 1 store, 2 UI components, 1 construct site, 1 runtime util, 1 test. VERIFIED.
+- **`IDestroyedComponent` HAS slot index** (`UnitCombatState.ts:31`): `readonly slot: number`. Per-slot repair costing is feasible; spec gap on this is closed.
+- **5 fields on `ICampaignUnitState` with NO equivalent on `IUnitCombatState`**: `status`, `repairCost`, `repairTime`, `pilotId`, `unitName`. Migration plan handles each:
+  - `unitName`, `pilotId` → roster projection type
+  - `status` → derived view, not stored
+  - `repairCost`, `repairTime` → computed by repair queue
+- **`RosterStateCards.tsx:73-74`** uses coarse `armorDamage` / `structureDamage` Records for damage bar display. Migration item: switch to `currentArmorPerLocation` with `IUnitMaxState` denominator.
+
+### Adversary objections (Oracle in red-team role)
+
+Three required revisions to the determination, all incorporated above:
+
+1. **`IUnitDamageState` name collision** — confirmed 3 independent definitions. Renaming the roster projection to a non-colliding name is mandatory.
+2. **Save/load round-trip** — flagged as critical, but the pre-release context (zero users) defuses it. No `persist` migration callback required.
+3. **Per-Part hit-count escalation** (engine 1/2/3, gyro 1/2) — current `destroyedComponents` is binary. Spec carve-out added under "Deferred extensions"; tracked as `TODO(per-part-hit-escalation)` in `IDestroyedComponent`.
+
+Performance caveat (dashboard re-render on every campaign-store write): noted in spec migration notes; will need `useMemo` or `zustand/shallow` selector contract during execution.
+
+### Spec authoring guardrails (5 traps avoided)
+
+1. Spec does not pin field-level location codes (varies by chassis).
+2. Spec does not re-spec damage application math (owned by `combat-resolution`).
+3. Spec separates "status" (derived view) from "combatReady" (stored field).
+4. Spec uses negative requirements to lock down anti-fields (no `unitName`, `pilotId`, `repairCost`, `repairTime`, `status` on combat state).
+5. Spec stays silent on persistence mechanism (Zustand / localStorage) — owned by store specs.
+
+## What ships from this session
+
+- **`openspec/specs/campaign-unit-combat-state/spec.md`** — canonical spec, 11 requirements, ~30 scenarios, deferred extensions section, migration notes.
+- **`openspec/council-decisions/2026-05-02-cluster-H5-unit-combat-state.md`** — this document.
+
+## Execution scope (deferred to next session)
+
+The implementation breaks cleanly into 3 sequential PRs. None are blocking on each other beyond ordering:
+
+### PR-A — Promote `unitCombatStates` to `ICampaign` (S, ~1 hour)
+
+- Add `unitCombatStates: Record<string, IUnitCombatState>` to `ICampaign` type
+- Remove 3 cast-through sites in `phase3RoundTrip.test.ts:320`, `phase4CampaignRoundTrip.test.ts:385`, `phase4CampaignRoundTrip.test.ts:392`
+- Remove local `ICampaignInput` interfaces in `postBattleProcessor.ts` and `repairQueueBuilderProcessor.ts` — accept `ICampaign` directly
+- Verify via integration round-trip tests
+
+### PR-B — Replace roster store unit shape with projection type (M, ~2-3 hours)
+
+- Author `IRosterUnitProjection` type (5 fields: `unitId`, `unitName`, `pilotId`, `chassisVariant`, derived `readiness`)
+- Migrate `useCampaignRosterStore.units: ICampaignUnitState[]` → `units: IRosterUnitProjection[]`
+- Migrate `RosterStateCards.tsx` damage bar to read `currentArmorPerLocation` from `campaign.unitCombatStates`
+- Migrate `RosterStateDisplay.tsx` to use projection type
+- Migrate `CreateCampaignPage.tsx` construct site to build projection (not full state)
+- Add `useMemo` / shallow selector for damage-bar derivation
+- All 30+ test references in `useCampaignRosterStore.test.ts` updated
+
+### PR-C — Delete `ICampaignUnitState` (S, ~30 min)
+
+- Delete `ICampaignUnitState` from `CampaignInterfaces.types.ts:113-136`
+- Delete `ICampaignRoster.units: ICampaignUnitState[]` field if unused after PR-B
+- Delete `IRecordMissionOutcomeInput.unitUpdates: Partial<ICampaignUnitState>[]` (replace with `Partial<IUnitCombatState>[]` keyed by unit id)
+- Delete `getOperationalUnits()` in `CampaignInterfaces.runtime.ts` if it returned the old shape
+- Final grep: `ICampaignUnitState` count = 0 in `src/`
+
+## Survival score breakdown
+
+- **Architectural soundness**: 9/10 — matches canonical reference implementation
+- **Migration risk**: 7/10 — 3 cast sites + roster store rewrite + name collision avoidance — non-trivial but bounded
+- **Spec quality**: 8/10 — explicit anti-fields, deferred extensions called out, cross-spec boundaries enumerated
+- **Verification depth**: 8/10 — Phase 0 + 3 Phase-2 seats + Phase 4.5 Haiku verification confirmed all 4 deciding facts
+
+**Overall: 8/10**.
+
+## Council seats
+
+| Seat | Position | Model |
+|---|---|---|
+| Phase 0 Metis | reframer (overruled "delta vs absolute" framing; flagged roster store dependency understatement) | sonnet |
+| Explore-Deep | call-graph verification (9 IUnitCombatState files; 7 ICampaignUnitState files; IDestroyedComponent slot field; 5 fields with no equivalent) | sonnet |
+| Oracle (adversary role) | red-team objections (name collision; persist migration; hit-count escalation; perf caveat) | opus |
+| general-purpose (spec scoping) | spec outline + 5 authoring guardrails | sonnet |
+| Phase 4.5 Haiku verifier | VERIFIED (4/4 deciding facts confirmed) | haiku |
+
+## Effort estimate
+
+PR-A + PR-B + PR-C = approximately 4-6 hours of focused work. All three can ship in a single follow-up session.
+
+## Phase 6 status
+
+**Skipped this session.** Per ULTRAWORK loop cap, Council #3 deliverable is decision-doc + spec authoring. PR-A through PR-C are the implementation chain, deferred to next session.

--- a/openspec/specs/campaign-unit-combat-state/spec.md
+++ b/openspec/specs/campaign-unit-combat-state/spec.md
@@ -1,0 +1,246 @@
+# Campaign Unit Combat State Specification
+
+**Status**: Active
+**Version**: 1.0
+**Last Updated**: 2026-05-02
+**Dependencies**: campaign-management, unit-entity-model
+**Affects**: repair, after-combat-report, campaign-roster, post-battle-processor
+
+---
+
+## Overview
+
+### Purpose
+
+Crystallize the canonical **runtime damage state** carried per unit between scenarios. Distinguish "what the unit was built with" (construction state, owned by `unit-entity-model`) from "what it currently has after wear" (combat state, owned here). Eliminate parallel/conflated shapes that mix display caches, repair-cost estimates, and damage state.
+
+This spec is the source-of-truth for `IUnitCombatState` and `ICampaign.unitCombatStates`. It supersedes the inline conventions previously embedded in `postBattleProcessor`, `repairQueueBuilder`, and the `useCampaignRosterStore` Zustand store.
+
+### Scope
+
+**In Scope:**
+
+- Canonical `IUnitCombatState` shape and field semantics (armor / structure remaining, destroyed locations + components, ammo remaining, end-of-battle heat, `combatReady` flag, idempotency keys).
+- `IUnitMaxState` reference shape (full-health snapshot for diff-based repair).
+- Ownership: `ICampaign.unitCombatStates: Record<string, IUnitCombatState>` is the single canonical map.
+- Lifecycle: when state is created (`createInitialCombatState`), updated (post-battle processor), and reset (post-repair).
+- Deploy gate semantics (`isUnitCombatReady`).
+- Idempotency contract via `lastCombatOutcomeId` for re-applying the same `matchId`.
+- Explicit anti-fields (what combat state SHALL NOT carry).
+
+**Out of Scope:**
+
+- Damage application math (owned by `combat-resolution`).
+- Repair cost / time / queue construction (owned by `repair`).
+- Pilot status (`WOUNDED` / `MIA` / `KIA`) — lives on `ICampaignRosterEntry`, not on combat state.
+- Unit display name / chassis / variant (cached on `ICampaignRosterEntry`, not duplicated here).
+- Salvage inventory (owned by `repair`).
+- Persistence mechanism (Zustand / localStorage / IndexedDB details belong to store specs).
+- Per-Part hit-count escalation (engine 1 / 2 / 3, gyro 1 / 2). See "Deferred extensions" below.
+
+### Key Concepts
+
+- **Construction state** vs **Combat state** vs **Roster entry** — three orthogonal type families with one-way derivation: construction → combat (at deploy), combat → roster projection (for display).
+- **Current remaining values, not deltas** — combat state stores positive-space "what's left" values, never damage-taken deltas (mirrors MegaMek `Entity.armor[loc]`).
+- **Idempotent post-battle merge** — keyed by `matchId` via `lastCombatOutcomeId`; re-applying the same outcome SHALL NOT double-decrement.
+- **Deploy gate** — `combatReady && CT > 0` is the canonical predicate (`isUnitCombatReady`).
+- **Max-state diff** — `IUnitMaxState` baseline lets `repair` compute diff-driven tickets without inspecting construction state.
+
+---
+
+## Requirements
+
+### Requirement: ICampaign owns the canonical unit combat state map
+
+`ICampaign` SHALL declare `unitCombatStates: Record<string, IUnitCombatState>` as a first-class field. All callers SHALL access the map directly via `campaign.unitCombatStates`. Cast-through patterns (`campaign as typeof campaign & { unitCombatStates?: ... }`) SHALL be removed.
+
+#### Scenario: Reading current armor for a deployed unit
+
+- **WHEN** a consumer needs current armor for unit `u-42`
+- **THEN** it reads `campaign.unitCombatStates['u-42']?.currentArmorPerLocation['LT']`
+- **AND** it SHALL NOT read `campaign.roster.units[*].armorDamage` (deleted shape).
+
+#### Scenario: Missing entry indicates undeployed unit
+
+- **WHEN** `campaign.unitCombatStates['u-42']` is `undefined`
+- **THEN** the unit has not yet been deployed (or its combat state was reset post-repair)
+- **AND** `createInitialCombatState` SHALL run on first deploy to populate the entry.
+
+#### Scenario: ICampaignUnitState is removed from the type system
+
+- **WHEN** searching `src/` for `ICampaignUnitState` references
+- **THEN** the count SHALL be 0 (the doomed shape from `CampaignInterfaces.types.ts`).
+
+### Requirement: Combat state shape is normative and positive-space
+
+`IUnitCombatState` SHALL store current remaining values, not damage-taken deltas. Numeric maps keyed by location SHALL hold the post-damage current value. Destroyed components SHALL be deduped by `(location, slot)`. Ammo SHALL be keyed by ammo bin id, not weapon name.
+
+#### Scenario: Armor encoding
+
+- **WHEN** a location loses 4 of 12 armor in battle
+- **THEN** `currentArmorPerLocation['RT']` is `8` (remaining)
+- **AND** the value `4` (damage taken) SHALL NOT appear anywhere in combat state.
+
+#### Scenario: Destroyed component dedup
+
+- **WHEN** the same critical slot is reported destroyed by multiple match outcomes
+- **THEN** `destroyedComponents` contains exactly one entry for that `(location, slot)` pair.
+
+#### Scenario: Ammo bin keying
+
+- **WHEN** a unit carries two SRM-6 ammo bins
+- **THEN** each bin has its own entry in `ammoRemaining` keyed by bin id
+- **AND** depleting bin A SHALL NOT affect bin B's count.
+
+### Requirement: Initial combat state is derived from construction at deploy time
+
+`createInitialCombatState` SHALL accept full-health values from the construction layer (`armorPerLocation`, `structurePerLocation`, optional `ammoPerBin`) and SHALL NOT introspect `unit-entity-model` types directly. The function output SHALL be a fresh `IUnitCombatState` with `combatReady: true` and no destroyed components.
+
+#### Scenario: Mech with no ammo
+
+- **WHEN** a laser-only mech is deployed
+- **THEN** `ammoRemaining` is `{}` (empty record, valid).
+
+#### Scenario: Construction layer is the source of max values
+
+- **WHEN** `createInitialCombatState` is called
+- **THEN** the caller SHALL pass armor / structure / ammo from construction
+- **AND** combat state SHALL NOT call into construction services itself.
+
+### Requirement: Post-battle merge is idempotent
+
+`postBattleProcessor` SHALL track `lastCombatOutcomeId` on each `IUnitCombatState`. Re-applying an outcome with the same `matchId` SHALL produce a structurally equal state.
+
+#### Scenario: Same matchId applied twice
+
+- **WHEN** an outcome with `matchId='m-7'` is applied to a unit, then applied again
+- **THEN** `destroyedComponents` length is unchanged after the second application
+- **AND** `ammoRemaining` values are unchanged after the second application.
+
+#### Scenario: New matchId proceeds normally
+
+- **WHEN** `lastCombatOutcomeId` is `'m-7'` and a new outcome with `matchId='m-8'` arrives
+- **THEN** the merge proceeds and `lastCombatOutcomeId` updates to `'m-8'`.
+
+### Requirement: Deploy gate predicate is centralized
+
+`isUnitCombatReady(state: IUnitCombatState): boolean` SHALL be the only place encoding deploy eligibility. UI and processor callers SHALL use this helper rather than inlining `state.combatReady && state.currentStructurePerLocation['CT'] > 0`.
+
+#### Scenario: Combat-ready flag false
+
+- **WHEN** `state.combatReady` is `false`
+- **THEN** `isUnitCombatReady` returns `false`.
+
+#### Scenario: CT destroyed
+
+- **WHEN** `state.currentStructurePerLocation['CT']` is `0`
+- **THEN** `isUnitCombatReady` returns `false` regardless of `combatReady`.
+
+#### Scenario: Non-mech unit with absent CT entry
+
+- **WHEN** `state.currentStructurePerLocation['CT']` is `undefined` (vehicle / aerospace / infantry) AND `state.combatReady` is `true`
+- **THEN** `isUnitCombatReady` returns `true` (treat unknown-CT as intact for non-mech chassis).
+
+#### Scenario: Repair completion flips combatReady
+
+- **WHEN** a "rebuild destroyed unit" repair job completes
+- **THEN** the repair flow flips `combatReady` from `false` back to `true`.
+
+### Requirement: Max-state companion shape supports repair diff
+
+`IUnitMaxState` SHALL hold full-health reference values built once at deploy from construction state. The repair ticket generator SHALL diff `IUnitCombatState` against `IUnitMaxState` to build `IDamageAssessment`. Locations absent from the max-state SHALL be skipped (no spurious tickets for partial-data units).
+
+#### Scenario: Diff-driven ticket generation
+
+- **WHEN** `currentArmorPerLocation['LT']` is `4` and `IUnitMaxState.maxArmorPerLocation['LT']` is `12`
+- **THEN** the repair queue contains an `armor` ticket for `LT` with `points = 8`.
+
+#### Scenario: Absent max-state entry
+
+- **WHEN** `IUnitMaxState.maxArmorPerLocation['LT']` is `undefined`
+- **THEN** no armor ticket is generated for `LT` (skipped).
+
+### Requirement: Combat state SHALL NOT carry display, cost, or roster fields
+
+`IUnitCombatState` SHALL NOT contain any of the following fields. UI display, repair pricing, and roster identity belong to other types per the cleavage above.
+
+#### Scenario: No display name field
+
+- **WHEN** searching `IUnitCombatState` for `unitName`
+- **THEN** the field is absent (display name is cached on `ICampaignRosterEntry`).
+
+#### Scenario: No repair cost field
+
+- **WHEN** searching `IUnitCombatState` for `repairCost` or `repairTime`
+- **THEN** both fields are absent (computed on demand by `repair` spec).
+
+#### Scenario: No pilot id field
+
+- **WHEN** searching `IUnitCombatState` for `pilotId`
+- **THEN** the field is absent (lives on `ICampaignRosterEntry`).
+
+#### Scenario: No status enum field
+
+- **WHEN** searching `IUnitCombatState` for `status` or `CampaignUnitStatus`
+- **THEN** both are absent. Any displayed "status" is a derived view from `combatReady` + `destroyedLocations` + roster context, not a stored field.
+
+### Requirement: Roster store consumes combat state via thin projection type
+
+`useCampaignRosterStore` SHALL expose a thin display projection (suggested name: `IRosterUnitProjection`) carrying only roster-identity and derived display fields (`unitId`, `unitName`, `pilotId`, `chassisVariant`, derived `readiness`). The projection SHALL NOT duplicate damage-state fields from `IUnitCombatState`. Components needing damage values SHALL read from `campaign.unitCombatStates[unitId]` directly.
+
+#### Scenario: Damage bar rendering
+
+- **WHEN** `RosterStateCards.tsx` renders a damage bar
+- **THEN** it reads `currentArmorPerLocation` from `IUnitCombatState`
+- **AND** computes the bar percentage against `IUnitMaxState.maxArmorPerLocation`
+- **AND** does not read `armorDamage` from a roster projection (deleted field).
+
+#### Scenario: Projection name does not collide
+
+- **WHEN** the projection type is named
+- **THEN** it SHALL NOT be `IUnitDamageState` (collides with three existing definitions in `lib/combat/acar.ts`, `utils/gameplay/damage/types.ts`, and the prior `useCampaignRosterStore`).
+
+### Requirement: Cross-spec consumption boundaries
+
+#### Scenario: Repair spec consumption
+
+- **WHEN** `repair/spec.md` describes damage assessment input
+- **THEN** it consumes `IUnitCombatState` + `IUnitMaxState` to drive `IDamageAssessment` and `IRepairJob`.
+
+#### Scenario: After-combat report production
+
+- **WHEN** `after-combat-report/spec.md` describes the post-battle data flow
+- **THEN** it produces the outcome data the post-battle processor merges into `unitCombatStates`.
+
+#### Scenario: Unit entity model upstream relationship
+
+- **WHEN** `unit-entity-model/spec.md` describes construction state
+- **THEN** combat state is its post-deploy projection, derived once via `createInitialCombatState`.
+
+---
+
+## Deferred extensions
+
+### Per-Part hit-count escalation
+
+MegaMek tracks engine hits (1 / 2 / 3 → MP penalty escalation, 3rd hit destroys) and gyro hits (1 → +3 PSR mod, 2 → destroyed) as accumulating counters, not binary destroyed flags. The current `IDestroyedComponent` shape encodes binary destruction. A future spec extension SHALL add an optional `hitCount?: number` to `IDestroyedComponent` and update merge semantics to escalate rather than dedupe for engine / gyro components.
+
+**Status**: Not required for current waves. Tracked as `TODO(per-part-hit-escalation)` in `IDestroyedComponent`.
+
+### Pilot consciousness
+
+`pilotConscious` is unreachable in current waves (combat-resolution Wave 5 gate). When wired, it SHALL live on `ICampaignRosterEntry`, not on `IUnitCombatState` — keeps the cleavage between unit-state and pilot-state intact.
+
+---
+
+## Migration notes
+
+This spec replaces the implicit conventions previously held by `useCampaignRosterStore` and the cast-through hacks in integration tests. Execution PRs (deferred from this session) SHALL:
+
+1. Promote `unitCombatStates` to `ICampaign` (1 type file + 3 test cast-removals).
+2. Replace `useCampaignRosterStore`'s `units: ICampaignUnitState[]` with the projection type (rename to avoid `IUnitDamageState` collision).
+3. Migrate `RosterStateCards.tsx` damage bar to read `currentArmorPerLocation` against `IUnitMaxState`.
+4. Delete `ICampaignUnitState` from `CampaignInterfaces.types.ts` and `CampaignInterfaces.runtime.ts`.
+5. Remove local `ICampaignInput` interfaces in `postBattleProcessor` and `repairQueueBuilderProcessor` — accept `ICampaign` directly.
+
+Pre-release context (zero released users, hard-cutover policy): no Zustand `persist` migration callback required. First load post-deletion rebuilds localStorage from defaults.


### PR DESCRIPTION
## Summary

Council #3 (Cluster H pair #5) determined `IUnitCombatState` is the canonical runtime damage state. `ICampaignUnitState` is deleted; `unitCombatStates` is promoted onto `ICampaign`; the roster store gets a thin display projection (NOT named `IUnitDamageState` — collides with 3 existing definitions).

This PR ships:
- New canonical spec at [`openspec/specs/campaign-unit-combat-state/spec.md`](openspec/specs/campaign-unit-combat-state/spec.md) — 11 requirements, ~30 scenarios, deferred extensions for per-Part hit-count escalation.
- Council #3 decision doc at [`openspec/council-decisions/2026-05-02-cluster-H5-unit-combat-state.md`](openspec/council-decisions/2026-05-02-cluster-H5-unit-combat-state.md) — includes 3-PR execution plan (PR-A promote, PR-B projection, PR-C delete).
- Council #2 decision doc (Cluster E IPerson) — staged from prior session.

**Reference**: MegaMek `Entity` / MekHQ `Unit` canonical pattern. Single canonical state type; current remaining values (not deltas); transient bridge only when crossing IPC boundaries.

## Council variant

Lean++ thin (Phase 0 Metis + 3 Phase-2 seats: Explore-Deep + Oracle-as-adversary + general-purpose for spec scoping). Phase 4.5 Haiku verifier confirmed all 4 deciding facts: source citations, pre-release localStorage status, cast-through count, name collision claim.

## Implementation status

**Decision doc + spec authoring only** — implementation deferred to next session per ULTRAWORK loop scope cap. PR-A through PR-C estimated at 4-6 hours total focused work.

## Test plan

- [x] Docs-only PR; no code changes
- [x] CI lint / format / typecheck still pass on docs-only diff