### PR TITLE
feat(ai): terrain-aware movement and difficulty tiers

### DIFF
--- a/openspec/changes/add-ai-terrain-aware-movement/tasks.md
+++ b/openspec/changes/add-ai-terrain-aware-movement/tasks.md
@@ -2,39 +2,39 @@
 
 ## 1. Extract Shared Terrain-Cost Utility
 
-- [ ] 1.1 Create `src/utils/gameplay/terrainMovementCost.ts` exporting `getTerrainMovementCost` and `getPrimaryTerrainFeature`, moved verbatim from `src/components/gameplay/HexMapDisplay/renderHelpers.ts`
-- [ ] 1.2 Re-export both functions from `renderHelpers.ts` so existing rendering call sites are untouched
-- [ ] 1.3 Confirm no `src/simulation/` import resolves into `src/components/` — the sim layer imports only the new utility
-- [ ] 1.4 Unit tests for the extracted utility (open ground = 1 MP, heavy woods > 1, deterministic for a given terrain)
+- [x] 1.1 Create `src/utils/gameplay/terrainMovementCost.ts` exporting `getTerrainMovementCost` and `getPrimaryTerrainFeature`, moved verbatim from `src/components/gameplay/HexMapDisplay/renderHelpers.ts`
+- [x] 1.2 Re-export both functions from `renderHelpers.ts` so existing rendering call sites are untouched
+- [x] 1.3 Confirm no `src/simulation/` import resolves into `src/components/` — the sim layer imports only the new utility
+- [x] 1.4 Unit tests for the extracted utility (open ground = 1 MP, heavy woods > 1, deterministic for a given terrain)
 
 ## 2. AI Difficulty Tier Registry
 
-- [ ] 2.1 Create `src/simulation/ai/AITierRegistry.ts` with `AITierName` (`Green` | `Regular` | `Veteran` | `Elite`), `IAITierParameters`, and `IAITierMovementParameters`
-- [ ] 2.2 Define the frozen tier table — `Green`/`Regular` set `pathfinderEnabled: false` with zeroed weights; `Veteran`/`Elite` enable the pathfinder with tuned weights
-- [ ] 2.3 Export `getTierParameters(name)` that throws an explicit error on an unknown tier name (mirror `getBehaviorVariant`)
-- [ ] 2.4 Add optional `tier?: AITierName` to `IBotBehavior` (default `Regular`) and map each `behaviorVariants.ts` preset onto a tier
-- [ ] 2.5 Tests: every tier resolves; unknown tier throws; `Green`/`Regular` parameters yield zero scoring delta vs. the legacy scorer
+- [x] 2.1 Create `src/simulation/ai/AITierRegistry.ts` with `AITierName` (`Green` | `Regular` | `Veteran` | `Elite`), `IAITierParameters`, and `IAITierMovementParameters`
+- [x] 2.2 Define the frozen tier table — `Green`/`Regular` set `pathfinderEnabled: false` with zeroed weights; `Veteran`/`Elite` enable the pathfinder with tuned weights
+- [x] 2.3 Export `getTierParameters(name)` that throws an explicit error on an unknown tier name (mirror `getBehaviorVariant`)
+- [x] 2.4 Add optional `tier?: AITierName` to `IBotBehavior` (default `Regular`) and map each `behaviorVariants.ts` preset onto a tier
+- [x] 2.5 Tests: every tier resolves; unknown tier throws; `Green`/`Regular` parameters yield zero scoring delta vs. the legacy scorer
 
 ## 3. Terrain-Cost Pathfinder
 
-- [ ] 3.1 Create `src/simulation/ai/AITerrainPathfinder.ts` implementing the frozen API contract from `design.md` D2 (`IAIPath`, `IAIPathfindRequest`, `findPath`, `findAllPaths`)
-- [ ] 3.2 Implement uniform-cost (Dijkstra) search over hex neighbors with edge weight = `getTerrainMovementCost`, tie-broken by canonical neighbor order
-- [ ] 3.3 `findPath` returns `reachable: false` with a best-effort partial path when the destination exceeds the MP budget
-- [ ] 3.4 `findAllPaths` returns the cheapest path to every reachable destination keyed by the canonical `"q,r"` string in a single pass
-- [ ] 3.5 Tests: cheapest path avoids costly terrain; identical request → identical path; unreachable destination flagged; `findAllPaths` agrees with per-destination `findPath`
+- [x] 3.1 Create `src/simulation/ai/AITerrainPathfinder.ts` implementing the frozen API contract from `design.md` D2 (`IAIPath`, `IAIPathfindRequest`, `findPath`, `findAllPaths`)
+- [x] 3.2 Implement uniform-cost (Dijkstra) search over hex neighbors with edge weight = `getTerrainMovementCost`, tie-broken by canonical neighbor order
+- [x] 3.3 `findPath` returns `reachable: false` with a best-effort partial path when the destination exceeds the MP budget
+- [x] 3.4 `findAllPaths` returns the cheapest path to every reachable destination keyed by the canonical `"q,r"` string in a single pass
+- [x] 3.5 Tests: cheapest path avoids costly terrain; identical request → identical path; unreachable destination flagged; `findAllPaths` agrees with per-destination `findPath`
 
 ## 4. Terrain-Aware Move Scoring
 
-- [ ] 4.1 In `MoveAI.selectMove`, call `findAllPaths` once and pass each destination's `IAIPath` into `scoreMove`
-- [ ] 4.2 Add the cover term to `scoreMove` — `+coverWeight` when the destination hex offers partial-or-better cover
-- [ ] 4.3 Add the LOS-denial term — `+losDenialWeight` when the destination breaks the highest-threat enemy's line of sight
-- [ ] 4.4 Add the terrain-cost term — `-terrainCostWeight * (pathMpCost - hexDistance)` so wasteful paths score lower
-- [ ] 4.5 Gate all three terms on `tier.movement.pathfinderEnabled`; when disabled, `scoreMove` output is byte-identical to today's
-- [ ] 4.6 Tests: a `Veteran` bot prefers a partial-cover hex over an equal-LOS open hex; an LOS-breaking hex outscores an exposed equal-cost hex; a `Regular` bot reproduces the legacy choice
+- [x] 4.1 In `MoveAI.selectMove`, call `findAllPaths` once and pass each destination's `IAIPath` into `scoreMove`
+- [x] 4.2 Add the cover term to `scoreMove` — `+coverWeight` when the destination hex offers partial-or-better cover
+- [x] 4.3 Add the LOS-denial term — `+losDenialWeight` when the destination breaks the highest-threat enemy's line of sight
+- [x] 4.4 Add the terrain-cost term — `-terrainCostWeight * (pathMpCost - hexDistance)` so wasteful paths score lower
+- [x] 4.5 Gate all three terms on `tier.movement.pathfinderEnabled`; when disabled, `scoreMove` output is byte-identical to today's
+- [x] 4.6 Tests: a `Veteran` bot prefers a partial-cover hex over an equal-LOS open hex; an LOS-breaking hex outscores an exposed equal-cost hex; a `Regular` bot reproduces the legacy choice
 
 ## 5. Verification
 
-- [ ] 5.1 Integration test: a `Veteran` bot on a map with woods routes around open ground into cover; the same scenario on `Regular` takes the straight line
-- [ ] 5.2 Determinism test: SimulationRunner golden traces on the legacy (`Regular`) tier are byte-identical to pre-change traces
-- [ ] 5.3 `npx openspec validate add-ai-terrain-aware-movement --strict` reports valid
-- [ ] 5.4 Build, lint, and typecheck pass
+- [x] 5.1 Integration test: a `Veteran` bot on a map with woods routes around open ground into cover; the same scenario on `Regular` takes the straight line
+- [x] 5.2 Determinism test: SimulationRunner golden traces on the legacy (`Regular`) tier are byte-identical to pre-change traces
+- [x] 5.3 `npx openspec validate add-ai-terrain-aware-movement --strict` reports valid
+- [x] 5.4 Build, lint, and typecheck pass

