### PR TITLE
feat(encounters): broken-pill + repair banner + seed empty-state (PR 3/3 repair-broken-encounter-drafts)

### DIFF
--- a/src/__tests__/api/encounters/seed-samples.test.ts
+++ b/src/__tests__/api/encounters/seed-samples.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Seed Sample Encounters API Tests
+ *
+ * Pin the contract for `POST /api/encounters/seed-samples`:
+ *  - Method allow-list: GET / PUT / DELETE / PATCH all 405.
+ *  - Successful seed: createEncounter called once per
+ *    ScenarioTemplateType (4 calls in Duel/Skirmish/Battle/Custom
+ *    order), names follow `Sample <Type> - <YYYY-MM-DD>` shape,
+ *    response is 200 + `{ success: true, ids: [4 strings] }`.
+ *  - Unique-name collision rolls back: a fake `createEncounter` mock
+ *    that fails on the third call causes the inner txn to throw,
+ *    handler responds 500 with the error message.
+ *  - DB init failure cleanly returns 500 instead of crashing the
+ *    Next.js worker.
+ *
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ *       (Requirement: Empty-State Seed Samples)
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import seedSamplesHandler from '@/pages/api/encounters/seed-samples';
+import { ScenarioTemplateType } from '@/types/encounter';
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+// `db.transaction(fn)` in production wraps `fn` in BEGIN/COMMIT and
+// returns a callable. For test purposes we synchronously invoke `fn`
+// and surface throws as ordinary exceptions — mirrors the SQLite
+// rollback path closely enough for the contract assertions.
+const mockDbTransaction = jest.fn(<T>(fn: (...args: unknown[]) => T) => {
+  return (...args: unknown[]) => fn(...args);
+});
+
+jest.mock('@/services/persistence/SQLiteService', () => ({
+  getSQLiteService: jest.fn(() => ({
+    initialize: jest.fn(),
+    getDatabase: jest.fn(() => ({ transaction: mockDbTransaction })),
+  })),
+}));
+
+const mockCreateEncounter = jest.fn();
+jest.mock('@/services/encounter/EncounterRepository', () => {
+  // Re-use the actual error code enum so this mock plays nicely with
+  // anything else in the same suite that might import it.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const actual = jest.requireActual<
+    typeof import('@/services/encounter/EncounterRepository')
+  >('@/services/encounter/EncounterRepository');
+  return {
+    ...actual,
+    getEncounterRepository: () => ({
+      createEncounter: mockCreateEncounter,
+    }),
+  };
+});
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+function createMockRequest(
+  overrides: Partial<NextApiRequest> = {},
+): NextApiRequest {
+  return {
+    method: 'POST',
+    query: {},
+    body: {},
+    headers: {},
+    ...overrides,
+  } as NextApiRequest;
+}
+
+interface MockNextApiResponse extends NextApiResponse {
+  status: jest.Mock;
+  json: jest.Mock;
+  setHeader: jest.Mock;
+}
+
+function createMockResponse(): MockNextApiResponse {
+  const res: Partial<MockNextApiResponse> = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+  };
+  return res as MockNextApiResponse;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('POST /api/encounters/seed-samples', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects non-POST methods with 405', async () => {
+    for (const method of ['GET', 'PUT', 'DELETE', 'PATCH'] as const) {
+      const req = createMockRequest({ method });
+      const res = createMockResponse();
+      await seedSamplesHandler(req, res);
+      expect(res.status).toHaveBeenCalledWith(405);
+      expect(res.setHeader).toHaveBeenCalledWith('Allow', ['POST']);
+    }
+  });
+
+  it('seeds 4 encounters in order and returns their ids', async () => {
+    // Each of the 4 createEncounter calls returns a distinct id.
+    mockCreateEncounter
+      .mockReturnValueOnce({ success: true, id: 'enc-1' })
+      .mockReturnValueOnce({ success: true, id: 'enc-2' })
+      .mockReturnValueOnce({ success: true, id: 'enc-3' })
+      .mockReturnValueOnce({ success: true, id: 'enc-4' });
+
+    const req = createMockRequest({ method: 'POST' });
+    const res = createMockResponse();
+
+    await seedSamplesHandler(req, res);
+
+    expect(mockCreateEncounter).toHaveBeenCalledTimes(4);
+    // Templates iterated in fixed order (Duel/Skirmish/Battle/Custom).
+    const calls = mockCreateEncounter.mock.calls.map((call) => call[0]);
+    expect(calls[0].template).toBe(ScenarioTemplateType.Duel);
+    expect(calls[1].template).toBe(ScenarioTemplateType.Skirmish);
+    expect(calls[2].template).toBe(ScenarioTemplateType.Battle);
+    expect(calls[3].template).toBe(ScenarioTemplateType.Custom);
+
+    // Names follow the date-suffix pattern.
+    for (const call of calls) {
+      expect(call.name).toMatch(
+        /^Sample (Duel|Skirmish|Battle|Custom) - \d{4}-\d{2}-\d{2}$/,
+      );
+    }
+
+    // All 4 names must be distinct so the unique-name constraint
+    // doesn't fire on a successful seed.
+    const names = new Set(calls.map((c) => c.name as string));
+    expect(names.size).toBe(4);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      ids: ['enc-1', 'enc-2', 'enc-3', 'enc-4'],
+    });
+  });
+
+  it('rolls back and returns 500 when a createEncounter call fails', async () => {
+    // First two succeed, third reports a unique-name collision.
+    mockCreateEncounter
+      .mockReturnValueOnce({ success: true, id: 'enc-1' })
+      .mockReturnValueOnce({ success: true, id: 'enc-2' })
+      .mockReturnValueOnce({
+        success: false,
+        error: 'UNIQUE constraint failed: encounters.name',
+      });
+
+    const req = createMockRequest({ method: 'POST' });
+    const res = createMockResponse();
+
+    await seedSamplesHandler(req, res);
+
+    // The handler does not retry on failure — it bubbles the error
+    // out of the txn so SQLite rolls back the previous successful
+    // inserts. The mock txn doesn't actually roll back (it's just a
+    // pass-through), so we assert on the response shape only.
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: 'UNIQUE constraint failed: encounters.name',
+    });
+    // Confirms the loop short-circuited at the failure — only 3 calls,
+    // the 4th template was never attempted.
+    expect(mockCreateEncounter).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns 500 when DB initialization throws', async () => {
+    const sqliteModule = jest.requireMock<{
+      getSQLiteService: jest.Mock;
+    }>('@/services/persistence/SQLiteService');
+    sqliteModule.getSQLiteService.mockImplementationOnce(() => ({
+      initialize: jest.fn(() => {
+        throw new Error('Database init failed');
+      }),
+      getDatabase: jest.fn(),
+    }));
+
+    const req = createMockRequest({ method: 'POST' });
+    const res = createMockResponse();
+
+    await seedSamplesHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: 'Database init failed',
+    });
+  });
+
+  it('handles repeated calls within the same day cleanly (collision is documented)', async () => {
+    // First seed succeeds.
+    mockCreateEncounter
+      .mockReturnValueOnce({ success: true, id: 'enc-1' })
+      .mockReturnValueOnce({ success: true, id: 'enc-2' })
+      .mockReturnValueOnce({ success: true, id: 'enc-3' })
+      .mockReturnValueOnce({ success: true, id: 'enc-4' });
+
+    let req = createMockRequest({ method: 'POST' });
+    let res = createMockResponse();
+    await seedSamplesHandler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+
+    // Second seed (same in-memory date) — first createEncounter call
+    // collides on the unique-name constraint.
+    mockCreateEncounter.mockReset();
+    mockCreateEncounter.mockReturnValueOnce({
+      success: false,
+      error: 'UNIQUE constraint failed: encounters.name',
+    });
+
+    req = createMockRequest({ method: 'POST' });
+    res = createMockResponse();
+    await seedSamplesHandler(req, res);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: 'UNIQUE constraint failed: encounters.name',
+    });
+  });
+});

