### PR TITLE
feat(replay-library): add central index reader + writer (PR 2/6)

### DIFF
--- a/openspec/changes/add-replay-library/tasks.md
+++ b/openspec/changes/add-replay-library/tasks.md
@@ -12,15 +12,15 @@
 
 ## 2. Index reader and writer (PR 2)
 
-- [ ] 2.1 Add `src/replay-library/index-reader.ts` with `readReplayIndex(): Promise<readonly IReplayManifestEntry[]>` that loads `simulation-reports/replay-index.json`, skips entries with unrecognized `replaySource`, logs skipped entries via the engine logger at debug level, and falls back to backfill scan when missing
-- [ ] 2.2 Add `src/replay-library/index-writer.ts` with `appendManifestEntry(entry: IReplayManifestEntry): Promise<void>` that atomically appends to `replay-index.json` (write to temp file, rename into place); creates the file if absent
-- [ ] 2.3 Unit tests: append preserves existing entries (1 → 2; 100 → 101)
-- [ ] 2.4 Unit tests: atomic write — simulate crash mid-write and verify original file is intact
-- [ ] 2.5 Unit tests: writer creates index when absent
-- [ ] 2.6 Unit tests: reader returns typed entries with correct discriminant narrowing
-- [ ] 2.7 Unit tests: reader skips unrecognized variants and logs at debug
-- [ ] 2.8 Run `npm run typecheck` clean
-- [ ] 2.9 Run `npm test` for new files clean
+- [x] 2.1 Add `src/replay-library/index-reader.ts` with `readReplayIndex(): Promise<readonly IReplayManifestEntry[]>` that loads `simulation-reports/replay-index.json`, skips entries with unrecognized `replaySource`, logs skipped entries via the engine logger at debug level, and falls back to backfill scan when missing
+- [x] 2.2 Add `src/replay-library/index-writer.ts` with `appendManifestEntry(entry: IReplayManifestEntry): Promise<void>` that atomically appends to `replay-index.json` (write to temp file, rename into place); creates the file if absent
+- [x] 2.3 Unit tests: append preserves existing entries (1 → 2; 100 → 101)
+- [x] 2.4 Unit tests: atomic write — simulate crash mid-write and verify original file is intact
+- [x] 2.5 Unit tests: writer creates index when absent
+- [x] 2.6 Unit tests: reader returns typed entries with correct discriminant narrowing
+- [x] 2.7 Unit tests: reader skips unrecognized variants and logs at debug
+- [x] 2.8 Run `npm run typecheck` clean
+- [x] 2.9 Run `npm test` for new files clean
 - [ ] 2.10 PR opened, CI green, merged
 
 ## 3. Backfill scan (PR 3)

