### PR TITLE
fix(battlearmor): make armorPerTrooper authoritative for pip display

### DIFF
--- a/src/components/customizer/armor/__tests__/BattleArmorPipGrid.test.tsx
+++ b/src/components/customizer/armor/__tests__/BattleArmorPipGrid.test.tsx
@@ -80,16 +80,64 @@ describe('BattleArmorPipGrid', () => {
     expect(screen.getByLabelText('Trooper 1: 7 of 7')).toBeInTheDocument();
   });
 
-  it('renders correct pip count for Assault weight class (15 pips)', () => {
+  it('renders correct pip count for Assault weight class fully allocated (15 pips)', () => {
     mockUseBattleArmorStore.mockImplementation((selector) =>
       selector(
         makeState({
           weightClass: BattleArmorWeightClass.ASSAULT,
+          armorPerTrooper: 15,
         }) as unknown as BattleArmorStore,
       ),
     );
     render(<BattleArmorPipGrid />);
     expect(screen.getByLabelText('Trooper 1: 15 of 15')).toBeInTheDocument();
+  });
+
+  // Regression coverage for the armorPerTrooper-authoritative fix
+  // (audit: docs/audits/2026-05-13-customizer-armor-megameklab-parity.md lines 238-255).
+  it('renders armorPerTrooper count even when above weight-class max (8 on LIGHT)', () => {
+    mockUseBattleArmorStore.mockImplementation((selector) =>
+      selector(
+        makeState({
+          weightClass: BattleArmorWeightClass.LIGHT,
+          armorPerTrooper: 8,
+          squadSize: 1,
+        }) as unknown as BattleArmorStore,
+      ),
+    );
+    render(<BattleArmorPipGrid />);
+    // Prior bug clamped to LIGHT max (5). After fix, armorPerTrooper wins.
+    expect(screen.getByLabelText('Trooper 1: 8 of 8')).toBeInTheDocument();
+  });
+
+  it('renders armorPerTrooper count even when below weight-class max (4 on HEAVY)', () => {
+    mockUseBattleArmorStore.mockImplementation((selector) =>
+      selector(
+        makeState({
+          weightClass: BattleArmorWeightClass.HEAVY,
+          armorPerTrooper: 4,
+          squadSize: 1,
+        }) as unknown as BattleArmorStore,
+      ),
+    );
+    render(<BattleArmorPipGrid />);
+    // Prior bug showed HEAVY max (11). After fix, armorPerTrooper wins.
+    expect(screen.getByLabelText('Trooper 1: 4 of 4')).toBeInTheDocument();
+  });
+
+  it('falls back to weight-class max when armorPerTrooper is undefined', () => {
+    mockUseBattleArmorStore.mockImplementation((selector) =>
+      selector(
+        makeState({
+          weightClass: BattleArmorWeightClass.HEAVY,
+          armorPerTrooper: undefined,
+          squadSize: 1,
+        }) as unknown as BattleArmorStore,
+      ),
+    );
+    render(<BattleArmorPipGrid />);
+    // Legacy fallback path — guard against regression.
+    expect(screen.getByLabelText('Trooper 1: 11 of 11')).toBeInTheDocument();
   });
 
   it('reduces remaining pips for a damaged trooper', () => {

--- a/src/components/customizer/battlearmor/BattleArmorPipGrid.tsx
+++ b/src/components/customizer/battlearmor/BattleArmorPipGrid.tsx
@@ -75,8 +75,14 @@ export function BattleArmorPipGrid({
   const weightClass = useBattleArmorStore((s) => s.weightClass);
   const chassisType = useBattleArmorStore((s) => s.chassisType);
 
-  // Derive pip max from weight class; fall back to armorPerTrooper if class unknown
-  const maxPips = MAX_PIPS_BY_WEIGHT_CLASS[weightClass] ?? armorPerTrooper;
+  // armorPerTrooper is authoritative — it reflects the player's current allocation.
+  // MAX_PIPS_BY_WEIGHT_CLASS is the weight-class cap, used only when armorPerTrooper
+  // is not yet set (legacy/undefined). Prior order showed full weight-class max even
+  // when the player had explicitly allocated less.
+  const maxPips =
+    armorPerTrooper != null
+      ? armorPerTrooper
+      : MAX_PIPS_BY_WEIGHT_CLASS[weightClass];
 
   const troopers = Array.from({ length: squadSize }, (_, i) => i);
 


### PR DESCRIPTION
## Summary

Inverts the pip-count fallback in `BattleArmorPipGrid` so `armorPerTrooper` (the player's current allocation) is the authoritative source for rendered pips. Weight-class max becomes the legacy/undefined fallback.

## Bug

A Heavy Battle Armor suit with `armorPerTrooper=4` was rendering 11 pips per trooper (the HEAVY weight-class max) instead of 4. The diagram was lying about how much armor the trooper actually had.

A Light Battle Armor suit with `armorPerTrooper=8` was clamping the display to 5 pips (the LIGHT weight-class max) instead of showing 8.

Source: [`docs/audits/2026-05-13-customizer-armor-megameklab-parity.md`](docs/audits/2026-05-13-customizer-armor-megameklab-parity.md) lines 238-255.

## Fix

`src/components/customizer/battlearmor/BattleArmorPipGrid.tsx:78-85` — invert the fallback. `armorPerTrooper != null ? armorPerTrooper : MAX_PIPS_BY_WEIGHT_CLASS[weightClass]`.

## Tests

12/12 local pass. Additions:
- Regression: `armorPerTrooper=8` on LIGHT renders 8 pips (was clamping to 5).
- Regression: `armorPerTrooper=4` on HEAVY renders 4 pips (was showing 11).
- Regression: `armorPerTrooper=undefined` falls back to weight-class max (guards legacy path).
- Updated the Assault test to set `armorPerTrooper=15` reflecting the new contract.

## Test plan

- [x] `npx jest BattleArmorPipGrid` — 12/12 pass
- [ ] CI green