### PR TITLE
test(gameplay): cover event-driven heat accumulation in resolveHeatPhase

### DIFF
--- a/src/utils/gameplay/__tests__/resolveHeatPhase.test.ts
+++ b/src/utils/gameplay/__tests__/resolveHeatPhase.test.ts
@@ -1,7 +1,16 @@
 /**
- * Heat Phase Resolution Tests
+ * resolveHeatPhase — event-driven heat integration tests.
  *
- * TDD tests for resolveHeatPhase function.
+ * `heatSystem.test.ts` covers `resolveHeatPhase` at the unit level by
+ * setting a unit's heat directly (`setUnitHeat`) and asserting dissipation
+ * / shutdown / pilot-damage math. It does NOT exercise the event-driven
+ * path: `resolveHeatPhase` derives each unit's per-turn heat by scanning
+ * the current turn's `MovementDeclared` and `AttackDeclared` events. This
+ * suite builds a real `IGameSession` through the public
+ * `declareMovement` / `declareAttack` API and verifies that heat is
+ * accumulated from those declared events, dissipated, and that the
+ * shutdown threshold check fires — the integration angle the previously
+ * skipped stub suite never actually asserted.
  */
 
 import {
@@ -9,16 +18,18 @@ import {
   GameSide,
   Facing,
   MovementType,
+  GameEventType,
   IGameConfig,
   IGameUnit,
   IGameSession,
   IHexCoordinate,
+  IHeatPayload,
   RangeBracket,
-  FiringArc,
   IWeaponAttack,
   WeaponCategory,
 } from '@/types/gameplay';
 
+import { type DiceRoller } from '../diceTypes';
 import {
   createGameSession,
   startGame,
@@ -28,11 +39,20 @@ import {
   lockMovement,
   declareAttack,
   lockAttack,
+  resolveHeatPhase,
 } from '../gameSession';
 
 // =============================================================================
 // Test Fixtures
 // =============================================================================
+
+/** Fixed 2d6 roller (always 12) so any shutdown/startup roll is deterministic. */
+const fixedRoller: DiceRoller = () => ({
+  dice: [6, 6],
+  total: 12,
+  isSnakeEyes: false,
+  isBoxcars: true,
+});
 
 function createTestConfig(overrides: Partial<IGameConfig> = {}): IGameConfig {
   return {
@@ -68,7 +88,33 @@ function createTestUnits(): readonly IGameUnit[] {
   ];
 }
 
-function createHeatPhaseSession(): IGameSession {
+/** A synthetic PPC — 10 heat per shot. */
+function ppc(weaponId: string): IWeaponAttack {
+  return {
+    weaponId,
+    weaponName: 'PPC',
+    damage: 10,
+    heat: 10,
+    category: WeaponCategory.ENERGY,
+    minRange: 3,
+    shortRange: 6,
+    mediumRange: 12,
+    longRange: 18,
+    isCluster: false,
+  };
+}
+
+/**
+ * Build a session advanced to the Heat phase.
+ *
+ * player-1 walks (0 movement heat) and declares `playerWeapons` against
+ * opponent-1; opponent-1 runs (2 movement heat) and fires nothing. The
+ * caller picks `playerWeapons` to land the post-dissipation heat in the
+ * band under test.
+ */
+function createHeatPhaseSession(
+  playerWeapons: IWeaponAttack[] = [ppc('ppc-1')],
+): IGameSession {
   const config = createTestConfig();
   const units = createTestUnits();
   let session = createGameSession(config, units);
@@ -76,9 +122,9 @@ function createHeatPhaseSession(): IGameSession {
   session = rollInitiative(session);
   session = advancePhase(session); // Movement
 
-  // Declare and lock movement for both units (with heat generation)
   const from: IHexCoordinate = { q: 0, r: 0 };
   const to: IHexCoordinate = { q: 1, r: 0 };
+  // player-1 walks: 0 movement heat. opponent-1 runs: 2 movement heat.
   session = declareMovement(
     session,
     'player-1',
@@ -104,108 +150,144 @@ function createHeatPhaseSession(): IGameSession {
 
   session = advancePhase(session); // Weapon Attack
 
-  // Declare and lock attacks (weapons generate heat)
-  const weapons: IWeaponAttack[] = [
-    {
-      weaponId: 'ppc-1',
-      weaponName: 'PPC',
-      damage: 10,
-      heat: 10,
-      category: WeaponCategory.ENERGY,
-      minRange: 3,
-      shortRange: 6,
-      mediumRange: 12,
-      longRange: 18,
-      isCluster: false,
-    },
-  ];
   session = declareAttack(
     session,
     'player-1',
     'opponent-1',
-    weapons,
+    playerWeapons,
     10,
     RangeBracket.Medium,
   );
   session = lockAttack(session, 'player-1');
   session = lockAttack(session, 'opponent-1');
 
+  session = advancePhase(session); // Physical Attack phase
   session = advancePhase(session); // Heat phase
-
   return session;
 }
 
+/** Sum the `amount` of every HeatGenerated event for a unit + source. */
+function heatGeneratedAmount(
+  session: IGameSession,
+  unitId: string,
+  source: IHeatPayload['source'],
+): number {
+  return session.events
+    .filter(
+      (e) => e.type === GameEventType.HeatGenerated && e.actorId === unitId,
+    )
+    .map((e) => e.payload as IHeatPayload)
+    .filter((p) => p.source === source)
+    .reduce((sum, p) => sum + p.amount, 0);
+}
+
+function eventsOfType(
+  session: IGameSession,
+  type: GameEventType,
+  unitId?: string,
+) {
+  return session.events.filter(
+    (e) => e.type === type && (unitId === undefined || e.actorId === unitId),
+  );
+}
+
 // =============================================================================
-// resolveHeatPhase Tests
+// Tests
 // =============================================================================
 
-describe.skip('resolveHeatPhase', () => {
-  it('should create heat dissipated events for all units', () => {
-    const session = createHeatPhaseSession();
-    expect(session).toBeDefined();
+describe('resolveHeatPhase — event-driven heat integration', () => {
+  describe('heat accumulation from declared events', () => {
+    it('accumulates firing heat from AttackDeclared weapon payloads', () => {
+      const session = resolveHeatPhase(createHeatPhaseSession(), fixedRoller);
+      // player-1 fired one PPC (10 heat).
+      expect(heatGeneratedAmount(session, 'player-1', 'firing')).toBe(10);
+    });
+
+    it('sums firing heat across multiple weapons fired by one unit', () => {
+      const session = resolveHeatPhase(
+        createHeatPhaseSession([ppc('ppc-1'), ppc('ppc-2'), ppc('ppc-3')]),
+        fixedRoller,
+      );
+      // 3 PPCs × 10 heat.
+      expect(heatGeneratedAmount(session, 'player-1', 'firing')).toBe(30);
+    });
+
+    it('accumulates movement heat from MovementDeclared payloads', () => {
+      const session = resolveHeatPhase(createHeatPhaseSession(), fixedRoller);
+      // opponent-1 ran for 2 movement heat.
+      expect(heatGeneratedAmount(session, 'opponent-1', 'movement')).toBe(2);
+    });
+
+    it('emits no firing-heat event for a unit that declared no attack', () => {
+      const session = resolveHeatPhase(createHeatPhaseSession(), fixedRoller);
+      expect(heatGeneratedAmount(session, 'opponent-1', 'firing')).toBe(0);
+    });
   });
 
-  it('should accumulate heat from weapon fire', () => {
-    const session = createHeatPhaseSession();
-    expect(session).toBeDefined();
+  describe('heat dissipation', () => {
+    it('emits a HeatDissipated event for every active unit', () => {
+      const session = resolveHeatPhase(createHeatPhaseSession(), fixedRoller);
+      expect(
+        eventsOfType(session, GameEventType.HeatDissipated, 'player-1').length,
+      ).toBeGreaterThanOrEqual(1);
+      expect(
+        eventsOfType(session, GameEventType.HeatDissipated, 'opponent-1')
+          .length,
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    it('dissipates sub-capacity heat fully to zero', () => {
+      // 10 firing heat / 2 movement heat are both within a 10-heat-sink
+      // dissipation capacity, so net heat clamps to 0.
+      const session = resolveHeatPhase(createHeatPhaseSession(), fixedRoller);
+      expect(session.currentState.units['player-1'].heat).toBe(0);
+      expect(session.currentState.units['opponent-1'].heat).toBe(0);
+    });
   });
 
-  it('should accumulate heat from movement', () => {
-    const session = createHeatPhaseSession();
-    expect(session).toBeDefined();
+  describe('shutdown threshold check', () => {
+    it('emits no shutdown check when net heat stays below 14', () => {
+      const session = resolveHeatPhase(createHeatPhaseSession(), fixedRoller);
+      expect(eventsOfType(session, GameEventType.ShutdownCheck).length).toBe(0);
+    });
+
+    it('emits a shutdown check once net heat reaches the shutdown band', () => {
+      // 5 PPCs = 50 firing heat − 10 dissipation = 40 net heat, well into
+      // the shutdown band.
+      const session = resolveHeatPhase(
+        createHeatPhaseSession([
+          ppc('ppc-1'),
+          ppc('ppc-2'),
+          ppc('ppc-3'),
+          ppc('ppc-4'),
+          ppc('ppc-5'),
+        ]),
+        fixedRoller,
+      );
+      expect(
+        eventsOfType(session, GameEventType.ShutdownCheck, 'player-1').length,
+      ).toBeGreaterThanOrEqual(1);
+      expect(
+        session.currentState.units['player-1'].heat,
+      ).toBeGreaterThanOrEqual(14);
+    });
   });
 
-  it('should dissipate heat based on heat sinks', () => {
-    const session = createHeatPhaseSession();
-    expect(session).toBeDefined();
-  });
+  describe('phase contract', () => {
+    it('keeps the session in the Heat phase', () => {
+      const session = resolveHeatPhase(createHeatPhaseSession(), fixedRoller);
+      expect(session.currentState.phase).toBe(GamePhase.Heat);
+    });
 
-  it('should apply water cooling bonus from terrain', () => {
-    const session = createHeatPhaseSession();
-    expect(session).toBeDefined();
-  });
-
-  it('should calculate net heat correctly', () => {
-    const session = createHeatPhaseSession();
-    expect(session).toBeDefined();
-  });
-
-  it('should create shutdown check event at heat 18+', () => {
-    const session = createHeatPhaseSession();
-    expect(session).toBeDefined();
-  });
-
-  it('should create ammo explosion check event at heat 19+', () => {
-    const session = createHeatPhaseSession();
-    expect(session).toBeDefined();
-  });
-
-  it('should advance to End phase when complete', () => {
-    const session = createHeatPhaseSession();
-    expect(session.currentState.phase).toBe(GamePhase.Heat);
-  });
-
-  it('should handle units with no heat generation', () => {
-    const config = createTestConfig();
-    const units = createTestUnits();
-    let session = createGameSession(config, units);
-    session = startGame(session, GameSide.Player);
-    expect(session).toBeDefined();
-  });
-
-  it('should handle multiple weapons fired by same unit', () => {
-    const config = createTestConfig();
-    const units = createTestUnits();
-    let session = createGameSession(config, units);
-    session = startGame(session, GameSide.Player);
-    expect(session).toBeDefined();
-  });
-
-  it('should throw error if not in heat phase', () => {
-    const config = createTestConfig();
-    const units = createTestUnits();
-    let session = createGameSession(config, units);
-    session = startGame(session, GameSide.Player);
-    expect(session).toBeDefined();
+    it('throws when invoked outside the heat phase', () => {
+      const config = createTestConfig();
+      let session = createGameSession(config, createTestUnits());
+      session = startGame(session, GameSide.Player);
+      session = rollInitiative(session);
+      session = advancePhase(session); // Movement — not Heat
+      expect(() => resolveHeatPhase(session, fixedRoller)).toThrow(
+        'Not in heat phase',
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Replaces the 12-case `describe.skip`'d hollow stub suite in `resolveHeatPhase.test.ts` with 10 real event-driven integration tests.
- `heatSystem.test.ts` already covers `resolveHeatPhase` at the unit level by setting heat directly via `setUnitHeat`. It never exercised the **event-driven** path — where `resolveHeatPhase` derives each unit's per-turn heat by scanning the turn's `MovementDeclared` / `AttackDeclared` events.
- This suite builds a real `IGameSession` through the public `declareMovement` / `declareAttack` API and asserts heat is accumulated from declared events, dissipated, and that the shutdown-threshold check fires.

## What's covered
- Firing heat summed from `AttackDeclared` weapon payloads (single + multi-weapon).
- Movement heat accumulated from `MovementDeclared` payloads.
- No firing-heat event for a unit that declared no attack.
- `HeatDissipated` event emitted for every active unit; sub-capacity heat clamps to 0.
- No shutdown check below 14 net heat; shutdown check fires once net heat reaches the band.
- Phase contract: stays in Heat phase; throws when invoked outside it.

## Notes
- The original stub's fixture comment was stale — it claimed 3 `advancePhase` calls reached the Heat phase, but the phase order (Movement → WeaponAttack → PhysicalAttack → Heat) needs 4. The suite would never have passed if un-skipped.

## Test plan
- [x] `npm test -- resolveHeatPhase` — 10/10 pass
- [x] lint / format / typecheck clean