### PR TITLE
fix(aerospace): correct diagram cap to construction-spec, unify cap math

### DIFF
--- a/src/components/customizer/aerospace/AerospaceArmorDiagram.tsx
+++ b/src/components/customizer/aerospace/AerospaceArmorDiagram.tsx
@@ -32,6 +32,7 @@ import { useAerospaceStore } from '@/stores/useAerospaceStore';
 import { getArmorDefinition } from '@/types/construction/ArmorType';
 import { AerospaceLocation } from '@/types/construction/UnitLocation';
 import { AerospaceSubType } from '@/types/unit/AerospaceInterfaces';
+import { maxArcArmorPointsForLocation } from '@/utils/construction/aerospace/armorArcCalculations';
 
 import { ArmorAllocationInput } from '../armor/ArmorAllocationInput';
 import { ArmorLocationBlock } from '../armor/ArmorLocationBlock';
@@ -41,55 +42,22 @@ import { ArmorLocationBlock } from '../armor/ArmorLocationBlock';
 // =============================================================================
 
 /**
- * Per-arc share of total armor points (matches store's autoAllocateArmor splits).
- *   Nose 35% / Wings 25% each / Aft 15%  → totals 100%
- */
-const ARC_SHARE: Record<AerospaceLocation, number> = {
-  [AerospaceLocation.NOSE]: 0.35,
-  [AerospaceLocation.LEFT_WING]: 0.25,
-  [AerospaceLocation.RIGHT_WING]: 0.25,
-  [AerospaceLocation.AFT]: 0.15,
-  [AerospaceLocation.FUSELAGE]: 0,
-};
-
-/**
- * Hard tonnage cap on armor per the rules:
- *   - Aerospace fighters: max 8 × tonnage points (per TM Aerospace).
- *   - Small craft: max 16 × tonnage points (per StratOps).
- *
- * Used as an upper-bound sanity cap when computing per-arc maxima so the
- * diagram never displays a max greater than the rules permit even if the
- * raw armor tonnage is over-allocated by the user.
- */
-function maxTotalArmorPoints(
-  tonnage: number,
-  subType: AerospaceSubType,
-): number {
-  if (subType === AerospaceSubType.SMALL_CRAFT) {
-    return tonnage * 16;
-  }
-  return tonnage * 8;
-}
-
-/**
  * Per-arc maximum armor points.
  *
- * = min(armorTonnage * pointsPerTon, maxTotalArmorPoints) * arcShare
+ * Delegates to the canonical construction-spec utility (TechManual / StratOps
+ * arc-factor tables: Nose 0.28, Wings/Sides 0.20 each, Aft 0.12 of tonnage).
  *
- * Honours the configured armor type's points-per-ton (Standard 16, Ferro 17.92, …)
- * and applies the chassis cap so arcs can never exceed legal limits.
+ * The previous local cap math derived arc maxima from `armorTonnage * pointsPerTon`
+ * and a 35/25/25/15 share, then clamped against `tonnage * 8` / `tonnage * 16`.
+ * That produced a cap ~10× larger than the construction-spec values and
+ * disagreed with the tab's clamp-on-write (which already used 0.28-of-tonnage).
  */
 function getArcMax(
   tonnage: number,
-  armorTonnage: number,
-  pointsPerTon: number,
   subType: AerospaceSubType,
   arc: AerospaceLocation,
 ): number {
-  const requested = Math.floor(armorTonnage * pointsPerTon);
-  const cap = maxTotalArmorPoints(tonnage, subType);
-  const total = Math.max(0, Math.min(requested, cap));
-  return Math.floor(total * (ARC_SHARE[arc] ?? 0));
+  return maxArcArmorPointsForLocation(arc, tonnage, subType);
 }
 
 // =============================================================================
