### PR TITLE
chore: maintenance sweep — decompose 6 bloated files + turnover modifier registry

### DIFF
--- a/src/engine/InteractiveSession.actions.ts
+++ b/src/engine/InteractiveSession.actions.ts
@@ -1,0 +1,132 @@
+/**
+ * Interactive Session — player-action collaborator.
+ *
+ * Extracted from `InteractiveSession` so the class stays a thin
+ * state-machine coordinator. This module owns the declare-then-lock
+ * logic for the two human-driven actions: declaring a unit's movement
+ * and declaring a weapon attack.
+ *
+ * Each function is pure with respect to the session: it takes the
+ * current `IGameSession` plus the cached lookup maps and returns the
+ * next session. The coordinator keeps ownership of the trailing
+ * `tryFinalizeAndPublish()` call so the once-per-session outcome guard
+ * stays in one place. Behaviour is preserved exactly.
+ */
+
+import type { IWeapon } from '@/simulation/ai/types';
+import type { IWeaponAttack } from '@/types/gameplay/CombatInterfaces';
+import type { IGameSession } from '@/types/gameplay/GameSessionInterfaces';
+
+import {
+  Facing,
+  MovementType,
+  RangeBracket,
+  type IHexCoordinate,
+  type IHexGrid,
+  type IMovementCapability,
+} from '@/types/gameplay/HexGridInterfaces';
+import {
+  declareAttack,
+  declareMovement,
+  lockAttack,
+  lockMovement,
+} from '@/utils/gameplay/gameSession';
+import {
+  buildMovementEventPath,
+  maxMovementCostForCapability,
+} from '@/utils/gameplay/movement/eventPath';
+import { buildWeaponAttacks } from '@/utils/gameplay/weaponAttackBuilder';
+
+/**
+ * Inputs for `applyInteractiveSessionMovement` — the live session, the
+ * grid the pathfinder uses, and the cached per-unit movement maps.
+ */
+export interface IApplyMovementInput {
+  readonly session: IGameSession;
+  readonly grid: IHexGrid;
+  readonly movementByUnit: Map<string, IMovementCapability>;
+  readonly unitId: string;
+  readonly to: IHexCoordinate;
+  readonly facing: Facing;
+  readonly movementType: MovementType;
+  /** Optional pre-computed path; built from the grid when omitted. */
+  readonly path?: readonly IHexCoordinate[];
+}
+
+/**
+ * Declare and lock a unit's movement for the current Movement phase.
+ * Returns the unchanged session when the unit id is unknown (callers
+ * treat a missing unit as a no-op). When no explicit path is given the
+ * event path is rebuilt from the grid so movement costs stay in
+ * lockstep with the pathfinder.
+ */
+export function applyInteractiveSessionMovement(
+  input: IApplyMovementInput,
+): IGameSession {
+  const unit = input.session.currentState.units[input.unitId];
+  if (!unit) return input.session;
+
+  const capability = input.movementByUnit.get(input.unitId);
+  const eventPath =
+    input.path ??
+    buildMovementEventPath({
+      grid: input.grid,
+      from: unit.position,
+      to: input.to,
+      movementType: input.movementType,
+      maxCost: maxMovementCostForCapability(capability, input.movementType),
+    });
+
+  let session = declareMovement(
+    input.session,
+    input.unitId,
+    unit.position,
+    input.to,
+    input.facing,
+    input.movementType,
+    0,
+    input.movementType === MovementType.Jump ? 1 : 0,
+    eventPath,
+  );
+  session = lockMovement(session, input.unitId);
+  return session;
+}
+
+/**
+ * Inputs for `applyInteractiveSessionAttack` — the live session and the
+ * cached per-unit weapon map.
+ */
+export interface IApplyAttackInput {
+  readonly session: IGameSession;
+  readonly weaponsByUnit: Map<string, readonly IWeapon[]>;
+  readonly attackerId: string;
+  readonly targetId: string;
+  readonly weaponIds: readonly string[];
+}
+
+/**
+ * Declare and lock a weapon attack for the current WeaponAttack phase.
+ * Firing arc is intentionally NOT pre-computed here — `resolveAttack`
+ * derives it from live positions + target facing at resolve time.
+ */
+export function applyInteractiveSessionAttack(
+  input: IApplyAttackInput,
+): IGameSession {
+  const unitWeapons = input.weaponsByUnit.get(input.attackerId) ?? [];
+  const weaponAttacks: IWeaponAttack[] = buildWeaponAttacks(
+    input.weaponIds,
+    unitWeapons,
+    input.attackerId,
+  );
+
+  let session = declareAttack(
+    input.session,
+    input.attackerId,
+    input.targetId,
+    weaponAttacks,
+    3,
+    RangeBracket.Short,
+  );
+  session = lockAttack(session, input.attackerId);
+  return session;
+}

--- a/src/engine/InteractiveSession.phases.ts
+++ b/src/engine/InteractiveSession.phases.ts
@@ -1,0 +1,158 @@
+/**
+ * Interactive Session — phase-transition collaborator.
+ *
+ * Extracted from `InteractiveSession` so the class stays a thin
+ * state-machine coordinator. This module owns the per-`GamePhase`
+ * branch logic that `advancePhase()` runs: rolling initiative, locking
+ * stragglers, resolving attacks / heat / physical attacks, queuing and
+ * draining piloting-skill rolls, and the End-phase game-over guard.
+ *
+ * Behaviour is preserved exactly — the End-phase `isGameOver` guard
+ * (do not advance past End once the game is over) and every resolver
+ * call order are identical to the pre-extraction class body.
+ */
+
+import type { IHexCoordinate } from '@/types/gameplay/HexGridInterfaces';
+import type { D6Roller, DiceRoller } from '@/utils/gameplay/diceTypes';
+
+import {
+  GamePhase,
+  LockState,
+  type IGameSession,
+} from '@/types/gameplay/GameSessionInterfaces';
+import {
+  advancePhase,
+  checkAndQueueDamagePSRs,
+  lockAttack,
+  lockMovement,
+  resolveAllAttacks,
+  resolveAllPhysicalAttacks,
+  resolveHeatPhase,
+  resolvePendingPSRs,
+  rollInitiative,
+  type IPhysicalAttackContext,
+} from '@/utils/gameplay/gameSession';
+
+/**
+ * Collaborator context the coordinator threads into the phase-advance
+ * driver. Mirrors the `InteractiveSession.ai` context shape: the class
+ * exposes its private state through getter/setter + provider callbacks
+ * so this module never reaches into the class internals directly.
+ */
+export interface IInteractiveSessionPhaseContext {
+  /** Current session snapshot — read fresh at the start of the call. */
+  readonly getSession: () => IGameSession;
+  /** Writes a new session snapshot back onto the coordinator. */
+  readonly setSession: (session: IGameSession) => void;
+  /** Resolver-shaped `D6Roller`; `undefined` falls back to engine default. */
+  readonly d6RollerForResolvers: () => D6Roller | undefined;
+  /** 2d6 `DiceRoller`; `undefined` falls back to engine default. */
+  readonly diceRollerForResolvers: () => DiceRoller | undefined;
+  /** Per-unit physical-attack context (tonnage / piloting / hexes moved). */
+  readonly physicalContextByUnit: () => Map<string, IPhysicalAttackContext>;
+  /** Water-depth provider for the Heat-phase cooling bonus. */
+  readonly waterDepthAt: (position: IHexCoordinate) => number;
+  /** Win-condition predicate — gates the End-phase advance. */
+  readonly isGameOver: () => boolean;
+}
+
+/**
+ * Lock every unit still in `Free`/`Declared` so the phase rolls over
+ * with a fully-locked board. Shared by the Movement and WeaponAttack
+ * branches, which differ only in the lock function they apply.
+ */
+function lockStragglers(
+  session: IGameSession,
+  lock: (session: IGameSession, unitId: string) => IGameSession,
+): IGameSession {
+  let next = session;
+  for (const unitId of Object.keys(next.currentState.units)) {
+    const u = next.currentState.units[unitId];
+    if (
+      u.lockState !== LockState.Locked &&
+      u.lockState !== LockState.Resolved
+    ) {
+      next = lock(next, unitId);
+    }
+  }
+  return next;
+}
+
+/**
+ * Run the phase-transition branch for the session's current `GamePhase`
+ * and write the resulting session back onto the coordinator. This is the
+ * verbatim body of `InteractiveSession.advancePhase()` minus the trailing
+ * `tryFinalizeAndPublish()` call, which the coordinator still owns so the
+ * outcome-publication idempotency guard stays in one place.
+ */
+export function advanceInteractiveSessionPhase(
+  context: IInteractiveSessionPhaseContext,
+): void {
+  let session = context.getSession();
+  const { phase } = session.currentState;
+
+  if (phase === GamePhase.Initiative) {
+    session = rollInitiative(
+      session,
+      undefined,
+      context.d6RollerForResolvers(),
+    );
+    session = advancePhase(session);
+  } else if (phase === GamePhase.Movement) {
+    // Lock any units that haven't been locked yet
+    session = lockStragglers(session, lockMovement);
+    session = advancePhase(session);
+  } else if (phase === GamePhase.WeaponAttack) {
+    // Lock any units that haven't been locked yet
+    session = lockStragglers(session, lockAttack);
+    session = resolveAllAttacks(session, context.diceRollerForResolvers());
+    // Per `wire-piloting-skill-rolls` § 2: after weapon damage has
+    // accumulated via the reducer, scan every unit and enqueue a
+    // `TwentyPlusPhaseDamage` PSR on any that crossed 20 damage.
+    // Resolution deliberately waits for the End phase.
+    session = checkAndQueueDamagePSRs(session);
+    session = advancePhase(session);
+  } else if (phase === GamePhase.PhysicalAttack) {
+    // Per `wire-bot-ai-helpers-and-capstone`: resolve any
+    // PhysicalAttackDeclared events for the current turn before
+    // advancing — without this, declarations made by `runAITurn`
+    // would silently expire when the phase rolls over.
+    session = resolveAllPhysicalAttacks(
+      session,
+      context.physicalContextByUnit(),
+      context.diceRollerForResolvers(),
+    );
+    // Per `wire-piloting-skill-rolls` § 5: physical-attack damage can
+    // also breach the 20+ threshold. Queue any new damage PSRs before
+    // the phase flips so they resolve in the End phase.
+    session = checkAndQueueDamagePSRs(session);
+    session = advancePhase(session);
+  } else if (phase === GamePhase.Heat) {
+    // Per `wire-heat-generation-and-effects` task 5 (water cooling):
+    // `resolveHeatPhase` accepts an optional `getWaterDepth`
+    // provider. `IHex.terrain` is a plain `string` here (no
+    // structured depth), so we parse the `water:N` convention (used
+    // by future water-tagged hexes) and return 0 for any terrain
+    // that doesn't match. Existing grids use `'clear'` → bonus 0.
+    session = resolveHeatPhase(session, context.diceRollerForResolvers(), {
+      getWaterDepth: (_unitId, position) => context.waterDepthAt(position),
+    });
+    session = advancePhase(session);
+  } else if (phase === GamePhase.End) {
+    // Per `wire-piloting-skill-rolls` § 7: drain the PSR queue for
+    // every unit. Failures invoke `applyFall` (→ `UnitFell` +
+    // `PilotHit`) and clear the remaining queue on that unit.
+    session = resolvePendingPSRs(session, context.diceRollerForResolvers());
+    // The End-phase advance is gated on `isGameOver`, which inspects
+    // the coordinator's live session. The PSR drain above can itself
+    // trip the win condition, so the post-drain session MUST be
+    // committed before the guard runs — matching the pre-extraction
+    // behaviour where `this.session` was reassigned in place.
+    context.setSession(session);
+    if (!context.isGameOver()) {
+      session = advancePhase(session);
+    }
+  }
+
+  context.setSession(session);
+}

--- a/src/engine/InteractiveSession.resolvers.ts
+++ b/src/engine/InteractiveSession.resolvers.ts
@@ -1,0 +1,95 @@
+/**
+ * Interactive Session — resolver-input collaborator.
+ *
+ * Extracted from `InteractiveSession` so the class stays a thin
+ * state-machine coordinator. This module owns the small, pure helpers
+ * that shape the inputs the gameplay resolvers consume: the injected
+ * roller adapters, the per-unit physical-attack context, and the
+ * water-depth lookup for the Heat phase.
+ *
+ * Every helper is a pure function of its arguments — no class state is
+ * touched. Behaviour is preserved exactly.
+ */
+
+import type { IGameSession } from '@/types/gameplay/GameSessionInterfaces';
+import type {
+  IHexCoordinate,
+  IHexGrid,
+} from '@/types/gameplay/HexGridInterfaces';
+import type { IPhysicalAttackContext } from '@/utils/gameplay/gameSession';
+
+import {
+  roll2d6 as roll2d6FromD6,
+  type D6Roller,
+  type DiceRoller,
+} from '@/utils/gameplay/diceTypes';
+import { waterDepthAtPosition } from '@/utils/gameplay/waterDepth';
+
+/**
+ * Resolver-shaped `D6Roller`. Returns `undefined` when no roller was
+ * injected so the resolver's own `defaultD6Roller` (`Math.random`)
+ * remains in effect for single-player / hot-seat callers.
+ *
+ * Per `add-authoritative-roll-arbitration` (Wave 3a): `ServerMatchHost`
+ * always injects a server-authoritative `D6Roller` (crypto-backed in
+ * prod, seeded in `?seed=N` debug mode), so this returns the live
+ * roller in multiplayer. Wrapping it via `RollCapture` further
+ * upstream is what lets the host stamp captured rolls onto event
+ * payloads.
+ */
+export function d6RollerForResolvers(
+  d6Roller: D6Roller | undefined,
+): D6Roller | undefined {
+  return d6Roller;
+}
+
+/**
+ * Adapter that lifts the injected `D6Roller` into a `DiceRoller` (a
+ * full 2d6 result). Resolvers like `resolveAllAttacks` /
+ * `resolveHeatPhase` / `resolveAllPhysicalAttacks` consume `DiceRoller`
+ * — this keeps the injection point uniform without refactoring those
+ * resolvers' parameter type. Returns `undefined` to fall back to the
+ * resolver's default when no roller was injected.
+ */
+export function diceRollerForResolvers(
+  d6Roller: D6Roller | undefined,
+): DiceRoller | undefined {
+  if (!d6Roller) return undefined;
+  return () => roll2d6FromD6(d6Roller);
+}
+
+/**
+ * Build the per-unit `IPhysicalAttackContext` map the physical-attack
+ * resolver needs (attacker tonnage, piloting skill, hexes moved this
+ * turn). Falls back to the Phase 1 defaults (65t / piloting 5) for any
+ * unit missing from the cached maps — same defaults the class used.
+ */
+export function physicalContextByUnit(
+  session: IGameSession,
+  tonnageByUnit: Map<string, number>,
+  pilotingByUnit: Map<string, number>,
+): Map<string, IPhysicalAttackContext> {
+  const map = new Map<string, IPhysicalAttackContext>();
+  for (const [unitId, unit] of Object.entries(session.currentState.units)) {
+    map.set(unitId, {
+      attackerTonnage: tonnageByUnit.get(unitId) ?? 65,
+      pilotingSkill: pilotingByUnit.get(unitId) ?? 5,
+      hexesMoved: unit.hexesMovedThisTurn,
+    });
+  }
+  return map;
+}
+
+/**
+ * Per `wire-heat-generation-and-effects` task 5 + decisions.md
+ * "Water cooling integration point": `IHex.terrain` is a plain
+ * `string` today. We parse the `water:N` convention so a future
+ * map author can tag a hex as `'water:1'` / `'water:2'` and get
+ * the dissipation bonus immediately; all other terrain strings
+ * (including `'clear'`, `'woods'`, etc.) return depth 0 → no
+ * water cooling contribution. Calling `getWaterCoolingBonus(0)`
+ * yields 0, preserving behaviour for every existing grid.
+ */
+export function waterDepthAt(grid: IHexGrid, position: IHexCoordinate): number {
+  return waterDepthAtPosition(grid, position);
+}

--- a/src/engine/InteractiveSession.setup.ts
+++ b/src/engine/InteractiveSession.setup.ts
@@ -1,0 +1,99 @@
+/**
+ * Interactive Session — construction-time setup collaborator.
+ *
+ * Extracted from `InteractiveSession` so the constructor stays a thin
+ * wiring step. This module owns the two pieces of construction-time
+ * derivation: building the per-unit lookup maps (weapons / movement /
+ * gunnery / piloting / tonnage) and assembling the `IGameConfig` from
+ * the raw constructor arguments + campaign linkage.
+ *
+ * Both functions are pure with respect to their inputs. Behaviour is
+ * preserved exactly — the Phase 1 tonnage stand-in (65t) and the
+ * `victoryConditions: ['elimination']` default are unchanged.
+ */
+
+import type { IWeapon } from '@/simulation/ai/types';
+import type {
+  IGameConfig,
+  IGameUnit,
+} from '@/types/gameplay/GameSessionInterfaces';
+import type { IMovementCapability } from '@/types/gameplay/HexGridInterfaces';
+
+import type { IInteractiveSessionLinkage } from './InteractiveSession.types';
+import type { IAdaptedUnit } from './types';
+
+import { toMovementCapability } from './GameEngine.helpers';
+
+/**
+ * The five per-unit lookup maps the engine caches at session start so
+ * the resolvers and AI driver can read unit attributes without
+ * re-adapting the catalog on every turn.
+ */
+export interface IInteractiveSessionUnitMaps {
+  readonly weaponsByUnit: Map<string, readonly IWeapon[]>;
+  readonly movementByUnit: Map<string, IMovementCapability>;
+  readonly gunneryByUnit: Map<string, number>;
+  readonly pilotingByUnit: Map<string, number>;
+  readonly tonnageByUnit: Map<string, number>;
+}
+
+/**
+ * Build the per-unit lookup maps from the adapted units (weapons +
+ * movement capability + tonnage) and the game units (gunnery +
+ * piloting). Tonnage uses the Phase 1 stand-in of 65t because catalog
+ * tonnage is not yet on `IAdaptedUnit` — matches `SimulationRunnerConstants`.
+ */
+export function buildInteractiveSessionUnitMaps(
+  playerUnits: readonly IAdaptedUnit[],
+  opponentUnits: readonly IAdaptedUnit[],
+  gameUnits: readonly IGameUnit[],
+): IInteractiveSessionUnitMaps {
+  const weaponsByUnit = new Map<string, readonly IWeapon[]>();
+  const movementByUnit = new Map<string, IMovementCapability>();
+  const gunneryByUnit = new Map<string, number>();
+  const pilotingByUnit = new Map<string, number>();
+  const tonnageByUnit = new Map<string, number>();
+
+  for (const u of [...playerUnits, ...opponentUnits]) {
+    weaponsByUnit.set(u.id, u.weapons);
+    movementByUnit.set(u.id, toMovementCapability(u));
+    // Phase 1 stand-in: catalog tonnage isn't on `IAdaptedUnit` yet,
+    // so we default to 65t (matches `SimulationRunnerConstants`).
+    tonnageByUnit.set(u.id, 65);
+  }
+  for (const gu of gameUnits) {
+    gunneryByUnit.set(gu.id, gu.gunnery);
+    pilotingByUnit.set(gu.id, gu.piloting);
+  }
+
+  return {
+    weaponsByUnit,
+    movementByUnit,
+    gunneryByUnit,
+    pilotingByUnit,
+    tonnageByUnit,
+  };
+}
+
+/**
+ * Assemble the `IGameConfig` from the raw constructor arguments and the
+ * campaign linkage. The Wave 5 round-trip identifiers are stamped onto
+ * the config so any later consumer of `IGameSession` (review UI,
+ * persistence layer) can read them without keeping a parallel map.
+ */
+export function buildInteractiveSessionGameConfig(
+  mapRadius: number,
+  turnLimit: number,
+  linkage: IInteractiveSessionLinkage,
+): IGameConfig {
+  return {
+    mapRadius,
+    turnLimit,
+    victoryConditions: ['elimination'],
+    optionalRules: [],
+    encounterId: linkage.encounterId ?? null,
+    campaignId: linkage.campaignId ?? null,
+    contractId: linkage.contractId ?? null,
+    scenarioId: linkage.scenarioId ?? null,
+  };
+}

--- a/src/engine/InteractiveSession.ts
+++ b/src/engine/InteractiveSession.ts
@@ -4,7 +4,7 @@
  */
 
 import type { IWeapon } from '@/simulation/ai/types';
