### PR TITLE
feat(combat): scenario objective engine

### DIFF
--- a/openspec/changes/add-scenario-objective-engine/tasks.md
+++ b/openspec/changes/add-scenario-objective-engine/tasks.md
@@ -2,52 +2,52 @@
 
 ## 1. Objective Data Model
 
-- [ ] 1.1 Add `IObjectiveMarker`, `HexKey`, `ObjectiveControlRule`, and `IObjectiveOutcome` to `src/types/scenario/ScenarioInterfaces.ts`
-- [ ] 1.2 Add `objectives: Record<HexKey, IObjectiveMarker>` to the game-session state type in `src/types/gameplay/GameSessionCoreTypes.ts`, defaulting to `{}`
-- [ ] 1.3 Map each non-`destroy` `IVictoryCondition` onto objective config (hex count, `holdTurnsRequired`, `requiredUnits`)
-- [ ] 1.4 Unit tests for the new types and a session serialization round-trip preserving the objective map
+- [x] 1.1 Add `IObjectiveMarker`, `HexKey`, `ObjectiveControlRule`, and `IObjectiveOutcome` to `src/types/scenario/ScenarioInterfaces.ts`
+- [x] 1.2 Add `objectives: Record<HexKey, IObjectiveMarker>` to the game-session state type in `src/types/gameplay/GameSessionCoreTypes.ts`, defaulting to `{}`
+- [x] 1.3 Map each non-`destroy` `IVictoryCondition` onto objective config (hex count, `holdTurnsRequired`, `requiredUnits`)
+- [x] 1.4 Unit tests for the new types and a session serialization round-trip preserving the objective map
 
 ## 2. Objective Placement During Generation
 
-- [ ] 2.1 In `ScenarioGenerator`, place objective hexes per objective type — Capture: 1–3 interior hexes; Defend: hexes inside the defender deployment zone; Breakthrough: exit-edge hexes opposite the attacker deployment
-- [ ] 2.2 Seed placement from the scenario seed so identical seeds yield identical objective maps
-- [ ] 2.3 Tests: each objective type yields a valid non-empty objective map; same seed → identical placement; markers sit on in-bounds hexes
+- [x] 2.1 In `ScenarioGenerator`, place objective hexes per objective type — Capture: 1–3 interior hexes; Defend: hexes inside the defender deployment zone; Breakthrough: exit-edge hexes opposite the attacker deployment
+- [x] 2.2 Seed placement from the scenario seed so identical seeds yield identical objective maps
+- [x] 2.3 Tests: each objective type yields a valid non-empty objective map; same seed → identical placement; markers sit on in-bounds hexes
 
 ## 3. Objective Control Detection
 
-- [ ] 3.1 Implement `detectObjectiveControl(marker, session)` — sole-occupancy rule, contested keeps the last controller
-- [ ] 3.2 Implement per-turn `holdProgress` advancement (increment while held, reset to 0 on loss of control)
-- [ ] 3.3 Tests: sole occupancy flips control; contested keeps last controller; a vacated hex keeps its last controller
+- [x] 3.1 Implement `detectObjectiveControl(marker, session)` — sole-occupancy rule, contested keeps the last controller
+- [x] 3.2 Implement per-turn `holdProgress` advancement (increment while held, reset to 0 on loss of control)
+- [x] 3.3 Tests: sole occupancy flips control; contested keeps last controller; a vacated hex keeps its last controller
 
 ## 4. Objective Victory Evaluation
 
-- [ ] 4.1 Implement `evaluateObjectiveOutcome(session): IObjectiveOutcome | null` covering Destroy / Capture / Defend / Breakthrough
-- [ ] 4.2 Capture: attacker wins when it holds all objective hexes for `holdTurnsRequired` consecutive turns
-- [ ] 4.3 Defend: defender wins at `turnLimit` if still in control; attacker wins immediately on capturing all objective hexes
-- [ ] 4.4 Breakthrough: attacker wins when `requiredUnits` of its units have reached an exit hex
-- [ ] 4.5 Tests per objective type, including partial progress, control loss mid-hold, and timeout
+- [x] 4.1 Implement `evaluateObjectiveOutcome(session): IObjectiveOutcome | null` covering Destroy / Capture / Defend / Breakthrough
+- [x] 4.2 Capture: attacker wins when it holds all objective hexes for `holdTurnsRequired` consecutive turns
+- [x] 4.3 Defend: defender wins at `turnLimit` if still in control; attacker wins immediately on capturing all objective hexes
+- [x] 4.4 Breakthrough: attacker wins when `requiredUnits` of its units have reached an exit hex
+- [x] 4.5 Tests per objective type, including partial progress, control loss mid-hold, and timeout
 
 ## 5. Game-Over Wiring
 
-- [ ] 5.1 Call `evaluateObjectiveOutcome` from the game-over check in `GameOutcomeCalculator` / `SimulationRunnerState` / `gameSessionCore` before the destruction fallback
-- [ ] 5.2 An objective outcome takes precedence over the turn-limit draw
-- [ ] 5.3 Tests: an objective win ends the game even with units alive on both sides; a markerless scenario still ends on destruction
+- [x] 5.1 Call `evaluateObjectiveOutcome` from the game-over check in `GameOutcomeCalculator` / `SimulationRunnerState` / `gameSessionCore` before the destruction fallback
+- [x] 5.2 An objective outcome takes precedence over the turn-limit draw
+- [x] 5.3 Tests: an objective win ends the game even with units alive on both sides; a markerless scenario still ends on destruction
 
 ## 6. Objective Marker Rendering
 
-- [ ] 6.1 Add `ObjectiveMarkersLayer` to `HexMapDisplay.layers`, above the terrain overlay and below unit tokens
-- [ ] 6.2 Style markers by control state — neutral / friendly / enemy / contested — and show `holdProgress` for Capture
-- [ ] 6.3 Storybook story plus render tests for each control state
+- [x] 6.1 Add `ObjectiveMarkersLayer` to `HexMapDisplay.layers`, above the terrain overlay and below unit tokens
+- [x] 6.2 Style markers by control state — neutral / friendly / enemy / contested — and show `holdProgress` for Capture
+- [x] 6.3 Storybook story plus render tests for each control state
 
 ## 7. Objective Lifecycle Events
 
-- [ ] 7.1 Add `ObjectiveCaptured`, `ObjectiveLost`, `ObjectiveProgress` to `GameEventType` with payloads
-- [ ] 7.2 Emit the events from the control-detection pass once per turn
-- [ ] 7.3 Tests: events are deterministic; replaying the event log reconstructs objective state
+- [x] 7.1 Add `ObjectiveCaptured`, `ObjectiveLost`, `ObjectiveProgress` to `GameEventType` with payloads
+- [x] 7.2 Emit the events from the control-detection pass once per turn
+- [x] 7.3 Tests: events are deterministic; replaying the event log reconstructs objective state
 
 ## 8. Verification
 
-- [ ] 8.1 Integration test: a generated Capture scenario is won by holding the objective for the required turns
-- [ ] 8.2 Integration test: a generated Breakthrough scenario is won by moving the required units to the exit edge
-- [ ] 8.3 Integration test: a generated Defend scenario is won by the defender surviving to the turn limit in control
-- [ ] 8.4 `openspec validate --strict` clean; build, lint, and typecheck pass
+- [x] 8.1 Integration test: a generated Capture scenario is won by holding the objective for the required turns
+- [x] 8.2 Integration test: a generated Breakthrough scenario is won by moving the required units to the exit edge
+- [x] 8.3 Integration test: a generated Defend scenario is won by the defender surviving to the turn limit in control
+- [x] 8.4 `openspec validate --strict` clean; build, lint, and typecheck pass

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.layers.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.layers.tsx
@@ -7,10 +7,13 @@ import type {
   IHexTerrain,
   IUnitToken,
 } from '@/types/gameplay';
+import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
 
 import { UnitTokenForType } from '@/components/gameplay/UnitToken/UnitTokenForType';
 import { HEX_SIZE } from '@/constants/hexMap';
-import { coordToKey } from '@/utils/gameplay/hexMath';
+import { GameSide } from '@/types/gameplay';
+import { coordToKey, keyToCoord } from '@/utils/gameplay/hexMath';
+import { gameSideToObjectiveSide } from '@/utils/gameplay/objectives';
 
 import type { MapInteractionState } from './useMapInteraction';
 
@@ -59,6 +62,129 @@ export function SensorRingsLayer({
             />
           );
         })}
+    </g>
+  );
+}
+
+/**
+ * Per `add-scenario-objective-engine` (D6 / task 6): control-state
+ * styling for objective markers. `contested` is the visually-distinct
+ * style for a hex occupied by both sides; it is derived per-render
+ * from token positions, never stored on the marker.
+ */
+const OBJECTIVE_MARKER_STYLES: Record<
+  'neutral' | 'friendly' | 'enemy' | 'contested',
+  { fill: string; stroke: string }
+> = {
+  neutral: { fill: '#94a3b8', stroke: '#475569' },
+  friendly: { fill: '#22c55e', stroke: '#15803d' },
+  enemy: { fill: '#ef4444', stroke: '#b91c1c' },
+  contested: { fill: '#f59e0b', stroke: '#b45309' },
+};
+
+interface ObjectiveMarkersLayerProps {
+  /** Objective markers keyed by canonical `"q,r"` hex key. */
+  readonly objectives: Readonly<Record<string, IObjectiveMarker>>;
+  /** Unit tokens — used to derive the per-render contested state. */
+  readonly tokens: readonly IUnitToken[];
+  /** The viewer's side; drives friendly vs. enemy styling. */
+  readonly friendlySide: GameSide;
+}
+
+/**
+ * Read-only SVG layer that renders every scenario objective marker.
+ * Rendered above the terrain overlay and below unit tokens (D6). Each
+ * marker is styled by `controlSide` (neutral / friendly / enemy) or by
+ * the contested state when both sides occupy the hex. Capture markers
+ * show `holdProgress` toward `holdTurnsRequired`.
+ *
+ * The layer NEVER mutates game state — it only reads markers + token
+ * positions.
+ *
+ * @spec scenario-objectives — Objective Marker Rendering
+ */
+export function ObjectiveMarkersLayer({
+  objectives,
+  tokens,
+  friendlySide,
+}: ObjectiveMarkersLayerProps): React.ReactElement {
+  const friendlyObjectiveSide = gameSideToObjectiveSide(friendlySide);
+
+  return (
+    <g data-testid="objective-markers-layer">
+      {Object.values(objectives).map((marker) => {
+        const coord = keyToCoord(marker.hexKey);
+        const center = hexToPixel(coord);
+
+        // Contested = both sides have at least one token on the hex.
+        let hasFriendly = false;
+        let hasEnemy = false;
+        for (const token of tokens) {
+          if (coordToKey(token.position) !== marker.hexKey) continue;
+          if (token.side === friendlySide) hasFriendly = true;
+          else hasEnemy = true;
+        }
+        const contested = hasFriendly && hasEnemy;
+
+        const styleKey: 'neutral' | 'friendly' | 'enemy' | 'contested' =
+          contested
+            ? 'contested'
+            : marker.controlSide === 'neutral'
+              ? 'neutral'
+              : marker.controlSide === friendlyObjectiveSide
+                ? 'friendly'
+                : 'enemy';
+        const style = OBJECTIVE_MARKER_STYLES[styleKey];
+
+        return (
+          <g
+            key={`objective-${marker.id}`}
+            data-testid={`objective-marker-${marker.id}`}
+            data-objective-type={marker.objectiveType}
+            data-control-state={styleKey}
+            pointerEvents="none"
+          >
+            <circle
+              cx={center.x}
+              cy={center.y}
+              r={HEX_SIZE * 0.55}
+              fill={style.fill}
+              fillOpacity={0.35}
+              stroke={style.stroke}
+              strokeWidth={3}
+            />
+            <text
+              x={center.x}
+              y={center.y - HEX_SIZE * 0.1}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontSize={HEX_SIZE * 0.4}
+              fontWeight="bold"
+              fill={style.stroke}
+            >
+              {marker.objectiveType === 'breakthrough'
+                ? '⮞'
+                : marker.objectiveType === 'defend'
+                  ? '⛨'
+                  : '◎'}
+            </text>
+            {marker.objectiveType === 'capture' && (
+              <text
+                x={center.x}
+                y={center.y + HEX_SIZE * 0.32}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fontSize={HEX_SIZE * 0.28}
+                fontWeight="bold"
+                fill={style.stroke}
+                data-testid={`objective-progress-${marker.id}`}
+              >
+                {marker.holdProgress}/{marker.holdTurnsRequired}
+              </text>
+            )}
+          </g>
+        );
+      })}
     </g>
   );
 }

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.tsx
@@ -10,6 +10,7 @@ import type {
   IGameEvent,
   IWeaponStatus,
 } from '@/types/gameplay';
+import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
 
 import { AttackEffectsLayer } from '@/components/gameplay/effects/AttackEffectsLayer';
 import { PersistentEffectsLayer } from '@/components/gameplay/effects/PersistentEffectsLayer';
