### PR TITLE
fix(customizer): stop /customizer crash on non-mech tabs

### DIFF
--- a/src/hooks/__tests__/useAutoSaveIndicator.test.tsx
+++ b/src/hooks/__tests__/useAutoSaveIndicator.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Tests for useAutoSaveIndicator.
+ *
+ * Regression focus: the hook is mounted by CustomizerWithRouter, which sits
+ * ABOVE the UnitStoreProvider boundary. On non-mech tabs there is no provider,
+ * so the hook must read UnitStoreContext as nullable and no-op rather than
+ * throw (the pre-existing /customizer crash — audit
+ * .audit/2026-05-14-customizer-armor-diagram-visual-audit.md Finding 1).
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+
+import { useAutoSaveIndicator } from '@/hooks/useAutoSaveIndicator';
+import { createNewUnitStore, UnitStoreContext } from '@/stores/useUnitStore';
+import { TechBase } from '@/types/enums/TechBase';
+
+const showToastMock = jest.fn();
+jest.mock('@/components/shared/Toast', () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}));
+
+function makeStore() {
+  return createNewUnitStore({
+    name: 'Test Mech TST-1',
+    tonnage: 50,
+    techBase: TechBase.INNER_SPHERE,
+  });
+}
+
+beforeEach(() => {
+  showToastMock.mockClear();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe('useAutoSaveIndicator', () => {
+  it('does not throw when rendered with NO UnitStoreProvider ancestor', () => {
+    // The pre-existing /customizer crash: non-mech tabs have no provider.
+    expect(() => {
+      renderHook(() => useAutoSaveIndicator());
+    }).not.toThrow();
+  });
+
+  it('does not fire a toast when there is no store in context', () => {
+    renderHook(() => useAutoSaveIndicator());
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(showToastMock).not.toHaveBeenCalled();
+  });
+
+  it('fires a "Saved" toast after a debounce when the store records a modification', () => {
+    const store = makeStore();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <UnitStoreContext.Provider value={store}>
+        {children}
+      </UnitStoreContext.Provider>
+    );
+    renderHook(() => useAutoSaveIndicator(), { wrapper });
+
+    act(() => {
+      store.setState({ lastModifiedAt: Date.now() });
+    });
+    // Toast is debounced 500ms — not fired immediately.
+    expect(showToastMock).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Saved', variant: 'success' }),
+    );
+  });
+
+  it('does not fire a toast when the store has no modification', () => {
+    const store = makeStore();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <UnitStoreContext.Provider value={store}>
+        {children}
+      </UnitStoreContext.Provider>
+    );
+    renderHook(() => useAutoSaveIndicator(), { wrapper });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(showToastMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useAutoSaveIndicator.ts
+++ b/src/hooks/useAutoSaveIndicator.ts
@@ -1,16 +1,29 @@
-import { useEffect, useRef } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 
 import { useToast } from '@/components/shared/Toast';
-import { useUnitStoreApi } from '@/stores/useUnitStore';
+import { UnitStoreContext } from '@/stores/useUnitStore';
 
+/**
+ * Shows a "Saved" toast when the active unit store records a modification.
+ *
+ * `UnitStoreContext` is only provided on the BattleMech editor branch of the
+ * customizer (see UnitStoreProvider in UnitTypeRouter). This hook is mounted by
+ * CustomizerWithRouter, which sits ABOVE that provider — so on non-mech tabs
+ * (Vehicle / Aerospace / Battle Armor / Infantry / ProtoMech) the context is
+ * null. Read the context directly (nullable) instead of useUnitStoreApi (which
+ * throws) and no-op the subscription when there is no store — autosave
+ * indication is a mech-store capability today.
+ */
 export function useAutoSaveIndicator(): void {
   const { showToast } = useToast();
-  const storeApi = useUnitStoreApi();
+  const storeApi = useContext(UnitStoreContext);
 
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
   const lastModifiedRef = useRef<number>(0);
 
   useEffect(() => {
+    if (!storeApi) return;
+
     const unsubscribe = storeApi.subscribe((state) => {
       if (state.lastModifiedAt !== lastModifiedRef.current) {
         lastModifiedRef.current = state.lastModifiedAt;


### PR DESCRIPTION
## Summary

The `/customizer` route crashed to a full-screen error boundary on cold load for every non-mech unit type (Vehicle / Aerospace / Battle Armor / Infantry / ProtoMech).

`useAutoSaveIndicator` is mounted by `CustomizerWithRouter`, which sits **above** the `UnitStoreProvider` boundary — the provider only wraps the BattleMech branch inside `UnitTypeRouter`. The hook called `useUnitStoreApi()` unconditionally, which throws when there is no provider ancestor.

## Fix

Read `UnitStoreContext` directly as nullable instead of `useUnitStoreApi()` (which asserts non-null), and no-op the subscription effect when there is no store. One file. No provider relocation, no API change, no rules-of-hooks violation.

Autosave indication is a mech-store capability today. The 5 non-mech stores already carry `lastModifiedAt` (`vehicleState.ts:305`, `aerospaceState.ts:273`, `battleArmorState.ts:215`, `infantryState.ts:190`, `protoMechState.ts:246`) and can be wired to their own indicators later without an API change.

## Provenance

Pre-existing bug — predates the customizer armor parity wave (PRs #572-576). Surfaced by the customizer armor diagram audit ([`.audit/2026-05-14-customizer-armor-diagram-visual-audit.md`](.audit/2026-05-14-customizer-armor-diagram-visual-audit.md) Finding 1) and triaged by an OMO Council. This is **Option E** — the council ranked it above lifting the provider (silent data-loss risk), gating on unit type (rules-of-hooks ordering bug), and making `useUnitStoreApi` nullable (pushes unchecked nulls across every consumer).

## Tests

4 new — no-throw without provider (the regression guard), no-toast without store, debounced "Saved" toast on modification, no-toast without modification.

## Verification

- [x] `npx jest useAutoSaveIndicator` — 4/4 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` (oxlint) — 0 warnings, 0 errors
- [ ] CI green