### PR TITLE
fix(campaign): award 5 XP on Coming-of-Age event

### DIFF
--- a/src/lib/campaign/events/__tests__/lifeEvents.test.ts
+++ b/src/lib/campaign/events/__tests__/lifeEvents.test.ts
@@ -186,7 +186,7 @@ describe('lifeEvents', () => {
       // Born 3009-06-15 → turns 16 on 3025-06-15.
       const entries: ILifeEventPersonPair[] = [
         makePair(
-          { pilotName: 'Cadet Vega' },
+          { pilotId: 'pilot-vega', pilotName: 'Cadet Vega' },
           makePilot({ birthDate: '3009-06-15' }),
         ),
       ];
@@ -201,6 +201,31 @@ describe('lifeEvents', () => {
       expect(coa?.category).toBe(RandomEventCategory.LIFE);
       expect(coa?.severity).toBe(RandomEventSeverity.MINOR);
       expect(coa?.description).toContain('Cadet Vega');
+    });
+
+    it('awards 5 XP to the coming-of-age pilot (random-events spec)', () => {
+      // Per `random-events` spec: the Coming-of-Age event carries a 5 XP award
+      // targeting the pilot's roster id.
+      const entries: ILifeEventPersonPair[] = [
+        makePair(
+          { pilotId: 'pilot-vega', pilotName: 'Cadet Vega' },
+          makePilot({ birthDate: '3009-06-15' }),
+        ),
+      ];
+      const events = processLifeEvents(
+        entries,
+        '3025-06-15',
+        createSeededRandom(42),
+      );
+
+      const coa = findCoA(events);
+      expect(coa).toBeDefined();
+      const xpEffect = coa?.effects.find((e) => e.type === 'xp_award');
+      expect(xpEffect).toEqual({
+        type: 'xp_award',
+        personId: 'pilot-vega',
+        amount: 5,
+      });
     });
 
     it('does not fire on a date that is not the pilot’s birthday', () => {

--- a/src/lib/campaign/events/lifeEvents.ts
+++ b/src/lib/campaign/events/lifeEvents.ts
@@ -64,6 +64,12 @@ export const CALENDAR_CELEBRATIONS: readonly ICalendarCelebration[] = [
  */
 const COMING_OF_AGE_YEARS = 16;
 
+/**
+ * XP awarded to a pilot on their Coming-of-Age event. Per the `random-events`
+ * spec ("Life Events" → "Coming-of-age at 16"), the event carries a 5 XP award.
+ */
+const COMING_OF_AGE_XP_AWARD = 5;
+
 let lifeEventCounter = 0;
 function generateLifeEventId(): string {
   return `life-evt-${Date.now()}-${++lifeEventCounter}`;
@@ -143,6 +149,11 @@ export function processLifeEvents(
         title: 'Coming of Age',
         description: `${entry.pilotName} has come of age, reaching adulthood at ${COMING_OF_AGE_YEARS}.`,
         effects: [
+          {
+            type: 'xp_award',
+            personId: entry.pilotId,
+            amount: COMING_OF_AGE_XP_AWARD,
+          },
           {
             type: 'notification',
             message: `${entry.pilotName} has come of age`,


### PR DESCRIPTION
## Summary
The `random-events` spec — requirement **Life Events**, scenario **Coming-of-age at 16** — requires the Coming-of-Age event to carry a **5 XP award**:

> **GIVEN** a person with birthDate 3009-06-15 and currentDate 3025-06-15
> **WHEN** life events are processed
> **THEN** a coming-of-age event is generated **with 5 XP award**

PR #595 wired the Coming-of-Age event but emitted only a `notification` effect, leaving that spec scenario unsatisfied.

This adds an `xp_award` effect (5 XP, targeting the roster entry's `pilotId`) alongside the existing notification.

## Test plan
- [x] New test asserts the CoA event's `xp_award` effect (`{ type: 'xp_award', personId, amount: 5 }`)
- [x] 20/20 `lifeEvents` tests pass; lint / format / typecheck clean