### PR TITLE
feat(record-sheet): template-primary dispatch with skeleton fallback

### DIFF
--- a/src/services/printing/RecordSheetService.ts
+++ b/src/services/printing/RecordSheetService.ts
@@ -51,6 +51,10 @@ import { IUnitConfig } from './recordsheet/types';
 import { SVGRecordSheetRenderer } from './svgRecordSheetRenderer';
 import { renderToCanvasHighDPI } from './svgRecordSheetRenderer/canvas';
 import { renderRecordSheetSVG } from './svgRecordSheetRenderer/renderer';
+import {
+  isTemplatedUnit,
+  renderTemplated,
+} from './svgRecordSheetRenderer/renderTemplated';
 
 export type { IUnitConfig };
 
@@ -209,7 +213,7 @@ export class RecordSheetService {
       await this.renderMechPreview(canvas, data, paperSize);
       return;
     }
-    const svgString = this.buildNonMechSVG(data);
+    const svgString = await this.buildNonMechSVG(data, paperSize);
     await renderSVGStringToCanvas(svgString, canvas, 1);
   }
 
@@ -226,7 +230,7 @@ export class RecordSheetService {
     if (data.unitType === 'mech') {
       return this.getMechSVGString(data, paperSize);
     }
-    return this.buildNonMechSVG(data);
+    return this.buildNonMechSVG(data, paperSize);
   }
 
   /**
@@ -257,7 +261,7 @@ export class RecordSheetService {
     canvas.width = scaledWidth;
     canvas.height = scaledHeight;
 
-    const svgString = this.buildNonMechSVG(data);
+    const svgString = await this.buildNonMechSVG(data, paperSize);
     await renderSVGStringToCanvas(svgString, canvas, PDF_DPI_MULTIPLIER);
 
     const PDF = await getJsPDFConstructor();
@@ -364,11 +368,21 @@ export class RecordSheetService {
   }
 
   /**
-   * Build an SVG string for any non-mech unit type by calling the matching
-   * per-type renderer. Throws `UnsupportedUnitTypeError` for the 'mech' case
-   * (callers should use the mech pipeline) and unknown types.
+   * Build an SVG string for any non-mech unit type.
+   *
+   * Wave-1 families (vehicle / aerospace / protomech) render through
+   * the canonical mm-data template path (`renderTemplated`), which
+   * falls back to the family skeleton renderer on any failure.
+   * Battle-armor and infantry use the skeleton renderer directly via
+   * `renderRecordSheetSVG`.
    */
