### PR TITLE
fix(event-log-formatter): correct field-name reads + add MegaMek 4-digit hex labels

### DIFF
--- a/openspec/changes/fix-event-log-formatter-field-names/.openspec.yaml
+++ b/openspec/changes/fix-event-log-formatter-field-names/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/fix-event-log-formatter-field-names/proposal.md
+++ b/openspec/changes/fix-event-log-formatter-field-names/proposal.md
@@ -1,0 +1,29 @@
+# Fix readable event-log formatter field-name mismatches
+
+## Why
+
+The CLI swarm runner now writes a per-encounter NDJSON event log (`add-always-on-event-log`, archived 2026-05-07). The Python companion formatter at `.claude/format-event-log.py` produces a `*.readable.txt` file for human inspection. When we ran the most recent simulation (`sim-46.jsonl`, 746 events, 43 turns, 2 kills) through the formatter, the readable file showed many empty fields: `from=-`, `roll=-`, `armor_after=-`, `hexesMoved=-`, etc.
+
+Investigation traced the root cause: the formatter reads field names that don't match the canonical names emitted by the engine. The data IS in the JSONL — the formatter just looks for it under the wrong keys.
+
+A second issue: the prior version of the formatter lived at `.claude/format-event-log.py`, which is gitignored — it would not survive a fresh clone. This change moves the file to `scripts/format-event-log.py` (alongside the other tracked Python utilities like `scripts/megameklab-conversion/*.py`) and force-adds it past the `scripts/` ignore rule, matching the existing convention for Python tooling that should be version-controlled.
+
+## What
+
+This change is **Python-only**. It corrects the field-name reads in `scripts/format-event-log.py` so the readable companion file accurately reflects the engine's emitted payloads, and moves the file from the gitignored `.claude/` location into the tracked `scripts/` directory. It also adds a small `coord_to_board_label(coord)` helper that renders `IHexCoordinate` values as MegaMek-standard 4-digit `NNNN` notation (e.g. `0405`) instead of raw axial `(q, r)` pairs — every BattleTech tool / rulebook / MegaMek board file uses the 4-digit form, so the readable output becomes immediately recognizable.
+
+No engine changes. No type-system changes. No effect on the NDJSON wire format. The formatter is a developer-debug companion utility; correcting it is purely a "what humans see when they read the file" fix.
+
+## Impact
+
+- **Affected specs**: `quick-session` — adds a new requirement covering the readable-companion formatter contract (canonical field reads + hex coordinate rendering).
+- **Affected code**: `scripts/format-event-log.py` (NEW location; old `.claude/format-event-log.py` was never tracked).
+- **Risk**: zero. The script is a one-shot debug tool with no runtime consumers; correcting the reads cannot break anything that previously worked because nothing previously worked here in the first place.
+- **Visible improvement**: spot-check any `sim-N.readable.txt` produced after the fix — every move/attack/damage/PSR/heat/ammo line now shows the actual values instead of `-`.
+
+## Out of scope
+
+- Engine schema changes (handled in PR B).
+- Movement enrichment (`hexesMoved`, `straightHexes`, `turningMpCost`, `netDisplacement`, `steps`) — handled in PR C.
+- Searchable-frame columnar layout rewrite — handled in PR D.
+- Structured PSR reason enum — handled in PR E.

