### PR TITLE
feat(replay-library): wire quick games to replay library + empty-state CTAs

### DIFF
--- a/src/__tests__/api/replay-library/quick.test.ts
+++ b/src/__tests__/api/replay-library/quick.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Replay Library quick-game persist API route — handler tests.
+ *
+ * Covers the four contract scenarios for `POST /api/replay-library/quick`:
+ *   1. Happy-path POST calls `persistQuickGame()` once with the parsed
+ *      body and forwards its result to the response.
+ *   2. Duplicate POST (gameId already present in manifest) short-circuits
+ *      to `{persisted: false, alreadyPersisted: true}` WITHOUT calling
+ *      `persistQuickGame` again — the dedup guard is the Momus blocking
+ *      gap fix, so it's the most important assertion.
+ *   3. 405 on non-POST methods.
+ *   4. 400 on bad input (bad gameId / non-array events / bad winner /
+ *      missing aiVariant / non-object body).
+ *
+ * The persist pipeline itself is covered by
+ * `src/components/quickgame/__tests__/persistQuickGame.test.ts` which
+ * exercises the actual filesystem write against a tmpdir cwd. This
+ * suite mocks `persistQuickGame` so we test ONLY the route's
+ * input-validation + dedup-guard + result-forwarding behavior.
+ *
+ * The dedup guard is exercised against the real `readReplayIndex()`
+ * implementation, with `process.cwd()` mocked to a tmpdir so we get
+ * full handler ↔ reader wiring coverage of the duplicate-detection
+ * path (the part that actually saved us from the blind-append footgun).
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type {
+  IQuickReplayManifestEntry,
+  IReplayManifestEntry,
+} from '@/replay-library/types';
+
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  ReplaySource,
+  type IGameEvent,
+} from '@/types/gameplay';
+import { enableTestMode } from '@/utils/logger';
+
+// =============================================================================
+// Module mock — must precede the handler import.
+// =============================================================================
+
+jest.mock('@/components/quickgame/persistQuickGame', () => {
+  const actual = jest.requireActual<
+    typeof import('@/components/quickgame/persistQuickGame')
+  >('@/components/quickgame/persistQuickGame');
+  return {
+    __esModule: true,
+    // Re-export `buildQuickManifestEntry` from the real module — the
+    // route uses it to shape the response on the dedup branch.
+    buildQuickManifestEntry: actual.buildQuickManifestEntry,
+    // `persistQuickGame` is the only side-effecting export; replace it
+    // with a jest mock so the handler test stays hermetic. The default
+    // mock returns a write-success shape; individual tests override
+    // with mockImplementationOnce when they need a different result.
+    persistQuickGame: jest.fn(),
+  };
+});
+
+// Import AFTER the mock is registered.
+// eslint-disable-next-line import/first
+import { persistQuickGame } from '@/components/quickgame/persistQuickGame';
+// eslint-disable-next-line import/first
+import handler from '@/pages/api/replay-library/quick';
+
+const mockedPersistQuickGame = persistQuickGame as jest.MockedFunction<
+  typeof persistQuickGame
+>;
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+interface MockNextApiResponse extends NextApiResponse {
+  status: jest.Mock;
+  json: jest.Mock;
+  setHeader: jest.Mock;
+}
+
+function createMockRequest(
+  overrides: Partial<NextApiRequest> = {},
+): NextApiRequest {
+  return {
+    method: 'POST',
+    query: {},
+    body: {},
+    headers: {},
+    ...overrides,
+  } as NextApiRequest;
+}
+
+function createMockResponse(): MockNextApiResponse {
+  const res: Partial<MockNextApiResponse> = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+  };
+  return res as MockNextApiResponse;
+}
+
+async function makeTmpReports(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'replay-library-quick-test-'));
+}
+
+// Build a minimal valid event log — one GameCreated + one TurnStarted.
+function makeEvents(gameId: string): IGameEvent[] {
+  return [
+    {
+      id: `${gameId}-evt-0`,
+      gameId,
+      sequence: 0,
+      timestamp: '2026-05-08T00:00:00.000Z',
+      type: GameEventType.GameCreated,
+      turn: 0,
+      phase: GamePhase.Initiative,
+      payload: {
+        config: {
+          mapRadius: 10,
+          turnLimit: 10,
+          victoryConditions: ['destruction'],
+          optionalRules: [],
+        },
+        units: [],
+      },
+    } as IGameEvent,
+    {
+      id: `${gameId}-evt-1`,
+      gameId,
+      sequence: 1,
+      timestamp: '2026-05-08T00:00:01.000Z',
+      type: GameEventType.TurnStarted,
+      turn: 1,
+      phase: GamePhase.Initiative,
+      payload: {},
+    } as IGameEvent,
+  ];
+}
+
+function validBody(gameId = 'quick-route-1'): {
+  gameId: string;
+  events: IGameEvent[];
+  winner: 'player' | 'opponent' | 'draw' | null;
+  aiVariant: string;
+} {
+  return {
+    gameId,
+    events: makeEvents(gameId),
+    winner: 'player',
+    aiVariant: 'aggressive-v2',
+  };
+}
+
+// Build a write-success result shape the route forwards to the client.
+// `manifestEntry` is typed `IQuickReplayManifestEntry` (not the union)
+// because the route's `persistQuickGame` always returns the Quick variant.
+function makeWriteSuccess(gameId: string): {
+  persisted: boolean;
+  path: string;
+  manifestEntry: IQuickReplayManifestEntry;
+} {
+  return {
+    persisted: true,
+    path: path.join('simulation-reports', 'quick', `${gameId}.jsonl`),
+    manifestEntry: {
+      id: gameId,
+      replaySource: ReplaySource.Quick,
+      path: `quick/${gameId}.jsonl`,
+      createdAt: '2026-05-08T00:00:00.000Z',
+      turns: 1,
+      winner: GameSide.Player,
+      bvTotal: 0,
+      playerSide: GameSide.Player,
+      aiVariant: 'aggressive-v2',
+    },
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('POST /api/replay-library/quick', () => {
+  let tmpDir: string;
+  let cwdSpy: jest.SpyInstance | null = null;
+
+  beforeAll(() => {
+    enableTestMode();
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    tmpDir = await makeTmpReports();
+    cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+    mockedPersistQuickGame.mockResolvedValue(makeWriteSuccess('default'));
+  });
+
+  afterEach(async () => {
+    cwdSpy?.mockRestore();
+    cwdSpy = null;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('calls persistQuickGame once with parsed body and forwards the result', async () => {
+    const result = makeWriteSuccess('quick-happy-1');
+    mockedPersistQuickGame.mockResolvedValueOnce(result);
+
+    const body = validBody('quick-happy-1');
+    const req = createMockRequest({ body });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(mockedPersistQuickGame).toHaveBeenCalledTimes(1);
+    expect(mockedPersistQuickGame).toHaveBeenCalledWith({
+      gameId: 'quick-happy-1',
+      events: body.events,
+      winner: 'player',
+      aiVariant: 'aggressive-v2',
+    });
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      persisted: true,
+      alreadyPersisted: false,
+      manifestEntry: result.manifestEntry,
+      path: result.path,
+    });
+  });
+
+  it('short-circuits with alreadyPersisted=true when gameId is already in the manifest', async () => {
+    // Pre-seed the manifest with the duplicate entry (Momus blocking-gap
+    // scenario: hard refresh fires the persist effect again on a game
+    // whose row already exists). Real `readReplayIndex()` reads this
+    // and the route MUST return the dedup branch without calling
+    // `persistQuickGame` again.
+    const reportsDir = path.join(tmpDir, 'simulation-reports');
+    await fs.mkdir(reportsDir, { recursive: true });
+    const seed: IReplayManifestEntry[] = [
+      {
+        id: 'quick-dup-1',
+        replaySource: ReplaySource.Quick,
+        path: 'quick/quick-dup-1.jsonl',
+        createdAt: '2026-05-08T00:00:00.000Z',
+        turns: 5,
+        winner: GameSide.Player,
+        bvTotal: 3000,
+        playerSide: GameSide.Player,
+        aiVariant: 'aggressive-v2',
+      } as IReplayManifestEntry,
+    ];
+    await fs.writeFile(
+      path.join(reportsDir, 'replay-index.json'),
+      JSON.stringify(seed),
+      'utf8',
+    );
+
+    const req = createMockRequest({ body: validBody('quick-dup-1') });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    // Critical: persistQuickGame() MUST NOT be called on a duplicate.
+    expect(mockedPersistQuickGame).not.toHaveBeenCalled();
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const jsonArg = res.json.mock.calls[0][0] as {
+      persisted: boolean;
+      alreadyPersisted: boolean;
+      path: string | null;
+      manifestEntry: { id: string };
+    };
+    expect(jsonArg.persisted).toBe(false);
+    expect(jsonArg.alreadyPersisted).toBe(true);
+    expect(jsonArg.path).toBe('quick/quick-dup-1.jsonl');
+    expect(jsonArg.manifestEntry.id).toBe('quick-dup-1');
+  });
+
+  it('continues to persist when the manifest read fails (does not 500)', async () => {
+    // Write a malformed replay-index.json. `readReplayIndex` propagates
+    // the JSON.parse error; the route catches and falls through to the
+    // persist call instead of 500-ing on a soft index issue.
+    const reportsDir = path.join(tmpDir, 'simulation-reports');
+    await fs.mkdir(reportsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(reportsDir, 'replay-index.json'),
+      'not valid json',
+      'utf8',
+    );
+
+    const result = makeWriteSuccess('quick-malformed-1');
+    mockedPersistQuickGame.mockResolvedValueOnce(result);
+
+    const req = createMockRequest({ body: validBody('quick-malformed-1') });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(mockedPersistQuickGame).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+    const jsonArg = res.json.mock.calls[0][0] as {
+      persisted: boolean;
+      alreadyPersisted: boolean;
+    };
+    expect(jsonArg.persisted).toBe(true);
+    expect(jsonArg.alreadyPersisted).toBe(false);
+  });
+
+  it('returns 500 PERSIST_FAILED when persistQuickGame throws', async () => {
+    mockedPersistQuickGame.mockRejectedValueOnce(new Error('disk full'));
+
+    const req = createMockRequest({ body: validBody('quick-error-1') });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'failed to persist quick game',
+      code: 'PERSIST_FAILED',
+    });
+  });
+
+  it('rejects non-POST methods with 405', async () => {
+    const req = createMockRequest({ method: 'GET', body: validBody() });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Allow', ['POST']);
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(mockedPersistQuickGame).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['contains dot-dot', '..'],
+    ['contains forward-slash', 'foo/bar'],
+    ['contains backslash', 'foo\\bar'],
+    ['contains dot', 'sim.1'],
+    ['empty string', ''],
+  ])('returns 400 BAD_GAME_ID when gameId %s', async (_label, badId) => {
+    const req = createMockRequest({
+      body: { ...validBody(), gameId: badId },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'invalid gameId',
+      code: 'BAD_GAME_ID',
+    });
+    expect(mockedPersistQuickGame).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 BAD_EVENTS when events is not an array', async () => {
+    const req = createMockRequest({
+      body: { ...validBody(), events: 'not-an-array' },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'events must be an array',
+      code: 'BAD_EVENTS',
+    });
+  });
+
+  it('returns 400 BAD_WINNER when winner is an unknown string', async () => {
+    const req = createMockRequest({
+      body: { ...validBody(), winner: 'mystery' },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'invalid winner',
+      code: 'BAD_WINNER',
+    });
+  });
+
+  it('accepts winner=null (timed-out / aborted game)', async () => {
+    const result = makeWriteSuccess('quick-null-1');
+    mockedPersistQuickGame.mockResolvedValueOnce(result);
+
+    const req = createMockRequest({
+      body: { ...validBody('quick-null-1'), winner: null },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockedPersistQuickGame).toHaveBeenCalledWith(
+      expect.objectContaining({ winner: null }),
+    );
+  });
+
+  it('returns 400 BAD_AI_VARIANT when aiVariant is missing', async () => {
+    const body = validBody();
+    delete (body as Partial<typeof body>).aiVariant;
+    const req = createMockRequest({ body });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'aiVariant must be a string',
+      code: 'BAD_AI_VARIANT',
+    });
+  });
+
+  it('returns 400 BAD_BODY when the body is not an object', async () => {
+    const req = createMockRequest({ body: 'plain-string' });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'request body must be an object',
+      code: 'BAD_BODY',
+    });
+  });
+});

