### PR TITLE
feat(quickgame): add hex-map replay tab to results page

### DIFF
--- a/openspec/changes/add-quickgame-replay-panel/.openspec.yaml
+++ b/openspec/changes/add-quickgame-replay-panel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/add-quickgame-replay-panel/proposal.md
+++ b/openspec/changes/add-quickgame-replay-panel/proposal.md
@@ -1,0 +1,59 @@
+# Add quick-game in-page replay panel powered by useHexMapStateFromEvents
+
+## Why
+
+PR A1 (`add-replay-viewer-from-ndjson`) shipped a drag-drop NDJSON loader + a state-from-events reducer that any consumer can mount over `<HexMapDisplay>`. PR #542 (`emit-game-created-from-runner`) made the headless runner emit `GameCreated` so the reducer's tokens always seed correctly.
+
+The quick-game flow already produces a complete `IGameEvent[]` log per encounter (stored in `useQuickGameSelector(s => s.game.events)`), and the existing `QuickGameResults.tsx` page renders four tabs (Summary / Units / Damage / Timeline). It's the natural home for an integrated replay viewer — users just finished an encounter and the events are in memory; they don't need to drag a file in.
+
+## What
+
+### `QuickGameReplayPanel.tsx` — composed replay panel for the quickgame flow
+
+New file at `src/components/quickgame/QuickGameReplayPanel.tsx`:
+
+- Accepts `events: readonly IGameEvent[]` as a prop (the host `QuickGameResults` passes `game.events` directly).
+- Mounts `useSharedReplayPlayer({ gameId, events })` for the scrubber + playback state.
+- Mounts `useHexMapStateFromEvents(events, currentSequence)` for the hex-map projection.
+- Renders the same composition as the standalone replay page, scoped to the panel:
+  - `<HexMapDisplay tokens hexTerrain radius events selectedHex={null} />` in the visible area.
+  - `<ReplayTimeline progress markers onSeek currentSequence />` below.
+  - `<ReplayControls playbackState canStepBackward canStepForward onPlay onPause onStop onStepForward onStepBackward />` at the bottom.
+
+The panel does NOT add a JsonlFileLoader — events come from the in-memory game store. There's no upload affordance because the encounter is already loaded.
+
+### `QuickGameResults` integration
+
+Modify `src/components/quickgame/QuickGameResults.tsx`:
+
+- Add a fifth tab `'replay'` to the existing `RESULTS_TABS` constant.
+- Render `<QuickGameReplayPanel events={game.events} gameId={game.id} />` inside the new tabpanel.
+- Keep all existing tabs (Summary / Units / Damage / Timeline) untouched.
+
+### Spec delta
+
+`quick-session` ADD: `Quick-Game Results Page Renders Hex-Map Replay`. Covers:
+
+- The Results page exposes a "Replay" tab.
+- The tab mounts a panel that drives the existing `<HexMapDisplay>` from `useHexMapStateFromEvents` over the in-memory `game.events`.
+- The panel reuses `useSharedReplayPlayer` for scrubber state — no separate replay state machine.
+- Switching between Replay and other tabs preserves existing page state (active tab is remembered; replay player is unmounted/remounted between toggles, which is the simpler scope choice — preserving scrubber position across tab switches is out of scope).
+
+## Impact
+
+- **Affected types**: none.
+- **Affected code**:
+  - NEW `src/components/quickgame/QuickGameReplayPanel.tsx` (~80-120 LOC)
+  - NEW `src/components/quickgame/__tests__/QuickGameReplayPanel.test.tsx` (~80-100 LOC)
+  - MODIFY `src/components/quickgame/quickGameResults.helpers.ts` — add `'replay'` to `RESULTS_TABS`
+  - MODIFY `src/components/quickgame/QuickGameResults.tsx` — add Replay tabpanel
+  - MODIFY `src/components/quickgame/index.ts` — re-export `QuickGameReplayPanel`
+- **Affected specs**: `quick-session` (ADDED — 1 requirement, 3 scenarios).
+- **Risk**: low — pure composition over already-shipped reducer + player; existing tab behavior unchanged; new tab is additive.
+
+## Out of scope
+
+- Persistence of scrubber position across tab switches (each Replay tab visit starts from sequence 0).
+- Animation interpolation between hexes (post-step states only — same as PR A1).
+- Key-moment markers on the timeline (PR A3).
+- Quick-game uses `useSharedReplayPlayer` not `useReplayPlayer`; no audit-store integration is added.