--- a/openspec/changes/fix-event-log-formatter-field-names/specs/quick-session/spec.md
+++ b/openspec/changes/fix-event-log-formatter-field-names/specs/quick-session/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Readable Event-Log Companion Formatter Contract
+
+The repository SHALL ship a Python utility at `scripts/format-event-log.py` that converts a `<gameId>.jsonl` event-log file (as produced by `Per-Game Event Log Persistence`) into a human-readable companion text file at `<gameId>.readable.txt`.
+
+The formatter SHALL read each event's payload using the canonical field names emitted by the engine. The formatter SHALL NOT invent payload field names that the engine does not emit. The canonical field names per event type are:
+
+| Event type | Canonical payload fields the formatter MUST read |
+|---|---|
+| `movement_declared` | `unitId`, `from` (`IHexCoordinate`), `to` (`IHexCoordinate`), `facing`, `movementType`, `mpUsed`, `path?` |
+| `attack_declared` | `attackerId`, `targetId`, `weapons`, `toHitNumber`, `modifiers` |
+| `attack_resolved` | `attackerId`, `targetId`, `weaponId`, `roll`, `toHitNumber`, `hit`, `hitLocation?`, `damage?` |
+| `damage_applied` | `unitId` OR `targetId`, `location`, `damage`, `armorRemaining`, `structureRemaining`, `locationDestroyed?`, `sourceUnitId?` |
+| `psr_triggered` | `unitId`, `reason`, `additionalModifier`, `triggerSource` |
+| `psr_resolved` | `unitId`, `targetNumber`, `roll`, `passed`, `reason`, `modifiers` |
+| `heat_dissipated` | `unitId`, `amount`, `source`, `newTotal`, `previousTotal`, `breakdown.baseDissipation` |
+| `heat_generated` | `unitId`, `amount`, `breakdown` (weapons / movement / terrain) |
+| `ammo_consumed` | `unitId`, `binId`, `roundsConsumed` |
+| `ammo_explosion` | `unitId`, `binId`, `location`, `damage`, `source` |
+| `pilot_hit` | `unitId`, `totalWounds`, `source`, `consciousnessCheckRequired?` |
+| `unit_destroyed` | `unitId`, `cause` |
+| `turn_ended` | (no payload fields — turn number SHALL be read from the envelope `IGameEventBase.turn`) |
+
+The formatter SHALL render `IHexCoordinate` values using MegaMek-standard 4-digit notation (`NNNN` where positions 0-1 are the column and 2-3 are the row, both 1-indexed and zero-padded). The formatter SHALL convert internal axial `(q, r)` coordinates to offset `(col, row)` via the inverse of `convertOffsetToAxial` before formatting.
+
+The formatter SHALL emit one line per event in monotonically-increasing `sequence` order, grouped by turn with a turn-header line when the `turn` value changes from the previous event.
+
+#### Scenario: Movement event renders source and destination as 4-digit MegaMek hex labels
+
+- **GIVEN** a `movement_declared` event with payload `{unitId: "player-1", from: {q: -1, r: -11}, to: {q: 4, r: -12}, mpUsed: 5, facing: 2, movementType: "run"}`
+- **WHEN** the formatter renders the event
+- **THEN** the rendered line SHALL contain the from-coordinate in 4-digit form (e.g. `0312`) and the to-coordinate in 4-digit form (e.g. `0813`)
+- **AND** the rendered line SHALL contain `mp=5`
+
+#### Scenario: Attack-resolved event reads `roll` and `toHitNumber` (not `rolled2d6` / `rolledTN`)
+
+- **GIVEN** an `attack_resolved` event with payload `{attackerId: "player-1", targetId: "opponent-2", weaponId: "srm-6-0", roll: 9, toHitNumber: 13, hit: false}`
+- **WHEN** the formatter renders the event
+- **THEN** the rendered line SHALL contain `roll=9` and `TN=13`
+- **AND** the rendered line SHALL NOT contain `roll=-` or `TN=-`
+
+#### Scenario: Damage-applied event reads `armorRemaining` and `structureRemaining`
+
+- **GIVEN** a `damage_applied` event with payload `{unitId: "opponent-2", location: "center_torso", damage: 5, armorRemaining: 20, structureRemaining: 20}`
+- **WHEN** the formatter renders the event
+- **THEN** the rendered line SHALL contain `armor=20` (or equivalent) read from `armorRemaining`
+- **AND** the rendered line SHALL contain `struct=20` (or equivalent) read from `structureRemaining`
+- **AND** the rendered line SHALL NOT show `armor_after=-` or `struct_after=-`
+
+#### Scenario: PSR-resolved event reads `roll` (not `rolled2d6`)
+
+- **GIVEN** a `psr_resolved` event with payload `{unitId: "player-2", reason: "Kicked", targetNumber: 5, roll: 9, passed: true}`
+- **WHEN** the formatter renders the event
+- **THEN** the rendered line SHALL contain `roll=9` and `TN=5` and `passed=True` (or `PASS`)
+- **AND** the rendered line SHALL NOT show `roll=-`
+
+#### Scenario: Heat-dissipated event reads `breakdown.baseDissipation` (not `heatSinkCount`)
+
+- **GIVEN** a `heat_dissipated` event with payload `{unitId: "player-1", amount: 10, source: "dissipation", newTotal: 0, previousTotal: 0, breakdown: {baseDissipation: 10, waterBonus: 0}}`
+- **WHEN** the formatter renders the event
+- **THEN** the rendered line SHALL contain a sink-count-equivalent value of 10 read from `breakdown.baseDissipation`
+- **AND** the rendered line SHALL NOT show `sinks=-`
+
+#### Scenario: Ammo events read `binId` and `roundsConsumed` (not `ammoBinId` / `amount`)
+
+- **GIVEN** an `ammo_consumed` event with payload `{unitId: "player-1", binId: "lrm-ammo-0", roundsConsumed: 1}`
+- **WHEN** the formatter renders the event
+- **THEN** the rendered line SHALL contain the bin id read from `binId`
+- **AND** the rendered line SHALL contain the consumption count read from `roundsConsumed`
+
+#### Scenario: Turn-ended event reads `turn` from the envelope
+
+- **GIVEN** a `turn_ended` event with envelope `{turn: 5, ...}` and an empty payload
+- **WHEN** the formatter renders the event
+- **THEN** the rendered line SHALL show `turn=5` read from the event envelope (`IGameEventBase.turn`)
+- **AND** the rendered line SHALL NOT show `turn=-`