@@ -135,6 +103,9 @@ export function AerospaceArmorDiagram({
   const siMax = Math.ceil(tonnage / 10); // structural integrity equals SI rating
 
   // Resolve points-per-ton for the configured armor type (defaults to 16).
+  // Retained for availablePoints display below; per-arc cap math no longer
+  // depends on armorTonnage or pointsPerTon (caps come from chassis tonnage
+  // and arc-factor table, per construction spec).
   const pointsPerTon = useMemo(() => {
     const def = getArmorDefinition(armorType);
     return def?.pointsPerTon ?? 16;
@@ -142,10 +113,10 @@ export function AerospaceArmorDiagram({
 
   const handleChange = useCallback(
     (arc: AerospaceLocation, raw: number) => {
-      const max = getArcMax(tonnage, armorTonnage, pointsPerTon, subType, arc);
+      const max = getArcMax(tonnage, subType, arc);
       setArcArmor(arc, Math.max(0, Math.min(max, raw)));
     },
-    [setArcArmor, tonnage, armorTonnage, pointsPerTon, subType],
+    [setArcArmor, tonnage, subType],
   );
 
   // Detect any non-default arc allocation for the confirm gate
@@ -276,13 +247,7 @@ export function AerospaceArmorDiagram({
       <div className="grid grid-cols-2 gap-3">
         {ARCS.map(({ arc, label }) => {
           const current = (armorAllocation as Record<string, number>)[arc] ?? 0;
-          const max = getArcMax(
-            tonnage,
-            armorTonnage,
-            pointsPerTon,
-            subType,
-            arc,
-          );
+          const max = getArcMax(tonnage, subType, arc);
           return (
             <div key={arc} className="flex flex-col gap-1">
               <ArmorLocationBlock

--- a/src/components/customizer/aerospace/AerospaceArmorTab.tsx
+++ b/src/components/customizer/aerospace/AerospaceArmorTab.tsx
@@ -16,6 +16,10 @@ import {
   getArmorDefinition,
 } from '@/types/construction/ArmorType';
 import { AerospaceLocation } from '@/types/construction/UnitLocation';
+import {
+  maxArcArmorPointsForLocation,
+  maxTotalArmorPoints,
+} from '@/utils/construction/aerospace/armorArcCalculations';
 import { ceilToHalfTon } from '@/utils/physical/weightUtils';
 
 import { customizerStyles as cs } from '../styles';
@@ -63,30 +67,6 @@ function calculateArmorPoints(
   return Math.floor(tonnage * pointsPerTon);
 }
 
-function getMaxAerospaceArmorForArc(
-  tonnage: number,
-  arc: AerospaceLocation,
-): number {
-  // Aerospace armor maximums are based on tonnage and arc
-  const baseArmor = Math.floor(tonnage * 0.8); // Max ~80% of tonnage in armor points
-
-  switch (arc) {
-    case AerospaceLocation.NOSE:
-      return Math.floor(baseArmor * 0.35); // Nose gets most
-    case AerospaceLocation.LEFT_WING:
-    case AerospaceLocation.RIGHT_WING:
-      return Math.floor(baseArmor * 0.25); // Wings get equal
-    case AerospaceLocation.AFT:
-      return Math.floor(baseArmor * 0.15); // Aft gets least
-    default:
-      return 0;
-  }
-}
-
-function getMaxTotalAerospaceArmor(tonnage: number): number {
-  return Math.floor(tonnage * 0.8); // Simplified max armor
-}
-
 // =============================================================================
 // Component
 // =============================================================================
@@ -100,6 +80,7 @@ export function AerospaceArmorTab({
   const armorType = useAerospaceStore((s) => s.armorType);
   const armorTonnage = useAerospaceStore((s) => s.armorTonnage);
   const armorAllocation = useAerospaceStore((s) => s.armorAllocation);
+  const subType = useAerospaceStore((s) => s.aerospaceSubType);
 
   // Get actions
   const setArmorType = useAerospaceStore((s) => s.setArmorType);
@@ -120,8 +101,8 @@ export function AerospaceArmorTab({
     [armorAllocation],
   );
   const maxTotalArmor = useMemo(
-    () => getMaxTotalAerospaceArmor(tonnage),
-    [tonnage],
+    () => maxTotalArmorPoints(tonnage, subType),
+    [tonnage, subType],
   );
   const maxUsefulTonnage = useMemo(
     () => ceilToHalfTon(maxTotalArmor / pointsPerTon),
@@ -148,11 +129,11 @@ export function AerospaceArmorTab({
 
   const handleArcArmorChange = useCallback(
     (arc: AerospaceLocation, points: number) => {
-      const max = getMaxAerospaceArmorForArc(tonnage, arc);
+      const max = maxArcArmorPointsForLocation(arc, tonnage, subType);
       const clamped = Math.max(0, Math.min(max, points));
       setArcArmor(arc, clamped);
     },
-    [setArcArmor, tonnage],
+    [setArcArmor, tonnage, subType],
   );
 
   const handleMaximizeArmor = useCallback(() => {
@@ -304,7 +285,11 @@ export function AerospaceArmorTab({
           <div className="space-y-3">
             {AEROSPACE_ARCS.map(({ arc, label }) => {
               const currentValue = armorAllocation[arc] ?? 0;
-              const maxValue = getMaxAerospaceArmorForArc(tonnage, arc);
+              const maxValue = maxArcArmorPointsForLocation(
+                arc,
+                tonnage,
+                subType,
+              );
 
               return (
                 <div

--- a/src/utils/construction/aerospace/__tests__/armorArcCalculations.test.ts
+++ b/src/utils/construction/aerospace/__tests__/armorArcCalculations.test.ts
@@ -7,6 +7,7 @@
  * maxArcArmorPoints = floor(tonnage × factor).
  */
 
+import { AerospaceLocation } from '@/types/construction/UnitLocation';
 import {
   AerospaceArc,
   AerospaceSubType,
@@ -16,7 +17,9 @@ import {
   arcMaxMap,
   ASF_CF_ARCS,
   getArcsForSubType,
+  mapAerospaceLocationToArc,
   maxArcArmorPoints,
+  maxArcArmorPointsForLocation,
   maxTotalArmorPoints,
   SMALL_CRAFT_ARCS,
 } from '../armorArcCalculations';
@@ -106,5 +109,124 @@ describe('arcMaxMap', () => {
     expect(map[AerospaceArc.LEFT_WING]).toBe(10);
     expect(map[AerospaceArc.RIGHT_WING]).toBe(10);
     expect(map[AerospaceArc.AFT]).toBe(6);
+  });
+});
+
+// =============================================================================
+// Enum bridge — AerospaceLocation (UI) → AerospaceArc (construction)
+// =============================================================================
+
+describe('mapAerospaceLocationToArc', () => {
+  it('maps every AerospaceLocation member to the corresponding AerospaceArc', () => {
+    expect(mapAerospaceLocationToArc(AerospaceLocation.NOSE)).toBe(
+      AerospaceArc.NOSE,
+    );
+    expect(mapAerospaceLocationToArc(AerospaceLocation.LEFT_WING)).toBe(
+      AerospaceArc.LEFT_WING,
+    );
+    expect(mapAerospaceLocationToArc(AerospaceLocation.RIGHT_WING)).toBe(
+      AerospaceArc.RIGHT_WING,
+    );
+    expect(mapAerospaceLocationToArc(AerospaceLocation.AFT)).toBe(
+      AerospaceArc.AFT,
+    );
+    expect(mapAerospaceLocationToArc(AerospaceLocation.FUSELAGE)).toBe(
+      AerospaceArc.FUSELAGE,
+    );
+  });
+});
+
+describe('maxArcArmorPointsForLocation — caps drop from 10× misleading display', () => {
+  // Audit findings (docs/audits/2026-05-13-customizer-armor-megameklab-parity.md):
+  // The diagram previously displayed `tonnage * 8 * arcShare` caps — 10× the
+  // construction-spec values. Post-PR2 the diagram uses these utility values.
+  it('50t ASF nose max = 14 (was 140 in old diagram)', () => {
+    expect(
+      maxArcArmorPointsForLocation(
+        AerospaceLocation.NOSE,
+        50,
+        AerospaceSubType.AEROSPACE_FIGHTER,
+      ),
+    ).toBe(14);
+  });
+
+  it('50t ASF wing maxes = 10 each (was 100 in old diagram)', () => {
+    expect(
+      maxArcArmorPointsForLocation(
+        AerospaceLocation.LEFT_WING,
+        50,
+        AerospaceSubType.AEROSPACE_FIGHTER,
+      ),
+    ).toBe(10);
+    expect(
+      maxArcArmorPointsForLocation(
+        AerospaceLocation.RIGHT_WING,
+        50,
+        AerospaceSubType.AEROSPACE_FIGHTER,
+      ),
+    ).toBe(10);
+  });
+
+  it('50t ASF aft max = 6 (was 60 in old diagram)', () => {
+    expect(
+      maxArcArmorPointsForLocation(
+        AerospaceLocation.AFT,
+        50,
+        AerospaceSubType.AEROSPACE_FIGHTER,
+      ),
+    ).toBe(6);
+  });
+
+  it('100t ASF totals match maxTotalArmorPoints (28+20+20+12=80)', () => {
+    const nose = maxArcArmorPointsForLocation(
+      AerospaceLocation.NOSE,
+      100,
+      AerospaceSubType.AEROSPACE_FIGHTER,
+    );
+    const lw = maxArcArmorPointsForLocation(
+      AerospaceLocation.LEFT_WING,
+      100,
+      AerospaceSubType.AEROSPACE_FIGHTER,
+    );
+    const rw = maxArcArmorPointsForLocation(
+      AerospaceLocation.RIGHT_WING,
+      100,
+      AerospaceSubType.AEROSPACE_FIGHTER,
+    );
+    const aft = maxArcArmorPointsForLocation(
+      AerospaceLocation.AFT,
+      100,
+      AerospaceSubType.AEROSPACE_FIGHTER,
+    );
+    expect(nose + lw + rw + aft).toBe(
+      maxTotalArmorPoints(100, AerospaceSubType.AEROSPACE_FIGHTER),
+    );
+  });
+
+  it('small craft via the wing-location bridge: wings yield 0 (sides are AerospaceArc-only)', () => {
+    // AerospaceLocation has no LEFT_SIDE / RIGHT_SIDE today — small-craft
+    // side-arc UI routing is the deferred audit P1 work. Wing locations on a
+    // small craft therefore yield 0 via the bridge, matching that scope guard.
+    expect(
+      maxArcArmorPointsForLocation(
+        AerospaceLocation.LEFT_WING,
+        200,
+        AerospaceSubType.SMALL_CRAFT,
+      ),
+    ).toBe(0);
+    expect(
+      maxArcArmorPointsForLocation(
+        AerospaceLocation.NOSE,
+        200,
+        AerospaceSubType.SMALL_CRAFT,
+      ),
+    ).toBe(56);
+    expect(
+      maxArcArmorPointsForLocation(
+        AerospaceLocation.AFT,
+        200,
+        AerospaceSubType.SMALL_CRAFT,
+      ),
+    ).toBe(24);
   });
 });

--- a/src/utils/construction/aerospace/armorArcCalculations.ts
+++ b/src/utils/construction/aerospace/armorArcCalculations.ts
@@ -9,6 +9,7 @@
  * Requirement: Armor Allocation per Firing Arc
  */
 
+import { AerospaceLocation } from '../../../types/construction/UnitLocation';
 import {
   AerospaceArc,
   AerospaceSubType,
@@ -121,4 +122,47 @@ export function arcMaxMap(
     result[arc] = maxArcArmorPoints(arc, tonnage, subType);
   }
   return result;
+}
+
+// ============================================================================
+// Enum Bridge
+// ============================================================================
+
+/**
+ * Bridge AerospaceLocation (used by the customizer UI) to AerospaceArc
+ * (used by construction-spec calc functions). The two enums carry the
+ * same semantic arcs but different string values; the UI's enum is the
+ * subset that omits the small-craft-only LEFT_SIDE / RIGHT_SIDE arcs.
+ *
+ * Returns null for arcs that have no AerospaceArc counterpart (none today;
+ * the function is total over AerospaceLocation members but kept as `| null`
+ * for future-proofing if non-arc locations are added).
+ */
+export function mapAerospaceLocationToArc(
+  loc: AerospaceLocation,
+): AerospaceArc {
+  switch (loc) {
+    case AerospaceLocation.NOSE:
+      return AerospaceArc.NOSE;
+    case AerospaceLocation.LEFT_WING:
+      return AerospaceArc.LEFT_WING;
+    case AerospaceLocation.RIGHT_WING:
+      return AerospaceArc.RIGHT_WING;
+    case AerospaceLocation.AFT:
+      return AerospaceArc.AFT;
+    case AerospaceLocation.FUSELAGE:
+      return AerospaceArc.FUSELAGE;
+  }
+}
+
+/**
+ * Convenience: max armor for a UI AerospaceLocation, dispatched to the
+ * construction-spec utility via the enum bridge.
+ */
+export function maxArcArmorPointsForLocation(
+  loc: AerospaceLocation,
+  tonnage: number,
+  subType: AerospaceSubType,
+): number {
+  return maxArcArmorPoints(mapAerospaceLocationToArc(loc), tonnage, subType);
 }


### PR DESCRIPTION
## Summary

**The aerospace armor diagram has been displaying a 10× cap.** This PR corrects the diagram to match the construction-spec utility — not a consolidation of two equivalent paths.

| Component | Old math | 50t ASF nose cap | New |
|---|---|---|---|
| `AerospaceArmorTab` (write-clamp) | `tonnage * 0.8 * 0.35` | **14** ✓ | `tonnage * 0.28` → **14** |
| `AerospaceArmorDiagram` (display) | `tonnage * 8 * 0.35` | **140** ✗ | `tonnage * 0.28` → **14** |
| `armorArcCalculations.ts` (canonical) | `tonnage * 0.28` | **14** ✓ | unchanged |

The tab has been clamping on write at the correct value all along, so saved over-cap data is not a real risk except for hand-edited JSON. Users will see the diagram suddenly show realistic caps.

Source: [`docs/audits/2026-05-13-customizer-armor-megameklab-parity.md`](docs/audits/2026-05-13-customizer-armor-megameklab-parity.md) lines 212-236.

## Why this isn't a "consolidation"

The OMO Council reframed PR2 as a **spec-tightening change**, not a consolidation. The diagram and the tab were displaying 10× different caps — they were never equivalent. The PR description has to lead with that so reviewers anticipate the visible-cap drop.

## Changes

- **`armorArcCalculations.ts`** — single source. Adds:
  - `mapAerospaceLocationToArc(loc)` enum bridge (UI `AerospaceLocation` → construction `AerospaceArc`).
  - `maxArcArmorPointsForLocation(loc, tonnage, subType)` convenience that dispatches through the bridge.
- **`AerospaceArmorTab.tsx`** — delete inline `getMaxAerospaceArmorForArc` + `getMaxTotalAerospaceArmor`; call canonical utility.
- **`AerospaceArmorDiagram.tsx`** — delete the local `ARC_SHARE` constant (lines 47-53 — was missing from the original plan, surfaced by council) and the local `maxTotalArmorPoints` + `getArcMax` inline math; call canonical utility. Drop the redundant `armorTonnage` / `pointsPerTon` args from the per-arc cap path.

## Tests

6 new unit tests:
- `mapAerospaceLocationToArc` maps every UI enum member to its construction counterpart.
- 50t ASF nose / wing / aft golden caps explicitly assert 14 / 10 / 6 (was 140 / 100 / 60).
- 100t ASF per-arc sum matches `maxTotalArmorPoints` invariant.
- Small-craft-via-wing-location yields 0 (matches deferred audit P1 — side-arc UI routing requires a separate change).

## Verification

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` (oxlint) — 0 warnings, 0 errors
- [x] `npx jest aerospace` — 539/539 pass
- [x] `npx tsx scripts/validate-bv.ts` — **ALL ACCURACY GATES PASSED** (BV parity preserved at 4187/4196 within 1%, 4196/4196 within 5%)
- [ ] CI green