### PR TITLE
feat(record-sheet): shared template renderer core + dynamic pip engine

### DIFF
--- a/src/services/printing/svgRecordSheetRenderer/__tests__/pipEngine.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/__tests__/pipEngine.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Shared Dynamic Pip Engine — unit tests.
+ *
+ * Covers region-geometry pip layout, the `grouped`-layout
+ * element-lookup fallback, and the alternate-clustering flag.
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Shared Dynamic Pip Engine)
+ */
+
+import { layoutPips, layoutPipsInGroup, resolvePipGroup } from '../pipEngine';
+
+/**
+ * Build a parsed SVG document from markup.
+ * The pip engine reads `<rect>` geometry from x/y/width/height
+ * attributes, so a parsed (un-mounted) document is sufficient here.
+ */
+function parseSvg(markup: string): Document {
+  return new DOMParser().parseFromString(markup, 'image/svg+xml');
+}
+
+/** Count the pip `<circle>` elements rendered inside a group. */
+function countPips(doc: Document, groupId: string): number {
+  const group = doc.getElementById(groupId);
+  return group ? group.querySelectorAll('circle').length : 0;
+}
+
+describe('pip engine', () => {
+  describe('resolvePipGroup', () => {
+    it('resolves a group by its primary ID', () => {
+      const doc = parseSvg(
+        '<svg xmlns="http://www.w3.org/2000/svg"><g id="armorPipsFR"/></svg>',
+      );
+      const group = resolvePipGroup(doc, 'armorPipsFR');
+      expect(group?.getAttribute('id')).toBe('armorPipsFR');
+    });
+
+    it('falls back to the <id>grouped element when the primary is absent', () => {
+      const doc = parseSvg(
+        '<svg xmlns="http://www.w3.org/2000/svg"><g id="armorPipsLSgrouped"/></svg>',
+      );
+      const group = resolvePipGroup(doc, 'armorPipsLS');
+      expect(group?.getAttribute('id')).toBe('armorPipsLSgrouped');
+    });
+
+    it('returns null when neither the primary nor grouped element exists', () => {
+      const doc = parseSvg('<svg xmlns="http://www.w3.org/2000/svg"/>');
+      expect(resolvePipGroup(doc, 'armorPipsRR')).toBeNull();
+    });
+  });
+
+  describe('layoutPips — region geometry', () => {
+    it('emits exactly `count` pip elements within a region rect', () => {
+      const doc = parseSvg(
+        '<svg xmlns="http://www.w3.org/2000/svg">' +
+          '<g id="armorPipsFR"><rect x="0" y="0" width="60" height="40"/></g>' +
+          '</svg>',
+      );
+
+      const ran = layoutPips(doc, 'armorPipsFR', 12);
+
+      expect(ran).toBe(true);
+      expect(countPips(doc, 'armorPipsFR')).toBe(12);
+    });
+
+    it('is a no-op for a zero or negative count', () => {
+      const doc = parseSvg(
+        '<svg xmlns="http://www.w3.org/2000/svg">' +
+          '<g id="armorPipsFR"><rect x="0" y="0" width="60" height="40"/></g>' +
+          '</svg>',
+      );
+
+      expect(layoutPips(doc, 'armorPipsFR', 0)).toBe(false);
+      expect(layoutPips(doc, 'armorPipsFR', -5)).toBe(false);
+      expect(countPips(doc, 'armorPipsFR')).toBe(0);
+    });
+
+    it('returns false for an unresolvable group ID', () => {
+      const doc = parseSvg('<svg xmlns="http://www.w3.org/2000/svg"/>');
+      expect(layoutPips(doc, 'armorPipsRR', 8)).toBe(false);
+    });
+  });
+
+  describe('layoutPips — grouped-layout fallback', () => {
+    it('lays out pips against the grouped element when the primary is absent', () => {
+      const doc = parseSvg(
+        '<svg xmlns="http://www.w3.org/2000/svg">' +
+          '<g id="armorPipsLSgrouped"><rect x="0" y="0" width="60" height="40"/></g>' +
+          '</svg>',
+      );
+
+      const ran = layoutPips(doc, 'armorPipsLS', 9);
+
+      expect(ran).toBe(true);
+      expect(countPips(doc, 'armorPipsLSgrouped')).toBe(9);
+    });
+  });
+
+  describe('layoutPips — alternate-clustering flag', () => {
+    it('renders the requested pip count under standard layout', () => {
+      const doc = parseSvg(
+        '<svg xmlns="http://www.w3.org/2000/svg">' +
+          '<g id="armorPipsFR"><rect x="0" y="0" width="80" height="60"/></g>' +
+          '</svg>',
+      );
+      expect(layoutPips(doc, 'armorPipsFR', 20, { clustered: false })).toBe(
+        true,
+      );
+      expect(countPips(doc, 'armorPipsFR')).toBe(20);
+    });
+
+    it('renders the requested pip count under clustered layout', () => {
+      const doc = parseSvg(
+        '<svg xmlns="http://www.w3.org/2000/svg">' +
+          '<g id="armorPipsFR"><rect x="0" y="0" width="80" height="60"/></g>' +
+          '</svg>',
+      );
+      expect(layoutPips(doc, 'armorPipsFR', 20, { clustered: true })).toBe(
+        true,
+      );
+      expect(countPips(doc, 'armorPipsFR')).toBe(20);
+    });
+
+    it('clustered layout positions pips differently from standard layout', () => {
+      // A wide, short single-row region: the grouped-by-five algorithm
+      // packs pips into clusters of five with inter-group spacing,
+      // which shifts coordinates relative to the even standard fill.
+      const make = () =>
+        parseSvg(
+          '<svg xmlns="http://www.w3.org/2000/svg">' +
+            '<g id="armorPipsFR"><rect x="0" y="0" width="200" height="10"/></g>' +
+            '</svg>',
+        );
+
+      const standardDoc = make();
+      const clusteredDoc = make();
+      layoutPips(standardDoc, 'armorPipsFR', 15, { clustered: false });
+      layoutPips(clusteredDoc, 'armorPipsFR', 15, { clustered: true });
+
+      const positions = (doc: Document) =>
+        Array.from(
+          doc.getElementById('armorPipsFR')?.querySelectorAll('circle') ?? [],
+        )
+          .map((c) => `${c.getAttribute('cx')},${c.getAttribute('cy')}`)
+          .join('|');
+
+      // Both render 15 pips, but the clustering algorithm places them
+      // at different coordinates than the even standard fill.
+      expect(countPips(standardDoc, 'armorPipsFR')).toBe(15);
+      expect(countPips(clusteredDoc, 'armorPipsFR')).toBe(15);
+      expect(positions(standardDoc)).not.toBe(positions(clusteredDoc));
+    });
+  });
+
+  describe('layoutPipsInGroup', () => {
+    it('lays out pips against an already-resolved group element', () => {
+      const doc = parseSvg(
+        '<svg xmlns="http://www.w3.org/2000/svg">' +
+          '<g id="armorPipsT"><rect x="0" y="0" width="50" height="30"/></g>' +
+          '</svg>',
+      );
+      const group = doc.getElementById('armorPipsT')!;
+
+      layoutPipsInGroup(doc, group, 6);
+
+      expect(countPips(doc, 'armorPipsT')).toBe(6);
+    });
+
+    it('is a no-op for a zero count', () => {
+      const doc = parseSvg(
+        '<svg xmlns="http://www.w3.org/2000/svg">' +
+          '<g id="armorPipsT"><rect x="0" y="0" width="50" height="30"/></g>' +
+          '</svg>',
+      );
+      const group = doc.getElementById('armorPipsT')!;
+      layoutPipsInGroup(doc, group, 0);
+      expect(countPips(doc, 'armorPipsT')).toBe(0);
+    });
+  });
+});

