### PR TITLE
feat(roster): PR1.5 — schema extension + bridge data integrity (Cluster E)

### DIFF
--- a/openspec/changes/wire-iperson-hard-cutover/tasks.md
+++ b/openspec/changes/wire-iperson-hard-cutover/tasks.md
@@ -15,47 +15,47 @@
 
 ### 0. Tier 1 — required field additions (live bug fixes)
 
-- [ ] 0.1 Add `primaryRole: CampaignPersonnelRole` (required) to `src/types/campaign/CampaignRosterEntry.ts`. Existing rows defaulted to `PILOT` in `useCampaignStore.deserializeCampaign` migration path.
+- [x] 0.1 Add `primaryRole: CampaignPersonnelRole` (required) to `src/types/campaign/CampaignRosterEntry.ts`. Existing rows defaulted to `PILOT` in `useCampaignStore.deserializeCampaign` migration path.
   - Acceptance: typecheck clean; deserialize backward-compatible.
   - QA: `npx jest --testPathPattern='useCampaignStore'`.
 
-- [ ] 0.2 Add `traits?: IPersonTraits` (optional) to `ICampaignRosterEntry`. Import `IPersonTraits` from `src/types/campaign/Person.ts`.
+- [x] 0.2 Add `traits?: IPersonTraits` (optional) to `ICampaignRosterEntry`. Import `IPersonTraits` from `src/types/campaign/Person.ts`.
   - Acceptance: typecheck clean.
 
-- [ ] 0.3 Add `rankIndex: number` (required) to `ICampaignRosterEntry`. Existing rows defaulted to `0` in deserialize migration.
+- [x] 0.3 Add `rankIndex: number` (required) to `ICampaignRosterEntry`. Existing rows defaulted to `0` in deserialize migration.
   - Acceptance: typecheck clean; deserialize backward-compatible.
 
-- [ ] 0.4 Add `lastPromotionDate?: Date` (optional) to `ICampaignRosterEntry`.
+- [x] 0.4 Add `lastPromotionDate?: Date` (optional) to `ICampaignRosterEntry`.
   - Acceptance: typecheck clean.
 
 ### 0.5 Tier 2 — additive optional fields (no production write path today)
 
-- [ ] 0.5.1 Add `isFounder?: boolean` (optional) to `ICampaignRosterEntry`.
-- [ ] 0.5.2 Add `isCommander?: boolean` (optional) to `ICampaignRosterEntry`.
+- [x] 0.5.1 Add `isFounder?: boolean` (optional) to `ICampaignRosterEntry`.
+- [x] 0.5.2 Add `isCommander?: boolean` (optional) to `ICampaignRosterEntry`.
 
 ### 0.6 Bridge update — forward instead of synthesize
 
-- [ ] 0.6.1 Update `src/lib/campaign/utils/rosterEntryToPerson.ts:164` to forward `primaryRole: entry.primaryRole` (drop hardcoded `PILOT`).
-- [ ] 0.6.2 Update bridge to forward `traits: entry.traits ?? {}` (currently omitted).
-- [ ] 0.6.3 Update bridge line 168 to forward `rankIndex: entry.rankIndex` (drop hardcoded 0).
-- [ ] 0.6.4 Add `lastPromotionDate: entry.lastPromotionDate` to bridge return block (currently omitted).
-- [ ] 0.6.5 Add `isFounder: entry.isFounder` and `isCommander: entry.isCommander` to bridge return.
-- [ ] 0.6.6 Update bridge tests in `src/lib/campaign/utils/__tests__/rosterEntryToPerson.test.ts` to cover the new forward paths.
+- [x] 0.6.1 Update `src/lib/campaign/utils/rosterEntryToPerson.ts:164` to forward `primaryRole: entry.primaryRole` (drop hardcoded `PILOT`).
+- [x] 0.6.2 Update bridge to forward `traits: entry.traits ?? {}` (currently omitted).
+- [x] 0.6.3 Update bridge line 168 to forward `rankIndex: entry.rankIndex` (drop hardcoded 0).
+- [x] 0.6.4 Add `lastPromotionDate: entry.lastPromotionDate` to bridge return block (currently omitted).
+- [x] 0.6.5 Add `isFounder: entry.isFounder` and `isCommander: entry.isCommander` to bridge return.
+- [x] 0.6.6 Update bridge tests in `src/lib/campaign/utils/__tests__/rosterEntryToPerson.test.ts` to cover the new forward paths.
 
 ### 0.7 Regression verification (live bug fixes)
 