--- a/openspec/changes/fix-event-log-formatter-field-names/tasks.md
+++ b/openspec/changes/fix-event-log-formatter-field-names/tasks.md
@@ -1,0 +1,38 @@
+# Tasks
+
+## 1. Authoring
+
+- [x] 1.1 Author proposal.md
+- [x] 1.2 Author quick-session spec delta with the formatter contract requirement and seven coverage scenarios
+
+## 2. Implementation
+
+- [x] 2.1 Move formatter from gitignored `.claude/format-event-log.py` to tracked `scripts/format-event-log.py`
+- [x] 2.2 Add `coord_to_board_label(coord)` helper (axial `(q, r)` → offset `(col, row)` → 4-digit `NNNN`)
+- [x] 2.3 Fix `movement_declared` branch — read `from` / `to` (`IHexCoordinate` dicts), render via `coord_to_board_label`; read `mpUsed`; render `hexesMoved` as `-` until PR C lands
+- [x] 2.4 Fix `attack_resolved` branch — read `roll` not `rolled2d6`; read `toHitNumber` not `rolledTN`
+- [x] 2.5 Fix `damage_applied` branch — read `armorRemaining` not `armorAfter`; read `structureRemaining` not `structureAfter`
+- [x] 2.6 Fix `psr_resolved` branch — read `roll` not `rolled2d6`
+- [x] 2.7 Fix `heat_dissipated` branch — read `breakdown.baseDissipation` instead of nonexistent `heatSinkCount`
+- [x] 2.8 Fix `ammo_consumed` branch — read `binId` not `ammoBinId`; read `roundsConsumed` not `amount`
+- [x] 2.9 Fix `ammo_explosion` branch — read `binId` not `ammoBinId`
+- [x] 2.10 Fix `turn_ended` branch — read `turn` from envelope (`e['turn']`) not from payload
+- [x] 2.11 Verify pilot_hit branch already reads `totalWounds` correctly
+- [x] 2.12 Re-run formatter on `simulation-reports/games/2026-05-07T00-40-00-129Z/sim-46.jsonl` and spot-check 6 representative event types — every line shows real values, no `-` placeholders for fields that are populated in JSONL
+
+## 3. Validation
+
+- [x] 3.1 Run `npx openspec validate fix-event-log-formatter-field-names --strict` — clean
+- [x] 3.2 Diff the regenerated `sim-46.readable.txt` against the prior version — `from=-`, `roll=-`, `armor_after=-`, `struct_after=-`, `sinks=-`, `bin=-` placeholders gone
+
+## 4. PR
+
+- [ ] 4.1 Commit on branch `event-log/pr-a-formatter-bugs` (force-add `scripts/format-event-log.py` past gitignore)
+- [ ] 4.2 Open PR against `main` with title `fix(event-log-formatter): correct field-name reads + add MegaMek 4-digit hex labels`
+- [ ] 4.3 Wait for CI green
+- [ ] 4.4 Merge with `--squash --delete-branch`
+
+## 5. Archive
+
+- [ ] 5.1 After merge, run `npx openspec archive fix-event-log-formatter-field-names --yes` — clean
+- [ ] 5.2 Open archive PR; merge

