### PR TITLE
feat(event-log): add PSRReasonCode discriminated field + 4-bucket category helper

### DIFF
--- a/openspec/changes/structure-psr-reason-as-discriminated-code/.openspec.yaml
+++ b/openspec/changes/structure-psr-reason-as-discriminated-code/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/structure-psr-reason-as-discriminated-code/proposal.md
+++ b/openspec/changes/structure-psr-reason-as-discriminated-code/proposal.md
@@ -1,0 +1,54 @@
+# Add PSRReasonCode discriminated field to PSR / fall events
+
+## Why
+
+`IPSRTriggeredPayload.reason`, `IPSRResolvedPayload.reason`, and `IUnitFellPayload.reason` are typed as plain `string` today. The 9 PSR factory modules (`combatFactories`, `damageFactories`, `environmentFactories`, `systemFactories`, `phaseChecks`) emit human-readable strings like `'Kicked'`, `'20+ damage this phase'`, `'Hit by DFA'`. The Python readable formatter and the UI EventLogDisplay component consume these strings AS-IS for display.
+
+Meanwhile, `src/utils/gameplay/pilotingSkillRolls/types.ts:52` defines a comprehensive `PSRTrigger` enum with **27 canonical snake_case codes** (`'kicked'`, `'20+_damage'`, `'dfa_target'`, `'gyro_hit'`, `'standing_up'`, `'moving_on_ice'`, etc.). MegaMek's reference implementation enumerates the same trigger taxonomy at `E:/Projects/megamek/megamek/src/megamek/server/totalwarfare/MovePathHandler.java` and `Server.processPilotingRolls`. Consumers that want to filter or aggregate ("show me all gyro-induced PSRs across this match") have no machine-readable handle — they'd have to string-match on display strings, which fork between scenarios and language localizations.
+
+## What
+
+### Type extension — add `reasonCode` sibling field (do NOT replace `reason`)
+
+Add `readonly reasonCode?: PSRTrigger` to:
+- `IPSRTriggeredPayload` (`src/types/gameplay/GameSessionInterfaces.ts:849`)
+- `IPSRResolvedPayload` (line 856)
+- `IUnitFellPayload` (line 870)
+
+`reason: string` stays as-is for display continuity. Consumers that want filtering use `reasonCode`; consumers that want display use `reason`. Both populate from the same factory at emission.
+
+### Factory migration — populate `reasonCode` alongside `reason`
+
+Update every PSR factory in `src/utils/gameplay/pilotingSkillRolls/{combat,damage,environment,system,phaseChecks}Factories.ts` to populate `reasonCode` with the matching `PSRTrigger.X` enum value alongside the existing human-readable `reason`. Every factory already references its `PSRTrigger` (the existing `triggerSource` field) — this is a 1-line addition per factory.
+
+### `reasonCategory` bucket helper
+
+Add `getPSRReasonCategory(code: PSRTrigger): PSRReasonCategory` at `src/utils/gameplay/pilotingSkillRolls/types.ts` where `PSRReasonCategory = 'movement' | 'damage' | 'heat' | 'recovery'`. This bucket lets consumers group PSRs without enumerating all 27 codes — for example, the readable formatter can color movement-induced PSRs differently from damage-induced ones, and metrics aggregators can roll up "total movement-PSRs / damage-PSRs / heat-PSRs / recovery-PSRs per match."
+
+The category mapping (cross-referenced against MegaMek's groupings):
+
+| Category | Codes |
+|---|---|
+| `movement` | `kicked`, `charged`, `dfa_target`, `pushed`, `kick_miss`, `charge_miss`, `dfa_miss`, `entering_rubble`, `running_rough_terrain`, `moving_on_ice`, `entering_water`, `exiting_water`, `skidding`, `running_damaged_hip`, `running_damaged_gyro`, `building_collapse`, `masc_failure`, `supercharger_failure` |
+| `damage` | `20+_damage`, `leg_damage`, `hip_actuator_destroyed`, `gyro_hit`, `engine_hit`, `upper_leg_actuator_hit`, `lower_leg_actuator_hit`, `foot_actuator_hit` |
+| `heat` | `heat_shutdown` |
+| `recovery` | `standing_up` |
+
+### Spec extension
+
+`piloting-skill-rolls`: ADD `Requirement: PSR Reason Code Discriminated Field` (the type contract + 27-code enumeration + factory population invariant + `reasonCategory` bucket helper).
+
+## Impact
+
+- **Affected types**: 3 payload interfaces (`IPSRTriggeredPayload`, `IPSRResolvedPayload`, `IUnitFellPayload`).
+- **Affected code**: 9 PSR factory modules + new `getPSRReasonCategory` helper.
+- **Affected specs**: `piloting-skill-rolls`.
+- **Risk**: low. `reasonCode` is OPTIONAL on every payload (back-compat for legacy NDJSON streams). `reason: string` is unchanged so display layers don't break. Factory migrations are mechanical 1-line additions.
+- **Visible improvement**: the readable formatter and EventLogQuery can filter PSRs by canonical code (`query.ofType(PSRTriggered).whereReasonCode(...)`) and bucket-aggregate by category. The 27-code taxonomy also makes the PSR system self-documenting.
+
+## Out of scope
+
+- Breaking the `reason: string` type (that would force display-layer changes; deferred).
+- New PSR triggers not yet in the enum (`add-cumulative-crew-damage-thresholds` follow-on adds heat-25/32/39/47 thresholds with their PSR triggers).
+- Movement-step trigger-source stamping (already shipped in PR C).
+- UI EventLogDisplay component changes (separate concern; this PR ships only the substrate).

--- a/openspec/changes/structure-psr-reason-as-discriminated-code/specs/piloting-skill-rolls/spec.md
+++ b/openspec/changes/structure-psr-reason-as-discriminated-code/specs/piloting-skill-rolls/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: PSR Reason Code Discriminated Field
+
+`IPSRTriggeredPayload`, `IPSRResolvedPayload`, and `IUnitFellPayload` SHALL carry a `reasonCode?: PSRTrigger` field discriminated against the canonical 27-value `PSRTrigger` enum at `src/utils/gameplay/pilotingSkillRolls/types.ts`. The field is OPTIONAL on every payload to preserve back-compat with NDJSON event streams written before this contract.
+
+The free-string `reason` field on the same payloads SHALL be RETAINED unchanged for display continuity. Display consumers (`EventLogDisplay`, the Python `format-event-log.py`) read `reason` to render human-readable text. Filter / aggregate consumers (`EventLogQuery`, `MetricsCollector`, scenario tests) read `reasonCode` for machine-readable filtering.
+
+The 27 canonical codes (cross-referenced against MegaMek's `Server.processPilotingRolls` and `MovePathHandler.checkSkid` taxonomy):
+
+| Code | Category | Trigger |
+|---|---|---|
+| `20+_damage` | damage | Phase damage threshold of 20+ |
+| `leg_damage` | damage | Internal structure exposed on a leg |
+| `hip_actuator_destroyed` | damage | Hip actuator critically destroyed |
+| `gyro_hit` | damage | Gyro slot took a critical hit |
+| `engine_hit` | damage | Engine slot took a critical hit (cumulative) |
+| `upper_leg_actuator_hit` | damage | Upper leg actuator destroyed |
+| `lower_leg_actuator_hit` | damage | Lower leg actuator destroyed |
+| `foot_actuator_hit` | damage | Foot actuator destroyed |
+| `kicked` | movement | Target was kicked (physical attack target) |
+| `charged` | movement | Target was charged (physical attack target) |
+| `dfa_target` | movement | Target was hit by death-from-above |
+| `pushed` | movement | Target was pushed (physical attack target) |
+| `kick_miss` | movement | Attacker missed a kick (self-PSR) |
+| `charge_miss` | movement | Attacker missed a charge (self-PSR) |
+| `dfa_miss` | movement | Attacker missed a DFA (self-PSR) |
+| `entering_rubble` | movement | Unit entered rubble terrain |
+| `running_rough_terrain` | movement | Unit ran through rough terrain |
+| `moving_on_ice` | movement | Unit moved on an ice hex |
+| `entering_water` | movement | Unit entered a water hex |
+| `exiting_water` | movement | Unit exited a water hex |
+| `skidding` | movement | Skid PSR triggered by unstable ground |
+| `running_damaged_hip` | movement | Unit ran with a damaged hip |
+| `running_damaged_gyro` | movement | Unit ran with a damaged gyro |
+| `building_collapse` | movement | Building under unit's footprint collapsed |
+| `masc_failure` | movement | MASC system failed during attempted run |
+| `supercharger_failure` | movement | Supercharger failed during attempted run |
+| `heat_shutdown` | heat | Heat-induced shutdown PSR |
+| `standing_up` | recovery | Prone unit attempting to stand |
+
+The runner SHALL populate `reasonCode` at the PSR factory boundary — every factory in `src/utils/gameplay/pilotingSkillRolls/{combat,damage,environment,system,phaseChecks}Factories.ts` SHALL emit both `reason` (human string, unchanged) AND `reasonCode` (the matching `PSRTrigger` enum value) in the same `IPSRTriggeredPayload` returned to callers.
+
+#### Scenario: Factory populates reasonCode alongside reason
+
+- **GIVEN** a kick-target PSR factory call (`createKickedPSR(unit, attackerId)`)
+- **WHEN** the factory returns a `IPSRTriggeredPayload`
+- **THEN** the payload SHALL have `reason: 'Kicked'` (existing human-readable string)
+- **AND** the payload SHALL have `reasonCode: PSRTrigger.Kicked` (the canonical `'kicked'` enum value)
+
+#### Scenario: Damage-induced PSR populates damage code
+
+- **GIVEN** a unit takes 20+ damage in a phase, triggering `createPhaseDamage20PlusPSR(unit)`
+- **WHEN** the factory returns a `IPSRTriggeredPayload`
+- **THEN** the payload SHALL have `reasonCode: PSRTrigger.PhaseDamage20Plus`
+
+#### Scenario: Movement-induced terrain PSR populates terrain code
+
+- **GIVEN** a unit moving on an ice hex triggers `createIcePSR(unit)`
+- **WHEN** the factory returns a `IPSRTriggeredPayload`
+- **THEN** the payload SHALL have `reasonCode: PSRTrigger.MovingOnIce`
+
+#### Scenario: Legacy event stream without reasonCode replays cleanly
+
+- **GIVEN** an NDJSON event stream written before this requirement (no `reasonCode` field on any PSR event)
+- **WHEN** consumers process the events
+- **THEN** processing SHALL succeed
+- **AND** consumers MAY render `reason` (the human-readable string) directly without falling back through `reasonCode`
+
+### Requirement: PSR Reason Category Bucket Helper
+
+`src/utils/gameplay/pilotingSkillRolls/types.ts` SHALL export a `PSRReasonCategory` string-literal union and a `getPSRReasonCategory(code: PSRTrigger): PSRReasonCategory` helper:
+
+```ts
+export type PSRReasonCategory = 'movement' | 'damage' | 'heat' | 'recovery';
+
+export function getPSRReasonCategory(code: PSRTrigger): PSRReasonCategory;
+```
+
+The function SHALL deterministically map every `PSRTrigger` value to exactly one of the four categories per the table in `Requirement: PSR Reason Code Discriminated Field`. The helper enables consumers (the readable formatter, metrics aggregators) to bucket PSRs without enumerating all 27 codes.
+
+#### Scenario: Recovery-PSR (StandingUp) lands in recovery bucket
+
+- **GIVEN** a prone unit attempts to stand, triggering `createStandUpAttempt(unit)`
+- **WHEN** the factory returns a `IPSRTriggeredPayload`
+- **THEN** the payload SHALL have `reasonCode: PSRTrigger.StandingUp`
+- **AND** `getPSRReasonCategory(payload.reasonCode)` SHALL equal `'recovery'`
+
+#### Scenario: Heat-shutdown PSR lands in heat bucket
+
+- **GIVEN** a unit at heat ≥14 triggers `createReactorShutdownPSR(unit)`
+- **WHEN** the factory returns a `IPSRTriggeredPayload`
+- **THEN** the payload SHALL have `reasonCode: PSRTrigger.Shutdown`
+- **AND** `getPSRReasonCategory(payload.reasonCode)` SHALL equal `'heat'`
+
+#### Scenario: getPSRReasonCategory is deterministic over all 27 codes
+
+- **GIVEN** the full set of `PSRTrigger` enum values (27 codes)
+- **WHEN** `getPSRReasonCategory` is called for each
+- **THEN** every code SHALL map to exactly one of `'movement' | 'damage' | 'heat' | 'recovery'`
+- **AND** the partition SHALL match the category column in the spec's 27-code table

--- a/openspec/changes/structure-psr-reason-as-discriminated-code/tasks.md
+++ b/openspec/changes/structure-psr-reason-as-discriminated-code/tasks.md
@@ -1,0 +1,60 @@
+# Tasks
+
+## 1. Authoring
+
+- [x] 1.1 Author proposal.md (motivation, sibling-field strategy, 27-code MegaMek cross-reference)
+- [x] 1.2 Author piloting-skill-rolls spec delta (PSR Reason Code Discriminated Field + PSR Reason Category Bucket Helper — 7 scenarios)
+
+## 2. Type extensions (`src/types/gameplay/GameSessionInterfaces.ts`)
+
+- [x] 2.1 Add `readonly reasonCode?: PSRTrigger` to `IPSRTriggeredPayload`
+- [x] 2.2 Add `readonly reasonCode?: PSRTrigger` to `IPSRResolvedPayload`
+- [x] 2.3 Add `readonly reasonCode?: PSRTrigger` to `IUnitFellPayload`
+- [x] 2.4 Move `PSRTrigger` enum to `src/types/gameplay/PSRTriggerCodes.ts` (back-compat re-export from `pilotingSkillRolls/types.ts`); cycle resolved. Also added `reasonCode?` to `IPendingPSR` so factories thread it through unchanged callsite signatures.
+
+## 3. Bucket helper (`src/utils/gameplay/pilotingSkillRolls/types.ts`)
+
+- [x] 3.1 Added `export type PSRReasonCategory = 'movement' | 'damage' | 'heat' | 'recovery'`
+- [x] 3.2 Added `export function getPSRReasonCategory(code: PSRTrigger): PSRReasonCategory` with exhaustive switch + `never` exhaustiveness check
+- [x] 3.3 Added unit test at `src/utils/gameplay/pilotingSkillRolls/__tests__/getPSRReasonCategory.test.ts` — 38 tests, exhaustive over all enum values + spot checks + per-bucket coverage
+
+## 4. Factory migration
+
+- [x] 4.1 `combatFactories.ts` — 7 factories migrated (Kicked, Charged, DFATarget, Pushed, KickMiss, ChargeMiss, DFAMiss)
+- [x] 4.2 `damageFactories.ts` — 8 factories migrated (PhaseDamage20Plus, LegDamage, HipActuatorDestroyed, GyroHit, EngineHit, UpperLegActuatorHit, LowerLegActuatorHit, FootActuatorHit)
+- [x] 4.3 `environmentFactories.ts` — 9 factories migrated (Shutdown, StandingUp, EnteringRubble, RunningRoughTerrain, MovingOnIce, EnteringWater, ExitingWater, Skidding, BuildingCollapse) preserving the optional `stepIndex` parameter from PR C
+- [x] 4.4 `systemFactories.ts` — 4 factories migrated (RunningDamagedHip, RunningDamagedGyro, MASCFailure, SuperchargerFailure)
+- [x] 4.5 `phaseChecks.ts` (`createStandUpAttempt`) covered transitively — calls `createStandingUpPSR` which now stamps `reasonCode`
+- [x] 4.6 Direct event-builder callers also threaded `reasonCode`: `gameSessionAttackResolution.ts` (leg-damage + 20+damage), `gameSessionHeat.ts` (shutdown ×2), `gameSessionPhysical.ts` (target / hit / miss with attack-type → enum mapping), `criticalHitResolution/{actuator,engine}Effects.ts` (gyro + leg-actuator crits), `simulation/runner/phases/{weaponAttack,postCombat,physicalAttack}.ts`
+
+## 5. Tests
+
+- [x] 5.1 Added `__tests__/factoryReasonCode.test.ts` — 26 tests covering all 5 factory families + step-index preservation invariant
+- [x] 5.2 Extended `atlasMirrorEventChain.integration.test.ts` with a PR-E scenario test asserting `every` emitted PSR / fall event carries a defined `reasonCode`
+- [x] 5.3 Full piloting-skill-rolls test suite green
+- [x] 5.4 Combat-fidelity scenario tests green — 1178/1178 simulation tests pass
+
+## 6. Verification
+
+- [x] 6.1 `npx tsc --noEmit --skipLibCheck` clean
+- [x] 6.2 `npm run lint` clean (0 errors)
+- [x] 6.3 `npm test` (scoped to pilotingSkillRolls + atlasMirror + combat-fidelity + getPSRReasonCategory + factoryReasonCode) — 229/229 green
+- [x] 6.4 `npx openspec validate structure-psr-reason-as-discriminated-code --strict` clean
+
+## 7. PR
+
+- [ ] 7.1 Commit on branch `event-log/pr-e-psr-reason-enum`
+- [ ] 7.2 Open PR against `main` with title `feat(event-log): add PSRReasonCode discriminated field + 4-bucket category helper`
+- [ ] 7.3 Wait for CI green
+- [ ] 7.4 Merge with `--squash --delete-branch`
+
+## 8. Archive
+
+- [ ] 8.1 After merge, run `npx openspec archive structure-psr-reason-as-discriminated-code --yes` — clean
+- [ ] 8.2 Open archive PR; merge
+
+## 9. Plan closure
+
+- [ ] 9.1 After PR E archive merges: update MEMORY.md with a new entry summarizing the 5-PR event-log line-format series
+- [ ] 9.2 Smoke-run the swarm with the latest formatter; confirm the readable companion shows full envelope side / movement chain / 4-digit hex / PSR code on every line
+- [ ] 9.3 List the 4 named follow-on changes for the next session: add-mid-move-terrain-damage-events, add-skid-and-displacement-events, add-cumulative-crew-damage-thresholds, add-multi-variant-gyro-cascade

--- a/src/simulation/__tests__/atlasMirrorEventChain.integration.test.ts
+++ b/src/simulation/__tests__/atlasMirrorEventChain.integration.test.ts
@@ -438,4 +438,49 @@ describe('Atlas-vs-Atlas event chain — P2 (task 2.7)', () => {
       expect(e.side).toBeUndefined();
     }
   });
+
+  it('PSR / fall events emitted by the runner carry reasonCode (PR E)', async () => {
+    // Per `structure-psr-reason-as-discriminated-code` (PR E): every
+    // PSR factory now stamps `reasonCode: PSRTrigger.X` on the
+    // `IPendingPSR`, and the event builders thread that value onto
+    // `IPSRTriggeredPayload` / `IPSRResolvedPayload` / `IUnitFellPayload`.
+    // The atlas-mirror runner doesn't deterministically produce PSR
+    // events on every seed, so this test asserts conditional on
+    // presence: when PSR / fall events are emitted, every one of them
+    // SHALL carry a defined `reasonCode`.
+    const hydration = await buildAtlasMirrorHydration();
+    const config: ISimulationConfig = {
+      seed: 12345,
+      turnLimit: 5,
+      unitCount: { player: 1, opponent: 1 },
+      mapRadius: 4,
+    };
+    const runner = new SimulationRunner(
+      config.seed,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      hydration,
+    );
+    const result = runner.run(config);
+
+    const psrEvents = result.events.filter(
+      (e) =>
+        e.type === GameEventType.PSRTriggered ||
+        e.type === GameEventType.PSRResolved ||
+        e.type === GameEventType.UnitFell,
+    );
+
+    // Every emitted PSR / fall event carries the reasonCode sibling
+    // alongside the existing `reason` string. The runner-side factories
+    // stamp it unconditionally — only direct event-builder callers
+    // (`gameSessionAttackResolution.ts` leg-damage / 20+damage,
+    // `gameSessionHeat.ts` shutdown, `gameSessionPhysical.ts` target /
+    // miss / hit) thread an explicit value.
+    for (const event of psrEvents) {
+      const payload = event.payload as { readonly reasonCode?: unknown };
+      expect(payload.reasonCode).toBeDefined();
+    }
+  });
 });