--- a/src/components/gameplay/HexMapDisplay/renderHelpers.ts
+++ b/src/components/gameplay/HexMapDisplay/renderHelpers.ts
@@ -10,7 +10,6 @@ import {
   TERRAIN_COLORS,
   WATER_DEPTH_COLORS,
   TERRAIN_PATTERNS,
-  TERRAIN_LAYER_ORDER,
 } from '@/constants/terrain';
 import {
   IHexCoordinate,
@@ -141,27 +140,19 @@ export function hexInList(
 // =============================================================================
 
 /**
- * Get the primary terrain feature (highest layer order) for a hex.
+ * `getPrimaryTerrainFeature` and `getTerrainMovementCost` were extracted into
+ * the simulation-accessible utility `src/utils/gameplay/terrainMovementCost.ts`
+ * per `add-ai-terrain-aware-movement` design D1 so the AI can consult terrain
+ * cost without importing this rendering module. They are re-exported here so
+ * existing rendering call sites are unchanged; `getPrimaryTerrainFeature` is
+ * also imported below for use by the remaining rendering helpers in this file.
  */
-export function getPrimaryTerrainFeature(
-  terrain: IHexTerrain | undefined,
-): { type: TerrainType; level: number } | null {
-  if (!terrain || terrain.features.length === 0) return null;
+export {
+  getPrimaryTerrainFeature,
+  getTerrainMovementCost,
+} from '@/utils/gameplay/terrainMovementCost';
 
-  const sortedFeatures = [...terrain.features].sort(
-    (a, b) => TERRAIN_LAYER_ORDER[b.type] - TERRAIN_LAYER_ORDER[a.type],
-  );
-  return sortedFeatures[0];
-}
-
-export function getTerrainMovementCost(
-  terrain: IHexTerrain | undefined,
-): number {
-  const feature = getPrimaryTerrainFeature(terrain);
-  if (!feature) return 1;
-  const props = TERRAIN_PROPERTIES[feature.type];
-  return 1 + (props?.movementCostModifier.walk ?? 0);
-}
+import { getPrimaryTerrainFeature } from '@/utils/gameplay/terrainMovementCost';
 
 export function getTerrainCoverLevel(
   terrain: IHexTerrain | undefined,

--- a/src/simulation/__tests__/aiLayeringGuard.test.ts
+++ b/src/simulation/__tests__/aiLayeringGuard.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Layering guard for the terrain-aware AI modules.
+ *
+ * Covers the `Shared Terrain Movement-Cost Utility` requirement scenario
+ * "Simulation layer does not import rendering code" — the AI pathfinder and
+ * move scorer must source terrain cost from the shared sim utility and never
+ * resolve an import into the rendering layer (`src/components/`).
+ *
+ * @spec openspec/changes/add-ai-terrain-aware-movement/specs/simulation-system/spec.md
+ *   Requirement: Shared Terrain Movement-Cost Utility
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/** Project-root-relative paths of the AI modules touched by this change. */
+const AI_MODULE_FILES = [
+  'src/simulation/ai/AITerrainPathfinder.ts',
+  'src/simulation/ai/AITierRegistry.ts',
+  'src/simulation/ai/MoveAI.ts',
+  'src/simulation/ai/types.ts',
+  'src/simulation/ai/behaviorVariants.ts',
+];
+
+/**
+ * Matches an ES import / re-export specifier — `from '...'` or `from "..."`.
+ * Captures the module specifier so we can assert it does not reach into the
+ * rendering layer.
+ */
+const IMPORT_SPECIFIER = /\bfrom\s+['"]([^'"]+)['"]/g;
+
+describe('AI module layering — no rendering imports', () => {
+  it.each(AI_MODULE_FILES)(
+    '%s does not import from the rendering layer (src/components/)',
+    (relativePath) => {
+      const source = readFileSync(join(process.cwd(), relativePath), 'utf-8');
+      const specifiers: string[] = [];
+      let match: RegExpExecArray | null;
+      while ((match = IMPORT_SPECIFIER.exec(source)) !== null) {
+        specifiers.push(match[1]);
+      }
+
+      for (const specifier of specifiers) {
+        expect(specifier).not.toMatch(/(^|\/)components\//);
+        expect(specifier).not.toContain('HexMapDisplay');
+        expect(specifier).not.toContain('renderHelpers');
+      }
+    },
+  );
+
+  it('the AI pathfinder sources terrain cost from the shared sim utility', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/simulation/ai/AITerrainPathfinder.ts'),
+      'utf-8',
+    );
+    expect(source).toContain('@/utils/gameplay/terrainMovementCost');
+  });
+});

--- a/src/simulation/__tests__/aiTerrainAwareMoveScoring.test.ts
+++ b/src/simulation/__tests__/aiTerrainAwareMoveScoring.test.ts
@@ -1,0 +1,471 @@
+/**
+ * Tests for terrain-aware move scoring.
+ *
+ * Covers the `Terrain-Aware Move Scoring` requirement of
+ * `add-ai-terrain-aware-movement` — scenarios "Veteran bot seeks cover",
+ * "Veteran bot breaks enemy line of sight", "Wasteful path scores below an
+ * efficient path", and "Regular bot ignores the new terms" — plus the
+ * `AI Difficulty Tier Registry` scenario "Lower tiers reproduce the legacy
+ * scorer" and the integration check from tasks 5.1 / 5.2.
+ *
+ * @spec openspec/changes/add-ai-terrain-aware-movement/specs/simulation-system/spec.md
+ *   Requirement: Terrain-Aware Move Scoring
+ */
+
+import type {
+  IHex,
+  IHexCoordinate,
+  IHexGrid,
+  IMovementCapability,
+} from '@/types/gameplay';
+
+import { Facing, MovementType, TerrainType } from '@/types/gameplay';
+import { hexDistance, hexLine } from '@/utils/gameplay/hexMath';
+import { calculateLOS } from '@/utils/gameplay/lineOfSight';
+
+import { findAllPaths, type IAIPath } from '../ai/AITerrainPathfinder';
+import { getTierParameters } from '../ai/AITierRegistry';
+import { MoveAI, scoreMove, type IScoreMoveContext } from '../ai/MoveAI';
+import {
+  DEFAULT_BEHAVIOR,
+  type IAIUnitState,
+  type IBotBehavior,
+  type IMove,
+} from '../ai/types';
+import { SeededRandom } from '../core/SeededRandom';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeGrid(
+  radius: number,
+  terrainAt: Record<string, string> = {},
+  occupied: IHexCoordinate[] = [],
+): IHexGrid {
+  const hexes = new Map<string, IHex>();
+  const occupiedSet = new Set(occupied.map((c) => `${c.q},${c.r}`));
+  for (let q = -radius; q <= radius; q++) {
+    for (let r = -radius; r <= radius; r++) {
+      if (Math.abs(q + r) > radius) continue;
+      const key = `${q},${r}`;
+      hexes.set(key, {
+        coord: { q, r },
+        occupantId: occupiedSet.has(key) ? 'blocker' : null,
+        terrain: terrainAt[key] ?? 'clear',
+        elevation: 0,
+      });
+    }
+  }
+  return { config: { radius }, hexes };
+}
+
+function makeUnit(
+  overrides: Partial<IAIUnitState> & { unitId: string },
+): IAIUnitState {
+  return {
+    position: { q: 0, r: 0 },
+    facing: Facing.North,
+    heat: 0,
+    weapons: [],
+    ammo: {},
+    destroyed: false,
+    gunnery: 4,
+    movementType: MovementType.Stationary,
+    hexesMoved: 0,
+    ...overrides,
+  };
+}
+
+function makeMove(
+  overrides: Partial<IMove> & { destination: IHexCoordinate },
+): IMove {
+  return {
+    facing: Facing.North,
+    movementType: MovementType.Walk,
+    mpCost: 1,
+    heatGenerated: 1,
+    ...overrides,
+  };
+}
+
+function capability(walk: number, jump = 0): IMovementCapability {
+  return { walkMP: walk, runMP: Math.ceil(walk * 1.5), jumpMP: jump };
+}
+
+const VETERAN_MOVEMENT = getTierParameters('Veteran').movement;
+const REGULAR_MOVEMENT = getTierParameters('Regular').movement;
+
+// =============================================================================
+// Scenario: Veteran bot seeks cover
+// =============================================================================
+
+describe('Veteran bot seeks cover', () => {
+  it('scores a partial-cover destination higher than an open one', () => {
+    // Cover hex at (2,0) is light woods; open hex at (-2,0) is clear.
+    // Cover hex (2,0) is light woods; open hex (-2,2) is clear. Both are
+    // hex-distance 6 from the single enemy at (0,6) — verified below — so
+    // the LOS and closing-distance terms are equal and only the cover
+    // term separates the two scores.
+    const coverDest = { q: 2, r: 0 };
+    const openDest = { q: -2, r: 2 };
+    const enemyPos = { q: 0, r: 6 };
+    expect(hexDistance(coverDest, enemyPos)).toBe(
+      hexDistance(openDest, enemyPos),
+    );
+
+    const grid = makeGrid(7, { '2,0': TerrainType.LightWoods });
+    const attacker = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'e', position: enemyPos });
+
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker, enemy],
+      grid,
+      tierMovement: VETERAN_MOVEMENT,
+    };
+
+    const coverScore = scoreMove(makeMove({ destination: coverDest }), ctx);
+    const openScore = scoreMove(makeMove({ destination: openDest }), ctx);
+
+    expect(coverScore).toBeGreaterThan(openScore);
+    expect(coverScore - openScore).toBe(VETERAN_MOVEMENT.coverWeight);
+  });
+
+  it('selectMove routes a Veteran bot into the cover hex', () => {
+    const coverDest = { q: 2, r: 0 };
+    const openDest = { q: -2, r: 2 };
+    const grid = makeGrid(7, { '2,0': TerrainType.LightWoods });
+    const attacker = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'e', position: { q: 0, r: 6 } });
+
+    const veteran: IBotBehavior = { ...DEFAULT_BEHAVIOR, tier: 'Veteran' };
+    const ai = new MoveAI(veteran);
+
+    const moves: IMove[] = [
+      makeMove({ destination: coverDest }),
+      makeMove({ destination: openDest }),
+    ];
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker, enemy],
+      grid,
+      capability: capability(4),
+    };
+
+    const chosen = ai.selectMove(moves, new SeededRandom(1), attacker, ctx);
+    expect(chosen?.destination).toEqual(coverDest);
+  });
+});
+
+// =============================================================================
+// Scenario: Veteran bot breaks enemy line of sight
+// =============================================================================
+
+describe('Veteran bot breaks enemy line of sight', () => {
+  it('scores an LOS-breaking destination higher than a visible one', () => {
+    // Two destinations equidistant (hex-distance 8) from the threat at
+    // (0,-6): hiddenDest (2,0) and visibleDest (-2,2). Heavy woods are
+    // placed on every intervening hex of the threat -> hiddenDest line so
+    // that destination breaks LOS; the threat -> visibleDest line is left
+    // clear. The setup is self-validating: calculateLOS is asserted below
+    // to confirm one destination is hidden and one visible before the
+    // scoring comparison runs.
+    const threatPos = { q: 0, r: -6 };
+    const hiddenDest = { q: 2, r: 0 };
+    const visibleDest = { q: -2, r: 2 };
+    expect(hexDistance(hiddenDest, threatPos)).toBe(
+      hexDistance(visibleDest, threatPos),
+    );
+
+    // Heavy woods on the intervening hexes of the line to the hidden hex,
+    // EXCLUDING any hex also on the line to the visible hex (the two lines
+    // share near-threat hexes) so the visible destination keeps clear LOS.
+    const lineToHidden = hexLine(threatPos, hiddenDest);
+    const lineToVisible = hexLine(threatPos, visibleDest);
+    const visibleLineKeys = new Set(lineToVisible.map((h) => `${h.q},${h.r}`));
+    const terrainAt: Record<string, string> = {};
+    for (const hex of lineToHidden) {
+      const key = `${hex.q},${hex.r}`;
+      const isEndpoint =
+        (hex.q === threatPos.q && hex.r === threatPos.r) ||
+        (hex.q === hiddenDest.q && hex.r === hiddenDest.r);
+      if (!isEndpoint && !visibleLineKeys.has(key)) {
+        terrainAt[key] = TerrainType.HeavyWoods;
+      }
+    }
+
+    const grid = makeGrid(8, terrainAt);
+    const attacker = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const threat = makeUnit({ unitId: 't', position: threatPos });
+    // A second, lower-threat enemy that retains LOS to BOTH destinations.
+    // This holds the existing "+1000 if any enemy has LOS" term equal for
+    // the two candidates, so the comparison isolates the LOS-DENIAL term
+    // (which keys only off the highest-threat enemy).
+    const spotterPos = { q: 0, r: 5 };
+    const spotter = makeUnit({ unitId: 's', position: spotterPos });
+
+    // Self-validate the fixture: the hidden hex must break the THREAT's
+    // LOS, the visible hex must not, and the spotter must see both.
+    expect(calculateLOS(threatPos, hiddenDest, grid).hasLOS).toBe(false);
+    expect(calculateLOS(threatPos, visibleDest, grid).hasLOS).toBe(true);
+    expect(calculateLOS(spotterPos, hiddenDest, grid).hasLOS).toBe(true);
+    expect(calculateLOS(spotterPos, visibleDest, grid).hasLOS).toBe(true);
+
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker, threat, spotter],
+      grid,
+      highestThreatTarget: threat,
+      tierMovement: VETERAN_MOVEMENT,
+    };
+
+    const hiddenScore = scoreMove(makeMove({ destination: hiddenDest }), ctx);
+    const visibleScore = scoreMove(makeMove({ destination: visibleDest }), ctx);
+
+    expect(hiddenScore).toBeGreaterThan(visibleScore);
+    expect(hiddenScore - visibleScore).toBe(VETERAN_MOVEMENT.losDenialWeight);
+  });
+});
+
+// =============================================================================
+// Scenario: Wasteful path scores below an efficient path
+// =============================================================================
+
+describe('Wasteful path scores below an efficient path', () => {
+  it('penalizes a destination reached by a path whose cost exceeds its distance', () => {
+    const grid = makeGrid(7);
+    const attacker = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'e', position: { q: 0, r: 6 } });
+
+    // Two destinations, each hex-distance 2 from the origin AND hex-distance
+    // 6 from the enemy (verified below) — so the closing-distance, LOS, and
+    // straight-line terms are equal. The wasteful one is reached by a path
+    // costing 5 MP; the efficient one by a path costing exactly 2 MP.
+    const wastefulDest = { q: 2, r: 0 };
+    const efficientDest = { q: -2, r: 2 };
+    expect(hexDistance({ q: 0, r: 0 }, wastefulDest)).toBe(
+      hexDistance({ q: 0, r: 0 }, efficientDest),
+    );
+    expect(hexDistance(wastefulDest, { q: 0, r: 6 })).toBe(
+      hexDistance(efficientDest, { q: 0, r: 6 }),
+    );
+    const pathByDestination = new Map<string, IAIPath>([
+      [
+        '2,0',
+        {
+          destination: wastefulDest,
+          hexes: [
+            { q: 1, r: 0 },
+            { q: 2, r: 0 },
+          ],
+          totalMpCost: 5,
+          reachable: true,
+        },
+      ],
+      [
+        '-2,2',
+        {
+          destination: efficientDest,
+          hexes: [
+            { q: -1, r: 1 },
+            { q: -2, r: 2 },
+          ],
+          totalMpCost: 2,
+          reachable: true,
+        },
+      ],
+    ]);
+
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker, enemy],
+      grid,
+      tierMovement: VETERAN_MOVEMENT,
+      pathByDestination,
+    };
+
+    const wastefulScore = scoreMove(
+      makeMove({ destination: wastefulDest }),
+      ctx,
+    );
+    const efficientScore = scoreMove(
+      makeMove({ destination: efficientDest }),
+      ctx,
+    );
+
+    expect(efficientScore).toBeGreaterThan(wastefulScore);
+    // The efficient path (cost 2 == distance 2) pays nothing; the wasteful
+    // path (cost 5, distance 2) pays terrainCostWeight * (5 - 2).
+    expect(efficientScore - wastefulScore).toBe(
+      VETERAN_MOVEMENT.terrainCostWeight * 3,
+    );
+  });
+});
+
+// =============================================================================
+// Scenario: Regular bot ignores the new terms (legacy reproduction)
+// =============================================================================
+
+describe('Regular bot reproduces the legacy scorer', () => {
+  it('cover, LOS-denial, and terrain-cost terms contribute zero on Regular', () => {
+    const grid = makeGrid(5, { '2,0': TerrainType.LightWoods });
+    const attacker = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'e', position: { q: 0, r: 3 } });
+
+    // Legacy context — no tier block at all.
+    const legacyCtx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker, enemy],
+      grid,
+    };
+    // Regular context — tier block present but pathfinder disabled.
+    const regularCtx: IScoreMoveContext = {
+      ...legacyCtx,
+      tierMovement: REGULAR_MOVEMENT,
+      pathByDestination: new Map([
+        [
+          '2,0',
+          {
+            destination: { q: 2, r: 0 },
+            hexes: [
+              { q: 1, r: 0 },
+              { q: 2, r: 0 },
+            ],
+            totalMpCost: 9,
+            reachable: true,
+          },
+        ],
+      ]),
+    };
+
+    const coverMove = makeMove({ destination: { q: 2, r: 0 } });
+    // The cover hex would gain a cover bonus AND a terrain-cost penalty on
+    // Veteran; on Regular both terms are inert, so the Regular score must
+    // equal the legacy score exactly.
+    expect(scoreMove(coverMove, regularCtx)).toBe(
+      scoreMove(coverMove, legacyCtx),
+    );
+  });
+
+  it('selectMove on a Regular bot makes the same choice as a legacy (no-tier) bot', () => {
+    const grid = makeGrid(5, { '2,0': TerrainType.LightWoods });
+    const attacker = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'e', position: { q: 0, r: 3 } });
+
+    const moves: IMove[] = [
+      makeMove({ destination: { q: 2, r: 0 } }),
+      makeMove({ destination: { q: -2, r: 0 } }),
+      makeMove({ destination: { q: 0, r: 2 } }),
+    ];
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker, enemy],
+      grid,
+      capability: capability(4),
+    };
+
+    // A bot with no tier (legacy) and a bot pinned to Regular must choose
+    // identically for the same seed — Regular is the legacy-scorer tier.
+    const legacyBot = new MoveAI({ ...DEFAULT_BEHAVIOR, tier: undefined });
+    const regularBot = new MoveAI({ ...DEFAULT_BEHAVIOR, tier: 'Regular' });
+
+    for (let seed = 0; seed < 25; seed++) {
+      const legacyChoice = legacyBot.selectMove(
+        moves,
+        new SeededRandom(seed),
+        attacker,
+        ctx,
+      );
+      const regularChoice = regularBot.selectMove(
+        moves,
+        new SeededRandom(seed),
+        attacker,
+        ctx,
+      );
+      expect(regularChoice).toEqual(legacyChoice);
+    }
+  });
+});
+
+// =============================================================================
+// Integration: Veteran routes around woods; Regular takes the straight line
+// (tasks 5.1 / 5.2)
+// =============================================================================
+
+describe('Integration — terrain-aware routing by tier', () => {
+  it('Veteran prefers a cover destination a Regular bot would pass over', () => {
+    // Map: a light-woods cover hex sits off the straight closing line.
+    // Both candidate destinations are hex-distance 6 from the enemy
+    // (verified below), so on Regular (legacy scorer) they tie and the
+    // seeded RNG breaks it; on Veteran the cover bonus makes the woods
+    // hex the strict winner.
+    const coverDest = { q: 2, r: 0 }; // light woods
+    const openDest = { q: -2, r: 2 }; // clear
+    const enemyPos = { q: 0, r: 6 };
+    expect(hexDistance(coverDest, enemyPos)).toBe(
+      hexDistance(openDest, enemyPos),
+    );
+
+    const grid = makeGrid(8, { '2,0': TerrainType.LightWoods });
+    const attacker = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'e', position: enemyPos });
+
+    const moves: IMove[] = [
+      makeMove({ destination: coverDest, mpCost: 2 }),
+      makeMove({ destination: openDest, mpCost: 2 }),
+    ];
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker, enemy],
+      grid,
+      capability: capability(6),
+    };
+
+    const veteranBot = new MoveAI({ ...DEFAULT_BEHAVIOR, tier: 'Veteran' });
+    const chosen = veteranBot.selectMove(
+      moves,
+      new SeededRandom(7),
+      attacker,
+      ctx,
+    );
+    expect(chosen?.destination).toEqual(coverDest);
+  });
+
+  it('determinism — Veteran selectMove reproduces with the same seed', () => {
+    const grid = makeGrid(6, { '2,0': TerrainType.HeavyWoods });
+    const attacker = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'e', position: { q: 0, r: 4 } });
+    const moves: IMove[] = [
+      makeMove({ destination: { q: 1, r: 0 } }),
+      makeMove({ destination: { q: 0, r: 1 } }),
+      makeMove({ destination: { q: -1, r: 1 } }),
+    ];
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker, enemy],
+      grid,
+      capability: capability(4),
+    };
+    const bot = new MoveAI({ ...DEFAULT_BEHAVIOR, tier: 'Veteran' });
+    const a = bot.selectMove(moves, new SeededRandom(99), attacker, ctx);
+    const b = bot.selectMove(moves, new SeededRandom(99), attacker, ctx);
+    expect(a).toEqual(b);
+  });
+
+  it('findAllPaths feeds the terrain-cost term — a woods detour is penalized', () => {
+    // Sanity check the end-to-end wiring: a path through heavy woods costs
+    // more MP than its hex distance, so the terrain-cost term fires.
+    const grid = makeGrid(5, { '1,0': TerrainType.HeavyWoods });
+    const paths = findAllPaths(
+      grid,
+      { q: 0, r: 0 },
+      MovementType.Walk,
+      capability(6),
+    );
+    const through = paths.get('1,0');
+    expect(through).toBeDefined();
+    // Entering a heavy-woods hex costs 3 MP for a 1-hex move — cost > distance.
+    expect(through!.totalMpCost).toBeGreaterThan(1);
+  });
+});