--- a/src/components/quickgame/QuickGameResults.tsx
+++ b/src/components/quickgame/QuickGameResults.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useRouter } from 'next/router';
-import { useState, useRef, useCallback, useMemo } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 
 import type { IGameOutcome, ICombatStats } from '@/services/game-resolution';
 import type { IDamageAssessment } from '@/services/game-resolution/DamageCalculator';
@@ -24,6 +24,7 @@ import {
 import { useGameplaySelector } from '@/stores/useGameplayStore';
 import { useQuickGameSelector } from '@/stores/useQuickGameStore';
 import { GameSide } from '@/types/gameplay';
+import { logger } from '@/utils/logger';
 
 import type { ResultsTab } from './quickGameResults.helpers';
 
@@ -46,14 +47,72 @@ export function QuickGameResults(): React.ReactElement {
   const [activeTab, setActiveTab] = useState<ResultsTab>('summary');
   const tabListRef = useRef<HTMLDivElement>(null);
 
-  // Per add-replay-library PR 5 v1 scope: the persistence pipeline lives
-  // in `./persistQuickGame.ts` and is unit-tested under Node, but the
-  // browser-side wire-up (calling persist on `endedAt` transitions)
-  // requires a Next.js API route since browser code can't write to the
-  // local filesystem. That route is a follow-on PR — quick-game replays
-  // are still discoverable via the backfill scan (PR 3) once written
-  // through any path. The helper is exported and ready for the API
-  // route to import.
+  // Persist-to-Replay-Library status. Drives the footer copy at the
+  // bottom of the results page. `idle` until the POST resolves; flips
+  // to `saved` on success (first persist or already-persisted) or
+  // `failed` on network/server error. Errors do NOT block the rest of
+  // the results UI — replay-library writes are best-effort.
+  const [persistStatus, setPersistStatus] = useState<
+    'idle' | 'saving' | 'saved' | 'failed'
+  >('idle');
+
+  // StrictMode-safe one-shot guard. The effect below runs on every
+  // render where `game.endedAt` flips truthy; without this ref, React
+  // 18 StrictMode would fire it twice in dev and the API would see two
+  // POSTs. The server-side dedup check in `/api/replay-library/quick`
+  // is the durable backstop (handles hard refresh + tab restore from
+  // sessionStorage), but cheap in-memory deduping here saves a round
+  // trip in the common case.
+  const persistFiredRef = useRef(false);
+
+  // Wire-up (Council-approved, replaces the prior deferred follow-on).
+  // POSTs once when `game.endedAt` becomes set. The API route handles:
+  //   - the actual `node:fs` write (browsers cannot write directly)
+  //   - dedup via `replay-index.json` (so a hard refresh of an
+  //     already-persisted game returns 200 alreadyPersisted=true).
+  //
+  // `aiVariant` source is `game.scenarioConfig.enemyFaction` per
+  // Phase 2 Explore-Deep verification — NOT `game.scenario?.template?.…`.
+  useEffect(() => {
+    if (!game || !game.endedAt) return;
+    if (persistFiredRef.current) return;
+    persistFiredRef.current = true;
+    setPersistStatus('saving');
+
+    const body = JSON.stringify({
+      gameId: game.id,
+      events: game.events,
+      winner: game.winner,
+      aiVariant: game.scenarioConfig.enemyFaction ?? '',
+    });
+
+    let cancelled = false;
+    void fetch('/api/replay-library/quick', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    })
+      .then((res) => {
+        if (cancelled) return;
+        if (!res.ok) {
+          logger.error('[quick-game] replay-library persist failed', {
+            status: res.status,
+          });
+          setPersistStatus('failed');
+          return;
+        }
+        setPersistStatus('saved');
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        logger.error('[quick-game] replay-library persist threw', { err });
+        setPersistStatus('failed');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [game]);
 
   const handleTabChange = useCallback((tabId: string) => {
     setActiveTab(tabId as ResultsTab);
@@ -351,8 +410,27 @@ export function QuickGameResults(): React.ReactElement {
         </Button>
       </div>
 
-      <p className="mt-6 text-center text-xs text-gray-500">
-        This was a quick game session. No data is persisted.
+      <p
+        className="mt-6 text-center text-xs text-gray-500"
+        data-testid="quick-game-persist-status"
+      >
+        {persistStatus === 'saved' && (
+          <>
+            Saved to{' '}
+            <button
+              type="button"
+              onClick={() => router.push('/replay-library')}
+              className="text-cyan-400 underline-offset-2 hover:underline"
+            >
+              Replay Library
+            </button>
+            .
+          </>
+        )}
+        {persistStatus === 'saving' && 'Saving replay…'}
+        {persistStatus === 'failed' &&
+          'Replay save failed (game state intact).'}
+        {persistStatus === 'idle' && 'This was a quick game session.'}
       </p>
     </div>
   );

--- a/src/components/quickgame/__tests__/QuickGameResults.test.tsx
+++ b/src/components/quickgame/__tests__/QuickGameResults.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import '@testing-library/jest-dom';
@@ -13,6 +13,13 @@ jest.mock('next/router', () => ({
     push: jest.fn(),
   }),
 }));
+
+// Save the original (jest.setup.js) fetch polyfill so per-suite overrides
+// can be restored cleanly. The default polyfill returns empty arrays for
+// `.json` URLs and throws for everything else, which is fine for the
+// existing tab/keyboard/summary tests but inadequate for asserting the
+// persist effect's POST shape — those tests install a typed jest.fn().
+const originalFetch = global.fetch;
 
 function createMockGame() {
   return {
@@ -376,6 +383,97 @@ describe('QuickGameResults', () => {
       expect(
         screen.getByText('No game results to display.'),
       ).toBeInTheDocument();
+    });
+  });
+
+  // ===========================================================================
+  // Replay Library persist effect (Council-approved wire-up).
+  //
+  // The effect POSTs to `/api/replay-library/quick` once per `endedAt`
+  // transition. The route + persist pipeline are exercised by their own
+  // suites — these tests assert ONLY the component contract: fired once
+  // with the right body, footer status reflects the POST result.
+  // ===========================================================================
+  describe('Replay Library persist effect', () => {
+    let fetchMock: jest.MockedFunction<typeof fetch>;
+
+    beforeEach(() => {
+      fetchMock = jest
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200 } as Response);
+      global.fetch = fetchMock as typeof fetch;
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('POSTs to /api/replay-library/quick exactly once with the correct body', async () => {
+      render(<QuickGameResults />);
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/replay-library/quick',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+      // Body is a JSON string — parse and assert shape (gameId, events
+      // array length, winner, aiVariant). The aiVariant source is
+      // `game.scenarioConfig.enemyFaction` per Phase 2 Explore-Deep
+      // verification — the mock game above doesn't define it, so we
+      // expect the empty-string fallback.
+      const callArgs = fetchMock.mock.calls[0];
+      const init = callArgs[1] as RequestInit;
+      const parsed = JSON.parse(init.body as string) as {
+        gameId: string;
+        events: unknown[];
+        winner: string;
+        aiVariant: string;
+      };
+      expect(parsed.gameId).toBe('test-game-1');
+      expect(Array.isArray(parsed.events)).toBe(true);
+      expect(parsed.events).toHaveLength(3);
+      expect(parsed.winner).toBe('player');
+      expect(parsed.aiVariant).toBe('');
+    });
+
+    it('does NOT fire when the game is null (no game terminal state)', async () => {
+      useQuickGameStore.setState({ game: null });
+
+      render(<QuickGameResults />);
+
+      // Wait one render-tick worth of microtasks so a stray fetch would
+      // surface — then assert the mock was never called.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('renders the saved status copy after a successful persist', async () => {
+      render(<QuickGameResults />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('quick-game-persist-status'),
+        ).toHaveTextContent(/saved to/i);
+      });
+    });
+
+    it('renders the failed status copy when the API returns non-OK', async () => {
+      fetchMock.mockResolvedValueOnce({ ok: false, status: 500 } as Response);
+
+      render(<QuickGameResults />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('quick-game-persist-status'),
+        ).toHaveTextContent(/replay save failed/i);
+      });
     });
   });
 });

