### PR TITLE
docs(openspec): author Waves 1-5 change proposals + council decision

### DIFF
--- a/openspec/changes/add-ai-advanced-systems/design.md
+++ b/openspec/changes/add-ai-advanced-systems/design.md
@@ -1,0 +1,124 @@
+# Design: Add AI Advanced Systems
+
+## Context
+
+A1–A3b made the bot move over terrain, plan resources, coordinate as a lance, and play the scenario. Three systems the engine already models remain invisible to it. Jump jets: `BotPlayer.selectMovementType` rolls a flat 20% to jump and `MoveAI` scores a jump destination exactly like a walk destination — the bot never jumps *for a reason*. Electronic warfare: `src/utils/gameplay/electronicWarfare/` is a finished module (`isInECMBubble`, `getEnemyECMSources`, `getFriendlyECCMSources`, BAP probe counters, stealth modifiers) the bot never calls. Spotting/vision: `src/lib/multiplayer/server/fogOfWar.ts` computes per-side visibility the bot never reads.
+
+A4 wires these three existing systems into AI awareness — it builds none of them. It registers an advanced parameter block into the AI Difficulty Tier Registry from A1, completing the `Elite` tier. `Green`/`Regular`/`Veteran` leave the block inert.
+
+The council preserved one dissent: A4's ECM "play" may want core-engine to-hit modifiers that may not exist. **A4 is scoped strictly to AI-awareness.** If the engine lacks ECM to-hit modifiers, that is a flagged gap for a later change — A4 does not touch combat resolution.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Score jump moves for terrain-clearing, elevation gain, and charge escape, weighed against jump heat via A2's heat planner.
+- Make the bot avoid hostile ECM bubbles and position friendly ECM/probe carriers usefully, consuming the existing `electronicWarfare` module.
+- Make the bot value scouting unspotted enemies and breaking enemy LOS, consuming the existing `fogOfWar.ts`.
+- Register the advanced block into the Tier Registry, additively.
+
+**Non-Goals:**
+
+- Core-engine ECM to-hit modifiers (out of scope, flagged). Building/modifying `electronicWarfare` or `fogOfWar.ts`. Hiding enemies from the bot's planner. C3 networked targeting.
+
+## Decisions
+
+### D1. `AIJumpTactics` — purposeful jump scoring
+
+A pure module scores a jump move's tactical value:
+
+- **terrain-clearing** — a jump destination reached over terrain that would cost heavy MP to walk through earns a bonus (jump ignores intervening terrain cost).
+- **elevation gain** — a jump destination at higher elevation than the origin earns a bonus (elevation aids LOS and to-hit).
+- **charge/melee escape** — when an enemy is adjacent and threatens a physical attack, a jump that breaks adjacency earns a bonus.
+
+The bonus is offset by jump heat: `AIJumpTactics` calls A2's `AIHeatPlanner.projectHeat` with the jump's heat and rejects (or heavily penalizes) a jump that pushes a shutdown inside the lookahead window. `BotPlayer.selectMovementType` consults `AIJumpTactics` instead of the flat 20% roll: it chooses Jump only when a jump destination's tactical value clears a threshold.
+
+```typescript
+interface IJumpEvaluation {
+  /** Net tactical score of the best jump destination. */
+  readonly bestJumpScore: number;
+  /** True when jumping risks a shutdown inside the heat lookahead window. */
+  readonly heatUnsafe: boolean;
+}
+
+function evaluateJump(
+  unit: IAIUnitState,
+  grid: IHexGrid,
+  capability: IMovementCapability,
+  enemies: readonly IAIUnitState[],
+): IJumpEvaluation;
+```
+
+### D2. `AIElectronicWarfareAdvisor` — ECM positioning
+
+A pure module consumes `src/utils/gameplay/electronicWarfare/` (no modification) and advises move scoring:
+
+- **avoidance** — a destination inside a hostile ECM bubble (`isInECMBubble` against `getEnemyECMSources`) earns `-ecmAvoidanceWeight`. ECM degrades the bot's own electronics (C3, targeting computers, Artemis), so the bot prefers clean hexes.
+- **coverage** — when the moving unit carries an ECM suite or BAP probe, a destination whose bubble covers more lancemates, or that counters an enemy ECM source (`getFriendlyECCMSources` / `getProbeECMCounterRange`), earns `+ecmCoverageWeight`.
+
+The advisor reads the electronic-warfare state already on the session; it never writes it and never touches to-hit resolution.
+
+```typescript
+interface IElectronicWarfareAdvice {
+  /** Penalty for ending inside a hostile ECM bubble (>= 0). */
+  readonly hostileBubblePenalty: number;
+  /** Bonus for an ECM/probe carrier covering or countering (>= 0). */
+  readonly coverageBonus: number;
+}
+```
+
+### D3. `AIVisionAdvisor` — spotting and LOS
+
+A pure module consumes `src/lib/multiplayer/server/fogOfWar.ts` (no modification) and advises move scoring:
+
+- **scouting** — a destination that newly spots a previously-unspotted enemy earns `+visionWeight` (spotting enables indirect fire and lance awareness).
+- **LOS-breaking** — a destination that breaks an enemy's line of sight to the moving unit earns a smaller `+visionWeight` share (this complements A1's LOS-denial term, which uses raw `calculateLOS`; A4's term is fog-of-war-aware — it values denying the *enemy's* spotting).
+
+```typescript
+interface IVisionAdvice {
+  /** Bonus for scouting a previously-unspotted enemy (>= 0). */
+  readonly scoutBonus: number;
+  /** Bonus for breaking an enemy's spotting line to this unit (>= 0). */
+  readonly losBreakBonus: number;
+}
+```
+
+### D4. New terms in `scoreMove`
+
+When `advancedSystems` is enabled, `scoreMove` adds three terms, each multiplied by its tier weight: the jump tactical bonus (only on jump moves), the ECM advice (`coverageBonus - hostileBubblePenalty`), and the vision advice (`scoutBonus + losBreakBonus`). All are additive over A1/A3a/A3b's terms. `selectMovementType` gains the jump-tactics gate. When `advancedSystems` is disabled, none of the three apply and `selectMovementType` keeps the flat 20% roll.
+
+### D5. A4 registers an advanced block into the Tier Registry
+
+`AITierRegistry` gains an `advanced` block on `IAITierParameters`:
+
+```typescript
+interface IAITierAdvancedParameters {
+  readonly advancedSystems: boolean;   // false = ignore jump tactics / ECM / vision
+  readonly jumpTacticsWeight: number;
+  readonly ecmAvoidanceWeight: number;
+  readonly ecmCoverageWeight: number;
+  readonly visionWeight: number;
+}
+```
+
+`Green`/`Regular`/`Veteran` set `advancedSystems: false` with zeroed weights — fully inert; `selectMovementType` keeps the flat 20% jump roll. `Elite` populates the block. This is an ADDED requirement; the movement, resource, coordination, and objective blocks are untouched.
+
+### D6. Determinism
+
+Jump scoring, ECM advice, and vision advice are pure functions of unit/grid/EW/fog state. None consume `SeededRandom` — the existing `selectMove` tie-break does. `selectMovementType`'s jump gate replaces a random roll with a deterministic threshold check, which *removes* a random draw on the `Elite` path; the council determinism contract is preserved by keeping `Green`/`Regular`/`Veteran` on the legacy random roll, so golden traces run on those tiers.
+
+## Risks / Trade-offs
+
+- **[Risk] A4 silently expands into core-engine ECM to-hit modifiers** → Mitigation: A4 modules only *read* electronic-warfare state and advise move scoring; the Non-Goals section and the spec requirements forbid touching combat resolution; a missing engine modifier is a flagged separate change.
+- **[Risk] Jump-tactics gate changes random consumption and breaks SimulationRunner determinism** → Mitigation: `Green`/`Regular`/`Veteran` keep the flat 20% roll; golden traces run on those tiers; the deterministic jump gate is asserted only on `Elite`.
+- **[Risk] ECM/fog modules have a different coordinate or state shape than the AI surface expects** → Mitigation: the advisor modules adapt at their boundary (pure adapter functions); no change to `electronicWarfare/` or `fogOfWar.ts`.
+- **[Risk] Registering an advanced block breaks the all-ADDED rule** → Mitigation: `advanced` is a new optional field; this change ADDs a separate requirement and never modifies A1/A2/A3a/A3b's blocks.
+
+## Migration Plan
+
+Purely additive. `Green`/`Regular`/`Veteran` tiers set `advancedSystems: false`, so the jump/ECM/vision advisors are never consulted, `selectMovementType` keeps the flat 20% jump roll, and every existing bot, the swarm harness, and SimulationRunner golden traces are unaffected until a caller selects `Elite`. A4 consumes `electronicWarfare/` and `fogOfWar.ts` without modifying them. No database migrations — advanced parameters live in the tier registry. Rollback = revert the change-set; the three advisor modules become dead code with no behavior change.
+
+## Open Questions
+
+- The jump-tactics threshold for choosing Jump on `Elite` — proposed: a jump is taken when its best destination's tactical score exceeds the best non-jump destination's score by a tunable margin. Revisit after swarm-harness tuning.
+- Whether the vision advisor should also drive indirect-fire target selection (LRM at a spotted-but-not-LOS enemy) — proposed: out of scope for A4; A4 values *gaining* spotting but does not change attack resolution. Candidate follow-on.

--- a/openspec/changes/add-ai-advanced-systems/proposal.md
+++ b/openspec/changes/add-ai-advanced-systems/proposal.md
@@ -1,0 +1,35 @@
+# Change: Add AI Advanced Systems
+
+## Why
+
+Three tactical systems the combat engine already models are invisible to the bot. **Jump jets**: `BotPlayer.selectMovementType` picks Jump on a flat 20% random roll and `MoveAI` has no jump-specific scoring — the bot never jumps to clear terrain, gain elevation, or escape a charge, and it cannot weigh jump heat against the multi-turn heat curve A2 introduced. **Electronic warfare**: `src/utils/gameplay/electronicWarfare/` is a complete module — ECM bubbles, ECCM countering, BAP probes, stealth-armor modifiers — and the bot consults none of it; it walks units into enemy ECM and never positions a friendly probe to counter it. **Spotting and vision**: `src/lib/multiplayer/server/fogOfWar.ts` implements per-side visibility, and the bot ignores it — it never moves to scout an unspotted enemy or break an enemy's line of sight to it.
+
+This change wires those three existing systems into AI awareness. It registers its parameters into the AI Difficulty Tier Registry from A1 and completes the `Elite` tier. It builds none of the three systems — it consumes them.
+
+## What Changes
+
+- ADDED jump-jet tactics: `AIJumpTactics` scores a jump move for terrain-clearing, elevation gain, and charge/melee escape, weighed against jump heat through A2's `AIHeatPlanner`; `MoveAI` evaluates jump moves with this scorer instead of a flat random roll
+- ADDED ECM awareness: `AIElectronicWarfareAdvisor` consumes `src/utils/gameplay/electronicWarfare/` to score positions — penalizing a destination inside a hostile ECM bubble, rewarding moving a friendly ECM/probe carrier to cover the lance or counter enemy ECM
+- ADDED spotting and vision awareness: `AIVisionAdvisor` consumes `fogOfWar.ts` to value scouting an unspotted enemy and to value a destination that breaks an enemy's line of sight to the bot
+- ADDED A4's parameter block to the AI Difficulty Tier Registry — jump-tactics weight, ECM-avoidance weight, ECM-coverage weight, and vision/spotting weight, plus an `advancedSystems` flag; lower tiers leave these inert
+
+## Dependencies
+
+- **Requires**: `add-ai-terrain-aware-movement` (A1) — consumes the pathfinder API and registers its parameter block into the Tier Registry
+- **Requires**: `add-ai-resource-planning` (A2) — jump-jet tactics weigh jump heat against A2's multi-turn `AIHeatPlanner`
+- **Required By**: none — A4 completes Wave 2
+
+## Impact
+
+- Affected specs: `simulation-system` (ADDED requirements only)
+- Affected code: `src/simulation/ai/MoveAI.ts` (jump/ECM/vision terms in `scoreMove`), `src/simulation/ai/BotPlayer.ts` (jump-aware `selectMovementType`), `src/simulation/ai/types.ts` (advanced parameter block), new `src/simulation/ai/AIJumpTactics.ts`, new `src/simulation/ai/AIElectronicWarfareAdvisor.ts`, new `src/simulation/ai/AIVisionAdvisor.ts`, `src/simulation/ai/AITierRegistry.ts` (register the advanced block)
+- Consumes existing modules: `src/utils/gameplay/electronicWarfare/` and `src/lib/multiplayer/server/fogOfWar.ts` — neither is modified
+- No database migrations — advanced parameters live in the tier registry
+- Reproducibility preserved: jump scoring, ECM advice, and vision advice are pure deterministic functions of unit and grid state; ties break via `SeededRandom`
+
+## Non-Goals
+
+- **Core-engine ECM to-hit modifiers — explicitly out of scope.** A4 is AI-*awareness* only: it makes the bot read and position around the electronic-warfare state the engine already tracks. If the core combat engine does not apply ECM modifiers to to-hit resolution, that is a flagged gap for a separate future change — A4 MUST NOT expand into core-engine combat work.
+- Building or modifying the `electronicWarfare` module or `fogOfWar.ts` — A4 consumes them as-is
+- Fog-of-war on the bot's *own* decision-making (the bot reasons with full knowledge of enemy positions) — A4 only *values* scouting; it does not hide enemies from the planner
+- C3 networked targeting tactics — beyond Wave 2 scope

--- a/openspec/changes/add-ai-advanced-systems/specs/simulation-system/spec.md
+++ b/openspec/changes/add-ai-advanced-systems/specs/simulation-system/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Advanced-Systems Tier Parameters
+
+The AI Difficulty Tier Registry SHALL carry an advanced parameter block on each tier, exposing `advancedSystems`, `jumpTacticsWeight`, `ecmAvoidanceWeight`, `ecmCoverageWeight`, and `visionWeight`. The `Green`, `Regular`, and `Veteran` tiers SHALL set `advancedSystems` to `false` with zeroed weights, leaving jump tactics, ECM awareness, and vision awareness inert and keeping the flat-probability jump-movement roll. The `Elite` tier SHALL populate the block with active values. This block SHALL be registered additively and SHALL NOT modify the movement, resource, coordination, or objective parameter blocks.
+
+#### Scenario: Every tier resolves an advanced block
+
+- **GIVEN** the tier names `Green`, `Regular`, `Veteran`, and `Elite`
+- **WHEN** the advanced parameter block is read for each
+- **THEN** each SHALL return a populated `IAITierAdvancedParameters` record
+
+#### Scenario: Lower tiers ignore advanced systems
+
+- **GIVEN** a bot configured with the `Green`, `Regular`, or `Veteran` tier
+- **WHEN** it selects movement and scores moves
+- **THEN** jump-movement selection SHALL use the flat-probability roll
+- **AND** the ECM and vision terms SHALL contribute zero
+
+### Requirement: AI Jump-Jet Tactics
+
+When `advancedSystems` is enabled, the system SHALL provide `AIJumpTactics.evaluateJump` that scores a unit's best jump destination for terrain-clearing, elevation gain, and charge or melee escape, and reports whether jumping risks a shutdown inside the heat lookahead window. Jump heat SHALL be weighed through the multi-turn heat projection from the resource-planning change. `BotPlayer.selectMovementType` SHALL choose the Jump movement type only when the best jump destination's tactical score clears a threshold; otherwise it SHALL NOT jump. When `advancedSystems` is disabled, jump selection SHALL keep the flat-probability roll.
+
+#### Scenario: Bot jumps to clear costly terrain
+
+- **GIVEN** an `Elite` unit whose jump destination is reachable only by walking through heavy terrain at high movement-point cost
+- **WHEN** `evaluateJump` runs
+- **THEN** the jump SHALL receive a high terrain-clearing score
+- **AND** `selectMovementType` SHALL choose Jump
+
+#### Scenario: Heat-unsafe jump is rejected
+
+- **GIVEN** an `Elite` unit whose jump heat would push a shutdown inside the heat lookahead window
+- **WHEN** `evaluateJump` runs
+- **THEN** `heatUnsafe` SHALL be `true`
+- **AND** the jump SHALL NOT be chosen on heat grounds alone
+
+#### Scenario: Bot jumps to escape a charge
+
+- **GIVEN** an `Elite` unit with an enemy adjacent and threatening a physical attack, and a heat-safe jump that breaks adjacency
+- **WHEN** `evaluateJump` runs
+- **THEN** the escape jump SHALL receive a charge-escape bonus
+- **AND** `selectMovementType` SHALL choose Jump
+
+#### Scenario: Lower tier keeps the flat jump roll
+
+- **GIVEN** a `Veteran` unit selecting movement
+- **WHEN** `selectMovementType` runs
+- **THEN** jump selection SHALL use the flat-probability roll unchanged from the pre-change behavior
+
+### Requirement: AI Electronic-Warfare Awareness
+
+When `advancedSystems` is enabled, the system SHALL provide `AIElectronicWarfareAdvisor` that consumes the existing electronic-warfare module to advise move scoring. A destination inside a hostile ECM bubble SHALL incur a penalty scaled by `ecmAvoidanceWeight`. A destination that lets an ECM-suite or BAP-probe carrier cover more lancemates, or counter an enemy ECM source, SHALL earn a bonus scaled by `ecmCoverageWeight`. The advisor SHALL only read electronic-warfare state; it SHALL NOT modify the electronic-warfare module and SHALL NOT alter combat to-hit resolution.
+
+#### Scenario: Bot avoids a hostile ECM bubble
+
+- **GIVEN** an `Elite` unit choosing between a destination inside a hostile ECM bubble and one outside it, with otherwise equal scoring
+- **WHEN** move scoring runs
+- **THEN** the destination outside the bubble SHALL score higher
+
+#### Scenario: ECM carrier is rewarded for covering the lance
+
+- **GIVEN** an `Elite` unit carrying an ECM suite, choosing a destination whose bubble covers two lancemates
+- **WHEN** move scoring runs
+- **THEN** that destination SHALL receive an ECM coverage bonus
+
+#### Scenario: Awareness does not touch combat resolution
+
+- **GIVEN** the electronic-warfare advisor in use
+- **WHEN** the bot scores moves
+- **THEN** no to-hit number, weapon eligibility, or combat-resolution path SHALL be modified by the advisor
+- **AND** the electronic-warfare module SHALL be unchanged
+
+### Requirement: AI Spotting and Vision Awareness
+
+When `advancedSystems` is enabled, the system SHALL provide `AIVisionAdvisor` that consumes the existing fog-of-war module to advise move scoring. A destination that newly spots a previously-unspotted enemy SHALL earn a scouting bonus scaled by `visionWeight`. A destination that breaks an enemy's spotting line to the moving unit SHALL earn a line-of-sight-break bonus scaled by `visionWeight`. The advisor SHALL only read fog-of-war visibility; it SHALL NOT modify the fog-of-war module and SHALL NOT hide enemy positions from the bot's planner.
+
+#### Scenario: Bot repositions to scout an unspotted enemy
+
+- **GIVEN** an `Elite` unit with a destination that newly spots an enemy not previously visible to the bot's side
+- **WHEN** move scoring runs
+- **THEN** that destination SHALL receive a scouting bonus
+
+#### Scenario: Bot values breaking an enemy's spotting line
+
+- **GIVEN** an `Elite` unit choosing between a destination spotted by an enemy and one that breaks that enemy's spotting line, with otherwise equal scoring
+- **WHEN** move scoring runs
+- **THEN** the line-of-sight-breaking destination SHALL score higher
+
+#### Scenario: Vision awareness does not modify fog-of-war
+
+- **GIVEN** the vision advisor in use
+- **WHEN** the bot scores moves
+- **THEN** the fog-of-war module SHALL be unchanged
+- **AND** enemy positions SHALL remain fully available to the bot's planner

--- a/openspec/changes/add-ai-advanced-systems/tasks.md
+++ b/openspec/changes/add-ai-advanced-systems/tasks.md
@@ -1,0 +1,45 @@
+# Tasks: Add AI Advanced Systems
+
+## 1. Advanced Tier Parameters
+
+- [ ] 1.1 Add `IAITierAdvancedParameters` (`advancedSystems`, `jumpTacticsWeight`, `ecmAvoidanceWeight`, `ecmCoverageWeight`, `visionWeight`) and an optional `advanced` block on `IAITierParameters` in `src/simulation/ai/AITierRegistry.ts`
+- [ ] 1.2 Populate the `advanced` block per tier — `Green`/`Regular`/`Veteran` fully inert (`advancedSystems: false`, zeroed weights); `Elite` populated
+- [ ] 1.3 Tests: every tier resolves an `advanced` block; lower tiers keep the flat-roll jump behavior and ignore ECM/vision
+
+## 2. Jump-Jet Tactics
+
+- [ ] 2.1 Create `src/simulation/ai/AIJumpTactics.ts` with `evaluateJump(unit, grid, capability, enemies)` returning `IJumpEvaluation`
+- [ ] 2.2 Score a jump destination for terrain-clearing (jump ignores intervening terrain cost), elevation gain, and charge/melee escape
+- [ ] 2.3 Weigh jump heat through A2's `AIHeatPlanner.projectHeat`; flag `heatUnsafe` when a jump pushes a shutdown inside the lookahead window
+- [ ] 2.4 In `BotPlayer.selectMovementType`, when `advancedSystems` is enabled, choose Jump only when the best jump score clears the tactical threshold; otherwise keep the flat 20% roll
+- [ ] 2.5 Tests: a jump over heavy terrain scores high; a heat-unsafe jump is flagged; a charge-escape jump is taken; a lower tier keeps the flat roll
+
+## 3. ECM Awareness
+
+- [ ] 3.1 Create `src/simulation/ai/AIElectronicWarfareAdvisor.ts` consuming `src/utils/gameplay/electronicWarfare/` without modifying it
+- [ ] 3.2 Compute a `hostileBubblePenalty` for a destination inside a hostile ECM bubble (`isInECMBubble` against `getEnemyECMSources`)
+- [ ] 3.3 Compute a `coverageBonus` for an ECM/probe carrier whose destination covers more lancemates or counters an enemy ECM source
+- [ ] 3.4 Tests: a hex inside hostile ECM is penalized; an ECM carrier covering the lance is rewarded; the `electronicWarfare` module is unmodified
+
+## 4. Spotting and Vision Awareness
+
+- [ ] 4.1 Create `src/simulation/ai/AIVisionAdvisor.ts` consuming `src/lib/multiplayer/server/fogOfWar.ts` without modifying it
+- [ ] 4.2 Compute a `scoutBonus` for a destination that newly spots a previously-unspotted enemy
+- [ ] 4.3 Compute a `losBreakBonus` for a destination that breaks an enemy's spotting line to the moving unit
+- [ ] 4.4 Tests: a destination that scouts an unspotted enemy is rewarded; an LOS-breaking destination is rewarded; `fogOfWar.ts` is unmodified
+
+## 5. Advanced Move Scoring
+
+- [ ] 5.1 In `scoreMove`, add the jump-tactics term (jump moves only), the ECM advice term (`coverageBonus - hostileBubblePenalty`), and the vision advice term (`scoutBonus + losBreakBonus`), each multiplied by its tier weight
+- [ ] 5.2 Gate all three terms on `advancedSystems`; when disabled none apply
+- [ ] 5.3 Tests: an `Elite` bot avoids a hostile ECM bubble; an `Elite` bot jumps to elevation; a `Veteran` bot is unaffected by all three terms
+
+## 6. Verification
+
+- [ ] 6.1 Integration test: an `Elite` bot jumps over an impassable ridge a `Veteran` bot walks around
+- [ ] 6.2 Integration test: an `Elite` bot routes its lance clear of an enemy ECM bubble; a `Veteran` bot walks through it
+- [ ] 6.3 Integration test: an `Elite` bot repositions to scout an unspotted enemy; a `Veteran` bot does not
+- [ ] 6.4 Confirm A4 touches no core combat-resolution code — `electronicWarfare/` and `fogOfWar.ts` are byte-identical to pre-change
+- [ ] 6.5 Determinism test: SimulationRunner golden traces on the `Veteran` tier are byte-identical to pre-change traces
+- [ ] 6.6 `npx openspec validate add-ai-advanced-systems --strict` reports valid
+- [ ] 6.7 Build, lint, and typecheck pass

--- a/openspec/changes/add-ai-coordination-tactics/design.md
+++ b/openspec/changes/add-ai-coordination-tactics/design.md
@@ -1,0 +1,106 @@
+# Design: Add AI Coordination Tactics
+
+## Context
+
+A1 and A2 made each bot unit smart on its own — terrain-aware movement, multi-turn resource planning. But a lance of four smart loners still loses to a lance of four mediocre units that focus-fire and move together. `BotPlayer` decides one unit at a time: `playAttackPhase` scores targets from that unit's view, `playMovementPhase` builds a `highestThreatTarget` from that unit's view, and nothing ties the four decisions together. The result is spread damage (four units chipping four targets, killing none) and a broken formation (one mech sprinting ahead into a kill-box).
+
+A3a adds the lance layer. Once per side per turn, an `AILancePlanner` computes a shared threat picture and a fire-assignment plan; each unit's existing per-unit decision then runs *within* that plan. A3a registers a coordination parameter block into the AI Difficulty Tier Registry from A1 and is the first half of the `Elite` tier. `Green`/`Regular`/`Veteran` leave the block inert (so `Veteran` is exactly A1+A2 depth, per the council decision); `Elite` switches it on.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Aggregate enemy threat against the whole friendly lance into one shared ranking.
+- Coordinate fire so the lance concentrates damage and finishes targets.
+- Keep the lance in formation through a movement cohesion term.
+- Run one deterministic per-lance plan that the existing per-unit decisions consume.
+
+**Non-Goals:**
+
+- Objective-aware coordination (A3b), cross-lance/army strategy, jump-jet/ECM spacing (A4).
+- Fog-of-war on the bot's view of its *own* side — the planner has full friendly knowledge.
+
+## Decisions
+
+### D1. `AIThreatMap` — lance-wide threat aggregation
+
+A pure module aggregates threat across the lance. For every enemy it sums that enemy's `scoreTarget`-style threat against *each* friendly unit, producing a single ranked threat list shared by the whole lance — not four separate per-unit views. The aggregation reuses A2's threat scoring so the numbers stay consistent with single-unit reasoning.
+
+```typescript
+interface IThreatEntry {
+  readonly enemyId: string;
+  /** Summed threat this enemy poses across all friendly lance units. */
+  readonly aggregateThreat: number;
+  /** Friendly units that can engage this enemy this turn. */
+  readonly engageableBy: readonly string[];
+}
+
+function buildThreatMap(
+  friendly: readonly IAIUnitState[],
+  enemies: readonly IAIUnitState[],
+): readonly IThreatEntry[];
+```
+
+### D2. `AIFireCoordinator` — focus-fire assignment
+
+A pure module assigns friendly units to targets. The objective is to **finish targets**: it prefers an assignment where the combined expected damage of the units assigned to a target meets or exceeds that target's remaining durability, concentrating fire rather than spreading it. When no target is finishable, it concentrates on the highest-aggregate-threat target the most units can engage. The output is a `Map<friendlyUnitId, targetId>` that `playAttackPhase` consults: a unit's `selectTarget` is biased toward its assigned target, falling back to its own `scoreTarget` pick when the assigned target is out of arc or range.
+
+```typescript
+interface IFireAssignment {
+  /** friendlyUnitId -> assigned targetId. */
+  readonly assignments: ReadonlyMap<string, string>;
+  /** Targets the lance's assigned firepower can finish this turn. */
+  readonly finishableTargets: readonly string[];
+}
+```
+
+### D3. Formation cohesion in `scoreMove`
+
+`scoreMove` gains a cohesion term, multiplied by the tier `cohesionWeight`: `-cohesionWeight` scaled by how far the destination sits beyond `cohesionRadius` from the lance centroid, plus an extra penalty when the destination puts the unit into enemy LOS *while no lancemate is within `cohesionRadius`* (advancing alone). A unit inside the radius pays nothing. The term is additive over A1's terrain-aware scoring and A2 is unaffected.
+
+### D4. `AILancePlanner` — one plan per side per turn
+
+`AILancePlanner.planTurn(friendly, enemies)` runs once per side at the start of the turn: it builds the threat map (D1) and the fire assignments (D2), and computes the lance centroid for cohesion (D3). The plan is an immutable value passed into each unit's `playMovementPhase`/`playAttackPhase` call. Per-unit decisions are unchanged in shape — they just read the plan. `BotPlayer` gains an optional lance-context parameter; callers that do not pass it get today's per-unit behavior.
+
+```typescript
+interface ILanceTurnPlan {
+  readonly threatMap: readonly IThreatEntry[];
+  readonly fireAssignment: IFireAssignment;
+  readonly lanceCentroid: IHexCoordinate;
+}
+```
+
+### D5. A3a registers a coordination block into the Tier Registry
+
+`AITierRegistry` gains a `coordination` block on `IAITierParameters`:
+
+```typescript
+interface IAITierCoordinationParameters {
+  readonly lanceCoordination: boolean; // false = per-unit only
+  readonly cohesionRadius: number;     // hexes
+  readonly cohesionWeight: number;
+  readonly focusFireWeight: number;
+}
+```
+
+`Green`/`Regular`/`Veteran` set `lanceCoordination: false` with zeroed weights — fully inert; `Veteran` therefore stays exactly A1+A2 depth. `Elite` populates the block. This is an ADDED requirement; A1's and A2's blocks are untouched.
+
+### D6. Determinism
+
+The threat map, fire assignment, centroid, and cohesion term are all pure functions of the unit set. The fire assignment uses a deterministic greedy algorithm with canonical unit-ID ordering for tie-breaks — no `SeededRandom` is consumed inside the planner. The existing per-unit tie-breaks in `selectMove`/`selectTarget` are unchanged, so SimulationRunner seed sequences stay stable.
+
+## Risks / Trade-offs
+
+- **[Risk] Focus-fire over-concentrates and ignores an emerging second threat** → Mitigation: when a target is already finishable by fewer units, the coordinator releases the surplus to the next-ranked threat rather than dog-piling.
+- **[Risk] Cohesion pins a unit out of effective range so it never fires** → Mitigation: cohesion is an additive penalty bounded by `cohesionWeight`, not a hard leash; A1's LOS/arc terms can outweigh it when a strong shot is available.
+- **[Risk] The lance plan and per-unit decision disagree (assigned target unreachable)** → Mitigation: the assignment is a *bias*, not a mandate; `playAttackPhase` falls back to the unit's own `scoreTarget` pick when the assigned target is out of arc/range.
+- **[Risk] Registering a coordination block breaks the all-ADDED rule** → Mitigation: `coordination` is a new optional field; this change ADDs a separate requirement and never modifies A1's or A2's.
+
+## Migration Plan
+
+Purely additive. `Green`/`Regular`/`Veteran` tiers set `lanceCoordination: false`, so the lance planner is never consulted and every existing bot, the swarm harness, and SimulationRunner golden traces are unaffected until a caller selects `Elite`. `BotPlayer`'s new lance-context parameter is optional — callers that do not pass it get today's per-unit behavior. No database migrations — coordination parameters live in the tier registry. Rollback = revert the change-set; the planner modules become dead code with no behavior change.
+
+## Open Questions
+
+- Default `cohesionRadius` for `Elite` — proposed `4` hexes; tight enough to mass fire, loose enough to use terrain. Revisit after swarm-harness tuning.
+- Whether the lance plan should also pre-assign retreat order (which unit covers a withdrawal) — proposed: out of scope for A3a; retreat stays per-unit (`add-bot-retreat-behavior`), revisit if coordinated withdrawal is wanted.

--- a/openspec/changes/add-ai-coordination-tactics/proposal.md
+++ b/openspec/changes/add-ai-coordination-tactics/proposal.md
@@ -1,0 +1,34 @@
+# Change: Add AI Coordination Tactics
+
+## Why
+
+The bot fights every unit as an island. `BotPlayer.playMovementPhase` and `playAttackPhase` (`src/simulation/ai/BotPlayer.ts`) take a single `unit` plus the flat `allUnits` list and decide in isolation — `scoreTarget` picks the most threatening enemy *from that one unit's view*, and `scoreMove`'s forward-arc bonus chases that one unit's `highestThreatTarget`. Nothing aggregates threat across a lance, nothing concentrates fire so two units finish a target in one turn instead of spreading damage across two, and nothing keeps a formation together so a lone bot mech does not wander into a kill-box ahead of its lancemates. A competent opponent focus-fires and moves as a unit; the current bot does neither.
+
+This change adds the lance-level layer: multi-unit threat aggregation, focus-fire target coordination, and formation cohesion in movement. It registers its parameters into the AI Difficulty Tier Registry from A1 and is the first half of the `Elite` tier.
+
+## What Changes
+
+- ADDED multi-unit threat aggregation: `AIThreatMap` aggregates every enemy's threat against the *whole* friendly lance, producing a shared threat ranking instead of per-unit views
+- ADDED focus-fire coordination: `AIFireCoordinator` assigns lance units to targets so combined firepower concentrates on a small number of targets — preferring a target the lance can finish this turn
+- ADDED formation cohesion in movement: `scoreMove` gains a cohesion term that rewards staying within a configurable radius of the lance centroid and penalizes a unit advancing alone into enemy LOS
+- ADDED a per-lance turn plan: `AILancePlanner` runs once per side per turn, computes the threat map and fire assignments, and feeds each unit's individual move/attack decision
+- ADDED A3a's parameter block to the AI Difficulty Tier Registry — cohesion radius, cohesion weight, focus-fire weight, and a `lanceCoordination` flag; lower tiers leave these inert
+
+## Dependencies
+
+- **Requires**: `add-ai-terrain-aware-movement` (A1) — consumes the pathfinder API for cohesion-aware pathing and registers its parameter block into the Tier Registry
+- **Required By**: `add-ai-objective-awareness` (A3b) — A3b's objective play is layered on the lance plan A3a produces
+
+## Impact
+
+- Affected specs: `simulation-system` (ADDED requirements only)
+- Affected code: `src/simulation/ai/BotPlayer.ts` (consume the lance plan in `playMovementPhase`/`playAttackPhase`), `src/simulation/ai/MoveAI.ts` (cohesion term in `scoreMove`), `src/simulation/ai/types.ts` (coordination parameter block, lance-context types), new `src/simulation/ai/AIThreatMap.ts`, new `src/simulation/ai/AIFireCoordinator.ts`, new `src/simulation/ai/AILancePlanner.ts`, `src/simulation/ai/AITierRegistry.ts` (register the coordination block)
+- No database migrations — coordination parameters live in the tier registry
+- Reproducibility preserved: threat aggregation, fire assignment, and the lance plan are pure deterministic functions of the unit set; ties break via `SeededRandom`
+
+## Non-Goals
+
+- Objective-aware coordination (sending a unit to capture a hex) — that is A3b, layered on this change's lance plan
+- Cross-lance / army-level strategy — A3a coordinates one lance; multi-lance command is out of scope for Wave 2
+- Jump-jet repositioning tactics and ECM-aware spacing — A4
+- Inter-unit communication latency or fog-of-war on the bot's own threat map — the bot plans with full knowledge of its own side

--- a/openspec/changes/add-ai-coordination-tactics/specs/simulation-system/spec.md
+++ b/openspec/changes/add-ai-coordination-tactics/specs/simulation-system/spec.md
@@ -1,0 +1,109 @@
+## ADDED Requirements
+
+### Requirement: Coordination Tier Parameters
+
+The AI Difficulty Tier Registry SHALL carry a coordination parameter block on each tier, exposing `lanceCoordination`, `cohesionRadius`, `cohesionWeight`, and `focusFireWeight`. The `Green`, `Regular`, and `Veteran` tiers SHALL set `lanceCoordination` to `false` with zeroed weights, leaving all coordination behavior inert so the `Veteran` tier remains exactly the depth of the movement and resource blocks. The `Elite` tier SHALL populate the block with active values. This block SHALL be registered additively and SHALL NOT modify the movement or resource parameter blocks.
+
+#### Scenario: Every tier resolves a coordination block
+
+- **GIVEN** the tier names `Green`, `Regular`, `Veteran`, and `Elite`
+- **WHEN** the coordination parameter block is read for each
+- **THEN** each SHALL return a populated `IAITierCoordinationParameters` record
+
+#### Scenario: Veteran tier excludes coordination
+
+- **GIVEN** a bot configured with the `Veteran` tier
+- **WHEN** it plans a turn
+- **THEN** the lance planner SHALL NOT be consulted
+- **AND** target selection and movement SHALL match the per-unit behavior of the movement and resource tiers
+
+### Requirement: Multi-Unit Threat Aggregation
+
+When `lanceCoordination` is enabled, the system SHALL provide `AIThreatMap.buildThreatMap` that aggregates each enemy's threat across every friendly lance unit into a single ranked list of `IThreatEntry` records. Each entry SHALL carry the enemy identifier, the summed threat the enemy poses across the lance, and the friendly units that can engage that enemy this turn. The aggregation SHALL be a pure deterministic function, independent of the order of the input unit lists.
+
+#### Scenario: Higher aggregate threat ranks first
+
+- **GIVEN** two enemies, one posing a large summed threat across the lance and one posing a small threat
+- **WHEN** `buildThreatMap` runs
+- **THEN** the high-threat enemy SHALL rank above the low-threat enemy
+
+#### Scenario: Aggregation is order-independent
+
+- **GIVEN** the same friendly and enemy unit sets supplied in two different orders
+- **WHEN** `buildThreatMap` runs for each
+- **THEN** both threat maps SHALL be identical
+
+#### Scenario: Engageable list excludes out-of-range units
+
+- **GIVEN** an enemy that one friendly unit can reach this turn and another cannot
+- **WHEN** `buildThreatMap` runs
+- **THEN** the enemy's `engageableBy` list SHALL contain only the friendly unit that can reach it
+
+### Requirement: Focus-Fire Coordination
+
+When `lanceCoordination` is enabled, the system SHALL provide `AIFireCoordinator` that produces an `IFireAssignment` mapping friendly units to targets. The coordinator SHALL prefer assignments whose combined expected damage finishes a target this turn, concentrating fire rather than spreading it. When a target is finishable by fewer units than assigned, the surplus firepower SHALL be released to the next-ranked threat. When no target is finishable, the lance SHALL concentrate on the highest-aggregate-threat target the most units can engage. `playAttackPhase` SHALL bias each unit's target selection toward its assigned target, falling back to the unit's own threat-scored pick when the assigned target is out of arc or range.
+
+#### Scenario: Lance concentrates fire to finish a target
+
+- **GIVEN** a target that one friendly unit cannot destroy alone but two can together
+- **WHEN** fire coordination runs on an `Elite` lance
+- **THEN** both units SHALL be assigned to that target
+- **AND** the target SHALL appear in `finishableTargets`
+
+#### Scenario: Surplus firepower is released
+
+- **GIVEN** a target already finishable by two units and a third unit that could also engage it
+- **WHEN** fire coordination runs
+- **THEN** the third unit SHALL be assigned to the next-ranked threat rather than the already-finishable target
+
+#### Scenario: Unreachable assignment falls back to the unit's own pick
+
+- **GIVEN** a unit assigned a target that is out of its weapons' arc and range
+- **WHEN** `playAttackPhase` runs
+- **THEN** the unit SHALL fall back to its own threat-scored target selection
+- **AND** no error SHALL be raised
+
+### Requirement: Formation Cohesion Movement
+
+When `lanceCoordination` is enabled, `MoveAI` SHALL extend move scoring with a cohesion term, multiplied by `cohesionWeight`, that penalizes a destination lying beyond `cohesionRadius` from the lance centroid and applies an additional penalty when the destination enters enemy line of sight while no lancemate is within `cohesionRadius`. A unit whose destination is inside the cohesion radius SHALL pay no cohesion penalty. The cohesion term SHALL be additive over the terrain-aware scoring terms. When `lanceCoordination` is disabled, the cohesion term SHALL contribute zero.
+
+#### Scenario: Drifting unit is pulled back toward the lance
+
+- **GIVEN** an `Elite` bot choosing between a destination inside `cohesionRadius` of the lance centroid and one beyond it, with otherwise equal scoring
+- **WHEN** move scoring runs
+- **THEN** the in-radius destination SHALL score higher
+
+#### Scenario: Advancing alone into enemy line of sight is penalized
+
+- **GIVEN** a destination that enters enemy line of sight with no lancemate within `cohesionRadius`
+- **WHEN** move scoring runs on an `Elite` bot
+- **THEN** that destination SHALL receive the additional lone-advance penalty
+
+#### Scenario: In-formation unit is unaffected
+
+- **GIVEN** a unit whose destination is inside `cohesionRadius` of the lance centroid
+- **WHEN** move scoring runs
+- **THEN** the cohesion term SHALL contribute zero to its score
+
+### Requirement: Per-Lance Turn Plan
+
+When `lanceCoordination` is enabled, the system SHALL provide `AILancePlanner.planTurn` that runs once per side per turn and returns an immutable `ILanceTurnPlan` carrying the aggregated threat map, the fire assignment, and the lance centroid. Each unit's movement and attack decisions SHALL consume this plan. `BotPlayer` SHALL accept an optional lance-context parameter; when it is omitted, the bot SHALL fall back to per-unit decisions identical to the pre-change behavior. The lance plan SHALL be a pure deterministic function of the unit set and SHALL NOT consume `SeededRandom`.
+
+#### Scenario: One plan drives every unit in the lance
+
+- **GIVEN** an `Elite` lance of four units beginning a turn
+- **WHEN** `planTurn` runs
+- **THEN** a single `ILanceTurnPlan` SHALL be produced
+- **AND** all four units' move and attack decisions SHALL read from that one plan
+
+#### Scenario: Omitting the lance context preserves per-unit behavior
+
+- **GIVEN** a `BotPlayer` call made without the lance-context parameter
+- **WHEN** the movement and attack phases run
+- **THEN** the decisions SHALL be identical to the pre-change per-unit behavior
+
+#### Scenario: The plan is deterministic
+
+- **GIVEN** the same friendly and enemy unit sets
+- **WHEN** `planTurn` is called twice
+- **THEN** both plans SHALL contain identical threat maps, fire assignments, and centroids

--- a/openspec/changes/add-ai-coordination-tactics/tasks.md
+++ b/openspec/changes/add-ai-coordination-tactics/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Add AI Coordination Tactics
+
+## 1. Coordination Tier Parameters
+
+- [ ] 1.1 Add `IAITierCoordinationParameters` (`lanceCoordination`, `cohesionRadius`, `cohesionWeight`, `focusFireWeight`) and an optional `coordination` block on `IAITierParameters` in `src/simulation/ai/AITierRegistry.ts`
+- [ ] 1.2 Populate the `coordination` block per tier — `Green`/`Regular`/`Veteran` fully inert (`lanceCoordination: false`, zeroed weights); `Elite` populated
+- [ ] 1.3 Tests: every tier resolves a `coordination` block; `Veteran` stays exactly A1+A2 depth (coordination disabled)
+
+## 2. Multi-Unit Threat Aggregation
+
+- [ ] 2.1 Create `src/simulation/ai/AIThreatMap.ts` with `buildThreatMap(friendly, enemies)` returning ranked `IThreatEntry` records
+- [ ] 2.2 Sum each enemy's threat across every friendly lance unit, reusing A2's threat scoring
+- [ ] 2.3 Populate `engageableBy` with the friendly units that can reach each enemy this turn
+- [ ] 2.4 Tests: a high-threat enemy ranks above a low-threat enemy; aggregation is order-independent; `engageableBy` excludes out-of-range units
+
+## 3. Focus-Fire Coordination
+
+- [ ] 3.1 Create `src/simulation/ai/AIFireCoordinator.ts` producing an `IFireAssignment` (`assignments` map + `finishableTargets`)
+- [ ] 3.2 Prefer assignments where combined expected damage finishes a target this turn
+- [ ] 3.3 Release surplus firepower from an already-finishable target to the next-ranked threat
+- [ ] 3.4 When no target is finishable, concentrate on the highest-aggregate-threat target the most units can engage
+- [ ] 3.5 In `playAttackPhase`, bias `selectTarget` toward the assigned target, falling back to the unit's own pick when the assignment is out of arc/range
+- [ ] 3.6 Tests: two units finishing one target concentrate fire; surplus is released; an unreachable assignment falls back cleanly
+
+## 4. Formation Cohesion
+
+- [ ] 4.1 Add a cohesion term to `scoreMove`, multiplied by `cohesionWeight`, penalizing destinations beyond `cohesionRadius` from the lance centroid
+- [ ] 4.2 Add an extra penalty when the destination enters enemy line of sight with no lancemate within `cohesionRadius`
+- [ ] 4.3 A unit inside the cohesion radius SHALL pay no cohesion penalty
+- [ ] 4.4 Gate the cohesion term on `lanceCoordination`; when disabled it contributes zero
+- [ ] 4.5 Tests: a unit drifting from the lance is pulled back; advancing alone into enemy LOS is penalized; an in-radius unit is unaffected
+
+## 5. Per-Lance Turn Plan
+
+- [ ] 5.1 Create `src/simulation/ai/AILancePlanner.ts` with `planTurn(friendly, enemies)` returning an immutable `ILanceTurnPlan`
+- [ ] 5.2 Compute the threat map, fire assignment, and lance centroid once per side per turn
+- [ ] 5.3 Add an optional lance-context parameter to `BotPlayer.playMovementPhase`/`playAttackPhase`; callers that omit it get the per-unit behavior
+- [ ] 5.4 Tests: the plan is deterministic for a given unit set; per-unit decisions consume the plan; omitting the context reproduces pre-change behavior
+
+## 6. Verification
+
+- [ ] 6.1 Integration test: an `Elite` lance focus-fires and destroys a target in one turn where a `Veteran` lance spreads damage and kills none
+- [ ] 6.2 Integration test: an `Elite` lance advances in formation; a `Veteran` lance lets a unit wander ahead
+- [ ] 6.3 Determinism test: SimulationRunner golden traces on the `Veteran` tier are byte-identical to pre-change traces
+- [ ] 6.4 `npx openspec validate add-ai-coordination-tactics --strict` reports valid
+- [ ] 6.5 Build, lint, and typecheck pass

--- a/openspec/changes/add-ai-objective-awareness/design.md
+++ b/openspec/changes/add-ai-objective-awareness/design.md
@@ -1,0 +1,114 @@
+# Design: Add AI Objective Awareness
+
+## Context
+
+Wave 1's `add-scenario-objective-engine` supplies the spatial objective system: `IObjectiveMarker` records on a `objectives: Record<HexKey, IObjectiveMarker>` session map, control detection, and `evaluateObjectiveOutcome`. A3a's `AILancePlanner` supplies a per-side per-turn plan with threat aggregation and fire assignments. Neither talks to the other: the bot wins a `Capture` scenario only by accident, defends an objective by chasing the enemy away from it, and never walks the exit edge in a `Breakthrough`.
+
+A3b is the connector. It reads the objective map, classifies each marker by what the bot must do with it, extends A3a's `ILanceTurnPlan` with an objective layer, and adds an objective scoring term so movement and target selection serve the scenario rather than pure attrition. A3b registers an objective parameter block into the AI Difficulty Tier Registry from A1 and is the second half of the `Elite` tier — `Green`/`Regular`/`Veteran` leave it inert and the bot plays `Destroy` only.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Read the session's objective map and objective type; classify each marker as take / hold / deny for the bot's side.
+- Extend A3a's lance plan with objective role assignments (capture, hold, screen).
+- Make movement seek take-objectives and stay on hold-objectives.
+- Keep target selection from abandoning an objective the bot must hold or capture.
+
+**Non-Goals:**
+
+- Modifying objective markers, placement, control detection, or victory evaluation — owned by `add-scenario-objective-engine`.
+- `Escort`/`Recon` types (the engine defers them), objective-aware retreat, feints/sequencing.
+
+## Decisions
+
+### D1. `AIObjectivePlanner` — read and classify the objective map
+
+A pure module reads `session.objectives` and the scenario objective type and classifies each marker for the bot's side:
+
+- **take** — a marker the bot must control to win (an attacker's `Capture` marker; a `Breakthrough` exit hex).
+- **hold** — a marker the bot must keep controlling to win (a defender's `Defend`/`Capture` marker it already holds or owns).
+- **deny** — a marker the bot must keep the enemy off (an attacker's marker the bot is defending against capture).
+
+When the objective map is empty the planner classifies the scenario as `Destroy` and produces no objective roles — the bot falls through to pure A3a behavior.
+
+```typescript
+type ObjectiveIntent = 'take' | 'hold' | 'deny';
+
+interface IClassifiedObjective {
+  readonly marker: IObjectiveMarker;
+  readonly intent: ObjectiveIntent;
+}
+
+function classifyObjectives(
+  session: IGameSession,
+  botSide: GameSide,
+): readonly IClassifiedObjective[];
+```
+
+### D2. Objective layer on the `ILanceTurnPlan`
+
+A3a's `ILanceTurnPlan` gains an optional `objectivePlan` field. `AILancePlanner.planTurn` calls `AIObjectivePlanner` and, when objective awareness is enabled and the scenario is not `Destroy`, assigns each unit an objective role:
+
+- **capture role** — assigned to the unit(s) closest (by A1 pathfinder cost) to a `take` marker.
+- **hold role** — assigned to the unit(s) currently on or nearest a `hold` marker.
+- **screen role** — every other unit; it plays normal A3a coordinated combat, covering the objective units.
+
+```typescript
+type ObjectiveRole = 'capture' | 'hold' | 'screen';
+
+interface IObjectiveLancePlan {
+  readonly scenarioType: ScenarioObjectiveType;
+  readonly roles: ReadonlyMap<string, ObjectiveRole>;
+  /** Per role-bearing unit, the hex it is working toward or holding. */
+  readonly targetHexes: ReadonlyMap<string, IHexCoordinate>;
+}
+```
+
+### D3. Objective term in `scoreMove`
+
+`scoreMove` gains an objective term, multiplied by tier weights:
+
+- For a **capture-role** unit: `+objectiveSeekingWeight` scaled by reduction in pathfinder distance to its `take` marker, with a large bonus for a destination *on* the marker hex.
+- For a **hold-role** unit: `+objectiveHoldWeight` for a destination on its `hold` marker, scaled-down for destinations adjacent to it (engage from cover near the marker), and zero for destinations that abandon it.
+- For a **screen-role** unit: the objective term contributes zero — it plays pure A3a movement.
+
+The term is additive over A1's terrain-aware and A3a's cohesion terms. A capture unit still values cover and LOS; the objective term tilts the balance toward the marker.
+
+### D4. Objective-aware target discipline
+
+When a unit has a `capture` or `hold` role, `playAttackPhase` constrains target selection: it prefers targets engageable *without leaving the objective hex or its path to it*. The bot fires from the marker rather than chasing an enemy off it. A `screen`-role unit's target selection is unchanged from A3a. This is a bias on top of A3a's fire assignment, not a replacement — a hold unit still focus-fires with the lance, it just will not pursue.
+
+### D5. A3b registers an objective block into the Tier Registry
+
+`AITierRegistry` gains an `objective` block on `IAITierParameters`:
+
+```typescript
+interface IAITierObjectiveParameters {
+  readonly objectiveAwareness: boolean;   // false = play Destroy only
+  readonly objectiveSeekingWeight: number;
+  readonly objectiveHoldWeight: number;
+}
+```
+
+`Green`/`Regular`/`Veteran` set `objectiveAwareness: false` with zeroed weights — the bot ignores the objective map and plays pure attrition. `Elite` populates the block. This is an ADDED requirement; the movement, resource, and coordination blocks are untouched.
+
+### D6. Determinism
+
+Classification, role assignment, and the objective scoring term are pure functions of the objective map and the unit set. Role assignment uses A1's deterministic pathfinder cost with canonical unit-ID tie-breaks — no `SeededRandom` is consumed. Existing per-unit tie-breaks are unchanged, so SimulationRunner seed sequences stay stable.
+
+## Risks / Trade-offs
+
+- **[Risk] A capture unit walks onto an undefended marker and gets focus-fired off it** → Mitigation: screen-role units cover objective units via A3a coordination; the objective term tilts movement but A1's cover/LOS terms still apply, so the capture unit prefers a covered approach.
+- **[Risk] A hold unit refuses a strong shot because the target is slightly off-objective** → Mitigation: target discipline is a bias bounded by the objective weights; a target engageable from the marker hex is always preferred, but the unit still fires on the best available in-discipline target.
+- **[Risk] Objective map present but objective type is `Destroy`** → Mitigation: `classifyObjectives` keys off the scenario objective type; a `Destroy` scenario yields no roles regardless of stray markers, and the bot plays pure A3a.
+- **[Risk] Registering an objective block breaks the all-ADDED rule** → Mitigation: `objective` is a new optional field; this change ADDs a separate requirement and never modifies A1's, A2's, or A3a's.
+
+## Migration Plan
+
+Purely additive. `Green`/`Regular`/`Veteran` tiers set `objectiveAwareness: false`, so the objective planner is never consulted and the bot plays `Destroy` exactly as A3a does — every existing bot, the swarm harness, and SimulationRunner golden traces are unaffected until a caller selects `Elite`. The `objectivePlan` field on `ILanceTurnPlan` is optional; A3a plans without it are unchanged. A3b only *reads* the objective map; it never writes markers, so the objective engine is untouched. No database migrations. Rollback = revert the change-set; `AIObjectivePlanner` becomes dead code with no behavior change.
+
+## Open Questions
+
+- How many units to commit to a `take` marker — proposed: the single closest unit per marker, with screen units covering; revisit if capture units are picked off before reaching the hex.
+- Whether a hold unit should ever leave its marker to finish a near-dead enemy (a guaranteed kill that removes the only contester) — proposed: out of scope for A3b; target discipline always keeps the unit on-objective. Revisit after swarm-harness tuning.

--- a/openspec/changes/add-ai-objective-awareness/proposal.md
+++ b/openspec/changes/add-ai-objective-awareness/proposal.md
@@ -1,0 +1,35 @@
+# Change: Add AI Objective Awareness
+
+## Why
+
+Wave 1's `add-scenario-objective-engine` made `Capture`, `Defend`, and `Breakthrough` scenarios winnable — but only by a human. The bot still plays every scenario as `Destroy`: `BotPlayer` and the `AILancePlanner` from A3a reason purely about enemy threat and never read the `objectives: Record<HexKey, IObjectiveMarker>` map on the game session. A bot defending an objective will happily chase an enemy off the hex it is supposed to hold; a bot attacking a capture objective will trade fire in the open instead of walking onto the marker; a bot in a breakthrough scenario never heads for the exit edge. The objective engine exists, the lance planner exists — nothing connects them.
+
+This change makes the bot read scenario objective markers and *play the scenario*: hold what it must hold, take what it must take, and run the exit when that wins. It registers its parameters into the AI Difficulty Tier Registry from A1 and is the second half of the `Elite` tier.
+
+## What Changes
+
+- ADDED objective ingestion: `AIObjectivePlanner` reads the session's `objectives` map and the scenario objective type, classifying each marker as one the bot must take, hold, or deny
+- ADDED objective-aware lance planning: the `ILanceTurnPlan` from A3a gains an objective layer — units are assigned objective roles (capture, hold, screen) alongside their fire assignments
+- ADDED objective-seeking movement: `scoreMove` gains an objective term that rewards moving onto or toward a marker the bot must take, and rewards staying on a marker the bot must hold
+- ADDED objective-aware target discipline: when holding or capturing, the bot's target selection is biased away from chasing enemies off the objective hex — it engages from the marker rather than abandoning it
+- ADDED A3b's parameter block to the AI Difficulty Tier Registry — objective-seeking weight, objective-hold weight, and an `objectiveAwareness` flag; lower tiers leave these inert and the bot plays `Destroy` only
+
+## Dependencies
+
+- **Requires**: Wave 1 `add-scenario-objective-engine` — the `IObjectiveMarker` data model, the `objectives` session map, and the objective-type enum the bot reads
+- **Requires**: `add-ai-coordination-tactics` (A3a) — the objective layer extends the `ILanceTurnPlan`; objective roles are assigned alongside fire assignments
+- **Required By**: none within Wave 2
+
+## Impact
+
+- Affected specs: `simulation-system` (ADDED requirements only)
+- Affected code: `src/simulation/ai/AILancePlanner.ts` (objective layer on the plan), `src/simulation/ai/MoveAI.ts` (objective term in `scoreMove`), `src/simulation/ai/BotPlayer.ts` (objective-aware target discipline), `src/simulation/ai/types.ts` (objective parameter block, objective-role types), new `src/simulation/ai/AIObjectivePlanner.ts`, `src/simulation/ai/AITierRegistry.ts` (register the objective block)
+- No database migrations — objective parameters live in the tier registry; objective markers are read from the existing session map
+- Reproducibility preserved: objective classification, role assignment, and scoring are pure deterministic functions of the objective map and unit set; ties break via `SeededRandom`
+
+## Non-Goals
+
+- Changing objective markers, placement, control detection, or victory evaluation — those are owned by `add-scenario-objective-engine`; A3b only *reads* the markers
+- `Escort` and `Recon` objective types — the objective engine itself defers them; A3b plays only the types the engine evaluates (`Destroy`, `Capture`, `Defend`, `Breakthrough`)
+- Objective-aware retreat (sacrificing an objective to save a unit) — retreat stays per-unit (`add-bot-retreat-behavior`)
+- Multi-objective sequencing or feints — the bot plays the objective map as evaluated, with no deception layer

--- a/openspec/changes/add-ai-objective-awareness/specs/simulation-system/spec.md
+++ b/openspec/changes/add-ai-objective-awareness/specs/simulation-system/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: Objective-Awareness Tier Parameters
+
+The AI Difficulty Tier Registry SHALL carry an objective parameter block on each tier, exposing `objectiveAwareness`, `objectiveSeekingWeight`, and `objectiveHoldWeight`. The `Green`, `Regular`, and `Veteran` tiers SHALL set `objectiveAwareness` to `false` with zeroed weights, leaving the bot blind to the objective map so it plays every scenario as `Destroy`. The `Elite` tier SHALL populate the block with active values. This block SHALL be registered additively and SHALL NOT modify the movement, resource, or coordination parameter blocks.
+
+#### Scenario: Every tier resolves an objective block
+
+- **GIVEN** the tier names `Green`, `Regular`, `Veteran`, and `Elite`
+- **WHEN** the objective parameter block is read for each
+- **THEN** each SHALL return a populated `IAITierObjectiveParameters` record
+
+#### Scenario: Lower tiers ignore the objective map
+
+- **GIVEN** a bot configured with the `Green`, `Regular`, or `Veteran` tier playing a `Capture` scenario
+- **WHEN** it plans a turn
+- **THEN** the objective planner SHALL NOT be consulted
+- **AND** the bot SHALL play the scenario as pure attrition
+
+### Requirement: Objective Ingestion and Classification
+
+When `objectiveAwareness` is enabled, the system SHALL provide `AIObjectivePlanner.classifyObjectives` that reads the game session's `objectives` map and scenario objective type and classifies each marker for the bot's side as `take` (a marker the bot must control to win), `hold` (a marker the bot must keep controlling to win), or `deny` (a marker the bot must keep the enemy off). An empty objective map or a `Destroy` scenario type SHALL yield no classified objectives. Classification SHALL be a pure deterministic function and SHALL NOT modify any objective marker.
+
+#### Scenario: Attacker capture marker classifies as take
+
+- **GIVEN** a `Capture` scenario where the bot is the attacking side
+- **WHEN** `classifyObjectives` runs
+- **THEN** each objective marker SHALL be classified `take`
+
+#### Scenario: Defender objective marker classifies as hold
+
+- **GIVEN** a `Defend` scenario where the bot is the defending side
+- **WHEN** `classifyObjectives` runs
+- **THEN** each objective marker SHALL be classified `hold`
+
+#### Scenario: Destroy scenario yields no objectives
+
+- **GIVEN** a scenario whose objective type is `Destroy`, with or without stray markers
+- **WHEN** `classifyObjectives` runs
+- **THEN** it SHALL return an empty list
+- **AND** the bot SHALL fall through to pure coordinated combat
+
+### Requirement: Objective-Aware Lance Planning
+
+When `objectiveAwareness` is enabled and the scenario objective type is not `Destroy`, the per-lance turn plan SHALL carry an objective plan assigning each unit an objective role — `capture`, `hold`, or `screen`. The capture role SHALL be assigned to the unit(s) closest by terrain-pathfinder cost to a `take` marker; the hold role to the unit(s) on or nearest a `hold` marker; the screen role to every other unit. Each role-bearing unit SHALL carry the hex it is working toward or holding. Role assignment SHALL be a pure deterministic function of the objective map and unit positions.
+
+#### Scenario: Capture role goes to the nearest unit
+
+- **GIVEN** a `take` marker and two friendly units at different pathfinder distances from it
+- **WHEN** the objective plan is computed
+- **THEN** the closer unit SHALL receive the `capture` role
+
+#### Scenario: Hold role goes to the unit on the marker
+
+- **GIVEN** a `hold` marker currently occupied by one friendly unit
+- **WHEN** the objective plan is computed
+- **THEN** that unit SHALL receive the `hold` role with the marker hex as its target hex
+
+#### Scenario: Remaining units screen
+
+- **GIVEN** a lance with one capture-role unit and one hold-role unit assigned
+- **WHEN** the objective plan is computed
+- **THEN** every other unit SHALL receive the `screen` role with no objective hex
+
+### Requirement: Objective-Seeking Movement
+
+When `objectiveAwareness` is enabled, `MoveAI` SHALL extend move scoring with an objective term. For a capture-role unit the term SHALL grant `objectiveSeekingWeight` scaled by the reduction in pathfinder distance to its `take` marker, with a large bonus for a destination on the marker hex. For a hold-role unit the term SHALL grant `objectiveHoldWeight` for a destination on its `hold` marker, a reduced value for adjacent hexes, and zero for destinations that abandon the marker. A screen-role unit SHALL receive a zero objective contribution. The objective term SHALL be additive over the terrain-aware and cohesion terms. When `objectiveAwareness` is disabled, the objective term SHALL contribute zero.
+
+#### Scenario: Capture unit moves onto its objective
+
+- **GIVEN** an `Elite` capture-role unit with a candidate destination on its `take` marker and another off it
+- **WHEN** move scoring runs
+- **THEN** the on-marker destination SHALL score higher
+- **AND** the unit SHALL move toward the marker
+
+#### Scenario: Hold unit stays on its objective
+
+- **GIVEN** an `Elite` hold-role unit choosing between staying on its `hold` marker and moving off it to chase an enemy
+- **WHEN** move scoring runs
+- **THEN** the on-marker destination SHALL score higher
+
+#### Scenario: Screen unit ignores the objective term
+
+- **GIVEN** an `Elite` screen-role unit
+- **WHEN** move scoring runs
+- **THEN** the objective term SHALL contribute zero to its score
+
+### Requirement: Objective-Aware Target Discipline
+
+When `objectiveAwareness` is enabled, a unit holding a `capture` or `hold` role SHALL have its target selection biased toward targets engageable without leaving its objective hex or its path to it — the unit SHALL fire from the objective rather than pursue an enemy off it. A `screen`-role unit's target selection SHALL be unchanged from the coordinated combat behavior. This discipline SHALL be a bias over the lance fire assignment, not a replacement — an objective-role unit still concentrates fire with the lance on an in-discipline target.
+
+#### Scenario: Hold unit engages from its objective
+
+- **GIVEN** an `Elite` hold-role unit on its marker with an enemy it could only engage by leaving the marker
+- **WHEN** target selection runs
+- **THEN** the unit SHALL NOT abandon the marker to pursue
+- **AND** it SHALL engage the best target reachable from the marker hex
+
+#### Scenario: Screen unit selects targets normally
+
+- **GIVEN** an `Elite` screen-role unit
+- **WHEN** target selection runs
+- **THEN** its target choice SHALL match the coordinated combat behavior with no objective bias

--- a/openspec/changes/add-ai-objective-awareness/tasks.md
+++ b/openspec/changes/add-ai-objective-awareness/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Add AI Objective Awareness
+
+## 1. Objective Tier Parameters
+
+- [ ] 1.1 Add `IAITierObjectiveParameters` (`objectiveAwareness`, `objectiveSeekingWeight`, `objectiveHoldWeight`) and an optional `objective` block on `IAITierParameters` in `src/simulation/ai/AITierRegistry.ts`
+- [ ] 1.2 Populate the `objective` block per tier — `Green`/`Regular`/`Veteran` fully inert (`objectiveAwareness: false`, zeroed weights); `Elite` populated
+- [ ] 1.3 Tests: every tier resolves an `objective` block; lower tiers ignore the objective map and play `Destroy`
+
+## 2. Objective Ingestion and Classification
+
+- [ ] 2.1 Create `src/simulation/ai/AIObjectivePlanner.ts` with `classifyObjectives(session, botSide)` returning `IClassifiedObjective` records
+- [ ] 2.2 Classify each marker as `take`, `hold`, or `deny` from the bot side's scenario objective type
+- [ ] 2.3 An empty objective map (or a `Destroy` scenario type) SHALL yield no classified objectives
+- [ ] 2.4 Tests: an attacker's capture marker classifies `take`; a defender's marker classifies `hold`; a `Destroy` scenario yields nothing
+
+## 3. Objective Layer on the Lance Plan
+
+- [ ] 3.1 Add an optional `objectivePlan` field (`IObjectiveLancePlan`) to A3a's `ILanceTurnPlan`
+- [ ] 3.2 In `AILancePlanner.planTurn`, when objective awareness is enabled and the scenario is not `Destroy`, assign each unit an `ObjectiveRole` (`capture`, `hold`, `screen`)
+- [ ] 3.3 Assign the capture role to the unit(s) closest by A1 pathfinder cost to a `take` marker; the hold role to the unit(s) on or nearest a `hold` marker; the screen role to the rest
+- [ ] 3.4 Populate `targetHexes` with the hex each role-bearing unit is working toward or holding
+- [ ] 3.5 Tests: a capture role goes to the nearest unit; a hold role goes to the unit on the marker; screen units get no objective hex
+
+## 4. Objective-Seeking Movement
+
+- [ ] 4.1 Add an objective term to `scoreMove` for capture-role units — `+objectiveSeekingWeight` scaled by pathfinder-distance reduction to the `take` marker, with a large bonus for a destination on the marker hex
+- [ ] 4.2 Add an objective term for hold-role units — `+objectiveHoldWeight` for a destination on the `hold` marker, reduced for adjacent hexes, zero for destinations abandoning it
+- [ ] 4.3 Screen-role units SHALL receive zero objective contribution and play pure A3a movement
+- [ ] 4.4 Gate the objective term on `objectiveAwareness`; when disabled it contributes zero
+- [ ] 4.5 Tests: a capture unit moves toward and onto its marker; a hold unit stays on its marker; a screen unit is unaffected
+
+## 5. Objective-Aware Target Discipline
+
+- [ ] 5.1 In `playAttackPhase`, for `capture`/`hold`-role units, prefer targets engageable without leaving the objective hex or its path
+- [ ] 5.2 A hold unit SHALL fire from the marker rather than pursue an enemy off it
+- [ ] 5.3 Screen-role units SHALL keep A3a target selection unchanged
+- [ ] 5.4 Tests: a hold unit engages from the marker and does not chase; a screen unit's selection matches A3a
+
+## 6. Verification
+
+- [ ] 6.1 Integration test: an `Elite` bot wins a generated `Capture` scenario by moving a unit onto the objective and holding it; a `Veteran` bot fails to capture
+- [ ] 6.2 Integration test: an `Elite` bot wins a generated `Defend` scenario by holding its marker to the turn limit
+- [ ] 6.3 Integration test: an `Elite` bot wins a generated `Breakthrough` scenario by moving units to the exit edge
+- [ ] 6.4 Determinism test: SimulationRunner golden traces on the `Veteran` tier are byte-identical to pre-change traces
+- [ ] 6.5 `npx openspec validate add-ai-objective-awareness --strict` reports valid
+- [ ] 6.6 Build, lint, and typecheck pass

--- a/openspec/changes/add-ai-resource-planning/design.md
+++ b/openspec/changes/add-ai-resource-planning/design.md
@@ -1,0 +1,106 @@
+# Design: Add AI Resource Planning
+
+## Context
+
+A1 made the bot move intelligently over terrain. A2 makes it *spend* intelligently. Today the bot's resource model is one turn deep: `AttackAI.applyHeatBudget` trims the fire list so projected heat fits `safeHeatThreshold` for the current turn and stops there. It cannot see that two more turns of the same fire list shut the unit down. Ammo is a binary gate — a weapon with `ammo[weaponId] <= 0` is culled, but a weapon with two shots left is treated exactly like one with forty. `scoreTarget` rewards threat and kill-probability but is indifferent to *where* damage lands; it never notices that a target with a stripped side torso is one good roll from a crit kill. Multi-mode weapons always fire their default mode.
+
+A2 is the second half of the `Veteran` tier. It registers a resource parameter block into the AI Difficulty Tier Registry from A1 — additively, never modifying A1's requirement. `Green`/`Regular` leave the block inert; `Veteran`/`Elite` switch it on.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Project the heat curve across a multi-turn lookahead window so the bot throttles fire *before* a shutdown.
+- Estimate per-weapon ammo runway and ration scarce ammo through a conservation weight.
+- Add a crit-seeking term to target scoring that rewards reachable crippling hits.
+- Select the best mode for multi-mode weapons (LB-X cluster/slug, Ultra/Rotary rate-of-fire).
+- Register the A2 parameter block into the Tier Registry without touching A1's block.
+
+**Non-Goals:**
+
+- Lance-level ammo sharing / fire allocation (A3a), objective-driven fire discipline (A3b), ECM effects (A4 / out of scope).
+- New weapon-mode mechanics — A2 only chooses among modes the engine already resolves.
+
+## Decisions
+
+### D1. `AIHeatPlanner` — multi-turn heat projection
+
+A new pure module projects the unit's heat over a lookahead window of `heatLookaheadTurns` (a tier parameter). The projection assumes the candidate fire list repeats each turn, applies the unit's dissipation, and reports the turn (if any) at which projected heat crosses the shutdown-risk ceiling. `AttackAI` consults the planner: if a shutdown is predicted inside the window, the effective heat budget is lowered so the curve flattens. The single-turn `applyHeatBudget` stays as the inner trim; the planner wraps it with a forward-looking ceiling.
+
+```typescript
+interface IHeatProjection {
+  /** Projected heat at the end of each turn in the window. */
+  readonly perTurnHeat: readonly number[];
+  /** First turn index at which a shutdown risk is predicted, or -1. */
+  readonly shutdownRiskTurn: number;
+}
+
+function projectHeat(
+  currentHeat: number,
+  dissipation: number,
+  perTurnHeatGenerated: number,
+  lookaheadTurns: number,
+): IHeatProjection;
+```
+
+### D2. `AIAmmoRunway` — turns-of-fire projection
+
+A pure module estimates, per ammo-dependent weapon, how many turns of fire the remaining ammo supports at the bot's expected per-turn fire rate. The result feeds a **conservation weight**: when runway is short, the weapon's effective selection priority drops so the bot saves it for a higher-value shot. When runway is long, the weight is neutral. Energy weapons (no ammo) are unaffected. The binary "0 ammo = culled" rule is unchanged — runway only modulates *priority*, never eligibility.
+
+```typescript
+interface IAmmoRunway {
+  readonly weaponId: string;
+  /** Estimated turns of fire remaining, or Infinity for energy weapons. */
+  readonly turnsRemaining: number;
+  /** Conservation multiplier in [0,1] applied to selection priority. */
+  readonly conservationWeight: number;
+}
+```
+
+### D3. Crit-seeking term in `scoreTarget`
+
+`scoreTarget` gains an additive crit-seeking term, multiplied by the tier `critSeekingWeight`. The term raises a target's score in proportion to how *exposed* its structure is — armor stripped from a location, prior internal damage, an already-open side torso. This is computed from target structure-state fields surfaced on `IAIUnitState` (armor and internal-structure remaining per location). A fresh, fully-armored target gets zero crit-seeking bonus; a target with an open side torso gets a large one. The existing threat and kill-probability terms are unchanged — crit-seeking is additive.
+
+### D4. `AIWeaponModeSelector` — multi-mode weapon mode choice
+
+For weapons exposing multiple firing modes, a pure selector picks the mode that maximizes *expected damage* given range, the target's armor state, and the remaining heat budget:
+
+- **LB-X** — cluster mode against an armor-stripped or fast/evading target (cluster hits spread and crit-seek); slug mode against a fresh, armored target at short range.
+- **Ultra / Rotary** — the higher rate of fire when the heat budget and ammo runway both allow; the lower rate when heat or ammo is constrained.
+
+`IWeapon` gains optional mode metadata; weapons without it are single-mode and pass through unchanged (legacy fixtures keep working). The selected mode is recorded on the declared attack so the combat engine resolves the chosen mode.
+
+### D5. A2 registers a resource block into the Tier Registry
+
+`AITierRegistry` gains a `resource` block on `IAITierParameters`:
+
+```typescript
+interface IAITierResourceParameters {
+  readonly heatLookaheadTurns: number;     // 0 disables multi-turn projection
+  readonly ammoConservationWeight: number; // 0 disables runway weighting
+  readonly critSeekingWeight: number;      // 0 disables crit-seeking
+  readonly weaponModeSelection: boolean;   // false = always default mode
+}
+```
+
+`Green`/`Regular` set `heatLookaheadTurns: 0`, zeroed weights, and `weaponModeSelection: false` — fully inert, legacy behavior preserved. `Veteran`/`Elite` populate the block. This is an ADDED requirement; A1's movement requirement is untouched.
+
+### D6. Determinism
+
+Heat projection, ammo runway, crit-seeking scoring, and mode selection are all pure functions of unit/weapon/target state. No `SeededRandom` is consumed inside them; existing tie-breaking in `selectTarget` / `selectWeapons` / `selectMove` is unchanged, so SimulationRunner seed sequences stay stable.
+
+## Risks / Trade-offs
+
+- **[Risk] Multi-turn projection assumes a static fire list and overshoots** → Mitigation: the projection is a conservative ceiling, not a commitment; the per-turn `applyHeatBudget` still runs and re-trims each turn from live state.
+- **[Risk] Crit-seeking makes the bot tunnel-vision a near-dead target and ignore a bigger threat** → Mitigation: crit-seeking is an *additive* term bounded by `critSeekingWeight`; the threat and kill-probability terms still dominate when a fresh heavy is the bigger danger.
+- **[Risk] Mode metadata absent on legacy `IWeapon` fixtures** → Mitigation: mode metadata is optional; a weapon without it is treated single-mode and the selector returns its default — byte-identical to today.
+- **[Risk] Registering a new tier block breaks the all-ADDED rule** → Mitigation: `resource` is a new optional field; this change ADDs a separate requirement and never modifies A1's.
+
+## Migration Plan
+
+Purely additive. `Green`/`Regular` tiers leave every A2 parameter inert, so existing bots, the swarm harness, and SimulationRunner golden traces are unaffected until a caller selects `Veteran`/`Elite`. Optional mode metadata on `IWeapon` means existing weapon fixtures need no change. No database migrations — resource parameters live in the tier registry. Rollback = revert the change-set; the new planner/runway/selector modules become dead code with no behavior change.
+
+## Open Questions
+
+- Default `heatLookaheadTurns` for `Veteran` — proposed `3`; long enough to catch a building curve, short enough to stay relevant. Revisit after swarm-harness tuning.
+- Whether crit-seeking should also influence *hit-location targeting* (called shots) or only target *selection* — proposed: target selection only for A2; called-shot location bias is a candidate follow-on.

--- a/openspec/changes/add-ai-resource-planning/proposal.md
+++ b/openspec/changes/add-ai-resource-planning/proposal.md
@@ -1,0 +1,34 @@
+# Change: Add AI Resource Planning
+
+## Why
+
+The bot's resource management is single-turn and shallow. `AttackAI.applyHeatBudget` (`src/simulation/ai/AttackAI.ts`) trims the fire list against a fixed `safeHeatThreshold` for the *current* turn only — it has no notion of the heat curve building across turns, so the bot alpha-strikes into a shutdown it could have seen coming. Ammo eligibility is binary (`ammo[weaponId] <= 0` culls the weapon) with no projection of how many turns of fire remain, so the bot empties an autocannon early and then has a dead-weight ton of nothing. `scoreTarget` weights threat and kill-probability but never seeks a crippling critical — it cannot tell that a side-torso shot finishes a unit faster than chipping a fresh leg. And multi-mode weapons (LB-X cluster vs. slug, Ultra single vs. double) always fire in their default mode; the bot never picks the mode the situation rewards.
+
+This change adds the depth that makes the `Veteran` difficulty tier worth selecting: multi-turn heat lookahead, ammo-runway projection, crit-seeking hit-location weighting, and weapon-mode selection. It registers its parameters into the AI Difficulty Tier Registry introduced by A1.
+
+## What Changes
+
+- ADDED a multi-turn heat projection: `AIHeatPlanner` projects the heat curve over a configurable lookahead window and reduces the effective fire budget before a predicted shutdown, not after
+- ADDED ammo-runway projection: `AIAmmoRunway` estimates remaining turns of fire per ammo-dependent weapon and feeds a conservation weight into weapon selection so the bot rations scarce ammo
+- ADDED crit-seeking target/location weighting: `scoreTarget` gains a crit-seeking term that raises the score of a target whose exposed structure (stripped armor, prior internal damage) makes a crippling hit reachable
+- ADDED weapon-mode selection: for multi-mode weapons (LB-X cluster/slug, Ultra/Rotary rate-of-fire), `AIWeaponModeSelector` picks the mode that maximizes expected damage given range, target armor state, and the heat budget
+- ADDED A2's parameter block to the AI Difficulty Tier Registry — heat-lookahead window, ammo-conservation weight, crit-seeking weight, and a `weaponModeSelection` flag; lower tiers leave these inert
+
+## Dependencies
+
+- **Requires**: `add-ai-terrain-aware-movement` (A1) — consumes the AI Difficulty Tier Registry and registers its own parameter block; reuses the pathfinder's per-turn cost so heat projection accounts for movement heat
+- **Required By**: `add-ai-advanced-systems` (A4) — A4's jump-jet tactics consult the heat planner so a jump does not strand the unit in a shutdown
+
+## Impact
+
+- Affected specs: `simulation-system` (ADDED requirements only)
+- Affected code: `src/simulation/ai/AttackAI.ts` (crit-seeking term in `scoreTarget`, mode-aware `selectWeapons`), `src/simulation/ai/types.ts` (resource parameter block, target structure-state fields on `IAIUnitState`/`IWeapon` mode metadata), `src/simulation/ai/behaviorVariants.ts` (no behavior change — tiers already mapped), new `src/simulation/ai/AIHeatPlanner.ts`, new `src/simulation/ai/AIAmmoRunway.ts`, new `src/simulation/ai/AIWeaponModeSelector.ts`, `src/simulation/ai/AITierRegistry.ts` (register the resource block)
+- No database migrations — resource parameters live in the tier registry
+- Reproducibility preserved: heat projection, ammo runway, and mode selection are pure deterministic functions of unit and weapon state; ties break via `SeededRandom`
+
+## Non-Goals
+
+- Lance-level ammo sharing or coordinated fire allocation — multi-unit resource coordination is A3a
+- Objective-driven fire discipline (holding fire to preserve a unit for a capture) — A3b
+- ECM/electronic-warfare effects on to-hit or weapon eligibility — A4 is AI-awareness only, and core-engine ECM modifiers are explicitly out of scope for all of Wave 2
+- New weapon-mode game mechanics — A2 selects among modes the combat engine already resolves; it does not add modes

--- a/openspec/changes/add-ai-resource-planning/specs/simulation-system/spec.md
+++ b/openspec/changes/add-ai-resource-planning/specs/simulation-system/spec.md
@@ -1,0 +1,114 @@
+## ADDED Requirements
+
+### Requirement: Resource-Planning Tier Parameters
+
+The AI Difficulty Tier Registry SHALL carry a resource parameter block on each tier, exposing `heatLookaheadTurns`, `ammoConservationWeight`, `critSeekingWeight`, and `weaponModeSelection`. The `Green` and `Regular` tiers SHALL set `heatLookaheadTurns` to `0`, zero the conservation and crit-seeking weights, and set `weaponModeSelection` to `false`, leaving all resource-planning behavior inert. The `Veteran` and `Elite` tiers SHALL populate the block with active values. This block SHALL be registered additively and SHALL NOT modify the movement parameter block.
+
+#### Scenario: Every tier resolves a resource block
+
+- **GIVEN** the tier names `Green`, `Regular`, `Veteran`, and `Elite`
+- **WHEN** the resource parameter block is read for each
+- **THEN** each SHALL return a populated `IAITierResourceParameters` record
+
+#### Scenario: Lower tiers disable resource planning
+
+- **GIVEN** a bot configured with the `Green` or `Regular` tier
+- **WHEN** it plans heat, ammo, crit-seeking, and weapon modes
+- **THEN** multi-turn heat projection SHALL be skipped, ammo conservation SHALL not alter selection, crit-seeking SHALL contribute zero, and every multi-mode weapon SHALL fire its default mode
+
+### Requirement: Multi-Turn Heat Projection
+
+When `heatLookaheadTurns` is greater than zero, the system SHALL provide `AIHeatPlanner.projectHeat` that projects the unit's heat across the lookahead window from current heat, dissipation, and the per-turn heat the candidate fire list generates, and reports the first turn at which a shutdown risk is predicted. When a shutdown is predicted inside the window, `AttackAI` SHALL lower the effective heat budget so the projected curve flattens. The single-turn heat-budget trim SHALL still run each turn. Heat projection SHALL be a pure deterministic function and SHALL NOT consume `SeededRandom`.
+
+#### Scenario: Rising heat curve flags the shutdown turn
+
+- **GIVEN** a unit whose candidate fire list generates more heat per turn than it dissipates
+- **WHEN** `projectHeat` runs over the lookahead window
+- **THEN** `shutdownRiskTurn` SHALL be the first turn the projected heat crosses the shutdown ceiling
+
+#### Scenario: Sustainable fire list reports no risk
+
+- **GIVEN** a unit whose candidate fire list generates no more heat than it dissipates
+- **WHEN** `projectHeat` runs
+- **THEN** `shutdownRiskTurn` SHALL be `-1`
+
+#### Scenario: Veteran bot throttles before shutdown
+
+- **GIVEN** a `Veteran` bot whose alpha strike would shut it down two turns out
+- **WHEN** it selects its fire list
+- **THEN** the effective heat budget SHALL be lowered and lower-efficiency weapons SHALL be culled
+- **AND** the unit SHALL NOT shut down within the lookahead window
+
+### Requirement: Ammo-Runway Projection
+
+When `ammoConservationWeight` is greater than zero, the system SHALL provide `AIAmmoRunway` that estimates, per ammo-dependent weapon, the turns of fire the remaining ammo supports and a conservation multiplier in the range `[0, 1]`. A short runway SHALL lower the weapon's selection priority; a long runway SHALL leave it neutral. Energy weapons SHALL report an infinite runway and a neutral weight. The binary rule that culls a weapon with zero ammo SHALL be unchanged — runway projection SHALL modulate priority only, never eligibility.
+
+#### Scenario: Scarce ammo lowers selection priority
+
+- **GIVEN** an ammo-dependent weapon with only a few turns of fire remaining
+- **WHEN** weapon selection runs on a `Veteran` bot
+- **THEN** the weapon's selection priority SHALL be reduced
+- **AND** the weapon SHALL still be eligible to fire
+
+#### Scenario: Abundant ammo is neutral
+
+- **GIVEN** an ammo-dependent weapon with a long runway of remaining fire
+- **WHEN** weapon selection runs
+- **THEN** the conservation weight SHALL leave the weapon's priority unchanged
+
+#### Scenario: Energy weapons are unaffected
+
+- **GIVEN** an energy weapon with no ammo dependency
+- **WHEN** ammo runway is projected
+- **THEN** it SHALL report an infinite runway and a neutral conservation weight
+
+### Requirement: Crit-Seeking Target Weighting
+
+When `critSeekingWeight` is greater than zero, `AttackAI.scoreTarget` SHALL add a crit-seeking term, multiplied by `critSeekingWeight`, that raises a target's score in proportion to its structural exposure — stripped armor, prior internal damage, or an opened location where a crippling critical hit is reachable. A fully-armored target SHALL receive a zero crit-seeking bonus. The existing threat and kill-probability terms SHALL be unchanged; crit-seeking SHALL be additive.
+
+#### Scenario: Exposed target scores higher
+
+- **GIVEN** two targets identical in threat and kill-probability, one with an open side torso and one fully armored
+- **WHEN** `scoreTarget` runs on a `Veteran` bot
+- **THEN** the open-side-torso target SHALL score higher
+
+#### Scenario: Threat still dominates crit-seeking
+
+- **GIVEN** a near-dead light with an open location and a fresh heavy posing a much larger threat
+- **WHEN** `scoreTarget` runs
+- **THEN** the threat and kill-probability terms MAY still place the fresh heavy above the light
+
+#### Scenario: Crit-seeking disabled yields the legacy score
+
+- **GIVEN** a bot whose `critSeekingWeight` is zero
+- **WHEN** `scoreTarget` runs
+- **THEN** the score SHALL equal the pre-change `scoreTarget` output
+
+### Requirement: Multi-Mode Weapon Selection
+
+When `weaponModeSelection` is enabled, the system SHALL provide `AIWeaponModeSelector` that picks, for each multi-mode weapon, the firing mode maximizing expected damage given range, the target's armor state, and the remaining heat budget. The selected mode SHALL be recorded on the declared attack. A weapon without firing-mode metadata SHALL be treated as single-mode and SHALL fire its default mode unchanged.
+
+#### Scenario: LB-X picks cluster against an exposed target
+
+- **GIVEN** an LB-X autocannon and a target with stripped armor or active evasion
+- **WHEN** mode selection runs
+- **THEN** cluster mode SHALL be selected
+
+#### Scenario: LB-X picks slug against a fresh target
+
+- **GIVEN** an LB-X autocannon and a fresh, fully-armored target at short range
+- **WHEN** mode selection runs
+- **THEN** slug mode SHALL be selected
+
+#### Scenario: Rate-of-fire weapon drops to single fire under heat pressure
+
+- **GIVEN** an Ultra autocannon and a heat budget that cannot absorb double fire
+- **WHEN** mode selection runs
+- **THEN** the single-fire mode SHALL be selected
+
+#### Scenario: Single-mode weapon passes through unchanged
+
+- **GIVEN** a weapon with no firing-mode metadata
+- **WHEN** mode selection runs
+- **THEN** the weapon SHALL fire its default mode
+- **AND** the declared attack SHALL match the pre-change behavior

--- a/openspec/changes/add-ai-resource-planning/tasks.md
+++ b/openspec/changes/add-ai-resource-planning/tasks.md
@@ -1,0 +1,45 @@
+# Tasks: Add AI Resource Planning
+
+## 1. Resource Tier Parameters
+
+- [ ] 1.1 Add `IAITierResourceParameters` (`heatLookaheadTurns`, `ammoConservationWeight`, `critSeekingWeight`, `weaponModeSelection`) and an optional `resource` block on `IAITierParameters` in `src/simulation/ai/AITierRegistry.ts`
+- [ ] 1.2 Populate the `resource` block per tier — `Green`/`Regular` fully inert (`heatLookaheadTurns: 0`, zeroed weights, `weaponModeSelection: false`); `Veteran`/`Elite` populated
+- [ ] 1.3 Tests: every tier resolves a `resource` block; `Green`/`Regular` values disable all A2 behavior
+
+## 2. Multi-Turn Heat Projection
+
+- [ ] 2.1 Create `src/simulation/ai/AIHeatPlanner.ts` with `projectHeat(currentHeat, dissipation, perTurnHeatGenerated, lookaheadTurns)` returning `IHeatProjection`
+- [ ] 2.2 Project per-turn heat across the lookahead window and report the first turn a shutdown risk is predicted (or `-1`)
+- [ ] 2.3 In `AttackAI`, when a shutdown is predicted inside the window, lower the effective heat budget passed to `applyHeatBudget`
+- [ ] 2.4 Tests: a rising heat curve flags the correct shutdown turn; a sustainable fire list reports `-1`; `heatLookaheadTurns: 0` skips projection entirely
+
+## 3. Ammo-Runway Projection
+
+- [ ] 3.1 Create `src/simulation/ai/AIAmmoRunway.ts` computing per-weapon `turnsRemaining` and `conservationWeight`
+- [ ] 3.2 Energy weapons report `Infinity` turns and a neutral conservation weight
+- [ ] 3.3 Feed `conservationWeight` into weapon selection priority — short runway lowers priority; the binary 0-ammo cull is unchanged
+- [ ] 3.4 Tests: scarce ammo lowers a weapon's selection priority without culling it; abundant ammo is neutral; energy weapons are unaffected
+
+## 4. Crit-Seeking Target Weighting
+
+- [ ] 4.1 Surface target structure-state fields (per-location armor and internal structure remaining) on `IAIUnitState`
+- [ ] 4.2 Add an additive crit-seeking term to `scoreTarget`, multiplied by `critSeekingWeight`, proportional to the target's structural exposure
+- [ ] 4.3 A fully-armored target SHALL receive zero crit-seeking bonus; an open side torso SHALL receive a large one
+- [ ] 4.4 Tests: crit-seeking raises an exposed target's score; a fresh heavy still outscores a near-dead light when its threat dominates; `critSeekingWeight: 0` yields the pre-change score
+
+## 5. Weapon-Mode Selection
+
+- [ ] 5.1 Add optional firing-mode metadata to `IWeapon`; weapons without it are single-mode
+- [ ] 5.2 Create `src/simulation/ai/AIWeaponModeSelector.ts` picking the expected-damage-maximizing mode given range, target armor state, and heat budget
+- [ ] 5.3 LB-X: cluster against armor-stripped/evading targets, slug against fresh armored targets at short range
+- [ ] 5.4 Ultra/Rotary: higher rate of fire when heat and ammo runway allow, lower rate otherwise
+- [ ] 5.5 Record the selected mode on the declared attack; gate selection on `weaponModeSelection`
+- [ ] 5.6 Tests: LB-X picks cluster vs. an open target and slug vs. a fresh one; Ultra drops to single fire under heat pressure; a single-mode weapon passes through unchanged
+
+## 6. Verification
+
+- [ ] 6.1 Integration test: a `Veteran` bot throttles its alpha strike across turns and does not shut down where a `Regular` bot does
+- [ ] 6.2 Integration test: a `Veteran` bot rations a low-ammo autocannon and a `Regular` bot empties it early
+- [ ] 6.3 Determinism test: SimulationRunner golden traces on the `Regular` tier are byte-identical to pre-change traces
+- [ ] 6.4 `npx openspec validate add-ai-resource-planning --strict` reports valid
+- [ ] 6.5 Build, lint, and typecheck pass

--- a/openspec/changes/add-ai-terrain-aware-movement/design.md
+++ b/openspec/changes/add-ai-terrain-aware-movement/design.md
@@ -1,0 +1,129 @@
+# Design: Add AI Terrain-Aware Movement
+
+## Context
+
+The bot's movement scorer is competent at the 1v1 "see and shoot" level but plays on a featureless plain. `MoveAI.scoreMove` weighs LOS, a forward-arc bonus, closing distance, and raw move heat; it never asks whether the destination hex offers cover, whether ending there denies an enemy's LOS, or whether a cheaper path reaches an equally good position. Terrain cost (`getTerrainMovementCost`) and cover (`getTerrainCoverLevel`) are already computed — but only inside `HexMapDisplay/renderHelpers.ts`, a rendering module the simulation layer is forbidden to import. `getValidDestinations` enforces MP budget but yields a flat set of reachable hexes with no notion of *which path* was cheapest.
+
+This change is the foundation of Wave 2. Beyond terrain-aware scoring it introduces the **AI Difficulty Tier Registry** — the single mechanism that makes "best-possible AI" shippable incrementally. Each later Wave 2 change (A2 resource planning, A3a coordination, A3b objectives, A4 advanced systems) ADDs its own parameter block to the registry rather than rewriting A1's. Tiers are player-facing: `Green`/`Regular` run shallow, `Veteran` adds A1+A2 depth, `Elite` adds A3+A4.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Extract `getTerrainMovementCost` into a shared sim utility so the AI can consult terrain cost without importing rendering code.
+- Give the bot a deterministic terrain-cost pathfinder with a stable, frozen API that every later Wave 2 change can depend on.
+- Add cover-seeking and LOS-denial terms to move scoring so the bot uses terrain defensively.
+- Stand up the AI Difficulty Tier Registry as an all-ADDED, never-MODIFIED extension point.
+
+**Non-Goals:**
+
+- Multi-turn movement lookahead, jump-jet pathing, objective-seeking movement (A2/A3a/A3b/A4).
+- Pathfinder performance optimization (caching, incremental replan).
+
+## Decisions
+
+### D1. Extract `getTerrainMovementCost` into `src/utils/gameplay/terrainMovementCost.ts`
+
+`getTerrainMovementCost` and its dependency `getPrimaryTerrainFeature` move to a new pure utility module under `src/utils/gameplay/`. `renderHelpers.ts` re-exports both so existing rendering callers are untouched. The simulation layer imports only from the new module — no rendering dependency leaks into `src/simulation/`.
+
+### D2. Frozen pathfinder API contract
+
+The pathfinder API is frozen here so A2/A3a/A3b/A4 author against a stable signature. A1 MUST ship exactly this surface:
+
+```typescript
+/** A single legal path from origin to a destination hex. */
+interface IAIPath {
+  readonly destination: IHexCoordinate;
+  /** Ordered hexes from origin (exclusive) to destination (inclusive). */
+  readonly hexes: readonly IHexCoordinate[];
+  /** Total movement points consumed along the path. */
+  readonly totalMpCost: number;
+  /** True when every hex on the path was within the MP budget. */
+  readonly reachable: boolean;
+}
+
+interface IAIPathfindRequest {
+  readonly grid: IHexGrid;
+  readonly origin: IHexCoordinate;
+  readonly destination: IHexCoordinate;
+  readonly movementType: MovementType;
+  readonly capability: IMovementCapability;
+}
+
+/**
+ * Deterministic cheapest-path search over per-hex terrain movement cost.
+ * Pure: identical request => identical IAIPath. Returns `reachable:false`
+ * with a best-effort partial path when the destination exceeds the budget.
+ */
+function findPath(request: IAIPathfindRequest): IAIPath;
+
+/**
+ * Cheapest path to every reachable destination in one pass. Keyed by the
+ * canonical "q,r" hex string. Used by scoreMove to avoid N separate searches.
+ */
+function findAllPaths(
+  grid: IHexGrid,
+  origin: IHexCoordinate,
+  movementType: MovementType,
+  capability: IMovementCapability,
+): ReadonlyMap<string, IAIPath>;
+```
+
+Implementation is uniform-cost (Dijkstra) search over hex neighbors with edge weight = `getTerrainMovementCost(destinationHexTerrain)`. Tie-break between equal-cost paths is the canonical hex-neighbor order so the result is deterministic without consuming `SeededRandom`.
+
+### D3. AI Difficulty Tier Registry
+
+A new `AITierRegistry.ts` exposes a frozen `Record<AITierName, IAITierParameters>` where `AITierName = 'Green' | 'Regular' | 'Veteran' | 'Elite'`. `IAITierParameters` is an open interface: A1 defines the movement block; A2/A3a/A3b/A4 each ADD their own block (resource, coordination, objective, advanced). Registration is **additive only** — no later change MODIFIES A1's requirement or the existing parameter fields. The registry exports `getTierParameters(name)` (throws on unknown, mirroring `getBehaviorVariant`).
+
+```typescript
+type AITierName = 'Green' | 'Regular' | 'Veteran' | 'Elite';
+
+interface IAITierMovementParameters {
+  readonly pathfinderEnabled: boolean;
+  readonly coverWeight: number;
+  readonly losDenialWeight: number;
+  readonly terrainCostWeight: number;
+}
+
+interface IAITierParameters {
+  readonly tier: AITierName;
+  readonly movement: IAITierMovementParameters;
+  // A2..A4 ADD: resource?, coordination?, objective?, advanced? blocks.
+}
+```
+
+`IBotBehavior` gains an optional `tier?: AITierName` (default `'Regular'`). `behaviorVariants.ts` presets map onto tiers (`default`→`Regular`, `aggressive`→`Veteran`, etc.) so existing callers keep working.
+
+### D4. Tiered scoring — lower tiers run the legacy scorer
+
+`Green` and `Regular` set `pathfinderEnabled: false` and zero the new weights, so they reproduce today's straight-line scorer byte-for-byte (legacy determinism preserved). `Veteran` and `Elite` enable the pathfinder and the new terms. This is how "best-possible AI" ships incrementally without regressing the baseline bot.
+
+### D5. New scoring terms in `scoreMove`
+
+When `pathfinderEnabled`, `scoreMove` adds three terms, each multiplied by its tier weight:
+
+- **Cover term** — `+coverWeight` when the destination hex's `getTerrainCoverLevel` is partial-or-better.
+- **LOS-denial term** — `+losDenialWeight` when the destination breaks `calculateLOS` from the highest-threat enemy (when `highestThreatTarget` is supplied).
+- **Terrain-cost term** — `-terrainCostWeight * (pathMpCost - hexDistance)` so a destination reached by a wasteful path scores below an equivalent destination reached cheaply.
+
+All terms are additive over the existing scorer; the existing LOS/arc/distance/heat terms are unchanged. Determinism: same grid + unit + tier → same score; ties still break via `SeededRandom`.
+
+### D6. Pathfinder is consulted once per move evaluation
+
+`MoveAI.selectMove` calls `findAllPaths` once, then `scoreMove` reads each destination's path from the returned map. No per-move search. Keeps the per-turn cost a single Dijkstra pass.
+
+## Risks / Trade-offs
+
+- **[Risk] Re-export cycle between `terrainMovementCost.ts` and `renderHelpers.ts`** → Mitigation: the new module imports nothing from `renderHelpers.ts`; the dependency is one-directional (renderHelpers re-exports the new module).
+- **[Risk] A later Wave 2 change MODIFIES A1's Tier Registry requirement, breaking the all-ADDED rule** → Mitigation: `IAITierParameters` blocks are optional and additive; each change ADDs a separate requirement; the registry merges blocks by key.
+- **[Risk] Pathfinder changes the bot's chosen hex and breaks SimulationRunner determinism golden tests** → Mitigation: `Green`/`Regular` keep `pathfinderEnabled:false` and reproduce the legacy scorer exactly; golden traces run on the legacy tier; new behavior is asserted on `Veteran`/`Elite`.
+- **[Trade-off] Dijkstra per turn is O(hexes·log hexes)** — acceptable at current map sizes; caching is a deferred non-goal.
+
+## Migration Plan
+
+Purely additive. `IBotBehavior.tier` is optional and defaults to `'Regular'`, which runs the legacy scorer — every existing bot, test fixture, and the swarm harness behave identically until a caller opts into `Veteran`/`Elite`. The `getTerrainMovementCost` extraction is a pure move plus a re-export; no call site changes. No database migrations — tier selection lives in the game-session config. Rollback = revert the change-set; the registry and pathfinder become dead code with no behavior change.
+
+## Open Questions
+
+- Default tier for player-vs-bot scenarios — proposed `Regular`; the scenario UI exposes the picker. Revisit once tiers A2–A4 are populated.
+- Whether `Elite` should always enable the pathfinder even before A3/A4 ship — proposed yes; `Elite` is the top tier and accumulates depth as later changes land.

--- a/openspec/changes/add-ai-terrain-aware-movement/proposal.md
+++ b/openspec/changes/add-ai-terrain-aware-movement/proposal.md
@@ -1,0 +1,35 @@
+# Change: Add AI Terrain-Aware Movement
+
+## Why
+
+`MoveAI.scoreMove` (`src/simulation/ai/MoveAI.ts`) scores a candidate move on line-of-sight to enemies, a forward-arc bonus, a closing-distance penalty, and a small raw heat penalty — but it is blind to **how much it costs to get there** and **what protects the unit once there**. `getValidMoves` calls `getValidDestinations`, which already accounts for movement-point cost, yet the scorer treats a hex reached by walking through open ground and a hex reached by clawing through heavy woods as equivalent. `getTerrainMovementCost` and `getTerrainCoverLevel` exist only inside `src/components/gameplay/HexMapDisplay/renderHelpers.ts` — a rendering module the simulation layer must not import. The bot also never seeks partial cover, never prefers a destination that breaks an enemy's LOS, and exposes no difficulty knob, so every bot plays at one fixed depth.
+
+This change gives the bot a terrain-cost-aware pathfinder and cover/LOS-aware move scoring, extracts the terrain-cost helper into a shared simulation utility, and introduces the **AI Difficulty Tier Registry** — the player-selectable depth control that every later Wave 2 AI change registers its own parameters into.
+
+## What Changes
+
+- ADDED a shared `getTerrainMovementCost` simulation utility (`src/utils/gameplay/terrainMovementCost.ts`); `renderHelpers.ts` re-exports from it so no rendering import leaks into the sim layer
+- ADDED `AITerrainPathfinder` — a deterministic terrain-cost pathfinder that computes the cheapest legal path to a destination using per-hex movement cost, returning total MP spent and the hex sequence
+- ADDED terrain-aware move scoring: `scoreMove` gains a cover-seeking term (partial cover at the destination), an LOS-denial term (destination breaks the highest-threat enemy's LOS), and a terrain-cost efficiency term that prefers cheaper paths to equivalent positions
+- ADDED the **AI Difficulty Tier Registry** — a named registry (`Green`, `Regular`, `Veteran`, `Elite`) mapping each tier to a frozen parameter set; the player picks a tier per scenario and the bot reads its scoring weights from the selected tier
+- ADDED `IAITierParameters` movement parameters: cover weight, LOS-denial weight, terrain-cost weight, and a `pathfinderEnabled` flag (lower tiers may run the legacy straight-line scorer)
+- ADDED a frozen pathfinder API contract (see `design.md` D2) so A2/A3a/A3b/A4 can depend on a stable signature
+
+## Dependencies
+
+- **Requires**: Wave 1 `add-procedural-map-variety` and `add-scenario-objective-engine` — terrain feature variety and the objective/terrain surface the pathfinder reasons over
+- **Required By**: `add-ai-resource-planning` (A2), `add-ai-coordination-tactics` (A3a), `add-ai-objective-awareness` (A3b), `add-ai-advanced-systems` (A4) — all consume the pathfinder API and register their parameters into the Tier Registry
+
+## Impact
+
+- Affected specs: `simulation-system` (ADDED requirements only)
+- Affected code: `src/simulation/ai/MoveAI.ts` (scoring terms), `src/simulation/ai/types.ts` (`IAITierParameters`, tier on `IBotBehavior`), `src/simulation/ai/behaviorVariants.ts` (variants resolve a tier), new `src/simulation/ai/AITierRegistry.ts`, new `src/simulation/ai/AITerrainPathfinder.ts`, new `src/utils/gameplay/terrainMovementCost.ts`, `src/components/gameplay/HexMapDisplay/renderHelpers.ts` (re-export)
+- No database migrations — tier selection serializes with the game session config
+- Reproducibility preserved: pathfinding and scoring are pure deterministic functions of grid + unit state; ties break through the existing `SeededRandom` discipline
+
+## Non-Goals
+
+- Multi-turn movement planning — A1 scores a single turn's move; multi-turn lookahead is A2 (heat) and A3a (coordination)
+- Jump-jet tactical pathing — jump-specific movement is A4
+- Objective-seeking movement — the bot reading objective markers to choose where to go is A3b
+- Pathfinder caching or incremental replanning — A1 recomputes per turn; performance tuning is deferred

--- a/openspec/changes/add-ai-terrain-aware-movement/specs/simulation-system/spec.md
+++ b/openspec/changes/add-ai-terrain-aware-movement/specs/simulation-system/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: Shared Terrain Movement-Cost Utility
+
+The system SHALL expose `getTerrainMovementCost` and `getPrimaryTerrainFeature` from a shared simulation-accessible utility module (`src/utils/gameplay/terrainMovementCost.ts`). The simulation layer (`src/simulation/`) SHALL consult terrain movement cost only through this utility and SHALL NOT import from the rendering layer (`src/components/`). The rendering module SHALL re-export both functions so existing rendering call sites are unchanged.
+
+#### Scenario: Open ground costs one movement point
+
+- **GIVEN** a hex with no terrain features
+- **WHEN** `getTerrainMovementCost` is evaluated for that hex
+- **THEN** it SHALL return `1`
+
+#### Scenario: Heavy terrain costs more than open ground
+
+- **GIVEN** a hex containing a heavy-woods terrain feature
+- **WHEN** `getTerrainMovementCost` is evaluated for that hex
+- **THEN** it SHALL return a value greater than `1`
+
+#### Scenario: Simulation layer does not import rendering code
+
+- **GIVEN** the AI pathfinder and move scorer
+- **WHEN** their module imports are resolved
+- **THEN** no import SHALL resolve into `src/components/`
+- **AND** terrain cost SHALL be sourced from `src/utils/gameplay/terrainMovementCost.ts`
+
+### Requirement: AI Difficulty Tier Registry
+
+The system SHALL provide an AI Difficulty Tier Registry mapping each tier name — `Green`, `Regular`, `Veteran`, `Elite` — to a frozen `IAITierParameters` record. The registry SHALL expose `getTierParameters(name)` which returns the parameter record for a known tier and throws an explicit error for an unknown name. `IBotBehavior` SHALL carry an optional `tier` field defaulting to `Regular`. The tier is player-selectable per scenario. `IAITierParameters` SHALL be additively extensible: later AI changes register their own parameter blocks without modifying the movement block defined here.
+
+The movement parameter block SHALL carry `pathfinderEnabled`, `coverWeight`, `losDenialWeight`, and `terrainCostWeight`. The `Green` and `Regular` tiers SHALL set `pathfinderEnabled` to `false` with zeroed scoring weights so they reproduce the pre-change move scorer exactly. The `Veteran` and `Elite` tiers SHALL set `pathfinderEnabled` to `true`.
+
+#### Scenario: Every tier resolves to a parameter record
+
+- **GIVEN** the tier names `Green`, `Regular`, `Veteran`, and `Elite`
+- **WHEN** `getTierParameters` is called for each
+- **THEN** each call SHALL return an `IAITierParameters` record with a populated movement block
+
+#### Scenario: Unknown tier name throws
+
+- **GIVEN** a tier name that is not in the registry
+- **WHEN** `getTierParameters` is called with that name
+- **THEN** an error SHALL be thrown naming the invalid tier and listing the valid tiers
+
+#### Scenario: Default tier is Regular
+
+- **GIVEN** an `IBotBehavior` constructed without an explicit `tier`
+- **WHEN** the bot resolves its tier parameters
+- **THEN** the `Regular` tier SHALL be used
+
+#### Scenario: Lower tiers reproduce the legacy scorer
+
+- **GIVEN** a bot configured with the `Green` or `Regular` tier
+- **WHEN** it scores a candidate move
+- **THEN** the score SHALL be identical to the pre-change `scoreMove` output for the same inputs
+
+### Requirement: AI Terrain-Cost Pathfinder
+
+The system SHALL provide `AITerrainPathfinder` exposing `findPath(request)` and `findAllPaths(grid, origin, movementType, capability)` per the frozen API contract. `findPath` SHALL return an `IAIPath` carrying the destination, the ordered hex sequence from origin to destination, the total movement-point cost, and a `reachable` flag. Path cost SHALL be the sum of per-hex `getTerrainMovementCost`. The search SHALL be deterministic — an identical request SHALL always produce an identical `IAIPath` — using canonical hex-neighbor order to break ties between equal-cost paths, without consuming `SeededRandom`.
+
+When a destination exceeds the movement-point budget, `findPath` SHALL return `reachable: false` with a best-effort partial path. `findAllPaths` SHALL return the cheapest path to every reachable destination keyed by the canonical `"q,r"` hex string.
+
+#### Scenario: Pathfinder routes around costly terrain
+
+- **GIVEN** an origin and a destination where the straight-line path crosses heavy woods and an alternate path of equal hex length crosses only open ground
+- **WHEN** `findPath` runs
+- **THEN** the returned path SHALL be the open-ground route
+- **AND** its `totalMpCost` SHALL be lower than the straight-line route's cost
+
+#### Scenario: Pathfinding is deterministic
+
+- **GIVEN** two identical `IAIPathfindRequest` values
+- **WHEN** `findPath` is called for each
+- **THEN** both SHALL return identical hex sequences and identical `totalMpCost`
+
+#### Scenario: Unreachable destination is flagged
+
+- **GIVEN** a destination whose cheapest path cost exceeds the unit's movement-point budget
+- **WHEN** `findPath` runs
+- **THEN** the returned `IAIPath` SHALL have `reachable` set to `false`
+
+#### Scenario: findAllPaths agrees with per-destination findPath
+
+- **GIVEN** an origin, movement type, and capability
+- **WHEN** `findAllPaths` returns its path map and `findPath` is called separately for one of those destinations
+- **THEN** the path for that destination SHALL be identical in both results
+
+### Requirement: Terrain-Aware Move Scoring
+
+When the active tier sets `pathfinderEnabled` to `true`, `MoveAI` SHALL extend move scoring with three additive terms, each multiplied by its tier weight: a cover term granting `coverWeight` when the destination hex offers partial cover or better, a line-of-sight-denial term granting `losDenialWeight` when the destination breaks the highest-threat enemy's line of sight, and a terrain-cost term subtracting `terrainCostWeight` scaled by the difference between the path's movement-point cost and the straight-line hex distance. The existing line-of-sight, firing-arc, closing-distance, and heat terms SHALL be unchanged. When `pathfinderEnabled` is `false`, none of the three new terms SHALL apply.
+
+#### Scenario: Veteran bot seeks cover
+
+- **GIVEN** a `Veteran` bot choosing between a partial-cover hex and an open hex with otherwise equal scoring inputs
+- **WHEN** move scoring runs
+- **THEN** the partial-cover hex SHALL score higher
+- **AND** the bot SHALL move to the partial-cover hex
+
+#### Scenario: Veteran bot breaks enemy line of sight
+
+- **GIVEN** a `Veteran` bot with two candidate destinations of equal path cost — one keeps it visible to the highest-threat enemy, one breaks that enemy's line of sight
+- **WHEN** move scoring runs
+- **THEN** the line-of-sight-breaking destination SHALL score higher
+
+#### Scenario: Wasteful path scores below an efficient path
+
+- **GIVEN** two destinations of equal tactical value, one reached by a path whose movement-point cost exceeds its hex distance and one reached by a path whose cost equals its hex distance
+- **WHEN** move scoring runs on a `Veteran` bot
+- **THEN** the efficiently-reached destination SHALL score higher
+
+#### Scenario: Regular bot ignores the new terms
+
+- **GIVEN** a `Regular` bot scoring the same candidate moves
+- **WHEN** move scoring runs
+- **THEN** the cover, line-of-sight-denial, and terrain-cost terms SHALL contribute zero
+- **AND** the chosen move SHALL match the pre-change scorer's choice

--- a/openspec/changes/add-ai-terrain-aware-movement/tasks.md
+++ b/openspec/changes/add-ai-terrain-aware-movement/tasks.md
@@ -1,0 +1,40 @@
+# Tasks: Add AI Terrain-Aware Movement
+
+## 1. Extract Shared Terrain-Cost Utility
+
+- [ ] 1.1 Create `src/utils/gameplay/terrainMovementCost.ts` exporting `getTerrainMovementCost` and `getPrimaryTerrainFeature`, moved verbatim from `src/components/gameplay/HexMapDisplay/renderHelpers.ts`
+- [ ] 1.2 Re-export both functions from `renderHelpers.ts` so existing rendering call sites are untouched
+- [ ] 1.3 Confirm no `src/simulation/` import resolves into `src/components/` — the sim layer imports only the new utility
+- [ ] 1.4 Unit tests for the extracted utility (open ground = 1 MP, heavy woods > 1, deterministic for a given terrain)
+
+## 2. AI Difficulty Tier Registry
+
+- [ ] 2.1 Create `src/simulation/ai/AITierRegistry.ts` with `AITierName` (`Green` | `Regular` | `Veteran` | `Elite`), `IAITierParameters`, and `IAITierMovementParameters`
+- [ ] 2.2 Define the frozen tier table — `Green`/`Regular` set `pathfinderEnabled: false` with zeroed weights; `Veteran`/`Elite` enable the pathfinder with tuned weights
+- [ ] 2.3 Export `getTierParameters(name)` that throws an explicit error on an unknown tier name (mirror `getBehaviorVariant`)
+- [ ] 2.4 Add optional `tier?: AITierName` to `IBotBehavior` (default `Regular`) and map each `behaviorVariants.ts` preset onto a tier
+- [ ] 2.5 Tests: every tier resolves; unknown tier throws; `Green`/`Regular` parameters yield zero scoring delta vs. the legacy scorer
+
+## 3. Terrain-Cost Pathfinder
+
+- [ ] 3.1 Create `src/simulation/ai/AITerrainPathfinder.ts` implementing the frozen API contract from `design.md` D2 (`IAIPath`, `IAIPathfindRequest`, `findPath`, `findAllPaths`)
+- [ ] 3.2 Implement uniform-cost (Dijkstra) search over hex neighbors with edge weight = `getTerrainMovementCost`, tie-broken by canonical neighbor order
+- [ ] 3.3 `findPath` returns `reachable: false` with a best-effort partial path when the destination exceeds the MP budget
+- [ ] 3.4 `findAllPaths` returns the cheapest path to every reachable destination keyed by the canonical `"q,r"` string in a single pass
+- [ ] 3.5 Tests: cheapest path avoids costly terrain; identical request → identical path; unreachable destination flagged; `findAllPaths` agrees with per-destination `findPath`
+
+## 4. Terrain-Aware Move Scoring
+
+- [ ] 4.1 In `MoveAI.selectMove`, call `findAllPaths` once and pass each destination's `IAIPath` into `scoreMove`
+- [ ] 4.2 Add the cover term to `scoreMove` — `+coverWeight` when the destination hex offers partial-or-better cover
+- [ ] 4.3 Add the LOS-denial term — `+losDenialWeight` when the destination breaks the highest-threat enemy's line of sight
+- [ ] 4.4 Add the terrain-cost term — `-terrainCostWeight * (pathMpCost - hexDistance)` so wasteful paths score lower
+- [ ] 4.5 Gate all three terms on `tier.movement.pathfinderEnabled`; when disabled, `scoreMove` output is byte-identical to today's
+- [ ] 4.6 Tests: a `Veteran` bot prefers a partial-cover hex over an equal-LOS open hex; an LOS-breaking hex outscores an exposed equal-cost hex; a `Regular` bot reproduces the legacy choice
+
+## 5. Verification
+
+- [ ] 5.1 Integration test: a `Veteran` bot on a map with woods routes around open ground into cover; the same scenario on `Regular` takes the straight line
+- [ ] 5.2 Determinism test: SimulationRunner golden traces on the legacy (`Regular`) tier are byte-identical to pre-change traces
+- [ ] 5.3 `npx openspec validate add-ai-terrain-aware-movement --strict` reports valid
+- [ ] 5.4 Build, lint, and typecheck pass

--- a/openspec/changes/add-campaign-bay-ui/design.md
+++ b/openspec/changes/add-campaign-bay-ui/design.md
@@ -1,0 +1,128 @@
+# Design: Add Campaign Bay UI
+
+## Context
+
+`add-campaign-combat-loop` (CP1) freezes `ICampaignInventory` — a campaign-attached
+structure with three bays (`repairBay`, `salvageBay`, `medicalBay`) and a
+`summary`. Each bay item is a read-only projection of an existing engine type.
+`campaign-ui` already establishes the conventions for campaign screens: a page
+per concern under `src/pages/campaigns/[id]/`, a campaign-navigation group, and
+standard loading / empty / error states. What is missing is any *screen* that
+renders the post-battle inventory.
+
+This change builds four bay surfaces over the frozen CP1 contract. There is no
+new business logic — the change is screens, selectors, and three small state
+mutations (salvage accept/decline, repair-ticket priority reorder) that toggle
+fields already on existing campaign types.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make every element of `ICampaignInventory` visible and actionable.
+- Match `campaign-ui` page, navigation, and state-handling conventions exactly.
+- Keep the change UI-only — render a frozen contract, mutate only existing
+  status fields.
+
+**Non-Goals:**
+
+- Command surfaces (CP2b), refit (CP3).
+- Any change to the `ICampaignInventory` schema.
+- New repair / salvage / medical engine logic.
+
+## Decisions
+
+### D1. New capability `campaign-bay-ui`, four surfaces, one navigation group
+
+The four bays are a cohesive post-battle cluster. A dedicated capability keeps
+them coherent and gives CP3 a clean dependency target (the refit surface links
+from the mech bay). They share one campaign-navigation group ("Bays").
+
+### D2. Mech Bay is the roster-wide entry point
+
+The Mech Bay page is a unit-status grid: one row per roster unit showing damage
+state (from `unitCombatStates`), repair-ticket count (count of `repairBay`
+items for that unit), and combat-readiness. It is the hub — each row drills into
+that unit's repair detail in the Repair Bay. The Mech Bay reads
+`unitCombatStates` and `ICampaignInventory.repairBay`; it owns no mutation.
+
+### D3. Repair Bay renders `repairBay`, grouped by unit, with priority reorder
+
+The Repair Bay page lists `ICampaignInventory.repairBay` grouped by `unitId`.
+Each ticket shows `kind`, `location`, `expectedHours`, `partsReady`, and
+`status`. The one mutation is **priority reorder** — the player drags tickets to
+set repair order. Reorder writes a `priority` ordinal onto the campaign's
+existing `repairTickets` (an existing field on `IRepairTicket` state); it does
+not change ticket content. The displayed `expectedHours` and `partsReady` are
+read-only projections.
+
+### D4. Medical Bay renders `medicalBay`, read-only
+
+The Medical Bay page lists `ICampaignInventory.medicalBay` — injured pilots with
+`injuryLevel`, `daysToRecover`, and `status`. It is read-only: recovery is
+driven by `healingProcessor` during day advancement, not by this UI. The page
+shows progress; it does not heal.
+
+### D5. Salvage Acceptance has the only value-bearing mutation
+
+The Salvage Acceptance panel lists `ICampaignInventory.salvageBay` with per-item
+**accept / decline** actions. Accepting/declining flips the item's `status`
+(`pending → accepted | declined`) on the campaign's existing
+`salvageAllocations` state and updates a running mercenary-share value total.
+The salvage *computation* (recovered value, disposition) is done by
+`salvageEngine` — this UI only records the player's accept/decline decision on
+already-computed candidates.
+
+### D6. All mutations route through the persistence store
+
+Priority reorder and salvage accept/decline mutate the live `ICampaign` and
+therefore mark the campaign dirty; the `campaign-persistence` store's debounced
+auto-save (CP0) picks them up. No bay surface writes to the server directly.
+
+### D7. State handling matches `campaign-ui`
+
+Each bay page implements the `campaign-ui` loading / empty / error pattern. An
+empty bay (no battles fought) shows an empty state, not an error. SSR/hydration
+safety follows the existing `campaign-ui` `SSR and Hydration Safety`
+requirement.
+
+### D8. Storybook coverage per surface
+
+Each of the four surfaces ships a Storybook story with populated, empty, and
+error variants — consistent with the project's storybook-build CI gate and the
+`storybook-component-library` conventions.
+
+## Risks / Trade-offs
+
+- **[Risk] Bay UI couples to a schema that later needs a field** → Mitigation:
+  the schema is CP1-frozen; if a field is genuinely missing the fix is a CP1
+  follow-up change, and the bay components consume the contract through typed
+  selectors so a schema addition is a compile-time update, not silent breakage.
+- **[Risk] Priority reorder races day-advancement repair processing** →
+  Mitigation: reorder only sets an ordinal; the repair processor reads the
+  ordinal at day-advancement time, so a reorder before the next day is honored
+  and a reorder after is honored next day — no lost write.
+- **[Risk] Salvage accept/decline double-applies value** → Mitigation: the
+  running total is a pure projection over `salvageBay` item `status`; toggling a
+  single item's status recomputes the total — there is no incremental
+  accumulator to double-count.
+- **[Risk] Medical Bay implies the player can heal pilots** → Mitigation: the
+  page is explicitly read-only (D4); recovery copy makes clear healing happens
+  on day advancement.
+
+## Migration Plan
+
+Purely additive. The four bay pages are new routes; the navigation group is a
+new entry. A campaign with no battles shows empty bays. No data model changes —
+the surfaces render the CP1 contract and toggle existing status fields. Rollback
+= revert the change-set; the campaign loop keeps working with the inventory
+computed but unrendered, as before CP2a.
+
+## Open Questions
+
+- Whether Mech Bay and Repair Bay should be one page with tabs or two routes —
+  proposed: two routes under one navigation group, matching the per-concern page
+  convention of `campaign-ui`.
+- Whether declined salvage is discarded or retained at zero value — proposed:
+  retained with `status = declined` and excluded from the value total; confirm
+  against `salvageEngine` semantics during implementation.

--- a/openspec/changes/add-campaign-bay-ui/proposal.md
+++ b/openspec/changes/add-campaign-bay-ui/proposal.md
@@ -1,0 +1,73 @@
+# Change: Add Campaign Bay UI
+
+## Why
+
+After a campaign battle, the post-battle effects are computed — repair tickets,
+salvage allocations, pilot injuries — and `add-campaign-combat-loop` (CP1)
+projects them into a frozen `ICampaignInventory`. But there is no screen where
+the player sees or acts on any of it. `campaign-ui` covers the campaign list,
+dashboard, roster, forces, and missions pages; it has **no bay surfaces**. The
+player cannot see which mechs are damaged, queue or prioritise repairs, track
+which pilots are in the infirmary, or accept/decline salvage. The campaign loop
+has a computed-but-invisible middle.
+
+This change adds the four post-battle bay UI surfaces — **mech bay**, **repair
+bay**, **medical bay**, and **salvage acceptance** — all rendering the frozen
+`ICampaignInventory` from CP1. It is a UI change: it builds screens over an
+existing data contract; it does not add new campaign business logic.
+
+## What Changes
+
+- ADDED a Mech Bay page: a roster-wide unit-status grid showing each unit's
+  damage state, repair-ticket count, and combat-readiness, with drill-down to
+  the unit's repair detail
+- ADDED a Repair Bay page: the repair-ticket queue from `ICampaignInventory.repairBay`,
+  grouped by unit, with per-ticket status, expected hours, parts-ready flag, and
+  a priority-reorder action
+- ADDED a Medical Bay page: the `ICampaignInventory.medicalBay` list of injured
+  pilots with injury level, days-to-recover, and recovery status
+- ADDED a Salvage Acceptance panel: the `ICampaignInventory.salvageBay` list with
+  per-item accept / decline actions and a running mercenary-share value total
+- ADDED bay navigation entries under the campaign navigation so the four
+  surfaces are reachable from the campaign dashboard
+- ADDED loading, empty, and error states for each surface consistent with the
+  existing `campaign-ui` patterns
+- ADDED Storybook stories for each bay surface covering populated, empty, and
+  error states
+
+## Dependencies
+
+- **Requires**: `add-campaign-combat-loop` (CP1 — the frozen `ICampaignInventory`
+  schema this UI renders), `campaign-ui` (the page/navigation/loading-state
+  patterns this matches), `campaign-persistence` (CP0 — accept/decline actions
+  mutate the campaign through the persistence store)
+- **Required By**: `add-campaign-refit-and-prestige` (CP3 — the refit surface
+  links from the mech bay)
+
+## Impact
+
+- Affected specs: `campaign-bay-ui` (new capability) — chosen over adding to
+  `campaign-ui` because the bay surfaces are a cohesive post-battle cluster with
+  their own navigation group and CP3 will link into them; a dedicated capability
+  keeps the four-surface set coherent
+- Affected code: `src/pages/campaigns/[id]/` (new bay pages),
+  `src/components/campaign/bays/` (new bay components),
+  `src/stores/campaign/` (read selectors over `ICampaignInventory`; accept/
+  decline / reorder actions)
+- No new data model — every surface renders the frozen CP1 `ICampaignInventory`;
+  accept/decline/reorder mutate existing campaign state (salvage status, ticket
+  priority) through the persistence store
+- Reversible: the bay pages are additive routes; removing them leaves the
+  campaign loop functional but invisible, as today
+
+## Non-Goals
+
+- Personnel hiring, finances/loans, and contract-market surfaces — those are
+  CP2b `add-campaign-command-ui`
+- The refit / equipment-swap surface — that is CP3 `add-campaign-refit-and-prestige`
+- Changing the `ICampaignInventory` schema — it is frozen by CP1; this change
+  only renders it
+- New repair / salvage / medical business logic — the engines exist; this change
+  surfaces their output and exposes accept/decline/reorder actions over existing
+  state
+- Tactical-map or in-battle UI — out of scope

--- a/openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+++ b/openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
@@ -1,0 +1,135 @@
+# campaign-bay-ui Specification
+
+## ADDED Requirements
+
+### Requirement: Bay Navigation Group
+
+The system SHALL provide a "Bays" campaign-navigation group giving access to the
+Mech Bay, Repair Bay, Medical Bay, and Salvage surfaces from the campaign
+dashboard.
+
+#### Scenario: Bay surfaces are reachable
+
+- **GIVEN** an open campaign
+- **WHEN** the campaign navigation renders
+- **THEN** a "Bays" group SHALL be present
+- **AND** it SHALL link to the Mech Bay, Repair Bay, Medical Bay, and Salvage pages
+
+### Requirement: Mech Bay Page
+
+The system SHALL provide a Mech Bay page showing a roster-wide unit-status grid
+with damage state, repair-ticket count, and combat-readiness, and drill-down to
+each unit's repair detail.
+
+#### Scenario: Mech Bay lists every roster unit
+
+- **GIVEN** a campaign roster with several units, some damaged
+- **WHEN** the Mech Bay page renders
+- **THEN** each roster unit SHALL appear as a row showing its damage state and repair-ticket count
+- **AND** each row SHALL provide a drill-down link to that unit's Repair Bay detail
+
+#### Scenario: Mech Bay empty state
+
+- **GIVEN** a campaign with no roster units
+- **WHEN** the Mech Bay page renders
+- **THEN** an empty state SHALL be shown rather than an error
+
+### Requirement: Repair Bay Page
+
+The system SHALL provide a Repair Bay page rendering `ICampaignInventory.repairBay`
+grouped by unit, with per-ticket detail and a priority-reorder action.
+
+#### Scenario: Repair Bay lists tickets grouped by unit
+
+- **GIVEN** a campaign whose inventory carries repair tickets for two units
+- **WHEN** the Repair Bay page renders
+- **THEN** the tickets SHALL be grouped by unit
+- **AND** each ticket SHALL show its kind, location, expected hours, parts-ready flag, and status
+
+#### Scenario: Priority reorder persists
+
+- **GIVEN** a Repair Bay with several queued tickets
+- **WHEN** the player reorders a ticket's priority
+- **THEN** a `priority` ordinal SHALL be written onto the campaign's repair-ticket state
+- **AND** the campaign SHALL be marked dirty so the persistence store auto-saves
+
+#### Scenario: Repair Bay empty state
+
+- **GIVEN** a campaign with no repair tickets
+- **WHEN** the Repair Bay page renders
+- **THEN** an empty state SHALL be shown rather than an error
+
+### Requirement: Medical Bay Page
+
+The system SHALL provide a read-only Medical Bay page rendering
+`ICampaignInventory.medicalBay` with each injured pilot's injury level,
+days-to-recover, and recovery status.
+
+#### Scenario: Medical Bay lists injured pilots
+
+- **GIVEN** a campaign whose inventory carries injured pilots
+- **WHEN** the Medical Bay page renders
+- **THEN** each injured pilot SHALL appear with injury level, days-to-recover, and status
+
+#### Scenario: Medical Bay exposes no healing controls
+
+- **GIVEN** the Medical Bay page is rendered
+- **WHEN** the player inspects the page
+- **THEN** no control SHALL allow healing a pilot directly
+- **AND** recovery copy SHALL indicate healing happens on day advancement
+
+#### Scenario: Medical Bay empty state
+
+- **GIVEN** a campaign with no injured pilots
+- **WHEN** the Medical Bay page renders
+- **THEN** an empty state SHALL be shown rather than an error
+
+### Requirement: Salvage Acceptance Panel
+
+The system SHALL provide a Salvage Acceptance panel rendering
+`ICampaignInventory.salvageBay` with per-item accept and decline actions and a
+running mercenary-share value total.
+
+#### Scenario: Accepting a salvage item persists its status
+
+- **GIVEN** a salvage item with status `pending`
+- **WHEN** the player accepts it
+- **THEN** the item's status SHALL become `accepted` on the campaign's salvage state
+- **AND** the campaign SHALL be marked dirty so the persistence store auto-saves
+
+#### Scenario: Declining a salvage item excludes it from the total
+
+- **GIVEN** a salvage item with status `pending` contributing to the value total
+- **WHEN** the player declines it
+- **THEN** the item's status SHALL become `declined`
+- **AND** the running mercenary-share value total SHALL no longer include that item
+
+#### Scenario: Value total is a pure projection
+
+- **GIVEN** a salvage bay with several accepted and declined items
+- **WHEN** the value total is computed
+- **THEN** it SHALL equal the sum of recovered values of items with status `accepted`
+- **AND** toggling one item's status SHALL recompute the total without double-counting
+
+#### Scenario: Salvage Acceptance empty state
+
+- **GIVEN** a campaign with no salvage candidates
+- **WHEN** the Salvage Acceptance panel renders
+- **THEN** an empty state SHALL be shown rather than an error
+
+### Requirement: Bay Surface Loading and Error States
+
+The system SHALL implement loading and error states on every bay surface
+consistent with the existing `campaign-ui` conventions.
+
+#### Scenario: Loading state while inventory resolves
+
+- **GIVEN** a campaign whose inventory has not yet loaded
+- **WHEN** any bay surface renders
+- **THEN** a loading state SHALL be shown
+
+#### Scenario: Error state on inventory failure
+
+- **GIVEN** an inventory load that fails
+- **WHEN** any bay surface renders
+- **THEN** an error state SHALL be shown with a retry affordance

--- a/openspec/changes/add-campaign-bay-ui/tasks.md
+++ b/openspec/changes/add-campaign-bay-ui/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: Add Campaign Bay UI
+
+## 1. Bay Navigation and Selectors
+
+- [ ] 1.1 Add a "Bays" campaign-navigation group with entries for Mech Bay, Repair Bay, Medical Bay, and Salvage
+- [ ] 1.2 Add typed campaign-store selectors over `ICampaignInventory` — `selectRepairBay`, `selectSalvageBay`, `selectMedicalBay`, `selectInventorySummary`
+- [ ] 1.3 Tests: selectors return the expected projections from a populated campaign and empty arrays from a battle-free campaign
+
+## 2. Mech Bay Page
+
+- [ ] 2.1 Build the Mech Bay page — a roster-wide unit-status grid (damage state, repair-ticket count, combat-readiness)
+- [ ] 2.2 Add per-row drill-down navigation into the unit's Repair Bay detail
+- [ ] 2.3 Implement loading, empty (no units), and error states matching `campaign-ui` conventions
+- [ ] 2.4 Storybook story with populated, empty, and error variants
+- [ ] 2.5 Render tests: grid rows, ticket counts, drill-down link
+
+## 3. Repair Bay Page
+
+- [ ] 3.1 Build the Repair Bay page — the `repairBay` ticket queue grouped by unit, each ticket showing kind, location, expected hours, parts-ready, status
+- [ ] 3.2 Implement priority reorder — dragging a ticket writes a `priority` ordinal onto the campaign's `repairTickets` state via the persistence store
+- [ ] 3.3 Implement loading, empty (no tickets), and error states
+- [ ] 3.4 Storybook story with populated, empty, and error variants
+- [ ] 3.5 Tests: queue grouping, priority reorder persists the ordinal, expected-hours and parts-ready render read-only
+
+## 4. Medical Bay Page
+
+- [ ] 4.1 Build the Medical Bay page — the `medicalBay` list of injured pilots (injury level, days-to-recover, status), read-only
+- [ ] 4.2 Add recovery-progress copy making clear healing happens on day advancement
+- [ ] 4.3 Implement loading, empty (no injuries), and error states
+- [ ] 4.4 Storybook story with populated, empty, and error variants
+- [ ] 4.5 Render tests: pilot rows, injury levels, no mutation controls present
+
+## 5. Salvage Acceptance Panel
+
+- [ ] 5.1 Build the Salvage Acceptance panel — the `salvageBay` list with per-item accept / decline actions
+- [ ] 5.2 Implement accept/decline — flips item `status` on the campaign's `salvageAllocations` state via the persistence store
+- [ ] 5.3 Implement the running mercenary-share value total as a pure projection over item status
+- [ ] 5.4 Implement loading, empty (no salvage), and error states
+- [ ] 5.5 Storybook story with populated, empty, and error variants
+- [ ] 5.6 Tests: accept/decline persists status, value total recomputes correctly, declined items excluded from the total
+
+## 6. Verification
+
+- [ ] 6.1 Integration test: after a campaign battle and day advancement, all four bays render the projected inventory
+- [ ] 6.2 Integration test: salvage accept and repair-priority reorder mark the campaign dirty and trigger an auto-save
+- [ ] 6.3 `openspec validate add-campaign-bay-ui --strict` clean
+- [ ] 6.4 Build, lint, typecheck, and storybook-build pass

--- a/openspec/changes/add-campaign-combat-loop/design.md
+++ b/openspec/changes/add-campaign-combat-loop/design.md
@@ -1,0 +1,185 @@
+# Design: Add Campaign Combat Loop
+
+## Context
+
+The campaign-to-combat-to-campaign round trip exists in pieces:
+
+- **Scenario generation** — `scenarioGenerationProcessor` runs weekly, checks
+  each combat team for a battle, and on a hit emits a `scenario_generated` day
+  event carrying a deterministic `scenarioId` (`scn-<contractId>-<date>-<teamId>`),
+  `contractId`, `opForBV`, `scenarioType`, `isAttacker`, and conditions.
+- **Encounters** — `encounter-system` defines `IEncounter`, the launch snapshot,
+  and the encounter store. A standalone encounter can be authored and launched.
+- **Outcome intake** — `game-session-management` specifies that a completed
+  `InteractiveSession` publishes `CombatOutcomeReady`, the campaign store
+  enqueues it on `pendingBattleOutcomes`, and day advancement drains the queue
+  through `postBattleProcessor` → `salvageProcessor` → `repairQueueBuilderProcessor`.
+
+The gap is the **connective tissue**: a `scenario_generated` event never becomes
+an `IEncounter`; a campaign mission has no launch path into a `GameSession`; and
+nothing automatically routes a campaign-originated session's outcome back to its
+campaign. This change supplies exactly those three connectors and freezes the
+inventory schema CP2a will render. The combat-effects processors are reused
+verbatim.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A generated scenario becomes a launchable encounter with full campaign
+  linkage.
+- Launching that encounter creates a campaign-linked `GameSession`.
+- Finishing that session automatically feeds `pendingBattleOutcomes`.
+- The post-battle inventory schema is frozen here so CP2a has a stable contract.
+- Every connector is idempotent.
+
+**Non-Goals:**
+
+- Rebuilding the battle-effects processors.
+- Any UI surface (CP2a).
+- AI behavior (Wave 2), co-op launch (Wave 5).
+
+## Decisions
+
+### D1. Scenario-event → encounter bridge runs in the day pipeline
+
+A new day processor (`scenarioEncounterBridgeProcessor`, phase
+`DayPhase.EVENTS + 10` so it runs after `scenarioGenerationProcessor`) reads the
+day's `scenario_generated` events from the pipeline result and, for each, builds
+and persists an `IEncounter`. The bridge is a *consumer* of the event stream,
+not a modification of `scenarioGenerationProcessor` — that processor stays
+untouched, satisfying the all-ADDED constraint.
+
+### D2. Encounter is built from scenario-event data + the contract
+
+`buildEncounterFromScenario(event, campaign)` maps the `scenario_generated`
+payload onto an `IEncounter`: the OpFor force from `opForBV` and `scenarioType`,
+the player force from the contract's assigned combat team, map config from the
+scenario conditions, and victory conditions from `scenarioType`. The encounter
+carries `campaignMeta: { campaignId, contractId, scenarioId }` so every
+downstream step can thread linkage back to the contract.
+
+### D3. Idempotency keys
+
+The bridge keys on `scenarioId`: a `campaign.bridgedScenarioIds` set records
+every scenario already turned into an encounter; a re-run skips it. The
+enqueue trigger keys on `matchId`, reusing the existing duplicate guard from the
+`Campaign Store Enqueues Outcomes` requirement. Both keys are deterministic, so
+re-running a day or replaying the pipeline produces no duplicates.
+
+### D4. Frozen post-battle inventory schema
+
+This is the contract CP2a depends on. **Frozen here, not changed by CP2a:**
+
+```typescript
+interface ICampaignInventory {
+  readonly campaignId: string;
+  readonly generatedAt: string;             // ISO 8601
+  readonly repairBay: readonly IRepairBayItem[];
+  readonly salvageBay: readonly ISalvageBayItem[];
+  readonly medicalBay: readonly IMedicalBayItem[];
+  readonly summary: IInventorySummary;
+}
+
+interface IRepairBayItem {
+  readonly ticketId: string;                // from IRepairTicket
+  readonly unitId: string;
+  readonly kind: 'armor' | 'structure' | 'component' | 'ammo' | 'heat-recovery';
+  readonly location: string | null;
+  readonly expectedHours: number;
+  readonly partsReady: boolean;             // all partsRequired matched
+  readonly status: 'queued' | 'parts-needed' | 'in-progress' | 'done';
+}
+
+interface ISalvageBayItem {
+  readonly partId: string;                  // from ISalvageCandidate
+  readonly sourceUnitId: string;
+  readonly designation: string;
+  readonly recoveredValue: number;          // C-bills
+  readonly disposition: 'mercenary' | 'employer';
+  readonly status: 'pending' | 'accepted' | 'declined';
+}
+
+interface IMedicalBayItem {
+  readonly pilotId: string;
+  readonly pilotName: string;
+  readonly injuryLevel: 'none' | 'light' | 'serious' | 'critical' | 'kia';
+  readonly daysToRecover: number;
+  readonly status: 'recovering' | 'ready' | 'discharged';
+}
+
+interface IInventorySummary {
+  readonly repairTicketCount: number;
+  readonly totalRepairHours: number;
+  readonly salvageValueTotal: number;       // C-bills, mercenary share
+  readonly pilotsInMedical: number;
+}
+```
+
+Every field is read-only. `IRepairBayItem` is a projection of `IRepairTicket`,
+`ISalvageBayItem` of `ISalvageCandidate`, `IMedicalBayItem` of the pilot's
+campaign-roster injury state. CP2a renders this structure and may *not* alter
+the schema; an inventory schema change requires its own change.
+
+### D5. Inventory projection step
+
+`projectCampaignInventory(campaign): ICampaignInventory` is a pure function that
+reads `campaign.repairTickets`, `campaign.salvageAllocations`, and the roster's
+pilot injury state and assembles `ICampaignInventory`. It runs in a
+`CLEANUP`-phase processor after the battle-effects block has drained, so the
+inventory always reflects post-battle state. The projection is derived and
+recomputed each day — it is not an independently mutated store.
+
+### D6. Campaign-linked launch path
+
+When the player opens a generated encounter from a campaign, the launch creates
+a `GameSession` via the existing `encounter-system` launch snapshot, then stamps
+the session's campaign linkage (`campaignId`, `contractId`, `scenarioId`) using
+the existing `Session Carries Campaign Linkage` requirement of
+`game-session-management`. No new session-creation path — the campaign supplies
+the linkage fields and reuses the encounter launch.
+
+### D7. Automatic enqueue trigger
+
+The campaign store already subscribes to `CombatOutcomeReady`. This change
+narrows the handler: when the completing session carries campaign linkage, the
+outcome is enqueued onto *that campaign's* `pendingBattleOutcomes`. A session
+without campaign linkage (a standalone skirmish) is ignored, exactly as today.
+The duplicate-by-`matchId` guard from the existing requirement is reused.
+
+## Risks / Trade-offs
+
+- **[Risk] A `scenario_generated` event is bridged twice** → Mitigation: the
+  `bridgedScenarioIds` idempotency set (D3); a re-run skips known scenario ids.
+- **[Risk] The inventory schema (D4) needs a field after CP2a starts** →
+  Mitigation: the schema is frozen here and CP2a is forbidden from changing it;
+  a genuine schema gap is a follow-up change, not silent drift. The schema was
+  designed against the *existing* `IRepairTicket` / `ISalvageCandidate` fields,
+  reducing the chance of a gap.
+- **[Risk] Inventory projection runs before the battle-effects block drains** →
+  Mitigation: the projection processor is phase `CLEANUP` (900), strictly after
+  the `MISSIONS - 50/-25/-10` battle-effects block; the day pipeline's phase
+  ordering guarantees it.
+- **[Risk] OpFor force generated from `opForBV` only is too coarse** →
+  Mitigation: this change scopes OpFor to a BV-matched force using the existing
+  `opForGeneration` util; richer OpFor composition is out of scope and noted as
+  an open question.
+
+## Migration Plan
+
+Purely additive. `scenarioGenerationProcessor` is untouched — the bridge is a
+new consumer processor. The enqueue handler is narrowed but its existing
+standalone-skirmish behavior is unchanged. The inventory projection is a new
+derived structure; campaigns with no battles produce an empty
+`ICampaignInventory`. No database migrations. Rollback = revert the change-set;
+generated scenarios revert to being non-launchable day events as today.
+
+## Open Questions
+
+- OpFor composition fidelity — proposed: BV-matched force from `opForGeneration`
+  for this change; richer composition (unit roles, lance structure) deferred.
+- Whether the bridge should auto-launch the encounter or only persist it —
+  proposed: persist only; the player chooses when to launch from CP2a/CP2b UI.
+- Medical-bay injury source — proposed: read from the campaign-roster pilot
+  injury state populated by `healingProcessor`; confirm the field name during
+  implementation.

--- a/openspec/changes/add-campaign-combat-loop/proposal.md
+++ b/openspec/changes/add-campaign-combat-loop/proposal.md
@@ -1,0 +1,85 @@
+# Change: Add Campaign Combat Loop
+
+## Why
+
+The campaign day pipeline and combat engine are each largely built, but the
+seam between them is missing. `scenarioGenerationProcessor` emits a
+`scenario_generated` day event carrying a deterministic `scenarioId`,
+`contractId`, `opForBV`, and conditions — but **nothing turns that event into a
+launchable `IEncounter`**. The player sees "a scenario was generated" and has no
+way to play it. Conversely, when a tactical match completes, `InteractiveSession`
+publishes `CombatOutcomeReady` and the campaign store enqueues it onto
+`pendingBattleOutcomes`; the day pipeline already drains that queue through
+`postBattleProcessor` → `salvageProcessor` → `repairQueueBuilderProcessor`. But
+there is no triggered, automatic path from finishing a *campaign* mission to
+that queue — the round trip is only specified, not wired for campaign-launched
+encounters.
+
+This change is **integration wire-up only**. `postBattleProcessor`,
+`salvageEngine`, and `repairQueueBuilder` are 60-70% built and are NOT
+rebuilt here. The change supplies the three missing connectors: the
+scenario-event → `IEncounter` persistence bridge, the campaign-mission →
+encounter launch path, and the automatic `GameSession` completion →
+`pendingBattleOutcomes` trigger for campaign-originated encounters — plus a
+frozen post-battle inventory schema that the bay-UI change (CP2a) renders.
+
+## What Changes
+
+- ADDED a scenario-event → `IEncounter` bridge: a day-pipeline consumer reads
+  `scenario_generated` events and persists a launchable `IEncounter` carrying
+  the `scenarioId` / `contractId` linkage, OpFor force, map config, and victory
+  conditions
+- ADDED a campaign-mission → encounter launch path: opening a generated
+  encounter from a campaign creates a `GameSession` with campaign linkage
+  (`campaignId`, `contractId`, `scenarioId`) stamped on the session
+- ADDED an automatic `GameSession` completion → `pendingBattleOutcomes` trigger:
+  a campaign-linked session that publishes `CombatOutcomeReady` enqueues its
+  outcome onto the originating campaign's queue without manual intervention
+- ADDED a frozen post-battle inventory schema (`ICampaignInventory` —
+  see design.md D4) that aggregates repair tickets, salvage allocations, and
+  medical entries into one campaign-attached structure the bay UI reads
+- ADDED an inventory-projection step: after the battle-effects processor block
+  drains, a projection assembles the `ICampaignInventory` from the campaign's
+  `repairTickets`, `salvageAllocations`, and `unitCombatStates`
+- ADDED idempotency across the bridge: a `scenario_generated` event already
+  bridged to an encounter is not bridged twice; a campaign-linked outcome
+  already enqueued is not enqueued twice (by `matchId`)
+
+## Dependencies
+
+- **Requires**: `add-campaign-persistence` (CP0 — the campaign is read and
+  written through the persistence store), `encounter-system` (`IEncounter`
+  model, launch snapshot), `game-session-management` (`CombatOutcomeReady`,
+  `Campaign Store Enqueues Outcomes`, `Day Advancement Applies Pending
+  Outcomes`), `scenario-generation` (the `scenario_generated` event shape)
+- **Required By**: `add-campaign-bay-ui` (CP2a — renders the frozen
+  `ICampaignInventory`), and Wave 5 `add-coop-campaign-play` (co-op mission
+  launch reuses this launch path)
+
+## Impact
+
+- Affected specs: `campaign-combat-loop` (new capability) — chosen over adding
+  to `game-session-management` because the bridge spans scenario generation,
+  encounter persistence, and the day pipeline; a dedicated capability keeps the
+  cross-cutting wire-up coherent and gives CP2a a single schema to depend on
+- Affected code: `src/lib/campaign/processors/` (new bridge consumer of
+  `scenario_generated`), `src/lib/campaign/encounter/` (new
+  scenario→encounter builder), `src/lib/campaign/inventory/` (new inventory
+  projection), `src/stores/campaign/` (campaign-linked launch + enqueue trigger),
+  `src/types/campaign/` (new `ICampaignInventory` and satellites)
+- No new database engine — encounters persist through the existing
+  `encounter-system` store; the inventory projection is a derived structure
+  attached to the campaign snapshot
+- Reuses, does not rebuild: `postBattleProcessor`, `salvageEngine`,
+  `repairQueueBuilder` are consumed as-is
+
+## Non-Goals
+
+- Rebuilding `postBattleProcessor`, `salvageEngine`, or `repairQueueBuilder` —
+  they are existing and only consumed
+- The bay / repair / medical / salvage UI surfaces — that is CP2a; this change
+  only freezes the schema CP2a renders
+- AI-driven OpFor behavior in the launched encounter — Wave 2 owns AI
+- Co-op mission launch with two players' forces — Wave 5 `add-coop-campaign-play`
+- Manual ad-hoc encounter creation outside a campaign — `encounter-system`
+  already covers standalone encounters

--- a/openspec/changes/add-campaign-combat-loop/specs/campaign-combat-loop/spec.md
+++ b/openspec/changes/add-campaign-combat-loop/specs/campaign-combat-loop/spec.md
@@ -1,0 +1,126 @@
+# campaign-combat-loop Specification
+
+## ADDED Requirements
+
+### Requirement: Frozen Post-Battle Inventory Schema
+
+The system SHALL define a frozen `ICampaignInventory` schema aggregating repair,
+salvage, and medical state into one campaign-attached structure. Every field
+MUST be read-only, and the schema MUST NOT be altered by consuming UI changes.
+
+#### Scenario: Inventory carries the three bays and a summary
+
+- **GIVEN** a campaign with post-battle repair, salvage, and medical state
+- **WHEN** an `ICampaignInventory` is constructed
+- **THEN** it SHALL carry `repairBay`, `salvageBay`, `medicalBay`, and `summary`
+- **AND** each bay item type SHALL be read-only in every field
+
+#### Scenario: Bay items project from existing engine types
+
+- **GIVEN** an `IRepairTicket` and an `ISalvageCandidate` from the existing engines
+- **WHEN** they are projected into `IRepairBayItem` and `ISalvageBayItem`
+- **THEN** every `IRepairBayItem` field SHALL be derivable from `IRepairTicket`
+- **AND** every `ISalvageBayItem` field SHALL be derivable from `ISalvageCandidate`
+
+### Requirement: Scenario-Event to Encounter Bridge
+
+The system SHALL consume `scenario_generated` day events and persist a
+launchable `IEncounter` for each, carrying campaign linkage back to the
+originating contract and scenario.
+
+#### Scenario: A generated scenario becomes a launchable encounter
+
+- **GIVEN** a day pipeline run that emits a `scenario_generated` event with `scenarioId` S and `contractId` C
+- **WHEN** the scenario-encounter bridge processor runs
+- **THEN** a launchable `IEncounter` SHALL be persisted through the encounter store
+- **AND** the encounter SHALL carry `campaignMeta` with `campaignId`, `contractId` C, and `scenarioId` S
+
+#### Scenario: Encounter is built from scenario data and the contract
+
+- **GIVEN** a `scenario_generated` event carrying `opForBV`, `scenarioType`, and conditions
+- **WHEN** `buildEncounterFromScenario` runs
+- **THEN** the encounter's OpFor force SHALL be BV-matched to `opForBV`
+- **AND** the encounter's victory conditions SHALL be derived from `scenarioType`
+- **AND** the encounter's map config SHALL be derived from the scenario conditions
+
+#### Scenario: Bridge runs after scenario generation
+
+- **GIVEN** the day pipeline's phase ordering
+- **WHEN** the day is processed
+- **THEN** `scenarioGenerationProcessor` SHALL run before the scenario-encounter bridge processor
+
+### Requirement: Scenario Bridge Idempotency
+
+The system SHALL bridge each `scenario_generated` event to an encounter at most
+once, keyed by `scenarioId`.
+
+#### Scenario: A re-run does not duplicate the encounter
+
+- **GIVEN** a scenario with id S already bridged to an encounter
+- **WHEN** the bridge processor runs again on a day carrying the same `scenario_generated` event
+- **THEN** no second encounter SHALL be created for scenario S
+- **AND** `campaign.bridgedScenarioIds` SHALL still contain S exactly once
+
+### Requirement: Campaign-Linked Encounter Launch
+
+The system SHALL launch a campaign-generated encounter into a `GameSession`
+stamped with campaign linkage.
+
+#### Scenario: Launching a generated encounter creates a linked session
+
+- **GIVEN** a persisted campaign-generated encounter for campaign C, contract K, scenario S
+- **WHEN** the player launches the encounter from the campaign
+- **THEN** a `GameSession` SHALL be created from the encounter launch snapshot
+- **AND** the session SHALL carry `campaignId` C, `contractId` K, and `scenarioId` S
+
+### Requirement: Automatic Outcome Enqueue
+
+The system SHALL automatically enqueue the combat outcome of a campaign-linked
+session onto the originating campaign's `pendingBattleOutcomes`, while ignoring
+sessions without campaign linkage.
+
+#### Scenario: Campaign-linked completion enqueues the outcome
+
+- **GIVEN** a campaign-linked session for campaign C that completes and publishes `CombatOutcomeReady`
+- **WHEN** the campaign store handles the event
+- **THEN** the outcome SHALL be appended to campaign C's `pendingBattleOutcomes`
+
+#### Scenario: Standalone skirmish is ignored
+
+- **GIVEN** a session without campaign linkage that completes and publishes `CombatOutcomeReady`
+- **WHEN** the campaign store handles the event
+- **THEN** no campaign's `pendingBattleOutcomes` SHALL change
+
+#### Scenario: Duplicate outcome is dropped
+
+- **GIVEN** a campaign-linked outcome with `matchId` M already enqueued
+- **WHEN** a second `CombatOutcomeReady` carrying the same `matchId` M arrives
+- **THEN** `pendingBattleOutcomes` SHALL remain unchanged
+
+### Requirement: Post-Battle Inventory Projection
+
+The system SHALL project an `ICampaignInventory` from the campaign's repair
+tickets, salvage allocations, and roster pilot injury state, after the
+battle-effects processor block has drained.
+
+#### Scenario: Projection reflects post-battle state
+
+- **GIVEN** a campaign whose battle-effects processors have produced repair tickets, salvage allocations, and pilot injuries
+- **WHEN** the inventory projection runs
+- **THEN** the resulting `ICampaignInventory` SHALL list every repair ticket as an `IRepairBayItem`
+- **AND** every salvage candidate as an `ISalvageBayItem`
+- **AND** every injured pilot as an `IMedicalBayItem`
+- **AND** the `summary` SHALL carry accurate counts and totals
+
+#### Scenario: Empty campaign yields an empty inventory
+
+- **GIVEN** a campaign with no battles fought
+- **WHEN** the inventory projection runs
+- **THEN** all three bays SHALL be empty
+- **AND** the `summary` counts and totals SHALL all be zero
+
+#### Scenario: Projection runs after battle effects
+
+- **GIVEN** the day pipeline's phase ordering
+- **WHEN** a day with pending outcomes is processed
+- **THEN** the inventory projection SHALL run strictly after `postBattleProcessor`, `salvageProcessor`, and `repairQueueBuilderProcessor`

--- a/openspec/changes/add-campaign-combat-loop/tasks.md
+++ b/openspec/changes/add-campaign-combat-loop/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Add Campaign Combat Loop
+
+## 1. Inventory Schema Freeze
+
+- [ ] 1.1 Add `ICampaignInventory`, `IRepairBayItem`, `ISalvageBayItem`, `IMedicalBayItem`, and `IInventorySummary` to `src/types/campaign/` exactly as frozen in design.md D4
+- [ ] 1.2 Add a doc comment on each type marking the schema frozen and pointing CP2a at this change for any schema-change request
+- [ ] 1.3 Type tests asserting every field is read-only and the projection sources (`IRepairTicket`, `ISalvageCandidate`) cover every `IRepairBayItem` / `ISalvageBayItem` field
+
+## 2. Scenario-Event to Encounter Bridge
+
+- [ ] 2.1 Implement `buildEncounterFromScenario(event, campaign)` mapping a `scenario_generated` payload onto an `IEncounter` with `campaignMeta = { campaignId, contractId, scenarioId }`
+- [ ] 2.2 Derive the OpFor force from `opForBV` and `scenarioType` via the existing `opForGeneration` util; derive map config from scenario conditions; derive victory conditions from `scenarioType`
+- [ ] 2.3 Implement `scenarioEncounterBridgeProcessor` at phase `DayPhase.EVENTS + 10`, consuming the day's `scenario_generated` events and persisting an `IEncounter` per event through the `encounter-system` store
+- [ ] 2.4 Implement the `bridgedScenarioIds` idempotency set — a scenario already bridged is skipped
+- [ ] 2.5 Register the bridge processor in `processorRegistration.ts`
+- [ ] 2.6 Tests: a `scenario_generated` event yields one persisted launchable encounter with correct linkage; a re-run produces no duplicate; an empty day produces no encounters
+
+## 3. Campaign-Linked Encounter Launch
+
+- [ ] 3.1 Implement the campaign launch path — opening a generated encounter from a campaign creates a `GameSession` via the existing `encounter-system` launch snapshot
+- [ ] 3.2 Stamp `campaignId`, `contractId`, and `scenarioId` onto the session using the existing `Session Carries Campaign Linkage` requirement
+- [ ] 3.3 Tests: launching a generated encounter produces a campaign-linked session; the linkage fields round-trip to the session
+
+## 4. Automatic Outcome Enqueue Trigger
+
+- [ ] 4.1 Narrow the campaign store's `CombatOutcomeReady` handler — a session carrying campaign linkage enqueues its outcome onto that campaign's `pendingBattleOutcomes`
+- [ ] 4.2 Preserve existing behavior — a session without campaign linkage is ignored
+- [ ] 4.3 Reuse the duplicate-by-`matchId` guard so a re-published outcome is not enqueued twice
+- [ ] 4.4 Tests: a campaign-linked session completion enqueues exactly once; a standalone skirmish is ignored; a duplicate `matchId` is dropped
+
+## 5. Inventory Projection
+
+- [ ] 5.1 Implement `projectCampaignInventory(campaign)` — a pure projection from `repairTickets`, `salvageAllocations`, and roster pilot injury state into `ICampaignInventory`
+- [ ] 5.2 Implement a `CLEANUP`-phase processor that runs `projectCampaignInventory` after the battle-effects block drains and attaches the result to the campaign snapshot
+- [ ] 5.3 Tests: projection from a populated post-battle campaign yields the expected `ICampaignInventory`; an empty campaign yields an empty inventory with zeroed summary; projection runs strictly after the battle-effects block
+
+## 6. End-to-End Round Trip
+
+- [ ] 6.1 Integration test: a generated scenario is bridged to an encounter, launched as a campaign-linked session, completed, and its outcome auto-enqueued
+- [ ] 6.2 Integration test: advancing the day drains the enqueued outcome through the existing battle-effects processors and the inventory projection reflects the result
+- [ ] 6.3 Integration test: the full round trip is idempotent — re-running the day produces no duplicate encounters, outcomes, or inventory entries
+
+## 7. Verification
+
+- [ ] 7.1 `openspec validate add-campaign-combat-loop --strict` clean
+- [ ] 7.2 Build, lint, and typecheck pass

--- a/openspec/changes/add-campaign-command-ui/design.md
+++ b/openspec/changes/add-campaign-command-ui/design.md
@@ -1,0 +1,140 @@
+# Design: Add Campaign Command UI
+
+## Context
+
+The command-tier campaign engines are built: `personnelMarketProcessor`
+refreshes the hiring pool, `campaign-finances` owns Money / transactions /
+balance, `contractMarketProcessor` and `mission-contracts` cover contract
+offers and acceptance. `campaign-ui` establishes the campaign-screen
+conventions — a page per concern, a campaign-navigation group, standard loading
+/ empty / error states. The missing piece is any *screen* for the player to
+hire pilots, manage money, or take contracts.
+
+This change builds three command surfaces over the existing engines. It is
+UI-plus-actions: it adds screens, selectors, and three actions (hire,
+accept-contract, take-loan). The only new data model is a small loan record;
+loan repayment reuses the existing daily-cost pipeline.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make personnel hiring, finances, and the contract market visible and
+  actionable.
+- Match `campaign-ui` page, navigation, and state-handling conventions.
+- Keep the change UI-plus-thin-actions — surface existing engines, add only the
+  loan record.
+
+**Non-Goals:**
+
+- Bay surfaces (CP2a), refit / prestige (CP3).
+- New hiring / finance / contract business logic.
+- A full loan-amortisation engine.
+
+## Decisions
+
+### D1. New capability `campaign-command-ui`, three surfaces, one navigation group
+
+The three command surfaces are a cohesive management cluster. A dedicated
+capability keeps them coherent and parallels `campaign-bay-ui`. They share one
+campaign-navigation group ("Command").
+
+### D2. Personnel & Hiring renders the existing market pool
+
+The Personnel & Hiring page lists the current personnel-market candidates (the
+pool `personnelMarketProcessor` maintains). Each candidate shows skills, salary,
+and traits. The **hire** action routes through the existing
+`personnel-management` hiring logic — it does not reimplement hiring; it calls
+it and the resulting roster/finance mutation flows through existing code.
+
+### D3. Finances & Loans renders the ledger and adds a loan surface
+
+The Finances & Loans page shows the campaign balance, the `campaign-finances`
+transaction ledger, and a daily-cost projection — all read from existing
+`campaign-finances` state. The new element is the **loan surface**: take a loan
+(principal, interest, term), and view outstanding loans with their repayment
+schedule.
+
+### D4. Loan record and repayment via the existing daily-cost pipeline
+
+A loan is a small record:
+
+```typescript
+interface ICampaignLoan {
+  readonly id: string;
+  readonly principal: number;        // C-bills borrowed
+  readonly interestRate: number;     // fractional, e.g. 0.10
+  readonly termDays: number;
+  readonly takenOnDate: string;      // ISO 8601
+  readonly remainingBalance: number; // C-bills still owed
+  readonly dailyRepayment: number;   // C-bills per day
+  readonly status: 'active' | 'repaid' | 'defaulted';
+}
+```
+
+Loans are stored on the campaign. Repayment is **not** a new engine: the loan's
+`dailyRepayment` is summed into the daily-cost figure the existing
+`dailyCostsProcessor` already debits. Taking a loan credits `principal` to the
+balance via an existing `campaign-finances` transaction. The loan ledger UI is a
+projection over `campaign.loans`; the math is fixed at loan-creation time
+(`dailyRepayment = principal * (1 + interestRate) / termDays`).
+
+### D5. Contract Market renders offers with accept/decline
+
+The Contract Market page lists current contract-market offers (the pool
+`contractMarketProcessor` maintains). Each offer shows employer, pay, salvage
+rights, and duration. **Accept** routes through the existing
+`mission-contracts` contract-acceptance logic; **decline** removes the offer
+from the player's view. Neither reimplements contract logic.
+
+### D6. All mutations route through the persistence store
+
+Hire, accept-contract, and take-loan mutate the live `ICampaign`, marking it
+dirty; the `campaign-persistence` store's debounced auto-save (CP0) picks them
+up. No command surface writes to the server directly.
+
+### D7. State handling matches `campaign-ui`
+
+Each command page implements the `campaign-ui` loading / empty / error pattern.
+An empty market (nothing on offer this cycle) shows an empty state, not an
+error. SSR/hydration safety follows the existing `campaign-ui` requirement.
+
+### D8. Storybook coverage per surface
+
+Each of the three surfaces ships a Storybook story with populated, empty, and
+error variants — consistent with the storybook-build CI gate.
+
+## Risks / Trade-offs
+
+- **[Risk] The loan surface grows into a full amortisation engine** →
+  Mitigation: D4 fixes the loan math at creation time and reuses the daily-cost
+  pipeline for repayment; compound interest, refinancing, and early payoff are
+  explicit non-goals.
+- **[Risk] Hiring / contract actions duplicate engine logic** → Mitigation: the
+  actions are thin call-throughs to `personnel-management` and
+  `mission-contracts` — the UI gathers input and invokes existing functions.
+- **[Risk] A loan default has no defined consequence** → Mitigation: `status`
+  carries a `defaulted` value for the daily-cost pipeline to set when the
+  balance cannot cover repayment; the *consequence* of a default (faction
+  standing hit, etc.) is out of scope and an open question.
+- **[Risk] Market state changes under the player between render and action** →
+  Mitigation: the action re-reads current market state at invocation; a hire or
+  accept of an offer no longer present fails gracefully with an error state.
+
+## Migration Plan
+
+Purely additive. The three command pages are new routes; the navigation group
+is a new entry. The loan record is a new optional `loans` field on the campaign,
+absent on existing campaigns and defaulting to an empty list. Repayment reuses
+the existing daily-cost pipeline. No destructive migration. Rollback = revert
+the change-set; command logic keeps working unsurfaced, as before CP2b.
+
+## Open Questions
+
+- Loan-default consequence — proposed: `status = defaulted` flagged by the
+  daily-cost pipeline; the downstream consequence (faction standing, contract
+  access) is deferred to a later change.
+- Whether declined contract offers reappear next market cycle — proposed: a
+  declined offer is hidden until the next `contractMarketProcessor` refresh,
+  which may legitimately re-offer it; confirm against the processor's dedup
+  behavior during implementation.

--- a/openspec/changes/add-campaign-command-ui/proposal.md
+++ b/openspec/changes/add-campaign-command-ui/proposal.md
@@ -1,0 +1,78 @@
+# Change: Add Campaign Command UI
+
+## Why
+
+The command-tier campaign systems — personnel hiring, finances, loans, and the
+contract market — all have working business logic. `personnel-management` and
+the `personnelMarketProcessor` handle hiring; `campaign-finances` provides the
+Money value object, transactions, and balance calculation; `contractMarketProcessor`
+and `mission-contracts` cover contract generation and negotiation. But the
+player has no command screens. `campaign-ui` covers the campaign list,
+dashboard, roster, forces, and missions pages — there is **no hiring screen, no
+finances screen, no contract-market screen**. The player can advance days and
+watch markets refresh in event logs but cannot act on any of it.
+
+This change adds the three command UI surfaces — **personnel & hiring**,
+**finances & loans**, and **contract market** — over the existing business
+logic. It is a UI change: it builds screens and exposes actions on existing
+engines; it does not add new campaign business logic.
+
+## What Changes
+
+- ADDED a Personnel & Hiring page: the current personnel-market candidate list
+  with per-candidate detail (skills, salary, traits) and a hire action that
+  routes through the existing personnel-hiring logic
+- ADDED a Finances & Loans page: the campaign balance, the transaction ledger
+  from `campaign-finances`, daily-cost projection, and a loan surface (take a
+  loan, view outstanding loans and repayment schedule)
+- ADDED a Contract Market page: the current contract-market offers with
+  per-contract detail (employer, pay, salvage rights, duration) and accept /
+  decline actions routing through the existing contract-acceptance logic
+- ADDED command navigation entries under the campaign navigation so the three
+  surfaces are reachable from the campaign dashboard
+- ADDED loading, empty, and error states for each surface consistent with the
+  existing `campaign-ui` patterns
+- ADDED a loan record type and a loan-ledger projection so outstanding loans and
+  repayment are visible (loan repayment itself is processed by the existing
+  daily-cost / finance pipeline)
+- ADDED Storybook stories for each command surface covering populated, empty,
+  and error states
+
+## Dependencies
+
+- **Requires**: `add-campaign-persistence` (CP0 — hire / accept-contract / take-loan
+  actions mutate the campaign through the persistence store), `campaign-ui` (the
+  page/navigation/state patterns this matches), `campaign-finances` (Money,
+  transactions, balance), `personnel-management` (hiring logic),
+  `mission-contracts` (contract model and acceptance)
+- **Required By**: none — terminal Wave 4 UI change alongside CP3
+
+## Impact
+
+- Affected specs: `campaign-command-ui` (new capability) — chosen over adding to
+  `campaign-ui` because the command surfaces are a cohesive management cluster
+  with their own navigation group; a dedicated capability keeps the three-surface
+  set coherent and parallels `campaign-bay-ui`
+- Affected code: `src/pages/campaigns/[id]/` (new command pages),
+  `src/components/campaign/command/` (new command components),
+  `src/stores/campaign/` (read selectors over personnel-market / finances /
+  contract-market state; hire / accept-contract / take-loan actions),
+  `src/types/campaign/` (new loan record type)
+- The loan record is the only new data — every other surface renders existing
+  campaign state; the loan type is small and the repayment is handled by the
+  existing daily-cost pipeline
+- Reversible: the command pages are additive routes; removing them leaves the
+  command logic functional but unsurfaced, as today
+
+## Non-Goals
+
+- The post-battle bay surfaces (mech / repair / medical / salvage) — those are
+  CP2a `add-campaign-bay-ui`
+- The refit / equipment-swap and prestige surfaces — those are CP3
+  `add-campaign-refit-and-prestige`
+- New hiring, finance, or contract business logic — the engines exist; this
+  change surfaces them and exposes their actions
+- Faction-standing and market-generation logic — already built; not re-specced
+- A full loan-amortisation engine — the loan record carries a simple repayment
+  schedule and the existing daily-cost pipeline applies repayments; no new
+  amortisation math

--- a/openspec/changes/add-campaign-command-ui/specs/campaign-command-ui/spec.md
+++ b/openspec/changes/add-campaign-command-ui/specs/campaign-command-ui/spec.md
@@ -1,0 +1,122 @@
+# campaign-command-ui Specification
+
+## ADDED Requirements
+
+### Requirement: Command Navigation Group
+
+The system SHALL provide a "Command" campaign-navigation group giving access to
+the Personnel & Hiring, Finances & Loans, and Contract Market surfaces from the
+campaign dashboard.
+
+#### Scenario: Command surfaces are reachable
+
+- **GIVEN** an open campaign
+- **WHEN** the campaign navigation renders
+- **THEN** a "Command" group SHALL be present
+- **AND** it SHALL link to the Personnel & Hiring, Finances & Loans, and Contract Market pages
+
+### Requirement: Personnel and Hiring Page
+
+The system SHALL provide a Personnel & Hiring page rendering the current
+personnel-market candidate pool with per-candidate detail and a hire action that
+routes through the existing personnel-management hiring logic.
+
+#### Scenario: Hiring page lists market candidates
+
+- **GIVEN** a campaign whose personnel market has candidates
+- **WHEN** the Personnel & Hiring page renders
+- **THEN** each candidate SHALL appear with skills, salary, and traits
+
+#### Scenario: Hiring a candidate routes through existing logic
+
+- **GIVEN** a candidate on the Personnel & Hiring page
+- **WHEN** the player hires the candidate
+- **THEN** the existing personnel-management hiring logic SHALL be invoked
+- **AND** the campaign SHALL be marked dirty so the persistence store auto-saves
+
+#### Scenario: Hiring page empty state
+
+- **GIVEN** a campaign whose personnel market is empty this cycle
+- **WHEN** the Personnel & Hiring page renders
+- **THEN** an empty state SHALL be shown rather than an error
+
+### Requirement: Finances and Loans Page
+
+The system SHALL provide a Finances & Loans page rendering the campaign balance,
+the transaction ledger, a daily-cost projection, and a loan surface.
+
+#### Scenario: Finances page shows balance and ledger
+
+- **GIVEN** a campaign with recorded transactions
+- **WHEN** the Finances & Loans page renders
+- **THEN** the current balance SHALL be shown
+- **AND** the transaction ledger from `campaign-finances` SHALL be listed
+- **AND** a daily-cost projection SHALL be shown
+
+#### Scenario: Taking a loan credits the balance and records the loan
+
+- **GIVEN** the loan surface with a principal, interest rate, and term entered
+- **WHEN** the player takes the loan
+- **THEN** the principal SHALL be credited to the balance via a `campaign-finances` transaction
+- **AND** an `ICampaignLoan` SHALL be appended with `dailyRepayment` fixed at creation time
+- **AND** the campaign SHALL be marked dirty so the persistence store auto-saves
+
+#### Scenario: Loan repayment flows through the daily-cost pipeline
+
+- **GIVEN** an active loan with a non-zero `dailyRepayment`
+- **WHEN** the player advances the day
+- **THEN** the loan's `dailyRepayment` SHALL be included in the daily cost debited by the existing daily-cost processor
+- **AND** the loan's `remainingBalance` SHALL decrease accordingly
+
+#### Scenario: Outstanding loans are listed with their schedule
+
+- **GIVEN** a campaign with one or more active loans
+- **WHEN** the Finances & Loans page renders
+- **THEN** each active loan SHALL appear with its remaining balance and repayment schedule
+
+### Requirement: Contract Market Page
+
+The system SHALL provide a Contract Market page rendering current contract-market
+offers with per-offer detail and accept / decline actions.
+
+#### Scenario: Contract Market lists offers
+
+- **GIVEN** a campaign whose contract market has offers
+- **WHEN** the Contract Market page renders
+- **THEN** each offer SHALL appear with employer, pay, salvage rights, and duration
+
+#### Scenario: Accepting a contract routes through existing logic
+
+- **GIVEN** an offer on the Contract Market page
+- **WHEN** the player accepts it
+- **THEN** the existing `mission-contracts` acceptance logic SHALL be invoked
+- **AND** the campaign SHALL be marked dirty so the persistence store auto-saves
+
+#### Scenario: Declining a contract hides the offer
+
+- **GIVEN** an offer on the Contract Market page
+- **WHEN** the player declines it
+- **THEN** the offer SHALL be hidden until the next contract-market refresh
+
+#### Scenario: Contract Market empty state
+
+- **GIVEN** a campaign whose contract market has no offers this cycle
+- **WHEN** the Contract Market page renders
+- **THEN** an empty state SHALL be shown rather than an error
+
+### Requirement: Command Surface Loading and Error States
+
+The system SHALL implement loading and error states on every command surface
+consistent with the existing `campaign-ui` conventions.
+
+#### Scenario: Loading state while command data resolves
+
+- **GIVEN** a campaign whose command data has not yet loaded
+- **WHEN** any command surface renders
+- **THEN** a loading state SHALL be shown
+
+#### Scenario: Error state on a stale action
+
+- **GIVEN** a hire or accept action on a market entry no longer present
+- **WHEN** the action is invoked
+- **THEN** the action SHALL fail gracefully with an error state rather than corrupting campaign state

--- a/openspec/changes/add-campaign-command-ui/tasks.md
+++ b/openspec/changes/add-campaign-command-ui/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: Add Campaign Command UI
+
+## 1. Command Navigation and Loan Type
+
+- [ ] 1.1 Add a "Command" campaign-navigation group with entries for Personnel & Hiring, Finances & Loans, and Contract Market
+- [ ] 1.2 Add the `ICampaignLoan` type to `src/types/campaign/` and an optional `loans` field on the campaign defaulting to an empty list
+- [ ] 1.3 Add typed campaign-store selectors over personnel-market, finances, contract-market, and loan state
+- [ ] 1.4 Tests: selectors return expected projections from a populated campaign and empty results from a fresh campaign
+
+## 2. Personnel & Hiring Page
+
+- [ ] 2.1 Build the Personnel & Hiring page — the current personnel-market candidate list with per-candidate skills, salary, and traits
+- [ ] 2.2 Implement the hire action as a thin call-through to the existing `personnel-management` hiring logic
+- [ ] 2.3 Implement loading, empty (no candidates), and error states matching `campaign-ui` conventions
+- [ ] 2.4 Storybook story with populated, empty, and error variants
+- [ ] 2.5 Tests: candidate list renders, hire invokes the existing hiring logic and marks the campaign dirty
+
+## 3. Finances & Loans Page
+
+- [ ] 3.1 Build the Finances & Loans page — campaign balance, the `campaign-finances` transaction ledger, and a daily-cost projection
+- [ ] 3.2 Build the loan surface — take a loan (principal, interest, term) and view outstanding loans with repayment schedule
+- [ ] 3.3 Implement take-loan — credits principal via a `campaign-finances` transaction, appends an `ICampaignLoan` with `dailyRepayment` fixed at creation time
+- [ ] 3.4 Sum active-loan `dailyRepayment` into the daily-cost figure consumed by the existing `dailyCostsProcessor`
+- [ ] 3.5 Implement loading, empty, and error states
+- [ ] 3.6 Storybook story with populated, empty, and error variants
+- [ ] 3.7 Tests: ledger renders, take-loan credits the balance and records the loan, daily cost includes loan repayment
+
+## 4. Contract Market Page
+
+- [ ] 4.1 Build the Contract Market page — current contract-market offers with per-offer employer, pay, salvage rights, and duration
+- [ ] 4.2 Implement accept as a thin call-through to the existing `mission-contracts` acceptance logic
+- [ ] 4.3 Implement decline — hides the offer until the next market refresh
+- [ ] 4.4 Implement loading, empty (no offers), and error states
+- [ ] 4.5 Storybook story with populated, empty, and error variants
+- [ ] 4.6 Tests: offer list renders, accept invokes the existing acceptance logic and marks the campaign dirty, decline hides the offer
+
+## 5. Verification
+
+- [ ] 5.1 Integration test: hiring a pilot, taking a loan, and accepting a contract each mark the campaign dirty and trigger an auto-save
+- [ ] 5.2 Integration test: a loan's daily repayment is debited by the daily-cost pipeline on day advancement until the loan is repaid
+- [ ] 5.3 `openspec validate add-campaign-command-ui --strict` clean
+- [ ] 5.4 Build, lint, typecheck, and storybook-build pass

--- a/openspec/changes/add-campaign-persistence/design.md
+++ b/openspec/changes/add-campaign-persistence/design.md
@@ -1,0 +1,148 @@
+# Design: Add Campaign Persistence
+
+## Context
+
+`auto-save-persistence` already establishes the pattern for durable server-side
+state: a `Server-Side Persistence Contract` requirement, a route under
+`/api/...`, a store backend keyed by id, and a save-metadata record. That
+contract is scoped to *game sessions* — the in-progress tactical match. A
+*campaign* is a different object: a long-lived mercenary-company record holding
+roster, forces, missions, finances, and options, mutated one day at a time by
+the day pipeline. It is persisted only to IndexedDB today.
+
+This change copies the `auto-save-persistence` server-store pattern for
+campaigns. The hard part is not the route — it is making the `ICampaign`
+JSON-safe (it carries `Map` fields and `Date` objects) and giving the snapshot a
+schema version so Wave 5 and later format changes have a migration seam.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A campaign survives a browser-storage wipe and opens on a second device.
+- The server holds an authoritative `SerializedCampaign` that Wave 5 co-op can
+  mirror.
+- Save is debounced and non-blocking; the player never waits on a network round
+  trip mid-campaign.
+- A stale write (two devices editing the same campaign) is detected, not
+  silently merged.
+
+**Non-Goals:**
+
+- Real-time multi-writer sync (Wave 5).
+- Ownership / sharing ACLs (Wave 5).
+- Portable file export.
+
+## Decisions
+
+### D1. New capability `campaign-persistence`, not an addition to `campaign-management`
+
+`campaign-management` owns campaign *creation and lifecycle*. Persistence is a
+separable concern with its own API surface, store, conflict model, and
+migration seam — and Wave 5 will extend persistence, not management. A dedicated
+capability keeps the Wave 5 delta clean (it ADDs to `campaign-persistence`).
+
+### D2. `SerializedCampaign` envelope
+
+The wire and storage format is an envelope around a JSON-safe campaign body:
+
+```typescript
+interface SerializedCampaign {
+  readonly schemaVersion: number;        // 1 for this change
+  readonly campaignId: string;
+  readonly savedAt: string;              // ISO 8601
+  readonly originDeviceId: string;       // which device wrote this
+  readonly version: number;              // monotonic write counter (D5)
+  readonly body: SerializedCampaignBody; // JSON-safe ICampaign
+}
+```
+
+`SerializedCampaignBody` is `ICampaign` with every `Map` field replaced by an
+array of `[key, value]` pairs and every `Date` replaced by an ISO string.
+`ICampaign` already carries `currentDate: Date` and `missions`, `personnel`,
+`forces` as `Map`s — the serializer walks a fixed field list, so adding a new
+`Map`/`Date` field to `ICampaign` requires a one-line serializer update (called
+out in tasks).
+
+### D3. Serialization is a pair of pure functions with a fixed field map
+
+`serializeCampaign(c: ICampaign): SerializedCampaignBody` and
+`deserializeCampaignBody(b: SerializedCampaignBody): ICampaign` are pure and
+total. They share one `CAMPAIGN_MAP_FIELDS` / `CAMPAIGN_DATE_FIELDS` constant so
+the two directions cannot drift. A round-trip test
+(`deserialize(serialize(c))` deep-equals `c`) is the contract.
+
+### D4. Schema version + migration ladder
+
+`schemaVersion` starts at `1`. `migrateSerializedCampaign(s)` runs on every read
+and applies an ordered ladder of `vN → vN+1` steps until the body matches the
+current version. This change ships only `v1` (identity migration), but the
+ladder exists from day one so Wave 5's format change is an added step, not a
+breaking read.
+
+### D5. Optimistic-concurrency stale-write guard
+
+The stored record carries a monotonic `version` integer. `PUT` includes
+`baseVersion` (the version the client last read). The route compares: if
+`baseVersion !== stored.version` it returns `409 Conflict` with the current
+record so the client can surface "this campaign was changed elsewhere". On a
+clean write the route stores `version = baseVersion + 1`. This catches the
+two-device race without a full merge engine — exactly the overdraft-class bug
+DP2 of the council decision warns about, contained at the persistence layer.
+
+### D6. Store responsibilities — `useCampaignPersistenceStore`
+
+The store owns: `loadCampaign(id)`, `saveCampaign()` (manual), debounced
+auto-save on dirty, `dirty` flag, `lastSaved` metadata, `saveState`
+(`idle | saving | saved | error | conflict`). It does **not** own campaign
+*content* — the live `ICampaign` stays in the existing campaign store; the
+persistence store reads from it on save and writes into it on load. Auto-save
+debounce is 2 s after the last mutation, matching `auto-save-persistence`'s
+batched-write cadence.
+
+### D7. List endpoint returns summaries, not bodies
+
+`GET /api/campaigns` returns `ICampaignSummary[]` — `{ id, name, factionId,
+currentDate, balance, updatedAt }`. The full body is fetched only by
+`GET /api/campaigns/[id]`. This keeps the campaign-list page cheap even with
+many saved campaigns.
+
+### D8. Server store backend reuse
+
+The route persists through the same storage backend `auto-save-persistence`
+uses for sessions (its `Server-Side Persistence Contract`), under a separate
+`campaigns:` keyspace. No new database engine, no migration of session storage.
+
+## Risks / Trade-offs
+
+- **[Risk] `ICampaign` gains a `Map`/`Date` field and the serializer misses it**
+  → Mitigation: the field map is a single exported constant; a type-level test
+  asserts every `Map`/`Date` field of `ICampaign` appears in it, failing the
+  build on drift.
+- **[Risk] Auto-save races a day-advancement mutation** → Mitigation: save reads
+  an immutable `ICampaign` snapshot at debounce-fire time; day advancement
+  produces a new campaign object, so the in-flight save serializes a consistent
+  prior state and the next mutation re-arms the debounce.
+- **[Risk] A `409 Conflict` leaves the player stuck** → Mitigation: the conflict
+  state exposes both versions; the player chooses keep-local (re-PUT with the
+  server's version as `baseVersion`) or take-server (reload). No silent merge.
+- **[Risk] Server unreachable offline** → Mitigation: IndexedDB remains the
+  offline source of truth; `saveState = error` is non-fatal and the next online
+  save retries. Offline play is unaffected.
+
+## Migration Plan
+
+Purely additive. Existing campaigns live only in IndexedDB; on first load with
+this change they are read locally as today, then serialized at `schemaVersion 1`
+and pushed to the server on the first save — a lazy one-time upload. No
+destructive migration. The new API routes and store are new files. Rollback =
+revert the change-set; campaigns fall back to IndexedDB-only with no data loss.
+
+## Open Questions
+
+- Whether to auto-save on *every* dirty transition or only on day-advancement
+  boundaries — proposed: debounced on every dirty transition (D6), revisit if
+  server write volume is high.
+- Device-id source — proposed: reuse the existing `player-identity` device/user
+  id rather than minting a new one. Confirmed if `player-identity` exposes a
+  stable id; otherwise mint a persisted UUID.

--- a/openspec/changes/add-campaign-persistence/proposal.md
+++ b/openspec/changes/add-campaign-persistence/proposal.md
@@ -1,0 +1,74 @@
+# Change: Add Campaign Persistence
+
+## Why
+
+Campaign state lives entirely client-side today. `campaign-management` declares
+"persist campaign state to IndexedDB and restore it on reload", and
+`auto-save-persistence` defines a `Server-Side Persistence Contract` for *game
+sessions* — but there is no equivalent for *campaigns*. A campaign cannot be
+opened on a second device, cannot be recovered if IndexedDB is cleared, and
+cannot be shared with a co-op partner. Wave 5 co-op (`add-shared-campaign-state`)
+needs an authoritative server-side campaign record to mirror; without it there
+is nothing for a guest to subscribe to.
+
+This change adds a server-side campaign save/load API and a persistence store so
+a campaign is durably stored, versioned, and reloadable independent of browser
+storage. It is the foundational Wave 4 change — every later campaign change
+(combat loop, bay UI, command UI, refit) reads and writes through this store.
+
+## What Changes
+
+- ADDED a server-side campaign persistence contract: `GET`/`PUT`/`DELETE`
+  `/api/campaigns/[id]` and `GET /api/campaigns` (list), persisting the full
+  `ICampaign` snapshot keyed by campaign id
+- ADDED a `campaignPersistenceStore` (client) that owns save/load lifecycle,
+  dirty tracking, debounced auto-save, and a manual save action
+- ADDED a `SerializedCampaign` envelope: schema version, save timestamp,
+  device id, and the serialized `ICampaign` body (Map fields → array-of-pairs
+  so the snapshot is JSON-safe)
+- ADDED a campaign save-metadata record (last-saved time, schema version,
+  origin device) surfaced to the dashboard
+- ADDED a load/restore path that rehydrates a `SerializedCampaign` back into a
+  live `ICampaign` and routes through schema-version migration on read
+- ADDED a campaign list endpoint returning lightweight summaries (id, name,
+  faction, currentDate, balance, updatedAt) without the full body
+- ADDED conflict detection on save: a stale-write guard rejects a `PUT` whose
+  `baseVersion` does not match the stored record's current version
+
+## Dependencies
+
+- **Requires**: `campaign-management` (`ICampaign` shape, `createCampaign`),
+  `auto-save-persistence` (the server-store pattern this mirrors),
+  `persistence-services` (the local persistence layer this layers onto)
+- **Required By**: `add-campaign-combat-loop` (CP1 — reads/writes the campaign
+  through this store), `add-campaign-command-ui` (CP2b), and Wave 5
+  `add-shared-campaign-state` (CO1 — the authoritative record it mirrors)
+
+## Impact
+
+- Affected specs: `campaign-persistence` (new capability) — chosen over adding
+  to `campaign-management` because persistence is a distinct concern (API
+  surface, store lifecycle, conflict handling) and Wave 5 will extend *this*
+  capability, not campaign management
+- Affected code: `src/pages/api/campaigns/` (new route handlers),
+  `src/stores/campaign/` (new `useCampaignPersistenceStore`),
+  `src/lib/campaign/persistence/` (new serialization + migration module),
+  `src/types/campaign/` (new `SerializedCampaign`, `ICampaignSummary`,
+  `ICampaignSaveMetadata`)
+- No new database engine — the server route persists to the same store backend
+  `auto-save-persistence` uses for game sessions; campaigns get their own
+  keyspace
+- Reversible: the local IndexedDB path remains the source of truth for offline
+  play; the server store is an additive durable mirror
+
+## Non-Goals
+
+- Real-time co-op campaign sync — that is Wave 5 `add-shared-campaign-state`;
+  this change provides only the static save/load record it will build on
+- Multi-user authorization / ownership ACLs — single-owner campaigns only;
+  ownership model is deferred to Wave 5
+- Campaign export to a portable file — file-level export/import is a separate
+  concern and out of scope
+- Migrating the existing IndexedDB campaign format — this change defines schema
+  version 1 going forward; older local campaigns are upgraded lazily on first
+  server save

--- a/openspec/changes/add-campaign-persistence/specs/campaign-persistence/spec.md
+++ b/openspec/changes/add-campaign-persistence/specs/campaign-persistence/spec.md
@@ -1,0 +1,185 @@
+# campaign-persistence Specification
+
+## ADDED Requirements
+
+### Requirement: Serialized Campaign Envelope
+
+The system SHALL define a `SerializedCampaign` envelope that wraps a JSON-safe
+campaign body with a schema version, campaign id, save timestamp, origin device
+id, and a monotonic write version. The envelope MUST be fully JSON-serializable.
+
+#### Scenario: Envelope carries required metadata
+
+- **GIVEN** a live `ICampaign` is prepared for saving
+- **WHEN** the persistence layer builds a `SerializedCampaign`
+- **THEN** the envelope SHALL include `schemaVersion`, `campaignId`, `savedAt`, `originDeviceId`, `version`, and `body`
+- **AND** the entire envelope SHALL pass `JSON.stringify` / `JSON.parse` without loss
+
+#### Scenario: Body is JSON-safe
+
+- **GIVEN** an `ICampaign` carrying `Map` fields and `Date` fields
+- **WHEN** it is serialized into a `SerializedCampaignBody`
+- **THEN** every `Map` field SHALL be represented as an array of `[key, value]` pairs
+- **AND** every `Date` field SHALL be represented as an ISO 8601 string
+
+### Requirement: Campaign Serialization Round-Trip
+
+The system SHALL provide pure, total `serializeCampaign` and
+`deserializeCampaignBody` functions that share a single field-map constant so
+the two directions cannot drift, and a round-trip MUST reproduce the original
+campaign.
+
+#### Scenario: Round-trip preserves the campaign
+
+- **GIVEN** a fully-populated `ICampaign` with non-empty `missions`, `personnel`, and `forces` maps
+- **WHEN** it is serialized and then deserialized
+- **THEN** the result SHALL deep-equal the original `ICampaign`
+- **AND** all `Map` fields SHALL be restored as `Map` instances
+- **AND** all `Date` fields SHALL be restored as `Date` instances
+
+#### Scenario: Field-map drift fails the build
+
+- **GIVEN** an `ICampaign` field of type `Map` or `Date`
+- **WHEN** that field is not listed in the shared field-map constant
+- **THEN** a type-level test SHALL fail the build
+
+### Requirement: Schema Version and Migration Ladder
+
+The system SHALL stamp every saved campaign with a schema version and SHALL run
+an ordered migration ladder on every read so a snapshot saved under an older
+version is upgraded to the current version before deserialization.
+
+#### Scenario: Current-version snapshot passes through
+
+- **GIVEN** a `SerializedCampaign` at the current schema version
+- **WHEN** `migrateSerializedCampaign` runs on read
+- **THEN** the snapshot SHALL be returned unchanged
+
+#### Scenario: Ladder is idempotent
+
+- **GIVEN** a snapshot already at the current schema version
+- **WHEN** the migration ladder runs twice
+- **THEN** both runs SHALL produce an identical snapshot
+
+### Requirement: Server-Side Campaign Persistence Contract
+
+The system SHALL persist campaigns server-side via `GET`, `PUT`, and `DELETE`
+on `/api/campaigns/[id]`, storing the `SerializedCampaign` keyed by campaign id
+through the shared server-store backend under a dedicated `campaigns:` keyspace.
+
+#### Scenario: Save a campaign
+
+- **GIVEN** a `SerializedCampaign` for campaign C
+- **WHEN** a client `PUT`s it to `/api/campaigns/C`
+- **THEN** the server SHALL store the record
+- **AND** the response SHALL carry the stored record with its incremented `version`
+
+#### Scenario: Load a saved campaign
+
+- **GIVEN** campaign C has been saved to the server
+- **WHEN** a client `GET`s `/api/campaigns/C`
+- **THEN** the server SHALL return the stored `SerializedCampaign`
+
+#### Scenario: Load a missing campaign
+
+- **GIVEN** no server record exists for campaign id `X`
+- **WHEN** a client `GET`s `/api/campaigns/X`
+- **THEN** the server SHALL respond `404`
+
+#### Scenario: Delete a server record
+
+- **GIVEN** campaign C has a server record
+- **WHEN** a client `DELETE`s `/api/campaigns/C`
+- **THEN** the server record SHALL be removed
+- **AND** the local IndexedDB copy SHALL be unaffected
+
+### Requirement: Stale-Write Conflict Detection
+
+The system SHALL detect a stale write by comparing the `baseVersion` of an
+incoming `PUT` against the stored record's current `version`, and MUST reject a
+mismatched write rather than silently overwriting.
+
+#### Scenario: Clean write increments the version
+
+- **GIVEN** a stored campaign record at `version` N
+- **WHEN** a `PUT` arrives with `baseVersion` equal to N
+- **THEN** the server SHALL store the record at `version` N+1
+
+#### Scenario: Stale write is rejected
+
+- **GIVEN** a stored campaign record at `version` N
+- **WHEN** a `PUT` arrives with `baseVersion` less than N
+- **THEN** the server SHALL respond `409 Conflict`
+- **AND** the response SHALL include the current stored record
+
+### Requirement: Campaign List Summaries
+
+The system SHALL provide `GET /api/campaigns` returning lightweight campaign
+summaries without the full campaign body.
+
+#### Scenario: List returns summaries only
+
+- **GIVEN** three campaigns are saved on the server
+- **WHEN** a client `GET`s `/api/campaigns`
+- **THEN** the response SHALL contain three `ICampaignSummary` entries
+- **AND** each entry SHALL carry `id`, `name`, `factionId`, `currentDate`, `balance`, and `updatedAt`
+- **AND** no entry SHALL include the full serialized body
+
+### Requirement: Campaign Persistence Store
+
+The system SHALL provide a `useCampaignPersistenceStore` that owns the save and
+load lifecycle, dirty tracking, debounced auto-save, and a save-state machine,
+while leaving live campaign content in the existing campaign store.
+
+#### Scenario: Auto-save fires after mutations settle
+
+- **GIVEN** a loaded campaign with `dirty` false
+- **WHEN** the campaign is mutated and no further mutation occurs for the debounce interval
+- **THEN** the store SHALL serialize an immutable campaign snapshot and `PUT` it to the server
+- **AND** `saveState` SHALL transition through `saving` to `saved`
+
+#### Scenario: Rapid mutations coalesce into one save
+
+- **GIVEN** a loaded campaign
+- **WHEN** several mutations occur within the debounce interval
+- **THEN** the store SHALL issue exactly one `PUT` after the last mutation
+
+#### Scenario: Load rehydrates the live campaign
+
+- **GIVEN** campaign C exists on the server
+- **WHEN** `loadCampaign("C")` is called
+- **THEN** the store SHALL fetch, migrate, and deserialize the record
+- **AND** the resulting `ICampaign` SHALL be written into the campaign store
+
+#### Scenario: Conflict surfaces both versions
+
+- **GIVEN** a save that receives a `409 Conflict`
+- **WHEN** the store handles the response
+- **THEN** `saveState` SHALL become `conflict`
+- **AND** both the local and server campaign versions SHALL be exposed for the player to choose between
+
+#### Scenario: Offline save failure is non-fatal
+
+- **GIVEN** the server is unreachable
+- **WHEN** an auto-save is attempted
+- **THEN** `saveState` SHALL become `error`
+- **AND** campaign play SHALL continue uninterrupted using the local IndexedDB copy
+
+### Requirement: Campaign Save Metadata
+
+The system SHALL expose campaign save metadata — last-saved time, schema
+version, and origin device — and surface it on the campaign dashboard with a
+manual save action.
+
+#### Scenario: Dashboard shows last-saved time
+
+- **GIVEN** a campaign that has been saved at least once
+- **WHEN** the campaign dashboard renders
+- **THEN** it SHALL display the last-saved timestamp
+
+#### Scenario: Manual save forces an immediate write
+
+- **GIVEN** a loaded campaign with pending changes
+- **WHEN** the player triggers the manual "Save now" action
+- **THEN** the store SHALL issue an immediate `PUT` without waiting for the debounce
+- **AND** the save metadata SHALL update on success

--- a/openspec/changes/add-campaign-persistence/tasks.md
+++ b/openspec/changes/add-campaign-persistence/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: Add Campaign Persistence
+
+## 1. Serialization Types and Functions
+
+- [ ] 1.1 Add `SerializedCampaign`, `SerializedCampaignBody`, `ICampaignSummary`, and `ICampaignSaveMetadata` to `src/types/campaign/`
+- [ ] 1.2 Add the `CAMPAIGN_MAP_FIELDS` and `CAMPAIGN_DATE_FIELDS` constants enumerating every `Map`/`Date` field of `ICampaign`
+- [ ] 1.3 Implement `serializeCampaign(c)` and `deserializeCampaignBody(b)` in `src/lib/campaign/persistence/` — pure, total, sharing the field-map constants
+- [ ] 1.4 Add a type-level test asserting every `Map`/`Date` field of `ICampaign` appears in the field-map constants
+- [ ] 1.5 Round-trip test: `deserializeCampaignBody(serializeCampaign(c))` deep-equals `c` for a fully-populated campaign
+
+## 2. Schema Version and Migration
+
+- [ ] 2.1 Define `CURRENT_CAMPAIGN_SCHEMA_VERSION = 1` and the `migrateSerializedCampaign(s)` migration-ladder function
+- [ ] 2.2 Ship the `v1` identity migration step and the ladder runner that applies steps until the body is current
+- [ ] 2.3 Tests: a `v1` snapshot passes through unchanged; the ladder is ordered and idempotent on an already-current snapshot
+
+## 3. Server-Side Campaign API Routes
+
+- [ ] 3.1 Implement `GET /api/campaigns/[id]` — returns the stored `SerializedCampaign`, `404` if absent
+- [ ] 3.2 Implement `PUT /api/campaigns/[id]` — validates `baseVersion`, stores `version = baseVersion + 1`, returns the new record
+- [ ] 3.3 Implement the `409 Conflict` path — `baseVersion` mismatch returns the current stored record
+- [ ] 3.4 Implement `DELETE /api/campaigns/[id]` — removes the server record (local IndexedDB unaffected)
+- [ ] 3.5 Implement `GET /api/campaigns` — returns `ICampaignSummary[]` without bodies
+- [ ] 3.6 Route the persistence through the `auto-save-persistence` server-store backend under a `campaigns:` keyspace
+- [ ] 3.7 Tests: each route's success and error paths, including the stale-write `409`
+
+## 4. Campaign Persistence Store
+
+- [ ] 4.1 Create `useCampaignPersistenceStore` with `loadCampaign(id)`, `saveCampaign()`, `dirty`, `lastSaved`, and `saveState`
+- [ ] 4.2 Implement debounced auto-save (2 s after last mutation) that serializes an immutable campaign snapshot
+- [ ] 4.3 Implement `loadCampaign` — fetch, migrate, deserialize, and write the live `ICampaign` into the campaign store
+- [ ] 4.4 Implement conflict handling — a `409` sets `saveState = conflict` and exposes both versions
+- [ ] 4.5 Wire `dirty` to campaign-store mutations so day advancement and edits re-arm the debounce
+- [ ] 4.6 Tests: dirty tracking, debounce coalescing, load-rehydrate, conflict surfacing, offline error is non-fatal
+
+## 5. Save Metadata Surface
+
+- [ ] 5.1 Expose `ICampaignSaveMetadata` (last-saved time, schema version, origin device) from the persistence store
+- [ ] 5.2 Render last-saved time and a manual "Save now" action on the campaign dashboard
+- [ ] 5.3 Tests: metadata updates after a save; manual save forces an immediate write
+
+## 6. Verification
+
+- [ ] 6.1 Integration test: create a campaign, save to server, clear local storage, reload from server, campaign is identical
+- [ ] 6.2 Integration test: two clients editing the same campaign — the second `PUT` gets a `409` and can recover via keep-local or take-server
+- [ ] 6.3 `openspec validate add-campaign-persistence --strict` clean
+- [ ] 6.4 Build, lint, and typecheck pass

--- a/openspec/changes/add-campaign-refit-and-prestige/design.md
+++ b/openspec/changes/add-campaign-refit-and-prestige/design.md
@@ -1,0 +1,179 @@
+# Design: Add Campaign Refit and Prestige
+
+## Context
+
+After CP0–CP2b, the campaign can be persisted, runs the combat loop, and exposes
+bay and command UIs. Two business systems are still missing. **Refit**: the
+construction tooling (`construction-services`, `construction-rules-core`) can
+build and validate units, but there is no path to apply a construction change to
+an *owned campaign unit* as a cost-and-time-bearing operation — the player
+cannot swap a weapon or upgrade a variant in-campaign. **Prestige and morale**:
+the campaign tracks faction standing and contract reputation but has no per-unit
+cohesion score and no company-morale model.
+
+Faction standing, markets, and negotiation are built and out of scope. This
+change adds exactly the refit pipeline and the prestige + morale state machine.
+The refit pipeline is modelled on the existing repair-ticket pipeline (hour
+budget consumed per day); the morale model is a small explicit state machine.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let the player refit an owned campaign unit — equipment swap, variant upgrade,
+  chassis conversion — as a cost-and-hours operation.
+- Validate every refit target against the existing construction rules.
+- Track a per-unit prestige score and a company-morale state machine.
+- Surface morale and prestige in a dedicated UI.
+
+**Non-Goals:**
+
+- Faction standing / markets / negotiation (built, out of scope).
+- A new construction engine; a loadout library; per-pilot loyalty;
+  prestige-gated unlocks.
+
+## Decisions
+
+### D1. New capability `campaign-refit-and-prestige`
+
+Refit and prestige/morale are two new business systems with no clean home in an
+existing campaign capability. Grouping them in one capability keeps Wave 4 at
+the five changes the council decomposition specified.
+
+### D2. `IRefitOrder` and refit classes
+
+A refit is described by an order:
+
+```typescript
+enum RefitClass {
+  EquipmentSwap = 'equipment-swap',   // swap items, same chassis/variant
+  VariantUpgrade = 'variant-upgrade', // change to a known variant of the chassis
+  ChassisConversion = 'chassis-conversion', // structural change (engine, structure)
+}
+
+interface IRefitOrder {
+  readonly id: string;
+  readonly unitId: string;                 // owned campaign unit
+  readonly targetConfiguration: unknown;   // the full target unit configuration
+  readonly refitClass: RefitClass;
+  readonly estimatedCost: number;          // C-bills
+  readonly estimatedHours: number;         // tech-hours
+  readonly hoursCompleted: number;
+  readonly status: 'proposed' | 'in-progress' | 'completed' | 'cancelled';
+  readonly createdAt: string;              // ISO 8601
+}
+```
+
+`refitClass` is assigned by `classifyRefit(currentConfig, targetConfig)` — it
+inspects the diff between the unit's current configuration and the target and
+returns the least-disruptive class that covers the change.
+
+### D3. Refit cost and hours mirror the repair model
+
+`estimateRefit(order)` computes cost and hours from the configuration diff and a
+per-`RefitClass` multiplier, mirroring `repairQueueBuilder`'s hour-table
+approach. An equipment swap is cheap and fast; a chassis conversion is expensive
+and slow. The estimate is fixed when the order is committed.
+
+### D4. Refit is validated against existing construction rules
+
+Before an `IRefitOrder` moves from `proposed` to `in-progress`, its
+`targetConfiguration` MUST pass the existing `construction-rules-core`
+validation — an invalid target unit cannot be refit toward. Refit does not
+reimplement construction; it gates on it.
+
+### D5. Refit day processor consumes hours per day
+
+`refitProcessor` (a day processor in the `UNITS` phase block) advances each
+`in-progress` refit by the day's available tech-hours, mirroring how repair
+tickets are worked. When `hoursCompleted >= estimatedHours` the refit completes:
+the unit's campaign configuration is replaced with `targetConfiguration` and a
+day event is emitted. A campaign with no active refits is a no-op.
+
+### D6. Refit launches from the mech bay
+
+The mech bay (CP2a) gains a per-unit "Refit" affordance. Selecting it opens a
+refit launch flow: choose a target configuration, see the classified refit class
+with estimated cost and hours, and commit — which creates a `proposed`
+`IRefitOrder` and, on construction-validation pass, moves it to `in-progress`.
+
+### D7. Unit prestige score
+
+`IUnitPrestige` is a per-unit `{ unitId, score, history }` record. `score` is a
+bounded integer adjusted by `adjustPrestige(unit, signal)` — victories and
+notable performance raise it, heavy damage and crew loss lower it. A
+prestige-update step runs when a battle outcome is applied (post-battle), so
+prestige tracks combat results deterministically.
+
+### D8. Company morale state machine
+
+Morale is an explicit state machine:
+
+```typescript
+enum MoraleState {
+  Mutinous = 'mutinous',
+  Unhappy = 'unhappy',
+  Steady = 'steady',
+  High = 'high',
+  Elite = 'elite',
+}
+```
+
+States are linearly ordered. `evaluateMoraleTransition(campaign, signals)`
+inspects morale-affecting signals — recent victories/defeats, whether pay was
+met, desertions from `personnel-progression` — and returns at most **one** step
+transition per day (up, down, or none). One step per day keeps morale from
+swinging wildly and makes the model legible.
+
+### D9. Morale day processor
+
+`moraleProcessor` (an `EVENTS`-phase day processor) gathers the day's signals,
+calls `evaluateMoraleTransition`, applies the at-most-one transition, and emits
+a day event when morale changes. Morale state persists on the campaign.
+
+### D10. Prestige & Morale UI surface
+
+A `Prestige & Morale` page (under the campaign navigation, near the bays) shows
+the current `MoraleState`, recent morale transitions, and the per-unit prestige
+scores. Read-only — morale and prestige change through processors, not the UI.
+
+## Risks / Trade-offs
+
+- **[Risk] Refit silently expands into construction-engine work** → Mitigation:
+  D4 — refit *gates on* the existing construction validation and never
+  reimplements it; the `targetConfiguration` is produced by existing
+  construction tooling.
+- **[Risk] A refit target configuration is invalid** → Mitigation: the
+  `proposed → in-progress` transition is blocked unless construction validation
+  passes; an invalid order stays `proposed` and surfaces the validation errors.
+- **[Risk] Morale oscillates day to day** → Mitigation: D8 — at most one step
+  transition per day; a single bad day cannot crater morale.
+- **[Risk] Prestige and morale signal sources are ambiguous** → Mitigation:
+  prestige updates only on battle-outcome application (D7); morale consumes a
+  fixed, enumerated signal set (D8). Both are deterministic functions of named
+  inputs.
+- **[Risk] Refit hours compete with repair hours for the same tech pool** →
+  Mitigation: this change scopes the refit processor to consume from the same
+  daily tech-hour budget as repairs; the budget-sharing policy (which gets hours
+  first) is an open question, defaulting to repairs-before-refits.
+
+## Migration Plan
+
+Purely additive. The refit pipeline, prestige scorer, and morale state machine
+are new modules; the refit and morale processors are new day processors. New
+campaign fields (`refitOrders`, `unitPrestige`, `moraleState`) are optional,
+absent on existing campaigns and defaulting (`[]`, `[]`, `MoraleState.Steady`).
+No destructive migration. Rollback = revert the change-set; the campaign loop
+keeps running without refit or morale.
+
+## Open Questions
+
+- Tech-hour budget sharing between repairs and refits — proposed: repairs
+  consume the daily tech-hour budget first, refits consume the remainder;
+  revisit if refits starve.
+- Default starting morale for a new campaign — proposed: `MoraleState.Steady`.
+- Prestige score bounds and the exact per-signal deltas — proposed: a bounded
+  0–100 integer with small per-signal deltas; tune during implementation.
+- Whether a chassis conversion should require the unit to be combat-ready —
+  proposed: no hard gate, but a destroyed unit cannot be refit; confirm against
+  the salvage write-off semantics during implementation.

--- a/openspec/changes/add-campaign-refit-and-prestige/proposal.md
+++ b/openspec/changes/add-campaign-refit-and-prestige/proposal.md
@@ -1,0 +1,81 @@
+# Change: Add Campaign Refit and Prestige
+
+## Why
+
+Two genuine campaign gaps remain after the persistence, combat-loop, and UI
+changes. First, **refit** — a campaign owns mechs but the player cannot swap
+equipment, upgrade a chassis variant, or convert a unit between configurations;
+the construction tooling builds units but nothing applies a construction change
+to an *owned campaign unit* as a time-and-cost-bearing refit. Second,
+**prestige and morale** — the campaign has faction standing and contract
+reputation, but no unit-cohesion prestige score and no company-morale state
+machine; a mercenary company's standing waxes and wanes with victories,
+desertions, and pay, and nothing models that.
+
+Faction standing, markets, and contract negotiation already exist and are **not
+re-specced here**. This change is deliberately narrow: it adds the refit /
+equipment-swap pipeline and the prestige + morale state machine — the two
+remaining campaign business systems.
+
+## What Changes
+
+- ADDED a refit pipeline: an `IRefitOrder` describing a target configuration for
+  an owned campaign unit, a refit-class classifier (the difficulty/kind of the
+  change), and a cost-and-hours estimator
+- ADDED refit classes graded by the scope of change (e.g. equipment swap,
+  variant upgrade, chassis conversion) each with a time-and-cost multiplier
+- ADDED a refit day processor: an in-progress refit consumes tech-hours per day
+  and completes when its hour budget is met, mirroring the repair-ticket model
+- ADDED a refit launch from the mech bay: the player selects an owned unit,
+  chooses a target configuration, sees the estimated cost and hours, and
+  commits the refit order
+- ADDED a unit prestige score: a per-unit cohesion/reputation value that rises
+  with victories and notable performance and falls with damage and crew loss
+- ADDED a company morale state machine with discrete morale states and defined
+  transitions driven by victories, defeats, pay, and desertions
+- ADDED a morale day processor: each day evaluates morale-affecting signals and
+  applies at most one state transition, emitting a day event on change
+- ADDED a Prestige & Morale UI surface showing the company morale state, recent
+  transitions, and per-unit prestige scores
+
+## Dependencies
+
+- **Requires**: `add-campaign-bay-ui` (CP2a — the refit launch links from the
+  mech bay), `add-campaign-persistence` (CP0 — refit orders and prestige/morale
+  state persist through the persistence store), `construction-services` /
+  `construction-rules-core` (the construction validation a target refit
+  configuration must pass), `personnel-progression` (the crew/desertion signals
+  morale consumes)
+- **Required By**: none — terminal Wave 4 change
+
+## Impact
+
+- Affected specs: `campaign-refit-and-prestige` (new capability) — chosen
+  because refit and prestige/morale are two new business systems that do not
+  fit any existing campaign capability cleanly; grouping them in one change
+  keeps Wave 4 at five changes as the council decomposition specified
+- Affected code: `src/lib/campaign/refit/` (new refit classifier, estimator,
+  pipeline), `src/lib/campaign/processors/` (new refit and morale day
+  processors), `src/lib/campaign/prestige/` (new prestige scorer and morale
+  state machine), `src/types/campaign/` (new `IRefitOrder`, refit-class enum,
+  `IUnitPrestige`, morale-state types), `src/pages/campaigns/[id]/` and
+  `src/components/campaign/` (refit launch + Prestige & Morale surface)
+- Refit reuses the existing construction validation — a target configuration
+  must be a valid unit per `construction-rules-core` before a refit order is
+  accepted
+- Reversible: the refit pipeline and prestige/morale processors are additive
+  day processors; removing them leaves the campaign loop intact without refit
+  or morale
+
+## Non-Goals
+
+- Faction standing, markets, and contract negotiation — already built and
+  explicitly out of scope per the council decomposition
+- A new construction engine — refit validates target configurations against the
+  existing construction rules; it does not reimplement construction
+- Persisting refit *templates* / saved loadouts as a library — refit operates on
+  a per-unit target configuration; a loadout library is a separate concern
+- Individual-pilot morale or loyalty — morale here is a company-level state
+  machine; per-pilot loyalty belongs to `turnover-retention` / `personnel-progression`
+- Prestige-gated content unlocks or rewards — prestige is a tracked score this
+  change surfaces; consuming it for unlocks is deferred

--- a/openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+++ b/openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
@@ -1,0 +1,194 @@
+# campaign-refit-and-prestige Specification
+
+## ADDED Requirements
+
+### Requirement: Refit Order Model
+
+The system SHALL define an `IRefitOrder` describing a target configuration for
+an owned campaign unit, carrying a refit class, cost and hour estimates,
+progress, and a status lifecycle.
+
+#### Scenario: A refit order carries the required fields
+
+- **GIVEN** the player commits a refit of an owned campaign unit
+- **WHEN** an `IRefitOrder` is created
+- **THEN** it SHALL carry `unitId`, `targetConfiguration`, `refitClass`, `estimatedCost`, `estimatedHours`, `hoursCompleted`, and `status`
+- **AND** its initial status SHALL be `proposed`
+
+### Requirement: Refit Classification
+
+The system SHALL classify a refit by diffing the unit's current configuration
+against the target and returning the least-disruptive refit class that covers
+the change.
+
+#### Scenario: An equipment swap classifies as equipment-swap
+
+- **GIVEN** a target configuration differing from the current only in mounted equipment
+- **WHEN** `classifyRefit` runs
+- **THEN** the refit class SHALL be `EquipmentSwap`
+
+#### Scenario: A structural change classifies as chassis-conversion
+
+- **GIVEN** a target configuration that changes the engine or internal structure
+- **WHEN** `classifyRefit` runs
+- **THEN** the refit class SHALL be `ChassisConversion`
+
+### Requirement: Refit Cost and Hours Estimation
+
+The system SHALL estimate a refit's C-bill cost and tech-hours from the
+configuration diff and a per-refit-class multiplier, fixing the estimate when
+the order is committed.
+
+#### Scenario: A heavier refit class costs more
+
+- **GIVEN** an equipment-swap order and a chassis-conversion order on comparable units
+- **WHEN** both are estimated
+- **THEN** the chassis-conversion estimate SHALL exceed the equipment-swap estimate in both cost and hours
+
+#### Scenario: Estimation is deterministic
+
+- **GIVEN** the same configuration diff
+- **WHEN** the refit is estimated twice
+- **THEN** both estimates SHALL be identical
+
+### Requirement: Refit Construction Validation Gate
+
+The system SHALL block a refit order from advancing to `in-progress` unless its
+target configuration passes the existing construction-rules validation.
+
+#### Scenario: A valid target advances the order
+
+- **GIVEN** a `proposed` refit order whose target configuration is a valid unit
+- **WHEN** the order is submitted to advance
+- **THEN** its status SHALL become `in-progress`
+
+#### Scenario: An invalid target blocks the order
+
+- **GIVEN** a `proposed` refit order whose target configuration fails construction validation
+- **WHEN** the order is submitted to advance
+- **THEN** its status SHALL remain `proposed`
+- **AND** the construction validation errors SHALL be surfaced
+
+### Requirement: Refit Day Processor
+
+The system SHALL provide a refit day processor that advances each in-progress
+refit by the day's available tech-hours and completes a refit when its hour
+budget is met.
+
+#### Scenario: A refit advances each day
+
+- **GIVEN** an `in-progress` refit order with `hoursCompleted` below `estimatedHours`
+- **WHEN** the player advances the day
+- **THEN** `hoursCompleted` SHALL increase by the day's available tech-hours
+
+#### Scenario: A refit completes and swaps the configuration
+
+- **GIVEN** an `in-progress` refit order whose `hoursCompleted` reaches `estimatedHours`
+- **WHEN** the day processor runs
+- **THEN** the order status SHALL become `completed`
+- **AND** the unit's campaign configuration SHALL be replaced with the `targetConfiguration`
+- **AND** a day event SHALL be emitted
+
+#### Scenario: No active refits is a no-op
+
+- **GIVEN** a campaign with no in-progress refit orders
+- **WHEN** the refit day processor runs
+- **THEN** the campaign SHALL be unchanged
+
+### Requirement: Refit Launch from the Mech Bay
+
+The system SHALL provide a refit launch flow reachable from the mech bay that
+classifies and estimates the refit and commits a refit order.
+
+#### Scenario: Launching a refit shows class and estimate
+
+- **GIVEN** an owned campaign unit in the mech bay
+- **WHEN** the player opens the refit launch flow and selects a target configuration
+- **THEN** the classified refit class SHALL be shown
+- **AND** the estimated cost and hours SHALL be shown
+
+#### Scenario: Committing a refit creates an order
+
+- **GIVEN** a refit launch flow with a target configuration selected
+- **WHEN** the player commits the refit
+- **THEN** a `proposed` `IRefitOrder` SHALL be created
+- **AND** on construction-validation pass the order SHALL advance to `in-progress`
+
+### Requirement: Unit Prestige Score
+
+The system SHALL track a per-unit prestige score that rises with victories and
+notable performance and falls with heavy damage and crew loss, updated when a
+battle outcome is applied.
+
+#### Scenario: A victory raises prestige
+
+- **GIVEN** a unit with a current prestige score
+- **WHEN** a battle outcome in which the unit's side won is applied
+- **THEN** the unit's prestige score SHALL increase
+
+#### Scenario: Heavy damage lowers prestige
+
+- **GIVEN** a unit with a current prestige score
+- **WHEN** a battle outcome in which the unit took heavy damage is applied
+- **THEN** the unit's prestige score SHALL decrease
+
+#### Scenario: Prestige stays within bounds
+
+- **GIVEN** a unit whose prestige is at its maximum or minimum
+- **WHEN** a prestige-raising or prestige-lowering signal is applied
+- **THEN** the score SHALL not exceed its bounds
+
+### Requirement: Company Morale State Machine
+
+The system SHALL model company morale as an ordered state machine that applies
+at most one step transition per day, driven by an enumerated set of
+morale-affecting signals.
+
+#### Scenario: Morale moves at most one step per day
+
+- **GIVEN** a campaign at a given morale state
+- **WHEN** the morale processor evaluates a day with multiple negative signals
+- **THEN** the morale state SHALL move by at most one step
+
+#### Scenario: Victories raise morale
+
+- **GIVEN** a campaign at a non-maximum morale state
+- **WHEN** the day's signals include recent victories and met pay
+- **THEN** the morale state SHALL move up by one step
+
+#### Scenario: Defeats and missed pay lower morale
+
+- **GIVEN** a campaign at a non-minimum morale state
+- **WHEN** the day's signals include recent defeats, missed pay, or desertions
+- **THEN** the morale state SHALL move down by one step
+
+#### Scenario: No signal yields no transition
+
+- **GIVEN** a campaign with no morale-affecting signals on a given day
+- **WHEN** the morale processor runs
+- **THEN** the morale state SHALL be unchanged
+
+#### Scenario: A morale change emits a day event
+
+- **GIVEN** a day on which the morale state transitions
+- **WHEN** the morale processor completes
+- **THEN** a day event describing the transition SHALL be emitted
+
+### Requirement: Prestige and Morale UI Surface
+
+The system SHALL provide a read-only Prestige & Morale page showing the current
+company morale state, recent morale transitions, and per-unit prestige scores.
+
+#### Scenario: The surface shows morale and prestige
+
+- **GIVEN** a campaign with a morale state, transition history, and units with prestige scores
+- **WHEN** the Prestige & Morale page renders
+- **THEN** the current morale state SHALL be shown
+- **AND** recent morale transitions SHALL be listed
+- **AND** each unit's prestige score SHALL be shown
+
+#### Scenario: The surface exposes no mutation controls
+
+- **GIVEN** the Prestige & Morale page is rendered
+- **WHEN** the player inspects the page
+- **THEN** no control SHALL allow editing morale or prestige directly

--- a/openspec/changes/add-campaign-refit-and-prestige/tasks.md
+++ b/openspec/changes/add-campaign-refit-and-prestige/tasks.md
@@ -1,0 +1,62 @@
+# Tasks: Add Campaign Refit and Prestige
+
+## 1. Refit Types and Classification
+
+- [ ] 1.1 Add `IRefitOrder`, the `RefitClass` enum, and an optional `refitOrders` campaign field defaulting to an empty list
+- [ ] 1.2 Implement `classifyRefit(currentConfig, targetConfig)` — diff the configurations and return the least-disruptive covering refit class
+- [ ] 1.3 Tests: equipment swap, variant upgrade, and chassis conversion each classify correctly; an identical target classifies as the cheapest class or none
+
+## 2. Refit Cost and Hours Estimation
+
+- [ ] 2.1 Implement `estimateRefit(order)` — cost and tech-hours from the configuration diff and a per-`RefitClass` multiplier, mirroring the repair hour-table approach
+- [ ] 2.2 Tests: an equipment swap estimates lower cost/hours than a chassis conversion; the estimate is deterministic for a given diff
+
+## 3. Refit Construction Validation Gate
+
+- [ ] 3.1 Gate the `proposed → in-progress` transition on the target configuration passing existing `construction-rules-core` validation
+- [ ] 3.2 An invalid target keeps the order `proposed` and surfaces the validation errors
+- [ ] 3.3 Tests: a valid target advances to `in-progress`; an invalid target stays `proposed` with errors
+
+## 4. Refit Day Processor
+
+- [ ] 4.1 Implement `refitProcessor` in the `UNITS` phase block — advance each `in-progress` refit by the day's available tech-hours
+- [ ] 4.2 On `hoursCompleted >= estimatedHours`, complete the refit — replace the unit's campaign configuration with `targetConfiguration` and emit a day event
+- [ ] 4.3 Register `refitProcessor` in `processorRegistration.ts`
+- [ ] 4.4 Tests: an in-progress refit advances per day, completes when the hour budget is met, swaps the configuration; a campaign with no refits is a no-op
+
+## 5. Refit Launch from the Mech Bay
+
+- [ ] 5.1 Add a per-unit "Refit" affordance to the mech bay (CP2a) opening a refit launch flow
+- [ ] 5.2 Build the launch flow — choose a target configuration, show the classified refit class with estimated cost and hours, commit
+- [ ] 5.3 Committing creates a `proposed` `IRefitOrder` and, on construction-validation pass, moves it to `in-progress`
+- [ ] 5.4 Tests: the launch flow classifies and estimates correctly; commit creates the order and gates on validation
+
+## 6. Unit Prestige
+
+- [ ] 6.1 Add `IUnitPrestige` and an optional `unitPrestige` campaign field defaulting to an empty list
+- [ ] 6.2 Implement `adjustPrestige(unit, signal)` — bounded score raised by victories/notable performance, lowered by heavy damage/crew loss
+- [ ] 6.3 Run a prestige-update step when a battle outcome is applied (post-battle)
+- [ ] 6.4 Tests: a victory raises prestige, heavy damage lowers it, the score stays within bounds, updates are deterministic
+
+## 7. Company Morale State Machine
+
+- [ ] 7.1 Add the `MoraleState` enum and an optional `moraleState` campaign field defaulting to `MoraleState.Steady`
+- [ ] 7.2 Implement `evaluateMoraleTransition(campaign, signals)` — at most one step transition per day from the enumerated signal set
+- [ ] 7.3 Implement `moraleProcessor` in the `EVENTS` phase block — gather signals, apply the transition, emit a day event on change
+- [ ] 7.4 Register `moraleProcessor` in `processorRegistration.ts`
+- [ ] 7.5 Tests: morale moves at most one step per day; victories raise it, defeats/missed pay/desertions lower it; no signal yields no transition
+
+## 8. Prestige & Morale UI Surface
+
+- [ ] 8.1 Build the Prestige & Morale page — current `MoraleState`, recent transitions, and per-unit prestige scores
+- [ ] 8.2 Add a campaign-navigation entry for the surface
+- [ ] 8.3 Implement loading, empty, and error states matching `campaign-ui` conventions
+- [ ] 8.4 Storybook story with populated, empty, and error variants
+- [ ] 8.5 Render tests: morale state, transition history, prestige scores; the page exposes no mutation controls
+
+## 9. Verification
+
+- [ ] 9.1 Integration test: launch a refit from the mech bay, advance days until it completes, the unit configuration is swapped
+- [ ] 9.2 Integration test: a sequence of victories and defeats moves the company morale state and updates per-unit prestige
+- [ ] 9.3 `openspec validate add-campaign-refit-and-prestige --strict` clean
+- [ ] 9.4 Build, lint, typecheck, and storybook-build pass

--- a/openspec/changes/add-combat-morale-and-withdrawal/design.md
+++ b/openspec/changes/add-combat-morale-and-withdrawal/design.md
@@ -1,0 +1,99 @@
+# Design: Add Combat Morale and Withdrawal
+
+## Context
+
+`add-bot-retreat-behavior` built a complete withdrawal mechanism — but it is reachable only through the bot's damage-based trigger. The withdrawal *machinery* (edge resolution via `RetreatAI.resolveEdge`, edge-ward movement scoring, `UnitRetreated` emission, the victory-check exclusion of `hasRetreated` units) is sound and reusable. This change does not fork that machinery; it adds two new *entry points* into it — a player action and a morale-driven forced trigger — and adds the in-battle morale state those triggers consult.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- An in-battle, per-side morale level that reacts to combat events deterministically.
+- A first-class withdrawal action a human player can take.
+- A Forced Withdrawal optional rule that applies uniformly to player and bot units.
+- Reuse the existing withdrawal machinery — no parallel retreat code path.
+
+**Non-Goals:**
+
+- Replacing campaign morale; per-unit morale; multiplayer surrender; team-coordinated AI withdrawal.
+
+## Decisions
+
+### D1. Morale is per-side, reusing the 7-level ordinal scale
+
+Morale is tracked as `battleMorale: Record<GameSide, MoraleLevel>` on the session. `MoraleLevel` reuses the existing 7-level ordinal scale from campaign morale (`ROUTED -3 … STEADY 0 … OVERWHELMING +3`) for vocabulary consistency, but the *state* is wholly separate — no shared store. Per-unit morale is deferred (KISS).
+
+### D2. Morale shifts are a deterministic function of the event log
+
+A pure function maps combat events to a morale delta for the affected side: an enemy unit destroyed is positive; an own unit destroyed is negative; an own vital-component critical is a small negative; loss of the side's heaviest unit is a larger negative. Because the shift is derived from the event log, replaying the log reconstructs morale exactly.
+
+### D3. In-battle morale is separate state from campaign morale
+
+This change writes nothing to `src/lib/campaign/scenario/morale.ts`. Battle-end morale MAY be exported for Wave 4 to feed campaign morale, but that wiring is explicitly out of scope here. Keeping the two systems separate avoids coupling a battle-runtime concern to campaign persistence.
+
+### D4. Player withdrawal is a declared action routed through existing machinery
+
+A new `WithdrawalDeclared` action flags a unit `isWithdrawing` and records a player-chosen target edge. From that point the unit is routed through the same edge-ward movement and `UnitRetreated` exit the bot uses. Bots continue to resolve the edge via `RetreatAI.resolveEdge`; players pick it explicitly.
+
+### D5. Forced Withdrawal is a scenario config flag
+
+`forcedWithdrawal: boolean` on the scenario config. When enabled, an end-of-phase check withdraws any unit whose side morale is `BROKEN` or worse, or that is crippled (a vital-component critical, or more than 50% internal-structure loss). For bots this composes with the existing `RetreatAI` damage triggers — it does not replace them. For players it surfaces a forced-withdrawal notice and auto-flags the unit `isWithdrawing`. When the flag is off, nothing is forced and units fight to destruction as today.
+
+### D6. Reuse, do not fork
+
+`UnitRetreated`, `RetreatAI.resolveEdge`, `RetreatAI.hasReachedEdge`, and the victory-check exclusion of `hasRetreated` units are all reused unchanged. This change generalizes the *entry points*, not the withdrawal mechanics. A withdrawing player unit and a retreating bot unit converge on the same exit path.
+
+### D7. Failed withdrawal uses the existing first-event-wins discriminator
+
+If `UnitDestroyed` fires for a unit before its `UnitRetreated`, it is a combat loss; if `UnitRetreated` fires first, it is a withdrawal. This is the discriminator already established by `add-bot-retreat-behavior` and is reused without change.
+
+### D8. Type contracts
+
+```typescript
+type MoraleLevel =
+  | 'ROUTED' | 'BROKEN' | 'SHAKEN' | 'STEADY'
+  | 'CONFIDENT' | 'INSPIRED' | 'OVERWHELMING';
+
+interface ISessionMoraleState {
+  readonly battleMorale: Record<GameSide, MoraleLevel>;
+}
+
+GameEventType.MoraleShifted             = 'MoraleShifted';
+GameEventType.WithdrawalDeclared        = 'WithdrawalDeclared';
+GameEventType.ForcedWithdrawalTriggered = 'ForcedWithdrawalTriggered';
+
+interface IMoraleShiftedPayload {
+  readonly side: GameSide;
+  readonly from: MoraleLevel;
+  readonly to: MoraleLevel;
+  readonly cause: string;
+  readonly turn: number;
+}
+interface IWithdrawalDeclaredPayload {
+  readonly unitId: string;
+  readonly edge: 'north' | 'south' | 'east' | 'west';
+  readonly declaredBy: 'player' | 'forced';
+  readonly turn: number;
+}
+interface IForcedWithdrawalTriggeredPayload {
+  readonly unitId: string;
+  readonly reason: 'morale-broken' | 'crippled';
+  readonly turn: number;
+}
+```
+
+## Risks / Trade-offs
+
+- **[Risk] Morale shift double-counts an event already processed by the bot retreat trigger** → Mitigation: morale and the bot damage trigger are independent inputs to the same withdrawal entry point; `isWithdrawing` / `isRetreating` are sticky, so a unit cannot be withdrawn twice.
+- **[Risk] Forced Withdrawal empties the board and ends a match abruptly** → Mitigation: the victory check already treats withdrawn units as removed; an abrupt end is the correct BattleTech Forced Withdrawal outcome. The rule is opt-in per scenario.
+- **[Risk] Player declares withdrawal toward a blocked edge** → Mitigation: edge-ward movement reuses the bot's path candidate generation, which routes around blockers; an immobilized withdrawing unit stays in place without error, exactly as the bot case.
+- **[Risk] In-battle morale confused with campaign morale by future contributors** → Mitigation: distinct state, distinct events, distinct spec capability; the design records the separation explicitly (D3).
+
+## Migration Plan
+
+Additive. `battleMorale` defaults every side to `STEADY`; `forcedWithdrawal` defaults to `false`, preserving current fight-to-destruction behavior. New event types are additive — existing consumers ignore unknown events. No database migrations. Rollback = revert the change-set; bot retreat continues to work because it was never modified.
+
+## Open Questions
+
+- Exact morale-delta magnitudes per event — proposed starting values: enemy unit destroyed `+1`, own unit destroyed `-1`, own vital crit `-1` (capped once per unit), heaviest own unit lost `-2`. Tunable after playtest.
+- Whether Forced Withdrawal should be on by default for generated scenarios — proposed `false`; revisit once playtested.

--- a/openspec/changes/add-combat-morale-and-withdrawal/proposal.md
+++ b/openspec/changes/add-combat-morale-and-withdrawal/proposal.md
@@ -1,0 +1,40 @@
+# Change: Add Combat Morale and Withdrawal
+
+## Why
+
+Bot units already retreat when crippled — `add-bot-retreat-behavior` (archived) shipped `RetreatTriggered` / `UnitRetreated`, edge resolution, and the withdrawal movement model. Two gaps remain for full tabletop play.
+
+First, there is no in-battle morale. Morale exists only as campaign-layer post-scenario state (`src/lib/campaign/scenario/morale.ts`, `combat-resolution` → `Contract Morale Tracking`) and never responds to events during a battle.
+
+Second, withdrawal is bot-only. `add-bot-retreat-behavior` listed player-driven retreat as an explicit non-goal, so a human player cannot formally withdraw a unit — they can only decline to move it — and there is no unit-agnostic Forced Withdrawal rule.
+
+This change adds an in-battle morale state machine and a player-and-bot withdrawal action, so any unit can disengage and exit the map.
+
+## What Changes
+
+- ADDED in-battle morale: a per-side morale level that shifts in response to combat events within the current battle (unit destroyed, vital-component critical, commander lost), distinct from campaign morale
+- ADDED player withdrawal declaration: a human player can mark a unit as withdrawing; it then moves toward a chosen map edge and exits via the existing `UnitRetreated` event
+- ADDED the Forced Withdrawal rule: when enabled on a scenario, a unit whose side morale breaks — or that is crippled — is compelled to withdraw, applied uniformly to player and bot units
+- ADDED withdrawal eligibility and map-edge exit for player units, generalizing the previously bot-only edge logic
+- ADDED failed-withdrawal handling: a withdrawing unit destroyed before reaching the edge counts as a combat loss, not a withdrawal
+
+## Dependencies
+
+- **Requires**: `add-bot-retreat-behavior` (archived) — reuses `UnitRetreated`, edge resolution, and the withdrawal movement model
+- **Requires**: `combat-resolution` — in-battle morale reads combat events; campaign `Contract Morale Tracking` is untouched and stays a separate system
+- **Required By**: Wave 2 AI changes (morale-aware AI); Wave 4 campaign loop (battle-end morale may feed campaign morale)
+
+## Impact
+
+- Affected specs: `combat-morale-and-withdrawal` (new capability)
+- Affected code: `src/utils/gameplay/` (morale state and reducer), `src/engine/GameEngine.phases.ts` and `src/engine/InteractiveSession.ts` (withdrawal action and forced-withdrawal check), `src/simulation/ai/RetreatAI.ts` (morale as an additional trigger), `src/types/gameplay/GameSessionCoreTypes.ts` (morale state and events), gameplay UI (withdraw control, morale indicator)
+- New event types: `MoraleShifted`, `WithdrawalDeclared`, `ForcedWithdrawalTriggered`
+- No database migrations
+
+## Non-Goals
+
+- Replacing campaign-layer morale — `Contract Morale Tracking` remains the post-scenario system; this change is in-battle only
+- Per-unit morale — morale is tracked per side here; per-unit morale is deferred
+- Surrender / concede negotiation in multiplayer — Wave 3 scope
+- Coordinated team-wide withdrawal AI — Wave 2 AI scope
+- Re-entry after a unit exits the map

--- a/openspec/changes/add-combat-morale-and-withdrawal/specs/combat-morale-and-withdrawal/spec.md
+++ b/openspec/changes/add-combat-morale-and-withdrawal/specs/combat-morale-and-withdrawal/spec.md
@@ -1,0 +1,133 @@
+## ADDED Requirements
+
+### Requirement: In-Battle Morale State
+
+The game session SHALL carry an in-battle morale state, `battleMorale: Record<GameSide, MoraleLevel>`, where `MoraleLevel` is the seven-level ordinal scale `ROUTED`, `BROKEN`, `SHAKEN`, `STEADY`, `CONFIDENT`, `INSPIRED`, `OVERWHELMING`. Every side SHALL start at `STEADY`. This state SHALL be independent of campaign-layer morale (`Contract Morale Tracking`) and SHALL NOT read or write campaign morale storage.
+
+#### Scenario: Battle morale starts steady
+
+- **GIVEN** a newly created game session with two sides
+- **WHEN** the session is initialized
+- **THEN** `battleMorale` SHALL record `STEADY` for both sides
+
+#### Scenario: Battle morale is independent of campaign morale
+
+- **GIVEN** a battle in which one side's `battleMorale` has shifted to `SHAKEN`
+- **WHEN** the campaign morale store is inspected
+- **THEN** campaign morale SHALL be unchanged by the battle
+
+### Requirement: Morale Shift Rules
+
+The system SHALL shift a side's `battleMorale` in response to combat events via a deterministic, pure function of the event log: an enemy unit destroyed SHALL shift the observing side upward; an own unit destroyed SHALL shift the side downward; an own vital-component critical SHALL shift the side downward; loss of the side's heaviest unit SHALL shift it further downward. Morale SHALL clamp at `ROUTED` and `OVERWHELMING`. Each shift SHALL emit a `MoraleShifted` event recording `side`, `from`, `to`, `cause`, and `turn`.
+
+#### Scenario: Losing a unit lowers morale
+
+- **GIVEN** a side at `STEADY` morale
+- **WHEN** one of that side's units is destroyed
+- **THEN** the side's `battleMorale` SHALL shift downward by one level
+- **AND** a `MoraleShifted` event SHALL be appended recording the change
+
+#### Scenario: Destroying an enemy raises morale
+
+- **GIVEN** a side at `STEADY` morale
+- **WHEN** an enemy unit is destroyed
+- **THEN** the side's `battleMorale` SHALL shift upward by one level
+
+#### Scenario: Morale clamps at the extremes
+
+- **GIVEN** a side already at `ROUTED` morale
+- **WHEN** another of that side's units is destroyed
+- **THEN** the side's `battleMorale` SHALL remain `ROUTED`
+
+#### Scenario: Morale replays from the event log
+
+- **GIVEN** a completed battle whose event log contains `MoraleShifted` events
+- **WHEN** the session is rebuilt by replaying the event log
+- **THEN** each side's final `battleMorale` SHALL match the value from the original battle
+
+### Requirement: Player Withdrawal Declaration
+
+A human player SHALL be able to declare withdrawal for a unit they own. Declaring withdrawal SHALL emit a `WithdrawalDeclared` event with the chosen target edge and `declaredBy: 'player'`, and SHALL set the unit's `isWithdrawing` flag. A withdrawing unit SHALL be routed toward its target edge and SHALL exit the map via the existing `UnitRetreated` event when it reaches an edge hex. The `isWithdrawing` flag SHALL be sticky for the rest of the match.
+
+#### Scenario: Player withdraws a unit off the chosen edge
+
+- **GIVEN** a player unit two hexes from the north edge with enough movement to reach it
+- **WHEN** the player declares withdrawal toward the north edge
+- **THEN** a `WithdrawalDeclared` event SHALL be emitted with `edge: 'north'` and `declaredBy: 'player'`
+- **AND** when the unit reaches the north edge a `UnitRetreated` event SHALL be emitted
+- **AND** the unit SHALL be excluded from its side's count in the victory check
+
+#### Scenario: Withdrawal declaration is sticky
+
+- **GIVEN** a player unit that has declared withdrawal
+- **WHEN** a later phase is processed
+- **THEN** the unit SHALL remain `isWithdrawing`
+- **AND** the player SHALL NOT be able to cancel the withdrawal
+
+#### Scenario: Immobilized withdrawing unit stays in place
+
+- **GIVEN** a withdrawing player unit with zero movement available
+- **WHEN** the movement phase resolves
+- **THEN** the unit SHALL remain in place without error
+- **AND** no `UnitRetreated` event SHALL be emitted
+
+### Requirement: Forced Withdrawal Rule
+
+The scenario config SHALL carry a `forcedWithdrawal` boolean, defaulting to `false`. When enabled, an end-of-phase check SHALL withdraw any unit — player or bot — whose side `battleMorale` is `BROKEN` or worse, or that is crippled (a vital-component critical, or more than 50% internal-structure loss). A forced withdrawal SHALL emit a `ForcedWithdrawalTriggered` event recording the `reason`, and SHALL flag the unit `isWithdrawing`. When `forcedWithdrawal` is `false`, no unit SHALL be withdrawn automatically.
+
+#### Scenario: Broken morale forces withdrawal
+
+- **GIVEN** a scenario with `forcedWithdrawal` enabled and a side whose `battleMorale` has fallen to `BROKEN`
+- **WHEN** the end-of-phase check runs
+- **THEN** each non-withdrawing unit of that side SHALL be flagged `isWithdrawing`
+- **AND** a `ForcedWithdrawalTriggered` event with `reason: 'morale-broken'` SHALL be emitted for each
+
+#### Scenario: Crippled unit is forced to withdraw
+
+- **GIVEN** a scenario with `forcedWithdrawal` enabled and a unit that has taken a through-armor critical to its engine
+- **WHEN** the end-of-phase check runs
+- **THEN** that unit SHALL be flagged `isWithdrawing`
+- **AND** a `ForcedWithdrawalTriggered` event with `reason: 'crippled'` SHALL be emitted
+
+#### Scenario: Rule disabled leaves units fighting
+
+- **GIVEN** a scenario with `forcedWithdrawal` disabled and a side at `ROUTED` morale
+- **WHEN** the end-of-phase check runs
+- **THEN** no unit SHALL be flagged `isWithdrawing`
+- **AND** no `ForcedWithdrawalTriggered` event SHALL be emitted
+
+#### Scenario: A unit is never withdrawn twice
+
+- **GIVEN** a bot unit already `isRetreating` from a damage trigger in a `forcedWithdrawal` scenario
+- **WHEN** the forced-withdrawal check also finds it eligible
+- **THEN** the unit SHALL NOT be re-triggered
+- **AND** no duplicate `ForcedWithdrawalTriggered` event SHALL be emitted
+
+### Requirement: Withdrawal Map-Edge Exit
+
+A withdrawing unit — whether flagged by player declaration or forced withdrawal — SHALL move toward its target edge and SHALL exit the map by emitting `UnitRetreated` when it reaches an edge hex, reusing the existing edge-resolution and edge-detection machinery. A withdrawn unit SHALL be excluded from its side's victory-check count and SHALL be distinguished from a combat loss in the post-battle summary.
+
+#### Scenario: Withdrawn unit excluded from the victory check
+
+- **GIVEN** a side of two units, one of which has emitted `UnitRetreated`
+- **WHEN** the victory check runs
+- **THEN** only the remaining unit SHALL count toward that side's total
+- **AND** if that remaining unit is also destroyed the opposing side SHALL be declared the winner
+
+#### Scenario: Post-battle summary distinguishes withdrawal from destruction
+
+- **GIVEN** a completed battle with one unit destroyed in combat and one unit withdrawn
+- **WHEN** the post-battle summary is generated
+- **THEN** the destroyed unit SHALL be listed as a combat loss
+- **AND** the withdrawn unit SHALL be listed as withdrawn
+
+### Requirement: Failed Withdrawal Handling
+
+When a withdrawing unit is destroyed before it reaches an edge hex, it SHALL be counted as a combat loss, not a withdrawal. The discriminator SHALL be event order: if `UnitDestroyed` is emitted for the unit before any `UnitRetreated`, the unit is a combat loss.
+
+#### Scenario: Withdrawing unit destroyed en route is a combat loss
+
+- **GIVEN** a withdrawing unit that has not yet reached its target edge
+- **WHEN** the unit is destroyed by enemy fire
+- **THEN** a `UnitDestroyed` event SHALL be emitted and no `UnitRetreated` event SHALL follow for that unit
+- **AND** the post-battle summary SHALL list the unit as a combat loss

--- a/openspec/changes/add-combat-morale-and-withdrawal/tasks.md
+++ b/openspec/changes/add-combat-morale-and-withdrawal/tasks.md
@@ -1,0 +1,41 @@
+# Tasks: Add Combat Morale and Withdrawal
+
+## 1. In-Battle Morale State
+
+- [ ] 1.1 Add `MoraleLevel`, `ISessionMoraleState`, and `battleMorale: Record<GameSide, MoraleLevel>` to the session state in `src/types/gameplay/GameSessionCoreTypes.ts`, defaulting every side to `STEADY`
+- [ ] 1.2 Implement the morale-shift function — a pure mapping from a combat event to a per-side morale delta
+- [ ] 1.3 Add the `MoraleShifted` event type, payload, and reducer
+- [ ] 1.4 Tests: each combat event shifts morale correctly; morale clamps at `ROUTED` / `OVERWHELMING`; replaying the event log reconstructs morale exactly
+
+## 2. Player Withdrawal Action
+
+- [ ] 2.1 Add `WithdrawalDeclared` event/intent, its payload, and an `isWithdrawing` unit flag
+- [ ] 2.2 Wire a withdraw action into `InteractiveSession` / `GameEngine.phases` allowing a player to declare withdrawal for an owned unit and choose the target edge
+- [ ] 2.3 Route withdrawing player units through the existing edge-ward movement and `UnitRetreated` exit (reuse `RetreatAI.hasReachedEdge`)
+- [ ] 2.4 Tests: a declared unit moves toward its edge and emits `UnitRetreated`; the victory check excludes it; an immobilized withdrawing unit stays in place without error
+
+## 3. Forced Withdrawal Rule
+
+- [ ] 3.1 Add the `forcedWithdrawal` boolean to the scenario config, defaulting to `false`
+- [ ] 3.2 Implement the end-of-phase check: when enabled, withdraw any unit whose side morale is `BROKEN` or worse, or that is crippled
+- [ ] 3.3 Add the `ForcedWithdrawalTriggered` event type and payload
+- [ ] 3.4 Bot path: the morale/crippled trigger composes with the existing `RetreatAI` damage triggers without double-withdrawing a unit
+- [ ] 3.5 Tests: broken side morale forces withdrawal of eligible units; with the rule off, units fight to destruction; a unit is never withdrawn twice
+
+## 4. Withdrawal UI
+
+- [ ] 4.1 Add a withdraw control with an edge picker to the unit action panel
+- [ ] 4.2 Show a forced-withdrawal notice when the rule auto-withdraws a player unit
+- [ ] 4.3 Add a per-side morale indicator to the gameplay HUD
+- [ ] 4.4 Storybook stories plus render tests for the withdraw control and morale indicator
+
+## 5. Failed Withdrawal
+
+- [ ] 5.1 Apply the first-event-wins discriminator — `UnitDestroyed` before `UnitRetreated` is a combat loss
+- [ ] 5.2 Tests: a withdrawing unit destroyed before reaching the edge counts as a combat loss, not a withdrawal
+
+## 6. Verification
+
+- [ ] 6.1 Integration test: a side loses two units, morale breaks, and the Forced Withdrawal rule withdraws a third
+- [ ] 6.2 Integration test: a player declares withdrawal, the unit exits the map, and the game-over check resolves correctly
+- [ ] 6.3 `openspec validate --strict` clean; build, lint, and typecheck pass

--- a/openspec/changes/add-coop-campaign-play/design.md
+++ b/openspec/changes/add-coop-campaign-play/design.md
@@ -1,0 +1,118 @@
+# Design: Add Co-op Campaign Play
+
+## Context
+
+`add-shared-campaign-state` (CO1) established the co-op campaign substrate: a server-authoritative campaign event log, a `CampaignMatchHost` running the `intent → validate → commit → broadcast` loop, and a read-only guest campaign mirror. CO1 proved the *transport* is correct — a guest's campaign action is an intent the host validates against the authoritative ledger.
+
+What CO1 deliberately did not build is the *game*:
+
+- A co-op campaign mission still launches one force into one encounter. There is no path to put both players' forces into a single battle, and no notion of a player who wants to skip the map this mission and manage the campaign instead.
+- CO1 said "the host validates campaign intents". It did not say *who the host is in gameplay terms* (the Game Master), nor *how* arbitration works beyond the mechanical balance check — there is no host-review step, no veto, no guest-facing pending-proposal feedback.
+
+This change supplies both. It is the merge of the roadmap's CO2 (co-op mission launch) and CO3 (campaign authority model) — merged because the authority model is meaningless without co-op gameplay to authorize, and co-op gameplay is unsafe without an authority model.
+
+Combat itself does not need re-architecting: `ServerMatchHost` already runs an authoritative `GameSession` for any number of seats across sides. Co-op mission launch is *composition* (build one encounter from two rosters) plus *routing* (send it through the existing combat host), not new netcode.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Launch a campaign mission as one encounter containing both players' forces, on a shared side against the encounter OpFor.
+- Let each player choose, per mission, to deploy onto the map or remain in command HQ.
+- Define the host as the campaign Game Master and guest campaign actions as proposals the host arbitrates.
+- Provide GM arbitration modes (auto-approve, host-review) and a typed veto.
+- Give the guest pending-proposal feedback and the host a review surface.
+- Reconcile the co-op encounter's outcome back into the shared campaign as CO1 campaign events.
+
+**Non-Goals:**
+
+- The CO1-owned transport (event log, `CampaignMatchHost` loop, mirror).
+- 3+ player campaigns, host migration, PvP campaign play, co-op spectators, co-op AI directing.
+
+## Decisions
+
+### D1. Co-op mission launch composes two rosters into one encounter
+
+A co-op campaign mission launch builds one `IEncounter` whose force roster is the union of both players' selected forces, all assigned to the same `GameSide` against the encounter's OpFor side. The resulting `GameSession` is run by the existing `ServerMatchHost` — co-op combat is *not* a new combat path. Each deploying player occupies seats for their own units; the host validates unit ownership exactly as `ServerMatchHost` already does (an intent for a unit the player does not own is rejected). The campaign mission→encounter bridge from `add-campaign-combat-loop` (CP1) is extended to accept a two-force composition rather than rebuilt.
+
+### D2. Per-mission participation choice — `deploy` vs `command-hq`
+
+Before a co-op mission launches, each player makes a `CoopParticipationChoice`:
+
+- **`deploy`** — the player's force enters the encounter and the player plays it on the tactical map through `ServerMatchHost`.
+- **`command-hq`** — the player does not take the map. Their force either sits the mission out or is fielded under host/AI control (the host's choice), and the player retains full access to campaign-management surfaces (bay, contracts, finances) while the battle runs.
+
+At least one player MUST choose `deploy` — a mission with both players in HQ has no one to fight it and SHALL be blocked at launch. A `command-hq` player still receives the co-op campaign events the battle produces (salvage, funds) through their CO1 mirror, so their campaign view stays current.
+
+### D3. The host is the campaign Game Master
+
+The host of a shared campaign (the CO1 single-writer) is, in gameplay terms, the **Game Master**. This is a naming and authority decision, not a new role: it is the same peer that CO1 already designated the authoritative campaign writer. Making it explicit lets the UX and the arbitration rules speak of "the GM" coherently. The guest is a co-op *player*, not a co-GM; the guest never holds campaign-write authority.
+
+### D4. Guest campaign actions are proposals, not commits
+
+Under CO1, a guest campaign action is an `ICampaignIntent` the host validates. This change refines what that means at the gameplay layer: a guest action is a **proposal** (`IGuestProposal`) — a request the GM arbitrates. A proposal carries the underlying `ICampaignIntent` plus proposal metadata (`proposalId`, the requesting guest, a timestamp). The host resolves each proposal to a `GmDecision` and only an `approve` decision proceeds to CO1's commit-and-broadcast. A `veto` returns a typed rejection and commits nothing.
+
+### D5. GM arbitration modes — `auto-approve` and `host-review`
+
+The campaign carries a `GmArbitrationMode` the host sets:
+
+- **`auto-approve`** — a guest proposal that passes CO1's mechanical validation (balance, standing, roster checks) is committed immediately, with no host interaction. This is the low-friction default for trusting co-op partners; the host still gets the *outcome* as a broadcast campaign event.
+- **`host-review`** — every guest proposal is surfaced to the host, who explicitly issues `approve` or `veto`. CO1's mechanical validation still runs first: a proposal that fails validation is rejected before it ever reaches the host's review queue (the host is never asked to approve an over-balance spend).
+
+In both modes the mechanical validation from CO1 is the floor — the GM can never approve a proposal that violates the ledger invariant. `host-review` adds a *discretionary* gate on top of the *mechanical* one.
+
+### D6. Veto is a typed, non-committing result
+
+A `veto` GM decision resolves a proposal without committing any campaign event. The guest receives a typed rejection (`code: 'PROPOSAL_VETOED'`) distinct from CO1's mechanical `INVALID_CAMPAIGN_INTENT`, so the guest UI can tell "the GM chose no" apart from "this was impossible". The connection stays open and the guest may submit a different proposal — same open-connection contract as CO1's intent rejection.
+
+### D7. Guest pending-proposal feedback and host review surface
+
+- **Guest side** — when a guest submits a proposal, the guest UI shows a *pending* indicator on that action and disables a duplicate submit until the proposal resolves (committed event, or `veto`, or mechanical rejection arrive on the CO1 broadcast channel).
+- **Host side** — in `host-review` mode the host sees a review surface listing pending guest proposals, each with the campaign context needed to decide: current C-bill balance, relevant faction standing, the roster effect. The host approves or vetoes from this surface.
+
+Both surfaces are driven entirely by the CO1 campaign event-broadcast channel and the proposal/decision messages; no new transport is introduced.
+
+### D8. Co-op post-battle reconciliation emits CO1 campaign events
+
+When a co-op encounter resolves, its campaign-level consequences — salvage, funds change, roster change, pilot XP — are reconciled into the shared campaign by emitting CO1 campaign events (`SalvageAllocated`, `FundsChanged`, `RosterUnitChanged`, etc.) through the `CampaignMatchHost`. Because both players' campaign views are CO1 mirrors fed by the same event log, the deploying player and the command-HQ player converge on the same post-battle campaign state. The co-op encounter's combat event log (from `ServerMatchHost`) and the campaign event log stay separate and linked by id, per CO1 D2.
+
+### D9. Type contracts
+
+```typescript
+// Per-mission, per-player participation choice.
+type CoopParticipationChoice = 'deploy' | 'command-hq';
+
+// How the GM arbitrates guest proposals for this campaign.
+type GmArbitrationMode = 'auto-approve' | 'host-review';
+
+// A guest campaign action awaiting GM arbitration.
+interface IGuestProposal {
+  readonly proposalId: string;       // client-generated, for correlation
+  readonly campaignId: string;
+  readonly proposingPlayerId: string;
+  readonly ts: string;
+  readonly intent: ICampaignIntent;  // the CO1 intent the GM arbitrates
+}
+
+// The GM's resolution of a proposal.
+type GmDecision = 'approve' | 'veto';
+```
+
+## Risks / Trade-offs
+
+- **[Risk] Both players choose `command-hq` and the mission cannot be fought** → Mitigation: D2 — a launch with zero `deploy` players is blocked at launch with a clear error; at least one player must deploy.
+- **[Risk] `auto-approve` lets a guest drain the campaign treasury** → Mitigation: CO1's mechanical validation is the floor in both modes — a guest can never spend past the balance; `auto-approve` only removes the *discretionary* host gate, never the *invariant* gate. A host who wants spend control sets `host-review`.
+- **[Risk] A host-review proposal is never answered (host AFK)** → Mitigation: the proposal stays pending and the guest sees the pending indicator; the host-review surface is the host's responsibility. A timeout-to-veto policy is an Open Question, not silently auto-approved.
+- **[Risk] Scope creep — co-op combat re-architecting** → Mitigation: D1 — co-op mission launch is roster composition + routing through the *existing* `ServerMatchHost`; no combat netcode is added. If two-force composition surfaces a genuine engine gap, that is a flagged question for a combat-layer change, not silent expansion here.
+- **[Risk] Command-HQ player's campaign view drifts from the battle outcome** → Mitigation: D8 — post-battle consequences are CO1 campaign events; the command-HQ player's CO1 mirror receives them exactly like the deploying player's.
+- **[Trade-off] `host-review` adds friction to every guest action** → Accepted and made a choice: `auto-approve` is the low-friction default; `host-review` is opt-in for hosts who want tighter campaign control.
+
+## Migration Plan
+
+Purely additive on top of CO1. A solo campaign is unaffected — no participation choice, no GM arbitration, no proposals. A shared campaign created under CO1 alone (transport only) continues to work; this change adds the co-op-play and GM-authority behavior when a co-op mission is launched. New types (`CoopParticipationChoice`, `GmArbitrationMode`, `IGuestProposal`, `GmDecision`) are additive. No database migration — proposals and decisions ride the CO1 campaign event-broadcast channel; co-op encounters use the existing `ServerMatchHost` store. Rollback = revert the change-set; CO1's shared campaign transport remains intact and solo campaigns are untouched.
+
+## Open Questions
+
+- Should an unanswered `host-review` proposal time out, and if so to `veto` or to `auto-approve`? Proposed: time out to `veto` (the safe default — no campaign mutation on host silence), with the timeout window configurable. Confirm during apply.
+- Should a `command-hq` player's force be auto-resolved into the encounter, fielded under host control, or simply sit out? Proposed: configurable per mission, defaulting to "sit out"; auto-resolve depends on a battle auto-resolver that may not exist — flag if so rather than expand scope.
+- Granularity of `GmArbitrationMode` — one mode per campaign, or per intent kind (e.g., auto-approve `AdvanceDay` but host-review `SpendFunds`)? Proposed: one mode per campaign for this change; per-kind granularity is a later refinement.

--- a/openspec/changes/add-coop-campaign-play/proposal.md
+++ b/openspec/changes/add-coop-campaign-play/proposal.md
@@ -1,0 +1,43 @@
+# Change: Add Co-op Campaign Play
+
+## Why
+
+`add-shared-campaign-state` (CO1) gives two friends one shared, server-authoritative campaign ledger — a campaign event log, a host-as-single-writer, and a read-only guest mirror. But CO1 is only the transport. It deliberately stops short of the two things that make a co-op campaign actually *playable*:
+
+1. **Co-op mission launch.** A campaign mission today launches one player's force into one encounter. A co-op campaign needs both players' forces in a single encounter, and it needs to handle the case where one player wants to fight while the other stays in the "command HQ" — managing the bay, reviewing contracts, watching the battle — without being forced onto the map.
+2. **The host-as-GM authority model.** CO1 defined the *transport* for campaign intents (`HirePilot`, `AcceptContract`, `SpendFunds`, …) and that the host validates them. It did not define the *gameplay model*: that the host is the campaign's Game Master, that guest campaign actions are *proposals* the host arbitrates against current balance and faction standing, and how the host approves, auto-approves, or vetoes them.
+
+This change builds both, on top of CO1's loop. It is the former CO2 (co-op mission launch) and CO3 (campaign authority model) merged, because the authority model only has meaning once there is co-op gameplay to authorize.
+
+## What Changes
+
+- ADDED co-op mission launch: a campaign mission can be launched with both players' forces composed into one `IEncounter` / `GameSession`, routed through the existing `ServerMatchHost` server-authoritative combat loop
+- ADDED a per-mission participation choice: each player chooses to **deploy** (their force joins the encounter and they play it on the map) or to remain in **command HQ** (their force may still be auto-resolved or sit out, and they keep access to campaign-management surfaces while the battle runs)
+- ADDED the host-as-GM authority model: the host is the campaign Game Master; guest campaign actions are proposals the host arbitrates
+- ADDED GM arbitration modes for guest intents: **auto-approve** (intent committed immediately if it passes CO1 validation), **host-review** (the host sees the proposal and explicitly approves or vetoes), and an explicit **veto** result that returns a typed rejection without committing
+- ADDED a guest-facing intent surface: guest "hire pilot" / "accept contract" / "spend" controls send proposals instead of mutating state, and show a pending-proposal indicator until the host's broadcast resolves them
+- ADDED a host-facing GM review surface: the host sees incoming guest proposals with the campaign context (current balance, standing) needed to approve or veto
+- ADDED co-op post-battle reconciliation: the encounter's campaign consequences (salvage, funds, roster, XP) are emitted as CO1 campaign events so both players' campaign views converge
+
+## Dependencies
+
+- **Requires**: `add-shared-campaign-state` (CO1) — the campaign event log, `CampaignMatchHost` validate-commit-broadcast loop, and read-only guest mirror this change builds its gameplay and authority model on
+- **Requires**: `add-campaign-combat-loop` (Wave 4 CP1) — the mission→encounter launch and post-battle→campaign bridge that co-op mission launch extends to two forces
+- **Requires** (transitively, via CO1): `harden-multiplayer-transport` (Wave 3 M2) and `add-campaign-persistence` (Wave 4 CP0)
+
+## Impact
+
+- Affected specs: `coop-campaign-sync` (the capability created by CO1) — this change ADDs the co-op-play and GM-authority requirements onto it, keeping all co-op campaign behavior in one capability
+- Affected code: `src/lib/campaign/` (co-op mission composition, post-battle reconciliation into campaign events), `src/lib/multiplayer/server/` (`CampaignMatchHost` extended with GM arbitration modes; co-op encounter launch through `ServerMatchHost`), `src/types/campaign/` (participation choice, GM arbitration types), `src/components/campaign/` (guest proposal surface, host GM review surface), `src/components/gameplay/` (co-op encounter with both forces)
+- New types: `CoopParticipationChoice` (`deploy` | `command-hq`), `GmArbitrationMode` (`auto-approve` | `host-review`), `IGuestProposal`, `GmDecision` (`approve` | `veto`)
+- No new transport — co-op mission launch reuses `ServerMatchHost`; campaign proposals reuse the CO1 campaign event-broadcast loop
+- No database migrations
+
+## Non-Goals
+
+- The campaign event log, `CampaignMatchHost` transport, and guest mirror mechanics — all owned by CO1; this change consumes them
+- Three-or-more-player co-op campaigns — the host/guest pair remains the scope
+- A dedicated co-op AI director or scaling of encounter difficulty to two forces beyond composing both rosters — encounter generation tuning is out of scope
+- Campaign-tier host migration — if the host disconnects, CO1's pause behavior stands; this change does not add host handoff
+- PvP campaign play (the two players' forces fighting *each other*) — co-op means cooperative; both forces share a side against the encounter's OpFor
+- Spectator seats for the co-op encounter — that consumes `add-matchmaking-and-spectator` (Wave 3 M3) and is a later integration

--- a/openspec/changes/add-coop-campaign-play/specs/coop-campaign-sync/spec.md
+++ b/openspec/changes/add-coop-campaign-play/specs/coop-campaign-sync/spec.md
@@ -1,0 +1,188 @@
+## ADDED Requirements
+
+### Requirement: Co-op Mission Launch With Both Forces
+
+The system SHALL launch a co-op campaign mission as one encounter composed from both players' selected forces, assigned to a shared `GameSide` against the encounter's OpFor. The composed encounter SHALL be run through the existing `ServerMatchHost` server-authoritative combat loop. Each deploying player SHALL own and command only their own units; an intent for a unit a player does not own SHALL be rejected.
+
+#### Scenario: Co-op encounter contains both rosters
+
+- **GIVEN** a co-op campaign mission with two players, each contributing a force
+- **WHEN** the mission is launched
+- **THEN** the resulting encounter SHALL contain the units of both forces
+- **AND** both forces SHALL be assigned to the same side against the encounter OpFor
+
+#### Scenario: Co-op encounter runs through the existing combat host
+
+- **GIVEN** a composed co-op encounter
+- **WHEN** the encounter starts
+- **THEN** it SHALL be run by `ServerMatchHost`
+- **AND** no new combat transport SHALL be introduced for co-op play
+
+#### Scenario: Cross-player unit intent is rejected
+
+- **GIVEN** a co-op encounter with two deploying players
+- **WHEN** one player sends a combat intent for a unit owned by the other player
+- **THEN** the host SHALL reject the intent as unauthorized
+- **AND** no event SHALL be appended for that intent
+
+### Requirement: Per-Mission Participation Choice
+
+The system SHALL allow each player, before a co-op mission launches, to choose a `CoopParticipationChoice` of `deploy` or `command-hq`. A `deploy` player's force enters the encounter and the player plays it on the tactical map. A `command-hq` player does not take the map and retains access to campaign-management surfaces while the battle runs. A co-op mission launch where no player chose `deploy` SHALL be blocked.
+
+#### Scenario: Player deploys onto the map
+
+- **GIVEN** a player who chose `deploy` for a co-op mission
+- **WHEN** the mission launches
+- **THEN** the player's force SHALL enter the encounter
+- **AND** the player SHALL command that force on the tactical map
+
+#### Scenario: Command-HQ player keeps campaign access
+
+- **GIVEN** a player who chose `command-hq` for a co-op mission
+- **WHEN** the mission's encounter is running
+- **THEN** the player SHALL NOT be placed on the tactical map
+- **AND** the player SHALL retain access to campaign-management surfaces
+
+#### Scenario: Mission with no deploying player is blocked
+
+- **GIVEN** a co-op mission where both players chose `command-hq`
+- **WHEN** a launch is attempted
+- **THEN** the launch SHALL be blocked with a clear error
+- **AND** no encounter SHALL be created
+
+### Requirement: Host-as-GM Authority Model
+
+The host of a shared campaign SHALL be the campaign Game Master and SHALL be the single campaign-write authority. The guest SHALL be a co-op player with no campaign-write authority. A guest campaign action SHALL be submitted as an `IGuestProposal` wrapping a CO1 `ICampaignIntent`, and SHALL NOT commit a campaign event until the GM resolves the proposal with an `approve` decision.
+
+#### Scenario: Guest action is a proposal, not a commit
+
+- **GIVEN** a guest in a shared campaign taking a campaign action
+- **WHEN** the action is submitted
+- **THEN** it SHALL be sent as an `IGuestProposal` to the host
+- **AND** no campaign event SHALL be committed until the GM approves the proposal
+
+#### Scenario: Approved proposal commits and broadcasts
+
+- **GIVEN** a guest proposal the GM resolves with `approve`
+- **WHEN** the decision is applied
+- **THEN** the underlying CO1 campaign intent SHALL be committed and broadcast as a campaign event
+- **AND** both the host and the guest mirror SHALL converge on the resulting state
+
+#### Scenario: Guest holds no campaign-write authority
+
+- **GIVEN** a shared campaign with a host and a guest
+- **WHEN** the guest attempts to commit a campaign change without a GM-approved proposal
+- **THEN** the change SHALL NOT be applied
+- **AND** the host SHALL remain the single campaign-write authority
+
+### Requirement: GM Arbitration Modes
+
+The campaign SHALL carry a `GmArbitrationMode` of `auto-approve` or `host-review`. In `auto-approve` mode, a guest proposal that passes CO1 mechanical validation SHALL be committed immediately with no host interaction. In `host-review` mode, a guest proposal that passes CO1 mechanical validation SHALL be surfaced to the host for an explicit `approve` or `veto`. In both modes CO1 mechanical validation SHALL run first, and a proposal that fails it SHALL be rejected before the host reviews it.
+
+#### Scenario: Auto-approve commits without a host step
+
+- **GIVEN** a campaign in `auto-approve` mode
+- **WHEN** a guest submits a proposal that passes CO1 mechanical validation
+- **THEN** the proposal SHALL be committed immediately
+- **AND** the host SHALL NOT be asked to review it
+
+#### Scenario: Host-review waits for the host
+
+- **GIVEN** a campaign in `host-review` mode
+- **WHEN** a guest submits a proposal that passes CO1 mechanical validation
+- **THEN** the proposal SHALL be surfaced to the host as pending
+- **AND** it SHALL NOT commit until the host issues an `approve` decision
+
+#### Scenario: Mechanical validation precedes host review
+
+- **GIVEN** a campaign in `host-review` mode
+- **WHEN** a guest submits a `SpendFunds` proposal for an amount over the campaign balance
+- **THEN** the proposal SHALL be rejected by CO1 mechanical validation with `INVALID_CAMPAIGN_INTENT`
+- **AND** the proposal SHALL NOT appear in the host's review surface
+
+### Requirement: GM Veto Is a Typed Non-Committing Result
+
+The GM SHALL be able to resolve a guest proposal with a `veto` decision. A veto SHALL commit no campaign event and SHALL return a typed rejection `Error {code: 'PROPOSAL_VETOED'}`, distinct from CO1's mechanical `INVALID_CAMPAIGN_INTENT`. The connection SHALL remain open and the guest SHALL be able to submit a different proposal.
+
+#### Scenario: Veto commits nothing
+
+- **GIVEN** a guest proposal the GM resolves with `veto`
+- **WHEN** the decision is applied
+- **THEN** no campaign event SHALL be committed
+- **AND** the guest SHALL receive `Error {code: 'PROPOSAL_VETOED'}`
+
+#### Scenario: Veto is distinct from a mechanical rejection
+
+- **GIVEN** a guest that received a `veto` and another that received an `INVALID_CAMPAIGN_INTENT`
+- **WHEN** the guest UI classifies each result
+- **THEN** the `veto` SHALL be presented as a GM decision
+- **AND** the `INVALID_CAMPAIGN_INTENT` SHALL be presented as an impossible action
+
+#### Scenario: Connection survives a veto
+
+- **GIVEN** a guest whose proposal was vetoed
+- **WHEN** the veto is delivered
+- **THEN** the connection SHALL remain open
+- **AND** the guest SHALL be able to submit a different proposal
+
+### Requirement: Guest Proposal Feedback Surface
+
+A guest submitting an `IGuestProposal` SHALL see a pending indicator on that action until the proposal resolves, and a duplicate submission of the same action SHALL be disabled while it is pending. On resolution the guest SHALL be shown whether the proposal committed a campaign event, was vetoed, or failed mechanical validation.
+
+#### Scenario: Pending indicator while a proposal is unresolved
+
+- **GIVEN** a guest who submitted a campaign proposal
+- **WHEN** the proposal has not yet resolved
+- **THEN** the action SHALL show a pending indicator
+- **AND** a duplicate submission of that action SHALL be disabled
+
+#### Scenario: Indicator clears on resolution
+
+- **GIVEN** a guest with a pending proposal
+- **WHEN** the proposal resolves with a committed event, a veto, or a mechanical rejection
+- **THEN** the pending indicator SHALL clear
+- **AND** the resolution outcome SHALL be surfaced to the guest
+
+### Requirement: Host GM Review Surface
+
+In `host-review` mode the host SHALL be presented with a review surface listing pending guest proposals. Each pending proposal SHALL be shown with the campaign context needed to decide — the current C-bill balance, the relevant faction standing, and the roster effect. The host SHALL be able to `approve` or `veto` each proposal from this surface.
+
+#### Scenario: Review surface lists pending proposals with context
+
+- **GIVEN** a campaign in `host-review` mode with two pending guest proposals
+- **WHEN** the host opens the GM review surface
+- **THEN** both proposals SHALL be listed
+- **AND** each SHALL show the current balance, the relevant standing, and the roster effect
+
+#### Scenario: Host decides from the review surface
+
+- **GIVEN** a pending proposal on the host's review surface
+- **WHEN** the host selects `approve`
+- **THEN** the proposal's CO1 campaign intent SHALL be committed and broadcast
+- **WHEN** the host selects `veto` on another proposal
+- **THEN** that proposal SHALL commit nothing and the guest SHALL receive `PROPOSAL_VETOED`
+
+### Requirement: Co-op Post-Battle Reconciliation
+
+When a co-op encounter resolves, its campaign-level consequences — salvage, funds change, roster change, and pilot XP — SHALL be reconciled into the shared campaign by emitting CO1 campaign events through the `CampaignMatchHost`. Both a deploying player and a `command-hq` player SHALL receive these events through their CO1 campaign mirror and SHALL converge on the same post-battle campaign state. The co-op combat event log and the campaign event log SHALL remain separate, linked by id.
+
+#### Scenario: Post-battle consequences become campaign events
+
+- **GIVEN** a resolved co-op encounter that produced salvage and a funds change
+- **WHEN** the encounter is reconciled into the campaign
+- **THEN** the consequences SHALL be emitted as CO1 campaign events through the `CampaignMatchHost`
+- **AND** the events SHALL be appended to the campaign event log
+
+#### Scenario: Both players converge on the post-battle state
+
+- **GIVEN** a co-op mission with one deploying player and one `command-hq` player
+- **WHEN** the encounter resolves and is reconciled
+- **THEN** both players' CO1 campaign mirrors SHALL receive the same post-battle campaign events
+- **AND** both players SHALL converge on the same post-battle campaign state
+
+#### Scenario: Combat and campaign logs stay separate
+
+- **GIVEN** a resolved co-op encounter
+- **WHEN** the combat event log and the campaign event log are inspected
+- **THEN** they SHALL be distinct logs linked by id
+- **AND** combat events SHALL NOT be merged into the campaign event log

--- a/openspec/changes/add-coop-campaign-play/tasks.md
+++ b/openspec/changes/add-coop-campaign-play/tasks.md
@@ -1,0 +1,66 @@
+# Tasks: Add Co-op Campaign Play
+
+## 1. Co-op Play Types
+
+- [ ] 1.1 Add `CoopParticipationChoice` (`deploy` | `command-hq`) and `GmArbitrationMode` (`auto-approve` | `host-review`) to `src/types/campaign/`
+- [ ] 1.2 Add `IGuestProposal` (proposalId, campaignId, proposingPlayerId, ts, the CO1 `ICampaignIntent`) and `GmDecision` (`approve` | `veto`) to `src/types/campaign/`
+- [ ] 1.3 Add a runtime validator for `IGuestProposal` and `GmDecision` so malformed proposals/decisions are rejected at the boundary
+- [ ] 1.4 Unit tests for the type set and a serialization round-trip for proposals and decisions
+
+## 2. Co-op Mission Launch — Two-Force Composition
+
+- [ ] 2.1 Extend the `add-campaign-combat-loop` mission→encounter bridge to compose one `IEncounter` from both players' selected forces on a shared `GameSide` against the OpFor
+- [ ] 2.2 Route the composed co-op encounter through the existing `ServerMatchHost` server-authoritative combat loop — no new combat path
+- [ ] 2.3 Confirm seat/unit-ownership validation: each deploying player owns only their own units; an intent for another player's unit is rejected
+- [ ] 2.4 Tests: a co-op encounter contains both rosters on the shared side; ownership validation rejects cross-player unit intents
+
+## 3. Per-Mission Participation Choice
+
+- [ ] 3.1 Implement the pre-launch `CoopParticipationChoice` for each player — `deploy` or `command-hq`
+- [ ] 3.2 Block a co-op mission launch where no player chose `deploy`, with a clear error
+- [ ] 3.3 Implement `command-hq` behavior — the player retains access to campaign-management surfaces while the battle runs and their force sits out (or is fielded per the configured default)
+- [ ] 3.4 Tests: a zero-`deploy` launch is blocked; a `command-hq` player keeps campaign-surface access; a mixed deploy/HQ launch composes correctly
+
+## 4. Host-as-GM Authority Model
+
+- [ ] 4.1 Designate the CO1 campaign host as the Game Master in gameplay terms — the single campaign-write authority; the guest is a co-op player with no campaign-write authority
+- [ ] 4.2 Implement `IGuestProposal` submission — a guest campaign action is sent as a proposal wrapping a CO1 `ICampaignIntent`, not as a direct intent commit
+- [ ] 4.3 Extend `CampaignMatchHost` to resolve each proposal to a `GmDecision` before CO1's commit-and-broadcast — only `approve` proceeds to commit
+- [ ] 4.4 Tests: a guest proposal does not commit until approved; an `approve` commits and broadcasts the CO1 campaign event; the GM is the single write authority
+
+## 5. GM Arbitration Modes
+
+- [ ] 5.1 Implement `auto-approve` mode — a proposal that passes CO1 mechanical validation is committed immediately with no host interaction
+- [ ] 5.2 Implement `host-review` mode — every proposal that passes CO1 mechanical validation is surfaced to the host for explicit `approve` / `veto`
+- [ ] 5.3 Ensure CO1 mechanical validation runs first in both modes — a proposal that fails validation is rejected before the host ever reviews it
+- [ ] 5.4 Implement the typed `veto` result — `Error {code: 'PROPOSAL_VETOED'}`, distinct from CO1's `INVALID_CAMPAIGN_INTENT`, committing no event and leaving the connection open
+- [ ] 5.5 Tests: `auto-approve` commits a valid proposal with no host step; `host-review` waits for the host; a vetoed proposal commits nothing; an over-balance proposal is rejected before review in both modes
+
+## 6. Guest Proposal Surface
+
+- [ ] 6.1 Wire guest "hire pilot" / "accept contract" / "spend" controls to submit `IGuestProposal`s instead of mutating campaign state
+- [ ] 6.2 Show a pending-proposal indicator on a submitted action and disable duplicate submit until the proposal resolves
+- [ ] 6.3 Surface the resolution — committed event, `veto`, or mechanical rejection — to the guest, telling a GM veto apart from an impossible action
+- [ ] 6.4 Tests: a guest control submits a proposal not a commit; the pending indicator clears on resolution; a veto and a mechanical rejection are visually distinct
+
+## 7. Host GM Review Surface
+
+- [ ] 7.1 Implement the host-side GM review surface listing pending guest proposals (only populated in `host-review` mode)
+- [ ] 7.2 Show each proposal with the campaign context needed to decide — current C-bill balance, relevant faction standing, the roster effect
+- [ ] 7.3 Wire `approve` / `veto` controls from the review surface to the `CampaignMatchHost`
+- [ ] 7.4 Tests: the review surface lists pending proposals with context; approving commits the CO1 event; vetoing commits nothing
+
+## 8. Co-op Post-Battle Reconciliation
+
+- [ ] 8.1 On co-op encounter resolution, reconcile salvage / funds / roster / pilot XP into the shared campaign by emitting CO1 campaign events through the `CampaignMatchHost`
+- [ ] 8.2 Confirm a `command-hq` player's CO1 mirror receives the same post-battle campaign events as the deploying player
+- [ ] 8.3 Keep the co-op combat event log and the campaign event log separate and linked by id
+- [ ] 8.4 Tests: post-battle consequences appear as CO1 campaign events; the deploying and command-HQ players converge on the same post-battle campaign state
+
+## 9. Verification
+
+- [ ] 9.1 Integration test: a host launches a co-op mission with both players deploying — the encounter contains both rosters on the shared side and resolves through `ServerMatchHost`
+- [ ] 9.2 Integration test: a co-op mission with one player in `command-hq` — the HQ player keeps campaign-surface access and receives the post-battle campaign events
+- [ ] 9.3 Integration test: in `host-review` mode a guest `HirePilot` proposal is approved by the host and both campaign views converge; a second proposal is vetoed and commits nothing
+- [ ] 9.4 Integration test: in `auto-approve` mode a valid guest proposal commits with no host step; an over-balance proposal is still rejected
+- [ ] 9.5 `npx openspec validate add-coop-campaign-play --strict` is clean; build, lint, and typecheck pass

--- a/openspec/changes/add-matchmaking-and-spectator/design.md
+++ b/openspec/changes/add-matchmaking-and-spectator/design.md
@@ -1,0 +1,76 @@
+# Design: Add Matchmaking and Spectator Support
+
+## Context
+
+By the end of M2 the multiplayer transport is durable and hardened: a durable `IMatchStore` survives restarts, host migration prevents aborts, and intents are rate-limited and replay-protected. M1 already made matches playable through `NetworkedGameSurface`, which renders a read-only mirror session from the server `Event` stream and emits intents over the WebSocket.
+
+Two gaps remain. First, *discovery*: the only way into a networked match is a 6-character room code passed out-of-band — the multiplayer hub (`src/pages/multiplayer/index.tsx`) has no list of open lobbies. Second, *observation*: the server already broadcasts per-player fog-redacted events (`fogOfWar.ts`, `FogOfWarVisibilityCache`, `filterEventForPlayer`) and the seat model has a `kind` discriminant (`'human' | 'ai'`), but there is no `spectator` kind and no path for a non-player to connect and watch.
+
+Both gaps are *additive surfaces over existing infrastructure*. The match browser is a query over the durable store (M2) plus a list UI. The spectator is a new seat kind plus a read-only reuse of M1's game surface, fed by the fog-redaction filter that already exists.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A match browser on the multiplayer hub listing joinable lobbies, with one-click join.
+- A server query over the durable store returning joinable lobbies.
+- A `spectator` seat kind for non-playing observers that own no game units.
+- Spectator connection over the existing WebSocket, building a read-only mirror like a player.
+- A defined spectator fog-of-war visibility scope so spectating a fog-on match leaks no hidden information.
+- A spectator surface reusing M1's `NetworkedGameSurface` in a no-controls mode.
+
+**Non-Goals:**
+
+- Ranked / skill-based matchmaking, spectator chat or casting, mid-match seat-kind changes, persisting spectator participation, modifying the fog algorithm.
+
+## Decisions
+
+### D1. A new `multiplayer-matchmaking` capability for the browser; spectator requirements go on `multiplayer-server`
+
+The match browser and matchmaking surface are a distinct discovery concern with no existing home — a new `multiplayer-matchmaking` capability. The spectator *seat kind* and spectator *broadcast* are intrinsic to the server seat model and the per-player broadcast that already live in `multiplayer-server`; those requirements are added there. Both deltas are purely `## ADDED` — the `spectator` kind is a *new* requirement added alongside the existing "Seat Slot Model" requirement, not a modification of it.
+
+### D2. The match browser is a query over the durable store, not a new index
+
+M2's durable store already holds every `IMatchMeta` including `status`, `layout`, `seats`, and `roomCode`. A joinable lobby is a match where `status === 'lobby'` and at least one `kind: 'human'` seat has no occupant. The browser endpoint is a `getJoinableLobbies()` query that filters the store's matches by that predicate and returns a compact projection (match id, layout, host display name, seat occupancy summary) — no leaked internal detail beyond what a joiner needs. No separate index structure is introduced; the query reads existing metadata.
+
+### D3. One-click join reuses the existing room-code path
+
+A browser row carries the match's `roomCode`. Clicking "Join" navigates to `/multiplayer/lobby/[roomCode]` — exactly the route a shared invite code would open. The browser is therefore a *discovery* layer; the join mechanics, auth, and seat occupancy are the unchanged M1 lobby flow. This keeps one join path and avoids a parallel matchmaking-only join code branch.
+
+### D4. `spectator` is a third seat `kind`
+
+The seat model's `kind` union (`'human' | 'ai'`) gains `'spectator'`. A spectator seat:
+- owns no game units — it is excluded from side assignment and from `recordMatchParticipation`;
+- is excluded from the readiness gate (`canLaunch`) — spectators never block or enable launch;
+- does not count toward the layout's player-seat budget — a `1v1` match still has exactly two human-playable seats regardless of spectator count.
+A spectator seat is occupied by an authenticated player id, bound at WebSocket-upgrade time exactly as a human seat is, so the existing identity-binding requirement applies unchanged.
+
+### D5. Spectator connection reuses the player join + replay path
+
+A spectator connects over the existing WebSocket with `SessionJoin` and `lastSeq`, receives the replay stream, and then live events — identical to a player's connection. The spectator builds the same read-only mirror session M1 already produces. The only difference is the *surface*: a spectator gets `NetworkedGameSurface` rendered with intent-emit controls disabled (no movement, attack, phase, or concede controls). A spectator can never produce an `Intent`.
+
+### D6. Spectator fog-of-war scope is defined and conservative
+
+The server's fog filter (`filterEventForPlayer`) is keyed on a `playerId` mapped to a game side via `sideOwners` / `sideAssignments`. A spectator owns no side, so it has no natural side-based visibility. The conservative rule: a spectator of a **fog-on** match sees the *intersection* of what no single side would consider hidden — i.e. only events classified `public` plus events whose subject unit is currently visible to *at least one participant is not* the rule; instead a spectator sees the **union is not** used either. The defined scope: a spectator of a fog-on match receives only `public`-classified events and events about units, so that spectating never reveals a unit a participant on the field could not yet see. A spectator of a **fog-off** match receives the full unredacted stream like any participant. The exact classification is: spectators are treated as a distinct fog audience that receives the *most-redacted* view — never more than the least-informed participant — so spectating cannot be used to scout for a player.
+
+### D7. The match browser refreshes on lobby lifecycle changes
+
+The browser is a snapshot of joinable lobbies at fetch time. It refreshes on an interval and on an explicit user refresh so a lobby that fills up or launches disappears from the list. A match that has transitioned out of `status: 'lobby'` (per the existing room-code expiry-at-launch rule) is never returned by the joinable-lobby query.
+
+## Risks / Trade-offs
+
+- **[Risk] Spectator fog scope leaks scouting information** → Mitigation: D6 — a spectator of a fog-on match receives the most-redacted view, never more than the least-informed participant; a verification test asserts a spectator never receives an event a hidden-unit participant would not.
+- **[Risk] The joinable-lobby query is slow as match volume grows** → Mitigation: D2 — the query is a filtered read over `IMatchMeta`; if volume warrants it, M2's durable store can index `status`, but for Wave 3 scale a scan is sufficient and is measured in verification.
+- **[Risk] A spectator seat is mistaken for a player seat by the readiness gate** → Mitigation: D4 — `canLaunch` and `recordMatchParticipation` explicitly exclude `kind: 'spectator'`; tests assert a match with spectators launches with exactly its human seats ready.
+- **[Risk] A spectator finds a way to emit an intent** → Mitigation: D5 — the spectator surface renders no intent controls, and the server independently rejects any intent from a `spectator`-kind seat as unauthorized.
+- **[Risk] Browser shows a lobby that just launched** → Mitigation: D7 — the query filters on `status: 'lobby'` and the browser refreshes; a launched match drops off, consistent with the existing room-code expiry-at-launch behavior.
+
+## Migration Plan
+
+Additive. The `spectator` value is a new member of an existing union — code that switches on `kind` gains a case but existing `human` / `ai` handling is untouched; `canLaunch` and participation recording add an explicit exclusion. The match browser is a new surface on the existing multiplayer hub plus a new REST route; no existing route changes. Spectator connection reuses the unchanged player join + replay path. No new database migration — the joinable-lobby query reads metadata M2's durable store already persists. Rollback = remove the browser surface and the `spectator` kind; M1 and M2 are unaffected.
+
+## Open Questions
+
+- Whether spectator count should be capped per match — proposed: a generous configured cap so a popular match cannot exhaust server sockets; the number is left to the verification stress test.
+- Whether the match browser should also surface `active` matches as spectatable (not just `lobby` matches as joinable) — proposed: yes, a second browser tab lists `active` matches with their spectator-join action; confirm during implementation that the joinable-lobby query and a separate spectatable-match query stay cleanly separated.
+- Whether a spectator of a fog-on match should optionally be allowed a full "director's view" when the host opts in — proposed: out of scope for Wave 3; the conservative most-redacted view is the only spectator scope shipped.

--- a/openspec/changes/add-matchmaking-and-spectator/proposal.md
+++ b/openspec/changes/add-matchmaking-and-spectator/proposal.md
@@ -1,0 +1,40 @@
+# Change: Add Matchmaking and Spectator Support
+
+## Why
+
+After M1 (`complete-multiplayer-game-surface`) makes networked matches playable and M2 (`harden-multiplayer-transport`) makes the transport durable and abuse-resistant, two discovery / observation gaps remain before multiplayer is feature-complete:
+
+1. **No way to find a match.** Today the only entry into a networked match is a 6-character room code shared out-of-band — a player must already know a code to join. There is no match browser and no matchmaking page; the multiplayer hub (`src/pages/multiplayer/index.tsx`) cannot list open lobbies a player could join.
+2. **No way to watch a match.** The server already redacts events per-player for fog-of-war (`fogOfWar.ts`, `FogOfWarVisibilityCache`), and the seat model has a `kind` discriminant (`human` | `ai`). But there is no spectator seat type — a third person cannot connect to an in-progress match to observe it, even though the per-player broadcast infrastructure that would feed a spectator already exists.
+
+This change adds a match browser / matchmaking surface so players can discover and join open lobbies, and a spectator seat type so non-players can watch a match through the server's existing fog-of-war redaction.
+
+## What Changes
+
+- ADDED a match browser: a surface on the multiplayer hub that lists joinable lobbies (matches in `status: 'lobby'` with at least one open human seat), with their layout, host, and seat occupancy
+- ADDED a server endpoint backing the browser — a query over the durable match store for joinable lobbies, returning the same shape the browser renders
+- ADDED a one-click join from a browser row that resolves the lobby and navigates the player into it, reusing the existing room-code-resolution path internally
+- ADDED a `spectator` seat kind alongside the existing `human` and `ai` kinds — a seat a non-playing observer occupies that owns no game units
+- ADDED spectator connection: a spectator joins an `active` match over the existing WebSocket and receives the server `Event` stream, building a read-only mirror session like a player but with no intent-emit controls
+- ADDED spectator fog-of-war handling: a spectator sees the match through the server's existing per-player redaction with a defined spectator visibility scope, so spectating a fog-on match does not leak hidden information that a participant would not see
+- ADDED a spectator surface that renders the networked game surface (from M1) in a read-only, no-controls mode
+
+## Dependencies
+
+- **Requires**: `complete-multiplayer-game-surface` (M1) — the spectator surface reuses the networked game surface and its read-only mirror path; `harden-multiplayer-transport` (M2) — the match browser queries the durable match store, and spectators rely on the non-aborting transport; `multiplayer-server` (the seat model, per-player broadcast, fog redaction — all source-of-truth)
+- **Required By**: none in Wave 3 — M3 closes the Wave 3 multiplayer set
+
+## Impact
+
+- Affected specs: `multiplayer-matchmaking` (new capability) for the match browser and matchmaking surface; `multiplayer-server` (new `## ADDED` requirements for the spectator seat kind, the joinable-lobby query, and spectator broadcast). No `MODIFIED` or `REMOVED` — the `spectator` kind is added as a new requirement alongside the existing seat-model requirement rather than editing it.
+- Affected code: `src/pages/multiplayer/index.tsx` (match browser surface), a new browser component under `src/components/multiplayer/`, a new REST route under `src/pages/api/multiplayer/` for the joinable-lobby query, the seat model in `src/types/multiplayer/Lobby.ts` (extend the `kind` union with `spectator`), `ServerMatchHost` / its socket-lifecycle satellites for spectator connection, `src/lib/multiplayer/server/fogOfWar.ts` consumption for spectator visibility scope, and the spectator render path reusing M1's `NetworkedGameSurface`
+- No new database migrations beyond what M2's durable store already introduced — the joinable-lobby query reads existing match metadata
+- Reproducibility preserved: spectators are read-only observers; they never produce intents, rolls, or authoritative state
+
+## Non-Goals
+
+- Skill-based or ranked matchmaking — the "matchmaking" here is a browse-and-join lobby list, not an automatic pairing or rating system
+- Spectator chat, casting tools, or delayed/replay-style spectating — spectators receive the live redacted stream only
+- Letting a spectator convert into a player mid-match, or a player into a spectator — seat kind is fixed for the match
+- Persisting spectator participation in the `IPlayerStore` — only human players are recorded as participants
+- Any change to the authoritative engine, roll capture, or the fog redaction algorithm itself — M3 consumes the existing fog filter, it does not modify it

--- a/openspec/changes/add-matchmaking-and-spectator/specs/multiplayer-matchmaking/spec.md
+++ b/openspec/changes/add-matchmaking-and-spectator/specs/multiplayer-matchmaking/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Joinable-Lobby Query
+
+The system SHALL provide a query over the durable match store that returns every match in `status: 'lobby'` with at least one open `kind: 'human'` seat. Each result SHALL be projected to a compact shape carrying the match id, room code, layout, host display name, and a seat-occupancy summary. Matches that have transitioned out of `status: 'lobby'` SHALL NOT be returned.
+
+#### Scenario: Open lobby is listed
+
+- **GIVEN** a match in `status: 'lobby'` with one occupied and one open human seat
+- **WHEN** the joinable-lobby query runs
+- **THEN** the match SHALL be returned with its layout, host display name, and seat-occupancy summary
+
+#### Scenario: Full lobby is excluded
+
+- **GIVEN** a match in `status: 'lobby'` whose every human seat is occupied
+- **WHEN** the joinable-lobby query runs
+- **THEN** the match SHALL NOT be returned
+
+#### Scenario: Launched match is excluded
+
+- **GIVEN** a match that has transitioned to `status: 'active'`
+- **WHEN** the joinable-lobby query runs
+- **THEN** the match SHALL NOT be returned
+
+### Requirement: Joinable-Lobby Endpoint
+
+The system SHALL expose an authenticated REST endpoint that returns the joinable-lobby query result. The endpoint SHALL require a valid player token, consistent with the other multiplayer endpoints.
+
+#### Scenario: Authenticated request returns lobbies
+
+- **GIVEN** a client with a valid player token
+- **WHEN** the client requests the joinable-lobby endpoint
+- **THEN** the response SHALL contain the joinable-lobby projection
+
+#### Scenario: Unauthenticated request rejected
+
+- **GIVEN** a client with no player token
+- **WHEN** the client requests the joinable-lobby endpoint
+- **THEN** the response SHALL be `401 Unauthorized`
+
+### Requirement: Match Browser
+
+The system SHALL render a match browser on the multiplayer hub listing joinable lobbies with their layout, host, and seat occupancy. The browser SHALL refresh on an interval and on an explicit user refresh, and SHALL offer a one-click join per row.
+
+#### Scenario: Browser lists joinable lobbies
+
+- **GIVEN** the joinable-lobby endpoint returns two open lobbies
+- **WHEN** the match browser renders
+- **THEN** both lobbies SHALL be shown with their layout, host, and seat occupancy
+
+#### Scenario: One-click join navigates into the lobby
+
+- **GIVEN** a match browser row for a joinable lobby
+- **WHEN** the player clicks "Join" on that row
+- **THEN** the player SHALL be navigated to `/multiplayer/lobby/[roomCode]` for that lobby
+
+#### Scenario: Browser reflects lobby lifecycle changes
+
+- **GIVEN** a match browser showing an open lobby
+- **WHEN** that lobby fills up or launches and the browser refreshes
+- **THEN** the lobby SHALL no longer appear in the list
+
+#### Scenario: Empty browser state
+
+- **GIVEN** the joinable-lobby endpoint returns no lobbies
+- **WHEN** the match browser renders
+- **THEN** the browser SHALL show an empty state rather than an error

--- a/openspec/changes/add-matchmaking-and-spectator/specs/multiplayer-server/spec.md
+++ b/openspec/changes/add-matchmaking-and-spectator/specs/multiplayer-server/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Spectator Seat Kind
+
+The system SHALL support a third seat `kind`, `'spectator'`, alongside `'human'` and `'ai'`. A spectator seat SHALL own no game units, SHALL be excluded from side assignment, SHALL be excluded from the readiness gate, and SHALL NOT count toward a layout's player-seat budget. A spectator seat SHALL be occupied by an authenticated player id bound at WebSocket-upgrade time.
+
+#### Scenario: Spectator seat owns no units
+
+- **GIVEN** a match with a `kind: 'spectator'` seat occupied by a player
+- **WHEN** side assignment is computed at launch
+- **THEN** the spectator seat SHALL receive no game units
+- **AND** the spectator SHALL NOT be recorded as a match participant
+
+#### Scenario: Spectator seat does not block launch
+
+- **GIVEN** a match whose human seats are all occupied and ready and which also has a spectator seat
+- **WHEN** the host sends `LaunchMatch`
+- **THEN** the readiness gate SHALL ignore the spectator seat
+- **AND** the match SHALL launch
+
+#### Scenario: Spectator does not consume a player slot
+
+- **GIVEN** a `1v1` match with two human seats and one spectator seat
+- **WHEN** the seat roster is inspected
+- **THEN** the layout SHALL still have exactly two human-playable seats
+
+### Requirement: Spectator Connection
+
+The system SHALL allow a `spectator`-kind seat to connect to an `active` match over the existing WebSocket. The spectator SHALL receive the replay history followed by live events exactly as a player does, and the server SHALL reject any `Intent` originating from a `spectator`-kind seat.
+
+#### Scenario: Spectator joins and receives the stream
+
+- **GIVEN** an active match and a spectator connecting with `SessionJoin`
+- **WHEN** the server handles the join
+- **THEN** the server SHALL stream the replay via `ReplayStart`, `ReplayChunk`, and `ReplayEnd`
+- **AND** the spectator SHALL then receive live `Event` messages
+
+#### Scenario: Spectator intent rejected
+
+- **GIVEN** a connected spectator
+- **WHEN** the spectator sends an `Intent` envelope
+- **THEN** the server SHALL reply `Error {code: 'INVALID_INTENT', reason: 'spectator-cannot-act'}`
+- **AND** no event SHALL be appended
+
+### Requirement: Spectator Fog-of-War Scope
+
+The server SHALL treat a spectator as a distinct fog audience. In a fog-on match a spectator SHALL receive only the most-redacted view — never more information than the least-informed participant — so spectating cannot reveal a unit hidden from a player. In a fog-off match a spectator SHALL receive the full unredacted event stream.
+
+#### Scenario: Spectator of a fog-on match sees no hidden units
+
+- **GIVEN** a fog-on match with a unit hidden from one participant
+- **WHEN** the server broadcasts events to a connected spectator
+- **THEN** the spectator SHALL NOT receive an event revealing a unit that is hidden from a participant
+
+#### Scenario: Spectator of a fog-off match sees everything
+
+- **GIVEN** a match with `config.fogOfWar: false` and a connected spectator
+- **WHEN** the server broadcasts an event
+- **THEN** the spectator SHALL receive the identical unredacted event

--- a/openspec/changes/add-matchmaking-and-spectator/tasks.md
+++ b/openspec/changes/add-matchmaking-and-spectator/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: Add Matchmaking and Spectator Support
+
+## 1. Joinable-Lobby Query
+
+- [ ] 1.1 Add a `getJoinableLobbies()` query over the durable match store returning matches in `status: 'lobby'` with at least one open human seat
+- [ ] 1.2 Project each result to a compact shape: match id, room code, layout, host display name, seat-occupancy summary
+- [ ] 1.3 Exclude matches that have transitioned out of `status: 'lobby'`
+- [ ] 1.4 Tests: only joinable lobbies are returned; a full lobby and a launched match are excluded
+
+## 2. Joinable-Lobby Endpoint
+
+- [ ] 2.1 Add a REST route under `src/pages/api/multiplayer/` that returns the `getJoinableLobbies()` result, authenticated like the other multiplayer endpoints
+- [ ] 2.2 Tests: the route returns the joinable-lobby projection; an unauthenticated request is rejected `401`
+
+## 3. Match Browser Surface
+
+- [ ] 3.1 Add a match-browser component under `src/components/multiplayer/` rendering the joinable-lobby list with layout, host, and seat occupancy
+- [ ] 3.2 Mount the browser on the multiplayer hub (`src/pages/multiplayer/index.tsx`)
+- [ ] 3.3 Refresh the list on an interval and on an explicit user refresh
+- [ ] 3.4 Add a one-click "Join" per row that navigates to `/multiplayer/lobby/[roomCode]`, reusing the existing room-code path
+- [ ] 3.5 Storybook story covering populated, empty, and refreshing states
+
+## 4. Spectator Seat Kind
+
+- [ ] 4.1 Extend the seat-model `kind` union in `src/types/multiplayer/Lobby.ts` with `'spectator'`
+- [ ] 4.2 Exclude `spectator` seats from side assignment and from `recordMatchParticipation`
+- [ ] 4.3 Exclude `spectator` seats from the readiness gate (`canLaunch`) and from the layout player-seat budget
+- [ ] 4.4 Tests: a match with spectator seats launches with exactly its human seats ready; a spectator seat owns no units and produces no participation record
+
+## 5. Spectator Connection
+
+- [ ] 5.1 Allow a `spectator`-kind seat to connect over the existing WebSocket via `SessionJoin`, bound to the authenticated player id at upgrade time
+- [ ] 5.2 Stream the replay history then live events to the spectator exactly as for a player
+- [ ] 5.3 Reject any `Intent` from a `spectator`-kind seat as unauthorized
+- [ ] 5.4 Tests: a spectator receives the replay then live events; a spectator intent is rejected with no event appended
+
+## 6. Spectator Fog-of-War Scope
+
+- [ ] 6.1 Define the spectator as a distinct fog audience receiving the most-redacted view — never more than the least-informed participant
+- [ ] 6.2 In a fog-off match a spectator receives the full unredacted stream
+- [ ] 6.3 Tests: a spectator of a fog-on match never receives an event about a unit hidden from a participant; a fog-off spectator receives every event
+
+## 7. Spectator Surface
+
+- [ ] 7.1 Render the spectator view by reusing M1's `NetworkedGameSurface` with intent-emit controls disabled
+- [ ] 7.2 Show a spectator indicator so the observer knows they are watching, not playing
+- [ ] 7.3 Tests: the spectator surface renders the mirror session and exposes no movement, attack, phase, or concede controls
+
+## 8. Verification
+
+- [ ] 8.1 Integration test: a player discovers a lobby in the browser, joins it, and the match launches and plays
+- [ ] 8.2 Integration test: a spectator connects to an active fog-on match and observes it without receiving hidden-unit events
+- [ ] 8.3 `openspec validate add-matchmaking-and-spectator --strict` passes
+- [ ] 8.4 `npm run build`, lint, and `tsc --noEmit` typecheck all pass

--- a/openspec/changes/add-procedural-map-variety/design.md
+++ b/openspec/changes/add-procedural-map-variety/design.md
@@ -1,0 +1,82 @@
+# Design: Add Procedural Map Variety
+
+## Context
+
+The `terrain-generation` spec defines a complete Perlin-noise pipeline: seeded RNG, octave noise, biome weights, elevation, and weighted terrain selection. It is deterministic and correct — but it is also the *only* input to a generated map. The map-preset system (`mapPresets.ts`) was built to vary maps by scenario, yet `generateTerrain()` never reads it. This change closes that gap without disturbing the existing pipeline: presets become a deterministic overlay applied after base generation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the 17 existing presets actually shape generated terrain.
+- Keep generation fully deterministic and seed-reproducible.
+- Leave the 13 existing `terrain-generation` requirements intact — this change is purely additive.
+
+**Non-Goals:**
+
+- New terrain types, dynamic terrain, imported boards, biome-weight changes.
+
+## Decisions
+
+### D1. The feature pass is an overlay, not a replacement
+
+Base biome generation runs unchanged and produces the grid exactly as today. The feature pass then takes that grid and stamps clustered features onto a copy. Every existing `terrain-generation` requirement (biome weights, elevation, determinism, distribution accuracy) still holds for the base pass; the feature pass is described entirely by new ADDED requirements.
+
+### D2. `presetFeatures` directive shape
+
+```typescript
+interface IFeatureDirective {
+  readonly type: TerrainType;   // Woods, Water, Building, Road, Pavement, Rough, ...
+  readonly density: number;     // target fraction of grid hexes [0, 1]
+  readonly clusterSize: number; // mean cluster radius in hexes
+}
+
+interface TerrainGeneratorConfig {
+  // ...existing width, height, biome, seed
+  readonly presetFeatures?: readonly IFeatureDirective[];
+}
+```
+
+When `presetFeatures` is omitted, generation is byte-identical to current behavior.
+
+### D3. Deterministic clustering algorithm
+
+For each directive: derive `K = ceil(density × hexCount / max(1, clusterSize²))` cluster origins by drawing hex coordinates from the seeded RNG; grow each origin via seeded flood-fill to roughly `clusterSize` hexes. The RNG used is the same `SeededRandom` already specified by `terrain-generation`, advanced past the base pass — so the whole map (base + features) is one deterministic function of the seed.
+
+### D4. Structure placement
+
+- **Buildings** — stamped as rectangular footprints of 1–4 hexes at seeded positions.
+- **Roads** — a path traced between two map edges (seeded edge pair); hexes along the path are set to `Road`.
+- **Pavement** — every hex orthogonally adjacent to a `Building` hex that is still natural terrain becomes `Pavement`.
+
+### D5. Fixed application order
+
+Directives are applied in a fixed order regardless of input order: natural features (Woods, Water, Rough) first, then `Building`, then `Road`, then `Pavement` auto-fill. Structures override natural terrain. The fixed order guarantees determinism independent of how the preset lists its features.
+
+### D6. Preset → directive mapping
+
+`IMapPreset.features` already carries `{ type, density, clusterSize }`-shaped entries. The change maps `IMapPreset.features` directly to `IFeatureDirective[]` and passes `selectMapPreset()`'s output into `generateTerrain` from both scenario-generation entry points (`ScenarioGeneratorService`, `ScenarioGenerator`).
+
+### D7. Distinctness invariant
+
+Verified by tests that build a terrain-type histogram for two different presets at the same seed and biome and assert the histograms differ beyond a tolerance. This is the regression guard that the presets are genuinely consumed.
+
+### D8. `presetId` recorded on the generated map
+
+The generated map records the originating `presetId` for replay and debugging. Optional and additive.
+
+## Risks / Trade-offs
+
+- **[Risk] The feature pass perturbs `terrain-generation`'s distribution-accuracy requirement** → Mitigation: the distribution-accuracy scenarios measure the *base* pass; the feature pass is governed by its own density tolerance requirement. They are independent and both verifiable.
+- **[Risk] Road tracing fails to connect on tiny grids** → Mitigation: on grids too small to trace a path the directive is skipped without error; covered by an edge-case scenario.
+- **[Risk] Buildings overrunning the deployment zones used by `scenario-objectives`** → Mitigation: structure placement avoids deployment-zone hexes when the config supplies them; otherwise placement is unconstrained (skirmish maps).
+- **[Risk] Determinism drift if directives are applied in list order** → Mitigation: fixed application order (D5).
+
+## Migration Plan
+
+Purely additive. `presetFeatures` is optional — every existing `generateTerrain` call without it produces identical output. No new event types, no database migrations. Rollback = revert the change-set; presets return to being dead code.
+
+## Open Questions
+
+- Whether `density` should be measured against total hexes or against non-structure hexes — proposed: total hexes, for predictability.
+- Whether road count should scale with map size — proposed: one road per preset directive for now; revisit if large maps look sparse.

--- a/openspec/changes/add-procedural-map-variety/proposal.md
+++ b/openspec/changes/add-procedural-map-variety/proposal.md
@@ -1,0 +1,35 @@
+# Change: Add Procedural Map Variety
+
+## Why
+
+`src/constants/scenario/mapPresets.ts` defines 17 map presets (`LIGHT_FOREST`, `DENSE_FOREST`, `INDUSTRIAL_COMPLEX`, `OPEN_PLAINS`, …) each declaring terrain-feature density and cluster-size configs. `generateTerrain()` ignores them entirely — `TerrainGeneratorConfig` accepts only `width`, `height`, `biome`, and `seed`, and terrain selection runs purely on the hardcoded `BIOME_WEIGHTS`. Every "procedurally generated" map of a given biome is therefore statistically identical, and the 17 presets are dead code.
+
+This change wires preset feature directives into the generator as a post-pass overlay so generated battle maps actually differ — clustered woods, building blocks, road networks — making "scenarios fully generated on a battle map" deliver genuinely varied terrain.
+
+## What Changes
+
+- ADDED `presetFeatures` on `TerrainGeneratorConfig`: an ordered list of feature-placement directives (feature type, density, cluster size)
+- ADDED a feature-application pass that runs after base biome generation and overlays clustered features deterministically
+- ADDED a feature-clustering algorithm: seeded cluster origins grown to a target cluster size, entirely from the generation seed
+- ADDED structure placement: buildings as footprint blocks, roads as connected paths between two map edges, pavement auto-filled around buildings
+- ADDED a preset-distinctness guarantee: two different presets at the same seed and biome SHALL produce measurably different terrain distributions
+
+## Dependencies
+
+- **Requires**: `terrain-generation` (existing source-of-truth — this change adds requirements to it)
+- **Requires**: `terrain-system` (the `TerrainType` enum — `Building`, `Road`, `Pavement`, `Rubble` already defined)
+- **Required By**: none
+
+## Impact
+
+- Affected specs: `terrain-generation` (added requirements)
+- Affected code: `src/utils/gameplay/terrainGenerator.ts`, `src/services/generators/ScenarioGeneratorService.ts`, `src/simulation/generator/ScenarioGenerator.ts`, `src/constants/scenario/mapPresets.ts` (presets become consumed rather than dead)
+- No new event types; no database migrations
+- Reproducibility preserved: feature placement is fully seeded — identical seed + preset yields identical maps, so multiplayer map sync still requires no terrain transmission
+
+## Non-Goals
+
+- New terrain types — works with the existing `TerrainType` enum only
+- Real-time terrain modification (fire spread, building collapse) — out of scope per the `terrain-generation` spec
+- Hand-authored or imported MegaMek board files — procedural generation only
+- Biome weight rebalancing — base biome generation and `BIOME_WEIGHTS` are unchanged

--- a/openspec/changes/add-procedural-map-variety/specs/terrain-generation/spec.md
+++ b/openspec/changes/add-procedural-map-variety/specs/terrain-generation/spec.md
@@ -1,0 +1,97 @@
+## ADDED Requirements
+
+### Requirement: Preset Feature Directives
+
+`TerrainGeneratorConfig` SHALL accept an optional `presetFeatures` field — an ordered list of `IFeatureDirective` records, each specifying a `type` (`TerrainType`), a `density` (target fraction of grid hexes, `[0, 1]`), and a `clusterSize` (mean cluster radius in hexes). When `presetFeatures` is omitted or empty, `generateTerrain` SHALL produce output identical to base biome generation.
+
+#### Scenario: Generation without presetFeatures is unchanged
+
+- **GIVEN** a `TerrainGeneratorConfig` with no `presetFeatures` field
+- **WHEN** `generateTerrain` runs
+- **THEN** the resulting grid SHALL be identical to the grid produced by base biome generation for the same width, height, biome, and seed
+
+#### Scenario: Directives are accepted and applied
+
+- **GIVEN** a `TerrainGeneratorConfig` with a `presetFeatures` directive for `HeavyWoods` at density `0.3`
+- **WHEN** `generateTerrain` runs
+- **THEN** the resulting grid SHALL contain `HeavyWoods` hexes
+- **AND** the `HeavyWoods` fraction SHALL be within tolerance of `0.3`
+
+### Requirement: Deterministic Feature Clustering
+
+The feature-application pass SHALL place each directive's hexes as clusters: cluster origins SHALL be drawn from the same seeded RNG used by base generation, and each origin SHALL be grown by seeded flood-fill to approximately `clusterSize` hexes. The full generated map — base pass plus feature pass — SHALL be a deterministic function of the seed.
+
+#### Scenario: Identical seed yields identical clustered map
+
+- **GIVEN** two `generateTerrain` calls with identical width, height, biome, seed, and `presetFeatures`
+- **WHEN** both complete
+- **THEN** the two grids SHALL be identical hex for hex, including all feature placements
+
+#### Scenario: Different seed yields different feature placement
+
+- **GIVEN** two `generateTerrain` calls identical except for the seed
+- **WHEN** both complete with the same `presetFeatures`
+- **THEN** at least some feature hexes SHALL be placed at different coordinates
+
+#### Scenario: Features form clusters, not uniform noise
+
+- **GIVEN** a directive with `clusterSize = 4` and density `0.25`
+- **WHEN** `generateTerrain` runs
+- **THEN** the directive's hexes SHALL be grouped into contiguous clusters rather than scattered uniformly across the grid
+
+### Requirement: Feature Application Pass
+
+The feature-application pass SHALL run after base biome generation and overlay directive features onto the generated grid. Directives SHALL be applied in a fixed order independent of their order in `presetFeatures` — natural features (`Woods`, `Water`, `Rough`) first, then `Building`, then `Road`, then `Pavement` auto-fill — so that structures override natural terrain deterministically.
+
+#### Scenario: Structures override natural terrain
+
+- **GIVEN** a `presetFeatures` list containing both a `HeavyWoods` directive and a `Building` directive whose clusters would overlap
+- **WHEN** `generateTerrain` runs
+- **THEN** hexes in the overlap region SHALL be `Building`, not `HeavyWoods`
+
+#### Scenario: Application order is independent of directive order
+
+- **GIVEN** two configs with the same directives listed in different orders
+- **WHEN** both run with the same seed
+- **THEN** the two grids SHALL be identical
+
+### Requirement: Structure Placement
+
+The feature-application pass SHALL place structural terrain so that generated maps contain coherent built environments. `Building` directives SHALL stamp rectangular footprints of 1–4 hexes. `Road` directives SHALL trace a connected path of `Road` hexes between two map edges. `Pavement` SHALL auto-fill natural hexes orthogonally adjacent to `Building` hexes. On a grid too small to trace a road, the `Road` directive SHALL be skipped without error.
+
+#### Scenario: Industrial preset produces buildings and roads
+
+- **GIVEN** a generation config using the `INDUSTRIAL_COMPLEX` preset's directives
+- **WHEN** `generateTerrain` runs
+- **THEN** the grid SHALL contain `Building` hexes grouped as footprints
+- **AND** the grid SHALL contain a connected run of `Road` hexes reaching two map edges
+
+#### Scenario: Pavement surrounds buildings
+
+- **GIVEN** a generated grid containing `Building` hexes
+- **WHEN** structure placement completes
+- **THEN** natural hexes orthogonally adjacent to a `Building` hex SHALL be `Pavement`
+
+#### Scenario: Road tracing skipped on a tiny grid
+
+- **GIVEN** a 2×2 generation grid with a `Road` directive
+- **WHEN** `generateTerrain` runs
+- **THEN** generation SHALL complete without error
+- **AND** the `Road` directive SHALL be skipped
+
+### Requirement: Preset Map Distinctness
+
+Two different presets generated at the same seed, width, height, and biome SHALL produce measurably different terrain. A terrain-type histogram of one preset's grid SHALL differ from the other's beyond a defined tolerance, so that no two distinct presets yield statistically identical maps.
+
+#### Scenario: Sparse and dense forest presets differ
+
+- **GIVEN** the `LIGHT_FOREST` and `DENSE_FOREST` presets generated at the same seed, dimensions, and biome
+- **WHEN** both grids are generated
+- **THEN** their `LightWoods` + `HeavyWoods` hex fractions SHALL differ beyond tolerance
+
+#### Scenario: Open and industrial presets differ
+
+- **GIVEN** the `OPEN_PLAINS` and `INDUSTRIAL_COMPLEX` presets generated at the same seed, dimensions, and biome
+- **WHEN** both grids are generated
+- **THEN** their terrain-type histograms SHALL differ beyond tolerance
+- **AND** only the `INDUSTRIAL_COMPLEX` grid SHALL contain `Building` hexes

--- a/openspec/changes/add-procedural-map-variety/tasks.md
+++ b/openspec/changes/add-procedural-map-variety/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: Add Procedural Map Variety
+
+## 1. Config and Directive Types
+
+- [ ] 1.1 Add `IFeatureDirective` and an optional `presetFeatures` field to `TerrainGeneratorConfig` in `src/utils/gameplay/terrainGenerator.ts`
+- [ ] 1.2 Map `IMapPreset.features` to `IFeatureDirective[]`; confirm all 17 presets in `mapPresets.ts` map without loss
+- [ ] 1.3 Tests for the directive type and full preset-mapping coverage
+
+## 2. Deterministic Feature Clustering
+
+- [ ] 2.1 Implement seeded cluster-origin derivation (`K` origins drawn from the generation `SeededRandom`)
+- [ ] 2.2 Implement seeded flood-fill cluster growth to the target `clusterSize`
+- [ ] 2.3 Tests: same seed yields identical clusters; different seed yields different clusters; realized density is within tolerance of the directive
+
+## 3. Feature Application Pass
+
+- [ ] 3.1 Implement `applyPresetFeatures(grid, directives, rng)` as an overlay run after base biome generation
+- [ ] 3.2 Apply directives in the fixed order — natural features, then buildings, then roads, then pavement auto-fill
+- [ ] 3.3 Tests: the base biome generation requirements still hold; the overlay is deterministic; omitting `presetFeatures` yields output identical to base generation
+
+## 4. Structure Placement
+
+- [ ] 4.1 Implement building footprint stamping (rectangular 1–4 hex blocks at seeded positions)
+- [ ] 4.2 Implement road path tracing between a seeded pair of map edges
+- [ ] 4.3 Implement pavement auto-fill on natural hexes orthogonally adjacent to building hexes
+- [ ] 4.4 Tests: buildings, roads, and pavement appear for the industrial and urban presets; a traced road connects edge to edge; tiny grids skip road tracing without error
+
+## 5. Generator Wiring
+
+- [ ] 5.1 Pass `selectMapPreset()` output into `generateTerrain` from `ScenarioGeneratorService` and `ScenarioGenerator`
+- [ ] 5.2 Record the originating `presetId` on the generated map
+- [ ] 5.3 Tests: scenario generation consumes the selected preset; `presetId` round-trips through serialization
+
+## 6. Distinctness and Verification
+
+- [ ] 6.1 Distinctness test: `LIGHT_FOREST` vs `DENSE_FOREST` at the same seed produce terrain histograms differing beyond tolerance
+- [ ] 6.2 Distinctness test: `OPEN_PLAINS` vs `INDUSTRIAL_COMPLEX` at the same seed produce terrain histograms differing beyond tolerance
+- [ ] 6.3 `openspec validate --strict` clean; build, lint, and typecheck pass

--- a/openspec/changes/add-scenario-objective-engine/design.md
+++ b/openspec/changes/add-scenario-objective-engine/design.md
@@ -1,0 +1,96 @@
+# Design: Add Scenario Objective Engine
+
+## Context
+
+The combat engine is otherwise complete for a standard skirmish — the six-phase loop, damage resolution, and the typed event log all work. The single gap blocking "play a fully generated scenario" is that victory is hardcoded to destruction. The scenario layer already declares objective *types* (`ScenarioObjectiveType`) and victory *conditions* (`IVictoryCondition`), but neither the map nor the game-over check carries any spatial objective data. This change supplies the missing middle: a spatial objective model, placement, control detection, and victory evaluation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `Capture`, `Defend`, and `Breakthrough` scenarios winnable end-to-end.
+- Express `Destroy` through the same objective engine so the game-over check has one uniform path.
+- Keep objective evaluation deterministic — a pure function of seed and unit positions.
+- Render objectives on the tactical map so a human player can see what to do.
+
+**Non-Goals:**
+
+- `Escort` / `Recon` objective types (separate lifecycle mechanics).
+- Multi-stage objectives, campaign rewards, AI objective-seeking.
+
+## Decisions
+
+### D1. Objective markers live on the game session, not on `IHex`
+
+`IHex` (`{ q, r, elevation, terrainType, features[] }`) is shared by terrain generation, the hex-coordinate system, and rendering. Adding objective fields would couple scenario logic into the hex primitive. Instead the session carries `objectives: Record<HexKey, IObjectiveMarker>` where `HexKey` is the canonical `"q,r"` string. Markerless sessions (`{}`) behave exactly as today.
+
+### D2. `IObjectiveMarker` shape
+
+```typescript
+type HexKey = string; // "q,r"
+
+interface IObjectiveMarker {
+  readonly id: string;
+  readonly hexKey: HexKey;
+  readonly objectiveType: 'capture' | 'defend' | 'breakthrough';
+  readonly owningSide: GameSide | 'neutral';   // initial controller
+  readonly controlSide: GameSide | 'neutral';  // current controller (mutable via reducer)
+  readonly controlRule: 'sole-occupancy';
+  readonly holdTurnsRequired: number;          // consecutive turns to win (Capture)
+  readonly holdProgress: number;               // consecutive turns currently held
+}
+```
+
+### D3. Control rule is sole-occupancy, sticky on contest
+
+A side controls a hex when it has ≥1 unit on that hex and the opposing side has 0. If both sides have units on the hex it is *contested* — `controlSide` is unchanged (sticky to the last controller). A vacated hex also keeps its last controller. This avoids per-turn flip-flop and is deterministic.
+
+### D4. Victory evaluation is one pure function consulted before the destruction fallback
+
+`evaluateObjectiveOutcome(session): IObjectiveOutcome | null` returns `null` while the scenario is undecided. The game-over check calls it first; only if it returns `null` does the existing destruction / turn-limit logic run. This keeps the change additive.
+
+### D5. Per-objective-type resolution
+
+- **Destroy** — the markerless default: a side wins when all enemy units are destroyed or withdrawn. Equivalent to current behavior, routed through the objective engine for uniformity.
+- **Capture** — the attacking side wins when it holds *all* objective hexes for `holdTurnsRequired` consecutive turns (`holdProgress` resets to 0 on any loss of control).
+- **Defend** — the defending side wins if it still controls the objective hex(es) at `turnLimit`; the attacker wins immediately on capturing them.
+- **Breakthrough** — objective markers are exit-edge hexes; the attacking side wins when `requiredUnits` of its units have reached an exit hex.
+
+### D6. Rendering — a dedicated SVG layer
+
+`ObjectiveMarkersLayer` is added to `HexMapDisplay.layers`, rendered above the terrain overlay and below unit tokens. Markers are styled by `controlSide` (neutral / friendly / enemy / contested). The layer is read-only — it never mutates state.
+
+### D7. Lifecycle events are derived, not authored
+
+The control-detection pass runs once per turn. When `controlSide` changes it emits `ObjectiveCaptured` / `ObjectiveLost`; when `holdProgress` changes it emits `ObjectiveProgress`. All three are deterministic functions of unit positions, so the event log fully replays objective state.
+
+### D8. Type contracts
+
+```typescript
+interface IObjectiveOutcome {
+  readonly decided: true;
+  readonly winningSide: GameSide;
+  readonly reason: 'objective';
+  readonly objectiveType: ScenarioObjectiveType;
+}
+
+GameEventType.ObjectiveCaptured  = 'ObjectiveCaptured';
+GameEventType.ObjectiveLost      = 'ObjectiveLost';
+GameEventType.ObjectiveProgress  = 'ObjectiveProgress';
+```
+
+## Risks / Trade-offs
+
+- **[Risk] Contested-hex flip-flop** → Mitigation: sticky control (D3) — control only changes on uncontested sole occupancy.
+- **[Risk] Breakthrough exit hexes overlap retreat edges (Change 3)** → Mitigation: breakthrough exit hexes are explicit `IObjectiveMarker`s; retreat/withdrawal edge logic is separate and never consults the objective map.
+- **[Risk] Objective outcome vs. turn-limit draw** → Mitigation: `evaluateObjectiveOutcome` is consulted first; an objective win always takes precedence over a turn-limit draw.
+- **[Risk] A scenario with no objective markers but a non-`destroy` type** → Mitigation: placement (task 2) guarantees a non-empty objective map for capture/defend/breakthrough; the evaluator treats an empty map as `destroy`.
+
+## Migration Plan
+
+Purely additive. Existing scenarios carry no `objectives` map, so `evaluateObjectiveOutcome` returns `null` and the current destruction path runs unchanged. New event types are additive — existing consumers ignore unknown events. No database migrations. Rollback = revert the change-set; the unused objective-type enum reverts to inert.
+
+## Open Questions
+
+- Default `holdTurnsRequired` for generated Capture scenarios — proposed `1` (control at end of a turn = captured). Revisit if matches end too quickly.
+- Whether neutral objectives may begin owned by a side — proposed: generated scenarios start all markers `neutral`; campaign scenarios (Wave 4) may pre-assign.

--- a/openspec/changes/add-scenario-objective-engine/proposal.md
+++ b/openspec/changes/add-scenario-objective-engine/proposal.md
@@ -1,0 +1,36 @@
+# Change: Add Scenario Objective Engine
+
+## Why
+
+Generated combat scenarios can only be won by total destruction. `ScenarioObjectiveType` (`destroy`, `capture`, `defend`, `escort`, `recon`, `breakthrough`) is declared in `src/types/scenario/ScenarioInterfaces.ts`, and `IVictoryCondition` exists in the `encounter-system` spec, but `determineWinner()` / `isGameOver()` only ever count surviving units (`src/services/game-resolution/GameOutcomeCalculator.ts`, `src/simulation/runner/SimulationRunnerState.ts`). Capture / Defend / Breakthrough are unwinnable because there is no spatial objective concept: `IHex` carries no objective data, `HexMapDisplay` has no objective layer, and `ScenarioGenerator` never places objective hexes.
+
+This change builds the objective-hex spatial system — placement, control detection, victory evaluation, rendering, and event logging — for the hex-based core objective types, so a procedurally generated scenario can actually be played to a non-destruction outcome.
+
+## What Changes
+
+- ADDED objective-marker data model: `IObjectiveMarker` keyed by hex coordinate (`"q,r"`), carried on the game session as a separate objective map — `IHex` stays unchanged
+- ADDED objective placement during scenario generation: `ScenarioGenerator` places objective hexes appropriate to the scenario's objective type and deployment zones, seeded for determinism
+- ADDED objective control detection: a side controls an objective hex under a sole-occupancy rule; contested hexes stay with the last controller
+- ADDED objective-based victory evaluation wired into the game-over check for `Destroy`, `Capture`, `Defend`, and `Breakthrough`
+- ADDED an objective-marker render layer in `HexMapDisplay` (`ObjectiveMarkersLayer`) with control-state styling
+- ADDED objective lifecycle events (`ObjectiveCaptured`, `ObjectiveLost`, `ObjectiveProgress`) appended to the typed event log
+
+## Dependencies
+
+- **Requires**: `encounter-system` (`IVictoryCondition`) and `scenario-generation` (objective-type enum, deployment zones) — both already source-of-truth
+- **Required By**: Wave 2 AI change `ai-coordination-and-objectives` (the AI must read objective markers to play the scenario, not just kill units)
+
+## Impact
+
+- Affected specs: `scenario-objectives` (new capability)
+- Affected code: `src/types/scenario/ScenarioInterfaces.ts`, `src/simulation/generator/ScenarioGenerator.ts`, `src/services/game-resolution/GameOutcomeCalculator.ts`, `src/simulation/runner/SimulationRunnerState.ts`, `src/utils/gameplay/gameSessionCore.ts` (game-over check), `src/components/gameplay/HexMapDisplay/` (new layer), `src/types/gameplay/GameSessionCoreTypes.ts` (new event types)
+- New event types: `ObjectiveCaptured`, `ObjectiveLost`, `ObjectiveProgress`
+- No database migrations — objective markers serialize with the game session
+- Reproducibility preserved: placement and control detection are deterministic functions of seed and unit positions
+
+## Non-Goals
+
+- `Escort` and `Recon` objective types — they need a protected-unit lifecycle and intel-hex reveal mechanics; deferred to a later change
+- Multi-stage / sequential objectives (capture A, then defend A) — single-objective evaluation only
+- Objective rewards / campaign salvage tie-in — campaign integration is Wave 4
+- AI objective-seeking behavior — the AI consuming markers is Wave 2

--- a/openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+++ b/openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
@@ -1,0 +1,141 @@
+## ADDED Requirements
+
+### Requirement: Objective Marker Data Model
+
+The system SHALL represent scenario objectives as `IObjectiveMarker` records keyed by hex coordinate, carried on the game session in an `objectives: Record<HexKey, IObjectiveMarker>` map. `HexKey` SHALL be the canonical `"q,r"` string. The `IHex` interface SHALL NOT be modified. A session with an empty objective map SHALL behave identically to a destruction-only scenario.
+
+Each marker SHALL carry: `id`, `hexKey`, `objectiveType` (`capture` | `defend` | `breakthrough`), `owningSide`, `controlSide`, `controlRule`, `holdTurnsRequired`, and `holdProgress`.
+
+#### Scenario: Markerless session resolves as destruction
+
+- **GIVEN** a game session whose `objectives` map is empty
+- **WHEN** the objective outcome is evaluated
+- **THEN** the evaluator SHALL treat the scenario as objective type `destroy`
+- **AND** victory SHALL be decided by unit elimination as before
+
+#### Scenario: Objective map survives serialization
+
+- **GIVEN** a game session carrying three `IObjectiveMarker` records
+- **WHEN** the session is serialized and deserialized
+- **THEN** all three markers SHALL be present with identical `controlSide` and `holdProgress` values
+
+### Requirement: Objective Placement During Scenario Generation
+
+`ScenarioGenerator` SHALL place objective hexes appropriate to the scenario's objective type, deriving every placement from the scenario seed so generation stays deterministic.
+
+- `capture` scenarios SHALL place 1–3 objective hexes within the map interior.
+- `defend` scenarios SHALL place objective hexes inside the defender deployment zone.
+- `breakthrough` scenarios SHALL place exit-hex markers along the map edge opposite the attacker deployment zone.
+
+A generated `capture`, `defend`, or `breakthrough` scenario SHALL always produce a non-empty objective map.
+
+#### Scenario: Capture scenario places interior objectives
+
+- **GIVEN** a scenario generated with objective type `capture`
+- **WHEN** generation completes
+- **THEN** the objective map SHALL contain between 1 and 3 markers
+- **AND** every marker hex SHALL lie within the map bounds and outside both deployment zones
+
+#### Scenario: Placement is deterministic for a given seed
+
+- **GIVEN** two scenarios generated with the same seed, objective type, and map dimensions
+- **WHEN** both complete generation
+- **THEN** their objective maps SHALL contain identical marker hex coordinates
+
+#### Scenario: Breakthrough places exit hexes opposite the attacker
+
+- **GIVEN** a `breakthrough` scenario with the attacker deployed on the south edge
+- **WHEN** generation completes
+- **THEN** all objective markers SHALL lie on the north map edge
+
+### Requirement: Objective Control Detection
+
+The system SHALL determine which side controls each objective hex using a sole-occupancy rule evaluated once per turn. A side controls a hex when it has at least one unit on that hex and the opposing side has none. When both sides occupy a hex it is contested and `controlSide` SHALL remain unchanged. When a controlled hex is vacated, `controlSide` SHALL remain the last controlling side.
+
+`holdProgress` SHALL increment by 1 each turn the marker is controlled by the same side and SHALL reset to 0 whenever control is lost or contested.
+
+#### Scenario: Sole occupancy takes control
+
+- **GIVEN** a neutral objective hex with one attacker unit on it and no defender units
+- **WHEN** control detection runs at end of turn
+- **THEN** `controlSide` SHALL become the attacker side
+
+#### Scenario: Contested hex keeps the last controller
+
+- **GIVEN** an objective hex controlled by the attacker, now occupied by both an attacker unit and a defender unit
+- **WHEN** control detection runs
+- **THEN** `controlSide` SHALL remain the attacker side
+- **AND** `holdProgress` SHALL reset to 0
+
+#### Scenario: Vacated hex keeps the last controller
+
+- **GIVEN** an objective hex controlled by the defender, now occupied by no units
+- **WHEN** control detection runs
+- **THEN** `controlSide` SHALL remain the defender side
+
+### Requirement: Objective-Based Victory Evaluation
+
+The system SHALL provide `evaluateObjectiveOutcome(session)` that returns an `IObjectiveOutcome` when a scenario is decided and `null` while it is undecided. The game-over check SHALL consult this function before the destruction / turn-limit fallback, and an objective outcome SHALL take precedence over a turn-limit draw.
+
+- **Destroy**: a side wins when every enemy unit is destroyed or withdrawn.
+- **Capture**: the attacking side wins when it holds every objective hex for `holdTurnsRequired` consecutive turns.
+- **Defend**: the defending side wins if it still controls the objective hex(es) at `turnLimit`; the attacking side wins immediately upon controlling all objective hexes.
+- **Breakthrough**: the attacking side wins when `requiredUnits` of its units have reached an exit hex.
+
+#### Scenario: Capture decided by sustained hold
+
+- **GIVEN** a Capture scenario with one objective hex and `holdTurnsRequired = 2`
+- **WHEN** the attacker controls that hex at the end of two consecutive turns
+- **THEN** `evaluateObjectiveOutcome` SHALL return an outcome with `winningSide` = attacker and `reason` = `objective`
+
+#### Scenario: Capture progress resets on lost control
+
+- **GIVEN** a Capture scenario where the attacker held the objective for one turn, then lost control
+- **WHEN** control detection runs
+- **THEN** `holdProgress` SHALL reset to 0
+- **AND** `evaluateObjectiveOutcome` SHALL return `null`
+
+#### Scenario: Defend decided at the turn limit
+
+- **GIVEN** a Defend scenario reaching `turnLimit` with the defender still controlling the objective hex
+- **WHEN** the game-over check runs
+- **THEN** `evaluateObjectiveOutcome` SHALL return an outcome with `winningSide` = defender
+
+#### Scenario: Objective win overrides surviving units
+
+- **GIVEN** a Breakthrough scenario where the required number of attacker units have reached exit hexes while units of both sides remain alive
+- **WHEN** the game-over check runs
+- **THEN** the game SHALL end with the attacker as the winner
+- **AND** the destruction fallback SHALL NOT be consulted
+
+### Requirement: Objective Marker Rendering
+
+`HexMapDisplay` SHALL render an `ObjectiveMarkersLayer` showing every objective marker, positioned above the terrain overlay and below unit tokens. Each marker SHALL be styled according to its `controlSide` — neutral, friendly, enemy, or contested — and Capture markers SHALL display `holdProgress` toward `holdTurnsRequired`. The layer SHALL be read-only and SHALL NOT mutate game state.
+
+#### Scenario: Marker reflects control state
+
+- **GIVEN** a tactical map with one objective marker controlled by the player's side
+- **WHEN** the map renders
+- **THEN** the marker SHALL be drawn with the friendly control style
+
+#### Scenario: Contested marker is visually distinct
+
+- **GIVEN** an objective marker on a hex occupied by units of both sides
+- **WHEN** the map renders
+- **THEN** the marker SHALL be drawn with the contested style, distinct from neutral, friendly, and enemy
+
+### Requirement: Objective Lifecycle Events
+
+The control-detection pass SHALL append typed events to the game event log: `ObjectiveCaptured` when `controlSide` changes to a side, `ObjectiveLost` when a controlled marker becomes contested or neutral, and `ObjectiveProgress` when `holdProgress` changes. The events SHALL be deterministic functions of unit positions so that replaying the event log reconstructs objective state exactly.
+
+#### Scenario: Capture emits an ObjectiveCaptured event
+
+- **GIVEN** a neutral objective hex that an attacker unit moves onto alone
+- **WHEN** control detection runs at end of turn
+- **THEN** an `ObjectiveCaptured` event SHALL be appended recording the marker `id`, the capturing side, and the turn number
+
+#### Scenario: Event log replays objective state
+
+- **GIVEN** a completed match whose event log contains objective lifecycle events
+- **WHEN** the session is rebuilt by replaying the event log from the start
+- **THEN** every marker's `controlSide` and `holdProgress` SHALL match the values from the original match

--- a/openspec/changes/add-scenario-objective-engine/tasks.md
+++ b/openspec/changes/add-scenario-objective-engine/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: Add Scenario Objective Engine
+
+## 1. Objective Data Model
+
+- [ ] 1.1 Add `IObjectiveMarker`, `HexKey`, `ObjectiveControlRule`, and `IObjectiveOutcome` to `src/types/scenario/ScenarioInterfaces.ts`
+- [ ] 1.2 Add `objectives: Record<HexKey, IObjectiveMarker>` to the game-session state type in `src/types/gameplay/GameSessionCoreTypes.ts`, defaulting to `{}`
+- [ ] 1.3 Map each non-`destroy` `IVictoryCondition` onto objective config (hex count, `holdTurnsRequired`, `requiredUnits`)
+- [ ] 1.4 Unit tests for the new types and a session serialization round-trip preserving the objective map
+
+## 2. Objective Placement During Generation
+
+- [ ] 2.1 In `ScenarioGenerator`, place objective hexes per objective type — Capture: 1–3 interior hexes; Defend: hexes inside the defender deployment zone; Breakthrough: exit-edge hexes opposite the attacker deployment
+- [ ] 2.2 Seed placement from the scenario seed so identical seeds yield identical objective maps
+- [ ] 2.3 Tests: each objective type yields a valid non-empty objective map; same seed → identical placement; markers sit on in-bounds hexes
+
+## 3. Objective Control Detection
+
+- [ ] 3.1 Implement `detectObjectiveControl(marker, session)` — sole-occupancy rule, contested keeps the last controller
+- [ ] 3.2 Implement per-turn `holdProgress` advancement (increment while held, reset to 0 on loss of control)
+- [ ] 3.3 Tests: sole occupancy flips control; contested keeps last controller; a vacated hex keeps its last controller
+
+## 4. Objective Victory Evaluation
+
+- [ ] 4.1 Implement `evaluateObjectiveOutcome(session): IObjectiveOutcome | null` covering Destroy / Capture / Defend / Breakthrough
+- [ ] 4.2 Capture: attacker wins when it holds all objective hexes for `holdTurnsRequired` consecutive turns
+- [ ] 4.3 Defend: defender wins at `turnLimit` if still in control; attacker wins immediately on capturing all objective hexes
+- [ ] 4.4 Breakthrough: attacker wins when `requiredUnits` of its units have reached an exit hex
+- [ ] 4.5 Tests per objective type, including partial progress, control loss mid-hold, and timeout
+
+## 5. Game-Over Wiring
+
+- [ ] 5.1 Call `evaluateObjectiveOutcome` from the game-over check in `GameOutcomeCalculator` / `SimulationRunnerState` / `gameSessionCore` before the destruction fallback
+- [ ] 5.2 An objective outcome takes precedence over the turn-limit draw
+- [ ] 5.3 Tests: an objective win ends the game even with units alive on both sides; a markerless scenario still ends on destruction
+
+## 6. Objective Marker Rendering
+
+- [ ] 6.1 Add `ObjectiveMarkersLayer` to `HexMapDisplay.layers`, above the terrain overlay and below unit tokens
+- [ ] 6.2 Style markers by control state — neutral / friendly / enemy / contested — and show `holdProgress` for Capture
+- [ ] 6.3 Storybook story plus render tests for each control state
+
+## 7. Objective Lifecycle Events
+
+- [ ] 7.1 Add `ObjectiveCaptured`, `ObjectiveLost`, `ObjectiveProgress` to `GameEventType` with payloads
+- [ ] 7.2 Emit the events from the control-detection pass once per turn
+- [ ] 7.3 Tests: events are deterministic; replaying the event log reconstructs objective state
+
+## 8. Verification
+
+- [ ] 8.1 Integration test: a generated Capture scenario is won by holding the objective for the required turns
+- [ ] 8.2 Integration test: a generated Breakthrough scenario is won by moving the required units to the exit edge
+- [ ] 8.3 Integration test: a generated Defend scenario is won by the defender surviving to the turn limit in control
+- [ ] 8.4 `openspec validate --strict` clean; build, lint, and typecheck pass

--- a/openspec/changes/add-shared-campaign-state/design.md
+++ b/openspec/changes/add-shared-campaign-state/design.md
@@ -1,0 +1,136 @@
+# Design: Add Shared Campaign State
+
+## Context
+
+MekStation has two mature, *separate* sync surfaces today:
+
+1. **Per-match combat sync** — `ServerMatchHost` runs the authoritative `GameSession`; clients send intents, the host validates and resolves them in the engine, commits events to the `IMatchStore`, and broadcasts them. The guest runs a `mirrorSession` advanced only by host-broadcast events. This is server-authoritative and cheat-resistant.
+2. **Content vault sync** — `useSyncedVaultStore` uses a Yjs `Y.Map` over y-webrtc to share unit/pilot/force *designs* between peers. Last-writer-wins is fine here: two players editing the same unit design just converge.
+
+Co-op campaign needs a *third* surface, and it is **not** a variant of either. It is not per-match (it spans the whole campaign), and it is not vault content (it is a ledger). The roadmap initially slotted it under surface 2 — "extend the Yjs vault-sync". The Council's DP2 decision rejected that: a campaign is a transactional ledger and CRDT last-writer-wins silently corrupts ledgers. The correct model is surface 1's structure — `intent → validate → commit → broadcast` — lifted to the campaign tier.
+
+This change builds that third surface: the transport, the event log, and the guest mirror. It deliberately does **not** build the co-op gameplay on top; that is CO2.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give the campaign a server-authoritative event log: every ledger mutation is a typed, ordered, replayable event.
+- Make the host the single writer of campaign state and the guest a strict read-only mirror.
+- Reuse the `ServerMatchHostIntent` validate-commit-broadcast structure rather than inventing a new sync mechanism.
+- Reuse the `mirrorSession` "guest cannot append" guard contract for the campaign store.
+- Keep the financial invariant enforceable: every funds-affecting decision passes through one validation point that sees the authoritative balance.
+
+**Non-Goals:**
+
+- Co-op mission launch and the guest-facing GM intent UX (CO2).
+- Migrating or retiring the Yjs vault sync.
+- Multi-guest (3+ player) campaigns; campaign-tier host migration; offline campaign editing.
+
+## Decisions
+
+### D1. Campaign sync is server-authoritative, NOT CRDT — and this is load-bearing
+
+Campaign state is a ledger: a C-bill balance, an owned roster, accepted contracts, faction standing, a day counter. The defining invariant is *balance never goes negative without an explicit loan*. A CRDT guarantees that concurrent writes converge to *a* value — it cannot guarantee that value satisfies an invariant. Two guests each spending 500,000 C-bills from a 600,000 balance, merged by last-writer-wins, yield a 100,000 balance instead of the overdraft the second spend should have been rejected as.
+
+Therefore the campaign uses the same shape as `ServerMatchHost`: the host holds authoritative campaign state, a guest action is an **intent**, the host **validates** it against current state (balance check, standing check, roster check), and only on success **commits** a campaign event and **broadcasts** it. The guest never mutates campaign state directly. This decision is the whole reason CO1 exists as written; everything below follows from it.
+
+### D2. The campaign event log is the campaign-tier analogue of `IMatchStore`
+
+Combat sync persists an ordered, gap-free, typed event log via `IMatchStore` (`appendEvent` / `getEvents`, transactional append, ascending-sequence read). The campaign gets the same: an ordered, gap-free, typed `ICampaignEvent` log, appended on every committed mutation, persisted alongside the campaign save (through `add-campaign-persistence`'s store). Replaying the log from the start reconstructs campaign state exactly. The guest mirror is built by replay, never by merge.
+
+The campaign event log is a *separate* log from the per-match combat event log. A combat encounter inside a co-op campaign still produces a combat event log via `ServerMatchHost`; when that encounter resolves, the *campaign-level consequences* (salvage allocated, funds changed, roster updated) are emitted as campaign events into the campaign log. The two logs are linked by id, not merged.
+
+### D3. Campaign event payload set
+
+The events cover the ledger-mutating campaign decisions. Each is a typed, serializable record carrying the committed result (never a request):
+
+```typescript
+type CampaignEventType =
+  | 'CampaignDayAdvanced'        // day counter moved; carries the new day index
+  | 'FundsChanged'               // C-bill balance delta; carries delta, reason, new balance
+  | 'PilotHired'                 // a pilot joined the roster; carries pilot ref + cost
+  | 'ContractAccepted'           // a contract was accepted; carries contract ref + terms
+  | 'RosterUnitChanged'          // a unit was added/removed/repaired in the roster
+  | 'SalvageAllocated'           // post-battle salvage assigned to the campaign inventory
+  | 'CampaignSnapshotPublished'; // a full-state baseline for a joining or resyncing guest
+
+interface ICampaignEvent {
+  readonly type: CampaignEventType;
+  readonly sequence: number;       // ascending, gap-free, host-assigned
+  readonly campaignId: string;
+  readonly ts: string;             // host wall-clock ISO
+  readonly authorPlayerId: string; // who committed it (host id for host-driven events)
+  readonly payload: unknown;       // narrowed per type
+}
+```
+
+`FundsChanged` carries the resulting balance, not just the delta, so a guest that missed an event can detect a gap. `CampaignSnapshotPublished` is the only event whose payload is a whole-campaign state object; every other event is an incremental delta.
+
+### D4. `CampaignMatchHost` reuses the `ServerMatchHostIntent` structure
+
+A new `CampaignMatchHost` is the campaign-tier host. It mirrors `ServerMatchHost`'s role exactly: own one campaign's authoritative state, accept campaign intents, validate, commit, broadcast. The intent handler is structured identically to `ServerMatchHostIntent.handleIntent`:
+
+1. reject if the session is closed,
+2. reject if the intent is malformed,
+3. **validate the intent against current authoritative campaign state** (this is where balance / standing / roster checks live — the campaign analogue of "unit ownership" validation),
+4. on success, apply the mutation to authoritative state and produce the resulting `ICampaignEvent`(s),
+5. append each event to the campaign event log,
+6. broadcast each event to all connected clients.
+
+A rejected intent mutates nothing and returns a typed `Error` envelope (`code: 'INVALID_CAMPAIGN_INTENT'`, `reason` such as `'insufficient-funds'`). The connection stays open so the guest can correct and retry — same as the combat intent error contract.
+
+### D5. The guest runs a read-only campaign mirror, guarded like `mirrorSession`
+
+The guest's `useCampaignStore` becomes a **mirror** when the campaign is a joined co-op campaign: it is advanced solely by host-broadcast `ICampaignEvent`s through one `applyCampaignEvent` reducer, and any local mutation path is hard-guarded — exactly the `mirrorSession` contract (`describeMirrorAppendRejection` / `assertMirrorAppendForbidden`). A guest "spend" button does not mutate the store; it sends an intent and waits for the resulting broadcast event. The mirror is identified the same way `isMirrorSession` works — the local peer is the guest, a host peer exists, and they differ.
+
+### D6. Campaign sync session lifecycle
+
+- **Host opens** a shared campaign: the host's `CampaignMatchHost` registers the campaign with the server, which issues a room code (the same 6-char alphabet as `multiplayer-server`, excluding I/O/0/1).
+- **Guest joins** with the room code over the server WebSocket. The host immediately sends a `CampaignSnapshotPublished` baseline, then streams the campaign event log from sequence 0, then live events — the campaign-tier analogue of `ReplayStart` / `ReplayChunk` / `ReplayEnd` followed by live `Event`s.
+- **Guest resyncs** after a brief disconnect by reconnecting and requesting events from its last sequence; if the gap is too large the host sends a fresh `CampaignSnapshotPublished` and resumes live streaming from there.
+- **Host disconnects**: the campaign session pauses. The guest's mirror is frozen and read-only (it already cannot write); no campaign-tier host migration happens in this change.
+
+### D7. The Yjs vault sync is fenced off, explicitly
+
+`useSyncedVaultStore` and the `p2p-sync-system` Yjs `Y.Map` stay exactly as they are, for unit/pilot/force *design* sharing. This change adds a spec requirement stating campaign state SHALL NOT be added to that Yjs document. The two sync surfaces never share a transport: vault content over y-webrtc CRDT, campaign state over the server-authoritative WebSocket event log. The boundary is documented so a future contributor cannot "just add a campaign Y.Map" and reintroduce the ledger-corruption bug DP2 ruled out.
+
+### D8. Type contracts
+
+```typescript
+// Campaign intent — what a guest sends; the host validates and may reject.
+interface ICampaignIntent {
+  readonly kind:
+    | 'HirePilot'
+    | 'AcceptContract'
+    | 'SpendFunds'
+    | 'AllocateSalvage'
+    | 'AdvanceDay';
+  readonly campaignId: string;
+  readonly intentId: string;        // client-generated, for error correlation
+  readonly payload: unknown;        // narrowed per kind
+}
+
+// The result of validating one intent against authoritative state.
+type CampaignIntentResult =
+  | { readonly ok: true; readonly events: readonly ICampaignEvent[] }
+  | { readonly ok: false; readonly code: 'INVALID_CAMPAIGN_INTENT'; readonly reason: string };
+```
+
+## Risks / Trade-offs
+
+- **[Risk] Wave 4 dependency artifacts (`add-campaign-persistence`, `add-campaign-combat-loop`) do not exist yet** → Mitigation: CO1 is authored *now* but is implementation-ordered after Wave 4 per the Council's PR sequence. The `## Dependencies` block names them explicitly; the apply phase blocks until they ship. The design depends only on their *contracts* (a campaign store with append/get; campaign mutations CP1 emits), which are stable enough to spec against.
+- **[Risk] Two host-driven and guest-driven events interleave out of order** → Mitigation: the host is the single writer and assigns sequence numbers; all events — host-initiated and guest-intent-derived — go through one `appendEvent` path, so the log is always totally ordered with no gaps (the `IMatchStore` transactional-append guarantee, reused).
+- **[Risk] A guest acts on a stale mirror (sends "hire" while the host already spent the funds)** → Mitigation: the host validates against *its* authoritative state at commit time, not the guest's view; a stale-mirror intent is simply rejected with `insufficient-funds` and the guest's next broadcast event corrects the mirror.
+- **[Risk] Scope creep into CO2's GM UX** → Mitigation: CO1 defines the intent *transport and validation contract* only. The guest-facing "this button now sends an intent" UI and the host's GM approval surface are explicitly CO2. The `## Non-Goals` fences this.
+- **[Trade-off] A server round-trip per campaign action is slower than a local Yjs write** → Accepted: campaign actions (hire, accept contract, advance day) are deliberate, low-frequency decisions, not per-frame mutations. Correctness of the ledger outweighs sub-second latency here.
+
+## Migration Plan
+
+Purely additive. A solo campaign creates no `CampaignMatchHost` and no campaign sync session — `useCampaignStore` behaves exactly as today, the campaign event log is unused, and there is no mirror. The shared-campaign path is entered only when a host explicitly opens a campaign for co-op. New event and intent types are additive; no existing campaign save format changes (the event log is appended *alongside* the save, not embedded in it). Rollback = revert the change-set; solo campaigns are untouched. No database migration — the campaign event log uses the `add-campaign-persistence` store.
+
+## Open Questions
+
+- Snapshot cadence — should the host emit a `CampaignSnapshotPublished` periodically (e.g., every N events) to bound guest resync cost, or only on join / large-gap reconnect? Proposed: on join and large-gap reconnect only; revisit if campaign event logs grow long enough that replay is slow.
+- Whether `AdvanceDay` should be a host-only action or a guest-proposable intent — proposed: guest-proposable but host-validated (a guest can request "end the day", the host commits it), deferred to CO2's GM model for the final UX call.
+- Whether a guest should see a pending-intent indicator while waiting for the host's broadcast — proposed yes, but the indicator UI is CO2 scope.

--- a/openspec/changes/add-shared-campaign-state/proposal.md
+++ b/openspec/changes/add-shared-campaign-state/proposal.md
@@ -1,0 +1,44 @@
+# Change: Add Shared Campaign State
+
+## Why
+
+Co-op campaign — two friends advancing one MekHQ-style campaign together — has no state-sharing layer today. The P2P sync surface (`SyncableItemType = 'unit' | 'pilot' | 'force'`) covers the content vault only; campaign state (money, roster, contracts, day-counter) sits entirely outside any sync boundary.
+
+The roadmap's original plan was to extend the Yjs `useSyncedVaultStore` to campaign state. The OMO Council's decision DP2 overrides that: campaign state is a **transactional ledger** — C-bill balance, hiring costs, contract acceptance, salvage allocation. Yjs `Y.Map` is last-writer-wins; it guarantees convergence, not correctness. Two players spending the same C-bills concurrently would silently merge into one debit with no overdraft check. CRDTs cannot enforce a balance invariant.
+
+This change supplies the missing layer the *right* way: it extends the already-mature **server-authoritative `intent → validate → commit → broadcast` loop** (the `ServerMatchHostIntent` pattern that arbitrates combat) to campaign state. The host owns the campaign and is the single writer; the guest runs a **read-only mirror** of the campaign store — the exact contract `mirrorSession` already established for combat. A typed campaign event log carries every committed mutation, so the guest's mirror is reconstructed by replaying events, never by merging.
+
+This change is the foundation. It builds the transport, the event log, and the mirror. `add-coop-campaign-play` (CO2) builds the co-op gameplay on top of it.
+
+## What Changes
+
+- ADDED a campaign event log: an ordered, typed, replayable record of every committed campaign mutation, persisted alongside the campaign save and streamed to the guest — the campaign-tier analogue of the combat `IMatchStore` event log
+- ADDED typed campaign event payloads (`CampaignDayAdvanced`, `FundsChanged`, `PilotHired`, `ContractAccepted`, `RosterUnitChanged`, `SalvageAllocated`, `CampaignSnapshotPublished`) covering the ledger-mutating campaign decisions
+- ADDED a `CampaignMatchHost`: the campaign-tier server host that accepts campaign intents, validates each against authoritative campaign state, commits the resulting event(s), and broadcasts them — reusing the `ServerMatchHostIntent` validate-commit-broadcast structure
+- ADDED a campaign mirror store: the guest's `useCampaignStore` runs read-only, advanced solely by host-broadcast campaign events, guarded by the same `mirrorSession` "no local append" contract
+- ADDED a campaign sync session lifecycle: a host opens a shared campaign over the server WebSocket; a guest joins with a room code, receives a `CampaignSnapshotPublished` baseline plus the event log, then live events
+- ADDED an explicit boundary statement: the Yjs `useSyncedVaultStore` stays for the content library (unit/pilot designs) only and SHALL NOT be extended to campaign state
+
+## Dependencies
+
+- **Requires**: `add-campaign-persistence` (Wave 4 CP0) — the server-side campaign save/load store the event log is appended to and the snapshot is read from
+- **Requires**: `add-campaign-combat-loop` (Wave 4 CP1) — the campaign mutations (post-battle salvage, repair, finance flow) the event log must capture
+- **Requires**: `harden-multiplayer-transport` (Wave 3 M2) — the durable match store and hardened WebSocket transport the campaign sync session rides on
+- **Required By**: `add-coop-campaign-play` (CO2) — co-op mission launch and the host-as-GM intent model build directly on this event-broadcast loop
+
+## Impact
+
+- Affected specs: `coop-campaign-sync` (new capability) — a clean home for the campaign-tier sync loop, distinct from `multiplayer-server` (per-match combat) and `p2p-sync-system` (Yjs vault content). The new capability documents its reuse of the `multiplayer-server` host pattern.
+- Affected code: `src/lib/multiplayer/server/` (new `CampaignMatchHost` + campaign intent handler, modeled on `ServerMatchHost` / `ServerMatchHostIntent`), `src/lib/p2p/` (new `campaignMirrorStore` modeled on `mirrorSession`), `src/types/campaign/` (new campaign event + intent types), `src/lib/campaign/` (campaign store wired to emit/consume campaign events)
+- New event types: `CampaignDayAdvanced`, `FundsChanged`, `PilotHired`, `ContractAccepted`, `RosterUnitChanged`, `SalvageAllocated`, `CampaignSnapshotPublished`
+- No new database technology — the campaign event log persists through the same `add-campaign-persistence` store; no Yjs document is introduced for campaign state
+- Determinism preserved: the guest mirror is a pure replay of the host event log; the host is the single source of truth and of randomness
+
+## Non-Goals
+
+- Co-op mission launch (both players' forces in one encounter) — that is `add-coop-campaign-play` (CO2)
+- The host-as-GM intent UX for guest "hire pilot" / "accept contract" actions — CO2 builds the guest-facing intent surface; CO1 only defines the campaign intent transport and validation contract it rides on
+- Replacing or migrating the Yjs `useSyncedVaultStore` — it stays as-is for content sharing; this change explicitly fences it off from campaign state
+- Three-or-more-player shared campaigns — the host/guest pair is the scope; multi-guest fan-out is a later change
+- Offline divergence and merge — the guest mirror is online-only and read-only; there is no offline campaign editing to reconcile
+- Host migration for a campaign session — if the host disconnects the campaign session pauses; campaign-tier host migration is deferred

--- a/openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+++ b/openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
@@ -1,0 +1,159 @@
+## ADDED Requirements
+
+### Requirement: Campaign State Is Server-Authoritative, Not CRDT
+
+Shared co-op campaign state SHALL be synchronized through a server-authoritative `intent → validate → commit → broadcast` loop, NOT through a CRDT. Campaign state is a transactional ledger; a single authoritative writer SHALL hold it and SHALL be the only party permitted to mutate it. The Yjs `useSyncedVaultStore` SHALL NOT be used for campaign state.
+
+#### Scenario: Campaign mutation requires host commit
+
+- **GIVEN** a shared co-op campaign with a host and a guest
+- **WHEN** the guest takes an action that would mutate campaign state
+- **THEN** the action SHALL be sent as a campaign intent to the host
+- **AND** campaign state SHALL change only after the host validates and commits the resulting campaign event
+- **AND** the guest SHALL NOT mutate campaign state directly
+
+#### Scenario: Campaign state never enters the Yjs vault document
+
+- **GIVEN** the P2P sync system's `SyncableItemType` enumeration
+- **WHEN** the enumeration is inspected
+- **THEN** it SHALL contain only `unit`, `pilot`, and `force`
+- **AND** campaign state SHALL NOT be added as a syncable Yjs vault type
+
+### Requirement: Campaign Event Log
+
+The system SHALL maintain a campaign event log — an ordered, gap-free, typed record of every committed campaign mutation. Each `ICampaignEvent` SHALL carry `type`, an ascending host-assigned `sequence`, `campaignId`, `ts`, `authorPlayerId`, and a per-type `payload`. The log SHALL be persisted alongside the campaign save and SHALL be replayable to reconstruct campaign state exactly.
+
+#### Scenario: Event log preserves order on read
+
+- **GIVEN** a shared campaign with 20 committed campaign events
+- **WHEN** the campaign event log is read
+- **THEN** the returned events SHALL be ordered by ascending `sequence`
+- **AND** there SHALL be no gaps in the sequence numbers
+
+#### Scenario: Concurrent append is transactional
+
+- **GIVEN** two concurrent appends to the campaign event log with the same `sequence`
+- **WHEN** the log handles both
+- **THEN** exactly one SHALL succeed
+- **AND** the other SHALL be rejected with a sequence-collision error
+
+#### Scenario: Replaying the log reconstructs campaign state
+
+- **GIVEN** a campaign event log of committed events
+- **WHEN** the log is replayed from sequence 0 into a fresh campaign state
+- **THEN** the reconstructed state SHALL equal the host's authoritative campaign state
+
+### Requirement: Campaign Event Payload Set
+
+The system SHALL define typed campaign event payloads covering the ledger-mutating campaign decisions: `CampaignDayAdvanced`, `FundsChanged`, `PilotHired`, `ContractAccepted`, `RosterUnitChanged`, `SalvageAllocated`, and `CampaignSnapshotPublished`. Each event SHALL record the committed result, never a request. `FundsChanged` SHALL carry the resulting C-bill balance so a guest can detect a missed event. `CampaignSnapshotPublished` SHALL carry a whole-campaign state baseline.
+
+#### Scenario: FundsChanged carries the resulting balance
+
+- **GIVEN** a `FundsChanged` event committed by the host
+- **WHEN** the event payload is inspected
+- **THEN** it SHALL include the C-bill delta, a reason, and the resulting balance after the change
+
+#### Scenario: Snapshot event carries a full baseline
+
+- **GIVEN** a `CampaignSnapshotPublished` event
+- **WHEN** the event payload is inspected
+- **THEN** it SHALL contain a whole-campaign state object sufficient to initialize a guest mirror without any prior events
+
+### Requirement: CampaignMatchHost Validates Intents Against Authoritative State
+
+The system SHALL provide a `CampaignMatchHost` that owns one campaign's authoritative state and processes campaign intents through a closed-check, malformed-check, validate, commit, broadcast sequence. Validation SHALL test the intent against the host's current authoritative campaign state — balance for spend-type intents, faction standing for contract intents, the salvage pool for allocation intents. A rejected intent SHALL mutate nothing and SHALL return a typed `Error {code: 'INVALID_CAMPAIGN_INTENT', reason}`.
+
+#### Scenario: Valid intent commits and broadcasts an event
+
+- **GIVEN** a guest sends a `SpendFunds` campaign intent for an amount within the campaign balance
+- **WHEN** the `CampaignMatchHost` processes it
+- **THEN** the host SHALL apply the mutation to authoritative state
+- **AND** the host SHALL append a `FundsChanged` event to the campaign event log
+- **AND** the host SHALL broadcast the event to all connected clients
+
+#### Scenario: Over-balance spend is rejected and mutates nothing
+
+- **GIVEN** a campaign with a 600,000 C-bill balance
+- **WHEN** a guest sends a `SpendFunds` intent for 700,000 C-bills
+- **THEN** the host SHALL respond `Error {code: 'INVALID_CAMPAIGN_INTENT', reason: 'insufficient-funds'}`
+- **AND** no campaign event SHALL be appended
+- **AND** the campaign balance SHALL remain 600,000 C-bills
+
+#### Scenario: Rejected intent keeps the connection open
+
+- **GIVEN** a guest whose campaign intent was rejected by the host
+- **WHEN** the rejection is delivered
+- **THEN** the connection SHALL remain open
+- **AND** the guest SHALL be able to send a corrected campaign intent
+
+#### Scenario: Stale-mirror intent is validated against host state
+
+- **GIVEN** a guest whose mirror shows a balance the host has since spent down
+- **WHEN** the guest sends a `SpendFunds` intent that fits the stale balance but not the current one
+- **THEN** the host SHALL validate against its current authoritative balance
+- **AND** the host SHALL reject the intent with `reason: 'insufficient-funds'`
+
+### Requirement: Guest Runs a Read-Only Campaign Mirror
+
+In a shared co-op campaign, the guest's campaign store SHALL run as a read-only mirror, advanced solely by host-broadcast campaign events through a single `applyCampaignEvent` reducer. Any local campaign mutation path on the guest SHALL be hard-guarded and SHALL fail loudly. A solo campaign SHALL NOT be treated as a mirror.
+
+#### Scenario: Host broadcast advances the guest mirror
+
+- **GIVEN** a guest running a campaign mirror
+- **WHEN** the host broadcasts a `CampaignDayAdvanced` event
+- **THEN** the guest's mirror SHALL apply the event through `applyCampaignEvent`
+- **AND** the guest's campaign day counter SHALL match the host's
+
+#### Scenario: Guest-side local mutation is rejected
+
+- **GIVEN** a guest running a campaign mirror
+- **WHEN** a local code path attempts to mutate the guest's campaign state directly
+- **THEN** the mutation SHALL be rejected by the mirror append guard
+- **AND** a structured rejection reason SHALL be surfaced
+
+#### Scenario: Solo campaign is not a mirror
+
+- **GIVEN** a single-player campaign with no host peer recorded
+- **WHEN** the mirror-identification check runs
+- **THEN** the campaign SHALL NOT be treated as a mirror
+- **AND** local campaign mutations SHALL proceed normally
+
+### Requirement: Campaign Sync Session Lifecycle
+
+The system SHALL support a campaign sync session lifecycle: a host opens a campaign for co-op and receives a room code; a guest joins with the room code, receives a `CampaignSnapshotPublished` baseline followed by the campaign event log and then live events; a guest may resync after a disconnect; and a host disconnect pauses the session. The room code SHALL use the same 6-character alphabet as the `multiplayer-server`, excluding I/O/0/1.
+
+#### Scenario: Host opens a shared campaign
+
+- **GIVEN** a host with an active campaign
+- **WHEN** the host opens the campaign for co-op
+- **THEN** the server SHALL register the campaign for sharing
+- **AND** the server SHALL issue a 6-character room code excluding the characters I, O, 0, and 1
+
+#### Scenario: Guest join receives a baseline then the log
+
+- **GIVEN** a guest joining a shared campaign with a valid room code
+- **WHEN** the join is accepted
+- **THEN** the host SHALL send a `CampaignSnapshotPublished` baseline event
+- **AND** the host SHALL then stream the campaign event log from sequence 0
+- **AND** the host SHALL then deliver live campaign events as they are committed
+
+#### Scenario: Guest resync streams only the missing tail
+
+- **GIVEN** a guest that disconnected after receiving up to sequence 40
+- **WHEN** the guest reconnects and requests events from sequence 41
+- **THEN** the host SHALL stream only events with sequence greater than 40
+- **AND** the guest mirror SHALL converge with no missing or duplicated events
+
+#### Scenario: Large-gap resync receives a fresh snapshot
+
+- **GIVEN** a guest whose last received sequence is far behind the current log
+- **WHEN** the guest reconnects
+- **THEN** the host SHALL send a fresh `CampaignSnapshotPublished` baseline
+- **AND** the host SHALL resume live streaming from after that snapshot
+
+#### Scenario: Host disconnect pauses the session
+
+- **GIVEN** an active shared campaign session
+- **WHEN** the host disconnects
+- **THEN** the campaign session SHALL pause
+- **AND** the guest mirror SHALL be frozen and remain read-only

--- a/openspec/changes/add-shared-campaign-state/tasks.md
+++ b/openspec/changes/add-shared-campaign-state/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: Add Shared Campaign State
+
+## 1. Campaign Event & Intent Types
+
+- [ ] 1.1 Add `ICampaignEvent`, `CampaignEventType`, and the per-type payload shapes to `src/types/campaign/` (`CampaignDayAdvanced`, `FundsChanged`, `PilotHired`, `ContractAccepted`, `RosterUnitChanged`, `SalvageAllocated`, `CampaignSnapshotPublished`)
+- [ ] 1.2 Add `ICampaignIntent`, the `kind` union (`HirePilot`, `AcceptContract`, `SpendFunds`, `AllocateSalvage`, `AdvanceDay`), and `CampaignIntentResult` to `src/types/campaign/`
+- [ ] 1.3 Add a zod schema (or equivalent runtime validator) for `ICampaignIntent` so malformed intents are rejected at the boundary
+- [ ] 1.4 Unit tests for the type set and a serialization round-trip preserving every campaign event payload
+
+## 2. Campaign Event Log
+
+- [ ] 2.1 Implement the campaign event log over the `add-campaign-persistence` store — ordered append, ascending gap-free `sequence`, transactional append (exactly one of two same-sequence appends succeeds)
+- [ ] 2.2 Implement `getCampaignEvents(campaignId, fromSeq)` returning events ordered by ascending sequence
+- [ ] 2.3 Implement campaign state reconstruction by replaying the event log from sequence 0
+- [ ] 2.4 Tests: append ordering, sequence-collision rejection, replay reconstructs identical campaign state
+
+## 3. CampaignMatchHost — Validate / Commit / Broadcast
+
+- [ ] 3.1 Implement `CampaignMatchHost` modeled on `ServerMatchHost` — owns one campaign's authoritative state, accepts campaign intents, exposes a close path
+- [ ] 3.2 Implement the campaign intent handler modeled on `ServerMatchHostIntent.handleIntent` — closed-check, malformed-check, validate-against-authoritative-state, commit, broadcast
+- [ ] 3.3 Implement per-intent validation: `HirePilot` / `SpendFunds` / `AcceptContract` check the authoritative C-bill balance and faction standing; `AllocateSalvage` checks the post-battle salvage pool; reject with `Error {code: 'INVALID_CAMPAIGN_INTENT', reason}` on failure
+- [ ] 3.4 On a valid intent, apply the mutation to authoritative state, produce the resulting `ICampaignEvent`(s), append to the log, and broadcast
+- [ ] 3.5 Tests: a valid intent commits an event and broadcasts it; an over-balance spend is rejected and mutates nothing; a rejected intent leaves the connection open for retry
+
+## 4. Campaign Mirror Store (Guest)
+
+- [ ] 4.1 Implement `applyCampaignEvent(state, event)` — the single reducer that advances the guest's campaign mirror from a host-broadcast event
+- [ ] 4.2 Wire the guest `useCampaignStore` to mirror mode — advanced only by `applyCampaignEvent`, never by local mutation
+- [ ] 4.3 Implement the mirror append guard modeled on `mirrorSession` (`describeMirrorAppendRejection` / `assertMirrorAppendForbidden`) so a local campaign mutation on the guest fails loudly
+- [ ] 4.4 Implement mirror identification (local peer is the guest, a host peer exists, they differ) modeled on `isMirrorSession`
+- [ ] 4.5 Tests: a host-broadcast event advances the mirror; a guest-side local campaign mutation is rejected; a solo campaign is never treated as a mirror
+
+## 5. Campaign Sync Session Lifecycle
+
+- [ ] 5.1 Implement host-side "open shared campaign" — register the campaign with the server, issue a 6-char room code (same alphabet as `multiplayer-server`, excluding I/O/0/1)
+- [ ] 5.2 Implement guest join — connect with the room code, receive a `CampaignSnapshotPublished` baseline, then the campaign event log from sequence 0, then live events
+- [ ] 5.3 Implement guest resync — reconnect and request events from the last received sequence; on a too-large gap, send a fresh `CampaignSnapshotPublished` and resume live streaming
+- [ ] 5.4 Implement host-disconnect handling — the campaign session pauses; the guest mirror is frozen and read-only
+- [ ] 5.5 Tests: join receives snapshot + full log; resync streams only the missing tail; large-gap resync receives a fresh snapshot; host disconnect pauses the session
+
+## 6. Yjs Vault Boundary
+
+- [ ] 6.1 Add a documented boundary in `p2p-sync-system` consumers / `useSyncedVaultStore` confirming campaign state is NOT a `SyncableItemType` and SHALL NOT enter the Yjs document
+- [ ] 6.2 Test: `SyncableItemType` remains `unit | pilot | force`; no campaign type is added to the Yjs vault map
+
+## 7. Verification
+
+- [ ] 7.1 Integration test: a host opens a shared campaign, a guest joins, the host advances the day and the guest mirror reflects it
+- [ ] 7.2 Integration test: a guest sends a `SpendFunds` intent within balance — the host commits a `FundsChanged` event and both the host and guest mirror converge to the new balance
+- [ ] 7.3 Integration test: a guest sends a `SpendFunds` intent over balance — the host rejects it, no event is committed, and both stores keep the prior balance
+- [ ] 7.4 Integration test: a guest disconnects and reconnects — the mirror resyncs from the campaign event log with no missing or duplicated events
+- [ ] 7.5 `npx openspec validate add-shared-campaign-state --strict` is clean; build, lint, and typecheck pass

--- a/openspec/changes/complete-multiplayer-game-surface/design.md
+++ b/openspec/changes/complete-multiplayer-game-surface/design.md
@@ -1,0 +1,75 @@
+# Design: Complete the Multiplayer Game Surface
+
+## Context
+
+The multiplayer netcode is server-authoritative and complete. `ServerMatchHost` owns one `InteractiveSession`, accepts `Intent` envelopes, runs engine resolution, captures every d6 a resolver consumes, stamps the rolls onto the resulting events, persists them through `IMatchStore`, and broadcasts `Event` envelopes (fog-redacted per recipient when `config.fogOfWar` is set). The lobby UI in `src/pages/multiplayer/lobby/[roomCode].tsx` already drives seat occupancy and `LaunchMatch` through `useMultiplayerSession`.
+
+The gap is the `active`-state branch of that page: when `session.lobbyState.status === 'active'` it renders a static placeholder. There is no component that takes the server's `Event` stream and renders a playable tactical map, and no path for a player's action to become an `Intent` on the wire. The single-player tactical map (`HexMapDisplay` and the gameplay surface) renders an `IGameSession` and is fully built — the missing middle is a *client mirror* of the authoritative session, fed by the network event stream instead of by local engine calls.
+
+The `multiplayer-sync` capability already defines the `mirrorSession` concept (a guest's session whose state is built purely by applying received `IGameEvent`s through the `appendEvent` reducer) and the `IGameIntent` contract. Per council decision DP1, that event-application pattern is kept as the **client layer** — this change points it at the server WebSocket rather than at y-webrtc.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make a launched networked match playable end-to-end for both human players from inside `/multiplayer/lobby/[roomCode]`.
+- Drive the tactical map from a client mirror session built solely from the server `Event` stream — never from local engine resolution.
+- Encode player actions as `Intent` envelopes on the existing WebSocket; the client never produces authoritative state.
+- Gate intent-producing controls by turn ownership so a player cannot act for the opponent's side or out of phase.
+- Surface the connection-lifecycle states the server already broadcasts (`MatchPaused`, `MatchResumed`, `Close`) inside the game surface.
+
+**Non-Goals:**
+
+- Durable persistence, host migration, rate-limiting (M2).
+- Match browser, matchmaking, spectator seats (M3).
+- Any server-side change — the surface consumes the existing broadcast contract.
+
+## Decisions
+
+### D1. A new `multiplayer-game-surface` capability, not a delta on `multiplayer-server`
+
+The work is entirely client-side rendering and intent emission. `multiplayer-server` requirements describe the authoritative server; `multiplayer-sync` describes the per-match transport and the mirror reducer. The game *surface* — the React component tree that renders a networked match and collects player input — is a third concern. A new capability keeps every requirement here purely `## ADDED` and avoids touching server requirements.
+
+### D2. Client mirror session fed by the `Event` stream
+
+`useMultiplayerSession` already accumulates `events` from the server. This change adds a `mirrorSession: IGameSession | null` to the hook's return surface. The mirror is built by feeding each received `IGameEvent` through the same `appendEvent` reducer the engine uses, in `sequence` order. The mirror is **read-only** to the UI — it is the render input for `HexMapDisplay`, never mutated by local controls. This is exactly the `multiplayer-sync` mirror pattern (DP1), with the server WebSocket as the event source.
+
+### D3. Intent emission is a typed forwarder, not a local engine call
+
+The game surface exposes player actions (declare movement, declare attack, declare physical, advance phase, concede) as a `sendGameIntent(intent: IGameIntent)` call that wraps the action in an `Intent` envelope and sends it over the existing socket. The client does **not** resolve the action locally — it waits for the server's broadcast `Event` to update the mirror. This keeps the single source of truth on the server and means an out-of-phase or unauthorized action is rejected by the server with an `Error` envelope, surfaced as a non-fatal toast.
+
+### D4. Turn-ownership gate derived from the mirror session
+
+The local player's side is known from the lobby seat assignment (`session.lobbyState.seats`, matched on `playerId`). The mirror session's `IGameState` carries the current `phase` and the side whose turn it is. Intent-producing controls are enabled only when `(localSide === activeSide)` for a phase that accepts that side's intents; otherwise the surface renders a passive "waiting for opponent" indicator. The gate is advisory UX — the server is still the authority and rejects a smuggled intent regardless.
+
+### D5. Fog-redacted events render without crashing
+
+When `config.fogOfWar` is enabled the server sends per-player redacted or omitted events. The mirror reducer already tolerates redacted payloads (`multiplayer-sync` "Redacted Event Shape"). The surface MUST render a unit the local player cannot currently see at its last-known position with a "last seen" indicator and MUST NOT attempt to animate an event it never received — this is the existing `multiplayer-sync` "Client Gracefully Handles Missing Events" contract, now exercised by a real surface.
+
+### D6. Lifecycle states surfaced in the game surface
+
+`useMultiplayerSession` already collapses lower-level frames into a `status` (`connecting` / `ready` / `paused` / `closed` / `error`) and exposes `MatchPaused` / `MatchResumed` / `Close` payloads. The game surface renders:
+- `paused` → a blocking overlay naming the pending seat(s) and the grace countdown; intent controls disabled.
+- `ready` → normal play.
+- `closed` → a terminal panel routing to a post-match summary or back to the multiplayer hub.
+
+### D7. Replay-on-join produces the same mirror as live play
+
+When a player (re)joins, the server streams `ReplayStart` / `ReplayChunk` / `ReplayEnd` before live events. The mirror session is built by applying the replayed events first, then live events, in one continuous `sequence` order. A reconnecting player therefore lands on a fully-rebuilt board identical to a player who was connected the whole time.
+
+## Risks / Trade-offs
+
+- **[Risk] Mirror divergence from the authoritative session** → Mitigation: the mirror is built only by applying server events in `sequence` order through the same reducer the server uses; it never runs engine resolution. Any divergence is a reducer bug caught by the existing `multiplayer-sync` convergence test, extended here with a surface-level integration test.
+- **[Risk] A player acts during the opponent's turn** → Mitigation: the D4 turn-ownership gate disables the controls; the server independently rejects the intent. The gate is UX, the server is the guarantee.
+- **[Risk] Fog-redacted stream produces an inconsistent board** → Mitigation: D5 — the surface honors the existing missing-event contract; "last seen" rendering and no-animation-for-unreceived-events keep the board coherent.
+- **[Risk] Large replay stream on join blocks first paint** → Mitigation: the mirror applies replay chunks incrementally; the surface shows a "loading match…" state until `ReplayEnd`, then renders the rebuilt board in one commit.
+- **[Risk] Scope creep into match persistence / migration** → Mitigation: explicitly deferred to M2; the surface depends on the transport but does not harden it.
+
+## Migration Plan
+
+Purely additive on the client. The `active`-state branch of `src/pages/multiplayer/lobby/[roomCode].tsx` is *replaced* — the placeholder JSX is removed and `NetworkedGameSurface` rendered in its place. The lobby branch (`!isActive`) is unchanged. `useMultiplayerSession` gains a `mirrorSession` field and a `sendGameIntent` method; existing consumers that read only `lobbyState` are unaffected. No server change, no database migration. Rollback = restore the placeholder branch; the lobby and server are untouched.
+
+## Open Questions
+
+- Whether the networked game surface should live at a dedicated route (`/multiplayer/match/[matchId]`) rather than swapping inside the lobby route — proposed: keep it inside the lobby route for Wave 3 so the player never loses the WebSocket; a dedicated route can follow if M3's match browser needs deep links.
+- Whether to show a minimal per-side initiative / phase HUD distinct from the single-player one — proposed: reuse the single-player HUD; revisit if the turn-ownership gate needs more prominent affordance.

--- a/openspec/changes/complete-multiplayer-game-surface/proposal.md
+++ b/openspec/changes/complete-multiplayer-game-surface/proposal.md
@@ -1,0 +1,37 @@
+# Change: Complete the Multiplayer Game Surface
+
+## Why
+
+The multiplayer stack is finished on the server side — `ServerMatchHost` runs an authoritative `InteractiveSession`, captures rolls, redacts fog-of-war events, streams replay, and broadcasts `Event` envelopes. The lobby works end-to-end: room-code invites, seat occupancy, readiness, and `LaunchMatch`. But the moment a match flips to `status === 'active'` the player surface dead-ends — `src/pages/multiplayer/lobby/[roomCode].tsx` (lines ~307-325) renders a hardcoded "Match starting…" placeholder that tells the user to "hop over to the existing gameplay surface" (the single-player UI, which has no connection to the running networked match).
+
+Two human players can fill a lobby and launch, but there is no way to actually *play* the resulting match against each other. This is the single critical gap in Wave 3 — every other piece of the netcode exists and is exercised by the integration suite. This change replaces the placeholder with a real networked game surface: it consumes the server's `Event` broadcast stream to drive the tactical map, sends player actions back as `Intent` envelopes, and renders the opponent's moves as they arrive.
+
+## What Changes
+
+- ADDED a networked game surface rendered when a lobby's `status` flips to `'active'` — replacing the placeholder in `src/pages/multiplayer/lobby/[roomCode].tsx`
+- ADDED a client-side mirror game session: the `mirrorSession` / `gameSessionChannel` event-application pattern, fed by the server `Event` stream rather than by y-webrtc, producing the `IGameSession` the tactical map renders
+- ADDED an intent-emit path from the tactical map UI — a player's movement / attack / phase-advance / concede action is encoded as an `Intent` envelope and sent over the existing WebSocket
+- ADDED opponent-move rendering: events broadcast from the server (including fog-redacted ones) are applied to the mirror session so the opponent's units animate and update on the local map
+- ADDED a turn-ownership gate so the UI only enables intent-producing controls for the local player's side during that side's phase, and shows a passive "waiting for opponent" state otherwise
+- ADDED handling for the connection-lifecycle states the server already broadcasts — `MatchPaused`, `MatchResumed`, `Close` — surfaced in the game surface rather than only the lobby
+
+## Dependencies
+
+- **Requires**: `multiplayer-server` (the `ServerMatchHost` authoritative session, `Event` broadcast, replay stream — all source-of-truth) and `multiplayer-sync` (the `mirrorSession` event-application reducer and `IGameIntent` contract)
+- **Required By**: `harden-multiplayer-transport` (M2) — the durable-store / host-migration / rate-limiting work hardens the transport this surface depends on; `add-matchmaking-and-spectator` (M3) — the spectator surface reuses the read-only path established here
+
+## Impact
+
+- Affected specs: `multiplayer-game-surface` (new capability) — the client-side game surface is a distinct concern from the server (`multiplayer-server`) and from per-match sync transport (`multiplayer-sync`); a new capability keeps the delta clean and avoids modifying server requirements
+- Affected code: `src/pages/multiplayer/lobby/[roomCode].tsx` (replace the `active`-state branch), `src/hooks/useMultiplayerSession.ts` (expose the mirror session + a typed `sendGameIntent`), `src/components/multiplayer/` (new `NetworkedGameSurface` component), `src/lib/multiplayer/client.ts` (mirror-session wiring from the `Event` stream)
+- No new server code — the surface consumes the existing `ServerMatchHost` broadcast contract unchanged
+- No database migrations — the surface is a read/render layer over the server's event stream
+- Reproducibility preserved: the surface never produces rolls or authoritative state; it only renders the server's events and emits intents
+
+## Non-Goals
+
+- Durable match persistence, host migration, rate-limiting, replay-attack protection — all M2 (`harden-multiplayer-transport`)
+- Match browser / matchmaking and the spectator seat type — M3 (`add-matchmaking-and-spectator`)
+- Post-match summary / replay-library integration for networked matches — out of Wave 3 scope
+- Any change to the server's authoritative engine, roll capture, or fog redaction — this change is client-surface only
+- New UI for AI-occupied seats beyond what the existing single-player tactical map already renders

--- a/openspec/changes/complete-multiplayer-game-surface/specs/multiplayer-game-surface/spec.md
+++ b/openspec/changes/complete-multiplayer-game-surface/specs/multiplayer-game-surface/spec.md
@@ -1,0 +1,121 @@
+## ADDED Requirements
+
+### Requirement: Networked Game Surface
+
+The system SHALL render a playable networked game surface whenever a match a player has joined transitions to `status === 'active'`, replacing the prior placeholder. The surface SHALL render the tactical map from a client mirror of the authoritative session and SHALL collect the player's actions as intents.
+
+#### Scenario: Active match renders the game surface
+
+- **GIVEN** a player connected to a match in `status: 'lobby'`
+- **WHEN** the match transitions to `status: 'active'`
+- **THEN** the surface SHALL render the networked tactical map instead of a placeholder
+- **AND** the surface SHALL NOT direct the player to the single-player gameplay route
+
+#### Scenario: Lobby surface still renders before launch
+
+- **GIVEN** a match in `status: 'lobby'`
+- **WHEN** the page renders
+- **THEN** the lobby panel SHALL be shown
+- **AND** the networked game surface SHALL NOT be mounted
+
+### Requirement: Client Mirror Session From Event Stream
+
+The system SHALL build a client mirror `IGameSession` by applying every received `IGameEvent` through the `appendEvent` reducer in ascending `sequence` order. The mirror SHALL be the render input for the tactical map and SHALL NOT be mutated by local controls or local engine resolution.
+
+#### Scenario: Mirror reflects authoritative state
+
+- **GIVEN** a networked match with events broadcast by the server
+- **WHEN** the client applies each `Event` to the mirror session in `sequence` order
+- **THEN** the mirror's `currentState` SHALL match the authoritative server state at the same `sequence`
+
+#### Scenario: Join replay rebuilds the board
+
+- **GIVEN** a player joining a match already in progress
+- **WHEN** the server streams `ReplayStart`, one or more `ReplayChunk`, and `ReplayEnd` followed by live `Event` messages
+- **THEN** the mirror SHALL apply the replayed events before the live events in one continuous `sequence` order
+- **AND** the resulting board SHALL be identical to that of a continuously-connected player
+
+#### Scenario: Mirror is never mutated locally
+
+- **GIVEN** a player using the networked game surface
+- **WHEN** the player triggers a movement control
+- **THEN** the mirror session SHALL NOT change until the corresponding server `Event` arrives
+- **AND** no local engine resolution SHALL be run against the mirror
+
+### Requirement: Intent Emission Over the Server WebSocket
+
+The system SHALL encode each player action as an `IGameIntent` wrapped in an `Intent` envelope and send it over the existing match WebSocket. The client SHALL NOT resolve actions locally and SHALL wait for the server's broadcast `Event` to update the mirror.
+
+#### Scenario: Player action becomes an intent
+
+- **GIVEN** a player on the networked game surface during their side's movement phase
+- **WHEN** the player declares a movement for a unit they own
+- **THEN** the client SHALL send an `Intent` envelope carrying a `declareMovement` `IGameIntent`
+- **AND** the unit SHALL move on the map only after the server's resulting `Event` is applied to the mirror
+
+#### Scenario: Rejected intent surfaces without breaking the surface
+
+- **GIVEN** a player who submits an action the server rejects
+- **WHEN** the server replies with an `Error` envelope
+- **THEN** the surface SHALL show a non-fatal notification with the rejection reason
+- **AND** the WebSocket connection SHALL remain open
+- **AND** the mirror session SHALL be unchanged
+
+### Requirement: Turn-Ownership Gate
+
+The system SHALL enable intent-producing controls only when the local player's side is the active side for a phase that accepts that side's intents. At all other times the surface SHALL render a passive "waiting for opponent" indicator.
+
+#### Scenario: Controls enabled on the local side's turn
+
+- **GIVEN** a networked match whose current phase is the movement phase for the local player's side
+- **WHEN** the surface renders
+- **THEN** the movement controls SHALL be enabled
+
+#### Scenario: Controls disabled during the opponent's turn
+
+- **GIVEN** a networked match whose current phase belongs to the opponent's side
+- **WHEN** the surface renders
+- **THEN** intent-producing controls SHALL be disabled
+- **AND** a "waiting for opponent" indicator SHALL be shown
+
+### Requirement: Opponent Move Rendering Under Fog of War
+
+The system SHALL render opponent moves from the server `Event` stream, including fog-redacted events, without crashing. A unit the local player cannot currently see SHALL be drawn at its last-known position with a "last seen" indicator, and the surface SHALL NOT animate an event it never received.
+
+#### Scenario: Opponent unit animates on a visible move
+
+- **GIVEN** a fog-on networked match and an opponent unit within the local player's line of sight
+- **WHEN** the server broadcasts a movement event for that unit
+- **THEN** the opponent unit SHALL move on the local map
+
+#### Scenario: Hidden unit shows last-known position
+
+- **GIVEN** a fog-on networked match and an opponent unit that has moved out of the local player's line of sight
+- **WHEN** the local client stops receiving that unit's events
+- **THEN** the unit SHALL be drawn at its last-known position with a "last seen" indicator
+- **AND** the surface SHALL NOT crash attempting to animate an unreceived event
+
+### Requirement: Connection-Lifecycle Surfacing in the Game Surface
+
+The system SHALL surface the connection-lifecycle states the server broadcasts — `MatchPaused`, `MatchResumed`, and `Close` — within the networked game surface.
+
+#### Scenario: Pause overlay blocks input
+
+- **GIVEN** a player in an active networked match
+- **WHEN** the server broadcasts `MatchPaused`
+- **THEN** the surface SHALL render a blocking overlay naming the pending seat(s) and the grace countdown
+- **AND** intent-producing controls SHALL be disabled
+
+#### Scenario: Resume restores play
+
+- **GIVEN** a networked game surface showing the pause overlay
+- **WHEN** the server broadcasts `MatchResumed`
+- **THEN** the overlay SHALL be removed
+- **AND** intent-producing controls SHALL be re-enabled per the turn-ownership gate
+
+#### Scenario: Close renders a terminal panel
+
+- **GIVEN** a player in an active networked match
+- **WHEN** the server broadcasts `Close`
+- **THEN** the surface SHALL render a terminal panel
+- **AND** the panel SHALL offer a route back to the multiplayer hub

--- a/openspec/changes/complete-multiplayer-game-surface/tasks.md
+++ b/openspec/changes/complete-multiplayer-game-surface/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: Complete the Multiplayer Game Surface
+
+## 1. Client Mirror Session
+
+- [ ] 1.1 Add a `mirrorSession: IGameSession | null` field to `useMultiplayerSession`, built by applying received `IGameEvent`s through the `appendEvent` reducer in ascending `sequence` order
+- [ ] 1.2 Apply replay-stream events (`ReplayStart` / `ReplayChunk` / `ReplayEnd`) before live `Event` messages, in one continuous sequence order
+- [ ] 1.3 Tolerate fog-redacted and omitted events without throwing — reuse the `multiplayer-sync` redacted-payload handling
+- [ ] 1.4 Unit tests: mirror built from a fixed event log matches the authoritative session; replay-then-live produces the same mirror as live-only
+
+## 2. Intent Emission
+
+- [ ] 2.1 Add a typed `sendGameIntent(intent: IGameIntent)` to `useMultiplayerSession` that wraps the intent in an `Intent` envelope and sends it over the existing socket
+- [ ] 2.2 Map tactical-map player actions (declare movement, declare attack, declare physical, advance phase, concede) onto `IGameIntent` shapes
+- [ ] 2.3 Surface a server `Error` envelope (e.g. wrong-phase, unauthorized-unit) as a non-fatal toast; the connection stays open
+- [ ] 2.4 Tests: each action produces the correct `Intent` envelope; a rejected intent does not mutate the mirror session
+
+## 3. Networked Game Surface Component
+
+- [ ] 3.1 Add `NetworkedGameSurface` under `src/components/multiplayer/` rendering `HexMapDisplay` from the mirror session
+- [ ] 3.2 Wire player controls to `sendGameIntent`; never resolve actions locally
+- [ ] 3.3 Render a "loading match…" state until the join replay drains (`ReplayEnd`), then commit the rebuilt board
+- [ ] 3.4 Storybook story covering loading, active-play, and opponent-turn states
+
+## 4. Turn-Ownership Gate
+
+- [ ] 4.1 Derive the local player's side from `session.lobbyState.seats` matched on `playerId`
+- [ ] 4.2 Enable intent-producing controls only when the local side is the active side for a phase that accepts its intents; otherwise render a passive "waiting for opponent" indicator
+- [ ] 4.3 Tests: controls disabled during the opponent's phase; enabled during the local side's phase
+
+## 5. Fog-of-War Rendering
+
+- [ ] 5.1 Render a unit the local player cannot currently see at its last-known position with a "last seen" indicator
+- [ ] 5.2 Do not animate an event the client never received; jump a re-revealed unit to its new position
+- [ ] 5.3 Tests: a fog-on match where an enemy leaves and re-enters LOS renders coherently and never crashes the surface
+
+## 6. Connection-Lifecycle Surfacing
+
+- [ ] 6.1 Render a blocking overlay on `MatchPaused` naming the pending seat(s) and the grace countdown; disable intent controls
+- [ ] 6.2 Restore normal play on `MatchResumed`
+- [ ] 6.3 Render a terminal panel on `Close` routing back to the multiplayer hub
+- [ ] 6.4 Tests: pause overlay shows on `MatchPaused`, clears on `MatchResumed`, terminal panel shows on `Close`
+
+## 7. Lobby Page Integration
+
+- [ ] 7.1 Replace the hardcoded `active`-state placeholder branch in `src/pages/multiplayer/lobby/[roomCode].tsx` (lines ~307-325) with `NetworkedGameSurface`
+- [ ] 7.2 Keep the `!isActive` lobby branch unchanged
+- [ ] 7.3 Tests: the page renders the lobby panel while `status === 'lobby'` and the game surface once `status === 'active'`
+
+## 8. Verification
+
+- [ ] 8.1 Integration test: two simulated clients launch a match, exchange movement and attack intents, and both mirrors converge to the same `IGameState` at every event boundary
+- [ ] 8.2 Integration test: a client that joins mid-match via replay lands on a board identical to a continuously-connected client
+- [ ] 8.3 `openspec validate complete-multiplayer-game-surface --strict` passes
+- [ ] 8.4 `npm run build`, lint, and `tsc --noEmit` typecheck all pass

--- a/openspec/changes/harden-multiplayer-transport/design.md
+++ b/openspec/changes/harden-multiplayer-transport/design.md
@@ -1,0 +1,83 @@
+# Design: Harden the Multiplayer Transport
+
+## Context
+
+The multiplayer server is server-authoritative and mature. `ServerMatchHost` owns one `InteractiveSession` per match, captures rolls, redacts fog events, streams replay, manages per-socket heartbeats, and handles a reconnect lifecycle (`PendingPeerTracker`, `ServerMatchHostReconnectLifecycle`) with per-seat grace timers. `IMatchStore` is a clean async persistence boundary — `createMatch`, `appendEvent`, `getEvents`, `getMatchMeta`, `updateMatchMeta`, `getMatchByRoomCode`, `closeMatch` — but the only implementation is `InMemoryMatchStore`, which warns on construction that it is dev-only.
+
+Three gaps block production use, all called out in the roadmap and the council decomposition: no durable store, host disconnect aborts the match, and no intent rate-limiting or replay protection. This change closes all three without a rewrite, per council decision **DP1**.
+
+### DP1 — Consolidate on the authoritative server (council decision, baked in here)
+
+The codebase has a *finished* server-authoritative stack — per-intent roll capture, fog-of-war redaction, reconnection grace timers, lobby intents, replay streaming. There is **no rewrite**. Wave 3 hardens this server; the P2P / y-webrtc layer is demoted to a fallback that receives no further investment. The P2P `mirrorSession` / `gameSessionChannel` event-application pattern is *kept* — but only as the **client-side** layer, pointed at the server WebSocket instead of y-webrtc (this is exactly what M1 does). Cheating defenses — authoritative roll capture, intent zod-refinement, fog redaction — are structurally impossible on a peer mesh; consolidating on the authoritative server is what makes M2's integrity work meaningful. Every requirement in this change therefore targets the *server* path; the y-webrtc path is documented as a non-authoritative fallback and nothing new is built on it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A durable `IMatchStore` so a server restart never loses an active match.
+- Server-startup match recovery that re-instantiates a `ServerMatchHost` for every `active` match from durable storage.
+- Host migration + graceful degradation so a host-connection loss does not abort the match.
+- Per-connection intent rate-limiting and replay-attack protection on the authoritative server.
+- A documented DP1 consolidation contract demoting y-webrtc to a non-authoritative fallback.
+
+**Non-Goals:**
+
+- The networked game surface (M1), match browser / spectators (M3), self-hosted signaling, deleting the P2P code, co-op campaign sync (Wave 5).
+
+## Decisions
+
+### D1. The durable store implements the existing `IMatchStore` contract unchanged
+
+The `IMatchStore` interface is already the persistence boundary and is "deliberately small and async so that future implementations can be transactional / network-backed". The durable store is a new class implementing that exact interface — no interface change, no call-site change. `ServerMatchHost`, the REST routes, and the WebSocket upgrade handler depend only on `IMatchStore` and are agnostic to which implementation is wired. `InMemoryMatchStore` is kept verbatim as the dev-only fallback (`getDefaultMatchStore()` selects the durable store in production, the in-memory store in dev/test).
+
+### D2. Durable store backed by an embedded persistent store, file-layout frozen here
+
+The durable store persists two things per match: the `IMatchMeta` blob and the ordered event log. The backing technology is an embedded persistent store (SQLite-class — single-file, no separate server process, transactional) chosen so the deployment story stays "run one Node process". The persisted shape:
+- a `matches` record per match holding the serialized `IMatchMeta`;
+- an `events` record per `(matchId, sequence)` holding the serialized `IGameEvent`, with `(matchId, sequence)` as the unique key so `appendEvent`'s sequence-collision guarantee is enforced by the storage layer's unique constraint.
+`appendEvent` MUST be transactional all-or-nothing and MUST reject a sequence collision with `MatchStoreSequenceCollisionError`, exactly as `InMemoryMatchStore` does today. `getEvents` MUST return events ordered by ascending `sequence` with no gaps.
+
+### D3. Startup recovery enumerates active matches and rebuilds hosts
+
+On server startup the recovery routine queries the durable store for every match with `status: 'active'`, and for each one constructs a fresh `ServerMatchHost` whose `InteractiveSession` is rebuilt by replaying the stored event log. This satisfies the existing `multiplayer-server` "Server Restart Survives Matches" requirement against a real backend rather than only the in-memory store. A reconnecting client's `SessionJoin` with its `lastSeq` then streams the missing events through the already-built replay path.
+
+### D4. Authority lives on the server, so a host *connection* loss is not an authority loss
+
+The critical insight: in the server-authoritative model the authoritative `InteractiveSession` lives on the *server*, not on the host's client. The "host" is the player holding `hostPlayerId` for privileged operations (close match, lobby overrides). When the host's *socket* drops, the engine keeps running on the server. Host migration is therefore not a state-transfer problem — it is a *privilege reassignment* problem: promote a surviving connected human seat to `hostPlayerId` so privileged operations remain available. The promotion is recorded in `IMatchMeta` via `updateMatchMeta` and broadcast to all clients.
+
+### D5. Host-connection loss enters the grace path, never an immediate abort
+
+A host-socket loss is routed through the *same* pending/grace mechanism already used for any human seat (`maybeMarkPlayerPending`, `PendingPeerTracker`). The match pauses (existing `MatchPaused` broadcast) rather than aborting. Resolution:
+- host reconnects within grace → match resumes (`MatchResumed`), `hostPlayerId` may revert or stay migrated;
+- grace expires → the match completes cleanly through the existing outcome path, **not** with the legacy `reason: 'aborted'` abort.
+The `multiplayer-sync` "Abort on Host Disconnect" requirement describes the *legacy y-webrtc* path; this change adds a new server-path requirement for graceful degradation rather than modifying the old one (DP1: y-webrtc is the demoted fallback).
+
+### D6. Intent rate-limiting per connection
+
+The authoritative intent dispatch (`ServerMatchHostIntent`) gains a per-connection token-bucket rate limiter. An intent that exceeds the configured budget is rejected with a non-fatal `Error {code: 'RATE_LIMITED'}`; the connection stays open and no event is appended. The budget is generous enough that legitimate fast play never trips it (a human cannot out-click the budget) and is configured, not hardcoded, so a stress test can tune it. Heartbeats and replay traffic are exempt.
+
+### D7. Replay-attack protection via per-intent unique ids
+
+Every `Intent` envelope already correlates via an intent id (the `Error` envelope carries an optional `intentId`). The server maintains a per-match set of accepted intent ids. An inbound intent whose id is already in the set is rejected with `Error {code: 'DUPLICATE_INTENT'}` and produces no event — a replayed envelope cannot re-trigger a movement or attack. The accepted-id set is bounded (it only needs to cover the window an attacker could realistically replay within); it is reconstructed from the event log on recovery so a restart does not reopen the replay window.
+
+### D8. y-webrtc demoted to a documented fallback
+
+No P2P code is deleted. The `multiplayer-sync` capability gains one new requirement stating that the authoritative server WebSocket is the supported transport for networked matches, that y-webrtc is a non-authoritative fallback receiving no further hardening, and that the `mirrorSession` / `gameSessionChannel` pattern is retained only as the client-side event-application layer pointed at the server WebSocket. This is the DP1 contract made explicit in spec form.
+
+## Risks / Trade-offs
+
+- **[Risk] Durable-store write latency on the hot `appendEvent` path** → Mitigation: an embedded transactional store (D2) keeps `appendEvent` a local synchronous-class write; the existing `appendEvent` is already async so latency is absorbed by the contract. A stress test in the verification section measures it.
+- **[Risk] Host migration promotes a player who then also disconnects** → Mitigation: D4 promotion picks the longest-connected surviving human seat; if that seat also drops, migration repeats; if no human seat survives, the match enters the grace path (D5) and completes cleanly.
+- **[Risk] Rate-limit budget too tight breaks legitimate fast play** → Mitigation: D6 — the budget is configured and generous; the verification suite asserts a worst-case human play rate never trips it.
+- **[Risk] Accepted-intent-id set grows unbounded** → Mitigation: D7 — the set is bounded to the realistic replay window and rebuilt from the event log on recovery.
+- **[Risk] Recovery rebuilds a corrupt session from a partial log** → Mitigation: D2's transactional `appendEvent` means the log never contains a torn write; recovery replays only fully-committed events.
+
+## Migration Plan
+
+Additive. The new durable store implements `IMatchStore` with no interface change, so `ServerMatchHost` and all call sites are untouched. `getDefaultMatchStore()` selects the durable store in production and `InMemoryMatchStore` in dev/test — existing tests that construct their own `InMemoryMatchStore` are unaffected. Host migration, rate-limiting, and replay protection are new code paths in `ServerMatchHost` / its satellites that no existing test exercises, so they are purely additive. The first production deployment starts with an empty durable store; there is no data to migrate from the in-memory store (it never persisted anything). Rollback = wire `getDefaultMatchStore()` back to `InMemoryMatchStore` and the new code paths go dormant.
+
+## Open Questions
+
+- Whether `hostPlayerId` should revert to the original host on their reconnect or stay with the migrated holder — proposed: stay migrated for the rest of the match to avoid a privilege ping-pong; revisit if testers find it confusing.
+- The exact rate-limit budget numbers — proposed: design freezes the *mechanism* (token bucket, per-connection, configured) and leaves the numbers to the stress test in verification task 6.
+- Whether the durable store should also persist completed-match logs for the 7-day retention window the `multiplayer-sync` spec describes for IndexedDB — proposed: yes, the durable store honors the same 7-day retention so server-side post-match inspection works; confirm during implementation.

--- a/openspec/changes/harden-multiplayer-transport/proposal.md
+++ b/openspec/changes/harden-multiplayer-transport/proposal.md
@@ -1,0 +1,43 @@
+# Change: Harden the Multiplayer Transport
+
+## Why
+
+Wave 3 M1 (`complete-multiplayer-game-surface`) makes networked matches playable, but the transport underneath has three production-blocking gaps:
+
+1. **No durable match store.** `InMemoryMatchStore` is the only `IMatchStore` implementation. Its own constructor logs "dev-only store in use; configure a persistent store for production". A server process restart loses every active match — the `multiplayer-server` spec promises "Server Restart Survives Matches", but with an in-memory store that promise cannot be kept.
+2. **A host disconnect aborts the match.** The `p2p-sync-system` path ends a match with `reason: 'aborted'` when the host peer's awareness is lost (`multiplayer-sync` "Abort on Host Disconnect"). There is no host migration and no graceful degradation — a transient host network blip kills a live game for everyone.
+3. **No intent integrity defenses.** The server validates intent *shape* (zod) and rejects client-supplied rolls, but there is no rate-limiting and no replay-attack protection. A malicious or buggy client can flood the host with intents or re-send a previously-accepted intent envelope.
+
+Per council decision **DP1**, this change does not rewrite anything. The server-authoritative stack (`ServerMatchHost` and its satellites) is mature and correct; y-webrtc / P2P is demoted to a fallback we stop investing in. M2 hardens the existing authoritative server so a real match survives a restart, survives a host blip, and resists abusive clients.
+
+## What Changes
+
+- ADDED a durable `IMatchStore` implementation that survives a server process restart, persisting match meta and the full event log; `InMemoryMatchStore` is retained only as the explicitly dev-labeled fallback
+- ADDED match recovery on server startup — the server enumerates `status: 'active'` matches from the durable store and re-instantiates a `ServerMatchHost` for each, satisfying the existing "Server Restart Survives Matches" requirement against a real backend
+- ADDED host migration: when the host's connection is lost, server authority continues (the authoritative session already lives on the server, not the host client) and a surviving connected human seat is promoted to `hostPlayerId` for privileged operations, rather than the match aborting
+- ADDED graceful degradation: a host-connection loss enters the existing pending/grace path instead of an immediate abort; the match resumes on host reconnect or completes cleanly on grace expiry
+- ADDED per-connection intent rate-limiting on the authoritative server, rejecting intents that exceed a configured budget with a non-fatal `Error` envelope
+- ADDED replay-attack protection: every `Intent` envelope carries a unique id, and the server rejects any intent whose id it has already accepted for the match
+- ADDED the DP1 transport-consolidation contract: y-webrtc is documented as a non-authoritative fallback, and the client mirror layer is the only retained client-side use of the `mirrorSession` / `gameSessionChannel` pattern, pointed at the server WebSocket
+
+## Dependencies
+
+- **Requires**: `complete-multiplayer-game-surface` (M1) — the hardened transport exists to serve a real playable surface; `multiplayer-server` (the `ServerMatchHost`, `IMatchStore` contract, reconnect lifecycle — all source-of-truth)
+- **Required By**: `add-matchmaking-and-spectator` (M3) — matchmaking and spectators rely on a durable store and a non-aborting transport; Wave 5 `add-shared-campaign-state` (CO1) — co-op campaign sync extends this hardened server-authoritative broadcast loop
+
+## Impact
+
+- Affected specs: `multiplayer-server` (new `## ADDED` requirements for durable store, recovery, host migration, rate-limiting, replay protection) and `multiplayer-sync` (new `## ADDED` requirement documenting the DP1 fallback-demotion contract). No `MODIFIED` or `REMOVED` — new behavior is expressed as new requirements added alongside the existing ones.
+- Affected code: a new durable store under `src/lib/multiplayer/server/` implementing `IMatchStore`; `src/lib/multiplayer/server/InMemoryMatchStore.ts` (kept, fallback only); `ServerMatchHost` and its reconnect-lifecycle satellites (`ServerMatchHostReconnectLifecycle`, `PendingPeerTracker`) for host migration; a startup recovery routine; intent dispatch (`ServerMatchHostIntent`) for rate-limiting and replay-id checks
+- New `Error` codes: `RATE_LIMITED`, `DUPLICATE_INTENT`
+- Database / persistence: the durable store introduces a persistence backend; its schema or file layout is frozen in this change's design.md
+- Reproducibility preserved: the durable store persists the same event log; replaying it reconstructs identical state, and seeded debug mode is unchanged
+
+## Non-Goals
+
+- The networked game surface itself — M1 (`complete-multiplayer-game-surface`)
+- Match browser, matchmaking, spectator seats — M3 (`add-matchmaking-and-spectator`)
+- Removing the y-webrtc / P2P code — DP1 demotes it to a documented fallback; deleting it is out of scope
+- Self-hosted WebRTC signaling — the roadmap's earlier M2 framing; superseded by DP1's "consolidate on the authoritative server"
+- Any change to the authoritative engine, roll capture, or fog redaction — those are correct and untouched
+- Co-op campaign state sync — Wave 5 (CO1), which depends on this change

--- a/openspec/changes/harden-multiplayer-transport/specs/multiplayer-server/spec.md
+++ b/openspec/changes/harden-multiplayer-transport/specs/multiplayer-server/spec.md
@@ -1,0 +1,121 @@
+## ADDED Requirements
+
+### Requirement: Durable Match Store
+
+The system SHALL provide a durable `IMatchStore` implementation that persists match metadata and the full event log across a server process restart. It SHALL implement the existing `IMatchStore` interface without modification, so the server core and call sites depend only on `IMatchStore`. `InMemoryMatchStore` SHALL be retained as the explicitly dev-labeled fallback.
+
+#### Scenario: Durable store survives a process restart
+
+- **GIVEN** a durable match store with an `active` match holding 30 persisted events
+- **WHEN** the server process restarts and the store is re-opened
+- **THEN** `getMatchMeta` SHALL return the match's metadata
+- **AND** `getEvents` SHALL return all 30 events in ascending `sequence` order with no gaps
+
+#### Scenario: Durable append is transactional
+
+- **GIVEN** the durable store handling two `appendEvent` calls for the same match with the same `sequence`
+- **WHEN** both are processed
+- **THEN** exactly one SHALL succeed
+- **AND** the other SHALL reject with `MatchStoreSequenceCollisionError`
+- **AND** the succeeding event SHALL be durably committed before the promise resolves
+
+#### Scenario: Default store selection is environment-aware
+
+- **GIVEN** the server selecting its match store via `getDefaultMatchStore()`
+- **WHEN** the process runs in production
+- **THEN** the durable store SHALL be returned
+- **AND** in development or test the in-memory store SHALL be returned
+
+### Requirement: Active Match Recovery on Startup
+
+The server SHALL, on startup, enumerate every match with `status: 'active'` in the durable store and re-instantiate a `ServerMatchHost` for each, rebuilding its `InteractiveSession` by replaying the stored event log.
+
+#### Scenario: Active matches rebuilt after restart
+
+- **GIVEN** a durable store containing two `active` matches
+- **WHEN** the server starts up
+- **THEN** a `ServerMatchHost` SHALL be instantiated for each of the two matches
+- **AND** each host's session SHALL reflect the full replayed event log
+
+#### Scenario: Client reconnects after recovery
+
+- **GIVEN** a recovered `active` match and a client reconnecting with its `lastSeq`
+- **WHEN** the client sends `SessionJoin`
+- **THEN** the server SHALL stream the events newer than `lastSeq` via `ReplayStart`, `ReplayChunk`, and `ReplayEnd`
+
+### Requirement: Host Migration on Host Disconnect
+
+When the connection of the player holding `hostPlayerId` is lost, the server SHALL promote a surviving connected human seat to `hostPlayerId` so privileged operations remain available, rather than aborting the match. The promotion SHALL be recorded in `IMatchMeta` and broadcast to all connected clients.
+
+#### Scenario: Surviving seat promoted to host
+
+- **GIVEN** an active match whose host's socket has dropped while another human seat remains connected
+- **WHEN** the server detects the host-connection loss
+- **THEN** the longest-connected surviving human seat SHALL be promoted to `hostPlayerId`
+- **AND** the new `hostPlayerId` SHALL be persisted via `updateMatchMeta`
+- **AND** all connected clients SHALL be notified of the migration
+
+#### Scenario: Privileged operations work for the migrated host
+
+- **GIVEN** a match whose host privilege has migrated to a surviving player
+- **WHEN** that player performs a privileged operation
+- **THEN** the server SHALL authorize it against the migrated `hostPlayerId`
+
+#### Scenario: Migration repeats if the promoted holder also disconnects
+
+- **GIVEN** a match whose migrated host then also disconnects while another human seat survives
+- **WHEN** the server detects the second host-connection loss
+- **THEN** the promotion SHALL repeat to the next surviving human seat
+
+### Requirement: Graceful Degradation on Host-Connection Loss
+
+The server SHALL route a host-connection loss through the existing pending/grace mechanism so the match pauses rather than aborting. The match SHALL resume on host reconnect within the grace window and SHALL complete cleanly through the normal outcome path on grace expiry, never via the legacy abort path.
+
+#### Scenario: Host blip pauses then resumes
+
+- **GIVEN** an active server-authoritative match
+- **WHEN** the host's connection is lost and then re-established within the grace window
+- **THEN** the match SHALL broadcast `MatchPaused` on the loss
+- **AND** the match SHALL broadcast `MatchResumed` on the host's reconnect
+
+#### Scenario: Grace expiry completes the match cleanly
+
+- **GIVEN** a paused match whose host has not reconnected
+- **WHEN** the grace timer expires
+- **THEN** the match SHALL complete through the normal outcome path
+- **AND** the match SHALL NOT end with the legacy `reason: 'aborted'` abort
+
+### Requirement: Intent Rate-Limiting
+
+The authoritative server SHALL apply a per-connection token-bucket rate limit to inbound intents. An intent that exceeds the configured budget SHALL be rejected with a non-fatal `Error {code: 'RATE_LIMITED'}`, the connection SHALL remain open, and no event SHALL be appended. Heartbeat and replay traffic SHALL be exempt.
+
+#### Scenario: Intent flood is throttled
+
+- **GIVEN** a connection sending intents faster than the configured budget
+- **WHEN** the budget is exceeded
+- **THEN** the server SHALL reply `Error {code: 'RATE_LIMITED'}`
+- **AND** no event SHALL be appended for the rejected intent
+- **AND** the WebSocket connection SHALL remain open
+
+#### Scenario: Legitimate play is not throttled
+
+- **GIVEN** a connection sending intents at a worst-case human play rate
+- **WHEN** the server processes them
+- **THEN** no intent SHALL be rejected with `RATE_LIMITED`
+
+### Requirement: Replay-Attack Protection
+
+Every `Intent` envelope SHALL carry a unique id, and the server SHALL maintain a per-match bounded set of accepted intent ids. An inbound intent whose id has already been accepted SHALL be rejected with `Error {code: 'DUPLICATE_INTENT'}` and SHALL append no event. The accepted-id set SHALL be reconstructed on match recovery so a restart does not reopen the replay window.
+
+#### Scenario: Re-sent intent is rejected
+
+- **GIVEN** an intent envelope the server has already accepted for a match
+- **WHEN** the same envelope is received again
+- **THEN** the server SHALL reply `Error {code: 'DUPLICATE_INTENT'}`
+- **AND** no event SHALL be appended
+
+#### Scenario: Replay window is closed after recovery
+
+- **GIVEN** a match recovered from the durable store on server restart
+- **WHEN** an intent previously accepted before the restart is re-sent
+- **THEN** the server SHALL reject it as a duplicate

--- a/openspec/changes/harden-multiplayer-transport/specs/multiplayer-sync/spec.md
+++ b/openspec/changes/harden-multiplayer-transport/specs/multiplayer-sync/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Authoritative Server Is the Supported Transport
+
+The system SHALL treat the authoritative server WebSocket as the supported transport for networked matches. The y-webrtc / peer-to-peer path SHALL be a non-authoritative fallback that receives no further hardening. The `mirrorSession` / `gameSessionChannel` event-application pattern SHALL be retained only as the client-side event-application layer, pointed at the server WebSocket rather than at y-webrtc.
+
+#### Scenario: Networked match runs over the server transport
+
+- **GIVEN** two players in a networked match
+- **WHEN** the match is played
+- **THEN** intents and events SHALL flow over the authoritative server WebSocket
+- **AND** the match SHALL NOT depend on a y-webrtc peer connection for correctness
+
+#### Scenario: Mirror pattern points at the server
+
+- **GIVEN** a client participating in a networked match
+- **WHEN** the client builds its mirror session
+- **THEN** the mirror SHALL be fed by the server `Event` stream
+- **AND** the `mirrorSession` / `gameSessionChannel` reducer SHALL be the client-side event-application layer for that stream
+
+#### Scenario: P2P is a non-authoritative fallback
+
+- **GIVEN** the y-webrtc peer-to-peer path
+- **WHEN** the transport contract is inspected
+- **THEN** the y-webrtc path SHALL be documented as a non-authoritative fallback
+- **AND** authoritative roll capture, fog redaction, and intent integrity SHALL be provided only by the server path

--- a/openspec/changes/harden-multiplayer-transport/tasks.md
+++ b/openspec/changes/harden-multiplayer-transport/tasks.md
@@ -1,0 +1,58 @@
+# Tasks: Harden the Multiplayer Transport
+
+## 1. Durable Match Store
+
+- [ ] 1.1 Add a durable `IMatchStore` implementation backed by an embedded transactional persistent store, implementing the `IMatchStore` interface unchanged
+- [ ] 1.2 Persist `IMatchMeta` per match and each `IGameEvent` keyed by `(matchId, sequence)` with a unique constraint enforcing the sequence-collision guarantee
+- [ ] 1.3 Make `appendEvent` transactional all-or-nothing, rejecting a sequence collision with `MatchStoreSequenceCollisionError`
+- [ ] 1.4 Make `getEvents` return events ordered by ascending `sequence` with no gaps; `closeMatch` idempotent
+- [ ] 1.5 Wire `getDefaultMatchStore()` to select the durable store in production and `InMemoryMatchStore` in dev/test
+- [ ] 1.6 Tests: round-trip meta and event log; sequence collision rejected; ordering preserved; the durable store passes the same contract tests as `InMemoryMatchStore`
+
+## 2. Server-Startup Match Recovery
+
+- [ ] 2.1 Add a startup recovery routine that enumerates `status: 'active'` matches from the durable store
+- [ ] 2.2 For each recovered match, re-instantiate a `ServerMatchHost` whose `InteractiveSession` is rebuilt by replaying the stored event log
+- [ ] 2.3 Tests: a match with persisted events survives a simulated process restart; a reconnecting client receives the missing events from its `lastSeq`
+
+## 3. Host Migration
+
+- [ ] 3.1 On host-socket loss, promote the longest-connected surviving human seat to `hostPlayerId` for privileged operations
+- [ ] 3.2 Record the promotion in `IMatchMeta` via `updateMatchMeta` and broadcast it to all connected clients
+- [ ] 3.3 If the promoted holder also disconnects, repeat the promotion; if no human seat survives, fall through to the grace path
+- [ ] 3.4 Tests: host disconnect promotes a survivor; privileged operations work for the new holder; the original host's reconnect does not abort the match
+
+## 4. Graceful Degradation
+
+- [ ] 4.1 Route a host-connection loss through the existing pending/grace mechanism (`PendingPeerTracker`) so the match pauses rather than aborts
+- [ ] 4.2 Resume the match on host reconnect within grace; complete it cleanly through the existing outcome path on grace expiry
+- [ ] 4.3 Ensure the legacy `reason: 'aborted'` abort path is not taken for a server-authoritative match
+- [ ] 4.4 Tests: host blip pauses then resumes the match; grace expiry completes the match cleanly without an abort
+
+## 5. Intent Rate-Limiting
+
+- [ ] 5.1 Add a per-connection token-bucket rate limiter to the authoritative intent dispatch, with a configured budget
+- [ ] 5.2 Reject an over-budget intent with a non-fatal `Error {code: 'RATE_LIMITED'}`; keep the connection open and append no event
+- [ ] 5.3 Exempt heartbeat and replay traffic from the limiter
+- [ ] 5.4 Tests: a flood of intents trips the limiter; a worst-case human play rate never trips it; a rejected intent appends no event
+
+## 6. Replay-Attack Protection
+
+- [ ] 6.1 Require every `Intent` envelope to carry a unique id; maintain a per-match bounded set of accepted intent ids
+- [ ] 6.2 Reject an intent whose id is already accepted with `Error {code: 'DUPLICATE_INTENT'}` and append no event
+- [ ] 6.3 Reconstruct the accepted-id set from the event log on recovery so a restart does not reopen the replay window
+- [ ] 6.4 Tests: a re-sent intent envelope is rejected and produces no event; the set is reconstructed correctly after recovery
+
+## 7. Transport Consolidation (DP1)
+
+- [ ] 7.1 Document the authoritative server WebSocket as the supported transport and y-webrtc as a non-authoritative fallback
+- [ ] 7.2 Confirm the client-side `mirrorSession` / `gameSessionChannel` pattern is retained only as the client event-application layer pointed at the server WebSocket
+- [ ] 7.3 Tests: a networked match runs end-to-end over the server WebSocket transport with no y-webrtc dependency
+
+## 8. Verification
+
+- [ ] 8.1 Integration test: an active match survives a server restart and both clients reconnect to the rebuilt host
+- [ ] 8.2 Integration test: a host disconnect mid-match migrates host privilege and the match continues to completion
+- [ ] 8.3 Stress test: measure `appendEvent` latency under the durable store and confirm the rate-limit budget is not tripped by legitimate play
+- [ ] 8.4 `openspec validate harden-multiplayer-transport --strict` passes
+- [ ] 8.5 `npm run build`, lint, and `tsc --noEmit` typecheck all pass

--- a/openspec/council-decisions/waves-2-5-decomposition.md
+++ b/openspec/council-decisions/waves-2-5-decomposition.md
@@ -1,0 +1,70 @@
+# OMO Council Decision — Waves 2-5 Decomposition
+
+**Date:** 2026-05-19
+**Question:** Decompose roadmap Waves 2-5 into concrete, dependency-ordered OpenSpec changes and resolve the open architectural decision points.
+**Variant:** Lean++ thin (Metis pre-phase + Oracle / Explore-Deep / Momus).
+**Survival score:** 7/10.
+
+## Architectural decisions
+
+### DP1 — Multiplayer transport: consolidate on the authoritative server
+`src/lib/multiplayer/server/ServerMatchHost.ts` and its satellites are a finished, mature server-authoritative stack — per-intent roll capture, fog-of-war redaction, reconnection grace timers, lobby intents, replay streaming, Wave-5 outcome publisher. There is **no rewrite**. Wave 3 hardens this server; P2P / y-webrtc is demoted to a fallback we stop investing in. The P2P `mirrorSession` / `gameSessionChannel` event-application pattern is kept as the **client-side** layer, pointed at the server WebSocket instead of y-webrtc. Cheating defense (roll capture, intent zod-refinement, fog redaction) is structurally impossible on a peer mesh — this decision is what makes Wave 3 M2 integrity achievable.
+
+### DP2 — Co-op campaign authority: host-as-GM, server-arbitrated (NOT CRDT)
+Campaign state is a transactional ledger (money, hiring, contract acceptance, salvage allocation). Yjs `Y.Map` last-writer-wins silently resolves "both players spent the same C-bills" with no overdraft check — CRDTs guarantee convergence, not correctness. **This overrides the roadmap's CO1 "extend Yjs vault-sync" plan.** Co-op campaign reuses the `ServerMatchHostIntent` pattern: a guest's "hire pilot" / "accept contract" is an intent the host validates against current state, then broadcasts the resulting campaign event. Sync uses the **server-authoritative event-broadcast channel** with campaign event payloads; the guest's campaign store is a read-only mirror. The Yjs vault-sync (`useSyncedVaultStore`) stays for the content library (sharing unit/pilot designs) only — LWW is harmless there.
+
+### DP3 — Wave ordering: Wave 2 (AI) before Wave 4 (campaign). Closed.
+Confirmed by roadmap §5 and user. Wave 3 (multiplayer) is independent and may run in parallel if staffed.
+
+## Final decomposition — 15 changes
+
+### Wave 2 — Tactical AI (5 changes)
+| Slug | Scope | Capability | Depends on |
+|---|---|---|---|
+| `add-ai-terrain-aware-movement` (A1) | Terrain-cost pathfinder + LOS/cover-aware move scoring; introduces the **AI Difficulty Tier Registry** (ADDED to `simulation-system`); design.md freezes the pathfinder API contract. Extract `getTerrainMovementCost` from `renderHelpers.ts` into a shared sim util. | `simulation-system` | Wave 1 (terrain/objectives) |
+| `add-ai-resource-planning` (A2) | Multi-turn heat lookahead, ammo-runway projection, crit-seeking + weapon-mode selection (LB-X cluster/slug). | `simulation-system` | A1 |
+| `add-ai-coordination-tactics` (A3a) | Lance/formation tactics, multi-unit threat aggregation. | `simulation-system` | A1 (pathfinder API) |
+| `add-ai-objective-awareness` (A3b) | AI reads scenario objective markers and plays the scenario, not just kills. | `simulation-system` | Wave 1 `add-scenario-objective-engine`, A3a |
+| `add-ai-advanced-systems` (A4) | Jump-jet tactics; ECM-awareness (consumes existing `src/utils/gameplay/electronicWarfare/`); spotting/vision (consumes existing `fogOfWar.ts`). | `simulation-system` | A1, A2 |
+
+Each A-change ADDs its tier parameters to the **AI Difficulty Tier Registry** requirement in `simulation-system` — all-ADDED, no MODIFIED chaining. Difficulty tiers are player-selectable (Veteran = A1+A2 depth, Elite = A3+A4).
+
+### Wave 3 — Multiplayer (3 changes)
+| Slug | Scope | Depends on |
+|---|---|---|
+| `complete-multiplayer-game-surface` (M1) | Replace the `active`-state stub at `src/pages/multiplayer/lobby/[roomCode].tsx:307-325` with the real networked game UI — board state over WS, intent send/receive, opponent moves. The critical gap. | — (server infra exists) |
+| `harden-multiplayer-transport` (M2) | Consolidate on the authoritative server; durable match store (replace `InMemoryMatchStore`); host migration / graceful degradation; intent rate-limiting + replay-attack protection (former M3, merged in). | M1 |
+| `add-matchmaking-and-spectator` (M3) | Match browser / matchmaking; spectator seat type (consumes existing server FoW). | M1, M2 |
+
+### Wave 4 — Campaign (5 changes)
+| Slug | Scope | Depends on |
+|---|---|---|
+| `add-campaign-persistence` (CP0) | Server-side campaign save/load API + store. Foundational — also a co-op prerequisite. | — |
+| `add-campaign-combat-loop` (CP1) | Auto `GameSession`→`pendingBattleOutcomes` trigger; scenario-event→`IEncounter` persistence bridge; mission→encounter launch. **Scoped to integration wire-up** — `postBattleProcessor`/`salvageProcessor`/`repairQueueBuilder` are 60-70% built. CP1 design.md freezes the inventory schema. | CP0 |
+| `add-campaign-bay-ui` (CP2a) | Mech bay, repair bay, medical, salvage-acceptance UI surfaces. | CP1 (inventory schema) |
+| `add-campaign-command-ui` (CP2b) | Personnel/hiring, finances/loans, contract-market UI surfaces. | CP0 |
+| `add-campaign-refit-and-prestige` (CP3) | Refit / equipment-swap; prestige + morale state machine. Other business logic (faction standing, markets, negotiation) already exists — scoped narrow. | CP2a |
+
+Roadmap's CP4 (`campaign-events-and-generation`) is **dropped** — `randomEventsProcessor`, contract processors, and `scenarioGenerationProcessor` already exist; the genuine remnant (encounter persistence) folds into CP1.
+
+### Wave 5 — Co-op Campaign (2 changes)
+| Slug | Scope | Depends on |
+|---|---|---|
+| `add-shared-campaign-state` (CO1) | Extend the **server-authoritative event-broadcast loop** to campaign state — campaign event log + guest mirror. NOT Yjs vault-sync (see DP2). | CP0, CP1, M2 |
+| `add-coop-campaign-play` (CO2) | Co-op mission launch with both players' forces + host-as-GM authority model (intent→validate→commit→broadcast for campaign decisions). Former CO2+CO3, merged. | CO1 |
+
+## Built-vs-missing notes (Explore-Deep)
+
+- **Wave 2:** `MoveAI.scoreMove` weighs LOS (terrain-aware via `calculateLOS`) but NOT movement-point cost or cover. `AttackAI` heat budget is single-turn; no crit-seeking. ECM module and server FoW already exist — A4 wires them into AI, does not build them.
+- **Wave 3:** Server infra, lobby state machine, and lobby UI are all real. The `active`-state game surface is a hardcoded stub. No durable match store, no matchmaking/browser, no spectator seat.
+- **Wave 4:** Day-pipeline + 12 processors + `postBattleProcessor` all built. Gaps: scenario-event→`IEncounter` bridge, repair/medical/salvage execution UI, server-side campaign persistence.
+- **Wave 5:** `SyncableItemType` = `unit|pilot|force` — no campaign type. Campaign state is entirely outside any sync boundary today.
+
+## Preserved dissent (Momus)
+
+- A4's ECM "play" may require to-hit modifiers in the **core combat engine**, which may not be implemented. A4 is scoped to **AI-awareness only**; if engine ECM modifiers are missing, that is a flagged question for a later change — A4 must not silently expand into engine work.
+- CP2a/CP2b remain large (UI surface area). If a single change exceeds ~80 tasks during authoring, split further into PR sub-waves.
+
+## Implementation order
+
+PR by PR, sequential to keep CI green: Wave 1 (3) → Wave 2 (A1→A2→A3a→A3b→A4) → Wave 3 (M1→M2→M3) → Wave 4 (CP0→CP1→CP2a→CP2b→CP3) → Wave 5 (CO1→CO2). 18 changes total.


### PR DESCRIPTION
## Summary

Authors 18 OpenSpec changes covering the full-functionality roadmap (procedurally-generated tabletop combat, best-possible tactical AI, real-time multiplayer, MekHQ-style campaign — solo or co-op).

- **Wave 1 (3):** `add-scenario-objective-engine`, `add-procedural-map-variety`, `add-combat-morale-and-withdrawal`
- **Wave 2 (5):** tactical AI — `add-ai-terrain-aware-movement`, `add-ai-resource-planning`, `add-ai-coordination-tactics`, `add-ai-objective-awareness`, `add-ai-advanced-systems`
- **Wave 3 (3):** `complete-multiplayer-game-surface`, `harden-multiplayer-transport`, `add-matchmaking-and-spectator`
- **Wave 4 (5):** `add-campaign-persistence`, `add-campaign-combat-loop`, `add-campaign-bay-ui`, `add-campaign-command-ui`, `add-campaign-refit-and-prestige`
- **Wave 5 (2):** `add-shared-campaign-state`, `add-coop-campaign-play`

## Architecture decisions (OMO Council)

Recorded in `openspec/council-decisions/waves-2-5-decomposition.md`:
- **DP1** — consolidate multiplayer on the existing authoritative server; demote P2P/y-webrtc to fallback (no rewrite — `ServerMatchHost` is already mature).
- **DP2** — co-op campaign uses host-as-GM server-arbitrated intents, **not** Yjs CRDT (a transactional ledger cannot tolerate last-writer-wins).

## Validation

All 18 changes pass `openspec validate --strict`. Specs only — no code. Implementation follows PR by PR, wave by wave.