### PR TITLE
feat(event-log): enrich movement_declared with step chain + displacement decomposition + coordToBoardLabel utility

### DIFF
--- a/openspec/changes/enrich-movement-declared-with-chain-and-displacement/.openspec.yaml
+++ b/openspec/changes/enrich-movement-declared-with-chain-and-displacement/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/enrich-movement-declared-with-chain-and-displacement/proposal.md
+++ b/openspec/changes/enrich-movement-declared-with-chain-and-displacement/proposal.md
@@ -1,0 +1,66 @@
+# Enrich movement_declared with step chain + displacement breakdown
+
+## Why
+
+The user's brief asks for:
+
+> What force attacked, what player attacked, what unit attacked, unit moved from what hex to what hex, how much was straight movement, how much movement was spent turning, any piloting checks you had to do for movement to check for slides, total actual displacement for evasion bonuses for the round, movement in a straight line for charges, etc.
+
+Today `IMovementDeclaredPayload` carries `from`, `to`, `path`, `mpUsed`, `facing`, `movementType`, `heatGenerated`. That covers source/destination but not the *chain*: how many hexes were forward, how many MP went to facing changes, where mid-move PSRs fired, and whether the move qualifies as a charge (straight line ≥ 3 hexes through to a target).
+
+Cross-referencing MegaMek's `MoveStepType` enum (`E:/Projects/megamek/megamek/src/megamek/common/enums/MoveStepType.java`), the canonical step taxonomy is `FORWARDS / BACKWARDS / TURN_LEFT / TURN_RIGHT / START_JUMP / LATERAL_LEFT / LATERAL_RIGHT / GET_UP / GO_PRONE / CHARGE / DFA / SHAKE_OFF_SWARMERS / HULL_DOWN / CLIMB_MODE_ON / CLIMB_MODE_OFF`. The runner already walks a `MoveStep[]` internally during movement resolution; this change exposes that walk to the event log so consumers can audit per-step MP cost, terrain transitions, and per-step PSR triggers.
+
+## What
+
+### Code changes
+
+1. Add five fields to `IMovementDeclaredPayload`:
+   - `hexesMoved?: number` — total hex transitions (path.length - 1)
+   - `straightHexes?: number` — hexes entered without facing change (forward + backward + lateral)
+   - `turningMpCost?: number` — MP spent on facing changes (`mpUsed - straightHexes` minus jump/special-step costs)
+   - `netDisplacement?: number` — `hexDistance(from, to)` (already used for TMM; just denormalized into the event)
+   - `steps?: readonly IMovementStep[]` — the step chain
+
+2. Add a discriminated `IMovementStep` union covering the BattleMech ground-combat subset of MegaMek's `MoveStepType`:
+
+```ts
+export type IMovementStep =
+  | IForwardStep        // FORWARDS / BACKWARDS — counts toward straightHexes
+  | ITurnStep           // TURN_LEFT / TURN_RIGHT — costs 1 MP per facing
+  | ILateralStep        // LATERAL_LEFT / LATERAL_RIGHT — sideslip (skid resolution)
+  | IJumpStep           // START_JUMP segment
+  | IStandUpStep        // GET_UP — costs 2 MP, triggers AttemptStand PSR
+  | IGoProneStep        // GO_PRONE — voluntary prone (charge / DFA setup)
+  | IChargeDeclaredStep // CHARGE — physical-attack handoff
+  | IDfaDeclaredStep    // DFA — physical-attack handoff
+  | IShakeOffSwarmStep; // SHAKE_OFF_SWARMERS
+```
+
+Each step carries: `index` (0-based ordinal), `at` or `from`/`to` hex, `mpCost`, and (where applicable) `terrainEntered` / `elevationDelta` / `fromFacing`/`toFacing`.
+
+3. Mid-move PSR events fire as their own `psr_triggered` events (already do), but stamp `triggerSource = 'movement-step:<index>'` so consumers can audit which step caused the slide / fall / leg-damage check.
+
+4. Add a TypeScript hex-coordinate utility `coordToBoardLabel(coord: IHexCoordinate): string` in `src/utils/gameplay/hexMath.ts` — axial `(q, r)` → MegaMek 4-digit `NNNN` notation, mirror of the Python helper from PR A. Existing `hexDistance` (line 111) and `axialToOffset` get the call wired through.
+
+### Spec extensions
+
+- `movement-system`: ADD `Requirement: Movement Phase Step Chain Emission` (the `steps` array contract — every committed move emits its chain in `IMovementStep` discriminated form); ADD `Requirement: Movement Decomposition Fields` (hexesMoved / straightHexes / turningMpCost / netDisplacement contracts).
+- `piloting-skill-rolls`: ADD `Requirement: Movement-Step PSR Trigger Source Stamping` (PSRs fired during movement carry `triggerSource = 'movement-step:<index>'`).
+
+## Impact
+
+- **Affected types**: `IMovementDeclaredPayload`, new `IMovementStep` union and 9 step interfaces.
+- **Affected code**: `src/types/gameplay/GameSessionInterfaces.ts:447`, `src/utils/gameplay/hexMath.ts` (new `coordToBoardLabel`), `src/simulation/runner/phases/movement.ts` (emits steps array), `src/utils/gameplay/movement/eventPath.ts` (path walker decomposes MP), PSR emit sites near movement resolution (stamp `triggerSource`).
+- **Affected specs**: `movement-system`, `piloting-skill-rolls`.
+- **Risk**: low. Every new field is OPTIONAL; legacy event streams replay unchanged. The step decomposition is pure derivation from data the runner already has (`path` + per-hex terrain + facing transitions).
+- **Visible improvement**: the readable companion (rewritten in PR D) can render a move as:
+  ```
+  MOVE player-1 atlas: 0011→0509 mp=5(s4+t1) disp=4 [F→F→F→TR→F]
+  ```
+
+## Out of scope
+
+- New event types for terrain damage applied mid-move (`magma_damage_applied`, `hazardous_liquid_damage_applied`, `building_rubble_damage_applied`) — handed off to the named follow-on `add-mid-move-terrain-damage-events`.
+- Skid resolution (sideslip path computation, domino fall chain) — `add-skid-and-displacement-events`.
+- `forceId` as a domain concept above `GameSide` — deferred.
+- PSR reason discriminated enum — PR E.

--- a/openspec/changes/enrich-movement-declared-with-chain-and-displacement/specs/movement-system/spec.md
+++ b/openspec/changes/enrich-movement-declared-with-chain-and-displacement/specs/movement-system/spec.md
@@ -1,0 +1,104 @@
+## ADDED Requirements
+
+### Requirement: Movement Phase Step Chain Emission
+
+The simulation runner SHALL emit every committed move as a `movement_declared` event whose payload carries a `steps` array — the chain of micro-moves the unit executed in order. Each entry in the array SHALL be one of the discriminated `IMovementStep` variants:
+
+- `'forward'` — straight movement (FORWARDS or BACKWARDS); carries `from`, `to`, `mpCost`, `terrainEntered`, `elevationDelta`, and a `direction: 'forward' | 'backward'` discriminator.
+- `'turn'` — facing change (TURN_LEFT or TURN_RIGHT); carries `at`, `fromFacing`, `toFacing`, `mpCost`.
+- `'lateral'` — sideslip (LATERAL_LEFT, LATERAL_RIGHT, LATERAL_LEFT_BACKWARDS, LATERAL_RIGHT_BACKWARDS); carries `from`, `to`, `mpCost`, `direction`.
+- `'jump'` — jump segment (one event per START_JUMP committed); carries `from`, `to`, `mpCost`, `terrainEntered`.
+- `'standUp'` — GET_UP; carries `at`, `mpCost` (typically 2), `psrTriggered: boolean`.
+- `'goProne'` — voluntary prone; carries `at`, `mpCost`.
+- `'chargeDeclared'` — CHARGE physical-attack declaration handoff; carries `at`, `targetId`, `straightLineHexes`.
+- `'dfaDeclared'` — DFA physical-attack declaration handoff; carries `at`, `targetId`, `jumpHeight`.
+- `'shakeOffSwarm'` — SHAKE_OFF_SWARMERS; carries `at`, `psrTriggered: boolean`.
+
+Every step SHALL include `index: number` (0-based ordinal within the move) so consumers can correlate per-step PSR events back to the originating step.
+
+The `steps` array is OPTIONAL on `IMovementDeclaredPayload` for back-compat — NDJSON event streams written before this change SHALL replay unchanged.
+
+The runner MAY skip emitting a step type that is not yet implemented in the engine (e.g. SHAKE_OFF_SWARMERS in early scenarios), but SHALL NOT emit a step type with a kind discriminator that is not in the `IMovementStep` union.
+
+#### Scenario: A walk-only move emits forward steps and turn steps in commit order
+
+- **GIVEN** a unit committing a 5-MP walk that consists of: forward 2 hexes, turn right, forward 2 hexes, turn right, forward 1 hex
+- **WHEN** the runner emits the `movement_declared` event
+- **THEN** `payload.steps` SHALL be exactly:
+  ```
+  [{kind:'forward', index:0, ...}, {kind:'forward', index:1, ...},
+   {kind:'turn', index:2, ...},
+   {kind:'forward', index:3, ...}, {kind:'forward', index:4, ...},
+   {kind:'turn', index:5, ...},
+   {kind:'forward', index:6, ...}]
+  ```
+- **AND** the sum of `step.mpCost` SHALL equal `payload.mpUsed`
+
+#### Scenario: A jump move emits a single jump step (not a chain of forward steps)
+
+- **GIVEN** a unit jumping 4 hexes from `(q=0, r=0)` to `(q=4, r=0)` for 4 MP
+- **WHEN** the runner emits the `movement_declared` event
+- **THEN** `payload.steps` SHALL contain exactly one entry with `kind: 'jump'`
+- **AND** that entry's `from` and `to` SHALL match the move's `from` and `to`
+- **AND** that entry's `mpCost` SHALL equal `payload.mpUsed`
+- **AND** `payload.movementType` SHALL be `'jump'`
+
+#### Scenario: A charge declaration produces a chargeDeclared step at the end of the chain
+
+- **GIVEN** a unit declaring a charge attack against opponent-1 at the end of a 3-hex straight-line forward move
+- **WHEN** the runner emits the `movement_declared` event
+- **THEN** the last entry in `payload.steps` SHALL have `kind: 'chargeDeclared'`
+- **AND** that entry's `targetId` SHALL be `'opponent-1'`
+- **AND** that entry's `straightLineHexes` SHALL be `3`
+
+#### Scenario: A stand-up step records its MP cost and PSR trigger
+
+- **GIVEN** a prone unit attempting to stand
+- **WHEN** the runner emits the `movement_declared` event
+- **THEN** `payload.steps` SHALL begin with a `kind: 'standUp'` entry
+- **AND** that entry's `mpCost` SHALL be 2 (per Total Warfare Errata)
+- **AND** that entry's `psrTriggered` SHALL be `true` (the AttemptStand PSR fires regardless of stand outcome)
+
+### Requirement: Movement Decomposition Fields
+
+Every `movement_declared` event SHALL include four optional decomposition fields summarizing the chain:
+
+- `hexesMoved: number` — total hex transitions (`path.length - 1`); equals the count of forward + lateral + jump steps that result in a hex-position change.
+- `straightHexes: number` — number of hexes entered without a facing change in the same step (forward + backward + lateral, excluding turns and stand-up / go-prone steps).
+- `turningMpCost: number` — `mpUsed - straightHexes - jumpMpCost - specialStepMpCost`; the residual MP that went to facing changes only.
+- `netDisplacement: number` — `hexDistance(from, to)` computed via the existing axial-distance utility; equals the straight-line distance from start to end regardless of path.
+
+These fields SHALL be derived deterministically from the `steps` array when both are present. When `steps` is omitted (legacy stream), consumers MAY treat the four fields as the only available decomposition.
+
+#### Scenario: Decomposition fields satisfy the conservation invariant
+
+- **GIVEN** a `movement_declared` event with `mpUsed: 5`, `straightHexes: 4`, `turningMpCost: 1`, no jump steps
+- **WHEN** consumers read the event
+- **THEN** `straightHexes + turningMpCost` SHALL equal `mpUsed`
+- **AND** `straightHexes` SHALL equal the count of `kind: 'forward' | 'backward' | 'lateral'` entries in `payload.steps`
+
+#### Scenario: Net displacement equals hexDistance regardless of path
+
+- **GIVEN** a unit moving from `(q=0, r=0)` to `(q=3, r=0)` via a winding path of 5 hex transitions
+- **WHEN** the runner emits the event
+- **THEN** `payload.hexesMoved` SHALL be 5
+- **AND** `payload.netDisplacement` SHALL be 3 (= `hexDistance({q:0,r:0}, {q:3,r:0})`)
+
+### Requirement: Hex Coordinate Board Label Utility
+
+The hex-math utility module (`src/utils/gameplay/hexMath.ts`) SHALL export a function `coordToBoardLabel(coord: IHexCoordinate): string` that converts an axial `(q, r)` coordinate to a MegaMek-standard 4-digit `NNNN` board-label string where the first two digits are the 1-indexed column and the last two digits are the 1-indexed row, both using `String.prototype.padStart(2, '0')` for zero-padding.
+
+The function SHALL be the inverse of the existing `convertOffsetToAxial(col, row)` in `src/lib/parsers/megaMekBoard.ts:141` so that round-tripping is identity over the valid coordinate range.
+
+#### Scenario: Axial origin maps to 4-digit `0101`
+
+- **GIVEN** an axial coordinate `{q: 0, r: 0}`
+- **WHEN** `coordToBoardLabel` is called
+- **THEN** the return value SHALL be `'0101'`
+
+#### Scenario: A typical board hex round-trips through axial and back
+
+- **GIVEN** a MegaMek board hex at column 12, row 7 (`'1207'`)
+- **AND** the axial coordinate produced by `convertOffsetToAxial(12, 7)`
+- **WHEN** `coordToBoardLabel` is called on that axial coordinate
+- **THEN** the return value SHALL be `'1207'`

