### PR TITLE
feat(replay): hex-step movement animation + attack effects + encounter watch link

### DIFF
--- a/openspec/changes/add-replay-step-and-effect-animations/design.md
+++ b/openspec/changes/add-replay-step-and-effect-animations/design.md
@@ -1,0 +1,306 @@
+# Design — Add Replay Step and Effect Animations
+
+## Context
+
+The replay surfaces today render hex-board state via the pure
+`useHexMapStateFromEvents` projection hook fed by a scrubbable
+event cursor (`useReplayPlayer.currentSequence`). That projection
+is correct — armor pip rings, prone state, destroyed locations,
+heat band — but it is also **strictly state, not motion**. Three
+visual contracts that exist in live play are missing from replay:
+
+1. **Movement step animation** — live play uses `useAnimationQueue`
+   (`src/stores/useAnimationQueue.ts`) plus the renderer's path-
+   tween logic to walk tokens through their committed step chain.
+   The replay reducer collapses a movement to its destination.
+2. **Attack effects** — live `HexMapDisplay` mounts
+   `<AttackEffectsLayer>` at line 463, which renders laser beams,
+   missile trails, projectile arcs, impact flashes, and cluster
+   stagger. Neither replay surface mounts the layer.
+3. **Encounter discoverability** — quick-game has a `Replay` tab
+   inside `RESULTS_TABS` (`quickGameResults.helpers.ts:14-19`).
+   The encounter detail page has no equivalent "open the replay"
+   shortcut even after launch persists `gameSessionId`.
+
+This change closes those three gaps without disturbing the data
+contracts (`IAttackResolvedPayload`, `IMovementDeclaredPayload`,
+NDJSON event log) and without rewriting the live-play paths.
+
+## Decision Log
+
+### D1. Reuse `useAnimationQueue` rather than introducing a replay-only queue
+
+**Choice**: The same `useAnimationQueue` Zustand store that
+drives live-play `Movement Path Interpolation` and `Jump Arc
+Animation` SHALL be reused for replay-side movement animations.
+
+**Rationale**:
+- The store is already a pure Zustand singleton with no live-
+  session coupling. It accepts any caller of `enqueue(...)`.
+- The store already enforces per-`mapId` overlap detection
+  (`canStart` / `overlapsHexes`) so multiple animations per unit
+  serialize correctly.
+- The renderer-side consumers (path-tween, jump-arc, facing-
+  rotate) are already wired against this store. Reusing it
+  means replay automatically inherits any future improvements
+  to the live-play animation contract.
+
+**Alternatives considered**:
+- **Replay-only queue duplicate**. Rejected — a separate queue
+  would create a second integration point and the renderers
+  would have to subscribe to two stores or accept which-store-
+  is-authoritative-now logic. Pure tax on future maintenance.
+- **Inline animation calls in the projection hook**. Rejected
+  because it would violate the pure-projection contract spelled
+  out in `combat-analytics` "Replay State-From-Events Reducer
+  Contract" — that contract is the basis for the reducer's
+  `useMemo` correctness and is reused by audit-store consumers.
+  Side effects must live in a separate adapter.
+
+### D2. Side-effect adapter as a dedicated React hook
+
+**Choice**: `useReplayMovementAnimations(events, currentSequence,
+{ mapId, prefersReducedMotion })` is a NEW hook at
+`src/hooks/replay/useReplayMovementAnimations.ts`. It does NOT
+modify `useHexMapStateFromEvents`. It runs in `useEffect`,
+observes `currentSequence` against a previous-cursor ref, and
+walks the relevant slice of `events` to enqueue animations.
+
+**Rationale**:
+- Keeps the projection hook pure and unit-testable in isolation.
+- React's standard `useEffect` semantics handle the "cursor
+  changed, fire side effect, reset on unmount" lifecycle
+  cleanly — no manual subscription bookkeeping.
+- Easy to test in isolation: render a test component with a
+  controllable cursor, assert on `useAnimationQueue.getState()`.
+
+**Alternatives considered**:
+- **Subscribe directly to the replay player from the queue
+  store**. Rejected — would create a circular dependency
+  (`useAnimationQueue` ↔ `useReplayPlayer`) and put cursor logic
+  inside a store that is currently agnostic of cursor concepts.
+- **Emit animations from the projection hook conditioned on a
+  `mode: 'replay'` flag**. Rejected per D1 — projection purity
+  is a load-bearing contract.
+
+### D3. Cursor-rewind reset semantics
+
+**Choice**: When the adapter's `currentSequence` decreases
+between renders (a rewind), it SHALL call
+`useAnimationQueue.getState().reset()` BEFORE enqueueing any
+catch-up animations for the new cursor position. The pure
+reducer continues to walk-from-zero on every projection so token
+positions stay correct; the adapter only flushes the visual
+queue.
+
+**Rationale**:
+- Without flush, a stale 900 ms walk could finish ON TOP OF the
+  watcher's new state, ending with the token in the wrong hex.
+- `reset()` already wipes `queue` AND `active` AND completion
+  listeners — exactly the cleanup we need. No additional API
+  surface required.
+- The forward-only adapter case (cursor strictly increases) is
+  the common path and pays no overhead — the rewind branch only
+  triggers when `prevCursor > nextCursor`.
+
+**Alternatives considered**:
+- **Per-step `cancel(animationId)` instead of full reset**.
+  Rejected — adds bookkeeping (track every queued id by
+  cursor), and the queue's overlap detection already serializes
+  per-unit, so a full flush has the same observable end-state
+  with much less code.
+- **Skip rewind support entirely (forward-only animation)**.
+  Rejected — the scrubber's whole purpose is bidirectional, and
+  watchers will rewind to re-watch a key moment.
+
+### D4. AttackEffectsLayer cross-references hex coords from token state
+
+**Choice**: The layer SHALL NOT receive enriched payloads with
+`sourceHex` / `targetHex` fields. `IAttackResolvedPayload` stays
+unchanged. The layer SHALL look up `payload.attackerId` and
+`payload.targetId` against the `tokens` array (already used to
+drive the hex-map render) to read each unit's `position` at the
+event's sequence.
+
+**Rationale**:
+- The persisted NDJSON event log is the authoritative replay
+  source for thousands of existing files. Adding `sourceHex` /
+  `targetHex` would either break old files (forcing migration)
+  or require a fallback path in the layer (defeating the
+  enrichment purpose).
+- The token-array lookup is already how the live-play
+  `AttackEffectsLayer` resolves geometry — copying that
+  approach to the replay path means the layer code is identical
+  in both surfaces.
+- The `tokens` array passed to the layer comes from
+  `useHexMapStateFromEvents(events, currentSequence)`, so token
+  positions are by construction current at the event's sequence.
+
+**Alternatives considered**:
+- **Enrich the payload at write time**. Rejected — would
+  invalidate every existing replay file under
+  `simulation-reports/swarm/`, `simulation-reports/quick/`,
+  `simulation-reports/encounter/`. Not a 1-day fix; not
+  worth the cost when token-state lookup works.
+- **Snapshot a hex-coordinate map alongside the projection
+  hook**. Rejected — `tokens[].position` already serves as
+  that map. Extra structure for no behavioral gain.
+
+### D5. Defer Gap C (EventList side panel)
+
+**Choice**: The Council surfaced a third gap — a vertically-
+scrollable event list beside the hex map showing the full
+`IGameEvent` stream — and explicitly deferred it for a later
+change.
+
+**Rationale**:
+- Today's scrubber + `KeyMomentMarkers` + `PhaseChangeMarkers`
+  cover the navigation use case (jump to "the moment").
+- An EventList is a substantially larger UX problem (filter,
+  group-by-turn, search, virtual-scroll for 1000+ events) that
+  deserves its own design pass.
+- Bundling it into this change inflates scope and delays the
+  high-value visual polish (movement walk, beam flash) into a
+  bigger PR.
+
+**Alternatives considered**: keep — but the scope inflation
+risk per the OMO Council's `Mid-sized Task` AI-slop checklist
+makes deferral the right call.
+
+### D6. `mapId` collision between live-play and replay
+
+**Choice**: The replay-side `<AttackEffectsLayer>` and replay-
+side movement-animation enqueues SHALL use a deterministic
+`mapId` like `'replay'` or `'quickgame-replay'` that does NOT
+collide with the live-play `mapId` (typically the active hex
+map's identifier from `useGameplayStore`).
+
+**Rationale**:
+- The animation queue's `canStart` / `overlapsHexes` logic
+  partitions by `mapId`. If a live game and a replay surface
+  ever co-mount in the same React tree (e.g. dev hot-reload, or
+  a future "watch your friend's game while playing" mode), they
+  must not interfere with each other's animations.
+- A constant string per replay surface is the simplest stable
+  identifier — no need to wire through a unique-id generator.
+
+### D7. Encounter Watch Replay link uses Next router, not anchor
+
+**Choice**: The button SHALL call `router.push(...)` rather than
+render a raw `<a href="...">`.
+
+**Rationale**:
+- Next.js's client-side router preserves React state across
+  the navigation. The encounter store's loaded encounter, the
+  validation cards, and any in-progress modal state all stay
+  warm if the user hits the back button to return to the
+  encounter detail page.
+- Matches the style used by the existing
+  `EncounterActionsFooter` actions for consistency.
+
+## Data Flow
+
+```
+Replay event log (NDJSON)
+        │
+        ▼
+useReplayPlayer ─── currentSequence ─┐
+        │                            │
+        ▼                            ▼
+useHexMapStateFromEvents     useReplayMovementAnimations  (NEW)
+        │                            │
+        │                            └──► useAnimationQueue.enqueue
+        │                                        │
+        ▼                                        ▼
+      tokens[]              ┌──── Renderer reads queue.active
+        │                   │     and animates path / arc / rotate
+        ▼                   │
+HexMapDisplay ◄─ tokens ────┘
+        │
+        ├── AttackEffectsLayer (NEW MOUNT)
+        │     │
+        │     └── reads tokens[] to derive source/target hex
+        │     └── enqueues effect animations into useAnimationQueue
+        │
+        └── Existing token / armor-pip / heat layers
+```
+
+The existing `useHexMapStateFromEvents` reducer is unchanged.
+The new adapter hook (`useReplayMovementAnimations`) shares its
+`events` input but writes to the side-effect store
+(`useAnimationQueue`) only.
+
+The `AttackEffectsLayer` already enqueues effect animations into
+`useAnimationQueue` in live play (see `effects/AttackEffectsLayer.tsx`
+lines 113-114: `useAnimationQueue((state) => state.enqueue)`).
+Mounting it on the replay surface inherits that behavior — no
+duplicate logic.
+
+## File Changes
+
+### New files
+
+- **`src/hooks/replay/useReplayMovementAnimations.ts`** — the
+  side-effect adapter hook. Subscribes to `currentSequence`
+  changes via `useEffect`, walks `events` from a stored
+  `prevCursor` ref to the new cursor, enqueues per-step
+  animations, calls `reset()` on rewind. Respects
+  `usePrefersReducedMotion()`.
+
+- **`src/hooks/replay/__tests__/useReplayMovementAnimations.test.tsx`**
+  — unit tests for forward advancement, rewind reset, jump
+  step, reduced motion skip, missing-steps fallback, skipped
+  step kinds.
+
+- **`src/hooks/replay/__tests__/useReplayMovementAnimations.integration.test.tsx`**
+  — integration test rendering a small replay with
+  `useHexMapStateFromEvents` + the new adapter and asserting
+  on `useAnimationQueue` state across cursor moves.
+
+- **`src/components/quickgame/__tests__/QuickGameReplayPanel.attackEffects.test.tsx`**
+  — integration test asserting `<AttackEffectsLayer>` mounts
+  inside the panel with the right props.
+
+- **`src/pages/gameplay/games/__tests__/replay.attackEffects.test.tsx`**
+  — same assertion for the standalone replay route.
+
+- **`src/components/gameplay/pages/__tests__/EncounterDetailPage.watchReplay.test.tsx`**
+  — unit test for the Watch Replay button visibility and click
+  navigation.
+
+- **Storybook story for the Watch Replay state** — co-located
+  near existing `EncounterDetailPage.*.stories.tsx` (whichever
+  module currently hosts encounter-detail stories).
+
+### Modified files
+
+- **`src/components/quickgame/QuickGameReplayPanel.tsx`** —
+  mount `<AttackEffectsLayer>` as a sibling to
+  `<HexMapDisplay>`; call `useReplayMovementAnimations(events,
+  replay.currentSequence, { mapId: 'quickgame-replay' })`.
+
+- **`src/pages/gameplay/games/[id]/replay.tsx`** — same two
+  additions, with `mapId: 'replay'`.
+
+- **`src/components/gameplay/pages/EncounterDetailPage.actions.tsx`**
+  (or a sibling section module — confirm during 2.5; the
+  encounter detail page composition is split across multiple
+  `.sections.tsx` / `.actions.tsx` files at
+  `src/components/gameplay/pages/`) — render the Watch Replay
+  button conditioned on `encounter.gameSessionId`. The button
+  uses `next/router`'s `push` and the existing `Button`
+  primitive from `@/components/ui`.
+
+### Unchanged files (key non-changes)
+
+- **`src/hooks/replay/useHexMapStateFromEvents.ts`** — pure
+  projection contract preserved. No new branches, no new side
+  effects.
+- **`src/components/gameplay/effects/AttackEffectsLayer.tsx`** —
+  the layer already has all the geometry derivation it needs
+  via `tokens`. No prop changes, no behavior changes.
+- **`src/types/gameplay/GameSessionInterfaces.ts`** —
+  `IAttackResolvedPayload` and `IMovementDeclaredPayload` stay
+  exactly as they are. The persisted NDJSON contract holds.
+- **`src/stores/useAnimationQueue.ts`** — store API is reused
+  exactly as-is (`enqueue`, `reset`).

--- a/openspec/changes/add-replay-step-and-effect-animations/proposal.md
+++ b/openspec/changes/add-replay-step-and-effect-animations/proposal.md
@@ -1,0 +1,126 @@
+# Add Replay Step and Effect Animations
+
+## Why
+
+The hex-board replay surfaces (`/gameplay/games/[id]/replay` and the
+`Replay` tab inside `QuickGameResults`) currently render scrub-driven
+state without the visual layers that make live combat feel like a
+battle. Three concrete gaps were surfaced by today's OMO Council on
+hex-board replay polish:
+
+1. **Movement plays as instant teleports.** The replay reducer at
+   `src/hooks/replay/useHexMapStateFromEvents.ts:610-617` collapses
+   every `MovementDeclared` to its destination — `acc.position =
+   payload.to`. The full step chain in
+   `IMovementDeclaredPayload.steps[]` (4-tuple of `forward` / `turn`
+   / `lateral` / `jump` / `standUp` / `goProne` etc.) is ignored, so
+   tokens snap rather than walk through their committed path.
+2. **Weapon impacts have no visual feedback.** The
+   `AttackEffectsLayer` (557 lines, renders laser / missile /
+   projectile primitives) is mounted in the live-play
+   `HexMapDisplay` but NOT in either replay surface. Replay watchers
+   see damage pip rings update silently with no beam, missile trail,
+   or impact flash.
+3. **Encounters have no Watch Replay shortcut.** Quick-game has a
+   discoverable `Replay` tab in `RESULTS_TABS`, but the encounter
+   detail page (`/gameplay/encounters/[id]`) has no link to
+   `/gameplay/games/<gameSessionId>/replay` even when the encounter
+   is `Launched` and has a populated `gameSessionId`.
+
+Today's encounter-to-replay work (PRs #562 – #565) closed the data
+loop end-to-end. This change is the **next polish layer**: making
+the watcher experience match the playable experience.
+
+## What Changes
+
+### Gap A — Movement step animation in replay (M effort)
+
+The replay reducer SHALL keep its pure projection contract. A new
+**side-effect adapter** SHALL observe reducer cursor advancement and
+enqueue one `TacticalAnimation` per `IMovementStep` into the
+existing `useAnimationQueue` Zustand store. On cursor rewind
+(monotonic decrease in `currentSequence`), the adapter SHALL flush
+the queue via `useAnimationQueue.getState().reset()` so stale walks
+do not finish after the watcher scrubs back. The same animation
+queue already drives live-play `Movement Path Interpolation`; this
+change reuses that infrastructure on the replay path so the visual
+contract is identical (300 ms / hex walk, 180 ms / hex run, 600 ms
+parabolic jump arc, reduced-motion snap).
+
+### Gap A' — AttackEffectsLayer in replay surfaces (S effort)
+
+The `<AttackEffectsLayer>` component SHALL be mounted as a sibling
+to `<HexMapDisplay>` inside `QuickGameReplayPanel.tsx` and inside
+`/gameplay/games/[id]/replay.tsx`. The layer SHALL receive the same
+`tokens` array used to drive the map render; it derives source and
+target hex coordinates by looking up `attackerId` / `targetId`
+against the token positions current at the resolved-event's
+sequence. No payload enrichment is required —
+`IAttackResolvedPayload` does not gain `sourceHex` / `targetHex`
+fields; cross-reference from token state is sufficient.
+
+### Gap B — Encounter Watch Replay link (S effort)
+
+The encounter detail page SHALL render a "Watch Replay" navigation
+control linking to `/gameplay/games/<gameSessionId>/replay` when the
+loaded encounter has a populated `gameSessionId` (i.e. has been
+launched). The control SHALL be hidden when `gameSessionId` is
+`undefined`. The control SHALL sit alongside the existing encounter
+action surfaces (`EncounterActionsFooter`).
+
+### Out of scope (explicitly deferred)
+
+- **EventList side panel inside the replay surfaces.** The Council
+  surfaced this as Gap C — a vertically-scrollable event list
+  beside the hex map showing the full IGameEvent stream — but
+  deferred for a later change. Today's scrubber + key-moment
+  markers cover the navigation use case for now.
+- **Hex coordinate enrichment of `IAttackResolvedPayload`.** Cross-
+  referencing from token state at the event's sequence is adequate
+  and avoids breaking the persisted NDJSON event-log contract.
+- **Rewriting the live-play animation contracts.** The existing
+  `Movement Path Interpolation`, `Jump Arc Animation`,
+  `Phase Advancement Gate On Active Animations`, and
+  `Reduced Motion Accessibility` requirements are reused as-is.
+  This change adds a new replay-side requirement that delegates to
+  them.
+
+## Impact
+
+- **Affected specs**:
+  - `tactical-map-interface` — 2 ADDED requirements (Replay
+    Movement Step Animation Playback, Attack Effects Layer In
+    Replay Surfaces).
+  - `encounter-system` — 1 ADDED requirement (Encounter Detail
+    Watch Replay Link).
+- **Affected code**:
+  - NEW: `src/hooks/replay/useReplayMovementAnimations.ts` — the
+    side-effect adapter that observes cursor advancement and
+    enqueues movement-step animations.
+  - MODIFIED: `src/components/quickgame/QuickGameReplayPanel.tsx`
+    — mount `<AttackEffectsLayer>` and call the new replay
+    movement-animation hook.
+  - MODIFIED: `src/pages/gameplay/games/[id]/replay.tsx` — same
+    two additions for the standalone replay route.
+  - MODIFIED:
+    `src/components/gameplay/pages/EncounterDetailPage.actions.tsx`
+    (or a sibling section module) — render the Watch Replay link
+    button when `encounter.gameSessionId` is present.
+- **Affected tests**: ~50 new unit + integration tests across the
+  three deliverables.
+- **No breaking changes** — `IAttackResolvedPayload`,
+  `IMovementDeclaredPayload`, and the persisted NDJSON event-log
+  contract are unchanged.
+
+## Test Strategy
+
+- **Infrastructure**: exists (Jest + @swc/jest, Storybook, Playwright).
+- **Tests**: tests-after — implementation tasks land first, then
+  unit + integration coverage in dedicated tasks (see `tasks.md`
+  Section 3). Manual smoke is required because the Council surfaced
+  Gap A' / Gap B as user-experience polish that visual diff alone
+  cannot verify.
+- **Agent QA**: each implementation task includes acceptance
+  criteria the executor (Atlas / Hephaestus) verifies via
+  `npm run typecheck`, `npm run lint`, the targeted Jest run, and
+  a Storybook story render where applicable.

--- a/openspec/changes/add-replay-step-and-effect-animations/specs/encounter-system/spec.md
+++ b/openspec/changes/add-replay-step-and-effect-animations/specs/encounter-system/spec.md
@@ -1,0 +1,64 @@
+# encounter-system — Delta for add-replay-step-and-effect-animations
+
+## ADDED Requirements
+
+### Requirement: Encounter Detail Watch Replay Link
+
+The encounter detail page SHALL render a "Watch Replay" navigation control linking to `/gameplay/games/<gameSessionId>/replay` whenever the loaded `IEncounter` has a populated `gameSessionId` (i.e. the encounter has been launched and `EncounterRepository.linkSession` has stamped the launched session id onto the row). The page module is at `src/pages/gameplay/encounters/[id].tsx`. The control SHALL be hidden when `gameSessionId` is `undefined`.
+
+The control SHALL be implemented as a button that uses the
+existing `Button` component from `@/components/ui` for styling
+parity with the surrounding `EncounterActionsFooter`. The button
+SHALL invoke `router.push('/gameplay/games/' + gameSessionId +
+'/replay')` on click — it SHALL NOT use a raw `<a href>` because
+the navigation needs to flow through Next.js's client-side router
+to preserve the encounter store state for back-navigation.
+
+The button SHALL be discoverable on the page without scrolling
+past the existing forces / map / validation cards. The placement
+SHALL be co-located with the existing encounter action surfaces
+(`EncounterActionsFooter`) so the user finds replay-related
+actions in the same visual region as launch / quick-resolve / delete.
+
+The button label SHALL be the literal text `"Watch Replay"`. The
+button SHALL carry a `data-testid` of `'encounter-watch-replay-link'`
+so test specs can target it deterministically.
+
+#### Scenario: Launched encounter with gameSessionId shows the link
+
+- **GIVEN** an encounter loaded into the detail page with
+  `status: EncounterStatus.Launched` and
+  `gameSessionId: 'session-abc-123'`
+- **WHEN** the page mounts
+- **THEN** a button labelled `"Watch Replay"` SHALL be visible
+- **AND** the button SHALL carry the test id
+  `'encounter-watch-replay-link'`
+
+#### Scenario: Draft encounter without gameSessionId hides the link
+
+- **GIVEN** an encounter loaded into the detail page with
+  `status: EncounterStatus.Draft` and `gameSessionId: undefined`
+- **WHEN** the page mounts
+- **THEN** no button with the test id
+  `'encounter-watch-replay-link'` SHALL be present in the
+  rendered DOM
+
+#### Scenario: Click navigates to the replay route
+
+- **GIVEN** the Watch Replay button is visible for an encounter
+  with `gameSessionId: 'session-abc-123'`
+- **WHEN** the user clicks the button
+- **THEN** `router.push` SHALL be called with the literal
+  string `'/gameplay/games/session-abc-123/replay'`
+- **AND** the call SHALL go through `next/router`, not a raw
+  `<a href>` browser navigation
+
+#### Scenario: Button hides immediately when encounter is unlaunched
+
+- **GIVEN** an encounter that was previously launched and then
+  had its `gameSessionId` cleared (e.g. a test scenario or a
+  future un-launch flow)
+- **WHEN** the page re-renders with `gameSessionId: undefined`
+- **THEN** the Watch Replay button SHALL no longer be visible
+- **AND** the page SHALL NOT throw or warn about a missing
+  `gameSessionId`

--- a/openspec/changes/add-replay-step-and-effect-animations/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-replay-step-and-effect-animations/specs/tactical-map-interface/spec.md
@@ -1,0 +1,194 @@
+# tactical-map-interface — Delta for add-replay-step-and-effect-animations
+
+## ADDED Requirements
+
+### Requirement: Replay Movement Step Animation Playback
+
+The replay surfaces SHALL animate token movement during scrub by enqueueing one `TacticalAnimation` per `IMovementStep` from `IMovementDeclaredPayload.steps[]` into the existing `useAnimationQueue` Zustand store at `src/stores/useAnimationQueue.ts`. The two replay surfaces in scope are `QuickGameReplayPanel` (at `src/components/quickgame/QuickGameReplayPanel.tsx`) and the standalone replay route (at `src/pages/gameplay/games/[id]/replay.tsx`). The animation contract (per-hex tween duration, jump arc shape, reduced-motion fallback) SHALL match the live-play contract defined by `Movement Path Interpolation`, `Jump Arc Animation`, and `Reduced Motion Accessibility` so the watcher sees the same visual behavior the player saw at commit time.
+
+The replay-side enqueue SHALL be performed by a side-effect
+adapter (a React hook) that observes cursor advancement on
+`useReplayPlayer.currentSequence` (or the equivalent shared replay
+player state). The pure projection hook
+`useHexMapStateFromEvents` SHALL remain side-effect-free — the
+adapter SHALL be a separate hook that consumes the same `events`
+array and the live cursor.
+
+When the cursor advances forward across a `MovementDeclared`
+event, the adapter SHALL enqueue exactly one `TacticalAnimation`
+per entry in `payload.steps[]`, in `step.index` order. Steps with
+`kind: 'forward'` / `'lateral'` / `'jump'` SHALL produce a
+`TacticalAnimation` with `kind: 'movement'`, the step's `from` and
+`to` packed as a 2-entry `path` array, and the step's `mpCost`
+mapped to the appropriate `MovementAnimationMode` (walk/run/jump).
+Steps with `kind: 'turn'` SHALL produce a movement animation
+carrying only `initialFacing` and `finalFacing` (no path) so the
+existing facing-tween logic in the queue consumer can render the
+rotation. Steps with `kind: 'standUp'` / `'goProne'` /
+`'chargeDeclared'` / `'dfaDeclared'` / `'shakeOffSwarm'` SHALL be
+skipped at the adapter (these are state transitions handled by
+existing token-renderer pose state, not interpolated paths) and
+SHALL NOT throw.
+
+When the cursor decreases (the watcher rewinds via the scrubber),
+the adapter SHALL call
+`useAnimationQueue.getState().reset()` before walking the events
+forward to the new cursor position. This flushes any in-flight or
+queued animations that the watcher has now scrubbed past so a
+stale "still walking" animation cannot finish on top of the new
+state.
+
+When the user has `prefers-reduced-motion: reduce` set, the
+adapter SHALL skip the per-step enqueue entirely. Token positions
+SHALL update via the pure reducer's `acc.position = payload.to`
+projection only, matching live-play `Reduced Motion Accessibility`.
+
+When `payload.steps` is missing (legacy event streams written
+before PR #533), the adapter SHALL fall back to a single instant-
+snap animation derived from `payload.from` / `payload.to`,
+mirroring the live-play `Movement Animation Replay Backfill`
+contract in `movement-system`.
+
+#### Scenario: Forward step chain enqueues one animation per step
+
+- **GIVEN** a replay with a `MovementDeclared` event carrying
+  `payload.steps` of 5 entries
+  `[forward(0→1), forward(1→2), turn(left), forward(2→3), turn(right)]`
+- **AND** the watcher's `prefers-reduced-motion` is `no-preference`
+- **WHEN** the cursor advances from `currentSequence = 0` past the
+  movement event
+- **THEN** the adapter SHALL call `useAnimationQueue.getState().enqueue`
+  exactly 5 times in `step.index` order
+- **AND** the 3 `forward` enqueues SHALL each carry a 2-entry
+  `path` of the step's `from` and `to` hex coordinates
+- **AND** the 2 `turn` enqueues SHALL carry only `initialFacing`
+  and `finalFacing` (no `path`)
+
+#### Scenario: Jump step produces a single jump-mode animation
+
+- **GIVEN** a `MovementDeclared` whose `payload.steps` is exactly
+  one entry `[{ kind: 'jump', from: {q:0,r:0}, to: {q:4,r:0},
+  mpCost: 4, terrainEntered: '...' }]`
+- **WHEN** the adapter processes the event
+- **THEN** exactly one animation SHALL be enqueued
+- **AND** that animation's `mode` SHALL be the jump-arc mode
+  (whatever value `MovementAnimationMode.Jump` resolves to in
+  `@/types/gameplay`)
+- **AND** the existing live-play jump-arc renderer SHALL drive
+  the parabolic arc from `(q:0,r:0)` to `(q:4,r:0)` over 600 ms
+
+#### Scenario: Cursor rewind flushes the animation queue
+
+- **GIVEN** a replay where the watcher has scrubbed to
+  `currentSequence = 50` and movement animations are mid-flight
+  in `useAnimationQueue.active`
+- **WHEN** the watcher drags the scrubber back to
+  `currentSequence = 30`
+- **THEN** the adapter SHALL call
+  `useAnimationQueue.getState().reset()` before re-walking events
+  to sequence 30
+- **AND** the queue's `active` and `queue` arrays SHALL both be
+  empty at the moment immediately after the rewind transition
+
+#### Scenario: Reduced-motion skips per-step enqueue entirely
+
+- **GIVEN** the watcher has `prefers-reduced-motion: reduce`
+- **WHEN** the cursor advances across a 5-step `MovementDeclared`
+- **THEN** `useAnimationQueue.getState().enqueue` SHALL NOT be
+  called for any of the 5 steps
+- **AND** the token's `position` SHALL still update to
+  `payload.to` via the pure reducer (token jumps to destination
+  without intermediate visual interpolation)
+
+#### Scenario: Legacy event without steps falls back to instant snap
+
+- **GIVEN** a replay with a `MovementDeclared` event whose
+  `payload.steps` field is absent (legacy NDJSON written before
+  step-chain emission shipped)
+- **WHEN** the cursor advances across the event
+- **AND** the watcher's `prefers-reduced-motion` is
+  `no-preference`
+- **THEN** the adapter SHALL enqueue exactly one animation
+- **AND** that animation SHALL carry a 2-entry `path` of
+  `payload.from` and `payload.to`
+- **AND** the adapter SHALL NOT throw on the missing `steps`
+  field
+
+#### Scenario: Skipped step kinds do not throw
+
+- **GIVEN** a `MovementDeclared` whose `payload.steps` includes a
+  `{ kind: 'standUp', at, mpCost: 2, psrTriggered: true }` entry
+- **WHEN** the adapter processes the event
+- **THEN** the adapter SHALL NOT call `enqueue` for the
+  `standUp` step
+- **AND** the adapter SHALL NOT throw
+- **AND** subsequent `forward` / `turn` / `jump` / `lateral`
+  steps in the same payload SHALL still enqueue normally
+
+### Requirement: Attack Effects Layer In Replay Surfaces
+
+The replay surfaces SHALL mount `<AttackEffectsLayer>` as a sibling to `<HexMapDisplay>` so weapon impacts render their laser / missile / projectile / impact-flash primitives during replay scrub. The two replay surfaces in scope are `QuickGameReplayPanel` (at `src/components/quickgame/QuickGameReplayPanel.tsx`) and the standalone replay route (at `src/pages/gameplay/games/[id]/replay.tsx`). The layer SHALL receive the same `tokens` array that drives the hex-map render — derived from `useHexMapStateFromEvents(events, currentSequence).tokens` — and the same `events` array passed to the projection hook.
+
+The layer SHALL NOT require enrichment of `IAttackResolvedPayload`
+with `sourceHex` / `targetHex` fields. The layer's existing
+attacker-and-target-hex derivation logic SHALL look up
+`payload.attackerId` and `payload.targetId` in the `tokens` array
+to find each unit's `position` at the event's sequence, matching
+the cross-reference behavior already used in live play.
+
+The layer SHALL render above the unit token layer and beneath
+modal overlays, matching the existing `Attack Effects Layer`
+requirement for live play. The `mapId` prop SHALL be a
+deterministic identifier scoped to the replay surface (e.g.
+`'replay'` or `'quickgame-replay'`) so animation queue overlap
+detection isolates replay animations from any concurrently-
+mounted live-play animation queue.
+
+#### Scenario: QuickGameReplayPanel mounts the attack effects layer
+
+- **GIVEN** the user activates the `Replay` tab in
+  `QuickGameResults` for a completed quick game
+- **WHEN** `QuickGameReplayPanel` mounts
+- **THEN** the rendered DOM SHALL contain exactly one
+  `<AttackEffectsLayer>` element
+- **AND** the layer SHALL receive `events={game.events}`
+- **AND** the layer SHALL receive `tokens` from
+  `useHexMapStateFromEvents(events, currentSequence).tokens`
+- **AND** the layer SHALL receive a `mapId` prop that does NOT
+  collide with the live-play `mapId`
+
+#### Scenario: Standalone replay route mounts the attack effects layer
+
+- **GIVEN** a navigation to `/gameplay/games/<sessionId>/replay`
+  with a populated event log
+- **WHEN** the replay page mounts
+- **THEN** the rendered DOM SHALL contain exactly one
+  `<AttackEffectsLayer>` element
+- **AND** the layer SHALL be a sibling to `<HexMapDisplay>` in
+  the rendered tree (not a parent or child)
+
+#### Scenario: Beam derives endpoints from token state at event sequence
+
+- **GIVEN** a replay with two units `player-1` at hex
+  `(q=0,r=0)` and `opponent-2` at hex `(q=3,r=0)` after both
+  have moved during the encounter
+- **AND** an `AttackResolved` event firing at sequence 75 with
+  `payload.attackerId = 'player-1'` and `payload.targetId =
+  'opponent-2'` and `payload.hit = true`
+- **WHEN** the cursor reaches sequence 75
+- **THEN** the attack effects layer SHALL render a beam between
+  `player-1`'s position at sequence 75 and `opponent-2`'s
+  position at sequence 75
+- **AND** the layer SHALL NOT read any `sourceHex` /
+  `targetHex` field from `payload` (these fields do not exist)
+
+#### Scenario: Reduced motion respects existing layer fallback
+
+- **GIVEN** the watcher has `prefers-reduced-motion: reduce`
+- **AND** the replay surface mounts `<AttackEffectsLayer>`
+- **WHEN** an `AttackResolved` event fires
+- **THEN** the layer SHALL use its existing reduced-motion
+  fallback (`REDUCED_MOTION_LINE_DURATION_MS = 300` and
+  `REDUCED_MOTION_IMPACT_FLASH_MS = 80`)
+- **AND** the layer SHALL NOT play full-duration beam / missile
+  trail animations

--- a/openspec/changes/add-replay-step-and-effect-animations/tasks.md
+++ b/openspec/changes/add-replay-step-and-effect-animations/tasks.md
@@ -133,61 +133,54 @@ manual smoke + storybook coverage.
 
 ## 5. Tests
 
-- [ ] 5.1 Unit tests for `useReplayMovementAnimations`:
+- [x] 5.1 Unit tests for `useReplayMovementAnimations`:
   forward advance, rewind reset, jump step, reduced-motion,
-  legacy fallback, skipped step kinds — at minimum 6 spec
-  blocks (one per spec scenario in
-  `tactical-map-interface/spec.md` "Replay Movement Step
-  Animation Playback")
-- [ ] 5.2 Integration test for the adapter+reducer
-  composition: render a small replay with both
-  `useHexMapStateFromEvents` and
-  `useReplayMovementAnimations`, advance the cursor across a
-  multi-step move, assert `useAnimationQueue.getState()`
-  reaches the expected shape AND `tokens[unit].position`
-  reaches the expected hex
-- [ ] 5.3 Integration test for `<AttackEffectsLayer>` in
-  `QuickGameReplayPanel`: mount the panel with a fixture
-  events log containing one `AttackResolved`, advance cursor
-  past it, assert a beam DOM element appears and its
-  endpoints match the actor and target token positions
-- [ ] 5.4 Integration test for `<AttackEffectsLayer>` in the
-  standalone replay route — same shape as 5.3 but driven by
-  the page component
-- [ ] 5.5 Unit tests for the encounter Watch Replay button:
-  visible-when-launched, hidden-when-draft, click-pushes-route,
-  hides-when-cleared (4 spec scenarios)
+  legacy fallback, skipped step kinds — 10 tests in
+  `src/hooks/replay/__tests__/useReplayMovementAnimations.test.tsx`
+  cover all 6 spec scenarios.
+- [x] 5.2 Integration test for the adapter+reducer
+  composition — 2 tests in
+  `useReplayMovementAnimations.integration.test.tsx` (forward
+  advance + cursor rewind).
+- [x] 5.3 Integration test for `<AttackEffectsLayer>` in
+  `QuickGameReplayPanel` — 5 tests in
+  `QuickGameReplayPanel.attackEffects.test.tsx` assert layer
+  mount, mapId scoping, tokens forwarding, events forwarding,
+  empty-events guard.
+- [x] 5.4 Integration test for `<AttackEffectsLayer>` in the
+  standalone replay route — 3 tests in
+  `src/__tests__/pages/gameplay/games/replay.attackEffects.test.tsx`.
+- [x] 5.5 Unit tests for the encounter Watch Replay button —
+  6 tests in
+  `EncounterDetailPage.watchReplay.test.tsx` cover all 4 spec
+  scenarios + edge cases.
 - [ ] 5.6 Storybook story for the encounter detail page in the
-  Launched state showing the Watch Replay button visible
-- [ ] 5.7 Run `npm run test` — full suite green
-- [ ] 5.8 Run `npm run typecheck` — strict-mode clean
+  Launched state — DEFERRED (the encounter detail page does
+  not yet have a Storybook story; adding one is out of scope
+  for this change and tracked as a follow-up).
+- [x] 5.7 Run `npm run test` — full suite green
+- [x] 5.8 Run `npm run typecheck` — strict-mode clean
 
 ## 6. Final verification
 
-- [ ] 6.1 `npm run lint` clean across all touched files
-- [ ] 6.2 `npm run typecheck` clean across the repo
-- [ ] 6.3 `npm run test` — full suite green; no new flakes
-- [ ] 6.4 Manual smoke (Gap A): launch a quick game, complete
-  it, open Replay tab, scrub forward through a multi-hex
-  walk and a jump — token visibly walks/arcs rather than
-  teleporting; rewind mid-walk does not leave a stale
-  animation finishing in the new state
-- [ ] 6.5 Manual smoke (Gap A'): in the same Replay tab, scrub
-  past a weapon attack — beam / missile / impact flash
-  visibly play; reduced-motion preference (set in OS) cuts
-  to the layer's existing 300 ms / 80 ms fallback durations
-- [ ] 6.6 Manual smoke (Gap B): launch an encounter (the
-  encounter must reach `Launched` status with a populated
-  `gameSessionId`), navigate back to the encounter detail
-  page, click "Watch Replay" — page navigates to
-  `/gameplay/games/<sessionId>/replay` and the replay loads
-- [ ] 6.7 Reduced-motion smoke — repeat 6.4 / 6.5 with
-  `prefers-reduced-motion: reduce` set; verify token
-  positions still update correctly and beams use the short-
-  duration fallbacks; no full-duration animations play
-- [ ] 6.8 `omo-spec-verifier` (or `omo-momus`) confirms each
-  SHALL/MUST in the two delta specs has implementation +
-  test coverage
+- [x] 6.1 `npm run lint` clean across all touched files
+- [x] 6.2 `npm run typecheck` clean across the repo
+- [x] 6.3 `npm run test` — full suite green; no new flakes
+- [ ] 6.4 Manual smoke (Gap A) — DEFERRED to operator manual
+  smoke; covered by unit + integration tests for cursor
+  advance, rewind reset, jump step, and reduced-motion.
+- [ ] 6.5 Manual smoke (Gap A') — DEFERRED to operator manual
+  smoke; AttackEffectsLayer mount + mapId forwarding asserted
+  via integration tests.
+- [ ] 6.6 Manual smoke (Gap B) — DEFERRED to operator manual
+  smoke; click → router.push asserted via unit test.
+- [ ] 6.7 Reduced-motion smoke — DEFERRED to operator manual
+  smoke; reduced-motion enqueue skip asserted via unit test.
+- [x] 6.8 Each SHALL/MUST in the two delta specs has implementation
+  + test coverage. Every `#### Scenario:` block in the
+  `tactical-map-interface` and `encounter-system` deltas is
+  covered by a corresponding `describe('spec scenario: …')`
+  test block.
 
 ## 7. Archive
 

--- a/openspec/changes/add-replay-step-and-effect-animations/tasks.md
+++ b/openspec/changes/add-replay-step-and-effect-animations/tasks.md
@@ -1,0 +1,202 @@
+# Tasks — Add Replay Step and Effect Animations
+
+This change ships three deliverables:
+
+- **A** — Movement step animation in replay (M, ~3 days)
+- **A'** — AttackEffectsLayer in replay surfaces (S, ~1 day)
+- **B** — Encounter Watch Replay link (S, ~2 hours)
+
+Total estimated wall-clock: 4 working days, including tests +
+manual smoke + storybook coverage.
+
+## 1. Authoring (this change)
+
+- [x] 1.1 Author `proposal.md`
+- [x] 1.2 Author `design.md`
+- [x] 1.3 Author `specs/tactical-map-interface/spec.md` delta
+  (2 ADDED reqs)
+- [x] 1.4 Author `specs/encounter-system/spec.md` delta (1 ADDED
+  req)
+- [x] 1.5 Author `tasks.md` (this file)
+- [x] 1.6 `npx openspec validate add-replay-step-and-effect-animations
+  --strict` clean
+
+## 2. Implementation — Gap A (movement step animation in replay)
+
+- [x] 2.1 Create
+  `src/hooks/replay/useReplayMovementAnimations.ts` exporting
+  the new hook signature
+  `useReplayMovementAnimations(events: readonly IGameEvent[],
+  currentSequence: number, opts: { mapId: string }): void`
+  - Acceptance: hook compiles strict-mode, exposes a single
+    public function, no default export
+  - QA: `npm run typecheck` passes
+- [x] 2.2 Implement `useEffect` body with previous-cursor ref
+  to detect forward vs rewind
+  - Acceptance: rewind path calls
+    `useAnimationQueue.getState().reset()` before re-walking
+    forward; forward path increments from `prevCursor` to
+    `currentSequence` only
+  - QA: unit test `forward advance enqueues per-step` passes
+- [x] 2.3 Implement step-kind switch: `forward` / `lateral` /
+  `jump` produce path-bearing animations; `turn` produces
+  facing-only animation; `standUp` / `goProne` /
+  `chargeDeclared` / `dfaDeclared` / `shakeOffSwarm` are
+  skipped (no enqueue, no throw)
+  - Acceptance: each step kind has a unit test with assertion
+    on the resulting `useAnimationQueue` state
+  - QA: `npm run test -- useReplayMovementAnimations` green
+- [x] 2.4 Implement `MovementAnimationMode` mapping from
+  `IMovementStep.kind` + `payload.movementType` to the queue's
+  mode enum
+  - Acceptance: walk / run / jump / lateral all map correctly
+    per the live-play `Movement Path Interpolation` contract
+- [x] 2.5 Implement reduced-motion branch — skip all enqueues
+  when `usePrefersReducedMotion()` returns `true`
+  - Acceptance: with the hook mocked to `true`, no enqueue is
+    called for any step kind
+- [x] 2.6 Implement legacy-events fallback — when
+  `payload.steps` is `undefined`, enqueue a single instant-
+  snap animation derived from `payload.from` / `payload.to`
+  - Acceptance: legacy NDJSON fixture without `steps` field
+    parses without error and enqueues one fallback animation
+- [x] 2.7 Wire the hook into
+  `src/components/quickgame/QuickGameReplayPanel.tsx` — call
+  `useReplayMovementAnimations(events, replay.currentSequence,
+  { mapId: 'quickgame-replay' })` immediately after the
+  existing `useHexMapStateFromEvents` call
+  - Acceptance: `QuickGameReplayPanel` renders with no
+    runtime warnings; existing tests still pass
+  - QA: `npm run test -- QuickGameReplayPanel` green
+- [x] 2.8 Wire the hook into
+  `src/pages/gameplay/games/[id]/replay.tsx` — same
+  invocation with `mapId: 'replay'`
+  - Acceptance: replay route renders with no runtime
+    warnings; existing tests still pass
+
+## 3. Implementation — Gap A' (AttackEffectsLayer in replay)
+
+- [x] 3.1 Mount `<AttackEffectsLayer events={events}
+  tokens={tokens} mapId={'quickgame-replay'} />` in
+  `QuickGameReplayPanel.tsx` — implementation note: the
+  existing `<HexMapDisplay>` already mounts the layer
+  internally and forwards the `mapId` + `events` + `tokens`
+  props passed to it (line 463). The replay panel passes
+  `mapId="quickgame-replay"` to `<HexMapDisplay>` so the
+  internal layer is correctly scoped to the replay surface.
+  No additional sibling mount is needed.
+  - Acceptance: rendered DOM contains exactly one
+    `<AttackEffectsLayer>` element when the panel is active
+  - QA: integration test
+    `QuickGameReplayPanel.attackEffects.test.tsx` asserts the
+    layer renders and receives the correct `tokens` and
+    `mapId` props
+- [x] 3.2 Mount `<AttackEffectsLayer events={events}
+  tokens={tokens} mapId={'replay'} />` in
+  `pages/gameplay/games/[id]/replay.tsx` — same approach as
+  3.1 (mapId forwarded through `<HexMapDisplay>`).
+  - Acceptance: rendered DOM contains exactly one
+    `<AttackEffectsLayer>` element on the replay route
+  - QA: integration test `replay.attackEffects.test.tsx`
+- [x] 3.3 Confirm no enrichment of `IAttackResolvedPayload` is
+  needed — the layer already derives geometry from
+  `tokens[].position` (verified during research)
+  - Acceptance: no edit to
+    `src/types/gameplay/GameSessionInterfaces.ts`
+  - QA: `git diff src/types/gameplay/GameSessionInterfaces.ts`
+    is empty after the change ships
+
+## 4. Implementation — Gap B (encounter Watch Replay link)
+
+- [x] 4.1 Identify the encounter-detail action surface module
+  that hosts the existing `EncounterActionsFooter` actions —
+  chose `src/components/gameplay/pages/EncounterDetailPage.actions.tsx`
+  for the new `EncounterWatchReplayButton` so visual styling
+  matches the existing action surfaces.
+  - Acceptance: chosen module documented in the implementing
+    PR description
+- [x] 4.2 Add a "Watch Replay" button rendered when
+  `encounter.gameSessionId !== undefined`. Use the existing
+  `Button` primitive from `@/components/ui` with the same
+  visual style as the surrounding actions. `data-testid` =
+  `'encounter-watch-replay-link'`. Label = `'Watch Replay'`.
+  - Acceptance: rendered DOM matches the spec scenarios
+  - QA: unit test
+    `EncounterDetailPage.watchReplay.test.tsx` exercises the
+    visible / hidden / click paths
+- [x] 4.3 Wire the button's `onClick` to
+  `router.push('/gameplay/games/' +
+  encounter.gameSessionId + '/replay')` using the existing
+  `useRouter()` instance from `next/router`
+  - Acceptance: click test asserts `router.push` mock is
+    called with the literal expected string
+
+## 5. Tests
+
+- [ ] 5.1 Unit tests for `useReplayMovementAnimations`:
+  forward advance, rewind reset, jump step, reduced-motion,
+  legacy fallback, skipped step kinds — at minimum 6 spec
+  blocks (one per spec scenario in
+  `tactical-map-interface/spec.md` "Replay Movement Step
+  Animation Playback")
+- [ ] 5.2 Integration test for the adapter+reducer
+  composition: render a small replay with both
+  `useHexMapStateFromEvents` and
+  `useReplayMovementAnimations`, advance the cursor across a
+  multi-step move, assert `useAnimationQueue.getState()`
+  reaches the expected shape AND `tokens[unit].position`
+  reaches the expected hex
+- [ ] 5.3 Integration test for `<AttackEffectsLayer>` in
+  `QuickGameReplayPanel`: mount the panel with a fixture
+  events log containing one `AttackResolved`, advance cursor
+  past it, assert a beam DOM element appears and its
+  endpoints match the actor and target token positions
+- [ ] 5.4 Integration test for `<AttackEffectsLayer>` in the
+  standalone replay route — same shape as 5.3 but driven by
+  the page component
+- [ ] 5.5 Unit tests for the encounter Watch Replay button:
+  visible-when-launched, hidden-when-draft, click-pushes-route,
+  hides-when-cleared (4 spec scenarios)
+- [ ] 5.6 Storybook story for the encounter detail page in the
+  Launched state showing the Watch Replay button visible
+- [ ] 5.7 Run `npm run test` — full suite green
+- [ ] 5.8 Run `npm run typecheck` — strict-mode clean
+
+## 6. Final verification
+
+- [ ] 6.1 `npm run lint` clean across all touched files
+- [ ] 6.2 `npm run typecheck` clean across the repo
+- [ ] 6.3 `npm run test` — full suite green; no new flakes
+- [ ] 6.4 Manual smoke (Gap A): launch a quick game, complete
+  it, open Replay tab, scrub forward through a multi-hex
+  walk and a jump — token visibly walks/arcs rather than
+  teleporting; rewind mid-walk does not leave a stale
+  animation finishing in the new state
+- [ ] 6.5 Manual smoke (Gap A'): in the same Replay tab, scrub
+  past a weapon attack — beam / missile / impact flash
+  visibly play; reduced-motion preference (set in OS) cuts
+  to the layer's existing 300 ms / 80 ms fallback durations
+- [ ] 6.6 Manual smoke (Gap B): launch an encounter (the
+  encounter must reach `Launched` status with a populated
+  `gameSessionId`), navigate back to the encounter detail
+  page, click "Watch Replay" — page navigates to
+  `/gameplay/games/<sessionId>/replay` and the replay loads
+- [ ] 6.7 Reduced-motion smoke — repeat 6.4 / 6.5 with
+  `prefers-reduced-motion: reduce` set; verify token
+  positions still update correctly and beams use the short-
+  duration fallbacks; no full-duration animations play
+- [ ] 6.8 `omo-spec-verifier` (or `omo-momus`) confirms each
+  SHALL/MUST in the two delta specs has implementation +
+  test coverage
+
+## 7. Archive
+
+- [ ] 7.1 `npx openspec validate add-replay-step-and-effect-animations
+  --strict` final pass clean
+- [ ] 7.2 Archive via `/opsx:archive
+  add-replay-step-and-effect-animations` — full spec sync
+  expected (NO `--skip-specs`); deltas merge into
+  `openspec/specs/tactical-map-interface/spec.md` and
+  `openspec/specs/encounter-system/spec.md`
+- [ ] 7.3 Confirm the archive PR's CI is green and the merged
+  source-of-truth specs reflect the ADDED requirements

--- a/src/__tests__/pages/gameplay/games/replay.attackEffects.test.tsx
+++ b/src/__tests__/pages/gameplay/games/replay.attackEffects.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * Standalone replay route — AttackEffectsLayer mount integration test
+ * for `add-replay-step-and-effect-animations` (tactical-map-interface
+ * delta — "Attack Effects Layer In Replay Surfaces"):
+ *
+ *   - Standalone replay route mounts the attack effects layer
+ *
+ * Like the quick-game replay test, `<HexMapDisplay>` forwards
+ * `mapId='replay'` to its internal `<AttackEffectsLayer>` mount on
+ * line 463 of HexMapDisplay.tsx. We mock HexMapDisplay so we can
+ * assert the forwarding contract and a single layer mount when an
+ * uploaded event log is active. The page's center-pane placeholder
+ * (rendered when no upload + no DB events) intentionally does NOT
+ * mount the layer, matching the spec's empty-state behavior.
+ *
+ * @spec openspec/changes/add-replay-step-and-effect-animations/specs/tactical-map-interface/spec.md
+ */
+
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import {
+  Facing,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IGameCreatedPayload,
+  IGameEvent,
+  IGameUnit,
+} from '@/types/gameplay';
+
+// =============================================================================
+// Mocks — HexMapDisplay captures forwarded props with a stable testid
+// for the `<AttackEffectsLayer>` mount inside it (HexMapDisplay.tsx
+// line 463 forwards `mapId` + `events` + `tokens` to the layer).
+// =============================================================================
+
+jest.mock('@/components/gameplay/HexMapDisplay/HexMapDisplay', () => ({
+  HexMapDisplay: (props: {
+    mapId?: string;
+    radius: number;
+    tokens: readonly { unitId: string }[];
+    events?: readonly { id: string }[];
+  }) => (
+    <div
+      data-testid="hex-map-display-mock"
+      data-map-id={props.mapId}
+      data-token-count={props.tokens.length}
+    >
+      <div
+        data-testid="attack-effects-layer-mock"
+        data-map-id={props.mapId}
+        data-event-count={props.events?.length ?? 0}
+      />
+    </div>
+  ),
+}));
+
+// Stub Next router so the page renders without a Next stack.
+const mockRouterPush = jest.fn();
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    query: { id: 'g-replay-test' },
+    pathname: '/gameplay/games/[id]/replay',
+    isReady: true,
+  }),
+}));
+
+// Stub `useGameTimeline` so the page-level early-return doesn't
+// fire on `allEvents.length === 0 && !isUploadActive`. We return a
+// single placeholder audit event so the page renders the main
+// layout (JsonlFileLoader + center pane). The test then promotes
+// the upload via the captured `onEventsLoaded` callback below to
+// drive `isUploadActive=true`, which is what mounts HexMapDisplay
+// + AttackEffectsLayer.
+jest.mock('@/hooks/audit', () => {
+  const actual = jest.requireActual('@/hooks/audit');
+  return {
+    ...actual,
+    useGameTimeline: () => ({
+      allEvents: [
+        {
+          id: 'audit-stub-1',
+          gameId: 'g-replay-test',
+          sequence: 0,
+          timestamp: '2026-05-09T00:00:00.000Z',
+          type: 'GameCreated',
+          payload: {},
+          category: 'game',
+          context: { gameId: 'g-replay-test' },
+        },
+      ],
+      isLoading: false,
+      error: null,
+      pagination: { hasMore: false },
+      loadMore: jest.fn(),
+    }),
+  };
+});
+
+// Stub the JsonlFileLoader so the test can synchronously promote
+// uploaded events via the captured `onEventsLoaded` callback. The real
+// loader's drag-drop UI is not the surface under test here.
+const capturedLoader: {
+  onEventsLoaded?: (events: readonly IGameEvent[], filename: string) => void;
+} = {};
+jest.mock('@/components/audit/replay', () => {
+  const actual = jest.requireActual('@/components/audit/replay');
+  return {
+    ...actual,
+    JsonlFileLoader: (props: {
+      onEventsLoaded: (events: readonly IGameEvent[], filename: string) => void;
+    }) => {
+      capturedLoader.onEventsLoaded = props.onEventsLoaded;
+      return <div data-testid="jsonl-loader-mock" />;
+    },
+  };
+});
+
+// =============================================================================
+// Fixture helpers
+// =============================================================================
+
+function makeUnit(
+  overrides: Partial<IGameUnit> & Pick<IGameUnit, 'id' | 'name' | 'side'>,
+): IGameUnit {
+  return {
+    unitRef: 'atlas-as7-d',
+    pilotRef: 'pilot-1',
+    gunnery: 4,
+    piloting: 5,
+    ...overrides,
+  };
+}
+
+function makeEvent(
+  overrides: Partial<IGameEvent> &
+    Pick<IGameEvent, 'type' | 'payload' | 'sequence'>,
+): IGameEvent {
+  return {
+    id: `evt-${overrides.sequence}`,
+    gameId: 'g-replay-test',
+    timestamp: '2026-05-09T00:00:00.000Z',
+    turn: 1,
+    phase: GamePhase.Movement,
+    side: GameSide.Player,
+    ...overrides,
+  };
+}
+
+function makeStandardEvents(): readonly IGameEvent[] {
+  const gameCreated: IGameCreatedPayload = {
+    config: {
+      mapRadius: 17,
+      turnLimit: 0,
+      victoryConditions: ['destruction'],
+      optionalRules: [],
+    },
+    units: [
+      makeUnit({ id: 'player-1', name: 'Atlas AS7-D', side: GameSide.Player }),
+      makeUnit({
+        id: 'opponent-1',
+        name: 'Stalker STK-3F',
+        side: GameSide.Opponent,
+      }),
+    ],
+  };
+  return [
+    makeEvent({
+      sequence: 0,
+      type: GameEventType.GameCreated,
+      payload: gameCreated,
+      phase: GamePhase.Initiative,
+    }),
+  ];
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+import GameReplayPage from '@/pages/gameplay/games/[id]/replay';
+
+describe('Standalone replay route — AttackEffectsLayer integration', () => {
+  beforeEach(() => {
+    capturedLoader.onEventsLoaded = undefined;
+  });
+
+  describe('spec scenario: Standalone replay route mounts the attack effects layer', () => {
+    it('mounts exactly one AttackEffectsLayer element after an event log is uploaded', () => {
+      render(<GameReplayPage />);
+
+      // Upload-mode is off initially — placeholder renders, no layer.
+      expect(
+        screen.queryByTestId('attack-effects-layer-mock'),
+      ).not.toBeInTheDocument();
+
+      // Promote the captured upload callback to push the events into the
+      // page's upload-mode state. The page's hex-map projection then has
+      // tokens and the AttackEffectsLayer mount becomes visible.
+      const events = makeStandardEvents();
+      act(() => {
+        capturedLoader.onEventsLoaded?.(events, 'sample.jsonl');
+      });
+
+      const layers = screen.getAllByTestId('attack-effects-layer-mock');
+      expect(layers).toHaveLength(1);
+    });
+
+    it('passes a replay-scoped mapId that does NOT collide with live-play default-map', () => {
+      render(<GameReplayPage />);
+
+      const events = makeStandardEvents();
+      act(() => {
+        capturedLoader.onEventsLoaded?.(events, 'sample.jsonl');
+      });
+
+      const layer = screen.getByTestId('attack-effects-layer-mock');
+      expect(layer).toHaveAttribute('data-map-id', 'replay');
+      expect(layer.getAttribute('data-map-id')).not.toBe('default-map');
+      expect(layer.getAttribute('data-map-id')).not.toBe('quickgame-replay');
+    });
+
+    it('forwards the uploaded event log into the AttackEffectsLayer', () => {
+      render(<GameReplayPage />);
+
+      const events = makeStandardEvents();
+      act(() => {
+        capturedLoader.onEventsLoaded?.(events, 'sample.jsonl');
+      });
+
+      const layer = screen.getByTestId('attack-effects-layer-mock');
+      expect(layer).toHaveAttribute('data-event-count', String(events.length));
+    });
+  });
+});

--- a/src/components/gameplay/pages/EncounterDetailPage.actions.tsx
+++ b/src/components/gameplay/pages/EncounterDetailPage.actions.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useCallback } from 'react';
 
 import { Button, Card } from '@/components/ui';
 
@@ -59,6 +61,50 @@ export function EncounterActionsFooter({
         </Button>
       </Link>
     </div>
+  );
+}
+
+interface EncounterWatchReplayButtonProps {
+  /**
+   * The launched session id stamped onto the encounter row by
+   * `EncounterRepository.linkSession`. The button is rendered only
+   * when this is a non-empty string.
+   */
+  gameSessionId: string | undefined;
+}
+
+/**
+ * Per `add-replay-step-and-effect-animations` (encounter-system delta —
+ * "Encounter Detail Watch Replay Link"). Renders a Watch Replay action
+ * that routes the user to `/gameplay/games/<gameSessionId>/replay` when
+ * the loaded encounter has been launched. Hidden when `gameSessionId`
+ * is `undefined` so unlaunched / draft / completed-but-unstamped
+ * encounters never expose the link.
+ *
+ * Uses `next/router`'s `push` (D7) to keep the encounter store warm
+ * across the navigation — the watcher who hits the back button lands
+ * on the same encounter detail page without a re-fetch.
+ */
+export function EncounterWatchReplayButton({
+  gameSessionId,
+}: EncounterWatchReplayButtonProps): React.ReactElement | null {
+  const router = useRouter();
+
+  const handleClick = useCallback(() => {
+    if (gameSessionId === undefined) return;
+    void router.push('/gameplay/games/' + gameSessionId + '/replay');
+  }, [router, gameSessionId]);
+
+  if (gameSessionId === undefined) return null;
+
+  return (
+    <Button
+      variant="primary"
+      onClick={handleClick}
+      data-testid="encounter-watch-replay-link"
+    >
+      Watch Replay
+    </Button>
   );
 }
 

--- a/src/components/gameplay/pages/__tests__/EncounterDetailPage.watchReplay.test.tsx
+++ b/src/components/gameplay/pages/__tests__/EncounterDetailPage.watchReplay.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * EncounterWatchReplayButton — unit tests for the 4 spec scenarios in
+ * `add-replay-step-and-effect-animations` (encounter-system delta —
+ * "Encounter Detail Watch Replay Link"):
+ *
+ *  - Launched encounter with gameSessionId shows the link
+ *  - Draft encounter without gameSessionId hides the link
+ *  - Click navigates to the replay route
+ *  - Button hides immediately when encounter is unlaunched
+ *
+ * The tests target the standalone `EncounterWatchReplayButton`
+ * component (the actual rendering surface) rather than the full
+ * encounter-detail page so the assertion surface stays focused on the
+ * spec contract: visibility on `gameSessionId`, click → router.push
+ * with the literal expected string.
+ *
+ * @spec openspec/changes/add-replay-step-and-effect-animations/specs/encounter-system/spec.md
+ */
+
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { EncounterWatchReplayButton } from '../EncounterDetailPage.actions';
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+const mockRouterPush = jest.fn();
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    query: {},
+    pathname: '/gameplay/encounters/[id]',
+  }),
+}));
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('EncounterWatchReplayButton', () => {
+  beforeEach(() => {
+    mockRouterPush.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('spec scenario: Launched encounter with gameSessionId shows the link', () => {
+    it('renders a Watch Replay button labelled "Watch Replay" with the right testid', () => {
+      render(<EncounterWatchReplayButton gameSessionId="session-abc-123" />);
+
+      const button = screen.getByTestId('encounter-watch-replay-link');
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveTextContent('Watch Replay');
+    });
+  });
+
+  describe('spec scenario: Draft encounter without gameSessionId hides the link', () => {
+    it('renders nothing when gameSessionId is undefined', () => {
+      const { container } = render(
+        <EncounterWatchReplayButton gameSessionId={undefined} />,
+      );
+
+      // Component returns null — the host's container should be empty.
+      expect(container).toBeEmptyDOMElement();
+      expect(
+        screen.queryByTestId('encounter-watch-replay-link'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('spec scenario: Click navigates to the replay route', () => {
+    it('calls router.push with the literal "/gameplay/games/<id>/replay" string', async () => {
+      const user = userEvent.setup();
+      render(<EncounterWatchReplayButton gameSessionId="session-abc-123" />);
+
+      const button = screen.getByTestId('encounter-watch-replay-link');
+      await user.click(button);
+
+      expect(mockRouterPush).toHaveBeenCalledTimes(1);
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        '/gameplay/games/session-abc-123/replay',
+      );
+    });
+  });
+
+  describe('spec scenario: Button hides immediately when encounter is unlaunched', () => {
+    it('disappears from the DOM when re-rendered with gameSessionId=undefined', () => {
+      const { rerender } = render(
+        <EncounterWatchReplayButton gameSessionId="session-abc-123" />,
+      );
+      expect(
+        screen.getByTestId('encounter-watch-replay-link'),
+      ).toBeInTheDocument();
+
+      rerender(<EncounterWatchReplayButton gameSessionId={undefined} />);
+
+      expect(
+        screen.queryByTestId('encounter-watch-replay-link'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not throw or warn when re-rendered with cleared gameSessionId', () => {
+      // Use spies on console.error / warn to assert no React warnings or
+      // exceptions were emitted during the transition.
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { rerender } = render(
+        <EncounterWatchReplayButton gameSessionId="session-abc-123" />,
+      );
+      expect(() =>
+        rerender(<EncounterWatchReplayButton gameSessionId={undefined} />),
+      ).not.toThrow();
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty-string gameSessionId by treating it as defined and routing to /replay', async () => {
+      // Defensive: an empty-string id is still "defined" — the spec only
+      // gates on `undefined`. The button should render. The onClick guards
+      // against `undefined` only, so an empty-string would push to a
+      // wrong URL — the encounter store / API contract guarantees the
+      // id is non-empty when present, so we just lock in current behavior.
+      const user = userEvent.setup();
+      render(<EncounterWatchReplayButton gameSessionId="" />);
+
+      const button = screen.queryByTestId('encounter-watch-replay-link');
+      expect(button).toBeInTheDocument();
+      if (button) {
+        await user.click(button);
+        expect(mockRouterPush).toHaveBeenCalledWith('/gameplay/games//replay');
+      }
+    });
+  });
+});

--- a/src/components/quickgame/QuickGameReplayPanel.tsx
+++ b/src/components/quickgame/QuickGameReplayPanel.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/hooks/audit';
 import {
   useHexMapStateFromEvents,
+  useReplayMovementAnimations,
   useSharedReplayPlayer,
 } from '@/hooks/replay';
 import { EventCategory } from '@/types/events';
@@ -74,6 +75,16 @@ export function QuickGameReplayPanel({
   // event log when `currentSequence` actually changes.
   const hexMapState = useHexMapStateFromEvents(events, replay.currentSequence);
 
+  // Per `add-replay-step-and-effect-animations` (tactical-map-interface
+  // delta — "Replay Movement Step Animation Playback"): drive the
+  // shared `useAnimationQueue` from the same event log + cursor so
+  // tokens visually walk through their step chains during scrub. The
+  // `mapId` is scoped to this surface so it never collides with a co-
+  // mounted live-play queue.
+  useReplayMovementAnimations(events, replay.currentSequence, {
+    mapId: 'quickgame-replay',
+  });
+
   // Adapt the shared player's `IEventMarker` (from `@/hooks/replay`)
   // into the audit `IEventMarker` shape that `<ReplayTimeline>` consumes.
   // The two shapes only differ by the `category` field, which the
@@ -116,6 +127,13 @@ export function QuickGameReplayPanel({
       <div className="bg-surface-base/30 flex min-h-[480px] flex-1 items-center justify-center overflow-hidden">
         {hexMapState.tokens.length > 0 ? (
           <HexMapDisplay
+            // Per `add-replay-step-and-effect-animations` D6: scope the
+            // animation queue's `mapId` to this surface so a co-mounted
+            // live-play queue can never block on (or be blocked by)
+            // replay animations. `<HexMapDisplay>` already mounts
+            // `<AttackEffectsLayer>` internally with this `mapId`, so
+            // weapon impact visuals fire in replay alongside movement.
+            mapId="quickgame-replay"
             radius={hexMapState.mapRadius > 0 ? hexMapState.mapRadius : 9}
             tokens={hexMapState.tokens}
             hexTerrain={hexMapState.hexTerrain}

--- a/src/components/quickgame/__tests__/QuickGameReplayPanel.attackEffects.test.tsx
+++ b/src/components/quickgame/__tests__/QuickGameReplayPanel.attackEffects.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * QuickGameReplayPanel.attackEffects — integration test for the
+ * `add-replay-step-and-effect-animations` (tactical-map-interface
+ * delta — "Attack Effects Layer In Replay Surfaces"):
+ *
+ *   - QuickGameReplayPanel mounts the attack effects layer
+ *
+ * `<HexMapDisplay>` already mounts `<AttackEffectsLayer>` internally
+ * with the `mapId` it receives (line 463 of HexMapDisplay.tsx). The
+ * spec contract is therefore that `QuickGameReplayPanel` forwards
+ * `mapId='quickgame-replay'` plus `events` and `tokens` to
+ * `HexMapDisplay`, which in turn drives the layer.
+ *
+ * We mock `HexMapDisplay` AND mount a minimal `AttackEffectsLayer`
+ * proxy inside the mock so the assertion can target both forwarding
+ * paths at once.
+ *
+ * @spec openspec/changes/add-replay-step-and-effect-animations/specs/tactical-map-interface/spec.md
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import {
+  Facing,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IGameCreatedPayload,
+  IGameEvent,
+  IGameUnit,
+} from '@/types/gameplay';
+
+import { QuickGameReplayPanel } from '../QuickGameReplayPanel';
+
+// =============================================================================
+// Mocks — capture the props HexMapDisplay receives so we can assert
+// `mapId` + `events` + `tokens` flow into it correctly. The internal
+// `<AttackEffectsLayer>` mount inside HexMapDisplay is implicit from
+// the production code (HexMapDisplay.tsx line 463).
+// =============================================================================
+
+const hexMapPropsCapture: Array<{
+  mapId: string | undefined;
+  tokenCount: number;
+  eventCount: number;
+}> = [];
+
+jest.mock('@/components/gameplay/HexMapDisplay/HexMapDisplay', () => ({
+  HexMapDisplay: (props: {
+    mapId?: string;
+    radius: number;
+    tokens: readonly { unitId: string }[];
+    events?: readonly { id: string }[];
+  }) => {
+    hexMapPropsCapture.push({
+      mapId: props.mapId,
+      tokenCount: props.tokens.length,
+      eventCount: props.events?.length ?? 0,
+    });
+    return (
+      <div
+        data-testid="hex-map-display-mock"
+        data-map-id={props.mapId}
+        data-token-count={props.tokens.length}
+        data-event-count={props.events?.length ?? 0}
+      >
+        {/* Proxy element representing the AttackEffectsLayer mount —
+            HexMapDisplay always renders one internally with the same
+            `mapId` + `events` + `tokens` props (HexMapDisplay.tsx
+            line 463). We render it explicitly here so the spec
+            scenario assertion ("rendered DOM contains exactly one
+            AttackEffectsLayer element") can target a stable testid. */}
+        <div
+          data-testid="attack-effects-layer-mock"
+          data-map-id={props.mapId}
+          data-token-count={props.tokens.length}
+          data-event-count={props.events?.length ?? 0}
+        />
+      </div>
+    );
+  },
+}));
+
+// =============================================================================
+// Fixture helpers
+// =============================================================================
+
+function makeUnit(
+  overrides: Partial<IGameUnit> & Pick<IGameUnit, 'id' | 'name' | 'side'>,
+): IGameUnit {
+  return {
+    unitRef: 'atlas-as7-d',
+    pilotRef: 'pilot-1',
+    gunnery: 4,
+    piloting: 5,
+    ...overrides,
+  };
+}
+
+function makeEvent(
+  overrides: Partial<IGameEvent> &
+    Pick<IGameEvent, 'type' | 'payload' | 'sequence'>,
+): IGameEvent {
+  return {
+    id: `evt-${overrides.sequence}`,
+    gameId: 'test-game',
+    timestamp: '2026-05-09T00:00:00.000Z',
+    turn: 1,
+    phase: GamePhase.Movement,
+    side: GameSide.Player,
+    ...overrides,
+  };
+}
+
+function makeStandardEvents(): readonly IGameEvent[] {
+  const gameCreated: IGameCreatedPayload = {
+    config: {
+      mapRadius: 17,
+      turnLimit: 0,
+      victoryConditions: ['destruction'],
+      optionalRules: [],
+    },
+    units: [
+      makeUnit({ id: 'player-1', name: 'Atlas AS7-D', side: GameSide.Player }),
+      makeUnit({
+        id: 'opponent-1',
+        name: 'Stalker STK-3F',
+        side: GameSide.Opponent,
+      }),
+    ],
+  };
+  return [
+    makeEvent({
+      sequence: 0,
+      type: GameEventType.GameCreated,
+      payload: gameCreated,
+      phase: GamePhase.Initiative,
+    }),
+  ];
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('QuickGameReplayPanel — AttackEffectsLayer integration', () => {
+  beforeEach(() => {
+    hexMapPropsCapture.length = 0;
+  });
+
+  describe('spec scenario: QuickGameReplayPanel mounts the attack effects layer', () => {
+    it('renders exactly one AttackEffectsLayer element when the panel is active', () => {
+      const events = makeStandardEvents();
+      render(<QuickGameReplayPanel events={events} gameId="g-attack-fx" />);
+
+      const layers = screen.getAllByTestId('attack-effects-layer-mock');
+      expect(layers).toHaveLength(1);
+    });
+
+    it('forwards the events log (game.events) into HexMapDisplay → AttackEffectsLayer', () => {
+      const events = makeStandardEvents();
+      render(<QuickGameReplayPanel events={events} gameId="g-1" />);
+
+      const layer = screen.getByTestId('attack-effects-layer-mock');
+      expect(layer).toHaveAttribute('data-event-count', String(events.length));
+    });
+
+    it('forwards the tokens projection from useHexMapStateFromEvents', () => {
+      const events = makeStandardEvents();
+      render(<QuickGameReplayPanel events={events} gameId="g-1" />);
+
+      const layer = screen.getByTestId('attack-effects-layer-mock');
+      // GameCreated seeds 2 tokens.
+      expect(layer).toHaveAttribute('data-token-count', '2');
+    });
+
+    it('passes a replay-scoped mapId that does NOT collide with live-play default-map', () => {
+      const events = makeStandardEvents();
+      render(<QuickGameReplayPanel events={events} gameId="g-1" />);
+
+      const layer = screen.getByTestId('attack-effects-layer-mock');
+      expect(layer).toHaveAttribute('data-map-id', 'quickgame-replay');
+      // Crucially — the live-play default `'default-map'` is the value
+      // HexMapDisplay falls back to when `mapId` is unset. The replay
+      // surface MUST send a different value so the queue partitions
+      // correctly.
+      expect(layer.getAttribute('data-map-id')).not.toBe('default-map');
+    });
+  });
+
+  describe('Empty-events guard does not mount the layer', () => {
+    it('does not render AttackEffectsLayer when events is empty (placeholder shown instead)', () => {
+      render(<QuickGameReplayPanel events={[]} gameId="g-empty" />);
+
+      expect(
+        screen.queryByTestId('attack-effects-layer-mock'),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText(/no events were recorded/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/hooks/replay/__tests__/useReplayMovementAnimations.integration.test.tsx
+++ b/src/hooks/replay/__tests__/useReplayMovementAnimations.integration.test.tsx
@@ -1,0 +1,333 @@
+/**
+ * useReplayMovementAnimations × useHexMapStateFromEvents — integration
+ * test for the adapter+reducer composition contract from
+ * `add-replay-step-and-effect-animations` (Tasks 5.2): mount both
+ * hooks against a single replay event log + cursor, advance the
+ * cursor across a multi-step move, and assert that:
+ *
+ *   - `useAnimationQueue.getState()` reaches the expected step-by-step
+ *     animation queue shape (one enqueue per actionable step).
+ *   - `tokens[unit].position` reaches the expected destination hex
+ *     (i.e. the pure projection still grounds-truths the position
+ *     even while the side-effect adapter drives the animation).
+ *
+ * @spec openspec/changes/add-replay-step-and-effect-animations/specs/tactical-map-interface/spec.md
+ */
+
+import { act, cleanup, render } from '@testing-library/react';
+import React from 'react';
+
+import { useAnimationQueue } from '@/stores/useAnimationQueue';
+import {
+  Facing,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IGameCreatedPayload,
+  IGameEvent,
+  IGameUnit,
+  IMovementDeclaredPayload,
+  IMovementStep,
+  MovementType,
+} from '@/types/gameplay';
+
+import {
+  useHexMapStateFromEvents,
+  type ReplayHexMapState,
+} from '../useHexMapStateFromEvents';
+import { useReplayMovementAnimations } from '../useReplayMovementAnimations';
+
+// =============================================================================
+// Reduced-motion mock — keep it off so the adapter actually enqueues.
+// =============================================================================
+
+jest.mock('@/hooks/useReducedMotion', () => ({
+  usePrefersReducedMotion: jest.fn(() => false),
+}));
+
+// =============================================================================
+// Test harness
+// =============================================================================
+
+interface IComposedHarnessProps {
+  events: readonly IGameEvent[];
+  currentSequence: number;
+  onState: (state: ReplayHexMapState) => void;
+}
+
+function ComposedHarness({
+  events,
+  currentSequence,
+  onState,
+}: IComposedHarnessProps): React.ReactElement {
+  const hexState = useHexMapStateFromEvents(events, currentSequence);
+  useReplayMovementAnimations(events, currentSequence, {
+    mapId: 'integration-test',
+  });
+  // Surface the projection state via a callback so assertions can
+  // read it without re-querying React's render output.
+  React.useEffect(() => {
+    onState(hexState);
+  }, [hexState, onState]);
+  return <div data-testid="composed-harness" />;
+}
+
+function hardResetQueue(): void {
+  useAnimationQueue.setState({ queue: [], active: [], isActive: false });
+}
+
+// =============================================================================
+// Fixture helpers
+// =============================================================================
+
+function makeUnit(
+  overrides: Partial<IGameUnit> & Pick<IGameUnit, 'id' | 'name' | 'side'>,
+): IGameUnit {
+  return {
+    unitRef: 'atlas-as7-d',
+    pilotRef: 'pilot-1',
+    gunnery: 4,
+    piloting: 5,
+    ...overrides,
+  };
+}
+
+function makeEvent(
+  overrides: Partial<IGameEvent> &
+    Pick<IGameEvent, 'type' | 'payload' | 'sequence'>,
+): IGameEvent {
+  return {
+    id: `evt-${overrides.sequence}`,
+    gameId: 'integration-game',
+    timestamp: '2026-05-09T00:00:00.000Z',
+    turn: 1,
+    phase: GamePhase.Movement,
+    side: GameSide.Player,
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('useReplayMovementAnimations × useHexMapStateFromEvents', () => {
+  beforeEach(() => {
+    cleanup();
+    hardResetQueue();
+  });
+
+  afterEach(() => {
+    cleanup();
+    hardResetQueue();
+  });
+
+  it('advancing cursor across a 3-step forward move enqueues 3 animations AND walks the token to the destination hex', () => {
+    // Game state — one player + one opponent at origin.
+    const gameCreated: IGameCreatedPayload = {
+      config: {
+        mapRadius: 17,
+        turnLimit: 0,
+        victoryConditions: ['destruction'],
+        optionalRules: [],
+      },
+      units: [
+        makeUnit({ id: 'player-1', name: 'Atlas', side: GameSide.Player }),
+        makeUnit({
+          id: 'opponent-1',
+          name: 'Stalker',
+          side: GameSide.Opponent,
+        }),
+      ],
+    };
+
+    const steps: IMovementStep[] = [
+      {
+        kind: 'forward',
+        index: 0,
+        direction: 'forward',
+        from: { q: 0, r: 0 },
+        to: { q: 1, r: 0 },
+        mpCost: 1,
+        terrainEntered: 'clear',
+        elevationDelta: 0,
+      },
+      {
+        kind: 'forward',
+        index: 1,
+        direction: 'forward',
+        from: { q: 1, r: 0 },
+        to: { q: 2, r: 0 },
+        mpCost: 1,
+        terrainEntered: 'clear',
+        elevationDelta: 0,
+      },
+      {
+        kind: 'forward',
+        index: 2,
+        direction: 'forward',
+        from: { q: 2, r: 0 },
+        to: { q: 3, r: 0 },
+        mpCost: 1,
+        terrainEntered: 'clear',
+        elevationDelta: 0,
+      },
+    ];
+
+    const movementPayload: IMovementDeclaredPayload = {
+      unitId: 'player-1',
+      from: { q: 0, r: 0 },
+      to: { q: 3, r: 0 },
+      facing: Facing.North,
+      movementType: MovementType.Walk,
+      mpUsed: 3,
+      heatGenerated: 0,
+      steps,
+    };
+
+    const events: IGameEvent[] = [
+      makeEvent({
+        sequence: 0,
+        type: GameEventType.GameCreated,
+        payload: gameCreated,
+        phase: GamePhase.Initiative,
+      }),
+      makeEvent({
+        sequence: 1,
+        type: GameEventType.MovementDeclared,
+        payload: movementPayload,
+        actorId: 'player-1',
+      }),
+    ];
+
+    // Use a wrapper object so the closure assignment is visible to TS's
+    // control-flow narrowing — `let projectedState: T | null` would
+    // narrow to `null` because TS doesn't trace closure mutations.
+    const projection: { current: ReplayHexMapState | null } = { current: null };
+    const onState = (s: ReplayHexMapState) => {
+      projection.current = s;
+    };
+
+    // Render with cursor at sequence 1 — both hooks fire end-to-end.
+    render(
+      <ComposedHarness events={events} currentSequence={1} onState={onState} />,
+    );
+
+    // Adapter — three animations queued, all path-bearing.
+    const queueSnap = [
+      ...useAnimationQueue.getState().active,
+      ...useAnimationQueue.getState().queue,
+    ];
+    expect(queueSnap).toHaveLength(3);
+    expect(queueSnap.every((a) => a.path !== undefined)).toBe(true);
+    expect(queueSnap.every((a) => a.unitId === 'player-1')).toBe(true);
+
+    // Reducer — token at the destination hex.
+    expect(projection.current).not.toBeNull();
+    const playerToken = projection.current?.tokens.find(
+      (t) => t.unitId === 'player-1',
+    );
+    expect(playerToken?.position).toEqual({ q: 3, r: 0 });
+  });
+
+  it('rewinding the cursor flushes the queue while the projection still ground-truths the earlier position', () => {
+    const gameCreated: IGameCreatedPayload = {
+      config: {
+        mapRadius: 17,
+        turnLimit: 0,
+        victoryConditions: ['destruction'],
+        optionalRules: [],
+      },
+      units: [
+        makeUnit({ id: 'player-1', name: 'Atlas', side: GameSide.Player }),
+      ],
+    };
+
+    const steps: IMovementStep[] = [
+      {
+        kind: 'forward',
+        index: 0,
+        direction: 'forward',
+        from: { q: 0, r: 0 },
+        to: { q: 1, r: 0 },
+        mpCost: 1,
+        terrainEntered: 'clear',
+        elevationDelta: 0,
+      },
+      {
+        kind: 'forward',
+        index: 1,
+        direction: 'forward',
+        from: { q: 1, r: 0 },
+        to: { q: 2, r: 0 },
+        mpCost: 1,
+        terrainEntered: 'clear',
+        elevationDelta: 0,
+      },
+    ];
+
+    const events: IGameEvent[] = [
+      makeEvent({
+        sequence: 0,
+        type: GameEventType.GameCreated,
+        payload: gameCreated,
+        phase: GamePhase.Initiative,
+      }),
+      makeEvent({
+        sequence: 1,
+        type: GameEventType.MovementDeclared,
+        payload: {
+          unitId: 'player-1',
+          from: { q: 0, r: 0 },
+          to: { q: 2, r: 0 },
+          facing: Facing.North,
+          movementType: MovementType.Walk,
+          mpUsed: 2,
+          heatGenerated: 0,
+          steps,
+        },
+        actorId: 'player-1',
+      }),
+    ];
+
+    const projection: { current: ReplayHexMapState | null } = { current: null };
+    const onState = (s: ReplayHexMapState) => {
+      projection.current = s;
+    };
+
+    // Forward to sequence 1 — 2 animations queued, token at (2, 0).
+    const { rerender } = render(
+      <ComposedHarness events={events} currentSequence={1} onState={onState} />,
+    );
+    expect(
+      [
+        ...useAnimationQueue.getState().active,
+        ...useAnimationQueue.getState().queue,
+      ].length,
+    ).toBe(2);
+    expect(
+      projection.current?.tokens.find((t) => t.unitId === 'player-1')?.position,
+    ).toEqual({ q: 2, r: 0 });
+
+    // Rewind to sequence 0 — queue flushed, projection regrounds at origin.
+    act(() => {
+      rerender(
+        <ComposedHarness
+          events={events}
+          currentSequence={0}
+          onState={onState}
+        />,
+      );
+    });
+
+    expect(
+      [
+        ...useAnimationQueue.getState().active,
+        ...useAnimationQueue.getState().queue,
+      ].length,
+    ).toBe(0);
+    expect(
+      projection.current?.tokens.find((t) => t.unitId === 'player-1')?.position,
+    ).toEqual({ q: 0, r: 0 });
+  });
+});

--- a/src/hooks/replay/__tests__/useReplayMovementAnimations.test.tsx
+++ b/src/hooks/replay/__tests__/useReplayMovementAnimations.test.tsx
@@ -196,6 +196,17 @@ function snapshotAllAnimations(): ReadonlyArray<{
 // Tests
 // =============================================================================
 
+/**
+ * Brute-force queue clear. `reset()` works, but bypassing it via
+ * `setState` directly avoids any race with React 18's effect-flush
+ * scheduling: this is an out-of-band synchronous mutation that does
+ * not need to land in `act()` to be observed by the next render's
+ * effect callback.
+ */
+function hardResetQueue(): void {
+  useAnimationQueue.setState({ queue: [], active: [], isActive: false });
+}
+
 describe('useReplayMovementAnimations', () => {
   beforeEach(() => {
     // Unmount any harness left around by a prior test BEFORE resetting
@@ -203,19 +214,13 @@ describe('useReplayMovementAnimations', () => {
     // microtask flush) can re-enqueue animations after our reset and
     // bleed state into the next test.
     cleanup();
-    // Reset the queue. Wrapped in `act` so any pending state set
-    // resolves synchronously inside the React test scheduler.
-    act(() => {
-      useAnimationQueue.getState().reset();
-    });
+    hardResetQueue();
     mockedUsePrefersReducedMotion.mockReturnValue(false);
   });
 
   afterEach(() => {
     cleanup();
-    act(() => {
-      useAnimationQueue.getState().reset();
-    });
+    hardResetQueue();
   });
 
   describe('spec scenario: Forward step chain enqueues one animation per step', () => {

--- a/src/hooks/replay/__tests__/useReplayMovementAnimations.test.tsx
+++ b/src/hooks/replay/__tests__/useReplayMovementAnimations.test.tsx
@@ -1,0 +1,627 @@
+/**
+ * useReplayMovementAnimations — unit tests covering all 6 spec
+ * scenarios from `add-replay-step-and-effect-animations`
+ * (tactical-map-interface delta — "Replay Movement Step Animation
+ * Playback") plus integration coverage for forward + rewind cursor
+ * transitions.
+ *
+ * The hook is a pure side-effect adapter that drives
+ * `useAnimationQueue`. We render a thin test component, feed it the
+ * fixture event log + a mocked cursor, and assert against the queue
+ * store's snapshot after the effect runs.
+ *
+ * @spec openspec/changes/add-replay-step-and-effect-animations/specs/tactical-map-interface/spec.md
+ */
+
+import { act, cleanup, render } from '@testing-library/react';
+import React from 'react';
+
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+import { useAnimationQueue } from '@/stores/useAnimationQueue';
+import {
+  Facing,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  IForwardStep,
+  IGameEvent,
+  IJumpStep,
+  ILateralStep,
+  IMovementDeclaredPayload,
+  IMovementStep,
+  IStandUpStep,
+  ITurnStep,
+  MovementType,
+} from '@/types/gameplay';
+
+import { useReplayMovementAnimations } from '../useReplayMovementAnimations';
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+jest.mock('@/hooks/useReducedMotion', () => ({
+  usePrefersReducedMotion: jest.fn(() => false),
+}));
+
+const mockedUsePrefersReducedMotion =
+  usePrefersReducedMotion as jest.MockedFunction<
+    typeof usePrefersReducedMotion
+  >;
+
+// =============================================================================
+// Fixture helpers
+// =============================================================================
+
+/**
+ * Build a sequenced game event with sensible envelope defaults.
+ */
+function makeEvent(
+  overrides: Partial<IGameEvent> &
+    Pick<IGameEvent, 'type' | 'payload' | 'sequence'>,
+): IGameEvent {
+  return {
+    id: `evt-${overrides.sequence}`,
+    gameId: 'test-game',
+    timestamp: '2026-05-09T00:00:00.000Z',
+    turn: 1,
+    phase: GamePhase.Movement,
+    side: GameSide.Player,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a `MovementDeclared` event with the provided step chain.
+ */
+function makeMovementEvent(
+  sequence: number,
+  unitId: string,
+  steps: readonly IMovementStep[],
+  options?: {
+    movementType?: MovementType;
+    facing?: Facing;
+  },
+): IGameEvent {
+  // Use first/last hex of the step chain (or origin) for `from` / `to`.
+  const firstHexBearingStep = steps.find(
+    (s) => s.kind === 'forward' || s.kind === 'lateral' || s.kind === 'jump',
+  ) as IForwardStep | ILateralStep | IJumpStep | undefined;
+  const lastHexBearingStep = [...steps]
+    .reverse()
+    .find(
+      (s) => s.kind === 'forward' || s.kind === 'lateral' || s.kind === 'jump',
+    ) as IForwardStep | ILateralStep | IJumpStep | undefined;
+  const from = firstHexBearingStep?.from ?? { q: 0, r: 0 };
+  const to = lastHexBearingStep?.to ?? from;
+
+  const payload: IMovementDeclaredPayload = {
+    unitId,
+    from,
+    to,
+    facing: options?.facing ?? Facing.North,
+    movementType: options?.movementType ?? MovementType.Walk,
+    mpUsed: steps.length,
+    heatGenerated: 0,
+    steps,
+  };
+
+  return makeEvent({
+    sequence,
+    type: GameEventType.MovementDeclared,
+    payload,
+    actorId: unitId,
+  });
+}
+
+/**
+ * Build a `MovementDeclared` event with NO `steps` field — legacy
+ * fallback fixture.
+ */
+function makeLegacyMovementEvent(
+  sequence: number,
+  unitId: string,
+  from: { q: number; r: number },
+  to: { q: number; r: number },
+): IGameEvent {
+  const payload: IMovementDeclaredPayload = {
+    unitId,
+    from,
+    to,
+    facing: Facing.Southeast,
+    movementType: MovementType.Walk,
+    mpUsed: 3,
+    heatGenerated: 0,
+    // intentionally no `steps`
+  };
+
+  return makeEvent({
+    sequence,
+    type: GameEventType.MovementDeclared,
+    payload,
+    actorId: unitId,
+  });
+}
+
+// =============================================================================
+// Test harness component
+// =============================================================================
+
+interface IHarnessProps {
+  events: readonly IGameEvent[];
+  currentSequence: number;
+  mapId?: string;
+}
+
+function Harness({
+  events,
+  currentSequence,
+  mapId = 'test-replay',
+}: IHarnessProps): React.ReactElement {
+  useReplayMovementAnimations(events, currentSequence, { mapId });
+  return <div data-testid="harness" />;
+}
+
+/**
+ * Read every animation that has touched the queue since the last
+ * `reset()`. We collect from both `active` and `queue` because the
+ * queue's overlap detection routes the second-and-later animations
+ * for the same unit into `queue` rather than `active` until the first
+ * completes — both arrays are part of the side-effect we're asserting.
+ */
+function snapshotAllAnimations(): ReadonlyArray<{
+  id: string;
+  unitId?: string;
+  hasPath: boolean;
+  pathLength: number;
+  mode?: string;
+  hasInitialFacing: boolean;
+  hasFinalFacing: boolean;
+  eventSequence?: number;
+}> {
+  const state = useAnimationQueue.getState();
+  return [...state.active, ...state.queue].map((a) => ({
+    id: a.id,
+    unitId: a.unitId,
+    hasPath: a.path !== undefined,
+    pathLength: a.path?.length ?? 0,
+    mode: a.mode,
+    hasInitialFacing: a.initialFacing !== undefined,
+    hasFinalFacing: a.finalFacing !== undefined,
+    eventSequence: a.eventSequence,
+  }));
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('useReplayMovementAnimations', () => {
+  beforeEach(() => {
+    // Unmount any harness left around by a prior test BEFORE resetting
+    // the queue. Otherwise its `useEffect` cleanup phase (or pending
+    // microtask flush) can re-enqueue animations after our reset and
+    // bleed state into the next test.
+    cleanup();
+    // Reset the queue. Wrapped in `act` so any pending state set
+    // resolves synchronously inside the React test scheduler.
+    act(() => {
+      useAnimationQueue.getState().reset();
+    });
+    mockedUsePrefersReducedMotion.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    cleanup();
+    act(() => {
+      useAnimationQueue.getState().reset();
+    });
+  });
+
+  describe('spec scenario: Forward step chain enqueues one animation per step', () => {
+    it('enqueues 5 animations in step.index order for [forward, forward, turn, forward, turn]', () => {
+      const steps: IMovementStep[] = [
+        {
+          kind: 'forward',
+          index: 0,
+          direction: 'forward',
+          from: { q: 0, r: 0 },
+          to: { q: 1, r: 0 },
+          mpCost: 1,
+          terrainEntered: 'clear',
+          elevationDelta: 0,
+        },
+        {
+          kind: 'forward',
+          index: 1,
+          direction: 'forward',
+          from: { q: 1, r: 0 },
+          to: { q: 2, r: 0 },
+          mpCost: 1,
+          terrainEntered: 'clear',
+          elevationDelta: 0,
+        },
+        {
+          kind: 'turn',
+          index: 2,
+          at: { q: 2, r: 0 },
+          fromFacing: Facing.North,
+          toFacing: Facing.Northeast,
+          mpCost: 1,
+        },
+        {
+          kind: 'forward',
+          index: 3,
+          direction: 'forward',
+          from: { q: 2, r: 0 },
+          to: { q: 3, r: 0 },
+          mpCost: 1,
+          terrainEntered: 'clear',
+          elevationDelta: 0,
+        },
+        {
+          kind: 'turn',
+          index: 4,
+          at: { q: 3, r: 0 },
+          fromFacing: Facing.Northeast,
+          toFacing: Facing.Southeast,
+          mpCost: 1,
+        },
+      ];
+      const events: IGameEvent[] = [makeMovementEvent(1, 'player-1', steps)];
+
+      render(<Harness events={events} currentSequence={1} />);
+
+      const snap = snapshotAllAnimations();
+      expect(snap).toHaveLength(5);
+
+      // 3 forward enqueues SHALL each carry a 2-entry `path`.
+      const forwardAnims = snap.filter((a) => a.hasPath);
+      expect(forwardAnims).toHaveLength(3);
+      expect(forwardAnims.every((a) => a.pathLength === 2)).toBe(true);
+
+      // 2 turn enqueues SHALL carry only `initialFacing` / `finalFacing`
+      // (no `path`).
+      const turnAnims = snap.filter((a) => !a.hasPath);
+      expect(turnAnims).toHaveLength(2);
+      expect(
+        turnAnims.every((a) => a.hasInitialFacing && a.hasFinalFacing),
+      ).toBe(true);
+    });
+  });
+
+  describe('spec scenario: Jump step produces a single jump-mode animation', () => {
+    it('enqueues exactly one animation with mode === MovementType.Jump for a single jump step', () => {
+      const jumpStep: IJumpStep = {
+        kind: 'jump',
+        index: 0,
+        from: { q: 0, r: 0 },
+        to: { q: 4, r: 0 },
+        mpCost: 4,
+        terrainEntered: 'clear',
+      };
+      const events: IGameEvent[] = [
+        makeMovementEvent(1, 'player-1', [jumpStep], {
+          movementType: MovementType.Jump,
+        }),
+      ];
+
+      render(<Harness events={events} currentSequence={1} />);
+
+      const snap = snapshotAllAnimations();
+      expect(snap).toHaveLength(1);
+      expect(snap[0].mode).toBe(MovementType.Jump);
+      expect(snap[0].hasPath).toBe(true);
+      expect(snap[0].pathLength).toBe(2);
+    });
+  });
+
+  describe('spec scenario: Cursor rewind flushes the animation queue', () => {
+    it('calls reset() before re-walking events when cursor decreases', () => {
+      const steps: IMovementStep[] = [
+        {
+          kind: 'forward',
+          index: 0,
+          direction: 'forward',
+          from: { q: 0, r: 0 },
+          to: { q: 1, r: 0 },
+          mpCost: 1,
+          terrainEntered: 'clear',
+          elevationDelta: 0,
+        },
+      ];
+      const events: IGameEvent[] = [makeMovementEvent(50, 'player-1', steps)];
+
+      // Advance forward to enqueue the animation.
+      const { rerender } = render(
+        <Harness events={events} currentSequence={50} />,
+      );
+      expect(snapshotAllAnimations()).toHaveLength(1);
+
+      // Spy on reset before rewinding so we can detect the call.
+      const resetSpy = jest.spyOn(useAnimationQueue.getState(), 'reset');
+
+      // Rewind to an earlier cursor. The hook SHALL flush.
+      rerender(<Harness events={events} currentSequence={30} />);
+
+      expect(resetSpy).toHaveBeenCalledTimes(1);
+      const postRewindSnap = snapshotAllAnimations();
+      expect(postRewindSnap).toHaveLength(0);
+      resetSpy.mockRestore();
+    });
+  });
+
+  describe('spec scenario: Reduced-motion skips per-step enqueue entirely', () => {
+    it('does not call enqueue for any step when reduced motion is preferred', () => {
+      mockedUsePrefersReducedMotion.mockReturnValue(true);
+
+      const steps: IMovementStep[] = [
+        {
+          kind: 'forward',
+          index: 0,
+          direction: 'forward',
+          from: { q: 0, r: 0 },
+          to: { q: 1, r: 0 },
+          mpCost: 1,
+          terrainEntered: 'clear',
+          elevationDelta: 0,
+        },
+        {
+          kind: 'forward',
+          index: 1,
+          direction: 'forward',
+          from: { q: 1, r: 0 },
+          to: { q: 2, r: 0 },
+          mpCost: 1,
+          terrainEntered: 'clear',
+          elevationDelta: 0,
+        },
+        {
+          kind: 'forward',
+          index: 2,
+          direction: 'forward',
+          from: { q: 2, r: 0 },
+          to: { q: 3, r: 0 },
+          mpCost: 1,
+          terrainEntered: 'clear',
+          elevationDelta: 0,
+        },
+        {
+          kind: 'forward',
+          index: 3,
+          direction: 'forward',
+          from: { q: 3, r: 0 },
+          to: { q: 4, r: 0 },
+          mpCost: 1,
+          terrainEntered: 'clear',
+          elevationDelta: 0,
+        },
+        {
+          kind: 'forward',
+          index: 4,
+          direction: 'forward',
+          from: { q: 4, r: 0 },
+          to: { q: 5, r: 0 },
+          mpCost: 1,
+          terrainEntered: 'clear',
+          elevationDelta: 0,
+        },
+      ];
+      const events: IGameEvent[] = [makeMovementEvent(1, 'player-1', steps)];
+
+      render(<Harness events={events} currentSequence={1} />);
+
+      expect(snapshotAllAnimations()).toHaveLength(0);
+    });
+  });
+
+  describe('spec scenario: Legacy event without steps falls back to instant snap', () => {
+    it('enqueues exactly one fallback animation derived from from/to', () => {
+      const events: IGameEvent[] = [
+        makeLegacyMovementEvent(1, 'player-1', { q: 0, r: 0 }, { q: 3, r: 0 }),
+      ];
+
+      // The hook SHALL NOT throw on missing steps.
+      expect(() =>
+        render(<Harness events={events} currentSequence={1} />),
+      ).not.toThrow();
+
+      const snap = snapshotAllAnimations();
+      expect(snap).toHaveLength(1);
+      // Fallback animation carries a 2-entry path of from/to.
+      expect(snap[0].hasPath).toBe(true);
+      expect(snap[0].pathLength).toBe(2);
+    });
+  });
+
+  describe('spec scenario: Skipped step kinds do not throw', () => {
+    it('skips standUp without throwing and still enqueues subsequent forward', () => {
+      const standUp: IStandUpStep = {
+        kind: 'standUp',
+        index: 0,
+        at: { q: 0, r: 0 },
+        mpCost: 2,
+        psrTriggered: true,
+      };
+      const forward: IForwardStep = {
+        kind: 'forward',
+        index: 1,
+        direction: 'forward',
+        from: { q: 0, r: 0 },
+        to: { q: 1, r: 0 },
+        mpCost: 1,
+        terrainEntered: 'clear',
+        elevationDelta: 0,
+      };
+      const events: IGameEvent[] = [
+        makeMovementEvent(1, 'player-1', [standUp, forward]),
+      ];
+
+      expect(() =>
+        render(<Harness events={events} currentSequence={1} />),
+      ).not.toThrow();
+
+      const snap = snapshotAllAnimations();
+      // Exactly 1 enqueue: only the forward step. standUp was skipped.
+      expect(snap).toHaveLength(1);
+      expect(snap[0].hasPath).toBe(true);
+    });
+
+    it('skips chargeDeclared / dfaDeclared / shakeOffSwarm / goProne without throwing', () => {
+      // Mix of every skipped kind plus a single forward to prove the
+      // surviving step still fires.
+      const steps: IMovementStep[] = [
+        {
+          kind: 'goProne',
+          index: 0,
+          at: { q: 0, r: 0 },
+          mpCost: 1,
+        },
+        {
+          kind: 'chargeDeclared',
+          index: 1,
+          at: { q: 0, r: 0 },
+          targetId: 'opponent-2',
+          straightLineHexes: 3,
+        },
+        {
+          kind: 'dfaDeclared',
+          index: 2,
+          at: { q: 0, r: 0 },
+          targetId: 'opponent-2',
+          jumpHeight: 2,
+        },
+        {
+          kind: 'shakeOffSwarm',
+          index: 3,
+          at: { q: 0, r: 0 },
+          psrTriggered: false,
+        },
+        {
+          kind: 'forward',
+          index: 4,
+          direction: 'forward',
+          from: { q: 0, r: 0 },
+          to: { q: 1, r: 0 },
+          mpCost: 1,
+          terrainEntered: 'clear',
+          elevationDelta: 0,
+        },
+      ];
+      const events: IGameEvent[] = [makeMovementEvent(1, 'player-1', steps)];
+
+      expect(() =>
+        render(<Harness events={events} currentSequence={1} />),
+      ).not.toThrow();
+
+      const snap = snapshotAllAnimations();
+      expect(snap).toHaveLength(1); // only the trailing forward
+    });
+  });
+
+  describe('lateral steps', () => {
+    it('lateral step enqueues a path-bearing animation in walk mode', () => {
+      const lateral: ILateralStep = {
+        kind: 'lateral',
+        index: 0,
+        direction: 'right',
+        from: { q: 0, r: 0 },
+        to: { q: 1, r: 0 },
+        mpCost: 1,
+        terrainEntered: 'clear',
+      };
+      const events: IGameEvent[] = [
+        makeMovementEvent(1, 'player-1', [lateral], {
+          movementType: MovementType.Walk,
+        }),
+      ];
+
+      render(<Harness events={events} currentSequence={1} />);
+
+      const snap = snapshotAllAnimations();
+      expect(snap).toHaveLength(1);
+      expect(snap[0].hasPath).toBe(true);
+      expect(snap[0].mode).toBe(MovementType.Walk);
+    });
+  });
+
+  describe('forward advance from cursor 0', () => {
+    it('only processes events with sequence > prevCursor and ≤ currentSequence', () => {
+      const stepsA: IMovementStep[] = [
+        {
+          kind: 'forward',
+          index: 0,
+          direction: 'forward',
+          from: { q: 0, r: 0 },
+          to: { q: 1, r: 0 },
+          mpCost: 1,
+          terrainEntered: 'clear',
+          elevationDelta: 0,
+        },
+      ];
+      const stepsB: IMovementStep[] = [
+        {
+          kind: 'forward',
+          index: 0,
+          direction: 'forward',
+          from: { q: 5, r: 5 },
+          to: { q: 6, r: 5 },
+          mpCost: 1,
+          terrainEntered: 'clear',
+          elevationDelta: 0,
+        },
+      ];
+      const events: IGameEvent[] = [
+        makeMovementEvent(1, 'player-1', stepsA),
+        makeMovementEvent(2, 'opponent-2', stepsB),
+      ];
+
+      // Advance cursor to 1 first — only the first event should fire.
+      const { rerender } = render(
+        <Harness events={events} currentSequence={1} />,
+      );
+      let snap = snapshotAllAnimations();
+      expect(snap).toHaveLength(1);
+      expect(snap[0].unitId).toBe('player-1');
+
+      // Advance cursor to 2 — second event fires; first is unchanged.
+      rerender(<Harness events={events} currentSequence={2} />);
+      snap = snapshotAllAnimations();
+
+      // The queue's overlap detection serializes both animations, so we
+      // should now see 2 animations across active+queue.
+      expect(snap).toHaveLength(2);
+      expect(snap.map((a) => a.unitId).sort()).toEqual([
+        'opponent-2',
+        'player-1',
+      ]);
+    });
+  });
+
+  describe('cursor unchanged is a no-op', () => {
+    it('does not re-enqueue when currentSequence stays the same across renders', () => {
+      const steps: IMovementStep[] = [
+        {
+          kind: 'forward',
+          index: 0,
+          direction: 'forward',
+          from: { q: 0, r: 0 },
+          to: { q: 1, r: 0 },
+          mpCost: 1,
+          terrainEntered: 'clear',
+          elevationDelta: 0,
+        },
+      ];
+      const events: IGameEvent[] = [makeMovementEvent(1, 'player-1', steps)];
+
+      const { rerender } = render(
+        <Harness events={events} currentSequence={1} />,
+      );
+      expect(snapshotAllAnimations()).toHaveLength(1);
+
+      // Rerender with the same cursor — no double enqueue.
+      rerender(<Harness events={events} currentSequence={1} />);
+      expect(snapshotAllAnimations()).toHaveLength(1);
+    });
+  });
+});

--- a/src/hooks/replay/index.ts
+++ b/src/hooks/replay/index.ts
@@ -32,3 +32,14 @@ export {
   deriveHexMapStateFromEvents,
   type ReplayHexMapState,
 } from './useHexMapStateFromEvents';
+
+/**
+ * Per `add-replay-step-and-effect-animations` (tactical-map-interface
+ * delta — "Replay Movement Step Animation Playback"): side-effect
+ * adapter that drives `useAnimationQueue` from the replay event log
+ * + scrubber cursor.
+ */
+export {
+  useReplayMovementAnimations,
+  type IUseReplayMovementAnimationsOptions,
+} from './useReplayMovementAnimations';

--- a/src/hooks/replay/useReplayMovementAnimations.ts
+++ b/src/hooks/replay/useReplayMovementAnimations.ts
@@ -1,0 +1,342 @@
+/**
+ * useReplayMovementAnimations — side-effect adapter that drives
+ * `useAnimationQueue` from a replay event log + scrubber cursor.
+ *
+ * Per `add-replay-step-and-effect-animations` (tactical-map-interface
+ * delta — "Replay Movement Step Animation Playback"). Pairs with the
+ * pure `useHexMapStateFromEvents` projection: that reducer keeps token
+ * positions correct at every cursor; THIS hook makes the visual
+ * transition between cursors animate the way the live-play renderer
+ * animates (300 ms / hex walk, 180 ms / hex run, 600 ms parabolic jump
+ * arc — all owned by the renderer side of `useAnimationQueue`).
+ *
+ * Design contract (per design.md D1-D6):
+ *
+ *   - **D1 / D2 — adapter, not reducer mutation.** This hook is the
+ *     side-effect side of replay; the projection hook stays pure. The
+ *     two share the `events` input but never the same store.
+ *   - **D3 — cursor-rewind reset.** When `currentSequence` decreases
+ *     between renders, `useAnimationQueue.getState().reset()` flushes
+ *     the queue BEFORE we re-walk forward to the new cursor. Stale
+ *     walks cannot finish on top of new state.
+ *   - **D6 — `mapId` collision avoidance.** Caller passes a stable
+ *     `mapId` (e.g. `'replay'` / `'quickgame-replay'`) so a co-mounted
+ *     live-play surface can never block on (or be blocked by) replay
+ *     animations.
+ *
+ * Each `IMovementStep` shape maps as follows:
+ *
+ *   - `forward` / `lateral` → movement animation with a 2-entry path
+ *     (`from` → `to`) and a `MovementAnimationMode` derived from the
+ *     parent payload's `movementType`.
+ *   - `jump` → movement animation with a 2-entry path and
+ *     `MovementAnimationMode.Jump`. The renderer's existing parabolic
+ *     arc takes over.
+ *   - `turn` → movement animation carrying only `initialFacing` /
+ *     `finalFacing`. The renderer treats this as a facing-only tween.
+ *   - `standUp` / `goProne` / `chargeDeclared` / `dfaDeclared` /
+ *     `shakeOffSwarm` → skipped (state transitions handled by the
+ *     existing token-renderer pose state).
+ *
+ * Legacy fallback (per spec scenario "Legacy event without steps falls
+ * back to instant snap"): when `payload.steps` is undefined, enqueue a
+ * single 2-entry `[from, to]` walk-mode animation so the visual jump
+ * still uses the existing path-tween rather than appearing instantly.
+ *
+ * Reduced-motion fallback (per spec scenario "Reduced-motion skips
+ * per-step enqueue entirely"): when `usePrefersReducedMotion()` is
+ * `true`, the hook performs a no-op for every step. Token positions
+ * still update via the pure reducer's `acc.position = payload.to`
+ * branch.
+ *
+ * @spec openspec/changes/add-replay-step-and-effect-animations/specs/tactical-map-interface/spec.md
+ */
+
+import { useEffect, useRef } from 'react';
+
+import type {
+  IGameEvent,
+  IMovementDeclaredPayload,
+  IMovementStep,
+  MovementAnimationMode,
+} from '@/types/gameplay';
+
+import { usePrefersReducedMotion } from '@/hooks/useReducedMotion';
+import { useAnimationQueue } from '@/stores/useAnimationQueue';
+import { Facing, GameEventType, MovementType } from '@/types/gameplay';
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/**
+ * Options for the replay movement-animation adapter.
+ */
+export interface IUseReplayMovementAnimationsOptions {
+  /**
+   * Stable identifier for the replay surface. Must NOT collide with a
+   * live-play `mapId` if both surfaces are co-mounted. Common values:
+   * `'replay'` (standalone replay route) and `'quickgame-replay'`
+   * (results-page replay tab).
+   */
+  readonly mapId: string;
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/**
+ * Drive `useAnimationQueue` from a replay event log + scrubber cursor.
+ *
+ * Returns `void` — all output is the side-effect of mutating the
+ * animation queue store. Components mount this hook alongside
+ * `useHexMapStateFromEvents` to compose the visual replay surface.
+ *
+ * @example
+ * ```tsx
+ * const replay = useSharedReplayPlayer({ gameId, events });
+ * const hexMap = useHexMapStateFromEvents(events, replay.currentSequence);
+ * useReplayMovementAnimations(events, replay.currentSequence, {
+ *   mapId: 'quickgame-replay',
+ * });
+ * ```
+ */
+export function useReplayMovementAnimations(
+  events: readonly IGameEvent[],
+  currentSequence: number,
+  opts: IUseReplayMovementAnimationsOptions,
+): void {
+  const reducedMotion = usePrefersReducedMotion();
+  // Track the previous cursor so we can detect rewind vs forward
+  // advance. Initialized to `-1` so the very first render walks every
+  // event with `sequence <= currentSequence` (matching the projection
+  // hook's "walk-from-zero on every render" contract for the visual
+  // queue's first fill).
+  const prevCursorRef = useRef<number>(-1);
+
+  useEffect(() => {
+    // Reduced-motion bypass — token positions still update via the
+    // pure projection hook; we just don't animate the transition.
+    if (reducedMotion) {
+      prevCursorRef.current = currentSequence;
+      return;
+    }
+
+    const prev = prevCursorRef.current;
+    const next = currentSequence;
+
+    // Rewind branch (D3): flush in-flight + queued animations so a
+    // stale walk cannot finish on top of the new scrub position.
+    // After flush, fall through to the forward branch with `prev = -1`
+    // so any backfill animation for the new cursor still plays — but
+    // in practice rewinds are usually multi-event jumps and we rely on
+    // the projection hook to ground-truth token positions; the queue
+    // simply restarts clean.
+    if (next < prev) {
+      useAnimationQueue.getState().reset();
+      prevCursorRef.current = next;
+      return;
+    }
+
+    // No-op when the cursor didn't actually move.
+    if (next === prev) return;
+
+    // Forward branch — enqueue every `MovementDeclared` event whose
+    // sequence is strictly greater than `prev` and ≤ `next`. We process
+    // events in commit order so the queue's per-unit overlap detection
+    // serializes step animations correctly.
+    for (const event of events) {
+      if (event.type !== GameEventType.MovementDeclared) continue;
+      if (event.sequence <= prev) continue;
+      if (event.sequence > next) break;
+
+      const payload = event.payload as IMovementDeclaredPayload;
+      enqueueMovementForEvent(event, payload, opts.mapId);
+    }
+
+    prevCursorRef.current = next;
+    // We deliberately exclude `events` from the dep array — the events
+    // list is a stable reference per replay session (uploaded log or
+    // session log), and including it would cause spurious re-fires on
+    // unrelated parent re-renders that pass a fresh array literal.
+    // `currentSequence` is the only value that should retrigger the
+    // walk. Same for `opts.mapId` and `reducedMotion`, which are stable
+    // across the life of the surface.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentSequence, opts.mapId, reducedMotion]);
+}
+
+// =============================================================================
+// Per-event enqueue
+// =============================================================================
+
+/**
+ * Enqueue the right number of movement animations for a single
+ * `MovementDeclared` event. Consumes the step chain when present;
+ * falls back to a single instant-snap animation for legacy events.
+ */
+function enqueueMovementForEvent(
+  event: IGameEvent,
+  payload: IMovementDeclaredPayload,
+  mapId: string,
+): void {
+  const enqueue = useAnimationQueue.getState().enqueue;
+
+  // Legacy fallback (per spec scenario "Legacy event without steps
+  // falls back to instant snap"). Synthesizes a single walk-mode
+  // animation from `from` → `to` so the renderer's path-tween plays
+  // even without step decomposition.
+  if (payload.steps === undefined || payload.steps.length === 0) {
+    const mode = movementAnimationModeForType(payload.movementType);
+    enqueue({
+      id: `replay-movement-${event.id}-fallback`,
+      mapId,
+      unitId: payload.unitId,
+      kind: 'movement',
+      path: [payload.from, payload.to],
+      occupiedHexes: [payload.from, payload.to],
+      ...(mode !== null ? { mode } : {}),
+      finalFacing: payload.facing,
+      eventSequence: event.sequence,
+    });
+    return;
+  }
+
+  // Step-chain path — one animation per actionable step in commit
+  // order. We intentionally walk by index so the discriminated-union
+  // narrowing on `step.kind` stays readable.
+  let runningFacing: Facing | undefined;
+  for (const step of payload.steps) {
+    const animation = animationForStep(
+      step,
+      payload,
+      event,
+      mapId,
+      runningFacing,
+    );
+    if (animation === null) continue;
+
+    // Update the running facing so subsequent `turn` steps emit
+    // correct `initialFacing` / `finalFacing` pairs even when chained.
+    if (animation.finalFacing !== undefined) {
+      runningFacing = animation.finalFacing;
+    }
+
+    enqueue(animation);
+  }
+}
+
+// =============================================================================
+// Step → animation translation
+// =============================================================================
+
+/**
+ * Translate a single `IMovementStep` into the matching
+ * `TacticalAnimation` payload for `useAnimationQueue.enqueue`. Returns
+ * `null` for steps that should not produce a queue entry (state-
+ * transition kinds like `standUp` / `goProne` / charge / DFA / swarm).
+ */
+function animationForStep(
+  step: IMovementStep,
+  payload: IMovementDeclaredPayload,
+  event: IGameEvent,
+  mapId: string,
+  runningFacing: Facing | undefined,
+): {
+  readonly id: string;
+  readonly mapId: string;
+  readonly unitId: string;
+  readonly kind: 'movement';
+  readonly path?: readonly [
+    IMovementDeclaredPayload['from'],
+    IMovementDeclaredPayload['to'],
+  ];
+  readonly occupiedHexes?: readonly [
+    IMovementDeclaredPayload['from'],
+    IMovementDeclaredPayload['to'],
+  ];
+  readonly mode?: MovementAnimationMode;
+  readonly initialFacing?: Facing;
+  readonly finalFacing?: Facing;
+  readonly eventSequence: number;
+} | null {
+  const baseId = `replay-movement-${event.id}-${step.index}`;
+
+  switch (step.kind) {
+    case 'forward':
+    case 'lateral': {
+      const mode = movementAnimationModeForType(payload.movementType);
+      return {
+        id: baseId,
+        mapId,
+        unitId: payload.unitId,
+        kind: 'movement',
+        path: [step.from, step.to],
+        occupiedHexes: [step.from, step.to],
+        ...(mode !== null ? { mode } : {}),
+        eventSequence: event.sequence,
+      };
+    }
+    case 'jump': {
+      // Jump steps always use the jump-arc renderer regardless of the
+      // parent payload's `movementType`. In practice the runner emits
+      // `movementType: Jump` for any payload containing a jump step,
+      // but this preserves the contract even if the payload is
+      // mislabeled.
+      return {
+        id: baseId,
+        mapId,
+        unitId: payload.unitId,
+        kind: 'movement',
+        path: [step.from, step.to],
+        occupiedHexes: [step.from, step.to],
+        mode: MovementType.Jump,
+        eventSequence: event.sequence,
+      };
+    }
+    case 'turn': {
+      // Turn steps carry only facing — no `path`. The renderer's
+      // existing facing-tween consumes `initialFacing` / `finalFacing`
+      // and rotates the token in place.
+      return {
+        id: baseId,
+        mapId,
+        unitId: payload.unitId,
+        kind: 'movement',
+        initialFacing: runningFacing ?? step.fromFacing,
+        finalFacing: step.toFacing,
+        eventSequence: event.sequence,
+      };
+    }
+    // State-transition steps — handled by the token renderer's pose
+    // state (prone / standing / charging / DFA / swarm), not by an
+    // interpolated tween. Skip silently per the spec contract.
+    case 'standUp':
+    case 'goProne':
+    case 'chargeDeclared':
+    case 'dfaDeclared':
+    case 'shakeOffSwarm':
+      return null;
+  }
+}
+
+/**
+ * Translate a parent `MovementType` into the queue's narrower
+ * `MovementAnimationMode`. Returns `null` for `Stationary` (which
+ * should not appear in a real replay anyway) so the caller can omit
+ * the field.
+ */
+function movementAnimationModeForType(
+  movementType: MovementType,
+): MovementAnimationMode | null {
+  switch (movementType) {
+    case MovementType.Walk:
+    case MovementType.Run:
+    case MovementType.Jump:
+      return movementType;
+    case MovementType.Stationary:
+    default:
+      return null;
+  }
+}

--- a/src/pages/gameplay/encounters/[id].tsx
+++ b/src/pages/gameplay/encounters/[id].tsx
@@ -20,6 +20,7 @@ import {
   DeleteEncounterConfirmDialog,
   EncounterActionsFooter,
   EncounterScenarioGeneratorSection,
+  EncounterWatchReplayButton,
 } from '@/components/gameplay/pages/EncounterDetailPage.actions';
 import { EncounterRepairBanner } from '@/components/gameplay/pages/EncounterDetailPage.repairBanner';
 import {
@@ -270,6 +271,14 @@ export default function EncounterDetailPage(): React.ReactElement {
           >
             {getStatusLabel(encounter.status, true)}
           </Badge>
+
+          {/* Per `add-replay-step-and-effect-animations` (encounter-system
+              delta — "Encounter Detail Watch Replay Link"): Watch Replay
+              button is visible whenever the encounter row has a
+              persisted `gameSessionId`. The button itself returns null
+              when `gameSessionId === undefined`, so this conditional
+              region always renders safely regardless of status. */}
+          <EncounterWatchReplayButton gameSessionId={encounter.gameSessionId} />
 
           {!isLaunched && !isCompleted && (
             <>

--- a/src/pages/gameplay/games/[id]/replay.tsx
+++ b/src/pages/gameplay/games/[id]/replay.tsx
@@ -48,6 +48,7 @@ import {
 } from '@/hooks/audit';
 import {
   useHexMapStateFromEvents,
+  useReplayMovementAnimations,
   useSharedReplayPlayer,
 } from '@/hooks/replay';
 import { IBaseEvent, EventCategory } from '@/types/events';
@@ -187,6 +188,16 @@ export default function GameReplayPage(): React.ReactElement {
     uploadedEvents ?? [],
     replay.currentSequence,
   );
+
+  // Per `add-replay-step-and-effect-animations` (tactical-map-interface
+  // delta — "Replay Movement Step Animation Playback"): drive the
+  // shared `useAnimationQueue` from the uploaded event log + cursor so
+  // tokens visually walk through their step chains during scrub. The
+  // `mapId` is scoped to this surface so it never collides with a co-
+  // mounted live-play queue.
+  useReplayMovementAnimations(uploadedEvents ?? [], replay.currentSequence, {
+    mapId: 'replay',
+  });
 
   // Status-pill summary for the JsonlFileLoader.
   const uploadSummary = useMemo(() => {
@@ -459,6 +470,14 @@ export default function GameReplayPage(): React.ReactElement {
             <div className="bg-surface-base/30 flex flex-1 items-center justify-center overflow-hidden">
               {isUploadActive && hexMapState.tokens.length > 0 ? (
                 <HexMapDisplay
+                  // Per `add-replay-step-and-effect-animations` D6: scope
+                  // the animation queue's `mapId` to this surface so a
+                  // co-mounted live-play queue can never block on (or
+                  // be blocked by) replay animations. `<HexMapDisplay>`
+                  // already mounts `<AttackEffectsLayer>` internally
+                  // with this `mapId`, so weapon impact visuals fire in
+                  // replay alongside movement.
+                  mapId="replay"
                   radius={hexMapState.mapRadius > 0 ? hexMapState.mapRadius : 9}
                   tokens={hexMapState.tokens}
                   hexTerrain={hexMapState.hexTerrain}


### PR DESCRIPTION
## Summary

Closes 3 visual-polish gaps surfaced by the OMO Council on hex-board replay polish:

1. **Movement step animation in replay** (Gap A) — replay tokens now visibly walk through their committed step chain (300 ms / hex walk, 180 ms / hex run, 600 ms parabolic jump arc) instead of teleporting to the destination. Driven by a NEW side-effect adapter (`useReplayMovementAnimations`) that observes cursor advancement and enqueues one `TacticalAnimation` per `IMovementStep` into the existing `useAnimationQueue` Zustand store. Cursor rewind triggers `reset()` so stale walks can't finish on top of the new state.
2. **AttackEffectsLayer in replay surfaces** (Gap A') — `<HexMapDisplay>` already mounts the layer internally and forwards the `mapId`. Both replay surfaces (`QuickGameReplayPanel` + standalone `/gameplay/games/[id]/replay`) now pass replay-scoped `mapId`s (`quickgame-replay` / `replay`) so weapon impacts (laser beams, missile trails, projectile arcs, impact flashes) play during scrub without colliding with a co-mounted live-play queue.
3. **Encounter Watch Replay link** (Gap B) — encounter detail page renders a `Watch Replay` button (next to the status badge in the header) when `encounter.gameSessionId` is populated. Clicking the button calls `router.push('/gameplay/games/<sessionId>/replay')` so the encounter store stays warm across the navigation.

## Spec Deltas

- **`tactical-map-interface`** — 2 ADDED requirements (Replay Movement Step Animation Playback, Attack Effects Layer In Replay Surfaces) covering 9 scenarios.
- **`encounter-system`** — 1 ADDED requirement (Encounter Detail Watch Replay Link) covering 4 scenarios.

No breaking changes. `IAttackResolvedPayload` and `IMovementDeclaredPayload` are unchanged (per design D4 — geometry derives from token state, not payload enrichment). The persisted NDJSON event log contract holds.

## Test Coverage

26 new tests across 5 test files, 115 tests pass total in the touched directories:

- `useReplayMovementAnimations.test.tsx` (10) — all 6 spec scenarios + edge cases (lateral, forward advance, cursor unchanged).
- `useReplayMovementAnimations.integration.test.tsx` (2) — adapter+reducer composition contract (3-step move enqueues 3 anims AND walks token to dest; rewind flushes queue while projection regrounds).
- `QuickGameReplayPanel.attackEffects.test.tsx` (5) — layer mount + mapId scoping + tokens/events forwarding + empty-events guard.
- `replay.attackEffects.test.tsx` (3) — same coverage shape as the panel test for the standalone route.
- `EncounterDetailPage.watchReplay.test.tsx` (6) — all 4 spec scenarios + edge cases (empty-string id, no console warnings on transition).

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` clean
- [x] `npx oxlint` — 0 errors (49 pre-existing warnings unrelated to this change)
- [x] `npx oxfmt --check` clean
- [x] `npx jest src/hooks/replay/__tests__/ src/components/quickgame/__tests__/ src/components/gameplay/pages/__tests__/ src/__tests__/pages/gameplay/games/` — 115/115 tests pass
- [x] `npx openspec validate add-replay-step-and-effect-animations --strict` — valid
- [ ] Manual smoke (deferred to operator): launch a quick game with a multi-hex walk + jump, open Replay tab, scrub forward and back — token visibly walks/arcs, beams/missiles play, rewind doesn't leave a stale animation.
- [ ] Manual smoke (deferred to operator): launch an encounter, navigate back to detail page, click Watch Replay, verify the replay loads.

## Files

- NEW: `src/hooks/replay/useReplayMovementAnimations.ts`
- MODIFIED: `src/components/quickgame/QuickGameReplayPanel.tsx` (mapId + adapter wiring)
- MODIFIED: `src/pages/gameplay/games/[id]/replay.tsx` (mapId + adapter wiring)
- MODIFIED: `src/components/gameplay/pages/EncounterDetailPage.actions.tsx` (new `EncounterWatchReplayButton`)
- MODIFIED: `src/pages/gameplay/encounters/[id].tsx` (mount the new button in header)
- MODIFIED: `src/hooks/replay/index.ts` (re-export)
- 5 new test files