-import type { IWeaponAttack } from '@/types/gameplay/CombatInterfaces';
+import type { D6Roller, DiceRoller } from '@/utils/gameplay/diceTypes';
 
 import {
   deriveCombatOutcome,
@@ -24,9 +24,7 @@ import {
 } from '@/types/combat/CombatOutcome';
 import {
   GameSide,
-  GamePhase,
   GameStatus,
-  LockState,
   type IGameSession,
   type IGameConfig,
   type IGameUnit,
@@ -36,45 +34,25 @@ import {
 import {
   Facing,
   MovementType,
-  RangeBracket,
   type IHexCoordinate,
   type IHexGrid,
   type IMovementCapability,
 } from '@/types/gameplay/HexGridInterfaces';
 import {
-  type D6Roller,
-  type DiceRoller,
-  roll2d6 as roll2d6FromD6,
-} from '@/utils/gameplay/diceTypes';
-import {
   createGameSession,
   startGame,
-  advancePhase,
   appendEvent,
-  rollInitiative,
-  declareMovement,
-  lockMovement,
-  declareAttack,
-  lockAttack,
-  resolveAllAttacks,
-  resolveHeatPhase,
-  resolveAllPhysicalAttacks,
-  checkAndQueueDamagePSRs,
-  resolvePendingPSRs,
   endGame,
   type IPhysicalAttackContext,
 } from '@/utils/gameplay/gameSession';
-import {
-  buildMovementEventPath,
-  maxMovementCostForCapability,
-} from '@/utils/gameplay/movement/eventPath';
-import { waterDepthAtPosition } from '@/utils/gameplay/waterDepth';
-import { buildWeaponAttacks } from '@/utils/gameplay/weaponAttackBuilder';
 
 import type { IInteractiveSessionLinkage } from './InteractiveSession.types';
 import type { IAdaptedUnit, IAvailableActions } from './types';
 
-import { toMovementCapability } from './GameEngine.helpers';
+import {
+  applyInteractiveSessionAttack,
+  applyInteractiveSessionMovement,
+} from './InteractiveSession.actions';
 import { runInteractiveSessionAITurn } from './InteractiveSession.ai';
 import { finalizeSessionOutcome } from './InteractiveSession.outcome';
 import {
@@ -82,7 +60,18 @@ import {
   reportMatchLogDivergence,
   type MatchLogHydrationStorage,
 } from './InteractiveSession.persistence';
+import { advanceInteractiveSessionPhase } from './InteractiveSession.phases';
 import { getAvailableActionsForState } from './InteractiveSession.queries';
+import {
+  d6RollerForResolvers,
+  diceRollerForResolvers,
+  physicalContextByUnit,
+  waterDepthAt,
+} from './InteractiveSession.resolvers';
+import {
+  buildInteractiveSessionGameConfig,
+  buildInteractiveSessionUnitMaps,
+} from './InteractiveSession.setup';
 
 /**
  * Per `wire-encounter-to-campaign-round-trip` Wave 5: campaign linkage
@@ -146,37 +135,24 @@ export class InteractiveSession {
     this.startedAt = new Date().toISOString();
     this.d6Roller = d6Roller;
 
-    this.weaponsByUnit = new Map();
-    this.movementByUnit = new Map();
-    this.gunneryByUnit = new Map();
-    this.pilotingByUnit = new Map();
-    this.tonnageByUnit = new Map();
+    // Per-unit lookup maps + game-config assembly live in
+    // `InteractiveSession.setup` so the constructor stays thin wiring.
+    const maps = buildInteractiveSessionUnitMaps(
+      playerUnits,
+      opponentUnits,
+      gameUnits,
+    );
+    this.weaponsByUnit = maps.weaponsByUnit;
+    this.movementByUnit = maps.movementByUnit;
+    this.gunneryByUnit = maps.gunneryByUnit;
+    this.pilotingByUnit = maps.pilotingByUnit;
+    this.tonnageByUnit = maps.tonnageByUnit;
 
-    for (const u of [...playerUnits, ...opponentUnits]) {
-      this.weaponsByUnit.set(u.id, u.weapons);
-      this.movementByUnit.set(u.id, toMovementCapability(u));
-      // Phase 1 stand-in: catalog tonnage isn't on `IAdaptedUnit` yet,
-      // so we default to 65t (matches `SimulationRunnerConstants`).
-      this.tonnageByUnit.set(u.id, 65);
-    }
-    for (const gu of gameUnits) {
-      this.gunneryByUnit.set(gu.id, gu.gunnery);
-      this.pilotingByUnit.set(gu.id, gu.piloting);
-    }
-
-    this.gameConfig = {
+    this.gameConfig = buildInteractiveSessionGameConfig(
       mapRadius,
       turnLimit,
-      victoryConditions: ['elimination'],
-      optionalRules: [],
-      // Wave 5 linkage: round-trip identifiers stamped on the config so
-      // any later consumer of `IGameSession` (review UI, persistence
-      // layer) can read them without keeping a parallel map.
-      encounterId: linkage.encounterId ?? null,
-      campaignId: linkage.campaignId ?? null,
-      contractId: linkage.contractId ?? null,
-      scenarioId: linkage.scenarioId ?? null,
-    };
+      linkage,
+    );
     this.linkage = linkage;
 
     this.session = createGameSession(this.gameConfig, gameUnits, {
@@ -241,31 +217,17 @@ export class InteractiveSession {
     movementType: MovementType,
     path?: readonly IHexCoordinate[],
   ): void {
-    const unit = this.session.currentState.units[unitId];
-    if (!unit) return;
-    const capability = this.movementByUnit.get(unitId);
-    const eventPath =
-      path ??
-      buildMovementEventPath({
-        grid: this.grid,
-        from: unit.position,
-        to,
-        movementType,
-        maxCost: maxMovementCostForCapability(capability, movementType),
-      });
-
-    this.session = declareMovement(
-      this.session,
+    // Declare-then-lock logic lives in `InteractiveSession.actions`.
+    this.session = applyInteractiveSessionMovement({
+      session: this.session,
+      grid: this.grid,
+      movementByUnit: this.movementByUnit,
       unitId,
-      unit.position,
       to,
       facing,
       movementType,
-      0,
-      movementType === MovementType.Jump ? 1 : 0,
-      eventPath,
-    );
-    this.session = lockMovement(this.session, unitId);
+      path,
+    });
     this.tryFinalizeAndPublish();
   }
 
@@ -274,110 +236,34 @@ export class InteractiveSession {
     targetId: string,
     weaponIds: readonly string[],
   ): void {
-    const unitWeapons = this.weaponsByUnit.get(attackerId) ?? [];
-    const weaponAttacks: IWeaponAttack[] = buildWeaponAttacks(
-      weaponIds,
-      unitWeapons,
-      attackerId,
-    );
-
-    // Firing arc is computed inside resolveAttack from current positions +
-    // target facing at resolve time. No need to pre-compute here.
-    this.session = declareAttack(
-      this.session,
+    // Declare-then-lock logic lives in `InteractiveSession.actions`.
+    this.session = applyInteractiveSessionAttack({
+      session: this.session,
+      weaponsByUnit: this.weaponsByUnit,
       attackerId,
       targetId,
-      weaponAttacks,
-      3,
-      RangeBracket.Short,
-    );
-    this.session = lockAttack(this.session, attackerId);
+      weaponIds,
+    });
     this.tryFinalizeAndPublish();
   }
 
   advancePhase(): void {
-    const { phase } = this.session.currentState;
-
-    if (phase === GamePhase.Initiative) {
-      this.session = rollInitiative(
-        this.session,
-        undefined,
-        this.d6RollerForResolvers(),
-      );
-      this.session = advancePhase(this.session);
-    } else if (phase === GamePhase.Movement) {
-      // Lock any units that haven't been locked yet
-      for (const unitId of Object.keys(this.session.currentState.units)) {
-        const u = this.session.currentState.units[unitId];
-        if (
-          u.lockState !== LockState.Locked &&
-          u.lockState !== LockState.Resolved
-        ) {
-          this.session = lockMovement(this.session, unitId);
-        }
-      }
-      this.session = advancePhase(this.session);
-    } else if (phase === GamePhase.WeaponAttack) {
-      // Lock any units that haven't been locked yet
-      for (const unitId of Object.keys(this.session.currentState.units)) {
-        const u = this.session.currentState.units[unitId];
-        if (
-          u.lockState !== LockState.Locked &&
-          u.lockState !== LockState.Resolved
-        ) {
-          this.session = lockAttack(this.session, unitId);
-        }
-      }
-      this.session = resolveAllAttacks(
-        this.session,
-        this.diceRollerForResolvers(),
-      );
-      // Per `wire-piloting-skill-rolls` § 2: after weapon damage has
-      // accumulated via the reducer, scan every unit and enqueue a
-      // `TwentyPlusPhaseDamage` PSR on any that crossed 20 damage.
-      // Resolution deliberately waits for the End phase.
-      this.session = checkAndQueueDamagePSRs(this.session);
-      this.session = advancePhase(this.session);
-    } else if (phase === GamePhase.PhysicalAttack) {
-      // Per `wire-bot-ai-helpers-and-capstone`: resolve any
-      // PhysicalAttackDeclared events for the current turn before
-      // advancing — without this, declarations made by `runAITurn`
-      // would silently expire when the phase rolls over.
-      this.session = resolveAllPhysicalAttacks(
-        this.session,
-        this.physicalContextByUnit(),
-        this.diceRollerForResolvers(),
-      );
-      // Per `wire-piloting-skill-rolls` § 5: physical-attack damage can
-      // also breach the 20+ threshold. Queue any new damage PSRs before
-      // the phase flips so they resolve in the End phase.
-      this.session = checkAndQueueDamagePSRs(this.session);
-      this.session = advancePhase(this.session);
-    } else if (phase === GamePhase.Heat) {
-      // Per `wire-heat-generation-and-effects` task 5 (water cooling):
-      // `resolveHeatPhase` accepts an optional `getWaterDepth`
-      // provider. `IHex.terrain` is a plain `string` here (no
-      // structured depth), so we parse the `water:N` convention (used
-      // by future water-tagged hexes) and return 0 for any terrain
-      // that doesn't match. Existing grids use `'clear'` → bonus 0.
-      this.session = resolveHeatPhase(
-        this.session,
-        this.diceRollerForResolvers(),
-        { getWaterDepth: (_unitId, position) => this.waterDepthAt(position) },
-      );
-      this.session = advancePhase(this.session);
-    } else if (phase === GamePhase.End) {
-      // Per `wire-piloting-skill-rolls` § 7: drain the PSR queue for
-      // every unit. Failures invoke `applyFall` (→ `UnitFell` +
-      // `PilotHit`) and clear the remaining queue on that unit.
-      this.session = resolvePendingPSRs(
-        this.session,
-        this.diceRollerForResolvers(),
-      );
-      if (!this.isGameOver()) {
-        this.session = advancePhase(this.session);
-      }
-    }
+    // Per-phase transition logic lives in `InteractiveSession.phases`.
+    // The class stays a thin coordinator: it threads its private state
+    // through the phase-context callbacks and keeps ownership of the
+    // trailing finalize/publish step so the once-per-session outcome
+    // guard is not split across modules.
+    advanceInteractiveSessionPhase({
+      getSession: () => this.session,
+      setSession: (session) => {
+        this.session = session;
+      },
+      d6RollerForResolvers: () => this.d6RollerForResolvers(),
+      diceRollerForResolvers: () => this.diceRollerForResolvers(),
+      physicalContextByUnit: () => this.physicalContextByUnit(),
+      waterDepthAt: (position) => this.waterDepthAt(position),
+      isGameOver: () => this.isGameOver(),
+    });
     // Wave 5: any phase transition can land us in a victory condition
     // (e.g., the final attack resolution destroys the last opponent
     // unit). Try to finalize+publish here so the campaign store is
@@ -413,18 +299,13 @@ export class InteractiveSession {
       });
   }
 
+  // Resolver-input shaping lives in `InteractiveSession.resolvers`.
   private physicalContextByUnit(): Map<string, IPhysicalAttackContext> {
-    const map = new Map<string, IPhysicalAttackContext>();
-    for (const [unitId, unit] of Object.entries(
-      this.session.currentState.units,
-    )) {
-      map.set(unitId, {
-        attackerTonnage: this.tonnageByUnit.get(unitId) ?? 65,
-        pilotingSkill: this.pilotingByUnit.get(unitId) ?? 5,
-        hexesMoved: unit.hexesMovedThisTurn,
-      });
-    }
-    return map;
+    return physicalContextByUnit(
+      this.session,
+      this.tonnageByUnit,
+      this.pilotingByUnit,
+    );
   }
 
   /**
@@ -506,48 +387,18 @@ export class InteractiveSession {
     return this.outcomePublished;
   }
 
-  /**
-   * Resolver-shaped `D6Roller`. Returns `undefined` when no roller was
-   * injected so the resolver's own `defaultD6Roller` (`Math.random`)
-   * remains in effect for single-player / hot-seat callers.
-   *
-   * Per `add-authoritative-roll-arbitration` (Wave 3a): `ServerMatchHost`
-   * always injects a server-authoritative `D6Roller` (crypto-backed in
-   * prod, seeded in `?seed=N` debug mode), so this returns the live
-   * roller in multiplayer. Wrapping it via `RollCapture` further
-   * upstream is what lets the host stamp captured rolls onto event
-   * payloads.
-   */
+  // Resolver-roller adapters live in `InteractiveSession.resolvers`.
   private d6RollerForResolvers(): D6Roller | undefined {
-    return this.d6Roller;
+    return d6RollerForResolvers(this.d6Roller);
   }
 
-  /**
-   * Adapter that lifts the injected `D6Roller` into a `DiceRoller` (a
-   * full 2d6 result). Resolvers like `resolveAllAttacks` /
-   * `resolveHeatPhase` / `resolveAllPhysicalAttacks` consume `DiceRoller`
-   * — this keeps the injection point uniform without refactoring those
-   * resolvers' parameter type. Returns `undefined` to fall back to the
-   * resolver's default when no roller was injected.
-   */
   private diceRollerForResolvers(): DiceRoller | undefined {
-    const d6 = this.d6Roller;
-    if (!d6) return undefined;
-    return () => roll2d6FromD6(d6);
+    return diceRollerForResolvers(this.d6Roller);
   }
 
-  /**
-   * Per `wire-heat-generation-and-effects` task 5 + decisions.md
-   * "Water cooling integration point": `IHex.terrain` is a plain
-   * `string` today. We parse the `water:N` convention so a future
-   * map author can tag a hex as `'water:1'` / `'water:2'` and get
-   * the dissipation bonus immediately; all other terrain strings
-   * (including `'clear'`, `'woods'`, etc.) return depth 0 → no
-   * water cooling contribution. Calling `getWaterCoolingBonus(0)`
-   * yields 0, preserving behaviour for every existing grid.
-   */
+  // Heat-phase water-depth lookup lives in `InteractiveSession.resolvers`.
   private waterDepthAt(position: IHexCoordinate): number {
-    return waterDepthAtPosition(this.grid, position);
+    return waterDepthAt(this.grid, position);
   }
 
   isGameOver(): boolean {

--- a/src/lib/campaign/contractMarket.ts
+++ b/src/lib/campaign/contractMarket.ts
@@ -7,175 +7,81 @@
  *
  * Based on MekHQ AbstractContractMarket.java, simplified for MVP.
  *
+ * The static lookup tables and tuning constants live in
+ * ./contracts/contractMarketConstants, the seeded-randomness primitives in
+ * ./contracts/contractRandomHelpers, and the per-attribute random selectors in
+ * ./contracts/contractSelection. They are re-exported here so the public API
+ * of this module remains unchanged for all existing importers and tests.
+ *
  * @module lib/campaign/contractMarket
  */
 
 import { ICampaign } from '@/types/campaign/Campaign';
-import {
-  AtBContractType,
-  CONTRACT_TYPE_DEFINITIONS,
-  ContractGroup,
-  getContractTypesByGroup,
-  getAvailableContractTypes,
-} from '@/types/campaign/contracts/contractTypes';
+import { CONTRACT_TYPE_DEFINITIONS } from '@/types/campaign/contracts/contractTypes';
 import { MissionStatus } from '@/types/campaign/enums/MissionStatus';
 import { getAllUnits } from '@/types/campaign/Force';
-import { IContract, createContract } from '@/types/campaign/Mission';
+import { IContract } from '@/types/campaign/Mission';
 import { Money } from '@/types/campaign/Money';
-import { createPaymentTerms } from '@/types/campaign/PaymentTerms';
 
 import {
   calculateContractLength,
   contractLengthToDays,
 } from './contracts/contractLength';
+import {
+  CBILLS_PER_BV,
+  PLACEHOLDER_BV_PER_UNIT,
+} from './contracts/contractMarketConstants';
 import { negotiateAllClauses } from './contracts/contractNegotiation';
 import {
-  getContractPayMultiplier,
+  buildContractRecord,
+  buildOutcomePaymentTerms,
+} from './contracts/contractPayment';
+import { defaultRandom, RandomFn } from './contracts/contractRandomHelpers';
+import {
+  generateContractId,
+  generateContractName,
+  generateRandomDuration,
+  generateRandomSalvagePercent,
+  randomContractType,
+  randomEmployer,
+  randomSystem,
+  randomTarget,
+  selectAtBContractType,
+  selectFollowupContractType,
+} from './contracts/contractSelection';
+import {
   getContractNegotiationModifier,
+  getContractPayMultiplier,
 } from './markets/marketStandingIntegration';
 
 // =============================================================================
-// Constants
+// Re-exports - preserve the historical public API of this module
 // =============================================================================
 
-/**
- * Available contract types for random selection.
- */
-export const CONTRACT_TYPES: readonly string[] = Object.freeze([
-  'Garrison Duty',
-  'Recon',
-  'Raid',
-  'Extraction',
-  'Escort',
-]);
-
-/**
- * Available employer factions for random selection.
- */
-export const EMPLOYER_FACTIONS: readonly string[] = Object.freeze([
-  // Inner Sphere Great Houses
-  'Davion',
-  'Steiner',
-  'Liao',
-  'Marik',
-  'Kurita',
-  // Clans
-  'Wolf',
-  'Jade Falcon',
-  'Ghost Bear',
-  // Mercenary
-  'Kell Hounds',
-  "Wolf's Dragoons",
-]);
-
-/**
- * Available star systems for random selection.
- */
-export const SYSTEMS: readonly string[] = Object.freeze([
-  'Hesperus II',
-  'Solaris VII',
-  'Tukayyid',
-  'New Avalon',
-  'Tharkad',
-  'Sian',
-  'Atreus',
-  'Luthien',
-  'Terra',
-  'Outreach',
-  'Galatea',
-  'Arc-Royal',
-  'Coventry',
-  'Tikonov',
-  'Strana Mechty',
-]);
-
-/**
- * Placeholder BV per unit (until real BV calculator is integrated).
- */
-export const PLACEHOLDER_BV_PER_UNIT = 1000;
-
-/**
- * Payment rate: C-bills per BV point.
- */
-export const CBILLS_PER_BV = 1000;
-
-/**
- * Payment multipliers for contract outcomes.
- */
-export const PAYMENT_MULTIPLIERS = Object.freeze({
-  success: 2.0,
-  partial: 1.5,
-  failure: 0.5,
-});
-
-/**
- * Duration range in days.
- */
-export const DURATION_MIN_DAYS = 30;
-export const DURATION_MAX_DAYS = 90;
-
-/**
- * Salvage percentage range.
- */
-export const SALVAGE_MIN_PERCENT = 40;
-export const SALVAGE_MAX_PERCENT = 60;
-
-/**
- * Weights for contract group selection.
- * Garrison is most common, guerrilla is rarest.
- */
-export const CONTRACT_GROUP_WEIGHTS: Record<ContractGroup, number> = {
-  garrison: 40,
-  raid: 30,
-  guerrilla: 10,
-  special: 20,
-};
-
-// =============================================================================
-// Random Helpers (seeded for testability)
-// =============================================================================
-
-/**
- * Random number generator function type.
- * Returns a number in [0, 1) like Math.random().
- */
-export type RandomFn = () => number;
-
-/**
- * Default random function using Math.random().
- */
-const defaultRandom: RandomFn = () => Math.random();
-
-/**
- * Pick a random element from an array.
- *
- * @param array - Array to pick from
- * @param random - Random function (default: Math.random)
- * @returns Random element from the array
- */
-function pickRandom<T>(
-  array: readonly T[],
-  random: RandomFn = defaultRandom,
-): T {
-  const index = Math.floor(random() * array.length);
-  return array[index];
-}
-
-/**
- * Generate a random integer in [min, max] inclusive.
- *
- * @param min - Minimum value (inclusive)
- * @param max - Maximum value (inclusive)
- * @param random - Random function (default: Math.random)
- * @returns Random integer in range
- */
-function randomInt(
-  min: number,
-  max: number,
-  random: RandomFn = defaultRandom,
-): number {
-  return Math.floor(random() * (max - min + 1)) + min;
-}
+export {
+  CBILLS_PER_BV,
+  CONTRACT_GROUP_WEIGHTS,
+  CONTRACT_TYPES,
+  DURATION_MAX_DAYS,
+  DURATION_MIN_DAYS,
+  EMPLOYER_FACTIONS,
+  PAYMENT_MULTIPLIERS,
+  PLACEHOLDER_BV_PER_UNIT,
+  SALVAGE_MAX_PERCENT,
+  SALVAGE_MIN_PERCENT,
+  SYSTEMS,
+} from './contracts/contractMarketConstants';
+export type { RandomFn } from './contracts/contractRandomHelpers';
+export {
+  generateContractName,
+  generateRandomDuration,
+  generateRandomSalvagePercent,
+  randomContractType,
+  randomEmployer,
+  randomSystem,
+  randomTarget,
+  selectAtBContractType,
+} from './contracts/contractSelection';
 
 // =============================================================================
 // Core Functions
@@ -200,138 +106,6 @@ export function calculateForceBV(campaign: ICampaign): number {
 
   const allUnitIds = getAllUnits(rootForce, campaign.forces);
   return allUnitIds.length * PLACEHOLDER_BV_PER_UNIT;
-}
-
-/**
- * Generate a contract name from type and employer.
- *
- * @param type - Contract type (e.g., "Garrison Duty")
- * @param employer - Employer faction name (e.g., "Davion")
- * @returns Contract name (e.g., "Garrison Duty for House Davion")
- */
-export function generateContractName(type: string, employer: string): string {
-  // Clans and mercenary units don't use "House" prefix
-  const clanFactions = ['Wolf', 'Jade Falcon', 'Ghost Bear'];
-  const mercFactions = ['Kell Hounds', "Wolf's Dragoons"];
-
-  if (clanFactions.includes(employer)) {
-    return `${type} for Clan ${employer}`;
-  }
-  if (mercFactions.includes(employer)) {
-    return `${type} for ${employer}`;
-  }
-  return `${type} for House ${employer}`;
-}
-
-/**
- * Generate a random contract duration in days.
- *
- * @param random - Random function (default: Math.random)
- * @returns Duration in days (30-90)
- */
-export function generateRandomDuration(
-  random: RandomFn = defaultRandom,
-): number {
-  return randomInt(DURATION_MIN_DAYS, DURATION_MAX_DAYS, random);
-}
-
-/**
- * Generate a random salvage percentage.
- *
- * @param random - Random function (default: Math.random)
- * @returns Salvage percentage (40-60)
- */
-export function generateRandomSalvagePercent(
-  random: RandomFn = defaultRandom,
-): number {
-  return randomInt(SALVAGE_MIN_PERCENT, SALVAGE_MAX_PERCENT, random);
-}
-
-/**
- * Select a random contract type.
- *
- * @param random - Random function (default: Math.random)
- * @returns Random contract type string
- */
-export function randomContractType(random: RandomFn = defaultRandom): string {
-  return pickRandom(CONTRACT_TYPES, random);
-}
-
-/**
- * Select a random employer faction.
- *
- * @param random - Random function (default: Math.random)
- * @returns Random employer faction name
- */
-export function randomEmployer(random: RandomFn = defaultRandom): string {
-  return pickRandom(EMPLOYER_FACTIONS, random);
-}
-
-/**
- * Select a random target faction different from the employer.
- *
- * @param employer - Employer faction to exclude
- * @param random - Random function (default: Math.random)
- * @returns Random target faction name (different from employer)
- */
-export function randomTarget(
-  employer: string,
-  random: RandomFn = defaultRandom,
-): string {
-  const targets = EMPLOYER_FACTIONS.filter((f) => f !== employer);
-  return pickRandom(targets, random);
-}
-
-/**
- * Select a random star system.
- *
- * @param random - Random function (default: Math.random)
- * @returns Random system name
- */
-export function randomSystem(random: RandomFn = defaultRandom): string {
-  return pickRandom(SYSTEMS, random);
-}
-
-/**
- * Select a random AtB contract type using group weights.
- * First selects a group weighted by CONTRACT_GROUP_WEIGHTS,
- * then uniformly selects a type within that group.
- *
- * @param random - Random function (default: Math.random)
- * @returns Random AtB contract type
- */
-export function selectAtBContractType(
-  random: RandomFn = defaultRandom,
-): AtBContractType {
-  const groups = Object.keys(CONTRACT_GROUP_WEIGHTS) as ContractGroup[];
-  const totalWeight = Object.values(CONTRACT_GROUP_WEIGHTS).reduce(
-    (a, b) => a + b,
-    0,
-  );
-
-  let roll = random() * totalWeight;
-  let selectedGroup: ContractGroup = 'garrison';
-  for (const group of groups) {
-    roll -= CONTRACT_GROUP_WEIGHTS[group];
-    if (roll <= 0) {
-      selectedGroup = group;
-      break;
-    }
-  }
-
-  const typesInGroup = getContractTypesByGroup(selectedGroup);
-  return pickRandom(typesInGroup, random);
-}
-
-/**
- * Generate a unique contract ID.
- *
- * @returns Unique contract ID string
- */
-function generateContractId(): string {
-  const timestamp = Date.now();
-  const random = Math.random().toString(36).substring(2, 9);
-  return `contract-${timestamp}-${random}`;
 }
 
 /**
@@ -370,29 +144,17 @@ export function generateContracts(
     const salvagePercent = generateRandomSalvagePercent(random);
 
     const basePayment = new Money(forceBV * CBILLS_PER_BV);
-    const paymentTerms = createPaymentTerms({
-      basePayment,
-      successPayment: basePayment.multiply(PAYMENT_MULTIPLIERS.success),
-      partialPayment: basePayment.multiply(PAYMENT_MULTIPLIERS.partial),
-      failurePayment: basePayment.multiply(PAYMENT_MULTIPLIERS.failure),
-      salvagePercent,
-    });
+    const paymentTerms = buildOutcomePaymentTerms(basePayment, salvagePercent);
 
-    const startDate = campaign.currentDate;
-    const endDate = new Date(
-      startDate.getTime() + duration * 24 * 60 * 60 * 1000,
-    );
-
-    const contract = createContract({
+    const contract = buildContractRecord({
       id: generateContractId(),
       name: generateContractName(type, employer),
-      status: MissionStatus.PENDING,
-      systemId: system,
-      employerId: employer,
-      targetId: target,
+      system,
+      employer,
+      target,
       paymentTerms,
-      startDate: startDate.toISOString(),
-      endDate: endDate.toISOString(),
+      startDate: campaign.currentDate,
+      durationDays: duration,
     });
 
     contracts.push(contract);
@@ -448,29 +210,17 @@ export function generateAtBContracts(
     );
     const salvagePercent = generateRandomSalvagePercent(random);
 
-    const paymentTerms = createPaymentTerms({
-      basePayment,
-      successPayment: basePayment.multiply(PAYMENT_MULTIPLIERS.success),
-      partialPayment: basePayment.multiply(PAYMENT_MULTIPLIERS.partial),
-      failurePayment: basePayment.multiply(PAYMENT_MULTIPLIERS.failure),
-      salvagePercent,
-    });
+    const paymentTerms = buildOutcomePaymentTerms(basePayment, salvagePercent);
 
-    const startDate = campaign.currentDate;
-    const endDate = new Date(
-      startDate.getTime() + durationDays * 24 * 60 * 60 * 1000,
-    );
-
-    const contract = createContract({
+    const contract = buildContractRecord({
       id: generateContractId(),
       name: generateContractName(typeDef.name, employer),
-      status: MissionStatus.PENDING,
-      systemId: system,
-      employerId: employer,
-      targetId: target,
+      system,
+      employer,
+      target,
       paymentTerms,
-      startDate: startDate.toISOString(),
-      endDate: endDate.toISOString(),
+      startDate: campaign.currentDate,
+      durationDays,
     });
 
     // Add AtB-specific fields
@@ -554,49 +304,17 @@ export function generateFollowupContract(
   const _forceBV = calculateForceBV(campaign);
 
   // Determine contract type - different from the completed one
-  let typeName: string;
-  let atbType: AtBContractType | undefined;
-
-  if (completedContract.atbContractType) {
-    // AtB contract: pick a different type from the same group
-    const completedDef =
-      CONTRACT_TYPE_DEFINITIONS[completedContract.atbContractType];
-    const groupTypes = getContractTypesByGroup(completedDef.group);
-    const otherTypes = groupTypes.filter(
-      (t) => t !== completedContract.atbContractType,
-    );
-
-    if (otherTypes.length > 0) {
-      atbType = pickRandom(otherTypes, random);
-    } else {
-      // Only one type in group, pick any different AtB type
-      const allTypes = getAvailableContractTypes().filter(
-        (t) => t !== completedContract.atbContractType,
-      );
-      atbType = pickRandom(allTypes, random);
-    }
-    typeName = CONTRACT_TYPE_DEFINITIONS[atbType].name;
-  } else {
-    // Legacy contract: pick a different legacy type
-    const completedType = CONTRACT_TYPES.find((t) =>
-      completedContract.name.includes(t),
-    );
-    const otherTypes = CONTRACT_TYPES.filter((t) => t !== completedType);
-    typeName = pickRandom(otherTypes, random);
-  }
+  const { typeName, atbType } = selectFollowupContractType(
+    completedContract,
+    random,
+  );
 
   // Scale payment up by 10%
   const baseAmount = completedContract.paymentTerms.basePayment.amount;
   const scaledPayment = new Money(Math.round(baseAmount * 1.1 * 100) / 100);
 
   const salvagePercent = generateRandomSalvagePercent(random);
-  const paymentTerms = createPaymentTerms({
-    basePayment: scaledPayment,
-    successPayment: scaledPayment.multiply(PAYMENT_MULTIPLIERS.success),
-    partialPayment: scaledPayment.multiply(PAYMENT_MULTIPLIERS.partial),
-    failurePayment: scaledPayment.multiply(PAYMENT_MULTIPLIERS.failure),
-    salvagePercent,
-  });
+  const paymentTerms = buildOutcomePaymentTerms(scaledPayment, salvagePercent);
 
   // Duration: use AtB length if applicable, otherwise legacy random
   let durationDays: number;
@@ -607,21 +325,15 @@ export function generateFollowupContract(
     durationDays = generateRandomDuration(random);
   }
 
-  const startDate = campaign.currentDate;
-  const endDate = new Date(
-    startDate.getTime() + durationDays * 24 * 60 * 60 * 1000,
-  );
-
-  const contract = createContract({
+  const contract = buildContractRecord({
     id: generateContractId(),
     name: generateContractName(typeName, employer),
-    status: MissionStatus.PENDING,
-    systemId: system,
-    employerId: employer,
-    targetId: target,
+    system,
+    employer,
+    target,
     paymentTerms,
-    startDate: startDate.toISOString(),
-    endDate: endDate.toISOString(),
+    startDate: campaign.currentDate,
+    durationDays,
   });
 
   if (atbType) {
@@ -666,13 +378,10 @@ export function generateContractsWithStanding(
   return contracts.map((contract) => {
     const scaledBase =
       contract.paymentTerms.basePayment.multiply(payMultiplier);
-    const scaledTerms = createPaymentTerms({
-      basePayment: scaledBase,
-      successPayment: scaledBase.multiply(PAYMENT_MULTIPLIERS.success),
-      partialPayment: scaledBase.multiply(PAYMENT_MULTIPLIERS.partial),
-      failurePayment: scaledBase.multiply(PAYMENT_MULTIPLIERS.failure),
-      salvagePercent: contract.paymentTerms.salvagePercent,
-    });
+    const scaledTerms = buildOutcomePaymentTerms(
+      scaledBase,
+      contract.paymentTerms.salvagePercent,
+    );
 
     return {
       ...contract,

--- a/src/lib/campaign/contractProcessing.ts
+++ b/src/lib/campaign/contractProcessing.ts
@@ -1,0 +1,63 @@
+/**
+ * Contract Processing - Contract-expiration phase of day advancement
+ *
+ * Extracted from `dayAdvancement.ts` (decompose refactor). Contains the
+ * standalone `processContracts` phase used by the legacy `advanceDay`
+ * path, by the registry `contractProcessor`, and by direct unit tests.
+ *
+ * Behavior is identical to the pre-refactor implementation — this module
+ * is a pure cut/paste of the contract phase with no logic change.
+ *
+ * @module lib/campaign/contractProcessing
+ */
+
+import { ICampaign } from '@/types/campaign/Campaign';
+import { MissionStatus } from '@/types/campaign/enums/MissionStatus';
+import { IContract, isContract, IMission } from '@/types/campaign/Mission';
+
+import { ExpiredContractEvent } from './dayReportTypes';
+
+/**
+ * Process contract expiration for the campaign.
+ *
+ * Checks all active contracts against the current date.
+ * If a contract's endDate has passed, it is marked as completed (SUCCESS).
+ *
+ * @param campaign - The campaign to process
+ * @returns Updated missions map and expiration events
+ */
+export function processContracts(campaign: ICampaign): {
+  missions: Map<string, IMission>;
+  events: ExpiredContractEvent[];
+} {
+  const updatedMissions = new Map(campaign.missions);
+  const events: ExpiredContractEvent[] = [];
+  const currentDate = campaign.currentDate;
+
+  Array.from(campaign.missions.entries()).forEach(([id, mission]) => {
+    // Only process active contracts with end dates
+    if (!isContract(mission)) return;
+    if (mission.status !== MissionStatus.ACTIVE) return;
+    if (!mission.endDate) return;
+
+    const endDate = new Date(mission.endDate);
+    if (currentDate >= endDate) {
+      const updatedContract: IContract = {
+        ...mission,
+        status: MissionStatus.SUCCESS,
+        updatedAt: new Date().toISOString(),
+      };
+
+      updatedMissions.set(id, updatedContract);
+
+      events.push({
+        contractId: id,
+        contractName: mission.name,
+        previousStatus: mission.status,
+        newStatus: MissionStatus.SUCCESS,
+      });
+    }
+  });
+
+  return { missions: updatedMissions, events };
+}

--- a/src/lib/campaign/contracts/contractMarketConstants.ts
+++ b/src/lib/campaign/contracts/contractMarketConstants.ts
@@ -1,0 +1,105 @@
+/**
+ * Contract Market Constants - Static data for contract generation
+ *
+ * Holds the frozen lookup tables (contract types, employers, systems) and the
+ * numeric tuning constants (payment rates, duration/salvage ranges, group
+ * weights) used across the contract market. Extracted from contractMarket.ts
+ * so the generation logic stays small and these magic numbers live in one place.
+ *
+ * @module lib/campaign/contracts/contractMarketConstants
+ */
+
+import { ContractGroup } from '@/types/campaign/contracts/contractTypes';
+
+/**
+ * Available contract types for random selection.
+ */
+export const CONTRACT_TYPES: readonly string[] = Object.freeze([
+  'Garrison Duty',
+  'Recon',
+  'Raid',
+  'Extraction',
+  'Escort',
+]);
+
+/**
+ * Available employer factions for random selection.
+ */
+export const EMPLOYER_FACTIONS: readonly string[] = Object.freeze([
+  // Inner Sphere Great Houses
+  'Davion',
+  'Steiner',
+  'Liao',
+  'Marik',
+  'Kurita',
+  // Clans
+  'Wolf',
+  'Jade Falcon',
+  'Ghost Bear',
+  // Mercenary
+  'Kell Hounds',
+  "Wolf's Dragoons",
+]);
+
+/**
+ * Available star systems for random selection.
+ */
+export const SYSTEMS: readonly string[] = Object.freeze([
+  'Hesperus II',
+  'Solaris VII',
+  'Tukayyid',
+  'New Avalon',
+  'Tharkad',
+  'Sian',
+  'Atreus',
+  'Luthien',
+  'Terra',
+  'Outreach',
+  'Galatea',
+  'Arc-Royal',
+  'Coventry',
+  'Tikonov',
+  'Strana Mechty',
+]);
+
+/**
+ * Placeholder BV per unit (until real BV calculator is integrated).
+ */
+export const PLACEHOLDER_BV_PER_UNIT = 1000;
+
+/**
+ * Payment rate: C-bills per BV point.
+ */
+export const CBILLS_PER_BV = 1000;
+
+/**
+ * Payment multipliers for contract outcomes.
+ */
+export const PAYMENT_MULTIPLIERS = Object.freeze({
+  success: 2.0,
+  partial: 1.5,
+  failure: 0.5,
+});
+
+/**
+ * Duration range in days.
+ */
+export const DURATION_MIN_DAYS = 30;
+export const DURATION_MAX_DAYS = 90;
+
+/**
+ * Salvage percentage range.
+ */
+export const SALVAGE_MIN_PERCENT = 40;
+export const SALVAGE_MAX_PERCENT = 60;
+
+/**
+ * Weights for contract group selection.
+ * Garrison is most common, guerrilla is rarest.
+ */
+export const CONTRACT_GROUP_WEIGHTS: Record<ContractGroup, number> = {
+  garrison: 40,
+  raid: 30,
+  guerrilla: 10,
+  special: 20,
+};

--- a/src/lib/campaign/contracts/contractPayment.ts
+++ b/src/lib/campaign/contracts/contractPayment.ts
@@ -1,0 +1,101 @@
+/**
+ * Contract Payment - Payment-terms and contract-record assembly helpers
+ *
+ * Provides the two pieces of construction logic that every contract generator
+ * shared verbatim: deriving outcome payment terms from a base payment via the
+ * success/partial/failure multipliers, and assembling an IContract from its
+ * resolved attributes plus campaign-relative start/end dates. Extracted from
+ * contractMarket.ts to remove four-way / three-way duplication while keeping
+ * the exact same arithmetic and field shape.
+ *
+ * @module lib/campaign/contracts/contractPayment
+ */
+
+import { MissionStatus } from '@/types/campaign/enums/MissionStatus';
+import { IContract, createContract } from '@/types/campaign/Mission';
+import { Money } from '@/types/campaign/Money';
+import {
+  IPaymentTerms,
+  createPaymentTerms,
+} from '@/types/campaign/PaymentTerms';
+
+import { PAYMENT_MULTIPLIERS } from './contractMarketConstants';
+
+/**
+ * Number of milliseconds in one day, used to offset a contract's end date.
+ */
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Build outcome payment terms from a base payment.
+ *
+ * Applies the success/partial/failure multipliers to the base payment so every
+ * generator derives outcome payments identically instead of repeating the
+ * four multiply calls inline.
+ *
+ * @param basePayment - Base contract payment
+ * @param salvagePercent - Salvage percentage for the contract (40-60)
+ * @returns Payment terms with all four outcome payments populated
+ */
+export function buildOutcomePaymentTerms(
+  basePayment: Money,
+  salvagePercent: number,
+): IPaymentTerms {
+  return createPaymentTerms({
+    basePayment,
+    successPayment: basePayment.multiply(PAYMENT_MULTIPLIERS.success),
+    partialPayment: basePayment.multiply(PAYMENT_MULTIPLIERS.partial),
+    failurePayment: basePayment.multiply(PAYMENT_MULTIPLIERS.failure),
+    salvagePercent,
+  });
+}
+
+/**
+ * Attributes needed to assemble a pending contract record.
+ */
+export interface ContractRecordInput {
+  /** Unique contract ID. */
+  id: string;
+  /** Display name of the contract. */
+  name: string;
+  /** Star system the contract takes place in. */
+  system: string;
+  /** Employer faction ID. */
+  employer: string;
+  /** Target faction ID. */
+  target: string;
+  /** Resolved payment terms. */
+  paymentTerms: IPaymentTerms;
+  /** Campaign current date used as the contract start date. */
+  startDate: Date;
+  /** Contract duration in days, used to derive the end date. */
+  durationDays: number;
+}
+
+/**
+ * Assemble a pending IContract from resolved attributes.
+ *
+ * Centralises the createContract call and the start/end date math so the three
+ * contract generators no longer repeat the identical record shape and the
+ * day-offset arithmetic.
+ *
+ * @param input - Resolved contract attributes
+ * @returns A new pending contract
+ */
+export function buildContractRecord(input: ContractRecordInput): IContract {
+  const endDate = new Date(
+    input.startDate.getTime() + input.durationDays * MS_PER_DAY,
+  );
+
+  return createContract({
+    id: input.id,
+    name: input.name,
+    status: MissionStatus.PENDING,
+    systemId: input.system,
+    employerId: input.employer,
+    targetId: input.target,
+    paymentTerms: input.paymentTerms,
+    startDate: input.startDate.toISOString(),
+    endDate: endDate.toISOString(),
+  });
+}

--- a/src/lib/campaign/contracts/contractRandomHelpers.ts
+++ b/src/lib/campaign/contracts/contractRandomHelpers.ts
@@ -1,0 +1,60 @@
+/**
+ * Contract Random Helpers - Seeded randomness primitives
+ *
+ * Provides the low-level random utilities (array picking, integer ranges) and
+ * the injectable RandomFn type used throughout contract generation. Extracted
+ * from contractMarket.ts so both the main module and its sibling selection
+ * module can share one seeded-randomness implementation for testability.
+ *
+ * @module lib/campaign/contracts/contractRandomHelpers
+ */
+
+/**
+ * Random number generator function type.
+ * Returns a number in [0, 1) like Math.random().
+ */
+export type RandomFn = () => number;
+
+/**
+ * Default random function using Math.random().
+ *
+ * Used as the fallback when a caller does not inject a seeded RandomFn.
+ */
+export const defaultRandom: RandomFn = () => Math.random();
+
+/**
+ * Pick a random element from an array.
+ *
+ * Centralised here so every random selection in the contract market uses the
+ * same index math and the same injectable RandomFn.
+ *
+ * @param array - Array to pick from
+ * @param random - Random function (default: Math.random)
+ * @returns Random element from the array
+ */
+export function pickRandom<T>(
+  array: readonly T[],
+  random: RandomFn = defaultRandom,
+): T {
+  const index = Math.floor(random() * array.length);
+  return array[index];
+}
+
+/**
+ * Generate a random integer in [min, max] inclusive.
+ *
+ * Centralised here so duration and salvage ranges use one inclusive-range
+ * implementation and remain deterministic under a seeded RandomFn.
+ *
+ * @param min - Minimum value (inclusive)
+ * @param max - Maximum value (inclusive)
+ * @param random - Random function (default: Math.random)
+ * @returns Random integer in range
+ */
+export function randomInt(
+  min: number,
+  max: number,
+  random: RandomFn = defaultRandom,
+): number {
+  return Math.floor(random() * (max - min + 1)) + min;
+}

--- a/src/lib/campaign/contracts/contractSelection.ts
+++ b/src/lib/campaign/contracts/contractSelection.ts
@@ -1,0 +1,239 @@
+/**
+ * Contract Selection - Random attribute selection for contract generation
+ *
+ * Provides the pure selection functions that pick a contract's type, employer,
+ * target, system, duration, salvage percentage, name, and ID. Extracted from
+ * contractMarket.ts so the main module focuses on assembling IContract objects
+ * while these reusable, individually testable pickers live together.
+ *
+ * @module lib/campaign/contracts/contractSelection
+ */
+
+import {
+  AtBContractType,
+  CONTRACT_TYPE_DEFINITIONS,
+  ContractGroup,
+  getAvailableContractTypes,
+  getContractTypesByGroup,
+} from '@/types/campaign/contracts/contractTypes';
+import { IContract } from '@/types/campaign/Mission';
+
+import {
+  CONTRACT_GROUP_WEIGHTS,
+  CONTRACT_TYPES,
+  DURATION_MAX_DAYS,
+  DURATION_MIN_DAYS,
+  EMPLOYER_FACTIONS,
+  SALVAGE_MAX_PERCENT,
+  SALVAGE_MIN_PERCENT,
+  SYSTEMS,
+} from './contractMarketConstants';
+import {
+  defaultRandom,
+  pickRandom,
+  randomInt,
+  RandomFn,
+} from './contractRandomHelpers';
+
+/**
+ * Generate a contract name from type and employer.
+ *
+ * Clans and mercenary units do not take a "House" prefix, so the faction is
+ * classified before formatting to keep generated names lore-accurate.
+ *
+ * @param type - Contract type (e.g., "Garrison Duty")
+ * @param employer - Employer faction name (e.g., "Davion")
+ * @returns Contract name (e.g., "Garrison Duty for House Davion")
+ */
+export function generateContractName(type: string, employer: string): string {
+  // Clans and mercenary units don't use "House" prefix
+  const clanFactions = ['Wolf', 'Jade Falcon', 'Ghost Bear'];
+  const mercFactions = ['Kell Hounds', "Wolf's Dragoons"];
+
+  if (clanFactions.includes(employer)) {
+    return `${type} for Clan ${employer}`;
+  }
+  if (mercFactions.includes(employer)) {
+    return `${type} for ${employer}`;
+  }
+  return `${type} for House ${employer}`;
+}
+
+/**
+ * Generate a unique contract ID.
+ *
+ * Combines a timestamp with a short random suffix so concurrently generated
+ * contracts in the same millisecond still get distinct IDs.
+ *
+ * @returns Unique contract ID string
+ */
+export function generateContractId(): string {
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).substring(2, 9);
+  return `contract-${timestamp}-${random}`;
+}
+
+/**
+ * Generate a random contract duration in days.
+ *
+ * @param random - Random function (default: Math.random)
+ * @returns Duration in days (30-90)
+ */
+export function generateRandomDuration(
+  random: RandomFn = defaultRandom,
+): number {
+  return randomInt(DURATION_MIN_DAYS, DURATION_MAX_DAYS, random);
+}
+
+/**
+ * Generate a random salvage percentage.
+ *
+ * @param random - Random function (default: Math.random)
+ * @returns Salvage percentage (40-60)
+ */
+export function generateRandomSalvagePercent(
+  random: RandomFn = defaultRandom,
+): number {
+  return randomInt(SALVAGE_MIN_PERCENT, SALVAGE_MAX_PERCENT, random);
+}
+
+/**
+ * Select a random contract type.
+ *
+ * @param random - Random function (default: Math.random)
+ * @returns Random contract type string
+ */
+export function randomContractType(random: RandomFn = defaultRandom): string {
+  return pickRandom(CONTRACT_TYPES, random);
+}
+
+/**
+ * Select a random employer faction.
+ *
+ * @param random - Random function (default: Math.random)
+ * @returns Random employer faction name
+ */
+export function randomEmployer(random: RandomFn = defaultRandom): string {
+  return pickRandom(EMPLOYER_FACTIONS, random);
+}
+
+/**
+ * Select a random target faction different from the employer.
+ *
+ * The employer is filtered out first so a faction is never contracted to
+ * attack itself.
+ *
+ * @param employer - Employer faction to exclude
+ * @param random - Random function (default: Math.random)
+ * @returns Random target faction name (different from employer)
+ */
+export function randomTarget(
+  employer: string,
+  random: RandomFn = defaultRandom,
+): string {
+  const targets = EMPLOYER_FACTIONS.filter((f) => f !== employer);
+  return pickRandom(targets, random);
+}
+
+/**
+ * Select a random star system.
+ *
+ * @param random - Random function (default: Math.random)
+ * @returns Random system name
+ */
+export function randomSystem(random: RandomFn = defaultRandom): string {
+  return pickRandom(SYSTEMS, random);
+}
+
+/**
+ * Select a random AtB contract type using group weights.
+ *
+ * First selects a group weighted by CONTRACT_GROUP_WEIGHTS, then uniformly
+ * selects a type within that group. The two-stage roll keeps common garrison
+ * work frequent and guerrilla work rare without per-type weights.
+ *
+ * @param random - Random function (default: Math.random)
+ * @returns Random AtB contract type
+ */
+export function selectAtBContractType(
+  random: RandomFn = defaultRandom,
+): AtBContractType {
+  const groups = Object.keys(CONTRACT_GROUP_WEIGHTS) as ContractGroup[];
+  const totalWeight = Object.values(CONTRACT_GROUP_WEIGHTS).reduce(
+    (a, b) => a + b,
+    0,
+  );
+
+  let roll = random() * totalWeight;
+  let selectedGroup: ContractGroup = 'garrison';
+  for (const group of groups) {
+    roll -= CONTRACT_GROUP_WEIGHTS[group];
+    if (roll <= 0) {
+      selectedGroup = group;
+      break;
+    }
+  }
+
+  const typesInGroup = getContractTypesByGroup(selectedGroup);
+  return pickRandom(typesInGroup, random);
+}
+
+/**
+ * A contract type chosen for a followup contract.
+ *
+ * `atbType` is set only when the completed contract was an AtB contract;
+ * `typeName` is always the human-readable name used to build the new contract.
+ */
+export interface FollowupTypeSelection {
+  /** Display name of the selected followup contract type. */
+  typeName: string;
+  /** AtB contract type, present only when the source contract was AtB. */
+  atbType: AtBContractType | undefined;
+}
+
+/**
+ * Select a contract type for a followup, distinct from the completed contract.
+ *
+ * For AtB contracts it prefers a different type in the same group and only
+ * falls back to any other AtB type when the group has a single member; for
+ * legacy contracts it picks a different legacy type. Extracted from
+ * generateFollowupContract so the type-distinctness rules live with the other
+ * selection logic and the generator stays focused on assembly.
+ *
+ * @param completedContract - The contract that was just completed
+ * @param random - Random function (default: Math.random)
+ * @returns The selected followup type name and optional AtB type
+ */
+export function selectFollowupContractType(
+  completedContract: IContract,
+  random: RandomFn = defaultRandom,
+): FollowupTypeSelection {
+  if (completedContract.atbContractType) {
+    // AtB contract: pick a different type from the same group
+    const completedDef =
+      CONTRACT_TYPE_DEFINITIONS[completedContract.atbContractType];
+    const groupTypes = getContractTypesByGroup(completedDef.group);
+    const otherTypes = groupTypes.filter(
+      (t) => t !== completedContract.atbContractType,
+    );
+
+    let atbType: AtBContractType;
+    if (otherTypes.length > 0) {
+      atbType = pickRandom(otherTypes, random);
+    } else {
+      // Only one type in group, pick any different AtB type
+      const allTypes = getAvailableContractTypes().filter(
+        (t) => t !== completedContract.atbContractType,
+      );
+      atbType = pickRandom(allTypes, random);
+    }
+    return { typeName: CONTRACT_TYPE_DEFINITIONS[atbType].name, atbType };
+  }
+
+  // Legacy contract: pick a different legacy type
+  const completedType = CONTRACT_TYPES.find((t) =>
+    completedContract.name.includes(t),
+  );
+  const otherTypes = CONTRACT_TYPES.filter((t) => t !== completedType);
+  return { typeName: pickRandom(otherTypes, random), atbType: undefined };
+}

--- a/src/lib/campaign/dailyCostsProcessing.ts
+++ b/src/lib/campaign/dailyCostsProcessing.ts
@@ -1,0 +1,118 @@
+/**
+ * Daily Costs Processing - Finance phase of day advancement
+ *
+ * Extracted from `dayAdvancement.ts` (decompose refactor). Contains the
+ * standalone `processDailyCosts` phase used by the legacy `advanceDay`
+ * path, by the registry `dailyCostsProcessor`, and by direct unit tests.
+ *
+ * Behavior is identical to the pre-refactor implementation — this module
+ * is a pure cut/paste of the daily-costs phase with no logic change.
+ *
+ * @module lib/campaign/dailyCostsProcessing
+ */
+
+import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
+import { ICampaign } from '@/types/campaign/Campaign';
+import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
+import { TransactionType } from '@/types/campaign/enums/TransactionType';
+import { getAllUnits } from '@/types/campaign/Force';
+import { Money } from '@/types/campaign/Money';
+import { Transaction } from '@/types/campaign/Transaction';
+
+import {
+  DailyCostBreakdown,
+  DEFAULT_DAILY_MAINTENANCE,
+  DEFAULT_DAILY_SALARY,
+} from './dayReportTypes';
+
+/**
+ * Process daily costs for the campaign.
+ *
+ * Calculates:
+ * - Salary: DEFAULT_DAILY_SALARY * salaryMultiplier per active person
+ * - Maintenance: DEFAULT_DAILY_MAINTENANCE * maintenanceCostMultiplier per unit
+ *
+ * Deducts from campaign balance and records transactions.
+ *
+ * @param campaign - The campaign to process
+ * @returns Updated finances and cost breakdown
+ */
+export function processDailyCosts(campaign: ICampaign): {
+  finances: { transactions: Transaction[]; balance: Money };
+  costs: DailyCostBreakdown;
+} {
+  const { options } = campaign;
+  const newTransactions: Transaction[] = [...campaign.finances.transactions];
+  let currentBalance = campaign.finances.balance;
+
+  // Count billable personnel for salary — read from roster store
+  // (canonical source per PR4 of `wire-iperson-hard-cutover`).
+  // CampaignPilotStatus.KIA is the only non-billable terminal status; Active,
+  // Wounded, Critical, and MIA all still draw salary.
+  const rosterEntries = useCampaignRosterStore.getState().pilots;
+  const personnelCount = rosterEntries.filter(
+    (e) => e.status !== CampaignPilotStatus.KIA,
+  ).length;
+
+  // Calculate salary costs
+  let salaries = Money.ZERO;
+  if (options.payForSalaries && personnelCount > 0) {
+    const dailySalaryPerPerson = new Money(
+      DEFAULT_DAILY_SALARY * options.salaryMultiplier,
+    );
+    salaries = dailySalaryPerPerson.multiply(personnelCount);
+
+    newTransactions.push({
+      id: `tx-salary-${campaign.currentDate.toISOString()}`,
+      type: TransactionType.Expense,
+      amount: salaries,
+      date: campaign.currentDate,
+      description: `Daily salaries for ${personnelCount} personnel`,
+    });
+
+    currentBalance = currentBalance.subtract(salaries);
+  }
+
+  // Count units for maintenance
+  let unitCount = 0;
+  const rootForce = campaign.forces.get(campaign.rootForceId);
+  if (rootForce) {
+    const allUnitIds = getAllUnits(rootForce, campaign.forces);
+    unitCount = allUnitIds.length;
+  }
+
+  // Calculate maintenance costs
+  let maintenance = Money.ZERO;
+  if (options.payForMaintenance && unitCount > 0) {
+    const dailyMaintenancePerUnit = new Money(
+      DEFAULT_DAILY_MAINTENANCE * options.maintenanceCostMultiplier,
+    );
+    maintenance = dailyMaintenancePerUnit.multiply(unitCount);
+
+    newTransactions.push({
+      id: `tx-maintenance-${campaign.currentDate.toISOString()}`,
+      type: TransactionType.Maintenance,
+      amount: maintenance,
+      date: campaign.currentDate,
+      description: `Daily maintenance for ${unitCount} units`,
+    });
+
+    currentBalance = currentBalance.subtract(maintenance);
+  }
+
+  const total = salaries.add(maintenance);
+
+  return {
+    finances: {
+      transactions: newTransactions,
+      balance: currentBalance,
+    },
+    costs: {
+      salaries,
+      maintenance,
+      total,
+      personnelCount,
+      unitCount,
+    },
+  };
+}

--- a/src/lib/campaign/dayAdvancement.ts
+++ b/src/lib/campaign/dayAdvancement.ts
@@ -10,6 +10,18 @@
  *
  * Based on MekHQ's daily advancement loop, simplified for MVP.
  *
+ * # Module layout (decompose refactor)
+ *
+ * This file is now a thin pipeline coordinator. The individual phase
+ * implementations live in co-located sibling modules and are re-exported
+ * here so that the public API of `dayAdvancement.ts` is unchanged for all
+ * existing importers/tests:
+ *
+ *   - `dayReportTypes.ts`       — report/event interfaces + cost constants
+ *   - `healingProcessing.ts`    — `processHealing` (personnel phase)
+ *   - `contractProcessing.ts`   — `processContracts` (missions phase)
+ *   - `dailyCostsProcessing.ts` — `processDailyCosts` (finance phase)
+ *
  * @module lib/campaign/dayAdvancement
  *
  * # Pipeline Order (Wave 5 / `wire-encounter-to-campaign-round-trip`)
@@ -89,380 +101,46 @@
  * is consistent with the `turnoverProcessor` pattern proven in PR2.
  */
 
-import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
-import type { IPilot } from '@/types/pilot/PilotInterfaces';
-
 import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
 import { ICampaign } from '@/types/campaign/Campaign';
-import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
-import { MissionStatus } from '@/types/campaign/enums/MissionStatus';
-import { TransactionType } from '@/types/campaign/enums/TransactionType';
-import { getAllUnits } from '@/types/campaign/Force';
-import { IContract, isContract, IMission } from '@/types/campaign/Mission';
 import { Money } from '@/types/campaign/Money';
-import { IInjury } from '@/types/campaign/Person';
-import { Transaction } from '@/types/campaign/Transaction';
 
+import { processContracts } from './contractProcessing';
+import { processDailyCosts } from './dailyCostsProcessing';
 import { IDayPipelineResult, IDayEvent } from './dayPipeline';
-import { getBestAvailableDoctor } from './medical/doctorCapacity';
-import { MedicalSystem } from './medical/medicalTypes';
-import { performMedicalCheck } from './medical/performMedicalCheck';
+import {
+  DailyCostBreakdown,
+  DayReport,
+  ExpiredContractEvent,
+  HealedPersonEvent,
+  TurnoverDepartureEvent,
+} from './dayReportTypes';
+import { processHealing } from './healingProcessing';
 import { asEventDataShape } from './utils/processorHelpers';
 
 // =============================================================================
-// Constants
+// Re-exports — preserve the historical public API of this module
 // =============================================================================
+//
+// The phase logic and shared types moved to sibling modules during the
+// decompose refactor. These re-exports keep every existing importer
+// (`useCampaignStore`, `DayReportPanel`, processors, tests, etc.) working
+// against `@/lib/campaign/dayAdvancement` exactly as before.
 
-/** Default daily salary per person in C-bills */
-export const DEFAULT_DAILY_SALARY = 50;
-
-/** Default daily maintenance cost per unit in C-bills */
-export const DEFAULT_DAILY_MAINTENANCE = 100;
-
-// =============================================================================
-// Report Types
-// =============================================================================
-
-/**
- * Event describing a person who completed healing.
- */
-export interface HealedPersonEvent {
-  /** Person ID */
-  readonly personId: string;
-  /** Person name */
-  readonly personName: string;
-  /** Injuries that were fully healed this day */
-  readonly healedInjuries: readonly string[];
-  /** Whether the person transitioned from WOUNDED to ACTIVE */
-  readonly returnedToActive: boolean;
-}
-
-/**
- * Event describing a contract that expired.
- */
-export interface ExpiredContractEvent {
-  /** Contract ID */
-  readonly contractId: string;
-  /** Contract name */
-  readonly contractName: string;
-  /** Previous status */
-  readonly previousStatus: MissionStatus;
-  /** New status after expiration */
-  readonly newStatus: MissionStatus;
-}
-
-/**
- * Breakdown of daily costs.
- */
-export interface DailyCostBreakdown {
-  /** Total salary costs */
-  readonly salaries: Money;
-  /** Total maintenance costs */
-  readonly maintenance: Money;
-  /** Total daily costs */
-  readonly total: Money;
-  /** Number of personnel paid */
-  readonly personnelCount: number;
-  /** Number of units maintained */
-  readonly unitCount: number;
-}
-
-/**
- * Report summarizing all events from a single day advancement.
- */
-export interface TurnoverDepartureEvent {
-  readonly personId: string;
-  readonly personName: string;
-  readonly departureType: 'retired' | 'deserted';
-  readonly roll: number;
-  readonly targetNumber: number;
-  readonly payoutAmount: number;
-  readonly modifiers: readonly {
-    modifierId: string;
-    displayName: string;
-    value: number;
-    isStub: boolean;
-  }[];
-}
-
-export interface DayReport {
-  readonly date: Date;
-  readonly healedPersonnel: readonly HealedPersonEvent[];
-  readonly expiredContracts: readonly ExpiredContractEvent[];
-  readonly costs: DailyCostBreakdown;
-  readonly turnoverDepartures: readonly TurnoverDepartureEvent[];
-  readonly campaign: ICampaign;
-}
-
-// =============================================================================
-// Healing Processing
-// =============================================================================
-
-/**
- * Process healing for all wounded roster entries.
- *
- * Per PR4 of `wire-iperson-hard-cutover`: this legacy function reads roster
- * entries directly (no personnel Map) and returns per-pilot patches that
- * the caller commits via `useCampaignRosterStore.applyPilotPatches`.
- * Production uses `healingProcessor` via the DayPipelineRegistry; this
- * standalone function is a thin wrapper kept for the `advanceDay` legacy
- * path and direct unit tests.
- *
- * For each wounded entry:
- * - Use selected medical system to process injuries
- * - Apply medical check results to reduce healing time
- * - Remove injuries where daysToHeal reaches 0
- * - Reduce recoveryTime by 1 (min 0)
- * - If entry is Wounded and all injuries healed + recoveryTime is 0,
- *   transition to Active
- *
- * @param entries - All roster entries (typically `useCampaignRosterStore.getState().pilots`)
- * @param campaign - Campaign with options for doctor assignment
- * @returns Per-pilot patches plus healing events
- */
-export function processHealing(
-  entries: readonly ICampaignRosterEntry[],
-  campaign?: ICampaign,
-): {
-  patches: Map<string, Partial<ICampaignRosterEntry>>;
-  events: HealedPersonEvent[];
-} {
-  const patches = new Map<string, Partial<ICampaignRosterEntry>>();
-  const events: HealedPersonEvent[] = [];
-
-  const medicalSystem =
-    campaign?.options.medicalSystem ?? MedicalSystem.STANDARD;
-  // Doctor lookup uses ALL entries (for primaryRole=DOCTOR filtering).
-  // No vault join in this legacy path — pass empty pilot map (NPCs only).
-  const emptyPilots: ReadonlyMap<string, IPilot> = new Map<string, IPilot>();
-
-  for (const entry of entries) {
-    if (entry.status !== CampaignPilotStatus.Wounded) continue;
-
-    // Process injuries: apply medical checks, track healed ones
-    const healedInjuryIds: string[] = [];
-    const updatedInjuries: IInjury[] = [];
-    const injuries: readonly IInjury[] = entry.injuries ?? [];
-
-    for (const injury of injuries) {
-      if (injury.permanent) {
-        // Permanent injuries don't heal
-        updatedInjuries.push(injury);
-        continue;
-      }
-
-      // Get assigned doctor for this patient using new two-arg signature
-      const doctorEntry = campaign
-        ? getBestAvailableDoctor(entry, entries, emptyPilots, campaign.options)
-        : null;
-
-      // Perform medical check using selected system with new two-arg signature
-      const medicalResult = campaign
-        ? performMedicalCheck(
-            medicalSystem,
-            entry,
-            injury,
-            doctorEntry,
-            null, // doctorPilot: no vault join in this legacy path
-            campaign.options,
-            Math.random,
-          )
-        : null;
-
-      const daysReduced = medicalResult?.healingDaysReduced ?? 1;
-      const newDaysToHeal = Math.max(0, injury.daysToHeal - daysReduced);
-
-      if (newDaysToHeal === 0) {
-        healedInjuryIds.push(injury.id);
-      } else {
-        updatedInjuries.push({ ...injury, daysToHeal: newDaysToHeal });
-      }
-    }
-
-    // Reduce recoveryTime (the roster-entry recovery counter)
-    const oldRecoveryTime = entry.recoveryTime ?? 0;
-    const newRecoveryTime = Math.max(0, oldRecoveryTime - 1);
-
-    // Check if entry should return to active duty
-    const hasHealableInjuries = updatedInjuries.some((i) => !i.permanent);
-    const returnedToActive = !hasHealableInjuries && newRecoveryTime === 0;
-
-    // Commit a patch when ANY field changes — recoveryTime decrements
-    // even when no injury cleared, so the early-return must consider
-    // the recoveryTime delta too. Otherwise wounded pilots would never
-    // tick down their recovery clock.
-    const recoveryChanged = newRecoveryTime !== oldRecoveryTime;
-    const injuriesChanged = healedInjuryIds.length > 0;
-    if (!injuriesChanged && !returnedToActive && !recoveryChanged) {
-      continue;
-    }
-
-    patches.set(entry.pilotId, {
-      injuries: updatedInjuries,
-      recoveryTime: newRecoveryTime,
-      status: returnedToActive ? CampaignPilotStatus.Active : entry.status,
-    });
-
-    // Only emit a healing event when something user-visible happened
-    // (injury cleared OR returned to active). A silent recovery-time
-    // tick stays internal to keep the event log noise-free.
-    if (injuriesChanged || returnedToActive) {
-      events.push({
-        personId: entry.pilotId,
-        personName: entry.pilotName,
-        healedInjuries: healedInjuryIds,
-        returnedToActive,
-      });
-    }
-  }
-
-  return { patches, events };
-}
-
-// =============================================================================
-// Contract Processing
-// =============================================================================
-
-/**
- * Process contract expiration for the campaign.
- *
- * Checks all active contracts against the current date.
- * If a contract's endDate has passed, it is marked as completed (SUCCESS).
- *
- * @param campaign - The campaign to process
- * @returns Updated missions map and expiration events
- */
-export function processContracts(campaign: ICampaign): {
-  missions: Map<string, IMission>;
-  events: ExpiredContractEvent[];
-} {
-  const updatedMissions = new Map(campaign.missions);
-  const events: ExpiredContractEvent[] = [];
-  const currentDate = campaign.currentDate;
-
-  Array.from(campaign.missions.entries()).forEach(([id, mission]) => {
-    // Only process active contracts with end dates
-    if (!isContract(mission)) return;
-    if (mission.status !== MissionStatus.ACTIVE) return;
-    if (!mission.endDate) return;
-
-    const endDate = new Date(mission.endDate);
-    if (currentDate >= endDate) {
-      const updatedContract: IContract = {
-        ...mission,
-        status: MissionStatus.SUCCESS,
-        updatedAt: new Date().toISOString(),
-      };
-
-      updatedMissions.set(id, updatedContract);
-
-      events.push({
-        contractId: id,
-        contractName: mission.name,
-        previousStatus: mission.status,
-        newStatus: MissionStatus.SUCCESS,
-      });
-    }
-  });
-
-  return { missions: updatedMissions, events };
-}
-
-// =============================================================================
-// Daily Costs Processing
-// =============================================================================
-
-/**
- * Process daily costs for the campaign.
- *
- * Calculates:
- * - Salary: DEFAULT_DAILY_SALARY * salaryMultiplier per active person
- * - Maintenance: DEFAULT_DAILY_MAINTENANCE * maintenanceCostMultiplier per unit
- *
- * Deducts from campaign balance and records transactions.
- *
- * @param campaign - The campaign to process
- * @returns Updated finances and cost breakdown
- */
-export function processDailyCosts(campaign: ICampaign): {
-  finances: { transactions: Transaction[]; balance: Money };
-  costs: DailyCostBreakdown;
-} {
-  const { options } = campaign;
-  const newTransactions: Transaction[] = [...campaign.finances.transactions];
-  let currentBalance = campaign.finances.balance;
-
-  // Count billable personnel for salary — read from roster store
-  // (canonical source per PR4 of `wire-iperson-hard-cutover`).
-  // CampaignPilotStatus.KIA is the only non-billable terminal status; Active,
-  // Wounded, Critical, and MIA all still draw salary.
-  const rosterEntries = useCampaignRosterStore.getState().pilots;
-  const personnelCount = rosterEntries.filter(
-    (e) => e.status !== CampaignPilotStatus.KIA,
-  ).length;
-
-  // Calculate salary costs
-  let salaries = Money.ZERO;
-  if (options.payForSalaries && personnelCount > 0) {
-    const dailySalaryPerPerson = new Money(
-      DEFAULT_DAILY_SALARY * options.salaryMultiplier,
-    );
-    salaries = dailySalaryPerPerson.multiply(personnelCount);
-
-    newTransactions.push({
-      id: `tx-salary-${campaign.currentDate.toISOString()}`,
-      type: TransactionType.Expense,
-      amount: salaries,
-      date: campaign.currentDate,
-      description: `Daily salaries for ${personnelCount} personnel`,
-    });
-
-    currentBalance = currentBalance.subtract(salaries);
-  }
-
-  // Count units for maintenance
-  let unitCount = 0;
-  const rootForce = campaign.forces.get(campaign.rootForceId);
-  if (rootForce) {
-    const allUnitIds = getAllUnits(rootForce, campaign.forces);
-    unitCount = allUnitIds.length;
-  }
-
-  // Calculate maintenance costs
-  let maintenance = Money.ZERO;
-  if (options.payForMaintenance && unitCount > 0) {
-    const dailyMaintenancePerUnit = new Money(
-      DEFAULT_DAILY_MAINTENANCE * options.maintenanceCostMultiplier,
-    );
-    maintenance = dailyMaintenancePerUnit.multiply(unitCount);
-
-    newTransactions.push({
-      id: `tx-maintenance-${campaign.currentDate.toISOString()}`,
-      type: TransactionType.Maintenance,
-      amount: maintenance,
-      date: campaign.currentDate,
-      description: `Daily maintenance for ${unitCount} units`,
-    });
-
-    currentBalance = currentBalance.subtract(maintenance);
-  }
-
-  const total = salaries.add(maintenance);
-
-  return {
-    finances: {
-      transactions: newTransactions,
-      balance: currentBalance,
-    },
-    costs: {
-      salaries,
-      maintenance,
-      total,
-      personnelCount,
-      unitCount,
-    },
-  };
-}
+export {
+  DEFAULT_DAILY_SALARY,
+  DEFAULT_DAILY_MAINTENANCE,
+} from './dayReportTypes';
+export type {
+  HealedPersonEvent,
+  ExpiredContractEvent,
+  DailyCostBreakdown,
+  TurnoverDepartureEvent,
+  DayReport,
+} from './dayReportTypes';
+export { processHealing } from './healingProcessing';
+export { processContracts } from './contractProcessing';
+export { processDailyCosts } from './dailyCostsProcessing';
 
 // =============================================================================
 // Main Day Advancement
@@ -529,6 +207,14 @@ export function advanceDay(campaign: ICampaign): DayReport {
 // Multi-Day Advancement
 // =============================================================================
 
+/**
+ * Advance the campaign by `count` days, threading each day's output
+ * campaign into the next iteration.
+ *
+ * @param campaign - The campaign to advance
+ * @param count - Number of days to advance
+ * @returns One DayReport per advanced day, in chronological order
+ */
 export function advanceDays(campaign: ICampaign, count: number): DayReport[] {
   const reports: DayReport[] = [];
   let currentCampaign = campaign;
@@ -546,6 +232,14 @@ export function advanceDays(campaign: ICampaign, count: number): DayReport[] {
 // Pipeline Integration
 // =============================================================================
 
+/**
+ * Convert a registry `IDayPipelineResult` into the legacy `DayReport`
+ * shape consumed by the campaign store and UI panels. Filters the typed
+ * event stream into the per-category arrays the report exposes.
+ *
+ * @param result - The pipeline result emitted by `DayPipelineRegistry`
+ * @returns A `DayReport` mirroring the legacy `advanceDay` output shape
+ */
 export function convertToLegacyDayReport(
   result: IDayPipelineResult,
 ): DayReport {
@@ -596,6 +290,15 @@ export function convertToLegacyDayReport(
   };
 }
 
+/**
+ * Run one day through the registry pipeline and adapt the result to the
+ * legacy `DayReport` shape. This is the canonical store path; `advanceDay`
+ * above is the registry-free fallback.
+ *
+ * @param campaign - The campaign to advance
+ * @param pipeline - An object exposing `processDay` (the day registry)
+ * @returns A legacy `DayReport` for the advanced day
+ */
 export function advanceDayViaPipeline(
   campaign: ICampaign,
   pipeline: { processDay(campaign: ICampaign): IDayPipelineResult },

--- a/src/lib/campaign/dayReportTypes.ts
+++ b/src/lib/campaign/dayReportTypes.ts
@@ -1,0 +1,104 @@
+/**
+ * Day Report Types - Shared types and constants for day advancement
+ *
+ * Holds the event/report interfaces and cost constants consumed by the
+ * day-advancement processor chain. Extracted from `dayAdvancement.ts`
+ * (decompose refactor) so that the individual phase modules and the
+ * pipeline coordinator can depend on a single, dependency-light type
+ * module rather than on the coordinator file itself.
+ *
+ * @module lib/campaign/dayReportTypes
+ */
+
+import { ICampaign } from '@/types/campaign/Campaign';
+import { MissionStatus } from '@/types/campaign/enums/MissionStatus';
+import { Money } from '@/types/campaign/Money';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Default daily salary per person in C-bills */
+export const DEFAULT_DAILY_SALARY = 50;
+
+/** Default daily maintenance cost per unit in C-bills */
+export const DEFAULT_DAILY_MAINTENANCE = 100;
+
+// =============================================================================
+// Report Types
+// =============================================================================
+
+/**
+ * Event describing a person who completed healing.
+ */
+export interface HealedPersonEvent {
+  /** Person ID */
+  readonly personId: string;
+  /** Person name */
+  readonly personName: string;
+  /** Injuries that were fully healed this day */
+  readonly healedInjuries: readonly string[];
+  /** Whether the person transitioned from WOUNDED to ACTIVE */
+  readonly returnedToActive: boolean;
+}
+
+/**
+ * Event describing a contract that expired.
+ */
+export interface ExpiredContractEvent {
+  /** Contract ID */
+  readonly contractId: string;
+  /** Contract name */
+  readonly contractName: string;
+  /** Previous status */
+  readonly previousStatus: MissionStatus;
+  /** New status after expiration */
+  readonly newStatus: MissionStatus;
+}
+
+/**
+ * Breakdown of daily costs.
+ */
+export interface DailyCostBreakdown {
+  /** Total salary costs */
+  readonly salaries: Money;
+  /** Total maintenance costs */
+  readonly maintenance: Money;
+  /** Total daily costs */
+  readonly total: Money;
+  /** Number of personnel paid */
+  readonly personnelCount: number;
+  /** Number of units maintained */
+  readonly unitCount: number;
+}
+
+/**
+ * Event describing a person who departed the campaign via turnover
+ * (retirement or desertion).
+ */
+export interface TurnoverDepartureEvent {
+  readonly personId: string;
+  readonly personName: string;
+  readonly departureType: 'retired' | 'deserted';
+  readonly roll: number;
+  readonly targetNumber: number;
+  readonly payoutAmount: number;
+  readonly modifiers: readonly {
+    modifierId: string;
+    displayName: string;
+    value: number;
+    isStub: boolean;
+  }[];
+}
+
+/**
+ * Report summarizing all events from a single day advancement.
+ */
+export interface DayReport {
+  readonly date: Date;
+  readonly healedPersonnel: readonly HealedPersonEvent[];
+  readonly expiredContracts: readonly ExpiredContractEvent[];
+  readonly costs: DailyCostBreakdown;
+  readonly turnoverDepartures: readonly TurnoverDepartureEvent[];
+  readonly campaign: ICampaign;
+}

--- a/src/lib/campaign/healingProcessing.ts
+++ b/src/lib/campaign/healingProcessing.ts
@@ -1,0 +1,146 @@
+/**
+ * Healing Processing - Personnel healing phase of day advancement
+ *
+ * Extracted from `dayAdvancement.ts` (decompose refactor). Contains the
+ * standalone `processHealing` phase used by the legacy `advanceDay` path
+ * and by direct unit tests. Production runs this logic through the
+ * `healingProcessor` registered in the `DayPipelineRegistry`.
+ *
+ * Behavior is identical to the pre-refactor implementation — this module
+ * is a pure cut/paste of the healing phase with no logic change.
+ *
+ * @module lib/campaign/healingProcessing
+ */
+
+import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
+import type { IPilot } from '@/types/pilot/PilotInterfaces';
+
+import { ICampaign } from '@/types/campaign/Campaign';
+import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
+import { IInjury } from '@/types/campaign/Person';
+
+import { HealedPersonEvent } from './dayReportTypes';
+import { getBestAvailableDoctor } from './medical/doctorCapacity';
+import { MedicalSystem } from './medical/medicalTypes';
+import { performMedicalCheck } from './medical/performMedicalCheck';
+
+/**
+ * Process healing for all wounded roster entries.
+ *
+ * Per PR4 of `wire-iperson-hard-cutover`: this legacy function reads roster
+ * entries directly (no personnel Map) and returns per-pilot patches that
+ * the caller commits via `useCampaignRosterStore.applyPilotPatches`.
+ * Production uses `healingProcessor` via the DayPipelineRegistry; this
+ * standalone function is a thin wrapper kept for the `advanceDay` legacy
+ * path and direct unit tests.
+ *
+ * For each wounded entry:
+ * - Use selected medical system to process injuries
+ * - Apply medical check results to reduce healing time
+ * - Remove injuries where daysToHeal reaches 0
+ * - Reduce recoveryTime by 1 (min 0)
+ * - If entry is Wounded and all injuries healed + recoveryTime is 0,
+ *   transition to Active
+ *
+ * @param entries - All roster entries (typically `useCampaignRosterStore.getState().pilots`)
+ * @param campaign - Campaign with options for doctor assignment
+ * @returns Per-pilot patches plus healing events
+ */
+export function processHealing(
+  entries: readonly ICampaignRosterEntry[],
+  campaign?: ICampaign,
+): {
+  patches: Map<string, Partial<ICampaignRosterEntry>>;
+  events: HealedPersonEvent[];
+} {
+  const patches = new Map<string, Partial<ICampaignRosterEntry>>();
+  const events: HealedPersonEvent[] = [];
+
+  const medicalSystem =
+    campaign?.options.medicalSystem ?? MedicalSystem.STANDARD;
+  // Doctor lookup uses ALL entries (for primaryRole=DOCTOR filtering).
+  // No vault join in this legacy path — pass empty pilot map (NPCs only).
+  const emptyPilots: ReadonlyMap<string, IPilot> = new Map<string, IPilot>();
+
+  for (const entry of entries) {
+    if (entry.status !== CampaignPilotStatus.Wounded) continue;
+
+    // Process injuries: apply medical checks, track healed ones
+    const healedInjuryIds: string[] = [];
+    const updatedInjuries: IInjury[] = [];
+    const injuries: readonly IInjury[] = entry.injuries ?? [];
+
+    for (const injury of injuries) {
+      if (injury.permanent) {
+        // Permanent injuries don't heal
+        updatedInjuries.push(injury);
+        continue;
+      }
+
+      // Get assigned doctor for this patient using new two-arg signature
+      const doctorEntry = campaign
+        ? getBestAvailableDoctor(entry, entries, emptyPilots, campaign.options)
+        : null;
+
+      // Perform medical check using selected system with new two-arg signature
+      const medicalResult = campaign
+        ? performMedicalCheck(
+            medicalSystem,
+            entry,
+            injury,
+            doctorEntry,
+            null, // doctorPilot: no vault join in this legacy path
+            campaign.options,
+            Math.random,
+          )
+        : null;
+
+      const daysReduced = medicalResult?.healingDaysReduced ?? 1;
+      const newDaysToHeal = Math.max(0, injury.daysToHeal - daysReduced);
+
+      if (newDaysToHeal === 0) {
+        healedInjuryIds.push(injury.id);
+      } else {
+        updatedInjuries.push({ ...injury, daysToHeal: newDaysToHeal });
+      }
+    }
+
+    // Reduce recoveryTime (the roster-entry recovery counter)
+    const oldRecoveryTime = entry.recoveryTime ?? 0;
+    const newRecoveryTime = Math.max(0, oldRecoveryTime - 1);
+
+    // Check if entry should return to active duty
+    const hasHealableInjuries = updatedInjuries.some((i) => !i.permanent);
+    const returnedToActive = !hasHealableInjuries && newRecoveryTime === 0;
+
+    // Commit a patch when ANY field changes — recoveryTime decrements
+    // even when no injury cleared, so the early-return must consider
+    // the recoveryTime delta too. Otherwise wounded pilots would never
+    // tick down their recovery clock.
+    const recoveryChanged = newRecoveryTime !== oldRecoveryTime;
+    const injuriesChanged = healedInjuryIds.length > 0;
+    if (!injuriesChanged && !returnedToActive && !recoveryChanged) {
+      continue;
+    }
+
+    patches.set(entry.pilotId, {
+      injuries: updatedInjuries,
+      recoveryTime: newRecoveryTime,
+      status: returnedToActive ? CampaignPilotStatus.Active : entry.status,
+    });
+
+    // Only emit a healing event when something user-visible happened
+    // (injury cleared OR returned to active). A silent recovery-time
+    // tick stays internal to keep the event log noise-free.
+    if (injuriesChanged || returnedToActive) {
+      events.push({
+        personId: entry.pilotId,
+        personName: entry.pilotName,
+        healedInjuries: healedInjuryIds,
+        returnedToActive,
+      });
+    }
+  }
+
+  return { patches, events };
+}

--- a/src/lib/campaign/turnover/modifierRegistry.ts
+++ b/src/lib/campaign/turnover/modifierRegistry.ts
@@ -1,0 +1,200 @@
+/**
+ * Turnover modifier registry
+ *
+ * Single source of truth for which modifiers contribute to a turnover check,
+ * in what order, and how each is labelled. Replaces the former 100-line
+ * hand-rolled `buildModifier(...)` block in `turnoverCheck.ts` — adding a new
+ * modifier is now one table entry instead of an edit to the check logic (OCP).
+ *
+ * The underlying modifier functions keep their natural arity; each registry
+ * entry wraps its function in a uniform `(entry, pilot, campaign) => number`
+ * evaluator so the consumer can iterate the table without per-modifier
+ * dispatch. Campaign-only modifiers simply ignore `entry`/`pilot`.
+ *
+ * @module campaign/turnover/modifierRegistry
+ */
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
+import type { IPilot } from '@/types/pilot/PilotInterfaces';
+
+import {
+  getAgeModifier,
+  getBaseTargetModifier,
+  getFactionCampaignModifier,
+  getFactionOriginModifier,
+  getFamilyModifier,
+  getFatigueModifier,
+  getFounderModifier,
+  getHostileTerritoryModifier,
+  getHRStrainModifier,
+  getInjuryModifier,
+  getLoyaltyModifier,
+  getManagementSkillModifier,
+  getMissionStatusModifier,
+  getOfficerModifier,
+  getRecentPromotionModifier,
+  getServiceContractModifier,
+  getSharesModifier,
+  getSkillDesirabilityModifier,
+  getUnitRatingModifier,
+} from './modifiers';
+
+/** Uniform evaluator signature — campaign-only modifiers ignore entry/pilot. */
+export type TurnoverModifierEvaluator = (
+  entry: ICampaignRosterEntry,
+  pilot: IPilot | null,
+  campaign: ICampaign,
+) => number;
+
+/**
+ * One row of the turnover modifier table.
+ *
+ * `isStub` flags modifiers whose underlying system is not yet implemented
+ * (they currently evaluate to 0); the flag is surfaced on the result so the
+ * UI can render them distinctly.
+ */
+export interface TurnoverModifierDefinition {
+  /** Stable identifier (e.g. 'founder', 'age'). */
+  readonly id: string;
+  /** Human-readable label for display (e.g. 'Founder', 'Age'). */
+  readonly displayName: string;
+  /** True when the underlying system is a not-yet-implemented stub. */
+  readonly isStub: boolean;
+  /** Wrapped evaluator producing the numeric modifier value. */
+  readonly evaluate: TurnoverModifierEvaluator;
+}
+
+/**
+ * The ordered turnover modifier table.
+ *
+ * Order is preserved exactly from the legacy `calculateModifiers` block so the
+ * `modifiers` array on every `TurnoverCheckResult` is byte-for-byte unchanged.
+ * The sum that forms the target number is order-independent, but the array is
+ * also surfaced verbatim in the result, so order is part of the contract.
+ */
+export const TURNOVER_MODIFIER_REGISTRY: readonly TurnoverModifierDefinition[] =
+  [
+    {
+      id: 'baseTarget',
+      displayName: 'Base Target',
+      isStub: false,
+      evaluate: (_entry, _pilot, campaign) => getBaseTargetModifier(campaign),
+    },
+    {
+      id: 'founder',
+      displayName: 'Founder',
+      isStub: false,
+      evaluate: (entry, pilot) => getFounderModifier(entry, pilot),
+    },
+    {
+      id: 'serviceContract',
+      displayName: 'Service Contract',
+      isStub: false,
+      evaluate: (entry, pilot) => getServiceContractModifier(entry, pilot),
+    },
+    {
+      id: 'skillDesirability',
+      displayName: 'Skill Desirability',
+      isStub: false,
+      evaluate: (entry, pilot, campaign) =>
+        getSkillDesirabilityModifier(entry, pilot, campaign),
+    },
+    {
+      id: 'recentPromotion',
+      displayName: 'Recent Promotion',
+      isStub: false,
+      evaluate: (entry, pilot, campaign) =>
+        getRecentPromotionModifier(entry, pilot, campaign),
+    },
+    {
+      id: 'fatigue',
+      displayName: 'Fatigue',
+      isStub: true,
+      evaluate: (entry, pilot) => getFatigueModifier(entry, pilot),
+    },
+    {
+      id: 'hrStrain',
+      displayName: 'HR Strain',
+      isStub: true,
+      evaluate: (_entry, _pilot, campaign) => getHRStrainModifier(campaign),
+    },
+    {
+      id: 'managementSkill',
+      displayName: 'Management Skill',
+      isStub: true,
+      evaluate: (_entry, _pilot, campaign) =>
+        getManagementSkillModifier(campaign),
+    },
+    {
+      id: 'shares',
+      displayName: 'Shares',
+      isStub: true,
+      evaluate: (entry, pilot, campaign) =>
+        getSharesModifier(entry, pilot, campaign),
+    },
+    {
+      id: 'unitRating',
+      displayName: 'Unit Rating',
+      isStub: true,
+      evaluate: (_entry, _pilot, campaign) => getUnitRatingModifier(campaign),
+    },
+    {
+      id: 'hostileTerritory',
+      displayName: 'Hostile Territory',
+      isStub: true,
+      evaluate: (_entry, _pilot, campaign) =>
+        getHostileTerritoryModifier(campaign),
+    },
+    {
+      id: 'missionStatus',
+      displayName: 'Mission Status',
+      isStub: false,
+      evaluate: (_entry, _pilot, campaign) =>
+        getMissionStatusModifier(campaign),
+    },
+    {
+      id: 'loyalty',
+      displayName: 'Loyalty',
+      isStub: true,
+      evaluate: (entry, pilot) => getLoyaltyModifier(entry, pilot),
+    },
+    {
+      id: 'factionCampaign',
+      displayName: 'Faction (Campaign)',
+      isStub: true,
+      evaluate: (_entry, _pilot, campaign) =>
+        getFactionCampaignModifier(campaign),
+    },
+    {
+      id: 'factionOrigin',
+      displayName: 'Faction (Origin)',
+      isStub: true,
+      evaluate: (entry, pilot) => getFactionOriginModifier(entry, pilot),
+    },
+    {
+      id: 'age',
+      displayName: 'Age',
+      isStub: false,
+      evaluate: (entry, pilot, campaign) =>
+        getAgeModifier(entry, pilot, campaign),
+    },
+    {
+      id: 'family',
+      displayName: 'Family',
+      isStub: true,
+      evaluate: (entry, pilot, campaign) =>
+        getFamilyModifier(entry, pilot, campaign),
+    },
+    {
+      id: 'injuries',
+      displayName: 'Injuries',
+      isStub: false,
+      evaluate: (entry, pilot) => getInjuryModifier(entry, pilot),
+    },
+    {
+      id: 'officer',
+      displayName: 'Officer Status',
+      isStub: false,
+      evaluate: (entry, pilot) => getOfficerModifier(entry, pilot),
+    },
+  ];

--- a/src/lib/campaign/turnover/turnoverCheck.ts
+++ b/src/lib/campaign/turnover/turnoverCheck.ts
@@ -7,27 +7,7 @@ import { Money } from '@/types/campaign/Money';
 
 import type { TurnoverModifierResult } from './modifiers/types';
 
-import {
-  getBaseTargetModifier,
-  getFounderModifier,
-  getRecentPromotionModifier,
-  getAgeModifier,
-  getInjuryModifier,
-  getOfficerModifier,
-  getServiceContractModifier,
-  getSkillDesirabilityModifier,
-  getMissionStatusModifier,
-  getFatigueModifier,
-  getHRStrainModifier,
-  getManagementSkillModifier,
-  getSharesModifier,
-  getUnitRatingModifier,
-  getHostileTerritoryModifier,
-  getLoyaltyModifier,
-  getFactionCampaignModifier,
-  getFactionOriginModifier,
-  getFamilyModifier,
-} from './modifiers';
+import { TURNOVER_MODIFIER_REGISTRY } from './modifierRegistry';
 
 export type RandomFn = () => number;
 
@@ -97,123 +77,26 @@ function isEligibleForCheck(
   return true;
 }
 
-function buildModifier(
-  modifierId: string,
-  displayName: string,
-  value: number,
-  isStub: boolean,
-): TurnoverModifierResult {
-  return { modifierId, displayName, value, isStub };
-}
-
 /**
  * Assembles all turnover modifier contributions for a single roster entry.
  *
- * NPC behavior: individual modifiers define their own NPC handling (see each
- * modifier's JSDoc). Aggregate behaviour: all modifiers whose domain is
- * PROCESS fire; officer-status modifier early-returns 0 for NPCs.
+ * Iterates the `TURNOVER_MODIFIER_REGISTRY` table (the single source of truth
+ * for which modifiers apply and in what order) and evaluates each against the
+ * entry. NPC behaviour: individual modifiers define their own NPC handling
+ * (see each modifier's JSDoc) — e.g. the officer-status modifier early-returns
+ * 0 for NPCs.
  */
 function calculateModifiers(
   entry: ICampaignRosterEntry,
   pilot: IPilot | null,
   campaign: ICampaign,
 ): TurnoverModifierResult[] {
-  return [
-    buildModifier(
-      'baseTarget',
-      'Base Target',
-      getBaseTargetModifier(campaign),
-      false,
-    ),
-    buildModifier(
-      'founder',
-      'Founder',
-      getFounderModifier(entry, pilot),
-      false,
-    ),
-    buildModifier(
-      'serviceContract',
-      'Service Contract',
-      getServiceContractModifier(entry, pilot),
-      false,
-    ),
-    buildModifier(
-      'skillDesirability',
-      'Skill Desirability',
-      getSkillDesirabilityModifier(entry, pilot, campaign),
-      false,
-    ),
-    buildModifier(
-      'recentPromotion',
-      'Recent Promotion',
-      getRecentPromotionModifier(entry, pilot, campaign),
-      false,
-    ),
-    buildModifier('fatigue', 'Fatigue', getFatigueModifier(entry, pilot), true),
-    buildModifier('hrStrain', 'HR Strain', getHRStrainModifier(campaign), true),
-    buildModifier(
-      'managementSkill',
-      'Management Skill',
-      getManagementSkillModifier(campaign),
-      true,
-    ),
-    buildModifier(
-      'shares',
-      'Shares',
-      getSharesModifier(entry, pilot, campaign),
-      true,
-    ),
-    buildModifier(
-      'unitRating',
-      'Unit Rating',
-      getUnitRatingModifier(campaign),
-      true,
-    ),
-    buildModifier(
-      'hostileTerritory',
-      'Hostile Territory',
-      getHostileTerritoryModifier(campaign),
-      true,
-    ),
-    buildModifier(
-      'missionStatus',
-      'Mission Status',
-      getMissionStatusModifier(campaign),
-      false,
-    ),
-    buildModifier('loyalty', 'Loyalty', getLoyaltyModifier(entry, pilot), true),
-    buildModifier(
-      'factionCampaign',
-      'Faction (Campaign)',
-      getFactionCampaignModifier(campaign),
-      true,
-    ),
-    buildModifier(
-      'factionOrigin',
-      'Faction (Origin)',
-      getFactionOriginModifier(entry, pilot),
-      true,
-    ),
-    buildModifier('age', 'Age', getAgeModifier(entry, pilot, campaign), false),
-    buildModifier(
-      'family',
-      'Family',
-      getFamilyModifier(entry, pilot, campaign),
-      true,
-    ),
-    buildModifier(
-      'injuries',
-      'Injuries',
-      getInjuryModifier(entry, pilot),
-      false,
-    ),
-    buildModifier(
-      'officer',
-      'Officer Status',
-      getOfficerModifier(entry, pilot),
-      false,
-    ),
-  ];
+  return TURNOVER_MODIFIER_REGISTRY.map((definition) => ({
+    modifierId: definition.id,
+    displayName: definition.displayName,
+    value: definition.evaluate(entry, pilot, campaign),
+    isStub: definition.isStub,
+  }));
 }
 
 /**

--- a/src/lib/multiplayer/server/ServerMatchHost.ts
+++ b/src/lib/multiplayer/server/ServerMatchHost.ts
@@ -25,6 +25,14 @@
  *     and ALSO rejects any inbound intent whose payload smuggles dice
  *     fields (zod refinement on `IntentSchema`).
  *
+ * Architecture: this class is a thin orchestrator. The heavy concerns
+ * live in co-located collaborators — `ServerMatchSocketLifecycle`,
+ * `ServerMatchBroadcaster`, `ServerMatchHostCapture` (roll capture),
+ * `ServerMatchHostOutcomePublisher` (Wave 5 publish safety net), and
+ * the `ServerMatchHost*` free-function modules for replay / intent /
+ * lobby / reconnect logic. `ServerMatchHostContexts` assembles the
+ * plain context objects those free functions consume.
+ *
  * Out of scope for this wave:
  *   - Lobby intents (Wave 3b)
  *   - Outcome bus passthrough (Wave 5 wires it).
@@ -39,10 +47,6 @@ import type { IGameEvent } from '@/types/gameplay/GameSessionInterfaces';
 import type { IGameSession } from '@/types/gameplay/GameSessionInterfaces';
 import type { IPlayerRef } from '@/types/multiplayer/Player';
 
-import {
-  publishCombatOutcome,
-  type ICombatOutcomeReadyEvent,
-} from '@/engine/combatOutcomeBus';
 import { InteractiveSession } from '@/engine/InteractiveSession';
 import {
   type IGameSessionChannel,
@@ -62,34 +66,39 @@ import {
 import type { IMatchStore } from './IMatchStore';
 import type { IMatchSocket } from './ServerMatchSocketTypes';
 
-import { CryptoDiceRoller, type IServerDiceRoller } from './CryptoDiceRoller';
+import { type IServerDiceRoller } from './CryptoDiceRoller';
 import { FogOfWarVisibilityCache } from './fogOfWar';
 import { PendingPeerTracker } from './reconnection/PendingPeerTracker';
-import { RollCapture } from './RollCapture';
 import { ServerMatchBroadcaster } from './ServerMatchBroadcaster';
 import {
   buildHostSession,
   type IMatchHostBootstrap,
 } from './ServerMatchHostBootstrap';
+import { ServerMatchHostCapture } from './ServerMatchHostCapture';
+import {
+  buildIntentContext,
+  buildLobbyContext,
+  buildReconnectContext,
+  buildReplayContext,
+  type IServerMatchHostInternals,
+} from './ServerMatchHostContexts';
 import { drainNewEvents } from './ServerMatchHostEngineDispatch';
 import {
   broadcastEvent as broadcastEventWithContext,
   persistInitialEvents,
-  stampRollsOnNewEvents,
 } from './ServerMatchHostEvents';
 import { handleIntent as handleIntentWithContext } from './ServerMatchHostIntent';
 import { handleLobbyIntent as handleLobbyIntentWithContext } from './ServerMatchHostLobbyIntents';
+import { ServerMatchHostOutcomePublisher } from './ServerMatchHostOutcomePublisher';
 import {
   maybeMarkPlayerPending,
   maybeResume,
-  type IServerMatchHostReconnectContext,
 } from './ServerMatchHostReconnectLifecycle';
 import {
   bindReconnectChannel,
   getEventsFromSeq,
   handleReconnectRequest,
   handleSessionJoin,
-  type IServerMatchHostReplayContext,
   sendReplay,
 } from './ServerMatchHostReplay';
 import { ServerMatchSocketLifecycle } from './ServerMatchSocketLifecycle';
@@ -151,31 +160,18 @@ export class ServerMatchHost {
   private isPaused = false;
 
   /**
-   * Wave 5: server-side `CombatOutcomeReady` publish guard. The
-   * `InteractiveSession.tryFinalizeAndPublish` is the primary publisher
-   * (already wired) — this host-side guard is the safety net that
-   * fires when the engine path is bypassed (e.g., closeMatch on a
-   * server-driven shutdown that left the session in `Active` but the
-   * win-condition predicate already trips). Idempotent — once set, no
-   * further publishes happen for this match.
+   * Wave 3a: the roll-capture cluster (source roller + per-intent
+   * `RollCapture` swap + per-event stamping). A dedicated collaborator
+   * so the host stays a thin orchestrator.
    */
-  private hostOutcomePublished = false;
+  private readonly capture: ServerMatchHostCapture;
 
   /**
-   * Per Wave 3a: the source roller (crypto in prod, seeded in debug).
-   * Stable for the entire match lifetime.
+   * Wave 5: server-side `CombatOutcomeReady` publish safety net. A
+   * dedicated collaborator owning the idempotency guard; the host
+   * calls `tryPublish()` from `closeMatch` and the `ForfeitMatch` path.
    */
-  private readonly sourceRoller: IServerDiceRoller;
-
-  /**
-   * Per Wave 3a: the *currently active* `RollCapture`. Reset between
-   * intent ticks via `installFreshCapture()` so each engine call's
-   * consumed rolls land in a buffer scoped to that call. The
-   * `dispatchD6Roller` callback handed to `InteractiveSession` reads
-   * THROUGH this pointer — that's how a fixed callback can target
-   * different capture buffers across intents.
-   */
-  private currentCapture: RollCapture;
+  private readonly outcomePublisher: ServerMatchHostOutcomePublisher;
 
   /**
    * Construct directly from an existing `InteractiveSession`. Used by
@@ -195,8 +191,8 @@ export class ServerMatchHost {
     sourceRoller?: IServerDiceRoller,
   ) {
     this.session = session;
-    this.sourceRoller = sourceRoller ?? new CryptoDiceRoller();
-    this.currentCapture = new RollCapture(this.sourceRoller);
+    this.capture = new ServerMatchHostCapture(sourceRoller);
+    this.outcomePublisher = new ServerMatchHostOutcomePublisher(session);
     this.lifecycle = new ServerMatchSocketLifecycle({
       matchId: this.matchId,
       broadcaster: this.broadcaster,
@@ -236,36 +232,11 @@ export class ServerMatchHost {
   ): ServerMatchHost {
     const { session, sourceRoller, captureRef } = buildHostSession(bootstrap);
     const host = new ServerMatchHost(matchId, store, session, sourceRoller);
-    host.adoptExternalCaptureRef(captureRef);
+    // Re-route the host's capture pointer through the ref the engine
+    // callback closed over, so per-intent swaps stay invisible.
+    host.capture.adoptExternalCaptureRef(captureRef);
     return host;
   }
-
-  /**
-   * Per Wave 3a internal: replace the host's capture pointer with the
-   * one closed over by the engine callback. Without this, the host's
-   * `currentCapture` and the callback's pointer would diverge after the
-   * first swap. Called only from `static create`.
-   */
-  private adoptExternalCaptureRef(ref: { current: RollCapture }): void {
-    // The host's own `currentCapture` is irrelevant once we have an
-    // external ref — we re-route both reads + writes through `ref`.
-    // We do this by overwriting `currentCapture` with the ref's current
-    // value AND replacing the in-memory swap helper to mutate `ref`.
-    this.currentCapture = ref.current;
-    this.captureSwap = (next: RollCapture) => {
-      ref.current = next;
-      this.currentCapture = next;
-    };
-  }
-
-  /**
-   * Default capture swap (no external ref): just update the host field.
-   * Overridden by `adoptExternalCaptureRef` when the session was built
-   * via `static create`.
-   */
-  private captureSwap: (next: RollCapture) => void = (next) => {
-    this.currentCapture = next;
-  };
 
   // ---------------------------------------------------------------------------
   // Socket management
@@ -315,9 +286,15 @@ export class ServerMatchHost {
    * `MatchPaused` (idempotent — broadcast only on first pending peer).
    */
   private async maybeMarkPlayerPending(playerId: string): Promise<void> {
-    await maybeMarkPlayerPending(this.reconnectContext(), playerId);
+    await maybeMarkPlayerPending(
+      buildReconnectContext(this.internals()),
+      playerId,
+    );
   }
 
+  /**
+   * Wave 4: resolve the pause when the last pending peer reconnects.
+   */
   private maybeResume(): void {
     maybeResume({
       matchId: this.matchId,
@@ -328,27 +305,6 @@ export class ServerMatchHost {
       },
       broadcast: (message) => this.broadcast(message),
     });
-  }
-
-  private reconnectContext(): IServerMatchHostReconnectContext {
-    return {
-      matchId: this.matchId,
-      store: this.store,
-      session: this.session,
-      pendingPeers: this.pendingPeers,
-      closed: this.closed,
-      isPaused: this.isPaused,
-      setPaused: (paused) => {
-        this.isPaused = paused;
-      },
-      broadcast: (message) => this.broadcast(message),
-      broadcastEvent: (message) => this.broadcastEvent(message),
-      closeMatch: () => this.closeMatch(),
-      installFreshCapture: () => this.installFreshCapture(),
-      drainNewEvents: () => this.drainNewEvents(),
-      stampRollsOnNewEvents: (events) => this.stampRollsOnNewEvents(events),
-      tryPublishOutcome: () => this.tryPublishOutcome(),
-    };
   }
 
   /**
@@ -364,26 +320,28 @@ export class ServerMatchHost {
   // ---------------------------------------------------------------------------
 
   /**
-   * Send the event history >= `fromSeq` to one socket as a
-   * `ReplayStart` → 0+ `ReplayChunk` → `ReplayEnd` triple. Wave 4
-   * paginates via `streamReplay` (default 64 events per chunk).
-   *
-   * Replay envelopes go ONLY to the requesting socket — they are NOT
-   * broadcast. Live events still go to every attached socket via
-   * `broadcast()`.
+   * Stream the event history >= `fromSeq` to one socket. Delegates to
+   * `ServerMatchHostReplay.sendReplay` (framing + fog filtering there).
    */
   async sendReplay(
     socket: IMatchSocket,
     fromSeq = 0,
     playerId?: string,
   ): Promise<void> {
-    await sendReplay(this.replayContext(), socket, fromSeq, playerId);
+    await sendReplay(
+      buildReplayContext(this.internals()),
+      socket,
+      fromSeq,
+      playerId,
+    );
   }
 
+  /** Read the raw event history >= `seq` (delegates to replay module). */
   async getEventsFromSeq(seq: number): Promise<readonly IGameEvent[]> {
-    return getEventsFromSeq(this.replayContext(), seq);
+    return getEventsFromSeq(buildReplayContext(this.internals()), seq);
   }
 
+  /** Answer a P2P reconnect request (delegates to replay module). */
   async handleReconnectRequest(
     request: IReconnectRequestEnvelope,
     channel: Pick<
@@ -395,13 +353,17 @@ export class ServerMatchHost {
     metadataReader: ReconnectMetadataReader = matchLogStorage,
   ): Promise<void> {
     await handleReconnectRequest(
-      this.replayContext(),
+      buildReplayContext(this.internals()),
       request,
       channel,
       metadataReader,
     );
   }
 
+  /**
+   * Subscribe to reconnect requests on a P2P channel; returns an
+   * unsubscribe function (delegates to replay module).
+   */
   bindReconnectChannel(
     channel: Pick<
       IGameSessionChannel,
@@ -412,9 +374,18 @@ export class ServerMatchHost {
     >,
     metadataReader: ReconnectMetadataReader = matchLogStorage,
   ): () => void {
-    return bindReconnectChannel(this.replayContext(), channel, metadataReader);
+    return bindReconnectChannel(
+      buildReplayContext(this.internals()),
+      channel,
+      metadataReader,
+    );
   }
 
+  /**
+   * Handle a `SessionJoin`: replay history, re-bind seat metadata, and
+   * broadcast `LobbyUpdated`/`MatchResumed` (delegates to replay
+   * module).
+   */
   async handleSessionJoin(
     socket: IMatchSocket,
     playerId: string,
@@ -422,22 +393,12 @@ export class ServerMatchHost {
     requestedMatchId = this.matchId,
   ): Promise<void> {
     await handleSessionJoin(
-      this.replayContext(),
+      buildReplayContext(this.internals()),
       socket,
       playerId,
       lastSeq,
       requestedMatchId,
     );
-  }
-
-  private replayContext(): IServerMatchHostReplayContext {
-    return {
-      matchId: this.matchId,
-      store: this.store,
-      session: this.session,
-      safeSend: (socket, message) => this.safeSend(socket, message),
-      maybeResume: () => this.maybeResume(),
-    };
   }
 
   // ---------------------------------------------------------------------------
@@ -451,22 +412,7 @@ export class ServerMatchHost {
    */
   async handleIntent(envelope: IIntent): Promise<readonly IServerMessage[]> {
     return handleIntentWithContext(
-      {
-        matchId: this.matchId,
-        store: this.store,
-        session: this.session,
-        closed: this.closed,
-        isPaused: this.isPaused,
-        broadcast: (message) => this.broadcast(message),
-        broadcastEvent: (message) => this.broadcastEvent(message),
-        closeMatch: () => this.closeMatch(),
-        handleLobbyIntent: (lobbyEnvelope) =>
-          this.handleLobbyIntent(lobbyEnvelope),
-        installFreshCapture: () => this.installFreshCapture(),
-        drainNewEvents: () => this.drainNewEvents(),
-        stampRollsOnNewEvents: (events) => this.stampRollsOnNewEvents(events),
-        tryPublishOutcome: () => this.tryPublishOutcome(),
-      },
+      buildIntentContext(this.internals()),
       envelope,
     );
   }
@@ -489,9 +435,10 @@ export class ServerMatchHost {
     // Wave 5: last-chance publish before we tear everything down.
     // If the match ended naturally (engine reached Completed) the bus
     // already fired through `InteractiveSession.tryFinalizeAndPublish`
-    // and our local `hostOutcomePublished` guard makes this a no-op.
-    // If the match was force-closed mid-fight (host crash, admin kill)
-    // and the win-condition predicate happens to trip, this catches it.
+    // and the publisher's `hostOutcomePublished` guard makes this a
+    // no-op. If the match was force-closed mid-fight (host crash, admin
+    // kill) and the win-condition predicate happens to trip, this
+    // catches it.
     this.tryPublishOutcome();
     const socketList = this.lifecycle.snapshot();
     for (const socket of socketList) {
@@ -507,58 +454,11 @@ export class ServerMatchHost {
   }
 
   /**
-   * Wave 5: server-side `CombatOutcomeReady` publish helper. Defensive
-   * safety net — `InteractiveSession.tryFinalizeAndPublish` is the
-   * primary path and runs synchronously inside `concede`,
-   * `advancePhase`, `applyAttack`, etc., so by the time `handleIntent`
-   * returns the bus has usually already fired (and our local guard
-   * mirrors the engine's `outcomePublished`). This method exists so
-   * the integration test can prove the bus emits even on the
-   * server-side `closeMatch` path, and so a future code path that
-   * bypasses the engine's lifecycle methods can still feed the
-   * campaign store.
-   *
-   * Behavior:
-   *   - Skip if we've already published from this host.
-   *   - Skip if the engine's own guard already published (we mirror
-   *     by reading `hasPublishedOutcome` so we never double-emit).
-   *   - Skip if the session isn't game-over (most common case).
-   *   - Otherwise, lift the outcome via `getOutcome()` and publish.
-   *
-   * Listener errors don't propagate (the bus swallows them).
+   * Wave 5: delegate to the outcome-publisher safety net. Kept as a
+   * host method so the context builders can pass a stable callback.
    */
   private tryPublishOutcome(): void {
-    if (this.hostOutcomePublished) return;
-    if (this.session.hasPublishedOutcome()) {
-      // Engine already fired; mirror the guard so we don't try again.
-      this.hostOutcomePublished = true;
-      return;
-    }
-    if (!this.session.isGameOver()) return;
-    let outcome;
-    try {
-      outcome = this.session.getOutcome();
-    } catch {
-      // Defensive: derivation should be safe post-game-over, but if
-      // anything throws we don't want to crash the host.
-      return;
-    }
-    // `getOutcome()` itself routes through `tryFinalizeAndPublish`,
-    // which means by the time it returns the engine guard is set and
-    // the bus has fired. Re-check the engine guard so we mirror it.
-    if (this.session.hasPublishedOutcome()) {
-      this.hostOutcomePublished = true;
-      return;
-    }
-    // Defensive belt: the engine guard didn't trip (shouldn't happen)
-    // — publish ourselves. Mark our guard before emitting so a
-    // re-entrant subscriber can't loop.
-    this.hostOutcomePublished = true;
-    const event: ICombatOutcomeReadyEvent = {
-      matchId: outcome.matchId,
-      outcome,
-    };
-    publishCombatOutcome(event);
+    this.outcomePublisher.tryPublish();
   }
 
   /** Test/observability: number of currently-connected sockets. */
@@ -576,6 +476,7 @@ export class ServerMatchHost {
     return this.session.getSession();
   }
 
+  /** Whether `closeMatch` has run. */
   isClosed(): boolean {
     return this.closed;
   }
@@ -601,6 +502,39 @@ export class ServerMatchHost {
   // ---------------------------------------------------------------------------
 
   /**
+   * Assemble the `IServerMatchHostInternals` port the context builders
+   * consume. A fresh object per call so the `closed` / `isPaused`
+   * fields are captured by value at the moment a context is built —
+   * matching the prior inline `*Context()` semantics exactly. All
+   * callbacks are bound arrows so the free-function modules can hold
+   * stable references without `this` rebinding.
+   */
+  private internals(): IServerMatchHostInternals {
+    return {
+      matchId: this.matchId,
+      store: this.store,
+      session: this.session,
+      closed: this.closed,
+      isPaused: this.isPaused,
+      playerRefs: this.playerRefs,
+      pendingPeers: this.pendingPeers,
+      setPaused: (paused) => {
+        this.isPaused = paused;
+      },
+      broadcast: (message) => this.broadcast(message),
+      broadcastEvent: (message) => this.broadcastEvent(message),
+      safeSend: (socket, message) => this.safeSend(socket, message),
+      closeMatch: () => this.closeMatch(),
+      maybeResume: () => this.maybeResume(),
+      installFreshCapture: () => this.installFreshCapture(),
+      drainNewEvents: () => this.drainNewEvents(),
+      stampRollsOnNewEvents: (events) => this.stampRollsOnNewEvents(events),
+      tryPublishOutcome: () => this.tryPublishOutcome(),
+      handleLobbyIntent: (envelope) => this.handleLobbyIntent(envelope),
+    };
+  }
+
+  /**
    * Snapshot any events the engine appended since our last broadcast
    * cursor and advance the cursor. Pure read against the live session.
    */
@@ -614,35 +548,23 @@ export class ServerMatchHost {
   }
 
   /**
-   * Per `add-authoritative-roll-arbitration` (Wave 3a): swap the active
-   * `RollCapture` for a fresh empty one so the next engine call's
-   * consumed rolls land in a clean buffer. Identity of the engine
-   * callback is stable — it reads through `currentCapture`.
+   * Per Wave 3a: swap the active `RollCapture` for a fresh empty one so
+   * the next engine call's consumed rolls land in a clean buffer.
+   * Delegates to the capture collaborator.
    */
   private installFreshCapture(): void {
-    this.captureSwap(new RollCapture(this.sourceRoller));
+    this.capture.installFresh();
   }
 
   /**
    * Per Wave 3a: stamp the captured d6 sequence onto every fresh event
-   * before persistence + broadcast. Strategy: ALL captured rolls land
-   * on the FIRST event whose payload doesn't already carry `rolls`.
-   *
-   * Why first-event attribution: splitting rolls across multiple events
-   * by consumption order requires per-resolver instrumentation (each
-   * resolver would need to drain a slice into its own emitted event).
-   * For Wave 3a MVP we surface the full buffer on the lead event so
-   * clients can render dice without re-rolling — finer-grained
-   * attribution is a follow-up if a resolver emits more than one
-   * dice-bearing event per intent.
-   *
-   * If the buffer is empty (deterministic intent like `Move` or
-   * `AdvancePhase` from a phase that consumes no dice), we no-op.
+   * before persistence + broadcast. Delegates to the capture
+   * collaborator (first-event attribution strategy documented there).
    */
   private stampRollsOnNewEvents(
     events: readonly IGameEvent[],
   ): readonly IGameEvent[] {
-    return stampRollsOnNewEvents(this.currentCapture, events);
+    return this.capture.stampRollsOnNewEvents(events);
   }
 
   /**
@@ -726,19 +648,7 @@ export class ServerMatchHost {
   ): Promise<readonly IServerMessage[]> {
     const wasPaused = this.isPaused;
     const messages = await handleLobbyIntentWithContext(
-      {
-        matchId: this.matchId,
-        store: this.store,
-        session: this.session,
-        playerRefs: this.playerRefs,
-        pendingPeers: this.pendingPeers,
-        broadcast: (message) => this.broadcast(message),
-        broadcastEvent: (message) => this.broadcastEvent(message),
-        maybeResume: () => this.maybeResume(),
-        installFreshCapture: () => this.installFreshCapture(),
-        drainNewEvents: () => this.drainNewEvents(),
-        stampRollsOnNewEvents: (events) => this.stampRollsOnNewEvents(events),
-      },
+      buildLobbyContext(this.internals()),
       envelope,
     );
     if (envelope.intent.kind === 'ForfeitMatch') {

--- a/src/lib/multiplayer/server/ServerMatchHostCapture.ts
+++ b/src/lib/multiplayer/server/ServerMatchHostCapture.ts
@@ -1,0 +1,95 @@
+/**
+ * ServerMatchHostCapture — the Wave 3a authoritative-roll-arbitration
+ * state for one `ServerMatchHost`.
+ *
+ * Why a separate collaborator: the host's roll-capture concern is a
+ * cohesive cluster (a source roller, a per-intent `RollCapture`
+ * pointer, a swap helper that may be re-routed through an engine-owned
+ * ref, and the per-event stamping step). Pulling it out of the host
+ * keeps `ServerMatchHost` a thin orchestrator while preserving the
+ * exact swap/stamp semantics — identity of the engine callback stays
+ * stable because the host hands the engine a closure over a ref, and
+ * this collaborator only ever mutates the value behind that ref.
+ *
+ * Behavior is byte-for-byte identical to the inline host fields it
+ * replaces — this is a pure structural extraction.
+ *
+ * @spec openspec/changes/add-authoritative-roll-arbitration/specs/multiplayer-server/spec.md
+ */
+
+import type { IGameEvent } from '@/types/gameplay/GameSessionInterfaces';
+
+import { CryptoDiceRoller, type IServerDiceRoller } from './CryptoDiceRoller';
+import { RollCapture } from './RollCapture';
+import { stampRollsOnNewEvents } from './ServerMatchHostEvents';
+
+export class ServerMatchHostCapture {
+  /**
+   * The source roller (crypto in prod, seeded in debug). Stable for
+   * the entire match lifetime — every fresh `RollCapture` draws from it.
+   */
+  private readonly sourceRoller: IServerDiceRoller;
+
+  /**
+   * The *currently active* `RollCapture`. Reset between intent ticks
+   * via `installFresh()` so each engine call's consumed rolls land in
+   * a buffer scoped to that call. The `dispatchD6Roller` callback the
+   * host hands to `InteractiveSession` reads THROUGH this pointer.
+   */
+  private currentCapture: RollCapture;
+
+  /**
+   * Default capture swap (no external ref): just update the field.
+   * Overridden by `adoptExternalCaptureRef` when the session was built
+   * via `ServerMatchHost.create`.
+   */
+  private captureSwap: (next: RollCapture) => void = (next) => {
+    this.currentCapture = next;
+  };
+
+  /**
+   * Construct the capture cluster. Falls back to a `CryptoDiceRoller`
+   * when no source roller is supplied, matching the host's prior
+   * inline default.
+   */
+  constructor(sourceRoller?: IServerDiceRoller) {
+    this.sourceRoller = sourceRoller ?? new CryptoDiceRoller();
+    this.currentCapture = new RollCapture(this.sourceRoller);
+  }
+
+  /**
+   * Replace the capture pointer with the one closed over by the engine
+   * callback. Without this, the host's `currentCapture` and the
+   * callback's pointer would diverge after the first swap. Called only
+   * from `ServerMatchHost.create` once the engine ref exists.
+   */
+  adoptExternalCaptureRef(ref: { current: RollCapture }): void {
+    // Re-route both reads + writes through `ref`: seed our pointer with
+    // the ref's current value, then make the swap helper mutate `ref`
+    // so the engine callback and this collaborator never diverge.
+    this.currentCapture = ref.current;
+    this.captureSwap = (next: RollCapture) => {
+      ref.current = next;
+      this.currentCapture = next;
+    };
+  }
+
+  /**
+   * Swap the active `RollCapture` for a fresh empty one so the next
+   * engine call's consumed rolls land in a clean buffer. Identity of
+   * the engine callback is unaffected — it reads through the ref.
+   */
+  installFresh(): void {
+    this.captureSwap(new RollCapture(this.sourceRoller));
+  }
+
+  /**
+   * Stamp the captured d6 sequence onto every fresh event before
+   * persistence + broadcast. Delegates to the shared
+   * `stampRollsOnNewEvents` helper using the live capture buffer; the
+   * first-event attribution strategy is documented there.
+   */
+  stampRollsOnNewEvents(events: readonly IGameEvent[]): readonly IGameEvent[] {
+    return stampRollsOnNewEvents(this.currentCapture, events);
+  }
+}

--- a/src/lib/multiplayer/server/ServerMatchHostContexts.ts
+++ b/src/lib/multiplayer/server/ServerMatchHostContexts.ts
@@ -1,0 +1,158 @@
+/**
+ * ServerMatchHostContexts — pure context-object factories for one
+ * `ServerMatchHost`.
+ *
+ * Why a separate collaborator: each sibling concern (reconnect
+ * lifecycle, replay, intent dispatch, lobby intents) consumes its own
+ * plain context object. Assembling those four objects is mechanical
+ * wiring with zero state of its own — keeping it inline bloated the
+ * host with ~110 lines of boilerplate. These builders take a single
+ * `IServerMatchHostInternals` port (the bits of the host the contexts
+ * need) and produce the exact same context shapes the host built
+ * inline.
+ *
+ * Behavior is identical to the inline `*Context()` methods + the
+ * inline literal objects passed to `handleIntent` / `handleLobbyIntent`
+ * — pure structural extraction.
+ */
+
+import type { InteractiveSession } from '@/engine/InteractiveSession';
+import type { IGameEvent } from '@/types/gameplay/GameSessionInterfaces';
+import type { IPlayerRef } from '@/types/multiplayer/Player';
+import type {
+  IEventMessage,
+  IIntent,
+  IServerMessage,
+} from '@/types/multiplayer/Protocol';
+
+import type { IMatchStore } from './IMatchStore';
+import type { PendingPeerTracker } from './reconnection/PendingPeerTracker';
+import type { IServerMatchHostIntentContext } from './ServerMatchHostIntent';
+import type { IServerMatchHostLobbyContext } from './ServerMatchHostLobbyIntents';
+import type { IServerMatchHostReconnectContext } from './ServerMatchHostReconnectLifecycle';
+import type { IServerMatchHostReplayContext } from './ServerMatchHostReplay';
+import type { IMatchSocket } from './ServerMatchSocketTypes';
+
+/**
+ * The slice of `ServerMatchHost` the context builders need. The host
+ * implements this port; the builders never reach for anything not
+ * declared here, which keeps the host ↔ context coupling explicit and
+ * one-directional.
+ */
+export interface IServerMatchHostInternals {
+  readonly matchId: string;
+  readonly store: IMatchStore;
+  readonly session: InteractiveSession;
+  /** Current closed flag — captured by value into each context. */
+  readonly closed: boolean;
+  /** Current paused flag — captured by value into each context. */
+  readonly isPaused: boolean;
+  readonly playerRefs: ReadonlyMap<string, IPlayerRef>;
+  readonly pendingPeers: PendingPeerTracker;
+  readonly setPaused: (paused: boolean) => void;
+  readonly broadcast: (message: IServerMessage) => void;
+  readonly broadcastEvent: (message: IEventMessage) => Promise<void>;
+  readonly safeSend: (socket: IMatchSocket, message: IServerMessage) => void;
+  readonly closeMatch: () => Promise<void>;
+  readonly maybeResume: () => void;
+  readonly installFreshCapture: () => void;
+  readonly drainNewEvents: () => readonly IGameEvent[];
+  readonly stampRollsOnNewEvents: (
+    events: readonly IGameEvent[],
+  ) => readonly IGameEvent[];
+  readonly tryPublishOutcome: () => void;
+  readonly handleLobbyIntent: (
+    envelope: IIntent,
+  ) => Promise<readonly IServerMessage[]>;
+}
+
+/**
+ * Build the reconnect-lifecycle context: the bits
+ * `maybeMarkPlayerPending` / `maybeResume` and the grace-timeout
+ * handler need to pause/resume a match and drive the engine.
+ */
+export function buildReconnectContext(
+  host: IServerMatchHostInternals,
+): IServerMatchHostReconnectContext {
+  return {
+    matchId: host.matchId,
+    store: host.store,
+    session: host.session,
+    pendingPeers: host.pendingPeers,
+    closed: host.closed,
+    isPaused: host.isPaused,
+    setPaused: host.setPaused,
+    broadcast: host.broadcast,
+    broadcastEvent: host.broadcastEvent,
+    closeMatch: host.closeMatch,
+    installFreshCapture: host.installFreshCapture,
+    drainNewEvents: host.drainNewEvents,
+    stampRollsOnNewEvents: host.stampRollsOnNewEvents,
+    tryPublishOutcome: host.tryPublishOutcome,
+  };
+}
+
+/**
+ * Build the replay context: replay + reconnect-request handlers only
+ * need to read the session, single-send to one socket, and resume.
+ */
+export function buildReplayContext(
+  host: IServerMatchHostInternals,
+): IServerMatchHostReplayContext {
+  return {
+    matchId: host.matchId,
+    store: host.store,
+    session: host.session,
+    safeSend: host.safeSend,
+    maybeResume: host.maybeResume,
+  };
+}
+
+/**
+ * Build the intent-dispatch context: everything `handleIntent` needs
+ * to validate, dispatch into the engine, capture rolls, broadcast, and
+ * route lobby intents back to the host.
+ */
+export function buildIntentContext(
+  host: IServerMatchHostInternals,
+): IServerMatchHostIntentContext {
+  return {
+    matchId: host.matchId,
+    store: host.store,
+    session: host.session,
+    closed: host.closed,
+    isPaused: host.isPaused,
+    broadcast: host.broadcast,
+    broadcastEvent: host.broadcastEvent,
+    closeMatch: host.closeMatch,
+    handleLobbyIntent: host.handleLobbyIntent,
+    installFreshCapture: host.installFreshCapture,
+    drainNewEvents: host.drainNewEvents,
+    stampRollsOnNewEvents: host.stampRollsOnNewEvents,
+    tryPublishOutcome: host.tryPublishOutcome,
+  };
+}
+
+/**
+ * Build the lobby-intent context: lobby intents need the player-ref
+ * cache + pending-peer tracker on top of the engine-dispatch bits, but
+ * NOT `closeMatch`/`tryPublishOutcome` (the host handles the
+ * `ForfeitMatch` outcome publish after the lobby handler returns).
+ */
+export function buildLobbyContext(
+  host: IServerMatchHostInternals,
+): IServerMatchHostLobbyContext {
+  return {
+    matchId: host.matchId,
+    store: host.store,
+    session: host.session,
+    playerRefs: host.playerRefs,
+    pendingPeers: host.pendingPeers,
+    broadcast: host.broadcast,
+    broadcastEvent: host.broadcastEvent,
+    maybeResume: host.maybeResume,
+    installFreshCapture: host.installFreshCapture,
+    drainNewEvents: host.drainNewEvents,
+    stampRollsOnNewEvents: host.stampRollsOnNewEvents,
+  };
+}

--- a/src/lib/multiplayer/server/ServerMatchHostOutcomePublisher.ts
+++ b/src/lib/multiplayer/server/ServerMatchHostOutcomePublisher.ts
@@ -1,0 +1,94 @@
+/**
+ * ServerMatchHostOutcomePublisher — the Wave 5 server-side
+ * `CombatOutcomeReady` publish safety net for one `ServerMatchHost`.
+ *
+ * Why a separate collaborator: outcome publishing is a self-contained
+ * Wave 5 responsibility with its own idempotency guard. Extracting it
+ * keeps `ServerMatchHost` a thin orchestrator while preserving the
+ * exact double-emit protection — the host now owns one of these and
+ * calls `tryPublish()` from `closeMatch` and the `ForfeitMatch` path.
+ *
+ * Behavior is identical to the inline `tryPublishOutcome` method it
+ * replaces — pure structural extraction.
+ *
+ * @spec openspec/changes/add-multiplayer-server-infrastructure/specs/multiplayer-server/spec.md
+ */
+
+import type { InteractiveSession } from '@/engine/InteractiveSession';
+
+import {
+  publishCombatOutcome,
+  type ICombatOutcomeReadyEvent,
+} from '@/engine/combatOutcomeBus';
+
+export class ServerMatchHostOutcomePublisher {
+  /**
+   * Server-side `CombatOutcomeReady` publish guard. The
+   * `InteractiveSession.tryFinalizeAndPublish` is the primary
+   * publisher (already wired) — this host-side guard is the safety net
+   * that fires when the engine path is bypassed (e.g. `closeMatch` on
+   * a server-driven shutdown). Idempotent — once set, no further
+   * publishes happen for this match.
+   */
+  private hostOutcomePublished = false;
+
+  /**
+   * Hold the session so the publisher can re-check the engine's own
+   * `outcomePublished` guard and lift the outcome on game-over.
+   */
+  constructor(private readonly session: InteractiveSession) {}
+
+  /**
+   * Defensive `CombatOutcomeReady` publish helper.
+   * `InteractiveSession.tryFinalizeAndPublish` is the primary path and
+   * runs synchronously inside `concede`, `advancePhase`, `applyAttack`,
+   * etc., so by the time the host's `handleIntent` returns the bus has
+   * usually already fired (and this local guard mirrors the engine's
+   * `outcomePublished`). This method exists so the integration test
+   * can prove the bus emits even on the server-side `closeMatch` path,
+   * and so a future code path that bypasses the engine's lifecycle
+   * methods can still feed the campaign store.
+   *
+   * Behavior:
+   *   - Skip if we've already published from this host.
+   *   - Skip if the engine's own guard already published (we mirror
+   *     by reading `hasPublishedOutcome` so we never double-emit).
+   *   - Skip if the session isn't game-over (most common case).
+   *   - Otherwise, lift the outcome via `getOutcome()` and publish.
+   *
+   * Listener errors don't propagate (the bus swallows them).
+   */
+  tryPublish(): void {
+    if (this.hostOutcomePublished) return;
+    if (this.session.hasPublishedOutcome()) {
+      // Engine already fired; mirror the guard so we don't try again.
+      this.hostOutcomePublished = true;
+      return;
+    }
+    if (!this.session.isGameOver()) return;
+    let outcome;
+    try {
+      outcome = this.session.getOutcome();
+    } catch {
+      // Defensive: derivation should be safe post-game-over, but if
+      // anything throws we don't want to crash the host.
+      return;
+    }
+    // `getOutcome()` itself routes through `tryFinalizeAndPublish`,
+    // which means by the time it returns the engine guard is set and
+    // the bus has fired. Re-check the engine guard so we mirror it.
+    if (this.session.hasPublishedOutcome()) {
+      this.hostOutcomePublished = true;
+      return;
+    }
+    // Defensive belt: the engine guard didn't trip (shouldn't happen)
+    // — publish ourselves. Mark our guard before emitting so a
+    // re-entrant subscriber can't loop.
+    this.hostOutcomePublished = true;
+    const event: ICombatOutcomeReadyEvent = {
+      matchId: outcome.matchId,
+      outcome,
+    };
+    publishCombatOutcome(event);
+  }
+}

--- a/src/simulation/runner/phases/weaponAttackHitResolution.helpers.ts
+++ b/src/simulation/runner/phases/weaponAttackHitResolution.helpers.ts
@@ -1,0 +1,438 @@
+import {
+  GameEventType,
+  GamePhase,
+  IGameEvent,
+  IGameState,
+} from '@/types/gameplay';
+import { consumeAmmo, isEnergyWeapon } from '@/utils/gameplay/ammoTracking';
+import { resolveDamage } from '@/utils/gameplay/damage';
+import { createDamagePSR } from '@/utils/gameplay/pilotingSkillRolls';
+
+import type { IWeapon } from '../../ai/types';
+
+import { DAMAGE_PSR_THRESHOLD } from '../SimulationRunnerConstants';
+import { createGameEvent } from './utils';
+import { weaponTypeFromMountId } from './weaponAttackHelpers';
+
+/**
+ * Canonical `UnitDestroyed` cause taxonomy. Extracted as a named alias
+ * so the resolution phase and its helpers share one definition instead
+ * of repeating the seven-member union at every call site (it appears in
+ * both `emitCritEvents` and `applyCritAmmoExplosions` today).
+ */
+export type DestructionCause =
+  | 'damage'
+  | 'ammo_explosion'
+  | 'pilot_death'
+  | 'engine_destroyed'
+  | 'shutdown'
+  | 'ct_destroyed'
+  | 'head_destroyed';
+
+/**
+ * The shape returned by `resolveDamage`. Aliased via `ReturnType` so the
+ * extracted helpers can accept a fully-typed damage result without
+ * importing the resolver's internal `IResolveDamageResult` interface.
+ */
+type DamageResolution = ReturnType<typeof resolveDamage>;
+
+/**
+ * Partial Cover Leg-Hit Conversion (Total Warfare p. 53): when the target
+ * is in partial cover, a hit that rolls a leg location is absorbed by the
+ * cover and resolves as a miss — no damage applies. Emits an
+ * `AttackResolved` event shaped exactly like a normal miss (`hit: false`,
+ * no `location`) so the `AttackDeclared`/`AttackResolved` count invariant
+ * holds. Extracted from `resolveWeaponHit` so the early-return miss path
+ * stays a single self-describing call.
+ */
+export function emitCoveredLegMiss(options: {
+  events: IGameEvent[];
+  gameId: string;
+  turn: number;
+  attackerId: string;
+  targetId: string;
+  weaponId: string;
+  weapon: IWeapon;
+  attackRoll: number;
+  toHitNumber: number;
+  firingArc: 'front' | 'left' | 'right' | 'rear';
+}): void {
+  const {
+    events,
+    gameId,
+    turn,
+    attackerId,
+    targetId,
+    weaponId,
+    weapon,
+    attackRoll,
+    toHitNumber,
+    firingArc,
+  } = options;
+
+  events.push(
+    createGameEvent(
+      gameId,
+      events.length,
+      GameEventType.AttackResolved,
+      turn,
+      GamePhase.WeaponAttack,
+      {
+        attackerId,
+        targetId,
+        weaponId,
+        roll: attackRoll,
+        toHitNumber,
+        hit: false,
+        heat: weapon.heat,
+        attackerArc: firingArc,
+      },
+      attackerId,
+    ),
+  );
+}
+
+/**
+ * Per `add-combat-fidelity-suite` Phase 4 (`combat-resolution` delta —
+ * Ammo Consumption and Explosion Events): when a non-energy weapon fires,
+ * decrement its ammo bin and emit `AmmoConsumed`. Energy weapons (laser /
+ * PPC / flamer / plasma) are skipped via `isEnergyWeapon`. When the unit
+ * has no `ammoState` populated (synthetic test fixtures, legacy session)
+ * the consumption is silently skipped — pre-P4 behaviour preserved.
+ *
+ * Extracted from `resolveWeaponHit` so the ammo-consumption branch reads
+ * as one cohesive step. Returns the (possibly updated) game state; the
+ * `AmmoConsumed` event is appended to `events` in place.
+ */
+export function consumeWeaponAmmo(options: {
+  currentState: IGameState;
+  events: IGameEvent[];
+  gameId: string;
+  attackerId: string;
+  weapon: IWeapon;
+}): IGameState {
+  const { events, gameId, attackerId, weapon } = options;
+  let { currentState } = options;
+
+  const attackerForAmmo = currentState.units[attackerId];
+  const ammoStateBefore = attackerForAmmo.ammoState;
+  if (
+    ammoStateBefore !== undefined &&
+    Object.keys(ammoStateBefore).length > 0 &&
+    !isEnergyWeapon(weapon.name)
+  ) {
+    const baseWeaponType = weaponTypeFromMountId(weapon.id);
+    const ammoResult = consumeAmmo(ammoStateBefore, attackerId, baseWeaponType);
+    if (ammoResult) {
+      currentState = {
+        ...currentState,
+        units: {
+          ...currentState.units,
+          [attackerId]: {
+            ...currentState.units[attackerId],
+            ammoState: ammoResult.updatedAmmoState,
+          },
+        },
+      };
+      events.push(
+        createGameEvent(
+          gameId,
+          events.length,
+          GameEventType.AmmoConsumed,
+          currentState.turn,
+          GamePhase.WeaponAttack,
+          {
+            unitId: attackerId,
+            binId: ammoResult.event.binId,
+            weaponType: ammoResult.event.weaponType,
+            roundsConsumed: ammoResult.event.roundsConsumed,
+            roundsRemaining: ammoResult.event.roundsRemaining,
+          },
+          attackerId,
+        ),
+      );
+    }
+  }
+
+  return currentState;
+}
+
+/**
+ * Per `combat-resolution` delta + `damage-system` delta: walk the ordered
+ * `locationDamages` chain and emit `DamageApplied` → `LocationDestroyed`
+ * (when zeroed) → `TransferDamage` (when residual flows). Mirrors the
+ * `gameSessionAttackResolution.ts` emission pattern (the session-layer
+ * twin of this runner phase) so replay consumers see the same event
+ * sequence regardless of which engine produced the trace.
+ *
+ * Side-torso → arm cascade: `applyDamageToLocation` zeroes the
+ * corresponding arm's armor/structure and pushes it onto
+ * `destroyedLocations`. The pre/post-state diff (`newlyDestroyed`) is
+ * computed by the caller and passed in so the cascade-arm
+ * `LocationDestroyed` event carries the right `cascadedTo` linkage AND
+ * its own follow-up event.
+ *
+ * Extracted from `resolveWeaponHit` — this loop was the single largest
+ * block in the function. Events are appended to `events` in place.
+ */
+export function emitDamageChainEvents(options: {
+  events: IGameEvent[];
+  gameId: string;
+  turn: number;
+  attackerId: string;
+  targetId: string;
+  damageResult: DamageResolution;
+  newlyDestroyed: readonly string[];
+}): void {
+  const {
+    events,
+    gameId,
+    turn,
+    attackerId,
+    targetId,
+    damageResult,
+    newlyDestroyed,
+  } = options;
+
+  const locationDamages = damageResult.result.locationDamages;
+  for (let i = 0; i < locationDamages.length; i++) {
+    const locDmg = locationDamages[i];
+    const isTransferStep = i > 0;
+
+    events.push(
+      createGameEvent(
+        gameId,
+        events.length,
+        GameEventType.DamageApplied,
+        turn,
+        GamePhase.WeaponAttack,
+        {
+          unitId: targetId,
+          location: locDmg.location,
+          damage: locDmg.damage,
+          armorRemaining: locDmg.armorRemaining,
+          structureRemaining: locDmg.structureRemaining,
+          locationDestroyed: locDmg.destroyed,
+          sourceUnitId: attackerId,
+        },
+        attackerId,
+      ),
+    );
+
+    if (locDmg.destroyed) {
+      // Detect the side-torso → arm cascade off the post-damage state
+      // diff. Only side torsos can cascade an arm.
+      let cascadedArm: string | undefined;
+      if (
+        locDmg.location === 'left_torso' &&
+        newlyDestroyed.includes('left_arm')
+      ) {
+        cascadedArm = 'left_arm';
+      } else if (
+        locDmg.location === 'right_torso' &&
+        newlyDestroyed.includes('right_arm')
+      ) {
+        cascadedArm = 'right_arm';
+      }
+
+      events.push(
+        createGameEvent(
+          gameId,
+          events.length,
+          GameEventType.LocationDestroyed,
+          turn,
+          GamePhase.WeaponAttack,
+          {
+            unitId: targetId,
+            location: locDmg.location,
+            cascadedTo: cascadedArm,
+            viaTransfer: isTransferStep,
+          },
+          attackerId,
+        ),
+      );
+
+      // Cascade arm gets its own LocationDestroyed event so downstream
+      // consumers (UI, replay, metrics) don't have to dedupe off the
+      // parent. `viaTransfer` is `false` because this is a structural
+      // cascade — the arm wasn't reached by residual damage flowing
+      // through the transfer chain, it was carried off by its parent
+      // torso.
+      if (cascadedArm) {
+        events.push(
+          createGameEvent(
+            gameId,
+            events.length,
+            GameEventType.LocationDestroyed,
+            turn,
+            GamePhase.WeaponAttack,
+            {
+              unitId: targetId,
+              location: cascadedArm,
+              viaTransfer: false,
+            },
+            attackerId,
+          ),
+        );
+      }
+    }
+
+    if (locDmg.transferredDamage > 0 && locDmg.transferLocation) {
+      events.push(
+        createGameEvent(
+          gameId,
+          events.length,
+          GameEventType.TransferDamage,
+          turn,
+          GamePhase.WeaponAttack,
+          {
+            unitId: targetId,
+            fromLocation: locDmg.location,
+            toLocation: locDmg.transferLocation,
+            damage: locDmg.transferredDamage,
+          },
+          attackerId,
+        ),
+      );
+    }
+  }
+}
+
+/**
+ * Per `combat-resolution` delta: emit a `PilotHit` event when raw head-hit
+ * damage inflicted pilot wounds. Suppressed when `emitCritEvents` already
+ * emitted a `pilot_hit` for this shot (cockpit-crit path) so the wound is
+ * not double-counted. Extracted from `resolveWeaponHit` to keep the
+ * de-dupe condition co-located with its emission.
+ */
+export function emitHeadHitPilotEvent(options: {
+  events: IGameEvent[];
+  gameId: string;
+  turn: number;
+  attackerId: string;
+  targetId: string;
+  damageResult: DamageResolution;
+}): void {
+  const { events, gameId, turn, attackerId, targetId, damageResult } = options;
+
+  const pilotDamageResult = damageResult.result.pilotDamage;
+  if (pilotDamageResult && pilotDamageResult.woundsInflicted > 0) {
+    const alreadyEmittedFromCrit =
+      damageResult.criticalEvents?.some((e) => e.type === 'pilot_hit') ?? false;
+    if (!alreadyEmittedFromCrit) {
+      events.push(
+        createGameEvent(
+          gameId,
+          events.length,
+          GameEventType.PilotHit,
+          turn,
+          GamePhase.WeaponAttack,
+          {
+            unitId: targetId,
+            wounds: pilotDamageResult.woundsInflicted,
+            totalWounds: pilotDamageResult.totalWounds,
+            source: 'head_hit' as const,
+            consciousnessCheckRequired:
+              pilotDamageResult.consciousnessCheckRequired,
+            consciousnessCheckPassed: pilotDamageResult.conscious,
+          },
+          attackerId,
+        ),
+      );
+    }
+  }
+}
+
+/**
+ * Emit `UnitDestroyed` once if the shot killed the target. The cause is
+ * sourced in priority order: (1) crit-induced destruction (engine 3-hit,
+ * cockpit hit) captured by `emitCritEvents`/`applyCritAmmoExplosions`;
+ * (2) raw damage destruction (CT zeroed, head zeroed) falling through with
+ * the resolver's `destructionCause`. Never emits a second `UnitDestroyed`
+ * when the target was already destroyed before this shot (multi-mount fire
+ * after the kill shot in the same volley). Extracted from `resolveWeaponHit`
+ * so the kill-detection guard reads as one step.
+ */
+export function emitUnitDestroyedEvent(options: {
+  events: IGameEvent[];
+  gameId: string;
+  turn: number;
+  attackerId: string;
+  targetId: string;
+  targetWasDestroyed: boolean;
+  targetIsDestroyed: boolean;
+  damageResult: DamageResolution;
+  critUnitDestroyed: boolean;
+  critDestructionCause: DestructionCause | undefined;
+}): void {
+  const {
+    events,
+    gameId,
+    turn,
+    attackerId,
+    targetId,
+    targetWasDestroyed,
+    targetIsDestroyed,
+    damageResult,
+    critUnitDestroyed,
+    critDestructionCause,
+  } = options;
+
+  if (targetIsDestroyed && !targetWasDestroyed) {
+    const fallbackCause = damageResult.result.destructionCause ?? 'damage';
+    const cause: DestructionCause =
+      critUnitDestroyed && critDestructionCause
+        ? critDestructionCause
+        : fallbackCause;
+    events.push(
+      createGameEvent(
+        gameId,
+        events.length,
+        GameEventType.UnitDestroyed,
+        turn,
+        GamePhase.WeaponAttack,
+        {
+          unitId: targetId,
+          cause,
+          killerUnitId: attackerId,
+        },
+      ),
+    );
+  }
+}
+
+/**
+ * Per the `piloting-skill-rolls` delta: when a surviving target has
+ * accumulated `DAMAGE_PSR_THRESHOLD` (20+) damage this phase, queue a
+ * `20+_damage` piloting skill roll. Idempotent — only one damage PSR is
+ * queued per phase even across a multi-weapon volley. Extracted from
+ * `resolveWeaponHit`; returns the (possibly updated) game state.
+ */
+export function applyDamageThresholdPSR(
+  currentState: IGameState,
+  targetId: string,
+): IGameState {
+  const targetPostDamage = currentState.units[targetId];
+  if (
+    !targetPostDamage.destroyed &&
+    (targetPostDamage.damageThisPhase ?? 0) >= DAMAGE_PSR_THRESHOLD
+  ) {
+    const existingPSRs = targetPostDamage.pendingPSRs ?? [];
+    const hasDamagePSR = existingPSRs.some(
+      (pendingPSR) => pendingPSR.triggerSource === '20+_damage',
+    );
+    if (!hasDamagePSR) {
+      return {
+        ...currentState,
+        units: {
+          ...currentState.units,
+          [targetId]: {
+            ...targetPostDamage,
+            pendingPSRs: [...existingPSRs, createDamagePSR(targetId)],
+          },
+        },
+      };
+    }
+  }
+  return currentState;
+}

--- a/src/simulation/runner/phases/weaponAttackHitResolution.ts
+++ b/src/simulation/runner/phases/weaponAttackHitResolution.ts
@@ -6,7 +6,6 @@ import {
   IGameEvent,
   IGameState,
 } from '@/types/gameplay';
-import { consumeAmmo, isEnergyWeapon } from '@/utils/gameplay/ammoTracking';
 import { resolveDamage } from '@/utils/gameplay/damage';
 import { buildDefaultComponentDamageState } from '@/utils/gameplay/gameSessionAttackResolutionHelpers';
 import {
@@ -14,26 +13,37 @@ import {
   isHeadHit,
   isLegLocation,
 } from '@/utils/gameplay/hitLocation';
-import { createDamagePSR } from '@/utils/gameplay/pilotingSkillRolls';
 
 import type { IWeapon } from '../../ai/types';
 
-import {
-  DAMAGE_PSR_THRESHOLD,
-  HEAD_HIT_DAMAGE_CAP,
-} from '../SimulationRunnerConstants';
+import { HEAD_HIT_DAMAGE_CAP } from '../SimulationRunnerConstants';
 import {
   applyDamageResultToState,
   buildDamageState,
 } from '../SimulationRunnerState';
 import { createGameEvent } from './utils';
 import { applyCritAmmoExplosions } from './weaponAttackAmmoExplosions';
+import { emitCritEvents, toFiringArc } from './weaponAttackHelpers';
 import {
-  emitCritEvents,
-  toFiringArc,
-  weaponTypeFromMountId,
-} from './weaponAttackHelpers';
+  DestructionCause,
+  applyDamageThresholdPSR,
+  consumeWeaponAmmo,
+  emitCoveredLegMiss,
+  emitDamageChainEvents,
+  emitHeadHitPilotEvent,
+  emitUnitDestroyedEvent,
+} from './weaponAttackHitResolution.helpers';
 
+/**
+ * Resolve a single confirmed weapon hit against a target unit: roll the
+ * hit location, apply damage (with crit dispatch), emit the full event
+ * chain (`AttackResolved` → `AmmoConsumed` → `DamageApplied` /
+ * `LocationDestroyed` / `TransferDamage` → crit events → `AmmoExplosion`
+ * → `PilotHit` → `UnitDestroyed`), and queue any 20+-damage piloting
+ * skill roll. The cohesive sub-steps (ammo consumption, damage-chain
+ * emission, pilot-hit, kill detection, PSR queueing) are delegated to
+ * `weaponAttackHitResolution.helpers.ts`. Returns the updated game state.
+ */
 export function resolveWeaponHit(options: {
   currentState: IGameState;
   events: IGameEvent[];
@@ -83,31 +93,20 @@ export function resolveWeaponHit(options: {
   // Partial Cover Leg-Hit Conversion (Total Warfare p. 53): when the target
   // is in partial cover, a hit that rolls a leg location is absorbed by the
   // cover and resolves as a miss — no damage applies. The hit-location roll
-  // is still consumed (above) so the dice stream stays deterministic. An
-  // `AttackResolved` event is emitted with `hit: false` and no `location`,
-  // matching the shape of a normal miss so the
-  // `AttackDeclared`/`AttackResolved` count invariant holds.
+  // is still consumed (above) so the dice stream stays deterministic.
   if (partialCover && isLegLocation(location)) {
-    events.push(
-      createGameEvent(
-        gameId,
-        events.length,
-        GameEventType.AttackResolved,
-        currentState.turn,
-        GamePhase.WeaponAttack,
-        {
-          attackerId: unitId,
-          targetId,
-          weaponId,
-          roll: attackRoll,
-          toHitNumber,
-          hit: false,
-          heat: weapon.heat,
-          attackerArc: firingArc,
-        },
-        unitId,
-      ),
-    );
+    emitCoveredLegMiss({
+      events,
+      gameId,
+      turn: currentState.turn,
+      attackerId: unitId,
+      targetId,
+      weaponId,
+      weapon,
+      attackRoll,
+      toHitNumber,
+      firingArc,
+    });
     return currentState;
   }
 
@@ -216,198 +215,40 @@ export function resolveWeaponHit(options: {
     ),
   );
 
-  // Per `add-combat-fidelity-suite` Phase 4 (`combat-resolution`
-  // delta — Ammo Consumption and Explosion Events): when a
-  // non-energy weapon fires, decrement its ammo bin and emit
-  // `AmmoConsumed`. Energy weapons (laser / PPC / flamer / plasma)
-  // skip this branch via `isEnergyWeapon`. When the unit has no
-  // `ammoState` populated (synthetic test fixtures, legacy
-  // session) the consumption is silently skipped — pre-P4
-  // behaviour preserved.
-  const attackerForAmmo = currentState.units[unitId];
-  const ammoStateBefore = attackerForAmmo.ammoState;
-  if (
-    ammoStateBefore !== undefined &&
-    Object.keys(ammoStateBefore).length > 0 &&
-    !isEnergyWeapon(weapon.name)
-  ) {
-    const baseWeaponType = weaponTypeFromMountId(weapon.id);
-    const ammoResult = consumeAmmo(ammoStateBefore, unitId, baseWeaponType);
-    if (ammoResult) {
-      currentState = {
-        ...currentState,
-        units: {
-          ...currentState.units,
-          [unitId]: {
-            ...currentState.units[unitId],
-            ammoState: ammoResult.updatedAmmoState,
-          },
-        },
-      };
-      events.push(
-        createGameEvent(
-          gameId,
-          events.length,
-          GameEventType.AmmoConsumed,
-          currentState.turn,
-          GamePhase.WeaponAttack,
-          {
-            unitId,
-            binId: ammoResult.event.binId,
-            weaponType: ammoResult.event.weaponType,
-            roundsConsumed: ammoResult.event.roundsConsumed,
-            roundsRemaining: ammoResult.event.roundsRemaining,
-          },
-          unitId,
-        ),
-      );
-    }
-  }
+  // Decrement the firing weapon's ammo bin and emit `AmmoConsumed`
+  // (non-energy weapons only). See `consumeWeaponAmmo`.
+  currentState = consumeWeaponAmmo({
+    currentState,
+    events,
+    gameId,
+    attackerId: unitId,
+    weapon,
+  });
 
-  // Per `combat-resolution` delta + `damage-system` delta: walk the
-  // ordered `locationDamages` chain and emit `DamageApplied` →
-  // `LocationDestroyed` (when zeroed) → `TransferDamage` (when
-  // residual flows). Mirrors the existing
-  // `gameSessionAttackResolution.ts` emission pattern (the
-  // session-layer twin of this runner phase) so replay consumers
-  // see the same event sequence regardless of which engine
-  // produced the trace.
-  //
-  // Side-torso → arm cascade: `applyDamageToLocation` zeroes the
-  // corresponding arm's armor/structure and pushes it onto
-  // `destroyedLocations`. We diff the pre/post-state sets so the
-  // cascade-arm `LocationDestroyed` event carries the right
-  // `cascadedTo` linkage AND its own follow-up event.
+  // Walk the ordered `locationDamages` chain and emit `DamageApplied` →
+  // `LocationDestroyed` → `TransferDamage`. The side-torso → arm cascade
+  // is detected off the pre/post-state `destroyedLocations` diff.
   const preDestroyedSet = new Set<string>(damageState.destroyedLocations);
   const newlyDestroyed = damageResult.state.destroyedLocations.filter(
     (loc) => !preDestroyedSet.has(loc),
   );
-
-  const locationDamages = damageResult.result.locationDamages;
-  for (let i = 0; i < locationDamages.length; i++) {
-    const locDmg = locationDamages[i];
-    const isTransferStep = i > 0;
-
-    events.push(
-      createGameEvent(
-        gameId,
-        events.length,
-        GameEventType.DamageApplied,
-        currentState.turn,
-        GamePhase.WeaponAttack,
-        {
-          unitId: targetId,
-          location: locDmg.location,
-          damage: locDmg.damage,
-          armorRemaining: locDmg.armorRemaining,
-          structureRemaining: locDmg.structureRemaining,
-          locationDestroyed: locDmg.destroyed,
-          sourceUnitId: unitId,
-        },
-        unitId,
-      ),
-    );
-
-    if (locDmg.destroyed) {
-      // Detect the side-torso → arm cascade off the post-damage
-      // state diff. Only side torsos can cascade an arm.
-      let cascadedArm: string | undefined;
-      if (
-        locDmg.location === 'left_torso' &&
-        newlyDestroyed.includes('left_arm')
-      ) {
-        cascadedArm = 'left_arm';
-      } else if (
-        locDmg.location === 'right_torso' &&
-        newlyDestroyed.includes('right_arm')
-      ) {
-        cascadedArm = 'right_arm';
-      }
-
-      events.push(
-        createGameEvent(
-          gameId,
-          events.length,
-          GameEventType.LocationDestroyed,
-          currentState.turn,
-          GamePhase.WeaponAttack,
-          {
-            unitId: targetId,
-            location: locDmg.location,
-            cascadedTo: cascadedArm,
-            viaTransfer: isTransferStep,
-          },
-          unitId,
-        ),
-      );
-
-      // Cascade arm gets its own LocationDestroyed event so
-      // downstream consumers (UI, replay, metrics) don't have to
-      // dedupe off the parent. `viaTransfer` is `false` because
-      // this is a structural cascade — the arm wasn't reached by
-      // residual damage flowing through the transfer chain, it
-      // was carried off by its parent torso.
-      if (cascadedArm) {
-        events.push(
-          createGameEvent(
-            gameId,
-            events.length,
-            GameEventType.LocationDestroyed,
-            currentState.turn,
-            GamePhase.WeaponAttack,
-            {
-              unitId: targetId,
-              location: cascadedArm,
-              viaTransfer: false,
-            },
-            unitId,
-          ),
-        );
-      }
-    }
-
-    if (locDmg.transferredDamage > 0 && locDmg.transferLocation) {
-      events.push(
-        createGameEvent(
-          gameId,
-          events.length,
-          GameEventType.TransferDamage,
-          currentState.turn,
-          GamePhase.WeaponAttack,
-          {
-            unitId: targetId,
-            fromLocation: locDmg.location,
-            toLocation: locDmg.transferLocation,
-            damage: locDmg.transferredDamage,
-          },
-          unitId,
-        ),
-      );
-    }
-  }
+  emitDamageChainEvents({
+    events,
+    gameId,
+    turn: currentState.turn,
+    attackerId: unitId,
+    targetId,
+    damageResult,
+    newlyDestroyed,
+  });
 
   // Per `add-combat-fidelity-suite` Phase 3: emit the crit chain
-  // produced by `resolveCriticalHits` (via `resolveDamage`). Each
-  // resolved slot fans out into:
-  //   `CriticalHit { component, count: 1 }` (per slot)
-  //   → `CriticalHitResolved { slotIndex, componentType, ... }`
-  //   → `ComponentDestroyed { componentType, slotIndex }` (when
-  //     the slot is fully destroyed — always today)
-  //   → `PSRTriggered` (gyro hit cascades)
-  //   → `PilotHit` (cockpit / head hit)
-  // Causal ordering: AFTER the full damage chain
-  // (DamageApplied → LocationDestroyed → TransferDamage) and
-  // BEFORE the `UnitDestroyed` event the runner emits below.
+  // produced by `resolveCriticalHits` (via `resolveDamage`). Causal
+  // ordering: AFTER the full damage chain (DamageApplied →
+  // LocationDestroyed → TransferDamage) and BEFORE the `UnitDestroyed`
+  // event emitted below.
   let critUnitDestroyed = false;
-  let critDestructionCause:
-    | 'damage'
-    | 'ammo_explosion'
-    | 'pilot_death'
-    | 'engine_destroyed'
-    | 'shutdown'
-    | 'ct_destroyed'
-    | 'head_destroyed'
-    | undefined = undefined;
+  let critDestructionCause: DestructionCause | undefined = undefined;
   if (damageResult.criticalEvents) {
     const emitted = emitCritEvents({
       events,
@@ -423,22 +264,10 @@ export function resolveWeaponHit(options: {
     critDestructionCause = emitted.destructionCause;
   }
 
-  // Per `add-combat-fidelity-suite` Phase 4 (`combat-resolution`
-  // delta — Heat Lifecycle / `ammo-explosion-system` delta —
-  // Critical Hit on Loaded Bin): when the resolver flagged an
-  // ammo slot as destroyed, emit `AmmoExplosion` and apply the
-  // explosion damage to the bin's location. CASE / CASE-II flags
-  // are not yet wired into `IUnitGameState` (deferred follow-up
-  // documented in `notepad/issues.md`); without CASE, the
-  // explosion damage cascades through the canonical transfer
-  // chain via a second `resolveDamage` call. Causal order:
-  //   `ComponentDestroyed { component: 'ammo' }` (already emitted
-  //   by emitCritEvents)
-  //   → `AmmoExplosion`
-  //   → `DamageApplied` to bin location (cascade)
-  //   → `LocationDestroyed` (if survives)
-  //   → `TransferDamage` (if no CASE)
-  //   → `UnitDestroyed` (if cascade reaches CT).
+  // Per `add-combat-fidelity-suite` Phase 4 (`ammo-explosion-system`
+  // delta): when the resolver flagged an ammo slot as destroyed, emit
+  // `AmmoExplosion` and cascade the explosion damage through the
+  // canonical transfer chain. May itself destroy the unit.
   const ammoExplosionResult = applyCritAmmoExplosions({
     currentState,
     events,
@@ -455,94 +284,34 @@ export function resolveWeaponHit(options: {
   critUnitDestroyed = ammoExplosionResult.critUnitDestroyed;
   critDestructionCause = ammoExplosionResult.critDestructionCause;
 
-  const pilotDamageResult = damageResult.result.pilotDamage;
-  if (pilotDamageResult && pilotDamageResult.woundsInflicted > 0) {
-    const alreadyEmittedFromCrit =
-      damageResult.criticalEvents?.some((e) => e.type === 'pilot_hit') ?? false;
-    if (!alreadyEmittedFromCrit) {
-      events.push(
-        createGameEvent(
-          gameId,
-          events.length,
-          GameEventType.PilotHit,
-          currentState.turn,
-          GamePhase.WeaponAttack,
-          {
-            unitId: targetId,
-            wounds: pilotDamageResult.woundsInflicted,
-            totalWounds: pilotDamageResult.totalWounds,
-            source: 'head_hit' as const,
-            consciousnessCheckRequired:
-              pilotDamageResult.consciousnessCheckRequired,
-            consciousnessCheckPassed: pilotDamageResult.conscious,
-          },
-          unitId,
-        ),
-      );
-    }
-  }
+  // Emit `PilotHit` for raw head-hit wounds (suppressed when a
+  // cockpit-crit already emitted one).
+  emitHeadHitPilotEvent({
+    events,
+    gameId,
+    turn: currentState.turn,
+    attackerId: unitId,
+    targetId,
+    damageResult,
+  });
 
-  // Emit `UnitDestroyed` once if the shot killed the target. The
-  // cause is sourced (in priority order):
-  //   1. crit-induced destruction (engine 3-hit → engine_destroyed,
-  //      cockpit hit → pilot_death) — captured by the helper above.
-  //   2. raw damage destruction (CT zeroed, head zeroed by armor
-  //      depletion) — falls through with cause 'damage' and the
-  //      `damageResult.result.destructionCause` enum.
-  // Never emit a second `UnitDestroyed` if the target was already
-  // destroyed before this shot (multi-mount fire after the kill
-  // shot in the same volley).
-  if (currentState.units[targetId].destroyed && !targetBefore.destroyed) {
-    const fallbackCause = damageResult.result.destructionCause ?? 'damage';
-    const cause:
-      | 'damage'
-      | 'ammo_explosion'
-      | 'pilot_death'
-      | 'engine_destroyed'
-      | 'shutdown'
-      | 'ct_destroyed'
-      | 'head_destroyed' =
-      critUnitDestroyed && critDestructionCause
-        ? critDestructionCause
-        : fallbackCause;
-    events.push(
-      createGameEvent(
-        gameId,
-        events.length,
-        GameEventType.UnitDestroyed,
-        currentState.turn,
-        GamePhase.WeaponAttack,
-        {
-          unitId: targetId,
-          cause,
-          killerUnitId: unitId,
-        },
-      ),
-    );
-  }
+  // Emit `UnitDestroyed` once if the shot killed the target, sourcing
+  // the cause from crit destruction first, then raw damage.
+  emitUnitDestroyedEvent({
+    events,
+    gameId,
+    turn: currentState.turn,
+    attackerId: unitId,
+    targetId,
+    targetWasDestroyed: targetBefore.destroyed,
+    targetIsDestroyed: currentState.units[targetId].destroyed,
+    damageResult,
+    critUnitDestroyed,
+    critDestructionCause,
+  });
 
-  const targetPostDamage = currentState.units[targetId];
-  if (
-    !targetPostDamage.destroyed &&
-    (targetPostDamage.damageThisPhase ?? 0) >= DAMAGE_PSR_THRESHOLD
-  ) {
-    const existingPSRs = targetPostDamage.pendingPSRs ?? [];
-    const hasDamagePSR = existingPSRs.some(
-      (pendingPSR) => pendingPSR.triggerSource === '20+_damage',
-    );
-    if (!hasDamagePSR) {
-      currentState = {
-        ...currentState,
-        units: {
-          ...currentState.units,
-          [targetId]: {
-            ...targetPostDamage,
-            pendingPSRs: [...existingPSRs, createDamagePSR(targetId)],
-          },
-        },
-      };
-    }
-  }
+  // Queue a 20+-damage piloting skill roll on the surviving target.
+  currentState = applyDamageThresholdPSR(currentState, targetId);
 
   return currentState;
 }

--- a/src/stores/campaign/campaignRosterStore.helpers.ts
+++ b/src/stores/campaign/campaignRosterStore.helpers.ts
@@ -1,0 +1,260 @@
+/**
+ * Campaign Roster Store — Pure Helper Functions
+ *
+ * Extracted from `useCampaignRosterStore.ts` as part of a behavior-preserving
+ * decomposition: the store module was over the 600-LOC critical threshold.
+ * Everything in this file is a pure function — no Zustand `set`/`get`, no
+ * store coupling — so the store definition itself stays thin and these
+ * derivations stay independently unit-testable.
+ *
+ * @see ./useCampaignRosterStore.ts
+ */
+
+import type {
+  IDestroyedComponent,
+  IUnitCombatState,
+} from '@/types/campaign/UnitCombatState';
+
+import {
+  deriveRosterReadiness,
+  type IRosterUnitProjection,
+} from '@/types/campaign/RosterUnitProjection';
+
+import type {
+  IUnitDamageState,
+  UnitReadiness,
+} from './campaignRosterStore.types';
+
+/**
+ * Generate a short, collision-resistant id.
+ *
+ * Combines the current epoch millis with a random base-36 suffix. Used to
+ * mint mission ids and the synthesized `matchId` for the legacy damage
+ * carry-forward bridge — uniqueness only needs to hold within a single
+ * client session, so a UUID dependency would be overkill.
+ */
+export function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+/**
+ * Build a fresh canonical combat state from a carry-forward payload.
+ *
+ * The carry-forward shape only carries deltas (damage points lost) and
+ * a destroyed-flag, so we construct the canonical state by:
+ * - Starting from any pre-existing canonical state (preserves accumulated
+ *   destruction history across multiple battles).
+ * - Subtracting reported damage from current armor / structure (clamped at
+ *   zero to avoid negative values).
+ * - Appending newly destroyed component names as `IDestroyedComponent`
+ *   entries with synthesized `slot=-1` / `componentType='unknown'` —
+ *   the carry-forward shape doesn't carry crit-slot detail, so the
+ *   placeholder marks "destroyed at this matchId" for audit purposes.
+ *   The canonical post-battle processor (the new path) writes proper
+ *   `IDestroyedComponent` entries with full crit-slot data; this
+ *   roster-store path is the legacy game-session bridge.
+ * - Flipping `combatReady` to false when the payload reports the unit
+ *   as destroyed.
+ *
+ * @param prior Existing canonical state for this unit, if any.
+ * @param damage Carry-forward payload from the game session layer.
+ * @param matchId Mission id used as `lastCombatOutcomeId` and on
+ *   destroyed-component `destroyedAt`.
+ * @returns A fresh `IUnitCombatState` ready to overwrite the entry on
+ *   `ICampaign.unitCombatStates`.
+ */
+export function applyDamageToCanonicalState(
+  prior: IUnitCombatState | undefined,
+  damage: IUnitDamageState,
+  matchId: string,
+): IUnitCombatState {
+  // Start from prior canonical state (preserves multi-battle accumulation)
+  // or seed an empty baseline for units with no prior state. The legacy
+  // game-session bridge does not have construction max values handy, so
+  // empty maps are the only safe baseline.
+  const priorArmor = prior?.currentArmorPerLocation ?? {};
+  const priorStructure = prior?.currentStructurePerLocation ?? {};
+  const priorDestroyedComponents = prior?.destroyedComponents ?? [];
+  const priorDestroyedLocations = prior?.destroyedLocations ?? [];
+
+  // Apply armor deltas (clamp at zero — carry-forward damage values are
+  // points-lost, not absolute remaining values).
+  const nextArmor: Record<string, number> = { ...priorArmor };
+  for (const [loc, dmg] of Object.entries(damage.armorDamage)) {
+    const current = nextArmor[loc] ?? 0;
+    nextArmor[loc] = Math.max(0, current - dmg);
+  }
+
+  // Same treatment for structure.
+  const nextStructure: Record<string, number> = { ...priorStructure };
+  for (const [loc, dmg] of Object.entries(damage.structureDamage)) {
+    const current = nextStructure[loc] ?? 0;
+    nextStructure[loc] = Math.max(0, current - dmg);
+  }
+
+  // Append newly destroyed components. Dedupe by name+matchId so the same
+  // outcome applied twice won't double-grow the array — full slot+location
+  // dedupe would require crit-slot info the carry-forward shape doesn't
+  // carry.
+  const seen = new Set(
+    priorDestroyedComponents.map((c) => `${c.name}|${c.destroyedAt}`),
+  );
+  const nextDestroyedComponents: IDestroyedComponent[] = [
+    ...priorDestroyedComponents,
+  ];
+  for (const name of damage.destroyedComponents) {
+    const key = `${name}|${matchId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    nextDestroyedComponents.push({
+      // Synthesized placeholder fields — the legacy bridge can't recover
+      // crit-slot detail. Audit consumers reading `destroyedAt` get the
+      // matchId; consumers needing slot-level detail should switch to the
+      // canonical postBattleProcessor path.
+      location: 'UNKNOWN',
+      slot: -1,
+      componentType: 'unknown',
+      name,
+      destroyedAt: matchId,
+    });
+  }
+
+  return {
+    unitId: damage.unitId,
+    currentArmorPerLocation: nextArmor,
+    currentStructurePerLocation: nextStructure,
+    destroyedLocations: priorDestroyedLocations,
+    destroyedComponents: nextDestroyedComponents,
+    heatEnd: prior?.heatEnd ?? 0,
+    ammoRemaining: prior?.ammoRemaining ?? {},
+    combatReady: damage.destroyed ? false : (prior?.combatReady ?? true),
+    lastCombatOutcomeId: matchId,
+    lastUpdated: new Date().toISOString(),
+  };
+}
+
+/**
+ * Derive a roster unit's refreshed `readiness` from a carry-forward payload.
+ *
+ * Builds a synthetic `IUnitCombatState` shell to feed `deriveRosterReadiness`
+ * — only `combatReady` + destroyed-component count matter to that helper, so
+ * the armor/structure maps stay empty. When the helper returns 'Ready' but the
+ * payload reports armor or structure damage, the result is bumped to 'Damaged'
+ * (the helper can't see armor deltas without a max-state companion, so this
+ * bridges that gap). Pure: returns the readiness, the store applies it.
+ *
+ * @param unitId The roster unit being refreshed.
+ * @param damage Carry-forward payload for that unit.
+ * @param matchId Mission id stamped onto synthesized destroyed-component
+ *   entries and `lastCombatOutcomeId`.
+ * @returns The derived `UnitReadiness` for the projection.
+ */
+export function deriveReadinessFromCarryForward(
+  unitId: string,
+  damage: IUnitDamageState,
+  matchId: string,
+): UnitReadiness {
+  // Build a synthetic combat state shell to feed `deriveRosterReadiness` —
+  // we don't need the canonical state's full detail for the readiness
+  // derivation, just `combatReady` + destroyed component count.
+  const synthState: IUnitCombatState = {
+    unitId,
+    currentArmorPerLocation: {},
+    currentStructurePerLocation: {},
+    destroyedLocations: [],
+    destroyedComponents: damage.destroyedComponents.map((name) => ({
+      location: 'UNKNOWN',
+      slot: -1,
+      componentType: 'unknown',
+      name,
+      destroyedAt: matchId,
+    })),
+    heatEnd: 0,
+    ammoRemaining: {},
+    combatReady: !damage.destroyed,
+    lastCombatOutcomeId: matchId,
+    lastUpdated: null,
+  };
+
+  const totalArmorDmg = Object.values(damage.armorDamage).reduce(
+    (sum, v) => sum + v,
+    0,
+  );
+  const totalStructDmg = Object.values(damage.structureDamage).reduce(
+    (sum, v) => sum + v,
+    0,
+  );
+  const tookDamage = totalArmorDmg > 0 || totalStructDmg > 0;
+
+  // Derive readiness — when the unit is destroyed, `deriveRosterReadiness`
+  // returns 'Destroyed' from `combatReady=false`. When alive but with
+  // destroyed components, it returns 'Damaged'. When alive without destroyed
+  // components but with armor/structure damage, the helper would return
+  // 'Ready' (since it can't see armor deltas without a max-state companion)
+  // — bridge that gap by checking damage totals here.
+  let readiness = deriveRosterReadiness(synthState);
+  if (readiness === 'Ready' && tookDamage) {
+    readiness = 'Damaged';
+  }
+  return readiness;
+}
+
+/**
+ * Refresh the `readiness` field of each roster projection from a batch of
+ * carry-forward payloads.
+ *
+ * Pure list transform: units with a matching payload get a new object with
+ * the derived readiness; units without a payload pass through by reference.
+ * The store wraps this in `set` — keeping the projection update independent
+ * of the canonical-state write so the two paths stay cleanly decoupled.
+ *
+ * @param units Current roster projection list.
+ * @param damageStates Carry-forward payloads from the battle result.
+ * @param matchId Mission id used for the synthetic-state derivation.
+ * @returns A new projection list with refreshed `readiness` values.
+ */
+export function refreshUnitsReadiness(
+  units: readonly IRosterUnitProjection[],
+  damageStates: readonly IUnitDamageState[],
+  matchId: string,
+): IRosterUnitProjection[] {
+  return units.map((unit) => {
+    const damage = damageStates.find((d) => d.unitId === unit.unitId);
+    if (!damage) return unit;
+    const readiness = deriveReadinessFromCarryForward(
+      unit.unitId,
+      damage,
+      matchId,
+    );
+    return { ...unit, readiness };
+  });
+}
+
+/**
+ * Compute the next canonical `unitCombatStates` map from a prior map plus a
+ * batch of carry-forward payloads.
+ *
+ * Pure: copies the prior map, then overwrites each affected unit's entry with
+ * the result of `applyDamageToCanonicalState`. The store passes the result to
+ * `useCampaignStore.updateCampaign`.
+ *
+ * @param priorMap The campaign's current `unitCombatStates` map.
+ * @param damageStates Carry-forward payloads from the battle result.
+ * @param matchId Mission id stamped onto each rebuilt combat state.
+ * @returns A new `unitCombatStates` map ready to write back to the campaign.
+ */
+export function buildNextCombatStateMap(
+  priorMap: Readonly<Record<string, IUnitCombatState>>,
+  damageStates: readonly IUnitDamageState[],
+  matchId: string,
+): Record<string, IUnitCombatState> {
+  const nextMap: Record<string, IUnitCombatState> = { ...priorMap };
+  for (const damage of damageStates) {
+    nextMap[damage.unitId] = applyDamageToCanonicalState(
+      priorMap[damage.unitId],
+      damage,
+      matchId,
+    );
+  }
+  return nextMap;
+}

--- a/src/stores/campaign/campaignRosterStore.types.ts
+++ b/src/stores/campaign/campaignRosterStore.types.ts
@@ -1,0 +1,173 @@
+/**
+ * Campaign Roster Store — Type Definitions
+ *
+ * Extracted from `useCampaignRosterStore.ts` as part of a behavior-preserving
+ * decomposition: the store module was over the 600-LOC critical threshold, so
+ * the type surface (store state shape, action contract, and the public
+ * payload/record interfaces) lives here as a co-located sibling. The store
+ * module re-exports the public names (`UnitReadiness`, `ICampaignMissionRecord`,
+ * `IUnitDamageState`, `CampaignRosterStore`) so all existing importers keep
+ * working unchanged.
+ *
+ * @see ./useCampaignRosterStore.ts
+ */
+
+import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
+import type { IRosterUnitProjection } from '@/types/campaign/RosterUnitProjection';
+
+/** Readiness status for dashboard display */
+export type UnitReadiness = 'Ready' | 'Damaged' | 'Destroyed';
+
+/** Mission outcome record */
+export interface ICampaignMissionRecord {
+  readonly id: string;
+  readonly missionNumber: number;
+  readonly name: string;
+  readonly result: 'victory' | 'defeat' | 'draw' | 'pending';
+  readonly encounterId?: string;
+  readonly gameSessionId?: string;
+  readonly campaignId: string;
+  readonly deployedUnitIds: readonly string[];
+  readonly completedAt?: string;
+  readonly turnsPlayed?: number;
+}
+
+/**
+ * Serializable damage carry-forward payload from the game-session layer.
+ *
+ * Produced by `GameSessionPage.states.tsx` from `IUnitGameState` after
+ * a battle completes. Consumed by the roster store to (a) refresh the roster
+ * projection's `readiness` field and (b) write deltas into the canonical
+ * `ICampaign.unitCombatStates` via `useCampaignStore.updateCampaign`.
+ *
+ * NOTE: The name retains the legacy `IUnitDamageState` label because two
+ * other shapes share the name elsewhere
+ * (`src/utils/gameplay/damage/types.ts`, `src/lib/combat/acar.ts`) and
+ * this carry-forward shape has been the roster-store-local one all
+ * along. The rename to a unique label is left to PR-C cleanup.
+ */
+export interface IUnitDamageState {
+  readonly unitId: string;
+  /** Per-location armor damage (points lost). */
+  readonly armorDamage: Record<string, number>;
+  /** Per-location structure damage (points lost). */
+  readonly structureDamage: Record<string, number>;
+  /** Destroyed component names (synthesized to IDestroyedComponent on write). */
+  readonly destroyedComponents: string[];
+  /** Is unit completely destroyed? */
+  readonly destroyed: boolean;
+}
+
+/** Reactive state slice held by the campaign roster store. */
+export interface CampaignRosterState {
+  /** Campaign ID this roster belongs to */
+  campaignId: string | null;
+
+  /**
+   * Roster projection list — display identity + cached readiness.
+   * Damage data lives on `ICampaign.unitCombatStates[unitId]`, NOT here.
+   */
+  units: IRosterUnitProjection[];
+
+  /** Pilot roster for the campaign */
+  pilots: ICampaignRosterEntry[];
+
+  /** Mission history */
+  missions: ICampaignMissionRecord[];
+
+  /** Current active mission (if any) */
+  activeMissionId: string | null;
+
+  /** Mission counter */
+  missionCount: number;
+}
+
+/** Action contract exposed by the campaign roster store. */
+export interface CampaignRosterActions {
+  /** Initialize roster for a campaign */
+  initRoster: (campaignId: string) => void;
+
+  /** Add a unit to the roster */
+  addUnit: (unit: IRosterUnitProjection) => void;
+
+  /** Remove a unit from the roster */
+  removeUnit: (unitId: string) => void;
+
+  /** Add a pilot to the roster */
+  addPilot: (pilot: ICampaignRosterEntry) => void;
+
+  /** Remove a pilot from the roster */
+  removePilot: (pilotId: string) => void;
+
+  /**
+   * Apply per-pilot patches in a single setState. Each entry in `patches`
+   * maps `pilotId` to a partial `ICampaignRosterEntry` that gets shallow-
+   * merged into the existing entry. Unknown ids are ignored.
+   *
+   * Day-pipeline processors call this once per phase to commit their
+   * accumulated mutations (wound progression, status transitions, XP
+   * awards, departure flags) without requiring direct setState access.
+   */
+  applyPilotPatches: (
+    patches: ReadonlyMap<string, Partial<ICampaignRosterEntry>>,
+  ) => void;
+
+  /** Assign a pilot to a unit */
+  assignPilot: (unitId: string, pilotId: string) => void;
+
+  /** Get unit readiness status */
+  getUnitReadiness: (unitId: string) => UnitReadiness;
+
+  /**
+   * Get all units with their readiness already cached on the projection.
+   * Returned shape matches `IRosterUnitProjection` (which itself carries
+   * `readiness`) — preserved as a separate accessor for legacy callers
+   * that explicitly typed the field as `Array<... & { readiness }>`.
+   */
+  getUnitsWithReadiness: () => IRosterUnitProjection[];
+
+  /** Get deployable units (Ready or Damaged) */
+  getDeployableUnits: () => IRosterUnitProjection[];
+
+  /** Create a new mission record */
+  createMission: (
+    name: string,
+    deployedUnitIds: string[],
+    encounterId?: string,
+  ) => string;
+
+  /** Record mission outcome and apply damage */
+  completeMission: (
+    missionId: string,
+    result: 'victory' | 'defeat' | 'draw',
+    damageStates: IUnitDamageState[],
+    gameSessionId?: string,
+    turnsPlayed?: number,
+  ) => void;
+
+  /**
+   * Apply damage carry-forward from battle results.
+   *
+   * Per PR-B: writes canonical combat-state deltas into
+   * `useCampaignStore.campaign.unitCombatStates` and refreshes the
+   * roster projection's `readiness` field. Does NOT store armor /
+   * structure / destroyed-component lists on the projection itself
+   * (that conflated legacy roster-unit shape was deleted in PR-C).
+   */
+  applyDamageCarryForward: (damageStates: IUnitDamageState[]) => void;
+
+  /** Get mission history */
+  getMissionHistory: () => ICampaignMissionRecord[];
+
+  /** Get the active mission */
+  getActiveMission: () => ICampaignMissionRecord | null;
+
+  /** Set active mission ID (when navigating to battle) */
+  setActiveMission: (missionId: string | null) => void;
+
+  /** Reset roster state */
+  reset: () => void;
+}
+
+/** Full campaign roster store type — reactive state plus actions. */
+export type CampaignRosterStore = CampaignRosterState & CampaignRosterActions;

--- a/src/stores/campaign/useCampaignRosterStore.ts
+++ b/src/stores/campaign/useCampaignRosterStore.ts
@@ -17,8 +17,17 @@
  * - Damage carry-forward write-through (this store proxies into
  *   canonical state via `useCampaignStore.updateCampaign`)
  *
+ * Decomposition note: the type surface lives in
+ * `campaignRosterStore.types.ts` and the pure helper functions in
+ * `campaignRosterStore.helpers.ts` — this module keeps only the Zustand
+ * store definition. Public names (`useCampaignRosterStore`,
+ * `UnitReadiness`, `ICampaignMissionRecord`, `IUnitDamageState`,
+ * `CampaignRosterStore`) are re-exported here so importers are unaffected.
+ *
  * @see openspec/specs/campaign-unit-combat-state/spec.md
  * @see src/types/campaign/RosterUnitProjection.ts
+ * @see ./campaignRosterStore.types.ts
+ * @see ./campaignRosterStore.helpers.ts
  */
 
 import { create } from 'zustand';
@@ -29,285 +38,35 @@ import {
 } from 'zustand/middleware';
 
 import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
-import type {
-  IDestroyedComponent,
-  IUnitCombatState,
-} from '@/types/campaign/UnitCombatState';
 
 import { clientSafeStorage } from '@/stores/utils/clientSafeStorage';
 import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
-import {
-  deriveRosterReadiness,
-  type IRosterUnitProjection,
-} from '@/types/campaign/RosterUnitProjection';
 
+import type {
+  CampaignRosterState,
+  CampaignRosterStore,
+  ICampaignMissionRecord,
+} from './campaignRosterStore.types';
+
+import {
+  buildNextCombatStateMap,
+  generateId,
+  refreshUnitsReadiness,
+} from './campaignRosterStore.helpers';
 import { getCampaignStoreForRoster } from './campaignStoreAccessor';
 
-// =============================================================================
-// Types
-// =============================================================================
-
-/** Readiness status for dashboard display */
-export type UnitReadiness = 'Ready' | 'Damaged' | 'Destroyed';
-
-/** Mission outcome record */
-export interface ICampaignMissionRecord {
-  readonly id: string;
-  readonly missionNumber: number;
-  readonly name: string;
-  readonly result: 'victory' | 'defeat' | 'draw' | 'pending';
-  readonly encounterId?: string;
-  readonly gameSessionId?: string;
-  readonly campaignId: string;
-  readonly deployedUnitIds: readonly string[];
-  readonly completedAt?: string;
-  readonly turnsPlayed?: number;
-}
-
-/**
- * Serializable damage carry-forward payload from the game-session layer.
- *
- * Produced by `GameSessionPage.states.tsx` from `IUnitGameState` after
- * a battle completes. Consumed here to (a) refresh the roster
- * projection's `readiness` field and (b) write deltas into the canonical
- * `ICampaign.unitCombatStates` via `useCampaignStore.updateCampaign`.
- *
- * NOTE: The name retains the legacy `IUnitDamageState` label because two
- * other shapes share the name elsewhere
- * (`src/utils/gameplay/damage/types.ts`, `src/lib/combat/acar.ts`) and
- * this carry-forward shape has been the roster-store-local one all
- * along. The rename to a unique label is left to PR-C cleanup.
- */
-export interface IUnitDamageState {
-  readonly unitId: string;
-  /** Per-location armor damage (points lost). */
-  readonly armorDamage: Record<string, number>;
-  /** Per-location structure damage (points lost). */
-  readonly structureDamage: Record<string, number>;
-  /** Destroyed component names (synthesized to IDestroyedComponent on write). */
-  readonly destroyedComponents: string[];
-  /** Is unit completely destroyed? */
-  readonly destroyed: boolean;
-}
-
-// =============================================================================
-// Store State
-// =============================================================================
-
-interface CampaignRosterState {
-  /** Campaign ID this roster belongs to */
-  campaignId: string | null;
-
-  /**
-   * Roster projection list — display identity + cached readiness.
-   * Damage data lives on `ICampaign.unitCombatStates[unitId]`, NOT here.
-   */
-  units: IRosterUnitProjection[];
-
-  /** Pilot roster for the campaign */
-  pilots: ICampaignRosterEntry[];
-
-  /** Mission history */
-  missions: ICampaignMissionRecord[];
-
-  /** Current active mission (if any) */
-  activeMissionId: string | null;
-
-  /** Mission counter */
-  missionCount: number;
-}
-
-interface CampaignRosterActions {
-  /** Initialize roster for a campaign */
-  initRoster: (campaignId: string) => void;
-
-  /** Add a unit to the roster */
-  addUnit: (unit: IRosterUnitProjection) => void;
-
-  /** Remove a unit from the roster */
-  removeUnit: (unitId: string) => void;
-
-  /** Add a pilot to the roster */
-  addPilot: (pilot: ICampaignRosterEntry) => void;
-
-  /** Remove a pilot from the roster */
-  removePilot: (pilotId: string) => void;
-
-  /**
-   * Apply per-pilot patches in a single setState. Each entry in `patches`
-   * maps `pilotId` to a partial `ICampaignRosterEntry` that gets shallow-
-   * merged into the existing entry. Unknown ids are ignored.
-   *
-   * Day-pipeline processors call this once per phase to commit their
-   * accumulated mutations (wound progression, status transitions, XP
-   * awards, departure flags) without requiring direct setState access.
-   */
-  applyPilotPatches: (
-    patches: ReadonlyMap<string, Partial<ICampaignRosterEntry>>,
-  ) => void;
-
-  /** Assign a pilot to a unit */
-  assignPilot: (unitId: string, pilotId: string) => void;
-
-  /** Get unit readiness status */
-  getUnitReadiness: (unitId: string) => UnitReadiness;
-
-  /**
-   * Get all units with their readiness already cached on the projection.
-   * Returned shape matches `IRosterUnitProjection` (which itself carries
-   * `readiness`) — preserved as a separate accessor for legacy callers
-   * that explicitly typed the field as `Array<... & { readiness }>`.
-   */
-  getUnitsWithReadiness: () => IRosterUnitProjection[];
-
-  /** Get deployable units (Ready or Damaged) */
-  getDeployableUnits: () => IRosterUnitProjection[];
-
-  /** Create a new mission record */
-  createMission: (
-    name: string,
-    deployedUnitIds: string[],
-    encounterId?: string,
-  ) => string;
-
-  /** Record mission outcome and apply damage */
-  completeMission: (
-    missionId: string,
-    result: 'victory' | 'defeat' | 'draw',
-    damageStates: IUnitDamageState[],
-    gameSessionId?: string,
-    turnsPlayed?: number,
-  ) => void;
-
-  /**
-   * Apply damage carry-forward from battle results.
-   *
-   * Per PR-B: writes canonical combat-state deltas into
-   * `useCampaignStore.campaign.unitCombatStates` and refreshes the
-   * roster projection's `readiness` field. Does NOT store armor /
-   * structure / destroyed-component lists on the projection itself
-   * (that conflated legacy roster-unit shape was deleted in PR-C).
-   */
-  applyDamageCarryForward: (damageStates: IUnitDamageState[]) => void;
-
-  /** Get mission history */
-  getMissionHistory: () => ICampaignMissionRecord[];
-
-  /** Get the active mission */
-  getActiveMission: () => ICampaignMissionRecord | null;
-
-  /** Set active mission ID (when navigating to battle) */
-  setActiveMission: (missionId: string | null) => void;
-
-  /** Reset roster state */
-  reset: () => void;
-}
-
-export type CampaignRosterStore = CampaignRosterState & CampaignRosterActions;
-
-// =============================================================================
-// Helper Functions
-// =============================================================================
-
-function generateId(): string {
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
-}
-
-/**
- * Build a fresh canonical combat state from a carry-forward payload.
- *
- * The carry-forward shape only carries deltas (damage points lost) and
- * a destroyed-flag, so we construct the canonical state by:
- * - Starting from any pre-existing canonical state (preserves accumulated
- *   destruction history across multiple battles).
- * - Subtracting reported damage from current armor / structure (clamped at
- *   zero to avoid negative values).
- * - Appending newly destroyed component names as `IDestroyedComponent`
- *   entries with synthesized `slot=-1` / `componentType='unknown'` —
- *   the carry-forward shape doesn't carry crit-slot detail, so the
- *   placeholder marks "destroyed at this matchId" for audit purposes.
- *   The canonical post-battle processor (the new path) writes proper
- *   `IDestroyedComponent` entries with full crit-slot data; this
- *   roster-store path is the legacy game-session bridge.
- * - Flipping `combatReady` to false when the payload reports the unit
- *   as destroyed.
- *
- * @param prior Existing canonical state for this unit, if any.
- * @param damage Carry-forward payload from the game session layer.
- * @param matchId Mission id used as `lastCombatOutcomeId` and on
- *   destroyed-component `destroyedAt`.
- * @returns A fresh `IUnitCombatState` ready to overwrite the entry on
- *   `ICampaign.unitCombatStates`.
- */
-function applyDamageToCanonicalState(
-  prior: IUnitCombatState | undefined,
-  damage: IUnitDamageState,
-  matchId: string,
-): IUnitCombatState {
-  // Start from prior canonical state (preserves multi-battle accumulation)
-  // or seed an empty baseline for units with no prior state. The legacy
-  // game-session bridge does not have construction max values handy, so
-  // empty maps are the only safe baseline.
-  const priorArmor = prior?.currentArmorPerLocation ?? {};
-  const priorStructure = prior?.currentStructurePerLocation ?? {};
-  const priorDestroyedComponents = prior?.destroyedComponents ?? [];
-  const priorDestroyedLocations = prior?.destroyedLocations ?? [];
-
-  // Apply armor deltas (clamp at zero — carry-forward damage values are
-  // points-lost, not absolute remaining values).
-  const nextArmor: Record<string, number> = { ...priorArmor };
-  for (const [loc, dmg] of Object.entries(damage.armorDamage)) {
-    const current = nextArmor[loc] ?? 0;
-    nextArmor[loc] = Math.max(0, current - dmg);
-  }
-
-  // Same treatment for structure.
-  const nextStructure: Record<string, number> = { ...priorStructure };
-  for (const [loc, dmg] of Object.entries(damage.structureDamage)) {
-    const current = nextStructure[loc] ?? 0;
-    nextStructure[loc] = Math.max(0, current - dmg);
-  }
-
-  // Append newly destroyed components. Dedupe by name+matchId so the same
-  // outcome applied twice won't double-grow the array — full slot+location
-  // dedupe would require crit-slot info the carry-forward shape doesn't
-  // carry.
-  const seen = new Set(
-    priorDestroyedComponents.map((c) => `${c.name}|${c.destroyedAt}`),
-  );
-  const nextDestroyedComponents: IDestroyedComponent[] = [
-    ...priorDestroyedComponents,
-  ];
-  for (const name of damage.destroyedComponents) {
-    const key = `${name}|${matchId}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    nextDestroyedComponents.push({
-      // Synthesized placeholder fields — the legacy bridge can't recover
-      // crit-slot detail. Audit consumers reading `destroyedAt` get the
-      // matchId; consumers needing slot-level detail should switch to the
-      // canonical postBattleProcessor path.
-      location: 'UNKNOWN',
-      slot: -1,
-      componentType: 'unknown',
-      name,
-      destroyedAt: matchId,
-    });
-  }
-
-  return {
-    unitId: damage.unitId,
-    currentArmorPerLocation: nextArmor,
-    currentStructurePerLocation: nextStructure,
-    destroyedLocations: priorDestroyedLocations,
-    destroyedComponents: nextDestroyedComponents,
-    heatEnd: prior?.heatEnd ?? 0,
-    ammoRemaining: prior?.ammoRemaining ?? {},
-    combatReady: damage.destroyed ? false : (prior?.combatReady ?? true),
-    lastCombatOutcomeId: matchId,
-    lastUpdated: new Date().toISOString(),
-  };
-}
+// Re-export the public type surface so existing importers
+// (`GameSessionPage.states.tsx`, `CampaignDashboardPage.utils.ts`, etc.)
+// keep resolving `UnitReadiness` / `ICampaignMissionRecord` /
+// `IUnitDamageState` / `CampaignRosterStore` from this module unchanged.
+export type {
+  CampaignRosterActions,
+  CampaignRosterState,
+  CampaignRosterStore,
+  ICampaignMissionRecord,
+  IUnitDamageState,
+  UnitReadiness,
+} from './campaignRosterStore.types';
 
 // =============================================================================
 // Store
@@ -471,8 +230,6 @@ export const useCampaignRosterStore = create<CampaignRosterStore>()(
         // store. The campaign-store accessor (`useCampaignStore`) is a
         // singleton getter — calling it here returns the StoreApi, not
         // a React hook value, despite the misleading `use*` prefix.
-        // The eslint-disable for `react-hooks/rules-of-hooks` below
-        // marks this for any future linter re-tightening.
         //
         // The active mission id is the closest analog to a `matchId`
         // for the legacy bridge — it's what `createMission` minted when
@@ -489,15 +246,11 @@ export const useCampaignRosterStore = create<CampaignRosterStore>()(
         // Skip the canonical write entirely when no campaign is loaded —
         // tests / orphan flows still get the readiness refresh.
         if (campaign) {
-          const priorMap = campaign.unitCombatStates;
-          const nextMap: Record<string, IUnitCombatState> = { ...priorMap };
-          for (const damage of damageStates) {
-            nextMap[damage.unitId] = applyDamageToCanonicalState(
-              priorMap[damage.unitId],
-              damage,
-              matchId,
-            );
-          }
+          const nextMap = buildNextCombatStateMap(
+            campaign.unitCombatStates,
+            damageStates,
+            matchId,
+          );
           campaignStore?.getState().updateCampaign({
             unitCombatStates: nextMap,
           });
@@ -508,62 +261,9 @@ export const useCampaignRosterStore = create<CampaignRosterStore>()(
         // directly so the projection update doesn't depend on the
         // canonical write completing — keeps the two paths cleanly
         // independent.
-        set((state) => {
-          const updatedUnits = state.units.map((unit) => {
-            const damage = damageStates.find((d) => d.unitId === unit.unitId);
-            if (!damage) return unit;
-
-            // Build a synthetic combat state shell to feed
-            // `deriveRosterReadiness` — we don't need the canonical
-            // state's full detail for the readiness derivation, just
-            // `combatReady` + destroyed component count.
-            const synthState: IUnitCombatState = {
-              unitId: unit.unitId,
-              currentArmorPerLocation: {},
-              currentStructurePerLocation: {},
-              destroyedLocations: [],
-              destroyedComponents: damage.destroyedComponents.map((name) => ({
-                location: 'UNKNOWN',
-                slot: -1,
-                componentType: 'unknown',
-                name,
-                destroyedAt: matchId,
-              })),
-              heatEnd: 0,
-              ammoRemaining: {},
-              combatReady: !damage.destroyed,
-              lastCombatOutcomeId: matchId,
-              lastUpdated: null,
-            };
-
-            const totalArmorDmg = Object.values(damage.armorDamage).reduce(
-              (sum, v) => sum + v,
-              0,
-            );
-            const totalStructDmg = Object.values(damage.structureDamage).reduce(
-              (sum, v) => sum + v,
-              0,
-            );
-            const tookDamage = totalArmorDmg > 0 || totalStructDmg > 0;
-
-            // Derive readiness — when the unit is destroyed,
-            // `deriveRosterReadiness` returns 'Destroyed' from
-            // `combatReady=false`. When alive but with destroyed
-            // components, it returns 'Damaged'. When alive without
-            // destroyed components but with armor/structure damage, the
-            // helper would return 'Ready' (since it can't see armor
-            // deltas without a max-state companion) — bridge that gap
-            // by checking damage totals here.
-            let readiness = deriveRosterReadiness(synthState);
-            if (readiness === 'Ready' && tookDamage) {
-              readiness = 'Damaged';
-            }
-
-            return { ...unit, readiness };
-          });
-
-          return { units: updatedUnits };
-        });
+        set((state) => ({
+          units: refreshUnitsReadiness(state.units, damageStates, matchId),
+        }));
       },
 
       getMissionHistory: () => {


### PR DESCRIPTION
## Summary

`/maintain` 11-scanner sweep of `src/`. The codebase scored **healthy** — 0 dead code, 0 circular deps (madge over 3,406 files), 0 unguarded type casts, 1 lint warning. This PR clears the actionable structural findings the user selected: file bloat, the lint warning, and one genuine design-pattern win.

7 behavior-preserving commits, each independently verified (tsc + oxlint + jest + pre-commit build) in an isolated worktree before integration:

| Commit | Before → after | Extracted |
|--------|---------------|-----------|
| `refactor(simulation)` weaponAttackHitResolution.ts | 548 → 317 LOC | `.helpers.ts` (clears the `max-lines:400` oxlint warning) |
| `refactor(multiplayer)` ServerMatchHost.ts | 756 → 666 LOC | 3 collaborators (capture / contexts / outcome-publisher) |
| `refactor(campaign)` contractMarket.ts | 682 → 391 LOC | 4 modules under `contracts/` |
| `refactor(stores)` useCampaignRosterStore.ts | 618 → 318 LOC | types + helpers modules |
| `refactor(campaign)` dayAdvancement.ts | 605 → 309 LOC | 4 phase-processor modules |
| `refactor(engine)` InteractiveSession.ts | 598 → 449 LOC | coordinator + 4 collaborators |
| `refactor(campaign)` turnover modifier registry | turnoverCheck.ts −95 LOC | `modifierRegistry.ts` table |

### Decompositions
Every decomposition preserves the public API exactly (same exports, signatures, class APIs) — extracted modules are co-located siblings the original file delegates to / re-exports. Every guard and ordering detail preserved; the trickiest (InteractiveSession's End-phase `isGameOver()` check after in-place PSR session reassignment) is explicitly documented inline.

### Turnover modifier registry
`calculateModifiers()` in `turnoverCheck.ts` was a ~100-line hand-rolled block of 19 repetitive `buildModifier()` calls. Extracted `TURNOVER_MODIFIER_REGISTRY` — a single ordered table; `calculateModifiers()` is now a 6-line `.map`. Adding a modifier is a one-line table entry (OCP). The 19 modifier functions are untouched. Registry order matches the legacy block exactly, so `TurnoverCheckResult.modifiers` is byte-for-byte unchanged.

### Deliberately NOT done (scanner over-flag / out of scope)
- No broad type-token or `any`-cast sweep — the 11 `as unknown as` casts are all justified contract-boundary adapters.
- The modifier *functions* themselves were not "registry-ified" — they have distinct logic, not duplicated logic; forcing an abstraction there would be churn.
- ~20 test-coverage gaps in `lib/campaign/` were flagged (report only — test authoring is a separate task).

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `oxlint` — **0 warnings, 0 errors** (was 1 `max-lines` warning)
- [x] `oxfmt --check` — all tracked files clean
- [x] Per-decomposition jest: weaponAttackHitResolution 103/103, ServerMatchHost 135/135, contractMarket 2106/2106, roster store 627/627, dayAdvancement 275/275, InteractiveSession 95/95, turnover 511/511
- [x] Every commit passed the pre-commit `next build`
- [ ] CI: full test matrix + 3-platform build

🤖 Generated with [Claude Code](https://claude.com/claude-code)