### PR TITLE
feat(replay-library): add ReplaySource enum + manifest types (PR 1/6)

### DIFF
--- a/openspec/changes/add-replay-library/.openspec.yaml
+++ b/openspec/changes/add-replay-library/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/add-replay-library/design.md
+++ b/openspec/changes/add-replay-library/design.md
@@ -1,0 +1,140 @@
+## Context
+
+The Replay Viewer Bundle (PRs #541–#547, archived 2026-05-07) shipped end-to-end frame-by-frame playback from any swarm `.jsonl`, including a 5th-tab in-page panel for quick games. **Discoverability is now the bottleneck**: 1000+ swarm runs sit on disk under `simulation-reports/games/<ts>/<gameId>.jsonl`, the user can't tell quick games from PvP from campaign without reading filenames, and there is no in-app catalog short of dragging files in.
+
+The `simulation-reports/` directory today contains only swarm CLI output (flat layout). Quick games run in-memory and die with the React tree. PvP runs against `InMemoryMatchStore` (dev-only). Campaign event emission isn't wired yet. Every replay source is on a different lifecycle and persistence trajectory — the architecture must accommodate that asymmetry without coupling them.
+
+The OMO Council convened on this question and ruled **Option C (hybrid)** with three load-bearing clarifications:
+1. Discriminator is primary (per K8s GVK + sc2reader's 7-year deprecation lesson)
+2. Filesystem partition is secondary (cheap win for per-source lifecycle isolation)
+3. Central index is the search primitive
+
+Council synthesis lives inline in the conversation that authored this change; key cited evidence: Kubernetes GVK `kind` field, sc2reader's 7-year string-discriminator deprecation, OpenDota `lobby_type` enum, OpenTelemetry Signal model, Temporal EventType, MekStation's existing `EventCategory` discriminator pattern on every `IGameEvent`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every event carries a `replaySource: ReplaySource` envelope field that survives schema evolution and serializes cleanly through NDJSON
+- Filesystem layout partitions by source so per-source GC, retention, and archival are independent operations
+- A single `replay-index.json` is the only thing the Replay Library page reads — no walking the filesystem from the UI
+- Quick games persist on completion (today they don't)
+- Swarm runs continue to work without behavior change beyond the partition path
+- One-time backfill scan covers pre-existing flat `simulation-reports/games/<ts>/*.jsonl` so users keep their history
+- PvP and Campaign sources are reserved in the enum and have manifest entry shapes pre-defined so future write paths plug in without spec churn
+
+**Non-Goals:**
+- PvP durable persistence — `InMemoryMatchStore` replacement is its own change
+- Campaign event emission — campaign mode doesn't emit events yet; that's a separate wiring change
+- Replay deletion / archival policy / retention windows — out of scope; users delete files manually for v1
+- Multi-machine replay sync (cloud, share-link, etc.) — out of scope
+- Replay search by event content (e.g., "find replays where Atlas killed Marauder") — index covers structural metadata only
+
+## Decisions
+
+### Decision 1: Envelope field name is `replaySource`, not `source`
+**Choice:** Add `replaySource: ReplaySource` to `IBaseEvent`.
+**Rationale:** Several existing event payloads already carry a `source` string (heat events: `"movement"|"weapons"|"dissipation"`; pilot-hit events: `"head_hit"|"ammo_explosion"|...`). An envelope-level `source` would shadow conceptually even though TypeScript wouldn't conflict. `replaySource` is unambiguous at any nesting depth.
+**Alternatives considered:** `source` (rejected — naming collision with payload semantics); `originKind` (rejected — opaque); `category` (rejected — already exists as `EventCategory` on `IGameEvent`, would alias).
+
+### Decision 2: `ReplaySource` is an enum, not a string union
+**Choice:**
+```ts
+export enum ReplaySource {
+  Swarm = 'swarm',
+  Quick = 'quick',
+  PvP = 'pvp',
+  Campaign = 'campaign',
+}
+```
+**Rationale:** sc2reader's 7-year deprecation pain came from a string discriminator that drifted as new replay sources were added with no exhaustiveness check. An enum forces every consumer to handle every variant or fail compilation. The string values match what's serialized to JSON, keeping NDJSON wire format human-readable.
+**Alternatives considered:** string literal union `'swarm'|'quick'|'pvp'|'campaign'` (rejected — TypeScript narrows correctly but doesn't flag missing variants in switch statements without explicit `never` checks; enum + exhaustive switch is the codebase's existing pattern, e.g. `EventCategory`).
+
+### Decision 3: Manifest entry is a discriminated union with one shape per source
+**Choice:**
+```ts
+export interface IReplayManifestEntryBase {
+  readonly id: string;             // gameId
+  readonly replaySource: ReplaySource;
+  readonly path: string;            // relative to simulation-reports/
+  readonly createdAt: string;       // ISO timestamp
+  readonly turns: number;           // events.length-derived if GameEnded.turns missing
+  readonly winner: GameSide | null;
+  readonly bvTotal: number;         // sum of unit BVs at GameCreated time
+}
+export interface ISwarmReplayManifestEntry extends IReplayManifestEntryBase {
+  readonly replaySource: ReplaySource.Swarm;
+  readonly configName: string;      // swarm config file name
+  readonly seed: number;
+  readonly batchTimestamp: string;  // groups runs from same `simulation-reports/games/<ts>/` cluster
+}
+export interface IQuickReplayManifestEntry extends IReplayManifestEntryBase {
+  readonly replaySource: ReplaySource.Quick;
+  readonly playerSide: GameSide;
+  readonly aiVariant: string;
+}
+export interface IPvPReplayManifestEntry extends IReplayManifestEntryBase {
+  readonly replaySource: ReplaySource.PvP;
+  readonly opponentName: string;
+  readonly matchId: string;
+}
+export interface ICampaignReplayManifestEntry extends IReplayManifestEntryBase {
+  readonly replaySource: ReplaySource.Campaign;
+  readonly campaignId: string;
+  readonly missionId: string;
+  readonly difficulty: string;
+}
+export type IReplayManifestEntry =
+  | ISwarmReplayManifestEntry
+  | IQuickReplayManifestEntry
+  | IPvPReplayManifestEntry
+  | ICampaignReplayManifestEntry;
+```
+**Rationale:** Each source has source-specific metadata users want to filter on (swarm: configName/seed; quick: aiVariant; pvp: opponent; campaign: mission). Discriminated union lets the UI render a different list-row template per source while sharing the base fields. Per Momus's MUST-RESOLVE: BV is computed at write time and stored on the entry — no lazy recompute on read.
+**Alternatives considered:** flat entry with optional fields (rejected — type system can't enforce "swarm entries always have configName"); separate index files per source (rejected — defeats the unified-search goal).
+
+### Decision 4: Filesystem layout is `simulation-reports/{swarm,quick,pvp,campaign}/<gameId>.jsonl`
+**Choice:** four sibling directories under `simulation-reports/`. Central `simulation-reports/replay-index.json` next to them.
+**Rationale:** Per-source lifecycle isolation (independent GC, retention, archival). Storage debugging is straightforward — `ls simulation-reports/quick/` answers "what quick games do I have?" Replaces today's flat `simulation-reports/games/<ts>/<id>.jsonl` for swarm output. Existing files covered by backfill scan.
+**Alternatives considered:** keep flat with `replaySource` field at the start of each NDJSON file's first line (rejected — defeats per-source lifecycle); nest deeper with `simulation-reports/swarm/<batchTimestamp>/<id>.jsonl` (rejected for v1 — backfill becomes more complex; can be added later if swarm volume warrants).
+
+### Decision 5: Index is regenerated on demand, not append-only
+**Choice:** `replay-index.json` is regenerated by scanning the four partition directories. Writers append manifest entries during run completion, but the canonical index is rebuilt from disk if missing or stale.
+**Rationale:** Keeps the index as a derivable artifact — corruption, stale entries, or hand-edits to the partition dirs all self-heal on next library load. Append-only with no rebuild path would force migration scripts for any layout drift.
+**Alternatives considered:** append-only index with version field (rejected — version conflicts on parallel writers); SQLite-backed index (rejected — added dep for marginal win on local-only catalog).
+
+### Decision 6: Quick-game write path goes through the same persistence module as swarm
+**Choice:** `eventLogPersistence.ts` (already exists; today only swarm uses it) becomes the single write surface. `QuickGameResults` calls into it on encounter completion. Env-aware IO (Node `fs` for desktop builds; structured-storage equivalent for browser-only builds) abstracted behind one interface.
+**Rationale:** One module, one set of tests, one source of truth for the partition path. Quick game and swarm differ only in which `IReplayManifestEntry` shape they emit.
+**Alternatives considered:** separate `quickGamePersistence.ts` (rejected — duplicates partition + index-writer logic).
+
+### Decision 7: Backfill scan runs on first library load and is idempotent
+**Choice:** When the Replay Library page mounts, it reads `replay-index.json` if present. If absent, it scans `simulation-reports/games/<ts>/<id>.jsonl` (legacy flat) and `simulation-reports/{swarm,quick,pvp,campaign}/` (new partitioned), materializes manifest entries by streaming the first event of each file, and writes the index. Subsequent loads short-circuit on the existing index.
+**Rationale:** No destructive migration. Users with 1000+ pre-existing swarm logs see them on first library open. The scan is bounded — one `IGameCreatedPayload` + one `IGameEndedPayload` read per file (or `events.length` derivation if the latter is missing).
+**Alternatives considered:** explicit migration script (rejected — adds friction); never backfill, only catalog new runs (rejected — defeats discoverability for the user's existing corpus).
+
+## Risks / Trade-offs
+
+- **[Risk] Quick-game IO env split (Node vs browser).** Today's QuickGameResults runs entirely in-browser. **Mitigation:** abstract write surface behind `IReplayPersistence` interface; ship Node implementation in v1; browser-only builds get a no-op or IndexedDB-backed implementation in a follow-on.
+- **[Risk] Backfill scan slow on large corpora.** Reading the first event of 1000+ files takes seconds. **Mitigation:** scan once, cache index; show a progress indicator on first library open. Scan is idempotent so partial completion isn't catastrophic.
+- **[Risk] BV computation cost at manifest-write time.** Computing BV from `IGameUnit` data is non-trivial. **Mitigation:** BV is already computed by SimulationRunner before GameCreated emission for swarm; reuse that value. Quick game has BV from unit picker. PvP/campaign defer.
+- **[Risk] `replay-index.json` corruption.** Manifest entries get out of sync with files on disk. **Mitigation:** idempotent rebuild path (Decision 5); index is a cache, not authoritative. If a user deletes a `.jsonl` manually, next load self-heals.
+- **[Risk] Filesystem layout breaking change for existing tooling.** Anything pointing at `simulation-reports/games/<ts>/` breaks. **Mitigation:** legacy path remains readable by backfill scan. Writers move to partitioned layout. No symlinks (cross-platform pain). Scripts that consume the flat layout get a deprecation note + the new path in PR descriptions.
+- **[Trade-off] PvP/Campaign manifest shapes pre-defined but unused in v1.** Risk of getting them wrong before real users arrive. **Mitigation:** the discriminated union design means a PR adding the PvP write path also adds tests against the entry shape; if the shape needs changes, those changes live in that PR not this one.
+
+## Migration Plan
+
+**Phase 1 (this change, single PR-ladder):**
+1. Add `ReplaySource` enum + `replaySource` envelope field on `IBaseEvent`. Default value provided by event factories so call-site changes are bounded.
+2. Implement `IReplayManifestEntry` discriminated union + index reader/writer in `src/replay-library/`.
+3. Switch `eventLogPersistence.ts` to write under `simulation-reports/swarm/<gameId>.jsonl` for swarm runs and emit a `ISwarmReplayManifestEntry` to the index.
+4. Add quick-game persistence write path; emit `IQuickReplayManifestEntry`.
+5. Implement backfill scan; integrate into Replay Library page mount.
+6. Build Replay Library page with list, source filter, click-to-open (reuses existing replay viewer via in-page mount or route).
+
+**Rollback strategy:** the change is additive at the wire format layer (new envelope field with default fallback) and the flat-layout legacy files remain readable. Reverting the PR ladder leaves users with the new partitioned dirs in place but no library page; they can drag files back into the standalone replay viewer as before.
+
+## Open Questions
+
+- **Library page route**: `/replay-library` standalone vs nested under `/gameplay/replays`? Default: standalone, navigable from primary nav. Revisit if frontend nav refactor surfaces.
+- **Index file location**: `simulation-reports/replay-index.json` (alongside partition dirs) vs `.replay-index.json` (hidden)? Default: visible; users may want to inspect or hand-edit during debugging.
+- **First-class search**: text search over `configName`/`opponentName`/`missionId` is in scope; full-text search over event content is not. If users ask for "find replays with ammo explosions" we revisit with a separate event-content index.

--- a/openspec/changes/add-replay-library/proposal.md
+++ b/openspec/changes/add-replay-library/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+We just shipped the Replay Viewer Bundle (PRs #541–#547) — drag any `.jsonl` into the standalone replay page or open the Quick-Game Replay tab and the battle plays back frame-by-frame on the hex map with timeline markers. But the **discoverability gap is now the limiting factor**: 1000+ swarm runs sit on disk under `simulation-reports/games/.../sim-N.jsonl`, the user can't tell quick games from PvP from campaign without filename archaeology, and there is no in-app way to find a specific replay short of dragging files in by hand.
+
+The user's brief: "I don't want to drag files I want instant integration ability with existing logs." The architectural constraint: "Quick simulator stuff should be separately identifiable from campaign, also kept separately from PvP challenges, etc." The OMO Council ruled Option C (hybrid: discriminator + filesystem partition + central index) with the discriminator as the load-bearing primitive (per K8s GVK + sc2reader's 7-year deprecation lesson) and partition as a cheap secondary win for per-source lifecycle isolation.
+
+## What Changes
+
+- **NEW** `ReplaySource` enum on every `IBaseEvent` (values: `Swarm | Quick | PvP | Campaign`) — discriminator that survives schema evolution
+- **NEW** `IReplayManifestEntry` discriminated union — one entry shape per source, written to a central `replay-index.json`
+- **NEW** filesystem partition: `simulation-reports/{swarm,quick,pvp,campaign}/<gameId>.jsonl` (replaces today's flat `simulation-reports/games/<ts>/<id>.jsonl`)
+- **NEW** Replay Library page — searchable list of all manifest entries, filter by source, click → existing replay viewer (no file drag)
+- **NEW** quick-game write path — `QuickGameResults` page persists events on encounter completion (env-aware IO; today the stream lives in memory and dies with the React tree)
+- **NEW** swarm-runner write path — `SimulationRunner` writes manifest entry + emits to `simulation-reports/swarm/...` (today writes to `simulation-reports/games/<ts>/...` flat)
+- **NEW** index reader/writer + backfill scan for pre-existing `simulation-reports/games/.../*.jsonl` (one-time migration on first library load)
+- **NEW** `ReplaySource.PvP` reserved in enum but write path **deferred** — `InMemoryMatchStore` is dev-only; manifest path skipped until durable PvP store lands
+- **NEW** `ReplaySource.Campaign` reserved in enum but write path **deferred** — campaign emit isn't wired yet; manifest entry shape pre-defined so campaign mode can plug in without touching the contract
+
+**BREAKING** filesystem layout change for swarm logs (existing logs covered by one-time backfill scan, no data loss).
+
+## Capabilities
+
+### New Capabilities
+- `replay-library`: discriminated, searchable catalog of replays from every source — covers the `ReplaySource` enum, `IReplayManifestEntry` discriminated union, central `replay-index.json` reader/writer, backfill scan for legacy flat layout, and the in-app Replay Library page (list + filter + click-to-open)
+
+### Modified Capabilities
+- `game-event-system`: adds `source: ReplaySource` field to `IBaseEvent`; existing factories default to the runtime-provided source so call-site changes are bounded
+- `quick-session`: adds quick-game persistence write path on `QuickGameResults` mount/finalize (today no write occurs); CLI Swarm Runner partitioning under `simulation-reports/swarm/` (today writes to `simulation-reports/games/<ts>/`)
+
+## Impact
+
+- **Code**: `src/types/gameplay/GameSessionInterfaces.ts` (`IBaseEvent.source`), `src/simulation/runner/eventLogPersistence.ts` (partition path), `src/simulation/runner/SimulationRunner.ts` (write `source: Swarm`), `src/components/quickgame/QuickGameResults.tsx` (write `source: Quick` on completion), new `src/replay-library/` module (manifest types + index reader/writer + backfill), new page route `/replay-library`, modify `src/components/audit/replay/JsonlFileLoader.tsx` to also accept "open from library" path
+- **Filesystem**: `simulation-reports/{swarm,quick,pvp,campaign}/` directories; `simulation-reports/replay-index.json` central index file
+- **Tests**: per-source write-path round-trip, backfill scan against fixture, manifest entry shape round-trip per discriminant, library page list/filter/open, enum exhaustiveness
+- **Existing logs**: pre-existing `simulation-reports/games/<ts>/<id>.jsonl` covered by one-time backfill scan that materializes `IReplayManifestEntry` records; no destructive migration
+- **Out of scope (this change)**: PvP durable store, campaign event emission, replay deletion/archival policy, multi-machine replay sync — all named follow-ons

--- a/openspec/changes/add-replay-library/specs/game-event-system/spec.md
+++ b/openspec/changes/add-replay-library/specs/game-event-system/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Event Envelope Replay Source Discriminator
+
+Every `IGameEvent` SHALL carry an optional `replaySource: ReplaySource` field on `IGameEventBase`. The field SHALL be set at emission time by whichever subsystem emits the event (swarm runner sets `Swarm`; quick-game subsystem sets `Quick`; future PvP subsystem sets `PvP`; future campaign emitter sets `Campaign`). The single-chokepoint event builder (`createGameEvent` in `src/simulation/runner/phases/utils.ts`) SHALL accept a `replaySource` argument and write it through to the produced event.
+
+The field SHALL be optional on `IGameEventBase` so legacy NDJSON event streams written before this change replay unchanged.
+
+The field name SHALL be `replaySource` and SHALL NOT be `source` to avoid naming collision with payload-level `source` fields on heat events (`'movement'|'weapons'|'dissipation'`) and pilot-hit events (`'head_hit'|'ammo_explosion'|...`).
+
+#### Scenario: Swarm runner emits events with replaySource=swarm
+
+- **GIVEN** the CLI swarm runner is producing events for a simulation
+- **WHEN** any `IGameEvent` is emitted via `createGameEvent`
+- **THEN** the resulting event SHALL have `replaySource: ReplaySource.Swarm`
+
+#### Scenario: Quick game emits events with replaySource=quick
+
+- **GIVEN** an in-app quick game session emitting events into the in-process event store
+- **WHEN** any `IGameEvent` is appended to the store
+- **THEN** the resulting event SHALL have `replaySource: ReplaySource.Quick`
+
+#### Scenario: Legacy event streams replay despite missing replaySource
+
+- **GIVEN** an NDJSON event log written before this change (no `replaySource` field on any event)
+- **WHEN** the events are loaded by the replay viewer or the backfill scan
+- **THEN** processing SHALL succeed
+- **AND** consumers MAY infer `replaySource = ReplaySource.Swarm` for files discovered under the legacy `simulation-reports/games/<ts>/` flat layout
+
+#### Scenario: replaySource serializes through NDJSON round-trip
+
+- **GIVEN** an event with `replaySource: ReplaySource.Quick` that is serialized via `JSON.stringify`
+- **WHEN** the resulting line is parsed via `JSON.parse`
+- **THEN** the parsed event's `replaySource` field SHALL equal `'quick'`
+- **AND** consumers SHALL be able to compare the field against `ReplaySource.Quick` enum value successfully
+
+## MODIFIED Requirements
+
+### Requirement: Base Event Properties
+
+The system SHALL create base event properties with gameId, sequence, timestamp, type, turn, phase, optional actorId, and optional `replaySource: ReplaySource`.
+
+#### Scenario: Create base event with all properties
+
+- **GIVEN** gameId="game-123", sequence=5, type=GameEventType.MovementDeclared, turn=3, phase=GamePhase.Movement, actorId="mech-1", replaySource=ReplaySource.Swarm
+- **WHEN** creating a base event
+- **THEN** the event SHALL have id (UUID), gameId="game-123", sequence=5, timestamp (ISO 8601), type=MovementDeclared, turn=3, phase=Movement, actorId="mech-1", replaySource=ReplaySource.Swarm
+
+#### Scenario: Create base event without actorId
+
+- **GIVEN** gameId="game-456", sequence=1, type=GameEventType.GameCreated, turn=0, phase=GamePhase.Initiative, replaySource=ReplaySource.Quick
+- **WHEN** creating a base event without actorId
+- **THEN** the event SHALL have actorId=undefined
+- **AND** SHALL have replaySource=ReplaySource.Quick
+
+#### Scenario: Timestamp is ISO 8601 format
+
+- **GIVEN** any event creation
+- **WHEN** the event is created
+- **THEN** the timestamp SHALL be a valid ISO 8601 string (e.g., "2026-02-12T10:30:00.000Z")
+
+#### Scenario: replaySource is optional for legacy streams
+
+- **GIVEN** an event constructed without specifying replaySource (legacy code path)
+- **WHEN** creating a base event
+- **THEN** the event SHALL be valid
+- **AND** the `replaySource` field SHALL be `undefined` (and SHALL be omitted from `JSON.stringify` output)

--- a/openspec/changes/add-replay-library/specs/quick-session/spec.md
+++ b/openspec/changes/add-replay-library/specs/quick-session/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Quick Game Event Log Persistence
+
+Every quick-game encounter that reaches a terminal state (a `GameEnded` event in its event store) SHALL persist its full chronological event log to disk in NDJSON format at the path `simulation-reports/quick/<gameId>.jsonl`. The persistence SHALL be triggered by the `QuickGameResults` page mount/finalize lifecycle and SHALL NOT block the user-visible results render.
+
+The persisted file SHALL follow the same NDJSON conventions as swarm output: one `IGameEvent` per line encoded as JSON, `\n` separator, no trailing newline. Events SHALL be written in monotonically-increasing `IGameEvent.sequence` order. The persistence module MUST NOT re-sort, filter, or transform the event payloads.
+
+After the file is written, the system SHALL append a corresponding `IQuickReplayManifestEntry` to the central `simulation-reports/replay-index.json`. The manifest entry SHALL be derived from the event log: `id`=`gameId`, `path`=`'quick/<gameId>.jsonl'`, `createdAt`=ISO 8601 timestamp at write time, `turns`=count of `turn_started` events (fallback `0`), `winner`=`GameEnded.payload.winner` (`null` for draws), `bvTotal`=sum of unit BVs from the `GameCreated` payload, `playerSide`=the player's `GameSide`, `aiVariant`=the AI variant identifier in use for that quick game.
+
+#### Scenario: Quick game persists on completion
+
+- **GIVEN** a quick-game encounter that has reached `GameEnded`
+- **WHEN** the user navigates to `QuickGameResults`
+- **THEN** a file SHALL be created at `simulation-reports/quick/<gameId>.jsonl`
+- **AND** the file SHALL contain one JSON-encoded `IGameEvent` per line in `sequence` order
+- **AND** the file SHALL NOT have a trailing newline
+
+#### Scenario: Quick game manifest entry is appended
+
+- **GIVEN** a successful quick-game persistence write
+- **WHEN** the persistence module finishes
+- **THEN** `simulation-reports/replay-index.json` SHALL contain one new entry with `replaySource: ReplaySource.Quick`
+- **AND** the entry's `id` SHALL equal the `gameId`
+- **AND** the entry's `path` SHALL equal `'quick/<gameId>.jsonl'`
+
+#### Scenario: Persistence does not block results render
+
+- **GIVEN** a quick-game completion with a slow disk
+- **WHEN** the user navigates to `QuickGameResults`
+- **THEN** the results page SHALL render its damage matrix and summary tabs without waiting for the persistence write to complete
+- **AND** the persistence write SHALL be observable via promise/effect lifecycle but SHALL NOT throw a render-blocking error
+
+#### Scenario: Quick game events carry replaySource=quick
+
+- **GIVEN** a persisted `simulation-reports/quick/<gameId>.jsonl`
+- **WHEN** any line is parsed
+- **THEN** the parsed event SHALL have `replaySource: ReplaySource.Quick` (or `undefined` for events authored before this change shipped if the quick game was started under a legacy code path)
+
+## MODIFIED Requirements
+
+### Requirement: Per-Game Event Log Persistence
+
+Every encounter executed by the CLI swarm runner SHALL persist its full chronological event log to disk in NDJSON format (one `IGameEvent` per line, encoded as JSON, `\n` separator, no trailing newline) at the path `simulation-reports/swarm/<gameId>.jsonl`. There SHALL NOT be an opt-out flag.
+
+The swarm output JSON SHALL include an `eventLogDir` field whose value is the absolute path of `simulation-reports/swarm/`.
+
+The events SHALL be written in the order returned by `result.events` (which the runner populates in monotonically-increasing `IGameEvent.sequence` order). The persistence module MUST NOT re-sort, filter, or transform the event payloads.
+
+For every persisted file, the system SHALL append a corresponding `ISwarmReplayManifestEntry` to the central `simulation-reports/replay-index.json`. The entry SHALL be derived from the event log: `id`=`gameId`, `path`=`'swarm/<gameId>.jsonl'`, `replaySource`=`ReplaySource.Swarm`, `configName`=the swarm config file basename, `seed`=the run seed, `batchTimestamp`=the per-invocation timestamp (preserved as a metadata field on the entry; no longer used as a directory segment), `turns`/`winner`/`bvTotal` as derived from the event log per the central index conventions.
+
+The legacy flat layout `simulation-reports/games/<run-timestamp>/<gameId>.jsonl` SHALL NOT be written by new runs. Pre-existing files at that legacy path SHALL remain readable by the backfill scan (see `replay-library` spec).
+
+#### Scenario: Five-run swarm produces five NDJSON files under the swarm partition
+
+- **GIVEN** the invocation `tsx scripts/run-simulation.ts --config scripts/swarm-configs/duel-3kbv-temperate.json --runs 5 --seed 42`
+- **WHEN** the swarm completes
+- **THEN** the directory `simulation-reports/swarm/` SHALL contain five new files matching `*.jsonl`
+- **AND** each file's basename SHALL equal the corresponding `gameId` from `result.gameId`
+- **AND** the swarm output JSON's `eventLogDir` field SHALL point at `simulation-reports/swarm/`
+- **AND** for each file, the line count SHALL equal the corresponding `result.events.length`
+
+#### Scenario: Persisted events round-trip via JSON.parse
+
+- **GIVEN** a `simulation-reports/swarm/<gameId>.jsonl` file written by the runner
+- **WHEN** the file is read and split on `\n`
+- **THEN** every line SHALL be a non-empty string parseable by `JSON.parse` into a valid `IGameEvent`
+- **AND** the `sequence` field SHALL strictly increase across consecutive lines within the same `gameId`
+- **AND** every event's `gameId` SHALL equal the file's basename without the `.jsonl` extension
+
+#### Scenario: Each swarm run appends one manifest entry
+
+- **GIVEN** a five-run swarm
+- **WHEN** all runs complete
+- **THEN** `simulation-reports/replay-index.json` SHALL contain five new `ISwarmReplayManifestEntry` records (one per `gameId`)
+- **AND** each entry's `replaySource` SHALL equal `ReplaySource.Swarm`
+- **AND** each entry's `path` SHALL equal `'swarm/<gameId>.jsonl'`
+- **AND** each entry's `seed` SHALL equal `42`
+- **AND** each entry's `configName` SHALL equal `'duel-3kbv-temperate'`
+
+#### Scenario: New runs do not write to legacy flat layout
+
+- **GIVEN** a swarm invocation under this change
+- **WHEN** the runner completes
+- **THEN** no file SHALL be written under `simulation-reports/games/`
+- **AND** any pre-existing `simulation-reports/games/<ts>/<id>.jsonl` files SHALL be left untouched

--- a/openspec/changes/add-replay-library/specs/replay-library/spec.md
+++ b/openspec/changes/add-replay-library/specs/replay-library/spec.md
@@ -1,0 +1,210 @@
+## ADDED Requirements
+
+### Requirement: ReplaySource Enum
+
+The system SHALL define a `ReplaySource` enum with exactly the values `Swarm`, `Quick`, `PvP`, and `Campaign`. The serialized string values SHALL be `'swarm'`, `'quick'`, `'pvp'`, `'campaign'` respectively. The enum SHALL be the single source of truth for replay-source discrimination at every layer (envelope field, manifest entry discriminant, filesystem partition directory name, library page filter values).
+
+#### Scenario: Enum has exactly four values
+
+- **GIVEN** the `ReplaySource` enum
+- **WHEN** `Object.values(ReplaySource)` is computed
+- **THEN** the result SHALL equal `['swarm', 'quick', 'pvp', 'campaign']` in any order
+
+#### Scenario: Enum value matches partition directory name
+
+- **GIVEN** any `ReplaySource` value `s`
+- **WHEN** the writer derives the filesystem partition path for `s`
+- **THEN** the partition directory name SHALL equal the string value of `s` (e.g. `ReplaySource.Swarm` → `simulation-reports/swarm/`)
+
+#### Scenario: Exhaustive switch fails compilation if a variant is missed
+
+- **GIVEN** a `switch (entry.replaySource)` statement that omits one of the four cases
+- **WHEN** TypeScript compilation runs in strict mode
+- **THEN** compilation SHALL fail with a `Type 'ReplaySource' is not assignable to type 'never'` error or equivalent exhaustiveness error
+
+### Requirement: IReplayManifestEntry Discriminated Union
+
+The system SHALL define an `IReplayManifestEntry` discriminated union with exactly four member interfaces — one per `ReplaySource` value. Every member SHALL extend a base interface with the fields `id: string` (the `gameId`), `replaySource: ReplaySource`, `path: string` (relative to `simulation-reports/`), `createdAt: string` (ISO 8601), `turns: number`, `winner: GameSide | null`, and `bvTotal: number`.
+
+Each member SHALL add source-specific fields:
+
+- `ISwarmReplayManifestEntry` (`replaySource: ReplaySource.Swarm`): `configName: string`, `seed: number`, `batchTimestamp: string`
+- `IQuickReplayManifestEntry` (`replaySource: ReplaySource.Quick`): `playerSide: GameSide`, `aiVariant: string`
+- `IPvPReplayManifestEntry` (`replaySource: ReplaySource.PvP`): `opponentName: string`, `matchId: string`
+- `ICampaignReplayManifestEntry` (`replaySource: ReplaySource.Campaign`): `campaignId: string`, `missionId: string`, `difficulty: string`
+
+`bvTotal` SHALL be computed at manifest-write time from unit data — consumers SHALL NOT lazy-recompute on read.
+
+#### Scenario: Swarm manifest entry has source-specific fields
+
+- **GIVEN** a `SimulationRunner` invocation with `configName='duel-3kbv-temperate'`, `seed=42`, completed `gameId='sim-7'`
+- **WHEN** the writer produces the manifest entry
+- **THEN** the entry SHALL be an `ISwarmReplayManifestEntry`
+- **AND** `entry.replaySource` SHALL equal `ReplaySource.Swarm`
+- **AND** `entry.configName` SHALL equal `'duel-3kbv-temperate'`
+- **AND** `entry.seed` SHALL equal `42`
+- **AND** `entry.id` SHALL equal `'sim-7'`
+
+#### Scenario: Quick manifest entry has source-specific fields
+
+- **GIVEN** a quick-game completion with `playerSide=GameSide.Player`, `aiVariant='aggressive-v2'`
+- **WHEN** the writer produces the manifest entry
+- **THEN** the entry SHALL be an `IQuickReplayManifestEntry`
+- **AND** `entry.replaySource` SHALL equal `ReplaySource.Quick`
+- **AND** `entry.aiVariant` SHALL equal `'aggressive-v2'`
+
+#### Scenario: bvTotal is stored at write time not derived on read
+
+- **GIVEN** a manifest entry written with `bvTotal=4500`
+- **WHEN** the entry is read from the index
+- **THEN** `entry.bvTotal` SHALL equal `4500`
+- **AND** the read path SHALL NOT execute any BV-recomputation code path
+
+#### Scenario: Discriminated union narrows on replaySource
+
+- **GIVEN** a value of type `IReplayManifestEntry`
+- **WHEN** code reads `entry.replaySource === ReplaySource.Swarm` inside a TypeScript narrowing branch
+- **THEN** within the narrowed branch, accessing `entry.configName` SHALL compile without further type assertion
+
+### Requirement: Filesystem Partition Layout
+
+The repository SHALL persist replay event logs under partition directories at `simulation-reports/<source>/<gameId>.jsonl`, where `<source>` is the string value of one of the four `ReplaySource` enum variants. Writers SHALL NOT write swarm logs to the legacy flat path `simulation-reports/games/<run-timestamp>/<gameId>.jsonl` after this change ships.
+
+The `simulation-reports/` directory SHALL also contain a single `replay-index.json` file at its top level, alongside the four partition directories.
+
+#### Scenario: Swarm runner writes under simulation-reports/swarm/
+
+- **GIVEN** a swarm invocation that produces `gameId='sim-1'`
+- **WHEN** the runner writes the event log
+- **THEN** the file SHALL exist at `simulation-reports/swarm/sim-1.jsonl`
+- **AND** no file SHALL be written under `simulation-reports/games/`
+
+#### Scenario: Quick game persists under simulation-reports/quick/
+
+- **GIVEN** a quick-game completion with `gameId='quick-99'`
+- **WHEN** the QuickGameResults page completes its persist effect
+- **THEN** the file SHALL exist at `simulation-reports/quick/quick-99.jsonl`
+
+#### Scenario: Index file lives next to partitions
+
+- **GIVEN** the populated `simulation-reports/` directory
+- **WHEN** its top-level entries are listed
+- **THEN** `replay-index.json` SHALL be present alongside the partition directories
+
+### Requirement: Central Replay Index Reader
+
+The system SHALL provide a reader that loads `simulation-reports/replay-index.json` and returns a typed `readonly IReplayManifestEntry[]`. The reader SHALL skip entries whose `replaySource` is not a recognized `ReplaySource` enum value (forward-compatibility for future variants written by newer code) and SHALL log skipped entries via the engine logger at debug level.
+
+If `replay-index.json` does not exist, the reader SHALL invoke the backfill scan (see Backfill Scan requirement) and return its result.
+
+#### Scenario: Reader returns typed entries
+
+- **GIVEN** a `replay-index.json` containing one swarm entry and one quick entry
+- **WHEN** the reader loads it
+- **THEN** the result SHALL be a `readonly IReplayManifestEntry[]` of length 2
+- **AND** entry types SHALL discriminate correctly via `replaySource`
+
+#### Scenario: Reader skips unrecognized variants
+
+- **GIVEN** a `replay-index.json` containing one entry with `replaySource: 'lan-coop'` (a future variant unknown to this build)
+- **WHEN** the reader loads it
+- **THEN** the result SHALL omit that entry
+- **AND** the reader SHALL emit a debug log naming the skipped entry's `id`
+
+#### Scenario: Missing index triggers backfill
+
+- **GIVEN** `simulation-reports/replay-index.json` does not exist
+- **WHEN** the reader is invoked
+- **THEN** the reader SHALL invoke the backfill scan
+- **AND** SHALL return the manifest produced by the scan
+
+### Requirement: Central Replay Index Writer
+
+The system SHALL provide a writer that accepts a single new `IReplayManifestEntry`, atomically appends it to the existing `replay-index.json` (or creates the file if absent), and SHALL preserve all existing entries. The append SHALL be atomic: a temporary file SHALL be written and renamed into place so a partial write cannot leave the index in a corrupt state.
+
+#### Scenario: Append preserves existing entries
+
+- **GIVEN** an index containing 100 entries
+- **WHEN** the writer appends one new entry
+- **THEN** the resulting index SHALL contain 101 entries
+- **AND** the original 100 entries SHALL be present unchanged
+
+#### Scenario: Atomic write survives mid-write crash
+
+- **GIVEN** an existing index
+- **WHEN** the writer is interrupted between the temp-file write and the rename
+- **THEN** the original `replay-index.json` SHALL still exist with its original 100 entries
+- **AND** the temp file SHALL be discoverable for cleanup but SHALL NOT be loaded by the reader
+
+#### Scenario: Writer creates index if absent
+
+- **GIVEN** `simulation-reports/replay-index.json` does not exist
+- **WHEN** the writer is called with one new entry
+- **THEN** the file SHALL be created with that single entry
+
+### Requirement: Backfill Scan
+
+The system SHALL provide a backfill scan that produces a `readonly IReplayManifestEntry[]` from the contents of `simulation-reports/`. The scan SHALL examine both the new partition layout (`simulation-reports/<source>/*.jsonl`) AND the legacy flat layout (`simulation-reports/games/<timestamp>/*.jsonl`).
+
+For each NDJSON file discovered, the scan SHALL stream-read enough lines to extract:
+
+- The first event (which SHALL be `GameCreated`) — used to derive `bvTotal` from `payload.units` and `playerSide`/`aiVariant`/etc. as available
+- The last `GameEnded` event (if present) — used to derive `winner` and `turns`. If `GameEnded.turns` is absent or undefined, `turns` SHALL fall back to the count of `turn_started` events in the file, then to `0` if no `turn_started` events exist.
+
+For legacy flat-layout files, the scan SHALL infer `replaySource = ReplaySource.Swarm` (legacy directory only contained swarm output) and SHALL set `batchTimestamp` from the parent directory name.
+
+The scan SHALL be idempotent: re-running on the same disk state SHALL produce the same manifest array.
+
+#### Scenario: Scan covers new partition layout
+
+- **GIVEN** `simulation-reports/swarm/sim-1.jsonl`, `simulation-reports/quick/quick-9.jsonl` exist
+- **WHEN** the backfill scan runs
+- **THEN** the result SHALL contain one `ISwarmReplayManifestEntry` for `sim-1`
+- **AND** SHALL contain one `IQuickReplayManifestEntry` for `quick-9`
+
+#### Scenario: Scan covers legacy flat layout
+
+- **GIVEN** `simulation-reports/games/2026-05-01T10-00-00-000Z/sim-77.jsonl` exists (legacy)
+- **WHEN** the backfill scan runs
+- **THEN** the result SHALL contain an `ISwarmReplayManifestEntry` for `sim-77`
+- **AND** the entry's `batchTimestamp` SHALL equal `'2026-05-01T10-00-00-000Z'`
+
+#### Scenario: GameEnded.turns optionality fallback
+
+- **GIVEN** a `<gameId>.jsonl` whose `GameEnded` event is missing the `turns` field
+- **WHEN** the backfill scan processes it
+- **THEN** `entry.turns` SHALL equal the count of `turn_started` events in the file
+- **AND** if no `turn_started` events exist, `entry.turns` SHALL equal `0`
+
+#### Scenario: Scan is idempotent
+
+- **GIVEN** an unchanged `simulation-reports/` directory
+- **WHEN** the backfill scan is run twice
+- **THEN** the two resulting manifest arrays SHALL be deep-equal (same length, same entries, same field values)
+
+### Requirement: Replay Library Page
+
+The system SHALL provide a Replay Library page accessible from the primary navigation. The page SHALL load the replay index on mount, display every manifest entry as a list row with source-appropriate metadata visible (e.g. swarm rows show `configName`/`seed`; quick rows show `aiVariant`), and SHALL provide a source filter that limits the displayed list to a chosen `ReplaySource`.
+
+Clicking a list row SHALL open the existing replay viewer with the chosen entry's events loaded — without requiring the user to drag a file.
+
+#### Scenario: Page loads and lists all entries
+
+- **GIVEN** the index contains 3 swarm entries and 2 quick entries
+- **WHEN** the user navigates to the Replay Library page
+- **THEN** the page SHALL render exactly 5 list rows
+- **AND** each row SHALL show the entry's `id`, `createdAt`, `turns`, `winner`, and `bvTotal`
+
+#### Scenario: Source filter restricts list
+
+- **GIVEN** the index contains 3 swarm entries and 2 quick entries
+- **WHEN** the user selects the Quick filter
+- **THEN** only 2 rows SHALL be visible
+- **AND** both rows SHALL display the source-specific `aiVariant` field
+
+#### Scenario: Click opens replay viewer with events loaded
+
+- **GIVEN** a list row for a swarm entry with `path='swarm/sim-1.jsonl'`
+- **WHEN** the user clicks the row
+- **THEN** the replay viewer SHALL mount with the events from that file already loaded
+- **AND** the user SHALL NOT be prompted to drag a file

--- a/openspec/changes/add-replay-library/tasks.md
+++ b/openspec/changes/add-replay-library/tasks.md
@@ -1,0 +1,91 @@
+## 1. Types and enum (PR 1)
+
+- [x] 1.1 Add `ReplaySource` enum to `src/types/gameplay/GameSessionInterfaces.ts` (or sibling file `ReplaySource.ts`) with exactly the values `Swarm = 'swarm' | Quick = 'quick' | PvP = 'pvp' | Campaign = 'campaign'`
+- [x] 1.2 Add optional `replaySource?: ReplaySource` field to `IGameEventBase` (or `IBaseEvent` — match the existing interface name in the file)
+- [x] 1.3 Thread `replaySource` argument through `createGameEvent` in `src/simulation/runner/phases/utils.ts`; default to `undefined` if caller does not pass it
+- [x] 1.4 Add `IReplayManifestEntry` discriminated union types in `src/replay-library/types.ts` covering `ISwarmReplayManifestEntry`, `IQuickReplayManifestEntry`, `IPvPReplayManifestEntry`, `ICampaignReplayManifestEntry` (extend a shared `IReplayManifestEntryBase`)
+- [x] 1.5 Add unit tests asserting `Object.values(ReplaySource)` equals exactly four expected values
+- [x] 1.6 Add unit tests asserting the discriminated union narrows correctly on `replaySource` (compile-time test via type assertion)
+- [x] 1.7 Run `npm run typecheck` clean
+- [x] 1.8 Run `npm test` for new files clean
+- [ ] 1.9 PR opened, CI green, merged
+
+## 2. Index reader and writer (PR 2)
+
+- [ ] 2.1 Add `src/replay-library/index-reader.ts` with `readReplayIndex(): Promise<readonly IReplayManifestEntry[]>` that loads `simulation-reports/replay-index.json`, skips entries with unrecognized `replaySource`, logs skipped entries via the engine logger at debug level, and falls back to backfill scan when missing
+- [ ] 2.2 Add `src/replay-library/index-writer.ts` with `appendManifestEntry(entry: IReplayManifestEntry): Promise<void>` that atomically appends to `replay-index.json` (write to temp file, rename into place); creates the file if absent
+- [ ] 2.3 Unit tests: append preserves existing entries (1 → 2; 100 → 101)
+- [ ] 2.4 Unit tests: atomic write — simulate crash mid-write and verify original file is intact
+- [ ] 2.5 Unit tests: writer creates index when absent
+- [ ] 2.6 Unit tests: reader returns typed entries with correct discriminant narrowing
+- [ ] 2.7 Unit tests: reader skips unrecognized variants and logs at debug
+- [ ] 2.8 Run `npm run typecheck` clean
+- [ ] 2.9 Run `npm test` for new files clean
+- [ ] 2.10 PR opened, CI green, merged
+
+## 3. Backfill scan (PR 3)
+
+- [ ] 3.1 Add `src/replay-library/backfill-scan.ts` with `scanReplayDirectory(): Promise<readonly IReplayManifestEntry[]>` covering both partition layout (`simulation-reports/<source>/*.jsonl`) and legacy flat layout (`simulation-reports/games/<ts>/*.jsonl`)
+- [ ] 3.2 Stream-read each file's first event (`GameCreated`) and last event; compute `bvTotal` from `payload.units`, `winner`/`turns` from `GameEnded` (with `turn_started`-count fallback for missing `turns`)
+- [ ] 3.3 Infer `replaySource = ReplaySource.Swarm` for legacy flat-layout files; set `batchTimestamp` from the parent directory name
+- [ ] 3.4 Unit tests: scan covers new partition layout (one swarm fixture + one quick fixture)
+- [ ] 3.5 Unit tests: scan covers legacy flat layout (`games/<ts>/<id>.jsonl` fixture)
+- [ ] 3.6 Unit tests: `GameEnded.turns` optionality fallback (count `turn_started`, then `0`)
+- [ ] 3.7 Unit tests: scan is idempotent — two runs produce deep-equal arrays
+- [ ] 3.8 Run `npm run typecheck` clean
+- [ ] 3.9 Run `npm test` for new files clean
+- [ ] 3.10 PR opened, CI green, merged
+
+## 4. Swarm runner partition + manifest emit (PR 4)
+
+- [ ] 4.1 Update `src/simulation/runner/eventLogPersistence.ts` to write to `simulation-reports/swarm/<gameId>.jsonl` (replace flat `simulation-reports/games/<run-timestamp>/<gameId>.jsonl` write path)
+- [ ] 4.2 Update swarm output JSON `eventLogDir` to point at `simulation-reports/swarm/`
+- [ ] 4.3 After each successful swarm run, build an `ISwarmReplayManifestEntry` and call `appendManifestEntry`; preserve `batchTimestamp` as a metadata field on the entry
+- [ ] 4.4 Update `SimulationRunner` to thread `replaySource: ReplaySource.Swarm` through `createGameEvent` calls (or set it once at the runner boundary if there's a single chokepoint)
+- [ ] 4.5 Unit tests: 5-run swarm produces 5 files under `simulation-reports/swarm/` (no files under `simulation-reports/games/`)
+- [ ] 4.6 Unit tests: each swarm run appends one manifest entry with correct `configName`/`seed`/`batchTimestamp`
+- [ ] 4.7 Unit tests: persisted events round-trip via JSON.parse and carry `replaySource: ReplaySource.Swarm`
+- [ ] 4.8 Run `npm run typecheck` clean
+- [ ] 4.9 Run `npm test` clean
+- [ ] 4.10 PR opened, CI green, merged
+
+## 5. Quick game persistence (PR 5)
+
+- [ ] 5.1 Add a persistence effect to `src/components/quickgame/QuickGameResults.tsx` that fires on mount/finalize when the game has `GameEnded`
+- [ ] 5.2 Effect writes events to `simulation-reports/quick/<gameId>.jsonl` via the env-aware persistence module (Node implementation in v1; browser-only get no-op or IndexedDB stub flagged for follow-on)
+- [ ] 5.3 After the file is written, build an `IQuickReplayManifestEntry` and call `appendManifestEntry`
+- [ ] 5.4 Thread `replaySource: ReplaySource.Quick` through the in-process event store / `createGameEvent` for quick games
+- [ ] 5.5 Unit tests: quick game completion writes the file and the manifest entry
+- [ ] 5.6 Unit tests: persistence does not block render — results page renders synchronously while the effect is in-flight
+- [ ] 5.7 Unit tests: persisted quick events carry `replaySource: ReplaySource.Quick`
+- [ ] 5.8 Run `npm run typecheck` clean
+- [ ] 5.9 Run `npm test` clean
+- [ ] 5.10 PR opened, CI green, merged
+
+## 6. Replay Library page (PR 6)
+
+- [ ] 6.1 Add a new page route `src/pages/replay-library/index.tsx` (or equivalent per the existing routing convention)
+- [ ] 6.2 On mount, call `readReplayIndex()` and render the resulting entries as list rows with source-appropriate metadata visible (swarm: `configName`/`seed`; quick: `aiVariant`; PvP/campaign: placeholder until write paths exist)
+- [ ] 6.3 Add a source filter (radio group or tab strip) that limits the displayed list to the chosen `ReplaySource`
+- [ ] 6.4 Clicking a row opens the existing replay viewer with the chosen entry's events loaded — re-use the existing `useHexMapStateFromEvents` + replay viewer plumbing; load events by reading the file at `entry.path`
+- [ ] 6.5 Add link from primary navigation to the Replay Library page
+- [ ] 6.6 Unit tests: page lists 5 entries when index has 3 swarm + 2 quick
+- [ ] 6.7 Unit tests: source filter restricts list correctly
+- [ ] 6.8 Unit tests: clicking a row mounts the replay viewer with events loaded (no file drag)
+- [ ] 6.9 Storybook story for the Replay Library page (default state, filtered state, empty state)
+- [ ] 6.10 Run `npm run typecheck`, `npm run lint`, `npm test`, `npm run storybook:build` clean
+- [ ] 6.11 PR opened, CI green, merged
+
+## 7. End-to-end verification
+
+- [ ] 7.1 Run a fresh swarm: `tsx scripts/run-simulation.ts --config scripts/swarm-configs/duel-3kbv-temperate.json --runs 3 --seed 42`; verify 3 files appear under `simulation-reports/swarm/` and 3 entries in `replay-index.json`
+- [ ] 7.2 Run a quick game in the app and click through to results; verify `simulation-reports/quick/<gameId>.jsonl` is created and a manifest entry is appended
+- [ ] 7.3 Open the Replay Library page; verify both the swarm and quick entries appear with correct metadata; filter by Quick and verify only the quick entry shows; click the entry and verify the replay viewer opens and plays through
+- [ ] 7.4 Delete `replay-index.json` manually; reload the Replay Library page; verify the backfill scan reconstructs the index from on-disk files (including any pre-existing legacy `simulation-reports/games/<ts>/*.jsonl` files)
+- [ ] 7.5 `openspec validate add-replay-library --strict` clean
+
+## 8. Archive
+
+- [ ] 8.1 All PRs (1–6) merged to main
+- [ ] 8.2 Memory anchor written under `~/.claude/projects/E--Projects-MekStation/memory/project_replay_library.md` summarizing capability shipped, key files, deltas, lessons
+- [ ] 8.3 `openspec archive add-replay-library` runs cleanly; deltas merge into source-of-truth specs

--- a/src/replay-library/__tests__/types.test.ts
+++ b/src/replay-library/__tests__/types.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Compile-time + runtime assertions for the replay-library type primitives.
+ * Per add-replay-library PR 1 — proves the enum has exactly the four expected
+ * variants and the discriminated union narrows correctly on `replaySource`.
+ *
+ * The narrowing tests double as a regression guard: if a future PR adds a
+ * fifth variant to `ReplaySource` without updating `IReplayManifestEntry`,
+ * the exhaustiveness check below fails compilation immediately.
+ */
+
+import { GameSide, ReplaySource } from '@/types/gameplay';
+
+import type {
+  ICampaignReplayManifestEntry,
+  IPvPReplayManifestEntry,
+  IQuickReplayManifestEntry,
+  IReplayManifestEntry,
+  ISwarmReplayManifestEntry,
+} from '../types';
+
+describe('ReplaySource enum', () => {
+  it('has exactly four variants', () => {
+    // Object.values on a string-valued enum returns the value strings.
+    const values = Object.values(ReplaySource).sort();
+    expect(values).toEqual(['campaign', 'pvp', 'quick', 'swarm']);
+  });
+
+  it('variant string values match filesystem partition directory names', () => {
+    // Each enum value is the partition directory name verbatim — the writer
+    // path layer reads `entry.replaySource` and uses it as a directory
+    // segment without translation.
+    expect(ReplaySource.Swarm).toBe('swarm');
+    expect(ReplaySource.Quick).toBe('quick');
+    expect(ReplaySource.PvP).toBe('pvp');
+    expect(ReplaySource.Campaign).toBe('campaign');
+  });
+});
+
+describe('IReplayManifestEntry discriminated union', () => {
+  // Typed fixtures — if the union shape drifts, these stop compiling.
+  const swarmFixture: ISwarmReplayManifestEntry = {
+    id: 'sim-1',
+    replaySource: ReplaySource.Swarm,
+    path: 'swarm/sim-1.jsonl',
+    createdAt: '2026-05-07T12:00:00.000Z',
+    turns: 7,
+    winner: GameSide.Player,
+    bvTotal: 4500,
+    configName: 'duel-3kbv-temperate',
+    seed: 42,
+    batchTimestamp: '2026-05-07T11-58-00-000Z',
+  };
+
+  const quickFixture: IQuickReplayManifestEntry = {
+    id: 'quick-1',
+    replaySource: ReplaySource.Quick,
+    path: 'quick/quick-1.jsonl',
+    createdAt: '2026-05-07T12:01:00.000Z',
+    turns: 5,
+    winner: GameSide.Opponent,
+    bvTotal: 3200,
+    playerSide: GameSide.Player,
+    aiVariant: 'aggressive-v2',
+  };
+
+  const pvpFixture: IPvPReplayManifestEntry = {
+    id: 'pvp-1',
+    replaySource: ReplaySource.PvP,
+    path: 'pvp/pvp-1.jsonl',
+    createdAt: '2026-05-07T12:02:00.000Z',
+    turns: 9,
+    winner: null,
+    bvTotal: 5000,
+    opponentName: 'Strazz',
+    matchId: 'match-77',
+  };
+
+  const campaignFixture: ICampaignReplayManifestEntry = {
+    id: 'camp-1',
+    replaySource: ReplaySource.Campaign,
+    path: 'campaign/camp-1.jsonl',
+    createdAt: '2026-05-07T12:03:00.000Z',
+    turns: 12,
+    winner: GameSide.Player,
+    bvTotal: 7800,
+    campaignId: 'campaign-alpha',
+    missionId: 'mission-3',
+    difficulty: 'veteran',
+  };
+
+  it('narrows to swarm fields when replaySource === Swarm', () => {
+    const entry: IReplayManifestEntry = swarmFixture;
+    if (entry.replaySource === ReplaySource.Swarm) {
+      // Inside the narrowed branch, swarm-specific fields are accessible
+      // without a type assertion. If narrowing breaks, this won't compile.
+      expect(entry.configName).toBe('duel-3kbv-temperate');
+      expect(entry.seed).toBe(42);
+      expect(entry.batchTimestamp).toBe('2026-05-07T11-58-00-000Z');
+    } else {
+      throw new Error('expected swarm narrowing');
+    }
+  });
+
+  it('narrows to quick fields when replaySource === Quick', () => {
+    const entry: IReplayManifestEntry = quickFixture;
+    if (entry.replaySource === ReplaySource.Quick) {
+      expect(entry.playerSide).toBe(GameSide.Player);
+      expect(entry.aiVariant).toBe('aggressive-v2');
+    } else {
+      throw new Error('expected quick narrowing');
+    }
+  });
+
+  it('narrows to pvp fields when replaySource === PvP', () => {
+    const entry: IReplayManifestEntry = pvpFixture;
+    if (entry.replaySource === ReplaySource.PvP) {
+      expect(entry.opponentName).toBe('Strazz');
+      expect(entry.matchId).toBe('match-77');
+    } else {
+      throw new Error('expected pvp narrowing');
+    }
+  });
+
+  it('narrows to campaign fields when replaySource === Campaign', () => {
+    const entry: IReplayManifestEntry = campaignFixture;
+    if (entry.replaySource === ReplaySource.Campaign) {
+      expect(entry.campaignId).toBe('campaign-alpha');
+      expect(entry.missionId).toBe('mission-3');
+      expect(entry.difficulty).toBe('veteran');
+    } else {
+      throw new Error('expected campaign narrowing');
+    }
+  });
+
+  it('exhaustive switch covers every variant (compile-time guard)', () => {
+    // The `assertNever` helper makes a missing variant a compile error.
+    // If a future PR adds `ReplaySource.LANCoop` to the enum without
+    // updating `IReplayManifestEntry`, this switch ceases to compile.
+    function describeEntry(entry: IReplayManifestEntry): string {
+      switch (entry.replaySource) {
+        case ReplaySource.Swarm:
+          return `swarm:${entry.configName}`;
+        case ReplaySource.Quick:
+          return `quick:${entry.aiVariant}`;
+        case ReplaySource.PvP:
+          return `pvp:${entry.opponentName}`;
+        case ReplaySource.Campaign:
+          return `campaign:${entry.missionId}`;
+        default: {
+          const _exhaustive: never = entry;
+          return _exhaustive;
+        }
+      }
+    }
+
+    expect(describeEntry(swarmFixture)).toBe('swarm:duel-3kbv-temperate');
+    expect(describeEntry(quickFixture)).toBe('quick:aggressive-v2');
+    expect(describeEntry(pvpFixture)).toBe('pvp:Strazz');
+    expect(describeEntry(campaignFixture)).toBe('campaign:mission-3');
+  });
+
+  it('bvTotal is always a number on every variant (write-time computed)', () => {
+    // Per Council Decision 3 + Momus MUST RESOLVE #1: BV is computed once
+    // at manifest-write time and stored as a number. Read paths MUST NOT
+    // recompute. This test enforces the field is always populated.
+    const entries: readonly IReplayManifestEntry[] = [
+      swarmFixture,
+      quickFixture,
+      pvpFixture,
+      campaignFixture,
+    ];
+    for (const entry of entries) {
+      expect(typeof entry.bvTotal).toBe('number');
+      expect(entry.bvTotal).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('winner is GameSide or null (draws + no-result are first-class)', () => {
+    expect(pvpFixture.winner).toBeNull();
+    expect(swarmFixture.winner).toBe(GameSide.Player);
+    expect(quickFixture.winner).toBe(GameSide.Opponent);
+  });
+});

--- a/src/replay-library/index.ts
+++ b/src/replay-library/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Public API barrel for the replay-library module. Per add-replay-library
+ * (PR 1 introduces types only; PR 2 adds index reader/writer; PR 3 adds
+ * backfill scan; subsequent PRs wire writers + UI).
+ */
+
+export type {
+  ICampaignReplayManifestEntry,
+  IPvPReplayManifestEntry,
+  IQuickReplayManifestEntry,
+  IReplayManifestEntry,
+  IReplayManifestEntryBase,
+  ISwarmReplayManifestEntry,
+} from './types';

--- a/src/replay-library/types.ts
+++ b/src/replay-library/types.ts
@@ -1,0 +1,107 @@
+/**
+ * Replay manifest types — discriminated union covering every replay source
+ * the engine produces. Per add-replay-library (replay-library spec —
+ * IReplayManifestEntry Discriminated Union): one entry shape per
+ * `ReplaySource` so the central `simulation-reports/replay-index.json`
+ * can be filtered, narrowed, and rendered with source-specific metadata.
+ *
+ * Council #4 ruled an enum-discriminated union (Option C hybrid) over a
+ * flat shape with optional fields because TypeScript can enforce that
+ * "swarm entries always have configName" while a flat shape cannot.
+ */
+
+import { GameSide, ReplaySource } from '@/types/gameplay';
+
+/**
+ * Fields shared by every replay manifest entry. `bvTotal` is computed at
+ * write time from `IGameCreatedPayload.units`; consumers MUST NOT lazy-
+ * recompute on read (Momus MUST RESOLVE #1 — IGameUnit has no `bv` field
+ * for cheap access, so the only correct answer is "compute once at write").
+ */
+export interface IReplayManifestEntryBase {
+  /** Game identifier — also the file basename (without `.jsonl` extension). */
+  readonly id: string;
+  /** Replay source discriminator. */
+  readonly replaySource: ReplaySource;
+  /**
+   * File path relative to `simulation-reports/` (e.g. `"swarm/sim-1.jsonl"`,
+   * `"quick/quick-99.jsonl"`). The Library page reads `simulation-reports/`
+   * + this path to load the event log.
+   */
+  readonly path: string;
+  /** ISO 8601 timestamp at manifest-write time. */
+  readonly createdAt: string;
+  /**
+   * Number of turns played. Derived from `GameEnded.turns` when present;
+   * falls back to count of `turn_started` events; falls back to `0` when
+   * neither is present (e.g. crashed mid-run).
+   */
+  readonly turns: number;
+  /** Winner side, or `null` for draws / no result. */
+  readonly winner: GameSide | null;
+  /** Sum of unit BVs from `GameCreated.payload.units`. */
+  readonly bvTotal: number;
+}
+
+/**
+ * Swarm CLI runner output. Stored under `simulation-reports/swarm/`.
+ * `batchTimestamp` groups runs from a single `run-simulation.ts` invocation
+ * (was the directory segment in the legacy flat layout; now a metadata
+ * field on the entry so the partition stays flat-by-id).
+ */
+export interface ISwarmReplayManifestEntry extends IReplayManifestEntryBase {
+  readonly replaySource: ReplaySource.Swarm;
+  /** Swarm config file basename (e.g. `"duel-3kbv-temperate"`). */
+  readonly configName: string;
+  /** Run seed for reproducibility. */
+  readonly seed: number;
+  /** Per-invocation timestamp (preserved from the legacy `run-timestamp`). */
+  readonly batchTimestamp: string;
+}
+
+/**
+ * In-app quick game. Stored under `simulation-reports/quick/`. Persisted
+ * by `QuickGameResults` on completion (today the stream lives in memory
+ * and dies with the React tree — this is the new write path).
+ */
+export interface IQuickReplayManifestEntry extends IReplayManifestEntryBase {
+  readonly replaySource: ReplaySource.Quick;
+  /** Side the player chose. */
+  readonly playerSide: GameSide;
+  /** AI variant identifier in use for this quick game. */
+  readonly aiVariant: string;
+}
+
+/**
+ * PvP match record. Reserved for future use — `InMemoryMatchStore` is
+ * dev-only today and has no durable persistence. Manifest shape pre-defined
+ * so the future PvP write path plugs in without spec churn.
+ */
+export interface IPvPReplayManifestEntry extends IReplayManifestEntryBase {
+  readonly replaySource: ReplaySource.PvP;
+  readonly opponentName: string;
+  readonly matchId: string;
+}
+
+/**
+ * Campaign mission record. Reserved for future use — campaign mode does
+ * not emit events yet. Manifest shape pre-defined so the future campaign
+ * emitter plugs in without spec churn.
+ */
+export interface ICampaignReplayManifestEntry extends IReplayManifestEntryBase {
+  readonly replaySource: ReplaySource.Campaign;
+  readonly campaignId: string;
+  readonly missionId: string;
+  readonly difficulty: string;
+}
+
+/**
+ * Discriminated union of every manifest entry shape. Narrows on
+ * `entry.replaySource`. Consumers iterating `IReplayManifestEntry[]`
+ * must handle every variant or fail compilation.
+ */
+export type IReplayManifestEntry =
+  | ISwarmReplayManifestEntry
+  | IQuickReplayManifestEntry
+  | IPvPReplayManifestEntry
+  | ICampaignReplayManifestEntry;

--- a/src/simulation/runner/phases/__tests__/utils.test.ts
+++ b/src/simulation/runner/phases/__tests__/utils.test.ts
@@ -22,6 +22,7 @@ import {
   GameSide,
   IDamageAppliedPayload,
   ITurnStartedPayload,
+  ReplaySource,
 } from '@/types/gameplay';
 
 import { createGameEvent } from '../utils';
@@ -123,5 +124,87 @@ describe('createGameEvent — side denormalization', () => {
     expect(event.side).toBe(GameSide.Player);
     // ISO-8601 timestamp parses as a valid date.
     expect(Number.isFinite(Date.parse(event.timestamp))).toBe(true);
+  });
+});
+
+describe('createGameEvent — replaySource discriminator', () => {
+  // Per add-replay-library (game-event-system delta — Event Envelope Replay
+  // Source Discriminator): the optional `replaySource` argument flows
+  // through to the envelope. Field is omitted from the serialized line
+  // when not provided so legacy NDJSON streams round-trip unchanged.
+  const turnStarted: ITurnStartedPayload = {};
+
+  it('attaches replaySource=Swarm when caller passes it', () => {
+    const event = createGameEvent(
+      'swarm-1',
+      0,
+      GameEventType.TurnStarted,
+      1,
+      GamePhase.Initiative,
+      turnStarted,
+      undefined,
+      ReplaySource.Swarm,
+    );
+
+    expect(event.replaySource).toBe(ReplaySource.Swarm);
+    expect(JSON.stringify(event)).toContain('"replaySource":"swarm"');
+  });
+
+  it('attaches replaySource=Quick for in-app quick games', () => {
+    const event = createGameEvent(
+      'quick-9',
+      3,
+      GameEventType.TurnStarted,
+      2,
+      GamePhase.Initiative,
+      turnStarted,
+      undefined,
+      ReplaySource.Quick,
+    );
+
+    expect(event.replaySource).toBe(ReplaySource.Quick);
+  });
+
+  it('omits replaySource when not provided (legacy callers / back-compat)', () => {
+    const event = createGameEvent(
+      'legacy-1',
+      0,
+      GameEventType.TurnStarted,
+      1,
+      GamePhase.Initiative,
+      turnStarted,
+      // no actorId, no replaySource
+    );
+
+    expect(event.replaySource).toBeUndefined();
+    // Contract: JSON.stringify omits undefined properties so the field
+    // does not appear in serialized event-log lines.
+    expect(JSON.stringify(event)).not.toContain('"replaySource"');
+  });
+
+  it('preserves both side and replaySource when both are derivable', () => {
+    const damagePayload: IDamageAppliedPayload = {
+      unitId: 'player-1',
+      location: 'center_torso',
+      damage: 5,
+      armorRemaining: 15,
+      structureRemaining: 10,
+      locationDestroyed: false,
+      sourceUnitId: 'opponent-2',
+    };
+
+    const event = createGameEvent(
+      'swarm-2',
+      7,
+      GameEventType.DamageApplied,
+      3,
+      GamePhase.WeaponAttack,
+      damagePayload,
+      'player-1',
+      ReplaySource.Swarm,
+    );
+
+    expect(event.side).toBe(GameSide.Player);
+    expect(event.replaySource).toBe(ReplaySource.Swarm);
   });
 });

--- a/src/simulation/runner/phases/utils.ts
+++ b/src/simulation/runner/phases/utils.ts
@@ -3,6 +3,7 @@ import {
   GamePhase,
   GameSide,
   IGameEvent,
+  ReplaySource,
 } from '@/types/gameplay';
 import { D6Roller } from '@/utils/gameplay/hitLocation';
 
@@ -34,6 +35,17 @@ function deriveSide(actorId: string | undefined): GameSide | undefined {
   return undefined;
 }
 
+/**
+ * Single chokepoint for emitting `IGameEvent` records. Per add-replay-library
+ * (game-event-system delta — Event Envelope Replay Source Discriminator):
+ * accepts an optional `replaySource` that flows onto the envelope so
+ * consumers (replay viewer, library page, backfill scan) can route events
+ * by origin without filename archaeology.
+ *
+ * `replaySource` is optional for back-compat: callers from legacy code
+ * paths that haven't been threaded yet pass nothing, the field is omitted,
+ * and consumers fall back to inferring from filesystem location.
+ */
 export function createGameEvent(
   gameId: string,
   sequence: number,
@@ -42,6 +54,7 @@ export function createGameEvent(
   phase: GamePhase,
   payload: IGameEvent['payload'],
   actorId?: string,
+  replaySource?: ReplaySource,
 ): IGameEvent {
   const side = deriveSide(actorId);
   return {
@@ -55,5 +68,6 @@ export function createGameEvent(
     payload,
     ...(actorId !== undefined ? { actorId } : {}),
     ...(side !== undefined ? { side } : {}),
+    ...(replaySource !== undefined ? { replaySource } : {}),
   };
 }

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -274,6 +274,27 @@ export enum GameSide {
   Opponent = 'opponent',
 }
 
+/**
+ * Origin domain of a replay event log. Discriminates the four replay sources
+ * the engine produces so the central replay index, filesystem partition, and
+ * Library UI can route entries without filename archaeology.
+ *
+ * Per add-replay-library (Council #4 — Option C hybrid): the enum values are
+ * the literal strings written to NDJSON and used as filesystem partition
+ * directory names (e.g. ReplaySource.Swarm → simulation-reports/swarm/).
+ *
+ * Why an enum instead of a string union: sc2reader's 7-year deprecation pain
+ * came from a string discriminator that drifted as new replay sources were
+ * added with no exhaustiveness check. An enum forces every consumer to
+ * handle every variant or fail compilation.
+ */
+export enum ReplaySource {
+  Swarm = 'swarm',
+  Quick = 'quick',
+  PvP = 'pvp',
+  Campaign = 'campaign',
+}
+
 // =============================================================================
 // Networked Game Intents
 // =============================================================================
@@ -344,6 +365,21 @@ export interface IGameEventBase {
    * streams written before this denormalization landed.
    */
   readonly side?: GameSide;
+  /**
+   * Replay source discriminator. Set at emission time by whichever subsystem
+   * authored the event (swarm runner → Swarm; quick-game store → Quick;
+   * future PvP → PvP; future campaign emitter → Campaign).
+   *
+   * Field name is `replaySource` (not `source`) to avoid collision with
+   * payload-level `source` strings on heat events ("movement"|"weapons"|
+   * "dissipation") and pilot-hit events ("head_hit"|"ammo_explosion"|...).
+   *
+   * Optional so legacy NDJSON streams written before this field landed
+   * replay unchanged. Per add-replay-library: consumers may infer
+   * `ReplaySource.Swarm` for files discovered under the legacy
+   * `simulation-reports/games/<ts>/` flat layout.
+   */
+  readonly replaySource?: ReplaySource;
 }
 
 /**


### PR DESCRIPTION
## Summary

Foundation for the **Replay Library** — searchable in-app catalog of every replay the engine produces, partitioned by source so swarm / quick / PvP / campaign stay distinct (per OMO Council #4 — Option C hybrid).

This PR is **types-only**:

- `ReplaySource` enum (`Swarm | Quick | PvP | Campaign`) added to `src/types/gameplay/GameSessionInterfaces.ts`. Enum values are the literal strings written to NDJSON and used as filesystem partition directory names. Enum-not-string-union picked per sc2reader's 7-year deprecation lesson — exhaustiveness checks block silent drift.
- Optional `replaySource?: ReplaySource` field on `IGameEventBase`. Field name avoids the existing payload-level `source` strings on heat events and pilot-hit events. Optional for back-compat with NDJSON streams written before this field landed.
- `replaySource` argument threaded through `createGameEvent` (the single emission chokepoint). Defaults to `undefined` for legacy callers; field is omitted from the serialized envelope when not provided.
- `IReplayManifestEntry` discriminated union (Swarm/Quick/PvP/Campaign variants extending a shared base) in `src/replay-library/types.ts`. Each variant carries source-specific metadata. `bvTotal` computed at write time per Council Decision 3 + Momus MUST RESOLVE #1.

**6-PR ladder:**
1. **types + enum (this PR)**
2. index reader/writer
3. backfill scan
4. swarm runner partition + manifest emit
5. quick game persistence
6. Replay Library page + nav

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx jest src/replay-library src/simulation/runner/phases/__tests__/utils.test.ts` — 18/18 green
- [x] `npm run lint` — 0 errors (44 pre-existing warnings, none from new files)
- [ ] CI green on this PR

Refs: \`openspec/changes/add-replay-library/{proposal,design,tasks}.md\`
Refs: \`openspec/changes/add-replay-library/specs/{replay-library,game-event-system,quick-session}/spec.md\`