--- a/src/components/replay-library/ReplayLibraryPage.tsx
+++ b/src/components/replay-library/ReplayLibraryPage.tsx
@@ -24,6 +24,7 @@
  * @spec openspec/changes/add-replay-library/specs/replay-library/spec.md
  */
 
+import { useRouter } from 'next/router';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import type { IReplayManifestEntry } from '@/replay-library/types';
@@ -242,6 +243,7 @@ interface IViewerState {
 }
 
 export function ReplayLibraryPage(): React.ReactElement {
+  const router = useRouter();
   const [entries, setEntries] = useState<readonly IReplayManifestEntry[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -429,8 +431,28 @@ export function ReplayLibraryPage(): React.ReactElement {
           }
           message={
             entries.length === 0
-              ? 'No replays yet — run a swarm or finish a quick game to populate the library.'
+              ? 'Finish a quick game or set up an encounter, and the resulting replay will show up here. Swarm CLI runs land here too.'
               : 'Try a different source filter.'
+          }
+          action={
+            entries.length === 0 ? (
+              <div className="flex flex-wrap justify-center gap-2">
+                <Button
+                  variant="primary"
+                  onClick={() => router.push('/gameplay/quick')}
+                  data-testid="empty-state-quick-game"
+                >
+                  Start Quick Game
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={() => router.push('/gameplay/encounters')}
+                  data-testid="empty-state-encounters"
+                >
+                  Browse Encounters
+                </Button>
+              </div>
+            ) : undefined
           }
         />
       ) : (

--- a/src/pages/api/replay-library/quick.ts
+++ b/src/pages/api/replay-library/quick.ts
@@ -1,0 +1,239 @@
+/**
+ * Replay Library — quick-game persist endpoint.
+ *
+ * `POST /api/replay-library/quick` — accepts a completed quick-game's
+ * event log + minimal metadata, validates inputs, **dedupes against the
+ * current manifest**, then delegates the actual write to the unit-tested
+ * `persistQuickGame()` pipeline.
+ *
+ * This route is the missing wire that closes the deferred follow-on
+ * (`add-replay-library` task 5.11): the browser cannot write to the
+ * local filesystem, so the React `<QuickGameResults>` POSTs here on the
+ * `endedAt` transition. The Council-approved plan calls this out
+ * explicitly — see the council synthesis "Replay Loop Closure" run.
+ *
+ * Idempotency (Momus blocking gap from Phase 2):
+ *   - Hard refresh of an already-persisted game would re-fire the
+ *     React effect (the `useRef` guard resets on remount).
+ *   - `appendManifestEntry` does a blind append with no dedup, so we
+ *     short-circuit on duplicates HERE — read the current manifest and
+ *     return `200 { persisted: false, alreadyPersisted: true }` when the
+ *     `gameId` already exists. Never invoke `persistQuickGame()` twice
+ *     for the same game.
+ *
+ * Validation pattern mirrors the sibling `[source]/[gameId].ts` route:
+ *   - inline runtime checks (no Zod — established convention in this
+ *     directory; future consolidation is a separate sweep)
+ *   - shared `ErrorResponse = { error, code? }` shape
+ *   - `gameId` regex `^[A-Za-z0-9_-]+$` — same pattern, copied not
+ *     imported (sibling route uses module-private const)
+ *
+ * Server-side only — `persistQuickGame` is Node-only by design. The
+ * shouldPersistToDisk three-gate guard inside it falls through cleanly
+ * when called from this handler under `next dev` or production.
+ *
+ * @spec openspec/changes/archive/2026-05-07-add-replay-library/specs/replay-library/spec.md
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import type { IGameEvent } from '@/types/gameplay';
+
+import {
+  buildQuickManifestEntry,
+  persistQuickGame,
+  type IPersistQuickGameInput,
+  type IPersistQuickGameResult,
+} from '@/components/quickgame/persistQuickGame';
+import { readReplayIndex } from '@/replay-library/index-reader';
+import { logger } from '@/utils/logger';
+
+// =============================================================================
+// Response Types
+// =============================================================================
+
+type SuccessResponse = {
+  persisted: boolean;
+  alreadyPersisted: boolean;
+  manifestEntry: IPersistQuickGameResult['manifestEntry'];
+  path: string | null;
+};
+
+type ErrorResponse = {
+  error: string;
+  code?: string;
+};
+
+// =============================================================================
+// Validation helpers
+// =============================================================================
+
+/**
+ * Same regex as the sibling `[source]/[gameId].ts` route. Duplicated
+ * intentionally — the sibling const is module-private and cross-route
+ * imports for a 1-line regex would couple two files harder than copying.
+ * If we ever need a third reuse, lift to `@/replay-library/validation`.
+ */
+const GAME_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+const VALID_WINNERS: ReadonlySet<string> = new Set([
+  'player',
+  'opponent',
+  'draw',
+]);
+
+/**
+ * Validates the POST body. Returns `null` on valid input + the typed
+ * `IPersistQuickGameInput`, or an `ErrorResponse` describing the first
+ * rejection. Callers should `res.status(400).json(...)` the error.
+ */
+function parseBody(
+  body: unknown,
+):
+  | { ok: true; input: Omit<IPersistQuickGameInput, 'cwd'> }
+  | { ok: false; error: ErrorResponse } {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    return {
+      ok: false,
+      error: { error: 'request body must be an object', code: 'BAD_BODY' },
+    };
+  }
+  const record = body as Record<string, unknown>;
+
+  const { gameId, events, winner, aiVariant } = record;
+
+  if (typeof gameId !== 'string' || !GAME_ID_PATTERN.test(gameId)) {
+    return {
+      ok: false,
+      error: { error: 'invalid gameId', code: 'BAD_GAME_ID' },
+    };
+  }
+
+  if (!Array.isArray(events)) {
+    return {
+      ok: false,
+      error: { error: 'events must be an array', code: 'BAD_EVENTS' },
+    };
+  }
+
+  // `winner` is `'player' | 'opponent' | 'draw' | null` per IQuickGameInstance.
+  // Allow the literal null (a timed-out / aborted game) and the three valid
+  // strings; reject everything else.
+  if (
+    winner !== null &&
+    (typeof winner !== 'string' || !VALID_WINNERS.has(winner))
+  ) {
+    return {
+      ok: false,
+      error: { error: 'invalid winner', code: 'BAD_WINNER' },
+    };
+  }
+
+  if (typeof aiVariant !== 'string') {
+    return {
+      ok: false,
+      error: { error: 'aiVariant must be a string', code: 'BAD_AI_VARIANT' },
+    };
+  }
+
+  return {
+    ok: true,
+    input: {
+      gameId,
+      events: events as readonly IGameEvent[],
+      winner: winner as IPersistQuickGameInput['winner'],
+      aiVariant,
+    },
+  };
+}
+
+// =============================================================================
+// Handler
+// =============================================================================
+
+/**
+ * POST /api/replay-library/quick — persist a completed quick-game.
+ *
+ * Returns:
+ *   - 200 `{ persisted: true,  alreadyPersisted: false, manifestEntry, path }` — first persist
+ *   - 200 `{ persisted: false, alreadyPersisted: true,  manifestEntry, path }` — already in manifest
+ *   - 400 on bad body / gameId / winner / events
+ *   - 405 on non-POST
+ *   - 500 if `persistQuickGame` throws
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<SuccessResponse | ErrorResponse>,
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    res.status(405).json({ error: `Method ${req.method} Not Allowed` });
+    return;
+  }
+
+  const parsed = parseBody(req.body);
+  if (!parsed.ok) {
+    res.status(400).json(parsed.error);
+    return;
+  }
+  const { input } = parsed;
+
+  // Dedup guard (Momus blocking gap). Read the current manifest and
+  // short-circuit if `gameId` is already present — `appendManifestEntry`
+  // does a blind append, so we MUST stop the duplicate write here.
+  // Build the same manifest entry the persist call would have produced
+  // so the client gets a consistent shape on both first-persist and
+  // already-persisted paths (the React component flips the same UI bit
+  // either way).
+  try {
+    const existing = await readReplayIndex();
+    if (existing.some((entry) => entry.id === input.gameId)) {
+      const manifestEntry = buildQuickManifestEntry({
+        gameId: input.gameId,
+        events: input.events,
+        winner: input.winner,
+        aiVariant: input.aiVariant,
+      });
+      logger.debug('[replay-library] quick-game already persisted; skipping', {
+        gameId: input.gameId,
+      });
+      res.status(200).json({
+        persisted: false,
+        alreadyPersisted: true,
+        manifestEntry,
+        path: `quick/${input.gameId}.jsonl`,
+      });
+      return;
+    }
+  } catch (err) {
+    // A malformed `replay-index.json` would surface as a parse error here.
+    // Log and continue — `persistQuickGame` will still write the file even
+    // if the manifest read failed; the manifest will get repaired by the
+    // backfill scan on next read. Don't 500 on a soft index issue.
+    logger.warn('[replay-library] failed to read manifest for dedup', {
+      gameId: input.gameId,
+      err,
+    });
+  }
+
+  let result: IPersistQuickGameResult;
+  try {
+    result = await persistQuickGame(input);
+  } catch (err) {
+    logger.error('[replay-library] quick persist failed', {
+      gameId: input.gameId,
+      err,
+    });
+    res
+      .status(500)
+      .json({ error: 'failed to persist quick game', code: 'PERSIST_FAILED' });
+    return;
+  }
+
+  res.status(200).json({
+    persisted: result.persisted,
+    alreadyPersisted: false,
+    manifestEntry: result.manifestEntry,
+    path: result.path,
+  });
+}


### PR DESCRIPTION
## Summary

Closes the deferred 5.11 follow-on (`add-replay-library`) by closing the quick-game replay loop end-to-end. The browser cannot write to the local filesystem, so this PR adds the missing wire: `<QuickGameResults>` POSTs the completed event log to a new server-side route, which dedupes against the manifest and delegates the actual write to the existing unit-tested `persistQuickGame()` pipeline. Result: finish a quick game → it shows up in the Replay Library automatically.

Council-approved Lean++ thin variant. Phase 4.5 Haiku verifier: VERIFIED.

## What ships

- **NEW `src/pages/api/replay-library/quick.ts`** — POST handler. Inline runtime validation (no Zod — mirrors sibling `[source]/[gameId].ts`). Idempotency: reads the manifest first and short-circuits on duplicate `gameId` so a hard refresh of an already-persisted game returns 200 `{alreadyPersisted: true}` instead of blind-appending a duplicate row (Momus blocking-gap fix — `appendManifestEntry` does NOT dedupe internally).
- **`QuickGameResults.tsx`** — replaces the deferred-followon comment with a `useEffect`+`useRef` guard that POSTs to the new route once on the `endedAt` transition. Footer copy is status-aware (idle / saving / saved / failed) with a clickable link to the Replay Library on success.
- **`ReplayLibraryPage.tsx`** — sharpens the empty-state message and adds two CTA buttons ("Start Quick Game" → `/gameplay/quick`, "Browse Encounters" → `/gameplay/encounters`). Only renders when the library is empty.

## Tests

- **`quick.test.ts` (NEW, 15 tests)** — happy-path forwards persist result with the right call shape, dedup short-circuit *never* re-invokes `persistQuickGame()`, malformed `replay-index.json` falls through (does not 500 on a soft index issue), 500 PERSIST_FAILED on persist throw, 405 method gate, 400 BAD_BODY / BAD_GAME_ID (5 forms) / BAD_EVENTS / BAD_WINNER / BAD_AI_VARIANT, accepts `winner: null`.
- **`QuickGameResults.test.tsx` (extended, 4 new tests)** — POSTs once with the correct body shape, never fires when `game` is null, saved status copy renders on success, failed status renders on non-OK.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (45 pre-existing warnings, none in new files)
- [x] `npm run format:check` — clean (only pre-existing `.omx/` runtime state)
- [x] `npx jest src/__tests__/api/replay-library src/components/quickgame src/components/replay-library` — 95 tests passing across 8 suites
- [ ] CI — pending
- [ ] Manual smoke: complete a quick game, observe footer flips to "Saved to Replay Library", click link, confirm row appears

## Out of scope (named follow-ons)

- Encounter-game persistence — separate OpenSpec change `link-encounters-to-replays` (Council Decision 4)
- Stale-draft encounter cleanup — 27 abandoned drafts at `/gameplay/encounters`, awaiting user nod