### PR TITLE
fix(replay-library): correct API route URL (drop /index suffix)

### DIFF
--- a/src/__tests__/pages/replay-library.test.tsx
+++ b/src/__tests__/pages/replay-library.test.tsx
@@ -2,7 +2,7 @@
  * Replay Library page tests.
  *
  * Phase A coverage:
- *   1. Lists entries from a mocked /api/replay-library/index fetch
+ *   1. Lists entries from a mocked /api/replay-library fetch
  *   2. Renders source-appropriate metadata per row (swarm + quick)
  *   3. Source filter restricts the visible rows
  *   4. Empty state when fetch returns { entries: [], total: 0 }
@@ -180,7 +180,7 @@ beforeEach(() => {
 });
 
 describe('ReplayLibraryPage', () => {
-  it('lists entries from a mocked /api/replay-library/index fetch', async () => {
+  it('lists entries from a mocked /api/replay-library fetch', async () => {
     const entries = [
       makeSwarmEntry({ id: 'sim-1' }),
       makeSwarmEntry({ id: 'sim-2', path: 'swarm/sim-2.jsonl' }),
@@ -193,7 +193,7 @@ describe('ReplayLibraryPage', () => {
     await renderLibrary();
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith('/api/replay-library/index');
+      expect(fetchMock).toHaveBeenCalledWith('/api/replay-library');
     });
 
     expect(screen.getByTestId('replay-row-sim-1')).toBeInTheDocument();
@@ -338,7 +338,7 @@ describe('ReplayLibraryPage', () => {
     ];
 
     fetchMock = jest.fn().mockImplementation((url: string) => {
-      if (url === '/api/replay-library/index') {
+      if (url === '/api/replay-library') {
         return Promise.resolve({
           ok: true,
           status: 200,
@@ -384,7 +384,7 @@ describe('ReplayLibraryPage', () => {
     const calledUrls = fetchMock.mock.calls.map(
       (call: ReadonlyArray<unknown>) => call[0],
     );
-    expect(calledUrls).toContain('/api/replay-library/index');
+    expect(calledUrls).toContain('/api/replay-library');
     expect(calledUrls).toContain('/api/replay-library/quick/quick-9');
 
     // Back button returns to the list.

--- a/src/components/replay-library/ReplayLibraryPage.stories.tsx
+++ b/src/components/replay-library/ReplayLibraryPage.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * Storybook stories for the Replay Library page.
  *
- * The page fetches `/api/replay-library/index` on mount via `globalThis.fetch`.
+ * The page fetches `/api/replay-library` on mount via `globalThis.fetch`.
  * Each story overrides `globalThis.fetch` in a decorator so the loading,
  * populated, empty, and error states render deterministically without
  * any backend.
@@ -117,7 +117,7 @@ function makeFetchDecorator(scenario: FetchScenario): Decorator {
             /* never resolves — story pinned to loading state */
           });
         }
-        if (url === '/api/replay-library/index') {
+        if (url === '/api/replay-library') {
           if (scenario.listError) {
             return Promise.resolve({
               ok: false,

--- a/src/components/replay-library/ReplayLibraryPage.tsx
+++ b/src/components/replay-library/ReplayLibraryPage.tsx
@@ -1,7 +1,7 @@
 /**
  * Replay Library page component.
  *
- * On mount, fetches `/api/replay-library/index` and renders the manifest
+ * On mount, fetches `/api/replay-library` and renders the manifest
  * entries as a card grid. Each row shows shared fields (id, createdAt,
  * turns, winner, bvTotal) plus source-specific metadata (configName/seed/
  * batchTimestamp for swarm; aiVariant/playerSide for quick; etc.).
@@ -254,7 +254,7 @@ export function ReplayLibraryPage(): React.ReactElement {
     let cancelled = false;
     async function load(): Promise<void> {
       try {
-        const res = await fetch('/api/replay-library/index');
+        const res = await fetch('/api/replay-library');
         if (!res.ok) {
           throw new Error(`HTTP ${res.status}`);
         }


### PR DESCRIPTION
## Summary

The Replay Library page (shipped in #553) was failing to load with a 404 on the API fetch when run against the real Next.js dev server. Surfaced during first manual smoke test.

## Root cause

Next.js Pages Router resolves `pages/api/replay-library/index.ts` to the bare path **`/api/replay-library`** — appending `/index` adds an extra path segment that doesn't match any route (the dynamic route is `[source]/[gameId]` which expects two segments, not one).

The unit test in #553 still passed before the fix because it intercepted whichever URL the page asked for — no real route resolution was happening.

## Fix

Change the page's fetch URL from `/api/replay-library/index` → `/api/replay-library`. Tests + storybook decorator + comment updated to match.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` clean
- [x] `npx jest src/__tests__/pages/replay-library.test.tsx` — 8/8 green
- [x] Pre-push `next build` (husky) — clean
- [x] `curl http://localhost:3000/api/replay-library` → HTTP 200, `{"entries":[],"total":0}` (empty until first swarm/quick replay)

Discovered post-archive of `add-replay-library`; ships as a follow-on fix PR rather than re-opening the change.