### PR TITLE
chore(openspec): archive repair-broken-encounter-drafts + stage link-encounters-to-replays

### DIFF
--- a/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/design.md
+++ b/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/design.md
@@ -1,0 +1,159 @@
+# Design: Repair Broken Encounter Drafts
+
+## Technical approach
+
+Three coupled fixes, ordered so each is shippable on its own and the next builds on the previous:
+
+1. **Cleanup-first** — write a script that classifies every encounter row and emits a JSON manifest BEFORE deleting anything. Run it once against the user's machine, archive the manifest, then delete the abandoned set. Reversible: the manifest contains the full pre-deletion state of every dropped row, so a developer can reconstruct the SQL to undo if a row was wrongly classified.
+2. **Cascade-second** — wire `ForceRepository.deleteForce()` to also clear references in the `encounters` table within the same SQLite transaction. Idempotent: a force that has already been deleted (or has no encounter references) cleans up zero rows, no error.
+3. **UI-third** — surface the broken state visibly. The list page gets a yellow "Force missing" pill where the silent empty-name pill is today; the detail page gets a banner that explains the situation and offers a one-click clear; the empty-state gets a "Seed samples" button so a new user post-cleanup can get to a working scenario in one click.
+
+The cleanup is one-time + manual (operator runs it). The cascade is permanent + automatic (future force deletions are clean by construction). The UI is the safety net for the gap between a force being deleted and the cascade running — and for any future drift.
+
+## Architecture decisions
+
+### Decision: One-time cleanup + permanent cascade, NOT migration-only
+
+**Choice**: Two artifacts — a one-time script (idempotent, classification-first, JSON-logged) AND a permanent cascade rule on `deleteForce`.
+
+**Rationale**: A single migration script would clean up the existing 27 rows but wouldn't prevent the next 27. The user is actively iterating on forces (Cluster E IPerson hard-cutover landed `IPilot` deletions, `wire-encounter-to-campaign-round-trip` lifecycle is in flight), so the failure mode is going to keep recurring. The cascade is the prevention; the cleanup is the one-time recovery. Both are needed.
+
+**Alternatives considered**:
+
+- **Cleanup script only** — leaves the prevention gap; the user files this same OpenSpec change again in two weeks.
+- **Cascade only** — doesn't help the existing 27 rows because they were created before the cascade existed.
+- **Soft-delete forces (set `deleted_at` instead of DELETE)** — bigger refactor; touches force lifecycle semantics; not needed for the bug we're fixing.
+
+### Decision: Classification-first, manifest-before-delete
+
+**Choice**: The cleanup script reads every encounter, classifies it, writes the full manifest (every row, every classification, every reason) to `simulation-reports/cleanup-encounters-<ISO>.json`, THEN deletes. The user can read the file before re-running with a `--commit` flag if we want a two-phase mode — but v1 keeps it single-phase + reversible-via-log.
+
+**Rationale**: The user MUST be able to look at the JSON file and see exactly what got deleted and why. Per the change brief: "the cleanup migration MUST be reversible (or at minimum MUST log every deletion to a file)." We choose log-as-receipt. Each entry contains: `id`, `name`, `description`, `status`, `playerForce`, `opponentForce`, `opForConfig`, `victoryConditions`, `mapConfig`, `createdAt`, `updatedAt`, `classification`, `classificationReason` — i.e. the full encounter row plus the verdict. Restoring is a SQL INSERT with the JSON values.
+
+**Alternatives considered**:
+
+- **Two-phase: dry-run + commit** — overkill for a one-time cleanup; the JSON manifest is easier to inspect than a dry-run console dump.
+- **Soft-delete instead of hard-delete** — adds a `deleted_at` column to the encounters table; the user can restore via SQL. Considered; rejected because: (a) would require schema migration, (b) the JSON log already provides reversibility, (c) keeping the encounters table free of soft-delete semantics keeps `getAllEncounters()` queries simple.
+
+### Decision: Cascade on `deleteForce`, NOT on hydration
+
+**Choice**: The cascade lives in `ForceRepository.deleteForce()` — when a force is deleted, the encounters table is updated in the same transaction. `hydrateEncounter()` ALSO replaces unresolvable refs with `null` as a defensive secondary, but the cascade is the source-of-truth fix.
+
+**Rationale**: Cleaning at write-time (delete) is one transaction, observable, and prevents the dangling state from existing on disk. Cleaning at read-time (hydration) requires every read path to do the orphan check forever, performance-wise it adds a `getForceById` per encounter row on the list page (already present, good), but it doesn't fix the database — the dangling JSON sits there until something hydrates and writes the encounter. The hydration replacement is the secondary safety net for any drift that escapes the cascade (e.g. raw SQL inserts, future bugs in `deleteForce`).
+
+**Alternatives considered**:
+
+- **Hydration-only repair** — leaves the database dirty; complicates every future query; performance penalty on every list-page render.
+- **Defer cascade to a nightly job** — encounters look broken between the force-delete and the next cron tick; users get a confused state window. Inline cascade is simpler.
+- **SQLite foreign-key constraints** — would require a schema migration to add explicit FK columns (the current schema stores forces as embedded JSON, not as proper FKs). Out of scope; the cascade rule covers the same ground without a schema change.
+
+### Decision: "Force missing" badge in the existing yellow-pill slot, not a new column
+
+**Choice**: The list-row UI already has a yellow pill for "No Player Force" / "No Opponent". We extend the same component to render "Player force missing" / "Opponent force missing" when the hydrated ref has an empty `forceName` (the hydration-miss signal). Same visual treatment, different text.
+
+**Rationale**: Visual real-estate is tight on the encounter card; users already scan the yellow pills as the warning slot. Reusing that slot avoids adding a new column and keeps the discriminator simple: `playerForce === null` → "No Player Force"; `playerForce` exists with empty `forceName` → "Player force missing"; `playerForce` exists with non-empty `forceName` → green pill with name. Adding a third state to a known affordance is cheaper than adding a new affordance.
+
+**Alternatives considered**:
+
+- **Dedicated "broken" status row in the status filter** — the status filter is an enum (`Draft | Ready | Launched | Completed`); shoehorning a non-status into it confuses the data model. Encounters with missing forces should still classify as `Draft` (which they will, after the cascade + recalc).
+- **Toast notification on list mount** — disrupts the page; not addressable; can't tell which encounter is broken.
+
+### Decision: Hydration-boundary orphan replacement returns `null`, not the empty-name ref
+
+**Choice**: Inside `hydrateEncounter()`, when `getForceById` returns null, the hydrated `playerForce` / `opponentForce` field is set to `null` — not left as the original embedded ref with empty name. The ref-with-empty-name is the buggy intermediate state today and we replace it with the explicit absence signal.
+
+**Rationale**: The "broken" pill in the UI keys off "ref exists but `forceName` is empty" today. After hydration is fixed, the hydrated value will be `null`, and the pill is detected by reading the `__broken` flag we add to the IEncounter shape OR by the list page calling a new helper `encounterBrokenRefs(encounter)` that compares the stored row's `forceId`s against the hydrated values. We choose the helper approach to keep IEncounter clean.
+
+The helper signature: `encounterBrokenRefs(encounter: IEncounter): { playerForceMissing: boolean; opponentForceMissing: boolean }`. It needs access to the raw row (to know if a `forceId` was stored) AND the hydrated value (to know if it resolved). Implementation: the repository's `rowToEncounter` exposes the raw `playerForceId` / `opponentForceId` separately on a sibling field `__rawForceIds: { playerForceId: string | null; opponentForceId: string | null }` that the UI consumes.
+
+**Alternatives considered**:
+
+- **Add `playerForceBroken: boolean` to IEncounter** — leaks repository-internal concerns into the type. The helper is cleaner.
+- **Throw on hydration miss** — breaks every callsite that reads encounters; the UX gets worse, not better.
+
+### Decision: Empty-state seed action, NOT auto-seed-on-empty-DB
+
+**Choice**: When the list page is empty after filtering, render a "Seed sample encounters" button alongside "Create First Encounter". Click → calls `POST /api/encounters/seed-samples` → creates 4 encounters using `SCENARIO_TEMPLATES` (Duel / Skirmish / Battle / Custom). Manual; explicit; clearly labeled "samples"; user can delete them.
+
+**Rationale**: Auto-seeding on first DB open conflicts with developer workflows (fresh test DBs need to stay empty). An explicit button keeps the user in control. The 4-template seed gives the user a working scenario shape to copy from — they're not configured with forces (we'd need to invent forces too) but they have valid map / victory conditions / template metadata, so the user immediately has something they can fill in.
+
+**Alternatives considered**:
+
+- **Auto-seed on first run** — surprises developers running fresh test DBs.
+- **No seed action** — leaves the post-cleanup empty-state as the same "create from scratch" flow that the user just walked away from on 27 drafts. The seed button is the "I want a starting point" shortcut.
+- **Seed includes player+opponent forces** — would need to also seed forces, which means seeding pilots, which means seeding units. Way out of scope. Templates only.
+
+## Data flow
+
+**Today (broken):**
+
+```
+deleteForce(F)
+   └→ DELETE FROM forces WHERE id = F
+   └→ encounters.player_force_json STILL contains {forceId: F, ...}
+   └→ next read: hydrateEncounter -> getForceById(F) -> null -> ref left as-is
+   └→ next launch: buildGameUnitsFromEncounter -> getForceById(F) -> null -> ERROR
+```
+
+**After this change:**
+
+```
+deleteForce(F)
+   └→ BEGIN TXN
+      └→ DELETE FROM forces WHERE id = F
+      └→ UPDATE encounters SET player_force_json = NULL WHERE
+              player_force_json IS NOT NULL
+              AND json_extract(player_force_json, '$.forceId') = F
+      └→ UPDATE encounters SET opponent_force_json = NULL WHERE
+              opponent_force_json IS NOT NULL
+              AND json_extract(opponent_force_json, '$.forceId') = F
+      └→ for each affected encounter id: recalculateStatus(id)
+   └→ COMMIT
+```
+
+The recalculate inside the same transaction means an affected encounter that had been Ready drops to Draft atomically with the force delete.
+
+## File changes
+
+- **NEW**: `scripts/cleanup-broken-encounters.ts` — Node script using `tsx` runner. Reads every encounter via `getEncounterRepository().getAllEncounters()`, classifies, writes manifest, deletes abandoned. Has CLI flags `--manifest-only` (skip deletes) and `--cwd <path>` (test injection).
+- **NEW**: `src/services/encounter/encounterBrokenRefs.ts` — pure helper exporting `encounterBrokenRefs(encounter, rawForceIds)` returning `{ playerForceMissing, opponentForceMissing }`.
+- **NEW**: `src/pages/api/encounters/seed-samples.ts` — `POST` handler creating 4 template-derived encounters in a single transaction; returns `{ success: true, ids: [4 ids] }`.
+- **MODIFIED**: `src/services/forces/ForceRepository.ts` — `deleteForce` wraps existing logic in a SQLite transaction and adds the encounters-table cascade UPDATE statements + per-affected-encounter `recalculateStatus` call (delegated to the encounter repo via a callback to avoid hard import coupling — the force repo accepts an optional `onForceDeleted: (forceId: string) => void` injected at construction time, default a no-op; the encounter repo subscribes via a singleton wiring step).
+- **MODIFIED**: `src/services/encounter/EncounterService.ts:415-452` — `hydrateEncounter` returns `playerForce: null` when `getForceById` returns null AND emits `logger.warn` once per missing force (no spamming on every read — uses a Set keyed on the encounter id + force id, reset on next process boot). Returns the same shape; consumers that read `encounter.playerForce?.forceName` already null-check via the optional chain.
+- **MODIFIED**: `src/services/encounter/EncounterRepository.ts` — adds `clearForceReference(forceId: string): { affectedEncounterIds: readonly string[] }` method that performs the JSON-extract UPDATE statements and triggers `recalculateStatus` for each affected encounter. Used by the cascade wiring.
+- **MODIFIED**: `src/pages/gameplay/encounters/index.tsx` — list page renders the new "Force missing" yellow pill when `encounterBrokenRefs(...)` returns true; empty-state gets the "Seed sample encounters" button when the list is empty AND no filters/search are active.
+- **MODIFIED**: `src/pages/gameplay/encounters/[id].tsx` — when the loaded encounter has `playerForceMissing` or `opponentForceMissing`, render a banner above the form with a "Clear missing force" button per missing side. Click calls `setPlayerForce(null)` / `clearOpponentForce()` via the existing store actions.
+
+## Test strategy
+
+- **Cleanup script** (`scripts/__tests__/cleanup-broken-encounters.test.ts`) — fixture DB with 5 encounters: 2 abandoned-empty (no playerForceId, no opponentForceId, no opForConfig), 2 orphaned (forceId stored but force deleted), 1 still-valid. Assert: classification matches, manifest contains all 5 entries, only the 2 abandoned-empty get deleted, re-running on the now-3-row DB writes a no-op manifest and deletes nothing.
+- **Cascade** (`src/services/forces/__tests__/ForceRepository.cascade.test.ts`) — create force F, create encounter E referencing F as player force, delete F, assert E's player_force_json is NULL after the delete and E's status is Draft. Multi-encounter: create 3 encounters all referencing F, assert all 3 are repaired in one transaction. Negative: delete F when no encounters reference it, assert no encounters table writes.
+- **Hydration** (`src/services/encounter/__tests__/EncounterService.hydration.test.ts`) — create encounter referencing force F, delete F via raw SQL (bypassing cascade), call `getEncounter(id)`, assert `playerForce === null` AND a `logger.warn` was emitted once. Re-call `getEncounter(id)`, assert no second warn (deduped).
+- **List UI** (`src/__tests__/pages/encounters/index.test.tsx`) — render with one encounter having a missing player force, assert "Player force missing" pill is visible AND has yellow background. Empty state: render with empty list and no filters, assert "Seed sample encounters" button is visible. Click → mock fetch, assert POST to `/api/encounters/seed-samples`, assert `loadEncounters()` called after success.
+- **Detail UI** (`src/__tests__/pages/encounters/[id].test.tsx`) — render with encounter having missing player force, assert banner is visible with "Clear missing player force" button. Click → assert `setPlayerForce` called with `null`.
+- **Seed-samples API** (`src/__tests__/api/encounters/seed-samples.test.ts`) — POST to handler, assert 4 encounters created with the 4 template types, assert IDs are returned. POST again → assert this is allowed (idempotency NOT required — user can seed multiple sample sets if they want; each call adds 4 new ones with auto-generated names like "Sample Duel (2)").
+
+## Test infrastructure
+
+Existing — Jest + better-sqlite3 in-memory test DB pattern is already established (see `EncounterRepository.test.ts:912 lines`). Cleanup script tests use the same pattern with a tmpdir-backed DB.
+
+## Rollout
+
+1. **Land Tier 1** — cleanup script + manifest format + cleanup tests (no production behavior change yet; script is opt-in CLI). PR #1.
+2. **Land Tier 2** — cascade + hydration replacement + helper + tests. Behavior change: `deleteForce` now also writes to encounters table. PR #2.
+3. **Land Tier 3** — UI surfaces (broken pill + repair banner + seed empty-state + API route) + UI tests. PR #3.
+4. **Operator runs cleanup once** — `tsx scripts/cleanup-broken-encounters.ts` against the user's actual DB. Manifest archived. PR #4 if the manifest review surfaces any false-positive deletions (would expand classification rules).
+
+Each tier is independently releasable. Tier 1 alone ships a useful tool. Tier 1+2 ships the full prevention. Tier 1+2+3 ships the visible recovery affordance.
+
+## Risk + mitigation
+
+- **Risk**: cleanup-script false positives delete a row the user wanted to keep. **Mitigation**: manifest log is the audit trail; user reviews and re-inserts via SQL if needed; classification rules are conservative (only delete when EVERY field besides `id`/`name`/`status`/`createdAt` is null/empty).
+- **Risk**: cascade transaction rollback leaves force deleted but encounters not updated. **Mitigation**: SQLite transactions are atomic; if any UPDATE in the cascade fails, the force delete is also rolled back. Test covers this.
+- **Risk**: hydration-boundary `logger.warn` floods the console on a DB with hundreds of orphans. **Mitigation**: dedup Set keyed on `${encounterId}:${forceId}`, reset only on process boot. First read warns; subsequent reads silent.
+- **Risk**: the existing 27 drafts are NOT actually broken (just abandoned), so the cascade fix is overkill. **Mitigation**: cleanup classification covers both abandoned and orphaned; we ship both fixes because the orphaned case definitely exists per the source-code audit (`deleteForce` doesn't touch encounters), even if the current 27 happen to all be abandoned.
+
+## Open questions
+
+- **Q**: Should the cleanup script delete `Launched` / `Completed` encounters that reference orphan forces? **A**: NO. Those encounters were live games at some point and may have a `gameSessionId` worth preserving. Orphan ref repair (NULLing the json) is fine; deletion is gated to `Draft` only.
+- **Q**: Should the seed action include encounters wired to existing forces from `ForceRepository.getAllForces()`? **A**: NO for v1. The seeded encounters are template-only; the user wires forces themselves. This keeps the seed predictable across user environments. Wire-up automation is a follow-on.

--- a/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/notepad/decisions.md
+++ b/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/notepad/decisions.md
@@ -1,0 +1,3 @@
+# Decisions — repair-broken-encounter-drafts
+
+(populated during execution)

--- a/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/notepad/issues.md
+++ b/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/notepad/issues.md
@@ -1,0 +1,12 @@
+# Issues — repair-broken-encounter-drafts
+
+## [2026-05-08 18:30] Session interrupted — partial delivery
+**State**: PR1 (#558) opened, CI in progress. PR2 and PR3 not started. Worktree at `.claude/worktrees/repair-pr1-cleanup` left in place with branch `feat/repair-encounters-pr1-cleanup`.
+
+**Why partial**: User-level Claude PostToolUse hook at `~/.claude/hooks/auto-format.sh` runs `npx prettier --write` on every Edit, but this project uses `oxfmt` (single quotes) — prettier defaults to double quotes. Each Edit reformatted entire files to double-quote style and re-printed the FULL file in the system reminder, causing 5-10x context multiplication per edit. Hard to push through 3 PRs end-to-end at that rate.
+
+**Mitigation for the next session**: either (a) suspend the auto-format hook globally while running PR2/PR3, or (b) lean on Write tool (single hook trigger per file) and follow each Write/Edit with `npx oxfmt --write <file>` to repair, or (c) delegate PR2/PR3 to omo-hephaestus via the Task tool (subagents do not inherit the user-level hook? — verify first).
+
+## [2026-05-08 18:30] Worktree state
+- `.claude/worktrees/repair-pr1-cleanup/` — PR1 branch (committed + pushed). Clean to delete after PR1 merges (`git worktree remove --force`).
+- Main repo `E:/Projects/MekStation` — clean (only known-untracked entries).

--- a/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/notepad/learnings.md
+++ b/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/notepad/learnings.md
@@ -1,0 +1,93 @@
+# Learnings — repair-broken-encounter-drafts
+
+## [2026-05-08 00:00] Session start
+**Source-of-truth files**:
+- `src/services/forces/ForceRepository.ts:195-221` — `deleteForce()`, currently does NOT cascade
+- `src/services/encounter/EncounterService.ts:415-452` — `hydrateEncounter()`, currently leaves dangling refs intact
+- `src/services/encounter/EncounterRepository.ts` — owns `recalculateStatus`, `rowToEncounter`
+- `src/types/encounter/EncounterInterfaces.ts:61-69` — `ScenarioTemplateType` enum (Duel|Skirmish|Battle|Custom)
+- `src/constants/scenario/templates.ts` — `SCENARIO_TEMPLATES` constant (6 entries; NOT what seed handler iterates)
+- `src/__tests__/pages/gameplay/encounters/` — existing encounter UI test convention (NOT `src/__tests__/pages/encounters/`)
+- `src/stores/useEncounterStore.ts` — `setPlayerForce` needs widening from `(id, string)` to `(id, string | null)`
+
+## [2026-05-08 00:00] Patches already applied to tasks.md
+- Task 3.4 — disambiguates `ScenarioTemplateType` (4 enum values) from `SCENARIO_TEMPLATES` (6-entry constant). Seed handler iterates the enum.
+- Task 3.5 — explicit prerequisite: widen `useEncounterStore.setPlayerForce` signature + API handler branch for `forceId: null`.
+- Task 3.6 — corrects test path to `src/__tests__/pages/gameplay/encounters/`.
+
+## [2026-05-08 00:00] Cascade reachability rule
+- **Cleanup-script DELETION** is gated to `Draft` AND `abandoned-empty` only.
+- **Cascade NULLing** of force refs runs on encounters of ALL statuses (including Launched/Completed).
+- For Launched encounters whose force is deleted: cascade clears the ref + `recalculateStatus` drops them back to Draft via the existing ladder. No special-case needed.
+
+## [2026-05-08 00:00] recalculateStatus existing behavior
+At `src/services/encounter/EncounterRepository.ts:484-489`, `recalculateStatus` short-circuits when status is `Launched` or `Completed`:
+```
+if (encounter.status === Launched || encounter.status === Completed) return;
+```
+For PR2, the cascade caller must NOT rely on `recalculateStatus` alone to drop a Launched encounter to Draft. Two options:
+- (a) Widen `recalculateStatus` so a Launched encounter with NO playerForce drops to Draft (clean but changes existing semantic; there are no tests asserting "Launched stays Launched after force cleared because that situation never existed").
+- (b) Cascade caller writes status=Draft directly when it cleared a ref AND the encounter was Launched/Ready, then calls recalculateStatus to re-evaluate Ready.
+Pick (a) — narrower change in caller, predictable semantics, test the new branch with cascade tests.
+
+## [2026-05-08 00:00] Existing setPlayerForce API
+- PUT `/api/encounters/[id]/player-force` requires non-null `forceId` (returns 400 on null/empty).
+- DELETE `/api/encounters/[id]/player-force` already exists and uses `updateEncounter({ playerForceId: undefined })` to clear.
+- Easiest path for PR3 task 3.5: store `setPlayerForce(id, null)` calls the existing DELETE endpoint when `forceId === null`. NO server-side widening needed if we route through DELETE. Consider this — task 3.5 prerequisite mentions widening but DELETE already does the same job. Safer: store routes null → DELETE; saves a server change.
+
+## [2026-05-08 00:00] EncounterRepository.createEncounter signature
+At `src/services/encounter/EncounterRepository.ts:160-209`. Takes `ICreateEncounterInput` with optional `template: ScenarioTemplateType | undefined`. Already wires SCENARIO_TEMPLATES lookup for defaults. Seed handler can call this 4 times — once per ScenarioTemplateType enum value.
+
+## [2026-05-08 00:00] Tests location
+- `src/services/encounter/__tests__/EncounterService.test.ts` exists (~1000+ lines) — extends here for hydration test.
+- `src/__tests__/pages/gameplay/encounters/[id]/` exists for detail-page tests (currently only `pre-battle.effect.test.tsx`).
+- No `src/__tests__/pages/gameplay/encounters/index.test.tsx` yet — PR3 creates it.
+- `src/__tests__/api/encounters/encounters.test.ts` is the API test pattern reference.
+
+## [2026-05-08 18:00] PR1 surfaced learnings (gotchas)
+- **`scripts/` is gitignored** — must `git add -f` for new script files. Existing scripts were force-added historically. The same trick is needed for any script in PR1/PR2/PR3. (`scripts/__tests__/` falls under the same rule.)
+- **User-level Claude `auto-format.sh` PostToolUse hook runs `npx prettier --write` on every Edit** — but this project uses `oxfmt` with single quotes (prettier defaults to double quotes). The hook reformats the WHOLE file with double quotes, so every Edit needs an immediate `npx oxfmt --write <file>` chaser to repair. Inserting whole new files via Write triggers the same hook but only on the new file, so the cost is bounded.
+- **`recalculateStatus` short-circuits Launched/Completed** at `EncounterRepository.ts:484-489`. PR2 cascade caller must handle this — design says "drop to Draft via existing recalculate" but the existing function won't. Either widen recalculate or set status=Draft directly in the cascade caller before calling recalculate.
+- **EncounterRepository was already over the 400-line `max-lines` warning threshold** (524 lines on main). Adding `getAllEncountersWithRawIds` pushed it to 569. Pre-existing warning, not a new violation. PR2 will push it further; consider extracting `recalculateStatus` + cascade methods to a `EncounterRepository.cascade.ts` helper file if PR2 PR review pushes back.
+- **Pre-commit hook runs FULL Next.js build (~5min)** when TS files are staged. Plan time budget accordingly. Skips for openspec-only / docs-only / Python-only commits.
+- **GH_TOKEN env var pollution** — `gh pr create` fails with `HTTP 401` if `GH_TOKEN` is set to an old token. Fix: `unset GH_TOKEN` (or `GH_TOKEN= gh pr create ...` inline) so it falls back to the keyring auth.
+
+## [2026-05-08 18:30] PR1 outcome
+- Branch: `feat/repair-encounters-pr1-cleanup`
+- Commit: `7a428127`
+- PR: https://github.com/SwiggitySwerve/MekStation/pull/558
+- Tests: 12/12 passing
+- Lint: 0 errors (46 pre-existing warnings)
+- Format: clean
+- Files: scripts/cleanup-broken-encounters.ts (NEW), scripts/__tests__/cleanup-broken-encounters.test.ts (NEW), src/services/encounter/EncounterRepository.ts (MOD), src/services/encounter/EncounterRepository.helpers.ts (MOD)
+
+## [2026-05-08 22:00] PR2 outcome
+- Branch: `feat/repair-encounters-pr2-cascade`
+- Phase A commit (cascade infrastructure): `e116e605`
+- Phase B commit (wiring): `4936a79e`
+- Phase C commit (API rawForceIds): `ed42cf4d`
+- Phase D commit (tests + store + back-patch + small Phase E test fix): TBD on push
+- PR: TBD on open
+- Tests in scope (relevant suites): **376/376 passing across 14 suites**
+  - encounterBrokenRefs.test.ts (NEW): 6/6
+  - EncounterRepository.cascade.test.ts (NEW): 7/7
+  - EncounterService.hydration.test.ts (NEW): 5/5
+  - ForceRepository.test.ts +deleteForce cascade describe block: 67 total (3 new + 64 pre-existing)
+  - encounters.test.ts (MOD): 60 total (3 GET tests rewritten for new shape + rawForceIds repository mock)
+  - useEncounterStore.test.ts (NEW): 4/4
+  - cleanup-broken-encounters.test.ts (MOD): 12/12 (orphan branch now repaired via cascade)
+  - EncounterService.test.ts (MOD): 49/49 — fixed stale "should handle deleted force gracefully" assertion to match Phase B contract (playerForce becomes null, not passed-through)
+- Lint: 0 errors (4 pre-existing max-lines warnings, one in repo lifted by 100 LOC due to Phase A)
+- Format: clean
+- Typecheck: clean
+- Phase E fix (in same PR): `EncounterService.test.ts` line 1011 was checking the old "dangling ref preserved" behavior, updated to assert null-replacement.
+
+### Gotchas/learnings for PR3
+- **`encountersHandler` GET shape changed** to `{ encounters, count, rawForceIds }`. Any consumer test (or new test) that mocks the handler or asserts the response MUST mock `getEncounterRepository().getAllEncountersWithRawIds()` — otherwise it returns 500 because the handler reads it. The pattern in `encounters.test.ts` uses `jest.requireActual` to keep `EncounterErrorCode` enum live.
+- **`logger.warn` spying works fine** via `jest.spyOn(logger, 'warn')` — since logger is an exported plain object, the spy replaces `.warn` cleanly even though the underlying `shouldLog('warn')` returns false in test env. The spy intercepts BEFORE `shouldLog` runs.
+- **`resetEncounterService()` clears the orphan-warn dedup Set** — required for hydration test isolation. Tests that load the same orphan ID across `beforeEach` boundaries WILL re-warn after reset; tests that don't reset within a single `it()` get dedup behavior.
+- **Cascade test isolation** uses a separate test-DB filename (`./data/test-encounter-repository-cascade.db`) so concurrent runs don't collide on file locks.
+- **`getEncounterById` returns `IEncounter` with `playerForce: undefined`** AFTER cascade NULL'd the column — `rowToEncounter` reads null JSON as undefined. The cleanup back-patch test asserts `encounter?.playerForce` is `undefined` (NOT null) post-repair. PR3 broken-pill detection uses `rawForceIds[id] !== null && encounter.playerForce === null` — but post-cleanup-repair the row's `playerForceId` AND `playerForce` are both null/undefined, so the broken-pill predicate cleanly reports "not missing" (which is correct: the repair erased the dangling state).
+- **`encounter.playerForce` interface widened** to `IForceReference | null | undefined`. The `null` value is the explicit "force was deleted" signal from Phase B's hydration boundary. Existing UI code that uses `!encounter.playerForce` already handles this correctly (both null and undefined are falsy). UI code that uses `encounter.playerForce !== undefined` will need updating in PR3 — search for that pattern.
+- **Auto-formatter (postToolUse hook) reformats with double-quotes**, project uses single quotes. Run `npx oxfmt --write <file>` after every Write/Edit on a TS/JS file.
+

--- a/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/notepad/problems.md
+++ b/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/notepad/problems.md
@@ -1,0 +1,3 @@
+# Problems — repair-broken-encounter-drafts
+
+(populated only with unresolved blockers)

--- a/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/proposal.md
+++ b/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+27 encounter rows at `/gameplay/encounters` are stuck in `Draft` forever. The user can't tell why, can't transition them, and gets no signal beyond "they're old and won't move." The list page is becoming a graveyard, which means a new user opening the app sees 27 broken-looking rows next to whatever they're trying to make work — terrible first-run experience.
+
+Three concrete failure modes are causing the backlog (in decreasing order of population):
+
+1. **Abandoned half-configurations** — most likely the dominant share. The user created an encounter, never finished assigning a player force / opponent force / opForConfig, and walked away. The encounter is correctly `Draft` but is functionally rubble.
+2. **Orphaned force references** — `ForceRepository.deleteForce()` (`src/services/forces/ForceRepository.ts:195-221`) deletes the force row but leaves dangling `forceId`s embedded in the `encounters.player_force_json` / `opponent_force_json` columns. There is no cascade. Recovery is silent: `EncounterService.hydrateEncounter()` (`src/services/encounter/EncounterService.ts:415-452`) calls `getForceById()`, gets `null`, and *leaves the stored ref object untouched* — so the encounter still appears to have a force (with `forceName: ''`, `totalBV: 0`), passes `validateEncounter()`, may even sit in `Ready`, but explodes at launch with `Player force <forceId> could not be resolved` from `buildGameUnitsFromEncounter()`. No UI surface tells the user this.
+3. **Status drift** — `recalculateStatus` only runs inside `updateEncounter`. If a force was deleted externally and the encounter wasn't touched again, status stays at whatever it last was — which can be `Ready` for an encounter that will fail to launch.
+
+The user's brief: "27 drafts at /gameplay/encounters that just say Draft. Why can't I get them past Draft? I have no idea what's wrong with them."
+
+## What Changes
+
+- **NEW** one-time cleanup script (`scripts/cleanup-broken-encounters.ts`) that classifies every existing encounter into `abandoned-empty` / `orphaned-force-reference` / `still-valid`, writes the full classification + every deletion to `simulation-reports/cleanup-encounters-<ISO>.json` BEFORE any DELETE, then deletes only the `abandoned-empty` set. **Idempotent**: re-running on the same disk state writes a no-op log and deletes nothing.
+- **NEW** force-deletion cascade rule on `ForceRepository.deleteForce()` — when a force is deleted, every encounter row whose `player_force_json` or `opponent_force_json` references that `forceId` SHALL have the affected reference column set to `NULL` AND its status recomputed via the existing `recalculateStatus()` ladder (so encounters re-drop to `Draft` automatically). All within the same SQLite transaction as the force delete.
+- **NEW** "broken: force missing" badge on `/gameplay/encounters` list rows — when the hydrated encounter has a `playerForce`/`opponentForce` ref whose `forceName` is empty (the hydration miss signal), the list row SHALL render an explicit yellow "Force missing" pill in place of the silent zero-BV ref AND the row SHALL link to the encounter detail page where a banner SHALL explain the broken-ref recovery options (clear the ref, pick a new force, or delete the encounter).
+- **NEW** orphan-detection at hydration boundary — `hydrateEncounter()` SHALL replace any unresolvable force reference with `null` (instead of leaving the dangling ref intact) AND emit a `logger.warn` with the encounter id + missing force id so future drift is observable.
+- **NEW** repair flow on the encounter detail page — when an encounter has at least one missing force, the detail page SHALL render a top-of-page banner with a "Clear missing force" action that calls the existing `setPlayerForce` / `clearOpponentForce` endpoints with `null` to drop the orphan ref.
+- **NEW** seed action — "Seed sample encounters" button on the empty-state of `/gameplay/encounters` (visible only when the list is empty after filtering). Click creates 4 starter encounters using the existing `SCENARIO_TEMPLATES` (Duel / Skirmish / Battle / Custom) so the new-user experience after cleanup is "0 broken" rather than "0 anything."
+
+**OUT OF SCOPE** — replay persistence for encounters (separate change `link-encounters-to-replays`); a generic foreign-key cascade framework (one-off rule on the encounter table is sufficient for v1); soft-delete / undo of cleanup (the JSON log is the audit trail).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `game-session-management` — three additions: orphaned force-reference cascade on `deleteForce`, hydration-boundary orphan replacement (currently silently passes through), and the broken-encounter UI surface (badge + repair banner). The existing `Encounter Launch` requirement gets one new scenario explicitly for "force was deleted between Ready transition and launch click."
+
+### New Capabilities
+
+None — this change rides existing capabilities and the new behaviors slot under `game-session-management`.
+
+## Impact
+
+- **Code**: `src/services/forces/ForceRepository.ts` (`deleteForce` cascade), `src/services/encounter/EncounterService.ts` (`hydrateEncounter` orphan replacement), `src/pages/gameplay/encounters/index.tsx` (broken badge + seed button on empty state), `src/pages/gameplay/encounters/[id].tsx` (repair banner), `src/pages/api/encounters/index.ts` (new `POST /api/encounters/seed-samples`), new `scripts/cleanup-broken-encounters.ts`
+- **Filesystem**: `simulation-reports/cleanup-encounters-<ISO>.json` — every classification + deletion log, never overwritten (timestamp suffix per run)
+- **Database**: no schema change. `encounters.player_force_json` / `opponent_force_json` are already nullable; the cascade just sets them to NULL.
+- **Tests**: `EncounterRepository.cascade.test.ts` (force-deletion cascade behavior, including transaction rollback on cascade failure), `EncounterService.hydration.test.ts` (orphan replacement + warn log), `cleanup-broken-encounters.test.ts` (classification fixture: abandoned + orphaned + still-valid + idempotent re-run), `EncountersListPage.test.tsx` (broken-pill render + seed-samples empty state), `[id].test.tsx` (repair-banner render + clear-action wiring)
+- **Existing data**: the 27 stuck drafts get classified by the cleanup script. Expected output: ~20 abandoned-empty deleted, ~5 orphaned-force-reference repaired in place (force ref cleared), ~2 still-valid retained.
+- **Out of scope (this change)**: encounter replay persistence (separate change), a generic FK-cascade framework, undo/restore of cleaned encounters (the JSON log is enough).

--- a/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/specs/game-session-management/spec.md
+++ b/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/specs/game-session-management/spec.md
@@ -1,0 +1,311 @@
+# Game Session Management Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Force-Deletion Cascade to Encounter References
+
+The system SHALL clear orphaned force references in the `encounters` table when a force is deleted. The cascade SHALL run inside the same SQLite transaction as `ForceRepository.deleteForce`, MUST NULL the affected `player_force_json` and `opponent_force_json` columns, and MUST trigger the existing `recalculateStatus` ladder for every affected encounter id so encounters drop back to `Draft` atomically with the force deletion.
+
+If any UPDATE in the cascade throws, the SQLite transaction MUST roll back AND the force row MUST remain present in the `forces` table. The cascade MUST NOT delete encounter rows — it only clears the dangling reference. Encounter deletion remains a separate user-initiated operation.
+
+#### Scenario: Single encounter affected
+
+- **GIVEN** a force `F` and an encounter `E` whose `player_force_json` references `F`
+- **WHEN** `ForceRepository.deleteForce(F)` is called
+- **THEN** the SQL transaction SHALL execute `DELETE FROM forces WHERE id = F` followed by `UPDATE encounters SET player_force_json = NULL WHERE json_extract(player_force_json, '$.forceId') = F`
+- **AND** `recalculateStatus(E.id)` SHALL be called inside the same transaction
+- **AND** after commit, `getForceById(F)` SHALL return `null`
+- **AND** `getEncounterById(E.id).playerForce` SHALL be `null`
+- **AND** `getEncounterById(E.id).status` SHALL be `EncounterStatus.Draft`
+
+#### Scenario: Multiple encounters affected in one transaction
+
+- **GIVEN** a force `F` referenced as the player force by encounter `E1`, as the opponent force by encounter `E2`, and as both player+opponent on encounter `E3`
+- **WHEN** `ForceRepository.deleteForce(F)` is called
+- **THEN** all three encounters SHALL have their respective `_force_json` columns set to `NULL` for the matching slot inside one transaction
+- **AND** all three encounters SHALL have status recomputed
+- **AND** `getForceById(F)` SHALL return `null`
+
+#### Scenario: Cascade rollback on UPDATE failure
+
+- **GIVEN** a force `F` and an encounter `E` whose `player_force_json` references `F`
+- **AND** the cascade UPDATE statement is configured to throw mid-transaction (test injection)
+- **WHEN** `ForceRepository.deleteForce(F)` is called
+- **THEN** the transaction SHALL roll back
+- **AND** `getForceById(F)` SHALL still return the original force record
+- **AND** `getEncounterById(E.id).playerForce.forceId` SHALL still equal `F`
+
+#### Scenario: No referencing encounters
+
+- **GIVEN** a force `F` with zero encounter rows referencing it
+- **WHEN** `ForceRepository.deleteForce(F)` is called
+- **THEN** the cascade SHALL execute zero UPDATE statements against `encounters`
+- **AND** the force deletion SHALL still commit normally
+
+### Requirement: Hydration-Boundary Orphaned Reference Replacement
+
+`EncounterService.hydrateEncounter` SHALL replace any unresolvable force reference with `null` in the returned `IEncounter` (instead of leaving the dangling embedded ref intact). When the resolver returns `null` for a stored `forceId`, the hydrated `playerForce` (or `opponentForce`) field SHALL be set to `null` AND the system SHALL emit a `logger.warn` exactly once per `${encounterId}:${forceId}:${side}` key per process lifetime.
+
+The dedup Set SHALL be reset by `resetEncounterService()` so test isolation is preserved.
+
+This requirement is the safety net for any orphan that escapes the force-deletion cascade (e.g. raw SQL inserts, future bugs, pre-cascade legacy rows). The cascade is the primary fix; this is the secondary fix.
+
+#### Scenario: Player force unresolvable returns null
+
+- **GIVEN** an encounter `E` whose stored `player_force_json` references force id `F`
+- **AND** `forceRepository.getForceById(F)` returns `null`
+- **WHEN** `EncounterService.getEncounter(E.id)` is called
+- **THEN** the returned `IEncounter.playerForce` SHALL be `null`
+- **AND** the returned `IEncounter.opponentForce` SHALL retain whatever resolution result it would otherwise have
+- **AND** `logger.warn` SHALL be called once with the keys `encounterId`, `forceId`, and `side: 'player'`
+
+#### Scenario: Warn dedup across reads
+
+- **GIVEN** the same orphaned encounter `E` referencing the deleted force `F`
+- **WHEN** `EncounterService.getEncounter(E.id)` is called twice in the same process
+- **THEN** `logger.warn` SHALL be called exactly once total — the second call SHALL be deduped
+
+#### Scenario: Reset clears dedup Set
+
+- **GIVEN** an orphaned encounter `E` already-warned for force `F`
+- **WHEN** `resetEncounterService()` is called
+- **AND** `EncounterService.getEncounter(E.id)` is then called
+- **THEN** `logger.warn` SHALL be called again with the same keys (the Set was cleared)
+
+### Requirement: Broken-Reference Detection Helper
+
+The system SHALL provide a pure helper `encounterBrokenRefs(encounter, rawForceIds)` at `src/services/encounter/encounterBrokenRefs.ts` that returns `{ playerForceMissing: boolean; opponentForceMissing: boolean }`. The helper SHALL report `playerForceMissing: true` if and only if `rawForceIds.playerForceId !== null` AND `encounter.playerForce === null`. Same predicate for the opponent side. Pure function — no IO, no logging.
+
+The helper SHALL NOT mutate either argument. The shape of `rawForceIds` SHALL be `{ playerForceId: string | null; opponentForceId: string | null }`.
+
+#### Scenario: Player ref stored but unresolved → missing
+
+- **GIVEN** an encounter with `playerForce: null` AND `rawForceIds: { playerForceId: 'F', opponentForceId: null }`
+- **WHEN** `encounterBrokenRefs` is called
+- **THEN** the result SHALL be `{ playerForceMissing: true, opponentForceMissing: false }`
+
+#### Scenario: Both refs stored, both unresolved → both missing
+
+- **GIVEN** an encounter with `playerForce: null` AND `opponentForce: null` AND `rawForceIds: { playerForceId: 'F1', opponentForceId: 'F2' }`
+- **WHEN** `encounterBrokenRefs` is called
+- **THEN** the result SHALL be `{ playerForceMissing: true, opponentForceMissing: true }`
+
+#### Scenario: No refs stored → not missing
+
+- **GIVEN** an encounter with `playerForce: null` AND `rawForceIds: { playerForceId: null, opponentForceId: null }`
+- **WHEN** `encounterBrokenRefs` is called
+- **THEN** the result SHALL be `{ playerForceMissing: false, opponentForceMissing: false }`
+
+#### Scenario: Refs resolved → not missing
+
+- **GIVEN** an encounter with `playerForce: { forceId: 'F', forceName: 'Alpha Lance', totalBV: 4500, unitCount: 4 }` AND `rawForceIds: { playerForceId: 'F', opponentForceId: null }`
+- **WHEN** `encounterBrokenRefs` is called
+- **THEN** the result SHALL be `{ playerForceMissing: false, opponentForceMissing: false }`
+
+### Requirement: Encounter List Surfaces Broken-Reference State
+
+The encounter list page at `/gameplay/encounters` SHALL render a yellow "Player force missing" pill (or "Opponent force missing" for the opponent slot) on any encounter card whose `encounterBrokenRefs` reports a missing reference. The pill SHALL replace the silent zero-name pill that today renders an empty `forceName`. The pill SHALL share the visual treatment of the existing yellow "No Player Force" / "No Opponent" pills so users scan the same warning slot.
+
+The list page response from `GET /api/encounters` SHALL include the raw force ids alongside the hydrated encounters so the page can call `encounterBrokenRefs` without an extra round-trip.
+
+#### Scenario: Broken-pill renders for missing player force
+
+- **GIVEN** an encounter with `playerForce: null` AND `rawForceIds.playerForceId !== null`
+- **WHEN** the list page renders the encounter card
+- **THEN** the card SHALL render a yellow pill with text "Player force missing"
+- **AND** the card SHALL NOT render an empty-name "Player: " pill
+
+#### Scenario: Both sides broken renders both pills
+
+- **GIVEN** an encounter with both `playerForce: null` AND `opponentForce: null` AND both raw force ids non-null
+- **WHEN** the list page renders the encounter card
+- **THEN** the card SHALL render one yellow "Player force missing" pill AND one yellow "Opponent force missing" pill
+
+#### Scenario: API exposes raw force ids
+
+- **GIVEN** the list page is loaded
+- **WHEN** the page issues `GET /api/encounters`
+- **THEN** the response body SHALL include `rawForceIds: Record<encounterId, { playerForceId: string | null; opponentForceId: string | null }>` keyed by encounter id
+
+### Requirement: Encounter Detail Repair Banner
+
+The encounter detail page at `/gameplay/encounters/[id]` SHALL render a top-of-page banner above the existing form when the loaded encounter has at least one broken force reference. The banner SHALL display:
+
+- Header text: `"This encounter has a broken force reference"`
+- Body text: explaining the dangling forceId(s) — `"The force <forceId> referenced as the player force was deleted."` (and/or the opponent equivalent)
+- One action button per affected slot: "Clear missing player force" and/or "Clear missing opponent force"
+
+Clicking a clear-action button SHALL call the existing `setPlayerForce(encounterId, null)` (for player) or `clearOpponentForce(encounterId)` (for opponent) store action AND SHALL reload the encounter so the banner disappears on success.
+
+#### Scenario: Banner renders when player force is broken
+
+- **GIVEN** an encounter with `playerForce: null` AND `rawForceIds.playerForceId === 'F'`
+- **WHEN** the detail page renders
+- **THEN** a banner SHALL be visible above the form
+- **AND** the banner SHALL contain the literal text `"The force F referenced as the player force was deleted."`
+- **AND** a button labeled `"Clear missing player force"` SHALL be present
+
+#### Scenario: Clear-action wires through to existing setPlayerForce
+
+- **GIVEN** the detail page is rendered with a broken player force
+- **WHEN** the user clicks "Clear missing player force"
+- **THEN** the `setPlayerForce(encounterId, null)` store action SHALL be called
+- **AND** the encounter SHALL be reloaded after success
+- **AND** the banner SHALL no longer be visible
+
+#### Scenario: Both sides broken renders two action buttons
+
+- **GIVEN** an encounter with both player and opponent forces broken
+- **WHEN** the detail page renders
+- **THEN** the banner SHALL contain both `"Clear missing player force"` AND `"Clear missing opponent force"` buttons
+
+### Requirement: Sample Encounter Seeding
+
+The system SHALL provide a `POST /api/encounters/seed-samples` endpoint that creates one encounter per `SCENARIO_TEMPLATES` entry (Duel, Skirmish, Battle, Custom — currently four) inside a single SQLite transaction. The endpoint SHALL return `{ success: true, ids: readonly string[] }` containing the four created encounter ids. On any creation failure mid-transaction, the entire seed operation SHALL roll back AND the response SHALL be `{ success: false, error: string }` with HTTP 500.
+
+The encounter list page SHALL render a "Seed sample encounters" button alongside the existing "Create First Encounter" button on the empty-state, visible only when the filtered list is empty AND no search query AND no status filter is active. Clicking the button SHALL POST to the endpoint, then call `loadEncounters()` to refresh the page.
+
+The seeded encounters SHALL be auto-named with a date-and-template suffix (e.g. `"Sample Duel - 2026-05-08"`). Repeated invocations SHALL use a numeric suffix on collisions (e.g. `"Sample Duel - 2026-05-08 (2)"`) so the operation is repeatable without unique-name conflicts. Seed encounters SHALL NOT have forces or opForConfigs auto-assigned — the user wires those manually.
+
+#### Scenario: Seed endpoint creates four encounters
+
+- **GIVEN** an empty encounters table
+- **WHEN** `POST /api/encounters/seed-samples` is called
+- **THEN** the response SHALL be `{ success: true, ids: [<4 strings>] }`
+- **AND** `getAllEncounters()` SHALL return four rows
+- **AND** the four rows SHALL have templates `Duel`, `Skirmish`, `Battle`, `Custom` exactly once each
+
+#### Scenario: Repeated seed creates four more with suffixed names
+
+- **GIVEN** the encounters table contains one prior seed batch (4 rows)
+- **WHEN** `POST /api/encounters/seed-samples` is called again
+- **THEN** the response SHALL be `{ success: true, ids: [<4 new strings>] }`
+- **AND** `getAllEncounters()` SHALL return eight rows
+- **AND** the four new rows SHALL have names ending with the `(2)` suffix
+
+#### Scenario: Empty-state button visibility
+
+- **GIVEN** the encounter list is empty AND there is no search query AND `statusFilter === 'all'`
+- **WHEN** the list page renders
+- **THEN** the empty-state SHALL display both "Create First Encounter" AND "Seed sample encounters" buttons
+
+#### Scenario: Empty-state button hidden under filters
+
+- **GIVEN** the encounter list is empty AND a non-default search query is active
+- **WHEN** the list page renders
+- **THEN** the empty-state SHALL NOT display the "Seed sample encounters" button (only the "Create First Encounter" button)
+
+### Requirement: One-Time Cleanup Script for Existing Broken Drafts
+
+The system SHALL provide a one-time CLI cleanup tool at `scripts/cleanup-broken-encounters.ts` (Node-only via the `tsx` runner) that classifies every encounter in the database into one of `'abandoned-empty'`, `'orphaned-force-reference'`, or `'still-valid'`. The script SHALL write the full classification manifest to `simulation-reports/cleanup-encounters-<ISO>.json` BEFORE performing any deletes. The manifest SHALL contain the full encounter row (id, name, description, status, playerForce, opponentForce, opForConfig, victoryConditions, mapConfig, createdAt, updatedAt) plus the `classification` and `classificationReason` for each encounter.
+
+The script SHALL delete only encounters classified as `'abandoned-empty'` AND only when their status is `Draft`. Encounters classified as `'orphaned-force-reference'` SHALL be repaired in place via `EncounterRepository.clearForceReference` (NULLing the dangling slot). Encounters classified as `'still-valid'` SHALL be left untouched.
+
+The script SHALL be idempotent — re-running on a database that no longer contains any abandoned-empty rows SHALL write a manifest with classifications but `deletedIds: []` AND SHALL not throw.
+
+The script SHALL accept a `--manifest-only` flag that writes the manifest but skips deletes and repairs, AND a `--cwd <path>` flag that overrides the working directory for the manifest output (used by tests).
+
+Classification rules:
+
+- `'abandoned-empty'` — `status === EncounterStatus.Draft` AND `playerForce === null` AND `opponentForce === null` AND `opForConfig === null`. Reason text: `"no forces and no opfor config — never finished setup"`.
+- `'orphaned-force-reference'` — at least one of the stored `playerForceId` / `opponentForceId` is non-null AND the corresponding `getForceById` lookup returns `null`. Reason text: `"player force <id> deleted"` and/or `"opponent force <id> deleted"`.
+- `'still-valid'` — anything else. Status MUST NOT be modified by the cleanup.
+
+#### Scenario: Manifest written before any DELETE
+
+- **GIVEN** a database with 5 encounters (2 abandoned-empty, 2 orphaned, 1 still-valid)
+- **WHEN** the cleanup script runs
+- **THEN** the file `simulation-reports/cleanup-encounters-<ISO>.json` SHALL exist before any DELETE statement is executed
+- **AND** the file SHALL contain 5 manifest entries with the correct classification for each
+- **AND** the script SHALL return `{ deletedIds: [<2 ids>], repairedIds: [<2 ids>], retainedIds: [<1 id>] }`
+
+#### Scenario: Idempotent re-run on cleaned database
+
+- **GIVEN** the cleanup script has already been run once and there are no abandoned-empty rows remaining
+- **WHEN** the cleanup script is run a second time
+- **THEN** a new manifest file SHALL be written with the new ISO suffix
+- **AND** `deletedIds` SHALL be an empty array
+- **AND** the second manifest SHALL still classify every encounter
+
+#### Scenario: manifest-only flag skips deletes
+
+- **GIVEN** the database has 2 abandoned-empty encounters
+- **WHEN** the cleanup script runs with `--manifest-only`
+- **THEN** the manifest SHALL be written
+- **AND** `deletedIds` SHALL be an empty array
+- **AND** all encounters SHALL still be present in the database after the run
+
+#### Scenario: Status-gated deletion
+
+- **GIVEN** an encounter that classifies as `'abandoned-empty'` BUT has status `EncounterStatus.Launched`
+- **WHEN** the cleanup script runs
+- **THEN** the encounter SHALL NOT be deleted
+- **AND** the manifest SHALL classify it as `'still-valid'` with reason `"non-draft encounter retained even though configuration is empty"`
+
+## MODIFIED Requirements
+
+### Requirement: Encounter Launch
+
+The store SHALL launch encounters and return the resulting game session ID. Launching SHALL fail cleanly with a user-actionable error message when the encounter has a broken force reference (the stored `playerForceId` or `opponentForceId` no longer resolves to a force in the `ForceRepository`). The error message SHALL name the missing force id so the user can correlate it with their force list.
+
+#### Scenario: Launch an encounter
+
+- **GIVEN** an encounter ID
+- **WHEN** `launchEncounter(id)` is called
+- **THEN** a POST request SHALL be made to `/api/encounters/{id}/launch`
+- **AND** on success, the response SHALL contain a `gameSessionId`
+- **AND** `loadEncounters()` SHALL be called to refresh the list
+- **AND** the `gameSessionId` SHALL be returned
+
+#### Scenario: Launch fails validation
+
+- **GIVEN** an encounter that fails validation
+- **WHEN** `launchEncounter(id)` is called
+- **THEN** the API SHALL return success=false with an error message
+- **AND** the error message SHALL be set in the store's `error` field
+- **AND** null SHALL be returned
+
+#### Scenario: Launch fails with broken force reference
+
+- **GIVEN** an encounter `E` whose stored `playerForceId` is `F` AND `forceRepository.getForceById(F)` returns null
+- **WHEN** `launchEncounter(E.id)` is called via the API
+- **THEN** the API SHALL return `{ success: false, error: "Cannot launch: Player force F could not be resolved" }`
+- **AND** the error message SHALL contain the literal forceId `F`
+- **AND** the encounter status SHALL NOT be changed
+
+### Requirement: Force Assignment
+
+The store SHALL provide methods to assign player and opponent forces to encounters. The clear-action methods (`setPlayerForce(encounterId, null)` for player; `clearOpponentForce(encounterId)` for opponent) SHALL accept the explicit clear path used by the encounter detail page's broken-reference repair banner. The clear-action SHALL set the corresponding `_force_json` column to NULL AND SHALL trigger `recalculateStatus` so an encounter with the cleared slot drops back to `Draft` if it was previously `Ready`.
+
+#### Scenario: Set player force
+
+- **GIVEN** an encounter ID and a force ID
+- **WHEN** `setPlayerForce(encounterId, forceId)` is called
+- **THEN** a PUT request SHALL be made to `/api/encounters/{encounterId}/player-force` with `{forceId}` as JSON
+- **AND** on success, `loadEncounters()` SHALL be called to refresh the list
+- **AND** true SHALL be returned
+
+#### Scenario: Set opponent force
+
+- **GIVEN** an encounter ID and a force ID
+- **WHEN** `setOpponentForce(encounterId, forceId)` is called
+- **THEN** a PUT request SHALL be made to `/api/encounters/{encounterId}/opponent-force` with `{forceId}` as JSON
+- **AND** on success, `loadEncounters()` SHALL be called to refresh the list
+- **AND** true SHALL be returned
+
+#### Scenario: Clear opponent force
+
+- **GIVEN** an encounter ID
+- **WHEN** `clearOpponentForce(encounterId)` is called
+- **THEN** a DELETE request SHALL be made to `/api/encounters/{encounterId}/opponent-force`
+- **AND** on success, `loadEncounters()` SHALL be called to refresh the list
+- **AND** true SHALL be returned
+
+#### Scenario: Clear player force via repair banner
+
+- **GIVEN** an encounter `E` with a broken player force reference
+- **WHEN** `setPlayerForce(E.id, null)` is called from the detail-page repair banner
+- **THEN** a PUT request SHALL be made to `/api/encounters/{E.id}/player-force` with `{forceId: null}` as JSON
+- **AND** the encounter's `player_force_json` column SHALL be set to NULL on the server side
+- **AND** `recalculateStatus(E.id)` SHALL run before the response returns
+- **AND** the response SHALL include the refreshed encounter object with `playerForce: null`

--- a/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/tasks.md
+++ b/openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/tasks.md
@@ -1,0 +1,90 @@
+# Tasks: Repair Broken Encounter Drafts
+
+## 1. Cleanup script + classification (PR 1)
+
+- [x] 1.1 Add `scripts/cleanup-broken-encounters.ts` Node-only script using `tsx` runner. Exports `classifyEncounter(encounter, rawForceIds, getForceById)` returning `{ classification: 'abandoned-empty' | 'orphaned-force-reference' | 'still-valid', reason: string }` and a `runCleanup({ cwd, manifestOnly }): Promise<{ manifestPath, deletedIds, repairedIds, retainedIds }>` driver.
+  - Done when: file imports compile, `tsx scripts/cleanup-broken-encounters.ts --help` prints usage.
+- [x] 1.2 Define classification rules in `classifyEncounter`:
+  - `abandoned-empty` — status is `Draft` AND no `playerForceId` AND no `opponentForceId` AND no `opForConfig` (regardless of name / map / victory conditions). Reason: "no forces and no opfor config — never finished setup."
+  - `orphaned-force-reference` — at least one of `playerForceId` / `opponentForceId` is non-null AND `getForceById` for that id returns null. Reason: `"player force <id> deleted"` / `"opponent force <id> deleted"`.
+  - `still-valid` — anything else. Status is preserved as-is.
+  - Done when: unit tests pass for all three branches.
+- [x] 1.3 Implement `runCleanup`:
+  - For each encounter, classify and append a manifest entry (full row + classification + reason).
+  - Write manifest to `simulation-reports/cleanup-encounters-<ISO>.json` BEFORE any DELETE. Use `mkdir -p` for the simulation-reports dir.
+  - When `manifestOnly` flag is true, return after writing manifest.
+  - Otherwise, for each `abandoned-empty` row: call `getEncounterRepository().deleteEncounter(id)`. Collect deleted ids.
+  - For each `orphaned-force-reference` row: call `clearForceReference` for each affected forceId — but only AFTER the cascade landed in PR 2. In PR 1, treat orphaned the same as still-valid (no repair attempted). Add a TODO comment referencing PR 2.
+  - Done when: integration test against a fixture DB with 5 encounters writes the expected manifest and deletes only the abandoned-empty rows.
+- [x] 1.4 Idempotency: re-running on a DB with no abandoned-empty rows writes a manifest with classifications but `deletedIds: []`.
+  - Done when: re-run test asserts second manifest has empty `deletedIds`.
+- [x] 1.5 Add unit tests at `scripts/__tests__/cleanup-broken-encounters.test.ts`:
+  - `classifyEncounter` for all three branches (~6 cases — abandoned with various leftover fields, orphaned player-only, orphaned opponent-only, orphaned both, still-valid Ready, still-valid Launched).
+  - `runCleanup` end-to-end: fixture with 2 abandoned + 2 orphaned + 1 still-valid → assert manifest has 5 entries, `deletedIds` length is 2, `retainedIds` length is 3.
+  - Idempotent re-run: second pass assert `deletedIds.length === 0`.
+  - Manifest schema: assert every entry has `id`, `name`, `status`, `playerForce`, `opponentForce`, `classification`, `classificationReason`.
+  - Done when: `npm test scripts/__tests__/cleanup-broken-encounters.test.ts` clean.
+- [x] 1.6 Run `npm run typecheck`, `npm run lint`, `npm test` clean. — 12/12 tests passing, typecheck clean, 0 lint errors.
+- [x] 1.7 Open PR 1, CI green, merge. — PR #558 opened; CI in progress; **Atlas merges after CI green**.
+
+## 2. Cascade on deleteForce + hydration repair (PR 2)
+
+- [x] 2.1 Add `clearForceReference(forceId: string): { affectedEncounterIds: readonly string[] }` to `EncounterRepository`. Performs two `UPDATE encounters SET <col> = NULL WHERE json_extract(<col>, '$.forceId') = ?` statements (one for player_force_json, one for opponent_force_json), collects the rowids hit, then iterates and calls the existing `recalculateStatus(id)` for each. All inside a SQLite `db.transaction(...)` block so partial failure rolls back.
+  - Done when: `EncounterRepository.cascade.test.ts` covers single-encounter and multi-encounter cases.
+- [x] 2.2 Wire `ForceRepository.deleteForce` to call `getEncounterRepository().clearForceReference(id)` BEFORE the `DELETE FROM forces` statement, all inside one outer SQLite transaction. Use a callback pattern to avoid hard import coupling: the encounter repo registers `onForceDeleted` on the force repo at module init time, the force repo's `deleteForce` invokes the callback if set.
+  - Done when: deleting a force with 3 referencing encounters returns `{ success: true }`, the force row is gone, and all 3 encounters have `player_force_json` / `opponent_force_json` set to NULL with status recomputed.
+- [x] 2.3 Add transaction-rollback test: cause `clearForceReference` to throw mid-transaction (mock the prepared statement to throw on the second UPDATE), assert the force row is still present in `forces` table after the rollback.
+- [x] 2.4 Modify `EncounterService.hydrateEncounter()` (`src/services/encounter/EncounterService.ts:415-452`) to set `playerForce`/`opponentForce` to `null` (instead of leaving the dangling ref) when `forceRepo.getForceById()` returns null. Emit `logger.warn('[encounter] orphaned force reference', { encounterId, forceId, side })` once per `${encounterId}:${forceId}` key (dedup via a module-level `Set`). Reset the Set on `resetEncounterService()`.
+  - Done when: `EncounterService.hydration.test.ts` asserts the returned encounter has `playerForce: null` AND warn was called once. Second call to `getEncounter(id)` does not re-warn.
+- [x] 2.5 Add `encounterBrokenRefs(encounter, rawForceIds)` helper at `src/services/encounter/encounterBrokenRefs.ts`:
+  ```
+  encounterBrokenRefs(
+    encounter: IEncounter,
+    rawForceIds: { playerForceId: string | null; opponentForceId: string | null }
+  ): { playerForceMissing: boolean; opponentForceMissing: boolean }
+  ```
+  - `playerForceMissing` is true when `rawForceIds.playerForceId !== null && encounter.playerForce === null`.
+  - Same shape for opponent.
+  - Done when: pure unit tests for 4 truth-table branches pass.
+- [x] 2.6 Expose `__rawForceIds` on the IEncounter shape returned from the repository. Either: (a) extend IEncounter with an optional `__rawForceIds` field stamped only by the repository's `rowToEncounter`, OR (b) add a separate repository method `getEncounterWithRawIds(id)` that returns `{ encounter, rawForceIds }`. Choose (b) — keeps IEncounter clean. The list page calls the new method when it needs broken-ref detection.
+  - Done when: API route `GET /api/encounters` returns `{ encounters: [...], rawForceIds: { [encounterId]: { playerForceId, opponentForceId } } }` (or sibling array).
+- [x] 2.7 Update the encounter store at `src/stores/useEncounterStore.ts` to also load + cache `rawForceIds` map alongside encounters. Selector: `getEncounterRawForceIds(id): { playerForceId, opponentForceId } | null`.
+  - Done when: selector returns the right ids for a loaded encounter.
+- [x] 2.8 Update PR 1's `runCleanup` orphaned branch — now that `clearForceReference` exists, repair orphaned encounters in place by calling `clearForceReference(forceId)` for each missing forceId. Add `repairedIds` to the result. Update the cleanup test to assert orphaned rows now appear in `repairedIds`.
+- [x] 2.9 Run `npm run typecheck`, `npm run lint`, `npm test` clean. — 376/376 in scope, typecheck + format + lint clean.
+- [x] 2.10 Open PR 2, CI green, merge. — PR opened by Phase D execution; orchestrator merges after CI green.
+
+## 3. UI surfaces — broken pill + repair banner + seed empty-state (PR 3)
+
+- [x] 3.1 Modify `src/pages/gameplay/encounters/index.tsx` `EncounterCard` component to call the `encounterBrokenRefs` helper with `(encounter, rawForceIds)` and render a yellow "Player force missing" / "Opponent force missing" pill (same yellow-bg pattern as the existing "No Player Force" pill) when the helper reports the slot is missing. Replace the existing zero-name fallback so the pill shows in place of the silent empty pill.
+  - Done when: a row whose `rawForceIds.playerForceId !== null && encounter.playerForce === null` renders the yellow "Player force missing" pill.
+- [x] 3.2 Add a "Seed sample encounters" button to the empty-state of the list page. Visible only when `filteredEncounters.length === 0 && !searchQuery && statusFilter === 'all'`. Position it next to the existing "Create First Encounter" button as a secondary action.
+  - Done when: the empty state with no filters renders both buttons. Filtered empty state does not render the seed button.
+- [x] 3.3 Wire the seed button to a new `seedSampleEncounters()` async store action that POSTs to `/api/encounters/seed-samples`, then calls `loadEncounters()` to refresh.
+  - Done when: clicking the button in the test renders 4 new encounter cards.
+- [x] 3.4 Add `src/pages/api/encounters/seed-samples.ts` POST handler. Calls `getEncounterRepository().createEncounter({ name, template })` 4 times — one per `ScenarioTemplateType` enum value (Duel | Skirmish | Battle | Custom, defined at `src/types/encounter/EncounterInterfaces.ts:61-69`) — inside a transaction. NOTE: `SCENARIO_TEMPLATES` is a different 6-entry constant in `src/constants/scenario/templates.ts` and is NOT the right import here; `ScenarioTemplateType` is the encounter-template enum on `IEncounter.template`. Returns `{ success: true, ids: [4 strings] }` on success; 500 on any failure with rollback. Uses date-suffixed names like `"Sample Duel - 2026-05-08"` to avoid collision on repeated seeds.
+  - Done when: first POST returns 4 ids, second POST returns 4 more ids with different name suffixes (or with `(2)` increment); `getAllEncounters()` returns 8 rows after both calls.
+- [x] 3.5 Modify `src/pages/gameplay/encounters/[id].tsx` to render a banner above the existing form when `encounterBrokenRefs(...)` reports either side is missing. Banner copy: "This encounter has a broken force reference. The force `<forceId>` was deleted." Plus a "Clear missing player force" / "Clear missing opponent force" button per affected slot. Click → call store action `setPlayerForce(encounterId, null)` / `clearOpponentForce(encounterId)` → reload.
+  - PREREQUISITE: widen `useEncounterStore.setPlayerForce` signature from `(encounterId: string, forceId: string)` to `(encounterId: string, forceId: string | null)` AND update the corresponding API handler (`src/pages/api/encounters/[id]/player-force.ts` or equivalent) to accept `forceId: null` and translate to a `clearPlayerForce()` repository call. The existing setter cannot pass `null` today; this is a 1-line type widening + API branch.
+  - Done when: detail page with a missing player force renders the banner + button. Click triggers the store action.
+- [x] 3.6 Update the encounter list / detail UI tests. NOTE: existing encounter UI tests live under `src/__tests__/pages/gameplay/encounters/` (NOT `src/__tests__/pages/encounters/`); follow the existing convention.
+  - `src/__tests__/pages/gameplay/encounters/index.test.tsx` (NEW) — broken-pill render, seed-button visibility logic, click-to-seed flow.
+  - `src/__tests__/pages/gameplay/encounters/[id]/index.test.tsx` (extend if exists, else NEW) — banner render, clear-action wiring.
+  - `src/__tests__/api/encounters/seed-samples.test.ts` — 4-encounter seed contract, repeated-call collision handling.
+- [x] 3.7 Add a Storybook story for `EncounterCard` covering: `valid`, `no-player-force`, `no-opponent`, `player-missing` (broken), `opponent-missing` (broken), `both-missing`. Co-locate at `src/components/gameplay/encounters/EncounterCard.stories.tsx` if the card component is extracted; otherwise add to `src/pages/gameplay/encounters/index.stories.tsx`.
+- [x] 3.8 Run `npm run typecheck`, `npm run lint`, `npm test`, `npm run storybook:build` clean.
+- [x] 3.9 Open PR 3, CI green, merge.
+
+## 4. Operator cleanup run + final verification
+
+- [x] 4.1 Operator (user) runs `tsx scripts/cleanup-broken-encounters.ts` against the production SQLite DB at the user's machine. Manifest archived to `simulation-reports/cleanup-encounters-<ISO>.json`. Operator visually inspects the manifest and confirms the deleted ids match expectation.
+  - Done when: the user reports the encounter list page shows fewer than 27 stuck-Draft encounters AND the manifest file exists.
+- [x] 4.2 Manual smoke test: delete a force that's referenced by an encounter, refresh `/gameplay/encounters`, confirm the encounter's row drops back to Draft and shows "Force missing" pill. Open the encounter detail page, confirm the banner renders, click clear, confirm the encounter's player force resets to null.
+- [x] 4.3 Manual smoke test: empty the encounter list (delete every encounter), refresh `/gameplay/encounters`, click "Seed sample encounters", confirm 4 new cards appear with the 4 template names.
+- [x] 4.4 `npx openspec validate repair-broken-encounter-drafts --strict` clean. Output captured for the final report.
+
+## 5. Archive
+
+- [x] 5.1 PRs 1, 2, 3 merged to main.
+- [x] 5.2 Memory anchor written to `~/.claude/projects/E--Projects-MekStation/memory/project_repair_broken_encounter_drafts.md` with capability shipped, files touched, lessons.
+- [x] 5.3 `openspec archive repair-broken-encounter-drafts` runs cleanly; deltas merge into `game-session-management/spec.md`.

--- a/openspec/changes/link-encounters-to-replays/design.md
+++ b/openspec/changes/link-encounters-to-replays/design.md
@@ -1,0 +1,179 @@
+# Design: Link Encounters to Replays
+
+## Technical approach
+
+Mirror the proven Quick-game persist pattern end-to-end:
+
+```
+quick:    QuickGameResults.tsx          → persistQuickGame()      → /api/replay-library/quick      → simulation-reports/quick/<gameId>.jsonl + replay-index.json
+encounter: EncounterDetailPage          → persistEncounterGame()  → /api/replay-library/encounter  → simulation-reports/encounter/<gameId>.jsonl + replay-index.json
+```
+
+Identical pipeline layout, identical idiom on every layer (boundary post-stamp, three-gate disk guard, dedup-via-manifest-read, NDJSON file + index append). The only meaningfully different decision is the manifest variant — the rest is "swap `Quick` for `Encounter`, swap the source-specific fields."
+
+The wire-up to the live encounter session uses the same boundary-post-stamp pattern: the `InteractiveSession` (or whatever runs after `launchEncounter`) emits events with whatever source the producer originally wrote. At the persistence boundary we post-stamp `replaySource: ReplaySource.Encounter` over any event missing the field, preserving explicit overrides (so a hypothetical future "encounter inside a campaign" call site can stamp `Campaign` and we don't clobber it).
+
+## Architecture decisions
+
+### Decision: Add `ReplaySource.Encounter` instead of overloading `Quick`
+
+**Choice**: New enum variant (fifth value) + new manifest interface (fifth union member).
+
+**Rationale**: Per the change brief: "Encounters do NOT fit any of these cleanly." Overloading `Quick` would mean:
+
+1. Lying about the discriminator — every consumer that switches on `replaySource === ReplaySource.Quick` would suddenly get encounter rows in the Quick branch. The `aiVariant` field on `IQuickReplayManifestEntry` doesn't exist for encounters; we'd either fake `aiVariant: 'encounter-default'` (nonsense) or make the field optional (breaks existing exhaustiveness contracts).
+2. Breaking the partition rule. The replay-library spec requires the partition directory to match the enum value (`enum value matches partition directory name` scenario). If encounters wrote to `simulation-reports/quick/`, the directory name no longer matches the discriminator, and the bug is two layers deep (manifest entry says Quick, on-disk file lives in `quick/`, but the user knows they ran an encounter).
+3. Silent metadata loss. Encounters have a real `encounterId` + `templateType` + force-summary text that the Library row should render. Forcing those into `aiVariant` mangles them.
+
+The codebase already paid for the cost of "exactly five values" by using the enum-discriminated discriminated-union pattern from sc2reader's lesson — adding a variant is the cheap operation. The exhaustiveness check (`assertNever(entry)` at every `switch (entry.replaySource)`) catches every consumer that needs an `Encounter` case. No silent drift risk.
+
+**Alternatives considered**:
+
+- **Reuse `Campaign`** — campaign-bound encounters have `campaignId`/`contractId`/`scenarioId`; standalone encounters do not. Forcing standalone into `Campaign` requires faking those fields, breaks the `IcampaignReplayManifestEntry.campaignId: string` contract, and conflates two distinct concepts. Rejected.
+- **Single `Game` source with a sub-type tag** — collapses the discriminator we worked hard to put in. Rejected.
+- **Compute the variant lazily from the events** — slow, requires a stream-read on every Library page render to derive the source. Rejected (the discriminator is supposed to be the cheap O(1) discriminant).
+
+### Decision: `playerForceSummary` / `opponentSummary` as strings, not structured objects
+
+**Choice**: The manifest entry stores the force descriptors as already-rendered strings (e.g. `"Lance Alpha (4500 BV, 4 units)"` for explicit forces or `"Generated Lance (~3000 BV)"` for opForConfig-driven), not as `{ name, totalBV, unitCount }` objects.
+
+**Rationale**: Library rows are list cells. They render text. Storing structured data only adds a layer of formatting on the read path — the Library row can't display the data without a stringifier anyway. Keeping the manifest entries cheap (no nested objects) keeps the index file small and parsing fast. The original force ids are NOT stored on the manifest because the manifest entry is a snapshot — the source forces may have been deleted by the time the user opens the replay (the same "broken force reference" condition Change A repairs). Keeping the manifest self-contained means the Library page can render every row without resolving any external references.
+
+**Alternatives considered**:
+
+- **Store force ids + names** — adds a layer of resolution risk; if the force is deleted the row can't render. We took the lesson from Change A: don't depend on external state for replay metadata.
+- **Store full `IForceReference`** — heavier; same problem with stale data.
+
+### Decision: Persist on launch / session-terminal boundary, NOT on encounter status transition
+
+**Choice**: The persist hook fires when the live game session reaches a terminal state (winner / draw / aborted), NOT when `EncounterService.launchEncounter` is called. The launch only mints the `gameSessionId`; the events accumulate during play; at terminal state the persist pipeline runs.
+
+**Rationale**: At launch time there are zero events to write. Events accumulate during play in the existing in-memory event log. The natural persist point is the same as quick games: terminal-state transition. The interactive session already has a "session ended" hook (the same hook that `wire-encounter-to-campaign-round-trip` uses to publish `ICombatOutcome`). We piggyback on it.
+
+**Implementation**: a new `persistEncounterGame()` call inside the InteractiveSession's terminal-state handler. The handler already gathers the final outcome; adding a sibling call to persist the events is the same shape as `persistQuickGame` does in the QuickGameResults effect. Browser-side: this fires from the React component handling the live session view (so the same Node-runtime gate as `persistQuickGame` short-circuits to the API route which does the actual disk write server-side).
+
+**Alternatives considered**:
+
+- **Persist on every event** — orders of magnitude more disk writes; doesn't match the existing pattern.
+- **Persist via a cron-style polling job** — added complexity; events live in memory and could be lost on tab close before the cron fires.
+- **Persist when the user explicitly hits "Save replay"** — adds a UX surface; the user expectation per the OMO Council "Replay Loop Closure" decision is "automatic, like quick games."
+
+### Decision: API route mirrors `quick.ts` exactly, no shared helper extracted
+
+**Choice**: Author `src/pages/api/replay-library/encounter.ts` as a near-copy of `src/pages/api/replay-library/quick.ts` (already shipped in PR #557). Same dedup logic, same parseBody shape, same `GAME_ID_PATTERN` regex. Do NOT extract a shared helper file.
+
+**Rationale**: Per the change brief: "duplicate it, don't share a generic wrapper." Two near-identical routes with one regex copied and one parseBody pattern copied is 50 lines of duplication; a generic wrapper that accepts a `(input) => persistFn(input)` callback would also be 50 lines of generic plumbing AND require all callers to thread their custom validation through a hook system. The duplication is cheaper. If a third route appears (campaign), revisit.
+
+The convention is also explicit in the existing `quick.ts` source comment: `"Validation pattern mirrors the sibling [source]/[gameId].ts route: inline runtime checks (no Zod — established convention in this directory; future consolidation is a separate sweep)"`. We're consistent with that convention.
+
+**Alternatives considered**:
+
+- **Extract `src/pages/api/replay-library/_shared.ts`** — explicit guideline says no.
+- **Single generic `POST /api/replay-library/persist` route with `replaySource` in the body** — flattens the API surface but loses per-source validation specificity (an encounter request with `aiVariant` should error; that's harder to express with a polymorphic handler).
+
+### Decision: Backfill scan picks up Encounter partition automatically
+
+**Choice**: `src/replay-library/backfill-scan.ts` already iterates `Object.values(ReplaySource)` for the partition layout. Adding the variant adds the partition without code change to the scanner. The `inferReplaySource(filePath)` helper in the scanner uses a switch on the partition directory name — we add the `case 'encounter': return ReplaySource.Encounter` line.
+
+**Rationale**: The replay-library spec scenario "Scan covers new partition layout" already covers per-source partition coverage. The scanner is generic over the enum. The only real additions are the type narrowing for building `IEncounterReplayManifestEntry` from a scanned file — that needs the encounter-specific fields, which we derive from the first `GameCreated` event's `payload` (which `EncounterService.launchEncounter` will stamp with `encounterId`, `encounterName`, etc.).
+
+**Alternatives considered**:
+
+- **No scan support; only forward-emit** — leaves the scanner inconsistent across enum values. Bad.
+
+### Decision: No data migration needed
+
+**Choice**: No existing encounter event logs on disk → no migration. Pre-cutover encounters are simply not replayable; users accept this.
+
+**Rationale**: Today the `EncounterService.launchEncounter` writes ZERO events. There is nothing on disk under any partition for encounters. The "Replay Library backfill scan" requirement covers swarm + quick + future variants; adding Encounter to the scan covers any future runs but has nothing to backfill from before the change ships.
+
+## Data flow
+
+**Today (broken):**
+
+```
+launchEncounter(E)
+   └→ buildGameUnitsFromEncounter(E)
+   └→ createGameSession(config, units)  → returns IGameSession with gameSessionId
+   └→ encounterRepository.linkGameSession(E.id, session.id)
+       (events accumulate in memory during play, never persist)
+   └→ session ends → events evaporate → no Replay Library entry
+```
+
+**After this change:**
+
+```
+launchEncounter(E)
+   └→ buildGameUnitsFromEncounter(E)
+   └→ createGameSession(config, units)  → returns IGameSession with gameSessionId
+   └→ encounterRepository.linkGameSession(E.id, session.id)
+       (events accumulate in memory during play, with replaySource: ReplaySource.Encounter post-stamped)
+   └→ session terminal state →
+       └→ POST /api/replay-library/encounter { gameId, events, encounterId, encounterName, templateType, playerForceSummary, opponentSummary, winner }
+            └→ dedup check via readReplayIndex
+            └→ persistEncounterGame
+                  └→ write simulation-reports/encounter/<gameId>.jsonl
+                  └→ appendManifestEntry IEncounterReplayManifestEntry
+       └→ Replay Library page picks up the new entry on next mount; filter "Encounter" surfaces it; click → existing replay viewer plays it back.
+```
+
+## File changes
+
+- **NEW**: `src/components/encounter/persistEncounterGame.ts`  — Node-only pipeline. Exports `IPersistEncounterGameInput`, `IPersistEncounterGameResult`, `buildEncounterManifestEntry`, `persistEncounterGame`. Mirrors the `persistQuickGame.ts` shape exactly: same `shouldPersistToDisk` three-gate guard duplicated (NOT shared — per the change brief), same boundary post-stamp via `stampEncounterReplaySource`, same NDJSON file write + `appendManifestEntry` call.
+- **NEW**: `src/pages/api/replay-library/encounter.ts` — POST handler. Inline runtime validation. Dedup via `readReplayIndex` + id check. Same response shape as `/api/replay-library/quick` (`{ persisted, alreadyPersisted, manifestEntry, path }`).
+- **MODIFIED**: `src/types/gameplay/GameSessionInterfaces.ts:291-296` — add fifth enum entry `Encounter = 'encounter'`. Update the `Object.values(ReplaySource)` length-asserting tests to expect five.
+- **MODIFIED**: `src/replay-library/types.ts` — add `IEncounterReplayManifestEntry` interface and append it to the `IReplayManifestEntry` union. Source-specific fields: `encounterId: string`, `encounterName: string`, `templateType: ScenarioTemplateType | null`, `playerForceSummary: string`, `opponentSummary: string`.
+- **MODIFIED**: `src/replay-library/backfill-scan.ts` — extend the partition switch with `case 'encounter'` returning `ReplaySource.Encounter` AND add the encounter manifest entry builder mirroring the existing per-source builders. The first `GameCreated` event SHALL carry the encounter metadata as part of its payload — `EncounterService.launchEncounter` stamps these.
+- **MODIFIED**: `src/services/encounter/EncounterService.ts:290-367` (`launchEncounter`) — at session terminal state, post-stamp `ReplaySource.Encounter` over the event log AND POST to `/api/replay-library/encounter`. Implementation lives at the boundary the InteractiveSession already exposes for outcome publishing — `wire-encounter-to-campaign-round-trip` Wave 5 already added that hook. Plus: include encounter metadata in the `GameCreated` event payload so the backfill scan can recover it.
+- **MODIFIED**: `src/components/replay-library/ReplayLibraryPage.tsx` — extend the row-renderer switch with the `case ReplaySource.Encounter` branch (renders `encounterName`, `templateType` label, `playerForceSummary` vs `opponentSummary`). Add the fifth filter button "Encounter" to the `SOURCE_FILTERS` array. The exhaustiveness `assertNever(entry)` switch picks up the variant for free.
+- **NO CHANGE**: `src/pages/api/replay-library/[source]/[gameId].ts` — already validates against `RECOGNIZED_REPLAY_SOURCES = new Set(Object.values(ReplaySource))`. Adding the enum value extends the recognized set automatically.
+
+## Test strategy
+
+- **Pipeline** (`src/components/encounter/__tests__/persistEncounterGame.test.ts`) — 5 scenarios mirroring `persistQuickGame.test.ts`:
+  - happy path with explicit cwd: writes file, appends manifest entry, returns `persisted: true`
+  - browser env (`shouldPersistToDisk` returns false): no file write, returns `persisted: false, manifestEntry: null`
+  - test env without cwd: no file write (jest no-op gate)
+  - explicit non-Encounter `replaySource` value preserved (post-stamp doesn't clobber existing values)
+  - manifest entry shape matches `IEncounterReplayManifestEntry` discriminant + all fields populated correctly
+- **API route** (`src/pages/api/replay-library/__tests__/encounter.test.ts`):
+  - happy path (POST → 200, persisted: true, manifestEntry returned)
+  - dedup (POST same gameId twice → first 200 persisted, second 200 alreadyPersisted)
+  - bad gameId (regex mismatch → 400)
+  - missing required fields (no `encounterId` → 400)
+  - non-POST (GET → 405)
+  - persistEncounterGame throws → 500
+- **Backfill scan** (`src/replay-library/__tests__/backfill-scan.test.ts`) — extend existing test with one Encounter fixture under `simulation-reports/encounter/<gameId>.jsonl`; assert the scan returns one `IEncounterReplayManifestEntry` with `encounterId`, `encounterName`, etc. populated from the first `GameCreated` event payload.
+- **Replay Library page** (`src/components/replay-library/__tests__/ReplayLibraryPage.test.tsx`) — extend existing test:
+  - filter set has 5 buttons (All / Swarm / Quick / PvP / Campaign / Encounter) — the change brief says the page gets a 5th filter (Encounter); the existing 4 source filters + All means the button strip goes from 5 to 6
+  - row renders `encounterName` + template + force summaries when `replaySource === ReplaySource.Encounter`
+  - click-through to viewer works
+- **Integration** (`src/services/encounter/__tests__/EncounterService.persist.test.ts`) — high-fidelity test: launch encounter → mock-run to terminal state → assert POST fired to `/api/replay-library/encounter` with the right body shape. Spies on the persistence boundary; doesn't actually run a real game session. The persist call's success is verified separately by the pipeline tests above.
+- **Enum value tests** — extend `replay-library/types.test.ts` `Object.values(ReplaySource).length` assertion from 4 → 5 (and update the swarm/quick assertions to NOT assert "exactly four values" — they currently do).
+
+## Test infrastructure
+
+Existing — Jest + jsdom + Node-env switching pattern is established (`persistQuickGame.test.ts` is the canonical example). API route tests use `next-test-api-route-handler` or the existing in-process pattern (whichever `quick.test.ts` uses; mirror).
+
+## Rollout
+
+Single PR or small ladder. The change is small enough (one enum value + one manifest interface + one new pipeline + one new API route + UI tweaks) to ship as ONE PR if Atlas is comfortable. If we ladder:
+
+1. **Tier 1** — types + enum + manifest interface + backfill-scan support. PR #1. Behavior change: zero (no callers yet).
+2. **Tier 2** — `persistEncounterGame` pipeline + `/api/replay-library/encounter` route + tests. PR #2. Behavior change: zero (no callers yet — the pipeline is unit-tested, route works in isolation).
+3. **Tier 3** — wire `EncounterService.launchEncounter` to fire the persist call on terminal state + ReplayLibraryPage filter+row renderer + UI tests. PR #3. Behavior change: encounter battles now appear in the Replay Library.
+
+Each tier independently passes typecheck/test/build. Tier 3 is the user-visible flip.
+
+## Risk + mitigation
+
+- **Risk**: a fifth `ReplaySource` variant breaks consumers that had been writing exhaustive switches. **Mitigation**: that's the point — the compiler tells us every consumer to update. We list known consumers in advance: `ReplayLibraryPage.tsx` row renderer, the backfill scan, the API route filter set (`RECOGNIZED_REPLAY_SOURCES`). Tests across all of these fail until each `Encounter` case is added.
+- **Risk**: encounter session never reaches terminal state (user closes tab). **Mitigation**: same risk as quick games today — events evaporate. Acceptable for v1; the IndexedDB local-buffer follow-on (already named for quick) covers both.
+- **Risk**: campaign-bound encounters might "want" to persist as `Campaign` not `Encounter`. **Mitigation**: explicit decision — campaign-bound encounters still emit as Encounter, with the campaign linkage threaded onto the GameCreated event payload. The `Campaign` variant is reserved for future campaign-driven scoring/contract sessions that don't go through `launchEncounter`. If the user wants both views ("show as Encounter" and "show as Campaign"), that's a follow-on feature.
+- **Risk**: `templateType: null` (custom encounter without a template) renders awkwardly in the row. **Mitigation**: row renderer falls back to the literal `"Custom"` label when `templateType === null`.
+
+## Open questions
+
+- **Q**: Should the encounter row link directly back to `/gameplay/encounters/[id]` (the source encounter) for context? **A**: Defer. The replay viewer is enough for v1; cross-linking is a UX polish.
+- **Q**: Do we need to dedup encounters that have been re-launched (same `encounterId`, different `gameSessionId`)? **A**: NO. Each launch produces a fresh `gameSessionId` which is the manifest `id`. Multiple launches of the same encounter produce multiple distinct replay entries — that's the right behavior; the user can scroll through their attempts.
+- **Q**: Should the encounter-name / force-summary text be localized? **A**: Defer. The codebase has no i18n machinery yet; persisting raw text is fine.

--- a/openspec/changes/link-encounters-to-replays/proposal.md
+++ b/openspec/changes/link-encounters-to-replays/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+The Replay Library page lists swarm runs and quick games but **encounter battles are invisible** — when the user launches an encounter from `/gameplay/encounters/[id]`, `EncounterService.launchEncounter()` mints a `gameSessionId` and hands off to the live game session, but **zero events are persisted to disk**. The session ends, the React tree unmounts, the events evaporate. The Replay Library page has no entry for the battle, the user can't replay it, and the discoverability work shipped in PRs #548–#553 stops one click short of "encounter battles are first-class replays."
+
+Quick games already solved the same problem: `persistQuickGame.ts` writes events to `simulation-reports/quick/<gameId>.jsonl` and appends to `replay-index.json`; the missing piece for quick was the API route, shipped in PR #557 (`/api/replay-library/quick`). Encounters need the same shape — a `persistEncounterGame.ts` pipeline + a `POST /api/replay-library/encounter` route — but the manifest needs a new variant because encounter metadata is genuinely different from any of the four existing `ReplaySource` values:
+
+- Not `Swarm` — encounters aren't CLI-driven and don't have `configName`/`seed`/`batchTimestamp`.
+- Not `Quick` — encounters have user-configured forces / opForConfig / map / victory conditions, not the hard-coded duel scaffold of QuickGameScenarios.
+- Not `PvP` — encounters are PvE single-player.
+- Not `Campaign` — encounters can be standalone (no `campaignId` / `contractId` / `scenarioId`) or campaign-bound (the `wire-encounter-to-campaign-round-trip` linkage). Forcing standalone encounters into the campaign variant would either lie (fake campaignId) or bend the campaign manifest schema.
+
+The clean answer is the fifth `ReplaySource.Encounter` variant with its own `IEncounterReplayManifestEntry` carrying `encounterId`, `encounterName`, `templateType`, `playerForceSummary`, and `opponentSummary`. The existing exhaustiveness checks at every consumer site fail compilation as soon as the variant lands, so the rollout naturally surfaces every place that needs an Encounter case.
+
+## What Changes
+
+- **NEW** `ReplaySource.Encounter = 'encounter'` added to the existing enum at `src/types/gameplay/GameSessionInterfaces.ts:291-296` (fifth value).
+- **NEW** `IEncounterReplayManifestEntry` member of the `IReplayManifestEntry` discriminated union at `src/replay-library/types.ts`. Source-specific fields: `encounterId: string`, `encounterName: string`, `templateType: ScenarioTemplateType | null`, `playerForceSummary: string`, `opponentSummary: string` (string description like `"Lance: Alpha (4500 BV)"` or `"Generated Lance (~3000 BV)"` to keep manifest entries cheap to render).
+- **NEW** filesystem partition: `simulation-reports/encounter/<gameId>.jsonl`. Existing partition layout already requires the directory name to match the enum value; adding the variant adds the partition.
+- **NEW** `src/components/encounter/persistEncounterGame.ts` Node-only pipeline that mirrors `persistQuickGame.ts` (same three-gate `shouldPersistToDisk` check, same `replaySource` post-stamp at the boundary, same NDJSON write + `appendManifestEntry` call). Browser builds short-circuit to a no-op via the same Node-runtime gate.
+- **NEW** `POST /api/replay-library/encounter` route at `src/pages/api/replay-library/encounter.ts` that mirrors the `quick.ts` route shape (inline runtime validation, no Zod; dedup-guard via `readReplayIndex` + `id` set check; same `IPersistEncounterGameInput` body validation idiom).
+- **MODIFIED** `EncounterService.launchEncounter()` (`src/services/encounter/EncounterService.ts:290-367`) now stamps `replaySource: ReplaySource.Encounter` on every event the live session emits, by post-stamping at the runner boundary the same way `SimulationRunner.run()` (PR #551) and `persistQuickGame()` (PR #552) post-stamp at their boundaries. Today the live encounter session writes nothing; this change adds the persist hook on session terminal state.
+- **MODIFIED** Replay Library page UI — the source-filter button strip gets a fifth "Encounter" filter; the row renderer adds an `Encounter`-case branch displaying `encounterName` + `templateType` (or "Custom" if null) + `playerForceSummary` vs `opponentSummary`; the exhaustiveness `assertNever(entry)` switch picks up the variant for free.
+- **MODIFIED** Replay Library backfill scan (`src/replay-library/backfill-scan.ts`) to walk the new `simulation-reports/encounter/` partition. The scan already covers `simulation-reports/<source>/*.jsonl` for each enum value; adding the variant adds the partition automatically (the scanner iterates `Object.values(ReplaySource)`).
+- **MODIFIED** `replay-library` spec — `ReplaySource Enum` requirement updated from "exactly four values" to "exactly five values"; `IReplayManifestEntry Discriminated Union` requirement updated to include the fifth member; `Filesystem Partition Layout` requirement gets an Encounter scenario; `Replay Library Page` requirement gets a fifth-filter scenario.
+
+**OUT OF SCOPE** — Battle reviewing UX inside the encounter detail page (the user can navigate from the Replay Library row); replay deletion/archival (existing follow-on); encounter-specific replay metrics (e.g. salvage-claim summary on the row — would require campaign linkage, defer).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `replay-library` — adds the fifth `ReplaySource` enum value, the fifth manifest variant, the fifth filesystem partition, the fifth list-page filter, and a backfill-scan branch.
+- `game-session-management` — adds the persist-on-launch hook in `EncounterService.launchEncounter` so encounter-driven sessions emit and persist event logs the same way swarm and quick games do.
+
+### New Capabilities
+
+None — this change rides existing capabilities.
+
+## Impact
+
+- **Code**: `src/types/gameplay/GameSessionInterfaces.ts` (one-line enum addition), `src/replay-library/types.ts` (new manifest interface + union member), `src/replay-library/backfill-scan.ts` (Encounter case in the per-source scan branch), new `src/components/encounter/persistEncounterGame.ts` (~150 LOC mirroring `persistQuickGame.ts`), new `src/pages/api/replay-library/encounter.ts` (~120 LOC mirroring `quick.ts`), `src/services/encounter/EncounterService.ts` (post-stamp at runner boundary + persist call on terminal state), `src/components/replay-library/ReplayLibraryPage.tsx` (Encounter case in the row-renderer switch + filter button), `src/pages/api/replay-library/[source]/[gameId].ts` (no code change — already iterates `Object.values(ReplaySource)`).
+- **Filesystem**: `simulation-reports/encounter/` partition directory; manifest entries with `replaySource: 'encounter'` and `path: 'encounter/<gameId>.jsonl'`.
+- **Tests**: `persistEncounterGame.test.ts` (5+ scenarios mirroring `persistQuickGame.test.ts`), `pages/api/replay-library/encounter.test.ts` (route validation + dedup + persist round-trip), `replay-library/backfill-scan.test.ts` (extend to add Encounter partition fixture), `ReplayLibraryPage.test.tsx` (extend filter test + add Encounter row-renderer test), one `EncounterService.persist.test.ts` integration covering "launch → run to terminal state → assert manifest entry present + jsonl on disk."
+- **Existing data**: zero impact — there are no existing encounter event logs on disk, so no backfill migration is needed. Future encounter runs persist forward; today's encounters that have already-finished `gameSessionId` rows simply have no replay (acceptable; the user knows pre-cutover battles aren't replayable).
+- **Out of scope (this change)**: encounter detail page does NOT add a "Watch latest replay" CTA (covered by the existing Replay Library navigation); encounter row does NOT show salvage / outcome metadata (would require pulling from campaign post-battle processors — separate change); encounter-specific replay deletion remains the same global delete mechanism.

--- a/openspec/changes/link-encounters-to-replays/specs/game-session-management/spec.md
+++ b/openspec/changes/link-encounters-to-replays/specs/game-session-management/spec.md
@@ -1,0 +1,92 @@
+# Game Session Management Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Encounter Battle Replay Persistence
+
+When an encounter battle launched via `EncounterService.launchEncounter` reaches a terminal state (winner / draw / aborted), the system SHALL persist the full event log to `simulation-reports/encounter/<gameId>.jsonl` AND append an `IEncounterReplayManifestEntry` to `simulation-reports/replay-index.json`. The persist hook SHALL fire from the same terminal-state boundary the campaign outcome publish hook uses.
+
+The persist call SHALL go through `POST /api/replay-library/encounter` (Node-side filesystem write) — the React component cannot write directly. The component SHALL guard against double-fire on remount via the same useRef+effect pattern `QuickGameResults` uses for the quick persist.
+
+The encounter metadata stamped onto the persist payload SHALL be a snapshot taken at launch time:
+
+- `encounterId` — the source encounter row id
+- `encounterName` — the encounter name as it was at launch
+- `templateType` — the scenario template applied, or `null` for fully-custom encounters
+- `playerForceSummary` — `"<forceName> (<totalBV> BV, <unitCount> units)"` when `playerForce` is non-null; `"<forceId> (missing force)"` if the player force was broken at launch time
+- `opponentSummary` — same shape for explicit opponent forces; `"Generated <type> (~<targetBV> BV)"` for opForConfig-driven opponents
+
+The metadata SHALL be embedded in the `GameCreated` event's payload AND in the persist call's request body — both copies stay in sync because the persist call derives from the event log.
+
+#### Scenario: Persist on encounter terminal state
+
+- **GIVEN** an encounter `E` with `playerForce.forceName='Alpha Lance'`, `playerForce.totalBV=4500`, `playerForce.unitCount=4`
+- **AND** `E` was launched via `EncounterService.launchEncounter(E.id)` producing `gameSessionId='session-77'`
+- **WHEN** the live session reaches terminal state
+- **THEN** `POST /api/replay-library/encounter` SHALL be called with body containing `gameId='session-77'`, `encounterId=E.id`, `encounterName=E.name`, `playerForceSummary='Alpha Lance (4500 BV, 4 units)'`
+- **AND** the file `simulation-reports/encounter/session-77.jsonl` SHALL exist on disk after the call returns
+- **AND** the manifest entry in `replay-index.json` SHALL have `replaySource: 'encounter'`
+
+#### Scenario: Custom encounter (no template) persists with null templateType
+
+- **GIVEN** an encounter `E` with `template=undefined` (built from scratch without a template)
+- **WHEN** `E` is launched and reaches terminal state
+- **THEN** the persist call SHALL include `templateType: null` in its body
+- **AND** the manifest entry SHALL have `templateType: null`
+
+#### Scenario: opForConfig-driven encounter persists generated summary
+
+- **GIVEN** an encounter `E` with `opForConfig` set and `opponentForce=undefined`
+- **AND** `E.opForConfig.targetBV=3000`
+- **WHEN** `E` is launched and reaches terminal state
+- **THEN** the `opponentSummary` field on the persist body SHALL contain the literal substring `'Generated'` AND the literal substring `'3000'`
+
+#### Scenario: Double-fire guard
+
+- **GIVEN** an encounter that has already persisted to the Replay Library
+- **WHEN** the React component remounts and the persist effect would re-fire
+- **THEN** the second persist call SHALL hit the API route's dedup guard
+- **AND** the response SHALL be `{ persisted: false, alreadyPersisted: true, ... }`
+- **AND** no second NDJSON file SHALL be written
+- **AND** the manifest SHALL NOT contain a duplicate entry for the same `gameId`
+
+#### Scenario: ReplaySource post-stamp at persist boundary
+
+- **GIVEN** a completed encounter session with events that do not have `replaySource` populated
+- **WHEN** the persist pipeline runs
+- **THEN** every event written to disk SHALL carry `replaySource: ReplaySource.Encounter`
+
+#### Scenario: Explicit non-Encounter ReplaySource preserved
+
+- **GIVEN** an event in the encounter session log that already has `replaySource: ReplaySource.Campaign` (a hypothetical campaign-bound emitter that pre-stamped its own source)
+- **WHEN** the persist pipeline post-stamps the events
+- **THEN** the existing `replaySource: ReplaySource.Campaign` value SHALL be preserved
+- **AND** the post-stamp SHALL only add `ReplaySource.Encounter` to events whose `replaySource` is `undefined`
+
+### Requirement: Encounter Metadata in GameCreated Event
+
+The `GameCreated` event emitted at encounter launch SHALL carry the encounter metadata in its payload so the replay-library backfill scan can reconstruct the manifest entry from the event log alone (without relying on external state).
+
+The `GameCreated.payload` SHALL include:
+
+- `encounterId: string` — the source encounter row id
+- `encounterName: string` — encounter name snapshot at launch
+- `templateType: ScenarioTemplateType | null` — null for custom encounters
+- `playerForceSummary: string` — pre-rendered player descriptor
+- `opponentSummary: string` — pre-rendered opponent descriptor
+
+These fields SHALL be set ONLY for encounters launched via `EncounterService.launchEncounter`. Quick-game and swarm `GameCreated` events SHALL NOT carry the encounter fields (they are TypeScript-narrowed via the source discriminator).
+
+#### Scenario: Launch stamps metadata on GameCreated
+
+- **GIVEN** an encounter `E` with `id='encounter-abc'`, `name='Foothold Strike'`, `template=ScenarioTemplateType.Skirmish`
+- **WHEN** `EncounterService.launchEncounter(E.id)` is called
+- **THEN** the first event emitted by the resulting session SHALL be a `GameCreated`
+- **AND** that event's `payload` SHALL include `encounterId: 'encounter-abc'`, `encounterName: 'Foothold Strike'`, `templateType: 'Skirmish'`
+
+#### Scenario: Backfill scan recovers metadata from GameCreated
+
+- **GIVEN** an `simulation-reports/encounter/session-77.jsonl` whose first event is a `GameCreated` with the encounter metadata in its payload
+- **WHEN** the backfill scan processes the file
+- **THEN** the produced `IEncounterReplayManifestEntry` SHALL have all five encounter-specific fields populated from that single event
+- **AND** the scan SHALL NOT call `EncounterRepository.getEncounterById` (the manifest is reconstructable from the file alone)

--- a/openspec/changes/link-encounters-to-replays/specs/replay-library/spec.md
+++ b/openspec/changes/link-encounters-to-replays/specs/replay-library/spec.md
@@ -1,0 +1,252 @@
+# Replay Library Spec Delta
+
+## ADDED Requirements
+
+### Requirement: IEncounterReplayManifestEntry Variant
+
+The `IReplayManifestEntry` discriminated union SHALL include a fifth member `IEncounterReplayManifestEntry` whose `replaySource` discriminant is `ReplaySource.Encounter`. The interface SHALL extend `IReplayManifestEntryBase` and add the source-specific fields:
+
+- `encounterId: string` — the source encounter row id
+- `encounterName: string` — snapshot of the encounter name at launch time
+- `templateType: ScenarioTemplateType | null` — the scenario template applied (Duel / Skirmish / Battle / Custom), or `null` for fully-custom encounters
+- `playerForceSummary: string` — already-rendered text describing the player force (e.g. `"Lance Alpha (4500 BV, 4 units)"`)
+- `opponentSummary: string` — already-rendered text describing the opponent (`"Lance Bravo (3800 BV, 4 units)"` for explicit forces; `"Generated Lance (~3000 BV)"` for opForConfig-driven)
+
+The summaries SHALL be stored as strings (not structured objects) so the Library row can render them without resolving any external state. The encounter row in `EncounterRepository` MAY have been deleted by the time the user reads the manifest entry; the manifest SHALL remain self-contained.
+
+`bvTotal` (inherited from the base) SHALL be computed at write time from the first `GameCreated` event's `payload.units` summed `.bv` fields, identical to the swarm and quick variants.
+
+#### Scenario: Encounter manifest entry has source-specific fields
+
+- **GIVEN** an encounter battle with `encounterId='encounter-abc'`, `encounterName='Foothold Strike'`, `templateType=ScenarioTemplateType.Skirmish`, completed `gameId='session-77'`
+- **WHEN** the writer produces the manifest entry
+- **THEN** the entry SHALL be an `IEncounterReplayManifestEntry`
+- **AND** `entry.replaySource` SHALL equal `ReplaySource.Encounter`
+- **AND** `entry.encounterId` SHALL equal `'encounter-abc'`
+- **AND** `entry.encounterName` SHALL equal `'Foothold Strike'`
+- **AND** `entry.templateType` SHALL equal `ScenarioTemplateType.Skirmish`
+- **AND** `entry.id` SHALL equal `'session-77'`
+
+#### Scenario: Custom encounter has null templateType
+
+- **GIVEN** an encounter created without a scenario template (the user built it from scratch)
+- **WHEN** the writer produces the manifest entry
+- **THEN** `entry.templateType` SHALL be `null`
+- **AND** the Library row SHALL render the fallback label `"Custom"` for the template column
+
+#### Scenario: Discriminated union narrows on Encounter
+
+- **GIVEN** a value of type `IReplayManifestEntry`
+- **WHEN** code reads `entry.replaySource === ReplaySource.Encounter` inside a TypeScript narrowing branch
+- **THEN** within the narrowed branch, accessing `entry.encounterId` SHALL compile without further type assertion
+
+#### Scenario: Force summary survives source-force deletion
+
+- **GIVEN** an encounter manifest entry with `playerForceSummary='Lance Alpha (4500 BV, 4 units)'`
+- **AND** the source force `'Alpha'` has been deleted from the `ForceRepository` after the manifest entry was written
+- **WHEN** the Library row renders the entry
+- **THEN** the row SHALL display the literal text `'Lance Alpha (4500 BV, 4 units)'`
+- **AND** the render SHALL NOT call `getForceById` or any other resolution function
+
+## MODIFIED Requirements
+
+### Requirement: ReplaySource Enum
+
+The system SHALL define a `ReplaySource` enum with exactly the values `Swarm`, `Quick`, `PvP`, `Campaign`, and `Encounter`. The serialized string values SHALL be `'swarm'`, `'quick'`, `'pvp'`, `'campaign'`, and `'encounter'` respectively. The enum SHALL be the single source of truth for replay-source discrimination at every layer (envelope field, manifest entry discriminant, filesystem partition directory name, library page filter values).
+
+#### Scenario: Enum has exactly five values
+
+- **GIVEN** the `ReplaySource` enum
+- **WHEN** `Object.values(ReplaySource)` is computed
+- **THEN** the result SHALL equal `['swarm', 'quick', 'pvp', 'campaign', 'encounter']` in any order
+
+#### Scenario: Enum value matches partition directory name
+
+- **GIVEN** any `ReplaySource` value `s`
+- **WHEN** the writer derives the filesystem partition path for `s`
+- **THEN** the partition directory name SHALL equal the string value of `s` (e.g. `ReplaySource.Encounter` → `simulation-reports/encounter/`)
+
+#### Scenario: Exhaustive switch fails compilation if a variant is missed
+
+- **GIVEN** a `switch (entry.replaySource)` statement that omits one of the five cases
+- **WHEN** TypeScript compilation runs in strict mode
+- **THEN** compilation SHALL fail with a `Type 'ReplaySource' is not assignable to type 'never'` error or equivalent exhaustiveness error
+
+### Requirement: IReplayManifestEntry Discriminated Union
+
+The system SHALL define an `IReplayManifestEntry` discriminated union with exactly five member interfaces — one per `ReplaySource` value. Every member SHALL extend a base interface with the fields `id: string` (the `gameId`), `replaySource: ReplaySource`, `path: string` (relative to `simulation-reports/`), `createdAt: string` (ISO 8601), `turns: number`, `winner: GameSide | null`, and `bvTotal: number`.
+
+Each member SHALL add source-specific fields:
+
+- `ISwarmReplayManifestEntry` (`replaySource: ReplaySource.Swarm`): `configName: string`, `seed: number`, `batchTimestamp: string`
+- `IQuickReplayManifestEntry` (`replaySource: ReplaySource.Quick`): `playerSide: GameSide`, `aiVariant: string`
+- `IPvPReplayManifestEntry` (`replaySource: ReplaySource.PvP`): `opponentName: string`, `matchId: string`
+- `ICampaignReplayManifestEntry` (`replaySource: ReplaySource.Campaign`): `campaignId: string`, `missionId: string`, `difficulty: string`
+- `IEncounterReplayManifestEntry` (`replaySource: ReplaySource.Encounter`): `encounterId: string`, `encounterName: string`, `templateType: ScenarioTemplateType | null`, `playerForceSummary: string`, `opponentSummary: string`
+
+`bvTotal` SHALL be computed at manifest-write time from unit data — consumers SHALL NOT lazy-recompute on read.
+
+#### Scenario: Swarm manifest entry has source-specific fields
+
+- **GIVEN** a `SimulationRunner` invocation with `configName='duel-3kbv-temperate'`, `seed=42`, completed `gameId='sim-7'`
+- **WHEN** the writer produces the manifest entry
+- **THEN** the entry SHALL be an `ISwarmReplayManifestEntry`
+- **AND** `entry.replaySource` SHALL equal `ReplaySource.Swarm`
+- **AND** `entry.configName` SHALL equal `'duel-3kbv-temperate'`
+- **AND** `entry.seed` SHALL equal `42`
+- **AND** `entry.id` SHALL equal `'sim-7'`
+
+#### Scenario: Quick manifest entry has source-specific fields
+
+- **GIVEN** a quick-game completion with `playerSide=GameSide.Player`, `aiVariant='aggressive-v2'`
+- **WHEN** the writer produces the manifest entry
+- **THEN** the entry SHALL be an `IQuickReplayManifestEntry`
+- **AND** `entry.replaySource` SHALL equal `ReplaySource.Quick`
+- **AND** `entry.aiVariant` SHALL equal `'aggressive-v2'`
+
+#### Scenario: bvTotal is stored at write time not derived on read
+
+- **GIVEN** a manifest entry written with `bvTotal=4500`
+- **WHEN** the entry is read from the index
+- **THEN** `entry.bvTotal` SHALL equal `4500`
+- **AND** the read path SHALL NOT execute any BV-recomputation code path
+
+#### Scenario: Discriminated union narrows on replaySource
+
+- **GIVEN** a value of type `IReplayManifestEntry`
+- **WHEN** code reads `entry.replaySource === ReplaySource.Swarm` inside a TypeScript narrowing branch
+- **THEN** within the narrowed branch, accessing `entry.configName` SHALL compile without further type assertion
+
+#### Scenario: Encounter manifest entry has source-specific fields
+
+- **GIVEN** an encounter battle with `encounterId='encounter-abc'`, `encounterName='Foothold Strike'`, `templateType=ScenarioTemplateType.Skirmish`, completed `gameId='session-77'`
+- **WHEN** the writer produces the manifest entry
+- **THEN** the entry SHALL be an `IEncounterReplayManifestEntry`
+- **AND** `entry.replaySource` SHALL equal `ReplaySource.Encounter`
+- **AND** `entry.encounterName` SHALL equal `'Foothold Strike'`
+- **AND** `entry.templateType` SHALL equal `ScenarioTemplateType.Skirmish`
+
+### Requirement: Filesystem Partition Layout
+
+The repository SHALL persist replay event logs under partition directories at `simulation-reports/<source>/<gameId>.jsonl`, where `<source>` is the string value of one of the five `ReplaySource` enum variants. Writers SHALL NOT write swarm logs to the legacy flat path `simulation-reports/games/<run-timestamp>/<gameId>.jsonl` after this change ships.
+
+The `simulation-reports/` directory SHALL also contain a single `replay-index.json` file at its top level, alongside the five partition directories.
+
+#### Scenario: Swarm runner writes under simulation-reports/swarm/
+
+- **GIVEN** a swarm invocation that produces `gameId='sim-1'`
+- **WHEN** the runner writes the event log
+- **THEN** the file SHALL exist at `simulation-reports/swarm/sim-1.jsonl`
+- **AND** no file SHALL be written under `simulation-reports/games/`
+
+#### Scenario: Quick game persists under simulation-reports/quick/
+
+- **GIVEN** a quick-game completion with `gameId='quick-99'`
+- **WHEN** the QuickGameResults page completes its persist effect
+- **THEN** the file SHALL exist at `simulation-reports/quick/quick-99.jsonl`
+
+#### Scenario: Encounter battle persists under simulation-reports/encounter/
+
+- **GIVEN** an encounter battle that reaches terminal state with `gameId='session-77'`
+- **WHEN** the persist pipeline completes
+- **THEN** the file SHALL exist at `simulation-reports/encounter/session-77.jsonl`
+- **AND** the `replay-index.json` SHALL contain a manifest entry with `replaySource: 'encounter'` and `path: 'encounter/session-77.jsonl'`
+
+#### Scenario: Index file lives next to partitions
+
+- **GIVEN** the populated `simulation-reports/` directory
+- **WHEN** its top-level entries are listed
+- **THEN** `replay-index.json` SHALL be present alongside the partition directories
+
+### Requirement: Backfill Scan
+
+The system SHALL provide a backfill scan that produces a `readonly IReplayManifestEntry[]` from the contents of `simulation-reports/`. The scan SHALL examine both the new partition layout (`simulation-reports/<source>/*.jsonl`) AND the legacy flat layout (`simulation-reports/games/<timestamp>/*.jsonl`).
+
+For each NDJSON file discovered, the scan SHALL stream-read enough lines to extract:
+
+- The first event (which SHALL be `GameCreated`) — used to derive `bvTotal` from `payload.units` and source-specific metadata as available. For encounter partitions, the scan SHALL extract `encounterId`, `encounterName`, `templateType`, `playerForceSummary`, and `opponentSummary` from the `GameCreated.payload`.
+- The last `GameEnded` event (if present) — used to derive `winner` and `turns`. If `GameEnded.turns` is absent or undefined, `turns` SHALL fall back to the count of `turn_started` events in the file, then to `0` if no `turn_started` events exist.
+
+For legacy flat-layout files, the scan SHALL infer `replaySource = ReplaySource.Swarm` (legacy directory only contained swarm output) and SHALL set `batchTimestamp` from the parent directory name.
+
+The scan SHALL be idempotent: re-running on the same disk state SHALL produce the same manifest array.
+
+#### Scenario: Scan covers new partition layout
+
+- **GIVEN** `simulation-reports/swarm/sim-1.jsonl`, `simulation-reports/quick/quick-9.jsonl`, `simulation-reports/encounter/session-77.jsonl` exist
+- **WHEN** the backfill scan runs
+- **THEN** the result SHALL contain one `ISwarmReplayManifestEntry` for `sim-1`
+- **AND** SHALL contain one `IQuickReplayManifestEntry` for `quick-9`
+- **AND** SHALL contain one `IEncounterReplayManifestEntry` for `session-77`
+
+#### Scenario: Scan covers legacy flat layout
+
+- **GIVEN** `simulation-reports/games/2026-05-01T10-00-00-000Z/sim-77.jsonl` exists (legacy)
+- **WHEN** the backfill scan runs
+- **THEN** the result SHALL contain an `ISwarmReplayManifestEntry` for `sim-77`
+- **AND** the entry's `batchTimestamp` SHALL equal `'2026-05-01T10-00-00-000Z'`
+
+#### Scenario: GameEnded.turns optionality fallback
+
+- **GIVEN** a `<gameId>.jsonl` whose `GameEnded` event is missing the `turns` field
+- **WHEN** the backfill scan processes it
+- **THEN** `entry.turns` SHALL equal the count of `turn_started` events in the file
+- **AND** if no `turn_started` events exist, `entry.turns` SHALL equal `0`
+
+#### Scenario: Scan is idempotent
+
+- **GIVEN** an unchanged `simulation-reports/` directory
+- **WHEN** the backfill scan is run twice
+- **THEN** the two resulting manifest arrays SHALL be deep-equal (same length, same entries, same field values)
+
+#### Scenario: Encounter scan recovers encounter metadata
+
+- **GIVEN** `simulation-reports/encounter/session-77.jsonl` whose first event is a `GameCreated` carrying `payload.encounterId='enc-abc'`, `payload.encounterName='Foothold Strike'`, `payload.templateType='Skirmish'`, `payload.playerForceSummary='Lance Alpha (4500 BV, 4 units)'`, `payload.opponentSummary='Generated Lance (~3000 BV)'`
+- **WHEN** the backfill scan processes the file
+- **THEN** the produced `IEncounterReplayManifestEntry` SHALL have `encounterId === 'enc-abc'`
+- **AND** `encounterName === 'Foothold Strike'`
+- **AND** `templateType === ScenarioTemplateType.Skirmish`
+- **AND** `playerForceSummary === 'Lance Alpha (4500 BV, 4 units)'`
+- **AND** `opponentSummary === 'Generated Lance (~3000 BV)'`
+
+### Requirement: Replay Library Page
+
+The system SHALL provide a Replay Library page accessible from the primary navigation. The page SHALL load the replay index on mount, display every manifest entry as a list row with source-appropriate metadata visible (e.g. swarm rows show `configName`/`seed`; quick rows show `aiVariant`; encounter rows show `encounterName` and `templateType` and force summaries), and SHALL provide a source filter that limits the displayed list to a chosen `ReplaySource`.
+
+The source filter button strip SHALL include exactly six buttons: All, Swarm, Quick, PvP, Campaign, Encounter. The button keys SHALL be `'all'` plus the five `ReplaySource` enum string values.
+
+Clicking a list row SHALL open the existing replay viewer with the chosen entry's events loaded — without requiring the user to drag a file.
+
+#### Scenario: Page loads and lists all entries
+
+- **GIVEN** the index contains 3 swarm entries, 2 quick entries, and 1 encounter entry
+- **WHEN** the user navigates to the Replay Library page
+- **THEN** the page SHALL render exactly 6 list rows
+- **AND** each row SHALL show the entry's `id`, `createdAt`, `turns`, `winner`, and `bvTotal`
+
+#### Scenario: Source filter restricts list
+
+- **GIVEN** the index contains 3 swarm entries, 2 quick entries, and 1 encounter entry
+- **WHEN** the user selects the Quick filter
+- **THEN** only 2 rows SHALL be visible
+- **AND** both rows SHALL display the source-specific `aiVariant` field
+
+#### Scenario: Encounter filter shows encounter entries
+
+- **GIVEN** the index contains 3 swarm entries, 2 quick entries, and 1 encounter entry
+- **WHEN** the user selects the Encounter filter
+- **THEN** exactly 1 row SHALL be visible
+- **AND** the row SHALL display `encounterName` and `templateType` (or `'Custom'` when `null`) and the player vs opponent summaries
+
+#### Scenario: Filter button strip has six buttons
+
+- **GIVEN** the Replay Library page is rendered
+- **WHEN** the user inspects the source filter button strip
+- **THEN** the strip SHALL contain exactly six buttons in order: `All`, `Swarm`, `Quick`, `PvP`, `Campaign`, `Encounter`
+
+#### Scenario: Click opens replay viewer with events loaded
+
+- **GIVEN** a list row for an encounter entry with `path='encounter/session-77.jsonl'`
+- **WHEN** the user clicks the row
+- **THEN** the replay viewer SHALL mount with the events from that file already loaded
+- **AND** the user SHALL NOT be prompted to drag a file

--- a/openspec/changes/link-encounters-to-replays/tasks.md
+++ b/openspec/changes/link-encounters-to-replays/tasks.md
@@ -1,0 +1,106 @@
+# Tasks: Link Encounters to Replays
+
+## 1. Types + enum + manifest interface (PR 1)
+
+- [ ] 1.1 Add `Encounter = 'encounter'` as the fifth value in `ReplaySource` at `src/types/gameplay/GameSessionInterfaces.ts:291-296`. Document the addition in the comment block above the enum.
+  - Done when: `Object.values(ReplaySource)` returns five strings.
+- [ ] 1.2 Add `IEncounterReplayManifestEntry` interface to `src/replay-library/types.ts`:
+  ```ts
+  export interface IEncounterReplayManifestEntry extends IReplayManifestEntryBase {
+    readonly replaySource: ReplaySource.Encounter;
+    readonly encounterId: string;
+    readonly encounterName: string;
+    readonly templateType: ScenarioTemplateType | null;
+    readonly playerForceSummary: string;
+    readonly opponentSummary: string;
+  }
+  ```
+  Append it to the `IReplayManifestEntry` discriminated union.
+  - Done when: typecheck clean; the union has 5 members.
+- [ ] 1.3 Update enum-length tests to expect 5 (search for `Object.values(ReplaySource).length` and `Object.values(ReplaySource)` deep-equal-array assertions). Add a "narrows to Encounter" type-level test mirroring the existing per-source narrowing tests.
+  - Done when: all enum-length assertions updated; new narrowing test passes.
+- [ ] 1.4 Update `RECOGNIZED_REPLAY_SOURCES` consumer at `src/pages/api/replay-library/[source]/[gameId].ts:51-53` — confirm it dynamically uses `Object.values(ReplaySource)` and therefore picks up the variant automatically (no code change expected; verify in the test).
+  - Done when: API route unit test asserts `encounter` is a recognized source.
+- [ ] 1.5 Update `src/replay-library/backfill-scan.ts` — extend the partition switch with `case 'encounter': return ReplaySource.Encounter`. Update the per-source manifest entry builder to handle the Encounter case by reading `encounterId`, `encounterName`, `templateType`, `playerForceSummary`, `opponentSummary` from the first `GameCreated` event's payload.
+  - Done when: a fixture jsonl at `simulation-reports/encounter/<gameId>.jsonl` is correctly read by `scanReplayDirectory` and produces an `IEncounterReplayManifestEntry`.
+- [ ] 1.6 Add backfill-scan unit test at `src/replay-library/__tests__/backfill-scan.test.ts` (extend existing) — Encounter fixture round-trip + idempotent re-scan.
+  - Done when: test passes; existing scan tests still green.
+- [ ] 1.7 Run `npm run typecheck`, `npm run lint`, `npm test` clean.
+- [ ] 1.8 Open PR 1, CI green, merge.
+
+## 2. Persist pipeline + API route (PR 2)
+
+- [ ] 2.1 Author `src/components/encounter/persistEncounterGame.ts` mirroring `src/components/quickgame/persistQuickGame.ts`:
+  - Export `IPersistEncounterGameInput` containing `gameId`, `events`, `winner` (`'player' | 'opponent' | 'draw' | null`), `encounterId`, `encounterName`, `templateType`, `playerForceSummary`, `opponentSummary`, optional `cwd`.
+  - Export `IPersistEncounterGameResult` with `persisted`, `path`, `manifestEntry` (typed as `IEncounterReplayManifestEntry | null`).
+  - Implement `shouldPersistToDisk` three-gate (Node runtime + cwd-or-NODE_ENV) — duplicate from `persistQuickGame.ts` per the change brief; do NOT extract a shared helper.
+  - Implement `stampEncounterReplaySource(events)` that post-stamps `ReplaySource.Encounter` over events that don't already have a `replaySource` field; preserves explicit values.
+  - Implement `buildEncounterManifestEntry(input)`: derives `turns` from `countTurnStartedEvents(events)` (duplicate the helper), `winner` from the input, `bvTotal` from the first `GameCreated.payload.units` summed `.bv` fields, `createdAt` from `new Date().toISOString()`. Returns the typed manifest entry.
+  - Implement `persistEncounterGame(input)`: writes `simulation-reports/encounter/<gameId>.jsonl` then calls `appendManifestEntry(manifestEntry, { cwd })`.
+  - Done when: file compiles; matches the shape of `persistQuickGame.ts` line-for-line where applicable.
+- [ ] 2.2 Add unit tests at `src/components/encounter/__tests__/persistEncounterGame.test.ts` mirroring the 5 quick-game scenarios + 1 Encounter-specific scenario:
+  - Happy path with explicit cwd: writes file under tmpdir, manifest entry appended, returns `persisted: true`, manifestEntry has the right discriminator.
+  - Browser env (no Node runtime): no-op, returns `persisted: false, manifestEntry: null`.
+  - Test env without cwd: no-op (jest-jsdom guard).
+  - Explicit non-Encounter `replaySource` preserved on a sample event.
+  - Manifest entry shape: `replaySource: 'encounter'`, all source-specific fields populated correctly.
+  - Round-trip: written file parses back into an event array with the post-stamped source.
+  - Done when: 6 tests pass.
+- [ ] 2.3 Author `src/pages/api/replay-library/encounter.ts` POST handler mirroring `quick.ts`:
+  - Same `GAME_ID_PATTERN` regex (`^[A-Za-z0-9_-]+$`) — duplicate not import.
+  - Same `parseBody` shape returning `{ ok: true, input } | { ok: false, error }` with explicit field-by-field validation: `gameId` (regex), `events` (array), `winner` (null OR one of 'player'/'opponent'/'draw'), `encounterId` (non-empty string), `encounterName` (string), `templateType` (string-of-ScenarioTemplateType OR null), `playerForceSummary` (string), `opponentSummary` (string).
+  - Same dedup guard via `readReplayIndex` + id check; on duplicate return `{ persisted: false, alreadyPersisted: true, manifestEntry: <built fresh>, path: 'encounter/<gameId>.jsonl' }`.
+  - On non-duplicate, call `persistEncounterGame(input)`, return `{ persisted, alreadyPersisted: false, manifestEntry, path }`.
+  - 405 on non-POST; 400 on parse failure; 500 on persistEncounterGame throw.
+  - Done when: handler compiles; returns shape matches the quick handler.
+- [ ] 2.4 Add API route tests at `src/__tests__/api/replay-library/encounter.test.ts` (NOT `src/pages/api/replay-library/__tests__/...` — existing convention: API route tests live under `src/__tests__/api/`; mirror the sibling at `src/__tests__/api/replay-library/quick.test.ts` from PR #557) mirroring the quick route tests:
+  - 200 happy path: POST returns `persisted: true, alreadyPersisted: false`.
+  - 200 dedup: POST same gameId twice; second returns `persisted: false, alreadyPersisted: true`.
+  - 400 bad gameId: POST with `gameId: 'foo/../bar'` → BAD_GAME_ID.
+  - 400 missing encounterId: POST without it → BAD_BODY or specific code.
+  - 400 invalid winner: POST with `winner: 'banana'` → BAD_WINNER.
+  - 405 on GET.
+  - 500 on persist failure: mock `persistEncounterGame` to throw → 500 PERSIST_FAILED.
+  - Done when: 7 tests pass.
+- [ ] 2.5 Run `npm run typecheck`, `npm run lint`, `npm test` clean.
+- [ ] 2.6 Open PR 2, CI green, merge.
+
+## 3. Wire EncounterService + Replay Library UI (PR 3)
+
+- [ ] 3.1 Modify `EncounterService.launchEncounter` (`src/services/encounter/EncounterService.ts:290-367`) to stamp the encounter metadata onto the `GameCreated` event payload at session creation: `encounterId`, `encounterName`, `templateType`, `playerForceSummary`, `opponentSummary`. The metadata SHALL be derived from the encounter row at launch time (snapshot — does not rebuild from forces if forces change later).
+  - `playerForceSummary` derivation: when `encounter.playerForce` is non-null, use `"<forceName> (<totalBV> BV, <unitCount> units)"`. When `null` (broken — Change A territory), use `"<forceId> (missing force)"` as the snapshot text.
+  - `opponentSummary` derivation: same shape for explicit opponent force; for opForConfig-driven, use `"Generated <type> (~<targetBV> BV)"` or whatever fields the opForConfig has.
+  - Done when: launching an encounter produces a session whose first emitted event includes the metadata.
+- [ ] 3.2 Add the persist hook to the encounter session terminal-state handler. The exact attachment point is wherever the existing campaign outcome publish hook lives (added by `wire-encounter-to-campaign-round-trip` Wave 5). Sibling call: build the `IPersistEncounterGameInput` from the session's accumulated event log + the encounter metadata stored on the GameCreated event, then `fetch('/api/replay-library/encounter', { method: 'POST', body: JSON.stringify(input) })`.
+  - Browser-side (component) concerns: use the same useRef+effect pattern as `QuickGameResults` to guard against double-fire on remount.
+  - Done when: a smoke run of an encounter from the UI ends with a manifest entry for the encounter and a `simulation-reports/encounter/<gameId>.jsonl` file.
+- [ ] 3.3 Add an integration test at `src/services/encounter/__tests__/EncounterService.persist.test.ts` that mocks the live session and asserts the persist POST fires with the correct body shape on terminal state. Use a spy on `global.fetch` (or the existing test pattern for `/api/replay-library/quick` if one is established).
+  - Done when: test asserts `fetch` was called with `/api/replay-library/encounter` and the body has `encounterId`, `encounterName`, `templateType`, `playerForceSummary`, `opponentSummary`, `gameId`, `events`, `winner`.
+- [ ] 3.4 Modify `src/components/replay-library/ReplayLibraryPage.tsx`:
+  - Append `{ key: ReplaySource.Encounter, label: 'Encounter' }` to the `SOURCE_FILTERS` array.
+  - Add the `case ReplaySource.Encounter` branch to the `renderSourceMetadata` switch — render `encounterName`, `templateType ?? 'Custom'`, `playerForceSummary` vs `opponentSummary`. Match the visual treatment of the existing 4 cases.
+  - The `assertNever(entry)` exhaustiveness guard now compiles cleanly with the new variant. Verify by manually omitting the case and confirming the typecheck breaks.
+  - Done when: rendering a fixture with an Encounter manifest entry shows the expected metadata; filter button strip has 6 buttons (All / Swarm / Quick / PvP / Campaign / Encounter).
+- [ ] 3.5 Extend `src/__tests__/pages/replay-library.test.tsx` (NOT `src/components/replay-library/__tests__/...` — the existing Replay Library page tests live at the centralized `src/__tests__/pages/replay-library.test.tsx`; extend that file):
+  - Filter button strip count assertion: 6 buttons.
+  - Encounter row renders `encounterName`, `templateType`, summary text.
+  - Source filter "Encounter" restricts to encounter-only rows.
+  - Click-to-watch fetches via `/api/replay-library/encounter/<gameId>` (the existing `[source]/[gameId].ts` route — confirms it accepts `encounter` source).
+  - Done when: 4 new test cases pass; existing tests still green.
+- [ ] 3.6 Add Storybook story for the Encounter row at `src/components/replay-library/ReplayLibraryPage.stories.tsx` (extend existing): `EncounterOnly` showing only encounter entries with template + summary metadata visible.
+  - Done when: storybook builds clean.
+- [ ] 3.7 Run `npm run typecheck`, `npm run lint`, `npm test`, `npm run storybook:build` clean.
+- [ ] 3.8 Open PR 3, CI green, merge.
+
+## 4. End-to-end verification
+
+- [ ] 4.1 Manual smoke: launch an encounter from `/gameplay/encounters/[id]`, play to terminal state (or simulate via dev tools), refresh `/replay-library`, click Encounter filter, confirm the new row appears with `encounterName` + template + force summaries. Click Watch, confirm the replay viewer plays back the events.
+- [ ] 4.2 Manual smoke: confirm `simulation-reports/encounter/<gameId>.jsonl` exists with the expected NDJSON content; confirm `simulation-reports/replay-index.json` has a new entry with `replaySource: 'encounter'`.
+- [ ] 4.3 Manual smoke: launch the same encounter twice (back-to-back), confirm two distinct manifest entries with two distinct `gameSessionId`s appear in the Library.
+- [ ] 4.4 `npx openspec validate link-encounters-to-replays --strict` clean. Output captured for the final report.
+
+## 5. Archive
+
+- [ ] 5.1 PRs 1, 2, 3 merged to main.
+- [ ] 5.2 Memory anchor written to `~/.claude/projects/E--Projects-MekStation/memory/project_link_encounters_to_replays.md` with the fifth ReplaySource decision, files touched, lessons.
+- [ ] 5.3 `openspec archive link-encounters-to-replays` runs cleanly; deltas merge into `replay-library/spec.md` and `game-session-management/spec.md`.


### PR DESCRIPTION
## Summary

Archives \`repair-broken-encounter-drafts\` to \`openspec/changes/archive/2026-05-09-repair-broken-encounter-drafts/\` after the 3-PR ladder shipped end-to-end:

- PR #558 \`725466a6\` — cleanup script + classification (PR 1/3)
- PR #559 \`ae5fa0ab\` — cascade-on-force-delete + hydration repair (PR 2/3)
- PR #560 \`86cd21dc\` — broken-pill + repair banner + seed empty-state (PR 3/3)

Used \`--skip-specs\` because the encounter-system requirements never had a source-of-truth spec (\`encounter-system\` was never synced from its archived authoring change). The change's full delta (proposal, design, tasks, spec deltas, notepad with PR-by-PR learnings) ships intact in the archive folder.

Also stages the next change \`link-encounters-to-replays\` (Prometheus-authored proposal/design/spec-deltas/tasks). Implementation begins after this archive PR merges.

## Test plan

- [x] All 3 sibling PRs merged + CI green
- [x] \`openspec archive repair-broken-encounter-drafts --skip-specs --yes\` clean
- [x] Archive folder contains: proposal.md, design.md, tasks.md (33/33 tasks done), specs/game-session-management/spec.md, notepad/ (4 files)
- [ ] CI green on this PR