--- a/src/replay-library/__tests__/index-reader.test.ts
+++ b/src/replay-library/__tests__/index-reader.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for the central replay-index reader.
+ *
+ * Covers the three Central Replay Index Reader spec scenarios:
+ *   1. Reader returns typed entries (1 swarm + 1 quick fixture)
+ *   2. Reader skips unrecognized variants and logs at debug
+ *   3. Missing index → backfill stub invoked, return value passed through
+ *
+ * Tests stage fixtures into `os.tmpdir()` and pass the parent as `cwd` so the
+ * reader resolves to a clean tmp `simulation-reports/replay-index.json`.
+ */
+
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { GameSide, ReplaySource } from '@/types/gameplay';
+import { disableTestMode, enableTestMode, logger } from '@/utils/logger';
+
+import type {
+  IQuickReplayManifestEntry,
+  IReplayManifestEntry,
+  ISwarmReplayManifestEntry,
+} from '../types';
+
+import { readReplayIndex } from '../index-reader';
+
+// ---------------------------------------------------------------------------
+// Test fixture factory — builds an isolated tmpdir per test so concurrent
+// runs cannot stomp each other (jest --runInBand is not assumed).
+// ---------------------------------------------------------------------------
+async function makeTmpCwd(): Promise<string> {
+  const dir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'replay-library-reader-'),
+  );
+  await fs.mkdir(path.join(dir, 'simulation-reports'), { recursive: true });
+  return dir;
+}
+
+async function writeIndex(cwd: string, contents: unknown): Promise<void> {
+  await fs.writeFile(
+    path.join(cwd, 'simulation-reports', 'replay-index.json'),
+    JSON.stringify(contents, null, 2),
+    'utf8',
+  );
+}
+
+const swarmFixture: ISwarmReplayManifestEntry = {
+  id: 'sim-1',
+  replaySource: ReplaySource.Swarm,
+  path: 'swarm/sim-1.jsonl',
+  createdAt: '2026-05-07T12:00:00.000Z',
+  turns: 7,
+  winner: GameSide.Player,
+  bvTotal: 4500,
+  configName: 'duel-3kbv-temperate',
+  seed: 42,
+  batchTimestamp: '2026-05-07T11-58-00-000Z',
+};
+
+const quickFixture: IQuickReplayManifestEntry = {
+  id: 'quick-1',
+  replaySource: ReplaySource.Quick,
+  path: 'quick/quick-1.jsonl',
+  createdAt: '2026-05-07T12:01:00.000Z',
+  turns: 5,
+  winner: GameSide.Opponent,
+  bvTotal: 3200,
+  playerSide: GameSide.Player,
+  aiVariant: 'aggressive-v2',
+};
+
+describe('readReplayIndex', () => {
+  let consoleDebugSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    enableTestMode();
+    consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+  });
+
+  afterEach(() => {
+    disableTestMode();
+    jest.restoreAllMocks();
+  });
+
+  it('returns typed entries that narrow on replaySource', async () => {
+    const cwd = await makeTmpCwd();
+    await writeIndex(cwd, [swarmFixture, quickFixture]);
+
+    const entries = await readReplayIndex({ cwd });
+
+    expect(entries).toHaveLength(2);
+    // Discriminant narrowing must work post-load — the reader returns a
+    // typed `IReplayManifestEntry[]` so consumers can narrow without casts.
+    const swarm = entries[0];
+    expect(swarm.replaySource).toBe(ReplaySource.Swarm);
+    if (swarm.replaySource === ReplaySource.Swarm) {
+      expect(swarm.configName).toBe('duel-3kbv-temperate');
+      expect(swarm.seed).toBe(42);
+    } else {
+      throw new Error('expected swarm narrowing');
+    }
+    const quick = entries[1];
+    expect(quick.replaySource).toBe(ReplaySource.Quick);
+    if (quick.replaySource === ReplaySource.Quick) {
+      expect(quick.aiVariant).toBe('aggressive-v2');
+    } else {
+      throw new Error('expected quick narrowing');
+    }
+  });
+
+  it('skips entries with unrecognized replaySource and logs at debug', async () => {
+    const cwd = await makeTmpCwd();
+    // The future-variant entry uses a `replaySource` value not in the current
+    // enum (`'lan-coop'`). Reader must filter it but preserve the recognized
+    // entries. `as unknown as IReplayManifestEntry` is the only way to
+    // construct an entry the type system would otherwise reject — the whole
+    // point of this test is to assert runtime forward-compat.
+    const futureVariant = {
+      ...swarmFixture,
+      id: 'future-99',
+      replaySource: 'lan-coop',
+    } as unknown as IReplayManifestEntry;
+
+    await writeIndex(cwd, [swarmFixture, futureVariant, quickFixture]);
+
+    const entries = await readReplayIndex({ cwd });
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((e) => e.id)).toEqual(['sim-1', 'quick-1']);
+
+    // Debug log must mention the skipped entry's id so a developer running
+    // with debug logs can identify what was filtered.
+    const debugCalls = consoleDebugSpy.mock.calls;
+    const skipLog = debugCalls.find(
+      (call) =>
+        typeof call[0] === 'string' &&
+        call[0].includes('unrecognized replaySource'),
+    );
+    expect(skipLog).toBeDefined();
+    expect(skipLog?.[1]).toMatchObject({
+      id: 'future-99',
+      replaySource: 'lan-coop',
+    });
+  });
+
+  it('falls back to the backfill scan when replay-index.json is missing', async () => {
+    const cwd = await makeTmpCwd();
+    // Sanity — confirm the file is genuinely absent before invoking.
+    await expect(
+      fs.access(path.join(cwd, 'simulation-reports', 'replay-index.json')),
+    ).rejects.toThrow();
+
+    // Inject a stub the test can assert on. PR 3 wires the real scan; this
+    // test pins the contract that "missing file → invoke fallback, return
+    // its array".
+    const backfillResult: readonly IReplayManifestEntry[] = [swarmFixture];
+    const backfillScan = jest.fn(() => Promise.resolve(backfillResult));
+
+    const entries = await readReplayIndex({ cwd, backfillScan });
+
+    expect(backfillScan).toHaveBeenCalledTimes(1);
+    expect(entries).toEqual(backfillResult);
+  });
+
+  it('logs the indexPath at debug when the missing-file fallback fires', async () => {
+    const cwd = await makeTmpCwd();
+    const backfillScan = jest.fn(() => Promise.resolve([]));
+
+    await readReplayIndex({ cwd, backfillScan });
+
+    // The missing-file branch logs a debug message; presence is the contract.
+    // Logger silences `debug` in production but emits in test mode (we set it
+    // above) — so the spy should have at least one call.
+    expect(consoleDebugSpy.mock.calls.length).toBeGreaterThan(0);
+    // Belt-and-braces: the logger module is the one we imported.
+    expect(typeof logger.debug).toBe('function');
+  });
+});

