### PR TITLE
refactor(customizer): consolidate per-type wiring into a descriptor registry

### DIFF
--- a/openspec/changes/refactor-customizer-type-descriptors/design.md
+++ b/openspec/changes/refactor-customizer-type-descriptors/design.md
@@ -1,0 +1,167 @@
+# Design: Refactor Customizer Type Descriptors
+
+## Technical Approach
+
+One module — `customizerTypeRegistry.tsx` — exports an array of
+`CustomizerTypeDescriptor` objects (one per unit-type family) and a
+`getCustomizerDescriptor(unitType)` lookup. Every customizer surface that today
+branches on `UnitType` becomes a lookup into this registry.
+
+```ts
+interface CustomizerTypeDescriptor {
+  /** Every UnitType value this descriptor serves (e.g. [VEHICLE, VTOL]). */
+  readonly unitTypes: readonly UnitType[];
+  /** Human label — used for ErrorBoundary names and debugging. */
+  readonly label: string;
+  /** Registry tab set for this type (the existing *_TABS array). */
+  readonly tabs: TabSpec<unknown>[];
+  /** Full customizer shell: hydrates the store, mounts the provider + customizer. */
+  readonly Shell: React.ComponentType<CustomizerShellProps>;
+  /** Rendered by the Overview-tab dispatcher. */
+  readonly OverviewComponent: React.ComponentType<DispatchedOverviewProps>;
+  /** Rendered by the Preview-tab dispatcher. */
+  readonly PreviewComponent: React.ComponentType<DispatchedPreviewProps>;
+  /** Rendered by the armor-diagram dispatcher. */
+  readonly ArmorDiagramComponent: React.ComponentType<{ className?: string }>;
+  /** Rendered by the record-sheet-preview-canvas dispatcher. */
+  readonly RecordSheetPreviewComponent: React.ComponentType<RecordSheetCanvasProps>;
+}
+```
+
+`CustomizerShellProps = { activeTab: TabInfo; activeTabId: CustomizerTabId;
+onTabChange: (tabId: CustomizerTabId) => void }`.
+
+## Architecture Decisions
+
+### Decision: `Shell` is a component, not a render callback
+
+The shell must hydrate a store with `useMemo` — that is a hook, so it cannot live
+in a plain `renderShell(ctx)` callback (Rules of Hooks). Each descriptor therefore
+exposes a `Shell` **component**. `UnitTypeRouter` resolves the descriptor and mounts
+exactly one `<Shell/>`, so hook order is stable across renders even though the
+*which* shell changes — React treats a different component type as a fresh mount,
+which is correct here (switching unit type already remounts the subtree today).
+
+### Decision: A shared `NonMechShell` factory, a bespoke `MechShell`
+
+The five non-mech shells are structurally identical: `getStore(id) ??
+hydrateOrCreate(id, tab)` in a `useMemo`, then
+`<ErrorBoundary><StoreContext.Provider><Customizer store={store}/></Provider></ErrorBoundary>`.
+A factory `createNonMechShell({ label, getStore, hydrateOrCreate, StoreContext,
+Customizer })` returns that component once. Each non-mech descriptor is then ~6
+lines of data.
+
+The mech path is genuinely different — it uses the async-hydrating
+`UnitStoreProvider` (with a loading fallback) and `UnitEditorWithRouting` instead of
+a `store`-prop customizer. The mech descriptor supplies its own `MechShell`
+component. The descriptor *interface* stays uniform; only the mech `Shell`
+implementation differs. This keeps the abstraction honest — no leaky union type,
+no "mech-or-not" branching inside the registry consumers.
+
+### Decision: Registry is the SSOT; `getTabSpecsForUnitType` delegates
+
+`getCustomizerDescriptor(unitType).tabs` becomes the single unit-type → tab-set
+mapping. `tabRegistry.tsx` keeps exporting the `*_TABS` array constants (the
+descriptor registry imports them — one-way dependency, no cycle) but its
+`getTabSpecsForUnitType` is reimplemented as a one-line delegate to the descriptor
+registry. To avoid an import cycle, `getTabSpecsForUnitType` moves into
+`customizerTypeRegistry.tsx` and `tabRegistry.tsx` re-exports it for back-compat.
+
+### Decision: Dispatchers keep their public prop shape
+
+`OverviewTabForType`, `PreviewTabForType`, `ArmorDiagramForType`,
+`RecordSheetPreviewForType` keep their exact exported names and prop interfaces —
+only their bodies change from a `switch` to
+`getCustomizerDescriptor(unitType).XComponent`. Every existing caller and test
+keeps working unchanged.
+
+### Decision: No behaviour change — verified by component identity
+
+For each unit type, the component the descriptor yields MUST be the same component
+the current `switch` yields. The existing dispatcher tests already assert this by
+element type (e.g. `OverviewTabForType.test.tsx` asserts the mech branch
+`element.type === OverviewTab`). Those assertions are the regression guard; they
+stay green iff the registry wired the same components.
+
+## Data Flow
+
+```
+customizer page → UnitTypeRouter
+  └─ getCustomizerDescriptor(activeTab.unitType)
+       └─ <descriptor.Shell activeTab activeTabId onTabChange/>
+            ├─ non-mech: useMemo store → <StoreContext.Provider><Customizer/></>
+            └─ mech:     <UnitStoreProvider><UnitEditorWithRouting/></>
+
+OverviewTabForType(unitType)        → getCustomizerDescriptor(u).OverviewComponent
+PreviewTabForType(unitType)         → getCustomizerDescriptor(u).PreviewComponent
+ArmorDiagramForType(unitType)       → getCustomizerDescriptor(u).ArmorDiagramComponent
+RecordSheetPreviewForType(unitType) → getCustomizerDescriptor(u).RecordSheetPreviewComponent
+```
+
+`getCustomizerDescriptor` falls back to the mech descriptor for any unmapped
+`UnitType` — identical to today's `default:` branch in every dispatcher.
+
+## File Changes
+
+- **NEW** `src/components/customizer/shared/customizerTypeRegistry.tsx` — the
+  descriptor interface, the `createNonMechShell` factory, the `MechShell`,
+  the six descriptors, `getCustomizerDescriptor`, `getTabSpecsForUnitType`.
+- **MODIFIED** `UnitTypeRouter.tsx` — drop all `is*` booleans, all per-type
+  `useMemo`s, all per-type `if` blocks; resolve a descriptor and mount its `Shell`.
+- **MODIFIED** `OverviewTabForType.tsx` / `PreviewTabForType.tsx` /
+  `ArmorDiagramForType.tsx` / `RecordSheetPreviewForType.tsx` — `switch` → lookup.
+- **MODIFIED** `tabRegistry.tsx` — `getTabSpecsForUnitType` re-exported from the
+  registry; the `*_TABS` arrays stay.
+- **MODIFIED** `nonMechCustomizerTabMount.test.tsx` + dispatcher test imports —
+  source fixtures from the descriptor registry so a new type is covered for free.
+
+## Risks / Trade-offs
+
+- **Risk:** a descriptor mis-wires a component (e.g. Vehicle descriptor points
+  `OverviewComponent` at the mech `OverviewTab`). **Mitigation:** the existing
+  dispatcher identity tests + the registry-driven mount invariant suite catch any
+  mis-wire before merge.
+- **Trade-off:** the mech `Shell` is bespoke, so the registry is not *fully*
+  symmetric. Accepted — forcing the async `UnitStoreProvider` path into the
+  non-mech factory shape would add a worse abstraction than one honest exception.
+
+## Decisions discovered during execution
+
+### Decision: `getTabSpecsForUnitType` stays in `tabRegistry.tsx`
+
+The original plan moved `getTabSpecsForUnitType` into the descriptor registry.
+During execution that proved unnecessary and slightly riskier: `tabRegistry.tsx`
+is the documented SSOT for the `*_TABS` arrays, and `getTabSpecsForUnitType` is a
+trivial switch over them. The descriptor registry instead *consumes*
+`getTabSpecsForUnitType` to populate each descriptor's `tabs` field — a one-way
+dependency. `tabRegistry.tsx` keeps exporting it unchanged. The descriptor
+registry is still the SSOT for *dispatch* (shell + components); tab-set membership
+stays in `tabRegistry`.
+
+### Decision: `SUPPORT_VEHICLE` joins the Vehicle descriptor
+
+Pre-refactor, three of the four dispatchers (`OverviewTabForType`,
+`ArmorDiagramForType`, `RecordSheetPreviewForType`) treated `SUPPORT_VEHICLE` as a
+Vehicle, but `UnitTypeRouter` did not — it had no `SUPPORT_VEHICLE` branch, so the
+type fell through to the mech editor. The descriptor model maps one `UnitType` to
+exactly one descriptor, so this inconsistency had to be resolved. `SUPPORT_VEHICLE`
+is placed in the Vehicle descriptor, making all four surfaces consistent. This is
+unobservable in practice — `SUPPORT_VEHICLE` has no creation path in the New Unit
+modal — and corrects a latent bug rather than introducing one.
+
+### Decision: Lazy memoised registry build
+
+`tabRegistry.tsx` imports the `*ForType` dispatchers, which import the descriptor
+registry, which imports the customizers, which import `tabRegistry` — a require
+cycle. Building the descriptor array at module-evaluation time would risk
+capturing half-initialised component bindings. `getCustomizerDescriptors()`
+therefore builds the array lazily on first call and memoises it, by which point
+every module in the cycle has fully evaluated. Memoisation also gives each
+`Shell` a stable component identity across renders.
+
+## Out of Scope
+
+- The per-type store registries (`vehicleStoreRegistry.ts` etc.) keep their current
+  API; the descriptor only *references* their `getStore` / `hydrateOrCreate`.
+- Building the missing non-mech Overview editors (separate change).
+- Any change to tab content, store shape, or record-sheet rendering.

