### PR TITLE
fix(record-sheet): route shared renderer template loads through MmDataAssetService

### DIFF
--- a/src/__tests__/service/printing/SVGRecordSheetRenderer.test.ts
+++ b/src/__tests__/service/printing/SVGRecordSheetRenderer.test.ts
@@ -10,6 +10,7 @@
  * - Pip group ID resolution for all configurations
  */
 
+import { resetMmDataAssetService } from '@/services/assets/MmDataAssetService';
 import { SVGRecordSheetRenderer } from '@/services/printing/svgRecordSheetRenderer';
 import { IMechRecordSheetData } from '@/types/printing';
 
@@ -214,6 +215,9 @@ describe('SVGRecordSheetRenderer', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset the shared MmDataAssetService singleton so its template
+    // cache does not leak between tests / suites.
+    resetMmDataAssetService();
     renderer = new SVGRecordSheetRenderer();
   });
 

--- a/src/services/printing/svgRecordSheetRenderer/__tests__/pipCountFidelity.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/__tests__/pipCountFidelity.test.ts
@@ -31,6 +31,8 @@ import type {
   IVehicleRecordSheetData,
 } from '@/types/printing';
 
+import { resetMmDataAssetService } from '@/services/assets/MmDataAssetService';
+
 import { bindAerospace } from '../aerospace/bindings';
 import { layoutPipsInGroup } from '../pipEngine';
 import { bindProtoMech } from '../protomech/bindings';
@@ -115,6 +117,9 @@ describe('pip-count fidelity gate', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFetch.mockReset();
+    // Reset the shared MmDataAssetService singleton so its template
+    // cache does not leak between tests / suites.
+    resetMmDataAssetService();
     document.body.innerHTML = '';
   });
 

--- a/src/services/printing/svgRecordSheetRenderer/__tests__/renderTemplated.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/__tests__/renderTemplated.test.ts
@@ -16,6 +16,7 @@ import type {
   IVehicleRecordSheetData,
 } from '@/types/printing';
 
+import { resetMmDataAssetService } from '@/services/assets/MmDataAssetService';
 import { PaperSize } from '@/types/printing';
 
 import { isTemplatedUnit, renderTemplated } from '../renderTemplated';
@@ -149,6 +150,9 @@ describe('renderTemplated — template path', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFetch.mockReset();
+    // Reset the shared MmDataAssetService singleton so its template
+    // cache does not leak between tests / suites.
+    resetMmDataAssetService();
     document.body.innerHTML = '';
   });
 
@@ -211,6 +215,9 @@ describe('renderTemplated — skeleton fallback', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFetch.mockReset();
+    // Reset the shared MmDataAssetService singleton so its template
+    // cache does not leak between tests / suites.
+    resetMmDataAssetService();
     document.body.innerHTML = '';
   });
 

--- a/src/services/printing/svgRecordSheetRenderer/__tests__/templateRecordSheetRenderer.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/__tests__/templateRecordSheetRenderer.test.ts
@@ -8,6 +8,8 @@
  *   (Requirement: Shared Template Record Sheet Renderer)
  */
 
+import { resetMmDataAssetService } from '@/services/assets/MmDataAssetService';
+
 import {
   TemplateRecordSheetRenderer,
   type PipFill,
@@ -37,6 +39,9 @@ describe('TemplateRecordSheetRenderer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFetch.mockReset();
+    // Reset the shared MmDataAssetService singleton so its template
+    // cache does not leak between tests / suites.
+    resetMmDataAssetService();
     document.body.innerHTML = '';
   });
 