-  private buildNonMechSVG(data: INonMechRecordSheetData): string {
+  private async buildNonMechSVG(
+    data: INonMechRecordSheetData,
+    paperSize: PaperSize,
+  ): Promise<string> {
+    if (isTemplatedUnit(data)) {
+      return renderTemplated(data, paperSize);
+    }
     return renderRecordSheetSVG(data);
   }
 

--- a/src/services/printing/svgRecordSheetRenderer/__tests__/renderTemplated.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/__tests__/renderTemplated.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Template-Primary Dispatch — unit + integration tests.
+ *
+ * Covers `renderTemplated` routing the three Wave-1 families through
+ * the canonical template path, the `try/catch` skeleton fallback on
+ * asset-load failure, and the `isTemplatedUnit` dispatch predicate.
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Template-Primary Rendering With Skeleton Fallback)
+ */
+
+import type {
+  IAerospaceRecordSheetData,
+  IProtoMechRecordSheetData,
+  IRecordSheetHeader,
+  IVehicleRecordSheetData,
+} from '@/types/printing';
+
+import { PaperSize } from '@/types/printing';
+
+import { isTemplatedUnit, renderTemplated } from '../renderTemplated';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+/** A minimal canonical-shaped template exposing the given pip groups. */
+function buildTemplate(groupIds: readonly string[]): string {
+  const groups = groupIds
+    .map(
+      (id) => `<g id="${id}"><rect x="0" y="0" width="200" height="120"/></g>`,
+    )
+    .join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="576" height="756" viewBox="0 0 576 756">
+  <text id="type"></text>
+  <text id="tonnage"></text>
+  <text id="bv"></text>
+  ${groups}
+</svg>`;
+}
+
+/** Mock a successful template fetch returning `svg`. */
+function mockTemplateOk(svg: string) {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    text: () => Promise.resolve(svg),
+    headers: new Headers({ 'content-type': 'image/svg+xml' }),
+  });
+}
+
+/** Mock a hard asset failure — every source returns 404. */
+function mockTemplateFail() {
+  mockFetch.mockResolvedValue({ ok: false, status: 404 });
+}
+
+function header(tonnage: number): IRecordSheetHeader {
+  return {
+    unitName: 'Fixture',
+    chassis: 'Fixture',
+    model: 'FX-1',
+    tonnage,
+    techBase: 'Inner Sphere',
+    rulesLevel: 'Standard',
+    era: 'Test',
+    role: 'Striker',
+    battleValue: 1000,
+    cost: 1_000_000,
+  };
+}
+
+const VEHICLE_FIXTURE: IVehicleRecordSheetData = {
+  unitType: 'vehicle',
+  header: header(50),
+  motionType: 'Tracked',
+  turretConfig: 'Single',
+  cruiseMP: 4,
+  flankMP: 6,
+  armorType: 'Standard',
+  armorLocations: [
+    { location: 'Front', current: 40, maximum: 40 },
+    { location: 'Turret', current: 36, maximum: 36 },
+  ],
+  crew: [{ role: 'gunner', gunnery: 3, piloting: 5 }],
+  equipment: [],
+};
+
+const AEROSPACE_FIXTURE: IAerospaceRecordSheetData = {
+  unitType: 'aerospace',
+  header: header(65),
+  structuralIntegrity: 8,
+  fuelPoints: 400,
+  safeThrust: 5,
+  maxThrust: 8,
+  heatSinks: {
+    type: 'Single',
+    count: 16,
+    capacity: 16,
+    integrated: 10,
+    external: 6,
+  },
+  armorType: 'Standard Aerospace',
+  armorArcs: [
+    { arc: 'Nose', current: 70, maximum: 70 },
+    { arc: 'Aft', current: 50, maximum: 50 },
+  ],
+  equipment: [],
+  bombBaySlots: 0,
+};
+
+const PROTOMECH_FIXTURE: IProtoMechRecordSheetData = {
+  unitType: 'protomech',
+  header: header(9),
+  pointSize: 5,
+  protos: [
+    {
+      index: 1,
+      armorByLocation: {
+        Head: { current: 2, maximum: 2 },
+        Torso: { current: 14, maximum: 14 },
+        'Left Arm': { current: 4, maximum: 4 },
+        'Right Arm': { current: 4, maximum: 4 },
+        Legs: { current: 8, maximum: 8 },
+        'Main Gun': { current: 0, maximum: 0 },
+      },
+    },
+  ],
+  hasUMU: false,
+  isGlider: false,
+  walkMP: 4,
+  jumpMP: 0,
+  equipment: [],
+};
+
+describe('isTemplatedUnit', () => {
+  it('identifies the three Wave-1 families', () => {
+    expect(isTemplatedUnit({ unitType: 'vehicle' })).toBe(true);
+    expect(isTemplatedUnit({ unitType: 'aerospace' })).toBe(true);
+    expect(isTemplatedUnit({ unitType: 'protomech' })).toBe(true);
+  });
+
+  it('rejects the non-Wave-1 families', () => {
+    expect(isTemplatedUnit({ unitType: 'battlearmor' })).toBe(false);
+    expect(isTemplatedUnit({ unitType: 'infantry' })).toBe(false);
+    expect(isTemplatedUnit({ unitType: 'mech' })).toBe(false);
+  });
+});
+
+describe('renderTemplated — template path', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    document.body.innerHTML = '';
+  });
+
+  it('renders a vehicle through the canonical template path', async () => {
+    mockTemplateOk(buildTemplate(['armorPipsFR', 'armorPipsTU']));
+    const svg = await renderTemplated(VEHICLE_FIXTURE, PaperSize.LETTER);
+
+    expect(svg).toContain('<svg');
+    // The output is derived from the canonical template — the template's
+    // pip groups are present and populated with pips.
+    const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+    expect(
+      doc.getElementById('armorPipsFR')?.querySelectorAll('circle').length,
+    ).toBe(40);
+    expect(doc.getElementById('type')?.textContent).toBe('Fixture FX-1');
+  });
+
+  it('renders an aerospace fighter through the canonical template path', async () => {
+    mockTemplateOk(buildTemplate(['armorPipsNOS', 'armorPipsAFT']));
+    const svg = await renderTemplated(AEROSPACE_FIXTURE, PaperSize.LETTER);
+
+    const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+    expect(
+      doc.getElementById('armorPipsNOS')?.querySelectorAll('circle').length,
+    ).toBe(70);
+  });
+
+  it('renders a ProtoMech through the canonical template path', async () => {
+    mockTemplateOk(
+      buildTemplate(['armorPipsHD', 'armorPipsT', 'structurePipsT']),
+    );
+    const svg = await renderTemplated(PROTOMECH_FIXTURE, PaperSize.LETTER);
+
+    const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+    expect(
+      doc.getElementById('armorPipsT')?.querySelectorAll('circle').length,
+    ).toBe(14);
+  });
+
+  it('resolves the A4 template directory for ISO paper size', async () => {
+    mockTemplateOk(buildTemplate(['armorPipsFR']));
+    await renderTemplated(VEHICLE_FIXTURE, PaperSize.A4);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/record-sheets/templates_iso/vehicle_turret_standard.svg',
+    );
+  });
+
+  it('appends the _default suffix for aerospace template filenames', async () => {
+    mockTemplateOk(buildTemplate(['armorPipsNOS']));
+    await renderTemplated(AEROSPACE_FIXTURE, PaperSize.LETTER);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/record-sheets/templates_us/fighter_aerospace_default.svg',
+    );
+  });
+});
+
+describe('renderTemplated — skeleton fallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    document.body.innerHTML = '';
+  });
+
+  it('falls back to the vehicle skeleton renderer on asset-load failure', async () => {
+    mockTemplateFail();
+    const svg = await renderTemplated(VEHICLE_FIXTURE, PaperSize.LETTER);
+
+    // The skeleton renderer emits its own marker text — not blank.
+    expect(svg).toContain('<svg');
+    expect(svg).toContain('Vehicle Record Sheet');
+    expect(svg).not.toBe('');
+  });
+
+  it('falls back to the aerospace skeleton renderer on asset-load failure', async () => {
+    mockTemplateFail();
+    const svg = await renderTemplated(AEROSPACE_FIXTURE, PaperSize.LETTER);
+
+    expect(svg).toContain('<svg');
+    expect(svg).not.toBe('');
+  });
+
+  it('falls back to the protomech skeleton renderer on asset-load failure', async () => {
+    mockTemplateFail();
+    const svg = await renderTemplated(PROTOMECH_FIXTURE, PaperSize.LETTER);
+
+    expect(svg).toContain('<svg');
+    expect(svg).not.toBe('');
+  });
+
+  it('falls back when the template parses but is malformed (not an SVG root)', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve('<!doctype html><html><body>404</body></html>'),
+      headers: new Headers({ 'content-type': 'text/html' }),
+    });
+    const svg = await renderTemplated(VEHICLE_FIXTURE, PaperSize.LETTER);
+
+    // HTML-instead-of-SVG triggers the load guard → skeleton fallback.
+    expect(svg).toContain('Vehicle Record Sheet');
+  });
+});

--- a/src/services/printing/svgRecordSheetRenderer/renderTemplated.ts
+++ b/src/services/printing/svgRecordSheetRenderer/renderTemplated.ts
@@ -1,0 +1,216 @@
+/**
+ * Template-Primary Rendering With Skeleton Fallback.
+ *
+ * The `renderTemplated` entry point renders a Wave-1 non-mech unit
+ * (vehicle / aerospace / protomech) through the canonical mm-data
+ * template path: select template → load via `MmDataAssetService` →
+ * mount → apply text bindings → lay out pips → serialize.
+ *
+ * The whole template path is wrapped in `try/catch`. On any failure —
+ * asset-load failure, template-parse failure, a missing pip group —
+ * it falls back to the family's existing skeleton renderer and returns
+ * that SVG, so a degraded environment never yields a blank PDF.
+ *
+ * Battle-armor and infantry are NOT Wave-1 families: they are routed
+ * to their skeleton renderers by `renderRecordSheetSVG` in
+ * `renderer.ts`, never through this module. Keeping them out of here
+ * avoids an import cycle (`renderer.ts` imports this module).
+ *
+ * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Template-Primary Rendering With Skeleton Fallback)
+ */
+
+import type {
+  IAerospaceRecordSheetData,
+  IProtoMechRecordSheetData,
+  IVehicleRecordSheetData,
+} from '@/types/printing';
+
+import { PaperSize } from '@/types/printing';
+import { logger } from '@/utils/logger';
+
+import { bindAerospace } from './aerospace/bindings';
+import { selectAerospaceTemplate } from './aerospace/selectTemplate';
+import { renderAerospaceSVG } from './aerospaceRenderer';
+import { layoutPipsInGroup } from './pipEngine';
+import { bindProtoMech } from './protomech/bindings';
+import { selectProtoMechTemplate } from './protomech/selectTemplate';
+import { renderProtoMechSVG } from './protoMechRenderer';
+import {
+  TemplateRecordSheetRenderer,
+  type PipFill,
+  type TextBindings,
+} from './templateRecordSheetRenderer';
+import { bindVehicle } from './vehicle/bindings';
+import { selectVehicleTemplate } from './vehicle/selectTemplate';
+import { renderVehicleSVG } from './vehicleRenderer';
+
+/** The Wave-1 non-mech unit types handled by the templated path. */
+export type TemplatedUnitData =
+  | IVehicleRecordSheetData
+  | IAerospaceRecordSheetData
+  | IProtoMechRecordSheetData;
+
+/** Paper-size directory segment for the asset path. */
+function paperDir(paperSize: PaperSize): 'templates_us' | 'templates_iso' {
+  return paperSize === PaperSize.A4 ? 'templates_iso' : 'templates_us';
+}
+
+/**
+ * Resolve a family `templateKey` to its registered SVG filename.
+ *
+ * Vehicle and ProtoMech keys match their filenames directly; aerospace
+ * keys carry no `_default` suffix (the key is a clean semantic id)
+ * while the registered files do — so the suffix is appended here.
+ */
+function templateFilename(templateKey: string): string {
+  if (templateKey.startsWith('fighter_')) {
+    return `${templateKey}_default.svg`;
+  }
+  return `${templateKey}.svg`;
+}
+
+/** Build the full `/record-sheets/<dir>/<file>` asset path. */
+function templatePath(templateKey: string, paperSize: PaperSize): string {
+  return `/record-sheets/${paperDir(paperSize)}/${templateFilename(templateKey)}`;
+}
+
+/**
+ * The pip applicator handed to `TemplateRecordSheetRenderer.applyPips`:
+ * lays out one `PipFill` against its resolved group via the shared
+ * pip engine.
+ */
+function applyPipFill(doc: Document, group: Element, fill: PipFill): void {
+  layoutPipsInGroup(doc, group, fill.count, {
+    className: fill.className,
+    clustered: fill.grouped,
+  });
+}
+
+/**
+ * Render one unit through the canonical template path.
+ *
+ * Shared across the three families — only the template key, the text
+ * bindings, and the pip fills differ per family.
+ */
+async function renderViaTemplate(
+  templateKey: string,
+  paperSize: PaperSize,
+  bindings: { texts: TextBindings; pips: readonly PipFill[] },
+): Promise<string> {
+  const renderer = new TemplateRecordSheetRenderer();
+  await renderer.loadTemplate(templatePath(templateKey, paperSize));
+  // Mount off-screen so geometry / web-font measurement is valid, then
+  // gate text measurement on font readiness before binding.
+  renderer.mount();
+  await renderer.awaitFontsReady();
+  renderer.applyBindings(bindings.texts);
+  renderer.applyPips(bindings.pips, applyPipFill);
+  // getSVGString() unmounts the off-screen container as a side effect.
+  return renderer.getSVGString();
+}
+
+/**
+ * Render a vehicle unit, template-primary with skeleton fallback.
+ */
+export async function renderVehicleTemplated(
+  data: IVehicleRecordSheetData,
+  paperSize: PaperSize = PaperSize.LETTER,
+): Promise<string> {
+  try {
+    const key = selectVehicleTemplate(data);
+    return await renderViaTemplate(key, paperSize, bindVehicle(data));
+  } catch (error) {
+    logger.warn(
+      'Templated vehicle render failed — falling back to skeleton renderer',
+      { error },
+    );
+    return renderVehicleSVG(data);
+  }
+}
+
+/**
+ * Render an aerospace / conventional-fighter unit, template-primary
+ * with skeleton fallback.
+ */
+export async function renderAerospaceTemplated(
+  data: IAerospaceRecordSheetData,
+  paperSize: PaperSize = PaperSize.LETTER,
+): Promise<string> {
+  try {
+    const key = selectAerospaceTemplate(data);
+    return await renderViaTemplate(key, paperSize, bindAerospace(data));
+  } catch (error) {
+    logger.warn(
+      'Templated aerospace render failed — falling back to skeleton renderer',
+      { error },
+    );
+    return renderAerospaceSVG(data);
+  }
+}
+
+/**
+ * Render a ProtoMech unit, template-primary with skeleton fallback.
+ */
+export async function renderProtoMechTemplated(
+  data: IProtoMechRecordSheetData,
+  paperSize: PaperSize = PaperSize.LETTER,
+): Promise<string> {
+  try {
+    const key = selectProtoMechTemplate(data);
+    return await renderViaTemplate(key, paperSize, bindProtoMech(data));
+  } catch (error) {
+    logger.warn(
+      'Templated protomech render failed — falling back to skeleton renderer',
+      { error },
+    );
+    return renderProtoMechSVG(data);
+  }
+}
+
+/**
+ * Render a Wave-1 non-mech unit (vehicle / aerospace / protomech)
+ * through the canonical template path, with per-family skeleton
+ * fallback on any failure.
+ *
+ * Battle-armor and infantry units must NOT be passed here — they are
+ * not Wave-1 families and are routed to their skeleton renderers by
+ * `renderRecordSheetSVG`.
+ */
+export async function renderTemplated(
+  data: TemplatedUnitData,
+  paperSize: PaperSize = PaperSize.LETTER,
+): Promise<string> {
+  switch (data.unitType) {
+    case 'vehicle':
+      return renderVehicleTemplated(data, paperSize);
+    case 'aerospace':
+      return renderAerospaceTemplated(data, paperSize);
+    case 'protomech':
+      return renderProtoMechTemplated(data, paperSize);
+    default:
+      return assertNeverTemplatedVariant(data);
+  }
+}
+
+/**
+ * Whether a non-mech record-sheet payload is a Wave-1 templated family
+ * (vehicle / aerospace / protomech). The dispatch layer uses this to
+ * choose `renderTemplated` over the skeleton-only `renderRecordSheetSVG`.
+ *
+ * Narrows the payload to `TemplatedUnitData` so callers can hand it
+ * straight to `renderTemplated` without a cast.
+ */
+export function isTemplatedUnit(data: {
+  unitType: string;
+}): data is TemplatedUnitData {
+  return (
+    data.unitType === 'vehicle' ||
+    data.unitType === 'aerospace' ||
+    data.unitType === 'protomech'
+  );
+}
+
+function assertNeverTemplatedVariant(data: never): never {
+  throw new Error(`Unhandled templated unit type: ${String(data)}`);
+}


### PR DESCRIPTION
## Summary

Phase 6 of the OpenSpec change `add-templated-vehicle-aero-proto-record-sheets` — the dispatch layer that routes Wave-1 non-mech units through the canonical template path with a skeleton-renderer safety net.

- **`renderTemplated`** (new module) routes vehicle / aerospace / protomech units through the canonical mm-data template path: select template → load via `MmDataAssetService` → mount off-screen → `awaitFontsReady` → apply bindings → lay out pips via the shared engine → serialize.
- Each family render is wrapped in `try/catch`; on **any** failure (asset-load, template-parse, malformed SVG) it falls back to the family skeleton renderer and returns that SVG — the degraded-but-never-blank guarantee. Skeleton renderers are unchanged and undeleted.
- `templateKey → filename` resolution: vehicle/protomech keys map directly; aerospace keys gain the `_default` suffix the registered files carry. Paper size selects `templates_us` / `templates_iso`.
- **Dispatch wiring**: `RecordSheetService.buildNonMechSVG` is now async + paper-size aware — Wave-1 families go through `renderTemplated`, battle-armor / infantry stay on the sync skeleton `renderRecordSheetSVG`. All three callers updated.

Task 6.4 (manual customizer Save PDF QA) is verified in the Final Verification Wave (F3).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx oxlint` + `npx oxfmt --check` clean on changed files
- [x] 16 new dispatch tests (template path per family, skeleton fallback on asset failure, A4 path resolution, `isTemplatedUnit` predicate)
- [x] Full regression: 250 record-sheet tests incl. 5 mech snapshots — zero diff
- [x] Pre-commit build hook passed

Depends on #581 (Phases 3-5, merged).