--- a/src/replay-library/__tests__/index-writer.test.ts
+++ b/src/replay-library/__tests__/index-writer.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for the central replay-index writer.
+ *
+ * Covers the four Central Replay Index Writer spec scenarios:
+ *   1. Append preserves existing entries (1 → 2; 100 → 101)
+ *   2. Atomic write — simulate crash mid-write (mock fs.rename to throw
+ *      after the temp file is written) and verify the original index is
+ *      intact AND the orphan temp file is not loaded by the reader
+ *   3. Writer creates the index file when absent
+ *   4. Concurrent appends produce both entries (Promise.all of two appends)
+ *
+ * Each test mints a fresh tmpdir so concurrent jest workers cannot stomp.
+ */
+
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { GameSide, ReplaySource } from '@/types/gameplay';
+
+import type {
+  IQuickReplayManifestEntry,
+  IReplayManifestEntry,
+  ISwarmReplayManifestEntry,
+} from '../types';
+
+import { readReplayIndex } from '../index-reader';
+import { appendManifestEntry } from '../index-writer';
+
+// ---------------------------------------------------------------------------
+// Tmpdir factory + fixture builders
+// ---------------------------------------------------------------------------
+async function makeTmpCwd(): Promise<string> {
+  const dir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'replay-library-writer-'),
+  );
+  await fs.mkdir(path.join(dir, 'simulation-reports'), { recursive: true });
+  return dir;
+}
+
+function indexPath(cwd: string): string {
+  return path.join(cwd, 'simulation-reports', 'replay-index.json');
+}
+
+async function writeIndexJson(cwd: string, contents: unknown): Promise<void> {
+  await fs.writeFile(indexPath(cwd), JSON.stringify(contents, null, 2), 'utf8');
+}
+
+function makeSwarmEntry(id: string, seed = 42): ISwarmReplayManifestEntry {
+  return {
+    id,
+    replaySource: ReplaySource.Swarm,
+    path: `swarm/${id}.jsonl`,
+    createdAt: '2026-05-07T12:00:00.000Z',
+    turns: 7,
+    winner: GameSide.Player,
+    bvTotal: 4500,
+    configName: 'duel-3kbv-temperate',
+    seed,
+    batchTimestamp: '2026-05-07T11-58-00-000Z',
+  };
+}
+
+function makeQuickEntry(id: string): IQuickReplayManifestEntry {
+  return {
+    id,
+    replaySource: ReplaySource.Quick,
+    path: `quick/${id}.jsonl`,
+    createdAt: '2026-05-07T12:01:00.000Z',
+    turns: 5,
+    winner: GameSide.Opponent,
+    bvTotal: 3200,
+    playerSide: GameSide.Player,
+    aiVariant: 'aggressive-v2',
+  };
+}
+
+describe('appendManifestEntry', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('appends to an existing 1-entry index → 2 entries', async () => {
+    const cwd = await makeTmpCwd();
+    const first = makeSwarmEntry('sim-1');
+    await writeIndexJson(cwd, [first]);
+
+    await appendManifestEntry(makeQuickEntry('quick-1'), { cwd });
+
+    const after: IReplayManifestEntry[] = JSON.parse(
+      await fs.readFile(indexPath(cwd), 'utf8'),
+    );
+    expect(after).toHaveLength(2);
+    // Existing entry preserved verbatim — round-trip via JSON to mirror what
+    // the reader sees, NOT a referential check (the writer rebuilds the array).
+    expect(after[0]).toEqual(first);
+    expect(after[1].id).toBe('quick-1');
+  });
+
+  it('appends to a 100-entry index → 101 entries', async () => {
+    const cwd = await makeTmpCwd();
+    // 100 existing entries — locks the bulk-preservation path.
+    const initial: IReplayManifestEntry[] = Array.from(
+      { length: 100 },
+      (_, i) => makeSwarmEntry(`sim-${i}`, i),
+    );
+    await writeIndexJson(cwd, initial);
+
+    await appendManifestEntry(makeQuickEntry('quick-new'), { cwd });
+
+    const after: IReplayManifestEntry[] = JSON.parse(
+      await fs.readFile(indexPath(cwd), 'utf8'),
+    );
+    expect(after).toHaveLength(101);
+    // Order preserved + every original entry intact.
+    for (let i = 0; i < 100; i += 1) {
+      expect(after[i]).toEqual(initial[i]);
+    }
+    expect(after[100].id).toBe('quick-new');
+  });
+
+  it('atomic write — fs.rename failure leaves the original index intact', async () => {
+    const cwd = await makeTmpCwd();
+    const original = [makeSwarmEntry('sim-original')];
+    await writeIndexJson(cwd, original);
+
+    // Snapshot the byte-perfect original content so we can assert it survives.
+    const originalBytes = await fs.readFile(indexPath(cwd), 'utf8');
+
+    // Mock fs.promises.rename to throw — simulates a crash AFTER the temp
+    // file landed but BEFORE the rename finalized.
+    const renameSpy = jest
+      .spyOn(fs, 'rename')
+      .mockImplementationOnce(() =>
+        Promise.reject(new Error('simulated mid-write crash')),
+      );
+
+    await expect(
+      appendManifestEntry(makeQuickEntry('quick-failed'), { cwd }),
+    ).rejects.toThrow('simulated mid-write crash');
+
+    // Original index unchanged byte-for-byte.
+    expect(await fs.readFile(indexPath(cwd), 'utf8')).toBe(originalBytes);
+
+    // Reader does not pick up any orphan temp file — only `replay-index.json`
+    // is read, and the temp suffix is not the canonical name. The writer
+    // best-effort-cleans the temp on rename failure, but the contract is
+    // "reader does not load it" not "the temp is guaranteed deleted".
+    const entries = await readReplayIndex({ cwd });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe('sim-original');
+
+    // Sanity — the rename was attempted exactly once (no retry loop).
+    expect(renameSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates the index file when absent', async () => {
+    const cwd = await makeTmpCwd();
+    // Sanity — confirm the file is genuinely absent before invoking.
+    await expect(fs.access(indexPath(cwd))).rejects.toThrow();
+
+    await appendManifestEntry(makeSwarmEntry('sim-first'), { cwd });
+
+    const after: IReplayManifestEntry[] = JSON.parse(
+      await fs.readFile(indexPath(cwd), 'utf8'),
+    );
+    expect(after).toHaveLength(1);
+    expect(after[0].id).toBe('sim-first');
+  });
+
+  it('creates the parent simulation-reports/ directory when absent', async () => {
+    // Edge case — fresh checkout where the writer is the first surface to
+    // materialize `simulation-reports/`. We use a tmpdir that does NOT
+    // pre-create the subdir.
+    const cwd = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'replay-library-writer-fresh-'),
+    );
+    await expect(
+      fs.access(path.join(cwd, 'simulation-reports')),
+    ).rejects.toThrow();
+
+    await appendManifestEntry(makeSwarmEntry('sim-genesis'), { cwd });
+
+    const after: IReplayManifestEntry[] = JSON.parse(
+      await fs.readFile(indexPath(cwd), 'utf8'),
+    );
+    expect(after).toHaveLength(1);
+    expect(after[0].id).toBe('sim-genesis');
+  });
+
+  it('concurrent appends serialize — both entries land', async () => {
+    const cwd = await makeTmpCwd();
+    // Empty starting state — both appends create-or-extend safely.
+    await Promise.all([
+      appendManifestEntry(makeSwarmEntry('sim-a'), { cwd }),
+      appendManifestEntry(makeQuickEntry('quick-b'), { cwd }),
+    ]);
+
+    const after: IReplayManifestEntry[] = JSON.parse(
+      await fs.readFile(indexPath(cwd), 'utf8'),
+    );
+    expect(after).toHaveLength(2);
+    // Order is deterministic via the per-path mutex (FIFO on the queue).
+    // Identity assertion — both ids are present, regardless of order.
+    const ids = after.map((e) => e.id).sort();
+    expect(ids).toEqual(['quick-b', 'sim-a']);
+  });
+});