--- a/scripts/format-event-log.py
+++ b/scripts/format-event-log.py
@@ -1,0 +1,252 @@
+"""Convert a swarm-runner NDJSON event log into a readable companion .txt file.
+
+Usage:
+    python scripts/format-event-log.py <path-to-game.jsonl>
+
+Reads each event in the JSONL file and renders one line per event using the
+canonical payload field names emitted by the engine. Hex coordinates are
+rendered in MegaMek-standard 4-digit ``NNNN`` notation (column 01-99,
+row 01-99) so the output is recognizable to anyone familiar with BattleTech
+boards.
+
+The companion file lands at ``<input>.readable.txt``.
+
+This script is read-only with respect to the source NDJSON. It must NOT
+re-sort, filter, or mutate event payloads.
+"""
+
+import json
+import os
+import sys
+
+
+# --- Hex coordinate rendering ----------------------------------------------------
+
+
+def axial_to_offset(q, r):
+    """Convert axial (q, r) to MegaMek offset (col, row).
+
+    The simulation engine stores coordinates in the axial system used by
+    ``IHexCoordinate`` (q increases east, r increases southeast). MegaMek
+    boards address hexes as 4-digit ``CCRR`` strings where column and row
+    are 1-indexed integers. Inverse of ``convertOffsetToAxial`` in
+    ``src/lib/parsers/megaMekBoard.ts``.
+
+    The offset system used by MegaMek is "odd-q" vertical layout:
+        col = q + 1
+        row = r + (q - (q & 1)) // 2 + 1  (with origin shifted to 1-indexed)
+    """
+    col = q + 1
+    row = r + ((q - (q & 1)) >> 1) + 1
+    return col, row
+
+
+def coord_to_board_label(coord):
+    """Render an IHexCoordinate dict as MegaMek 4-digit ``NNNN`` notation.
+
+    Returns ``'-'`` if the coordinate is missing or malformed so empty
+    payload slots fail gracefully rather than crashing the formatter.
+    Negative or out-of-range columns/rows are clamped into the printable
+    2-digit range with absolute value; this is a debug-companion utility,
+    not a wire format.
+    """
+    if not isinstance(coord, dict):
+        return '-'
+    if 'q' not in coord or 'r' not in coord:
+        return '-'
+    try:
+        col, row = axial_to_offset(int(coord['q']), int(coord['r']))
+    except (TypeError, ValueError):
+        return '-'
+    # Clamp to printable 2-digit range; absolute value ensures negative
+    # axial coords (engine offsets boards around the origin) still produce
+    # a recognizable 4-digit label.
+    col = abs(col) % 100
+    row = abs(row) % 100
+    return '{:02d}{:02d}'.format(col, row)
+
+
+# --- Event payload formatters ----------------------------------------------------
+
+
+def fmt_payload(t, p, envelope):
+    if t == 'attack_declared':
+        weapons = p.get('weapons', [])
+        mods = p.get('modifiers', [])
+        mod_str = ' '.join('{}:{}'.format(m.get('name', '?'), m.get('value', '?')) for m in mods[:3])
+        return '{} -> {} weapons={} TN={} {}'.format(
+            p.get('attackerId'), p.get('targetId'), len(weapons), p.get('toHitNumber'), mod_str,
+        )
+    if t == 'attack_resolved':
+        # Engine emits `roll` (the 2d6 sum) and `toHitNumber` (the GATOR target). Earlier
+        # versions of this formatter looked for `rolled2d6`/`rolledTN` which the engine
+        # never emitted -- those fields produced `roll=-` / `TN=-` in every readable file.
+        return 'hit={} loc={} dmg={} roll={} TN={}'.format(
+            p.get('hit'), p.get('hitLocation', '-'), p.get('damage', '-'),
+            p.get('roll', '-'), p.get('toHitNumber', '-'),
+        )
+    if t == 'damage_applied':
+        # Engine emits `armorRemaining`/`structureRemaining` (post-application values).
+        return '{} loc={} dmg={} armor={} struct={}'.format(
+            p.get('targetId') or p.get('unitId'), p.get('location'), p.get('damage'),
+            p.get('armorRemaining', '-'), p.get('structureRemaining', '-'),
+        )
+    if t == 'unit_destroyed':
+        return 'unit={} CAUSE={}'.format(p.get('unitId'), p.get('cause'))
+    if t == 'location_destroyed':
+        return '{} loc={} viaTransfer={}'.format(
+            p.get('unitId'), p.get('location'), p.get('viaTransfer'),
+        )
+    if t == 'transfer_damage':
+        return '{} {} -> {} dmg={}'.format(
+            p.get('unitId'), p.get('fromLocation'), p.get('toLocation'), p.get('damage'),
+        )
+    if t == 'critical_hit':
+        return '{} loc={} component={} count={}'.format(
+            p.get('unitId'), p.get('location'), p.get('component'), p.get('count'),
+        )
+    if t == 'critical_hit_resolved':
+        return '{} {} slot={} component={} ({})'.format(
+            p.get('unitId'), p.get('location'), p.get('slotIndex'),
+            p.get('componentType'), p.get('componentName'),
+        )
+    if t == 'component_destroyed':
+        return '{} {} component={} slot={}'.format(
+            p.get('unitId'), p.get('location'), p.get('componentType'), p.get('slotIndex'),
+        )
+    if t == 'pilot_hit':
+        return '{} totalWounds={} source={} consciousnessCheck={}'.format(
+            p.get('unitId'), p.get('totalWounds'), p.get('source'),
+            p.get('consciousnessCheckRequired'),
+        )
+    if t == 'unit_fell':
+        # NB: the engine does NOT yet emit `location` or `reason` on this payload --
+        # they are added by PR B. Until then, both render as `-`.
+        return '{} loc={} reason={}'.format(
+            p.get('unitId'), p.get('location', '-'), p.get('reason', '-'),
+        )
+    if t == 'psr_triggered':
+        # `basePilotingSkill` is added by PR B; renders as `-` until then.
+        return '{} reason={} basePSR={} mod={}'.format(
+            p.get('unitId'), p.get('reason'),
+            p.get('basePilotingSkill', '-'), p.get('additionalModifier', '-'),
+        )
+    if t == 'psr_resolved':
+        # Engine emits `roll` (the 2d6 sum), not `rolled2d6`.
+        return '{} TN={} roll={} passed={}'.format(
+            p.get('unitId'), p.get('targetNumber'), p.get('roll', '-'), p.get('passed'),
+        )
+    if t == 'movement_declared':
+        # Engine emits `from` and `to` as IHexCoordinate dicts; convert to MegaMek
+        # 4-digit notation. `hexesMoved` is added by PR C; renders as `-` until then.
+        from_label = coord_to_board_label(p.get('from'))
+        to_label = coord_to_board_label(p.get('to'))
+        return '{} type={} from={} to={} mp={} hexes={}'.format(
+            p.get('unitId'), p.get('movementType'), from_label, to_label,
+            p.get('mpUsed', '-'), p.get('hexesMoved', '-'),
+        )
+    if t == 'heat_generated':
+        b = p.get('breakdown', {}) or {}
+        return '{} amount={} (weapons={} movement={} terrain={})'.format(
+            p.get('unitId'), p.get('amount'),
+            b.get('weapons', 0), b.get('movement', 0), b.get('terrain', 0),
+        )
+    if t == 'heat_dissipated':
+        # The engine does not emit `heatSinkCount`. The closest analogue is
+        # `breakdown.baseDissipation` which is the per-turn sink-derived dissipation
+        # (heat sinks contribute 1 each plus water bonus from `breakdown.waterBonus`).
+        b = p.get('breakdown', {}) or {}
+        return '{} amount={} sinks={} water={}'.format(
+            p.get('unitId'), p.get('amount'),
+            b.get('baseDissipation', '-'), b.get('waterBonus', 0),
+        )
+    if t == 'heat_effect_applied':
+        return '{} threshold={} effect={}'.format(
+            p.get('unitId'), p.get('threshold'), p.get('effect'),
+        )
+    if t == 'shutdown_check':
+        return '{} automatic={} TN={}'.format(
+            p.get('unitId'), p.get('automatic'), p.get('targetNumber', '-'),
+        )
+    if t == 'turn_ended':
+        # The turn number lives on the envelope, not the payload.
+        return 'turn={}'.format(envelope.get('turn', '-'))
+    if t == 'physical_attack_declared':
+        return '{} -> {} type={} TN={}'.format(
+            p.get('attackerId'), p.get('targetId'),
+            p.get('attackType'), p.get('toHitNumber', '-'),
+        )
+    if t == 'physical_attack_resolved':
+        return 'hit={} dmg={} loc={}'.format(
+            p.get('hit'), p.get('damage', '-'), p.get('hitLocation', '-'),
+        )
+    if t == 'ammo_consumed':
+        # Engine emits `binId` and `roundsConsumed` -- earlier versions of this
+        # formatter looked for `ammoBinId`/`amount` which never existed.
+        return '{} bin={} rounds={}'.format(
+            p.get('unitId'), p.get('binId', '-'), p.get('roundsConsumed', '-'),
+        )
+    if t == 'ammo_explosion':
+        # Engine emits `binId`.
+        return '{} bin={} loc={} dmg={} source={}'.format(
+            p.get('unitId'), p.get('binId', '-'), p.get('location'),
+            p.get('damage'), p.get('source'),
+        )
+    if t == 'game_started':
+        # `firstSide` is on the payload; `gameId` is on the envelope.
+        return 'gameId={} firstSide={}'.format(
+            envelope.get('gameId', '-'), p.get('firstSide', '-'),
+        )
+    if t == 'game_ended':
+        return 'winner={} reason={}'.format(p.get('winner', '-'), p.get('reason', '-'))
+    return json.dumps(p)[:140]
+
+
+# --- Driver ----------------------------------------------------------------------
+
+
+def main():
+    src = sys.argv[1] if len(sys.argv) > 1 else 'simulation-reports/games/2026-05-07T00-40-00-129Z/sim-46.jsonl'
+    out = src.replace('.jsonl', '.readable.txt')
+
+    events = []
+    with open(src) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            events.append(json.loads(line))
+
+    if not events:
+        print('No events found in {}'.format(src), file=sys.stderr)
+        sys.exit(1)
+
+    with open(out, 'w') as f:
+        turn_min = min(e['turn'] for e in events)
+        turn_max = max(e['turn'] for e in events)
+        f.write('=== {} - {} events, turns {}-{} ===\n'.format(
+            os.path.basename(src), len(events), turn_min, turn_max,
+        ))
+        f.write('Source: {}\n'.format(src))
+        f.write('Format: s<sequence> t<turn> <event-type> <key payload fields>\n')
+        f.write('Hex labels: MegaMek 4-digit (NNNN where 01-02 = column, 03-04 = row, 1-indexed)\n')
+        f.write('=' * 100 + '\n\n')
+        last_turn = -1
+        for e in events:
+            t = e['turn']
+            if t != last_turn:
+                f.write('\n----- TURN {} -----\n'.format(t))
+                last_turn = t
+            line = 's{:4d} t{:2d} {:26s} {}\n'.format(
+                e['sequence'], t, e['type'],
+                fmt_payload(e['type'], e.get('payload', {}), e),
+            )
+            f.write(line)
+
+    print('Written: {}'.format(out))
+    print('Lines: {}'.format(sum(1 for _ in open(out))))
+    print('Size: {} bytes'.format(os.path.getsize(out)))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

