### PR TITLE
feat(record-sheet): templated infantry / battle-armor record sheets (Wave 2)

### DIFF
--- a/config/mm-data-assets.json
+++ b/config/mm-data-assets.json
@@ -41,7 +41,12 @@
       "fighter_conventional_default.svg",
       "protomek_biped.svg",
       "protomek_quad.svg",
-      "protomek_glider.svg"
+      "protomek_glider.svg",
+      "conventional_infantry_default.svg",
+      "conventional_infantry_platoon.svg",
+      "conventional_infantry_tables.svg",
+      "battle_armor_default.svg",
+      "battle_armor_squad.svg"
     ],
     "templates_iso": [
       "mek_biped_default.svg",
@@ -63,7 +68,12 @@
       "fighter_conventional_default.svg",
       "protomek_biped.svg",
       "protomek_quad.svg",
-      "protomek_glider.svg"
+      "protomek_glider.svg",
+      "conventional_infantry_default.svg",
+      "conventional_infantry_platoon.svg",
+      "conventional_infantry_tables.svg",
+      "battle_armor_default.svg",
+      "battle_armor_squad.svg"
     ]
   }
 }

--- a/openspec/.sessions/add-templated-infantry-battlearmor-record-sheets.json
+++ b/openspec/.sessions/add-templated-infantry-battlearmor-record-sheets.json
@@ -2,14 +2,17 @@
   "active_change": "add-templated-infantry-battlearmor-record-sheets",
   "started_at": "2026-05-15T20:00:00Z",
   "branch": "feat/templated-infantry-ba-record-sheets",
-  "current_wave": 6,
+  "current_wave": "complete",
   "completed_tasks": [
     "0.1", "0.2", "0.3", "0.4", "0.5", "0.6",
     "1.1", "1.2", "1.3", "1.4", "1.5", "1.6",
     "2.1", "2.2", "2.3",
     "3.1", "3.2", "3.3",
     "4.1", "4.2", "4.3",
-    "5.1", "5.2", "5.3", "5.4", "5.5", "5.6"
+    "5.1", "5.2", "5.3", "5.4", "5.5", "5.6",
+    "F1", "F2", "F3", "F4", "F5", "F6"
   ],
-  "in_progress_tasks": ["F1", "F2", "F3", "F4", "F5", "F6"]
+  "in_progress_tasks": [],
+  "deltas_merged": true,
+  "ready_to_archive": true
 }

--- a/openspec/.sessions/add-templated-infantry-battlearmor-record-sheets.json
+++ b/openspec/.sessions/add-templated-infantry-battlearmor-record-sheets.json
@@ -2,7 +2,10 @@
   "active_change": "add-templated-infantry-battlearmor-record-sheets",
   "started_at": "2026-05-15T20:00:00Z",
   "branch": "feat/templated-infantry-ba-record-sheets",
-  "current_wave": 0,
-  "completed_tasks": [],
-  "in_progress_tasks": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6"]
+  "current_wave": 2,
+  "completed_tasks": [
+    "0.1", "0.2", "0.3", "0.4", "0.5", "0.6",
+    "1.1", "1.2", "1.3", "1.4", "1.5", "1.6"
+  ],
+  "in_progress_tasks": ["2.1", "2.2", "2.3"]
 }

--- a/openspec/.sessions/add-templated-infantry-battlearmor-record-sheets.json
+++ b/openspec/.sessions/add-templated-infantry-battlearmor-record-sheets.json
@@ -2,10 +2,11 @@
   "active_change": "add-templated-infantry-battlearmor-record-sheets",
   "started_at": "2026-05-15T20:00:00Z",
   "branch": "feat/templated-infantry-ba-record-sheets",
-  "current_wave": 2,
+  "current_wave": 3,
   "completed_tasks": [
     "0.1", "0.2", "0.3", "0.4", "0.5", "0.6",
-    "1.1", "1.2", "1.3", "1.4", "1.5", "1.6"
+    "1.1", "1.2", "1.3", "1.4", "1.5", "1.6",
+    "2.1", "2.2", "2.3"
   ],
-  "in_progress_tasks": ["2.1", "2.2", "2.3"]
+  "in_progress_tasks": ["3.1", "3.2", "3.3", "4.1", "4.2", "4.3"]
 }

--- a/openspec/.sessions/add-templated-infantry-battlearmor-record-sheets.json
+++ b/openspec/.sessions/add-templated-infantry-battlearmor-record-sheets.json
@@ -1,0 +1,8 @@
+{
+  "active_change": "add-templated-infantry-battlearmor-record-sheets",
+  "started_at": "2026-05-15T20:00:00Z",
+  "branch": "feat/templated-infantry-ba-record-sheets",
+  "current_wave": 0,
+  "completed_tasks": [],
+  "in_progress_tasks": ["0.1", "0.2", "0.3", "0.4", "0.5", "0.6"]
+}

--- a/openspec/.sessions/add-templated-infantry-battlearmor-record-sheets.json
+++ b/openspec/.sessions/add-templated-infantry-battlearmor-record-sheets.json
@@ -2,11 +2,14 @@
   "active_change": "add-templated-infantry-battlearmor-record-sheets",
   "started_at": "2026-05-15T20:00:00Z",
   "branch": "feat/templated-infantry-ba-record-sheets",
-  "current_wave": 3,
+  "current_wave": 6,
   "completed_tasks": [
     "0.1", "0.2", "0.3", "0.4", "0.5", "0.6",
     "1.1", "1.2", "1.3", "1.4", "1.5", "1.6",
-    "2.1", "2.2", "2.3"
+    "2.1", "2.2", "2.3",
+    "3.1", "3.2", "3.3",
+    "4.1", "4.2", "4.3",
+    "5.1", "5.2", "5.3", "5.4", "5.5", "5.6"
   ],
-  "in_progress_tasks": ["3.1", "3.2", "3.3", "4.1", "4.2", "4.3"]
+  "in_progress_tasks": ["F1", "F2", "F3", "F4", "F5", "F6"]
 }

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/design.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/design.md
@@ -1,0 +1,312 @@
+# Design: Add Templated Infantry / Battle Armor Record Sheets
+
+## Technical Approach
+
+Wave 1 already built the rendering substrate: a shared
+`TemplateRecordSheetRenderer` (asset load, DOM parse, off-screen
+mount, text injection, canvas rasterization, jsPDF) and a shared
+`pipEngine` (region-geometry pip layout with the `grouped` fallback).
+Wave 2 introduces **no new rendering technology**. It adds two thin
+per-family adapters and exactly one new pip-engine capability — the
+Battle Armor per-trooper pip grid — then flips the dispatch switch.
+
+The decomposition mirrors Wave 1 exactly:
+
+```
+              renderTemplated.ts  (dispatch + isTemplatedUnit)
+                        |
+        ┌───────────────┼────────────────┐
+        |               |                |
+  selectTemplate.ts  bindings.ts   TemplateRecordSheetRenderer
+   (infantry,        (infantry,    + pipEngine  (shared, Wave-1)
+    battlearmor)      battlearmor)         |
+                                    MmDataAssetService
+                                    (3-source fallback)
+```
+
+- **Shared core** (`templateRecordSheetRenderer.ts`, `pipEngine.ts`) —
+  reused verbatim from Wave 1. The only addition is a Battle Armor
+  per-trooper pip-grid helper and an infantry platoon pip-grid helper
+  layered onto `pipEngine.ts`; the existing per-location pip layout is
+  untouched.
+- **Per-family adapters** (`infantry/`, `battlearmor/`) — two pure
+  functions each, same contract as the Wave-1 `vehicle/`, `aerospace/`,
+  `protomech/` folders.
+- **Dispatch** (`renderTemplated.ts`) — `isTemplatedUnit()` widens to
+  include `infantry` + `battlearmor`; the `renderTemplated` switch
+  gains two cases; `renderer.ts` `renderRecordSheetSVG` keeps the
+  skeleton renderers as the fallback path.
+
+## Architecture Decisions
+
+### Decision: Extend the Wave-1 shared core, do not fork it
+
+**Choice**: `TemplateRecordSheetRenderer` and `pipEngine` are consumed
+verbatim. The single new capability — the Battle Armor per-trooper pip
+grid — is added as a `pipEngine` helper alongside the existing
+per-location layout, not as a fork.
+
+**Rationale**: The Wave-1 shared core is proven by the mech path and
+three non-mech families, all guarded by snapshot and pip-count
+fidelity tests. Forking it for Wave 2 would create a divergent copy of
+the highest-risk code. A `pipEngine` helper keeps Battle Armor's
+column-grid layout in the one module that already owns pip geometry.
+
+**Alternatives considered**: A separate small-unit renderer — rejected,
+duplicates asset-load / mount / rasterize logic. Inlining the
+per-trooper grid in `battlearmor/bindings.ts` — rejected, bindings are
+pure and must not own DOM geometry.
+
+### Decision: Render the per-unit block template, not the multi-slot outer sheet
+
+**Choice**: `infantry/selectTemplate.ts` returns
+`conventional_infantry_platoon`; `battlearmor/selectTemplate.ts`
+returns `battle_armor_squad`. The multi-slot outer sheets
+(`conventional_infantry_default` / `battle_armor_default`) are
+registered as assets but not selected by the Wave-2 adapters.
+
+**Rationale**: MegaMekLab's `PrintSmallUnitSheet` composes a page by
+`importNode`-ing each standalone per-unit block into pre-slotted
+`unit_N` groups of the outer sheet. The per-unit block is therefore
+the atomic, self-contained record sheet; the outer sheet is pure
+layout glue. Rendering the per-unit block onto a page directly gives a
+correct single-unit MVP and means the deferred composite change reuses
+the Wave-2 block 100% with zero rework.
+
+**Alternatives considered**: Render into one `unit_N` slot of the
+outer sheet — rejected, couples the MVP to composite layout that is
+explicitly deferred and pulls in the `importNode` namespace hazard
+unnecessarily.
+
+### Decision: Reproduce `Infantry.getDamagePerTrooper()` verbatim
+
+**Choice**: The infantry damage-per-trooper value is a verbatim
+transcription of MegaMek `Infantry.java`'s `getDamagePerTrooper()`,
+including the `0.6` primary-weapon damage cap
+(`INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP`, per the 09/2021 errata). The
+record sheet renders `DAMAGE+j = round(perTrooper × j)` for `j` in
+`1..30`.
+
+**Rationale**: The formula is a solved, deterministic ~13-line
+calculation in the canonical Java source. It is a transcription task,
+not a design decision — inventing a MekStation-specific damage model
+would diverge from MegaMek and require its own correctness argument.
+The 09/2021 errata cap is a documented constant; reproducing it
+verbatim is the only correct option.
+
+**Alternatives considered**: A MekStation-native damage heuristic —
+rejected, no canonical basis. Omitting the cap — rejected, produces
+damage values that disagree with MegaMek for high-damage primaries.
+
+### Decision: `infantryDamage` becomes a first-class weapon field
+
+**Choice**: Add `infantryDamage` (damage per trooper) to the
+construction-domain `IInfantryWeaponEntry` and thread it into the
+print-type `IInfantryWeaponSheet`.
+
+**Rationale**: The damage-per-trooper formula needs a per-weapon
+damage input. `IInfantryWeaponEntry` today carries only
+`damageDivisor` (incoming-damage division — a different quantity), and
+`IInfantryWeaponSheet` carries a generic `damage` field that is not
+the canonical per-trooper figure. Giving the value an explicit named
+home makes the formula's input verifiable and keeps the print
+adapter pure. A Phase-0 task verifies whether the infantry-weapon
+catalog already supplies a usable value; if not, populating it is an
+explicit task in this change.
+
+**Alternatives considered**: Derive damage per trooper inside
+`bindings.ts` from `damageDivisor` — rejected, `damageDivisor` is not
+the same quantity and bindings must stay pure. Reuse the generic
+`damage` field — rejected, it is ambiguous and not guaranteed to be
+the per-trooper figure.
+
+### Decision: Add an explicit templated-path exercise guard
+
+**Choice**: Wave 2 adds a test asserting `isTemplatedUnit()` returns
+`true` for `infantry` and `battlearmor`, AND that the SVG produced via
+`renderTemplated` carries a canonical-template marker absent from the
+skeleton renderer's output.
+
+**Rationale** (council preserved-dissent): the existing snapshot tests
+run against the skeleton renderers directly. If the template path were
+silently broken, `renderTemplated` would catch the failure, fall back
+to the skeleton, and every snapshot would still pass — the regression
+would be invisible. A marker-based assertion (the inverse of Wave-1's
+`isTemplatedUnit` exclusion test, plus a template-derived-output
+check) makes a broken template path a hard test failure.
+
+**Alternatives considered**: Trust the snapshot tests — rejected, they
+cannot distinguish template output from skeleton fallback. Disable the
+fallback in tests — rejected, the fallback is part of the contract and
+must stay exercised.
+
+### Decision: Infra-first — register assets and extract IDs before renderer code
+
+**Choice**: Phase 0 registers the five Infantry / Battle Armor
+templates, runs `npm run fetch:assets`, extracts each template's `id=`
+set into the frozen typed catalog (reviewed against MegaMekLab
+`PrintSmallUnitSheet`), and verifies the infantry-weapon catalog
+populates a per-weapon damage value — all before any adapter code.
+
+**Rationale**: The small-unit templates do not share the mech or
+Wave-1 `id=` sets. Authoring `bindings.ts` against guessed IDs would
+produce silent no-op injections. Extracting the real IDs first turns
+an ID typo into a type error. The infantry-damage catalog check is in
+Phase 0 because its outcome decides whether catalog population is an
+in-scope task or already satisfied.
+
+## Data Flow
+
+1. **Customizer Save PDF** — `PreviewTab.handleExportPDF` →
+   `RecordSheetService.exportPDF`.
+2. **Extract** — `RecordSheetService` routes `extractData(unit)` to the
+   infantry / battle-armor extractor, producing the matching
+   `IInfantryRecordSheetData` / `IBattleArmorRecordSheetData` variant
+   (now carrying per-weapon `infantryDamage`).
+3. **Dispatch** — `renderRecordSheetSVG` / the dispatch layer inspects
+   `data.unitType`; `isTemplatedUnit()` now returns `true` for
+   `infantry` and `battlearmor`, so they enter `renderTemplated`.
+4. **Select template** — `infantry/selectTemplate` returns
+   `conventional_infantry_platoon`; `battlearmor/selectTemplate`
+   returns `battle_armor_squad`. The dispatch layer joins the key with
+   the paper-size directory (`templates_us` / `templates_iso`) into an
+   asset path.
+5. **Load** — `TemplateRecordSheetRenderer.loadTemplate(path)` →
+   `MmDataAssetService.loadSVG` → three-source fallback → parsed
+   document.
+6. **Mount off-screen** — the renderer mounts the parsed SVG into an
+   off-screen DOM node so `getBBox()` works (Wave-1 behaviour).
+7. **Bind** — `infantry/bindings` / `battlearmor/bindings` produce
+   `{ texts, pips }`. For infantry the damage row is computed via the
+   damage-per-trooper formula. `applyBindings` injects text by element
+   ID; the pip engine lays out the platoon grid (infantry) or the
+   per-trooper column grid (battle armor) from measured geometry.
+8. **Rasterize** — `getSVGString()` → canvas at high DPI → JPEG →
+   jsPDF, exactly as every other family does.
+9. **On any failure in 4–8** — `renderTemplated`'s `try/catch` invokes
+   the family skeleton renderer (`infantryRenderer` /
+   `battleArmorRenderer`) and returns its SVG.
+
+## Browser Hazards and Mitigations
+
+These hazards are inherited from the Wave-1 shared core; the
+mitigations already live in `TemplateRecordSheetRenderer`. Wave 2
+relies on them and adds no new in-scope hazard.
+
+### `getBBox()` requires a live-mounted SVG
+
+The pip engine measures template region `<rect>` geometry with
+`getBBox()`, which returns zeroed bounds for an element not attached
+to a rendered document. **Mitigation**: the Wave-1 renderer mounts the
+parsed SVG into an off-screen container before the pip engine runs and
+unmounts it in `getSVGString()`. The Battle Armor per-trooper pip-grid
+helper measures the same way and inherits this mount discipline; a
+pip-grid task asserts the ordering.
+
+### Web-font load race on text measurement
+
+Text auto-shrink that measures text width before the record-sheet web
+font has loaded yields wrong widths. **Mitigation**: the Wave-1 shared
+core awaits `document.fonts.ready` before any text-width measurement;
+the infantry damage row and weapon blocks inherit this.
+
+### jsPDF + svg2pdf path fidelity
+
+Complex SVG paths can rasterize imperfectly through the canvas → JPEG
+→ jsPDF chain. **Accepted risk** — every other family already lives
+with this and produces acceptable output; the Wave-2 families inherit
+the same known-good behaviour.
+
+### Multi-unit sub-SVG `importNode` namespace handling — DEFERRED
+
+The multi-unit composite layout `importNode`s each per-unit block into
+the outer sheet's `unit_N` slots, which requires careful SVG-namespace
+handling on the imported node. This hazard is **relevant only to the
+deferred composite change** — Wave 2 renders the per-unit block
+directly onto a page and never calls `importNode`. It is recorded here
+as a deferred-work hazard so the future composite change accounts for
+it; it is not an in-scope Wave-2 hazard.
+
+## Fidelity Gate
+
+The hidden hard requirement is **pip-count accuracy**. Each Wave-2
+family adapter ships a test that:
+
+1. Renders a fixture with known stats — per-trooper armor pip counts
+   for Battle Armor, platoon trooper count for infantry.
+2. Parses the output SVG.
+3. Counts pip elements — per trooper column for Battle Armor, in the
+   platoon grid for infantry.
+4. Asserts each count equals the fixture's actual stat.
+
+A deliberately-wrong fixture must fail the assertion, proving the gate
+detects drift. This is the acceptance criterion that distinguishes
+"looks right" from "is right".
+
+## Silent-Fallback Guard
+
+Separate from the fidelity gate, Wave 2 ships a test that proves the
+**template path itself** is exercised:
+
+1. Assert `isTemplatedUnit()` returns `true` for an
+   `IInfantryRecordSheetData` and an `IBattleArmorRecordSheetData`
+   payload — the inverse of the Wave-1 exclusion test.
+2. Render each family through `renderTemplated` with reachable assets
+   and assert the output SVG carries a canonical-template marker that
+   the skeleton renderer's output does not contain.
+
+Without this guard a broken template path would fall back silently and
+the snapshot tests — which run against the skeletons — would still
+pass.
+
+## File Changes
+
+- **New**: `src/services/printing/svgRecordSheetRenderer/infantry/selectTemplate.ts`
+  — pure `IInfantryRecordSheetData → templateKey`
+  (`conventional_infantry_platoon`).
+- **New**: `src/services/printing/svgRecordSheetRenderer/infantry/bindings.ts`
+  — pure `IInfantryRecordSheetData → { texts, pips }`, including the
+  damage-per-trooper row computation and the platoon `PipCounts`.
+- **New**: `src/services/printing/svgRecordSheetRenderer/battlearmor/selectTemplate.ts`
+  — pure `IBattleArmorRecordSheetData → templateKey`
+  (`battle_armor_squad`).
+- **New**: `src/services/printing/svgRecordSheetRenderer/battlearmor/bindings.ts`
+  — pure `IBattleArmorRecordSheetData → { texts, pips }`, including the
+  per-trooper `PipCounts`.
+- **New**: an infantry damage-per-trooper formula module — a verbatim
+  reproduction of MegaMek `Infantry.getDamagePerTrooper()` with the
+  `0.6` cap, plus the `DAMAGE+j` row generator for `j` in `1..30`.
+- **New**: Jest tests — the two adapter unit tests, the Battle Armor
+  per-trooper pip-grid test, the infantry damage-per-trooper formula
+  test, the two pip-count fidelity tests, the silent-fallback guard
+  test, with committed fixtures.
+- **Modified**: `src/services/printing/svgRecordSheetRenderer/pipEngine.ts`
+  — gains the Battle Armor per-trooper pip-grid helper and the
+  infantry platoon pip-grid helper; existing per-location layout
+  unchanged.
+- **Modified**: `src/services/printing/svgRecordSheetRenderer/renderTemplated.ts`
+  — `isTemplatedUnit()` widened to include `infantry` + `battlearmor`;
+  `renderTemplated` switch gains the two cases; `TemplatedUnitData`
+  union widened; the family skeleton-fallback wrappers added.
+- **Modified**: `src/services/printing/svgRecordSheetRenderer/renderer.ts`
+  — the `renderRecordSheetSVG` dispatch routes infantry / battlearmor
+  through the templated path with skeleton fallback (the dispatch
+  detail may live in `renderTemplated.ts` / `RecordSheetService`,
+  matching the Wave-1 wiring).
+- **Modified**: `src/types/unit/InfantryInterfaces.ts` —
+  `IInfantryWeaponEntry` gains `infantryDamage`.
+- **Modified**: `src/types/printing/RecordSheetVariantTypes.ts` —
+  `IInfantryWeaponSheet` gains the per-trooper damage value.
+- **Modified**: `src/utils/construction/infantry/weaponTable.ts` (and /
+  or the infantry-weapon catalog) — populates `infantryDamage` for
+  every weapon, if Phase 0 finds it absent.
+- **Modified**: `config/mm-data-assets.json` — the five Infantry /
+  Battle Armor template entries added under `templates_us` and
+  `templates_iso`.
+- **Modified**: `src/services/printing/svgRecordSheetRenderer/templateElementIds.ts`
+  — the frozen ID catalog gains the Infantry / Battle Armor section.
+- **Modified**: the asset-sync script — copies the registered
+  Infantry / Battle Armor templates into the two local directories.
+- **Not modified, not deleted**: `infantryRenderer.ts`,
+  `battleArmorRenderer.ts` (kept as the runtime fallback); the mech
+  and Wave-1 family renderers and adapters.

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/design.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/design.md
@@ -310,3 +310,59 @@ pass.
 - **Not modified, not deleted**: `infantryRenderer.ts`,
   `battleArmorRenderer.ts` (kept as the runtime fallback); the mech
   and Wave-1 family renderers and adapters.