--- a/src/replay-library/index-reader.ts
+++ b/src/replay-library/index-reader.ts
@@ -1,0 +1,151 @@
+/**
+ * Central replay index reader. Loads `simulation-reports/replay-index.json`
+ * and returns a typed `readonly IReplayManifestEntry[]`. Forward-compatible
+ * with future `ReplaySource` variants — entries whose `replaySource` is not a
+ * recognized enum value are skipped (with a debug log) so a newer build
+ * writing a future variant cannot crash this reader.
+ *
+ * Per add-replay-library spec (Central Replay Index Reader requirement):
+ *   - Skip + debug-log unknown variants
+ *   - When the index file is missing, invoke the backfill scan and return
+ *     its result. PR 2 ships the reader with a stub fallback (returns an
+ *     empty array); PR 3 plugs the real `scanReplayDirectory` in.
+ *
+ * PR 2 is Node-only; PR 5 will introduce env-aware abstraction for browser builds.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { ReplaySource } from '@/types/gameplay';
+import { logger } from '@/utils/logger';
+
+import type { IReplayManifestEntry } from './types';
+
+/**
+ * Stub backfill scan used when `replay-index.json` is missing. PR 3 replaces
+ * this with the real on-disk scan; for PR 2 the empty-array stub keeps the
+ * reader exhaustively testable without coupling to the scan implementation.
+ */
+export type BackfillScan = () => Promise<readonly IReplayManifestEntry[]>;
+
+/**
+ * Default backfill stub — returns an empty manifest. Exported so the test can
+ * spy on it and PR 3 can flip the default in one diff.
+ */
+export const defaultBackfillScan: BackfillScan = () => Promise.resolve([]);
+
+/**
+ * Options for the reader. `cwd` lets tests inject a tmpdir without polluting
+ * the real `simulation-reports/`; `backfillScan` lets tests assert the
+ * fallback path is invoked.
+ */
+export interface IReadReplayIndexOptions {
+  /** Override `process.cwd()` for the index path resolution. */
+  readonly cwd?: string;
+  /** Override the missing-file fallback (defaults to the empty-array stub). */
+  readonly backfillScan?: BackfillScan;
+}
+
+/**
+ * Resolves the absolute path to `simulation-reports/replay-index.json` rooted
+ * at the supplied `cwd` (or `process.cwd()` when omitted).
+ */
+function resolveIndexPath(cwd?: string): string {
+  return path.resolve(
+    cwd ?? process.cwd(),
+    'simulation-reports',
+    'replay-index.json',
+  );
+}
+
+/**
+ * Set of recognized `ReplaySource` enum values, materialized once. Membership
+ * check uses this set instead of pattern-matching each variant individually
+ * so adding a fifth `ReplaySource` value automatically extends the recognized
+ * set without touching this file.
+ */
+const RECOGNIZED_REPLAY_SOURCES: ReadonlySet<string> = new Set(
+  Object.values(ReplaySource),
+);
+
+/**
+ * Type guard — narrows a parsed-JSON candidate to `IReplayManifestEntry`
+ * provided its `replaySource` is a recognized enum value. Other shape checks
+ * are intentionally minimal: we trust the writer to produce well-formed
+ * entries and rely on TypeScript at the consumer boundary. The forward-compat
+ * filter is the load-bearing check here.
+ */
+function hasRecognizedReplaySource(
+  candidate: unknown,
+): candidate is IReplayManifestEntry {
+  if (typeof candidate !== 'object' || candidate === null) return false;
+  const source = (candidate as { replaySource?: unknown }).replaySource;
+  return typeof source === 'string' && RECOGNIZED_REPLAY_SOURCES.has(source);
+}
+
+/**
+ * Loads the central replay index. Forward-compatible with unknown variants.
+ *
+ * Behavior:
+ *   - If `replay-index.json` exists and parses, returns the recognized
+ *     entries (skips + debug-logs forward-compat ones).
+ *   - If `replay-index.json` does not exist (`ENOENT`), invokes the
+ *     `backfillScan` option (default: empty-array stub) and returns its
+ *     result.
+ *   - Any other read/parse error propagates — the caller decides whether
+ *     to surface it.
+ */
+export async function readReplayIndex(
+  options: IReadReplayIndexOptions = {},
+): Promise<readonly IReplayManifestEntry[]> {
+  const indexPath = resolveIndexPath(options.cwd);
+  const backfillScan = options.backfillScan ?? defaultBackfillScan;
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(indexPath, 'utf8');
+  } catch (err) {
+    // Missing file → defer to the backfill scan. Other errors propagate.
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      logger.debug(
+        '[replay-library] replay-index.json missing — falling back to backfill scan',
+        { indexPath },
+      );
+      return backfillScan();
+    }
+    throw err;
+  }
+
+  const parsed = JSON.parse(raw) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `[replay-library] replay-index.json is malformed — expected JSON array, got ${typeof parsed}`,
+    );
+  }
+
+  const recognized: IReplayManifestEntry[] = [];
+  for (const candidate of parsed) {
+    if (hasRecognizedReplaySource(candidate)) {
+      recognized.push(candidate);
+    } else {
+      // Forward-compat: a newer build wrote an entry whose `replaySource`
+      // is not in this build's enum. Skip it but log at debug so a developer
+      // running with debug logs sees what was filtered.
+      const id =
+        typeof candidate === 'object' && candidate !== null
+          ? (candidate as { id?: unknown }).id
+          : undefined;
+      const replaySource =
+        typeof candidate === 'object' && candidate !== null
+          ? (candidate as { replaySource?: unknown }).replaySource
+          : undefined;
+      logger.debug(
+        '[replay-library] skipping replay-index entry with unrecognized replaySource',
+        { id, replaySource },
+      );
+    }
+  }
+
+  return recognized;
+}