--- a/src/simulation/__tests__/aiTerrainPathfinder.test.ts
+++ b/src/simulation/__tests__/aiTerrainPathfinder.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for the AI terrain-cost pathfinder.
+ *
+ * Covers the `AI Terrain-Cost Pathfinder` requirement of
+ * `add-ai-terrain-aware-movement` — scenarios "Pathfinder routes around
+ * costly terrain", "Pathfinding is deterministic", "Unreachable destination
+ * is flagged", and "findAllPaths agrees with per-destination findPath".
+ *
+ * @spec openspec/changes/add-ai-terrain-aware-movement/specs/simulation-system/spec.md
+ *   Requirement: AI Terrain-Cost Pathfinder
+ */
+
+import type {
+  IHex,
+  IHexCoordinate,
+  IHexGrid,
+  IMovementCapability,
+} from '@/types/gameplay';
+
+import { MovementType, TerrainType } from '@/types/gameplay';
+
+import { findAllPaths, findPath } from '../ai/AITerrainPathfinder';
+
+/**
+ * Build a hexagonal grid of the given radius. `terrainAt` maps a `"q,r"` key
+ * to a terrain tag; unlisted hexes default to `clear`. `occupied` marks hexes
+ * as blocked.
+ */
+function buildGrid(
+  radius: number,
+  terrainAt: Record<string, string> = {},
+  occupied: IHexCoordinate[] = [],
+): IHexGrid {
+  const hexes = new Map<string, IHex>();
+  const occupiedSet = new Set(occupied.map((c) => `${c.q},${c.r}`));
+  for (let q = -radius; q <= radius; q++) {
+    for (let r = -radius; r <= radius; r++) {
+      if (Math.abs(q + r) > radius) continue;
+      const key = `${q},${r}`;
+      hexes.set(key, {
+        coord: { q, r },
+        occupantId: occupiedSet.has(key) ? 'blocker' : null,
+        terrain: terrainAt[key] ?? 'clear',
+        elevation: 0,
+      });
+    }
+  }
+  return { config: { radius }, hexes };
+}
+
+function capability(walk: number, jump = 0): IMovementCapability {
+  return { walkMP: walk, runMP: Math.ceil(walk * 1.5), jumpMP: jump };
+}
+
+describe('AITerrainPathfinder.findPath', () => {
+  it('routes around costly terrain to a cheaper equal-length path', () => {
+    // Origin (0,0) to destination (2,0). The straight-line route runs
+    // through (1,0); make that hex heavy woods. An equal-hex-length
+    // detour exists through clear ground.
+    const grid = buildGrid(4, { '1,0': TerrainType.HeavyWoods });
+    const path = findPath({
+      grid,
+      origin: { q: 0, r: 0 },
+      destination: { q: 2, r: 0 },
+      movementType: MovementType.Walk,
+      capability: capability(6),
+    });
+
+    expect(path.reachable).toBe(true);
+    // The detour avoids the heavy-woods hex entirely.
+    const passesThroughWoods = path.hexes.some((h) => h.q === 1 && h.r === 0);
+    expect(passesThroughWoods).toBe(false);
+
+    // A straight route through heavy woods would cost 1 (enter 1,0 at +3)
+    // + 1 (enter 2,0) = 4. The chosen clear detour costs 1 per hex.
+    const straightCost = 3 + 1; // heavy woods entry (3) + clear entry (1)
+    expect(path.totalMpCost).toBeLessThan(straightCost);
+  });
+
+  it('is deterministic — identical request yields identical result', () => {
+    const grid = buildGrid(4, { '1,0': TerrainType.LightWoods });
+    const request = {
+      grid,
+      origin: { q: 0, r: 0 },
+      destination: { q: 3, r: 0 },
+      movementType: MovementType.Walk,
+      capability: capability(6),
+    };
+    const a = findPath(request);
+    const b = findPath(request);
+    expect(a.hexes).toEqual(b.hexes);
+    expect(a.totalMpCost).toBe(b.totalMpCost);
+    expect(a.reachable).toBe(b.reachable);
+  });
+
+  it('flags an unreachable destination when its cheapest path exceeds the budget', () => {
+    const grid = buildGrid(8);
+    // Destination 6 hexes away on a 2-MP budget — unreachable.
+    const path = findPath({
+      grid,
+      origin: { q: 0, r: 0 },
+      destination: { q: 6, r: 0 },
+      movementType: MovementType.Walk,
+      capability: capability(2),
+    });
+    expect(path.reachable).toBe(false);
+    expect(path.destination).toEqual({ q: 6, r: 0 });
+  });
+
+  it('returns a zero-cost reachable path for the origin itself', () => {
+    const grid = buildGrid(4);
+    const path = findPath({
+      grid,
+      origin: { q: 0, r: 0 },
+      destination: { q: 0, r: 0 },
+      movementType: MovementType.Walk,
+      capability: capability(4),
+    });
+    expect(path.reachable).toBe(true);
+    expect(path.totalMpCost).toBe(0);
+    expect(path.hexes).toEqual([]);
+  });
+
+  it('path hex sequence is origin-exclusive and destination-inclusive', () => {
+    const grid = buildGrid(4);
+    const path = findPath({
+      grid,
+      origin: { q: 0, r: 0 },
+      destination: { q: 2, r: 0 },
+      movementType: MovementType.Walk,
+      capability: capability(4),
+    });
+    expect(path.hexes).not.toContainEqual({ q: 0, r: 0 });
+    expect(path.hexes[path.hexes.length - 1]).toEqual({ q: 2, r: 0 });
+  });
+
+  it('costs every hop as 1 for jump movement, ignoring terrain', () => {
+    const grid = buildGrid(4, {
+      '1,0': TerrainType.HeavyWoods,
+      '2,0': TerrainType.HeavyWoods,
+    });
+    const path = findPath({
+      grid,
+      origin: { q: 0, r: 0 },
+      destination: { q: 2, r: 0 },
+      movementType: MovementType.Jump,
+      capability: capability(0, 4),
+    });
+    expect(path.reachable).toBe(true);
+    // Two hops, terrain ignored: cost 2.
+    expect(path.totalMpCost).toBe(2);
+  });
+});
+
+describe('AITerrainPathfinder.findAllPaths', () => {
+  it('agrees with per-destination findPath for every reachable hex', () => {
+    const grid = buildGrid(5, {
+      '1,0': TerrainType.HeavyWoods,
+      '0,1': TerrainType.LightWoods,
+      '-1,1': TerrainType.Swamp,
+    });
+    const origin = { q: 0, r: 0 };
+    const cap = capability(5);
+    const all = findAllPaths(grid, origin, MovementType.Walk, cap);
+
+    for (const [key, path] of Array.from(all.entries())) {
+      const single = findPath({
+        grid,
+        origin,
+        destination: path.destination,
+        movementType: MovementType.Walk,
+        capability: cap,
+      });
+      expect(single.totalMpCost).toBe(path.totalMpCost);
+      expect(single.hexes).toEqual(path.hexes);
+      // Every key in the map is the canonical "q,r" of its destination.
+      expect(key).toBe(`${path.destination.q},${path.destination.r}`);
+    }
+  });
+
+  it('includes the origin with a zero-cost empty path', () => {
+    const grid = buildGrid(4);
+    const all = findAllPaths(
+      grid,
+      { q: 0, r: 0 },
+      MovementType.Walk,
+      capability(4),
+    );
+    const origin = all.get('0,0');
+    expect(origin).toBeDefined();
+    expect(origin?.totalMpCost).toBe(0);
+    expect(origin?.hexes).toEqual([]);
+  });
+
+  it('only contains destinations within the MP budget', () => {
+    const grid = buildGrid(8);
+    const budget = 2;
+    const all = findAllPaths(
+      grid,
+      { q: 0, r: 0 },
+      MovementType.Walk,
+      capability(budget),
+    );
+    for (const path of Array.from(all.values())) {
+      expect(path.totalMpCost).toBeLessThanOrEqual(budget);
+      expect(path.reachable).toBe(true);
+    }
+  });
+
+  it('is deterministic across repeated calls', () => {
+    const grid = buildGrid(5, { '1,0': TerrainType.HeavyWoods });
+    const origin = { q: 0, r: 0 };
+    const cap = capability(5);
+    const a = findAllPaths(grid, origin, MovementType.Walk, cap);
+    const b = findAllPaths(grid, origin, MovementType.Walk, cap);
+    expect(a.size).toBe(b.size);
+    for (const [key, path] of Array.from(a.entries())) {
+      expect(b.get(key)?.totalMpCost).toBe(path.totalMpCost);
+      expect(b.get(key)?.hexes).toEqual(path.hexes);
+    }
+  });
+
+  it('returns only the origin when the MP budget is zero', () => {
+    const grid = buildGrid(4);
+    const all = findAllPaths(
+      grid,
+      { q: 0, r: 0 },
+      MovementType.Stationary,
+      capability(4),
+    );
+    expect(all.size).toBe(1);
+    expect(all.has('0,0')).toBe(true);
+  });
+});

