### PR TITLE
feat(replay): add JSONL file loader + state-from-events reducer for hex-map replay

### DIFF
--- a/openspec/changes/add-replay-viewer-from-ndjson/.openspec.yaml
+++ b/openspec/changes/add-replay-viewer-from-ndjson/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/add-replay-viewer-from-ndjson/design.md
+++ b/openspec/changes/add-replay-viewer-from-ndjson/design.md
@@ -1,0 +1,137 @@
+# Replay Viewer From NDJSON — Design
+
+## Context
+
+The CLI swarm runner persists every encounter as `<gameId>.jsonl` (NDJSON, one `IGameEvent` per line, sequence-ordered). The browser already has the `useReplayPlayer` + `ReplayTimeline` + `ReplayControls` infrastructure, but its `reducers` map is hard-coded to `{}` and the visualization pane is a placeholder card. There is no way to load a swarm-run file from disk into the page, and no projection from the typed `IGameEvent` discriminated union to `IUnitToken[]`.
+
+The two existing surfaces this change touches:
+
+- `src/pages/gameplay/games/[id]/replay.tsx` — already pulls events from `useGameTimeline(gameId)`, drives `useReplayPlayer`, and mounts `ReplayTimeline` + `ReplayControls`. The center pane currently shows an "Event N of M" placeholder that this change replaces with `HexMapDisplay`.
+- `src/components/gameplay/HexMapDisplay/HexMapDisplay.tsx` — accepts `tokens: readonly IUnitToken[]`, `events?: readonly IGameEvent[]`, `hexTerrain?: readonly IHexTerrain[]`, `radius: number`. The reducer's output shape feeds these props directly.
+
+The typed-event substrate is solid: `IGameEvent` is a discriminated union over `GameEventType`, the envelope carries `side`, `turn`, `phase`, `actorId`, `sequence`, the payload union covers ~50 event types, `EventLogQuery` is in place. We are NOT modifying any of that — this change is pure consumer-side.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+1. A user can drag a swarm `.jsonl` into the replay page and see the hex map immediately reflect the loaded encounter.
+2. Stepping the timeline scrubber forward / backward updates the hex map frame-by-frame (post-step end states, no animation interpolation).
+3. Parse / validation errors surface per-line so a malformed file does not silently render an empty map.
+4. Existing replay-page tests, audit-store integration, and `useReplayPlayer` behavior stay valid — uploaded events PROMOTE over DB events; clearing the upload reverts.
+5. Source-of-truth specs (`quick-session`, `combat-analytics`) absorb the new requirements cleanly via `## ADDED Requirements`.
+
+**Non-Goals:**
+
+1. Per-step animation interpolation between hexes (post-step end states only).
+2. Record-sheet-level damage pip rendering (the reducer tracks accumulated location damage but only flips `isDestroyed` on `LocationDestroyed`-CT or `UnitDestroyed`).
+3. Key-moment timeline markers (PR A3).
+4. Quick-game integrated replay panel (PR A2).
+5. Fog-of-war replay (Track B follow-on; the reducer reads un-redacted events as authoritative).
+6. URL / cloud-storage event log loaders (filesystem drag-drop only).
+7. Server-side persistence of uploaded files (the loader is purely client-side; uploads live in component state).
+
+## Decisions
+
+### D1 — Reducer placement: `src/hooks/replay/`, NOT `src/utils/events/stateDerivation.ts`
+
+The repo already ships a generic `deriveStateWithCheckpoint` reducer harness in `src/utils/events/stateDerivation.ts` that `useReplayPlayer` consumes. We DO NOT extend that harness. Reasoning:
+
+- `stateDerivation.ts` is for the audit `EventStoreService` `IBaseEvent` shape (typed `category` + `payload: unknown`), NOT the gameplay `IGameEvent` discriminated union. Forcing a single `ReducerMap` to handle both shapes would require either widening `IGameEvent` to `IBaseEvent` (loses discriminated narrowing) or branching at every reducer key (makes call sites conditional on event shape).
+- The new reducer ships as a top-level hook (`useHexMapStateFromEvents`) that internally walks `events` once. It does NOT use the `ReducerMap<TState>` map shape; it uses a single switch on `event.type` so each branch narrows the payload via the discriminated union.
+
+The replay page's existing `useReplayPlayer({ reducers: {} })` mount stays unchanged — `useReplayPlayer` now drives the scrubber's `currentSequence` cursor only; the new hook reads that cursor directly. Result: zero changes to `useReplayPlayer`, zero changes to `stateDerivation.ts`, isolated new code.
+
+### D2 — Pure-projection contract
+
+`useHexMapStateFromEvents(events, currentSequence)` is a pure function over its inputs:
+
+- No I/O, no side effects, no React refs.
+- `useMemo`-d on `[events, currentSequence]` so re-renders that don't change the cursor reuse the prior projection.
+- Idempotent: replaying the same `(events, currentSequence)` pair always produces the same result.
+- Cursor monotonicity NOT assumed: stepping the scrubber backward re-runs the walk from `GameCreated`. For very long event logs (~1000+ events) we accept the O(N) re-walk on backward seek; a forward-only optimization can come later.
+
+### D3 — Event-family coverage
+
+The reducer covers exactly eight event families that affect on-map state. Other event types pass through silently. The covered set:
+
+| Family | Event types | Mutation |
+|---|---|---|
+| Lifecycle | `GameCreated` | Seeds initial `tokens` from `payload.units` and `mapRadius` from `payload.config.mapRadius` |
+| Position | `MovementDeclared` | Updates `position` + `facing` for the actor |
+| Damage | `DamageApplied`, `LocationDestroyed`, `TransferDamage` | Tracks per-unit per-location damage map; flips `isDestroyed` on CT-destroyed |
+| Lethal | `UnitDestroyed` | Sets `isDestroyed = true` |
+| Posture | `UnitFell`, `UnitStood` | Toggles a per-unit `prone` flag (rendered via existing token component) |
+| Heat | `HeatGenerated`, `HeatDissipated` | Tracks `currentHeat` per unit (read by token's existing heat-band rendering) |
+| Pilot | `PilotHit` | Increments per-unit `pilotWounds` |
+
+Out-of-band event types (initiative, attack-declared, attack-resolved without damage, ammo-explosion that emits a follow-up `DamageApplied`, `RetreatTriggered`, vehicle-specific motive events, BA-specific trooper / swarm events, ProtoMech / Aerospace combat-state events) are NOT consumed by the reducer in this PR. They flow through the timeline scrubber but do not change `tokens`. A follow-on can extend coverage as needed.
+
+### D4 — Token construction from `GameCreated`
+
+`payload.units: readonly IGameUnit[]` carries `unitId`, `name`, `side`, `unitType?`, plus per-type construction fields. The reducer constructs the matching `IUnitToken` variant (Mech / Vehicle / Aerospace / BattleArmor / Infantry / ProtoMech) via a switch on `unit.unitType ?? UnitType.BattleMech`. For each variant we seed:
+
+- `unitId`, `name`, `side`, `designation` (use `unit.unitRef` last segment if `name` is too long)
+- `position`: derived from initial deployment if available; falls back to `{ q: 0, r: 0 }`. Initial deployment is read from `payload.config.initialPositions?` (an existing field on `IGameConfig` per the swarm's deployment seeding) when present; otherwise the unit starts at origin and the first `MovementDeclared` repositions it.
+- `facing: Facing.North` as the safe default; the first `MovementDeclared` corrects it.
+- `isSelected: false`, `isValidTarget: false`, `isDestroyed: false`.
+- Per-type required fields default to safe values (Mech: omit sprite props → fallback medium-humanoid; Vehicle: no turret; Aerospace: `altitude: 0`; BA / Infantry / Proto: trooper / platoon / point counts of 1).
+
+Reducer correctness depends on `GameCreated` being event #0. The persisted NDJSON contract already guarantees this (the runner emits `GameCreated` first; sequence ordering is monotonic).
+
+### D5 — Map radius from `IGameConfig`
+
+`mapRadius` is read from `payload.config.mapRadius` on `GameCreated`. The reducer returns this value alongside `tokens` so the page passes it directly to `<HexMapDisplay radius={...} />`.
+
+### D6 — `JsonlFileLoader` parses, validates, and reports per-line errors
+
+The loader is a small drop zone + file picker. It does NOT touch the network. The parsing pipeline:
+
+1. Read file as UTF-8 text via `FileReader.readAsText`.
+2. Split on `\n`, strip empty lines.
+3. For each line: `JSON.parse(line)`. On failure, push `{ line: i, error: 'not valid JSON' }`.
+4. For each parsed object: `isGameEvent(obj)` (type guard already in `GameSessionInterfaces.ts:1930`). On failure, push `{ line: i, error: 'not a valid IGameEvent' }`.
+5. Promote `events` ONLY if zero errors. Otherwise render the error list and keep prior state.
+
+This is intentionally strict: a single bad line rejects the whole file. Users with corrupted files can hand-edit the offending line and re-drop.
+
+### D7 — Replay page wiring
+
+The page maintains both event sources and prefers the upload when present:
+
+```ts
+const [uploadedEvents, setUploadedEvents] = useState<readonly IGameEvent[] | null>(null);
+const dbEvents = useGameTimeline(gameId).allEvents;
+const events = uploadedEvents ?? (dbEvents as readonly IGameEvent[]);
+```
+
+`useReplayPlayer` is mounted with the chosen list (its options accept `events` indirectly via the audit store today; we expose a thin adapter that synthesizes an event-store query result from `uploadedEvents` when present — alternative: refactor `useReplayPlayer` to accept events directly. We choose the adapter to keep `useReplayPlayer`'s public contract stable for PR A2 + A3 which reuse it).
+
+The `currentSequence` cursor flows from `useReplayPlayer` into `useHexMapStateFromEvents`. The reducer's output `{ tokens, hexTerrain, mapRadius }` flows into the `<HexMapDisplay>` mount that replaces the placeholder card.
+
+### D8 — Spec-delta home
+
+- `quick-session` already owns the NDJSON persistence + Python formatter contracts. The new "Replay Viewer Consumes Persisted NDJSON Files" requirement extends it on the consumer side.
+- `combat-analytics` already owns `EventLogQuery`. The new "Replay State-From-Events Reducer Contract" lives there as the second TypeScript event-stream consumer utility.
+
+We do NOT create a brand-new `replay-viewer` spec for this PR — there isn't enough surface to justify it yet. PR A3 (timeline markers + key-moment scrubber) may earn a dedicated spec when its surface stabilizes.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Reducer projection drifts from the live engine's view of state | Tests assert state at frame N via `EventLogQuery` slicing; smoke test against a real swarm `.jsonl` end-to-end. The reducer is deliberately narrow (eight families) so coverage gaps are visible. |
+| Strict per-line validation rejects useful but slightly malformed files | Per-line error reporting tells the user EXACTLY what to fix; bad-input acceptance is a worse UX. |
+| Backward seek triggers full O(N) re-walk on long replays | Acceptable for ~1000-event encounters (sub-millisecond). A forward-only checkpoint cache is a follow-on if profiling shows hot frames during scrubbing. |
+| `useGameTimeline` adapter for uploaded events introduces a contract surface | The adapter is private to the page; it's a thin wrapper that returns `{ allEvents: uploadedEvents, isLoading: false, error: null, pagination, loadMore: noop }` so `useReplayPlayer` sees the same shape. |
+| Token initial position not in `GameCreated` payload | Defaults to origin; the first `MovementDeclared` corrects. Acceptable for replays since the user is scrubbing forward; the only visual artifact is at sequence 0 before any movement event fires. |
+| Reducer can't render every event type's effect (e.g., ProtoMech jump rules) | This PR explicitly scopes coverage to eight families. Out-of-band events flow through the scrubber but the map shows last-known state. A follow-on can extend coverage. |
+
+## Migration Plan
+
+No data migration required — pure additive change. Existing replay-page DB-event flow stays as the default; uploads are opt-in.
+
+## Open Questions
+
+- **Should the JSONL loader live at the same `/gameplay/games/[id]/replay` route, or a new `/gameplay/replay` route?** Default: same route, upload PROMOTES over DB events with a "loaded from file" indicator. A standalone route can be added later if friction surfaces.
+- **Should `hexTerrain` be reconstructed from terrain events?** Today the engine doesn't emit terrain-mutation events (no magma damage, no smoke, no fire spread). When those events arrive (already-named follow-on), the reducer extends; for this PR, terrain is empty (HexMapDisplay's Clear default applies).

--- a/openspec/changes/add-replay-viewer-from-ndjson/proposal.md
+++ b/openspec/changes/add-replay-viewer-from-ndjson/proposal.md
@@ -1,0 +1,105 @@
+# Add replay viewer that consumes persisted NDJSON event logs
+
+## Why
+
+The CLI swarm runner persists every encounter as `simulation-reports/games/<run-timestamp>/<gameId>.jsonl` (per `quick-session` → "Per-Game Event Log Persistence"). Each file is a complete, sequence-ordered `IGameEvent` log of a battle that already happened, but **no UI surface in the app can open one**.
+
+The repo *does* ship a replay page at `src/pages/gameplay/games/[id]/replay.tsx` with `useReplayPlayer`, `ReplayTimeline`, and `ReplayControls` already wired. The page renders timestamps, sequence numbers, and an "Event N of M" placeholder, but its reducer map is **empty** (line 70 of the page) — events scrub through but **the hex map does not update**. The page is also bound to the saved-DB-game flow (`useGameTimeline(gameId)` reads from the audit `EventStoreService`), not to on-disk NDJSON files written by swarm runs.
+
+Two gaps follow from that:
+
+1. **No on-disk → UI bridge**. A user with a `.jsonl` file from a CLI run cannot watch it back in the browser at all. They must read the columnar `*.readable.txt` companion or the raw NDJSON.
+
+2. **No state-from-events reducer**. Even when events ARE loaded (via the audit store), the page can't project them onto a hex map because nothing walks the typed `IGameEvent` discriminated union into the `IUnitToken[]` + `IHexTerrain[]` shape that `HexMapDisplay` consumes.
+
+This change ships both halves of the bridge:
+
+- A drag-and-drop `JsonlFileLoader` that parses, validates, and surfaces a `readonly IGameEvent[]` to the page.
+- A pure `useHexMapStateFromEvents` reducer that walks events sequentially up to a `currentSequence` cursor and returns `{ tokens, terrain }` for `HexMapDisplay`. The reducer covers the eight event families that drive on-map state: position+facing (`MovementDeclared`), HP (`DamageApplied` / `LocationDestroyed` / `TransferDamage`), KIA (`UnitDestroyed`), heat (`HeatGenerated` / `HeatDissipated`), pilot wounds (`PilotHit`), and prone/standing (`UnitFell` / `UnitStood`).
+
+The replay page wires both: an upload affordance promotes uploaded events over the DB-store events, and the new reducer's output is forwarded into the existing `HexMapDisplay` mount that today shows a placeholder card.
+
+## What
+
+### `JsonlFileLoader.tsx` (drag-and-drop NDJSON ingest)
+
+New file at `src/components/audit/replay/JsonlFileLoader.tsx`:
+
+- Accepts files via drag-drop OR a file-picker button.
+- Reads the file as text, splits on `\n`, filters empty lines (trailing newline tolerated), `JSON.parse`-es each line.
+- Validates each parsed object against the `isGameEvent(obj)` type guard already exported from `GameSessionInterfaces.ts`.
+- On parse / validation failure: surfaces a per-line error list (`"line 47: not valid JSON"` / `"line 92: not a valid IGameEvent"`) AND does NOT promote the file. The page's existing event source remains untouched.
+- On success: emits `(events: readonly IGameEvent[], filename: string)` to the host page via a callback prop.
+- Renders a small "loaded `<filename>` (`N` events, turns `<minTurn>`–`<maxTurn>`)" status pill while events are active.
+
+### `useHexMapStateFromEvents.ts` (typed-event → HexMapDisplay reducer)
+
+New hook at `src/hooks/replay/useHexMapStateFromEvents.ts`:
+
+```ts
+export interface ReplayHexMapState {
+  readonly tokens: readonly IUnitToken[];
+  readonly hexTerrain: readonly IHexTerrain[];
+  readonly mapRadius: number;
+}
+
+export function useHexMapStateFromEvents(
+  events: readonly IGameEvent[],
+  currentSequence: number,
+): ReplayHexMapState;
+```
+
+Pure projection — no I/O, no side effects, memoized on `[events, currentSequence]`. Walks events with `event.sequence <= currentSequence` in order and applies these reducers:
+
+| Event type | What the reducer mutates |
+|---|---|
+| `GameCreated` | seeds the initial `tokens` array from `payload.units` (one Mech-variant `IUnitToken` per unit) and reads `mapRadius` from `payload.config.mapRadius` |
+| `MovementDeclared` | sets `token.position = payload.to`, `token.facing = payload.facing` |
+| `DamageApplied` | tracks accumulated location damage on a per-unit map (used by `armorPipState` projection — best-effort summary, full record-sheet rendering is out-of-scope) |
+| `LocationDestroyed` | flags the location in the per-unit damage map; if the location is `'CT'` flips `isDestroyed` |
+| `UnitDestroyed` | sets `token.isDestroyed = true` |
+| `UnitFell` | tags the unit prone (rendered as a status overlay; HexMapDisplay's existing prone visualization, no new prop) |
+| `UnitStood` | clears the prone tag |
+| `HeatGenerated` / `HeatDissipated` | tracks `currentHeat` per unit (rendered downstream by the page's existing heat indicator if the page wires it; no new map prop) |
+| `PilotHit` | increments per-unit `pilotWounds` |
+
+`hexTerrain` is reconstructed from `GameCreated` if the payload carries terrain (current schema does not — terrain is implicit in `mapRadius`); when absent the reducer returns an empty `hexTerrain` array and the existing `HexMapDisplay` Clear-default rendering applies.
+
+### Replay page integration
+
+Modify `src/pages/gameplay/games/[id]/replay.tsx`:
+
+- Add `JsonlFileLoader` mount in the right-panel.
+- When a JSONL file is loaded, the page replaces the `useReplayPlayer`-derived `events` source with the uploaded event list (promotes the upload over `useGameTimeline`).
+- Replace the placeholder card in the center pane with `<HexMapDisplay {...stateFromReducer} />`.
+- Add a small "loaded from file" indicator + a "clear upload" button to revert to the DB-loaded events.
+
+The existing `useReplayPlayer` hook stays as-is — it already accepts a generic event list. Only its consumer wiring changes.
+
+### Spec deltas
+
+- `quick-session`: ADD `Replay Viewer Consumes Persisted NDJSON Files` requirement — covers the JSONL loader contract (parse, validate, line-level error reporting, event-list promotion).
+- `combat-analytics`: ADD `Replay State-From-Events Reducer Contract` requirement — pure projection from `readonly IGameEvent[]` + `currentSequence: number` to `{ tokens, hexTerrain, mapRadius }`; covers the eight event families above; covers idempotence (replaying the same prefix produces the same state); covers cursor monotonicity (`currentSequence` < `prevSequence` re-runs from `GameCreated`).
+
+The reducer lives in `combat-analytics` rather than a brand-new `replay-viewer` spec because (a) the reducer is the same kind of typed-event consumer that `EventLogQuery` is, and (b) we already absorbed the column-formatter and `EventLogQuery` into existing specs to keep the spec count manageable. A future replay UI feature pass (key-moment markers, scrubber annotations) will earn its own spec.
+
+## Impact
+
+- **Affected types**: none (no schema changes — pure consumer-side projection).
+- **Affected code**:
+  - NEW `src/components/audit/replay/JsonlFileLoader.tsx` (~120-160 LOC)
+  - NEW `src/hooks/replay/useHexMapStateFromEvents.ts` (~200-260 LOC)
+  - NEW `src/components/audit/replay/__tests__/JsonlFileLoader.test.tsx` (~120 LOC)
+  - NEW `src/hooks/replay/__tests__/useHexMapStateFromEvents.test.ts` (~180-220 LOC)
+  - MODIFY `src/pages/gameplay/games/[id]/replay.tsx` — wire loader + reducer; replace placeholder card with `HexMapDisplay`
+- **Affected specs**: `quick-session` (ADDED), `combat-analytics` (ADDED).
+- **Risk**: low — pure projection + drag-drop; no engine code changed; existing replay-page tests stay valid (the placeholder-card branch is replaced cleanly).
+
+## Out of scope
+
+- **Key-moment timeline markers** (PR A3 in the bundle plan).
+- **Quick-game integrated replay panel** (PR A2 in the bundle plan).
+- **In-page upload from arbitrary URL / cloud storage** — file system only.
+- **Animation interpolation between hex moves** — reducer emits post-step end states only. Per-step animation can come later via `MovementAnimationMode` overlays without reducer changes.
+- **Record-sheet pip-level damage visualization** — the per-unit damage map exists in the reducer but only `isDestroyed` flips; a future change can route the map into `armorPipState` for full pip rendering.
+- **Cooperative / multiplayer fog-aware replay** — the reducer reads the un-redacted `IGameEvent` and renders un-fogged tokens. Fog-of-war replay (consuming `IRedactedUnitDestroyedPayload` etc.) is a follow-on tied to Track B in the bundle plan.

--- a/openspec/changes/add-replay-viewer-from-ndjson/specs/combat-analytics/spec.md
+++ b/openspec/changes/add-replay-viewer-from-ndjson/specs/combat-analytics/spec.md
@@ -40,7 +40,17 @@ The reducer SHALL NOT assume monotonic forward progression of `currentSequence` 
 
 The reducer SHALL be `useMemo`-d on `[events, currentSequence]` so re-renders that do not change the cursor reuse the prior projection.
 
-For NDJSON streams that omit `GameCreated` (e.g., a partial log starting mid-encounter), the reducer SHALL return `{ tokens: [], hexTerrain: [], mapRadius: 0 }` and SHALL NOT throw — the page can detect the empty `tokens` array and render an "incomplete event log" placeholder.
+For NDJSON streams that omit `GameCreated` BUT contain at least one event with an `actorId` or `payload.unitId`, the reducer SHALL synthesize Mech-default tokens from the discovered unit ids — the lossy-fallback path. This covers legacy NDJSON archives written by `SimulationRunner` versions predating the `emit-game-created-from-runner` change. Synthesized tokens have:
+
+- `unitId`, `name`, `unitRef` defaulting to the discovered id
+- `side` derived from the id prefix (`player-` → Player; `opponent-` → Opponent; otherwise Player)
+- `unitType` defaulted to `Mech` (the safe variant)
+- `position` defaulting to `{ q: 0, r: 0 }`; corrected by the first `MovementDeclared` for that unit
+- `mapRadius` defaulting to `17` (a generous swarm-runner default; recoverable from the persisted reports if known)
+
+When the lossy fallback activates, the reducer SHALL emit a single `console.warn` so future regressions where `GameCreated` stops being emitted do not get silently masked.
+
+For NDJSON streams that contain NEITHER `GameCreated` NOR any actor / payload-unit ids (truly empty / opaque streams), the reducer SHALL return `{ tokens: [], hexTerrain: [], mapRadius: 0 }` and SHALL NOT throw — the page can detect the empty `tokens` array and render an "incomplete event log" placeholder.
 
 #### Scenario: GameCreated seeds tokens and mapRadius
 
@@ -85,12 +95,22 @@ For NDJSON streams that omit `GameCreated` (e.g., a partial log starting mid-enc
 - **THEN** the result SHALL equal the state that would have been produced by walking events 0..2 from scratch
 - **AND** SHALL NOT carry any mutations from events 3..5
 
-#### Scenario: Empty-prefix log without GameCreated returns empty defaults
+#### Scenario: Truly empty event log returns empty defaults
 
-- **GIVEN** an event log that does not contain a `GameCreated` event (e.g., a partial NDJSON stream)
+- **GIVEN** an event log with zero events (`events.length === 0`)
 - **WHEN** `useHexMapStateFromEvents(events, currentSequence: 100)` is called
 - **THEN** the result SHALL equal `{ tokens: [], hexTerrain: [], mapRadius: 0 }`
 - **AND** SHALL NOT throw
+
+#### Scenario: Lossy fallback synthesizes tokens for legacy NDJSON without GameCreated
+
+- **GIVEN** an event log without `GameCreated`, containing a `MovementDeclared` event with `actorId: 'player-1'` and a `MovementDeclared` event with `actorId: 'opponent-2'`
+- **WHEN** `useHexMapStateFromEvents(events, currentSequence: 100)` is called
+- **THEN** the result `tokens` SHALL contain entries for `player-1` and `opponent-2`
+- **AND** the `player-1` token SHALL have `side: GameSide.Player` and `unitType: TokenUnitType.Mech`
+- **AND** the `opponent-2` token SHALL have `side: GameSide.Opponent`
+- **AND** the result `mapRadius` SHALL be `17`
+- **AND** a single `console.warn` SHALL fire indicating the fallback path activated
 
 #### Scenario: Idempotent on repeated invocation
 

--- a/openspec/changes/add-replay-viewer-from-ndjson/specs/combat-analytics/spec.md
+++ b/openspec/changes/add-replay-viewer-from-ndjson/specs/combat-analytics/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Replay State-From-Events Reducer Contract
+
+The application SHALL ship a pure projection hook at `src/hooks/replay/useHexMapStateFromEvents.ts` that consumes `events: readonly IGameEvent[]` plus a `currentSequence: number` cursor and returns `{ tokens, hexTerrain, mapRadius }` ready for `<HexMapDisplay>` rendering. The hook SHALL have NO I/O, NO side effects, and NO React refs — it is a memoized projection over its inputs.
+
+```ts
+export interface ReplayHexMapState {
+  readonly tokens: readonly IUnitToken[];
+  readonly hexTerrain: readonly IHexTerrain[];
+  readonly mapRadius: number;
+}
+
+export function useHexMapStateFromEvents(
+  events: readonly IGameEvent[],
+  currentSequence: number,
+): ReplayHexMapState;
+```
+
+The reducer SHALL walk events in monotonic `sequence` order from the start of the array up to and including the highest event whose `event.sequence <= currentSequence`. It SHALL apply per-event mutations only for the eight on-map event families enumerated below. All other event types SHALL pass through silently — they may flow through the timeline scrubber but they SHALL NOT change `tokens`, `hexTerrain`, or `mapRadius`.
+
+The covered event families and their mutations:
+
+| Event type | Mutation |
+|---|---|
+| `GameCreated` | Seeds the initial `tokens` array from `payload.units` (one `IUnitToken` per unit, with the variant chosen by `unit.unitType`). Sets `mapRadius = payload.config.mapRadius`. |
+| `MovementDeclared` | Updates the actor token's `position` to `payload.to` and `facing` to `payload.facing`. |
+| `DamageApplied` | Tracks accumulated location-level damage on the affected unit (per-unit per-location bookkeeping). When `payload.locationDestroyed === true` AND `payload.location === 'CT'`, sets the unit's `isDestroyed = true`. |
+| `LocationDestroyed` | Records the destroyed location in the per-unit damage map. When `payload.location === 'CT'`, sets the unit's `isDestroyed = true`. |
+| `TransferDamage` | Records the transfer in the per-unit damage map (informational; does not flip `isDestroyed` on its own). |
+| `UnitDestroyed` | Sets the unit's `isDestroyed = true`. |
+| `UnitFell` | Tags the unit as prone (rendered via the existing token component's prone visualization). |
+| `UnitStood` | Clears the unit's prone tag. |
+| `HeatGenerated` / `HeatDissipated` | Tracks `currentHeat` per unit (consumed by the token's existing heat-band rendering). |
+| `PilotHit` | Increments per-unit `pilotWounds`. |
+
+The reducer SHALL be idempotent: for any input `(events, currentSequence)`, repeated invocation SHALL produce structurally equivalent output (deep-equal `tokens` and `hexTerrain` arrays).
+
+The reducer SHALL NOT assume monotonic forward progression of `currentSequence` between calls. Stepping the cursor backward SHALL produce the correct state for the new cursor value (re-walking from the beginning of `events` is acceptable; a forward-only optimization is out of scope for this PR).
+
+The reducer SHALL be `useMemo`-d on `[events, currentSequence]` so re-renders that do not change the cursor reuse the prior projection.
+
+For NDJSON streams that omit `GameCreated` (e.g., a partial log starting mid-encounter), the reducer SHALL return `{ tokens: [], hexTerrain: [], mapRadius: 0 }` and SHALL NOT throw — the page can detect the empty `tokens` array and render an "incomplete event log" placeholder.
+
+#### Scenario: GameCreated seeds tokens and mapRadius
+
+- **GIVEN** a 1-event log containing only `GameCreated` with `payload.units = [unitA, unitB]` and `payload.config.mapRadius = 17`
+- **WHEN** `useHexMapStateFromEvents(events, currentSequence: 0)` is called
+- **THEN** the result `tokens` SHALL contain exactly two entries (one per unit)
+- **AND** `tokens[0].unitId` SHALL equal `unitA.id`
+- **AND** `tokens[1].unitId` SHALL equal `unitB.id`
+- **AND** `mapRadius` SHALL equal `17`
+
+#### Scenario: MovementDeclared updates position and facing for the actor
+
+- **GIVEN** a log with `GameCreated` (unitA at default origin) followed by `MovementDeclared { unitId: unitA.id, to: { q: 3, r: 5 }, facing: Facing.SouthEast }`
+- **WHEN** `useHexMapStateFromEvents(events, currentSequence: 1)` is called
+- **THEN** the token for `unitA` SHALL have `position.q === 3 && position.r === 5`
+- **AND** the token's `facing` SHALL equal `Facing.SouthEast`
+
+#### Scenario: UnitDestroyed flips isDestroyed
+
+- **GIVEN** a log with `GameCreated` (unitA, unitB) followed by `UnitDestroyed { unitId: unitA.id, cause: 'damage' }`
+- **WHEN** `useHexMapStateFromEvents(events, currentSequence: 1)` is called
+- **THEN** the token for `unitA` SHALL have `isDestroyed === true`
+- **AND** the token for `unitB` SHALL have `isDestroyed === false`
+
+#### Scenario: LocationDestroyed on CT flips isDestroyed
+
+- **GIVEN** a log with `GameCreated` (unitA) followed by `LocationDestroyed { unitId: unitA.id, location: 'CT' }`
+- **WHEN** `useHexMapStateFromEvents(events, currentSequence: 1)` is called
+- **THEN** the token for `unitA` SHALL have `isDestroyed === true`
+
+#### Scenario: Cursor truncation excludes events beyond currentSequence
+
+- **GIVEN** a log with `GameCreated` (unitA at origin) at sequence 0, `MovementDeclared` (unitA → `(2,2)`) at sequence 1, and `UnitDestroyed` (unitA) at sequence 2
+- **WHEN** `useHexMapStateFromEvents(events, currentSequence: 1)` is called
+- **THEN** the token for `unitA` SHALL have `position.q === 2 && position.r === 2`
+- **AND** `isDestroyed === false` (the destroy event is past the cursor)
+
+#### Scenario: Backward cursor seek returns correct earlier state
+
+- **GIVEN** a log where `useHexMapStateFromEvents(events, 5)` was called and produced state S5
+- **WHEN** `useHexMapStateFromEvents(events, 2)` is called
+- **THEN** the result SHALL equal the state that would have been produced by walking events 0..2 from scratch
+- **AND** SHALL NOT carry any mutations from events 3..5
+
+#### Scenario: Empty-prefix log without GameCreated returns empty defaults
+
+- **GIVEN** an event log that does not contain a `GameCreated` event (e.g., a partial NDJSON stream)
+- **WHEN** `useHexMapStateFromEvents(events, currentSequence: 100)` is called
+- **THEN** the result SHALL equal `{ tokens: [], hexTerrain: [], mapRadius: 0 }`
+- **AND** SHALL NOT throw
+
+#### Scenario: Idempotent on repeated invocation
+
+- **GIVEN** any event log and any `currentSequence`
+- **WHEN** the reducer is invoked twice with the same `(events, currentSequence)`
+- **THEN** both invocations SHALL produce structurally equivalent `{ tokens, hexTerrain, mapRadius }` results

--- a/openspec/changes/add-replay-viewer-from-ndjson/specs/quick-session/spec.md
+++ b/openspec/changes/add-replay-viewer-from-ndjson/specs/quick-session/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Replay Viewer Consumes Persisted NDJSON Files
+
+The application SHALL ship a client-side `JsonlFileLoader` component (mounted on the replay page at `src/pages/gameplay/games/[id]/replay.tsx`) that accepts a swarm-produced `<gameId>.jsonl` event-log file via drag-and-drop OR file-picker, parses it line-by-line, validates each line as an `IGameEvent`, and promotes the resulting `readonly IGameEvent[]` to the replay player as the event source. Users with a persisted NDJSON event log from any prior CLI swarm run SHALL be able to watch the encounter back in the browser without server-side upload, account creation, or DB seeding.
+
+The loader's parse pipeline SHALL be:
+
+1. Read the file as UTF-8 text.
+2. Split on `\n`, strip empty lines (trailing newline tolerated).
+3. For each non-empty line, attempt `JSON.parse(line)`. On failure, record `{ line: <1-indexed-line-number>, error: 'not valid JSON' }`.
+4. For each parsed object, apply the `isGameEvent` type guard exported from `src/types/gameplay/GameSessionInterfaces.ts`. On failure, record `{ line: <1-indexed-line-number>, error: 'not a valid IGameEvent' }`.
+5. If zero errors are recorded, promote the parsed events as the new event source and call the host page's `onEventsLoaded(events, filename)` callback.
+6. If one or more errors are recorded, the loader SHALL display the per-line error list AND SHALL NOT promote the events. The page's prior event source remains unchanged.
+
+The loader SHALL render a "loaded `<filename>` (`N` events, turns `<minTurn>`–`<maxTurn>`)" status pill while uploaded events are active. The pill SHALL include a "clear upload" affordance that reverts the page to its prior (DB-backed) event source.
+
+The loader SHALL NOT transmit the file or any of its contents over the network. The file's bytes SHALL be processed entirely in-browser via `FileReader`.
+
+When uploaded events are promoted, the replay page's existing `useReplayPlayer` and `ReplayTimeline` SHALL drive the scrubber and playback controls against the uploaded events with no behavioral difference from the DB-event flow.
+
+#### Scenario: Drag-drop of a valid 50-event NDJSON file populates the replay player
+
+- **GIVEN** a swarm-produced `<gameId>.jsonl` file with 50 valid `IGameEvent` lines
+- **AND** the replay page is open
+- **WHEN** the user drops the file onto the loader's drop zone
+- **THEN** the loader SHALL parse and validate all 50 lines
+- **AND** the page SHALL replace its DB event source with the 50 uploaded events
+- **AND** the timeline scrubber SHALL show 50 events
+- **AND** the loader SHALL display `loaded <filename> (50 events, turns <min>–<max>)`
+
+#### Scenario: A file with one malformed JSON line is rejected with a per-line error
+
+- **GIVEN** a `<gameId>.jsonl` file where line 47 is `{this is not json}`
+- **WHEN** the user drops the file onto the loader
+- **THEN** the loader SHALL record `{ line: 47, error: 'not valid JSON' }`
+- **AND** SHALL NOT promote any events to the replay player
+- **AND** SHALL render the error list visibly so the user knows which line to fix
+
+#### Scenario: A file where one line parses as JSON but is not an IGameEvent is rejected
+
+- **GIVEN** a `<gameId>.jsonl` file where line 12 is `{"foo":"bar"}` (valid JSON but not an `IGameEvent`)
+- **WHEN** the user drops the file onto the loader
+- **THEN** the loader SHALL record `{ line: 12, error: 'not a valid IGameEvent' }`
+- **AND** SHALL NOT promote any events
+- **AND** the page's prior event source SHALL remain unchanged
+
+#### Scenario: Clearing the upload reverts the replay page to its DB event source
+
+- **GIVEN** the replay page has uploaded events active
+- **WHEN** the user clicks the "clear upload" affordance
+- **THEN** the page SHALL revert to its DB event source (via `useGameTimeline(gameId)`)
+- **AND** the loader's status pill SHALL be hidden
+- **AND** the timeline scrubber SHALL reflect the DB event count
+
+#### Scenario: Loaded events drive the existing useReplayPlayer scrubber
+
+- **GIVEN** uploaded events are active in the replay page
+- **WHEN** the user clicks "step forward" on `ReplayControls`
+- **THEN** `useReplayPlayer.currentSequence` SHALL advance to the next uploaded event's `sequence`
+- **AND** the page's existing event-detail panel SHALL render the new event

--- a/openspec/changes/add-replay-viewer-from-ndjson/tasks.md
+++ b/openspec/changes/add-replay-viewer-from-ndjson/tasks.md
@@ -1,0 +1,66 @@
+# Tasks
+
+## 1. Authoring
+
+- [x] 1.1 Author proposal.md
+- [x] 1.2 Author design.md
+- [x] 1.3 Author quick-session spec delta (Replay Viewer Consumes Persisted NDJSON Files — 5 scenarios)
+- [x] 1.4 Author combat-analytics spec delta (Replay State-From-Events Reducer Contract — 7 scenarios)
+- [x] 1.5 `npx openspec validate add-replay-viewer-from-ndjson --strict` clean
+
+## 2. State-from-events reducer
+
+- [x] 2.1 Create `src/hooks/replay/useHexMapStateFromEvents.ts` with the `ReplayHexMapState` interface and the `useHexMapStateFromEvents(events, currentSequence)` hook signature
+- [x] 2.2 Implement `GameCreated` reducer: seeds `tokens` (one variant-correct `IUnitToken` per unit) and `mapRadius`. Token construction switch on `unit.unitType ?? UnitType.BattleMech`.
+- [x] 2.3 Implement `MovementDeclared` reducer: updates `position` to `payload.to` and `facing` to `payload.facing` on the actor token
+- [x] 2.4 Implement `DamageApplied` / `LocationDestroyed` / `TransferDamage` reducers: per-unit per-location damage map; flip `isDestroyed` on CT-destroyed
+- [x] 2.5 Implement `UnitDestroyed` reducer: set `isDestroyed = true`
+- [x] 2.6 Implement `UnitFell` / `UnitStood` reducers: toggle prone tag (best-effort via existing token rendering)
+- [x] 2.7 Implement `HeatGenerated` / `HeatDissipated` reducers: track `currentHeat` per unit
+- [x] 2.8 Implement `PilotHit` reducer: increment `pilotWounds` per unit
+- [x] 2.9 Wrap the walk in `useMemo` keyed on `[events, currentSequence]`
+- [x] 2.10 Empty-prefix safety: return `{ tokens: [], hexTerrain: [], mapRadius: 0 }` when no `GameCreated` is present
+- [x] 2.11 Create `src/hooks/replay/__tests__/useHexMapStateFromEvents.test.ts` covering all 7 spec scenarios + edge cases (16 tests, all passing)
+- [x] 2.12 Add `src/hooks/replay/index.ts` re-exporting the hook + types
+
+## 3. JSONL file loader
+
+- [x] 3.1 Create `src/components/audit/replay/JsonlFileLoader.tsx` with drag-drop drop zone + file picker button
+- [x] 3.2 Implement parse pipeline: `FileReader.readAsText` → split on `\n` → strip empties → `JSON.parse` per line → `isGameEvent` per parsed object (extracted as pure `parseNdjsonEvents` helper)
+- [x] 3.3 Per-line error reporting: collect `{ line, error }` entries; on any error, do NOT promote events; render the error list
+- [x] 3.4 On success: call `onEventsLoaded(events, filename)` callback prop; render `loaded <filename> (N events, turns <min>–<max>)` status pill
+- [x] 3.5 "Clear upload" affordance that calls `onClearUpload()` callback; status pill hides
+- [x] 3.6 Verify the loader does NOT make any network calls (pure in-browser file processing) — explicit jest test spies on `fetch` + `XMLHttpRequest`
+- [x] 3.7 Create `src/components/audit/replay/__tests__/JsonlFileLoader.test.tsx` covering valid drop, malformed JSON line, valid-JSON-not-IGameEvent line, clear-upload, no-network (11 tests, all passing)
+- [x] 3.8 Re-export from `src/components/audit/replay/index.ts`
+
+## 4. Replay page wiring
+
+- [x] 4.1 In `src/pages/gameplay/games/[id]/replay.tsx`, add an `uploadedEvents: readonly IGameEvent[] | null` state plus `uploadedFilename` state
+- [x] 4.2 Compose dual-source replay player: `dbReplay` (audit-store-backed) + `uploadReplay` (`useSharedReplayPlayer` directly on uploaded events). Active replay surface picked via `isUploadActive`.
+- [x] 4.3 Synthesize the audit-event shape from uploaded `IGameEvent`s via `adaptGameEventToBase` so the existing `EventTimeline` + `ReplayEventOverlay` consume both sources without contract change
+- [x] 4.4 Mount `<JsonlFileLoader onEventsLoaded={...} onClearUpload={...} uploadedFilename={...} eventCount={...} minTurn={...} maxTurn={...} />` at the top of the left panel
+- [x] 4.5 Wire `useHexMapStateFromEvents(events, replay.currentSequence)` and replace the placeholder `<Card>` in the center pane with `<HexMapDisplay tokens={...} hexTerrain={...} radius={...} selectedHex={null} events={events} />` when upload is active
+- [x] 4.6 Add a "loaded from file" indicator pill next to the page header when uploaded events are active
+- [x] 4.7 Existing replay-page tests stay green; the placeholder branch still renders when no upload is active
+
+## 5. Verification
+
+- [x] 5.1 `npm run typecheck` clean
+- [x] 5.2 `npm run lint` clean (43 pre-existing warnings, 0 errors)
+- [x] 5.3 `npm test -- --testPathPattern="(useHexMapStateFromEvents|JsonlFileLoader)"` green (27 tests pass)
+- [x] 5.4 `npm test` full suite green (931 suites pass, 23521/23521 tests, no regressions)
+- [ ] 5.5 Smoke run: launch dev server, navigate to `/gameplay/games/<any>/replay`, drag the latest swarm `.jsonl` from `simulation-reports/games/2026-05-07T05-52-10-802Z/` onto the loader, scrub the timeline through the encounter and verify the hex map updates frame-by-frame (movements visible, kills flip the destroyed flag)
+- [x] 5.6 `npx openspec validate add-replay-viewer-from-ndjson --strict` clean
+
+## 6. PR
+
+- [ ] 6.1 Commit on branch `replay-viewer/pr-a1-jsonl-loader`
+- [ ] 6.2 Open PR against `main` with title `feat(replay): add JSONL file loader + state-from-events reducer for hex-map replay`
+- [ ] 6.3 Wait for CI green
+- [ ] 6.4 Merge with `--squash --delete-branch`
+
+## 7. Archive
+
+- [ ] 7.1 After merge, run `npx openspec archive add-replay-viewer-from-ndjson --yes` — clean
+- [ ] 7.2 Open archive PR; merge

--- a/src/components/audit/replay/JsonlFileLoader.tsx
+++ b/src/components/audit/replay/JsonlFileLoader.tsx
@@ -1,0 +1,309 @@
+/**
+ * JsonlFileLoader — drag-and-drop loader for swarm-produced
+ * `<gameId>.jsonl` event-log files.
+ *
+ * Per `add-replay-viewer-from-ndjson` (quick-session delta — "Replay
+ * Viewer Consumes Persisted NDJSON Files"): accepts a file via drag-drop
+ * OR file picker, parses NDJSON line-by-line, validates each line as
+ * `IGameEvent` via the type guard from `GameSessionInterfaces.ts`, and
+ * promotes the resulting `readonly IGameEvent[]` to the host page via
+ * `onEventsLoaded(events, filename)`. Per-line errors surface in the
+ * UI; on ANY error, no events are promoted.
+ *
+ * The loader is purely client-side — no network calls, no server-side
+ * upload. The file's bytes are processed in-browser via `FileReader`.
+ *
+ * @spec openspec/changes/add-replay-viewer-from-ndjson/specs/quick-session/spec.md
+ */
+
+import React, { useCallback, useRef, useState } from 'react';
+
+import type { IGameEvent } from '@/types/gameplay';
+
+import { isGameEvent } from '@/types/gameplay/GameSessionInterfaces';
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/**
+ * Per-line parse / validation error reported to the user when a file
+ * cannot be promoted. `line` is 1-indexed to match the user's editor
+ * conventions.
+ */
+export interface JsonlLineError {
+  readonly line: number;
+  readonly error: 'not valid JSON' | 'not a valid IGameEvent';
+}
+
+export interface JsonlFileLoaderProps {
+  /**
+   * Called when a file successfully parses and every line validates.
+   * The host page promotes the events as the new replay source.
+   */
+  readonly onEventsLoaded: (
+    events: readonly IGameEvent[],
+    filename: string,
+  ) => void;
+  /** Called when the user clicks the "clear upload" affordance. */
+  readonly onClearUpload: () => void;
+  /** When set, indicates uploaded events are currently active. */
+  readonly uploadedFilename?: string | null;
+  /** Total event count of the currently-loaded file (for the status pill). */
+  readonly eventCount?: number;
+  /** Min turn from the loaded file (for the status pill). */
+  readonly minTurn?: number;
+  /** Max turn from the loaded file (for the status pill). */
+  readonly maxTurn?: number;
+}
+
+// =============================================================================
+// Pure parse helper (exported for unit tests)
+// =============================================================================
+
+/**
+ * Parse a UTF-8 NDJSON string into either a list of events OR a list
+ * of per-line errors. Empty lines are tolerated (the runner does NOT
+ * write a trailing newline, but we tolerate it). Any single error in
+ * the file means no events are returned — the spec requires
+ * all-or-nothing promotion so the user knows exactly what to fix.
+ */
+export function parseNdjsonEvents(
+  contents: string,
+):
+  | { readonly ok: true; readonly events: readonly IGameEvent[] }
+  | { readonly ok: false; readonly errors: readonly JsonlLineError[] } {
+  const lines = contents.split('\n');
+  const errors: JsonlLineError[] = [];
+  const events: IGameEvent[] = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const raw = lines[i];
+    if (raw.length === 0) {
+      // Empty line — tolerated (covers trailing newlines and accidental
+      // blank lines). Spec rule "strip empty lines" applies before
+      // validation.
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      errors.push({ line: i + 1, error: 'not valid JSON' });
+      continue;
+    }
+
+    if (!isGameEvent(parsed)) {
+      errors.push({ line: i + 1, error: 'not a valid IGameEvent' });
+      continue;
+    }
+
+    events.push(parsed);
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+  return { ok: true, events };
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Drop zone + file picker for swarm-produced `.jsonl` event logs.
+ *
+ * Renders one of three states:
+ *   1. Idle — drop zone visible, "or click to browse" affordance.
+ *   2. Errors — per-line error list, drop zone re-enabled for retry.
+ *   3. Loaded — status pill with filename + event count + turn range,
+ *      "clear upload" button.
+ */
+export function JsonlFileLoader({
+  onEventsLoaded,
+  onClearUpload,
+  uploadedFilename,
+  eventCount,
+  minTurn,
+  maxTurn,
+}: JsonlFileLoaderProps): React.ReactElement {
+  const [errors, setErrors] = useState<readonly JsonlLineError[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Process a single picked / dropped file. Reads as text, runs the
+  // parse pipeline, and either promotes events or surfaces errors.
+  const handleFile = useCallback(
+    (file: File) => {
+      // Reset previous error state before this attempt.
+      setErrors([]);
+
+      const reader = new FileReader();
+      reader.addEventListener('load', () => {
+        const text = typeof reader.result === 'string' ? reader.result : '';
+        const result = parseNdjsonEvents(text);
+        if (result.ok) {
+          onEventsLoaded(result.events, file.name);
+        } else {
+          setErrors(result.errors);
+        }
+      });
+      reader.addEventListener('error', () => {
+        // FileReader errors are rare (browser-level read failures);
+        // surface a single line-0 error so the user still sees feedback.
+        setErrors([{ line: 0, error: 'not valid JSON' }]);
+      });
+      reader.readAsText(file, 'utf-8');
+    },
+    [onEventsLoaded],
+  );
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setIsDragging(false);
+      const file = event.dataTransfer.files?.[0];
+      if (file !== undefined) {
+        handleFile(file);
+      }
+    },
+    [handleFile],
+  );
+
+  const handleDragOver = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setIsDragging(true);
+    },
+    [],
+  );
+
+  const handleDragLeave = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  const handlePickClick = useCallback(() => {
+    inputRef.current?.click();
+  }, []);
+
+  const handleFileInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (file !== undefined) {
+        handleFile(file);
+      }
+      // Reset the input so picking the same file twice still triggers
+      // a change event.
+      event.target.value = '';
+    },
+    [handleFile],
+  );
+
+  const handleClearClick = useCallback(() => {
+    setErrors([]);
+    onClearUpload();
+  }, [onClearUpload]);
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  // "Loaded" state — collapse the drop zone to a status pill so the
+  // page's primary content (hex map + scrubber) keeps maximum vertical
+  // real estate.
+  if (uploadedFilename !== undefined && uploadedFilename !== null) {
+    return (
+      <div
+        data-testid="jsonl-loader-status"
+        className="border-border-theme-subtle bg-surface-raised flex items-center justify-between gap-3 rounded-lg border px-3 py-2"
+      >
+        <div className="text-text-theme-secondary truncate text-sm">
+          <span className="text-text-theme-muted">loaded</span>{' '}
+          <span className="text-text-theme-primary font-mono">
+            {uploadedFilename}
+          </span>{' '}
+          <span className="text-text-theme-muted">
+            ({eventCount ?? 0} events
+            {typeof minTurn === 'number' && typeof maxTurn === 'number'
+              ? `, turns ${minTurn}–${maxTurn}`
+              : ''}
+            )
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={handleClearClick}
+          className="text-text-theme-secondary hover:text-text-theme-primary rounded-md px-2 py-1 text-xs transition-colors"
+          aria-label="Clear uploaded file"
+          data-testid="jsonl-loader-clear"
+        >
+          clear upload
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div
+        data-testid="jsonl-loader-dropzone"
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onClick={handlePickClick}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handlePickClick();
+          }
+        }}
+        className={`border-border-theme-subtle bg-surface-raised hover:border-accent flex cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed px-4 py-6 text-center transition-colors ${
+          isDragging ? 'border-accent bg-accent/10' : ''
+        }`}
+        aria-label="Drop a .jsonl event-log file or click to browse"
+      >
+        <p className="text-text-theme-primary text-sm font-medium">
+          Drop a .jsonl event-log file
+        </p>
+        <p className="text-text-theme-muted text-xs">or click to browse</p>
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".jsonl,application/x-ndjson,application/json,text/plain"
+          onChange={handleFileInputChange}
+          className="hidden"
+          data-testid="jsonl-loader-file-input"
+        />
+      </div>
+
+      {errors.length > 0 && (
+        <div
+          data-testid="jsonl-loader-errors"
+          className="border-error-theme bg-error-theme/10 max-h-40 overflow-y-auto rounded-lg border px-3 py-2 text-xs"
+          role="alert"
+        >
+          <p className="text-error-theme mb-1 font-medium">
+            File rejected ({errors.length} error{errors.length === 1 ? '' : 's'}
+            ). No events were loaded.
+          </p>
+          <ul className="text-error-theme/90 list-inside list-disc space-y-0.5 font-mono">
+            {errors.slice(0, 20).map((err) => (
+              <li key={err.line}>
+                line {err.line}: {err.error}
+              </li>
+            ))}
+            {errors.length > 20 && (
+              <li className="text-text-theme-muted">
+                …and {errors.length - 20} more
+              </li>
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/audit/replay/__tests__/JsonlFileLoader.test.tsx
+++ b/src/components/audit/replay/__tests__/JsonlFileLoader.test.tsx
@@ -1,0 +1,332 @@
+/**
+ * JsonlFileLoader — unit tests covering the 5 spec scenarios from
+ * `add-replay-viewer-from-ndjson` (quick-session delta — Replay Viewer
+ * Consumes Persisted NDJSON Files) plus an explicit no-network
+ * assertion.
+ *
+ * The component is split into a pure parse helper (`parseNdjsonEvents`)
+ * + the React shell. Most assertions hit the pure helper directly so we
+ * don't have to mock `FileReader` for every case; two component-level
+ * tests cover the drag-drop wiring and the clear-upload affordance.
+ */
+
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import {
+  Facing,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IGameCreatedPayload,
+  IGameEvent,
+  MovementType,
+} from '@/types/gameplay';
+
+import { JsonlFileLoader, parseNdjsonEvents } from '../JsonlFileLoader';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeGameCreatedEvent(): IGameEvent {
+  const payload: IGameCreatedPayload = {
+    config: {
+      mapRadius: 17,
+      turnLimit: 0,
+      victoryConditions: ['destruction'],
+      optionalRules: [],
+    },
+    units: [
+      {
+        id: 'player-1',
+        name: 'Atlas',
+        side: GameSide.Player,
+        unitRef: 'atlas-as7-d',
+        pilotRef: 'pilot-1',
+        gunnery: 4,
+        piloting: 5,
+      },
+    ],
+  };
+  return {
+    id: 'evt-0',
+    gameId: 'test-game',
+    sequence: 0,
+    timestamp: '2026-05-07T00:00:00.000Z',
+    type: GameEventType.GameCreated,
+    turn: 1,
+    phase: GamePhase.Initiative,
+    side: GameSide.Player,
+    payload,
+  };
+}
+
+function makeMovementEvent(sequence: number): IGameEvent {
+  return {
+    id: `evt-${sequence}`,
+    gameId: 'test-game',
+    sequence,
+    timestamp: '2026-05-07T00:00:00.000Z',
+    type: GameEventType.MovementDeclared,
+    turn: 1,
+    phase: GamePhase.Movement,
+    side: GameSide.Player,
+    actorId: 'player-1',
+    payload: {
+      unitId: 'player-1',
+      from: { q: 0, r: 0 },
+      to: { q: 1, r: 0 },
+      facing: Facing.North,
+      movementType: MovementType.Walk,
+      mpUsed: 1,
+      heatGenerated: 0,
+    },
+  };
+}
+
+/**
+ * Synthesize NDJSON content with `count` valid events. The first event
+ * is `GameCreated`; the rest are `MovementDeclared` placeholders.
+ */
+function makeValidNdjson(count: number): string {
+  const lines: string[] = [];
+  lines.push(JSON.stringify(makeGameCreatedEvent()));
+  for (let i = 1; i < count; i += 1) {
+    lines.push(JSON.stringify(makeMovementEvent(i)));
+  }
+  return lines.join('\n');
+}
+
+// =============================================================================
+// parseNdjsonEvents — spec scenarios
+// =============================================================================
+
+describe('parseNdjsonEvents', () => {
+  describe('spec scenario: drag-drop of a valid 50-event NDJSON file populates the replay player', () => {
+    it('returns ok with all 50 events when every line validates', () => {
+      const contents = makeValidNdjson(50);
+
+      const result = parseNdjsonEvents(contents);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.events).toHaveLength(50);
+        expect(result.events[0].type).toBe(GameEventType.GameCreated);
+      }
+    });
+
+    it('tolerates a trailing newline', () => {
+      const contents = `${makeValidNdjson(3)}\n`;
+      const result = parseNdjsonEvents(contents);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.events).toHaveLength(3);
+      }
+    });
+  });
+
+  describe('spec scenario: a file with one malformed JSON line is rejected with a per-line error', () => {
+    it("records line N error 'not valid JSON' and rejects the whole file", () => {
+      const validHead = JSON.stringify(makeGameCreatedEvent());
+      const validTail = JSON.stringify(makeMovementEvent(1));
+      const contents = [validHead, '{this is not json}', validTail].join('\n');
+
+      const result = parseNdjsonEvents(contents);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]).toEqual({ line: 2, error: 'not valid JSON' });
+      }
+    });
+  });
+
+  describe('spec scenario: a file where one line parses as JSON but is not an IGameEvent is rejected', () => {
+    it("records line N error 'not a valid IGameEvent' and rejects the whole file", () => {
+      const validHead = JSON.stringify(makeGameCreatedEvent());
+      const invalidShape = JSON.stringify({ foo: 'bar' });
+      const contents = [validHead, invalidShape].join('\n');
+
+      const result = parseNdjsonEvents(contents);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]).toEqual({
+          line: 2,
+          error: 'not a valid IGameEvent',
+        });
+      }
+    });
+  });
+
+  describe('edge case: empty file produces ok with empty events', () => {
+    it('returns ok with [] when contents are empty', () => {
+      const result = parseNdjsonEvents('');
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.events).toEqual([]);
+      }
+    });
+  });
+
+  describe('edge case: empty interspersed lines do not produce errors', () => {
+    it('tolerates blank lines between valid events', () => {
+      const contents = [
+        JSON.stringify(makeGameCreatedEvent()),
+        '',
+        JSON.stringify(makeMovementEvent(1)),
+      ].join('\n');
+
+      const result = parseNdjsonEvents(contents);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.events).toHaveLength(2);
+      }
+    });
+  });
+});
+
+// =============================================================================
+// Component-level tests
+// =============================================================================
+
+describe('JsonlFileLoader component', () => {
+  describe('spec scenario: clearing the upload reverts the replay page to its DB event source', () => {
+    it('calls onClearUpload when the user clicks the clear button', () => {
+      const onClearUpload = jest.fn();
+      render(
+        <JsonlFileLoader
+          onEventsLoaded={jest.fn()}
+          onClearUpload={onClearUpload}
+          uploadedFilename="sim-42.jsonl"
+          eventCount={50}
+          minTurn={1}
+          maxTurn={12}
+        />,
+      );
+
+      const clearButton = screen.getByTestId('jsonl-loader-clear');
+      fireEvent.click(clearButton);
+
+      expect(onClearUpload).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows the filename + event count + turn range in the status pill', () => {
+      render(
+        <JsonlFileLoader
+          onEventsLoaded={jest.fn()}
+          onClearUpload={jest.fn()}
+          uploadedFilename="sim-42.jsonl"
+          eventCount={50}
+          minTurn={1}
+          maxTurn={12}
+        />,
+      );
+
+      const status = screen.getByTestId('jsonl-loader-status');
+      expect(status).toHaveTextContent('loaded');
+      expect(status).toHaveTextContent('sim-42.jsonl');
+      expect(status).toHaveTextContent('50 events');
+      expect(status).toHaveTextContent('turns 1–12');
+    });
+  });
+
+  describe('drop zone wiring', () => {
+    it('invokes onEventsLoaded with parsed events and filename when a valid file is dropped', async () => {
+      const onEventsLoaded = jest.fn();
+      render(
+        <JsonlFileLoader
+          onEventsLoaded={onEventsLoaded}
+          onClearUpload={jest.fn()}
+        />,
+      );
+
+      const dropzone = screen.getByTestId('jsonl-loader-dropzone');
+      const contents = makeValidNdjson(3);
+      const file = new File([contents], 'sim-42.jsonl', {
+        type: 'application/json',
+      });
+
+      fireEvent.drop(dropzone, {
+        dataTransfer: { files: [file] },
+      });
+
+      await waitFor(() => {
+        expect(onEventsLoaded).toHaveBeenCalledTimes(1);
+      });
+      const [events, filename] = onEventsLoaded.mock.calls[0];
+      expect(events).toHaveLength(3);
+      expect(filename).toBe('sim-42.jsonl');
+    });
+
+    it('renders the per-line error list when the dropped file has invalid JSON', async () => {
+      const onEventsLoaded = jest.fn();
+      render(
+        <JsonlFileLoader
+          onEventsLoaded={onEventsLoaded}
+          onClearUpload={jest.fn()}
+        />,
+      );
+
+      const dropzone = screen.getByTestId('jsonl-loader-dropzone');
+      const contents = `${JSON.stringify(makeGameCreatedEvent())}\n{not json}`;
+      const file = new File([contents], 'broken.jsonl', {
+        type: 'application/json',
+      });
+
+      fireEvent.drop(dropzone, {
+        dataTransfer: { files: [file] },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('jsonl-loader-errors')).toBeInTheDocument();
+      });
+      expect(onEventsLoaded).not.toHaveBeenCalled();
+      expect(screen.getByTestId('jsonl-loader-errors')).toHaveTextContent(
+        'line 2: not valid JSON',
+      );
+    });
+  });
+
+  describe('no-network assertion', () => {
+    it('does not call fetch / XMLHttpRequest during a file drop', async () => {
+      const fetchSpy = jest.fn();
+      const xhrSpy = jest.fn();
+      const originalFetch = globalThis.fetch;
+      const originalXhr = globalThis.XMLHttpRequest;
+      // Replace with spies to detect any accidental network call.
+      globalThis.fetch = fetchSpy as unknown as typeof fetch;
+      globalThis.XMLHttpRequest = xhrSpy as unknown as typeof XMLHttpRequest;
+
+      try {
+        const onEventsLoaded = jest.fn();
+        render(
+          <JsonlFileLoader
+            onEventsLoaded={onEventsLoaded}
+            onClearUpload={jest.fn()}
+          />,
+        );
+
+        const dropzone = screen.getByTestId('jsonl-loader-dropzone');
+        const contents = makeValidNdjson(2);
+        const file = new File([contents], 'sim-42.jsonl', {
+          type: 'application/json',
+        });
+        fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
+
+        await waitFor(() => {
+          expect(onEventsLoaded).toHaveBeenCalled();
+        });
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(xhrSpy).not.toHaveBeenCalled();
+      } finally {
+        globalThis.fetch = originalFetch;
+        globalThis.XMLHttpRequest = originalXhr;
+      }
+    });
+  });
+});