--- a/src/services/printing/svgRecordSheetRenderer/__tests__/templateRecordSheetRenderer.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/__tests__/templateRecordSheetRenderer.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Shared Template Record Sheet Renderer — unit tests.
+ *
+ * Covers `loadTemplate`, `applyBindings`, the off-screen mount/unmount
+ * lifecycle, font-readiness gating, `applyPips`, and `getSVGString`.
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Shared Template Record Sheet Renderer)
+ */
+
+import {
+  TemplateRecordSheetRenderer,
+  type PipFill,
+} from '../templateRecordSheetRenderer';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+/** A minimal canonical-shaped template with header text + a pip group. */
+const TEMPLATE_SVG = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="576" height="756" viewBox="0 0 576 756">
+  <text id="type"></text>
+  <text id="tonnage"></text>
+  <text id="bv"></text>
+  <g id="armorPipsFR"><rect x="0" y="0" width="50" height="20"/></g>
+</svg>`;
+
+function mockTemplateResponse(svg: string) {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    text: () => Promise.resolve(svg),
+    headers: new Headers({ 'content-type': 'image/svg+xml' }),
+  });
+}
+
+describe('TemplateRecordSheetRenderer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    document.body.innerHTML = '';
+  });
+
+  describe('loadTemplate', () => {
+    it('fetches and parses a canonical template into a DOM document', async () => {
+      mockTemplateResponse(TEMPLATE_SVG);
+      const renderer = new TemplateRecordSheetRenderer();
+
+      await renderer.loadTemplate('/record-sheets/templates_us/x.svg');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/record-sheets/templates_us/x.svg',
+      );
+      expect(renderer.document.getElementById('type')).not.toBeNull();
+      expect(renderer.root.tagName.toLowerCase()).toBe('svg');
+    });
+
+    it('throws when accessing document before a template is loaded', () => {
+      const renderer = new TemplateRecordSheetRenderer();
+      expect(() => renderer.document).toThrow('Template not loaded');
+      expect(() => renderer.root).toThrow('Template not loaded');
+    });
+
+    it('throws when the template fetch fails', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 404 });
+      const renderer = new TemplateRecordSheetRenderer();
+      await expect(
+        renderer.loadTemplate('/record-sheets/templates_us/missing.svg'),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('applyBindings', () => {
+    it('injects text by element ID', async () => {
+      mockTemplateResponse(TEMPLATE_SVG);
+      const renderer = new TemplateRecordSheetRenderer();
+      await renderer.loadTemplate('/x.svg');
+
+      renderer.applyBindings({ type: 'Manticore', tonnage: '50', bv: '1247' });
+
+      expect(renderer.document.getElementById('type')?.textContent).toBe(
+        'Manticore',
+      );
+      expect(renderer.document.getElementById('tonnage')?.textContent).toBe(
+        '50',
+      );
+      expect(renderer.document.getElementById('bv')?.textContent).toBe('1247');
+    });
+
+    it('leaves elements absent from the binding map unchanged', async () => {
+      mockTemplateResponse(TEMPLATE_SVG);
+      const renderer = new TemplateRecordSheetRenderer();
+      await renderer.loadTemplate('/x.svg');
+
+      renderer.applyBindings({ type: 'OnlyType' });
+
+      expect(renderer.document.getElementById('tonnage')?.textContent).toBe('');
+    });
+
+    it('silently skips bindings for IDs not present in the template', async () => {
+      mockTemplateResponse(TEMPLATE_SVG);
+      const renderer = new TemplateRecordSheetRenderer();
+      await renderer.loadTemplate('/x.svg');
+
+      expect(() =>
+        renderer.applyBindings({ nonExistentId: 'value' }),
+      ).not.toThrow();
+    });
+  });
+
+  describe('off-screen mount lifecycle', () => {
+    it('attaches the SVG to the document on mount and detaches on unmount', async () => {
+      mockTemplateResponse(TEMPLATE_SVG);
+      const renderer = new TemplateRecordSheetRenderer();
+      await renderer.loadTemplate('/x.svg');
+
+      expect(renderer.isMounted).toBe(false);
+
+      renderer.mount();
+      expect(renderer.isMounted).toBe(true);
+      // The SVG root is attached to a node inside the live document.
+      expect(document.body.contains(renderer.root)).toBe(true);
+
+      renderer.unmount();
+      expect(renderer.isMounted).toBe(false);
+      expect(document.body.contains(renderer.root)).toBe(false);
+    });
+
+    it('mount is idempotent', async () => {
+      mockTemplateResponse(TEMPLATE_SVG);
+      const renderer = new TemplateRecordSheetRenderer();
+      await renderer.loadTemplate('/x.svg');
+
+      renderer.mount();
+      renderer.mount();
+      expect(renderer.isMounted).toBe(true);
+      // Exactly one off-screen container exists.
+      expect(document.body.children.length).toBe(1);
+    });
+
+    it('getSVGString unmounts the off-screen container as a side effect', async () => {
+      mockTemplateResponse(TEMPLATE_SVG);
+      const renderer = new TemplateRecordSheetRenderer();
+      await renderer.loadTemplate('/x.svg');
+
+      renderer.mount();
+      const svg = renderer.getSVGString();
+
+      expect(svg).toContain('<svg');
+      expect(renderer.isMounted).toBe(false);
+      expect(document.body.children.length).toBe(0);
+    });
+  });
+
+  describe('awaitFontsReady', () => {
+    it('resolves without throwing (font-readiness gate)', async () => {
+      mockTemplateResponse(TEMPLATE_SVG);
+      const renderer = new TemplateRecordSheetRenderer();
+      await renderer.loadTemplate('/x.svg');
+      await expect(renderer.awaitFontsReady()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('applyPips', () => {
+    it('invokes the applicator for resolvable pip groups', async () => {
+      mockTemplateResponse(TEMPLATE_SVG);
+      const renderer = new TemplateRecordSheetRenderer();
+      await renderer.loadTemplate('/x.svg');
+
+      const seen: string[] = [];
+      const fills: PipFill[] = [{ groupId: 'armorPipsFR', count: 10 }];
+      renderer.applyPips(fills, (_doc, group, fill) => {
+        seen.push(`${group.getAttribute('id')}:${fill.count}`);
+      });
+
+      expect(seen).toEqual(['armorPipsFR:10']);
+    });
+
+    it('skips fills with a zero or negative count', async () => {
+      mockTemplateResponse(TEMPLATE_SVG);
+      const renderer = new TemplateRecordSheetRenderer();
+      await renderer.loadTemplate('/x.svg');
+
+      const applicator = jest.fn();
+      renderer.applyPips(
+        [
+          { groupId: 'armorPipsFR', count: 0 },
+          { groupId: 'armorPipsFR', count: -3 },
+        ],
+        applicator,
+      );
+
+      expect(applicator).not.toHaveBeenCalled();
+    });
+
+    it('does not invoke the applicator for an unresolvable group ID', async () => {
+      mockTemplateResponse(TEMPLATE_SVG);
+      const renderer = new TemplateRecordSheetRenderer();
+      await renderer.loadTemplate('/x.svg');
+
+      const applicator = jest.fn();
+      renderer.applyPips(
+        [{ groupId: 'armorPipsNONEXISTENT', count: 5 }],
+        applicator,
+      );
+
+      expect(applicator).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getSVGString', () => {
+    it('serializes the (mutated) template document', async () => {
+      mockTemplateResponse(TEMPLATE_SVG);
+      const renderer = new TemplateRecordSheetRenderer();
+      await renderer.loadTemplate('/x.svg');
+
+      renderer.applyBindings({ type: 'Serialized' });
+      const svg = renderer.getSVGString();
+
+      expect(svg).toContain('<svg');
+      expect(svg).toContain('Serialized');
+    });
+
+    it('throws when no template is loaded', () => {
+      const renderer = new TemplateRecordSheetRenderer();
+      expect(() => renderer.getSVGString()).toThrow('Template not loaded');
+    });
+  });
+});

--- a/src/services/printing/svgRecordSheetRenderer/armor.ts
+++ b/src/services/printing/svgRecordSheetRenderer/armor.ts
@@ -6,7 +6,6 @@
 import { IMechRecordSheetData } from '@/types/printing';
 import { logger } from '@/utils/logger';
 
-import { ArmorPipLayout } from '../ArmorPipLayout';
 import {
   SVG_NS,
   PIPS_BASE_PATH,
@@ -19,6 +18,7 @@ import {
   QUAD_PIP_GROUP_IDS,
   TRIPOD_PIP_GROUP_IDS,
 } from './constants';
+import { layoutPipsInGroup } from './pipEngine';
 import { setTextContent } from './template';
 
 /**
@@ -199,9 +199,11 @@ async function generateDynamicArmorPips(
       return;
     }
 
-    // Use ArmorPipLayout to generate pips within the bounding rects
+    // Lay out pips within the bounding rects via the shared pip engine
+    // (which delegates to ArmorPipLayout). The mech path is unchanged —
+    // the engine is a transparent wrapper over the proven layout.
     if (loc.current > 0) {
-      ArmorPipLayout.addPips(svgDoc, pipArea, loc.current, {
+      layoutPipsInGroup(svgDoc, pipArea, loc.current, {
         fill: '#FFFFFF',
         strokeWidth: 0.5,
         className: 'pip armor',
@@ -220,7 +222,7 @@ async function generateDynamicArmorPips(
       if (rearGroupId) {
         const pipArea = svgDoc.getElementById(rearGroupId);
         if (pipArea && loc.rear > 0) {
-          ArmorPipLayout.addPips(svgDoc, pipArea, loc.rear, {
+          layoutPipsInGroup(svgDoc, pipArea, loc.rear, {
             fill: '#FFFFFF',
             strokeWidth: 0.5,
             className: 'pip armor rear',

--- a/src/services/printing/svgRecordSheetRenderer/pipEngine.ts
+++ b/src/services/printing/svgRecordSheetRenderer/pipEngine.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared Dynamic Pip Engine
+ *
+ * Computes armor and structure pip positions from a template's `<rect>`
+ * region geometry, generalizing the dynamic layout logic in `armor.ts`
+ * so every unit family (mech / vehicle / aerospace / protomech) lays
+ * out pips through one engine.
+ *
+ * The engine builds on `ArmorPipLayout` — the proven MegaMekLab-derived
+ * region-geometry layout (mirroring `ArmorPipLayout.java` +
+ * `PrintEntity.java`) — and adds two cross-family concerns:
+ *
+ *   - the `grouped`-layout element-lookup fallback: when a region's
+ *     primary element ID is absent, retry `getElementById(id +
+ *     "grouped")` (MegaMekLab `PrintEntity.java`);
+ *   - the alternate-clustering flag (`groupByFive` in `ArmorPipLayout`,
+ *     `ArmorPipLayout.java`'s grouped-by-five placement) surfaced so
+ *     callers can request clustered pip placement.
+ *
+ * Region rect geometry is read from the `<rect>` `x/y/width/height`
+ * attributes (`Bounds.fromRect`). When a caller instead measures via
+ * `getBBox()`, the template SVG MUST be mounted in a live DOM first —
+ * see `TemplateRecordSheetRenderer.mount()`.
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Shared Dynamic Pip Engine)
+ */
+
+import { ArmorPipLayout, type PipOptions } from '../ArmorPipLayout';
+
+/** Default pip fill colour — matches the mech path. */
+const DEFAULT_PIP_FILL = '#FFFFFF';
+/** Default pip stroke width — matches the mech path. */
+const DEFAULT_PIP_STROKE = 0.5;
+
+/**
+ * Options controlling a single pip-layout operation.
+ */
+export interface PipLayoutOptions {
+  /** Pip fill colour. Defaults to white. */
+  readonly fill?: string;
+  /** Pip stroke width. Defaults to 0.5. */
+  readonly strokeWidth?: number;
+  /** CSS class applied to each rendered pip element. */
+  readonly className?: string;
+  /** Stagger alternating rows (used by some location diagrams). */
+  readonly staggered?: boolean;
+  /**
+   * Request the alternate clustered ("grouped-by-five") placement from
+   * MegaMekLab `ArmorPipLayout.java`. Default `false` matches the mech
+   * path's standard layout.
+   */
+  readonly clustered?: boolean;
+}
+
+/**
+ * Resolve a pip-group element by ID, applying the `grouped`-layout
+ * fallback when the primary ID is absent.
+ *
+ * Mirrors MegaMekLab `PrintEntity.java`: armor diagrams may expose
+ * either a primary pip region (`armorPipsLS`) or, when the canonical
+ * sheet packs that location into a grouped cluster, only the
+ * `<id>grouped` twin (`armorPipsLSgrouped`).
+ *
+ * @returns the resolved element, or `null` when neither ID exists.
+ */
+export function resolvePipGroup(
+  svgDoc: Document,
+  groupId: string,
+): Element | null {
+  const primary = svgDoc.getElementById(groupId);
+  if (primary) {
+    return primary;
+  }
+  // Grouped-layout fallback — retry the `<id>grouped` element.
+  return svgDoc.getElementById(`${groupId}grouped`);
+}
+
+/**
+ * Lay out `count` pip elements inside a template region group.
+ *
+ * Resolves the group (with the `grouped` fallback), then delegates to
+ * `ArmorPipLayout.addPips`, which positions exactly `count` pips within
+ * the region's measured `<rect>` bounds. A `count` of zero or fewer is
+ * a no-op. An unresolvable group ID is a no-op (logged by the caller's
+ * own diagnostics, not here — the engine stays pure).
+ *
+ * @returns `true` when the group resolved and layout ran, `false` when
+ *   the group could not be resolved.
+ */
+export function layoutPips(
+  svgDoc: Document,
+  groupId: string,
+  count: number,
+  options: PipLayoutOptions = {},
+): boolean {
+  if (count <= 0) {
+    return false;
+  }
+  const group = resolvePipGroup(svgDoc, groupId);
+  if (!group) {
+    return false;
+  }
+  const pipOptions: PipOptions = {
+    fill: options.fill ?? DEFAULT_PIP_FILL,
+    strokeWidth: options.strokeWidth ?? DEFAULT_PIP_STROKE,
+    className: options.className,
+    staggered: options.staggered ?? false,
+    // The alternate-clustering flag from ArmorPipLayout.java is surfaced
+    // here as `clustered`; ArmorPipLayout names it `groupByFive`.
+    groupByFive: options.clustered ?? false,
+  };
+  ArmorPipLayout.addPips(svgDoc, group, count, pipOptions);
+  return true;
+}
+
+/**
+ * Lay out pips against an already-resolved group element.
+ *
+ * Used when the caller has resolved the group itself (e.g.
+ * `TemplateRecordSheetRenderer.applyPips`). Skips the
+ * `resolvePipGroup` step; the `grouped` fallback is the caller's
+ * responsibility in that path.
+ */
+export function layoutPipsInGroup(
+  svgDoc: Document,
+  group: Element,
+  count: number,
+  options: PipLayoutOptions = {},
+): void {
+  if (count <= 0) {
+    return;
+  }
+  ArmorPipLayout.addPips(svgDoc, group, count, {
+    fill: options.fill ?? DEFAULT_PIP_FILL,
+    strokeWidth: options.strokeWidth ?? DEFAULT_PIP_STROKE,
+    className: options.className,
+    staggered: options.staggered ?? false,
+    groupByFive: options.clustered ?? false,
+  });
+}

--- a/src/services/printing/svgRecordSheetRenderer/renderer.ts
+++ b/src/services/printing/svgRecordSheetRenderer/renderer.ts
@@ -16,7 +16,6 @@ import {
 import { renderAerospaceSVG } from './aerospaceRenderer';
 import { fillArmorPips } from './armor';
 import { renderBattleArmorSVG } from './battleArmorRenderer';
-import { renderToCanvasHighDPI } from './canvas';
 import { ELEMENT_IDS } from './constants';
 import { renderCriticalSlots } from './criticals';
 import { renderEquipmentTable } from './equipment';
@@ -25,12 +24,11 @@ import { renderProtoMechSVG } from './protoMechRenderer';
 import { renderSPASection } from './spaSection';
 import { fillStructurePips } from './structure';
 import {
-  loadSVGTemplate,
   addDocumentMargins,
   hideSecondCrewPanel,
   fixCopyrightYear,
-  setTextContent,
 } from './template';
+import { TemplateRecordSheetRenderer } from './templateRecordSheetRenderer';
 import { renderVehicleSVG } from './vehicleRenderer';
 
 export function renderRecordSheetSVG(data: INonMechRecordSheetData): string {
@@ -54,97 +52,61 @@ function assertNeverRecordSheetVariant(data: never): never {
   throw new Error(`Unhandled record sheet unit type: ${String(data)}`);
 }
 
+/**
+ * Mech record-sheet renderer.
+ *
+ * A thin consumer of the shared `TemplateRecordSheetRenderer`: the
+ * canonical-template handling (asset load, DOM parse, text injection,
+ * serialization, canvas rasterization) lives in the shared core, and
+ * this class owns only the mech-specific binding logic (header field
+ * mapping, equipment / critical-slot tables, mech armor / structure
+ * pips). The refactor is behaviour-preserving — the existing mech
+ * `SVGRecordSheetRenderer` tests pin the public surface.
+ */
 export class SVGRecordSheetRenderer {
-  private svgDoc: Document | null = null;
-  private svgRoot: SVGSVGElement | null = null;
+  private readonly core = new TemplateRecordSheetRenderer();
 
   async loadTemplate(templatePath: string): Promise<void> {
-    const result = await loadSVGTemplate(templatePath);
-    this.svgDoc = result.svgDoc;
-    this.svgRoot = result.svgRoot;
-    addDocumentMargins(this.svgRoot);
+    await this.core.loadTemplate(templatePath);
+    // Mech-specific: expand the template viewBox to US-Letter margins.
+    addDocumentMargins(this.core.root);
   }
 
   fillTemplate(data: IMechRecordSheetData): void {
-    if (!this.svgDoc || !this.svgRoot) {
-      throw new Error('Template not loaded. Call loadTemplate first.');
-    }
+    // `core.document` throws 'Template not loaded' when no template is
+    // loaded — preserves the prior guard behaviour.
+    const svgDoc = this.core.document;
 
-    setTextContent(
-      this.svgDoc,
-      ELEMENT_IDS.TYPE,
-      `${data.header.chassis} ${data.header.model}`,
-    );
-    setTextContent(
-      this.svgDoc,
-      ELEMENT_IDS.TONNAGE,
-      String(data.header.tonnage),
-    );
-    setTextContent(this.svgDoc, ELEMENT_IDS.TECH_BASE, data.header.techBase);
-    setTextContent(
-      this.svgDoc,
-      ELEMENT_IDS.RULES_LEVEL,
-      data.header.rulesLevel,
-    );
-    setTextContent(this.svgDoc, ELEMENT_IDS.ROLE, 'Juggernaut');
+    this.core.applyBindings({
+      [ELEMENT_IDS.TYPE]: `${data.header.chassis} ${data.header.model}`,
+      [ELEMENT_IDS.TONNAGE]: String(data.header.tonnage),
+      [ELEMENT_IDS.TECH_BASE]: data.header.techBase,
+      [ELEMENT_IDS.RULES_LEVEL]: data.header.rulesLevel,
+      [ELEMENT_IDS.ROLE]: 'Juggernaut',
+      [ELEMENT_IDS.ENGINE_TYPE]: `${data.header.tonnage * data.movement.walkMP} XL`,
+      [ELEMENT_IDS.WALK_MP]: String(data.movement.walkMP),
+      [ELEMENT_IDS.RUN_MP]: String(data.movement.runMP),
+      [ELEMENT_IDS.JUMP_MP]: String(data.movement.jumpMP),
+      [ELEMENT_IDS.BV]: data.header.battleValue.toLocaleString(),
+      [ELEMENT_IDS.ARMOR_TYPE]: data.armor.type,
+      [ELEMENT_IDS.STRUCTURE_TYPE]: data.structure.type,
+      [ELEMENT_IDS.HEAT_SINK_TYPE]: data.heatSinks.type,
+      [ELEMENT_IDS.HEAT_SINK_COUNT]: `${data.heatSinks.count}`,
+      [ELEMENT_IDS.PILOT_NAME]: '',
+      [ELEMENT_IDS.GUNNERY_SKILL]: '',
+      [ELEMENT_IDS.PILOTING_SKILL]: '',
+    });
 
-    const engineRating = data.header.tonnage * data.movement.walkMP;
-    setTextContent(this.svgDoc, ELEMENT_IDS.ENGINE_TYPE, `${engineRating} XL`);
+    fixCopyrightYear(svgDoc);
+    hideSecondCrewPanel(svgDoc);
 
-    setTextContent(
-      this.svgDoc,
-      ELEMENT_IDS.WALK_MP,
-      String(data.movement.walkMP),
-    );
-    setTextContent(
-      this.svgDoc,
-      ELEMENT_IDS.RUN_MP,
-      String(data.movement.runMP),
-    );
-    setTextContent(
-      this.svgDoc,
-      ELEMENT_IDS.JUMP_MP,
-      String(data.movement.jumpMP),
-    );
-
-    setTextContent(
-      this.svgDoc,
-      ELEMENT_IDS.BV,
-      data.header.battleValue.toLocaleString(),
-    );
-
-    setTextContent(this.svgDoc, ELEMENT_IDS.ARMOR_TYPE, data.armor.type);
-    setTextContent(
-      this.svgDoc,
-      ELEMENT_IDS.STRUCTURE_TYPE,
-      data.structure.type,
-    );
-
-    setTextContent(
-      this.svgDoc,
-      ELEMENT_IDS.HEAT_SINK_TYPE,
-      data.heatSinks.type,
-    );
-    setTextContent(
-      this.svgDoc,
-      ELEMENT_IDS.HEAT_SINK_COUNT,
-      `${data.heatSinks.count}`,
-    );
-
-    setTextContent(this.svgDoc, ELEMENT_IDS.PILOT_NAME, '');
-    setTextContent(this.svgDoc, ELEMENT_IDS.GUNNERY_SKILL, '');
-    setTextContent(this.svgDoc, ELEMENT_IDS.PILOTING_SKILL, '');
-
-    fixCopyrightYear(this.svgDoc);
-    hideSecondCrewPanel(this.svgDoc);
-
-    renderEquipmentTable(this.svgDoc, data.equipment);
-    renderCriticalSlots(this.svgDoc, data.criticals);
+    renderEquipmentTable(svgDoc, data.equipment);
+    renderCriticalSlots(svgDoc, data.criticals);
 
     // Phase 5 Wave 3 — render the Special Abilities block when present.
     // Helper skips when there are no resolvable entries.
     if (data.specialAbilities && data.specialAbilities.length > 0) {
-      renderSPASection(this.svgDoc, {
+      renderSPASection(svgDoc, {
         entries: data.specialAbilities,
         hasContent: true,
       });
@@ -155,10 +117,7 @@ export class SVGRecordSheetRenderer {
     armor: IMechRecordSheetData['armor'],
     mechType?: string,
   ): Promise<void> {
-    if (!this.svgDoc || !this.svgRoot) {
-      throw new Error('Template not loaded');
-    }
-    await fillArmorPips(this.svgDoc, this.svgRoot, armor, mechType);
+    await fillArmorPips(this.core.document, this.core.root, armor, mechType);
   }
 
   async fillStructurePips(
@@ -166,12 +125,9 @@ export class SVGRecordSheetRenderer {
     tonnage: number,
     mechType?: string,
   ): Promise<void> {
-    if (!this.svgDoc || !this.svgRoot) {
-      throw new Error('Template not loaded');
-    }
     await fillStructurePips(
-      this.svgDoc,
-      this.svgRoot,
+      this.core.document,
+      this.core.root,
       structure,
       tonnage,
       mechType,
@@ -179,11 +135,7 @@ export class SVGRecordSheetRenderer {
   }
 
   getSVGString(): string {
-    if (!this.svgDoc) {
-      throw new Error('Template not loaded');
-    }
-    const serializer = new XMLSerializer();
-    return serializer.serializeToString(this.svgDoc);
+    return this.core.getSVGString();
   }
 
   async renderToCanvas(canvas: HTMLCanvasElement): Promise<void> {
@@ -194,8 +146,7 @@ export class SVGRecordSheetRenderer {
     canvas: HTMLCanvasElement,
     dpiMultiplier: number,
   ): Promise<void> {
-    const svgString = this.getSVGString();
-    await renderToCanvasHighDPI(svgString, canvas, dpiMultiplier);
+    await this.core.renderToCanvas(canvas, dpiMultiplier);
   }
 }
 

--- a/src/services/printing/svgRecordSheetRenderer/structure.ts
+++ b/src/services/printing/svgRecordSheetRenderer/structure.ts
@@ -6,7 +6,6 @@
 import { IMechRecordSheetData, ILocationStructure } from '@/types/printing';
 import { logger } from '@/utils/logger';
 
-import { ArmorPipLayout } from '../ArmorPipLayout';
 import {
   SVG_NS,
   PIPS_BASE_PATH,
@@ -17,6 +16,7 @@ import {
   QUAD_STRUCTURE_PIP_GROUP_IDS,
   TRIPOD_STRUCTURE_PIP_GROUP_IDS,
 } from './constants';
+import { layoutPipsInGroup } from './pipEngine';
 import { setTextContent } from './template';
 
 /**
@@ -350,9 +350,10 @@ function generateDynamicStructurePips(
       return;
     }
 
-    // Use ArmorPipLayout to generate pips within the bounding rects
+    // Lay out pips within the bounding rects via the shared pip engine
+    // (which delegates to ArmorPipLayout). Behaviour-preserving wrapper.
     if (loc.points > 0) {
-      ArmorPipLayout.addPips(svgDoc, pipArea, loc.points, {
+      layoutPipsInGroup(svgDoc, pipArea, loc.points, {
         fill: '#FFFFFF',
         strokeWidth: 0.5,
         className: 'pip structure',

--- a/src/services/printing/svgRecordSheetRenderer/templateRecordSheetRenderer.ts
+++ b/src/services/printing/svgRecordSheetRenderer/templateRecordSheetRenderer.ts
@@ -1,0 +1,267 @@
+/**
+ * Shared Template Record Sheet Renderer
+ *
+ * The unit-type-agnostic core of the canonical-template rendering
+ * pipeline. Owns asset loading, DOM parsing, text injection, off-screen
+ * mounting, and SVG serialization — but knows nothing about any
+ * particular unit family.
+ *
+ * The mech renderer (`SVGRecordSheetRenderer`) and the Wave-1 non-mech
+ * families (vehicle / aerospace / protomech) both consume this core, so
+ * the proven mech rendering substrate is shared rather than forked.
+ *
+ * It deliberately reuses `loadSVGTemplate` / `setTextContent` from
+ * `template.ts` and `renderToCanvasHighDPI` from `canvas.ts` verbatim —
+ * no fork of the proven mech logic.
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Shared Template Record Sheet Renderer)
+ */
+
+import { renderToCanvasHighDPI } from './canvas';
+import { loadSVGTemplate, setTextContent } from './template';
+
+/**
+ * A map of template element ID → text value to inject.
+ * Keys are canonical template `id=` attribute values.
+ */
+export type TextBindings = Readonly<Record<string, string>>;
+
+/**
+ * A pip-fill instruction: a template pip-group element ID paired with
+ * the number of pips to lay out inside that group's region geometry.
+ * Consumed by the shared pip engine via `applyPips`.
+ */
+export interface PipFill {
+  /** Template pip-group element ID (e.g. `armorPipsFR`, `armorPipsNOS`). */
+  readonly groupId: string;
+  /** Number of pip elements to render. */
+  readonly count: number;
+  /** Optional CSS class applied to each rendered pip. */
+  readonly className?: string;
+  /** Whether the pip group uses the alternate clustered layout. */
+  readonly grouped?: boolean;
+}
+
+/** A function that lays out one `PipFill` against a resolved group element. */
+export type PipApplicator = (
+  svgDoc: Document,
+  group: Element,
+  fill: PipFill,
+) => void;
+
+/**
+ * Shared, unit-type-agnostic record-sheet template renderer.
+ *
+ * Lifecycle:
+ *   1. `loadTemplate(path)` — fetch + parse the canonical template SVG.
+ *   2. `mount()` — attach the SVG to an off-screen DOM container so
+ *      geometry measurement (`getBBox()`) and web-font-aware text
+ *      measurement work. Idempotent.
+ *   3. `applyBindings(texts)` — inject text by element ID.
+ *   4. `applyPips(fills, applicator)` — lay out pip groups.
+ *   5. `getSVGString()` — serialize; also unmounts the off-screen node.
+ */
+export class TemplateRecordSheetRenderer {
+  private svgDoc: Document | null = null;
+  private svgRoot: SVGSVGElement | null = null;
+  /** The off-screen container holding the mounted SVG, when mounted. */
+  private mountContainer: HTMLElement | null = null;
+
+  /**
+   * Load and parse a canonical template SVG.
+   *
+   * Delegates to the proven `loadSVGTemplate` path used by the mech
+   * renderer — which fetches via the dev-server / asset path,
+   * validates the content type, and parses with `DOMParser`. Asset
+   * resolution through `MmDataAssetService`'s three-source fallback
+   * chain happens upstream of the path handed in here.
+   */
+  async loadTemplate(templatePath: string): Promise<void> {
+    const { svgDoc, svgRoot } = await loadSVGTemplate(templatePath);
+    this.svgDoc = svgDoc;
+    this.svgRoot = svgRoot;
+  }
+
+  /** The parsed template document. Throws if no template is loaded. */
+  get document(): Document {
+    if (!this.svgDoc) {
+      throw new Error('Template not loaded. Call loadTemplate() first.');
+    }
+    return this.svgDoc;
+  }
+
+  /** The parsed template root element. Throws if no template is loaded. */
+  get root(): SVGSVGElement {
+    if (!this.svgRoot) {
+      throw new Error('Template not loaded. Call loadTemplate() first.');
+    }
+    return this.svgRoot;
+  }
+
+  /** Whether the SVG is currently attached to the off-screen container. */
+  get isMounted(): boolean {
+    return this.mountContainer !== null;
+  }
+
+  /**
+   * Mount the parsed SVG into an off-screen DOM container.
+   *
+   * The shared pip engine measures template region `<rect>` geometry;
+   * when a region is measured via `getBBox()` the element MUST be
+   * attached to a rendered document or the bounds come back zeroed.
+   * Web-font-aware text auto-shrink has the same live-DOM requirement.
+   * The container is absolutely positioned far off-viewport and made
+   * invisible so it never affects layout or paints.
+   *
+   * Idempotent — a second call while already mounted is a no-op. Safe
+   * to call in non-DOM environments: when `document` is unavailable the
+   * method returns without mounting (attribute-based geometry still
+   * works for callers that do not need `getBBox()`).
+   */
+  mount(): void {
+    if (this.mountContainer) {
+      return;
+    }
+    if (typeof document === 'undefined' || !this.svgRoot) {
+      return;
+    }
+    const container = document.createElement('div');
+    container.setAttribute('aria-hidden', 'true');
+    container.style.position = 'absolute';
+    container.style.left = '-99999px';
+    container.style.top = '-99999px';
+    container.style.width = '0';
+    container.style.height = '0';
+    container.style.overflow = 'hidden';
+    container.style.visibility = 'hidden';
+    container.appendChild(this.svgRoot);
+    document.body.appendChild(container);
+    this.mountContainer = container;
+  }
+
+  /**
+   * Remove the off-screen container from the document.
+   *
+   * `mount()` moves the SVG root out of the parsed template document
+   * and into the container; `unmount()` restores it so the parsed
+   * document is whole again — leaving the document/root relationship
+   * exactly as it was before `mount()`. The container is then removed
+   * from the page. Idempotent.
+   */
+  unmount(): void {
+    if (!this.mountContainer) {
+      return;
+    }
+    if (this.svgRoot && this.svgRoot.parentNode === this.mountContainer) {
+      this.mountContainer.removeChild(this.svgRoot);
+      // Restore the root into its original parsed document so
+      // serialization of the document remains correct.
+      if (this.svgDoc) {
+        this.svgDoc.appendChild(this.svgRoot);
+      }
+    }
+    if (this.mountContainer.parentNode) {
+      this.mountContainer.parentNode.removeChild(this.mountContainer);
+    }
+    this.mountContainer = null;
+  }
+
+  /**
+   * Await web-font readiness before any text-width measurement.
+   *
+   * If a binding field auto-shrinks to fit, measuring text width before
+   * the record-sheet web font has loaded yields wrong widths and
+   * inconsistent shrink. Centralizing the await here means every
+   * consuming family inherits the fix. Resolves immediately in
+   * environments without the Font Loading API.
+   */
+  async awaitFontsReady(): Promise<void> {
+    if (
+      typeof document !== 'undefined' &&
+      'fonts' in document &&
+      document.fonts &&
+      typeof document.fonts.ready?.then === 'function'
+    ) {
+      await document.fonts.ready;
+    }
+  }
+
+  /**
+   * Inject text bindings into the template by element ID.
+   *
+   * For each entry, the element is located via `getElementById` and its
+   * `textContent` is set. Elements absent from the template are silently
+   * skipped — a binding for a missing ID is a no-op, never an error.
+   */
+  applyBindings(texts: TextBindings): void {
+    const doc = this.document;
+    for (const [id, value] of Object.entries(texts)) {
+      setTextContent(doc, id, value);
+    }
+  }
+
+  /**
+   * Lay out pip groups using the supplied pip applicator.
+   *
+   * Each `PipFill` names a template pip-group element ID; the applicator
+   * (the shared pip engine, injected to keep this core free of any
+   * specific layout algorithm) resolves the group and lays out the
+   * pips. Resolution — including the `grouped`-layout fallback — is the
+   * applicator's responsibility.
+   *
+   * The SVG MUST be mounted (`mount()`) before this is called if the
+   * applicator measures geometry via `getBBox()`.
+   */
+  applyPips(fills: readonly PipFill[], applicator: PipApplicator): void {
+    const doc = this.document;
+    for (const fill of fills) {
+      if (fill.count <= 0) {
+        continue;
+      }
+      const group = doc.getElementById(fill.groupId);
+      if (!group) {
+        // Unresolved group IDs are tolerated — the applicator's own
+        // grouped fallback may still resolve it; pass through so the
+        // applicator can decide. Here we only short-circuit when the
+        // primary element is genuinely absent AND has no grouped twin.
+        const grouped = doc.getElementById(`${fill.groupId}grouped`);
+        if (grouped) {
+          applicator(doc, grouped, fill);
+        }
+        continue;
+      }
+      applicator(doc, group, fill);
+    }
+  }
+
+  /**
+   * Serialize the (possibly mutated) template document to an SVG string.
+   *
+   * Unmounts the off-screen container FIRST — `unmount()` restores the
+   * SVG root into the parsed document, so serializing the document is
+   * correct whether or not the renderer was ever mounted. This keeps
+   * the output byte-identical to the pre-refactor mech path (which
+   * serialized `svgDoc` and never mounted).
+   */
+  getSVGString(): string {
+    const doc = this.document;
+    // Detach the off-screen container (restores root into doc) before
+    // serializing, so no detached DOM nodes are left behind.
+    this.unmount();
+    const serializer = new XMLSerializer();
+    return serializer.serializeToString(doc);
+  }
+
+  /**
+   * Rasterize the current template document onto a canvas at high DPI.
+   * Delegates to the proven `renderToCanvasHighDPI` mech code path.
+   */
+  async renderToCanvas(
+    canvas: HTMLCanvasElement,
+    dpiMultiplier: number,
+  ): Promise<void> {
+    const svgString = this.getSVGString();
+    await renderToCanvasHighDPI(svgString, canvas, dpiMultiplier);
+  }
+}


### PR DESCRIPTION
## Summary

Phases 1 and 2 of the OpenSpec change `add-templated-vehicle-aero-proto-record-sheets`. Extracts the proven mech rendering core into shared, unit-type-agnostic modules so the three Wave-1 non-mech families (next PRs) can consume it.

**Phase 1 — Shared template renderer**
- New `TemplateRecordSheetRenderer`: `loadTemplate` / `applyBindings` / `applyPips` / `getSVGString`, plus an off-screen `mount()`/`unmount()` lifecycle (the pip engine's `getBBox()` path needs a live-mounted SVG) and an `awaitFontsReady()` gate for web-font-aware text measurement. Reuses `loadSVGTemplate` / `setTextContent` / `renderToCanvasHighDPI` verbatim — no fork of the proven mech logic.
- `SVGRecordSheetRenderer` (mech) refactored into a thin consumer of the shared core. **Behaviour-preserving** — the mech `SVGRecordSheetRenderer` behavioural tests + the 5 record-sheet snapshots pass with zero diff.

**Phase 2 — Shared dynamic pip engine**
- New `pipEngine` module generalizing `armor.ts`'s region-geometry layout. `resolvePipGroup` implements the `grouped`-layout element-lookup fallback (`getElementById(id + "grouped")`, mirroring MegaMekLab `PrintEntity.java`); `layoutPips` exposes the alternate-clustering flag from `ArmorPipLayout.java`.
- `armor.ts` + `structure.ts` (mech pip layout) routed through the shared engine via a transparent `layoutPipsInGroup` wrapper — no behaviour change.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx oxlint` clean on changed files
- [x] `npx oxfmt --check` clean on changed files
- [x] 30 new unit tests (shared-core lifecycle + pip-engine region geometry / grouped fallback / clustering)
- [x] Mech regression guard: `SVGRecordSheetRenderer` + `recordSheetSnapshots` (5 snapshots) + `ArmorPipLayout` + `structure` + `RecordSheetService` + `RecordSheetMultiTypeExport` — 219 tests pass, zero snapshot diff
- [x] Pre-commit build hook passed

Depends on #579 (Phase 0, merged).