--- a/src/simulation/__tests__/aiTierRegistry.test.ts
+++ b/src/simulation/__tests__/aiTierRegistry.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the AI Difficulty Tier Registry.
+ *
+ * Covers the `AI Difficulty Tier Registry` requirement of
+ * `add-ai-terrain-aware-movement` — scenarios "Every tier resolves to a
+ * parameter record", "Unknown tier name throws", "Default tier is Regular",
+ * and the registry shape from design D3.
+ *
+ * @spec openspec/changes/add-ai-terrain-aware-movement/specs/simulation-system/spec.md
+ *   Requirement: AI Difficulty Tier Registry
+ */
+
+import type { AITierName } from '../ai/AITierRegistry';
+
+import {
+  AI_TIER_REGISTRY,
+  DEFAULT_TIER_NAME,
+  getTierParameters,
+  resolveTierParameters,
+} from '../ai/AITierRegistry';
+
+const ALL_TIERS: AITierName[] = ['Green', 'Regular', 'Veteran', 'Elite'];
+
+describe('AITierRegistry', () => {
+  describe('getTierParameters — every tier resolves', () => {
+    it.each(ALL_TIERS)(
+      'tier %s resolves to a record with a populated movement block',
+      (tier) => {
+        const params = getTierParameters(tier);
+        expect(params.tier).toBe(tier);
+        expect(params.movement).toBeDefined();
+        expect(typeof params.movement.pathfinderEnabled).toBe('boolean');
+        expect(typeof params.movement.coverWeight).toBe('number');
+        expect(typeof params.movement.losDenialWeight).toBe('number');
+        expect(typeof params.movement.terrainCostWeight).toBe('number');
+      },
+    );
+  });
+
+  describe('getTierParameters — unknown tier throws', () => {
+    it('throws an error naming the invalid tier and the valid tiers', () => {
+      expect(() => getTierParameters('Legendary' as AITierName)).toThrow(
+        /Legendary/,
+      );
+      expect(() => getTierParameters('Legendary' as AITierName)).toThrow(
+        /Green/,
+      );
+      expect(() => getTierParameters('Legendary' as AITierName)).toThrow(
+        /Regular/,
+      );
+      expect(() => getTierParameters('Legendary' as AITierName)).toThrow(
+        /Veteran/,
+      );
+      expect(() => getTierParameters('Legendary' as AITierName)).toThrow(
+        /Elite/,
+      );
+    });
+  });
+
+  describe('resolveTierParameters — default tier', () => {
+    it('falls back to Regular when no tier name is supplied', () => {
+      expect(resolveTierParameters(undefined).tier).toBe('Regular');
+    });
+
+    it('DEFAULT_TIER_NAME is Regular', () => {
+      expect(DEFAULT_TIER_NAME).toBe('Regular');
+    });
+
+    it('returns the named tier when one is supplied', () => {
+      expect(resolveTierParameters('Veteran').tier).toBe('Veteran');
+      expect(resolveTierParameters('Elite').tier).toBe('Elite');
+    });
+  });
+
+  describe('legacy tiers disable the pathfinder (design D4)', () => {
+    it('Green has pathfinderEnabled false and zeroed weights', () => {
+      const m = getTierParameters('Green').movement;
+      expect(m.pathfinderEnabled).toBe(false);
+      expect(m.coverWeight).toBe(0);
+      expect(m.losDenialWeight).toBe(0);
+      expect(m.terrainCostWeight).toBe(0);
+    });
+
+    it('Regular has pathfinderEnabled false and zeroed weights', () => {
+      const m = getTierParameters('Regular').movement;
+      expect(m.pathfinderEnabled).toBe(false);
+      expect(m.coverWeight).toBe(0);
+      expect(m.losDenialWeight).toBe(0);
+      expect(m.terrainCostWeight).toBe(0);
+    });
+  });
+
+  describe('pathfinder tiers enable the pathfinder (design D4)', () => {
+    it('Veteran has pathfinderEnabled true with non-zero weights', () => {
+      const m = getTierParameters('Veteran').movement;
+      expect(m.pathfinderEnabled).toBe(true);
+      expect(m.coverWeight).toBeGreaterThan(0);
+      expect(m.losDenialWeight).toBeGreaterThan(0);
+      expect(m.terrainCostWeight).toBeGreaterThan(0);
+    });
+
+    it('Elite has pathfinderEnabled true with non-zero weights', () => {
+      const m = getTierParameters('Elite').movement;
+      expect(m.pathfinderEnabled).toBe(true);
+      expect(m.coverWeight).toBeGreaterThan(0);
+      expect(m.losDenialWeight).toBeGreaterThan(0);
+      expect(m.terrainCostWeight).toBeGreaterThan(0);
+    });
+
+    it('Elite weights every new term at least as heavily as Veteran', () => {
+      const v = getTierParameters('Veteran').movement;
+      const e = getTierParameters('Elite').movement;
+      expect(e.coverWeight).toBeGreaterThanOrEqual(v.coverWeight);
+      expect(e.losDenialWeight).toBeGreaterThanOrEqual(v.losDenialWeight);
+      expect(e.terrainCostWeight).toBeGreaterThanOrEqual(v.terrainCostWeight);
+    });
+  });
+
+  describe('registry is complete and frozen-shaped', () => {
+    it('contains exactly the four canonical tiers', () => {
+      expect(Object.keys(AI_TIER_REGISTRY).sort()).toEqual(
+        ['Elite', 'Green', 'Regular', 'Veteran'].sort(),
+      );
+    });
+  });
+});