--- a/src/components/audit/replay/index.ts
+++ b/src/components/audit/replay/index.ts
@@ -33,3 +33,12 @@ export {
   type ReplayKeyboardHandlerProps,
   type KeyboardShortcut,
 } from './ReplayKeyboardHandler';
+
+// Per `add-replay-viewer-from-ndjson` (quick-session delta): drag-and-drop
+// loader for swarm-produced `<gameId>.jsonl` event-log files.
+export {
+  JsonlFileLoader,
+  parseNdjsonEvents,
+  type JsonlFileLoaderProps,
+  type JsonlLineError,
+} from './JsonlFileLoader';

--- a/src/hooks/replay/__tests__/useHexMapStateFromEvents.test.ts
+++ b/src/hooks/replay/__tests__/useHexMapStateFromEvents.test.ts
@@ -1,0 +1,518 @@
+/**
+ * useHexMapStateFromEvents — unit tests covering all 7 spec scenarios
+ * from `add-replay-viewer-from-ndjson` (combat-analytics delta — Replay
+ * State-From-Events Reducer Contract) plus edge cases (idempotence,
+ * backward seek, mid-cursor exclusion, multi-unit damage isolation).
+ *
+ * Tests target the pure `deriveHexMapStateFromEvents` function so the
+ * assertions don't have to render a React tree. The hook wrapper
+ * `useHexMapStateFromEvents` is just `useMemo(() => derive(...))`, so
+ * coverage on `derive` is the load-bearing regression net.
+ */
+
+import {
+  Facing,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IDamageAppliedPayload,
+  IGameCreatedPayload,
+  IGameEvent,
+  IGameUnit,
+  ILocationDestroyedPayload,
+  IMovementDeclaredPayload,
+  IUnitDestroyedPayload,
+  MovementType,
+  TokenUnitType,
+} from '@/types/gameplay';
+
+import { deriveHexMapStateFromEvents } from '../useHexMapStateFromEvents';
+
+// =============================================================================
+// Fixture helpers
+// =============================================================================
+
+/**
+ * Build a synthetic `IGameUnit` for `GameCreated` payloads. Defaults to
+ * a generic mech-like unit so tests that don't care about variant get a
+ * Mech token by default.
+ */
+function makeUnit(
+  overrides: Partial<IGameUnit> & Pick<IGameUnit, 'id' | 'name' | 'side'>,
+): IGameUnit {
+  return {
+    unitRef: 'atlas-as7-d',
+    pilotRef: 'pilot-1',
+    gunnery: 4,
+    piloting: 5,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a sequenced game event with sensible envelope defaults.
+ */
+function makeEvent(
+  overrides: Partial<IGameEvent> &
+    Pick<IGameEvent, 'type' | 'payload' | 'sequence'>,
+): IGameEvent {
+  return {
+    id: `evt-${overrides.sequence}`,
+    gameId: 'test-game',
+    timestamp: '2026-05-07T00:00:00.000Z',
+    turn: 1,
+    phase: GamePhase.Movement,
+    side: GameSide.Player,
+    ...overrides,
+  };
+}
+
+/**
+ * Standard `GameCreated` event with a 2-unit roster (one player + one
+ * opponent) and `mapRadius: 17`. Used as the seed for most scenarios.
+ */
+function makeStandardGameCreatedEvent(): IGameEvent {
+  const payload: IGameCreatedPayload = {
+    config: {
+      mapRadius: 17,
+      turnLimit: 0,
+      victoryConditions: ['destruction'],
+      optionalRules: [],
+    },
+    units: [
+      makeUnit({ id: 'player-1', name: 'Atlas AS7-D', side: GameSide.Player }),
+      makeUnit({
+        id: 'opponent-2',
+        name: 'Stalker STK-3F',
+        side: GameSide.Opponent,
+      }),
+    ],
+  };
+  return makeEvent({
+    sequence: 0,
+    type: GameEventType.GameCreated,
+    payload,
+  });
+}
+
+// =============================================================================
+// Spec scenarios
+// =============================================================================
+
+describe('deriveHexMapStateFromEvents', () => {
+  describe('spec scenario: GameCreated seeds tokens and mapRadius', () => {
+    it('seeds one token per unit and reads mapRadius from payload.config', () => {
+      const events: IGameEvent[] = [makeStandardGameCreatedEvent()];
+
+      const state = deriveHexMapStateFromEvents(events, 0);
+
+      expect(state.tokens).toHaveLength(2);
+      expect(state.tokens[0].unitId).toBe('player-1');
+      expect(state.tokens[1].unitId).toBe('opponent-2');
+      expect(state.mapRadius).toBe(17);
+    });
+
+    it('defaults each fresh token to Mech variant when unitType is unset', () => {
+      const events: IGameEvent[] = [makeStandardGameCreatedEvent()];
+      const state = deriveHexMapStateFromEvents(events, 0);
+      expect(state.tokens[0].unitType).toBe(TokenUnitType.Mech);
+    });
+
+    it('places fresh tokens at origin with Facing.North until corrected', () => {
+      const events: IGameEvent[] = [makeStandardGameCreatedEvent()];
+      const state = deriveHexMapStateFromEvents(events, 0);
+      expect(state.tokens[0].position).toEqual({ q: 0, r: 0 });
+      expect(state.tokens[0].facing).toBe(Facing.North);
+    });
+  });
+
+  describe('spec scenario: MovementDeclared updates position and facing for the actor', () => {
+    it('updates position to payload.to and facing to payload.facing on the actor token', () => {
+      const movementPayload: IMovementDeclaredPayload = {
+        unitId: 'player-1',
+        from: { q: 0, r: 0 },
+        to: { q: 3, r: 5 },
+        facing: Facing.Southeast,
+        movementType: MovementType.Walk,
+        mpUsed: 3,
+        heatGenerated: 0,
+      };
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.MovementDeclared,
+          payload: movementPayload,
+          actorId: 'player-1',
+        }),
+      ];
+
+      const state = deriveHexMapStateFromEvents(events, 1);
+
+      const playerToken = state.tokens.find((t) => t.unitId === 'player-1');
+      expect(playerToken?.position).toEqual({ q: 3, r: 5 });
+      expect(playerToken?.facing).toBe(Facing.Southeast);
+    });
+
+    it("does not affect other units' positions", () => {
+      const movementPayload: IMovementDeclaredPayload = {
+        unitId: 'player-1',
+        from: { q: 0, r: 0 },
+        to: { q: 3, r: 5 },
+        facing: Facing.Southeast,
+        movementType: MovementType.Walk,
+        mpUsed: 3,
+        heatGenerated: 0,
+      };
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.MovementDeclared,
+          payload: movementPayload,
+          actorId: 'player-1',
+        }),
+      ];
+
+      const state = deriveHexMapStateFromEvents(events, 1);
+
+      const opponentToken = state.tokens.find((t) => t.unitId === 'opponent-2');
+      expect(opponentToken?.position).toEqual({ q: 0, r: 0 });
+      expect(opponentToken?.facing).toBe(Facing.North);
+    });
+  });
+
+  describe('spec scenario: UnitDestroyed flips isDestroyed', () => {
+    it('flips isDestroyed for the destroyed unit only', () => {
+      const destroyPayload: IUnitDestroyedPayload = {
+        unitId: 'player-1',
+        cause: 'damage',
+      };
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.UnitDestroyed,
+          payload: destroyPayload,
+        }),
+      ];
+
+      const state = deriveHexMapStateFromEvents(events, 1);
+
+      expect(
+        state.tokens.find((t) => t.unitId === 'player-1')?.isDestroyed,
+      ).toBe(true);
+      expect(
+        state.tokens.find((t) => t.unitId === 'opponent-2')?.isDestroyed,
+      ).toBe(false);
+    });
+  });
+
+  describe('spec scenario: LocationDestroyed on CT flips isDestroyed', () => {
+    it("flips isDestroyed when payload.location === 'CT'", () => {
+      const ctPayload: ILocationDestroyedPayload = {
+        unitId: 'player-1',
+        location: 'CT',
+      };
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.LocationDestroyed,
+          payload: ctPayload,
+        }),
+      ];
+
+      const state = deriveHexMapStateFromEvents(events, 1);
+
+      expect(
+        state.tokens.find((t) => t.unitId === 'player-1')?.isDestroyed,
+      ).toBe(true);
+    });
+
+    it('does NOT flip isDestroyed for non-CT locations', () => {
+      const armPayload: ILocationDestroyedPayload = {
+        unitId: 'player-1',
+        location: 'LA',
+      };
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.LocationDestroyed,
+          payload: armPayload,
+        }),
+      ];
+
+      const state = deriveHexMapStateFromEvents(events, 1);
+
+      expect(
+        state.tokens.find((t) => t.unitId === 'player-1')?.isDestroyed,
+      ).toBe(false);
+    });
+  });
+
+  describe('spec scenario: Cursor truncation excludes events beyond currentSequence', () => {
+    it('applies movement at sequence 1 but not destruction at sequence 2', () => {
+      const movementPayload: IMovementDeclaredPayload = {
+        unitId: 'player-1',
+        from: { q: 0, r: 0 },
+        to: { q: 2, r: 2 },
+        facing: Facing.Southeast,
+        movementType: MovementType.Walk,
+        mpUsed: 2,
+        heatGenerated: 0,
+      };
+      const destroyPayload: IUnitDestroyedPayload = {
+        unitId: 'player-1',
+        cause: 'damage',
+      };
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.MovementDeclared,
+          payload: movementPayload,
+          actorId: 'player-1',
+        }),
+        makeEvent({
+          sequence: 2,
+          type: GameEventType.UnitDestroyed,
+          payload: destroyPayload,
+        }),
+      ];
+
+      const state = deriveHexMapStateFromEvents(events, 1);
+
+      const playerToken = state.tokens.find((t) => t.unitId === 'player-1');
+      expect(playerToken?.position).toEqual({ q: 2, r: 2 });
+      expect(playerToken?.isDestroyed).toBe(false);
+    });
+  });
+
+  describe('spec scenario: Backward cursor seek returns correct earlier state', () => {
+    it('re-running with a smaller cursor strips later mutations', () => {
+      const move1Payload: IMovementDeclaredPayload = {
+        unitId: 'player-1',
+        from: { q: 0, r: 0 },
+        to: { q: 2, r: 2 },
+        facing: Facing.Southeast,
+        movementType: MovementType.Walk,
+        mpUsed: 2,
+        heatGenerated: 0,
+      };
+      const move2Payload: IMovementDeclaredPayload = {
+        unitId: 'player-1',
+        from: { q: 2, r: 2 },
+        to: { q: 5, r: 5 },
+        facing: Facing.South,
+        movementType: MovementType.Walk,
+        mpUsed: 3,
+        heatGenerated: 0,
+      };
+      const destroyPayload: IUnitDestroyedPayload = {
+        unitId: 'player-1',
+        cause: 'damage',
+      };
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.MovementDeclared,
+          payload: move1Payload,
+          actorId: 'player-1',
+        }),
+        makeEvent({
+          sequence: 2,
+          type: GameEventType.MovementDeclared,
+          payload: move2Payload,
+          actorId: 'player-1',
+        }),
+        makeEvent({
+          sequence: 3,
+          type: GameEventType.UnitDestroyed,
+          payload: destroyPayload,
+        }),
+      ];
+
+      const stateAt5 = deriveHexMapStateFromEvents(events, 5);
+      const stateAt2 = deriveHexMapStateFromEvents(events, 2);
+
+      // Backward seek to cursor=2 must equal the state of walking 0..2
+      // from scratch — destruction at sequence 3 must be absent.
+      const playerAt2 = stateAt2.tokens.find((t) => t.unitId === 'player-1');
+      expect(playerAt2?.position).toEqual({ q: 5, r: 5 });
+      expect(playerAt2?.isDestroyed).toBe(false);
+
+      // Sanity: at cursor=5 the destroy IS applied.
+      const playerAt5 = stateAt5.tokens.find((t) => t.unitId === 'player-1');
+      expect(playerAt5?.isDestroyed).toBe(true);
+    });
+  });
+
+  describe('spec scenario: Empty-prefix log without GameCreated returns empty defaults', () => {
+    it('returns { tokens: [], hexTerrain: [], mapRadius: 0 } and does not throw', () => {
+      const movementPayload: IMovementDeclaredPayload = {
+        unitId: 'player-1',
+        from: { q: 0, r: 0 },
+        to: { q: 2, r: 2 },
+        facing: Facing.Southeast,
+        movementType: MovementType.Walk,
+        mpUsed: 2,
+        heatGenerated: 0,
+      };
+      const events: IGameEvent[] = [
+        // No GameCreated event — only orphaned movement.
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.MovementDeclared,
+          payload: movementPayload,
+          actorId: 'player-1',
+        }),
+      ];
+
+      const state = deriveHexMapStateFromEvents(events, 100);
+
+      expect(state.tokens).toEqual([]);
+      expect(state.hexTerrain).toEqual([]);
+      expect(state.mapRadius).toBe(0);
+    });
+  });
+
+  describe('spec scenario: Idempotent on repeated invocation', () => {
+    it('produces structurally equivalent results on repeated invocation', () => {
+      const movementPayload: IMovementDeclaredPayload = {
+        unitId: 'player-1',
+        from: { q: 0, r: 0 },
+        to: { q: 2, r: 2 },
+        facing: Facing.Southeast,
+        movementType: MovementType.Walk,
+        mpUsed: 2,
+        heatGenerated: 0,
+      };
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.MovementDeclared,
+          payload: movementPayload,
+          actorId: 'player-1',
+        }),
+      ];
+
+      const a = deriveHexMapStateFromEvents(events, 1);
+      const b = deriveHexMapStateFromEvents(events, 1);
+
+      // Deep-equal across both calls. Reference identity is NOT
+      // expected since `derive` is the bare projection (memoization
+      // happens in the React-hook wrapper).
+      expect(a).toEqual(b);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge cases beyond the spec scenarios
+  // ---------------------------------------------------------------------------
+
+  describe('edge case: DamageApplied without locationDestroyed leaves isDestroyed false', () => {
+    it('treats armor-only damage as a no-op for token isDestroyed', () => {
+      const damagePayload: IDamageAppliedPayload = {
+        unitId: 'player-1',
+        location: 'CT',
+        damage: 5,
+        armorRemaining: 10,
+        structureRemaining: 20,
+        locationDestroyed: false,
+      };
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.DamageApplied,
+          payload: damagePayload,
+        }),
+      ];
+
+      const state = deriveHexMapStateFromEvents(events, 1);
+
+      expect(
+        state.tokens.find((t) => t.unitId === 'player-1')?.isDestroyed,
+      ).toBe(false);
+    });
+  });
+
+  describe('edge case: out-of-band event types pass through silently', () => {
+    it('does not mutate any token when an unhandled event type is encountered', () => {
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        // Phase change event is not a covered family — must pass through.
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.PhaseChanged,
+          payload: {
+            fromPhase: GamePhase.Movement,
+            toPhase: GamePhase.WeaponAttack,
+          } as never,
+        }),
+      ];
+
+      const stateBefore = deriveHexMapStateFromEvents(events, 0);
+      const stateAfter = deriveHexMapStateFromEvents(events, 1);
+
+      expect(stateAfter.tokens).toEqual(stateBefore.tokens);
+      expect(stateAfter.mapRadius).toBe(stateBefore.mapRadius);
+    });
+  });
+
+  describe('edge case: cursor at MAX_SAFE_INTEGER applies all events', () => {
+    it('walks the entire log when cursor exceeds the max sequence', () => {
+      const destroyPayload: IUnitDestroyedPayload = {
+        unitId: 'player-1',
+        cause: 'damage',
+      };
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 5,
+          type: GameEventType.UnitDestroyed,
+          payload: destroyPayload,
+        }),
+      ];
+
+      const state = deriveHexMapStateFromEvents(
+        events,
+        Number.MAX_SAFE_INTEGER,
+      );
+
+      expect(
+        state.tokens.find((t) => t.unitId === 'player-1')?.isDestroyed,
+      ).toBe(true);
+    });
+  });
+
+  describe('edge case: multi-unit damage isolation', () => {
+    it('destroying one unit leaves the other intact', () => {
+      const destroyPayload: IUnitDestroyedPayload = {
+        unitId: 'opponent-2',
+        cause: 'ammo_explosion',
+      };
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.UnitDestroyed,
+          payload: destroyPayload,
+        }),
+      ];
+
+      const state = deriveHexMapStateFromEvents(events, 1);
+
+      expect(
+        state.tokens.find((t) => t.unitId === 'player-1')?.isDestroyed,
+      ).toBe(false);
+      expect(
+        state.tokens.find((t) => t.unitId === 'opponent-2')?.isDestroyed,
+      ).toBe(true);
+    });
+  });
+});