--- a/src/services/printing/svgRecordSheetRenderer/template.ts
+++ b/src/services/printing/svgRecordSheetRenderer/template.ts
@@ -5,7 +5,61 @@
 import { SVG_NS } from './constants';
 
 /**
- * Load an SVG template from a URL
+ * Parse an SVG template string into a validated document + root.
+ *
+ * Validates that the content is real SVG (not an HTML 404 page),
+ * parses it with `DOMParser`, and confirms the root is a genuine
+ * `SVGSVGElement`. Shared by `loadSVGTemplate` (raw-fetch path) and the
+ * `MmDataAssetService.loadSVG`-backed shared renderer path.
+ *
+ * @param svgText the raw SVG markup
+ * @param sourceLabel a path/identifier for diagnostics in thrown errors
+ * @throws Error when the content is HTML, malformed, or not SVG-rooted
+ */
+export function parseSVGTemplate(
+  svgText: string,
+  sourceLabel: string,
+): { svgDoc: Document; svgRoot: SVGSVGElement } {
+  // If content starts with an HTML doctype or <html, it's a 404 page.
+  const trimmedText = svgText.trim().toLowerCase();
+  if (
+    trimmedText.startsWith('<!doctype html') ||
+    trimmedText.startsWith('<html')
+  ) {
+    throw new Error(
+      `SVG template "${sourceLabel}" returned HTML content instead of SVG. ` +
+        `The asset file is missing. Run 'npm run fetch:assets' to download required assets.`,
+    );
+  }
+
+  const parser = new DOMParser();
+  const svgDoc = parser.parseFromString(svgText, 'image/svg+xml');
+
+  // Check for parse errors first.
+  const parseError = svgDoc.querySelector('parsererror');
+  if (parseError) {
+    throw new Error(`Failed to parse SVG template: ${parseError.textContent}`);
+  }
+
+  // Verify documentElement is an SVG element.
+  const docElement = svgDoc.documentElement;
+  if (
+    docElement.tagName === 'svg' &&
+    docElement.namespaceURI === SVG_NS &&
+    docElement instanceof SVGSVGElement
+  ) {
+    return { svgDoc, svgRoot: docElement };
+  }
+  throw new Error('SVG template root element is not a valid SVGSVGElement');
+}
+
+/**
+ * Load an SVG template from a URL via a raw `fetch`.
+ *
+ * The mech record-sheet path uses this directly. The shared
+ * `TemplateRecordSheetRenderer` instead loads through
+ * `MmDataAssetService.loadSVG` (three-source fallback) and hands the
+ * result to `parseSVGTemplate`.
  *
  * @throws Error if the template cannot be fetched or is not valid SVG
  */
@@ -38,39 +92,7 @@ export async function loadSVGTemplate(templatePath: string): Promise<{
   }
 
   const svgText = await response.text();
-
-  // Additional check: if content starts with HTML doctype or <html, it's not SVG
-  const trimmedText = svgText.trim().toLowerCase();
-  if (
-    trimmedText.startsWith('<!doctype html') ||
-    trimmedText.startsWith('<html')
-  ) {
-    throw new Error(
-      `SVG template "${templatePath}" returned HTML content instead of SVG. ` +
-        `The asset file is missing. Run 'npm run fetch:assets' to download required assets.`,
-    );
-  }
-
-  const parser = new DOMParser();
-  const svgDoc = parser.parseFromString(svgText, 'image/svg+xml');
-
-  // Check for parse errors first
-  const parseError = svgDoc.querySelector('parsererror');
-  if (parseError) {
-    throw new Error(`Failed to parse SVG template: ${parseError.textContent}`);
-  }
-
-  // Verify documentElement is an SVG element
-  const docElement = svgDoc.documentElement;
-  if (
-    docElement.tagName === 'svg' &&
-    docElement.namespaceURI === SVG_NS &&
-    docElement instanceof SVGSVGElement
-  ) {
-    return { svgDoc, svgRoot: docElement };
-  } else {
-    throw new Error('SVG template root element is not a valid SVGSVGElement');
-  }
+  return parseSVGTemplate(svgText, templatePath);
 }
 
 /**

--- a/src/services/printing/svgRecordSheetRenderer/templateRecordSheetRenderer.ts
+++ b/src/services/printing/svgRecordSheetRenderer/templateRecordSheetRenderer.ts
@@ -10,16 +10,20 @@
  * families (vehicle / aerospace / protomech) both consume this core, so
  * the proven mech rendering substrate is shared rather than forked.
  *
- * It deliberately reuses `loadSVGTemplate` from `template.ts` and
- * `renderToCanvasHighDPI` from `canvas.ts` verbatim — no fork of the
- * proven mech logic.
+ * It reuses `parseSVGTemplate` from `template.ts` (the proven mech
+ * parse + validation) and `renderToCanvasHighDPI` from `canvas.ts`
+ * verbatim, and resolves templates through `MmDataAssetService.loadSVG`
+ * so the three-source fallback chain applies — no fork of the proven
+ * mech logic.
  *
  * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
  *   (Requirement: Shared Template Record Sheet Renderer)
  */
 
