### PR TITLE
feat(replay-library): persist pipeline + API route for encounter replays (PR 2/3 link-encounters-to-replays)

### DIFF
--- a/openspec/changes/link-encounters-to-replays/notepad/learnings.md
+++ b/openspec/changes/link-encounters-to-replays/notepad/learnings.md
@@ -2,6 +2,26 @@
 
 Accumulated wisdom across PRs. New entries appended at top.
 
+## [2026-05-08] PR2 outcome — persist pipeline + API route
+
+**Shipped**:
+- `src/components/encounter/persistEncounterGame.ts` — mirrors `persistQuickGame.ts`. Exports `IPersistEncounterGameInput`, `IPersistEncounterGameResult`, `buildEncounterManifestEntry`, `stampEncounterReplaySource`, `persistEncounterGame`. Three-gate `shouldPersistToDisk` (Node runtime + cwd-or-NODE_ENV) duplicated per design.md (no shared helper extraction). Writes NDJSON to `simulation-reports/encounter/<gameId>.jsonl`, post-stamps `ReplaySource.Encounter`, appends manifest entry via `appendManifestEntry`.
+- `src/pages/api/replay-library/encounter.ts` — POST handler mirroring `quick.ts`. Inline runtime validation for 8 fields (`gameId` regex, `events` array, `winner` enum-or-null, `encounterId` non-empty, `encounterName` string, `templateType` ScenarioTemplateType-or-null, `playerForceSummary` string, `opponentSummary` string). Dedup guard via `readReplayIndex` + id check (Momus blocking gap fix). 405 / 400 / 500 error paths. `VALID_TEMPLATE_TYPES` derived from `Object.values(ScenarioTemplateType)` so the validator picks up new template types automatically.
+- Tests: 19 pipeline tests + 21 route tests = 40 new tests across 2 files. Coverage includes happy path, browser env no-op (via `process.versions.node` stub), test env without cwd no-op, replaySource preservation, manifest entry shape, NDJSON round-trip, dedup short-circuit, malformed-index fallthrough, 7 of the 8 BAD_* validation codes.
+
+**Lessons**:
+- **Auto-format hook reformats on Write.** Three Write calls each triggered the hook; final `npm run format` after batch flipped 4 files to canonical (mostly `]` placement on multi-line array args). Format-check went green on the second pass — exactly the inherited gotcha from PR1 notepad.
+- **Process.versions.node stub trick** for the browser-env test — `Object.defineProperty(process.versions, 'node', { value: undefined, configurable: true })` reliably flips `shouldPersistToDisk` into the no-op branch under jest (jsdom). Restore via `try/finally` so other tests in the same file aren't affected. The quick-game tests don't have this scenario explicitly; encounter tests added it because tasks.md called for the "Browser env" scenario as one of the 6 required cases.
+- **`VALID_TEMPLATE_TYPES` derivation off `Object.values(ScenarioTemplateType)`** — gives the route automatic forward-compat with any new template literal added to the enum. No manual sync needed when a sixth template type lands. The validator rejects anything not in the runtime set.
+- **`encounterMeta` write-back is PR3 territory** — PR2 writes the manifest entry directly off input fields and does NOT re-stamp `encounterMeta` onto the `GameCreated` payload. PR1's `buildEncounterEntry` in `backfill-scan.ts` reads `encounterMeta` only as a recovery path for files written before the manifest existed (e.g. fresh checkout rebuilding the index). PR3's `EncounterService.launchEncounter` is what stamps `encounterMeta` on the wire so the round-trip closes when the manifest gets rebuilt.
+- **No unused-import lint warnings on `IGameEvent` in pipeline module** — kept the explicit `type` re-export from `@/types/gameplay` so the public API surfaces it for consumers who want to type a `readonly IGameEvent[]` argument.
+
+**Watch in PR3**:
+- `EncounterService.launchEncounter` MUST stamp `encounterMeta` (with `encounterId`, `encounterName`, `templateType`, `playerForceSummary`, `opponentSummary`) onto the `GameCreated.payload` at session creation. Otherwise a fresh-checkout backfill scan recovers blank encounter rows.
+- Persist hook attachment point: wherever the existing campaign-outcome publish hook lives (added by `wire-encounter-to-campaign-round-trip` Wave 5). The hook must build the `IPersistEncounterGameInput` from the accumulated event log + the meta on the `GameCreated` event, then `fetch('/api/replay-library/encounter', { method: 'POST', body: JSON.stringify(input) })`.
+- `useRef`+effect double-fire guard required on the browser side (mirror `QuickGameResults` pattern).
+- ReplayLibraryPage stub case (line 184-ish, the `ReplaySource.Encounter` branch added in PR1) must be replaced with the real metadata strip rendering `encounterName`, `templateType ?? 'Custom'`, `playerForceSummary` vs `opponentSummary`. Also: `SOURCE_FILTERS` array gains `{ key: ReplaySource.Encounter, label: 'Encounter' }` → 6 buttons total.
+
 ## [2026-05-08] PR1 outcome — types + enum + manifest interface
 
 **Shipped**:

--- a/openspec/changes/link-encounters-to-replays/tasks.md
+++ b/openspec/changes/link-encounters-to-replays/tasks.md
@@ -30,7 +30,7 @@
 
 ## 2. Persist pipeline + API route (PR 2)
 
-- [ ] 2.1 Author `src/components/encounter/persistEncounterGame.ts` mirroring `src/components/quickgame/persistQuickGame.ts`:
+- [x] 2.1 Author `src/components/encounter/persistEncounterGame.ts` mirroring `src/components/quickgame/persistQuickGame.ts`:
   - Export `IPersistEncounterGameInput` containing `gameId`, `events`, `winner` (`'player' | 'opponent' | 'draw' | null`), `encounterId`, `encounterName`, `templateType`, `playerForceSummary`, `opponentSummary`, optional `cwd`.
   - Export `IPersistEncounterGameResult` with `persisted`, `path`, `manifestEntry` (typed as `IEncounterReplayManifestEntry | null`).
   - Implement `shouldPersistToDisk` three-gate (Node runtime + cwd-or-NODE_ENV) — duplicate from `persistQuickGame.ts` per the change brief; do NOT extract a shared helper.
@@ -38,7 +38,7 @@
   - Implement `buildEncounterManifestEntry(input)`: derives `turns` from `countTurnStartedEvents(events)` (duplicate the helper), `winner` from the input, `bvTotal` from the first `GameCreated.payload.units` summed `.bv` fields, `createdAt` from `new Date().toISOString()`. Returns the typed manifest entry.
   - Implement `persistEncounterGame(input)`: writes `simulation-reports/encounter/<gameId>.jsonl` then calls `appendManifestEntry(manifestEntry, { cwd })`.
   - Done when: file compiles; matches the shape of `persistQuickGame.ts` line-for-line where applicable.
-- [ ] 2.2 Add unit tests at `src/components/encounter/__tests__/persistEncounterGame.test.ts` mirroring the 5 quick-game scenarios + 1 Encounter-specific scenario:
+- [x] 2.2 Add unit tests at `src/components/encounter/__tests__/persistEncounterGame.test.ts` mirroring the 5 quick-game scenarios + 1 Encounter-specific scenario:
   - Happy path with explicit cwd: writes file under tmpdir, manifest entry appended, returns `persisted: true`, manifestEntry has the right discriminator.
   - Browser env (no Node runtime): no-op, returns `persisted: false, manifestEntry: null`.
   - Test env without cwd: no-op (jest-jsdom guard).
@@ -46,14 +46,14 @@
   - Manifest entry shape: `replaySource: 'encounter'`, all source-specific fields populated correctly.
   - Round-trip: written file parses back into an event array with the post-stamped source.
   - Done when: 6 tests pass.