--- a/openspec/changes/add-quickgame-replay-panel/specs/quick-session/spec.md
+++ b/openspec/changes/add-quickgame-replay-panel/specs/quick-session/spec.md
@@ -1,0 +1,31 @@
+# quick-session Specification — Delta
+
+## ADDED Requirements
+
+### Requirement: Quick-Game Results Page Renders Hex-Map Replay
+
+The Quick-Game Results page SHALL expose a "Replay" tab that mounts a hex-map replay panel driven by `useHexMapStateFromEvents` over the in-memory `game.events` array, with playback driven by `useSharedReplayPlayer`.
+
+#### Scenario: Replay tab is visible alongside existing tabs
+
+- **GIVEN** a completed quick-game encounter with a populated `game.events` log
+- **WHEN** the user lands on `QuickGameResults`
+- **THEN** the tab list contains five tabs: `Summary`, `Units`, `Damage`, `Timeline`, and `Replay`
+- **AND** the `Replay` tab is keyboard-navigable via the existing `useTabKeyboardNavigation` hook
+- **AND** the four pre-existing tab panels (`Summary`/`Units`/`Damage`/`Timeline`) render unchanged when their tab is active
+
+#### Scenario: Replay panel projects hex-map state from in-memory events
+
+- **GIVEN** the user activates the `Replay` tab on a completed encounter
+- **WHEN** `QuickGameReplayPanel` mounts with `events={game.events}` and `gameId={game.id}`
+- **THEN** the panel renders `<HexMapDisplay>` with `tokens`, `hexTerrain`, `radius`, and `events` derived from `useHexMapStateFromEvents(events, currentSequence)`
+- **AND** the panel does NOT render a `JsonlFileLoader` (events come from the in-memory store, not a file upload)
+- **AND** the panel reuses the shared `<ReplayTimeline>` and `<ReplayControls>` components
+
+#### Scenario: Scrubber state is owned by useSharedReplayPlayer
+
+- **GIVEN** the `Replay` tab is active
+- **WHEN** the user clicks Play / Pause / Step / Stop or drags the timeline scrubber
+- **THEN** all playback state transitions flow through `useSharedReplayPlayer({ gameId, events })`
+- **AND** the panel does NOT instantiate a separate replay state machine
+- **AND** switching to another tab unmounts the panel; switching back remounts the panel and reinitialises the player at sequence 0 (preserving scrubber position across tab switches is explicitly out of scope)