--- a/openspec/changes/enrich-movement-declared-with-chain-and-displacement/specs/piloting-skill-rolls/spec.md
+++ b/openspec/changes/enrich-movement-declared-with-chain-and-displacement/specs/piloting-skill-rolls/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Movement-Step PSR Trigger-Source Stamping
+
+When the simulation runner triggers a `psr_triggered` event during the resolution of a movement step (skid on ice, leaping leg damage on elevation drop, jump landing on rough terrain, AttemptStand from a `'standUp'` step, swarm-dislodge from a `'shakeOffSwarm'` step, etc.), the runner SHALL populate `IPSRTriggeredPayload.triggerSource` with the string `'movement-step:<index>'` where `<index>` is the 0-based ordinal of the step in the corresponding `movement_declared.payload.steps` array.
+
+This contract lets consumers correlate per-step PSR events back to the originating step without joining on hex coordinate or timing alone. The `triggerSource` field is REQUIRED on `IPSRTriggeredPayload` (already in the type), so this requirement narrows the value space for movement-induced PSRs without adding a new field.
+
+For PSRs that fire OUTSIDE of movement-step resolution (damage-induced, heat-induced, recovery-induced), `triggerSource` SHALL retain its existing free-string semantics — for example `'damage-20-threshold'`, `'heat-26'`, `'gyro-destroyed'`, `'cockpit-recovery'`. PR E (`structure-psr-reason-as-discriminated-code`) tightens these into a discriminated `PSRReasonCode` union; this requirement does NOT depend on PR E.
+
+#### Scenario: Skid PSR fired during a forward step references that step
+
+- **GIVEN** a unit running across an ice hex at step index 2 of its movement chain
+- **AND** the runner triggers a Skid PSR
+- **WHEN** the `psr_triggered` event is emitted
+- **THEN** the event payload SHALL have `triggerSource: 'movement-step:2'`
+- **AND** the corresponding `movement_declared.payload.steps[2]` SHALL be a `'forward'` step entering an ice hex
+
+#### Scenario: AttemptStand PSR from a stand-up step references the stand-up step's index
+
+- **GIVEN** a prone unit whose movement chain begins with a `'standUp'` step at index 0
+- **AND** the runner triggers an AttemptStand PSR (always fires for stand-up)
+- **WHEN** the `psr_triggered` event is emitted
+- **THEN** the event payload SHALL have `triggerSource: 'movement-step:0'`
+
+#### Scenario: Damage-induced PSR retains its original trigger-source string
+
+- **GIVEN** a unit takes 21+ damage in a phase, triggering a damage-PSR via the existing damage-threshold check
+- **WHEN** the `psr_triggered` event is emitted
+- **THEN** the event payload SHALL NOT have `triggerSource` starting with `'movement-step:'`
+- **AND** the event payload's `triggerSource` SHALL retain its existing free-string value (e.g. `'damage-20-threshold'`)

--- a/openspec/changes/enrich-movement-declared-with-chain-and-displacement/tasks.md
+++ b/openspec/changes/enrich-movement-declared-with-chain-and-displacement/tasks.md
@@ -1,0 +1,60 @@
+# Tasks
+
+## 1. Authoring
+
+- [x] 1.1 Author proposal.md (motivation, decomposition fields, step union, MegaMek `MoveStepType` cross-reference)
+- [x] 1.2 Author movement-system spec delta (Movement Phase Step Chain Emission + Movement Decomposition Fields + Hex Coordinate Board Label Utility)
+- [x] 1.3 Author piloting-skill-rolls spec delta (Movement-Step PSR Trigger-Source Stamping)
+
+## 2. Type extensions (`src/types/gameplay/GameSessionInterfaces.ts`)
+
+- [x] 2.1 Add five optional fields to `IMovementDeclaredPayload` (line 447): `hexesMoved?`, `straightHexes?`, `turningMpCost?`, `netDisplacement?`, `steps?: readonly IMovementStep[]`
+- [x] 2.2 Add `IMovementStep` discriminated union covering 9 kinds: `forward`, `turn`, `lateral`, `jump`, `standUp`, `goProne`, `chargeDeclared`, `dfaDeclared`, `shakeOffSwarm`
+- [x] 2.3 Add per-kind interfaces (`IForwardStep`, `ITurnStep`, etc.) — each carries `index`, kind discriminator, plus kind-specific fields (`from`/`to`/`at`/`mpCost`/`terrainEntered`/`fromFacing`/`toFacing`/etc.)
+- [x] 2.4 Export `IMovementStep` and the per-kind interfaces from the gameplay types barrel (auto-exported via `export * from './GameSessionInterfaces'` in `src/types/gameplay/index.ts`)
+
+## 3. Hex utility (`src/utils/gameplay/hexMath.ts`)
+
+- [x] 3.1 Add `coordToBoardLabel(coord: IHexCoordinate): string` — axial `(q,r)` → MegaMek 4-digit `NNNN` (1-indexed col + row, zero-padded)
+- [x] 3.2 Verify the inverse round-trip with `convertOffsetToAxial` from `src/lib/parsers/megaMekBoard.ts:30`
+- [x] 3.3 Add unit test at `src/utils/gameplay/__tests__/coordToBoardLabel.test.ts` — origin, typical hex, round-trip sweep over a 16×17 standard board, modulo-100 wrap on out-of-range columns
+
+## 4. Runner movement-step decomposition (`src/simulation/runner/phases/movement.ts` + `src/utils/gameplay/movement/eventPath.ts`)
+
+- [x] 4.1 Extend the move-resolution path walker to emit a step array — `decomposeMovementSteps` synthesizes the chain from `(from, fromFacing, to, toFacing, movementType, mpUsed, path)` since the bot's `IMove` shape today doesn't expose a true `MoveStep[]`. Forward-compatible with the future runner that walks a real `MoveStep[]`.
+- [x] 4.2 Compute `hexesMoved`, `straightHexes`, `turningMpCost`, `netDisplacement` deterministically from the steps array
+- [x] 4.3 Populate `payload.steps` and the four decomposition fields on every `movement_declared` event (runner movement.ts emit site updated)
+- [x] 4.4 Verify the conservation invariant in a runtime assertion (test-only) via `assertMovementStepConservation`: `straightHexes + turningMpCost + jumpMp === mpUsed` (special-step MP rolls into `turningMpCost` in this implementation)
+
+## 5. Movement-step PSR trigger-source stamping
+
+- [x] 5.1 Extend `createStandingUpPSR`, `createSkiddingPSR`, `createIcePSR`, `createRubblePSR`, `createRunningRoughTerrainPSR`, `createEnteringWaterPSR`, `createExitingWaterPSR`, and `createStandUpAttempt` to accept an optional `stepIndex` parameter. When provided, the factory overrides `triggerSource` to `'movement-step:<index>'`. `createSkiddingPSR` (skid resolution), `createStandingUpPSR` (AttemptStand), and the four mid-move terrain PSRs are the canonical movement-step PSR call sites; the runner-side wiring lands when the runner gains true mid-move PSR resolution (documented as a `TODO PR-C follow-on` in `src/simulation/runner/phases/movement.ts`).
+- [x] 5.2 Existing damage / heat / gyro-destroyed PSR sites retain their free-string `triggerSource` values (no migration). The `stepIndex` parameter is OPTIONAL on every factory — every existing call site that doesn't yet thread step context falls through to its legacy `PSRTrigger.*` enum value, preserving current behavior.
+
+## 6. Tests
+
+- [x] 6.1 Add `src/__tests__/unit/utils/gameplay/movement-decomposition.test.ts` — assert decomposition for a 5-MP F+F+TR+F+F+TR+F chain produces 7 steps with correct ordinals (5 forwards + 2 turns) and `mpCost` sum equals 7
+- [x] 6.2 Scenario test for a 4-MP jump producing exactly 1 `'jump'` step
+- [x] 6.3 Scenario test for AttemptStand: prone unit (`startedProne: true`), `steps[0].kind === 'standUp'`, `psrTriggered: true`, MP cost 2
+- [x] 6.4 Scenario test for charge declaration: `IChargeDeclaredStep` type-guard discrimination on `step.kind === 'chargeDeclared'` with correct `targetId` + `straightLineHexes` (asserts the read-side discriminated-union contract — the runner does not yet emit chargeDeclared, that lands when the future physical-attack handoff wiring exists)
+- [x] 6.5 Scenario test for movement-induced PSR `triggerSource: 'movement-step:<index>'` — three assertions covering the AttemptStand factory's optional `stepIndex` parameter (movement-step:0, movement-step:2, and the legacy fallback when stepIndex is omitted)
+- [x] 6.6 Run the full test suite — green (1950 simulation tests + 255 movement / PSR / coord tests)
+
+## 7. Validation
+
+- [x] 7.1 `npm run typecheck` clean
+- [x] 7.2 `npm run lint` clean (0 errors, 42 pre-existing warnings — none in files touched by this change)
+- [x] 7.3 `npm test` green (related test pattern: 255/255 movement/PSR/coord; full simulation suite: 1950/1950)
+- [x] 7.4 `npx openspec validate enrich-movement-declared-with-chain-and-displacement --strict` clean
+
+## 8. PR
+
+- [ ] 8.1 Commit on branch `event-log/pr-c-movement-enrichment`
+- [ ] 8.2 Open PR against `main` with title `feat(event-log): enrich movement_declared with step chain + displacement decomposition`
+- [ ] 8.3 Wait for CI green
+- [ ] 8.4 Merge with `--squash --delete-branch`
+
+## 9. Archive
+
+- [ ] 9.1 After merge, run `npx openspec archive enrich-movement-declared-with-chain-and-displacement --yes` — clean
+- [ ] 9.2 Open archive PR; merge

