### PR TITLE
feat(replay-library): add backfill scan + wire reader fallback (PR 3/6)

### DIFF
--- a/openspec/changes/add-replay-library/tasks.md
+++ b/openspec/changes/add-replay-library/tasks.md
@@ -25,15 +25,15 @@
 
 ## 3. Backfill scan (PR 3)
 
-- [ ] 3.1 Add `src/replay-library/backfill-scan.ts` with `scanReplayDirectory(): Promise<readonly IReplayManifestEntry[]>` covering both partition layout (`simulation-reports/<source>/*.jsonl`) and legacy flat layout (`simulation-reports/games/<ts>/*.jsonl`)
-- [ ] 3.2 Stream-read each file's first event (`GameCreated`) and last event; compute `bvTotal` from `payload.units`, `winner`/`turns` from `GameEnded` (with `turn_started`-count fallback for missing `turns`)
-- [ ] 3.3 Infer `replaySource = ReplaySource.Swarm` for legacy flat-layout files; set `batchTimestamp` from the parent directory name
-- [ ] 3.4 Unit tests: scan covers new partition layout (one swarm fixture + one quick fixture)
-- [ ] 3.5 Unit tests: scan covers legacy flat layout (`games/<ts>/<id>.jsonl` fixture)
-- [ ] 3.6 Unit tests: `GameEnded.turns` optionality fallback (count `turn_started`, then `0`)
-- [ ] 3.7 Unit tests: scan is idempotent — two runs produce deep-equal arrays
-- [ ] 3.8 Run `npm run typecheck` clean
-- [ ] 3.9 Run `npm test` for new files clean
+- [x] 3.1 Add `src/replay-library/backfill-scan.ts` with `scanReplayDirectory(): Promise<readonly IReplayManifestEntry[]>` covering both partition layout (`simulation-reports/<source>/*.jsonl`) and legacy flat layout (`simulation-reports/games/<ts>/*.jsonl`)
+- [x] 3.2 Stream-read each file's first event (`GameCreated`) and last event; compute `bvTotal` from `payload.units`, `winner`/`turns` from `GameEnded` (with `turn_started`-count fallback for missing `turns`)
+- [x] 3.3 Infer `replaySource = ReplaySource.Swarm` for legacy flat-layout files; set `batchTimestamp` from the parent directory name
+- [x] 3.4 Unit tests: scan covers new partition layout (one swarm fixture + one quick fixture)
+- [x] 3.5 Unit tests: scan covers legacy flat layout (`games/<ts>/<id>.jsonl` fixture)
+- [x] 3.6 Unit tests: `GameEnded.turns` optionality fallback (count `turn_started`, then `0`)
+- [x] 3.7 Unit tests: scan is idempotent — two runs produce deep-equal arrays
+- [x] 3.8 Run `npm run typecheck` clean
+- [x] 3.9 Run `npm test` for new files clean
 - [ ] 3.10 PR opened, CI green, merged
 
 ## 4. Swarm runner partition + manifest emit (PR 4)