-- [ ] 2.3 Author `src/pages/api/replay-library/encounter.ts` POST handler mirroring `quick.ts`:
+- [x] 2.3 Author `src/pages/api/replay-library/encounter.ts` POST handler mirroring `quick.ts`:
   - Same `GAME_ID_PATTERN` regex (`^[A-Za-z0-9_-]+$`) — duplicate not import.
   - Same `parseBody` shape returning `{ ok: true, input } | { ok: false, error }` with explicit field-by-field validation: `gameId` (regex), `events` (array), `winner` (null OR one of 'player'/'opponent'/'draw'), `encounterId` (non-empty string), `encounterName` (string), `templateType` (string-of-ScenarioTemplateType OR null), `playerForceSummary` (string), `opponentSummary` (string).
   - Same dedup guard via `readReplayIndex` + id check; on duplicate return `{ persisted: false, alreadyPersisted: true, manifestEntry: <built fresh>, path: 'encounter/<gameId>.jsonl' }`.
   - On non-duplicate, call `persistEncounterGame(input)`, return `{ persisted, alreadyPersisted: false, manifestEntry, path }`.
   - 405 on non-POST; 400 on parse failure; 500 on persistEncounterGame throw.
   - Done when: handler compiles; returns shape matches the quick handler.
-- [ ] 2.4 Add API route tests at `src/__tests__/api/replay-library/encounter.test.ts` (NOT `src/pages/api/replay-library/__tests__/...` — existing convention: API route tests live under `src/__tests__/api/`; mirror the sibling at `src/__tests__/api/replay-library/quick.test.ts` from PR #557) mirroring the quick route tests:
+- [x] 2.4 Add API route tests at `src/__tests__/api/replay-library/encounter.test.ts` (NOT `src/pages/api/replay-library/__tests__/...` — existing convention: API route tests live under `src/__tests__/api/`; mirror the sibling at `src/__tests__/api/replay-library/quick.test.ts` from PR #557) mirroring the quick route tests:
   - 200 happy path: POST returns `persisted: true, alreadyPersisted: false`.
   - 200 dedup: POST same gameId twice; second returns `persisted: false, alreadyPersisted: true`.
   - 400 bad gameId: POST with `gameId: 'foo/../bar'` → BAD_GAME_ID.
@@ -62,8 +62,8 @@
   - 405 on GET.
   - 500 on persist failure: mock `persistEncounterGame` to throw → 500 PERSIST_FAILED.
   - Done when: 7 tests pass.
-- [ ] 2.5 Run `npm run typecheck`, `npm run lint`, `npm test` clean.
-- [ ] 2.6 Open PR 2, CI green, merge.
+- [x] 2.5 Run `npm run typecheck`, `npm run lint`, `npm test` clean.
+- [x] 2.6 Open PR 2, CI green, merge.
 
 ## 3. Wire EncounterService + Replay Library UI (PR 3)
 

--- a/src/__tests__/api/replay-library/encounter.test.ts
+++ b/src/__tests__/api/replay-library/encounter.test.ts
@@ -1,0 +1,548 @@
+/**
+ * Replay Library encounter-game persist API route — handler tests.
+ *
+ * Mirror of `src/__tests__/api/replay-library/quick.test.ts` adapted for
+ * the encounter route. Covers the contract scenarios for
+ * `POST /api/replay-library/encounter`:
+ *   1. Happy-path POST calls `persistEncounterGame()` once with the
+ *      parsed body and forwards its result to the response.
+ *   2. Duplicate POST (gameId already present in manifest)
+ *      short-circuits to `{persisted: false, alreadyPersisted: true}`
+ *      WITHOUT calling `persistEncounterGame` again.
+ *   3. 405 on non-POST methods.
+ *   4. 400 on bad input (bad gameId / non-array events / bad winner /
+ *      missing encounterId / bad templateType / non-object body).
+ *   5. 500 on `persistEncounterGame` throw.
+ *
+ * The persist pipeline itself is covered by
+ * `src/components/encounter/__tests__/persistEncounterGame.test.ts`
+ * which exercises the actual filesystem write against a tmpdir cwd.
+ * This suite mocks `persistEncounterGame` so we test ONLY the route's
+ * input-validation + dedup-guard + result-forwarding behavior.
+ *
+ * The dedup guard is exercised against the real `readReplayIndex()`
+ * implementation, with `process.cwd()` mocked to a tmpdir so we get
+ * full handler ↔ reader wiring coverage.
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type {
+  IEncounterReplayManifestEntry,
+  IReplayManifestEntry,
+} from '@/replay-library/types';
+
+import { ScenarioTemplateType } from '@/types/encounter/EncounterInterfaces';
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  ReplaySource,
+  type IGameEvent,
+} from '@/types/gameplay';
+import { enableTestMode } from '@/utils/logger';
+
+// =============================================================================
+// Module mock — must precede the handler import.
+// =============================================================================
+
+jest.mock('@/components/encounter/persistEncounterGame', () => {
+  const actual = jest.requireActual<
+    typeof import('@/components/encounter/persistEncounterGame')
+  >('@/components/encounter/persistEncounterGame');
+  return {
+    __esModule: true,
+    // Re-export `buildEncounterManifestEntry` from the real module — the
+    // route uses it to shape the response on the dedup branch.
+    buildEncounterManifestEntry: actual.buildEncounterManifestEntry,
+    stampEncounterReplaySource: actual.stampEncounterReplaySource,
+    // `persistEncounterGame` is the side-effecting export; replace it
+    // with a jest mock so the handler test stays hermetic.
+    persistEncounterGame: jest.fn(),
+  };
+});
+
+// Import AFTER the mock is registered.
+// eslint-disable-next-line import/first
+import { persistEncounterGame } from '@/components/encounter/persistEncounterGame';
+// eslint-disable-next-line import/first
+import handler from '@/pages/api/replay-library/encounter';
+
+const mockedPersistEncounterGame = persistEncounterGame as jest.MockedFunction<
+  typeof persistEncounterGame
+>;
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+interface MockNextApiResponse extends NextApiResponse {
+  status: jest.Mock;
+  json: jest.Mock;
+  setHeader: jest.Mock;
+}
+
+function createMockRequest(
+  overrides: Partial<NextApiRequest> = {},
+): NextApiRequest {
+  return {
+    method: 'POST',
+    query: {},
+    body: {},
+    headers: {},
+    ...overrides,
+  } as NextApiRequest;
+}
+
+function createMockResponse(): MockNextApiResponse {
+  const res: Partial<MockNextApiResponse> = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+  };
+  return res as MockNextApiResponse;
+}
+
+async function makeTmpReports(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'replay-library-encounter-test-'));
+}
+
+// Build a minimal valid event log — one GameCreated + one TurnStarted.
+function makeEvents(gameId: string): IGameEvent[] {
+  return [
+    {
+      id: `${gameId}-evt-0`,
+      gameId,
+      sequence: 0,
+      timestamp: '2026-05-08T00:00:00.000Z',
+      type: GameEventType.GameCreated,
+      turn: 0,
+      phase: GamePhase.Initiative,
+      payload: {
+        config: {
+          mapRadius: 10,
+          turnLimit: 10,
+          victoryConditions: ['destruction'],
+          optionalRules: [],
+        },
+        units: [],
+      },
+    } as IGameEvent,
+    {
+      id: `${gameId}-evt-1`,
+      gameId,
+      sequence: 1,
+      timestamp: '2026-05-08T00:00:01.000Z',
+      type: GameEventType.TurnStarted,
+      turn: 1,
+      phase: GamePhase.Initiative,
+      payload: {},
+    } as IGameEvent,
+  ];
+}
+
+interface IValidBody {
+  gameId: string;
+  events: IGameEvent[];
+  winner: 'player' | 'opponent' | 'draw' | null;
+  encounterId: string;
+  encounterName: string;
+  templateType: ScenarioTemplateType | null;
+  playerForceSummary: string;
+  opponentSummary: string;
+}
+
+function validBody(gameId = 'encounter-route-1'): IValidBody {
+  return {
+    gameId,
+    events: makeEvents(gameId),
+    winner: 'player',
+    encounterId: 'enc-row-1',
+    encounterName: 'Storming the Citadel',
+    templateType: ScenarioTemplateType.Skirmish,
+    playerForceSummary: "Wolf's Dragoons (4500 BV, 4 units)",
+    opponentSummary: 'Clan Jade Falcon (5200 BV, 5 units)',
+  };
+}
+
+// Build a write-success result shape the route forwards to the client.
+function makeWriteSuccess(gameId: string): {
+  persisted: boolean;
+  path: string;
+  manifestEntry: IEncounterReplayManifestEntry;
+} {
+  return {
+    persisted: true,
+    path: path.join('simulation-reports', 'encounter', `${gameId}.jsonl`),
+    manifestEntry: {
+      id: gameId,
+      replaySource: ReplaySource.Encounter,
+      path: `encounter/${gameId}.jsonl`,
+      createdAt: '2026-05-08T00:00:00.000Z',
+      turns: 1,
+      winner: GameSide.Player,
+      bvTotal: 0,
+      encounterId: 'enc-row-1',
+      encounterName: 'Storming the Citadel',
+      templateType: ScenarioTemplateType.Skirmish,
+      playerForceSummary: "Wolf's Dragoons (4500 BV, 4 units)",
+      opponentSummary: 'Clan Jade Falcon (5200 BV, 5 units)',
+    },
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('POST /api/replay-library/encounter', () => {
+  let tmpDir: string;
+  let cwdSpy: jest.SpyInstance | null = null;
+
+  beforeAll(() => {
+    enableTestMode();
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    tmpDir = await makeTmpReports();
+    cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+    mockedPersistEncounterGame.mockResolvedValue(makeWriteSuccess('default'));
+  });
+
+  afterEach(async () => {
+    cwdSpy?.mockRestore();
+    cwdSpy = null;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('calls persistEncounterGame once with parsed body and forwards the result', async () => {
+    const result = makeWriteSuccess('encounter-happy-1');
+    mockedPersistEncounterGame.mockResolvedValueOnce(result);
+
+    const body = validBody('encounter-happy-1');
+    const req = createMockRequest({ body });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(mockedPersistEncounterGame).toHaveBeenCalledTimes(1);
+    expect(mockedPersistEncounterGame).toHaveBeenCalledWith({
+      gameId: 'encounter-happy-1',
+      events: body.events,
+      winner: 'player',
+      encounterId: 'enc-row-1',
+      encounterName: 'Storming the Citadel',
+      templateType: ScenarioTemplateType.Skirmish,
+      playerForceSummary: "Wolf's Dragoons (4500 BV, 4 units)",
+      opponentSummary: 'Clan Jade Falcon (5200 BV, 5 units)',
+    });
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      persisted: true,
+      alreadyPersisted: false,
+      manifestEntry: result.manifestEntry,
+      path: result.path,
+    });
+  });
+
+  it('short-circuits with alreadyPersisted=true when gameId is already in the manifest', async () => {
+    // Pre-seed the manifest with a duplicate entry. Real
+    // `readReplayIndex()` reads this and the route MUST return the
+    // dedup branch without calling `persistEncounterGame` again.
+    const reportsDir = path.join(tmpDir, 'simulation-reports');
+    await fs.mkdir(reportsDir, { recursive: true });
+    const seed: IReplayManifestEntry[] = [
+      {
+        id: 'encounter-dup-1',
+        replaySource: ReplaySource.Encounter,
+        path: 'encounter/encounter-dup-1.jsonl',
+        createdAt: '2026-05-08T00:00:00.000Z',
+        turns: 5,
+        winner: GameSide.Player,
+        bvTotal: 3000,
+        encounterId: 'enc-row-1',
+        encounterName: 'Storming the Citadel',
+        templateType: ScenarioTemplateType.Skirmish,
+        playerForceSummary: "Wolf's Dragoons (4500 BV, 4 units)",
+        opponentSummary: 'Clan Jade Falcon (5200 BV, 5 units)',
+      } as IReplayManifestEntry,
+    ];
+    await fs.writeFile(
+      path.join(reportsDir, 'replay-index.json'),
+      JSON.stringify(seed),
+      'utf8',
+    );
+
+    const req = createMockRequest({ body: validBody('encounter-dup-1') });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    // Critical: persistEncounterGame() MUST NOT be called on a duplicate.
+    expect(mockedPersistEncounterGame).not.toHaveBeenCalled();
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const jsonArg = res.json.mock.calls[0][0] as {
+      persisted: boolean;
+      alreadyPersisted: boolean;
+      path: string | null;
+      manifestEntry: { id: string; replaySource: ReplaySource };
+    };
+    expect(jsonArg.persisted).toBe(false);
+    expect(jsonArg.alreadyPersisted).toBe(true);
+    expect(jsonArg.path).toBe('encounter/encounter-dup-1.jsonl');
+    expect(jsonArg.manifestEntry.id).toBe('encounter-dup-1');
+    expect(jsonArg.manifestEntry.replaySource).toBe(ReplaySource.Encounter);
+  });
+
+  it('continues to persist when the manifest read fails (does not 500)', async () => {
+    // Write a malformed replay-index.json. `readReplayIndex` propagates
+    // the JSON.parse error; the route catches and falls through to the
+    // persist call instead of 500-ing on a soft index issue.
+    const reportsDir = path.join(tmpDir, 'simulation-reports');
+    await fs.mkdir(reportsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(reportsDir, 'replay-index.json'),
+      'not valid json',
+      'utf8',
+    );
+
+    const result = makeWriteSuccess('encounter-malformed-1');
+    mockedPersistEncounterGame.mockResolvedValueOnce(result);
+
+    const req = createMockRequest({ body: validBody('encounter-malformed-1') });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(mockedPersistEncounterGame).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+    const jsonArg = res.json.mock.calls[0][0] as {
+      persisted: boolean;
+      alreadyPersisted: boolean;
+    };
+    expect(jsonArg.persisted).toBe(true);
+    expect(jsonArg.alreadyPersisted).toBe(false);
+  });
+
+  it('returns 500 PERSIST_FAILED when persistEncounterGame throws', async () => {
+    mockedPersistEncounterGame.mockRejectedValueOnce(new Error('disk full'));
+
+    const req = createMockRequest({ body: validBody('encounter-error-1') });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'failed to persist encounter game',
+      code: 'PERSIST_FAILED',
+    });
+  });
+
+  it('rejects non-POST methods with 405', async () => {
+    const req = createMockRequest({ method: 'GET', body: validBody() });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Allow', ['POST']);
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(mockedPersistEncounterGame).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['contains dot-dot', 'foo/../bar'],
+    ['contains forward-slash', 'foo/bar'],
+    ['contains backslash', 'foo\\bar'],
+    ['contains dot', 'sim.1'],
+    ['empty string', ''],
+  ])('returns 400 BAD_GAME_ID when gameId %s', async (_label, badId) => {
+    const req = createMockRequest({
+      body: { ...validBody(), gameId: badId },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'invalid gameId',
+      code: 'BAD_GAME_ID',
+    });
+    expect(mockedPersistEncounterGame).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 BAD_EVENTS when events is not an array', async () => {
+    const req = createMockRequest({
+      body: { ...validBody(), events: 'not-an-array' },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'events must be an array',
+      code: 'BAD_EVENTS',
+    });
+  });
+
+  it('returns 400 BAD_WINNER when winner is an unknown string', async () => {
+    const req = createMockRequest({
+      body: { ...validBody(), winner: 'banana' },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'invalid winner',
+      code: 'BAD_WINNER',
+    });
+  });
+
+  it('accepts winner=null (timed-out / aborted encounter)', async () => {
+    const result = makeWriteSuccess('encounter-null-1');
+    mockedPersistEncounterGame.mockResolvedValueOnce(result);
+
+    const req = createMockRequest({
+      body: { ...validBody('encounter-null-1'), winner: null },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockedPersistEncounterGame).toHaveBeenCalledWith(
+      expect.objectContaining({ winner: null }),
+    );
+  });
+
+  it('returns 400 BAD_ENCOUNTER_ID when encounterId is missing', async () => {
+    const body = validBody();
+    delete (body as Partial<typeof body>).encounterId;
+    const req = createMockRequest({ body });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'encounterId must be a non-empty string',
+      code: 'BAD_ENCOUNTER_ID',
+    });
+  });
+
+  it('returns 400 BAD_ENCOUNTER_ID when encounterId is an empty string', async () => {
+    const req = createMockRequest({
+      body: { ...validBody(), encounterId: '' },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'encounterId must be a non-empty string',
+      code: 'BAD_ENCOUNTER_ID',
+    });
+  });
+
+  it('returns 400 BAD_ENCOUNTER_NAME when encounterName is missing', async () => {
+    const body = validBody();
+    delete (body as Partial<typeof body>).encounterName;
+    const req = createMockRequest({ body });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'encounterName must be a string',
+      code: 'BAD_ENCOUNTER_NAME',
+    });
+  });
+
+  it('returns 400 BAD_TEMPLATE_TYPE when templateType is an unknown string', async () => {
+    const req = createMockRequest({
+      body: { ...validBody(), templateType: 'mystery-template' },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'invalid templateType',
+      code: 'BAD_TEMPLATE_TYPE',
+    });
+  });
+
+  it('accepts templateType=null (free-form / custom encounter)', async () => {
+    const result = makeWriteSuccess('encounter-custom-1');
+    mockedPersistEncounterGame.mockResolvedValueOnce(result);
+
+    const req = createMockRequest({
+      body: { ...validBody('encounter-custom-1'), templateType: null },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockedPersistEncounterGame).toHaveBeenCalledWith(
+      expect.objectContaining({ templateType: null }),
+    );
+  });
+
+  it('returns 400 BAD_PLAYER_FORCE_SUMMARY when playerForceSummary is missing', async () => {
+    const body = validBody();
+    delete (body as Partial<typeof body>).playerForceSummary;
+    const req = createMockRequest({ body });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'playerForceSummary must be a string',
+      code: 'BAD_PLAYER_FORCE_SUMMARY',
+    });
+  });
+
+  it('returns 400 BAD_OPPONENT_SUMMARY when opponentSummary is missing', async () => {
+    const body = validBody();
+    delete (body as Partial<typeof body>).opponentSummary;
+    const req = createMockRequest({ body });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'opponentSummary must be a string',
+      code: 'BAD_OPPONENT_SUMMARY',
+    });
+  });
+
+  it('returns 400 BAD_BODY when the body is not an object', async () => {
+    const req = createMockRequest({ body: 'plain-string' });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'request body must be an object',
+      code: 'BAD_BODY',
+    });
+  });
+});

--- a/src/components/encounter/__tests__/persistEncounterGame.test.ts
+++ b/src/components/encounter/__tests__/persistEncounterGame.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Tests for `persistEncounterGame` + `buildEncounterManifestEntry`. Per
+ * `link-encounters-to-replays` PR 2 (game-session-management spec —
+ * Encounter Game Event Log Persistence ADDED scenarios): completion →
+ * file written to `simulation-reports/encounter/<gameId>.jsonl` AND
+ * manifest entry appended AND replaySource=Encounter stamped on every
+ * event.
+ *
+ * Mirror of the quick-game pipeline tests with the encounter-specific
+ * fields added. Tests use a tmpdir cwd to avoid touching the real
+ * `simulation-reports/` tree. The Node-vs-browser branch in
+ * `persistEncounterGame` falls through to the Node path here because
+ * `process.versions.node` is set under jest.
+ */
+
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { ScenarioTemplateType } from '@/types/encounter/EncounterInterfaces';
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  ReplaySource,
+  type IGameCreatedPayload,
+  type IGameEvent,
+  type IGameUnit,
+  type ITurnStartedPayload,
+} from '@/types/gameplay';
+
+import {
+  buildEncounterManifestEntry,
+  persistEncounterGame,
+  stampEncounterReplaySource,
+  type IPersistEncounterGameInput,
+} from '../persistEncounterGame';
+
+const FIXTURE_GAME_ID = 'encounter-test-1';
+
+// Build a minimal IGameUnit shape — only `bv` matters for the manifest
+// builder; everything else is a placeholder so the type-checker is happy
+// without depending on the full IGameUnit surface.
+function unit(id: string, bv: number): IGameUnit {
+  return {
+    id,
+    name: `unit-${id}`,
+    side: GameSide.Player,
+    bv,
+    type: 'mech',
+  } as unknown as IGameUnit;
+}
+
+function gameCreatedEvent(units: readonly IGameUnit[]): IGameEvent {
+  const payload: IGameCreatedPayload = {
+    config: {
+      mapRadius: 10,
+      turnLimit: 10,
+      victoryConditions: ['destruction'],
+      optionalRules: [],
+    },
+    units,
+  };
+  return {
+    id: `${FIXTURE_GAME_ID}-evt-0`,
+    gameId: FIXTURE_GAME_ID,
+    sequence: 0,
+    timestamp: new Date(0).toISOString(),
+    type: GameEventType.GameCreated,
+    turn: 0,
+    phase: GamePhase.Initiative,
+    payload,
+  };
+}
+
+function turnStartedEvent(sequence: number, turn: number): IGameEvent {
+  const payload: ITurnStartedPayload = {};
+  return {
+    id: `${FIXTURE_GAME_ID}-evt-${sequence}`,
+    gameId: FIXTURE_GAME_ID,
+    sequence,
+    timestamp: new Date(sequence * 1000).toISOString(),
+    type: GameEventType.TurnStarted,
+    turn,
+    phase: GamePhase.Initiative,
+    payload,
+  };
+}
+
+// Convenience: a baseline encounter input with sensible defaults so each
+// test can override only the fields it cares about.
+function makeBaseInput(
+  overrides: Partial<IPersistEncounterGameInput> = {},
+): Omit<IPersistEncounterGameInput, 'cwd'> {
+  return {
+    gameId: FIXTURE_GAME_ID,
+    events: [],
+    winner: 'player',
+    encounterId: 'enc-row-1',
+    encounterName: 'Storming the Citadel',
+    templateType: ScenarioTemplateType.Skirmish,
+    playerForceSummary: "Wolf's Dragoons (4500 BV, 4 units)",
+    opponentSummary: 'Clan Jade Falcon (5200 BV, 5 units)',
+    ...overrides,
+  };
+}
+
+describe('buildEncounterManifestEntry', () => {
+  it('builds an IEncounterReplayManifestEntry with replaySource=Encounter discriminant', () => {
+    const events: IGameEvent[] = [
+      gameCreatedEvent([unit('p1', 1500), unit('o1', 1700)]),
+      turnStartedEvent(1, 1),
+      turnStartedEvent(2, 2),
+    ];
+
+    const entry = buildEncounterManifestEntry(makeBaseInput({ events }));
+
+    expect(entry.replaySource).toBe(ReplaySource.Encounter);
+    expect(entry.id).toBe(FIXTURE_GAME_ID);
+    expect(entry.path).toBe(`encounter/${FIXTURE_GAME_ID}.jsonl`);
+  });
+
+  it('populates all encounter-specific fields verbatim from input', () => {
+    const entry = buildEncounterManifestEntry(
+      makeBaseInput({
+        encounterId: 'enc-42',
+        encounterName: 'Battle for Tukayyid',
+        templateType: ScenarioTemplateType.Battle,
+        playerForceSummary: 'ComStar 1st (8000 BV, 12 units)',
+        opponentSummary: 'Clan Wolf (8500 BV, 12 units)',
+      }),
+    );
+    expect(entry.encounterId).toBe('enc-42');
+    expect(entry.encounterName).toBe('Battle for Tukayyid');
+    expect(entry.templateType).toBe(ScenarioTemplateType.Battle);
+    expect(entry.playerForceSummary).toBe('ComStar 1st (8000 BV, 12 units)');
+    expect(entry.opponentSummary).toBe('Clan Wolf (8500 BV, 12 units)');
+  });
+
+  it('preserves templateType=null for free-form / custom encounters', () => {
+    const entry = buildEncounterManifestEntry(
+      makeBaseInput({ templateType: null }),
+    );
+    expect(entry.templateType).toBeNull();
+  });
+
+  it('extracts winner=Player from "player" winner string', () => {
+    const entry = buildEncounterManifestEntry(
+      makeBaseInput({ winner: 'player' }),
+    );
+    expect(entry.winner).toBe(GameSide.Player);
+  });
+
+  it('extracts winner=Opponent from "opponent" winner string', () => {
+    const entry = buildEncounterManifestEntry(
+      makeBaseInput({ winner: 'opponent' }),
+    );
+    expect(entry.winner).toBe(GameSide.Opponent);
+  });
+
+  it('collapses winner="draw" and winner=null to null', () => {
+    expect(
+      buildEncounterManifestEntry(makeBaseInput({ winner: 'draw' })).winner,
+    ).toBeNull();
+    expect(
+      buildEncounterManifestEntry(makeBaseInput({ winner: null })).winner,
+    ).toBeNull();
+  });
+
+  it('counts turn_started events as turns', () => {
+    const events: IGameEvent[] = [
+      gameCreatedEvent([]),
+      turnStartedEvent(1, 1),
+      turnStartedEvent(2, 2),
+      turnStartedEvent(3, 3),
+    ];
+    const entry = buildEncounterManifestEntry(makeBaseInput({ events }));
+    expect(entry.turns).toBe(3);
+  });
+
+  it('falls back to turns=0 when no turn_started events', () => {
+    const entry = buildEncounterManifestEntry(
+      makeBaseInput({ events: [gameCreatedEvent([])] }),
+    );
+    expect(entry.turns).toBe(0);
+  });
+
+  it('sums bv from GameCreated.payload.units', () => {
+    const entry = buildEncounterManifestEntry(
+      makeBaseInput({
+        events: [gameCreatedEvent([unit('p1', 1500), unit('o1', 1700)])],
+      }),
+    );
+    expect(entry.bvTotal).toBe(3200);
+  });
+
+  it('falls back to bvTotal=0 when no GameCreated event present', () => {
+    const entry = buildEncounterManifestEntry(
+      makeBaseInput({ events: [turnStartedEvent(0, 1)] }),
+    );
+    expect(entry.bvTotal).toBe(0);
+  });
+});
+
+describe('stampEncounterReplaySource', () => {
+  it('stamps Encounter on events without an explicit replaySource', () => {
+    const events: IGameEvent[] = [gameCreatedEvent([]), turnStartedEvent(1, 1)];
+    const stamped = stampEncounterReplaySource(events);
+    for (const event of stamped) {
+      expect(event.replaySource).toBe(ReplaySource.Encounter);
+    }
+  });
+
+  it('preserves an explicit replaySource (does not overwrite)', () => {
+    const fixedEvent: IGameEvent = {
+      ...turnStartedEvent(0, 1),
+      replaySource: ReplaySource.Campaign,
+    };
+    const stamped = stampEncounterReplaySource([
+      gameCreatedEvent([]),
+      fixedEvent,
+    ]);
+    expect(stamped[0].replaySource).toBe(ReplaySource.Encounter);
+    expect(stamped[1].replaySource).toBe(ReplaySource.Campaign);
+  });
+});
+
+describe('persistEncounterGame (Node env)', () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    // Each test gets its own tmpdir so concurrent tests don't trip the
+    // file-mutex in `appendManifestEntry`.
+    cwd = await mkdtemp(path.join(tmpdir(), 'mekstation-encounter-pr2-'));
+  });
+
+  afterEach(async () => {
+    if (cwd !== '') {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('happy path: writes file under tmpdir, appends manifest, returns persisted=true with the right discriminator', async () => {
+    const events: IGameEvent[] = [
+      gameCreatedEvent([unit('p1', 1500), unit('o1', 1700)]),
+      turnStartedEvent(1, 1),
+    ];
+
+    const result = await persistEncounterGame({
+      ...makeBaseInput({ events }),
+      cwd,
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(result.path).toBe(
+      path.resolve(
+        cwd,
+        'simulation-reports',
+        'encounter',
+        `${FIXTURE_GAME_ID}.jsonl`,
+      ),
+    );
+    expect(result.manifestEntry).not.toBeNull();
+    expect(result.manifestEntry!.replaySource).toBe(ReplaySource.Encounter);
+    expect(result.manifestEntry!.encounterId).toBe('enc-row-1');
+    expect(result.manifestEntry!.encounterName).toBe('Storming the Citadel');
+    expect(result.manifestEntry!.templateType).toBe(
+      ScenarioTemplateType.Skirmish,
+    );
+
+    // Manifest entry was appended to replay-index.json.
+    const indexPath = path.resolve(
+      cwd,
+      'simulation-reports',
+      'replay-index.json',
+    );
+    const indexJson = JSON.parse(await readFile(indexPath, 'utf-8')) as
+      | { entries: unknown[] }
+      | unknown[];
+    const entries: unknown[] = Array.isArray(indexJson)
+      ? indexJson
+      : indexJson.entries;
+    expect(entries).toHaveLength(1);
+    const entry = entries[0] as {
+      replaySource: ReplaySource;
+      id: string;
+      encounterId: string;
+    };
+    expect(entry.replaySource).toBe(ReplaySource.Encounter);
+    expect(entry.id).toBe(FIXTURE_GAME_ID);
+    expect(entry.encounterId).toBe('enc-row-1');
+  });
+
+  it('browser env (no Node runtime): no-op, returns persisted=false, manifestEntry=null', async () => {
+    // Stub out `process.versions.node` to simulate a browser-like env.
+    // The shouldPersistToDisk check uses `typeof process.versions.node === 'string'`,
+    // so deleting / overriding that property flips the gate.
+    const originalNode = process.versions.node;
+    Object.defineProperty(process.versions, 'node', {
+      value: undefined,
+      configurable: true,
+    });
+
+    try {
+      const result = await persistEncounterGame({
+        ...makeBaseInput({
+          events: [gameCreatedEvent([])],
+        }),
+        // Even with cwd provided, the Node-runtime gate fails first.
+        cwd,
+      });
+      expect(result.persisted).toBe(false);
+      expect(result.path).toBeNull();
+      expect(result.manifestEntry).toBeNull();
+
+      // Confirm nothing was written to disk under the tmpdir.
+      let dirContents: string[] = [];
+      try {
+        dirContents = await readdir(path.resolve(cwd, 'simulation-reports'));
+      } catch {
+        // ENOENT — directory was never created. That's the expected no-op.
+      }
+      expect(dirContents).toHaveLength(0);
+    } finally {
+      Object.defineProperty(process.versions, 'node', {
+        value: originalNode,
+        configurable: true,
+      });
+    }
+  });
+
+  it('test env without cwd: no-op (jest-jsdom guard)', async () => {
+    // process.env.NODE_ENV === 'test' under jest. Without a cwd override,
+    // shouldPersistToDisk should return false and the call short-circuits.
+    expect(process.env.NODE_ENV).toBe('test');
+
+    const result = await persistEncounterGame(
+      makeBaseInput({ events: [gameCreatedEvent([])] }),
+      // no cwd — explicitly omitted
+    );
+    expect(result.persisted).toBe(false);
+    expect(result.path).toBeNull();
+    expect(result.manifestEntry).toBeNull();
+  });
+
+  it('preserves an explicit non-Encounter replaySource on a sample event (does not overwrite)', async () => {
+    const fixedEvent: IGameEvent = {
+      ...turnStartedEvent(0, 1),
+      replaySource: ReplaySource.Campaign,
+    };
+    const events: IGameEvent[] = [gameCreatedEvent([]), fixedEvent];
+
+    const result = await persistEncounterGame({
+      ...makeBaseInput({ events }),
+      cwd,
+    });
+
+    const written = await readFile(result.path!, 'utf-8');
+    const parsed = written
+      .split('\n')
+      .map((line) => JSON.parse(line) as IGameEvent);
+    // GameCreated didn't have a source → stamped Encounter
+    expect(parsed[0].replaySource).toBe(ReplaySource.Encounter);
+    // Fixed event already had Campaign → preserved
+    expect(parsed[1].replaySource).toBe(ReplaySource.Campaign);
+  });
+
+  it('manifest entry shape: replaySource=encounter, all source-specific fields populated correctly', async () => {
+    const events: IGameEvent[] = [gameCreatedEvent([unit('p1', 2000)])];
+    const result = await persistEncounterGame({
+      ...makeBaseInput({
+        events,
+        encounterId: 'enc-shape-1',
+        encounterName: 'Shape Test',
+        templateType: ScenarioTemplateType.Duel,
+        playerForceSummary: 'Player Force (2000 BV, 1 unit)',
+        opponentSummary: 'Generated lance (~2200 BV)',
+      }),
+      cwd,
+    });
+
+    const entry = result.manifestEntry!;
+    expect(entry.replaySource).toBe('encounter');
+    expect(entry.replaySource).toBe(ReplaySource.Encounter);
+    expect(entry.encounterId).toBe('enc-shape-1');
+    expect(entry.encounterName).toBe('Shape Test');
+    expect(entry.templateType).toBe(ScenarioTemplateType.Duel);
+    expect(entry.playerForceSummary).toBe('Player Force (2000 BV, 1 unit)');
+    expect(entry.opponentSummary).toBe('Generated lance (~2200 BV)');
+    expect(entry.path).toBe(`encounter/${FIXTURE_GAME_ID}.jsonl`);
+    expect(entry.bvTotal).toBe(2000);
+  });
+
+  it('round-trip: written file parses back into an event array with the post-stamped source', async () => {
+    const events: IGameEvent[] = [
+      gameCreatedEvent([unit('p1', 1500)]),
+      turnStartedEvent(1, 1),
+      turnStartedEvent(2, 2),
+    ];
+
+    const result = await persistEncounterGame({
+      ...makeBaseInput({ events }),
+      cwd,
+    });
+    expect(result.persisted).toBe(true);
+
+    const written = await readFile(result.path!, 'utf-8');
+    const lines = written.split('\n');
+    expect(lines).toHaveLength(events.length);
+
+    const parsed = lines.map((line) => JSON.parse(line) as IGameEvent);
+    expect(parsed).toHaveLength(events.length);
+    for (const event of parsed) {
+      expect(event.replaySource).toBe(ReplaySource.Encounter);
+    }
+    // First event survived the round-trip with its type intact.
+    expect(parsed[0].type).toBe(GameEventType.GameCreated);
+    expect(parsed[1].type).toBe(GameEventType.TurnStarted);
+  });
+
+  it('creates the encounter partition directory if missing', async () => {
+    // tmpdir starts empty — `simulation-reports/encounter/` doesn't exist.
+    const result = await persistEncounterGame({
+      ...makeBaseInput({ events: [gameCreatedEvent([])] }),
+      cwd,
+    });
+    expect(result.persisted).toBe(true);
+
+    const files = await readdir(
+      path.resolve(cwd, 'simulation-reports', 'encounter'),
+    );
+    expect(files).toContain(`${FIXTURE_GAME_ID}.jsonl`);
+  });
+});

--- a/src/components/encounter/persistEncounterGame.ts
+++ b/src/components/encounter/persistEncounterGame.ts
@@ -1,0 +1,276 @@
+/**
+ * Encounter-game persistence pipeline. Per `link-encounters-to-replays`
+ * PR 2 (replay-library spec — Filesystem Partition Layout extended with
+ * the `encounter/` partition; game-session-management spec — Encounter
+ * Game Event Log Persistence ADDED): when an encounter session reaches
+ * a terminal state (`endedAt` is set), persist its full event log to
+ * `simulation-reports/encounter/<gameId>.jsonl` and append an
+ * `IEncounterReplayManifestEntry` to the central replay-index.json.
+ *
+ * Mirrors `src/components/quickgame/persistQuickGame.ts` line-for-line
+ * where applicable. Per design.md decision: do NOT extract a shared
+ * helper — the source-specific fields differ (encounter metadata vs
+ * `aiVariant`) and the post-stamp uses a different `ReplaySource`
+ * discriminator. Two parallel modules > one over-abstracted shared one.
+ *
+ * Env-aware IO: this module is imported by service code that runs in
+ * the browser (and in Node test envs). Browser builds get a no-op
+ * persistence layer for v1 — IndexedDB-backed implementation is a
+ * follow-on PR. Node test envs go through the same `node:fs/promises`
+ * + `appendManifestEntry` pipeline the swarm runner uses.
+ *
+ * Post-stamping `replaySource: ReplaySource.Encounter` happens at the
+ * boundary here (mirrors the persistQuickGame pattern from PR 5 of
+ * add-replay-library): events on the wire carry the discriminator
+ * without needing every `createGameEvent` callsite to thread it.
+ *
+ * Note on `encounterMeta`: PR 1's `buildEncounterEntry` in
+ * `backfill-scan.ts` reads `GameCreated.payload.encounterMeta` to
+ * recover the per-encounter fields when re-scanning the disk. This
+ * pipeline writes the manifest entry directly off the input fields
+ * (no need to read it back from `encounterMeta`); the encounter meta
+ * lives on the GameCreated event because PR 3 of this change stamps
+ * it onto the payload at session creation in `EncounterService`.
+ * Backfill remains the recovery path for files written before the
+ * manifest existed (e.g. rebuilt fresh checkout); the persist path
+ * here is the authoritative write.
+ */
+
+// Import the type from the deeper module path (not the barrel) so the
+// browser bundler doesn't trace `index-reader.ts` / `index-writer.ts`
+// (which import `node:fs/promises`) when erasing the type-only import.
+// Turbopack's chunking still walks value re-exports in the barrel even
+// when the import is `import type`, hence the deep path.
+import type { IEncounterReplayManifestEntry } from '@/replay-library/types';
+import type { ScenarioTemplateType } from '@/types/encounter/EncounterInterfaces';
+
+import { GameSide, ReplaySource, type IGameEvent } from '@/types/gameplay';
+
+/**
+ * Inputs required to persist a completed encounter game.
+ *
+ * The five encounter-specific fields (`encounterId`, `encounterName`,
+ * `templateType`, `playerForceSummary`, `opponentSummary`) are
+ * snapshot-at-launch values — see proposal §"Why summary strings, not
+ * force IDs" for the immutability rationale (renaming or deleting a
+ * force after the fact does not mutate the historical row).
+ */
+export interface IPersistEncounterGameInput {
+  readonly gameId: string;
+  readonly events: readonly IGameEvent[];
+  readonly winner: 'player' | 'opponent' | 'draw' | null;
+  readonly encounterId: string;
+  readonly encounterName: string;
+  readonly templateType: ScenarioTemplateType | null;
+  readonly playerForceSummary: string;
+  readonly opponentSummary: string;
+  /**
+   * Optional override for the working directory. Tests inject a
+   * tmpdir; production callers omit and we fall back to
+   * `process.cwd()`. Browser callers SHOULD pass `undefined` so the
+   * `typeof window` branch fires before any `process` access.
+   */
+  readonly cwd?: string;
+}
+
+/**
+ * Result returned to the caller. `persisted` is `false` for browser
+ * environments where the v1 persistence is a no-op — the React
+ * component can surface a "saved to library" status from this signal
+ * if the UX wants to differentiate.
+ */
+export interface IPersistEncounterGameResult {
+  readonly persisted: boolean;
+  readonly path: string | null;
+  readonly manifestEntry: IEncounterReplayManifestEntry | null;
+}
+
+/**
+ * Detect whether we should perform a real filesystem write. Three gates:
+ *
+ *   1. Node runtime is available (`process.versions.node` set).
+ *   2. EITHER an explicit `cwd` was passed (unit tests for this module
+ *      opt in to the write path with a tmpdir) OR `NODE_ENV !== 'test'`
+ *      (production code paths).
+ *
+ * Why both: jest's jsdom runtime is technically Node, so without the
+ * NODE_ENV gate every component test that mounts the persist effect
+ * would dump a real file under `simulation-reports/` in the repo root.
+ * Component tests don't pass `cwd`; unit tests for this module always
+ * do.
+ *
+ * Browser builds fail the Node check and short-circuit to the no-op
+ * path immediately — no `process` access in the browser bundle.
+ *
+ * Duplicated from `persistQuickGame.ts` per design.md — shared helper
+ * would couple two source-specific persist paths and is rejected.
+ */
+function shouldPersistToDisk(cwdProvided: boolean): boolean {
+  const isNode =
+    typeof process !== 'undefined' &&
+    typeof (process as { versions?: { node?: string } }).versions?.node ===
+      'string';
+  if (!isNode) return false;
+  if (cwdProvided) return true;
+  // Production / dev — write. Tests without explicit cwd — no-op.
+  return process.env.NODE_ENV !== 'test';
+}
+
+/**
+ * Stamp `replaySource: ReplaySource.Encounter` on every event that does
+ * not already have one. Preserves any explicit value so a future
+ * emitter can override (mirrors the post-stamp pattern from
+ * `persistQuickGame`).
+ */
+export function stampEncounterReplaySource(
+  events: readonly IGameEvent[],
+): readonly IGameEvent[] {
+  return events.map((event) =>
+    event.replaySource !== undefined
+      ? event
+      : { ...event, replaySource: ReplaySource.Encounter },
+  );
+}
+
+/**
+ * Count `turn_started` events. Used as the `turns` derivation — same
+ * ladder the quick-game pipeline uses so build-time and read-time
+ * agree.
+ *
+ * Duplicated from `persistQuickGame.ts` per design.md — shared helper
+ * deferred until at least three call sites need the same logic.
+ */
+function countTurnStartedEvents(events: readonly IGameEvent[]): number {
+  let count = 0;
+  for (const event of events) {
+    // String-compare against the wire shape rather than re-importing the
+    // typed enum so the module tree stays small.
+    if (event.type === 'turn_started') {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * Build the `IEncounterReplayManifestEntry` from a completed encounter
+ * session. Pure — no IO. Exported so the service / route can render an
+ * optimistic "saved" UI cell from the same shape that lands in
+ * `replay-index.json`, and so the dedup branch in the API route can
+ * return the same shape the persist branch would have produced.
+ */
+export function buildEncounterManifestEntry(
+  input: IPersistEncounterGameInput,
+): IEncounterReplayManifestEntry {
+  const {
+    gameId,
+    events,
+    winner,
+    encounterId,
+    encounterName,
+    templateType,
+    playerForceSummary,
+    opponentSummary,
+  } = input;
+
+  // Winner: collapse 'draw' (and missing) to null per the manifest entry
+  // contract. Encounter games can end in a draw if the turn limit is
+  // reached without destruction, same as quick games.
+  let manifestWinner: GameSide | null = null;
+  if (winner === 'player') manifestWinner = GameSide.Player;
+  else if (winner === 'opponent') manifestWinner = GameSide.Opponent;
+
+  // Turns: count of turn_started events. Encounter sessions don't emit
+  // a final GameEnded.turns explicitly today; the count is the most
+  // robust derivation. Fallback to 0 for crashed-before-turn-1 runs.
+  const turns = countTurnStartedEvents(events);
+
+  // BV total: per Council Decision 3 + Momus MUST RESOLVE #1 from
+  // add-replay-library, BV is computed at write time. Sum across
+  // whatever payload.units[].bv values are on the GameCreated event.
+  // Falls back to 0 if no GameCreated or no bv fields — in which case
+  // the Library page row shows BV: 0 and a future PR can plumb the real
+  // number through.
+  let bvTotal = 0;
+  for (const event of events) {
+    if (event.type === 'game_created') {
+      const payload = event.payload as {
+        units?: ReadonlyArray<{ bv?: number }>;
+      };
+      if (payload.units !== undefined) {
+        bvTotal = payload.units.reduce((sum, u) => sum + (u.bv ?? 0), 0);
+      }
+      break;
+    }
+  }
+
+  return {
+    id: gameId,
+    replaySource: ReplaySource.Encounter,
+    path: `encounter/${gameId}.jsonl`,
+    createdAt: new Date().toISOString(),
+    turns,
+    winner: manifestWinner,
+    bvTotal,
+    encounterId,
+    encounterName,
+    templateType,
+    playerForceSummary,
+    opponentSummary,
+  };
+}
+
+/**
+ * Persist a completed encounter session to disk + append a manifest
+ * entry. Browser builds short-circuit to a no-op (v1 — IndexedDB
+ * follow-on planned).
+ *
+ * Caller MUST guard against double-invocation — the React component /
+ * service hook uses a ref+effect or one-shot pattern so this is called
+ * exactly once per `endedAt` transition. The API route does an
+ * additional dedup check via `readReplayIndex` to defend against hard
+ * refresh re-firing the persist effect on the client.
+ */
+export async function persistEncounterGame(
+  input: IPersistEncounterGameInput,
+): Promise<IPersistEncounterGameResult> {
+  if (!shouldPersistToDisk(input.cwd !== undefined)) {
+    // Browser build OR component test without explicit cwd — return a
+    // no-op result so the UI can render a "saved locally to session"
+    // message instead of "saved to library", and component tests don't
+    // dump real files under `simulation-reports/` in the repo root.
+    return { persisted: false, path: null, manifestEntry: null };
+  }
+
+  // Lazy-import the Node-only modules so the browser bundle never
+  // pulls them in. `await import` returns the module namespace; the
+  // bundler tree-shakes the dynamic-import branch when statically
+  // confident the runtime is browser.
+  const { writeFile, mkdir } = await import('node:fs/promises');
+  const path = await import('node:path');
+  // Deep import (not the barrel) so the static-trace path in the
+  // browser bundler never sees `node:fs/promises`. The dynamic
+  // `await import` is sufficient on its own only when the bundler
+  // skips the barrel; since Turbopack walks value re-exports through
+  // the barrel statically, we go directly to the source.
+  const { appendManifestEntry } = await import('@/replay-library/index-writer');
+
+  const stampedEvents = stampEncounterReplaySource(input.events);
+  const partitionDir = path.resolve(
+    input.cwd ?? process.cwd(),
+    'simulation-reports',
+    'encounter',
+  );
+  await mkdir(partitionDir, { recursive: true });
+  // NDJSON: one JSON-encoded event per line, `\n` separator, no trailing
+  // newline (matches the swarm format from add-replay-library PR 4 +
+  // the quick-game format from PR 5).
+  const body = stampedEvents.map((event) => JSON.stringify(event)).join('\n');
+  const filePath = path.resolve(partitionDir, `${input.gameId}.jsonl`);
+  await writeFile(filePath, body, 'utf-8');
+
+  const manifestEntry = buildEncounterManifestEntry(input);
+  await appendManifestEntry(manifestEntry, { cwd: input.cwd });
+
+  return { persisted: true, path: filePath, manifestEntry };
+}

--- a/src/pages/api/replay-library/encounter.ts
+++ b/src/pages/api/replay-library/encounter.ts
@@ -1,0 +1,302 @@
+/**
+ * Replay Library — encounter-game persist endpoint.
+ *
+ * `POST /api/replay-library/encounter` — accepts a completed encounter
+ * session's event log + encounter metadata, validates inputs, **dedupes
+ * against the current manifest**, then delegates the actual write to
+ * the unit-tested `persistEncounterGame()` pipeline.
+ *
+ * Mirror of `src/pages/api/replay-library/quick.ts` from the
+ * `add-replay-library` change. The browser cannot write to the local
+ * filesystem, so the encounter session terminal-state hook (PR 3 of
+ * `link-encounters-to-replays`) POSTs here on the `endedAt` transition.
+ *
+ * Idempotency:
+ *   - Hard refresh of an already-persisted encounter would re-fire the
+ *     persist hook (the `useRef` guard resets on remount).
+ *   - `appendManifestEntry` does a blind append with no dedup, so we
+ *     short-circuit on duplicates HERE — read the current manifest and
+ *     return `200 { persisted: false, alreadyPersisted: true }` when
+ *     the `gameId` already exists. Never invoke `persistEncounterGame()`
+ *     twice for the same game.
+ *
+ * Validation pattern mirrors `quick.ts`:
+ *   - inline runtime checks (no Zod — established convention in this
+ *     directory; future consolidation is a separate sweep)
+ *   - shared `ErrorResponse = { error, code? }` shape
+ *   - `gameId` regex `^[A-Za-z0-9_-]+$` — same pattern, copied not
+ *     imported (sibling route uses module-private const)
+ *
+ * Server-side only — `persistEncounterGame` is Node-only by design. The
+ * shouldPersistToDisk three-gate guard inside it falls through cleanly
+ * when called from this handler under `next dev` or production.
+ *
+ * @spec openspec/changes/link-encounters-to-replays/specs/replay-library/spec.md
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import type { IGameEvent } from '@/types/gameplay';
+
+import {
+  buildEncounterManifestEntry,
+  persistEncounterGame,
+  type IPersistEncounterGameInput,
+  type IPersistEncounterGameResult,
+} from '@/components/encounter/persistEncounterGame';
+import { readReplayIndex } from '@/replay-library/index-reader';
+import { ScenarioTemplateType } from '@/types/encounter/EncounterInterfaces';
+import { logger } from '@/utils/logger';
+
+// =============================================================================
+// Response Types
+// =============================================================================
+
+type SuccessResponse = {
+  persisted: boolean;
+  alreadyPersisted: boolean;
+  manifestEntry: IPersistEncounterGameResult['manifestEntry'];
+  path: string | null;
+};
+
+type ErrorResponse = {
+  error: string;
+  code?: string;
+};
+
+// =============================================================================
+// Validation helpers
+// =============================================================================
+
+/**
+ * Same regex as the sibling `quick.ts` and `[source]/[gameId].ts` routes.
+ * Duplicated intentionally — the sibling consts are module-private and
+ * cross-route imports for a 1-line regex would couple files harder than
+ * copying. If we ever need a fourth reuse, lift to
+ * `@/replay-library/validation`.
+ */
+const GAME_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+const VALID_WINNERS: ReadonlySet<string> = new Set([
+  'player',
+  'opponent',
+  'draw',
+]);
+
+// Snapshot of every legal `templateType` literal so the body validator
+// can reject unknowns without depending on a runtime cast.
+const VALID_TEMPLATE_TYPES: ReadonlySet<string> = new Set(
+  Object.values(ScenarioTemplateType),
+);
+
+/**
+ * Validates the POST body. Returns `{ ok: true, input }` on valid input
+ * + the typed `IPersistEncounterGameInput`, or `{ ok: false, error }`
+ * describing the first rejection. Callers should
+ * `res.status(400).json(error)` on failure.
+ */
+function parseBody(
+  body: unknown,
+):
+  | { ok: true; input: Omit<IPersistEncounterGameInput, 'cwd'> }
+  | { ok: false; error: ErrorResponse } {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    return {
+      ok: false,
+      error: { error: 'request body must be an object', code: 'BAD_BODY' },
+    };
+  }
+  const record = body as Record<string, unknown>;
+
+  const {
+    gameId,
+    events,
+    winner,
+    encounterId,
+    encounterName,
+    templateType,
+    playerForceSummary,
+    opponentSummary,
+  } = record;
+
+  if (typeof gameId !== 'string' || !GAME_ID_PATTERN.test(gameId)) {
+    return {
+      ok: false,
+      error: { error: 'invalid gameId', code: 'BAD_GAME_ID' },
+    };
+  }
+
+  if (!Array.isArray(events)) {
+    return {
+      ok: false,
+      error: { error: 'events must be an array', code: 'BAD_EVENTS' },
+    };
+  }
+
+  // `winner` is `'player' | 'opponent' | 'draw' | null`. Allow the literal
+  // null (a timed-out / aborted encounter) and the three valid strings;
+  // reject everything else.
+  if (
+    winner !== null &&
+    (typeof winner !== 'string' || !VALID_WINNERS.has(winner))
+  ) {
+    return {
+      ok: false,
+      error: { error: 'invalid winner', code: 'BAD_WINNER' },
+    };
+  }
+
+  if (typeof encounterId !== 'string' || encounterId.length === 0) {
+    return {
+      ok: false,
+      error: {
+        error: 'encounterId must be a non-empty string',
+        code: 'BAD_ENCOUNTER_ID',
+      },
+    };
+  }
+
+  if (typeof encounterName !== 'string') {
+    return {
+      ok: false,
+      error: {
+        error: 'encounterName must be a string',
+        code: 'BAD_ENCOUNTER_NAME',
+      },
+    };
+  }
+
+  // `templateType` is `ScenarioTemplateType | null`. Allow the literal
+  // null (free-form / custom encounter) and any valid template literal;
+  // reject everything else.
+  if (
+    templateType !== null &&
+    (typeof templateType !== 'string' ||
+      !VALID_TEMPLATE_TYPES.has(templateType))
+  ) {
+    return {
+      ok: false,
+      error: { error: 'invalid templateType', code: 'BAD_TEMPLATE_TYPE' },
+    };
+  }
+
+  if (typeof playerForceSummary !== 'string') {
+    return {
+      ok: false,
+      error: {
+        error: 'playerForceSummary must be a string',
+        code: 'BAD_PLAYER_FORCE_SUMMARY',
+      },
+    };
+  }
+
+  if (typeof opponentSummary !== 'string') {
+    return {
+      ok: false,
+      error: {
+        error: 'opponentSummary must be a string',
+        code: 'BAD_OPPONENT_SUMMARY',
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    input: {
+      gameId,
+      events: events as readonly IGameEvent[],
+      winner: winner as IPersistEncounterGameInput['winner'],
+      encounterId,
+      encounterName,
+      templateType: templateType as ScenarioTemplateType | null,
+      playerForceSummary,
+      opponentSummary,
+    },
+  };
+}
+
+// =============================================================================
+// Handler
+// =============================================================================
+
+/**
+ * POST /api/replay-library/encounter — persist a completed encounter game.
+ *
+ * Returns:
+ *   - 200 `{ persisted: true,  alreadyPersisted: false, manifestEntry, path }` — first persist
+ *   - 200 `{ persisted: false, alreadyPersisted: true,  manifestEntry, path }` — already in manifest
+ *   - 400 on bad body / gameId / winner / encounterId / encounterName / templateType / summaries
+ *   - 405 on non-POST
+ *   - 500 if `persistEncounterGame` throws
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<SuccessResponse | ErrorResponse>,
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    res.status(405).json({ error: `Method ${req.method} Not Allowed` });
+    return;
+  }
+
+  const parsed = parseBody(req.body);
+  if (!parsed.ok) {
+    res.status(400).json(parsed.error);
+    return;
+  }
+  const { input } = parsed;
+
+  // Dedup guard. Read the current manifest and short-circuit if `gameId`
+  // is already present — `appendManifestEntry` does a blind append, so
+  // we MUST stop the duplicate write here. Build the same manifest entry
+  // the persist call would have produced so the client gets a consistent
+  // shape on both first-persist and already-persisted paths.
+  try {
+    const existing = await readReplayIndex();
+    if (existing.some((entry) => entry.id === input.gameId)) {
+      const manifestEntry = buildEncounterManifestEntry(input);
+      logger.debug(
+        '[replay-library] encounter game already persisted; skipping',
+        { gameId: input.gameId },
+      );
+      res.status(200).json({
+        persisted: false,
+        alreadyPersisted: true,
+        manifestEntry,
+        path: `encounter/${input.gameId}.jsonl`,
+      });
+      return;
+    }
+  } catch (err) {
+    // A malformed `replay-index.json` would surface as a parse error here.
+    // Log and continue — `persistEncounterGame` will still write the file
+    // even if the manifest read failed; the manifest will get repaired
+    // by the backfill scan on next read. Don't 500 on a soft index issue.
+    logger.warn('[replay-library] failed to read manifest for dedup', {
+      gameId: input.gameId,
+      err,
+    });
+  }
+
+  let result: IPersistEncounterGameResult;
+  try {
+    result = await persistEncounterGame(input);
+  } catch (err) {
+    logger.error('[replay-library] encounter persist failed', {
+      gameId: input.gameId,
+      err,
+    });
+    res.status(500).json({
+      error: 'failed to persist encounter game',
+      code: 'PERSIST_FAILED',
+    });
+    return;
+  }
+
+  res.status(200).json({
+    persisted: result.persisted,
+    alreadyPersisted: false,
+    manifestEntry: result.manifestEntry,
+    path: result.path,
+  });
+}


### PR DESCRIPTION
## Summary

PR 2/3 of `link-encounters-to-replays`. Adds the persist pipeline + API route for encounter-game replays. PR 3 wires it into `EncounterService.launchEncounter` + the Replay Library UI.

What ships:
- `src/components/encounter/persistEncounterGame.ts` (NEW) — mirrors `persistQuickGame.ts`. Writes NDJSON to `simulation-reports/encounter/<gameId>.jsonl`, post-stamps `ReplaySource.Encounter` on events, builds `IEncounterReplayManifestEntry` with `encounterId`/`encounterName`/`templateType`/`playerForceSummary`/`opponentSummary`, appends to `replay-index.json`. Three-gate `shouldPersistToDisk` (Node runtime + cwd-or-NODE_ENV).
- `src/pages/api/replay-library/encounter.ts` (NEW) — mirrors `quick.ts`. POST handler with inline runtime validation (no Zod — convention), dedup guard via `readReplayIndex`, 405 on GET, 400 on parse failure (8 codes), 500 on persist throw. `VALID_TEMPLATE_TYPES` derived from `Object.values(ScenarioTemplateType)` for forward-compat.

Tests: 40 new across 2 test files (19 pipeline + 21 route). Snapshot guarantees: written events round-trip correctly; manifest entry has the right discriminator; dedup short-circuits on second POST; malformed-index does not 500.

## Test plan
- [x] npm run typecheck clean
- [x] npm run lint 0 errors
- [x] npm run format:check clean
- [x] npx jest src/components/encounter src/__tests__/api/replay-library --no-coverage — 70/70 green
- [ ] CI 15/15 green