### PR TITLE
chore(openspec): sync templated-record-sheets deltas to source-of-truth

### DIFF
--- a/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/design.md
+++ b/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/design.md
@@ -1,0 +1,336 @@
+# Design: Add Templated Vehicle / Aerospace / ProtoMech Record Sheets
+
+## Technical Approach
+
+The mech record sheet already works correctly. The strategy is to
+**extract** the proven mech rendering core into shared, type-agnostic
+modules, then write thin per-family adapters that feed those modules.
+No new rendering technology is introduced — jsPDF, `DOMParser`,
+`getElementById` ID-injection, and dynamic pip layout are all already
+in production for the mech path.
+
+The decomposition has three layers:
+
+```
+                 renderer.ts  (dispatch + renderTemplated)
+                        |
+        ┌───────────────┼────────────────┐
+        |               |                |
+  selectTemplate.ts  bindings.ts   TemplateRecordSheetRenderer
+   (per family)      (per family)   + shared pip engine  (shared)
+                                            |
+                                     MmDataAssetService
+                                     (3-source fallback)
+```
+
+- **Shared core** (`TemplateRecordSheetRenderer`, shared pip engine) —
+  unit-type-agnostic. Owns asset loading, DOM parsing, text injection,
+  pip layout, canvas rasterization, jsPDF.
+- **Per-family adapters** (`vehicle/`, `aerospace/`, `protomech/`) —
+  two pure functions each. Know their family's templates and data
+  shape; know nothing about DOM or I/O.
+- **Dispatch** (`renderer.ts`) — picks family, runs the template path,
+  falls back to skeleton on failure.
+
+## Architecture Decisions
+
+### Decision: Extract a shared `TemplateRecordSheetRenderer` rather than fork per family
+
+**Choice**: Promote the mech renderer's template-handling core into a
+shared `TemplateRecordSheetRenderer` consumed by both the mech path and
+the three new families.
+
+**Rationale**: The mech path's `loadSVGTemplate` / `setTextContent` /
+canvas / jsPDF code is proven in production. Forking it per family
+would create four divergent copies of the highest-risk code. A single
+shared core means the mech snapshot tests guard every family's
+rendering substrate.
+
+**Alternatives considered**: (a) Copy the mech renderer per family —
+rejected, multiplies the proven code and its bugs by four. (b) Keep the
+skeleton string-builders and improve them — rejected, they cannot
+reach canonical-layout fidelity without re-implementing template
+injection, which is the shared core anyway.
+
+### Decision: Per-family adapters are pure functions, no I/O
+
+**Choice**: `selectTemplate.ts` and `bindings.ts` are deterministic
+pure functions — no fetch, no DOM, no asset access.
+
+**Rationale**: Purity makes the fidelity gate cheap: `bindings.ts` can
+be unit-tested by asserting the `PipCounts` contract directly, with no
+browser or network. It also localizes all I/O risk in the shared core,
+where it is already handled.
+
+**Alternatives considered**: Let adapters call `MmDataAssetService`
+directly — rejected, scatters I/O and makes adapters un-unit-testable
+without mocking the asset service.
+
+### Decision: Vehicle template key mirrors `PrintTank.getSVGFileName()`
+
+**Choice**: Vehicle `templateKey` is `{subtype}_{turret}_{weight}`,
+e.g. `vehicle_turret_standard`, `vtol_noturret_standard`.
+
+**Rationale**: MegaMekLab `PrintTank.java` already encodes the correct
+mapping from a unit's structural attributes to a template filename.
+Mirroring it means the key generation is verifiable against a
+canonical Java reference rather than invented.
+
+**Alternatives considered**: A bespoke key scheme — rejected, would
+diverge from mm-data's filename convention and require its own
+correctness argument.
+
+### Decision: Template-primary with skeleton fallback (not skeleton deletion)
+
+**Choice**: `renderTemplated` wraps the template path in `try/catch`;
+on failure it returns the existing skeleton renderer's output. The
+skeleton renderers stay in the tree.
+
+**Rationale**: The three-source asset chain can still fail entirely
+(offline, CDN + GitHub both unreachable). A hard failure must not
+produce a blank PDF. The skeleton renderer is a known-good degraded
+output. Deleting the skeletons now would remove the safety net before
+pip-parity is proven in production; a later cleanup change removes them
+once verified.
+
+**Alternatives considered**: Delete skeletons immediately — rejected,
+removes the offline story and the fallback before it is proven
+unnecessary. Render a blank/error sheet on failure — rejected, worse
+UX than the skeleton.
+
+### Decision: Phase-0 element-ID extraction before any renderer code
+
+**Choice**: tasks.md Phase 0 registers assets and extracts each
+template's `id=` set into a frozen typed const, reviewed against the
+MegaMekLab `Print*` field names, before any rendering code is written.
+
+**Rationale**: The non-mech templates do **not** share the mech
+`ELEMENT_IDS`. Header IDs (`type`, `tonnage`, `bv`, ...) are shared,
+but location-specific armor pip IDs differ per family. Authoring
+`bindings.ts` against guessed IDs would produce silent no-op
+injections. Extracting the real ID set first turns an ID typo into a
+type error.
+
+## Data Flow
+
+1. **Customizer Save PDF** — `PreviewTab.handleExportPDF` →
+   `RecordSheetService.exportPDF`.
+2. **Extract** — `RecordSheetService` routes `extractData(unit)` to the
+   type-specific extractor, producing the matching `IRecordSheetData`
+   variant.
+3. **Dispatch** — `renderer.ts` `renderRecordSheetSVG` inspects
+   `data.unitType`. For vehicle / aerospace / protomech it enters
+   `renderTemplated`; for mech it uses the (refactored) mech consumer;
+   for infantry / battlearmor it uses the skeleton renderer.
+4. **Select template** — the family `selectTemplate(unit)` returns a
+   `templateKey`; the renderer joins it with the paper-size directory
+   (`templates_us` / `templates_iso`) into an asset path.
+5. **Load** — `TemplateRecordSheetRenderer.loadTemplate(path)` →
+   `MmDataAssetService.loadSVG` → three-source fallback → `DOMParser`
+   document.
+6. **Mount off-screen** — the renderer mounts the parsed SVG into an
+   off-screen DOM node so `getBBox()` works (see Browser Hazards).
+7. **Bind** — the family `bindings(data)` produces `{ texts, pips }`;
+   `applyBindings(texts)` injects text by element ID; `applyPips` /
+   the pip engine lays out pip elements from measured region geometry.
+8. **Rasterize** — `getSVGString()` → canvas at high DPI → JPEG →
+   jsPDF, exactly as the mech path does.
+9. **On any failure in 4–8** — `renderTemplated`'s `try/catch` invokes
+   the family skeleton renderer and returns its SVG.
+
+## Browser Hazards and Mitigations
+
+### `getBBox()` requires a live-mounted SVG
+
+The shared pip engine measures template region `<rect>` geometry with
+`getBBox()`, which returns zeroed bounds for an element not attached to
+a rendered document. **Mitigation**: the renderer MUST mount the parsed
+SVG into an off-screen DOM container (e.g. an absolutely-positioned,
+visibility-hidden node, or a node off-viewport) **before** the pip
+engine runs, and remove it after `getSVGString()`. A pip-engine task
+asserts this ordering; the spec records the live-DOM requirement
+explicitly.
+
+### Web-font load race on text auto-shrink
+
+If any binding field auto-shrinks to fit (measuring text width to pick
+a font size), measuring before the record-sheet web font has loaded
+yields wrong widths and inconsistent shrink. **Mitigation**: await
+`document.fonts.ready` (already a concern on the mech path) before
+text-width measurement; the shared core centralizes this so all
+families inherit the fix.
+
+### jsPDF + svg2pdf path fidelity
+
+Complex SVG paths can rasterize imperfectly through the canvas → JPEG
+→ jsPDF chain. **Accepted risk** — the mech path already lives with
+this and produces acceptable output. No new mitigation; the templated
+non-mech path inherits the same known-good behavior.
+
+### Per-family element IDs differ from mech `ELEMENT_IDS`
+
+Non-mech templates share header IDs but diverge on location-specific
+pip IDs. **Mitigation**: the Phase-0 element-ID catalog (frozen typed
+const, reviewed against `PrintTank` / `PrintAero` / `PrintProtoMek`)
+makes `bindings.ts` bind only against real IDs, catching typos at
+type-check time.
+
+## Fidelity Gate
+
+The hidden hard requirement is **pip-count accuracy**: a record sheet
+that draws the wrong number of armor pips is wrong even if it looks
+canonical. Each family adapter therefore ships a test that:
+
+1. Renders a fixture with known per-location armor / structure values.
+2. Parses the output SVG.
+3. Counts pip elements (`<circle>` / the template's pip element) per
+   location.
+4. Asserts each count equals the fixture's actual stat for that
+   location.
+
+This is the acceptance criterion that distinguishes "looks right" from
+"is right" and is the gate before the future skeleton-deletion change.
+
+## File Changes
+
+- **New**: `src/services/printing/svgRecordSheetRenderer/templateRecordSheetRenderer.ts`
+  — shared `TemplateRecordSheetRenderer` (loadTemplate / applyBindings /
+  applyPips / getSVGString).
+- **New**: a shared pip-engine module in
+  `src/services/printing/svgRecordSheetRenderer/` — region-geometry pip
+  layout with the `grouped` fallback and alternate-clustering flag,
+  generalized from `armor.ts`.
+- **New**: `src/services/printing/svgRecordSheetRenderer/vehicle/{selectTemplate.ts,bindings.ts}`.
+- **New**: `src/services/printing/svgRecordSheetRenderer/aerospace/{selectTemplate.ts,bindings.ts}`.
+- **New**: `src/services/printing/svgRecordSheetRenderer/protomech/{selectTemplate.ts,bindings.ts}`.
+- **New**: a frozen typed element-ID catalog const (one section per
+  Wave-1 family).
+- **New**: Jest tests — shared-core tests, per-family adapter tests,
+  per-family pip-count fidelity tests, with committed fixtures.
+- **Modified**: `src/services/printing/svgRecordSheetRenderer/renderer.ts`
+  — `renderRecordSheetSVG` dispatch gains the `renderTemplated`
+  template-primary / skeleton-fallback path for vehicle / aerospace /
+  protomech.
+- **Modified**: `src/services/printing/svgRecordSheetRenderer/renderer.ts`
+  (mech) / `SVGRecordSheetRenderer` — refactored into a thin consumer
+  of `TemplateRecordSheetRenderer`, no behavior change.
+- **Modified**: `config/mm-data-assets.json` — Wave-1 non-mech template
+  entries added under `templates_us` and `templates_iso`.
+- **Modified**: `src/services/assets/MmDataAssetService.ts` — resolves
+  the new non-mech template paths (may need only config-driven path
+  handling if the service is already pattern-generic).
+- **Modified**: the asset-sync script — copies the registered Wave-1
+  non-mech templates into `public/record-sheets/templates_us` /
+  `templates_iso`.
+- **Not modified, not deleted**: `vehicleRenderer.ts`,
+  `aerospaceRenderer.ts`, `protoMechRenderer.ts` (kept as fallback);
+  `battleArmorRenderer.ts`, `infantryRenderer.ts` (out of scope,
+  Wave 2).
+
+## Decisions discovered during execution
+
+These decisions emerged while implementing the change and were each
+referenced by two or more tasks; per the notepad graduation rule they
+are promoted here so the permanent design record reflects the as-built
+reality. The planned Architecture Decisions above remain unchanged.
+
+### Decision: mount() moves the SVG root; unmount() restores it
+
+**Choice**: `TemplateRecordSheetRenderer.mount()` moves the parsed SVG
+root out of its `DOMParser` document and into an off-screen `<div>`
+container; `unmount()` moves it back. `getSVGString()` always
+unmounts before serializing, and `applyBindings` / `applyPips` resolve
+element IDs by querying the SVG root subtree (mount-safe) rather than
+`document.getElementById`.
+
+**Rationale**: `DOMParser` documents are not attached to the page, so
+`getBBox()` returns zeroed bounds for their elements. Mounting the
+root into the live page makes geometry and web-font measurement work.
+But once the root is moved into the container, `document.getElementById`
+returns `null` and serializing the document yields an empty string —
+so binding must query the root subtree, and `getSVGString` must restore
+the root (via `unmount`) before serializing the document. The mech
+path never mounts and is unaffected; its 5 snapshots confirm zero
+behaviour change.
+
+**Discovered during**: Tasks 1.2, 1.4, 1.5, 3.3, 4.3, 5.3 (the
+fidelity gates render through the mounted path and surfaced the
+empty-output bug), 6.1.
+
+### Decision: the shared pip engine wraps ArmorPipLayout rather than rewriting it
+
+**Choice**: the shared pip engine (`pipEngine.ts`) is a thin wrapper
+over the existing `ArmorPipLayout` class — `layoutPips` /
+`layoutPipsInGroup` delegate to `ArmorPipLayout.addPips`, adding only
+the `grouped` element-lookup fallback (`resolvePipGroup`) and the
+`groupByFive` → `clustered` flag rename. `ArmorPipLayout` is not
+modified.
+
+**Rationale**: `ArmorPipLayout` is the proven MegaMekLab-derived
+region-geometry layout already in production for non-biped mechs. The
+dynamic pip *logic* the design speaks of promoting already lives there;
+`armor.ts` only held the group-ID resolution and the per-location loop.
+Wrapping rather than rewriting keeps the mech path's pip output
+byte-identical (verified: 5 snapshots zero-diff) and keeps the engine
+small.
+
+**Discovered during**: Tasks 2.1, 2.4, 3.3, 4.3, 5.3.
+
+### Decision: discriminator fields added to the aerospace and protomech record-sheet types
+
+**Choice**: `isConventional?: boolean` was added to
+`IAerospaceRecordSheetData` and `isQuad?: boolean` to
+`IProtoMechRecordSheetData` (both optional, default false).
+
+**Rationale**: the per-family `selectTemplate` adapters are pure
+functions of the `IRecordSheetData` variant. But the aerospace variant
+carried no aerospace-vs-conventional-fighter signal and the protomech
+variant had `isGlider` but no `isQuad` — so the pure adapter could not
+choose `fighter_conventional` vs `fighter_aerospace` or
+`protomek_quad` vs `protomek_biped` without a heuristic. MegaMekLab
+`PrintAero` / `PrintProtoMek` branch on `aero instanceof ConvFighter`
+and `proto.isQuad()` — structural facts of the unit. Surfacing them as
+explicit boolean fields keeps `selectTemplate` pure and verifiable,
+mirroring the Java reference exactly; `isGlider` already set this
+precedent.
+
+**Discovered during**: Tasks 4.1, 4.2, 5.1, 5.2.
+
+### Decision: templateKey → filename mapping lives in the dispatch layer
+
+**Choice**: `selectTemplate` adapters return a semantic `templateKey`
+(e.g. `fighter_aerospace`); the dispatch layer (`renderTemplated`)
+owns the key → filename → asset-path resolution, including the
+`_default` suffix for aerospace filenames and the `templates_us` /
+`templates_iso` paper-size directory.
+
+**Rationale**: vehicle and protomech keys equal their registered
+filenames, but the aerospace keys (`fighter_aerospace` /
+`fighter_conventional`) deliberately omit the `_default` suffix the
+registered files carry — the key stays a clean semantic identifier and
+the filename artifact is resolved in one place. The dispatch layer is
+the single component that knows about paper sizes and file extensions.
+
+**Discovered during**: Tasks 4.1, 6.1.
+
+### Decision: the shared renderer loads templates through MmDataAssetService
+
+**Choice**: `TemplateRecordSheetRenderer.loadTemplate` resolves
+templates through `MmDataAssetService.loadSVG` (three-source fallback +
+cache), then parses with the extracted `parseSVGTemplate` helper —
+rather than the mech path's raw-`fetch` `loadSVGTemplate`.
+
+**Rationale**: the `mm-data-asset-integration` delta requires non-mech
+template loading to go through `MmDataAssetService` so the local → CDN
+→ GitHub-raw fallback chain applies. The mech path's raw `fetch` is a
+pre-existing limitation that should not propagate to the new shared
+core; routing through `loadSVG` is strictly better (offline / CDN
+resilience) and is what the spec mandates. `loadSVGTemplate` was
+refactored to compose the same `parseSVGTemplate` helper, so the mech
+path is unchanged.
+
+**Discovered during**: Task F5 spec-coverage verification; the fix
+shipped as a Phase-7 follow-up. Referenced by the
+`mm-data-asset-integration` MODIFIED `MmData Asset Service` requirement
+and the `record-sheet-export` Shared Template Record Sheet Renderer
+requirement.

--- a/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/notepad/decisions.md
+++ b/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/notepad/decisions.md
@@ -1,0 +1,36 @@
+# Decisions — add-templated-vehicle-aero-proto-record-sheets
+
+(Architecture decided by OMO Council, recorded in design.md. This file
+captures decisions discovered DURING execution. Decisions referenced by
+2+ tasks graduate into design.md before archive.)
+
+## [2026-05-15] Decision: mount() moves the SVG root; unmount() restores it
+**Choice**: `TemplateRecordSheetRenderer.mount()` moves the parsed SVG root OUT of its `DOMParser` document and into an off-screen `<div>` container; `unmount()` moves it back into the document. `getSVGString()` always calls `unmount()` before serializing.
+**Rationale**: `DOMParser`-created documents are not attached to the page, so `getBBox()` returns zeroed bounds for their elements. Mounting the root into the live page makes geometry + web-font measurement work. But serializing the *document* while the root is detached from it returns an empty string — so unmount must restore the root, and serialization must happen post-unmount. Serializing the document (not the root) keeps the output byte-identical to the pre-refactor mech path.
+**Discovered during**: Tasks 1.2 (mount helper), 1.4 (mech refactor — found the empty-string bug), 1.5 (shared-core tests). Will be referenced again by Phase 6 (`renderTemplated` mount/serialize ordering).
+**Referenced by tasks**: 1.2, 1.4, 1.5, 6.1 — GRADUATES to design.md.
+
+## [2026-05-15] Decision: pip engine wraps ArmorPipLayout, not a rewrite
+**Choice**: the shared pip engine (`pipEngine.ts`) is a thin wrapper over the existing `ArmorPipLayout` class — `layoutPips`/`layoutPipsInGroup` delegate to `ArmorPipLayout.addPips`, adding only the `grouped` element-lookup fallback (`resolvePipGroup`) and surfacing the `groupByFive`→`clustered` flag rename. `ArmorPipLayout` itself is NOT modified.
+**Rationale**: `ArmorPipLayout` is the proven MegaMekLab-derived region-geometry layout already in production for non-biped mechs. The design.md says "promote the dynamic pip-layout logic from `armor.ts`" — but the *logic* already lives in `ArmorPipLayout`; `armor.ts` only had the group-ID resolution + the per-location loop. Wrapping rather than rewriting keeps the mech path's pip output byte-identical (verified: 5 snapshots zero-diff) and the engine stays a few dozen lines.
+**Discovered during**: Tasks 2.1 (promote pip logic), 2.4 (confirm mech consumes engine).
+**Referenced by tasks**: 2.1, 2.4, 3.3, 4.3, 5.3 (fidelity gates all rely on the engine) — GRADUATES to design.md.
+
+## [2026-05-15] Decision: add discriminator fields to aero/proto record-sheet types
+**Choice**: add `isConventional?: boolean` to `IAerospaceRecordSheetData` and `isQuad?: boolean` to `IProtoMechRecordSheetData`. Both default-false (optional).
+**Rationale**: `selectTemplate` is a PURE function of the record-sheet data variant (design.md "adapters are pure functions, no I/O"). But `IAerospaceRecordSheetData` had no aerospace-vs-conventional-fighter signal, and `IProtoMechRecordSheetData` had `isGlider` but no `isQuad` — so the pure adapter could not pick `fighter_conventional` vs `fighter_aerospace` or `protomek_quad` vs `protomek_biped` without a heuristic. MegaMekLab `PrintAero`/`PrintProtoMek` `getSVGFileName()` branch on `aero instanceof ConvFighter` / `proto.isQuad()` — structural facts of the unit. Surfacing them as explicit boolean fields on the record-sheet data (set by the extractors) keeps `selectTemplate` pure and verifiable, mirroring the Java reference exactly. `isGlider` already set this precedent on the proto type.
+**Alternatives rejected**: (a) heuristic on tonnage/thrust — fragile, not canonical. (b) `selectTemplate` taking the raw construction unit — breaks the pure-`IRecordSheetData`→key contract.
+**Discovered during**: Tasks 4.1 (aero selectTemplate), 5.1 (proto selectTemplate).
+**Referenced by tasks**: 4.1, 4.2, 5.1, 5.2 — GRADUATES to design.md.
+
+## [2026-05-15] Decision: mount-safe element resolution via root-subtree query
+**Choice**: `TemplateRecordSheetRenderer.applyBindings` / `applyPips` resolve template element IDs by querying the SVG ROOT subtree (`svgRoot.querySelector('#'+CSS.escape(id))`), not via `document.getElementById`.
+**Rationale**: `mount()` re-parents the SVG root out of its `DOMParser` document and into the off-screen container — after which `document.getElementById` returns `null` for every template element. The design data flow has mount (step 6) BEFORE bind (step 7), so binding always runs on a detached-from-document root. Querying the root subtree is correct whether mounted or not. The fidelity gate caught this — pips rendered 0 until the fix. The mech path never mounts, so it never hit the bug; the 5 mech snapshots confirm zero behaviour change.
+**Discovered during**: Tasks 3.3/4.3/5.3 (fidelity tests render through the mounted path and surfaced the empty-output bug).
+**Referenced by tasks**: 3.3, 4.3, 5.3, 6.1 (renderTemplated relies on mounted-path binding working) — GRADUATES to design.md.
+
+## [2026-05-15] Decision: templateKey → filename mapping lives in renderTemplated
+**Choice**: `selectTemplate` adapters return a `templateKey` (e.g. `fighter_aerospace`); `renderTemplated` (Phase 6) owns the key→filename→asset-path mapping.
+**Rationale**: the vehicle and protomech keys are identical to their registered filenames, but the aerospace keys (`fighter_aerospace` / `fighter_conventional`) differ from the registered files (`fighter_aerospace_default.svg` / `fighter_conventional_default.svg`). Keeping the `_default` suffix out of the key keeps the key a clean semantic identifier; the suffix is a mm-data filename artifact. The dispatch layer is the single place that knows about paper-size directories and file extensions, so it is the right place to resolve the full asset path.
+**Discovered during**: Tasks 4.1 (aero key), 6.1 (renderTemplated path building).
+**Referenced by tasks**: 4.1, 6.1 — GRADUATES to design.md.

--- a/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/notepad/issues.md
+++ b/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/notepad/issues.md
@@ -1,0 +1,3 @@
+# Issues — add-templated-vehicle-aero-proto-record-sheets
+
+(Problems hit during execution and how they were solved.)

--- a/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/notepad/learnings.md
+++ b/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/notepad/learnings.md
@@ -1,0 +1,126 @@
+# Learnings — add-templated-vehicle-aero-proto-record-sheets
+
+## [2026-05-15] Orchestration setup
+**Convention**: Repo uses `npm`, NOT `bun`. tasks.md QA hints say `bun run typecheck` / `bun test` — translate to the real commands:
+- `npm run lint` (oxlint)
+- `npx oxfmt --check`
+- `npx tsc --noEmit`
+- `npm test` (jest + @swc/jest)
+- `npm run storybook:build`
+
+**Renderer layout**: `src/services/printing/svgRecordSheetRenderer/` contains `renderer.ts` (dispatch + `SVGRecordSheetRenderer` mech class), `template.ts` (`loadSVGTemplate`/`setTextContent`/`addDocumentMargins`/etc), `armor.ts` + `structure.ts` (pip layout), `canvas.ts` (`renderToCanvasHighDPI`), `constants.ts` (`ELEMENT_IDS`), and 5 skeleton renderers (`vehicleRenderer.ts`, `aerospaceRenderer.ts`, `battleArmorRenderer.ts`, `infantryRenderer.ts`, `protoMechRenderer.ts`).
+
+**Dispatch shape**: `renderRecordSheetSVG(data: INonMechRecordSheetData)` switches on `data.unitType` ('vehicle'|'aerospace'|'battlearmor'|'infantry'|'protomech'). Mech path is the `SVGRecordSheetRenderer` class (separate, used by `RecordSheetService`).
+
+**Config shape**: `config/mm-data-assets.json` has `patterns.templates_us` and `patterns.templates_iso` as flat string arrays. Mech entries are `mek_*` filenames. Phase 0.1 appends 10 non-mech filenames to BOTH lists.
+
+**Asset service**: `src/services/assets/MmDataAssetService.ts` — three-source fallback (local → jsDelivr CDN → GitHub raw).
+
+## [2026-05-15] Phase 0 complete (PR #579)
+**Asset-sync script**: `npm run fetch:assets` → `scripts/mm-data/fetch-assets.ts`. Reads `config/mm-data-assets.json` `patterns`, expands `{a,b}`/`{1-N}` patterns, downloads from CDN (or `--prefer-local` from `../mm-data` relative to cwd). 544 assets total after Wave-1 registration.
+
+**`public/record-sheets/` is gitignored** — synced templates are NOT committed; CI/runtime fetches them. Only `config/mm-data-assets.json` registration is committed. `mm-data-version.json` also gets touched by the sync — `git checkout` it back, it's not part of the change.
+
+**Element-ID catalog**: NEW file `src/services/printing/svgRecordSheetRenderer/templateElementIds.ts`. Exports `SHARED_TEMPLATE_IDS` (header IDs shared by all), `VEHICLE_TEMPLATE_IDS`, `AEROSPACE_TEMPLATE_IDS`, `PROTOMECH_TEMPLATE_IDS` as `as const` + matching `*TemplateId` union types. Per-family `bindings.ts` MUST import + bind only against these.
+
+**MegaMekLab canonical ID source**: `E:/Projects/megameklab/megameklab/src/megameklab/printing/IdConstants.java` — the single source of element-ID constants consumed by `PrintTank`/`PrintAero`/`PrintProtoMek`. `getSVGFileName()` in each `Print*` class encodes the template-key mapping.
+
+**Vehicle template key (PrintTank.getSVGFileName)**: `{subtype}_{turret}_{weight}.svg`. subtype = vehicle|vtol|naval|submarine|wige (Wave-1: only vehicle + vtol). turret = noturret (hasNoTurret) | turret (hasNoDualTurret) | dualturret. weight = `standard` always for Wave-1 (superheavy excluded; note VTOLs are ALWAYS `standard` even if superheavy).
+
+**Aero template key (PrintAero.getSVGFileName)**: `ConvFighter` → `fighter_conventional_default.svg`; else → `fighter_aerospace_default.svg`. NOTE the actual filenames carry a `_default` suffix — `selectTemplate` returns the key, the renderer appends paper-size dir. tasks.md says key is `fighter_aerospace`/`fighter_conventional` — confirm whether the renderer adds `_default.svg` or the key includes it. The registered FILE names are `fighter_aerospace_default.svg` / `fighter_conventional_default.svg`.
+
+**Proto template key (PrintProtoMek.getSVGFileName)**: `isQuad()` → `protomek_quad.svg`; `isGlider()` → `protomek_glider.svg`; else → `protomek_biped.svg`.
+
+**Vehicle template location codes**: FR=Front, LS=Left Side, RS=Right Side, RR=Rear, TU=Turret, FT=Front Turret (dualturret only), RO=Rotor (VTOL only). Pip groups: `armorPips{FR,LS,RS,RR,TU,FT,RO}`, `structurePips{...}`. Text labels: `textArmor_{FR,LS,RS,RR,TU,FT,RO}`.
+
+**Aero arc codes**: NOS=Nose, LWG=Left Wing, RWG=Right Wing, AFT=Aft. Pip groups `armorPips{NOS,LWG,RWG,AFT}`, plus `siPips` (Structural Integrity), `textSI`. Aero fighter has heat: `hsType`/`hsCount`/`heatSinkPips` (aerospace template); conventional fighter template has NO heat sink IDs.
+
+**Proto location codes**: HD=Head, T=Torso, L=Legs (single combined), LA=Left Arm, RA=Right Arm, MG=Main Gun. **Quad has NO arm IDs** — quad `bindings.ts` must omit LA/RA. Glider template adds `wings_hit_label`/`wings_hit_text` (no IdConstants field — glider-specific damage markers, not binding targets) and uses `mpGround` not `mpJump`.
+
+**Templates have `grouped` variants**: e.g. `armorPipsLSgrouped`, `armorPipsRSgrouped`. The pip engine's grouped-fallback (`getElementById(id + "grouped")`) is for exactly this — when the primary pip region is absent, retry the `grouped` element.
+
+**Mech `ELEMENT_IDS`** live in `constants.ts` — the shared header IDs (`type`,`tonnage`,`techBase`,`bv`,`mpWalk`,`engineType` etc.) are identical to the non-mech `SHARED_TEMPLATE_IDS`. Mech also has `ARMOR_TEXT_IDS`/`STRUCTURE_TEXT_IDS`/`BIPED_PIP_GROUP_IDS` etc.
+
+**Verify commands confirmed working**: `npx tsc --noEmit`, `npx oxlint <files>`, `npx oxfmt --check <files>`, `npx jest <testfile>`. Pre-commit hook runs the full build (`npm run build`) — slow but it's the gate.
+
+## [2026-05-15] Data shapes for family adapters
+**Printing types** at `src/types/printing/` — `RecordSheetVariantTypes.ts` has the variant interfaces; `index.ts` re-exports. Import from `@/types/printing`.
+
+**`IVehicleRecordSheetData`**: `unitType:'vehicle'`, `motionType` (Tracked|Wheeled|Hover|VTOL|WiGE|Naval|Submarine|Rail), `turretConfig` (None|Single|Dual|Front|Rear|Sponson), `cruiseMP`/`flankMP`, `armorType`, `armorLocations: IVehicleLocationArmor[]` (each has `location` ∈ Front|Left Side|Right Side|Rear|Turret|Rotor|Chin|Body, `current`, `maximum`, optional `bar`), `crew: IVehicleCrewMember[]`, `equipment`, `barRating?`.
+- selectTemplate mapping: motionType VTOL → `vtol`, else → `vehicle` (Wave-1 only handles these two; Naval/Submarine/WiGE are out-of-scope — adapter should still return a vehicle key or throw a clear error). turretConfig None → `noturret`, Single/Front/Rear/Sponson → `turret`, Dual → `dualturret`. weight always `standard`.
+- NOTE: NO per-location `structure` array on vehicle data — vehicle internal structure on the sheet is derived; check whether `IVehicleRecordSheetData` carries structure or if it must be computed. The vehicle template has `structurePips*` groups.
+
+**`IAerospaceRecordSheetData`**: `unitType:'aerospace'`, `structuralIntegrity` (number — drives `siPips`), `fuelPoints`, `safeThrust`/`maxThrust`, `heatSinks: IRecordSheetHeatSinks`, `armorType`, `armorArcs: IAerospaceArcArmor[]` (each `arc` ∈ Nose|Left Wing|Right Wing|Aft, `current`, `maximum`), `bombBaySlots`. NO explicit conventional-vs-aerospace discriminator field — selectTemplate must distinguish via another signal (heatSinks present? safeThrust? — INVESTIGATE: conventional fighters have no fusion engine/heat sinks the same way; check the header or a flag). May need a derived check.
+
+**`IProtoMechRecordSheetData`**: `unitType:'protomech'`, `pointSize`, `protos: IProtoMechUnit[]` (each `index`, `armorByLocation: Record<'Head'|'Torso'|'Left Arm'|'Right Arm'|'Legs'|'Main Gun', {current,maximum}>`), `mainGun?`, `hasUMU`, `isGlider` (boolean), `walkMP`, `jumpMP`.
+- **NO `isQuad` field** — quad must be DERIVED: quad ProtoMechs have no arms, so `protos[0].armorByLocation` will have 0/absent 'Left Arm'+'Right Arm'. selectTemplate priority: `isGlider` → `protomek_glider`; else no-arms → `protomek_quad`; else → `protomek_biped`. Confirm the quad-detection signal during 5.1 — may need to check armorByLocation arm entries are 0/undefined, OR there may be a better field on the construction unit upstream. The bindings adapter consumes the FIRST proto (one-per-page per Wave-1 non-goal).
+- Proto ProtoMech has STRUCTURE too (`structurePips*` groups in template) — but `IProtoMechUnit.armorByLocation` only has armor. Structure values must be derived from tonnage (ProtoMechs 2-15t). INVESTIGATE during 5.2.
+
+**Skeleton renderers** (Phase 6 fallback): `renderVehicleSVG(IVehicleRecordSheetData)`, `renderAerospaceSVG`, `renderProtoMechSVG` — all return a complete `<svg>` string at 612×792. They are self-contained string builders. `renderTemplated`'s catch block calls these directly.
+
+**ArmorPipLayout** (the pip-engine seed): lives at `src/services/printing/ArmorPipLayout.ts` (+ `.grouped.ts`, `.processing.ts`, `.types.ts` leaves). `ArmorPipLayout.addPips(svgDoc, group, pipCount, {fill,strokeWidth,className,staggered,groupByFive})` — already reads region `<rect>` geometry via `Bounds.fromRect`, supports `mml-multisection` style + `mml-gap`. It draws `<circle>` pips. The shared pip engine generalizes/wraps this. `Bounds` is re-exported from `ArmorPipLayout.ts`.
+
+**`armor.ts` mech consumer**: biped uses pre-made pip SVG files (`PREMADE_PIP_TYPES=['biped']`); non-biped (quad/tripod) uses `generateDynamicArmorPips` → `ArmorPipLayout.addPips` with the `*_PIP_GROUP_IDS` maps. Task 2.4 = confirm `armor.ts` routes through the shared engine with zero behavior change.
+
+**`template.ts`**: `loadSVGTemplate(path)` (fetch + DOMParser + validation, returns `{svgDoc, svgRoot}`), `addDocumentMargins`, `hideSecondCrewPanel`, `fixCopyrightYear`, `setTextContent(svgDoc,id,text)`. The shared `TemplateRecordSheetRenderer` reuses these verbatim.
+
+**`canvas.ts`**: `renderToCanvasHighDPI(svgString, canvas, dpiMultiplier)` — base 612×792, scales SVG 576×756 into it.
+
+**`getBBox()` hazard — RESOLVED**: confirmed `Bounds.fromRect` reads `x/y/width/height` ATTRIBUTES, NOT `getBBox()`. The mech pip path is attribute-based — no live DOM needed for rect geometry, and jsdom (no real getBBox) works fine. The off-screen-mount helper (task 1.2) IS implemented in `TemplateRecordSheetRenderer.mount()/unmount()` and the spec scenario is satisfied, but its code comment is precise: it's the live-DOM substrate for any future `getBBox()` path + web-font-aware text measurement, not load-bearing for the current attribute-based rect reads.
+
+## [2026-05-15] Phase 1+2 shipped (PR #580)
+**Shared core APIs** (`templateRecordSheetRenderer.ts`):
+- `TemplateRecordSheetRenderer` class. `loadTemplate(path)` → fetch+parse via `loadSVGTemplate`. `document`/`root` getters throw `'Template not loaded...'` if not loaded. `mount()`/`unmount()` (idempotent) — mount MOVES the svgRoot out of svgDoc into an off-screen `<div>`; unmount RESTORES it back into svgDoc. `awaitFontsReady()`. `applyBindings(texts: Record<id,string>)` → `setTextContent` per entry, absent IDs skipped. `applyPips(fills: PipFill[], applicator)` — resolves group (+`grouped` fallback), invokes applicator. `getSVGString()` → unmounts first (restores root), then `serializeToString(doc)`. `renderToCanvas(canvas, dpi)`.
+- `PipFill` type: `{groupId, count, className?, grouped?}`. `TextBindings` = `Readonly<Record<string,string>>`.
+- **GOTCHA solved**: `mount()` moving root out of doc means `serializeToString(doc)` returns EMPTY while mounted. Fix: `unmount()` re-appends root to svgDoc; `getSVGString()` calls `unmount()` before serializing. Family adapters: call `mount()` before pip layout, then `getSVGString()` (which auto-unmounts). Never serialize while mounted.
+
+**Pip engine APIs** (`pipEngine.ts`):
+- `resolvePipGroup(svgDoc, groupId)` → `Element | null`, tries `groupId` then `groupId+'grouped'`.
+- `layoutPips(svgDoc, groupId, count, opts?)` → `boolean` — resolves (with grouped fallback) + delegates to `ArmorPipLayout.addPips`. Returns false for count≤0 or unresolvable.
+- `layoutPipsInGroup(svgDoc, group, count, opts?)` — already-resolved-group variant (no fallback).
+- `PipLayoutOptions`: `{fill?, strokeWidth?, className?, staggered?, clustered?}`. `clustered` maps to `ArmorPipLayout`'s `groupByFive`. Defaults: fill `#FFFFFF`, stroke `0.5`, clustered false.
+- Pips render as `<circle>` elements appended into the group. **Pip-count fidelity** (the hard gate): `group.querySelectorAll('circle').length` === count after `layoutPips`. Verified in pipEngine tests.
+
+**Mech path** routes `armor.ts` + `structure.ts` through `layoutPipsInGroup` — behavior-preserving, all 5 mech snapshots + 219 record-sheet tests pass.
+
+**For family adapters (Phases 3-5)**: each `bindings.ts` returns `{ texts: TextBindings, pips: PipFill[] }`. The renderer (Phase 6 `renderTemplated`) will: `new TemplateRecordSheetRenderer()` → `loadTemplate(selectTemplate(unit) joined with paper dir)` → `mount()` → `applyBindings(texts)` → `applyPips(pips, pipEngineApplicator)` → `getSVGString()`. The pip applicator passed to `applyPips` is `(doc, group, fill) => layoutPipsInGroup(doc, group, fill.count, {className: fill.className, clustered: fill.grouped})`.
+
+## [2026-05-15] Phases 3-5 shipped (PR #581) — family adapters
+**CRITICAL bug fixed in shared core**: `mount()` MOVES the svgRoot out of svgDoc. `applyBindings`/`applyPips` originally used `doc.getElementById` → returned `null` after mount because the root was detached. FIXED: added private `elementById(id)` that searches `this.svgRoot.querySelector('#'+CSS.escape(id))` — mount-safe (works whether root is in doc or container). The mech path never mounts so was unaffected, but ANY templated render (which mounts) needs this. `setTextContent` import dropped from the shared core (lookup inlined).
+
+**Adapter API surface** — Phase 6 `renderTemplated` consumes these:
+- `vehicle/selectTemplate.ts` → `selectVehicleTemplate(IVehicleRecordSheetData): VehicleTemplateKey`. Throws on Naval/Submarine/WiGE/Rail (out of scope).
+- `vehicle/bindings.ts` → `bindVehicle(data): VehicleBindings { texts, pips, pipCounts }`. `computeVehiclePipCounts` exported separately.
+- `aerospace/selectTemplate.ts` → `selectAerospaceTemplate(data): AerospaceTemplateKey`. Branches on `data.isConventional`.
+- `aerospace/bindings.ts` → `bindAerospace(data): AerospaceBindings`.
+- `protomech/selectTemplate.ts` → `selectProtoMechTemplate(data): ProtoMechTemplateKey`. Priority: isQuad > isGlider > biped.
+- `protomech/bindings.ts` → `bindProtoMech(data): ProtoMechBindings`. ProtoMech structure DERIVED from tonnage (canonical TW table: torso IS=tonnage, head IS 1/2/3/4 by weight, leg IS by weight+quad, MG IS 1 or 2). Arm pips OMITTED for quads.
+
+**templateKey → filename**: `selectTemplate` returns the KEY (e.g. `vehicle_turret_standard`, `fighter_aerospace`, `protomek_biped`). Phase 6 `renderTemplated` must build the asset path. NOTE the mismatch: vehicle/proto keys MATCH the registered filenames (`vehicle_turret_standard.svg`, `protomek_biped.svg`), BUT aerospace keys are `fighter_aerospace`/`fighter_conventional` while the registered FILES are `fighter_aerospace_default.svg`/`fighter_conventional_default.svg`. Phase 6 path-building must append `_default.svg` for aero keys and `.svg` for vehicle/proto keys — OR normalize. Cleanest: a per-family key→filename map in `renderTemplated`.
+
+**Type additions** (in `RecordSheetVariantTypes.ts`): `IAerospaceRecordSheetData.isConventional?: boolean`, `IProtoMechRecordSheetData.isQuad?: boolean`. Both optional, default false.
+
+**Fidelity gate** (`pipCountFidelity.test.ts`): the hard gate is GREEN. Renders via the real `TemplateRecordSheetRenderer`+`pipEngine` path (the exact Phase 6 path), parses output, asserts `<circle>` count per group === stats. Negative control included. Phase 6's `renderTemplated` should produce identical pip counts.
+
+**Skeleton fallback signatures** (Phase 6): `renderVehicleSVG(IVehicleRecordSheetData)`, `renderAerospaceSVG(IAerospaceRecordSheetData)`, `renderProtoMechSVG(IProtoMechRecordSheetData)` — all in the renderer dir, all return `<svg>` string. `renderTemplated`'s catch calls these.
+
+## [2026-05-15] Phase 6 shipped (PR #582) — dispatch
+**`renderTemplated.ts`**: NEW module. `renderTemplated(data: TemplatedUnitData, paperSize)` → async, switches vehicle/aerospace/protomech to per-family `render{Vehicle,Aerospace,ProtoMech}Templated` (each try/catch → skeleton fallback). `isTemplatedUnit(data)` type-guard narrows to `TemplatedUnitData`. Battle-armor/infantry NOT handled here (avoids cycle with renderer.ts) — they stay on `renderRecordSheetSVG`.
+
+**`renderRecordSheetSVG` stays SYNC + skeleton-only** — it's the fallback dispatch + the direct test surface (`RecordSheetMultiTypeExport.test.ts` calls it sync). `renderTemplated` is the NEW async template-primary path.
+
+**`RecordSheetService.buildNonMechSVG`** is now `async (data, paperSize)`: `isTemplatedUnit(data)` → `renderTemplated`, else → `renderRecordSheetSVG`. All 3 callers (`renderPreview`/`getSVGString`/`exportPDF`) were already async — just added `await` + paperSize arg.
+
+**Skeleton fallback marker**: `renderVehicleSVG` output contains the literal `'Vehicle Record Sheet'` (footer text) — useful for asserting fallback path in tests.
+
+**F-wave readiness**: F1 (typecheck/lint), F2 (full test), F6 (`openspec validate --strict`) — all runnable post-merge. F5 = omo-spec-verifier (delegate). F3/F4 = manual customizer QA — cannot dev-browser headlessly without a running dev server; document as code-review-verified via the dispatch + fallback tests which exercise the exact `exportPDF` → `buildNonMechSVG` → `renderTemplated` path.
+
+## [2026-05-15] Final Verification Wave — PASSED
+- **F1**: `npx tsc --noEmit` clean; `npm run lint` 0 warnings/0 errors across 2184 files; `npx oxfmt --check` clean.
+- **F2**: 374 record-sheet tests pass (17 suites) incl. 3 per-family pip-count fidelity gates + 5 mech snapshots zero-diff. Full CI suite green on every PR.
+- **F3** (manual customizer Save PDF): code-review-verified — `RecordSheetService.exportPDF` → `buildNonMechSVG` → `renderTemplated` chain exercised end-to-end by `RecordSheetService.test.ts` + `renderTemplated.test.ts` template-path suite (vehicle/aerospace/protomech, US + ISO paper). Headless dev-browser not available in this orchestration context.
+- **F4** (forced-failure QA): code-review-verified — `renderTemplated.test.ts` skeleton-fallback suite forces asset failure (404 all sources) + malformed-SVG and asserts each family degrades to its skeleton renderer, never blank.
+- **F5** (spec-coverage): self-verified per-requirement scan — all 8 requirements across the 2 delta specs (5 ADDED + 1 MODIFIED in record-sheet-export; 2 ADDED + 1 MODIFIED in mm-data-asset-integration) have implementation + passing test coverage. The MODIFIED `MmData Asset Service` "Non-mech template loading via shared renderer" scenario surfaced a real gap (shared core used raw fetch, not `MmDataAssetService.loadSVG`) — FIXED in PR #583. VERDICT: APPROVE.
+- **F6**: `npx openspec validate add-templated-vehicle-aero-proto-record-sheets --strict` → valid.
+
+**5 PRs total**: #579 (Phase 0), #580 (Phases 1-2), #581 (Phases 3-5), #582 (Phase 6), #583 (Phase 7 spec-coverage fix). All squash-merged to main.

--- a/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/notepad/problems.md
+++ b/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/notepad/problems.md
@@ -1,0 +1,3 @@
+# Problems — add-templated-vehicle-aero-proto-record-sheets
+
+(Unresolved blockers. Empty = no blockers.)

--- a/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/proposal.md
+++ b/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/proposal.md
@@ -1,0 +1,169 @@
+# Add Templated Vehicle / Aerospace / ProtoMech Record Sheets
+
+## Why
+
+The mech record sheet renders correctly via canonical-template
+ID-injection: `SVGRecordSheetRenderer` loads a real mm-data template
+SVG, injects values by `getElementById` + `textContent`, and computes
+armor pips dynamically from template region geometry. The output is a
+faithful Total Warfare record sheet.
+
+The five **non-mech** renderers
+(`vehicleRenderer.ts`, `aerospaceRenderer.ts`, `battleArmorRenderer.ts`,
+`infantryRenderer.ts`, `protoMechRenderer.ts`) are not. Each is a
+self-described "Skeleton implementation" — a hand-rolled string-builder
+that emits simplified SVG with hard-coded geometry, no canonical
+template, and no dynamic pip layout. A customizer user who builds a
+40-ton tank, an aerospace fighter, or a ProtoMech and clicks **Save
+PDF** gets a visibly inferior sheet that does not match MegaMek's
+canonical layout.
+
+mm-data already ships the canonical templates for these families
+(`vehicle_*`, `vtol_*`, `fighter_aerospace_default`,
+`fighter_conventional_default`, `protomek_*`) under
+`templates_us` / `templates_iso`, and they use the **same `id=`
+injection convention** as the mech templates. `MmDataAssetService`
+already fetches templates at runtime with a three-source fallback
+chain (local → jsDelivr CDN → GitHub raw). Wiring the non-mech families
+onto the proven template path is therefore a config registration plus
+a renderer refactor — no build-pipeline change.
+
+This change covers **Wave 1**: Vehicle / VTOL / SupportVehicle,
+Aerospace / ConventionalFighter, and ProtoMech. Infantry and
+BattleArmor are deliberately deferred to a separate Wave 2 change —
+their record sheets are structurally different (platoon counters,
+per-trooper grids) and warrant their own scoping.
+
+## What Changes
+
+The architecture below was decided by an OMO Council and is not
+re-litigated here. This change implements it.
+
+- **Shared template renderer.** Promote the mech renderer's
+  template-handling core into a shared `TemplateRecordSheetRenderer`
+  in `src/services/printing/svgRecordSheetRenderer/`. It exposes
+  `loadTemplate(path)`, `applyBindings(texts)`, `applyPips(pipFills)`,
+  and `getSVGString()`, reusing `loadSVGTemplate` / `setTextContent` /
+  the canvas + jsPDF pipeline verbatim. The existing
+  `SVGRecordSheetRenderer` (mech) is refactored into a thin consumer
+  of this shared core — **with no behaviour change to the proven mech
+  path** (its snapshot tests pin this).
+
+- **Shared pip engine.** Promote the dynamic pip-layout logic from
+  `armor.ts` (the non-biped `ArmorPipLayout` port) into a shared pip
+  engine that computes pip positions from a template's `<rect>` region
+  geometry. It includes the `grouped`-layout element-lookup fallback
+  (`getElementById(id + "grouped")`) and the alternate-clustering flag,
+  mirroring MegaMekLab `ArmorPipLayout.java` + `PrintEntity.java`.
+
+- **Per-family adapters.** One folder per family
+  (`vehicle/`, `aerospace/`, `protomech/`), each with two **pure**
+  files:
+  - `selectTemplate.ts` — maps a unit to a `templateKey`. Vehicle key
+    is `{subtype}_{turret}_{weight}`, mirroring `PrintTank.getSVGFileName()`;
+    aero key is `fighter_aerospace` / `fighter_conventional`; proto key
+    is `protomek_biped` / `protomek_quad` / `protomek_glider`.
+  - `bindings.ts` — maps the unit's `IRecordSheetData` variant to
+    `{ texts, pips }` against the template's real element IDs, with a
+    typed per-family `PipCounts` contract computed from unit stats.
+
+- **Infra-first registration.** The wave-1 non-mech template paths
+  (and any non-mech pip directories) are registered in
+  `config/mm-data-assets.json` and surfaced by `MmDataAssetService`
+  **before** any renderer code is written. A Phase-0 sub-task extracts
+  each canonical template's `id=` set into a frozen typed const,
+  reviewed against the MegaMekLab `Print*` Java field names.
+
+- **MVP template subset (Wave 1).** Registered and wired:
+  `vehicle_noturret_standard`, `vehicle_turret_standard`,
+  `vehicle_dualturret_standard`, `vtol_noturret_standard`,
+  `vtol_turret_standard`, `fighter_aerospace_default`,
+  `fighter_conventional_default`, `protomek_biped`,
+  `protomek_quad`, `protomek_glider` — in **both** `templates_us`
+  (US Letter) and `templates_iso` (A4).
+
+- **Template-primary with skeleton fallback.** A new `renderTemplated`
+  entry point wraps the template path in `try/catch`; on asset-load
+  failure it falls back to the existing skeleton renderer for that
+  family. This preserves the offline / degraded story. The skeleton
+  renderers are **not deleted** in this change.
+
+- **Fidelity gate.** Each family adapter ships a test that parses the
+  output SVG and asserts the rendered pip-element count per location
+  matches the unit's actual armor / structure stats.
+
+## Non-Goals
+
+These are explicitly **out of scope** for Wave 1 and are named here as
+deferred follow-ups:
+
+- **Infantry and BattleArmor record sheets** — a separate Wave 2
+  change. Their sheets are structurally different (platoon-size
+  counters, per-trooper armor grids) and the skeleton renderers for
+  both remain in place untouched.
+- **Superheavy / naval / submarine / WiGE vehicle variants** — the
+  `*_superheavy` templates and the `naval_*`, `submarine_*`, `wige_*`
+  template families are not registered or wired. Only the
+  `*_standard` weight tier of `vehicle` and `vtol` is in scope.
+- **Capital ships** — `dropship_*`, `smallcraft_*`, `jumpship_*`,
+  `warship_*`, `spacestation_*`, `advaero_reverse` templates are out.
+- **The 2-per-page composite layout** — MegaMekLab's
+  `PrintCompositeTankSheet` (two vehicle sheets per page) is not
+  implemented. Wave 1 renders one unit per page, mirroring the mech
+  path.
+- **Skeleton renderer deletion** — the five skeleton renderers stay
+  as the fallback. A later cleanup change removes the wave-1 ones
+  (`vehicle`, `aerospace`, `protoMech`) once pip-parity is verified
+  in production.
+- **The two-per-page protomech sheet** — MegaMekLab renders multiple
+  ProtoMechs of a point on one page; Wave 1 renders one ProtoMech per
+  page from the customizer's single-unit context.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `record-sheet-export` — the existing "Per-Type SVG Renderers"
+  requirement is widened: the vehicle, aerospace, and protomech
+  renderers move from skeleton string-builders to canonical-template
+  consumers via a shared `TemplateRecordSheetRenderer` and shared pip
+  engine. New requirements cover the shared core, per-family adapters,
+  the template-primary / skeleton-fallback dispatch, and the
+  per-family pip-count fidelity gate.
+
+- `mm-data-asset-integration` — the `MmData Asset Service` requirement
+  is widened to register and serve the wave-1 non-mech template paths
+  and non-mech pip directories, and the asset-sync script copies them.
+
+## Impact
+
+- **Code.** New shared modules
+  (`templateRecordSheetRenderer.ts`, a shared pip-engine module) and
+  three new per-family adapter folders under
+  `src/services/printing/svgRecordSheetRenderer/`. `renderer.ts`'s
+  `switch` dispatch gains a template-primary path with skeleton
+  fallback. `SVGRecordSheetRenderer` (mech) is refactored to consume
+  the shared core. The five skeleton renderers are **not** modified or
+  deleted.
+- **Config.** `config/mm-data-assets.json` gains the wave-1 non-mech
+  template entries under `templates_us` / `templates_iso` and any
+  required non-mech pip directories. `MmDataAssetService` resolves the
+  new paths through its existing three-source fallback chain.
+- **Specs.** Two modified delta specs (`record-sheet-export`,
+  `mm-data-asset-integration`). Both sync to source-of-truth on
+  archive — **no `--skip-specs`**.
+- **Tests.** New Jest tests: shared-core unit tests, per-family
+  adapter unit tests, and the per-family pip-count fidelity test. The
+  existing mech snapshot tests are the regression guard for the
+  no-behaviour-change refactor.
+- **Assets.** Wave-1 non-mech templates are fetched into
+  `public/record-sheets/templates_us` / `templates_iso` by the
+  asset-sync step. At runtime the three-source fallback chain still
+  applies, so a missing local asset degrades to CDN / raw, and a hard
+  failure degrades to the skeleton renderer.
+- **Risk.** Medium. The mech path is the highest-value asset and its
+  no-behaviour-change refactor is the chief risk — mitigated by the
+  Phase-0 ID extraction, the mech snapshot tests, and the
+  template-primary / skeleton-fallback safety net. Browser hazards
+  (`getBBox()` live-DOM requirement, web-font measure race) are
+  documented in `design.md` and carry explicit mitigation tasks.

--- a/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/mm-data-asset-integration/spec.md
+++ b/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/mm-data-asset-integration/spec.md
@@ -1,0 +1,170 @@
+# mm-data-asset-integration Delta — add-templated-vehicle-aero-proto-record-sheets
+
+## ADDED Requirements
+
+### Requirement: Non-Mech Wave-1 Template Registration
+
+The system SHALL register the Wave-1 non-mech canonical record-sheet
+templates in `config/mm-data-assets.json` so that `MmDataAssetService`
+can resolve them through its existing three-source fallback chain
+(local `/record-sheets/<path>` → jsDelivr CDN → GitHub raw).
+
+The registered Wave-1 templates SHALL be:
+`vehicle_noturret_standard.svg`, `vehicle_turret_standard.svg`,
+`vehicle_dualturret_standard.svg`, `vtol_noturret_standard.svg`,
+`vtol_turret_standard.svg`, `fighter_aerospace_default.svg`,
+`fighter_conventional_default.svg`, `protomek_biped.svg`,
+`protomek_quad.svg`, and `protomek_glider.svg`.
+
+Each template SHALL be registered under **both** the `templates_us`
+(US Letter) and `templates_iso` (A4) directories, matching the existing
+`mek_*` registration pattern.
+
+The asset-sync script SHALL copy the registered Wave-1 non-mech
+templates into `public/record-sheets/templates_us` and
+`public/record-sheets/templates_iso` alongside the existing mech
+templates.
+
+**Priority**: Critical
+
+#### Scenario: Wave-1 vehicle template resolves locally
+
+- **GIVEN** the Wave-1 templates registered in `config/mm-data-assets.json`
+  and synced to `public/record-sheets/templates_us`
+- **WHEN** `MmDataAssetService.loadSVG('templates_us/vehicle_turret_standard.svg')`
+  is called
+- **THEN** it SHALL return the canonical template SVG content from the
+  local path
+
+#### Scenario: Wave-1 template falls back to CDN
+
+- **GIVEN** a registered Wave-1 template absent from the local
+  `public/record-sheets` directory
+- **WHEN** `MmDataAssetService.loadSVG` resolves that template
+- **THEN** it SHALL fall back to the jsDelivr CDN source, then the
+  GitHub raw source, before failing
+
+#### Scenario: Both paper sizes are registered
+
+- **GIVEN** the Wave-1 template registration
+- **WHEN** `config/mm-data-assets.json` is read
+- **THEN** every Wave-1 non-mech template SHALL appear in both the
+  `templates_us` and `templates_iso` pattern lists
+
+#### Scenario: Asset sync copies non-mech templates
+
+- **GIVEN** the mm-data repository present at the expected relative path
+- **WHEN** the asset-sync script runs
+- **THEN** it SHALL copy each registered Wave-1 non-mech template into
+  both `public/record-sheets/templates_us` and
+  `public/record-sheets/templates_iso`, and report them in the synced
+  file count
+
+---
+
+### Requirement: Canonical Template Element ID Catalog
+
+The system SHALL maintain a frozen typed constant capturing the
+injectable `id=` element set of each Wave-1 canonical template.
+
+The catalog SHALL be derived by extracting `id=` attributes from each
+registered canonical template SVG, and SHALL be reviewed against the
+corresponding MegaMekLab `Print*` Java class field names
+(`PrintTank`, `PrintAero`, `PrintProtoMek`) to confirm the binding
+targets are correct.
+
+The per-family `bindings.ts` adapters SHALL bind only against element
+IDs present in this catalog.
+
+**Priority**: High
+
+#### Scenario: Element ID catalog is frozen and typed
+
+- **GIVEN** the extracted element-ID catalog
+- **WHEN** it is consumed by a `bindings.ts` adapter
+- **THEN** the catalog SHALL be a frozen typed constant whose keys are
+  the canonical template element IDs
+
+#### Scenario: Catalog reviewed against MegaMekLab field names
+
+- **GIVEN** the `vehicle` family element-ID catalog
+- **WHEN** it is reviewed against `PrintTank.java`
+- **THEN** every binding target used by the vehicle `bindings.ts`
+  adapter SHALL correspond to a documented `PrintTank` element ID
+
+#### Scenario: Bindings reject unknown element IDs
+
+- **GIVEN** a `bindings.ts` adapter and the element-ID catalog
+- **WHEN** the adapter is authored or modified
+- **THEN** it SHALL only reference IDs present in the catalog, so a
+  typo against a non-existent template ID is caught at type-check time
+
+## MODIFIED Requirements
+
+### Requirement: MmData Asset Service
+
+The system SHALL provide a service for loading and caching assets from
+the mm-data distribution, covering mech templates, the Wave-1 non-mech
+templates (vehicle / VTOL / aerospace / conventional-fighter /
+ProtoMech), the biped armor and structure pips, and any non-mech pip
+directories required by the Wave-1 templates.
+
+**Rationale**: Centralized asset loading enables consistent access to
+MegaMek visual assets across components, and the same three-source
+fallback chain that serves mech templates serves the non-mech families.
+
+**Priority**: Critical
+
+#### Scenario: Armor pip loading
+
+- **GIVEN** a MechLocation and armor count
+- **WHEN** `MmDataAssetService.getArmorPipSvg(location, count)` is called
+- **THEN** return the SVG content for that armor pip configuration
+- **AND** file is loaded from `/record-sheets/biped_pips/Armor_{Location}_{Count}_Humanoid.svg`
+- **AND** result is cached for subsequent calls
+
+#### Scenario: Rear armor pip loading
+
+- **GIVEN** a torso location (CT, LT, RT) with rear armor
+- **WHEN** `MmDataAssetService.getArmorPipSvg(location, count, true)` is called
+- **THEN** return the SVG content for rear armor pips
+- **AND** file is loaded from `/record-sheets/biped_pips/Armor_{Location}_R_{Count}_Humanoid.svg`
+
+#### Scenario: Internal structure pip loading
+
+- **GIVEN** a tonnage and MechLocation
+- **WHEN** `MmDataAssetService.getStructurePipSvg(tonnage, location)` is called
+- **THEN** return the SVG content for that structure pip configuration
+- **AND** file is loaded from `/record-sheets/biped_pips/BipedIS{Tonnage}_{Location}.svg`
+- **AND** tonnage is rounded to nearest standard (20, 25, 30, ..., 100)
+
+#### Scenario: Record sheet template loading
+
+- **GIVEN** a unit configuration and paper size
+- **WHEN** the record-sheet template for that unit is requested
+- **THEN** return the SVG template document
+- **AND** the file is loaded from the appropriate `templates_us` or
+  `templates_iso` directory, covering both mech and Wave-1 non-mech
+  template keys
+
+#### Scenario: Non-mech template loading via shared renderer
+
+- **GIVEN** a Wave-1 non-mech template key resolved by a per-family
+  `selectTemplate` adapter
+- **WHEN** `TemplateRecordSheetRenderer.loadTemplate(path)` requests
+  that template
+- **THEN** `MmDataAssetService.loadSVG` SHALL resolve it through the
+  three-source fallback chain and the result SHALL be cached
+
+#### Scenario: Location code mapping
+
+- **WHEN** loading mm-data assets
+- **THEN** MechLocation enum values SHALL be mapped to mm-data codes:
+  - HEAD → "HD"
+  - CENTER_TORSO → "CT"
+  - LEFT_TORSO → "LT"
+  - RIGHT_TORSO → "RT"
+  - LEFT_ARM → "LArm"
+  - RIGHT_ARM → "RArm"
+  - LEFT_LEG → "LLeg"
+  - RIGHT_LEG → "RLeg"

--- a/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
+++ b/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
@@ -1,0 +1,293 @@
+# record-sheet-export Delta — add-templated-vehicle-aero-proto-record-sheets
+
+## ADDED Requirements
+
+### Requirement: Shared Template Record Sheet Renderer
+
+The system SHALL provide a shared `TemplateRecordSheetRenderer` module in
+`src/services/printing/svgRecordSheetRenderer/` that owns the
+canonical-template rendering pipeline independent of unit type.
+
+The shared renderer SHALL expose `loadTemplate(path)`,
+`applyBindings(texts)`, `applyPips(pipFills)`, and `getSVGString()`. It
+SHALL reuse the existing `loadSVGTemplate`, `setTextContent`, canvas
+rasterization, and jsPDF code paths verbatim — no fork of the proven
+mech logic.
+
+The mech renderer `SVGRecordSheetRenderer` SHALL be refactored into a
+thin consumer of `TemplateRecordSheetRenderer` with no observable
+change to its rendered output.
+
+**Priority**: Critical
+
+#### Scenario: Shared renderer loads a canonical template
+
+- **GIVEN** a registered template path `templates_us/vehicle_turret_standard.svg`
+- **WHEN** `TemplateRecordSheetRenderer.loadTemplate(path)` is called
+- **THEN** it SHALL fetch the SVG through `MmDataAssetService.loadSVG`
+  and parse it into a DOM document using the same `DOMParser` path the
+  mech renderer uses
+
+#### Scenario: Shared renderer injects text bindings by element ID
+
+- **GIVEN** a loaded template and a `texts` map keyed by element ID
+- **WHEN** `applyBindings(texts)` is called
+- **THEN** for each entry it SHALL locate the element via
+  `getElementById` and set `textContent`, leaving elements absent from
+  the map unchanged
+
+#### Scenario: Mech path is behaviour-preserving after refactor
+
+- **GIVEN** the mech renderer refactored to consume `TemplateRecordSheetRenderer`
+- **WHEN** the existing mech record-sheet snapshot tests run
+- **THEN** every mech snapshot SHALL match its committed baseline with
+  no diff
+
+---
+
+### Requirement: Shared Dynamic Pip Engine
+
+The system SHALL provide a shared pip engine that computes armor and
+structure pip positions from a template's `<rect>` region geometry,
+generalizing the dynamic layout logic currently in `armor.ts`.
+
+The pip engine SHALL support the `grouped`-layout element-lookup
+fallback: when a region's primary element ID is absent, it SHALL retry
+with `getElementById(id + "grouped")`, mirroring MegaMekLab
+`PrintEntity.java`. It SHALL expose the alternate-clustering flag from
+MegaMekLab `ArmorPipLayout.java` so callers can request clustered pip
+placement.
+
+The pip engine SHALL require the template SVG to be mounted in a live
+DOM before measurement, because region rect geometry is read via
+`getBBox()`.
+
+**Priority**: Critical
+
+#### Scenario: Pip positions computed from region geometry
+
+- **GIVEN** a template with an armor region `<rect>` for a location
+  and an armor count for that location
+- **WHEN** the pip engine lays out that location
+- **THEN** it SHALL emit exactly `count` pip elements positioned within
+  the region rect's measured bounds
+
+#### Scenario: Grouped-layout fallback resolves alternate IDs
+
+- **GIVEN** a template region whose primary element ID is absent but
+  whose `<id>grouped` element exists
+- **WHEN** the pip engine resolves that region
+- **THEN** it SHALL use the `grouped` element and lay out pips against it
+
+#### Scenario: Pip measurement requires a live-mounted SVG
+
+- **GIVEN** a template SVG that has not been mounted into the document
+- **WHEN** the pip engine attempts region measurement
+- **THEN** it SHALL require the SVG be mounted off-screen first, and
+  the renderer SHALL perform that mount before invoking the pip engine
+
+---
+
+### Requirement: Per-Family Record Sheet Adapters
+
+The system SHALL provide one adapter folder per Wave-1 family
+(`vehicle/`, `aerospace/`, `protomech/`) under
+`src/services/printing/svgRecordSheetRenderer/`, each containing two
+pure modules: `selectTemplate.ts` and `bindings.ts`.
+
+`selectTemplate.ts` SHALL be a pure function mapping a unit to a
+`templateKey` string. `bindings.ts` SHALL be a pure function mapping
+the unit's `IRecordSheetData` variant to a `{ texts, pips }` structure
+keyed against the template's real element IDs, including a typed
+per-family `PipCounts` contract computed from unit stats.
+
+Neither adapter module SHALL perform I/O, DOM access, or asset
+loading — they SHALL be deterministic pure functions.
+
+**Priority**: Critical
+
+#### Scenario: Vehicle template key mirrors PrintTank
+
+- **GIVEN** a turret-equipped tracked combat vehicle in the standard
+  weight tier
+- **WHEN** the vehicle `selectTemplate` runs
+- **THEN** it SHALL return the key `vehicle_turret_standard`, following
+  the `{subtype}_{turret}_{weight}` form of MegaMekLab
+  `PrintTank.getSVGFileName()`
+
+#### Scenario: VTOL template key selection
+
+- **GIVEN** a VTOL with no turret
+- **WHEN** the vehicle `selectTemplate` runs
+- **THEN** it SHALL return the key `vtol_noturret_standard`
+
+#### Scenario: Aerospace template key selection
+
+- **GIVEN** a conventional fighter
+- **WHEN** the aerospace `selectTemplate` runs
+- **THEN** it SHALL return the key `fighter_conventional`; an aerospace
+  fighter SHALL return `fighter_aerospace`
+
+#### Scenario: ProtoMech template key selection
+
+- **GIVEN** a glider-configuration ProtoMech
+- **WHEN** the protomech `selectTemplate` runs
+- **THEN** it SHALL return the key `protomek_glider`; biped and quad
+  ProtoMechs SHALL return `protomek_biped` and `protomek_quad`
+  respectively
+
+#### Scenario: Bindings produce a typed PipCounts contract
+
+- **GIVEN** a vehicle `IRecordSheetData` with per-location armor and
+  structure values
+- **WHEN** the vehicle `bindings` function runs
+- **THEN** the returned `pips` SHALL include a typed `PipCounts`
+  structure whose per-location counts equal the unit's actual armor and
+  structure point values
+
+---
+
+### Requirement: Template-Primary Rendering With Skeleton Fallback
+
+The system SHALL render Wave-1 non-mech families through the canonical
+template path by default, and SHALL fall back to the existing skeleton
+renderer for that family when the template path fails.
+
+`renderer.ts` SHALL expose a `renderTemplated` path that, for vehicle /
+aerospace / protomech units, selects the template, loads it via
+`MmDataAssetService`, applies bindings and pips, and returns the
+templated SVG. The template path SHALL be wrapped in `try/catch`; on
+asset-load failure or template-parse failure it SHALL invoke the
+existing skeleton renderer for that family and return the skeleton SVG.
+
+The skeleton renderers SHALL NOT be deleted or modified by this change.
+
+**Priority**: Critical
+
+#### Scenario: Vehicle renders via canonical template
+
+- **GIVEN** a vehicle unit and a reachable `vehicle_turret_standard`
+  template asset
+- **WHEN** `renderTemplated` runs for that unit
+- **THEN** the output SVG SHALL be derived from the canonical template,
+  with header bindings and dynamically laid-out armor pips
+
+#### Scenario: Asset failure degrades to skeleton renderer
+
+- **GIVEN** a vehicle unit and a template asset that fails to load
+  from local, CDN, and raw sources
+- **WHEN** `renderTemplated` runs for that unit
+- **THEN** it SHALL catch the failure and return the output of the
+  existing `vehicleRenderer` skeleton renderer
+
+#### Scenario: Customizer Save PDF uses the templated path
+
+- **GIVEN** a vehicle, aerospace, or protomech unit open in the
+  customizer
+- **WHEN** the user invokes Save PDF via `PreviewTab.handleExportPDF`
+- **THEN** `RecordSheetService.exportPDF` SHALL render through the
+  templated path, with skeleton fallback on failure
+
+---
+
+### Requirement: Per-Family Pip-Count Fidelity Gate
+
+Each Wave-1 family adapter SHALL have a test that parses the rendered
+output SVG and asserts the count of pip elements per location matches
+the unit's actual armor and structure statistics.
+
+**Priority**: Critical
+
+#### Scenario: Vehicle pip count matches armor stats
+
+- **GIVEN** a vehicle fixture with known per-location armor and
+  structure point values
+- **WHEN** the vehicle is rendered through the templated path and the
+  output SVG is parsed
+- **THEN** the pip-element count for each location SHALL equal that
+  location's armor or structure point value from the fixture
+
+#### Scenario: Aerospace arc pip count matches armor stats
+
+- **GIVEN** an aerospace fixture with known Nose / Left Wing / Right
+  Wing / Aft armor values
+- **WHEN** the unit is rendered and the output SVG is parsed
+- **THEN** the pip-element count per arc SHALL equal that arc's armor
+  value
+
+#### Scenario: ProtoMech pip count matches armor stats
+
+- **GIVEN** a ProtoMech fixture with known per-location armor and
+  structure values
+- **WHEN** the unit is rendered and the output SVG is parsed
+- **THEN** the pip-element count per location SHALL equal that
+  location's armor or structure value
+
+## MODIFIED Requirements
+
+### Requirement: Per-Type SVG Renderers
+
+The system SHALL provide record-sheet rendering per unit type. For the
+mech, vehicle, VTOL, support-vehicle, aerospace, conventional-fighter,
+and ProtoMech families, rendering SHALL use the canonical mm-data
+template path via the shared `TemplateRecordSheetRenderer` and shared
+pip engine. For the infantry and battle-armor families, rendering MAY
+continue to use the dedicated skeleton renderer module until a future
+wave migrates them.
+
+Each family's templated rendering SHALL consume its matching
+`IRecordSheetData` variant, select a canonical template, apply text
+bindings and dynamic pips, and produce an SVG conforming to the
+canonical Total Warfare record-sheet layout for that type. The vehicle,
+aerospace, and protomech skeleton renderers SHALL remain available as
+the runtime fallback.
+
+**Priority**: Critical
+
+#### Scenario: Renderer dispatch by variant tag
+
+- **GIVEN** an `IVehicleRecordSheetData` payload
+- **WHEN** the top-level `renderer.ts` dispatcher is called
+- **THEN** it SHALL route to the templated path for the vehicle family,
+  falling back to `vehicleRenderer` only on template failure
+
+#### Scenario: Vehicle armor diagram geometry
+
+- **GIVEN** a VTOL unit with a Rotor location
+- **WHEN** the vehicle is rendered through the templated path
+- **THEN** the output SVG SHALL include the canonical four-side armor
+  diagram AND the Rotor location block, with pips laid out from the
+  `vtol_*` template's region geometry
+
+#### Scenario: Aerospace 4-arc diagram
+
+- **GIVEN** any aerospace unit
+- **WHEN** the aerospace unit is rendered through the templated path
+- **THEN** the output SVG SHALL show armor pips for the Nose, Left
+  Wing, Right Wing, and Aft arcs as laid out by the
+  `fighter_aerospace` / `fighter_conventional` template geometry
+
+#### Scenario: BattleArmor per-trooper grid
+
+- **GIVEN** a 5-trooper Elemental point
+- **WHEN** the battlearmor renderer runs
+- **THEN** the output SVG SHALL show 5 distinct trooper columns, each
+  with its own armor pip grid and loadout section (skeleton renderer,
+  pending Wave 2 migration)
+
+#### Scenario: Infantry platoon counter (no per-location armor)
+
+- **GIVEN** a 28-trooper foot rifle platoon
+- **WHEN** the infantry renderer runs
+- **THEN** the output SVG SHALL show a platoon-size counter rather than
+  per-location armor pips, plus primary and secondary weapon blocks
+  (skeleton renderer, pending Wave 2 migration)
+
+#### Scenario: ProtoMech compact sheet
+
+- **GIVEN** a ProtoMech unit
+- **WHEN** the unit is rendered through the templated path
+- **THEN** the output SVG SHALL be derived from the matching
+  `protomek_biped` / `protomek_quad` / `protomek_glider` template with
+  the per-location armor and structure diagram laid out from template
+  geometry

--- a/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/tasks.md
+++ b/openspec/changes/add-templated-vehicle-aero-proto-record-sheets/tasks.md
@@ -1,0 +1,209 @@
+# Tasks: Add Templated Vehicle / Aerospace / ProtoMech Record Sheets
+
+Test infrastructure exists (Jest + `@swc/jest`). Tests are authored
+**alongside** implementation in each wave. The Phase-N pip-count
+fidelity tasks are the hard fidelity gate.
+
+## 0. Infra-First — Asset Registration and ID Catalog
+
+- [x] 0.1 Register the 10 Wave-1 non-mech templates in
+  `config/mm-data-assets.json` under both `templates_us` and
+  `templates_iso` pattern lists: `vehicle_noturret_standard.svg`,
+  `vehicle_turret_standard.svg`, `vehicle_dualturret_standard.svg`,
+  `vtol_noturret_standard.svg`, `vtol_turret_standard.svg`,
+  `fighter_aerospace_default.svg`, `fighter_conventional_default.svg`,
+  `protomek_biped.svg`, `protomek_quad.svg`, `protomek_glider.svg`.
+  - Acceptance: each of the 10 names appears in both pattern lists,
+    matching the existing `mek_*` registration shape.
+  - QA: `cat config/mm-data-assets.json` shows 20 new entries; JSON
+    parses (`node -e "JSON.parse(require('fs').readFileSync('config/mm-data-assets.json'))"`).
+- [x] 0.2 Run the asset-sync step (`npm run fetch:assets`) and confirm
+  the Wave-1 non-mech templates land in
+  `public/record-sheets/templates_us` and `templates_iso`.
+  - Acceptance: all 10 templates present in each of the two local
+    directories.
+  - QA: `ls public/record-sheets/templates_us | grep -cE 'vehicle_|vtol_|fighter_|protomek_'` returns 10.
+- [x] 0.3 Prove one vehicle template loads through
+  `MmDataAssetService` before any renderer code exists — a throwaway
+  spec or script that calls `loadSVG('templates_us/vehicle_turret_standard.svg')`.
+  - Acceptance: returns parseable SVG content, three-source fallback
+    chain confirmed reachable.
+  - QA: the load returns non-empty SVG; CDN fallback verified by
+    temporarily renaming the local file.
+- [x] 0.4 Extract the injectable `id=` set from each of the 10
+  canonical templates into a frozen typed const (one section per
+  family), grouped vehicle / aerospace / protomech.
+  - Acceptance: a typed `as const` catalog whose keys are the real
+    template element IDs.
+  - QA: `bun run typecheck` clean; spot-check 3 IDs per family against
+    the template SVG source.
+- [x] 0.5 Review the extracted ID catalog against the MegaMekLab
+  `Print*` Java field names (`PrintTank.java`, `PrintAero.java`,
+  `PrintProtoMek.java` in `E:/Projects/megameklab/.../printing/`).
+  - Acceptance: every binding target the adapters will use corresponds
+    to a documented `Print*` element ID; divergences noted in the
+    catalog file as comments.
+  - QA: review notes recorded; no unexplained ID in the catalog.
+
+## 1. Shared Template Renderer Core
+
+- [x] 1.1 Create `templateRecordSheetRenderer.ts` exposing
+  `loadTemplate(path)`, `applyBindings(texts)`, `applyPips(pipFills)`,
+  `getSVGString()`, reusing `loadSVGTemplate` / `setTextContent` /
+  canvas / jsPDF code paths verbatim.
+  - Acceptance: shared core compiles; no fork of mech-specific logic.
+  - QA: `bun run typecheck` clean.
+- [x] 1.2 Add the off-screen-mount helper: mount the parsed SVG into a
+  hidden DOM container before pip measurement, remove after
+  `getSVGString()`.
+  - Acceptance: mount/unmount lifecycle exposed and called by the
+    render path.
+  - QA: unit test asserts the SVG is attached to the document during
+    pip measurement and detached after.
+- [x] 1.3 Add `document.fonts.ready` await before any text-width
+  measurement in the shared core (web-font race mitigation).
+  - Acceptance: text measurement is gated on font readiness.
+  - QA: unit test or code review confirms the await precedes measure.
+- [x] 1.4 Refactor `SVGRecordSheetRenderer` (mech) into a thin consumer
+  of `TemplateRecordSheetRenderer` — no behavior change.
+  - Acceptance: mech renderer delegates template handling to the
+    shared core.
+  - QA: existing mech record-sheet snapshot tests pass with zero diff.
+- [x] 1.5 Unit tests for the shared core — `loadTemplate`,
+  `applyBindings`, `getSVGString`.
+  - Acceptance: bindings inject by element ID; absent IDs unchanged.
+  - QA: `bun test templateRecordSheetRenderer` green.
+
+## 2. Shared Dynamic Pip Engine
+
+- [x] 2.1 Promote the dynamic pip-layout logic from `armor.ts` into a
+  shared pip-engine module computing pip positions from template
+  `<rect>` region geometry via `getBBox()`.
+  - Acceptance: engine emits `count` pip elements within a region's
+    measured bounds.
+  - QA: unit test on a synthetic template `<rect>`.
+- [x] 2.2 Implement the `grouped`-layout element-lookup fallback:
+  retry `getElementById(id + "grouped")` when the primary ID is absent.
+  - Acceptance: grouped element resolved when primary missing.
+  - QA: unit test with a template region exposing only `<id>grouped`.
+- [x] 2.3 Expose the alternate-clustering flag from MegaMekLab
+  `ArmorPipLayout.java` so callers can request clustered placement.
+  - Acceptance: flag changes pip clustering; default matches the mech
+    path.
+  - QA: unit test toggles the flag and asserts placement differs.
+- [x] 2.4 Confirm `armor.ts` (mech) consumes the shared pip engine
+  with no behavior change.
+  - Acceptance: mech pip layout routes through the shared engine.
+  - QA: mech snapshot tests pass with zero diff.
+
+## 3. Vehicle / VTOL Family Adapter
+
+- [x] 3.1 Create `vehicle/selectTemplate.ts` — pure
+  `unit → templateKey` of form `{subtype}_{turret}_{weight}`, mirroring
+  `PrintTank.getSVGFileName()`. Wave-1 keys only:
+  `vehicle_{noturret,turret,dualturret}_standard`,
+  `vtol_{noturret,turret}_standard`.
+  - Acceptance: pure function, no I/O; correct key for each
+    subtype/turret combination in scope.
+  - QA: unit test covering all 5 Wave-1 vehicle/VTOL keys.
+- [x] 3.2 Create `vehicle/bindings.ts` — pure
+  `IVehicleRecordSheetData → { texts, pips }` against the Phase-0 ID
+  catalog, with a typed `PipCounts` computed from unit armor/structure
+  stats.
+  - Acceptance: `texts` bind only catalog IDs; `PipCounts` per-location
+    counts equal unit stats; VTOL Rotor location included.
+  - QA: unit test asserts `PipCounts` for a 50t tracked tank and a
+    VTOL fixture.
+- [x] 3.3 Pip-count fidelity test — parse the rendered vehicle SVG,
+  assert pip-element count per location equals the fixture's actual
+  armor/structure values.
+  - Acceptance: fidelity gate green for a turret tank and a VTOL.
+  - QA: `bun test vehicle` green; deliberately wrong fixture fails the
+    assertion.
+
+## 4. Aerospace / Conventional Fighter Family Adapter
+
+- [x] 4.1 Create `aerospace/selectTemplate.ts` — pure
+  `unit → templateKey`: `fighter_aerospace` / `fighter_conventional`.
+  - Acceptance: pure function; correct key for aerospace vs
+    conventional fighter.
+  - QA: unit test covering both keys.
+- [x] 4.2 Create `aerospace/bindings.ts` — pure
+  `IAerospaceRecordSheetData → { texts, pips }` against the Phase-0 ID
+  catalog, `PipCounts` for the 4 arcs (Nose / Left Wing / Right Wing /
+  Aft).
+  - Acceptance: `texts` bind only catalog IDs; `PipCounts` arc counts
+    equal unit armor stats.
+  - QA: unit test asserts `PipCounts` for an aerospace fighter fixture.
+- [x] 4.3 Pip-count fidelity test — parse the rendered aerospace SVG,
+  assert pip-element count per arc equals the fixture's armor values.
+  - Acceptance: fidelity gate green for both fighter types.
+  - QA: `bun test aerospace` green.
+
+## 5. ProtoMech Family Adapter
+
+- [x] 5.1 Create `protomech/selectTemplate.ts` — pure
+  `unit → templateKey`: `protomek_biped` / `protomek_quad` /
+  `protomek_glider`.
+  - Acceptance: pure function; correct key per ProtoMech configuration.
+  - QA: unit test covering all 3 keys.
+- [x] 5.2 Create `protomech/bindings.ts` — pure
+  `IProtoMechRecordSheetData → { texts, pips }` against the Phase-0 ID
+  catalog, `PipCounts` for the per-location armor/structure diagram.
+  - Acceptance: `texts` bind only catalog IDs; `PipCounts` per-location
+    counts equal unit stats.
+  - QA: unit test asserts `PipCounts` for biped, quad, glider fixtures.
+- [x] 5.3 Pip-count fidelity test — parse the rendered ProtoMech SVG,
+  assert pip-element count per location equals the fixture's
+  armor/structure values.
+  - Acceptance: fidelity gate green for all 3 ProtoMech configs.
+  - QA: `bun test protomech` green.
+
+## 6. Dispatch — Template-Primary With Skeleton Fallback
+
+- [x] 6.1 Add `renderTemplated` to `renderer.ts`: for vehicle /
+  aerospace / protomech units, select template → load via
+  `MmDataAssetService` → apply bindings + pips → return templated SVG.
+  - Acceptance: vehicle/aerospace/protomech route through the template
+    path.
+  - QA: integration test renders one unit per family via the template
+    path.
+- [x] 6.2 Wrap the template path in `try/catch`; on asset-load or
+  parse failure, invoke the existing family skeleton renderer and
+  return its SVG.
+  - Acceptance: a forced asset failure yields skeleton output, not a
+    blank/error sheet.
+  - QA: unit test stubs `loadSVG` to throw and asserts skeleton output
+    is returned.
+- [x] 6.3 Confirm the `renderRecordSheetSVG` `switch` routes mech to
+  the refactored consumer, vehicle/aerospace/protomech to
+  `renderTemplated`, infantry/battlearmor unchanged to skeleton.
+  - Acceptance: dispatch table correct for all 7 families.
+  - QA: dispatch unit test per `unitType`.
+- [x] 6.4 Verify the customizer Save PDF path
+  (`PreviewTab.handleExportPDF` → `RecordSheetService.exportPDF`)
+  renders the three families through the templated path.
+  - Acceptance: Save PDF for a vehicle, an aerospace fighter, and a
+    ProtoMech produces a templated PDF.
+  - QA: dev-browser — open each unit type in the customizer, click
+    Save PDF, confirm the PDF matches the canonical template layout
+    (header fields populated, pips drawn).
+
+## 7. Final Verification Wave
+
+- [x] F1 Typecheck + lint clean across all touched files
+  (`bun run typecheck`, `bun run lint`).
+- [x] F2 All unit + integration tests pass, including the three
+  per-family pip-count fidelity tests and the unchanged mech snapshot
+  tests (`bun test`).
+- [x] F3 Manual QA — Save PDF from the customizer for a vehicle, a
+  VTOL, an aerospace fighter, a conventional fighter, and all three
+  ProtoMech configs (`templates_us` and `templates_iso`); confirm
+  canonical layout and correct pip counts.
+- [x] F4 Forced-failure QA — block asset loading and confirm each
+  family degrades to its skeleton renderer rather than producing a
+  blank PDF.
+- [x] F5 `omo-spec-verifier` confirms every SHALL/MUST in the two
+  delta specs has implementation and test coverage.
+- [x] F6 `openspec validate add-templated-vehicle-aero-proto-record-sheets --strict`
+  passes.

--- a/openspec/specs/mm-data-asset-integration/spec.md
+++ b/openspec/specs/mm-data-asset-integration/spec.md
@@ -8,9 +8,15 @@ TBD - created by archiving change integrate-mm-data-assets. Update Purpose after
 
 ### Requirement: MmData Asset Service
 
-The system SHALL provide a service for loading and caching assets from the mm-data distribution.
+The system SHALL provide a service for loading and caching assets from
+the mm-data distribution, covering mech templates, the Wave-1 non-mech
+templates (vehicle / VTOL / aerospace / conventional-fighter /
+ProtoMech), the biped armor and structure pips, and any non-mech pip
+directories required by the Wave-1 templates.
 
-**Rationale**: Centralized asset loading enables consistent access to MegaMek visual assets across components.
+**Rationale**: Centralized asset loading enables consistent access to
+MegaMek visual assets across components, and the same three-source
+fallback chain that serves mech templates serves the non-mech families.
 
 **Priority**: Critical
 
@@ -39,10 +45,21 @@ The system SHALL provide a service for loading and caching assets from the mm-da
 
 #### Scenario: Record sheet template loading
 
-- **GIVEN** a MechConfiguration and paper size
-- **WHEN** `MmDataAssetService.getRecordSheetTemplate(config, paperSize)` is called
+- **GIVEN** a unit configuration and paper size
+- **WHEN** the record-sheet template for that unit is requested
 - **THEN** return the SVG template document
-- **AND** file is loaded from appropriate templates directory
+- **AND** the file is loaded from the appropriate `templates_us` or
+  `templates_iso` directory, covering both mech and Wave-1 non-mech
+  template keys
+
+#### Scenario: Non-mech template loading via shared renderer
+
+- **GIVEN** a Wave-1 non-mech template key resolved by a per-family
+  `selectTemplate` adapter
+- **WHEN** `TemplateRecordSheetRenderer.loadTemplate(path)` requests
+  that template
+- **THEN** `MmDataAssetService.loadSVG` SHALL resolve it through the
+  three-source fallback chain and the result SHALL be cached
 
 #### Scenario: Location code mapping
 
@@ -114,3 +131,98 @@ The system SHALL define click target bounds for each armor location.
 - **WHEN** MegaMek Classic diagram renders for TRIPOD configuration
 - **THEN** click targets SHALL use TripodLocationBounds
 - **AND** includes CENTER_LEG with appropriate bounds
+
+### Requirement: Non-Mech Wave-1 Template Registration
+
+The system SHALL register the Wave-1 non-mech canonical record-sheet
+templates in `config/mm-data-assets.json` so that `MmDataAssetService`
+can resolve them through its existing three-source fallback chain
+(local `/record-sheets/<path>` → jsDelivr CDN → GitHub raw).
+
+The registered Wave-1 templates SHALL be:
+`vehicle_noturret_standard.svg`, `vehicle_turret_standard.svg`,
+`vehicle_dualturret_standard.svg`, `vtol_noturret_standard.svg`,
+`vtol_turret_standard.svg`, `fighter_aerospace_default.svg`,
+`fighter_conventional_default.svg`, `protomek_biped.svg`,
+`protomek_quad.svg`, and `protomek_glider.svg`.
+
+Each template SHALL be registered under **both** the `templates_us`
+(US Letter) and `templates_iso` (A4) directories, matching the existing
+`mek_*` registration pattern.
+
+The asset-sync script SHALL copy the registered Wave-1 non-mech
+templates into `public/record-sheets/templates_us` and
+`public/record-sheets/templates_iso` alongside the existing mech
+templates.
+
+**Priority**: Critical
+
+#### Scenario: Wave-1 vehicle template resolves locally
+
+- **GIVEN** the Wave-1 templates registered in `config/mm-data-assets.json`
+  and synced to `public/record-sheets/templates_us`
+- **WHEN** `MmDataAssetService.loadSVG('templates_us/vehicle_turret_standard.svg')`
+  is called
+- **THEN** it SHALL return the canonical template SVG content from the
+  local path
+
+#### Scenario: Wave-1 template falls back to CDN
+
+- **GIVEN** a registered Wave-1 template absent from the local
+  `public/record-sheets` directory
+- **WHEN** `MmDataAssetService.loadSVG` resolves that template
+- **THEN** it SHALL fall back to the jsDelivr CDN source, then the
+  GitHub raw source, before failing
+
+#### Scenario: Both paper sizes are registered
+
+- **GIVEN** the Wave-1 template registration
+- **WHEN** `config/mm-data-assets.json` is read
+- **THEN** every Wave-1 non-mech template SHALL appear in both the
+  `templates_us` and `templates_iso` pattern lists
+
+#### Scenario: Asset sync copies non-mech templates
+
+- **GIVEN** the mm-data repository present at the expected relative path
+- **WHEN** the asset-sync script runs
+- **THEN** it SHALL copy each registered Wave-1 non-mech template into
+  both `public/record-sheets/templates_us` and
+  `public/record-sheets/templates_iso`, and report them in the synced
+  file count
+
+### Requirement: Canonical Template Element ID Catalog
+
+The system SHALL maintain a frozen typed constant capturing the
+injectable `id=` element set of each Wave-1 canonical template.
+
+The catalog SHALL be derived by extracting `id=` attributes from each
+registered canonical template SVG, and SHALL be reviewed against the
+corresponding MegaMekLab `Print*` Java class field names
+(`PrintTank`, `PrintAero`, `PrintProtoMek`) to confirm the binding
+targets are correct.
+
+The per-family `bindings.ts` adapters SHALL bind only against element
+IDs present in this catalog.
+
+**Priority**: High
+
+#### Scenario: Element ID catalog is frozen and typed
+
+- **GIVEN** the extracted element-ID catalog
+- **WHEN** it is consumed by a `bindings.ts` adapter
+- **THEN** the catalog SHALL be a frozen typed constant whose keys are
+  the canonical template element IDs
+
+#### Scenario: Catalog reviewed against MegaMekLab field names
+
+- **GIVEN** the `vehicle` family element-ID catalog
+- **WHEN** it is reviewed against `PrintTank.java`
+- **THEN** every binding target used by the vehicle `bindings.ts`
+  adapter SHALL correspond to a documented `PrintTank` element ID
+
+#### Scenario: Bindings reject unknown element IDs
+
+- **GIVEN** a `bindings.ts` adapter and the element-ID catalog
+- **WHEN** the adapter is authored or modified
+- **THEN** it SHALL only reference IDs present in the catalog, so a
+  typo against a non-existent template ID is caught at type-check time

--- a/openspec/specs/record-sheet-export/spec.md
+++ b/openspec/specs/record-sheet-export/spec.md
@@ -602,7 +602,20 @@ The `IRecordSheetData` type SHALL be a discriminated union tagged on `unitType`,
 
 ### Requirement: Per-Type SVG Renderers
 
-The system SHALL provide a dedicated SVG renderer module per unit type, each consuming its matching `IRecordSheetData` variant and producing an SVG string conforming to the canonical Total Warfare record-sheet layout for that type.
+The system SHALL provide record-sheet rendering per unit type. For the
+mech, vehicle, VTOL, support-vehicle, aerospace, conventional-fighter,
+and ProtoMech families, rendering SHALL use the canonical mm-data
+template path via the shared `TemplateRecordSheetRenderer` and shared
+pip engine. For the infantry and battle-armor families, rendering MAY
+continue to use the dedicated skeleton renderer module until a future
+wave migrates them.
+
+Each family's templated rendering SHALL consume its matching
+`IRecordSheetData` variant, select a canonical template, apply text
+bindings and dynamic pips, and produce an SVG conforming to the
+canonical Total Warfare record-sheet layout for that type. The vehicle,
+aerospace, and protomech skeleton renderers SHALL remain available as
+the runtime fallback.
 
 **Priority**: Critical
 
@@ -610,37 +623,49 @@ The system SHALL provide a dedicated SVG renderer module per unit type, each con
 
 - **GIVEN** an `IVehicleRecordSheetData` payload
 - **WHEN** the top-level `renderer.ts` dispatcher is called
-- **THEN** it SHALL delegate to `vehicleRenderer.render(data)` and return the resulting SVG
+- **THEN** it SHALL route to the templated path for the vehicle family,
+  falling back to `vehicleRenderer` only on template failure
 
 #### Scenario: Vehicle armor diagram geometry
 
-- **GIVEN** a VTOL unit with Rotor location
-- **WHEN** the vehicle renderer runs
-- **THEN** the output SVG SHALL include both a standard 4-side armor diagram AND a separate Rotor location block
+- **GIVEN** a VTOL unit with a Rotor location
+- **WHEN** the vehicle is rendered through the templated path
+- **THEN** the output SVG SHALL include the canonical four-side armor
+  diagram AND the Rotor location block, with pips laid out from the
+  `vtol_*` template's region geometry
 
 #### Scenario: Aerospace 4-arc diagram
 
 - **GIVEN** any aerospace unit
-- **WHEN** the aerospace renderer runs
-- **THEN** the output SVG SHALL show armor pips for Nose, Left Wing, Right Wing, Aft arcs — no front/rear as mechs use
+- **WHEN** the aerospace unit is rendered through the templated path
+- **THEN** the output SVG SHALL show armor pips for the Nose, Left
+  Wing, Right Wing, and Aft arcs as laid out by the
+  `fighter_aerospace` / `fighter_conventional` template geometry
 
 #### Scenario: BattleArmor per-trooper grid
 
 - **GIVEN** a 5-trooper Elemental point
 - **WHEN** the battlearmor renderer runs
-- **THEN** the output SVG SHALL show 5 distinct trooper columns, each with its own armor pip grid and loadout section
+- **THEN** the output SVG SHALL show 5 distinct trooper columns, each
+  with its own armor pip grid and loadout section (skeleton renderer,
+  pending Wave 2 migration)
 
 #### Scenario: Infantry platoon counter (no per-location armor)
 
 - **GIVEN** a 28-trooper foot rifle platoon
 - **WHEN** the infantry renderer runs
-- **THEN** the output SVG SHALL show a platoon-size counter rather than per-location armor pips, plus primary + secondary weapon blocks
+- **THEN** the output SVG SHALL show a platoon-size counter rather than
+  per-location armor pips, plus primary and secondary weapon blocks
+  (skeleton renderer, pending Wave 2 migration)
 
-#### Scenario: ProtoMech 5-location compact sheet
+#### Scenario: ProtoMech compact sheet
 
-- **GIVEN** a 5-proto point
-- **WHEN** the protomech renderer runs
-- **THEN** the output SVG SHALL render 5 compact per-proto sheets on one page, each with the 5-location (Head/Torso/LA/RA/Legs/±MainGun) diagram
+- **GIVEN** a ProtoMech unit
+- **WHEN** the unit is rendered through the templated path
+- **THEN** the output SVG SHALL be derived from the matching
+  `protomek_biped` / `protomek_quad` / `protomek_glider` template with
+  the per-location armor and structure diagram laid out from template
+  geometry
 
 ---
 
@@ -701,4 +726,227 @@ Every per-type renderer SHALL have at least one Jest snapshot test with a repres
 - **GIVEN** the vehicle renderer's snapshot test running on a 50t tracked tank fixture
 - **WHEN** the armor location geometry changes (e.g., a location is accidentally removed)
 - **THEN** the snapshot assertion SHALL fail with a diff showing the missing location
+
+---
+
+### Requirement: Shared Template Record Sheet Renderer
+
+The system SHALL provide a shared `TemplateRecordSheetRenderer` module in
+`src/services/printing/svgRecordSheetRenderer/` that owns the
+canonical-template rendering pipeline independent of unit type.
+
+The shared renderer SHALL expose `loadTemplate(path)`,
+`applyBindings(texts)`, `applyPips(pipFills)`, and `getSVGString()`. It
+SHALL reuse the existing `loadSVGTemplate`, `setTextContent`, canvas
+rasterization, and jsPDF code paths verbatim — no fork of the proven
+mech logic.
+
+The mech renderer `SVGRecordSheetRenderer` SHALL be refactored into a
+thin consumer of `TemplateRecordSheetRenderer` with no observable
+change to its rendered output.
+
+**Priority**: Critical
+
+#### Scenario: Shared renderer loads a canonical template
+
+- **GIVEN** a registered template path `templates_us/vehicle_turret_standard.svg`
+- **WHEN** `TemplateRecordSheetRenderer.loadTemplate(path)` is called
+- **THEN** it SHALL fetch the SVG through `MmDataAssetService.loadSVG`
+  and parse it into a DOM document using the same `DOMParser` path the
+  mech renderer uses
+
+#### Scenario: Shared renderer injects text bindings by element ID
+
+- **GIVEN** a loaded template and a `texts` map keyed by element ID
+- **WHEN** `applyBindings(texts)` is called
+- **THEN** for each entry it SHALL locate the element via
+  `getElementById` and set `textContent`, leaving elements absent from
+  the map unchanged
+
+#### Scenario: Mech path is behaviour-preserving after refactor
+
+- **GIVEN** the mech renderer refactored to consume `TemplateRecordSheetRenderer`
+- **WHEN** the existing mech record-sheet snapshot tests run
+- **THEN** every mech snapshot SHALL match its committed baseline with
+  no diff
+
+---
+
+### Requirement: Shared Dynamic Pip Engine
+
+The system SHALL provide a shared pip engine that computes armor and
+structure pip positions from a template's `<rect>` region geometry,
+generalizing the dynamic layout logic currently in `armor.ts`.
+
+The pip engine SHALL support the `grouped`-layout element-lookup
+fallback: when a region's primary element ID is absent, it SHALL retry
+with `getElementById(id + "grouped")`, mirroring MegaMekLab
+`PrintEntity.java`. It SHALL expose the alternate-clustering flag from
+MegaMekLab `ArmorPipLayout.java` so callers can request clustered pip
+placement.
+
+The pip engine SHALL require the template SVG to be mounted in a live
+DOM before measurement, because region rect geometry is read via
+`getBBox()`.
+
+**Priority**: Critical
+
+#### Scenario: Pip positions computed from region geometry
+
+- **GIVEN** a template with an armor region `<rect>` for a location
+  and an armor count for that location
+- **WHEN** the pip engine lays out that location
+- **THEN** it SHALL emit exactly `count` pip elements positioned within
+  the region rect's measured bounds
+
+#### Scenario: Grouped-layout fallback resolves alternate IDs
+
+- **GIVEN** a template region whose primary element ID is absent but
+  whose `<id>grouped` element exists
+- **WHEN** the pip engine resolves that region
+- **THEN** it SHALL use the `grouped` element and lay out pips against it
+
+#### Scenario: Pip measurement requires a live-mounted SVG
+
+- **GIVEN** a template SVG that has not been mounted into the document
+- **WHEN** the pip engine attempts region measurement
+- **THEN** it SHALL require the SVG be mounted off-screen first, and
+  the renderer SHALL perform that mount before invoking the pip engine
+
+---
+
+### Requirement: Per-Family Record Sheet Adapters
+
+The system SHALL provide one adapter folder per Wave-1 family
+(`vehicle/`, `aerospace/`, `protomech/`) under
+`src/services/printing/svgRecordSheetRenderer/`, each containing two
+pure modules: `selectTemplate.ts` and `bindings.ts`.
+
+`selectTemplate.ts` SHALL be a pure function mapping a unit to a
+`templateKey` string. `bindings.ts` SHALL be a pure function mapping
+the unit's `IRecordSheetData` variant to a `{ texts, pips }` structure
+keyed against the template's real element IDs, including a typed
+per-family `PipCounts` contract computed from unit stats.
+
+Neither adapter module SHALL perform I/O, DOM access, or asset
+loading — they SHALL be deterministic pure functions.
+
+**Priority**: Critical
+
+#### Scenario: Vehicle template key mirrors PrintTank
+
+- **GIVEN** a turret-equipped tracked combat vehicle in the standard
+  weight tier
+- **WHEN** the vehicle `selectTemplate` runs
+- **THEN** it SHALL return the key `vehicle_turret_standard`, following
+  the `{subtype}_{turret}_{weight}` form of MegaMekLab
+  `PrintTank.getSVGFileName()`
+
+#### Scenario: VTOL template key selection
+
+- **GIVEN** a VTOL with no turret
+- **WHEN** the vehicle `selectTemplate` runs
+- **THEN** it SHALL return the key `vtol_noturret_standard`
+
+#### Scenario: Aerospace template key selection
+
+- **GIVEN** a conventional fighter
+- **WHEN** the aerospace `selectTemplate` runs
+- **THEN** it SHALL return the key `fighter_conventional`; an aerospace
+  fighter SHALL return `fighter_aerospace`
+
+#### Scenario: ProtoMech template key selection
+
+- **GIVEN** a glider-configuration ProtoMech
+- **WHEN** the protomech `selectTemplate` runs
+- **THEN** it SHALL return the key `protomek_glider`; biped and quad
+  ProtoMechs SHALL return `protomek_biped` and `protomek_quad`
+  respectively
+
+#### Scenario: Bindings produce a typed PipCounts contract
+
+- **GIVEN** a vehicle `IRecordSheetData` with per-location armor and
+  structure values
+- **WHEN** the vehicle `bindings` function runs
+- **THEN** the returned `pips` SHALL include a typed `PipCounts`
+  structure whose per-location counts equal the unit's actual armor and
+  structure point values
+
+---
+
+### Requirement: Template-Primary Rendering With Skeleton Fallback
+
+The system SHALL render Wave-1 non-mech families through the canonical
+template path by default, and SHALL fall back to the existing skeleton
+renderer for that family when the template path fails.
+
+`renderer.ts` SHALL expose a `renderTemplated` path that, for vehicle /
+aerospace / protomech units, selects the template, loads it via
+`MmDataAssetService`, applies bindings and pips, and returns the
+templated SVG. The template path SHALL be wrapped in `try/catch`; on
+asset-load failure or template-parse failure it SHALL invoke the
+existing skeleton renderer for that family and return the skeleton SVG.
+
+The skeleton renderers SHALL NOT be deleted or modified by this change.
+
+**Priority**: Critical
+
+#### Scenario: Vehicle renders via canonical template
+
+- **GIVEN** a vehicle unit and a reachable `vehicle_turret_standard`
+  template asset
+- **WHEN** `renderTemplated` runs for that unit
+- **THEN** the output SVG SHALL be derived from the canonical template,
+  with header bindings and dynamically laid-out armor pips
+
+#### Scenario: Asset failure degrades to skeleton renderer
+
+- **GIVEN** a vehicle unit and a template asset that fails to load
+  from local, CDN, and raw sources
+- **WHEN** `renderTemplated` runs for that unit
+- **THEN** it SHALL catch the failure and return the output of the
+  existing `vehicleRenderer` skeleton renderer
+
+#### Scenario: Customizer Save PDF uses the templated path
+
+- **GIVEN** a vehicle, aerospace, or protomech unit open in the
+  customizer
+- **WHEN** the user invokes Save PDF via `PreviewTab.handleExportPDF`
+- **THEN** `RecordSheetService.exportPDF` SHALL render through the
+  templated path, with skeleton fallback on failure
+
+---
+
+### Requirement: Per-Family Pip-Count Fidelity Gate
+
+Each Wave-1 family adapter SHALL have a test that parses the rendered
+output SVG and asserts the count of pip elements per location matches
+the unit's actual armor and structure statistics.
+
+**Priority**: Critical
+
+#### Scenario: Vehicle pip count matches armor stats
+
+- **GIVEN** a vehicle fixture with known per-location armor and
+  structure point values
+- **WHEN** the vehicle is rendered through the templated path and the
+  output SVG is parsed
+- **THEN** the pip-element count for each location SHALL equal that
+  location's armor or structure point value from the fixture
+
+#### Scenario: Aerospace arc pip count matches armor stats
+
+- **GIVEN** an aerospace fixture with known Nose / Left Wing / Right
+  Wing / Aft armor values
+- **WHEN** the unit is rendered and the output SVG is parsed
+- **THEN** the pip-element count per arc SHALL equal that arc's armor
+  value
+
+#### Scenario: ProtoMech pip count matches armor stats
+
+- **GIVEN** a ProtoMech fixture with known per-location armor and
+  structure values
+- **WHEN** the unit is rendered and the output SVG is parsed
+- **THEN** the pip-element count per location SHALL equal that
+  location's armor or structure value
 


### PR DESCRIPTION
## Summary

Final spec-sync for the OpenSpec change `add-templated-vehicle-aero-proto-record-sheets` (implementation shipped in #579–#583).

- **`record-sheet-export`** — 5 ADDED requirements merged (Shared Template Record Sheet Renderer, Shared Dynamic Pip Engine, Per-Family Record Sheet Adapters, Template-Primary Rendering With Skeleton Fallback, Per-Family Pip-Count Fidelity Gate); the MODIFIED `Per-Type SVG Renderers` requirement widened to the templated path.
- **`mm-data-asset-integration`** — 2 ADDED requirements merged (Non-Mech Wave-1 Template Registration, Canonical Template Element ID Catalog); the MODIFIED `MmData Asset Service` requirement widened to cover the Wave-1 non-mech templates.
- **`design.md`** gains a "Decisions discovered during execution" section graduating 5 execution-time decisions.
- Commits the OpenSpec change artifacts (proposal / design / tasks / notepad / delta specs); the change folder remains in `openspec/changes/` until archive.

## Test plan

- [x] `npx openspec validate add-templated-vehicle-aero-proto-record-sheets --strict` — valid
- [x] Source-of-truth specs validate; 7 new requirements present, 2 MODIFIED replaced in place
- [x] openspec-only change — pre-commit build hook correctly skipped