### PR TITLE
feat(encounters): cascade on force-delete + hydration repair (PR 2/3 repair-broken-encounter-drafts)

### DIFF
--- a/scripts/__tests__/cleanup-broken-encounters.test.ts
+++ b/scripts/__tests__/cleanup-broken-encounters.test.ts
@@ -379,7 +379,11 @@ describe('runCleanup', () => {
     expect(result.deletedIds).toEqual(
       expect.arrayContaining(['enc-abandoned-1', 'enc-abandoned-2']),
     );
-    expect(result.repairedIds).toHaveLength(0); // PR 1: orphans not yet repaired
+    // PR 2: orphans ARE repaired now via clearForceReference cascade.
+    expect(result.repairedIds).toHaveLength(2);
+    expect(result.repairedIds).toEqual(
+      expect.arrayContaining(['enc-orphaned-player', 'enc-orphaned-opp']),
+    );
     expect(result.retainedIds).toHaveLength(3);
 
     // DB state confirms the deletions actually happened
@@ -388,6 +392,14 @@ describe('runCleanup', () => {
     const remainingIds = remaining.map((e) => e.id);
     expect(remainingIds).not.toContain('enc-abandoned-1');
     expect(remainingIds).not.toContain('enc-abandoned-2');
+
+    // Repaired rows had their dangling force refs NULL'd in place.
+    const repairedPlayer = encounterRepo.getEncounterById(
+      'enc-orphaned-player',
+    );
+    const repairedOpp = encounterRepo.getEncounterById('enc-orphaned-opp');
+    expect(repairedPlayer?.playerForce).toBeUndefined();
+    expect(repairedOpp?.opponentForce).toBeUndefined();
   });
 
   it('is idempotent — re-running on cleaned DB writes manifest with empty deletedIds', async () => {

--- a/scripts/cleanup-broken-encounters.ts
+++ b/scripts/cleanup-broken-encounters.ts
@@ -277,9 +277,37 @@ export async function runCleanup(
     }
   }
 
-  // PR 1: orphaned rows are NOT repaired here (no clearForceReference yet).
-  // TODO(PR 2): wire orphaned-branch repair via repo.clearForceReference.
-  const repairedIds: string[] = [];
+  // PR 2 back-patch: orphaned rows are repaired in place by NULLing the
+  // dangling force reference. `clearForceReference` keys on forceId (not
+  // encounterId), so we collect the unique orphaned forceIds across the
+  // manifest first and call once per id. The cascade hits every encounter
+  // pointing at that forceId; we track the affected encounter ids for
+  // the result manifest.
+  const orphanedForceIds = new Set<string>();
+  for (const row of rows) {
+    const entry = entries.find((e) => e.id === row.encounter.id);
+    if (entry?.classification !== 'orphaned-force-reference') continue;
+    if (
+      row.rawForceIds.playerForceId !== null &&
+      forceRepo.getForceById(row.rawForceIds.playerForceId) === null
+    ) {
+      orphanedForceIds.add(row.rawForceIds.playerForceId);
+    }
+    if (
+      row.rawForceIds.opponentForceId !== null &&
+      forceRepo.getForceById(row.rawForceIds.opponentForceId) === null
+    ) {
+      orphanedForceIds.add(row.rawForceIds.opponentForceId);
+    }
+  }
+  const repairedIdSet = new Set<string>();
+  for (const forceId of orphanedForceIds) {
+    const cascade = repo.clearForceReference(forceId);
+    for (const id of cascade.affectedEncounterIds) {
+      repairedIdSet.add(id);
+    }
+  }
+  const repairedIds: string[] = Array.from(repairedIdSet);
 
   const retainedIds = entries
     .filter((e) => !deletedIds.includes(e.id))

--- a/src/__tests__/api/encounters/encounters.test.ts
+++ b/src/__tests__/api/encounters/encounters.test.ts
@@ -68,6 +68,25 @@ jest.mock('@/services/encounter/EncounterService', () => ({
   getEncounterService: () => mockEncounterService,
 }));
 
+// Mock Encounter repository (the GET /api/encounters handler reads
+// `getAllEncountersWithRawIds` to build the rawForceIds response field).
+const mockEncounterRepository = {
+  getAllEncountersWithRawIds: jest.fn(),
+};
+
+jest.mock('@/services/encounter/EncounterRepository', () => {
+  // Re-use the actual error code enum so tests can still reference
+  // EncounterErrorCode.* without rebuilding it.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const actual = jest.requireActual<
+    typeof import('@/services/encounter/EncounterRepository')
+  >('@/services/encounter/EncounterRepository');
+  return {
+    ...actual,
+    getEncounterRepository: () => mockEncounterRepository,
+  };
+});
+
 // =============================================================================
 // Test Helpers
 // =============================================================================
@@ -153,14 +172,27 @@ function createErrorResult(
 describe('GET /api/encounters', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default: repository returns nothing — individual tests override to
+    // seed rawForceIds entries when they care about the broken-pill payload.
+    mockEncounterRepository.getAllEncountersWithRawIds.mockReturnValue([]);
   });
 
-  it('should list all encounters', async () => {
+  it('should list all encounters with rawForceIds map', async () => {
     const encounters = [
       createMockEncounter({ id: 'enc-1', name: 'Encounter 1' }),
       createMockEncounter({ id: 'enc-2', name: 'Encounter 2' }),
     ];
     mockEncounterService.getAllEncounters.mockReturnValue(encounters);
+    mockEncounterRepository.getAllEncountersWithRawIds.mockReturnValue([
+      {
+        encounter: encounters[0],
+        rawForceIds: { playerForceId: 'f-1', opponentForceId: null },
+      },
+      {
+        encounter: encounters[1],
+        rawForceIds: { playerForceId: null, opponentForceId: 'f-2' },
+      },
+    ]);
 
     const req = createMockRequest({ method: 'GET' });
     const res = createMockResponse();
@@ -171,10 +203,14 @@ describe('GET /api/encounters', () => {
     expect(res.json).toHaveBeenCalledWith({
       encounters,
       count: 2,
+      rawForceIds: {
+        'enc-1': { playerForceId: 'f-1', opponentForceId: null },
+        'enc-2': { playerForceId: null, opponentForceId: 'f-2' },
+      },
     });
   });
 
-  it('should return empty list when no encounters exist', async () => {
+  it('should return empty list with empty rawForceIds when no encounters exist', async () => {
     mockEncounterService.getAllEncounters.mockReturnValue([]);
 
     const req = createMockRequest({ method: 'GET' });
@@ -186,6 +222,35 @@ describe('GET /api/encounters', () => {
     expect(res.json).toHaveBeenCalledWith({
       encounters: [],
       count: 0,
+      rawForceIds: {},
+    });
+  });
+
+  it('returns null rawForceIds for an encounter with no forces stored', async () => {
+    const encounter = createMockEncounter({ id: 'enc-empty' });
+    mockEncounterService.getAllEncounters.mockReturnValue([encounter]);
+    mockEncounterRepository.getAllEncountersWithRawIds.mockReturnValue([
+      {
+        encounter,
+        rawForceIds: { playerForceId: null, opponentForceId: null },
+      },
+    ]);
+
+    const req = createMockRequest({ method: 'GET' });
+    const res = createMockResponse();
+
+    await encountersHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const responseJson = res.json.mock.calls[0]?.[0] as {
+      rawForceIds: Record<
+        string,
+        { playerForceId: string | null; opponentForceId: string | null }
+      >;
+    };
+    expect(responseJson.rawForceIds['enc-empty']).toEqual({
+      playerForceId: null,
+      opponentForceId: null,
     });
   });
 

--- a/src/pages/api/encounters/index.ts
+++ b/src/pages/api/encounters/index.ts
@@ -9,7 +9,10 @@
 
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-import { IEncounterOperationResult } from '@/services/encounter/EncounterRepository';
+import {
+  getEncounterRepository,
+  IEncounterOperationResult,
+} from '@/services/encounter/EncounterRepository';
 import { getEncounterService } from '@/services/encounter/EncounterService';
 import { getSQLiteService } from '@/services/persistence/SQLiteService';
 import { IEncounter, ICreateEncounterInput } from '@/types/encounter';
@@ -18,9 +21,25 @@ import { IEncounter, ICreateEncounterInput } from '@/types/encounter';
 // Response Types
 // =============================================================================
 
+/**
+ * Raw stored force-id strings keyed by encounter id, returned alongside the
+ * hydrated encounter array so the list page can call `encounterBrokenRefs`
+ * without an extra round-trip. Per the
+ * `repair-broken-encounter-drafts → Encounter List Surfaces Broken-Reference State`
+ * requirement.
+ */
+export type RawForceIdsByEncounterId = Record<
+  string,
+  {
+    readonly playerForceId: string | null;
+    readonly opponentForceId: string | null;
+  }
+>;
+
 type ListResponse = {
   encounters: readonly IEncounter[];
   count: number;
+  rawForceIds: RawForceIdsByEncounterId;
 };
 
 type CreateResponse = IEncounterOperationResult & {
@@ -66,6 +85,21 @@ export default async function handler(
 
 /**
  * GET /api/encounters - List all encounters
+ *
+ * Response shape (post repair-broken-encounter-drafts PR 2):
+ *   {
+ *     encounters: IEncounter[],         // hydrated (forces resolved or null)
+ *     count: number,
+ *     rawForceIds: Record<id, {         // raw stored force-id strings
+ *       playerForceId: string | null,   // for broken-pill detection on the
+ *       opponentForceId: string | null  // list page (no extra round-trip).
+ *     }>,
+ *   }
+ *
+ * `rawForceIds` is sourced directly from the encounter repository (NOT the
+ * service) because the service-layer hydration would have already collapsed
+ * the broken refs to null and we'd lose the "the row stored a forceId"
+ * signal needed to detect orphans.
  */
 function handleGet(
   encounterService: ReturnType<typeof getEncounterService>,
@@ -73,9 +107,18 @@ function handleGet(
 ) {
   try {
     const encounters = encounterService.getAllEncounters();
+    // Build the raw-force-ids map by reading the rows again (cheap — same
+    // SQLite query, no service-layer hydration). Keyed by encounter id so
+    // the list page can do `rawForceIds[encounter.id]` directly.
+    const rows = getEncounterRepository().getAllEncountersWithRawIds();
+    const rawForceIds: RawForceIdsByEncounterId = {};
+    for (const row of rows) {
+      rawForceIds[row.encounter.id] = row.rawForceIds;
+    }
     return res.status(200).json({
       encounters,
       count: encounters.length,
+      rawForceIds,
     });
   } catch (error) {
     const message =

--- a/src/services/encounter/EncounterRepository.ts
+++ b/src/services/encounter/EncounterRepository.ts
@@ -25,6 +25,7 @@ import {
   createSingleton,
   type SingletonFactory,
 } from '../core/createSingleton';
+import { setEncounterCascadeHook } from '../forces/ForceRepository.cascade';
 import { getSQLiteService } from '../persistence/SQLiteService';
 import {
   extractRawForceIds,
@@ -96,6 +97,7 @@ export interface IEncounterRepository {
   initialize(): void;
   createEncounter(input: ICreateEncounterInput): IEncounterOperationResult;
   getEncounterById(id: string): IEncounter | null;
+  getEncounterWithRawIds(id: string): IEncounterWithRawForceIds | null;
   getAllEncounters(): readonly IEncounter[];
   getAllEncountersWithRawIds(): readonly IEncounterWithRawForceIds[];
   getEncountersByStatus(status: EncounterStatus): readonly IEncounter[];
@@ -112,6 +114,9 @@ export interface IEncounterRepository {
     encounterId: string,
     gameSessionId: string,
   ): IEncounterOperationResult;
+  clearForceReference(forceId: string): {
+    affectedEncounterIds: readonly string[];
+  };
 }
 
 // =============================================================================
@@ -254,6 +259,30 @@ export class EncounterRepository implements IEncounterRepository {
     }
 
     return rowToEncounter(row);
+  }
+
+  /**
+   * Get an encounter by ID paired with its raw stored force-id strings.
+   *
+   * Singular sibling of `getAllEncountersWithRawIds`. Used by the detail-page
+   * API route (and the encounter detail UI) to detect "the row stores a
+   * forceId but the force is gone" without a second round-trip to the DB.
+   *
+   * Returns null when no row matches `id`.
+   */
+  getEncounterWithRawIds(id: string): IEncounterWithRawForceIds | null {
+    this.initialize();
+
+    const db = getSQLiteService().getDatabase();
+    const row = db.prepare('SELECT * FROM encounters WHERE id = ?').get(id) as
+      | EncounterRow
+      | undefined;
+
+    if (!row) {
+      return null;
+    }
+
+    return extractRawForceIds(row);
   }
 
   /**
@@ -515,21 +544,134 @@ export class EncounterRepository implements IEncounterRepository {
   }
 
   // ===========================================================================
+  // Force-Deletion Cascade
+  // ===========================================================================
+
+  /**
+   * NULL the dangling force reference on every encounter that points to
+   * `forceId`, then recompute each affected encounter's status. Wraps both
+   * UPDATE statements (player + opponent slot) AND the per-row recompute in
+   * one SQLite transaction so partial failures roll back atomically.
+   *
+   * Called by ForceRepository.deleteForce via the cascade hook BEFORE the
+   * `DELETE FROM forces` statement. The whole sequence — cascade + force
+   * delete — runs inside the outer transaction the cascade hook wraps so
+   * a thrown UPDATE rolls the force-row delete back too.
+   *
+   * @param forceId — the force being deleted
+   * @returns the encounter ids that had at least one slot cleared
+   *
+   * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+   *       (Requirement: Force-Deletion Cascade to Encounter References)
+   */
+  clearForceReference(forceId: string): {
+    affectedEncounterIds: readonly string[];
+  } {
+    this.initialize();
+
+    const db = getSQLiteService().getDatabase();
+    const now = new Date().toISOString();
+
+    // Collect affected encounter ids BEFORE the UPDATE so we know which rows
+    // to recompute status on. The two queries are cheap (indexed on id, scan
+    // on json_extract is fine for the encounter table size).
+    const playerSlotMatches = db
+      .prepare(
+        `SELECT id FROM encounters
+         WHERE json_extract(player_force_json, '$.forceId') = ?`,
+      )
+      .all(forceId) as { id: string }[];
+    const opponentSlotMatches = db
+      .prepare(
+        `SELECT id FROM encounters
+         WHERE json_extract(opponent_force_json, '$.forceId') = ?`,
+      )
+      .all(forceId) as { id: string }[];
+
+    const affectedSet = new Set<string>();
+    for (const row of playerSlotMatches) affectedSet.add(row.id);
+    for (const row of opponentSlotMatches) affectedSet.add(row.id);
+
+    if (affectedSet.size === 0) {
+      // No-op cascade — still return cleanly so the outer transaction commits.
+      return { affectedEncounterIds: [] };
+    }
+
+    // Convert to a stable array — Set iteration order is insertion-order in
+    // V8 but explicit array avoids the downlevelIteration TS flag dance.
+    const affectedIds: readonly string[] = Array.from(affectedSet);
+
+    // Both UPDATEs + the recompute pass run in one transaction. The caller
+    // (ForceRepository.deleteForce) wraps THIS call PLUS the force-row delete
+    // in its own outer transaction; better-sqlite3 treats nested
+    // `db.transaction(...)` as savepoints so the inner failure rolls the
+    // outer back via re-throw.
+    const txn = db.transaction((fid: string) => {
+      db.prepare(
+        `UPDATE encounters
+         SET player_force_json = NULL, updated_at = ?
+         WHERE json_extract(player_force_json, '$.forceId') = ?`,
+      ).run(now, fid);
+      db.prepare(
+        `UPDATE encounters
+         SET opponent_force_json = NULL, updated_at = ?
+         WHERE json_extract(opponent_force_json, '$.forceId') = ?`,
+      ).run(now, fid);
+
+      for (const id of affectedIds) {
+        this.recalculateStatus(id);
+      }
+    });
+
+    txn(forceId);
+
+    return { affectedEncounterIds: affectedIds };
+  }
+
+  // ===========================================================================
   // Helper Methods
   // ===========================================================================
 
   /**
    * Recalculate encounter status based on configuration completeness.
+   *
+   * NOTE — Launched/Completed widening: prior to PR 2 (repair-broken-encounter-
+   * drafts) this method short-circuited unconditionally for Launched and
+   * Completed encounters. The cascade now needs to drop a Launched encounter
+   * back to Draft when a force-delete just cleared its only player force —
+   * otherwise a Launched encounter would point at a NULL playerForce and
+   * launch attempts (or detail-page loads) would render an inconsistent
+   * state. The widening is narrow:
+   *
+   *   - Launched + playerForce === null + opponentForce === null  →  Draft
+   *   - Completed                                                 →  unchanged (history)
+   *   - All other Launched cases                                  →  unchanged
+   *
+   * Completed never gets demoted: the encounter ran, history matters more
+   * than current force state.
    */
   private recalculateStatus(id: string): void {
     const encounter = this.getEncounterById(id);
     if (!encounter) return;
 
-    // If already launched or completed, don't change
-    if (
-      encounter.status === EncounterStatus.Launched ||
-      encounter.status === EncounterStatus.Completed
-    ) {
+    // Completed encounters NEVER get their status modified — history is fixed.
+    if (encounter.status === EncounterStatus.Completed) {
+      return;
+    }
+
+    // Launched encounter whose only player force was cleared by a cascade
+    // drops back to Draft. Spec scenario: "Single encounter affected" — the
+    // Launched encounter pointing at the deleted force ends up Draft.
+    if (encounter.status === EncounterStatus.Launched) {
+      const bothForcesCleared =
+        !encounter.playerForce && !encounter.opponentForce;
+      if (bothForcesCleared) {
+        const db = getSQLiteService().getDatabase();
+        const now = new Date().toISOString();
+        db.prepare(
+          'UPDATE encounters SET status = ?, updated_at = ? WHERE id = ?',
+        ).run(EncounterStatus.Draft, now, id);
+      }
       return;
     }
 
@@ -558,7 +700,18 @@ export class EncounterRepository implements IEncounterRepository {
 // =============================================================================
 
 const encounterRepositoryFactory: SingletonFactory<EncounterRepository> =
-  createSingleton((): EncounterRepository => new EncounterRepository());
+  createSingleton((): EncounterRepository => {
+    const repo = new EncounterRepository();
+    // Wire the force-delete cascade hook so ForceRepository.deleteForce
+    // NULLs every encounter slot pointing at the deleted force BEFORE the
+    // force row is deleted. The hook registration is idempotent — if a
+    // previous repo instance was disposed, this overwrites the dangling
+    // reference cleanly.
+    setEncounterCascadeHook((forceId: string) => {
+      repo.clearForceReference(forceId);
+    });
+    return repo;
+  });
 
 export function getEncounterRepository(): EncounterRepository {
   return encounterRepositoryFactory.get();

--- a/src/services/encounter/EncounterService.ts
+++ b/src/services/encounter/EncounterService.ts
@@ -18,6 +18,7 @@ import {
   ScenarioTemplateType,
 } from '@/types/encounter';
 import { createGameSession } from '@/utils/gameplay/gameSessionCore';
+import { logger } from '@/utils/logger';
 
 import {
   createSingleton,
@@ -411,12 +412,26 @@ export class EncounterService implements IEncounterService {
 
   /**
    * Hydrate encounter with current force data.
+   *
+   * Hydration-Boundary Orphaned Reference Replacement (PR 2 of
+   * repair-broken-encounter-drafts):
+   *
+   *   - Stored `playerForceId` resolves via `forceRepo.getForceById` →
+   *     return a fully hydrated IForceReference (BV + unitCount + name).
+   *   - Stored `playerForceId` resolves to `null` (force was deleted but
+   *     the cascade did not run, e.g. legacy data, raw SQL inserts) →
+   *     return `null` for the slot AND emit `logger.warn` once per
+   *     `${encounterId}:${forceId}:${side}` key per process lifetime.
+   *   - No stored id (slot was always undefined) → leave undefined.
+   *
+   * The dedup Set is reset by `resetEncounterService()` so test isolation is
+   * preserved (each test boundary clears the seen-keys cache).
    */
   private hydrateEncounter(encounter: IEncounter): IEncounter {
     const forceRepo = getForceRepository();
 
-    let playerForce = encounter.playerForce;
-    let opponentForce = encounter.opponentForce;
+    let playerForce: IEncounter['playerForce'] = encounter.playerForce;
+    let opponentForce: IEncounter['opponentForce'] = encounter.opponentForce;
 
     // Hydrate player force
     if (playerForce?.forceId) {
@@ -428,6 +443,10 @@ export class EncounterService implements IEncounterService {
           totalBV: force.stats.totalBV,
           unitCount: force.stats.assignedUnits,
         };
+      } else {
+        // Resolver returned null — force was deleted but a stored ref remains.
+        warnOrphanedForceRef(encounter.id, playerForce.forceId, 'player');
+        playerForce = null;
       }
     }
 
@@ -441,6 +460,9 @@ export class EncounterService implements IEncounterService {
           totalBV: force.stats.totalBV,
           unitCount: force.stats.assignedUnits,
         };
+      } else {
+        warnOrphanedForceRef(encounter.id, opponentForce.forceId, 'opponent');
+        opponentForce = null;
       }
     }
 
@@ -450,6 +472,43 @@ export class EncounterService implements IEncounterService {
       opponentForce,
     };
   }
+}
+
+// =============================================================================
+// Orphaned-Force-Reference warn dedup
+// =============================================================================
+
+/**
+ * Module-level dedup Set: each `${encounterId}:${forceId}:${side}` key is
+ * stored on the first orphan-warn call so subsequent reads of the same
+ * orphaned encounter stay quiet. The Set is reset by `resetEncounterService`
+ * so each test boundary starts with a clean slate (cf. spec scenario "Reset
+ * clears dedup Set").
+ *
+ * Module-scoped (rather than instance-scoped) because the singleton factory
+ * may construct a new EncounterService instance after a reset and we still
+ * want the warn cache to clear deterministically — the factory reset
+ * triggers `resetOrphanWarnDedup()` from `resetEncounterService`.
+ */
+const orphanWarnSeen = new Set<string>();
+
+function warnOrphanedForceRef(
+  encounterId: string,
+  forceId: string,
+  side: 'player' | 'opponent',
+): void {
+  const key = `${encounterId}:${forceId}:${side}`;
+  if (orphanWarnSeen.has(key)) return;
+  orphanWarnSeen.add(key);
+  logger.warn('[encounter] orphaned force reference', {
+    encounterId,
+    forceId,
+    side,
+  });
+}
+
+function resetOrphanWarnDedup(): void {
+  orphanWarnSeen.clear();
 }
 
 // =============================================================================
@@ -465,4 +524,5 @@ export function getEncounterService(): EncounterService {
 
 export function resetEncounterService(): void {
   encounterServiceFactory.reset();
+  resetOrphanWarnDedup();
 }

--- a/src/services/encounter/__tests__/EncounterRepository.cascade.test.ts
+++ b/src/services/encounter/__tests__/EncounterRepository.cascade.test.ts
@@ -1,0 +1,346 @@
+/**
+ * EncounterRepository — Force-Deletion Cascade Tests
+ *
+ * Pin the contract from the
+ * `repair-broken-encounter-drafts → Force-Deletion Cascade to Encounter References`
+ * requirement:
+ *   - Single + multi-encounter cascade NULLs both force-id slots and recomputes status.
+ *   - No-op cascade (forceId not referenced anywhere) returns empty array, no rows touched.
+ *   - Launched encounter whose only player force was cleared drops back to Draft.
+ *   - Launched encounter that still retains an opponent stays Launched.
+ *   - Completed encounter NEVER demotes — history is fixed.
+ *   - Transaction rollback semantics: a thrown UPDATE rolls the prior UPDATE
+ *     back atomically (verified structurally because the cascade is wrapped
+ *     in `db.transaction(...)` which better-sqlite3 guarantees is atomic).
+ *
+ * Uses a separate test-DB filename (`./data/test-encounter-repository-cascade.db`)
+ * so concurrent runs of this suite + the existing EncounterRepository.test.ts
+ * don't collide on file locks.
+ *
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import {
+  getSQLiteService,
+  resetSQLiteService,
+} from '@/services/persistence/SQLiteService';
+import { EncounterStatus } from '@/types/encounter';
+
+import { EncounterRepository } from '../EncounterRepository';
+
+// =============================================================================
+// Test fixtures
+// =============================================================================
+
+const TEST_DB_PATH = './data/test-encounter-repository-cascade.db';
+
+/**
+ * Insert a raw encounter row directly via SQL — bypasses
+ * `repository.createEncounter` so we can drop a stored forceId in BEFORE
+ * the cascade test runs (createEncounter doesn't accept playerForce on
+ * create — it's set via update). Keeps the fixtures compact.
+ */
+function insertEncounterRow(input: {
+  id: string;
+  name: string;
+  status: EncounterStatus;
+  playerForceJson?: object | null;
+  opponentForceJson?: object | null;
+  victoryConditions?: unknown[];
+}): void {
+  const db = getSQLiteService().getDatabase();
+  const now = new Date().toISOString();
+  const map = {
+    radius: 6,
+    terrain: 'clear',
+    playerDeploymentZone: 'south',
+    opponentDeploymentZone: 'north',
+  };
+  db.prepare(
+    `INSERT INTO encounters (
+      id, name, description, status, template,
+      player_force_json, opponent_force_json, opfor_config_json,
+      map_config_json, victory_conditions_json, optional_rules_json,
+      game_session_id, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    input.id,
+    input.name,
+    null,
+    input.status,
+    null,
+    input.playerForceJson ? JSON.stringify(input.playerForceJson) : null,
+    input.opponentForceJson ? JSON.stringify(input.opponentForceJson) : null,
+    null,
+    JSON.stringify(map),
+    JSON.stringify(input.victoryConditions ?? []),
+    JSON.stringify([]),
+    null,
+    now,
+    now,
+  );
+}
+
+function readPlayerForceJsonRaw(id: string): string | null {
+  const db = getSQLiteService().getDatabase();
+  const row = db
+    .prepare('SELECT player_force_json FROM encounters WHERE id = ?')
+    .get(id) as { player_force_json: string | null } | undefined;
+  return row?.player_force_json ?? null;
+}
+
+function readStatus(id: string): string | null {
+  const db = getSQLiteService().getDatabase();
+  const row = db
+    .prepare('SELECT status FROM encounters WHERE id = ?')
+    .get(id) as { status: string } | undefined;
+  return row?.status ?? null;
+}
+
+// =============================================================================
+// Suite
+// =============================================================================
+
+describe('EncounterRepository.clearForceReference (cascade)', () => {
+  let repository: EncounterRepository;
+
+  beforeEach(() => {
+    if (fs.existsSync(TEST_DB_PATH)) fs.unlinkSync(TEST_DB_PATH);
+    const walPath = `${TEST_DB_PATH}-wal`;
+    const shmPath = `${TEST_DB_PATH}-shm`;
+    if (fs.existsSync(walPath)) fs.unlinkSync(walPath);
+    if (fs.existsSync(shmPath)) fs.unlinkSync(shmPath);
+
+    const dataDir = path.dirname(TEST_DB_PATH);
+    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+
+    resetSQLiteService();
+    const sqlite = getSQLiteService({ path: TEST_DB_PATH });
+    sqlite.initialize();
+
+    repository = new EncounterRepository();
+    repository.initialize();
+  });
+
+  afterEach(() => {
+    resetSQLiteService();
+    if (fs.existsSync(TEST_DB_PATH)) fs.unlinkSync(TEST_DB_PATH);
+    const walPath = `${TEST_DB_PATH}-wal`;
+    const shmPath = `${TEST_DB_PATH}-shm`;
+    if (fs.existsSync(walPath)) fs.unlinkSync(walPath);
+    if (fs.existsSync(shmPath)) fs.unlinkSync(shmPath);
+  });
+
+  it('clears a single encounter pointing at the deleted force (player slot)', () => {
+    insertEncounterRow({
+      id: 'enc-1',
+      name: 'Single Player Cascade',
+      status: EncounterStatus.Draft,
+      playerForceJson: {
+        forceId: 'force-X',
+        forceName: 'Old',
+        totalBV: 0,
+        unitCount: 0,
+      },
+    });
+
+    const result = repository.clearForceReference('force-X');
+
+    expect(result.affectedEncounterIds).toEqual(['enc-1']);
+    expect(readPlayerForceJsonRaw('enc-1')).toBeNull();
+    // Status stays Draft — it was already Draft, recalculate is a no-op here.
+    expect(readStatus('enc-1')).toBe(EncounterStatus.Draft);
+  });
+
+  it('clears multiple encounters across both player and opponent slots', () => {
+    insertEncounterRow({
+      id: 'enc-a',
+      name: 'A — player ref',
+      status: EncounterStatus.Draft,
+      playerForceJson: {
+        forceId: 'force-shared',
+        forceName: '',
+        totalBV: 0,
+        unitCount: 0,
+      },
+    });
+    insertEncounterRow({
+      id: 'enc-b',
+      name: 'B — opponent ref',
+      status: EncounterStatus.Draft,
+      opponentForceJson: {
+        forceId: 'force-shared',
+        forceName: '',
+        totalBV: 0,
+        unitCount: 0,
+      },
+    });
+    insertEncounterRow({
+      id: 'enc-c',
+      name: 'C — both refs',
+      status: EncounterStatus.Draft,
+      playerForceJson: {
+        forceId: 'force-shared',
+        forceName: '',
+        totalBV: 0,
+        unitCount: 0,
+      },
+      opponentForceJson: {
+        forceId: 'force-shared',
+        forceName: '',
+        totalBV: 0,
+        unitCount: 0,
+      },
+    });
+
+    const result = repository.clearForceReference('force-shared');
+
+    expect(result.affectedEncounterIds).toHaveLength(3);
+    expect(result.affectedEncounterIds).toEqual(
+      expect.arrayContaining(['enc-a', 'enc-b', 'enc-c']),
+    );
+
+    // Both slots NULL across the board
+    expect(readPlayerForceJsonRaw('enc-a')).toBeNull();
+    expect(readPlayerForceJsonRaw('enc-c')).toBeNull();
+    const db = getSQLiteService().getDatabase();
+    const oppB = db
+      .prepare('SELECT opponent_force_json FROM encounters WHERE id = ?')
+      .get('enc-b') as { opponent_force_json: string | null };
+    const oppC = db
+      .prepare('SELECT opponent_force_json FROM encounters WHERE id = ?')
+      .get('enc-c') as { opponent_force_json: string | null };
+    expect(oppB.opponent_force_json).toBeNull();
+    expect(oppC.opponent_force_json).toBeNull();
+  });
+
+  it('no-op cascade when forceId is referenced nowhere', () => {
+    insertEncounterRow({
+      id: 'enc-untouched',
+      name: 'Untouched',
+      status: EncounterStatus.Draft,
+      playerForceJson: {
+        forceId: 'force-other',
+        forceName: '',
+        totalBV: 0,
+        unitCount: 0,
+      },
+    });
+
+    const result = repository.clearForceReference('force-does-not-exist');
+
+    expect(result.affectedEncounterIds).toEqual([]);
+    // Untouched row still has its player force ref intact
+    const raw = readPlayerForceJsonRaw('enc-untouched');
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!)).toMatchObject({ forceId: 'force-other' });
+  });
+
+  it('Launched encounter with only-player-ref-cleared drops to Draft', () => {
+    // Launched encounter referencing forceId on the player slot (single-side
+    // launched scenario — no opponent ever set, encounter went Launched via
+    // legacy path or test fixture). The cascade must drop status to Draft
+    // because the encounter no longer has any forces resolved.
+    insertEncounterRow({
+      id: 'enc-launched',
+      name: 'Launched',
+      status: EncounterStatus.Launched,
+      playerForceJson: {
+        forceId: 'force-Y',
+        forceName: '',
+        totalBV: 0,
+        unitCount: 0,
+      },
+    });
+
+    repository.clearForceReference('force-Y');
+
+    expect(readPlayerForceJsonRaw('enc-launched')).toBeNull();
+    expect(readStatus('enc-launched')).toBe(EncounterStatus.Draft);
+  });
+
+  it('Launched encounter that still retains an opponent stays Launched', () => {
+    // The widening only fires when BOTH forces are cleared. A launched
+    // encounter that still has an opponent stays launched — the cascade
+    // cleared one slot, the encounter retains a referenced opponent, status
+    // is preserved.
+    insertEncounterRow({
+      id: 'enc-launched-half',
+      name: 'Launched Half',
+      status: EncounterStatus.Launched,
+      playerForceJson: {
+        forceId: 'force-Z',
+        forceName: '',
+        totalBV: 0,
+        unitCount: 0,
+      },
+      opponentForceJson: {
+        forceId: 'force-other-opp',
+        forceName: '',
+        totalBV: 0,
+        unitCount: 0,
+      },
+    });
+
+    repository.clearForceReference('force-Z');
+
+    expect(readPlayerForceJsonRaw('enc-launched-half')).toBeNull();
+    // opponent still set; status preserved
+    expect(readStatus('enc-launched-half')).toBe(EncounterStatus.Launched);
+  });
+
+  it('Completed encounter NEVER demotes even when both forces cleared', () => {
+    insertEncounterRow({
+      id: 'enc-completed',
+      name: 'Completed',
+      status: EncounterStatus.Completed,
+      playerForceJson: {
+        forceId: 'force-W',
+        forceName: '',
+        totalBV: 0,
+        unitCount: 0,
+      },
+      opponentForceJson: {
+        forceId: 'force-W',
+        forceName: '',
+        totalBV: 0,
+        unitCount: 0,
+      },
+    });
+
+    repository.clearForceReference('force-W');
+
+    // Both refs cleared, but status remains Completed (history is fixed).
+    expect(readPlayerForceJsonRaw('enc-completed')).toBeNull();
+    expect(readStatus('enc-completed')).toBe(EncounterStatus.Completed);
+  });
+
+  it('wraps the cascade in db.transaction for atomic rollback semantics', () => {
+    // Structural assertion: clearForceReference uses the better-sqlite3
+    // `db.transaction(...)` API for the UPDATE+recompute pass, which
+    // guarantees rollback on any throw. We spy on `db.transaction` and
+    // assert it gets called exactly once per cascade invocation.
+    insertEncounterRow({
+      id: 'enc-txn',
+      name: 'Txn Witness',
+      status: EncounterStatus.Draft,
+      playerForceJson: {
+        forceId: 'force-T',
+        forceName: '',
+        totalBV: 0,
+        unitCount: 0,
+      },
+    });
+
+    const db = getSQLiteService().getDatabase();
+    const txnSpy = jest.spyOn(db, 'transaction');
+
+    repository.clearForceReference('force-T');
+
+    expect(txnSpy).toHaveBeenCalledTimes(1);
+    txnSpy.mockRestore();
+  });
+});

--- a/src/services/encounter/__tests__/EncounterService.hydration.test.ts
+++ b/src/services/encounter/__tests__/EncounterService.hydration.test.ts
@@ -1,0 +1,266 @@
+/**
+ * EncounterService.hydrateEncounter — Orphaned-Reference Repair Tests
+ *
+ * Pin the contract from the
+ * `repair-broken-encounter-drafts → Hydration-Boundary Orphaned-Reference Replacement`
+ * requirement:
+ *   - Valid stored forceId resolves to IForceReference; no warn fires.
+ *   - Stored forceId pointing at a deleted force returns null + warns once
+ *     per `${encounterId}:${forceId}:${side}` key.
+ *   - Repeated reads of the same orphan stay quiet (dedup).
+ *   - `resetEncounterService()` clears the dedup so a fresh test boundary
+ *     re-warns on the same orphan.
+ *   - Both player + opponent missing → both nulls, two warn calls (one
+ *     per side, distinct keys).
+ *
+ * Uses jest module mocks so the hydration logic runs against an in-memory
+ * encounter row + a stub force repo that returns null for the deleted ids.
+ *
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ */
+
+import {
+  EncounterStatus,
+  type IEncounter,
+  TerrainPreset,
+} from '@/types/encounter';
+import { type IForce, ForceType, ForceStatus } from '@/types/force';
+import { logger } from '@/utils/logger';
+
+// =============================================================================
+// Mocks — must be hoisted before importing the service
+// =============================================================================
+
+const mockEncounters = new Map<string, IEncounter>();
+const mockForces = new Map<string, IForce>();
+
+jest.mock('../../forces/ForceRepository', () => ({
+  getForceRepository: () => ({
+    getForceById: (id: string) => mockForces.get(id) ?? null,
+    getAllForces: () => Array.from(mockForces.values()),
+  }),
+}));
+
+jest.mock('../EncounterRepository', () => ({
+  getEncounterRepository: () => ({
+    getEncounterById: (id: string) => mockEncounters.get(id) ?? null,
+    getAllEncounters: () => Array.from(mockEncounters.values()),
+    getEncountersByStatus: (status: EncounterStatus) =>
+      Array.from(mockEncounters.values()).filter((e) => e.status === status),
+    initialize: jest.fn(),
+  }),
+  EncounterRepository: class {},
+}));
+
+jest.mock('../../pilots/PilotService', () => ({
+  getPilotService: () => ({ getPilot: () => null }),
+}));
+
+// Import AFTER mocks
+import {
+  getEncounterService,
+  resetEncounterService,
+} from '../EncounterService';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeEncounter(overrides: Partial<IEncounter> = {}): IEncounter {
+  return {
+    id: 'encounter-fix',
+    name: 'Hydration Fixture',
+    status: EncounterStatus.Draft,
+    template: undefined,
+    playerForce: undefined,
+    opponentForce: undefined,
+    opForConfig: undefined,
+    mapConfig: {
+      radius: 6,
+      terrain: TerrainPreset.Clear,
+      playerDeploymentZone: 'south',
+      opponentDeploymentZone: 'north',
+    },
+    victoryConditions: [],
+    optionalRules: [],
+    createdAt: '2026-04-01T00:00:00.000Z',
+    updatedAt: '2026-04-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeForce(id: string, name: string): IForce {
+  return {
+    id,
+    name,
+    forceType: ForceType.Lance,
+    status: ForceStatus.Active,
+    childIds: [],
+    assignments: [],
+    stats: {
+      totalBV: 4500,
+      totalTonnage: 200,
+      assignedPilots: 4,
+      assignedUnits: 4,
+      emptySlots: 0,
+      averageSkill: { gunnery: 4, piloting: 5 },
+    },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+// =============================================================================
+// Suite
+// =============================================================================
+
+describe('EncounterService.hydrateEncounter — orphaned reference repair', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockEncounters.clear();
+    mockForces.clear();
+    resetEncounterService();
+    warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('hydrates a valid forceId without warning', () => {
+    mockForces.set('force-good', makeForce('force-good', 'Alpha Lance'));
+    mockEncounters.set(
+      'enc-1',
+      makeEncounter({
+        id: 'enc-1',
+        playerForce: {
+          forceId: 'force-good',
+          forceName: '',
+          totalBV: 0,
+          unitCount: 0,
+        },
+      }),
+    );
+
+    const result = getEncounterService().getEncounter('enc-1');
+
+    expect(result?.playerForce).toEqual({
+      forceId: 'force-good',
+      forceName: 'Alpha Lance',
+      totalBV: 4500,
+      unitCount: 4,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('replaces an orphaned playerForce with null and warns once', () => {
+    // No mockForces.set — getForceById will return null for the stored id.
+    mockEncounters.set(
+      'enc-orphan-p',
+      makeEncounter({
+        id: 'enc-orphan-p',
+        playerForce: {
+          forceId: 'force-deleted',
+          forceName: '',
+          totalBV: 0,
+          unitCount: 0,
+        },
+      }),
+    );
+
+    const result = getEncounterService().getEncounter('enc-orphan-p');
+
+    expect(result?.playerForce).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[encounter] orphaned force reference',
+      {
+        encounterId: 'enc-orphan-p',
+        forceId: 'force-deleted',
+        side: 'player',
+      },
+    );
+  });
+
+  it('dedups the warn — second read of the same orphan stays quiet', () => {
+    mockEncounters.set(
+      'enc-orphan-dedup',
+      makeEncounter({
+        id: 'enc-orphan-dedup',
+        playerForce: {
+          forceId: 'force-deleted',
+          forceName: '',
+          totalBV: 0,
+          unitCount: 0,
+        },
+      }),
+    );
+
+    const service = getEncounterService();
+    service.getEncounter('enc-orphan-dedup');
+    service.getEncounter('enc-orphan-dedup');
+    service.getEncounter('enc-orphan-dedup');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-warns after resetEncounterService() clears the dedup Set', () => {
+    mockEncounters.set(
+      'enc-orphan-reset',
+      makeEncounter({
+        id: 'enc-orphan-reset',
+        playerForce: {
+          forceId: 'force-deleted',
+          forceName: '',
+          totalBV: 0,
+          unitCount: 0,
+        },
+      }),
+    );
+
+    getEncounterService().getEncounter('enc-orphan-reset');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    resetEncounterService();
+
+    getEncounterService().getEncounter('enc-orphan-reset');
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('null-replaces both sides and warns once per side when both are orphans', () => {
+    mockEncounters.set(
+      'enc-orphan-both',
+      makeEncounter({
+        id: 'enc-orphan-both',
+        playerForce: {
+          forceId: 'force-deleted-p',
+          forceName: '',
+          totalBV: 0,
+          unitCount: 0,
+        },
+        opponentForce: {
+          forceId: 'force-deleted-o',
+          forceName: '',
+          totalBV: 0,
+          unitCount: 0,
+        },
+      }),
+    );
+
+    const result = getEncounterService().getEncounter('enc-orphan-both');
+
+    expect(result?.playerForce).toBeNull();
+    expect(result?.opponentForce).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    // Distinct (encounterId, forceId, side) keys for the two warns
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[encounter] orphaned force reference',
+      expect.objectContaining({ side: 'player', forceId: 'force-deleted-p' }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[encounter] orphaned force reference',
+      expect.objectContaining({ side: 'opponent', forceId: 'force-deleted-o' }),
+    );
+  });
+});

--- a/src/services/encounter/__tests__/EncounterService.test.ts
+++ b/src/services/encounter/__tests__/EncounterService.test.ts
@@ -995,20 +995,23 @@ describe('EncounterService', () => {
       expect(encounter?.opponentForce?.unitCount).toBe(4);
     });
 
-    it('should handle deleted force gracefully', () => {
+    it('should null out playerForce when the referenced force was deleted', () => {
+      // Phase B of repair-broken-encounter-drafts widened the hydration
+      // boundary: a stored forceId that no longer resolves now becomes
+      // `null` (rather than passing the dangling ref through). Detection
+      // of "force deleted out from under the encounter" is downstream's
+      // job via `encounterBrokenRefs(encounter, rawForceIds)`.
       const force = createMockForce('force-deleted', 'Deleted Force');
       const createResult = service.createEncounter({
         name: 'Deleted Force Test',
       });
       service.setPlayerForce(createResult.id!, force.id);
 
-      // Delete the force
+      // Delete the force out from under the encounter.
       mockForces.delete(force.id);
 
       const encounter = service.getEncounter(createResult.id!);
-
-      // Should still have the reference but not hydrated with current data
-      expect(encounter?.playerForce?.forceId).toBe(force.id);
+      expect(encounter?.playerForce).toBeNull();
     });
   });
 

--- a/src/services/encounter/__tests__/encounterBrokenRefs.test.ts
+++ b/src/services/encounter/__tests__/encounterBrokenRefs.test.ts
@@ -1,0 +1,135 @@
+/**
+ * encounterBrokenRefs — pure-helper unit tests
+ *
+ * Pin the truth-table for the broken-reference predicate so the list page
+ * (broken-pill rendering) and the detail page (repair banner) share one
+ * source of truth. These tests intentionally do NOT touch the DB or any
+ * service layer — the helper is pure.
+ *
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ *       (Requirement: Broken-Reference Detection Helper)
+ */
+
+import {
+  EncounterStatus,
+  type IEncounter,
+  type IForceReference,
+  TerrainPreset,
+} from '@/types/encounter';
+
+import { encounterBrokenRefs } from '../encounterBrokenRefs';
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+/**
+ * Minimal IEncounter factory — overrides drive the slot under test. The
+ * helper is pure so the rest of the encounter shape is irrelevant to the
+ * predicate; we still provide valid defaults so `IEncounter` typechecks.
+ */
+function makeEncounter(overrides: Partial<IEncounter> = {}): IEncounter {
+  return {
+    id: 'encounter-test',
+    name: 'Test',
+    status: EncounterStatus.Draft,
+    template: undefined,
+    playerForce: undefined,
+    opponentForce: undefined,
+    opForConfig: undefined,
+    mapConfig: {
+      radius: 6,
+      terrain: TerrainPreset.Clear,
+      playerDeploymentZone: 'south',
+      opponentDeploymentZone: 'north',
+    },
+    victoryConditions: [],
+    optionalRules: [],
+    createdAt: '2026-04-01T00:00:00.000Z',
+    updatedAt: '2026-04-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const hydratedForce: IForceReference = {
+  forceId: 'force-1',
+  forceName: 'Alpha Lance',
+  totalBV: 4500,
+  unitCount: 4,
+};
+
+// =============================================================================
+// Truth-table tests
+// =============================================================================
+
+describe('encounterBrokenRefs', () => {
+  it('reports neither side missing when no forceIds were ever stored', () => {
+    const encounter = makeEncounter();
+    const result = encounterBrokenRefs(encounter, {
+      playerForceId: null,
+      opponentForceId: null,
+    });
+    expect(result).toEqual({
+      playerForceMissing: false,
+      opponentForceMissing: false,
+    });
+  });
+
+  it('reports player NOT missing when forceId stored AND playerForce hydrated', () => {
+    const encounter = makeEncounter({ playerForce: hydratedForce });
+    const result = encounterBrokenRefs(encounter, {
+      playerForceId: 'force-1',
+      opponentForceId: null,
+    });
+    expect(result.playerForceMissing).toBe(false);
+    expect(result.opponentForceMissing).toBe(false);
+  });
+
+  it('reports player missing when forceId stored AND playerForce === null', () => {
+    const encounter = makeEncounter({ playerForce: null });
+    const result = encounterBrokenRefs(encounter, {
+      playerForceId: 'force-deleted',
+      opponentForceId: null,
+    });
+    expect(result.playerForceMissing).toBe(true);
+    expect(result.opponentForceMissing).toBe(false);
+  });
+
+  it('reports opponent missing when forceId stored AND opponentForce === null', () => {
+    const encounter = makeEncounter({ opponentForce: null });
+    const result = encounterBrokenRefs(encounter, {
+      playerForceId: null,
+      opponentForceId: 'force-opp-deleted',
+    });
+    expect(result.playerForceMissing).toBe(false);
+    expect(result.opponentForceMissing).toBe(true);
+  });
+
+  it('reports BOTH missing when both forceIds stored AND both hydrated to null', () => {
+    const encounter = makeEncounter({
+      playerForce: null,
+      opponentForce: null,
+    });
+    const result = encounterBrokenRefs(encounter, {
+      playerForceId: 'force-deleted-p',
+      opponentForceId: 'force-deleted-o',
+    });
+    expect(result).toEqual({
+      playerForceMissing: true,
+      opponentForceMissing: true,
+    });
+  });
+
+  it('treats undefined playerForce as NOT missing — slot was never set', () => {
+    // The predicate is: stored-id-present AND hydrated-to-null. An
+    // undefined playerForce means the slot was never populated, NOT that
+    // the force was deleted. Spec scenario: "broken-pill is for orphans
+    // only".
+    const encounter = makeEncounter({ playerForce: undefined });
+    const result = encounterBrokenRefs(encounter, {
+      playerForceId: null,
+      opponentForceId: null,
+    });
+    expect(result.playerForceMissing).toBe(false);
+  });
+});

--- a/src/services/encounter/encounterBrokenRefs.ts
+++ b/src/services/encounter/encounterBrokenRefs.ts
@@ -1,0 +1,54 @@
+/**
+ * Encounter Broken-Reference Detection Helper
+ *
+ * Pure function — no IO, no logging, no mutation. Compares the hydrated
+ * `IEncounter` against the raw stored force-id strings to report which
+ * sides are "broken" (i.e. a forceId is stored on the row but the hydrated
+ * playerForce / opponentForce came back as null because the force was
+ * deleted).
+ *
+ * Used by the encounter list page (broken-pill rendering) and the encounter
+ * detail page (repair banner) so both surfaces share the same predicate
+ * without each having to re-implement it.
+ *
+ * The shape of `rawForceIds` mirrors what `EncounterRepository.getEncounterWithRawIds`
+ * (and the list variant) returns — `string | null` for each side.
+ *
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ *       (Requirement: Broken-Reference Detection Helper)
+ */
+
+import type { IEncounter } from '@/types/encounter';
+
+export interface IRawForceIds {
+  readonly playerForceId: string | null;
+  readonly opponentForceId: string | null;
+}
+
+export interface IEncounterBrokenRefs {
+  readonly playerForceMissing: boolean;
+  readonly opponentForceMissing: boolean;
+}
+
+/**
+ * Detect orphaned force references on an encounter.
+ *
+ * `playerForceMissing` is true if and only if a forceId was stored on the
+ * row (rawForceIds.playerForceId !== null) AND the hydration boundary set
+ * `encounter.playerForce` to null (resolver returned null). Same predicate
+ * for opponent.
+ *
+ * NOTE: an `undefined` `encounter.playerForce` (slot was never set) is NOT
+ * "missing" — it's empty. Only the explicit-null case from the hydration
+ * boundary counts as missing. The pure-helper unit tests pin this behavior.
+ */
+export function encounterBrokenRefs(
+  encounter: IEncounter,
+  rawForceIds: IRawForceIds,
+): IEncounterBrokenRefs {
+  const playerForceMissing =
+    rawForceIds.playerForceId !== null && encounter.playerForce === null;
+  const opponentForceMissing =
+    rawForceIds.opponentForceId !== null && encounter.opponentForce === null;
+  return { playerForceMissing, opponentForceMissing };
+}

--- a/src/services/forces/ForceRepository.cascade.ts
+++ b/src/services/forces/ForceRepository.cascade.ts
@@ -1,0 +1,72 @@
+/**
+ * Force-Deletion Cascade Hook
+ *
+ * Decouples ForceRepository from EncounterRepository so the two modules can
+ * sit in their own dependency layers without a hard import. The encounter
+ * repository registers a callback at module-init time via
+ * `setEncounterCascadeHook(...)`; ForceRepository.deleteForce invokes the
+ * callback (if registered) BEFORE deleting the force row, all inside one
+ * SQLite transaction so partial failures roll back atomically.
+ *
+ * Why a callback rather than a direct import?
+ *   - ForceRepository pre-dates EncounterRepository in the dependency graph;
+ *     a direct `import { getEncounterRepository } from '../encounter/...'`
+ *     would create a circular import (EncounterService imports ForceRepository
+ *     in `hydrateEncounter`).
+ *   - The callback keeps cascade logic owned by EncounterRepository (the
+ *     module that knows how to NULL the force-id columns and recompute status)
+ *     while letting ForceRepository remain agnostic.
+ *
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ *       (Requirement: Force-Deletion Cascade to Encounter References)
+ */
+
+/**
+ * Callback shape — invoked synchronously inside the same SQLite transaction
+ * as the force-row DELETE. The callback MUST throw on any internal failure so
+ * the surrounding `db.transaction(...)` rolls back; returning silently on a
+ * partial failure would leave the orphan invariant broken.
+ *
+ * The callback returns nothing — affected encounter ids are not propagated
+ * out of the cascade because the calling code (ForceRepository.deleteForce)
+ * does not need them. Tests inspect the resulting DB state directly.
+ */
+export type EncounterCascadeHook = (forceId: string) => void;
+
+let registeredHook: EncounterCascadeHook | null = null;
+
+/**
+ * Register the cascade hook. EncounterRepository's singleton factory wires
+ * itself as the hook on first creation. Tests that bypass the singleton
+ * (e.g. construct a fresh repo manually) can register their own hook.
+ *
+ * Idempotent — re-registering overwrites the previous hook.
+ */
+export function setEncounterCascadeHook(hook: EncounterCascadeHook): void {
+  registeredHook = hook;
+}
+
+/**
+ * Clear the registered hook. Used by `resetEncounterRepository` test helpers
+ * so a fresh test does not inherit the previous test's hook (which may be
+ * bound to a closed/disposed DB).
+ */
+export function clearEncounterCascadeHook(): void {
+  registeredHook = null;
+}
+
+/**
+ * Internal — called by ForceRepository.deleteForce. Returns true if a hook
+ * was registered AND the cascade ran without throwing; returns false if no
+ * hook is registered (so the caller can fall back to legacy non-cascade
+ * behavior, e.g. during cold-start before the encounter module is loaded).
+ *
+ * If the hook throws, the exception propagates so the surrounding SQLite
+ * transaction rolls back. Callers SHALL NOT swallow the exception — that
+ * would defeat the rollback contract.
+ */
+export function invokeEncounterCascadeHook(forceId: string): boolean {
+  if (!registeredHook) return false;
+  registeredHook(forceId);
+  return true;
+}

--- a/src/services/forces/ForceRepository.ts
+++ b/src/services/forces/ForceRepository.ts
@@ -19,6 +19,7 @@ import {
   type SingletonFactory,
 } from '../core/createSingleton';
 import { getSQLiteService } from '../persistence/SQLiteService';
+import { invokeEncounterCascadeHook } from './ForceRepository.cascade';
 import { hydrateForce, type ForceRow } from './ForceRepository.helpers';
 import {
   createForceOperation,
@@ -191,6 +192,20 @@ export class ForceRepository implements IForceRepository {
 
   /**
    * Delete a force and its assignments.
+   *
+   * Cascade contract (PR 2 of repair-broken-encounter-drafts):
+   *   The whole sequence — encounter cascade + parent-id un-link + assignments
+   *   delete + force delete — runs inside ONE SQLite transaction so a thrown
+   *   UPDATE in the encounter cascade rolls every step back atomically. The
+   *   force row remains present after a rollback, so callers see the force
+   *   delete as having "not happened" rather than a half-applied state.
+   *
+   *   The cascade hook is invoked BEFORE the force-row DELETE so the
+   *   referential pattern is "clear references first, then drop the target" —
+   *   if we deleted the force first, the json_extract WHERE clauses in the
+   *   cascade would still match (the IDs are stored in JSON columns, not
+   *   FK-linked), but ordering matters for crash-mid-transaction recovery
+   *   semantics.
    */
   deleteForce(id: string): IForceOperationResult {
     this.initialize();
@@ -198,16 +213,30 @@ export class ForceRepository implements IForceRepository {
     const db = getSQLiteService().getDatabase();
 
     try {
-      // Set children's parent to null
-      db.prepare('UPDATE forces SET parent_id = NULL WHERE parent_id = ?').run(
-        id,
-      );
+      const txn = db.transaction((forceId: string) => {
+        // Step 1: Cascade-clear any encounters that reference this force.
+        // Hook is registered by EncounterRepository's singleton factory at
+        // module-init time; if it throws, the whole transaction rolls back.
+        // No-op when the encounter module is not yet loaded (e.g. cold-start
+        // standalone Force-only flow).
+        invokeEncounterCascadeHook(forceId);
 
-      // Delete assignments (cascade should handle this, but be explicit)
-      db.prepare('DELETE FROM force_assignments WHERE force_id = ?').run(id);
+        // Step 2: Un-link any child forces (FK ON DELETE SET NULL would do
+        // this for us, but explicit is clearer + survives schema changes).
+        db.prepare(
+          'UPDATE forces SET parent_id = NULL WHERE parent_id = ?',
+        ).run(forceId);
 
-      // Delete force
-      db.prepare('DELETE FROM forces WHERE id = ?').run(id);
+        // Step 3: Delete assignments (cascade should handle this, but be explicit).
+        db.prepare('DELETE FROM force_assignments WHERE force_id = ?').run(
+          forceId,
+        );
+
+        // Step 4: Delete the force row itself.
+        db.prepare('DELETE FROM forces WHERE id = ?').run(forceId);
+      });
+
+      txn(id);
 
       return { success: true };
     } catch (error) {

--- a/src/services/forces/__tests__/ForceRepository.test.ts
+++ b/src/services/forces/__tests__/ForceRepository.test.ts
@@ -773,6 +773,232 @@ describe('ForceRepository', () => {
   });
 
   // ===========================================================================
+  // deleteForce — Cascade to Encounter References (PR 2 of repair-broken-encounter-drafts)
+  // ===========================================================================
+
+  describe('deleteForce — encounter cascade hook', () => {
+    /**
+     * Insert a raw encounter row referencing the given forceId on the chosen
+     * slot. Skips the EncounterRepository's createEncounter API because that
+     * doesn't seed playerForce on insert (it's update-only). For the cascade
+     * tests we want a row that looks like the "force was just deleted out
+     * from under it" scenario.
+     */
+    function ensureEncountersTable(): void {
+      const db = getSQLiteService().getDatabase();
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS encounters (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          description TEXT,
+          status TEXT NOT NULL DEFAULT 'draft',
+          template TEXT,
+          player_force_json TEXT,
+          opponent_force_json TEXT,
+          opfor_config_json TEXT,
+          map_config_json TEXT NOT NULL,
+          victory_conditions_json TEXT NOT NULL,
+          optional_rules_json TEXT NOT NULL DEFAULT '[]',
+          game_session_id TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        )
+      `);
+    }
+
+    function insertEncounterWithForce(input: {
+      id: string;
+      forceId: string;
+      slot: 'player' | 'opponent';
+    }): void {
+      const db = getSQLiteService().getDatabase();
+      const ref = JSON.stringify({
+        forceId: input.forceId,
+        forceName: '',
+        totalBV: 0,
+        unitCount: 0,
+      });
+      const map = JSON.stringify({
+        radius: 6,
+        terrain: 'clear',
+        playerDeploymentZone: 'south',
+        opponentDeploymentZone: 'north',
+      });
+      const now = new Date().toISOString();
+      db.prepare(
+        `INSERT INTO encounters (
+          id, name, description, status, template,
+          player_force_json, opponent_force_json, opfor_config_json,
+          map_config_json, victory_conditions_json, optional_rules_json,
+          game_session_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        input.id,
+        `Encounter ${input.id}`,
+        null,
+        'draft',
+        null,
+        input.slot === 'player' ? ref : null,
+        input.slot === 'opponent' ? ref : null,
+        null,
+        map,
+        JSON.stringify([]),
+        JSON.stringify([]),
+        null,
+        now,
+        now,
+      );
+    }
+
+    function readEncounterPlayerForceJson(id: string): string | null {
+      const db = getSQLiteService().getDatabase();
+      const row = db
+        .prepare('SELECT player_force_json FROM encounters WHERE id = ?')
+        .get(id) as { player_force_json: string | null } | undefined;
+      return row?.player_force_json ?? null;
+    }
+
+    function readEncounterOpponentForceJson(id: string): string | null {
+      const db = getSQLiteService().getDatabase();
+      const row = db
+        .prepare('SELECT opponent_force_json FROM encounters WHERE id = ?')
+        .get(id) as { opponent_force_json: string | null } | undefined;
+      return row?.opponent_force_json ?? null;
+    }
+
+    function forceRowExists(id: string): boolean {
+      const db = getSQLiteService().getDatabase();
+      const row = db.prepare('SELECT id FROM forces WHERE id = ?').get(id);
+      return !!row;
+    }
+
+    beforeEach(() => {
+      ensureEncountersTable();
+      // Reset cascade hook between tests so a thrown-hook test from earlier
+      // can't leak into a later "no encounter ref" test.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const cascade =
+        require('../ForceRepository.cascade') as typeof import('../ForceRepository.cascade');
+      cascade.clearEncounterCascadeHook();
+    });
+
+    it('deletes a force not referenced by any encounter — encounters unchanged', () => {
+      // Encounter referencing a DIFFERENT force should be untouched.
+      const keepResult = repository.createForce({
+        name: 'Keep',
+        forceType: ForceType.Lance,
+      });
+      const dropResult = repository.createForce({
+        name: 'Drop',
+        forceType: ForceType.Lance,
+      });
+      insertEncounterWithForce({
+        id: 'enc-untouched',
+        forceId: keepResult.id!,
+        slot: 'player',
+      });
+
+      const deleteResult = repository.deleteForce(dropResult.id!);
+
+      expect(deleteResult.success).toBe(true);
+      expect(forceRowExists(dropResult.id!)).toBe(false);
+      // Untouched encounter still references the OTHER force
+      const ref = readEncounterPlayerForceJson('enc-untouched');
+      expect(ref).not.toBeNull();
+      expect(JSON.parse(ref!)).toMatchObject({ forceId: keepResult.id });
+    });
+
+    it('cascade-NULLs every encounter slot (player + opponent) when the force is deleted', () => {
+      // Create a force, then plant 3 encounter references at it (mix of
+      // player/opponent slots), then register the cascade hook + delete.
+      const target = repository.createForce({
+        name: 'Target',
+        forceType: ForceType.Lance,
+      });
+
+      insertEncounterWithForce({
+        id: 'enc-p1',
+        forceId: target.id!,
+        slot: 'player',
+      });
+      insertEncounterWithForce({
+        id: 'enc-p2',
+        forceId: target.id!,
+        slot: 'player',
+      });
+      insertEncounterWithForce({
+        id: 'enc-o1',
+        forceId: target.id!,
+        slot: 'opponent',
+      });
+
+      // Wire a real-shaped cascade hook: NULL the json columns by forceId.
+      // Mirrors the production EncounterRepository.clearForceReference.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const cascade =
+        require('../ForceRepository.cascade') as typeof import('../ForceRepository.cascade');
+      cascade.setEncounterCascadeHook((forceId: string) => {
+        const db = getSQLiteService().getDatabase();
+        const now = new Date().toISOString();
+        db.prepare(
+          `UPDATE encounters
+           SET player_force_json = NULL, updated_at = ?
+           WHERE json_extract(player_force_json, '$.forceId') = ?`,
+        ).run(now, forceId);
+        db.prepare(
+          `UPDATE encounters
+           SET opponent_force_json = NULL, updated_at = ?
+           WHERE json_extract(opponent_force_json, '$.forceId') = ?`,
+        ).run(now, forceId);
+      });
+
+      const deleteResult = repository.deleteForce(target.id!);
+
+      expect(deleteResult.success).toBe(true);
+      expect(forceRowExists(target.id!)).toBe(false);
+      // All 3 encounter slots NULL
+      expect(readEncounterPlayerForceJson('enc-p1')).toBeNull();
+      expect(readEncounterPlayerForceJson('enc-p2')).toBeNull();
+      expect(readEncounterOpponentForceJson('enc-o1')).toBeNull();
+    });
+
+    it('rolls back the force-row delete when the cascade hook throws', () => {
+      // Thrown hook → outer transaction rolls back, force row stays.
+      const target = repository.createForce({
+        name: 'Rollback Target',
+        forceType: ForceType.Lance,
+      });
+
+      insertEncounterWithForce({
+        id: 'enc-rollback',
+        forceId: target.id!,
+        slot: 'player',
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const cascade =
+        require('../ForceRepository.cascade') as typeof import('../ForceRepository.cascade');
+      cascade.setEncounterCascadeHook(() => {
+        throw new Error('Simulated cascade failure');
+      });
+
+      const deleteResult = repository.deleteForce(target.id!);
+
+      // Outer transaction caught the throw; result reports the error.
+      expect(deleteResult.success).toBe(false);
+      expect(deleteResult.error).toContain('Simulated cascade failure');
+
+      // Force row STILL present — atomic rollback held.
+      expect(forceRowExists(target.id!)).toBe(true);
+
+      // Encounter row also untouched — the hook threw before any UPDATE landed.
+      const ref = readEncounterPlayerForceJson('enc-rollback');
+      expect(ref).not.toBeNull();
+      expect(JSON.parse(ref!)).toMatchObject({ forceId: target.id });
+    });
+  });
+
+  // ===========================================================================
   // updateAssignment Tests
   // ===========================================================================
 
@@ -780,10 +1006,12 @@ describe('ForceRepository', () => {
     // Helper to create a test pilot in the database
     function createTestPilot(id: string): void {
       const db = getSQLiteService().getDatabase();
-      db.prepare(`
+      db.prepare(
+        `
         INSERT INTO pilots (id, name, gunnery, piloting, type, status, created_at, updated_at)
         VALUES (?, ?, 4, 5, 'persistent', 'active', datetime('now'), datetime('now'))
-      `).run(id, `Test Pilot ${id}`);
+      `,
+      ).run(id, `Test Pilot ${id}`);
     }
 
     it('should update pilot ID', () => {
@@ -972,10 +1200,12 @@ describe('ForceRepository', () => {
     // Helper to create a test pilot in the database
     function createSwapTestPilot(id: string): void {
       const db = getSQLiteService().getDatabase();
-      db.prepare(`
+      db.prepare(
+        `
         INSERT INTO pilots (id, name, gunnery, piloting, type, status, created_at, updated_at)
         VALUES (?, ?, 4, 5, 'persistent', 'active', datetime('now'), datetime('now'))
-      `).run(id, `Test Pilot ${id}`);
+      `,
+      ).run(id, `Test Pilot ${id}`);
     }
 
     it('should swap pilot and unit between two assignments', () => {
@@ -1092,10 +1322,12 @@ describe('ForceRepository', () => {
     // Helper to create a test pilot in the database
     function createClearTestPilot(id: string): void {
       const db = getSQLiteService().getDatabase();
-      db.prepare(`
+      db.prepare(
+        `
         INSERT INTO pilots (id, name, gunnery, piloting, type, status, created_at, updated_at)
         VALUES (?, ?, 4, 5, 'persistent', 'active', datetime('now'), datetime('now'))
-      `).run(id, `Test Pilot ${id}`);
+      `,
+      ).run(id, `Test Pilot ${id}`);
     }
 
     it('should clear pilot and unit from assignment', () => {

--- a/src/stores/__tests__/useEncounterStore.test.ts
+++ b/src/stores/__tests__/useEncounterStore.test.ts
@@ -1,0 +1,155 @@
+/**
+ * useEncounterStore — rawForceIds Slot Tests
+ *
+ * Pin the Phase D contract from `repair-broken-encounter-drafts` PR 2:
+ *   - `loadEncounters()` reads `data.rawForceIds` from the API response and
+ *     populates the store's `rawForceIds` slot.
+ *   - `getEncounterRawForceIds(id)` returns the entry or null if not loaded.
+ *   - Older server builds that omit `rawForceIds` from the GET response
+ *     leave the slot empty without crashing the loader.
+ *
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ *       (Requirement: Encounter List Surfaces Broken-Reference State)
+ */
+
+import { act, renderHook } from '@testing-library/react';
+
+import {
+  EncounterStatus,
+  ScenarioTemplateType,
+  TerrainPreset,
+  VictoryConditionType,
+  type IEncounter,
+} from '@/types/encounter';
+
+import { useEncounterStore } from '../useEncounterStore';
+
+// =============================================================================
+// Fetch mock
+// =============================================================================
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function mockFetchResponse(response: unknown, ok = true, status = 200): void {
+  mockFetch.mockResolvedValueOnce({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    json: async () => response,
+  });
+}
+
+function makeEncounter(id: string, name: string): IEncounter {
+  return {
+    id,
+    name,
+    status: EncounterStatus.Draft,
+    template: ScenarioTemplateType.Custom,
+    playerForce: undefined,
+    opponentForce: undefined,
+    opForConfig: undefined,
+    mapConfig: {
+      radius: 6,
+      terrain: TerrainPreset.Clear,
+      playerDeploymentZone: 'south',
+      opponentDeploymentZone: 'north',
+    },
+    victoryConditions: [{ type: VictoryConditionType.DestroyAll }],
+    optionalRules: [],
+    createdAt: '2026-04-01T00:00:00.000Z',
+    updatedAt: '2026-04-01T00:00:00.000Z',
+  };
+}
+
+// Reset store + fetch mocks between tests
+beforeEach(() => {
+  mockFetch.mockClear();
+  useEncounterStore.setState({
+    encounters: [],
+    rawForceIds: {},
+    selectedEncounterId: null,
+    isLoading: false,
+    error: null,
+    statusFilter: 'all',
+    searchQuery: '',
+    validations: new Map(),
+  });
+});
+
+// =============================================================================
+// Suite
+// =============================================================================
+
+describe('useEncounterStore — rawForceIds slot', () => {
+  it('populates rawForceIds from the API response on loadEncounters', async () => {
+    const enc1 = makeEncounter('enc-1', 'First');
+    const enc2 = makeEncounter('enc-2', 'Second');
+    mockFetchResponse({
+      encounters: [enc1, enc2],
+      count: 2,
+      rawForceIds: {
+        'enc-1': { playerForceId: 'force-A', opponentForceId: null },
+        'enc-2': { playerForceId: null, opponentForceId: 'force-B' },
+      },
+    });
+
+    const { result } = renderHook(() => useEncounterStore());
+    await act(async () => {
+      await result.current.loadEncounters();
+    });
+
+    expect(result.current.encounters).toHaveLength(2);
+    expect(result.current.rawForceIds).toEqual({
+      'enc-1': { playerForceId: 'force-A', opponentForceId: null },
+      'enc-2': { playerForceId: null, opponentForceId: 'force-B' },
+    });
+  });
+
+  it('getEncounterRawForceIds returns the matching entry after load', async () => {
+    const enc = makeEncounter('enc-X', 'Single');
+    mockFetchResponse({
+      encounters: [enc],
+      count: 1,
+      rawForceIds: {
+        'enc-X': { playerForceId: 'f-1', opponentForceId: 'f-2' },
+      },
+    });
+
+    const { result } = renderHook(() => useEncounterStore());
+    await act(async () => {
+      await result.current.loadEncounters();
+    });
+
+    expect(result.current.getEncounterRawForceIds('enc-X')).toEqual({
+      playerForceId: 'f-1',
+      opponentForceId: 'f-2',
+    });
+  });
+
+  it('getEncounterRawForceIds returns null for an unknown id', () => {
+    const { result } = renderHook(() => useEncounterStore());
+    expect(result.current.getEncounterRawForceIds('missing-id')).toBeNull();
+  });
+
+  it('falls back to empty rawForceIds when the API response omits the field', async () => {
+    // Server build prior to the PR 2 cutover may not return rawForceIds.
+    // The loader must default to {} so the list page degrades gracefully
+    // (broken-pill rendering simply no-ops, no crash on undefined access).
+    const enc = makeEncounter('enc-legacy', 'Legacy');
+    mockFetchResponse({
+      encounters: [enc],
+      count: 1,
+      // rawForceIds intentionally omitted
+    });
+
+    const { result } = renderHook(() => useEncounterStore());
+    await act(async () => {
+      await result.current.loadEncounters();
+    });
+
+    expect(result.current.encounters).toHaveLength(1);
+    expect(result.current.rawForceIds).toEqual({});
+    expect(result.current.getEncounterRawForceIds('enc-legacy')).toBeNull();
+  });
+});

--- a/src/stores/useEncounterStore.ts
+++ b/src/stores/useEncounterStore.ts
@@ -22,9 +22,26 @@ import {
 // API Response Types
 // =============================================================================
 
+/**
+ * Raw stored force-id strings keyed by encounter id, returned alongside the
+ * hydrated encounter array so the list page can detect broken-pill state
+ * without an extra round-trip.
+ *
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ *       (Requirement: Encounter List Surfaces Broken-Reference State)
+ */
+export type RawForceIdsByEncounterId = Record<
+  string,
+  {
+    readonly playerForceId: string | null;
+    readonly opponentForceId: string | null;
+  }
+>;
+
 interface ListEncountersResponse {
   encounters: IEncounter[];
   count: number;
+  rawForceIds?: RawForceIdsByEncounterId;
 }
 
 interface EncounterResponse {
@@ -57,6 +74,13 @@ interface ValidationResponse {
 interface EncounterStoreState {
   /** All loaded encounters */
   encounters: IEncounter[];
+  /**
+   * Raw stored force-id strings keyed by encounter id, populated from the
+   * `/api/encounters` GET response. Consumed by `getEncounterRawForceIds`
+   * + the `encounterBrokenRefs` helper for broken-pill detection on the
+   * list page.
+   */
+  rawForceIds: RawForceIdsByEncounterId;
   /** Currently selected encounter ID */
   selectedEncounterId: string | null;
   /** Loading state */
@@ -76,6 +100,15 @@ interface EncounterStoreActions {
   loadEncounters: () => Promise<void>;
   /** Get a single encounter by ID */
   getEncounter: (id: string) => IEncounter | undefined;
+  /**
+   * Get the raw stored force-id strings for an encounter. Returns null if
+   * the encounter id is unknown to the store (no entry in `rawForceIds`).
+   * Pair with `encounterBrokenRefs` to render broken-pill state.
+   */
+  getEncounterRawForceIds: (id: string) => {
+    playerForceId: string | null;
+    opponentForceId: string | null;
+  } | null;
   /** Create a new encounter */
   createEncounter: (input: ICreateEncounterInput) => Promise<string | null>;
   /** Update an encounter */
@@ -128,6 +161,7 @@ type EncounterStore = EncounterStoreState & EncounterStoreActions;
 export const useEncounterStore = create<EncounterStore>((set, get) => ({
   // State
   encounters: [],
+  rawForceIds: {},
   selectedEncounterId: null,
   isLoading: false,
   error: null,
@@ -144,7 +178,14 @@ export const useEncounterStore = create<EncounterStore>((set, get) => ({
         throw new Error('Failed to load encounters');
       }
       const data = (await response.json()) as ListEncountersResponse;
-      set({ encounters: data.encounters, isLoading: false });
+      // `rawForceIds` may be absent on older server builds; default to {}
+      // so list-page broken-pill detection cleanly falls back to "no
+      // missing refs" instead of crashing on undefined access.
+      set({
+        encounters: data.encounters,
+        rawForceIds: data.rawForceIds ?? {},
+        isLoading: false,
+      });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error';
       set({ error: message, isLoading: false });
@@ -154,6 +195,12 @@ export const useEncounterStore = create<EncounterStore>((set, get) => ({
   // Get an encounter by ID
   getEncounter: (id: string) => {
     return get().encounters.find((e) => e.id === id);
+  },
+
+  // Get raw stored force-id strings for the encounter. Used by the list
+  // page to feed `encounterBrokenRefs` for broken-pill rendering.
+  getEncounterRawForceIds: (id: string) => {
+    return get().rawForceIds[id] ?? null;
   },
 
   // Create a new encounter

--- a/src/types/encounter/EncounterInterfaces.ts
+++ b/src/types/encounter/EncounterInterfaces.ts
@@ -163,10 +163,24 @@ export interface IEncounter {
   readonly status: EncounterStatus;
   /** Scenario template used (if any) */
   readonly template?: ScenarioTemplateType;
-  /** Player force reference */
-  readonly playerForce?: IForceReference;
-  /** Opponent force (explicit) */
-  readonly opponentForce?: IForceReference;
+  /**
+   * Player force reference.
+   *
+   * `undefined` — no force was ever stored for this encounter.
+   * `null`      — a force was stored but the referenced row is gone.
+   *               The hydration boundary (`EncounterService.hydrateEncounter`)
+   *               sets this slot to `null` when the resolver returns null,
+   *               so downstream UI / helpers can distinguish "never set" from
+   *               "set but broken". See repair-broken-encounter-drafts.
+   */
+  readonly playerForce?: IForceReference | null;
+  /**
+   * Opponent force reference (explicit).
+   *
+   * Same null-vs-undefined distinction as `playerForce` — null means a stored
+   * ref no longer resolves, undefined means none was ever stored.
+   */
+  readonly opponentForce?: IForceReference | null;
   /** Opponent force config (for generation) */
   readonly opForConfig?: IOpForConfig;
   /** Map configuration */


### PR DESCRIPTION
## Summary

PR 2/3 of `repair-broken-encounter-drafts`. Closes the silent-orphan bug where a deleted force left dangling encounter references — encounters got stuck in Draft because `validateEncounter()` requires the force OBJECT (not just the id), and the silent failure was undetectable.

What ships:
- `clearForceReference(forceId)` in EncounterRepository — atomically NULLs both force-id slots across all matching encounters and recomputes status, transactionally.
- ForceRepository.deleteForce now runs the cascade hook BEFORE deleting the force row, all in one outer SQLite transaction (atomic rollback if cascade throws).
- EncounterService.hydrateEncounter sets dangling forces to null + dedup-warns instead of silently passing the broken ref through.
- `encounterBrokenRefs(encounter, rawForceIds)` pure predicate for UI broken-pill / repair-banner detection (used by PR 3).
- GET /api/encounters returns ` {encounters, count, rawForceIds}` map for the React store.
- useEncounterStore now caches rawForceIds + exposes `getEncounterRawForceIds(id)` selector.
- PR 1's cleanup script orphan branch is back-patched to repair via `clearForceReference` (orphaned encounters now appear in `repairedIds`, not just classified).

## Phase commits in this PR
- `e116e605` Phase A — cascade infrastructure (`ForceRepository.cascade.ts`, `clearForceReference`, `getEncounterWithRawIds`, `encounterBrokenRefs.ts`, IEncounter widening)
- `4936a79e` Phase B — wiring (`deleteForce` calls cascade hook BEFORE force-row delete; `hydrateEncounter` null-replaces + dedup-warns)
- `ed42cf4d` Phase C — API exposes `rawForceIds`
- `5b1a4764` Phase D — tests, store, cleanup back-patch (this commit)

Tests: 25 new tests across 4 new test files, 5 modified test files. 376/376 in-scope tests passing across 14 suites. One stale assertion fix in `EncounterService.test.ts` to match the new Phase B null-replacement contract (Phase E nit-fix folded into Phase D).

## Test plan

- [x] npm run typecheck clean
- [x] npm run lint 0 errors (4 pre-existing max-lines warnings)
- [x] oxfmt --check clean
- [x] In-scope jest suites green: encounterBrokenRefs (6/6), EncounterRepository.cascade (7/7), EncounterService.hydration (5/5), EncounterService (49/49), EncounterRepository (existing), ForceRepository (67 total: 64 existing + 3 cascade), encounters API (60 total), useEncounterStore (4/4), cleanup-broken-encounters (12/12)
- [ ] CI 15/15 green
- [ ] Manual: delete a force referenced by an encounter, observe encounter playerForce becomes null + status drops to Draft (PR 3 will surface the broken-pill UI)