### PR TITLE
chore: prevent responsive constant drift

### DIFF
--- a/openspec/changes/consolidate-responsive-constants/.openspec.yaml
+++ b/openspec/changes/consolidate-responsive-constants/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-02

--- a/openspec/changes/consolidate-responsive-constants/design.md
+++ b/openspec/changes/consolidate-responsive-constants/design.md
@@ -1,0 +1,114 @@
+## Context
+
+The MekStation responsive surface has grown organically and now defines breakpoints and the WCAG 2.5.5 minimum touch target size in three places each. [src/constants/layout.ts](src/constants/layout.ts) already declares itself "Single source of truth for responsive design values" in its file-header comment (line 5), and exports `BREAKPOINTS` (line 56, keys `SM/MD/LG/XL/XXL`) and `TOUCH.MIN_TARGET_SIZE` (line 75). However, [src/utils/responsive.ts:3](src/utils/responsive.ts) defines its own `BREAKPOINTS` (lowercase keys `sm/md/lg/xl/2xl` matching Tailwind defaults), [src/hooks/useDeviceType.ts:6](src/hooks/useDeviceType.ts) defines a private `BREAKPOINTS` with two-key shape (`mobile/tablet`), and [src/hooks/useTouchTarget.ts:28](src/hooks/useTouchTarget.ts) hardcodes `DEFAULT_MIN_SIZE = 44`.
+
+Numeric values agree today but key naming has already drifted (uppercase vs lowercase vs domain-keyed). Any future edit to a breakpoint must touch all three files in lockstep, and there is no compile-time enforcement.
+
+This change closes that drift without modifying any consumer code or any numeric value.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One canonical numeric definition of `BREAKPOINTS` and `MIN_TOUCH_TARGET` per repo (in `layout.ts`).
+- Zero changes to existing public API surfaces — all current import paths and named exports keep working.
+- Zero changes to any test (existing tests must pass unmodified).
+- Add an invariant test that fails if the constants are re-fragmented.
+
+**Non-Goals:**
+
+- Hook canonicalization (`useIsMobile` family vs `useDeviceType`) — separate change.
+- Codemod of consumers to import directly from `layout.ts` — re-exports keep this change minimal; direct-import migration is a follow-up.
+- Capability-first CSS adoption (`pointer:`, `@container`, `svh/dvh/lvh`).
+- Resolving the four orphan touch hooks (`useLongPress`, `useSwipeGestures`, `useVirtualKeyboard`, `useTouchTarget` orphan CSS class).
+- Renaming `BREAKPOINTS` keys (`SM` vs `sm`) — preserved for backward compat; the project convention disagreement is not blocking and resolving it would force consumer churn.
+
+## Decisions
+
+### D1. Canonical module is `src/constants/layout.ts`
+
+**Rationale:** It already declares itself as the SoT in its header comment, already organizes related constants under namespaces (`SIDEBAR`, `Z_INDEX`, `TOUCH`, `ANIMATION`, `HEADER`), and uses the project's UPPER_SNAKE_CASE constant convention. The other two files (`responsive.ts`, `useDeviceType.ts`) have their definitions inline next to hook implementations, which is exactly the pattern that produced the drift.
+
+**Alternative considered:** Make `responsive.ts` canonical and have `layout.ts` re-export. Rejected because `responsive.ts` mixes constants with React hooks (`useMediaQuery`, `useIsMobile`, etc.) — that's a worse home for shared constants than a pure constants module.
+
+### D2. Re-export, don't codemod
+
+`responsive.ts` and `useDeviceType.ts` build their existing exports from `layout.ts` values. Existing import paths keep working unchanged.
+
+```typescript
+// src/utils/responsive.ts (new)
+import { BREAKPOINTS as LAYOUT_BREAKPOINTS, TOUCH } from '@/constants/layout';
+
+/**
+ * Tailwind-keyed breakpoints. Re-exported from `@/constants/layout` BREAKPOINTS.
+ * @see src/constants/layout.ts for the canonical definition.
+ */
+export const BREAKPOINTS = {
+  sm: LAYOUT_BREAKPOINTS.SM,
+  md: LAYOUT_BREAKPOINTS.MD,
+  lg: LAYOUT_BREAKPOINTS.LG,
+  xl: LAYOUT_BREAKPOINTS.XL,
+  '2xl': LAYOUT_BREAKPOINTS.XXL,
+} as const;
+
+/**
+ * Re-exported from `@/constants/layout` TOUCH.MIN_TARGET_SIZE.
+ * @see src/constants/layout.ts for the canonical definition.
+ */
+export const MIN_TOUCH_TARGET = TOUCH.MIN_TARGET_SIZE;
+```
+
+```typescript
+// src/hooks/useDeviceType.ts (new)
+import { BREAKPOINTS as LAYOUT_BREAKPOINTS } from '@/constants/layout';
+
+const BREAKPOINTS = {
+  mobile: LAYOUT_BREAKPOINTS.MD,
+  tablet: LAYOUT_BREAKPOINTS.LG,
+} as const;
+```
+
+```typescript
+// src/hooks/useTouchTarget.ts (new)
+import { TOUCH } from '@/constants/layout';
+
+const DEFAULT_MIN_SIZE = TOUCH.MIN_TARGET_SIZE;
+```
+
+**Alternative considered:** Codemod every consumer to import directly from `layout.ts`. Rejected for this change because (a) it expands blast radius beyond what's necessary to close the SoT gap, (b) the lowercase-keyed `BREAKPOINTS` shape from `responsive.ts` is more ergonomic for Tailwind-aligned code than `layout.ts` `SM/MD/LG`, so consumers should keep using whichever shape suits them. A future change can decide whether to deprecate one shape entirely.
+
+### D3. Invariant test prevents re-fragmentation
+
+Add `src/__tests__/constants/responsive-constants-sot.test.ts` that:
+
+1. Imports `BREAKPOINTS` and `MIN_TOUCH_TARGET` (and `TOUCH.MIN_TARGET_SIZE`) from all four files.
+2. Asserts the numeric values are equal across all definitions (`responsive.ts.BREAKPOINTS.md === layout.ts.BREAKPOINTS.MD`, etc.).
+3. Asserts the canonical values match the spec-cited 44px and `640/768/1024/1280/1536` ladder.
+
+The test is mechanical and serves as a tripwire: any future PR that re-fragments the constants by adding a new private definition will immediately diverge from `layout.ts` and break this test.
+
+**Alternative considered:** Lint rule. Rejected because writing a custom ESLint rule that detects "module-local BREAKPOINTS constant" requires more infrastructure than the test, and the test runs in CI today.
+
+### D4. JSDoc `@see` markers, not `@deprecated`
+
+The re-exports get an `@see src/constants/layout.ts` JSDoc pointer, not `@deprecated`. Reason: `responsive.ts` `BREAKPOINTS` (lowercase keys) and `useDeviceType` `BREAKPOINTS` (mobile/tablet keys) are *different shapes* of the same data, both valid for their use sites. Marking them deprecated would be misleading — they are not going away, only their numeric values are derived. `@deprecated` would be right if/when D2's "future change" decides to consolidate shapes.
+
+## Risks / Trade-offs
+
+- **Risk:** A consumer that imports `BREAKPOINTS` from `responsive.ts` and treats it as a tuple type (e.g., `keyof typeof BREAKPOINTS`) might be sensitive to the order or named keys. → **Mitigation:** Re-export preserves the exact shape and key order. The new file is byte-similar minus the literal numbers, which are now imports.
+- **Risk:** TypeScript narrowing might lose `as const` literal-type behavior if the re-export pattern is wrong. → **Mitigation:** Keep `as const` on the re-exported object; the underlying literal types from `layout.ts` are already `as const` and preserve through indexed access.
+- **Risk:** Circular import (`layout.ts` → `responsive.ts` → ...) since both might be imported by hooks. → **Mitigation:** `layout.ts` has zero imports today (verified by Read); the new direction is one-way (`responsive.ts` and hooks → `layout.ts`). No cycle.
+- **Trade-off:** Three named shapes still exist for `BREAKPOINTS` (uppercase / lowercase / mobile-tablet). This change does not unify shapes, only values. Acceptable: a single SoT for *values* closes 100% of the drift risk; shape convergence is a separate readability debate worth its own change.
+
+## Migration Plan
+
+1. Add the invariant test first — it must fail before the refactor (proves it's catching real drift) and pass after.
+2. Refactor `responsive.ts` to re-export from `layout.ts`.
+3. Refactor `useDeviceType.ts` to derive private `BREAKPOINTS` from `layout.ts`.
+4. Refactor `useTouchTarget.ts` to derive `DEFAULT_MIN_SIZE` from `layout.ts`.
+5. Run full test suite — must remain at 22477/22477 (or whatever the current baseline is at branch time).
+6. No rollback needed: pure refactor, no behavior change.
+
+## Open Questions
+
+None — all four file changes are mechanical and the invariant test is straightforward. If the user later decides to unify `BREAKPOINTS` shapes (e.g., remove the lowercase variant), that is a separate change that this one explicitly defers.

--- a/openspec/changes/consolidate-responsive-constants/proposal.md
+++ b/openspec/changes/consolidate-responsive-constants/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+Three independent definitions of `BREAKPOINTS` and three independent definitions of `MIN_TOUCH_TARGET = 44` exist across `src/utils/responsive.ts`, `src/constants/layout.ts`, and `src/hooks/useDeviceType.ts` / `src/hooks/useTouchTarget.ts`. The numeric values agree today but key naming has already drifted (`sm/md/lg` vs `SM/MD/LG` vs `mobile/tablet`), and any future change to a breakpoint or the touch-target constant requires editing three files in lockstep. An OMO Council audit on 2026-05-02 surfaced this as the highest-leverage / lowest-risk fragmentation in the responsive surface, and the existing `mobile-interaction-patterns` spec already names the canonical values — the implementation just doesn't have a single source of truth.
+
+## What Changes
+
+- Designate `src/constants/layout.ts` as the canonical module for `BREAKPOINTS` and `MIN_TOUCH_TARGET`.
+- Convert `src/utils/responsive.ts` `BREAKPOINTS` and `MIN_TOUCH_TARGET` to re-exports of the values defined in `layout.ts` (preserving existing import paths and export names — no consumer changes required).
+- Convert `src/hooks/useDeviceType.ts` private `BREAKPOINTS` to derive its `mobile`/`tablet` thresholds from `layout.ts` `BREAKPOINTS.MD` / `BREAKPOINTS.LG`.
+- Convert `src/hooks/useTouchTarget.ts` private `DEFAULT_MIN_SIZE` to import from `layout.ts` `TOUCH.MIN_TARGET_SIZE`.
+- Add JSDoc `@deprecated`-style hints on the re-exports pointing to `layout.ts` as canonical, so new code is steered to the canonical import.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `mobile-interaction-patterns`: add a "Single Source of Truth for Responsive Constants" requirement under the existing Responsive Breakpoints requirement. Numeric values do not change; the requirement codifies that BREAKPOINTS and MIN_TOUCH_TARGET have exactly one canonical definition module.
+
+## Non-Goals
+
+- Hook canonicalization (`useIsMobile` family vs `useDeviceType`). Tracked separately.
+- Wiring orphan hooks (`useLongPress`, `useSwipeGestures`, `useVirtualKeyboard`) into UI surfaces. Tracked separately.
+- Capability-first CSS adoption (`pointer:`, `@container`, `svh/dvh/lvh`, `@tailwindcss/container-queries` plugin). Tracked separately.
+- `BottomNavBar.tsx` `min-h-[44px]` → `min-h-touch` token migration. Tracked separately.
+- Codemod of consumers to import `BREAKPOINTS` / `MIN_TOUCH_TARGET` directly from `layout.ts`. Re-exports keep this change minimal; direct-import migration is a follow-up.
+
+## Impact
+
+**Code:**
+- `src/constants/layout.ts` — add explicit `BREAKPOINTS` numeric source (already exists at line 56), add documentation comment marking it canonical.
+- `src/utils/responsive.ts` — `BREAKPOINTS` and `MIN_TOUCH_TARGET` become re-exports.
+- `src/hooks/useDeviceType.ts` — private `BREAKPOINTS` removed; `useDeviceType` reads from `layout.ts`.
+- `src/hooks/useTouchTarget.ts` — `DEFAULT_MIN_SIZE` removed; reads from `layout.ts`.
+
+**Tests:**
+- [src/__tests__/responsive.test.tsx](src/__tests__/responsive.test.tsx) — must continue to pass without modification (numeric values unchanged).
+- [src/__tests__/hooks/useTouchTarget.test.ts](src/__tests__/hooks/useTouchTarget.test.ts) — must continue to pass (default min size unchanged).
+- Add a new lightweight invariant test asserting that `BREAKPOINTS` and `MIN_TOUCH_TARGET` are exported from exactly one module (`layout.ts`).
+
+**APIs / Dependencies:**
+- No external API changes.
+- No new dependencies.
+- Public hook API (`useIsMobile`, `useIsTablet`, `useIsDesktop`, `useDeviceType`, `useTouchTarget`) unchanged.
+
+**Risk:**
+- Very low. No calculation code changes; no consumer-facing import path changes (re-exports preserve compatibility).
+- BV parity unaffected (no battle-value code touched).
+- Test baseline 22477/22477 must remain green.

--- a/openspec/changes/consolidate-responsive-constants/specs/mobile-interaction-patterns/spec.md
+++ b/openspec/changes/consolidate-responsive-constants/specs/mobile-interaction-patterns/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Single Source of Truth for Responsive Constants
+
+The system SHALL define `BREAKPOINTS` and `MIN_TOUCH_TARGET` numeric values in exactly one canonical module (`src/constants/layout.ts`). All other modules that expose breakpoint or touch-target constants under different shapes (e.g., Tailwind-keyed lowercase, mobile/tablet domain keys) SHALL derive their values from the canonical module via import or re-export.
+
+#### Scenario: Canonical module is the only place numeric values are written
+
+- **WHEN** any source file under `src/` declares a `BREAKPOINTS` constant or a `MIN_TOUCH_TARGET` / `MIN_TARGET_SIZE` / `DEFAULT_MIN_SIZE` constant
+- **THEN** the constant SHALL either be defined in `src/constants/layout.ts`, OR derive its numeric value(s) by importing from `src/constants/layout.ts`
+- **AND** no source file SHALL hardcode the numeric values 640, 768, 1024, 1280, 1536 (breakpoint values) or 44 (touch target value) as a constant declaration outside `src/constants/layout.ts`
+
+#### Scenario: Re-exported breakpoints preserve numeric equivalence
+
+- **WHEN** a module re-exports `BREAKPOINTS` under a different key shape (e.g., Tailwind-keyed `sm/md/lg/xl/2xl` or domain-keyed `mobile/tablet`)
+- **THEN** the re-exported numeric values SHALL be byte-equivalent to the canonical `src/constants/layout.ts` `BREAKPOINTS.SM/MD/LG/XL/XXL` values
+- **AND** the re-export SHALL include a JSDoc `@see src/constants/layout.ts` pointer marking the canonical source
+
+#### Scenario: Touch target minimum is derived from canonical module
+
+- **WHEN** a hook or utility uses the WCAG 2.5.5 minimum touch target size (44px)
+- **THEN** the value SHALL be derived from `src/constants/layout.ts` `TOUCH.MIN_TARGET_SIZE`
+- **AND** the value SHALL NOT be hardcoded in the hook or utility module
+
+#### Scenario: Invariant test prevents re-fragmentation
+
+- **WHEN** the test suite runs (`npm test`)
+- **THEN** an invariant test SHALL assert that `BREAKPOINTS` numeric values are equal across all current re-export sites (`src/utils/responsive.ts`, `src/hooks/useDeviceType.ts` private constant, `src/constants/layout.ts`)
+- **AND** the test SHALL assert that `MIN_TOUCH_TARGET` numeric values are equal across all current sites (`src/utils/responsive.ts`, `src/hooks/useTouchTarget.ts` private constant, `src/constants/layout.ts` `TOUCH.MIN_TARGET_SIZE`)
+- **AND** the test SHALL fail if any future PR introduces a new module-local hardcoded definition that diverges from the canonical values
+
+#### Scenario: Public API surface is preserved
+
+- **WHEN** a consumer imports `BREAKPOINTS` or `MIN_TOUCH_TARGET` from `src/utils/responsive.ts`, or imports `useDeviceType`, `useTouchTarget`, or any of the `useIsMobile`/`useIsTablet`/`useIsDesktop` hooks
+- **THEN** the import SHALL resolve to the same exported names with the same shape they had before this consolidation
+- **AND** no consumer code SHALL require modification as a result of this change

--- a/openspec/changes/consolidate-responsive-constants/tasks.md
+++ b/openspec/changes/consolidate-responsive-constants/tasks.md
@@ -1,0 +1,33 @@
+## 1. Tripwire Test First (TDD)
+
+- [x] 1.1 Create `src/__tests__/constants/responsive-constants-sot.test.ts` with three assertion blocks: (a) `BREAKPOINTS.md`/`md`/`MD`/`mobile` resolve to 768 across all four sites, (b) `BREAKPOINTS.lg`/`LG`/`tablet` resolve to 1024 across all sites, (c) `MIN_TOUCH_TARGET` / `TOUCH.MIN_TARGET_SIZE` / `DEFAULT_MIN_SIZE` all equal 44.
+- [x] 1.2 Run the test against the current (pre-refactor) codebase — it MUST PASS now (values agree today). This proves the test reads the right symbols.
+- [x] 1.3 Temporarily edit `src/utils/responsive.ts` `BREAKPOINTS.md` to 769 and confirm the test FAILS (proves the test is sensitive to drift). Revert the edit.
+
+## 2. Refactor Re-Exports
+
+- [x] 2.1 Edit `src/utils/responsive.ts`: replace literal numeric `BREAKPOINTS` object with one that imports values from `@/constants/layout` (preserve lowercase Tailwind keys `sm/md/lg/xl/2xl`). Add JSDoc `@see src/constants/layout.ts` on the export.
+- [x] 2.2 Edit `src/utils/responsive.ts`: replace literal `MIN_TOUCH_TARGET = 44` with `import { TOUCH } from '@/constants/layout'; export const MIN_TOUCH_TARGET = TOUCH.MIN_TARGET_SIZE;`. Add `@see` JSDoc.
+- [x] 2.3 Edit `src/hooks/useDeviceType.ts`: replace private `BREAKPOINTS = { mobile: 768, tablet: 1024 }` with `import { BREAKPOINTS as LAYOUT_BREAKPOINTS } from '@/constants/layout';` and derive `mobile: LAYOUT_BREAKPOINTS.MD` / `tablet: LAYOUT_BREAKPOINTS.LG`.
+- [x] 2.4 Edit `src/hooks/useTouchTarget.ts`: replace `DEFAULT_MIN_SIZE = 44` with `import { TOUCH } from '@/constants/layout'; const DEFAULT_MIN_SIZE = TOUCH.MIN_TARGET_SIZE;`.
+- [x] 2.5 Add documentation comment at the top of `src/constants/layout.ts` `BREAKPOINTS` export explicitly stating it is canonical and that `responsive.ts` and `useDeviceType.ts` derive from it.
+
+## 3. Verification
+
+- [x] 3.1 Re-run `src/__tests__/constants/responsive-constants-sot.test.ts` — must PASS.
+- [x] 3.2 Run `npm run typecheck` — must pass with zero errors. Pay particular attention to literal-type narrowing on `BREAKPOINTS` (the `as const` assertion must still produce literal types).
+- [x] 3.3 Run `npm test` — full suite must pass. Existing tests `src/__tests__/responsive.test.tsx` and `src/__tests__/hooks/useTouchTarget.test.ts` must pass without modification.
+- [x] 3.4 Run `npm run build` — production build must succeed.
+- [x] 3.5 Grep verification: `grep -r "BREAKPOINTS = {" src/` must return ONLY hits in `src/constants/layout.ts` (canonical) and `src/utils/responsive.ts` / `src/hooks/useDeviceType.ts` (derived re-exports). No other module may declare a fresh `BREAKPOINTS = {` literal.
+- [x] 3.6 Grep verification: `grep -rn "= 44" src/hooks/ src/utils/` must NOT show any line where `44` is a hardcoded literal for touch-target sizing (it is allowed in tests and CSS class strings like `min-h-[44px]`, which is a separate concern out of scope here).
+
+## 4. Spec Sync (Done at Archive Time)
+
+- [ ] 4.1 At archive time, OpenSpec sync will merge the ADDED Requirement "Single Source of Truth for Responsive Constants" from this change's delta spec into `openspec/specs/mobile-interaction-patterns/spec.md`. No manual sync needed during apply phase.
+
+## 5. PR
+
+- [x] 5.1 Branch: `chore/consolidate-responsive-constants`. Commit messages follow conventional-commits style. Single PR targeting `main`.
+- [x] 5.2 PR description references the OMO Council session findings and links to the new global skill `~/.claude/skills/adaptive-ui-capabilities/SKILL.md`.
+- [ ] 5.3 Wait for CI green: `Lint and Test`, `Build Test / win/mac/linux` (3 platforms), and the new `responsive-constants-sot` test must all pass.
+- [ ] 5.4 Merge via squash. After merge, run `/opsx:archive consolidate-responsive-constants`.

--- a/src/__tests__/constants/responsive-constants-sot.test.ts
+++ b/src/__tests__/constants/responsive-constants-sot.test.ts
@@ -1,0 +1,87 @@
+import { renderHook } from '@testing-library/react';
+
+import { BREAKPOINTS as LAYOUT_BREAKPOINTS, TOUCH } from '@/constants/layout';
+import { useDeviceType } from '@/hooks/useDeviceType';
+import { useTouchTarget } from '@/hooks/useTouchTarget';
+import {
+  BREAKPOINTS as RESPONSIVE_BREAKPOINTS,
+  MIN_TOUCH_TARGET,
+} from '@/utils/responsive';
+
+const originalInnerWidth = window.innerWidth;
+const originalMatchMedia = window.matchMedia;
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    value: width,
+    writable: true,
+  });
+
+  window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }));
+}
+
+describe('responsive constants source of truth', () => {
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: originalInnerWidth,
+      writable: true,
+    });
+
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('keeps md/mobile breakpoints resolved to 768 across current sites', () => {
+    expect(LAYOUT_BREAKPOINTS.MD).toBe(768);
+    expect(RESPONSIVE_BREAKPOINTS.md).toBe(LAYOUT_BREAKPOINTS.MD);
+
+    setViewportWidth(LAYOUT_BREAKPOINTS.MD - 1);
+    const { result: mobileResult } = renderHook(() => useDeviceType());
+    expect(mobileResult.current.isMobile).toBe(true);
+    expect(mobileResult.current.isTablet).toBe(false);
+
+    setViewportWidth(LAYOUT_BREAKPOINTS.MD);
+    const { result: tabletResult } = renderHook(() => useDeviceType());
+    expect(tabletResult.current.isMobile).toBe(false);
+    expect(tabletResult.current.isTablet).toBe(true);
+  });
+
+  it('keeps lg/tablet breakpoints resolved to 1024 across current sites', () => {
+    expect(LAYOUT_BREAKPOINTS.LG).toBe(1024);
+    expect(RESPONSIVE_BREAKPOINTS.lg).toBe(LAYOUT_BREAKPOINTS.LG);
+
+    setViewportWidth(LAYOUT_BREAKPOINTS.LG - 1);
+    const { result: tabletResult } = renderHook(() => useDeviceType());
+    expect(tabletResult.current.isTablet).toBe(true);
+    expect(tabletResult.current.isDesktop).toBe(false);
+
+    setViewportWidth(LAYOUT_BREAKPOINTS.LG);
+    const { result: desktopResult } = renderHook(() => useDeviceType());
+    expect(desktopResult.current.isTablet).toBe(false);
+    expect(desktopResult.current.isDesktop).toBe(true);
+  });
+
+  it('keeps minimum touch target defaults resolved to 44 across current sites', () => {
+    expect(TOUCH.MIN_TARGET_SIZE).toBe(44);
+    expect(MIN_TOUCH_TARGET).toBe(TOUCH.MIN_TARGET_SIZE);
+
+    const { result } = renderHook(() =>
+      useTouchTarget({ contentWidth: 20, contentHeight: 20 }),
+    );
+
+    expect(result.current.style.paddingLeft).toBe(12);
+    expect(result.current.style.paddingRight).toBe(12);
+    expect(result.current.style.paddingTop).toBe(12);
+    expect(result.current.style.paddingBottom).toBe(12);
+  });
+});

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -53,6 +53,13 @@ export const Z_INDEX = {
 // Breakpoints (matches Tailwind defaults)
 // =============================================================================
 
+/**
+ * Canonical responsive breakpoint values.
+ *
+ * Other breakpoint shapes, including `src/utils/responsive.ts` lowercase
+ * Tailwind keys and `src/hooks/useDeviceType.ts` mobile/tablet keys, derive
+ * from this export.
+ */
 export const BREAKPOINTS = {
   /** Small devices (phones) */
   SM: 640,

--- a/src/hooks/useDeviceType.ts
+++ b/src/hooks/useDeviceType.ts
@@ -1,13 +1,16 @@
 import { useState, useEffect, useCallback } from 'react';
 
+import { BREAKPOINTS as LAYOUT_BREAKPOINTS } from '@/constants/layout';
+
 /**
  * Screen size breakpoints (in pixels)
+ * @see src/constants/layout.ts
  */
 const BREAKPOINTS = {
   /** Mobile: < 768px */
-  mobile: 768,
+  mobile: LAYOUT_BREAKPOINTS.MD,
   /** Tablet: >= 768px and < 1024px */
-  tablet: 1024,
+  tablet: LAYOUT_BREAKPOINTS.LG,
 } as const;
 
 /**

--- a/src/hooks/useTouchTarget.ts
+++ b/src/hooks/useTouchTarget.ts
@@ -1,5 +1,7 @@
 import { CSSProperties, useMemo } from 'react';
 
+import { TOUCH } from '@/constants/layout';
+
 /**
  * Touch target configuration
  */
@@ -25,7 +27,7 @@ interface TouchTargetStyles {
 /**
  * Minimum touch target size per iOS and Android accessibility guidelines
  */
-const DEFAULT_MIN_SIZE = 44;
+const DEFAULT_MIN_SIZE = TOUCH.MIN_TARGET_SIZE;
 
 /**
  * Hook to ensure interactive elements meet minimum touch target size.

--- a/src/utils/responsive.ts
+++ b/src/utils/responsive.ts
@@ -1,11 +1,17 @@
 import { useState, useEffect, useCallback } from 'react';
 
+import { BREAKPOINTS as LAYOUT_BREAKPOINTS, TOUCH } from '@/constants/layout';
+
+/**
+ * Tailwind-keyed breakpoints derived from the canonical layout constants.
+ * @see src/constants/layout.ts
+ */
 export const BREAKPOINTS = {
-  sm: 640,
-  md: 768,
-  lg: 1024,
-  xl: 1280,
-  '2xl': 1536,
+  sm: LAYOUT_BREAKPOINTS.SM,
+  md: LAYOUT_BREAKPOINTS.MD,
+  lg: LAYOUT_BREAKPOINTS.LG,
+  xl: LAYOUT_BREAKPOINTS.XL,
+  '2xl': LAYOUT_BREAKPOINTS.XXL,
 } as const;
 
 export function useMediaQuery(query: string): boolean {
@@ -45,8 +51,11 @@ export function useIsDesktop(): boolean {
   return useMediaQuery(`(min-width: ${BREAKPOINTS.lg}px)`);
 }
 
-/** WCAG 2.5.5 minimum touch target size in px */
-export const MIN_TOUCH_TARGET = 44;
+/**
+ * WCAG 2.5.5 minimum touch target size in px.
+ * @see src/constants/layout.ts
+ */
+export const MIN_TOUCH_TARGET = TOUCH.MIN_TARGET_SIZE;
 
 export const TOUCH_TARGET_CLASSES = 'min-h-[44px] min-w-[44px]';
 


### PR DESCRIPTION
## Summary
- Designates \\src/constants/layout.ts\\ as the canonical numeric source for responsive breakpoints and touch target size.
- Derives the existing lowercase \\esponsive.ts\\ shape, \\useDeviceType\\ thresholds, and \\useTouchTarget\\ default from the canonical layout constants.
- Adds \\esponsive-constants-sot.test.ts\\ as a drift tripwire, including a TDD sensitivity check performed locally by temporarily changing \\esponsive.BREAKPOINTS.md\\ to 769 and confirming failure.

## Context
- Implements OpenSpec change \\consolidate-responsive-constants\\.
- Follows the OMO Council session finding that duplicate responsive constants were the highest-leverage, lowest-risk responsive-surface cleanup.
- Related adaptive UI guidance: \\~/.claude/skills/adaptive-ui-capabilities/SKILL.md\\.

## Verification
- \\
pm test -- src/__tests__/constants/responsive-constants-sot.test.ts --watchAll=false\\
- \\
pm test -- src/__tests__/constants/responsive-constants-sot.test.ts src/__tests__/responsive.test.tsx src/__tests__/hooks/useTouchTarget.test.ts --watchAll=false\\
- \\
pm run typecheck\\
- \\
pm test -- --watchAll=false\\ (879 suites passed, 22,981 tests passed, 1 skipped)
- \\
pm run build\\ (exit 0; Windows emitted existing standalone trace-copy warning for generated \\
ode:crypto\\ chunk path)
- \\
pm run lint\\ (0 errors; existing warnings only)
- \\
pm run format:check\\
- \\openspec validate consolidate-responsive-constants --strict\\

## Notes
- Removed stale clean local worktree \\.claude/worktrees/vibrant-cannon-d630bf\\ from the working copy because Jest was discovering duplicate tests there. The branch \\chore/wire-auto-awards-persistence\\ remains on the remote.