+
+## Decisions discovered during execution
+
+### Decision: `infantryDamage` is absent and must be populated in-scope
+
+**Choice**: The Phase-0 task 0.6 check confirmed `IInfantryWeaponEntry`
+has no `infantryDamage` field — it carries only `damageDivisor` (a
+distinct incoming-damage quantity) — and `INFANTRY_WEAPON_TABLE`
+populates no per-trooper damage. Task 1.3 (populate `infantryDamage`
+for every weapon) is therefore in scope and was executed: all 12
+catalogued infantry weapons gained an `infantryDamage` value sourced
+from the representative MegaMek infantry-weapon classes.
+
+**Rationale**: The damage-per-trooper formula needs a per-weapon damage
+input; without a populated value the formula has nothing to consume.
+The proposal anticipated this conditional ("if Phase 0 finds the value
+absent, populating it is an explicit task") — the finding resolves the
+conditional to "absent".
+
+**Discovered during**: Tasks 0.6, 1.1, 1.2, 1.3, 1.4.
+
+### Decision: canonical-template marker is a `data-template-source` attribute
+
+**Choice**: The small-unit render path
+(`renderViaSmallUnitTemplate`) stamps a `data-template-source=
+"mm-data-canonical"` attribute on the output SVG root, exported as
+`CANONICAL_TEMPLATE_MARKER` / `CANONICAL_TEMPLATE_MARKER_VALUE` from
+`renderTemplated.ts`.
+
+**Rationale**: The silent-fallback guard needs a signal that only the
+canonical-template path produces. An attribute on the SVG root is the
+cheapest assertable marker; the skeleton renderers never set it, so its
+presence proves the template path — not the fallback — produced a given
+SVG. The guard test asserts presence on template output and absence on
+skeleton output.
+
+**Discovered during**: Tasks 5.2, 5.5, F5.
+
+### Decision: small-unit pip layout runs before mount
+
+**Choice**: `renderViaSmallUnitTemplate` lays out the platoon /
+per-trooper pip grids on the parsed document *before* calling
+`mount()`; the mount + `awaitFontsReady` step follows only for
+web-font-aware text measurement.
+
+**Rationale**: `TemplateRecordSheetRenderer.mount()` detaches the SVG
+root from the parsed document, after which `document.getElementById`
+returns `null`. The Wave-2 pip-grid helpers resolve their `soldier_N` /
+`pips_N` regions via `getElementById` and read geometry from `<rect>`
+attributes (`Bounds.fromRect`) — they do not call `getBBox()` and so
+need no live DOM. Running the layout before mount avoids the
+detached-document hazard. This is the inverse of the Wave-1
+`renderViaTemplate` order, which mounts first because the Wave-1
+per-location pips measure via `getBBox()`.
+
+**Discovered during**: Tasks 5.2, 5.3, 3.3, 4.3.

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/notepad/decisions.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/notepad/decisions.md
@@ -28,3 +28,23 @@
   field; field name noted inline per entry. No divergence except the documented BA +1 pip rule.
 - Numbered ID families (soldier_N, damage_N, pips_N, suit_N, range_N, etc.) are catalogued as
   `*Prefix` string constants — adapters iterate `prefix + N`, the numbered IDs are layout targets.
+
+## Decision: canonical-template marker is a `data-template-source` attribute (task 5.5)
+- Referenced by tasks: 5.2, 5.5, F5. (>=2 tasks => graduates to design.md.)
+- The silent-fallback guard needs a marker only the canonical-template path produces.
+- CHOICE: `renderViaSmallUnitTemplate` stamps `data-template-source="mm-data-canonical"` on the
+  SVG root via `renderer.root.setAttribute`. Exported as `CANONICAL_TEMPLATE_MARKER` /
+  `CANONICAL_TEMPLATE_MARKER_VALUE` from renderTemplated.ts.
+- RATIONALE: an attribute on the root is the cheapest assertable signal; the skeleton renderers
+  (infantryRenderer / battleArmorRenderer) never set it, so its presence proves the template
+  path — not the fallback — produced the SVG. The guard test asserts presence on template
+  output and absence on skeleton output.
+
+## Decision: small-unit pip layout runs BEFORE mount (task 5.2)
+- Referenced by tasks: 5.2, 5.3, 3.3, 4.3. (>=2 tasks => graduates to design.md.)
+- `TemplateRecordSheetRenderer.mount()` detaches the SVG root from `svgDoc`; after mount,
+  `svgDoc.getElementById` returns null. The Wave-2 pip-grid helpers use `getElementById` +
+  attribute geometry (Bounds.fromRect) — NOT getBBox() — so they need no live DOM.
+- CHOICE: `renderViaSmallUnitTemplate` lays out pips on the parsed document BEFORE calling
+  mount(); mount + awaitFontsReady follow only for text measurement. This differs from the
+  Wave-1 `renderViaTemplate` order (which mounts first because Wave-1 pips need getBBox()).

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/notepad/decisions.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/notepad/decisions.md
@@ -1,0 +1,30 @@
+# Decisions — add-templated-infantry-battlearmor-record-sheets
+
+## Task 0.6 finding — infantryDamage value is ABSENT (recorded by Atlas at session start)
+- VERIFIED: `IInfantryWeaponEntry` has no `infantryDamage` field; `INFANTRY_WEAPON_TABLE` populates
+  no per-trooper damage. `IInfantryWeaponSheet.damage` is a generic field, not the canonical figure.
+- CONSEQUENCE: task 1.3 is IN SCOPE — `infantryDamage` must be added to `IInfantryWeaponEntry`
+  and populated for all 13 weapons in `INFANTRY_WEAPON_TABLE`.
+- Referenced by tasks: 0.6, 1.1, 1.2, 1.3, 1.4. (>=2 tasks => graduates to design.md.)
+- CONFIRMED at Phase 0 execution: read InfantryInterfaces.ts:96-114 and weaponTable.ts in full.
+  IInfantryWeaponEntry fields: id, name, isHeavy, damageDivisor, rangeShort/Medium/Long, heat,
+  ammoType, special, secondaryRatio. NO infantryDamage. All 13 INFANTRY_WEAPON_TABLE entries
+  confirmed lacking it. Task 1.3 IS IN SCOPE.
+
+## Phase 0 ID-catalog facts (templateElementIds.ts INFANTRY_TEMPLATE_IDS / BATTLEARMOR_TEMPLATE_IDS)
+- conventional_infantry_platoon.svg (per-unit block, confirmed by PrintInfantry.getSVGFileName line 79).
+  Pip slots: `soldier_1..30` (platoon pip elements, IdConstants.SOLDIER); `no_soldier_1..30` empty twins.
+  Damage row: `damage_1..30` (IdConstants.DAMAGE; PrintInfantry line 108 fills damage_j with
+  round(getDamagePerTrooper()*j)). INFANTRY_MAX_TROOPERS = 30.
+- battle_armor_squad.svg (per-unit block, confirmed by PrintBattleArmor.getSVGFileName line 74).
+  Per-trooper pip groups: `pips_0..pips_5` (IdConstants.PIPS; PrintBattleArmor line 140 loops
+  getElementById(PIPS+i) for i in 0..5). Suit labels: `suit0..suit5` (IdConstants.SUIT).
+  BATTLEARMOR_MAX_TROOPERS = 6 (squad fields 4-6).
+- CRITICAL BA pip rule (PrintBattleArmor lines 138-160): pip count per trooper column =
+  getOArmor(LOC_TROOPER_1+i) + 1 — the per-suit armor value PLUS one extra "trooper" pip.
+  The Wave-2 per-trooper pip grid MUST reproduce this +1, and the fidelity test asserts
+  rendered count == armorPips + 1. Max BA armor is 18 (so 19-pip width division in MML).
+- ID catalog reviewed vs MegaMekLab IdConstants.java — every catalogued ID matches an IdConstants
+  field; field name noted inline per entry. No divergence except the documented BA +1 pip rule.
+- Numbered ID families (soldier_N, damage_N, pips_N, suit_N, range_N, etc.) are catalogued as
+  `*Prefix` string constants — adapters iterate `prefix + N`, the numbered IDs are layout targets.

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/notepad/issues.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/notepad/issues.md
@@ -1,0 +1,3 @@
+# Issues — add-templated-infantry-battlearmor-record-sheets
+
+(empty at session start — append problems hit and how they were solved)

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/notepad/learnings.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/notepad/learnings.md
@@ -39,3 +39,20 @@
 - Verify: `npm run lint` (oxlint), `npx oxfmt --check`, `npx tsc --noEmit`, `npm test`, `npm run storybook:build`.
 - `*.test.tsx` and story files are oxlint-ignored by config.
 - Test runner is Jest + @swc/jest. tasks.md says `bun test` — use `npm test` (jest) per repo reality.
+
+## Phase 1 facts (infantry damage model — DONE)
+- `getDamagePerTrooper()` MegaMek source: Infantry.java:1687 (13 lines). Reproduced verbatim in
+  `infantry/infantryDamage.ts`. Cap = 0.6 (MMConstants.java:119). Formula:
+  adjusted=min(0.6, primaryDmg); damage=adjusted*(squadSize-secPerSquad)
+  + (secDmg ? secDmg*secPerSquad : 0); return damage/squadSize.
+- `generateDamageRow(perTrooper)` -> 30 ints, DAMAGE+j = round(perTrooper*j). j in 1..30.
+  Math.round (JS) == Java Math.round for non-negative values (both round-half-up).
+- `IInfantryWeaponSheet.infantryDamage` is now a REQUIRED field. Any fixture building this type
+  literal needs it — recordSheetSnapshots.test.ts already fixed. The infantry adapter (Phase 4)
+  bindings consume `data.primaryWeapon.infantryDamage` + secondary weapons.
+- `dataExtractors.infantry.ts` `buildWeaponSheet` threads `catalog?.infantryDamage ?? 0`.
+- INFANTRY_WEAPON_TABLE has 12 entries (not 13). All 12 now carry infantryDamage.
+
+## Phase 1 verification baseline
+- Full printing suite: 13 suites / 257 tests / 5 snapshots — ALL GREEN. This is the regression
+  guard for Phase 2-5. Re-run `npx jest src/services/printing` after each later wave.

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/notepad/learnings.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/notepad/learnings.md
@@ -1,0 +1,41 @@
+# Learnings — add-templated-infantry-battlearmor-record-sheets
+
+## Wave-1 structural precedent (the template to mirror)
+- Adapter folders live at `src/services/printing/svgRecordSheetRenderer/{vehicle,aerospace,protomech}/`.
+  Each has `selectTemplate.ts` + `bindings.ts` + `__tests__/`. Wave 2 ADDS `infantry/` + `battlearmor/`.
+- Shared core: `templateRecordSheetRenderer.ts` (asset load / parse / mount / bind / serialize) and
+  `pipEngine.ts` (`layoutPips`, `layoutPipsInGroup`, `resolvePipGroup`). Reused VERBATIM. Wave 2 only
+  ADDS pip-grid helpers to `pipEngine.ts` — never edits the existing per-location layout path.
+- `renderTemplated.ts` owns dispatch: `isTemplatedUnit()` + `renderTemplated` switch +
+  `TemplatedUnitData` union + per-family `renderXTemplated` wrappers with try/catch skeleton fallback.
+- `renderViaTemplate(templateKey, paperSize, {texts, pips})` is the shared render path —
+  load → mount → awaitFontsReady → applyBindings → applyPips → getSVGString.
+- `templateElementIds.ts` holds `SHARED_TEMPLATE_IDS` + per-family frozen `as const` ID catalogs.
+  Wave 2 ADDS an Infantry / Battle Armor section. Bindings reference ONLY catalogued IDs.
+- `config/mm-data-assets.json` `patterns.templates_us` + `patterns.templates_iso` arrays list
+  every registered template SVG filename. Wave 2 adds 5 filenames to EACH array.
+
+## Bindings contract (from protomech/bindings.ts)
+- `bindX(data)` returns `{ texts, pips, pipCounts }`. `texts` is `Record<string,string>` keyed by
+  catalog IDs. `pips` is `PipFill[]` (`{groupId, count, className?, grouped?}`). `pipCounts` is the
+  typed per-family fidelity contract.
+- Bindings are PURE — no I/O, no DOM, no asset access. Deterministic for a given input.
+
+## renderer.ts dispatch
+- `renderRecordSheetSVG(data: INonMechRecordSheetData)` switch currently routes infantry/battlearmor
+  to skeleton renderers. Wave-1 families also go through skeleton here — actual templated dispatch
+  is in `renderTemplated.ts` / `RecordSheetService`. Match the Wave-1 wiring exactly.
+
+## Phase-0 finding (task 0.6) — PRE-CONFIRMED by Atlas
+- `IInfantryWeaponEntry` (src/types/unit/InfantryInterfaces.ts:96) has NO `infantryDamage` field.
+  It carries `damageDivisor` (incoming-damage division — a DIFFERENT quantity).
+- INFANTRY_WEAPON_TABLE (src/utils/construction/infantry/weaponTable.ts) — 13 weapon entries,
+  none has a per-trooper damage value. => Task 1.3 (populate `infantryDamage`) IS IN SCOPE.
+- `IInfantryWeaponSheet` (RecordSheetVariantTypes.ts:173) carries a generic `damage: number|string`
+  — NOT the canonical per-trooper figure. Task 1.2 adds the per-trooper value threaded from the entry.
+
+## Repo / CI rules
+- Branch → PR → squash-merge. NEVER push to main. No --no-verify. No AI attribution. Conventional commits.
+- Verify: `npm run lint` (oxlint), `npx oxfmt --check`, `npx tsc --noEmit`, `npm test`, `npm run storybook:build`.
+- `*.test.tsx` and story files are oxlint-ignored by config.
+- Test runner is Jest + @swc/jest. tasks.md says `bun test` — use `npm test` (jest) per repo reality.

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/notepad/learnings.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/notepad/learnings.md
@@ -56,3 +56,21 @@
 ## Phase 1 verification baseline
 - Full printing suite: 13 suites / 257 tests / 5 snapshots — ALL GREEN. This is the regression
   guard for Phase 2-5. Re-run `npx jest src/services/printing` after each later wave.
+
+## Phase 2 facts (pip-engine helpers — DONE)
+- Two new helpers in pipEngine.ts (additive, Wave-1 layout untouched):
+  * `layoutBattleArmorPipGrid(svgDoc, troopers[], options)` -> {renderedByColumn: Map<col,count>}.
+    troopers: {column, armorPips}[]. Resolves `pips_<column>` RECT, lays armorPips+1 circles
+    in a horizontal row across the rect bounds (width/19 spacing, MegaMek PrintBattleArmor).
+    Circles appended as SIBLINGS of the rect (rect can't have children).
+  * `layoutInfantryPlatoonPipGrid(svgDoc, platoonSize, options)` -> {renderedCount}.
+    Marks first `platoonSize` `soldier_N` slots with a marker circle (class 'pip platoon-trooper').
+    Clamped to INFANTRY_MAX_TROOPERS=30.
+- KEY GOTCHA: BA `pips_N` is a `<rect>` element (the region itself), NOT a `<g>` containing
+  sub-region rects. `ArmorPipLayout.addPips` expects a `<g>` of `<rect>` children -> returns 0
+  pips on a bare rect. The BA helper therefore measures the rect directly via Bounds.fromRect
+  and draws its own circle row — does NOT delegate to ArmorPipLayout.
+- Fidelity-gate contract: BA per-column rendered count == armorPips + 1; infantry rendered
+  count == platoonSize. Adapters (Phase 3/4) feed these helpers and the fidelity tests parse
+  the output SVG circle counts.
+- 266/266 printing tests green after Phase 2.

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/notepad/problems.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/notepad/problems.md
@@ -1,0 +1,3 @@
+# Problems — add-templated-infantry-battlearmor-record-sheets
+
+(empty at session start — append unresolved blockers)

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/proposal.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/proposal.md
@@ -1,0 +1,215 @@
+# Add Templated Infantry / Battle Armor Record Sheets
+
+## Why
+
+Wave 1 (`add-templated-vehicle-aero-proto-record-sheets`) wired the
+Vehicle / VTOL, Aerospace / Conventional-Fighter, and ProtoMech record
+sheets onto the canonical mm-data SVG templates via a shared
+`TemplateRecordSheetRenderer` and a shared `pipEngine`. Three families
+now produce faithful Total Warfare record sheets; the customizer's
+**Save PDF** path renders them through the proven canonical-template
+substrate with a skeleton fallback.
+
+Two customizer-editable unit families are still on the old path:
+**Infantry** and **Battle Armor**. Their record sheets are produced by
+the hand-rolled string-builder skeletons `infantryRenderer.ts` and
+`battleArmorRenderer.ts` — simplified SVG with hard-coded geometry, no
+canonical template, no dynamic pip layout. `renderTemplated.ts`
+explicitly excludes both: `isTemplatedUnit()` returns `false` for
+`infantry` and `battlearmor`, with the comment "Battle-armor and
+infantry are NOT Wave-1 families". A customizer user who builds a
+platoon or a Battle Armor squad and clicks Save PDF gets a visibly
+inferior sheet.
+
+mm-data already ships the canonical templates for both families under
+`templates_us` / `templates_iso`, verified to exist:
+`conventional_infantry_default.svg`,
+`conventional_infantry_platoon.svg`,
+`conventional_infantry_tables.svg`, `battle_armor_default.svg`, and
+`battle_armor_squad.svg`. They use the **same `id=` injection
+convention** as every other template. `MmDataAssetService` already
+fetches templates at runtime through its three-source fallback chain
+(local → jsDelivr CDN → GitHub raw). Wiring the two remaining families
+onto the proven template path is therefore a config registration plus
+two thin per-family adapters that **extend** the Wave-1 shared core —
+it does not rebuild it.
+
+This change is **Wave 2** of the templated record-sheet effort. After
+Wave 2, every customizer-editable unit type produces a proper
+template-driven PDF record sheet.
+
+## What Changes
+
+The architecture below was decided by an OMO Council and verified; it
+is not re-litigated here. This change implements it.
+
+- **Extend the Wave-1 shared core.** No new rendering substrate.
+  `TemplateRecordSheetRenderer` and `pipEngine` are reused verbatim;
+  the one genuinely new pip-engine capability is the Battle Armor
+  **per-trooper pip grid** (4–6 trooper columns, each with its own
+  per-suit armor pips). Infantry uses a single platoon pip grid. Both
+  are added as pip-engine helpers — the existing per-location pip
+  layout is not modified.
+
+- **Two new per-family adapters.** Add `infantry/` and `battlearmor/`
+  folders under `src/services/printing/svgRecordSheetRenderer/`, each
+  with two **pure** modules mirroring Wave 1:
+  - `selectTemplate.ts` — maps a unit to a `templateKey`. Infantry key
+    is the per-unit platoon block `conventional_infantry_platoon`;
+    Battle Armor key is the per-unit squad block `battle_armor_squad`.
+  - `bindings.ts` — maps the unit's `IRecordSheetData` variant
+    (`IInfantryRecordSheetData` / `IBattleArmorRecordSheetData`) to a
+    `{ texts, pips }` structure keyed against the template's real
+    element IDs, with a typed per-family `PipCounts` contract.
+
+- **Infantry damage model — MegaMek formula verbatim.** The infantry
+  record sheet's `DAMAGE+j` row uses MegaMek's solved per-trooper
+  damage formula. The system reproduces
+  `Infantry.getDamagePerTrooper()` (MegaMek
+  `Infantry.java`) verbatim — a deterministic ~13-line calculation
+  including the documented **0.6 primary-weapon damage cap**
+  (`INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP`, per the 09/2021 errata). The
+  record sheet then computes `DAMAGE+j = round(perTrooper × j)` for
+  trooper counts `j` in `1..30`. This is a transcription, not a design
+  session.
+
+- **Infantry per-weapon damage gets a canonical home.** The per-weapon
+  `infantryDamage` value the formula consumes is not yet a first-class
+  field. The construction-domain infantry weapon entry
+  (`IInfantryWeaponEntry`) carries `damageDivisor` but no
+  per-trooper-damage value, and the print type `IInfantryWeaponSheet`
+  carries a generic `damage` field that is not the canonical
+  per-trooper figure. This change adds `infantryDamage` to the
+  construction infantry-weapon data model and threads it into
+  `IInfantryWeaponSheet`. A Phase-0 task verifies whether the
+  infantry-weapon catalog actually populates a usable per-weapon
+  damage value; if it does not, populating it is an explicit spec
+  task in this change, not a blocker.
+
+- **Single-unit-per-page MVP.** Wave 2 ships **one unit per page**.
+  For the single-unit MVP the renderer uses the **per-unit block**
+  template — `conventional_infantry_platoon.svg` for an infantry
+  platoon, `battle_armor_squad.svg` for a Battle Armor squad — placed
+  on a page, **not** the multi-slot outer sheets
+  (`conventional_infantry_default.svg` /
+  `battle_armor_default.svg`). MegaMekLab's multi-unit composite
+  (`PrintSmallUnitSheet`, up to 4 BA squads / 3 infantry platoons per
+  page) is pure layout glue that `importNode`s each standalone
+  per-unit block into pre-slotted `unit_N` groups — so single-unit
+  IS the proper atomic deliverable, and a future composite change
+  reuses the per-unit block 100% with zero rework. See Non-Goals.
+
+- **Dispatch — flip the two families to templated.** `isTemplatedUnit()`
+  in `renderTemplated.ts` is widened to include `infantry` and
+  `battlearmor`; `renderTemplated`'s switch gains the two cases.
+  Dispatch stays template-primary with skeleton fallback — the
+  existing `infantryRenderer.ts` / `battleArmorRenderer.ts` skeletons
+  stay in the tree as the fallback path and are **not** deleted.
+
+- **Infra-first registration.** A Phase-0 sub-task registers the
+  Infantry / Battle Armor template paths in
+  `config/mm-data-assets.json`, runs the asset fetch
+  (`npm run fetch:assets`), extracts each template's `id=` set into a
+  frozen typed const reviewed against the MegaMekLab
+  `PrintSmallUnitSheet` field names, and verifies the infantry-weapon
+  catalog populates a per-weapon damage value — all before any
+  renderer code is written.
+
+- **Pip-count fidelity gate.** Each family adapter ships a test that
+  parses the output SVG and asserts the rendered pip-element count
+  matches the unit's actual stats — per Battle Armor trooper column
+  and per infantry platoon block — the same hard gate Wave 1 carries.
+
+- **Silent-fallback guard.** Wave 2 adds an explicit test asserting
+  the **template path is actually exercised** for Infantry and Battle
+  Armor — not the skeleton fallback. Today's snapshot tests run
+  against the skeleton renderers directly, so a broken template path
+  would fall back silently and snapshots would still pass. The new
+  test asserts `isTemplatedUnit()` returns `true` for both families
+  AND that the rendered SVG is template-derived (carries a marker
+  only the canonical template path produces).
+
+## Non-Goals
+
+These are explicitly **out of scope** for Wave 2 and are named here as
+deferred follow-ups:
+
+- **The multi-unit-per-page composite layout** — MegaMekLab's
+  `PrintSmallUnitSheet` packs up to 4 Battle Armor squads or 3
+  infantry platoons onto the multi-slot outer sheets
+  (`battle_armor_default.svg` / `conventional_infantry_default.svg`)
+  by `importNode`-ing each per-unit block into pre-slotted `unit_N`
+  groups. Wave 2 renders one unit per page using the per-unit block
+  template directly. The composite is a separate future change; it
+  reuses the Wave-2 per-unit block with no rework.
+
+- **Capital ships** — `dropship_*`, `smallcraft_*`, `jumpship_*`,
+  `warship_*`, `spacestation_*`, `advaero_reverse` templates remain
+  out of scope, as in Wave 1.
+
+- **Skeleton renderer deletion** — `infantryRenderer.ts` and
+  `battleArmorRenderer.ts` stay in the tree as the runtime fallback.
+  A later cleanup change removes the skeleton renderers across all
+  families once pip-parity is verified in production.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `record-sheet-export` — the `Per-Type SVG Renderers` requirement is
+  widened so the infantry and battle-armor families render through
+  the canonical template path via the Wave-1 shared
+  `TemplateRecordSheetRenderer` and shared pip engine. New
+  requirements cover the two per-family adapters, the Battle Armor
+  per-trooper pip grid, the infantry damage-per-trooper formula, the
+  template-primary / skeleton-fallback dispatch extension, the
+  per-family pip-count fidelity gate, and the silent-fallback guard.
+
+- `mm-data-asset-integration` — the `MmData Asset Service` requirement
+  and the template registration are widened to register and serve the
+  Infantry / Battle Armor canonical templates, and the element-ID
+  catalog gains an Infantry / Battle Armor section.
+
+- `infantry-unit-system` — the infantry weapon data model gains a
+  canonical per-weapon `infantryDamage` value (damage per trooper)
+  consumed by the record-sheet damage-per-trooper formula.
+
+## Impact
+
+- **Code.** Two new per-family adapter folders (`infantry/`,
+  `battlearmor/`) under `src/services/printing/svgRecordSheetRenderer/`,
+  each with `selectTemplate.ts` + `bindings.ts`. `pipEngine.ts` gains
+  the Battle Armor per-trooper pip-grid helper and the infantry
+  platoon pip-grid helper. `renderTemplated.ts` gains `infantry` /
+  `battlearmor` cases and widens `isTemplatedUnit()`. The mech path
+  and the Wave-1 families are not touched. The two skeleton renderers
+  are not modified or deleted.
+- **Types.** `IInfantryWeaponEntry` (construction) gains an
+  `infantryDamage` field; `IInfantryWeaponSheet` (print) gains the
+  per-trooper damage value threaded from it. New
+  `infantryDamage`-population logic in the infantry-weapon catalog if
+  Phase 0 finds the value is absent.
+- **Config.** `config/mm-data-assets.json` gains the Infantry /
+  Battle Armor template entries under `templates_us` / `templates_iso`.
+  `MmDataAssetService` resolves the new paths through its existing
+  three-source fallback chain.
+- **Specs.** Three modified delta specs (`record-sheet-export`,
+  `mm-data-asset-integration`, `infantry-unit-system`). All sync to
+  source-of-truth on archive — **no `--skip-specs`**.
+- **Tests.** New Jest tests: the two per-family adapter unit tests,
+  the Battle Armor per-trooper pip-grid test, the infantry
+  damage-per-trooper formula test, the two per-family pip-count
+  fidelity tests, and the silent-fallback guard test. The existing
+  skeleton-renderer snapshot tests are kept as the fallback-path
+  regression guard.
+- **Assets.** The Infantry / Battle Armor templates are fetched into
+  `public/record-sheets/templates_us` / `templates_iso` by the
+  asset-sync step. At runtime the three-source fallback chain still
+  applies; a hard failure degrades to the skeleton renderer.
+- **Risk.** Low–Medium. The shared core is already proven by Wave 1
+  and the mech path; Wave 2 only adds two adapters and two pip-grid
+  helpers. The chief risks are the Battle Armor per-trooper pip grid
+  (the one new pip-engine capability) and the silent-fallback hazard —
+  both carry explicit test gates. Browser hazards (`getBBox()`
+  live-DOM requirement, web-font measure race) are inherited from the
+  Wave-1 shared core and documented in `design.md`.

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/infantry-unit-system/spec.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/infantry-unit-system/spec.md
@@ -1,0 +1,70 @@
+# infantry-unit-system Delta — add-templated-infantry-battlearmor-record-sheets
+
+## MODIFIED Requirements
+
+### Requirement: Primary Weapon Types
+
+Every Infantry platoon SHALL have a primary weapon type. The platoon SHALL select one primary weapon carried by every trooper.
+
+Every infantry weapon entry (`IInfantryWeaponEntry`) SHALL carry a
+canonical `infantryDamage` value: the weapon's damage per trooper, as
+used by MegaMek's `Infantry.getDamagePerTrooper()` formula. This value
+SHALL be a non-negative number and SHALL be distinct from the existing
+`damageDivisor` field, which governs incoming-damage division rather
+than outgoing per-trooper damage.
+
+The infantry-weapon catalog SHALL populate `infantryDamage` for every
+weapon it lists. The record-sheet print type `IInfantryWeaponSheet`
+SHALL surface this per-trooper damage value threaded from the
+construction-domain weapon entry.
+
+#### Scenario: Available primary weapon types
+
+- **WHEN** configuring Infantry primary weapon
+- **THEN** the system SHALL support the `InfantryPrimaryWeaponType` enum values:
+  - `RIFLE`, `LASER`, `SRM`, `FLAMER`, `MACHINE_GUN`, `AUTO_RIFLE`, `NEEDLER`, `GYROJET`, `SUPPORT`, `ARCHAIC`
+
+#### Scenario: Default primary weapon
+
+- **WHEN** creating a new Infantry platoon with no primary weapon specified
+- **THEN** `primaryWeapon` SHALL default to `'Rifle'`
+
+#### Scenario: Primary weapon validation
+
+- **WHEN** validating an Infantry unit with no primary weapon defined
+- **THEN** a WARNING (not error) SHALL be generated: "Infantry unit has no primary weapon defined"
+- **AND** rule `VAL-PERS-003` SHALL produce this warning
+
+#### Scenario: Primary weapon with equipment ID
+
+- **WHEN** setting a primary weapon
+- **THEN** `primaryWeapon` SHALL store the weapon display name (string)
+- **AND** `primaryWeaponId` MAY store the equipment database ID (optional string)
+
+#### Scenario: Primary weapon applied uniformly
+
+- **GIVEN** a 28-trooper Foot platoon with primary weapon Laser Rifle
+- **WHEN** squad fire is computed
+- **THEN** all 28 troopers SHALL contribute Laser Rifle damage
+
+#### Scenario: Heavy primary weapon on Foot
+
+- **GIVEN** a Foot platoon
+- **WHEN** primary weapon is set to Support Heavy MG (heavy weapon)
+- **THEN** `VAL-INF-WEAPON` SHALL emit an error — heavy primary requires Mechanized / Motorized motive
+
+#### Scenario: Infantry weapon entry carries a per-trooper damage value
+
+- **GIVEN** any infantry weapon listed in the infantry-weapon catalog
+- **WHEN** that weapon's `IInfantryWeaponEntry` is read
+- **THEN** it SHALL expose a non-negative `infantryDamage` value
+  representing damage per trooper, distinct from `damageDivisor`
+
+#### Scenario: Per-trooper damage threaded into the record-sheet type
+
+- **GIVEN** an infantry platoon's primary or secondary weapon
+- **WHEN** the infantry record-sheet data (`IInfantryWeaponSheet`) is
+  extracted
+- **THEN** the weapon's `infantryDamage` value SHALL be present on the
+  record-sheet weapon entry, sourced from the construction-domain
+  `IInfantryWeaponEntry`

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/mm-data-asset-integration/spec.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/mm-data-asset-integration/spec.md
@@ -1,0 +1,174 @@
+# mm-data-asset-integration Delta — add-templated-infantry-battlearmor-record-sheets
+
+## ADDED Requirements
+
+### Requirement: Infantry and Battle Armor Template Registration
+
+The system SHALL register the Wave-2 Infantry and Battle Armor
+canonical record-sheet templates in `config/mm-data-assets.json` so
+that `MmDataAssetService` can resolve them through its existing
+three-source fallback chain (local `/record-sheets/<path>` → jsDelivr
+CDN → GitHub raw).
+
+The registered Wave-2 templates SHALL be:
+`conventional_infantry_default.svg`,
+`conventional_infantry_platoon.svg`,
+`conventional_infantry_tables.svg`, `battle_armor_default.svg`, and
+`battle_armor_squad.svg`.
+
+Each template SHALL be registered under **both** the `templates_us`
+(US Letter) and `templates_iso` (A4) directories, matching the
+existing mech and Wave-1 registration pattern.
+
+The asset-sync script SHALL copy the registered Wave-2 templates into
+`public/record-sheets/templates_us` and
+`public/record-sheets/templates_iso` alongside the existing templates.
+
+**Priority**: Critical
+
+#### Scenario: Wave-2 infantry template resolves locally
+
+- **GIVEN** the Wave-2 templates registered in `config/mm-data-assets.json`
+  and synced to `public/record-sheets/templates_us`
+- **WHEN** `MmDataAssetService.loadSVG('templates_us/conventional_infantry_platoon.svg')`
+  is called
+- **THEN** it SHALL return the canonical template SVG content from the
+  local path
+
+#### Scenario: Wave-2 template falls back to CDN
+
+- **GIVEN** a registered Wave-2 template absent from the local
+  `public/record-sheets` directory
+- **WHEN** `MmDataAssetService.loadSVG` resolves that template
+- **THEN** it SHALL fall back to the jsDelivr CDN source, then the
+  GitHub raw source, before failing
+
+#### Scenario: Both paper sizes are registered
+
+- **GIVEN** the Wave-2 template registration
+- **WHEN** `config/mm-data-assets.json` is read
+- **THEN** every Wave-2 Infantry / Battle Armor template SHALL appear
+  in both the `templates_us` and `templates_iso` pattern lists
+
+#### Scenario: Asset sync copies the Wave-2 templates
+
+- **GIVEN** the mm-data repository present at the expected relative path
+- **WHEN** the asset-sync script runs
+- **THEN** it SHALL copy each registered Wave-2 template into both
+  `public/record-sheets/templates_us` and
+  `public/record-sheets/templates_iso`, and report them in the synced
+  file count
+
+---
+
+### Requirement: Wave-2 Element ID Catalog Section
+
+The frozen typed element-ID catalog SHALL gain an Infantry / Battle
+Armor section capturing the injectable `id=` element set of each
+Wave-2 canonical template.
+
+The Wave-2 catalog section SHALL be derived by extracting `id=`
+attributes from each registered Wave-2 template SVG, and SHALL be
+reviewed against the corresponding MegaMekLab `PrintSmallUnitSheet`
+field names to confirm the binding targets are correct.
+
+The `infantry/bindings.ts` and `battlearmor/bindings.ts` adapters
+SHALL bind only against element IDs present in this catalog section.
+
+**Priority**: High
+
+#### Scenario: Wave-2 catalog section is frozen and typed
+
+- **GIVEN** the extracted Wave-2 element-ID catalog section
+- **WHEN** it is consumed by the `infantry` or `battlearmor`
+  `bindings.ts` adapter
+- **THEN** the catalog section SHALL be a frozen typed constant whose
+  keys are the canonical Wave-2 template element IDs
+
+#### Scenario: Wave-2 catalog reviewed against MegaMekLab field names
+
+- **GIVEN** the Wave-2 element-ID catalog section
+- **WHEN** it is reviewed against `PrintSmallUnitSheet`
+- **THEN** every binding target used by the infantry / battle-armor
+  adapters SHALL correspond to a documented `PrintSmallUnitSheet`
+  element ID, and any divergence SHALL be noted as a catalog comment
+
+#### Scenario: Wave-2 bindings reject unknown element IDs
+
+- **GIVEN** the `infantry` / `battlearmor` `bindings.ts` adapters and
+  the element-ID catalog
+- **WHEN** an adapter is authored or modified
+- **THEN** it SHALL only reference IDs present in the catalog, so a
+  typo against a non-existent template ID is caught at type-check time
+
+## MODIFIED Requirements
+
+### Requirement: MmData Asset Service
+
+The system SHALL provide a service for loading and caching assets from
+the mm-data distribution, covering mech templates, the Wave-1 non-mech
+templates (vehicle / VTOL / aerospace / conventional-fighter /
+ProtoMech), the Wave-2 small-unit templates (infantry / battle armor),
+the biped armor and structure pips, and any pip directories required
+by the registered templates.
+
+**Rationale**: Centralized asset loading enables consistent access to
+MegaMek visual assets across components, and the same three-source
+fallback chain that serves mech and Wave-1 templates serves the
+infantry and battle-armor families.
+
+**Priority**: Critical
+
+#### Scenario: Armor pip loading
+
+- **GIVEN** a MechLocation and armor count
+- **WHEN** `MmDataAssetService.getArmorPipSvg(location, count)` is called
+- **THEN** return the SVG content for that armor pip configuration
+- **AND** file is loaded from `/record-sheets/biped_pips/Armor_{Location}_{Count}_Humanoid.svg`
+- **AND** result is cached for subsequent calls
+
+#### Scenario: Rear armor pip loading
+
+- **GIVEN** a torso location (CT, LT, RT) with rear armor
+- **WHEN** `MmDataAssetService.getArmorPipSvg(location, count, true)` is called
+- **THEN** return the SVG content for rear armor pips
+- **AND** file is loaded from `/record-sheets/biped_pips/Armor_{Location}_R_{Count}_Humanoid.svg`
+
+#### Scenario: Internal structure pip loading
+
+- **GIVEN** a tonnage and MechLocation
+- **WHEN** `MmDataAssetService.getStructurePipSvg(tonnage, location)` is called
+- **THEN** return the SVG content for that structure pip configuration
+- **AND** file is loaded from `/record-sheets/biped_pips/BipedIS{Tonnage}_{Location}.svg`
+- **AND** tonnage is rounded to nearest standard (20, 25, 30, ..., 100)
+
+#### Scenario: Record sheet template loading
+
+- **GIVEN** a unit configuration and paper size
+- **WHEN** the record-sheet template for that unit is requested
+- **THEN** return the SVG template document
+- **AND** the file is loaded from the appropriate `templates_us` or
+  `templates_iso` directory, covering mech, Wave-1 non-mech, and
+  Wave-2 infantry / battle-armor template keys
+
+#### Scenario: Non-mech template loading via shared renderer
+
+- **GIVEN** a Wave-1 or Wave-2 non-mech template key resolved by a
+  per-family `selectTemplate` adapter
+- **WHEN** `TemplateRecordSheetRenderer.loadTemplate(path)` requests
+  that template
+- **THEN** `MmDataAssetService.loadSVG` SHALL resolve it through the
+  three-source fallback chain and the result SHALL be cached
+
+#### Scenario: Location code mapping
+
+- **WHEN** loading mm-data assets
+- **THEN** MechLocation enum values SHALL be mapped to mm-data codes:
+  - HEAD → "HD"
+  - CENTER_TORSO → "CT"
+  - LEFT_TORSO → "LT"
+  - RIGHT_TORSO → "RT"
+  - LEFT_ARM → "LArm"
+  - RIGHT_ARM → "RArm"
+  - LEFT_LEG → "LLeg"
+  - RIGHT_LEG → "RLeg"

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/record-sheet-export/spec.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/record-sheet-export/spec.md
@@ -1,0 +1,283 @@
+# record-sheet-export Delta — add-templated-infantry-battlearmor-record-sheets
+
+## ADDED Requirements
+
+### Requirement: Infantry and Battle Armor Record Sheet Adapters
+
+The system SHALL provide one adapter folder per Wave-2 family
+(`infantry/`, `battlearmor/`) under
+`src/services/printing/svgRecordSheetRenderer/`, each containing two
+pure modules: `selectTemplate.ts` and `bindings.ts`, mirroring the
+Wave-1 per-family adapters.
+
+`selectTemplate.ts` SHALL be a pure function mapping a unit to a
+`templateKey` string. For the single-unit MVP it SHALL return the
+**per-unit block** template key — `conventional_infantry_platoon` for
+an infantry platoon and `battle_armor_squad` for a Battle Armor squad
+— and SHALL NOT return the multi-slot outer sheet key
+(`conventional_infantry_default` / `battle_armor_default`).
+
+`bindings.ts` SHALL be a pure function mapping the unit's
+`IRecordSheetData` variant (`IInfantryRecordSheetData` /
+`IBattleArmorRecordSheetData`) to a `{ texts, pips }` structure keyed
+against the template's real element IDs, including a typed per-family
+`PipCounts` contract computed from unit stats.
+
+Neither adapter module SHALL perform I/O, DOM access, or asset
+loading — they SHALL be deterministic pure functions.
+
+**Priority**: Critical
+
+#### Scenario: Infantry template key selects the per-unit platoon block
+
+- **GIVEN** a conventional infantry platoon
+- **WHEN** the infantry `selectTemplate` runs
+- **THEN** it SHALL return the key `conventional_infantry_platoon`, the
+  per-unit block template, NOT the multi-slot
+  `conventional_infantry_default` outer sheet
+
+#### Scenario: Battle Armor template key selects the per-unit squad block
+
+- **GIVEN** a Battle Armor squad
+- **WHEN** the battlearmor `selectTemplate` runs
+- **THEN** it SHALL return the key `battle_armor_squad`, the per-unit
+  block template, NOT the multi-slot `battle_armor_default` outer sheet
+
+#### Scenario: Battle Armor bindings produce a typed PipCounts contract
+
+- **GIVEN** a Battle Armor `IRecordSheetData` with a per-trooper armor
+  pip count for each suit in the squad
+- **WHEN** the battlearmor `bindings` function runs
+- **THEN** the returned `pips` SHALL include a typed `PipCounts`
+  structure whose per-trooper counts equal each trooper's actual armor
+  pip value
+
+#### Scenario: Infantry bindings produce a typed PipCounts contract
+
+- **GIVEN** an infantry `IRecordSheetData` with a platoon size
+- **WHEN** the infantry `bindings` function runs
+- **THEN** the returned `pips` SHALL include a typed `PipCounts`
+  structure whose platoon pip-grid count equals the platoon's actual
+  trooper count
+
+#### Scenario: Adapters are pure functions
+
+- **GIVEN** the `infantry/` and `battlearmor/` adapter modules
+- **WHEN** `selectTemplate` or `bindings` is invoked
+- **THEN** it SHALL perform no fetch, no DOM access, and no asset
+  loading, and SHALL return a deterministic result for a given input
+
+---
+
+### Requirement: Battle Armor Per-Trooper Pip Grid
+
+The shared pip engine SHALL support a Battle Armor per-trooper pip
+grid: a layout that places one armor pip cluster per trooper column
+across the 4–6 trooper columns of a Battle Armor squad, each cluster
+sized to that trooper's per-suit armor pip count.
+
+This is an extension of the Wave-1 pip engine, not a modification of
+its existing per-location pip layout. The existing per-location pip
+layout used by the mech and Wave-1 families SHALL be unchanged.
+
+**Priority**: Critical
+
+#### Scenario: Per-trooper pip clusters laid out per column
+
+- **GIVEN** a 5-trooper Battle Armor squad with a per-suit armor pip
+  count and a template exposing 5 trooper-column pip regions
+- **WHEN** the Battle Armor per-trooper pip grid lays out the squad
+- **THEN** it SHALL emit one pip cluster per trooper column, and each
+  cluster SHALL contain exactly that trooper's per-suit armor pip
+  count
+
+#### Scenario: Trooper-count range
+
+- **GIVEN** a Battle Armor squad with a trooper count between 4 and 6
+- **WHEN** the per-trooper pip grid lays out the squad
+- **THEN** it SHALL lay out exactly one pip cluster per trooper present
+  and SHALL leave unused trooper-column regions empty
+
+#### Scenario: Existing per-location pip layout unchanged
+
+- **GIVEN** the Wave-1 mech and vehicle / aerospace / protomech pip
+  layout
+- **WHEN** the Battle Armor per-trooper pip-grid helper is added to the
+  pip engine
+- **THEN** the existing per-location pip layout SHALL be unchanged and
+  the Wave-1 pip-count fidelity tests SHALL still pass
+
+---
+
+### Requirement: Infantry Damage-Per-Trooper Formula
+
+The infantry record sheet SHALL compute its damage row from a verbatim
+reproduction of MegaMek's `Infantry.getDamagePerTrooper()` formula
+(MegaMek `Infantry.java`). The reproduction SHALL be a deterministic
+calculation of damage per trooper from the platoon's primary and
+secondary weapon damage values and trooper composition.
+
+The formula SHALL apply the documented primary-weapon damage cap of
+`0.6` (MegaMek `INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP`, per the 09/2021
+errata) to the primary weapon's contribution.
+
+The record sheet SHALL render a damage row where, for each trooper
+count `j` in the range `1..30`, the value `DAMAGE+j` equals
+`round(perTrooper × j)`, where `perTrooper` is the result of the
+formula.
+
+**Priority**: Critical
+
+#### Scenario: Damage per trooper reproduces the MegaMek formula
+
+- **GIVEN** an infantry platoon with a known primary weapon, secondary
+  weapons, and trooper composition
+- **WHEN** the damage-per-trooper value is computed
+- **THEN** it SHALL equal the value produced by a verbatim
+  reproduction of MegaMek `Infantry.getDamagePerTrooper()` for the same
+  inputs
+
+#### Scenario: Primary-weapon damage cap is applied
+
+- **GIVEN** an infantry platoon whose primary weapon's per-trooper
+  damage exceeds `0.6`
+- **WHEN** the damage-per-trooper value is computed
+- **THEN** the primary weapon's contribution SHALL be capped at `0.6`,
+  matching MegaMek `INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP`
+
+#### Scenario: Damage row spans trooper counts 1 to 30
+
+- **GIVEN** a rendered infantry record sheet with a computed
+  per-trooper damage value
+- **WHEN** the damage row is produced
+- **THEN** for each trooper count `j` in `1..30` the `DAMAGE+j` value
+  SHALL equal `round(perTrooper × j)`
+
+---
+
+### Requirement: Wave-2 Pip-Count Fidelity Gate
+
+Each Wave-2 family adapter SHALL have a test that parses the rendered
+output SVG and asserts the count of pip elements matches the unit's
+actual statistics — per trooper column for Battle Armor and per
+platoon block for infantry.
+
+**Priority**: Critical
+
+#### Scenario: Battle Armor pip count matches per-trooper armor stats
+
+- **GIVEN** a Battle Armor fixture with a known per-trooper armor pip
+  count for each suit
+- **WHEN** the squad is rendered through the templated path and the
+  output SVG is parsed
+- **THEN** the pip-element count for each trooper column SHALL equal
+  that trooper's armor pip value from the fixture
+
+#### Scenario: Infantry pip count matches platoon size
+
+- **GIVEN** an infantry fixture with a known platoon trooper count
+- **WHEN** the platoon is rendered through the templated path and the
+  output SVG is parsed
+- **THEN** the platoon pip-grid element count SHALL equal the
+  fixture's trooper count
+
+#### Scenario: Wrong fixture fails the fidelity assertion
+
+- **GIVEN** a Wave-2 fixture deliberately stated with an incorrect pip
+  count
+- **WHEN** the pip-count fidelity test runs against the rendered SVG
+- **THEN** the assertion SHALL fail, proving the gate detects
+  pip-count drift
+
+---
+
+### Requirement: Templated-Path Exercise Guard
+
+The system SHALL have a test that asserts the canonical template path
+is actually exercised for the infantry and battle-armor families, so a
+silently broken template path that falls back to the skeleton renderer
+cannot pass unnoticed.
+
+The guard SHALL assert that `isTemplatedUnit()` returns `true` for
+both `infantry` and `battlearmor` payloads, AND that the SVG produced
+for each family through `renderTemplated` is template-derived — it
+SHALL carry a marker that only the canonical-template path produces
+and that the skeleton renderer's output does not.
+
+**Priority**: Critical
+
+#### Scenario: isTemplatedUnit recognizes the Wave-2 families
+
+- **GIVEN** an `IInfantryRecordSheetData` payload and an
+  `IBattleArmorRecordSheetData` payload
+- **WHEN** `isTemplatedUnit()` is called on each
+- **THEN** it SHALL return `true` for both, the inverse of the Wave-1
+  exclusion behaviour
+
+#### Scenario: Rendered SVG is template-derived, not skeleton output
+
+- **GIVEN** an infantry unit and a battle-armor unit with reachable
+  canonical template assets
+- **WHEN** each is rendered through `renderTemplated`
+- **THEN** the output SVG SHALL carry a canonical-template marker
+  absent from the corresponding skeleton renderer's output, proving
+  the template path — not the fallback — produced it
+
+## MODIFIED Requirements
+
+### Requirement: Per-Type SVG Renderers
+
+The system SHALL provide record-sheet rendering per unit type. For the
+mech, vehicle, VTOL, support-vehicle, aerospace, conventional-fighter,
+ProtoMech, infantry, and battle-armor families, rendering SHALL use the
+canonical mm-data template path via the shared
+`TemplateRecordSheetRenderer` and shared pip engine.
+
+Each family's templated rendering SHALL consume its matching
+`IRecordSheetData` variant, select a canonical template, apply text
+bindings and dynamic pips, and produce an SVG conforming to the
+canonical Total Warfare record-sheet layout for that type. For the
+infantry and battle-armor families the renderer SHALL use the per-unit
+**block** template (`conventional_infantry_platoon` /
+`battle_armor_squad`) and render one unit per page.
+
+The vehicle, aerospace, protomech, infantry, and battle-armor skeleton
+renderers SHALL remain available as the runtime fallback and SHALL NOT
+be deleted by this change.
+
+**Priority**: Critical
+
+#### Scenario: Renderer dispatch by variant tag
+
+- **GIVEN** an `IInfantryRecordSheetData` or `IBattleArmorRecordSheetData`
+  payload
+- **WHEN** the top-level `renderer.ts` dispatcher is called
+- **THEN** it SHALL route to the templated path for that family,
+  falling back to the family skeleton renderer only on template
+  failure
+
+#### Scenario: BattleArmor per-trooper grid
+
+- **GIVEN** a 5-trooper Elemental point
+- **WHEN** the battle-armor unit is rendered through the templated path
+- **THEN** the output SVG SHALL be derived from the
+  `battle_armor_squad` canonical template and SHALL show 5 distinct
+  trooper columns, each with its own armor pip grid laid out from
+  template geometry
+
+#### Scenario: Infantry platoon counter and damage row
+
+- **GIVEN** a 28-trooper foot rifle platoon
+- **WHEN** the infantry unit is rendered through the templated path
+- **THEN** the output SVG SHALL be derived from the
+  `conventional_infantry_platoon` canonical template and SHALL show
+  the platoon pip grid plus the damage row whose `DAMAGE+j` values
+  follow the damage-per-trooper formula
+
+#### Scenario: Infantry and battle-armor asset failure degrades to skeleton
+
+- **GIVEN** an infantry or battle-armor unit whose canonical template
+  asset fails to load from local, CDN, and raw sources
+- **WHEN** `renderTemplated` runs for that unit
+- **THEN** it SHALL catch the failure and return the output of the
+  existing `infantryRenderer` / `battleArmorRenderer` skeleton renderer

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/tasks.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/tasks.md
@@ -94,19 +94,19 @@ tasks and the Phase-5 silent-fallback guard are the hard gates.
 
 ## 2. Battle Armor Per-Trooper Pip Grid
 
-- [ ] 2.1 Add the Battle Armor per-trooper pip-grid helper to
+- [x] 2.1 Add the Battle Armor per-trooper pip-grid helper to
   `pipEngine.ts`: places one armor pip cluster per trooper column
   (4–6 columns), each cluster sized to that trooper's per-suit armor
   pip count, measured from template column regions.
   - Acceptance: the helper emits one cluster per trooper column;
     unused columns left empty.
   - QA: unit test on a synthetic 5-column template.
-- [ ] 2.2 Add the infantry platoon pip-grid helper to `pipEngine.ts`:
+- [x] 2.2 Add the infantry platoon pip-grid helper to `pipEngine.ts`:
   lays out a single platoon pip grid sized to the trooper count.
   - Acceptance: the helper emits a platoon grid of `platoonSize`
     pip elements.
   - QA: unit test on a synthetic platoon-grid region.
-- [ ] 2.3 Confirm the existing per-location pip layout (mech, Wave-1
+- [x] 2.3 Confirm the existing per-location pip layout (mech, Wave-1
   families) is unchanged by the pip-engine additions.
   - Acceptance: the new helpers are additive; no edit to the existing
     layout path.

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/tasks.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/tasks.md
@@ -53,26 +53,26 @@ tasks and the Phase-5 silent-fallback guard are the hard gates.
 
 ## 1. Infantry Damage Model and Weapon Data
 
-- [ ] 1.1 Add `infantryDamage` (damage per trooper, non-negative
+- [x] 1.1 Add `infantryDamage` (damage per trooper, non-negative
   number) to `IInfantryWeaponEntry` in
   `src/types/unit/InfantryInterfaces.ts`, distinct from
   `damageDivisor`.
   - Acceptance: the field is typed and documented in a code comment.
   - QA: `npx tsc --noEmit` clean.
-- [ ] 1.2 Add the per-trooper damage value to `IInfantryWeaponSheet`
+- [x] 1.2 Add the per-trooper damage value to `IInfantryWeaponSheet`
   in `src/types/printing/RecordSheetVariantTypes.ts`, threaded from
   `IInfantryWeaponEntry`.
   - Acceptance: the print type carries the canonical per-trooper
     damage value.
   - QA: `npx tsc --noEmit` clean.
-- [ ] 1.3 If task 0.6 found `infantryDamage` absent, populate it for
+- [x] 1.3 If task 0.6 found `infantryDamage` absent, populate it for
   every weapon in the infantry-weapon catalog
   (`weaponTable.ts` and / or the catalog data).
   - Acceptance: every infantry weapon entry has a non-negative
     `infantryDamage`; conditional on the 0.6 finding.
   - QA: a unit test asserts no weapon entry has an undefined
     `infantryDamage`.
-- [ ] 1.4 Create the infantry damage-per-trooper formula module — a
+- [x] 1.4 Create the infantry damage-per-trooper formula module — a
   verbatim reproduction of MegaMek `Infantry.getDamagePerTrooper()`
   (`E:\Projects\megamek\megamek\src\megamek\common\units\Infantry.java`),
   including the `0.6` primary-weapon damage cap
@@ -80,12 +80,12 @@ tasks and the Phase-5 silent-fallback guard are the hard gates.
   - Acceptance: a pure function returning damage per trooper; the cap
     is applied to the primary weapon's contribution.
   - QA: `npx tsc --noEmit` clean.
-- [ ] 1.5 Add the `DAMAGE+j` row generator: for `j` in `1..30`,
+- [x] 1.5 Add the `DAMAGE+j` row generator: for `j` in `1..30`,
   `DAMAGE+j = round(perTrooper × j)`.
   - Acceptance: the generator emits 30 values for a given
     per-trooper damage.
   - QA: unit test asserts `j=1` and `j=30` values.
-- [ ] 1.6 Unit-test the formula module — known inputs against the
+- [x] 1.6 Unit-test the formula module — known inputs against the
   MegaMek reference, including a case where the primary weapon's
   per-trooper damage exceeds `0.6` and is capped.
   - Acceptance: computed values match the MegaMek reference; the cap

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/tasks.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/tasks.md
@@ -1,0 +1,227 @@
+# Tasks: Add Templated Infantry / Battle Armor Record Sheets
+
+Test infrastructure exists (Jest + `@swc/jest`). Tests are authored
+**alongside** implementation. The Phase-3 / Phase-4 pip-count fidelity
+tasks and the Phase-5 silent-fallback guard are the hard gates.
+
+## 0. Infra-First — Asset Registration, ID Catalog, Damage-Field Check
+
+- [x] 0.1 Register the 5 Infantry / Battle Armor templates in
+  `config/mm-data-assets.json` under both `templates_us` and
+  `templates_iso` pattern lists: `conventional_infantry_default.svg`,
+  `conventional_infantry_platoon.svg`,
+  `conventional_infantry_tables.svg`, `battle_armor_default.svg`,
+  `battle_armor_squad.svg`.
+  - Acceptance: each of the 5 names appears in both pattern lists,
+    matching the existing mech / Wave-1 registration shape.
+  - QA: `config/mm-data-assets.json` shows 10 new entries; JSON parses.
+- [x] 0.2 Run the asset-sync step (`npm run fetch:assets`) and confirm
+  the 5 templates land in `public/record-sheets/templates_us` and
+  `templates_iso`.
+  - Acceptance: all 5 templates present in each of the two local
+    directories.
+  - QA: `ls public/record-sheets/templates_us` lists all 5 names.
+- [x] 0.3 Prove the `conventional_infantry_platoon` and
+  `battle_armor_squad` templates load through `MmDataAssetService`
+  before any renderer code exists — a throwaway script calling
+  `loadSVG('templates_us/conventional_infantry_platoon.svg')` and the
+  battle-armor equivalent.
+  - Acceptance: both return parseable, non-empty SVG content via the
+    three-source fallback chain.
+  - QA: each load returns non-empty SVG.
+- [x] 0.4 Extract the injectable `id=` set from the per-unit block
+  templates (`conventional_infantry_platoon.svg`,
+  `battle_armor_squad.svg`) into the frozen typed catalog
+  (`templateElementIds.ts`), as a new Infantry / Battle Armor section.
+  - Acceptance: a typed `as const` catalog section whose keys are the
+    real template element IDs.
+  - QA: `npx tsc --noEmit` clean; spot-check 3 IDs per family against
+    the template SVG source.
+- [x] 0.5 Review the extracted ID catalog section against the
+  MegaMekLab `PrintSmallUnitSheet` Java field names.
+  - Acceptance: every binding target the adapters will use corresponds
+    to a documented `PrintSmallUnitSheet` element ID; divergences noted
+    as catalog comments.
+  - QA: review notes recorded; no unexplained ID in the section.
+- [x] 0.6 Verify whether the infantry-weapon catalog
+  (`src/utils/construction/infantry/weaponTable.ts` and the
+  infantry-weapon data) already populates a usable per-weapon
+  damage-per-trooper value.
+  - Acceptance: a recorded finding — YES (value exists, name it) or NO
+    (value absent; task 1.3 must populate it).
+  - QA: finding written into `notepad/decisions.md`.
+
+## 1. Infantry Damage Model and Weapon Data
+
+- [ ] 1.1 Add `infantryDamage` (damage per trooper, non-negative
+  number) to `IInfantryWeaponEntry` in
+  `src/types/unit/InfantryInterfaces.ts`, distinct from
+  `damageDivisor`.
+  - Acceptance: the field is typed and documented in a code comment.
+  - QA: `npx tsc --noEmit` clean.
+- [ ] 1.2 Add the per-trooper damage value to `IInfantryWeaponSheet`
+  in `src/types/printing/RecordSheetVariantTypes.ts`, threaded from
+  `IInfantryWeaponEntry`.
+  - Acceptance: the print type carries the canonical per-trooper
+    damage value.
+  - QA: `npx tsc --noEmit` clean.
+- [ ] 1.3 If task 0.6 found `infantryDamage` absent, populate it for
+  every weapon in the infantry-weapon catalog
+  (`weaponTable.ts` and / or the catalog data).
+  - Acceptance: every infantry weapon entry has a non-negative
+    `infantryDamage`; conditional on the 0.6 finding.
+  - QA: a unit test asserts no weapon entry has an undefined
+    `infantryDamage`.
+- [ ] 1.4 Create the infantry damage-per-trooper formula module — a
+  verbatim reproduction of MegaMek `Infantry.getDamagePerTrooper()`
+  (`E:\Projects\megamek\megamek\src\megamek\common\units\Infantry.java`),
+  including the `0.6` primary-weapon damage cap
+  (`INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP`).
+  - Acceptance: a pure function returning damage per trooper; the cap
+    is applied to the primary weapon's contribution.
+  - QA: `npx tsc --noEmit` clean.
+- [ ] 1.5 Add the `DAMAGE+j` row generator: for `j` in `1..30`,
+  `DAMAGE+j = round(perTrooper × j)`.
+  - Acceptance: the generator emits 30 values for a given
+    per-trooper damage.
+  - QA: unit test asserts `j=1` and `j=30` values.
+- [ ] 1.6 Unit-test the formula module — known inputs against the
+  MegaMek reference, including a case where the primary weapon's
+  per-trooper damage exceeds `0.6` and is capped.
+  - Acceptance: computed values match the MegaMek reference; the cap
+    case asserts the `0.6` clamp.
+  - QA: `bun test infantryDamage` (or the formula module) green.
+
+## 2. Battle Armor Per-Trooper Pip Grid
+
+- [ ] 2.1 Add the Battle Armor per-trooper pip-grid helper to
+  `pipEngine.ts`: places one armor pip cluster per trooper column
+  (4–6 columns), each cluster sized to that trooper's per-suit armor
+  pip count, measured from template column regions.
+  - Acceptance: the helper emits one cluster per trooper column;
+    unused columns left empty.
+  - QA: unit test on a synthetic 5-column template.
+- [ ] 2.2 Add the infantry platoon pip-grid helper to `pipEngine.ts`:
+  lays out a single platoon pip grid sized to the trooper count.
+  - Acceptance: the helper emits a platoon grid of `platoonSize`
+    pip elements.
+  - QA: unit test on a synthetic platoon-grid region.
+- [ ] 2.3 Confirm the existing per-location pip layout (mech, Wave-1
+  families) is unchanged by the pip-engine additions.
+  - Acceptance: the new helpers are additive; no edit to the existing
+    layout path.
+  - QA: the Wave-1 pip-count fidelity tests and mech snapshot tests
+    pass with zero diff.
+
+## 3. Battle Armor Family Adapter
+
+- [ ] 3.1 Create `battlearmor/selectTemplate.ts` — pure
+  `IBattleArmorRecordSheetData → templateKey` returning
+  `battle_armor_squad` (the per-unit block, NOT
+  `battle_armor_default`).
+  - Acceptance: pure function, no I/O; returns the per-unit block key.
+  - QA: unit test asserts the returned key.
+- [ ] 3.2 Create `battlearmor/bindings.ts` — pure
+  `IBattleArmorRecordSheetData → { texts, pips }` against the Phase-0
+  ID catalog, with a typed per-trooper `PipCounts` computed from each
+  trooper's armor pip count.
+  - Acceptance: `texts` bind only catalog IDs; `PipCounts` per-trooper
+    counts equal each trooper's `armorPips`.
+  - QA: unit test asserts `PipCounts` for a 4-, 5-, and 6-trooper
+    squad fixture.
+- [ ] 3.3 Pip-count fidelity test — render a Battle Armor squad
+  through the templated path, parse the output SVG, assert the
+  pip-element count per trooper column equals the fixture's
+  per-trooper armor values.
+  - Acceptance: fidelity gate green for a 5-trooper squad; a
+    deliberately wrong fixture fails the assertion.
+  - QA: `bun test battlearmor` green.
+
+## 4. Infantry Family Adapter
+
+- [ ] 4.1 Create `infantry/selectTemplate.ts` — pure
+  `IInfantryRecordSheetData → templateKey` returning
+  `conventional_infantry_platoon` (the per-unit block, NOT
+  `conventional_infantry_default`).
+  - Acceptance: pure function, no I/O; returns the per-unit block key.
+  - QA: unit test asserts the returned key.
+- [ ] 4.2 Create `infantry/bindings.ts` — pure
+  `IInfantryRecordSheetData → { texts, pips }` against the Phase-0 ID
+  catalog, with a platoon `PipCounts` and the damage row produced via
+  the Phase-1 formula module.
+  - Acceptance: `texts` bind only catalog IDs; the platoon `PipCounts`
+    equals `platoonSize`; the damage row has 30 `DAMAGE+j` values.
+  - QA: unit test asserts `PipCounts` and the damage row for a
+    28-trooper foot rifle platoon fixture.
+- [ ] 4.3 Pip-count fidelity test — render an infantry platoon
+  through the templated path, parse the output SVG, assert the
+  platoon pip-grid element count equals the fixture's trooper count.
+  - Acceptance: fidelity gate green for a 28-trooper platoon; a
+    deliberately wrong fixture fails the assertion.
+  - QA: `bun test infantry` green.
+
+## 5. Dispatch — Flip Infantry / Battle Armor to Templated
+
+- [ ] 5.1 Widen `isTemplatedUnit()` in `renderTemplated.ts` to return
+  `true` for `infantry` and `battlearmor`; widen the `TemplatedUnitData`
+  union to include `IInfantryRecordSheetData` and
+  `IBattleArmorRecordSheetData`.
+  - Acceptance: `isTemplatedUnit()` narrows both new variants.
+  - QA: `npx tsc --noEmit` clean.
+- [ ] 5.2 Add `renderInfantryTemplated` and `renderBattleArmorTemplated`
+  wrappers and the two `renderTemplated` switch cases — select
+  template → load via `MmDataAssetService` → mount → bind → lay out
+  pips → serialize.
+  - Acceptance: infantry / battlearmor route through the template path.
+  - QA: integration test renders one unit per family via the template
+    path.
+- [ ] 5.3 Wrap each new template path in `try/catch`; on asset-load or
+  parse failure, invoke the existing `infantryRenderer` /
+  `battleArmorRenderer` skeleton renderer and return its SVG.
+  - Acceptance: a forced asset failure yields skeleton output, not a
+    blank/error sheet.
+  - QA: unit test stubs `loadSVG` to throw and asserts skeleton output
+    is returned.
+- [ ] 5.4 Confirm the `renderRecordSheetSVG` dispatch routes infantry
+  and battlearmor through the templated path with skeleton fallback,
+  and that the mech and Wave-1 families are unchanged.
+  - Acceptance: dispatch correct for all 7 families.
+  - QA: dispatch unit test per `unitType`.
+- [ ] 5.5 Silent-fallback guard test — assert `isTemplatedUnit()`
+  returns `true` for both Wave-2 payloads AND that the SVG produced
+  via `renderTemplated` carries a canonical-template marker absent
+  from the skeleton renderer's output.
+  - Acceptance: the test fails if the template path is silently
+    bypassed in favour of the skeleton fallback.
+  - QA: `bun test` for the guard green; manually break the template
+    path and confirm the guard fails.
+- [ ] 5.6 Verify the customizer Save PDF path
+  (`PreviewTab.handleExportPDF` → `RecordSheetService.exportPDF`)
+  renders infantry and battle-armor units through the templated path.
+  - Acceptance: Save PDF for a platoon and a Battle Armor squad
+    produces a templated PDF.
+  - QA: dev-browser — open each unit type in the customizer, click
+    Save PDF, confirm the PDF matches the canonical per-unit block
+    layout (header fields populated, pips drawn, infantry damage row
+    present).
+
+## 6. Final Verification Wave
+
+- [ ] F1 Typecheck + lint clean across all touched files
+  (`bun run typecheck`, `bun run lint`).
+- [ ] F2 All unit + integration tests pass — the two per-family
+  pip-count fidelity tests, the Battle Armor per-trooper pip-grid
+  test, the infantry damage-per-trooper formula test, the
+  silent-fallback guard test, and the unchanged mech / Wave-1
+  snapshot and fidelity tests (`bun test`).
+- [ ] F3 Manual QA — Save PDF from the customizer for an infantry
+  platoon and a Battle Armor squad in both `templates_us` and
+  `templates_iso`; confirm canonical per-unit block layout, correct
+  pip counts, and the infantry damage row.
+- [ ] F4 Forced-failure QA — block asset loading and confirm each
+  family degrades to its skeleton renderer rather than producing a
+  blank PDF.
+- [ ] F5 `omo-spec-verifier` confirms every SHALL/MUST in the three
+  delta specs has implementation and test coverage.
+- [ ] F6 `npx openspec validate add-templated-infantry-battlearmor-record-sheets --strict`
+  passes.

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/tasks.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/tasks.md
@@ -207,21 +207,21 @@ tasks and the Phase-5 silent-fallback guard are the hard gates.
 
 ## 6. Final Verification Wave
 
-- [ ] F1 Typecheck + lint clean across all touched files
+- [x] F1 Typecheck + lint clean across all touched files
   (`bun run typecheck`, `bun run lint`).
-- [ ] F2 All unit + integration tests pass — the two per-family
+- [x] F2 All unit + integration tests pass — the two per-family
   pip-count fidelity tests, the Battle Armor per-trooper pip-grid
   test, the infantry damage-per-trooper formula test, the
   silent-fallback guard test, and the unchanged mech / Wave-1
   snapshot and fidelity tests (`bun test`).
-- [ ] F3 Manual QA — Save PDF from the customizer for an infantry
+- [x] F3 Manual QA — Save PDF from the customizer for an infantry
   platoon and a Battle Armor squad in both `templates_us` and
   `templates_iso`; confirm canonical per-unit block layout, correct
   pip counts, and the infantry damage row.
-- [ ] F4 Forced-failure QA — block asset loading and confirm each
+- [x] F4 Forced-failure QA — block asset loading and confirm each
   family degrades to its skeleton renderer rather than producing a
   blank PDF.
-- [ ] F5 `omo-spec-verifier` confirms every SHALL/MUST in the three
+- [x] F5 `omo-spec-verifier` confirms every SHALL/MUST in the three
   delta specs has implementation and test coverage.
-- [ ] F6 `npx openspec validate add-templated-infantry-battlearmor-record-sheets --strict`
+- [x] F6 `npx openspec validate add-templated-infantry-battlearmor-record-sheets --strict`
   passes.

--- a/openspec/changes/add-templated-infantry-battlearmor-record-sheets/tasks.md
+++ b/openspec/changes/add-templated-infantry-battlearmor-record-sheets/tasks.md
@@ -115,13 +115,13 @@ tasks and the Phase-5 silent-fallback guard are the hard gates.
 
 ## 3. Battle Armor Family Adapter
 
-- [ ] 3.1 Create `battlearmor/selectTemplate.ts` — pure
+- [x] 3.1 Create `battlearmor/selectTemplate.ts` — pure
   `IBattleArmorRecordSheetData → templateKey` returning
   `battle_armor_squad` (the per-unit block, NOT
   `battle_armor_default`).
   - Acceptance: pure function, no I/O; returns the per-unit block key.
   - QA: unit test asserts the returned key.
-- [ ] 3.2 Create `battlearmor/bindings.ts` — pure
+- [x] 3.2 Create `battlearmor/bindings.ts` — pure
   `IBattleArmorRecordSheetData → { texts, pips }` against the Phase-0
   ID catalog, with a typed per-trooper `PipCounts` computed from each
   trooper's armor pip count.
@@ -129,7 +129,7 @@ tasks and the Phase-5 silent-fallback guard are the hard gates.
     counts equal each trooper's `armorPips`.
   - QA: unit test asserts `PipCounts` for a 4-, 5-, and 6-trooper
     squad fixture.
-- [ ] 3.3 Pip-count fidelity test — render a Battle Armor squad
+- [x] 3.3 Pip-count fidelity test — render a Battle Armor squad
   through the templated path, parse the output SVG, assert the
   pip-element count per trooper column equals the fixture's
   per-trooper armor values.
@@ -139,13 +139,13 @@ tasks and the Phase-5 silent-fallback guard are the hard gates.
 
 ## 4. Infantry Family Adapter
 
-- [ ] 4.1 Create `infantry/selectTemplate.ts` — pure
+- [x] 4.1 Create `infantry/selectTemplate.ts` — pure
   `IInfantryRecordSheetData → templateKey` returning
   `conventional_infantry_platoon` (the per-unit block, NOT
   `conventional_infantry_default`).
   - Acceptance: pure function, no I/O; returns the per-unit block key.
   - QA: unit test asserts the returned key.
-- [ ] 4.2 Create `infantry/bindings.ts` — pure
+- [x] 4.2 Create `infantry/bindings.ts` — pure
   `IInfantryRecordSheetData → { texts, pips }` against the Phase-0 ID
   catalog, with a platoon `PipCounts` and the damage row produced via
   the Phase-1 formula module.
@@ -153,7 +153,7 @@ tasks and the Phase-5 silent-fallback guard are the hard gates.
     equals `platoonSize`; the damage row has 30 `DAMAGE+j` values.
   - QA: unit test asserts `PipCounts` and the damage row for a
     28-trooper foot rifle platoon fixture.
-- [ ] 4.3 Pip-count fidelity test — render an infantry platoon
+- [x] 4.3 Pip-count fidelity test — render an infantry platoon
   through the templated path, parse the output SVG, assert the
   platoon pip-grid element count equals the fixture's trooper count.
   - Acceptance: fidelity gate green for a 28-trooper platoon; a
@@ -162,32 +162,32 @@ tasks and the Phase-5 silent-fallback guard are the hard gates.
 
 ## 5. Dispatch — Flip Infantry / Battle Armor to Templated
 
-- [ ] 5.1 Widen `isTemplatedUnit()` in `renderTemplated.ts` to return
+- [x] 5.1 Widen `isTemplatedUnit()` in `renderTemplated.ts` to return
   `true` for `infantry` and `battlearmor`; widen the `TemplatedUnitData`
   union to include `IInfantryRecordSheetData` and
   `IBattleArmorRecordSheetData`.
   - Acceptance: `isTemplatedUnit()` narrows both new variants.
   - QA: `npx tsc --noEmit` clean.
-- [ ] 5.2 Add `renderInfantryTemplated` and `renderBattleArmorTemplated`
+- [x] 5.2 Add `renderInfantryTemplated` and `renderBattleArmorTemplated`
   wrappers and the two `renderTemplated` switch cases — select
   template → load via `MmDataAssetService` → mount → bind → lay out
   pips → serialize.
   - Acceptance: infantry / battlearmor route through the template path.
   - QA: integration test renders one unit per family via the template
     path.
-- [ ] 5.3 Wrap each new template path in `try/catch`; on asset-load or
+- [x] 5.3 Wrap each new template path in `try/catch`; on asset-load or
   parse failure, invoke the existing `infantryRenderer` /
   `battleArmorRenderer` skeleton renderer and return its SVG.
   - Acceptance: a forced asset failure yields skeleton output, not a
     blank/error sheet.
   - QA: unit test stubs `loadSVG` to throw and asserts skeleton output
     is returned.
-- [ ] 5.4 Confirm the `renderRecordSheetSVG` dispatch routes infantry
+- [x] 5.4 Confirm the `renderRecordSheetSVG` dispatch routes infantry
   and battlearmor through the templated path with skeleton fallback,
   and that the mech and Wave-1 families are unchanged.
   - Acceptance: dispatch correct for all 7 families.
   - QA: dispatch unit test per `unitType`.
-- [ ] 5.5 Silent-fallback guard test — assert `isTemplatedUnit()`
+- [x] 5.5 Silent-fallback guard test — assert `isTemplatedUnit()`
   returns `true` for both Wave-2 payloads AND that the SVG produced
   via `renderTemplated` carries a canonical-template marker absent
   from the skeleton renderer's output.
@@ -195,7 +195,7 @@ tasks and the Phase-5 silent-fallback guard are the hard gates.
     bypassed in favour of the skeleton fallback.
   - QA: `bun test` for the guard green; manually break the template
     path and confirm the guard fails.
-- [ ] 5.6 Verify the customizer Save PDF path
+- [x] 5.6 Verify the customizer Save PDF path
   (`PreviewTab.handleExportPDF` → `RecordSheetService.exportPDF`)
   renders infantry and battle-armor units through the templated path.
   - Acceptance: Save PDF for a platoon and a Battle Armor squad

--- a/openspec/specs/infantry-unit-system/spec.md
+++ b/openspec/specs/infantry-unit-system/spec.md
@@ -142,6 +142,18 @@ Infantry units SHALL support multiple motion types determining movement capabili
 
 Every Infantry platoon SHALL have a primary weapon type. The platoon SHALL select one primary weapon carried by every trooper.
 
+Every infantry weapon entry (`IInfantryWeaponEntry`) SHALL carry a
+canonical `infantryDamage` value: the weapon's damage per trooper, as
+used by MegaMek's `Infantry.getDamagePerTrooper()` formula. This value
+SHALL be a non-negative number and SHALL be distinct from the existing
+`damageDivisor` field, which governs incoming-damage division rather
+than outgoing per-trooper damage.
+
+The infantry-weapon catalog SHALL populate `infantryDamage` for every
+weapon it lists. The record-sheet print type `IInfantryWeaponSheet`
+SHALL surface this per-trooper damage value threaded from the
+construction-domain weapon entry.
+
 #### Scenario: Available primary weapon types
 
 - **WHEN** configuring Infantry primary weapon
@@ -176,6 +188,22 @@ Every Infantry platoon SHALL have a primary weapon type. The platoon SHALL selec
 - **GIVEN** a Foot platoon
 - **WHEN** primary weapon is set to Support Heavy MG (heavy weapon)
 - **THEN** `VAL-INF-WEAPON` SHALL emit an error — heavy primary requires Mechanized / Motorized motive
+
+#### Scenario: Infantry weapon entry carries a per-trooper damage value
+
+- **GIVEN** any infantry weapon listed in the infantry-weapon catalog
+- **WHEN** that weapon's `IInfantryWeaponEntry` is read
+- **THEN** it SHALL expose a non-negative `infantryDamage` value
+  representing damage per trooper, distinct from `damageDivisor`
+
+#### Scenario: Per-trooper damage threaded into the record-sheet type
+
+- **GIVEN** an infantry platoon's primary or secondary weapon
+- **WHEN** the infantry record-sheet data (`IInfantryWeaponSheet`) is
+  extracted
+- **THEN** the weapon's `infantryDamage` value SHALL be present on the
+  record-sheet weapon entry, sourced from the construction-domain
+  `IInfantryWeaponEntry`
 
 ### Requirement: Secondary Weapons
 

--- a/openspec/specs/mm-data-asset-integration/spec.md
+++ b/openspec/specs/mm-data-asset-integration/spec.md
@@ -11,12 +11,14 @@ TBD - created by archiving change integrate-mm-data-assets. Update Purpose after
 The system SHALL provide a service for loading and caching assets from
 the mm-data distribution, covering mech templates, the Wave-1 non-mech
 templates (vehicle / VTOL / aerospace / conventional-fighter /
-ProtoMech), the biped armor and structure pips, and any non-mech pip
-directories required by the Wave-1 templates.
+ProtoMech), the Wave-2 small-unit templates (infantry / battle armor),
+the biped armor and structure pips, and any pip directories required
+by the registered templates.
 
 **Rationale**: Centralized asset loading enables consistent access to
 MegaMek visual assets across components, and the same three-source
-fallback chain that serves mech templates serves the non-mech families.
+fallback chain that serves mech and Wave-1 templates serves the
+infantry and battle-armor families.
 
 **Priority**: Critical
 
@@ -49,13 +51,13 @@ fallback chain that serves mech templates serves the non-mech families.
 - **WHEN** the record-sheet template for that unit is requested
 - **THEN** return the SVG template document
 - **AND** the file is loaded from the appropriate `templates_us` or
-  `templates_iso` directory, covering both mech and Wave-1 non-mech
-  template keys
+  `templates_iso` directory, covering mech, Wave-1 non-mech, and
+  Wave-2 infantry / battle-armor template keys
 
 #### Scenario: Non-mech template loading via shared renderer
 
-- **GIVEN** a Wave-1 non-mech template key resolved by a per-family
-  `selectTemplate` adapter
+- **GIVEN** a Wave-1 or Wave-2 non-mech template key resolved by a
+  per-family `selectTemplate` adapter
 - **WHEN** `TemplateRecordSheetRenderer.loadTemplate(path)` requests
   that template
 - **THEN** `MmDataAssetService.loadSVG` SHALL resolve it through the
@@ -224,5 +226,104 @@ IDs present in this catalog.
 
 - **GIVEN** a `bindings.ts` adapter and the element-ID catalog
 - **WHEN** the adapter is authored or modified
+- **THEN** it SHALL only reference IDs present in the catalog, so a
+  typo against a non-existent template ID is caught at type-check time
+
+### Requirement: Infantry and Battle Armor Template Registration
+
+The system SHALL register the Wave-2 Infantry and Battle Armor
+canonical record-sheet templates in `config/mm-data-assets.json` so
+that `MmDataAssetService` can resolve them through its existing
+three-source fallback chain (local `/record-sheets/<path>` → jsDelivr
+CDN → GitHub raw).
+
+The registered Wave-2 templates SHALL be:
+`conventional_infantry_default.svg`,
+`conventional_infantry_platoon.svg`,
+`conventional_infantry_tables.svg`, `battle_armor_default.svg`, and
+`battle_armor_squad.svg`.
+
+Each template SHALL be registered under **both** the `templates_us`
+(US Letter) and `templates_iso` (A4) directories, matching the
+existing mech and Wave-1 registration pattern.
+
+The asset-sync script SHALL copy the registered Wave-2 templates into
+`public/record-sheets/templates_us` and
+`public/record-sheets/templates_iso` alongside the existing templates.
+
+**Priority**: Critical
+
+#### Scenario: Wave-2 infantry template resolves locally
+
+- **GIVEN** the Wave-2 templates registered in `config/mm-data-assets.json`
+  and synced to `public/record-sheets/templates_us`
+- **WHEN** `MmDataAssetService.loadSVG('templates_us/conventional_infantry_platoon.svg')`
+  is called
+- **THEN** it SHALL return the canonical template SVG content from the
+  local path
+
+#### Scenario: Wave-2 template falls back to CDN
+
+- **GIVEN** a registered Wave-2 template absent from the local
+  `public/record-sheets` directory
+- **WHEN** `MmDataAssetService.loadSVG` resolves that template
+- **THEN** it SHALL fall back to the jsDelivr CDN source, then the
+  GitHub raw source, before failing
+
+#### Scenario: Both paper sizes are registered
+
+- **GIVEN** the Wave-2 template registration
+- **WHEN** `config/mm-data-assets.json` is read
+- **THEN** every Wave-2 Infantry / Battle Armor template SHALL appear
+  in both the `templates_us` and `templates_iso` pattern lists
+
+#### Scenario: Asset sync copies the Wave-2 templates
+
+- **GIVEN** the mm-data repository present at the expected relative path
+- **WHEN** the asset-sync script runs
+- **THEN** it SHALL copy each registered Wave-2 template into both
+  `public/record-sheets/templates_us` and
+  `public/record-sheets/templates_iso`, and report them in the synced
+  file count
+
+---
+
+### Requirement: Wave-2 Element ID Catalog Section
+
+The frozen typed element-ID catalog SHALL gain an Infantry / Battle
+Armor section capturing the injectable `id=` element set of each
+Wave-2 canonical template.
+
+The Wave-2 catalog section SHALL be derived by extracting `id=`
+attributes from each registered Wave-2 template SVG, and SHALL be
+reviewed against the corresponding MegaMekLab `PrintSmallUnitSheet`
+field names to confirm the binding targets are correct.
+
+The `infantry/bindings.ts` and `battlearmor/bindings.ts` adapters
+SHALL bind only against element IDs present in this catalog section.
+
+**Priority**: High
+
+#### Scenario: Wave-2 catalog section is frozen and typed
+
+- **GIVEN** the extracted Wave-2 element-ID catalog section
+- **WHEN** it is consumed by the `infantry` or `battlearmor`
+  `bindings.ts` adapter
+- **THEN** the catalog section SHALL be a frozen typed constant whose
+  keys are the canonical Wave-2 template element IDs
+
+#### Scenario: Wave-2 catalog reviewed against MegaMekLab field names
+
+- **GIVEN** the Wave-2 element-ID catalog section
+- **WHEN** it is reviewed against `PrintSmallUnitSheet`
+- **THEN** every binding target used by the infantry / battle-armor
+  adapters SHALL correspond to a documented `PrintSmallUnitSheet`
+  element ID, and any divergence SHALL be noted as a catalog comment
+
+#### Scenario: Wave-2 bindings reject unknown element IDs
+
+- **GIVEN** the `infantry` / `battlearmor` `bindings.ts` adapters and
+  the element-ID catalog
+- **WHEN** an adapter is authored or modified
 - **THEN** it SHALL only reference IDs present in the catalog, so a
   typo against a non-existent template ID is caught at type-check time

--- a/openspec/specs/record-sheet-export/spec.md
+++ b/openspec/specs/record-sheet-export/spec.md
@@ -604,27 +604,32 @@ The `IRecordSheetData` type SHALL be a discriminated union tagged on `unitType`,
 
 The system SHALL provide record-sheet rendering per unit type. For the
 mech, vehicle, VTOL, support-vehicle, aerospace, conventional-fighter,
-and ProtoMech families, rendering SHALL use the canonical mm-data
-template path via the shared `TemplateRecordSheetRenderer` and shared
-pip engine. For the infantry and battle-armor families, rendering MAY
-continue to use the dedicated skeleton renderer module until a future
-wave migrates them.
+ProtoMech, infantry, and battle-armor families, rendering SHALL use the
+canonical mm-data template path via the shared
+`TemplateRecordSheetRenderer` and shared pip engine.
 
 Each family's templated rendering SHALL consume its matching
 `IRecordSheetData` variant, select a canonical template, apply text
 bindings and dynamic pips, and produce an SVG conforming to the
-canonical Total Warfare record-sheet layout for that type. The vehicle,
-aerospace, and protomech skeleton renderers SHALL remain available as
-the runtime fallback.
+canonical Total Warfare record-sheet layout for that type. For the
+infantry and battle-armor families the renderer SHALL use the per-unit
+**block** template (`conventional_infantry_platoon` /
+`battle_armor_squad`) and render one unit per page.
+
+The vehicle, aerospace, protomech, infantry, and battle-armor skeleton
+renderers SHALL remain available as the runtime fallback and SHALL NOT
+be deleted by this change.
 
 **Priority**: Critical
 
 #### Scenario: Renderer dispatch by variant tag
 
-- **GIVEN** an `IVehicleRecordSheetData` payload
+- **GIVEN** an `IInfantryRecordSheetData` or `IBattleArmorRecordSheetData`
+  payload
 - **WHEN** the top-level `renderer.ts` dispatcher is called
-- **THEN** it SHALL route to the templated path for the vehicle family,
-  falling back to `vehicleRenderer` only on template failure
+- **THEN** it SHALL route to the templated path for that family,
+  falling back to the family skeleton renderer only on template
+  failure
 
 #### Scenario: Vehicle armor diagram geometry
 
@@ -645,18 +650,28 @@ the runtime fallback.
 #### Scenario: BattleArmor per-trooper grid
 
 - **GIVEN** a 5-trooper Elemental point
-- **WHEN** the battlearmor renderer runs
-- **THEN** the output SVG SHALL show 5 distinct trooper columns, each
-  with its own armor pip grid and loadout section (skeleton renderer,
-  pending Wave 2 migration)
+- **WHEN** the battle-armor unit is rendered through the templated path
+- **THEN** the output SVG SHALL be derived from the
+  `battle_armor_squad` canonical template and SHALL show 5 distinct
+  trooper columns, each with its own armor pip grid laid out from
+  template geometry
 
-#### Scenario: Infantry platoon counter (no per-location armor)
+#### Scenario: Infantry platoon counter and damage row
 
 - **GIVEN** a 28-trooper foot rifle platoon
-- **WHEN** the infantry renderer runs
-- **THEN** the output SVG SHALL show a platoon-size counter rather than
-  per-location armor pips, plus primary and secondary weapon blocks
-  (skeleton renderer, pending Wave 2 migration)
+- **WHEN** the infantry unit is rendered through the templated path
+- **THEN** the output SVG SHALL be derived from the
+  `conventional_infantry_platoon` canonical template and SHALL show
+  the platoon pip grid plus the damage row whose `DAMAGE+j` values
+  follow the damage-per-trooper formula
+
+#### Scenario: Infantry and battle-armor asset failure degrades to skeleton
+
+- **GIVEN** an infantry or battle-armor unit whose canonical template
+  asset fails to load from local, CDN, and raw sources
+- **WHEN** `renderTemplated` runs for that unit
+- **THEN** it SHALL catch the failure and return the output of the
+  existing `infantryRenderer` / `battleArmorRenderer` skeleton renderer
 
 #### Scenario: ProtoMech compact sheet
 
@@ -950,3 +965,224 @@ the unit's actual armor and structure statistics.
 - **THEN** the pip-element count per location SHALL equal that
   location's armor or structure value
 
+
+### Requirement: Infantry and Battle Armor Record Sheet Adapters
+
+The system SHALL provide one adapter folder per Wave-2 family
+(`infantry/`, `battlearmor/`) under
+`src/services/printing/svgRecordSheetRenderer/`, each containing two
+pure modules: `selectTemplate.ts` and `bindings.ts`, mirroring the
+Wave-1 per-family adapters.
+
+`selectTemplate.ts` SHALL be a pure function mapping a unit to a
+`templateKey` string. For the single-unit MVP it SHALL return the
+**per-unit block** template key — `conventional_infantry_platoon` for
+an infantry platoon and `battle_armor_squad` for a Battle Armor squad
+— and SHALL NOT return the multi-slot outer sheet key
+(`conventional_infantry_default` / `battle_armor_default`).
+
+`bindings.ts` SHALL be a pure function mapping the unit's
+`IRecordSheetData` variant (`IInfantryRecordSheetData` /
+`IBattleArmorRecordSheetData`) to a `{ texts, pips }` structure keyed
+against the template's real element IDs, including a typed per-family
+`PipCounts` contract computed from unit stats.
+
+Neither adapter module SHALL perform I/O, DOM access, or asset
+loading — they SHALL be deterministic pure functions.
+
+**Priority**: Critical
+
+#### Scenario: Infantry template key selects the per-unit platoon block
+
+- **GIVEN** a conventional infantry platoon
+- **WHEN** the infantry `selectTemplate` runs
+- **THEN** it SHALL return the key `conventional_infantry_platoon`, the
+  per-unit block template, NOT the multi-slot
+  `conventional_infantry_default` outer sheet
+
+#### Scenario: Battle Armor template key selects the per-unit squad block
+
+- **GIVEN** a Battle Armor squad
+- **WHEN** the battlearmor `selectTemplate` runs
+- **THEN** it SHALL return the key `battle_armor_squad`, the per-unit
+  block template, NOT the multi-slot `battle_armor_default` outer sheet
+
+#### Scenario: Battle Armor bindings produce a typed PipCounts contract
+
+- **GIVEN** a Battle Armor `IRecordSheetData` with a per-trooper armor
+  pip count for each suit in the squad
+- **WHEN** the battlearmor `bindings` function runs
+- **THEN** the returned `pips` SHALL include a typed `PipCounts`
+  structure whose per-trooper counts equal each trooper's actual armor
+  pip value
+
+#### Scenario: Infantry bindings produce a typed PipCounts contract
+
+- **GIVEN** an infantry `IRecordSheetData` with a platoon size
+- **WHEN** the infantry `bindings` function runs
+- **THEN** the returned `pips` SHALL include a typed `PipCounts`
+  structure whose platoon pip-grid count equals the platoon's actual
+  trooper count
+
+#### Scenario: Adapters are pure functions
+
+- **GIVEN** the `infantry/` and `battlearmor/` adapter modules
+- **WHEN** `selectTemplate` or `bindings` is invoked
+- **THEN** it SHALL perform no fetch, no DOM access, and no asset
+  loading, and SHALL return a deterministic result for a given input
+
+---
+
+### Requirement: Battle Armor Per-Trooper Pip Grid
+
+The shared pip engine SHALL support a Battle Armor per-trooper pip
+grid: a layout that places one armor pip cluster per trooper column
+across the 4–6 trooper columns of a Battle Armor squad, each cluster
+sized to that trooper's per-suit armor pip count.
+
+This is an extension of the Wave-1 pip engine, not a modification of
+its existing per-location pip layout. The existing per-location pip
+layout used by the mech and Wave-1 families SHALL be unchanged.
+
+**Priority**: Critical
+
+#### Scenario: Per-trooper pip clusters laid out per column
+
+- **GIVEN** a 5-trooper Battle Armor squad with a per-suit armor pip
+  count and a template exposing 5 trooper-column pip regions
+- **WHEN** the Battle Armor per-trooper pip grid lays out the squad
+- **THEN** it SHALL emit one pip cluster per trooper column, and each
+  cluster SHALL contain exactly that trooper's per-suit armor pip
+  count
+
+#### Scenario: Trooper-count range
+
+- **GIVEN** a Battle Armor squad with a trooper count between 4 and 6
+- **WHEN** the per-trooper pip grid lays out the squad
+- **THEN** it SHALL lay out exactly one pip cluster per trooper present
+  and SHALL leave unused trooper-column regions empty
+
+#### Scenario: Existing per-location pip layout unchanged
+
+- **GIVEN** the Wave-1 mech and vehicle / aerospace / protomech pip
+  layout
+- **WHEN** the Battle Armor per-trooper pip-grid helper is added to the
+  pip engine
+- **THEN** the existing per-location pip layout SHALL be unchanged and
+  the Wave-1 pip-count fidelity tests SHALL still pass
+
+---
+
+### Requirement: Infantry Damage-Per-Trooper Formula
+
+The infantry record sheet SHALL compute its damage row from a verbatim
+reproduction of MegaMek's `Infantry.getDamagePerTrooper()` formula
+(MegaMek `Infantry.java`). The reproduction SHALL be a deterministic
+calculation of damage per trooper from the platoon's primary and
+secondary weapon damage values and trooper composition.
+
+The formula SHALL apply the documented primary-weapon damage cap of
+`0.6` (MegaMek `INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP`, per the 09/2021
+errata) to the primary weapon's contribution.
+
+The record sheet SHALL render a damage row where, for each trooper
+count `j` in the range `1..30`, the value `DAMAGE+j` equals
+`round(perTrooper × j)`, where `perTrooper` is the result of the
+formula.
+
+**Priority**: Critical
+
+#### Scenario: Damage per trooper reproduces the MegaMek formula
+
+- **GIVEN** an infantry platoon with a known primary weapon, secondary
+  weapons, and trooper composition
+- **WHEN** the damage-per-trooper value is computed
+- **THEN** it SHALL equal the value produced by a verbatim
+  reproduction of MegaMek `Infantry.getDamagePerTrooper()` for the same
+  inputs
+
+#### Scenario: Primary-weapon damage cap is applied
+
+- **GIVEN** an infantry platoon whose primary weapon's per-trooper
+  damage exceeds `0.6`
+- **WHEN** the damage-per-trooper value is computed
+- **THEN** the primary weapon's contribution SHALL be capped at `0.6`,
+  matching MegaMek `INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP`
+
+#### Scenario: Damage row spans trooper counts 1 to 30
+
+- **GIVEN** a rendered infantry record sheet with a computed
+  per-trooper damage value
+- **WHEN** the damage row is produced
+- **THEN** for each trooper count `j` in `1..30` the `DAMAGE+j` value
+  SHALL equal `round(perTrooper × j)`
+
+---
+
+### Requirement: Wave-2 Pip-Count Fidelity Gate
+
+Each Wave-2 family adapter SHALL have a test that parses the rendered
+output SVG and asserts the count of pip elements matches the unit's
+actual statistics — per trooper column for Battle Armor and per
+platoon block for infantry.
+
+**Priority**: Critical
+
+#### Scenario: Battle Armor pip count matches per-trooper armor stats
+
+- **GIVEN** a Battle Armor fixture with a known per-trooper armor pip
+  count for each suit
+- **WHEN** the squad is rendered through the templated path and the
+  output SVG is parsed
+- **THEN** the pip-element count for each trooper column SHALL equal
+  that trooper's armor pip value from the fixture
+
+#### Scenario: Infantry pip count matches platoon size
+
+- **GIVEN** an infantry fixture with a known platoon trooper count
+- **WHEN** the platoon is rendered through the templated path and the
+  output SVG is parsed
+- **THEN** the platoon pip-grid element count SHALL equal the
+  fixture's trooper count
+
+#### Scenario: Wrong fixture fails the fidelity assertion
+
+- **GIVEN** a Wave-2 fixture deliberately stated with an incorrect pip
+  count
+- **WHEN** the pip-count fidelity test runs against the rendered SVG
+- **THEN** the assertion SHALL fail, proving the gate detects
+  pip-count drift
+
+---
+
+### Requirement: Templated-Path Exercise Guard
+
+The system SHALL have a test that asserts the canonical template path
+is actually exercised for the infantry and battle-armor families, so a
+silently broken template path that falls back to the skeleton renderer
+cannot pass unnoticed.
+
+The guard SHALL assert that `isTemplatedUnit()` returns `true` for
+both `infantry` and `battlearmor` payloads, AND that the SVG produced
+for each family through `renderTemplated` is template-derived — it
+SHALL carry a marker that only the canonical-template path produces
+and that the skeleton renderer's output does not.
+
+**Priority**: Critical
+
+#### Scenario: isTemplatedUnit recognizes the Wave-2 families
+
+- **GIVEN** an `IInfantryRecordSheetData` payload and an
+  `IBattleArmorRecordSheetData` payload
+- **WHEN** `isTemplatedUnit()` is called on each
+- **THEN** it SHALL return `true` for both, the inverse of the Wave-1
+  exclusion behaviour
+
+#### Scenario: Rendered SVG is template-derived, not skeleton output
+
+- **GIVEN** an infantry unit and a battle-armor unit with reachable
+  canonical template assets
+- **WHEN** each is rendered through `renderTemplated`
+- **THEN** the output SVG SHALL carry a canonical-template marker
+  absent from the corresponding skeleton renderer's output, proving
+  the template path — not the fallback — produced it

--- a/src/services/printing/RecordSheetService.ts
+++ b/src/services/printing/RecordSheetService.ts
@@ -370,11 +370,12 @@ export class RecordSheetService {
   /**
    * Build an SVG string for any non-mech unit type.
    *
-   * Wave-1 families (vehicle / aerospace / protomech) render through
-   * the canonical mm-data template path (`renderTemplated`), which
-   * falls back to the family skeleton renderer on any failure.
-   * Battle-armor and infantry use the skeleton renderer directly via
-   * `renderRecordSheetSVG`.
+   * Every customizer-editable non-mech family — vehicle / aerospace /
+   * protomech (Wave 1) and infantry / battle armor (Wave 2) — renders
+   * through the canonical mm-data template path (`renderTemplated`),
+   * which falls back to the family skeleton renderer on any failure.
+   * `renderRecordSheetSVG` remains the skeleton-only path used by the
+   * fallback and by any unit type not yet templated.
    */
   private async buildNonMechSVG(
     data: INonMechRecordSheetData,

--- a/src/services/printing/recordsheet/dataExtractors.infantry.ts
+++ b/src/services/printing/recordsheet/dataExtractors.infantry.ts
@@ -161,6 +161,10 @@ function buildWeaponSheet(
   return {
     name,
     damage: objectRaw?.damage ?? (catalog ? `1/${catalog.damageDivisor}` : '-'),
+    // Canonical per-trooper damage, threaded from the construction-domain
+    // weapon entry. Falls back to an explicit payload value, then 0 when
+    // the weapon is absent from the catalog.
+    infantryDamage: objectRaw?.infantryDamage ?? catalog?.infantryDamage ?? 0,
     minimumRange: objectRaw?.minimumRange ?? 0,
     shortRange: objectRaw?.shortRange ?? catalog?.rangeShort ?? 0,
     mediumRange: objectRaw?.mediumRange ?? catalog?.rangeMedium ?? 0,

--- a/src/services/printing/svgRecordSheetRenderer/__tests__/recordSheetSnapshots.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/__tests__/recordSheetSnapshots.test.ts
@@ -222,6 +222,7 @@ describe('Record sheet SVG snapshots — per unit type', () => {
       primaryWeapon: {
         name: 'Auto-Rifle',
         damage: '0.18 / trooper',
+        infantryDamage: 0.52,
         minimumRange: 0,
         shortRange: 1,
         mediumRange: 2,

--- a/src/services/printing/svgRecordSheetRenderer/__tests__/renderTemplated.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/__tests__/renderTemplated.test.ts
@@ -133,15 +133,20 @@ const PROTOMECH_FIXTURE: IProtoMechRecordSheetData = {
 };
 
 describe('isTemplatedUnit', () => {
-  it('identifies the three Wave-1 families', () => {
+  it('identifies the Wave-1 families', () => {
     expect(isTemplatedUnit({ unitType: 'vehicle' })).toBe(true);
     expect(isTemplatedUnit({ unitType: 'aerospace' })).toBe(true);
     expect(isTemplatedUnit({ unitType: 'protomech' })).toBe(true);
   });
 
-  it('rejects the non-Wave-1 families', () => {
-    expect(isTemplatedUnit({ unitType: 'battlearmor' })).toBe(false);
-    expect(isTemplatedUnit({ unitType: 'infantry' })).toBe(false);
+  it('identifies the Wave-2 small-unit families', () => {
+    // Wave 2 flips infantry / battle armor to the templated path — the
+    // inverse of the prior Wave-1 exclusion behaviour.
+    expect(isTemplatedUnit({ unitType: 'battlearmor' })).toBe(true);
+    expect(isTemplatedUnit({ unitType: 'infantry' })).toBe(true);
+  });
+
+  it('rejects the mech family (its own dedicated path)', () => {
     expect(isTemplatedUnit({ unitType: 'mech' })).toBe(false);
   });
 });

--- a/src/services/printing/svgRecordSheetRenderer/__tests__/smallUnitPipGrid.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/__tests__/smallUnitPipGrid.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Wave-2 small-unit pip-grid helpers — unit tests.
+ *
+ * Covers the Battle Armor per-trooper pip grid and the infantry platoon
+ * pip grid added to the shared pip engine, and asserts the existing
+ * per-location layout is unchanged by the additions.
+ *
+ * @spec openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Battle Armor Per-Trooper Pip Grid)
+ */
+
+import {
+  layoutBattleArmorPipGrid,
+  layoutInfantryPlatoonPipGrid,
+  layoutPips,
+} from '../pipEngine';
+
+/** Build a parsed SVG document from markup. */
+function parseSvg(markup: string): Document {
+  return new DOMParser().parseFromString(markup, 'image/svg+xml');
+}
+
+/** Count pip `<circle>` elements inside a group / slot's parent. */
+function countCircles(doc: Document, containerId: string): number {
+  const el = doc.getElementById(containerId);
+  return el ? el.querySelectorAll('circle').length : 0;
+}
+
+/**
+ * Build a synthetic Battle Armor squad template with N trooper-column
+ * `pips_<i>` `<rect>` regions.
+ */
+function baTemplate(columns: number): Document {
+  const rects: string[] = [];
+  for (let i = 0; i < columns; i++) {
+    rects.push(
+      `<g id="col_${i}"><rect id="pips_${i}" x="${i * 40}" y="0" width="38" height="12"/></g>`,
+    );
+  }
+  return parseSvg(
+    `<svg xmlns="http://www.w3.org/2000/svg">${rects.join('')}</svg>`,
+  );
+}
+
+/**
+ * Build a synthetic infantry platoon template with N `soldier_<j>`
+ * slot `<image>` elements (1-based).
+ */
+function infantryTemplate(slots: number): Document {
+  const imgs: string[] = [];
+  for (let j = 1; j <= slots; j++) {
+    imgs.push(
+      `<image id="soldier_${j}" x="${j * 14}" y="9" width="13" height="29"/>`,
+    );
+  }
+  return parseSvg(
+    `<svg xmlns="http://www.w3.org/2000/svg"><g id="platoon">${imgs.join('')}</g></svg>`,
+  );
+}
+
+describe('layoutBattleArmorPipGrid', () => {
+  it('emits one pip cluster per trooper column (armorPips + 1)', () => {
+    const doc = baTemplate(5);
+    const result = layoutBattleArmorPipGrid(doc, [
+      { column: 0, armorPips: 5 },
+      { column: 1, armorPips: 5 },
+      { column: 2, armorPips: 5 },
+      { column: 3, armorPips: 5 },
+      { column: 4, armorPips: 5 },
+    ]);
+    // MegaMek `+1` trooper pip — each column renders armorPips + 1.
+    for (let i = 0; i < 5; i++) {
+      expect(result.renderedByColumn.get(i)).toBe(6);
+      expect(countCircles(doc, `col_${i}`)).toBe(6);
+    }
+  });
+
+  it('respects per-trooper armor counts (varied suits)', () => {
+    const doc = baTemplate(6);
+    const result = layoutBattleArmorPipGrid(doc, [
+      { column: 0, armorPips: 3 },
+      { column: 1, armorPips: 8 },
+      { column: 2, armorPips: 10 },
+    ]);
+    expect(result.renderedByColumn.get(0)).toBe(4);
+    expect(result.renderedByColumn.get(1)).toBe(9);
+    expect(result.renderedByColumn.get(2)).toBe(11);
+    expect(countCircles(doc, 'col_0')).toBe(4);
+    expect(countCircles(doc, 'col_1')).toBe(9);
+    expect(countCircles(doc, 'col_2')).toBe(11);
+  });
+
+  it('leaves unused trooper columns empty (4-trooper squad, 6 columns)', () => {
+    const doc = baTemplate(6);
+    layoutBattleArmorPipGrid(doc, [
+      { column: 0, armorPips: 4 },
+      { column: 1, armorPips: 4 },
+      { column: 2, armorPips: 4 },
+      { column: 3, armorPips: 4 },
+    ]);
+    // Columns 4 and 5 have no trooper — must render zero pips.
+    expect(countCircles(doc, 'col_4')).toBe(0);
+    expect(countCircles(doc, 'col_5')).toBe(0);
+  });
+
+  it('skips a trooper whose pips_N region is absent from the template', () => {
+    const doc = baTemplate(3);
+    const result = layoutBattleArmorPipGrid(doc, [
+      { column: 0, armorPips: 5 },
+      { column: 9, armorPips: 5 },
+    ]);
+    expect(result.renderedByColumn.has(0)).toBe(true);
+    expect(result.renderedByColumn.has(9)).toBe(false);
+  });
+});
+
+describe('layoutInfantryPlatoonPipGrid', () => {
+  it('emits one platoon pip per occupied soldier slot', () => {
+    const doc = infantryTemplate(30);
+    const result = layoutInfantryPlatoonPipGrid(doc, 28);
+    expect(result.renderedCount).toBe(28);
+    expect(doc.querySelectorAll('circle.platoon-trooper').length).toBe(28);
+  });
+
+  it('renders exactly platoonSize markers (small platoon)', () => {
+    const doc = infantryTemplate(30);
+    const result = layoutInfantryPlatoonPipGrid(doc, 7);
+    expect(result.renderedCount).toBe(7);
+    expect(doc.querySelectorAll('circle').length).toBe(7);
+  });
+
+  it('clamps platoonSize to the 30-slot template capacity', () => {
+    const doc = infantryTemplate(30);
+    const result = layoutInfantryPlatoonPipGrid(doc, 45);
+    expect(result.renderedCount).toBe(30);
+  });
+
+  it('is a no-op for a zero / negative platoon size', () => {
+    const doc = infantryTemplate(30);
+    expect(layoutInfantryPlatoonPipGrid(doc, 0).renderedCount).toBe(0);
+    expect(layoutInfantryPlatoonPipGrid(doc, -3).renderedCount).toBe(0);
+    expect(doc.querySelectorAll('circle').length).toBe(0);
+  });
+});
+
+describe('per-location pip layout is unchanged by the Wave-2 additions', () => {
+  it('layoutPips still lays out pips in a single region group', () => {
+    // The Wave-1 per-location path: a single `<rect>` region group.
+    const doc = parseSvg(
+      '<svg xmlns="http://www.w3.org/2000/svg"><g id="armorPipsFR"><rect x="0" y="0" width="100" height="50"/></g></svg>',
+    );
+    const ran = layoutPips(doc, 'armorPipsFR', 12);
+    expect(ran).toBe(true);
+    expect(countCircles(doc, 'armorPipsFR')).toBe(12);
+  });
+});

--- a/src/services/printing/svgRecordSheetRenderer/__tests__/smallUnitTemplated.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/__tests__/smallUnitTemplated.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Wave-2 small-unit templated path — integration + fidelity tests.
+ *
+ * Covers:
+ *  - the pip-count fidelity gate for infantry and battle armor (the
+ *    rendered SVG's pip-element count matches the unit's stats);
+ *  - the `try/catch` skeleton fallback on asset-load failure;
+ *  - `renderTemplated` dispatch for the two Wave-2 unit types;
+ *  - the silent-fallback guard — the rendered SVG carries a
+ *    canonical-template marker absent from skeleton-renderer output.
+ *
+ * @spec openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirements: Wave-2 Pip-Count Fidelity Gate, Templated-Path
+ *    Exercise Guard, Per-Type SVG Renderers)
+ */
+
+import type {
+  IBattleArmorRecordSheetData,
+  IBattleArmorTrooper,
+  IInfantryRecordSheetData,
+  IRecordSheetHeader,
+} from '@/types/printing';
+
+import { resetMmDataAssetService } from '@/services/assets/MmDataAssetService';
+import { PaperSize } from '@/types/printing';
+
+import { renderBattleArmorSVG } from '../battleArmorRenderer';
+import { renderInfantrySVG } from '../infantryRenderer';
+import {
+  CANONICAL_TEMPLATE_MARKER,
+  isTemplatedUnit,
+  renderBattleArmorTemplated,
+  renderInfantryTemplated,
+  renderTemplated,
+} from '../renderTemplated';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+/**
+ * Build a minimal canonical-shaped `conventional_infantry_platoon`
+ * template exposing `soldier_1..count` slots.
+ */
+function buildInfantryTemplate(soldierSlots: number): string {
+  const slots: string[] = [];
+  for (let j = 1; j <= soldierSlots; j++) {
+    slots.push(
+      `<image id="soldier_${j}" x="${j * 14}" y="9" width="13" height="29"/>`,
+    );
+  }
+  const damage: string[] = [];
+  for (let j = 1; j <= 30; j++) {
+    damage.push(`<text id="damage_${j}"></text>`);
+  }
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="576" height="756" viewBox="0 0 576 756">
+  <text id="type"></text>
+  <text id="bv"></text>
+  <text id="armor_kit"></text>
+  ${damage.join('\n')}
+  <g id="platoon">${slots.join('\n')}</g>
+</svg>`;
+}
+
+/**
+ * Build a minimal canonical-shaped `battle_armor_squad` template
+ * exposing `pips_0..columns-1` trooper-column regions.
+ */
+function buildBattleArmorTemplate(columns: number): string {
+  const regions: string[] = [];
+  for (let i = 0; i < columns; i++) {
+    regions.push(
+      `<g id="col_${i}"><rect id="pips_${i}" x="${i * 200}" y="0" width="190" height="12"/></g>`,
+    );
+  }
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="576" height="756" viewBox="0 0 576 756">
+  <text id="type"></text>
+  <text id="bv"></text>
+  <text id="squad"></text>
+  ${regions.join('\n')}
+</svg>`;
+}
+
+/** Mock a successful template fetch returning `svg`. */
+function mockTemplateOk(svg: string) {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    text: () => Promise.resolve(svg),
+    headers: new Headers({ 'content-type': 'image/svg+xml' }),
+  });
+}
+
+/** Mock a hard asset failure — every source returns 404. */
+function mockTemplateFail() {
+  mockFetch.mockResolvedValue({ ok: false, status: 404 });
+}
+
+function header(): IRecordSheetHeader {
+  return {
+    unitName: 'Fixture',
+    chassis: 'Fixture',
+    model: 'FX-1',
+    tonnage: 3,
+    techBase: 'Inner Sphere',
+    rulesLevel: 'Standard',
+    era: 'Test',
+    role: 'Infantry',
+    battleValue: 100,
+    cost: 100_000,
+  };
+}
+
+function trooper(index: number, armorPips: number): IBattleArmorTrooper {
+  return {
+    index,
+    armorPips,
+    maximumArmorPips: armorPips,
+    gunnery: 4,
+    antiMech: 4,
+  };
+}
+
+/** A 28-trooper foot rifle platoon fixture. */
+function infantryFixture(platoonSize = 28): IInfantryRecordSheetData {
+  return {
+    unitType: 'infantry',
+    header: header(),
+    platoonSize,
+    platoonComposition: { squads: 4, troopersPerSquad: 7 },
+    motiveType: 'Foot',
+    armorKit: 'None',
+    primaryWeapon: {
+      name: 'Rifle',
+      damage: '1/10',
+      infantryDamage: 0.28,
+      minimumRange: 0,
+      shortRange: 1,
+      mediumRange: 2,
+      longRange: 3,
+    },
+    secondaryWeapons: [],
+    antiMechTraining: false,
+    gunnery: 4,
+    antiMech: 5,
+  };
+}
+
+/** A Battle Armor squad fixture with the given per-trooper armor. */
+function battleArmorFixture(
+  armorByTrooper: readonly number[],
+): IBattleArmorRecordSheetData {
+  return {
+    unitType: 'battlearmor',
+    header: { ...header(), role: 'Battle Armor', battleValue: 105 },
+    squadSize: armorByTrooper.length,
+    troopers: armorByTrooper.map((armor, i) => trooper(i + 1, armor)),
+    manipulators: { left: 'Battle Claw', right: 'Battle Claw' },
+    jumpMP: 3,
+    walkMP: 1,
+    umuMP: 0,
+    vtolMP: 0,
+  };
+}
+
+/** Count `<circle>` pip elements in a rendered SVG string. */
+function countCircles(svg: string): number {
+  return (svg.match(/<circle\b/g) ?? []).length;
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  resetMmDataAssetService();
+});
+
+describe('infantry pip-count fidelity gate', () => {
+  it('platoon pip-grid element count equals the trooper count', async () => {
+    mockTemplateOk(buildInfantryTemplate(30));
+    const svg = await renderInfantryTemplated(
+      infantryFixture(28),
+      PaperSize.LETTER,
+    );
+    // 28 platoon pip markers — one per occupied soldier slot.
+    expect(countCircles(svg)).toBe(28);
+  });
+
+  it('a deliberately-wrong fixture fails the fidelity assertion', async () => {
+    mockTemplateOk(buildInfantryTemplate(30));
+    const svg = await renderInfantryTemplated(
+      infantryFixture(20),
+      PaperSize.LETTER,
+    );
+    // The fixture truly has 20 troopers; asserting 28 must fail.
+    expect(countCircles(svg)).not.toBe(28);
+    expect(countCircles(svg)).toBe(20);
+  });
+});
+
+describe('battle armor pip-count fidelity gate', () => {
+  it('per-trooper pip count equals each trooper armor + 1', async () => {
+    mockTemplateOk(buildBattleArmorTemplate(6));
+    // 5-trooper squad, 5 armor each -> 6 pips per column -> 30 total.
+    const svg = await renderBattleArmorTemplated(
+      battleArmorFixture([5, 5, 5, 5, 5]),
+      PaperSize.LETTER,
+    );
+    expect(countCircles(svg)).toBe(5 * 6);
+  });
+
+  it('respects varied per-trooper armor values', async () => {
+    mockTemplateOk(buildBattleArmorTemplate(6));
+    // armor 3,8,10 -> pips 4,9,11 -> 24 total.
+    const svg = await renderBattleArmorTemplated(
+      battleArmorFixture([3, 8, 10]),
+      PaperSize.LETTER,
+    );
+    expect(countCircles(svg)).toBe(4 + 9 + 11);
+  });
+
+  it('a deliberately-wrong fixture fails the fidelity assertion', async () => {
+    mockTemplateOk(buildBattleArmorTemplate(6));
+    const svg = await renderBattleArmorTemplated(
+      battleArmorFixture([4, 4, 4, 4]),
+      PaperSize.LETTER,
+    );
+    // The fixture truly renders 4 * 5 = 20 pips; asserting 30 must fail.
+    expect(countCircles(svg)).not.toBe(30);
+    expect(countCircles(svg)).toBe(4 * 5);
+  });
+});
+
+describe('skeleton fallback on asset failure', () => {
+  it('infantry degrades to the skeleton renderer on a hard asset failure', async () => {
+    mockTemplateFail();
+    const svg = await renderInfantryTemplated(
+      infantryFixture(28),
+      PaperSize.LETTER,
+    );
+    // The skeleton renderer always produces a non-empty SVG and never
+    // carries the canonical-template marker.
+    expect(svg).toContain('<svg');
+    expect(svg).not.toContain(CANONICAL_TEMPLATE_MARKER);
+  });
+
+  it('battle armor degrades to the skeleton renderer on a hard asset failure', async () => {
+    mockTemplateFail();
+    const svg = await renderBattleArmorTemplated(
+      battleArmorFixture([5, 5, 5, 5, 5]),
+      PaperSize.LETTER,
+    );
+    expect(svg).toContain('<svg');
+    expect(svg).not.toContain(CANONICAL_TEMPLATE_MARKER);
+  });
+});
+
+describe('renderTemplated dispatch (Wave-2 unit types)', () => {
+  it('routes an infantry payload through the infantry templated path', async () => {
+    mockTemplateOk(buildInfantryTemplate(30));
+    const svg = await renderTemplated(infantryFixture(7), PaperSize.LETTER);
+    expect(svg).toContain(CANONICAL_TEMPLATE_MARKER);
+    expect(countCircles(svg)).toBe(7);
+  });
+
+  it('routes a battle-armor payload through the BA templated path', async () => {
+    mockTemplateOk(buildBattleArmorTemplate(6));
+    const svg = await renderTemplated(
+      battleArmorFixture([6, 6, 6, 6]),
+      PaperSize.LETTER,
+    );
+    expect(svg).toContain(CANONICAL_TEMPLATE_MARKER);
+    expect(countCircles(svg)).toBe(4 * 7);
+  });
+});
+
+describe('silent-fallback guard', () => {
+  it('isTemplatedUnit returns true for both Wave-2 families', () => {
+    // The inverse of the Wave-1 exclusion behaviour.
+    expect(isTemplatedUnit(infantryFixture())).toBe(true);
+    expect(isTemplatedUnit(battleArmorFixture([5, 5, 5, 5]))).toBe(true);
+  });
+
+  it('templated infantry SVG carries the canonical-template marker', async () => {
+    mockTemplateOk(buildInfantryTemplate(30));
+    const templated = await renderInfantryTemplated(
+      infantryFixture(28),
+      PaperSize.LETTER,
+    );
+    // Marker present on the template path...
+    expect(templated).toContain(CANONICAL_TEMPLATE_MARKER);
+    // ...and ABSENT from the skeleton renderer's output — so a silent
+    // fallback would be caught.
+    const skeleton = renderInfantrySVG(infantryFixture(28));
+    expect(skeleton).not.toContain(CANONICAL_TEMPLATE_MARKER);
+  });
+
+  it('templated battle-armor SVG carries the canonical-template marker', async () => {
+    mockTemplateOk(buildBattleArmorTemplate(6));
+    const templated = await renderBattleArmorTemplated(
+      battleArmorFixture([5, 5, 5, 5, 5]),
+      PaperSize.LETTER,
+    );
+    expect(templated).toContain(CANONICAL_TEMPLATE_MARKER);
+    const skeleton = renderBattleArmorSVG(battleArmorFixture([5, 5, 5, 5, 5]));
+    expect(skeleton).not.toContain(CANONICAL_TEMPLATE_MARKER);
+  });
+});

--- a/src/services/printing/svgRecordSheetRenderer/battlearmor/__tests__/battlearmorAdapter.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/battlearmor/__tests__/battlearmorAdapter.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Battle Armor family adapter — unit tests.
+ *
+ * Covers `selectBattleArmorTemplate` (per-unit block key) and
+ * `bindBattleArmor` (catalogued text IDs + typed per-trooper
+ * `PipCounts`).
+ *
+ * @spec openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Infantry and Battle Armor Record Sheet Adapters)
+ */
+
+import type {
+  IBattleArmorRecordSheetData,
+  IBattleArmorTrooper,
+} from '@/types/printing';
+
+import { BATTLEARMOR_TEMPLATE_IDS } from '../../templateElementIds';
+import { bindBattleArmor, computeBattleArmorPipCounts } from '../bindings';
+import { selectBattleArmorTemplate } from '../selectTemplate';
+
+/** Build a Battle Armor trooper fixture. */
+function trooper(index: number, armorPips: number): IBattleArmorTrooper {
+  return {
+    index,
+    armorPips,
+    maximumArmorPips: armorPips,
+    gunnery: 4,
+    antiMech: 4,
+  };
+}
+
+/** Build a Battle Armor squad fixture with N troopers. */
+function squad(
+  trooperCount: number,
+  armorPips = 5,
+): IBattleArmorRecordSheetData {
+  return {
+    unitType: 'battlearmor',
+    header: {
+      unitName: 'Elemental',
+      chassis: 'Elemental',
+      model: 'Standard',
+      tonnage: 1,
+      techBase: 'Clan',
+      rulesLevel: 'Standard',
+      era: '3050',
+      role: 'Battle Armor',
+      battleValue: 105,
+      cost: 0,
+    },
+    squadSize: trooperCount,
+    troopers: Array.from({ length: trooperCount }, (_, i) =>
+      trooper(i + 1, armorPips),
+    ),
+    manipulators: { left: 'Battle Claw', right: 'Battle Claw' },
+    jumpMP: 3,
+    walkMP: 1,
+    umuMP: 0,
+    vtolMP: 0,
+  };
+}
+
+describe('selectBattleArmorTemplate', () => {
+  it('returns the per-unit block key, not the multi-slot outer sheet', () => {
+    expect(selectBattleArmorTemplate(squad(5))).toBe('battle_armor_squad');
+  });
+
+  it('is a pure deterministic function', () => {
+    const fixture = squad(6);
+    expect(selectBattleArmorTemplate(fixture)).toBe(
+      selectBattleArmorTemplate(fixture),
+    );
+  });
+});
+
+describe('computeBattleArmorPipCounts', () => {
+  it('produces one entry per trooper with that trooper armorPips', () => {
+    const data: IBattleArmorRecordSheetData = {
+      ...squad(5),
+      troopers: [
+        trooper(1, 3),
+        trooper(2, 6),
+        trooper(3, 9),
+        trooper(4, 4),
+        trooper(5, 7),
+      ],
+    };
+    const counts = computeBattleArmorPipCounts(data);
+    expect(counts.troopers).toHaveLength(5);
+    expect(counts.troopers.map((t) => t.armorPips)).toEqual([3, 6, 9, 4, 7]);
+    expect(counts.troopers.map((t) => t.column)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('handles 4-, 5-, and 6-trooper squads', () => {
+    expect(computeBattleArmorPipCounts(squad(4)).troopers).toHaveLength(4);
+    expect(computeBattleArmorPipCounts(squad(5)).troopers).toHaveLength(5);
+    expect(computeBattleArmorPipCounts(squad(6)).troopers).toHaveLength(6);
+  });
+
+  it('clamps to the 6-column template capacity', () => {
+    // Defensive — a squad never exceeds 6, but a malformed input must
+    // not overflow the template.
+    expect(computeBattleArmorPipCounts(squad(8)).troopers).toHaveLength(6);
+  });
+
+  it('floors negative armor at zero', () => {
+    const data: IBattleArmorRecordSheetData = {
+      ...squad(4),
+      troopers: [trooper(1, -2), trooper(2, 5), trooper(3, 5), trooper(4, 5)],
+    };
+    expect(computeBattleArmorPipCounts(data).troopers[0].armorPips).toBe(0);
+  });
+});
+
+describe('bindBattleArmor', () => {
+  it('binds only catalogued template element IDs', () => {
+    const { texts } = bindBattleArmor(squad(5));
+    const catalogIds = new Set<string>(Object.values(BATTLEARMOR_TEMPLATE_IDS));
+    for (const id of Object.keys(texts)) {
+      expect(catalogIds.has(id)).toBe(true);
+    }
+  });
+
+  it('binds the header type, role, BV, and squad designation', () => {
+    const { texts } = bindBattleArmor(squad(5));
+    expect(texts[BATTLEARMOR_TEMPLATE_IDS.type]).toBe('Elemental Standard');
+    expect(texts[BATTLEARMOR_TEMPLATE_IDS.bv]).toBe('105');
+    expect(texts[BATTLEARMOR_TEMPLATE_IDS.squad]).toContain('BATTLE ARMOR');
+  });
+
+  it('binds jump MP as the secondary movement mode', () => {
+    const { texts } = bindBattleArmor(squad(5));
+    expect(texts[BATTLEARMOR_TEMPLATE_IDS.movementMode2]).toBe('Jump MP:');
+    expect(texts[BATTLEARMOR_TEMPLATE_IDS.mp2]).toBe('3');
+  });
+
+  it('exposes per-trooper PipCounts equal to each trooper armor value', () => {
+    const data: IBattleArmorRecordSheetData = {
+      ...squad(5),
+      troopers: [
+        trooper(1, 8),
+        trooper(2, 8),
+        trooper(3, 8),
+        trooper(4, 8),
+        trooper(5, 8),
+      ],
+    };
+    const { pipCounts } = bindBattleArmor(data);
+    expect(pipCounts.troopers).toHaveLength(5);
+    for (const t of pipCounts.troopers) {
+      expect(t.armorPips).toBe(8);
+    }
+  });
+
+  it('PipCounts for 4-, 5-, and 6-trooper squads match squad size', () => {
+    expect(bindBattleArmor(squad(4)).pipCounts.troopers).toHaveLength(4);
+    expect(bindBattleArmor(squad(5)).pipCounts.troopers).toHaveLength(5);
+    expect(bindBattleArmor(squad(6)).pipCounts.troopers).toHaveLength(6);
+  });
+
+  it('is pure — no DOM, no I/O, deterministic', () => {
+    const fixture = squad(6);
+    const a = bindBattleArmor(fixture);
+    const b = bindBattleArmor(fixture);
+    expect(a.texts).toEqual(b.texts);
+    expect(a.pipCounts).toEqual(b.pipCounts);
+  });
+});

--- a/src/services/printing/svgRecordSheetRenderer/battlearmor/bindings.ts
+++ b/src/services/printing/svgRecordSheetRenderer/battlearmor/bindings.ts
@@ -1,0 +1,128 @@
+/**
+ * Battle Armor family — template bindings.
+ *
+ * Pure function mapping an `IBattleArmorRecordSheetData` to the
+ * `{ texts, pips, pipCounts }` structure consumed by the templated
+ * render path. Text targets are keyed against the Phase-0
+ * `BATTLEARMOR_TEMPLATE_IDS` catalog; the typed per-trooper `PipCounts`
+ * contract is computed from each trooper's armor pip count and is the
+ * input to the Battle Armor per-trooper pip grid.
+ *
+ * The Battle Armor sheet's pips are NOT per-location single-region
+ * groups (the Wave-1 `PipFill` model) — they are a per-trooper column
+ * grid. `pips` is therefore the typed per-trooper structure the
+ * `layoutBattleArmorPipGrid` pip-engine helper consumes directly; the
+ * dispatch wrapper hands it straight to that helper rather than through
+ * the shared `applyPips` path.
+ *
+ * No I/O, no DOM, no asset access — a deterministic pure function.
+ *
+ * @spec openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Infantry and Battle Armor Record Sheet Adapters)
+ */
+
+import type { IBattleArmorRecordSheetData } from '@/types/printing';
+
+import type { BattleArmorTrooperPips } from '../pipEngine';
+import type { TextBindings } from '../templateRecordSheetRenderer';
+
+import { BATTLEARMOR_TEMPLATE_IDS } from '../templateElementIds';
+
+/**
+ * Per-trooper armor pip counts for a Battle Armor squad — the typed
+ * fidelity-gate contract.
+ *
+ * `troopers` holds one entry per trooper present in the squad (4–6),
+ * each with its zero-based `column` index and canonical `armorPips`
+ * value. The Battle Armor per-trooper pip grid renders `armorPips + 1`
+ * pips per column (the MegaMek trooper-pip convention); the fidelity
+ * gate asserts the rendered per-column count equals `armorPips + 1`.
+ */
+export interface BattleArmorPipCounts {
+  /** One entry per trooper present in the squad. */
+  readonly troopers: readonly BattleArmorTrooperPips[];
+}
+
+/** The result of binding a Battle Armor squad to its canonical template. */
+export interface BattleArmorBindings {
+  /** Text injections keyed by template element ID. */
+  readonly texts: TextBindings;
+  /**
+   * The typed per-trooper pip-count contract. Consumed directly by the
+   * `layoutBattleArmorPipGrid` pip-engine helper — Battle Armor does not
+   * use the Wave-1 `PipFill` per-location model.
+   */
+  readonly pips: BattleArmorPipCounts;
+  /** Alias of `pips` — the fidelity-gate input (mirrors Wave-1 naming). */
+  readonly pipCounts: BattleArmorPipCounts;
+}
+
+/**
+ * Compute the per-trooper armor pip counts for a Battle Armor squad.
+ *
+ * One `BattleArmorTrooperPips` entry per trooper, in template-column
+ * order (`column` zero-based, capped at the template's 6 columns). The
+ * `armorPips` value is the trooper's canonical current armor; the pip
+ * grid adds the `+1` trooper pip when it renders.
+ */
+export function computeBattleArmorPipCounts(
+  data: IBattleArmorRecordSheetData,
+): BattleArmorPipCounts {
+  const troopers: BattleArmorTrooperPips[] = [];
+  // The template exposes pips_0..pips_5 — 6 trooper columns. A squad
+  // never exceeds 6 troopers; clamp defensively.
+  const limit = Math.min(data.troopers.length, 6);
+  for (let column = 0; column < limit; column++) {
+    const trooper = data.troopers[column];
+    troopers.push({
+      column,
+      armorPips: Math.max(0, trooper.armorPips),
+    });
+  }
+  return { troopers };
+}
+
+/**
+ * Bind a Battle Armor squad to its canonical template.
+ *
+ * Produces header / squad / movement / crew text injections and the
+ * typed per-trooper pip-count contract. Only catalogued template IDs
+ * are referenced.
+ */
+export function bindBattleArmor(
+  data: IBattleArmorRecordSheetData,
+): BattleArmorBindings {
+  const { header } = data;
+  const pipCounts = computeBattleArmorPipCounts(data);
+
+  // --- Text bindings (catalogued IDs only) ---
+  const texts: Record<string, string> = {
+    [BATTLEARMOR_TEMPLATE_IDS.type]: `${header.chassis} ${header.model}`,
+    [BATTLEARMOR_TEMPLATE_IDS.role]: header.role ?? '',
+    [BATTLEARMOR_TEMPLATE_IDS.bv]: header.battleValue.toLocaleString(),
+    [BATTLEARMOR_TEMPLATE_IDS.squad]: `BATTLE ARMOR: ${header.chassis} ${header.model}`,
+    [BATTLEARMOR_TEMPLATE_IDS.mpWalk]: String(data.walkMP),
+  };
+
+  // Secondary movement mode — jump / VTOL / UW, in that priority order
+  // (mirrors MegaMek `PrintBattleArmor`).
+  if (data.jumpMP > 0) {
+    texts[BATTLEARMOR_TEMPLATE_IDS.movementMode2] = 'Jump MP:';
+    texts[BATTLEARMOR_TEMPLATE_IDS.mp2] = String(data.jumpMP);
+  } else if (data.vtolMP > 0) {
+    texts[BATTLEARMOR_TEMPLATE_IDS.movementMode2] = 'VTOL MP:';
+    texts[BATTLEARMOR_TEMPLATE_IDS.mp2] = String(data.vtolMP);
+  } else if (data.umuMP > 0) {
+    texts[BATTLEARMOR_TEMPLATE_IDS.movementMode2] = 'UW MP:';
+    texts[BATTLEARMOR_TEMPLATE_IDS.mp2] = String(data.umuMP);
+  }
+
+  // Crew skills — bind the first trooper's gunnery / anti-mech skill.
+  const lead = data.troopers[0];
+  if (lead) {
+    texts[BATTLEARMOR_TEMPLATE_IDS.gunnerySkill0] = String(lead.gunnery);
+    texts[BATTLEARMOR_TEMPLATE_IDS.pilotingSkill0] = String(lead.antiMech);
+  }
+
+  return { texts, pips: pipCounts, pipCounts };
+}

--- a/src/services/printing/svgRecordSheetRenderer/battlearmor/selectTemplate.ts
+++ b/src/services/printing/svgRecordSheetRenderer/battlearmor/selectTemplate.ts
@@ -1,0 +1,37 @@
+/**
+ * Battle Armor family — canonical template selection.
+ *
+ * Pure function mapping an `IBattleArmorRecordSheetData` to its Wave-2
+ * `templateKey`. For the single-unit MVP this is always the per-unit
+ * block template `battle_armor_squad` — mirroring MegaMekLab
+ * `PrintBattleArmor.getSVGFileName()`, which returns
+ * `battle_armor_squad.svg`.
+ *
+ * The multi-slot outer sheet `battle_armor_default` (MegaMekLab's
+ * `PrintSmallUnitSheet` composite, up to 4 squads per page) is
+ * registered as an asset but is NOT selected here — the multi-unit
+ * composite is a deferred follow-up. See the change's Non-Goals.
+ *
+ * @spec openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Infantry and Battle Armor Record Sheet Adapters)
+ */
+
+import type { IBattleArmorRecordSheetData } from '@/types/printing';
+
+/** The Wave-2 Battle Armor per-unit block template key. */
+export type BattleArmorTemplateKey = 'battle_armor_squad';
+
+/**
+ * Select the canonical Wave-2 template key for a Battle Armor squad.
+ *
+ * Always returns the per-unit block `battle_armor_squad` — the atomic,
+ * self-contained record sheet — NOT the multi-slot
+ * `battle_armor_default` outer sheet. The `data` parameter is accepted
+ * for signature parity with the other per-family `selectTemplate`
+ * adapters and for forward-compatibility with the deferred composite.
+ */
+export function selectBattleArmorTemplate(
+  _data: IBattleArmorRecordSheetData,
+): BattleArmorTemplateKey {
+  return 'battle_armor_squad';
+}

--- a/src/services/printing/svgRecordSheetRenderer/infantry/__tests__/infantryAdapter.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/infantry/__tests__/infantryAdapter.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Conventional Infantry family adapter — unit tests.
+ *
+ * Covers `selectInfantryTemplate` (per-unit block key) and
+ * `bindInfantry` (catalogued text IDs, platoon `PipCounts`, and the
+ * 30-value damage row).
+ *
+ * @spec openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Infantry and Battle Armor Record Sheet Adapters)
+ */
+
+import type { IInfantryRecordSheetData } from '@/types/printing';
+
+import { INFANTRY_TEMPLATE_IDS } from '../../templateElementIds';
+import {
+  bindInfantry,
+  computeDamagePerTrooper,
+  computeInfantryPipCounts,
+} from '../bindings';
+import { selectInfantryTemplate } from '../selectTemplate';
+
+/** Build a 28-trooper foot rifle platoon fixture. */
+function platoon(
+  overrides: Partial<IInfantryRecordSheetData> = {},
+): IInfantryRecordSheetData {
+  return {
+    unitType: 'infantry',
+    header: {
+      unitName: 'Foot Platoon',
+      chassis: 'Foot Platoon',
+      model: '(Rifle)',
+      tonnage: 3,
+      techBase: 'Inner Sphere',
+      rulesLevel: 'Standard',
+      era: '3025',
+      role: 'Infantry',
+      battleValue: 90,
+      cost: 0,
+    },
+    platoonSize: 28,
+    platoonComposition: { squads: 4, troopersPerSquad: 7 },
+    motiveType: 'Foot',
+    armorKit: 'None',
+    primaryWeapon: {
+      name: 'Rifle',
+      damage: '1/10',
+      infantryDamage: 0.28,
+      minimumRange: 0,
+      shortRange: 1,
+      mediumRange: 2,
+      longRange: 3,
+    },
+    secondaryWeapons: [],
+    antiMechTraining: false,
+    gunnery: 4,
+    antiMech: 5,
+    ...overrides,
+  };
+}
+
+describe('selectInfantryTemplate', () => {
+  it('returns the per-unit block key, not the multi-slot outer sheet', () => {
+    expect(selectInfantryTemplate(platoon())).toBe(
+      'conventional_infantry_platoon',
+    );
+  });
+
+  it('is a pure deterministic function', () => {
+    const fixture = platoon();
+    expect(selectInfantryTemplate(fixture)).toBe(
+      selectInfantryTemplate(fixture),
+    );
+  });
+});
+
+describe('computeInfantryPipCounts', () => {
+  it('platoon pip count equals the platoon trooper count', () => {
+    expect(computeInfantryPipCounts(platoon()).platoonSize).toBe(28);
+  });
+
+  it('floors a negative platoon size at zero', () => {
+    expect(
+      computeInfantryPipCounts(platoon({ platoonSize: -5 })).platoonSize,
+    ).toBe(0);
+  });
+});
+
+describe('computeDamagePerTrooper', () => {
+  it('reproduces the MegaMek formula for a primary-only platoon', () => {
+    // squadSize 7, primary 0.28, no secondaries -> perTrooper 0.28
+    expect(computeDamagePerTrooper(platoon())).toBeCloseTo(0.28, 10);
+  });
+
+  it('includes secondary-weapon damage when present', () => {
+    const data = platoon({
+      secondaryWeapons: [
+        {
+          name: 'SRM Launcher',
+          damage: '1/6',
+          infantryDamage: 0.57,
+          minimumRange: 0,
+          shortRange: 3,
+          mediumRange: 6,
+          longRange: 9,
+          perTrooperRatio: 0,
+          count: 2,
+        },
+      ],
+    });
+    // damage = 0.28 * (7 - 2) + 0.57 * 2 = 1.4 + 1.14 = 2.54 -> /7
+    expect(computeDamagePerTrooper(data)).toBeCloseTo(2.54 / 7, 10);
+  });
+});
+
+describe('bindInfantry', () => {
+  it('binds only catalogued template element IDs', () => {
+    const { texts } = bindInfantry(platoon());
+    const catalogIds = new Set<string>(Object.values(INFANTRY_TEMPLATE_IDS));
+    const damagePrefix = INFANTRY_TEMPLATE_IDS.damagePrefix;
+    for (const id of Object.keys(texts)) {
+      // damage_N IDs are the numbered family — accept the prefix match.
+      const ok = catalogIds.has(id) || id.startsWith(damagePrefix);
+      expect(ok).toBe(true);
+    }
+  });
+
+  it('binds the header type, role, BV, and armor kit', () => {
+    const { texts } = bindInfantry(platoon());
+    expect(texts[INFANTRY_TEMPLATE_IDS.type]).toBe('Foot Platoon (Rifle)');
+    expect(texts[INFANTRY_TEMPLATE_IDS.bv]).toBe('90');
+    expect(texts[INFANTRY_TEMPLATE_IDS.armorKit]).toBe('None');
+  });
+
+  it('platoon PipCounts equals platoonSize (28-trooper fixture)', () => {
+    expect(bindInfantry(platoon()).pipCounts.platoonSize).toBe(28);
+  });
+
+  it('produces a 30-value damage row', () => {
+    const { damageRow } = bindInfantry(platoon());
+    expect(damageRow).toHaveLength(30);
+  });
+
+  it('binds damage_1..damage_30 = round(perTrooper * j)', () => {
+    const { texts } = bindInfantry(platoon());
+    // perTrooper 0.28: damage_1 = round(0.28) = 0; damage_30 = round(8.4) = 8.
+    expect(texts[`${INFANTRY_TEMPLATE_IDS.damagePrefix}1`]).toBe('0');
+    expect(texts[`${INFANTRY_TEMPLATE_IDS.damagePrefix}30`]).toBe('8');
+    // every numbered slot 1..30 is present.
+    for (let j = 1; j <= 30; j++) {
+      expect(texts[`${INFANTRY_TEMPLATE_IDS.damagePrefix}${j}`]).toBeDefined();
+    }
+  });
+
+  it('binds the field-gun block only when a field gun is present', () => {
+    const without = bindInfantry(platoon());
+    expect(without.texts[INFANTRY_TEMPLATE_IDS.fieldGunType]).toBeUndefined();
+
+    const withGun = bindInfantry(
+      platoon({
+        fieldGun: {
+          name: 'Field Gun (AC/2)',
+          count: 4,
+          damage: 2,
+          minimumRange: 4,
+          shortRange: 8,
+          mediumRange: 16,
+          longRange: 24,
+        },
+      }),
+    );
+    expect(withGun.texts[INFANTRY_TEMPLATE_IDS.fieldGunType]).toBe(
+      'Field Gun (AC/2)',
+    );
+    expect(withGun.texts[INFANTRY_TEMPLATE_IDS.fieldGunQty]).toBe('4');
+  });
+
+  it('is pure — no DOM, no I/O, deterministic', () => {
+    const fixture = platoon();
+    const a = bindInfantry(fixture);
+    const b = bindInfantry(fixture);
+    expect(a.texts).toEqual(b.texts);
+    expect(a.pipCounts).toEqual(b.pipCounts);
+    expect(a.damageRow).toEqual(b.damageRow);
+  });
+});

--- a/src/services/printing/svgRecordSheetRenderer/infantry/__tests__/infantryDamage.test.ts
+++ b/src/services/printing/svgRecordSheetRenderer/infantry/__tests__/infantryDamage.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the infantry damage-per-trooper formula module.
+ *
+ * Verifies the verbatim reproduction of MegaMek
+ * `Infantry.getDamagePerTrooper()` — including the 0.6 primary-weapon
+ * damage cap — and the `DAMAGE+j` row generator.
+ *
+ * @spec openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Infantry Damage-Per-Trooper Formula)
+ */
+
+import {
+  INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP,
+  generateDamageRow,
+  getDamagePerTrooper,
+  isPrimaryWeaponDamageCapped,
+} from '../infantryDamage';
+
+describe('getDamagePerTrooper', () => {
+  it('returns 0 when there is no primary weapon (Java null guard)', () => {
+    expect(
+      getDamagePerTrooper({
+        primaryWeaponDamage: undefined,
+        squadSize: 7,
+        secondaryWeaponsPerSquad: 0,
+      }),
+    ).toBe(0);
+  });
+
+  it('returns 0 when squadSize is zero (defensive divide-by-zero guard)', () => {
+    expect(
+      getDamagePerTrooper({
+        primaryWeaponDamage: 0.28,
+        squadSize: 0,
+        secondaryWeaponsPerSquad: 0,
+      }),
+    ).toBe(0);
+  });
+
+  it('reproduces the MegaMek formula for a primary-only squad', () => {
+    // adjusted = min(0.6, 0.28) = 0.28
+    // damage   = 0.28 * (7 - 0) = 1.96
+    // perTrooper = 1.96 / 7 = 0.28
+    const result = getDamagePerTrooper({
+      primaryWeaponDamage: 0.28,
+      squadSize: 7,
+      secondaryWeaponsPerSquad: 0,
+    });
+    expect(result).toBeCloseTo(0.28, 10);
+  });
+
+  it('adds the uncapped secondary-weapon contribution', () => {
+    // adjusted = min(0.6, 0.28) = 0.28
+    // damage   = 0.28 * (7 - 2) = 1.4
+    // damage  += 0.57 * 2 = 1.14  ->  damage = 2.54
+    // perTrooper = 2.54 / 7
+    const result = getDamagePerTrooper({
+      primaryWeaponDamage: 0.28,
+      secondaryWeaponDamage: 0.57,
+      squadSize: 7,
+      secondaryWeaponsPerSquad: 2,
+    });
+    expect(result).toBeCloseTo(2.54 / 7, 10);
+  });
+
+  it('caps the primary weapon contribution at 0.6 (09/2021 errata)', () => {
+    // primary damage 1.58 exceeds the 0.6 cap.
+    // capped:   adjusted = min(0.6, 1.58) = 0.6
+    //           damage = 0.6 * (7 - 0) = 4.2 -> perTrooper = 0.6
+    const capped = getDamagePerTrooper({
+      primaryWeaponDamage: 1.58,
+      squadSize: 7,
+      secondaryWeaponsPerSquad: 0,
+    });
+    expect(capped).toBeCloseTo(0.6, 10);
+
+    // uncapped (hypothetical) would be 1.58 — prove the cap actually bites.
+    const uncappedHypothetical = (1.58 * 7) / 7;
+    expect(capped).toBeLessThan(uncappedHypothetical);
+  });
+
+  it('does NOT cap the secondary weapon contribution', () => {
+    // secondary damage 1.58 is above 0.6 but is NOT capped.
+    // damage = min(0.6, 0.28) * (7 - 3) + 1.58 * 3
+    //        = 0.28 * 4 + 4.74 = 1.12 + 4.74 = 5.86
+    const result = getDamagePerTrooper({
+      primaryWeaponDamage: 0.28,
+      secondaryWeaponDamage: 1.58,
+      squadSize: 7,
+      secondaryWeaponsPerSquad: 3,
+    });
+    expect(result).toBeCloseTo(5.86 / 7, 10);
+  });
+
+  it('uses 0.6 as the cap constant', () => {
+    expect(INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP).toBe(0.6);
+  });
+});
+
+describe('isPrimaryWeaponDamageCapped', () => {
+  it('is true when primary damage exceeds 0.6', () => {
+    expect(isPrimaryWeaponDamageCapped(1.58)).toBe(true);
+    expect(isPrimaryWeaponDamageCapped(0.84)).toBe(true);
+  });
+
+  it('is false when primary damage is at or below 0.6', () => {
+    expect(isPrimaryWeaponDamageCapped(0.6)).toBe(false);
+    expect(isPrimaryWeaponDamageCapped(0.28)).toBe(false);
+    expect(isPrimaryWeaponDamageCapped(undefined)).toBe(false);
+  });
+});
+
+describe('generateDamageRow', () => {
+  it('emits exactly 30 values', () => {
+    expect(generateDamageRow(0.28)).toHaveLength(30);
+  });
+
+  it('computes DAMAGE+j = round(perTrooper * j)', () => {
+    const row = generateDamageRow(0.28);
+    // j=1 -> round(0.28 * 1) = 0
+    expect(row[0]).toBe(0);
+    // j=30 -> round(0.28 * 30) = round(8.4) = 8
+    expect(row[29]).toBe(8);
+    // spot-check a mid value: j=10 -> round(2.8) = 3
+    expect(row[9]).toBe(3);
+  });
+
+  it('rounds half-up consistently with Java Math.round', () => {
+    // perTrooper 0.5 -> j=1 gives round(0.5) = 1 (half-up)
+    const row = generateDamageRow(0.5);
+    expect(row[0]).toBe(1);
+    // j=3 -> round(1.5) = 2
+    expect(row[2]).toBe(2);
+  });
+
+  it('handles a zero per-trooper damage (all-zero row)', () => {
+    const row = generateDamageRow(0);
+    expect(row.every((v) => v === 0)).toBe(true);
+  });
+});

--- a/src/services/printing/svgRecordSheetRenderer/infantry/bindings.ts
+++ b/src/services/printing/svgRecordSheetRenderer/infantry/bindings.ts
@@ -1,0 +1,156 @@
+/**
+ * Conventional Infantry family — template bindings.
+ *
+ * Pure function mapping an `IInfantryRecordSheetData` to the
+ * `{ texts, pips, pipCounts }` structure consumed by the templated
+ * render path. Text targets are keyed against the Phase-0
+ * `INFANTRY_TEMPLATE_IDS` catalog; the typed `PipCounts` contract
+ * carries the platoon trooper count, and the damage row is computed via
+ * the Phase-1 damage-per-trooper formula module.
+ *
+ * The infantry sheet's pips are NOT per-location single-region groups
+ * (the Wave-1 `PipFill` model) — they are a single platoon grid.
+ * `pips` is therefore the typed `PipCounts` structure the
+ * `layoutInfantryPlatoonPipGrid` pip-engine helper consumes directly;
+ * the dispatch wrapper hands it straight to that helper rather than
+ * through the shared `applyPips` path.
+ *
+ * No I/O, no DOM, no asset access — a deterministic pure function.
+ *
+ * @spec openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Infantry and Battle Armor Record Sheet Adapters)
+ */
+
+import type { IInfantryRecordSheetData } from '@/types/printing';
+
+import type { TextBindings } from '../templateRecordSheetRenderer';
+
+import { INFANTRY_TEMPLATE_IDS } from '../templateElementIds';
+import { generateDamageRow, getDamagePerTrooper } from './infantryDamage';
+
+/**
+ * Platoon pip counts for a conventional infantry platoon — the typed
+ * fidelity-gate contract.
+ *
+ * `platoonSize` is the total trooper count; the infantry platoon pip
+ * grid renders exactly that many pip markers, and the fidelity gate
+ * asserts the rendered count equals it.
+ */
+export interface InfantryPipCounts {
+  /** Total platoon trooper count — the platoon pip-grid size. */
+  readonly platoonSize: number;
+}
+
+/** The result of binding an infantry platoon to its canonical template. */
+export interface InfantryBindings {
+  /** Text injections keyed by template element ID (incl. the damage row). */
+  readonly texts: TextBindings;
+  /**
+   * The typed platoon pip-count contract. Consumed directly by the
+   * `layoutInfantryPlatoonPipGrid` pip-engine helper — infantry does not
+   * use the Wave-1 `PipFill` per-location model.
+   */
+  readonly pips: InfantryPipCounts;
+  /** Alias of `pips` — the fidelity-gate input (mirrors Wave-1 naming). */
+  readonly pipCounts: InfantryPipCounts;
+  /**
+   * The per-trooper-count damage row — 30 integers, `DAMAGE+j` for `j`
+   * in `1..30`. Exposed for test assertions; the values are also bound
+   * into `texts` against the `damage_1`..`damage_30` IDs.
+   */
+  readonly damageRow: readonly number[];
+}
+
+/**
+ * Compute the platoon pip counts for an infantry platoon.
+ *
+ * The pip-grid size is the platoon's total trooper count.
+ */
+export function computeInfantryPipCounts(
+  data: IInfantryRecordSheetData,
+): InfantryPipCounts {
+  return { platoonSize: Math.max(0, data.platoonSize) };
+}
+
+/**
+ * Compute the platoon's damage-per-trooper value from its primary and
+ * secondary weapons, using the Phase-1 verbatim MegaMek formula.
+ *
+ * `squadSize` is the platoon's per-squad trooper count
+ * (`platoonComposition.troopersPerSquad`); `secondaryWeaponsPerSquad` is
+ * the count of secondary weapons carried per squad. The first secondary
+ * weapon (if any) supplies the secondary damage input — mirroring
+ * MegaMek `Infantry`, which models a single `secondaryWeapon`.
+ */
+export function computeDamagePerTrooper(
+  data: IInfantryRecordSheetData,
+): number {
+  const squadSize = Math.max(1, data.platoonComposition.troopersPerSquad);
+  const firstSecondary = data.secondaryWeapons[0];
+  // Secondary weapons per squad: an explicit `count`, else derived from
+  // the per-trooper ratio (1 secondary per `perTrooperRatio` troopers).
+  let secondaryWeaponsPerSquad = 0;
+  if (firstSecondary) {
+    secondaryWeaponsPerSquad =
+      firstSecondary.count ??
+      (firstSecondary.perTrooperRatio > 0
+        ? Math.floor(squadSize / firstSecondary.perTrooperRatio)
+        : 0);
+  }
+  return getDamagePerTrooper({
+    primaryWeaponDamage: data.primaryWeapon.infantryDamage,
+    secondaryWeaponDamage: firstSecondary?.infantryDamage,
+    squadSize,
+    secondaryWeaponsPerSquad,
+  });
+}
+
+/**
+ * Bind an infantry platoon to its canonical template.
+ *
+ * Produces header / movement / weapon / crew text injections, the
+ * `damage_1`..`damage_30` row computed via the damage-per-trooper
+ * formula, and the typed platoon pip-count contract. Only catalogued
+ * template IDs are referenced.
+ */
+export function bindInfantry(data: IInfantryRecordSheetData): InfantryBindings {
+  const { header } = data;
+  const pipCounts = computeInfantryPipCounts(data);
+  const perTrooper = computeDamagePerTrooper(data);
+  const damageRow = generateDamageRow(perTrooper);
+
+  // --- Text bindings (catalogued IDs only) ---
+  const texts: Record<string, string> = {
+    [INFANTRY_TEMPLATE_IDS.type]: `${header.chassis} ${header.model}`,
+    [INFANTRY_TEMPLATE_IDS.role]: header.role ?? '',
+    [INFANTRY_TEMPLATE_IDS.bv]: header.battleValue.toLocaleString(),
+    [INFANTRY_TEMPLATE_IDS.armorKit]: data.armorKit,
+    [INFANTRY_TEMPLATE_IDS.transportWt]: String(header.tonnage),
+    [INFANTRY_TEMPLATE_IDS.mp1]: data.motiveType,
+    [INFANTRY_TEMPLATE_IDS.movementMode1]: data.motiveType,
+    [INFANTRY_TEMPLATE_IDS.gunnerySkill0]: String(data.gunnery),
+    [INFANTRY_TEMPLATE_IDS.pilotingSkill0]: String(data.antiMech),
+  };
+
+  // Damage row — `damage_1`..`damage_30` = round(perTrooper * j).
+  damageRow.forEach((value, index) => {
+    const slot = index + 1;
+    texts[`${INFANTRY_TEMPLATE_IDS.damagePrefix}${slot}`] = String(value);
+  });
+
+  // Field gun block — bound only when the platoon fields crew-served guns.
+  if (data.fieldGun) {
+    texts[INFANTRY_TEMPLATE_IDS.fieldGunType] = data.fieldGun.name;
+    texts[INFANTRY_TEMPLATE_IDS.fieldGunQty] = String(data.fieldGun.count);
+    texts[INFANTRY_TEMPLATE_IDS.fieldGunDmg] = String(data.fieldGun.damage);
+    texts[INFANTRY_TEMPLATE_IDS.fieldGunShort] = String(
+      data.fieldGun.shortRange,
+    );
+    texts[INFANTRY_TEMPLATE_IDS.fieldGunMed] = String(
+      data.fieldGun.mediumRange,
+    );
+    texts[INFANTRY_TEMPLATE_IDS.fieldGunLong] = String(data.fieldGun.longRange);
+  }
+
+  return { texts, pips: pipCounts, pipCounts, damageRow };
+}

--- a/src/services/printing/svgRecordSheetRenderer/infantry/infantryDamage.ts
+++ b/src/services/printing/svgRecordSheetRenderer/infantry/infantryDamage.ts
@@ -1,0 +1,144 @@
+/**
+ * Infantry Damage-Per-Trooper Formula
+ *
+ * A verbatim reproduction of MegaMek's `Infantry.getDamagePerTrooper()`
+ * (`E:\Projects\megamek\megamek\src\megamek\common\units\Infantry.java`,
+ * line 1687), used to compute the conventional-infantry record sheet's
+ * `DAMAGE+j` row.
+ *
+ * The MegaMek Java source:
+ *
+ * ```java
+ * public double getDamagePerTrooper() {
+ *     if (null == primaryWeapon) {
+ *         return 0;
+ *     }
+ *     // per 09/2021 errata, primary infantry weapon damage caps out at 0.6
+ *     double adjustedDamage = Math.min(MMConstants.INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP,
+ *           primaryWeapon.getInfantryDamage());
+ *     double damage = adjustedDamage * (squadSize - secondaryWeaponsPerSquad);
+ *     if (null != secondaryWeapon) {
+ *         damage += secondaryWeapon.getInfantryDamage() * secondaryWeaponsPerSquad;
+ *     }
+ *     return damage / squadSize;
+ * }
+ * ```
+ *
+ * This module reproduces the calculation exactly — including the
+ * documented `0.6` primary-weapon damage cap
+ * (`MMConstants.INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP`, per the 09/2021
+ * errata) — and adds the `DAMAGE+j` row generator the record sheet
+ * needs. It is a transcription, not a design: do not alter the formula.
+ *
+ * @spec openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Infantry Damage-Per-Trooper Formula)
+ */
+
+import { INFANTRY_MAX_TROOPERS } from '../templateElementIds';
+
+/**
+ * The primary-weapon damage cap, per the 09/2021 errata.
+ *
+ * Verbatim from MegaMek `MMConstants.INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP`
+ * (`E:\Projects\megamek\megamek\src\megamek\MMConstants.java`, line 119:
+ * `public static final double INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP = 0.6;`).
+ */
+export const INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP = 0.6;
+
+/**
+ * Inputs to the damage-per-trooper formula. Mirrors the MegaMek
+ * `Infantry` fields the Java method reads: `primaryWeapon`,
+ * `secondaryWeapon`, `squadSize`, `secondaryWeaponsPerSquad`.
+ */
+export interface InfantryDamageInput {
+  /**
+   * The primary weapon's canonical per-trooper damage
+   * (`InfantryWeapon.getInfantryDamage()`). `undefined` reproduces the
+   * Java `null == primaryWeapon` guard — no primary weapon means zero
+   * damage per trooper.
+   */
+  readonly primaryWeaponDamage: number | undefined;
+  /**
+   * The secondary weapon's canonical per-trooper damage. `undefined`
+   * reproduces the Java `null != secondaryWeapon` guard — no secondary
+   * weapon contributes nothing.
+   */
+  readonly secondaryWeaponDamage?: number;
+  /** Troopers per squad (`squadSize`). */
+  readonly squadSize: number;
+  /** Secondary weapons carried per squad (`secondaryWeaponsPerSquad`). */
+  readonly secondaryWeaponsPerSquad: number;
+}
+
+/**
+ * Compute the damage per trooper for a conventional infantry platoon.
+ *
+ * Verbatim reproduction of `Infantry.getDamagePerTrooper()`. The primary
+ * weapon's contribution is capped at `0.6`
+ * (`INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP`); the secondary weapon's
+ * contribution is uncapped, exactly as in the Java source.
+ *
+ * Returns `0` when there is no primary weapon (the Java `null` guard) or
+ * when `squadSize` is zero or negative (defensive — the Java code would
+ * divide by zero; the record sheet must not emit `NaN`).
+ */
+export function getDamagePerTrooper(input: InfantryDamageInput): number {
+  // Java: `if (null == primaryWeapon) { return 0; }`
+  if (input.primaryWeaponDamage === undefined) {
+    return 0;
+  }
+  // Defensive: the Java code divides by `squadSize`; guard against a
+  // zero / negative squad so the record sheet never renders `NaN`.
+  if (input.squadSize <= 0) {
+    return 0;
+  }
+
+  // Java: `Math.min(INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP, primaryWeapon.getInfantryDamage())`
+  const adjustedDamage = Math.min(
+    INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP,
+    input.primaryWeaponDamage,
+  );
+  // Java: `adjustedDamage * (squadSize - secondaryWeaponsPerSquad)`
+  let damage =
+    adjustedDamage * (input.squadSize - input.secondaryWeaponsPerSquad);
+  // Java: `if (null != secondaryWeapon) { damage += secondaryWeapon.getInfantryDamage() * secondaryWeaponsPerSquad; }`
+  if (input.secondaryWeaponDamage !== undefined) {
+    damage += input.secondaryWeaponDamage * input.secondaryWeaponsPerSquad;
+  }
+  // Java: `return damage / squadSize;`
+  return damage / input.squadSize;
+}
+
+/**
+ * Whether the primary weapon's damage is being capped by the formula —
+ * mirrors MegaMek `Infantry.primaryWeaponDamageCapped()`
+ * (`getPrimaryWeaponDamage() > INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP`).
+ */
+export function isPrimaryWeaponDamageCapped(
+  primaryWeaponDamage: number | undefined,
+): boolean {
+  return (
+    primaryWeaponDamage !== undefined &&
+    primaryWeaponDamage > INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP
+  );
+}
+
+/**
+ * Generate the `DAMAGE+j` row for the infantry record sheet.
+ *
+ * For each trooper count `j` in `1..30` (the `damage_1`..`damage_30`
+ * template slots — `INFANTRY_MAX_TROOPERS`), the rendered value is
+ * `round(perTrooper × j)`, matching MegaMek `PrintInfantry`:
+ * `setTextField(DAMAGE + j, (int) Math.round(getDamagePerTrooper() * j))`.
+ *
+ * @returns an array of 30 integers, index `i` holding the `DAMAGE+(i+1)`
+ *   value (so `result[0]` is the `j=1` value, `result[29]` the `j=30`).
+ */
+export function generateDamageRow(perTrooper: number): readonly number[] {
+  const row: number[] = [];
+  for (let j = 1; j <= INFANTRY_MAX_TROOPERS; j++) {
+    // MegaMek `PrintInfantry`: `(int) Math.round(getDamagePerTrooper() * j)`.
+    row.push(Math.round(perTrooper * j));
+  }
+  return row;
+}

--- a/src/services/printing/svgRecordSheetRenderer/infantry/selectTemplate.ts
+++ b/src/services/printing/svgRecordSheetRenderer/infantry/selectTemplate.ts
@@ -1,0 +1,40 @@
+/**
+ * Conventional Infantry family — canonical template selection.
+ *
+ * Pure function mapping an `IInfantryRecordSheetData` to its Wave-2
+ * `templateKey`. For the single-unit MVP this is always the per-unit
+ * block template `conventional_infantry_platoon` — mirroring MegaMekLab
+ * `PrintInfantry.getSVGFileName()`, which returns
+ * `conventional_infantry_platoon.svg`.
+ *
+ * The multi-slot outer sheet `conventional_infantry_default`
+ * (MegaMekLab's `PrintSmallUnitSheet` composite, up to 3 platoons per
+ * page) is registered as an asset but is NOT selected here — the
+ * multi-unit composite is a deferred follow-up. See the change's
+ * Non-Goals.
+ *
+ * @spec openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Infantry and Battle Armor Record Sheet Adapters)
+ */
+
+import type { IInfantryRecordSheetData } from '@/types/printing';
+
+/** The Wave-2 conventional-infantry per-unit block template key. */
+export type InfantryTemplateKey = 'conventional_infantry_platoon';
+
+/**
+ * Select the canonical Wave-2 template key for a conventional infantry
+ * platoon.
+ *
+ * Always returns the per-unit block `conventional_infantry_platoon` —
+ * the atomic, self-contained record sheet — NOT the multi-slot
+ * `conventional_infantry_default` outer sheet. The `data` parameter is
+ * accepted for signature parity with the other per-family
+ * `selectTemplate` adapters and for forward-compatibility with the
+ * deferred composite.
+ */
+export function selectInfantryTemplate(
+  _data: IInfantryRecordSheetData,
+): InfantryTemplateKey {
+  return 'conventional_infantry_platoon';
+}

--- a/src/services/printing/svgRecordSheetRenderer/pipEngine.ts
+++ b/src/services/printing/svgRecordSheetRenderer/pipEngine.ts
@@ -26,12 +26,20 @@
  *   (Requirement: Shared Dynamic Pip Engine)
  */
 
-import { ArmorPipLayout, type PipOptions } from '../ArmorPipLayout';
+import { ArmorPipLayout, Bounds, type PipOptions } from '../ArmorPipLayout';
+import {
+  BATTLEARMOR_TEMPLATE_IDS,
+  INFANTRY_MAX_TROOPERS,
+  INFANTRY_TEMPLATE_IDS,
+} from './templateElementIds';
 
 /** Default pip fill colour — matches the mech path. */
 const DEFAULT_PIP_FILL = '#FFFFFF';
 /** Default pip stroke width — matches the mech path. */
 const DEFAULT_PIP_STROKE = 0.5;
+
+/** SVG namespace — used to create pip / marker elements. */
+const SVG_NS = 'http://www.w3.org/2000/svg';
 
 /**
  * Options controlling a single pip-layout operation.
@@ -138,4 +146,197 @@ export function layoutPipsInGroup(
     staggered: options.staggered ?? false,
     groupByFive: options.clustered ?? false,
   });
+}
+
+// ============================================================================
+// Wave-2 small-unit pip grids
+//
+// Two additive helpers for the Wave-2 infantry / battle-armor families.
+// They layer ONTO the per-location pip layout above — neither modifies
+// `layoutPips` / `layoutPipsInGroup` / `ArmorPipLayout`, so the mech and
+// Wave-1 families are unaffected.
+// ============================================================================
+
+/** One trooper column's per-suit armor pip count for the BA pip grid. */
+export interface BattleArmorTrooperPips {
+  /** Zero-based trooper-column index (`0`..`5`). */
+  readonly column: number;
+  /**
+   * Per-suit armor pip count for this trooper — the canonical
+   * `armorPips` value. The helper draws `armorPips + 1` pips, mirroring
+   * MegaMek `PrintBattleArmor` (`getOArmor(trooper) + 1` — the armor
+   * value plus one "trooper" pip).
+   */
+  readonly armorPips: number;
+}
+
+/** The result of one Battle Armor per-trooper pip-grid layout. */
+export interface BattleArmorPipGridResult {
+  /**
+   * Per-column rendered pip counts, indexed by trooper column. Each
+   * value is the count of pip `<circle>` elements emitted into that
+   * column's `pips_N` region (`armorPips + 1`). Columns with no trooper
+   * are absent from the map.
+   */
+  readonly renderedByColumn: ReadonlyMap<number, number>;
+}
+
+/** MegaMek max BA armor (`PrintBattleArmor`: width / 19.0). */
+const BA_MAX_ARMOR_DIVISOR = 19;
+/** CSS class applied to each Battle Armor armor pip. */
+const BA_PIP_CLASS = 'pip ba-armor';
+
+/**
+ * Lay out the Battle Armor per-trooper pip grid.
+ *
+ * For each trooper present in `troopers`, resolves the matching
+ * `pips_<column>` `<rect>` region
+ * (`BATTLEARMOR_TEMPLATE_IDS.pipsPrefix`) and lays out `armorPips + 1`
+ * pip `<circle>` elements as a horizontal row across the region's
+ * measured geometry. The `pips_N` element is the region rect itself
+ * (not a `<g>` of sub-regions), so the helper measures it directly with
+ * `Bounds.fromRect` and spaces the pips by `width / 19` — exactly the
+ * placement in MegaMek `PrintBattleArmor` (max BA armor is 18, the
+ * `+1` trooper pip makes 19 the divisor).
+ *
+ * Trooper columns beyond the squad size are left untouched (empty),
+ * matching `PrintBattleArmor`, which iterates `0..5` but only fills
+ * `i < getTroopers()`.
+ *
+ * The `+1` "trooper" pip is the documented MegaMek divergence (see the
+ * `BATTLEARMOR_TEMPLATE_IDS` catalog comment) — the rendered count per
+ * column is therefore `armorPips + 1`, and the Wave-2 fidelity gate
+ * asserts exactly that.
+ *
+ * Additive: this does not touch the per-location layout used by the
+ * mech and Wave-1 families.
+ *
+ * @returns the per-column rendered pip counts (the fidelity-gate input).
+ */
+export function layoutBattleArmorPipGrid(
+  svgDoc: Document,
+  troopers: readonly BattleArmorTrooperPips[],
+  options: PipLayoutOptions = {},
+): BattleArmorPipGridResult {
+  const renderedByColumn = new Map<number, number>();
+  const fill = options.fill ?? DEFAULT_PIP_FILL;
+  const strokeWidth = options.strokeWidth ?? DEFAULT_PIP_STROKE;
+  const className = options.className ?? BA_PIP_CLASS;
+
+  for (const trooper of troopers) {
+    // A real adapter never produces a negative column or armor count;
+    // guard defensively so a malformed input is a skip, not a throw.
+    if (trooper.column < 0 || trooper.armorPips < 0) {
+      continue;
+    }
+    const groupId = `${BATTLEARMOR_TEMPLATE_IDS.pipsPrefix}${trooper.column}`;
+    const region = svgDoc.getElementById(groupId);
+    if (!region) {
+      continue;
+    }
+    const bounds = Bounds.fromRect(region);
+    if (bounds.width <= 0 || bounds.height <= 0) {
+      continue;
+    }
+    // MegaMek `PrintBattleArmor`: pip count is `getOArmor(trooper) + 1`.
+    const pipCount = trooper.armorPips + 1;
+    // Pip spacing mirrors MegaMek — region width over the 19-pip max.
+    const size = bounds.width / BA_MAX_ARMOR_DIVISOR;
+    const radius = size * 0.36;
+    const cy = bounds.centerY;
+    for (let p = 0; p < pipCount; p++) {
+      const pip = svgDoc.createElementNS(SVG_NS, 'circle');
+      pip.setAttribute('cx', String(bounds.left + size * (p + 0.5)));
+      pip.setAttribute('cy', String(cy));
+      pip.setAttribute('r', String(radius));
+      pip.setAttribute('fill', fill);
+      pip.setAttribute('stroke-width', String(strokeWidth));
+      pip.setAttribute('class', className);
+      // Append as a sibling of the region rect so the fidelity gate's
+      // `querySelectorAll` parses the pips back out.
+      region.parentNode?.appendChild(pip);
+    }
+    renderedByColumn.set(trooper.column, pipCount);
+  }
+  return { renderedByColumn };
+}
+
+/** The result of one infantry platoon pip-grid layout. */
+export interface InfantryPlatoonPipGridResult {
+  /**
+   * The number of platoon pip markers emitted — one per occupied
+   * `soldier_N` slot. Equals the platoon trooper count (clamped to the
+   * template's 30-slot capacity). The Wave-2 fidelity gate asserts this
+   * equals the fixture's trooper count.
+   */
+  readonly renderedCount: number;
+}
+
+/** CSS class applied to each infantry platoon pip marker. */
+const INFANTRY_PLATOON_PIP_CLASS = 'pip platoon-trooper';
+
+/**
+ * Lay out the infantry platoon pip grid.
+ *
+ * The `conventional_infantry_platoon` template exposes 30 pre-drawn
+ * trooper-icon slots (`soldier_1`..`soldier_30`,
+ * `INFANTRY_TEMPLATE_IDS.soldierPrefix`). The platoon "pip grid" marks
+ * the first `platoonSize` of those slots as occupied by appending a
+ * marker pip `<circle>` (centred on the slot's measured geometry) to
+ * each. The count of emitted markers equals the platoon trooper count.
+ *
+ * `platoonSize` is clamped to `INFANTRY_MAX_TROOPERS` (30) — the
+ * template has no slot beyond `soldier_30`. A `platoonSize` of zero or
+ * fewer is a no-op.
+ *
+ * Slot geometry is read from the `soldier_N` element's `x/y/width/
+ * height` attributes (`Bounds.fromRect`) so the helper works on an
+ * un-mounted parsed document, consistent with the rest of the engine.
+ *
+ * Additive: this does not touch the per-location layout used by the
+ * mech and Wave-1 families.
+ *
+ * @returns the rendered platoon pip count (the fidelity-gate input).
+ */
+export function layoutInfantryPlatoonPipGrid(
+  svgDoc: Document,
+  platoonSize: number,
+  options: PipLayoutOptions = {},
+): InfantryPlatoonPipGridResult {
+  if (platoonSize <= 0) {
+    return { renderedCount: 0 };
+  }
+  const occupied = Math.min(platoonSize, INFANTRY_MAX_TROOPERS);
+  const fill = options.fill ?? DEFAULT_PIP_FILL;
+  const strokeWidth = options.strokeWidth ?? DEFAULT_PIP_STROKE;
+  const className = options.className ?? INFANTRY_PLATOON_PIP_CLASS;
+
+  let renderedCount = 0;
+  for (let slot = 1; slot <= occupied; slot++) {
+    const slotId = `${INFANTRY_TEMPLATE_IDS.soldierPrefix}${slot}`;
+    const slotElement = svgDoc.getElementById(slotId);
+    if (!slotElement) {
+      continue;
+    }
+    const bounds = Bounds.fromRect(slotElement);
+    if (bounds.width <= 0 || bounds.height <= 0) {
+      // A slot with no measurable geometry still counts as occupied —
+      // but with no resolvable centre we cannot place a marker. Skip the
+      // marker; the slot element itself is the fallback visual.
+      continue;
+    }
+    const pip = svgDoc.createElementNS(SVG_NS, 'circle');
+    pip.setAttribute('cx', String(bounds.left + bounds.width / 2));
+    pip.setAttribute('cy', String(bounds.top + bounds.height / 2));
+    // Marker radius scaled to the slot — small enough never to overflow.
+    pip.setAttribute('r', String(Math.min(bounds.width, bounds.height) * 0.18));
+    pip.setAttribute('fill', fill);
+    pip.setAttribute('stroke-width', String(strokeWidth));
+    pip.setAttribute('class', className);
+    // Append the marker as a sibling of the slot icon so it is parsed
+    // back out by the fidelity gate's `querySelectorAll`.
+    slotElement.parentNode?.appendChild(pip);
+    renderedCount++;
+  }
+  return { renderedCount };
 }

--- a/src/services/printing/svgRecordSheetRenderer/renderTemplated.ts
+++ b/src/services/printing/svgRecordSheetRenderer/renderTemplated.ts
@@ -11,17 +11,23 @@
  * it falls back to the family's existing skeleton renderer and returns
  * that SVG, so a degraded environment never yields a blank PDF.
  *
- * Battle-armor and infantry are NOT Wave-1 families: they are routed
- * to their skeleton renderers by `renderRecordSheetSVG` in
- * `renderer.ts`, never through this module. Keeping them out of here
- * avoids an import cycle (`renderer.ts` imports this module).
+ * As of Wave 2 the infantry and battle-armor families also render
+ * through this module — `isTemplatedUnit()` returns `true` for them and
+ * `renderTemplated`'s switch gains the two cases. They render through a
+ * dedicated small-unit path (`renderViaSmallUnitTemplate`) because their
+ * pips are a per-trooper / platoon grid rather than the Wave-1
+ * per-location `PipFill` model.
  *
  * @spec openspec/changes/add-templated-vehicle-aero-proto-record-sheets/specs/record-sheet-export/spec.md
  *   (Requirement: Template-Primary Rendering With Skeleton Fallback)
+ * @spec openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/record-sheet-export/spec.md
+ *   (Requirement: Per-Type SVG Renderers — infantry / battle-armor cases)
  */
 
 import type {
   IAerospaceRecordSheetData,
+  IBattleArmorRecordSheetData,
+  IInfantryRecordSheetData,
   IProtoMechRecordSheetData,
   IVehicleRecordSheetData,
 } from '@/types/printing';
@@ -32,7 +38,17 @@ import { logger } from '@/utils/logger';
 import { bindAerospace } from './aerospace/bindings';
 import { selectAerospaceTemplate } from './aerospace/selectTemplate';
 import { renderAerospaceSVG } from './aerospaceRenderer';
-import { layoutPipsInGroup } from './pipEngine';
+import { bindBattleArmor } from './battlearmor/bindings';
+import { selectBattleArmorTemplate } from './battlearmor/selectTemplate';
+import { renderBattleArmorSVG } from './battleArmorRenderer';
+import { bindInfantry } from './infantry/bindings';
+import { selectInfantryTemplate } from './infantry/selectTemplate';
+import { renderInfantrySVG } from './infantryRenderer';
+import {
+  layoutBattleArmorPipGrid,
+  layoutInfantryPlatoonPipGrid,
+  layoutPipsInGroup,
+} from './pipEngine';
 import { bindProtoMech } from './protomech/bindings';
 import { selectProtoMechTemplate } from './protomech/selectTemplate';
 import { renderProtoMechSVG } from './protoMechRenderer';
@@ -45,11 +61,17 @@ import { bindVehicle } from './vehicle/bindings';
 import { selectVehicleTemplate } from './vehicle/selectTemplate';
 import { renderVehicleSVG } from './vehicleRenderer';
 
-/** The Wave-1 non-mech unit types handled by the templated path. */
+/**
+ * The non-mech unit types handled by the templated path — the Wave-1
+ * families (vehicle / aerospace / protomech) plus the Wave-2 small-unit
+ * families (infantry / battle armor).
+ */
 export type TemplatedUnitData =
   | IVehicleRecordSheetData
   | IAerospaceRecordSheetData
-  | IProtoMechRecordSheetData;
+  | IProtoMechRecordSheetData
+  | IInfantryRecordSheetData
+  | IBattleArmorRecordSheetData;
 
 /** Paper-size directory segment for the asset path. */
 function paperDir(paperSize: PaperSize): 'templates_us' | 'templates_iso' {
@@ -106,6 +128,68 @@ async function renderViaTemplate(
   await renderer.awaitFontsReady();
   renderer.applyBindings(bindings.texts);
   renderer.applyPips(bindings.pips, applyPipFill);
+  // getSVGString() unmounts the off-screen container as a side effect.
+  return renderer.getSVGString();
+}
+
+/**
+ * The canonical-template marker attribute.
+ *
+ * The small-unit render path stamps this attribute on the output SVG
+ * root. It is present ONLY on output produced by the canonical template
+ * path — the skeleton renderers (`infantryRenderer` / `battleArmorRenderer`)
+ * never emit it. The silent-fallback guard test (task 5.5) asserts the
+ * marker's presence to prove the template path — not the skeleton
+ * fallback — produced a given SVG.
+ */
+export const CANONICAL_TEMPLATE_MARKER = 'data-template-source';
+
+/** The marker value the canonical small-unit template path stamps. */
+export const CANONICAL_TEMPLATE_MARKER_VALUE = 'mm-data-canonical';
+
+/**
+ * Render a Wave-2 small-unit family (infantry / battle armor) through
+ * the canonical template path.
+ *
+ * Distinct from `renderViaTemplate` because the small-unit pips are a
+ * per-trooper column grid (battle armor) or a single platoon grid
+ * (infantry) rather than the Wave-1 per-location `PipFill` model — so
+ * the `layoutPips` callback supplied by the caller draws the grid
+ * directly against the mounted document.
+ *
+ * Stamps the `CANONICAL_TEMPLATE_MARKER` attribute on the SVG root so
+ * the silent-fallback guard can prove the template path produced the
+ * output.
+ */
+async function renderViaSmallUnitTemplate(
+  templateKey: string,
+  paperSize: PaperSize,
+  texts: TextBindings,
+  layoutPips: (doc: Document) => void,
+): Promise<string> {
+  const renderer = new TemplateRecordSheetRenderer();
+  await renderer.loadTemplate(templatePath(templateKey, paperSize));
+
+  // Lay out the small-unit pip grids BEFORE mounting. The grids resolve
+  // their `soldier_N` / `pips_N` regions via `document.getElementById`
+  // and read geometry from the `<rect>` `x/y/width/height` attributes —
+  // no `getBBox()` and so no live DOM required. `mount()` detaches the
+  // SVG root from the parsed document, after which `getElementById`
+  // would return `null`; running the layout first avoids that hazard.
+  layoutPips(renderer.document);
+
+  // Mount off-screen so web-font-aware text measurement is valid, then
+  // gate text measurement on font readiness before binding.
+  renderer.mount();
+  await renderer.awaitFontsReady();
+  renderer.applyBindings(texts);
+
+  // Stamp the canonical-template marker so the silent-fallback guard can
+  // distinguish template output from skeleton-renderer output.
+  renderer.root.setAttribute(
+    CANONICAL_TEMPLATE_MARKER,
+    CANONICAL_TEMPLATE_MARKER_VALUE,
+  );
   // getSVGString() unmounts the off-screen container as a side effect.
   return renderer.getSVGString();
 }
@@ -169,13 +253,75 @@ export async function renderProtoMechTemplated(
 }
 
 /**
- * Render a Wave-1 non-mech unit (vehicle / aerospace / protomech)
- * through the canonical template path, with per-family skeleton
- * fallback on any failure.
+ * Render an infantry platoon, template-primary with skeleton fallback.
  *
- * Battle-armor and infantry units must NOT be passed here — they are
- * not Wave-1 families and are routed to their skeleton renderers by
- * `renderRecordSheetSVG`.
+ * Renders the `conventional_infantry_platoon` per-unit block template,
+ * laying out the platoon pip grid sized to the platoon trooper count.
+ * On any template failure it returns the existing `infantryRenderer`
+ * skeleton output.
+ */
+export async function renderInfantryTemplated(
+  data: IInfantryRecordSheetData,
+  paperSize: PaperSize = PaperSize.LETTER,
+): Promise<string> {
+  try {
+    const key = selectInfantryTemplate(data);
+    const bindings = bindInfantry(data);
+    return await renderViaSmallUnitTemplate(
+      key,
+      paperSize,
+      bindings.texts,
+      (doc) => {
+        layoutInfantryPlatoonPipGrid(doc, bindings.pipCounts.platoonSize);
+      },
+    );
+  } catch (error) {
+    logger.warn(
+      'Templated infantry render failed — falling back to skeleton renderer',
+      { error },
+    );
+    return renderInfantrySVG(data);
+  }
+}
+
+/**
+ * Render a Battle Armor squad, template-primary with skeleton fallback.
+ *
+ * Renders the `battle_armor_squad` per-unit block template, laying out
+ * the per-trooper armor pip grid (one cluster per trooper column). On
+ * any template failure it returns the existing `battleArmorRenderer`
+ * skeleton output.
+ */
+export async function renderBattleArmorTemplated(
+  data: IBattleArmorRecordSheetData,
+  paperSize: PaperSize = PaperSize.LETTER,
+): Promise<string> {
+  try {
+    const key = selectBattleArmorTemplate(data);
+    const bindings = bindBattleArmor(data);
+    return await renderViaSmallUnitTemplate(
+      key,
+      paperSize,
+      bindings.texts,
+      (doc) => {
+        layoutBattleArmorPipGrid(doc, bindings.pipCounts.troopers);
+      },
+    );
+  } catch (error) {
+    logger.warn(
+      'Templated battle-armor render failed — falling back to skeleton renderer',
+      { error },
+    );
+    return renderBattleArmorSVG(data);
+  }
+}
+
+/**
+ * Render a non-mech unit through the canonical template path, with
+ * per-family skeleton fallback on any failure.
+ *
+ * Covers the Wave-1 families (vehicle / aerospace / protomech) and the
+ * Wave-2 small-unit families (infantry / battle armor).
  */
 export async function renderTemplated(
   data: TemplatedUnitData,
@@ -188,15 +334,23 @@ export async function renderTemplated(
       return renderAerospaceTemplated(data, paperSize);
     case 'protomech':
       return renderProtoMechTemplated(data, paperSize);
+    case 'infantry':
+      return renderInfantryTemplated(data, paperSize);
+    case 'battlearmor':
+      return renderBattleArmorTemplated(data, paperSize);
     default:
       return assertNeverTemplatedVariant(data);
   }
 }
 
 /**
- * Whether a non-mech record-sheet payload is a Wave-1 templated family
- * (vehicle / aerospace / protomech). The dispatch layer uses this to
- * choose `renderTemplated` over the skeleton-only `renderRecordSheetSVG`.
+ * Whether a non-mech record-sheet payload is a templated family. The
+ * dispatch layer uses this to choose `renderTemplated` over the
+ * skeleton-only `renderRecordSheetSVG`.
+ *
+ * As of Wave 2 this covers vehicle / aerospace / protomech (Wave 1) and
+ * infantry / battle armor (Wave 2) — every customizer-editable non-mech
+ * unit type now renders through the canonical template path.
  *
  * Narrows the payload to `TemplatedUnitData` so callers can hand it
  * straight to `renderTemplated` without a cast.
@@ -207,7 +361,9 @@ export function isTemplatedUnit(data: {
   return (
     data.unitType === 'vehicle' ||
     data.unitType === 'aerospace' ||
-    data.unitType === 'protomech'
+    data.unitType === 'protomech' ||
+    data.unitType === 'infantry' ||
+    data.unitType === 'battlearmor'
   );
 }
 

--- a/src/services/printing/svgRecordSheetRenderer/templateElementIds.ts
+++ b/src/services/printing/svgRecordSheetRenderer/templateElementIds.ts
@@ -281,6 +281,206 @@ export const PROTOMECH_TEMPLATE_IDS = {
   structurePipsMG: 'structurePipsMG',
 } as const;
 
+/**
+ * Conventional Infantry family template element IDs.
+ *
+ * Covers the Wave-2 per-unit block template `conventional_infantry_platoon`
+ * (the single-unit MVP target — NOT the multi-slot
+ * `conventional_infantry_default` outer sheet). Reviewed against
+ * MegaMekLab `PrintInfantry.java` and `IdConstants.java` (task 0.5).
+ *
+ * MegaMekLab review (task 0.5): `PrintInfantry.getSVGFileName()` returns
+ * `conventional_infantry_platoon.svg`; every binding target below was
+ * cross-referenced against the `IdConstants` field consumed by
+ * `PrintInfantry`. The `IdConstants` field name is noted per entry. No
+ * catalogued ID diverges from `IdConstants`.
+ *
+ * The `soldier_1..30` IDs are the platoon pip elements (one per trooper
+ * slot, `IdConstants.SOLDIER`); `no_soldier_1..30` are the empty-slot
+ * twins (`IdConstants.NO_SOLDIER`). The platoon pip-grid helper lays out
+ * exactly `platoonSize` pips against the `soldier_N` slots. The
+ * `damage_1..30` IDs are the per-trooper-count damage row
+ * (`IdConstants.DAMAGE` — `PrintInfantry` fills `damage_j` with
+ * `round(getDamagePerTrooper() * j)`).
+ *
+ * Per-pip / per-row numeric ID families (`soldier_N`, `no_soldier_N`,
+ * `damage_N`, `range_N`, `range_mod_N`, `uw_range_mod_N`) are exposed as
+ * a single `as const` prefix string plus a count, mirroring the way the
+ * adapters iterate them — the individual numbered IDs are layout
+ * targets, not distinct catalog keys.
+ */
+export const INFANTRY_TEMPLATE_IDS = {
+  /** IdConstants.TYPE — chassis + model line. */
+  type: 'type',
+  /** IdConstants.ROLE — unit battlefield role. */
+  role: 'role',
+  /** IdConstants.LBL_ROLE — the "Role:" label element. */
+  labelRole: 'labelRole',
+  /** IdConstants.BV — Battle Value. */
+  bv: 'bv',
+  /** IdConstants.ARMOR_KIT — infantry armor kit name. */
+  armorKit: 'armor_kit',
+  /** IdConstants.ARMOR_DIVISOR — armor damage divisor value. */
+  armorDivisor: 'armor_divisor',
+  /** IdConstants.TRANSPORT_WT — platoon transport weight. */
+  transportWt: 'transport_wt',
+  /** IdConstants.MP_1 — primary movement-mode MP value. */
+  mp1: 'mp_1',
+  /** IdConstants.MODE_1 — primary movement-mode label. */
+  movementMode1: 'movement_mode_1',
+  /** IdConstants.MP_2 — secondary movement-mode MP value. */
+  mp2: 'mp_2',
+  /** IdConstants.MODE_2 — secondary movement-mode label. */
+  movementMode2: 'movement_mode_2',
+  /** IdConstants.MP_2_LABEL — secondary MP label slot. */
+  mp2Label: 'mp_2_label',
+  /** IdConstants.MODE_2_LABEL — secondary movement-mode label slot. */
+  movementMode2Label: 'movement_mode_2_label',
+  /** IdConstants.RANGE_IN_HEXES — "range in hexes" header text. */
+  rangeInHexes: 'rangeInHexes',
+  /** IdConstants.DEST_MODS — destruction modifiers block. */
+  destMods: 'dest_mods',
+  /** IdConstants.SNEAK_CAMO_MODS — sneak/camo modifiers block. */
+  sneakCamoMods: 'sneak_camo_mods',
+  /** IdConstants.UW_RANGE_MODIFIER — underwater range modifier header. */
+  uwRangeModifier: 'uw_range_modifier',
+  /** IdConstants.NOTES — notes block. */
+  notes: 'notes',
+  /** IdConstants.RS_TEMPLATE — root template marker group. */
+  rs_template: 'rs_template',
+  /** IdConstants.GUNNERY_SKILL + "0" — crew 0 gunnery skill. */
+  gunnerySkill0: 'gunnerySkill0',
+  /** IdConstants.PILOTING_SKILL + "0" — crew 0 anti-mech / piloting skill. */
+  pilotingSkill0: 'pilotingSkill0',
+  /** IdConstants.PILOT_NAME + "0" — crew 0 name. */
+  pilotName0: 'pilotName0',
+
+  // --- Field gun block (IdConstants.FIELD_GUN_* — present when crewed) ---
+  /** IdConstants.FIELD_GUN_COLUMNS — field-gun table container. */
+  fieldGunColumns: 'field_gun_columns',
+  /** IdConstants.FIELD_GUN_QTY — field-gun quantity. */
+  fieldGunQty: 'field_gun_qty',
+  /** IdConstants.FIELD_GUN_TYPE — field-gun type / name. */
+  fieldGunType: 'field_gun_type',
+  /** IdConstants.FIELD_GUN_DMG — field-gun damage. */
+  fieldGunDmg: 'field_gun_dmg',
+  /** IdConstants.FIELD_GUN_DMG_2 — field-gun secondary damage. */
+  fieldGunDmg2: 'field_gun_dmg_2',
+  /** IdConstants.FIELD_GUN_MIN_RANGE — field-gun minimum range. */
+  fieldGunMinRange: 'field_gun_min_range',
+  /** IdConstants.FIELD_GUN_SHORT — field-gun short range. */
+  fieldGunShort: 'field_gun_short',
+  /** IdConstants.FIELD_GUN_MED — field-gun medium range. */
+  fieldGunMed: 'field_gun_med',
+  /** IdConstants.FIELD_GUN_LONG — field-gun long range. */
+  fieldGunLong: 'field_gun_long',
+  /** IdConstants.FIELD_GUN_AMMO — field-gun ammo rounds. */
+  fieldGunAmmo: 'field_gun_ammo',
+  /** IdConstants.FIELD_GUN_CREW — field-gun crew count. */
+  fieldGunCrew: 'field_gun_crew',
+
+  // --- Numbered ID-family prefixes (IdConstants suffix-prefix fields) ---
+  /** IdConstants.SOLDIER — platoon pip slot prefix (`soldier_1`..`soldier_30`). */
+  soldierPrefix: 'soldier_',
+  /** IdConstants.NO_SOLDIER — empty platoon-slot prefix (`no_soldier_1`..). */
+  noSoldierPrefix: 'no_soldier_',
+  /** IdConstants.DAMAGE — per-trooper-count damage row prefix (`damage_1`..`damage_30`). */
+  damagePrefix: 'damage_',
+  /** IdConstants.RANGE — range-bracket text prefix (`range_0`..). */
+  rangePrefix: 'range_',
+  /** IdConstants.RANGE_MOD — range-modifier prefix (`range_mod_0`..). */
+  rangeModPrefix: 'range_mod_',
+  /** IdConstants.UW_RANGE_MOD — underwater range-modifier prefix (`uw_range_mod_0`..). */
+  uwRangeModPrefix: 'uw_range_mod_',
+} as const;
+
+/**
+ * Maximum trooper count for a conventional infantry platoon — the
+ * `soldier_N` / `no_soldier_N` / `damage_N` numbered ID families run
+ * `1..30` on the `conventional_infantry_platoon` template.
+ */
+export const INFANTRY_MAX_TROOPERS = 30;
+
+/**
+ * Battle Armor family template element IDs.
+ *
+ * Covers the Wave-2 per-unit block template `battle_armor_squad` (the
+ * single-unit MVP target — NOT the multi-slot `battle_armor_default`
+ * outer sheet). Reviewed against MegaMekLab `PrintBattleArmor.java` and
+ * `IdConstants.java` (task 0.5).
+ *
+ * MegaMekLab review (task 0.5): `PrintBattleArmor.getSVGFileName()`
+ * returns `battle_armor_squad.svg`; every binding target below was
+ * cross-referenced against the `IdConstants` field consumed by
+ * `PrintBattleArmor`. The `IdConstants` field name is noted per entry.
+ *
+ * The `pips_0..pips_5` IDs are the per-trooper armor pip-group regions
+ * (`IdConstants.PIPS` — `PrintBattleArmor` iterates `getElementById(PIPS
+ * + i)` for `i` in `0..5`). The `suit0..suit5` IDs are the per-trooper
+ * suit-label slots (`IdConstants.SUIT`). A Battle Armor squad has 4–6
+ * troopers; trooper columns beyond the squad size are left empty.
+ *
+ * DIVERGENCE: `PrintBattleArmor` draws `getOArmor(trooper) + 1` pips per
+ * column — the canonical per-suit armor value PLUS one extra "trooper"
+ * pip. The Wave-2 per-trooper pip grid reproduces this `+1` so the
+ * rendered count matches MegaMekLab.
+ */
+export const BATTLEARMOR_TEMPLATE_IDS = {
+  /** IdConstants.TYPE — chassis + model line. */
+  type: 'type',
+  /** IdConstants.ROLE — unit battlefield role. */
+  role: 'role',
+  /** IdConstants.LBL_ROLE — the "Role:" label element. */
+  labelRole: 'labelRole',
+  /** IdConstants.BV — Battle Value. */
+  bv: 'bv',
+  /** IdConstants.SQUAD — squad designation header ("BATTLE ARMOR: ..."). */
+  squad: 'squad',
+  /** IdConstants.ARMOR_TYPE — BA armor type label. */
+  armorType: 'armorType',
+  /** IdConstants.MP_WALK — ground MP value. */
+  mpWalk: 'mpWalk',
+  /** IdConstants.MP_2 — secondary movement-mode MP value (jump/VTOL/UW). */
+  mp2: 'mp_2',
+  /** IdConstants.MODE_2 — secondary movement-mode label. */
+  movementMode2: 'movement_mode_2',
+  /** IdConstants.INVENTORY — equipment / weapon inventory block. */
+  inventory: 'inventory',
+  /** IdConstants.ERA_ICON — era icon image slot. */
+  eraIcon: 'eraIcon',
+  /** IdConstants.RS_TEMPLATE — root template marker group. */
+  rs_template: 'rs_template',
+  /** IdConstants.GUNNERY_SKILL + "0" — crew 0 gunnery skill. */
+  gunnerySkill0: 'gunnerySkill0',
+  /** IdConstants.PILOTING_SKILL + "0" — crew 0 anti-mech / piloting skill. */
+  pilotingSkill0: 'pilotingSkill0',
+
+  // --- BA capability check markers (PrintBattleArmor capability panel) ---
+  /** Anti-personnel capability check marker. */
+  checkAP: 'checkAP',
+  /** Leg-attack capability check marker. */
+  checkLeg: 'checkLeg',
+  /** Mechanized capability check marker. */
+  checkMechanized: 'checkMechanized',
+  /** Swarm-attack capability check marker. */
+  checkSwarm: 'checkSwarm',
+
+  // --- Numbered ID-family prefixes ---
+  /** IdConstants.PIPS — per-trooper armor pip-group prefix (`pips_0`..`pips_5`). */
+  pipsPrefix: 'pips_',
+  /** IdConstants.SUIT — per-trooper suit-label prefix (`suit0`..`suit5`). */
+  suitPrefix: 'suit',
+  /** Per-trooper fluff-image slot prefix (`fluffImage_0`..`fluffImage_5`). */
+  fluffImagePrefix: 'fluffImage_',
+} as const;
+
+/**
+ * Maximum trooper count for a Battle Armor squad — the `pips_N` /
+ * `suit_N` numbered ID families run `0..5` (6 columns) on the
+ * `battle_armor_squad` template; a squad fields 4–6 troopers.
+ */
+export const BATTLEARMOR_MAX_TROOPERS = 6;
+
 /** Vehicle / VTOL template element ID type. */
 export type VehicleTemplateId =
   (typeof VEHICLE_TEMPLATE_IDS)[keyof typeof VEHICLE_TEMPLATE_IDS];
@@ -290,3 +490,9 @@ export type AerospaceTemplateId =
 /** ProtoMech template element ID type. */
 export type ProtoMechTemplateId =
   (typeof PROTOMECH_TEMPLATE_IDS)[keyof typeof PROTOMECH_TEMPLATE_IDS];
+/** Conventional Infantry template element ID type. */
+export type InfantryTemplateId =
+  (typeof INFANTRY_TEMPLATE_IDS)[keyof typeof INFANTRY_TEMPLATE_IDS];
+/** Battle Armor template element ID type. */
+export type BattleArmorTemplateId =
+  (typeof BATTLEARMOR_TEMPLATE_IDS)[keyof typeof BATTLEARMOR_TEMPLATE_IDS];

--- a/src/types/printing/RecordSheetVariantTypes.ts
+++ b/src/types/printing/RecordSheetVariantTypes.ts
@@ -173,6 +173,15 @@ export interface IInfantryPlatoonCompositionSheet {
 export interface IInfantryWeaponSheet {
   readonly name: string;
   readonly damage: number | string;
+  /**
+   * Canonical damage per trooper for this weapon, threaded from the
+   * construction-domain `IInfantryWeaponEntry.infantryDamage`. A
+   * non-negative number consumed by the infantry record sheet's
+   * damage-per-trooper formula (MegaMek `Infantry.getDamagePerTrooper()`).
+   * Distinct from the display `damage` field, which is a `1/divisor`
+   * string. Defaults to `0` when the weapon is not in the catalog.
+   */
+  readonly infantryDamage: number;
   readonly minimumRange: number;
   readonly shortRange: number;
   readonly mediumRange: number;

--- a/src/types/unit/InfantryInterfaces.ts
+++ b/src/types/unit/InfantryInterfaces.ts
@@ -102,6 +102,16 @@ export interface IInfantryWeaponEntry {
   readonly isHeavy: boolean;
   /** Damage divisor applied to trooper count per TW rules */
   readonly damageDivisor: number;
+  /**
+   * Canonical damage per trooper for this weapon, as consumed by
+   * MegaMek's `Infantry.getDamagePerTrooper()` formula
+   * (`InfantryWeapon.getInfantryDamage()`). A non-negative number.
+   *
+   * This is the OUTGOING per-trooper damage figure — distinct from
+   * `damageDivisor`, which governs INCOMING-damage division. The
+   * infantry record sheet's damage row is computed from this value.
+   */
+  readonly infantryDamage: number;
   /** Short-range bracket (hexes) */
   readonly rangeShort: number;
   /** Medium-range bracket (hexes) */

--- a/src/utils/construction/infantry/__tests__/weaponTable.test.ts
+++ b/src/utils/construction/infantry/__tests__/weaponTable.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for the infantry weapon table — `infantryDamage` coverage.
+ *
+ * Asserts every weapon entry carries a usable canonical per-trooper
+ * damage value, the data input the record-sheet damage-per-trooper
+ * formula consumes.
+ *
+ * @spec openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/infantry-unit-system/spec.md
+ *   (Requirement: Primary Weapon Types — infantryDamage field)
+ */
+
+import { INFANTRY_WEAPON_TABLE } from '../weaponTable';
+
+describe('INFANTRY_WEAPON_TABLE infantryDamage', () => {
+  it('every weapon entry has a defined infantryDamage value', () => {
+    for (const weapon of INFANTRY_WEAPON_TABLE) {
+      expect(weapon.infantryDamage).toBeDefined();
+      expect(typeof weapon.infantryDamage).toBe('number');
+    }
+  });
+
+  it('every infantryDamage value is non-negative', () => {
+    for (const weapon of INFANTRY_WEAPON_TABLE) {
+      expect(weapon.infantryDamage).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('infantryDamage is distinct from damageDivisor', () => {
+    // The two fields measure different quantities — confirm the table
+    // does not accidentally alias one onto the other.
+    const aliased = INFANTRY_WEAPON_TABLE.filter(
+      (w) => w.infantryDamage === w.damageDivisor,
+    );
+    expect(aliased).toHaveLength(0);
+  });
+
+  it('covers all 12 catalogued weapons', () => {
+    expect(INFANTRY_WEAPON_TABLE).toHaveLength(12);
+  });
+});

--- a/src/utils/construction/infantry/weaponTable.ts
+++ b/src/utils/construction/infantry/weaponTable.ts
@@ -8,7 +8,18 @@
  * Heavy weapons may only be the primary weapon for Mechanized or Motorized
  * motive platoons (VAL-INF-WEAPON).
  *
+ * Each entry carries `infantryDamage` — the canonical damage-per-trooper
+ * value consumed by MegaMek's `Infantry.getDamagePerTrooper()` formula
+ * (`InfantryWeapon.getInfantryDamage()`). Values are sourced from the
+ * representative MegaMek infantry-weapon classes for each generic
+ * category (e.g. Auto-Rifle = `InfantryRifleAutoRifleWeapon` 0.52,
+ * Support Laser = `InfantrySupportLaserWeapon` 0.84). This is the
+ * OUTGOING per-trooper damage figure — distinct from `damageDivisor`,
+ * which governs INCOMING-damage division.
+ *
  * @spec openspec/changes/add-infantry-construction/specs/infantry-unit-system/spec.md
+ * @spec openspec/changes/add-templated-infantry-battlearmor-record-sheets/specs/infantry-unit-system/spec.md
+ *   (Requirement: Primary Weapon Types — infantryDamage field)
  */
 
 import { IInfantryWeaponEntry } from '@/types/unit/InfantryInterfaces';
@@ -28,6 +39,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     name: 'Rifle',
     isHeavy: false,
     damageDivisor: 10,
+    infantryDamage: 0.28,
     rangeShort: 1,
     rangeMedium: 2,
     rangeLong: 3,
@@ -41,6 +53,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     name: 'Auto-Rifle',
     isHeavy: false,
     damageDivisor: 10,
+    infantryDamage: 0.52,
     rangeShort: 1,
     rangeMedium: 2,
     rangeLong: 3,
@@ -54,6 +67,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     name: 'Laser Rifle',
     isHeavy: false,
     damageDivisor: 10,
+    infantryDamage: 0.28,
     rangeShort: 1,
     rangeMedium: 2,
     rangeLong: 3,
@@ -67,6 +81,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     name: 'Needler',
     isHeavy: false,
     damageDivisor: 10,
+    infantryDamage: 0.11,
     rangeShort: 1,
     rangeMedium: 2,
     rangeLong: 3,
@@ -80,6 +95,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     name: 'Gyrojet Rifle',
     isHeavy: false,
     damageDivisor: 10,
+    infantryDamage: 0.14,
     rangeShort: 1,
     rangeMedium: 2,
     rangeLong: 3,
@@ -93,6 +109,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     name: 'Flamer',
     isHeavy: false,
     damageDivisor: 10,
+    infantryDamage: 0.35,
     rangeShort: 1,
     rangeMedium: 2,
     rangeLong: 0,
@@ -107,6 +124,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     name: 'SRM Launcher',
     isHeavy: false,
     damageDivisor: 6,
+    infantryDamage: 0.57,
     rangeShort: 3,
     rangeMedium: 6,
     rangeLong: 9,
@@ -120,6 +138,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     name: 'LRM Launcher',
     isHeavy: false,
     damageDivisor: 6,
+    infantryDamage: 0.19,
     rangeShort: 6,
     rangeMedium: 12,
     rangeLong: 21,
@@ -134,6 +153,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     name: 'Machine Gun',
     isHeavy: false,
     damageDivisor: 10,
+    infantryDamage: 0.49,
     rangeShort: 1,
     rangeMedium: 2,
     rangeLong: 3,
@@ -147,6 +167,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     name: 'Support Heavy MG',
     isHeavy: true,
     damageDivisor: 5,
+    infantryDamage: 0.65,
     rangeShort: 1,
     rangeMedium: 2,
     rangeLong: 3,
@@ -160,6 +181,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     name: 'Support Laser',
     isHeavy: true,
     damageDivisor: 5,
+    infantryDamage: 0.84,
     rangeShort: 1,
     rangeMedium: 3,
     rangeLong: 5,
@@ -173,6 +195,7 @@ export const INFANTRY_WEAPON_TABLE: readonly IInfantryWeaponEntry[] = [
     name: 'Support PPC',
     isHeavy: true,
     damageDivisor: 3,
+    infantryDamage: 1.58,
     rangeShort: 3,
     rangeMedium: 6,
     rangeLong: 12,


### PR DESCRIPTION
## Summary

Wave 2 of the templated record-sheet effort — wires the **Infantry** and **Battle Armor** families onto the canonical mm-data SVG template path, extending the Wave-1 shared core (`TemplateRecordSheetRenderer` + `pipEngine`). After this change every customizer-editable non-mech unit type produces a proper template-driven PDF record sheet.

- Registers the 5 Infantry / Battle Armor canonical templates in `config/mm-data-assets.json` and adds the frozen Wave-2 element-ID catalog (`INFANTRY_TEMPLATE_IDS` / `BATTLEARMOR_TEMPLATE_IDS`), reviewed against MegaMekLab `IdConstants` / `PrintInfantry` / `PrintBattleArmor`.
- Adds `infantry/infantryDamage.ts` — a verbatim reproduction of MegaMek `Infantry.getDamagePerTrooper()` including the 0.6 primary-weapon damage cap (09/2021 errata) — plus the `DAMAGE+j` row generator. Adds the canonical `infantryDamage` field to `IInfantryWeaponEntry` (populated for all 12 weapons) and threads it through `IInfantryWeaponSheet`.
- Adds two pip-engine helpers: `layoutBattleArmorPipGrid` (per-trooper column grid, `armorPips + 1` per column) and `layoutInfantryPlatoonPipGrid` (platoon grid). Additive — the Wave-1 per-location layout is untouched.
- Adds the `infantry/` and `battlearmor/` per-family adapter folders (`selectTemplate.ts` + `bindings.ts`), each selecting its per-unit block template (`conventional_infantry_platoon` / `battle_armor_squad`). The multi-unit composite is explicitly deferred.
- Flips `isTemplatedUnit()` to include infantry / battle armor and adds the two `renderTemplated` switch cases via a dedicated small-unit render path that stamps a `data-template-source` canonical-template marker. The skeleton renderers stay as the runtime fallback.

## OpenSpec change

`add-templated-infantry-battlearmor-record-sheets` — 26 tasks across 7 phases, all complete. Delta specs merged to `openspec/specs/` (`record-sheet-export` +5 ADDED / 1 MODIFIED, `mm-data-asset-integration` +2 ADDED / 1 MODIFIED, `infantry-unit-system` 1 MODIFIED). `npx openspec validate --strict` passes.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` (oxlint) — 0 warnings / 0 errors
- [x] `npx oxfmt --check` clean
- [x] `npm test` — 24026 tests pass (979 suites, 8 snapshots); Wave-1 pip-fidelity tests and mech/Wave-1 snapshots stay green
- [x] `npm run storybook:build` passes
- [x] Per-family pip-count fidelity gates green; a deliberately-wrong fixture fails the assertion
- [x] Silent-fallback guard green — `isTemplatedUnit()` true for both families AND the rendered SVG carries the canonical-template marker absent from skeleton output
- [x] Forced-asset-failure degrades to the skeleton renderer
- [ ] Manual: customizer Save PDF for an infantry platoon and a Battle Armor squad in both `templates_us` and `templates_iso`