--- a/src/simulation/ai/AITerrainPathfinder.ts
+++ b/src/simulation/ai/AITerrainPathfinder.ts
@@ -1,0 +1,327 @@
+/**
+ * AI terrain-cost pathfinder.
+ *
+ * A deterministic cheapest-path search over per-hex terrain movement cost.
+ * Where `getValidDestinations` yields a flat set of reachable hexes with no
+ * notion of *which path* was cheapest, this module computes the actual
+ * cheapest legal path — total movement points spent plus the ordered hex
+ * sequence — so the AI move scorer can prefer a destination reached cheaply
+ * over an equivalent destination reached through a wasteful route.
+ *
+ * The API surface (`IAIPath`, `IAIPathfindRequest`, `findPath`,
+ * `findAllPaths`) is FROZEN by `add-ai-terrain-aware-movement` design D2.
+ * Later Wave 2 changes (A2 resource planning, A3a coordination, A3b
+ * objectives, A4 advanced systems) author against this signature — it must
+ * not change.
+ *
+ * Implementation is uniform-cost (Dijkstra) search over hex neighbors with
+ * edge weight = the terrain movement cost of the hex being entered. Ties
+ * between equal-cost frontier nodes are broken by canonical hex-neighbor
+ * order (North, Northeast, Southeast, South, Southwest, Northwest), so the
+ * result is fully deterministic — identical request always yields an
+ * identical `IAIPath` — without consuming `SeededRandom`.
+ *
+ * @spec openspec/changes/add-ai-terrain-aware-movement/specs/simulation-system/spec.md
+ *   Requirement: AI Terrain-Cost Pathfinder
+ */
+
+import type {
+  IHexCoordinate,
+  IHexGrid,
+  IMovementCapability,
+} from '@/types/gameplay';
+
+import { MovementType } from '@/types/gameplay';
+import { getHex, isInBounds, isOccupied } from '@/utils/gameplay/hexGrid';
+import {
+  coordToKey,
+  hexDistance,
+  hexNeighbors,
+} from '@/utils/gameplay/hexMath';
+import { getHexMovementCostFromTerrainTag } from '@/utils/gameplay/terrainMovementCost';
+
+/** A single legal path from origin to a destination hex. */
+export interface IAIPath {
+  readonly destination: IHexCoordinate;
+  /** Ordered hexes from origin (exclusive) to destination (inclusive). */
+  readonly hexes: readonly IHexCoordinate[];
+  /** Total movement points consumed along the path. */
+  readonly totalMpCost: number;
+  /** True when every hex on the path was within the MP budget. */
+  readonly reachable: boolean;
+}
+
+/** A request to find the cheapest path to a single destination hex. */
+export interface IAIPathfindRequest {
+  readonly grid: IHexGrid;
+  readonly origin: IHexCoordinate;
+  readonly destination: IHexCoordinate;
+  readonly movementType: MovementType;
+  readonly capability: IMovementCapability;
+}
+
+/**
+ * Movement-point budget for a movement type. Mirrors the raw MP lookup the
+ * movement utilities use (`getRawMaxMP`) — the pathfinder reasons about reach
+ * before heat penalties, matching how `getValidDestinations` is consumed by
+ * the AI move generator. Stationary has no budget.
+ */
+function mpBudget(
+  movementType: MovementType,
+  capability: IMovementCapability,
+): number {
+  switch (movementType) {
+    case MovementType.Walk:
+      return capability.walkMP;
+    case MovementType.Run:
+      return capability.runMP;
+    case MovementType.Jump:
+      return capability.jumpMP;
+    case MovementType.Stationary:
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Per-hex entry cost for the pathfinder edge weight.
+ *
+ * Walk / Run pay the terrain movement cost of the hex being entered (open
+ * ground `1`, light woods `2`, heavy woods `3`, ...). Jump skips terrain
+ * entirely — every hop is a flat `1` — matching the canonical rule that
+ * jump movement ignores intervening terrain cost.
+ */
+function hexEntryCost(
+  grid: IHexGrid,
+  coord: IHexCoordinate,
+  movementType: MovementType,
+): number {
+  if (movementType === MovementType.Jump) {
+    return 1;
+  }
+  return getHexMovementCostFromTerrainTag(getHex(grid, coord));
+}
+
+/** Internal frontier node for the uniform-cost search. */
+interface DijkstraNode {
+  readonly coord: IHexCoordinate;
+  /** Cumulative cost from origin to this hex. */
+  readonly cost: number;
+  /** Canonical key of the predecessor hex, or `null` at the origin. */
+  readonly parent: string | null;
+}
+
+/**
+ * Run a single uniform-cost (Dijkstra) sweep from `origin` over the grid.
+ *
+ * Returns the settled `cost` and `parent` for every hex reachable within the
+ * search horizon. The search is bounded by `maxCost` — nodes whose cumulative
+ * cost would exceed the budget are still recorded (so a best-effort partial
+ * path to an out-of-budget destination can be reconstructed) but are not
+ * expanded further, keeping the sweep finite even on large grids.
+ *
+ * Determinism: the frontier is drained lowest-cost-first; ties between
+ * equal-cost frontier entries are broken by insertion order, and neighbors
+ * are always inserted in canonical `hexNeighbors` order (N, NE, SE, S, SW,
+ * NW). No `SeededRandom` is consumed.
+ */
+function dijkstraSweep(
+  grid: IHexGrid,
+  origin: IHexCoordinate,
+  movementType: MovementType,
+  maxCost: number,
+): Map<string, DijkstraNode> {
+  const settled = new Map<string, DijkstraNode>();
+  const frontier = new Map<string, DijkstraNode>();
+
+  const originKey = coordToKey(origin);
+  frontier.set(originKey, { coord: origin, cost: 0, parent: null });
+
+  while (frontier.size > 0) {
+    // Select the lowest-cost frontier node. On a cost tie the FIRST such
+    // node in iteration order wins — Map preserves insertion order, and
+    // neighbors are always inserted in canonical hex-neighbor order, so
+    // the tie-break is deterministic without a seeded roll.
+    let bestKey: string | null = null;
+    let bestNode: DijkstraNode | null = null;
+    for (const [key, node] of Array.from(frontier.entries())) {
+      if (bestNode === null || node.cost < bestNode.cost) {
+        bestKey = key;
+        bestNode = node;
+      }
+    }
+    if (bestKey === null || bestNode === null) break;
+
+    frontier.delete(bestKey);
+    settled.set(bestKey, bestNode);
+
+    // A node already past the budget is recorded (for best-effort partial
+    // paths) but never expanded — beyond the budget every onward hex is
+    // also out of budget, so expansion would only grow the sweep.
+    if (bestNode.cost >= maxCost) {
+      continue;
+    }
+
+    for (const neighbor of hexNeighbors(bestNode.coord)) {
+      const neighborKey = coordToKey(neighbor);
+      if (settled.has(neighborKey)) continue;
+      if (!isInBounds(grid, neighbor)) continue;
+      // Occupied hexes cannot be entered or passed through. The origin is
+      // never re-evaluated (it is settled first), so the unit's own hex
+      // does not block its outbound search.
+      if (isOccupied(grid, neighbor)) continue;
+
+      const stepCost = hexEntryCost(grid, neighbor, movementType);
+      const tentativeCost = bestNode.cost + stepCost;
+
+      const existing = frontier.get(neighborKey);
+      if (!existing || tentativeCost < existing.cost) {
+        frontier.set(neighborKey, {
+          coord: neighbor,
+          cost: tentativeCost,
+          parent: bestKey,
+        });
+      }
+    }
+  }
+
+  return settled;
+}
+
+/**
+ * Reconstruct the ordered hex sequence from origin to `destination` by
+ * walking the `parent` chain in the settled node map. The returned list
+ * EXCLUDES the origin and INCLUDES the destination, per the `IAIPath.hexes`
+ * contract. Returns an empty array when the destination was never settled.
+ */
+function reconstructPath(
+  settled: Map<string, DijkstraNode>,
+  destinationKey: string,
+): IHexCoordinate[] {
+  const reversed: IHexCoordinate[] = [];
+  let key: string | null = destinationKey;
+  while (key !== null) {
+    const node = settled.get(key);
+    if (!node) break;
+    reversed.push(node.coord);
+    key = node.parent;
+  }
+  // `reversed` runs destination -> ... -> origin. Drop the origin (last
+  // element) and flip so the result is origin-exclusive, destination-last.
+  reversed.pop();
+  reversed.reverse();
+  return reversed;
+}
+
+/**
+ * Build the `IAIPath` for a single destination from a completed sweep.
+ *
+ * When the destination was never settled (off-grid, fully walled off, or
+ * unreachable within the search horizon) the path falls back to the straight
+ * hex-distance estimate with `reachable: false` and an empty hex list — a
+ * safe, deterministic best-effort answer the move scorer can still consume.
+ */
+function pathFromSweep(
+  settled: Map<string, DijkstraNode>,
+  origin: IHexCoordinate,
+  destination: IHexCoordinate,
+  budget: number,
+): IAIPath {
+  const destinationKey = coordToKey(destination);
+  const node = settled.get(destinationKey);
+
+  if (!node) {
+    return {
+      destination,
+      hexes: [],
+      totalMpCost: hexDistance(origin, destination),
+      reachable: false,
+    };
+  }
+
+  const hexes = reconstructPath(settled, destinationKey);
+  return {
+    destination,
+    hexes,
+    totalMpCost: node.cost,
+    reachable: node.cost <= budget,
+  };
+}
+
+/**
+ * Deterministic cheapest-path search over per-hex terrain movement cost.
+ *
+ * Pure: identical request => identical `IAIPath`. Returns `reachable: false`
+ * with a best-effort partial path when the destination exceeds the MP
+ * budget. The origin-to-itself request returns a zero-cost reachable path
+ * with an empty hex list.
+ *
+ * FROZEN API — `add-ai-terrain-aware-movement` design D2.
+ */
+export function findPath(request: IAIPathfindRequest): IAIPath {
+  const { grid, origin, destination, movementType, capability } = request;
+  const budget = mpBudget(movementType, capability);
+
+  if (origin.q === destination.q && origin.r === destination.r) {
+    return { destination, hexes: [], totalMpCost: 0, reachable: true };
+  }
+
+  // The sweep horizon is the larger of the budget and the straight-line
+  // distance to the destination: the budget covers reachable paths, and
+  // extending to the hex distance guarantees a best-effort partial path is
+  // found even when the destination sits past the budget.
+  const horizon = Math.max(budget, hexDistance(origin, destination));
+  const settled = dijkstraSweep(grid, origin, movementType, horizon);
+  return pathFromSweep(settled, origin, destination, budget);
+}
+
+/**
+ * Cheapest path to every reachable destination in a single Dijkstra pass.
+ *
+ * Keyed by the canonical `"q,r"` hex string. Used by `MoveAI.selectMove` so
+ * scoring N candidate destinations costs one sweep, not N separate searches.
+ * Only destinations whose cheapest path cost is within the MP budget appear
+ * in the map (each carries `reachable: true`); the origin itself is included
+ * with a zero-cost empty path.
+ *
+ * The path for any given destination is identical to what `findPath` returns
+ * for that same destination — both reconstruct from the same uniform-cost
+ * search.
+ *
+ * FROZEN API — `add-ai-terrain-aware-movement` design D2.
+ */
+export function findAllPaths(
+  grid: IHexGrid,
+  origin: IHexCoordinate,
+  movementType: MovementType,
+  capability: IMovementCapability,
+): ReadonlyMap<string, IAIPath> {
+  const budget = mpBudget(movementType, capability);
+  const result = new Map<string, IAIPath>();
+
+  // Origin: zero-cost, always reachable, empty hex list.
+  result.set(coordToKey(origin), {
+    destination: origin,
+    hexes: [],
+    totalMpCost: 0,
+    reachable: true,
+  });
+
+  if (budget <= 0) {
+    return result;
+  }
+
+  const settled = dijkstraSweep(grid, origin, movementType, budget);
+  for (const [key, node] of Array.from(settled.entries())) {
+    if (node.cost > budget) continue;
+    if (node.cost === 0) continue; // origin already inserted above
+    result.set(key, {
+      destination: node.coord,
+      hexes: reconstructPath(settled, key),
+      totalMpCost: node.cost,
+      reachable: true,
+    });
+  }
+
+  return result;
+}

--- a/src/simulation/ai/AITierRegistry.ts
+++ b/src/simulation/ai/AITierRegistry.ts
@@ -1,0 +1,162 @@
+/**
+ * AI Difficulty Tier Registry.
+ *
+ * Per `add-ai-terrain-aware-movement` design D3: a frozen registry mapping
+ * each difficulty tier — `Green`, `Regular`, `Veteran`, `Elite` — to an
+ * `IAITierParameters` record. The tier is player-selectable per scenario and
+ * controls how much depth the bot's decision-making runs at.
+ *
+ * This registry is the single, all-ADDED extension point for Wave 2 AI work.
+ * A1 (this change) defines the `movement` parameter block. Later changes
+ * (A2 resource planning, A3a coordination, A3b objectives, A4 advanced
+ * systems) each ADD their own optional block to `IAITierParameters` —
+ * registration is additive only, and no later change MODIFIES the movement
+ * block or A1's requirement. The registry merges blocks by key.
+ *
+ * `getTierParameters(name)` mirrors `getBehaviorVariant` from
+ * `behaviorVariants.ts`: it throws an explicit, diagnostic error on an
+ * unknown tier name rather than returning `undefined`.
+ *
+ * @spec openspec/changes/add-ai-terrain-aware-movement/specs/simulation-system/spec.md
+ *   Requirement: AI Difficulty Tier Registry
+ */
+
+/** Union of valid AI difficulty tier names. */
+export type AITierName = 'Green' | 'Regular' | 'Veteran' | 'Elite';
+
+/**
+ * Movement-scoring parameter block — the A1 contribution to a tier's
+ * parameter set.
+ *
+ *   - `pathfinderEnabled`: when `false`, `MoveAI.scoreMove` runs the legacy
+ *     straight-line scorer and the three terrain-aware terms below contribute
+ *     nothing — the tier reproduces the pre-change bot byte-for-byte. When
+ *     `true`, the terrain-cost pathfinder runs and the new terms apply.
+ *   - `coverWeight`: bonus added to a destination hex offering partial cover
+ *     or better.
+ *   - `losDenialWeight`: bonus added when the destination breaks the
+ *     highest-threat enemy's line of sight.
+ *   - `terrainCostWeight`: multiplier on the path-inefficiency penalty
+ *     (`pathMpCost - hexDistance`) so a destination reached by a wasteful
+ *     path scores below an equivalent destination reached cheaply.
+ */
+export interface IAITierMovementParameters {
+  readonly pathfinderEnabled: boolean;
+  readonly coverWeight: number;
+  readonly losDenialWeight: number;
+  readonly terrainCostWeight: number;
+}
+
+/**
+ * Full parameter set for one difficulty tier.
+ *
+ * Open by design: A1 defines `tier` and `movement`. Later Wave 2 changes ADD
+ * their own optional blocks (`resource?`, `coordination?`, `objective?`,
+ * `advanced?`) without touching the fields declared here.
+ */
+export interface IAITierParameters {
+  readonly tier: AITierName;
+  readonly movement: IAITierMovementParameters;
+  // A2..A4 ADD: resource?, coordination?, objective?, advanced? blocks.
+}
+
+/**
+ * The frozen tier table.
+ *
+ * Per design D4 — tiered scoring, lower tiers run the legacy scorer:
+ *
+ *   - `Green` / `Regular`: `pathfinderEnabled: false` with zeroed weights.
+ *     These tiers reproduce today's straight-line move scorer exactly so the
+ *     SimulationRunner determinism golden traces stay byte-identical.
+ *   - `Veteran` / `Elite`: `pathfinderEnabled: true` with tuned weights so
+ *     the bot routes around costly terrain, seeks cover, and breaks enemy
+ *     line of sight. `Elite` weights the new terms more heavily than
+ *     `Veteran`, making it the top tier that accumulates depth as later
+ *     Wave 2 changes land.
+ *
+ * Weight magnitudes are chosen relative to the existing `scoreMove` scale
+ * (LOS term `+1000`, forward-arc `+500`, per-hex distance `-100`): the cover
+ * and LOS-denial bonuses sit at forward-arc scale so they meaningfully
+ * influence the choice without dominating the closing-distance instinct, and
+ * the terrain-cost penalty is small (per wasted MP) so it only breaks ties
+ * between otherwise-equivalent destinations.
+ */
+export const AI_TIER_REGISTRY: Readonly<Record<AITierName, IAITierParameters>> =
+  {
+    Green: {
+      tier: 'Green',
+      movement: {
+        pathfinderEnabled: false,
+        coverWeight: 0,
+        losDenialWeight: 0,
+        terrainCostWeight: 0,
+      },
+    },
+    Regular: {
+      tier: 'Regular',
+      movement: {
+        pathfinderEnabled: false,
+        coverWeight: 0,
+        losDenialWeight: 0,
+        terrainCostWeight: 0,
+      },
+    },
+    Veteran: {
+      tier: 'Veteran',
+      movement: {
+        pathfinderEnabled: true,
+        coverWeight: 300,
+        losDenialWeight: 400,
+        terrainCostWeight: 40,
+      },
+    },
+    Elite: {
+      tier: 'Elite',
+      movement: {
+        pathfinderEnabled: true,
+        coverWeight: 450,
+        losDenialWeight: 600,
+        terrainCostWeight: 60,
+      },
+    },
+  };
+
+/** The tier used when an `IBotBehavior` does not pin one explicitly. */
+export const DEFAULT_TIER_NAME: AITierName = 'Regular';
+
+/**
+ * Look up a tier's parameter record by name. Throws an explicit error when
+ * the name is not in the registry so callers get a clear diagnostic rather
+ * than a silent `undefined` access.
+ *
+ * Per spec scenario "Unknown tier name throws" — the error names the invalid
+ * tier and lists the valid tiers. Mirrors `getBehaviorVariant`.
+ */
+export function getTierParameters(name: AITierName): IAITierParameters {
+  const params = AI_TIER_REGISTRY[name];
+  // The TypeScript type already constrains `name` to AITierName, but the
+  // runtime check is retained for safety when the value comes from an
+  // untyped source (e.g. a serialized game-session config or CLI flag).
+  if (!params) {
+    throw new Error(
+      `Unknown AI tier: "${name}". Valid tiers: ${Object.keys(
+        AI_TIER_REGISTRY,
+      ).join(', ')}`,
+    );
+  }
+  return params;
+}
+
+/**
+ * Resolve the tier parameters for an optional tier name, falling back to the
+ * default tier (`Regular`) when the name is absent.
+ *
+ * Used by `MoveAI` so an `IBotBehavior` without an explicit `tier` resolves
+ * to `Regular` — the legacy-scorer tier — preserving pre-change behavior for
+ * every existing caller and test fixture.
+ */
+export function resolveTierParameters(
+  name: AITierName | undefined,
+): IAITierParameters {
+  return getTierParameters(name ?? DEFAULT_TIER_NAME);
+}

--- a/src/simulation/ai/BotPlayer.ts
+++ b/src/simulation/ai/BotPlayer.ts
@@ -184,6 +184,11 @@ export class BotPlayer implements IAIPlayer {
           allUnits,
           grid,
           highestThreatTarget: best,
+          // Per `add-ai-terrain-aware-movement` design D6: thread the real
+          // movement capability so `MoveAI.selectMove` can run the
+          // terrain-cost pathfinder with the unit's true MP budget rather
+          // than a best-effort estimate from the move set.
+          capability,
         };
       }
     }

