### PR TITLE
feat(encounters): cleanup-broken-encounters script + classification (PR 1/3)

### DIFF
--- a/scripts/__tests__/cleanup-broken-encounters.test.ts
+++ b/scripts/__tests__/cleanup-broken-encounters.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Tests for scripts/cleanup-broken-encounters.ts
+ *
+ * Covers:
+ *   - classifyEncounter pure-function branches (~6 cases)
+ *   - runCleanup end-to-end with fixture DB (5 encounters: 2 abandoned + 2 orphaned + 1 still-valid)
+ *   - Idempotent re-run on cleaned database
+ *   - --manifest-only flag skips deletes
+ *   - Manifest schema completeness (all required fields per spec)
+ *   - Status-gated deletion (non-Draft empty rows classify as still-valid)
+ *
+ * Spec: openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ *       (Requirement: One-Time Cleanup Script for Existing Broken Drafts)
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { EncounterRepository } from '@/services/encounter/EncounterRepository';
+import { ForceRepository } from '@/services/forces/ForceRepository';
+import {
+  getSQLiteService,
+  resetSQLiteService,
+} from '@/services/persistence/SQLiteService';
+import {
+  EncounterStatus,
+  PilotSkillTemplate,
+  ScenarioTemplateType,
+  TerrainPreset,
+  VictoryConditionType,
+  type IEncounter,
+  type IForceReference,
+  type IMapConfiguration,
+  type IOpForConfig,
+} from '@/types/encounter';
+import {
+  ForcePosition,
+  ForceType,
+  type ICreateForceRequest,
+} from '@/types/force';
+
+import {
+  classifyEncounter,
+  runCleanup,
+  type ClassificationResult,
+  type ManifestEntry,
+} from '../cleanup-broken-encounters';
+
+// =============================================================================
+// classifyEncounter — pure-function branch tests
+// =============================================================================
+
+describe('classifyEncounter', () => {
+  const baseEncounter: IEncounter = {
+    id: 'encounter-test',
+    name: 'Test',
+    status: EncounterStatus.Draft,
+    template: undefined,
+    playerForce: undefined,
+    opponentForce: undefined,
+    opForConfig: undefined,
+    mapConfig: {
+      radius: 6,
+      terrain: TerrainPreset.Clear,
+      playerDeploymentZone: 'south',
+      opponentDeploymentZone: 'north',
+    },
+    victoryConditions: [],
+    optionalRules: [],
+    createdAt: '2026-04-01T00:00:00.000Z',
+    updatedAt: '2026-04-01T00:00:00.000Z',
+  };
+
+  const playerForceRef: IForceReference = {
+    forceId: 'force-1',
+    forceName: 'Alpha Lance',
+    totalBV: 4500,
+    unitCount: 4,
+  };
+
+  const opForConfig: IOpForConfig = {
+    targetBV: 4500,
+    pilotSkillTemplate: PilotSkillTemplate.Veteran,
+  };
+
+  const resolverThatAlwaysReturnsNull = () => null;
+  const resolverThatAlwaysReturnsForce = () => ({
+    id: 'mock',
+    name: 'Mock Force',
+  });
+
+  it('classifies as abandoned-empty when Draft + empty configuration + no stored ids', () => {
+    const result = classifyEncounter(
+      baseEncounter,
+      { playerForceId: null, opponentForceId: null },
+      resolverThatAlwaysReturnsNull,
+    );
+    expect(result.classification).toBe('abandoned-empty');
+    expect(result.reason).toContain('never finished setup');
+  });
+
+  it('classifies abandoned-config Launched encounter as still-valid (status-gated deletion)', () => {
+    const launched: IEncounter = {
+      ...baseEncounter,
+      status: EncounterStatus.Launched,
+    };
+    const result = classifyEncounter(
+      launched,
+      { playerForceId: null, opponentForceId: null },
+      resolverThatAlwaysReturnsNull,
+    );
+    expect(result.classification).toBe('still-valid');
+    expect(result.reason).toBe(
+      'non-draft encounter retained even though configuration is empty',
+    );
+  });
+
+  it('classifies as orphaned-force-reference when player ref stored but unresolved', () => {
+    const result = classifyEncounter(
+      baseEncounter,
+      { playerForceId: 'F-deleted', opponentForceId: null },
+      resolverThatAlwaysReturnsNull,
+    );
+    expect(result.classification).toBe('orphaned-force-reference');
+    expect(result.reason).toContain('player force F-deleted deleted');
+  });
+
+  it('classifies as orphaned when opponent ref stored but unresolved', () => {
+    const result = classifyEncounter(
+      baseEncounter,
+      { playerForceId: null, opponentForceId: 'F-opp-deleted' },
+      resolverThatAlwaysReturnsNull,
+    );
+    expect(result.classification).toBe('orphaned-force-reference');
+    expect(result.reason).toContain('opponent force F-opp-deleted deleted');
+  });
+
+  it('classifies as orphaned when BOTH refs stored and BOTH unresolved', () => {
+    const result = classifyEncounter(
+      baseEncounter,
+      { playerForceId: 'F1', opponentForceId: 'F2' },
+      resolverThatAlwaysReturnsNull,
+    );
+    expect(result.classification).toBe('orphaned-force-reference');
+    expect(result.reason).toContain('player force F1 deleted');
+    expect(result.reason).toContain('opponent force F2 deleted');
+  });
+
+  it('classifies as still-valid when Ready encounter has resolved forces', () => {
+    const valid: IEncounter = {
+      ...baseEncounter,
+      status: EncounterStatus.Ready,
+      playerForce: playerForceRef,
+      opForConfig,
+      victoryConditions: [{ type: VictoryConditionType.Annihilation } as never],
+    };
+    const result = classifyEncounter(
+      valid,
+      { playerForceId: 'force-1', opponentForceId: null },
+      resolverThatAlwaysReturnsForce,
+    );
+    expect(result.classification).toBe('still-valid');
+  });
+
+  it('classifies as still-valid when Launched encounter has resolved forces', () => {
+    const launched: IEncounter = {
+      ...baseEncounter,
+      status: EncounterStatus.Launched,
+      playerForce: playerForceRef,
+      opForConfig,
+    };
+    const result = classifyEncounter(
+      launched,
+      { playerForceId: 'force-1', opponentForceId: null },
+      resolverThatAlwaysReturnsForce,
+    );
+    expect(result.classification).toBe('still-valid');
+  });
+});
+
+// =============================================================================
+// runCleanup — end-to-end fixture tests
+// =============================================================================
+
+describe('runCleanup', () => {
+  let testDbPath: string;
+  let testCwd: string;
+  let encounterRepo: EncounterRepository;
+  let forceRepo: ForceRepository;
+
+  function createForce(name: string): string {
+    const req: ICreateForceRequest = {
+      name,
+      forceType: ForceType.Lance,
+      affiliation: 'Test',
+    };
+    const result = forceRepo.createForce(req);
+    if (!result.success || !result.id) {
+      throw new Error(`createForce failed: ${result.error}`);
+    }
+    return result.id;
+  }
+
+  function insertEncounterRow(input: {
+    id: string;
+    name: string;
+    status: EncounterStatus;
+    playerForceJson?: object | null;
+    opponentForceJson?: object | null;
+    opForConfigJson?: object | null;
+    victoryConditions?: unknown[];
+  }): void {
+    const db = getSQLiteService().getDatabase();
+    const now = new Date().toISOString();
+    const map: IMapConfiguration = {
+      radius: 6,
+      terrain: TerrainPreset.Clear,
+      playerDeploymentZone: 'south',
+      opponentDeploymentZone: 'north',
+    };
+    db.prepare(
+      `INSERT INTO encounters (
+        id, name, description, status, template,
+        player_force_json, opponent_force_json, opfor_config_json,
+        map_config_json, victory_conditions_json, optional_rules_json,
+        game_session_id, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      input.id,
+      input.name,
+      null,
+      input.status,
+      null,
+      input.playerForceJson === undefined
+        ? null
+        : input.playerForceJson === null
+          ? null
+          : JSON.stringify(input.playerForceJson),
+      input.opponentForceJson === undefined
+        ? null
+        : input.opponentForceJson === null
+          ? null
+          : JSON.stringify(input.opponentForceJson),
+      input.opForConfigJson === undefined
+        ? null
+        : input.opForConfigJson === null
+          ? null
+          : JSON.stringify(input.opForConfigJson),
+      JSON.stringify(map),
+      JSON.stringify(input.victoryConditions ?? []),
+      JSON.stringify([]),
+      null,
+      now,
+      now,
+    );
+  }
+
+  beforeEach(() => {
+    // Per-test temp DB and per-test temp cwd for manifest output
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), `cleanup-${stamp}-`));
+    testDbPath = path.join(tmpRoot, 'test.db');
+    testCwd = tmpRoot;
+
+    resetSQLiteService();
+    const sqlite = getSQLiteService({ path: testDbPath });
+    sqlite.initialize();
+
+    encounterRepo = new EncounterRepository();
+    encounterRepo.initialize();
+    forceRepo = new ForceRepository();
+    forceRepo.initialize();
+
+    // Stub the repository singleton getters to point at our test instances.
+    // The script uses getEncounterRepository / getForceRepository — but since
+    // the singletons are reset, the next get() call will create fresh ones
+    // backed by the test SQLite path. So we don't need to mock — we just
+    // invoke the singletons after setup so the test database is the live one.
+  });
+
+  afterEach(() => {
+    resetSQLiteService();
+    // Best-effort cleanup; OS will mop up tmp dir eventually.
+    try {
+      if (fs.existsSync(testDbPath)) fs.unlinkSync(testDbPath);
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('writes manifest before any DELETE and deletes only abandoned-empty rows (5-encounter fixture)', async () => {
+    // 1+2: two abandoned-empty Drafts
+    insertEncounterRow({
+      id: 'enc-abandoned-1',
+      name: 'Abandoned 1',
+      status: EncounterStatus.Draft,
+    });
+    insertEncounterRow({
+      id: 'enc-abandoned-2',
+      name: 'Abandoned 2',
+      status: EncounterStatus.Draft,
+    });
+
+    // 3: orphaned player ref (force was never created — the id points nowhere)
+    insertEncounterRow({
+      id: 'enc-orphaned-player',
+      name: 'Orphaned Player',
+      status: EncounterStatus.Draft,
+      playerForceJson: {
+        forceId: 'force-deleted-player',
+        forceName: '',
+        totalBV: 0,
+        unitCount: 0,
+      },
+    });
+
+    // 4: orphaned opponent ref (different deleted forceId)
+    insertEncounterRow({
+      id: 'enc-orphaned-opp',
+      name: 'Orphaned Opp',
+      status: EncounterStatus.Ready,
+      opponentForceJson: {
+        forceId: 'force-deleted-opp',
+        forceName: '',
+        totalBV: 0,
+        unitCount: 0,
+      },
+    });
+
+    // 5: still-valid (Ready, has resolved forces, has opForConfig)
+    const validForceId = createForce('Valid Force');
+    insertEncounterRow({
+      id: 'enc-valid',
+      name: 'Valid Encounter',
+      status: EncounterStatus.Ready,
+      playerForceJson: {
+        forceId: validForceId,
+        forceName: 'Valid Force',
+        totalBV: 4500,
+        unitCount: 4,
+      },
+      opForConfigJson: {
+        targetBV: 4500,
+        pilotSkillTemplate: PilotSkillTemplate.Veteran,
+      },
+      victoryConditions: [{ type: VictoryConditionType.Annihilation }],
+    });
+
+    const result = await runCleanup({ cwd: testCwd });
+
+    // Manifest exists
+    expect(fs.existsSync(result.manifestPath)).toBe(true);
+    const manifestRaw = fs.readFileSync(result.manifestPath, 'utf-8');
+    const manifest = JSON.parse(manifestRaw) as {
+      version: string;
+      generatedAt: string;
+      totalEncounters: number;
+      entries: ManifestEntry[];
+    };
+
+    expect(manifest.entries).toHaveLength(5);
+    expect(manifest.totalEncounters).toBe(5);
+
+    // Verify per-row classifications
+    const byId = new Map(manifest.entries.map((e) => [e.id, e]));
+    expect(byId.get('enc-abandoned-1')?.classification).toBe('abandoned-empty');
+    expect(byId.get('enc-abandoned-2')?.classification).toBe('abandoned-empty');
+    expect(byId.get('enc-orphaned-player')?.classification).toBe(
+      'orphaned-force-reference',
+    );
+    expect(byId.get('enc-orphaned-opp')?.classification).toBe(
+      'orphaned-force-reference',
+    );
+    expect(byId.get('enc-valid')?.classification).toBe('still-valid');
+
+    // Counts
+    expect(result.deletedIds).toHaveLength(2);
+    expect(result.deletedIds).toEqual(
+      expect.arrayContaining(['enc-abandoned-1', 'enc-abandoned-2']),
+    );
+    expect(result.repairedIds).toHaveLength(0); // PR 1: orphans not yet repaired
+    expect(result.retainedIds).toHaveLength(3);
+
+    // DB state confirms the deletions actually happened
+    const remaining = encounterRepo.getAllEncounters();
+    expect(remaining).toHaveLength(3);
+    const remainingIds = remaining.map((e) => e.id);
+    expect(remainingIds).not.toContain('enc-abandoned-1');
+    expect(remainingIds).not.toContain('enc-abandoned-2');
+  });
+
+  it('is idempotent — re-running on cleaned DB writes manifest with empty deletedIds', async () => {
+    insertEncounterRow({
+      id: 'enc-abandoned-only',
+      name: 'Abandoned',
+      status: EncounterStatus.Draft,
+    });
+    const validForceId = createForce('Solo Valid');
+    insertEncounterRow({
+      id: 'enc-valid-only',
+      name: 'Valid',
+      status: EncounterStatus.Ready,
+      playerForceJson: {
+        forceId: validForceId,
+        forceName: 'Solo Valid',
+        totalBV: 4500,
+        unitCount: 4,
+      },
+      opForConfigJson: {
+        targetBV: 4500,
+        pilotSkillTemplate: PilotSkillTemplate.Veteran,
+      },
+      victoryConditions: [{ type: VictoryConditionType.Annihilation }],
+    });
+
+    // First run deletes the abandoned row
+    const firstRun = await runCleanup({ cwd: testCwd });
+    expect(firstRun.deletedIds).toEqual(['enc-abandoned-only']);
+
+    // Second run must return empty deletedIds AND not throw
+    const secondRun = await runCleanup({ cwd: testCwd });
+    expect(secondRun.deletedIds).toEqual([]);
+    expect(fs.existsSync(secondRun.manifestPath)).toBe(true);
+
+    // Second manifest still classifies remaining row
+    const secondManifest = JSON.parse(
+      fs.readFileSync(secondRun.manifestPath, 'utf-8'),
+    ) as { entries: ManifestEntry[] };
+    expect(secondManifest.entries).toHaveLength(1);
+    expect(secondManifest.entries[0]?.classification).toBe('still-valid');
+  });
+
+  it('--manifest-only skips deletes — DB unchanged', async () => {
+    insertEncounterRow({
+      id: 'enc-abandoned-mo',
+      name: 'Abandoned MO',
+      status: EncounterStatus.Draft,
+    });
+    insertEncounterRow({
+      id: 'enc-abandoned-mo-2',
+      name: 'Abandoned MO 2',
+      status: EncounterStatus.Draft,
+    });
+
+    const result = await runCleanup({ cwd: testCwd, manifestOnly: true });
+
+    expect(result.deletedIds).toEqual([]);
+    expect(fs.existsSync(result.manifestPath)).toBe(true);
+
+    // DB still has both rows
+    expect(encounterRepo.getAllEncounters()).toHaveLength(2);
+  });
+
+  it('manifest entries include every required field', async () => {
+    insertEncounterRow({
+      id: 'enc-schema-check',
+      name: 'Schema Check',
+      status: EncounterStatus.Draft,
+    });
+
+    const result = await runCleanup({ cwd: testCwd });
+    const manifest = JSON.parse(
+      fs.readFileSync(result.manifestPath, 'utf-8'),
+    ) as { entries: ManifestEntry[] };
+
+    const entry = manifest.entries[0];
+    expect(entry).toBeDefined();
+    expect(entry).toMatchObject({
+      id: 'enc-schema-check',
+      name: 'Schema Check',
+      status: EncounterStatus.Draft,
+      classification: 'abandoned-empty',
+    });
+    // Every spec-required field is present (presence-check; null is allowed)
+    expect(entry).toHaveProperty('id');
+    expect(entry).toHaveProperty('name');
+    expect(entry).toHaveProperty('description');
+    expect(entry).toHaveProperty('status');
+    expect(entry).toHaveProperty('playerForce');
+    expect(entry).toHaveProperty('opponentForce');
+    expect(entry).toHaveProperty('opForConfig');
+    expect(entry).toHaveProperty('victoryConditions');
+    expect(entry).toHaveProperty('mapConfig');
+    expect(entry).toHaveProperty('createdAt');
+    expect(entry).toHaveProperty('updatedAt');
+    expect(entry).toHaveProperty('classification');
+    expect(entry).toHaveProperty('classificationReason');
+  });
+
+  it('Launched encounter with empty config is retained (status-gated deletion)', async () => {
+    insertEncounterRow({
+      id: 'enc-launched-empty',
+      name: 'Launched Empty',
+      status: EncounterStatus.Launched,
+    });
+
+    const result = await runCleanup({ cwd: testCwd });
+
+    expect(result.deletedIds).toEqual([]);
+    expect(result.retainedIds).toEqual(['enc-launched-empty']);
+
+    const manifest = JSON.parse(
+      fs.readFileSync(result.manifestPath, 'utf-8'),
+    ) as { entries: ManifestEntry[] };
+    expect(manifest.entries[0]?.classification).toBe('still-valid');
+    expect(manifest.entries[0]?.classificationReason).toBe(
+      'non-draft encounter retained even though configuration is empty',
+    );
+  });
+});

--- a/scripts/cleanup-broken-encounters.ts
+++ b/scripts/cleanup-broken-encounters.ts
@@ -1,0 +1,393 @@
+#!/usr/bin/env npx tsx
+/**
+ * Cleanup Broken Encounters
+ *
+ * One-time CLI tool that classifies every encounter in the database into
+ * one of three buckets:
+ *   - 'abandoned-empty'           — Draft + no forces + no opForConfig.
+ *                                   Deleted (only when status === Draft).
+ *   - 'orphaned-force-reference'  — at least one stored forceId no longer
+ *                                   resolves via getForceById. Repaired
+ *                                   in-place by NULLing the slot, but ONLY
+ *                                   in PR 2 once `clearForceReference` lands.
+ *                                   In PR 1, treated the same as 'still-valid'
+ *                                   (no repair attempted).
+ *   - 'still-valid'               — anything else. Untouched.
+ *
+ * Writes the full classification manifest to
+ *   simulation-reports/cleanup-encounters-<ISO>.json
+ * BEFORE any DELETE. Idempotent: re-running on a cleaned DB writes a manifest
+ * with `deletedIds: []`.
+ *
+ * Flags:
+ *   --manifest-only        Skip deletes + repairs; only write manifest.
+ *   --cwd <path>           Override working dir for manifest output (test).
+ *   --help                 Print usage and exit 0.
+ *
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ *       (Requirement: One-Time Cleanup Script for Existing Broken Drafts)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {
+  getEncounterRepository,
+  resetEncounterRepository,
+  type IEncounterWithRawForceIds,
+} from '../src/services/encounter/EncounterRepository';
+import {
+  getForceRepository,
+  resetForceRepository,
+} from '../src/services/forces/ForceRepository';
+import {
+  getSQLiteService,
+  resetSQLiteService,
+} from '../src/services/persistence/SQLiteService';
+import { EncounterStatus, type IEncounter } from '../src/types/encounter';
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+export type CleanupClassification =
+  | 'abandoned-empty'
+  | 'orphaned-force-reference'
+  | 'still-valid';
+
+export interface ClassificationResult {
+  readonly classification: CleanupClassification;
+  readonly reason: string;
+}
+
+export interface ManifestEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly status: string;
+  readonly playerForce: IEncounter['playerForce'] | null;
+  readonly opponentForce: IEncounter['opponentForce'] | null;
+  readonly opForConfig: IEncounter['opForConfig'] | null;
+  readonly victoryConditions: IEncounter['victoryConditions'];
+  readonly mapConfig: IEncounter['mapConfig'];
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly classification: CleanupClassification;
+  readonly classificationReason: string;
+}
+
+export interface CleanupResult {
+  readonly manifestPath: string;
+  readonly deletedIds: readonly string[];
+  readonly repairedIds: readonly string[];
+  readonly retainedIds: readonly string[];
+}
+
+export interface CleanupOptions {
+  readonly cwd?: string;
+  readonly manifestOnly?: boolean;
+}
+
+// =============================================================================
+// Pure classification helper (testable in isolation)
+// =============================================================================
+
+/**
+ * Classify a single encounter.
+ *
+ * Pure function — does not mutate inputs. Caller supplies the hydrated
+ * encounter, the raw stored force ids (so we can detect "ref stored, force
+ * gone"), and a `getForceById` resolver.
+ *
+ * Status-gated deletion: an encounter that *would* classify as
+ * abandoned-empty BUT has status !== Draft (i.e. Launched / Completed)
+ * SHALL classify as 'still-valid' instead, with a distinguishing reason
+ * string. Per the spec: "non-draft encounter retained even though
+ * configuration is empty".
+ */
+export function classifyEncounter(
+  encounter: IEncounter,
+  rawForceIds: { playerForceId: string | null; opponentForceId: string | null },
+  getForceById: (id: string) => unknown | null,
+): ClassificationResult {
+  const isDraft = encounter.status === EncounterStatus.Draft;
+  const hasNoPlayerForce = !encounter.playerForce;
+  const hasNoOpponentForce = !encounter.opponentForce;
+  const hasNoOpForConfig = !encounter.opForConfig;
+  const hasNoStoredPlayerId = rawForceIds.playerForceId === null;
+  const hasNoStoredOpponentId = rawForceIds.opponentForceId === null;
+
+  // --- abandoned-empty branch ---
+  // Empty configuration AND no stored ids (a stored id with missing force
+  // is the orphaned branch, not abandoned).
+  const configurationIsEmpty =
+    hasNoPlayerForce &&
+    hasNoOpponentForce &&
+    hasNoOpForConfig &&
+    hasNoStoredPlayerId &&
+    hasNoStoredOpponentId;
+
+  if (configurationIsEmpty) {
+    if (!isDraft) {
+      return {
+        classification: 'still-valid',
+        reason:
+          'non-draft encounter retained even though configuration is empty',
+      };
+    }
+    return {
+      classification: 'abandoned-empty',
+      reason: 'no forces and no opfor config — never finished setup',
+    };
+  }
+
+  // --- orphaned-force-reference branch ---
+  const playerOrphan =
+    rawForceIds.playerForceId !== null &&
+    getForceById(rawForceIds.playerForceId) === null;
+  const opponentOrphan =
+    rawForceIds.opponentForceId !== null &&
+    getForceById(rawForceIds.opponentForceId) === null;
+
+  if (playerOrphan || opponentOrphan) {
+    const reasons: string[] = [];
+    if (playerOrphan) {
+      reasons.push(`player force ${rawForceIds.playerForceId} deleted`);
+    }
+    if (opponentOrphan) {
+      reasons.push(`opponent force ${rawForceIds.opponentForceId} deleted`);
+    }
+    return {
+      classification: 'orphaned-force-reference',
+      reason: reasons.join('; '),
+    };
+  }
+
+  // --- still-valid branch ---
+  return {
+    classification: 'still-valid',
+    reason: 'configuration intact',
+  };
+}
+
+// =============================================================================
+// Manifest construction
+// =============================================================================
+
+function buildManifestEntry(
+  encounter: IEncounter,
+  result: ClassificationResult,
+): ManifestEntry {
+  return {
+    id: encounter.id,
+    name: encounter.name,
+    description: encounter.description ?? null,
+    status: encounter.status,
+    playerForce: encounter.playerForce ?? null,
+    opponentForce: encounter.opponentForce ?? null,
+    opForConfig: encounter.opForConfig ?? null,
+    victoryConditions: encounter.victoryConditions,
+    mapConfig: encounter.mapConfig,
+    createdAt: encounter.createdAt,
+    updatedAt: encounter.updatedAt,
+    classification: result.classification,
+    classificationReason: result.reason,
+  };
+}
+
+function manifestFilename(now: Date = new Date()): string {
+  // Replace ':' with '-' for Windows filename safety.
+  return `cleanup-encounters-${now.toISOString().replace(/:/g, '-')}.json`;
+}
+
+// =============================================================================
+// Main driver
+// =============================================================================
+
+/**
+ * Run the cleanup classification + (optionally) deletion pass.
+ *
+ * 1. Read every encounter (with raw force ids).
+ * 2. Classify each.
+ * 3. Write the full manifest to simulation-reports/cleanup-encounters-<ISO>.json.
+ * 4. If !manifestOnly: delete every abandoned-empty row.
+ *    Orphaned rows are NOT repaired in PR 1 (clearForceReference lands in PR 2).
+ *
+ * Idempotent: re-running on a cleaned DB writes a fresh manifest with empty
+ * deletedIds.
+ */
+export async function runCleanup(
+  options: CleanupOptions = {},
+): Promise<CleanupResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const manifestOnly = options.manifestOnly ?? false;
+
+  const repo = getEncounterRepository();
+  const forceRepo = getForceRepository();
+  const rows = repo.getAllEncountersWithRawIds();
+
+  // Classify every row.
+  const entries: ManifestEntry[] = rows.map(
+    (entry: IEncounterWithRawForceIds) => {
+      const result = classifyEncounter(
+        entry.encounter,
+        entry.rawForceIds,
+        (id: string) => forceRepo.getForceById(id),
+      );
+      return buildManifestEntry(entry.encounter, result);
+    },
+  );
+
+  // Write manifest BEFORE any DELETE.
+  const reportsDir = path.join(cwd, 'simulation-reports');
+  fs.mkdirSync(reportsDir, { recursive: true });
+  const manifestPath = path.join(reportsDir, manifestFilename());
+  fs.writeFileSync(
+    manifestPath,
+    JSON.stringify(
+      {
+        version: '1.0',
+        generatedAt: new Date().toISOString(),
+        totalEncounters: entries.length,
+        entries,
+      },
+      null,
+      2,
+    ),
+    'utf-8',
+  );
+
+  if (manifestOnly) {
+    return {
+      manifestPath,
+      deletedIds: [],
+      repairedIds: [],
+      retainedIds: entries.map((e) => e.id),
+    };
+  }
+
+  // Delete abandoned-empty rows (status-gated to Draft via classification).
+  const deletedIds: string[] = [];
+  for (const entry of entries) {
+    if (entry.classification === 'abandoned-empty') {
+      const result = repo.deleteEncounter(entry.id);
+      if (result.success) {
+        deletedIds.push(entry.id);
+      }
+    }
+  }
+
+  // PR 1: orphaned rows are NOT repaired here (no clearForceReference yet).
+  // TODO(PR 2): wire orphaned-branch repair via repo.clearForceReference.
+  const repairedIds: string[] = [];
+
+  const retainedIds = entries
+    .filter((e) => !deletedIds.includes(e.id))
+    .map((e) => e.id);
+
+  return {
+    manifestPath,
+    deletedIds,
+    repairedIds,
+    retainedIds,
+  };
+}
+
+// =============================================================================
+// CLI entry point
+// =============================================================================
+
+interface CliArgs {
+  manifestOnly: boolean;
+  cwd: string | undefined;
+  help: boolean;
+}
+
+function parseArgs(argv: readonly string[]): CliArgs {
+  const args: CliArgs = { manifestOnly: false, cwd: undefined, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+    } else if (arg === '--manifest-only') {
+      args.manifestOnly = true;
+    } else if (arg === '--cwd') {
+      const next = argv[i + 1];
+      if (!next || next.startsWith('--')) {
+        throw new Error('--cwd requires a path argument');
+      }
+      args.cwd = next;
+      i++;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+const USAGE = `cleanup-broken-encounters — classify and clean up broken encounter rows
+
+USAGE
+  npx tsx scripts/cleanup-broken-encounters.ts [options]
+
+OPTIONS
+  --manifest-only        Write classification manifest but skip deletes/repairs.
+  --cwd <path>           Override working directory for manifest output.
+  --help, -h             Show this message and exit.
+
+OUTPUT
+  Writes simulation-reports/cleanup-encounters-<ISO>.json containing the full
+  classification + classificationReason for every encounter row in the DB.
+  When --manifest-only is NOT set, additionally deletes every encounter row
+  classified as 'abandoned-empty' (status === Draft AND no configuration).
+
+CLASSIFICATION
+  abandoned-empty            Draft + no forces + no opForConfig — DELETE.
+  orphaned-force-reference   forceId stored but force was deleted — RETAIN
+                             (PR 2 will repair these in-place).
+  still-valid                everything else — RETAIN.
+`;
+
+async function cliMain(): Promise<void> {
+  let args: CliArgs;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'argument parse error';
+    process.stderr.write(`error: ${message}\n\n${USAGE}`);
+    process.exit(1);
+  }
+
+  if (args.help) {
+    process.stdout.write(USAGE);
+    process.exit(0);
+  }
+
+  // Initialize singletons. The script targets the user's actual SQLite DB
+  // unless tests inject a fresh one before calling runCleanup directly.
+  resetSQLiteService();
+  resetEncounterRepository();
+  resetForceRepository();
+  getSQLiteService().initialize();
+
+  const result = await runCleanup({
+    cwd: args.cwd,
+    manifestOnly: args.manifestOnly,
+  });
+
+  process.stdout.write(
+    `Cleanup complete.\n` +
+      `  manifest:  ${result.manifestPath}\n` +
+      `  deleted:   ${result.deletedIds.length}\n` +
+      `  repaired:  ${result.repairedIds.length}\n` +
+      `  retained:  ${result.retainedIds.length}\n`,
+  );
+}
+
+if (require.main === module) {
+  cliMain().catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`cleanup-broken-encounters failed: ${message}\n`);
+    process.exit(1);
+  });
+}

--- a/src/services/encounter/EncounterRepository.helpers.ts
+++ b/src/services/encounter/EncounterRepository.helpers.ts
@@ -58,3 +58,45 @@ export function rowToEncounter(row: EncounterRow): IEncounter {
     gameSessionId: row.game_session_id ?? undefined,
   };
 }
+
+/**
+ * Encounter paired with raw stored force ids.
+ *
+ * Defined inline (rather than imported from EncounterRepository.ts) to avoid
+ * a helpers→repository circular import while still keeping the row-shaped
+ * extractor co-located with `rowToEncounter`.
+ */
+export interface IEncounterWithRawForceIdsHelper {
+  readonly encounter: IEncounter;
+  readonly rawForceIds: {
+    readonly playerForceId: string | null;
+    readonly opponentForceId: string | null;
+  };
+}
+
+/**
+ * Pull the raw `forceId` strings out of the JSON columns BEFORE hydration.
+ * Returns null when the column is null OR the JSON does not contain a
+ * `forceId` key (defensive — a malformed row should not crash the read).
+ */
+export function extractRawForceIds(
+  row: EncounterRow,
+): IEncounterWithRawForceIdsHelper {
+  const encounter = rowToEncounter(row);
+  const playerForceId = readForceIdFromJson(row.player_force_json);
+  const opponentForceId = readForceIdFromJson(row.opponent_force_json);
+  return {
+    encounter,
+    rawForceIds: { playerForceId, opponentForceId },
+  };
+}
+
+function readForceIdFromJson(json: string | null): string | null {
+  if (!json) return null;
+  try {
+    const parsed = JSON.parse(json) as { forceId?: unknown };
+    return typeof parsed.forceId === 'string' ? parsed.forceId : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/services/encounter/EncounterRepository.ts
+++ b/src/services/encounter/EncounterRepository.ts
@@ -26,7 +26,10 @@ import {
   type SingletonFactory,
 } from '../core/createSingleton';
 import { getSQLiteService } from '../persistence/SQLiteService';
-import { rowToEncounter } from './EncounterRepository.helpers';
+import {
+  extractRawForceIds,
+  rowToEncounter,
+} from './EncounterRepository.helpers';
 
 // =============================================================================
 // Database Row Types
@@ -68,6 +71,23 @@ export interface IEncounterOperationResult {
   readonly errorCode?: EncounterErrorCode;
 }
 
+/**
+ * Encounter paired with the raw force-id strings stored in the row.
+ *
+ * The raw ids are needed by callers that distinguish between "no force ever
+ * stored" (rawForceId is null) and "force was stored but the referenced row
+ * is gone" (rawForceId is non-null but the hydrated `playerForce` resolves
+ * to undefined / null). The cleanup-broken-encounters script and the
+ * encounter list page broken-pill UI both consume this shape.
+ */
+export interface IEncounterWithRawForceIds {
+  readonly encounter: IEncounter;
+  readonly rawForceIds: {
+    readonly playerForceId: string | null;
+    readonly opponentForceId: string | null;
+  };
+}
+
 // =============================================================================
 // Repository Interface
 // =============================================================================
@@ -77,6 +97,7 @@ export interface IEncounterRepository {
   createEncounter(input: ICreateEncounterInput): IEncounterOperationResult;
   getEncounterById(id: string): IEncounter | null;
   getAllEncounters(): readonly IEncounter[];
+  getAllEncountersWithRawIds(): readonly IEncounterWithRawForceIds[];
   getEncountersByStatus(status: EncounterStatus): readonly IEncounter[];
   updateEncounter(
     id: string,
@@ -247,6 +268,30 @@ export class EncounterRepository implements IEncounterRepository {
       .all() as EncounterRow[];
 
     return rows.map((row) => rowToEncounter(row));
+  }
+
+  /**
+   * Get every encounter alongside its raw stored force-id strings.
+   *
+   * The hydrated `IEncounter.playerForce` only contains a forceId when the
+   * referenced force exists; if it was deleted the hydrated value is empty
+   * (today: zero-name ref; after hydration repair: null/undefined). To detect
+   * "the row stores a forceId but the force is gone" the caller needs the
+   * raw stored ids — that's what this method exposes.
+   *
+   * Used by:
+   *   - scripts/cleanup-broken-encounters.ts (classify orphaned-force-reference)
+   *   - the encounter list page (broken-pill rendering)
+   */
+  getAllEncountersWithRawIds(): readonly IEncounterWithRawForceIds[] {
+    this.initialize();
+
+    const db = getSQLiteService().getDatabase();
+    const rows = db
+      .prepare('SELECT * FROM encounters ORDER BY updated_at DESC')
+      .all() as EncounterRow[];
+
+    return rows.map((row) => extractRawForceIds(row));
   }
 
   getEncountersByStatus(status: EncounterStatus): readonly IEncounter[] {


### PR DESCRIPTION
## Summary

PR 1 of 3 in OpenSpec change `repair-broken-encounter-drafts` (closes the Draft-graveyard for /gameplay/encounters).

Adds a one-time CLI cleanup tool that classifies every encounter row into:
- **abandoned-empty** — Draft + no forces + no opForConfig → DELETE
- **orphaned-force-reference** — forceId stored but force was deleted → RETAIN (PR 2 wires the repair)
- **still-valid** — anything else → RETAIN

Manifest is written to `simulation-reports/cleanup-encounters-<ISO>.json` BEFORE any DELETE so the operator has a full audit trail.

Idempotent — re-running on a cleaned DB writes `deletedIds: []` and does not throw.

## Spec coverage

`openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md` — Requirement "One-Time Cleanup Script for Existing Broken Drafts":
- [x] Manifest written before any DELETE
- [x] Idempotent re-run on cleaned DB
- [x] `--manifest-only` flag skips deletes
- [x] Status-gated deletion (Launched empty-config row classifies as still-valid)
- [x] Manifest entries include all required fields
- [x] Classification rules match spec wording

## Files

- **NEW** `scripts/cleanup-broken-encounters.ts` — `classifyEncounter` + `runCleanup` + CLI driver
- **NEW** `scripts/__tests__/cleanup-broken-encounters.test.ts` — 12 tests (7 classification branches + 5 e2e/idempotency/schema)
- **MODIFIED** `src/services/encounter/EncounterRepository.ts` — adds `IEncounterWithRawForceIds` shape + `getAllEncountersWithRawIds()` method
- **MODIFIED** `src/services/encounter/EncounterRepository.helpers.ts` — adds `extractRawForceIds(row)` helper

## Verification

- `npx tsc --noEmit` clean
- `npx oxlint` 0 errors (46 warnings pre-existing)
- `npx oxfmt --check .` clean
- `npx jest scripts/__tests__/cleanup-broken-encounters.test.ts` 12/12 passing
- Pre-commit hook ran full Next.js build — clean

## Out of scope (PR 2 / PR 3)

- PR 2: `clearForceReference` cascade on `deleteForce` + hydration-boundary orphan replacement + `encounterBrokenRefs` helper.
- PR 3: encounter list broken-pill UI + detail-page repair banner + seed-samples empty state.