--- a/src/simulation/runner/phases/physicalAttack.ts
+++ b/src/simulation/runner/phases/physicalAttack.ts
@@ -3,6 +3,7 @@ import {
   GamePhase,
   IGameEvent,
   IGameState,
+  PSRTrigger,
 } from '@/types/gameplay';
 import { resolveDamage } from '@/utils/gameplay/damage';
 import { hexDistance } from '@/utils/gameplay/hexMath';
@@ -187,6 +188,13 @@ export function runPhysicalAttackPhase(options: {
     if (!result.hit && result.attackerPSR) {
       const attackerUnit = currentState.units[unitId];
       const existingPSRs = attackerUnit.pendingPSRs ?? [];
+      // Per `structure-psr-reason-as-discriminated-code` (PR E):
+      // canonical reasonCode for the kick / punch miss attacker PSR.
+      // Punch-miss has no canonical enum code today (the spec catalog
+      // is kick / charge / DFA), so only kick maps cleanly. Punch
+      // remains coded by triggerSource only.
+      const missReasonCode =
+        bestAttack === 'kick' ? PSRTrigger.KickMiss : undefined;
       currentState = {
         ...currentState,
         units: {
@@ -200,6 +208,9 @@ export function runPhysicalAttackPhase(options: {
                 reason: `${bestAttack} missed`,
                 additionalModifier: result.attackerPSRModifier,
                 triggerSource: `${bestAttack}_miss`,
+                ...(missReasonCode !== undefined
+                  ? { reasonCode: missReasonCode }
+                  : {}),
               },
             ],
           },

--- a/src/simulation/runner/phases/postCombat.ts
+++ b/src/simulation/runner/phases/postCombat.ts
@@ -72,6 +72,12 @@ export function runPSRPhase(options: {
             targetNumber: psrResult.targetNumber,
             roll: psrResult.roll,
             passed: psrResult.passed,
+            // Per `structure-psr-reason-as-discriminated-code` (PR E):
+            // forward the canonical reasonCode the factory stamped onto
+            // the source IPendingPSR.
+            ...(psrResult.psr.reasonCode !== undefined
+              ? { reasonCode: psrResult.psr.reasonCode }
+              : {}),
           },
           unitId,
         ),
@@ -118,6 +124,12 @@ export function runPSRPhase(options: {
             pilotDamage: 1,
             location: 'center_torso',
             ...(failedPsr ? { reason: failedPsr.psr.reason } : {}),
+            // Per `structure-psr-reason-as-discriminated-code` (PR E):
+            // canonical reasonCode of the failed PSR that caused the
+            // fall.
+            ...(failedPsr?.psr.reasonCode !== undefined
+              ? { reasonCode: failedPsr.psr.reasonCode }
+              : {}),
           },
           unitId,
         ),

--- a/src/simulation/runner/phases/weaponAttack.ts
+++ b/src/simulation/runner/phases/weaponAttack.ts
@@ -351,6 +351,13 @@ function emitCritEvents(options: {
             ...(targetPilotingSkill !== undefined
               ? { basePilotingSkill: targetPilotingSkill }
               : {}),
+            // Per `structure-psr-reason-as-discriminated-code` (PR E):
+            // forward the canonical `reasonCode` if the upstream
+            // critical-hit pipeline produced one. The catalog of
+            // crit-driven PSR reasons (gyro hit, engine hit, hip /
+            // upper-leg / lower-leg / foot actuator destroyed) is
+            // covered by the damage-family factory migration.
+            ...(p.reasonCode !== undefined ? { reasonCode: p.reasonCode } : {}),
           },
           attackerId,
         ),

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -26,6 +26,7 @@ import type {
 import type { IEnvironmentalConditions } from './EnvironmentalConditions';
 
 import { IHexCoordinate, Facing, MovementType } from './HexGridInterfaces';
+import { PSRTrigger } from './PSRTriggerCodes';
 
 // =============================================================================
 // Enums
@@ -1024,6 +1025,16 @@ export interface IPSRTriggeredPayload {
    * landed.
    */
   readonly basePilotingSkill?: number;
+  /**
+   * Per `structure-psr-reason-as-discriminated-code` (PR E): canonical
+   * `PSRTrigger` enum value paired with the human-readable `reason`
+   * string. Display consumers (`EventLogDisplay`, `format-event-log.py`)
+   * keep reading `reason`; filter / aggregate consumers
+   * (`EventLogQuery`, `MetricsCollector`) read `reasonCode` for
+   * machine-readable filtering. OPTIONAL for back-compat with NDJSON
+   * streams written before this field landed.
+   */
+  readonly reasonCode?: PSRTrigger;
 }
 
 export interface IPSRResolvedPayload {
@@ -1038,6 +1049,13 @@ export interface IPSRResolvedPayload {
    * compose `roll`. OPTIONAL — see `IInitiativeRolledPayload.rolls`.
    */
   readonly rolls?: readonly number[];
+  /**
+   * Per `structure-psr-reason-as-discriminated-code` (PR E): canonical
+   * `PSRTrigger` enum value paired with the human-readable `reason`
+   * string. Same back-compat semantics as `IPSRTriggeredPayload.reasonCode`.
+   * OPTIONAL.
+   */
+  readonly reasonCode?: PSRTrigger;
 }
 
 export interface IUnitFellPayload {
@@ -1061,12 +1079,18 @@ export interface IUnitFellPayload {
   /**
    * Free-string reason describing the fall cause (e.g. `'gyro-hit'`,
    * `'took-20-damage'`). PR E (`structure-psr-reason-as-discriminated-code`)
-   * tightens this to a `PSRReasonCode` discriminated union; for now it is
-   * deliberately string-typed to remain compatible with the existing
-   * free-form PSR reason strings emitted by the runner. Optional for
+   * keeps this string-typed for display continuity and adds the sibling
+   * `reasonCode` below for machine-readable filtering. Optional for
    * back-compat.
    */
   readonly reason?: string;
+  /**
+   * Per `structure-psr-reason-as-discriminated-code` (PR E): canonical
+   * `PSRTrigger` enum value paired with the human-readable `reason`
+   * string. Same back-compat semantics as `IPSRTriggeredPayload.reasonCode`.
+   * OPTIONAL.
+   */
+  readonly reasonCode?: PSRTrigger;
 }
 
 /**
@@ -1687,6 +1711,17 @@ export interface IPendingPSR {
   readonly additionalModifier: number;
   /** What triggered this PSR */
   readonly triggerSource: string;
+  /**
+   * Per `structure-psr-reason-as-discriminated-code` (PR E): canonical
+   * `PSRTrigger` enum value carried alongside the human-readable
+   * `reason` string. Populated by every PSR factory in
+   * `src/utils/gameplay/pilotingSkillRolls/`. The downstream event
+   * builder (`createPSRTriggeredEvent`) threads this through to
+   * `IPSRTriggeredPayload.reasonCode` so consumers can filter / bucket
+   * PSRs by canonical code. OPTIONAL for back-compat with synthetic
+   * `IPendingPSR` fixtures predating PR E.
+   */
+  readonly reasonCode?: PSRTrigger;
 }
 
 // =============================================================================

--- a/src/types/gameplay/PSRTriggerCodes.ts
+++ b/src/types/gameplay/PSRTriggerCodes.ts
@@ -1,0 +1,64 @@
+/**
+ * Piloting Skill Roll trigger codes — canonical enum.
+ *
+ * Lives in `src/types/gameplay/` (the pure-types layer) so it can be
+ * referenced by both `GameSessionInterfaces.ts` (event payloads carry
+ * `reasonCode?: PSRTrigger`) and `src/utils/gameplay/pilotingSkillRolls/types.ts`
+ * (factories populate `reasonCode`) without forming a cycle. Prior to PR E
+ * (`structure-psr-reason-as-discriminated-code`) this enum lived in
+ * `pilotingSkillRolls/types.ts`; back-compat is preserved via a re-export
+ * from that module.
+ *
+ * The 27 canonical snake_case codes mirror MegaMek's
+ * `Server.processPilotingRolls` and `MovePathHandler.checkSkid`
+ * taxonomy. See the `piloting-skill-rolls` spec
+ * (`Requirement: PSR Reason Code Discriminated Field`) for the
+ * code → category mapping.
+ *
+ * @spec openspec/specs/piloting-skill-rolls/spec.md
+ */
+export enum PSRTrigger {
+  // Damage triggers
+  PhaseDamage20Plus = '20+_damage',
+  LegDamage = 'leg_damage',
+
+  // Component damage triggers
+  HipActuatorDestroyed = 'hip_actuator_destroyed',
+  GyroHit = 'gyro_hit',
+  EngineHit = 'engine_hit',
+  UpperLegActuatorHit = 'upper_leg_actuator_hit',
+  LowerLegActuatorHit = 'lower_leg_actuator_hit',
+  FootActuatorHit = 'foot_actuator_hit',
+
+  // Physical attack triggers (target)
+  Kicked = 'kicked',
+  Charged = 'charged',
+  DFATarget = 'dfa_target',
+  Pushed = 'pushed',
+
+  // Physical attack miss triggers (attacker)
+  KickMiss = 'kick_miss',
+  ChargeMiss = 'charge_miss',
+  DFAMiss = 'dfa_miss',
+
+  // Shutdown/startup triggers
+  Shutdown = 'heat_shutdown',
+  StandingUp = 'standing_up',
+
+  // Terrain triggers
+  EnteringRubble = 'entering_rubble',
+  RunningRoughTerrain = 'running_rough_terrain',
+  MovingOnIce = 'moving_on_ice',
+  EnteringWater = 'entering_water',
+  ExitingWater = 'exiting_water',
+  Skidding = 'skidding',
+
+  // Movement with damage triggers
+  RunningDamagedHip = 'running_damaged_hip',
+  RunningDamagedGyro = 'running_damaged_gyro',
+
+  // Collapse/failure triggers
+  BuildingCollapse = 'building_collapse',
+  MASCFailure = 'masc_failure',
+  SuperchargerFailure = 'supercharger_failure',
+}

--- a/src/types/gameplay/index.ts
+++ b/src/types/gameplay/index.ts
@@ -23,6 +23,10 @@ export * from './EnvironmentalConditions';
 export * from './GameSessionInterfaces';
 export * from './GameLobbyInterfaces';
 
+// PSR trigger codes (PR E: lifted to its own module to avoid cycle
+// between GameSessionInterfaces and pilotingSkillRolls/types).
+export * from './PSRTriggerCodes';
+
 // Combat Resolution
 export * from './CombatInterfaces';
 

--- a/src/utils/gameplay/criticalHitResolution/actuatorEffects.ts
+++ b/src/utils/gameplay/criticalHitResolution/actuatorEffects.ts
@@ -1,5 +1,9 @@
 import { ActuatorType } from '@/types/construction/MechConfigurationSystem';
-import { CriticalEffectType, ICriticalEffect } from '@/types/gameplay';
+import {
+  CriticalEffectType,
+  ICriticalEffect,
+  PSRTrigger,
+} from '@/types/gameplay';
 
 import {
   SHOULDER_TO_HIT_MODIFIER,
@@ -48,6 +52,19 @@ export function applyActuatorHit(
           ? FOOT_PSR_MODIFIER
           : LEG_ACTUATOR_PSR_MODIFIER;
 
+    // Per `structure-psr-reason-as-discriminated-code` (PR E): the
+    // crit-driven leg-actuator PSRs map onto the canonical damage-bucket
+    // codes so consumers can filter / aggregate by reasonCode the same
+    // way they do for runner-initiated PSRs.
+    const reasonCode =
+      actuatorType === ActuatorType.HIP
+        ? PSRTrigger.HipActuatorDestroyed
+        : actuatorType === ActuatorType.UPPER_LEG
+          ? PSRTrigger.UpperLegActuatorHit
+          : actuatorType === ActuatorType.LOWER_LEG
+            ? PSRTrigger.LowerLegActuatorHit
+            : PSRTrigger.FootActuatorHit;
+
     events.push({
       type: 'psr_triggered',
       payload: {
@@ -55,6 +72,7 @@ export function applyActuatorHit(
         reason: `${slot.componentName} destroyed`,
         additionalModifier: modifier,
         triggerSource: 'actuator_critical',
+        reasonCode,
       },
     });
   }

--- a/src/utils/gameplay/criticalHitResolution/engineEffects.ts
+++ b/src/utils/gameplay/criticalHitResolution/engineEffects.ts
@@ -1,4 +1,8 @@
-import { CriticalEffectType, ICriticalEffect } from '@/types/gameplay';
+import {
+  CriticalEffectType,
+  ICriticalEffect,
+  PSRTrigger,
+} from '@/types/gameplay';
 
 import {
   ENGINE_DESTRUCTION_THRESHOLD,
@@ -47,6 +51,9 @@ export function applyGyroHit(
   const newHits = componentDamage.gyroHits + 1;
   const updatedDamage = { ...componentDamage, gyroHits: newHits };
 
+  // Per `structure-psr-reason-as-discriminated-code` (PR E): canonical
+  // damage-bucket reasonCode for crit-driven gyro PSRs. Mirrors the
+  // `createGyroPSR` factory.
   events.push({
     type: 'psr_triggered',
     payload: {
@@ -54,6 +61,7 @@ export function applyGyroHit(
       reason: 'Gyro hit',
       additionalModifier: GYRO_PSR_MODIFIER_PER_HIT * newHits,
       triggerSource: 'gyro_critical',
+      reasonCode: PSRTrigger.GyroHit,
     },
   });
 

--- a/src/utils/gameplay/gameEvents/status.ts
+++ b/src/utils/gameplay/gameEvents/status.ts
@@ -20,6 +20,7 @@ import {
   IPhysicalAttackDeclaredPayload,
   IPhysicalAttackResolvedPayload,
   PhysicalAttackEventType,
+  PSRTrigger,
 } from '@/types/gameplay';
 
 import { createEventBase } from './base';
@@ -235,6 +236,7 @@ export function createPSRTriggeredEvent(
   additionalModifier: number,
   triggerSource: string,
   basePilotingSkill?: number,
+  reasonCode?: PSRTrigger,
 ): IGameEvent {
   const payload: IPSRTriggeredPayload = {
     unitId,
@@ -242,6 +244,7 @@ export function createPSRTriggeredEvent(
     additionalModifier,
     triggerSource,
     ...(basePilotingSkill !== undefined ? { basePilotingSkill } : {}),
+    ...(reasonCode !== undefined ? { reasonCode } : {}),
   };
 
   return {
@@ -268,6 +271,7 @@ export function createPSRResolvedEvent(
   modifiers: number,
   passed: boolean,
   reason: string,
+  reasonCode?: PSRTrigger,
 ): IGameEvent {
   const payload: IPSRResolvedPayload = {
     unitId,
@@ -276,6 +280,7 @@ export function createPSRResolvedEvent(
     modifiers,
     passed,
     reason,
+    ...(reasonCode !== undefined ? { reasonCode } : {}),
   };
 
   return {
@@ -302,6 +307,7 @@ export function createUnitFellEvent(
   pilotDamage: number,
   location?: string,
   reason?: string,
+  reasonCode?: PSRTrigger,
 ): IGameEvent {
   const payload: IUnitFellPayload = {
     unitId,
@@ -310,6 +316,7 @@ export function createUnitFellEvent(
     pilotDamage,
     ...(location !== undefined ? { location } : {}),
     ...(reason !== undefined ? { reason } : {}),
+    ...(reasonCode !== undefined ? { reasonCode } : {}),
   };
 
   return {

--- a/src/utils/gameplay/gameSessionAttackResolution.ts
+++ b/src/utils/gameplay/gameSessionAttackResolution.ts
@@ -6,6 +6,7 @@ import {
   IGameEvent,
   IGameSession,
   IWeaponAttackData,
+  PSRTrigger,
 } from '@/types/gameplay';
 import { logger } from '@/utils/logger';
 
@@ -403,6 +404,7 @@ export function resolveAttack(
               0,
               'leg_damage',
               targetUnit?.piloting,
+              PSRTrigger.LegDamage,
             ),
           );
           break;
@@ -432,6 +434,7 @@ export function resolveAttack(
             0,
             'phase_damage_20_plus',
             targetUnit?.piloting,
+            PSRTrigger.PhaseDamage20Plus,
           ),
         );
       }

--- a/src/utils/gameplay/gameSessionAttackResolutionHelpers.ts
+++ b/src/utils/gameplay/gameSessionAttackResolutionHelpers.ts
@@ -106,6 +106,7 @@ export function emitCriticalEvents(
           payload.additionalModifier,
           payload.triggerSource,
           psrUnit?.piloting,
+          payload.reasonCode,
         ),
       );
       continue;

--- a/src/utils/gameplay/gameSessionHeat.ts
+++ b/src/utils/gameplay/gameSessionHeat.ts
@@ -11,6 +11,7 @@ import {
   IGameSession,
   IHexCoordinate,
   IMovementDeclaredPayload,
+  PSRTrigger,
 } from '@/types/gameplay';
 import { logger } from '@/utils/logger';
 
@@ -294,6 +295,7 @@ export function resolveHeatPhase(
           0,
           'heat_shutdown',
           unit?.piloting,
+          PSRTrigger.Shutdown,
         ),
       );
     } else {

--- a/src/utils/gameplay/gameSessionPSR.ts
+++ b/src/utils/gameplay/gameSessionPSR.ts
@@ -48,6 +48,7 @@ export function checkAndQueueDamagePSRs(session: IGameSession): IGameSession {
           damagePSR.additionalModifier,
           damagePSR.triggerSource,
           unit?.piloting,
+          damagePSR.reasonCode,
         ),
       );
     }
@@ -108,6 +109,7 @@ export function resolvePendingPSRs(
             0,
             false,
             pending.reason,
+            pending.reasonCode,
           ),
         );
       }
@@ -132,6 +134,7 @@ export function resolvePendingPSRs(
           fallResult.pilotDamage,
           'center_torso',
           pendingPSRs[0]?.reason ?? 'gyro_destroyed',
+          pendingPSRs[0]?.reasonCode,
         ),
       );
 
@@ -185,6 +188,7 @@ export function resolvePendingPSRs(
           result.modifiers.reduce((sum, modifier) => sum + modifier.value, 0),
           result.passed,
           result.psr.reason,
+          result.psr.reasonCode,
         ),
       );
     }
@@ -204,6 +208,7 @@ export function resolvePendingPSRs(
           0,
           false,
           cleared.reason,
+          cleared.reasonCode,
         ),
       );
     }
@@ -232,6 +237,7 @@ export function resolvePendingPSRs(
           fallResult.pilotDamage,
           'center_torso',
           failedPsr?.psr.reason ?? pendingPSRs[0]?.reason,
+          failedPsr?.psr.reasonCode ?? pendingPSRs[0]?.reasonCode,
         ),
       );
 
@@ -300,6 +306,7 @@ export function attemptStandUp(
       psr.additionalModifier,
       psr.triggerSource,
       unit.piloting,
+      psr.reasonCode,
     ),
   );
 
@@ -328,6 +335,7 @@ export function attemptStandUp(
       gyroModifier + woundModifier,
       passed,
       psr.reason,
+      psr.reasonCode,
     ),
   );
 

--- a/src/utils/gameplay/gameSessionPhysical.ts
+++ b/src/utils/gameplay/gameSessionPhysical.ts
@@ -18,6 +18,7 @@ import {
   IGameEvent,
   IGameSession,
   IPhysicalAttackDeclaredPayload,
+  PSRTrigger,
 } from '@/types/gameplay';
 
 import { resolveDamage as resolveDamagePipeline } from './damage';
@@ -467,6 +468,20 @@ export function resolveAllPhysicalAttacks(
       (u) => u.id === payload.targetId,
     );
     if (result.hit && result.targetPSR) {
+      // Per `structure-psr-reason-as-discriminated-code` (PR E): map the
+      // generic `physical_attack_target` trigger source to the canonical
+      // `PSRTrigger` matching the originating attack type so consumers
+      // can filter target PSRs by attack family.
+      const targetReasonCode =
+        payload.attackType === 'kick'
+          ? PSRTrigger.Kicked
+          : payload.attackType === 'charge'
+            ? PSRTrigger.Charged
+            : payload.attackType === 'dfa'
+              ? PSRTrigger.DFATarget
+              : payload.attackType === 'push'
+                ? PSRTrigger.Pushed
+                : undefined;
       const psrSeq = currentSession.events.length;
       currentSession = appendEvent(
         currentSession,
@@ -480,6 +495,7 @@ export function resolveAllPhysicalAttacks(
           0,
           'physical_attack_target',
           targetUnit?.piloting,
+          targetReasonCode,
         ),
       );
     }
@@ -493,6 +509,16 @@ export function resolveAllPhysicalAttacks(
           : payload.attackType === 'dfa'
             ? 'dfa_attacker_hit'
             : 'physical_attacker_hit';
+      // Attacker-on-hit PSRs share the canonical movement codes for the
+      // attack family — Charged / DFATarget mirror the target codes per
+      // the PSR Trigger Catalog. Kept undefined when no canonical code
+      // applies (e.g. generic `physical_attacker_hit`).
+      const attackerHitReasonCode =
+        payload.attackType === 'charge'
+          ? PSRTrigger.Charged
+          : payload.attackType === 'dfa'
+            ? PSRTrigger.DFATarget
+            : undefined;
       const psrSeq = currentSession.events.length;
       currentSession = appendEvent(
         currentSession,
@@ -506,6 +532,7 @@ export function resolveAllPhysicalAttacks(
           result.attackerPSRModifier,
           attackerHitTrigger,
           context.pilotingSkill,
+          attackerHitReasonCode,
         ),
       );
     }
@@ -518,6 +545,14 @@ export function resolveAllPhysicalAttacks(
             : payload.attackType === 'dfa'
               ? 'dfa_miss'
               : 'physical_miss';
+      const missReasonCode =
+        payload.attackType === 'kick'
+          ? PSRTrigger.KickMiss
+          : payload.attackType === 'charge'
+            ? PSRTrigger.ChargeMiss
+            : payload.attackType === 'dfa'
+              ? PSRTrigger.DFAMiss
+              : undefined;
       const psrSeq = currentSession.events.length;
       currentSession = appendEvent(
         currentSession,
@@ -531,6 +566,7 @@ export function resolveAllPhysicalAttacks(
           result.attackerPSRModifier,
           triggerSource,
           context.pilotingSkill,
+          missReasonCode,
         ),
       );
     }

--- a/src/utils/gameplay/pilotingSkillRolls/__tests__/factoryReasonCode.test.ts
+++ b/src/utils/gameplay/pilotingSkillRolls/__tests__/factoryReasonCode.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Per `structure-psr-reason-as-discriminated-code` (PR E): each PSR
+ * factory across the five module families
+ * (combat / damage / environment / system / phaseChecks) MUST populate
+ * `reasonCode: PSRTrigger.X` on the returned `IPendingPSR` alongside the
+ * existing free-form `reason: string`. These tests are a one-per-family
+ * regression net for the factory migration; they don't enumerate every
+ * factory in every family.
+ *
+ * @spec openspec/changes/structure-psr-reason-as-discriminated-code/specs/piloting-skill-rolls/spec.md
+ *   Requirement: PSR Reason Code Discriminated Field — Scenario "Factory populates reasonCode alongside reason"
+ */
+import {
+  // combat family
+  createKickedPSR,
+  createChargedPSR,
+  createDFATargetPSR,
+  createPushedPSR,
+  createKickMissPSR,
+  createChargeMissPSR,
+  createDFAMissPSR,
+
+  // damage family
+  createDamagePSR,
+  createLegDamagePSR,
+  createHipActuatorPSR,
+  createGyroPSR,
+  createEngineHitPSR,
+  createUpperLegActuatorPSR,
+  createLowerLegActuatorPSR,
+  createFootActuatorPSR,
+
+  // environment family
+  createShutdownPSR,
+  createStandingUpPSR,
+  createRubblePSR,
+  createRunningRoughTerrainPSR,
+  createIcePSR,
+  createEnteringWaterPSR,
+  createExitingWaterPSR,
+  createSkiddingPSR,
+  createBuildingCollapsePSR,
+
+  // system family
+  createRunningDamagedHipPSR,
+  createRunningDamagedGyroPSR,
+  createMASCFailurePSR,
+  createSuperchargerFailurePSR,
+  PSRTrigger,
+} from '../../pilotingSkillRolls';
+import { createStandUpAttempt } from '../../pilotingSkillRolls';
+
+describe('PSR factory reasonCode population (PR E)', () => {
+  const ENTITY = 'unit-1';
+
+  describe('combat factories', () => {
+    it.each([
+      ['createKickedPSR', createKickedPSR(ENTITY), PSRTrigger.Kicked],
+      ['createChargedPSR', createChargedPSR(ENTITY), PSRTrigger.Charged],
+      ['createDFATargetPSR', createDFATargetPSR(ENTITY), PSRTrigger.DFATarget],
+      ['createPushedPSR', createPushedPSR(ENTITY), PSRTrigger.Pushed],
+      ['createKickMissPSR', createKickMissPSR(ENTITY), PSRTrigger.KickMiss],
+      [
+        'createChargeMissPSR',
+        createChargeMissPSR(ENTITY),
+        PSRTrigger.ChargeMiss,
+      ],
+      ['createDFAMissPSR', createDFAMissPSR(ENTITY), PSRTrigger.DFAMiss],
+    ])('%s populates reasonCode', (_name, psr, expected) => {
+      expect(psr.reasonCode).toBe(expected);
+      expect(typeof psr.reason).toBe('string');
+      expect(psr.reason.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('damage factories', () => {
+    it.each([
+      [
+        'createDamagePSR',
+        createDamagePSR(ENTITY),
+        PSRTrigger.PhaseDamage20Plus,
+      ],
+      ['createLegDamagePSR', createLegDamagePSR(ENTITY), PSRTrigger.LegDamage],
+      [
+        'createHipActuatorPSR',
+        createHipActuatorPSR(ENTITY),
+        PSRTrigger.HipActuatorDestroyed,
+      ],
+      ['createGyroPSR', createGyroPSR(ENTITY), PSRTrigger.GyroHit],
+      ['createEngineHitPSR', createEngineHitPSR(ENTITY), PSRTrigger.EngineHit],
+      [
+        'createUpperLegActuatorPSR',
+        createUpperLegActuatorPSR(ENTITY),
+        PSRTrigger.UpperLegActuatorHit,
+      ],
+      [
+        'createLowerLegActuatorPSR',
+        createLowerLegActuatorPSR(ENTITY),
+        PSRTrigger.LowerLegActuatorHit,
+      ],
+      [
+        'createFootActuatorPSR',
+        createFootActuatorPSR(ENTITY),
+        PSRTrigger.FootActuatorHit,
+      ],
+    ])('%s populates reasonCode', (_name, psr, expected) => {
+      expect(psr.reasonCode).toBe(expected);
+      expect(typeof psr.reason).toBe('string');
+      expect(psr.reason.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('environment factories', () => {
+    it.each([
+      ['createShutdownPSR', createShutdownPSR(ENTITY), PSRTrigger.Shutdown],
+      [
+        'createStandingUpPSR',
+        createStandingUpPSR(ENTITY),
+        PSRTrigger.StandingUp,
+      ],
+      ['createRubblePSR', createRubblePSR(ENTITY), PSRTrigger.EnteringRubble],
+      [
+        'createRunningRoughTerrainPSR',
+        createRunningRoughTerrainPSR(ENTITY),
+        PSRTrigger.RunningRoughTerrain,
+      ],
+      ['createIcePSR', createIcePSR(ENTITY), PSRTrigger.MovingOnIce],
+      [
+        'createEnteringWaterPSR',
+        createEnteringWaterPSR(ENTITY),
+        PSRTrigger.EnteringWater,
+      ],
+      [
+        'createExitingWaterPSR',
+        createExitingWaterPSR(ENTITY),
+        PSRTrigger.ExitingWater,
+      ],
+      ['createSkiddingPSR', createSkiddingPSR(ENTITY), PSRTrigger.Skidding],
+      [
+        'createBuildingCollapsePSR',
+        createBuildingCollapsePSR(ENTITY),
+        PSRTrigger.BuildingCollapse,
+      ],
+    ])('%s populates reasonCode', (_name, psr, expected) => {
+      expect(psr.reasonCode).toBe(expected);
+      expect(typeof psr.reason).toBe('string');
+      expect(psr.reason.length).toBeGreaterThan(0);
+    });
+
+    it('environment factories preserve the optional movement-step trigger source while still stamping reasonCode', () => {
+      // PR-C invariant: passing stepIndex overrides triggerSource to
+      // `'movement-step:<n>'` but reasonCode stays the canonical enum
+      // value so consumers can still bucket.
+      const stepBound = createIcePSR(ENTITY, 3);
+      expect(stepBound.triggerSource).toBe('movement-step:3');
+      expect(stepBound.reasonCode).toBe(PSRTrigger.MovingOnIce);
+    });
+  });
+
+  describe('system factories', () => {
+    it.each([
+      [
+        'createRunningDamagedHipPSR',
+        createRunningDamagedHipPSR(ENTITY),
+        PSRTrigger.RunningDamagedHip,
+      ],
+      [
+        'createRunningDamagedGyroPSR',
+        createRunningDamagedGyroPSR(ENTITY),
+        PSRTrigger.RunningDamagedGyro,
+      ],
+      [
+        'createMASCFailurePSR',
+        createMASCFailurePSR(ENTITY),
+        PSRTrigger.MASCFailure,
+      ],
+      [
+        'createSuperchargerFailurePSR',
+        createSuperchargerFailurePSR(ENTITY),
+        PSRTrigger.SuperchargerFailure,
+      ],
+    ])('%s populates reasonCode', (_name, psr, expected) => {
+      expect(psr.reasonCode).toBe(expected);
+      expect(typeof psr.reason).toBe('string');
+      expect(psr.reason.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('phaseChecks factory', () => {
+    it('createStandUpAttempt produces a PSR with reasonCode StandingUp', () => {
+      const stub = {
+        id: ENTITY,
+        prone: true,
+      } as unknown as Parameters<typeof createStandUpAttempt>[0];
+      const result = createStandUpAttempt(stub, 4);
+      expect(result).not.toBeNull();
+      expect(result!.psr.reasonCode).toBe(PSRTrigger.StandingUp);
+    });
+  });
+});

--- a/src/utils/gameplay/pilotingSkillRolls/__tests__/getPSRReasonCategory.test.ts
+++ b/src/utils/gameplay/pilotingSkillRolls/__tests__/getPSRReasonCategory.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for `getPSRReasonCategory` — the bucket helper that partitions
+ * the 27-code `PSRTrigger` taxonomy into the four `PSRReasonCategory`
+ * buckets (movement / damage / heat / recovery).
+ *
+ * @spec openspec/changes/structure-psr-reason-as-discriminated-code/specs/piloting-skill-rolls/spec.md
+ *   Requirement: PSR Reason Category Bucket Helper
+ */
+import { PSRTrigger, PSRReasonCategory, getPSRReasonCategory } from '../types';
+
+describe('getPSRReasonCategory', () => {
+  describe('spot checks (one per bucket)', () => {
+    it('maps Kicked to movement', () => {
+      expect(getPSRReasonCategory(PSRTrigger.Kicked)).toBe('movement');
+    });
+
+    it('maps PhaseDamage20Plus to damage', () => {
+      expect(getPSRReasonCategory(PSRTrigger.PhaseDamage20Plus)).toBe('damage');
+    });
+
+    it('maps Shutdown (heat-induced) to heat', () => {
+      expect(getPSRReasonCategory(PSRTrigger.Shutdown)).toBe('heat');
+    });
+
+    it('maps StandingUp to recovery', () => {
+      expect(getPSRReasonCategory(PSRTrigger.StandingUp)).toBe('recovery');
+    });
+  });
+
+  describe('exhaustive partitioning over all 27 codes', () => {
+    const allTriggers = Object.values(PSRTrigger) as readonly PSRTrigger[];
+
+    it('enumerates the canonical PSRTrigger codes', () => {
+      // Sanity check on the enum size — if a code is added in a follow-on
+      // change, this assertion fails first and forces a category decision.
+      // The spec proposal calls out "27 canonical snake_case codes"; the
+      // enum carries one extra (`Pushed` in the physical-attack target
+      // family) for a total of 28. Both numbers are stable; if either
+      // changes the test fails and forces a spec / enum reconciliation.
+      expect(allTriggers).toHaveLength(28);
+    });
+
+    it('every PSRTrigger value maps to exactly one of the four buckets', () => {
+      const valid: readonly PSRReasonCategory[] = [
+        'movement',
+        'damage',
+        'heat',
+        'recovery',
+      ];
+      for (const trigger of allTriggers) {
+        const bucket = getPSRReasonCategory(trigger);
+        expect(valid).toContain(bucket);
+      }
+    });
+
+    it('all four buckets are non-empty', () => {
+      const buckets: Record<PSRReasonCategory, number> = {
+        movement: 0,
+        damage: 0,
+        heat: 0,
+        recovery: 0,
+      };
+      for (const trigger of allTriggers) {
+        buckets[getPSRReasonCategory(trigger)] += 1;
+      }
+      expect(buckets.movement).toBeGreaterThan(0);
+      expect(buckets.damage).toBeGreaterThan(0);
+      expect(buckets.heat).toBeGreaterThan(0);
+      expect(buckets.recovery).toBeGreaterThan(0);
+    });
+
+    it('matches the canonical partition documented in the spec', () => {
+      // 18 movement + 8 damage + 1 heat + 1 recovery = 28
+      // (8 + 18 + 1 + 1; the spec text mentions 27 but the enum carries
+      // 28 — the bucket helper treats every enum member, regardless).
+      const buckets: Record<PSRReasonCategory, number> = {
+        movement: 0,
+        damage: 0,
+        heat: 0,
+        recovery: 0,
+      };
+      for (const trigger of allTriggers) {
+        buckets[getPSRReasonCategory(trigger)] += 1;
+      }
+      expect(buckets.damage).toBe(8);
+      expect(buckets.movement).toBe(18);
+      expect(buckets.heat).toBe(1);
+      expect(buckets.recovery).toBe(1);
+    });
+  });
+
+  describe('per-code expectations from the spec table', () => {
+    const damageCodes: readonly PSRTrigger[] = [
+      PSRTrigger.PhaseDamage20Plus,
+      PSRTrigger.LegDamage,
+      PSRTrigger.HipActuatorDestroyed,
+      PSRTrigger.GyroHit,
+      PSRTrigger.EngineHit,
+      PSRTrigger.UpperLegActuatorHit,
+      PSRTrigger.LowerLegActuatorHit,
+      PSRTrigger.FootActuatorHit,
+    ];
+    const movementCodes: readonly PSRTrigger[] = [
+      PSRTrigger.Kicked,
+      PSRTrigger.Charged,
+      PSRTrigger.DFATarget,
+      PSRTrigger.Pushed,
+      PSRTrigger.KickMiss,
+      PSRTrigger.ChargeMiss,
+      PSRTrigger.DFAMiss,
+      PSRTrigger.EnteringRubble,
+      PSRTrigger.RunningRoughTerrain,
+      PSRTrigger.MovingOnIce,
+      PSRTrigger.EnteringWater,
+      PSRTrigger.ExitingWater,
+      PSRTrigger.Skidding,
+      PSRTrigger.RunningDamagedHip,
+      PSRTrigger.RunningDamagedGyro,
+      PSRTrigger.BuildingCollapse,
+      PSRTrigger.MASCFailure,
+      PSRTrigger.SuperchargerFailure,
+    ];
+
+    it.each(damageCodes)('%s maps to damage', (code) => {
+      expect(getPSRReasonCategory(code)).toBe('damage');
+    });
+
+    it.each(movementCodes)('%s maps to movement', (code) => {
+      expect(getPSRReasonCategory(code)).toBe('movement');
+    });
+  });
+});

--- a/src/utils/gameplay/pilotingSkillRolls/combatFactories.ts
+++ b/src/utils/gameplay/pilotingSkillRolls/combatFactories.ts
@@ -14,6 +14,7 @@ export function createKickedPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Kicked',
+    reasonCode: PSRTrigger.Kicked,
     additionalModifier: 0,
     triggerSource: PSRTrigger.Kicked,
   };
@@ -26,6 +27,7 @@ export function createChargedPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Charged',
+    reasonCode: PSRTrigger.Charged,
     additionalModifier: 0,
     triggerSource: PSRTrigger.Charged,
   };
@@ -38,6 +40,7 @@ export function createDFATargetPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Hit by DFA',
+    reasonCode: PSRTrigger.DFATarget,
     additionalModifier: 0,
     triggerSource: PSRTrigger.DFATarget,
   };
@@ -50,6 +53,7 @@ export function createPushedPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Pushed',
+    reasonCode: PSRTrigger.Pushed,
     additionalModifier: 0,
     triggerSource: PSRTrigger.Pushed,
   };
@@ -62,6 +66,7 @@ export function createKickMissPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Kick missed',
+    reasonCode: PSRTrigger.KickMiss,
     additionalModifier: 0,
     triggerSource: PSRTrigger.KickMiss,
   };
@@ -74,6 +79,7 @@ export function createChargeMissPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Charge missed',
+    reasonCode: PSRTrigger.ChargeMiss,
     additionalModifier: 0,
     triggerSource: PSRTrigger.ChargeMiss,
   };
@@ -86,6 +92,7 @@ export function createDFAMissPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'DFA missed',
+    reasonCode: PSRTrigger.DFAMiss,
     additionalModifier: 4,
     triggerSource: PSRTrigger.DFAMiss,
   };

--- a/src/utils/gameplay/pilotingSkillRolls/damageFactories.ts
+++ b/src/utils/gameplay/pilotingSkillRolls/damageFactories.ts
@@ -14,6 +14,7 @@ export function createDamagePSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: '20+ damage this phase',
+    reasonCode: PSRTrigger.PhaseDamage20Plus,
     additionalModifier: 0,
     triggerSource: PSRTrigger.PhaseDamage20Plus,
   };
@@ -26,6 +27,7 @@ export function createLegDamagePSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Leg damage (internal structure exposed)',
+    reasonCode: PSRTrigger.LegDamage,
     additionalModifier: 0,
     triggerSource: PSRTrigger.LegDamage,
   };
@@ -38,6 +40,7 @@ export function createHipActuatorPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Hip actuator destroyed',
+    reasonCode: PSRTrigger.HipActuatorDestroyed,
     additionalModifier: 0,
     triggerSource: PSRTrigger.HipActuatorDestroyed,
   };
@@ -50,6 +53,7 @@ export function createGyroPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Gyro hit',
+    reasonCode: PSRTrigger.GyroHit,
     additionalModifier: 0,
     triggerSource: PSRTrigger.GyroHit,
   };
@@ -73,6 +77,7 @@ export function createEngineHitPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Engine hit',
+    reasonCode: PSRTrigger.EngineHit,
     additionalModifier: 0,
     triggerSource: PSRTrigger.EngineHit,
   };
@@ -85,6 +90,7 @@ export function createUpperLegActuatorPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Upper leg actuator hit',
+    reasonCode: PSRTrigger.UpperLegActuatorHit,
     additionalModifier: 0,
     triggerSource: PSRTrigger.UpperLegActuatorHit,
   };
@@ -97,6 +103,7 @@ export function createLowerLegActuatorPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Lower leg actuator hit',
+    reasonCode: PSRTrigger.LowerLegActuatorHit,
     additionalModifier: 0,
     triggerSource: PSRTrigger.LowerLegActuatorHit,
   };
@@ -109,6 +116,7 @@ export function createFootActuatorPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Foot actuator hit',
+    reasonCode: PSRTrigger.FootActuatorHit,
     additionalModifier: 0,
     triggerSource: PSRTrigger.FootActuatorHit,
   };

--- a/src/utils/gameplay/pilotingSkillRolls/environmentFactories.ts
+++ b/src/utils/gameplay/pilotingSkillRolls/environmentFactories.ts
@@ -32,6 +32,7 @@ export function createShutdownPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Reactor shutdown',
+    reasonCode: PSRTrigger.Shutdown,
     additionalModifier: 0,
     triggerSource: PSRTrigger.Shutdown,
   };
@@ -57,6 +58,7 @@ export function createStandingUpPSR(
   return {
     entityId,
     reason: 'Standing up',
+    reasonCode: PSRTrigger.StandingUp,
     additionalModifier: 0,
     triggerSource: movementStepSource ?? PSRTrigger.StandingUp,
   };
@@ -78,6 +80,7 @@ export function createRubblePSR(
   return {
     entityId,
     reason: 'Entering rubble',
+    reasonCode: PSRTrigger.EnteringRubble,
     additionalModifier: 0,
     triggerSource: movementStepSource ?? PSRTrigger.EnteringRubble,
   };
@@ -94,6 +97,7 @@ export function createRunningRoughTerrainPSR(
   return {
     entityId,
     reason: 'Running through rough terrain',
+    reasonCode: PSRTrigger.RunningRoughTerrain,
     additionalModifier: 0,
     triggerSource: movementStepSource ?? PSRTrigger.RunningRoughTerrain,
   };
@@ -110,6 +114,7 @@ export function createIcePSR(
   return {
     entityId,
     reason: 'Moving on ice',
+    reasonCode: PSRTrigger.MovingOnIce,
     additionalModifier: 0,
     triggerSource: movementStepSource ?? PSRTrigger.MovingOnIce,
   };
@@ -126,6 +131,7 @@ export function createEnteringWaterPSR(
   return {
     entityId,
     reason: 'Entering water',
+    reasonCode: PSRTrigger.EnteringWater,
     additionalModifier: 0,
     triggerSource: movementStepSource ?? PSRTrigger.EnteringWater,
   };
@@ -142,6 +148,7 @@ export function createExitingWaterPSR(
   return {
     entityId,
     reason: 'Exiting water',
+    reasonCode: PSRTrigger.ExitingWater,
     additionalModifier: 0,
     triggerSource: movementStepSource ?? PSRTrigger.ExitingWater,
   };
@@ -164,6 +171,7 @@ export function createSkiddingPSR(
   return {
     entityId,
     reason: 'Skidding',
+    reasonCode: PSRTrigger.Skidding,
     additionalModifier: 0,
     triggerSource: movementStepSource ?? PSRTrigger.Skidding,
   };
@@ -176,6 +184,7 @@ export function createBuildingCollapsePSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Building collapse',
+    reasonCode: PSRTrigger.BuildingCollapse,
     additionalModifier: 0,
     triggerSource: PSRTrigger.BuildingCollapse,
   };

--- a/src/utils/gameplay/pilotingSkillRolls/systemFactories.ts
+++ b/src/utils/gameplay/pilotingSkillRolls/systemFactories.ts
@@ -14,6 +14,7 @@ export function createRunningDamagedHipPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Running with damaged hip',
+    reasonCode: PSRTrigger.RunningDamagedHip,
     additionalModifier: 0,
     triggerSource: PSRTrigger.RunningDamagedHip,
   };
@@ -26,6 +27,7 @@ export function createRunningDamagedGyroPSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Running with damaged gyro',
+    reasonCode: PSRTrigger.RunningDamagedGyro,
     additionalModifier: 0,
     triggerSource: PSRTrigger.RunningDamagedGyro,
   };
@@ -38,6 +40,7 @@ export function createMASCFailurePSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'MASC failure',
+    reasonCode: PSRTrigger.MASCFailure,
     additionalModifier: 0,
     triggerSource: PSRTrigger.MASCFailure,
   };
@@ -50,6 +53,7 @@ export function createSuperchargerFailurePSR(entityId: string): IPendingPSR {
   return {
     entityId,
     reason: 'Supercharger failure',
+    reasonCode: PSRTrigger.SuperchargerFailure,
     additionalModifier: 0,
     triggerSource: PSRTrigger.SuperchargerFailure,
   };

--- a/src/utils/gameplay/pilotingSkillRolls/types.ts
+++ b/src/utils/gameplay/pilotingSkillRolls/types.ts
@@ -5,6 +5,17 @@
 
 import type { IPendingPSR } from '@/types/gameplay/GameSessionInterfaces';
 
+// PR E (`structure-psr-reason-as-discriminated-code`): the `PSRTrigger`
+// enum was moved to `src/types/gameplay/PSRTriggerCodes.ts` so
+// `GameSessionInterfaces.ts` can reference it for the new
+// `IPSRTriggeredPayload.reasonCode` / `IPSRResolvedPayload.reasonCode` /
+// `IUnitFellPayload.reasonCode` fields without forming a cycle. Re-exported
+// here for backward-compat with existing callers (factories,
+// `resolution.ts`, tests) that import from `./types`.
+import { PSRTrigger } from '@/types/gameplay/PSRTriggerCodes';
+
+export { PSRTrigger };
+
 /**
  * Result of a single PSR resolution.
  */
@@ -45,52 +56,76 @@ export interface IPSRBatchResult {
 }
 
 /**
- * PSR trigger types — all 27 canonical trigger sources, including the
- * `EngineHit` entry required by the piloting-skill-rolls spec
- * ("PSR Trigger Catalog") and consistent with MegaMek's engine-crit PSR.
+ * Per `structure-psr-reason-as-discriminated-code` (PR E): the four
+ * coarse buckets that partition the 27-code `PSRTrigger` taxonomy.
+ * Consumers (the readable formatter, metrics aggregators) bucket PSRs
+ * by category instead of enumerating all 27 codes.
+ *
+ * @spec openspec/specs/piloting-skill-rolls/spec.md
+ *   Requirement: PSR Reason Category Bucket Helper
  */
-export enum PSRTrigger {
-  // Damage triggers
-  PhaseDamage20Plus = '20+_damage',
-  LegDamage = 'leg_damage',
+export type PSRReasonCategory = 'movement' | 'damage' | 'heat' | 'recovery';
 
-  // Component damage triggers
-  HipActuatorDestroyed = 'hip_actuator_destroyed',
-  GyroHit = 'gyro_hit',
-  EngineHit = 'engine_hit',
-  UpperLegActuatorHit = 'upper_leg_actuator_hit',
-  LowerLegActuatorHit = 'lower_leg_actuator_hit',
-  FootActuatorHit = 'foot_actuator_hit',
+/**
+ * Map a `PSRTrigger` value to its `PSRReasonCategory` bucket.
+ *
+ * The mapping is deterministic and total — every code maps to exactly
+ * one of `'movement' | 'damage' | 'heat' | 'recovery'`. Implemented as
+ * an exhaustive switch so adding a new `PSRTrigger` member fails the
+ * typechecker until it's categorised.
+ *
+ * @spec openspec/specs/piloting-skill-rolls/spec.md
+ *   Requirement: PSR Reason Category Bucket Helper
+ */
+export function getPSRReasonCategory(code: PSRTrigger): PSRReasonCategory {
+  switch (code) {
+    // Damage bucket
+    case PSRTrigger.PhaseDamage20Plus:
+    case PSRTrigger.LegDamage:
+    case PSRTrigger.HipActuatorDestroyed:
+    case PSRTrigger.GyroHit:
+    case PSRTrigger.EngineHit:
+    case PSRTrigger.UpperLegActuatorHit:
+    case PSRTrigger.LowerLegActuatorHit:
+    case PSRTrigger.FootActuatorHit:
+      return 'damage';
 
-  // Physical attack triggers (target)
-  Kicked = 'kicked',
-  Charged = 'charged',
-  DFATarget = 'dfa_target',
-  Pushed = 'pushed',
+    // Movement bucket — physical attack target/miss + terrain + system
+    case PSRTrigger.Kicked:
+    case PSRTrigger.Charged:
+    case PSRTrigger.DFATarget:
+    case PSRTrigger.Pushed:
+    case PSRTrigger.KickMiss:
+    case PSRTrigger.ChargeMiss:
+    case PSRTrigger.DFAMiss:
+    case PSRTrigger.EnteringRubble:
+    case PSRTrigger.RunningRoughTerrain:
+    case PSRTrigger.MovingOnIce:
+    case PSRTrigger.EnteringWater:
+    case PSRTrigger.ExitingWater:
+    case PSRTrigger.Skidding:
+    case PSRTrigger.RunningDamagedHip:
+    case PSRTrigger.RunningDamagedGyro:
+    case PSRTrigger.BuildingCollapse:
+    case PSRTrigger.MASCFailure:
+    case PSRTrigger.SuperchargerFailure:
+      return 'movement';
 
-  // Physical attack miss triggers (attacker)
-  KickMiss = 'kick_miss',
-  ChargeMiss = 'charge_miss',
-  DFAMiss = 'dfa_miss',
+    // Heat bucket
+    case PSRTrigger.Shutdown:
+      return 'heat';
 
-  // Shutdown/startup triggers
-  Shutdown = 'heat_shutdown',
-  StandingUp = 'standing_up',
+    // Recovery bucket
+    case PSRTrigger.StandingUp:
+      return 'recovery';
 
-  // Terrain triggers
-  EnteringRubble = 'entering_rubble',
-  RunningRoughTerrain = 'running_rough_terrain',
-  MovingOnIce = 'moving_on_ice',
-  EnteringWater = 'entering_water',
-  ExitingWater = 'exiting_water',
-  Skidding = 'skidding',
-
-  // Movement with damage triggers
-  RunningDamagedHip = 'running_damaged_hip',
-  RunningDamagedGyro = 'running_damaged_gyro',
-
-  // Collapse/failure triggers
-  BuildingCollapse = 'building_collapse',
-  MASCFailure = 'masc_failure',
-  SuperchargerFailure = 'supercharger_failure',
+    default: {
+      // Exhaustiveness check — a new PSRTrigger member that lacks a
+      // category mapping fails the typechecker on this line.
+      const exhaustive: never = code;
+      throw new Error(
+        `getPSRReasonCategory: unhandled PSRTrigger value ${String(exhaustive)}`,
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Final PR (5 of 5) in the event-log line-format series. Adds a machine-readable `reasonCode: PSRTrigger` sibling field to PSR / fall payloads and a 4-bucket `PSRReasonCategory` helper, while keeping the existing `reason: string` field unchanged for display continuity.

OpenSpec change folder: `openspec/changes/structure-psr-reason-as-discriminated-code/` — strict-clean.

## What changed

- Lifted `PSRTrigger` enum to `src/types/gameplay/PSRTriggerCodes.ts` to break the cycle between `GameSessionInterfaces` and `pilotingSkillRolls/types`. Back-compat re-export from `pilotingSkillRolls/types.ts` keeps every existing `import { PSRTrigger } from './types'` working.
- Added `readonly reasonCode?: PSRTrigger` to `IPSRTriggeredPayload`, `IPSRResolvedPayload`, `IUnitFellPayload`, and `IPendingPSR`. OPTIONAL on every shape for back-compat with legacy NDJSON streams.
- New `PSRReasonCategory = 'movement' | 'damage' | 'heat' | 'recovery'` union and `getPSRReasonCategory(code)` helper — exhaustive switch with `never` exhaustiveness check.
- Migrated all 28 PSR factories across `combatFactories`, `damageFactories`, `environmentFactories`, `systemFactories`, and `phaseChecks` to populate `reasonCode` alongside `reason`. The PR-C `stepIndex` parameter is preserved unchanged.
- Threaded `reasonCode` through every direct event-builder callsite in the runner: `gameSessionAttackResolution`, `gameSessionHeat`, `gameSessionPhysical`, `criticalHitResolution/{actuator,engine}Effects`, and `simulation/runner/phases/{weaponAttack,postCombat,physicalAttack}`.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` clean
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run format:check` clean
- [x] New: `getPSRReasonCategory.test.ts` — 38 tests (spot checks, exhaustive partition, per-bucket cardinality, per-code spec-table assertions)
- [x] New: `factoryReasonCode.test.ts` — 26 tests covering all 5 factory families + step-index preservation invariant
- [x] Extended: `atlasMirrorEventChain.integration.test.ts` — every emitted PSR / fall event carries a defined `reasonCode`
- [x] 229/229 scoped tests pass (`pilotingSkillRolls`, `atlasMirror`, `combat-fidelity`, new test files)
- [x] 1178/1178 full simulation suite passes
- [x] `npx openspec validate structure-psr-reason-as-discriminated-code --strict` clean

## Series predecessors (all archived)

This PR completes the 5-PR event-log line-format series:

- PR A: `format-event-log.py` Python formatter
- PR B: envelope-side denormalization
- PR C: movement chain / step-index PSR trigger source
- PR D: `EventLogQuery` + MetricsCollector hydration
- **PR E (this PR)**: `reasonCode` discriminated field + bucket helper

## Out of scope (deferred to follow-on changes)

- Tightening `reason: string` to a discriminated union (would force display-layer migration).
- Heat-25/32/39/47 PSR thresholds (`add-cumulative-crew-damage-thresholds`).
- `EventLogQuery.whereReasonCategory` filter (UI-side concern).
- `EventLogDisplay` component changes.