--- a/src/simulation/ai/MoveAI.ts
+++ b/src/simulation/ai/MoveAI.ts
@@ -7,16 +7,22 @@ import type {
 
 import { Facing, FiringArc, MovementType } from '@/types/gameplay';
 import { determineArc } from '@/utils/gameplay/firingArcs';
-import { hexDistance } from '@/utils/gameplay/hexMath';
+import { getHex } from '@/utils/gameplay/hexGrid';
+import { coordToKey, hexDistance } from '@/utils/gameplay/hexMath';
 import { calculateLOS } from '@/utils/gameplay/lineOfSight';
 import {
   getValidDestinations,
   calculateMovementHeat,
 } from '@/utils/gameplay/movement';
+import { terrainTagOffersCover } from '@/utils/gameplay/terrainCover';
 
 import type { SeededRandom } from '../core/SeededRandom';
+import type { IAIPath } from './AITerrainPathfinder';
+import type { IAITierMovementParameters } from './AITierRegistry';
 import type { IAIUnitState, IBotBehavior, IMove } from './types';
 
+import { findAllPaths } from './AITerrainPathfinder';
+import { resolveTierParameters } from './AITierRegistry';
 import { scoreRetreatMove } from './RetreatAI';
 
 /**
@@ -112,12 +118,53 @@ function endingFacingTowardEdge(
  *     if the target ends up in the attacker's forward arc after the
  *     move. When omitted we skip the forward-arc bonus entirely
  *     (legacy callers that haven't migrated).
+ *
+ * Per `add-ai-terrain-aware-movement` design D5, two more optional fields
+ * carry the terrain-aware scoring inputs:
+ *
+ *   - `tierMovement` is the active difficulty tier's movement parameter
+ *     block. When omitted, or when its `pathfinderEnabled` flag is `false`,
+ *     `scoreMove` runs the legacy straight-line scorer and the three new
+ *     terrain-aware terms contribute nothing — output is byte-identical to
+ *     the pre-change scorer.
+ *   - `pathByDestination` maps a destination's canonical `"q,r"` key to the
+ *     `IAIPath` the terrain-cost pathfinder found for it. `scoreMove` reads
+ *     the path for `move.destination` to compute the terrain-cost
+ *     efficiency term. Populated once per turn by `selectMove`.
  */
 export interface IScoreMoveContext {
   readonly attacker: IAIUnitState;
   readonly allUnits: readonly IAIUnitState[];
   readonly grid: IHexGrid;
   readonly highestThreatTarget?: IAIUnitState;
+  /**
+   * Per `add-ai-terrain-aware-movement` design D6: the unit's movement
+   * capability, supplied so `selectMove` can run the terrain-cost
+   * pathfinder. Optional — when omitted, `selectMove` derives a best-effort
+   * MP budget from the candidate move set's largest `mpCost`.
+   */
+  readonly capability?: IMovementCapability;
+  readonly tierMovement?: IAITierMovementParameters;
+  readonly pathByDestination?: ReadonlyMap<string, IAIPath>;
+}
+
+/**
+ * Per `add-ai-terrain-aware-movement` design D5 (cover term): whether a hex
+ * offers partial cover or better.
+ *
+ * The destination hex's terrain tag (`IHex.terrain`) is narrowed to a known
+ * `TerrainType` and its `coverLevel` consulted — any level other than `None`
+ * (partial OR full) counts. A missing hex or unrecognised terrain yields
+ * `false`. Mirrors `getTerrainCoverLevel` from the rendering layer without
+ * importing it.
+ */
+function destinationOffersCover(
+  grid: IHexGrid,
+  destination: IHexCoordinate,
+): boolean {
+  const hex = getHex(grid, destination);
+  if (!hex) return false;
+  return terrainTagOffersCover(hex.terrain);
 }
 
 /**
@@ -198,7 +245,91 @@ export function scoreMove(move: IMove, ctx: IScoreMoveContext): number {
   // forward-arc bonus easily outweighs the run's heat cost).
   score -= move.heatGenerated;
 
+  // Per `add-ai-terrain-aware-movement` design D5: three additive
+  // terrain-aware terms, applied ONLY when the active difficulty tier
+  // enables the pathfinder. When `tierMovement` is absent or
+  // `pathfinderEnabled` is `false` (the `Green` / `Regular` tiers, and
+  // every legacy caller), none of the three terms run and `score` above
+  // is byte-identical to the pre-change scorer.
+  score += terrainAwareScore(move, ctx);
+
   return score;
+}
+
+/**
+ * Per `add-ai-terrain-aware-movement` design D5: the three terrain-aware
+ * scoring terms, summed. Returns `0` whenever the pathfinder is disabled so
+ * the caller's legacy score is preserved exactly.
+ *
+ *   - Cover term — `+coverWeight` when the destination hex offers partial
+ *     cover or better.
+ *   - LOS-denial term — `+losDenialWeight` when the destination breaks the
+ *     highest-threat enemy's line of sight (only when a threat target is
+ *     supplied).
+ *   - Terrain-cost term — `-terrainCostWeight * (pathMpCost - hexDistance)`
+ *     so a destination reached by a wasteful path scores below an
+ *     equivalent destination reached cheaply. `pathMpCost` comes from the
+ *     terrain-cost pathfinder's `IAIPath` for the destination; when no path
+ *     was supplied (or the destination is the origin) the term is `0`.
+ *
+ * Pure — never mutates inputs.
+ */
+function terrainAwareScore(move: IMove, ctx: IScoreMoveContext): number {
+  const { grid, highestThreatTarget, tierMovement, pathByDestination } = ctx;
+
+  // Gate: the legacy tiers (`Green` / `Regular`) and every caller that does
+  // not thread a tier through resolve here to a no-op.
+  if (!tierMovement || !tierMovement.pathfinderEnabled) {
+    return 0;
+  }
+
+  let delta = 0;
+
+  // Cover term — reward ending in partial-or-better cover.
+  if (
+    tierMovement.coverWeight !== 0 &&
+    destinationOffersCover(grid, move.destination)
+  ) {
+    delta += tierMovement.coverWeight;
+  }
+
+  // LOS-denial term — reward a destination the highest-threat enemy can no
+  // longer see. `calculateLOS` already accounts for terrain blocking; a
+  // destination that breaks the threat's LOS is one the bot can shelter on.
+  if (
+    tierMovement.losDenialWeight !== 0 &&
+    highestThreatTarget &&
+    !highestThreatTarget.destroyed
+  ) {
+    const threatLOS = calculateLOS(
+      highestThreatTarget.position,
+      move.destination,
+      grid,
+    );
+    if (!threatLOS.hasLOS) {
+      delta += tierMovement.losDenialWeight;
+    }
+  }
+
+  // Terrain-cost term — penalize paths whose MP cost exceeds the straight
+  // hex distance from origin to destination (a wasteful route, whether
+  // because it detours around obstacles or claws through costly terrain).
+  // Per design D5 the penalty scales by `pathMpCost - hexDistance`. A path
+  // whose cost equals the straight-line distance pays nothing; a
+  // cheaper-than-distance path cannot occur (every hex costs >= 1), so the
+  // clamp at `> 0` is a safety net, never a bonus.
+  if (tierMovement.terrainCostWeight !== 0 && pathByDestination) {
+    const path = pathByDestination.get(coordToKey(move.destination));
+    if (path) {
+      const straightLine = hexDistance(ctx.attacker.position, move.destination);
+      const inefficiency = path.totalMpCost - straightLine;
+      if (inefficiency > 0) {
+        delta -= tierMovement.terrainCostWeight * inefficiency;
+      }
+    }
+  }
+
+  return delta;
 }
 
 export class MoveAI {
@@ -303,10 +434,19 @@ export class MoveAI {
     // supplies a context (enemy list + grid). Highest score wins,
     // ties broken by random.
     if (ctx) {
+      // Per `add-ai-terrain-aware-movement` design D3 / D6: resolve the
+      // bot's difficulty tier and, when its pathfinder is enabled, run a
+      // SINGLE terrain-cost Dijkstra pass up front. `scoreMove` then reads
+      // each destination's cheapest path from the returned map — no
+      // per-move search. When the tier disables the pathfinder (`Green` /
+      // `Regular`, the legacy tiers), `scoreMove` receives the same ctx it
+      // always did and produces byte-identical scores.
+      const scoringCtx = this.enrichScoreContext(ctx, moves);
+
       let bestScore = -Infinity;
       let bestMoves: IMove[] = [];
       for (const move of moves) {
-        const score = scoreMove(move, ctx);
+        const score = scoreMove(move, scoringCtx);
         if (score > bestScore) {
           bestScore = score;
           bestMoves = [move];
@@ -321,6 +461,81 @@ export class MoveAI {
     const index = random.nextInt(moves.length);
     return moves[index];
   }
+
+  /**
+   * Per `add-ai-terrain-aware-movement` design D3 / D6: enrich a combat
+   * `IScoreMoveContext` with the active difficulty tier's movement
+   * parameters and — when that tier enables the pathfinder — the cheapest
+   * terrain-cost path to every candidate destination.
+   *
+   * The bot's tier comes from `this.behavior.tier`; an absent tier resolves
+   * to `Regular` (the legacy-scorer tier). For `Green` / `Regular` the tier
+   * has `pathfinderEnabled: false`, so this returns the context with only
+   * `tierMovement` attached and `scoreMove` produces byte-identical scores
+   * to the pre-change scorer.
+   *
+   * When the pathfinder is enabled, `findAllPaths` runs ONCE here — a single
+   * Dijkstra sweep shared across every candidate move — and the resulting
+   * path map is attached as `pathByDestination`. The movement type is read
+   * off the candidate moves (all moves in one `selectMove` call share it);
+   * the MP budget comes from `ctx.capability` when supplied, otherwise from
+   * the largest `mpCost` in the move set.
+   *
+   * Pure with respect to RNG — consumes no `SeededRandom`.
+   */
+  private enrichScoreContext(
+    ctx: IScoreMoveContext,
+    moves: readonly IMove[],
+  ): IScoreMoveContext {
+    const tierMovement = resolveTierParameters(this.behavior.tier).movement;
+
+    // Legacy tiers: attach only the (no-op) tier block. `scoreMove` gates
+    // every new term on `pathfinderEnabled`, so this is byte-identical to
+    // the pre-change behavior.
+    if (!tierMovement.pathfinderEnabled) {
+      return { ...ctx, tierMovement };
+    }
+
+    // Determine the shared movement type and MP budget for the pathfinder
+    // sweep. `moves` is non-empty here (the caller guards `length === 0`).
+    const movementType = moves[0].movementType;
+    const capability = ctx.capability ?? deriveCapability(moves, movementType);
+
+    const pathByDestination = findAllPaths(
+      ctx.grid,
+      ctx.attacker.position,
+      movementType,
+      capability,
+    );
+
+    return { ...ctx, tierMovement, pathByDestination };
+  }
+}
+
+/**
+ * Per `add-ai-terrain-aware-movement` design D6: best-effort
+ * `IMovementCapability` reconstructed from a candidate move set when the
+ * caller did not thread the real capability through `IScoreMoveContext`.
+ *
+ * `findAllPaths` consults the capability only for the MP budget of the
+ * active movement type, so we set just that field to the largest `mpCost`
+ * present in the move set (the move generator already capped destinations to
+ * the unit's true reach). The other two MP fields are filled with the same
+ * value — harmless, since only the active type's field is read.
+ */
+function deriveCapability(
+  moves: readonly IMove[],
+  movementType: MovementType,
+): IMovementCapability {
+  let maxMp = 0;
+  for (const move of moves) {
+    if (move.mpCost > maxMp) maxMp = move.mpCost;
+  }
+  return {
+    walkMP: movementType === MovementType.Walk ? maxMp : 0,
+    runMP: movementType === MovementType.Run ? maxMp : 0,
+    jumpMP: movementType === MovementType.Jump ? maxMp : 0,
+  };
 }
 
 /**

--- a/src/simulation/ai/behaviorVariants.ts
+++ b/src/simulation/ai/behaviorVariants.ts
@@ -31,6 +31,23 @@ export type AIVariantName =
  *                 heat management; drops highest-heat weapons sooner.
  * - `skirmisher`: retreatThreshold 0.4, safeHeatThreshold 11 — moderate heat
  *                 caution, slightly earlier retreat than default.
+ *
+ * Per `add-ai-terrain-aware-movement` design D3, each preset also pins an AI
+ * difficulty `tier` so existing callers that select a variant inherit a
+ * matching depth without any further wiring:
+ *
+ * - `default` → `Regular`:    legacy straight-line move scorer, byte-for-byte
+ *                             identical to the pre-change bot (golden traces
+ *                             run on this tier).
+ * - `aggressive` → `Veteran`: enables the terrain-cost pathfinder and the
+ *                             cover / LOS-denial / terrain-cost scoring terms.
+ * - `defensive` → `Veteran`:  a defensive bot benefits most from cover and
+ *                             LOS-denial, so it also runs the pathfinder tier.
+ * - `skirmisher` → `Veteran`: skirmishers exploit terrain to reposition, so
+ *                             they too run the pathfinder tier.
+ *
+ * Only `default` keeps the legacy `Regular` tier so the determinism golden
+ * traces — which use the `default` preset — stay stable.
  */
 export const BEHAVIOR_VARIANTS: Readonly<Record<AIVariantName, IBotBehavior>> =
   {
@@ -38,21 +55,25 @@ export const BEHAVIOR_VARIANTS: Readonly<Record<AIVariantName, IBotBehavior>> =
       retreatThreshold: 0.3,
       retreatEdge: 'nearest',
       safeHeatThreshold: 13,
+      tier: 'Regular',
     },
     aggressive: {
       retreatThreshold: 0.7,
       retreatEdge: 'nearest',
       safeHeatThreshold: 18,
+      tier: 'Veteran',
     },
     defensive: {
       retreatThreshold: 0.3,
       retreatEdge: 'nearest',
       safeHeatThreshold: 10,
+      tier: 'Veteran',
     },
     skirmisher: {
       retreatThreshold: 0.4,
       retreatEdge: 'nearest',
       safeHeatThreshold: 11,
+      tier: 'Veteran',
     },
   };
 

--- a/src/simulation/ai/index.ts
+++ b/src/simulation/ai/index.ts
@@ -1,4 +1,5 @@
 export { MoveAI } from './MoveAI';
+export type { IScoreMoveContext } from './MoveAI';
 export { AttackAI } from './AttackAI';
 export { BotPlayer } from './BotPlayer';
 export type { BotGameEvent, IMovementEvent, IAttackEvent } from './BotPlayer';
@@ -10,3 +11,20 @@ export type {
   IAIUnitState,
   RetreatEdge,
 } from './types';
+
+// Per `add-ai-terrain-aware-movement`: the frozen terrain-cost pathfinder
+// API (design D2) and the AI Difficulty Tier Registry (design D3). Wave 2
+// changes (A2/A3a/A3b/A4) import these.
+export { findPath, findAllPaths } from './AITerrainPathfinder';
+export type { IAIPath, IAIPathfindRequest } from './AITerrainPathfinder';
+export {
+  AI_TIER_REGISTRY,
+  DEFAULT_TIER_NAME,
+  getTierParameters,
+  resolveTierParameters,
+} from './AITierRegistry';
+export type {
+  AITierName,
+  IAITierParameters,
+  IAITierMovementParameters,
+} from './AITierRegistry';

--- a/src/simulation/ai/types.ts
+++ b/src/simulation/ai/types.ts
@@ -10,6 +10,8 @@ import {
   MovementType,
 } from '@/types/gameplay';
 
+import type { AITierName } from './AITierRegistry';
+
 // =============================================================================
 // Bot Behavior
 // =============================================================================
@@ -53,15 +55,38 @@ export interface IBotBehavior {
    * profiles can override this without recompiling the AI.
    */
   readonly safeHeatThreshold: number;
+
+  /**
+   * Per `add-ai-terrain-aware-movement` design D3: the AI difficulty tier
+   * this bot plays at. The tier name keys into the AI Difficulty Tier
+   * Registry (`AITierRegistry.ts`), which supplies the movement-scoring
+   * parameters (pathfinder enable flag + cover / LOS-denial / terrain-cost
+   * weights).
+   *
+   * Optional for backward compatibility: when absent, the bot resolves to
+   * the `Regular` tier, which runs the legacy straight-line move scorer
+   * byte-for-byte. Every existing bot, test fixture, and the swarm harness
+   * keep their pre-change behavior until a caller opts into `Veteran` /
+   * `Elite`. The tier is player-selectable per scenario and serializes with
+   * the game-session config.
+   */
+  readonly tier?: AITierName;
 }
 
 /**
  * Default bot behavior settings.
+ *
+ * `tier: 'Regular'` is the legacy-scorer tier — `MoveAI` resolves an absent
+ * `tier` to `Regular` anyway, so pinning it explicitly here is purely
+ * self-documenting and keeps `DEFAULT_BEHAVIOR` aligned with the `default`
+ * preset in `behaviorVariants.ts`. The bot's pre-change move scoring is
+ * unchanged.
  */
 export const DEFAULT_BEHAVIOR: IBotBehavior = {
   retreatThreshold: 0.3,
   retreatEdge: 'nearest',
   safeHeatThreshold: 13,
+  tier: 'Regular',
 };
 
 // =============================================================================

--- a/src/utils/gameplay/__tests__/terrainMovementCost.test.ts
+++ b/src/utils/gameplay/__tests__/terrainMovementCost.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the shared terrain movement-cost utility.
+ *
+ * Covers the `Shared Terrain Movement-Cost Utility` requirement of
+ * `add-ai-terrain-aware-movement` — scenarios "Open ground costs one movement
+ * point" and "Heavy terrain costs more than open ground" — plus determinism
+ * and the grid-tag adapter the AI pathfinder consults.
+ *
+ * @spec openspec/changes/add-ai-terrain-aware-movement/specs/simulation-system/spec.md
+ *   Requirement: Shared Terrain Movement-Cost Utility
+ */
+
+import type { IHex, IHexTerrain, ITerrainFeature } from '@/types/gameplay';
+
+import { TerrainType } from '@/types/gameplay';
+import {
+  getHexMovementCostFromTerrainTag,
+  getPrimaryTerrainFeature,
+  getTerrainMovementCost,
+} from '@/utils/gameplay/terrainMovementCost';
+
+function terrain(features: ITerrainFeature[]): IHexTerrain {
+  return { coordinate: { q: 0, r: 0 }, elevation: 0, features };
+}
+
+function feature(type: TerrainType, level = 1): ITerrainFeature {
+  return { type, level };
+}
+
+function hex(tag: string): IHex {
+  return {
+    coord: { q: 0, r: 0 },
+    occupantId: null,
+    terrain: tag,
+    elevation: 0,
+  };
+}
+
+describe('getTerrainMovementCost', () => {
+  it('returns 1 for a hex with no terrain features (open ground)', () => {
+    expect(getTerrainMovementCost(terrain([]))).toBe(1);
+  });
+
+  it('returns 1 for an absent hex terrain', () => {
+    expect(getTerrainMovementCost(undefined)).toBe(1);
+  });
+
+  it('returns 1 for clear terrain', () => {
+    expect(getTerrainMovementCost(terrain([feature(TerrainType.Clear)]))).toBe(
+      1,
+    );
+  });
+
+  it('returns a value greater than 1 for heavy woods', () => {
+    const cost = getTerrainMovementCost(
+      terrain([feature(TerrainType.HeavyWoods)]),
+    );
+    expect(cost).toBeGreaterThan(1);
+    // Heavy woods adds walk modifier 2 on top of the base 1.
+    expect(cost).toBe(3);
+  });
+
+  it('returns a value greater than 1 for light woods', () => {
+    const cost = getTerrainMovementCost(
+      terrain([feature(TerrainType.LightWoods)]),
+    );
+    expect(cost).toBeGreaterThan(1);
+    expect(cost).toBe(2);
+  });
+
+  it('heavy woods costs more to enter than light woods', () => {
+    const heavy = getTerrainMovementCost(
+      terrain([feature(TerrainType.HeavyWoods)]),
+    );
+    const light = getTerrainMovementCost(
+      terrain([feature(TerrainType.LightWoods)]),
+    );
+    expect(heavy).toBeGreaterThan(light);
+  });
+
+  it('is deterministic for a given terrain', () => {
+    const t = terrain([feature(TerrainType.HeavyWoods)]);
+    const first = getTerrainMovementCost(t);
+    const second = getTerrainMovementCost(t);
+    const third = getTerrainMovementCost(t);
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+  });
+
+  it('uses the highest-layer feature when a hex stacks features', () => {
+    // Woods over rough — woods is the primary (higher layer) feature.
+    const cost = getTerrainMovementCost(
+      terrain([feature(TerrainType.Rough), feature(TerrainType.HeavyWoods)]),
+    );
+    expect(cost).toBe(3);
+  });
+});
+
+describe('getPrimaryTerrainFeature', () => {
+  it('returns null for an empty or absent hex terrain', () => {
+    expect(getPrimaryTerrainFeature(undefined)).toBeNull();
+    expect(getPrimaryTerrainFeature(terrain([]))).toBeNull();
+  });
+
+  it('returns the single feature when only one is present', () => {
+    const result = getPrimaryTerrainFeature(
+      terrain([feature(TerrainType.LightWoods, 2)]),
+    );
+    expect(result?.type).toBe(TerrainType.LightWoods);
+    expect(result?.level).toBe(2);
+  });
+});
+
+describe('getHexMovementCostFromTerrainTag', () => {
+  it('returns 1 for an open / clear grid hex', () => {
+    expect(getHexMovementCostFromTerrainTag(hex('clear'))).toBe(1);
+  });
+
+  it('returns 1 for an unrecognised terrain tag', () => {
+    expect(getHexMovementCostFromTerrainTag(hex('not-a-terrain'))).toBe(1);
+  });
+
+  it('returns 1 for an absent hex', () => {
+    expect(getHexMovementCostFromTerrainTag(undefined)).toBe(1);
+  });
+
+  it('returns 3 for a heavy-woods grid hex', () => {
+    expect(getHexMovementCostFromTerrainTag(hex(TerrainType.HeavyWoods))).toBe(
+      3,
+    );
+  });
+
+  it('returns 2 for a light-woods grid hex', () => {
+    expect(getHexMovementCostFromTerrainTag(hex(TerrainType.LightWoods))).toBe(
+      2,
+    );
+  });
+
+  it('agrees with getTerrainMovementCost for the equivalent feature', () => {
+    for (const type of [
+      TerrainType.Clear,
+      TerrainType.LightWoods,
+      TerrainType.HeavyWoods,
+      TerrainType.Rough,
+      TerrainType.Swamp,
+    ]) {
+      const tagCost = getHexMovementCostFromTerrainTag(hex(type));
+      const featureCost = getTerrainMovementCost(terrain([feature(type)]));
+      expect(tagCost).toBe(featureCost);
+    }
+  });
+});

--- a/src/utils/gameplay/terrainCover.ts
+++ b/src/utils/gameplay/terrainCover.ts
@@ -37,3 +37,25 @@ export function hexProvidesPartialCover(hex: IHex | undefined): boolean {
     CoverLevel.Partial
   );
 }
+
+/**
+ * Return whether a terrain tag grants partial cover OR better (i.e. any
+ * cover level other than `None` — partial or full).
+ *
+ * The AI move scorer's cover term — per `add-ai-terrain-aware-movement`
+ * design D5 — rewards a destination hex that offers "partial cover or
+ * better", so it needs the partial-OR-full predicate rather than the
+ * partial-only `hexProvidesPartialCover`. The argument is the raw
+ * `IHex.terrain` string tag; an unrecognised or absent tag yields `false`.
+ *
+ * @spec openspec/changes/add-ai-terrain-aware-movement/specs/simulation-system/spec.md
+ *   Requirement: Terrain-Aware Move Scoring
+ */
+export function terrainTagOffersCover(terrain: string | undefined): boolean {
+  if (terrain === undefined || !TERRAIN_TYPE_VALUES.has(terrain)) {
+    return false;
+  }
+  return (
+    TERRAIN_PROPERTIES[terrain as TerrainType].coverLevel !== CoverLevel.None
+  );
+}

--- a/src/utils/gameplay/terrainMovementCost.ts
+++ b/src/utils/gameplay/terrainMovementCost.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared terrain movement-cost utility.
+ *
+ * `getTerrainMovementCost` and `getPrimaryTerrainFeature` were originally
+ * defined inside `src/components/gameplay/HexMapDisplay/renderHelpers.ts` — a
+ * rendering module the simulation layer (`src/simulation/`) is forbidden to
+ * import. This module is the simulation-accessible home for both functions:
+ * pure, dependency-light, importing nothing from the rendering layer. The
+ * rendering module re-exports from here so existing rendering call sites are
+ * unchanged.
+ *
+ * Per `add-ai-terrain-aware-movement` design D1 — Extract `getTerrainMovementCost`
+ * into a shared sim utility.
+ *
+ * @spec openspec/changes/add-ai-terrain-aware-movement/specs/simulation-system/spec.md
+ *   Requirement: Shared Terrain Movement-Cost Utility
+ */
+
+import type { IHex, IHexTerrain } from '@/types/gameplay';
+
+import { TERRAIN_LAYER_ORDER } from '@/constants/terrain';
+import { TerrainType } from '@/types/gameplay';
+import { TERRAIN_PROPERTIES } from '@/types/gameplay/TerrainTypes';
+
+/** Set of valid `TerrainType` string values, used to narrow a raw `IHex.terrain`. */
+const TERRAIN_TYPE_VALUES: ReadonlySet<string> = new Set<string>(
+  Object.values(TerrainType),
+);
+
+/**
+ * Get the primary terrain feature (highest layer order) for a hex.
+ *
+ * Moved verbatim from `renderHelpers.ts` per design D1 — when a hex carries
+ * multiple stacked features (e.g. woods over rough), the one drawn on top
+ * (highest `TERRAIN_LAYER_ORDER`) is treated as the primary feature for
+ * cost / cover purposes. Returns `null` for an empty or absent hex.
+ */
+export function getPrimaryTerrainFeature(
+  terrain: IHexTerrain | undefined,
+): { type: TerrainType; level: number } | null {
+  if (!terrain || terrain.features.length === 0) return null;
+
+  const sortedFeatures = [...terrain.features].sort(
+    (a, b) => TERRAIN_LAYER_ORDER[b.type] - TERRAIN_LAYER_ORDER[a.type],
+  );
+  return sortedFeatures[0];
+}
+
+/**
+ * Movement-point cost to enter a hex given its terrain features.
+ *
+ * Moved verbatim from `renderHelpers.ts` per design D1. Open ground (no
+ * features) costs `1`; each terrain type adds its `movementCostModifier.walk`
+ * on top of the base `1` (e.g. heavy woods adds `2`, total `3`). Used as the
+ * edge weight for the AI terrain-cost pathfinder.
+ */
+export function getTerrainMovementCost(
+  terrain: IHexTerrain | undefined,
+): number {
+  const feature = getPrimaryTerrainFeature(terrain);
+  if (!feature) return 1;
+  const props = TERRAIN_PROPERTIES[feature.type];
+  return 1 + (props?.movementCostModifier.walk ?? 0);
+}
+
+/**
+ * Movement-point cost to enter a grid hex, derived from its `IHex.terrain`
+ * string tag.
+ *
+ * The `IHexGrid` the simulation layer threads around stores each hex's
+ * terrain as a free-form `string` (`IHex.terrain`), not the richer
+ * `IHexTerrain` feature list. This adapter narrows that string to a known
+ * `TerrainType` and returns the same per-hex cost `getTerrainMovementCost`
+ * would yield for a hex carrying that single feature. An unrecognised or
+ * absent terrain tag — including the all-`clear` grid the simulation runner
+ * builds — yields `1`, matching open ground, so this never throws and never
+ * over-reports cost.
+ *
+ * This is the function the AI terrain-cost pathfinder consults; it keeps the
+ * pathfinder's edge weight identical to what `getTerrainMovementCost` would
+ * produce for the equivalent `IHexTerrain`.
+ */
+export function getHexMovementCostFromTerrainTag(
+  hex: IHex | undefined,
+): number {
+  if (!hex || !TERRAIN_TYPE_VALUES.has(hex.terrain)) {
+    return 1;
+  }
+  const props = TERRAIN_PROPERTIES[hex.terrain as TerrainType];
+  return 1 + (props?.movementCostModifier.walk ?? 0);
+}


### PR DESCRIPTION
Implements the `add-ai-terrain-aware-movement` OpenSpec change — the Wave 2 AI foundation. All 24 tasks complete; OpenSpec change left unarchived.

## What this builds

- **Shared terrain-cost utility** — `getTerrainMovementCost` / `getPrimaryTerrainFeature` extracted to `src/utils/gameplay/terrainMovementCost.ts`; `renderHelpers.ts` re-exports them so the simulation layer never imports rendering code. Adds `getHexMovementCostFromTerrainTag` (grid-`IHex`-tag adapter).
- **AITerrainPathfinder** — deterministic uniform-cost (Dijkstra) terrain-cost pathfinder implementing the frozen design-D2 API (`IAIPath`, `IAIPathfindRequest`, `findPath`, `findAllPaths`). Ties break by canonical hex-neighbor order; consumes no `SeededRandom`.
- **AI Difficulty Tier Registry** — `AITierRegistry.ts` with `Green`/`Regular`/`Veteran`/`Elite`. `Green`/`Regular` disable the pathfinder and zero the new weights (legacy scorer byte-for-byte); `Veteran`/`Elite` enable it. All-ADDED extension point for A2-A4.
- **Terrain-aware move scoring** — `MoveAI.scoreMove` gains cover, LOS-denial, and terrain-cost terms, all gated on `tier.movement.pathfinderEnabled`. `selectMove` runs `findAllPaths` once per turn (design D6).
- `IBotBehavior` gains optional `tier` (default `Regular`); `behaviorVariants.ts` presets map onto tiers.

## Verification

- `npx tsc --noEmit` — zero errors
- `npx oxlint src/` — 0 warnings, 0 errors
- `npx oxfmt --check` — all changed files correctly formatted
- `npx openspec validate add-ai-terrain-aware-movement --strict` — valid
- `npx jest` — 137 simulation suites + 144 component/hook suites green; no golden-trace regressions (legacy `Regular` tier reproduces the pre-change scorer). 41 new tests across 5 new suites covering every delta-spec scenario.

## Notes / deviations

- The terrain-cost term uses `hexDistance(origin, destination)` as the straight-line baseline (design D5's literal `pathMpCost - hexDistance`), sourced from `ctx.attacker.position`.
- `IScoreMoveContext` gains optional `capability`, `tierMovement`, `pathByDestination` fields (additive; legacy callers unaffected). `BotPlayer.playMovementPhase` threads the real `capability` through.
- `DEFAULT_BEHAVIOR` and the `default` variant pin `tier: 'Regular'` explicitly (semantically identical to omitting it — the resolver defaults to `Regular`).