--- a/src/__tests__/unit/utils/gameplay/movement-decomposition.test.ts
+++ b/src/__tests__/unit/utils/gameplay/movement-decomposition.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Unit tests for `decomposeMovementSteps` per
+ * `enrich-movement-declared-with-chain-and-displacement` (movement-system
+ * delta — Movement Phase Step Chain Emission + Movement Decomposition Fields).
+ *
+ * The contract under test:
+ *   - Walk / Run moves walk the path, emitting `'forward'` steps for
+ *     each adjacent hex transition and `'turn'` steps when the unit's
+ *     synthetic facing must change to align with the next hex.
+ *   - Jump moves emit a single `'jump'` step regardless of distance.
+ *   - Stand-up (when `startedProne === true`) prepends a `'standUp'`
+ *     step with `mpCost: 2` and `psrTriggered: true`.
+ *   - The four decomposition fields (`hexesMoved` / `straightHexes` /
+ *     `turningMpCost` / `netDisplacement`) match the chain bookkeeping.
+ *   - Ordinals (`step.index`) are 0-based and contiguous across the
+ *     entire chain.
+ *
+ * Per the piloting-skill-rolls delta (Movement-Step PSR Trigger-Source
+ * Stamping): the AttemptStand PSR factory accepts an optional step
+ * index that overrides `triggerSource` to `'movement-step:<index>'`.
+ * The last test in this suite asserts that contract.
+ */
+
+import {
+  Facing,
+  IChargeDeclaredStep,
+  IForwardStep,
+  IJumpStep,
+  IMovementStep,
+  IStandUpStep,
+  ITurnStep,
+  MovementType,
+} from '@/types/gameplay';
+import {
+  IMovementDecomposition,
+  assertMovementStepConservation,
+  decomposeMovementSteps,
+} from '@/utils/gameplay/movement/eventPath';
+import {
+  PSRTrigger,
+  createStandingUpPSR,
+} from '@/utils/gameplay/pilotingSkillRolls';
+
+const ORIGIN = { q: 0, r: 0 };
+
+describe('decomposeMovementSteps', () => {
+  describe('walk / run moves', () => {
+    it('emits a single forward step for a 1-hex straight walk', () => {
+      // North-facing unit walking 1 hex north. AXIAL_DIRECTION_DELTAS[Facing.North] = {q:0, r:-1}.
+      const result = decomposeMovementSteps({
+        from: ORIGIN,
+        to: { q: 0, r: -1 },
+        fromFacing: Facing.North,
+        toFacing: Facing.North,
+        movementType: MovementType.Walk,
+        mpUsed: 1,
+      });
+
+      expect(result.steps).toHaveLength(1);
+      const step = result.steps[0] as IForwardStep;
+      expect(step.kind).toBe('forward');
+      expect(step.index).toBe(0);
+      expect(step.direction).toBe('forward');
+      expect(step.from).toEqual(ORIGIN);
+      expect(step.to).toEqual({ q: 0, r: -1 });
+      expect(step.mpCost).toBe(1);
+
+      expect(result.hexesMoved).toBe(1);
+      expect(result.straightHexes).toBe(1);
+      expect(result.turningMpCost).toBe(0);
+      expect(result.netDisplacement).toBe(1);
+
+      assertMovementStepConservation(result, 1);
+    });
+
+    it('emits forward+turn+forward chain when the path bends mid-way', () => {
+      // North-facing unit walks 2 hexes north, then turns NE (1 facing-step
+      // right) and walks 1 hex NE.
+      // Facing.North delta = {q:0, r:-1}; Facing.Northeast delta = {q:1, r:-1}.
+      // Path: (0,0) -> (0,-1) -> (0,-2) -> (1,-3).
+      // Step chain: F (idx 0), F (idx 1), TR (idx 2), F (idx 3).
+      // mpUsed = 4 = 3 forwards + 1 turn.
+      const path = [
+        { q: 0, r: 0 },
+        { q: 0, r: -1 },
+        { q: 0, r: -2 },
+        { q: 1, r: -3 },
+      ];
+      const result = decomposeMovementSteps({
+        from: { q: 0, r: 0 },
+        to: { q: 1, r: -3 },
+        fromFacing: Facing.North,
+        toFacing: Facing.Northeast,
+        movementType: MovementType.Walk,
+        mpUsed: 4,
+        path,
+      });
+
+      // 3 forwards + 1 turn = 4 total steps.
+      expect(result.steps).toHaveLength(4);
+
+      const step0 = result.steps[0] as IForwardStep;
+      expect(step0.kind).toBe('forward');
+      expect(step0.index).toBe(0);
+      expect(step0.from).toEqual({ q: 0, r: 0 });
+      expect(step0.to).toEqual({ q: 0, r: -1 });
+      expect(step0.mpCost).toBe(1);
+
+      const step1 = result.steps[1] as IForwardStep;
+      expect(step1.kind).toBe('forward');
+      expect(step1.index).toBe(1);
+      expect(step1.from).toEqual({ q: 0, r: -1 });
+      expect(step1.to).toEqual({ q: 0, r: -2 });
+
+      const step2 = result.steps[2] as ITurnStep;
+      expect(step2.kind).toBe('turn');
+      expect(step2.index).toBe(2);
+      expect(step2.fromFacing).toBe(Facing.North);
+      expect(step2.toFacing).toBe(Facing.Northeast);
+      expect(step2.mpCost).toBe(1);
+
+      const step3 = result.steps[3] as IForwardStep;
+      expect(step3.kind).toBe('forward');
+      expect(step3.index).toBe(3);
+      expect(step3.from).toEqual({ q: 0, r: -2 });
+      expect(step3.to).toEqual({ q: 1, r: -3 });
+      expect(step3.mpCost).toBe(1);
+
+      // Decomposition fields match.
+      expect(result.hexesMoved).toBe(3);
+      expect(result.straightHexes).toBe(3);
+      expect(result.turningMpCost).toBe(1);
+      // hexDistance origin → (1,-3) axial = max(|1|, |-3|, |-2|) = 3.
+      expect(result.netDisplacement).toBe(3);
+
+      assertMovementStepConservation(result, 4);
+    });
+
+    it('produces 7 steps for a 5-MP F+F+TR+F+F+TR+F chain (spec Scenario 1)', () => {
+      // Spec scenario: 5-MP walk = forward 2, turn right, forward 2, turn right, forward 1
+      // Starting facing: North (0). After two right-turns we end at SE (Facing.Southeast = 2).
+      // Path: north 2 hexes, then NE step (after turn), then NE step, then SE turn, then SE step.
+      // For simplicity we use the same path the bot would produce — the
+      // decomposer's contract is "given the path, produce 7 steps with
+      // 5 forwards and 2 turns". We assert the structural shape rather
+      // than the exact axial coordinates.
+      const path = [
+        { q: 0, r: 0 }, // start
+        { q: 0, r: -1 }, // forward N (idx 0)
+        { q: 0, r: -2 }, // forward N (idx 1)
+        // turn N → NE (idx 2)
+        { q: 1, r: -2 }, // forward NE (idx 3)
+        { q: 2, r: -3 }, // forward NE - wait, Facing.NE delta is {q:1, r:-1}
+      ];
+      // Recalibrate: NE delta is {q:1, r:-1}. From (1,-2) NE step → (2,-3).
+      // Then turn NE → SE (delta {q:1, r:0}), then SE step (3,-3).
+      const fullPath = [
+        { q: 0, r: 0 },
+        { q: 0, r: -1 },
+        { q: 0, r: -2 },
+        { q: 1, r: -3 },
+        { q: 2, r: -4 },
+        { q: 3, r: -4 },
+      ];
+      const result = decomposeMovementSteps({
+        from: { q: 0, r: 0 },
+        to: { q: 3, r: -4 },
+        fromFacing: Facing.North,
+        toFacing: Facing.Southeast, // NE then SE = two right-turns from N
+        movementType: MovementType.Walk,
+        mpUsed: 7, // 5 forwards + 2 turns
+        path: fullPath,
+      });
+
+      // 5 forwards + 2 turns = 7 steps.
+      expect(result.steps).toHaveLength(7);
+      const forwards = result.steps.filter((s) => s.kind === 'forward');
+      const turns = result.steps.filter((s) => s.kind === 'turn');
+      expect(forwards.length).toBe(5);
+      expect(turns.length).toBe(2);
+
+      // 0-based, contiguous ordinals.
+      result.steps.forEach((s: IMovementStep, i: number) => {
+        expect(s.index).toBe(i);
+      });
+
+      // Sum of mpCost = mpUsed.
+      const totalMp = result.steps.reduce(
+        (acc: number, s: IMovementStep) => acc + ('mpCost' in s ? s.mpCost : 0),
+        0,
+      );
+      expect(totalMp).toBe(7);
+
+      expect(result.straightHexes).toBe(5);
+      expect(result.turningMpCost).toBe(2);
+      assertMovementStepConservation(result, 7);
+    });
+  });
+
+  describe('jump moves', () => {
+    it('emits exactly 1 jump step for a 4-MP jump (spec Scenario 2)', () => {
+      const result = decomposeMovementSteps({
+        from: { q: 0, r: 0 },
+        to: { q: 4, r: 0 },
+        fromFacing: Facing.North,
+        toFacing: Facing.North,
+        movementType: MovementType.Jump,
+        mpUsed: 4,
+      });
+
+      expect(result.steps).toHaveLength(1);
+      const step = result.steps[0] as IJumpStep;
+      expect(step.kind).toBe('jump');
+      expect(step.index).toBe(0);
+      expect(step.from).toEqual({ q: 0, r: 0 });
+      expect(step.to).toEqual({ q: 4, r: 0 });
+      expect(step.mpCost).toBe(4);
+
+      // Per spec: hexesMoved = hexDistance(from, to) for jump moves.
+      expect(result.hexesMoved).toBe(4);
+      expect(result.straightHexes).toBe(0);
+      expect(result.turningMpCost).toBe(0);
+      expect(result.netDisplacement).toBe(4);
+
+      assertMovementStepConservation(result, 4);
+    });
+  });
+
+  describe('stationary / no-op moves', () => {
+    it('emits zero steps when from === to and movement is stationary', () => {
+      const result = decomposeMovementSteps({
+        from: { q: 0, r: 0 },
+        to: { q: 0, r: 0 },
+        fromFacing: Facing.North,
+        toFacing: Facing.North,
+        movementType: MovementType.Stationary,
+        mpUsed: 0,
+      });
+
+      expect(result.steps).toHaveLength(0);
+      expect(result.hexesMoved).toBe(0);
+      expect(result.straightHexes).toBe(0);
+      expect(result.turningMpCost).toBe(0);
+      expect(result.netDisplacement).toBe(0);
+    });
+  });
+
+  describe('stand-up (prone unit) prefix', () => {
+    it('prepends a standUp step with mpCost 2 and psrTriggered=true (spec Scenario 4)', () => {
+      // Prone unit attempts to stand at origin, then walks 1 hex north.
+      // Total mpUsed = 2 (stand) + 1 (forward) = 3.
+      const result: IMovementDecomposition = decomposeMovementSteps({
+        from: { q: 0, r: 0 },
+        to: { q: 0, r: -1 },
+        fromFacing: Facing.North,
+        toFacing: Facing.North,
+        movementType: MovementType.Walk,
+        mpUsed: 3,
+        path: [
+          { q: 0, r: 0 },
+          { q: 0, r: -1 },
+        ],
+        startedProne: true,
+      });
+
+      // 1 standUp + 1 forward = 2 steps.
+      expect(result.steps).toHaveLength(2);
+
+      const stand = result.steps[0] as IStandUpStep;
+      expect(stand.kind).toBe('standUp');
+      expect(stand.index).toBe(0);
+      expect(stand.mpCost).toBe(2);
+      expect(stand.psrTriggered).toBe(true);
+      expect(stand.at).toEqual({ q: 0, r: 0 });
+
+      const forward = result.steps[1] as IForwardStep;
+      expect(forward.kind).toBe('forward');
+      expect(forward.index).toBe(1);
+      expect(forward.mpCost).toBe(1);
+
+      // Stand-up MP rolls into turningMpCost (residual non-straight,
+      // non-jump MP). Conservation:
+      //   straightHexes(1) + turningMpCost(2) + jumpMp(0) = 3 = mpUsed ✓
+      expect(result.straightHexes).toBe(1);
+      expect(result.turningMpCost).toBe(2);
+      assertMovementStepConservation(result, 3);
+    });
+  });
+});
+
+describe('IMovementStep type-guard discrimination (spec Scenario 3 wiring)', () => {
+  it('narrows on `kind` to access kind-specific fields', () => {
+    // Build a synthetic chargeDeclared step to assert the type-guard
+    // contract. The runner does not yet emit chargeDeclared, but the
+    // `IMovementStep` discriminated union must support it on read.
+    const charge: IChargeDeclaredStep = {
+      kind: 'chargeDeclared',
+      index: 4,
+      at: { q: 5, r: 0 },
+      targetId: 'opponent-1',
+      straightLineHexes: 3,
+    };
+
+    const steps: readonly IMovementStep[] = [charge];
+    const last = steps[steps.length - 1];
+    if (last.kind === 'chargeDeclared') {
+      // Inside this guard, last is narrowed to IChargeDeclaredStep.
+      expect(last.targetId).toBe('opponent-1');
+      expect(last.straightLineHexes).toBe(3);
+    } else {
+      throw new Error('expected chargeDeclared step');
+    }
+  });
+});
+
+describe('Movement-Step PSR Trigger-Source Stamping (piloting-skill-rolls delta)', () => {
+  it('uses `movement-step:<index>` when stepIndex is provided to the AttemptStand factory (spec Scenario 2)', () => {
+    // Per the spec scenario: a prone unit's movement chain begins with
+    // a 'standUp' step at index 0; the AttemptStand PSR fires and
+    // SHALL carry triggerSource: 'movement-step:0'.
+    const psr = createStandingUpPSR('player-1', 0);
+    expect(psr.triggerSource).toBe('movement-step:0');
+    expect(psr.entityId).toBe('player-1');
+    expect(psr.reason).toBe('Standing up');
+  });
+
+  it('falls back to the legacy PSRTrigger.StandingUp when stepIndex is omitted (spec Scenario 3)', () => {
+    // Per the spec scenario: PSRs that fire OUTSIDE movement-step
+    // resolution (or before the runner threads step context through)
+    // SHALL retain their existing free-string triggerSource value.
+    const psr = createStandingUpPSR('player-1');
+    expect(psr.triggerSource).toBe(PSRTrigger.StandingUp);
+  });
+
+  it('handles non-zero stepIndex correctly (spec Scenario 1: skid PSR at step 2)', () => {
+    // Spec scenario reference: a unit running across an ice hex at
+    // step index 2 of its movement chain. When the runner triggers a
+    // Skid PSR with stepIndex=2, the resulting triggerSource SHALL be
+    // 'movement-step:2'. The AttemptStand factory uses identical
+    // semantics — we exercise it here as a representative.
+    const psr = createStandingUpPSR('opponent-2', 2);
+    expect(psr.triggerSource).toBe('movement-step:2');
+  });
+});

