### PR TITLE
Scaffold wire-iperson-hard-cutover + canonical personnel architecture spec

### DIFF
--- a/openspec/changes/wire-iperson-hard-cutover/.openspec.yaml
+++ b/openspec/changes/wire-iperson-hard-cutover/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-02

--- a/openspec/changes/wire-iperson-hard-cutover/design.md
+++ b/openspec/changes/wire-iperson-hard-cutover/design.md
@@ -1,0 +1,151 @@
+# Design: Wire IPerson Hard-Cutover
+
+> Source-of-truth references: Council #2 decision at `openspec/council-decisions/2026-05-02-cluster-E-iperson-hard-cutover.md` and canonical spec at `openspec/specs/campaign-personnel-architecture/spec.md`. This document covers implementation-level design decisions only.
+
+## Decision: Two-arg helper signature (NOT god-type rename)
+
+Every cross-store helper accepts:
+
+```ts
+function helperFn(entry: ICampaignRosterEntry, pilot: IPilot | null): ResultType {
+  // entry provides campaign-scoped fields (wounds, recoveryTime, salary, etc.)
+  // pilot provides vault identity (skills, abilities, career stats), or null for NPCs
+}
+```
+
+Rationale (Council #2 ruling, both proposers and adversary converged):
+- Two args make the dependency on each store explicit at the call site.
+- A god-type rename (`IPersonnelView = ICampaignRosterEntry & { pilot: IPilot }`) re-conflates the two layers we just split. The vault/roster split exists precisely so the same vault pilot can be hired by multiple campaigns; bundling them into one type re-creates the original problem.
+- Null vs non-null pilot is a discriminator for NPC vs persistent-pilot domains.
+
+## Decision: Pre-join template (Map<pilotId, IPilot>)
+
+Processors that iterate the roster pre-build a vault lookup once:
+
+```ts
+// In dayAdvancement or per-processor entry point:
+const pilotsByPilotId = new Map<string, IPilot>(
+  vault.pilots.map((p) => [p.id, p])
+);
+
+for (const entry of roster.pilots) {
+  const pilot = pilotsByPilotId.get(entry.pilotId) ?? null;
+  helperFn(entry, pilot);
+}
+```
+
+Rationale:
+- Avoids O(N²) `vault.find(p => p.id === entry.pilotId)` per helper invocation.
+- The map is built once per pipeline run, not per helper.
+- For helpers called outside processor pipelines (e.g., from UI components), the caller passes `pilot` directly (already known in context).
+
+Lint gate: helpers SHALL NOT internally call `vault.find(...)` or any equivalent linear search over the vault list. Helpers receive the pilot pre-resolved.
+
+## Decision: NPC domain matrix (per Council #2 open question #2)
+
+Per-domain NPC handling, documented inline in each helper:
+
+| Domain | NPC behavior |
+|---|---|
+| medical (healing, wounds, recovery) | Process — NPCs heal too (wounds tracked on roster entry, no vault pilot needed) |
+| turnover (departure rolls) | Process — NPCs can leave too |
+| ranks (officer status) | Skip if `pilot === null` — rank progression is vault-only |
+| salary | Process — entry carries `salary` override or `BASE_MONTHLY_SALARY` |
+| tax / finances | Process — finance is per-entry |
+| progression (skill increase, XP spend) | Skip if `pilot === null` — vault-only |
+| skills (skill checks) | Skip if `pilot === null` — vault-only |
+| awards (medal/citation checks) | Skip if `pilot === null` — vault-only |
+| vocational training | Skip if `pilot === null` — vault-only |
+| random events | Process — events fire on roster entries |
+| auto-awards engine | Skip if `pilot === null` |
+
+Each helper SHALL document its NPC behavior in a JSDoc comment matching this table. PR2 per-domain commits include the doc additions.
+
+## Decision: Delta-return contract for cross-store mutations
+
+Helpers that change state in multiple stores return delta objects:
+
+```ts
+interface SkillProgressionDelta {
+  readonly vault?: { readonly pilotId: string; readonly skillUpdates: Partial<IPilotSkills> };
+  readonly roster?: { readonly pilotId: string; readonly xpDelta: number };
+}
+
+function progressSkill(
+  entry: ICampaignRosterEntry,
+  pilot: IPilot | null
+): SkillProgressionDelta {
+  // Compute the delta. Do NOT call useStores().setState() here.
+  // Caller decides when to commit.
+}
+```
+
+Rationale:
+- Processors are pure functions (input campaign state → output campaign state). They cannot side-effect mutate Zustand stores.
+- The delta-return pattern lets the processor pipeline accumulate all changes and commit atomically at the end (consistent with `dayAdvancement.ts` immutable spread chain).
+- Per Council #2 open question #3: "Delta-return contract for cross-store mutations: PR2 progression returns delta objects; PR3 processors commit deltas to right store."
+
+## Decision: Atomic processor pipeline (no per-processor PR)
+
+Council #2 verified `dayAdvancement.ts:425-452` chains 6 processors via immutable `ICampaign` spreads:
+
+```ts
+let working = campaign;
+working = healingProcessor(working);
+working = autoAwardsProcessor(working);
+working = vocationalTrainingProcessor(working);
+working = turnoverProcessor(working);
+working = randomEventsProcessor(working);
+working = postBattleProcessor(working);
+return working;
+```
+
+Splitting this into 6 PRs would require maintaining cross-PR compatibility shims for the 5 intermediate states. Council ruled: ship as ONE PR (PR3). All 6 processors repoint atomically; integration tests verify identical outputs.
+
+## Decision: Bridge function deletion in PR4 (not earlier)
+
+`derivePersonnelFromRoster()` and `syncRosterFromPersonnel()` stay alive through PR2-PR3 because:
+- Test fixtures (PR1, already shipped) call `rosterEntryToPerson()` to synthesize `IPerson` for legacy assertions.
+- Production code in PR2-PR3 transitional state may still read `campaign.personnel` (which is bridge-derived).
+
+PR4 deletes both bridge functions in the same commit as `ICampaign.personnel` removal — atomic cut.
+
+The lossy Critical→Wounded round-trip bug at `useCampaignStore.ts:343-351` is in `syncRosterFromPersonnel` and is fixed BY the deletion (no round-trip means no downgrade).
+
+## Decision: ICampaign.personnel removal cascade
+
+PR4 removes `ICampaign.personnel`. Cascade fixes in same PR:
+1. `isCampaign()` type guard at `Campaign.ts:163` — drop the `'personnel' in value` check (ruling: drop entirely, NOT keep as derived getter, per Council #2).
+2. Legacy preservation merge at `useCampaignStore.ts:743-750` — delete the merge logic.
+3. All factories that initialize `personnel: new Map()` — delete the field initialization.
+4. All test fixtures still emitting `personnel: new Map()` (post-PR1 there should be none, but verify).
+
+## Decision: PR5 cleanup verification
+
+Final grep:
+
+```bash
+grep -rn "IPerson\b" src/  # word-boundary to exclude IPersonnelView etc.
+# Expected: zero hits
+```
+
+If PR5's grep finds any reference, that reference is either:
+- A new file added between PR4 and PR5 — escalate to fix in PR5.
+- A residual file PR4 missed — fix in PR5.
+- A legitimate use case we missed — STOP and reconsider.
+
+## Open questions (to verify during PR2)
+
+1. **`IInjury[]` migration**: lives on `IPerson.injuries`; verify `ICampaignRosterEntry.injuries` exists in PR2 medical commit; add if absent. Council #2 flagged this as the ONE understated risk.
+2. **NPC checker functions in awards (~18 functions)**: verify each handles `pilot === null` correctly per the NPC domain matrix above.
+3. **Type-layer helpers in `Campaign.ts:147,163,180,300`**: 4 helpers; verify each has the right two-arg signature after PR2 § type-layer commit.
+
+## Open questions (to verify during PR3)
+
+1. **Order of operations in `dayAdvancement.ts:425-452`**: confirm the 6-processor chain has no implicit data dependency on `campaign.personnel` being populated mid-chain (e.g., processor N reads what processor N-1 wrote into `personnel`).
+2. **UI `.size` readers**: `campaigns/index.tsx:46` and `CampaignDashboardPage.sections.tsx:157` read `.size` on the Map. Replace with `useCampaignRosterStore.getState().pilots.length` (live count, not derived from snapshot).
+
+## Open questions (to verify during PR4)
+
+1. **Save game compat**: pre-release, no released users — but in-flight save files from current dev sessions may still serialize the `personnel` field. Verify deserialize path drops the field cleanly without throwing.
+2. **`isCampaign()` callers**: grep for the type guard's call sites; ensure none of them implicitly relied on the personnel check for discrimination.

--- a/openspec/changes/wire-iperson-hard-cutover/proposal.md
+++ b/openspec/changes/wire-iperson-hard-cutover/proposal.md
@@ -1,0 +1,61 @@
+# Wire IPerson Hard-Cutover
+
+## Intent
+
+The previous change `migrate-personnel-to-roster-employment` (archived 2026-05-01) split personnel data into vault (`usePilotStore`) + roster (`useCampaignRosterStore`) but intentionally preserved the legacy `IPerson` shim, the `ICampaign.personnel: Map<string, IPerson>` field, and 72 helper signatures accepting `IPerson`. Under the pre-release hard-cutover policy, that bridge must come down.
+
+Council #2 (Lean++ thin variant, decision at `openspec/council-decisions/2026-05-02-cluster-E-iperson-hard-cutover.md`) ruled: STAGED CUTOVER across 5 sequential PRs. PR1 (test fixture migration) shipped 2026-05-02 as [#486](https://github.com/SwiggitySwerve/MekStation/pull/486). This change implements PR2-PR5: helper signature migration → atomic processor repointing → Map drop + lossy bug fix → IPerson deletion.
+
+The new canonical spec at `openspec/specs/campaign-personnel-architecture/spec.md` (authored alongside this change) is the source-of-truth this change implements. PR4 fixes a known lossy bug in `syncRosterFromPersonnel` at `useCampaignStore.ts:343-351` (Critical → Wounded round-trip downgrade) by deleting the bridge function entirely.
+
+## Scope
+
+### In
+
+- **PR2**: Migrate ~72 helper signatures across ~84 files in `src/lib/campaign/` and `src/lib/finances/` from `(person: IPerson)` to `(entry: ICampaignRosterEntry, pilot: IPilot | null)`. Per-domain commits in ONE PR (medical → turnover → finances → progression/skills → awards → ranks/maintenance/events → type-layer helpers in `Campaign.ts`). Use pre-join `Map<pilotId, IPilot>` template to avoid N² `vault.find()` calls.
+- **PR3**: Atomic processor pipeline repointing. Update `dayAdvancement.ts` + 6 processors (`healingProcessor`, `autoAwardsProcessor`, `vocationalTrainingProcessor`, `turnoverProcessor`, `randomEventsProcessor`, `postBattleProcessor`) + 4 type-layer helpers in `Campaign.ts` + 2 UI `.size` readers (`campaigns/index.tsx:46`, `CampaignDashboardPage.sections.tsx:157`). Bridge functions stay alive but no production code reads `campaign.personnel`. Atomic because `dayAdvancement.ts:425-452` chains 6 processors via immutable `ICampaign` spreads.
+- **PR4**: Delete `ICampaign.personnel` field. Delete `derivePersonnelFromRoster`, `syncRosterFromPersonnel`, the `isCampaign()` guard's personnel coupling, and the legacy preservation merge at `useCampaignStore.ts:743-750`. This kills the lossy Critical→Wounded round-trip bug.
+- **PR5**: Delete `IPerson` interface from `src/types/campaign/Person.ts`. Delete `rosterEntryToPerson.ts` shim + its tests. Final grep: `IPerson` count = 0 in `src/`.
+
+### Out
+
+- **`IPersonnelView` god-type rename** — REFUSED by Council #2. Would re-conflate the layers we just split.
+- **6 parallel domain waves** — REFUSED by Council #2. The `dayAdvancement` processor pipeline atomicity blocks parallelism.
+- **`PersonnelStatus` (37 values) vs `CampaignPilotStatus` (5 values) reconciliation** — out of scope; separate future spec change. The two enums serve different audiences.
+- **Memoization of derived views** — premature; current N² is acceptable for current campaign sizes.
+- **`IAttributes` aspirational fields** on roster entry.
+- **Pilot consciousness on `ICampaignRosterEntry`** — combat-resolution Wave 5 gate; tracked under `campaign-unit-combat-state` deferred extensions.
+- **PR1 (test fixture migration)** — already shipped as PR #486.
+
+## Approach
+
+Domains touched:
+- `personnel-management` (helper signatures, NPC handling contract, type-layer helpers in `Campaign.ts`).
+- `personnel-progression` (skill progression delta-return contract).
+- `personnel-status-roles` (statusRules + finance integration).
+- `campaign-management` (`ICampaign.personnel` field deletion, `isCampaign()` decoupling).
+
+Pattern: a clean three-store architecture (vault + roster + force assignment) with the two-arg `(entry, pilot | null)` helper signature replacing the `IPerson` god-type. Bridge functions exist only during cutover and are deleted in PR4. Mirrors the Council #2-validated path; honors the staged sequencing because the processor pipeline is not splittable.
+
+PR sequencing (sequential, each blocks the next):
+- **PR2** (L, ~5-7 days): Helper signature migration. Largest PR. Per-domain commits keep diff reviewable.
+- **PR3** (M, ~2-3 days): Atomic processor repointing. Smaller code-wise but coupled — must land in one PR per Council #2 ruling.
+- **PR4** (M, ~1-2 days): Map drop + bug fix. Touches `ICampaign` interface, all factories, and `useCampaignStore` migration paths.
+- **PR5** (S, ~half day): Cleanup. Should be a clean grep-driven deletion after PR4.
+
+Total: 3-4 weeks of focused work per Council #2 estimate.
+
+## Test Strategy
+
+- **PR2 verification**: Per-domain commit boundaries map to per-domain test suites. After each commit, run `npx jest --testPathPattern='<domain>'` (medical, turnover, finances, progression, awards, ranks). Full test suite at the end. Pre-join template performance verified by checking no helper internally calls `vault.find(...)` (lint/grep gate).
+- **PR3 verification**: `dayPipeline.test.ts` and `dayAdvancement.test.ts` continue to pass. Integration round-trip tests (`phase3RoundTrip.test.ts`, `phase4CampaignRoundTrip.test.ts`) confirm processor pipeline produces identical outputs after repointing. UI `.size` readers verified via component snapshot tests.
+- **PR4 verification**: `npx tsc --noEmit --skipLibCheck` exit 0 (the field deletion will surface any remaining `campaign.personnel` reads). Critical→Wounded round-trip regression test added to confirm the bug is fixed (input Critical → roster reload → still Critical).
+- **PR5 verification**: `grep -rn "IPerson" src/` returns zero hits. Full test suite passes. Type-check clean.
+
+## References
+
+- Council #2 decision: `openspec/council-decisions/2026-05-02-cluster-E-iperson-hard-cutover.md`
+- Canonical spec: `openspec/specs/campaign-personnel-architecture/spec.md`
+- Prior change (PR1 already shipped): PR [#486](https://github.com/SwiggitySwerve/MekStation/pull/486) — test fixture migration
+- Originating change (archived): `openspec/changes/archive/2026-05-01-migrate-personnel-to-roster-employment/`
+- Lossy bug location: `src/stores/campaign/useCampaignStore.ts:343-351` (`syncRosterFromPersonnel`)

--- a/openspec/changes/wire-iperson-hard-cutover/specs/campaign-personnel-architecture/spec.md
+++ b/openspec/changes/wire-iperson-hard-cutover/specs/campaign-personnel-architecture/spec.md
@@ -1,0 +1,112 @@
+# Delta Spec: campaign-personnel-architecture
+
+> Adds the `campaign-personnel-architecture` capability to the source-of-truth spec at `openspec/specs/campaign-personnel-architecture/spec.md`. This delta is a NEW spec — no MODIFIED or REMOVED requirements (the capability did not exist as a standalone spec before; previous personnel architecture was implicit in `personnel-management` and the archived `migrate-personnel-to-roster-employment` change).
+
+## ADDED Requirements
+
+### Requirement: Personnel are stored across three orthogonal stores
+
+The system SHALL maintain personnel data across three stores with no overlapping ownership: vault (`usePilotStore`), roster (`useCampaignRosterStore`), and force assignment.
+
+#### Scenario: Pilot identity lives in vault
+
+- **WHEN** a new pilot is created
+- **THEN** identity (id, name, base skills, career stats, abilities) is written to `usePilotStore`
+- **AND** no copy of these fields appears on `ICampaignRosterEntry`.
+
+#### Scenario: Campaign employment lives on roster
+
+- **WHEN** a vault pilot is hired into a campaign
+- **THEN** an `ICampaignRosterEntry` is created with `pilotId` referencing the vault pilot
+- **AND** the entry carries only campaign-scoped fields.
+
+### Requirement: Cross-store helpers accept the two-arg signature
+
+Helper functions that operate on personnel data SHALL accept `(entry: ICampaignRosterEntry, pilot: IPilot | null)`. They SHALL NOT accept `IPerson` (deleted) or `IPersonnelView` (REFUSED).
+
+#### Scenario: Medical helper signature
+
+- **WHEN** a medical helper computes healing rate
+- **THEN** it accepts `(entry: ICampaignRosterEntry, pilot: IPilot | null)`.
+
+#### Scenario: NPC entries pass null pilot
+
+- **WHEN** a helper is called for an NPC roster entry
+- **THEN** the second arg is `null`
+- **AND** the helper handles `pilot === null` per its NPC contract.
+
+### Requirement: Pre-join template avoids N² find() calls
+
+Helpers operating over a list of roster entries SHALL receive a pre-built `Map<pilotId, IPilot>` rather than calling `vault.find(...)` per iteration.
+
+#### Scenario: Daily processor pre-joins vault
+
+- **WHEN** `dayAdvancement` iterates campaign roster entries
+- **THEN** it builds `pilotsByPilotId: Map<string, IPilot>` once from vault
+- **AND** no helper internally calls `vault.find(...)`.
+
+### Requirement: NPC handling is documented per helper
+
+Each domain helper SHALL document whether it processes or skips NPC entries (entries where `vaultPilot === null`).
+
+#### Scenario: Vocational training skips NPCs
+
+- **WHEN** `vocationalTrainingProcessor` encounters an NPC roster entry
+- **THEN** it skips the entry.
+
+#### Scenario: Salary processing applies to NPCs
+
+- **WHEN** `salaryService` encounters an NPC roster entry
+- **THEN** it applies the entry's `salary` field regardless of vault pilot presence.
+
+### Requirement: Cross-store mutations return delta objects
+
+Helpers that change state in multiple stores SHALL return delta objects keyed by store, not perform in-place mutations.
+
+#### Scenario: Skill progression returns dual delta
+
+- **WHEN** a progression helper increases vault skill AND records campaign XP spent
+- **THEN** it returns `{ vault: { pilotId, skillUpdates }, roster: { pilotId, xpDelta } }`.
+
+### Requirement: Bridge functions are transitional infrastructure
+
+`derivePersonnelFromRoster()` and `syncRosterFromPersonnel()` SHALL exist only during the cutover. After PR4 lands, both functions SHALL be deleted.
+
+#### Scenario: Bridge functions absent post-PR4
+
+- **WHEN** searching `src/` for `derivePersonnelFromRoster` or `syncRosterFromPersonnel`
+- **THEN** the count SHALL be 0.
+
+#### Scenario: Lossy Critical→Wounded round-trip is fixed
+
+- **WHEN** a pilot has `CampaignPilotStatus.Critical` on their roster entry
+- **AND** a save/load round-trip occurs
+- **THEN** the status remains `Critical` (NOT downgraded to `Wounded`).
+
+### Requirement: ICampaign.personnel field is removed entirely
+
+`ICampaign` SHALL NOT contain a `personnel` field after PR4.
+
+#### Scenario: Legacy field absent
+
+- **WHEN** searching `ICampaign` interface for a `personnel` field
+- **THEN** the field is absent.
+
+#### Scenario: isCampaign() guard not coupled to personnel
+
+- **WHEN** the `isCampaign(value)` type guard runs
+- **THEN** it does NOT check for `value.personnel`.
+
+### Requirement: IPerson type is deleted from src/
+
+After PR5 lands, `IPerson` SHALL have zero references in `src/`. The `rosterEntryToPerson.ts` shim and tests SHALL also be deleted.
+
+#### Scenario: IPerson grep returns zero
+
+- **WHEN** running `grep -rn "IPerson\b" src/`
+- **THEN** the count SHALL be 0.
+
+#### Scenario: rosterEntryToPerson shim absent
+
+- **WHEN** searching for `src/lib/campaign/utils/rosterEntryToPerson.ts`
+- **THEN** the file SHALL NOT exist.

--- a/openspec/changes/wire-iperson-hard-cutover/tasks.md
+++ b/openspec/changes/wire-iperson-hard-cutover/tasks.md
@@ -1,0 +1,214 @@
+# Tasks: Wire IPerson Hard-Cutover
+
+> Council #2 ruling: ship as 5 sequential PRs. PR1 already shipped as [#486](https://github.com/SwiggitySwerve/MekStation/pull/486). PR2 is the largest (helper signatures, ~84 files). PR3 is atomic (processor pipeline cannot split). PR4 fixes the lossy Critical→Wounded bug by deleting bridge functions. PR5 is final IPerson cleanup.
+>
+> **Sequencing**: PR2 → PR3 → PR4 → PR5. Each PR blocks the next. Each is independently shippable and CI-verifiable.
+>
+> **PR1 (already shipped)**: Test fixture migration to `(entry, pilot) → rosterEntryToPerson()` bridge pattern. 33 sites across 6 files. Bridge functions stay alive (PR4 deletes them).
+
+---
+
+## PR2 — Helper signature migration
+
+### 1. Pre-flight: open question #1 verification
+
+- [ ] 1.1 Verify `ICampaignRosterEntry.injuries` field existence (open question from Council #2).
+  - If absent: add `readonly injuries?: readonly IInjury[]` to `ICampaignRosterEntry` in `src/types/campaign/CampaignRosterEntry.ts` BEFORE the medical commit.
+  - Acceptance: typecheck clean; type imports resolve.
+  - QA: `npx tsc --noEmit --skipLibCheck`.
+
+- [ ] 1.2 Verify pre-join template helpers exist or author them.
+  - Helper: `buildPilotLookup(vault: IPilot[]): Map<string, IPilot>` in `src/lib/campaign/utils/pilotLookup.ts` (new file).
+  - Acceptance: helper covered by unit test; importable from `@/lib/campaign/utils/pilotLookup`.
+
+### 2. Per-domain commits (each commit independently buildable + tested)
+
+- [ ] 2.1 **Medical commit** (7 files in `src/lib/campaign/medical/`).
+  - Migrate every helper signature from `(person: IPerson)` to `(entry: ICampaignRosterEntry, pilot: IPilot | null)`.
+  - NPC behavior: PROCESS (NPCs heal too).
+  - Update all callers in same commit.
+  - Acceptance: all medical tests pass; NPC handling JSDoc added.
+  - QA: `npx jest --testPathPattern='medical'`.
+
+- [ ] 2.2 **Turnover commit** (5 files in `src/lib/campaign/turnover/` + `ranks/rankService.isOfficer` cross-call).
+  - Same signature migration.
+  - NPC behavior: PROCESS for departure rolls; SKIP for officer status.
+  - Acceptance: turnover tests pass.
+  - QA: `npx jest --testPathPattern='turnover'`.
+
+- [ ] 2.3 **Finances commit** (`statusRules` + 3 finance services in `src/lib/finances/`: `salaryService`, `taxService`, `FinanceService`).
+  - NPC behavior: PROCESS (salary/tax apply to all roster entries).
+  - Acceptance: finances tests pass.
+  - QA: `npx jest --testPathPattern='(finances|statusRules)'`.
+
+- [ ] 2.4 **Progression + skills commit** (4 progression files + 3 skills files in `src/lib/campaign/`).
+  - NPC behavior: SKIP (`pilot === null` early-return).
+  - Use delta-return pattern per design.md decision.
+  - Acceptance: progression + skills tests pass.
+  - QA: `npx jest --testPathPattern='(progression|skills)'`.
+
+- [ ] 2.5 **Awards commit** (2 files, ~18 checker functions in `src/lib/campaign/awards/`).
+  - NPC behavior: SKIP all checker functions on `pilot === null`.
+  - Acceptance: awards tests pass.
+  - QA: `npx jest --testPathPattern='awards'`.
+
+- [ ] 2.6 **Ranks + maintenance + events commit** (mixed files in `src/lib/campaign/`).
+  - NPC behavior per design.md NPC matrix.
+  - Acceptance: ranks/maintenance/events tests pass.
+  - QA: `npx jest --testPathPattern='(ranks|maintenance|events)'`.
+
+- [ ] 2.7 **Type-layer helpers commit** (4 helpers in `src/types/campaign/Campaign.ts:147,163,180,300`).
+  - These are the cross-cutting type-guards / accessor helpers.
+  - Acceptance: typecheck clean.
+  - QA: `npx tsc --noEmit --skipLibCheck`.
+
+### 3. PR2 verification
+
+- [ ] 3.1 `npx tsc --noEmit --skipLibCheck` exit 0.
+- [ ] 3.2 Full test suite (~22.5k tests) passes.
+- [ ] 3.3 Lint gate: grep `vault\.find\b` in `src/lib/campaign/` and `src/lib/finances/` → ZERO hits in non-test files (helpers must use pre-join template).
+- [ ] 3.4 `npx oxfmt --check` clean.
+- [ ] 3.5 PR opened, CI green, merged.
+
+---
+
+## PR3 — Atomic processor + dayAdvancement repointing
+
+### 4. Open question #1 (PR3) verification
+
+- [ ] 4.1 Audit `dayAdvancement.ts:425-452` chain for implicit data dependency on `campaign.personnel` mid-chain.
+  - Read each of the 6 processors: does processor N read what processor N-1 wrote into `personnel`?
+  - Acceptance: dependency map documented inline as a comment in `dayAdvancement.ts`. If a true dependency exists, design.md needs revision.
+
+### 5. Atomic repointing
+
+- [ ] 5.1 Update `src/lib/campaign/dayAdvancement.ts` to:
+  - Pre-build `pilotsByPilotId` map at entry.
+  - Pass entries + pre-resolved pilots to each processor (NOT `campaign.personnel`).
+  - Acceptance: typecheck clean; processors accept new input shape.
+
+- [ ] 5.2 Update each of the 6 processors to read from `(entry, pilot | null)` instead of `campaign.personnel`:
+  - `src/lib/campaign/processors/healingProcessor.ts`
+  - `src/lib/campaign/processors/autoAwardsProcessor.ts`
+  - `src/lib/campaign/processors/vocationalTrainingProcessor.ts`
+  - `src/lib/campaign/processors/turnoverProcessor.ts`
+  - `src/lib/campaign/processors/randomEventsProcessor.ts`
+  - `src/lib/campaign/processors/postBattleProcessor.ts`
+  - Each commit per processor (within ONE PR for atomicity per Council #2 ruling).
+  - Acceptance: per-processor tests pass after each commit.
+  - QA: `npx jest --testPathPattern='<processor>'`.
+
+- [ ] 5.3 Update 4 type-layer helpers in `src/types/campaign/Campaign.ts` (lines 147, 163, 180, 300) to NOT read from `campaign.personnel`.
+  - Acceptance: typecheck clean.
+
+- [ ] 5.4 Update 2 UI `.size` readers:
+  - `src/pages/campaigns/index.tsx:46` — replace `campaign.personnel.size` with `useCampaignRosterStore((s) => s.pilots.length)`.
+  - `src/components/CampaignDashboardPage.sections.tsx:157` — same migration.
+  - Acceptance: components render; counts match.
+  - QA: storybook smoke test for both.
+
+- [ ] 5.5 Audit `autoAwardEngine.ts:55` and `turnoverCheck.ts:257` (other `campaign.personnel` readers per Council #2 finding).
+  - Migrate to read from stores.
+  - Acceptance: tests pass.
+
+### 6. PR3 verification
+
+- [ ] 6.1 `npx tsc --noEmit --skipLibCheck` exit 0.
+- [ ] 6.2 Integration round-trip tests pass: `phase3RoundTrip.test.ts`, `phase4CampaignRoundTrip.test.ts`.
+- [ ] 6.3 `dayAdvancement.test.ts` and `dayPipeline.test.ts` produce identical outputs vs pre-PR3 baseline.
+- [ ] 6.4 Bridge functions still alive (deletion is PR4's job).
+- [ ] 6.5 Production code grep: zero hits for `campaign.personnel` in `src/` excluding `useCampaignStore.ts` (where bridge functions live).
+- [ ] 6.6 PR opened, CI green, merged.
+
+---
+
+## PR4 — Map drop + lossy bug fix
+
+### 7. Bridge function deletion
+
+- [ ] 7.1 Delete `derivePersonnelFromRoster` function from `src/stores/campaign/useCampaignStore.ts:311`.
+  - Acceptance: typecheck surfaces any remaining callers.
+
+- [ ] 7.2 Delete `syncRosterFromPersonnel` function from `src/stores/campaign/useCampaignStore.ts:343-351`.
+  - This is the lossy Critical→Wounded round-trip bug location.
+  - Acceptance: typecheck clean.
+
+- [ ] 7.3 Delete legacy preservation merge at `src/stores/campaign/useCampaignStore.ts:743-750`.
+  - Acceptance: typecheck clean.
+
+### 8. ICampaign.personnel field removal
+
+- [ ] 8.1 Delete `personnel: Map<string, IPerson>` field from `ICampaign` interface.
+  - Location: search `src/types/campaign/Campaign.ts` for the field.
+  - Acceptance: typecheck surfaces all factories that initialize the field.
+
+- [ ] 8.2 Update all factories to drop `personnel: new Map()` initialization:
+  - `src/stores/campaign/useCampaignStore.ts` (deserialize / loadCampaign / merge / createCampaign).
+  - Any helper that constructs an `ICampaign` literal.
+  - Acceptance: typecheck clean.
+
+- [ ] 8.3 Delete `personnel` check from `isCampaign()` type guard at `src/types/campaign/Campaign.ts:163`.
+  - Acceptance: type guard still discriminates correctly via remaining fields.
+
+### 9. Lossy bug regression test
+
+- [ ] 9.1 Add a regression test that confirms the Critical→Wounded round-trip is fixed.
+  - Test: create a roster pilot with `CampaignPilotStatus.Critical`, save campaign, reload, confirm status is still `Critical`.
+  - Acceptance: test passes (would have failed pre-PR4 with the bug).
+  - QA: `npx jest --testPathPattern='criticalRoundTrip'` (new test file).
+
+### 10. PR4 verification
+
+- [ ] 10.1 `npx tsc --noEmit --skipLibCheck` exit 0.
+- [ ] 10.2 Full test suite passes (~22.5k tests).
+- [ ] 10.3 Critical→Wounded regression test passes.
+- [ ] 10.4 Grep `derivePersonnelFromRoster|syncRosterFromPersonnel` in `src/` returns ZERO hits.
+- [ ] 10.5 Grep `\.personnel\b` in `src/types/campaign/Campaign.ts` returns ZERO hits.
+- [ ] 10.6 `npx oxfmt --check` clean.
+- [ ] 10.7 PR opened, CI green, merged.
+
+---
+
+## PR5 — IPerson interface + shim deletion
+
+### 11. Pre-deletion grep + audit
+
+- [ ] 11.1 `grep -rn "IPerson\b" src/` — record count.
+  - Expected: only `src/types/campaign/Person.ts` (definition) + `src/lib/campaign/utils/rosterEntryToPerson.ts` (shim) + their tests.
+  - Acceptance: count matches expectation.
+
+- [ ] 11.2 `grep -rn "rosterEntryToPerson" src/` — confirm only the shim file + its tests reference it.
+
+### 12. Delete IPerson + shim
+
+- [ ] 12.1 Delete `IPerson` interface and related types from `src/types/campaign/Person.ts`.
+  - May need to keep `IInjury` if referenced elsewhere — verify with grep.
+  - Acceptance: typecheck clean.
+
+- [ ] 12.2 Delete `src/lib/campaign/utils/rosterEntryToPerson.ts` shim file.
+  - Acceptance: typecheck clean.
+
+- [ ] 12.3 Delete `src/lib/campaign/utils/__tests__/rosterEntryToPerson.test.ts` (or wherever the shim tests live).
+  - Acceptance: jest still discovers other tests.
+
+### 13. Final verification
+
+- [ ] 13.1 `grep -rn "IPerson\b" src/` returns ZERO hits.
+- [ ] 13.2 `grep -rn "rosterEntryToPerson" src/` returns ZERO hits.
+- [ ] 13.3 `npx tsc --noEmit --skipLibCheck` exit 0.
+- [ ] 13.4 Full test suite passes.
+- [ ] 13.5 `npx oxfmt --check` clean.
+- [ ] 13.6 PR opened, CI green, merged.
+
+### 14. Spec sync + archive
+
+- [ ] 14.1 On change archive (post-merge of PR5), the delta spec syncs into `openspec/specs/campaign-personnel-architecture/spec.md`.
+  - The source-of-truth spec already exists.
+  - Sync should be a no-op or near-no-op.
+  - Acceptance: `openspec sync` reports no diff or expected diff only.
+
+- [ ] 14.2 Update `openspec/specs/personnel-management/spec.md` to reference `IPilot` + `ICampaignRosterEntry` instead of legacy `IPerson` (if any references remain).
+  - Acceptance: personnel-management spec is internally consistent post-cutover.
+
+- [ ] 14.3 Archive change to `openspec/changes/archive/YYYY-MM-DD-wire-iperson-hard-cutover/`.
+  - Acceptance: `openspec list` no longer shows this change as active.

--- a/openspec/specs/campaign-personnel-architecture/spec.md
+++ b/openspec/specs/campaign-personnel-architecture/spec.md
@@ -1,0 +1,191 @@
+# Campaign Personnel Architecture Specification
+
+**Status**: Active
+**Version**: 1.0
+**Last Updated**: 2026-05-02
+**Dependencies**: campaign-management, pilot-system, personnel-management
+**Affects**: personnel-progression, personnel-status-roles, repair, after-combat-report
+
+---
+
+## Overview
+
+### Purpose
+
+Crystallize the canonical architecture for personnel data in a campaign. Distinguish three orthogonal stores (vault, roster, force assignment) and codify the migration path away from the legacy `IPerson` god-type that conflated all three concerns. This spec is the source-of-truth for the post-`migrate-personnel-to-roster-employment` end state and for the in-flight `wire-iperson-hard-cutover` PRs that complete the cutover.
+
+This spec supersedes the implicit conventions previously held by `derivePersonnelFromRoster`, `syncRosterFromPersonnel`, and the `ICampaign.personnel: Map<string, IPerson>` legacy field. After PR4 of `wire-iperson-hard-cutover` lands, the bridge functions are deleted and `campaign.personnel` no longer exists.
+
+### Scope
+
+**In Scope:**
+
+- Three-store architecture: vault (`usePilotStore`) + roster (`useCampaignRosterStore`) + force assignment (separate force-slot mirror).
+- Helper signature contract: every cross-store helper accepts `(entry: ICampaignRosterEntry, pilot: IPilot | null)` — the two-arg pattern (NOT a `IPersonnelView` god-type rename).
+- Pre-join template: helpers operating in a loop receive a `Map<pilotId, IPilot>` from vault to avoid N² `find()` calls.
+- NPC handling contract: domain helpers explicitly document whether they skip NPC entries (statblock-only, no vault pilot).
+- Delta-return contract for cross-store mutations: helpers that mutate state return delta objects keyed by store, not in-place mutations.
+- Bridge function deletion: `derivePersonnelFromRoster` and `syncRosterFromPersonnel` are NOT permanent infrastructure; they exist only during the cutover.
+- `IPerson` deletion: the legacy god-type is removed entirely from `src/types/`.
+
+**Out of Scope:**
+
+- `IPersonnelView` god-type rename (REFUSED by Council #2 — would re-conflate roles).
+- `PersonnelStatus` (37 values, `personnel-status-roles` spec) vs `CampaignPilotStatus` (5 values, roster-only) reconciliation. They serve different audiences; reconciliation is a separate spec change.
+- Vault/roster store split architecture (already shipped via `migrate-personnel-to-roster-employment`).
+- Memoization of derived views (premature; current N² is acceptable for current campaign sizes).
+- `IAttributes` aspirational fields on roster entry.
+- Pilot consciousness on `ICampaignRosterEntry` (combat-resolution Wave 5 gate; tracked under `campaign-unit-combat-state` deferred extensions).
+
+### Key Concepts
+
+- **Vault** (`usePilotStore`) — long-lived persistent pilot identities. One pilot can be hired by multiple campaigns over their career. Owns: identity, vault skills, lifetime career stats, awards, ability/SPA progression.
+- **Roster** (`useCampaignRosterStore`) — per-campaign employment record. Joins to vault via `pilotId`. Owns: campaign-scoped wounds, recovery time, salary override, hire date, departure reason, campaign XP earned, campaign kills, campaign missions.
+- **Force assignment** — slot-mirrored on `ICampaignRosterEntry.assignedUnitId`; the canonical force structure lives elsewhere.
+- **Bridge functions** — `derivePersonnelFromRoster()` and `syncRosterFromPersonnel()` synthesize the legacy `IPerson` shape from `(entry, pilot)`. Transitional infrastructure only.
+
+---
+
+## Requirements
+
+### Requirement: Personnel are stored across three orthogonal stores
+
+The system SHALL maintain personnel data across three stores with no overlapping ownership: vault (pilot identity), roster (per-campaign employment), and force assignment (unit-slot membership). No store SHALL hold a copy of another store's canonical fields.
+
+#### Scenario: Pilot identity lives in vault
+
+- **WHEN** a new pilot is created
+- **THEN** the pilot's identity (id, name, base skills, career stats, abilities) is written to `usePilotStore`
+- **AND** no copy of these identity fields appears on `ICampaignRosterEntry`.
+
+#### Scenario: Campaign employment lives on roster
+
+- **WHEN** a vault pilot is hired into a campaign
+- **THEN** an `ICampaignRosterEntry` is created with `pilotId` referencing the vault pilot
+- **AND** the entry carries only campaign-scoped fields (wounds, recoveryTime, salary, hireDate, campaign XP/kills/missions).
+
+#### Scenario: Force assignment is a slot mirror
+
+- **WHEN** a roster pilot is assigned to a unit
+- **THEN** `ICampaignRosterEntry.assignedUnitId` is set
+- **AND** the canonical force-slot record lives in the force store, not on the roster entry.
+
+### Requirement: Cross-store helpers accept the two-arg signature
+
+Helper functions that operate on personnel data SHALL accept `(entry: ICampaignRosterEntry, pilot: IPilot | null)` as their primary signature. Helpers SHALL NOT accept `IPerson` (deleted) or `IPersonnelView` (REFUSED by Council #2).
+
+#### Scenario: Medical helper signature
+
+- **WHEN** a medical helper computes healing rate
+- **THEN** it accepts `(entry: ICampaignRosterEntry, pilot: IPilot | null)`
+- **AND** reads wounds/recoveryTime from `entry`, vault medical bonuses from `pilot`.
+
+#### Scenario: NPC entries pass null pilot
+
+- **WHEN** a helper is called for an NPC roster entry (statblock-only, no vault pilot)
+- **THEN** the second arg is `null`
+- **AND** the helper handles `pilot === null` per its NPC contract.
+
+### Requirement: Pre-join template avoids N² find() calls
+
+Helpers operating over a list of roster entries SHALL receive a pre-built `Map<pilotId, IPilot>` rather than calling `vault.find(p => p.id === entry.pilotId)` per iteration.
+
+#### Scenario: Daily processor pre-joins vault
+
+- **WHEN** `dayAdvancement` iterates campaign roster entries
+- **THEN** it builds `pilotsByPilotId: Map<string, IPilot>` once from vault
+- **AND** passes the lookup map (or per-entry pre-resolved pilot) into each helper
+- **AND** no helper internally calls `vault.find(...)` on the vault array.
+
+#### Scenario: NPC pilot resolves to undefined
+
+- **WHEN** `pilotsByPilotId.get(entry.pilotId)` returns undefined for an NPC
+- **THEN** the caller passes `null` (not `undefined`) as the second arg to helpers.
+
+### Requirement: NPC handling is documented per helper
+
+Each domain helper SHALL document whether it processes or skips NPC entries (entries where `vaultPilot === null`). NPC-skipping helpers SHALL early-return without mutating state.
+
+#### Scenario: Vocational training skips NPCs
+
+- **WHEN** `vocationalTrainingProcessor` encounters an NPC roster entry
+- **THEN** it skips the entry (no XP awarded, no skill increase rolled).
+
+#### Scenario: Salary processing applies to NPCs
+
+- **WHEN** `salaryService` encounters an NPC roster entry
+- **THEN** it applies the entry's `salary` field (with `BASE_MONTHLY_SALARY` fallback) regardless of vault pilot presence.
+
+### Requirement: Cross-store mutations return delta objects
+
+Helpers that change state in multiple stores SHALL return delta objects keyed by store, not perform in-place mutations. Callers (processors) SHALL apply deltas atomically.
+
+#### Scenario: Skill progression returns dual delta
+
+- **WHEN** a progression helper increases vault skill AND records campaign XP spent
+- **THEN** it returns `{ vault: { pilotId, skillUpdates }, roster: { pilotId, xpDelta } }`
+- **AND** the calling processor commits each delta to the right store in one atomic transaction.
+
+### Requirement: Bridge functions are transitional infrastructure
+
+`derivePersonnelFromRoster()` and `syncRosterFromPersonnel()` SHALL exist only during the `wire-iperson-hard-cutover` migration. After PR4 of that change lands, both functions SHALL be deleted.
+
+#### Scenario: Bridge functions absent post-PR4
+
+- **WHEN** searching `src/` for `derivePersonnelFromRoster` or `syncRosterFromPersonnel`
+- **THEN** the count SHALL be 0 (after PR4 lands).
+
+#### Scenario: Lossy Critical→Wounded round-trip is fixed
+
+- **WHEN** a pilot has `CampaignPilotStatus.Critical` on their roster entry
+- **THEN** the round-trip through bridge functions historically downgraded the status to `Wounded` (the bug)
+- **AND** PR4 fixes this by deleting the round-trip entirely (no derivation, no sync).
+
+### Requirement: ICampaign.personnel field is removed entirely
+
+`ICampaign` SHALL NOT contain a `personnel` field after PR4 of `wire-iperson-hard-cutover` lands. Production code SHALL read personnel via `useCampaignRosterStore` + `usePilotStore` directly.
+
+#### Scenario: Legacy field absent
+
+- **WHEN** searching `ICampaign` interface for a `personnel` field
+- **THEN** the field is absent.
+
+#### Scenario: isCampaign() guard not coupled to personnel
+
+- **WHEN** the `isCampaign(value): value is ICampaign` type guard runs
+- **THEN** it does NOT check for `value.personnel` (decoupled in PR4).
+
+### Requirement: IPerson type is deleted from src/
+
+After PR5 of `wire-iperson-hard-cutover` lands, `IPerson` SHALL have zero references in `src/`. The `rosterEntryToPerson.ts` shim and its tests SHALL also be deleted.
+
+#### Scenario: IPerson grep returns zero
+
+- **WHEN** `grep -rn "IPerson" src/`
+- **THEN** the count SHALL be 0 (after PR5 lands).
+
+#### Scenario: rosterEntryToPerson shim absent
+
+- **WHEN** searching for `src/lib/campaign/utils/rosterEntryToPerson.ts`
+- **THEN** the file SHALL NOT exist (after PR5 lands).
+
+### Requirement: Cross-spec consumption boundaries
+
+#### Scenario: personnel-management spec consumes the architecture
+
+- **WHEN** `personnel-management/spec.md` describes Person Entity attributes
+- **THEN** the attributes are split between vault (`usePilotStore.IPilot`) and roster (`useCampaignRosterStore.ICampaignRosterEntry`) per this spec
+- **AND** legacy `IPerson` references in `personnel-management/spec.md` are updated post-PR5 to reference the split.
+
+#### Scenario: personnel-progression spec consumes the contract
+
+- **WHEN** `personnel-progression/spec.md` describes XP spending and skill increase
+- **THEN** the helpers it references SHALL accept the two-arg `(entry, pilot)` signature.
+
+---
+
+## Migration notes
+
+This spec is authored post-PR1 of `wire-iperson-hard-cutover` (already shipped as PR #486 — test fixture migration). PR2-PR5 implement the remainder per Council #2's staged cutover. Implementation tracked at `openspec/changes/wire-iperson-hard-cutover/`.
+
+Pre-release context (zero released users, hard-cutover policy): no Zustand `persist` migration callback required. First load post-PR4 rebuilds localStorage from defaults.


### PR DESCRIPTION
## Summary

Authors the OpenSpec change for Cluster E (PR2-PR5) and the canonical source-of-truth spec, completing the codification of Council #2's decision.

**New canonical spec**: [`openspec/specs/campaign-personnel-architecture/spec.md`](openspec/specs/campaign-personnel-architecture/spec.md) — 9 requirements, ~30 scenarios. Codifies the three-store architecture (vault + roster + force assignment), two-arg helper signature contract, NPC handling matrix, pre-join template requirement, delta-return contract, and the bridge-deletion contract.

**New openspec change**: [`openspec/changes/wire-iperson-hard-cutover/`](openspec/changes/wire-iperson-hard-cutover/) — 4-artifact change with PR2/PR3/PR4/PR5 task breakdown:
- **PR2**: Helper signature migration (~72 helpers / 84 files, per-domain commits)
- **PR3**: Atomic processor + dayAdvancement repointing (6 processors, can't split per Council #2)
- **PR4**: Map drop + lossy Critical→Wounded bug fix (deletes bridge functions)
- **PR5**: IPerson interface + shim deletion (final cleanup)

PR1 already shipped as [#486](https://github.com/SwiggitySwerve/MekStation/pull/486).

## Validation

- `openspec validate wire-iperson-hard-cutover --strict` — clean
- `openspec status --change wire-iperson-hard-cutover` — 4/4 artifacts complete

## Next session

Run `/opsx:apply wire-iperson-hard-cutover` to start PR2.

## Test plan

- [x] Docs-only PR; no code changes
- [x] CI lint / format / typecheck still pass on docs-only diff