--- a/src/replay-library/index-writer.ts
+++ b/src/replay-library/index-writer.ts
@@ -1,0 +1,184 @@
+/**
+ * Central replay index writer. Atomically appends a single
+ * `IReplayManifestEntry` to `simulation-reports/replay-index.json`, creating
+ * the file if absent.
+ *
+ * Atomicity:
+ *   - Write the full new array to a temp file `replay-index.json.tmp-<ts>-<rand>`
+ *   - `fs.rename` the temp into place (POSIX rename is atomic; Windows is
+ *     mostly atomic and throws on collisions instead of silently corrupting,
+ *     which is acceptable for this use case)
+ *   - The temp filename includes a high-resolution timestamp + crypto-random
+ *     suffix so concurrent appends from the same process cannot collide on
+ *     the temp path
+ *
+ * Concurrency:
+ *   - Read-modify-write is serialized via a per-file in-memory mutex so
+ *     concurrent `appendManifestEntry` calls produce both entries (no
+ *     last-writer-wins). The mutex is a `Promise<void>` chain stored in a
+ *     module-level `Map` keyed by absolute path. Cross-process safety is
+ *     out of scope — the swarm runner and quick-game persistence both run
+ *     in the same Node process.
+ *
+ * PR 2 is Node-only; PR 5 will introduce env-aware abstraction for browser builds.
+ */
+
+import { randomBytes } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import type { IReplayManifestEntry } from './types';
+
+/**
+ * Options for the writer. `cwd` lets tests inject a tmpdir without polluting
+ * the real `simulation-reports/`.
+ */
+export interface IAppendManifestEntryOptions {
+  /** Override `process.cwd()` for the index path resolution. */
+  readonly cwd?: string;
+}
+
+/**
+ * Resolves the absolute path to `simulation-reports/replay-index.json` rooted
+ * at the supplied `cwd` (or `process.cwd()` when omitted).
+ */
+function resolveIndexPath(cwd?: string): string {
+  return path.resolve(
+    cwd ?? process.cwd(),
+    'simulation-reports',
+    'replay-index.json',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-path mutex — serializes read-modify-write across concurrent callers in
+// the same Node process. Map key is the absolute index path so two different
+// `cwd`s in tests do not block each other.
+// ---------------------------------------------------------------------------
+const writeQueues: Map<string, Promise<void>> = new Map();
+
+/**
+ * Runs `task` after any previously-queued task for the same `key` completes.
+ * The queue stores the tail Promise; we install a new tail that resolves
+ * after `task` settles. Failures unwind the queue without leaving the slot
+ * "stuck" — the next caller starts from a resolved state.
+ */
+async function runSerialized<T>(
+  key: string,
+  task: () => Promise<T>,
+): Promise<T> {
+  const previous = writeQueues.get(key) ?? Promise.resolve();
+  let release: (() => void) | undefined;
+  const next = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  writeQueues.set(
+    key,
+    previous.then(() => next),
+  );
+
+  try {
+    await previous;
+    return await task();
+  } finally {
+    release?.();
+    // If we are the current tail, clear the slot so the map does not grow
+    // unbounded on long-running processes.
+    if (writeQueues.get(key) === previous.then(() => next)) {
+      writeQueues.delete(key);
+    }
+  }
+}
+
+/**
+ * Reads the existing manifest array from `indexPath`. Returns an empty array
+ * when the file does not exist (writer-creates-when-absent path). Other read
+ * or parse errors propagate.
+ */
+async function readExistingManifest(
+  indexPath: string,
+): Promise<IReplayManifestEntry[]> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(indexPath, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+
+  const parsed = JSON.parse(raw) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `[replay-library] replay-index.json is malformed — expected JSON array, got ${typeof parsed}`,
+    );
+  }
+  // Cast is safe at write time — the writer only ever round-trips entries it
+  // (or another writer in the same partition layout) produced. The reader is
+  // responsible for forward-compat filtering.
+  return parsed as IReplayManifestEntry[];
+}
+
+/**
+ * Generates a unique temp-file suffix for the atomic write. Format:
+ * `<unix-ms>-<8-hex-crypto-random>`. The random suffix is the load-bearing
+ * part — concurrent appends in the same millisecond would otherwise collide.
+ */
+function makeTempSuffix(): string {
+  const ts = Date.now();
+  const rand = randomBytes(4).toString('hex');
+  return `${ts}-${rand}`;
+}
+
+/**
+ * Atomically appends a single new `IReplayManifestEntry` to the central
+ * replay index. Creates the index file (and its parent directory) when
+ * absent. Concurrent calls in the same process are serialized so no entry
+ * is lost.
+ *
+ * Atomicity guarantees:
+ *   - On success: the index file at `indexPath` reflects all prior entries
+ *     plus the new one
+ *   - On rename failure (or any prior step throwing): the original index
+ *     file is untouched. A temp file may be left behind for cleanup, but
+ *     the reader's load path will not pick it up because the reader only
+ *     reads `replay-index.json` (the unsuffixed name)
+ */
+export async function appendManifestEntry(
+  entry: IReplayManifestEntry,
+  options: IAppendManifestEntryOptions = {},
+): Promise<void> {
+  const indexPath = resolveIndexPath(options.cwd);
+
+  await runSerialized(indexPath, async () => {
+    // Ensure the parent `simulation-reports/` directory exists; the writer
+    // is the first surface that materializes it on a fresh checkout.
+    await fs.mkdir(path.dirname(indexPath), { recursive: true });
+
+    const existing = await readExistingManifest(indexPath);
+    const next: IReplayManifestEntry[] = [...existing, entry];
+
+    // Atomic write: temp file + rename. The temp filename is colocated with
+    // the index so the rename is on the same filesystem (cross-fs renames
+    // would not be atomic).
+    const tempPath = `${indexPath}.tmp-${makeTempSuffix()}`;
+    const serialized = `${JSON.stringify(next, null, 2)}\n`;
+
+    await fs.writeFile(tempPath, serialized, 'utf8');
+    try {
+      await fs.rename(tempPath, indexPath);
+    } catch (err) {
+      // Rename failed — best-effort cleanup of the temp file so a long-lived
+      // process does not accumulate orphans. The original index is untouched
+      // (rename is the only mutation of the canonical name) so callers can
+      // safely retry.
+      try {
+        await fs.unlink(tempPath);
+      } catch {
+        // Swallow cleanup failure — the original error is the meaningful one.
+      }
+      throw err;
+    }
+  });
+}