-- [ ] 0.7.1 Run `npx jest src/lib/finances/__tests__/salaryService.test.ts` — confirm non-PILOT fixtures (DOCTOR/TECH/MEK_TECH/SOLDIER/DEPENDENT at lines 340/349/358/367/454/657/666) now produce correct salary categorization.
-- [ ] 0.7.2 Run `npx jest src/lib/campaign/medical/__tests__/doctorCapacity.test.ts` — confirm `getBestAvailableDoctor` returns DOCTOR roster entries.
-- [ ] 0.7.3 Run `npx jest src/lib/campaign/ranks/__tests__/rankService.test.ts` — confirm promotion logic accepts non-zero rank inputs.
-- [ ] 0.7.4 Run `npx jest src/lib/campaign/__tests__/aging.test.ts` and `src/lib/campaign/processors/__tests__/vocationalTrainingProcessor.test.ts` — confirm trait accumulation persists across passes.
+- [x] 0.7.1 Run `npx jest src/lib/finances/__tests__/salaryService.test.ts` — confirm non-PILOT fixtures (DOCTOR/TECH/MEK_TECH/SOLDIER/DEPENDENT at lines 340/349/358/367/454/657/666) now produce correct salary categorization.
+- [x] 0.7.2 Run `npx jest src/lib/campaign/medical/__tests__/doctorCapacity.test.ts` — confirm `getBestAvailableDoctor` returns DOCTOR roster entries.
+- [x] 0.7.3 Run `npx jest src/lib/campaign/ranks/__tests__/rankService.test.ts` — confirm promotion logic accepts non-zero rank inputs.
+- [x] 0.7.4 Run `npx jest src/lib/campaign/__tests__/aging.test.ts` and `src/lib/campaign/processors/__tests__/vocationalTrainingProcessor.test.ts` — confirm trait accumulation persists across passes.
 
 ### 0.8 PR1.5 verification
 
-- [ ] 0.8.1 `npx tsc --noEmit --skipLibCheck` exit 0.
-- [ ] 0.8.2 Full test suite passes (~22.5k tests).
-- [ ] 0.8.3 `npx oxfmt --check` clean.
+- [x] 0.8.1 `npx tsc --noEmit --skipLibCheck` exit 0.
+- [x] 0.8.2 Full test suite passes (~22.5k tests).
+- [x] 0.8.3 `npx oxfmt --check` clean.
 - [ ] 0.8.4 PR opened, CI green, merged.
-- [ ] 0.8.5 Branch `chore/cluster-e-pr2-helper-signatures` (containing pre-flight commit `b323121b`: injuries field + buildPilotLookup) is folded into PR1.5 via cherry-pick or rebase.
+- [x] 0.8.5 Branch `chore/cluster-e-pr2-helper-signatures` (containing pre-flight commit `b323121b`: injuries field + buildPilotLookup) is folded into PR1.5 via cherry-pick or rebase.
 
 ---
 

--- a/openspec/changes/wire-iperson-hard-cutover/tasks.md
+++ b/openspec/changes/wire-iperson-hard-cutover/tasks.md
@@ -70,7 +70,7 @@
   - Acceptance: typecheck clean; type imports resolve.
   - QA: `npx tsc --noEmit --skipLibCheck`.
 
-- [ ] 1.2 Verify pre-join template helpers exist or author them.
+- [x] 1.2 Verify pre-join template helpers exist or author them.
   - Helper: `buildPilotLookup(vault: IPilot[]): Map<string, IPilot>` in `src/lib/campaign/utils/pilotLookup.ts` (new file).
   - Acceptance: helper covered by unit test; importable from `@/lib/campaign/utils/pilotLookup`.
 

--- a/src/__tests__/integration/phase3RoundTrip.test.ts
+++ b/src/__tests__/integration/phase3RoundTrip.test.ts
@@ -56,6 +56,7 @@ import {
   useCampaignStore,
 } from '@/stores/campaign/useCampaignStore';
 import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
 import { MissionStatus } from '@/types/campaign/enums/MissionStatus';
 import { PersonnelStatus } from '@/types/campaign/enums/PersonnelStatus';
 import { createContract } from '@/types/campaign/Mission';
