### PR TITLE
chore(ui): wave 1 UI/UX polish touch-ups for gameplay/replay surfaces

### DIFF
--- a/src/components/audit/replay/GameReplayPage.states.tsx
+++ b/src/components/audit/replay/GameReplayPage.states.tsx
@@ -1,17 +1,10 @@
 import Link from 'next/link';
 
 import { KeyboardShortcutsHelp } from '@/components/audit/replay';
-import { Button } from '@/components/ui';
+import { Button, PageLoading } from '@/components/ui';
 
 export function ReplayLoading(): React.ReactElement {
-  return (
-    <div className="flex h-screen items-center justify-center bg-gray-900">
-      <div className="text-center">
-        <div className="border-accent mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-4 border-t-transparent" />
-        <p className="text-text-theme-secondary">Loading game replay...</p>
-      </div>
-    </div>
-  );
+  return <PageLoading message="Loading game replay..." />;
 }
 
 interface ReplayErrorProps {
@@ -24,7 +17,7 @@ export function ReplayError({
   gameId,
 }: ReplayErrorProps): React.ReactElement {
   return (
-    <div className="flex h-screen items-center justify-center bg-gray-900">
+    <div className="bg-surface-deep flex h-screen items-center justify-center">
       <div className="max-w-md text-center">
         <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-900/20">
           <svg

--- a/src/components/gameplay/pages/GameSessionPage.states.tsx
+++ b/src/components/gameplay/pages/GameSessionPage.states.tsx
@@ -14,12 +14,12 @@ import { GameSide } from '@/types/gameplay';
 export function GameLoading(): React.ReactElement {
   return (
     <div
-      className="flex h-screen items-center justify-center bg-gray-900"
+      className="bg-surface-deep flex h-screen items-center justify-center"
       data-testid="game-loading"
     >
       <div className="text-center">
-        <div className="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" />
-        <p className="text-gray-400">Loading game session...</p>
+        <div className="border-accent mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-4 border-t-transparent" />
+        <p className="text-text-theme-secondary">Loading game session...</p>
       </div>
     </div>
   );
@@ -124,14 +124,14 @@ export function CompletedGame({
 
   return (
     <div
-      className="flex h-screen items-center justify-center bg-gray-900"
+      className="bg-surface-deep flex h-screen items-center justify-center"
       data-testid="game-completed"
     >
       <div className="max-w-lg text-center">
         <div className={`mb-4 text-6xl font-bold ${winnerColor}`}>
           {winnerText}
         </div>
-        <p className="mb-8 text-lg text-gray-400 capitalize">
+        <p className="text-text-theme-secondary mb-8 text-lg capitalize">
           {reason.replace('_', ' ')}
         </p>
 
@@ -169,7 +169,7 @@ export function CompletedGame({
           </div>
         </div>
 
-        <div className="mt-8 border-t border-gray-700 pt-8">
+        <div className="border-border-theme mt-8 border-t pt-8">
           <Link
             href={`/audit/timeline?gameId=${gameId}`}
             className="flex items-center justify-center gap-2 text-sm text-cyan-400 transition-colors hover:text-cyan-300"
@@ -193,7 +193,7 @@ export function GameError({
 }: GameErrorProps): React.ReactElement {
   return (
     <div
-      className="flex h-screen items-center justify-center bg-gray-900"
+      className="bg-surface-deep flex h-screen items-center justify-center"
       data-testid="game-error"
     >
       <div className="max-w-md text-center">
@@ -212,10 +212,10 @@ export function GameError({
             />
           </svg>
         </div>
-        <h2 className="mb-2 text-xl font-bold text-white">
+        <h2 className="text-text-theme-primary mb-2 text-xl font-bold">
           Failed to Load Game
         </h2>
-        <p className="mb-4 text-gray-400">{message}</p>
+        <p className="text-text-theme-secondary mb-4">{message}</p>
         <div className="flex items-center justify-center gap-3">
           <Button
             variant="primary"

--- a/src/components/replay-library/ReplayLibraryList.tsx
+++ b/src/components/replay-library/ReplayLibraryList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import type { IReplayManifestEntry } from '@/replay-library/types';
 
-import { Button, Card } from '@/components/ui';
+import { Badge, Button, Card } from '@/components/ui';
 import { ReplaySource } from '@/types/gameplay';
 
 export type SourceFilter = 'all' | ReplaySource;
@@ -44,12 +44,9 @@ export function ReplayRow({
         >
           {entry.id}
         </h3>
-        <span
-          className="bg-surface-raised text-text-theme-secondary rounded px-2 py-1 text-xs"
-          data-testid="replay-source"
-        >
+        <Badge variant="slate" size="md" data-testid="replay-source">
           {entry.replaySource}
-        </span>
+        </Badge>
       </div>
 
       <SourceMetadata entry={entry} />

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -54,7 +54,7 @@ export function Button({
   ...props
 }: ButtonProps): React.ReactElement {
   const baseClasses =
-    'rounded-lg font-medium transition-colors inline-flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed';
+    'rounded-lg font-medium transition-colors inline-flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface-deep';
   const widthClass = fullWidth ? 'w-full' : '';
 
   return (


### PR DESCRIPTION
## Summary

OMO Council **Wave 1** — close the gap between MekStation's existing design system (Tailwind v4 `@theme` tokens, `src/components/ui/` primitives, 4 themes) and three audited surfaces. Small, independently-verifiable polish touch-ups; no behavior change.

- **Chrome-token fix** — gameplay (`GameSessionPage.states.tsx`) and replay (`GameReplayPage.states.tsx`) loading/error state shells were rendering hardcoded `bg-gray-900` / `text-gray-400` / `border-gray-700` / `border-blue-500`, so they showed the wrong colors when the user switched themes. Now use semantic tokens (`bg-surface-deep`, `text-text-theme-*`, `border-accent`, `border-border-theme`).
- **Focus-visible ring on `Button`** — the shared primitive had no keyboard-focus indicator; added `focus-visible:ring-accent` (theme-tracking).
- **Primitive adoption** — `ReplayLoading` now routes through the shared `PageLoading` instead of a hand-rolled copy.
- **Badge consistency** — the replay-source pill in `ReplayLibraryList` was a hand-rolled `<span>`; swapped to the shared `<Badge>` component.

Semantic status colors (victory/defeat/draw) and red error accents are intentionally left unchanged — they already match the shared `PageError` convention. The broad ~678-hit SVG/terrain/effect-art "token drift" was deliberately **not** swept (council consensus: intentional art, invisible churn).

## Council provenance

5-agent Lean+ OMO Council + 2-agent Phase 3 cross-attack. The Phase 2 frontrunner ("broad token sweep is the #1 win") was killed by verified counts and replaced with this narrowed chrome-only subset. The `/customizer` crash was verified already fixed; interaction-friction was flagged as a Wave 2 follow-up (no agent walked the click-flows).

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `oxlint` on changed files — 0 warnings / 0 errors
- [x] `oxfmt --check` on changed files — clean
- [x] `jest` — 54/54 pass (Button, Button a11y, replay-library page)
- [x] pre-commit `next build` — passed
- [ ] Manual: load gameplay + replay surfaces, toggle all 4 themes, confirm chrome tracks theme and focus rings appear on keyboard tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)