--- a/src/replay-library/index.ts
+++ b/src/replay-library/index.ts
@@ -4,6 +4,10 @@
  * backfill scan; subsequent PRs wire writers + UI).
  */
 
+export { defaultBackfillScan, readReplayIndex } from './index-reader';
+export type { BackfillScan, IReadReplayIndexOptions } from './index-reader';
+export { appendManifestEntry } from './index-writer';
+export type { IAppendManifestEntryOptions } from './index-writer';
 export type {
   ICampaignReplayManifestEntry,
   IPvPReplayManifestEntry,


### PR DESCRIPTION
## Summary

PR 2 of the 6-PR `add-replay-library` ladder — adds the central index reader and writer that PR 4 (swarm runner manifest emit), PR 5 (quick-game persistence), and PR 6 (Replay Library page) all depend on.

- **`src/replay-library/index-reader.ts`** — `readReplayIndex({ cwd?, backfillScan? })` loads `simulation-reports/replay-index.json`, returns a typed `readonly IReplayManifestEntry[]`. Forward-compatible with future `ReplaySource` variants: entries whose `replaySource` is not in the current enum are skipped + debug-logged so a newer build cannot crash this reader. When the index file is missing, the reader invokes a backfill scan fallback. PR 2 ships with a stub fallback (`() => Promise.resolve([])`) exposed via the `BackfillScan` parameter so tests can inject; PR 3 wires the real on-disk scan in one diff.
- **`src/replay-library/index-writer.ts`** — `appendManifestEntry(entry, { cwd? })` atomically appends to the index. Atomicity = write the full new array to a temp file (`replay-index.json.tmp-<unix-ms>-<8hex-random>`) then `fs.rename` into place; concurrent appends in the same Node process are serialized via a per-absolute-path `Promise<void>` mutex so no entry is lost. On rename failure the temp is best-effort cleaned and the original index is untouched.
- **`src/replay-library/index.ts`** — barrel re-exports both new modules alongside the PR-1 types.
- **Tasks 2.1–2.9 flipped to `[x]`** in `openspec/changes/add-replay-library/tasks.md`.

PR 2 is Node-only; PR 5 will introduce env-aware abstraction for browser builds.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` clean
- [x] `npx jest src/replay-library` → 3 suites, 19 tests, 0 failures (10 new: 4 reader + 6 writer)
- [x] `npx oxlint src/replay-library` → 0 warnings, 0 errors
- [x] Husky pre-commit (lint-staged + oxfmt + tsc) + pre-push (full build) green on all 3 phased commits
- [x] CI to verify on this PR

### Reader test scenarios (4)

1. Returns typed entries with discriminant narrowing (1 swarm + 1 quick fixture)
2. Skips entries with unrecognized `replaySource` and logs at debug
3. Falls back to the backfill scan when `replay-index.json` is missing
4. Logs `indexPath` at debug when the missing-file fallback fires

### Writer test scenarios (6)

1. Appends to a 1-entry index → 2 entries (existing entry preserved verbatim)
2. Appends to a 100-entry index → 101 entries (bulk preservation)
3. Atomic write — `fs.rename` failure leaves the original index intact byte-for-byte and the reader does not load any orphan temp file
4. Creates the index file when absent
5. Creates the parent `simulation-reports/` directory when absent (fresh-checkout path)
6. Concurrent appends serialize via the per-path mutex — both entries land

## Refs

- `openspec/changes/add-replay-library/specs/replay-library/spec.md` — `Central Replay Index Reader` + `Central Replay Index Writer` requirements
- `openspec/changes/add-replay-library/tasks.md` — section 2 (this PR)
- PR 1: #548 (types + enum, merged)