### PR TITLE
chore(storybook): add per-unit-type armor diagram stories

### DIFF
--- a/src/components/customizer/aerospace/AerospaceArmorDiagram.stories.tsx
+++ b/src/components/customizer/aerospace/AerospaceArmorDiagram.stories.tsx
@@ -1,0 +1,79 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+
+import { useMemo } from 'react';
+
+import {
+  AerospaceStoreContext,
+  createNewAerospaceStore,
+} from '@/stores/useAerospaceStore';
+import { AerospaceLocation } from '@/types/construction/UnitLocation';
+import { TechBase } from '@/types/enums/TechBase';
+import { AerospaceSubType } from '@/types/unit/AerospaceInterfaces';
+
+import { AerospaceArmorDiagram } from './AerospaceArmorDiagram';
+
+/**
+ * Wrap a story in an AerospaceStoreContext provider. The diagram reads the
+ * active aerospace unit from the store; each story creates its own store and
+ * may seed post-creation state through the optional callback.
+ */
+function withAerospaceStore(
+  options: Parameters<typeof createNewAerospaceStore>[0],
+  seed?: (store: ReturnType<typeof createNewAerospaceStore>) => void,
+): Decorator {
+  return function AerospaceStoreDecorator(Story) {
+    const store = useMemo(() => {
+      const s = createNewAerospaceStore(options);
+      seed?.(s);
+      return s;
+    }, []);
+    return (
+      <AerospaceStoreContext.Provider value={store}>
+        <Story />
+      </AerospaceStoreContext.Provider>
+    );
+  };
+}
+
+const baseOptions = {
+  name: 'Story Fighter',
+  tonnage: 50,
+  techBase: TechBase.INNER_SPHERE,
+} as const;
+
+const meta: Meta<typeof AerospaceArmorDiagram> = {
+  title: 'Customizer/Armor/AerospaceArmorDiagram',
+  component: AerospaceArmorDiagram,
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof AerospaceArmorDiagram>;
+
+/** Aerospace fighter — 4 arcs at construction-spec caps (50t nose = 14). */
+export const Default: Story = {
+  decorators: [withAerospaceStore(baseOptions)],
+};
+
+/** Small craft — arc caps shift to the small-craft arc-factor table. */
+export const SmallCraft: Story = {
+  decorators: [
+    withAerospaceStore({ ...baseOptions, tonnage: 150 }, (store) => {
+      store.setState({ aerospaceSubType: AerospaceSubType.SMALL_CRAFT });
+    }),
+  ],
+};
+
+/** Over-cap allocation — the Nose arc holds more than its diagram cap. */
+export const OverCap: Story = {
+  decorators: [
+    withAerospaceStore(baseOptions, (store) => {
+      store.setState((s) => ({
+        armorAllocation: {
+          ...s.armorAllocation,
+          [AerospaceLocation.NOSE]: 200,
+        },
+      }));
+    }),
+  ],
+};

--- a/src/components/customizer/armor/ArmorDiagramForType.stories.tsx
+++ b/src/components/customizer/armor/ArmorDiagramForType.stories.tsx
@@ -1,0 +1,121 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+
+import { useMemo } from 'react';
+
+import {
+  AerospaceStoreContext,
+  createNewAerospaceStore,
+} from '@/stores/useAerospaceStore';
+import {
+  BattleArmorStoreContext,
+  createNewBattleArmorStore,
+} from '@/stores/useBattleArmorStore';
+import {
+  createNewInfantryStore,
+  InfantryStoreContext,
+} from '@/stores/useInfantryStore';
+import {
+  createNewProtoMechStore,
+  ProtoMechStoreContext,
+} from '@/stores/useProtoMechStore';
+import {
+  createNewVehicleStore,
+  VehicleStoreContext,
+} from '@/stores/useVehicleStore';
+import { TechBase } from '@/types/enums/TechBase';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+
+import { ArmorDiagramForType } from './ArmorDiagramForType';
+
+/**
+ * The dispatcher routes UnitType → per-type diagram. Each per-type diagram is
+ * store-coupled, so this decorator mounts all five per-type store providers at
+ * once — that lets the `unitType` arg control switch between every routable
+ * type without a missing-provider crash.
+ */
+const withAllStores: Decorator = function AllStoresDecorator(Story) {
+  const vehicle = useMemo(
+    () =>
+      createNewVehicleStore({
+        name: 'Story Vehicle',
+        tonnage: 50,
+        techBase: TechBase.INNER_SPHERE,
+      }),
+    [],
+  );
+  const aerospace = useMemo(
+    () =>
+      createNewAerospaceStore({
+        name: 'Story Fighter',
+        tonnage: 50,
+        techBase: TechBase.INNER_SPHERE,
+      }),
+    [],
+  );
+  const battleArmor = useMemo(() => createNewBattleArmorStore({}), []);
+  const protoMech = useMemo(
+    () => createNewProtoMechStore({ name: 'Story ProtoMech', tonnage: 6 }),
+    [],
+  );
+  const infantry = useMemo(() => createNewInfantryStore({}), []);
+
+  return (
+    <VehicleStoreContext.Provider value={vehicle}>
+      <AerospaceStoreContext.Provider value={aerospace}>
+        <BattleArmorStoreContext.Provider value={battleArmor}>
+          <ProtoMechStoreContext.Provider value={protoMech}>
+            <InfantryStoreContext.Provider value={infantry}>
+              <Story />
+            </InfantryStoreContext.Provider>
+          </ProtoMechStoreContext.Provider>
+        </BattleArmorStoreContext.Provider>
+      </AerospaceStoreContext.Provider>
+    </VehicleStoreContext.Provider>
+  );
+};
+
+const meta: Meta<typeof ArmorDiagramForType> = {
+  title: 'Customizer/Armor/ArmorDiagramForType',
+  component: ArmorDiagramForType,
+  tags: ['autodocs'],
+  decorators: [withAllStores],
+  argTypes: {
+    unitType: {
+      control: 'select',
+      options: Object.values(UnitType),
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ArmorDiagramForType>;
+
+/** Ground vehicle — routes to VehicleArmorDiagram. */
+export const Vehicle: Story = {
+  args: { unitType: UnitType.VEHICLE },
+};
+
+/** Aerospace fighter — routes to AerospaceArmorDiagram. */
+export const Aerospace: Story = {
+  args: { unitType: UnitType.AEROSPACE },
+};
+
+/** Battle Armor — routes to BattleArmorPipGrid. */
+export const BattleArmor: Story = {
+  args: { unitType: UnitType.BATTLE_ARMOR },
+};
+
+/** ProtoMech — routes to ProtoMechArmorDiagram. */
+export const ProtoMech: Story = {
+  args: { unitType: UnitType.PROTOMECH },
+};
+
+/** Infantry — routes to InfantryPlatoonCounter. */
+export const Infantry: Story = {
+  args: { unitType: UnitType.INFANTRY },
+};
+
+/** Mech types fall through to the "use ArmorDiagram directly" placeholder. */
+export const MechPlaceholder: Story = {
+  args: { unitType: UnitType.BATTLEMECH },
+};

--- a/src/components/customizer/battlearmor/BattleArmorPipGrid.stories.tsx
+++ b/src/components/customizer/battlearmor/BattleArmorPipGrid.stories.tsx
@@ -1,0 +1,132 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+
+import { useMemo } from 'react';
+
+import {
+  BattleArmorStoreContext,
+  createNewBattleArmorStore,
+} from '@/stores/useBattleArmorStore';
+import { BattleArmorWeightClass } from '@/types/unit/PersonnelInterfaces';
+
+import { BattleArmorPipGrid } from './BattleArmorPipGrid';
+
+/**
+ * Wrap a story in a BattleArmorStoreContext provider. The pip grid reads the
+ * squad entirely from the store; each story creates its own store and may
+ * seed `armorPerTrooper` (not a create-option) through the seed callback.
+ */
+function withBattleArmorStore(
+  options: Parameters<typeof createNewBattleArmorStore>[0],
+  seed?: (store: ReturnType<typeof createNewBattleArmorStore>) => void,
+): Decorator {
+  return function BattleArmorStoreDecorator(Story) {
+    const store = useMemo(() => {
+      const s = createNewBattleArmorStore(options);
+      seed?.(s);
+      return s;
+    }, []);
+    return (
+      <BattleArmorStoreContext.Provider value={store}>
+        <Story />
+      </BattleArmorStoreContext.Provider>
+    );
+  };
+}
+
+const meta: Meta<typeof BattleArmorPipGrid> = {
+  title: 'Customizer/Armor/BattleArmorPipGrid',
+  component: BattleArmorPipGrid,
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof BattleArmorPipGrid>;
+
+/** PA(L) — 3 pips per trooper at full weight-class allocation. */
+export const PaLight: Story = {
+  decorators: [
+    withBattleArmorStore(
+      { weightClass: BattleArmorWeightClass.PA_L, squadSize: 4 },
+      (store) => store.setState({ armorPerTrooper: 3 }),
+    ),
+  ],
+};
+
+/** Light — 5 pips per trooper. */
+export const Light: Story = {
+  decorators: [
+    withBattleArmorStore(
+      { weightClass: BattleArmorWeightClass.LIGHT, squadSize: 4 },
+      (store) => store.setState({ armorPerTrooper: 5 }),
+    ),
+  ],
+};
+
+/** Medium — 7 pips per trooper. */
+export const Medium: Story = {
+  decorators: [
+    withBattleArmorStore(
+      { weightClass: BattleArmorWeightClass.MEDIUM, squadSize: 4 },
+      (store) => store.setState({ armorPerTrooper: 7 }),
+    ),
+  ],
+};
+
+/** Heavy — 11 pips per trooper. */
+export const Heavy: Story = {
+  decorators: [
+    withBattleArmorStore(
+      { weightClass: BattleArmorWeightClass.HEAVY, squadSize: 4 },
+      (store) => store.setState({ armorPerTrooper: 11 }),
+    ),
+  ],
+};
+
+/** Assault — 15 pips per trooper, 5-trooper squad. */
+export const Assault: Story = {
+  decorators: [
+    withBattleArmorStore(
+      { weightClass: BattleArmorWeightClass.ASSAULT, squadSize: 5 },
+      (store) => store.setState({ armorPerTrooper: 15 }),
+    ),
+  ],
+};
+
+/**
+ * Allocation above the weight-class cap — armorPerTrooper is authoritative, so
+ * a Light suit allocated 10 renders 10 pips (not clamped to the class max of 5).
+ */
+export const AboveClassAllocation: Story = {
+  decorators: [
+    withBattleArmorStore(
+      { weightClass: BattleArmorWeightClass.LIGHT, squadSize: 4 },
+      (store) => store.setState({ armorPerTrooper: 10 }),
+    ),
+  ],
+};
+
+/**
+ * Allocation below the weight-class cap — a Heavy suit allocated 4 renders 4
+ * pips, reflecting the player's actual allocation rather than the class max.
+ */
+export const BelowClassAllocation: Story = {
+  decorators: [
+    withBattleArmorStore(
+      { weightClass: BattleArmorWeightClass.HEAVY, squadSize: 4 },
+      (store) => store.setState({ armorPerTrooper: 4 }),
+    ),
+  ],
+};
+
+/**
+ * Legacy fallback — when armorPerTrooper is unset the grid falls back to the
+ * weight-class maximum (Heavy → 11 pips).
+ */
+export const WeightClassFallback: Story = {
+  decorators: [
+    withBattleArmorStore(
+      { weightClass: BattleArmorWeightClass.HEAVY, squadSize: 4 },
+      (store) => store.setState({ armorPerTrooper: undefined }),
+    ),
+  ],
+};

--- a/src/components/customizer/protomech/ProtoMechArmorDiagram.stories.tsx
+++ b/src/components/customizer/protomech/ProtoMechArmorDiagram.stories.tsx
@@ -1,0 +1,68 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+
+import { useMemo } from 'react';
+
+import {
+  createNewProtoMechStore,
+  ProtoMechStoreContext,
+} from '@/stores/useProtoMechStore';
+import { ProtoChassis } from '@/types/unit/ProtoMechInterfaces';
+
+import { ProtoMechArmorDiagram } from './ProtoMechArmorDiagram';
+
+/**
+ * Wrap a story in a ProtoMechStoreContext provider. The diagram reads tonnage,
+ * hasMainGun, and armorByLocation from the store; each story creates its own
+ * store and may seed post-creation state through the optional callback.
+ */
+function withProtoMechStore(
+  options: Parameters<typeof createNewProtoMechStore>[0],
+  seed?: (store: ReturnType<typeof createNewProtoMechStore>) => void,
+): Decorator {
+  return function ProtoMechStoreDecorator(Story) {
+    const store = useMemo(() => {
+      const s = createNewProtoMechStore(options);
+      seed?.(s);
+      return s;
+    }, []);
+    return (
+      <ProtoMechStoreContext.Provider value={store}>
+        <Story />
+      </ProtoMechStoreContext.Provider>
+    );
+  };
+}
+
+const meta: Meta<typeof ProtoMechArmorDiagram> = {
+  title: 'Customizer/Armor/ProtoMechArmorDiagram',
+  component: ProtoMechArmorDiagram,
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof ProtoMechArmorDiagram>;
+
+/** Biped ProtoMech — 5 standard locations (Head / Torso / LA / RA / Legs). */
+export const Default: Story = {
+  decorators: [
+    withProtoMechStore({
+      name: 'Story ProtoMech',
+      tonnage: 6,
+      chassisType: ProtoChassis.BIPED,
+    }),
+  ],
+};
+
+/** Quad ProtoMech with a Main Gun — adds the conditional Main Gun location. */
+export const Quad: Story = {
+  decorators: [
+    withProtoMechStore(
+      {
+        name: 'Story ProtoMech',
+        tonnage: 6,
+        chassisType: ProtoChassis.QUAD,
+      },
+      (store) => store.setState({ hasMainGun: true }),
+    ),
+  ],
+};

--- a/src/components/customizer/vehicle/VehicleArmorDiagram.stories.tsx
+++ b/src/components/customizer/vehicle/VehicleArmorDiagram.stories.tsx
@@ -1,0 +1,86 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+
+import { useMemo } from 'react';
+
+import type { ITurretConfiguration } from '@/types/unit/VehicleInterfaces';
+
+import {
+  createNewVehicleStore,
+  VehicleStoreContext,
+} from '@/stores/useVehicleStore';
+import { TechBase } from '@/types/enums/TechBase';
+import { GroundMotionType } from '@/types/unit/BaseUnitInterfaces';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+import { TurretType } from '@/types/unit/VehicleInterfaces';
+
+import { VehicleArmorDiagram } from './VehicleArmorDiagram';
+
+/**
+ * Wrap a story in a VehicleStoreContext provider. The diagram reads the active
+ * vehicle entirely from the store, so each story spins up its own store with
+ * the create-options + an optional seed callback for post-creation state.
+ */
+function withVehicleStore(
+  options: Parameters<typeof createNewVehicleStore>[0],
+  seed?: (store: ReturnType<typeof createNewVehicleStore>) => void,
+): Decorator {
+  return function VehicleStoreDecorator(Story) {
+    const store = useMemo(() => {
+      const s = createNewVehicleStore(options);
+      seed?.(s);
+      return s;
+    }, []);
+    return (
+      <VehicleStoreContext.Provider value={store}>
+        <Story />
+      </VehicleStoreContext.Provider>
+    );
+  };
+}
+
+const baseOptions = {
+  name: 'Story Vehicle',
+  tonnage: 50,
+  techBase: TechBase.INNER_SPHERE,
+} as const;
+
+const turret: ITurretConfiguration = {
+  type: TurretType.SINGLE,
+  maxWeight: 10,
+  currentWeight: 0,
+  rotationArc: 360,
+};
+
+const meta: Meta<typeof VehicleArmorDiagram> = {
+  title: 'Customizer/Armor/VehicleArmorDiagram',
+  component: VehicleArmorDiagram,
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof VehicleArmorDiagram>;
+
+/** Ground vehicle, 4 base locations only. */
+export const Default: Story = {
+  decorators: [withVehicleStore(baseOptions)],
+};
+
+/** VTOL — adds the conditional Rotor location. */
+export const VTOL: Story = {
+  decorators: [
+    withVehicleStore({
+      ...baseOptions,
+      motionType: GroundMotionType.VTOL,
+      unitType: UnitType.VTOL,
+    }),
+  ],
+};
+
+/** Both turrets present — exercises the Turret + Turret 2 conditional rows. */
+export const SecondaryTurret: Story = {
+  decorators: [
+    withVehicleStore(baseOptions, (store) => {
+      store.setState({ turret, secondaryTurret: turret });
+    }),
+  ],
+};


### PR DESCRIPTION
## Summary

Adds Storybook stories for the 4 per-unit-type armor diagrams and the `ArmorDiagramForType` dispatcher. Closes the visual-harness gap surfaced as **Finding 2** in the 2026-05-14 customizer armor diagram visual audit — the components changed by PRs #574/#575/#576 previously had zero Storybook coverage, so a visual regression in any of them would not be caught by the CI Storybook build.

## What's added

- **`ArmorDiagramForType.stories.tsx`** — dispatcher with `unitType` as a `select` arg control. A combined decorator mounts all five per-type store providers at once so switching the arg never hits a missing-provider crash. Stories: Vehicle / Aerospace / BattleArmor / ProtoMech / Infantry / MechPlaceholder.
- **`VehicleArmorDiagram.stories.tsx`** — Default / VTOL (Rotor location) / SecondaryTurret (Turret + Turret 2 rows).
- **`AerospaceArmorDiagram.stories.tsx`** — Default / SmallCraft (small-craft arc-factor caps) / OverCap.
- **`BattleArmorPipGrid.stories.tsx`** — PA(L)/Light/Medium/Heavy/Assault + AboveClassAllocation + BelowClassAllocation + WeightClassFallback (legacy undefined-`armorPerTrooper` path).
- **`ProtoMechArmorDiagram.stories.tsx`** — Default (biped) / Quad (with Main Gun location).

Each per-type diagram is store-coupled, so every story wraps the component in its unit-type store context via a `createNew*Store`-backed decorator.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run storybook:build` succeeds — all 5 story files compile
- [x] Pre-push full `next build` passes