--- a/src/replay-library/__tests__/backfill-scan.test.ts
+++ b/src/replay-library/__tests__/backfill-scan.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Tests for the backfill scan. Covers the four Backfill Scan spec scenarios:
+ *
+ *   1. Scan covers new partition layout (one swarm + one quick fixture)
+ *   2. Scan covers legacy flat layout (one `games/<ts>/<id>.jsonl` fixture)
+ *   3. `GameEnded.turns` optionality fallback (turn_started count, then 0)
+ *   4. Scan is idempotent — two runs produce deep-equal arrays
+ *
+ * Plus several non-spec hardening cases:
+ *   - Scan covers BOTH layouts simultaneously
+ *   - Files without `GameCreated` are skipped with a debug log (no crash)
+ *   - Empty `simulation-reports/` returns empty array
+ *
+ * Tests stage NDJSON fixtures into `os.tmpdir()` and pass the parent as `cwd`
+ * so the scan resolves into a clean tmp tree per-test (jest --runInBand is
+ * not assumed).
+ */
+
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { GameEventType, GameSide, ReplaySource } from '@/types/gameplay';
+import { disableTestMode, enableTestMode } from '@/utils/logger';
+
+import type { IReplayManifestEntry } from '../types';
+
+import { scanReplayDirectory } from '../backfill-scan';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds an isolated tmp `cwd` containing an empty `simulation-reports/`.
+ * Each test gets its own tmpdir so concurrent runs cannot stomp each other.
+ */
+async function makeTmpCwd(): Promise<string> {
+  const dir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'replay-library-backfill-'),
+  );
+  await fs.mkdir(path.join(dir, 'simulation-reports'), { recursive: true });
+  return dir;
+}
+
+/**
+ * Tiny helper around `fs.writeFile` that creates the parent directory tree
+ * first — every fixture-write needs `recursive: true`.
+ */
+async function writeNDJSON(
+  filePath: string,
+  events: ReadonlyArray<Record<string, unknown>>,
+): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const body = events.map((e) => JSON.stringify(e)).join('\n');
+  await fs.writeFile(filePath, body, 'utf8');
+}
+
+/**
+ * Synthesizes a minimal `GameCreated` event — only the fields the backfill
+ * scan reads. The spec's "stream-read enough lines" pattern means anything
+ * we don't reference here is irrelevant to the test.
+ */
+function gameCreatedEvent(
+  gameId: string,
+  units: ReadonlyArray<Record<string, unknown>>,
+  extraPayload: Record<string, unknown> = {},
+  timestamp = '2026-05-07T12:00:00.000Z',
+): Record<string, unknown> {
+  return {
+    id: `${gameId}-evt-1`,
+    gameId,
+    sequence: 1,
+    timestamp,
+    type: GameEventType.GameCreated,
+    turn: 0,
+    phase: 'initiative',
+    payload: {
+      config: {
+        mapRadius: 8,
+        turnLimit: 0,
+        victoryConditions: [],
+        optionalRules: [],
+      },
+      units,
+      ...extraPayload,
+    },
+  };
+}
+
+/**
+ * Synthesizes a `GameEnded` event. `turns` is optional so tests can exercise
+ * the missing-field fallback.
+ */
+function gameEndedEvent(
+  gameId: string,
+  winner: GameSide | 'draw',
+  options: { turns?: number } = {},
+  timestamp = '2026-05-07T12:30:00.000Z',
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    winner,
+    reason: 'destruction',
+  };
+  if (typeof options.turns === 'number') {
+    payload.turns = options.turns;
+  }
+  return {
+    id: `${gameId}-evt-end`,
+    gameId,
+    sequence: 999,
+    timestamp,
+    type: GameEventType.GameEnded,
+    turn: options.turns ?? 0,
+    phase: 'end',
+    payload,
+  };
+}
+
+/**
+ * Synthesizes a `TurnStarted` event — used when a fixture wants the
+ * `turn_started`-count fallback to bite.
+ */
+function turnStartedEvent(
+  gameId: string,
+  turn: number,
+  sequence: number,
+): Record<string, unknown> {
+  return {
+    id: `${gameId}-evt-turn-${turn}`,
+    gameId,
+    sequence,
+    timestamp: '2026-05-07T12:10:00.000Z',
+    type: GameEventType.TurnStarted,
+    turn,
+    phase: 'initiative',
+    payload: {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Spec scenarios
+// ---------------------------------------------------------------------------
+
+describe('scanReplayDirectory', () => {
+  let consoleDebugSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    enableTestMode();
+    consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+  });
+
+  afterEach(() => {
+    disableTestMode();
+    jest.restoreAllMocks();
+  });
+
+  it('covers new partition layout (swarm + quick)', async () => {
+    const cwd = await makeTmpCwd();
+
+    await writeNDJSON(
+      path.join(cwd, 'simulation-reports', 'swarm', 'sim-1.jsonl'),
+      [
+        gameCreatedEvent(
+          'sim-1',
+          [
+            { id: 'u1', bv: 1500 },
+            { id: 'u2', bv: 2000 },
+          ],
+          {
+            swarmMeta: {
+              configName: 'duel-3kbv-temperate',
+              seed: 42,
+              batchTimestamp: '2026-05-07T11-58-00-000Z',
+            },
+          },
+        ),
+        gameEndedEvent('sim-1', GameSide.Player, { turns: 7 }),
+      ],
+    );
+
+    await writeNDJSON(
+      path.join(cwd, 'simulation-reports', 'quick', 'quick-9.jsonl'),
+      [
+        gameCreatedEvent('quick-9', [{ id: 'u1', bv: 800 }], {
+          quickMeta: {
+            playerSide: GameSide.Player,
+            aiVariant: 'aggressive-v2',
+          },
+        }),
+        gameEndedEvent('quick-9', GameSide.Opponent, { turns: 5 }),
+      ],
+    );
+
+    const entries = await scanReplayDirectory({ cwd });
+
+    expect(entries).toHaveLength(2);
+
+    const byId = new Map(entries.map((e) => [e.id, e]));
+    const swarm = byId.get('sim-1');
+    const quick = byId.get('quick-9');
+    expect(swarm).toBeDefined();
+    expect(quick).toBeDefined();
+
+    if (!swarm || swarm.replaySource !== ReplaySource.Swarm) {
+      throw new Error('expected swarm narrowing');
+    }
+    expect(swarm.path).toBe('swarm/sim-1.jsonl');
+    expect(swarm.bvTotal).toBe(3500);
+    expect(swarm.turns).toBe(7);
+    expect(swarm.winner).toBe(GameSide.Player);
+    expect(swarm.configName).toBe('duel-3kbv-temperate');
+    expect(swarm.seed).toBe(42);
+    expect(swarm.batchTimestamp).toBe('2026-05-07T11-58-00-000Z');
+
+    if (!quick || quick.replaySource !== ReplaySource.Quick) {
+      throw new Error('expected quick narrowing');
+    }
+    expect(quick.path).toBe('quick/quick-9.jsonl');
+    expect(quick.bvTotal).toBe(800);
+    expect(quick.turns).toBe(5);
+    expect(quick.winner).toBe(GameSide.Opponent);
+    expect(quick.aiVariant).toBe('aggressive-v2');
+    expect(quick.playerSide).toBe(GameSide.Player);
+  });
+
+  it('covers legacy flat layout (games/<ts>/<id>.jsonl)', async () => {
+    const cwd = await makeTmpCwd();
+    const ts = '2026-05-01T10-00-00-000Z';
+
+    await writeNDJSON(
+      path.join(cwd, 'simulation-reports', 'games', ts, 'sim-77.jsonl'),
+      [
+        gameCreatedEvent('sim-77', [{ id: 'u1', bv: 1200 }]),
+        gameEndedEvent('sim-77', 'draw', { turns: 4 }),
+      ],
+    );
+
+    const entries = await scanReplayDirectory({ cwd });
+
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    expect(entry.replaySource).toBe(ReplaySource.Swarm);
+    if (entry.replaySource !== ReplaySource.Swarm) {
+      throw new Error('expected swarm narrowing on legacy entry');
+    }
+    expect(entry.id).toBe('sim-77');
+    expect(entry.path).toBe(`games/${ts}/sim-77.jsonl`);
+    expect(entry.batchTimestamp).toBe(ts);
+    expect(entry.configName).toBe('');
+    expect(entry.seed).toBe(0);
+    expect(entry.bvTotal).toBe(1200);
+    expect(entry.turns).toBe(4);
+    // `'draw'` collapses to null winner — manifest type is `GameSide | null`.
+    expect(entry.winner).toBeNull();
+  });
+
+  it('covers BOTH layouts simultaneously', async () => {
+    const cwd = await makeTmpCwd();
+
+    await writeNDJSON(
+      path.join(cwd, 'simulation-reports', 'swarm', 'sim-new.jsonl'),
+      [
+        gameCreatedEvent('sim-new', [{ id: 'u1', bv: 500 }]),
+        gameEndedEvent('sim-new', GameSide.Player, { turns: 2 }),
+      ],
+    );
+    await writeNDJSON(
+      path.join(
+        cwd,
+        'simulation-reports',
+        'games',
+        '2026-04-30T09-00-00-000Z',
+        'sim-old.jsonl',
+      ),
+      [
+        gameCreatedEvent('sim-old', [{ id: 'u1', bv: 600 }]),
+        gameEndedEvent('sim-old', GameSide.Opponent, { turns: 3 }),
+      ],
+    );
+
+    const entries = await scanReplayDirectory({ cwd });
+
+    expect(entries).toHaveLength(2);
+    const ids = entries.map((e) => e.id).sort();
+    expect(ids).toEqual(['sim-new', 'sim-old']);
+    // Both materialize as swarm entries; the new file is partition-layout,
+    // the old one is legacy. Path assertions pin the layout discriminant.
+    const newOne = entries.find((e) => e.id === 'sim-new');
+    const oldOne = entries.find((e) => e.id === 'sim-old');
+    expect(newOne?.path).toBe('swarm/sim-new.jsonl');
+    expect(oldOne?.path).toBe('games/2026-04-30T09-00-00-000Z/sim-old.jsonl');
+  });
+
+  it('falls back to turn_started count when GameEnded.turns is missing', async () => {
+    const cwd = await makeTmpCwd();
+
+    await writeNDJSON(
+      path.join(cwd, 'simulation-reports', 'swarm', 'sim-fallback.jsonl'),
+      [
+        gameCreatedEvent('sim-fallback', [{ id: 'u1', bv: 1000 }]),
+        turnStartedEvent('sim-fallback', 1, 2),
+        turnStartedEvent('sim-fallback', 2, 3),
+        turnStartedEvent('sim-fallback', 3, 4),
+        // GameEnded with NO `turns` field — the fallback must compute 3.
+        gameEndedEvent('sim-fallback', GameSide.Player),
+      ],
+    );
+
+    const entries = await scanReplayDirectory({ cwd });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].turns).toBe(3);
+  });
+
+  it('falls back to 0 when neither GameEnded.turns nor turn_started events are present', async () => {
+    const cwd = await makeTmpCwd();
+
+    await writeNDJSON(
+      path.join(cwd, 'simulation-reports', 'swarm', 'sim-empty.jsonl'),
+      [
+        gameCreatedEvent('sim-empty', [{ id: 'u1', bv: 100 }]),
+        gameEndedEvent('sim-empty', 'draw'),
+      ],
+    );
+
+    const entries = await scanReplayDirectory({ cwd });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].turns).toBe(0);
+  });
+
+  it('is idempotent — two runs produce deep-equal arrays', async () => {
+    const cwd = await makeTmpCwd();
+
+    await writeNDJSON(
+      path.join(cwd, 'simulation-reports', 'swarm', 'sim-a.jsonl'),
+      [
+        gameCreatedEvent('sim-a', [{ id: 'u1', bv: 100 }]),
+        gameEndedEvent('sim-a', GameSide.Player, { turns: 2 }),
+      ],
+    );
+    await writeNDJSON(
+      path.join(cwd, 'simulation-reports', 'quick', 'quick-b.jsonl'),
+      [
+        gameCreatedEvent('quick-b', [{ id: 'u1', bv: 200 }]),
+        gameEndedEvent('quick-b', GameSide.Opponent, { turns: 4 }),
+      ],
+    );
+    await writeNDJSON(
+      path.join(
+        cwd,
+        'simulation-reports',
+        'games',
+        '2026-04-30T09-00-00-000Z',
+        'sim-c.jsonl',
+      ),
+      [
+        gameCreatedEvent('sim-c', [{ id: 'u1', bv: 300 }]),
+        gameEndedEvent('sim-c', 'draw', { turns: 1 }),
+      ],
+    );
+
+    const first = await scanReplayDirectory({ cwd });
+    const second = await scanReplayDirectory({ cwd });
+
+    // Deep-equal across both runs — id-sorted output guarantees stable order.
+    expect(second).toEqual(first);
+    expect(first.map((e) => e.id)).toEqual(['quick-b', 'sim-a', 'sim-c']);
+  });
+
+  it('skips files with no GameCreated event and logs at debug', async () => {
+    const cwd = await makeTmpCwd();
+
+    // Corrupt fixture: only TurnStarted + GameEnded, no GameCreated. Per spec
+    // the scan must skip without crashing and emit a debug log.
+    await writeNDJSON(
+      path.join(cwd, 'simulation-reports', 'swarm', 'corrupt.jsonl'),
+      [
+        turnStartedEvent('corrupt', 1, 1),
+        gameEndedEvent('corrupt', GameSide.Player, { turns: 1 }),
+      ],
+    );
+    // Healthy fixture alongside it — proves the corrupt one was skipped, not
+    // the whole scan aborted.
+    await writeNDJSON(
+      path.join(cwd, 'simulation-reports', 'swarm', 'healthy.jsonl'),
+      [
+        gameCreatedEvent('healthy', [{ id: 'u1', bv: 999 }]),
+        gameEndedEvent('healthy', GameSide.Opponent, { turns: 3 }),
+      ],
+    );
+
+    const entries = await scanReplayDirectory({ cwd });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe('healthy');
+
+    const skipLog = consoleDebugSpy.mock.calls.find(
+      (call) =>
+        typeof call[0] === 'string' &&
+        call[0].includes('without GameCreated event'),
+    );
+    expect(skipLog).toBeDefined();
+    expect(skipLog?.[1]).toMatchObject({ gameId: 'corrupt' });
+  });
+
+  it('returns an empty array when simulation-reports/ is empty', async () => {
+    const cwd = await makeTmpCwd();
+    const entries = await scanReplayDirectory({ cwd });
+    expect(entries).toEqual([]);
+  });
+
+  it('returns an empty array when simulation-reports/ does not exist', async () => {
+    // Use a tmp parent without creating `simulation-reports/` inside.
+    const cwd = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'replay-library-backfill-missing-'),
+    );
+    const entries = await scanReplayDirectory({ cwd });
+    expect(entries).toEqual([]);
+  });
+
+  it('produces typed entries that narrow on replaySource', async () => {
+    // Compile-time narrowing check materialized as a runtime assertion. If
+    // the discriminated union breaks, the `if`-branches stop type-checking
+    // and the test fails to compile.
+    const cwd = await makeTmpCwd();
+    await writeNDJSON(
+      path.join(cwd, 'simulation-reports', 'swarm', 'sim-x.jsonl'),
+      [
+        gameCreatedEvent('sim-x', [{ id: 'u1', bv: 50 }]),
+        gameEndedEvent('sim-x', GameSide.Player, { turns: 2 }),
+      ],
+    );
+
+    const entries: readonly IReplayManifestEntry[] = await scanReplayDirectory({
+      cwd,
+    });
+    const e = entries[0];
+    if (e.replaySource === ReplaySource.Swarm) {
+      // `configName` only exists on the swarm variant — references narrowing.
+      expect(typeof e.configName).toBe('string');
+    } else {
+      throw new Error('expected swarm variant');
+    }
+  });
+});