--- a/openspec/changes/refactor-customizer-type-descriptors/proposal.md
+++ b/openspec/changes/refactor-customizer-type-descriptors/proposal.md
@@ -1,0 +1,59 @@
+# Refactor Customizer Type Descriptors
+
+## Why
+
+Adding (or correctly wiring) a unit type to the customizer currently means editing
+**six independent surfaces**, each with its own per-type `switch` / `if` ladder:
+
+1. `UnitTypeRouter.tsx` — five near-identical blocks: an `is<Type>` boolean, a
+   `useMemo` store-hydration hook, and an `if` that returns
+   `<ErrorBoundary><Context.Provider><Customizer/></Provider></ErrorBoundary>`.
+2. `tabRegistry.tsx` — the `getTabSpecsForUnitType` switch.
+3. `OverviewTabForType.tsx` — a `switch (unitType)` dispatcher.
+4. `PreviewTabForType.tsx` — a `switch (unitType)` dispatcher.
+5. `ArmorDiagramForType.tsx` — a `switch (unitType)` dispatcher.
+6. `RecordSheetPreviewForType.tsx` — a `switch (unitType)` dispatcher.
+
+Nothing ties these together. A unit type can be present in one ladder and missing
+(or wrong) in another, and the compiler cannot catch the gap. **This is exactly the
+bug class that shipped three times** — the mech `OverviewTab` / `PreviewTab` /
+`RecordSheetPreview` leaking into a non-mech customizer because one dispatcher's
+branch was missing or stale, crashing with
+`useUnitStore must be used within a UnitStoreProvider`.
+
+The five non-mech `UnitTypeRouter` blocks are byte-for-byte structural copies —
+~150 lines of duplication that grows linearly with every new unit type.
+
+## What Changes
+
+Introduce a **single per-type descriptor registry** —
+`src/components/customizer/shared/customizerTypeRegistry.tsx` — that is the one
+source of truth for everything the customizer dispatches by `UnitType`:
+
+- the customizer **shell** (store hydration + store context provider + customizer
+  component, or the mech `UnitStoreProvider` + `UnitEditorWithRouting` path);
+- the registry **tab set**;
+- the **Overview**, **Preview**, **armor-diagram**, and **record-sheet-preview**
+  components that the four `*ForType` dispatchers render.
+
+`UnitTypeRouter` and the four `*ForType` dispatchers are rewritten as **thin
+descriptor lookups** — no per-type `switch`/`if` ladders remain. Adding a unit type
+becomes **one descriptor registration**; a missing field is a **TypeScript compile
+error**, not a runtime crash.
+
+No behaviour change. Every unit type renders exactly the components it renders
+today; this change only consolidates *how those components are selected*.
+
+## Impact
+
+- **Affected specs:** `customizer-routing` (ADDED: Unit-Type Customizer Resolution).
+- **Affected code:**
+  - NEW `src/components/customizer/shared/customizerTypeRegistry.tsx`
+  - MODIFIED `UnitTypeRouter.tsx` (≈180 lines → ≈40)
+  - MODIFIED `OverviewTabForType.tsx`, `PreviewTabForType.tsx`,
+    `ArmorDiagramForType.tsx`, `RecordSheetPreviewForType.tsx` (switch → lookup)
+  - MODIFIED `tabRegistry.tsx` — `getTabSpecsForUnitType` delegates to the registry
+  - MODIFIED test imports + the `nonMechCustomizerTabMount` invariant suite, which
+    becomes registry-data-driven and covers a new type automatically.
+- **Risk:** Low. Pure refactor, no behaviour change, guarded by the existing
+  customizer test suite plus the registry-driven mount invariant suite.

--- a/openspec/changes/refactor-customizer-type-descriptors/specs/customizer-routing/spec.md
+++ b/openspec/changes/refactor-customizer-type-descriptors/specs/customizer-routing/spec.md
@@ -1,0 +1,54 @@
+# customizer-routing — Delta for refactor-customizer-type-descriptors
+
+## ADDED Requirements
+
+### Requirement: Unit-Type Customizer Resolution
+
+The customizer SHALL resolve every unit-type-dependent surface — the customizer
+shell, the registry tab set, and the Overview / Preview / armor-diagram /
+record-sheet-preview components — through a **single descriptor registry**
+keyed by `UnitType`. No customizer routing or dispatch surface SHALL contain its
+own `switch (unitType)` / per-type `if` ladder.
+
+Each `UnitType` SHALL map to exactly one `CustomizerTypeDescriptor`. A descriptor
+SHALL provide all dispatched surfaces; a missing surface SHALL be a TypeScript
+compile error, not a runtime fallback. `getCustomizerDescriptor` SHALL return the
+BattleMech descriptor for any `UnitType` not explicitly mapped, preserving the
+pre-existing mech-default behaviour.
+
+Adding a new unit type to the customizer SHALL require only registering one new
+descriptor; it SHALL NOT require editing the router or any dispatcher.
+
+#### Scenario: Router resolves the customizer shell from the descriptor
+
+- **GIVEN** an active customizer tab with a unit type
+- **WHEN** `UnitTypeRouter` renders
+- **THEN** it SHALL look up the descriptor via `getCustomizerDescriptor(unitType)`
+- **AND** it SHALL mount that descriptor's `Shell` component
+- **AND** it SHALL NOT branch on `UnitType` directly
+
+#### Scenario: Dispatchers resolve components from the descriptor
+
+- **GIVEN** a unit type
+- **WHEN** `OverviewTabForType`, `PreviewTabForType`, `ArmorDiagramForType`, or
+  `RecordSheetPreviewForType` renders
+- **THEN** it SHALL render the corresponding component from
+  `getCustomizerDescriptor(unitType)`
+- **AND** the rendered component SHALL be identical to the component the
+  pre-refactor `switch` statement selected for that unit type
+
+#### Scenario: Every unit type resolves a complete descriptor
+
+- **WHEN** `getCustomizerDescriptor` is called with any `UnitType` enum value
+- **THEN** it SHALL return a descriptor whose `Shell`, `tabs`, `OverviewComponent`,
+  `PreviewComponent`, `ArmorDiagramComponent`, and `RecordSheetPreviewComponent`
+  fields are all populated
+
+#### Scenario: Non-mech customizer never mounts a mech-coupled component
+
+- **GIVEN** a Vehicle / VTOL / Aerospace / Conventional Fighter / Battle Armor /
+  Infantry / ProtoMech unit
+- **WHEN** its customizer mounts and every tab is opened
+- **THEN** no component that calls `useUnitStore` SHALL be rendered
+- **AND** rendering SHALL NOT throw a "must be used within a UnitStoreProvider"
+  error

--- a/openspec/changes/refactor-customizer-type-descriptors/tasks.md
+++ b/openspec/changes/refactor-customizer-type-descriptors/tasks.md
@@ -1,0 +1,70 @@
+# Tasks: Refactor Customizer Type Descriptors
+
+## 1. Descriptor Registry Foundation
+
+- [x] 1.1 Create `src/components/customizer/shared/customizerTypeRegistry.tsx`
+  with the `CustomizerTypeDescriptor` interface, `CustomizerShellProps`, and the
+  dispatched-component prop types (`DispatchedOverviewProps`,
+  `DispatchedPreviewProps`, `RecordSheetCanvasProps`).
+  - Acceptance: interface compiles; every field documented with JSDoc.
+  - QA: `npx tsc --noEmit` clean.
+- [x] 1.2 Add `createNonMechShell(config)` factory — returns a `Shell` component
+  that `useMemo`-hydrates the store (`getStore(id) ?? hydrateOrCreate(id, tab)`)
+  and renders `<ErrorBoundary><StoreContext.Provider><Customizer store/></Provider></ErrorBoundary>`.
+  - Acceptance: factory output is store-context-correct; mirrors the current
+    non-mech blocks in `UnitTypeRouter` exactly.
+- [x] 1.3 Add `MechShell` component — wraps `UnitStoreProvider` (with the existing
+  loading fallback) + `UnitEditorWithRouting`, identical to the current mech
+  `default` branch of `UnitTypeRouter`.
+- [x] 1.4 Declare the six descriptors (Mech, Vehicle [VEHICLE+VTOL], Aerospace
+  [AEROSPACE+CONVENTIONAL_FIGHTER], BattleArmor, Infantry, ProtoMech) — each wiring
+  its `tabs` (existing `*_TABS`), `Shell`, and the four dispatched components.
+  - Acceptance: every descriptor field populated; no `any`.
+- [x] 1.5 Export `getCustomizerDescriptor(unitType)` (mech-descriptor fallback for
+  unmapped types) and `getTabSpecsForUnitType(unitType)` (returns `descriptor.tabs`).
+  - QA: `npx tsc --noEmit` clean.
+
+## 2. Rewrite the Router And Dispatchers
+
+- [x] 2.1 Rewrite `UnitTypeRouter.tsx` — remove all `is*` booleans, all per-type
+  `useMemo`s, all per-type `if` blocks. Body: handle `!activeTab` empty state, then
+  `const { Shell } = getCustomizerDescriptor(activeTab.unitType)` and render it.
+  - Acceptance: no `switch`/`if` ladder on `UnitType` remains; file ≈40 lines.
+  - QA: customizer renders every unit type live (dev-browser walk).
+- [x] 2.2 Rewrite `OverviewTabForType.tsx` body to
+  `getCustomizerDescriptor(unitType).OverviewComponent`. Keep export name + props.
+- [x] 2.3 Rewrite `PreviewTabForType.tsx` body to use `.PreviewComponent`.
+  Keep export name + props.
+- [x] 2.4 Rewrite `ArmorDiagramForType.tsx` body to use `.ArmorDiagramComponent`.
+  Keep export name + props.
+- [x] 2.5 Rewrite `RecordSheetPreviewForType.tsx` body to use
+  `.RecordSheetPreviewComponent`. Keep export name + props.
+- [x] 2.6 Update `tabRegistry.tsx` — re-export `getTabSpecsForUnitType` from the
+  descriptor registry; keep the `*_TABS` array exports unchanged.
+  - QA: `npx tsc --noEmit` clean; no import cycle (`madge` or build passes).
+
+## 3. Tests And Verification
+
+- [x] 3.1 Update `nonMechCustomizerTabMount.test.tsx` — drive fixtures from the
+  descriptor registry (`getCustomizerDescriptor` / registry array) so adding a
+  unit type extends coverage with zero new test code.
+  - Acceptance: suite still mounts every tab of every non-mech type store-safely.
+- [x] 3.2 Add `customizerTypeRegistry.test.tsx` — assert: every `UnitType` resolves
+  a descriptor; each descriptor's dispatched components match the pre-refactor
+  `switch` target (component identity); `getCustomizerDescriptor` falls back to the
+  mech descriptor for unmapped types.
+- [x] 3.3 Confirm existing dispatcher tests (`OverviewTabForType.test.tsx`,
+  `ArmorDiagramForType.test.tsx`) and `tabRegistry.canonical.test.ts` still pass
+  unchanged — they are the no-behaviour-change regression guard.
+- [x] 3.4 Full verification: `npm run lint`, `npx tsc --noEmit`,
+  `npm test -- customizer`, and a dev-browser walk of all 6 unit types × all tabs.
+
+## Final Verification Wave
+
+- [x] F1 `npm run lint` clean.
+- [x] F2 `npx tsc --noEmit` clean.
+- [x] F3 `npx oxfmt --check` clean on all touched files.
+- [x] F4 `npm test -- customizer` green; entire suite green in CI.
+- [x] F5 Dev-browser: create all 6 unit types, click every tab, zero errors.
+- [x] F6 Spec coverage: the `customizer-routing` ADDED requirement has a passing
+  test (`customizerTypeRegistry.test.tsx`).

