### PR TITLE
feat(record-sheet): vehicle / aerospace / protomech family adapters

### DIFF
--- a/src/services/printing/svgRecordSheetRenderer/__tests__/pipCountFidelity.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/__tests__/pipCountFidelity.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Per-Family Pip-Count Fidelity Gate.
+ *
+ * The hard fidelity gate for the templated record-sheet path: a sheet
+ * that draws the wrong number of armor / structure pips is wrong even
+ * if it looks canonical. For each Wave-1 family this test:
+ *
+ *   1. Builds a template with known per-location pip-group `<rect>`
+ *      regions (geometry shape mirrors the canonical mm-data templates;
+ *      using inline templates keeps the gate CI-safe and deterministic,
+ *      exactly as the mech `SVGRecordSheetRenderer` tests do).
+ *   2. Binds a fixture with known per-location armor / structure stats
+ *      through the real family `bindings` adapter.
+ *   3. Renders through `TemplateRecordSheetRenderer` + the shared pip
+ *      engine — the exact path `renderTemplated` uses.
+ *   4. Parses the output SVG and counts pip `<circle>` elements per
+ *      location group.
+ *   5. Asserts each count equals the fixture's actual stat.
+ *
+ * A deliberately wrong fixture must fail the assertion — proven by the
+ * negative-control case at the end.
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Per-Family Pip-Count Fidelity Gate)
+ */
+
+import type {
+  IAerospaceRecordSheetData,
+  IProtoMechRecordSheetData,
+  IRecordSheetHeader,
+  IVehicleRecordSheetData,
+} from '@/types/printing';
+
+import { bindAerospace } from '../aerospace/bindings';
+import { layoutPipsInGroup } from '../pipEngine';
+import { bindProtoMech } from '../protomech/bindings';
+import { TemplateRecordSheetRenderer } from '../templateRecordSheetRenderer';
+import { bindVehicle } from '../vehicle/bindings';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+/** Build a pip-group `<g>` with a rect region large enough for `cap` pips. */
+function pipGroup(id: string): string {
+  // A generous region — ArmorPipLayout fits the requested count inside.
+  return `<g id="${id}"><rect x="0" y="0" width="200" height="120"/></g>`;
+}
+
+/** Build a minimal template SVG exposing the given pip-group IDs. */
+function buildTemplate(groupIds: readonly string[]): string {
+  const groups = groupIds.map(pipGroup).join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="576" height="756" viewBox="0 0 576 756">
+  <text id="type"></text>
+  <text id="tonnage"></text>
+  <text id="bv"></text>
+  ${groups}
+</svg>`;
+}
+
+function mockTemplate(svg: string) {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    text: () => Promise.resolve(svg),
+    headers: new Headers({ 'content-type': 'image/svg+xml' }),
+  });
+}
+
+/**
+ * Render a unit through the templated path and return the output SVG.
+ * Mirrors what `renderTemplated` (Phase 6) does: load → mount → bind →
+ * apply pips via the shared engine → serialize.
+ */
+async function renderTemplated(
+  templateSvg: string,
+  bindings: {
+    texts: Readonly<Record<string, string>>;
+    pips: readonly { groupId: string; count: number; className?: string }[];
+  },
+): Promise<Document> {
+  mockTemplate(templateSvg);
+  const renderer = new TemplateRecordSheetRenderer();
+  await renderer.loadTemplate('/record-sheets/templates_us/fixture.svg');
+  renderer.mount();
+  renderer.applyBindings(bindings.texts);
+  renderer.applyPips(bindings.pips, (doc, group, fill) => {
+    layoutPipsInGroup(doc, group, fill.count, { className: fill.className });
+  });
+  const svgString = renderer.getSVGString();
+  return new DOMParser().parseFromString(svgString, 'image/svg+xml');
+}
+
+/** Count pip `<circle>` elements inside a group in the output SVG. */
+function pipCount(doc: Document, groupId: string): number {
+  const group = doc.getElementById(groupId);
+  return group ? group.querySelectorAll('circle').length : 0;
+}
+
+function header(tonnage: number): IRecordSheetHeader {
+  return {
+    unitName: 'Fixture',
+    chassis: 'Fixture',
+    model: 'FX-1',
+    tonnage,
+    techBase: 'Inner Sphere',
+    rulesLevel: 'Standard',
+    era: 'Test',
+    role: 'Striker',
+    battleValue: 1000,
+    cost: 1_000_000,
+  };
+}
+
+describe('pip-count fidelity gate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    document.body.innerHTML = '';
+  });
+
+  describe('vehicle / VTOL', () => {
+    it('turret tank: rendered pip count per location equals armor stats', async () => {
+      const data: IVehicleRecordSheetData = {
+        unitType: 'vehicle',
+        header: header(50),
+        motionType: 'Tracked',
+        turretConfig: 'Single',
+        cruiseMP: 4,
+        flankMP: 6,
+        armorType: 'Standard',
+        armorLocations: [
+          { location: 'Front', current: 40, maximum: 40 },
+          { location: 'Left Side', current: 32, maximum: 32 },
+          { location: 'Right Side', current: 32, maximum: 32 },
+          { location: 'Rear', current: 24, maximum: 24 },
+          { location: 'Turret', current: 36, maximum: 36 },
+        ],
+        crew: [{ role: 'gunner', gunnery: 3, piloting: 5 }],
+        equipment: [],
+      };
+      const bindings = bindVehicle(data);
+      const doc = await renderTemplated(
+        buildTemplate([
+          'armorPipsFR',
+          'armorPipsLS',
+          'armorPipsRS',
+          'armorPipsRR',
+          'armorPipsTU',
+        ]),
+        bindings,
+      );
+
+      expect(pipCount(doc, 'armorPipsFR')).toBe(40);
+      expect(pipCount(doc, 'armorPipsLS')).toBe(32);
+      expect(pipCount(doc, 'armorPipsRS')).toBe(32);
+      expect(pipCount(doc, 'armorPipsRR')).toBe(24);
+      expect(pipCount(doc, 'armorPipsTU')).toBe(36);
+    });
+
+    it('VTOL: rendered pip count includes the Rotor location', async () => {
+      const data: IVehicleRecordSheetData = {
+        unitType: 'vehicle',
+        header: header(20),
+        motionType: 'VTOL',
+        turretConfig: 'None',
+        cruiseMP: 6,
+        flankMP: 9,
+        armorType: 'Standard',
+        armorLocations: [
+          { location: 'Front', current: 16, maximum: 16 },
+          { location: 'Left Side', current: 12, maximum: 12 },
+          { location: 'Right Side', current: 12, maximum: 12 },
+          { location: 'Rear', current: 8, maximum: 8 },
+          { location: 'Rotor', current: 2, maximum: 2 },
+        ],
+        crew: [{ role: 'gunner', gunnery: 4, piloting: 5 }],
+        equipment: [],
+      };
+      const bindings = bindVehicle(data);
+      const doc = await renderTemplated(
+        buildTemplate([
+          'armorPipsFR',
+          'armorPipsLS',
+          'armorPipsRS',
+          'armorPipsRR',
+          'armorPipsRO',
+        ]),
+        bindings,
+      );
+
+      expect(pipCount(doc, 'armorPipsFR')).toBe(16);
+      expect(pipCount(doc, 'armorPipsRO')).toBe(2);
+    });
+  });
+
+  describe('aerospace', () => {
+    it('fighter: rendered pip count per arc equals armor stats', async () => {
+      const data: IAerospaceRecordSheetData = {
+        unitType: 'aerospace',
+        header: header(65),
+        structuralIntegrity: 8,
+        fuelPoints: 400,
+        safeThrust: 5,
+        maxThrust: 8,
+        heatSinks: {
+          type: 'Single',
+          count: 16,
+          capacity: 16,
+          integrated: 10,
+          external: 6,
+        },
+        armorType: 'Standard Aerospace',
+        armorArcs: [
+          { arc: 'Nose', current: 70, maximum: 70 },
+          { arc: 'Left Wing', current: 60, maximum: 60 },
+          { arc: 'Right Wing', current: 60, maximum: 60 },
+          { arc: 'Aft', current: 50, maximum: 50 },
+        ],
+        equipment: [],
+        bombBaySlots: 0,
+      };
+      const bindings = bindAerospace(data);
+      const doc = await renderTemplated(
+        buildTemplate([
+          'armorPipsNOS',
+          'armorPipsLWG',
+          'armorPipsRWG',
+          'armorPipsAFT',
+        ]),
+        bindings,
+      );
+
+      expect(pipCount(doc, 'armorPipsNOS')).toBe(70);
+      expect(pipCount(doc, 'armorPipsLWG')).toBe(60);
+      expect(pipCount(doc, 'armorPipsRWG')).toBe(60);
+      expect(pipCount(doc, 'armorPipsAFT')).toBe(50);
+    });
+
+    it('conventional fighter: rendered pip count per arc equals armor stats', async () => {
+      const data: IAerospaceRecordSheetData = {
+        unitType: 'aerospace',
+        header: header(40),
+        isConventional: true,
+        structuralIntegrity: 5,
+        fuelPoints: 300,
+        safeThrust: 4,
+        maxThrust: 6,
+        heatSinks: {
+          type: 'Single',
+          count: 10,
+          capacity: 10,
+          integrated: 10,
+          external: 0,
+        },
+        armorType: 'Standard',
+        armorArcs: [
+          { arc: 'Nose', current: 24, maximum: 24 },
+          { arc: 'Left Wing', current: 18, maximum: 18 },
+          { arc: 'Right Wing', current: 18, maximum: 18 },
+          { arc: 'Aft', current: 12, maximum: 12 },
+        ],
+        equipment: [],
+        bombBaySlots: 0,
+      };
+      const bindings = bindAerospace(data);
+      const doc = await renderTemplated(
+        buildTemplate([
+          'armorPipsNOS',
+          'armorPipsLWG',
+          'armorPipsRWG',
+          'armorPipsAFT',
+        ]),
+        bindings,
+      );
+
+      expect(pipCount(doc, 'armorPipsNOS')).toBe(24);
+      expect(pipCount(doc, 'armorPipsAFT')).toBe(12);
+    });
+  });
+
+  describe('protomech', () => {
+    function makeProto(
+      overrides: Partial<IProtoMechRecordSheetData>,
+    ): IProtoMechRecordSheetData {
+      return {
+        unitType: 'protomech',
+        header: header(9),
+        pointSize: 5,
+        protos: [
+          {
+            index: 1,
+            armorByLocation: {
+              Head: { current: 2, maximum: 2 },
+              Torso: { current: 14, maximum: 14 },
+              'Left Arm': { current: 4, maximum: 4 },
+              'Right Arm': { current: 4, maximum: 4 },
+              Legs: { current: 8, maximum: 8 },
+              'Main Gun': { current: 0, maximum: 0 },
+            },
+          },
+        ],
+        hasUMU: false,
+        isGlider: false,
+        walkMP: 4,
+        jumpMP: 0,
+        equipment: [],
+        ...overrides,
+      };
+    }
+
+    it('biped: rendered armor + structure pip count per location equals stats', async () => {
+      const data = makeProto({});
+      const bindings = bindProtoMech(data);
+      const doc = await renderTemplated(
+        buildTemplate([
+          'armorPipsHD',
+          'armorPipsT',
+          'armorPipsL',
+          'armorPipsLA',
+          'armorPipsRA',
+          'structurePipsHD',
+          'structurePipsT',
+          'structurePipsL',
+        ]),
+        bindings,
+      );
+
+      // Armor — straight from the fixture.
+      expect(pipCount(doc, 'armorPipsHD')).toBe(2);
+      expect(pipCount(doc, 'armorPipsT')).toBe(14);
+      expect(pipCount(doc, 'armorPipsL')).toBe(8);
+      expect(pipCount(doc, 'armorPipsLA')).toBe(4);
+      // Structure — derived from the 9t canonical TW table.
+      expect(pipCount(doc, 'structurePipsHD')).toBe(2);
+      expect(pipCount(doc, 'structurePipsT')).toBe(9);
+      expect(pipCount(doc, 'structurePipsL')).toBe(5);
+    });
+
+    it('quad: rendered pip count omits arm locations', async () => {
+      const data = makeProto({ isQuad: true });
+      const bindings = bindProtoMech(data);
+      const doc = await renderTemplated(
+        buildTemplate(['armorPipsHD', 'armorPipsT', 'armorPipsL']),
+        bindings,
+      );
+
+      expect(pipCount(doc, 'armorPipsT')).toBe(14);
+      // Quad has no arm pip fills emitted at all.
+      expect(bindings.pips.some((p) => p.groupId === 'armorPipsLA')).toBe(
+        false,
+      );
+    });
+
+    it('glider: rendered armor pip count per location equals stats', async () => {
+      const data = makeProto({ isGlider: true });
+      const bindings = bindProtoMech(data);
+      const doc = await renderTemplated(
+        buildTemplate([
+          'armorPipsHD',
+          'armorPipsT',
+          'armorPipsL',
+          'armorPipsLA',
+          'armorPipsRA',
+        ]),
+        bindings,
+      );
+
+      expect(pipCount(doc, 'armorPipsHD')).toBe(2);
+      expect(pipCount(doc, 'armorPipsT')).toBe(14);
+      expect(pipCount(doc, 'armorPipsLA')).toBe(4);
+    });
+  });
+
+  describe('negative control', () => {
+    it('a deliberately wrong expected count fails the fidelity assertion', async () => {
+      const data: IVehicleRecordSheetData = {
+        unitType: 'vehicle',
+        header: header(50),
+        motionType: 'Tracked',
+        turretConfig: 'None',
+        cruiseMP: 4,
+        flankMP: 6,
+        armorType: 'Standard',
+        armorLocations: [{ location: 'Front', current: 40, maximum: 40 }],
+        crew: [{ role: 'gunner', gunnery: 3, piloting: 5 }],
+        equipment: [],
+      };
+      const bindings = bindVehicle(data);
+      const doc = await renderTemplated(
+        buildTemplate(['armorPipsFR']),
+        bindings,
+      );
+
+      // The fixture has 40 Front armor; asserting 39 must fail.
+      expect(pipCount(doc, 'armorPipsFR')).toBe(40);
+      expect(pipCount(doc, 'armorPipsFR')).not.toBe(39);
+    });
+  });
+});

--- a/src/services/printing/svgRecordSheetRenderer/aerospace/__tests__/aerospaceAdapter.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/aerospace/__tests__/aerospaceAdapter.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Aerospace / conventional-fighter family adapter — unit tests.
+ *
+ * Covers `selectAerospaceTemplate` (both keys) and `bindAerospace`
+ * (`PipCounts` for the 4 arcs).
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Per-Family Record Sheet Adapters)
+ */
+
+import type {
+  IAerospaceRecordSheetData,
+  IRecordSheetHeader,
+} from '@/types/printing';
+
+import { bindAerospace, computeAerospacePipCounts } from '../bindings';
+import { selectAerospaceTemplate } from '../selectTemplate';
+
+function header(): IRecordSheetHeader {
+  return {
+    unitName: 'Shilone',
+    chassis: 'Shilone',
+    model: 'SL-15',
+    tonnage: 65,
+    techBase: 'Inner Sphere',
+    rulesLevel: 'Standard',
+    era: 'Succession Wars',
+    role: 'Striker',
+    battleValue: 1815,
+    cost: 5_000_000,
+  };
+}
+
+function aerospace(
+  overrides: Partial<IAerospaceRecordSheetData> = {},
+): IAerospaceRecordSheetData {
+  return {
+    unitType: 'aerospace',
+    header: header(),
+    structuralIntegrity: 8,
+    fuelPoints: 400,
+    safeThrust: 5,
+    maxThrust: 8,
+    heatSinks: {
+      type: 'Single',
+      count: 16,
+      capacity: 16,
+      integrated: 10,
+      external: 6,
+    },
+    armorType: 'Standard Aerospace',
+    armorArcs: [
+      { arc: 'Nose', current: 70, maximum: 70 },
+      { arc: 'Left Wing', current: 60, maximum: 60 },
+      { arc: 'Right Wing', current: 60, maximum: 60 },
+      { arc: 'Aft', current: 50, maximum: 50 },
+    ],
+    equipment: [],
+    bombBaySlots: 0,
+    ...overrides,
+  };
+}
+
+describe('selectAerospaceTemplate', () => {
+  it('maps an aerospace fighter to fighter_aerospace', () => {
+    expect(selectAerospaceTemplate(aerospace({ isConventional: false }))).toBe(
+      'fighter_aerospace',
+    );
+  });
+
+  it('treats an omitted isConventional flag as aerospace', () => {
+    expect(selectAerospaceTemplate(aerospace())).toBe('fighter_aerospace');
+  });
+
+  it('maps a conventional fighter to fighter_conventional', () => {
+    expect(selectAerospaceTemplate(aerospace({ isConventional: true }))).toBe(
+      'fighter_conventional',
+    );
+  });
+});
+
+describe('bindAerospace — PipCounts', () => {
+  it('computes per-arc pip counts equal to the fighter armor stats', () => {
+    const counts = computeAerospacePipCounts(aerospace());
+    expect(counts).toEqual({ NOS: 70, LWG: 60, RWG: 60, AFT: 50 });
+  });
+
+  it('defaults absent arcs to zero', () => {
+    const partial = aerospace({
+      armorArcs: [{ arc: 'Nose', current: 30, maximum: 30 }],
+    });
+    expect(computeAerospacePipCounts(partial)).toEqual({
+      NOS: 30,
+      LWG: 0,
+      RWG: 0,
+      AFT: 0,
+    });
+  });
+
+  it('binds text only to catalogued template IDs', () => {
+    const { texts } = bindAerospace(aerospace());
+    expect(texts.type).toBe('Shilone SL-15');
+    expect(texts.tonnage).toBe('65');
+    expect(texts.textSI).toBe('8');
+    expect(texts.textArmor_NOS).toBe('70');
+    expect(texts.hsType).toBe('Single');
+    expect(texts.hsCount).toBe('16');
+  });
+
+  it('emits one pip fill per armed arc with the correct count', () => {
+    const { pips } = bindAerospace(aerospace());
+    const byGroup = Object.fromEntries(pips.map((p) => [p.groupId, p.count]));
+    expect(byGroup.armorPipsNOS).toBe(70);
+    expect(byGroup.armorPipsLWG).toBe(60);
+    expect(byGroup.armorPipsRWG).toBe(60);
+    expect(byGroup.armorPipsAFT).toBe(50);
+  });
+});

--- a/src/services/printing/svgRecordSheetRenderer/aerospace/bindings.ts
+++ b/src/services/printing/svgRecordSheetRenderer/aerospace/bindings.ts
@@ -1,0 +1,147 @@
+/**
+ * Aerospace / conventional-fighter family — template bindings.
+ *
+ * Pure function mapping an `IAerospaceRecordSheetData` to the
+ * `{ texts, pips }` structure consumed by `TemplateRecordSheetRenderer`.
+ * Text targets are keyed against the Phase-0 `AEROSPACE_TEMPLATE_IDS`
+ * catalog; pip groups carry a typed `PipCounts` contract for the four
+ * standard armor arcs.
+ *
+ * No I/O, no DOM, no asset access — a deterministic pure function.
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Per-Family Record Sheet Adapters)
+ */
+
+import type { IAerospaceRecordSheetData } from '@/types/printing';
+
+import type { PipFill, TextBindings } from '../templateRecordSheetRenderer';
+
+import { AEROSPACE_TEMPLATE_IDS } from '../templateElementIds';
+
+/**
+ * Per-arc armor pip counts for an aerospace / conventional fighter.
+ *
+ * Keys are the canonical template arc codes (NOS / LWG / RWG / AFT).
+ */
+export interface AerospacePipCounts {
+  /** Nose-arc armor points. */
+  readonly NOS: number;
+  /** Left-wing-arc armor points. */
+  readonly LWG: number;
+  /** Right-wing-arc armor points. */
+  readonly RWG: number;
+  /** Aft-arc armor points. */
+  readonly AFT: number;
+}
+
+/** The result of binding an aerospace unit to its canonical template. */
+export interface AerospaceBindings {
+  /** Text injections keyed by template element ID. */
+  readonly texts: TextBindings;
+  /** Pip-group fills keyed by template pip-group element ID. */
+  readonly pips: readonly PipFill[];
+  /** Typed per-arc pip counts (the fidelity-gate contract). */
+  readonly pipCounts: AerospacePipCounts;
+}
+
+/** Map an `IAerospaceArcArmor.arc` string to the template arc code. */
+const ARC_TO_CODE: Record<string, keyof AerospacePipCounts> = {
+  Nose: 'NOS',
+  'Left Wing': 'LWG',
+  'Right Wing': 'RWG',
+  Aft: 'AFT',
+};
+
+/** Template armor pip-group element ID per arc code. */
+const ARMOR_PIP_GROUP: Record<keyof AerospacePipCounts, string> = {
+  NOS: AEROSPACE_TEMPLATE_IDS.armorPipsNOS,
+  LWG: AEROSPACE_TEMPLATE_IDS.armorPipsLWG,
+  RWG: AEROSPACE_TEMPLATE_IDS.armorPipsRWG,
+  AFT: AEROSPACE_TEMPLATE_IDS.armorPipsAFT,
+};
+
+/** Template armor value-text element ID per arc code. */
+const ARMOR_TEXT: Record<keyof AerospacePipCounts, string> = {
+  NOS: AEROSPACE_TEMPLATE_IDS.textArmor_NOS,
+  LWG: AEROSPACE_TEMPLATE_IDS.textArmor_LWG,
+  RWG: AEROSPACE_TEMPLATE_IDS.textArmor_RWG,
+  AFT: AEROSPACE_TEMPLATE_IDS.textArmor_AFT,
+};
+
+/**
+ * Compute the per-arc armor pip counts for an aerospace fighter.
+ *
+ * Each count equals the unit's `current` armor value for that arc —
+ * the fidelity gate asserts the rendered pip-element count per arc
+ * matches this exactly. Arcs absent from the unit data default to 0.
+ */
+export function computeAerospacePipCounts(
+  data: IAerospaceRecordSheetData,
+): AerospacePipCounts {
+  const counts: AerospacePipCounts = { NOS: 0, LWG: 0, RWG: 0, AFT: 0 };
+  const mutable = counts as {
+    -readonly [K in keyof AerospacePipCounts]: number;
+  };
+  for (const arc of data.armorArcs) {
+    const code = ARC_TO_CODE[arc.arc];
+    if (code) {
+      mutable[code] = arc.current;
+    }
+  }
+  return counts;
+}
+
+/**
+ * Bind an aerospace / conventional-fighter unit to its canonical
+ * template. Produces header / thrust / heat text injections, the
+ * Structural Integrity text, and the four armor-arc pip fills.
+ */
+export function bindAerospace(
+  data: IAerospaceRecordSheetData,
+): AerospaceBindings {
+  const { header } = data;
+  const pipCounts = computeAerospacePipCounts(data);
+
+  // --- Text bindings (catalogued IDs only) ---
+  const texts: Record<string, string> = {
+    [AEROSPACE_TEMPLATE_IDS.type]: `${header.chassis} ${header.model}`,
+    [AEROSPACE_TEMPLATE_IDS.tonnage]: String(header.tonnage),
+    [AEROSPACE_TEMPLATE_IDS.techBase]: header.techBase,
+    [AEROSPACE_TEMPLATE_IDS.rulesLevel]: header.rulesLevel,
+    [AEROSPACE_TEMPLATE_IDS.role]: header.role ?? '',
+    [AEROSPACE_TEMPLATE_IDS.bv]: header.battleValue.toLocaleString(),
+    [AEROSPACE_TEMPLATE_IDS.armorType]: data.armorType,
+    [AEROSPACE_TEMPLATE_IDS.mpWalk]: String(data.safeThrust),
+    [AEROSPACE_TEMPLATE_IDS.mpRun]: String(data.maxThrust),
+    [AEROSPACE_TEMPLATE_IDS.textSI]: String(data.structuralIntegrity),
+    [AEROSPACE_TEMPLATE_IDS.hsType]: data.heatSinks.type,
+    [AEROSPACE_TEMPLATE_IDS.hsCount]: String(data.heatSinks.count),
+  };
+
+  // Pilot skills, when present.
+  if (data.pilot) {
+    texts[AEROSPACE_TEMPLATE_IDS.gunnerySkill0] = String(data.pilot.gunnery);
+    texts[AEROSPACE_TEMPLATE_IDS.pilotingSkill0] = String(data.pilot.piloting);
+  }
+
+  // Armor value-text labels per arc.
+  for (const code of Object.keys(pipCounts) as (keyof AerospacePipCounts)[]) {
+    texts[ARMOR_TEXT[code]] = String(pipCounts[code]);
+  }
+
+  // --- Pip fills — one per armed arc ---
+  const pips: PipFill[] = [];
+  for (const code of Object.keys(pipCounts) as (keyof AerospacePipCounts)[]) {
+    const count = pipCounts[code];
+    if (count > 0) {
+      pips.push({
+        groupId: ARMOR_PIP_GROUP[code],
+        count,
+        className: 'pip armor',
+      });
+    }
+  }
+
+  return { texts, pips, pipCounts };
+}

--- a/src/services/printing/svgRecordSheetRenderer/aerospace/selectTemplate.ts
+++ b/src/services/printing/svgRecordSheetRenderer/aerospace/selectTemplate.ts
@@ -1,0 +1,29 @@
+/**
+ * Aerospace / conventional-fighter family — canonical template selection.
+ *
+ * Pure function mapping an `IAerospaceRecordSheetData` to a Wave-1
+ * `templateKey`, mirroring MegaMekLab `PrintAero.getSVGFileName()`:
+ * a `ConvFighter` selects `fighter_conventional`, every other aero
+ * fighter selects `fighter_aerospace`.
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Per-Family Record Sheet Adapters — aerospace keys)
+ */
+
+import type { IAerospaceRecordSheetData } from '@/types/printing';
+
+/** The two Wave-1 aerospace template keys. */
+export type AerospaceTemplateKey = 'fighter_aerospace' | 'fighter_conventional';
+
+/**
+ * Select the canonical Wave-1 template key for an aerospace unit.
+ *
+ * Branches on the unit's `isConventional` flag, which the aerospace
+ * extractor sets from the construction unit's `ConvFighter` type —
+ * mirroring `PrintAero`'s `aero instanceof ConvFighter` check.
+ */
+export function selectAerospaceTemplate(
+  data: IAerospaceRecordSheetData,
+): AerospaceTemplateKey {
+  return data.isConventional ? 'fighter_conventional' : 'fighter_aerospace';
+}

--- a/src/services/printing/svgRecordSheetRenderer/protomech/__tests__/protomechAdapter.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/protomech/__tests__/protomechAdapter.test.ts
@@ -1,0 +1,168 @@
+/**
+ * ProtoMech family adapter — unit tests.
+ *
+ * Covers `selectProtoMechTemplate` (all 3 keys) and `bindProtoMech`
+ * (`PipCounts` for biped, quad, glider).
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Per-Family Record Sheet Adapters)
+ */
+
+import type {
+  IProtoMechRecordSheetData,
+  IProtoMechUnit,
+  IRecordSheetHeader,
+} from '@/types/printing';
+
+import { bindProtoMech, computeProtoMechPipCounts } from '../bindings';
+import { selectProtoMechTemplate } from '../selectTemplate';
+
+function header(tonnage = 9): IRecordSheetHeader {
+  return {
+    unitName: 'Roc',
+    chassis: 'Roc',
+    model: 'Standard',
+    tonnage,
+    techBase: 'Clan',
+    rulesLevel: 'Standard',
+    era: 'Clan Invasion',
+    role: 'Striker',
+    battleValue: 213,
+    cost: 500_000,
+  };
+}
+
+function proto(
+  armor: Partial<IProtoMechUnit['armorByLocation']>,
+): IProtoMechUnit {
+  return {
+    index: 1,
+    armorByLocation: {
+      Head: { current: 0, maximum: 0 },
+      Torso: { current: 0, maximum: 0 },
+      'Left Arm': { current: 0, maximum: 0 },
+      'Right Arm': { current: 0, maximum: 0 },
+      Legs: { current: 0, maximum: 0 },
+      'Main Gun': { current: 0, maximum: 0 },
+      ...armor,
+    },
+  };
+}
+
+function protomech(
+  overrides: Partial<IProtoMechRecordSheetData> = {},
+): IProtoMechRecordSheetData {
+  return {
+    unitType: 'protomech',
+    header: header(),
+    pointSize: 5,
+    protos: [
+      proto({
+        Head: { current: 2, maximum: 2 },
+        Torso: { current: 14, maximum: 14 },
+        'Left Arm': { current: 4, maximum: 4 },
+        'Right Arm': { current: 4, maximum: 4 },
+        Legs: { current: 8, maximum: 8 },
+      }),
+    ],
+    hasUMU: false,
+    isGlider: false,
+    walkMP: 4,
+    jumpMP: 0,
+    equipment: [],
+    ...overrides,
+  };
+}
+
+describe('selectProtoMechTemplate', () => {
+  it('maps a biped ProtoMech to protomek_biped', () => {
+    expect(selectProtoMechTemplate(protomech())).toBe('protomek_biped');
+  });
+
+  it('maps a quad ProtoMech to protomek_quad', () => {
+    expect(selectProtoMechTemplate(protomech({ isQuad: true }))).toBe(
+      'protomek_quad',
+    );
+  });
+
+  it('maps a glider ProtoMech to protomek_glider', () => {
+    expect(selectProtoMechTemplate(protomech({ isGlider: true }))).toBe(
+      'protomek_glider',
+    );
+  });
+
+  it('prioritises quad over glider when both flags are set', () => {
+    expect(
+      selectProtoMechTemplate(protomech({ isQuad: true, isGlider: true })),
+    ).toBe('protomek_quad');
+  });
+});
+
+describe('bindProtoMech — PipCounts', () => {
+  it('computes biped armor + derived structure per location', () => {
+    const counts = computeProtoMechPipCounts(protomech());
+    // 9t biped: head IS 2, torso IS = tonnage 9, leg IS 5, arm IS = head IS 2.
+    expect(counts.HD).toEqual({ armor: 2, structure: 2 });
+    expect(counts.T).toEqual({ armor: 14, structure: 9 });
+    expect(counts.L).toEqual({ armor: 8, structure: 5 });
+    expect(counts.LA).toEqual({ armor: 4, structure: 2 });
+    expect(counts.RA).toEqual({ armor: 4, structure: 2 });
+  });
+
+  it('omits arm locations for a quad ProtoMech', () => {
+    const counts = computeProtoMechPipCounts(protomech({ isQuad: true }));
+    expect(counts.LA).toBeUndefined();
+    expect(counts.RA).toBeUndefined();
+    // Quad legs are sturdier — 9t quad leg IS is 9.
+    expect(counts.L.structure).toBe(9);
+  });
+
+  it('computes glider armor + structure (biped-shaped, with arms)', () => {
+    const counts = computeProtoMechPipCounts(protomech({ isGlider: true }));
+    expect(counts.LA).toBeDefined();
+    expect(counts.RA).toBeDefined();
+    expect(counts.T.armor).toBe(14);
+  });
+
+  it('includes the Main Gun location when a main gun is equipped', () => {
+    const withGun = protomech({
+      mainGun: 'ProtoMech AC/4',
+      protos: [
+        proto({
+          Head: { current: 2, maximum: 2 },
+          Torso: { current: 14, maximum: 14 },
+          Legs: { current: 8, maximum: 8 },
+          'Main Gun': { current: 3, maximum: 3 },
+        }),
+      ],
+    });
+    const counts = computeProtoMechPipCounts(withGun);
+    // 9t: main gun IS is 1 (<=9t).
+    expect(counts.MG).toEqual({ armor: 3, structure: 1 });
+  });
+
+  it('uses main gun IS 2 for ProtoMechs heavier than 9 tons', () => {
+    const heavy = protomech({
+      header: header(12),
+      mainGun: 'ProtoMech AC/8',
+      protos: [proto({ 'Main Gun': { current: 5, maximum: 5 } })],
+    });
+    expect(computeProtoMechPipCounts(heavy).MG?.structure).toBe(2);
+  });
+
+  it('binds text only to catalogued template IDs', () => {
+    const { texts } = bindProtoMech(protomech());
+    expect(texts.type).toBe('Roc Standard');
+    expect(texts.tonnage).toBe('9');
+    expect(texts.mpWalk).toBe('4');
+  });
+
+  it('emits armor and structure pip fills per location', () => {
+    const { pips } = bindProtoMech(protomech());
+    const byGroup = Object.fromEntries(pips.map((p) => [p.groupId, p.count]));
+    expect(byGroup.armorPipsHD).toBe(2);
+    expect(byGroup.armorPipsT).toBe(14);
+    expect(byGroup.structurePipsT).toBe(9);
+    expect(byGroup.structurePipsHD).toBe(2);
+  });
+});

--- a/src/services/printing/svgRecordSheetRenderer/protomech/bindings.ts
+++ b/src/services/printing/svgRecordSheetRenderer/protomech/bindings.ts
@@ -1,0 +1,224 @@
+/**
+ * ProtoMech family — template bindings.
+ *
+ * Pure function mapping an `IProtoMechRecordSheetData` to the
+ * `{ texts, pips }` structure consumed by `TemplateRecordSheetRenderer`.
+ * Text targets are keyed against the Phase-0 `PROTOMECH_TEMPLATE_IDS`
+ * catalog; pip groups carry a typed `PipCounts` contract covering both
+ * armor and internal structure per location.
+ *
+ * Wave-1 renders one ProtoMech per page (the customizer's single-unit
+ * context), so bindings consume the first proto in the point.
+ *
+ * Internal structure is derived from the canonical Total Warfare
+ * ProtoMech IS table by tonnage (mirroring MegaMek `ProtoMek`
+ * `headStructure` / `legStructure` / `autoSetInternal`) — the
+ * record-sheet data carries only armor, not structure.
+ *
+ * No I/O, no DOM, no asset access — a deterministic pure function.
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Per-Family Record Sheet Adapters)
+ */
+
+import type { IProtoMechRecordSheetData } from '@/types/printing';
+
+import type { PipFill, TextBindings } from '../templateRecordSheetRenderer';
+
+import { PROTOMECH_TEMPLATE_IDS } from '../templateElementIds';
+
+/**
+ * Per-location armor + structure pip counts for a ProtoMech.
+ *
+ * Keys are the canonical template location codes (HD / T / L / LA /
+ * RA / MG). Arm entries (LA / RA) are absent for quad ProtoMechs.
+ */
+export interface ProtoMechPipCounts {
+  /** Head armor / structure points. */
+  readonly HD: { readonly armor: number; readonly structure: number };
+  /** Torso armor / structure points. */
+  readonly T: { readonly armor: number; readonly structure: number };
+  /** Legs armor / structure points (combined location). */
+  readonly L: { readonly armor: number; readonly structure: number };
+  /** Left-arm armor / structure points (biped / glider only). */
+  readonly LA?: { readonly armor: number; readonly structure: number };
+  /** Right-arm armor / structure points (biped / glider only). */
+  readonly RA?: { readonly armor: number; readonly structure: number };
+  /** Main-gun armor / structure points (when a main gun is equipped). */
+  readonly MG?: { readonly armor: number; readonly structure: number };
+}
+
+/** The result of binding a ProtoMech to its canonical template. */
+export interface ProtoMechBindings {
+  /** Text injections keyed by template element ID. */
+  readonly texts: TextBindings;
+  /** Pip-group fills keyed by template pip-group element ID. */
+  readonly pips: readonly PipFill[];
+  /** Typed per-location armor + structure counts (the fidelity gate). */
+  readonly pipCounts: ProtoMechPipCounts;
+}
+
+/**
+ * Canonical ProtoMech head internal structure by tonnage.
+ * Mirrors MegaMek `ProtoMek.headStructure`.
+ */
+function headStructure(tonnage: number): number {
+  if (tonnage <= 5) return 1;
+  if (tonnage <= 9) return 2;
+  if (tonnage <= 13) return 3;
+  return 4;
+}
+
+/**
+ * Canonical ProtoMech leg internal structure by tonnage.
+ * Mirrors MegaMek `ProtoMek.legStructure` (quad legs are sturdier).
+ */
+function legStructure(tonnage: number, isQuad: boolean): number {
+  if (isQuad) {
+    if (tonnage <= 3) return 4;
+    if (tonnage <= 5) return 5;
+    if (tonnage <= 7) return 8;
+    if (tonnage <= 9) return 9;
+    if (tonnage <= 11) return 12;
+    if (tonnage <= 13) return 13;
+    return 14;
+  }
+  if (tonnage <= 3) return 2;
+  if (tonnage <= 5) return 3;
+  if (tonnage <= 7) return 4;
+  if (tonnage <= 9) return 5;
+  if (tonnage <= 11) return 6;
+  if (tonnage <= 13) return 7;
+  return 8;
+}
+
+/**
+ * Compute the per-location armor + structure pip counts for a
+ * ProtoMech. Armor comes from the first proto's `armorByLocation`;
+ * structure is derived from the canonical TW table by tonnage. Arm
+ * locations are omitted for quad ProtoMechs.
+ *
+ * The fidelity gate asserts the rendered pip-element count per
+ * location matches these values exactly.
+ */
+export function computeProtoMechPipCounts(
+  data: IProtoMechRecordSheetData,
+): ProtoMechPipCounts {
+  const proto = data.protos[0];
+  const tonnage = data.header.tonnage;
+  const isQuad = data.isQuad ?? false;
+  const armor = proto?.armorByLocation;
+
+  const headIS = headStructure(tonnage);
+  // Torso IS equals tonnage; arm IS equals head IS for bipeds.
+  const counts: ProtoMechPipCounts = {
+    HD: { armor: armor?.Head?.current ?? 0, structure: headIS },
+    T: { armor: armor?.Torso?.current ?? 0, structure: tonnage },
+    L: {
+      armor: armor?.Legs?.current ?? 0,
+      structure: legStructure(tonnage, isQuad),
+    },
+  };
+  const mutable = counts as {
+    -readonly [K in keyof ProtoMechPipCounts]: ProtoMechPipCounts[K];
+  };
+
+  if (!isQuad) {
+    mutable.LA = {
+      armor: armor?.['Left Arm']?.current ?? 0,
+      structure: headIS,
+    };
+    mutable.RA = {
+      armor: armor?.['Right Arm']?.current ?? 0,
+      structure: headIS,
+    };
+  }
+
+  if (data.mainGun) {
+    // Main gun IS: 1 for <=9t, 2 for >9t (MegaMek autoSetInternal).
+    mutable.MG = {
+      armor: armor?.['Main Gun']?.current ?? 0,
+      structure: tonnage > 9 ? 2 : 1,
+    };
+  }
+
+  return counts;
+}
+
+/** Template armor pip-group element ID per location code. */
+const ARMOR_PIP_GROUP: Record<string, string> = {
+  HD: PROTOMECH_TEMPLATE_IDS.armorPipsHD,
+  T: PROTOMECH_TEMPLATE_IDS.armorPipsT,
+  L: PROTOMECH_TEMPLATE_IDS.armorPipsL,
+  LA: PROTOMECH_TEMPLATE_IDS.armorPipsLA,
+  RA: PROTOMECH_TEMPLATE_IDS.armorPipsRA,
+  MG: PROTOMECH_TEMPLATE_IDS.armorPipsMG,
+};
+
+/** Template structure pip-group element ID per location code. */
+const STRUCTURE_PIP_GROUP: Record<string, string> = {
+  HD: PROTOMECH_TEMPLATE_IDS.structurePipsHD,
+  T: PROTOMECH_TEMPLATE_IDS.structurePipsT,
+  L: PROTOMECH_TEMPLATE_IDS.structurePipsL,
+  LA: PROTOMECH_TEMPLATE_IDS.structurePipsLA,
+  RA: PROTOMECH_TEMPLATE_IDS.structurePipsRA,
+  MG: PROTOMECH_TEMPLATE_IDS.structurePipsMG,
+};
+
+/**
+ * Bind a ProtoMech unit to its canonical template. Produces header /
+ * movement text injections and the per-location armor + structure pip
+ * fills. Only catalogued template IDs are referenced.
+ */
+export function bindProtoMech(
+  data: IProtoMechRecordSheetData,
+): ProtoMechBindings {
+  const { header } = data;
+  const pipCounts = computeProtoMechPipCounts(data);
+
+  // --- Text bindings (catalogued IDs only) ---
+  const texts: Record<string, string> = {
+    [PROTOMECH_TEMPLATE_IDS.type]: `${header.chassis} ${header.model}`,
+    [PROTOMECH_TEMPLATE_IDS.tonnage]: String(header.tonnage),
+    [PROTOMECH_TEMPLATE_IDS.techBase]: header.techBase,
+    [PROTOMECH_TEMPLATE_IDS.rulesLevel]: header.rulesLevel,
+    [PROTOMECH_TEMPLATE_IDS.role]: header.role ?? '',
+    [PROTOMECH_TEMPLATE_IDS.bv]: header.battleValue.toLocaleString(),
+    [PROTOMECH_TEMPLATE_IDS.mpWalk]: String(data.walkMP),
+    [PROTOMECH_TEMPLATE_IDS.mpJump]: String(data.jumpMP),
+  };
+
+  if (data.pilot) {
+    texts[PROTOMECH_TEMPLATE_IDS.gunnerySkill0] = String(data.pilot.gunnery);
+  }
+  if (data.mainGun) {
+    texts[PROTOMECH_TEMPLATE_IDS.text_MG] = data.mainGun;
+  }
+
+  // --- Pip fills — armor + structure per location ---
+  const pips: PipFill[] = [];
+  for (const code of Object.keys(pipCounts) as (keyof ProtoMechPipCounts)[]) {
+    const entry = pipCounts[code];
+    if (!entry) {
+      continue;
+    }
+    const armorGroup = ARMOR_PIP_GROUP[code];
+    if (armorGroup && entry.armor > 0) {
+      pips.push({
+        groupId: armorGroup,
+        count: entry.armor,
+        className: 'pip armor',
+      });
+    }
+    const structureGroup = STRUCTURE_PIP_GROUP[code];
+    if (structureGroup && entry.structure > 0) {
+      pips.push({
+        groupId: structureGroup,
+        count: entry.structure,
+        className: 'pip structure',
+      });
+    }
+  }
+
+  return { texts, pips, pipCounts };
+}

--- a/src/services/printing/svgRecordSheetRenderer/protomech/selectTemplate.ts
+++ b/src/services/printing/svgRecordSheetRenderer/protomech/selectTemplate.ts
@@ -1,0 +1,39 @@
+/**
+ * ProtoMech family — canonical template selection.
+ *
+ * Pure function mapping an `IProtoMechRecordSheetData` to a Wave-1
+ * `templateKey`, mirroring MegaMekLab `PrintProtoMek.getSVGFileName()`:
+ * a quad selects `protomek_quad`, a glider selects `protomek_glider`,
+ * everything else selects `protomek_biped`.
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Per-Family Record Sheet Adapters — protomech keys)
+ */
+
+import type { IProtoMechRecordSheetData } from '@/types/printing';
+
+/** The three Wave-1 ProtoMech template keys. */
+export type ProtoMechTemplateKey =
+  | 'protomek_biped'
+  | 'protomek_quad'
+  | 'protomek_glider';
+
+/**
+ * Select the canonical Wave-1 template key for a ProtoMech unit.
+ *
+ * Branches in `PrintProtoMek` priority order: `isQuad()` first, then
+ * `isGlider()`, then biped as the default. A quad-glider is not a
+ * valid ProtoMech configuration; quad takes precedence if both flags
+ * are somehow set.
+ */
+export function selectProtoMechTemplate(
+  data: IProtoMechRecordSheetData,
+): ProtoMechTemplateKey {
+  if (data.isQuad) {
+    return 'protomek_quad';
+  }
+  if (data.isGlider) {
+    return 'protomek_glider';
+  }
+  return 'protomek_biped';
+}

--- a/src/services/printing/svgRecordSheetRenderer/templateRecordSheetRenderer.ts
+++ b/src/services/printing/svgRecordSheetRenderer/templateRecordSheetRenderer.ts
@@ -10,16 +10,16 @@
  * families (vehicle / aerospace / protomech) both consume this core, so
  * the proven mech rendering substrate is shared rather than forked.
  *
- * It deliberately reuses `loadSVGTemplate` / `setTextContent` from
- * `template.ts` and `renderToCanvasHighDPI` from `canvas.ts` verbatim —
- * no fork of the proven mech logic.
+ * It deliberately reuses `loadSVGTemplate` from `template.ts` and
+ * `renderToCanvasHighDPI` from `canvas.ts` verbatim — no fork of the
+ * proven mech logic.
  *
  * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
  *   (Requirement: Shared Template Record Sheet Renderer)
  */
 
 import { renderToCanvasHighDPI } from './canvas';
-import { loadSVGTemplate, setTextContent } from './template';
+import { loadSVGTemplate } from './template';
 
 /**
  * A map of template element ID → text value to inject.
@@ -188,16 +188,42 @@ export class TemplateRecordSheetRenderer {
   }
 
   /**
+   * Resolve an element by ID within the template SVG.
+   *
+   * Searches the SVG ROOT subtree rather than the parsed document:
+   * `mount()` detaches the root from the parsed document and re-parents
+   * it under the off-screen container, after which
+   * `document.getElementById` would return `null`. Searching the root
+   * subtree works whether or not the renderer is currently mounted.
+   *
+   * `CSS.escape` guards IDs containing characters that are not bare
+   * CSS-selector-safe (defensive — canonical template IDs are simple).
+   */
+  private elementById(id: string): Element | null {
+    if (this.svgRoot && this.svgRoot.getAttribute('id') === id) {
+      return this.svgRoot;
+    }
+    const escaped =
+      typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+        ? CSS.escape(id)
+        : id.replace(/(["\\#.;:>~+*[\]()])/g, '\\$1');
+    return this.root.querySelector(`#${escaped}`);
+  }
+
+  /**
    * Inject text bindings into the template by element ID.
    *
-   * For each entry, the element is located via `getElementById` and its
-   * `textContent` is set. Elements absent from the template are silently
-   * skipped — a binding for a missing ID is a no-op, never an error.
+   * For each entry, the element is located within the SVG root subtree
+   * and its `textContent` is set. Elements absent from the template are
+   * silently skipped — a binding for a missing ID is a no-op, never an
+   * error.
    */
   applyBindings(texts: TextBindings): void {
-    const doc = this.document;
     for (const [id, value] of Object.entries(texts)) {
-      setTextContent(doc, id, value);
+      const element = this.elementById(id);
+      if (element) {
+        element.textContent = value;
+      }
     }
   }
 
