### PR TITLE
feat(campaign): wire Coming-of-Age life events

### DIFF
--- a/src/lib/campaign/events/__tests__/lifeEvents.test.ts
+++ b/src/lib/campaign/events/__tests__/lifeEvents.test.ts
@@ -177,19 +177,90 @@ describe('lifeEvents', () => {
     });
   });
 
-  describe('processLifeEvents - coming of age (deferred)', () => {
-    // TODO(person-dob-field): Coming of Age / birthday events require `dateOfBirth`
-    // on ICampaignRosterEntry or IPilot. Neither type carries the field yet.
-    // Re-enable these tests once `ICampaignRosterEntry.dateOfBirth` lands.
-    it('does not fire coming-of-age events (dateOfBirth field not yet available)', () => {
-      // Even with personnel on a potential "birthday", no CoA event fires
-      // because the loop is stubbed with `void entries` in the production code.
-      const entries: ILifeEventPersonPair[] = [makePair()];
-      const random = createSeededRandom(42);
-      const events = processLifeEvents(entries, '3025-01-01', random);
+  describe('processLifeEvents - coming of age', () => {
+    /** Find the Coming-of-Age event in a result set, if any. */
+    const findCoA = (events: ReturnType<typeof processLifeEvents>) =>
+      events.find((e) => e.title === 'Coming of Age');
 
-      const comingOfAgeEvent = events.find((e) => e.title === 'Coming of Age');
-      expect(comingOfAgeEvent).toBeUndefined();
+    it('fires a Coming-of-Age event on the pilot’s 16th birthday', () => {
+      // Born 3009-06-15 → turns 16 on 3025-06-15.
+      const entries: ILifeEventPersonPair[] = [
+        makePair(
+          { pilotName: 'Cadet Vega' },
+          makePilot({ birthDate: '3009-06-15' }),
+        ),
+      ];
+      const events = processLifeEvents(
+        entries,
+        '3025-06-15',
+        createSeededRandom(42),
+      );
+
+      const coa = findCoA(events);
+      expect(coa).toBeDefined();
+      expect(coa?.category).toBe(RandomEventCategory.LIFE);
+      expect(coa?.severity).toBe(RandomEventSeverity.MINOR);
+      expect(coa?.description).toContain('Cadet Vega');
+    });
+
+    it('does not fire on a date that is not the pilot’s birthday', () => {
+      const entries: ILifeEventPersonPair[] = [
+        makePair({}, makePilot({ birthDate: '3009-06-15' })),
+      ];
+      const events = processLifeEvents(
+        entries,
+        '3025-06-16',
+        createSeededRandom(42),
+      );
+      expect(findCoA(events)).toBeUndefined();
+    });
+
+    it('does not fire when the pilot turns an age other than 16', () => {
+      // Born 3008-06-15 → turns 17 on 3025-06-15, not a coming-of-age year.
+      const entries: ILifeEventPersonPair[] = [
+        makePair({}, makePilot({ birthDate: '3008-06-15' })),
+      ];
+      const events = processLifeEvents(
+        entries,
+        '3025-06-15',
+        createSeededRandom(42),
+      );
+      expect(findCoA(events)).toBeUndefined();
+    });
+
+    it('does not fire for an entry with no joined pilot (NPC)', () => {
+      const entries: ILifeEventPersonPair[] = [makePair({}, null)];
+      const events = processLifeEvents(
+        entries,
+        '3025-06-15',
+        createSeededRandom(42),
+      );
+      expect(findCoA(events)).toBeUndefined();
+    });
+
+    it('does not fire when the joined pilot has no recorded birth date', () => {
+      const entries: ILifeEventPersonPair[] = [makePair()]; // default pilot, no birthDate
+      const events = processLifeEvents(
+        entries,
+        '3025-06-15',
+        createSeededRandom(42),
+      );
+      expect(findCoA(events)).toBeUndefined();
+    });
+
+    it('fires alongside a calendar celebration that lands the same day', () => {
+      // Born 3009-01-01 → 16th birthday coincides with New Year’s Day.
+      const entries: ILifeEventPersonPair[] = [
+        makePair({}, makePilot({ birthDate: '3009-01-01' })),
+      ];
+      const events = processLifeEvents(
+        entries,
+        '3025-01-01',
+        createSeededRandom(42),
+      );
+      expect(events.map((e) => e.title)).toEqual(
+        expect.arrayContaining(["New Year's Day", 'Coming of Age']),
+      );
     });
   });
 

--- a/src/lib/campaign/events/lifeEvents.ts
+++ b/src/lib/campaign/events/lifeEvents.ts
@@ -5,7 +5,11 @@ import type {
 } from '@/types/campaign/events/randomEventTypes';
 import type { IPilot } from '@/types/pilot/PilotInterfaces';
 
-import { isSpecificDate } from '@/lib/campaign/events/eventProbability';
+import {
+  calculateAge,
+  isBirthday,
+  isSpecificDate,
+} from '@/lib/campaign/events/eventProbability';
 import {
   RandomEventCategory,
   RandomEventSeverity,
@@ -54,6 +58,12 @@ export const CALENDAR_CELEBRATIONS: readonly ICalendarCelebration[] = [
   },
 ];
 
+/**
+ * Age (in years) at which a pilot "comes of age" — reaches adulthood. Matches
+ * the MekHQ convention used elsewhere in the progression rules.
+ */
+const COMING_OF_AGE_YEARS = 16;
+
 let lifeEventCounter = 0;
 function generateLifeEventId(): string {
   return `life-evt-${Date.now()}-${++lifeEventCounter}`;
@@ -75,13 +85,14 @@ export interface ILifeEventPersonPair {
  * Calendar celebrations (New Year's, Commander's Day, Freedom Day, Winter Holiday)
  * are checked against the current date. They do not require per-person data.
  *
- * Birthday / Coming of Age events are deferred: `ICampaignRosterEntry` and `IPilot`
- * do not carry a `dateOfBirth` field yet. The loop is intentionally stubbed out
- * with a TODO until `ICampaignRosterEntry.dateOfBirth` lands (tracked under
- * FIXME(person-dob-field) in the roster entry spec).
+ * Coming-of-Age events fire for a PC roster entry on the calendar day the
+ * joined vault `IPilot` turns 16. They are driven by `IPilot.birthDate`
+ * (resolved via the entry→pilot join); NPC entries carry a frozen statblock
+ * with no birth date, so they do not generate Coming-of-Age events.
  *
- * NPC behavior: PROCESS — calendar events fire regardless of personnel contents.
- * Per-person events will apply to NPCs and PCs alike once dateOfBirth is available.
+ * NPC behavior: PROCESS — calendar events fire regardless of personnel
+ * contents; Coming-of-Age is PC-only because only vault pilots carry a
+ * birth date.
  *
  * @param entries - Array of joined entry+pilot pairs for the active roster
  * @param currentDate - ISO date string for the current campaign turn
@@ -115,20 +126,33 @@ export function processLifeEvents(
     }
   }
 
-  // TODO(person-dob-field): Coming of Age / birthday events require `dateOfBirth`
-  // on ICampaignRosterEntry or IPilot. Neither type carries the field yet.
-  // Re-enable this loop once the field lands:
-  //
-  //   for (const { entry } of entries) {
-  //     if (!entry.dateOfBirth) continue;
-  //     const dobStr = entry.dateOfBirth instanceof Date
-  //       ? entry.dateOfBirth.toISOString()
-  //       : entry.dateOfBirth;
-  //     if (isBirthday(dobStr, currentDate) && calculateAge(dobStr, currentDate) === 16) {
-  //       events.push({ ... Coming of Age event using entry.pilotName / entry.pilotId ... });
-  //     }
-  //   }
-  void entries; // suppress unused-variable lint until the loop above is re-enabled
+  // Coming-of-Age events — fire on the day a PC pilot turns 16. Driven by the
+  // joined vault `IPilot.birthDate`; entries with no joined pilot (NPCs) or no
+  // recorded birth date are skipped.
+  for (const { entry, pilot } of entries) {
+    const birthDate = pilot?.birthDate;
+    if (!birthDate) continue;
+    if (
+      isBirthday(birthDate, currentDate) &&
+      calculateAge(birthDate, currentDate) === COMING_OF_AGE_YEARS
+    ) {
+      events.push({
+        id: generateLifeEventId(),
+        category: RandomEventCategory.LIFE,
+        severity: RandomEventSeverity.MINOR,
+        title: 'Coming of Age',
+        description: `${entry.pilotName} has come of age, reaching adulthood at ${COMING_OF_AGE_YEARS}.`,
+        effects: [
+          {
+            type: 'notification',
+            message: `${entry.pilotName} has come of age`,
+            severity: 'positive',
+          },
+        ],
+        timestamp: currentDate,
+      });
+    }
+  }
 
   return events;
 }


### PR DESCRIPTION
## Summary
`processLifeEvents` carried a stubbed-out Coming-of-Age loop guarded by `FIXME(person-dob-field)` — the comment claimed neither `ICampaignRosterEntry` nor `IPilot` carried a birth date, so the loop was replaced with `void entries`.

That premise is **stale**: `IPilot.birthDate` exists (and is already consumed by `aging.ts`), and `processLifeEvents` already receives the joined `IPilot` for each roster entry. This wires the loop with **zero type changes**.

- A PC roster entry emits a `Coming of Age` life event on the calendar day its joined vault pilot turns 16, driven by `IPilot.birthDate` and the canonical `isBirthday` / `calculateAge` helpers.
- Entries with no joined pilot (NPCs) or no recorded birth date are skipped — NPC statblocks carry no birth date.
- Removes the `void entries` lint suppression and the dead `FIXME(person-dob-field)`.

## Test plan
- [x] 6 new Coming-of-Age cases: fires on the 16th birthday; not on a non-birthday; not at other ages; not for NPC (no joined pilot); not when birthDate is absent; fires alongside a same-day calendar celebration
- [x] Existing calendar-celebration + NPC-support tests still pass (19/19 total)
- [x] lint / format / typecheck clean