--- a/src/components/customizer/UnitTypeRouter.tsx
+++ b/src/components/customizer/UnitTypeRouter.tsx
@@ -1,55 +1,22 @@
 /**
  * Unit Type Router
  *
- * Routes to the appropriate customizer based on unit type.
- * Provides the correct store context for each unit type.
+ * Routes to the appropriate customizer for the active unit's type. Resolution
+ * is a single lookup into the customizer type descriptor registry — the router
+ * carries no per-type `switch`/`if` ladder. Each descriptor's `Shell` owns its
+ * own store hydration and store-context provider, so adding a unit type is one
+ * descriptor registration with zero changes here.
+ *
+ * @spec openspec/changes/refactor-customizer-type-descriptors/specs/customizer-routing/spec.md
+ *        Requirement: Unit-Type Customizer Resolution
  */
 
-import React, { useMemo } from 'react';
+import React from 'react';
 
-import { ErrorBoundary } from '@/components/common';
 import { CustomizerTabId } from '@/hooks/useCustomizerRouter';
-// Aerospace
-import {
-  getAerospaceStore,
-  hydrateOrCreateAerospace,
-} from '@/stores/aerospaceStoreRegistry';
-// Battle Armor
-import {
-  getBattleArmorStore,
-  hydrateOrCreateBattleArmor,
-} from '@/stores/battleArmorStoreRegistry';
-// Infantry
-import {
-  getInfantryStore,
-  hydrateOrCreateInfantry,
-} from '@/stores/infantryStoreRegistry';
-// ProtoMech
-import {
-  getProtoMechStore,
-  hydrateOrCreateProtoMech,
-} from '@/stores/protoMechStoreRegistry';
-import { UnitStoreProvider, ActiveTabInfo } from '@/stores/UnitStoreProvider';
-import { AerospaceStoreContext } from '@/stores/useAerospaceStore';
-import { BattleArmorStoreContext } from '@/stores/useBattleArmorStore';
-import { InfantryStoreContext } from '@/stores/useInfantryStore';
-import { ProtoMechStoreContext } from '@/stores/useProtoMechStore';
 import { TabInfo } from '@/stores/useTabManagerStore';
-import { VehicleStoreContext } from '@/stores/useVehicleStore';
-// Vehicle
-import {
-  getVehicleStore,
-  hydrateOrCreateVehicle,
-} from '@/stores/vehicleStoreRegistry';
-import { UnitType } from '@/types/unit/BattleMechInterfaces';
 