@@ -25,6 +26,7 @@ import { HexCell } from './HexCell';
 import {
   MapControls,
   MapHtmlOverlays,
+  ObjectiveMarkersLayer,
   SensorRingsLayer,
   TerrainOverlayLayers,
   UnitTokensLayer,
@@ -47,6 +49,14 @@ export interface HexMapDisplayProps {
   attackRange?: readonly IHexCoordinate[];
   unitWeapons?: Record<string, readonly IWeaponStatus[]>;
   friendlySide?: GameSide;
+  /**
+   * Per `add-scenario-objective-engine` (D6 / task 6): scenario
+   * objective markers keyed by canonical `"q,r"` hex key. When
+   * present, `ObjectiveMarkersLayer` renders them above the terrain
+   * overlay and below unit tokens. Absent / empty → no objective
+   * layer is drawn (markerless scenario).
+   */
+  objectives?: Readonly<Record<string, IObjectiveMarker>>;
   highlightPath?: readonly IHexCoordinate[];
   /**
    * Per `add-movement-phase-ui` task 4.3: cumulative MP cost of the
@@ -119,6 +129,7 @@ export function HexMapDisplay({
   attackRange = [],
   unitWeapons = {},
   friendlySide = GameSide.Player,
+  objectives,
   highlightPath = [],
   hoverMpCost,
   hoverUnreachable = false,
@@ -407,6 +418,19 @@ export function HexMapDisplay({
               testId="los-overlay"
             />
           )}
+
+        {/*
+          Per add-scenario-objective-engine D6: objective markers
+          render above the terrain layer and below unit tokens so a
+          token standing on an objective hex stays visible on top.
+        */}
+        {objectives && Object.keys(objectives).length > 0 && (
+          <ObjectiveMarkersLayer
+            objectives={objectives}
+            tokens={tokens}
+            friendlySide={friendlySide}
+          />
+        )}
 
         <SensorRingsLayer orderedTokens={orderedTokens} />
 

--- a/src/components/gameplay/HexMapDisplay/ObjectiveMarkersLayer.stories.tsx
+++ b/src/components/gameplay/HexMapDisplay/ObjectiveMarkersLayer.stories.tsx
@@ -1,0 +1,149 @@
+/**
+ * Storybook stories for the scenario objective marker layer.
+ *
+ * One story per control state (neutral / friendly / enemy / contested)
+ * plus a mixed-objective-type story, per `add-scenario-objective-engine`
+ * task 6.3.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
+
+import {
+  Facing,
+  GameSide,
+  type IUnitToken,
+  TokenUnitType,
+} from '@/types/gameplay';
+
+import { HexMapDisplay } from './HexMapDisplay';
+
+const meta: Meta<typeof HexMapDisplay> = {
+  title: 'Gameplay/ObjectiveMarkersLayer',
+  component: HexMapDisplay,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="h-[600px] w-full">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof HexMapDisplay>;
+
+function marker(overrides: Partial<IObjectiveMarker>): IObjectiveMarker {
+  return {
+    id: 'objective-1',
+    hexKey: '0,0',
+    objectiveType: 'capture',
+    owningSide: 'neutral',
+    controlSide: 'neutral',
+    controlRule: 'sole-occupancy',
+    holdTurnsRequired: 3,
+    holdProgress: 0,
+    ...overrides,
+  };
+}
+
+function token(overrides: Partial<IUnitToken>): IUnitToken {
+  return {
+    unitId: 'unit',
+    name: 'Unit',
+    side: GameSide.Player,
+    position: { q: 0, r: 0 },
+    facing: Facing.North,
+    isSelected: false,
+    isValidTarget: false,
+    isDestroyed: false,
+    designation: 'UNT',
+    unitType: TokenUnitType.Mech,
+    ...overrides,
+  } as IUnitToken;
+}
+
+export const NeutralObjective: Story = {
+  args: {
+    radius: 5,
+    tokens: [],
+    selectedHex: null,
+    friendlySide: GameSide.Player,
+    objectives: { '0,0': marker({ controlSide: 'neutral', holdProgress: 0 }) },
+  },
+};
+
+export const FriendlyControlled: Story = {
+  args: {
+    radius: 5,
+    tokens: [token({ unitId: 'p1', position: { q: 0, r: 0 } })],
+    selectedHex: null,
+    friendlySide: GameSide.Player,
+    objectives: { '0,0': marker({ controlSide: 'player', holdProgress: 2 }) },
+  },
+};
+
+export const EnemyControlled: Story = {
+  args: {
+    radius: 5,
+    tokens: [
+      token({
+        unitId: 'o1',
+        side: GameSide.Opponent,
+        position: { q: 0, r: 0 },
+      }),
+    ],
+    selectedHex: null,
+    friendlySide: GameSide.Player,
+    objectives: { '0,0': marker({ controlSide: 'opponent', holdProgress: 1 }) },
+  },
+};
+
+export const ContestedObjective: Story = {
+  args: {
+    radius: 5,
+    tokens: [
+      token({ unitId: 'p1', side: GameSide.Player, position: { q: 0, r: 0 } }),
+      token({
+        unitId: 'o1',
+        side: GameSide.Opponent,
+        position: { q: 0, r: 0 },
+      }),
+    ],
+    selectedHex: null,
+    friendlySide: GameSide.Player,
+    objectives: { '0,0': marker({ controlSide: 'player', holdProgress: 0 }) },
+  },
+};
+
+export const MixedObjectiveTypes: Story = {
+  args: {
+    radius: 5,
+    tokens: [],
+    selectedHex: null,
+    friendlySide: GameSide.Player,
+    objectives: {
+      '0,0': marker({
+        id: 'objective-1',
+        hexKey: '0,0',
+        objectiveType: 'capture',
+        controlSide: 'player',
+        holdProgress: 1,
+      }),
+      '2,-1': marker({
+        id: 'objective-2',
+        hexKey: '2,-1',
+        objectiveType: 'defend',
+        controlSide: 'opponent',
+      }),
+      '-2,3': marker({
+        id: 'objective-3',
+        hexKey: '-2,3',
+        objectiveType: 'breakthrough',
+        controlSide: 'neutral',
+      }),
+    },
+  },
+};

--- a/src/components/gameplay/HexMapDisplay/__tests__/ObjectiveMarkersLayer.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/ObjectiveMarkersLayer.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * ObjectiveMarkersLayer render tests.
+ *
+ * Covers `scenario-objectives` delta-spec scenarios for Objective
+ * Marker Rendering (control-state styling, contested distinctness,
+ * Capture hold-progress display).
+ *
+ * @spec openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+ */
+
+import { render } from '@testing-library/react';
+
+import type { IUnitToken } from '@/types/gameplay';
+import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
+
+import { Facing, GameSide, TokenUnitType } from '@/types/gameplay';
+
+import { HexMapDisplay } from '../HexMapDisplay';
+
+function marker(overrides: Partial<IObjectiveMarker> = {}): IObjectiveMarker {
+  return {
+    id: 'objective-1',
+    hexKey: '0,0',
+    objectiveType: 'capture',
+    owningSide: 'neutral',
+    controlSide: 'neutral',
+    controlRule: 'sole-occupancy',
+    holdTurnsRequired: 3,
+    holdProgress: 0,
+    ...overrides,
+  };
+}
+
+function token(overrides: Partial<IUnitToken>): IUnitToken {
+  return {
+    unitId: 'unit',
+    name: 'Unit',
+    side: GameSide.Player,
+    position: { q: 0, r: 0 },
+    facing: Facing.North,
+    isSelected: false,
+    isValidTarget: false,
+    isDestroyed: false,
+    designation: 'UNT',
+    unitType: TokenUnitType.Mech,
+    ...overrides,
+  } as IUnitToken;
+}
+
+function renderMap(
+  objectives: Record<string, IObjectiveMarker>,
+  tokens: IUnitToken[] = [],
+) {
+  return render(
+    <HexMapDisplay
+      radius={5}
+      tokens={tokens}
+      selectedHex={null}
+      objectives={objectives}
+      friendlySide={GameSide.Player}
+    />,
+  );
+}
+
+describe('ObjectiveMarkersLayer', () => {
+  it('renders the layer when objectives are present', () => {
+    const { getByTestId } = renderMap({ '0,0': marker() });
+    expect(getByTestId('objective-markers-layer')).toBeInTheDocument();
+    expect(getByTestId('objective-marker-objective-1')).toBeInTheDocument();
+  });
+
+  it('does not render the layer for a markerless map', () => {
+    const { queryByTestId } = renderMap({});
+    expect(queryByTestId('objective-markers-layer')).not.toBeInTheDocument();
+  });
+
+  it('styles a player-controlled marker with the friendly style', () => {
+    const { getByTestId } = renderMap({
+      '0,0': marker({ controlSide: 'player' }),
+    });
+    expect(
+      getByTestId('objective-marker-objective-1').getAttribute(
+        'data-control-state',
+      ),
+    ).toBe('friendly');
+  });
+
+  it('styles an opponent-controlled marker with the enemy style', () => {
+    const { getByTestId } = renderMap({
+      '0,0': marker({ controlSide: 'opponent' }),
+    });
+    expect(
+      getByTestId('objective-marker-objective-1').getAttribute(
+        'data-control-state',
+      ),
+    ).toBe('enemy');
+  });
+
+  it('styles a neutral marker with the neutral style', () => {
+    const { getByTestId } = renderMap({ '0,0': marker() });
+    expect(
+      getByTestId('objective-marker-objective-1').getAttribute(
+        'data-control-state',
+      ),
+    ).toBe('neutral');
+  });
+
+  it('draws a contested marker with the distinct contested style', () => {
+    const { getByTestId } = renderMap(
+      { '0,0': marker({ controlSide: 'player' }) },
+      [
+        token({
+          unitId: 'p1',
+          side: GameSide.Player,
+          position: { q: 0, r: 0 },
+        }),
+        token({
+          unitId: 'o1',
+          side: GameSide.Opponent,
+          position: { q: 0, r: 0 },
+        }),
+      ],
+    );
+    const el = getByTestId('objective-marker-objective-1');
+    const state = el.getAttribute('data-control-state');
+    expect(state).toBe('contested');
+    // Contested must be distinct from neutral / friendly / enemy.
+    expect(['neutral', 'friendly', 'enemy']).not.toContain(state);
+  });
+
+  it('shows hold progress for a Capture marker', () => {
+    const { getByTestId } = renderMap({
+      '0,0': marker({
+        objectiveType: 'capture',
+        holdProgress: 2,
+        holdTurnsRequired: 3,
+      }),
+    });
+    expect(getByTestId('objective-progress-objective-1').textContent).toBe(
+      '2/3',
+    );
+  });
+});

--- a/src/services/game-resolution/GameOutcomeCalculator.ts
+++ b/src/services/game-resolution/GameOutcomeCalculator.ts
@@ -17,8 +17,10 @@ import {
   IUnitDestroyedPayload,
   IDamageAppliedPayload,
 } from '@/types/gameplay';
+import { ScenarioObjectiveType } from '@/types/scenario/ScenarioInterfaces';
 import { isTurnLimitDraw } from '@/utils/gameplay/gameSessionCore';
 import { deriveState } from '@/utils/gameplay/gameState';
+import { evaluateObjectiveOutcome } from '@/utils/gameplay/objectives/objectiveEngine';
 
 // =============================================================================
 // Types
@@ -196,7 +198,25 @@ export function calculateGameOutcome(
   let winner: 'player' | 'opponent' | 'draw';
   let reason: VictoryReason;
 
-  if (playerEliminated && opponentEliminated) {
+  // Per `add-scenario-objective-engine` (design.md D4 / task 5): an
+  // objective win is evaluated BEFORE the destruction / turn-limit
+  // path so it takes precedence over a turn-limit draw and over
+  // surviving-unit counts. A markerless scenario routes through the
+  // engine's `destroy` path; that outcome is left to fall through to
+  // the destruction branch below so it keeps the richer
+  // `elimination` / `mutual_destruction` reason labels this calculator
+  // has always produced. Only a true objective-marker win (Capture /
+  // Defend / Breakthrough) short-circuits with reason `objective`.
+  const objectiveOutcome = evaluateObjectiveOutcome(state, config.turnLimit);
+  const objectiveDecided =
+    objectiveOutcome !== null &&
+    objectiveOutcome.objectiveType !== ScenarioObjectiveType.Destroy;
+
+  if (objectiveDecided) {
+    winner =
+      objectiveOutcome!.winningSide === GameSide.Player ? 'player' : 'opponent';
+    reason = 'objective';
+  } else if (playerEliminated && opponentEliminated) {
     // Both eliminated
     winner = 'draw';
     reason = 'mutual_destruction';
@@ -337,6 +357,12 @@ export function calculateCombatStats(
  * Check if a game has ended based on current state.
  */
 export function isGameEnded(state: IGameState, config: IGameConfig): boolean {
+  // Per `add-scenario-objective-engine` (task 5): an objective win
+  // ends the game even with units alive on both sides.
+  if (evaluateObjectiveOutcome(state, config.turnLimit) !== null) {
+    return true;
+  }
+
   const playerEliminated = isSideEliminated(state, GameSide.Player);
   const opponentEliminated = isSideEliminated(state, GameSide.Opponent);
 
@@ -360,6 +386,16 @@ export function determineWinner(
   state: IGameState,
   config: IGameConfig,
 ): 'player' | 'opponent' | 'draw' | null {
+  // Per `add-scenario-objective-engine` (task 5): consult the objective
+  // evaluator first so an objective win is reported even while units
+  // survive on both sides.
+  const objectiveOutcome = evaluateObjectiveOutcome(state, config.turnLimit);
+  if (objectiveOutcome !== null) {
+    return objectiveOutcome.winningSide === GameSide.Player
+      ? 'player'
+      : 'opponent';
+  }
+
   const playerSurviving = countSurvivingUnits(state, GameSide.Player);
   const opponentSurviving = countSurvivingUnits(state, GameSide.Opponent);
 

--- a/src/simulation/__tests__/scenarioObjectiveEngine.integration.test.ts
+++ b/src/simulation/__tests__/scenarioObjectiveEngine.integration.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Scenario Objective Engine — integration tests.
+ *
+ * Drives generated scenarios end-to-end through placement, the per-turn
+ * control pass, and the game-over check to prove a Capture / Defend /
+ * Breakthrough scenario can be won by playing to objectives.
+ *
+ * Covers `scenario-objectives` delta-spec tasks 8.1 / 8.2 / 8.3.
+ *
+ * @spec openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+ */
+
+import type { IGameState, IUnitGameState } from '@/types/gameplay';
+
+import {
+  Facing,
+  GamePhase,
+  GameSide,
+  GameStatus,
+  LockState,
+  MovementType,
+} from '@/types/gameplay';
+import { ScenarioObjectiveType } from '@/types/scenario/ScenarioInterfaces';
+import { checkVictoryConditions } from '@/utils/gameplay/gameState';
+import { keyToCoord } from '@/utils/gameplay/hexMath';
+import { runObjectiveControlPass } from '@/utils/gameplay/objectives';
+
+import type { ISimulationConfig } from '../core/types';
+
+import { SeededRandom } from '../core/SeededRandom';
+import {
+  createDefaultTerrainWeights,
+  createDefaultUnitWeights,
+  ScenarioGenerator,
+} from '../generator/ScenarioGenerator';
+
+function makeGenerator(): ScenarioGenerator {
+  return new ScenarioGenerator(
+    createDefaultUnitWeights(),
+    createDefaultTerrainWeights(),
+  );
+}
+
+function baseConfig(
+  objectiveType: ScenarioObjectiveType,
+  overrides: Partial<ISimulationConfig> = {},
+): ISimulationConfig {
+  return {
+    seed: 4242,
+    turnLimit: 8,
+    unitCount: { player: 2, opponent: 2 },
+    mapRadius: 5,
+    objectiveType,
+    ...overrides,
+  };
+}
+
+function unit(
+  id: string,
+  side: GameSide,
+  q: number,
+  r: number,
+): IUnitGameState {
+  return {
+    id,
+    side,
+    position: { q, r },
+    facing: Facing.North,
+    heat: 0,
+    movementThisTurn: MovementType.Stationary,
+    hexesMovedThisTurn: 0,
+    armor: {},
+    structure: {},
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {},
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+  };
+}
+
+/** Replaces a state's units, keeping objectives + turn. */
+function withUnits(state: IGameState, units: IUnitGameState[]): IGameState {
+  return {
+    ...state,
+    units: Object.fromEntries(units.map((u) => [u.id, u])),
+  };
+}
+
+describe('integration — generated Capture scenario won by sustained hold', () => {
+  it('places objectives and is won by holding for the required turns', () => {
+    const generator = makeGenerator();
+    const config = baseConfig(ScenarioObjectiveType.Capture);
+    const session = generator.generate(config, new SeededRandom(config.seed));
+
+    const objectives = session.currentState.objectives;
+    expect(objectives).toBeDefined();
+    expect(Object.keys(objectives!).length).toBeGreaterThanOrEqual(1);
+
+    // Park a player unit on every objective hex; opponent stays away.
+    const objectiveCoords = Object.values(objectives!).map((m) =>
+      keyToCoord(m.hexKey),
+    );
+    const playerUnits = objectiveCoords.map((c, i) =>
+      unit(`player-${i + 1}`, GameSide.Player, c.q, c.r),
+    );
+    const opponentUnits = [unit('opponent-1', GameSide.Opponent, 0, -4)];
+
+    let state: IGameState = withUnits(session.currentState, [
+      ...playerUnits,
+      ...opponentUnits,
+    ]);
+    const holdTurns = Object.values(objectives!)[0].holdTurnsRequired;
+
+    // Run the control pass each turn; the game must NOT be decided
+    // until the hold requirement is met.
+    let decidedTurn = -1;
+    for (let turn = 1; turn <= holdTurns + 2; turn++) {
+      state = { ...state, turn };
+      const pass = runObjectiveControlPass('g', state, 0, turn, GamePhase.End);
+      state = { ...state, objectives: pass.objectives };
+      const winner = checkVictoryConditions(state, {
+        mapRadius: 5,
+        turnLimit: 8,
+        victoryConditions: [],
+        optionalRules: [],
+      });
+      if (winner !== null && decidedTurn === -1) decidedTurn = turn;
+    }
+
+    expect(decidedTurn).toBe(holdTurns);
+    const finalWinner = checkVictoryConditions(state, {
+      mapRadius: 5,
+      turnLimit: 8,
+      victoryConditions: [],
+      optionalRules: [],
+    });
+    expect(finalWinner).toBe(GameSide.Player);
+  });
+});
+
+describe('integration — generated Breakthrough scenario won at the exit edge', () => {
+  it('is won by moving the required units onto an exit hex', () => {
+    const generator = makeGenerator();
+    const config = baseConfig(ScenarioObjectiveType.Breakthrough);
+    const session = generator.generate(config, new SeededRandom(config.seed));
+
+    const objectives = session.currentState.objectives;
+    expect(objectives).toBeDefined();
+    const exitCoord = keyToCoord(Object.values(objectives!)[0].hexKey);
+    // Breakthrough exits sit on the north edge (opposite the attacker).
+    expect(exitCoord.r).toBe(config.mapRadius);
+
+    // Before the unit reaches the exit → undecided.
+    const beforeState = withUnits(session.currentState, [
+      unit('player-1', GameSide.Player, 0, 0),
+      unit('opponent-1', GameSide.Opponent, 0, -4),
+    ]);
+    expect(
+      checkVictoryConditions(beforeState, {
+        mapRadius: 5,
+        turnLimit: 8,
+        victoryConditions: [],
+        optionalRules: [],
+      }),
+    ).toBeNull();
+
+    // Move the required attacker units onto the exit hex.
+    const required = Object.values(objectives!)[0].holdTurnsRequired;
+    const reached = Array.from({ length: required }, (_, i) =>
+      unit(`player-${i + 1}`, GameSide.Player, exitCoord.q, exitCoord.r),
+    );
+    const afterState = withUnits(session.currentState, [
+      ...reached,
+      unit('opponent-1', GameSide.Opponent, 0, -4),
+    ]);
+    expect(
+      checkVictoryConditions(afterState, {
+        mapRadius: 5,
+        turnLimit: 8,
+        victoryConditions: [],
+        optionalRules: [],
+      }),
+    ).toBe(GameSide.Player);
+  });
+});
+
+describe('integration — generated Defend scenario won at the turn limit', () => {
+  it('is won by the defender surviving to the turn limit in control', () => {
+    const generator = makeGenerator();
+    const config = baseConfig(ScenarioObjectiveType.Defend, { turnLimit: 6 });
+    const session = generator.generate(config, new SeededRandom(config.seed));
+
+    const objectives = session.currentState.objectives;
+    expect(objectives).toBeDefined();
+    const objCoord = keyToCoord(Object.values(objectives!)[0].hexKey);
+
+    // Defender (opponent) parks a unit on the objective; attacker
+    // stays off it.
+    let state: IGameState = withUnits(session.currentState, [
+      unit('opponent-1', GameSide.Opponent, objCoord.q, objCoord.r),
+      unit('player-1', GameSide.Player, 0, -4),
+    ]);
+
+    const gameConfig = {
+      mapRadius: 5,
+      turnLimit: 6,
+      victoryConditions: [],
+      optionalRules: [],
+    };
+
+    // Undecided before the turn limit.
+    for (let turn = 1; turn < 6; turn++) {
+      state = { ...state, turn };
+      const pass = runObjectiveControlPass('g', state, 0, turn, GamePhase.End);
+      state = { ...state, objectives: pass.objectives };
+      expect(checkVictoryConditions(state, gameConfig)).toBeNull();
+    }
+
+    // At the turn limit the defender wins while still in control.
+    state = { ...state, turn: 6 };
+    const finalPass = runObjectiveControlPass('g', state, 0, 6, GamePhase.End);
+    state = { ...state, objectives: finalPass.objectives };
+    expect(checkVictoryConditions(state, gameConfig)).toBe(GameSide.Opponent);
+  });
+});
+
+describe('integration — markerless scenario still ends on destruction', () => {
+  it('a destroy scenario generates no objectives and ends on elimination', () => {
+    const generator = makeGenerator();
+    const config = baseConfig(ScenarioObjectiveType.Destroy);
+    const session = generator.generate(config, new SeededRandom(config.seed));
+    expect(session.currentState.objectives).toBeUndefined();
+
+    const gameConfig = {
+      mapRadius: 5,
+      turnLimit: 8,
+      victoryConditions: [],
+      optionalRules: [],
+    };
+    // Both alive → undecided.
+    const alive: IGameState = {
+      gameId: 'g',
+      status: GameStatus.Active,
+      turn: 1,
+      phase: GamePhase.End,
+      activationIndex: 0,
+      units: {
+        'player-1': unit('player-1', GameSide.Player, 0, 0),
+        'opponent-1': unit('opponent-1', GameSide.Opponent, 0, 1),
+      },
+      turnEvents: [],
+    };
+    expect(checkVictoryConditions(alive, gameConfig)).toBeNull();
+
+    // Opponent eliminated → player wins by destruction path.
+    const eliminated: IGameState = {
+      ...alive,
+      units: {
+        'player-1': unit('player-1', GameSide.Player, 0, 0),
+        'opponent-1': {
+          ...unit('opponent-1', GameSide.Opponent, 0, 1),
+          destroyed: true,
+        },
+      },
+    };
+    expect(checkVictoryConditions(eliminated, gameConfig)).toBe(
+      GameSide.Player,
+    );
+  });
+});

--- a/src/simulation/core/types.ts
+++ b/src/simulation/core/types.ts
@@ -2,6 +2,11 @@
  * Core simulation type definitions
  */
 
+import type {
+  ScenarioObjectiveType,
+  VictoryCondition,
+} from '@/types/scenario/ScenarioInterfaces';
+
 import { IGameEvent } from '@/types/gameplay/GameSessionInterfaces';
 
 /**
@@ -22,6 +27,21 @@ export interface ISimulationConfig {
 
   /** Map radius in hexes */
   readonly mapRadius: number;
+
+  /**
+   * Per `add-scenario-objective-engine`: optional scenario objective
+   * type. When set to `capture` / `defend` / `breakthrough`,
+   * `ScenarioGenerator` places objective hexes deterministically from
+   * the seed. Omitted / `destroy` → markerless destruction scenario.
+   */
+  readonly objectiveType?: ScenarioObjectiveType;
+
+  /**
+   * Optional victory conditions used to derive objective placement
+   * detail (Capture objective count, hold turns, Breakthrough
+   * required-units). When absent the placement uses engine defaults.
+   */
+  readonly victoryConditions?: readonly VictoryCondition[];
 }
 
 /**

--- a/src/simulation/generator/ScenarioGenerator.ts
+++ b/src/simulation/generator/ScenarioGenerator.ts
@@ -1,3 +1,5 @@
+import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
+
 import {
   IGameSession,
   IGameState,
@@ -16,6 +18,11 @@ import {
   Facing,
   MovementType,
 } from '@/types/gameplay/HexGridInterfaces';
+import { ScenarioObjectiveType } from '@/types/scenario/ScenarioInterfaces';
+import {
+  deriveObjectivePlacementConfig,
+  placeObjectives,
+} from '@/utils/gameplay/objectives';
 
 import { SeededRandom } from '../core/SeededRandom';
 import { ISimulationConfig } from '../core/types';
@@ -67,10 +74,20 @@ export class ScenarioGenerator {
 
     const unitStates = this.placeUnits(gameUnits, grid, random);
 
+    // Per `add-scenario-objective-engine` (task 2): place objective
+    // hexes for a non-`destroy` scenario. Placement is seeded from the
+    // scenario seed so identical seeds yield identical objective maps.
+    const objectives = this.placeScenarioObjectives(config);
+
+    const objectiveType = config.objectiveType ?? ScenarioObjectiveType.Destroy;
     const gameConfig: IGameConfig = {
       mapRadius: config.mapRadius,
       turnLimit: config.turnLimit,
-      victoryConditions: ['destruction'],
+      victoryConditions: [
+        objectiveType === ScenarioObjectiveType.Destroy
+          ? 'destruction'
+          : objectiveType,
+      ],
       optionalRules: [],
     };
 
@@ -82,6 +99,7 @@ export class ScenarioGenerator {
       activationIndex: 0,
       units: unitStates,
       turnEvents: [],
+      ...(Object.keys(objectives).length > 0 ? { objectives } : {}),
     };
 
     const now = new Date().toISOString();
@@ -95,6 +113,45 @@ export class ScenarioGenerator {
       events: [],
       currentState: gameState,
     };
+  }
+
+  /**
+   * Per `add-scenario-objective-engine` (task 2 + 2.2): derives the
+   * objective placement config from the scenario objective type +
+   * victory conditions, then places objective hexes deterministically
+   * from the scenario seed. Returns an empty map for a markerless
+   * (`destroy` / unset) scenario.
+   *
+   * Deployment rows mirror `placeUnits`: the player occupies
+   * `-(radius - 1)` and the opponent occupies `radius - 1`.
+   */
+  private placeScenarioObjectives(
+    config: ISimulationConfig,
+  ): Record<string, IObjectiveMarker> {
+    const objectiveType = config.objectiveType;
+    if (
+      objectiveType === undefined ||
+      objectiveType === ScenarioObjectiveType.Destroy
+    ) {
+      return {};
+    }
+
+    const placementConfig = deriveObjectivePlacementConfig(
+      objectiveType,
+      config.victoryConditions ?? [],
+    );
+    if (placementConfig === null) return {};
+
+    const radius = config.mapRadius;
+    return placeObjectives(
+      placementConfig,
+      {
+        radius,
+        playerRow: -(radius - 1),
+        opponentRow: radius - 1,
+      },
+      config.seed,
+    );
   }
 
   private generateMap(radius: number, random: SeededRandom): IHexGrid {

--- a/src/simulation/runner/SimulationRunner.ts
+++ b/src/simulation/runner/SimulationRunner.ts
@@ -5,6 +5,7 @@ import {
   ReplaySource,
 } from '@/types/gameplay';
 import { GameSide } from '@/types/gameplay';
+import { runObjectiveControlPass } from '@/utils/gameplay/objectives';
 
 import type { IAIPlayer, AIPlayerFactory } from '../ai/IAIPlayer';
 import type { IWeapon } from '../ai/types';
@@ -142,6 +143,10 @@ export class SimulationRunner {
 
     const grid = createMinimalGrid(config.mapRadius);
     const state = createInitialState(config, this.hydration);
+    // Per `add-scenario-objective-engine`: the objective map seeded
+    // into the initial state is also stamped onto the GameCreated
+    // payload so the persisted event log replays objective state.
+    const seededObjectives = state.objectives;
 
     // Per `emit-game-created-from-runner` (`simulation-system` delta —
     // "Runner Emits GameCreated as Seed Event"): emit `GameCreated` as
@@ -172,6 +177,13 @@ export class SimulationRunner {
             optionalRules: [],
           },
           units: gameUnits,
+          // Per `add-scenario-objective-engine`: stamp the placed
+          // objective markers so the event log fully replays
+          // objective state. Omitted for markerless runs.
+          ...(seededObjectives !== undefined &&
+          Object.keys(seededObjectives).length > 0
+            ? { objectives: seededObjectives }
+            : {}),
         },
       ),
     );
@@ -226,7 +238,7 @@ export class SimulationRunner {
         random: this.random,
       });
 
-      if (isGameOver(currentState)) {
+      if (isGameOver(currentState, config.turnLimit)) {
         break;
       }
 
@@ -246,7 +258,7 @@ export class SimulationRunner {
         random: this.random,
       });
 
-      if (isGameOver(currentState)) {
+      if (isGameOver(currentState, config.turnLimit)) {
         break;
       }
 
@@ -261,6 +273,26 @@ export class SimulationRunner {
       currentState = { ...currentState, phase: GamePhase.End };
       violations.push(...this.invariantRunner.runAll(currentState));
 
+      // Per `add-scenario-objective-engine` (D7 / task 7.2): run the
+      // objective control-detection pass once per turn at the End
+      // phase. It resolves control + hold progress from unit positions
+      // and emits `ObjectiveCaptured` / `ObjectiveLost` /
+      // `ObjectiveProgress` events. No-op for markerless runs.
+      if (
+        currentState.objectives !== undefined &&
+        Object.keys(currentState.objectives).length > 0
+      ) {
+        const pass = runObjectiveControlPass(
+          gameId,
+          currentState,
+          events.length,
+          turn,
+          GamePhase.End,
+        );
+        events.push(...pass.events);
+        currentState = { ...currentState, objectives: pass.objectives };
+      }
+
       events.push(
         createGameEvent(
           gameId,
@@ -271,6 +303,13 @@ export class SimulationRunner {
           { _type: 'turn_ended' as const },
         ),
       );
+
+      // Per `add-scenario-objective-engine` (task 5): an objective win
+      // detected by the End-phase control pass ends the match
+      // immediately — even with units alive on both sides.
+      if (isGameOver(currentState, config.turnLimit)) {
+        break;
+      }
 
       if (this.detectorConfig.haltOnCritical) {
         const anomalyBattleState = buildAnomalyBattleState(currentState);
@@ -292,7 +331,7 @@ export class SimulationRunner {
     }
 
     const durationMs = Date.now() - startTime;
-    const winner = determineWinner(currentState);
+    const winner = determineWinner(currentState, config.turnLimit);
 
     // Phase 0.5 — engine-layer match terminal state. Survivor counts are
     // derived from the same `isUnitOperable` predicate used by

--- a/src/simulation/runner/SimulationRunnerState.ts
+++ b/src/simulation/runner/SimulationRunnerState.ts
@@ -2,10 +2,17 @@ import type {
   IComponentDamageState,
   IGameUnit,
 } from '@/types/gameplay/GameSessionInterfaces';
+import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
 import type { IUnitDamageState } from '@/utils/gameplay/damage';
 
 import { GamePhase, GameSide, GameStatus } from '@/types/gameplay';
 import { CombatLocation, IGameState, IUnitGameState } from '@/types/gameplay';
+import { ScenarioObjectiveType } from '@/types/scenario/ScenarioInterfaces';
+import {
+  deriveObjectivePlacementConfig,
+  placeObjectives,
+} from '@/utils/gameplay/objectives';
+import { evaluateObjectiveOutcome } from '@/utils/gameplay/objectives/objectiveEngine';
 
 import type { ISimulationConfig } from '../core/types';
 
@@ -81,6 +88,13 @@ export function createInitialState(
     hydration,
   );
 
+  // Per `add-scenario-objective-engine` (task 2 + task 5): a runner
+  // config carrying an objective type seeds the objective map so the
+  // simulation loop can be won by holding / capturing / breaking
+  // through, not only by destruction. Markerless configs leave
+  // `objectives` undefined and behave exactly as before.
+  const objectives = buildObjectivesForConfig(config);
+
   return {
     gameId: `sim-${config.seed}`,
     status: GameStatus.Active,
@@ -89,7 +103,44 @@ export function createInitialState(
     activationIndex: 0,
     units,
     turnEvents: [],
+    ...(Object.keys(objectives).length > 0 ? { objectives } : {}),
   };
+}
+
+/**
+ * Per `add-scenario-objective-engine`: derives the objective marker map
+ * for a runner config. Mirrors `ScenarioGenerator`'s deployment-row
+ * convention (`createSideUnits` places the player at `-mapRadius + 1`
+ * and the opponent at `mapRadius - 1`). Returns `{}` for a markerless
+ * (`destroy` / unset) config.
+ */
+export function buildObjectivesForConfig(
+  config: ISimulationConfig,
+): Record<string, IObjectiveMarker> {
+  const objectiveType = config.objectiveType;
+  if (
+    objectiveType === undefined ||
+    objectiveType === ScenarioObjectiveType.Destroy
+  ) {
+    return {};
+  }
+
+  const placementConfig = deriveObjectivePlacementConfig(
+    objectiveType,
+    config.victoryConditions ?? [],
+  );
+  if (placementConfig === null) return {};
+
+  const radius = config.mapRadius;
+  return placeObjectives(
+    placementConfig,
+    {
+      radius,
+      playerRow: -radius + 1,
+      opponentRow: radius - 1,
+    },
+    config.seed,
+  );
 }
 
 /**
@@ -317,7 +368,16 @@ export function isUnitOperable(unit: IUnitGameState): boolean {
   return !unit.destroyed && unit.pilotConscious !== false;
 }
 
-export function isGameOver(state: IGameState): boolean {
+export function isGameOver(state: IGameState, turnLimit = 0): boolean {
+  // Per `add-scenario-objective-engine` (task 5): an objective win
+  // ends the simulation even with units alive on both sides. A
+  // markerless state routes through `destroy` and returns null until
+  // a side is eliminated, so the legacy check below still governs
+  // destruction-only runs.
+  if (evaluateObjectiveOutcome(state, turnLimit) !== null) {
+    return true;
+  }
+
   const playerAlive = Object.values(state.units).some(
     (unit) => unit.side === GameSide.Player && isUnitOperable(unit),
   );
@@ -329,7 +389,17 @@ export function isGameOver(state: IGameState): boolean {
 
 export function determineWinner(
   state: IGameState,
+  turnLimit = 0,
 ): 'player' | 'opponent' | 'draw' | null {
+  // Per `add-scenario-objective-engine` (task 5): an objective outcome
+  // takes precedence over the destruction comparison below.
+  const objectiveOutcome = evaluateObjectiveOutcome(state, turnLimit);
+  if (objectiveOutcome !== null) {
+    return objectiveOutcome.winningSide === GameSide.Player
+      ? 'player'
+      : 'opponent';
+  }
+
   const playerAlive = Object.values(state.units).some(
     (unit) => unit.side === GameSide.Player && isUnitOperable(unit),
   );

--- a/src/types/gameplay/GameSessionCoreTypes.ts
+++ b/src/types/gameplay/GameSessionCoreTypes.ts
@@ -241,6 +241,30 @@ export enum GameEventType {
    * an attacker targeting this squad (Basic / Improved / Prototype).
    */
   StealthBonus = 'stealth_bonus',
+
+  // Scenario objective events
+  /**
+   * Per `add-scenario-objective-engine` (D7): emitted by the per-turn
+   * control-detection pass when an objective marker's `controlSide`
+   * changes to a side (was neutral / contested / the other side).
+   * Carries the marker id, capturing side, and turn number so the
+   * event log fully replays objective state.
+   */
+  ObjectiveCaptured = 'objective_captured',
+  /**
+   * Per `add-scenario-objective-engine` (D7): emitted when a marker
+   * that a side controlled becomes contested, neutral, or flips to the
+   * other side. The marker's `controlSide` stays sticky on contest /
+   * vacate — this event records the loss of accrued hold, not a
+   * change of the stored controller.
+   */
+  ObjectiveLost = 'objective_lost',
+  /**
+   * Per `add-scenario-objective-engine` (D7): emitted when a marker's
+   * `holdProgress` changes during the control-detection pass (Capture
+   * scenarios advance toward `holdTurnsRequired`).
+   */
+  ObjectiveProgress = 'objective_progress',
 }
 
 /**

--- a/src/types/gameplay/GameSessionInterfaces.ts
+++ b/src/types/gameplay/GameSessionInterfaces.ts
@@ -10,6 +10,7 @@ export * from './GameSessionUnitTypes';
 export * from './GameSessionLifecycleEvents';
 export * from './GameSessionMovementEvents';
 export * from './GameSessionAttackEvents';
+export * from './GameSessionObjectiveEvents';
 export * from './GameSessionStatusEvents';
 export * from './GameSessionStateTypes';
 

--- a/src/types/gameplay/GameSessionLifecycleEvents.ts
+++ b/src/types/gameplay/GameSessionLifecycleEvents.ts
@@ -3,6 +3,8 @@
  * Extracted from GameSessionInterfaces.ts to keep focused type modules under the lint line cap.
  */
 
+import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
+
 import type { GamePhase, GameSide } from './GameSessionCoreTypes';
 import type { IGameConfig, IGameUnit } from './GameSessionUnitTypes';
 
@@ -63,6 +65,14 @@ export interface IGameCreatedPayload {
    * manifest from disk.
    */
   readonly encounterMeta?: IEncounterMeta;
+  /**
+   * Per `add-scenario-objective-engine`: scenario objective markers
+   * placed at generation time, keyed by canonical `"q,r"` hex key.
+   * Carried on the seed event so `deriveState` can reconstruct the
+   * objective map from the event log alone. Omitted for destruction-
+   * only scenarios — an absent map behaves identically to today.
+   */
+  readonly objectives?: Record<string, IObjectiveMarker>;
 }
 
 /**

--- a/src/types/gameplay/GameSessionObjectiveEvents.ts
+++ b/src/types/gameplay/GameSessionObjectiveEvents.ts
@@ -1,0 +1,61 @@
+/**
+ * Scenario objective lifecycle event payloads.
+ *
+ * Per `add-scenario-objective-engine` (design.md D7): the control-
+ * detection pass emits `ObjectiveCaptured` / `ObjectiveLost` /
+ * `ObjectiveProgress` as deterministic functions of unit positions, so
+ * replaying the event log reconstructs objective state exactly.
+ *
+ * @spec openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+ */
+
+import type { ObjectiveSide } from '@/types/scenario/ScenarioInterfaces';
+
+/**
+ * `ObjectiveCaptured` payload — a marker's `controlSide` changed to a
+ * concrete side this turn.
+ */
+export interface IObjectiveCapturedPayload {
+  /** Stable marker id (`objective-1`, …). */
+  readonly objectiveId: string;
+  /** Canonical `"q,r"` hex key of the captured objective. */
+  readonly hexKey: string;
+  /** Side that took control. */
+  readonly capturingSide: ObjectiveSide;
+  /** Turn on which the capture was detected. */
+  readonly turn: number;
+}
+
+/**
+ * `ObjectiveLost` payload — a marker a side controlled became
+ * contested / neutral / flipped, resetting its hold progress.
+ */
+export interface IObjectiveLostPayload {
+  /** Stable marker id. */
+  readonly objectiveId: string;
+  /** Canonical `"q,r"` hex key of the objective. */
+  readonly hexKey: string;
+  /** Side that lost the accrued hold. */
+  readonly losingSide: ObjectiveSide;
+  /** Turn on which the loss was detected. */
+  readonly turn: number;
+}
+
+/**
+ * `ObjectiveProgress` payload — a marker's `holdProgress` changed
+ * during the control-detection pass.
+ */
+export interface IObjectiveProgressPayload {
+  /** Stable marker id. */
+  readonly objectiveId: string;
+  /** Canonical `"q,r"` hex key of the objective. */
+  readonly hexKey: string;
+  /** Side currently holding the marker (`neutral` when uncontrolled). */
+  readonly controlSide: ObjectiveSide;
+  /** Consecutive turns held after this pass. */
+  readonly holdProgress: number;
+  /** Consecutive turns required for a Capture win. */
+  readonly holdTurnsRequired: number;
+  /** Turn on which the progress changed. */
+  readonly turn: number;
+}

--- a/src/types/gameplay/GameSessionStateTypes.ts
+++ b/src/types/gameplay/GameSessionStateTypes.ts
@@ -3,6 +3,7 @@
  * Extracted from GameSessionInterfaces.ts to keep focused type modules under the lint line cap.
  */
 
+import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
 import type { IAerospaceCombatState } from '@/utils/gameplay/aerospace/state';
 import type { IInfantryCombatState } from '@/utils/gameplay/infantry/state';
 import type { IProtoMechCombatState } from '@/utils/gameplay/protomech/state';
@@ -257,6 +258,15 @@ export interface IGameState {
     readonly winner: GameSide | 'draw';
     readonly reason: string;
   };
+  /**
+   * Per `add-scenario-objective-engine` (design.md D1): scenario
+   * objective markers keyed by canonical `"q,r"` hex coordinate.
+   * Carried on the derived state so victory evaluation, control
+   * detection, and rendering all read one channel — `IHex` is never
+   * modified. A session with no objectives leaves this `undefined` or
+   * `{}` and behaves identically to a destruction-only scenario.
+   */
+  readonly objectives?: Record<string, IObjectiveMarker>;
 }
 
 // =============================================================================

--- a/src/types/gameplay/GameSessionStatusEvents.ts
+++ b/src/types/gameplay/GameSessionStatusEvents.ts
@@ -47,6 +47,11 @@ import type {
   IMovementDeclaredPayload,
   IMovementLockedPayload,
 } from './GameSessionMovementEvents';
+import type {
+  IObjectiveCapturedPayload,
+  IObjectiveLostPayload,
+  IObjectiveProgressPayload,
+} from './GameSessionObjectiveEvents';
 
 export interface IShutdownCheckPayload {
   readonly unitId: string;
@@ -385,7 +390,10 @@ export type GameEventPayload =
   | ISwarmDismountedPayload
   | ILegAttackPayload
   | IMimeticBonusPayload
-  | IStealthBonusPayload;
+  | IStealthBonusPayload
+  | IObjectiveCapturedPayload
+  | IObjectiveLostPayload
+  | IObjectiveProgressPayload;
 
 /**
  * Complete game event with payload.

--- a/src/types/scenario/ScenarioInterfaces.ts
+++ b/src/types/scenario/ScenarioInterfaces.ts
@@ -5,6 +5,8 @@
  * @spec openspec/changes/add-scenario-generators/spec.md
  */
 
+import type { GameSide } from '@/types/gameplay/GameSessionCoreTypes';
+
 // =============================================================================
 // Scenario Template Enums
 // =============================================================================
@@ -559,6 +561,124 @@ export interface IScenarioGeneratorConfig {
 // =============================================================================
 // Type Guards
 // =============================================================================
+
+// =============================================================================
+// Scenario Objective Engine
+// =============================================================================
+
+/**
+ * Canonical hex-coordinate key — the `"q,r"` string produced by
+ * `coordToKey`. Used as the map key for the objective-marker map carried
+ * on the game session.
+ *
+ * @spec openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+ */
+export type HexKey = string;
+
+/**
+ * Side that can control an objective hex. `'neutral'` is the
+ * uncontrolled state — every generated marker starts neutral
+ * (design.md Open Question: generated scenarios start all markers
+ * neutral; campaign scenarios may pre-assign in a later change).
+ */
+export type ObjectiveSide = 'player' | 'opponent' | 'neutral';
+
+/**
+ * Control rule used to decide which side holds an objective hex.
+ * Only `'sole-occupancy'` is supported today (design.md D3): a side
+ * controls a hex when it has >=1 unit on it and the opposing side has 0.
+ */
+export type ObjectiveControlRule = 'sole-occupancy';
+
+/**
+ * Hex-based objective types covered by this engine. `escort` / `recon`
+ * are explicitly out of scope (proposal Non-Goals) and `destroy` is the
+ * markerless default — neither appears here because neither produces an
+ * `IObjectiveMarker`.
+ */
+export type ObjectiveMarkerType = 'capture' | 'defend' | 'breakthrough';
+
+/**
+ * A single scenario objective bound to one hex. Markers live on the
+ * game session in an `objectives: Record<HexKey, IObjectiveMarker>`
+ * map (design.md D1) — `IHex` is never modified.
+ *
+ * @spec openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+ */
+export interface IObjectiveMarker {
+  /** Stable unique id (e.g. `objective-1`). */
+  readonly id: string;
+  /** Canonical `"q,r"` key of the hex this marker sits on. */
+  readonly hexKey: HexKey;
+  /** Which hex-objective family this marker belongs to. */
+  readonly objectiveType: ObjectiveMarkerType;
+  /** Initial controller at generation time (always `neutral` today). */
+  readonly owningSide: ObjectiveSide;
+  /** Current controller — mutated by the control-detection pass. */
+  readonly controlSide: ObjectiveSide;
+  /** Control rule applied when detecting `controlSide`. */
+  readonly controlRule: ObjectiveControlRule;
+  /**
+   * Consecutive turns of sole control required to win a Capture
+   * scenario. Ignored for `defend` / `breakthrough` markers.
+   */
+  readonly holdTurnsRequired: number;
+  /**
+   * Consecutive turns the current `controlSide` has held the hex.
+   * Resets to 0 whenever control is lost or contested.
+   */
+  readonly holdProgress: number;
+}
+
+/**
+ * Decided outcome returned by `evaluateObjectiveOutcome`. `null` (not
+ * this interface) is returned while a scenario is still undecided.
+ *
+ * @spec openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+ */
+export interface IObjectiveOutcome {
+  /** Always `true` — the presence of this object means "decided". */
+  readonly decided: true;
+  /** Side that won the scenario. */
+  readonly winningSide: GameSide;
+  /** Always `'objective'` — distinguishes from the destruction path. */
+  readonly reason: 'objective';
+  /** Objective type that produced the win. */
+  readonly objectiveType: ScenarioObjectiveType;
+}
+
+/**
+ * Generation-time objective configuration derived from the scenario's
+ * `IVictoryCondition` (task 1.3). Drives `ScenarioGenerator` placement.
+ */
+export interface IObjectivePlacementConfig {
+  /** Objective family to place. */
+  readonly objectiveType: ObjectiveMarkerType;
+  /** Number of objective hexes to place. */
+  readonly hexCount: number;
+  /** Consecutive hold turns for a Capture win (1 when not Capture). */
+  readonly holdTurnsRequired: number;
+  /** Attacker units that must exit for a Breakthrough win. */
+  readonly requiredUnits: number;
+}
+
+/**
+ * Type guard for `IObjectiveMarker`.
+ */
+export function isObjectiveMarker(obj: unknown): obj is IObjectiveMarker {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const marker = obj as IObjectiveMarker;
+  return (
+    typeof marker.id === 'string' &&
+    typeof marker.hexKey === 'string' &&
+    (marker.objectiveType === 'capture' ||
+      marker.objectiveType === 'defend' ||
+      marker.objectiveType === 'breakthrough') &&
+    typeof marker.controlSide === 'string' &&
+    typeof marker.holdTurnsRequired === 'number' &&
+    typeof marker.holdProgress === 'number'
+  );
+}
 
 /**
  * Type guard for IScenarioTemplate.

--- a/src/utils/gameplay/gameEvents/lifecycle.ts
+++ b/src/utils/gameplay/gameEvents/lifecycle.ts
@@ -1,3 +1,5 @@
+import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
+
 import {
   GameEventType,
   GamePhase,
@@ -21,17 +23,27 @@ import { createEventBase } from './base';
  * sessions (swarm runner, raw quick-game). Carried verbatim onto the
  * payload so the replay-library backfill scan can recover the
  * per-encounter fields without resolving any external references.
+ *
+ * Per `add-scenario-objective-engine`: optional `objectives` carries
+ * the placed objective markers so `deriveState` can reconstruct the
+ * objective map from the event log. Omitted for destruction-only
+ * scenarios.
  */
 export function createGameCreatedEvent(
   gameId: string,
   config: IGameConfig,
   units: readonly IGameUnit[],
   encounterMeta?: IEncounterMeta,
+  objectives?: Record<string, IObjectiveMarker>,
 ): IGameEvent {
-  const payload: IGameCreatedPayload =
-    encounterMeta === undefined
-      ? { config, units }
-      : { config, units, encounterMeta };
+  const payload: IGameCreatedPayload = {
+    config,
+    units,
+    ...(encounterMeta !== undefined ? { encounterMeta } : {}),
+    ...(objectives !== undefined && Object.keys(objectives).length > 0
+      ? { objectives }
+      : {}),
+  };
   return {
     ...createEventBase(
       gameId,

--- a/src/utils/gameplay/gameState/gameStateReducer.ts
+++ b/src/utils/gameplay/gameState/gameStateReducer.ts
@@ -14,6 +14,9 @@ import {
   IHeatPayload,
   IInitiativeRolledPayload,
   IMovementDeclaredPayload,
+  IObjectiveCapturedPayload,
+  IObjectiveLostPayload,
+  IObjectiveProgressPayload,
   IPhysicalAttackDeclaredPayload,
   IPhysicalAttackResolvedPayload,
   IPhaseChangedPayload,
@@ -31,6 +34,7 @@ import {
   IGameStartedPayload,
   LockState,
 } from '@/types/gameplay';
+import { evaluateObjectiveOutcome } from '@/utils/gameplay/objectives/objectiveEngine';
 
 import {
   applyAttackDeclared,
@@ -67,6 +71,11 @@ import {
   applyGameEnded,
   applyGameStarted,
 } from './lifecycle';
+import {
+  applyObjectiveCaptured,
+  applyObjectiveLost,
+  applyObjectiveProgress,
+} from './objectiveReducer';
 import {
   applyInitiativeRolled,
   applyPhaseChanged,
@@ -181,6 +190,21 @@ export function applyEvent(state: IGameState, event: IGameEvent): IGameState {
 
     case GameEventType.UnitRetreated:
       return applyUnitRetreated(state, event.payload as IUnitRetreatedPayload);
+
+    case GameEventType.ObjectiveCaptured:
+      return applyObjectiveCaptured(
+        state,
+        event.payload as IObjectiveCapturedPayload,
+      );
+
+    case GameEventType.ObjectiveLost:
+      return applyObjectiveLost(state, event.payload as IObjectiveLostPayload);
+
+    case GameEventType.ObjectiveProgress:
+      return applyObjectiveProgress(
+        state,
+        event.payload as IObjectiveProgressPayload,
+      );
 
     case GameEventType.TurnEnded:
     case GameEventType.InitiativeOrderSet:
@@ -308,6 +332,18 @@ export function checkVictoryConditions(
   state: IGameState,
   config: IGameConfig,
 ): GameSide | 'draw' | null {
+  // Per `add-scenario-objective-engine` (design.md D4 / task 5): the
+  // objective evaluator is consulted FIRST. When it decides a scenario
+  // (Capture / Defend / Breakthrough — and a markerless map routed
+  // through `destroy`) its outcome takes precedence over the
+  // turn-limit draw below. `null` means undecided → fall through to
+  // the destruction / turn-limit path so markerless scenarios still
+  // end on elimination exactly as before.
+  const objectiveOutcome = evaluateObjectiveOutcome(state, config.turnLimit);
+  if (objectiveOutcome !== null) {
+    return objectiveOutcome.winningSide;
+  }
+
   const playerEliminated = isSideEliminated(state, GameSide.Player);
   const opponentEliminated = isSideEliminated(state, GameSide.Opponent);
 

--- a/src/utils/gameplay/gameState/lifecycle.ts
+++ b/src/utils/gameplay/gameState/lifecycle.ts
@@ -40,6 +40,12 @@ export function applyGameCreated(
     ...state,
     status: GameStatus.Setup,
     units,
+    // Per `add-scenario-objective-engine`: seed the objective map from
+    // the GameCreated payload so the derived state carries objectives
+    // from sequence 0. Absent → markerless (destruction-only) scenario.
+    ...(payload.objectives !== undefined
+      ? { objectives: { ...payload.objectives } }
+      : {}),
   };
 }
 

--- a/src/utils/gameplay/gameState/objectiveReducer.ts
+++ b/src/utils/gameplay/gameState/objectiveReducer.ts
@@ -1,0 +1,101 @@
+/**
+ * Objective lifecycle event reducers.
+ *
+ * Per `add-scenario-objective-engine` (design.md D7): `ObjectiveCaptured`
+ * / `ObjectiveLost` / `ObjectiveProgress` events fully describe the
+ * mutable objective state, so replaying the event log reconstructs
+ * `state.objectives` exactly.
+ *
+ * @spec openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+ */
+
+import type {
+  IGameState,
+  IObjectiveCapturedPayload,
+  IObjectiveLostPayload,
+  IObjectiveProgressPayload,
+} from '@/types/gameplay';
+import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
+
+/**
+ * Locates an objective marker by its stable id within `state.objectives`.
+ * Returns the `[hexKey, marker]` pair, or `null` when absent.
+ */
+function findObjective(
+  state: IGameState,
+  objectiveId: string,
+): readonly [string, IObjectiveMarker] | null {
+  const objectives = state.objectives;
+  if (!objectives) return null;
+  for (const [hexKey, marker] of Object.entries(objectives)) {
+    if (marker.id === objectiveId) return [hexKey, marker];
+  }
+  return null;
+}
+
+/**
+ * Applies an `ObjectiveCaptured` event — sets the marker's
+ * `controlSide` to the capturing side.
+ */
+export function applyObjectiveCaptured(
+  state: IGameState,
+  payload: IObjectiveCapturedPayload,
+): IGameState {
+  const found = findObjective(state, payload.objectiveId);
+  if (!found || !state.objectives) return state;
+  const [hexKey, marker] = found;
+  return {
+    ...state,
+    objectives: {
+      ...state.objectives,
+      [hexKey]: { ...marker, controlSide: payload.capturingSide },
+    },
+  };
+}
+
+/**
+ * Applies an `ObjectiveLost` event — resets the marker's accrued hold.
+ * `controlSide` is sticky (design.md D3): a contested / vacated hex
+ * keeps its last controller, so only `holdProgress` clears here.
+ */
+export function applyObjectiveLost(
+  state: IGameState,
+  payload: IObjectiveLostPayload,
+): IGameState {
+  const found = findObjective(state, payload.objectiveId);
+  if (!found || !state.objectives) return state;
+  const [hexKey, marker] = found;
+  return {
+    ...state,
+    objectives: {
+      ...state.objectives,
+      [hexKey]: { ...marker, holdProgress: 0 },
+    },
+  };
+}
+
+/**
+ * Applies an `ObjectiveProgress` event — the canonical carrier of the
+ * marker's mutable state. Sets both `controlSide` and `holdProgress`
+ * from the payload so a log that contains progress events fully
+ * reconstructs objective state on replay.
+ */
+export function applyObjectiveProgress(
+  state: IGameState,
+  payload: IObjectiveProgressPayload,
+): IGameState {
+  const found = findObjective(state, payload.objectiveId);
+  if (!found || !state.objectives) return state;
+  const [hexKey, marker] = found;
+  return {
+    ...state,
+    objectives: {
+      ...state.objectives,
+      [hexKey]: {
+        ...marker,
+        controlSide: payload.controlSide,
+        holdProgress: payload.holdProgress,
+      },
+    },
+  };
+}

--- a/src/utils/gameplay/objectives/__tests__/objectiveEngine.test.ts
+++ b/src/utils/gameplay/objectives/__tests__/objectiveEngine.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Scenario Objective Engine — control detection + victory evaluation.
+ *
+ * Covers the `scenario-objectives` delta-spec scenarios for:
+ *   - Objective Marker Data Model (markerless → destroy)
+ *   - Objective Control Detection (sole occupancy / contested / vacated)
+ *   - Objective-Based Victory Evaluation (Capture / Defend / Breakthrough)
+ *
+ * @spec openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+ */
+
+import type { IGameState, IUnitGameState } from '@/types/gameplay';
+import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
+
+import {
+  Facing,
+  GamePhase,
+  GameSide,
+  GameStatus,
+  LockState,
+  MovementType,
+} from '@/types/gameplay';
+import { ScenarioObjectiveType } from '@/types/scenario/ScenarioInterfaces';
+
+import {
+  advanceObjectiveControl,
+  detectObjectiveControl,
+  evaluateObjectiveOutcome,
+} from '../objectiveEngine';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function unit(
+  id: string,
+  side: GameSide,
+  q: number,
+  r: number,
+  overrides: Partial<IUnitGameState> = {},
+): IUnitGameState {
+  return {
+    id,
+    side,
+    position: { q, r },
+    facing: Facing.North,
+    heat: 0,
+    movementThisTurn: MovementType.Stationary,
+    hexesMovedThisTurn: 0,
+    armor: {},
+    structure: {},
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {},
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+    ...overrides,
+  };
+}
+
+function marker(overrides: Partial<IObjectiveMarker> = {}): IObjectiveMarker {
+  return {
+    id: 'objective-1',
+    hexKey: '0,0',
+    objectiveType: 'capture',
+    owningSide: 'neutral',
+    controlSide: 'neutral',
+    controlRule: 'sole-occupancy',
+    holdTurnsRequired: 1,
+    holdProgress: 0,
+    ...overrides,
+  };
+}
+
+function state(
+  units: IUnitGameState[],
+  objectives?: Record<string, IObjectiveMarker>,
+  turn = 1,
+): IGameState {
+  return {
+    gameId: 'test-game',
+    status: GameStatus.Active,
+    turn,
+    phase: GamePhase.End,
+    activationIndex: 0,
+    units: Object.fromEntries(units.map((u) => [u.id, u])),
+    turnEvents: [],
+    ...(objectives !== undefined ? { objectives } : {}),
+  };
+}
+
+// =============================================================================
+// Objective Marker Data Model — markerless → destroy
+// =============================================================================
+
+describe('evaluateObjectiveOutcome — markerless session', () => {
+  it('treats an absent objective map as a destroy scenario', () => {
+    const s = state([
+      unit('player-1', GameSide.Player, 0, 0),
+      unit('opponent-1', GameSide.Opponent, 0, 0, { destroyed: true }),
+    ]);
+    const outcome = evaluateObjectiveOutcome(s);
+    expect(outcome).not.toBeNull();
+    expect(outcome?.objectiveType).toBe(ScenarioObjectiveType.Destroy);
+    expect(outcome?.winningSide).toBe(GameSide.Player);
+  });
+
+  it('treats an empty objective map identically to destruction', () => {
+    const s = state(
+      [
+        unit('player-1', GameSide.Player, 0, 0),
+        unit('opponent-1', GameSide.Opponent, 0, 0),
+      ],
+      {},
+    );
+    // Both sides alive → undecided.
+    expect(evaluateObjectiveOutcome(s)).toBeNull();
+  });
+});
+
+// =============================================================================
+// Objective Control Detection
+// =============================================================================
+
+describe('detectObjectiveControl — sole occupancy', () => {
+  it('takes control when one side occupies a neutral hex alone', () => {
+    const s = state([unit('player-1', GameSide.Player, 0, 0)]);
+    const result = detectObjectiveControl(marker(), s);
+    expect(result.controlSide).toBe('player');
+  });
+
+  it('keeps the last controller when the hex is contested', () => {
+    const s = state([
+      unit('player-1', GameSide.Player, 0, 0),
+      unit('opponent-1', GameSide.Opponent, 0, 0),
+    ]);
+    const held = marker({ controlSide: 'player' });
+    expect(detectObjectiveControl(held, s).controlSide).toBe('player');
+  });
+
+  it('keeps the last controller when the hex is vacated', () => {
+    const s = state([unit('player-1', GameSide.Player, 5, 5)]);
+    const held = marker({ controlSide: 'opponent' });
+    expect(detectObjectiveControl(held, s).controlSide).toBe('opponent');
+  });
+
+  it('ignores destroyed and retreated units for control', () => {
+    const s = state([
+      unit('player-1', GameSide.Player, 0, 0, { destroyed: true }),
+      unit('opponent-1', GameSide.Opponent, 0, 0, { hasRetreated: true }),
+    ]);
+    // Neither projects control → hex stays neutral.
+    expect(detectObjectiveControl(marker(), s).controlSide).toBe('neutral');
+  });
+});
+
+describe('advanceObjectiveControl — hold progress', () => {
+  it('takes control and starts hold progress at 1', () => {
+    const s = state([unit('player-1', GameSide.Player, 0, 0)]);
+    const change = advanceObjectiveControl(marker(), s);
+    expect(change.captured).toBe(true);
+    expect(change.marker.controlSide).toBe('player');
+    expect(change.marker.holdProgress).toBe(1);
+    expect(change.progressChanged).toBe(true);
+  });
+
+  it('increments hold progress while a side keeps sole occupancy', () => {
+    const s = state([unit('player-1', GameSide.Player, 0, 0)]);
+    const held = marker({ controlSide: 'player', holdProgress: 1 });
+    const change = advanceObjectiveControl(held, s);
+    expect(change.captured).toBe(false);
+    expect(change.marker.holdProgress).toBe(2);
+  });
+
+  it('resets hold progress to 0 when the hex becomes contested', () => {
+    const s = state([
+      unit('player-1', GameSide.Player, 0, 0),
+      unit('opponent-1', GameSide.Opponent, 0, 0),
+    ]);
+    const held = marker({ controlSide: 'player', holdProgress: 3 });
+    const change = advanceObjectiveControl(held, s);
+    expect(change.marker.controlSide).toBe('player');
+    expect(change.marker.holdProgress).toBe(0);
+    expect(change.lost).toBe(true);
+  });
+
+  it('resets hold progress when control is lost to the other side', () => {
+    const s = state([unit('opponent-1', GameSide.Opponent, 0, 0)]);
+    const held = marker({ controlSide: 'player', holdProgress: 2 });
+    const change = advanceObjectiveControl(held, s);
+    expect(change.marker.controlSide).toBe('opponent');
+    expect(change.marker.holdProgress).toBe(1);
+    expect(change.lost).toBe(true);
+    expect(change.captured).toBe(true);
+  });
+
+  it('keeps the controller but stops accruing hold when the hex is vacated', () => {
+    const s = state([unit('player-1', GameSide.Player, 9, 9)]);
+    const held = marker({ controlSide: 'player', holdProgress: 2 });
+    const change = advanceObjectiveControl(held, s);
+    expect(change.marker.controlSide).toBe('player');
+    expect(change.marker.holdProgress).toBe(0);
+  });
+});
+
+// =============================================================================
+// Victory Evaluation — Capture
+// =============================================================================
+
+describe('evaluateObjectiveOutcome — Capture', () => {
+  it('decides for the attacker once it holds for the required turns', () => {
+    const objectives = {
+      '0,0': marker({ holdTurnsRequired: 2, controlSide: 'player' }),
+    };
+    // holdProgress below threshold → undecided.
+    objectives['0,0'] = { ...objectives['0,0'], holdProgress: 1 };
+    const s1 = state([], objectives);
+    expect(evaluateObjectiveOutcome(s1)).toBeNull();
+
+    // holdProgress meets threshold → attacker wins.
+    const s2 = state([], {
+      '0,0': marker({
+        holdTurnsRequired: 2,
+        controlSide: 'player',
+        holdProgress: 2,
+      }),
+    });
+    const outcome = evaluateObjectiveOutcome(s2);
+    expect(outcome?.winningSide).toBe(GameSide.Player);
+    expect(outcome?.reason).toBe('objective');
+    expect(outcome?.objectiveType).toBe(ScenarioObjectiveType.Capture);
+  });
+
+  it('requires ALL objective hexes held', () => {
+    const s = state([], {
+      '0,0': marker({
+        id: 'objective-1',
+        hexKey: '0,0',
+        controlSide: 'player',
+        holdProgress: 1,
+      }),
+      '1,0': marker({
+        id: 'objective-2',
+        hexKey: '1,0',
+        controlSide: 'neutral',
+        holdProgress: 0,
+      }),
+    });
+    expect(evaluateObjectiveOutcome(s)).toBeNull();
+  });
+
+  it('returns null after control is lost mid-hold (progress reset)', () => {
+    // Attacker held 1 turn, then lost control → holdProgress 0.
+    const s = state([], {
+      '0,0': marker({
+        objectiveType: 'capture',
+        holdTurnsRequired: 2,
+        controlSide: 'player',
+        holdProgress: 0,
+      }),
+    });
+    expect(evaluateObjectiveOutcome(s)).toBeNull();
+  });
+});
+
+// =============================================================================
+// Victory Evaluation — Defend
+// =============================================================================
+
+describe('evaluateObjectiveOutcome — Defend', () => {
+  it('decides for the defender at the turn limit when still in control', () => {
+    const s = state(
+      [],
+      {
+        '0,0': marker({ objectiveType: 'defend', controlSide: 'opponent' }),
+      },
+      6,
+    );
+    const outcome = evaluateObjectiveOutcome(s, 6);
+    expect(outcome?.winningSide).toBe(GameSide.Opponent);
+    expect(outcome?.objectiveType).toBe(ScenarioObjectiveType.Defend);
+  });
+
+  it('stays undecided before the turn limit', () => {
+    const s = state(
+      [],
+      {
+        '0,0': marker({ objectiveType: 'defend', controlSide: 'opponent' }),
+      },
+      3,
+    );
+    expect(evaluateObjectiveOutcome(s, 6)).toBeNull();
+  });
+
+  it('decides for the attacker immediately on capturing the objective', () => {
+    const s = state(
+      [],
+      {
+        '0,0': marker({ objectiveType: 'defend', controlSide: 'player' }),
+      },
+      2,
+    );
+    const outcome = evaluateObjectiveOutcome(s, 6);
+    expect(outcome?.winningSide).toBe(GameSide.Player);
+    expect(outcome?.objectiveType).toBe(ScenarioObjectiveType.Defend);
+  });
+});
+
+// =============================================================================
+// Victory Evaluation — Breakthrough
+// =============================================================================
+
+describe('evaluateObjectiveOutcome — Breakthrough', () => {
+  it('decides for the attacker when enough units reach an exit hex', () => {
+    const objectives = {
+      '0,4': marker({
+        id: 'objective-1',
+        hexKey: '0,4',
+        objectiveType: 'breakthrough',
+        // holdTurnsRequired carries the required-units count.
+        holdTurnsRequired: 2,
+      }),
+    };
+    // Only one attacker on the exit hex → undecided.
+    const s1 = state([unit('player-1', GameSide.Player, 0, 4)], objectives);
+    expect(evaluateObjectiveOutcome(s1)).toBeNull();
+
+    // Two attacker units on the exit hex → attacker wins.
+    const s2 = state(
+      [
+        unit('player-1', GameSide.Player, 0, 4),
+        unit('player-2', GameSide.Player, 0, 4),
+      ],
+      objectives,
+    );
+    const outcome = evaluateObjectiveOutcome(s2);
+    expect(outcome?.winningSide).toBe(GameSide.Player);
+    expect(outcome?.objectiveType).toBe(ScenarioObjectiveType.Breakthrough);
+  });
+
+  it('overrides surviving units — objective win even with both sides alive', () => {
+    const objectives = {
+      '0,4': marker({
+        id: 'objective-1',
+        hexKey: '0,4',
+        objectiveType: 'breakthrough',
+        holdTurnsRequired: 1,
+      }),
+    };
+    const s = state(
+      [
+        unit('player-1', GameSide.Player, 0, 4),
+        unit('player-2', GameSide.Player, 0, 0),
+        unit('opponent-1', GameSide.Opponent, 0, -4),
+      ],
+      objectives,
+    );
+    const outcome = evaluateObjectiveOutcome(s);
+    expect(outcome).not.toBeNull();
+    expect(outcome?.winningSide).toBe(GameSide.Player);
+  });
+});

--- a/src/utils/gameplay/objectives/__tests__/objectiveEvents.test.ts
+++ b/src/utils/gameplay/objectives/__tests__/objectiveEvents.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Scenario objective lifecycle events + control pass.
+ *
+ * Covers the `scenario-objectives` delta-spec scenarios for Objective
+ * Lifecycle Events (emit on capture, deterministic, event-log replay).
+ *
+ * @spec openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+ */
+
+import type {
+  IGameState,
+  IObjectiveCapturedPayload,
+  IObjectiveProgressPayload,
+  IUnitGameState,
+} from '@/types/gameplay';
+import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
+
+import {
+  Facing,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  GameStatus,
+  LockState,
+  MovementType,
+} from '@/types/gameplay';
+import { createGameCreatedEvent } from '@/utils/gameplay/gameEvents/lifecycle';
+import { deriveState } from '@/utils/gameplay/gameState';
+
+import { runObjectiveControlPass } from '../objectiveEvents';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function unit(
+  id: string,
+  side: GameSide,
+  q: number,
+  r: number,
+): IUnitGameState {
+  return {
+    id,
+    side,
+    position: { q, r },
+    facing: Facing.North,
+    heat: 0,
+    movementThisTurn: MovementType.Stationary,
+    hexesMovedThisTurn: 0,
+    armor: {},
+    structure: {},
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {},
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+  };
+}
+
+function marker(overrides: Partial<IObjectiveMarker> = {}): IObjectiveMarker {
+  return {
+    id: 'objective-1',
+    hexKey: '0,0',
+    objectiveType: 'capture',
+    owningSide: 'neutral',
+    controlSide: 'neutral',
+    controlRule: 'sole-occupancy',
+    holdTurnsRequired: 3,
+    holdProgress: 0,
+    ...overrides,
+  };
+}
+
+function state(
+  units: IUnitGameState[],
+  objectives: Record<string, IObjectiveMarker>,
+  turn = 1,
+): IGameState {
+  return {
+    gameId: 'test-game',
+    status: GameStatus.Active,
+    turn,
+    phase: GamePhase.End,
+    activationIndex: 0,
+    units: Object.fromEntries(units.map((u) => [u.id, u])),
+    turnEvents: [],
+    objectives,
+  };
+}
+
+// =============================================================================
+// Lifecycle event emission
+// =============================================================================
+
+describe('runObjectiveControlPass — capture emits ObjectiveCaptured', () => {
+  it('appends an ObjectiveCaptured event with id, side, and turn', () => {
+    const s = state([unit('player-1', GameSide.Player, 0, 0)], {
+      '0,0': marker(),
+    });
+    const pass = runObjectiveControlPass('g', s, 10, 4, GamePhase.End);
+
+    const captured = pass.events.find(
+      (e) => e.type === GameEventType.ObjectiveCaptured,
+    );
+    expect(captured).toBeDefined();
+    const payload = captured!.payload as IObjectiveCapturedPayload;
+    expect(payload.objectiveId).toBe('objective-1');
+    expect(payload.capturingSide).toBe('player');
+    expect(payload.turn).toBe(4);
+    expect(captured!.sequence).toBeGreaterThanOrEqual(10);
+
+    // Marker was advanced in the returned objective map.
+    expect(pass.objectives['0,0'].controlSide).toBe('player');
+    expect(pass.objectives['0,0'].holdProgress).toBe(1);
+  });
+
+  it('emits an ObjectiveProgress event when hold progress changes', () => {
+    const s = state([unit('player-1', GameSide.Player, 0, 0)], {
+      '0,0': marker({ controlSide: 'player', holdProgress: 1 }),
+    });
+    const pass = runObjectiveControlPass('g', s, 0, 2, GamePhase.End);
+    const progress = pass.events.find(
+      (e) => e.type === GameEventType.ObjectiveProgress,
+    );
+    expect(progress).toBeDefined();
+    const payload = progress!.payload as IObjectiveProgressPayload;
+    expect(payload.holdProgress).toBe(2);
+    expect(payload.holdTurnsRequired).toBe(3);
+  });
+
+  it('emits an ObjectiveLost event when a controlled hex is contested', () => {
+    const s = state(
+      [
+        unit('player-1', GameSide.Player, 0, 0),
+        unit('opponent-1', GameSide.Opponent, 0, 0),
+      ],
+      { '0,0': marker({ controlSide: 'player', holdProgress: 2 }) },
+    );
+    const pass = runObjectiveControlPass('g', s, 0, 5, GamePhase.End);
+    expect(
+      pass.events.some((e) => e.type === GameEventType.ObjectiveLost),
+    ).toBe(true);
+    expect(pass.objectives['0,0'].holdProgress).toBe(0);
+  });
+
+  it('is a no-op for a markerless state', () => {
+    const s = state([unit('player-1', GameSide.Player, 0, 0)], {});
+    const pass = runObjectiveControlPass('g', s, 0, 1, GamePhase.End);
+    expect(pass.events).toHaveLength(0);
+    expect(Object.keys(pass.objectives)).toHaveLength(0);
+  });
+
+  it('produces identical events for identical inputs (determinism)', () => {
+    const build = () =>
+      state([unit('player-1', GameSide.Player, 0, 0)], { '0,0': marker() });
+    const a = runObjectiveControlPass('g', build(), 0, 1, GamePhase.End);
+    const b = runObjectiveControlPass('g', build(), 0, 1, GamePhase.End);
+    expect(a.events.map((e) => [e.type, e.sequence])).toEqual(
+      b.events.map((e) => [e.type, e.sequence]),
+    );
+    expect(a.objectives).toEqual(b.objectives);
+  });
+});
+
+// =============================================================================
+// Event-log replay
+// =============================================================================
+
+describe('event log replays objective state', () => {
+  it('reconstructs controlSide and holdProgress by replaying the log', () => {
+    const objectives = { '0,0': marker({ holdTurnsRequired: 3 }) };
+    // Seed event carries the placed markers.
+    const created = createGameCreatedEvent(
+      'g',
+      { mapRadius: 5, turnLimit: 10, victoryConditions: [], optionalRules: [] },
+      [],
+      undefined,
+      objectives,
+    );
+
+    // Run three turns of the control pass with a player unit holding
+    // the hex, threading the objective map turn-to-turn.
+    const events = [created];
+    let liveObjectives: Record<string, IObjectiveMarker> = objectives;
+    let sequence = 1;
+    for (let turn = 1; turn <= 3; turn++) {
+      const s = state(
+        [unit('player-1', GameSide.Player, 0, 0)],
+        liveObjectives,
+        turn,
+      );
+      const pass = runObjectiveControlPass(
+        'g',
+        s,
+        sequence,
+        turn,
+        GamePhase.End,
+      );
+      events.push(...pass.events);
+      sequence += pass.events.length;
+      liveObjectives = pass.objectives;
+    }
+
+    // Replaying the full log from scratch must reconstruct the same
+    // objective state the live pass produced.
+    const replayed = deriveState('g', events);
+    expect(replayed.objectives).toBeDefined();
+    expect(replayed.objectives!['0,0'].controlSide).toBe('player');
+    expect(replayed.objectives!['0,0'].holdProgress).toBe(
+      liveObjectives['0,0'].holdProgress,
+    );
+    expect(liveObjectives['0,0'].holdProgress).toBe(3);
+  });
+
+  it('seeds the objective map from the GameCreated event', () => {
+    const objectives = { '0,0': marker() };
+    const created = createGameCreatedEvent(
+      'g',
+      { mapRadius: 5, turnLimit: 10, victoryConditions: [], optionalRules: [] },
+      [],
+      undefined,
+      objectives,
+    );
+    const replayed = deriveState('g', [created]);
+    expect(replayed.objectives).toBeDefined();
+    expect(replayed.objectives!['0,0'].id).toBe('objective-1');
+  });
+
+  it('leaves objectives undefined for a markerless GameCreated event', () => {
+    const created = createGameCreatedEvent(
+      'g',
+      {
+        mapRadius: 5,
+        turnLimit: 10,
+        victoryConditions: [],
+        optionalRules: [],
+      },
+      [],
+    );
+    const replayed = deriveState('g', [created]);
+    expect(replayed.objectives).toBeUndefined();
+  });
+});

--- a/src/utils/gameplay/objectives/__tests__/objectivePlacement.test.ts
+++ b/src/utils/gameplay/objectives/__tests__/objectivePlacement.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Scenario Objective Placement tests.
+ *
+ * Covers the `scenario-objectives` delta-spec scenarios for Objective
+ * Placement During Scenario Generation.
+ *
+ * @spec openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+ */
+
+import type { VictoryCondition } from '@/types/scenario/ScenarioInterfaces';
+
+import { ScenarioObjectiveType } from '@/types/scenario/ScenarioInterfaces';
+import { keyToCoord } from '@/utils/gameplay/hexMath';
+
+import {
+  deriveObjectivePlacementConfig,
+  objectiveMarkerTypeFor,
+  placeObjectives,
+} from '../objectivePlacement';
+
+const RADIUS = 5;
+const ZONE = {
+  radius: RADIUS,
+  playerRow: -(RADIUS - 1),
+  opponentRow: RADIUS - 1,
+};
+
+function inBounds(q: number, r: number): boolean {
+  return (
+    Math.abs(q) <= RADIUS && Math.abs(r) <= RADIUS && Math.abs(q + r) <= RADIUS
+  );
+}
+
+describe('objectiveMarkerTypeFor', () => {
+  it('maps hex objective types and rejects markerless types', () => {
+    expect(objectiveMarkerTypeFor(ScenarioObjectiveType.Capture)).toBe(
+      'capture',
+    );
+    expect(objectiveMarkerTypeFor(ScenarioObjectiveType.Defend)).toBe('defend');
+    expect(objectiveMarkerTypeFor(ScenarioObjectiveType.Breakthrough)).toBe(
+      'breakthrough',
+    );
+    expect(objectiveMarkerTypeFor(ScenarioObjectiveType.Destroy)).toBeNull();
+    expect(objectiveMarkerTypeFor(ScenarioObjectiveType.Escort)).toBeNull();
+    expect(objectiveMarkerTypeFor(ScenarioObjectiveType.Recon)).toBeNull();
+  });
+});
+
+describe('deriveObjectivePlacementConfig', () => {
+  it('returns null for a destroy scenario', () => {
+    expect(
+      deriveObjectivePlacementConfig(ScenarioObjectiveType.Destroy),
+    ).toBeNull();
+  });
+
+  it('clamps Capture objective count to 1..3 from victory conditions', () => {
+    const vc: VictoryCondition[] = [
+      {
+        id: 'capture_and_hold',
+        name: 'Capture and Hold',
+        description: '',
+        primary: true,
+        objectiveCount: 9,
+        holdTurns: 3,
+      },
+    ];
+    const cfg = deriveObjectivePlacementConfig(
+      ScenarioObjectiveType.Capture,
+      vc,
+    );
+    expect(cfg?.hexCount).toBe(3);
+    expect(cfg?.holdTurnsRequired).toBe(3);
+  });
+
+  it('uses Breakthrough requiredUnits from victory conditions', () => {
+    const vc: VictoryCondition[] = [
+      {
+        id: 'breakthrough',
+        name: 'Breakthrough',
+        description: '',
+        primary: true,
+        requiredUnits: 2,
+      },
+    ];
+    const cfg = deriveObjectivePlacementConfig(
+      ScenarioObjectiveType.Breakthrough,
+      vc,
+    );
+    expect(cfg?.requiredUnits).toBe(2);
+  });
+});
+
+describe('placeObjectives — Capture', () => {
+  const cfg = deriveObjectivePlacementConfig(ScenarioObjectiveType.Capture);
+
+  it('places 1-3 interior markers outside both deployment zones', () => {
+    const objectives = placeObjectives(cfg!, ZONE, 12345);
+    const keys = Object.keys(objectives);
+    expect(keys.length).toBeGreaterThanOrEqual(1);
+    expect(keys.length).toBeLessThanOrEqual(3);
+    for (const key of keys) {
+      const coord = keyToCoord(key);
+      expect(inBounds(coord.q, coord.r)).toBe(true);
+      expect(coord.r).not.toBe(ZONE.playerRow);
+      expect(coord.r).not.toBe(ZONE.opponentRow);
+    }
+  });
+
+  it('is deterministic for a given seed', () => {
+    const a = placeObjectives(cfg!, ZONE, 999);
+    const b = placeObjectives(cfg!, ZONE, 999);
+    expect(Object.keys(a).sort()).toEqual(Object.keys(b).sort());
+  });
+
+  it('yields different placements for different seeds', () => {
+    const a = Object.keys(placeObjectives(cfg!, ZONE, 1)).sort();
+    const b = Object.keys(placeObjectives(cfg!, ZONE, 2)).sort();
+    // Not a hard guarantee, but interior pools are large enough that
+    // two seeds picking identical sets is vanishingly unlikely.
+    expect(a).not.toEqual(b);
+  });
+
+  it('starts every marker neutral with zero hold progress', () => {
+    const objectives = placeObjectives(cfg!, ZONE, 77);
+    for (const m of Object.values(objectives)) {
+      expect(m.owningSide).toBe('neutral');
+      expect(m.controlSide).toBe('neutral');
+      expect(m.holdProgress).toBe(0);
+      expect(m.objectiveType).toBe('capture');
+    }
+  });
+});
+
+describe('placeObjectives — Defend', () => {
+  it('places objectives inside the defender deployment zone', () => {
+    const cfg = deriveObjectivePlacementConfig(ScenarioObjectiveType.Defend);
+    const objectives = placeObjectives(cfg!, ZONE, 42);
+    const keys = Object.keys(objectives);
+    expect(keys.length).toBeGreaterThanOrEqual(1);
+    for (const key of keys) {
+      expect(keyToCoord(key).r).toBe(ZONE.opponentRow);
+    }
+  });
+});
+
+describe('placeObjectives — Breakthrough', () => {
+  it('places exit hexes on the edge opposite the attacker', () => {
+    const cfg = deriveObjectivePlacementConfig(
+      ScenarioObjectiveType.Breakthrough,
+    );
+    const objectives = placeObjectives(cfg!, ZONE, 314);
+    const keys = Object.keys(objectives);
+    expect(keys.length).toBeGreaterThanOrEqual(1);
+    // Attacker deploys on the south (negative-r) edge → exits on the
+    // north (most-positive-r) edge.
+    for (const key of keys) {
+      expect(keyToCoord(key).r).toBe(RADIUS);
+    }
+  });
+});

--- a/src/utils/gameplay/objectives/__tests__/objectiveSerialization.test.ts
+++ b/src/utils/gameplay/objectives/__tests__/objectiveSerialization.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Objective marker type guard + session serialization round-trip.
+ *
+ * Covers `scenario-objectives` delta-spec scenario "Objective map
+ * survives serialization" and task 1.4.
+ *
+ * @spec openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+ */
+
+import type { IGameState } from '@/types/gameplay';
+import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
+
+import { GamePhase, GameStatus } from '@/types/gameplay';
+import { isObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
+
+function marker(overrides: Partial<IObjectiveMarker> = {}): IObjectiveMarker {
+  return {
+    id: 'objective-1',
+    hexKey: '0,0',
+    objectiveType: 'capture',
+    owningSide: 'neutral',
+    controlSide: 'player',
+    controlRule: 'sole-occupancy',
+    holdTurnsRequired: 3,
+    holdProgress: 2,
+    ...overrides,
+  };
+}
+
+describe('isObjectiveMarker', () => {
+  it('accepts a well-formed marker', () => {
+    expect(isObjectiveMarker(marker())).toBe(true);
+  });
+
+  it('rejects non-objects and malformed markers', () => {
+    expect(isObjectiveMarker(null)).toBe(false);
+    expect(isObjectiveMarker(42)).toBe(false);
+    expect(isObjectiveMarker({ id: 'x' })).toBe(false);
+    expect(isObjectiveMarker({ ...marker(), objectiveType: 'escort' })).toBe(
+      false,
+    );
+  });
+});
+
+describe('objective map survives serialization', () => {
+  it('preserves three markers with identical control + hold values', () => {
+    const objectives: Record<string, IObjectiveMarker> = {
+      '0,0': marker({
+        id: 'objective-1',
+        hexKey: '0,0',
+        controlSide: 'player',
+        holdProgress: 2,
+      }),
+      '1,0': marker({
+        id: 'objective-2',
+        hexKey: '1,0',
+        controlSide: 'opponent',
+        holdProgress: 1,
+      }),
+      '0,1': marker({
+        id: 'objective-3',
+        hexKey: '0,1',
+        objectiveType: 'breakthrough',
+        controlSide: 'neutral',
+        holdProgress: 0,
+      }),
+    };
+
+    const state: IGameState = {
+      gameId: 'serial-test',
+      status: GameStatus.Active,
+      turn: 4,
+      phase: GamePhase.End,
+      activationIndex: 0,
+      units: {},
+      turnEvents: [],
+      objectives,
+    };
+
+    const roundTripped: IGameState = JSON.parse(JSON.stringify(state));
+
+    expect(roundTripped.objectives).toBeDefined();
+    expect(Object.keys(roundTripped.objectives!)).toHaveLength(3);
+
+    for (const key of Object.keys(objectives)) {
+      const original = objectives[key];
+      const restored = roundTripped.objectives![key];
+      expect(restored.id).toBe(original.id);
+      expect(restored.controlSide).toBe(original.controlSide);
+      expect(restored.holdProgress).toBe(original.holdProgress);
+      expect(restored.holdTurnsRequired).toBe(original.holdTurnsRequired);
+      expect(restored.objectiveType).toBe(original.objectiveType);
+      expect(isObjectiveMarker(restored)).toBe(true);
+    }
+  });
+});

--- a/src/utils/gameplay/objectives/index.ts
+++ b/src/utils/gameplay/objectives/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Scenario Objective Engine — public barrel.
+ *
+ * @spec openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+ */
+
+export {
+  ATTACKER_SIDE,
+  DEFENDER_SIDE,
+  advanceObjectiveControl,
+  detectObjectiveControl,
+  evaluateObjectiveOutcome,
+  gameSideToObjectiveSide,
+  objectiveSideToGameSide,
+} from './objectiveEngine';
+export type { IObjectiveControlChange } from './objectiveEngine';
+
+export {
+  DEFAULT_BREAKTHROUGH_REQUIRED_UNITS,
+  DEFAULT_CAPTURE_HOLD_TURNS,
+  deriveObjectivePlacementConfig,
+  objectiveMarkerTypeFor,
+  placeObjectives,
+} from './objectivePlacement';
+export type { IObjectiveZoneConfig } from './objectivePlacement';
+
+export {
+  createObjectiveCapturedEvent,
+  createObjectiveLostEvent,
+  createObjectiveProgressEvent,
+  runObjectiveControlPass,
+} from './objectiveEvents';

--- a/src/utils/gameplay/objectives/objectiveEngine.ts
+++ b/src/utils/gameplay/objectives/objectiveEngine.ts
@@ -1,0 +1,364 @@
+/**
+ * Scenario Objective Engine
+ *
+ * Control detection and victory evaluation for hex-based scenario
+ * objectives. The engine is a set of pure functions consumed by the
+ * game-over check and the per-turn control-detection pass.
+ *
+ * @spec openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+ */
+
+import type { IGameState, IUnitGameState } from '@/types/gameplay';
+import type {
+  IObjectiveMarker,
+  IObjectiveOutcome,
+  ObjectiveSide,
+} from '@/types/scenario/ScenarioInterfaces';
+
+import { GameSide } from '@/types/gameplay';
+import { ScenarioObjectiveType } from '@/types/scenario/ScenarioInterfaces';
+import { coordToKey } from '@/utils/gameplay/hexMath';
+
+/**
+ * Maps a `GameSide` enum value onto the `ObjectiveSide` string used by
+ * objective markers.
+ */
+export function gameSideToObjectiveSide(side: GameSide): ObjectiveSide {
+  return side === GameSide.Player ? 'player' : 'opponent';
+}
+
+/**
+ * Maps an `ObjectiveSide` back onto a `GameSide`. Returns `null` for
+ * the `neutral` controller (no winning side).
+ */
+export function objectiveSideToGameSide(side: ObjectiveSide): GameSide | null {
+  if (side === 'player') return GameSide.Player;
+  if (side === 'opponent') return GameSide.Opponent;
+  return null;
+}
+
+/**
+ * True when a unit still occupies a hex for control purposes — it must
+ * be alive and not yet withdrawn from the battlefield. A destroyed or
+ * retreated unit no longer projects control onto its hex.
+ */
+function unitOccupiesHexes(unit: IUnitGameState): boolean {
+  return !unit.destroyed && !unit.hasRetreated;
+}
+
+/**
+ * Counts, per side, how many participating units sit on a given hex.
+ */
+function occupantsByHex(
+  state: IGameState,
+  hexKey: string,
+): { player: number; opponent: number } {
+  let player = 0;
+  let opponent = 0;
+  for (const unit of Object.values(state.units)) {
+    if (!unitOccupiesHexes(unit)) continue;
+    if (coordToKey(unit.position) !== hexKey) continue;
+    if (unit.side === GameSide.Player) player += 1;
+    else if (unit.side === GameSide.Opponent) opponent += 1;
+  }
+  return { player, opponent };
+}
+
+/**
+ * Resolves the controller of a single objective hex under the
+ * sole-occupancy rule (design.md D3):
+ *
+ *   - One side alone on the hex → that side takes control.
+ *   - Both sides on the hex → contested → `controlSide` is unchanged
+ *     (sticky to the last controller).
+ *   - Hex vacated → `controlSide` is unchanged (sticky).
+ *
+ * Returns the NEW marker (control may be unchanged). `holdProgress` is
+ * NOT advanced here — see `advanceObjectiveControl`.
+ *
+ * @spec scenario-objectives — Objective Control Detection
+ */
+export function detectObjectiveControl(
+  marker: IObjectiveMarker,
+  state: IGameState,
+): IObjectiveMarker {
+  const { player, opponent } = occupantsByHex(state, marker.hexKey);
+
+  // Contested or vacated → control is sticky to the last controller.
+  if (player > 0 && opponent > 0) return marker;
+  if (player === 0 && opponent === 0) return marker;
+
+  const newControl: ObjectiveSide = player > 0 ? 'player' : 'opponent';
+  if (newControl === marker.controlSide) return marker;
+
+  return { ...marker, controlSide: newControl };
+}
+
+/**
+ * Result of advancing one objective marker through a control-detection
+ * pass — the updated marker plus what changed, so callers can emit the
+ * matching lifecycle events without recomputing the diff.
+ */
+export interface IObjectiveControlChange {
+  /** Marker after control + hold-progress advancement. */
+  readonly marker: IObjectiveMarker;
+  /** `controlSide` changed to a non-neutral side this turn. */
+  readonly captured: boolean;
+  /** A previously-controlled marker became contested/vacated/flipped. */
+  readonly lost: boolean;
+  /** `holdProgress` value changed this turn. */
+  readonly progressChanged: boolean;
+  /** Side that lost control, when `lost` is true. */
+  readonly previousControlSide: ObjectiveSide;
+}
+
+/**
+ * Runs the once-per-turn control-detection pass for a single marker:
+ * resolves the new controller, then advances `holdProgress` (increment
+ * while held by the same side, reset to 0 on any loss of control or
+ * contest).
+ *
+ * @spec scenario-objectives — Objective Control Detection
+ */
+export function advanceObjectiveControl(
+  marker: IObjectiveMarker,
+  state: IGameState,
+): IObjectiveControlChange {
+  const previousControlSide = marker.controlSide;
+  const { player, opponent } = occupantsByHex(state, marker.hexKey);
+  const contested = player > 0 && opponent > 0;
+
+  const afterControl = detectObjectiveControl(marker, state);
+  const controlChanged = afterControl.controlSide !== previousControlSide;
+
+  // Hold progress: a marker accrues hold ONLY while a single side has
+  // uncontested sole occupancy of it AND the controller did not change
+  // this turn. A contest, a vacate-after-flip, or any control change
+  // resets progress to 0.
+  let nextProgress: number;
+  if (contested) {
+    nextProgress = 0;
+  } else if (controlChanged) {
+    // Control just flipped — the new holder starts a fresh count, but
+    // only counts if it currently occupies the hex this turn.
+    nextProgress = player > 0 || opponent > 0 ? 1 : 0;
+  } else if (afterControl.controlSide === 'neutral') {
+    nextProgress = 0;
+  } else {
+    // Control unchanged. Increment only while the controller still has
+    // a unit physically on the hex; a vacated hex keeps the controller
+    // but stops accruing hold.
+    const stillHeld =
+      (afterControl.controlSide === 'player' && player > 0) ||
+      (afterControl.controlSide === 'opponent' && opponent > 0);
+    nextProgress = stillHeld ? marker.holdProgress + 1 : 0;
+  }
+
+  const nextMarker: IObjectiveMarker = {
+    ...afterControl,
+    holdProgress: nextProgress,
+  };
+
+  const captured = controlChanged && afterControl.controlSide !== 'neutral';
+  const lost =
+    previousControlSide !== 'neutral' &&
+    (contested || afterControl.controlSide !== previousControlSide);
+
+  return {
+    marker: nextMarker,
+    captured,
+    lost,
+    progressChanged: nextProgress !== marker.holdProgress,
+    previousControlSide,
+  };
+}
+
+/**
+ * The two scenario sides expressed as objective-side strings, with the
+ * attacker / defender role mapping. For generated scenarios the player
+ * is always the attacker (Capture / Breakthrough) and the defender for
+ * `defend` — matching `ScenarioGenerator` placement and the proposal's
+ * single-objective model.
+ */
+export const ATTACKER_SIDE: ObjectiveSide = 'player';
+export const DEFENDER_SIDE: ObjectiveSide = 'opponent';
+
+/**
+ * Counts participating (alive, non-withdrawn) units on a side.
+ */
+function countParticipating(state: IGameState, side: GameSide): number {
+  return Object.values(state.units).filter(
+    (u) => u.side === side && unitOccupiesHexes(u),
+  ).length;
+}
+
+/**
+ * Resolves a markerless (Destroy) scenario: a side wins when every
+ * enemy unit is destroyed or withdrawn. Mutual elimination is a draw
+ * and returns `null` (the destruction fallback handles draw labelling).
+ */
+function evaluateDestroy(state: IGameState): IObjectiveOutcome | null {
+  const playerAlive = countParticipating(state, GameSide.Player) > 0;
+  const opponentAlive = countParticipating(state, GameSide.Opponent) > 0;
+
+  if (playerAlive && opponentAlive) return null;
+  if (!playerAlive && !opponentAlive) return null;
+
+  return {
+    decided: true,
+    winningSide: playerAlive ? GameSide.Player : GameSide.Opponent,
+    reason: 'objective',
+    objectiveType: ScenarioObjectiveType.Destroy,
+  };
+}
+
+/**
+ * Resolves a Capture scenario: the attacking side wins when it holds
+ * EVERY objective hex for `holdTurnsRequired` consecutive turns.
+ * The defending side wins by destruction (handled by the caller's
+ * destruction fallback) — Capture only decides an attacker win here.
+ */
+function evaluateCapture(
+  markers: readonly IObjectiveMarker[],
+): IObjectiveOutcome | null {
+  if (markers.length === 0) return null;
+
+  const attackerHoldsAll = markers.every(
+    (m) =>
+      m.controlSide === ATTACKER_SIDE && m.holdProgress >= m.holdTurnsRequired,
+  );
+  if (!attackerHoldsAll) return null;
+
+  const winning = objectiveSideToGameSide(ATTACKER_SIDE);
+  if (winning === null) return null;
+
+  return {
+    decided: true,
+    winningSide: winning,
+    reason: 'objective',
+    objectiveType: ScenarioObjectiveType.Capture,
+  };
+}
+
+/**
+ * Resolves a Defend scenario: the attacking side wins IMMEDIATELY upon
+ * controlling all objective hexes; otherwise the defending side wins
+ * once the turn limit is reached while still in control.
+ */
+function evaluateDefend(
+  state: IGameState,
+  markers: readonly IObjectiveMarker[],
+  turnLimit: number,
+): IObjectiveOutcome | null {
+  if (markers.length === 0) return null;
+
+  const attackerHoldsAll = markers.every(
+    (m) => m.controlSide === ATTACKER_SIDE,
+  );
+  if (attackerHoldsAll) {
+    const winning = objectiveSideToGameSide(ATTACKER_SIDE);
+    if (winning === null) return null;
+    return {
+      decided: true,
+      winningSide: winning,
+      reason: 'objective',
+      objectiveType: ScenarioObjectiveType.Defend,
+    };
+  }
+
+  // Defender wins at the turn limit if it still holds the objective(s).
+  // `state.turn` is the 1-based current turn; the scenario reaches its
+  // limit once `turn >= turnLimit`.
+  if (turnLimit > 0 && state.turn >= turnLimit) {
+    const defenderHoldsAny = markers.some(
+      (m) => m.controlSide === DEFENDER_SIDE,
+    );
+    if (defenderHoldsAny) {
+      const winning = objectiveSideToGameSide(DEFENDER_SIDE);
+      if (winning === null) return null;
+      return {
+        decided: true,
+        winningSide: winning,
+        reason: 'objective',
+        objectiveType: ScenarioObjectiveType.Defend,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolves a Breakthrough scenario: the attacking side wins when
+ * `requiredUnits` of its units have reached an exit hex (a hex carrying
+ * a `breakthrough` objective marker). `holdTurnsRequired` carries the
+ * required-units count for breakthrough markers (set by placement).
+ */
+function evaluateBreakthrough(
+  state: IGameState,
+  markers: readonly IObjectiveMarker[],
+): IObjectiveOutcome | null {
+  if (markers.length === 0) return null;
+
+  const exitHexKeys = new Set(markers.map((m) => m.hexKey));
+  // Every breakthrough marker carries the same required-units count;
+  // a single objective hex is the common case.
+  const requiredUnits = Math.max(1, ...markers.map((m) => m.holdTurnsRequired));
+
+  const attackerGameSide = objectiveSideToGameSide(ATTACKER_SIDE);
+  if (attackerGameSide === null) return null;
+
+  let reached = 0;
+  for (const unit of Object.values(state.units)) {
+    if (unit.side !== attackerGameSide) continue;
+    if (unit.destroyed) continue;
+    if (exitHexKeys.has(coordToKey(unit.position))) reached += 1;
+  }
+
+  if (reached < requiredUnits) return null;
+
+  return {
+    decided: true,
+    winningSide: attackerGameSide,
+    reason: 'objective',
+    objectiveType: ScenarioObjectiveType.Breakthrough,
+  };
+}
+
+/**
+ * Evaluates the scenario objective outcome for a game state. Returns an
+ * `IObjectiveOutcome` when the scenario is decided, or `null` while it
+ * is still undecided. The game-over check consults this BEFORE the
+ * destruction / turn-limit fallback (design.md D4) so an objective win
+ * takes precedence over a turn-limit draw.
+ *
+ * An empty / absent objective map is treated as a `destroy` scenario
+ * (spec: "Markerless session resolves as destruction").
+ *
+ * @spec scenario-objectives — Objective-Based Victory Evaluation
+ */
+export function evaluateObjectiveOutcome(
+  state: IGameState,
+  turnLimit = 0,
+): IObjectiveOutcome | null {
+  const markers = Object.values(state.objectives ?? {});
+
+  if (markers.length === 0) {
+    return evaluateDestroy(state);
+  }
+
+  // Single-objective model: every marker shares one objective type.
+  const objectiveType = markers[0].objectiveType;
+  const sameType = markers.filter((m) => m.objectiveType === objectiveType);
+
+  switch (objectiveType) {
+    case 'capture':
+      return evaluateCapture(sameType);
+    case 'defend':
+      return evaluateDefend(state, sameType, turnLimit);
+    case 'breakthrough':
+      return evaluateBreakthrough(state, sameType);
+    default:
+      return evaluateDestroy(state);
+  }
+}

--- a/src/utils/gameplay/objectives/objectiveEvents.ts
+++ b/src/utils/gameplay/objectives/objectiveEvents.ts
@@ -1,0 +1,210 @@
+/**
+ * Scenario objective lifecycle event builders + the per-turn control-
+ * detection pass that emits them.
+ *
+ * @spec openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+ */
+
+import type {
+  IGameEvent,
+  IGameState,
+  IObjectiveCapturedPayload,
+  IObjectiveLostPayload,
+  IObjectiveProgressPayload,
+} from '@/types/gameplay';
+import type {
+  IObjectiveMarker,
+  ObjectiveSide,
+} from '@/types/scenario/ScenarioInterfaces';
+
+import { GameEventType, GamePhase } from '@/types/gameplay';
+import { createEventBase } from '@/utils/gameplay/gameEvents/base';
+
+import { advanceObjectiveControl } from './objectiveEngine';
+
+/**
+ * Builds an `ObjectiveCaptured` event. Emitted when a marker's
+ * `controlSide` changes to a concrete side.
+ */
+export function createObjectiveCapturedEvent(
+  gameId: string,
+  sequence: number,
+  turn: number,
+  objectiveId: string,
+  hexKey: string,
+  capturingSide: ObjectiveSide,
+  phase: GamePhase = GamePhase.End,
+): IGameEvent {
+  const payload: IObjectiveCapturedPayload = {
+    objectiveId,
+    hexKey,
+    capturingSide,
+    turn,
+  };
+  return {
+    ...createEventBase(
+      gameId,
+      sequence,
+      GameEventType.ObjectiveCaptured,
+      turn,
+      phase,
+    ),
+    payload,
+  };
+}
+
+/**
+ * Builds an `ObjectiveLost` event. Emitted when a marker a side
+ * controlled becomes contested / neutral / flips.
+ */
+export function createObjectiveLostEvent(
+  gameId: string,
+  sequence: number,
+  turn: number,
+  objectiveId: string,
+  hexKey: string,
+  losingSide: ObjectiveSide,
+  phase: GamePhase = GamePhase.End,
+): IGameEvent {
+  const payload: IObjectiveLostPayload = {
+    objectiveId,
+    hexKey,
+    losingSide,
+    turn,
+  };
+  return {
+    ...createEventBase(
+      gameId,
+      sequence,
+      GameEventType.ObjectiveLost,
+      turn,
+      phase,
+    ),
+    payload,
+  };
+}
+
+/**
+ * Builds an `ObjectiveProgress` event. Emitted when a marker's
+ * `holdProgress` changes during the control-detection pass.
+ */
+export function createObjectiveProgressEvent(
+  gameId: string,
+  sequence: number,
+  turn: number,
+  marker: IObjectiveMarker,
+  phase: GamePhase = GamePhase.End,
+): IGameEvent {
+  const payload: IObjectiveProgressPayload = {
+    objectiveId: marker.id,
+    hexKey: marker.hexKey,
+    controlSide: marker.controlSide,
+    holdProgress: marker.holdProgress,
+    holdTurnsRequired: marker.holdTurnsRequired,
+    turn,
+  };
+  return {
+    ...createEventBase(
+      gameId,
+      sequence,
+      GameEventType.ObjectiveProgress,
+      turn,
+      phase,
+    ),
+    payload,
+  };
+}
+
+/**
+ * Result of running the once-per-turn objective control-detection
+ * pass: the updated objective map plus the lifecycle events to append
+ * to the game event log.
+ */
+export interface IObjectiveControlPassResult {
+  /** Objective map after control + hold-progress advancement. */
+  readonly objectives: Record<string, IObjectiveMarker>;
+  /** Lifecycle events produced this pass, in deterministic order. */
+  readonly events: readonly IGameEvent[];
+}
+
+/**
+ * Runs the per-turn control-detection pass over every objective marker
+ * in `state.objectives`. Markers are processed in `hexKey`-sorted order
+ * so event emission is deterministic. Returns the new objective map and
+ * the `ObjectiveCaptured` / `ObjectiveLost` / `ObjectiveProgress`
+ * events to append. Events are sequenced starting at `startSequence`.
+ *
+ * Designed to be a pure function of `state` (unit positions) so
+ * replaying the event log reconstructs objective state exactly
+ * (design.md D7).
+ *
+ * @spec scenario-objectives — Objective Lifecycle Events
+ */
+export function runObjectiveControlPass(
+  gameId: string,
+  state: IGameState,
+  startSequence: number,
+  turn: number,
+  phase: GamePhase = GamePhase.End,
+): IObjectiveControlPassResult {
+  const current = state.objectives ?? {};
+  const keys = Object.keys(current).sort();
+  if (keys.length === 0) {
+    return { objectives: {}, events: [] };
+  }
+
+  const nextObjectives: Record<string, IObjectiveMarker> = {};
+  const events: IGameEvent[] = [];
+  let sequence = startSequence;
+
+  for (const key of keys) {
+    const change = advanceObjectiveControl(current[key], state);
+    nextObjectives[key] = change.marker;
+
+    if (change.lost) {
+      const losing =
+        change.previousControlSide !== 'neutral'
+          ? change.previousControlSide
+          : change.marker.controlSide;
+      events.push(
+        createObjectiveLostEvent(
+          gameId,
+          sequence++,
+          turn,
+          change.marker.id,
+          change.marker.hexKey,
+          losing,
+          phase,
+        ),
+      );
+    }
+
+    if (change.captured) {
+      events.push(
+        createObjectiveCapturedEvent(
+          gameId,
+          sequence++,
+          turn,
+          change.marker.id,
+          change.marker.hexKey,
+          change.marker.controlSide,
+          phase,
+        ),
+      );
+    }
+
+    if (change.progressChanged) {
+      events.push(
+        createObjectiveProgressEvent(
+          gameId,
+          sequence++,
+          turn,
+          change.marker,
+          phase,
+        ),
+      );
+    }
+  }
+
+  return { objectives: nextObjectives, events };
+}

--- a/src/utils/gameplay/objectives/objectivePlacement.ts
+++ b/src/utils/gameplay/objectives/objectivePlacement.ts
@@ -1,0 +1,251 @@
+/**
+ * Scenario Objective Placement
+ *
+ * Maps a scenario's objective type + victory condition onto a concrete
+ * placement config, and places objective hexes deterministically from
+ * the scenario seed.
+ *
+ * @spec openspec/changes/add-scenario-objective-engine/specs/scenario-objectives/spec.md
+ */
+
+import type { IHexCoordinate } from '@/types/gameplay';
+import type {
+  IObjectiveMarker,
+  IObjectivePlacementConfig,
+  ObjectiveMarkerType,
+  VictoryCondition,
+} from '@/types/scenario/ScenarioInterfaces';
+
+import { SeededRandom } from '@/simulation/core/SeededRandom';
+import {
+  DeploymentZone,
+  ScenarioObjectiveType,
+} from '@/types/scenario/ScenarioInterfaces';
+import { coordToKey } from '@/utils/gameplay/hexMath';
+
+/**
+ * Default consecutive hold turns for a generated Capture scenario.
+ * Per design.md Open Question: control at the end of a turn counts as
+ * captured. Revisit if Capture matches end too quickly.
+ */
+export const DEFAULT_CAPTURE_HOLD_TURNS = 1;
+
+/**
+ * Default required-unit count for a generated Breakthrough scenario
+ * when no victory condition specifies one.
+ */
+export const DEFAULT_BREAKTHROUGH_REQUIRED_UNITS = 1;
+
+/**
+ * Maps a scenario `ScenarioObjectiveType` to the hex-objective family
+ * the engine supports. `destroy` / `escort` / `recon` / `custom` have
+ * no hex markers and return `null`.
+ */
+export function objectiveMarkerTypeFor(
+  type: ScenarioObjectiveType,
+): ObjectiveMarkerType | null {
+  switch (type) {
+    case ScenarioObjectiveType.Capture:
+      return 'capture';
+    case ScenarioObjectiveType.Defend:
+      return 'defend';
+    case ScenarioObjectiveType.Breakthrough:
+      return 'breakthrough';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Derives the objective placement config for a scenario from its
+ * objective type and (optionally) its victory conditions (task 1.3).
+ * Returns `null` for a markerless (`destroy` / `escort` / `recon`)
+ * scenario.
+ *
+ * Hex count:
+ *   - Capture — `objectiveCount` from an `ICaptureVictoryCondition`,
+ *     clamped to 1..3.
+ *   - Defend  — 1 hex (single defended position).
+ *   - Breakthrough — 1 exit hex.
+ *
+ * Hold turns / required units are pulled from the matching victory
+ * condition when present, else the defaults above.
+ */
+export function deriveObjectivePlacementConfig(
+  objectiveType: ScenarioObjectiveType,
+  victoryConditions: readonly VictoryCondition[] = [],
+): IObjectivePlacementConfig | null {
+  const markerType = objectiveMarkerTypeFor(objectiveType);
+  if (markerType === null) return null;
+
+  if (markerType === 'capture') {
+    const capture = victoryConditions.find(
+      (v) => v.id === 'capture_objective' || v.id === 'capture_and_hold',
+    ) as { objectiveCount?: number; holdTurns?: number } | undefined;
+    const hexCount = clamp(capture?.objectiveCount ?? 1, 1, 3);
+    const holdTurnsRequired =
+      capture?.holdTurns && capture.holdTurns > 0
+        ? capture.holdTurns
+        : DEFAULT_CAPTURE_HOLD_TURNS;
+    return {
+      objectiveType: 'capture',
+      hexCount,
+      holdTurnsRequired,
+      requiredUnits: 0,
+    };
+  }
+
+  if (markerType === 'defend') {
+    return {
+      objectiveType: 'defend',
+      hexCount: 1,
+      holdTurnsRequired: 1,
+      requiredUnits: 0,
+    };
+  }
+
+  // breakthrough
+  const movement = victoryConditions.find((v) => v.id === 'breakthrough') as
+    | { requiredUnits?: number }
+    | undefined;
+  const requiredUnits =
+    movement?.requiredUnits && movement.requiredUnits > 0
+      ? movement.requiredUnits
+      : DEFAULT_BREAKTHROUGH_REQUIRED_UNITS;
+  return {
+    objectiveType: 'breakthrough',
+    hexCount: 1,
+    holdTurnsRequired: 1,
+    requiredUnits,
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Generates every in-bounds axial coordinate for a hex map of the
+ * given radius, ordered deterministically (q ascending, then r).
+ */
+function allHexCoordinates(radius: number): IHexCoordinate[] {
+  const coords: IHexCoordinate[] = [];
+  for (let q = -radius; q <= radius; q++) {
+    for (let r = -radius; r <= radius; r++) {
+      if (Math.abs(q + r) <= radius) coords.push({ q, r });
+    }
+  }
+  return coords;
+}
+
+/**
+ * Picks `count` distinct entries from `pool` using a seeded
+ * Fisher-Yates partial shuffle so the same seed yields identical
+ * picks. Returns at most `pool.length` entries.
+ */
+function pickSeeded<T>(
+  pool: readonly T[],
+  count: number,
+  random: SeededRandom,
+): T[] {
+  const arr = [...pool];
+  const n = Math.min(count, arr.length);
+  for (let i = 0; i < n; i++) {
+    const j = i + random.nextInt(arr.length - i);
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr.slice(0, n);
+}
+
+/**
+ * Deployment-zone occupancy rows used by `ScenarioGenerator`: the
+ * player deploys at `-(radius - 1)` (south) and the opponent at
+ * `radius - 1` (north). Interior placement excludes both rows plus the
+ * outer edge so Capture objectives sit between the two armies.
+ */
+export interface IObjectiveZoneConfig {
+  readonly radius: number;
+  /** Player deployment row r-coordinate. */
+  readonly playerRow: number;
+  /** Opponent deployment row r-coordinate. */
+  readonly opponentRow: number;
+}
+
+/**
+ * Places objective hexes for a scenario, deterministically from the
+ * given seed. The returned map is keyed by canonical `"q,r"` strings.
+ *
+ *   - Capture — 1..3 interior hexes, excluding both deployment rows
+ *     and the outer ring.
+ *   - Defend — hex(es) inside the defender (opponent) deployment zone.
+ *   - Breakthrough — exit hexes on the map edge opposite the attacker
+ *     (player deploys south → exits are on the north edge).
+ *
+ * @spec scenario-objectives — Objective Placement During Scenario Generation
+ */
+export function placeObjectives(
+  config: IObjectivePlacementConfig,
+  zone: IObjectiveZoneConfig,
+  seed: number,
+): Record<string, IObjectiveMarker> {
+  const random = new SeededRandom(seed >>> 0);
+  const all = allHexCoordinates(zone.radius);
+  const radius = zone.radius;
+
+  let pool: IHexCoordinate[];
+  if (config.objectiveType === 'capture') {
+    // Interior hexes: not on either deployment row, not on the outer
+    // ring. Falls back to anything off the deployment rows if the map
+    // is too small for a true interior.
+    pool = all.filter(
+      (c) =>
+        c.r !== zone.playerRow &&
+        c.r !== zone.opponentRow &&
+        Math.abs(c.q) + Math.abs(c.r) + Math.abs(-c.q - c.r) < radius * 2,
+    );
+    if (pool.length === 0) {
+      pool = all.filter(
+        (c) => c.r !== zone.playerRow && c.r !== zone.opponentRow,
+      );
+    }
+  } else if (config.objectiveType === 'defend') {
+    // Defender (opponent) deployment zone.
+    pool = all.filter((c) => c.r === zone.opponentRow);
+  } else {
+    // Breakthrough: exit edge opposite the attacker. The player
+    // deploys on the south row (most-negative r); the exit edge is the
+    // north row (most-positive r).
+    pool = all.filter((c) => c.r === radius);
+  }
+
+  if (pool.length === 0) return {};
+
+  const picks = pickSeeded(pool, config.hexCount, random);
+  const markers: Record<string, IObjectiveMarker> = {};
+
+  picks.forEach((coord, index) => {
+    const hexKey = coordToKey(coord);
+    const holdTurnsRequired =
+      config.objectiveType === 'breakthrough'
+        ? config.requiredUnits
+        : config.holdTurnsRequired;
+    markers[hexKey] = {
+      id: `objective-${index + 1}`,
+      hexKey,
+      objectiveType: config.objectiveType,
+      owningSide: 'neutral',
+      controlSide: 'neutral',
+      controlRule: 'sole-occupancy',
+      holdTurnsRequired,
+      holdProgress: 0,
+    };
+  });
+
+  return markers;
+}
+
+/**
+ * `DeploymentZone` is re-exported so callers that only need placement
+ * do not have to import from two modules.
+ */
+export { DeploymentZone };


### PR DESCRIPTION
## Summary

Implements the OpenSpec change `add-scenario-objective-engine` end-to-end. Generated combat scenarios could previously only be won by total destruction; this builds the objective-hex spatial system so a procedurally generated scenario can be played to a non-destruction outcome (Capture / Defend / Breakthrough).

## What was implemented

- **Objective data model** — `IObjectiveMarker`, `HexKey`, `ObjectiveControlRule`, `IObjectiveOutcome` in `ScenarioInterfaces.ts`; `objectives: Record<HexKey, IObjectiveMarker>` carried on `IGameState` (design D1 — `IHex` unchanged). A markerless map behaves identically to today.
- **Placement** — `ScenarioGenerator` (and the `SimulationRunner` path) place objective hexes per type, seeded deterministically from the scenario seed. Capture → 1–3 interior hexes; Defend → defender deployment zone; Breakthrough → exit edge opposite the attacker.
- **Control detection** — `detectObjectiveControl` / `advanceObjectiveControl` implement the sole-occupancy rule with sticky-on-contest control (design D3) and per-turn `holdProgress` advancement.
- **Victory evaluation** — `evaluateObjectiveOutcome` covers Destroy / Capture / Defend / Breakthrough (design D5), consulted before the destruction fallback in `checkVictoryConditions`, `GameOutcomeCalculator`, and `SimulationRunner` (design D4). An objective win overrides a turn-limit draw and surviving units.
- **Rendering** — read-only `ObjectiveMarkersLayer` in `HexMapDisplay`, above terrain and below tokens (design D6), styled by control state (neutral / friendly / enemy / contested) with Capture hold-progress display.
- **Lifecycle events** — `ObjectiveCaptured` / `ObjectiveLost` / `ObjectiveProgress` event types + payloads; emitted by the per-turn control pass and applied by a reducer so the event log fully replays objective state (design D7).

## Verification

- `npx tsc --noEmit` — zero errors
- `npx oxlint src/` — 0 warnings, 0 errors
- `npx oxfmt --check` — all new/changed files clean
- `npx openspec validate add-scenario-objective-engine --strict` — valid
- Tests — 51 new objective tests (unit + integration + render); full gameplay/simulation/component/service suites green (8900+ tests, 0 failures)

## Notes / deviations

- `GameOutcomeCalculator` keeps its richer `elimination` / `mutual_destruction` reason labels for markerless scenarios — only a true objective-marker win (Capture / Defend / Breakthrough) short-circuits with reason `objective`. Routing markerless `destroy` straight through `reason: 'objective'` would have regressed existing post-battle summary semantics; design D5 ("express Destroy through the same engine for uniformity") is honored at the evaluation layer while preserving the calculator's label contract.
- Task 5.1 names `gameSessionCore` — its game-over logic is `checkVictoryConditions` in `gameStateReducer`, which is the surface that was wired.
- BV parity and determinism untouched: no construction-layer changes; placement uses `SeededRandom` and control detection is a pure function of unit positions.