--- a/src/__tests__/pages/gameplay/encounters/[id]/repair-banner.test.tsx
+++ b/src/__tests__/pages/gameplay/encounters/[id]/repair-banner.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * EncounterRepairBanner Tests
+ *
+ * Pin the PR3 detail-page banner contract:
+ *  - Banner renders when at least one side has a missing forceId.
+ *  - Banner stays hidden when neither side is broken.
+ *  - "Clear missing player force" routes through the store's
+ *    `clearPlayerForce(id)` action — which under the hood DELETEs
+ *    /api/encounters/[id]/player-force.
+ *  - "Clear missing opponent force" routes through the existing
+ *    `clearOpponentForce(id)` action.
+ *
+ * These tests target the banner component in isolation rather than
+ * the full detail page (which depends on a forces store, pilots
+ * store, validation flow, quick-resolve modal, etc). The full-page
+ * banner integration is covered by manual smoke + the test below
+ * that wires real `useEncounterStore` calls through fetch.
+ *
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ *       (Requirement: Encounter Detail Page Repair Banner)
+ */
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { EncounterRepairBanner } from '@/components/gameplay/pages/EncounterDetailPage.repairBanner';
+import { useEncounterStore } from '@/stores/useEncounterStore';
+
+// =============================================================================
+// Fetch Mock Setup
+// =============================================================================
+
+let fetchMock: jest.Mock;
+
+function setupFetchMock(): void {
+  fetchMock = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    // The store's clearPlayerForce / clearOpponentForce both DELETE,
+    // then call loadEncounters(). Stub all three with success
+    // responses so the action chain completes.
+    if (init?.method === 'DELETE') {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true }),
+      } as Response;
+    }
+    if (url === '/api/encounters' && (!init || init.method === undefined)) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ encounters: [], count: 0, rawForceIds: {} }),
+      } as Response;
+    }
+    throw new Error(`Unmocked fetch: ${init?.method ?? 'GET'} ${url}`);
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+}
+
+// =============================================================================
+// Setup
+// =============================================================================
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Reset store between tests so prior state doesn't leak.
+  useEncounterStore.setState({
+    encounters: [],
+    rawForceIds: {},
+    selectedEncounterId: null,
+    isLoading: false,
+    error: null,
+    statusFilter: 'all',
+    searchQuery: '',
+    validations: new Map(),
+  });
+  setupFetchMock();
+});
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('EncounterRepairBanner — render', () => {
+  it('renders nothing when both missing-id props are null', () => {
+    const { container } = render(
+      <EncounterRepairBanner
+        encounterId="enc-1"
+        missingPlayerForceId={null}
+        missingOpponentForceId={null}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the banner with player row only when player slot is broken', () => {
+    render(
+      <EncounterRepairBanner
+        encounterId="enc-1"
+        missingPlayerForceId="force-deleted-p"
+        missingOpponentForceId={null}
+      />,
+    );
+
+    expect(screen.getByTestId('encounter-repair-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('repair-banner-player')).toHaveTextContent(
+      'force-deleted-p',
+    );
+    expect(
+      screen.queryByTestId('repair-banner-opponent'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('clear-missing-player-force-btn'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders both rows when both slots are broken', () => {
+    render(
+      <EncounterRepairBanner
+        encounterId="enc-1"
+        missingPlayerForceId="force-deleted-p"
+        missingOpponentForceId="force-deleted-o"
+      />,
+    );
+
+    expect(screen.getByTestId('repair-banner-player')).toBeInTheDocument();
+    expect(screen.getByTestId('repair-banner-opponent')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('clear-missing-player-force-btn'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('clear-missing-opponent-force-btn'),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('EncounterRepairBanner — clear actions wire through to store', () => {
+  it('clicking "Clear missing player force" routes through DELETE /api/encounters/[id]/player-force', async () => {
+    render(
+      <EncounterRepairBanner
+        encounterId="enc-broken"
+        missingPlayerForceId="force-deleted-p"
+        missingOpponentForceId={null}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await act(async () => {
+      await user.click(screen.getByTestId('clear-missing-player-force-btn'));
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/encounters/enc-broken/player-force',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+
+  it('clicking "Clear missing opponent force" routes through DELETE /api/encounters/[id]/opponent-force', async () => {
+    render(
+      <EncounterRepairBanner
+        encounterId="enc-broken"
+        missingPlayerForceId={null}
+        missingOpponentForceId="force-deleted-o"
+      />,
+    );
+
+    const user = userEvent.setup();
+    await act(async () => {
+      await user.click(screen.getByTestId('clear-missing-opponent-force-btn'));
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/encounters/enc-broken/opponent-force',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+
+  it('shows "Clearing..." label while the request is in flight', async () => {
+    // Block the fetch so we can observe the in-flight UI state.
+    let resolveFetch: () => void = () => {};
+    fetchMock = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = () =>
+            resolve({
+              ok: true,
+              status: 200,
+              json: async () => ({ success: true }),
+            } as Response);
+        }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(
+      <EncounterRepairBanner
+        encounterId="enc-broken"
+        missingPlayerForceId="force-deleted-p"
+        missingOpponentForceId={null}
+      />,
+    );
+
+    const user = userEvent.setup();
+    // Fire the click but don't await it — the fetch is pending so the
+    // promise won't resolve until we explicitly call resolveFetch().
+    // We assert on the in-flight UI state, then resolve to drain the
+    // microtask queue.
+    const clickPromise = user.click(
+      screen.getByTestId('clear-missing-player-force-btn'),
+    );
+
+    // While the fetch is pending, the button should switch to the
+    // "Clearing..." label and become disabled.
+    await waitFor(() => {
+      const button = screen.getByTestId('clear-missing-player-force-btn');
+      expect(button).toHaveTextContent('Clearing...');
+      expect(button).toBeDisabled();
+    });
+
+    // Resolve the fetch + flush the click — wrapping the resolution in
+    // act keeps any post-resolution state transitions inside the act
+    // boundary so React doesn't log a warning.
+    await act(async () => {
+      resolveFetch();
+      await clickPromise;
+    });
+  });
+});

--- a/src/__tests__/pages/gameplay/encounters/index.test.tsx
+++ b/src/__tests__/pages/gameplay/encounters/index.test.tsx
@@ -1,0 +1,366 @@
+/**
+ * Encounter List Page Tests
+ *
+ * Pin the PR3 UI surfaces from `repair-broken-encounter-drafts`:
+ *  - Yellow "Player force missing" / "Opponent force missing" pills
+ *    render when the row's stored forceId no longer resolves (ie. the
+ *    rawForceIds map says a forceId was stored but `playerForce` /
+ *    `opponentForce` came back null at hydration).
+ *  - Empty-state shows BOTH "Create First Encounter" AND "Seed sample
+ *    encounters" buttons when no filter is active. Filtered empty
+ *    states (search query / status filter) hide the seed button so
+ *    the user doesn't accidentally double-seed when narrowing.
+ *  - Click on the seed button POSTs to /api/encounters/seed-samples,
+ *    then re-renders with the new encounter cards.
+ *
+ * Tests live under src/__tests__/pages/gameplay/encounters/ rather
+ * than co-located under src/pages/ so Next.js's TypeScript route
+ * validator doesn't treat them as broken API routes.
+ *
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ *       (Requirement: Encounter List Surfaces Broken-Reference State,
+ *        Requirement: Empty-State Seed Samples)
+ */
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import {
+  EncounterStatus,
+  ScenarioTemplateType,
+  TerrainPreset,
+  VictoryConditionType,
+  type IEncounter,
+} from '@/types/encounter';
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+// Stub `useRouter` so the page renders without a Next.js router stack.
+const mockRouterPush = jest.fn();
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    query: {},
+    pathname: '/gameplay/encounters',
+  }),
+}));
+
+// =============================================================================
+// Test Data
+// =============================================================================
+
+function makeEncounter(overrides: Partial<IEncounter> = {}): IEncounter {
+  return {
+    id: 'enc-1',
+    name: 'Test Encounter',
+    status: EncounterStatus.Draft,
+    template: ScenarioTemplateType.Custom,
+    playerForce: undefined,
+    opponentForce: undefined,
+    opForConfig: undefined,
+    mapConfig: {
+      radius: 6,
+      terrain: TerrainPreset.Clear,
+      playerDeploymentZone: 'south',
+      opponentDeploymentZone: 'north',
+    },
+    victoryConditions: [{ type: VictoryConditionType.DestroyAll }],
+    optionalRules: [],
+    createdAt: '2026-04-01T00:00:00.000Z',
+    updatedAt: '2026-04-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// Fetch Mock
+// =============================================================================
+
+interface ListPayload {
+  encounters: IEncounter[];
+  count: number;
+  rawForceIds: Record<
+    string,
+    { playerForceId: string | null; opponentForceId: string | null }
+  >;
+}
+
+function setupFetchMock(initialPayload: ListPayload): {
+  fetchMock: jest.Mock;
+  setNextPayload: (next: ListPayload) => void;
+} {
+  let currentPayload: ListPayload = initialPayload;
+  // Each fetch resolves with whatever currentPayload is at call time.
+  // setNextPayload mutates the shared reference so the next fetch
+  // (typically the post-seed refresh) sees the updated list.
+  const fetchMock = jest.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url === '/api/encounters' && (!init || init.method === undefined)) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => currentPayload,
+        } as Response;
+      }
+      if (url === '/api/encounters/seed-samples' && init?.method === 'POST') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            success: true,
+            ids: ['enc-d', 'enc-s', 'enc-b', 'enc-c'],
+          }),
+        } as Response;
+      }
+      throw new Error(`Unmocked fetch: ${init?.method ?? 'GET'} ${url}`);
+    },
+  );
+  global.fetch = fetchMock as unknown as typeof fetch;
+
+  return {
+    fetchMock,
+    setNextPayload: (next) => {
+      currentPayload = next;
+    },
+  };
+}
+
+// =============================================================================
+// Imports (after mocks)
+// =============================================================================
+
+import EncountersListPage from '@/pages/gameplay/encounters/index';
+import { useEncounterStore } from '@/stores/useEncounterStore';
+
+// =============================================================================
+// Render helper — flushes the mount-effect before returning.
+// =============================================================================
+
+async function renderPage(): Promise<ReturnType<typeof render>> {
+  let result: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(<EncountersListPage />);
+  });
+  return result!;
+}
+
+// =============================================================================
+// Setup
+// =============================================================================
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Reset Zustand store between tests so cached encounters / filters
+  // from one test don't bleed into the next.
+  useEncounterStore.setState({
+    encounters: [],
+    rawForceIds: {},
+    selectedEncounterId: null,
+    isLoading: false,
+    error: null,
+    statusFilter: 'all',
+    searchQuery: '',
+    validations: new Map(),
+  });
+});
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('EncountersListPage — broken pills', () => {
+  it('renders yellow "Player force missing" pill when rawForceIds says a forceId was stored but hydration came back null', async () => {
+    setupFetchMock({
+      encounters: [
+        makeEncounter({
+          id: 'enc-broken-player',
+          name: 'Broken Player Encounter',
+          // Hydration boundary set this to null because the resolver
+          // returned null for the stored forceId.
+          playerForce: null,
+        }),
+      ],
+      count: 1,
+      rawForceIds: {
+        'enc-broken-player': {
+          playerForceId: 'force-deleted-123',
+          opponentForceId: null,
+        },
+      },
+    });
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('encounter-card-enc-broken-player'),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId('encounter-card-player-missing'),
+    ).toHaveTextContent('Player force missing');
+    // The encounter has no opponent force at all, so we should NOT
+    // render an opponent-missing pill — that's the empty case.
+    expect(
+      screen.queryByTestId('encounter-card-opponent-missing'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders yellow "Opponent force missing" pill on the opponent side', async () => {
+    setupFetchMock({
+      encounters: [
+        makeEncounter({
+          id: 'enc-broken-opponent',
+          opponentForce: null,
+        }),
+      ],
+      count: 1,
+      rawForceIds: {
+        'enc-broken-opponent': {
+          playerForceId: null,
+          opponentForceId: 'force-deleted-456',
+        },
+      },
+    });
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('encounter-card-enc-broken-opponent'),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId('encounter-card-opponent-missing'),
+    ).toHaveTextContent('Opponent force missing');
+  });
+
+  it('does NOT render the missing pill when the slot is empty (never set)', async () => {
+    setupFetchMock({
+      encounters: [
+        makeEncounter({
+          id: 'enc-empty',
+          playerForce: undefined,
+          opponentForce: undefined,
+        }),
+      ],
+      count: 1,
+      rawForceIds: {
+        'enc-empty': { playerForceId: null, opponentForceId: null },
+      },
+    });
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('encounter-card-enc-empty'),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByTestId('encounter-card-player-missing'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('encounter-card-opponent-missing'),
+    ).not.toBeInTheDocument();
+    // The "No Player Force" silent-empty pill should still render in
+    // place of the missing-pill — the predicate is broken-not-empty.
+    expect(screen.getByText('No Player Force')).toBeInTheDocument();
+    expect(screen.getByText('No Opponent')).toBeInTheDocument();
+  });
+});
+
+describe('EncountersListPage — empty-state seed button', () => {
+  it('shows the seed button when filteredEncounters is empty AND no filter is active', async () => {
+    setupFetchMock({ encounters: [], count: 0, rawForceIds: {} });
+    await renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId('encounters-empty-state')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('seed-samples-btn')).toBeInTheDocument();
+    expect(screen.getByText('Create First Encounter')).toBeInTheDocument();
+  });
+
+  it('hides the seed button when a search query produces an empty result', async () => {
+    setupFetchMock({
+      encounters: [makeEncounter({ id: 'enc-1', name: 'Some Encounter' })],
+      count: 1,
+      rawForceIds: { 'enc-1': { playerForceId: null, opponentForceId: null } },
+    });
+    await renderPage();
+
+    // Apply a search query that won't match anything.
+    await act(async () => {
+      useEncounterStore.setState({ searchQuery: 'xyzNoMatch' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('encounters-empty-state')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('seed-samples-btn')).not.toBeInTheDocument();
+  });
+
+  it('hides the seed button when a status filter produces an empty result', async () => {
+    setupFetchMock({ encounters: [], count: 0, rawForceIds: {} });
+    await renderPage();
+    await act(async () => {
+      useEncounterStore.setState({ statusFilter: EncounterStatus.Ready });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('encounters-empty-state')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('seed-samples-btn')).not.toBeInTheDocument();
+  });
+
+  it('clicking the seed button POSTs to /api/encounters/seed-samples and refreshes the list', async () => {
+    const { fetchMock, setNextPayload } = setupFetchMock({
+      encounters: [],
+      count: 0,
+      rawForceIds: {},
+    });
+    await renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId('seed-samples-btn')).toBeInTheDocument();
+    });
+
+    // Prime the post-seed refresh response — once seed succeeds the
+    // store calls loadEncounters() again, which fetches /api/encounters
+    // and should now see 4 cards.
+    setNextPayload({
+      encounters: [
+        makeEncounter({ id: 'enc-d', name: 'Sample Duel - 2026-05-08' }),
+        makeEncounter({ id: 'enc-s', name: 'Sample Skirmish - 2026-05-08' }),
+        makeEncounter({ id: 'enc-b', name: 'Sample Battle - 2026-05-08' }),
+        makeEncounter({ id: 'enc-c', name: 'Sample Custom - 2026-05-08' }),
+      ],
+      count: 4,
+      rawForceIds: {},
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('seed-samples-btn'));
+
+    // The POST should fire with method:POST, then a follow-up GET.
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/encounters/seed-samples',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    // After refresh, all 4 cards should be on screen.
+    await waitFor(() => {
+      expect(screen.getByTestId('encounter-card-enc-d')).toBeInTheDocument();
+      expect(screen.getByTestId('encounter-card-enc-s')).toBeInTheDocument();
+      expect(screen.getByTestId('encounter-card-enc-b')).toBeInTheDocument();
+      expect(screen.getByTestId('encounter-card-enc-c')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/gameplay/encounters/EncounterCard.stories.tsx
+++ b/src/components/gameplay/encounters/EncounterCard.stories.tsx
@@ -1,0 +1,228 @@
+/**
+ * EncounterCard Storybook Stories
+ *
+ * Visual fixtures for every meaningful permutation of the encounter
+ * row pill block:
+ *   - `valid`         — both forces resolved, gray pills
+ *   - `no-player`     — empty player slot (yellow "No Player Force")
+ *   - `no-opponent`   — empty opponent slot, no opForConfig
+ *   - `opfor-config`  — empty opponent slot but `opForConfig` set
+ *   - `player-missing`    — broken player (yellow "Player force missing")
+ *   - `opponent-missing`  — broken opponent (yellow "Opponent force missing")
+ *   - `both-missing`      — both sides broken (the worst-case row a
+ *                           user might land on after a force purge)
+ *
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ *       (Requirement: Encounter List Surfaces Broken-Reference State)
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import {
+  EncounterStatus,
+  PilotSkillTemplate,
+  ScenarioTemplateType,
+  TerrainPreset,
+  VictoryConditionType,
+  type IEncounter,
+  type IForceReference,
+  type IOpForConfig,
+} from '@/types/encounter';
+
+import { EncounterCard } from './EncounterCard';
+
+// =============================================================================
+// Test fixtures
+// =============================================================================
+
+function makeEncounter(overrides: Partial<IEncounter> = {}): IEncounter {
+  return {
+    id: 'enc-story',
+    name: 'Sample Battle - 2026-05-08',
+    description:
+      'Lance vs lance skirmish on the Hesperus II ridge. Generated for the storybook fixture.',
+    status: EncounterStatus.Draft,
+    template: ScenarioTemplateType.Skirmish,
+    playerForce: undefined,
+    opponentForce: undefined,
+    opForConfig: undefined,
+    mapConfig: {
+      radius: 6,
+      terrain: TerrainPreset.Clear,
+      playerDeploymentZone: 'south',
+      opponentDeploymentZone: 'north',
+    },
+    victoryConditions: [{ type: VictoryConditionType.DestroyAll }],
+    optionalRules: [],
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-08T12:34:56.000Z',
+    ...overrides,
+  };
+}
+
+const PLAYER_REF: IForceReference = {
+  forceId: 'force-alpha-lance',
+  forceName: 'Alpha Lance',
+  totalBV: 5400,
+  unitCount: 4,
+};
+
+const OPPONENT_REF: IForceReference = {
+  forceId: 'force-clan-star',
+  forceName: 'Clan Smoke Jaguar Star',
+  totalBV: 5800,
+  unitCount: 4,
+};
+
+const OPFOR_CFG: IOpForConfig = {
+  targetBVPercent: 100,
+  pilotSkillTemplate: PilotSkillTemplate.Veteran,
+};
+
+// =============================================================================
+// Meta
+// =============================================================================
+
+const meta: Meta<typeof EncounterCard> = {
+  title: 'Gameplay/EncounterCard',
+  component: EncounterCard,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Single row on `/gameplay/encounters`. Renders broken-pill state when the encounter has a forceId stored on disk but the hydrated `playerForce`/`opponentForce` came back null (force was deleted).',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="w-96">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    onClick: () => {
+      // No-op in storybook — click is wired to router.push at the
+      // page level in production.
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EncounterCard>;
+
+// =============================================================================
+// Stories
+// =============================================================================
+
+export const Valid: Story = {
+  args: {
+    encounter: makeEncounter({
+      id: 'enc-valid',
+      name: 'Valid Encounter',
+      status: EncounterStatus.Ready,
+      playerForce: PLAYER_REF,
+      opponentForce: OPPONENT_REF,
+    }),
+    rawForceIds: {
+      playerForceId: PLAYER_REF.forceId,
+      opponentForceId: OPPONENT_REF.forceId,
+    },
+  },
+};
+
+export const NoPlayerForce: Story = {
+  args: {
+    encounter: makeEncounter({
+      id: 'enc-no-player',
+      name: 'Empty Player Slot',
+      playerForce: undefined,
+      opponentForce: OPPONENT_REF,
+    }),
+    rawForceIds: {
+      playerForceId: null,
+      opponentForceId: OPPONENT_REF.forceId,
+    },
+  },
+};
+
+export const NoOpponent: Story = {
+  args: {
+    encounter: makeEncounter({
+      id: 'enc-no-opp',
+      name: 'No Opponent Configured',
+      playerForce: PLAYER_REF,
+      opponentForce: undefined,
+      opForConfig: undefined,
+    }),
+    rawForceIds: {
+      playerForceId: PLAYER_REF.forceId,
+      opponentForceId: null,
+    },
+  },
+};
+
+export const OpforConfigured: Story = {
+  args: {
+    encounter: makeEncounter({
+      id: 'enc-opfor',
+      name: 'OpFor Generation Enabled',
+      playerForce: PLAYER_REF,
+      opponentForce: undefined,
+      opForConfig: OPFOR_CFG,
+    }),
+    rawForceIds: {
+      playerForceId: PLAYER_REF.forceId,
+      opponentForceId: null,
+    },
+  },
+};
+
+export const PlayerMissing: Story = {
+  args: {
+    encounter: makeEncounter({
+      id: 'enc-broken-p',
+      name: 'Player Force Was Deleted',
+      // null is the explicit "stored but unresolved" hydration signal.
+      playerForce: null,
+      opponentForce: OPPONENT_REF,
+    }),
+    rawForceIds: {
+      playerForceId: 'force-alpha-deleted',
+      opponentForceId: OPPONENT_REF.forceId,
+    },
+  },
+};
+
+export const OpponentMissing: Story = {
+  args: {
+    encounter: makeEncounter({
+      id: 'enc-broken-o',
+      name: 'Opponent Force Was Deleted',
+      playerForce: PLAYER_REF,
+      opponentForce: null,
+    }),
+    rawForceIds: {
+      playerForceId: PLAYER_REF.forceId,
+      opponentForceId: 'force-clan-deleted',
+    },
+  },
+};
+
+export const BothMissing: Story = {
+  args: {
+    encounter: makeEncounter({
+      id: 'enc-broken-both',
+      name: 'Both Forces Deleted',
+      playerForce: null,
+      opponentForce: null,
+    }),
+    rawForceIds: {
+      playerForceId: 'force-alpha-deleted',
+      opponentForceId: 'force-clan-deleted',
+    },
+  },
+};

--- a/src/components/gameplay/encounters/EncounterCard.tsx
+++ b/src/components/gameplay/encounters/EncounterCard.tsx
@@ -1,0 +1,149 @@
+/**
+ * EncounterCard
+ *
+ * One row on the encounter list page. Renders the encounter name, status,
+ * description, template, and a per-side pill for the player and opponent
+ * slot. Two pill flavours per side:
+ *
+ *  - "set + valid"     — gray pill with the force name (or `OpFor: Generated`
+ *                        for an opponent slot fed by `opForConfig`).
+ *  - "missing"         — yellow pill with `Player force missing` /
+ *                        `Opponent force missing` when the row stored a
+ *                        forceId but the hydrated reference came back null
+ *                        (the force was deleted out from under the row).
+ *  - "empty"           — yellow pill with `No Player Force` / `No Opponent`
+ *                        when the row never had a force in that slot.
+ *
+ * Broken-state detection runs through `encounterBrokenRefs(encounter,
+ * rawForceIds)` so this component shares the same predicate as the detail
+ * page repair banner. The page passes `rawForceIds` in from the store
+ * slot populated by `loadEncounters()`.
+ *
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ *       (Requirement: Encounter List Surfaces Broken-Reference State)
+ */
+
+import { Badge, Card } from '@/components/ui';
+import {
+  encounterBrokenRefs,
+  type IRawForceIds,
+} from '@/services/encounter/encounterBrokenRefs';
+import { IEncounter, SCENARIO_TEMPLATES } from '@/types/encounter';
+import { getStatusColor, getStatusLabel } from '@/utils/encounterStatus';
+
+export interface EncounterCardProps {
+  readonly encounter: IEncounter;
+  /**
+   * Raw stored force-id strings for this encounter. When `null` the card
+   * defaults to "no missing refs" — useful for callers (Storybook, older
+   * server builds) that don't have the rawForceIds payload.
+   */
+  readonly rawForceIds?: IRawForceIds | null;
+  readonly onClick: () => void;
+}
+
+const EMPTY_RAW_IDS: IRawForceIds = {
+  playerForceId: null,
+  opponentForceId: null,
+};
+
+export function EncounterCard({
+  encounter,
+  rawForceIds,
+  onClick,
+}: EncounterCardProps): React.ReactElement {
+  const template = encounter.template
+    ? SCENARIO_TEMPLATES.find((t) => t.type === encounter.template)
+    : null;
+
+  // Detect broken refs via the shared helper so the card and the detail
+  // page banner agree on the predicate. When rawForceIds is unavailable
+  // (legacy server, Storybook valid story) treat both sides as "not
+  // missing" — the helper still returns `false/false` for empty inputs.
+  const broken = encounterBrokenRefs(encounter, rawForceIds ?? EMPTY_RAW_IDS);
+
+  return (
+    <Card
+      className="hover:border-accent/50 cursor-pointer transition-all"
+      onClick={onClick}
+      data-testid={`encounter-card-${encounter.id}`}
+    >
+      <div className="mb-3 flex items-start justify-between">
+        <h3
+          className="text-text-theme-primary truncate font-medium"
+          data-testid="encounter-name"
+        >
+          {encounter.name}
+        </h3>
+        <Badge
+          variant={getStatusColor(encounter.status)}
+          data-testid="encounter-status"
+        >
+          {getStatusLabel(encounter.status)}
+        </Badge>
+      </div>
+
+      {encounter.description && (
+        <p className="text-text-theme-secondary mb-3 line-clamp-2 text-sm">
+          {encounter.description}
+        </p>
+      )}
+
+      {template && (
+        <div className="text-text-theme-muted mb-3 text-xs">
+          Template: {template.name}
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2 text-xs">
+        {/* Player slot — broken (yellow + "missing") wins over the empty
+            yellow pill, which itself wins over the gray "Set" pill. */}
+        {broken.playerForceMissing ? (
+          <span
+            className="rounded bg-yellow-900/20 px-2 py-1 text-yellow-400"
+            data-testid="encounter-card-player-missing"
+          >
+            Player force missing
+          </span>
+        ) : encounter.playerForce ? (
+          <span className="bg-surface-raised text-text-theme-secondary rounded px-2 py-1">
+            Player: {encounter.playerForce.forceName || 'Set'}
+          </span>
+        ) : (
+          <span className="rounded bg-yellow-900/20 px-2 py-1 text-yellow-400">
+            No Player Force
+          </span>
+        )}
+
+        {/* Opponent slot — same precedence: broken > set > opForConfig
+            generation > empty. */}
+        {broken.opponentForceMissing ? (
+          <span
+            className="rounded bg-yellow-900/20 px-2 py-1 text-yellow-400"
+            data-testid="encounter-card-opponent-missing"
+          >
+            Opponent force missing
+          </span>
+        ) : encounter.opponentForce ? (
+          <span className="bg-surface-raised text-text-theme-secondary rounded px-2 py-1">
+            Opponent: {encounter.opponentForce.forceName || 'Set'}
+          </span>
+        ) : encounter.opForConfig ? (
+          <span className="bg-surface-raised text-text-theme-secondary rounded px-2 py-1">
+            OpFor: Generated
+          </span>
+        ) : (
+          <span className="rounded bg-yellow-900/20 px-2 py-1 text-yellow-400">
+            No Opponent
+          </span>
+        )}
+      </div>
+
+      <div className="border-border-theme-subtle text-text-theme-muted mt-3 border-t pt-3 text-xs">
+        Updated: {new Date(encounter.updatedAt).toLocaleDateString()}
+      </div>
+    </Card>
+  );
+}
+
+export default EncounterCard;

--- a/src/components/gameplay/pages/EncounterDetailPage.repairBanner.tsx
+++ b/src/components/gameplay/pages/EncounterDetailPage.repairBanner.tsx
@@ -1,0 +1,145 @@
+/**
+ * Encounter Detail Page — Broken-Reference Repair Banner
+ *
+ * Renders above the existing form when either side of the encounter has
+ * a broken force reference (a forceId is stored on the row but the
+ * hydrated `playerForce`/`opponentForce` came back null because the
+ * referenced force was deleted).
+ *
+ * Per affected slot:
+ *  - One banner row with the broken-id called out by name.
+ *  - One "Clear missing X force" button that routes through the
+ *    relevant clear-action on `useEncounterStore`:
+ *      * Player slot   → `clearPlayerForce(id)` → DELETE
+ *                        `/api/encounters/[id]/player-force`
+ *      * Opponent slot → `clearOpponentForce(id)` (existing).
+ *  - After a successful click, the banner reloads the encounter list
+ *    so the cleared row's banner disappears (the hydrated encounter no
+ *    longer reports either side as missing).
+ *
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ *       (Requirement: Encounter Detail Page Repair Banner)
+ */
+
+import { useCallback, useState } from 'react';
+
+import { Button } from '@/components/ui';
+import { useEncounterSelector } from '@/stores/useEncounterStore';
+
+export interface EncounterRepairBannerProps {
+  readonly encounterId: string;
+  /** Stored player forceId — non-null when the slot is broken. */
+  readonly missingPlayerForceId: string | null;
+  /** Stored opponent forceId — non-null when the slot is broken. */
+  readonly missingOpponentForceId: string | null;
+}
+
+export function EncounterRepairBanner({
+  encounterId,
+  missingPlayerForceId,
+  missingOpponentForceId,
+}: EncounterRepairBannerProps): React.ReactElement | null {
+  const clearPlayerForce = useEncounterSelector(
+    (state) => state.clearPlayerForce,
+  );
+  const clearOpponentForce = useEncounterSelector(
+    (state) => state.clearOpponentForce,
+  );
+
+  // Per-side "in flight" flags so the operator can't double-click the
+  // same button while the DELETE is mid-air. Tracked independently
+  // because clearing one side does not block clearing the other.
+  const [isClearingPlayer, setIsClearingPlayer] = useState(false);
+  const [isClearingOpponent, setIsClearingOpponent] = useState(false);
+
+  const handleClearPlayer = useCallback(async () => {
+    setIsClearingPlayer(true);
+    try {
+      // The store action calls `loadEncounters()` on success, which
+      // refreshes the cached encounter — `playerForce` flips back to
+      // undefined and the banner condition no longer matches, so the
+      // banner unmounts on next render.
+      await clearPlayerForce(encounterId);
+    } finally {
+      setIsClearingPlayer(false);
+    }
+  }, [clearPlayerForce, encounterId]);
+
+  const handleClearOpponent = useCallback(async () => {
+    setIsClearingOpponent(true);
+    try {
+      await clearOpponentForce(encounterId);
+    } finally {
+      setIsClearingOpponent(false);
+    }
+  }, [clearOpponentForce, encounterId]);
+
+  // Render nothing when both sides are clean — keeps the banner from
+  // claiming vertical space on the detail page in the common case.
+  if (!missingPlayerForceId && !missingOpponentForceId) {
+    return null;
+  }
+
+  return (
+    <div
+      className="mb-6 rounded-lg border border-yellow-600/40 bg-yellow-900/20 p-4"
+      data-testid="encounter-repair-banner"
+      role="alert"
+    >
+      <h3 className="mb-2 text-sm font-semibold text-yellow-300">
+        Broken force reference
+      </h3>
+      <div className="flex flex-col gap-3">
+        {missingPlayerForceId && (
+          <div
+            className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+            data-testid="repair-banner-player"
+          >
+            <p className="text-sm text-yellow-200">
+              This encounter has a broken force reference. The force{' '}
+              <code className="rounded bg-yellow-900/40 px-1 py-0.5 text-xs">
+                {missingPlayerForceId}
+              </code>{' '}
+              was deleted.
+            </p>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleClearPlayer}
+              disabled={isClearingPlayer}
+              data-testid="clear-missing-player-force-btn"
+            >
+              {isClearingPlayer ? 'Clearing...' : 'Clear missing player force'}
+            </Button>
+          </div>
+        )}
+
+        {missingOpponentForceId && (
+          <div
+            className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+            data-testid="repair-banner-opponent"
+          >
+            <p className="text-sm text-yellow-200">
+              This encounter has a broken force reference. The force{' '}
+              <code className="rounded bg-yellow-900/40 px-1 py-0.5 text-xs">
+                {missingOpponentForceId}
+              </code>{' '}
+              was deleted.
+            </p>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleClearOpponent}
+              disabled={isClearingOpponent}
+              data-testid="clear-missing-opponent-force-btn"
+            >
+              {isClearingOpponent
+                ? 'Clearing...'
+                : 'Clear missing opponent force'}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/api/encounters/seed-samples.ts
+++ b/src/pages/api/encounters/seed-samples.ts
@@ -1,0 +1,141 @@
+/**
+ * Encounters API — Seed Sample Encounters
+ *
+ * `POST /api/encounters/seed-samples` — creates 4 starter encounters,
+ * one per `ScenarioTemplateType` enum value (Duel | Skirmish | Battle |
+ * Custom). Used by the empty-state CTA on `/gameplay/encounters` so a
+ * user landing on a freshly-cleaned list can populate it with realistic
+ * starter rows in a single click.
+ *
+ * Behaviour:
+ *  - Names are date-suffixed (`Sample <Type> - <YYYY-MM-DD>`) so a
+ *    same-day double-click hits SQLite's unique-name constraint and
+ *    triggers the rollback path. A next-day click succeeds because the
+ *    suffix changed.
+ *  - All 4 inserts run inside a SQLite `db.transaction(...)` so a
+ *    partial failure (e.g. unique-name collision on the 3rd insert)
+ *    rolls back the first two — the response is then 500 with the
+ *    underlying error message and the encounters table is unchanged.
+ *  - On success: 200 + `{ success: true, ids: [4 strings] }`.
+ *
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ *       (Requirement: Empty-State Seed Samples)
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { getEncounterRepository } from '@/services/encounter/EncounterRepository';
+import { getSQLiteService } from '@/services/persistence/SQLiteService';
+import { ScenarioTemplateType } from '@/types/encounter';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+type SuccessResponse = {
+  readonly success: true;
+  readonly ids: readonly string[];
+};
+
+type FailureResponse = {
+  readonly success: false;
+  readonly error: string;
+};
+
+// =============================================================================
+// Sample template list
+// =============================================================================
+
+/**
+ * Ordered list of templates to seed. Mirrors the four
+ * `ScenarioTemplateType` values defined at
+ * `src/types/encounter/EncounterInterfaces.ts:61-69`.
+ *
+ * Pin the order here (rather than `Object.values(ScenarioTemplateType)`)
+ * so the resulting list is deterministic regardless of TS enum-emit
+ * ordering — the test suite asserts ids in this order.
+ */
+const SAMPLE_TEMPLATES: ReadonlyArray<{
+  readonly type: ScenarioTemplateType;
+  readonly displayName: string;
+}> = [
+  { type: ScenarioTemplateType.Duel, displayName: 'Duel' },
+  { type: ScenarioTemplateType.Skirmish, displayName: 'Skirmish' },
+  { type: ScenarioTemplateType.Battle, displayName: 'Battle' },
+  { type: ScenarioTemplateType.Custom, displayName: 'Custom' },
+];
+
+/**
+ * `Sample <Type> - <YYYY-MM-DD>`. Date-suffixing avoids the unique-name
+ * constraint on a same-session re-click; same-day re-click still
+ * collides and triggers the rollback path (which is the documented
+ * "fail cleanly" behaviour).
+ */
+function buildSampleName(displayName: string, dateIso: string): string {
+  // ISO 8601 date prefix (`YYYY-MM-DD`) — slice off the time portion
+  // so we don't wedge unreadable timestamps into the encounter name.
+  const datePart = dateIso.slice(0, 10);
+  return `Sample ${displayName} - ${datePart}`;
+}
+
+// =============================================================================
+// Handler
+// =============================================================================
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<SuccessResponse | FailureResponse>,
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).json({
+      success: false,
+      error: `Method ${req.method ?? 'unknown'} Not Allowed`,
+    });
+  }
+
+  // DB init failure → 500 (matches sibling handlers under /api/encounters/*).
+  try {
+    getSQLiteService().initialize();
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Database initialization failed';
+    return res.status(500).json({ success: false, error: message });
+  }
+
+  const dateIso = new Date().toISOString();
+  const repo = getEncounterRepository();
+  const db = getSQLiteService().getDatabase();
+
+  // Atomic 4-insert: better-sqlite3's `db.transaction(fn)` returns a
+  // wrapped function that runs inside BEGIN/COMMIT, rolling back the
+  // entire batch if anything inside throws.
+  const txn = db.transaction((): readonly string[] => {
+    const ids: string[] = [];
+    for (const sample of SAMPLE_TEMPLATES) {
+      const name = buildSampleName(sample.displayName, dateIso);
+      const result = repo.createEncounter({ name, template: sample.type });
+      // `createEncounter` returns `{ success: false, error }` on a
+      // unique-name collision (or any other DB error). Throw here so the
+      // outer transaction rolls back the previous successful inserts.
+      if (!result.success || !result.id) {
+        throw new Error(
+          result.error ?? `Failed to seed sample encounter "${name}"`,
+        );
+      }
+      ids.push(result.id);
+    }
+    return ids;
+  });
+
+  try {
+    const ids = txn();
+    return res.status(200).json({ success: true, ids });
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Failed to seed sample encounters';
+    return res.status(500).json({ success: false, error: message });
+  }
+}

--- a/src/pages/gameplay/encounters/[id].tsx
+++ b/src/pages/gameplay/encounters/[id].tsx
@@ -21,6 +21,7 @@ import {
   EncounterActionsFooter,
   EncounterScenarioGeneratorSection,
 } from '@/components/gameplay/pages/EncounterDetailPage.actions';
+import { EncounterRepairBanner } from '@/components/gameplay/pages/EncounterDetailPage.repairBanner';
 import {
   EncounterBattleSettingsCard,
   EncounterDetailLoadingState,
@@ -32,6 +33,7 @@ import { buildPreparedBattleData } from '@/components/gameplay/pages/preBattleSe
 import { QuickResolveLauncher } from '@/components/gameplay/quickResolve/QuickResolveLauncher';
 import { useToast } from '@/components/shared/Toast';
 import { Badge, Button, PageLayout } from '@/components/ui';
+import { encounterBrokenRefs } from '@/services/encounter/encounterBrokenRefs';
 import { useEncounterSelector } from '@/stores/useEncounterStore';
 import { useForceSelector } from '@/stores/useForceStore';
 import { usePilotSelector } from '@/stores/usePilotStore';
@@ -45,6 +47,9 @@ export default function EncounterDetailPage(): React.ReactElement {
   const { showToast } = useToast();
 
   const getEncounter = useEncounterSelector((state) => state.getEncounter);
+  const getEncounterRawForceIds = useEncounterSelector(
+    (state) => state.getEncounterRawForceIds,
+  );
   const loadEncounters = useEncounterSelector((state) => state.loadEncounters);
   const deleteEncounter = useEncounterSelector(
     (state) => state.deleteEncounter,
@@ -231,6 +236,17 @@ export default function EncounterDetailPage(): React.ReactElement {
   const isLaunched = encounter.status === EncounterStatus.Launched;
   const isCompleted = encounter.status === EncounterStatus.Completed;
 
+  // Broken-reference detection — fed by the rawForceIds map populated
+  // alongside the hydrated encounter list on `loadEncounters()`. When the
+  // map has no entry for this id (older API build, race window before the
+  // first list load resolves) the helper falls back to "no broken refs"
+  // and the repair banner stays hidden.
+  const rawForceIds = getEncounterRawForceIds(encounterId);
+  const brokenRefs = encounterBrokenRefs(
+    encounter,
+    rawForceIds ?? { playerForceId: null, opponentForceId: null },
+  );
+
   const breadcrumbs = [
     { label: 'Home', href: '/' },
     { label: 'Gameplay', href: '/gameplay' },
@@ -293,6 +309,25 @@ export default function EncounterDetailPage(): React.ReactElement {
           <p className="text-sm text-red-400">{error}</p>
         </div>
       )}
+
+      {/* Repair banner — only renders when the encounter has at least
+          one broken force reference (a forceId stored on the row whose
+          hydrated lookup came back null). The shared
+          `encounterBrokenRefs` helper drives both this banner and the
+          list-page broken pill so the predicate stays consistent. */}
+      <EncounterRepairBanner
+        encounterId={encounterId}
+        missingPlayerForceId={
+          brokenRefs.playerForceMissing
+            ? (rawForceIds?.playerForceId ?? null)
+            : null
+        }
+        missingOpponentForceId={
+          brokenRefs.opponentForceMissing
+            ? (rawForceIds?.opponentForceId ?? null)
+            : null
+        }
+      />
 
       <EncounterValidationCard validation={validation} />
 

--- a/src/pages/gameplay/encounters/index.tsx
+++ b/src/pages/gameplay/encounters/index.tsx
@@ -4,9 +4,13 @@ import { useRouter } from 'next/router';
  * Browse, search, and manage encounter configurations.
  *
  * @spec openspec/changes/add-encounter-system/specs/encounter-system/spec.md
+ * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+ *       (Requirement: Encounter List Surfaces Broken-Reference State,
+ *        Requirement: Empty-State Seed Samples)
  */
 import { useEffect, useState, useCallback } from 'react';
 
+import { EncounterCard } from '@/components/gameplay/encounters/EncounterCard';
 import {
   PageLayout,
   PageLoading,
@@ -14,98 +18,10 @@ import {
   Input,
   Button,
   EmptyState,
-  Badge,
 } from '@/components/ui';
 import { useEncounterSelector } from '@/stores/useEncounterStore';
-import {
-  IEncounter,
-  EncounterStatus,
-  SCENARIO_TEMPLATES,
-} from '@/types/encounter';
-import { getStatusColor, getStatusLabel } from '@/utils/encounterStatus';
-
-// =============================================================================
-// Encounter Card Component
-// =============================================================================
-
-interface EncounterCardProps {
-  encounter: IEncounter;
-  onClick: () => void;
-}
-
-function EncounterCard({
-  encounter,
-  onClick,
-}: EncounterCardProps): React.ReactElement {
-  const template = encounter.template
-    ? SCENARIO_TEMPLATES.find((t) => t.type === encounter.template)
-    : null;
-
-  return (
-    <Card
-      className="hover:border-accent/50 cursor-pointer transition-all"
-      onClick={onClick}
-      data-testid={`encounter-card-${encounter.id}`}
-    >
-      <div className="mb-3 flex items-start justify-between">
-        <h3
-          className="text-text-theme-primary truncate font-medium"
-          data-testid="encounter-name"
-        >
-          {encounter.name}
-        </h3>
-        <Badge
-          variant={getStatusColor(encounter.status)}
-          data-testid="encounter-status"
-        >
-          {getStatusLabel(encounter.status)}
-        </Badge>
-      </div>
-
-      {encounter.description && (
-        <p className="text-text-theme-secondary mb-3 line-clamp-2 text-sm">
-          {encounter.description}
-        </p>
-      )}
-
-      {template && (
-        <div className="text-text-theme-muted mb-3 text-xs">
-          Template: {template.name}
-        </div>
-      )}
-
-      <div className="flex flex-wrap gap-2 text-xs">
-        {encounter.playerForce ? (
-          <span className="bg-surface-raised text-text-theme-secondary rounded px-2 py-1">
-            Player: {encounter.playerForce.forceName || 'Set'}
-          </span>
-        ) : (
-          <span className="rounded bg-yellow-900/20 px-2 py-1 text-yellow-400">
-            No Player Force
-          </span>
-        )}
-
-        {encounter.opponentForce ? (
-          <span className="bg-surface-raised text-text-theme-secondary rounded px-2 py-1">
-            Opponent: {encounter.opponentForce.forceName || 'Set'}
-          </span>
-        ) : encounter.opForConfig ? (
-          <span className="bg-surface-raised text-text-theme-secondary rounded px-2 py-1">
-            OpFor: Generated
-          </span>
-        ) : (
-          <span className="rounded bg-yellow-900/20 px-2 py-1 text-yellow-400">
-            No Opponent
-          </span>
-        )}
-      </div>
-
-      <div className="border-border-theme-subtle text-text-theme-muted mt-3 border-t pt-3 text-xs">
-        Updated: {new Date(encounter.updatedAt).toLocaleDateString()}
-      </div>
-    </Card>
-  );
-}
+import { IEncounter, EncounterStatus } from '@/types/encounter';
+import { getStatusLabel } from '@/utils/encounterStatus';
 
 // =============================================================================
 // Main Page Component
@@ -116,6 +32,9 @@ export default function EncountersListPage(): React.ReactElement {
   const isLoading = useEncounterSelector((state) => state.isLoading);
   const error = useEncounterSelector((state) => state.error);
   const loadEncounters = useEncounterSelector((state) => state.loadEncounters);
+  const seedSampleEncounters = useEncounterSelector(
+    (state) => state.seedSampleEncounters,
+  );
   const searchQuery = useEncounterSelector((state) => state.searchQuery);
   const setSearchQuery = useEncounterSelector((state) => state.setSearchQuery);
   const statusFilter = useEncounterSelector((state) => state.statusFilter);
@@ -125,12 +44,20 @@ export default function EncountersListPage(): React.ReactElement {
   const getFilteredEncounters = useEncounterSelector(
     (state) => state.getFilteredEncounters,
   );
+  const getEncounterRawForceIds = useEncounterSelector(
+    (state) => state.getEncounterRawForceIds,
+  );
   const selectEncounter = useEncounterSelector(
     (state) => state.selectEncounter,
   );
 
   const filteredEncounters = getFilteredEncounters();
   const [isInitialized, setIsInitialized] = useState(false);
+  // Local "seeding in progress" so we can disable the button while the
+  // POST round-trip resolves. Tracked here rather than the store because
+  // the loadEncounters() refresh inside the action already toggles
+  // `isLoading` and we don't want both spinners stacking.
+  const [isSeeding, setIsSeeding] = useState(false);
 
   // Load encounters on mount
   useEffect(() => {
@@ -154,6 +81,18 @@ export default function EncountersListPage(): React.ReactElement {
     router.push('/gameplay/encounters/create');
   }, [router]);
 
+  // Seed 4 sample encounters via the new POST /api/encounters/seed-samples
+  // route. The store action takes care of the refresh, so the click handler
+  // only manages the local "in flight" flag for the button disabled state.
+  const handleSeedSamples = useCallback(async () => {
+    setIsSeeding(true);
+    try {
+      await seedSampleEncounters();
+    } finally {
+      setIsSeeding(false);
+    }
+  }, [seedSampleEncounters]);
+
   // Navigate to encounter detail
   const handleEncounterClick = useCallback(
     (encounter: IEncounter) => {
@@ -166,6 +105,13 @@ export default function EncountersListPage(): React.ReactElement {
   if (!isInitialized || isLoading) {
     return <PageLoading message="Loading encounters..." />;
   }
+
+  // Truly-empty (no filter, no search) is the only state where seeding
+  // makes sense. A filtered empty state still has encounters in the DB
+  // and the user is just narrowing — adding 4 starter encounters there
+  // would be confusing.
+  const isTrulyEmpty =
+    filteredEncounters.length === 0 && !searchQuery && statusFilter === 'all';
 
   return (
     <PageLayout
@@ -286,11 +232,21 @@ export default function EncountersListPage(): React.ReactElement {
               : 'Create an encounter to set up a battle scenario'
           }
           action={
-            !(searchQuery || statusFilter !== 'all') && (
-              <Button variant="primary" onClick={handleCreateEncounter}>
-                Create First Encounter
-              </Button>
-            )
+            isTrulyEmpty ? (
+              <div className="flex flex-wrap items-center justify-center gap-3">
+                <Button variant="primary" onClick={handleCreateEncounter}>
+                  Create First Encounter
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={handleSeedSamples}
+                  disabled={isSeeding}
+                  data-testid="seed-samples-btn"
+                >
+                  {isSeeding ? 'Seeding...' : 'Seed sample encounters'}
+                </Button>
+              </div>
+            ) : null
           }
         />
       ) : (
@@ -299,6 +255,7 @@ export default function EncountersListPage(): React.ReactElement {
             <EncounterCard
               key={encounter.id}
               encounter={encounter}
+              rawForceIds={getEncounterRawForceIds(encounter.id)}
               onClick={() => handleEncounterClick(encounter)}
             />
           ))}

--- a/src/stores/useEncounterStore.ts
+++ b/src/stores/useEncounterStore.ts
@@ -57,6 +57,12 @@ interface LaunchResponse {
   error?: string;
 }
 
+interface SeedSamplesResponse {
+  success: boolean;
+  ids?: readonly string[];
+  error?: string;
+}
+
 interface LaunchEncounterOptions {
   readonly campaignId?: string | null;
   readonly contractId?: string | null;
@@ -124,10 +130,32 @@ interface EncounterStoreActions {
   getSelectedEncounter: () => IEncounter | null;
   /** Set player force */
   setPlayerForce: (encounterId: string, forceId: string) => Promise<boolean>;
+  /**
+   * Clear the player force on an encounter. Routes through the existing
+   * `DELETE /api/encounters/[id]/player-force` endpoint — used by the
+   * detail-page repair banner when the operator confirms the broken
+   * reference should be cleared.
+   *
+   * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+   *       (Requirement: Encounter Detail Page Repair Banner)
+   */
+  clearPlayerForce: (encounterId: string) => Promise<boolean>;
   /** Set opponent force */
   setOpponentForce: (encounterId: string, forceId: string) => Promise<boolean>;
   /** Clear opponent force */
   clearOpponentForce: (encounterId: string) => Promise<boolean>;
+  /**
+   * POST `/api/encounters/seed-samples` — creates 4 starter encounters,
+   * one per `ScenarioTemplateType` value (Duel/Skirmish/Battle/Custom),
+   * then refreshes the local list. Used by the empty-state seed button.
+   *
+   * Returns the array of newly-created ids on success, `null` on failure
+   * (with `error` populated on the store).
+   *
+   * @spec openspec/changes/repair-broken-encounter-drafts/specs/game-session-management/spec.md
+   *       (Requirement: Empty-State Seed Samples)
+   */
+  seedSampleEncounters: () => Promise<readonly string[] | null>;
   /** Apply a template */
   applyTemplate: (
     encounterId: string,
@@ -323,6 +351,37 @@ export const useEncounterStore = create<EncounterStore>((set, get) => ({
     }
   },
 
+  // Clear player force — DELETE /api/encounters/[id]/player-force.
+  // The server-side handler updates the encounter with
+  // `playerForceId: undefined`, which collapses to NULL in storage and
+  // re-runs `recalculateStatus` so a previously-Ready encounter drops
+  // back to Draft. Used by the detail-page repair banner.
+  clearPlayerForce: async (encounterId: string) => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await fetch(
+        `/api/encounters/${encounterId}/player-force`,
+        {
+          method: 'DELETE',
+        },
+      );
+      const data = (await response.json()) as EncounterResponse;
+      if (!data.success) {
+        set({
+          error: data.error ?? 'Failed to clear player force',
+          isLoading: false,
+        });
+        return false;
+      }
+      await get().loadEncounters();
+      return true;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      set({ error: message, isLoading: false });
+      return false;
+    }
+  },
+
   // Set opponent force
   setOpponentForce: async (encounterId: string, forceId: string) => {
     set({ isLoading: true, error: null });
@@ -376,6 +435,34 @@ export const useEncounterStore = create<EncounterStore>((set, get) => ({
       const message = err instanceof Error ? err.message : 'Unknown error';
       set({ error: message, isLoading: false });
       return false;
+    }
+  },
+
+  // Seed 4 sample encounters via POST /api/encounters/seed-samples.
+  // The route creates one encounter per ScenarioTemplateType value
+  // (Duel/Skirmish/Battle/Custom), then we refresh the local list so
+  // the empty state flips to a populated grid.
+  seedSampleEncounters: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await fetch('/api/encounters/seed-samples', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const data = (await response.json()) as SeedSamplesResponse;
+      if (!data.success || !data.ids) {
+        set({
+          error: data.error ?? 'Failed to seed sample encounters',
+          isLoading: false,
+        });
+        return null;
+      }
+      await get().loadEncounters();
+      return data.ids;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      set({ error: message, isLoading: false });
+      return null;
     }
   },
 


### PR DESCRIPTION
## Summary

PR 3/3 of `repair-broken-encounter-drafts`. Closes the user-facing piece of the silent-orphan story:

- **Broken pills** on the encounter list — when an encounter's stored forceId points at a deleted force, render a yellow "Player force missing" / "Opponent force missing" pill instead of a silent empty pill.
- **Repair banner** on the detail page — clear-out buttons per affected slot. "Player" routes through the existing DELETE endpoint, "Opponent" uses `clearOpponentForce`. Click → reload, slot becomes a true empty selector again.
- **Seed empty-state** — when the encounter list is truly empty (no filter, no search), show a "Seed sample encounters" button next to "Create First Encounter". POSTs to a new `/api/encounters/seed-samples` route that creates 4 encounters (one per ScenarioTemplateType: Duel/Skirmish/Battle/Custom) with date-suffixed names.

Tests: 18 new tests across 3 new test files + 7 new EncounterCard storybook stories.

## Files

Production:
- `src/components/gameplay/encounters/EncounterCard.tsx` — extracted card with broken-pill rendering
- `src/components/gameplay/pages/EncounterDetailPage.repairBanner.tsx` — new repair banner
- `src/pages/api/encounters/seed-samples.ts` — new POST endpoint
- `src/pages/gameplay/encounters/index.tsx` — wires card + seed CTA
- `src/pages/gameplay/encounters/[id].tsx` — wires repair banner
- `src/stores/useEncounterStore.ts` — adds `clearPlayerForce` + `seedSampleEncounters`

Tests + stories:
- `src/__tests__/api/encounters/seed-samples.test.ts` (5 tests)
- `src/__tests__/pages/gameplay/encounters/index.test.tsx` (7 tests)
- `src/__tests__/pages/gameplay/encounters/[id]/repair-banner.test.tsx` (6 tests)
- `src/components/gameplay/encounters/EncounterCard.stories.tsx` (7 stories)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` 0 errors (47 pre-existing warnings, no new violations)
- [x] `npm run format:check` clean
- [x] `npx jest src/__tests__/pages/gameplay/encounters src/__tests__/api/encounters src/stores src/services/encounter` — 868/868 tests passing across 38 suites
- [x] `npm run storybook:build` clean
- [ ] CI 15/15 green
- [ ] Manual: list with broken encounters shows pills; detail page renders banner; click clear → encounter resets to Draft + clean slot; empty state seed button creates 4 encounters; second click on the same date doesn't double-fire (idempotent — 500 with rollback)

## Decisions worth flagging

- **Card moved out of `src/pages/`** — initial drop at `src/pages/gameplay/encounters/EncounterCard.tsx` exploded the pre-commit `next build` because Next.js's TypeScript route validator treats every `.tsx` under `src/pages/` as a page route. Final location: `src/components/gameplay/encounters/EncounterCard.tsx`.
- **No server-side widening of `setPlayerForce`** — instead added `clearPlayerForce(id)` to the store that DELETEs through the existing `/api/encounters/[id]/player-force` route. The PR1 notepad called for widening the handler; on second look the existing DELETE already does the same job, so the cheaper path keeps the API minimal.
- **Same-day re-seed is documented as fail-cleanly** — names are date-suffixed (`Sample <Type> - <YYYY-MM-DD>`), so a same-day double-click hits the `UNIQUE constraint` on `encounters.name` and the SQLite `db.transaction` rolls back. Response is 500 with the underlying error. Day-over-day re-clicks succeed.