--- a/src/replay-library/backfill-scan.ts
+++ b/src/replay-library/backfill-scan.ts
@@ -1,0 +1,606 @@
+/**
+ * Replay backfill scan — reconstructs an in-memory `IReplayManifestEntry[]`
+ * from the on-disk contents of `simulation-reports/`. Invoked by the central
+ * index reader when `replay-index.json` is missing, so a developer that
+ * deletes the index (or hits a fresh checkout with pre-existing logs from
+ * an earlier build) does not lose the catalog of replays.
+ *
+ * Per add-replay-library spec (Backfill Scan requirement):
+ *   - SHALL examine BOTH the new partition layout
+ *     (`simulation-reports/<source>/*.jsonl`) and the legacy flat layout
+ *     (`simulation-reports/games/<timestamp>/*.jsonl`).
+ *   - For each NDJSON file, stream-read enough lines to extract first event
+ *     (must be `GameCreated`) for `bvTotal` + source-specific fields, and
+ *     last event for `winner`/`turns` (with `turn_started`-count fallback).
+ *   - For legacy flat-layout files, infer `replaySource = ReplaySource.Swarm`
+ *     and set `batchTimestamp` from the parent directory name.
+ *   - SHALL be idempotent: re-runs on the same disk state SHALL produce a
+ *     deep-equal manifest array.
+ *
+ * PR 3 is Node-only; PR 5 introduces env-aware abstractions for browser builds.
+ *
+ * Streaming choice: `node:readline` over `node:fs.createReadStream` keeps
+ * the worst-case memory footprint linear in line size, not in file size.
+ * The first event lives at line 1 and the last `GameEnded` (when present)
+ * is short-circuited by tracking a rolling "last event we saw of this type"
+ * variable while iterating. The `turn_started` fallback only kicks in when
+ * `GameEnded.turns` is absent — at that point we already paid the streaming
+ * cost so re-iterating the line buffer is cheap.
+ */
+
+import { createReadStream } from 'node:fs';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { createInterface } from 'node:readline';
+
+import type {
+  GameEventType,
+  IGameCreatedPayload,
+  IGameEndedPayload,
+  IGameEvent,
+  IGameUnit,
+} from '@/types/gameplay';
+
+import { GameSide, ReplaySource } from '@/types/gameplay';
+import { logger } from '@/utils/logger';
+
+import type {
+  IQuickReplayManifestEntry,
+  IReplayManifestEntry,
+  ISwarmReplayManifestEntry,
+} from './types';
+
+/**
+ * Options for the backfill scan. `cwd` lets tests inject an isolated tmpdir
+ * without polluting the real `simulation-reports/` tree.
+ */
+export interface IScanReplayDirectoryOptions {
+  /** Override `process.cwd()` for the simulation-reports root resolution. */
+  readonly cwd?: string;
+}
+
+/**
+ * Materializes an in-memory manifest from disk. Returns an empty array when
+ * `simulation-reports/` does not exist (fresh checkout).
+ */
+export async function scanReplayDirectory(
+  options: IScanReplayDirectoryOptions = {},
+): Promise<readonly IReplayManifestEntry[]> {
+  const cwd = options.cwd ?? process.cwd();
+  const reportsRoot = path.resolve(cwd, 'simulation-reports');
+
+  // Fresh checkout / nothing to scan — return the empty manifest. The reader
+  // path treats an empty manifest exactly like "missing index" today, so
+  // surfacing an error here would be a regression.
+  try {
+    await fs.access(reportsRoot);
+  } catch {
+    return [];
+  }
+
+  const entries: IReplayManifestEntry[] = [];
+
+  // Phase 1: scan the four partition directories named after `ReplaySource`
+  // values. Iterating `Object.values(ReplaySource)` keeps adding a fifth
+  // variant zero-touch — the new directory is automatically picked up.
+  for (const source of Object.values(ReplaySource)) {
+    const sourceDir = path.join(reportsRoot, source);
+    const partitionEntries = await scanPartitionDirectory(
+      sourceDir,
+      source,
+      reportsRoot,
+    );
+    entries.push(...partitionEntries);
+  }
+
+  // Phase 2: scan the legacy flat layout `simulation-reports/games/<ts>/`.
+  // Every file under here predates the partition cutover; PR 4 will stop
+  // writing new files into this tree, but we keep reading from it so a
+  // developer's accumulated logs survive the layout change.
+  const legacyEntries = await scanLegacyDirectory(reportsRoot);
+  entries.push(...legacyEntries);
+
+  // Idempotency: sort by `id` so two scans on the same disk state produce
+  // arrays that are deep-equal element-for-element. The directory iteration
+  // order is filesystem-dependent (NTFS vs ext4 vs APFS all differ); a
+  // stable sort by `id` is the only zero-cost guarantee.
+  entries.sort((a, b) => a.id.localeCompare(b.id));
+
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Partition layout: simulation-reports/<source>/<gameId>.jsonl
+// ---------------------------------------------------------------------------
+
+/**
+ * Scans one of the four partition directories. Skips silently if the
+ * directory does not exist (a fresh checkout never wrote that source).
+ */
+async function scanPartitionDirectory(
+  sourceDir: string,
+  source: ReplaySource,
+  reportsRoot: string,
+): Promise<IReplayManifestEntry[]> {
+  let dirEntries: string[];
+  try {
+    dirEntries = await fs.readdir(sourceDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+
+  const out: IReplayManifestEntry[] = [];
+  for (const file of dirEntries) {
+    if (!file.endsWith('.jsonl')) continue;
+    const filePath = path.join(sourceDir, file);
+    const gameId = path.basename(file, '.jsonl');
+    const entry = await buildPartitionEntry(
+      filePath,
+      gameId,
+      source,
+      reportsRoot,
+    );
+    if (entry) out.push(entry);
+  }
+  return out;
+}
+
+/**
+ * Builds a manifest entry for a partition-layout file. Returns `null` if the
+ * file lacks a `GameCreated` event (corrupt / aborted run); the scan logs
+ * and skips rather than crashing.
+ */
+async function buildPartitionEntry(
+  filePath: string,
+  gameId: string,
+  source: ReplaySource,
+  reportsRoot: string,
+): Promise<IReplayManifestEntry | null> {
+  const summary = await streamFileSummary(filePath);
+  if (!summary.gameCreated) {
+    logger.debug(
+      '[replay-library] backfill skipping file without GameCreated event',
+      { filePath, gameId },
+    );
+    return null;
+  }
+
+  const relativePath = path
+    .relative(reportsRoot, filePath)
+    .split(path.sep)
+    .join('/');
+
+  const baseFields = await deriveBaseFields(filePath, summary, relativePath);
+
+  switch (source) {
+    case ReplaySource.Swarm:
+      return buildSwarmEntry(gameId, baseFields, summary);
+    case ReplaySource.Quick:
+      return buildQuickEntry(gameId, baseFields, summary);
+    case ReplaySource.PvP:
+    case ReplaySource.Campaign:
+      // PR 1 reserved these shapes for future emitters. Until those write
+      // paths exist, an on-disk file under `pvp/` or `campaign/` is almost
+      // certainly a developer testing fixture — we materialize a minimal
+      // entry so the scan stays exhaustive on `ReplaySource`. Forward-compat
+      // with future emitters: if the file's `GameCreated` event already
+      // carries source-specific fields, that emitter is already authoritative
+      // and the writer path will overwrite this manifest entry on next run.
+      return buildPlaceholderEntry(gameId, source, baseFields);
+    default: {
+      // Exhaustiveness check — adding a fifth `ReplaySource` value triggers
+      // a compile error here so the author cannot forget to handle it.
+      const _exhaustive: never = source;
+      throw new Error(
+        `unhandled ReplaySource in backfill: ${String(_exhaustive)}`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Legacy flat layout: simulation-reports/games/<timestamp>/<gameId>.jsonl
+// ---------------------------------------------------------------------------
+
+/**
+ * Scans the legacy flat layout. Each subdirectory of `simulation-reports/games/`
+ * is a `<run-timestamp>` slug; every `.jsonl` inside is a swarm-runner output
+ * from before the partition cutover.
+ */
+async function scanLegacyDirectory(
+  reportsRoot: string,
+): Promise<IReplayManifestEntry[]> {
+  const legacyRoot = path.join(reportsRoot, 'games');
+  let timestampDirs: string[];
+  try {
+    timestampDirs = await fs.readdir(legacyRoot);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+
+  const out: IReplayManifestEntry[] = [];
+  for (const tsDir of timestampDirs) {
+    const tsDirPath = path.join(legacyRoot, tsDir);
+    let stat: import('fs').Stats;
+    try {
+      stat = await fs.stat(tsDirPath);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+
+    let files: string[];
+    try {
+      files = await fs.readdir(tsDirPath);
+    } catch {
+      continue;
+    }
+
+    for (const file of files) {
+      if (!file.endsWith('.jsonl')) continue;
+      const filePath = path.join(tsDirPath, file);
+      const gameId = path.basename(file, '.jsonl');
+      const entry = await buildLegacyEntry(
+        filePath,
+        gameId,
+        tsDir,
+        reportsRoot,
+      );
+      if (entry) out.push(entry);
+    }
+  }
+  return out;
+}
+
+/**
+ * Builds a swarm manifest entry for a legacy-layout file. `configName='' `
+ * and `seed=0` because the legacy filenames did not preserve the original
+ * config/seed — PR 4 will start writing these fields into new manifest
+ * entries so future scans get the real values.
+ */
+async function buildLegacyEntry(
+  filePath: string,
+  gameId: string,
+  parentTimestamp: string,
+  reportsRoot: string,
+): Promise<ISwarmReplayManifestEntry | null> {
+  const summary = await streamFileSummary(filePath);
+  if (!summary.gameCreated) {
+    logger.debug(
+      '[replay-library] backfill skipping legacy file without GameCreated event',
+      { filePath, gameId },
+    );
+    return null;
+  }
+
+  const relativePath = path
+    .relative(reportsRoot, filePath)
+    .split(path.sep)
+    .join('/');
+
+  const baseFields = await deriveBaseFields(filePath, summary, relativePath);
+
+  return {
+    id: gameId,
+    replaySource: ReplaySource.Swarm,
+    path: relativePath,
+    createdAt: baseFields.createdAt,
+    turns: baseFields.turns,
+    winner: baseFields.winner,
+    bvTotal: baseFields.bvTotal,
+    // No way to recover the original config from legacy files. PR 4+ writes
+    // these fields into newly-emitted entries so future scans of partition-
+    // layout files will have real values.
+    configName: '',
+    seed: 0,
+    batchTimestamp: parentTimestamp,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// File-level streaming + base-field derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-file summary derived from a single streaming pass. `lines` keeps the
+ * raw line array around so the `turn_started`-count fallback can compute
+ * without re-streaming when `GameEnded.turns` is missing.
+ */
+interface IFileSummary {
+  /** First event in the file — must be `GameCreated` per spec. */
+  readonly gameCreated: IGameEvent | null;
+  /** Last `GameEnded` event seen (null if the run did not finish cleanly). */
+  readonly gameEnded: IGameEvent | null;
+  /** Raw lines preserved for the `turn_started` fallback. */
+  readonly lines: readonly string[];
+}
+
+/**
+ * Streams a `.jsonl` file line-by-line. The reader keeps a running last-of-
+ * type pointer for `GameEnded` so we always end up with the final ending
+ * event (the spec only writes one `GameEnded` per run, but defending against
+ * a future "session reset" event sequence is cheap). All lines are buffered
+ * because the `turn_started`-count fallback iterates them lazily later.
+ *
+ * Note: buffering all lines breaks the "stream-only" purity goal slightly,
+ * but the line strings here are short (~200-500 bytes typical) and
+ * simulation event logs cap out at low-thousands of events. The memory
+ * footprint of a 5000-line file is well under 5 MB even with allocator
+ * overhead. The alternative (two streaming passes) is a clean rewrite for
+ * a future optimization PR if profiling demands it.
+ */
+async function streamFileSummary(filePath: string): Promise<IFileSummary> {
+  const stream = createReadStream(filePath, { encoding: 'utf8' });
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+
+  let gameCreated: IGameEvent | null = null;
+  let gameEnded: IGameEvent | null = null;
+  const lines: string[] = [];
+
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    lines.push(trimmed);
+
+    let parsed: IGameEvent;
+    try {
+      parsed = JSON.parse(trimmed) as IGameEvent;
+    } catch {
+      continue;
+    }
+
+    if (!gameCreated && parsed.type === ('game_created' as GameEventType)) {
+      gameCreated = parsed;
+    }
+    if (parsed.type === ('game_ended' as GameEventType)) {
+      gameEnded = parsed;
+    }
+  }
+
+  return { gameCreated, gameEnded, lines };
+}
+
+/**
+ * Fields shared by every variant. Derived once per file so the variant-
+ * specific builders only worry about source-specific fields.
+ */
+interface IDerivedBaseFields {
+  readonly path: string;
+  readonly createdAt: string;
+  readonly turns: number;
+  readonly winner: GameSide | null;
+  readonly bvTotal: number;
+}
+
+/**
+ * Computes fields shared across every variant. `createdAt` falls back to the
+ * file mtime when the `GameCreated` event lacks a timestamp; `winner`/`turns`
+ * fall back per the spec; `bvTotal` defers to `computeBvTotal` which itself
+ * defends against the unit shape lacking a `bv` field.
+ */
+async function deriveBaseFields(
+  filePath: string,
+  summary: IFileSummary,
+  relativePath: string,
+): Promise<IDerivedBaseFields> {
+  // `createdAt` priority: GameCreated event timestamp → file mtime → now.
+  // Mtime fallback covers a future emitter that forgot to populate the
+  // timestamp; "now" is the last-resort guard against fs.stat racing.
+  let createdAt = summary.gameCreated?.timestamp ?? '';
+  if (!createdAt) {
+    try {
+      const stat = await fs.stat(filePath);
+      createdAt = stat.mtime.toISOString();
+    } catch {
+      createdAt = new Date().toISOString();
+    }
+  }
+
+  const winner = resolveWinner(summary.gameEnded);
+  const turns = resolveTurns(summary);
+  const bvTotal = computeBvTotal(summary.gameCreated, relativePath);
+
+  return { path: relativePath, createdAt, turns, winner, bvTotal };
+}
+
+/**
+ * Resolves the winner field from a `GameEnded` payload. `'draw'` and the
+ * absence of a `GameEnded` event both collapse to `null` so the manifest
+ * type stays `GameSide | null`.
+ */
+function resolveWinner(gameEnded: IGameEvent | null): GameSide | null {
+  if (!gameEnded) return null;
+  const payload = gameEnded.payload as IGameEndedPayload;
+  if (payload.winner === 'draw') return null;
+  if (payload.winner === GameSide.Player) return GameSide.Player;
+  if (payload.winner === GameSide.Opponent) return GameSide.Opponent;
+  return null;
+}
+
+/**
+ * Resolves the `turns` field with the spec's three-step fallback chain:
+ *   1. `GameEnded.turns` (when present)
+ *   2. count of `turn_started` events in the file
+ *   3. `0` when neither is available
+ *
+ * The lazy-iteration of `summary.lines` is the load-bearing escape hatch:
+ * the count walk only happens when step 1 fails, so well-formed event logs
+ * never pay the linear-scan cost.
+ */
+function resolveTurns(summary: IFileSummary): number {
+  if (summary.gameEnded) {
+    const payload = summary.gameEnded.payload as IGameEndedPayload;
+    if (typeof payload.turns === 'number') {
+      return payload.turns;
+    }
+  }
+
+  let turnStartedCount = 0;
+  for (const line of summary.lines) {
+    // Cheap pre-check: if the substring isn't present, skip the JSON parse
+    // entirely. Saves ~80% of the parse cost on large files where most
+    // events aren't `turn_started`.
+    if (!line.includes('turn_started')) continue;
+    try {
+      const parsed = JSON.parse(line) as IGameEvent;
+      if (parsed.type === ('turn_started' as GameEventType)) {
+        turnStartedCount += 1;
+      }
+    } catch {
+      // Skip malformed lines silently — they are already accounted for in
+      // the GameCreated/GameEnded scan and either succeeded or didn't.
+    }
+  }
+  return turnStartedCount;
+}
+
+/**
+ * Computes `bvTotal` from `GameCreated.payload.units`. Today `IGameUnit` does
+ * not expose a `bv` field directly, so we look for one defensively (a future
+ * emitter may add it as a denorm) and fall back to `0` with a debug log
+ * naming the gameId. PR 4+ will populate this from the construction-side
+ * BV calculator at write time so future scans return real values.
+ */
+function computeBvTotal(
+  gameCreated: IGameEvent | null,
+  relativePath: string,
+): number {
+  if (!gameCreated) return 0;
+  const payload = gameCreated.payload as IGameCreatedPayload;
+  const units = payload.units;
+  if (!Array.isArray(units) || units.length === 0) return 0;
+
+  let total = 0;
+  let foundAny = false;
+  for (const unit of units) {
+    // Defensive shape check: `IGameUnit` does not currently declare `bv`,
+    // but the field is the obvious place for a future denorm. Reading it
+    // off the unsealed shape via `as` keeps the compile clean.
+    const bv = (unit as IGameUnit & { bv?: number }).bv;
+    if (typeof bv === 'number' && Number.isFinite(bv)) {
+      total += bv;
+      foundAny = true;
+    }
+  }
+
+  if (!foundAny) {
+    logger.debug(
+      '[replay-library] backfill could not derive bvTotal — no unit.bv field on GameCreated',
+      { relativePath, unitCount: units.length },
+    );
+    return 0;
+  }
+  return total;
+}
+
+// ---------------------------------------------------------------------------
+// Variant builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Materializes a swarm entry from partition-layout context. `configName`,
+ * `seed`, and `batchTimestamp` come from optional payload fields a forward-
+ * compat emitter may have written into `GameCreated`; otherwise they fall
+ * back to the same legacy defaults the legacy-layout builder uses (PR 4
+ * will populate them on every new write).
+ */
+function buildSwarmEntry(
+  gameId: string,
+  baseFields: IDerivedBaseFields,
+  summary: IFileSummary,
+): ISwarmReplayManifestEntry {
+  const created = summary.gameCreated;
+  const meta = (created?.payload as { swarmMeta?: unknown } | undefined)
+    ?.swarmMeta as
+    | { configName?: string; seed?: number; batchTimestamp?: string }
+    | undefined;
+  return {
+    id: gameId,
+    replaySource: ReplaySource.Swarm,
+    path: baseFields.path,
+    createdAt: baseFields.createdAt,
+    turns: baseFields.turns,
+    winner: baseFields.winner,
+    bvTotal: baseFields.bvTotal,
+    configName: meta?.configName ?? '',
+    seed: typeof meta?.seed === 'number' ? meta.seed : 0,
+    batchTimestamp: meta?.batchTimestamp ?? baseFields.createdAt,
+  };
+}
+
+/**
+ * Materializes a quick entry from partition-layout context. `playerSide` and
+ * `aiVariant` come from optional payload fields the QuickGameResults emitter
+ * may have written; otherwise they fall back to `Player` / `'unknown'` with
+ * a debug log so a developer can spot the missing denorm.
+ */
+function buildQuickEntry(
+  gameId: string,
+  baseFields: IDerivedBaseFields,
+  summary: IFileSummary,
+): IQuickReplayManifestEntry {
+  const created = summary.gameCreated;
+  const meta = (created?.payload as { quickMeta?: unknown } | undefined)
+    ?.quickMeta as { playerSide?: GameSide; aiVariant?: string } | undefined;
+  if (!meta) {
+    logger.debug(
+      '[replay-library] backfill quick entry missing quickMeta — using fallbacks',
+      { gameId },
+    );
+  }
+  return {
+    id: gameId,
+    replaySource: ReplaySource.Quick,
+    path: baseFields.path,
+    createdAt: baseFields.createdAt,
+    turns: baseFields.turns,
+    winner: baseFields.winner,
+    bvTotal: baseFields.bvTotal,
+    playerSide: meta?.playerSide ?? GameSide.Player,
+    aiVariant: meta?.aiVariant ?? 'unknown',
+  };
+}
+
+/**
+ * Materializes a placeholder entry for `pvp` / `campaign` partitions. The
+ * shape is reserved by PR 1 but no emitter writes into these partitions yet.
+ * If a developer drops a fixture in there, we keep the scan exhaustive
+ * rather than skipping silently.
+ */
+function buildPlaceholderEntry(
+  gameId: string,
+  source: ReplaySource.PvP | ReplaySource.Campaign,
+  baseFields: IDerivedBaseFields,
+): IReplayManifestEntry {
+  if (source === ReplaySource.PvP) {
+    return {
+      id: gameId,
+      replaySource: ReplaySource.PvP,
+      path: baseFields.path,
+      createdAt: baseFields.createdAt,
+      turns: baseFields.turns,
+      winner: baseFields.winner,
+      bvTotal: baseFields.bvTotal,
+      opponentName: '',
+      matchId: '',
+    };
+  }
+  return {
+    id: gameId,
+    replaySource: ReplaySource.Campaign,
+    path: baseFields.path,
+    createdAt: baseFields.createdAt,
+    turns: baseFields.turns,
+    winner: baseFields.winner,
+    bvTotal: baseFields.bvTotal,
+    campaignId: '',
+    missionId: '',
+    difficulty: '',
+  };
+}

--- a/src/replay-library/index-reader.ts
+++ b/src/replay-library/index-reader.ts
@@ -22,18 +22,27 @@ import { logger } from '@/utils/logger';
 
 import type { IReplayManifestEntry } from './types';
 
-/**
- * Stub backfill scan used when `replay-index.json` is missing. PR 3 replaces
- * this with the real on-disk scan; for PR 2 the empty-array stub keeps the
- * reader exhaustively testable without coupling to the scan implementation.
- */
-export type BackfillScan = () => Promise<readonly IReplayManifestEntry[]>;
+import { scanReplayDirectory } from './backfill-scan';
 
 /**
- * Default backfill stub — returns an empty manifest. Exported so the test can
- * spy on it and PR 3 can flip the default in one diff.
+ * Backfill scan invoked when `replay-index.json` is missing. PR 3 wires the
+ * real on-disk scan as the default; tests may still inject a stub through
+ * the `backfillScan` option to assert the fallback path is hit without
+ * touching the filesystem. The signature accepts the reader's resolved
+ * `cwd` so an injected scan can honour the same isolation tests rely on.
  */
-export const defaultBackfillScan: BackfillScan = () => Promise.resolve([]);
+export type BackfillScan = (
+  cwd: string,
+) => Promise<readonly IReplayManifestEntry[]>;
+
+/**
+ * Default backfill — delegates to `scanReplayDirectory` so a fresh checkout
+ * (or a developer that deleted `replay-index.json`) reconstructs the manifest
+ * from the on-disk `simulation-reports/` tree. Exported so callers can wrap
+ * or compose it without depending on `backfill-scan` directly.
+ */
+export const defaultBackfillScan: BackfillScan = (cwd) =>
+  scanReplayDirectory({ cwd });
 
 /**
  * Options for the reader. `cwd` lets tests inject a tmpdir without polluting
@@ -99,7 +108,8 @@ function hasRecognizedReplaySource(
 export async function readReplayIndex(
   options: IReadReplayIndexOptions = {},
 ): Promise<readonly IReplayManifestEntry[]> {
-  const indexPath = resolveIndexPath(options.cwd);
+  const cwd = options.cwd ?? process.cwd();
+  const indexPath = resolveIndexPath(cwd);
   const backfillScan = options.backfillScan ?? defaultBackfillScan;
 
   let raw: string;
@@ -112,7 +122,7 @@ export async function readReplayIndex(
         '[replay-library] replay-index.json missing — falling back to backfill scan',
         { indexPath },
       );
-      return backfillScan();
+      return backfillScan(cwd);
     }
     throw err;
   }

--- a/src/replay-library/index.ts
+++ b/src/replay-library/index.ts
@@ -4,6 +4,8 @@
  * backfill scan; subsequent PRs wire writers + UI).
  */
 
+export { scanReplayDirectory } from './backfill-scan';
+export type { IScanReplayDirectoryOptions } from './backfill-scan';
 export { defaultBackfillScan, readReplayIndex } from './index-reader';
 export type { BackfillScan, IReadReplayIndexOptions } from './index-reader';
 export { appendManifestEntry } from './index-writer';


### PR DESCRIPTION
## Summary

PR 3 of 6 in the **add-replay-library** ladder — backfill scan that materializes `IReplayManifestEntry[]` from on-disk NDJSON files, covering both the new partition layout (`simulation-reports/{swarm,quick,pvp,campaign}/<gameId>.jsonl`) AND the legacy flat layout (`simulation-reports/games/<run-timestamp>/<gameId>.jsonl`). Wired into the reader's missing-index fallback so a fresh checkout (or a developer who deleted \`replay-index.json\`) self-heals on next library load.

## What's in this PR

- New \`src/replay-library/backfill-scan.ts\` exporting \`scanReplayDirectory({ cwd? })\`. Streams each file line-by-line; extracts first event (must be \`GameCreated\` for \`bvTotal\` / quick \`playerSide\` / quick \`aiVariant\`) and last event (\`GameEnded\` for \`winner\` + \`turns\`). Falls back to \`turn_started\` count when \`GameEnded.turns\` is missing, then to \`0\`. Idempotent — two runs on the same disk state produce deep-equal arrays.
- Update \`src/replay-library/index-reader.ts\`: \`BackfillScan\` signature now takes \`cwd: string\`, default delegates to \`scanReplayDirectory\`. Existing reader tests' injected stubs remain compatible.
- Re-export \`scanReplayDirectory\` + \`IScanReplayDirectoryOptions\` from the \`src/replay-library/\` barrel.

## Test plan

- [x] Scan covers new partition layout (swarm + quick fixtures) → 2 entries with correct discriminants
- [x] Scan covers legacy flat layout (\`games/<ts>/<id>.jsonl\`) → 1 swarm entry with \`batchTimestamp\` derived from parent dir
- [x] Scan covers both layouts simultaneously
- [x] \`GameEnded.turns\` optionality fallback (count \`turn_started\`, then \`0\`)
- [x] Files with no \`GameCreated\` event are skipped with debug log
- [x] Empty \`simulation-reports/\` directory → empty array
- [x] Idempotent: deep-equal across runs
- [x] Reader tests still green with new \`BackfillScan(cwd)\` signature
- [x] \`npx tsc --noEmit --skipLibCheck\` clean
- [x] \`npx jest src/replay-library\` 29/29 green
- [x] Husky pre-commit + pre-push hooks green
- [x] Worktree contamination check clean (3 separate checks)
- [ ] CI green on this PR

## 6-PR ladder

1. types + enum (#548 ✓)
2. index reader/writer (#549 ✓)
3. **backfill scan + reader rewire (this PR)**
4. swarm runner partition + manifest emit
5. quick game persistence
6. Replay Library page + nav

Refs: \`openspec/changes/add-replay-library/specs/replay-library/spec.md\` — \`Backfill Scan\` + \`Central Replay Index Reader\` requirements
Refs: \`openspec/changes/add-replay-library/{proposal,design,tasks}.md\`