### PR TITLE
test(customizer): cover secondary-turret tab UI + aerospace subType propagation

### DIFF
--- a/src/components/customizer/aerospace/__tests__/AerospaceArmorDiagram.test.tsx
+++ b/src/components/customizer/aerospace/__tests__/AerospaceArmorDiagram.test.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 
 import { useAerospaceStore, AerospaceStore } from '@/stores/useAerospaceStore';
 import { AerospaceLocation } from '@/types/construction/UnitLocation';
+import { AerospaceSubType } from '@/types/unit/AerospaceInterfaces';
 
 import { AerospaceArmorDiagram } from '../AerospaceArmorDiagram';
 
@@ -79,5 +80,44 @@ describe('AerospaceArmorDiagram', () => {
   it('renders SI label containing Structural Integrity text', () => {
     render(<AerospaceArmorDiagram />);
     expect(screen.getByText('Structural Integrity')).toBeInTheDocument();
+  });
+});
+
+describe('AerospaceArmorDiagram — subType propagation', () => {
+  // Regression guard (council audit 2026-05-15): the diagram's per-arc caps
+  // must be driven by the store's aerospaceSubType. If the subType wire is
+  // lost or hardcoded, arc caps silently diverge from the unit's actual type.
+  function lwInput() {
+    return screen.getByTestId(
+      `aerospace-arc-diagram-input-${AerospaceLocation.LEFT_WING}`,
+    );
+  }
+
+  it('applies the ASF wing factor when the store subType is AEROSPACE_FIGHTER', () => {
+    mockUseAerospaceStore.mockImplementation((selector) =>
+      selector(
+        makeState({
+          aerospaceSubType: AerospaceSubType.AEROSPACE_FIGHTER,
+        }) as unknown as AerospaceStore,
+      ),
+    );
+    render(<AerospaceArmorDiagram />);
+    // 50t × 0.20 wing factor = 10
+    expect(lwInput()).toHaveAttribute('max', '10');
+  });
+
+  it('drops the wing cap to 0 when the store subType is SMALL_CRAFT', () => {
+    // Small craft carry side arcs, not wings — the wing location yields 0
+    // through the enum bridge. A non-zero here would mean the diagram ignored
+    // the store subType.
+    mockUseAerospaceStore.mockImplementation((selector) =>
+      selector(
+        makeState({
+          aerospaceSubType: AerospaceSubType.SMALL_CRAFT,
+        }) as unknown as AerospaceStore,
+      ),
+    );
+    render(<AerospaceArmorDiagram />);
+    expect(lwInput()).toHaveAttribute('max', '0');
   });
 });