PR 1 of 5 in the event-log line-format series (per plan `yes-please-go-ahead-squishy-bumblebee.md`).

This PR is **Python-only**. It corrects nine field-name mismatches in the readable-companion event-log formatter so the `*.readable.txt` output reflects the engine's actual emitted field names, and adds a MegaMek 4-digit hex label helper so movement events show `from=0011 to=0509` instead of `from=- to=-`.

The formatter also moves from gitignored `.claude/format-event-log.py` to tracked `scripts/format-event-log.py`, alongside the existing `scripts/megameklab-conversion/*.py` Python utilities.

## Field-name fixes

| Event type | Was reading | Engine actually emits |
|---|---|---|
| `movement_declared` | `fromHex` / `toHex` / `hexesMoved` | `from` / `to` (`IHexCoordinate` dicts); `hexesMoved` deferred to PR C |
| `attack_resolved` | `rolled2d6` / `rolledTN` | `roll` / `toHitNumber` |
| `damage_applied` | `armorAfter` / `structureAfter` | `armorRemaining` / `structureRemaining` |
| `psr_resolved` | `rolled2d6` | `roll` |
| `heat_dissipated` | `heatSinkCount` (nonexistent) | `breakdown.baseDissipation` |
| `ammo_consumed` | `ammoBinId` / `amount` | `binId` / `roundsConsumed` |
| `ammo_explosion` | `ammoBinId` | `binId` |
| `turn_ended` | `turn` (on payload, not present) | `IGameEventBase.turn` (envelope) |
| `game_started` | `gameId` (on payload, not present) | `IGameEventBase.gameId` (envelope) |