--- a/src/simulation/runner/phases/movement.ts
+++ b/src/simulation/runner/phases/movement.ts
@@ -6,6 +6,11 @@ import {
   IGameState,
   IHexGrid,
 } from '@/types/gameplay';
+import {
+  decomposeMovementSteps,
+  movementAnimationModeForType,
+  normalizeMovementEventPath,
+} from '@/utils/gameplay/movement/eventPath';
 
 import type { IAIPlayer } from '../../ai/IAIPlayer';
 import type { IWeapon } from '../../ai/types';
@@ -65,6 +70,45 @@ export function runMovementPhase(options: {
         moveEvent.payload,
       );
 
+      // Per `enrich-movement-declared-with-chain-and-displacement`
+      // (movement-system delta): synthesize the per-step chain plus the
+      // four decomposition fields (`hexesMoved` / `straightHexes` /
+      // `turningMpCost` / `netDisplacement`) and the visited path so
+      // every `MovementDeclared` event carries a complete picture of
+      // the move's commit history. The bot today does not surface a
+      // pre-computed path, so we let the helper fall back to a
+      // straight-line `hexLine` projection — adequate for the runner's
+      // simulation needs and for the readable-companion formatter.
+      //
+      // TODO PR-C follow-on (`enrich-movement-declared-with-chain-and-displacement`
+      // piloting-skill-rolls delta — Movement-Step PSR Trigger-Source Stamping):
+      // when the runner gains true mid-move PSR resolution (skid on
+      // ice, jump-landing leg damage, AttemptStand, swarm-dislodge),
+      // pass `decomposition.steps[i].index` into the corresponding
+      // `createSkiddingPSR` / `createIcePSR` / `createStandingUpPSR`
+      // factory call so the emitted `psr_triggered` event carries
+      // `triggerSource: 'movement-step:<index>'`. The factories
+      // already accept the optional `stepIndex` parameter; the only
+      // missing piece is the runner-side wiring once the mid-move
+      // PSR phase exists. PSRs that fire OUTSIDE movement-step
+      // resolution (damage, heat, gyro destroyed) MUST RETAIN their
+      // existing free-string `triggerSource` values.
+      const path = normalizeMovementEventPath(
+        unit.position,
+        moveEvent.payload.to,
+      );
+      const decomposition = decomposeMovementSteps({
+        from: unit.position,
+        to: moveEvent.payload.to,
+        fromFacing: unit.facing as Facing,
+        toFacing: moveEvent.payload.facing as Facing,
+        movementType: moveEvent.payload.movementType,
+        mpUsed: moveEvent.payload.mpUsed,
+        path,
+        grid,
+      });
+      const mode = movementAnimationModeForType(moveEvent.payload.movementType);
+
       events.push(
         createGameEvent(
           gameId,
@@ -78,8 +122,15 @@ export function runMovementPhase(options: {
             to: moveEvent.payload.to,
             facing: moveEvent.payload.facing as Facing,
             movementType: moveEvent.payload.movementType,
+            ...(mode ? { mode } : {}),
+            path,
             mpUsed: moveEvent.payload.mpUsed,
             heatGenerated: 0,
+            hexesMoved: decomposition.hexesMoved,
+            straightHexes: decomposition.straightHexes,
+            turningMpCost: decomposition.turningMpCost,
+            netDisplacement: decomposition.netDisplacement,
+            steps: decomposition.steps,
           },
           unitId,
         ),

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -481,7 +481,158 @@ export interface IMovementDeclaredPayload {
   readonly mpUsed: number;
   /** Heat generated */
   readonly heatGenerated: number;
+  /**
+   * Per `enrich-movement-declared-with-chain-and-displacement` (movement-system
+   * delta — Movement Decomposition Fields): total hex transitions in the
+   * move (`path.length - 1`). Equals the count of forward + backward +
+   * lateral + jump steps that result in a hex-position change. Optional
+   * for legacy event-stream compat.
+   */
+  readonly hexesMoved?: number;
+  /**
+   * Per the same delta: hexes entered without a facing change in the
+   * same step (forward + backward + lateral, excluding turns and
+   * stand-up / go-prone steps). Used by the readable-companion formatter
+   * to render `mp=N(s<sh>+t<th>)` with the straight-vs-turning split.
+   */
+  readonly straightHexes?: number;
+  /**
+   * Per the same delta: MP spent on facing changes only. Equals
+   * `mpUsed - straightHexes - sum(jumpMpCost) - sum(specialStepMpCost)`.
+   */
+  readonly turningMpCost?: number;
+  /**
+   * Per the same delta: `hexDistance(from, to)` — straight-line distance
+   * from start to end regardless of path. Already used for TMM elsewhere;
+   * just denormalized onto the event payload.
+   */
+  readonly netDisplacement?: number;
+  /**
+   * Per `enrich-movement-declared-with-chain-and-displacement` (movement-system
+   * delta — Movement Phase Step Chain Emission). The chain of micro-moves
+   * the unit executed in commit order. Optional for legacy event-stream
+   * compat. Discriminated union keyed on `kind`.
+   */
+  readonly steps?: readonly IMovementStep[];
 }
+
+/**
+ * Per `enrich-movement-declared-with-chain-and-displacement` (movement-system
+ * delta — Movement Phase Step Chain Emission): a single micro-move
+ * within a committed move. The `IMovementStep` union covers the
+ * BattleMech ground-combat subset of MegaMek's `MoveStepType`
+ * (`E:/Projects/megamek/megamek/src/megamek/common/enums/MoveStepType.java`).
+ * Aerospace / infantry / battle-armor step types are out-of-scope
+ * follow-ons named in `proposal.md`.
+ */
+export interface IForwardStep {
+  readonly kind: 'forward';
+  /** 0-based ordinal within the move's `steps` array. */
+  readonly index: number;
+  /** Direction of travel — FORWARDS or BACKWARDS in MegaMek terms. */
+  readonly direction: 'forward' | 'backward';
+  readonly from: IHexCoordinate;
+  readonly to: IHexCoordinate;
+  /** Base MP plus terrain modifier (e.g. +1 entering Light Woods). */
+  readonly mpCost: number;
+  /**
+   * `TerrainType`-as-string for forward-compat with new terrain types
+   * appearing in source data without breaking serialized event logs.
+   */
+  readonly terrainEntered: string;
+  /** `toElevation - fromElevation` — positive = climbing, negative = falling. */
+  readonly elevationDelta: number;
+}
+
+export interface ITurnStep {
+  readonly kind: 'turn';
+  readonly index: number;
+  readonly at: IHexCoordinate;
+  readonly fromFacing: Facing;
+  readonly toFacing: Facing;
+  /** 1 MP per facing-step (TURN_LEFT / TURN_RIGHT each cost 1 MP). */
+  readonly mpCost: number;
+}
+
+export interface ILateralStep {
+  readonly kind: 'lateral';
+  readonly index: number;
+  /**
+   * Sideslip direction — covers MegaMek's LATERAL_LEFT / LATERAL_RIGHT
+   * and their backward variants used during skid resolution.
+   */
+  readonly direction: 'left' | 'right' | 'left-backwards' | 'right-backwards';
+  readonly from: IHexCoordinate;
+  readonly to: IHexCoordinate;
+  readonly mpCost: number;
+  readonly terrainEntered: string;
+}
+
+export interface IJumpStep {
+  readonly kind: 'jump';
+  readonly index: number;
+  readonly from: IHexCoordinate;
+  readonly to: IHexCoordinate;
+  /** Distance jumped (1 MP per hex of jump distance for ground 'Mechs). */
+  readonly mpCost: number;
+  readonly terrainEntered: string;
+}
+
+export interface IStandUpStep {
+  readonly kind: 'standUp';
+  readonly index: number;
+  readonly at: IHexCoordinate;
+  /** Typically 2 MP per Total Warfare Errata stand-up cost. */
+  readonly mpCost: number;
+  /** AttemptStand fires regardless of stand outcome — always `true`. */
+  readonly psrTriggered: boolean;
+}
+
+export interface IGoProneStep {
+  readonly kind: 'goProne';
+  readonly index: number;
+  readonly at: IHexCoordinate;
+  readonly mpCost: number;
+}
+
+export interface IChargeDeclaredStep {
+  readonly kind: 'chargeDeclared';
+  readonly index: number;
+  readonly at: IHexCoordinate;
+  readonly targetId: string;
+  /** Length of the trailing forward run that qualifies the charge. */
+  readonly straightLineHexes: number;
+}
+
+export interface IDfaDeclaredStep {
+  readonly kind: 'dfaDeclared';
+  readonly index: number;
+  readonly at: IHexCoordinate;
+  readonly targetId: string;
+  readonly jumpHeight: number;
+}
+
+export interface IShakeOffSwarmStep {
+  readonly kind: 'shakeOffSwarm';
+  readonly index: number;
+  readonly at: IHexCoordinate;
+  readonly psrTriggered: boolean;
+}
+
+/**
+ * Discriminated union of all movement-step shapes. Consumers narrow on
+ * `step.kind` before reading kind-specific fields.
+ */
+export type IMovementStep =
+  | IForwardStep
+  | ITurnStep
+  | ILateralStep
+  | IJumpStep
+  | IStandUpStep
+  | IGoProneStep
+  | IChargeDeclaredStep
+  | IDfaDeclaredStep
+  | IShakeOffSwarmStep;
 
 /**
  * Movement locked event payload.

--- a/src/utils/gameplay/__tests__/coordToBoardLabel.test.ts
+++ b/src/utils/gameplay/__tests__/coordToBoardLabel.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for `coordToBoardLabel` per
+ * `enrich-movement-declared-with-chain-and-displacement` (movement-system
+ * delta — Hex Coordinate Board Label Utility).
+ *
+ * The contract:
+ *   - Axial origin `{q:0, r:0}` → `'0101'`
+ *   - Round-trip identity with `convertOffsetToAxial` from
+ *     `src/lib/parsers/megaMekBoard.ts:30` over the in-range MegaMek
+ *     board coordinate space.
+ *   - Output is always exactly 4 chars (zero-padded col + row).
+ */
+
+import { coordToBoardLabel } from '../hexMath';
+
+// Mirror of the inverse helper at src/lib/parsers/megaMekBoard.ts:30
+// — duplicated locally so this test can run without parser imports.
+function convertOffsetToAxial(
+  col: number,
+  row: number,
+): { q: number; r: number } {
+  const q = col - 1;
+  const r = row - 1 - Math.floor((col - 1) / 2);
+  return { q, r };
+}
+
+describe('coordToBoardLabel', () => {
+  it('maps axial origin {q:0, r:0} to "0101"', () => {
+    expect(coordToBoardLabel({ q: 0, r: 0 })).toBe('0101');
+  });
+
+  it('round-trips the (col=12, row=7) board hex via axial', () => {
+    const axial = convertOffsetToAxial(12, 7);
+    expect(coordToBoardLabel(axial)).toBe('1207');
+  });
+
+  it('round-trips (col=1, row=1) — top-left of a standard board', () => {
+    const axial = convertOffsetToAxial(1, 1);
+    expect(coordToBoardLabel(axial)).toBe('0101');
+  });
+
+  it('round-trips (col=2, row=1) — exercises the offset-row offset', () => {
+    // col=2 has the +1 row offset: q=1, r=1-1-0=0 (floor(1/2) = 0).
+    // Inverse: col = q+1 = 2, row = r+1+floor(q/2) = 0+1+0 = 1.
+    const axial = convertOffsetToAxial(2, 1);
+    expect(coordToBoardLabel(axial)).toBe('0201');
+  });
+
+  it('round-trips (col=3, row=5) — exercises the floor-div ramp', () => {
+    // col=3 → q=2, r=5-1-floor(2/2)=3. Back: col=3, row=3+1+1=5.
+    const axial = convertOffsetToAxial(3, 5);
+    expect(coordToBoardLabel(axial)).toBe('0305');
+  });
+
+  it('round-trips a sweep across the 1..16 × 1..17 standard board', () => {
+    // The default MegaMek "standard" board is 16 cols × 17 rows; the
+    // in-range coordinate set is the 1-indexed Cartesian product. We
+    // assert exact round-trip identity for every cell.
+    for (let col = 1; col <= 16; col++) {
+      for (let row = 1; row <= 17; row++) {
+        const axial = convertOffsetToAxial(col, row);
+        const expected =
+          String(col).padStart(2, '0') + String(row).padStart(2, '0');
+        expect(coordToBoardLabel(axial)).toBe(expected);
+      }
+    }
+  });
+
+  it('always returns a 4-character string', () => {
+    expect(coordToBoardLabel({ q: 0, r: 0 }).length).toBe(4);
+    expect(coordToBoardLabel({ q: 9, r: 9 }).length).toBe(4);
+    expect(coordToBoardLabel({ q: 50, r: 50 }).length).toBe(4);
+  });
+
+  it('zero-pads single-digit columns and rows', () => {
+    // q=0 → col=1 ("01"), r=0 → row=1 ("01")
+    expect(coordToBoardLabel({ q: 0, r: 0 })).toBe('0101');
+    // q=8 → col=9 ("09"), r=4 → row=4+1+floor(8/2)=9 ("09")
+    expect(coordToBoardLabel({ q: 8, r: 4 })).toBe('0909');
+  });
+
+  it('wraps modulo-100 to preserve the 4-char length on out-of-range inputs', () => {
+    // 100 % 100 = 0 → "00", which is what the inverse parser would
+    // need to read a 4-digit token. This is defensive — production
+    // boards never exceed 99 columns.
+    const wrapped = coordToBoardLabel({ q: 99, r: 0 });
+    expect(wrapped.length).toBe(4);
+    // col = q+1 = 100 → "00", row = r+1+floor(99/2)=1+49=50 → "50"
+    expect(wrapped).toBe('0050');
+  });
+});

--- a/src/utils/gameplay/hexMath.ts
+++ b/src/utils/gameplay/hexMath.ts
@@ -329,3 +329,44 @@ export function angleToFacing(angle: number): Facing {
 export function facingToAngle(facing: Facing): number {
   return facing * 60;
 }
+
+// =============================================================================
+// MegaMek Board Label Conversion
+// =============================================================================
+
+/**
+ * Per `enrich-movement-declared-with-chain-and-displacement` (movement-system
+ * delta — Hex Coordinate Board Label Utility): convert an axial `(q, r)`
+ * coordinate to a MegaMek-standard 4-digit `NNNN` board-label string
+ * where the first two digits are the 1-indexed column and the last
+ * two digits are the 1-indexed row, both zero-padded with
+ * `String.prototype.padStart(2, '0')`.
+ *
+ * This is the inverse of the offset-axial conversion in
+ * `src/lib/parsers/megaMekBoard.ts:30` (`convertOffsetToAxial`):
+ *
+ *   forward: `q = col - 1`, `r = row - 1 - Math.floor((col - 1) / 2)`
+ *   inverse: `col = q + 1`, `row = r + 1 + Math.floor(q / 2)`
+ *
+ * Round-trip identity holds for any in-range board coordinate:
+ *   `coordToBoardLabel(convertOffsetToAxial(col, row)) === \`${col}${row}\``
+ * when `col` and `row` are 1-indexed and within the standard 1..99
+ * MegaMek board range. Out-of-range columns wrap modulo 100 to keep
+ * the output exactly 4 chars (matching what the inverse parser would
+ * accept on read-back from `.board` files).
+ *
+ * Mirrors the Python `coord_to_board_label` helper added in PR A so
+ * the readable-companion formatter (PR D) renders identical labels
+ * for the same axial coordinate regardless of language.
+ */
+export function coordToBoardLabel(coord: IHexCoordinate): string {
+  const col = coord.q + 1;
+  const row = coord.r + 1 + Math.floor(coord.q / 2);
+  // Wrap modulo 100 so the output is always exactly 4 chars even when
+  // a stray fixture / out-of-range coordinate sneaks through; this
+  // matches the 4-digit `NNNN` constraint the inverse parser enforces
+  // via `if (!/^\d{4}$/.test(coordStr)) throw` in megaMekBoard.ts.
+  const colStr = String(((col % 100) + 100) % 100).padStart(2, '0');
+  const rowStr = String(((row % 100) + 100) % 100).padStart(2, '0');
+  return `${colStr}${rowStr}`;
+}

--- a/src/utils/gameplay/movement/eventPath.ts
+++ b/src/utils/gameplay/movement/eventPath.ts
@@ -1,12 +1,23 @@
 import type {
+  Facing,
+  IForwardStep,
   IHexCoordinate,
   IHexGrid,
+  IJumpStep,
   IMovementCapability,
+  IMovementStep,
+  IStandUpStep,
+  ITurnStep,
   MovementAnimationMode,
 } from '@/types/gameplay';
 
-import { MovementType } from '@/types/gameplay';
-import { hexEquals, hexLine } from '@/utils/gameplay/hexMath';
+import { AXIAL_DIRECTION_DELTAS, MovementType } from '@/types/gameplay';
+import {
+  coordToKey,
+  hexDistance,
+  hexEquals,
+  hexLine,
+} from '@/utils/gameplay/hexMath';
 
 import { findPath } from './pathfinding';
 
@@ -81,4 +92,329 @@ export function maxMovementCostForCapability(
 
 function copyHex(coord: IHexCoordinate): IHexCoordinate {
   return { q: coord.q, r: coord.r };
+}
+
+// =============================================================================
+// Movement-step decomposition
+//
+// Per `enrich-movement-declared-with-chain-and-displacement` (movement-system
+// delta — Movement Phase Step Chain Emission + Movement Decomposition Fields):
+// synthesize the `IMovementStep[]` chain and the four decomposition
+// numbers from the runner's existing `(from, fromFacing, to, toFacing,
+// movementType, mpUsed, path)` data.
+//
+// The runner today emits a single `MovementDeclared` event per committed
+// move; it does NOT walk an internal `MoveStep[]` like MegaMek's Java
+// engine does. We synthesize the chain by:
+//
+//   1. Jump / Stationary moves emit one `'jump'` step (or zero steps
+//      when `from === to`).
+//   2. Walk / Run moves walk the path: at each hex transition we
+//      compute the facing the unit must hold to enter the next hex.
+//      If that facing differs from the unit's current synthetic
+//      facing, we emit `'turn'` steps (cheapest rotation, 1 MP each)
+//      until aligned, then emit a `'forward'` step. After the last
+//      forward, we emit terminal turns to land on `toFacing` if the
+//      unit's final synthetic facing differs.
+//
+// This is forward-compatible with the future runner that walks a true
+// `MoveStep[]` — the decomposition shape is identical, the only thing
+// that changes is the input source. The conservation invariant
+// (`straightHexes + turningMpCost + sum(jumpMpCost) === mpUsed`) is
+// asserted in test mode via `assertMovementStepConservation`.
+// =============================================================================
+
+/**
+ * Result of `decomposeMovementSteps` — the four decomposition fields
+ * plus the step chain that produced them.
+ */
+export interface IMovementDecomposition {
+  readonly steps: readonly IMovementStep[];
+  readonly hexesMoved: number;
+  readonly straightHexes: number;
+  readonly turningMpCost: number;
+  readonly netDisplacement: number;
+}
+
+export interface IDecomposeMovementInput {
+  readonly from: IHexCoordinate;
+  readonly to: IHexCoordinate;
+  readonly fromFacing: Facing;
+  readonly toFacing: Facing;
+  readonly movementType: MovementType;
+  readonly mpUsed: number;
+  readonly path?: readonly IHexCoordinate[];
+  readonly grid?: IHexGrid;
+  /**
+   * When `true`, the unit was prone before the move and the
+   * decomposition prepends a `'standUp'` step (mpCost 2, psrTriggered
+   * true) consuming 2 MP from `mpUsed`. Optional — runner does not
+   * track this today, but the helper is forward-compatible for the
+   * future stand-up wiring.
+   */
+  readonly startedProne?: boolean;
+}
+
+/**
+ * Compute the direction (facing index) that maps `from → to` for two
+ * adjacent hexes. Returns `null` when the hexes are not orthogonally
+ * adjacent on the axial grid (jump / line-drawn segments).
+ */
+function facingForHexTransition(
+  from: IHexCoordinate,
+  to: IHexCoordinate,
+): Facing | null {
+  const dq = to.q - from.q;
+  const dr = to.r - from.r;
+  for (let i = 0; i < AXIAL_DIRECTION_DELTAS.length; i++) {
+    const delta = AXIAL_DIRECTION_DELTAS[i];
+    if (delta.q === dq && delta.r === dr) {
+      return i as Facing;
+    }
+  }
+  return null;
+}
+
+/**
+ * Cheapest rotation count between two facings — clockwise vs
+ * counterclockwise — bounded to 3 (opposite facings). Returns the
+ * signed delta count; positive = clockwise turns, negative =
+ * counterclockwise. Zero means already aligned.
+ */
+function shortestRotation(from: Facing, to: Facing): number {
+  const diff = ((to - from) % 6) + 6;
+  const cw = diff % 6; // 0..5
+  if (cw === 0) return 0;
+  if (cw <= 3) return cw;
+  return cw - 6; // -1, -2 (counterclockwise)
+}
+
+/**
+ * Look up the terrain string + elevation for a hex from the grid.
+ * Falls back to the legacy "unknown" / 0 pair when the grid is missing
+ * the hex or the caller didn't provide one.
+ */
+function lookupTerrain(
+  grid: IHexGrid | undefined,
+  coord: IHexCoordinate,
+): { terrain: string; elevation: number } {
+  if (!grid) return { terrain: 'unknown', elevation: 0 };
+  const hex = grid.hexes.get(coordToKey(coord));
+  if (!hex) return { terrain: 'unknown', elevation: 0 };
+  return { terrain: hex.terrain, elevation: hex.elevation };
+}
+
+/**
+ * Per `enrich-movement-declared-with-chain-and-displacement` (movement-system
+ * delta): decompose a committed move into its `IMovementStep[]` chain
+ * and the four summary fields (`hexesMoved` / `straightHexes` /
+ * `turningMpCost` / `netDisplacement`).
+ *
+ * The synthesizer is best-effort: when `path` is omitted the helper
+ * uses a straight-line `hexLine` projection. When the path is not
+ * fully orthogonal-adjacent (rare — the runner currently ALWAYS
+ * produces hex-adjacent paths via `findPath` for ground moves), the
+ * non-adjacent transition is emitted as a single forward step with
+ * the legacy `'unknown'` terrain.
+ */
+export function decomposeMovementSteps(
+  input: IDecomposeMovementInput,
+): IMovementDecomposition {
+  const { from, to, fromFacing, toFacing, movementType, mpUsed, grid } = input;
+  const path = input.path ?? [from, to];
+  const netDisplacement = hexDistance(from, to);
+
+  // Stationary moves emit no step chain.
+  if (movementType === MovementType.Stationary || hexEquals(from, to)) {
+    return {
+      steps: [],
+      hexesMoved: 0,
+      straightHexes: 0,
+      turningMpCost: 0,
+      netDisplacement,
+    };
+  }
+
+  // Jump moves emit a single jump step.
+  if (movementType === MovementType.Jump) {
+    const { terrain } = lookupTerrain(grid, to);
+    const jumpStep: IJumpStep = {
+      kind: 'jump',
+      index: 0,
+      from: copyHex(from),
+      to: copyHex(to),
+      mpCost: mpUsed,
+      terrainEntered: terrain,
+    };
+    return {
+      steps: [jumpStep],
+      hexesMoved: hexDistance(from, to),
+      straightHexes: 0,
+      turningMpCost: 0,
+      netDisplacement,
+    };
+  }
+
+  // Walk / Run path walk.
+  const steps: IMovementStep[] = [];
+  let nextIndex = 0;
+  let currentFacing: Facing = fromFacing;
+  let currentCoord: IHexCoordinate = from;
+  let straightHexes = 0;
+  let turningMpCost = 0;
+
+  // Optional stand-up prefix (forward-compat for prone handling).
+  if (input.startedProne) {
+    const standUp: IStandUpStep = {
+      kind: 'standUp',
+      index: nextIndex++,
+      at: copyHex(from),
+      mpCost: 2,
+      psrTriggered: true,
+    };
+    steps.push(standUp);
+    turningMpCost += 2;
+  }
+
+  for (let i = 1; i < path.length; i++) {
+    const next = path[i];
+    if (hexEquals(currentCoord, next)) {
+      // Path entries can repeat the origin (rare); skip without emit.
+      continue;
+    }
+    const requiredFacing = facingForHexTransition(currentCoord, next);
+    if (requiredFacing === null) {
+      // Non-adjacent transition — emit as a single forward step with
+      // terrain looked up at the destination. mpCost is the hex
+      // distance covered (matches the legacy `mpUsed` budget when the
+      // runner didn't provide a finer path).
+      const { terrain, elevation: toEl } = lookupTerrain(grid, next);
+      const { elevation: fromEl } = lookupTerrain(grid, currentCoord);
+      const stepHexes = hexDistance(currentCoord, next);
+      const forward: IForwardStep = {
+        kind: 'forward',
+        index: nextIndex++,
+        direction: 'forward',
+        from: copyHex(currentCoord),
+        to: copyHex(next),
+        mpCost: stepHexes,
+        terrainEntered: terrain,
+        elevationDelta: toEl - fromEl,
+      };
+      steps.push(forward);
+      straightHexes += stepHexes;
+      currentCoord = next;
+      continue;
+    }
+
+    // Insert turn steps until facing aligns with requiredFacing.
+    let rotations = shortestRotation(currentFacing, requiredFacing);
+    while (rotations !== 0) {
+      const stepDir: 1 | -1 = rotations > 0 ? 1 : -1;
+      const newFacing = (((currentFacing + stepDir) % 6) + 6) % 6;
+      const turn: ITurnStep = {
+        kind: 'turn',
+        index: nextIndex++,
+        at: copyHex(currentCoord),
+        fromFacing: currentFacing,
+        toFacing: newFacing as Facing,
+        mpCost: 1,
+      };
+      steps.push(turn);
+      turningMpCost += 1;
+      currentFacing = newFacing as Facing;
+      rotations = shortestRotation(currentFacing, requiredFacing);
+    }
+
+    // Now emit the forward step entering `next`.
+    const { terrain, elevation: toEl } = lookupTerrain(grid, next);
+    const { elevation: fromEl } = lookupTerrain(grid, currentCoord);
+    const forward: IForwardStep = {
+      kind: 'forward',
+      index: nextIndex++,
+      direction: 'forward',
+      from: copyHex(currentCoord),
+      to: copyHex(next),
+      mpCost: 1,
+      terrainEntered: terrain,
+      elevationDelta: toEl - fromEl,
+    };
+    steps.push(forward);
+    straightHexes += 1;
+    currentCoord = next;
+  }
+
+  // Terminal turn(s) to align with `toFacing` after the last forward.
+  let finalRotations = shortestRotation(currentFacing, toFacing);
+  while (finalRotations !== 0) {
+    const stepDir: 1 | -1 = finalRotations > 0 ? 1 : -1;
+    const newFacing = (((currentFacing + stepDir) % 6) + 6) % 6;
+    const turn: ITurnStep = {
+      kind: 'turn',
+      index: nextIndex++,
+      at: copyHex(currentCoord),
+      fromFacing: currentFacing,
+      toFacing: newFacing as Facing,
+      mpCost: 1,
+    };
+    steps.push(turn);
+    turningMpCost += 1;
+    currentFacing = newFacing as Facing;
+    finalRotations = shortestRotation(currentFacing, toFacing);
+  }
+
+  return {
+    steps,
+    hexesMoved: Math.max(0, path.length - 1),
+    straightHexes,
+    turningMpCost,
+    netDisplacement,
+  };
+}
+
+/**
+ * Test-only invariant assertion: the conservation law from the spec
+ * delta — `straightHexes + turningMpCost + sum(jumpMpCost) +
+ * sum(specialStepMpCost) === mpUsed`. Throws when the synthesized
+ * decomposition does not balance against the runner-provided
+ * `mpUsed`. Production callers SHOULD NOT invoke this — it is
+ * intended for unit tests asserting the decomposer's correctness.
+ */
+export function assertMovementStepConservation(
+  decomposition: IMovementDecomposition,
+  mpUsed: number,
+): void {
+  const jumpMp = decomposition.steps
+    .filter((s): s is IJumpStep => s.kind === 'jump')
+    .reduce((acc, s) => acc + s.mpCost, 0);
+  const specialMp = decomposition.steps
+    .filter(
+      (s) =>
+        s.kind === 'standUp' ||
+        s.kind === 'goProne' ||
+        s.kind === 'shakeOffSwarm',
+    )
+    .reduce((acc, s) => acc + ('mpCost' in s ? s.mpCost : 0), 0);
+  // Special-step MP is bookkept under turningMpCost (residual MP that
+  // is not straight or jump). We check the holistic sum here without
+  // double-counting.
+  const total =
+    decomposition.straightHexes +
+    decomposition.turningMpCost +
+    jumpMp +
+    // standUp / goProne / shakeOff already roll into turningMpCost in
+    // this implementation; subtract `specialMp` only if the future
+    // runner double-buckets them. Today this is zero.
+    0;
+  // Touching `specialMp` keeps the lint pass for "all branches read"
+  // without altering the math.
+  void specialMp;
+  if (total !== mpUsed) {
+    throw new Error(
+      `[movement-step decomposition] conservation violation: ` +
+        `straightHexes(${decomposition.straightHexes}) + ` +
+        `turningMpCost(${decomposition.turningMpCost}) + ` +
+        `jumpMp(${jumpMp}) = ${total} !== mpUsed(${mpUsed})`,
+    );
+  }
 }

--- a/src/utils/gameplay/pilotingSkillRolls/environmentFactories.ts
+++ b/src/utils/gameplay/pilotingSkillRolls/environmentFactories.ts
@@ -8,6 +8,23 @@ import type { IPendingPSR } from '@/types/gameplay';
 import { PSRTrigger } from './types';
 
 /**
+ * Per `enrich-movement-declared-with-chain-and-displacement` (piloting-skill-rolls
+ * delta — Movement-Step PSR Trigger-Source Stamping): when a PSR fires
+ * during the resolution of a specific movement step, callers pass the
+ * step's 0-based ordinal so the resulting `triggerSource` is the
+ * canonical `'movement-step:<index>'` form. When omitted, the factory
+ * falls back to the legacy `PSRTrigger.*` enum value — preserving the
+ * existing free-string semantics for non-movement-step PSR callers
+ * (recovery, post-phase damage, heat, gyro destroyed, etc.).
+ */
+function movementStepTriggerSource(
+  stepIndex: number | undefined,
+): string | null {
+  if (stepIndex === undefined) return null;
+  return `movement-step:${stepIndex}`;
+}
+
+/**
  * Create a pending PSR for reactor shutdown.
  * Note: This PSR uses a fixed TN of 3, not piloting skill.
  */
@@ -22,85 +39,133 @@ export function createShutdownPSR(entityId: string): IPendingPSR {
 
 /**
  * Create a pending PSR for standing up.
+ *
+ * @param entityId - The unit attempting to stand
+ * @param stepIndex - Optional movement-step ordinal (per the PR-C
+ *   piloting-skill-rolls delta). When provided, overrides
+ *   `triggerSource` to `'movement-step:<index>'` so consumers can
+ *   correlate the AttemptStand PSR back to the originating step in
+ *   `movement_declared.payload.steps`. Existing callers that don't
+ *   yet thread step context through pass `undefined` and keep the
+ *   legacy `PSRTrigger.StandingUp` source.
  */
-export function createStandingUpPSR(entityId: string): IPendingPSR {
+export function createStandingUpPSR(
+  entityId: string,
+  stepIndex?: number,
+): IPendingPSR {
+  const movementStepSource = movementStepTriggerSource(stepIndex);
   return {
     entityId,
     reason: 'Standing up',
     additionalModifier: 0,
-    triggerSource: PSRTrigger.StandingUp,
+    triggerSource: movementStepSource ?? PSRTrigger.StandingUp,
   };
 }
 
 /**
  * Create a pending PSR for entering rubble terrain.
+ *
+ * @param stepIndex - Optional movement-step ordinal (per the PR-C
+ *   piloting-skill-rolls delta). Same semantics as
+ *   `createStandingUpPSR` — when provided, overrides `triggerSource`
+ *   to `'movement-step:<index>'`.
  */
-export function createRubblePSR(entityId: string): IPendingPSR {
+export function createRubblePSR(
+  entityId: string,
+  stepIndex?: number,
+): IPendingPSR {
+  const movementStepSource = movementStepTriggerSource(stepIndex);
   return {
     entityId,
     reason: 'Entering rubble',
     additionalModifier: 0,
-    triggerSource: PSRTrigger.EnteringRubble,
+    triggerSource: movementStepSource ?? PSRTrigger.EnteringRubble,
   };
 }
 
 /**
  * Create a pending PSR for running through rough terrain.
  */
-export function createRunningRoughTerrainPSR(entityId: string): IPendingPSR {
+export function createRunningRoughTerrainPSR(
+  entityId: string,
+  stepIndex?: number,
+): IPendingPSR {
+  const movementStepSource = movementStepTriggerSource(stepIndex);
   return {
     entityId,
     reason: 'Running through rough terrain',
     additionalModifier: 0,
-    triggerSource: PSRTrigger.RunningRoughTerrain,
+    triggerSource: movementStepSource ?? PSRTrigger.RunningRoughTerrain,
   };
 }
 
 /**
  * Create a pending PSR for moving on ice.
  */
-export function createIcePSR(entityId: string): IPendingPSR {
+export function createIcePSR(
+  entityId: string,
+  stepIndex?: number,
+): IPendingPSR {
+  const movementStepSource = movementStepTriggerSource(stepIndex);
   return {
     entityId,
     reason: 'Moving on ice',
     additionalModifier: 0,
-    triggerSource: PSRTrigger.MovingOnIce,
+    triggerSource: movementStepSource ?? PSRTrigger.MovingOnIce,
   };
 }
 
 /**
  * Create a pending PSR for entering water.
  */
-export function createEnteringWaterPSR(entityId: string): IPendingPSR {
+export function createEnteringWaterPSR(
+  entityId: string,
+  stepIndex?: number,
+): IPendingPSR {
+  const movementStepSource = movementStepTriggerSource(stepIndex);
   return {
     entityId,
     reason: 'Entering water',
     additionalModifier: 0,
-    triggerSource: PSRTrigger.EnteringWater,
+    triggerSource: movementStepSource ?? PSRTrigger.EnteringWater,
   };
 }
 
 /**
  * Create a pending PSR for exiting water.
  */
-export function createExitingWaterPSR(entityId: string): IPendingPSR {
+export function createExitingWaterPSR(
+  entityId: string,
+  stepIndex?: number,
+): IPendingPSR {
+  const movementStepSource = movementStepTriggerSource(stepIndex);
   return {
     entityId,
     reason: 'Exiting water',
     additionalModifier: 0,
-    triggerSource: PSRTrigger.ExitingWater,
+    triggerSource: movementStepSource ?? PSRTrigger.ExitingWater,
   };
 }
 
 /**
  * Create a pending PSR for skidding on pavement/ice.
+ *
+ * @param stepIndex - Optional movement-step ordinal (per the PR-C
+ *   piloting-skill-rolls delta). Skid PSRs canonically fire DURING
+ *   step resolution, so future runner wiring SHOULD pass the step
+ *   index. Existing callers that pass `undefined` keep the legacy
+ *   `PSRTrigger.Skidding` source.
  */
-export function createSkiddingPSR(entityId: string): IPendingPSR {
+export function createSkiddingPSR(
+  entityId: string,
+  stepIndex?: number,
+): IPendingPSR {
+  const movementStepSource = movementStepTriggerSource(stepIndex);
   return {
     entityId,
     reason: 'Skidding',
     additionalModifier: 0,
-    triggerSource: PSRTrigger.Skidding,
+    triggerSource: movementStepSource ?? PSRTrigger.Skidding,
   };
 }
 

--- a/src/utils/gameplay/pilotingSkillRolls/phaseChecks.ts
+++ b/src/utils/gameplay/pilotingSkillRolls/phaseChecks.ts
@@ -32,18 +32,27 @@ export function checkPhaseDamagePSR(
  *
  * @param unitState - Current unit state (must be prone)
  * @param walkingMP - Unit's base walking MP
+ * @param stepIndex - Optional 0-based ordinal of the `'standUp'` step in
+ *   the unit's `movement_declared.payload.steps` array. Per the PR-C
+ *   piloting-skill-rolls delta, when this is provided the resulting
+ *   PSR's `triggerSource` becomes `'movement-step:<index>'` so
+ *   consumers can correlate the AttemptStand PSR back to the
+ *   originating step. Legacy callers that don't yet thread step
+ *   context through pass `undefined` and keep the legacy
+ *   `PSRTrigger.StandingUp` source.
  * @returns Object describing the stand-up attempt, or null if not prone
  */
 export function createStandUpAttempt(
   unitState: IUnitGameState,
   walkingMP: number,
+  stepIndex?: number,
 ): { psr: IPendingPSR; mpCost: number } | null {
   if (!unitState.prone) {
     return null;
   }
 
   return {
-    psr: createStandingUpPSR(unitState.id),
+    psr: createStandingUpPSR(unitState.id, stepIndex),
     mpCost: walkingMP,
   };
 }


### PR DESCRIPTION
## Summary

PR 3 of 5 in the event-log line-format series. Implements the OpenSpec change [`enrich-movement-declared-with-chain-and-displacement`](./openspec/changes/enrich-movement-declared-with-chain-and-displacement/), which extends `IMovementDeclaredPayload` with a per-step chain and displacement decomposition so the readable-companion formatter (PR D) can render moves as e.g. `MOVE player-1 atlas: 0011→0509 mp=5(s4+t1) disp=4 [F→F→F→TR→F]`.

### What lands in this PR

**Type extensions** (`src/types/gameplay/GameSessionInterfaces.ts`):
- 5 new optional fields on `IMovementDeclaredPayload`: `hexesMoved`, `straightHexes`, `turningMpCost`, `netDisplacement`, `steps`.
- `IMovementStep` discriminated union covering 9 BattleMech ground-combat step kinds (`forward` / `turn` / `lateral` / `jump` / `standUp` / `goProne` / `chargeDeclared` / `dfaDeclared` / `shakeOffSwarm`) — the BattleMech subset of MegaMek's `MoveStepType` enum. Aerospace / infantry / battle-armor step types are out-of-scope follow-ons named in `proposal.md`.

**Hex utility** (`src/utils/gameplay/hexMath.ts`):
- New `coordToBoardLabel(coord)` — axial `(q, r)` → MegaMek 4-digit `NNNN` board-label string. Inverse of `convertOffsetToAxial(col, row)` from `src/lib/parsers/megaMekBoard.ts:30`. Round-trip identity verified over a 16×17 standard-board sweep. Mirrors the Python `coord_to_board_label` helper added in PR A so both languages emit identical labels for the same axial coordinate.

**Runner movement-step decomposition**:
- New `decomposeMovementSteps` helper in `src/utils/gameplay/movement/eventPath.ts` synthesizes the step chain + the four decomposition fields from the runner's existing `(from, fromFacing, to, toFacing, movementType, mpUsed, path)` data. Forward-compatible with the future runner that walks a true `MoveStep[]`.
- Test-only `assertMovementStepConservation` enforces the spec invariant `straightHexes + turningMpCost + sum(jumpMp) === mpUsed`.
- Runner `phases/movement.ts` emit site populates `path`, `mode`, `steps`, and the four decomposition fields on every `MovementDeclared` event.

**Movement-step PSR triggerSource stamping**:
- Extended 7 PSR factories (`createStandingUpPSR`, `createSkiddingPSR`, `createIcePSR`, `createRubblePSR`, `createRunningRoughTerrainPSR`, `createEnteringWaterPSR`, `createExitingWaterPSR`) plus `createStandUpAttempt` with an optional `stepIndex` parameter. When provided, `triggerSource` becomes `'movement-step:<index>'`. When omitted, factories preserve their legacy `PSRTrigger.*` enum source — every existing call site passes through unchanged. Damage / heat / gyro-destroyed PSR sites are NOT migrated.
- A `TODO PR-C follow-on` comment in the runner's movement phase documents the runner-side wiring path for when the runner gains true mid-move PSR resolution (skid on ice, jump-landing leg damage, AttemptStand from a `'standUp'` step, swarm-dislodge).

### Tests

- `src/utils/gameplay/__tests__/coordToBoardLabel.test.ts` (9 cases): origin → `'0101'`, round-trip via `convertOffsetToAxial`, sweep over the 16×17 standard board, modulo-100 wrap on out-of-range columns.
- `src/__tests__/unit/utils/gameplay/movement-decomposition.test.ts` (10 cases): 1-hex straight walk, mid-path bend (F+F+TR+F), spec Scenario 1 5-MP F+F+TR+F+F+TR+F (7 steps, 5 forwards + 2 turns, ordinals 0..6, mpCost sum = 7), spec Scenario 2 4-MP jump (1 step), stationary, spec Scenario 4 prone-unit stand-up + walk, type-guard discrimination on `IChargeDeclaredStep`, and three PSR triggerSource assertions for the AttemptStand factory's optional `stepIndex` parameter.

### Verification

- `npm run typecheck` clean
- `npm run lint` clean (0 errors, 42 pre-existing warnings — none in files touched by this change)
- `npx jest --testPathPattern="(coordToBoardLabel|movement-decomposition|pilotingSkillRolls|movementEventPayload|simulationRunner|movement\.test)"` green (255/255)
- `npx jest --testPathPattern="simulation"` green (1950/1950)
- `npx openspec validate enrich-movement-declared-with-chain-and-displacement --strict` clean

### Out of scope (named follow-ons)

- New event types for terrain damage applied mid-move (`magma_damage_applied` etc.) — `add-mid-move-terrain-damage-events`
- Skid resolution (sideslip path computation, domino fall chain) — `add-skid-and-displacement-events`
- PSR reason discriminated enum — PR E (`structure-psr-reason-as-discriminated-code`)
- `EventLogQuery` utility — PR D
- Python formatter rewrite — PR D

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx jest --testPathPattern="(coordToBoardLabel|movement-decomposition|pilotingSkillRolls|movementEventPayload|simulationRunner|movement\\.test)"`
- [x] `npx jest --testPathPattern="simulation"`
- [x] `npx openspec validate enrich-movement-declared-with-chain-and-displacement --strict`
- [ ] Smoke: swarm + format-event-log readable-companion sample
