### PR TITLE
Cluster H5 PR-A — Promote unitCombatStates to ICampaign

### DIFF
--- a/openspec/changes/canonicalize-unit-combat-state/tasks.md
+++ b/openspec/changes/canonicalize-unit-combat-state/tasks.md
@@ -8,50 +8,57 @@
 
 ### 1. Type promotion + open question verification
 
-- [ ] 1.1 Grep `src/types/campaign/Campaign.ts` for any field named `unitCombatStates` (open question #1 from design.md).
+- [x] 1.1 Grep `src/types/campaign/Campaign.ts` for any field named `unitCombatStates` (open question #1 from design.md).
   - Acceptance: zero pre-existing references.
   - QA: `npx tsc --noEmit --skipLibCheck` clean before any change.
+  - Result: zero hits — clean slate.
 
-- [ ] 1.2 Add `unitCombatStates: Readonly<Record<string, IUnitCombatState>>` field to `ICampaign` interface in `src/types/campaign/Campaign.ts`.
+- [x] 1.2 Add `unitCombatStates: Readonly<Record<string, IUnitCombatState>>` field to `ICampaign` interface in `src/types/campaign/Campaign.ts`.
   - Required field (not optional). Initialize empty `{}` in fresh-campaign factories.
   - Add `import type { IUnitCombatState } from './UnitCombatState';` at top of file.
   - Acceptance: type-only addition, integration tests still type-check.
   - QA: `npx tsc --noEmit --skipLibCheck` clean.
+  - Result: field added; both `createCampaign` and `createCampaignWithData` factories seed `unitCombatStates: {}`.
 
-- [ ] 1.3 Update fresh-campaign factories to initialize `unitCombatStates: {}`.
+- [x] 1.3 Update fresh-campaign factories to initialize `unitCombatStates: {}`.
   - Locations: `src/stores/campaign/useCampaignStore.ts` (deserialize / loadCampaign / merge paths), any `createCampaign(...)` helpers.
   - Acceptance: typecheck clean; existing campaign-creation tests pass.
   - QA: `npx jest --testPathPattern='useCampaignStore'`.
+  - Result: `deserializeCampaign` (used by `loadCampaign` + `merge`) seeds `unitCombatStates: {}`. Other in-store ICampaign literals (`createCampaign`, `updateCampaign`, `saveCampaign`, `advanceDay`) all use `{ ...campaign }` spread and inherit the field.
 
 ### 2. Cast-through removal
 
-- [ ] 2.1 Remove cast-through pattern in `src/__tests__/integration/phase3RoundTrip.test.ts:320`.
+- [x] 2.1 Remove cast-through pattern in `src/__tests__/integration/phase3RoundTrip.test.ts:320`.
   - Replace `(campaign as typeof campaign & { readonly unitCombatStates?: ... })` with direct `campaign.unitCombatStates?.['unit-A']`.
   - Acceptance: test passes; no `as` cast remains in this file targeting `unitCombatStates`.
   - QA: `npx jest src/__tests__/integration/phase3RoundTrip.test.ts`.
+  - Result: `unitCombatStates` line dropped from the cast surface; remaining cast preserves `salvageReports` + `repairQueue` (both still pending promotion). `IUnitCombatState` import removed (unused after refactor).
 
-- [ ] 2.2 Remove cast-through patterns in `src/__tests__/integration/phase4CampaignRoundTrip.test.ts:385` and `:392`.
+- [x] 2.2 Remove cast-through patterns in `src/__tests__/integration/phase4CampaignRoundTrip.test.ts:385` and `:392`.
   - Same pattern as 2.1.
   - Acceptance: test passes; no `as` cast remains targeting `unitCombatStates`.
   - QA: `npx jest src/__tests__/integration/phase4CampaignRoundTrip.test.ts`.
+  - Result: same surgical pattern — only the `unitCombatStates` line removed from the cast (it covered 6 fields total). `IUnitCombatState` import removed.
 
 ### 3. Local interface removal in processors
 
-- [ ] 3.1 Delete local `ICampaignInput` interface in `src/lib/campaign/processors/postBattleProcessor.ts` (~lines 68-80).
+- [x] 3.1 Delete local `ICampaignInput` interface in `src/lib/campaign/processors/postBattleProcessor.ts` (~lines 68-80).
   - Update function signature to accept `ICampaign` directly.
   - Acceptance: typecheck clean; postBattleProcessor unit tests pass.
   - QA: `npx jest src/lib/campaign/processors/__tests__/postBattleProcessor.test.ts`.
+  - Result: actual local extension is `IPostBattleCampaignExtensions`; only the `unitCombatStates` field was removed from it (kept the wrapper for `pendingBattleOutcomes`, `processedBattleIds`, `pendingFulfilledContractIds` — still pending promotion). Consumers now read via `campaign.unitCombatStates`.
 
-- [ ] 3.2 Delete local `ICampaignInput` interface in `src/lib/campaign/processors/repairQueueBuilderProcessor.ts` (~lines 60-70).
+- [x] 3.2 Delete local `ICampaignInput` interface in `src/lib/campaign/processors/repairQueueBuilderProcessor.ts` (~lines 60-70).
   - Update function signature to accept `ICampaign` directly.
   - Acceptance: typecheck clean; processor unit tests pass.
   - QA: `npx jest src/lib/campaign/processors/__tests__/repairQueueBuilderProcessor.test.ts`.
+  - Result: actual local interface is `ICampaignWithBattleState extends ICampaign`; the `unitCombatStates?: Record<...>` field removed (had a mutable-vs-Readonly mismatch with the canonical type, so removal was mandatory for typecheck). `IUnitCombatState` import dropped (no longer referenced).
 
 ### 4. PR-A verification
 
-- [ ] 4.1 `npx tsc --noEmit --skipLibCheck` exit 0.
-- [ ] 4.2 `npx jest --testPathPattern='(phase3RoundTrip|phase4CampaignRoundTrip|postBattleProcessor|repairQueueBuilderProcessor|useCampaignStore)'` all pass.
-- [ ] 4.3 `npx oxfmt --check` clean on all changed files.
+- [x] 4.1 `npx tsc --noEmit --skipLibCheck` exit 0.
+- [x] 4.2 `npx jest --testPathPattern='(phase3RoundTrip|phase4CampaignRoundTrip|postBattleProcessor|repairQueueBuilderProcessor|useCampaignStore)'` all pass. Result: 8 suites / 102 tests pass. Broader sweep across all touched test fixtures: 71 suites / 1823 tests + 32 skipped pass.
+- [x] 4.3 `npx oxfmt --check` clean on all changed files.
 - [ ] 4.4 PR opened, CI green, merged to main.
 
 ---

--- a/src/__tests__/integration/phase3RoundTrip.test.ts
+++ b/src/__tests__/integration/phase3RoundTrip.test.ts
@@ -36,10 +36,7 @@ import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 
 import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
 import type { IPerson } from '@/types/campaign/Person';
-import type {
-  IUnitCombatState,
-  IUnitMaxState,
-} from '@/types/campaign/UnitCombatState';
+import type { IUnitMaxState } from '@/types/campaign/UnitCombatState';
 import type {
   ICombatOutcome,
   IUnitCombatDelta,
@@ -322,12 +319,15 @@ describe('Phase 3 capstone — encounter → outcome → campaign round trip', (
     expect(updatedPilot?.totalXpEarned ?? 0).toBeGreaterThan(0);
 
     // 5b. postBattle effects: per-unit damage state persisted.
+    // Per canonicalize-unit-combat-state PR-A: unitCombatStates is a
+    // first-class ICampaign field and is read directly. The remaining
+    // cast covers fields (salvageReports, repairQueue) that are still
+    // pending promotion via separate openspec changes.
     const extended = updatedCampaign as typeof updatedCampaign & {
-      readonly unitCombatStates?: Record<string, IUnitCombatState>;
       readonly salvageReports?: Record<string, unknown>;
       readonly repairQueue?: readonly { matchId: string; ticketId: string }[];
     };
-    const unitState = extended?.unitCombatStates?.['unit-A'];
+    const unitState = updatedCampaign?.unitCombatStates?.['unit-A'];
     expect(unitState).toBeDefined();
     expect(unitState?.currentArmorPerLocation['CT']).toBe(5);
     expect(unitState?.currentStructurePerLocation['CT']).toBe(6);

--- a/src/__tests__/integration/phase4CampaignRoundTrip.test.ts
+++ b/src/__tests__/integration/phase4CampaignRoundTrip.test.ts
@@ -43,10 +43,7 @@ import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
 import type { IDailyBattleAuditEntry } from '@/types/campaign/IDailyBattleAuditEntry';
 import type { IPerson } from '@/types/campaign/Person';
-import type {
-  IUnitCombatState,
-  IUnitMaxState,
-} from '@/types/campaign/UnitCombatState';
+import type { IUnitMaxState } from '@/types/campaign/UnitCombatState';
 import type {
   ICombatOutcome,
   IUnitCombatDelta,
@@ -388,15 +385,19 @@ describe('Phase 4 capstone — full campaign round-trip with audit ledger + fulf
       expect(updatedPilot?.status).toBe(PersonnelStatus.WOUNDED);
 
       // 10.2(c) Units have combat state reflecting damage.
+      // Per canonicalize-unit-combat-state PR-A: unitCombatStates is a
+      // first-class ICampaign field and is read directly. The remaining
+      // cast covers fields (salvageReports, repairQueue, dailyBattleAudit,
+      // pendingFulfilledContractIds, processedFulfilledContractIds) that
+      // are still pending promotion via separate openspec changes.
       const extended = updatedCampaign as typeof updatedCampaign & {
-        readonly unitCombatStates?: Record<string, IUnitCombatState>;
         readonly salvageReports?: Record<string, unknown>;
         readonly repairQueue?: readonly { matchId: string; ticketId: string }[];
         readonly dailyBattleAudit?: readonly IDailyBattleAuditEntry[];
         readonly pendingFulfilledContractIds?: readonly string[];
         readonly processedFulfilledContractIds?: readonly string[];
       };
-      const unitState = extended?.unitCombatStates?.['unit-A'];
+      const unitState = updatedCampaign?.unitCombatStates?.['unit-A'];
       expect(unitState).toBeDefined();
       expect(unitState?.currentArmorPerLocation['CT']).toBe(5);
       expect(unitState?.currentStructurePerLocation['CT']).toBe(6);

--- a/src/lib/campaign/__tests__/contractMarket.test.ts
+++ b/src/lib/campaign/__tests__/contractMarket.test.ts
@@ -105,6 +105,8 @@ function createTestCampaign(overrides?: {
     campaignType: CampaignType.MERCENARY,
     createdAt: '2026-01-26T10:00:00Z',
     updatedAt: '2026-01-26T10:00:00Z',
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: {},
   };
 }
 

--- a/src/lib/campaign/__tests__/dailyBattleAuditBuilder.test.ts
+++ b/src/lib/campaign/__tests__/dailyBattleAuditBuilder.test.ts
@@ -106,6 +106,8 @@ function makeCampaign(
     campaignType: CampaignType.MERCENARY,
     createdAt: '3024-12-01T00:00:00Z',
     updatedAt: '3025-06-14T00:00:00Z',
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: {},
     ...overrides,
   };
 }

--- a/src/lib/campaign/__tests__/dayAdvancement.test.ts
+++ b/src/lib/campaign/__tests__/dayAdvancement.test.ts
@@ -132,6 +132,10 @@ function createTestCampaign(overrides?: Partial<ICampaign>): ICampaign {
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
     ...overrides,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    // Placed after the spread so Partial<ICampaign>'s optional widening
+    // cannot leave the field as `undefined`.
+    unitCombatStates: overrides?.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/campaign/__tests__/dayPipeline.test.ts
+++ b/src/lib/campaign/__tests__/dayPipeline.test.ts
@@ -55,6 +55,8 @@ function createTestCampaign(overrides?: Partial<ICampaign>): ICampaign {
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
     ...overrides,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides?.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/campaign/__tests__/integration.test.ts
+++ b/src/lib/campaign/__tests__/integration.test.ts
@@ -128,6 +128,8 @@ function createTestCampaign(overrides?: Partial<ICampaign>): ICampaign {
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
     ...overrides,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides?.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/campaign/acquisition/__tests__/autoLogistics.test.ts
+++ b/src/lib/campaign/acquisition/__tests__/autoLogistics.test.ts
@@ -35,6 +35,8 @@ function createTestCampaign(overrides?: Partial<ICampaign>): ICampaign {
     updatedAt: '3025-01-15T00:00:00Z',
     ...overrides,
     campaignType: CampaignType.MERCENARY,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides?.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/campaign/awards/__tests__/autoAwardEngine.test.ts
+++ b/src/lib/campaign/awards/__tests__/autoAwardEngine.test.ts
@@ -38,6 +38,8 @@ function createTestCampaign(overrides?: Partial<ICampaign>): ICampaign {
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     ...overrides,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides?.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/campaign/markets/__tests__/contractMarketEnhancement.test.ts
+++ b/src/lib/campaign/markets/__tests__/contractMarketEnhancement.test.ts
@@ -78,6 +78,8 @@ function createMockCampaign(unitCount: number = 4): ICampaign {
     campaignType: CampaignType.MERCENARY,
     createdAt: '2025-01-01',
     updatedAt: '2025-01-01',
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: {},
   };
 }
 

--- a/src/lib/campaign/markets/__tests__/marketStandingIntegration.test.ts
+++ b/src/lib/campaign/markets/__tests__/marketStandingIntegration.test.ts
@@ -28,6 +28,8 @@ describe('marketStandingIntegration', () => {
     campaignType: CampaignType.MERCENARY,
     createdAt: '2025-01-01',
     updatedAt: '2025-01-01',
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: {},
   };
 
   describe('getUnitMarketRarityModifier', () => {

--- a/src/lib/campaign/markets/__tests__/personnelMarket.test.ts
+++ b/src/lib/campaign/markets/__tests__/personnelMarket.test.ts
@@ -69,6 +69,8 @@ function createTestCampaign(overrides?: {
     campaignType: CampaignType.MERCENARY,
     createdAt: '2026-01-26T10:00:00Z',
     updatedAt: '2026-01-26T10:00:00Z',
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: {},
   };
 }
 

--- a/src/lib/campaign/markets/__tests__/unitMarket.test.ts
+++ b/src/lib/campaign/markets/__tests__/unitMarket.test.ts
@@ -67,6 +67,8 @@ function createTestCampaign(
     campaignType: CampaignType.MERCENARY,
     createdAt: '2026-01-26T10:00:00Z',
     updatedAt: '2026-01-26T10:00:00Z',
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: {},
   };
 }
 

--- a/src/lib/campaign/processors/__tests__/acquisitionProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/acquisitionProcessor.test.ts
@@ -49,6 +49,8 @@ function createTestCampaign(
     },
     createdAt: '3025-01-01T00:00:00Z',
     updatedAt: '3025-01-15T00:00:00Z',
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: {},
     ...campaignOverrides,
     campaignType: CampaignType.MERCENARY,
   };

--- a/src/lib/campaign/processors/__tests__/autoAwardsProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/autoAwardsProcessor.test.ts
@@ -74,6 +74,8 @@ function createTestCampaign(overrides: Partial<ICampaign> = {}): ICampaign {
     createdAt: '3020-01-01T00:00:00Z',
     updatedAt: '3025-06-15T00:00:00Z',
     ...overrides,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/campaign/processors/__tests__/factionStandingProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/factionStandingProcessor.test.ts
@@ -34,6 +34,8 @@ function createTestCampaign(overrides?: Partial<ICampaign>): ICampaign {
     missions: new Map(),
     ...overrides,
     campaignType: CampaignType.MERCENARY,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides?.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/campaign/processors/__tests__/financialProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/financialProcessor.test.ts
@@ -90,6 +90,8 @@ function createTestCampaign(overrides: Partial<ICampaign> = {}): ICampaign {
     createdAt: '3020-01-01T00:00:00Z',
     updatedAt: '3025-06-15T00:00:00Z',
     ...overrides,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/campaign/processors/__tests__/marketProcessors.test.ts
+++ b/src/lib/campaign/processors/__tests__/marketProcessors.test.ts
@@ -34,6 +34,8 @@ function createTestCampaign(overrides?: Partial<ICampaign>): ICampaign {
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
     ...overrides,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides?.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/campaign/processors/__tests__/postBattleProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/postBattleProcessor.test.ts
@@ -95,6 +95,8 @@ function createTestCampaign(
     campaignType: CampaignType.MERCENARY,
     createdAt: '3024-12-01T00:00:00Z',
     updatedAt: '3025-06-14T00:00:00Z',
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: {},
     ...overrides,
   };
 }

--- a/src/lib/campaign/processors/__tests__/processors.test.ts
+++ b/src/lib/campaign/processors/__tests__/processors.test.ts
@@ -89,6 +89,8 @@ function createTestCampaign(overrides?: Partial<ICampaign>): ICampaign {
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
     ...overrides,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides?.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/campaign/processors/__tests__/repairQueueBuilderProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/repairQueueBuilderProcessor.test.ts
@@ -38,6 +38,8 @@ function makeBaseCampaign(): ICampaign {
     campaignType: CampaignType.MERCENARY,
     createdAt: TEST_DATE.toISOString(),
     updatedAt: TEST_DATE.toISOString(),
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: {},
   };
 }
 

--- a/src/lib/campaign/processors/__tests__/salvageProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/salvageProcessor.test.ts
@@ -98,6 +98,8 @@ function makeCampaign(
     shoppingList: { items: [] },
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: {},
   };
   return { ...base, ...overrides };
 }

--- a/src/lib/campaign/processors/__tests__/scenarioGenerationProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/scenarioGenerationProcessor.test.ts
@@ -72,6 +72,8 @@ function createMockCampaign(overrides?: Partial<ICampaign>): ICampaign {
     createdAt: '2025-01-01T00:00:00Z',
     updatedAt: '2025-01-01T00:00:00Z',
     ...overrides,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides?.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/campaign/processors/__tests__/turnoverProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/turnoverProcessor.test.ts
@@ -72,6 +72,8 @@ function createTestCampaign(overrides: Partial<ICampaign> = {}): ICampaign {
     updatedAt: '3025-06-15T00:00:00Z',
     ...overrides,
     campaignType: CampaignType.MERCENARY,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/campaign/processors/__tests__/vocationalTrainingProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/vocationalTrainingProcessor.test.ts
@@ -81,6 +81,8 @@ function createTestCampaign(overrides: Partial<ICampaign> = {}): ICampaign {
     updatedAt: '3025-06-15T00:00:00Z',
     ...overrides,
     campaignType: CampaignType.MERCENARY,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/campaign/processors/postBattleProcessor.ts
+++ b/src/lib/campaign/processors/postBattleProcessor.ts
@@ -62,14 +62,16 @@ import {
  * campaign. They are added here as an intersection so we don't have to
  * widen `ICampaign` itself in this Wave — Wave 4/5 may promote them to
  * the core interface.
+ *
+ * Per canonicalize-unit-combat-state PR-A: `unitCombatStates` has been
+ * promoted to ICampaign and is no longer declared on this extension.
+ * Consumers read it via the canonical `campaign.unitCombatStates` slot.
  */
 export interface IPostBattleCampaignExtensions {
   /** Queue of outcomes pending application. */
   readonly pendingBattleOutcomes?: readonly ICombatOutcome[];
   /** Set of match ids already applied (idempotency guard). */
   readonly processedBattleIds?: readonly string[];
-  /** Persisted post-battle state per unit id. */
-  readonly unitCombatStates?: Readonly<Record<string, IUnitCombatState>>;
   /**
    * Per `wire-encounter-to-campaign-round-trip` Wave 5 §9: contract ids
    * the post-battle processor flagged as fulfilled this day. The

--- a/src/lib/campaign/processors/repairQueueBuilderProcessor.ts
+++ b/src/lib/campaign/processors/repairQueueBuilderProcessor.ts
@@ -20,10 +20,7 @@
 
 import type { ICampaign } from '@/types/campaign/Campaign';
 import type { IRepairTicket } from '@/types/campaign/RepairTicket';
-import type {
-  IUnitCombatState,
-  IUnitMaxState,
-} from '@/types/campaign/UnitCombatState';
+import type { IUnitMaxState } from '@/types/campaign/UnitCombatState';
 
 import {
   DayPhase,
@@ -57,11 +54,14 @@ interface IPendingBattleOutcome {
  *
  * All fields are optional so existing ICampaign consumers are
  * unaffected. The processor narrows when it reads.
+ *
+ * Per canonicalize-unit-combat-state PR-A: `unitCombatStates` has been
+ * promoted to ICampaign and is no longer declared on this extension.
+ * Consumers read it via the canonical `campaign.unitCombatStates` slot.
  */
 export interface ICampaignWithBattleState extends ICampaign {
   readonly pendingBattleOutcomes?: readonly IPendingBattleOutcome[];
   readonly processedBattleIds?: readonly string[];
-  readonly unitCombatStates?: Record<string, IUnitCombatState>;
   readonly unitMaxStates?: Record<string, IUnitMaxState>;
   readonly salvagePool?: ISalvagePool;
   readonly repairQueue?: readonly IRepairTicket[];

--- a/src/lib/campaign/turnover/__tests__/turnoverCheck.test.ts
+++ b/src/lib/campaign/turnover/__tests__/turnoverCheck.test.ts
@@ -141,6 +141,8 @@ function createTestCampaign(overrides: Partial<ICampaign> = {}): ICampaign {
     updatedAt: '3025-06-15T00:00:00Z',
     ...overrides,
     campaignType: CampaignType.MERCENARY,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/campaign/turnover/modifiers/__tests__/modifiers.test.ts
+++ b/src/lib/campaign/turnover/modifiers/__tests__/modifiers.test.ts
@@ -151,6 +151,8 @@ function createTestCampaign(overrides: Partial<ICampaign> = {}): ICampaign {
     updatedAt: '3025-06-15T00:00:00Z',
     ...overrides,
     campaignType: CampaignType.MERCENARY,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/finances/__tests__/FinanceService.test.ts
+++ b/src/lib/finances/__tests__/FinanceService.test.ts
@@ -140,6 +140,8 @@ function createTestCampaign(overrides?: Partial<ICampaign>): ICampaign {
     updatedAt: '2026-01-01T00:00:00Z',
     ...overrides,
     campaignType: CampaignType.MERCENARY,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides?.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/finances/__tests__/salaryService.test.ts
+++ b/src/lib/finances/__tests__/salaryService.test.ts
@@ -86,6 +86,8 @@ function createTestCampaign(overrides?: Partial<ICampaign>): ICampaign {
     updatedAt: '2026-01-01T00:00:00Z',
     ...overrides,
     campaignType: CampaignType.MERCENARY,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides?.unitCombatStates ?? {},
   };
 }
 

--- a/src/lib/finances/__tests__/taxService.test.ts
+++ b/src/lib/finances/__tests__/taxService.test.ts
@@ -152,6 +152,8 @@ describe('taxService', () => {
       updatedAt: '2025-01-01T00:00:00Z',
       ...overrides,
       campaignType: CampaignType.MERCENARY,
+      // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+      unitCombatStates: overrides.unitCombatStates ?? {},
     };
   }
 

--- a/src/stores/campaign/useCampaignStore.ts
+++ b/src/stores/campaign/useCampaignStore.ts
@@ -459,6 +459,13 @@ function deserializeCampaign(
     iconUrl: serialized.iconUrl,
     createdAt: serialized.createdAt,
     updatedAt: serialized.updatedAt,
+    // Per canonicalize-unit-combat-state PR-A: ICampaign owns the
+    // canonical post-deploy combat-state map. Hydrated empty here;
+    // SerializedCampaignState does not (yet) persist combat states —
+    // first deploy after rehydrate seeds entries via
+    // createInitialCombatState. Future SerializedCampaignState extension
+    // can pipe persisted combat states through this slot.
+    unitCombatStates: {},
     // Restore the daily-battle audit ledger so the dashboard's audit
     // feed survives reloads. Cast through `as ICampaign` because the
     // field is on the optional extension type, not the core ICampaign.

--- a/src/types/campaign/Campaign.ts
+++ b/src/types/campaign/Campaign.ts
@@ -13,6 +13,7 @@ import type { ICampaignOptions } from './CampaignOptions';
 import type { IFactionStanding } from './factionStanding/IFactionStanding';
 import type { SalvageRights, CommandRights } from './Mission';
 import type { ICombatTeam } from './scenario/scenarioTypes';
+import type { IUnitCombatState } from './UnitCombatState';
 
 import { CampaignType } from './CampaignType';
 import { createDefaultCampaignOptions } from './createDefaultCampaignOptions';
@@ -128,6 +129,18 @@ export interface ICampaign {
 
   /** Last update timestamp (ISO 8601) */
   readonly updatedAt: string;
+
+  /**
+   * Canonical post-deploy combat state per unit, keyed by unitId.
+   * Populated by createInitialCombatState at first deploy, updated by
+   * postBattleProcessor, reset by repair completion. Absent entry means
+   * the unit has not yet been deployed (or its combat state was reset
+   * post-repair).
+   *
+   * See openspec/specs/campaign-unit-combat-state/spec.md for the
+   * canonical shape contract and idempotency rules.
+   */
+  readonly unitCombatStates: Readonly<Record<string, IUnitCombatState>>;
 }
 
 // =============================================================================
@@ -543,6 +556,10 @@ export function createCampaign(
     campaignStartDate: new Date(),
     createdAt: now,
     updatedAt: now,
+    // Per canonicalize-unit-combat-state PR-A: ICampaign owns the
+    // canonical post-deploy combat-state map. Fresh campaigns start
+    // empty; createInitialCombatState writes entries on first deploy.
+    unitCombatStates: {},
   };
 }
 
@@ -608,5 +625,11 @@ export function createCampaignWithData(params: {
     iconUrl: params.iconUrl,
     createdAt: now,
     updatedAt: now,
+    // Per canonicalize-unit-combat-state PR-A: ICampaign owns the
+    // canonical combat-state map. Loaded campaigns start empty here;
+    // callers that hold combat state pass it via the merge layer in
+    // useCampaignStore (deserializeCampaign) or as a post-construction
+    // spread.
+    unitCombatStates: {},
   };
 }

--- a/src/types/campaign/__tests__/Campaign.test.ts
+++ b/src/types/campaign/__tests__/Campaign.test.ts
@@ -215,6 +215,8 @@ function createTestCampaign(): ICampaign {
     campaignStartDate: new Date('3025-01-01'),
     createdAt: '2026-01-26T10:00:00Z',
     updatedAt: '2026-01-26T10:00:00Z',
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: {},
   };
 }
 


### PR DESCRIPTION
## Summary

PR-A of openspec change [`canonicalize-unit-combat-state`](https://github.com/SwiggitySwerve/MekStation/blob/main/openspec/changes/canonicalize-unit-combat-state/proposal.md) — promotes `unitCombatStates` to a first-class `ICampaign` field and removes the cast-through hacks. Council #3 ruled this is the canonical state shape; PR-B (roster store + UI projection) and PR-C (delete `ICampaignUnitState`) follow as separate PRs per `tasks.md` §5+.

## Sections completed (1–4 of `tasks.md`)

- **§1 Type promotion + open-question verification**
  - Verified zero pre-existing `unitCombatStates` references in `Campaign.ts`.
  - Added `readonly unitCombatStates: Readonly<Record<string, IUnitCombatState>>` to `ICampaign` (required field, hard-cutover policy per design.md).
  - Seeded `unitCombatStates: {}` in `createCampaign` + `createCampaignWithData` factories.
  - Added init in `useCampaignStore.deserializeCampaign` (covers `loadCampaign` + persist-merge paths).
- **§2 Cast-through removal**
  - Removed the `unitCombatStates` line from the `extended` casts in `phase3RoundTrip.test.ts` and `phase4CampaignRoundTrip.test.ts` (other still-pending fields like `salvageReports`, `repairQueue`, `dailyBattleAudit` keep a slimmed cast).
  - Dropped now-unused `IUnitCombatState` imports in both files.
- **§3 Local interface removal in processors**
  - Dropped the `unitCombatStates` field from `IPostBattleCampaignExtensions` (`postBattleProcessor.ts`).
  - Dropped the `unitCombatStates` field from `ICampaignWithBattleState` (`repairQueueBuilderProcessor.ts`); also removed the now-unused `IUnitCombatState` import. The redeclared field had `Record<...>` (mutable) which clashed with the new canonical `Readonly<Record<...>>` — removal was mandatory for typecheck.
- **§4 Verification**
  - `npx tsc --noEmit --skipLibCheck` exit 0.
  - `npx jest --testPathPattern='(phase3RoundTrip|phase4CampaignRoundTrip|postBattleProcessor|repairQueueBuilderProcessor|useCampaignStore)'`: **102/102 tests pass across 8 suites**.
  - Broader sweep across all touched test fixtures (`dayAdvancement`, `integration`, `dayPipeline`, autoAwards/factionStanding/financial/market/scenario/turnover/vocational processors, finance services, turnover modifiers, contract/personnel/unit market): **71 suites / 1823 tests + 32 skipped, 0 failures**.
  - `npx oxfmt --check`: clean.

## Notes for reviewers

- 23 additional `ICampaign` test fixtures (out of the council's <10 estimate) needed `unitCombatStates: {}` because the typecheck surfaced them once the field went required. All are mechanical `unitCombatStates: {}` additions — most use the `unitCombatStates: overrides?.unitCombatStates ?? {}` form when the helper takes a `Partial<ICampaign>` override (placed AFTER the spread so `Partial`'s optional widening can't leave the field as `undefined`).
- Production sites (`useCampaignStore.ts:createCampaign/updateCampaign/saveCampaign/advanceDay`, `dayPipeline.ts`, `dayAdvancement.ts`, the `financialProcessor`, `healingProcessor`, `dailyCostsProcessor`, `contractProcessor`, `acquisitionProcessor`) all build new `ICampaign` literals via `{ ...campaign, ... }` spread and inherit `unitCombatStates` cleanly — no production logic change.
- The `IPostBattleCampaignExtensions` and `repairQueueBuilderProcessor.ICampaignWithBattleState` wrappers stay alive (they still carry fields that have not yet been promoted to `ICampaign`); only the `unitCombatStates` field was peeled off.

## PR-B / PR-C scope (out of this PR)

- **PR-B** (M, ~2-3h): `useCampaignRosterStore` projection-type migration + `RosterStateCards` damage-bar refactor + `CreateCampaignPage` construct-site update + roster-store test fixtures.
- **PR-C** (S, ~30m): delete `ICampaignUnitState`, `ICampaignRoster.units`, `IRecordMissionOutcomeInput.unitUpdates` (or repoint to `Partial<IUnitCombatState>` per task §5.1), `getOperationalUnits()`, then archive the change.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` exit 0
- [x] `npx jest --testPathPattern='(phase3RoundTrip|phase4CampaignRoundTrip|postBattleProcessor|repairQueueBuilderProcessor|useCampaignStore)'` all pass
- [x] `npx oxfmt --check` clean
- [ ] CI green on the PR