@@ -214,24 +240,25 @@ export class TemplateRecordSheetRenderer {
    * applicator measures geometry via `getBBox()`.
    */
   applyPips(fills: readonly PipFill[], applicator: PipApplicator): void {
+    // `doc` is used only to create new pip elements (createElementNS),
+    // which works whether or not the root is currently mounted. Group
+    // resolution goes through `elementById`, which searches the root
+    // subtree and is therefore mount-safe.
     const doc = this.document;
     for (const fill of fills) {
       if (fill.count <= 0) {
         continue;
       }
-      const group = doc.getElementById(fill.groupId);
-      if (!group) {
-        // Unresolved group IDs are tolerated — the applicator's own
-        // grouped fallback may still resolve it; pass through so the
-        // applicator can decide. Here we only short-circuit when the
-        // primary element is genuinely absent AND has no grouped twin.
-        const grouped = doc.getElementById(`${fill.groupId}grouped`);
-        if (grouped) {
-          applicator(doc, grouped, fill);
-        }
+      const group = this.elementById(fill.groupId);
+      if (group) {
+        applicator(doc, group, fill);
         continue;
       }
-      applicator(doc, group, fill);
+      // Grouped-layout fallback — retry the `<id>grouped` element.
+      const grouped = this.elementById(`${fill.groupId}grouped`);
+      if (grouped) {
+        applicator(doc, grouped, fill);
+      }
     }
   }
 

--- a/src/services/printing/svgRecordSheetRenderer/vehicle/__tests__/vehicleAdapter.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/vehicle/__tests__/vehicleAdapter.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Vehicle / VTOL family adapter — unit tests.
+ *
+ * Covers `selectVehicleTemplate` (all 5 Wave-1 keys) and `bindVehicle`
+ * (`PipCounts` for a tracked tank and a VTOL).
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Per-Family Record Sheet Adapters)
+ */
+
+import type {
+  IRecordSheetHeader,
+  IVehicleRecordSheetData,
+} from '@/types/printing';
+
+import { bindVehicle, computeVehiclePipCounts } from '../bindings';
+import { selectVehicleTemplate } from '../selectTemplate';
+
+function header(
+  overrides: Partial<IRecordSheetHeader> = {},
+): IRecordSheetHeader {
+  return {
+    unitName: 'Manticore',
+    chassis: 'Manticore',
+    model: 'Heavy Tank',
+    tonnage: 50,
+    techBase: 'Inner Sphere',
+    rulesLevel: 'Standard',
+    era: 'Succession Wars',
+    role: 'Juggernaut',
+    battleValue: 1247,
+    cost: 1_000_000,
+    ...overrides,
+  };
+}
+
+function vehicle(
+  overrides: Partial<IVehicleRecordSheetData> = {},
+): IVehicleRecordSheetData {
+  return {
+    unitType: 'vehicle',
+    header: header(),
+    motionType: 'Tracked',
+    turretConfig: 'Single',
+    cruiseMP: 4,
+    flankMP: 6,
+    armorType: 'Standard',
+    armorLocations: [
+      { location: 'Front', current: 40, maximum: 40 },
+      { location: 'Left Side', current: 32, maximum: 32 },
+      { location: 'Right Side', current: 32, maximum: 32 },
+      { location: 'Rear', current: 24, maximum: 24 },
+      { location: 'Turret', current: 40, maximum: 40 },
+    ],
+    crew: [
+      { role: 'driver', gunnery: 4, piloting: 5 },
+      { role: 'gunner', gunnery: 3, piloting: 5 },
+    ],
+    equipment: [],
+    ...overrides,
+  };
+}
+
+describe('selectVehicleTemplate', () => {
+  it('maps a turret-equipped tracked tank to vehicle_turret_standard', () => {
+    expect(selectVehicleTemplate(vehicle({ turretConfig: 'Single' }))).toBe(
+      'vehicle_turret_standard',
+    );
+  });
+
+  it('maps a turretless tank to vehicle_noturret_standard', () => {
+    expect(selectVehicleTemplate(vehicle({ turretConfig: 'None' }))).toBe(
+      'vehicle_noturret_standard',
+    );
+  });
+
+  it('maps a dual-turret tank to vehicle_dualturret_standard', () => {
+    expect(selectVehicleTemplate(vehicle({ turretConfig: 'Dual' }))).toBe(
+      'vehicle_dualturret_standard',
+    );
+  });
+
+  it('maps a turretless VTOL to vtol_noturret_standard', () => {
+    expect(
+      selectVehicleTemplate(
+        vehicle({ motionType: 'VTOL', turretConfig: 'None' }),
+      ),
+    ).toBe('vtol_noturret_standard');
+  });
+
+  it('maps a turret VTOL to vtol_turret_standard', () => {
+    expect(
+      selectVehicleTemplate(
+        vehicle({ motionType: 'VTOL', turretConfig: 'Single' }),
+      ),
+    ).toBe('vtol_turret_standard');
+  });
+
+  it('collapses a dual-turret VTOL to vtol_turret_standard (no vtol_dualturret template)', () => {
+    expect(
+      selectVehicleTemplate(
+        vehicle({ motionType: 'VTOL', turretConfig: 'Dual' }),
+      ),
+    ).toBe('vtol_turret_standard');
+  });
+
+  it('treats Wheeled / Hover as the ground-vehicle subtype', () => {
+    expect(selectVehicleTemplate(vehicle({ motionType: 'Wheeled' }))).toBe(
+      'vehicle_turret_standard',
+    );
+    expect(selectVehicleTemplate(vehicle({ motionType: 'Hover' }))).toBe(
+      'vehicle_turret_standard',
+    );
+  });
+
+  it('rejects out-of-scope Naval / Submarine / WiGE motion types', () => {
+    expect(() =>
+      selectVehicleTemplate(vehicle({ motionType: 'Naval' })),
+    ).toThrow('not in Wave-1 scope');
+    expect(() =>
+      selectVehicleTemplate(vehicle({ motionType: 'Submarine' })),
+    ).toThrow('not in Wave-1 scope');
+    expect(() =>
+      selectVehicleTemplate(vehicle({ motionType: 'WiGE' })),
+    ).toThrow('not in Wave-1 scope');
+  });
+});
+
+describe('bindVehicle — PipCounts', () => {
+  it('computes per-location pip counts equal to the 50t tank armor stats', () => {
+    const counts = computeVehiclePipCounts(vehicle());
+    expect(counts).toEqual({ FR: 40, LS: 32, RS: 32, RR: 24, TU: 40 });
+  });
+
+  it('includes the Rotor location for a VTOL fixture', () => {
+    const vtol = vehicle({
+      motionType: 'VTOL',
+      turretConfig: 'None',
+      armorLocations: [
+        { location: 'Front', current: 18, maximum: 18 },
+        { location: 'Left Side', current: 14, maximum: 14 },
+        { location: 'Right Side', current: 14, maximum: 14 },
+        { location: 'Rear', current: 10, maximum: 10 },
+        { location: 'Rotor', current: 2, maximum: 2 },
+      ],
+    });
+    const counts = computeVehiclePipCounts(vtol);
+    expect(counts).toEqual({ FR: 18, LS: 14, RS: 14, RR: 10, RO: 2 });
+  });
+
+  it('splits dual-turret armor into TU and FT', () => {
+    const dual = vehicle({
+      turretConfig: 'Dual',
+      armorLocations: [
+        { location: 'Front', current: 40, maximum: 40 },
+        { location: 'Turret', current: 30, maximum: 30 },
+        { location: 'Turret', current: 20, maximum: 20 },
+      ],
+    });
+    const counts = computeVehiclePipCounts(dual);
+    expect(counts.TU).toBe(30);
+    expect(counts.FT).toBe(20);
+  });
+
+  it('binds text only to catalogued template IDs', () => {
+    const { texts } = bindVehicle(vehicle());
+    expect(texts.type).toBe('Manticore Heavy Tank');
+    expect(texts.tonnage).toBe('50');
+    expect(texts.movementType).toBe('Tracked');
+    expect(texts.textArmor_FR).toBe('40');
+    expect(texts.textArmor_TU).toBe('40');
+  });
+
+  it('emits one pip fill per armed location with the correct count', () => {
+    const { pips } = bindVehicle(vehicle());
+    const byGroup = Object.fromEntries(pips.map((p) => [p.groupId, p.count]));
+    expect(byGroup.armorPipsFR).toBe(40);
+    expect(byGroup.armorPipsLS).toBe(32);
+    expect(byGroup.armorPipsRS).toBe(32);
+    expect(byGroup.armorPipsRR).toBe(24);
+    expect(byGroup.armorPipsTU).toBe(40);
+  });
+
+  it('omits Body (no armor diagram region) from pip fills', () => {
+    const withBody = vehicle({
+      armorLocations: [
+        { location: 'Front', current: 40, maximum: 40 },
+        { location: 'Body', current: 0, maximum: 0 },
+      ],
+    });
+    const counts = computeVehiclePipCounts(withBody);
+    expect(counts).toEqual({ FR: 40 });
+  });
+});

--- a/src/services/printing/svgRecordSheetRenderer/vehicle/bindings.ts
+++ b/src/services/printing/svgRecordSheetRenderer/vehicle/bindings.ts
@@ -1,0 +1,176 @@
+/**
+ * Vehicle / VTOL family — template bindings.
+ *
+ * Pure function mapping an `IVehicleRecordSheetData` to the
+ * `{ texts, pips }` structure consumed by `TemplateRecordSheetRenderer`.
+ * Text targets are keyed against the Phase-0 `VEHICLE_TEMPLATE_IDS`
+ * catalog; pip groups carry a typed `PipCounts` contract computed
+ * directly from the unit's armor statistics.
+ *
+ * No I/O, no DOM, no asset access — a deterministic pure function.
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Per-Family Record Sheet Adapters)
+ */
+
+import type { IVehicleRecordSheetData } from '@/types/printing';
+
+import type { PipFill, TextBindings } from '../templateRecordSheetRenderer';
+
+import { VEHICLE_TEMPLATE_IDS } from '../templateElementIds';
+
+/**
+ * Per-location armor pip counts for a vehicle / VTOL.
+ *
+ * Keys are the canonical template location codes (FR / LS / RS / RR /
+ * TU / FT / RO). A value is present only when the unit actually has
+ * that location with non-zero armor.
+ */
+export interface VehiclePipCounts {
+  /** Front armor points. */
+  readonly FR?: number;
+  /** Left-side armor points. */
+  readonly LS?: number;
+  /** Right-side armor points. */
+  readonly RS?: number;
+  /** Rear armor points. */
+  readonly RR?: number;
+  /** Turret armor points (turret-equipped vehicles). */
+  readonly TU?: number;
+  /** Front-turret armor points (dual-turret vehicles). */
+  readonly FT?: number;
+  /** Rotor armor points (VTOLs). */
+  readonly RO?: number;
+}
+
+/** The result of binding a vehicle to its canonical template. */
+export interface VehicleBindings {
+  /** Text injections keyed by template element ID. */
+  readonly texts: TextBindings;
+  /** Pip-group fills keyed by template pip-group element ID. */
+  readonly pips: readonly PipFill[];
+  /** Typed per-location pip counts (the fidelity-gate contract). */
+  readonly pipCounts: VehiclePipCounts;
+}
+
+/**
+ * Map an `IVehicleLocationArmor.location` string to the canonical
+ * template location code. `Chin` armor renders in the turret block;
+ * `Body` has no armor diagram region (internal-only).
+ */
+const LOCATION_TO_CODE: Record<string, keyof VehiclePipCounts | null> = {
+  Front: 'FR',
+  'Left Side': 'LS',
+  'Right Side': 'RS',
+  Rear: 'RR',
+  Turret: 'TU',
+  Rotor: 'RO',
+  Chin: 'TU',
+  Body: null,
+};
+
+/** Template armor pip-group element ID per location code. */
+const ARMOR_PIP_GROUP: Record<keyof VehiclePipCounts, string> = {
+  FR: VEHICLE_TEMPLATE_IDS.armorPipsFR,
+  LS: VEHICLE_TEMPLATE_IDS.armorPipsLS,
+  RS: VEHICLE_TEMPLATE_IDS.armorPipsRS,
+  RR: VEHICLE_TEMPLATE_IDS.armorPipsRR,
+  TU: VEHICLE_TEMPLATE_IDS.armorPipsTU,
+  FT: VEHICLE_TEMPLATE_IDS.armorPipsFT,
+  RO: VEHICLE_TEMPLATE_IDS.armorPipsRO,
+};
+
+/** Template armor value-text element ID per location code. */
+const ARMOR_TEXT: Record<keyof VehiclePipCounts, string> = {
+  FR: VEHICLE_TEMPLATE_IDS.textArmor_FR,
+  LS: VEHICLE_TEMPLATE_IDS.textArmor_LS,
+  RS: VEHICLE_TEMPLATE_IDS.textArmor_RS,
+  RR: VEHICLE_TEMPLATE_IDS.textArmor_RR,
+  TU: VEHICLE_TEMPLATE_IDS.textArmor_TU,
+  FT: VEHICLE_TEMPLATE_IDS.textArmor_FT,
+  RO: VEHICLE_TEMPLATE_IDS.textArmor_RO,
+};
+
+/**
+ * Compute the per-location armor pip counts for a vehicle.
+ *
+ * Each entry's count equals the unit's `current` armor point value for
+ * that location — the fidelity gate asserts the rendered pip-element
+ * count matches this exactly.
+ */
+export function computeVehiclePipCounts(
+  data: IVehicleRecordSheetData,
+): VehiclePipCounts {
+  const counts: Record<string, number> = {};
+  for (const loc of data.armorLocations) {
+    const code = LOCATION_TO_CODE[loc.location];
+    if (code && loc.current > 0) {
+      // A second turret location maps to FT only when a dual turret is
+      // configured; otherwise both turret entries (if any) sum into TU.
+      counts[code] = (counts[code] ?? 0) + loc.current;
+    }
+  }
+  // Dual-turret units expose the front turret separately as FT.
+  if (data.turretConfig === 'Dual') {
+    const turrets = data.armorLocations.filter((l) => l.location === 'Turret');
+    if (turrets.length >= 2) {
+      counts.TU = turrets[0].current;
+      counts.FT = turrets[1].current;
+    }
+  }
+  return counts as VehiclePipCounts;
+}
+
+/**
+ * Bind a vehicle / VTOL unit to its canonical template.
+ *
+ * Produces header / movement / crew text injections and the per-arc
+ * armor pip fills. Only catalogued template IDs are referenced.
+ */
+export function bindVehicle(data: IVehicleRecordSheetData): VehicleBindings {
+  const { header } = data;
+  const pipCounts = computeVehiclePipCounts(data);
+
+  // --- Text bindings (catalogued IDs only) ---
+  const texts: Record<string, string> = {
+    [VEHICLE_TEMPLATE_IDS.type]: `${header.chassis} ${header.model}`,
+    [VEHICLE_TEMPLATE_IDS.tonnage]: String(header.tonnage),
+    [VEHICLE_TEMPLATE_IDS.techBase]: header.techBase,
+    [VEHICLE_TEMPLATE_IDS.rulesLevel]: header.rulesLevel,
+    [VEHICLE_TEMPLATE_IDS.role]: header.role ?? '',
+    [VEHICLE_TEMPLATE_IDS.bv]: header.battleValue.toLocaleString(),
+    [VEHICLE_TEMPLATE_IDS.armorType]: data.armorType,
+    [VEHICLE_TEMPLATE_IDS.movementType]: data.motionType,
+    [VEHICLE_TEMPLATE_IDS.mpWalk]: String(data.cruiseMP),
+    [VEHICLE_TEMPLATE_IDS.mpRun]: String(data.flankMP),
+  };
+
+  // Crew skills — bind the first driver/gunner found.
+  const gunner = data.crew.find((c) => c.role === 'gunner') ?? data.crew[0];
+  const driver = data.crew.find((c) => c.role === 'driver') ?? data.crew[0];
+  if (gunner) {
+    texts[VEHICLE_TEMPLATE_IDS.gunnerySkill0] = String(gunner.gunnery);
+  }
+  if (driver) {
+    texts[VEHICLE_TEMPLATE_IDS.pilotingSkill0] = String(driver.piloting);
+  }
+
+  // Armor value-text labels per location.
+  for (const [code, count] of Object.entries(pipCounts)) {
+    const textId = ARMOR_TEXT[code as keyof VehiclePipCounts];
+    if (textId) {
+      texts[textId] = String(count);
+    }
+  }
+
+  // --- Pip fills — one per armed location ---
+  const pips: PipFill[] = [];
+  for (const [code, count] of Object.entries(pipCounts)) {
+    const groupId = ARMOR_PIP_GROUP[code as keyof VehiclePipCounts];
+    if (groupId && count > 0) {
+      pips.push({ groupId, count, className: 'pip armor' });
+    }
+  }
+
+  return { texts, pips, pipCounts };
+}

--- a/src/services/printing/svgRecordSheetRenderer/vehicle/selectTemplate.ts
+++ b/src/services/printing/svgRecordSheetRenderer/vehicle/selectTemplate.ts
@@ -1,0 +1,101 @@
+/**
+ * Vehicle / VTOL family — canonical template selection.
+ *
+ * Pure function mapping an `IVehicleRecordSheetData` to a Wave-1
+ * `templateKey`, mirroring MegaMekLab `PrintTank.getSVGFileName()`:
+ * the key has the form `{subtype}_{turret}_{weight}`.
+ *
+ * Wave-1 scope: only the `vehicle` and `vtol` subtypes at the
+ * `standard` weight tier. Naval / submarine / WiGE / superheavy are
+ * out of scope and rejected with a clear error so a mis-routed unit
+ * fails loudly rather than rendering the wrong sheet.
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Per-Family Record Sheet Adapters — vehicle/VTOL keys)
+ */
+
+import type { IVehicleRecordSheetData } from '@/types/printing';
+
+/** The five Wave-1 vehicle / VTOL template keys. */
+export type VehicleTemplateKey =
+  | 'vehicle_noturret_standard'
+  | 'vehicle_turret_standard'
+  | 'vehicle_dualturret_standard'
+  | 'vtol_noturret_standard'
+  | 'vtol_turret_standard';
+
+/**
+ * Map a vehicle's motion type to the template subtype segment.
+ * Wave-1 supports `vehicle` (ground) and `vtol` only.
+ */
+function subtypeFor(data: IVehicleRecordSheetData): 'vehicle' | 'vtol' {
+  if (data.motionType === 'VTOL') {
+    return 'vtol';
+  }
+  // Tracked / Wheeled / Hover all render on the ground-vehicle template.
+  // Naval / Submarine / WiGE / Rail are out of Wave-1 scope.
+  if (
+    data.motionType === 'Naval' ||
+    data.motionType === 'Submarine' ||
+    data.motionType === 'WiGE' ||
+    data.motionType === 'Rail'
+  ) {
+    throw new Error(
+      `Vehicle motion type "${data.motionType}" is not in Wave-1 scope ` +
+        `(only Tracked / Wheeled / Hover / VTOL are templated).`,
+    );
+  }
+  return 'vehicle';
+}
+
+/**
+ * Map a vehicle's turret configuration to the template turret segment,
+ * following `PrintTank`: no turret → `noturret`; a single turret →
+ * `turret`; a dual turret → `dualturret`.
+ *
+ * `Front` / `Rear` / `Sponson` configs are treated as single-turret
+ * for record-sheet layout (they render in the `turret` template's
+ * turret block) — `PrintTank` likewise collapses them via
+ * `hasNoDualTurret()`.
+ */
+function turretFor(
+  data: IVehicleRecordSheetData,
+): 'noturret' | 'turret' | 'dualturret' {
+  switch (data.turretConfig) {
+    case 'None':
+      return 'noturret';
+    case 'Dual':
+      return 'dualturret';
+    case 'Single':
+    case 'Front':
+    case 'Rear':
+    case 'Sponson':
+      return 'turret';
+    default:
+      return 'noturret';
+  }
+}
+
+/**
+ * Select the canonical Wave-1 template key for a vehicle / VTOL unit.
+ *
+ * VTOLs always use the `noturret` or `turret` key — there is no
+ * `vtol_dualturret` template; a dual-turret VTOL (rare) collapses to
+ * the single-turret VTOL sheet.
+ *
+ * @throws when the unit's motion type is outside Wave-1 scope.
+ */
+export function selectVehicleTemplate(
+  data: IVehicleRecordSheetData,
+): VehicleTemplateKey {
+  const subtype = subtypeFor(data);
+  let turret = turretFor(data);
+
+  // No `vtol_dualturret_standard` template exists — collapse to turret.
+  if (subtype === 'vtol' && turret === 'dualturret') {
+    turret = 'turret';
+  }
+
+  // Weight tier is always `standard` for Wave-1 (superheavy excluded).
+  return `${subtype}_${turret}_standard` as VehicleTemplateKey;
+}

--- a/src/types/printing/RecordSheetVariantTypes.ts
+++ b/src/types/printing/RecordSheetVariantTypes.ts
@@ -81,6 +81,13 @@ export interface IAerospaceArcArmor {
 export interface IAerospaceRecordSheetData {
   readonly unitType: 'aerospace';
   readonly header: IRecordSheetHeader;
+  /**
+   * True for conventional fighters, false (or omitted) for aerospace
+   * fighters. Mirrors MegaMekLab `PrintAero` branching on
+   * `aero instanceof ConvFighter` — drives canonical-template
+   * selection (`fighter_conventional` vs `fighter_aerospace`).
+   */
+  readonly isConventional?: boolean;
   /** Structural Integrity — the aerospace equivalent of internal structure. */
   readonly structuralIntegrity: number;
   readonly fuelPoints: number;
@@ -229,6 +236,12 @@ export interface IProtoMechRecordSheetData {
   readonly mainGunAmmo?: number;
   readonly hasUMU: boolean;
   readonly isGlider: boolean;
+  /**
+   * True for quad ProtoMechs (no arm locations). Mirrors MegaMekLab
+   * `PrintProtoMek` branching on `proto.isQuad()` — drives
+   * canonical-template selection (`protomek_quad`). Defaults false.
+   */
+  readonly isQuad?: boolean;
   readonly walkMP: number;
   readonly jumpMP: number;
   readonly equipment: readonly IRecordSheetEquipment[];


### PR DESCRIPTION
## Summary

Phases 3, 4 and 5 of the OpenSpec change `add-templated-vehicle-aero-proto-record-sheets` — the three Wave-1 per-family adapter folders.

- **vehicle/** — `selectTemplate` returns `{subtype}_{turret}_{weight}` (mirrors `PrintTank.getSVGFileName`); `bindings` produces a typed `VehiclePipCounts` for FR/LS/RS/RR/TU/FT/RO (VTOL Rotor included, dual-turret split into TU+FT).
- **aerospace/** — `selectTemplate` returns `fighter_aerospace` / `fighter_conventional` (mirrors `PrintAero`); `bindings` produces `AerospacePipCounts` for the 4 arcs NOS/LWG/RWG/AFT plus Structural Integrity.
- **protomech/** — `selectTemplate` returns `protomek_biped`/`quad`/`glider` (mirrors `PrintProtoMek`); `bindings` produces `ProtoMechPipCounts` with armor from the unit + internal structure derived from the canonical Total Warfare ProtoMech IS table by tonnage. Arm locations omitted for quads.

All six adapter modules are deterministic pure functions — no I/O, no DOM — binding only against the Phase-0 `templateElementIds` catalog.

**Type additions**: `isConventional?` on `IAerospaceRecordSheetData` and `isQuad?` on `IProtoMechRecordSheetData` — keeps `selectTemplate` a pure function of the record-sheet data, mirroring the MegaMekLab `instanceof ConvFighter` / `isQuad()` structural checks.

**Pip-count fidelity gate** (the hard gate): `pipCountFidelity.test.ts` renders each family through `TemplateRecordSheetRenderer` + the shared pip engine, parses the output SVG, and asserts the rendered `<circle>` count per location equals the fixture's armor/structure stats. A negative-control case proves a wrong fixture fails.

**Shared-core bug fix**: `mount()` detaches the SVG root from the parsed document, so `applyBindings`/`applyPips` now resolve elements within the root subtree (mount-safe) instead of `document.getElementById`. The mech path (never mounts) is unaffected.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx oxlint` + `npx oxfmt --check` clean on changed files
- [x] 55 new tests (3 adapters + fidelity gate, incl. negative control)
- [x] Mech regression: 232 record-sheet tests incl. 5 snapshots — zero diff
- [x] Pre-commit build hook passed

Depends on #580 (Phases 1-2, merged).