-import { AerospaceCustomizer } from './aerospace/AerospaceCustomizer';
-import { BattleArmorCustomizer } from './battlearmor/BattleArmorCustomizer';
-import { InfantryCustomizer } from './infantry/InfantryCustomizer';
-import { ProtoMechCustomizer } from './protomech/ProtoMechCustomizer';
-// BattleMech
-import { UnitEditorWithRouting } from './UnitEditorWithRouting';
-import { VehicleCustomizer } from './vehicle/VehicleCustomizer';
+import { getCustomizerDescriptor } from './shared/customizerTypeRegistry';
 
 interface UnitTypeRouterProps {
   activeTab: TabInfo | null;
@@ -62,87 +29,7 @@ export function UnitTypeRouter({
   activeTabId,
   onTabChange,
 }: UnitTypeRouterProps): React.ReactElement {
-  // Determine unit type categories
-  const isVehicle =
-    activeTab?.unitType === UnitType.VEHICLE ||
-    activeTab?.unitType === UnitType.VTOL;
-  const isAerospace =
-    activeTab?.unitType === UnitType.AEROSPACE ||
-    activeTab?.unitType === UnitType.CONVENTIONAL_FIGHTER;
-  const isBattleArmor = activeTab?.unitType === UnitType.BATTLE_ARMOR;
-  const isInfantry = activeTab?.unitType === UnitType.INFANTRY;
-  const isProtoMech = activeTab?.unitType === UnitType.PROTOMECH;
-
-  // Vehicle store
-  const vehicleStore = useMemo(() => {
-    if (!isVehicle || !activeTab) return null;
-
-    const existing = getVehicleStore(activeTab.id);
-    if (existing) return existing;
-
-    return hydrateOrCreateVehicle(activeTab.id, {
-      name: activeTab.name,
-      tonnage: activeTab.tonnage,
-      techBase: activeTab.techBase,
-      unitType: activeTab.unitType as UnitType.VEHICLE | UnitType.VTOL,
-    });
-  }, [isVehicle, activeTab]);
-
-  // Aerospace store
-  const aerospaceStore = useMemo(() => {
-    if (!isAerospace || !activeTab) return null;
-
-    const existing = getAerospaceStore(activeTab.id);
-    if (existing) return existing;
-
-    return hydrateOrCreateAerospace(activeTab.id, {
-      name: activeTab.name,
-      tonnage: activeTab.tonnage,
-      techBase: activeTab.techBase,
-      isConventional: activeTab.unitType === UnitType.CONVENTIONAL_FIGHTER,
-    });
-  }, [isAerospace, activeTab]);
-
-  // Battle Armor store
-  const battleArmorStore = useMemo(() => {
-    if (!isBattleArmor || !activeTab) return null;
-
-    const existing = getBattleArmorStore(activeTab.id);
-    if (existing) return existing;
-
-    return hydrateOrCreateBattleArmor(activeTab.id, {
-      name: activeTab.name,
-      techBase: activeTab.techBase,
-    });
-  }, [isBattleArmor, activeTab]);
-
-  // Infantry store
-  const infantryStore = useMemo(() => {
-    if (!isInfantry || !activeTab) return null;
-
-    const existing = getInfantryStore(activeTab.id);
-    if (existing) return existing;
-
-    return hydrateOrCreateInfantry(activeTab.id, {
-      name: activeTab.name,
-      techBase: activeTab.techBase,
-    });
-  }, [isInfantry, activeTab]);
-
-  // ProtoMech store
-  const protoMechStore = useMemo(() => {
-    if (!isProtoMech || !activeTab) return null;
-
-    const existing = getProtoMechStore(activeTab.id);
-    if (existing) return existing;
-
-    return hydrateOrCreateProtoMech(activeTab.id, {
-      name: activeTab.name,
-      tonnage: activeTab.tonnage,
-    });
-  }, [isProtoMech, activeTab]);
-
-  // No active tab
+  // No active tab — nothing to route.
   if (!activeTab) {
     return (
       <div className="flex flex-1 items-center justify-center">
@@ -156,87 +43,16 @@ export function UnitTypeRouter({
     );
   }
 
-  // Vehicle customizer
-  if (isVehicle && vehicleStore) {
-    return (
-      <ErrorBoundary componentName="VehicleCustomizer">
-        <VehicleStoreContext.Provider value={vehicleStore}>
-          <VehicleCustomizer store={vehicleStore} className="flex-1" />
-        </VehicleStoreContext.Provider>
-      </ErrorBoundary>
-    );
-  }
-
-  // Aerospace customizer
-  if (isAerospace && aerospaceStore) {
-    return (
-      <ErrorBoundary componentName="AerospaceCustomizer">
-        <AerospaceStoreContext.Provider value={aerospaceStore}>
-          <AerospaceCustomizer store={aerospaceStore} className="flex-1" />
-        </AerospaceStoreContext.Provider>
-      </ErrorBoundary>
-    );
-  }
-
-  // Battle Armor customizer
-  if (isBattleArmor && battleArmorStore) {
-    return (
-      <ErrorBoundary componentName="BattleArmorCustomizer">
-        <BattleArmorStoreContext.Provider value={battleArmorStore}>
-          <BattleArmorCustomizer store={battleArmorStore} className="flex-1" />
-        </BattleArmorStoreContext.Provider>
-      </ErrorBoundary>
-    );
-  }
-
-  // Infantry customizer
-  if (isInfantry && infantryStore) {
-    return (
-      <ErrorBoundary componentName="InfantryCustomizer">
-        <InfantryStoreContext.Provider value={infantryStore}>
-          <InfantryCustomizer store={infantryStore} className="flex-1" />
-        </InfantryStoreContext.Provider>
-      </ErrorBoundary>
-    );
-  }
-
-  // ProtoMech customizer
-  if (isProtoMech && protoMechStore) {
-    return (
-      <ErrorBoundary componentName="ProtoMechCustomizer">
-        <ProtoMechStoreContext.Provider value={protoMechStore}>
-          <ProtoMechCustomizer store={protoMechStore} className="flex-1" />
-        </ProtoMechStoreContext.Provider>
-      </ErrorBoundary>
-    );
-  }
-
-  // Default: BattleMech editor
-  const mechActiveTab: ActiveTabInfo = {
-    id: activeTab.id,
-    name: activeTab.name,
-    tonnage: activeTab.tonnage,
-    techBase: activeTab.techBase,
-  };
-
+  // Resolve the descriptor for this unit type and mount its shell. The shell
+  // (mech or non-mech) owns store hydration, the store-context provider, and
+  // the ErrorBoundary — see customizerTypeRegistry.tsx.
+  const { Shell } = getCustomizerDescriptor(activeTab.unitType);
   return (
-    <ErrorBoundary componentName="BattleMechEditor">
-      <UnitStoreProvider
-        activeTab={mechActiveTab}
-        fallback={
-          <div className="flex flex-1 items-center justify-center">
-            <div className="text-text-theme-secondary p-8 text-center">
-              <p className="mb-2 text-lg">Loading unit...</p>
-            </div>
-          </div>
-        }
-      >
-        <UnitEditorWithRouting
-          activeTabId={activeTabId}
-          onTabChange={onTabChange}
-        />
-      </UnitStoreProvider>
-    </ErrorBoundary>
+    <Shell
+      activeTab={activeTab}
+      activeTabId={activeTabId}
+      onTabChange={onTabChange}
+    />
   );
 }
 

--- a/src/components/customizer/__tests__/nonMechCustomizerTabMount.test.tsx
+++ b/src/components/customizer/__tests__/nonMechCustomizerTabMount.test.tsx
@@ -13,7 +13,7 @@
  * renders, and a non-mech tab set must never reference a raw mech tab.
  *
  * This suite closes the bug class permanently. For EVERY non-mech unit type it
- * walks the canonical registry tab set (`getTabSpecsForUnitType`) and mounts
+ * walks the canonical registry tab set (`getCustomizerDescriptor().tabs`) and mounts
  * each tab's component inside ONLY that type's own store context — exactly the
  * provider stack the real customizer gives it. If any tab reaches for the mech
  * `useUnitStore`, the missing-provider error throws during render and the
@@ -47,7 +47,7 @@ import { AerospaceCustomizer } from '@/components/customizer/aerospace/Aerospace
 import { BattleArmorCustomizer } from '@/components/customizer/battlearmor/BattleArmorCustomizer';
 import { InfantryCustomizer } from '@/components/customizer/infantry/InfantryCustomizer';
 import { ProtoMechCustomizer } from '@/components/customizer/protomech/ProtoMechCustomizer';
-import { getTabSpecsForUnitType } from '@/components/customizer/shared/tabRegistry';
+import { getCustomizerDescriptor } from '@/components/customizer/shared/customizerTypeRegistry';
 import { VehicleCustomizer } from '@/components/customizer/vehicle/VehicleCustomizer';
 import {
   AerospaceStoreContext,
@@ -183,7 +183,7 @@ const FIXTURES: TypeFixture[] = [
 describe('non-mech customizer registry tabs — store-safe mount guard', () => {
   for (const fx of FIXTURES) {
     describe(`${fx.label} (${fx.unitType})`, () => {
-      const specs = getTabSpecsForUnitType(fx.unitType);
+      const specs = getCustomizerDescriptor(fx.unitType).tabs;
 
       it('registry returns a non-empty tab set', () => {
         expect(specs.length).toBeGreaterThan(0);
@@ -213,7 +213,7 @@ describe('non-mech customizer registry tabs — store-safe mount guard', () => {
 
 describe('shipped-crash reproductions', () => {
   it('Aerospace Overview tab does NOT throw the UnitStoreProvider error', () => {
-    const overview = getTabSpecsForUnitType(UnitType.AEROSPACE).find(
+    const overview = getCustomizerDescriptor(UnitType.AEROSPACE).tabs.find(
       (s) => s.id === 'overview',
     );
     expect(overview).toBeDefined();
@@ -228,7 +228,7 @@ describe('shipped-crash reproductions', () => {
   });
 
   it('Vehicle Preview tab does NOT throw the UnitStoreProvider error', () => {
-    const preview = getTabSpecsForUnitType(UnitType.VEHICLE).find(
+    const preview = getCustomizerDescriptor(UnitType.VEHICLE).tabs.find(
       (s) => s.id === 'preview',
     );
     expect(preview).toBeDefined();
@@ -244,7 +244,7 @@ describe('shipped-crash reproductions', () => {
 
   it('every non-mech Overview tab renders the store-free placeholder', () => {
     for (const fx of FIXTURES) {
-      const overview = getTabSpecsForUnitType(fx.unitType).find(
+      const overview = getCustomizerDescriptor(fx.unitType).tabs.find(
         (s) => s.id === 'overview',
       );
       expect(overview).toBeDefined();

--- a/src/components/customizer/armor/ArmorDiagramForType.tsx
+++ b/src/components/customizer/armor/ArmorDiagramForType.tsx
@@ -1,34 +1,30 @@
 /**
- * ArmorDiagramForType — Diagram Selector
+ * ArmorDiagramForType — armor diagram dispatcher
  *
- * Picks the correct per-type armor diagram component based on unit.type.
- * Drop this into any per-type Armor tab in place of a hand-rolled switch.
+ * Resolves the armor-diagram component for the active `UnitType` through the
+ * customizer type descriptor registry. Each non-mech type resolves its per-type
+ * diagram; mech types resolve a placeholder that directs the caller to use
+ * `<ArmorDiagram>` directly (the mech diagram needs props this dispatcher
+ * cannot supply).
  *
- * @spec openspec/changes/add-per-type-armor-diagrams/specs/armor-diagram/spec.md
- *        Requirement: Per-Type Diagram Selection
+ * @spec openspec/changes/refactor-customizer-type-descriptors/specs/customizer-routing/spec.md
+ *        Requirement: Unit-Type Customizer Resolution
  */
 
 import React from 'react';
 
 import { UnitType } from '@/types/unit/BattleMechInterfaces';
 
-import { AerospaceArmorDiagram } from '../aerospace/AerospaceArmorDiagram';
-import { BattleArmorPipGrid } from '../battlearmor/BattleArmorPipGrid';
-import { InfantryPlatoonCounter } from '../infantry/InfantryPlatoonCounter';
-import { ProtoMechArmorDiagram } from '../protomech/ProtoMechArmorDiagram';
-import { VehicleArmorDiagram } from '../vehicle/VehicleArmorDiagram';
+import { getCustomizerDescriptor } from '../shared/customizerTypeRegistry';
 
 // =============================================================================
 // Types
 // =============================================================================
 
 export interface ArmorDiagramForTypeProps {
-  /**
-   * The unit type that controls which diagram is rendered.
-   * Accepts any UnitType enum value.
-   */
+  /** The unit type that controls which diagram is rendered. */
   unitType: UnitType;
-  /** Optional extra CSS classes forwarded to the rendered diagram */
+  /** Optional extra CSS classes forwarded to the rendered diagram. */
   className?: string;
 }
 
@@ -37,7 +33,7 @@ export interface ArmorDiagramForTypeProps {
 // =============================================================================
 
 /**
- * Renders the correct armor diagram for the supplied unit type.
+ * Renders the armor diagram the descriptor registry maps to `unitType`.
  *
  * Routing:
  *   VEHICLE / VTOL / SUPPORT_VEHICLE  → VehicleArmorDiagram
@@ -45,45 +41,12 @@ export interface ArmorDiagramForTypeProps {
  *   BATTLE_ARMOR                      → BattleArmorPipGrid
  *   INFANTRY                          → InfantryPlatoonCounter
  *   PROTOMECH                         → ProtoMechArmorDiagram
- *   Everything else (mechs, etc.)     → ArmorDiagram (existing mech diagram)
+ *   Mech types                        → placeholder (use <ArmorDiagram> directly)
  */
 export function ArmorDiagramForType({
   unitType,
   className = '',
 }: ArmorDiagramForTypeProps): React.ReactElement {
-  switch (unitType) {
-    case UnitType.VEHICLE:
-    case UnitType.VTOL:
-    case UnitType.SUPPORT_VEHICLE:
-      return <VehicleArmorDiagram className={className} />;
-
-    case UnitType.AEROSPACE:
-    case UnitType.CONVENTIONAL_FIGHTER:
-      return <AerospaceArmorDiagram className={className} />;
-
-    case UnitType.BATTLE_ARMOR:
-      return <BattleArmorPipGrid className={className} />;
-
-    case UnitType.INFANTRY:
-      return <InfantryPlatoonCounter className={className} />;
-
-    case UnitType.PROTOMECH:
-      return <ProtoMechArmorDiagram className={className} />;
-
-    // BattleMech / OmniMech / IndustrialMech and capital ships fall through to
-    // the existing mech armor diagram — those types are handled by the pre-existing
-    // Armor tab and do not need this selector.
-    default:
-      // The mech ArmorDiagram requires its own props (armorData, callbacks, etc.)
-      // which are not available here. Return a placeholder directing the caller to
-      // use ArmorDiagram directly for mech types.
-      return (
-        <div
-          className={`text-text-theme-secondary p-4 text-center text-sm ${className}`}
-        >
-          Use <code className="font-mono text-xs">&lt;ArmorDiagram&gt;</code>{' '}
-          for mech-type units.
-        </div>
-      );
-  }
+  const { ArmorDiagramComponent } = getCustomizerDescriptor(unitType);
+  return <ArmorDiagramComponent className={className} />;
 }

--- a/src/components/customizer/preview/RecordSheetPreviewForType.tsx
+++ b/src/components/customizer/preview/RecordSheetPreviewForType.tsx
@@ -1,18 +1,16 @@
 /**
  * RecordSheetPreviewForType — record-sheet preview canvas dispatcher
  *
- * The mech `RecordSheetPreview` hard-calls `useUnitStore` and crashes inside a
- * non-mech customizer. This dispatcher switches on the active `UnitType` and
- * renders the correct per-type canvas component, mirroring the proven
- * `ArmorDiagramForType` pattern:
- *   - BattleMech / OmniMech / IndustrialMech → existing `RecordSheetPreview`
- *   - each non-mech type                     → its per-type canvas component
+ * Resolves the record-sheet preview canvas for the active `UnitType` through
+ * the customizer type descriptor registry. Mech types resolve the mech
+ * `RecordSheetPreview`; each non-mech type resolves its per-type canvas.
  *
- * Each per-type canvas calls exactly one per-type store hook and is only ever
- * rendered for its matching type — satisfying the Rules of Hooks.
+ * The mech `RecordSheetPreview` hard-calls `useUnitStore`; the registry wires
+ * it only into the mech descriptor, so it is rendered only inside the mech
+ * `UnitStoreProvider`.
  *
- * @spec openspec/changes/wire-non-mech-customizer-preview/specs/record-sheet-export/spec.md
- *        Requirement: Record Sheet Preview Component Is Unit-Type Aware
+ * @spec openspec/changes/refactor-customizer-type-descriptors/specs/customizer-routing/spec.md
+ *        Requirement: Unit-Type Customizer Resolution
  */
 
 import React from 'react';
@@ -20,12 +18,7 @@ import React from 'react';
 import { PaperSize } from '@/types/printing';
 import { UnitType } from '@/types/unit/BattleMechInterfaces';
 
-import { AerospaceRecordSheetPreview } from '../aerospace/AerospaceRecordSheetPreview';
-import { BattleArmorRecordSheetPreview } from '../battlearmor/BattleArmorRecordSheetPreview';
-import { InfantryRecordSheetPreview } from '../infantry/InfantryRecordSheetPreview';
-import { ProtoMechRecordSheetPreview } from '../protomech/ProtoMechRecordSheetPreview';
-import { VehicleRecordSheetPreview } from '../vehicle/VehicleRecordSheetPreview';
-import { RecordSheetPreview } from './RecordSheetPreview';
+import { getCustomizerDescriptor } from '../shared/customizerTypeRegistry';
 
 // =============================================================================
 // Types
@@ -47,15 +40,7 @@ export interface RecordSheetPreviewForTypeProps {
 // =============================================================================
 
 /**
- * Renders the correct record-sheet preview canvas for the supplied unit type.
- *
- * Routing:
- *   VEHICLE / VTOL / SUPPORT_VEHICLE  → VehicleRecordSheetPreview
- *   AEROSPACE / CONVENTIONAL_FIGHTER  → AerospaceRecordSheetPreview
- *   BATTLE_ARMOR                      → BattleArmorRecordSheetPreview
- *   INFANTRY                          → InfantryRecordSheetPreview
- *   PROTOMECH                         → ProtoMechRecordSheetPreview
- *   BattleMech / OmniMech / Industrial → RecordSheetPreview (existing mech)
+ * Renders the record-sheet preview canvas the registry maps to `unitType`.
  */
 export function RecordSheetPreviewForType({
   unitType,
@@ -63,65 +48,12 @@ export function RecordSheetPreviewForType({
   scale,
   className = '',
 }: RecordSheetPreviewForTypeProps): React.ReactElement {
-  switch (unitType) {
-    case UnitType.VEHICLE:
-    case UnitType.VTOL:
-    case UnitType.SUPPORT_VEHICLE:
-      return (
-        <VehicleRecordSheetPreview
-          paperSize={paperSize}
-          scale={scale}
-          className={className}
-        />
-      );
-
-    case UnitType.AEROSPACE:
-    case UnitType.CONVENTIONAL_FIGHTER:
-      return (
-        <AerospaceRecordSheetPreview
-          paperSize={paperSize}
-          scale={scale}
-          className={className}
-        />
-      );
-
-    case UnitType.BATTLE_ARMOR:
-      return (
-        <BattleArmorRecordSheetPreview
-          paperSize={paperSize}
-          scale={scale}
-          className={className}
-        />
-      );
-
-    case UnitType.INFANTRY:
-      return (
-        <InfantryRecordSheetPreview
-          paperSize={paperSize}
-          scale={scale}
-          className={className}
-        />
-      );
-
-    case UnitType.PROTOMECH:
-      return (
-        <ProtoMechRecordSheetPreview
-          paperSize={paperSize}
-          scale={scale}
-          className={className}
-        />
-      );
-
-    // BattleMech / OmniMech / IndustrialMech (and any future mech type) keep
-    // the existing mech preview canvas with no behaviour change. The mech
-    // RecordSheetPreview calls useUnitStore, so it is only rendered here.
-    default:
-      return (
-        <RecordSheetPreview
-          paperSize={paperSize}
-          scale={scale}
-          className={className}
-        />
-      );
-  }
+  const { RecordSheetPreviewComponent } = getCustomizerDescriptor(unitType);
+  return (
+    <RecordSheetPreviewComponent
+      paperSize={paperSize}
+      scale={scale}
+      className={className}
+    />
+  );
 }

--- a/src/components/customizer/shared/__tests__/customizerTypeRegistry.test.tsx
+++ b/src/components/customizer/shared/__tests__/customizerTypeRegistry.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * customizerTypeRegistry — descriptor registry contract tests.
+ *
+ * The descriptor registry is the single source of truth the customizer router
+ * and the four `*ForType` dispatchers resolve against. These tests lock that
+ * contract:
+ *   - every `UnitType` resolves a descriptor with every field populated;
+ *   - each descriptor wires the SAME component the pre-refactor `switch`
+ *     selected for that type (component-identity regression guard);
+ *   - unmapped types fall back to the BattleMech descriptor.
+ *
+ * @spec openspec/changes/refactor-customizer-type-descriptors/specs/customizer-routing/spec.md
+ *        Requirement: Unit-Type Customizer Resolution
+ */
+
+// PreviewTab transitively imports jspdf (ESM-only). Stub it so the descriptor
+// import chain resolves under jest.
+jest.mock('jspdf', () => ({
+  jsPDF: jest.fn().mockImplementation(() => ({
+    addImage: jest.fn(),
+    save: jest.fn(),
+  })),
+}));
+
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+
+import { AerospacePreviewTab } from '../../aerospace/AerospacePreviewTab';
+import { BattleArmorPreviewTab } from '../../battlearmor/BattleArmorPreviewTab';
+import { InfantryPreviewTab } from '../../infantry/InfantryPreviewTab';
+import { ProtoMechPreviewTab } from '../../protomech/ProtoMechPreviewTab';
+import { NonMechOverviewPlaceholder } from '../../tabs/NonMechOverviewPlaceholder';
+import { OverviewTab } from '../../tabs/OverviewTab';
+import { PreviewTab } from '../../tabs/PreviewTab';
+import { VehiclePreviewTab } from '../../vehicle/VehiclePreviewTab';
+import {
+  getCustomizerDescriptor,
+  getCustomizerDescriptors,
+} from '../customizerTypeRegistry';
+
+const ALL_UNIT_TYPES: UnitType[] = Object.values(UnitType);
+
+// Types with a dedicated descriptor (every other type falls back to mech).
+const MAPPED_TYPES: UnitType[] = [
+  UnitType.BATTLEMECH,
+  UnitType.OMNIMECH,
+  UnitType.INDUSTRIALMECH,
+  UnitType.VEHICLE,
+  UnitType.VTOL,
+  UnitType.SUPPORT_VEHICLE,
+  UnitType.AEROSPACE,
+  UnitType.CONVENTIONAL_FIGHTER,
+  UnitType.BATTLE_ARMOR,
+  UnitType.INFANTRY,
+  UnitType.PROTOMECH,
+];
+
+// Capital craft etc. — intentionally unmapped, must fall back to mech.
+const UNMAPPED_TYPES: UnitType[] = [
+  UnitType.SMALL_CRAFT,
+  UnitType.DROPSHIP,
+  UnitType.JUMPSHIP,
+  UnitType.WARSHIP,
+  UnitType.SPACE_STATION,
+];
+
+describe('customizerTypeRegistry — descriptor completeness', () => {
+  it.each(ALL_UNIT_TYPES)(
+    'resolves a complete descriptor for %s',
+    (unitType) => {
+      const d = getCustomizerDescriptor(unitType);
+      expect(d).toBeDefined();
+      expect(d.Shell).toBeDefined();
+      expect(d.tabs.length).toBeGreaterThan(0);
+      expect(d.OverviewComponent).toBeDefined();
+      expect(d.PreviewComponent).toBeDefined();
+      expect(d.ArmorDiagramComponent).toBeDefined();
+      expect(d.RecordSheetPreviewComponent).toBeDefined();
+      expect(d.label.length).toBeGreaterThan(0);
+    },
+  );
+
+  it('memoises the descriptor list (stable identity across calls)', () => {
+    expect(getCustomizerDescriptors()).toBe(getCustomizerDescriptors());
+  });
+
+  it('declares no overlapping unitTypes across descriptors', () => {
+    const seen = new Set<UnitType>();
+    for (const d of getCustomizerDescriptors()) {
+      for (const t of d.unitTypes) {
+        expect(seen.has(t)).toBe(false);
+        seen.add(t);
+      }
+    }
+  });
+
+  it('maps every dedicated unit type to a descriptor (not the fallback)', () => {
+    for (const t of MAPPED_TYPES) {
+      expect(getCustomizerDescriptor(t).unitTypes).toContain(t);
+    }
+  });
+});
+
+describe('customizerTypeRegistry — mech fallback', () => {
+  it.each(UNMAPPED_TYPES)(
+    'falls back to the BattleMech descriptor for %s',
+    (unitType) => {
+      const d = getCustomizerDescriptor(unitType);
+      expect(d.label).toBe('BattleMech');
+      expect(d.OverviewComponent).toBe(OverviewTab);
+      expect(d.PreviewComponent).toBe(PreviewTab);
+    },
+  );
+});
+
+describe('customizerTypeRegistry — component identity (no-behaviour-change guard)', () => {
+  it('mech descriptor wires the mech Overview/Preview components', () => {
+    const d = getCustomizerDescriptor(UnitType.BATTLEMECH);
+    expect(d.OverviewComponent).toBe(OverviewTab);
+    expect(d.PreviewComponent).toBe(PreviewTab);
+  });
+
+  it('every non-mech Overview resolves the store-free placeholder', () => {
+    for (const t of [
+      UnitType.VEHICLE,
+      UnitType.VTOL,
+      UnitType.SUPPORT_VEHICLE,
+      UnitType.AEROSPACE,
+      UnitType.CONVENTIONAL_FIGHTER,
+      UnitType.BATTLE_ARMOR,
+      UnitType.INFANTRY,
+      UnitType.PROTOMECH,
+    ]) {
+      expect(getCustomizerDescriptor(t).OverviewComponent).toBe(
+        NonMechOverviewPlaceholder,
+      );
+    }
+  });
+
+  it('each non-mech Preview resolves its per-type preview component', () => {
+    expect(getCustomizerDescriptor(UnitType.VEHICLE).PreviewComponent).toBe(
+      VehiclePreviewTab,
+    );
+    expect(getCustomizerDescriptor(UnitType.AEROSPACE).PreviewComponent).toBe(
+      AerospacePreviewTab,
+    );
+    expect(
+      getCustomizerDescriptor(UnitType.BATTLE_ARMOR).PreviewComponent,
+    ).toBe(BattleArmorPreviewTab);
+    expect(getCustomizerDescriptor(UnitType.INFANTRY).PreviewComponent).toBe(
+      InfantryPreviewTab,
+    );
+    expect(getCustomizerDescriptor(UnitType.PROTOMECH).PreviewComponent).toBe(
+      ProtoMechPreviewTab,
+    );
+  });
+
+  it('mech and Vehicle descriptors do not share an armor diagram', () => {
+    expect(
+      getCustomizerDescriptor(UnitType.BATTLEMECH).ArmorDiagramComponent,
+    ).not.toBe(getCustomizerDescriptor(UnitType.VEHICLE).ArmorDiagramComponent);
+  });
+});

--- a/src/components/customizer/shared/customizerTypeRegistry.tsx
+++ b/src/components/customizer/shared/customizerTypeRegistry.tsx
@@ -1,0 +1,424 @@
+/**
+ * Customizer Type Descriptor Registry — SINGLE SOURCE OF TRUTH for everything
+ * the customizer dispatches by `UnitType`.
+ *
+ * Before this module, six independent surfaces each carried their own
+ * `switch (unitType)` / per-type `if` ladder — `UnitTypeRouter` and the four
+ * `*ForType` dispatchers (`OverviewTabForType`, `PreviewTabForType`,
+ * `ArmorDiagramForType`, `RecordSheetPreviewForType`). Nothing tied them
+ * together, so a unit type could be wired in one ladder and missing/stale in
+ * another — the exact bug class that crashed non-mech customizers with
+ * `useUnitStore must be used within a UnitStoreProvider`.
+ *
+ * Now every unit type maps to one `CustomizerTypeDescriptor`. The router and the
+ * dispatchers are thin lookups into this registry; adding a unit type is one
+ * descriptor registration and a missing field is a TypeScript compile error.
+ *
+ * The registry is built lazily on first access. `tabRegistry.tsx` imports the
+ * `*ForType` dispatchers and those import this module back — a require cycle.
+ * Building the descriptor array at module-evaluation time would capture
+ * half-initialised component bindings; a lazy memoised build runs only after
+ * every module in the cycle has fully evaluated.
+ *
+ * @spec openspec/changes/refactor-customizer-type-descriptors/specs/customizer-routing/spec.md
+ *        Requirement: Unit-Type Customizer Resolution
+ */
+
+import type { StoreApi } from 'zustand';
+
+import React, { useMemo } from 'react';
+
+import type { CustomizerTabId } from '@/hooks/useCustomizerRouter';
+import type { ActiveTabInfo } from '@/stores/UnitStoreProvider';
+import type { AerospaceStore } from '@/stores/useAerospaceStore';
+import type { BattleArmorStore } from '@/stores/useBattleArmorStore';
+import type { InfantryStore } from '@/stores/useInfantryStore';
+import type { ProtoMechStore } from '@/stores/useProtoMechStore';
+import type { TabInfo } from '@/stores/useTabManagerStore';
+import type { VehicleStore } from '@/stores/useVehicleStore';
+import type { PaperSize } from '@/types/printing';
+
+import { ErrorBoundary } from '@/components/common';
+import {
+  getAerospaceStore,
+  hydrateOrCreateAerospace,
+} from '@/stores/aerospaceStoreRegistry';
+import {
+  getBattleArmorStore,
+  hydrateOrCreateBattleArmor,
+} from '@/stores/battleArmorStoreRegistry';
+import {
+  getInfantryStore,
+  hydrateOrCreateInfantry,
+} from '@/stores/infantryStoreRegistry';
+import {
+  getProtoMechStore,
+  hydrateOrCreateProtoMech,
+} from '@/stores/protoMechStoreRegistry';
+import { UnitStoreProvider } from '@/stores/UnitStoreProvider';
+import { AerospaceStoreContext } from '@/stores/useAerospaceStore';
+import { BattleArmorStoreContext } from '@/stores/useBattleArmorStore';
+import { InfantryStoreContext } from '@/stores/useInfantryStore';
+import { ProtoMechStoreContext } from '@/stores/useProtoMechStore';
+import { VehicleStoreContext } from '@/stores/useVehicleStore';
+import {
+  getVehicleStore,
+  hydrateOrCreateVehicle,
+} from '@/stores/vehicleStoreRegistry';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+
+import type { TabSpec } from './TabSpec';
+
+import { AerospaceArmorDiagram } from '../aerospace/AerospaceArmorDiagram';
+import { AerospaceCustomizer } from '../aerospace/AerospaceCustomizer';
+import { AerospacePreviewTab } from '../aerospace/AerospacePreviewTab';
+import { AerospaceRecordSheetPreview } from '../aerospace/AerospaceRecordSheetPreview';
+import { BattleArmorCustomizer } from '../battlearmor/BattleArmorCustomizer';
+import { BattleArmorPipGrid } from '../battlearmor/BattleArmorPipGrid';
+import { BattleArmorPreviewTab } from '../battlearmor/BattleArmorPreviewTab';
+import { BattleArmorRecordSheetPreview } from '../battlearmor/BattleArmorRecordSheetPreview';
+import { InfantryCustomizer } from '../infantry/InfantryCustomizer';
+import { InfantryPlatoonCounter } from '../infantry/InfantryPlatoonCounter';
+import { InfantryPreviewTab } from '../infantry/InfantryPreviewTab';
+import { InfantryRecordSheetPreview } from '../infantry/InfantryRecordSheetPreview';
+import { RecordSheetPreview } from '../preview/RecordSheetPreview';
+import { ProtoMechArmorDiagram } from '../protomech/ProtoMechArmorDiagram';
+import { ProtoMechCustomizer } from '../protomech/ProtoMechCustomizer';
+import { ProtoMechPreviewTab } from '../protomech/ProtoMechPreviewTab';
+import { ProtoMechRecordSheetPreview } from '../protomech/ProtoMechRecordSheetPreview';
+import { NonMechOverviewPlaceholder } from '../tabs/NonMechOverviewPlaceholder';
+import { OverviewTab } from '../tabs/OverviewTab';
+import { PreviewTab } from '../tabs/PreviewTab';
+import { UnitEditorWithRouting } from '../UnitEditorWithRouting';
+import { VehicleArmorDiagram } from '../vehicle/VehicleArmorDiagram';
+import { VehicleCustomizer } from '../vehicle/VehicleCustomizer';
+import { VehiclePreviewTab } from '../vehicle/VehiclePreviewTab';
+import { VehicleRecordSheetPreview } from '../vehicle/VehicleRecordSheetPreview';
+import { getTabSpecsForUnitType } from './tabRegistry';
+
+// =============================================================================
+// Public prop shapes — the supersets the four dispatchers pass through
+// =============================================================================
+
+/** Props the active customizer shell receives from `UnitTypeRouter`. */
+export interface CustomizerShellProps {
+  /** The active customizer tab (unit identity + type). */
+  activeTab: TabInfo;
+  /** The active sub-tab id (mech editor only; non-mech shells self-manage). */
+  activeTabId: CustomizerTabId;
+  /** Sub-tab change callback (mech editor only). */
+  onTabChange: (tabId: CustomizerTabId) => void;
+}
+
+/** Props the Overview-tab dispatcher forwards to a descriptor's Overview. */
+export interface DispatchedOverviewProps {
+  unitType: UnitType;
+  readOnly?: boolean;
+  className?: string;
+}
+
+/** Props the Preview-tab dispatcher forwards to a descriptor's Preview. */
+export interface DispatchedPreviewProps {
+  _readOnly?: boolean;
+  className?: string;
+}
+
+/** Props the armor-diagram dispatcher forwards to a descriptor's diagram. */
+export interface DispatchedArmorDiagramProps {
+  className?: string;
+}
+
+/** Props the record-sheet-preview dispatcher forwards to a descriptor canvas. */
+export interface DispatchedRecordSheetPreviewProps {
+  paperSize?: PaperSize;
+  scale?: number;
+  className?: string;
+}
+
+// =============================================================================
+// Descriptor interface
+// =============================================================================
+
+/**
+ * Everything the customizer needs to render one unit-type family. One
+ * descriptor per family; `getCustomizerDescriptor` resolves a `UnitType` to it.
+ */
+export interface CustomizerTypeDescriptor {
+  /** Every `UnitType` value this descriptor serves. */
+  readonly unitTypes: readonly UnitType[];
+  /** Human label — used for ErrorBoundary names and debugging. */
+  readonly label: string;
+  /** Registry tab set for this unit-type family. */
+  readonly tabs: TabSpec<unknown>[];
+  /** Full customizer shell: hydrates the store, mounts provider + customizer. */
+  readonly Shell: React.ComponentType<CustomizerShellProps>;
+  /** Component rendered by `OverviewTabForType`. */
+  readonly OverviewComponent: React.ComponentType<DispatchedOverviewProps>;
+  /** Component rendered by `PreviewTabForType`. */
+  readonly PreviewComponent: React.ComponentType<DispatchedPreviewProps>;
+  /** Component rendered by `ArmorDiagramForType`. */
+  readonly ArmorDiagramComponent: React.ComponentType<DispatchedArmorDiagramProps>;
+  /** Component rendered by `RecordSheetPreviewForType`. */
+  readonly RecordSheetPreviewComponent: React.ComponentType<DispatchedRecordSheetPreviewProps>;
+}
+
+// =============================================================================
+// Shell builders
+// =============================================================================
+
+/**
+ * Build the customizer shell shared by every non-mech unit type: hydrate the
+ * per-type store, then mount it in its store context with the customizer. This
+ * is the consolidation of the five byte-identical blocks that lived in
+ * `UnitTypeRouter`.
+ */
+function createNonMechShell<S>(config: {
+  label: string;
+  getStore: (id: string) => StoreApi<S> | undefined;
+  hydrateOrCreate: (id: string, tab: TabInfo) => StoreApi<S>;
+  StoreContext: React.Context<StoreApi<S> | null>;
+  Customizer: React.ComponentType<{ store: StoreApi<S>; className?: string }>;
+}): React.FC<CustomizerShellProps> {
+  const { label, getStore, hydrateOrCreate, StoreContext, Customizer } = config;
+
+  function NonMechShell({
+    activeTab,
+  }: CustomizerShellProps): React.ReactElement {
+    // Reuse a registered store for this unit id, else hydrate/create one.
+    const store = useMemo(
+      () => getStore(activeTab.id) ?? hydrateOrCreate(activeTab.id, activeTab),
+      [activeTab],
+    );
+    return (
+      <ErrorBoundary componentName={label}>
+        <StoreContext.Provider value={store}>
+          <Customizer store={store} className="flex-1" />
+        </StoreContext.Provider>
+      </ErrorBoundary>
+    );
+  }
+  NonMechShell.displayName = `${label}Shell`;
+  return NonMechShell;
+}
+
+/**
+ * The BattleMech shell. Unlike the non-mech shells it uses the async-hydrating
+ * `UnitStoreProvider` (with a loading fallback) and `UnitEditorWithRouting`
+ * rather than a `store`-prop customizer — so it is a bespoke component, not a
+ * `createNonMechShell` instance.
+ */
+function MechShell({
+  activeTab,
+  activeTabId,
+  onTabChange,
+}: CustomizerShellProps): React.ReactElement {
+  const mechActiveTab: ActiveTabInfo = {
+    id: activeTab.id,
+    name: activeTab.name,
+    tonnage: activeTab.tonnage,
+    techBase: activeTab.techBase,
+  };
+  return (
+    <ErrorBoundary componentName="BattleMechEditor">
+      <UnitStoreProvider
+        activeTab={mechActiveTab}
+        fallback={
+          <div className="flex flex-1 items-center justify-center">
+            <div className="text-text-theme-secondary p-8 text-center">
+              <p className="mb-2 text-lg">Loading unit...</p>
+            </div>
+          </div>
+        }
+      >
+        <UnitEditorWithRouting
+          activeTabId={activeTabId}
+          onTabChange={onTabChange}
+        />
+      </UnitStoreProvider>
+    </ErrorBoundary>
+  );
+}
+MechShell.displayName = 'MechShell';
+
+/**
+ * Placeholder armor diagram for mech types. The mech `ArmorDiagram` needs props
+ * (armorData, callbacks) the dispatcher cannot supply, so mech Armor tabs use
+ * `<ArmorDiagram>` directly — this preserves the pre-refactor `default` branch
+ * of `ArmorDiagramForType`.
+ */
+function MechArmorDiagramPlaceholder({
+  className = '',
+}: DispatchedArmorDiagramProps): React.ReactElement {
+  return (
+    <div
+      className={`text-text-theme-secondary p-4 text-center text-sm ${className}`}
+    >
+      Use <code className="font-mono text-xs">&lt;ArmorDiagram&gt;</code> for
+      mech-type units.
+    </div>
+  );
+}
+MechArmorDiagramPlaceholder.displayName = 'MechArmorDiagramPlaceholder';
+
+// =============================================================================
+// Lazy descriptor registry
+// =============================================================================
+
+let DESCRIPTORS: CustomizerTypeDescriptor[] | null = null;
+let MECH_DESCRIPTOR: CustomizerTypeDescriptor | null = null;
+
+/** Build the descriptor array once, after the require cycle has settled. */
+function buildDescriptors(): CustomizerTypeDescriptor[] {
+  const mech: CustomizerTypeDescriptor = {
+    unitTypes: [
+      UnitType.BATTLEMECH,
+      UnitType.OMNIMECH,
+      UnitType.INDUSTRIALMECH,
+    ],
+    label: 'BattleMech',
+    tabs: getTabSpecsForUnitType(UnitType.BATTLEMECH),
+    Shell: MechShell,
+    OverviewComponent: OverviewTab,
+    PreviewComponent: PreviewTab,
+    ArmorDiagramComponent: MechArmorDiagramPlaceholder,
+    RecordSheetPreviewComponent: RecordSheetPreview,
+  };
+  MECH_DESCRIPTOR = mech;
+
+  const vehicle: CustomizerTypeDescriptor = {
+    unitTypes: [UnitType.VEHICLE, UnitType.VTOL, UnitType.SUPPORT_VEHICLE],
+    label: 'Vehicle',
+    tabs: getTabSpecsForUnitType(UnitType.VEHICLE),
+    Shell: createNonMechShell<VehicleStore>({
+      label: 'VehicleCustomizer',
+      getStore: getVehicleStore,
+      hydrateOrCreate: (id, tab) =>
+        hydrateOrCreateVehicle(id, {
+          name: tab.name,
+          tonnage: tab.tonnage,
+          techBase: tab.techBase,
+          unitType: tab.unitType as
+            | UnitType.VEHICLE
+            | UnitType.VTOL
+            | UnitType.SUPPORT_VEHICLE,
+        }),
+      StoreContext: VehicleStoreContext,
+      Customizer: VehicleCustomizer,
+    }),
+    OverviewComponent: NonMechOverviewPlaceholder,
+    PreviewComponent: VehiclePreviewTab,
+    ArmorDiagramComponent: VehicleArmorDiagram,
+    RecordSheetPreviewComponent: VehicleRecordSheetPreview,
+  };
+
+  const aerospace: CustomizerTypeDescriptor = {
+    unitTypes: [UnitType.AEROSPACE, UnitType.CONVENTIONAL_FIGHTER],
+    label: 'Aerospace',
+    tabs: getTabSpecsForUnitType(UnitType.AEROSPACE),
+    Shell: createNonMechShell<AerospaceStore>({
+      label: 'AerospaceCustomizer',
+      getStore: getAerospaceStore,
+      hydrateOrCreate: (id, tab) =>
+        hydrateOrCreateAerospace(id, {
+          name: tab.name,
+          tonnage: tab.tonnage,
+          techBase: tab.techBase,
+          isConventional: tab.unitType === UnitType.CONVENTIONAL_FIGHTER,
+        }),
+      StoreContext: AerospaceStoreContext,
+      Customizer: AerospaceCustomizer,
+    }),
+    OverviewComponent: NonMechOverviewPlaceholder,
+    PreviewComponent: AerospacePreviewTab,
+    ArmorDiagramComponent: AerospaceArmorDiagram,
+    RecordSheetPreviewComponent: AerospaceRecordSheetPreview,
+  };
+
+  const battleArmor: CustomizerTypeDescriptor = {
+    unitTypes: [UnitType.BATTLE_ARMOR],
+    label: 'BattleArmor',
+    tabs: getTabSpecsForUnitType(UnitType.BATTLE_ARMOR),
+    Shell: createNonMechShell<BattleArmorStore>({
+      label: 'BattleArmorCustomizer',
+      getStore: getBattleArmorStore,
+      hydrateOrCreate: (id, tab) =>
+        hydrateOrCreateBattleArmor(id, {
+          name: tab.name,
+          techBase: tab.techBase,
+        }),
+      StoreContext: BattleArmorStoreContext,
+      Customizer: BattleArmorCustomizer,
+    }),
+    OverviewComponent: NonMechOverviewPlaceholder,
+    PreviewComponent: BattleArmorPreviewTab,
+    ArmorDiagramComponent: BattleArmorPipGrid,
+    RecordSheetPreviewComponent: BattleArmorRecordSheetPreview,
+  };
+
+  const infantry: CustomizerTypeDescriptor = {
+    unitTypes: [UnitType.INFANTRY],
+    label: 'Infantry',
+    tabs: getTabSpecsForUnitType(UnitType.INFANTRY),
+    Shell: createNonMechShell<InfantryStore>({
+      label: 'InfantryCustomizer',
+      getStore: getInfantryStore,
+      hydrateOrCreate: (id, tab) =>
+        hydrateOrCreateInfantry(id, {
+          name: tab.name,
+          techBase: tab.techBase,
+        }),
+      StoreContext: InfantryStoreContext,
+      Customizer: InfantryCustomizer,
+    }),
+    OverviewComponent: NonMechOverviewPlaceholder,
+    PreviewComponent: InfantryPreviewTab,
+    ArmorDiagramComponent: InfantryPlatoonCounter,
+    RecordSheetPreviewComponent: InfantryRecordSheetPreview,
+  };
+
+  const protoMech: CustomizerTypeDescriptor = {
+    unitTypes: [UnitType.PROTOMECH],
+    label: 'ProtoMech',
+    tabs: getTabSpecsForUnitType(UnitType.PROTOMECH),
+    Shell: createNonMechShell<ProtoMechStore>({
+      label: 'ProtoMechCustomizer',
+      getStore: getProtoMechStore,
+      hydrateOrCreate: (id, tab) =>
+        hydrateOrCreateProtoMech(id, {
+          name: tab.name,
+          tonnage: tab.tonnage,
+        }),
+      StoreContext: ProtoMechStoreContext,
+      Customizer: ProtoMechCustomizer,
+    }),
+    OverviewComponent: NonMechOverviewPlaceholder,
+    PreviewComponent: ProtoMechPreviewTab,
+    ArmorDiagramComponent: ProtoMechArmorDiagram,
+    RecordSheetPreviewComponent: ProtoMechRecordSheetPreview,
+  };
+
+  return [mech, vehicle, aerospace, battleArmor, infantry, protoMech];
+}
+
+/** Return the descriptor list, building it once on first access. */
+export function getCustomizerDescriptors(): CustomizerTypeDescriptor[] {
+  if (!DESCRIPTORS) {
+    DESCRIPTORS = buildDescriptors();
+  }
+  return DESCRIPTORS;
+}
+
+/**
+ * Resolve a `UnitType` to its descriptor. Any type not explicitly mapped (e.g.
+ * capital ships) falls back to the BattleMech descriptor — identical to the
+ * pre-refactor `default:` branch every dispatcher carried.
+ */
+export function getCustomizerDescriptor(
+  unitType: UnitType,
+): CustomizerTypeDescriptor {
+  const descriptors = getCustomizerDescriptors();
+  const match = descriptors.find((d) => d.unitTypes.includes(unitType));
+  // MECH_DESCRIPTOR is assigned inside buildDescriptors(), which get
+  // CustomizerDescriptors() guarantees has run.
+  return match ?? MECH_DESCRIPTOR!;
+}

--- a/src/components/customizer/tabs/OverviewTabForType.tsx
+++ b/src/components/customizer/tabs/OverviewTabForType.tsx
@@ -1,27 +1,24 @@
 /**
  * OverviewTabForType — Overview tab dispatcher
  *
- * The shared mech `OverviewTab` hard-calls `useUnitStore` and crashes when
- * mounted in a non-mech customizer. This dispatcher switches on the active
- * `UnitType` and renders the correct per-type component, mirroring the proven
- * `ArmorDiagramForType` pattern:
- *   - BattleMech / OmniMech / IndustrialMech → existing `OverviewTab` (unchanged)
- *   - every non-mech type                   → `NonMechOverviewPlaceholder`
+ * Resolves the Overview component for the active `UnitType` through the
+ * customizer type descriptor registry — the single source of truth shared with
+ * the router and the other `*ForType` dispatchers. Mech types resolve the mech
+ * `OverviewTab`; every non-mech type resolves `NonMechOverviewPlaceholder`.
  *
- * Because hooks cannot be conditional, the mech `OverviewTab` (which calls
- * `useUnitStore`) is only ever rendered for mech types — i.e. only inside the
+ * Because the mech `OverviewTab` hard-calls `useUnitStore`, the registry only
+ * ever wires it into the mech descriptor — so it is rendered only inside the
  * mech `UnitStoreProvider`.
  *
- * @spec openspec/changes/wire-non-mech-customizer-preview/specs/customizer-tabs/spec.md
- *        Requirement: Overview Tab Non-Mech Crash Guard
+ * @spec openspec/changes/refactor-customizer-type-descriptors/specs/customizer-routing/spec.md
+ *        Requirement: Unit-Type Customizer Resolution
  */
 
 import React from 'react';
 
 import { UnitType } from '@/types/unit/BattleMechInterfaces';
 
-import { NonMechOverviewPlaceholder } from './NonMechOverviewPlaceholder';
-import { OverviewTab } from './OverviewTab';
+import { getCustomizerDescriptor } from '../shared/customizerTypeRegistry';
 
 // =============================================================================
 // Types
@@ -30,9 +27,9 @@ import { OverviewTab } from './OverviewTab';
 export interface OverviewTabForTypeProps {
   /** The unit type that controls which Overview component is rendered. */
   unitType: UnitType;
-  /** Read-only mode — forwarded to the mech `OverviewTab`. */
+  /** Read-only mode — forwarded to the resolved Overview component. */
   readOnly?: boolean;
-  /** Optional extra CSS classes forwarded to the rendered component. */
+  /** Optional extra CSS classes forwarded to the resolved component. */
   className?: string;
 }
 
@@ -41,41 +38,19 @@ export interface OverviewTabForTypeProps {
 // =============================================================================
 
 /**
- * Renders the correct Overview component for the supplied unit type.
- *
- * Routing:
- *   VEHICLE / VTOL / SUPPORT_VEHICLE   → NonMechOverviewPlaceholder
- *   AEROSPACE / CONVENTIONAL_FIGHTER   → NonMechOverviewPlaceholder
- *   BATTLE_ARMOR                       → NonMechOverviewPlaceholder
- *   INFANTRY                           → NonMechOverviewPlaceholder
- *   PROTOMECH                          → NonMechOverviewPlaceholder
- *   BattleMech / OmniMech / Industrial → OverviewTab (existing mech editor)
+ * Renders the Overview component the descriptor registry maps to `unitType`.
  */
 export function OverviewTabForType({
   unitType,
   readOnly = false,
   className = '',
 }: OverviewTabForTypeProps): React.ReactElement {
-  switch (unitType) {
-    case UnitType.VEHICLE:
-    case UnitType.VTOL:
-    case UnitType.SUPPORT_VEHICLE:
-    case UnitType.AEROSPACE:
-    case UnitType.CONVENTIONAL_FIGHTER:
-    case UnitType.BATTLE_ARMOR:
-    case UnitType.INFANTRY:
-    case UnitType.PROTOMECH:
-      // Non-mech types have no per-type Overview editor yet — render the
-      // store-free placeholder so the tab never crashes.
-      return (
-        <NonMechOverviewPlaceholder unitType={unitType} className={className} />
-      );
-
-    // BattleMech / OmniMech / IndustrialMech (and any future mech type) keep
-    // the existing mech Overview editor with no behaviour change. OverviewTab
-    // calls useUnitStore, so it is only ever rendered here — inside the mech
-    // UnitStoreProvider.
-    default:
-      return <OverviewTab readOnly={readOnly} className={className} />;
-  }
+  const { OverviewComponent } = getCustomizerDescriptor(unitType);
+  return (
+    <OverviewComponent
+      unitType={unitType}
+      readOnly={readOnly}
+      className={className}
+    />
+  );
 }

--- a/src/components/customizer/tabs/PreviewTabForType.tsx
+++ b/src/components/customizer/tabs/PreviewTabForType.tsx
@@ -1,31 +1,24 @@
 /**
  * PreviewTabForType — Preview tab dispatcher
  *
- * The shared mech `PreviewTab` hard-calls `useUnitStore` and crashes when
- * mounted in a non-mech customizer. This dispatcher switches on the active
- * `UnitType` and renders the correct per-type preview component, mirroring the
- * proven `ArmorDiagramForType` pattern:
- *   - BattleMech / OmniMech / IndustrialMech → existing `PreviewTab` (verbatim)
- *   - each non-mech type                     → its per-type preview component
+ * Resolves the Preview component for the active `UnitType` through the
+ * customizer type descriptor registry. Mech types resolve the mech `PreviewTab`;
+ * each non-mech type resolves its per-type preview component.
  *
- * The mech `PreviewTab` (which calls `useUnitStore`) is only ever rendered for
- * mech types — i.e. only inside the mech `UnitStoreProvider`. Each non-mech
- * preview component reads only its own per-type store.
+ * The mech `PreviewTab` hard-calls `useUnitStore`; the registry wires it only
+ * into the mech descriptor, so it is rendered only inside the mech
+ * `UnitStoreProvider`. Each non-mech preview component reads only its own
+ * per-type store.
  *
- * @spec openspec/changes/wire-non-mech-customizer-preview/specs/customizer-tabs/spec.md
- *        Requirement: Preview Tab
+ * @spec openspec/changes/refactor-customizer-type-descriptors/specs/customizer-routing/spec.md
+ *        Requirement: Unit-Type Customizer Resolution
  */
 
 import React from 'react';
 
 import { UnitType } from '@/types/unit/BattleMechInterfaces';
 
-import { AerospacePreviewTab } from '../aerospace/AerospacePreviewTab';
-import { BattleArmorPreviewTab } from '../battlearmor/BattleArmorPreviewTab';
-import { InfantryPreviewTab } from '../infantry/InfantryPreviewTab';
-import { ProtoMechPreviewTab } from '../protomech/ProtoMechPreviewTab';
-import { VehiclePreviewTab } from '../vehicle/VehiclePreviewTab';
-import { PreviewTab } from './PreviewTab';
+import { getCustomizerDescriptor } from '../shared/customizerTypeRegistry';
 
 // =============================================================================
 // Types
@@ -34,9 +27,9 @@ import { PreviewTab } from './PreviewTab';
 export interface PreviewTabForTypeProps {
   /** The unit type that controls which preview component is rendered. */
   unitType: UnitType;
-  /** Read-only mode — forwarded to the rendered preview component. */
+  /** Read-only mode — forwarded to the resolved preview component. */
   _readOnly?: boolean;
-  /** Optional extra CSS classes forwarded to the rendered component. */
+  /** Optional extra CSS classes forwarded to the resolved component. */
   className?: string;
 }
 
@@ -45,51 +38,13 @@ export interface PreviewTabForTypeProps {
 // =============================================================================
 
 /**
- * Renders the correct Preview component for the supplied unit type.
- *
- * Routing:
- *   VEHICLE / VTOL / SUPPORT_VEHICLE   → VehiclePreviewTab
- *   AEROSPACE / CONVENTIONAL_FIGHTER   → AerospacePreviewTab
- *   BATTLE_ARMOR                       → BattleArmorPreviewTab
- *   INFANTRY                           → InfantryPreviewTab
- *   PROTOMECH                          → ProtoMechPreviewTab
- *   BattleMech / OmniMech / Industrial → PreviewTab (existing mech preview)
+ * Renders the Preview component the descriptor registry maps to `unitType`.
  */
 export function PreviewTabForType({
   unitType,
   _readOnly = false,
   className = '',
 }: PreviewTabForTypeProps): React.ReactElement {
-  switch (unitType) {
-    case UnitType.VEHICLE:
-    case UnitType.VTOL:
-    case UnitType.SUPPORT_VEHICLE:
-      return <VehiclePreviewTab _readOnly={_readOnly} className={className} />;
-
-    case UnitType.AEROSPACE:
-    case UnitType.CONVENTIONAL_FIGHTER:
-      return (
-        <AerospacePreviewTab _readOnly={_readOnly} className={className} />
-      );
-
-    case UnitType.BATTLE_ARMOR:
-      return (
-        <BattleArmorPreviewTab _readOnly={_readOnly} className={className} />
-      );
-
-    case UnitType.INFANTRY:
-      return <InfantryPreviewTab _readOnly={_readOnly} className={className} />;
-
-    case UnitType.PROTOMECH:
-      return (
-        <ProtoMechPreviewTab _readOnly={_readOnly} className={className} />
-      );
-
-    // BattleMech / OmniMech / IndustrialMech (and any future mech type) keep
-    // the existing mech Preview tab with no behaviour change. PreviewTab calls
-    // useUnitStore, so it is only ever rendered here — inside the mech
-    // UnitStoreProvider.
-    default:
-      return <PreviewTab _readOnly={_readOnly} className={className} />;
-  }
+  const { PreviewComponent } = getCustomizerDescriptor(unitType);
+  return <PreviewComponent _readOnly={_readOnly} className={className} />;
 }


### PR DESCRIPTION
## Summary

The customizer dispatched on `UnitType` across **six independent surfaces** —
`UnitTypeRouter` plus the four `*ForType` dispatchers — each with its own
`switch`/`if` ladder and nothing tying them together. A unit type could be wired
in one ladder and missing or stale in another, with no compiler check. That is
the exact bug class that crashed non-mech customizers three times
(`useUnitStore must be used within a UnitStoreProvider`).

This change introduces `customizerTypeRegistry.tsx` — one
`CustomizerTypeDescriptor` per unit-type family bundling the customizer shell,
the registry tab set, and the Overview / Preview / armor-diagram /
record-sheet-preview components. `UnitTypeRouter` and the four dispatchers become
thin descriptor lookups.

- `UnitTypeRouter.tsx`: 224 → 53 lines; no `UnitType` `switch`/`if` ladder remains.
- Adding a unit type is now **one descriptor registration** — a missing field is
  a TypeScript compile error, not a runtime crash.
- **No behaviour change.** Every unit type renders exactly the components it
  rendered before; only *how they are selected* changed.

OpenSpec change: `refactor-customizer-type-descriptors` (ADDED requirement
*Unit-Type Customizer Resolution* on the `customizer-routing` spec).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` + `oxfmt --check` clean
- [x] New `customizerTypeRegistry.test.tsx` — descriptor completeness, component
      identity (no-behaviour-change guard), mech fallback for unmapped types
- [x] Existing dispatcher + canonical tab-registry tests pass unchanged
- [x] `nonMechCustomizerTabMount` invariant suite (now registry-driven) green
- [x] All 75 customizer test suites pass (918 tests)
- [ ] CI green