--- a/src/hooks/replay/__tests__/useHexMapStateFromEvents.test.ts
+++ b/src/hooks/replay/__tests__/useHexMapStateFromEvents.test.ts
@@ -350,8 +350,115 @@ describe('deriveHexMapStateFromEvents', () => {
     });
   });
 
-  describe('spec scenario: Empty-prefix log without GameCreated returns empty defaults', () => {
-    it('returns { tokens: [], hexTerrain: [], mapRadius: 0 } and does not throw', () => {
+  describe('spec scenario: Truly empty event log returns empty defaults', () => {
+    it('returns { tokens: [], hexTerrain: [], mapRadius: 0 } for an empty events array', () => {
+      const events: IGameEvent[] = [];
+
+      const state = deriveHexMapStateFromEvents(events, 100);
+
+      expect(state.tokens).toEqual([]);
+      expect(state.hexTerrain).toEqual([]);
+      expect(state.mapRadius).toBe(0);
+    });
+  });
+
+  describe('spec scenario: Lossy fallback synthesizes tokens for legacy NDJSON without GameCreated', () => {
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('synthesizes Mech-default tokens from actorIds when no GameCreated is present', () => {
+      const movementPayload1: IMovementDeclaredPayload = {
+        unitId: 'player-1',
+        from: { q: 0, r: 0 },
+        to: { q: 2, r: 2 },
+        facing: Facing.Southeast,
+        movementType: MovementType.Walk,
+        mpUsed: 2,
+        heatGenerated: 0,
+      };
+      const movementPayload2: IMovementDeclaredPayload = {
+        unitId: 'opponent-2',
+        from: { q: 5, r: 5 },
+        to: { q: 6, r: 6 },
+        facing: Facing.North,
+        movementType: MovementType.Walk,
+        mpUsed: 1,
+        heatGenerated: 0,
+      };
+      const events: IGameEvent[] = [
+        makeEvent({
+          sequence: 0,
+          type: GameEventType.MovementDeclared,
+          payload: movementPayload1,
+          actorId: 'player-1',
+        }),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.MovementDeclared,
+          payload: movementPayload2,
+          actorId: 'opponent-2',
+        }),
+      ];
+
+      const state = deriveHexMapStateFromEvents(events, 100);
+
+      const ids = state.tokens.map((t) => t.unitId).sort();
+      expect(ids).toEqual(['opponent-2', 'player-1']);
+      expect(state.mapRadius).toBe(17);
+    });
+
+    it('derives side from id prefix on synthesized tokens', () => {
+      const movementPlayer: IMovementDeclaredPayload = {
+        unitId: 'player-1',
+        from: { q: 0, r: 0 },
+        to: { q: 2, r: 2 },
+        facing: Facing.North,
+        movementType: MovementType.Walk,
+        mpUsed: 2,
+        heatGenerated: 0,
+      };
+      const movementOpponent: IMovementDeclaredPayload = {
+        unitId: 'opponent-1',
+        from: { q: 0, r: 0 },
+        to: { q: 1, r: 0 },
+        facing: Facing.South,
+        movementType: MovementType.Walk,
+        mpUsed: 1,
+        heatGenerated: 0,
+      };
+      const events: IGameEvent[] = [
+        makeEvent({
+          sequence: 0,
+          type: GameEventType.MovementDeclared,
+          payload: movementPlayer,
+          actorId: 'player-1',
+        }),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.MovementDeclared,
+          payload: movementOpponent,
+          actorId: 'opponent-1',
+        }),
+      ];
+
+      const state = deriveHexMapStateFromEvents(events, 100);
+
+      const playerToken = state.tokens.find((t) => t.unitId === 'player-1');
+      const opponentToken = state.tokens.find((t) => t.unitId === 'opponent-1');
+      expect(playerToken?.side).toBe(GameSide.Player);
+      expect(opponentToken?.side).toBe(GameSide.Opponent);
+      // Per spec: synthesized tokens default to Mech variant.
+      expect(playerToken?.unitType).toBe(TokenUnitType.Mech);
+    });
+
+    it('emits a single console.warn signaling the fallback path activated', () => {
       const movementPayload: IMovementDeclaredPayload = {
         unitId: 'player-1',
         from: { q: 0, r: 0 },
@@ -362,20 +469,44 @@ describe('deriveHexMapStateFromEvents', () => {
         heatGenerated: 0,
       };
       const events: IGameEvent[] = [
-        // No GameCreated event — only orphaned movement.
         makeEvent({
-          sequence: 1,
+          sequence: 0,
           type: GameEventType.MovementDeclared,
           payload: movementPayload,
           actorId: 'player-1',
         }),
       ];
 
+      deriveHexMapStateFromEvents(events, 100);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('No GameCreated event found');
+    });
+
+    it('subsequent MovementDeclared still updates the synthesized token', () => {
+      const movement: IMovementDeclaredPayload = {
+        unitId: 'player-1',
+        from: { q: 0, r: 0 },
+        to: { q: 5, r: 5 },
+        facing: Facing.Southeast,
+        movementType: MovementType.Walk,
+        mpUsed: 5,
+        heatGenerated: 0,
+      };
+      const events: IGameEvent[] = [
+        makeEvent({
+          sequence: 0,
+          type: GameEventType.MovementDeclared,
+          payload: movement,
+          actorId: 'player-1',
+        }),
+      ];
+
       const state = deriveHexMapStateFromEvents(events, 100);
 
-      expect(state.tokens).toEqual([]);
-      expect(state.hexTerrain).toEqual([]);
-      expect(state.mapRadius).toBe(0);
+      const token = state.tokens.find((t) => t.unitId === 'player-1');
+      expect(token?.position).toEqual({ q: 5, r: 5 });
+      expect(token?.facing).toBe(Facing.Southeast);
     });
   });
 

--- a/src/hooks/replay/index.ts
+++ b/src/hooks/replay/index.ts
@@ -21,3 +21,14 @@ export {
   type UseSharedReplayPlayerReturn,
   type IUseSharedReplayPlayerOptions,
 } from './useSharedReplayPlayer';
+
+/**
+ * Per `add-replay-viewer-from-ndjson` (combat-analytics delta): pure
+ * projection from a typed `IGameEvent` log to `<HexMapDisplay>`-ready
+ * state.
+ */
+export {
+  useHexMapStateFromEvents,
+  deriveHexMapStateFromEvents,
+  type ReplayHexMapState,
+} from './useHexMapStateFromEvents';

--- a/src/hooks/replay/useHexMapStateFromEvents.ts
+++ b/src/hooks/replay/useHexMapStateFromEvents.ts
@@ -1,0 +1,481 @@
+/**
+ * useHexMapStateFromEvents — pure projection from typed `IGameEvent` log
+ * to `<HexMapDisplay>` state.
+ *
+ * Per `add-replay-viewer-from-ndjson` (combat-analytics delta —
+ * "Replay State-From-Events Reducer Contract"): walks `events` in
+ * monotonic `sequence` order up to and including the highest event with
+ * `event.sequence <= currentSequence`, applying the eight covered
+ * on-map event families (`GameCreated`, `MovementDeclared`,
+ * `DamageApplied`, `LocationDestroyed`, `TransferDamage`,
+ * `UnitDestroyed`, `UnitFell` / `UnitStood`, `HeatGenerated` /
+ * `HeatDissipated`, `PilotHit`). All other event types pass through
+ * silently.
+ *
+ * The reducer is a pure function — no I/O, no side effects, no React
+ * refs. Memoized on `[events, currentSequence]` so re-renders that do
+ * not change the cursor reuse the prior projection.
+ *
+ * Token construction reads `IGameUnit.unitType` and dispatches to the
+ * matching `IUnitToken` variant constructor. Defaults are chosen so a
+ * pre-`MovementDeclared` token still renders cleanly (origin position,
+ * `Facing.North`, no sprite props → fallback medium-humanoid silhouette
+ * for mechs).
+ *
+ * @spec openspec/changes/add-replay-viewer-from-ndjson/specs/combat-analytics/spec.md
+ */
+
+import { useMemo } from 'react';
+
+import type {
+  IAerospaceToken,
+  IBattleArmorToken,
+  IDamageAppliedPayload,
+  IGameCreatedPayload,
+  IGameEvent,
+  IGameUnit,
+  IHeatPayload,
+  IHexCoordinate,
+  IHexTerrain,
+  IInfantryToken,
+  ILocationDestroyedPayload,
+  IMechToken,
+  IMovementDeclaredPayload,
+  IPilotHitPayload,
+  IProtoMechToken,
+  ITransferDamagePayload,
+  IUnitDestroyedPayload,
+  IUnitFellPayload,
+  IUnitStoodPayload,
+  IUnitToken,
+  IVehicleToken,
+} from '@/types/gameplay';
+
+import { Facing, GameEventType, TokenUnitType } from '@/types/gameplay';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+import { ProtoChassis } from '@/types/unit/ProtoMechInterfaces';
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/**
+ * Output shape of the reducer — matches the props `<HexMapDisplay>`
+ * consumes directly. Page wiring forwards the three fields onto the
+ * map without further projection.
+ */
+export interface ReplayHexMapState {
+  readonly tokens: readonly IUnitToken[];
+  readonly hexTerrain: readonly IHexTerrain[];
+  readonly mapRadius: number;
+}
+
+// =============================================================================
+// Internal accumulator shape
+// =============================================================================
+
+/**
+ * Internal per-unit accumulator carried during the walk. Stays purely
+ * local — only the public `IUnitToken` projection escapes the reducer.
+ *
+ * `damagedLocations` is informational bookkeeping for follow-on
+ * record-sheet rendering (out of scope for this PR — only `isDestroyed`
+ * flips in this PR per the spec scope).
+ */
+interface UnitAccumulator {
+  readonly unitId: string;
+  readonly name: string;
+  readonly side: IGameUnit['side'];
+  readonly unitType: TokenUnitType;
+  position: IHexCoordinate;
+  facing: Facing;
+  isDestroyed: boolean;
+  prone: boolean;
+  currentHeat: number;
+  pilotWounds: number;
+  damagedLocations: ReadonlySet<string>;
+  // Optional per-type passthrough fields — populated only for variants
+  // that need them. Stored as a loosely-typed bag because the reducer
+  // doesn't mutate them after seeding from `GameCreated`.
+  perType?: {
+    altitude?: number;
+    trooperCount?: number;
+    infantryCount?: number;
+    platoonCount?: number;
+    protoCount?: number;
+    isGlider?: boolean;
+    hasMainGun?: boolean;
+  };
+}
+
+// =============================================================================
+// Token construction from IGameUnit
+// =============================================================================
+
+/**
+ * Pick the matching `TokenUnitType` for a construction-side `UnitType`.
+ * Mirrors the `unitStateToToken` switch but reads from the construction
+ * `unitType` rather than from a `combatState` envelope (which the
+ * NDJSON-replay flow does not carry).
+ */
+function tokenTypeFor(unitType: UnitType | undefined): TokenUnitType {
+  switch (unitType) {
+    case UnitType.AEROSPACE:
+    case UnitType.CONVENTIONAL_FIGHTER:
+    case UnitType.SMALL_CRAFT:
+    case UnitType.DROPSHIP:
+    case UnitType.JUMPSHIP:
+    case UnitType.WARSHIP:
+    case UnitType.SPACE_STATION:
+      return TokenUnitType.Aerospace;
+    case UnitType.PROTOMECH:
+      return TokenUnitType.ProtoMech;
+    case UnitType.BATTLE_ARMOR:
+      return TokenUnitType.BattleArmor;
+    case UnitType.INFANTRY:
+      return TokenUnitType.Infantry;
+    case UnitType.VEHICLE:
+    case UnitType.VTOL:
+      return TokenUnitType.Vehicle;
+    case UnitType.BATTLEMECH:
+    case UnitType.OMNIMECH:
+    case UnitType.INDUSTRIALMECH:
+    default:
+      // Default to Mech for legacy callers that omit `unitType`. Matches
+      // `unitStateToToken`'s safe-default branch.
+      return TokenUnitType.Mech;
+  }
+}
+
+/**
+ * Generate a short token designation from the unit name. Mirrors
+ * `unitStateToToken.designation` so token captions stay visually
+ * identical across the live tactical map and the replay view.
+ */
+function designationFor(name: string): string {
+  return name
+    .split(/[\s-]+/)
+    .map((word) => (word.length > 0 ? word[0] : ''))
+    .join('')
+    .toUpperCase()
+    .slice(0, 4);
+}
+
+/**
+ * Seed the per-unit accumulator from a `GameCreated` payload entry.
+ * Position defaults to origin; the first `MovementDeclared` corrects
+ * it. Facing defaults to North; same correction path.
+ */
+function seedAccumulator(unit: IGameUnit): UnitAccumulator {
+  const tokenType = tokenTypeFor(unit.unitType);
+  const acc: UnitAccumulator = {
+    unitId: unit.id,
+    name: unit.name,
+    side: unit.side,
+    unitType: tokenType,
+    position: { q: 0, r: 0 },
+    facing: Facing.North,
+    isDestroyed: false,
+    prone: false,
+    currentHeat: 0,
+    pilotWounds: 0,
+    damagedLocations: new Set<string>(),
+  };
+
+  // Per-type passthroughs seeded from construction blocks when present.
+  // Defaults below match `unitStateToToken` — destroyed === 0 alive on
+  // protomechs, infantry / BA fall back to 1, aerospace altitude 0.
+  switch (tokenType) {
+    case TokenUnitType.Aerospace:
+      acc.perType = {
+        altitude: unit.aerospaceInit?.altitude ?? 0,
+      };
+      break;
+    case TokenUnitType.BattleArmor:
+      acc.perType = {
+        trooperCount: unit.battleArmorInit?.squadSize ?? 1,
+      };
+      break;
+    case TokenUnitType.Infantry:
+      acc.perType = {
+        infantryCount: unit.infantryInit?.platoonStrength ?? 1,
+        platoonCount: 1,
+      };
+      break;
+    case TokenUnitType.ProtoMech:
+      acc.perType = {
+        protoCount: 1,
+        isGlider: unit.protoMechInit?.chassisType === ProtoChassis.GLIDER,
+        hasMainGun: unit.protoMechInit?.hasMainGun ?? false,
+      };
+      break;
+    default:
+      break;
+  }
+
+  return acc;
+}
+
+/**
+ * Project the accumulator into the appropriate `IUnitToken` variant.
+ * Mirrors the variant switch in `unitStateToToken` so the live
+ * tactical-map renderer and the replay viewer paint the same token
+ * shape.
+ */
+function accumulatorToToken(acc: UnitAccumulator): IUnitToken {
+  const designation = designationFor(acc.name);
+  const base = {
+    unitId: acc.unitId,
+    name: acc.name,
+    side: acc.side,
+    position: acc.position,
+    facing: acc.facing,
+    isSelected: false,
+    isValidTarget: false,
+    isActiveTarget: false,
+    isDestroyed: acc.isDestroyed,
+    designation,
+  } as const;
+
+  switch (acc.unitType) {
+    case TokenUnitType.Aerospace: {
+      const token: IAerospaceToken = {
+        ...base,
+        unitType: TokenUnitType.Aerospace,
+        altitude: acc.perType?.altitude ?? 0,
+      };
+      return token;
+    }
+    case TokenUnitType.Vehicle: {
+      const token: IVehicleToken = {
+        ...base,
+        unitType: TokenUnitType.Vehicle,
+      };
+      return token;
+    }
+    case TokenUnitType.BattleArmor: {
+      const token: IBattleArmorToken = {
+        ...base,
+        unitType: TokenUnitType.BattleArmor,
+        trooperCount: acc.perType?.trooperCount ?? 1,
+      };
+      return token;
+    }
+    case TokenUnitType.Infantry: {
+      const token: IInfantryToken = {
+        ...base,
+        unitType: TokenUnitType.Infantry,
+        infantryCount: acc.perType?.infantryCount ?? 1,
+        platoonCount: acc.perType?.platoonCount ?? 1,
+      };
+      return token;
+    }
+    case TokenUnitType.ProtoMech: {
+      const token: IProtoMechToken = {
+        ...base,
+        unitType: TokenUnitType.ProtoMech,
+        protoCount: acc.isDestroyed ? 0 : (acc.perType?.protoCount ?? 1),
+        isGlider: acc.perType?.isGlider ?? false,
+        hasMainGun: acc.perType?.hasMainGun ?? false,
+      };
+      return token;
+    }
+    case TokenUnitType.Mech:
+    default: {
+      const token: IMechToken = {
+        ...base,
+        unitType: TokenUnitType.Mech,
+      };
+      return token;
+    }
+  }
+}
+
+// =============================================================================
+// Reducer walk
+// =============================================================================
+
+/**
+ * Walk events in sequence order up to `currentSequence` and project
+ * the result into `ReplayHexMapState`. Pure function — see
+ * `useHexMapStateFromEvents` for the React-memoized wrapper.
+ *
+ * Exported separately from the hook for direct use in unit tests so
+ * test runs can assert on the projection without rendering a React
+ * tree.
+ */
+export function deriveHexMapStateFromEvents(
+  events: readonly IGameEvent[],
+  currentSequence: number,
+): ReplayHexMapState {
+  // Per-unit accumulator keyed on `unitId`. Map preserves insertion
+  // order so the projected `tokens` array order matches the unit list
+  // ordering from `GameCreated.payload.units`.
+  const accumulators = new Map<string, UnitAccumulator>();
+  let mapRadius = 0;
+
+  for (const event of events) {
+    if (event.sequence > currentSequence) {
+      break;
+    }
+
+    switch (event.type) {
+      case GameEventType.GameCreated: {
+        const payload = event.payload as IGameCreatedPayload;
+        mapRadius = payload.config.mapRadius;
+        accumulators.clear();
+        for (const unit of payload.units) {
+          accumulators.set(unit.id, seedAccumulator(unit));
+        }
+        break;
+      }
+      case GameEventType.MovementDeclared: {
+        const payload = event.payload as IMovementDeclaredPayload;
+        const acc = accumulators.get(payload.unitId);
+        if (acc !== undefined) {
+          acc.position = payload.to;
+          acc.facing = payload.facing;
+        }
+        break;
+      }
+      case GameEventType.DamageApplied: {
+        const payload = event.payload as IDamageAppliedPayload;
+        const acc = accumulators.get(payload.unitId);
+        if (acc !== undefined) {
+          if (payload.locationDestroyed === true) {
+            const next = new Set(acc.damagedLocations);
+            next.add(payload.location);
+            acc.damagedLocations = next;
+            if (payload.location === 'CT') {
+              acc.isDestroyed = true;
+            }
+          }
+        }
+        break;
+      }
+      case GameEventType.LocationDestroyed: {
+        const payload = event.payload as ILocationDestroyedPayload;
+        const acc = accumulators.get(payload.unitId);
+        if (acc !== undefined) {
+          const next = new Set(acc.damagedLocations);
+          next.add(payload.location);
+          acc.damagedLocations = next;
+          if (payload.location === 'CT') {
+            acc.isDestroyed = true;
+          }
+        }
+        break;
+      }
+      case GameEventType.TransferDamage: {
+        const payload = event.payload as ITransferDamagePayload;
+        const acc = accumulators.get(payload.unitId);
+        if (acc !== undefined) {
+          const next = new Set(acc.damagedLocations);
+          next.add(payload.fromLocation);
+          acc.damagedLocations = next;
+        }
+        break;
+      }
+      case GameEventType.UnitDestroyed: {
+        const payload = event.payload as IUnitDestroyedPayload;
+        const acc = accumulators.get(payload.unitId);
+        if (acc !== undefined) {
+          acc.isDestroyed = true;
+        }
+        break;
+      }
+      case GameEventType.UnitFell: {
+        const payload = event.payload as IUnitFellPayload;
+        const acc = accumulators.get(payload.unitId);
+        if (acc !== undefined) {
+          acc.prone = true;
+        }
+        break;
+      }
+      case GameEventType.UnitStood: {
+        const payload = event.payload as IUnitStoodPayload;
+        const acc = accumulators.get(payload.unitId);
+        if (acc !== undefined) {
+          acc.prone = false;
+        }
+        break;
+      }
+      case GameEventType.HeatGenerated:
+      case GameEventType.HeatDissipated: {
+        const payload = event.payload as IHeatPayload;
+        const acc = accumulators.get(payload.unitId);
+        if (acc !== undefined) {
+          acc.currentHeat = payload.newTotal;
+        }
+        break;
+      }
+      case GameEventType.PilotHit: {
+        const payload = event.payload as IPilotHitPayload;
+        const acc = accumulators.get(payload.unitId);
+        if (acc !== undefined) {
+          acc.pilotWounds = payload.totalWounds;
+        }
+        break;
+      }
+      default:
+        // Out-of-band event types pass through silently. The timeline
+        // scrubber still sees them; the reducer simply does not mutate
+        // the map state on them. Per the spec scope, only the eight
+        // covered families above can change `tokens` / `hexTerrain` /
+        // `mapRadius`.
+        break;
+    }
+  }
+
+  // Project accumulators to the public `IUnitToken` shape. The map's
+  // insertion order is preserved by `Array.from(map.values())`, which
+  // matches the `GameCreated.payload.units` ordering.
+  const tokens: IUnitToken[] = Array.from(accumulators.values()).map(
+    accumulatorToToken,
+  );
+
+  return {
+    tokens,
+    // Terrain reconstruction from events is out of scope for this PR
+    // (engine emits no terrain-mutation events today). HexMapDisplay's
+    // Clear-default rendering applies when `hexTerrain` is empty.
+    hexTerrain: [],
+    mapRadius,
+  };
+}
+
+// =============================================================================
+// React hook wrapper
+// =============================================================================
+
+/**
+ * React hook wrapper around `deriveHexMapStateFromEvents`. Memoizes on
+ * `[events, currentSequence]` so re-renders that do not change the
+ * cursor reuse the prior projection.
+ *
+ * @example
+ * ```tsx
+ * const { tokens, hexTerrain, mapRadius } = useHexMapStateFromEvents(
+ *   events,
+ *   replay.currentSequence,
+ * );
+ * return (
+ *   <HexMapDisplay
+ *     tokens={tokens}
+ *     hexTerrain={hexTerrain}
+ *     radius={mapRadius}
+ *     selectedHex={null}
+ *     events={events}
+ *   />
+ * );
+ * ```
+ */
+export function useHexMapStateFromEvents(
+  events: readonly IGameEvent[],
+  currentSequence: number,
+): ReplayHexMapState {
+  return useMemo(
+    () => deriveHexMapStateFromEvents(events, currentSequence),
+    [events, currentSequence],
+  );
+}

--- a/src/hooks/replay/useHexMapStateFromEvents.ts
+++ b/src/hooks/replay/useHexMapStateFromEvents.ts
@@ -51,7 +51,12 @@ import type {
   IVehicleToken,
 } from '@/types/gameplay';
 
-import { Facing, GameEventType, TokenUnitType } from '@/types/gameplay';
+import {
+  Facing,
+  GameEventType,
+  GameSide,
+  TokenUnitType,
+} from '@/types/gameplay';
 import { UnitType } from '@/types/unit/BattleMechInterfaces';
 import { ProtoChassis } from '@/types/unit/ProtoMechInterfaces';
 
@@ -313,6 +318,78 @@ export function deriveHexMapStateFromEvents(
   // ordering from `GameCreated.payload.units`.
   const accumulators = new Map<string, UnitAccumulator>();
   let mapRadius = 0;
+
+  // ---------------------------------------------------------------------------
+  // Lossy fallback for legacy NDJSON files predating
+  // `emit-game-created-from-runner` (PR #542). Per the OMO Council
+  // synthesis: the headless `SimulationRunner` did not historically emit
+  // `GameCreated`, so existing `simulation-reports/games/<ts>/*.jsonl`
+  // archives have no seed event for the reducer to consume. Without
+  // this fallback, the reducer's `tokens` array stays empty and the
+  // hex map renders nothing for those legacy files.
+  //
+  // Strategy: if no `GameCreated` event is present in the input, walk
+  // the visible-up-to-cursor slice and synthesize Mech-default
+  // accumulators for every unique `actorId` / `payload.unitId` we
+  // encounter. Names default to the id; side is derived from the id
+  // prefix (`player-` / `opponent-`); position defaults to origin and
+  // gets corrected by the first `MovementDeclared` for that unit. This
+  // is intentionally lossy — full visual fidelity comes from re-running
+  // the swarm post-#542. The fallback exists so the smoke-test fixture
+  // and any pre-fix archive remain usable.
+  // ---------------------------------------------------------------------------
+  const hasGameCreated = events.some(
+    (e) => e.type === GameEventType.GameCreated,
+  );
+  if (!hasGameCreated && events.length > 0) {
+    const discoveredUnits = new Map<string, IGameUnit>();
+    // Walk only the events at or before the cursor so backward seek
+    // doesn't manufacture units that haven't appeared yet.
+    for (const event of events) {
+      if (event.sequence > currentSequence) break;
+      const ids: string[] = [];
+      if (event.actorId !== undefined) ids.push(event.actorId);
+      const payloadUnitId = (event.payload as { unitId?: string }).unitId;
+      if (payloadUnitId !== undefined) ids.push(payloadUnitId);
+      for (const id of ids) {
+        if (discoveredUnits.has(id)) continue;
+        // Derive side from the runner's slot-id convention. Unknown
+        // prefixes (test fixtures with synthetic ids) default to
+        // Player to keep rendering deterministic.
+        const side = id.startsWith('opponent-')
+          ? GameSide.Opponent
+          : GameSide.Player;
+        discoveredUnits.set(id, {
+          id,
+          name: id,
+          side,
+          unitRef: id,
+          pilotRef: `synthetic-${id}`,
+          gunnery: 4,
+          piloting: 5,
+        });
+      }
+    }
+    // Iterate via forEach to dodge `MapIterator` downlevelIteration
+    // requirement on the project's ES5 target.
+    discoveredUnits.forEach((unit) => {
+      accumulators.set(unit.id, seedAccumulator(unit));
+    });
+    // Map radius is unrecoverable from events alone — fall back to a
+    // generous default so the map still renders. The page can override
+    // via prop if it knows the radius from another source.
+    mapRadius = 17;
+    if (typeof console !== 'undefined' && discoveredUnits.size > 0) {
+      // Single console.warn signals that this code path activated, so
+      // future regressions where #542 stops emitting GameCreated don't
+      // get masked by the fallback.
+      console.warn(
+        `[useHexMapStateFromEvents] No GameCreated event found; ` +
+          `synthesized ${discoveredUnits.size} Mech-default tokens from ` +
+          `actorIds. Re-run the swarm post-#542 for full token fidelity.`,
+      );
+    }
+  }
 
   for (const event of events) {
     if (event.sequence > currentSequence) {

--- a/src/pages/gameplay/games/[id]/replay.tsx
+++ b/src/pages/gameplay/games/[id]/replay.tsx
@@ -2,17 +2,30 @@
  * Game Replay Page
  * Replay completed games with VCR-style controls.
  *
+ * Per `add-replay-viewer-from-ndjson` (quick-session + combat-analytics
+ * deltas): in addition to the DB-event flow that loads via
+ * `useGameTimeline(gameId)`, the page now mounts a `JsonlFileLoader`
+ * drag-drop affordance that lets users open a swarm-produced
+ * `<gameId>.jsonl` event-log file from disk. When uploaded events are
+ * active, the center pane swaps the placeholder card for an actual
+ * `<HexMapDisplay>` populated by `useHexMapStateFromEvents`, and the
+ * scrubber + controls drive the upload through `useSharedReplayPlayer`.
+ *
  * @spec openspec/changes/add-audit-timeline/specs/audit-timeline/spec.md
+ * @spec openspec/changes/add-replay-viewer-from-ndjson/specs/quick-session/spec.md
+ * @spec openspec/changes/add-replay-viewer-from-ndjson/specs/combat-analytics/spec.md
  */
 
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 
+import type { IGameEvent } from '@/types/gameplay';
 import type { ReducerMap } from '@/utils/events/stateDerivation';
 
 import {
+  JsonlFileLoader,
   ReplayControls,
   ReplayTimeline,
   ReplaySpeedSelector,
@@ -25,6 +38,7 @@ import {
   ReplayLoading,
 } from '@/components/audit/replay/GameReplayPage.states';
 import { EventTimeline } from '@/components/audit/timeline';
+import { HexMapDisplay } from '@/components/gameplay/HexMapDisplay/HexMapDisplay';
 import { Card } from '@/components/ui';
 import {
   useReplayPlayer,
@@ -32,9 +46,36 @@ import {
   PLAYBACK_SPEEDS,
   formatSpeed,
 } from '@/hooks/audit';
-import { IBaseEvent } from '@/types/events';
+import {
+  useHexMapStateFromEvents,
+  useSharedReplayPlayer,
+} from '@/hooks/replay';
+import { IBaseEvent, EventCategory } from '@/types/events';
 
 type ReplayViewTab = 'timeline' | 'events';
+
+/**
+ * Adapt an `IGameEvent` (gameplay) into the `IBaseEvent` (audit) shape
+ * the existing `<ReplayEventOverlay>` and `<EventTimeline>` consume.
+ *
+ * Per the quick-session delta scope: uploaded events drive the existing
+ * UI surfaces, but those surfaces only need the audit envelope's `id`,
+ * `sequence`, `timestamp`, `type`, `payload`, and `category` fields.
+ * Synthesizing `category: EventCategory.Game` plus a thin `context: {
+ * gameId }` keeps the renderers happy without requiring schema work on
+ * either side.
+ */
+function adaptGameEventToBase(event: IGameEvent): IBaseEvent {
+  return {
+    id: event.id,
+    sequence: event.sequence,
+    timestamp: event.timestamp,
+    category: EventCategory.Game,
+    type: event.type,
+    payload: event.payload,
+    context: { gameId: event.gameId },
+  };
+}
 
 export default function GameReplayPage(): React.ReactElement {
   const router = useRouter();
@@ -45,6 +86,17 @@ export default function GameReplayPage(): React.ReactElement {
   const [showKeyboardHelp, setShowKeyboardHelp] = useState(false);
   const [activeTab, setActiveTab] = useState<ReplayViewTab>('timeline');
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
+
+  // -------------------------------------------------------------------------
+  // Upload state — when set, the page is in "upload mode": hex map drives,
+  // scrubber binds to the uploaded events via `useSharedReplayPlayer`.
+  // Per `add-replay-viewer-from-ndjson` (quick-session delta).
+  // -------------------------------------------------------------------------
+  const [uploadedEvents, setUploadedEvents] = useState<
+    readonly IGameEvent[] | null
+  >(null);
+  const [uploadedFilename, setUploadedFilename] = useState<string | null>(null);
+  const isUploadActive = uploadedEvents !== null;
 
   // Hydration fix
   useEffect(() => {
@@ -67,13 +119,88 @@ export default function GameReplayPage(): React.ReactElement {
   // Initialize replay player
   // Note: Empty reducers map - visualization only, no state derivation
   const emptyReducers: ReducerMap<Record<string, unknown>> = {};
-  const replay = useReplayPlayer<Record<string, unknown>>({
+  const dbReplay = useReplayPlayer<Record<string, unknown>>({
     gameId,
     reducers: emptyReducers,
     initialState: {},
     autoPlay: false,
     baseInterval: 1000,
   });
+
+  // Upload-mode replay player. Mounted unconditionally so the React
+  // hooks order stays stable across upload toggles. When upload is not
+  // active, it sees an empty event list and stays idle.
+  const uploadReplay = useSharedReplayPlayer({
+    gameId,
+    events: uploadedEvents ?? [],
+    autoPlay: false,
+    baseInterval: 1000,
+  });
+
+  // Active replay surface. The upload path returns `IGameEvent`-shaped
+  // currentEvent; the audit path returns `IBaseEvent`. Both expose
+  // identical scrubber / control surfaces (progress, markers,
+  // currentSequence, etc.), so a thin union projection drives the
+  // page's visual surfaces.
+  const replay = useMemo(() => {
+    if (isUploadActive) {
+      const currentBaseEvent = uploadReplay.currentEvent
+        ? adaptGameEventToBase(uploadReplay.currentEvent)
+        : null;
+      return {
+        playbackState: uploadReplay.playbackState,
+        speed: uploadReplay.speed,
+        currentSequence: uploadReplay.currentSequence,
+        currentEvent: currentBaseEvent,
+        currentIndex: uploadReplay.currentIndex,
+        totalEvents: uploadReplay.totalEvents,
+        progress: uploadReplay.progress,
+        markers: uploadReplay.markers.map((m) => ({
+          id: m.id,
+          sequence: m.sequence,
+          position: m.position,
+          type: m.type,
+          // Synthesize the audit-marker `category` field for marker-
+          // based renderers; `EventCategory.Game` is the safe default
+          // for every gameplay event.
+          category: EventCategory.Game,
+          label: m.label,
+        })),
+        play: uploadReplay.play,
+        pause: uploadReplay.pause,
+        stop: uploadReplay.stop,
+        stepForward: uploadReplay.stepForward,
+        stepBackward: uploadReplay.stepBackward,
+        jumpToIndex: uploadReplay.jumpToIndex,
+        jumpToEvent: uploadReplay.jumpToEvent,
+        setSpeed: uploadReplay.setSpeed,
+        seek: uploadReplay.seek,
+      };
+    }
+    return dbReplay;
+  }, [isUploadActive, uploadReplay, dbReplay]);
+
+  // Hex-map projection from the uploaded event log. Only meaningful in
+  // upload mode — when the upload is cleared, this returns the
+  // empty-defaults shape and the placeholder card renders instead.
+  const hexMapState = useHexMapStateFromEvents(
+    uploadedEvents ?? [],
+    replay.currentSequence,
+  );
+
+  // Status-pill summary for the JsonlFileLoader.
+  const uploadSummary = useMemo(() => {
+    if (uploadedEvents === null || uploadedEvents.length === 0) {
+      return { count: 0, minTurn: undefined, maxTurn: undefined };
+    }
+    let minTurn = uploadedEvents[0].turn;
+    let maxTurn = uploadedEvents[0].turn;
+    for (const e of uploadedEvents) {
+      if (e.turn < minTurn) minTurn = e.turn;
+      if (e.turn > maxTurn) maxTurn = e.turn;
+    }
+    return { count: uploadedEvents.length, minTurn, maxTurn };
+  }, [uploadedEvents]);
 
   // Keyboard shortcuts
   useReplayKeyboardShortcuts({
@@ -112,27 +239,53 @@ export default function GameReplayPage(): React.ReactElement {
     [replay],
   );
 
+  // JsonlFileLoader callbacks. Promote on success; clear on revert.
+  // Per `add-replay-viewer-from-ndjson` (quick-session delta).
+  const handleEventsLoaded = useCallback(
+    (events: readonly IGameEvent[], filename: string) => {
+      setUploadedEvents(events);
+      setUploadedFilename(filename);
+      setSelectedEventId(null);
+    },
+    [],
+  );
+  const handleClearUpload = useCallback(() => {
+    setUploadedEvents(null);
+    setUploadedFilename(null);
+    setSelectedEventId(null);
+  }, []);
+
   // Loading states
   if (!isClient || eventsLoading) {
     return <ReplayLoading />;
   }
 
-  // Error state
-  if (eventsError) {
+  // Error state — only when the audit-store side errors out AND no
+  // upload is active. An upload always rescues the page.
+  if (eventsError && !isUploadActive) {
     return (
       <ReplayError message={eventsError.message} gameId={gameId || undefined} />
     );
   }
 
-  // No events
-  if (allEvents.length === 0) {
+  // No events available from the audit store AND no upload — show the
+  // standard empty-state error. With an upload, fall through to the
+  // normal layout.
+  if (allEvents.length === 0 && !isUploadActive) {
     return (
       <ReplayError
-        message="No events found for this game."
+        message="No events found for this game. You can drop a swarm-produced .jsonl event-log file to load one from disk."
         gameId={gameId || undefined}
       />
     );
   }
+
+  // Active event list for the audit-side renderers (`EventTimeline`,
+  // `ReplayEventOverlay`). Uses uploaded events when active, falls back
+  // to DB events otherwise.
+  const activeEvents: readonly IBaseEvent[] = isUploadActive
+    ? (uploadedEvents ?? []).map(adaptGameEventToBase)
+    : (allEvents as IBaseEvent[]);
 
   return (
     <>
@@ -176,6 +329,14 @@ export default function GameReplayPage(): React.ReactElement {
             >
               Game Replay
             </h1>
+            {isUploadActive && (
+              <span
+                className="bg-accent/20 text-accent rounded-full px-2 py-0.5 text-xs font-medium"
+                data-testid="replay-loaded-from-file"
+              >
+                loaded from file
+              </span>
+            )}
             <span
               className="text-text-theme-muted text-sm"
               data-testid="replay-event-count"
@@ -223,8 +384,20 @@ export default function GameReplayPage(): React.ReactElement {
 
         {/* Main Content */}
         <div className="flex flex-1 overflow-hidden">
-          {/* Left Panel - Event Info */}
+          {/* Left Panel - Event Info + JSONL Loader */}
           <div className="border-border-theme-subtle bg-surface-deep w-80 flex-shrink-0 overflow-y-auto border-r">
+            {/* JSONL file loader — drag-and-drop or file picker. */}
+            <div className="border-border-theme-subtle border-b p-3">
+              <JsonlFileLoader
+                onEventsLoaded={handleEventsLoaded}
+                onClearUpload={handleClearUpload}
+                uploadedFilename={uploadedFilename}
+                eventCount={uploadSummary.count}
+                minTurn={uploadSummary.minTurn}
+                maxTurn={uploadSummary.maxTurn}
+              />
+            </div>
+
             {/* Tabs */}
             <div className="border-border-theme-subtle flex border-b">
               <button
@@ -269,10 +442,10 @@ export default function GameReplayPage(): React.ReactElement {
               ) : (
                 /* All Events List */
                 <EventTimeline
-                  events={allEvents as IBaseEvent[]}
+                  events={activeEvents}
                   onEventClick={handleEventClick}
-                  onLoadMore={loadMore}
-                  hasMore={pagination.hasMore}
+                  onLoadMore={isUploadActive ? () => {} : loadMore}
+                  hasMore={isUploadActive ? false : pagination.hasMore}
                   isLoading={eventsLoading}
                   selectedEventId={selectedEventId || replay.currentEvent?.id}
                   maxHeight="calc(100vh - 200px)"
@@ -281,61 +454,69 @@ export default function GameReplayPage(): React.ReactElement {
             </div>
           </div>
 
-          {/* Center - Game Visualization Placeholder */}
+          {/* Center - Game Visualization (HexMap when upload active, else placeholder) */}
           <div className="flex flex-1 flex-col">
-            {/* Game State Visualization Area */}
-            <div className="bg-surface-base/30 flex flex-1 items-center justify-center">
-              <Card className="max-w-lg p-8 text-center">
-                <div className="bg-surface-raised mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-2xl">
-                  <svg
-                    className="text-accent h-10 w-10"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={1.5}
-                      d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
-                    />
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={1.5}
-                      d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                    />
-                  </svg>
-                </div>
-                <h2 className="text-text-theme-primary mb-3 text-xl font-bold">
-                  Event {replay.currentIndex + 1} of {replay.totalEvents}
-                </h2>
-                {replay.currentEvent && (
-                  <div className="space-y-2 text-sm">
-                    <p className="text-text-theme-secondary">
-                      <span className="text-text-theme-muted">Type:</span>{' '}
-                      <span className="text-accent font-medium">
-                        {replay.currentEvent.type}
-                      </span>
-                    </p>
-                    <p className="text-text-theme-secondary">
-                      <span className="text-text-theme-muted">Category:</span>{' '}
-                      {replay.currentEvent.category}
-                    </p>
-                    <p className="text-text-theme-secondary">
-                      <span className="text-text-theme-muted">Sequence:</span> #
-                      {replay.currentSequence}
+            <div className="bg-surface-base/30 flex flex-1 items-center justify-center overflow-hidden">
+              {isUploadActive && hexMapState.tokens.length > 0 ? (
+                <HexMapDisplay
+                  radius={hexMapState.mapRadius > 0 ? hexMapState.mapRadius : 9}
+                  tokens={hexMapState.tokens}
+                  hexTerrain={hexMapState.hexTerrain}
+                  selectedHex={null}
+                  events={uploadedEvents ?? []}
+                />
+              ) : (
+                <Card className="max-w-lg p-8 text-center">
+                  <div className="bg-surface-raised mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-2xl">
+                    <svg
+                      className="text-accent h-10 w-10"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
+                      />
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                      />
+                    </svg>
+                  </div>
+                  <h2 className="text-text-theme-primary mb-3 text-xl font-bold">
+                    Event {replay.currentIndex + 1} of {replay.totalEvents}
+                  </h2>
+                  {replay.currentEvent && (
+                    <div className="space-y-2 text-sm">
+                      <p className="text-text-theme-secondary">
+                        <span className="text-text-theme-muted">Type:</span>{' '}
+                        <span className="text-accent font-medium">
+                          {replay.currentEvent.type}
+                        </span>
+                      </p>
+                      <p className="text-text-theme-secondary">
+                        <span className="text-text-theme-muted">Category:</span>{' '}
+                        {replay.currentEvent.category}
+                      </p>
+                      <p className="text-text-theme-secondary">
+                        <span className="text-text-theme-muted">Sequence:</span>{' '}
+                        #{replay.currentSequence}
+                      </p>
+                    </div>
+                  )}
+                  <div className="border-border-theme-subtle mt-6 border-t pt-4">
+                    <p className="text-text-theme-muted text-xs">
+                      Drop a <code>.jsonl</code> swarm event log on the left to
+                      see the battle play out on a hex map.
                     </p>
                   </div>
-                )}
-                <div className="border-border-theme-subtle mt-6 border-t pt-4">
-                  <p className="text-text-theme-muted text-xs">
-                    Full game state visualization coming soon.
-                    <br />
-                    Use the controls below to step through events.
-                  </p>
-                </div>
-              </Card>
+                </Card>
+              )}
             </div>
 
             {/* Bottom Controls */}


### PR DESCRIPTION
## Summary

Closes the on-disk → UI gap shipped by the 5-PR event-log line-format suite. Adds:

- A drag-and-drop `JsonlFileLoader` for swarm-produced `<gameId>.jsonl` files (pure client-side parse, per-line error reporting, all-or-nothing promotion).
- A pure projection hook `useHexMapStateFromEvents(events, currentSequence)` that walks the typed `IGameEvent` discriminated union and emits `<HexMapDisplay>`-ready `{ tokens, hexTerrain, mapRadius }` for the eight on-map event families.
- Replay-page wiring — when uploaded events are active, the center pane shows an actual hex map (replacing the placeholder card) and the scrubber drives via `useSharedReplayPlayer`.

## Spec

OpenSpec change: `add-replay-viewer-from-ndjson`

- `quick-session` ADD: Replay Viewer Consumes Persisted NDJSON Files (5 scenarios)
- `combat-analytics` ADD: Replay State-From-Events Reducer Contract (8 scenarios)

`npx openspec validate add-replay-viewer-from-ndjson --strict` clean.

## Test plan

- [x] typecheck clean
- [x] lint clean (43 pre-existing warnings, 0 errors)
- [x] 27 new unit tests pass (16 reducer scenarios + 11 loader scenarios; covers all 12 spec scenarios + edge cases)
- [x] full Jest suite green: 23521/23521 tests across 931 suites
- [x] `npx openspec validate add-replay-viewer-from-ndjson --strict` clean
- [ ] Manual smoke test: drag a real swarm `.jsonl` from `simulation-reports/games/2026-05-07T05-52-10-802Z/` onto the loader; verify hex map updates frame-by-frame