### PR TITLE
test(campaign): assert the Coming-of-Age notification effect

### DIFF
--- a/src/lib/campaign/events/__tests__/lifeEvents.test.ts
+++ b/src/lib/campaign/events/__tests__/lifeEvents.test.ts
@@ -228,6 +228,31 @@ describe('lifeEvents', () => {
       });
     });
 
+    it('emits a positive notification effect naming the pilot', () => {
+      // The Coming-of-Age event carries a player-facing notification effect
+      // alongside the xp_award — both must be present.
+      const entries: ILifeEventPersonPair[] = [
+        makePair(
+          { pilotName: 'Cadet Vega' },
+          makePilot({ birthDate: '3009-06-15' }),
+        ),
+      ];
+      const events = processLifeEvents(
+        entries,
+        '3025-06-15',
+        createSeededRandom(42),
+      );
+
+      const coa = findCoA(events);
+      expect(coa).toBeDefined();
+      const notification = coa?.effects.find((e) => e.type === 'notification');
+      expect(notification).toEqual({
+        type: 'notification',
+        message: 'Cadet Vega has come of age',
+        severity: 'positive',
+      });
+    });
+
     it('does not fire on a date that is not the pilot’s birthday', () => {
       const entries: ILifeEventPersonPair[] = [
         makePair({}, makePilot({ birthDate: '3009-06-15' })),


### PR DESCRIPTION
## Summary
- Adds a regression test asserting the Coming-of-Age life event emits a positive `notification` effect naming the pilot, alongside the existing `xp_award` effect.
- Closes the test gap flagged by the verification subagent during the triage wave — the `notification` effect was implemented but never asserted.

## Test plan
- [x] `npm test -- lifeEvents` — 42/42 pass
- [x] lint + format clean