### PR TITLE
feat(ui): History nav dropdown + GitHub repo link + port 3600

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN addgroup --system --gid 1001 nodejs && \
 # Set environment variables
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
-ENV PORT=3000
+ENV PORT=3600
 ENV HOSTNAME="0.0.0.0"
 
 # Copy necessary files from builder
@@ -75,11 +75,11 @@ RUN mkdir -p /app/data && \
 USER nextjs
 
 # Expose port
-EXPOSE 3000
+EXPOSE 3600
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:3600/api/health || exit 1
 
 # Start the application
 CMD ["node", "server.js"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -18,7 +18,7 @@ RUN npm ci
 COPY . .
 
 # Expose port
-EXPOSE 3000
+EXPOSE 3600
 
 # Set environment variables
 ENV NODE_ENV=development

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Run MekStation anywhere.
 ```bash
 npm install
 npm run fetch:assets   # Download record sheet assets
-npm run dev            # Start at http://localhost:3000
+npm run dev            # Start at http://localhost:3600
 ```
 
 > **Note**: The `fetch:assets` command downloads record sheet templates and armor pips from the MegaMek mm-data repository via jsDelivr CDN. These assets are required for PDF export and record sheet rendering. See [Asset Management](#asset-management) below for details.

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -714,7 +714,7 @@ X-GNOME-Autostart-enabled=true
 
     // Load the application
     if (this.config.developmentMode) {
-      await this.mainWindow.loadURL('http://localhost:3000');
+      await this.mainWindow.loadURL('http://localhost:3600');
       this.mainWindow.webContents.openDevTools();
     } else {
       // In production, start the Next.js standalone server and load it

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -27,7 +27,7 @@
     "build:watch": "tsc --watch",
     "start": "electron dist/electron/main.js",
     "dev": "concurrently \"npm run build:watch\" \"wait-on dist/electron/main.js && cross-env NODE_ENV=development electron dist/electron/main.js\"",
-    "dev:full": "concurrently \"npm --prefix .. run dev\" \"wait-on http://localhost:3000 && npm run dev\"",
+    "dev:full": "concurrently \"npm --prefix .. run dev\" \"wait-on http://localhost:3600 && npm run dev\"",
     "rebuild:next-standalone": "node scripts/rebuild-next-standalone.js",
     "release:prepare-update-metadata": "node scripts/release/prepare-update-metadata.js",
     "release:publish-update-metadata": "node scripts/release/publish-update-metadata-gh-pages.js",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     container_name: mekstation
     restart: unless-stopped
     ports:
-      - '${PORT:-3000}:3000'
+      - '${PORT:-3600}:3600'
     environment:
       - NODE_ENV=production
       - DATABASE_PATH=/app/data/mekstation.db
@@ -38,7 +38,7 @@ services:
           '--no-verbose',
           '--tries=1',
           '--spider',
-          'http://localhost:3000/api/health',
+          'http://localhost:3600/api/health',
         ]
       interval: 30s
       timeout: 10s
@@ -47,7 +47,7 @@ services:
     labels:
       - 'traefik.enable=true'
       - 'traefik.http.routers.mekstation.rule=Host(`mekstation.localhost`)'
-      - 'traefik.http.services.mekstation.loadbalancer.server.port=3000'
+      - 'traefik.http.services.mekstation.loadbalancer.server.port=3600'
 
   # ==========================================================================
   # Development Server with Hot Reload
@@ -58,7 +58,7 @@ services:
       dockerfile: Dockerfile.dev
     container_name: mekstation-dev
     ports:
-      - '${DEV_PORT:-3000}:3000'
+      - '${DEV_PORT:-3600}:3600'
     environment:
       - NODE_ENV=development
       - WATCHPACK_POLLING=true

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -25,7 +25,7 @@ npm run fetch:assets
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) to view the application.
+Open [http://localhost:3600](http://localhost:3600) to view the application.
 
 ## Asset Management
 

--- a/docs/development/troubleshooting.md
+++ b/docs/development/troubleshooting.md
@@ -44,10 +44,10 @@ if ('property' in config) {
 
 ```bash
 # Find and kill the process
-npx kill-port 3000
+npx kill-port 3600
 
-# Or use a different port
-npm run dev -- -p 3001
+# Or use a different port (the dev script defaults to 3600)
+PORT=3700 npm run dev
 ```
 
 ### Hot Reload Not Working

--- a/e2e/app-routes.spec.ts
+++ b/e2e/app-routes.spec.ts
@@ -14,7 +14,7 @@ test.describe('Application Routes', () => {
     await page.waitForLoadState('networkidle');
 
     // Page should load
-    await expect(page).toHaveURL(/localhost:3000/);
+    await expect(page).toHaveURL(/localhost:3600/);
 
     // Filter out expected/benign errors
     const criticalErrors = errors.filter(

--- a/openspec/specs/p2p-sync-system/spec.md
+++ b/openspec/specs/p2p-sync-system/spec.md
@@ -842,7 +842,7 @@ function setupSyncEventLogger() {
 
 ```typescript
 // In E2E test setup
-const testUrl = 'http://localhost:3000?mockSync=true';
+const testUrl = 'http://localhost:3600?mockSync=true';
 
 // In application code
 import { shouldUseMockSync } from '@/lib/p2p/MockSyncProvider';

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "email": "swervelabs@proton.me"
   },
   "scripts": {
-    "dev": "npx kill-port 3000 --silent && node server.js",
-    "dev:e2e": "npx kill-port 3000 --silent && next dev --webpack",
+    "dev": "npx kill-port 3600 --silent && node server.js",
+    "dev:e2e": "npx kill-port 3600 --silent && next dev --webpack --port 3600",
     "build": "next build",
     "build:analyze": "ANALYZE=true next build",
     "start": "next start",
@@ -70,7 +70,7 @@
     "terminology:fix:dry-run": "npx ts-node openspec/scripts/terminology-tool.ts fix --dry-run",
     "terminology:check": "node openspec/scripts/validate-terminology.js",
     "docker:build": "docker build -t mekstation .",
-    "docker:run": "docker run -p 3000:3000 -v mekstation-data:/app/data mekstation",
+    "docker:run": "docker run -p 3600:3600 -v mekstation-data:/app/data mekstation",
     "docker:dev": "docker-compose up dev",
     "docker:prod": "docker-compose up app -d",
     "docker:stop": "docker-compose down",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -55,7 +55,7 @@ export default defineConfig({
   /* Shared settings for all the projects below */
   use: {
     /* Base URL to use in actions like `await page.goto('/')` */
-    baseURL: 'http://localhost:3000',
+    baseURL: 'http://localhost:3600',
 
     /* Collect trace when retrying the failed test */
     trace: 'on-first-retry',
@@ -124,7 +124,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'npm run dev:e2e',
-    url: 'http://localhost:3000',
+    url: 'http://localhost:3600',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
     // Pipe stdout to help with process cleanup on Windows

--- a/server.js
+++ b/server.js
@@ -169,7 +169,7 @@ async function verifyWireToken(wire, nowMs = Date.now()) {
 // =============================================================================
 
 const dev = process.env.NODE_ENV !== 'production';
-const port = parseInt(process.env.PORT ?? '3000', 10);
+const port = parseInt(process.env.PORT ?? '3600', 10);
 const hostname = process.env.HOSTNAME ?? 'localhost';
 
 const app = next({ dev, hostname, port });

--- a/src/components/common/TopBar.tsx
+++ b/src/components/common/TopBar.tsx
@@ -30,7 +30,7 @@ import {
 import { DropdownMenu, NavLink, type NavItemConfig } from './TopBarMenu';
 import { MobileMenu } from './TopBarMobileMenu';
 
-type DropdownId = 'browse' | 'tools' | 'gameplay' | null;
+type DropdownId = 'browse' | 'tools' | 'gameplay' | 'history' | null;
 
 const TopBar: React.FC = () => {
   const router = useRouter();
@@ -91,6 +91,9 @@ const TopBar: React.FC = () => {
   const isAnyGameplayActive = gameplayItems.some((item) =>
     isPathActive(item.href),
   );
+  const isAnyHistoryActive = historyItems.some((item) =>
+    isPathActive(item.href),
+  );
 
   return (
     <>
@@ -148,11 +151,15 @@ const TopBar: React.FC = () => {
               onOpen={() => setOpenDropdown('gameplay')}
               onClose={() => setOpenDropdown(null)}
             />
-            <NavLink
-              href="/audit/timeline"
+            <DropdownMenu
+              label="History"
               icon={<TimelineIcon />}
-              label="Timeline"
-              isActive={isPathActive('/audit/timeline')}
+              items={historyItems}
+              isAnyActive={isAnyHistoryActive}
+              isPathActive={isPathActive}
+              isOpen={openDropdown === 'history'}
+              onOpen={() => setOpenDropdown('history')}
+              onClose={() => setOpenDropdown(null)}
             />
           </nav>
 
@@ -198,11 +205,15 @@ const TopBar: React.FC = () => {
               onClose={() => setOpenDropdown(null)}
               iconOnly
             />
-            <NavLink
-              href="/audit/timeline"
+            <DropdownMenu
+              label="History"
               icon={<TimelineIcon />}
-              label="Timeline"
-              isActive={isPathActive('/audit/timeline')}
+              items={historyItems}
+              isAnyActive={isAnyHistoryActive}
+              isPathActive={isPathActive}
+              isOpen={openDropdown === 'history'}
+              onOpen={() => setOpenDropdown('history')}
+              onClose={() => setOpenDropdown(null)}
               iconOnly
             />
           </nav>
@@ -224,7 +235,7 @@ const TopBar: React.FC = () => {
                 </a>
               </Link>
               <a
-                href="https://github.com"
+                href="https://github.com/SwiggitySwerve/MekStation"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-text-theme-secondary hover:text-text-theme-primary hover:bg-surface-raised/50 rounded-lg p-2 transition-colors"

--- a/src/pages/api/multiplayer/matches/index.ts
+++ b/src/pages/api/multiplayer/matches/index.ts
@@ -128,7 +128,7 @@ function buildWsUrl(req: NextApiRequest, matchId: string): string {
   // Use the same host the request came in on; the WS upgrade handler in
   // server.js binds to the same port as the HTTP server. Default to
   // `ws://` because production proxies typically rewrite to wss.
-  const host = req.headers.host ?? 'localhost:3000';
+  const host = req.headers.host ?? 'localhost:3600';
   const proto =
     (req.headers['x-forwarded-proto'] as string | undefined) === 'https'
       ? 'wss'

--- a/src/services/units/CanonicalUnitService.ts
+++ b/src/services/units/CanonicalUnitService.ts
@@ -150,7 +150,7 @@ function getBaseUrl(): string {
   // Use NEXT_PUBLIC_BASE_URL if set, otherwise default to localhost
   const baseUrl =
     process.env.NEXT_PUBLIC_BASE_URL ||
-    `http://localhost:${process.env.PORT || 3000}`;
+    `http://localhost:${process.env.PORT || 3600}`;
   return baseUrl;
 }
 

--- a/src/stores/simulation-viewer/__tests__/useTabNavigationStore.test.ts
+++ b/src/stores/simulation-viewer/__tests__/useTabNavigationStore.test.ts
@@ -33,7 +33,7 @@ describe('useTabNavigationStore', () => {
 
     // Mock window.location (simple assignment works better than defineProperty in Jest)
     (window as any).location = {
-      href: 'http://localhost:3000/simulation-viewer',
+      href: 'http://localhost:3600/simulation-viewer',
       search: '',
     };
   });
@@ -377,7 +377,7 @@ describe('useTabNavigationStore', () => {
 
     it('should preserve existing query parameters', () => {
       (window as any).location = {
-        href: 'http://localhost:3000/simulation-viewer?foo=bar',
+        href: 'http://localhost:3600/simulation-viewer?foo=bar',
         search: '?foo=bar',
       };
 
@@ -397,7 +397,7 @@ describe('useTabNavigationStore', () => {
 
     it('should replace existing tab parameter', () => {
       (window as any).location = {
-        href: 'http://localhost:3000/simulation-viewer?tab=old-tab',
+        href: 'http://localhost:3600/simulation-viewer?tab=old-tab',
         search: '?tab=old-tab',
       };
 
@@ -433,7 +433,7 @@ describe('useTabNavigationStore', () => {
 
     it('should use correct URL format', () => {
       (window as any).location = {
-        href: 'http://localhost:3000/simulation-viewer',
+        href: 'http://localhost:3600/simulation-viewer',
         search: '',
       };
 
@@ -716,7 +716,7 @@ describe('useTabNavigationStore', () => {
 
     it('should handle hook initialization with valid location', () => {
       (window as any).location = {
-        href: 'http://localhost:3000/simulation-viewer?tab=encounter-history',
+        href: 'http://localhost:3600/simulation-viewer?tab=encounter-history',
         search: '?tab=encounter-history',
       };
 


### PR DESCRIPTION
## Summary

Three UI / config tweaks bundled because each is small and they share verification cost.

### 1. History nav dropdown
The standalone Timeline NavLink in desktop + tablet nav becomes a **History** dropdown containing both **Timeline** and **Replay Library**, mirroring the existing Browse / Tools / Gameplay pattern. Mobile menu already rendered the History group via the shared `historyItems` config.

### 2. GitHub link
Bump the TopBar GitHub anchor from the placeholder `https://github.com` to the real repo at `https://github.com/SwiggitySwerve/MekStation`.

### 3. UI port 3600 (was 3000)
Free the well-known dev port for other tooling. Updated everywhere it's hardcoded:

- `package.json` (dev / dev:e2e / docker:run scripts; explicit `--port 3600` on `next dev` for dev:e2e since it doesn't read `server.js`)
- `server.js` default
- `playwright.config.ts` (baseURL + webServer URL)
- `Dockerfile` + `Dockerfile.dev` + `docker-compose.yml` (ENV / EXPOSE / health checks / traefik label / port maps)
- `desktop/electron/main.ts` (loadURL) + `desktop/package.json` (wait-on URL in dev:full)
- `e2e/app-routes.spec.ts` (URL regex)
- `src/pages/api/multiplayer/matches/index.ts` (host fallback)
- `src/services/units/CanonicalUnitService.ts` (port fallback)
- `src/stores/simulation-viewer/__tests__/useTabNavigationStore.test.ts` (5 fixture URLs)
- README + docs/development/getting-started.md + docs/development/troubleshooting.md
- `openspec/specs/p2p-sync-system/spec.md` (example URL)

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` clean
- [x] `npx oxlint` — 0/0
- [x] `npx oxfmt --check` clean
- [x] `npx jest src/components/common src/__tests__/pages src/stores/simulation-viewer src/services/units` — 28 suites / 1498 tests / 0 failures
- [x] Pre-push `next build` (husky) — clean; `/replay-library` prerendered as static; no `node:fs` traced into client bundle

The running dev server needs to be restarted to bind the new port — just run `npm run dev` again; the `kill-port` step now targets 3600 so it'll relinquish 3000 cleanly.