### PR TITLE
docs(openspec): Council #4 — insert PR1.5 to fix 4 live IPerson-bridge bugs

### DIFF
--- a/openspec/changes/wire-iperson-hard-cutover/tasks.md
+++ b/openspec/changes/wire-iperson-hard-cutover/tasks.md
@@ -1,18 +1,71 @@
 # Tasks: Wire IPerson Hard-Cutover
 
-> Council #2 ruling: ship as 5 sequential PRs. PR1 already shipped as [#486](https://github.com/SwiggitySwerve/MekStation/pull/486). PR2 is the largest (helper signatures, ~84 files). PR3 is atomic (processor pipeline cannot split). PR4 fixes the lossy Critical→Wounded bug by deleting bridge functions. PR5 is final IPerson cleanup.
+> Council #2 ruling (2026-05-02): ship as 5 sequential PRs.
+> Council #4 revision (2026-05-02): insert NEW **PR1.5** before PR2 because PR2 hephaestus surfaced 4 LIVE BUGS in `rosterEntryToPerson` bridge that block clean helper migration. See `openspec/council-decisions/2026-05-02-cluster-E-iperson-contract-revision.md`.
 >
-> **Sequencing**: PR2 → PR3 → PR4 → PR5. Each PR blocks the next. Each is independently shippable and CI-verifiable.
+> **Revised sequencing**: PR1 (shipped) → **PR1.5 (NEW, schema extension + bridge data integrity)** → PR2 → PR3 → PR4 → PR5. Each PR blocks the next.
 >
