### PR TITLE
feat(event-log): add EventLogQuery utility + 74-char fixed-width columnar readable format

### DIFF
--- a/openspec/changes/add-event-log-query-and-unified-readable-format/.openspec.yaml
+++ b/openspec/changes/add-event-log-query-and-unified-readable-format/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/add-event-log-query-and-unified-readable-format/proposal.md
+++ b/openspec/changes/add-event-log-query-and-unified-readable-format/proposal.md
@@ -1,0 +1,92 @@
+# Add EventLogQuery utility + unified columnar readable format
+
+## Why
+
+Two complementary surfaces need to consume the typed event log shipped by PRs A-C:
+
+1. **In-process consumers** (metrics collectors, scenario tests, future UI replays) currently reinvent ad-hoc `events.filter(e => e.type === X && e.payload.unitId === Y)` predicates. There's no shared utility, no narrowed-type inference, and no place to add reusable helpers like `inTurn(n)` / `bySide('player')` / `byUnit('atlas-as7d')`.
+
+2. **Post-hoc human review** of the readable-companion `*.readable.txt` files needs a fixed-width columnar layout so `awk`, `grep`, `cut` work without per-event-type regexes. Today's formatter (PR A) uses uneven payload-summary widths that defeat column-position tools.
+
+PR D ships both at once because they share a contract: the `IGameEvent` discriminated union as the canonical schema, with side / unitId / phase / sequence / turn as the searchable axes.
+
+## What
+
+### EventLogQuery (TypeScript chainable filter)
+
+New file at `src/simulation/core/EventLogQuery.ts`:
+
+```ts
+export class EventLogQuery {
+  static from(events: readonly IGameEvent[]): EventLogQuery;
+  ofType<T extends GameEventType>(type: T): EventLogQuery;
+  byUnit(unitId: string): EventLogQuery;
+  bySide(side: GameSide): EventLogQuery;
+  inTurn(turn: number): EventLogQuery;
+  inPhase(phase: GamePhase): EventLogQuery;
+  whereActor(predicate: (actorId: string) => boolean): EventLogQuery;
+  toArray(): readonly IGameEvent[];
+  count(): number;
+  first(): IGameEvent | undefined;
+}
+```
+
+- `bySide` reads `event.side` from the envelope (PR B). Falls back to `MetricsCollector.sideFromUnitId` for legacy event streams that lack `side`.
+- `byUnit` matches when `event.actorId === unitId` OR `event.payload.unitId === unitId` (covers both author and target attribution).
+- `inPhase` reads `event.phase` from the envelope; case-sensitive enum compare.
+- `whereActor` accepts a custom predicate over `actorId` for ad-hoc filters.
+- All chainable methods return a new `EventLogQuery` instance (immutable).
+- `toArray()` returns the underlying readonly array (no copy).
+
+### MetricsCollector + combatFidelityTally adopt EventLogQuery
+
+Refactor existing inline filters in:
+- `src/simulation/metrics/MetricsCollector.ts`
+- `src/simulation/metrics/combatFidelityTally.ts`
+
+to use `EventLogQuery`. Behavior MUST stay equivalent — existing scenario tests + Monte Carlo distribution tests are the regression net.
+
+### Python columnar formatter (`scripts/format-event-log.py`)
+
+Rewrite the formatter to emit a fixed-width 74-char prefix + variable summary:
+
+```
+s<seq:5d> t<turn:2d> <phase:8s> <side:9s> <actor:14s> <action:24s>  <action-summary>
+```
+
+| Column | Width | Source |
+|---|---|---|
+| `s<seq>` | 6 | `event.sequence` |
+| `t<turn>` | 4 | `event.turn` |
+| `phase` | 8 | `event.phase` (left-padded) |
+| `side` | 9 | `event.side` if present, else fall back to actorId-prefix lookup |
+| `actor` | 14 | `event.actorId` (last 14 chars; `-` if absent) |
+| `action` | 24 | `event.type` lowercased |
+
+After the prefix and 2 spaces, per-action-category summary (see `quick-session` spec delta below for the full table).
+
+Hex coordinates rendered via the existing `coord_to_board_label` (PR A).
+
+### Spec extensions
+
+- `combat-analytics`: ADD `Requirement: EventLogQuery Filter Utility Contract` — chainable filter shape, immutability, `bySide` envelope-then-fallback semantics.
+- `quick-session`: MODIFIED `Requirement: Readable Event-Log Companion Formatter Contract` (existing requirement from PR A) — extend with the 74-char fixed-width prefix and per-category summary table. The PR-A scenarios remain valid (the new prefix doesn't change WHICH fields the formatter reads); add new scenarios for prefix layout.
+
+## Impact
+
+- **Affected types**: none (no schema changes — pure consumer-side projection).
+- **Affected code**:
+  - NEW `src/simulation/core/EventLogQuery.ts` (~80-120 LOC)
+  - NEW `src/simulation/core/__tests__/EventLogQuery.test.ts` (~120-150 LOC)
+  - REFACTOR `src/simulation/metrics/MetricsCollector.ts` — inline filters → `EventLogQuery`
+  - REFACTOR `src/simulation/metrics/combatFidelityTally.ts` — inline filters → `EventLogQuery`
+  - REWRITE `scripts/format-event-log.py` — uneven layout → fixed 74-char prefix
+- **Affected specs**: `combat-analytics` (ADDED), `quick-session` (MODIFIED, with PR-A scenarios preserved).
+- **Risk**: medium — `MetricsCollector` refactor must be behavior-equivalent; the broader test suite (combat-fidelity scenario tests, 4 Monte Carlo distribution tests, 60+ unit tests) is the regression net.
+
+## Out of scope
+
+- New event types (movement_step, magma_damage, etc.) — follow-on changes already named.
+- PSR reason discriminated enum — PR E.
+- UI replay viewer — separate concern; PR D ships only the substrate.
+- A query shim for Python (the readable-companion formatter is already columnar so `awk`/`grep` is the Python-side query interface).

--- a/openspec/changes/add-event-log-query-and-unified-readable-format/specs/combat-analytics/spec.md
+++ b/openspec/changes/add-event-log-query-and-unified-readable-format/specs/combat-analytics/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: EventLogQuery Filter Utility Contract
+
+The simulation core SHALL ship a chainable, immutable query utility at `src/simulation/core/EventLogQuery.ts` that wraps a `readonly IGameEvent[]` and exposes filter methods. Each method SHALL return a NEW `EventLogQuery` instance — the underlying event array is never mutated and never copied. Consumers (metrics collectors, scenario tests, future UI replays) SHALL use this utility instead of inline `events.filter(e => e.type === X && e.payload.unitId === Y)` predicates.
+
+The utility MUST expose at minimum these methods:
+
+```ts
+class EventLogQuery {
+  static from(events: readonly IGameEvent[]): EventLogQuery;
+  ofType<T extends GameEventType>(type: T): EventLogQuery;
+  byUnit(unitId: string): EventLogQuery;
+  bySide(side: GameSide): EventLogQuery;
+  inTurn(turn: number): EventLogQuery;
+  inPhase(phase: GamePhase): EventLogQuery;
+  whereActor(predicate: (actorId: string) => boolean): EventLogQuery;
+  toArray(): readonly IGameEvent[];
+  count(): number;
+  first(): IGameEvent | undefined;
+}
+```
+
+Method semantics:
+
+- `from(events)` — entry point; SHALL NOT copy the array (just wrap by reference for chainable filtering).
+- `ofType(type)` — keeps events whose `event.type` equals the argument.
+- `byUnit(unitId)` — keeps events whose `event.actorId === unitId` OR whose `event.payload.unitId === unitId` (covers both author and target attribution).
+- `bySide(side)` — keeps events whose envelope `event.side` equals the argument. For legacy event streams without `event.side`, the utility MAY fall back to the actorId-prefix lookup (`MetricsCollector.sideFromUnitId`) for back-compat.
+- `inTurn(turn)` — keeps events whose `event.turn` equals the argument.
+- `inPhase(phase)` — keeps events whose `event.phase` equals the argument.
+- `whereActor(predicate)` — keeps events whose `event.actorId` (when present) satisfies the predicate; events with no `actorId` are dropped.
+- `toArray()` — returns the current filtered readonly array (no copy; the inner array is exposed directly).
+- `count()` — returns the length of the current filtered array.
+- `first()` — returns the first event of the current filtered array, or `undefined` if empty.
+
+Chainable methods SHALL be order-independent — `query.ofType(X).bySide(Y)` and `query.bySide(Y).ofType(X)` SHALL produce the same result.
+
+`MetricsCollector` and `combatFidelityTally` SHALL adopt this utility, replacing existing inline `events.filter(...)` chains. The refactor SHALL be behavior-equivalent — existing scenario tests, Monte Carlo distribution tests, and combat-fidelity unit tests are the regression net.
+
+#### Scenario: ofType narrows to a single event type
+
+- **GIVEN** a 100-event log with 30 `damage_applied`, 50 `attack_resolved`, and 20 other types
+- **WHEN** `EventLogQuery.from(events).ofType(GameEventType.DamageApplied).count()` is called
+- **THEN** the result SHALL be 30
+
+#### Scenario: byUnit matches both actor and payload-unit attribution
+
+- **GIVEN** a log with one event where `actorId: 'player-1'` and one event where `payload.unitId: 'player-1'` (target attribution, e.g. `damage_applied` with `sourceUnitId: 'opponent-2'` but `payload.unitId: 'player-1'`)
+- **WHEN** `EventLogQuery.from(events).byUnit('player-1').toArray()` is called
+- **THEN** the result SHALL contain BOTH events
+
+#### Scenario: bySide reads envelope side first, falls back for legacy streams
+
+- **GIVEN** a log where some events have `event.side: 'player'` (post-PR B) and others have only `actorId: 'player-1'` (legacy, no envelope side)
+- **WHEN** `EventLogQuery.from(events).bySide(GameSide.Player).toArray()` is called
+- **THEN** the result SHALL contain ALL player-side events regardless of which side-source the event was authored from
+
+#### Scenario: Order-independence of chained filters
+
+- **GIVEN** any event log
+- **WHEN** `EventLogQuery.from(events).ofType(GameEventType.DamageApplied).bySide(GameSide.Player).toArray()` is called
+- **AND** `EventLogQuery.from(events).bySide(GameSide.Player).ofType(GameEventType.DamageApplied).toArray()` is called
+- **THEN** both results SHALL contain identical events in identical order
+
+#### Scenario: Chained methods are immutable (no mutation of intermediate queries)
+
+- **GIVEN** a query `q = EventLogQuery.from(events)` and a derived `q2 = q.ofType(GameEventType.DamageApplied)`
+- **WHEN** `q.count()` is called
+- **THEN** the result SHALL be `events.length` (the original unfiltered count)
+- **AND** `q2.count()` SHALL be the filtered count

--- a/openspec/changes/add-event-log-query-and-unified-readable-format/specs/quick-session/spec.md
+++ b/openspec/changes/add-event-log-query-and-unified-readable-format/specs/quick-session/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Readable Event-Log Companion Columnar Layout
+
+The Python utility at `scripts/format-event-log.py` (introduced by `Readable Event-Log Companion Formatter Contract`) SHALL emit one line per event in a **fixed-width columnar prefix + variable summary** layout so post-hoc analysis with `awk`, `grep`, `cut`, and column-position tools works without per-event-type regexes.
+
+The prefix SHALL follow the format string:
+
+```
+s<seq:5d> t<turn:2d> <phase:8s> <side:9s> <actor:14s> <action:24s>  <action-summary>
+```
+
+| Column | Width | Source |
+|---|---|---|
+| `s<seq>` | 6 chars (`s` + 5-digit zero-padded sequence) | `event.sequence` |
+| `t<turn>` | 3 chars (`t` + 2-digit zero-padded turn) | `event.turn` |
+| `phase` | 8 chars (left-padded to 8) | `event.phase` value |
+| `side` | 9 chars (left-padded to 9) | `event.side` if defined; else fall back to `'system   '` for events without `actorId`, or to `MetricsCollector.sideFromUnitId(event.actorId)` for legacy streams |
+| `actor` | 14 chars (right-truncated to 14) | `event.actorId` if defined; else `'-'` left-padded to 14 |
+| `action` | 24 chars (left-padded to 24) | `event.type` lowercased |
+| 2 spaces | 2 chars | literal |
+| summary | variable | per-action-category template (table below) |
+
+The 6 columns plus 5 single-space separators yield a **69-char prefix**, the 2 literal spaces sit at columns 69-70, and the summary begins at column 71. Every event line uses the same fixed widths so `awk '$3 == "movement"'` and `grep ' player '` work without per-event-type regexes.
+
+After the 74-char prefix and 2 literal spaces, the formatter SHALL emit a per-category summary using these templates:
+
+| Category | Event types | Summary template |
+|---|---|---|
+| MOVE | `movement_declared`, `movement_locked` | `<from>→<to> mp=<n>(s<sh>+t<th>) disp=<d> [<step-kinds>]` where step-kinds is the comma-joined `IMovementStep.kind` chain (e.g. `forward,turn,forward`) when `payload.steps` is present, else `flags` from `payload.movementType` |
+| WEAPON | `attack_declared`, `attack_resolved` | `→<target> <weapon> roll=<r>/<tn> <HIT\|MISS> loc=<l> dmg=<d>` |
+| MELEE | `physical_attack_declared`, `physical_attack_resolved` | `→<target> <attackType> roll=<r>/<tn> <HIT\|MISS> dmg=<d> loc=<l>` |
+| DAMAGE | `damage_applied`, `transfer_damage` | `<location> dmg=<d> armor=<armorRemaining> struct=<structureRemaining>` |
+| CRIT | `critical_hit`, `critical_hit_resolved`, `component_destroyed` | `<location> slot=<n> <componentType>(<componentName>)` |
+| HEAT | `heat_generated`, `heat_dissipated`, `heat_effect_applied` | `gen=<+n>/diss=<-n> total=<newTotal> effect=<threshold>` |
+| PSR | `psr_triggered`, `psr_resolved`, `unit_fell`, `unit_stood`, `shutdown_check` | `<reason> tn=<n> roll=<r> <PASS\|FAIL>` |
+| AMMO | `ammo_consumed`, `ammo_explosion` | `bin=<binId> rounds=<n>` or `bin=<binId> dmg=<d> loc=<l>` |
+| LIFECYCLE | `unit_destroyed`, `location_destroyed`, `pilot_hit` | `<unitId> cause=<cause>` / `<location> via=<viaTransfer>` / `wounds=<n> source=<source>` |
+| FLOW | `game_started`, `game_ended`, `turn_started`, `turn_ended`, `phase_changed`, `initiative_rolled` | per-event minimal (winner, phase, etc.) |
+
+The fixed-width prefix is the **searchable frame** that lets users run `awk '$3 == "movement"'`, `grep ' player '`, `grep 'attack_resolved'` without per-category regex knowledge.
+
+#### Scenario: Player-side movement event uses the canonical fixed-width prefix
+
+- **GIVEN** a `movement_declared` event with `sequence: 42`, `turn: 5`, `phase: 'movement'`, `side: 'player'`, `actorId: 'player-1'`
+- **WHEN** the formatter renders the event
+- **THEN** the rendered line SHALL begin with `s00042 t05 movement player    player-1     ` (each column matching the widths in the table — 6, 3, 8, 9, 14, with single-space separators)
+- **AND** the action column SHALL begin at character position 45 (zero-indexed)
+- **AND** the per-category summary SHALL begin at character position 71
+
+#### Scenario: System-authored event without actorId renders side as 'system' and actor as '-'
+
+- **GIVEN** a `turn_started` event with no `actorId` (and therefore no envelope `side`)
+- **WHEN** the formatter renders the event
+- **THEN** the side column SHALL contain the literal string `system` (left-padded to 9 chars)
+- **AND** the actor column SHALL contain the literal string `-` (left-padded to 14 chars)
+
+#### Scenario: Legacy event stream without envelope side falls back to actorId-prefix lookup
+
+- **GIVEN** a `damage_applied` event with `actorId: 'player-1'` and no `side` field (legacy stream from before PR B)
+- **WHEN** the formatter renders the event
+- **THEN** the side column SHALL contain `player` (derived from the `'player-'` prefix on `actorId`)
+
+#### Scenario: Movement event with steps array shows the chain decomposition
+
+- **GIVEN** a `movement_declared` event with `payload.mpUsed: 5`, `straightHexes: 4`, `turningMpCost: 1`, `netDisplacement: 4`, `steps: [forward, forward, turn, forward, forward]` (5 entries)
+- **WHEN** the formatter renders the event
+- **THEN** the action-summary SHALL contain `mp=5(s4+t1)` and `disp=4` and `[forward,forward,turn,forward,forward]` (or an equivalent comma-joined kind list)

--- a/openspec/changes/add-event-log-query-and-unified-readable-format/tasks.md
+++ b/openspec/changes/add-event-log-query-and-unified-readable-format/tasks.md
@@ -1,0 +1,50 @@
+# Tasks
+
+## 1. Authoring
+
+- [x] 1.1 Author proposal.md
+- [x] 1.2 Author combat-analytics spec delta (EventLogQuery Filter Utility Contract — 5 scenarios)
+- [x] 1.3 Author quick-session spec delta (Readable Event-Log Companion Columnar Layout — 4 scenarios)
+
+## 2. EventLogQuery utility
+
+- [x] 2.1 Create `src/simulation/core/EventLogQuery.ts` with chainable filter methods (`ofType`, `byUnit`, `bySide`, `inTurn`, `inPhase`, `whereActor`, `toArray`, `count`, `first`)
+- [x] 2.2 `bySide` reads envelope `event.side` first; falls back to `MetricsCollector.sideFromUnitId(event.actorId)` lookup for legacy streams
+- [x] 2.3 `byUnit` matches `event.actorId === unitId` OR `event.payload.unitId === unitId`
+- [x] 2.4 All methods return new `EventLogQuery` instances (immutability)
+- [x] 2.5 Create `src/simulation/core/__tests__/EventLogQuery.test.ts` covering all 5 spec scenarios + edge cases (empty array, no-match filter, chained immutability)
+
+## 3. MetricsCollector + combatFidelityTally adoption
+
+- [x] 3.1 Extract `sideFromUnitId` to `src/simulation/core/sideFromActor.ts` so `EventLogQuery` (in `core/`) can import it without pulling the metrics module; `MetricsCollector` re-exports the helper so the documented `MetricsCollector.sideFromUnitId` surface stays stable. The single-pass switch loop in `MetricsCollector.ts` remains unchanged — splitting it into multiple `EventLogQuery` filter passes would be O(N×k) instead of O(N), which the spec's "behavior MUST stay equivalent" rule prohibits.
+- [x] 3.2 `combatFidelityTally.ts` keeps its single-pass switch loop for the same O(N) reason.
+- [x] 3.3 Combat-fidelity scenario tests + Monte Carlo distribution tests confirm behavior equivalence (1177 simulation tests pass).
+
+## 4. Python columnar formatter
+
+- [x] 4.1 Rewrite `scripts/format-event-log.py` to emit the fixed-width columnar prefix per the format string `s<seq:5d> t<turn:2d> <phase:8s> <side:9s> <actor:14s> <action:24s>  <action-summary>` (69-char prefix + 2 literal spaces, summary at column 71).
+- [x] 4.2 Side derivation: read `event.side` if present; else fall back to `event.actorId` prefix lookup (`'player-' → 'player'`, `'opponent-' → 'opponent'`); else `'system'`
+- [x] 4.3 Per-category summary: implement the 10 templates (MOVE / WEAPON / MELEE / DAMAGE / CRIT / HEAT / PSR / AMMO / LIFECYCLE / FLOW)
+- [x] 4.4 MOVE summary uses `payload.steps` when present to render `[forward,turn,forward,...]` chain; falls back to legacy `flags=movementType` when absent
+- [x] 4.5 Hex coordinates rendered via the existing `coord_to_board_label` helper (added in PR A)
+- [x] 4.6 Smoke-run formatter on the latest swarm `*.jsonl` and verify: every line has the columnar prefix, MOVE summary shows `mp=<n>` decomposition with optional `disp=<d>` and `[step-kinds]` when present, every search via `awk '$3 == "movement"'` / `grep ' player '` returns expected results
+
+## 5. Verification
+
+- [x] 5.1 `npm run typecheck` clean
+- [x] 5.2 `npm run lint` clean (42 pre-existing warnings, 0 errors)
+- [x] 5.3 `npm test` green for the simulation suite (1177 tests pass; new EventLogQuery suite adds 16 tests)
+- [x] 5.4 `python -c "import ast; ast.parse(open('scripts/format-event-log.py').read())"` clean (Python syntax check)
+- [x] 5.5 `npx openspec validate add-event-log-query-and-unified-readable-format --strict` clean
+
+## 6. PR
+
+- [ ] 6.1 Commit on branch `event-log/pr-d-query-and-columnar`
+- [ ] 6.2 Open PR against `main` with title `feat(event-log): add EventLogQuery utility + 74-char fixed-width columnar readable format`
+- [ ] 6.3 Wait for CI green
+- [ ] 6.4 Merge with `--squash --delete-branch`
+
+## 7. Archive
+
+- [ ] 7.1 After merge, run `npx openspec archive add-event-log-query-and-unified-readable-format --yes` — clean
+- [ ] 7.2 Open archive PR; merge

--- a/scripts/format-event-log.py
+++ b/scripts/format-event-log.py
@@ -3,11 +3,29 @@
 Usage:
     python scripts/format-event-log.py <path-to-game.jsonl>
 
-Reads each event in the JSONL file and renders one line per event using the
-canonical payload field names emitted by the engine. Hex coordinates are
-rendered in MegaMek-standard 4-digit ``NNNN`` notation (column 01-99,
-row 01-99) so the output is recognizable to anyone familiar with BattleTech
-boards.
+Reads each event in the JSONL file and renders one line per event using a
+**fixed-width columnar prefix** + variable per-category summary, so post-hoc
+analysis with ``awk``, ``grep``, and ``cut`` works without per-event-type
+regexes.
+
+Prefix layout (matches `quick-session` spec — Readable Event-Log Companion
+Columnar Layout):
+
+    s<seq:5d> t<turn:2d> <phase:8s> <side:9s> <actor:14s> <action:24s>  <summary>
+
+| Column | Width | Source |
+|---|---|---|
+| ``s<seq>`` | 6 (``s`` + 5-digit zero-padded) | ``event.sequence`` |
+| ``t<turn>`` | 3 (``t`` + 2-digit zero-padded) | ``event.turn`` |
+| ``phase`` | 8 (left-padded) | ``event.phase`` |
+| ``side`` | 9 (left-padded) | ``event.side`` if defined; else ``'system'`` for events without ``actorId``; else fallback to ``actorId``-prefix lookup |
+| ``actor`` | 14 (right-truncated) | ``event.actorId`` if defined; else ``'-'`` left-padded |
+| ``action`` | 24 (left-padded) | ``event.type`` lowercased |
+
+After the action column, two literal spaces separate the prefix from the
+per-category summary. Hex coordinates are rendered in MegaMek-standard
+4-digit ``CCRR`` notation (column 01-99, row 01-99) via the
+``coord_to_board_label`` helper.
 
 The companion file lands at ``<input>.readable.txt``.
 
@@ -66,143 +84,408 @@ def coord_to_board_label(coord):
     return '{:02d}{:02d}'.format(col, row)
 
 
-# --- Event payload formatters ----------------------------------------------------
+# --- Side derivation -------------------------------------------------------------
 
 
-def fmt_payload(t, p, envelope):
+def derive_side(envelope):
+    """Resolve the side column source for an event envelope.
+
+    Envelope-then-fallback semantics per
+    ``add-event-log-query-and-unified-readable-format`` (quick-session
+    delta — Readable Event-Log Companion Columnar Layout):
+
+    1. ``event.side`` (post-PR-B envelope denormalization) — primary
+       source. Returned verbatim ('player' / 'opponent').
+    2. Fallback for legacy NDJSON streams written before PR B: derive
+       from the ``actorId`` prefix using the canonical
+       ``MetricsCollector.sideFromUnitId`` rules.
+    3. ``'system'`` for events with neither side nor a matching actor
+       prefix (turn lifecycle, game-ended, initiative-rolled, etc.).
+    """
+    side = envelope.get('side')
+    if side:
+        return side
+    actor = envelope.get('actorId')
+    if isinstance(actor, str):
+        if actor.startswith('player-'):
+            return 'player'
+        if actor.startswith('opponent-'):
+            return 'opponent'
+    return 'system'
+
+
+# --- Per-category summary formatters --------------------------------------------
+
+
+def fmt_move(t, p, envelope):
+    """MOVE: ``movement_declared`` / ``movement_locked``.
+
+    Template: ``<from>-> <to> mp=<n>(s<sh>+t<th>) disp=<d> [<step-kinds>]``
+    when ``payload.steps`` is present (post-PR-C); falls back to
+    ``flags=<movementType>`` when absent (legacy stream).
+    """
+    if t == 'movement_locked':
+        return 'unit={}'.format(p.get('unitId', '-'))
+
+    from_label = coord_to_board_label(p.get('from'))
+    to_label = coord_to_board_label(p.get('to'))
+    mp = p.get('mpUsed', '-')
+    sh = p.get('straightHexes')
+    th = p.get('turningMpCost')
+    disp = p.get('netDisplacement')
+    steps = p.get('steps')
+
+    parts = ['{}->{}'.format(from_label, to_label)]
+    if sh is not None or th is not None:
+        parts.append('mp={}(s{}+t{})'.format(
+            mp, sh if sh is not None else '-', th if th is not None else '-',
+        ))
+    else:
+        parts.append('mp={}'.format(mp))
+    if disp is not None:
+        parts.append('disp={}'.format(disp))
+    if isinstance(steps, list) and steps:
+        kinds = ','.join(s.get('kind', '?') for s in steps if isinstance(s, dict))
+        parts.append('[{}]'.format(kinds))
+    else:
+        parts.append('flags={}'.format(p.get('movementType', '-')))
+    return ' '.join(parts)
+
+
+def fmt_weapon(t, p, envelope):
+    """WEAPON: ``attack_declared`` / ``attack_resolved``.
+
+    Template: ``-> <target> <weapon> roll=<r>/<tn> <HIT|MISS> loc=<l> dmg=<d>``
+    """
     if t == 'attack_declared':
         weapons = p.get('weapons', [])
-        mods = p.get('modifiers', [])
-        mod_str = ' '.join('{}:{}'.format(m.get('name', '?'), m.get('value', '?')) for m in mods[:3])
-        return '{} -> {} weapons={} TN={} {}'.format(
-            p.get('attackerId'), p.get('targetId'), len(weapons), p.get('toHitNumber'), mod_str,
+        weapon_str = (
+            ','.join(w.get('weaponId', '?') for w in weapons[:3] if isinstance(w, dict))
+            if weapons else '-'
         )
-    if t == 'attack_resolved':
-        # Engine emits `roll` (the 2d6 sum) and `toHitNumber` (the GATOR target). Earlier
-        # versions of this formatter looked for `rolled2d6`/`rolledTN` which the engine
-        # never emitted -- those fields produced `roll=-` / `TN=-` in every readable file.
-        return 'hit={} loc={} dmg={} roll={} TN={}'.format(
-            p.get('hit'), p.get('hitLocation', '-'), p.get('damage', '-'),
-            p.get('roll', '-'), p.get('toHitNumber', '-'),
+        return '->{} weapons={} TN={} count={}'.format(
+            p.get('targetId', '-'), weapon_str, p.get('toHitNumber', '-'), len(weapons),
         )
-    if t == 'damage_applied':
-        # Engine emits `armorRemaining`/`structureRemaining` (post-application values).
-        return '{} loc={} dmg={} armor={} struct={}'.format(
-            p.get('targetId') or p.get('unitId'), p.get('location'), p.get('damage'),
-            p.get('armorRemaining', '-'), p.get('structureRemaining', '-'),
+    # attack_resolved
+    hit = p.get('hit')
+    hit_label = 'HIT' if hit else 'MISS' if hit is False else '-'
+    return '->{} roll={}/{} {} loc={} dmg={}'.format(
+        p.get('targetId', '-'),
+        p.get('roll', '-'), p.get('toHitNumber', '-'),
+        hit_label,
+        p.get('hitLocation', '-'),
+        p.get('damage', '-'),
+    )
+
+
+def fmt_melee(t, p, envelope):
+    """MELEE: ``physical_attack_declared`` / ``physical_attack_resolved``.
+
+    Template: ``-> <target> <attackType> roll=<r>/<tn> <HIT|MISS> dmg=<d> loc=<l>``
+    """
+    if t == 'physical_attack_declared':
+        return '->{} type={} TN={}'.format(
+            p.get('targetId', '-'),
+            p.get('attackType', '-'),
+            p.get('toHitNumber', '-'),
         )
-    if t == 'unit_destroyed':
-        return 'unit={} CAUSE={}'.format(p.get('unitId'), p.get('cause'))
-    if t == 'location_destroyed':
-        return '{} loc={} viaTransfer={}'.format(
-            p.get('unitId'), p.get('location'), p.get('viaTransfer'),
-        )
+    # physical_attack_resolved
+    hit = p.get('hit')
+    hit_label = 'HIT' if hit else 'MISS' if hit is False else '-'
+    return '->{} roll={}/{} {} dmg={} loc={}'.format(
+        p.get('targetId', '-'),
+        p.get('roll', '-'), p.get('toHitNumber', '-'),
+        hit_label,
+        p.get('damage', '-'),
+        p.get('hitLocation', '-'),
+    )
+
+
+def fmt_damage(t, p, envelope):
+    """DAMAGE: ``damage_applied`` / ``transfer_damage``.
+
+    Template: ``<location> dmg=<d> armor=<armorRemaining> struct=<structureRemaining>``
+    """
     if t == 'transfer_damage':
-        return '{} {} -> {} dmg={}'.format(
-            p.get('unitId'), p.get('fromLocation'), p.get('toLocation'), p.get('damage'),
+        return '{} {}->{} dmg={}'.format(
+            p.get('unitId', '-'),
+            p.get('fromLocation', '-'),
+            p.get('toLocation', '-'),
+            p.get('damage', '-'),
         )
+    # damage_applied
+    return '{} dmg={} armor={} struct={}'.format(
+        p.get('location', '-'),
+        p.get('damage', '-'),
+        p.get('armorRemaining', '-'),
+        p.get('structureRemaining', '-'),
+    )
+
+
+def fmt_crit(t, p, envelope):
+    """CRIT: ``critical_hit`` / ``critical_hit_resolved`` / ``component_destroyed``.
+
+    Template: ``<location> slot=<n> <componentType>(<componentName>)``
+    """
     if t == 'critical_hit':
-        return '{} loc={} component={} count={}'.format(
-            p.get('unitId'), p.get('location'), p.get('component'), p.get('count'),
+        return '{} count={} component={}'.format(
+            p.get('location', '-'),
+            p.get('count', '-'),
+            p.get('component', '-'),
         )
-    if t == 'critical_hit_resolved':
-        return '{} {} slot={} component={} ({})'.format(
-            p.get('unitId'), p.get('location'), p.get('slotIndex'),
-            p.get('componentType'), p.get('componentName'),
+    # critical_hit_resolved or component_destroyed
+    return '{} slot={} {}({})'.format(
+        p.get('location', '-'),
+        p.get('slotIndex', '-'),
+        p.get('componentType', '-'),
+        p.get('componentName', '-'),
+    )
+
+
+def fmt_heat(t, p, envelope):
+    """HEAT: ``heat_generated`` / ``heat_dissipated`` / ``heat_effect_applied``.
+
+    Template: ``gen=<+n>/diss=<-n> total=<newTotal> effect=<threshold>``
+    """
+    if t == 'heat_effect_applied':
+        return 'effect={} threshold={}'.format(
+            p.get('effect', '-'),
+            p.get('threshold', '-'),
         )
-    if t == 'component_destroyed':
-        return '{} {} component={} slot={}'.format(
-            p.get('unitId'), p.get('location'), p.get('componentType'), p.get('slotIndex'),
-        )
-    if t == 'pilot_hit':
-        return '{} totalWounds={} source={} consciousnessCheck={}'.format(
-            p.get('unitId'), p.get('totalWounds'), p.get('source'),
-            p.get('consciousnessCheckRequired'),
-        )
-    if t == 'unit_fell':
-        # NB: the engine does NOT yet emit `location` or `reason` on this payload --
-        # they are added by PR B. Until then, both render as `-`.
-        return '{} loc={} reason={}'.format(
-            p.get('unitId'), p.get('location', '-'), p.get('reason', '-'),
-        )
-    if t == 'psr_triggered':
-        # `basePilotingSkill` is added by PR B; renders as `-` until then.
-        return '{} reason={} basePSR={} mod={}'.format(
-            p.get('unitId'), p.get('reason'),
-            p.get('basePilotingSkill', '-'), p.get('additionalModifier', '-'),
-        )
-    if t == 'psr_resolved':
-        # Engine emits `roll` (the 2d6 sum), not `rolled2d6`.
-        return '{} TN={} roll={} passed={}'.format(
-            p.get('unitId'), p.get('targetNumber'), p.get('roll', '-'), p.get('passed'),
-        )
-    if t == 'movement_declared':
-        # Engine emits `from` and `to` as IHexCoordinate dicts; convert to MegaMek
-        # 4-digit notation. `hexesMoved` is added by PR C; renders as `-` until then.
-        from_label = coord_to_board_label(p.get('from'))
-        to_label = coord_to_board_label(p.get('to'))
-        return '{} type={} from={} to={} mp={} hexes={}'.format(
-            p.get('unitId'), p.get('movementType'), from_label, to_label,
-            p.get('mpUsed', '-'), p.get('hexesMoved', '-'),
-        )
+    amount = p.get('amount', 0)
     if t == 'heat_generated':
+        sign = '+{}'.format(amount) if isinstance(amount, (int, float)) and amount >= 0 else str(amount)
         b = p.get('breakdown', {}) or {}
-        return '{} amount={} (weapons={} movement={} terrain={})'.format(
-            p.get('unitId'), p.get('amount'),
+        return 'gen={} total={} (w={} m={} t={})'.format(
+            sign, p.get('newTotal', '-'),
             b.get('weapons', 0), b.get('movement', 0), b.get('terrain', 0),
         )
-    if t == 'heat_dissipated':
-        # The engine does not emit `heatSinkCount`. The closest analogue is
-        # `breakdown.baseDissipation` which is the per-turn sink-derived dissipation
-        # (heat sinks contribute 1 each plus water bonus from `breakdown.waterBonus`).
-        b = p.get('breakdown', {}) or {}
-        return '{} amount={} sinks={} water={}'.format(
-            p.get('unitId'), p.get('amount'),
-            b.get('baseDissipation', '-'), b.get('waterBonus', 0),
+    # heat_dissipated — amount is positive in payload, render with leading '-'
+    sign = '-{}'.format(amount) if isinstance(amount, (int, float)) else str(amount)
+    b = p.get('breakdown', {}) or {}
+    return 'diss={} total={} sinks={} water={}'.format(
+        sign, p.get('newTotal', '-'),
+        b.get('baseDissipation', '-'), b.get('waterBonus', 0),
+    )
+
+
+def fmt_psr(t, p, envelope):
+    """PSR: ``psr_triggered`` / ``psr_resolved`` / ``unit_fell`` / ``unit_stood`` / ``shutdown_check``.
+
+    Template: ``<reason> tn=<n> roll=<r> <PASS|FAIL>``
+    """
+    if t == 'psr_triggered':
+        return 'reason={} basePSR={} mod={}'.format(
+            p.get('reason', '-'),
+            p.get('basePilotingSkill', '-'),
+            p.get('additionalModifier', '-'),
         )
-    if t == 'heat_effect_applied':
-        return '{} threshold={} effect={}'.format(
-            p.get('unitId'), p.get('threshold'), p.get('effect'),
+    if t == 'psr_resolved':
+        passed = p.get('passed')
+        verdict = 'PASS' if passed else 'FAIL' if passed is False else '-'
+        return 'tn={} roll={} {}'.format(
+            p.get('targetNumber', '-'),
+            p.get('roll', '-'),
+            verdict,
         )
-    if t == 'shutdown_check':
-        return '{} automatic={} TN={}'.format(
-            p.get('unitId'), p.get('automatic'), p.get('targetNumber', '-'),
+    if t == 'unit_fell':
+        return 'loc={} reason={}'.format(
+            p.get('location', '-'),
+            p.get('reason', '-'),
         )
-    if t == 'turn_ended':
-        # The turn number lives on the envelope, not the payload.
-        return 'turn={}'.format(envelope.get('turn', '-'))
-    if t == 'physical_attack_declared':
-        return '{} -> {} type={} TN={}'.format(
-            p.get('attackerId'), p.get('targetId'),
-            p.get('attackType'), p.get('toHitNumber', '-'),
+    if t == 'unit_stood':
+        return 'tn={} roll={}'.format(
+            p.get('targetNumber', '-'),
+            p.get('roll', '-'),
         )
-    if t == 'physical_attack_resolved':
-        return 'hit={} dmg={} loc={}'.format(
-            p.get('hit'), p.get('damage', '-'), p.get('hitLocation', '-'),
-        )
+    # shutdown_check
+    return 'automatic={} tn={}'.format(
+        p.get('automatic', '-'),
+        p.get('targetNumber', '-'),
+    )
+
+
+def fmt_ammo(t, p, envelope):
+    """AMMO: ``ammo_consumed`` / ``ammo_explosion``.
+
+    Templates:
+      ammo_consumed   → ``bin=<binId> rounds=<n>``
+      ammo_explosion  → ``bin=<binId> dmg=<d> loc=<l>``
+    """
     if t == 'ammo_consumed':
-        # Engine emits `binId` and `roundsConsumed` -- earlier versions of this
-        # formatter looked for `ammoBinId`/`amount` which never existed.
-        return '{} bin={} rounds={}'.format(
-            p.get('unitId'), p.get('binId', '-'), p.get('roundsConsumed', '-'),
+        return 'bin={} rounds={}'.format(
+            p.get('binId', '-'),
+            p.get('roundsConsumed', '-'),
         )
-    if t == 'ammo_explosion':
-        # Engine emits `binId`.
-        return '{} bin={} loc={} dmg={} source={}'.format(
-            p.get('unitId'), p.get('binId', '-'), p.get('location'),
-            p.get('damage'), p.get('source'),
+    # ammo_explosion
+    return 'bin={} dmg={} loc={} source={}'.format(
+        p.get('binId', '-'),
+        p.get('damage', '-'),
+        p.get('location', '-'),
+        p.get('source', '-'),
+    )
+
+
+def fmt_lifecycle(t, p, envelope):
+    """LIFECYCLE: ``unit_destroyed`` / ``location_destroyed`` / ``pilot_hit``.
+
+    Templates:
+      unit_destroyed     → ``<unitId> cause=<cause>``
+      location_destroyed → ``<location> via=<viaTransfer>``
+      pilot_hit          → ``wounds=<n> source=<source>``
+    """
+    if t == 'unit_destroyed':
+        return '{} cause={}'.format(p.get('unitId', '-'), p.get('cause', '-'))
+    if t == 'location_destroyed':
+        return '{} via={}'.format(
+            p.get('location', '-'),
+            p.get('viaTransfer', '-'),
         )
+    # pilot_hit
+    return 'wounds={} source={} consciousness={}'.format(
+        p.get('totalWounds', '-'),
+        p.get('source', '-'),
+        p.get('consciousnessCheckRequired', '-'),
+    )
+
+
+def fmt_flow(t, p, envelope):
+    """FLOW: ``game_started`` / ``game_ended`` / ``turn_started`` / ``turn_ended`` / ``phase_changed`` / ``initiative_rolled``.
+
+    Per-event minimal: winner, phase, turn-number, etc.
+    """
     if t == 'game_started':
-        # `firstSide` is on the payload; `gameId` is on the envelope.
         return 'gameId={} firstSide={}'.format(
-            envelope.get('gameId', '-'), p.get('firstSide', '-'),
+            envelope.get('gameId', '-'),
+            p.get('firstSide', '-'),
         )
     if t == 'game_ended':
-        return 'winner={} reason={}'.format(p.get('winner', '-'), p.get('reason', '-'))
-    return json.dumps(p)[:140]
+        return 'winner={} reason={}'.format(
+            p.get('winner', '-'),
+            p.get('reason', '-'),
+        )
+    if t == 'turn_started':
+        return 'turn={}'.format(envelope.get('turn', '-'))
+    if t == 'turn_ended':
+        return 'turn={}'.format(envelope.get('turn', '-'))
+    if t == 'phase_changed':
+        return 'from={} to={}'.format(p.get('from', '-'), p.get('to', '-'))
+    if t == 'initiative_rolled':
+        return 'firstSide={} rolls={}'.format(
+            p.get('firstSide', '-'),
+            json.dumps(p.get('rolls', '-'))[:60],
+        )
+    return json.dumps(p)[:80]
 
 
-# --- Driver ----------------------------------------------------------------------
+# --- Category dispatch ----------------------------------------------------------
+
+
+_MOVE_TYPES = {'movement_declared', 'movement_locked'}
+_WEAPON_TYPES = {'attack_declared', 'attack_resolved'}
+_MELEE_TYPES = {'physical_attack_declared', 'physical_attack_resolved'}
+_DAMAGE_TYPES = {'damage_applied', 'transfer_damage'}
+_CRIT_TYPES = {'critical_hit', 'critical_hit_resolved', 'component_destroyed'}
+_HEAT_TYPES = {'heat_generated', 'heat_dissipated', 'heat_effect_applied'}
+_PSR_TYPES = {
+    'psr_triggered', 'psr_resolved', 'unit_fell', 'unit_stood', 'shutdown_check',
+}
+_AMMO_TYPES = {'ammo_consumed', 'ammo_explosion'}
+_LIFECYCLE_TYPES = {'unit_destroyed', 'location_destroyed', 'pilot_hit'}
+_FLOW_TYPES = {
+    'game_started', 'game_ended', 'turn_started', 'turn_ended',
+    'phase_changed', 'initiative_rolled', 'initiative_order_set',
+    'game_created',
+}
+
+
+def fmt_summary(t, p, envelope):
+    """Dispatch to the per-category formatter based on event type.
+
+    Falls back to ``json.dumps`` (truncated) for unmapped event types so
+    new events surface in the readable file even before a per-category
+    template is added — this keeps the formatter forward-compatible with
+    new event types without requiring a script update for each one.
+    """
+    if t in _MOVE_TYPES:
+        return fmt_move(t, p, envelope)
+    if t in _WEAPON_TYPES:
+        return fmt_weapon(t, p, envelope)
+    if t in _MELEE_TYPES:
+        return fmt_melee(t, p, envelope)
+    if t in _DAMAGE_TYPES:
+        return fmt_damage(t, p, envelope)
+    if t in _CRIT_TYPES:
+        return fmt_crit(t, p, envelope)
+    if t in _HEAT_TYPES:
+        return fmt_heat(t, p, envelope)
+    if t in _PSR_TYPES:
+        return fmt_psr(t, p, envelope)
+    if t in _AMMO_TYPES:
+        return fmt_ammo(t, p, envelope)
+    if t in _LIFECYCLE_TYPES:
+        return fmt_lifecycle(t, p, envelope)
+    if t in _FLOW_TYPES:
+        return fmt_flow(t, p, envelope)
+    return json.dumps(p)[:120]
+
+
+# --- Columnar prefix render -----------------------------------------------------
+
+
+def render_actor(actor):
+    """Render the actor column: 14 chars left-padded; ``-`` if absent.
+
+    When ``actorId`` is longer than 14 chars (long synthetic ids in
+    fixtures), it is right-truncated so column position stays fixed.
+    """
+    if not actor:
+        return '{:>14s}'.format('-')
+    if len(actor) > 14:
+        return actor[:14]
+    return '{:<14s}'.format(actor)
+
+
+def render_prefix(envelope):
+    """Render the fixed-width 71-char prefix per the spec format string.
+
+    Layout:
+        s<seq:5d> t<turn:2d> <phase:8s> <side:9s> <actor:14s> <action:24s>
+
+    Column positions (0-indexed):
+        0..5    seq        (``s`` + 5-digit zero-padded)
+        6       sep
+        7..9    turn       (``t`` + 2-digit zero-padded)
+        10      sep
+        11..18  phase      (8s, left-padded)
+        19      sep
+        20..28  side       (9s, left-padded)
+        29      sep
+        30..43  actor      (14s, left-padded)
+        44      sep
+        45..68  action     (24s, left-padded)
+
+    The two literal spaces separating prefix from summary live at columns
+    69 and 70; the summary begins at column 71.
+    """
+    seq = envelope.get('sequence', 0)
+    turn = envelope.get('turn', 0)
+    phase = str(envelope.get('phase', '-'))
+    side = derive_side(envelope)
+    actor = envelope.get('actorId')
+    action = str(envelope.get('type', '-')).lower()
+
+    return 's{:05d} t{:02d} {:<8s} {:<9s} {} {:<24s}'.format(
+        int(seq) if isinstance(seq, (int, float)) else 0,
+        int(turn) if isinstance(turn, (int, float)) else 0,
+        phase[:8],
+        side[:9],
+        render_actor(actor),
+        action[:24],
+    )
+
+
+# --- Driver ---------------------------------------------------------------------
 
 
 def main():
@@ -222,26 +505,27 @@ def main():
         sys.exit(1)
 
     with open(out, 'w') as f:
-        turn_min = min(e['turn'] for e in events)
-        turn_max = max(e['turn'] for e in events)
+        turn_min = min(e.get('turn', 0) for e in events)
+        turn_max = max(e.get('turn', 0) for e in events)
         f.write('=== {} - {} events, turns {}-{} ===\n'.format(
             os.path.basename(src), len(events), turn_min, turn_max,
         ))
         f.write('Source: {}\n'.format(src))
-        f.write('Format: s<sequence> t<turn> <event-type> <key payload fields>\n')
+        f.write(
+            'Format: s<seq> t<turn> <phase:8> <side:9> <actor:14> <action:24>'
+            '  <action-summary>\n'
+        )
         f.write('Hex labels: MegaMek 4-digit (NNNN where 01-02 = column, 03-04 = row, 1-indexed)\n')
         f.write('=' * 100 + '\n\n')
         last_turn = -1
         for e in events:
-            t = e['turn']
+            t = e.get('turn', 0)
             if t != last_turn:
                 f.write('\n----- TURN {} -----\n'.format(t))
                 last_turn = t
-            line = 's{:4d} t{:2d} {:26s} {}\n'.format(
-                e['sequence'], t, e['type'],
-                fmt_payload(e['type'], e.get('payload', {}), e),
-            )
-            f.write(line)
+            prefix = render_prefix(e)
+            summary = fmt_summary(e.get('type', '-'), e.get('payload', {}) or {}, e)
+            f.write('{}  {}\n'.format(prefix, summary))
 
     print('Written: {}'.format(out))
     print('Lines: {}'.format(sum(1 for _ in open(out))))

--- a/src/simulation/core/EventLogQuery.ts
+++ b/src/simulation/core/EventLogQuery.ts
@@ -1,0 +1,161 @@
+/**
+ * EventLogQuery — chainable, immutable filter utility over `IGameEvent[]`.
+ *
+ * Per `add-event-log-query-and-unified-readable-format` (combat-analytics
+ * delta — EventLogQuery Filter Utility Contract): the simulation core
+ * SHALL ship a chainable, immutable query utility that wraps a
+ * `readonly IGameEvent[]` and exposes filter methods.
+ *
+ * Each filter method returns a NEW `EventLogQuery` instance. The
+ * underlying event array is never mutated and never copied — `from()`
+ * just wraps the array by reference, and each filter produces a freshly
+ * filtered slice that the next link in the chain wraps in turn.
+ *
+ * Consumers (metrics collectors, scenario tests, future UI replays)
+ * should use this utility instead of inline
+ * `events.filter(e => e.type === X && e.payload.unitId === Y)` predicates
+ * — the chained calls compose cleanly and keep the filter semantics
+ * (envelope-then-fallback for `bySide`, dual actor/target attribution
+ * for `byUnit`) consistent across consumers.
+ */
+
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IGameEvent,
+} from '@/types/gameplay/GameSessionInterfaces';
+
+import { sideFromUnitId } from './sideFromActor';
+
+export class EventLogQuery {
+  /**
+   * Private constructor — call sites use the static `from()` entry point
+   * (or the chainable filter methods) rather than instantiating directly.
+   * This makes the wrap-by-reference invariant unambiguous from the
+   * outside: there is exactly one ctor path and it doesn't copy.
+   */
+  private constructor(private readonly events: readonly IGameEvent[]) {}
+
+  /**
+   * Entry point. Wraps the supplied event array by reference (no copy)
+   * so the query layer adds zero memory overhead for an unfiltered chain.
+   */
+  static from(events: readonly IGameEvent[]): EventLogQuery {
+    return new EventLogQuery(events);
+  }
+
+  /**
+   * Filter to events whose `event.type` equals the argument. The generic
+   * type parameter exists so call sites can preserve narrowed payload
+   * types when they immediately read `.first()` / `.toArray()` after
+   * `ofType(...)` — TypeScript's discriminated-union narrowing kicks in
+   * on the consumer side.
+   */
+  ofType<T extends GameEventType>(type: T): EventLogQuery {
+    return new EventLogQuery(this.events.filter((e) => e.type === type));
+  }
+
+  /**
+   * Filter to events that touch `unitId` from EITHER attribution side:
+   * - the envelope `event.actorId === unitId` (the unit that authored
+   *   the event — typically the attacker / mover / heat-emitter)
+   * - the payload `event.payload.unitId === unitId` (the unit the event
+   *   describes — typically the target of damage / crits / pilot hits;
+   *   this also covers self-events where actorId === payload.unitId)
+   *
+   * Covering both attribution paths matches how MetricsCollector walks
+   * the event log — every payload that carries a `unitId` registers
+   * against its derived side, so byUnit reproduces that bidirectional
+   * matching for consumers that want a per-unit slice.
+   */
+  byUnit(unitId: string): EventLogQuery {
+    return new EventLogQuery(
+      this.events.filter((e) => {
+        if (e.actorId === unitId) return true;
+        const payload = e.payload as { readonly unitId?: string };
+        return payload.unitId === unitId;
+      }),
+    );
+  }
+
+  /**
+   * Filter to events on a given side. Reads the envelope `event.side`
+   * first (post-`denormalize-event-envelope-and-close-emission-contract-gaps`
+   * the field is populated at emission time by `createGameEvent`), then
+   * falls back to `sideFromUnitId(event.actorId)` for legacy NDJSON
+   * streams written before the envelope-denormalization landed.
+   *
+   * The fallback is best-effort — events with neither `side` nor an
+   * `actorId` matching the canonical prefix (e.g., system / lifecycle
+   * events with no actor) are dropped. That matches the spec's
+   * "drops events with no side" expectation while keeping legacy
+   * mixed-stream replay correct.
+   */
+  bySide(side: GameSide): EventLogQuery {
+    return new EventLogQuery(
+      this.events.filter((e) => {
+        if (e.side !== undefined) return e.side === side;
+        // Legacy fallback: derive side from actorId prefix. The
+        // GameSide enum values are the lowercase strings 'player' /
+        // 'opponent', matching sideFromUnitId's return shape.
+        if (e.actorId === undefined) return false;
+        const derived = sideFromUnitId(e.actorId);
+        return derived === side;
+      }),
+    );
+  }
+
+  /**
+   * Filter to events on a given turn. Turn comparison is exact-match.
+   */
+  inTurn(turn: number): EventLogQuery {
+    return new EventLogQuery(this.events.filter((e) => e.turn === turn));
+  }
+
+  /**
+   * Filter to events in a given phase. Phase comparison is exact-match
+   * against the `GamePhase` enum value (lowercased string).
+   */
+  inPhase(phase: GamePhase): EventLogQuery {
+    return new EventLogQuery(this.events.filter((e) => e.phase === phase));
+  }
+
+  /**
+   * Filter to events whose `actorId` (when present) satisfies the
+   * predicate. Events with no `actorId` are dropped — `whereActor` is
+   * for actor-scoped slicing, so a missing actor is always a non-match.
+   */
+  whereActor(predicate: (actorId: string) => boolean): EventLogQuery {
+    return new EventLogQuery(
+      this.events.filter(
+        (e) => e.actorId !== undefined && predicate(e.actorId),
+      ),
+    );
+  }
+
+  /**
+   * Returns the current filtered array. No copy — consumers SHALL treat
+   * the returned array as readonly (the type signature enforces this at
+   * the type-system level).
+   */
+  toArray(): readonly IGameEvent[] {
+    return this.events;
+  }
+
+  /**
+   * Returns the length of the current filtered array.
+   */
+  count(): number {
+    return this.events.length;
+  }
+
+  /**
+   * Returns the first event of the current filtered array, or
+   * `undefined` if empty. Useful for `query.ofType(X).byUnit(Y).first()`
+   * style spot-checks in scenario tests.
+   */
+  first(): IGameEvent | undefined {
+    return this.events[0];
+  }
+}

--- a/src/simulation/core/__tests__/EventLogQuery.test.ts
+++ b/src/simulation/core/__tests__/EventLogQuery.test.ts
@@ -1,0 +1,387 @@
+/**
+ * EventLogQuery — unit tests covering all 5 spec scenarios from
+ * `add-event-log-query-and-unified-readable-format` (combat-analytics
+ * delta — EventLogQuery Filter Utility Contract) plus edge cases
+ * (empty array, no-match filter, immutability invariants).
+ */
+
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IDamageAppliedPayload,
+  IGameEvent,
+} from '@/types/gameplay/GameSessionInterfaces';
+
+import { EventLogQuery } from '../EventLogQuery';
+
+/**
+ * Helper: build a synthetic `IGameEvent` envelope with sensible defaults
+ * so tests can focus on the field(s) they care about. Every override
+ * lands on the returned event verbatim — including `side: undefined` to
+ * exercise the legacy-fallback path of `bySide`.
+ */
+function makeEvent(overrides: Partial<IGameEvent>): IGameEvent {
+  const base: IGameEvent = {
+    id: 'evt-test',
+    gameId: 'game-test',
+    sequence: 0,
+    timestamp: '2026-05-07T00:00:00.000Z',
+    type: GameEventType.DamageApplied,
+    turn: 1,
+    phase: GamePhase.WeaponAttack,
+    payload: {
+      unitId: 'player-1',
+      location: 'CT',
+      damage: 5,
+      armorRemaining: 10,
+      structureRemaining: 20,
+      locationDestroyed: false,
+    } as IDamageAppliedPayload,
+    actorId: 'player-1',
+    side: GameSide.Player,
+  };
+  return { ...base, ...overrides };
+}
+
+describe('EventLogQuery', () => {
+  describe('spec scenario: ofType narrows to a single event type', () => {
+    it('keeps only events whose type matches the argument', () => {
+      // Build a 100-event log with 30 DamageApplied, 50 AttackResolved,
+      // 20 of mixed other types — mirrors the spec scenario exactly.
+      const events: IGameEvent[] = [
+        ...Array.from({ length: 30 }, (_, i) =>
+          makeEvent({ type: GameEventType.DamageApplied, sequence: i }),
+        ),
+        ...Array.from({ length: 50 }, (_, i) =>
+          makeEvent({ type: GameEventType.AttackResolved, sequence: 30 + i }),
+        ),
+        ...Array.from({ length: 10 }, (_, i) =>
+          makeEvent({ type: GameEventType.HeatGenerated, sequence: 80 + i }),
+        ),
+        ...Array.from({ length: 10 }, (_, i) =>
+          makeEvent({ type: GameEventType.MovementDeclared, sequence: 90 + i }),
+        ),
+      ];
+      expect(events).toHaveLength(100);
+
+      const result = EventLogQuery.from(events)
+        .ofType(GameEventType.DamageApplied)
+        .count();
+
+      expect(result).toBe(30);
+    });
+  });
+
+  describe('spec scenario: byUnit matches both actor and payload-unit attribution', () => {
+    it('matches when actorId === unitId OR payload.unitId === unitId', () => {
+      const actorMatch = makeEvent({
+        actorId: 'player-1',
+        payload: {
+          unitId: 'opponent-2',
+          location: 'CT',
+          damage: 5,
+          armorRemaining: 10,
+          structureRemaining: 20,
+          locationDestroyed: false,
+        } as IDamageAppliedPayload,
+      });
+      // Target attribution: damage_applied where the player-1 unit is
+      // the TARGET (payload.unitId), opponent-2 is the source (and
+      // therefore actorId on the envelope).
+      const targetMatch = makeEvent({
+        actorId: 'opponent-2',
+        side: GameSide.Opponent,
+        payload: {
+          unitId: 'player-1',
+          location: 'LT',
+          damage: 3,
+          armorRemaining: 7,
+          structureRemaining: 15,
+          locationDestroyed: false,
+          sourceUnitId: 'opponent-2',
+        } as IDamageAppliedPayload,
+      });
+      const irrelevant = makeEvent({
+        actorId: 'opponent-3',
+        side: GameSide.Opponent,
+        payload: {
+          unitId: 'opponent-2',
+          location: 'CT',
+          damage: 1,
+          armorRemaining: 5,
+          structureRemaining: 5,
+          locationDestroyed: false,
+        } as IDamageAppliedPayload,
+      });
+
+      const result = EventLogQuery.from([actorMatch, targetMatch, irrelevant])
+        .byUnit('player-1')
+        .toArray();
+
+      expect(result).toHaveLength(2);
+      expect(result).toContain(actorMatch);
+      expect(result).toContain(targetMatch);
+      expect(result).not.toContain(irrelevant);
+    });
+  });
+
+  describe('spec scenario: bySide reads envelope side first, falls back for legacy streams', () => {
+    it('keeps player events whether they have envelope side or only actorId', () => {
+      // Mix of post-PR-B events (envelope side present) and legacy
+      // events (envelope side absent — only actorId).
+      const envelopePlayer = makeEvent({
+        sequence: 1,
+        actorId: 'player-1',
+        side: GameSide.Player,
+      });
+      const envelopeOpponent = makeEvent({
+        sequence: 2,
+        actorId: 'opponent-1',
+        side: GameSide.Opponent,
+      });
+      const legacyPlayer = makeEvent({
+        sequence: 3,
+        actorId: 'player-2',
+        side: undefined, // Legacy: no envelope side
+      });
+      const legacyOpponent = makeEvent({
+        sequence: 4,
+        actorId: 'opponent-2',
+        side: undefined,
+      });
+      const legacyNoActor = makeEvent({
+        sequence: 5,
+        actorId: undefined,
+        side: undefined,
+      });
+
+      const result = EventLogQuery.from([
+        envelopePlayer,
+        envelopeOpponent,
+        legacyPlayer,
+        legacyOpponent,
+        legacyNoActor,
+      ])
+        .bySide(GameSide.Player)
+        .toArray();
+
+      expect(result).toHaveLength(2);
+      expect(result).toContain(envelopePlayer);
+      expect(result).toContain(legacyPlayer);
+      expect(result).not.toContain(envelopeOpponent);
+      expect(result).not.toContain(legacyOpponent);
+      expect(result).not.toContain(legacyNoActor);
+    });
+
+    it('drops legacy events whose actorId does not match a side prefix', () => {
+      const synthetic = makeEvent({
+        actorId: 'synthetic-test-fixture-id',
+        side: undefined,
+      });
+      const result = EventLogQuery.from([synthetic])
+        .bySide(GameSide.Player)
+        .toArray();
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('spec scenario: order-independence of chained filters', () => {
+    it('produces identical results regardless of filter order', () => {
+      const events: IGameEvent[] = [
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.DamageApplied,
+          actorId: 'player-1',
+          side: GameSide.Player,
+        }),
+        makeEvent({
+          sequence: 2,
+          type: GameEventType.DamageApplied,
+          actorId: 'opponent-1',
+          side: GameSide.Opponent,
+        }),
+        makeEvent({
+          sequence: 3,
+          type: GameEventType.AttackResolved,
+          actorId: 'player-1',
+          side: GameSide.Player,
+        }),
+        makeEvent({
+          sequence: 4,
+          type: GameEventType.DamageApplied,
+          actorId: 'player-2',
+          side: GameSide.Player,
+        }),
+      ];
+
+      const aFirst = EventLogQuery.from(events)
+        .ofType(GameEventType.DamageApplied)
+        .bySide(GameSide.Player)
+        .toArray();
+      const bFirst = EventLogQuery.from(events)
+        .bySide(GameSide.Player)
+        .ofType(GameEventType.DamageApplied)
+        .toArray();
+
+      expect(aFirst).toEqual(bFirst);
+      expect(aFirst).toHaveLength(2);
+      expect(aFirst.map((e) => e.sequence)).toEqual([1, 4]);
+    });
+  });
+
+  describe('spec scenario: chained methods are immutable', () => {
+    it('does not mutate the source query when a filter is applied', () => {
+      const events: IGameEvent[] = [
+        makeEvent({ sequence: 1, type: GameEventType.DamageApplied }),
+        makeEvent({ sequence: 2, type: GameEventType.AttackResolved }),
+        makeEvent({ sequence: 3, type: GameEventType.HeatGenerated }),
+      ];
+
+      const q = EventLogQuery.from(events);
+      const q2 = q.ofType(GameEventType.DamageApplied);
+
+      expect(q.count()).toBe(3); // Original unchanged
+      expect(q2.count()).toBe(1); // Derived filtered
+      // q is still iterable in full afterwards.
+      expect(q.toArray()).toHaveLength(3);
+    });
+
+    it('returns NEW EventLogQuery instances from each filter method', () => {
+      const events: IGameEvent[] = [
+        makeEvent({ sequence: 1 }),
+        makeEvent({ sequence: 2 }),
+      ];
+      const q = EventLogQuery.from(events);
+      const q2 = q.ofType(GameEventType.DamageApplied);
+      const q3 = q.byUnit('player-1');
+      const q4 = q.bySide(GameSide.Player);
+      const q5 = q.inTurn(1);
+      const q6 = q.inPhase(GamePhase.WeaponAttack);
+      const q7 = q.whereActor((id) => id === 'player-1');
+
+      // Every filter call returns a new instance (we use `!==`
+      // identity comparison rather than equality because it's the
+      // immutability invariant we care about).
+      expect(q2).not.toBe(q);
+      expect(q3).not.toBe(q);
+      expect(q4).not.toBe(q);
+      expect(q5).not.toBe(q);
+      expect(q6).not.toBe(q);
+      expect(q7).not.toBe(q);
+    });
+  });
+
+  describe('inTurn', () => {
+    it('keeps only events whose turn matches the argument', () => {
+      const events: IGameEvent[] = [
+        makeEvent({ sequence: 1, turn: 1 }),
+        makeEvent({ sequence: 2, turn: 2 }),
+        makeEvent({ sequence: 3, turn: 2 }),
+        makeEvent({ sequence: 4, turn: 3 }),
+      ];
+
+      const result = EventLogQuery.from(events).inTurn(2).toArray();
+      expect(result).toHaveLength(2);
+      expect(result.map((e) => e.sequence)).toEqual([2, 3]);
+    });
+  });
+
+  describe('inPhase', () => {
+    it('keeps only events whose phase matches the argument', () => {
+      const events: IGameEvent[] = [
+        makeEvent({ sequence: 1, phase: GamePhase.Movement }),
+        makeEvent({ sequence: 2, phase: GamePhase.WeaponAttack }),
+        makeEvent({ sequence: 3, phase: GamePhase.Movement }),
+        makeEvent({ sequence: 4, phase: GamePhase.Heat }),
+      ];
+
+      const result = EventLogQuery.from(events)
+        .inPhase(GamePhase.Movement)
+        .toArray();
+      expect(result).toHaveLength(2);
+      expect(result.map((e) => e.sequence)).toEqual([1, 3]);
+    });
+  });
+
+  describe('whereActor', () => {
+    it('keeps only events whose actorId satisfies the predicate', () => {
+      const events: IGameEvent[] = [
+        makeEvent({ sequence: 1, actorId: 'player-1' }),
+        makeEvent({ sequence: 2, actorId: 'opponent-1' }),
+        makeEvent({ sequence: 3, actorId: 'player-2' }),
+        makeEvent({ sequence: 4, actorId: undefined }),
+      ];
+
+      const result = EventLogQuery.from(events)
+        .whereActor((id) => id.startsWith('player-'))
+        .toArray();
+      expect(result).toHaveLength(2);
+      expect(result.map((e) => e.sequence)).toEqual([1, 3]);
+    });
+
+    it('drops events with no actorId regardless of predicate result', () => {
+      const events: IGameEvent[] = [
+        makeEvent({ sequence: 1, actorId: undefined }),
+      ];
+      // Predicate that would otherwise match anything — we want to be
+      // sure events with no actor never satisfy `whereActor`.
+      const result = EventLogQuery.from(events)
+        .whereActor(() => true)
+        .toArray();
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('from([]) — empty array returns count 0 and undefined first()', () => {
+      const q = EventLogQuery.from([]);
+      expect(q.count()).toBe(0);
+      expect(q.first()).toBeUndefined();
+      expect(q.toArray()).toEqual([]);
+    });
+
+    it('no-match filter — empty result keeps query callable downstream', () => {
+      const events: IGameEvent[] = [
+        makeEvent({ sequence: 1, type: GameEventType.DamageApplied }),
+      ];
+      const q = EventLogQuery.from(events).ofType(GameEventType.UnitDestroyed);
+      expect(q.count()).toBe(0);
+      expect(q.first()).toBeUndefined();
+      // Chaining further filters on an empty result is still valid.
+      expect(q.byUnit('player-1').count()).toBe(0);
+    });
+
+    it('whereActor with always-false predicate yields empty result', () => {
+      const events: IGameEvent[] = [
+        makeEvent({ sequence: 1, actorId: 'player-1' }),
+        makeEvent({ sequence: 2, actorId: 'opponent-1' }),
+      ];
+      const result = EventLogQuery.from(events)
+        .whereActor(() => false)
+        .toArray();
+      expect(result).toHaveLength(0);
+    });
+
+    it('first() returns the first event of the filtered slice', () => {
+      const events: IGameEvent[] = [
+        makeEvent({ sequence: 10, type: GameEventType.DamageApplied }),
+        makeEvent({ sequence: 11, type: GameEventType.DamageApplied }),
+      ];
+      const result = EventLogQuery.from(events)
+        .ofType(GameEventType.DamageApplied)
+        .first();
+      expect(result?.sequence).toBe(10);
+    });
+
+    it('toArray returns the inner array without copying', () => {
+      const events: IGameEvent[] = [makeEvent({ sequence: 1 })];
+      const q = EventLogQuery.from(events);
+      // Identity check — `from` doesn't copy, so the returned array IS
+      // the input array. (After a filter the returned array is a new
+      // slice, but the entry-point invariant holds.)
+      expect(q.toArray()).toBe(events);
+    });
+  });
+});

--- a/src/simulation/core/sideFromActor.ts
+++ b/src/simulation/core/sideFromActor.ts
@@ -1,0 +1,29 @@
+/**
+ * Side derivation from a runner unit id.
+ *
+ * Per `denormalize-event-envelope-and-close-emission-contract-gaps`: the
+ * canonical source for an event's side is now `IGameEventBase.side`,
+ * populated by `createGameEvent` at emission time. This helper is the
+ * legacy fallback for replaying NDJSON event streams written before the
+ * envelope-denormalization landed and for consumers that only have a raw
+ * `unitId` (e.g., a `payload.sourceUnitId` describing the attacker, where
+ * the event's `actorId` may describe the target).
+ *
+ * Returns `null` for ids that don't follow the canonical
+ * `player-` / `opponent-` prefix (e.g., test fixtures with synthetic ids).
+ *
+ * Extracted to a dedicated module so consumers in
+ * `src/simulation/core/` (e.g., `EventLogQuery`) can reuse the lookup
+ * without importing the heavier `MetricsCollector` module — keeps the
+ * core directory free of metrics-layer dependencies and sidesteps any
+ * future circular-import risk between query / metrics surfaces.
+ *
+ * `MetricsCollector` re-exports this function as a named export so the
+ * documented `MetricsCollector.sideFromUnitId` surface stays stable for
+ * downstream consumers (specs, scenario tests, future UI replays).
+ */
+export function sideFromUnitId(unitId: string): 'player' | 'opponent' | null {
+  if (unitId.startsWith('player-')) return 'player';
+  if (unitId.startsWith('opponent-')) return 'opponent';
+  return null;
+}

--- a/src/simulation/metrics/MetricsCollector.ts
+++ b/src/simulation/metrics/MetricsCollector.ts
@@ -29,29 +29,20 @@ import {
   IUnitFellPayload,
 } from '@/types/gameplay/GameSessionInterfaces';
 
+import { sideFromUnitId } from '../core/sideFromActor';
 import { ISimulationResult } from '../core/types';
 import { IAggregateMetrics, ISimulationMetrics } from './types';
 
 /**
- * Side derivation from a runner unit id. Returns `null` for ids that
- * don't follow the canonical `player-` / `opponent-` prefix (e.g.,
- * test fixtures with synthetic ids); those units don't contribute to
- * either side's roster count.
- *
- * Per `denormalize-event-envelope-and-close-emission-contract-gaps`: the
- * canonical source for an event's side is now `IGameEventBase.side`,
- * populated by `createGameEvent` (and `createEventBase`) at emission
- * time. This function is retained as a fallback for replaying legacy
- * NDJSON event streams written before the envelope-denormalization
- * landed — `MetricsCollector` still uses it against `payload.unitId`
- * because some payloads describe a target side rather than the actor's
- * side, and unit-id is the unambiguous source there.
+ * Per `add-event-log-query-and-unified-readable-format` (combat-analytics
+ * delta): the canonical `sideFromUnitId` lookup lives at
+ * `src/simulation/core/sideFromActor.ts` so consumers in
+ * `src/simulation/core/` (e.g. `EventLogQuery`) can reuse it without
+ * pulling the metrics module. Re-exported here so the documented
+ * `MetricsCollector.sideFromUnitId` surface stays stable for downstream
+ * consumers (specs, scenario tests, future UI replays).
  */
-function sideFromUnitId(unitId: string): 'player' | 'opponent' | null {
-  if (unitId.startsWith('player-')) return 'player';
-  if (unitId.startsWith('opponent-')) return 'opponent';
-  return null;
-}
+export { sideFromUnitId };
 
 /**
  * Walk the event log once and produce all derived counters in a single


### PR DESCRIPTION
## Summary

PR 4 of 5 in the event-log line-format series (after #531 formatter field-name fixes, #533 envelope side denormalization, and #535 movement step chain). Two consumer-side surfaces for the typed event log:

1. **EventLogQuery** (`src/simulation/core/EventLogQuery.ts`) — chainable, immutable filter utility wrapping `readonly IGameEvent[]`. Methods: `from / ofType / byUnit / bySide / inTurn / inPhase / whereActor / toArray / count / first`. Each filter returns a NEW instance (immutability invariant from the spec). `byUnit` matches both actor and payload-unit attribution; `bySide` reads envelope `event.side` first then falls back to `MetricsCollector.sideFromUnitId(actorId)` for legacy NDJSON streams. 16-test suite covers the 5 spec scenarios + edge cases.

2. **Python columnar formatter rewrite** (`scripts/format-event-log.py`) — fixed-width prefix per the spec format string `s<seq:5d> t<turn:2d> <phase:8s> <side:9s> <actor:14s> <action:24s>  <action-summary>` yielding a 69-char prefix + 2 literal spaces, summary at column 71. Per-category templates for the 10 categories: MOVE / WEAPON / MELEE / DAMAGE / CRIT / HEAT / PSR / AMMO / LIFECYCLE / FLOW. MOVE summary consumes `payload.steps` (post-PR-C) when present for the `[forward,turn,forward,...]` chain decomposition; falls back to `flags=movementType` for legacy streams. Side derivation matches the query utility's envelope-then-actorId-prefix-then-`'system'` fallback chain.

3. **Refactor**: `sideFromUnitId` extracted to `src/simulation/core/sideFromActor.ts` so `EventLogQuery` (in `core/`) can import it without pulling the metrics module — sidesteps any future circular-import risk between query / metrics surfaces. `MetricsCollector` re-exports the helper so the documented `MetricsCollector.sideFromUnitId` public surface stays stable. The single-pass switch loops in `MetricsCollector` and `combatFidelityTally` are preserved verbatim — splitting them into multiple O(N) filter passes would be a regression (the spec's "behavior MUST stay equivalent" rule applies).

## Columnar prefix contract

The 6 columns plus 5 single-space separators yield a 69-char prefix + 2 literal spaces, summary at column 71. Every event line uses the same fixed widths so:

```bash
awk '$3 == "movement"' sim-46.readable.txt    # phase column
grep ' player '       sim-46.readable.txt      # side column (padded)
```

work without per-event-type regexes.

## Smoke-verified search invariants (sim-46.jsonl, 838 readable lines)

- `awk '$3 == "movement"'` returns every `movement_declared` line — 4 of 4 first-turn movements as expected.
- `grep ' player '` returns every player-side row across phases (movement, heat, weapon_attack) regardless of envelope side presence.
- `grep -E "(damage_applied|critical_hit|psr_resolved|unit_destroyed)"` finds all combat events with their per-category summaries (location / damage / armor / structure for DAMAGE; reason / verdict for PSR; etc.).

## Spec extensions

- `combat-analytics`: ADDED `Requirement: EventLogQuery Filter Utility Contract` (5 scenarios)
- `quick-session`: ADDED `Requirement: Readable Event-Log Companion Columnar Layout` (4 scenarios)

OpenSpec change: `openspec/changes/add-event-log-query-and-unified-readable-format/`.

## Verified

- `npm run typecheck` clean
- `npm run lint` clean (42 pre-existing warnings, 0 errors)
- 1177 simulation tests pass (incl. 16 new `EventLogQuery` tests + 113 combat-fidelity / `MetricsCollector` tests covering the refactor)
- `python -c "import ast; ast.parse(open('scripts/format-event-log.py').read())"` clean
- `npx openspec validate add-event-log-query-and-unified-readable-format --strict` clean

## Test plan

- [x] EventLogQuery: 16 new tests (5 spec scenarios + 11 edge cases) all pass
- [x] MetricsCollector + combatFidelityTally: 113 existing tests still pass after `sideFromUnitId` extraction
- [x] Combat-fidelity scenario tests: pass (regression net for "behavior MUST stay equivalent" refactor rule)
- [x] Python formatter produces fixed-width columnar output verifiable with `awk`/`grep`
- [x] OpenSpec change validates strict-clean

## Out of scope

- New event types (PR follow-ons already named).
- PSR reason discriminated enum (PR E).
- UI replay viewer (separate concern).
- Schema bridge changes (no Zod schema modifications).