--- a/src/components/customizer/vehicle/__tests__/VehicleTurretTab.test.tsx
+++ b/src/components/customizer/vehicle/__tests__/VehicleTurretTab.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for VehicleTurretTab.
+ *
+ * Coverage gap closed (council audit 2026-05-15): the secondary-turret /
+ * TURRET_2 toggle UI in this tab had no test. The store logic is covered by
+ * useVehicleStore.secondaryTurret.test.ts and the diagram by
+ * VehicleArmorDiagram.test.tsx — but the tab that wires the toggle and the
+ * secondary-turret-type select to those store actions was untested.
+ *
+ * Validates:
+ *  - secondary-turret toggle is gated on `!isVTOL && hasTurret`
+ *  - toggling it dispatches setHasSecondaryTurret
+ *  - the secondary-turret-type select appears only when a secondary turret is
+ *    configured and dispatches setSecondaryTurretType
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { useVehicleStore, VehicleStore } from '@/stores/useVehicleStore';
+import { GroundMotionType } from '@/types/unit/BaseUnitInterfaces';
+import {
+  ITurretConfiguration,
+  TurretType,
+} from '@/types/unit/VehicleInterfaces';
+
+import { VehicleTurretTab } from '../VehicleTurretTab';
+
+jest.mock('@/stores/useVehicleStore');
+const mockUseVehicleStore = useVehicleStore as jest.MockedFunction<
+  typeof useVehicleStore
+>;
+
+const setHasSecondaryTurret = jest.fn();
+const setSecondaryTurretType = jest.fn();
+
+function turretConfig(
+  type: TurretType = TurretType.SINGLE,
+): ITurretConfiguration {
+  return { type, maxWeight: 5, currentWeight: 0, rotationArc: 360 };
+}
+
+function makeState(overrides: Record<string, unknown> = {}) {
+  return {
+    tonnage: 50,
+    motionType: GroundMotionType.TRACKED,
+    turret: turretConfig(),
+    secondaryTurret: null,
+    equipment: [],
+    setTurretType: jest.fn(),
+    setHasSecondaryTurret,
+    setSecondaryTurretType,
+    updateEquipmentLocation: jest.fn(),
+    ...overrides,
+  };
+}
+
+function renderWithState(overrides: Record<string, unknown> = {}) {
+  mockUseVehicleStore.mockImplementation((selector) =>
+    selector(makeState(overrides) as unknown as VehicleStore),
+  );
+  return render(<VehicleTurretTab />);
+}
+
+beforeEach(() => {
+  setHasSecondaryTurret.mockClear();
+  setSecondaryTurretType.mockClear();
+});
+
+describe('VehicleTurretTab — secondary turret', () => {
+  it('hides the secondary turret toggle when there is no primary turret', () => {
+    renderWithState({ turret: null });
+    expect(
+      screen.queryByTestId('vehicle-secondary-turret-toggle'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides the secondary turret toggle for a VTOL (chin turrets only)', () => {
+    renderWithState({ motionType: GroundMotionType.VTOL });
+    expect(
+      screen.queryByTestId('vehicle-secondary-turret-toggle'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows an unchecked toggle for a ground vehicle with a primary turret', () => {
+    renderWithState();
+    const toggle = screen.getByTestId('vehicle-secondary-turret-toggle');
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).not.toBeChecked();
+  });
+
+  it('dispatches setHasSecondaryTurret when the toggle is clicked', () => {
+    renderWithState();
+    fireEvent.click(screen.getByTestId('vehicle-secondary-turret-toggle'));
+    expect(setHasSecondaryTurret).toHaveBeenCalledWith(true);
+  });
+
+  it('shows the secondary-turret-type select and dispatches setSecondaryTurretType', () => {
+    renderWithState({ secondaryTurret: turretConfig(TurretType.SINGLE) });
+    const select = screen.getByTestId('vehicle-secondary-turret-type');
+    expect(select).toBeInTheDocument();
+    fireEvent.change(select, { target: { value: TurretType.DUAL } });
+    expect(setSecondaryTurretType).toHaveBeenCalledWith(TurretType.DUAL);
+  });
+
+  it('hides the secondary-turret-type select when no secondary turret is set', () => {
+    renderWithState();
+    expect(
+      screen.queryByTestId('vehicle-secondary-turret-type'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/utils/construction/aerospace/__tests__/armorArcCalculations.test.ts
+++ b/src/utils/construction/aerospace/__tests__/armorArcCalculations.test.ts
@@ -110,6 +110,17 @@ describe('arcMaxMap', () => {
     expect(map[AerospaceArc.RIGHT_WING]).toBe(10);
     expect(map[AerospaceArc.AFT]).toBe(6);
   });
+
+  it('returns non-zero side arcs for small craft (regression: side factors must not collapse to 0)', () => {
+    // Guards the SMALL_CRAFT_ARC_FACTORS table: if a side factor is ever
+    // zeroed, a small craft silently loses its side-arc armor cap and a
+    // player can "build" one with no side armor and no validation error.
+    const map = arcMaxMap(200, AerospaceSubType.SMALL_CRAFT);
+    expect(map[AerospaceArc.NOSE]).toBe(56);
+    expect(map[AerospaceArc.LEFT_SIDE]).toBe(40);
+    expect(map[AerospaceArc.RIGHT_SIDE]).toBe(40);
+    expect(map[AerospaceArc.AFT]).toBe(24);
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Closes the two test-coverage gaps the OMO Council surfaced in its customizer test audit (2026-05-15).

- **`VehicleTurretTab.tsx` had no test** — the tab wires the secondary-turret (TURRET_2) toggle and the secondary-turret-type select to `setHasSecondaryTurret` / `setSecondaryTurretType`. The store logic was tested (`useVehicleStore.secondaryTurret.test.ts`) and the diagram was tested (`VehicleArmorDiagram.test.tsx`), but the tab that connects them was not. Adds `VehicleTurretTab.test.tsx` — 6 cases covering toggle gating (`!isVTOL && hasTurret`), toggle dispatch, and the type-select appearance + dispatch.
- **Aerospace small-craft subType propagation** — the diagram's per-arc caps are driven by the store `aerospaceSubType`; a wrong subType silently collapses side/wing caps with no validation error. Adds an `arcMaxMap` small-craft regression assertion and two `AerospaceArmorDiagram` tests proving the diagram's caps are genuinely driven by the store subType.

Test-only change — no production code touched.

## Test plan

- [x] `npx jest` — all 3 files green (31 tests, 8 new)
- [x] oxlint + oxfmt clean
- [x] pre-push full build passed