### PR TITLE
chore(openspec): sync encounter + replay source-of-truth specs

### DIFF
--- a/openspec/changes/sync-encounter-and-replay-source-of-truth/design.md
+++ b/openspec/changes/sync-encounter-and-replay-source-of-truth/design.md
@@ -1,0 +1,265 @@
+# Design: Sync Encounter and Replay Source-of-Truth
+
+## Technical Approach
+
+This is a **spec-only** change. The deliverable is markdown that
+snapshots existing behaviour. No data flow, no architectural choices,
+no code paths to design. The "design" decisions are about how the
+source-of-truth specs are organised — which spec owns which
+requirement, how deltas absorb cleanly, and how to avoid double-coverage
+between specs.
+
+## Architecture Decisions
+
+### Decision: New `encounter-system` source-of-truth, NOT absorb into `game-session-management`
+
+**Choice**: Create a new `openspec/specs/encounter-system/spec.md`
+domain via the change folder's
+`specs/encounter-system/spec.md` (full ADDED suite). Author it as the
+canonical home for the encounter entity model, lifecycle, force config,
+template enum, map config, victory conditions, validation, broken-ref
+helper, list/detail UI, sample seeding, and cleanup script.
+
+**Rationale**: The original `2026-01-18-add-encounter-system` change
+explicitly called out `Affected specs: None (new capability)` and
+`New specs: encounter-system`. The fact that the spec was never
+promoted is a paperwork failure, not a domain-modelling decision.
+Re-promoting it preserves the original intent. Conflating the encounter
+domain into `game-session-management` would:
+
+1. Mix concerns — `game-session-management` already covers the
+   live-game session lifecycle (turn orchestration, phase advancement,
+   damage PSR queue, event append, replay/time-travel). Encounters are
+   the *config inputs* to a game session; collapsing the two layers
+   loses the clean separation.
+2. Bloat the `game-session-management` spec — already 2130+ lines on
+   `main`. Adding ~25 encounter requirements pushes it past every
+   reviewer's working memory.
+3. Contradict the existing per-domain pattern — `quick-session` is its
+   own spec, `replay-library` is its own spec, `combat-resolution` is
+   its own spec. Encounters deserve the same treatment.
+
+**What stays in `game-session-management`**: the seven encounter store /
+API requirements that earlier waves already merged
+(`Encounter Launch Status Transition`, `Encounter CRUD via API Routes`,
+`Encounter Selection and Retrieval`, `Force Assignment`,
+`Template Application`, `Encounter Validation`, `Encounter Launch`,
+`Encounter Cloning`, `Filtering and Search`) — those describe the store
+client interface, not the encounter entity model.
+
+**Alternatives considered**:
+
+- **Promote `encounter-system` and back-port the existing seven store
+  requirements out of `game-session-management`** — would require
+  REMOVED entries on `game-session-management`, which complicates the
+  archive sync. Rejected: leave the existing requirements where they
+  are; new behaviour goes to the new spec.
+- **Split `encounter-system` into `encounter-entity-model` +
+  `encounter-ui` + `encounter-cleanup`** — over-decomposition. The
+  encounter domain is small enough to fit in one spec.
+
+### Decision: Repair / cascade / persist additions land on `game-session-management`, NOT the new `encounter-system` spec
+
+**Choice**: The force-deletion cascade, hydration replacement,
+encounter game-event-log persistence, `IEncounterMeta` field on
+`IGameCreatedPayload`, and the browser persist hook on
+`/gameplay/games/[id].tsx` go in the `game-session-management` delta.
+
+**Rationale**:
+
+- The cascade is a `ForceRepository` behaviour that happens to mention
+  the `encounters` table. It belongs with the force lifecycle
+  (which `game-session-management` already covers via
+  `Force Assignment`).
+- The hydration replacement is `EncounterService.hydrateEncounter`
+  behaviour — same module that already owns
+  `Encounter Selection and Retrieval` in `game-session-management`.
+- Encounter game-event-log persistence is a session-level concern
+  (the game session emits events; the persist boundary fires at
+  session terminal state). Mirrors how the spec already covers quick-game
+  persistence.
+- `IEncounterMeta` lives on `IGameCreatedPayload` — a shape owned by
+  `game-session-management`.
+- The browser persist hook is on `/gameplay/games/[id].tsx`, the live
+  game-session viewer page, also owned by `game-session-management`.
+
+**What goes in `encounter-system`** (the encounter-entity / encounter-UI side):
+
+- The broken-ref helper at `src/services/encounter/encounterBrokenRefs.ts`
+  (pure function, encounter-domain).
+- The encounter-list broken-pill render and the encounter-detail
+  repair-banner render (both are encounter-page UI).
+- The sample-seeding API and empty-state seed button (encounter-list
+  surface).
+- The cleanup script (operates over the encounter table, classifies
+  encounters).
+
+This split keeps every requirement on the spec whose code-side
+"home module" matches.
+
+**Alternatives considered**:
+
+- **All repair behaviour on `encounter-system`** — would yank the
+  cascade out of force-lifecycle context. Rejected.
+- **All repair behaviour on `game-session-management`** — would put
+  the encounter UI surfaces (broken pills, repair banner, seed empty
+  state) under a session-management heading where they don't naturally
+  fit. Rejected.
+
+### Decision: Replay-library delta uses MODIFIED for the four existing requirements, ADDED for the new manifest-variant requirement
+
+**Choice**:
+
+- `MODIFIED` — `ReplaySource Enum` (4→5 values), `IReplayManifestEntry
+  Discriminated Union` (4→5 members), `Filesystem Partition Layout`
+  (4→5 partitions), `Backfill Scan` (encounter case), `Replay Library
+  Page` (6-button strip + Encounter row metadata).
+- `ADDED` — none. The `IEncounterReplayManifestEntry Variant`
+  requirement collapses into the union requirement (modified) and the
+  enum requirement (modified); a standalone added requirement would
+  duplicate constraints already covered by the modified versions.
+
+**Rationale**: Each delta directive in the modified requirement is a
+small, self-contained widening. OpenSpec's MODIFIED directive carries
+the new full requirement text plus all preserved scenarios — that
+matches the shipped behaviour without splitting concerns across two
+requirements (one "general union" + one "Encounter-specific").
+
+**Alternatives considered**:
+
+- **Author `IEncounterReplayManifestEntry Variant` as a standalone
+  ADDED requirement** (per the original `link-encounters-to-replays`
+  delta). Considered; rejected because the source-of-truth spec already
+  has the union requirement, and adding a sibling requirement that
+  re-asserts "the union has the Encounter member" duplicates the
+  modified version.
+
+### Decision: Snapshot summary strings stored as strings, not structured objects
+
+**Choice**: The encounter-system spec's launch-snapshot requirement and
+the replay-library spec's manifest variant requirement both pin
+`playerForceSummary` and `opponentSummary` as strings (e.g.
+`"Wolf's Dragoons (4500 BV, 4 units)"`).
+
+**Rationale**: Documents the existing immutability semantics. The
+shipped code at `src/replay-library/types.ts:117-127` and the meta type
+at `src/types/gameplay/GameSessionInterfaces.ts:423-429` both store
+strings. The rationale lives in the
+`link-encounters-to-replays` design.md
+("snapshot baked at write-time so a force renamed/deleted post-write
+does not change the historical row"). The spec text MUST repeat the
+contract so future readers don't try to "improve" it into structured
+objects.
+
+### Decision: Cleanup script described as a behaviour spec, NOT a CLI contract
+
+**Choice**: The cleanup script's requirement language pins the
+classification taxonomy (`abandoned-empty` / `orphaned-force-reference` /
+`still-valid`), the manifest-before-DELETE ordering, the idempotency
+guarantee, and the two CLI flags (`--manifest-only`, `--cwd`). It does
+NOT pin the exact JSON envelope, the file path beyond the directory,
+or the prose of the manifest reason strings.
+
+**Rationale**: Behaviour specs are durable; CLI envelope details
+change. The task brief from `repair-broken-encounter-drafts` already
+locked the JSON shape (full-row plus `classification` and
+`classificationReason`). The spec asserts what matters: the manifest
+exists, contains every encounter, classifies them per the taxonomy,
+and is written before any DELETE. The exact JSON fields are
+implementation. The two CLI flags ARE pinned because they are part of
+the behavioural contract (tests inject `--cwd`; ops use `--manifest-only`).
+
+## Spec Organisation
+
+```
+encounter-system (NEW source-of-truth)
+├── Encounter Entity Model              # entity, status enum, force-ref shape
+├── Encounter Status Lifecycle          # Draft / Ready / Launched / Completed transitions
+├── Force Configuration                 # explicit refs vs opForConfig + null-vs-undefined
+├── Map Configuration                   # radius, terrain, deployment zones
+├── Victory Conditions                  # 5-type enum, turn limit semantics
+├── Scenario Templates                  # 4-template enum + built-in templates
+├── Encounter Launch Snapshot Metadata  # launch-time stamp onto GameCreated payload
+├── Broken-Reference Detection Helper   # pure helper at encounterBrokenRefs.ts
+├── Encounter List Broken-Pill UI       # yellow pill on missing-force slots
+├── Encounter Detail Repair Banner      # banner + clear actions
+├── Sample Encounter Seeding            # POST /api/encounters/seed-samples + button
+└── Cleanup Script                      # 3-class taxonomy + manifest-before-delete
+
+replay-library (delta — all MODIFIED)
+├── ReplaySource Enum                   # 4 → 5 values
+├── IReplayManifestEntry Discriminated Union  # 4 → 5 members
+├── Filesystem Partition Layout         # adds simulation-reports/encounter/ partition
+├── Backfill Scan                       # adds encounter-metadata recovery
+└── Replay Library Page                 # 6-button filter + Encounter row metadata
+
+game-session-management (delta — all ADDED)
+├── Force-Deletion Cascade to Encounter References
+├── Hydration-Boundary Orphaned Reference Replacement
+├── Encounter Game Event Log Persistence
+├── Encounter Metadata in GameCreated Event Payload
+└── Browser-Side Encounter Persist Hook
+```
+
+## File Changes
+
+- **NEW** `openspec/changes/sync-encounter-and-replay-source-of-truth/proposal.md`
+- **NEW** `openspec/changes/sync-encounter-and-replay-source-of-truth/design.md` (this file)
+- **NEW** `openspec/changes/sync-encounter-and-replay-source-of-truth/tasks.md`
+- **NEW** `openspec/changes/sync-encounter-and-replay-source-of-truth/specs/encounter-system/spec.md`
+  (full ADDED suite — promotes the new spec)
+- **NEW** `openspec/changes/sync-encounter-and-replay-source-of-truth/specs/replay-library/spec.md`
+  (delta — MODIFIED widening from 4 → 5 sources)
+- **NEW** `openspec/changes/sync-encounter-and-replay-source-of-truth/specs/game-session-management/spec.md`
+  (delta — ADDED requirements for cascade, hydration, persist, encounter-meta, browser hook)
+- **NEW** `openspec/changes/sync-encounter-and-replay-source-of-truth/notepad/README.md`
+  (cross-delegation wisdom for the operator)
+- **ZERO** changes to `openspec/specs/<domain>/spec.md` files in this PR.
+  All source-of-truth merges happen at archive time via `openspec archive`.
+
+## Risk + Mitigation
+
+- **Risk**: replay-library MODIFIED scenarios subtly mismatch the
+  existing source-of-truth scenario text and fail the archive merge.
+  **Mitigation**: every MODIFIED requirement carries the FULL replacement
+  text — no partial edits. The delta header `## MODIFIED Requirements`
+  signals to OpenSpec that the requirement (and all its scenarios)
+  replaces the existing one wholesale.
+- **Risk**: the encounter-system source-of-truth already has stale
+  authoring noise from `2026-01-18-add-encounter-system` (e.g. "MVP:
+  clear terrain only"). **Mitigation**: this change snapshots
+  *current behaviour*, not the original 2026-01-18 description. Where
+  the shipped code differs, the spec text reflects the shipped
+  behaviour.
+- **Risk**: cited file paths drift after this change ships and the next
+  refactor moves them. **Mitigation**: cite paths inline only when they
+  add specificity (e.g. "the helper at
+  `src/services/encounter/encounterBrokenRefs.ts`"). Where the path is
+  not load-bearing for the requirement, omit it.
+- **Risk**: archive sync needs to create the new
+  `openspec/specs/encounter-system/` directory; if `openspec archive`
+  doesn't auto-create the directory the sync fails.
+  **Mitigation**: the `tasks.md` final wave directs the operator to
+  verify directory creation in the archive step and create it manually
+  if needed before re-running. No `--skip-specs` fallback.
+
+## Open Questions
+
+- **Q**: Should the encounter-system spec absorb the seven encounter
+  store / API requirements currently living in `game-session-management`?
+  **A**: Defer. They work where they are; back-porting them would
+  require REMOVED directives and complicate this change. A future
+  consolidation change can do the migration if it's worth the churn.
+
+- **Q**: The replay-library `Replay Library Page` requirement on `main`
+  is silent on the exact button strip count. Should the delta version
+  REQUIRE 6 buttons, or just MUST contain an Encounter button?
+  **A**: REQUIRE the explicit count. The shipped code lays out exactly
+  6 (`All` + 5 sources) and the test at
+  `src/__tests__/pages/replay-library.test.tsx` asserts the count.
+  Documenting the count gives future readers a sharp invariant.
+
+- **Q**: Do we author scenarios for the deferred IndexedDB local-buffer
+  follow-on?
+  **A**: No. Out of scope per the proposal. The current spec describes
+  what ships; the IndexedDB work will land on its own change.

--- a/openspec/changes/sync-encounter-and-replay-source-of-truth/notepad/README.md
+++ b/openspec/changes/sync-encounter-and-replay-source-of-truth/notepad/README.md
@@ -1,0 +1,93 @@
+# Notepad — sync-encounter-and-replay-source-of-truth
+
+## Purpose
+
+Cross-delegation wisdom for the operator (and any subagent) authoring this
+spec-only change. NO TypeScript code changes — every artifact in this notepad
+is observation, not instruction.
+
+## Source-of-truth audit (state on main as of 2026-05-09)
+
+### Existing source-of-truth specs (`openspec/specs/<domain>/spec.md`)
+
+| Domain | Encounter coverage today |
+|---|---|
+| `replay-library` | 4-source `ReplaySource` enum (Swarm/Quick/PvP/Campaign), 4-member discriminated union, 4-partition layout, page filter referenced abstractly. **No Encounter variant.** |
+| `game-session-management` | Has `Encounter Launch Status Transition`, `Encounter CRUD via API Routes`, `Encounter Selection and Retrieval`, `Force Assignment`, `Template Application`, `Encounter Validation`, `Encounter Launch`, `Encounter Cloning`, `Filtering and Search` — all from earlier waves (already merged). **No** broken-ref repair, **no** force cascade, **no** seed-samples, **no** encounter persist hook, **no** `IEncounterMeta` on `IGameCreatedPayload`. |
+| `encounter-system` | **DOES NOT EXIST.** Original `2026-01-18-add-encounter-system` shipped its delta but archived with `--skip-specs`. |
+| `quick-session` | Owns the quick-game replay loop (already absorbed). No encounter coverage; out of scope here. |
+
+### Archived encounter/replay changes (5 reviewed)
+
+| Archive folder | What it shipped | Where it should land |
+|---|---|---|
+| `archive/2026-01-18-add-encounter-system/` | Original encounter entity model, lifecycle, force config, map config, victory conditions, scenario templates, launch flow. | New `encounter-system` source-of-truth spec (this change). |
+| `archive/2026-05-01-wire-encounter-to-campaign-round-trip/` | Already merged into `game-session-management`, `contract-types`, `scenario-generation`. **OUT OF SCOPE** for this change — confirmed via grep on main specs. |
+| `archive/2026-05-07-add-replay-library/` | Already merged into `replay-library` (4-source baseline). |
+| `archive/2026-05-09-repair-broken-encounter-drafts/` | Cascade + repair UI + seed-samples + cleanup script. Delta archived with `--skip-specs`. |
+| `archive/2026-05-09-link-encounters-to-replays/` | 5th `ReplaySource.Encounter` + manifest variant + persist pipeline + browser hook. Delta archived with `--skip-specs`. |
+
+## Domain layout for this change
+
+```
+openspec/changes/sync-encounter-and-replay-source-of-truth/
+├── proposal.md                         # NEW
+├── design.md                           # NEW
+├── tasks.md                            # NEW
+└── specs/
+    ├── encounter-system/spec.md        # NEW source-of-truth (full ADDED suite)
+    ├── replay-library/spec.md          # Delta — 5th variant + scan + page
+    └── game-session-management/spec.md # Delta — repair + cascade + seed + persist
+```
+
+## Scope rules (re-stated for any subagent)
+
+1. **NO TypeScript / TSX / test code** — markdown only.
+2. **No `--skip-specs` mindset** — these deltas WILL merge to source-of-truth on archive.
+3. **Snapshot what shipped, not what was discussed** — every requirement
+   must correspond to behavior verifiable on main today.
+4. **Cite real file paths** — verified existing files only:
+   - `src/types/encounter/EncounterInterfaces.ts` (lines 15-70 for enums, 141-198 for IEncounter)
+   - `src/types/gameplay/GameSessionInterfaces.ts:298-304` (ReplaySource), `:423-429` (IEncounterMeta), `:434-449` (IGameCreatedPayload)
+   - `src/replay-library/types.ts` (5-member union)
+   - `src/replay-library/backfill-scan.ts` (encounter partition handling)
+   - `src/services/encounter/EncounterService.ts` (launchEncounter line 382 stamps meta)
+   - `src/services/encounter/EncounterRepository.ts` (`IEncounterWithRawForceIds`, `clearForceReference`, `getEncounterWithRawIds`)
+   - `src/services/encounter/encounterBrokenRefs.ts` (pure helper)
+   - `src/services/forces/ForceRepository.cascade.ts` (callback registry — `setEncounterCascadeHook`, `invokeEncounterCascadeHook`)
+   - `src/components/encounter/persistEncounterGame.ts` (Node-side pipeline)
+   - `src/components/encounter/persistEncounterFromSession.ts` (browser-side helper)
+   - `src/components/gameplay/encounters/EncounterCard.tsx` (broken pills)
+   - `src/components/gameplay/pages/EncounterDetailPage.repairBanner.tsx` (banner)
+   - `src/components/replay-library/ReplayLibraryPage.tsx` (6-button strip + Encounter row branch)
+   - `src/pages/api/replay-library/encounter.ts` (POST route)
+   - `src/pages/api/encounters/seed-samples.ts` (sample seeding)
+   - `src/pages/gameplay/games/[id].tsx` (browser persist hook, `useRef`+`useEffect` double-fire guard)
+   - `scripts/cleanup-broken-encounters.ts` (393 lines; CLI flags `--manifest-only`, `--cwd`)
+
+## Confirmed inherited wisdom (per task brief)
+
+- `ScenarioTemplateType` enum has 4 values: `Duel='duel'`, `Skirmish='skirmish'`, `Battle='battle'`, `Custom='custom'` (verified at `src/types/encounter/EncounterInterfaces.ts:61-69`).
+- `SCENARIO_TEMPLATES` constant (line 261) has 4 entries matching the enum 1:1.
+- `IEncounterMeta` lives on `IGameCreatedPayload` as an optional field (snapshot-at-launch).
+- `playerForceSummary` shape: `"<forceName> (<bv> BV, <units> units)"` for explicit forces, `"<forceId> (missing force)"` for orphans.
+- `recalculateStatus` short-circuits Launched/Completed; only Launched + both forces null → Draft (Completed never demotes).
+- `setPlayerForce` DELETE endpoint already does null-clear (no server widening was needed).
+- API route tests live at `src/__tests__/api/replay-library/` (NOT under `src/pages/api/...`).
+
+## Validation target
+
+```
+npx openspec validate sync-encounter-and-replay-source-of-truth --strict
+```
+
+Iterate until clean. The change archives with full spec sync (NO `--skip-specs`).
+
+## Out of scope (do not author)
+
+- IndexedDB browser-side persistence (deferred; never shipped).
+- Encounter-replay deletion / archival (deferred).
+- Encounter-row → encounter-source-page cross-link (deferred per `link-encounters-to-replays` design.md open question).
+- Replay metadata for salvage / outcome (would require campaign linkage).
+- Localization of summary strings (deferred).
+- Wire-encounter-to-campaign-round-trip — already in source-of-truth.

--- a/openspec/changes/sync-encounter-and-replay-source-of-truth/proposal.md
+++ b/openspec/changes/sync-encounter-and-replay-source-of-truth/proposal.md
@@ -1,0 +1,147 @@
+# Sync Encounter and Replay Source-of-Truth
+
+## Why
+
+Five archived OpenSpec changes shipped working encounter and replay code,
+but the source-of-truth specs never absorbed the deltas. Each archive ran
+with `--skip-specs` because the original `2026-01-18-add-encounter-system`
+change was archived before its `encounter-system` spec was promoted to
+`openspec/specs/`, and every downstream change inherited that gap and
+worked around it. The current state on `main`:
+
+- `openspec/specs/encounter-system/` **does not exist**, even though
+  `src/types/encounter/EncounterInterfaces.ts`, `EncounterService`,
+  `EncounterRepository`, the `/gameplay/encounters/*` page tree, and
+  `/api/encounters/*` routes have been live since 2026-01-18.
+- `openspec/specs/replay-library/spec.md` describes a 4-source enum
+  (`Swarm`, `Quick`, `PvP`, `Campaign`), 4-member `IReplayManifestEntry`
+  union, 4-partition filesystem layout, and a page filter button strip
+  with no count constraint. The shipped code on `main` has a 5th
+  `Encounter` variant, a 5th union member, a 5th partition, and an
+  explicit 6-button strip (`All` + 5 sources).
+- `openspec/specs/game-session-management/spec.md` covers the encounter
+  store CRUD + launch from earlier waves, but does not cover the
+  force-deletion cascade, broken-reference helper, broken-pill UI, repair
+  banner, sample seeding, cleanup script, encounter-game replay
+  persistence, encounter-meta on `IGameCreatedPayload`, or the browser
+  persist hook on `/gameplay/games/[id].tsx`.
+
+The drift is silent today because the code typechecks and the tests
+pass — but the next planner reading the source-of-truth specs gets a
+materially false picture of the system. This change closes the gap by
+authoring three artefacts (one new spec, two delta specs) that snapshot
+what is already on `main`.
+
+This is a **spec-only** change. Zero TypeScript files are touched.
+Every requirement reflects behaviour observable on `main` as of
+commit `2b996146` (archive of `link-encounters-to-replays`).
+
+## What Changes
+
+- **NEW** source-of-truth spec at `openspec/specs/encounter-system/`.
+  The change folder authors it as a full ADDED-requirements suite under
+  `openspec/changes/sync-encounter-and-replay-source-of-truth/specs/encounter-system/spec.md`.
+  The archive sync will create the new directory in `openspec/specs/`.
+  Contents: encounter entity model, lifecycle status enum, force
+  configuration semantics (including the `null`-vs-`undefined`
+  distinction introduced by `repair-broken-encounter-drafts`), opForConfig
+  shape, scenario template enum + built-in templates, map configuration,
+  victory conditions, validation rules, broken-reference helper,
+  list/detail UI surfaces (broken pills + repair banner),
+  cleanup-script semantics, sample-seeding API, and the launch metadata
+  snapshot stamped onto `IGameCreatedPayload.encounterMeta`.
+
+- **MODIFIED** `replay-library` spec — delta widens the existing
+  4-source coverage to 5 sources:
+  - `ReplaySource Enum` updated from "exactly four values" to "exactly
+    five values".
+  - `IReplayManifestEntry Discriminated Union` updated to include the
+    fifth `IEncounterReplayManifestEntry` member with its source-specific
+    fields (`encounterId`, `encounterName`, `templateType`,
+    `playerForceSummary`, `opponentSummary`).
+  - `Filesystem Partition Layout` extended with the
+    `simulation-reports/encounter/` partition.
+  - `Backfill Scan` extended with encounter-metadata recovery from the
+    first `GameCreated` event.
+  - `Replay Library Page` updated to require the 6-button filter strip
+    (`All`, `Swarm`, `Quick`, `PvP`, `Campaign`, `Encounter`) and the
+    encounter row metadata strip.
+
+- **MODIFIED** `game-session-management` spec — delta adds the
+  encounter-replay loop and the broken-encounter repair surfaces:
+  - Force-deletion cascade on `ForceRepository.deleteForce` — clears
+    dangling `playerForce` / `opponentForce` references on every
+    affected encounter inside the same SQLite transaction, then triggers
+    `recalculateStatus`.
+  - Hydration-boundary orphan replacement — `EncounterService.hydrateEncounter`
+    sets unresolvable refs to `null` and emits a deduped warn log.
+  - Broken-reference detection helper at `src/services/encounter/encounterBrokenRefs.ts`.
+  - Encounter list broken-pill render + repair-banner detail-page render
+    + `setPlayerForce(id, null)` / `clearOpponentForce(id)` clear actions.
+  - Sample-encounter seeding API (`POST /api/encounters/seed-samples`)
+    + empty-state seed button.
+  - One-time cleanup script at `scripts/cleanup-broken-encounters.ts`
+    with `--manifest-only` / `--cwd` flags and the three-class
+    classification taxonomy.
+  - Encounter game-event-log persistence pipeline + `POST /api/replay-library/encounter`
+    route + browser persist hook on `/gameplay/games/[id].tsx`
+    (`useRef`+`useEffect` double-fire guard, encounter-meta-presence
+    discriminator).
+  - `IEncounterMeta` snapshot stamped onto `IGameCreatedPayload.encounterMeta`
+    by `EncounterService.launchEncounter`.
+
+**OUT OF SCOPE** — IndexedDB browser-side persistence (deferred follow-on
+named in `link-encounters-to-replays`); replay deletion / archival;
+encounter-row → source-encounter cross-link in the Replay Library page;
+encounter-specific replay metrics (salvage / outcome — would require
+campaign linkage); localization of snapshot summary strings;
+the `wire-encounter-to-campaign-round-trip` linkage (already absorbed
+into source-of-truth in an earlier wave). No code is changed by this
+change.
+
+## Capabilities
+
+### New Capabilities
+
+- `encounter-system` — promoted to source-of-truth from the
+  `2026-01-18-add-encounter-system` archive plus everything
+  `repair-broken-encounter-drafts` and `link-encounters-to-replays`
+  added on top of it.
+
+### Modified Capabilities
+
+- `replay-library` — five-source widening across enum, manifest union,
+  partition layout, backfill scan, and library page.
+- `game-session-management` — encounter cascade + hydration repair +
+  broken-pill UI + repair banner + seed-samples + cleanup script +
+  encounter game-event-log persistence + `IEncounterMeta` on
+  `IGameCreatedPayload` + browser persist hook.
+
+## Impact
+
+- **Code**: zero changes. This is a spec-authoring change. Every
+  requirement is verifiable against existing files on `main`.
+- **Specs**: one new source-of-truth spec (`encounter-system/spec.md`)
+  and two modified deltas (`replay-library/spec.md`,
+  `game-session-management/spec.md`). All three sync to source-of-truth
+  on archive — **NO `--skip-specs`**.
+- **Tests**: zero new tests. Behaviour is already covered by
+  `EncounterRepository.cascade.test.ts`,
+  `EncounterService.hydration.test.ts`,
+  `cleanup-broken-encounters.test.ts`,
+  `EncountersListPage.test.tsx`,
+  `[id].test.tsx`,
+  `persistEncounterGame.test.ts`,
+  `src/__tests__/api/replay-library/encounter.test.ts`,
+  `backfill-scan.test.ts`,
+  `src/__tests__/pages/replay-library.test.tsx`,
+  and `EncounterService.persist.test.ts`.
+- **Filesystem**: no runtime artefacts. The change folder is
+  documentation-only.
+- **Existing data**: no migration. The change is observation, not action.
+- **Risk**: low. The drift between specs and code already exists; this
+  change closes it without changing behaviour. The archive-sync step
+  carries the only material risk (delta merge into existing
+  source-of-truth) — addressed by the validation discipline in
+  `tasks.md` (validate strict before archive, no `--skip-specs`
+  fallback).

--- a/openspec/changes/sync-encounter-and-replay-source-of-truth/specs/encounter-system/spec.md
+++ b/openspec/changes/sync-encounter-and-replay-source-of-truth/specs/encounter-system/spec.md
@@ -1,0 +1,685 @@
+# Encounter System Specification
+
+## ADDED Requirements
+
+### Requirement: Encounter Entity Model
+
+The system SHALL define an `IEncounter` entity that represents a
+configured game-session setup. Every encounter MUST carry a unique
+`id`, a human-readable `name`, a current `status` from the
+`EncounterStatus` enum, a `mapConfig: IMapConfiguration`, a
+non-empty-by-contract `victoryConditions: readonly IVictoryCondition[]`
+array, an `optionalRules: readonly string[]` array, and ISO-8601
+`createdAt` and `updatedAt` timestamps. The entity MAY carry an
+optional `description: string`, an optional `template: ScenarioTemplateType`,
+an optional `gameSessionId: string` (set after launch), an optional
+`opForConfig: IOpForConfig`, and the two force-reference slots
+(`playerForce` and `opponentForce`) which follow the
+null-vs-undefined contract defined in the **Force-Reference Slot
+Semantics** requirement.
+
+The entity SHALL be defined in `src/types/encounter/EncounterInterfaces.ts`
+and the type SHALL be exported as `IEncounter`.
+
+#### Scenario: Required fields present on every encounter
+
+- **GIVEN** an `IEncounter` value loaded from the encounter repository
+- **WHEN** consumers read its fields
+- **THEN** `id`, `name`, `status`, `mapConfig`, `victoryConditions`,
+  `optionalRules`, `createdAt`, and `updatedAt` SHALL all be present
+- **AND** `id` SHALL be a non-empty string
+- **AND** `victoryConditions.length` SHALL be `>= 0` (at-least-one is
+  enforced by validation, not by the type)
+
+#### Scenario: Optional fields are typed as optional
+
+- **GIVEN** an `IEncounter` declaration
+- **WHEN** TypeScript checks the shape
+- **THEN** `description`, `template`, `gameSessionId`, `opForConfig`
+  SHALL all be `?:` optional
+- **AND** `playerForce` and `opponentForce` SHALL be typed as
+  `?: IForceReference | null` (optional with explicit-null support)
+
+#### Scenario: Type guard recognises shape
+
+- **GIVEN** an arbitrary `unknown` value with the encounter shape
+- **WHEN** `isEncounter(value)` is called
+- **THEN** the result SHALL be `true` only when `id`, `name`, `status`
+  are strings AND `mapConfig` is an object AND `victoryConditions` is
+  an array
+
+### Requirement: Encounter Status Lifecycle
+
+The system SHALL define an `EncounterStatus` enum with exactly four
+values: `Draft = 'draft'`, `Ready = 'ready'`, `Launched = 'launched'`,
+`Completed = 'completed'`. The enum SHALL be the single source of
+truth for encounter lifecycle classification.
+
+The repository's `recalculateStatus(encounterId)` operation SHALL
+short-circuit on encounters whose stored status is `Launched` or
+`Completed` — it MUST NOT demote a `Completed` encounter back to
+`Draft` even if its forces become orphaned (history is fixed). It MUST
+demote a `Launched` encounter back to `Draft` only when both
+`playerForce` and `opponentForce` are `null` after the cascade has
+run; otherwise the `Launched` status remains.
+
+For encounters in `Draft` or `Ready`, `recalculateStatus` SHALL
+recompute the status from the current configuration:
+
+- `Draft` — at least one of `playerForce`, `opponentForce` (or
+  `opForConfig`), or `victoryConditions` is missing or invalid.
+- `Ready` — `validateEncounter(encounter).valid === true`.
+
+#### Scenario: Status enum values are exactly four
+
+- **GIVEN** the `EncounterStatus` enum
+- **WHEN** `Object.values(EncounterStatus)` is computed
+- **THEN** the result SHALL equal `['draft', 'ready', 'launched', 'completed']`
+  in any order
+
+#### Scenario: Completed never demotes
+
+- **GIVEN** an encounter `E` in status `Completed` with
+  `playerForce: null` AND `opponentForce: null`
+- **WHEN** `recalculateStatus(E.id)` runs
+- **THEN** `E.status` SHALL remain `Completed`
+
+#### Scenario: Launched demotes to Draft only when both forces null
+
+- **GIVEN** an encounter `E` in status `Launched` with
+  `playerForce: null` AND `opponentForce: null`
+- **WHEN** `recalculateStatus(E.id)` runs
+- **THEN** `E.status` SHALL become `Draft`
+
+#### Scenario: Launched with one force still present remains Launched
+
+- **GIVEN** an encounter `E` in status `Launched` with
+  `playerForce: null` AND `opponentForce: { forceId: 'F2', ... }`
+- **WHEN** `recalculateStatus(E.id)` runs
+- **THEN** `E.status` SHALL remain `Launched`
+
+### Requirement: Force-Reference Slot Semantics
+
+The `playerForce` and `opponentForce` slots on `IEncounter` SHALL
+distinguish three states using `undefined`, `null`, and the
+`IForceReference` shape:
+
+- `undefined` — no force was ever stored for this slot. The user has
+  not made a selection.
+- `null` — a force WAS stored on the row, but the referenced force row
+  has been deleted from the `ForceRepository`. The hydration boundary
+  (`EncounterService.hydrateEncounter`) sets the slot to `null` when
+  the resolver returns `null` for the stored `forceId`.
+- `IForceReference` (a non-null object with `forceId`, `forceName`,
+  `totalBV`, `unitCount`) — the force resolved successfully.
+
+This three-state distinction SHALL persist through every read path so
+downstream UI / helpers can distinguish "never set" from "set but
+broken." The repair surfaces (broken pill + repair banner + cleanup
+script) all key off the `null` state.
+
+#### Scenario: Undefined slot for new encounter
+
+- **GIVEN** an encounter `E` newly created via `createEncounter`
+- **WHEN** consumers read `E.playerForce`
+- **THEN** the slot SHALL be `undefined`
+
+#### Scenario: Null slot after force deletion
+
+- **GIVEN** an encounter `E` whose stored `playerForce.forceId` is `F`
+  AND force `F` has been deleted from the `ForceRepository`
+- **WHEN** `EncounterService.getEncounter(E.id)` is called
+- **THEN** the returned `E.playerForce` SHALL be `null`
+- **AND** consumers SHALL be able to distinguish this from `undefined`
+
+#### Scenario: Resolved slot for valid reference
+
+- **GIVEN** an encounter `E` whose stored `playerForce.forceId` is `F`
+  AND force `F` exists with `forceName: 'Alpha'`, `totalBV: 4500`,
+  `unitCount: 4`
+- **WHEN** `EncounterService.getEncounter(E.id)` is called
+- **THEN** `E.playerForce` SHALL be the `IForceReference` object with
+  matching values
+
+### Requirement: Force Configuration
+
+The system SHALL support both explicit force selection and OpFor-based
+opponent generation for an encounter. An encounter SHALL be valid for
+launch when EITHER an explicit `opponentForce: IForceReference` is set
+OR an `opForConfig: IOpForConfig` is set. The `playerForce` SHALL
+always be required (the player must select a force; OpFor generation
+is not available for the player side).
+
+The `IOpForConfig` shape SHALL include a `pilotSkillTemplate` from the
+`PilotSkillTemplate` enum (`Green`, `Regular`, `Veteran`, `Elite`,
+`Mixed`) and MAY include `targetBV` (absolute), `targetBVPercent`
+(percentage of player force), `era`, `faction`, and `unitTypes`
+filters.
+
+#### Scenario: Explicit-force encounter is valid
+
+- **GIVEN** an encounter `E` with `playerForce`, `opponentForce`, and
+  at least one victory condition
+- **WHEN** `validateEncounter(E)` is called
+- **THEN** the result `valid` SHALL be `true`
+
+#### Scenario: OpFor-driven encounter is valid
+
+- **GIVEN** an encounter `E` with `playerForce`, no `opponentForce`,
+  `opForConfig.pilotSkillTemplate: PilotSkillTemplate.Regular`, and at
+  least one victory condition
+- **WHEN** `validateEncounter(E)` is called
+- **THEN** the result `valid` SHALL be `true`
+
+#### Scenario: Missing player force fails validation
+
+- **GIVEN** an encounter `E` with no `playerForce` and an
+  `opForConfig` set
+- **WHEN** `validateEncounter(E)` is called
+- **THEN** `valid` SHALL be `false`
+- **AND** `errors` SHALL contain a string mentioning the player force
+
+#### Scenario: Missing opponent and opForConfig fails validation
+
+- **GIVEN** an encounter `E` with `playerForce` set but no
+  `opponentForce` and no `opForConfig`
+- **WHEN** `validateEncounter(E)` is called
+- **THEN** `valid` SHALL be `false`
+- **AND** `errors` SHALL contain a string mentioning opponent / OpFor
+
+#### Scenario: BV imbalance produces warning, not error
+
+- **GIVEN** an encounter `E` with `playerForce.totalBV = 1000` and
+  `opponentForce.totalBV = 5000`
+- **WHEN** `validateEncounter(E)` is called
+- **THEN** `valid` SHALL be `true`
+- **AND** `warnings` SHALL contain a string about BV imbalance
+
+### Requirement: Map Configuration
+
+The system SHALL define an `IMapConfiguration` shape with `radius`
+(hex radius from centre, e.g. 5 = 11×11 hex grid), `terrain` (a value
+from the `TerrainPreset` enum), `playerDeploymentZone`, and
+`opponentDeploymentZone` (each one of `'north' | 'south' | 'east' | 'west'`).
+
+The `TerrainPreset` enum SHALL include `Clear`, `LightWoods`,
+`HeavyWoods`, `Urban`, and `Rough`. The shipped game runtime fully
+supports `Clear`; non-`Clear` terrain presets are recognised by the
+type system but their full battlefield generation is implementation-
+forward.
+
+#### Scenario: Default scenario template populates valid map config
+
+- **GIVEN** the `Skirmish` template is applied to a new encounter
+- **WHEN** the encounter's `mapConfig` is read
+- **THEN** `radius` SHALL equal `8`
+- **AND** `terrain` SHALL equal `TerrainPreset.Clear`
+- **AND** `playerDeploymentZone` SHALL equal `'south'`
+- **AND** `opponentDeploymentZone` SHALL equal `'north'`
+
+#### Scenario: Deployment zones must be opposites
+
+- **GIVEN** a scenario template's `defaultMapConfig`
+- **WHEN** the deployment zones are inspected
+- **THEN** `playerDeploymentZone` and `opponentDeploymentZone` SHALL
+  be on opposite map edges (north/south pair OR east/west pair)
+
+### Requirement: Victory Conditions
+
+The system SHALL define an `IVictoryCondition` shape carrying a
+`type: VictoryConditionType` and optional `description`, `turnLimit`,
+and `threshold` fields. The `VictoryConditionType` enum SHALL include
+`DestroyAll`, `Cripple`, `Retreat`, `TurnLimit`, and `Custom`.
+
+`Cripple` MAY carry an explicit `threshold` percentage (default `50`).
+`TurnLimit` MUST carry a positive `turnLimit` integer; validation
+SHALL surface an error otherwise.
+
+#### Scenario: DestroyAll has no extra fields
+
+- **GIVEN** a victory condition `{ type: VictoryConditionType.DestroyAll }`
+- **WHEN** the encounter is validated
+- **THEN** the condition SHALL pass validation
+
+#### Scenario: TurnLimit requires positive turnLimit
+
+- **GIVEN** a victory condition
+  `{ type: VictoryConditionType.TurnLimit, turnLimit: 0 }`
+- **WHEN** `validateEncounter(encounter)` runs
+- **THEN** `valid` SHALL be `false`
+- **AND** an error SHALL mention "turn limit" with a positivity
+  requirement
+
+#### Scenario: Cripple defaults threshold
+
+- **GIVEN** a victory condition `{ type: VictoryConditionType.Cripple }`
+  on an otherwise valid encounter
+- **WHEN** the encounter is validated
+- **THEN** `valid` SHALL be `true`
+- **AND** the condition SHALL be treated as `threshold: 50` by the
+  game-runtime consumers
+
+### Requirement: Scenario Templates
+
+The system SHALL define a `ScenarioTemplateType` enum with exactly
+four values: `Duel = 'duel'`, `Skirmish = 'skirmish'`,
+`Battle = 'battle'`, `Custom = 'custom'`. The `SCENARIO_TEMPLATES`
+constant SHALL export exactly four `IScenarioTemplate` entries — one
+per enum value — covering name, description, default map config,
+default victory conditions, suggested unit count, and suggested BV
+range.
+
+The seed-samples API and the encounter-list empty-state seed button
+both iterate `SCENARIO_TEMPLATES` to create one starter encounter per
+template.
+
+#### Scenario: Enum has exactly four values
+
+- **GIVEN** the `ScenarioTemplateType` enum
+- **WHEN** `Object.values(ScenarioTemplateType)` is computed
+- **THEN** the result SHALL equal `['duel', 'skirmish', 'battle', 'custom']`
+  in any order
+
+#### Scenario: Template constant covers every enum value exactly once
+
+- **GIVEN** the `SCENARIO_TEMPLATES` constant
+- **WHEN** the entries' `type` fields are collected into a set
+- **THEN** the set SHALL equal the set of `ScenarioTemplateType` values
+
+#### Scenario: Applying template populates encounter defaults
+
+- **GIVEN** a freshly created encounter `E` with the `Duel` template
+  applied
+- **WHEN** `E.mapConfig` and `E.victoryConditions` are read
+- **THEN** they SHALL match the `SCENARIO_TEMPLATES[Duel]` defaults
+- **AND** the user MAY override either field via subsequent updates
+
+### Requirement: Encounter Launch Snapshot Metadata
+
+The system SHALL stamp an `IEncounterMeta` snapshot onto the
+resulting `IGameSession`'s configuration when
+`EncounterService.launchEncounter(encounterId)` succeeds, so the
+eventual `GameCreated` event carries it on its
+`payload.encounterMeta` field. The snapshot SHALL
+be derived from the encounter row at launch time and SHALL be
+immutable thereafter — later mutations to the source encounter (or
+its forces) MUST NOT propagate into the persisted event log.
+
+The `IEncounterMeta` shape SHALL contain:
+
+- `encounterId: string` — the source `IEncounter.id`.
+- `encounterName: string` — `IEncounter.name` snapshot.
+- `templateType: string | null` — the encounter's `template` value as
+  a string (e.g. `'duel'`), or `null` for fully-custom encounters.
+- `playerForceSummary: string` — pre-rendered player descriptor.
+- `opponentSummary: string` — pre-rendered opponent descriptor.
+
+The `playerForceSummary` derivation SHALL be:
+
+- `IEncounter.playerForce` non-null → `"<forceName> (<totalBV> BV, <unitCount> units)"`
+- `IEncounter.playerForce === null` → `"<storedForceId> (missing force)"`
+  (broken-encounter snapshot text)
+
+The `opponentSummary` derivation SHALL be:
+
+- `IEncounter.opponentForce` non-null → same shape as
+  `playerForceSummary` for explicit forces
+- `IEncounter.opForConfig` set (and no explicit opponent) →
+  `"Generated <type> (~<targetBV> BV)"` substring derived from the
+  config's filters and target BV
+
+The `encounterMeta` field SHALL be optional on `IGameCreatedPayload` so
+non-encounter sessions (swarm CLI runs, hot-seat quick games, raw
+`createGameSession` callers) write nothing in the slot.
+
+#### Scenario: Launch stamps encounterMeta
+
+- **GIVEN** an encounter `E` with `id='enc-abc'`, `name='Foothold Strike'`,
+  `template=ScenarioTemplateType.Skirmish`, `playerForce={forceName:'Alpha',totalBV:4500,unitCount:4}`,
+  `opponentForce={forceName:'Bravo',totalBV:3800,unitCount:4}`
+- **WHEN** `EncounterService.launchEncounter('enc-abc')` is called
+- **THEN** the resulting session's first emitted `GameCreated` event
+  SHALL have `payload.encounterMeta` populated
+- **AND** `encounterMeta.encounterId` SHALL equal `'enc-abc'`
+- **AND** `encounterMeta.encounterName` SHALL equal `'Foothold Strike'`
+- **AND** `encounterMeta.templateType` SHALL equal `'skirmish'`
+- **AND** `encounterMeta.playerForceSummary` SHALL equal `'Alpha (4500 BV, 4 units)'`
+- **AND** `encounterMeta.opponentSummary` SHALL equal `'Bravo (3800 BV, 4 units)'`
+
+#### Scenario: Custom encounter snapshots templateType as null
+
+- **GIVEN** an encounter `E` with `template === undefined`
+- **WHEN** `EncounterService.launchEncounter(E.id)` is called
+- **THEN** the stamped `encounterMeta.templateType` SHALL be `null`
+
+#### Scenario: opForConfig-driven opponent stamps Generated summary
+
+- **GIVEN** an encounter `E` with `opponentForce: undefined` and
+  `opForConfig: { targetBV: 3000, pilotSkillTemplate: PilotSkillTemplate.Regular }`
+- **WHEN** `EncounterService.launchEncounter(E.id)` is called
+- **THEN** `encounterMeta.opponentSummary` SHALL contain the literal
+  substring `'Generated'`
+- **AND** SHALL contain the literal substring `'3000'`
+
+#### Scenario: Broken player force stamps missing-force snapshot
+
+- **GIVEN** an encounter `E` whose stored `playerForce.forceId` is
+  `'F-deleted'` AND the force has been deleted (slot is `null` after
+  hydration)
+- **WHEN** `EncounterService.launchEncounter(E.id)` is called and the
+  service decides to launch anyway (or this is the snapshot used by a
+  pre-launch persist test)
+- **THEN** `encounterMeta.playerForceSummary` SHALL equal
+  `'F-deleted (missing force)'` exactly
+
+#### Scenario: Non-encounter session has no encounterMeta
+
+- **GIVEN** a raw `createGameSession(config, units)` call with no
+  encounter context
+- **WHEN** the resulting `GameCreated` event is read
+- **THEN** `payload.encounterMeta` SHALL be `undefined`
+
+### Requirement: Broken-Reference Detection Helper
+
+The system SHALL provide a pure helper at
+`src/services/encounter/encounterBrokenRefs.ts` exporting the
+function:
+
+```
+encounterBrokenRefs(
+  encounter: IEncounter,
+  rawForceIds: { playerForceId: string | null; opponentForceId: string | null }
+): { playerForceMissing: boolean; opponentForceMissing: boolean }
+```
+
+The helper SHALL report `playerForceMissing: true` if and only if
+`rawForceIds.playerForceId !== null` AND `encounter.playerForce === null`.
+The opponent predicate SHALL mirror this shape. The helper SHALL be a
+pure function — no IO, no logging, no mutation of either argument.
+The repository's `getEncounterWithRawIds` (and the list variant) SHALL
+expose the raw stored force ids alongside the hydrated encounter so
+the helper can be invoked without an extra round-trip.
+
+#### Scenario: Player ref stored but unresolved → missing
+
+- **GIVEN** an encounter with `playerForce: null` AND
+  `rawForceIds: { playerForceId: 'F', opponentForceId: null }`
+- **WHEN** `encounterBrokenRefs(encounter, rawForceIds)` is called
+- **THEN** the result SHALL be `{ playerForceMissing: true, opponentForceMissing: false }`
+
+#### Scenario: Both refs unresolved → both missing
+
+- **GIVEN** an encounter with `playerForce: null` AND `opponentForce: null`
+  AND `rawForceIds: { playerForceId: 'F1', opponentForceId: 'F2' }`
+- **WHEN** the helper is called
+- **THEN** the result SHALL be `{ playerForceMissing: true, opponentForceMissing: true }`
+
+#### Scenario: No refs stored → not missing
+
+- **GIVEN** an encounter with `playerForce: null` (or `undefined`) AND
+  `rawForceIds: { playerForceId: null, opponentForceId: null }`
+- **WHEN** the helper is called
+- **THEN** the result SHALL be `{ playerForceMissing: false, opponentForceMissing: false }`
+
+#### Scenario: Refs resolved → not missing
+
+- **GIVEN** an encounter with `playerForce: { forceId: 'F', forceName: 'Alpha', totalBV: 4500, unitCount: 4 }`
+  AND `rawForceIds: { playerForceId: 'F', opponentForceId: null }`
+- **WHEN** the helper is called
+- **THEN** the result SHALL be `{ playerForceMissing: false, opponentForceMissing: false }`
+
+### Requirement: Encounter List Broken-Pill Render
+
+The encounter list view at `/gameplay/encounters` SHALL render a
+yellow `"Player force missing"` pill (or `"Opponent force missing"`
+for the opponent slot) on any encounter card whose
+`encounterBrokenRefs` reports a missing reference. The pill SHALL
+replace the silent zero-name pill that the legacy render produced for
+encounters with hydrated force-ref objects carrying empty
+`forceName`. The pill SHALL share the visual treatment of the existing
+yellow `"No Player Force"` / `"No Opponent"` pills so users scan the
+same warning slot.
+
+The encounter card SHALL be implemented in
+`src/components/gameplay/encounters/EncounterCard.tsx` (or a co-located
+helper) and SHALL receive both the hydrated encounter and the raw
+force ids so it can call `encounterBrokenRefs`.
+
+#### Scenario: Broken pill renders for missing player force
+
+- **GIVEN** an encounter card prop with `encounter.playerForce === null`
+  AND `rawForceIds.playerForceId !== null`
+- **WHEN** the card renders
+- **THEN** a yellow pill with text `"Player force missing"` SHALL be
+  visible
+- **AND** no empty-name `"Player: "` pill SHALL render
+
+#### Scenario: Both sides broken renders both pills
+
+- **GIVEN** an encounter card prop with both `playerForce: null` AND
+  `opponentForce: null` AND both raw force ids non-null
+- **WHEN** the card renders
+- **THEN** the card SHALL render exactly one `"Player force missing"`
+  pill AND exactly one `"Opponent force missing"` pill
+
+#### Scenario: Resolved sides render the green name pill
+
+- **GIVEN** an encounter card with `playerForce: { forceName: 'Alpha', ... }`
+- **WHEN** the card renders
+- **THEN** a non-yellow pill displaying the force name SHALL render
+  for the player slot
+- **AND** no broken pill SHALL render for the player slot
+
+### Requirement: Encounter Detail Repair Banner
+
+The encounter detail view at `/gameplay/encounters/[id]` SHALL render
+a top-of-page banner above the existing form when the loaded
+encounter has at least one broken force reference. The banner SHALL
+display:
+
+- Header text: `"This encounter has a broken force reference"`
+- Body text explaining the dangling forceId(s) — e.g. `"The force <forceId> referenced as the player force was deleted."`
+  (and/or the opponent equivalent).
+- One action button per affected slot:
+  `"Clear missing player force"` and/or `"Clear missing opponent force"`.
+
+Clicking a clear-action button SHALL call the existing
+`setPlayerForce(encounterId, null)` (for the player slot) or
+`clearOpponentForce(encounterId)` (for the opponent slot) store
+action AND SHALL reload the encounter so the banner disappears on
+success. The banner module SHALL be implemented in
+`src/components/gameplay/pages/EncounterDetailPage.repairBanner.tsx`
+(or co-located on the page module).
+
+#### Scenario: Banner renders when player force is broken
+
+- **GIVEN** the detail page is rendering an encounter with
+  `playerForce: null` AND `rawForceIds.playerForceId === 'F'`
+- **WHEN** the page mounts
+- **THEN** a banner SHALL be visible above the form
+- **AND** the banner body SHALL contain the literal text
+  `"The force F referenced as the player force was deleted."`
+- **AND** a button labelled `"Clear missing player force"` SHALL be
+  present
+
+#### Scenario: Clear-action wires through to existing setPlayerForce
+
+- **GIVEN** the detail page is rendered with a broken player force
+- **WHEN** the user clicks `"Clear missing player force"`
+- **THEN** the `setPlayerForce(encounterId, null)` store action SHALL
+  be called
+- **AND** the page SHALL reload the encounter after success
+- **AND** the banner SHALL no longer be visible
+
+#### Scenario: Both sides broken renders two action buttons
+
+- **GIVEN** an encounter with both player and opponent forces broken
+- **WHEN** the detail page renders
+- **THEN** the banner SHALL contain both
+  `"Clear missing player force"` AND
+  `"Clear missing opponent force"` buttons
+
+#### Scenario: No broken refs hides banner
+
+- **GIVEN** an encounter with both forces resolved (or both slots
+  `undefined`)
+- **WHEN** the detail page renders
+- **THEN** no repair banner SHALL be visible
+
+### Requirement: Sample Encounter Seeding
+
+The system SHALL provide a `POST /api/encounters/seed-samples`
+endpoint at `src/pages/api/encounters/seed-samples.ts` that creates
+one encounter per `SCENARIO_TEMPLATES` entry inside a single SQLite
+transaction. The endpoint SHALL return
+`{ success: true, ids: readonly string[] }` containing the created
+encounter ids on success, or `{ success: false, error: string }` with
+HTTP 500 on any creation failure mid-transaction (the entire seed
+operation MUST roll back).
+
+The encounter list page SHALL render a
+`"Seed sample encounters"` button alongside the existing
+`"Create First Encounter"` button on the empty-state, visible only
+when the filtered list is empty AND no search query AND
+`statusFilter === 'all'`. Clicking the button SHALL POST to the
+endpoint, then call `loadEncounters()` to refresh the page.
+
+The seeded encounters SHALL be auto-named with a date-and-template
+suffix (e.g. `"Sample Duel - 2026-05-08"`). Repeated invocations SHALL
+use a numeric suffix on collisions (e.g. `"Sample Duel - 2026-05-08 (2)"`)
+so the operation is repeatable without unique-name conflicts. Seeded
+encounters SHALL NOT have forces or `opForConfig` auto-assigned —
+the user wires those manually after the seed.
+
+#### Scenario: Seed endpoint creates one encounter per template
+
+- **GIVEN** an empty encounters table
+- **WHEN** `POST /api/encounters/seed-samples` is called
+- **THEN** the response body SHALL be
+  `{ success: true, ids: <one id per ScenarioTemplateType value> }`
+- **AND** `getAllEncounters()` SHALL return one row per
+  `ScenarioTemplateType` value
+- **AND** each row's `template` field SHALL match the corresponding
+  enum value exactly once
+
+#### Scenario: Repeated seed appends with suffixed names
+
+- **GIVEN** the encounters table contains one prior seed batch
+- **WHEN** `POST /api/encounters/seed-samples` is called again
+- **THEN** the response SHALL succeed with as many new ids as there
+  are templates
+- **AND** the new rows SHALL have names ending with the `(2)` suffix
+
+#### Scenario: Empty-state button visibility
+
+- **GIVEN** the encounter list is empty AND there is no search query
+  AND `statusFilter === 'all'`
+- **WHEN** the list page renders
+- **THEN** the empty-state SHALL display both
+  `"Create First Encounter"` AND `"Seed sample encounters"` buttons
+
+#### Scenario: Empty-state button hidden under filters
+
+- **GIVEN** the encounter list is empty AND a non-default search query
+  is active (or `statusFilter !== 'all'`)
+- **WHEN** the list page renders
+- **THEN** the empty-state SHALL NOT display the
+  `"Seed sample encounters"` button
+
+#### Scenario: Mid-transaction failure rolls back
+
+- **GIVEN** a database-level error injected on the second template
+  insert
+- **WHEN** `POST /api/encounters/seed-samples` runs
+- **THEN** the response SHALL be
+  `{ success: false, error: <string> }` with HTTP 500
+- **AND** zero encounters SHALL be present in the database after the
+  failed call (no partial seed)
+
+### Requirement: One-Time Cleanup Script for Broken Drafts
+
+The system SHALL provide a one-time CLI cleanup tool at
+`scripts/cleanup-broken-encounters.ts` (Node-only via the `tsx` runner)
+that classifies every encounter in the database into one of:
+
+- `'abandoned-empty'` — `status === EncounterStatus.Draft` AND
+  `playerForce === null/undefined` AND
+  `opponentForce === null/undefined` AND
+  `opForConfig === null/undefined`. These rows are deleted.
+- `'orphaned-force-reference'` — at least one stored
+  `playerForceId` / `opponentForceId` is non-null AND the
+  corresponding `getForceById` lookup returns `null`. These rows are
+  repaired in place via `EncounterRepository.clearForceReference`
+  (NULLing the dangling slot).
+- `'still-valid'` — anything else. Status MUST NOT be modified.
+
+The script SHALL write the full classification manifest to
+`simulation-reports/cleanup-encounters-<ISO>.json` BEFORE performing
+any deletes. The manifest SHALL contain every encounter (full row
+plus the classification verdict and a `classificationReason` string)
+so the operator can audit what changed before re-running.
+
+The script SHALL gate deletion to encounters whose status is `Draft`
+even when the row otherwise classifies as `'abandoned-empty'`. Rows
+with status `Launched` or `Completed` SHALL be reclassified as
+`'still-valid'` with a reason explaining the status gate.
+
+The script SHALL be idempotent — re-running on a database that no
+longer contains any abandoned-empty rows SHALL still write a manifest
+classifying every encounter, but the `deletedIds` array SHALL be
+empty.
+
+The script SHALL accept two CLI flags:
+
+- `--manifest-only` — write the manifest but skip all deletes and
+  repairs. Used for pre-flight audits.
+- `--cwd <path>` — override the working directory for the manifest
+  output (used by tests).
+
+#### Scenario: Manifest written before any DELETE
+
+- **GIVEN** a database with 5 encounters (2 abandoned-empty,
+  2 orphaned, 1 still-valid)
+- **WHEN** the cleanup script runs without flags
+- **THEN** the file `simulation-reports/cleanup-encounters-<ISO>.json`
+  SHALL exist before any DELETE statement is executed
+- **AND** the file SHALL contain 5 manifest entries with the correct
+  classification for each
+- **AND** the script SHALL return
+  `{ deletedIds: <2 ids>, repairedIds: <2 ids>, retainedIds: <1 id> }`
+
+#### Scenario: Idempotent re-run on cleaned database
+
+- **GIVEN** the cleanup script has already been run once and there
+  are no abandoned-empty rows remaining
+- **WHEN** the cleanup script is run a second time
+- **THEN** a new manifest file SHALL be written with the new ISO
+  suffix
+- **AND** `deletedIds` SHALL be an empty array
+
+#### Scenario: manifest-only flag skips deletes
+
+- **GIVEN** the database has 2 abandoned-empty encounters
+- **WHEN** the cleanup script runs with `--manifest-only`
+- **THEN** the manifest SHALL be written
+- **AND** `deletedIds` SHALL be an empty array
+- **AND** all encounters SHALL still be present in the database
+
+#### Scenario: Status-gated deletion preserves Launched and Completed rows
+
+- **GIVEN** an encounter `E` that classifies as `'abandoned-empty'`
+  by content BUT has status `EncounterStatus.Launched`
+- **WHEN** the cleanup script runs
+- **THEN** `E` SHALL NOT be deleted
+- **AND** the manifest SHALL classify `E` as `'still-valid'` with a
+  reason mentioning the status gate
+
+#### Scenario: Orphan rows repaired in place
+
+- **GIVEN** an encounter `E` whose stored `playerForceId` is `F` AND
+  `getForceById(F)` returns `null`
+- **WHEN** the cleanup script runs
+- **THEN** `E` SHALL be reclassified as `'orphaned-force-reference'`
+- **AND** `E.playerForce` SHALL be set to `null` via
+  `clearForceReference('F')`
+- **AND** `E` SHALL remain present in the database

--- a/openspec/changes/sync-encounter-and-replay-source-of-truth/specs/game-session-management/spec.md
+++ b/openspec/changes/sync-encounter-and-replay-source-of-truth/specs/game-session-management/spec.md
@@ -1,0 +1,346 @@
+# Game Session Management Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Force-Deletion Cascade to Encounter References
+
+The system SHALL clear orphaned force references in the `encounters`
+table when a force is deleted. The cascade SHALL run inside the same
+SQLite transaction as `ForceRepository.deleteForce`, MUST NULL the
+affected `player_force_json` and `opponent_force_json` columns, and
+MUST trigger the existing `recalculateStatus` ladder for every
+affected encounter id so encounters drop back to `Draft` atomically
+with the force deletion (within the constraints of the
+**Encounter Status Lifecycle** requirement — `Launched` only demotes
+when both forces are now `null`; `Completed` never demotes).
+
+The cascade SHALL be wired via a callback registry at
+`src/services/forces/ForceRepository.cascade.ts` exporting
+`setEncounterCascadeHook(hook)` and `invokeEncounterCascadeHook(forceId)`.
+The encounter repository's singleton factory SHALL register itself as
+the hook on first creation. This decoupling SHALL prevent a circular
+import between `ForceRepository` and `EncounterRepository`
+(`EncounterService` already imports `ForceRepository` for hydration).
+
+If any UPDATE in the cascade throws, the SQLite transaction MUST roll
+back AND the force row MUST remain present in the `forces` table. The
+cascade MUST NOT delete encounter rows — it only clears the dangling
+reference. Encounter deletion remains a separate user-initiated
+operation.
+
+The cascade SHALL iterate affected encounters serially (not via
+`forEach` — `forEach` is not async-safe with TypeORM/better-sqlite3
+patterns; use `for...of` or batched single-statement UPDATEs).
+
+#### Scenario: Single encounter affected
+
+- **GIVEN** a force `F` and an encounter `E` whose `player_force_json`
+  references `F`
+- **WHEN** `ForceRepository.deleteForce(F)` is called
+- **THEN** the SQL transaction SHALL execute
+  `DELETE FROM forces WHERE id = F` followed by an UPDATE that NULLs
+  `E.player_force_json`
+- **AND** `recalculateStatus(E.id)` SHALL be called inside the same
+  transaction
+- **AND** after commit, `getForceById(F)` SHALL return `null`
+- **AND** `getEncounterById(E.id).playerForce` SHALL be `null`
+- **AND** `getEncounterById(E.id).status` SHALL be `EncounterStatus.Draft`
+
+#### Scenario: Multiple encounters affected in one transaction
+
+- **GIVEN** a force `F` referenced as the player force by encounter
+  `E1`, as the opponent force by encounter `E2`, and as both
+  player+opponent on encounter `E3`
+- **WHEN** `ForceRepository.deleteForce(F)` is called
+- **THEN** all three encounters SHALL have their respective
+  `_force_json` columns set to `NULL` for the matching slot inside
+  one transaction
+- **AND** all three encounters SHALL have status recomputed
+- **AND** `getForceById(F)` SHALL return `null`
+
+#### Scenario: Cascade rollback on UPDATE failure
+
+- **GIVEN** a force `F` and an encounter `E` whose
+  `player_force_json` references `F`
+- **AND** the cascade UPDATE statement is configured to throw
+  mid-transaction (test injection)
+- **WHEN** `ForceRepository.deleteForce(F)` is called
+- **THEN** the transaction SHALL roll back
+- **AND** `getForceById(F)` SHALL still return the original force record
+- **AND** `getEncounterById(E.id).playerForce.forceId` SHALL still
+  equal `F`
+
+#### Scenario: No registered hook does not block force deletion
+
+- **GIVEN** the `EncounterRepository` singleton has not yet been
+  initialised (cold-start, no encounter module loaded)
+- **WHEN** `ForceRepository.deleteForce(F)` is called
+- **THEN** the cascade hook SHALL be skipped (no callback to invoke)
+- **AND** the force deletion SHALL still commit
+- **AND** any pre-existing encounter references to `F` SHALL remain
+  on disk (the secondary safety net at hydration time covers them)
+
+#### Scenario: No referencing encounters
+
+- **GIVEN** a force `F` with zero encounter rows referencing it
+- **WHEN** `ForceRepository.deleteForce(F)` is called
+- **THEN** the cascade SHALL execute zero UPDATE statements against
+  `encounters`
+- **AND** the force deletion SHALL still commit normally
+
+### Requirement: Hydration-Boundary Orphaned Reference Replacement
+
+`EncounterService.hydrateEncounter` SHALL replace any unresolvable
+force reference with `null` in the returned `IEncounter` (instead of
+leaving the dangling embedded ref intact). When the resolver
+(`ForceRepository.getForceById`) returns `null` for a stored
+`forceId`, the hydrated `playerForce` (or `opponentForce`) field
+SHALL be set to `null` AND the system SHALL emit a `logger.warn`
+exactly once per `<encounterId>:<forceId>:<side>` key per process
+lifetime. The warn dedup Set SHALL be reset by
+`resetEncounterService()` so test isolation is preserved.
+
+This requirement is the safety net for any orphan that escapes the
+force-deletion cascade (e.g. raw SQL inserts, future bugs, pre-cascade
+legacy rows). The cascade is the primary fix; this is the secondary
+fix.
+
+#### Scenario: Player force unresolvable returns null
+
+- **GIVEN** an encounter `E` whose stored `player_force_json`
+  references force id `F`
+- **AND** `forceRepository.getForceById(F)` returns `null`
+- **WHEN** `EncounterService.getEncounter(E.id)` is called
+- **THEN** the returned `IEncounter.playerForce` SHALL be `null`
+- **AND** the returned `IEncounter.opponentForce` SHALL retain
+  whatever resolution result it would otherwise have
+- **AND** `logger.warn` SHALL be called once with the keys
+  `encounterId`, `forceId`, and `side: 'player'`
+
+#### Scenario: Warn dedup across reads
+
+- **GIVEN** the same orphaned encounter `E` referencing the deleted
+  force `F`
+- **WHEN** `EncounterService.getEncounter(E.id)` is called twice in
+  the same process
+- **THEN** `logger.warn` SHALL be called exactly once total — the
+  second call SHALL be deduped
+
+#### Scenario: Reset clears dedup Set
+
+- **GIVEN** an orphaned encounter `E` already-warned for force `F`
+- **WHEN** `resetEncounterService()` is called
+- **AND** `EncounterService.getEncounter(E.id)` is then called
+- **THEN** `logger.warn` SHALL be called again with the same keys
+  (the Set was cleared)
+
+### Requirement: Encounter Game Event Log Persistence
+
+The system SHALL persist the full event log of every encounter battle
+to `simulation-reports/encounter/<gameId>.jsonl` AND append an
+`IEncounterReplayManifestEntry` to
+`simulation-reports/replay-index.json` when an encounter session
+launched via `EncounterService.launchEncounter` reaches a terminal
+state (winner / draw / aborted).
+The persist call SHALL go through the
+`POST /api/replay-library/encounter` API route (Node-side filesystem
+write); the React client cannot write directly. The persist pipeline
+SHALL be implemented at `src/components/encounter/persistEncounterGame.ts`
+(Node-only) and SHALL mirror the proven
+`src/components/quickgame/persistQuickGame.ts` shape line-for-line —
+same `shouldPersistToDisk` three-gate guard, same boundary
+post-stamp via `stampEncounterReplaySource`, same NDJSON file write
+followed by `appendManifestEntry`.
+
+The persist pipeline SHALL post-stamp every event missing a
+`replaySource` field with `ReplaySource.Encounter`. Events that
+already carry an explicit `replaySource` value (e.g. a hypothetical
+campaign-bound emitter that pre-stamped its own source) SHALL be
+preserved unchanged — the post-stamp SHALL only fill in `undefined`
+slots.
+
+The API route SHALL implement a dedup guard via `readReplayIndex` +
+`id` set check; on duplicate `gameId` it SHALL return
+`{ persisted: false, alreadyPersisted: true, manifestEntry: <built fresh>, path: 'encounter/<gameId>.jsonl' }`
+with HTTP 200. The route SHALL return HTTP 405 on non-POST, HTTP 400
+on body validation failure (with explicit error codes for `BAD_GAME_ID`,
+`BAD_BODY`, `BAD_WINNER`), and HTTP 500 on `persistEncounterGame`
+throw.
+
+#### Scenario: Persist on encounter terminal state
+
+- **GIVEN** an encounter `E` launched via
+  `EncounterService.launchEncounter(E.id)` producing
+  `gameSessionId='session-77'`
+- **AND** `E.playerForce` had `forceName='Alpha Lance'`, `totalBV=4500`,
+  `unitCount=4` at launch
+- **WHEN** the live session reaches terminal state
+- **THEN** `POST /api/replay-library/encounter` SHALL be called with
+  body containing `gameId='session-77'`, `encounterId=E.id`,
+  `encounterName=E.name`,
+  `playerForceSummary='Alpha Lance (4500 BV, 4 units)'`
+- **AND** the file `simulation-reports/encounter/session-77.jsonl`
+  SHALL exist on disk after the call returns
+- **AND** the manifest entry in `replay-index.json` SHALL have
+  `replaySource: 'encounter'`
+
+#### Scenario: ReplaySource post-stamp at persist boundary
+
+- **GIVEN** a completed encounter session with events that do not
+  have `replaySource` populated
+- **WHEN** the persist pipeline runs
+- **THEN** every event written to disk SHALL carry
+  `replaySource: ReplaySource.Encounter`
+
+#### Scenario: Explicit non-Encounter ReplaySource preserved
+
+- **GIVEN** an event in the encounter session log that already has
+  `replaySource: ReplaySource.Campaign` (a hypothetical campaign-bound
+  emitter that pre-stamped its own source)
+- **WHEN** the persist pipeline post-stamps the events
+- **THEN** the existing `replaySource: ReplaySource.Campaign` value
+  SHALL be preserved
+- **AND** the post-stamp SHALL only add `ReplaySource.Encounter` to
+  events whose `replaySource` is `undefined`
+
+#### Scenario: Dedup guard rejects duplicate gameId
+
+- **GIVEN** a manifest entry for `gameId='session-77'` already exists
+  in the replay index
+- **WHEN** `POST /api/replay-library/encounter` is called again with
+  the same `gameId`
+- **THEN** the response SHALL be HTTP 200 with body
+  `{ persisted: false, alreadyPersisted: true, manifestEntry: <entry>, path: 'encounter/session-77.jsonl' }`
+- **AND** no second NDJSON file SHALL be written
+- **AND** the manifest SHALL NOT contain a duplicate entry for
+  `session-77`
+
+#### Scenario: API route validates body shape
+
+- **GIVEN** a `POST /api/replay-library/encounter` call with
+  `gameId: 'foo/../bar'` (regex mismatch)
+- **WHEN** the route handler runs
+- **THEN** the response SHALL be HTTP 400 with an explicit error code
+  matching `BAD_GAME_ID`
+
+#### Scenario: API route rejects non-POST methods
+
+- **GIVEN** a `GET /api/replay-library/encounter` call
+- **WHEN** the route handler runs
+- **THEN** the response SHALL be HTTP 405
+
+#### Scenario: persistEncounterGame throw bubbles to 500
+
+- **GIVEN** a `POST /api/replay-library/encounter` call where
+  `persistEncounterGame` throws (test injection)
+- **WHEN** the route handler runs
+- **THEN** the response SHALL be HTTP 500 with error code
+  `PERSIST_FAILED`
+
+### Requirement: Encounter Metadata in GameCreated Event Payload
+
+The `GameCreated` event emitted at encounter launch SHALL carry an
+`encounterMeta: IEncounterMeta` snapshot in its payload so the
+replay-library backfill scan can reconstruct the manifest entry from
+the event log alone (without relying on external state).
+
+The `IGameCreatedPayload.encounterMeta` SHALL be optional (`?:`) so
+non-encounter sessions (swarm CLI runs, hot-seat quick games, raw
+`createGameSession` callers) write nothing in the slot. Encounter
+sessions launched via `EncounterService.launchEncounter` SHALL stamp
+the field with the snapshot derived per the **Encounter Launch
+Snapshot Metadata** requirement in the encounter-system spec.
+
+The `IEncounterMeta` shape SHALL contain:
+
+- `encounterId: string` — the source encounter row id
+- `encounterName: string` — encounter name snapshot at launch
+- `templateType: string | null` — null for custom encounters
+- `playerForceSummary: string` — pre-rendered player descriptor
+- `opponentSummary: string` — pre-rendered opponent descriptor
+
+#### Scenario: Launch stamps encounterMeta on GameCreated payload
+
+- **GIVEN** an encounter `E` with `id='encounter-abc'`,
+  `name='Foothold Strike'`,
+  `template=ScenarioTemplateType.Skirmish`
+- **WHEN** `EncounterService.launchEncounter(E.id)` is called
+- **THEN** the first event emitted by the resulting session SHALL be
+  a `GameCreated`
+- **AND** `event.payload.encounterMeta` SHALL be defined
+- **AND** `event.payload.encounterMeta.encounterId` SHALL equal
+  `'encounter-abc'`
+- **AND** `event.payload.encounterMeta.encounterName` SHALL equal
+  `'Foothold Strike'`
+- **AND** `event.payload.encounterMeta.templateType` SHALL equal
+  `'skirmish'`
+
+#### Scenario: Non-encounter session has no encounterMeta
+
+- **GIVEN** a quick-game `GameCreated` event
+- **WHEN** consumers read its payload
+- **THEN** `payload.encounterMeta` SHALL be `undefined`
+
+#### Scenario: Backfill scan recovers metadata from GameCreated
+
+- **GIVEN** an `simulation-reports/encounter/session-77.jsonl` whose
+  first event is a `GameCreated` with `payload.encounterMeta` populated
+- **WHEN** the backfill scan processes the file
+- **THEN** the produced `IEncounterReplayManifestEntry` SHALL have
+  all five encounter-specific fields populated from that single event
+- **AND** the scan SHALL NOT call
+  `EncounterRepository.getEncounterById`
+
+### Requirement: Browser-Side Encounter Persist Hook
+
+The system SHALL guard the encounter-persist call against double-fire
+on component remount via a `useRef`+`useEffect` pattern in the live
+game-session viewer at `src/pages/gameplay/games/[id].tsx`, identical
+to the pattern `QuickGameResults` uses for quick-game persistence. The hook
+SHALL distinguish encounter-originated sessions from other session
+types by checking for the presence of `event.payload.encounterMeta`
+on the session's `GameCreated` event — only sessions that carry
+encounter metadata SHALL trigger the encounter persist call. The
+persist call body shape derivation SHALL live in
+`src/components/encounter/persistEncounterFromSession.ts` so unit
+tests can pin the contract without mounting the full gameplay page.
+
+Quick-game and skirmish-direct sessions SHALL NOT trigger the
+encounter persist hook (they have their own pipelines or are
+intentionally non-persistent).
+
+#### Scenario: Encounter session triggers persist exactly once
+
+- **GIVEN** a live game-session view mounted on
+  `/gameplay/games/<encounterGameSessionId>` whose `GameCreated`
+  event carries `encounterMeta`
+- **WHEN** the session reaches terminal state
+- **THEN** `POST /api/replay-library/encounter` SHALL be called
+  exactly once
+
+#### Scenario: Component remount does not re-persist
+
+- **GIVEN** the same session has already triggered the encounter
+  persist call
+- **WHEN** the React component remounts (and the persist effect
+  re-runs)
+- **THEN** the second persist effect SHALL short-circuit on the
+  `useRef` guard
+- **AND** no second POST SHALL be issued from the client
+
+#### Scenario: Quick-game session does not trigger encounter persist
+
+- **GIVEN** a live game-session view mounted for a quick-game session
+  whose `GameCreated` event has no `encounterMeta`
+- **WHEN** the session reaches terminal state
+- **THEN** the encounter persist hook SHALL NOT fire
+- **AND** the quick-game persist pipeline SHALL run via its own
+  effect
+
+#### Scenario: Persist failure logs but does not crash the page
+
+- **GIVEN** the encounter persist call returns a non-OK response
+  (network error, server 500)
+- **WHEN** the live view's effect handles the result
+- **THEN** the error SHALL be surfaced via `logger.warn`
+- **AND** the page SHALL remain mounted and interactive

--- a/openspec/changes/sync-encounter-and-replay-source-of-truth/specs/replay-library/spec.md
+++ b/openspec/changes/sync-encounter-and-replay-source-of-truth/specs/replay-library/spec.md
@@ -1,0 +1,328 @@
+# Replay Library Spec Delta
+
+## MODIFIED Requirements
+
+### Requirement: ReplaySource Enum
+
+The system SHALL define a `ReplaySource` enum with exactly the values
+`Swarm`, `Quick`, `PvP`, `Campaign`, and `Encounter`. The serialized
+string values SHALL be `'swarm'`, `'quick'`, `'pvp'`, `'campaign'`,
+and `'encounter'` respectively. The enum SHALL be the single source
+of truth for replay-source discrimination at every layer (envelope
+field, manifest entry discriminant, filesystem partition directory
+name, library page filter values).
+
+#### Scenario: Enum has exactly five values
+
+- **GIVEN** the `ReplaySource` enum
+- **WHEN** `Object.values(ReplaySource)` is computed
+- **THEN** the result SHALL equal
+  `['swarm', 'quick', 'pvp', 'campaign', 'encounter']` in any order
+
+#### Scenario: Enum value matches partition directory name
+
+- **GIVEN** any `ReplaySource` value `s`
+- **WHEN** the writer derives the filesystem partition path for `s`
+- **THEN** the partition directory name SHALL equal the string value
+  of `s` (e.g. `ReplaySource.Encounter` → `simulation-reports/encounter/`)
+
+#### Scenario: Exhaustive switch fails compilation if a variant is missed
+
+- **GIVEN** a `switch (entry.replaySource)` statement that omits one
+  of the five cases
+- **WHEN** TypeScript compilation runs in strict mode
+- **THEN** compilation SHALL fail with a
+  `Type 'ReplaySource' is not assignable to type 'never'` error or
+  equivalent exhaustiveness error
+
+### Requirement: IReplayManifestEntry Discriminated Union
+
+The system SHALL define an `IReplayManifestEntry` discriminated union
+with exactly five member interfaces — one per `ReplaySource` value.
+Every member SHALL extend a base interface with the fields
+`id: string` (the `gameId`), `replaySource: ReplaySource`,
+`path: string` (relative to `simulation-reports/`),
+`createdAt: string` (ISO 8601), `turns: number`,
+`winner: GameSide | null`, and `bvTotal: number`.
+
+Each member SHALL add source-specific fields:
+
+- `ISwarmReplayManifestEntry` (`replaySource: ReplaySource.Swarm`):
+  `configName: string`, `seed: number`, `batchTimestamp: string`
+- `IQuickReplayManifestEntry` (`replaySource: ReplaySource.Quick`):
+  `playerSide: GameSide`, `aiVariant: string`
+- `IPvPReplayManifestEntry` (`replaySource: ReplaySource.PvP`):
+  `opponentName: string`, `matchId: string`
+- `ICampaignReplayManifestEntry` (`replaySource: ReplaySource.Campaign`):
+  `campaignId: string`, `missionId: string`, `difficulty: string`
+- `IEncounterReplayManifestEntry` (`replaySource: ReplaySource.Encounter`):
+  `encounterId: string`, `encounterName: string`,
+  `templateType: ScenarioTemplateType | null`,
+  `playerForceSummary: string`, `opponentSummary: string`
+
+`bvTotal` SHALL be computed at manifest-write time from unit data —
+consumers SHALL NOT lazy-recompute on read.
+
+The `playerForceSummary` and `opponentSummary` fields on the
+encounter variant SHALL be stored as strings (not structured objects)
+so the Library row can render them without resolving any external
+state. The encounter row in `EncounterRepository` MAY have been
+deleted by the time the user reads the manifest entry; the manifest
+entry SHALL remain self-contained.
+
+#### Scenario: Swarm manifest entry has source-specific fields
+
+- **GIVEN** a `SimulationRunner` invocation with
+  `configName='duel-3kbv-temperate'`, `seed=42`, completed `gameId='sim-7'`
+- **WHEN** the writer produces the manifest entry
+- **THEN** the entry SHALL be an `ISwarmReplayManifestEntry`
+- **AND** `entry.replaySource` SHALL equal `ReplaySource.Swarm`
+- **AND** `entry.configName` SHALL equal `'duel-3kbv-temperate'`
+- **AND** `entry.seed` SHALL equal `42`
+- **AND** `entry.id` SHALL equal `'sim-7'`
+
+#### Scenario: Quick manifest entry has source-specific fields
+
+- **GIVEN** a quick-game completion with `playerSide=GameSide.Player`,
+  `aiVariant='aggressive-v2'`
+- **WHEN** the writer produces the manifest entry
+- **THEN** the entry SHALL be an `IQuickReplayManifestEntry`
+- **AND** `entry.replaySource` SHALL equal `ReplaySource.Quick`
+- **AND** `entry.aiVariant` SHALL equal `'aggressive-v2'`
+
+#### Scenario: Encounter manifest entry has source-specific fields
+
+- **GIVEN** an encounter battle with `encounterId='encounter-abc'`,
+  `encounterName='Foothold Strike'`,
+  `templateType=ScenarioTemplateType.Skirmish`, completed
+  `gameId='session-77'`
+- **WHEN** the writer produces the manifest entry
+- **THEN** the entry SHALL be an `IEncounterReplayManifestEntry`
+- **AND** `entry.replaySource` SHALL equal `ReplaySource.Encounter`
+- **AND** `entry.encounterId` SHALL equal `'encounter-abc'`
+- **AND** `entry.encounterName` SHALL equal `'Foothold Strike'`
+- **AND** `entry.templateType` SHALL equal `ScenarioTemplateType.Skirmish`
+- **AND** `entry.id` SHALL equal `'session-77'`
+
+#### Scenario: Custom encounter entry has null templateType
+
+- **GIVEN** an encounter created without a scenario template
+- **WHEN** the writer produces the manifest entry
+- **THEN** `entry.templateType` SHALL be `null`
+
+#### Scenario: bvTotal is stored at write time not derived on read
+
+- **GIVEN** a manifest entry written with `bvTotal=4500`
+- **WHEN** the entry is read from the index
+- **THEN** `entry.bvTotal` SHALL equal `4500`
+- **AND** the read path SHALL NOT execute any BV-recomputation code path
+
+#### Scenario: Discriminated union narrows on replaySource
+
+- **GIVEN** a value of type `IReplayManifestEntry`
+- **WHEN** code reads `entry.replaySource === ReplaySource.Encounter`
+  inside a TypeScript narrowing branch
+- **THEN** within the narrowed branch, accessing `entry.encounterId`
+  SHALL compile without further type assertion
+
+#### Scenario: Encounter summary strings survive source-force deletion
+
+- **GIVEN** an encounter manifest entry with
+  `playerForceSummary='Lance Alpha (4500 BV, 4 units)'`
+- **AND** the source force `'Alpha'` has been deleted from the
+  `ForceRepository` after the manifest entry was written
+- **WHEN** the Library row renders the entry
+- **THEN** the row SHALL display the literal text
+  `'Lance Alpha (4500 BV, 4 units)'`
+- **AND** the render SHALL NOT call `getForceById` or any other
+  resolution function
+
+### Requirement: Filesystem Partition Layout
+
+The repository SHALL persist replay event logs under partition
+directories at `simulation-reports/<source>/<gameId>.jsonl`, where
+`<source>` is the string value of one of the five `ReplaySource`
+enum variants. Writers SHALL NOT write swarm logs to the legacy flat
+path `simulation-reports/games/<run-timestamp>/<gameId>.jsonl` after
+this layout is in effect.
+
+The `simulation-reports/` directory SHALL also contain a single
+`replay-index.json` file at its top level, alongside the five
+partition directories.
+
+#### Scenario: Swarm runner writes under simulation-reports/swarm/
+
+- **GIVEN** a swarm invocation that produces `gameId='sim-1'`
+- **WHEN** the runner writes the event log
+- **THEN** the file SHALL exist at `simulation-reports/swarm/sim-1.jsonl`
+- **AND** no file SHALL be written under `simulation-reports/games/`
+
+#### Scenario: Quick game persists under simulation-reports/quick/
+
+- **GIVEN** a quick-game completion with `gameId='quick-99'`
+- **WHEN** the QuickGameResults page completes its persist effect
+- **THEN** the file SHALL exist at
+  `simulation-reports/quick/quick-99.jsonl`
+
+#### Scenario: Encounter battle persists under simulation-reports/encounter/
+
+- **GIVEN** an encounter battle that reaches terminal state with
+  `gameId='session-77'`
+- **WHEN** the persist pipeline completes
+- **THEN** the file SHALL exist at
+  `simulation-reports/encounter/session-77.jsonl`
+- **AND** the `replay-index.json` SHALL contain a manifest entry with
+  `replaySource: 'encounter'` and `path: 'encounter/session-77.jsonl'`
+
+#### Scenario: Index file lives next to partitions
+
+- **GIVEN** the populated `simulation-reports/` directory
+- **WHEN** its top-level entries are listed
+- **THEN** `replay-index.json` SHALL be present alongside the
+  partition directories
+
+### Requirement: Backfill Scan
+
+The system SHALL provide a backfill scan that produces a
+`readonly IReplayManifestEntry[]` from the contents of
+`simulation-reports/`. The scan SHALL examine both the partition
+layout (`simulation-reports/<source>/*.jsonl`) AND the legacy flat
+layout (`simulation-reports/games/<timestamp>/*.jsonl`).
+
+For each NDJSON file discovered, the scan SHALL stream-read enough
+lines to extract:
+
+- The first event (which SHALL be `GameCreated`) — used to derive
+  `bvTotal` from `payload.units` summed `.bv` fields and source-specific
+  metadata as available. For encounter partitions, the scan SHALL
+  extract `encounterId`, `encounterName`, `templateType`,
+  `playerForceSummary`, and `opponentSummary` from the
+  `GameCreated.payload.encounterMeta` field.
+- The last `GameEnded` event (if present) — used to derive `winner`
+  and `turns`. If `GameEnded.turns` is absent or undefined, `turns`
+  SHALL fall back to the count of `turn_started` events in the file,
+  then to `0` if no `turn_started` events exist.
+
+For legacy flat-layout files, the scan SHALL infer
+`replaySource = ReplaySource.Swarm` (legacy directory only contained
+swarm output) and SHALL set `batchTimestamp` from the parent directory
+name.
+
+The scan SHALL be idempotent: re-running on the same disk state SHALL
+produce the same manifest array.
+
+#### Scenario: Scan covers new partition layout
+
+- **GIVEN** `simulation-reports/swarm/sim-1.jsonl`,
+  `simulation-reports/quick/quick-9.jsonl`,
+  `simulation-reports/encounter/session-77.jsonl` exist
+- **WHEN** the backfill scan runs
+- **THEN** the result SHALL contain one `ISwarmReplayManifestEntry`
+  for `sim-1`
+- **AND** SHALL contain one `IQuickReplayManifestEntry` for `quick-9`
+- **AND** SHALL contain one `IEncounterReplayManifestEntry` for `session-77`
+
+#### Scenario: Scan covers legacy flat layout
+
+- **GIVEN** `simulation-reports/games/2026-05-01T10-00-00-000Z/sim-77.jsonl`
+  exists
+- **WHEN** the backfill scan runs
+- **THEN** the result SHALL contain an `ISwarmReplayManifestEntry`
+  for `sim-77`
+- **AND** the entry's `batchTimestamp` SHALL equal
+  `'2026-05-01T10-00-00-000Z'`
+
+#### Scenario: GameEnded.turns optionality fallback
+
+- **GIVEN** a `<gameId>.jsonl` whose `GameEnded` event is missing the
+  `turns` field
+- **WHEN** the backfill scan processes it
+- **THEN** `entry.turns` SHALL equal the count of `turn_started`
+  events in the file
+- **AND** if no `turn_started` events exist, `entry.turns` SHALL
+  equal `0`
+
+#### Scenario: Scan is idempotent
+
+- **GIVEN** an unchanged `simulation-reports/` directory
+- **WHEN** the backfill scan is run twice
+- **THEN** the two resulting manifest arrays SHALL be deep-equal
+
+#### Scenario: Encounter scan recovers metadata from GameCreated payload
+
+- **GIVEN** `simulation-reports/encounter/session-77.jsonl` whose
+  first event is a `GameCreated` carrying
+  `payload.encounterMeta = { encounterId: 'enc-abc', encounterName: 'Foothold Strike', templateType: 'skirmish', playerForceSummary: 'Lance Alpha (4500 BV, 4 units)', opponentSummary: 'Generated Lance (~3000 BV)' }`
+- **WHEN** the backfill scan processes the file
+- **THEN** the produced `IEncounterReplayManifestEntry` SHALL have
+  `encounterId === 'enc-abc'`
+- **AND** `encounterName === 'Foothold Strike'`
+- **AND** `templateType === ScenarioTemplateType.Skirmish`
+- **AND** `playerForceSummary === 'Lance Alpha (4500 BV, 4 units)'`
+- **AND** `opponentSummary === 'Generated Lance (~3000 BV)'`
+- **AND** the scan SHALL NOT call `EncounterRepository.getEncounterById`
+  (the manifest is reconstructable from the file alone)
+
+### Requirement: Replay Library Page
+
+The system SHALL provide a Replay Library page accessible from the
+primary navigation. The page SHALL load the replay index on mount,
+display every manifest entry as a list row with source-appropriate
+metadata visible (e.g. swarm rows show `configName`/`seed`; quick
+rows show `aiVariant`; encounter rows show `encounterName` and
+`templateType` and force summaries), and SHALL provide a source
+filter that limits the displayed list to a chosen `ReplaySource`.
+
+The source filter button strip SHALL contain exactly six buttons in
+order: `All`, `Swarm`, `Quick`, `PvP`, `Campaign`, `Encounter`. The
+button keys SHALL be `'all'` plus the five `ReplaySource` enum string
+values. The encounter row SHALL render `templateType ?? 'Custom'`
+when the value is `null` (custom encounters get the literal `'Custom'`
+label in the template column).
+
+Clicking a list row SHALL open the existing replay viewer with the
+chosen entry's events loaded — without requiring the user to drag a
+file.
+
+#### Scenario: Page loads and lists all entries
+
+- **GIVEN** the index contains 3 swarm entries, 2 quick entries, and
+  1 encounter entry
+- **WHEN** the user navigates to the Replay Library page
+- **THEN** the page SHALL render exactly 6 list rows
+- **AND** each row SHALL show the entry's `id`, `createdAt`, `turns`,
+  `winner`, and `bvTotal`
+
+#### Scenario: Source filter restricts list
+
+- **GIVEN** the index contains 3 swarm entries, 2 quick entries, and
+  1 encounter entry
+- **WHEN** the user selects the Quick filter
+- **THEN** only 2 rows SHALL be visible
+- **AND** both rows SHALL display the source-specific `aiVariant` field
+
+#### Scenario: Encounter filter shows encounter entries
+
+- **GIVEN** the index contains 3 swarm entries, 2 quick entries, and
+  1 encounter entry
+- **WHEN** the user selects the Encounter filter
+- **THEN** exactly 1 row SHALL be visible
+- **AND** the row SHALL display `encounterName`, the template label
+  (or `'Custom'` when `templateType === null`), and the player vs
+  opponent summaries
+
+#### Scenario: Filter button strip has six buttons
+
+- **GIVEN** the Replay Library page is rendered
+- **WHEN** the user inspects the source filter button strip
+- **THEN** the strip SHALL contain exactly six buttons in order:
+  `All`, `Swarm`, `Quick`, `PvP`, `Campaign`, `Encounter`
+
+#### Scenario: Click opens replay viewer with events loaded
+
+- **GIVEN** a list row for an encounter entry with
+  `path='encounter/session-77.jsonl'`
+- **WHEN** the user clicks the row
+- **THEN** the replay viewer SHALL mount with the events from that
+  file already loaded
+- **AND** the user SHALL NOT be prompted to drag a file

--- a/openspec/changes/sync-encounter-and-replay-source-of-truth/tasks.md
+++ b/openspec/changes/sync-encounter-and-replay-source-of-truth/tasks.md
@@ -1,0 +1,183 @@
+# Tasks: sync-encounter-and-replay-source-of-truth
+
+This is a **spec-only** change. No TypeScript, TSX, or test files are
+touched in any wave. Every task either authors / edits a markdown
+file under `openspec/changes/sync-encounter-and-replay-source-of-truth/`
+or runs the OpenSpec validator. The final wave runs the archive **with
+full spec sync — NO `--skip-specs`**.
+
+## 1. Source-Audit Wave (read-only)
+
+- [ ] 1.1 Read `openspec/specs/encounter-system/spec.md` — confirm it
+  does not exist on `main`. If it does exist, this change is
+  redundant; abort and re-evaluate scope.
+- [ ] 1.2 Read `openspec/specs/replay-library/spec.md` end-to-end.
+  Confirm it pins exactly four `ReplaySource` values, four
+  manifest-union members, and a four-partition layout (i.e. drift
+  exists vs the shipped 5-source code).
+- [ ] 1.3 Read `openspec/specs/game-session-management/spec.md`
+  encounter-related sections (`Encounter Launch Status Transition`,
+  `Encounter CRUD via API Routes`, `Force Assignment`,
+  `Encounter Validation`, `Encounter Launch`, `Encounter Cloning`).
+  Confirm the existing seven encounter store / API requirements stay
+  untouched by this change.
+- [ ] 1.4 Read each of the five archived encounter/replay changes in
+  `openspec/changes/archive/` — confirm what they shipped matches
+  what's covered by the three deltas being authored here.
+  - [ ] 1.4.1 `archive/2026-01-18-add-encounter-system/`
+  - [ ] 1.4.2 `archive/2026-05-01-wire-encounter-to-campaign-round-trip/`
+    (verify out-of-scope — already merged into source-of-truth)
+  - [ ] 1.4.3 `archive/2026-05-07-add-replay-library/` (verify the
+    4-source baseline matches `openspec/specs/replay-library/`)
+  - [ ] 1.4.4 `archive/2026-05-09-repair-broken-encounter-drafts/`
+  - [ ] 1.4.5 `archive/2026-05-09-link-encounters-to-replays/`
+- [ ] 1.5 Spot-verify cited code paths exist on `main`:
+  - [ ] 1.5.1 `src/types/encounter/EncounterInterfaces.ts` — read
+    enum + interface definitions to confirm shape.
+  - [ ] 1.5.2 `src/types/gameplay/GameSessionInterfaces.ts` — verify
+    `ReplaySource` enum has 5 values; `IEncounterMeta` interface
+    exists; `IGameCreatedPayload.encounterMeta` is optional.
+  - [ ] 1.5.3 `src/replay-library/types.ts` — verify
+    `IReplayManifestEntry` union has 5 members.
+  - [ ] 1.5.4 `src/services/encounter/encounterBrokenRefs.ts` — verify
+    pure helper signature.
+  - [ ] 1.5.5 `src/services/forces/ForceRepository.cascade.ts` — verify
+    callback registry exports.
+  - [ ] 1.5.6 `src/components/encounter/persistEncounterGame.ts`,
+    `persistEncounterFromSession.ts`,
+    `src/pages/api/replay-library/encounter.ts`,
+    `src/pages/api/encounters/seed-samples.ts`,
+    `scripts/cleanup-broken-encounters.ts` — verify each file exists.
+
+## 2. Author Wave
+
+- [ ] 2.1 Author `proposal.md` — drift summary, scope (in/out),
+  capabilities (new + modified), impact.
+- [ ] 2.2 Author `design.md` — domain split rationale (new
+  `encounter-system` vs absorb-into-`game-session-management`),
+  per-spec organisation table, file change list, risk +
+  mitigation, open questions.
+- [ ] 2.3 Author `specs/encounter-system/spec.md` — full ADDED suite
+  for the new source-of-truth domain. Required requirements (each
+  with at least one Scenario):
+  - [ ] 2.3.1 Encounter Entity Model
+  - [ ] 2.3.2 Encounter Status Lifecycle
+  - [ ] 2.3.3 Force-Reference Slot Semantics
+  - [ ] 2.3.4 Force Configuration
+  - [ ] 2.3.5 Map Configuration
+  - [ ] 2.3.6 Victory Conditions
+  - [ ] 2.3.7 Scenario Templates
+  - [ ] 2.3.8 Encounter Launch Snapshot Metadata
+  - [ ] 2.3.9 Broken-Reference Detection Helper
+  - [ ] 2.3.10 Encounter List Broken-Pill Render
+  - [ ] 2.3.11 Encounter Detail Repair Banner
+  - [ ] 2.3.12 Sample Encounter Seeding
+  - [ ] 2.3.13 One-Time Cleanup Script for Broken Drafts
+- [ ] 2.4 Author `specs/replay-library/spec.md` — MODIFIED delta. Each
+  requirement carries the FULL replacement text plus all preserved
+  scenarios:
+  - [ ] 2.4.1 ReplaySource Enum (4 → 5 values)
+  - [ ] 2.4.2 IReplayManifestEntry Discriminated Union (4 → 5 members,
+    with the encounter variant absorbed into the union requirement)
+  - [ ] 2.4.3 Filesystem Partition Layout (adds
+    `simulation-reports/encounter/` partition + scenario)
+  - [ ] 2.4.4 Backfill Scan (adds encounter-metadata recovery
+    scenario)
+  - [ ] 2.4.5 Replay Library Page (6-button strip + Encounter row
+    metadata strip)
+- [ ] 2.5 Author `specs/game-session-management/spec.md` — ADDED
+  delta. Required requirements (each with at least one Scenario):
+  - [ ] 2.5.1 Force-Deletion Cascade to Encounter References
+  - [ ] 2.5.2 Hydration-Boundary Orphaned Reference Replacement
+  - [ ] 2.5.3 Encounter Game Event Log Persistence
+  - [ ] 2.5.4 Encounter Metadata in GameCreated Event Payload
+  - [ ] 2.5.5 Browser-Side Encounter Persist Hook
+- [ ] 2.6 Author `notepad/README.md` — cross-delegation wisdom.
+  Capture: domain layout, source-of-truth audit, rule reminders,
+  out-of-scope list.
+
+## 3. Self-Review Wave
+
+- [ ] 3.1 Re-read `proposal.md`. Confirm:
+  - [ ] 3.1.1 Every change item maps to a requirement in one of the
+    three spec files.
+  - [ ] 3.1.2 The "spec-only" framing is repeated explicitly so the
+    operator does not accidentally execute code changes.
+  - [ ] 3.1.3 The OUT OF SCOPE list matches the design.md scope
+    decisions.
+- [ ] 3.2 Re-read `design.md`. Confirm:
+  - [ ] 3.2.1 Every architecture decision has a rationale + listed
+    alternatives.
+  - [ ] 3.2.2 The spec organisation table reflects what was actually
+    authored.
+- [ ] 3.3 Re-read each spec file. Confirm:
+  - [ ] 3.3.1 Every Requirement uses RFC 2119 keywords (SHALL / MUST /
+    MAY) consistently.
+  - [ ] 3.3.2 Every Requirement carries at least one Scenario block
+    with `GIVEN` / `WHEN` / `THEN` bullets.
+  - [ ] 3.3.3 No Requirement cites a code path that wasn't verified
+    in 1.5.x.
+  - [ ] 3.3.4 No Requirement describes deferred / out-of-scope
+    behaviour (e.g. IndexedDB persistence).
+- [ ] 3.4 Cross-spec consistency check:
+  - [ ] 3.4.1 The `IEncounterMeta` shape pinned in
+    `encounter-system/spec.md` (Encounter Launch Snapshot Metadata)
+    matches the shape pinned in
+    `game-session-management/spec.md` (Encounter Metadata in
+    GameCreated Event Payload).
+  - [ ] 3.4.2 The `playerForceSummary` derivation rules are stated
+    once in `encounter-system/spec.md` and referenced (not
+    duplicated) in the replay-library and game-session deltas.
+  - [ ] 3.4.3 The three-state force slot semantics (`undefined` /
+    `null` / resolved object) are defined once in
+    `encounter-system/spec.md` (Force-Reference Slot Semantics).
+  - [ ] 3.4.4 Cleanup-script taxonomy strings (`'abandoned-empty'`,
+    `'orphaned-force-reference'`, `'still-valid'`) are spelled
+    identically wherever they appear.
+
+## 4. Validation Wave
+
+- [ ] 4.1 Run `npx openspec validate sync-encounter-and-replay-source-of-truth --strict`
+  from the repo root.
+- [ ] 4.2 If strict-mode reports errors, fix the markdown (do NOT
+  invent code, do NOT loosen requirements). Re-run until clean.
+- [ ] 4.3 If strict-mode reports warnings the operator deems
+  acceptable, document them in the final report.
+- [ ] 4.4 Capture the validator's output for the archive PR
+  description.
+
+## 5. Archive Wave (full spec sync — NO `--skip-specs`)
+
+- [ ] 5.1 Open a PR with the change folder as the only file change
+  set. The PR description SHALL include the validator output from
+  4.4 and call out that this is a spec-only change.
+- [ ] 5.2 Merge the PR (after CI green).
+- [ ] 5.3 Run `openspec archive sync-encounter-and-replay-source-of-truth`
+  from the repo root. **MUST NOT pass `--skip-specs`** — the entire
+  point of this change is to merge the deltas into source-of-truth.
+- [ ] 5.4 Verify the archive step:
+  - [ ] 5.4.1 `openspec/specs/encounter-system/spec.md` now exists at
+    the source-of-truth tree (created by the archive sync from the
+    full ADDED suite). If the archive command did not auto-create
+    the directory, create it manually with the correct contents and
+    re-run the archive — DO NOT fall back to `--skip-specs`.
+  - [ ] 5.4.2 `openspec/specs/replay-library/spec.md` reflects the
+    five-source enum, five-member union, five-partition layout,
+    encounter backfill recovery, and 6-button page filter strip.
+  - [ ] 5.4.3 `openspec/specs/game-session-management/spec.md`
+    contains the five new requirements (cascade, hydration repair,
+    encounter persist, encounter-meta on GameCreated, browser persist
+    hook).
+  - [ ] 5.4.4 The pre-existing seven encounter store / API
+    requirements (Encounter Launch Status Transition, Encounter CRUD,
+    Encounter Selection and Retrieval, Force Assignment, Template
+    Application, Encounter Validation, Encounter Launch, Encounter
+    Cloning, Filtering and Search) are preserved unchanged.
+- [ ] 5.5 The archive command moves the change folder to
+  `openspec/changes/archive/YYYY-MM-DD-sync-encounter-and-replay-source-of-truth/`.
+  Confirm the move and that the source-of-truth specs reflect the
+  new state.
+- [ ] 5.6 Update memory anchor at
+  `~/.claude/projects/E--Projects-MekStation/memory/MEMORY.md`
+  noting that the encounter / replay specs are now fully in
+  source-of-truth and the `--skip-specs` legacy is closed.


### PR DESCRIPTION
## Summary

Closes the source-of-truth drift caused by 4+ archived encounter changes using `--skip-specs`. **Spec-only — no TS / TSX / test diff.**

After today's wave (Change A `repair-broken-encounter-drafts` + Change B `link-encounters-to-replays`), the implementation has accumulated significant capability that the canonical specs don't reflect:

- `openspec/specs/encounter-system/` — does not exist (the original `add-encounter-system` was archived without source-of-truth promotion)
- `openspec/specs/replay-library/spec.md` — describes a 4-source enum despite shipped code being 5-source (Encounter variant)
- `openspec/specs/game-session-management/spec.md` — missing force-deletion cascade, encounter persist pipeline, and `encounterMeta` payload requirements

This change retroactively merges what's actually shipped into 3 specs.

## Deltas (23 across 3 specs)

| Spec | Action | Count | Coverage |
|---|---|---|---|
| `encounter-system` | NEW + 13 ADDED | 685 lines | Entity model, lifecycle, force refs, scenario templates, launch snapshot, broken-pill render, repair banner, sample seeding, cleanup script |
| `replay-library` | 5 MODIFIED | 328 lines | ReplaySource enum (4→5), manifest discriminated union, filesystem partition, backfill scan, page filter (5→6 buttons + metadata strip) |
| `game-session-management` | 5 ADDED | 346 lines | Force-deletion cascade, hydration orphan replacement, encounter event log persistence, encounterMeta on GameCreated, browser persist hook |

## Authoring + review

- **Authored** by `omo-prometheus`. 2047 lines markdown total.
- **Reviewed** by `omo-momus` — APPROVE. All 20+ cited file paths verified against codebase, type names + function signatures match shipped TS, MODIFIED requirements are full-text replacements (no partial edits that would break archive merge).
- `npx openspec validate sync-encounter-and-replay-source-of-truth --strict` passes clean.

## Archive plan

After merge, run `openspec archive sync-encounter-and-replay-source-of-truth` **without** `--skip-specs`. The archive will:
1. Create `openspec/specs/encounter-system/spec.md` from ADDED requirements (new domain)
2. Merge MODIFIED replacements into `openspec/specs/replay-library/spec.md`
3. Append ADDED requirements to `openspec/specs/game-session-management/spec.md`
4. Move change folder to `openspec/changes/archive/2026-05-09-sync-encounter-and-replay-source-of-truth/`

This breaks the `--skip-specs` cycle that's been accumulating since Jan 18 — future encounter / replay changes can author normal deltas against real source-of-truth.

## Test plan

- [x] `npx openspec validate sync-encounter-and-replay-source-of-truth --strict` clean
- [x] Momus executability review APPROVE
- [x] All cited file paths verified to exist (Glob/Grep against main)
- [ ] CI green (no TS / Jest changes — only docs / openspec checks should run)
- [ ] Post-merge archive succeeds without `--skip-specs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)