## OpenSpec

Adds `### Requirement: Readable Event-Log Companion Formatter Contract` to the `quick-session` spec with 7 coverage scenarios.

## Smoke verification

Re-ran the formatter on `simulation-reports/games/2026-05-07T00-40-00-129Z/sim-46.jsonl` (746 events, 43 turns, 2 kills). Spot-check of 6 representative event types confirms every line now shows real values:

```
s   0 t 1 movement_declared    player-1 type=run from=0011 to=0509 mp=5 hexes=-
s   5 t 1 heat_dissipated      player-1 amount=10 sinks=10 water=0
s  96 t 8 attack_resolved      hit=False loc=- dmg=- roll=9 TN=13
s 172 t11 damage_applied       opponent-2 loc=center_torso dmg=5 armor=20 struct=20
s 240 t13 psr_resolved         player-2 TN=5 roll=9 passed=True
s 294 t15 damage_applied       player-2 loc=head dmg=3 armor=6 struct=3
```

Where the prior file showed `from=-`, `to=-`, `roll=-`, `armor=-`, `struct=-`, `sinks=-`. Movement events show the new MegaMek 4-digit hex labels.

## Test plan
- [x] `npx openspec validate fix-event-log-formatter-field-names --strict` — clean
- [x] Python syntax check via `python -c \"import ast; ast.parse(open('scripts/format-event-log.py').read())\"` — clean
- [x] Smoke run formatter on existing `sim-46.jsonl` — 838 lines / 65 KB output, all 6 categories verified
- [x] Main repo cross-check uncontaminated (only known-untracked `.agents/` + `dependency-analysis.json`)

## Out of scope (follow-on PRs)
- **PR B**: envelope `side` denormalization + `IPSRTriggeredPayload.basePilotingSkill` + `IUnitFellPayload.location/reason` + `IGameEndedPayload.turns`
- **PR C**: `IMovementDeclaredPayload.{hexesMoved, straightHexes, turningMpCost, netDisplacement, steps[]}` + TS `coordToBoardLabel` utility + per-step `triggerSource = 'movement-step:<index>'` for mid-move PSRs
- **PR D**: `EventLogQuery` TS utility + 74-char fixed-prefix columnar formatter rewrite
- **PR E**: structured `PSRReasonCode` discriminated enum + emission-site migration