--- a/openspec/changes/add-quickgame-replay-panel/tasks.md
+++ b/openspec/changes/add-quickgame-replay-panel/tasks.md
@@ -1,0 +1,62 @@
+# Tasks — add-quickgame-replay-panel
+
+## 1. Authoring
+
+- [x] 1.1 Author `proposal.md`
+- [x] 1.2 Author spec delta for `quick-session` (1 ADDED requirement, 3 scenarios)
+- [x] 1.3 Author `tasks.md`
+- [x] 1.4 `npx openspec validate add-quickgame-replay-panel --strict` clean
+
+## 2. Implement QuickGameReplayPanel
+
+- [x] 2.1 Create `src/components/quickgame/QuickGameReplayPanel.tsx`
+  - Props: `{ events: readonly IGameEvent[]; gameId: string }`
+  - Mount `useSharedReplayPlayer({ gameId, events })` for scrubber/playback
+  - Mount `useHexMapStateFromEvents(events, currentSequence)` for hex-map projection
+  - Render `<HexMapDisplay>` (visible area), `<ReplayTimeline>` (below), `<ReplayControls>` (bottom)
+  - Empty-events guard: render a friendly placeholder when `events.length === 0`
+  - NO `JsonlFileLoader` — events are in-memory only
+
+## 3. Wire QuickGameResults integration
+
+- [x] 3.1 Modify `src/components/quickgame/quickGameResults.helpers.ts`
+  - Extend `ResultsTab` union with `'replay'`
+  - Append `{ id: 'replay', label: 'Replay' }` to `RESULTS_TABS`
+- [x] 3.2 Modify `src/components/quickgame/QuickGameResults.tsx`
+  - Add fifth `<div role="tabpanel" id="tabpanel-replay" ...>` block
+  - Render `<QuickGameReplayPanel events={game.events} gameId={game.id} />` inside (conditionally — panel mounts only when active to keep replay state derivation off the critical path of the four other tabs, per spec scenario "panel is unmounted/remounted between tab toggles")
+  - Existing four tabpanels remain untouched
+- [x] 3.3 Modify `src/components/quickgame/index.ts`
+  - Re-export `QuickGameReplayPanel`
+
+## 4. Tests
+
+- [x] 4.1 Create `src/components/quickgame/__tests__/QuickGameReplayPanel.test.tsx`
+  - Empty-events guard test (placeholder renders, no HexMapDisplay)
+  - Hex-map projection test (HexMapDisplay mounts with 2 tokens, radius 17)
+  - Transport controls test (Play/Step Forward/Step Backward render)
+  - Step-forward advances playback test
+- [x] 4.2 Update `src/components/quickgame/__tests__/QuickGameResults.test.tsx`
+  - Tab count assertion: 4 → 5 tabs (now includes Replay)
+  - Wrap-from-last test: Timeline → Replay (new last tab)
+  - Mock fixture: add minimal payloads to GameStarted/UnitDestroyed/GameEnded so reducer walk doesn't throw when Replay tab mounts
+
+## 5. Verification
+
+- [x] 5.1 `npx tsc --noEmit` clean
+- [x] 5.2 `npx oxlint src/components/quickgame/ src/hooks/replay/` — no new errors (1 pre-existing console.warn from #541's lossy-fallback)
+- [x] 5.3 `npx jest --testPathPattern="QuickGameReplayPanel|QuickGameResults"` — 25/25 green
+- [x] 5.4 `npx openspec validate add-quickgame-replay-panel --strict` clean
+
+## 6. PR
+
+- [ ] 6.1 Commit (`feat(quickgame): add hex-map replay tab to results page`)
+- [ ] 6.2 Push branch `replay-viewer/pr-a2-quickgame-panel`
+- [ ] 6.3 Open PR targeting `main`
+- [ ] 6.4 Wait for CI green
+- [ ] 6.5 Merge (squash, delete branch)
+
+## 7. Archive
+
+- [ ] 7.1 `openspec archive add-quickgame-replay-panel`
+- [ ] 7.2 Verify `quick-session` source-of-truth spec absorbed the new requirement

--- a/src/components/quickgame/QuickGameReplayPanel.tsx
+++ b/src/components/quickgame/QuickGameReplayPanel.tsx
@@ -1,0 +1,182 @@
+/**
+ * Quick Game Replay Panel
+ *
+ * Composed replay panel for the quick-game results page. Drives the
+ * existing `<HexMapDisplay>` from `useHexMapStateFromEvents` over the
+ * in-memory `game.events` log, with playback state owned by
+ * `useSharedReplayPlayer`.
+ *
+ * Per `add-quickgame-replay-panel/proposal.md`. The standalone replay
+ * page (`src/pages/gameplay/games/[id]/replay.tsx`) keeps the file-upload
+ * affordance for off-disk NDJSON; this panel deliberately does NOT mount
+ * `<JsonlFileLoader>` because the encounter is already loaded.
+ *
+ * @spec openspec/changes/add-quickgame-replay-panel/proposal.md
+ */
+
+import React, { useMemo } from 'react';
+
+import { ReplayControls, ReplayTimeline } from '@/components/audit/replay';
+import { HexMapDisplay } from '@/components/gameplay/HexMapDisplay/HexMapDisplay';
+import { Card } from '@/components/ui';
+import {
+  formatSpeed,
+  type IEventMarker as IAuditEventMarker,
+} from '@/hooks/audit';
+import {
+  useHexMapStateFromEvents,
+  useSharedReplayPlayer,
+} from '@/hooks/replay';
+import { EventCategory } from '@/types/events';
+import { IGameEvent } from '@/types/gameplay';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface IQuickGameReplayPanelProps {
+  /** Game ID — passed through to `useSharedReplayPlayer`. */
+  readonly gameId: string;
+  /** In-memory game event log (typically `game.events`). */
+  readonly events: readonly IGameEvent[];
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Renders the in-page replay viewer for a completed quick-game.
+ *
+ * Composition:
+ * - `useSharedReplayPlayer({ gameId, events })` owns scrubber + playback
+ *   state. The panel never instantiates a separate replay state machine
+ *   (per spec scenario "Scrubber state is owned by useSharedReplayPlayer").
+ * - `useHexMapStateFromEvents(events, currentSequence)` projects the
+ *   event log up to the current scrubber position into hex-map tokens +
+ *   terrain.
+ * - `<HexMapDisplay>` renders the projected state. `<ReplayTimeline>`
+ *   exposes scrubber + markers; `<ReplayControls>` exposes
+ *   play/pause/stop/step.
+ *
+ * Empty-events guard: when `events.length === 0` (the encounter ended
+ * without persisting an event log) the panel renders a friendly
+ * placeholder instead of mounting the player.
+ */
+export function QuickGameReplayPanel({
+  gameId,
+  events,
+}: IQuickGameReplayPanelProps): React.ReactElement {
+  const replay = useSharedReplayPlayer({ gameId, events });
+
+  // Pure projection — re-derives on every `currentSequence` tick. The
+  // hook is memoized internally so the projection only re-walks the
+  // event log when `currentSequence` actually changes.
+  const hexMapState = useHexMapStateFromEvents(events, replay.currentSequence);
+
+  // Adapt the shared player's `IEventMarker` (from `@/hooks/replay`)
+  // into the audit `IEventMarker` shape that `<ReplayTimeline>` consumes.
+  // The two shapes only differ by the `category` field, which the
+  // gameplay-event marker doesn't carry — synthesizing
+  // `EventCategory.Game` keeps the marker renderer happy for every
+  // gameplay event. Mirrors the adapter in `src/pages/gameplay/games/[id]/replay.tsx`.
+  const adaptedMarkers = useMemo<readonly IAuditEventMarker[]>(
+    () =>
+      replay.markers.map((m) => ({
+        id: m.id,
+        sequence: m.sequence,
+        position: m.position,
+        type: m.type,
+        category: EventCategory.Game,
+        label: m.label,
+      })),
+    [replay.markers],
+  );
+
+  // Empty-events guard. Rendered before the player UI because there's
+  // nothing useful to show when the log is empty.
+  if (events.length === 0) {
+    return (
+      <Card className="m-4 p-8 text-center">
+        <p className="text-text-theme-secondary">
+          No events were recorded for this encounter.
+        </p>
+        <p className="text-text-theme-muted mt-2 text-xs">
+          Replay is unavailable.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col" data-testid="quickgame-replay-panel">
+      {/* Hex-map area — fills available vertical space; falls back to a
+          minimum height so it stays visible inside the tabpanel even if
+          the panel sits in a flow-layout parent. */}
+      <div className="bg-surface-base/30 flex min-h-[480px] flex-1 items-center justify-center overflow-hidden">
+        {hexMapState.tokens.length > 0 ? (
+          <HexMapDisplay
+            radius={hexMapState.mapRadius > 0 ? hexMapState.mapRadius : 9}
+            tokens={hexMapState.tokens}
+            hexTerrain={hexMapState.hexTerrain}
+            selectedHex={null}
+            events={events}
+          />
+        ) : (
+          <div className="p-6 text-center">
+            <p className="text-text-theme-secondary">
+              Waiting for unit roster…
+            </p>
+            <p className="text-text-theme-muted mt-2 text-xs">
+              Step forward to load the first frame.
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Bottom controls — timeline above, transport buttons below. */}
+      <div className="bg-surface-base border-border-theme-subtle flex-shrink-0 border-t p-4">
+        <div className="mb-4">
+          <ReplayTimeline
+            progress={replay.progress}
+            markers={adaptedMarkers}
+            onSeek={replay.seek}
+            currentSequence={replay.currentSequence}
+          />
+        </div>
+
+        <div className="flex items-center justify-center">
+          <ReplayControls
+            playbackState={replay.playbackState}
+            canStepBackward={replay.currentIndex > 0}
+            canStepForward={replay.currentIndex < replay.totalEvents - 1}
+            onPlay={replay.play}
+            onPause={replay.pause}
+            onStop={replay.stop}
+            onStepForward={replay.stepForward}
+            onStepBackward={replay.stepBackward}
+          />
+        </div>
+
+        <div className="text-text-theme-muted mt-3 text-center text-sm">
+          {replay.playbackState === 'playing' && (
+            <span className="text-emerald-400">
+              Playing at {formatSpeed(replay.speed)}
+            </span>
+          )}
+          {replay.playbackState === 'paused' && (
+            <span className="text-amber-400">Paused</span>
+          )}
+          {replay.playbackState === 'stopped' && (
+            <span>
+              Event {replay.currentIndex + 1} of {replay.totalEvents} — Press
+              Play to start
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default QuickGameReplayPanel;

--- a/src/components/quickgame/QuickGameResults.tsx
+++ b/src/components/quickgame/QuickGameResults.tsx
@@ -28,6 +28,7 @@ import { GameSide } from '@/types/gameplay';
 import type { ResultsTab } from './quickGameResults.helpers';
 
 import { DamageMatrix } from './DamageMatrix';
+import { QuickGameReplayPanel } from './QuickGameReplayPanel';
 import { RESULTS_TABS } from './quickGameResults.helpers';
 import {
   ResultBanner,
@@ -289,6 +290,25 @@ export function QuickGameResults(): React.ReactElement {
                 <TimelineEventRow key={event.id} event={event} index={index} />
               ))}
             </div>
+          )}
+        </div>
+
+        <div
+          role="tabpanel"
+          id="tabpanel-replay"
+          aria-labelledby="tab-replay"
+          hidden={activeTab !== 'replay'}
+        >
+          {/*
+           * Per `add-quickgame-replay-panel/specs/quick-session/spec.md`
+           * scenario 3: the panel is unmounted/remounted between tab
+           * toggles (preserving scrubber position across tab switches
+           * is explicitly out of scope). Conditional render also keeps
+           * the heavy `useSharedReplayPlayer` state-derivation walk off
+           * the critical path for users who never open the Replay tab.
+           */}
+          {activeTab === 'replay' && (
+            <QuickGameReplayPanel events={game.events} gameId={game.id} />
           )}
         </div>
       </Card>

--- a/src/components/quickgame/__tests__/QuickGameReplayPanel.test.tsx
+++ b/src/components/quickgame/__tests__/QuickGameReplayPanel.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * QuickGameReplayPanel — render tests covering the 3 spec scenarios
+ * from `add-quickgame-replay-panel` (quick-session delta —
+ * "Quick-Game Results Page Renders Hex-Map Replay"):
+ *
+ * 1. Replay tab is visible alongside existing tabs (covered indirectly
+ *    via QuickGameResults.test.tsx — this file proves the panel itself
+ *    renders).
+ * 2. Replay panel projects hex-map state from in-memory events
+ *    (`<HexMapDisplay>` mounts with non-empty token set).
+ * 3. Scrubber state is owned by useSharedReplayPlayer (transport
+ *    controls render and respond to clicks via the hook's actions).
+ *
+ * Plus an empty-events guard.
+ *
+ * @spec openspec/changes/add-quickgame-replay-panel/specs/quick-session/spec.md
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import '@testing-library/jest-dom';
+import {
+  Facing,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IGameCreatedPayload,
+  IGameEvent,
+  IGameUnit,
+  IMovementDeclaredPayload,
+  MovementType,
+} from '@/types/gameplay';
+
+import { QuickGameReplayPanel } from '../QuickGameReplayPanel';
+
+// =============================================================================
+// Mock the heavy HexMapDisplay component so the test stays fast and
+// asserts only the wiring contract — that QuickGameReplayPanel passes a
+// non-empty token set + hex terrain + radius into the map.
+// =============================================================================
+
+jest.mock('@/components/gameplay/HexMapDisplay/HexMapDisplay', () => ({
+  HexMapDisplay: ({
+    radius,
+    tokens,
+  }: {
+    radius: number;
+    tokens: readonly { unitId: string }[];
+  }) => (
+    <div
+      data-testid="hex-map-display-mock"
+      data-radius={radius}
+      data-token-count={tokens.length}
+    >
+      {tokens.map((t) => (
+        <span key={t.unitId} data-testid={`token-${t.unitId}`} />
+      ))}
+    </div>
+  ),
+}));
+
+// =============================================================================
+// Fixture helpers
+// =============================================================================
+
+function makeUnit(
+  overrides: Partial<IGameUnit> & Pick<IGameUnit, 'id' | 'name' | 'side'>,
+): IGameUnit {
+  return {
+    unitRef: 'atlas-as7-d',
+    pilotRef: 'pilot-1',
+    gunnery: 4,
+    piloting: 5,
+    ...overrides,
+  };
+}
+
+function makeEvent(
+  overrides: Partial<IGameEvent> &
+    Pick<IGameEvent, 'type' | 'payload' | 'sequence'>,
+): IGameEvent {
+  return {
+    id: `evt-${overrides.sequence}`,
+    gameId: 'test-game',
+    timestamp: '2026-05-07T00:00:00.000Z',
+    turn: 1,
+    phase: GamePhase.Movement,
+    side: GameSide.Player,
+    ...overrides,
+  };
+}
+
+function makeStandardEvents(): readonly IGameEvent[] {
+  const gameCreated: IGameCreatedPayload = {
+    config: {
+      mapRadius: 17,
+      turnLimit: 0,
+      victoryConditions: ['destruction'],
+      optionalRules: [],
+    },
+    units: [
+      makeUnit({ id: 'player-1', name: 'Atlas AS7-D', side: GameSide.Player }),
+      makeUnit({
+        id: 'opponent-1',
+        name: 'Stalker STK-3F',
+        side: GameSide.Opponent,
+      }),
+    ],
+  };
+  const move1: IMovementDeclaredPayload = {
+    unitId: 'player-1',
+    movementType: MovementType.Walk,
+    from: { q: 0, r: 0 },
+    to: { q: 1, r: 0 },
+    facing: Facing.North,
+    mpUsed: 1,
+    heatGenerated: 1,
+    path: [
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+    ],
+  };
+  return [
+    makeEvent({
+      sequence: 0,
+      type: GameEventType.GameCreated,
+      payload: gameCreated,
+      phase: GamePhase.Initiative,
+    }),
+    makeEvent({
+      sequence: 1,
+      type: GameEventType.MovementDeclared,
+      payload: move1,
+      actorId: 'player-1',
+    }),
+  ];
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('QuickGameReplayPanel', () => {
+  describe('Empty-events guard', () => {
+    it('renders the placeholder when events.length === 0', () => {
+      render(<QuickGameReplayPanel events={[]} gameId="g-empty" />);
+
+      expect(screen.getByText(/no events were recorded/i)).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('hex-map-display-mock'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Hex-map projection', () => {
+    it('mounts HexMapDisplay with tokens projected from useHexMapStateFromEvents', () => {
+      const events = makeStandardEvents();
+      render(<QuickGameReplayPanel events={events} gameId="g-1" />);
+
+      const map = screen.getByTestId('hex-map-display-mock');
+      expect(map).toBeInTheDocument();
+      // GameCreated seeds 2 tokens (player-1 + opponent-1).
+      expect(map).toHaveAttribute('data-token-count', '2');
+      expect(screen.getByTestId('token-player-1')).toBeInTheDocument();
+      expect(screen.getByTestId('token-opponent-1')).toBeInTheDocument();
+      // mapRadius from GameCreated payload.
+      expect(map).toHaveAttribute('data-radius', '17');
+    });
+  });
+
+  describe('Scrubber state owned by useSharedReplayPlayer', () => {
+    it('renders the transport controls (play / step) sourced from the shared player hook', () => {
+      const events = makeStandardEvents();
+      render(<QuickGameReplayPanel events={events} gameId="g-1" />);
+
+      // The shared ReplayControls component renders title-bearing
+      // buttons. Their presence confirms the panel composed
+      // useSharedReplayPlayer's actions correctly.
+      expect(screen.getByRole('button', { name: /play/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /step forward/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /step backward/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('clicking step forward advances playback (no separate state machine)', async () => {
+      const user = userEvent.setup();
+      const events = makeStandardEvents();
+      render(<QuickGameReplayPanel events={events} gameId="g-1" />);
+
+      // Initial state: stopped — "Press Play to start" copy.
+      expect(screen.getByText(/press play to start/i)).toBeInTheDocument();
+
+      const stepForward = screen.getByRole('button', { name: /step forward/i });
+      await user.click(stepForward);
+
+      // After a single step the panel is no longer at the start; the
+      // step-backward button should now be enabled (not disabled).
+      const stepBackward = screen.getByRole('button', {
+        name: /step backward/i,
+      });
+      expect(stepBackward).not.toBeDisabled();
+    });
+  });
+});

--- a/src/components/quickgame/__tests__/QuickGameResults.test.tsx
+++ b/src/components/quickgame/__tests__/QuickGameResults.test.tsx
@@ -112,6 +112,11 @@ function createMockGame() {
         phase: GamePhase.Initiative,
         sequence: 1,
         timestamp: '2025-01-01T00:00:00Z',
+        // Replay tab mounts useSharedReplayPlayer which calls
+        // `applyGameStarted(payload.firstSide)` — supply a minimal
+        // payload so the reducer walk doesn't throw when the user
+        // navigates to the Replay tab.
+        payload: { firstSide: 'player' },
       },
       {
         id: 'event-2',
@@ -123,6 +128,7 @@ function createMockGame() {
         sequence: 2,
         timestamp: '2025-01-01T00:05:00Z',
         actorId: 'unit-1',
+        payload: { unitId: 'unit-1', reason: 'destroyed' },
       },
       {
         id: 'event-3',
@@ -133,6 +139,7 @@ function createMockGame() {
         phase: GamePhase.End,
         sequence: 3,
         timestamp: '2025-01-01T00:10:00Z',
+        payload: { winner: 'player', reason: 'all_enemies_destroyed' },
       },
     ],
     winner: 'player' as const,
@@ -163,13 +170,14 @@ describe('QuickGameResults', () => {
   });
 
   describe('Tab Navigation', () => {
-    it('renders all four tabs', () => {
+    it('renders all five tabs', () => {
       render(<QuickGameResults />);
 
       expect(screen.getByRole('tab', { name: 'Summary' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Units' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Damage' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Timeline' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Replay' })).toBeInTheDocument();
     });
 
     it('starts with Summary tab selected', () => {
@@ -238,8 +246,8 @@ describe('QuickGameResults', () => {
       const user = userEvent.setup();
       render(<QuickGameResults />);
 
-      const timelineTab = screen.getByRole('tab', { name: 'Timeline' });
-      await user.click(timelineTab);
+      const replayTab = screen.getByRole('tab', { name: 'Replay' });
+      await user.click(replayTab);
 
       await user.keyboard('{ArrowRight}');
 

--- a/src/components/quickgame/index.ts
+++ b/src/components/quickgame/index.ts
@@ -8,3 +8,5 @@ export { QuickGameReview } from './QuickGameReview';
 export { QuickGamePlay } from './QuickGamePlay';
 export { QuickGameResults } from './QuickGameResults';
 export { QuickGameTimeline } from './QuickGameTimeline';
+export { QuickGameReplayPanel } from './QuickGameReplayPanel';
+export type { IQuickGameReplayPanelProps } from './QuickGameReplayPanel';

--- a/src/components/quickgame/quickGameResults.helpers.ts
+++ b/src/components/quickgame/quickGameResults.helpers.ts
@@ -5,13 +5,14 @@
 
 import { GameEventType, GamePhase } from '@/types/gameplay';
 
-export type ResultsTab = 'summary' | 'units' | 'damage' | 'timeline';
+export type ResultsTab = 'summary' | 'units' | 'damage' | 'timeline' | 'replay';
 
 export const RESULTS_TABS: readonly { id: ResultsTab; label: string }[] = [
   { id: 'summary', label: 'Summary' },
   { id: 'units', label: 'Units' },
   { id: 'damage', label: 'Damage' },
   { id: 'timeline', label: 'Timeline' },
+  { id: 'replay', label: 'Replay' },
 ];
 
 export const EVENT_LABELS: Partial<Record<GameEventType, string>> = {


### PR DESCRIPTION
## Summary

Adds a fifth **Replay** tab to `QuickGameResults` that mounts an in-page hex-map replay panel driven by `useHexMapStateFromEvents` over the in-memory `game.events` log. Playback state is owned by `useSharedReplayPlayer` — no separate state machine.

PR A2 of the **Replay Viewer Bundle** (A1 #541 → A2 [this] → A3).

## What

- **NEW** `src/components/quickgame/QuickGameReplayPanel.tsx` — composes `useSharedReplayPlayer` + `useHexMapStateFromEvents` + `<HexMapDisplay>` + `<ReplayTimeline>` + `<ReplayControls>`.
- **MODIFY** `quickGameResults.helpers.ts` — extends `ResultsTab` union and `RESULTS_TABS` array with `'replay'`.
- **MODIFY** `QuickGameResults.tsx` — renders a fifth tabpanel; conditionally mounts the panel only when active.
- **MODIFY** `index.ts` — re-exports `QuickGameReplayPanel` + props type.

Unlike the standalone replay page, this panel does **NOT** mount `<JsonlFileLoader>` because the encounter is already loaded.

## Spec delta

`quick-session` ADD requirement **Quick-Game Results Page Renders Hex-Map Replay** — 3 scenarios (tab visible, panel projects state, scrubber owned by useSharedReplayPlayer). Strict-validated.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx oxlint` clean (1 pre-existing console.warn from #541's lossy-fallback, unrelated)
- [x] `npx jest --testPathPattern="QuickGameReplayPanel|QuickGameResults"` — **25 / 25** green
- [x] `npx openspec validate add-quickgame-replay-panel --strict` clean
- [ ] Manual: complete a quick-game encounter, click **Replay** tab, scrub through events end-to-end