### PR TITLE
feat(replay): add timeline markers + ComponentDestroyed armorPipState arm

### DIFF
--- a/openspec/changes/add-replay-timeline-markers/.openspec.yaml
+++ b/openspec/changes/add-replay-timeline-markers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/add-replay-timeline-markers/proposal.md
+++ b/openspec/changes/add-replay-timeline-markers/proposal.md
@@ -1,0 +1,86 @@
+# Add timeline key-moment markers + ComponentDestroyed reducer arm
+
+## Why
+
+The Replay Viewer Bundle's PR A1 (`add-replay-viewer-from-ndjson`) shipped a hex-map state-from-events reducer covering eight event families. PR A2 (`add-quickgame-replay-panel`) wired the panel into the quick-game results page. Two threads remain to close the bundle:
+
+1. **Timeline visual aids.** The `<ReplayTimeline>` today renders one colored marker per event using only the audit-style `EventCategory` palette — every gameplay event collapses to the same amber color. A 1000-event swarm replay is unreadable: the user can't visually find the kills, crits, or pilot hits without scrubbing event-by-event. Phase boundaries are also invisible, so locating "turn 7 weapon-attack phase" requires reading every event label.
+
+2. **Damage rendering on the hex map.** The Council's Phase-3 follow-on (2026-05-07) found that `ComponentDestroyed` + `CriticalHitResolved` are the **only** reducer-expansion candidates that pass all three Oracle gates: (a) the runner emits these events today, (b) the consumer field exists on the token (`IMechToken.armorPipState` per `UnitSpriteTypes.ts:122`), AND (c) the reducer transformation is mechanical. Wiring this arm makes the hex-map replay show real damage progression instead of every mech rendering as fresh-off-the-lot until it's fully destroyed.
+
+PR A3 closes both threads in one change.
+
+## What
+
+### Thread 1 — Timeline marker overlays
+
+NEW component `src/components/audit/replay/KeyMomentMarkers.tsx`:
+
+- Overlay rendered above the existing `<ReplayTimeline>` track.
+- Slices key-moment events from the timeline's event log via `EventLogQuery.from(events).ofType(X)` (per the just-shipped PR D from the line-format suite).
+- Renders colored badges at marker `position` (0–1) per event type:
+  - `UnitDestroyed` → red
+  - `CriticalHit` / `CriticalHitResolved` → orange
+  - `AmmoExplosion` → purple
+  - `PilotHit` → yellow
+  - `UnitFell` → gray
+- Click → seek to the event's `sequence` via the parent's `onSeek` callback.
+
+NEW component `src/components/audit/replay/PhaseChangeMarkers.tsx`:
+
+- Dotted vertical lines at every `TurnStarted` and `PhaseChanged` event position.
+- Reads `event.turn` + `event.phase` from the envelope (already shipped via PR B of the line-format suite).
+- Tooltip on hover: "Turn 7 — Weapon Attack".
+
+MODIFY `src/components/audit/replay/ReplayTimeline.tsx`:
+
+- Accept two optional new props: `keyMoments?: readonly IGameEvent[]` and `phaseChanges?: readonly IGameEvent[]`.
+- When provided, compose `<KeyMomentMarkers>` and `<PhaseChangeMarkers>` overlays on top of the existing track.
+- When omitted, the timeline renders unchanged (preserves audit-store consumers that don't have gameplay events).
+
+### Thread 2 — `ComponentDestroyed` + `CriticalHitResolved` reducer arm
+
+MODIFY `src/hooks/replay/useHexMapStateFromEvents.ts`:
+
+- Extend the reducer's covered event-families table with two new entries:
+  - `ComponentDestroyed` → If unit is a Mech, populate `IMechToken.armorPipState`. Compute archetype (`humanoid` / `quad` / `lam` from the unit's `unitType` / `isQuad` / `isLAM` flags). Initialize the `locations` map to `'full'` for all `BipedPipLocation`s (or `QuadPipLocation`s) on first damage, then transition the affected location:
+    - `armor: full → partial` on first damage event
+    - `armor: partial → structure` when armor reaches 0 (proxy: location appears on `damagedLocations` AND payload's `componentType` is internal — `engine`, `gyro`, `weapon`, `actuator`, `heat_sink`, `cockpit`, `sensor`, `life_support`, `jump_jet`, `ammo`)
+    - `structure → destroyed` when `LocationDestroyed` already fired on this location (cross-references the existing per-unit damage map)
+  - `CriticalHitResolved` → Same transition logic; covers the new (P4) emitter path while `ComponentDestroyed` covers the legacy (Phase-3) path.
+- Per-unit damage map already exists in the accumulator (per PR A1 design); this PR threads it into the public `armorPipState` field on the projected token.
+- Non-Mech tokens (Vehicles, Aerospace, BattleArmor, Infantry, ProtoMech) SHALL pass `ComponentDestroyed` events through silently — `armorPipState` is Mech-only per `IMechToken`.
+
+### Spec deltas
+
+`combat-analytics` MODIFIED:
+
+1. **Replay State-From-Events Reducer Contract** — extends the covered-event-families table with `ComponentDestroyed` and `CriticalHitResolved` rows; documents the `armorPipState` projection for Mech tokens.
+
+`combat-analytics` ADDED:
+
+2. **Replay Timeline Key-Moment Markers Contract** — describes the new marker overlays, click-to-seek, and the optional-prop opt-in for the existing `<ReplayTimeline>`.
+
+## Impact
+
+- **Affected types**: none (`IMechToken.armorPipState` and `ArmorPipState` already exist; `ComponentDestroyed` + `CriticalHitResolved` payloads already exist).
+- **Affected code**:
+  - NEW `src/components/audit/replay/KeyMomentMarkers.tsx` (~80-120 LOC)
+  - NEW `src/components/audit/replay/PhaseChangeMarkers.tsx` (~60-80 LOC)
+  - NEW `src/components/audit/replay/__tests__/KeyMomentMarkers.test.tsx` (~80 LOC)
+  - NEW `src/components/audit/replay/__tests__/PhaseChangeMarkers.test.tsx` (~60 LOC)
+  - MODIFY `src/components/audit/replay/ReplayTimeline.tsx` — add optional `keyMoments` / `phaseChanges` props and compose overlays when present
+  - MODIFY `src/components/audit/replay/index.ts` — re-export new components
+  - MODIFY `src/hooks/replay/useHexMapStateFromEvents.ts` — add `ComponentDestroyed` + `CriticalHitResolved` reducer arms; extend Mech token projection with `armorPipState`
+  - MODIFY `src/hooks/replay/__tests__/useHexMapStateFromEvents.test.ts` — add coverage for the new reducer arms
+  - MODIFY `src/pages/gameplay/games/[id]/replay.tsx` — pass `keyMoments` + `phaseChanges` from the uploaded events into the timeline
+  - MODIFY `src/components/quickgame/QuickGameReplayPanel.tsx` — same pass-through for the in-page panel
+- **Affected specs**: `combat-analytics` (1 MODIFIED, 1 ADDED requirement).
+- **Risk**: low-medium. Pure projection extension on the reducer side; pure overlay composition on the UI side. The new ReplayTimeline props are optional, so existing audit-store consumers are unaffected.
+
+## Out of scope
+
+- Animation interpolation between hex steps (still post-step states only — same as A1).
+- Other reducer expansions deferred per Council #3 — `UnitRetreated`, `TrooperKilled`, `MotiveDamaged`, pilot-wound rendering. Each fails one of the three gates today.
+- Vehicle / Aerospace damage projection (no `armorPipState` field on those tokens; future work).
+- Marker virtualization for >5000-event logs (current naive render fine up to ~2000 events).

--- a/openspec/changes/add-replay-timeline-markers/specs/combat-analytics/spec.md
+++ b/openspec/changes/add-replay-timeline-markers/specs/combat-analytics/spec.md
@@ -1,0 +1,155 @@
+# combat-analytics Specification — Delta
+
+## ADDED Requirements
+
+### Requirement: Replay Timeline Key-Moment Markers Contract
+
+The application SHALL ship two timeline overlay components — `KeyMomentMarkers` and `PhaseChangeMarkers` — that render on top of the existing `<ReplayTimeline>` track to surface high-value events at a glance and let the user click-to-seek to those events.
+
+`KeyMomentMarkers` (`src/components/audit/replay/KeyMomentMarkers.tsx`) SHALL:
+
+- Accept props `{ events: readonly IGameEvent[]; minSequence: number; maxSequence: number; onSeek: (progress: number) => void }`.
+- Filter the event log via `EventLogQuery.from(events)` for the five key-moment types and render one colored badge per match at the timeline-relative position `(event.sequence - minSequence) / (maxSequence - minSequence)`:
+  - `UnitDestroyed` → red badge
+  - `CriticalHit` and `CriticalHitResolved` → orange badge
+  - `AmmoExplosion` → purple badge
+  - `PilotHit` → yellow badge
+  - `UnitFell` → gray badge
+- On badge click, invoke `onSeek(position)` with the badge's relative position so the parent scrubber jumps to that event's `sequence`.
+- Render NOTHING when `events.length === 0` or no event matches the five key-moment types.
+
+`PhaseChangeMarkers` (`src/components/audit/replay/PhaseChangeMarkers.tsx`) SHALL:
+
+- Accept the same prop shape as `KeyMomentMarkers`.
+- Render dotted vertical lines at every `TurnStarted` and `PhaseChanged` event's relative position.
+- On hover, render a tooltip displaying `Turn ${event.turn} — ${formattedPhase}` (e.g. "Turn 7 — Weapon Attack"), using a human-readable phase label derived from the `GamePhase` enum.
+- Render NOTHING when no events match.
+
+`<ReplayTimeline>` (`src/components/audit/replay/ReplayTimeline.tsx`) SHALL accept two optional new props:
+
+```ts
+interface ReplayTimelineProps {
+  // ... existing props ...
+  /**
+   * Gameplay event log used to derive key-moment + phase-change overlays.
+   * When omitted, no overlays render (existing audit-store consumers are unaffected).
+   */
+  keyMoments?: readonly IGameEvent[];
+  phaseChanges?: readonly IGameEvent[];
+}
+```
+
+When `keyMoments` is provided, `<ReplayTimeline>` SHALL render `<KeyMomentMarkers>` as an overlay above the track. When `phaseChanges` is provided, it SHALL render `<PhaseChangeMarkers>` as an overlay above the track. Both overlays SHALL forward `onSeek` from the timeline's existing seek callback so badge clicks scrub the player.
+
+#### Scenario: Key-moment markers render at the correct positions
+
+- **GIVEN** an event log with one `UnitDestroyed` at sequence 50, one `CriticalHit` at sequence 100, and `minSequence: 0, maxSequence: 200`
+- **WHEN** `<KeyMomentMarkers events={log} minSequence={0} maxSequence={200} onSeek={seek}>` mounts
+- **THEN** two badges render
+- **AND** the `UnitDestroyed` badge sits at left: 25% (50/200)
+- **AND** the `CriticalHit` badge sits at left: 50% (100/200)
+- **AND** the `UnitDestroyed` badge has the red color class
+- **AND** the `CriticalHit` badge has the orange color class
+
+#### Scenario: Clicking a key-moment badge seeks the timeline
+
+- **GIVEN** a `<KeyMomentMarkers>` rendered with one `UnitDestroyed` at sequence 50 in a [0, 200] range
+- **WHEN** the user clicks the badge
+- **THEN** `onSeek(0.25)` is called exactly once
+
+#### Scenario: Phase-change markers render at every TurnStarted and PhaseChanged
+
+- **GIVEN** an event log containing `TurnStarted` at sequences 10, 30, 50 and `PhaseChanged` at sequences 15, 35, 55
+- **WHEN** `<PhaseChangeMarkers>` mounts
+- **THEN** six dotted vertical lines render
+- **AND** hovering each line reveals a tooltip with `Turn N — <phase>`
+
+#### Scenario: ReplayTimeline composes overlays only when the optional props are set
+
+- **GIVEN** a `<ReplayTimeline>` rendered without the `keyMoments` or `phaseChanges` props
+- **WHEN** the timeline mounts
+- **THEN** neither `<KeyMomentMarkers>` nor `<PhaseChangeMarkers>` renders
+- **AND** the existing audit-style markers prop continues to render unchanged
+
+#### Scenario: Empty event log renders no marker overlays
+
+- **GIVEN** `<KeyMomentMarkers events={[]} ...>` and `<PhaseChangeMarkers events={[]} ...>`
+- **WHEN** the components mount
+- **THEN** both render an empty fragment (no badges, no lines)
+
+## MODIFIED Requirements
+
+### Requirement: Replay State-From-Events Reducer Contract
+
+The application SHALL ship a pure projection hook at `src/hooks/replay/useHexMapStateFromEvents.ts` that consumes `events: readonly IGameEvent[]` plus a `currentSequence: number` cursor and returns `{ tokens, hexTerrain, mapRadius }` ready for `<HexMapDisplay>` rendering. The hook SHALL have NO I/O, NO side effects, and NO React refs — it is a memoized projection over its inputs.
+
+```ts
+export interface ReplayHexMapState {
+  readonly tokens: readonly IUnitToken[];
+  readonly hexTerrain: readonly IHexTerrain[];
+  readonly mapRadius: number;
+}
+
+export function useHexMapStateFromEvents(
+  events: readonly IGameEvent[],
+  currentSequence: number,
+): ReplayHexMapState;
+```
+
+The reducer SHALL walk events in monotonic `sequence` order from the start of the array up to and including the highest event whose `event.sequence <= currentSequence`. It SHALL apply per-event mutations only for the on-map event families enumerated below. All other event types SHALL pass through silently — they may flow through the timeline scrubber but they SHALL NOT change `tokens`, `hexTerrain`, or `mapRadius`.
+
+The covered event families and their mutations:
+
+| Event type | Mutation |
+|---|---|
+| `GameCreated` | Seeds the initial `tokens` array from `payload.units` (one `IUnitToken` per unit, with the variant chosen by `unit.unitType`). Sets `mapRadius = payload.config.mapRadius`. |
+| `MovementDeclared` | Updates the actor token's `position` to `payload.to` and `facing` to `payload.facing`. |
+| `DamageApplied` | Tracks accumulated location-level damage on the affected unit (per-unit per-location bookkeeping). When `payload.locationDestroyed === true` AND `payload.location === 'CT'`, sets the unit's `isDestroyed = true`. |
+| `LocationDestroyed` | Records the destroyed location in the per-unit damage map. When `payload.location === 'CT'`, sets the unit's `isDestroyed = true`. |
+| `TransferDamage` | Records the transfer in the per-unit damage map (informational; does not flip `isDestroyed` on its own). |
+| `UnitDestroyed` | Sets the unit's `isDestroyed = true`. |
+| `UnitFell` | Tags the unit as prone (rendered via the existing token component's prone visualization). |
+| `UnitStood` | Clears the unit's prone tag. |
+| `HeatGenerated` / `HeatDissipated` | Tracks `currentHeat` per unit (consumed by the token's existing heat-band rendering). |
+| `PilotHit` | Increments per-unit `pilotWounds`. |
+| `ComponentDestroyed` | When the actor unit projects to an `IMechToken` (Mech archetype): translates the runner's 2-letter MegaMek location code (`'HD'`, `'CT'`, `'LT'`, `'RT'`, `'LA'`, `'RA'`, `'LL'`, `'RL'`, plus the quad-specific `'FLL'`, `'FRL'`, `'RLL'`, `'RRL'`) into the corresponding `BipedPipLocation` / `QuadPipLocation` key, then updates the unit's `armorPipState.locations[mappedKey]`. The reducer SHALL initialize `armorPipState` lazily — first damage event allocates the `archetype`-appropriate `locations` map (humanoid / quad / lam) with every location set to `'full'`, then mutates the affected location. Transitions: `'full'` → `'partial'` on the first damage event for that location, and from any state → `'structure'` when `payload.componentType` is an internal component (`engine`, `gyro`, `weapon`, `actuator`, `heat_sink`, `cockpit`, `sensor`, `life_support`, `jump_jet`, `ammo`). When `LocationDestroyed` has already fired on the same location, transitions to `'destroyed'`. Non-Mech tokens SHALL pass `ComponentDestroyed` through silently — `armorPipState` is Mech-only per `IMechToken`. Unrecognized location codes SHALL pass through silently (no throw, no mutation). |
+| `CriticalHitResolved` | Same projection logic as `ComponentDestroyed` (covers the post-PR-`add-combat-fidelity-suite` Phase-4 emitter path while `ComponentDestroyed` covers the legacy Phase-3 path). |
+
+The reducer SHALL be idempotent: for any input `(events, currentSequence)`, repeated invocation SHALL produce structurally equivalent output (deep-equal `tokens` and `hexTerrain` arrays).
+
+The reducer SHALL NOT assume monotonic forward progression of `currentSequence` between calls. Stepping the cursor backward SHALL produce the correct state for the new cursor value (re-walking from the beginning of `events` is acceptable; a forward-only optimization is out of scope for this PR).
+
+The reducer SHALL be `useMemo`-d on `[events, currentSequence]` so re-renders that do not change the cursor reuse the prior projection.
+
+#### Scenario: ComponentDestroyed populates Mech armorPipState
+
+- **GIVEN** an event log containing `GameCreated` (seeding a humanoid Mech `player-1`) followed by `ComponentDestroyed { unitId: 'player-1', location: 'LA', componentType: 'actuator' }`
+- **WHEN** the reducer walks to `currentSequence ≥ 2`
+- **THEN** the `player-1` token's `armorPipState.archetype === 'humanoid'`
+- **AND** `armorPipState.locations.leftArm === 'structure'` (actuator is an internal component)
+- **AND** all other `BipedPipLocation` values default to `'full'`
+
+#### Scenario: First non-internal damage transitions full → partial
+
+- **GIVEN** a humanoid Mech with no prior `armorPipState`
+- **WHEN** a `ComponentDestroyed { location: 'RT', componentType: 'armor' }` event applies
+- **THEN** `armorPipState.locations.rightTorso === 'partial'`
+
+#### Scenario: LocationDestroyed plus ComponentDestroyed transitions to destroyed
+
+- **GIVEN** a humanoid Mech that received `LocationDestroyed { location: 'LL' }` at sequence 5
+- **WHEN** `ComponentDestroyed { location: 'LL', componentType: 'actuator' }` applies at sequence 10 with cursor at 10
+- **THEN** `armorPipState.locations.leftLeg === 'destroyed'`
+
+#### Scenario: ComponentDestroyed on a vehicle is a no-op
+
+- **GIVEN** an event log seeding an `IVehicleToken` for `tank-1` followed by `ComponentDestroyed { unitId: 'tank-1', location: 'turret', componentType: 'weapon' }`
+- **WHEN** the reducer walks past the destroyed event
+- **THEN** the `tank-1` token has NO `armorPipState` field (vehicles do not project `armorPipState`)
+- **AND** the reducer does NOT throw
+
+#### Scenario: CriticalHitResolved follows the same projection rules
+
+- **GIVEN** the Phase-4 emitter shipping `CriticalHitResolved` instead of `ComponentDestroyed`
+- **WHEN** the reducer applies a `CriticalHitResolved { unitId: 'player-1', location: 'CT', componentType: 'engine', destroyed: true }` event to a humanoid Mech
+- **THEN** `armorPipState.locations.centerTorso === 'structure'` (or `'destroyed'` if `LocationDestroyed` already fired on CT)

--- a/openspec/changes/add-replay-timeline-markers/tasks.md
+++ b/openspec/changes/add-replay-timeline-markers/tasks.md
@@ -1,0 +1,88 @@
+# Tasks — add-replay-timeline-markers
+
+## 1. Authoring
+
+- [x] 1.1 Author `proposal.md`
+- [x] 1.2 Author spec delta for `combat-analytics` (1 ADDED + 1 MODIFIED requirement)
+- [x] 1.3 Author `tasks.md`
+- [x] 1.4 `npx openspec validate add-replay-timeline-markers --strict` clean
+
+## 2. Reducer arm — ComponentDestroyed + CriticalHitResolved → armorPipState
+
+- [x] 2.1 Modify `src/hooks/replay/useHexMapStateFromEvents.ts`:
+  - Extend `UnitAccumulator` with optional `armorPipState` field (Mech-only)
+  - Add `applyComponentDestroyed(acc, event, locationDestroyedSet)` helper:
+    - Init `armorPipState` lazily on first damage with archetype derived from `unit.unitType` / `isQuad` / `isLAM` and all locations set to `'full'`
+    - Mutate the affected location: `'full' → 'partial'` if external; `'full' | 'partial' → 'structure'` if internal component; `→ 'destroyed'` if `LocationDestroyed` has fired
+    - Internal-component allowlist: `engine`, `gyro`, `weapon`, `actuator`, `heat_sink`, `cockpit`, `sensor`, `life_support`, `jump_jet`, `ammo`
+  - Wire `case GameEventType.ComponentDestroyed` and `case GameEventType.CriticalHitResolved` in the reducer switch
+  - Skip non-Mech units silently (no throw, no mutation)
+  - Surface `armorPipState` only on the public Mech token projection
+
+## 3. Marker components
+
+- [x] 3.1 Create `src/components/audit/replay/KeyMomentMarkers.tsx`:
+  - Props: `{ events, minSequence, maxSequence, onSeek, className? }`
+  - Filter via `EventLogQuery.from(events)` (or inline filter for the 5 types if Query has no `.ofType()` overload covering all)
+  - Map color: red / orange / purple / yellow / gray
+  - Click → `onSeek((sequence - minSeq) / (maxSeq - minSeq))`
+- [x] 3.2 Create `src/components/audit/replay/PhaseChangeMarkers.tsx`:
+  - Props: same shape
+  - Filter for `TurnStarted` + `PhaseChanged`
+  - Render dotted vertical line + hover tooltip "Turn N — <phase>"
+
+## 4. Wire into ReplayTimeline
+
+- [x] 4.1 Modify `src/components/audit/replay/ReplayTimeline.tsx`:
+  - Add optional `keyMoments?: readonly IGameEvent[]` and `phaseChanges?: readonly IGameEvent[]` props
+  - Compose `<KeyMomentMarkers>` and `<PhaseChangeMarkers>` as overlays above the existing track when the props are present
+  - Forward the existing seek callback to overlays
+  - Existing audit markers continue to render unchanged
+- [x] 4.2 Modify `src/components/audit/replay/index.ts` — re-export `KeyMomentMarkers` and `PhaseChangeMarkers`
+
+## 5. Wire into existing replay surfaces
+
+- [x] 5.1 Modify `src/pages/gameplay/games/[id]/replay.tsx`:
+  - Pass `uploadedEvents` (when in upload mode) to `<ReplayTimeline keyMoments phaseChanges>`
+- [x] 5.2 Modify `src/components/quickgame/QuickGameReplayPanel.tsx`:
+  - Pass `events` to `<ReplayTimeline keyMoments phaseChanges>`
+
+## 6. Tests
+
+- [x] 6.1 Create `src/components/audit/replay/__tests__/KeyMomentMarkers.test.tsx`:
+  - Position test: 2 markers at correct relative positions
+  - Color test: marker color matches event type
+  - Click test: `onSeek` called with expected position
+  - Empty-log test: no badges render
+- [x] 6.2 Create `src/components/audit/replay/__tests__/PhaseChangeMarkers.test.tsx`:
+  - Position + count test for `TurnStarted` + `PhaseChanged`
+  - Tooltip-on-hover smoke test
+  - Empty-log test
+- [x] 6.3 Modify `src/hooks/replay/__tests__/useHexMapStateFromEvents.test.ts`:
+  - Scenario: ComponentDestroyed populates Mech `armorPipState` (humanoid + quad)
+  - Scenario: First external-component event transitions `full → partial`
+  - Scenario: Internal-component event transitions to `structure`
+  - Scenario: LocationDestroyed + ComponentDestroyed transitions to `destroyed`
+  - Scenario: ComponentDestroyed on a Vehicle is a no-op (no throw, no `armorPipState`)
+  - Scenario: CriticalHitResolved follows same logic
+
+## 7. Verification
+
+- [x] 7.1 `npx tsc --noEmit` clean
+- [x] 7.2 `npx oxlint src/hooks/replay/ src/components/audit/replay/` clean (no new errors)
+- [x] 7.3 `npx jest --testPathPattern="(KeyMomentMarkers|PhaseChangeMarkers|useHexMapStateFromEvents)"` green
+- [x] 7.4 `npx openspec validate add-replay-timeline-markers --strict` clean
+- [ ] 7.5 Smoke: load the standalone replay page with an NDJSON; verify red badges at unit-destroyed events, orange at crits, dotted lines at turn boundaries; click a badge → scrubber seeks; mech tokens render damage progression on the hex map
+
+## 8. PR
+
+- [ ] 8.1 Commit (`feat(replay): add key-moment timeline markers + ComponentDestroyed armorPipState arm`)
+- [ ] 8.2 Push branch `replay-viewer/pr-a3-timeline-markers`
+- [ ] 8.3 Open PR targeting `main`
+- [ ] 8.4 CI green
+- [ ] 8.5 Merge (squash, delete branch)
+
+## 9. Archive
+
+- [ ] 9.1 `openspec archive add-replay-timeline-markers`
+- [ ] 9.2 Verify `combat-analytics` source-of-truth absorbed both deltas

--- a/src/components/audit/replay/KeyMomentMarkers.tsx
+++ b/src/components/audit/replay/KeyMomentMarkers.tsx
@@ -1,0 +1,176 @@
+/**
+ * KeyMomentMarkers — overlay for `<ReplayTimeline>` that renders colored
+ * badges at high-value gameplay events (kills, crits, ammo cookoffs,
+ * pilot hits, falls). Click a badge to seek the scrubber to that event.
+ *
+ * Per `add-replay-timeline-markers` (combat-analytics delta —
+ * "Replay Timeline Key-Moment Markers Contract").
+ *
+ * @spec openspec/changes/add-replay-timeline-markers/specs/combat-analytics/spec.md
+ */
+
+import React, { useMemo } from 'react';
+
+import { GameEventType, IGameEvent } from '@/types/gameplay';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface KeyMomentMarkersProps {
+  /** Gameplay event log used to derive key moments. */
+  readonly events: readonly IGameEvent[];
+  /**
+   * Lower bound of the timeline range (inclusive). Used to project an
+   * event's `sequence` onto a 0–1 horizontal position. Typically the
+   * sequence of the first event in the visible range.
+   */
+  readonly minSequence: number;
+  /**
+   * Upper bound of the timeline range (inclusive). When `minSequence
+   * === maxSequence` (single-event log), all badges collapse to
+   * position 0.
+   */
+  readonly maxSequence: number;
+  /**
+   * Seek callback invoked when the user clicks a badge. Receives the
+   * 0–1 relative position of the clicked event.
+   */
+  readonly onSeek: (progress: number) => void;
+  /** Optional class names appended to the overlay container. */
+  readonly className?: string;
+}
+
+interface KeyMoment {
+  readonly id: string;
+  readonly sequence: number;
+  readonly position: number;
+  readonly type: GameEventType;
+  readonly label: string;
+}
+
+// =============================================================================
+// Color mapping
+// =============================================================================
+
+/**
+ * Five key-moment event types and their badge colors. Per the spec
+ * scenario "Key-moment markers render at the correct positions": red /
+ * orange / purple / yellow / gray.
+ *
+ * `CriticalHit` and `CriticalHitResolved` share the orange badge —
+ * legacy and Phase-4 emitters both surface as critical hits.
+ */
+const MARKER_COLOR: Partial<Record<GameEventType, string>> = {
+  [GameEventType.UnitDestroyed]: 'bg-red-500 hover:bg-red-400',
+  [GameEventType.CriticalHit]: 'bg-orange-500 hover:bg-orange-400',
+  [GameEventType.CriticalHitResolved]: 'bg-orange-500 hover:bg-orange-400',
+  [GameEventType.AmmoExplosion]: 'bg-purple-500 hover:bg-purple-400',
+  [GameEventType.PilotHit]: 'bg-yellow-500 hover:bg-yellow-400',
+  [GameEventType.UnitFell]: 'bg-gray-400 hover:bg-gray-300',
+};
+
+const TARGET_TYPES: ReadonlySet<GameEventType> = new Set(
+  Object.keys(MARKER_COLOR) as GameEventType[],
+);
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Render a colored badge per key-moment event. Memoizes the filtered
+ * marker list on `[events, minSequence, maxSequence]` so re-renders
+ * during scrubbing don't re-walk the full event log.
+ */
+export function KeyMomentMarkers({
+  events,
+  minSequence,
+  maxSequence,
+  onSeek,
+  className = '',
+}: KeyMomentMarkersProps): React.ReactElement | null {
+  const moments = useMemo<readonly KeyMoment[]>(() => {
+    if (events.length === 0) return [];
+    const range = maxSequence - minSequence;
+    // Guard against divide-by-zero — single-event ranges collapse to 0.
+    const denom = range > 0 ? range : 1;
+    const out: KeyMoment[] = [];
+    for (const event of events) {
+      if (!TARGET_TYPES.has(event.type)) continue;
+      const position = (event.sequence - minSequence) / denom;
+      // Clamp out-of-range events to [0, 1] so a stray event with
+      // `sequence < minSequence` doesn't render at a negative offset.
+      const clamped = Math.max(0, Math.min(1, position));
+      out.push({
+        id: event.id,
+        sequence: event.sequence,
+        position: clamped,
+        type: event.type,
+        label: formatLabel(event),
+      });
+    }
+    return out;
+  }, [events, minSequence, maxSequence]);
+
+  if (moments.length === 0) return null;
+
+  return (
+    <div
+      className={`pointer-events-none absolute inset-0 ${className}`}
+      data-testid="key-moment-markers"
+    >
+      {moments.map((moment) => (
+        <button
+          key={moment.id}
+          type="button"
+          data-testid={`key-moment-marker-${moment.id}`}
+          data-event-type={moment.type}
+          className={`pointer-events-auto absolute top-0 h-full w-2 cursor-pointer rounded-sm transition-all duration-150 ${
+            MARKER_COLOR[moment.type] ?? 'bg-slate-500'
+          } opacity-80 hover:scale-110 hover:opacity-100`}
+          style={{
+            left: `${moment.position * 100}%`,
+            transform: 'translateX(-50%)',
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSeek(moment.position);
+          }}
+          title={moment.label}
+        />
+      ))}
+    </div>
+  );
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Build a hover-tooltip label for a key-moment badge. Plain-English so
+ * the user can identify the event without parsing the type string.
+ */
+function formatLabel(event: IGameEvent): string {
+  const baseLabel = ((): string => {
+    switch (event.type) {
+      case GameEventType.UnitDestroyed:
+        return 'Unit destroyed';
+      case GameEventType.CriticalHit:
+      case GameEventType.CriticalHitResolved:
+        return 'Critical hit';
+      case GameEventType.AmmoExplosion:
+        return 'Ammo explosion';
+      case GameEventType.PilotHit:
+        return 'Pilot hit';
+      case GameEventType.UnitFell:
+        return 'Unit fell';
+      default:
+        return String(event.type);
+    }
+  })();
+  return `${baseLabel} — Turn ${event.turn} (#${event.sequence})`;
+}
+
+export default KeyMomentMarkers;

--- a/src/components/audit/replay/PhaseChangeMarkers.tsx
+++ b/src/components/audit/replay/PhaseChangeMarkers.tsx
@@ -1,0 +1,119 @@
+/**
+ * PhaseChangeMarkers — overlay for `<ReplayTimeline>` that renders
+ * dotted vertical lines at every `TurnStarted` and `PhaseChanged`
+ * event. Hovering a line reveals a tooltip with the turn number and
+ * human-readable phase name (e.g. "Turn 7 — Weapon Attack").
+ *
+ * Per `add-replay-timeline-markers` (combat-analytics delta —
+ * "Replay Timeline Key-Moment Markers Contract").
+ *
+ * @spec openspec/changes/add-replay-timeline-markers/specs/combat-analytics/spec.md
+ */
+
+import React, { useMemo } from 'react';
+
+import { GameEventType, GamePhase, IGameEvent } from '@/types/gameplay';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface PhaseChangeMarkersProps {
+  /** Gameplay event log used to derive phase / turn boundaries. */
+  readonly events: readonly IGameEvent[];
+  /** Lower bound of the timeline range (inclusive). */
+  readonly minSequence: number;
+  /** Upper bound of the timeline range (inclusive). */
+  readonly maxSequence: number;
+  /** Optional class names appended to the overlay container. */
+  readonly className?: string;
+}
+
+interface PhaseMarker {
+  readonly id: string;
+  readonly sequence: number;
+  readonly position: number;
+  readonly turn: number;
+  readonly phase: GamePhase;
+}
+
+// =============================================================================
+// Phase label mapping
+// =============================================================================
+
+const PHASE_LABEL: Record<GamePhase, string> = {
+  [GamePhase.Initiative]: 'Initiative',
+  [GamePhase.Movement]: 'Movement',
+  [GamePhase.WeaponAttack]: 'Weapon Attack',
+  [GamePhase.PhysicalAttack]: 'Physical Attack',
+  [GamePhase.Heat]: 'Heat',
+  [GamePhase.End]: 'End',
+};
+
+const TARGET_TYPES: ReadonlySet<GameEventType> = new Set([
+  GameEventType.TurnStarted,
+  GameEventType.PhaseChanged,
+]);
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Render a dotted vertical line per phase / turn boundary. Visual style
+ * is intentionally subtle (low-contrast dotted) so it sits behind the
+ * key-moment markers without competing for attention.
+ */
+export function PhaseChangeMarkers({
+  events,
+  minSequence,
+  maxSequence,
+  className = '',
+}: PhaseChangeMarkersProps): React.ReactElement | null {
+  const markers = useMemo<readonly PhaseMarker[]>(() => {
+    if (events.length === 0) return [];
+    const range = maxSequence - minSequence;
+    const denom = range > 0 ? range : 1;
+    const out: PhaseMarker[] = [];
+    for (const event of events) {
+      if (!TARGET_TYPES.has(event.type)) continue;
+      const position = (event.sequence - minSequence) / denom;
+      const clamped = Math.max(0, Math.min(1, position));
+      out.push({
+        id: event.id,
+        sequence: event.sequence,
+        position: clamped,
+        turn: event.turn,
+        phase: event.phase,
+      });
+    }
+    return out;
+  }, [events, minSequence, maxSequence]);
+
+  if (markers.length === 0) return null;
+
+  return (
+    <div
+      className={`pointer-events-none absolute inset-0 ${className}`}
+      data-testid="phase-change-markers"
+    >
+      {markers.map((marker) => (
+        <div
+          key={marker.id}
+          data-testid={`phase-change-marker-${marker.id}`}
+          // pointer-events-auto on the line itself so the hover tooltip
+          // (browser-native title) reveals on the marker, not the empty
+          // space around it.
+          className="pointer-events-auto absolute top-0 h-full w-px border-l border-dotted border-slate-400/60 hover:border-slate-200"
+          style={{
+            left: `${marker.position * 100}%`,
+            transform: 'translateX(-50%)',
+          }}
+          title={`Turn ${marker.turn} — ${PHASE_LABEL[marker.phase] ?? marker.phase}`}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default PhaseChangeMarkers;

--- a/src/components/audit/replay/ReplayTimeline.tsx
+++ b/src/components/audit/replay/ReplayTimeline.tsx
@@ -7,8 +7,13 @@
 
 import React, { useCallback, useRef, useState } from 'react';
 
+import type { IGameEvent } from '@/types/gameplay';
+
 import { type IEventMarker } from '@/hooks/audit';
 import { EventCategory } from '@/types/events';
+
+import { KeyMomentMarkers } from './KeyMomentMarkers';
+import { PhaseChangeMarkers } from './PhaseChangeMarkers';
 
 // =============================================================================
 // Types
@@ -25,6 +30,16 @@ export interface ReplayTimelineProps {
   currentSequence: number;
   /** Optional additional class names */
   className?: string;
+  /**
+   * Per `add-replay-timeline-markers` (combat-analytics delta):
+   * gameplay event log used to derive key-moment + phase-change marker
+   * overlays. When provided, the timeline composes
+   * `<KeyMomentMarkers>` and `<PhaseChangeMarkers>` above the existing
+   * track. When omitted (e.g. existing audit-store consumers), no
+   * overlay renders.
+   */
+  keyMoments?: readonly IGameEvent[];
+  phaseChanges?: readonly IGameEvent[];
 }
 
 // =============================================================================
@@ -50,6 +65,43 @@ const CATEGORY_HOVER_COLORS: Record<EventCategory, string> = {
 };
 
 // =============================================================================
+// Sequence-range helpers
+// =============================================================================
+
+/**
+ * Compute the lowest sequence across the union of `primary` and
+ * `secondary` event arrays. Used to align the key-moment + phase-change
+ * overlays to a common timeline range so badges and dotted lines line
+ * up with each other (and with the underlying audit-style markers).
+ */
+function resolveMinSequence(
+  primary: readonly IGameEvent[],
+  secondary: readonly IGameEvent[] | undefined,
+): number {
+  let min = Infinity;
+  for (const e of primary) if (e.sequence < min) min = e.sequence;
+  if (secondary !== undefined) {
+    for (const e of secondary) if (e.sequence < min) min = e.sequence;
+  }
+  return min === Infinity ? 0 : min;
+}
+
+/**
+ * Mirror of `resolveMinSequence` for the upper bound.
+ */
+function resolveMaxSequence(
+  primary: readonly IGameEvent[],
+  secondary: readonly IGameEvent[] | undefined,
+): number {
+  let max = -Infinity;
+  for (const e of primary) if (e.sequence > max) max = e.sequence;
+  if (secondary !== undefined) {
+    for (const e of secondary) if (e.sequence > max) max = e.sequence;
+  }
+  return max === -Infinity ? 0 : max;
+}
+
+// =============================================================================
 // Component
 // =============================================================================
 
@@ -59,6 +111,8 @@ export function ReplayTimeline({
   onSeek,
   currentSequence,
   className = '',
+  keyMoments,
+  phaseChanges,
 }: ReplayTimelineProps): React.ReactElement {
   const trackRef = useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -145,6 +199,28 @@ export function ReplayTimeline({
           className="from-accent/40 to-accent/60 absolute inset-y-0 left-0 bg-gradient-to-r transition-all duration-75"
           style={{ width: `${progress * 100}%` }}
         />
+
+        {/* Phase / turn boundary overlay (renders behind key-moment
+            badges; subtle dotted lines). Only present when the
+            consumer passed gameplay events. */}
+        {phaseChanges !== undefined && phaseChanges.length > 0 && (
+          <PhaseChangeMarkers
+            events={phaseChanges}
+            minSequence={resolveMinSequence(phaseChanges, keyMoments)}
+            maxSequence={resolveMaxSequence(phaseChanges, keyMoments)}
+          />
+        )}
+
+        {/* Key-moment overlay (kills / crits / ammo / pilot hits /
+            falls). Click a badge to seek to that event. */}
+        {keyMoments !== undefined && keyMoments.length > 0 && (
+          <KeyMomentMarkers
+            events={keyMoments}
+            minSequence={resolveMinSequence(keyMoments, phaseChanges)}
+            maxSequence={resolveMaxSequence(keyMoments, phaseChanges)}
+            onSeek={onSeek}
+          />
+        )}
 
         {/* Event Markers */}
         <div className="absolute inset-0 flex items-center">

--- a/src/components/audit/replay/__tests__/KeyMomentMarkers.test.tsx
+++ b/src/components/audit/replay/__tests__/KeyMomentMarkers.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * KeyMomentMarkers — render tests covering the spec scenarios from
+ * `add-replay-timeline-markers` (combat-analytics delta —
+ * "Replay Timeline Key-Moment Markers Contract"):
+ *
+ * 1. Position test — markers at correct relative positions
+ * 2. Color test — marker color matches event type
+ * 3. Click test — onSeek called with expected position
+ * 4. Empty-log test — no badges render
+ *
+ * @spec openspec/changes/add-replay-timeline-markers/specs/combat-analytics/spec.md
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IGameEvent,
+} from '@/types/gameplay';
+
+import { KeyMomentMarkers } from '../KeyMomentMarkers';
+
+// =============================================================================
+// Fixture helper
+// =============================================================================
+
+function makeEvent(
+  overrides: Partial<IGameEvent> & Pick<IGameEvent, 'type' | 'sequence' | 'id'>,
+): IGameEvent {
+  return {
+    gameId: 'test-game',
+    timestamp: '2026-05-07T00:00:00.000Z',
+    turn: 1,
+    phase: GamePhase.WeaponAttack,
+    side: GameSide.Player,
+    payload: {} as IGameEvent['payload'],
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('KeyMomentMarkers', () => {
+  describe('Empty-log guard', () => {
+    it('renders nothing when events is empty', () => {
+      const { container } = render(
+        <KeyMomentMarkers
+          events={[]}
+          minSequence={0}
+          maxSequence={100}
+          onSeek={jest.fn()}
+        />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing when no events match the five key-moment types', () => {
+      const events: readonly IGameEvent[] = [
+        makeEvent({
+          id: 'evt-1',
+          type: GameEventType.MovementDeclared,
+          sequence: 10,
+        }),
+        makeEvent({
+          id: 'evt-2',
+          type: GameEventType.DamageApplied,
+          sequence: 20,
+        }),
+      ];
+      const { container } = render(
+        <KeyMomentMarkers
+          events={events}
+          minSequence={0}
+          maxSequence={100}
+          onSeek={jest.fn()}
+        />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('Position projection', () => {
+    it('renders markers at correct relative positions', () => {
+      const events: readonly IGameEvent[] = [
+        makeEvent({
+          id: 'kill-1',
+          type: GameEventType.UnitDestroyed,
+          sequence: 50,
+        }),
+        makeEvent({
+          id: 'crit-1',
+          type: GameEventType.CriticalHit,
+          sequence: 100,
+        }),
+      ];
+      render(
+        <KeyMomentMarkers
+          events={events}
+          minSequence={0}
+          maxSequence={200}
+          onSeek={jest.fn()}
+        />,
+      );
+
+      const killBadge = screen.getByTestId('key-moment-marker-kill-1');
+      const critBadge = screen.getByTestId('key-moment-marker-crit-1');
+      expect(killBadge).toHaveStyle({ left: '25%' }); // 50 / 200
+      expect(critBadge).toHaveStyle({ left: '50%' }); // 100 / 200
+    });
+  });
+
+  describe('Color mapping', () => {
+    it('UnitDestroyed renders red, CriticalHit renders orange', () => {
+      const events: readonly IGameEvent[] = [
+        makeEvent({
+          id: 'kill-1',
+          type: GameEventType.UnitDestroyed,
+          sequence: 50,
+        }),
+        makeEvent({
+          id: 'crit-1',
+          type: GameEventType.CriticalHit,
+          sequence: 100,
+        }),
+      ];
+      render(
+        <KeyMomentMarkers
+          events={events}
+          minSequence={0}
+          maxSequence={200}
+          onSeek={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('key-moment-marker-kill-1').className).toMatch(
+        /bg-red-/,
+      );
+      expect(screen.getByTestId('key-moment-marker-crit-1').className).toMatch(
+        /bg-orange-/,
+      );
+    });
+
+    it('AmmoExplosion renders purple, PilotHit renders yellow, UnitFell renders gray', () => {
+      const events: readonly IGameEvent[] = [
+        makeEvent({
+          id: 'ammo-1',
+          type: GameEventType.AmmoExplosion,
+          sequence: 30,
+        }),
+        makeEvent({
+          id: 'pilot-1',
+          type: GameEventType.PilotHit,
+          sequence: 60,
+        }),
+        makeEvent({
+          id: 'fell-1',
+          type: GameEventType.UnitFell,
+          sequence: 90,
+        }),
+      ];
+      render(
+        <KeyMomentMarkers
+          events={events}
+          minSequence={0}
+          maxSequence={100}
+          onSeek={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('key-moment-marker-ammo-1').className).toMatch(
+        /bg-purple-/,
+      );
+      expect(screen.getByTestId('key-moment-marker-pilot-1').className).toMatch(
+        /bg-yellow-/,
+      );
+      expect(screen.getByTestId('key-moment-marker-fell-1').className).toMatch(
+        /bg-gray-/,
+      );
+    });
+  });
+
+  describe('Click-to-seek', () => {
+    it("clicking a badge invokes onSeek with the badge's relative position", () => {
+      const onSeek = jest.fn();
+      const events: readonly IGameEvent[] = [
+        makeEvent({
+          id: 'kill-1',
+          type: GameEventType.UnitDestroyed,
+          sequence: 50,
+        }),
+      ];
+      render(
+        <KeyMomentMarkers
+          events={events}
+          minSequence={0}
+          maxSequence={200}
+          onSeek={onSeek}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('key-moment-marker-kill-1'));
+      expect(onSeek).toHaveBeenCalledTimes(1);
+      expect(onSeek).toHaveBeenCalledWith(0.25);
+    });
+  });
+});

--- a/src/components/audit/replay/__tests__/PhaseChangeMarkers.test.tsx
+++ b/src/components/audit/replay/__tests__/PhaseChangeMarkers.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * PhaseChangeMarkers — render tests covering the spec scenarios from
+ * `add-replay-timeline-markers` (combat-analytics delta —
+ * "Replay Timeline Key-Moment Markers Contract"):
+ *
+ * - Phase-change markers render at every TurnStarted and PhaseChanged
+ * - Tooltip on hover reveals "Turn N — <phase>"
+ * - Empty-log test
+ *
+ * @spec openspec/changes/add-replay-timeline-markers/specs/combat-analytics/spec.md
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IGameEvent,
+} from '@/types/gameplay';
+
+import { PhaseChangeMarkers } from '../PhaseChangeMarkers';
+
+function makeEvent(
+  overrides: Partial<IGameEvent> &
+    Pick<IGameEvent, 'type' | 'sequence' | 'id' | 'turn' | 'phase'>,
+): IGameEvent {
+  return {
+    gameId: 'test-game',
+    timestamp: '2026-05-07T00:00:00.000Z',
+    side: GameSide.Player,
+    payload: {} as IGameEvent['payload'],
+    ...overrides,
+  };
+}
+
+describe('PhaseChangeMarkers', () => {
+  describe('Empty-log guard', () => {
+    it('renders nothing when events is empty', () => {
+      const { container } = render(
+        <PhaseChangeMarkers events={[]} minSequence={0} maxSequence={100} />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing when no events are TurnStarted or PhaseChanged', () => {
+      const events: readonly IGameEvent[] = [
+        makeEvent({
+          id: 'evt-1',
+          type: GameEventType.MovementDeclared,
+          sequence: 10,
+          turn: 1,
+          phase: GamePhase.Movement,
+        }),
+      ];
+      const { container } = render(
+        <PhaseChangeMarkers
+          events={events}
+          minSequence={0}
+          maxSequence={100}
+        />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('Render every TurnStarted and PhaseChanged', () => {
+    it('renders six markers when log has 3 turn-starts + 3 phase-changes', () => {
+      const events: readonly IGameEvent[] = [
+        makeEvent({
+          id: 'ts-1',
+          type: GameEventType.TurnStarted,
+          sequence: 10,
+          turn: 1,
+          phase: GamePhase.Initiative,
+        }),
+        makeEvent({
+          id: 'pc-1',
+          type: GameEventType.PhaseChanged,
+          sequence: 15,
+          turn: 1,
+          phase: GamePhase.Movement,
+        }),
+        makeEvent({
+          id: 'ts-2',
+          type: GameEventType.TurnStarted,
+          sequence: 30,
+          turn: 2,
+          phase: GamePhase.Initiative,
+        }),
+        makeEvent({
+          id: 'pc-2',
+          type: GameEventType.PhaseChanged,
+          sequence: 35,
+          turn: 2,
+          phase: GamePhase.WeaponAttack,
+        }),
+        makeEvent({
+          id: 'ts-3',
+          type: GameEventType.TurnStarted,
+          sequence: 50,
+          turn: 3,
+          phase: GamePhase.Initiative,
+        }),
+        makeEvent({
+          id: 'pc-3',
+          type: GameEventType.PhaseChanged,
+          sequence: 55,
+          turn: 3,
+          phase: GamePhase.Heat,
+        }),
+      ];
+      render(
+        <PhaseChangeMarkers events={events} minSequence={0} maxSequence={60} />,
+      );
+
+      // All six markers present.
+      expect(
+        screen.getByTestId('phase-change-marker-ts-1'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId('phase-change-marker-pc-1'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId('phase-change-marker-pc-3'),
+      ).toBeInTheDocument();
+    });
+
+    it('tooltip uses human-readable phase labels', () => {
+      const events: readonly IGameEvent[] = [
+        makeEvent({
+          id: 'pc-wa',
+          type: GameEventType.PhaseChanged,
+          sequence: 35,
+          turn: 7,
+          phase: GamePhase.WeaponAttack,
+        }),
+      ];
+      render(
+        <PhaseChangeMarkers events={events} minSequence={0} maxSequence={50} />,
+      );
+
+      const marker = screen.getByTestId('phase-change-marker-pc-wa');
+      expect(marker).toHaveAttribute('title', 'Turn 7 — Weapon Attack');
+    });
+  });
+});

--- a/src/components/audit/replay/index.ts
+++ b/src/components/audit/replay/index.ts
@@ -42,3 +42,14 @@ export {
   type JsonlFileLoaderProps,
   type JsonlLineError,
 } from './JsonlFileLoader';
+
+// Per `add-replay-timeline-markers` (combat-analytics delta): timeline
+// overlays for key-moment events + phase / turn boundaries.
+export {
+  KeyMomentMarkers,
+  type KeyMomentMarkersProps,
+} from './KeyMomentMarkers';
+export {
+  PhaseChangeMarkers,
+  type PhaseChangeMarkersProps,
+} from './PhaseChangeMarkers';

--- a/src/components/quickgame/QuickGameReplayPanel.tsx
+++ b/src/components/quickgame/QuickGameReplayPanel.tsx
@@ -142,6 +142,11 @@ export function QuickGameReplayPanel({
             markers={adaptedMarkers}
             onSeek={replay.seek}
             currentSequence={replay.currentSequence}
+            // Per `add-replay-timeline-markers`: pass the in-memory
+            // gameplay event log so the timeline composes
+            // <KeyMomentMarkers> + <PhaseChangeMarkers> overlays.
+            keyMoments={events}
+            phaseChanges={events}
           />
         </div>
 

--- a/src/hooks/replay/__tests__/useHexMapStateFromEvents.test.ts
+++ b/src/hooks/replay/__tests__/useHexMapStateFromEvents.test.ts
@@ -25,6 +25,7 @@ import {
   MovementType,
   TokenUnitType,
 } from '@/types/gameplay';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
 
 import { deriveHexMapStateFromEvents } from '../useHexMapStateFromEvents';
 
@@ -644,6 +645,199 @@ describe('deriveHexMapStateFromEvents', () => {
       expect(
         state.tokens.find((t) => t.unitId === 'opponent-2')?.isDestroyed,
       ).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // add-replay-timeline-markers — ComponentDestroyed + CriticalHitResolved
+  // populate IMechToken.armorPipState
+  // ===========================================================================
+
+  describe('spec scenario: ComponentDestroyed populates Mech armorPipState', () => {
+    it('humanoid Mech: actuator on LA → leftArm transitions to structure', () => {
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.ComponentDestroyed,
+          actorId: 'opponent-2',
+          payload: {
+            unitId: 'player-1',
+            location: 'LA',
+            componentType: 'actuator',
+            slotIndex: 0,
+          },
+        }),
+      ];
+      const state = deriveHexMapStateFromEvents(events, 1);
+      const mech = state.tokens.find((t) => t.unitId === 'player-1');
+      expect(mech?.unitType).toBe(TokenUnitType.Mech);
+      // armorPipState should be populated.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pipState = (mech as any)?.armorPipState;
+      expect(pipState).toBeDefined();
+      expect(pipState.archetype).toBe('humanoid');
+      expect(pipState.locations.leftArm).toBe('structure');
+      // All other locations remain 'full'.
+      expect(pipState.locations.head).toBe('full');
+      expect(pipState.locations.rightArm).toBe('full');
+      expect(pipState.locations.centerTorso).toBe('full');
+    });
+  });
+
+  describe('spec scenario: First non-internal damage transitions full → partial', () => {
+    it('armor componentType on RT → rightTorso becomes partial', () => {
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.ComponentDestroyed,
+          payload: {
+            unitId: 'player-1',
+            location: 'RT',
+            componentType: 'armor',
+            slotIndex: 0,
+          },
+        }),
+      ];
+      const state = deriveHexMapStateFromEvents(events, 1);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pipState = (
+        state.tokens.find((t) => t.unitId === 'player-1') as any
+      )?.armorPipState;
+      expect(pipState.locations.rightTorso).toBe('partial');
+    });
+  });
+
+  describe('spec scenario: LocationDestroyed plus ComponentDestroyed transitions to destroyed', () => {
+    it('LL: LocationDestroyed at seq 5 + ComponentDestroyed at seq 10 → leftLeg destroyed', () => {
+      const locDestroyedPayload: ILocationDestroyedPayload = {
+        unitId: 'player-1',
+        location: 'LL',
+      };
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 5,
+          type: GameEventType.LocationDestroyed,
+          payload: locDestroyedPayload,
+        }),
+        makeEvent({
+          sequence: 10,
+          type: GameEventType.ComponentDestroyed,
+          payload: {
+            unitId: 'player-1',
+            location: 'LL',
+            componentType: 'actuator',
+            slotIndex: 0,
+          },
+        }),
+      ];
+      const state = deriveHexMapStateFromEvents(events, 10);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pipState = (
+        state.tokens.find((t) => t.unitId === 'player-1') as any
+      )?.armorPipState;
+      expect(pipState.locations.leftLeg).toBe('destroyed');
+    });
+  });
+
+  describe('spec scenario: ComponentDestroyed on a vehicle is a no-op', () => {
+    it('vehicle token has no armorPipState and reducer does not throw', () => {
+      const vehiclePayload: IGameCreatedPayload = {
+        config: {
+          mapRadius: 17,
+          turnLimit: 0,
+          victoryConditions: ['destruction'],
+          optionalRules: [],
+        },
+        units: [
+          {
+            id: 'tank-1',
+            name: 'Test Tank',
+            side: GameSide.Player,
+            unitRef: 'tank-ref',
+            pilotRef: 'pilot-tank',
+            gunnery: 4,
+            piloting: 5,
+            // Force Vehicle path explicitly. UnitType.VEHICLE === 'Vehicle'.
+            unitType: UnitType.VEHICLE,
+          },
+        ],
+      };
+      const events: IGameEvent[] = [
+        makeEvent({
+          sequence: 0,
+          type: GameEventType.GameCreated,
+          payload: vehiclePayload,
+        }),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.ComponentDestroyed,
+          payload: {
+            unitId: 'tank-1',
+            location: 'turret',
+            componentType: 'weapon',
+            slotIndex: 0,
+          },
+        }),
+      ];
+      // Must not throw.
+      const state = deriveHexMapStateFromEvents(events, 1);
+      const tank = state.tokens.find((t) => t.unitId === 'tank-1');
+      expect(tank).toBeDefined();
+      expect(tank?.unitType).toBe(TokenUnitType.Vehicle);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((tank as any).armorPipState).toBeUndefined();
+    });
+  });
+
+  describe('spec scenario: CriticalHitResolved follows the same projection rules', () => {
+    it('engine on CT (internal) → centerTorso transitions to structure', () => {
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.CriticalHitResolved,
+          payload: {
+            unitId: 'player-1',
+            location: 'CT',
+            slotIndex: 0,
+            componentType: 'engine',
+            componentName: 'Engine',
+            effect: 'destroyed',
+            destroyed: true,
+          },
+        }),
+      ];
+      const state = deriveHexMapStateFromEvents(events, 1);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pipState = (
+        state.tokens.find((t) => t.unitId === 'player-1') as any
+      )?.armorPipState;
+      expect(pipState.locations.centerTorso).toBe('structure');
+    });
+  });
+
+  describe('edge case: unrecognized location code is silently ignored', () => {
+    it('does not throw and does not allocate armorPipState', () => {
+      const events: IGameEvent[] = [
+        makeStandardGameCreatedEvent(),
+        makeEvent({
+          sequence: 1,
+          type: GameEventType.ComponentDestroyed,
+          payload: {
+            unitId: 'player-1',
+            location: 'UNKNOWN_LOC',
+            componentType: 'actuator',
+            slotIndex: 0,
+          },
+        }),
+      ];
+      const state = deriveHexMapStateFromEvents(events, 1);
+      const mech = state.tokens.find((t) => t.unitId === 'player-1');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((mech as any).armorPipState).toBeUndefined();
     });
   });
 });

--- a/src/hooks/replay/useHexMapStateFromEvents.ts
+++ b/src/hooks/replay/useHexMapStateFromEvents.ts
@@ -30,6 +30,8 @@ import { useMemo } from 'react';
 import type {
   IAerospaceToken,
   IBattleArmorToken,
+  IComponentDestroyedPayload,
+  ICriticalHitResolvedPayload,
   IDamageAppliedPayload,
   IGameCreatedPayload,
   IGameEvent,
@@ -50,6 +52,12 @@ import type {
   IUnitToken,
   IVehicleToken,
 } from '@/types/gameplay';
+import type {
+  ArmorPipState,
+  BipedPipLocation,
+  PipLocationState,
+  QuadPipLocation,
+} from '@/types/gameplay/UnitSpriteTypes';
 
 import {
   Facing,
@@ -99,6 +107,15 @@ interface UnitAccumulator {
   currentHeat: number;
   pilotWounds: number;
   damagedLocations: ReadonlySet<string>;
+  /**
+   * Per-location armor-pip state. Populated lazily on the first
+   * `ComponentDestroyed` / `CriticalHitResolved` event for the unit, and
+   * only on Mech archetype tokens. Other unit types ignore the field.
+   *
+   * Per `add-replay-timeline-markers` (combat-analytics delta — Replay
+   * State-From-Events Reducer Contract).
+   */
+  armorPipState?: ArmorPipState;
   // Optional per-type passthrough fields — populated only for variants
   // that need them. Stored as a loosely-typed bag because the reducer
   // doesn't mutate them after seeding from `GameCreated`.
@@ -287,13 +304,197 @@ function accumulatorToToken(acc: UnitAccumulator): IUnitToken {
     }
     case TokenUnitType.Mech:
     default: {
+      // `armorPipState` is the only optional field forwarded from the
+      // accumulator; populated by the `ComponentDestroyed` /
+      // `CriticalHitResolved` reducer arms. Absent → `<HexMapDisplay>`
+      // renders the fresh-off-the-lot pip ring.
       const token: IMechToken = {
         ...base,
         unitType: TokenUnitType.Mech,
+        ...(acc.armorPipState !== undefined && {
+          armorPipState: acc.armorPipState,
+        }),
       };
       return token;
     }
   }
+}
+
+// =============================================================================
+// Armor-pip state projection (per add-replay-timeline-markers)
+// =============================================================================
+
+/**
+ * Components considered "internal" for armor-pip transitions. When a
+ * `ComponentDestroyed` / `CriticalHitResolved` carries one of these
+ * `componentType` values, the affected location's pip state advances
+ * past `'partial'` straight into `'structure'` (or `'destroyed'` if
+ * `LocationDestroyed` already fired). Mirrors MegaMek's hit-location
+ * crit table.
+ */
+const INTERNAL_COMPONENT_TYPES: ReadonlySet<string> = new Set([
+  'engine',
+  'gyro',
+  'weapon',
+  'actuator',
+  'heat_sink',
+  'cockpit',
+  'sensor',
+  'life_support',
+  'jump_jet',
+  'ammo',
+]);
+
+/**
+ * Map the runner's 2-letter MegaMek location codes to the camelCase
+ * `BipedPipLocation` keys used by `ArmorPipState`. Returns `null` for
+ * unrecognized codes so the caller can no-op without throwing.
+ */
+function bipedLocationFromCode(code: string): BipedPipLocation | null {
+  switch (code) {
+    case 'HD':
+      return 'head';
+    case 'CT':
+      return 'centerTorso';
+    case 'LT':
+      return 'leftTorso';
+    case 'RT':
+      return 'rightTorso';
+    case 'LA':
+      return 'leftArm';
+    case 'RA':
+      return 'rightArm';
+    case 'LL':
+      return 'leftLeg';
+    case 'RL':
+      return 'rightLeg';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Same translation for quad mechs. Quad legs split front/rear so the
+ * runner emits `FLL` / `FRL` / `RLL` / `RRL` plus the shared `HD` and
+ * `CT` codes. Returns `null` for unrecognized codes.
+ */
+function quadLocationFromCode(code: string): QuadPipLocation | null {
+  switch (code) {
+    case 'HD':
+      return 'head';
+    case 'CT':
+      return 'centerTorso';
+    case 'FLL':
+      return 'frontLeftLeg';
+    case 'FRL':
+      return 'frontRightLeg';
+    case 'RLL':
+      return 'rearLeftLeg';
+    case 'RRL':
+      return 'rearRightLeg';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Build a fresh `ArmorPipState` for the given Mech accumulator with
+ * every location set to `'full'`. Picks the archetype based on the
+ * unit's chassis flags — quads use the 6-key quad layout, LAMs use the
+ * humanoid 8-key layout under the `'lam'` archetype, and everything
+ * else defaults to `'humanoid'`.
+ *
+ * Note: the reducer doesn't have unit-record-level access to `isQuad`
+ * or `isLAM` from the construction layer (the `IGameUnit` shape is
+ * intentionally light), so we default to `'humanoid'` here. Quad and
+ * LAM archetypes can be unlocked later if `IGameUnit` gains the flag.
+ * For now, the runner emits 2-letter biped codes for all Mech types
+ * including quads — `quadLocationFromCode` is wired but unreachable
+ * via the runner today.
+ */
+function emptyArmorPipState(): ArmorPipState {
+  const fullLocations: Record<BipedPipLocation, PipLocationState> = {
+    head: 'full',
+    centerTorso: 'full',
+    leftTorso: 'full',
+    rightTorso: 'full',
+    leftArm: 'full',
+    rightArm: 'full',
+    leftLeg: 'full',
+    rightLeg: 'full',
+  };
+  return {
+    archetype: 'humanoid',
+    locations: fullLocations,
+  };
+}
+
+/**
+ * Apply a `ComponentDestroyed` or `CriticalHitResolved` event to the
+ * accumulator's `armorPipState`. Pure — returns the next state without
+ * mutating the input. The caller assigns the result back to the
+ * accumulator.
+ *
+ * Transition rules (per `add-replay-timeline-markers` spec delta):
+ *   1. If `LocationDestroyed` already fired on this location (via
+ *      `damagedLocations`), the pip transitions to `'destroyed'`.
+ *   2. Else if `componentType` is internal, the pip transitions to
+ *      `'structure'`.
+ *   3. Else (external component, e.g. armor), the pip transitions to
+ *      `'partial'` only if it was `'full'` (downgrades stick — never
+ *      regress from `'structure'` to `'partial'`).
+ */
+function applyComponentDestroyedToPips(
+  prev: ArmorPipState | undefined,
+  locationCode: string,
+  componentType: string,
+  locationAlreadyDestroyed: boolean,
+): ArmorPipState | undefined {
+  // Lazily allocate the pip state on first damage. If we can't resolve
+  // the location code, return `prev` unchanged — unrecognized codes
+  // pass through silently per the spec contract.
+  const base = prev ?? emptyArmorPipState();
+  if (base.archetype === 'quad') {
+    const key = quadLocationFromCode(locationCode);
+    if (key === null) return prev;
+    const current = base.locations[key];
+    const next = nextPipState(current, componentType, locationAlreadyDestroyed);
+    if (next === current) return prev;
+    return {
+      archetype: 'quad',
+      locations: { ...base.locations, [key]: next },
+    };
+  }
+  // Humanoid + LAM share the 8-key biped layout.
+  const key = bipedLocationFromCode(locationCode);
+  if (key === null) return prev;
+  const current = base.locations[key];
+  const next = nextPipState(current, componentType, locationAlreadyDestroyed);
+  if (next === current) return prev;
+  return {
+    archetype: base.archetype,
+    locations: { ...base.locations, [key]: next },
+  };
+}
+
+/**
+ * Compute the next pip state for one location given the current state,
+ * the component type, and whether `LocationDestroyed` already fired.
+ * Returns the unchanged input if no transition applies (e.g. already
+ * destroyed and a follow-on event arrives).
+ */
+function nextPipState(
+  current: PipLocationState,
+  componentType: string,
+  locationAlreadyDestroyed: boolean,
+): PipLocationState {
+  if (current === 'destroyed' || current === 'missing') return current;
+  if (locationAlreadyDestroyed) return 'destroyed';
+  if (INTERNAL_COMPONENT_TYPES.has(componentType)) return 'structure';
+  // External component damage — only downgrade `'full' → 'partial'`.
+  // Do not regress from `'structure'` to `'partial'`.
+  if (current === 'full') return 'partial';
+  return current;
 }
 
 // =============================================================================
@@ -494,11 +695,45 @@ export function deriveHexMapStateFromEvents(
         }
         break;
       }
+      case GameEventType.ComponentDestroyed: {
+        const payload = event.payload as IComponentDestroyedPayload;
+        const acc = accumulators.get(payload.unitId);
+        // armorPipState is Mech-only — non-Mech units pass through
+        // silently per the spec contract.
+        if (acc !== undefined && acc.unitType === TokenUnitType.Mech) {
+          const locationAlreadyDestroyed = acc.damagedLocations.has(
+            payload.location,
+          );
+          acc.armorPipState = applyComponentDestroyedToPips(
+            acc.armorPipState,
+            payload.location,
+            payload.componentType,
+            locationAlreadyDestroyed,
+          );
+        }
+        break;
+      }
+      case GameEventType.CriticalHitResolved: {
+        const payload = event.payload as ICriticalHitResolvedPayload;
+        const acc = accumulators.get(payload.unitId);
+        if (acc !== undefined && acc.unitType === TokenUnitType.Mech) {
+          const locationAlreadyDestroyed = acc.damagedLocations.has(
+            payload.location,
+          );
+          acc.armorPipState = applyComponentDestroyedToPips(
+            acc.armorPipState,
+            payload.location,
+            payload.componentType,
+            locationAlreadyDestroyed,
+          );
+        }
+        break;
+      }
       default:
         // Out-of-band event types pass through silently. The timeline
         // scrubber still sees them; the reducer simply does not mutate
-        // the map state on them. Per the spec scope, only the eight
-        // covered families above can change `tokens` / `hexTerrain` /
+        // the map state on them. Per the spec scope, only the covered
+        // families above can change `tokens` / `hexTerrain` /
         // `mapRadius`.
         break;
     }

--- a/src/pages/gameplay/games/[id]/replay.tsx
+++ b/src/pages/gameplay/games/[id]/replay.tsx
@@ -528,6 +528,20 @@ export default function GameReplayPage(): React.ReactElement {
                   markers={replay.markers}
                   onSeek={replay.seek}
                   currentSequence={replay.currentSequence}
+                  // Per `add-replay-timeline-markers`: when an upload
+                  // is active we have the raw gameplay event log,
+                  // which lets the timeline derive key-moment +
+                  // phase-change overlays. DB-loaded replays go
+                  // through the audit envelope path and don't expose
+                  // the gameplay log here, so the overlays stay off
+                  // for those (existing audit markers continue to
+                  // render unchanged).
+                  keyMoments={
+                    isUploadActive ? (uploadedEvents ?? undefined) : undefined
+                  }
+                  phaseChanges={
+                    isUploadActive ? (uploadedEvents ?? undefined) : undefined
+                  }
                 />
               </div>
 


### PR DESCRIPTION
## Summary

Closes the **Replay Viewer Bundle** (PR A3 — after A1 #541 + A2 #544). Two threads in one change:

1. **Timeline visual aids** — new `<KeyMomentMarkers>` and `<PhaseChangeMarkers>` overlays for `<ReplayTimeline>`. Key moments render as colored badges (red kills / orange crits / purple ammo / yellow pilot hits / gray falls); phase boundaries render as dotted vertical lines with hover tooltips ("Turn 7 — Weapon Attack"). Click a badge to seek the scrubber. Both overlays are opt-in via two new optional props — existing audit-store consumers unaffected.

2. **`ComponentDestroyed` + `CriticalHitResolved` reducer arm** — wires component-destruction events into `IMechToken.armorPipState` so the hex-map replay shows real damage progression. Per the OMO Council #3 follow-on (2026-05-07): the only reducer-expansion candidate that passes all three Oracle gates (runner emits today / token field exists / mechanical transformation).

## Spec delta

`combat-analytics`:
- ADDED `Replay Timeline Key-Moment Markers Contract` (5 scenarios)
- MODIFIED `Replay State-From-Events Reducer Contract` (extends covered-event-families table + 6 new scenarios)

Strict-validated.

## What

- **NEW** `src/components/audit/replay/KeyMomentMarkers.tsx`
- **NEW** `src/components/audit/replay/PhaseChangeMarkers.tsx`
- **NEW** `src/components/audit/replay/__tests__/{KeyMomentMarkers,PhaseChangeMarkers}.test.tsx`
- **MODIFY** `src/components/audit/replay/ReplayTimeline.tsx` — add optional `keyMoments` / `phaseChanges` props + compose overlays
- **MODIFY** `src/components/audit/replay/index.ts` — re-export new components
- **MODIFY** `src/hooks/replay/useHexMapStateFromEvents.ts` — `ComponentDestroyed` + `CriticalHitResolved` reducer arms; project `armorPipState` onto Mech tokens
- **MODIFY** `src/hooks/replay/__tests__/useHexMapStateFromEvents.test.ts` — 6 new arm scenarios
- **MODIFY** `src/pages/gameplay/games/[id]/replay.tsx` — pass uploaded events to overlays in upload mode
- **MODIFY** `src/components/quickgame/QuickGameReplayPanel.tsx` — same pass-through for the in-page panel

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx oxlint` clean (only the 2 pre-existing console.warn warnings from #541's lossy-fallback)
- [x] `npx jest --testPathPattern="(KeyMomentMarkers|PhaseChangeMarkers|useHexMapStateFromEvents|QuickGameReplayPanel)"` — **40 / 40** green
- [x] `npx openspec validate add-replay-timeline-markers --strict` clean
- [ ] Manual smoke: drag an NDJSON into the standalone replay page; verify red badges at unit-destroyed, orange at crits, dotted lines at turn boundaries; click a badge → scrubber seeks; mech tokens show damage progression on the hex map