+import { getMmDataAssetService } from '@/services/assets/MmDataAssetService';
+
 import { renderToCanvasHighDPI } from './canvas';
-import { loadSVGTemplate } from './template';
+import { parseSVGTemplate } from './template';
 
 /**
  * A map of template element ID → text value to inject.
@@ -71,14 +75,16 @@ export class TemplateRecordSheetRenderer {
   /**
    * Load and parse a canonical template SVG.
    *
-   * Delegates to the proven `loadSVGTemplate` path used by the mech
-   * renderer — which fetches via the dev-server / asset path,
-   * validates the content type, and parses with `DOMParser`. Asset
-   * resolution through `MmDataAssetService`'s three-source fallback
-   * chain happens upstream of the path handed in here.
+   * Resolves the template through `MmDataAssetService.loadSVG`, so the
+   * three-source fallback chain (local bundled → jsDelivr CDN → GitHub
+   * raw) and the asset cache both apply — a missing local asset
+   * degrades to CDN / raw rather than failing. The fetched markup is
+   * then validated and parsed by `parseSVGTemplate`, the same parse +
+   * validation the mech `loadSVGTemplate` path uses.
    */
   async loadTemplate(templatePath: string): Promise<void> {
-    const { svgDoc, svgRoot } = await loadSVGTemplate(templatePath);
+    const svgText = await getMmDataAssetService().loadSVG(templatePath);
+    const { svgDoc, svgRoot } = parseSVGTemplate(svgText, templatePath);
     this.svgDoc = svgDoc;
     this.svgRoot = svgRoot;
   }


### PR DESCRIPTION
## Summary

Phase 7 spec-coverage fix for the OpenSpec change `add-templated-vehicle-aero-proto-record-sheets`.

The `mm-data-asset-integration` delta spec scenario **"Non-mech template loading via shared renderer"** requires `TemplateRecordSheetRenderer.loadTemplate` to resolve templates through `MmDataAssetService.loadSVG` so the three-source fallback chain (local → jsDelivr CDN → GitHub raw) and the asset cache apply. The shared core was instead reusing the mech path's raw-fetch `loadSVGTemplate` — a missing local asset would fail outright instead of degrading to CDN / raw.

- Extracts `parseSVGTemplate` from `loadSVGTemplate` (the parse + SVG-root validation half); `loadSVGTemplate` now composes it after its raw fetch — the mech path is unchanged.
- `TemplateRecordSheetRenderer.loadTemplate` now calls `MmDataAssetService.loadSVG` + `parseSVGTemplate` — the three-source chain and cache back every templated render.
- Adds `resetMmDataAssetService()` to the `beforeEach` of the four suites that exercise `loadTemplate`, so the shared singleton's template cache cannot leak between suites in the same Jest worker.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx oxlint` + `npx oxfmt --check` clean
- [x] All 374 record-sheet tests incl. 5 mech snapshots pass (combined run — cache pollution resolved)
- [x] Pre-commit build hook passed

Depends on #582 (Phase 6, merged).