-> **PR1 (already shipped)**: Test fixture migration to `(entry, pilot) → rosterEntryToPerson()` bridge pattern. 33 sites across 6 files. Bridge functions stay alive (PR4 deletes them).
+> **PR1 (already shipped as #486)**: Test fixture migration to `(entry, pilot) → rosterEntryToPerson()` bridge pattern. 33 sites across 6 files. Bridge functions stay alive (PR4 deletes them).
+>
+> **PR1.5 (NEW per Council #4)**: Fix 4 live bugs in bridge by adding 4 missing fields to `ICampaignRosterEntry` (`primaryRole` required, `traits?` optional, `rankIndex` required, `lastPromotionDate?` optional) + 2 additive Tier 2 fields (`isFounder?`, `isCommander?`). Bridge `rosterEntryToPerson.ts` forwards these instead of synthesizing defaults. Pre-flight commit `b323121b` (injuries field + buildPilotLookup helper) folds in here. ~2 hours.
+
+---
+
+## PR1.5 — Schema extension + bridge data integrity (NEW per Council #4)
+
+### 0. Tier 1 — required field additions (live bug fixes)
+
+- [ ] 0.1 Add `primaryRole: CampaignPersonnelRole` (required) to `src/types/campaign/CampaignRosterEntry.ts`. Existing rows defaulted to `PILOT` in `useCampaignStore.deserializeCampaign` migration path.
+  - Acceptance: typecheck clean; deserialize backward-compatible.
+  - QA: `npx jest --testPathPattern='useCampaignStore'`.
+
+- [ ] 0.2 Add `traits?: IPersonTraits` (optional) to `ICampaignRosterEntry`. Import `IPersonTraits` from `src/types/campaign/Person.ts`.
+  - Acceptance: typecheck clean.
+
+- [ ] 0.3 Add `rankIndex: number` (required) to `ICampaignRosterEntry`. Existing rows defaulted to `0` in deserialize migration.
+  - Acceptance: typecheck clean; deserialize backward-compatible.
+
+- [ ] 0.4 Add `lastPromotionDate?: Date` (optional) to `ICampaignRosterEntry`.
+  - Acceptance: typecheck clean.
+
+### 0.5 Tier 2 — additive optional fields (no production write path today)
+
+- [ ] 0.5.1 Add `isFounder?: boolean` (optional) to `ICampaignRosterEntry`.
+- [ ] 0.5.2 Add `isCommander?: boolean` (optional) to `ICampaignRosterEntry`.
+
+### 0.6 Bridge update — forward instead of synthesize
+
+- [ ] 0.6.1 Update `src/lib/campaign/utils/rosterEntryToPerson.ts:164` to forward `primaryRole: entry.primaryRole` (drop hardcoded `PILOT`).
+- [ ] 0.6.2 Update bridge to forward `traits: entry.traits ?? {}` (currently omitted).
+- [ ] 0.6.3 Update bridge line 168 to forward `rankIndex: entry.rankIndex` (drop hardcoded 0).
+- [ ] 0.6.4 Add `lastPromotionDate: entry.lastPromotionDate` to bridge return block (currently omitted).
+- [ ] 0.6.5 Add `isFounder: entry.isFounder` and `isCommander: entry.isCommander` to bridge return.
+- [ ] 0.6.6 Update bridge tests in `src/lib/campaign/utils/__tests__/rosterEntryToPerson.test.ts` to cover the new forward paths.
+
+### 0.7 Regression verification (live bug fixes)
+
+- [ ] 0.7.1 Run `npx jest src/lib/finances/__tests__/salaryService.test.ts` — confirm non-PILOT fixtures (DOCTOR/TECH/MEK_TECH/SOLDIER/DEPENDENT at lines 340/349/358/367/454/657/666) now produce correct salary categorization.
+- [ ] 0.7.2 Run `npx jest src/lib/campaign/medical/__tests__/doctorCapacity.test.ts` — confirm `getBestAvailableDoctor` returns DOCTOR roster entries.
+- [ ] 0.7.3 Run `npx jest src/lib/campaign/ranks/__tests__/rankService.test.ts` — confirm promotion logic accepts non-zero rank inputs.
+- [ ] 0.7.4 Run `npx jest src/lib/campaign/__tests__/aging.test.ts` and `src/lib/campaign/processors/__tests__/vocationalTrainingProcessor.test.ts` — confirm trait accumulation persists across passes.
+
+### 0.8 PR1.5 verification
+
+- [ ] 0.8.1 `npx tsc --noEmit --skipLibCheck` exit 0.
+- [ ] 0.8.2 Full test suite passes (~22.5k tests).
+- [ ] 0.8.3 `npx oxfmt --check` clean.
+- [ ] 0.8.4 PR opened, CI green, merged.
+- [ ] 0.8.5 Branch `chore/cluster-e-pr2-helper-signatures` (containing pre-flight commit `b323121b`: injuries field + buildPilotLookup) is folded into PR1.5 via cherry-pick or rebase.
 
 ---
 
 ## PR2 — Helper signature migration
 
-### 1. Pre-flight: open question #1 verification
+> **REVISED PER COUNCIL #4**: PR1.5 ships first. Bridge now forwards correct values, so helpers can safely migrate without losing test scenario coverage. The 4 live bugs (primaryRole/traits/rankIndex/lastPromotionDate) are FIXED by PR1.5 — PR2 just continues the planned helper signature migration.
 
-- [ ] 1.1 Verify `ICampaignRosterEntry.injuries` field existence (open question from Council #2).
+### 1. Pre-flight: open question #1 verification (subsumed by PR1.5)
+
+- [x] 1.1 Verify `ICampaignRosterEntry.injuries` field existence (open question from Council #2).
   - If absent: add `readonly injuries?: readonly IInjury[]` to `ICampaignRosterEntry` in `src/types/campaign/CampaignRosterEntry.ts` BEFORE the medical commit.
   - Acceptance: typecheck clean; type imports resolve.
   - QA: `npx tsc --noEmit --skipLibCheck`.

--- a/openspec/council-decisions/2026-05-02-cluster-E-iperson-contract-revision.md
+++ b/openspec/council-decisions/2026-05-02-cluster-E-iperson-contract-revision.md
@@ -1,0 +1,124 @@
+# Council #4 Decision — Cluster E IPerson Contract Revision
+
+**Date**: 2026-05-02
+**Variant**: Lean+ collapsed to Phase 0 + 1 Phase-2 verifier (Metis reframe was decisive; Oracle deemed unnecessary)
+**Verdict**: VERIFIED (Phase 4.5 Haiku — all 4 deciding facts confirmed)
+**Survival Score**: 9/10
+**Predecessor**: Council #2 (`2026-05-02-cluster-E-iperson-hard-cutover.md`) — 5-PR plan stands, but a precursor PR1.5 is inserted before PR2.
+
+---
+
+## Trigger
+
+PR2 hephaestus stopped after Section 1 (pre-flight) with a STOP-and-Report citing 7 IPerson fields with no equivalent on `ICampaignRosterEntry` or `IPilot`. Bridge function `rosterEntryToPerson.ts` synthesizes defaults that hephaestus claimed would break test scenarios once helpers migrate to the `(entry, pilot)` contract.
+
+## Question
+
+Council #2 ruled that helpers in `src/lib/campaign/` and `src/lib/finances/` migrate to `(entry: ICampaignRosterEntry, pilot: IPilot | null)`. PR2 surfaced ~7 IPerson fields not on either store. How to resolve?
+
+5 options under consideration: A (add all 7), B (accept defaults + delete usage), C (refactor helpers per-field), D (hybrid per-field), E (per-domain PRs with shims).
+
+## Critical reframe (Phase 0 Metis + Phase 2 Explore-Deep)
+
+**The 7 fields are NOT a uniform problem. They sort into 3 tiers, and 4 of them are LIVE BUGS in production today** (the bridge silently breaks behavior; PR2 doesn't introduce these — it exposes them).
+
+### Tier 1 — LIVE BUGS that block PR2 and must be fixed first
+
+| Field | Live bug evidence | Fix |
+|---|---|---|
+| `primaryRole` | Hardcoded PILOT in bridge ([rosterEntryToPerson.ts:164](src/lib/campaign/utils/rosterEntryToPerson.ts:164)) breaks `getBestAvailableDoctor` filter ([doctorCapacity.ts:120-124](src/lib/campaign/medical/doctorCapacity.ts:120)) and `salaryService` role-based pay ([salaryService.ts:283,431-434](src/lib/finances/salaryService.ts:283)). Doctors are invisible; non-PILOT roles paid as PILOT. | Add as **required** field on `ICampaignRosterEntry`. Bridge maps from roster entry. |
+| `traits` | Bridge omits entirely ([rosterEntryToPerson.ts:151-195](src/lib/campaign/utils/rosterEntryToPerson.ts:151)). `aging.ts:449-470` and `vocationalTrainingProcessor.ts:141,164-166,173-175` read AND write `traits.glassJaw`, `traits.slowLearner`, `traits.vocationalXPTimer`. Every read is `undefined?.x`; every spread write discards prior flags. Glass Jaw / Slow Learner / vocational timer **silently lost on every processing pass**. | Add as **optional** field on `ICampaignRosterEntry`. Bridge forwards via `traits: entry.traits ?? {}`. |
+| `rankIndex` | Hardcoded 0 in bridge ([rosterEntryToPerson.ts:168](src/lib/campaign/utils/rosterEntryToPerson.ts:168)). `rankService.ts:111,149,207,265` reads `person.rankIndex ?? 0`. **Promotion gate at line 208 (`newRankIndex <= currentRankIndex`) blocks all promotions** because current is always 0. | Add as **required** field on `ICampaignRosterEntry`. Bridge forwards. |
+| `lastPromotionDate` | Bridge omits. `rankService.ts:369,373` reads `person.lastPromotionDate`; absent → `isRecentlyPromoted` always returns `false`. Promotion-recency turnover modifier never fires. | Add as **optional** field on `ICampaignRosterEntry`. Bridge forwards. |
+
+**Verified via Phase 2 Explore-Deep** — all 4 claims VERIFIED with `path:line` evidence; Phase 4.5 Haiku VERIFIED the Tier classification.
+
+### Tier 2 — Additive, low risk (handle inside PR2 medical/turnover commits)
+
+| Field | Production write path | Disposition |
+|---|---|---|
+| `isFounder` | Zero hits in `src/stores/` or `src/components/` (only test fixtures) — verified | Add as **optional** boolean on `ICampaignRosterEntry`. Pure additive; no migration risk. |
+| `isCommander` | Same as above — verified | Add as **optional** boolean on `ICampaignRosterEntry`. |
+
+### Tier 3 — Already no-ops, do not block
+
+| Field | Status |
+|---|---|
+| `serviceContractEndDate` | Explicit stub at `personalModifiers.ts:87` returns 0 unconditionally with FIXME comment. |
+| `isImmortal` | 3 hits total in `src/`, all on `Person.ts` definition. Zero production reads. Dead field. |
+| `skills.administration.level` | `getDoctorCapacity` reads with `?? 0` fallback. Defaults gracefully. |
+| `attributes.BOD` | Bridge supplies `DEFAULT_ATTRIBUTES` (BOD=5). Same value as production has ever stored. Defensible default. |
+
+## Decision
+
+**HYBRID OPTION D — TIER-BASED PR1.5 INSERTION.**
+
+The Council #2 5-PR plan stands. **Insert a new PR1.5 before PR2**:
+
+### PR1.5 (NEW) — Schema extension + bridge data integrity (S, ~2 hours)
+
+- Add 4 fields to `ICampaignRosterEntry`:
+  - `primaryRole: CampaignPersonnelRole` (required; existing rows defaulted to PILOT in deserialize migration)
+  - `traits?: IPersonTraits` (optional)
+  - `rankIndex: number` (required; existing rows defaulted to 0 in deserialize migration)
+  - `lastPromotionDate?: Date` (optional)
+- Update `rosterEntryToPerson.ts` bridge to FORWARD these from the roster entry instead of synthesizing defaults
+- Update bridge tests
+- Add Tier 2 fields (`isFounder?`, `isCommander?`) as optional booleans (additive, pure)
+- Verify regression: existing `salaryService.test.ts` non-PILOT fixtures (DOCTOR/TECH/MEK_TECH/SOLDIER/DEPENDENT) now produce correct salary categorization
+- **No helper signature migration** — that stays in PR2
+
+### PR2 (revised) — Helper signature migration
+
+Same plan as Council #2 said, but now WITH data-integrity guaranteed by PR1.5. Bridge always forwards correct field values, so helpers can safely migrate without losing test scenario coverage.
+
+### PR3-PR5 — Unchanged
+
+- PR3: Atomic processor + dayAdvancement repointing
+- PR4: Map drop + lossy Critical→Wounded bug fix (deletes bridge functions)
+- PR5: IPerson + shim deletion
+
+## What also ships from this council
+
+- This decision document
+- Update `openspec/changes/wire-iperson-hard-cutover/tasks.md` to insert PR1.5 section + revise PR2 contract notes
+- Update `openspec/specs/campaign-personnel-architecture/spec.md` to add a Requirement codifying the Tier 1 fields' presence on roster entry
+- Pre-flight commit `b323121b` (injuries field + buildPilotLookup) folds into PR1.5 since it already touches `ICampaignRosterEntry` schema
+
+## Out of scope (explicitly REFUSED)
+
+- Hephaestus's Option E (per-domain PRs with `*FromPerson` shims) — UNNECESSARY now that PR1.5 lands the substrate
+- Refactoring helpers to not need the fields (Option C) — adds behavior change risk for no benefit
+- Adding all 7 fields uniformly (Option A) — overshoots; Tier 3 fields don't need to ship
+- `attributes` migration — defer until alternate medical system becomes a first-class feature
+
+## Survival Score breakdown
+
+- **Architectural soundness**: 9/10 — claims verified with line-numbered evidence
+- **Scope clarity**: 9/10 — explicit Tier 1/2/3 split + concrete PR1.5 task list
+- **Verification depth**: 9/10 — Phase 0 + Phase 2 (1 seat) + Phase 4.5 Haiku, all VERIFIED
+- **Risk to existing plan**: 9/10 — Council #2's 5-PR plan stands, just adds PR1.5 precursor
+
+**Overall: 9/10**.
+
+## Council seats
+
+| Seat | Position | Model |
+|---|---|---|
+| Phase 0 Metis | reframer (collapsed 5 options to Tier 1/2/3) | sonnet |
+| Phase 2 Explore-Deep | call-graph verification (4 live bugs VERIFIED + Tier 2 no-write VERIFIED) | sonnet |
+| Phase 4.5 Haiku verifier | VERIFIED (all 4 deciding facts confirmed) | haiku |
+| Hephaestus | Phase 0 stop-and-report surfaced the issue (out of council per protocol — was the trigger, not a seat) | n/a |
+| Oracle | NOT consulted (Metis explicit recommendation; question collapsed to scoping refinement, not strategic pivot) | n/a |
+
+## Effort estimate
+
+**PR1.5**: ~2 hours focused work (schema additions + bridge forwarding + bridge tests + regression check on salaryService).
+**PR2 (revised)**: same as Council #2 estimated (~5-7 days), but with data integrity guaranteed.
+**PR3-5**: unchanged.
+
+Total wire-iperson-hard-cutover initiative: **3-4 weeks** (slight extension from Council #2's estimate due to PR1.5 insertion).
+
+## Phase 6 status
+
+**Skipped this session.** Per ULTRAWORK loop cap, Council #4 deliverable is decision doc + tasks.md update. PR1.5 → PR2 → PR3-5 implementation chain is deferred to follow-up sessions.

--- a/openspec/specs/campaign-personnel-architecture/spec.md
+++ b/openspec/specs/campaign-personnel-architecture/spec.md
@@ -70,6 +70,35 @@ The system SHALL maintain personnel data across three stores with no overlapping
 - **THEN** `ICampaignRosterEntry.assignedUnitId` is set
 - **AND** the canonical force-slot record lives in the force store, not on the roster entry.
 
+### Requirement: ICampaignRosterEntry carries the campaign-scoped fields production needs
+
+`ICampaignRosterEntry` SHALL carry the per-campaign personnel fields that production helpers branch on. The bridge function `rosterEntryToPerson` SHALL forward these fields verbatim, NOT synthesize defaults. (Per Council #4 2026-05-02; replaces the prior implicit "bridge synthesizes everything" assumption that produced 4 live bugs in salaryService role-categorization, getBestAvailableDoctor filtering, rankService promotion gating, and aging/vocationalTrainingProcessor trait persistence.)
+
+#### Scenario: Required campaign-scoped fields
+
+- **WHEN** an `ICampaignRosterEntry` is constructed
+- **THEN** it carries `primaryRole: CampaignPersonnelRole` (required) AND `rankIndex: number` (required) AND pre-existing required fields (`pilotId`, `joinedAt`, `status`, etc.)
+- **AND** the deserialize migration defaults legacy stored entries to `primaryRole: PILOT` and `rankIndex: 0` for backward read compatibility.
+
+#### Scenario: Optional campaign-scoped fields
+
+- **WHEN** a campaign-specific behavior applies to a roster entry
+- **THEN** the corresponding optional field exists on the entry: `traits?: IPersonTraits`, `lastPromotionDate?: Date`, `isFounder?: boolean`, `isCommander?: boolean`, in addition to pre-existing optional fields (`salary?`, `departureReason?`, etc.).
+
+#### Scenario: Bridge forwards instead of synthesizing
+
+- **WHEN** `rosterEntryToPerson(entry, pilot)` runs
+- **THEN** it forwards `primaryRole`, `traits`, `rankIndex`, `lastPromotionDate`, `isFounder`, `isCommander` verbatim from the roster entry
+- **AND** it SHALL NOT hardcode `primaryRole: PILOT`, `rankIndex: 0`, omit `traits`, or omit `lastPromotionDate`.
+
+#### Scenario: Live bug regression coverage
+
+- **WHEN** a non-PILOT roster entry (DOCTOR, MEK_TECH, TECH, SOLDIER, DEPENDENT) is processed by `salaryService`
+- **THEN** the salary category SHALL match the role
+- **AND** `getBestAvailableDoctor` SHALL include DOCTOR/MEDIC entries (not filter them out as non-PILOT)
+- **AND** `rankService.processPromotion` SHALL succeed for entries with `rankIndex > 0` baseline
+- **AND** `aging.ts` and `vocationalTrainingProcessor.ts` SHALL preserve `traits.glassJaw`, `traits.slowLearner`, and `traits.vocationalXPTimer` across processing passes.
+
 ### Requirement: Cross-store helpers accept the two-arg signature
 
 Helper functions that operate on personnel data SHALL accept `(entry: ICampaignRosterEntry, pilot: IPilot | null)` as their primary signature. Helpers SHALL NOT accept `IPerson` (deleted) or `IPersonnelView` (REFUSED by Council #2).
@@ -170,6 +199,8 @@ After PR5 of `wire-iperson-hard-cutover` lands, `IPerson` SHALL have zero refere
 - **THEN** the file SHALL NOT exist (after PR5 lands).
 
 ### Requirement: Cross-spec consumption boundaries
+
+Other specs that reference personnel data SHALL consume the split contract defined here (vault + roster + force assignment) and SHALL NOT reference the deleted `IPerson` type after PR5 of `wire-iperson-hard-cutover` lands.
 
 #### Scenario: personnel-management spec consumes the architecture
 

--- a/openspec/specs/campaign-unit-combat-state/spec.md
+++ b/openspec/specs/campaign-unit-combat-state/spec.md
@@ -202,6 +202,8 @@ This spec is the source-of-truth for `IUnitCombatState` and `ICampaign.unitComba
 
 ### Requirement: Cross-spec consumption boundaries
 
+Other specs that reference unit-state data SHALL consume `IUnitCombatState`, `IUnitMaxState`, or `IRosterUnitProjection` per their audience and SHALL NOT reference the deleted `ICampaignUnitState` interface or `CampaignUnitStatus` enum.
+
 #### Scenario: Repair spec consumption
 
 - **WHEN** `repair/spec.md` describes damage assessment input


### PR DESCRIPTION
## Summary

- Council #4 reframed PR2's 7-field blocker into 3 tiers and surfaced **4 LIVE BUGS** in the `rosterEntryToPerson` bridge today (not introduced by PR2 — exposed by it).
- Decision: insert **PR1.5** (~2h) before PR2 to add Tier 1 fields (`primaryRole`, `traits?`, `rankIndex`, `lastPromotionDate?`) and Tier 2 fields (`isFounder?`, `isCommander?`) to `ICampaignRosterEntry`, and update the bridge to forward instead of synthesize defaults.
- Council #2's 5-PR plan otherwise stands.

## Live bugs documented

| Field | Live bug |
|---|---|
| `primaryRole` | Hardcoded PILOT in bridge → doctors invisible to capacity, non-PILOT roles paid as PILOT |
| `traits` | Bridge omits → `glassJaw` / `slowLearner` / `vocationalXPTimer` lost on every aging + vocational pass |
| `rankIndex` | Hardcoded 0 → all promotions blocked by `newRankIndex <= currentRankIndex` gate |
| `lastPromotionDate` | Bridge omits → recently-promoted turnover modifier never fires |

All 4 verified via Phase 2 Explore-Deep with `path:line` evidence; Phase 4.5 Haiku verifier VERIFIED the Tier classification. Survival Score 9/10.

## Files changed

- `openspec/council-decisions/2026-05-02-cluster-E-iperson-contract-revision.md` (new) — full Council #4 decision doc with Tier 1/2/3 split + verification trail
- `openspec/changes/wire-iperson-hard-cutover/tasks.md` — inserts PR1.5 section before PR2 with concrete task list
- `openspec/specs/campaign-personnel-architecture/spec.md` — adds new Requirement codifying the Tier 1 fields' presence on roster entry, with live-bug regression coverage scenarios
- `openspec/specs/campaign-unit-combat-state/spec.md` — drive-by SHALL backfill on pre-existing "Cross-spec consumption boundaries" requirement (was failing strict validation pre-edit)

## Test plan

- [x] `openspec validate --specs --strict` → 182/182 pass
- [x] `openspec validate wire-iperson-hard-cutover --strict` → valid
- [x] No code changes (docs/specs only); CI lint+format only

## Out of scope

- PR1.5 implementation (multi-week sequence per Council #2 + Council #4)
- Pre-flight branch `chore/cluster-e-pr2-helper-signatures` (commit `b323121b`) — folds into PR1.5 per Council #4