@@ -98,6 +99,8 @@ function makePerson(overrides: Partial<IPerson> = {}): IPerson {
     campaignKills: 0,
     campaignMissions: 0,
     hireDate: new Date('3024-01-01'),
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rankIndex: 0,
   };
   const vault: IPilot = {
     id,

--- a/src/__tests__/integration/phase4CampaignRoundTrip.test.ts
+++ b/src/__tests__/integration/phase4CampaignRoundTrip.test.ts
@@ -69,6 +69,7 @@ import {
   useCampaignStore,
 } from '@/stores/campaign/useCampaignStore';
 import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
 import { MissionStatus } from '@/types/campaign/enums/MissionStatus';
 import { PersonnelStatus } from '@/types/campaign/enums/PersonnelStatus';
 import { createContract } from '@/types/campaign/Mission';
@@ -111,6 +112,8 @@ function makePerson(overrides: Partial<IPerson> = {}): IPerson {
     campaignKills: 0,
     campaignMissions: 0,
     hireDate: new Date('3024-01-01'),
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rankIndex: 0,
   };
   const vault: IPilot = {
     id,

--- a/src/__tests__/integration/pilotXpSpendFromCampaign.test.tsx
+++ b/src/__tests__/integration/pilotXpSpendFromCampaign.test.tsx
@@ -24,6 +24,7 @@ import {
 import React from 'react';
 
 import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
 import { ForcePosition, ForceStatus, ForceType } from '@/types/force';
 import { PilotStatus, PilotType, type IPilot } from '@/types/pilot';
 
@@ -176,6 +177,8 @@ beforeEach(() => {
         recoveryTime: 0,
         // Hard-cutover policy (PR2 cluster J): hireDate required.
         hireDate: new Date('2025-01-01T00:00:00Z'),
+        primaryRole: CampaignPersonnelRole.PILOT,
+        rankIndex: 0,
       },
     ],
     missions: [],

--- a/src/__tests__/integration/rosterEmploymentDerive.test.ts
+++ b/src/__tests__/integration/rosterEmploymentDerive.test.ts
@@ -19,6 +19,7 @@ import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore
 import { useCampaignStore } from '@/stores/campaign/useCampaignStore';
 import { usePilotStore } from '@/stores/usePilotStore';
 import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
 import {
   PilotStatus,
   PilotType,
@@ -73,6 +74,8 @@ function makeRosterEntry(
     campaignMissions: 0,
     // Hard-cutover policy (PR2 cluster J): hireDate is required.
     hireDate: new Date('2025-01-01T00:00:00Z'),
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rankIndex: 0,
   };
 }
 

--- a/src/components/gameplay/pages/campaigns/create/CreateCampaignPage.tsx
+++ b/src/components/gameplay/pages/campaigns/create/CreateCampaignPage.tsx
@@ -12,6 +12,7 @@ import { useCampaignStore } from '@/stores/campaign/useCampaignStore';
 import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces';
 import { CampaignPreset, ALL_PRESETS } from '@/types/campaign/CampaignPreset';
 import { CampaignType } from '@/types/campaign/CampaignType';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
 
 import type {
   PilotAssignments,
@@ -177,6 +178,8 @@ export default function CreateCampaignPage(): React.ReactElement {
             campaignMissions: 0,
             recoveryTime: 0,
             hireDate,
+            primaryRole: CampaignPersonnelRole.PILOT,
+            rankIndex: 0,
             assignedUnitId: getAssignedUnitIdForPilot(
               pilotAssignments,
               pilot.id,

--- a/src/lib/campaign/__tests__/dailyBattleAuditBuilder.test.ts
+++ b/src/lib/campaign/__tests__/dailyBattleAuditBuilder.test.ts
@@ -21,6 +21,7 @@ import { rosterEntryToPerson } from '@/lib/campaign/utils/rosterEntryToPerson';
 import { createDefaultCampaignOptions } from '@/types/campaign/Campaign';
 import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
 import { CampaignType } from '@/types/campaign/CampaignType';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
 import { MissionStatus } from '@/types/campaign/enums/MissionStatus';
 import { createContract } from '@/types/campaign/Mission';
 import { Money } from '@/types/campaign/Money';
@@ -70,6 +71,8 @@ function makePerson(
     campaignKills: 0,
     campaignMissions: 0,
     hireDate: new Date('3024-01-01'),
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rankIndex: 0,
   };
   const vault: IPilot = {
     id,

--- a/src/lib/campaign/processors/__tests__/vocationalTrainingProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/vocationalTrainingProcessor.test.ts
@@ -46,6 +46,8 @@ function createTestPerson(overrides: Partial<IPerson> = {}): IPerson {
     campaignKills: 3,
     campaignMissions: 5,
     hireDate: new Date('3000-01-01'),
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rankIndex: 0,
   };
   const vault: IPilot = {
     id,

--- a/src/lib/campaign/utils/__tests__/pilotLookup.test.ts
+++ b/src/lib/campaign/utils/__tests__/pilotLookup.test.ts
@@ -1,0 +1,99 @@
+/**
+ * pilotLookup helper — unit tests.
+ *
+ * Asserts the pre-join template helper used by every two-arg
+ * `(entry, pilot | null)` processor in the IPerson hard-cutover migration
+ * (Council #2, Cluster E). Builds Map<pilotId, IPilot> in linear time so
+ * helpers can resolve vault pilots by `entry.pilotId` without N² find().
+ *
+ * @spec openspec/specs/campaign-personnel-architecture/spec.md
+ */
+
+import {
+  PilotStatus,
+  PilotType,
+  type IPilot,
+} from '@/types/pilot/PilotInterfaces';
+
+import { buildPilotLookup } from '../pilotLookup';
+
+// =============================================================================
+// Fixture builder
+// =============================================================================
+
+function makeVaultPilot(overrides?: Partial<IPilot>): IPilot {
+  const now = new Date('2025-01-01T00:00:00Z').toISOString();
+  return {
+    id: 'pilot-vault-1',
+    name: 'Sarah Connor',
+    type: PilotType.Persistent,
+    status: PilotStatus.Active,
+    skills: { gunnery: 3, piloting: 4 },
+    wounds: 0,
+    abilities: [],
+    awards: [],
+    career: {
+      missionsCompleted: 0,
+      victories: 0,
+      defeats: 0,
+      draws: 0,
+      totalKills: 0,
+      killRecords: [],
+      missionHistory: [],
+      xp: 0,
+      totalXpEarned: 0,
+      rank: 'MechWarrior',
+    },
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('buildPilotLookup', () => {
+  it('returns an empty Map when vault is empty', () => {
+    const lookup = buildPilotLookup([]);
+    expect(lookup.size).toBe(0);
+  });
+
+  it('keys each pilot by their id', () => {
+    const a = makeVaultPilot({ id: 'pilot-a', name: 'Alpha' });
+    const b = makeVaultPilot({ id: 'pilot-b', name: 'Bravo' });
+    const c = makeVaultPilot({ id: 'pilot-c', name: 'Charlie' });
+    const lookup = buildPilotLookup([a, b, c]);
+
+    expect(lookup.size).toBe(3);
+    expect(lookup.get('pilot-a')).toBe(a);
+    expect(lookup.get('pilot-b')).toBe(b);
+    expect(lookup.get('pilot-c')).toBe(c);
+  });
+
+  it('returns undefined for unknown pilot ids (NPC contract: caller coerces to null)', () => {
+    const lookup = buildPilotLookup([makeVaultPilot()]);
+    expect(lookup.get('npc-roster-local-id')).toBeUndefined();
+  });
+
+  it('preserves pilot reference identity (no clone)', () => {
+    const original = makeVaultPilot();
+    const lookup = buildPilotLookup([original]);
+    expect(lookup.get(original.id)).toBe(original);
+  });
+
+  it('overwrites duplicate ids with the later occurrence (last write wins)', () => {
+    const first = makeVaultPilot({ id: 'dup', name: 'First' });
+    const second = makeVaultPilot({ id: 'dup', name: 'Second' });
+    const lookup = buildPilotLookup([first, second]);
+    expect(lookup.size).toBe(1);
+    expect(lookup.get('dup')).toBe(second);
+  });
+
+  it('accepts a readonly array (type contract)', () => {
+    const vault: readonly IPilot[] = [makeVaultPilot()];
+    const lookup = buildPilotLookup(vault);
+    expect(lookup.size).toBe(1);
+  });
+});

--- a/src/lib/campaign/utils/__tests__/rosterEntryToPerson.test.ts
+++ b/src/lib/campaign/utils/__tests__/rosterEntryToPerson.test.ts
@@ -74,6 +74,9 @@ function makeRosterEntry(
     // Hard-cutover policy (PR2 cluster J): hireDate required on
     // every roster entry — fixtures must provide a deterministic value.
     hireDate: new Date('2025-06-15T00:00:00Z'),
+    // PR1.5 Tier 1 required fields (live bug fixes)
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rankIndex: 0,
     ...overrides,
   };
 }
@@ -106,7 +109,7 @@ describe('rosterEntryToPerson', () => {
       expect(person.totalKills).toBe(3);
       expect(person.missionsCompleted).toBe(4);
 
-      // Always defaults to PILOT role until follow-up role-expansion change
+      // PR1.5: primaryRole forwarded from roster entry (was hardcoded PILOT)
       expect(person.primaryRole).toBe(CampaignPersonnelRole.PILOT);
     });
 
@@ -262,6 +265,87 @@ describe('rosterEntryToPerson', () => {
       expect(person.xp).toBe(25);
       // person.totalXpEarned tracks vault lifetime (cross-campaign aggregate).
       expect(person.totalXpEarned).toBe(999);
+    });
+  });
+
+  // ===========================================================================
+  // PR1.5 forward paths — verifies all 6 new fields forwarded from roster entry
+  // (Council #4 Tier 1 live bug fixes + Tier 2 additive fields)
+  // ===========================================================================
+
+  describe('PR1.5 forward paths', () => {
+    it('forwards non-PILOT primaryRole (Tier 1 live bug fix)', () => {
+      // Live bug: bridge hardcoded PILOT, making DOCTOR entries invisible
+      // to getBestAvailableDoctor and salary-role categorization.
+      const entry = makeRosterEntry({
+        primaryRole: CampaignPersonnelRole.DOCTOR,
+      });
+      const person = rosterEntryToPerson(entry, makeVaultPilot());
+      expect(person.primaryRole).toBe(CampaignPersonnelRole.DOCTOR);
+    });
+
+    it('forwards non-zero rankIndex (Tier 1 live bug fix)', () => {
+      // Live bug: bridge hardcoded 0, blocking all promotions because
+      // rankService.ts:208 compares newRankIndex <= currentRankIndex.
+      const entry = makeRosterEntry({ rankIndex: 3 });
+      const person = rosterEntryToPerson(entry, makeVaultPilot());
+      expect(person.rankIndex).toBe(3);
+    });
+
+    it('forwards traits with glassJaw / slowLearner flags (Tier 1 live bug fix)', () => {
+      // Live bug: bridge omitted traits entirely, so aging.ts and
+      // vocationalTrainingProcessor.ts silently discarded all trait flags
+      // on every processing pass.
+      const entry = makeRosterEntry({
+        traits: { glassJaw: true, slowLearner: true },
+      });
+      const person = rosterEntryToPerson(entry, makeVaultPilot());
+      expect(person.traits).toEqual({ glassJaw: true, slowLearner: true });
+    });
+
+    it('defaults traits to empty object when roster entry has no traits', () => {
+      // No traits set → bridge yields {} so helpers don't crash on
+      // undefined?.glassJaw access.
+      const entry = makeRosterEntry({ traits: undefined });
+      const person = rosterEntryToPerson(entry, makeVaultPilot());
+      expect(person.traits).toEqual({});
+    });
+
+    it('forwards lastPromotionDate (Tier 1 live bug fix)', () => {
+      // Live bug: bridge omitted this field, so isRecentlyPromoted always
+      // returned false and the promotion-recency turnover modifier never fired.
+      const promoDate = new Date('2025-03-10T00:00:00Z');
+      const entry = makeRosterEntry({ lastPromotionDate: promoDate });
+      const person = rosterEntryToPerson(entry, makeVaultPilot());
+      expect(person.lastPromotionDate).toEqual(promoDate);
+    });
+
+    it('lastPromotionDate is undefined when not set on roster entry', () => {
+      const entry = makeRosterEntry({ lastPromotionDate: undefined });
+      const person = rosterEntryToPerson(entry, makeVaultPilot());
+      expect(person.lastPromotionDate).toBeUndefined();
+    });
+
+    it('forwards isFounder flag (Tier 2 additive)', () => {
+      const entry = makeRosterEntry({ isFounder: true });
+      const person = rosterEntryToPerson(entry, makeVaultPilot());
+      expect(person.isFounder).toBe(true);
+    });
+
+    it('forwards isCommander flag (Tier 2 additive)', () => {
+      const entry = makeRosterEntry({ isCommander: true });
+      const person = rosterEntryToPerson(entry, makeVaultPilot());
+      expect(person.isCommander).toBe(true);
+    });
+
+    it('isFounder and isCommander are undefined when not set', () => {
+      const entry = makeRosterEntry({
+        isFounder: undefined,
+        isCommander: undefined,
+      });
+      const person = rosterEntryToPerson(entry, makeVaultPilot());
+      expect(person.isFounder).toBeUndefined();
+      expect(person.isCommander).toBeUndefined();
     });
   });
 });

--- a/src/lib/campaign/utils/pilotLookup.ts
+++ b/src/lib/campaign/utils/pilotLookup.ts
@@ -1,0 +1,55 @@
+/**
+ * Pre-join template helper — vault pilot lookup map.
+ *
+ * Used by processors that iterate the campaign roster and need each
+ * iteration's vault `IPilot` resolved by `pilotId`. Built ONCE per pipeline
+ * run and passed to per-entry helpers via `pilotLookup.get(entry.pilotId) ?? null`,
+ * avoiding the N² `vault.find(p => p.id === entry.pilotId)` that the previous
+ * `IPerson` god-type pattern paid per call.
+ *
+ * Mandated by Council #2 (Cluster E IPerson hard-cutover, decision
+ * 2026-05-02). The two-arg helper signature `(entry, pilot | null)` SHALL NOT
+ * internally call `vault.find(...)` — helpers receive pre-resolved pilots.
+ *
+ * @spec openspec/specs/campaign-personnel-architecture/spec.md — Pre-join template requirement
+ * @spec openspec/changes/wire-iperson-hard-cutover/design.md — Pre-join template decision
+ */
+
+import type { IPilot } from '@/types/pilot/PilotInterfaces';
+
+// =============================================================================
+// Pre-join helper
+// =============================================================================
+
+/**
+ * Build a `Map<pilotId, IPilot>` lookup over the vault pilot list.
+ *
+ * Linear in `vault.length`. Build once per pipeline run; reuse for every
+ * per-entry helper invocation. NPC roster entries (whose `pilotId` is a
+ * roster-local identifier with no vault counterpart) resolve to `undefined`
+ * via `lookup.get(...)`; callers SHALL coerce to `null` before passing the
+ * second argument to two-arg helpers.
+ *
+ * @example
+ * ```ts
+ * const pilotsByPilotId = buildPilotLookup(usePilotStore.getState().pilots);
+ * for (const entry of useCampaignRosterStore.getState().pilots) {
+ *   const pilot = pilotsByPilotId.get(entry.pilotId) ?? null;
+ *   helper(entry, pilot);
+ * }
+ * ```
+ *
+ * @param vault - The vault pilot list (typically `usePilotStore.getState().pilots`).
+ * @returns A `Map` keyed by `IPilot.id`. Empty when `vault` is empty.
+ */
+export function buildPilotLookup(
+  vault: readonly IPilot[],
+): Map<string, IPilot> {
+  // Direct iteration is cheaper than .map(([k,v]) => …) ↦ new Map(...) for
+  // large vaults because we avoid the intermediate tuple array allocation.
+  const lookup = new Map<string, IPilot>();
+  for (const pilot of vault) {
+    lookup.set(pilot.id, pilot);
+  }
+  return lookup;
+}

--- a/src/lib/campaign/utils/rosterEntryToPerson.ts
+++ b/src/lib/campaign/utils/rosterEntryToPerson.ts
@@ -24,7 +24,6 @@ import type { IAttributes } from '@/types/campaign/skills/IAttributes';
 import type { IPilot, IPilotStatblock } from '@/types/pilot/PilotInterfaces';
 
 import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
-import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
 import { PersonnelStatus } from '@/types/campaign/enums/PersonnelStatus';
 
 // =============================================================================
@@ -159,18 +158,24 @@ export function rosterEntryToPerson(
     givenName: firstName,
     surname: lastName,
 
-    // Status / role
+    // Status / role — forwarded from roster entry (PR1.5 live bug fix: was
+    // hardcoded CampaignPersonnelRole.PILOT, breaking DOCTOR/TECH categorization)
     status: mapStatus(rosterEntry.status),
-    primaryRole: CampaignPersonnelRole.PILOT,
+    primaryRole: rosterEntry.primaryRole,
 
     // Career
     rank,
-    rankIndex: 0,
+    // Forwarded from roster entry (PR1.5 live bug fix: was hardcoded 0,
+    // blocking all promotions in rankService.ts:208)
+    rankIndex: rosterEntry.rankIndex,
     recruitmentDate,
     missionsCompleted: rosterEntry.campaignMissions,
     totalKills: rosterEntry.campaignKills,
     awards: awardIds,
     departureReason: rosterEntry.departureReason,
+    // Forwarded from roster entry (PR1.5 live bug fix: was omitted, so
+    // rankService.isRecentlyPromoted always returned false)
+    lastPromotionDate: rosterEntry.lastPromotionDate,
 
     // Experience
     xp: rosterEntry.xp,
@@ -190,7 +195,14 @@ export function rosterEntryToPerson(
     // Assignment
     unitId: rosterEntry.assignedUnitId,
 
-    // Traits + abilities
+    // Traits — forwarded from roster entry (PR1.5 live bug fix: was omitted,
+    // causing aging.ts + vocationalTrainingProcessor.ts to silently discard
+    // glassJaw / slowLearner / vocationalXPTimer flags on every pass)
+    traits: rosterEntry.traits ?? {},
+
+    // Abilities + unit flags
     specialAbilities,
+    isFounder: rosterEntry.isFounder,
+    isCommander: rosterEntry.isCommander,
   };
 }

--- a/src/lib/campaign/utils/rosterEntryToPerson.ts
+++ b/src/lib/campaign/utils/rosterEntryToPerson.ts
@@ -179,7 +179,7 @@ export function rosterEntryToPerson(
 
     // Combat state
     hits: rosterEntry.wounds,
-    injuries: [],
+    injuries: rosterEntry.injuries ?? [],
     daysToWaitForHealing: rosterEntry.recoveryTime,
 
     // Skills + attributes (vault pilots don't carry IAttributes; default)

--- a/src/lib/finances/__tests__/taxService.test.ts
+++ b/src/lib/finances/__tests__/taxService.test.ts
@@ -45,6 +45,8 @@ function makePerson(overrides: Partial<IPerson> = {}): IPerson {
     campaignKills: 0,
     campaignMissions: 0,
     hireDate: new Date('3025-01-01'),
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rankIndex: 0,
   };
   const vault: IPilot = {
     id,

--- a/src/stores/campaign/__tests__/useCampaignStore.test.ts
+++ b/src/stores/campaign/__tests__/useCampaignStore.test.ts
@@ -15,6 +15,7 @@ import {
   FormationLevel,
   MissionStatus,
 } from '@/types/campaign/enums';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
 import { IForce } from '@/types/campaign/Force';
 import { IPerson } from '@/types/campaign/Person';
 import { IPilot, PilotStatus, PilotType } from '@/types/pilot/PilotInterfaces';
@@ -56,6 +57,8 @@ const createTestPerson = (overrides?: Partial<IPerson>): IPerson => {
     campaignKills: 0,
     campaignMissions: 0,
     hireDate: new Date(),
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rankIndex: 0,
   };
   const vault: IPilot = {
     id,

--- a/src/stores/campaign/useCampaignRosterStore.ts
+++ b/src/stores/campaign/useCampaignRosterStore.ts
@@ -22,7 +22,11 @@
  */
 
 import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware';
+import {
+  persist,
+  createJSONStorage,
+  type StorageValue,
+} from 'zustand/middleware';
 
 import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
 import type {
@@ -31,6 +35,7 @@ import type {
 } from '@/types/campaign/UnitCombatState';
 
 import { clientSafeStorage } from '@/stores/utils/clientSafeStorage';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
 import {
   deriveRosterReadiness,
   type IRosterUnitProjection,
@@ -575,6 +580,25 @@ export const useCampaignRosterStore = create<CampaignRosterStore>()(
     {
       name: 'campaign-roster-store',
       storage: createJSONStorage(() => clientSafeStorage),
+      // Version 2 — Council #4 PR1.5 added required `primaryRole` and
+      // `rankIndex` fields. Existing v0/v1 entries get defaulted on load:
+      // primaryRole=PILOT (the historical implicit default) and rankIndex=0
+      // (matches the old hardcoded bridge value, so behavior is preserved
+      // until the user sets a real rank).
+      version: 2,
+      migrate: (persistedState, version) => {
+        if (version >= 2 || !persistedState) return persistedState;
+        const state = persistedState as Partial<CampaignRosterState>;
+        const upgradedPilots = (state.pilots ?? []).map((entry) => ({
+          ...entry,
+          primaryRole: entry.primaryRole ?? CampaignPersonnelRole.PILOT,
+          rankIndex: entry.rankIndex ?? 0,
+        })) as ICampaignRosterEntry[];
+        return {
+          ...state,
+          pilots: upgradedPilots,
+        } as StorageValue<CampaignRosterStore>['state'];
+      },
     },
   ),
 );

--- a/src/types/campaign/CampaignRosterEntry.ts
+++ b/src/types/campaign/CampaignRosterEntry.ts
@@ -21,8 +21,10 @@
 import type { IPilotStatblock } from '@/types/pilot/PilotInterfaces';
 
 import type { CampaignPilotStatus } from './CampaignInterfaces.types';
+import type { CampaignPersonnelRole } from './enums/CampaignPersonnelRole';
 import type { Money } from './Money';
 import type { IInjury } from './Person';
+import type { IPersonTraits } from './progression/progressionTypes';
 
 // =============================================================================
 // Roster Entry Interface
@@ -150,4 +152,79 @@ export interface ICampaignRosterEntry {
    * @spec openspec/specs/campaign-personnel-architecture/spec.md
    */
   readonly injuries?: readonly IInjury[];
+
+  // ===========================================================================
+  // Personnel role + rank (PR1.5 — Tier 1 live bug fixes, Council #4)
+  // ===========================================================================
+
+  /**
+   * Primary role in the unit. Required — every entry must declare its role
+   * so downstream helpers (doctorCapacity, salaryService) can filter and
+   * categorize without synthesizing defaults.
+   *
+   * Live bug: bridge previously hardcoded `PILOT`, making DOCTOR/TECH entries
+   * invisible to `getBestAvailableDoctor` and salary-role categorization.
+   *
+   * Backward compat: `useCampaignRosterStore` persist migration defaults
+   * existing entries without this field to `CampaignPersonnelRole.PILOT`.
+   *
+   * @spec openspec/specs/campaign-personnel-architecture/spec.md
+   */
+  readonly primaryRole: CampaignPersonnelRole;
+
+  /**
+   * Numeric rank index (0-based position in the rank table).
+   * Required — every entry must declare a rank index so the promotion gate
+   * in `rankService` can compare `newRankIndex <= currentRankIndex` correctly.
+   *
+   * Live bug: bridge previously hardcoded 0, blocking all promotions because
+   * `rankService.ts:208` compares `newRankIndex <= currentRankIndex` and 0
+   * is always the floor.
+   *
+   * Backward compat: `useCampaignRosterStore` persist migration defaults
+   * existing entries without this field to `0`.
+   *
+   * @spec openspec/specs/campaign-personnel-architecture/spec.md
+   */
+  readonly rankIndex: number;
+
+  /**
+   * Trait flags that modify skill costs and aging/progression mechanics.
+   *
+   * Optional. `aging.ts` and `vocationalTrainingProcessor.ts` read AND write
+   * `traits.glassJaw`, `traits.slowLearner`, `traits.vocationalXPTimer`.
+   * Without this field on the roster entry the bridge omitted traits entirely,
+   * causing every write to discard prior flags — a silent per-pass data loss.
+   *
+   * Bridge forwards as `traits: entry.traits ?? {}`.
+   *
+   * @spec openspec/specs/campaign-personnel-architecture/spec.md
+   */
+  readonly traits?: IPersonTraits;
+
+  /**
+   * Date of last promotion. Optional.
+   *
+   * Live bug: bridge omitted this field, so `rankService.isRecentlyPromoted`
+   * always returned `false` and the promotion-recency turnover modifier never
+   * fired.
+   */
+  readonly lastPromotionDate?: Date;
+
+  // ===========================================================================
+  // Unit flags (PR1.5 — Tier 2 additive, no production write path today)
+  // ===========================================================================
+
+  /**
+   * Whether this person is a founder of the unit (entitles +1 share).
+   * Additive optional — no migration risk; existing entries without it
+   * are treated as non-founders.
+   */
+  readonly isFounder?: boolean;
+
+  /**
+   * Whether this person is the unit commander.
+   * Additive optional — existing entries without it treated as non-commander.
+   */
+  readonly isCommander?: boolean;
 }

--- a/src/types/campaign/CampaignRosterEntry.ts
+++ b/src/types/campaign/CampaignRosterEntry.ts
@@ -22,6 +22,7 @@ import type { IPilotStatblock } from '@/types/pilot/PilotInterfaces';
 
 import type { CampaignPilotStatus } from './CampaignInterfaces.types';
 import type { Money } from './Money';
+import type { IInjury } from './Person';
 
 // =============================================================================
 // Roster Entry Interface
@@ -135,4 +136,18 @@ export interface ICampaignRosterEntry {
    * Used by the turnover processor for narrative + ledger entries.
    */
   readonly departureReason?: string;
+
+  /**
+   * Active injuries for advanced medical tracking.
+   *
+   * Optional + readonly. Defaults to `[]` (no injuries) when unset, matching
+   * the legacy `IPerson.injuries` semantics so the bridge synthesis and the
+   * direct two-arg helpers behave identically. Wired in PR2 of
+   * `wire-iperson-hard-cutover` (Council #2 open question #1) so medical
+   * helpers can read injuries from the roster entry without going through
+   * the `rosterEntryToPerson` shim once PR4 deletes the bridge.
+   *
+   * @spec openspec/specs/campaign-personnel-architecture/spec.md
+   */
+  readonly injuries?: readonly IInjury[];
 }

--- a/src/types/campaign/__tests__/CampaignInterfaces.test.ts
+++ b/src/types/campaign/__tests__/CampaignInterfaces.test.ts
@@ -24,6 +24,7 @@ import {
   isCampaign,
   isCampaignMission,
 } from '../CampaignInterfaces';
+import { CampaignPersonnelRole } from '../enums/CampaignPersonnelRole';
 
 // =============================================================================
 // Test Data Factories
@@ -48,6 +49,8 @@ function createTestPilot(
     recoveryTime: 0,
     // Hard-cutover policy (PR2 cluster J): hireDate required.
     hireDate: new Date('2025-01-01T00:00:00Z'),
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rankIndex: 0,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

PR1.5 of the `wire-iperson-hard-cutover` OpenSpec change (Council #4 insertion before PR2).

Fixes 4 live bugs in `rosterEntryToPerson` bridge by extending `ICampaignRosterEntry` with the fields the bridge was synthesizing as hardcoded defaults.

## Live bugs fixed

| Field | Bug | Fix |
|---|---|---|
| `primaryRole` | Bridge hardcoded `PILOT` — DOCTOR/TECH entries invisible to role-aware helpers | Forward `entry.primaryRole` |
| `rankIndex` | Bridge hardcoded `0` — promotions beyond rank 0 were lost on round-trip | Forward `entry.rankIndex` |
| `traits` | Bridge omitted — per-pass trait accumulation silently lost | Forward `entry.traits ?? {}` |
| `lastPromotionDate` | Bridge omitted — `isRecentlyPromoted` always returned false | Forward `entry.lastPromotionDate` |

## Additional Tier 2 fields (additive, no migration risk)
- `isFounder?: boolean`
- `isCommander?: boolean`

## Store migration
`useCampaignRosterStore` persist version bumped to `2`; migrate callback defaults legacy entries to `primaryRole: PILOT, rankIndex: 0` for backward compatibility.

## Verification
- `npx tsc --noEmit --skipLibCheck` — exit 0
- `npx oxfmt --check src/` — all 3093 files clean
- Regression suites: salaryService (DOCTOR/TECH/SOLDIER categorization), doctorCapacity, rankService, aging + vocationalTraining — all pass
- Full jest suite: 23217/23261 tests pass (44 skipped = quarantined flakes)
- Next.js build: compiled successfully

## OpenSpec tasks
Sections 0.1–0.8.3 and 0.8.5 marked `[x]` in `openspec/changes/wire-iperson-hard-cutover/tasks.md`.
Task 0.8.4 (PR merged) to be flipped post-merge.

## Sequence
PR1 (shipped #486) → **PR1.5 (this PR)** → PR2 → PR3 → PR4 → PR5