### PR TITLE
feat(event-log): denormalize side onto envelope + backfill schema gaps + 4 emission-contract spec extensions

### DIFF
--- a/openspec/changes/denormalize-event-envelope-and-close-emission-contract-gaps/.openspec.yaml
+++ b/openspec/changes/denormalize-event-envelope-and-close-emission-contract-gaps/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/denormalize-event-envelope-and-close-emission-contract-gaps/proposal.md
+++ b/openspec/changes/denormalize-event-envelope-and-close-emission-contract-gaps/proposal.md
@@ -1,0 +1,44 @@
+# Denormalize side onto the event envelope + close emission-contract gaps
+
+## Why
+
+Two pain points surfaced when reading the just-shipped always-on event log:
+
+1. **Side derivation duplication**: `MetricsCollector.sideFromUnitId(unitId)` derives `'player' | 'opponent'` from the `player-` / `opponent-` prefix on `unitId`. Every consumer (metrics, scenario tests, the readable formatter, future UI replays) reinvents the same lookup. A field on the envelope removes the duplication and lets line-level renderers show side for events whose `actorId` is empty (turn-lifecycle, game-ended, initiative-rolled).
+2. **Schema gaps the readable formatter expects**: PR A's seven-scenario spec reveals fields the engine doesn't carry today — `IPSRTriggeredPayload.basePilotingSkill`, `IUnitFellPayload.location` and `reason`, `IGameEndedPayload.turns`. Those fields exist in the runner's internal state at emit time; they just aren't propagated to the payload.
+
+Concurrent research (omo-explore Java oracle against `E:/Projects/megamek/`) also surfaced an **emission-contract gap**: several lifecycle events shipped during the combat-fidelity-suite (PRs #517-528) lack an explicit `### Requirement: ... emits ...` heading in their owning spec — `turn_started` / `turn_ended` / `phase_changed` / `attacks_revealed` / `location_destroyed` / `transfer_damage` / `pilot_hit`. The events fire correctly but no spec requires them by name, so future regressions wouldn't be caught by spec-verifier.
+
+## What
+
+### Code changes
+
+1. Add `readonly side?: GameSide` to `IGameEventBase` (line 320 of `src/types/gameplay/GameSessionInterfaces.ts`).
+2. Extend `createGameEvent` (`src/simulation/runner/phases/utils.ts`) to derive `side` from `actorId` via the same prefix lookup `MetricsCollector.sideFromUnitId` uses. The derivation runs at emission time so every event lands with the field populated.
+3. Backfill `IPSRTriggeredPayload` with `readonly basePilotingSkill?: number` and propagate from `unit.pilot.piloting` at emit sites.
+4. Backfill `IUnitFellPayload` with `readonly location?: string` and `readonly reason?: string` (string-typed for now; PR E tightens to `PSRReasonCode`).
+5. Backfill `IGameEndedPayload` with `readonly turns?: number` (final turn count from runner state).
+
+### Spec extensions
+
+Each delta scopes only the **emission-contract gap** it owns — no behavioral changes, just naming what the runner already does:
+
+- `game-event-system`: ADD `Requirement: Event Envelope Side Denormalization` (every emitted event SHALL carry `side` derived from `actorId`); ADD `Requirement: Turn Lifecycle Event Emission` (covers turn_started / turn_ended / phase_changed); ADD `Requirement: Initiative Event Emission` (initiative_rolled / initiative_order_set).
+- `combat-resolution`: ADD `Requirement: AttackResolved Side Effect Chain` (location_destroyed → transfer_damage → critical_hit cascade ordering contract).
+- `damage-system`: ADD `Requirement: DamageApplied Emission Contract` (every armor/structure mutation produces a `damage_applied` event; cascade order: damage_applied → location_destroyed → transfer_damage).
+- `piloting-skill-rolls`: ADD `Requirement: PSRTriggered Carries Base Skill` (`basePilotingSkill` field); ADD `Requirement: UnitFell Carries Location and Reason` (location of fall + reason classification, free-string-typed for back-compat).
+
+## Impact
+
+- **Affected types**: `IGameEventBase`, `IPSRTriggeredPayload`, `IUnitFellPayload`, `IGameEndedPayload`.
+- **Affected code**: `src/simulation/runner/phases/utils.ts` (single chokepoint — adds derivation), 4-6 PSR/fall/end emit sites.
+- **Affected specs**: `game-event-system`, `combat-resolution`, `damage-system`, `piloting-skill-rolls`.
+- **Risk**: low. Every new field is OPTIONAL — legacy event streams compile and replay unchanged. The single-chokepoint `createGameEvent` change means we don't touch all 94 emit sites.
+- **Visible improvement**: every readable-companion line shows side, and PSR / unit-fell / game-ended lines show the data the formatter already tries to print.
+
+## Out of scope
+
+- `forceId` as a domain concept above `GameSide` (deferred per Decision Summary in plan).
+- Tightening `IPSRTriggeredPayload.reason` and `IUnitFellPayload.reason` to a discriminated `PSRReasonCode` enum (PR E).
+- New movement / charge / DFA event types (PR C, follow-on changes).
+- Heat-threshold / gyro-variant / cockpit-cascade spec extensions (named follow-on changes).

--- a/openspec/changes/denormalize-event-envelope-and-close-emission-contract-gaps/specs/combat-resolution/spec.md
+++ b/openspec/changes/denormalize-event-envelope-and-close-emission-contract-gaps/specs/combat-resolution/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: AttackResolved Side-Effect Chain Ordering
+
+When a weapon attack resolves with `hit: true`, the simulation runner SHALL emit the resulting events in causal-deterministic order so consumers can replay the cascade without ambiguity. The canonical ordering for a single resolved hit is:
+
+1. `attack_resolved` (the GATOR-validated outcome of the to-hit roll)
+2. `damage_applied` (one event per location that takes damage; for cluster weapons, one per cluster after the cluster-hits-table roll)
+3. `location_destroyed` (if the location's structure dropped to 0; carries `viaTransfer: false` for the directly-hit location)
+4. `transfer_damage` (if there is residual damage to transfer to a parent location)
+5. `damage_applied` (cascade — repeats steps 2-4 for each transfer until a location absorbs the residual or the unit is destroyed)
+6. `critical_hit` (one event per crit roll triggered by the damage chain)
+7. `critical_hit_resolved` (one event per slot resolved by the crit)
+8. `component_destroyed` (one event per destroyed component slot)
+9. `unit_destroyed` (if the cascade caused unit destruction; carries the canonical `cause`)
+
+For cluster / multi-location attacks (LRMs, SRMs, LB-X, etc.), the runner SHALL repeat steps 2-8 once per cluster in the order produced by the per-cluster location rolls.
+
+For misses (`hit: false`), the runner SHALL emit `attack_resolved` and SHALL NOT emit any of the side-effect events 2-9.
+
+#### Scenario: Hit producing direct damage with no transfer emits the minimum chain
+
+- **GIVEN** a weapon attack that hits with damage less than the location's armor remaining
+- **WHEN** the runner resolves the attack
+- **THEN** the event log SHALL contain `attack_resolved` (hit=true) followed by `damage_applied` for the hit location
+- **AND** the runner SHALL NOT emit `location_destroyed`, `transfer_damage`, `critical_hit`, or `unit_destroyed` for this hit
+
+#### Scenario: Hit destroying a location triggers the transfer chain
+
+- **GIVEN** a weapon attack whose damage exceeds the hit location's combined armor + structure
+- **WHEN** the runner resolves the attack
+- **THEN** the events SHALL appear in order: `attack_resolved`, `damage_applied` (hit location), `location_destroyed` (`viaTransfer: false`), `transfer_damage` (toLocation = parent), `damage_applied` (parent location)
+- **AND** if the parent location also destroys, the chain SHALL continue (`location_destroyed` with `viaTransfer: true` for the parent), terminating either when residual damage is absorbed or when the unit is destroyed
+
+#### Scenario: Cluster weapon emits per-cluster damage events
+
+- **GIVEN** an LRM-20 attack that hits with the cluster-hits-table producing 11 missiles
+- **WHEN** the runner resolves the attack
+- **THEN** the events SHALL contain exactly one `attack_resolved`
+- **AND** the events SHALL contain at least 11 `damage_applied` events (one per cluster), distributed by the per-cluster location roll
+- **AND** the cluster's per-location damage chain (steps 3-8) SHALL repeat for each cluster that destroys a location
+
+#### Scenario: Miss emits only attack_resolved
+
+- **GIVEN** a weapon attack with `roll < toHitNumber`
+- **WHEN** the runner resolves the attack
+- **THEN** the event log SHALL contain exactly one `attack_resolved` event with `hit: false`
+- **AND** the event log SHALL NOT contain any of `damage_applied`, `location_destroyed`, `transfer_damage`, `critical_hit`, `critical_hit_resolved`, `component_destroyed`, `unit_destroyed` causally attributable to this attack

--- a/openspec/changes/denormalize-event-envelope-and-close-emission-contract-gaps/specs/damage-system/spec.md
+++ b/openspec/changes/denormalize-event-envelope-and-close-emission-contract-gaps/specs/damage-system/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: DamageApplied Event Emission Contract
+
+Every armor or structure mutation that occurs during weapon-attack, physical-attack, mid-move terrain, ammo-explosion, or heat-damage resolution SHALL produce exactly one `damage_applied` event with the post-mutation `armorRemaining` and `structureRemaining` values populated. The event payload SHALL include:
+
+- `unitId` — the unit that took damage
+- `location` — the location enum value (e.g. `'center_torso'`, `'right_leg'`)
+- `damage` — the amount of damage applied at this location (after partial-cover / hardening / etc. adjustments, before any transfer)
+- `armorRemaining` — armor remaining at the location AFTER application (may be 0)
+- `structureRemaining` — structure remaining at the location AFTER application (may be 0)
+- `locationDestroyed` — `true` if the structure dropped to 0 in this event
+- `sourceUnitId` — the unit that caused the damage (`null` for self/environment damage)
+
+The runner SHALL NOT emit `damage_applied` events with stale armor/structure values; the event SHALL be emitted AFTER the mutation lands so consumers can replay the unit's HP curve directly from the event log.
+
+#### Scenario: Damage event reports post-application armor and structure
+
+- **GIVEN** a unit with 25 armor / 14 structure on the center_torso
+- **AND** an incoming hit of 5 damage to the center_torso
+- **WHEN** the damage is applied
+- **THEN** the emitted `damage_applied` event SHALL have `armorRemaining: 20` and `structureRemaining: 14`
+
+#### Scenario: Self/environment damage carries sourceUnitId=null
+
+- **GIVEN** a heat-induced ammo-explosion damage event
+- **WHEN** the damage is applied via the ammo-explosion side-effect chain
+- **THEN** the emitted `damage_applied.sourceUnitId` SHALL be `null`
+
+### Requirement: Transfer Damage and Location Destruction Event Contract
+
+When damage exceeds a location's combined armor + structure, the runner SHALL emit a `location_destroyed` event followed by a `transfer_damage` event before applying the residual damage to the parent location. The `location_destroyed.viaTransfer` flag distinguishes:
+
+- `viaTransfer: false` — the location was destroyed by the original directly-incoming hit
+- `viaTransfer: true` — the location was destroyed by residual damage cascading from a child location
+
+The runner SHALL emit `transfer_damage` with `unitId`, `fromLocation`, `toLocation`, and `damage` (residual amount), even if the residual is 0 (so consumers can audit cascade termination).
+
+#### Scenario: Direct-hit destruction emits viaTransfer=false
+
+- **GIVEN** a unit with 5 armor / 3 structure on the right_arm
+- **AND** an incoming hit of 12 damage to the right_arm
+- **WHEN** the damage is applied
+- **THEN** the events SHALL include `damage_applied` (right_arm, locationDestroyed=true), `location_destroyed` (right_arm, viaTransfer=false), `transfer_damage` (right_arm → right_torso, damage=4)
+
+#### Scenario: Cascade destruction emits viaTransfer=true on the parent
+
+- **GIVEN** a unit with 0 armor / 0 structure on the right_arm (already destroyed)
+- **AND** 5 armor / 3 structure remaining on the right_torso
+- **AND** an incoming residual transfer of 12 damage from the right_arm
+- **WHEN** the cascade resolves
+- **THEN** the events SHALL include `damage_applied` (right_torso), `location_destroyed` (right_torso, viaTransfer=true), `transfer_damage` (right_torso → center_torso, damage=4)

--- a/openspec/changes/denormalize-event-envelope-and-close-emission-contract-gaps/specs/game-event-system/spec.md
+++ b/openspec/changes/denormalize-event-envelope-and-close-emission-contract-gaps/specs/game-event-system/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Event Envelope Side Denormalization
+
+Every `IGameEvent` SHALL carry an optional `side: GameSide` field on `IGameEventBase` denormalized from the event's `actorId` at emission time. Consumers (metrics collectors, scenario tests, the readable companion formatter, future UI replay viewers) SHALL be able to filter or display side without separately joining `unitId` to `IGameUnit.side`.
+
+The single-chokepoint event builder (`createGameEvent` in `src/simulation/runner/phases/utils.ts`) SHALL derive `side` from `actorId` using the same prefix rules as `MetricsCollector.sideFromUnitId`:
+
+- `actorId` starting with `'player-'` → `GameSide.Player`
+- `actorId` starting with `'opponent-'` → `GameSide.Opponent`
+- `actorId` undefined or matching no prefix → `side` field SHALL be omitted (events authored by the system, not a unit, e.g. turn lifecycle)
+
+The field is optional on `IGameEventBase` so legacy NDJSON event streams written before this change replay unchanged.
+
+#### Scenario: Player-prefixed actor produces side=player
+
+- **GIVEN** a `damage_applied` event with `actorId: 'player-1'`
+- **WHEN** `createGameEvent` builds the event
+- **THEN** the resulting event SHALL have `side: GameSide.Player`
+
+#### Scenario: Opponent-prefixed actor produces side=opponent
+
+- **GIVEN** an `attack_resolved` event with `actorId: 'opponent-2'`
+- **WHEN** `createGameEvent` builds the event
+- **THEN** the resulting event SHALL have `side: GameSide.Opponent`
+
+#### Scenario: System-authored events (no actorId) omit the side field
+
+- **GIVEN** a `turn_started` event built without an `actorId`
+- **WHEN** `createGameEvent` builds the event
+- **THEN** the resulting event SHALL NOT have a `side` field (or SHALL have it set to `undefined`)
+- **AND** `JSON.stringify` SHALL omit `side` from the serialized line
+
+#### Scenario: Legacy event streams replay despite missing side
+
+- **GIVEN** an NDJSON event log written before this change (no `side` field on any event)
+- **WHEN** the events are loaded and processed by `MetricsCollector` or any other consumer
+- **THEN** processing SHALL succeed
+- **AND** consumers MAY fall back to the legacy `sideFromUnitId(actorId)` derivation
+
+### Requirement: Turn Lifecycle Event Emission Contract
+
+The simulation runner SHALL emit `turn_started`, `turn_ended`, and `phase_changed` events at the boundaries of every turn and phase, in monotonically-increasing `sequence` order. These events SHALL be authored without an `actorId` (system-emitted) and SHALL therefore omit `side` per the Event Envelope Side Denormalization requirement.
+
+#### Scenario: Every turn boundary emits turn_started and turn_ended
+
+- **GIVEN** a simulation that runs N turns
+- **WHEN** the event log is collected
+- **THEN** there SHALL be exactly N `turn_started` events
+- **AND** there SHALL be exactly N `turn_ended` events
+- **AND** for each turn t, the `turn_started` event for turn t SHALL precede the `turn_ended` event for turn t in `sequence` order
+
+#### Scenario: Every phase change inside a turn emits phase_changed
+
+- **GIVEN** a turn that traverses Movement → WeaponAttack → PhysicalAttack → PostCombat phases
+- **WHEN** the event log for that turn is collected
+- **THEN** the events SHALL include at least three `phase_changed` events (one per phase boundary)
+- **AND** each `phase_changed.payload.phase` SHALL match the upcoming phase identifier
+
+### Requirement: Initiative Event Emission Contract
+
+The simulation runner SHALL emit an `initiative_rolled` event at the start of every turn that uses dice-based initiative. The event payload SHALL carry the rolled values for each side and the resulting initiative winner.
+
+#### Scenario: Initiative rolled at turn start
+
+- **GIVEN** the runner enters a new turn with dice-based initiative enabled
+- **WHEN** the initiative-determination step runs
+- **THEN** an `initiative_rolled` event SHALL be emitted before the first phase event of the turn
+- **AND** the event payload SHALL carry both sides' rolled values

--- a/openspec/changes/denormalize-event-envelope-and-close-emission-contract-gaps/specs/piloting-skill-rolls/spec.md
+++ b/openspec/changes/denormalize-event-envelope-and-close-emission-contract-gaps/specs/piloting-skill-rolls/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: PSRTriggered Carries Base Piloting Skill
+
+Every `psr_triggered` event SHALL include the unit's `basePilotingSkill` (the unmodified piloting skill value before per-trigger and cumulative modifiers) in its payload. Consumers SHALL use this field to render the full PSR target-number arithmetic (`basePilotingSkill + additionalModifier + cumulative-mods = targetNumber`) without separately joining to the unit's pilot record.
+
+The `basePilotingSkill` field is OPTIONAL on the payload to preserve compatibility with NDJSON event streams written before this change.
+
+#### Scenario: PSR-triggered event carries base piloting skill from the unit
+
+- **GIVEN** a unit with `pilot.piloting: 4`
+- **AND** the runner triggers a PSR with `additionalModifier: 2` for reason `'gyro-hit'`
+- **WHEN** the `psr_triggered` event is emitted
+- **THEN** the event payload SHALL have `basePilotingSkill: 4`
+- **AND** the event payload SHALL have `additionalModifier: 2`
+
+#### Scenario: Legacy event streams without basePilotingSkill replay
+
+- **GIVEN** an NDJSON event log written before this change (no `basePilotingSkill` on `psr_triggered` events)
+- **WHEN** consumers process the events
+- **THEN** processing SHALL succeed
+- **AND** consumers MAY render the missing field as `'-'` or fall back to a separate unit-record lookup
+
+### Requirement: UnitFell Carries Location and Reason
+
+Every `unit_fell` event SHALL include the location at which the fall happened and a free-string `reason` describing the fall cause. Both fields are OPTIONAL on `IUnitFellPayload` for back-compat. The `reason` field is typed as `string` in this change; PR E (`structure-psr-reason-as-discriminated-code`) tightens it to a `PSRReasonCode` discriminated union.
+
+The `location` field SHALL be populated from the runner's PSR resolution context (the hex coordinate or unit-internal location associated with the trigger) — for example `'left_leg'` when leg-damage caused the fall, `'center_torso'` for damage-PSR falls, or the hex-coordinate string when the fall was triggered by terrain.
+
+#### Scenario: Damage-induced fall carries the structure location
+
+- **GIVEN** a unit takes 20+ damage in a phase, triggering a damage-PSR
+- **AND** the PSR fails, causing the unit to fall
+- **WHEN** the `unit_fell` event is emitted
+- **THEN** the event payload SHALL have a populated `location` (e.g. `'center_torso'` referencing the damaged location)
+- **AND** the event payload SHALL have a populated `reason` (e.g. `'took-20-damage'`)
+
+#### Scenario: Gyro-hit-induced fall carries the gyro location
+
+- **GIVEN** a critical hit destroys a gyro slot
+- **AND** the resulting PSR fails, causing the unit to fall
+- **WHEN** the `unit_fell` event is emitted
+- **THEN** the event payload SHALL have `location` populated with the gyro-bearing location (typically `'center_torso'` for standard mechs)
+- **AND** the event payload SHALL have `reason` populated with a string identifying the gyro cause (e.g. `'gyro-hit'`)

--- a/openspec/changes/denormalize-event-envelope-and-close-emission-contract-gaps/tasks.md
+++ b/openspec/changes/denormalize-event-envelope-and-close-emission-contract-gaps/tasks.md
@@ -1,0 +1,55 @@
+# Tasks
+
+## 1. Authoring
+
+- [x] 1.1 Author proposal.md with motivation + scope
+- [x] 1.2 Author game-event-system spec delta (Side Denormalization + Turn Lifecycle + Initiative emission contracts)
+- [x] 1.3 Author combat-resolution spec delta (AttackResolved Side-Effect Chain Ordering)
+- [x] 1.4 Author damage-system spec delta (DamageApplied + Transfer/LocationDestroyed Contracts)
+- [x] 1.5 Author piloting-skill-rolls spec delta (PSRTriggered Base Skill + UnitFell Location & Reason)
+
+## 2. Type extensions
+
+- [ ] 2.1 Add `readonly side?: GameSide` to `IGameEventBase` in `src/types/gameplay/GameSessionInterfaces.ts:320`
+- [ ] 2.2 Add `readonly basePilotingSkill?: number` to `IPSRTriggeredPayload` (line 849)
+- [ ] 2.3 Add `readonly location?: string` and `readonly reason?: string` to `IUnitFellPayload` (line 870)
+- [ ] 2.4 Add `readonly turns?: number` to `IGameEndedPayload` (line 362)
+
+## 3. Single-chokepoint side derivation
+
+- [ ] 3.1 Extend `createGameEvent` in `src/simulation/runner/phases/utils.ts:10` to derive `side` from `actorId` (`'player-'` prefix → `GameSide.Player`, `'opponent-'` prefix → `GameSide.Opponent`, else omit field)
+- [ ] 3.2 Update existing `MetricsCollector.sideFromUnitId` to remain a fallback (do NOT remove — needed for legacy event-stream replay), but add a comment noting the envelope is the canonical source going forward
+
+## 4. Schema-gap propagation
+
+- [ ] 4.1 Update PSR-trigger emit sites in `src/simulation/runner/phases/postCombat.ts` and any other PSR sites to pass `basePilotingSkill: unit.pilot.piloting` into the payload
+- [ ] 4.2 Update `unit_fell` emit site (`postCombat.ts:106`) to pass `location` and `reason` derived from the PSR context (the trigger that caused the fall)
+- [ ] 4.3 Update the `game_ended` emit site to populate `turns` with the runner's final turn counter
+
+## 5. Tests
+
+- [ ] 5.1 Update or add unit tests verifying `createGameEvent` populates `side` from `actorId` for all three branches (player, opponent, system-no-actor)
+- [ ] 5.2 Add scenario test verifying a player-1 attack produces events all carrying `side: 'player'`
+- [ ] 5.3 Update / extend the existing PSR-resolved scenario test to also assert `psr_triggered.basePilotingSkill` populates
+- [ ] 5.4 Update / extend an existing fall scenario test (or add one) to assert `unit_fell.location` and `unit_fell.reason` populate
+- [ ] 5.5 Update / extend the existing game-end scenario test to assert `game_ended.turns` matches the final turn count
+- [ ] 5.6 Run the full test suite — green
+
+## 6. Validation
+
+- [ ] 6.1 `npm run typecheck` clean
+- [ ] 6.2 `npm run lint` clean
+- [ ] 6.3 `npm test` green
+- [ ] 6.4 `npx openspec validate denormalize-event-envelope-and-close-emission-contract-gaps --strict` clean
+
+## 7. PR
+
+- [ ] 7.1 Commit on branch `event-log/pr-b-envelope-and-emission-contracts`
+- [ ] 7.2 Open PR against `main` with title `feat(event-log): denormalize side onto envelope + backfill schema gaps + 4 emission-contract spec extensions`
+- [ ] 7.3 Wait for CI green
+- [ ] 7.4 Merge with `--squash --delete-branch`
+
+## 8. Archive
+
+- [ ] 8.1 After merge, run `npx openspec archive denormalize-event-envelope-and-close-emission-contract-gaps --yes` — clean
+- [ ] 8.2 Open archive PR; merge

--- a/src/__tests__/unit/utils/gameplay/wirePilotingSkillRolls.smoke.test.ts
+++ b/src/__tests__/unit/utils/gameplay/wirePilotingSkillRolls.smoke.test.ts
@@ -22,6 +22,7 @@ import {
   IGameUnit,
   IPSRResolvedPayload,
   IPSRTriggeredPayload,
+  IUnitFellPayload,
   IUnitStoodPayload,
   MovementType,
 } from '@/types/gameplay';
@@ -166,6 +167,13 @@ describe('wire-piloting-skill-rolls — smoke test', () => {
     expect(triggered.length).toBe(1);
     expect(session.currentState.units['attacker'].pendingPSRs?.length).toBe(1);
 
+    // Per `denormalize-event-envelope-and-close-emission-contract-gaps`
+    // (piloting-skill-rolls delta — PSRTriggered Carries Base Skill):
+    // the trigger payload SHALL carry the unit's base piloting skill
+    // (here `units[0].piloting === 5`).
+    const triggerPayload = triggered[0].payload as IPSRTriggeredPayload;
+    expect(triggerPayload.basePilotingSkill).toBe(5);
+
     // Roll 9 — passes TN 5 (piloting). resolveAllPSRs internally calls
     // d6Roller twice (taking dice[0] each time), so the mock must
     // return two rolls whose dice[0] values sum to the desired total.
@@ -218,6 +226,16 @@ describe('wire-piloting-skill-rolls — smoke test', () => {
       (e: IGameEvent) => e.type === GameEventType.UnitFell,
     );
     expect(fellEvents).toHaveLength(1);
+
+    // Per `denormalize-event-envelope-and-close-emission-contract-gaps`
+    // (piloting-skill-rolls delta — UnitFell Carries Location and Reason):
+    // the failed-PSR-induced fall MUST carry both `location` and `reason`
+    // on the payload. Location defaults to `'center_torso'`; reason
+    // mirrors the failed PSR's reason string.
+    const fellPayload = fellEvents[0].payload as IUnitFellPayload;
+    expect(fellPayload.location).toBe('center_torso');
+    expect(typeof fellPayload.reason).toBe('string');
+    expect(fellPayload.reason!.length).toBeGreaterThan(0);
 
     const pilotHits = session.events.filter(
       (e: IGameEvent) => e.type === GameEventType.PilotHit,

--- a/src/simulation/__tests__/atlasMirrorEventChain.integration.test.ts
+++ b/src/simulation/__tests__/atlasMirrorEventChain.integration.test.ts
@@ -394,4 +394,48 @@ describe('Atlas-vs-Atlas event chain — P2 (task 2.7)', () => {
     // End-of-run: every declared shot has a matching resolved.
     expect(pendingResolved).toBe(false);
   });
+
+  it('envelope side is denormalized from actorId on every player-actored event', async () => {
+    // Per `denormalize-event-envelope-and-close-emission-contract-gaps`
+    // (game-event-system delta — Event Envelope Side Denormalization):
+    // events authored by `player-1` MUST land with `side === Player`,
+    // events authored by `opponent-1` MUST land with `side === Opponent`,
+    // and system-authored events (no actorId) MUST omit `side`.
+    const hydration = await buildAtlasMirrorHydration();
+    const config: ISimulationConfig = {
+      seed: 12345,
+      turnLimit: 5,
+      unitCount: { player: 1, opponent: 1 },
+      mapRadius: 4,
+    };
+    const runner = new SimulationRunner(
+      config.seed,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      hydration,
+    );
+    const result = runner.run(config);
+
+    const playerEvents = result.events.filter((e) => e.actorId === 'player-1');
+    const opponentEvents = result.events.filter(
+      (e) => e.actorId === 'opponent-1',
+    );
+    const systemEvents = result.events.filter((e) => e.actorId === undefined);
+
+    expect(playerEvents.length).toBeGreaterThan(0);
+    expect(opponentEvents.length).toBeGreaterThan(0);
+    expect(systemEvents.length).toBeGreaterThan(0);
+
+    for (const e of playerEvents) {
+      expect(e.side).toBe(GameSide.Player);
+    }
+    for (const e of opponentEvents) {
+      expect(e.side).toBe(GameSide.Opponent);
+    }
+    for (const e of systemEvents) {
+      expect(e.side).toBeUndefined();
+    }
+  });
 });

--- a/src/simulation/metrics/MetricsCollector.ts
+++ b/src/simulation/metrics/MetricsCollector.ts
@@ -37,6 +37,15 @@ import { IAggregateMetrics, ISimulationMetrics } from './types';
  * don't follow the canonical `player-` / `opponent-` prefix (e.g.,
  * test fixtures with synthetic ids); those units don't contribute to
  * either side's roster count.
+ *
+ * Per `denormalize-event-envelope-and-close-emission-contract-gaps`: the
+ * canonical source for an event's side is now `IGameEventBase.side`,
+ * populated by `createGameEvent` (and `createEventBase`) at emission
+ * time. This function is retained as a fallback for replaying legacy
+ * NDJSON event streams written before the envelope-denormalization
+ * landed — `MetricsCollector` still uses it against `payload.unitId`
+ * because some payloads describe a target side rather than the actor's
+ * side, and unit-id is the unambiguous source there.
  */
 function sideFromUnitId(unitId: string): 'player' | 'opponent' | null {
   if (unitId.startsWith('player-')) return 'player';

--- a/src/simulation/runner/phases/__tests__/utils.test.ts
+++ b/src/simulation/runner/phases/__tests__/utils.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for `createGameEvent` per
+ * `denormalize-event-envelope-and-close-emission-contract-gaps`
+ * (game-event-system delta — Event Envelope Side Denormalization).
+ *
+ * The spec contract:
+ *   - `actorId` starting with `'player-'` → envelope SHALL carry
+ *     `side: GameSide.Player`.
+ *   - `actorId` starting with `'opponent-'` → envelope SHALL carry
+ *     `side: GameSide.Opponent`.
+ *   - `actorId` undefined or unmatched prefix → envelope SHALL omit
+ *     `side` (system-authored events such as `turn_started`).
+ *
+ * These assertions guard the single-chokepoint derivation that lets
+ * every emit site land with `side` denormalized without joining
+ * `payload.unitId` against `IGameUnit.side`.
+ */
+
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IDamageAppliedPayload,
+  ITurnStartedPayload,
+} from '@/types/gameplay';
+
+import { createGameEvent } from '../utils';
+
+describe('createGameEvent — side denormalization', () => {
+  const baseDamagePayload: IDamageAppliedPayload = {
+    unitId: 'player-1',
+    location: 'center_torso',
+    damage: 5,
+    armorRemaining: 15,
+    structureRemaining: 10,
+    locationDestroyed: false,
+    sourceUnitId: 'opponent-2',
+  };
+
+  const baseTurnStarted: ITurnStartedPayload = {};
+
+  it('derives side=Player from a player-prefixed actorId', () => {
+    const event = createGameEvent(
+      'game-1',
+      0,
+      GameEventType.DamageApplied,
+      1,
+      GamePhase.WeaponAttack,
+      baseDamagePayload,
+      'player-1',
+    );
+
+    expect(event.side).toBe(GameSide.Player);
+    expect(event.actorId).toBe('player-1');
+  });
+
+  it('derives side=Opponent from an opponent-prefixed actorId', () => {
+    const event = createGameEvent(
+      'game-1',
+      1,
+      GameEventType.AttackResolved,
+      1,
+      GamePhase.WeaponAttack,
+      baseDamagePayload,
+      'opponent-2',
+    );
+
+    expect(event.side).toBe(GameSide.Opponent);
+    expect(event.actorId).toBe('opponent-2');
+  });
+
+  it('omits side for system-authored events with no actorId', () => {
+    const event = createGameEvent(
+      'game-1',
+      2,
+      GameEventType.TurnStarted,
+      2,
+      GamePhase.Initiative,
+      baseTurnStarted,
+      // no actorId
+    );
+
+    expect(event.side).toBeUndefined();
+    expect(event.actorId).toBeUndefined();
+    // Contract: JSON.stringify omits undefined properties so the field
+    // does not appear in serialized event-log lines.
+    expect(JSON.stringify(event)).not.toContain('"side"');
+  });
+
+  it('omits side when actorId has no canonical prefix', () => {
+    const event = createGameEvent(
+      'game-1',
+      3,
+      GameEventType.DamageApplied,
+      1,
+      GamePhase.WeaponAttack,
+      { ...baseDamagePayload, unitId: 'fixture-99' },
+      'fixture-99',
+    );
+
+    expect(event.side).toBeUndefined();
+    expect(event.actorId).toBe('fixture-99');
+  });
+
+  it('preserves the rest of the envelope (id / sequence / type / turn / phase / payload)', () => {
+    const event = createGameEvent(
+      'game-7',
+      42,
+      GameEventType.DamageApplied,
+      3,
+      GamePhase.PhysicalAttack,
+      baseDamagePayload,
+      'player-1',
+    );
+
+    expect(event.id).toBe('game-7-evt-42');
+    expect(event.gameId).toBe('game-7');
+    expect(event.sequence).toBe(42);
+    expect(event.type).toBe(GameEventType.DamageApplied);
+    expect(event.turn).toBe(3);
+    expect(event.phase).toBe(GamePhase.PhysicalAttack);
+    expect(event.payload).toEqual(baseDamagePayload);
+    expect(event.side).toBe(GameSide.Player);
+    // ISO-8601 timestamp parses as a valid date.
+    expect(Number.isFinite(Date.parse(event.timestamp))).toBe(true);
+  });
+});

--- a/src/simulation/runner/phases/postCombat.ts
+++ b/src/simulation/runner/phases/postCombat.ts
@@ -99,6 +99,13 @@ export function runPSRPhase(options: {
         },
       };
 
+      // Per `denormalize-event-envelope-and-close-emission-contract-gaps`
+      // (piloting-skill-rolls delta — UnitFell Carries Location and Reason):
+      // pull the failing-PSR reason from batchResult; default location is
+      // `'center_torso'` (canonical fall-damage location for damage-induced
+      // PSR failures — PR E tightens this to a per-trigger discriminated
+      // location once `PSRReasonCode` lands).
+      const failedPsr = batchResult.results.find((r) => !r.passed);
       events.push(
         createGameEvent(
           gameId,
@@ -109,6 +116,8 @@ export function runPSRPhase(options: {
           {
             unitId,
             pilotDamage: 1,
+            location: 'center_torso',
+            ...(failedPsr ? { reason: failedPsr.psr.reason } : {}),
           },
           unitId,
         ),

--- a/src/simulation/runner/phases/utils.ts
+++ b/src/simulation/runner/phases/utils.ts
@@ -1,10 +1,37 @@
-import { GameEventType, GamePhase, IGameEvent } from '@/types/gameplay';
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IGameEvent,
+} from '@/types/gameplay';
 import { D6Roller } from '@/utils/gameplay/hitLocation';
 
 import { SeededRandom } from '../../core/SeededRandom';
 
 export function createD6Roller(random: SeededRandom): D6Roller {
   return () => Math.floor(random.next() * 6) + 1;
+}
+
+/**
+ * Per `denormalize-event-envelope-and-close-emission-contract-gaps`
+ * (game-event-system delta — Event Envelope Side Denormalization): derive
+ * the `side` field from the `actorId` prefix using the same lookup the
+ * runner already uses for its `player-N` / `opponent-N` unit ids. This is
+ * the canonical chokepoint — `createGameEvent` is the single emission
+ * builder used by every runner phase, so populating `side` here means
+ * every event lands on the wire with side already denormalized.
+ *
+ * Returns `undefined` for ids that don't match either prefix (system
+ * events with no actor, or test fixtures with synthetic ids); the
+ * envelope omits the field in that case so consumers can fall back to
+ * `MetricsCollector.sideFromUnitId` if they need to derive it from
+ * `payload.unitId` instead.
+ */
+function deriveSide(actorId: string | undefined): GameSide | undefined {
+  if (!actorId) return undefined;
+  if (actorId.startsWith('player-')) return GameSide.Player;
+  if (actorId.startsWith('opponent-')) return GameSide.Opponent;
+  return undefined;
 }
 
 export function createGameEvent(
@@ -16,6 +43,7 @@ export function createGameEvent(
   payload: IGameEvent['payload'],
   actorId?: string,
 ): IGameEvent {
+  const side = deriveSide(actorId);
   return {
     id: `${gameId}-evt-${sequence}`,
     gameId,
@@ -26,5 +54,6 @@ export function createGameEvent(
     phase,
     payload,
     ...(actorId !== undefined ? { actorId } : {}),
+    ...(side !== undefined ? { side } : {}),
   };
 }

--- a/src/simulation/runner/phases/weaponAttack.ts
+++ b/src/simulation/runner/phases/weaponAttack.ts
@@ -214,6 +214,15 @@ function emitCritEvents(options: {
   targetId: string;
   critEvents: readonly CriticalHitEvent[];
   targetAlreadyDestroyed: boolean;
+  /**
+   * Per `denormalize-event-envelope-and-close-emission-contract-gaps`
+   * (piloting-skill-rolls delta — PSRTriggered Carries Base Skill): the
+   * target's base piloting skill, threaded onto each emitted
+   * `psr_triggered` event so consumers don't have to join back to the
+   * unit record. Optional for back-compat with synthetic-unit fixtures
+   * that don't seed `IUnitGameState.piloting`.
+   */
+  targetPilotingSkill?: number;
 }): {
   unitDestroyed: boolean;
   destructionCause:
@@ -234,6 +243,7 @@ function emitCritEvents(options: {
     targetId,
     critEvents,
     targetAlreadyDestroyed,
+    targetPilotingSkill,
   } = options;
 
   let unitDestroyed = false;
@@ -338,6 +348,9 @@ function emitCritEvents(options: {
             reason: p.reason,
             additionalModifier: p.additionalModifier,
             triggerSource: p.triggerSource,
+            ...(targetPilotingSkill !== undefined
+              ? { basePilotingSkill: targetPilotingSkill }
+              : {}),
           },
           attackerId,
         ),
@@ -990,6 +1003,7 @@ export function runAttackPhase(options: {
           targetId,
           critEvents: damageResult.criticalEvents,
           targetAlreadyDestroyed: targetBefore.destroyed,
+          targetPilotingSkill: targetBefore.piloting,
         });
         critUnitDestroyed = emitted.unitDestroyed;
         critDestructionCause = emitted.destructionCause;

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -336,6 +336,13 @@ export interface IGameEventBase {
   readonly actorId?: string;
   /** Fog-of-war delivery class used by multiplayer event filtering. */
   readonly visibility?: GameEventVisibility;
+  /**
+   * Side denormalization. Derived from `actorId` at emission time by
+   * `createGameEvent` so consumers can filter/display side without joining
+   * unitId to IGameUnit.side. Optional for back-compat with NDJSON event
+   * streams written before this denormalization landed.
+   */
+  readonly side?: GameSide;
 }
 
 /**
@@ -369,6 +376,11 @@ export interface IGameEndedPayload {
     | 'turn_limit'
     | 'objective'
     | 'aborted';
+  /**
+   * Final turn count when the game ended. Optional for back-compat with
+   * NDJSON event streams written before this field was populated.
+   */
+  readonly turns?: number;
 }
 
 /**
@@ -851,6 +863,16 @@ export interface IPSRTriggeredPayload {
   readonly reason: string;
   readonly additionalModifier: number;
   readonly triggerSource: string;
+  /**
+   * The unit's pilot piloting skill BEFORE per-trigger and cumulative
+   * modifiers (i.e. the raw value from `IGameUnit.piloting`). Consumers
+   * use this to render the full PSR target-number arithmetic
+   * (`basePilotingSkill + additionalModifier + cumulative-mods = TN`)
+   * without separately joining to the unit record. Optional for
+   * back-compat with NDJSON event streams written before this field
+   * landed.
+   */
+  readonly basePilotingSkill?: number;
 }
 
 export interface IPSRResolvedPayload {
@@ -877,6 +899,23 @@ export interface IUnitFellPayload {
    * the fall direction + per-cluster hit-location rolls. OPTIONAL.
    */
   readonly rolls?: readonly number[];
+  /**
+   * Location at which the fall happened (e.g. `'left_leg'`, `'center_torso'`,
+   * or a hex-coordinate string when the trigger was terrain). Sourced from
+   * the PSR resolution context that caused the fall. Optional for
+   * back-compat with NDJSON event streams written before this field
+   * landed.
+   */
+  readonly location?: string;
+  /**
+   * Free-string reason describing the fall cause (e.g. `'gyro-hit'`,
+   * `'took-20-damage'`). PR E (`structure-psr-reason-as-discriminated-code`)
+   * tightens this to a `PSRReasonCode` discriminated union; for now it is
+   * deliberately string-typed to remain compatible with the existing
+   * free-form PSR reason strings emitted by the runner. Optional for
+   * back-compat.
+   */
+  readonly reason?: string;
 }
 
 /**

--- a/src/utils/gameplay/__tests__/gameEvents.test.ts
+++ b/src/utils/gameplay/__tests__/gameEvents.test.ts
@@ -192,10 +192,17 @@ describe('Lifecycle Event Factories', () => {
       const payload = event.payload as {
         winner: GameSide | 'draw';
         reason: string;
+        turns?: number;
       };
 
       expect(payload.winner).toBe(GameSide.Opponent);
       expect(payload.reason).toBe('concede');
+      // Per `denormalize-event-envelope-and-close-emission-contract-gaps`
+      // (game-event-system delta — backfill `IGameEndedPayload.turns`):
+      // the final turn count threads through from the `turn` parameter
+      // so summary consumers can read it directly without scanning the
+      // turn-lifecycle events.
+      expect(payload.turns).toBe(5);
     });
 
     it('should handle draw result', () => {

--- a/src/utils/gameplay/gameEvents/base.ts
+++ b/src/utils/gameplay/gameEvents/base.ts
@@ -2,11 +2,28 @@ import { v4 as uuidv4 } from 'uuid';
 
 import type { IGameEventBase } from '@/types/gameplay';
 
-import { GameEventType, GamePhase } from '@/types/gameplay';
+import { GameEventType, GamePhase, GameSide } from '@/types/gameplay';
 import { classifyGameEventVisibility } from '@/utils/gameplay/gameEventVisibility';
 
 export function generateEventId(): string {
   return uuidv4();
+}
+
+/**
+ * Per `denormalize-event-envelope-and-close-emission-contract-gaps`
+ * (game-event-system delta — Event Envelope Side Denormalization): mirror
+ * `createGameEvent`'s `actorId` → `side` derivation here so the
+ * non-runner emit paths (lifecycle / status / movement helpers) also land
+ * with `side` populated on the envelope. The two builders use the same
+ * `'player-'` / `'opponent-'` prefix rules; legacy `MetricsCollector.sideFromUnitId`
+ * remains the fallback for replaying NDJSON streams written before this
+ * change.
+ */
+function deriveSide(actorId: string | undefined): GameSide | undefined {
+  if (!actorId) return undefined;
+  if (actorId.startsWith('player-')) return GameSide.Player;
+  if (actorId.startsWith('opponent-')) return GameSide.Opponent;
+  return undefined;
 }
 
 export function createEventBase(
@@ -17,6 +34,7 @@ export function createEventBase(
   phase: GamePhase,
   actorId?: string,
 ): IGameEventBase {
+  const side = deriveSide(actorId);
   return {
     id: generateEventId(),
     gameId,
@@ -27,5 +45,6 @@ export function createEventBase(
     phase,
     actorId,
     visibility: classifyGameEventVisibility({ type }),
+    ...(side !== undefined ? { side } : {}),
   };
 }

--- a/src/utils/gameplay/gameEvents/lifecycle.ts
+++ b/src/utils/gameplay/gameEvents/lifecycle.ts
@@ -56,7 +56,11 @@ export function createGameEndedEvent(
   winner: GameSide | 'draw',
   reason: 'destruction' | 'concede' | 'turn_limit' | 'objective' | 'aborted',
 ): IGameEvent {
-  const payload: IGameEndedPayload = { winner, reason };
+  // Per `denormalize-event-envelope-and-close-emission-contract-gaps`
+  // (game-event-system / piloting-skill-rolls deltas): backfill the final
+  // turn count onto `IGameEndedPayload.turns` so summary consumers don't
+  // have to re-derive it from the last `turn_started` event.
+  const payload: IGameEndedPayload = { winner, reason, turns: turn };
   return {
     ...createEventBase(gameId, sequence, GameEventType.GameEnded, turn, phase),
     payload,

--- a/src/utils/gameplay/gameEvents/status.ts
+++ b/src/utils/gameplay/gameEvents/status.ts
@@ -234,12 +234,14 @@ export function createPSRTriggeredEvent(
   reason: string,
   additionalModifier: number,
   triggerSource: string,
+  basePilotingSkill?: number,
 ): IGameEvent {
   const payload: IPSRTriggeredPayload = {
     unitId,
     reason,
     additionalModifier,
     triggerSource,
+    ...(basePilotingSkill !== undefined ? { basePilotingSkill } : {}),
   };
 
   return {
@@ -298,12 +300,16 @@ export function createUnitFellEvent(
   fallDamage: number,
   newFacing: Facing,
   pilotDamage: number,
+  location?: string,
+  reason?: string,
 ): IGameEvent {
   const payload: IUnitFellPayload = {
     unitId,
     fallDamage,
     newFacing,
     pilotDamage,
+    ...(location !== undefined ? { location } : {}),
+    ...(reason !== undefined ? { reason } : {}),
   };
 
   return {

--- a/src/utils/gameplay/gameSessionAttackResolution.ts
+++ b/src/utils/gameplay/gameSessionAttackResolution.ts
@@ -379,6 +379,12 @@ export function resolveAttack(
         }
       }
 
+      // Per `denormalize-event-envelope-and-close-emission-contract-gaps`
+      // (piloting-skill-rolls delta — PSRTriggered Carries Base Skill):
+      // look up the target's base piloting skill once for both the
+      // leg-damage and 20+damage PSR triggers below.
+      const targetUnit = currentSession.units.find((u) => u.id === targetId);
+
       for (const locationDamage of damageResult.result.locationDamages) {
         if (
           isLegLocation(locationDamage.location) &&
@@ -396,6 +402,7 @@ export function resolveAttack(
               'Leg damage (internal structure exposed)',
               0,
               'leg_damage',
+              targetUnit?.piloting,
             ),
           );
           break;
@@ -424,6 +431,7 @@ export function resolveAttack(
             '20+ damage this phase',
             0,
             'phase_damage_20_plus',
+            targetUnit?.piloting,
           ),
         );
       }

--- a/src/utils/gameplay/gameSessionAttackResolutionHelpers.ts
+++ b/src/utils/gameplay/gameSessionAttackResolutionHelpers.ts
@@ -89,6 +89,11 @@ export function emitCriticalEvents(
 
     if (event.type === 'psr_triggered') {
       const payload = event.payload;
+      // Per `denormalize-event-envelope-and-close-emission-contract-gaps`
+      // (piloting-skill-rolls delta — PSRTriggered Carries Base Skill):
+      // pass the unit's base piloting skill so consumers can render the
+      // full PSR target-number arithmetic.
+      const psrUnit = currentSession.units.find((u) => u.id === payload.unitId);
       currentSession = appendEvent(
         currentSession,
         createPSRTriggeredEvent(
@@ -100,6 +105,7 @@ export function emitCriticalEvents(
           payload.reason,
           payload.additionalModifier,
           payload.triggerSource,
+          psrUnit?.piloting,
         ),
       );
       continue;

--- a/src/utils/gameplay/gameSessionHeat.ts
+++ b/src/utils/gameplay/gameSessionHeat.ts
@@ -293,6 +293,7 @@ export function resolveHeatPhase(
           'Reactor shutdown',
           0,
           'heat_shutdown',
+          unit?.piloting,
         ),
       );
     } else {
@@ -330,6 +331,7 @@ export function resolveHeatPhase(
               'Reactor shutdown',
               0,
               'heat_shutdown',
+              unit?.piloting,
             ),
           );
         }

--- a/src/utils/gameplay/gameSessionPSR.ts
+++ b/src/utils/gameplay/gameSessionPSR.ts
@@ -30,6 +30,12 @@ export function checkAndQueueDamagePSRs(session: IGameSession): IGameSession {
     const damagePSR = checkPhaseDamagePSR(unitState);
     if (damagePSR) {
       const sequence = currentSession.events.length;
+      // Per `denormalize-event-envelope-and-close-emission-contract-gaps`
+      // (piloting-skill-rolls delta): carry the unit's base piloting
+      // skill onto the trigger event so consumers can render the full
+      // PSR target-number arithmetic without joining to the unit
+      // record. `IGameUnit.piloting` is the unmodified skill value.
+      const unit = currentSession.units.find((entry) => entry.id === unitId);
       currentSession = appendEvent(
         currentSession,
         createPSRTriggeredEvent(
@@ -41,6 +47,7 @@ export function checkAndQueueDamagePSRs(session: IGameSession): IGameSession {
           damagePSR.reason,
           damagePSR.additionalModifier,
           damagePSR.triggerSource,
+          unit?.piloting,
         ),
       );
     }
@@ -105,6 +112,12 @@ export function resolvePendingPSRs(
         );
       }
 
+      // Per `denormalize-event-envelope-and-close-emission-contract-gaps`
+      // (piloting-skill-rolls delta — UnitFell Carries Location and Reason):
+      // a destroyed gyro forces an automatic fall; canonical location is
+      // `'center_torso'` (where the gyro lives on standard mechs) and the
+      // reason is the gyro-hit trigger. Fallback to the first pending
+      // PSR's reason if for some reason the queue is empty.
       const fellSequence = currentSession.events.length;
       currentSession = appendEvent(
         currentSession,
@@ -117,6 +130,8 @@ export function resolvePendingPSRs(
           fallResult.totalDamage,
           fallResult.newFacing,
           fallResult.pilotDamage,
+          'center_torso',
+          pendingPSRs[0]?.reason ?? 'gyro_destroyed',
         ),
       );
 
@@ -196,6 +211,13 @@ export function resolvePendingPSRs(
     if (batchResult.unitFell) {
       const fallResult = resolveFall(50, unitState.facing, 0, d6Roller);
 
+      // Per `denormalize-event-envelope-and-close-emission-contract-gaps`
+      // (piloting-skill-rolls delta — UnitFell Carries Location and Reason):
+      // pick the first FAILED PSR's reason as the canonical fall reason;
+      // location defaults to `'center_torso'` (the failed-PSR pathway
+      // doesn't carry a per-trigger location today — PR E tightens this
+      // when reasons become a discriminated `PSRReasonCode`).
+      const failedPsr = batchResult.results.find((r) => !r.passed);
       const fellSequence = currentSession.events.length;
       currentSession = appendEvent(
         currentSession,
@@ -208,6 +230,8 @@ export function resolvePendingPSRs(
           fallResult.totalDamage,
           fallResult.newFacing,
           fallResult.pilotDamage,
+          'center_torso',
+          failedPsr?.psr.reason ?? pendingPSRs[0]?.reason,
         ),
       );
 
@@ -275,6 +299,7 @@ export function attemptStandUp(
       psr.reason,
       psr.additionalModifier,
       psr.triggerSource,
+      unit.piloting,
     ),
   );
 

--- a/src/utils/gameplay/gameSessionPhysical.ts
+++ b/src/utils/gameplay/gameSessionPhysical.ts
@@ -457,6 +457,15 @@ export function resolveAllPhysicalAttacks(
     // PSR queueing: target gets PhysicalAttackTarget on hit; attacker
     // gets the per-attack-type miss PSR on miss. Per task 6.6 / 7.5,
     // charge + DFA hits queue PSRs for BOTH attacker and target.
+    //
+    // Per `denormalize-event-envelope-and-close-emission-contract-gaps`
+    // (piloting-skill-rolls delta — PSRTriggered Carries Base Skill):
+    // pass the unit's base piloting skill (looked up from `IGameUnit`).
+    // For the attacker the runner already has `context.pilotingSkill`;
+    // for the target we look it up from `currentSession.units`.
+    const targetUnit = currentSession.units.find(
+      (u) => u.id === payload.targetId,
+    );
     if (result.hit && result.targetPSR) {
       const psrSeq = currentSession.events.length;
       currentSession = appendEvent(
@@ -470,6 +479,7 @@ export function resolveAllPhysicalAttacks(
           'Hit by physical attack',
           0,
           'physical_attack_target',
+          targetUnit?.piloting,
         ),
       );
     }
@@ -495,6 +505,7 @@ export function resolveAllPhysicalAttacks(
           `Hit ${payload.attackType}`,
           result.attackerPSRModifier,
           attackerHitTrigger,
+          context.pilotingSkill,
         ),
       );
     }
@@ -519,6 +530,7 @@ export function resolveAllPhysicalAttacks(
           `Missed ${payload.attackType}`,
           result.attackerPSRModifier,
           triggerSource,
+          context.pilotingSkill,
         ),
       );
     }


### PR DESCRIPTION
## Summary

PR 2 of 5 in the event-log line-format series (per `yes-please-go-ahead-squishy-bumblebee.md`). Implements the OpenSpec change [`denormalize-event-envelope-and-close-emission-contract-gaps`](../tree/event-log/pr-b-envelope-and-emission-contracts/openspec/changes/denormalize-event-envelope-and-close-emission-contract-gaps).

Two pain points closed:

1. **Side derivation duplication.** Every consumer (metrics, scenario tests, the readable formatter, future UI replays) was reinventing the `'player-' / 'opponent-'` prefix lookup that `MetricsCollector.sideFromUnitId` already does. `IGameEventBase.side` is now denormalized from `actorId` at emission time via the single chokepoint (`createGameEvent` in the runner + `createEventBase` for non-runner emit paths). 94 emit sites pick this up automatically — no per-call-site edits.
2. **Schema gaps the readable formatter expects.** `IPSRTriggeredPayload.basePilotingSkill`, `IUnitFellPayload.{location,reason}`, and `IGameEndedPayload.turns` now exist on the runner's payloads. Every emit site that has the data threads it through.

Plus 4 emission-contract spec extensions (no behavior change — they name lifecycle events the runner already emits so spec-verifier can guard against future regressions).

## Type changes

- `IGameEventBase.side?: GameSide`
- `IPSRTriggeredPayload.basePilotingSkill?: number`
- `IUnitFellPayload.location?: string` + `reason?: string` (free-string; PR E tightens to `PSRReasonCode`)
- `IGameEndedPayload.turns?: number`

All optional — legacy NDJSON streams replay unchanged.

## Single-chokepoint side derivation

`createGameEvent` (runner) + `createEventBase` (lifecycle / status helpers) now derive `side` from `actorId` using the same prefix rules `MetricsCollector.sideFromUnitId` uses. The legacy collector function stays as a fallback for replaying NDJSON streams written before this change.

## Spec extensions

- `game-event-system`: Event Envelope Side Denormalization, Turn Lifecycle Event Emission, Initiative Event Emission
- `combat-resolution`: AttackResolved Side-Effect Chain Ordering
- `damage-system`: DamageApplied Emission Contract
- `piloting-skill-rolls`: PSRTriggered Carries Base Skill, UnitFell Carries Location and Reason

These spec deltas lock in event-emission contracts the runner already meets after the combat-fidelity-suite landings (PRs #517–528).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 errors)
- [x] `npm test` green — 23394/23442 passing (48 pre-skipped)
- [x] `npx openspec validate denormalize-event-envelope-and-close-emission-contract-gaps --strict` clean
- [x] New `src/simulation/runner/phases/__tests__/utils.test.ts` exercises all three branches of the chokepoint derivation (player / opponent / system-no-actor)
- [x] Existing atlas-mirror integration test asserts envelope `side` per actor across a full 5-turn run
- [x] `wirePilotingSkillRolls.smoke.test.ts` asserts `basePilotingSkill` on PSRTriggered and `{location,reason}` on UnitFell
- [x] `gameEvents.test.ts` asserts `game_ended.turns` matches the final turn count