### PR TITLE
feat(ai): resource planning — heat lookahead, ammo runway, crit-seeking

### DIFF
--- a/openspec/changes/add-ai-resource-planning/tasks.md
+++ b/openspec/changes/add-ai-resource-planning/tasks.md
@@ -2,44 +2,44 @@
 
 ## 1. Resource Tier Parameters
 
-- [ ] 1.1 Add `IAITierResourceParameters` (`heatLookaheadTurns`, `ammoConservationWeight`, `critSeekingWeight`, `weaponModeSelection`) and an optional `resource` block on `IAITierParameters` in `src/simulation/ai/AITierRegistry.ts`
-- [ ] 1.2 Populate the `resource` block per tier — `Green`/`Regular` fully inert (`heatLookaheadTurns: 0`, zeroed weights, `weaponModeSelection: false`); `Veteran`/`Elite` populated
-- [ ] 1.3 Tests: every tier resolves a `resource` block; `Green`/`Regular` values disable all A2 behavior
+- [x] 1.1 Add `IAITierResourceParameters` (`heatLookaheadTurns`, `ammoConservationWeight`, `critSeekingWeight`, `weaponModeSelection`) and an optional `resource` block on `IAITierParameters` in `src/simulation/ai/AITierRegistry.ts`
+- [x] 1.2 Populate the `resource` block per tier — `Green`/`Regular` fully inert (`heatLookaheadTurns: 0`, zeroed weights, `weaponModeSelection: false`); `Veteran`/`Elite` populated
+- [x] 1.3 Tests: every tier resolves a `resource` block; `Green`/`Regular` values disable all A2 behavior
 
 ## 2. Multi-Turn Heat Projection
 
-- [ ] 2.1 Create `src/simulation/ai/AIHeatPlanner.ts` with `projectHeat(currentHeat, dissipation, perTurnHeatGenerated, lookaheadTurns)` returning `IHeatProjection`
-- [ ] 2.2 Project per-turn heat across the lookahead window and report the first turn a shutdown risk is predicted (or `-1`)
-- [ ] 2.3 In `AttackAI`, when a shutdown is predicted inside the window, lower the effective heat budget passed to `applyHeatBudget`
-- [ ] 2.4 Tests: a rising heat curve flags the correct shutdown turn; a sustainable fire list reports `-1`; `heatLookaheadTurns: 0` skips projection entirely
+- [x] 2.1 Create `src/simulation/ai/AIHeatPlanner.ts` with `projectHeat(currentHeat, dissipation, perTurnHeatGenerated, lookaheadTurns)` returning `IHeatProjection`
+- [x] 2.2 Project per-turn heat across the lookahead window and report the first turn a shutdown risk is predicted (or `-1`)
+- [x] 2.3 In `AttackAI`, when a shutdown is predicted inside the window, lower the effective heat budget passed to `applyHeatBudget`
+- [x] 2.4 Tests: a rising heat curve flags the correct shutdown turn; a sustainable fire list reports `-1`; `heatLookaheadTurns: 0` skips projection entirely
 
 ## 3. Ammo-Runway Projection
 
-- [ ] 3.1 Create `src/simulation/ai/AIAmmoRunway.ts` computing per-weapon `turnsRemaining` and `conservationWeight`
-- [ ] 3.2 Energy weapons report `Infinity` turns and a neutral conservation weight
-- [ ] 3.3 Feed `conservationWeight` into weapon selection priority — short runway lowers priority; the binary 0-ammo cull is unchanged
-- [ ] 3.4 Tests: scarce ammo lowers a weapon's selection priority without culling it; abundant ammo is neutral; energy weapons are unaffected
+- [x] 3.1 Create `src/simulation/ai/AIAmmoRunway.ts` computing per-weapon `turnsRemaining` and `conservationWeight`
+- [x] 3.2 Energy weapons report `Infinity` turns and a neutral conservation weight
+- [x] 3.3 Feed `conservationWeight` into weapon selection priority — short runway lowers priority; the binary 0-ammo cull is unchanged
+- [x] 3.4 Tests: scarce ammo lowers a weapon's selection priority without culling it; abundant ammo is neutral; energy weapons are unaffected
 
 ## 4. Crit-Seeking Target Weighting
 
-- [ ] 4.1 Surface target structure-state fields (per-location armor and internal structure remaining) on `IAIUnitState`
-- [ ] 4.2 Add an additive crit-seeking term to `scoreTarget`, multiplied by `critSeekingWeight`, proportional to the target's structural exposure
-- [ ] 4.3 A fully-armored target SHALL receive zero crit-seeking bonus; an open side torso SHALL receive a large one
-- [ ] 4.4 Tests: crit-seeking raises an exposed target's score; a fresh heavy still outscores a near-dead light when its threat dominates; `critSeekingWeight: 0` yields the pre-change score
+- [x] 4.1 Surface target structure-state fields (per-location armor and internal structure remaining) on `IAIUnitState`
+- [x] 4.2 Add an additive crit-seeking term to `scoreTarget`, multiplied by `critSeekingWeight`, proportional to the target's structural exposure
+- [x] 4.3 A fully-armored target SHALL receive zero crit-seeking bonus; an open side torso SHALL receive a large one
+- [x] 4.4 Tests: crit-seeking raises an exposed target's score; a fresh heavy still outscores a near-dead light when its threat dominates; `critSeekingWeight: 0` yields the pre-change score
 
 ## 5. Weapon-Mode Selection
 
-- [ ] 5.1 Add optional firing-mode metadata to `IWeapon`; weapons without it are single-mode
-- [ ] 5.2 Create `src/simulation/ai/AIWeaponModeSelector.ts` picking the expected-damage-maximizing mode given range, target armor state, and heat budget
-- [ ] 5.3 LB-X: cluster against armor-stripped/evading targets, slug against fresh armored targets at short range
-- [ ] 5.4 Ultra/Rotary: higher rate of fire when heat and ammo runway allow, lower rate otherwise
-- [ ] 5.5 Record the selected mode on the declared attack; gate selection on `weaponModeSelection`
-- [ ] 5.6 Tests: LB-X picks cluster vs. an open target and slug vs. a fresh one; Ultra drops to single fire under heat pressure; a single-mode weapon passes through unchanged
+- [x] 5.1 Add optional firing-mode metadata to `IWeapon`; weapons without it are single-mode
+- [x] 5.2 Create `src/simulation/ai/AIWeaponModeSelector.ts` picking the expected-damage-maximizing mode given range, target armor state, and heat budget
+- [x] 5.3 LB-X: cluster against armor-stripped/evading targets, slug against fresh armored targets at short range
+- [x] 5.4 Ultra/Rotary: higher rate of fire when heat and ammo runway allow, lower rate otherwise
+- [x] 5.5 Record the selected mode on the declared attack; gate selection on `weaponModeSelection`
+- [x] 5.6 Tests: LB-X picks cluster vs. an open target and slug vs. a fresh one; Ultra drops to single fire under heat pressure; a single-mode weapon passes through unchanged
 
 ## 6. Verification
 
-- [ ] 6.1 Integration test: a `Veteran` bot throttles its alpha strike across turns and does not shut down where a `Regular` bot does
-- [ ] 6.2 Integration test: a `Veteran` bot rations a low-ammo autocannon and a `Regular` bot empties it early
-- [ ] 6.3 Determinism test: SimulationRunner golden traces on the `Regular` tier are byte-identical to pre-change traces
-- [ ] 6.4 `npx openspec validate add-ai-resource-planning --strict` reports valid
-- [ ] 6.5 Build, lint, and typecheck pass
+- [x] 6.1 Integration test: a `Veteran` bot throttles its alpha strike across turns and does not shut down where a `Regular` bot does
+- [x] 6.2 Integration test: a `Veteran` bot rations a low-ammo autocannon and a `Regular` bot empties it early
+- [x] 6.3 Determinism test: SimulationRunner golden traces on the `Regular` tier are byte-identical to pre-change traces
+- [x] 6.4 `npx openspec validate add-ai-resource-planning --strict` reports valid
+- [x] 6.5 Build, lint, and typecheck pass

--- a/src/simulation/__tests__/aiAmmoRunway.test.ts
+++ b/src/simulation/__tests__/aiAmmoRunway.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for the AI Ammo Runway — turns-of-fire projection.
+ *
+ * Covers `add-ai-resource-planning` Requirement "Ammo-Runway Projection":
+ * scenarios "Scarce ammo lowers selection priority", "Abundant ammo is
+ * neutral", and "Energy weapons are unaffected".
+ *
+ * @spec openspec/changes/add-ai-resource-planning/specs/simulation-system/spec.md
+ *   Requirement: Ammo-Runway Projection
+ */
+
+import type { IWeapon } from '../ai/types';
+
+import {
+  MIN_CONSERVATION_WEIGHT,
+  SCARCE_RUNWAY_TURNS,
+  computeAmmoRunway,
+  projectAmmoRunway,
+} from '../ai/AIAmmoRunway';
+
+function ammoWeapon(overrides: Partial<IWeapon> = {}): IWeapon {
+  return {
+    id: 'ac20',
+    name: 'AC/20',
+    shortRange: 3,
+    mediumRange: 6,
+    longRange: 9,
+    damage: 20,
+    heat: 7,
+    minRange: 0,
+    ammoPerTon: 5,
+    destroyed: false,
+    ...overrides,
+  };
+}
+
+function energyWeapon(overrides: Partial<IWeapon> = {}): IWeapon {
+  return {
+    id: 'mlas',
+    name: 'Medium Laser',
+    shortRange: 3,
+    mediumRange: 6,
+    longRange: 9,
+    damage: 5,
+    heat: 3,
+    minRange: 0,
+    ammoPerTon: -1,
+    destroyed: false,
+    ...overrides,
+  };
+}
+
+describe('AIAmmoRunway.computeAmmoRunway', () => {
+  describe('energy weapons are unaffected', () => {
+    it('reports infinite runway and a neutral weight', () => {
+      const runway = computeAmmoRunway(energyWeapon(), undefined);
+      expect(runway.turnsRemaining).toBe(Infinity);
+      expect(runway.conservationWeight).toBe(1);
+    });
+
+    it('an energy weapon with a stray ammo count is still neutral', () => {
+      // ammoPerTon <= 0 short-circuits regardless of the count passed.
+      const runway = computeAmmoRunway(energyWeapon(), 1);
+      expect(runway.turnsRemaining).toBe(Infinity);
+      expect(runway.conservationWeight).toBe(1);
+    });
+  });
+
+  describe('abundant ammo is neutral', () => {
+    it('a long runway yields a conservation weight of 1', () => {
+      const runway = computeAmmoRunway(ammoWeapon(), 40);
+      expect(runway.turnsRemaining).toBe(40);
+      expect(runway.conservationWeight).toBe(1);
+    });
+
+    it('exactly SCARCE_RUNWAY_TURNS of fire is still neutral', () => {
+      const runway = computeAmmoRunway(ammoWeapon(), SCARCE_RUNWAY_TURNS);
+      expect(runway.turnsRemaining).toBe(SCARCE_RUNWAY_TURNS);
+      expect(runway.conservationWeight).toBe(1);
+    });
+  });
+
+  describe('scarce ammo lowers the conservation weight', () => {
+    it('a near-empty weapon drops toward the floor but stays eligible', () => {
+      const runway = computeAmmoRunway(ammoWeapon(), 0);
+      expect(runway.turnsRemaining).toBe(0);
+      expect(runway.conservationWeight).toBe(MIN_CONSERVATION_WEIGHT);
+      // Crucially the weapon is NOT culled — runway modulates priority only.
+      expect(runway.conservationWeight).toBeGreaterThan(0);
+    });
+
+    it('the weight ramps linearly between empty and abundant', () => {
+      const empty = computeAmmoRunway(ammoWeapon(), 0).conservationWeight;
+      const one = computeAmmoRunway(ammoWeapon(), 1).conservationWeight;
+      const two = computeAmmoRunway(ammoWeapon(), 2).conservationWeight;
+      const full = computeAmmoRunway(ammoWeapon(), 3).conservationWeight;
+      expect(empty).toBeLessThan(one);
+      expect(one).toBeLessThan(two);
+      expect(two).toBeLessThan(full);
+      expect(full).toBe(1);
+    });
+
+    it('a higher shots-per-turn rate shortens the runway', () => {
+      const single = computeAmmoRunway(ammoWeapon(), 6, 1);
+      const double = computeAmmoRunway(ammoWeapon(), 6, 2);
+      expect(single.turnsRemaining).toBe(6);
+      expect(double.turnsRemaining).toBe(3);
+    });
+  });
+
+  describe('unknown ammo count is treated as abundant', () => {
+    it('an ammo weapon with no count entry is neutral', () => {
+      // Legacy IAIUnitState fixtures have an empty `ammo` map — they must
+      // not be rationed (matching legacy `selectWeapons` non-cull).
+      const runway = computeAmmoRunway(ammoWeapon(), undefined);
+      expect(runway.turnsRemaining).toBe(Infinity);
+      expect(runway.conservationWeight).toBe(1);
+    });
+  });
+});
+
+describe('AIAmmoRunway.projectAmmoRunway', () => {
+  it('projects a runway for every weapon in a fire list', () => {
+    const weapons = [
+      ammoWeapon({ id: 'ac20' }),
+      energyWeapon({ id: 'mlas' }),
+      ammoWeapon({ id: 'lrm', ammoPerTon: 24 }),
+    ];
+    const runways = projectAmmoRunway(weapons, { ac20: 1, lrm: 30 });
+    expect(runways).toHaveLength(3);
+    expect(runways[0].weaponId).toBe('ac20');
+    expect(runways[0].conservationWeight).toBeLessThan(1); // scarce
+    expect(runways[1].turnsRemaining).toBe(Infinity); // energy
+    expect(runways[2].conservationWeight).toBe(1); // abundant
+  });
+
+  it('honours per-weapon shots-per-turn overrides', () => {
+    const weapons = [ammoWeapon({ id: 'rac' })];
+    const runways = projectAmmoRunway(weapons, { rac: 12 }, { rac: 6 });
+    // 12 rounds at 6/turn → 2 turns of fire.
+    expect(runways[0].turnsRemaining).toBe(2);
+  });
+});

--- a/src/simulation/__tests__/aiHeatPlanner.test.ts
+++ b/src/simulation/__tests__/aiHeatPlanner.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the AI Heat Planner — multi-turn heat projection.
+ *
+ * Covers `add-ai-resource-planning` Requirement "Multi-Turn Heat Projection":
+ * scenarios "Rising heat curve flags the shutdown turn", "Sustainable fire
+ * list reports no risk", and the `heatLookaheadTurns: 0` skip path.
+ *
+ * @spec openspec/changes/add-ai-resource-planning/specs/simulation-system/spec.md
+ *   Requirement: Multi-Turn Heat Projection
+ */
+
+import {
+  SHUTDOWN_RISK_HEAT,
+  effectiveHeatBudget,
+  projectHeat,
+} from '../ai/AIHeatPlanner';
+
+describe('AIHeatPlanner.projectHeat', () => {
+  describe('rising heat curve flags the shutdown turn', () => {
+    it('reports the first turn projected heat crosses the ceiling', () => {
+      // Start at 8 heat, generate 12/turn, dissipate 6/turn → net +6/turn.
+      // Turn 0: 8 + 6 = 14 (>= 14 ceiling). Shutdown predicted at turn 0.
+      const projection = projectHeat(8, 6, 12, 4);
+      expect(projection.perTurnHeat).toEqual([14, 20, 26, 32]);
+      expect(projection.shutdownRiskTurn).toBe(0);
+    });
+
+    it('flags a shutdown a few turns out when the curve builds slowly', () => {
+      // Start at 2, generate 9, dissipate 6 → net +3/turn.
+      // Turn 0: 5, turn 1: 8, turn 2: 11, turn 3: 14 (>= ceiling).
+      const projection = projectHeat(2, 6, 9, 5);
+      expect(projection.perTurnHeat).toEqual([5, 8, 11, 14, 17]);
+      expect(projection.shutdownRiskTurn).toBe(3);
+    });
+  });
+
+  describe('sustainable fire list reports no risk', () => {
+    it('returns shutdownRiskTurn -1 when generated <= dissipated', () => {
+      // Net heat per turn is zero — the curve is flat at the start value.
+      const projection = projectHeat(5, 10, 10, 4);
+      expect(projection.perTurnHeat).toEqual([5, 5, 5, 5]);
+      expect(projection.shutdownRiskTurn).toBe(-1);
+    });
+
+    it('returns -1 when the curve cools toward zero', () => {
+      // Generate less than dissipated — heat falls and floors at zero.
+      const projection = projectHeat(8, 10, 4, 3);
+      expect(projection.perTurnHeat).toEqual([2, 0, 0]);
+      expect(projection.shutdownRiskTurn).toBe(-1);
+    });
+
+    it('a curve that rises but stays under the ceiling reports -1', () => {
+      // Net +2/turn from 4 → 6, 8, 10, 12 — never reaches 14.
+      const projection = projectHeat(4, 4, 6, 4);
+      expect(projection.perTurnHeat).toEqual([6, 8, 10, 12]);
+      expect(projection.shutdownRiskTurn).toBe(-1);
+    });
+  });
+
+  describe('heatLookaheadTurns: 0 skips projection entirely', () => {
+    it('returns an empty projection with no risk', () => {
+      const projection = projectHeat(20, 0, 30, 0);
+      expect(projection.perTurnHeat).toEqual([]);
+      expect(projection.shutdownRiskTurn).toBe(-1);
+    });
+
+    it('treats negative lookahead the same as zero', () => {
+      const projection = projectHeat(20, 0, 30, -3);
+      expect(projection.perTurnHeat).toEqual([]);
+      expect(projection.shutdownRiskTurn).toBe(-1);
+    });
+  });
+
+  describe('determinism — pure function of its arguments', () => {
+    it('repeated calls with identical arguments are identical', () => {
+      const a = projectHeat(8, 6, 12, 4);
+      const b = projectHeat(8, 6, 12, 4);
+      expect(a).toEqual(b);
+    });
+  });
+
+  it('SHUTDOWN_RISK_HEAT is the canonical heat-14 ceiling', () => {
+    expect(SHUTDOWN_RISK_HEAT).toBe(14);
+  });
+});
+
+describe('AIHeatPlanner.effectiveHeatBudget', () => {
+  it('passes the base budget through unchanged when no shutdown predicted', () => {
+    const projection = projectHeat(4, 4, 6, 4); // never crosses ceiling
+    expect(effectiveHeatBudget(13, projection, 4)).toBe(13);
+  });
+
+  it('lowers the budget when a shutdown is predicted in the window', () => {
+    // Shutdown at turn 0 with a large overshoot — budget must drop.
+    const projection = projectHeat(8, 6, 12, 4);
+    expect(projection.shutdownRiskTurn).toBe(0);
+    const lowered = effectiveHeatBudget(13, projection, 8);
+    expect(lowered).toBeLessThan(13);
+    // Never trimmed below the heat already on the track.
+    expect(lowered).toBeGreaterThanOrEqual(8);
+  });
+
+  it('softens the correction for a more distant predicted shutdown', () => {
+    // Two projections with the SAME overshoot at the shutdown turn but
+    // predicted at different distances — the nearer one gets the harsher
+    // budget reduction (proximity scales the correction down).
+    // Near: start 14, +6/turn → turn 0 at 20 (overshoot 6).
+    const nearTerm = projectHeat(14, 0, 6, 4);
+    // Far: start 2, +9/turn → 11, 20 — shutdown turn 1, overshoot 6.
+    const farTerm = projectHeat(2, 0, 9, 4);
+    expect(nearTerm.shutdownRiskTurn).toBe(0);
+    expect(farTerm.shutdownRiskTurn).toBe(1);
+    const nearBudget = effectiveHeatBudget(20, nearTerm, 0);
+    const farBudget = effectiveHeatBudget(20, farTerm, 0);
+    expect(20 - nearBudget).toBeGreaterThan(20 - farBudget);
+  });
+
+  it('never lowers the budget below current heat', () => {
+    // A unit already running hot (25 heat) with a high base budget. Even
+    // with a predicted shutdown the budget must not be trimmed below the
+    // heat already on the track — that would cull every weapon pointlessly.
+    const projection = projectHeat(25, 5, 30, 3);
+    expect(projection.shutdownRiskTurn).toBeGreaterThanOrEqual(0);
+    const lowered = effectiveHeatBudget(40, projection, 25, 5, 0);
+    expect(lowered).toBeGreaterThanOrEqual(25);
+  });
+});

--- a/src/simulation/__tests__/aiResourcePlanning.integration.test.ts
+++ b/src/simulation/__tests__/aiResourcePlanning.integration.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration tests for A2 resource planning through `BotPlayer`.
+ *
+ * Covers `add-ai-resource-planning` tasks 6.1 (Veteran throttles its alpha
+ * strike across turns) and 6.2 (Veteran rations a low-ammo autocannon a
+ * Regular bot empties early), and the spec scenario "Veteran bot throttles
+ * before shutdown".
+ *
+ * @spec openspec/changes/add-ai-resource-planning/specs/simulation-system/spec.md
+ *   Requirement: Multi-Turn Heat Projection
+ *   Requirement: Ammo-Runway Projection
+ */
+
+import { Facing, MovementType } from '@/types/gameplay';
+
+import type { IBotBehavior, IAIUnitState, IWeapon } from '../ai/types';
+
+import { BotPlayer } from '../ai/BotPlayer';
+import { DEFAULT_BEHAVIOR } from '../ai/types';
+import { SeededRandom } from '../core/SeededRandom';
+
+function weapon(overrides: Partial<IWeapon> = {}): IWeapon {
+  return {
+    id: 'mlas',
+    name: 'Medium Laser',
+    shortRange: 3,
+    mediumRange: 6,
+    longRange: 9,
+    damage: 5,
+    heat: 3,
+    minRange: 0,
+    ammoPerTon: -1,
+    destroyed: false,
+    ...overrides,
+  };
+}
+
+function unit(overrides: Partial<IAIUnitState> = {}): IAIUnitState {
+  return {
+    unitId: 'attacker',
+    position: { q: 0, r: 0 },
+    facing: Facing.North,
+    heat: 0,
+    weapons: [weapon()],
+    ammo: {},
+    destroyed: false,
+    gunnery: 4,
+    movementType: MovementType.Stationary,
+    hexesMoved: 0,
+    ...overrides,
+  };
+}
+
+function behavior(tier: IBotBehavior['tier']): IBotBehavior {
+  return { ...DEFAULT_BEHAVIOR, tier };
+}
+
+describe('A2 integration — Veteran throttles its alpha strike', () => {
+  // A hot fire list: six laser-class energy weapons at 3 heat each. A full
+  // alpha strike generates 18 heat/turn; with a 10-sink dissipation the curve
+  // climbs +8/turn and a shutdown is reached inside the lookahead window.
+  // The Regular bot's single-turn trim fits four weapons under its fixed
+  // safe threshold (13); the Veteran's heat planner lowers the effective
+  // budget so it fires strictly fewer.
+  function hotAttacker(): IAIUnitState {
+    return unit({
+      heat: 0,
+      heatDissipation: 10,
+      weapons: Array.from({ length: 6 }, (_, i) =>
+        weapon({ id: `las-${i}`, name: 'Large Laser', damage: 8, heat: 3 }),
+      ),
+    });
+  }
+
+  const target = unit({ unitId: 'target', position: { q: 4, r: 0 } });
+
+  it('a Veteran bot fires fewer weapons than a Regular bot under a heat curve', () => {
+    const veteran = new BotPlayer(new SeededRandom(1), behavior('Veteran'));
+    const regular = new BotPlayer(new SeededRandom(1), behavior('Regular'));
+
+    const vAttack = veteran.playAttackPhase(hotAttacker(), [
+      hotAttacker(),
+      target,
+    ]);
+    const rAttack = regular.playAttackPhase(hotAttacker(), [
+      hotAttacker(),
+      target,
+    ]);
+
+    expect(vAttack).not.toBeNull();
+    expect(rAttack).not.toBeNull();
+    // The Veteran's multi-turn projection lowers the budget — it commits to
+    // a strictly smaller fire list than the Regular bot's single-turn trim.
+    expect(vAttack!.payload.weapons.length).toBeLessThan(
+      rAttack!.payload.weapons.length,
+    );
+  });
+
+  it('the Veteran fire list does not shut the unit down within the window', () => {
+    const veteran = new BotPlayer(new SeededRandom(7), behavior('Veteran'));
+    const attacker = hotAttacker();
+    const attack = veteran.playAttackPhase(attacker, [attacker, target]);
+    expect(attack).not.toBeNull();
+
+    // Project the heat the chosen fire list generates over 3 turns and
+    // confirm it stays under the shutdown ceiling (14).
+    const firedHeat = attack!.payload.weapons.reduce((sum, id) => {
+      const w = attacker.weapons.find((x) => x.id === id);
+      return sum + (w?.heat ?? 0);
+    }, 0);
+    let heat = attacker.heat;
+    for (let turn = 0; turn < 3; turn++) {
+      heat = Math.max(0, heat + firedHeat - (attacker.heatDissipation ?? 10));
+    }
+    expect(heat).toBeLessThan(14);
+  });
+});
+
+describe('A2 integration — Veteran rations a low-ammo autocannon', () => {
+  // The attacker has one energy weapon and one nearly-empty autocannon of
+  // equal efficiency. The Veteran's ammo conservation must sink the
+  // autocannon in priority; the Regular bot orders them by raw efficiency.
+  function makeAttacker(): IAIUnitState {
+    return unit({
+      heat: 0,
+      heatDissipation: 10,
+      weapons: [
+        weapon({ id: 'ac5', name: 'AC/5', damage: 6, heat: 3, ammoPerTon: 5 }),
+        weapon({ id: 'mlas', name: 'Medium Laser', damage: 6, heat: 3 }),
+      ],
+      ammo: { ac5: 1 },
+    });
+  }
+  const target = unit({ unitId: 'target', position: { q: 4, r: 0 } });
+
+  it('the Veteran ranks the energy weapon ahead of the scarce autocannon', () => {
+    const veteran = new BotPlayer(new SeededRandom(3), behavior('Veteran'));
+    const attacker = makeAttacker();
+    const attack = veteran.playAttackPhase(attacker, [attacker, target]);
+    expect(attack).not.toBeNull();
+    const ids = attack!.payload.weapons;
+    expect(ids).toContain('ac5'); // not culled — still eligible
+    expect(ids).toContain('mlas');
+    expect(ids.indexOf('mlas')).toBeLessThan(ids.indexOf('ac5'));
+  });
+
+  it('the Regular bot keeps the legacy efficiency order (no conservation)', () => {
+    const regular = new BotPlayer(new SeededRandom(3), behavior('Regular'));
+    const attacker = makeAttacker();
+    const attack = regular.playAttackPhase(attacker, [attacker, target]);
+    expect(attack).not.toBeNull();
+    // Equal-efficiency weapons — the Regular bot does not reorder for ammo.
+    // The scarce autocannon is NOT pushed behind the laser by conservation.
+    const ids = attack!.payload.weapons;
+    expect(ids).toContain('ac5');
+    expect(ids).toContain('mlas');
+  });
+});
+
+describe('A2 integration — legacy tiers reproduce pre-A2 behavior', () => {
+  it('a Regular bot with no multi-mode weapons emits no weaponModes map', () => {
+    const regular = new BotPlayer(new SeededRandom(5), behavior('Regular'));
+    const attacker = unit({
+      weapons: [weapon({ id: 'l1' }), weapon({ id: 'l2' })],
+    });
+    const target = unit({ unitId: 'target', position: { q: 3, r: 0 } });
+    const attack = regular.playAttackPhase(attacker, [attacker, target]);
+    expect(attack).not.toBeNull();
+    expect(attack!.payload.weaponModes).toBeUndefined();
+  });
+
+  it('a Regular and an undefined-tier bot pick the identical fire list', () => {
+    const regular = new BotPlayer(new SeededRandom(9), behavior('Regular'));
+    const untiered = new BotPlayer(new SeededRandom(9), behavior(undefined));
+    const attacker = unit({
+      weapons: [
+        weapon({ id: 'l1', damage: 10, heat: 2 }),
+        weapon({ id: 'l2', damage: 5, heat: 4 }),
+      ],
+    });
+    const target = unit({ unitId: 'target', position: { q: 3, r: 0 } });
+    const rAttack = regular.playAttackPhase(attacker, [attacker, target]);
+    const uAttack = untiered.playAttackPhase(attacker, [attacker, target]);
+    expect(rAttack!.payload.weapons).toEqual(uAttack!.payload.weapons);
+  });
+});

--- a/src/simulation/__tests__/aiResourcePlanning.test.ts
+++ b/src/simulation/__tests__/aiResourcePlanning.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for the A2 resource-planning integration into `AttackAI` —
+ * crit-seeking target weighting and the resource-aware `planFireList`.
+ *
+ * Covers `add-ai-resource-planning` Requirements "Crit-Seeking Target
+ * Weighting" and "Ammo-Runway Projection" (the selection-priority half).
+ *
+ * @spec openspec/changes/add-ai-resource-planning/specs/simulation-system/spec.md
+ *   Requirement: Crit-Seeking Target Weighting
+ *   Requirement: Ammo-Runway Projection
+ */
+
+import { Facing, MovementType } from '@/types/gameplay';
+
+import type {
+  IAIStructureState,
+  IAIUnitState,
+  IWeapon,
+  IWeaponFiringModes,
+} from '../ai/types';
+
+import {
+  resolveResourceParameters,
+  getTierParameters,
+} from '../ai/AITierRegistry';
+import { AttackAI, scoreTarget, structuralExposure } from '../ai/AttackAI';
+
+const VETERAN_RESOURCE = resolveResourceParameters(
+  getTierParameters('Veteran'),
+);
+const REGULAR_RESOURCE = resolveResourceParameters(
+  getTierParameters('Regular'),
+);
+
+function weapon(overrides: Partial<IWeapon> = {}): IWeapon {
+  return {
+    id: 'mlas',
+    name: 'Medium Laser',
+    shortRange: 3,
+    mediumRange: 6,
+    longRange: 9,
+    damage: 5,
+    heat: 3,
+    minRange: 0,
+    ammoPerTon: -1,
+    destroyed: false,
+    ...overrides,
+  };
+}
+
+function unit(overrides: Partial<IAIUnitState> = {}): IAIUnitState {
+  return {
+    unitId: 'u1',
+    position: { q: 0, r: 0 },
+    facing: Facing.North,
+    heat: 0,
+    weapons: [weapon()],
+    ammo: {},
+    destroyed: false,
+    gunnery: 4,
+    movementType: MovementType.Stationary,
+    hexesMoved: 0,
+    ...overrides,
+  };
+}
+
+const FRESH: IAIStructureState = {
+  armorByLocation: { center_torso: 21, left_torso: 14, right_torso: 14 },
+  armorMaxByLocation: { center_torso: 21, left_torso: 14, right_torso: 14 },
+  internalByLocation: { center_torso: 11, left_torso: 7, right_torso: 7 },
+  internalMaxByLocation: { center_torso: 11, left_torso: 7, right_torso: 7 },
+};
+
+const OPEN_SIDE_TORSO: IAIStructureState = {
+  armorByLocation: { center_torso: 21, left_torso: 0, right_torso: 14 },
+  armorMaxByLocation: { center_torso: 21, left_torso: 14, right_torso: 14 },
+  internalByLocation: { center_torso: 11, left_torso: 1, right_torso: 7 },
+  internalMaxByLocation: { center_torso: 11, left_torso: 7, right_torso: 7 },
+};
+
+describe('structuralExposure', () => {
+  it('a fully-armoured undamaged target has zero exposure', () => {
+    expect(structuralExposure(FRESH)).toBe(0);
+  });
+
+  it('a target with no structure state has zero exposure', () => {
+    expect(structuralExposure(undefined)).toBe(0);
+  });
+
+  it('an open side torso with internal damage has high exposure', () => {
+    expect(structuralExposure(OPEN_SIDE_TORSO)).toBeGreaterThan(0);
+  });
+
+  it('more stripped locations raise exposure monotonically', () => {
+    const oneOpen = structuralExposure(OPEN_SIDE_TORSO);
+    const twoOpen = structuralExposure({
+      armorByLocation: { center_torso: 21, left_torso: 0, right_torso: 0 },
+      armorMaxByLocation: { center_torso: 21, left_torso: 14, right_torso: 14 },
+      internalByLocation: { center_torso: 11, left_torso: 1, right_torso: 2 },
+      internalMaxByLocation: {
+        center_torso: 11,
+        left_torso: 7,
+        right_torso: 7,
+      },
+    });
+    expect(twoOpen).toBeGreaterThan(oneOpen);
+  });
+});
+
+describe('scoreTarget — crit-seeking term', () => {
+  it('crit-seeking disabled yields the legacy threat-only score', () => {
+    const attacker = unit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const target = unit({
+      unitId: 't',
+      position: { q: 2, r: 0 },
+      structureState: OPEN_SIDE_TORSO,
+    });
+    // No resource block at all == legacy. Regular's zeroed block == legacy.
+    const legacy = scoreTarget(attacker, target);
+    const regular = scoreTarget(attacker, target, REGULAR_RESOURCE);
+    expect(regular).toBe(legacy);
+  });
+
+  it('an exposed target scores higher than an identical fresh one', () => {
+    const attacker = unit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const fresh = unit({
+      unitId: 'fresh',
+      position: { q: 2, r: 0 },
+      structureState: FRESH,
+    });
+    const exposed = unit({
+      unitId: 'exposed',
+      position: { q: 2, r: 0 },
+      structureState: OPEN_SIDE_TORSO,
+    });
+    const freshScore = scoreTarget(attacker, fresh, VETERAN_RESOURCE);
+    const exposedScore = scoreTarget(attacker, exposed, VETERAN_RESOURCE);
+    expect(exposedScore).toBeGreaterThan(freshScore);
+  });
+
+  it('a fully-armoured target gets a zero crit-seeking bonus', () => {
+    const attacker = unit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const fresh = unit({
+      unitId: 'fresh',
+      position: { q: 2, r: 0 },
+      structureState: FRESH,
+    });
+    // With a fresh target the Veteran score equals the legacy score —
+    // the crit-seeking term contributes exactly zero.
+    expect(scoreTarget(attacker, fresh, VETERAN_RESOURCE)).toBe(
+      scoreTarget(attacker, fresh),
+    );
+  });
+
+  it('a fresh heavy can still outscore a near-dead light when threat dominates', () => {
+    const attacker = unit({ unitId: 'a', position: { q: 0, r: 0 } });
+    // Near-dead light: open torso (high exposure) but tiny threat.
+    const light = unit({
+      unitId: 'light',
+      position: { q: 2, r: 0 },
+      gunnery: 6,
+      weapons: [weapon({ damage: 3 })],
+      remainingHpFraction: 0.15,
+      structureState: OPEN_SIDE_TORSO,
+    });
+    // Fresh heavy: a much larger threat, fully armoured.
+    const heavy = unit({
+      unitId: 'heavy',
+      position: { q: 2, r: 0 },
+      gunnery: 3,
+      weapons: [
+        weapon({ id: 'w1', damage: 20 }),
+        weapon({ id: 'w2', damage: 20 }),
+        weapon({ id: 'w3', damage: 15 }),
+      ],
+      remainingHpFraction: 1,
+      structureState: FRESH,
+    });
+    const lightScore = scoreTarget(attacker, light, VETERAN_RESOURCE);
+    const heavyScore = scoreTarget(attacker, heavy, VETERAN_RESOURCE);
+    expect(heavyScore).toBeGreaterThan(lightScore);
+  });
+});
+
+describe('AttackAI.planFireList — ammo conservation', () => {
+  const attackAI = new AttackAI();
+
+  it('scarce ammo lowers a weapon priority without culling it', () => {
+    // Two weapons of equal efficiency: an energy weapon and an ammo weapon
+    // running on fumes. Conservation must sink the scarce one in priority
+    // but it must remain in the list (still eligible).
+    const energy = weapon({
+      id: 'energy',
+      damage: 6,
+      heat: 3,
+      ammoPerTon: -1,
+    });
+    const scarce = weapon({
+      id: 'scarce',
+      damage: 6,
+      heat: 3,
+      ammoPerTon: 5,
+    });
+    const attacker = unit({
+      unitId: 'a',
+      position: { q: 0, r: 0 },
+      weapons: [scarce, energy],
+      ammo: { scarce: 1 },
+    });
+    const target = unit({ unitId: 't', position: { q: 2, r: 0 } });
+
+    const planned = attackAI.planFireList(attacker, target, {
+      resource: VETERAN_RESOURCE,
+    });
+    const ids = planned.map((e) => e.weapon.id);
+    // Both weapons present — scarce ammo never culls.
+    expect(ids).toContain('scarce');
+    expect(ids).toContain('energy');
+    // The energy weapon outranks the scarce ammo weapon.
+    expect(ids.indexOf('energy')).toBeLessThan(ids.indexOf('scarce'));
+  });
+
+  it('abundant ammo leaves priority at the legacy efficiency order', () => {
+    const energy = weapon({ id: 'energy', damage: 6, heat: 3, ammoPerTon: -1 });
+    const abundant = weapon({
+      id: 'abundant',
+      damage: 6,
+      heat: 3,
+      ammoPerTon: 5,
+    });
+    const attacker = unit({
+      unitId: 'a',
+      position: { q: 0, r: 0 },
+      weapons: [abundant, energy],
+      ammo: { abundant: 40 },
+    });
+    const target = unit({ unitId: 't', position: { q: 2, r: 0 } });
+
+    const veteran = attackAI
+      .planFireList(attacker, target, { resource: VETERAN_RESOURCE })
+      .map((e) => e.weapon.id);
+    const regular = attackAI
+      .planFireList(attacker, target, { resource: REGULAR_RESOURCE })
+      .map((e) => e.weapon.id);
+    // Abundant ammo == neutral conservation; the Veteran order equals the
+    // legacy (Regular) order.
+    expect(veteran).toEqual(regular);
+  });
+
+  it('the inert (Regular) block reproduces the legacy selectWeapons order', () => {
+    const attacker = unit({
+      unitId: 'a',
+      position: { q: 0, r: 0 },
+      weapons: [
+        weapon({ id: 'w1', damage: 10, heat: 2 }),
+        weapon({ id: 'w2', damage: 5, heat: 3 }),
+        weapon({ id: 'w3', damage: 8, heat: 4 }),
+      ],
+    });
+    const target = unit({ unitId: 't', position: { q: 2, r: 0 } });
+    const planned = attackAI
+      .planFireList(attacker, target, { resource: REGULAR_RESOURCE })
+      .map((e) => e.weapon.id);
+    const legacy = attackAI.selectWeapons(attacker, target).map((w) => w.id);
+    expect(planned).toEqual(legacy);
+  });
+
+  it('records the selected mode for a multi-mode weapon', () => {
+    const lbxModes: IWeaponFiringModes = {
+      kind: 'cluster-slug',
+      defaultModeId: 'slug',
+      modes: [
+        { id: 'slug', damage: 10, heat: 2, shotsPerTurn: 1 },
+        { id: 'cluster', damage: 6, heat: 2, shotsPerTurn: 1 },
+      ],
+    };
+    const lbx = weapon({
+      id: 'lbx',
+      damage: 10,
+      heat: 2,
+      ammoPerTon: 10,
+      shortRange: 6,
+      mediumRange: 12,
+      longRange: 18,
+      firingModes: lbxModes,
+    });
+    const attacker = unit({
+      unitId: 'a',
+      position: { q: 0, r: 0 },
+      weapons: [lbx],
+      ammo: { lbx: 20 },
+    });
+    // Exposed target → cluster mode.
+    const target = unit({
+      unitId: 't',
+      position: { q: 5, r: 0 },
+      structureState: OPEN_SIDE_TORSO,
+    });
+    const planned = attackAI.planFireList(attacker, target, {
+      resource: VETERAN_RESOURCE,
+    });
+    expect(planned[0].mode.modeId).toBe('cluster');
+  });
+});

--- a/src/simulation/__tests__/aiTierRegistry.test.ts
+++ b/src/simulation/__tests__/aiTierRegistry.test.ts
@@ -15,7 +15,9 @@ import type { AITierName } from '../ai/AITierRegistry';
 import {
   AI_TIER_REGISTRY,
   DEFAULT_TIER_NAME,
+  INERT_RESOURCE_PARAMETERS,
   getTierParameters,
+  resolveResourceParameters,
   resolveTierParameters,
 } from '../ai/AITierRegistry';
 
@@ -122,5 +124,87 @@ describe('AITierRegistry', () => {
         ['Elite', 'Green', 'Regular', 'Veteran'].sort(),
       );
     });
+  });
+
+  // ===========================================================================
+  // `add-ai-resource-planning` (A2) — Requirement: Resource-Planning Tier
+  // Parameters. Scenarios "Every tier resolves a resource block" and
+  // "Lower tiers disable resource planning".
+  // ===========================================================================
+  describe('resource block — every tier resolves a populated record', () => {
+    it.each(ALL_TIERS)('tier %s resolves to a resource block', (tier) => {
+      const params = getTierParameters(tier);
+      const resource = resolveResourceParameters(params);
+      expect(resource).toBeDefined();
+      expect(typeof resource.heatLookaheadTurns).toBe('number');
+      expect(typeof resource.ammoConservationWeight).toBe('number');
+      expect(typeof resource.critSeekingWeight).toBe('number');
+      expect(typeof resource.weaponModeSelection).toBe('boolean');
+    });
+
+    it('every registry entry populates the resource field directly', () => {
+      for (const tier of ALL_TIERS) {
+        expect(AI_TIER_REGISTRY[tier].resource).toBeDefined();
+      }
+    });
+  });
+
+  describe('resource block — lower tiers disable resource planning', () => {
+    it.each(['Green', 'Regular'] as const)(
+      'tier %s is fully inert (zeroed weights, no lookahead, no modes)',
+      (tier) => {
+        const r = resolveResourceParameters(getTierParameters(tier));
+        expect(r.heatLookaheadTurns).toBe(0);
+        expect(r.ammoConservationWeight).toBe(0);
+        expect(r.critSeekingWeight).toBe(0);
+        expect(r.weaponModeSelection).toBe(false);
+      },
+    );
+  });
+
+  describe('resource block — Veteran/Elite are populated and active', () => {
+    it.each(['Veteran', 'Elite'] as const)(
+      'tier %s has an active resource block',
+      (tier) => {
+        const r = resolveResourceParameters(getTierParameters(tier));
+        expect(r.heatLookaheadTurns).toBeGreaterThan(0);
+        expect(r.ammoConservationWeight).toBeGreaterThan(0);
+        expect(r.critSeekingWeight).toBeGreaterThan(0);
+        expect(r.weaponModeSelection).toBe(true);
+      },
+    );
+
+    it('Elite weights every resource term at least as heavily as Veteran', () => {
+      const v = resolveResourceParameters(getTierParameters('Veteran'));
+      const e = resolveResourceParameters(getTierParameters('Elite'));
+      expect(e.heatLookaheadTurns).toBeGreaterThanOrEqual(v.heatLookaheadTurns);
+      expect(e.ammoConservationWeight).toBeGreaterThanOrEqual(
+        v.ammoConservationWeight,
+      );
+      expect(e.critSeekingWeight).toBeGreaterThanOrEqual(v.critSeekingWeight);
+    });
+  });
+
+  describe('resolveResourceParameters — fallback for pre-A2 records', () => {
+    it('returns the inert block when a record has no resource field', () => {
+      const legacyRecord = { tier: 'Veteran', movement: {} } as never;
+      const r = resolveResourceParameters(legacyRecord);
+      expect(r).toBe(INERT_RESOURCE_PARAMETERS);
+      expect(r.heatLookaheadTurns).toBe(0);
+      expect(r.weaponModeSelection).toBe(false);
+    });
+  });
+
+  describe('A2 registration is additive — movement block untouched', () => {
+    it.each(ALL_TIERS)(
+      'tier %s movement block matches its A1 values',
+      (tier) => {
+        // The movement block must be byte-identical to A1 — A2 only ADDs
+        // the `resource` block.
+        const m = getTierParameters(tier).movement;
+        const pathfinderTier = tier === 'Veteran' || tier === 'Elite';
+        expect(m.pathfinderEnabled).toBe(pathfinderTier);
+      },
+    );
   });
 });

--- a/src/simulation/__tests__/aiWeaponModeSelector.test.ts
+++ b/src/simulation/__tests__/aiWeaponModeSelector.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for the AI Weapon-Mode Selector — multi-mode weapon mode choice.
+ *
+ * Covers `add-ai-resource-planning` Requirement "Multi-Mode Weapon Selection":
+ * scenarios "LB-X picks cluster against an exposed target", "LB-X picks slug
+ * against a fresh target", "Rate-of-fire weapon drops to single fire under
+ * heat pressure", and "Single-mode weapon passes through unchanged".
+ *
+ * @spec openspec/changes/add-ai-resource-planning/specs/simulation-system/spec.md
+ *   Requirement: Multi-Mode Weapon Selection
+ */
+
+import type {
+  IAIStructureState,
+  IWeapon,
+  IWeaponFiringModes,
+} from '../ai/types';
+
+import {
+  type IWeaponModeContext,
+  selectWeaponMode,
+} from '../ai/AIWeaponModeSelector';
+
+const LBX_MODES: IWeaponFiringModes = {
+  kind: 'cluster-slug',
+  defaultModeId: 'slug',
+  modes: [
+    { id: 'slug', damage: 10, heat: 2, shotsPerTurn: 1 },
+    { id: 'cluster', damage: 6, heat: 2, shotsPerTurn: 1 },
+  ],
+};
+
+const ULTRA_MODES: IWeaponFiringModes = {
+  kind: 'rate-of-fire',
+  defaultModeId: 'single',
+  modes: [
+    { id: 'single', damage: 5, heat: 1, shotsPerTurn: 1 },
+    { id: 'double', damage: 10, heat: 2, shotsPerTurn: 2 },
+  ],
+};
+
+function lbxWeapon(overrides: Partial<IWeapon> = {}): IWeapon {
+  return {
+    id: 'lbx10',
+    name: 'LB 10-X AC',
+    shortRange: 6,
+    mediumRange: 12,
+    longRange: 18,
+    damage: 10,
+    heat: 2,
+    minRange: 0,
+    ammoPerTon: 10,
+    destroyed: false,
+    firingModes: LBX_MODES,
+    ...overrides,
+  };
+}
+
+function ultraWeapon(overrides: Partial<IWeapon> = {}): IWeapon {
+  return {
+    id: 'uac5',
+    name: 'Ultra AC/5',
+    shortRange: 6,
+    mediumRange: 12,
+    longRange: 18,
+    damage: 5,
+    heat: 1,
+    minRange: 0,
+    ammoPerTon: 20,
+    destroyed: false,
+    firingModes: ULTRA_MODES,
+    ...overrides,
+  };
+}
+
+function singleModeWeapon(): IWeapon {
+  return {
+    id: 'mlas',
+    name: 'Medium Laser',
+    shortRange: 3,
+    mediumRange: 6,
+    longRange: 9,
+    damage: 5,
+    heat: 3,
+    minRange: 0,
+    ammoPerTon: -1,
+    destroyed: false,
+  };
+}
+
+const FRESH_STRUCTURE: IAIStructureState = {
+  armorByLocation: { center_torso: 21, left_torso: 14, right_torso: 14 },
+  armorMaxByLocation: { center_torso: 21, left_torso: 14, right_torso: 14 },
+  internalByLocation: { center_torso: 11, left_torso: 7, right_torso: 7 },
+  internalMaxByLocation: { center_torso: 11, left_torso: 7, right_torso: 7 },
+};
+
+const EXPOSED_STRUCTURE: IAIStructureState = {
+  armorByLocation: { center_torso: 21, left_torso: 0, right_torso: 14 },
+  armorMaxByLocation: { center_torso: 21, left_torso: 14, right_torso: 14 },
+  internalByLocation: { center_torso: 11, left_torso: 3, right_torso: 7 },
+  internalMaxByLocation: { center_torso: 11, left_torso: 7, right_torso: 7 },
+};
+
+function ctx(overrides: Partial<IWeaponModeContext> = {}): IWeaponModeContext {
+  return {
+    distance: 5,
+    targetStructure: FRESH_STRUCTURE,
+    targetEvading: false,
+    heatHeadroom: 100,
+    ammoTurnsRemaining: Infinity,
+    ...overrides,
+  };
+}
+
+describe('AIWeaponModeSelector.selectWeaponMode', () => {
+  describe('LB-X cluster/slug', () => {
+    it('picks cluster against an armour-stripped target', () => {
+      const sel = selectWeaponMode(
+        lbxWeapon(),
+        ctx({ targetStructure: EXPOSED_STRUCTURE }),
+        true,
+      );
+      expect(sel.modeId).toBe('cluster');
+      expect(sel.effectiveDamage).toBe(6);
+    });
+
+    it('picks cluster against an evading target even when fresh', () => {
+      const sel = selectWeaponMode(
+        lbxWeapon(),
+        ctx({ targetStructure: FRESH_STRUCTURE, targetEvading: true }),
+        true,
+      );
+      expect(sel.modeId).toBe('cluster');
+    });
+
+    it('picks slug against a fresh fully-armoured target at short range', () => {
+      const sel = selectWeaponMode(
+        lbxWeapon(),
+        ctx({ targetStructure: FRESH_STRUCTURE, distance: 4 }),
+        true,
+      );
+      expect(sel.modeId).toBe('slug');
+      expect(sel.effectiveDamage).toBe(10);
+    });
+
+    it('picks cluster against a fresh target beyond short range', () => {
+      const sel = selectWeaponMode(
+        lbxWeapon(),
+        ctx({ targetStructure: FRESH_STRUCTURE, distance: 14 }),
+        true,
+      );
+      expect(sel.modeId).toBe('cluster');
+    });
+  });
+
+  describe('Ultra/Rotary rate of fire', () => {
+    it('picks the higher rate of fire when heat and ammo allow', () => {
+      const sel = selectWeaponMode(
+        ultraWeapon(),
+        ctx({ heatHeadroom: 100, ammoTurnsRemaining: 40 }),
+        true,
+      );
+      expect(sel.modeId).toBe('double');
+      expect(sel.effectiveDamage).toBe(10);
+    });
+
+    it('drops to single fire when the heat budget cannot absorb double', () => {
+      // Double mode generates 2 heat; only 1 point of headroom is left.
+      const sel = selectWeaponMode(
+        ultraWeapon(),
+        ctx({ heatHeadroom: 1, ammoTurnsRemaining: 40 }),
+        true,
+      );
+      expect(sel.modeId).toBe('single');
+      expect(sel.effectiveHeat).toBe(1);
+    });
+
+    it('drops to single fire when the ammo runway is short', () => {
+      // Only 4 rounds left — double fire (2/turn) leaves a 2-turn runway,
+      // below the rate-of-fire ammo floor.
+      const sel = selectWeaponMode(
+        ultraWeapon(),
+        ctx({ heatHeadroom: 100, ammoTurnsRemaining: 4 }),
+        true,
+      );
+      expect(sel.modeId).toBe('single');
+    });
+  });
+
+  describe('single-mode weapon passes through unchanged', () => {
+    it('a weapon with no firingModes returns its default mode', () => {
+      const sel = selectWeaponMode(singleModeWeapon(), ctx(), true);
+      expect(sel.modeId).toBe('default');
+      expect(sel.effectiveDamage).toBe(5);
+      expect(sel.effectiveHeat).toBe(3);
+    });
+
+    it('mode selection disabled forces the default mode on a multi-mode weapon', () => {
+      // weaponModeSelection = false (the Green/Regular inert path).
+      const sel = selectWeaponMode(
+        lbxWeapon(),
+        ctx({ targetStructure: EXPOSED_STRUCTURE }),
+        false,
+      );
+      // Default LB-X mode is slug — even against an exposed target the
+      // selector is bypassed entirely.
+      expect(sel.modeId).toBe('slug');
+    });
+
+    it('the declared mode matches default-mode behavior when disabled', () => {
+      const enabledFresh = selectWeaponMode(
+        lbxWeapon(),
+        ctx({ targetStructure: FRESH_STRUCTURE, distance: 4 }),
+        true,
+      );
+      const disabled = selectWeaponMode(
+        lbxWeapon(),
+        ctx({ targetStructure: FRESH_STRUCTURE, distance: 4 }),
+        false,
+      );
+      // Against a fresh short-range target both pick slug — the default.
+      expect(enabledFresh.modeId).toBe(disabled.modeId);
+    });
+  });
+
+  describe('determinism — pure function of its arguments', () => {
+    it('repeated calls with identical arguments are identical', () => {
+      const a = selectWeaponMode(ultraWeapon(), ctx(), true);
+      const b = selectWeaponMode(ultraWeapon(), ctx(), true);
+      expect(a).toEqual(b);
+    });
+  });
+});

--- a/src/simulation/ai/AIAmmoRunway.ts
+++ b/src/simulation/ai/AIAmmoRunway.ts
@@ -1,0 +1,163 @@
+/**
+ * AI Ammo Runway — turns-of-fire projection.
+ *
+ * Per `add-ai-resource-planning` design D2: the legacy bot's ammo model is
+ * binary — a weapon with `ammo[weaponId] <= 0` is culled, but a weapon with
+ * two shots left is treated exactly like one with forty. The bot empties an
+ * autocannon early and is left with a dead-weight ton of nothing.
+ *
+ * `projectAmmoRunway` estimates, per ammo-dependent weapon, how many turns of
+ * fire the remaining ammo supports at the bot's expected per-turn fire rate,
+ * and derives a **conservation weight** in `[0, 1]`. When runway is short the
+ * weight drops so the weapon's selection priority falls and the bot saves it
+ * for a higher-value shot. When runway is long the weight is neutral (`1`).
+ * Energy weapons report an infinite runway and a neutral weight.
+ *
+ * The binary "0 ammo = culled" rule is unchanged — runway only modulates
+ * *priority*, never *eligibility*. This module is a pure deterministic
+ * function of weapon/ammo state — it never consumes `SeededRandom`.
+ *
+ * @spec openspec/changes/add-ai-resource-planning/specs/simulation-system/spec.md
+ *   Requirement: Ammo-Runway Projection
+ */
+
+import type { IWeapon } from './types';
+
+/**
+ * Runway below which a weapon is considered scarce — at or under this many
+ * turns of fire the conservation weight starts dropping below neutral.
+ *
+ * Three turns is the design "few turns of fire remaining" threshold: a
+ * weapon that can fire only three more times is rationed; one with four or
+ * more turns of fire is treated as abundant and left neutral.
+ */
+export const SCARCE_RUNWAY_TURNS = 3;
+
+/**
+ * The conservation weight floor — the lowest priority multiplier a very
+ * scarce weapon receives. A nearly-empty weapon is still eligible to fire
+ * (the binary cull is untouched) but its selection priority is multiplied
+ * down to this fraction, so the bot prefers an equivalent energy weapon and
+ * holds the scarce shot for a high-value opportunity.
+ */
+export const MIN_CONSERVATION_WEIGHT = 0.25;
+
+/** Per-weapon runway projection result. */
+export interface IAmmoRunway {
+  /** The weapon this runway is for. */
+  readonly weaponId: string;
+  /**
+   * Estimated turns of fire the remaining ammo supports, or `Infinity` for
+   * an energy weapon with no ammo dependency.
+   */
+  readonly turnsRemaining: number;
+  /**
+   * Conservation multiplier in `[0, 1]` applied to the weapon's selection
+   * priority. `1` is neutral (abundant ammo / energy weapon); values below
+   * `1` ration a scarce weapon. Never reaches `0` — a scarce weapon stays
+   * eligible.
+   */
+  readonly conservationWeight: number;
+}
+
+/**
+ * True when a weapon draws on ammo. Mirrors the `AttackAI.selectWeapons`
+ * eligibility check: `ammoPerTon > 0` marks an ammo-dependent weapon;
+ * `ammoPerTon === -1` (or `0`) marks an energy weapon.
+ */
+function isAmmoDependent(weapon: IWeapon): boolean {
+  return weapon.ammoPerTon > 0;
+}
+
+/**
+ * Compute the runway for a single weapon given the remaining ammo count and
+ * the expected number of shots the weapon consumes per turn.
+ *
+ * Energy weapons (`ammoPerTon <= 0`) short-circuit to an infinite runway and
+ * a neutral weight. For ammo-dependent weapons, `turnsRemaining` is the
+ * remaining ammo divided by the per-turn fire rate (floored — a partial
+ * turn of fire is not a full turn). The conservation weight ramps linearly
+ * from `MIN_CONSERVATION_WEIGHT` at zero runway up to `1` at
+ * `SCARCE_RUNWAY_TURNS` turns, and stays `1` beyond that.
+ *
+ * @param weapon         the weapon to project
+ * @param ammoRemaining  rounds of ammo available to this weapon; when
+ *                       `undefined` the weapon's ammo is unknown and treated
+ *                       as abundant (neutral weight) — matching the legacy
+ *                       `selectWeapons` behavior where an absent ammo entry
+ *                       does not cull the weapon
+ * @param shotsPerTurn   expected rounds the weapon fires each turn; defaults
+ *                       to `1` (one shot per weapon per turn). Rate-of-fire
+ *                       weapons firing in a higher mode pass a larger value.
+ */
+export function computeAmmoRunway(
+  weapon: IWeapon,
+  ammoRemaining: number | undefined,
+  shotsPerTurn = 1,
+): IAmmoRunway {
+  // Energy weapons never run dry — infinite runway, neutral weight.
+  if (!isAmmoDependent(weapon)) {
+    return {
+      weaponId: weapon.id,
+      turnsRemaining: Infinity,
+      conservationWeight: 1,
+    };
+  }
+
+  // Unknown ammo count — treat as abundant so we never ration a weapon the
+  // caller has not supplied data for. This keeps legacy `IAIUnitState`
+  // fixtures (empty `ammo` map) neutral.
+  if (ammoRemaining === undefined) {
+    return {
+      weaponId: weapon.id,
+      turnsRemaining: Infinity,
+      conservationWeight: 1,
+    };
+  }
+
+  const rate = Math.max(1, shotsPerTurn);
+  const turnsRemaining = Math.max(0, Math.floor(ammoRemaining / rate));
+
+  // Linear ramp: 0 turns -> MIN_CONSERVATION_WEIGHT, SCARCE_RUNWAY_TURNS
+  // turns -> 1, clamped to [MIN_CONSERVATION_WEIGHT, 1] beyond either end.
+  let conservationWeight: number;
+  if (turnsRemaining >= SCARCE_RUNWAY_TURNS) {
+    conservationWeight = 1;
+  } else {
+    const t = turnsRemaining / SCARCE_RUNWAY_TURNS;
+    conservationWeight =
+      MIN_CONSERVATION_WEIGHT + (1 - MIN_CONSERVATION_WEIGHT) * t;
+  }
+
+  return { weaponId: weapon.id, turnsRemaining, conservationWeight };
+}
+
+/**
+ * Project the ammo runway for every weapon in a fire list.
+ *
+ * Returns one `IAmmoRunway` per input weapon, keyed by `weaponId`. The
+ * `conservationWeight` of each entry is what `AttackAI` multiplies into the
+ * weapon's selection priority — energy weapons and abundant-ammo weapons
+ * pass through neutral; scarce weapons drop.
+ *
+ * Pure and deterministic.
+ *
+ * @param weapons     the candidate fire list
+ * @param ammoByWeaponId  remaining ammo keyed by weapon id (the
+ *                        `IAIUnitState.ammo` map)
+ * @param shotsPerTurnByWeaponId  optional per-weapon expected shots per turn;
+ *                                weapons absent from the map default to `1`
+ */
+export function projectAmmoRunway(
+  weapons: readonly IWeapon[],
+  ammoByWeaponId: Readonly<Record<string, number>>,
+  shotsPerTurnByWeaponId?: Readonly<Record<string, number>>,
+): readonly IAmmoRunway[] {
+  return weapons.map((weapon) =>
+    computeAmmoRunway(
+      weapon,
+      ammoByWeaponId[weapon.id],
+      shotsPerTurnByWeaponId?.[weapon.id] ?? 1,
+    ),
+  );
+}

--- a/src/simulation/ai/AIHeatPlanner.ts
+++ b/src/simulation/ai/AIHeatPlanner.ts
@@ -1,0 +1,222 @@
+/**
+ * AI Heat Planner — multi-turn heat projection.
+ *
+ * Per `add-ai-resource-planning` design D1: the legacy bot's heat model is
+ * one turn deep — `AttackAI.applyHeatBudget` trims the fire list so projected
+ * heat fits `safeHeatThreshold` for the *current* turn and stops there. It
+ * cannot see that two more turns of the same fire list shut the unit down.
+ *
+ * `projectHeat` projects the unit's heat curve across a configurable
+ * lookahead window, assuming the candidate fire list repeats each turn, and
+ * reports the first turn (if any) at which projected heat crosses the
+ * shutdown-risk ceiling. `AttackAI` consults the planner: if a shutdown is
+ * predicted inside the window, the effective heat budget is lowered so the
+ * curve flattens. The single-turn `applyHeatBudget` stays as the inner trim;
+ * the planner wraps it with a forward-looking ceiling.
+ *
+ * This module is a pure deterministic function of numeric heat state — it
+ * never consumes `SeededRandom`, so SimulationRunner seed sequences stay
+ * stable (design D6).
+ *
+ * @spec openspec/changes/add-ai-resource-planning/specs/simulation-system/spec.md
+ *   Requirement: Multi-Turn Heat Projection
+ */
+
+/**
+ * The shutdown-risk ceiling, in BattleTech heat points.
+ *
+ * Per the canonical heat scale, automatic-shutdown rolls begin at heat 14
+ * (heat 14: shutdown on 4+, climbing to an automatic shutdown at 30). The
+ * planner treats 14 as the ceiling the projected curve must not cross — the
+ * point at which the unit is at material risk of being taken out of the
+ * fight by its own heat. This is intentionally distinct from
+ * `IBotBehavior.safeHeatThreshold` (default 13, the +1-to-hit penalty
+ * threshold the single-turn trim targets): the planner guards against
+ * *shutdown*, the single-turn trim guards against *to-hit penalties*.
+ */
+export const SHUTDOWN_RISK_HEAT = 14;
+
+/**
+ * The result of a multi-turn heat projection.
+ */
+export interface IHeatProjection {
+  /**
+   * Projected heat at the end of each turn in the lookahead window. Index
+   * `0` is the end of the first projected turn. The array length equals the
+   * `lookaheadTurns` argument (empty when `lookaheadTurns <= 0`).
+   */
+  readonly perTurnHeat: readonly number[];
+  /**
+   * First turn index (0-based, into `perTurnHeat`) at which a shutdown risk
+   * is predicted — projected heat at or above `SHUTDOWN_RISK_HEAT` — or `-1`
+   * when the candidate fire list is sustainable across the whole window.
+   */
+  readonly shutdownRiskTurn: number;
+}
+
+/** An empty projection — returned when projection is disabled or skipped. */
+const EMPTY_PROJECTION: IHeatProjection = {
+  perTurnHeat: [],
+  shutdownRiskTurn: -1,
+};
+
+/**
+ * Project a unit's heat curve across a lookahead window.
+ *
+ * The projection assumes the candidate fire list (and movement) repeats each
+ * turn: every turn adds `perTurnHeatGenerated` and removes `dissipation`,
+ * starting from `currentHeat`. Heat is floored at `0` — a unit cannot carry
+ * negative heat. The first turn projected heat reaches `SHUTDOWN_RISK_HEAT`
+ * is reported as `shutdownRiskTurn`.
+ *
+ * Pure and deterministic — a function of its numeric arguments only.
+ *
+ * @param currentHeat          the unit's heat right now (before this turn)
+ * @param dissipation          heat sinks' per-turn dissipation capacity
+ * @param perTurnHeatGenerated heat the candidate fire list + movement adds
+ *                             each turn
+ * @param lookaheadTurns       how many turns to project; `<= 0` disables
+ *                             projection and returns an empty result
+ */
+export function projectHeat(
+  currentHeat: number,
+  dissipation: number,
+  perTurnHeatGenerated: number,
+  lookaheadTurns: number,
+): IHeatProjection {
+  // `lookaheadTurns <= 0` is the `Green`/`Regular` inert path — projection
+  // is skipped entirely and the caller falls back to the single-turn trim.
+  if (lookaheadTurns <= 0) {
+    return EMPTY_PROJECTION;
+  }
+
+  const perTurnHeat: number[] = [];
+  let shutdownRiskTurn = -1;
+
+  // Walk the window turn by turn. Each turn applies the net heat delta
+  // (generated minus dissipated) and floors the result at zero — a unit's
+  // heat track does not go negative.
+  let heat = Math.max(0, currentHeat);
+  for (let turn = 0; turn < lookaheadTurns; turn++) {
+    heat = Math.max(0, heat + perTurnHeatGenerated - dissipation);
+    perTurnHeat.push(heat);
+    if (shutdownRiskTurn === -1 && heat >= SHUTDOWN_RISK_HEAT) {
+      shutdownRiskTurn = turn;
+    }
+  }
+
+  return { perTurnHeat, shutdownRiskTurn };
+}
+
+/**
+ * Compute the effective heat budget `AttackAI` should pass to the single-turn
+ * `applyHeatBudget` trim, given a multi-turn projection.
+ *
+ * When the projection predicts a shutdown inside the window, the budget is
+ * lowered toward a *sustainable* ceiling — the heat level at which the next
+ * turn's fired heat no longer exceeds dissipation, so the curve flattens
+ * instead of climbing. The proximity of the predicted shutdown blends the
+ * two: an imminent (next-turn) shutdown pulls the budget all the way to the
+ * sustainable ceiling; a distant one only nudges it part-way, because the
+ * per-turn `applyHeatBudget` re-trim has more turns to correct the curve.
+ *
+ * The single-turn `applyHeatBudget` keeps `currentHeat + movementHeat +
+ * firedHeat <= budget`. The sustainable ceiling is therefore
+ * `currentHeat + movementHeat + dissipation` — at that budget the fired
+ * heat cannot exceed what the unit sheds each turn, and the curve is flat.
+ *
+ * When no shutdown is predicted, the original budget passes through
+ * unchanged. The budget is never lowered below zero or below the heat
+ * already on the track.
+ *
+ * Pure and deterministic.
+ *
+ * @param baseBudget   the single-turn `safeHeatThreshold` the caller would
+ *                     otherwise use
+ * @param projection   the result of `projectHeat`
+ * @param currentHeat  the unit's heat right now — sets the floor so the
+ *                     budget is never trimmed below what is already on the
+ *                     track
+ * @param dissipation  the unit's per-turn heat dissipation — defines the
+ *                     sustainable ceiling the budget is pulled toward
+ * @param movementHeat heat already committed to movement this turn — folds
+ *                     into the sustainable ceiling so the single-turn trim's
+ *                     accounting lines up
+ */
+export function effectiveHeatBudget(
+  baseBudget: number,
+  projection: IHeatProjection,
+  currentHeat: number,
+  dissipation = 0,
+  movementHeat = 0,
+): number {
+  // No predicted shutdown — the single-turn trim is sufficient.
+  if (projection.shutdownRiskTurn < 0) {
+    return baseBudget;
+  }
+
+  const floor = Math.max(0, currentHeat);
+
+  // The sustainable ceiling: a budget at or below which the single-turn
+  // trim leaves `firedHeat <= dissipation`, so the multi-turn curve is flat.
+  const sustainableBudget = Math.max(
+    floor,
+    currentHeat + movementHeat + dissipation,
+  );
+
+  // If the base budget is already sustainable there is nothing to do — the
+  // shutdown was predicted from a fire list the single-turn trim will cull
+  // on its own.
+  if (baseBudget <= sustainableBudget) {
+    return baseBudget;
+  }
+
+  // Blend between the base budget (distant risk) and the sustainable ceiling
+  // (imminent risk). `proximityScale` is 1 for a next-turn shutdown and
+  // shrinks each turn the shutdown is further out.
+  const riskTurn = projection.shutdownRiskTurn;
+  const proximityScale = 1 / (riskTurn + 1);
+  const blended =
+    baseBudget - proximityScale * (baseBudget - sustainableBudget);
+
+  return Math.max(floor, blended);
+}
+
+/**
+ * Compute the effective single-turn heat budget for an attack, applying the
+ * A2 multi-turn projection in one call.
+ *
+ * When `lookaheadTurns` is `0` the base budget passes through unchanged (the
+ * `Green`/`Regular` inert path). Otherwise the heat curve is projected
+ * assuming the candidate fire list repeats each turn, and the budget is
+ * lowered via `effectiveHeatBudget` if a shutdown is predicted in the window.
+ *
+ * This is the high-level entry point `AttackAI` / `BotPlayer` calls — it
+ * folds `projectHeat` + `effectiveHeatBudget` into a single deterministic
+ * function so callers do not re-implement the two-step dance.
+ */
+export function planEffectiveThreshold(
+  baseBudget: number,
+  currentHeat: number,
+  dissipation: number,
+  perTurnHeatGenerated: number,
+  movementHeat: number,
+  lookaheadTurns: number,
+): number {
+  if (lookaheadTurns <= 0) {
+    return baseBudget;
+  }
+  const projection = projectHeat(
+    currentHeat,
+    dissipation,
+    perTurnHeatGenerated,
+    lookaheadTurns,
+  );
+  return effectiveHeatBudget(
+    baseBudget,
+    projection,
+    currentHeat,
+    dissipation,
+    movementHeat,
+  );
+}

--- a/src/simulation/ai/AIPlayerEvents.ts
+++ b/src/simulation/ai/AIPlayerEvents.ts
@@ -20,6 +20,15 @@ export interface IAttackEvent {
     attackerId: string;
     targetId: string;
     weapons: readonly string[];
+    /**
+     * Per `add-ai-resource-planning` (A2) design D4: the firing mode the bot
+     * selected for each declared weapon, keyed by weapon id. Present only
+     * when the bot's tier enables `weaponModeSelection` and at least one
+     * declared weapon is multi-mode; absent (and the combat engine resolves
+     * default modes) for the `Green`/`Regular` tiers and single-mode-only
+     * fire lists — byte-identical to pre-A2 behavior.
+     */
+    weaponModes?: Readonly<Record<string, string>>;
   };
 }
 

--- a/src/simulation/ai/AITierRegistry.ts
+++ b/src/simulation/ai/AITierRegistry.ts
@@ -48,17 +48,62 @@ export interface IAITierMovementParameters {
 }
 
 /**
+ * Resource-planning parameter block — the A2 contribution to a tier's
+ * parameter set (`add-ai-resource-planning` design D5).
+ *
+ *   - `heatLookaheadTurns`: how many turns ahead `AIHeatPlanner.projectHeat`
+ *     projects the heat curve. `0` disables multi-turn projection entirely —
+ *     the bot falls back to the single-turn `applyHeatBudget` trim only, so
+ *     `Green`/`Regular` reproduce pre-change behavior byte-for-byte.
+ *   - `ammoConservationWeight`: scales how aggressively a short ammo runway
+ *     drops a weapon's selection priority. `0` disables runway weighting —
+ *     ammo remains a binary eligibility gate, never a priority modulator.
+ *   - `critSeekingWeight`: multiplier on the additive crit-seeking term in
+ *     `scoreTarget`. `0` disables crit-seeking — `scoreTarget` returns the
+ *     pre-change `threat * killProbability` value exactly.
+ *   - `weaponModeSelection`: when `false`, every multi-mode weapon fires its
+ *     default mode and `AIWeaponModeSelector` is never consulted. When
+ *     `true`, the selector picks the expected-damage-maximizing mode.
+ */
+export interface IAITierResourceParameters {
+  readonly heatLookaheadTurns: number;
+  readonly ammoConservationWeight: number;
+  readonly critSeekingWeight: number;
+  readonly weaponModeSelection: boolean;
+}
+
+/**
  * Full parameter set for one difficulty tier.
  *
- * Open by design: A1 defines `tier` and `movement`. Later Wave 2 changes ADD
- * their own optional blocks (`resource?`, `coordination?`, `objective?`,
- * `advanced?`) without touching the fields declared here.
+ * Open by design: A1 defines `tier` and `movement`. A2 ADDs the optional
+ * `resource` block below. Later Wave 2 changes ADD their own optional blocks
+ * (`coordination?`, `objective?`, `advanced?`) without touching the fields
+ * declared here.
  */
 export interface IAITierParameters {
   readonly tier: AITierName;
   readonly movement: IAITierMovementParameters;
-  // A2..A4 ADD: resource?, coordination?, objective?, advanced? blocks.
+  /**
+   * A2 resource-planning block. Optional so a tier record built before A2
+   * (or a hand-rolled test fixture) still type-checks; every entry in
+   * `AI_TIER_REGISTRY` populates it. Resolve it through
+   * `resolveResourceParameters` to get the inert default when absent.
+   */
+  readonly resource?: IAITierResourceParameters;
+  // A3..A4 ADD: coordination?, objective?, advanced? blocks.
 }
+
+/**
+ * The inert resource block — every A2 behavior disabled. Used by
+ * `resolveResourceParameters` when a tier record predates A2 and as the
+ * literal value `Green`/`Regular` carry so the legacy bot is unchanged.
+ */
+export const INERT_RESOURCE_PARAMETERS: IAITierResourceParameters = {
+  heatLookaheadTurns: 0,
+  ammoConservationWeight: 0,
+  critSeekingWeight: 0,
+  weaponModeSelection: false,
+};
 
 /**
  * The frozen tier table.
@@ -91,6 +136,14 @@ export const AI_TIER_REGISTRY: Readonly<Record<AITierName, IAITierParameters>> =
         losDenialWeight: 0,
         terrainCostWeight: 0,
       },
+      // A2: fully inert — the legacy bot's single-turn heat trim, binary
+      // ammo gate, threat-only target score, and default weapon modes.
+      resource: {
+        heatLookaheadTurns: 0,
+        ammoConservationWeight: 0,
+        critSeekingWeight: 0,
+        weaponModeSelection: false,
+      },
     },
     Regular: {
       tier: 'Regular',
@@ -99,6 +152,14 @@ export const AI_TIER_REGISTRY: Readonly<Record<AITierName, IAITierParameters>> =
         coverWeight: 0,
         losDenialWeight: 0,
         terrainCostWeight: 0,
+      },
+      // A2: fully inert — see `Green`. The determinism golden traces are
+      // pinned to this tier, so every A2 weight must stay zero here.
+      resource: {
+        heatLookaheadTurns: 0,
+        ammoConservationWeight: 0,
+        critSeekingWeight: 0,
+        weaponModeSelection: false,
       },
     },
     Veteran: {
@@ -109,6 +170,18 @@ export const AI_TIER_REGISTRY: Readonly<Record<AITierName, IAITierParameters>> =
         losDenialWeight: 400,
         terrainCostWeight: 40,
       },
+      // A2: resource planning active. `heatLookaheadTurns: 3` (design open
+      // question — long enough to catch a building curve, short enough to
+      // stay relevant). Conservation and crit-seeking weights are tuned to
+      // `scoreTarget`'s scale (threat * killProbability is typically
+      // O(1-50)); a crit-seeking weight of `8` makes a fully-exposed target
+      // competitive without overruling a much larger threat.
+      resource: {
+        heatLookaheadTurns: 3,
+        ammoConservationWeight: 0.6,
+        critSeekingWeight: 8,
+        weaponModeSelection: true,
+      },
     },
     Elite: {
       tier: 'Elite',
@@ -117,6 +190,15 @@ export const AI_TIER_REGISTRY: Readonly<Record<AITierName, IAITierParameters>> =
         coverWeight: 450,
         losDenialWeight: 600,
         terrainCostWeight: 60,
+      },
+      // A2: resource planning active, weighted at least as heavily as
+      // `Veteran` — `Elite` looks one turn further ahead, rations ammo and
+      // hunts crits more aggressively.
+      resource: {
+        heatLookaheadTurns: 4,
+        ammoConservationWeight: 0.8,
+        critSeekingWeight: 12,
+        weaponModeSelection: true,
       },
     },
   };
@@ -159,4 +241,21 @@ export function resolveTierParameters(
   name: AITierName | undefined,
 ): IAITierParameters {
   return getTierParameters(name ?? DEFAULT_TIER_NAME);
+}
+
+/**
+ * Resolve the A2 resource-planning block for a tier parameter record,
+ * falling back to `INERT_RESOURCE_PARAMETERS` when the record predates A2
+ * (the optional `resource` field is absent).
+ *
+ * Used by `AttackAI` so a hand-rolled `IAITierParameters` fixture without a
+ * `resource` block resolves to fully-inert resource planning — the legacy
+ * bot behavior — rather than throwing on an undefined access. Every entry in
+ * `AI_TIER_REGISTRY` populates `resource`, so production callers always get
+ * the real tier values.
+ */
+export function resolveResourceParameters(
+  params: IAITierParameters,
+): IAITierResourceParameters {
+  return params.resource ?? INERT_RESOURCE_PARAMETERS;
 }

--- a/src/simulation/ai/AIWeaponModeSelector.ts
+++ b/src/simulation/ai/AIWeaponModeSelector.ts
@@ -1,0 +1,283 @@
+/**
+ * AI Weapon-Mode Selector — multi-mode weapon mode choice.
+ *
+ * Per `add-ai-resource-planning` design D4: multi-mode weapons (LB-X
+ * cluster/slug, Ultra/Rotary rate-of-fire) always fire their default mode in
+ * the legacy bot. This selector picks the mode that maximizes *expected
+ * damage* given range, the target's armour state, and the remaining heat
+ * budget.
+ *
+ *   - **LB-X** — cluster mode against an armour-stripped or fast/evading
+ *     target (cluster hits spread and crit-seek); slug mode against a fresh,
+ *     fully-armoured target at short range.
+ *   - **Ultra / Rotary** — the higher rate of fire when the heat budget and
+ *     ammo runway both allow; the lower rate when heat or ammo is
+ *     constrained.
+ *
+ * A weapon WITHOUT `firingModes` metadata is single-mode — the selector
+ * returns its default mode unchanged (byte-identical to "always default
+ * mode" for legacy fixtures). The selected mode is recorded on the declared
+ * attack so the combat engine resolves the chosen mode.
+ *
+ * Pure and deterministic — never consumes `SeededRandom` (design D6).
+ *
+ * @spec openspec/changes/add-ai-resource-planning/specs/simulation-system/spec.md
+ *   Requirement: Multi-Mode Weapon Selection
+ */
+
+import type { IAIStructureState, IWeapon, IWeaponFiringMode } from './types';
+
+/** Mode-id constants for the LB-X cluster/slug family. */
+export const LBX_CLUSTER_MODE_ID = 'cluster';
+export const LBX_SLUG_MODE_ID = 'slug';
+
+/**
+ * The result of a weapon-mode selection: which mode was chosen and the
+ * effective per-turn damage/heat/ammo cost of that mode. `AttackAI` records
+ * `modeId` on the declared attack and uses `effectiveHeat` / `effectiveShots`
+ * for downstream heat and ammo accounting.
+ */
+export interface IWeaponModeSelection {
+  /** The weapon the selection is for. */
+  readonly weaponId: string;
+  /** The selected mode's id (the default mode id for single-mode weapons). */
+  readonly modeId: string;
+  /** Damage the selected mode deals per turn. */
+  readonly effectiveDamage: number;
+  /** Heat the selected mode generates per turn. */
+  readonly effectiveHeat: number;
+  /** Ammo rounds the selected mode consumes per turn. */
+  readonly effectiveShots: number;
+}
+
+/**
+ * Context the selector needs to weigh modes: the engagement range and the
+ * target's structural state plus the heat budget the attacker has left.
+ */
+export interface IWeaponModeContext {
+  /** Hex distance to the target. */
+  readonly distance: number;
+  /** The target's armour / structure snapshot, if known. */
+  readonly targetStructure?: IAIStructureState;
+  /** Whether the target is actively evading (ran / jumped this turn). */
+  readonly targetEvading?: boolean;
+  /**
+   * Heat headroom the attacker has left this turn — `safeHeatThreshold`
+   * minus heat already committed (movement + weapons chosen so far). A mode
+   * whose heat exceeds this headroom is treated as over-budget.
+   */
+  readonly heatHeadroom: number;
+  /**
+   * Estimated turns of fire remaining for this weapon (from `AIAmmoRunway`).
+   * A short runway discourages the higher-rate-of-fire mode. `Infinity` for
+   * an energy weapon or an unknown ammo count.
+   */
+  readonly ammoTurnsRemaining: number;
+}
+
+/**
+ * The runway, in turns, below which a rate-of-fire weapon avoids its
+ * highest-consumption mode — burning two rounds a turn out of a four-turn
+ * runway halves the runway, so the bot drops to single fire to ration it.
+ */
+const RATE_OF_FIRE_AMMO_FLOOR = 3;
+
+/**
+ * Build the single-mode pass-through selection for a weapon. Used for
+ * weapons with no `firingModes` metadata and for the default mode lookup.
+ */
+function singleModeSelection(weapon: IWeapon): IWeaponModeSelection {
+  return {
+    weaponId: weapon.id,
+    modeId: 'default',
+    effectiveDamage: weapon.damage,
+    effectiveHeat: weapon.heat,
+    // Energy weapons consume no ammo; ammo-dependent weapons fire one round.
+    effectiveShots: weapon.ammoPerTon > 0 ? 1 : 0,
+  };
+}
+
+/** Project an `IWeaponFiringMode` into an `IWeaponModeSelection`. */
+function modeToSelection(
+  weapon: IWeapon,
+  mode: IWeaponFiringMode,
+): IWeaponModeSelection {
+  return {
+    weaponId: weapon.id,
+    modeId: mode.id,
+    effectiveDamage: mode.damage,
+    effectiveHeat: mode.heat,
+    effectiveShots: mode.shotsPerTurn,
+  };
+}
+
+/**
+ * True when the target is "exposed" — any location has stripped armour
+ * (armour at zero) or prior internal damage. Cluster fire's spread is worth
+ * more against an exposed target because individual cluster hits can reach
+ * open internal structure and seek a crit.
+ */
+function isTargetExposed(structure: IAIStructureState | undefined): boolean {
+  if (!structure) return false;
+  for (const [loc, armorMax] of Object.entries(structure.armorMaxByLocation)) {
+    if (armorMax > 0 && (structure.armorByLocation[loc] ?? armorMax) <= 0) {
+      return true;
+    }
+  }
+  for (const [loc, internalMax] of Object.entries(
+    structure.internalMaxByLocation,
+  )) {
+    if (
+      internalMax > 0 &&
+      (structure.internalByLocation[loc] ?? internalMax) < internalMax
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Pick the firing mode for the LB-X cluster/slug family.
+ *
+ * Cluster mode is chosen when the target is exposed (stripped armour / prior
+ * internal damage) or evading — its spread reliably lands hits and seeks
+ * crits on an opened unit, and lands *some* damage on a hard-to-hit target.
+ * Slug mode is chosen against a fresh, fully-armoured, stationary target at
+ * short range — a focused slug punches a single deep wound to start cracking
+ * armour. Beyond short range slug accuracy falls off, so cluster is
+ * preferred there too.
+ */
+function selectClusterSlugMode(
+  weapon: IWeapon,
+  cluster: IWeaponFiringMode,
+  slug: IWeaponFiringMode,
+  ctx: IWeaponModeContext,
+): IWeaponFiringMode {
+  const exposed = isTargetExposed(ctx.targetStructure);
+  const evading = ctx.targetEvading === true;
+  // Cluster against an opened or evading target.
+  if (exposed || evading) return cluster;
+  // Slug against a fresh target only at short range — `weapon.shortRange`
+  // bounds the slug's reliable bracket.
+  if (ctx.distance <= weapon.shortRange) return slug;
+  // Beyond short range against a fresh target — cluster's spread beats a
+  // long slug shot.
+  return cluster;
+}
+
+/**
+ * Pick the firing mode for the Ultra / Rotary rate-of-fire family.
+ *
+ * The modes are ranked by `shotsPerTurn` ascending — index `0` is the
+ * lowest-consumption mode, the last index the highest. The selector walks
+ * from the highest mode down and returns the first whose heat fits the
+ * remaining heat headroom AND whose ammo consumption leaves the runway above
+ * `RATE_OF_FIRE_AMMO_FLOOR`. If no higher mode qualifies, it falls back to
+ * the lowest-consumption mode — single fire under heat or ammo pressure.
+ */
+function selectRateOfFireMode(
+  modes: readonly IWeaponFiringMode[],
+  ctx: IWeaponModeContext,
+): IWeaponFiringMode {
+  const ranked = [...modes].sort((a, b) => a.shotsPerTurn - b.shotsPerTurn);
+  for (let i = ranked.length - 1; i >= 1; i--) {
+    const mode = ranked[i];
+    const heatFits = mode.heat <= ctx.heatHeadroom;
+    // Firing `shotsPerTurn` rounds a turn must leave a runway above the
+    // floor — `Infinity` ammo (unknown / energy) always passes.
+    const runwayAfter =
+      ctx.ammoTurnsRemaining === Infinity
+        ? Infinity
+        : Math.floor(ctx.ammoTurnsRemaining / Math.max(1, mode.shotsPerTurn));
+    const ammoFits = runwayAfter > RATE_OF_FIRE_AMMO_FLOOR;
+    if (heatFits && ammoFits) return mode;
+  }
+  // Heat or ammo constrained — drop to the lowest-consumption (single) mode.
+  return ranked[0];
+}
+
+/**
+ * Select the firing mode for one weapon.
+ *
+ * When `weaponModeSelection` is disabled (or the weapon has no `firingModes`
+ * metadata), the weapon's default mode is returned — single-mode
+ * pass-through. Otherwise the mode-kind heuristic picks the
+ * expected-damage-maximizing mode.
+ *
+ * @param weapon  the weapon to select a mode for
+ * @param ctx     range / target / heat / ammo context
+ * @param enabled the tier's `weaponModeSelection` flag — `false` forces the
+ *                default mode (the `Green`/`Regular` inert path)
+ */
+export function selectWeaponMode(
+  weapon: IWeapon,
+  ctx: IWeaponModeContext,
+  enabled: boolean,
+): IWeaponModeSelection {
+  const modes = weapon.firingModes;
+
+  // Single-mode weapon, or mode selection disabled by tier — pass through
+  // the default mode unchanged. For a metadata-bearing weapon we still
+  // resolve the default mode so the engine gets the right numbers; for a
+  // metadata-free weapon we fall back to the weapon's base stats.
+  if (!modes || modes.modes.length === 0) {
+    return singleModeSelection(weapon);
+  }
+
+  const defaultMode =
+    modes.modes.find((m) => m.id === modes.defaultModeId) ?? modes.modes[0];
+
+  if (!enabled) {
+    return modeToSelection(weapon, defaultMode);
+  }
+
+  if (modes.kind === 'cluster-slug') {
+    const cluster =
+      modes.modes.find((m) => m.id === LBX_CLUSTER_MODE_ID) ?? modes.modes[0];
+    const slug =
+      modes.modes.find((m) => m.id === LBX_SLUG_MODE_ID) ??
+      modes.modes[modes.modes.length - 1];
+    return modeToSelection(
+      weapon,
+      selectClusterSlugMode(weapon, cluster, slug, ctx),
+    );
+  }
+
+  // 'rate-of-fire'
+  return modeToSelection(weapon, selectRateOfFireMode(modes.modes, ctx));
+}
+
+/**
+ * Per `add-ai-resource-planning` (A2) design D4: build the `weaponModes` map
+ * recorded on a declared attack — the selected firing mode of every
+ * multi-mode weapon that survived the heat trim.
+ *
+ * Returns `undefined` when no surviving weapon is multi-mode, which is the
+ * pre-A2 attack-payload shape (byte-identical for the `Green`/`Regular`
+ * tiers and single-mode-only fire lists). Defined here, alongside the
+ * selector, so `BotPlayer` does not re-implement the mode-id bookkeeping.
+ *
+ * @param entries        the planned fire list — weapon + selected mode pairs
+ * @param survivingIds   ids of the weapons that survived the heat-budget trim
+ */
+export function collectWeaponModes(
+  entries: readonly {
+    readonly weapon: IWeapon;
+    readonly mode: IWeaponModeSelection;
+  }[],
+  survivingIds: readonly string[],
+): Readonly<Record<string, string>> | undefined {
+  const surviving = new Set(survivingIds);
+  const modes: Record<string, string> = {};
+  for (const entry of entries) {
+    if (
+      surviving.has(entry.weapon.id) &&
+      entry.weapon.firingModes &&
+      entry.mode.modeId !== 'default'
+    ) {
+      modes[entry.weapon.id] = entry.mode.modeId;
+    }
+  }
+  return Object.keys(modes).length > 0 ? modes : undefined;
+}

--- a/src/simulation/ai/AttackAI.ts
+++ b/src/simulation/ai/AttackAI.ts
@@ -7,7 +7,18 @@ import { determineArc } from '@/utils/gameplay/firingArcs';
 import { hexDistance } from '@/utils/gameplay/hexMath';
 
 import type { SeededRandom } from '../core/SeededRandom';
-import type { IAIUnitState, IWeapon } from './types';
+import type { IAIStructureState, IAIUnitState, IWeapon } from './types';
+
+import { computeAmmoRunway } from './AIAmmoRunway';
+import {
+  type IAITierResourceParameters,
+  INERT_RESOURCE_PARAMETERS,
+} from './AITierRegistry';
+import {
+  type IWeaponModeContext,
+  type IWeaponModeSelection,
+  selectWeaponMode,
+} from './AIWeaponModeSelector';
 
 /**
  * Per `improve-bot-basic-combat-competence` task 2: score a target
@@ -18,7 +29,7 @@ import type { IAIUnitState, IWeapon } from './types';
  *
  *   threat = totalWeaponDamagePerTurn * remainingHpFraction / max(gunnery, 1)
  *   killProbability = clamp(1 - (toHitTN / 12), 0, 1)
- *   score = threat * killProbability
+ *   score = threat * killProbability + critSeekingTerm
  *
  * `toHitTN` is estimated from the attacker's gunnery + a range modifier.
  * Firing-arc TN contribution is deferred to the weapon-selection step
@@ -28,11 +39,20 @@ import type { IAIUnitState, IWeapon } from './types';
  * yet supply per-unit HP totals — that preserves the legacy scoring
  * for test fixtures while letting real wiring opt in.
  *
- * Pure function — no state mutation.
+ * Per `add-ai-resource-planning` (A2) design D3: when `resource` carries a
+ * non-zero `critSeekingWeight`, an ADDITIVE crit-seeking term is added —
+ * proportional to the target's structural exposure (stripped armour, prior
+ * internal damage). When `resource` is omitted or its `critSeekingWeight`
+ * is `0` (the `Green`/`Regular` inert path, and every legacy caller),
+ * the crit-seeking term is exactly `0` and `scoreTarget` returns the
+ * pre-change `threat * killProbability` value byte-for-byte.
+ *
+ * Pure function — no state mutation, no `SeededRandom` consumption.
  */
 export function scoreTarget(
   attacker: IAIUnitState,
   target: IAIUnitState,
+  resource?: IAITierResourceParameters,
 ): number {
   if (target.destroyed || target.unitId === attacker.unitId) return 0;
 
@@ -57,7 +77,74 @@ export function scoreTarget(
   const tn = attacker.gunnery + rangeMod;
   const killProbability = clamp01(1 - tn / 12);
 
-  return threat * killProbability;
+  const baseScore = threat * killProbability;
+
+  // A2 crit-seeking term — additive, gated on `critSeekingWeight`. The
+  // exposure fraction is `0` for a fully-armoured target (or a target with
+  // no structure-state data), so a zero weight OR no exposure yields a zero
+  // term and the legacy score is reproduced exactly.
+  const critWeight = resource?.critSeekingWeight ?? 0;
+  if (critWeight <= 0) return baseScore;
+  const exposure = structuralExposure(target.structureState);
+  return baseScore + critWeight * exposure;
+}
+
+/**
+ * Per `add-ai-resource-planning` (A2) design D3: a target's structural
+ * exposure in `[0, 1]` — a measure of how reachable a crippling critical
+ * hit is.
+ *
+ * Two signals contribute:
+ *
+ *   - **Stripped armour** — the fraction of locations whose armour is at
+ *     zero. A stripped location takes every hit straight to internal
+ *     structure / the critical table.
+ *   - **Prior internal damage** — `1 - (internalRemaining / internalMax)`
+ *     summed across locations. An already-damaged internal structure is
+ *     close to a destroyed location.
+ *
+ * The two are averaged and clamped to `[0, 1]`. A fresh, fully-armoured
+ * target scores `0`; a target with an opened side torso scores high. A
+ * target with no `structureState` scores `0` — the crit-seeking term then
+ * contributes nothing, preserving legacy behavior.
+ *
+ * Pure function.
+ */
+export function structuralExposure(
+  structure: IAIStructureState | undefined,
+): number {
+  if (!structure) return 0;
+
+  const armorLocations = Object.entries(structure.armorMaxByLocation);
+  const internalLocations = Object.entries(structure.internalMaxByLocation);
+
+  // Stripped-armour signal — fraction of armoured locations now at zero.
+  let strippedCount = 0;
+  let armorLocationCount = 0;
+  for (const [loc, armorMax] of armorLocations) {
+    if (armorMax <= 0) continue;
+    armorLocationCount++;
+    const remaining = structure.armorByLocation[loc] ?? armorMax;
+    if (remaining <= 0) strippedCount++;
+  }
+  const strippedFraction =
+    armorLocationCount > 0 ? strippedCount / armorLocationCount : 0;
+
+  // Internal-damage signal — average fraction of internal structure lost.
+  let internalDamageSum = 0;
+  let internalLocationCount = 0;
+  for (const [loc, internalMax] of internalLocations) {
+    if (internalMax <= 0) continue;
+    internalLocationCount++;
+    const remaining = structure.internalByLocation[loc] ?? internalMax;
+    internalDamageSum += clamp01(1 - remaining / internalMax);
+  }
+  const internalDamageFraction =
+    internalLocationCount > 0 ? internalDamageSum / internalLocationCount : 0;
+
+  // Average the two signals — a target that is both stripped and internally
+  // damaged is maximally exposed.
+  return clamp01((strippedFraction + internalDamageFraction) / 2);
 }
 
 function clamp01(n: number): number {
@@ -245,11 +332,17 @@ export class AttackAI {
    * `attacker` is now required to compute the score; existing callers
    * with only `targets + random` still get the deterministic-tiebreak
    * behavior via the optional-attacker overload.
+   *
+   * Per `add-ai-resource-planning` (A2): `resource` threads the tier's
+   * resource block into `scoreTarget` so the crit-seeking term is applied.
+   * Omitted (or with a zero `critSeekingWeight`) the score is the legacy
+   * threat-only value — every existing caller is unaffected.
    */
   selectTarget(
     targets: readonly IAIUnitState[],
     random: SeededRandom,
     attacker?: IAIUnitState,
+    resource?: IAITierResourceParameters,
   ): IAIUnitState | null {
     if (targets.length === 0) {
       return null;
@@ -269,7 +362,7 @@ export class AttackAI {
     // consumption depended on whether a tie existed).
     const scored = targets.map((t) => ({
       target: t,
-      score: scoreTarget(attacker, t),
+      score: scoreTarget(attacker, t, resource),
     }));
     scored.sort((a, b) => b.score - a.score);
     const topScore = scored[0].score;
@@ -337,6 +430,138 @@ export class AttackAI {
     // sorted list and drops from the tail.
     return orderWeaponsByEfficiency(afterMinRange, distance);
   }
+
+  /**
+   * Per `add-ai-resource-planning` (A2): the resource-aware fire-list
+   * planner. Wraps `selectWeapons` with the three A2 priority modulators —
+   * ammo-runway conservation, weapon-mode selection — and reports the
+   * per-weapon mode so the caller can record it on the declared attack.
+   *
+   * The pipeline:
+   *
+   *   1. Run the legacy `selectWeapons` filter pipeline (destroyed / range /
+   *      ammo / arc / minRange / efficiency sort).
+   *   2. For each surviving weapon, project its ammo runway (`AIAmmoRunway`)
+   *      and select its firing mode (`AIWeaponModeSelector`).
+   *   3. Re-order the list by an effective priority that folds the ammo
+   *      `conservationWeight` into the legacy damage-per-heat efficiency —
+   *      a scarce-ammo weapon sinks toward the tail so the downstream
+   *      heat-budget trim drops it first; an abundant / energy weapon is
+   *      unchanged. The binary 0-ammo cull from `selectWeapons` is
+   *      untouched — conservation modulates ORDER, never eligibility.
+   *
+   * When `resource` is the inert block (`Green`/`Regular`, or omitted),
+   * `ammoConservationWeight` is `0` so the re-order is a no-op and
+   * `weaponModeSelection` is `false` so every weapon reports its default
+   * mode — the result is the legacy `selectWeapons` order, byte-for-byte.
+   *
+   * Pure function — no `SeededRandom` consumption.
+   */
+  planFireList(
+    attacker: IAIUnitState,
+    target: IAIUnitState,
+    options: {
+      readonly resource?: IAITierResourceParameters;
+      /** Heat headroom for mode selection (safe threshold minus committed). */
+      readonly heatHeadroom?: number;
+    } = {},
+  ): readonly IFireListEntry[] {
+    const resource = options.resource ?? INERT_RESOURCE_PARAMETERS;
+    const ordered = this.selectWeapons(attacker, target);
+    const distance = hexDistance(attacker.position, target.position);
+
+    const modeContextBase: Omit<IWeaponModeContext, 'ammoTurnsRemaining'> = {
+      distance,
+      targetStructure: target.structureState,
+      targetEvading: target.isEvading,
+      // A generous default headroom when the caller does not supply one —
+      // mode selection still works, it just does not see heat pressure.
+      heatHeadroom: options.heatHeadroom ?? Number.POSITIVE_INFINITY,
+    };
+
+    // Build a fire-list entry per weapon: runway + selected mode.
+    const entries: IFireListEntry[] = ordered.map((weapon) => {
+      const ammoRemaining = attacker.ammo[weapon.id];
+      // The mode-selection step needs an estimate of shots-per-turn; use
+      // the weapon's default mode shot count when metadata is present.
+      const defaultShots = defaultShotsPerTurn(weapon);
+      const runway = computeAmmoRunway(weapon, ammoRemaining, defaultShots);
+      const mode = selectWeaponMode(
+        weapon,
+        { ...modeContextBase, ammoTurnsRemaining: runway.turnsRemaining },
+        resource.weaponModeSelection,
+      );
+      // Re-project the runway against the SELECTED mode's shot count so a
+      // higher-rate-of-fire mode shows its true (shorter) runway.
+      const modeRunway = computeAmmoRunway(
+        weapon,
+        ammoRemaining,
+        Math.max(1, mode.effectiveShots),
+      );
+      return { weapon, mode, runway: modeRunway };
+    });
+
+    // When ammo conservation is inert, keep the legacy efficiency order.
+    if (resource.ammoConservationWeight <= 0) {
+      return entries;
+    }
+
+    // Re-order by effective priority: legacy damage-per-heat efficiency
+    // scaled by a conservation factor. A neutral runway (`weight === 1`)
+    // leaves priority at full efficiency; a scarce runway pulls it toward
+    // zero in proportion to `ammoConservationWeight`. A stable sort keeps
+    // equal-priority weapons in their legacy relative order.
+    const withPriority = entries.map((entry, index) => {
+      const efficiency =
+        entry.mode.effectiveDamage / Math.max(1, entry.mode.effectiveHeat);
+      // conservationFactor in [1 - w, 1]: weight 1 -> factor 1 (neutral);
+      // weight MIN -> factor (1 - w * (1 - MIN)).
+      const conservationFactor =
+        1 -
+        resource.ammoConservationWeight * (1 - entry.runway.conservationWeight);
+      return {
+        entry,
+        index,
+        priority: efficiency * conservationFactor,
+      };
+    });
+    withPriority.sort((a, b) => {
+      if (b.priority !== a.priority) return b.priority - a.priority;
+      // Stable tie-break — preserve the legacy efficiency order.
+      return a.index - b.index;
+    });
+    return withPriority.map((p) => p.entry);
+  }
+}
+
+/**
+ * Per `add-ai-resource-planning` (A2): one entry in a resource-planned fire
+ * list — the weapon, its selected firing mode, and its ammo runway. Returned
+ * by `AttackAI.planFireList`.
+ */
+export interface IFireListEntry {
+  /** The weapon to fire. */
+  readonly weapon: IWeapon;
+  /** The firing mode selected for this weapon this turn. */
+  readonly mode: IWeaponModeSelection;
+  /** The weapon's projected ammo runway against the selected mode. */
+  readonly runway: ReturnType<typeof computeAmmoRunway>;
+}
+
+/**
+ * The expected shots-per-turn for a weapon's DEFAULT firing mode — used to
+ * seed the ammo-runway estimate before a mode is chosen. A weapon with
+ * `firingModes` metadata uses its default mode's `shotsPerTurn`; a
+ * single-mode ammo weapon fires one shot; an energy weapon fires zero.
+ */
+function defaultShotsPerTurn(weapon: IWeapon): number {
+  const modes = weapon.firingModes;
+  if (modes && modes.modes.length > 0) {
+    const def =
+      modes.modes.find((m) => m.id === modes.defaultModeId) ?? modes.modes[0];
+    return Math.max(1, def.shotsPerTurn);
+  }
+  return weapon.ammoPerTon > 0 ? 1 : 0;
 }
 
 /**

--- a/src/simulation/ai/BotPlayer.ts
+++ b/src/simulation/ai/BotPlayer.ts
@@ -19,6 +19,13 @@ import type {
 import type { IAIPlayer } from './IAIPlayer';
 import type { IBotBehavior, IAIUnitState, IMove, IWeapon } from './types';
 
+import { planEffectiveThreshold } from './AIHeatPlanner';
+import {
+  type IAITierResourceParameters,
+  resolveResourceParameters,
+  resolveTierParameters,
+} from './AITierRegistry';
+import { collectWeaponModes } from './AIWeaponModeSelector';
 import { AttackAI, applyHeatBudget, scoreTarget } from './AttackAI';
 import { MoveAI, type IScoreMoveContext } from './MoveAI';
 import {
@@ -47,17 +54,35 @@ const DEFAULT_PILOTING_SKILL = 5;
 /** Melee range in hexes — punches/kicks/charges all need adjacency. */
 const MELEE_RANGE_HEXES = 1;
 
+/**
+ * Per `add-ai-resource-planning` (A2): the canonical 10-heat-sink baseline
+ * dissipation used by the multi-turn heat planner when an `IAIUnitState`
+ * does not carry an explicit `heatDissipation`. Matches the standard 'Mech
+ * loadout (10 single heat sinks dissipating 1 each per turn).
+ */
+const DEFAULT_HEAT_DISSIPATION = 10;
+
 export class BotPlayer implements IAIPlayer {
   private readonly moveAI: MoveAI;
   private readonly attackAI: AttackAI;
   private readonly random: SeededRandom;
   private readonly behavior: IBotBehavior;
+  /**
+   * Per `add-ai-resource-planning` (A2): the resource-planning block resolved
+   * from the bot's difficulty tier. `Green`/`Regular` (and an absent tier)
+   * carry the fully-inert block so pre-A2 behavior is byte-identical;
+   * `Veteran`/`Elite` carry the active block.
+   */
+  private readonly resource: IAITierResourceParameters;
 
   constructor(random: SeededRandom, behavior: IBotBehavior = DEFAULT_BEHAVIOR) {
     this.random = random;
     this.behavior = behavior;
     this.moveAI = new MoveAI(behavior);
     this.attackAI = new AttackAI();
+    this.resource = resolveResourceParameters(
+      resolveTierParameters(behavior.tier),
+    );
   }
 
   /**
@@ -232,11 +257,14 @@ export class BotPlayer implements IAIPlayer {
 
     // Per `improve-bot-basic-combat-competence` task 2.5: pass attacker
     // so the threat-scored selector picks the most threatening target
-    // instead of a uniform-random pick.
+    // instead of a uniform-random pick. Per `add-ai-resource-planning`
+    // (A2): the tier's resource block is threaded so the crit-seeking term
+    // applies — inert for `Green`/`Regular`, active for `Veteran`/`Elite`.
     const target = this.attackAI.selectTarget(
       validTargets,
       this.random,
       attacker,
+      this.resource,
     );
     if (!target) {
       return null;
@@ -253,36 +281,102 @@ export class BotPlayer implements IAIPlayer {
     const arcAttacker: IAIUnitState = attacker.isRetreating
       ? { ...attacker, torsoTwist: undefined }
       : attacker;
-    const candidateWeapons = this.attackAI.selectWeapons(arcAttacker, target);
-    if (candidateWeapons.length === 0) {
-      return null;
-    }
 
-    // Per `improve-bot-basic-combat-competence` task 5: trim the fire
-    // list against the heat budget. `effectiveSafeHeatThreshold` lowers
-    // the ceiling by 2 when the bot is retreating so it stops firing
-    // sooner and runs faster.
+    // Per `improve-bot-basic-combat-competence` task 5: the heat budget.
+    // `effectiveSafeHeatThreshold` lowers the ceiling by 2 when the bot is
+    // retreating so it stops firing sooner and runs faster.
     const movementHeat = computeMovementHeat(
       attacker.movementType,
       attacker.hexesMoved,
     );
-    const threshold = effectiveSafeHeatThreshold(attacker, this.behavior);
-    const weapons: readonly IWeapon[] = applyHeatBudget(
-      candidateWeapons,
-      attacker.heat,
-      movementHeat,
-      threshold,
+    const baseThreshold = effectiveSafeHeatThreshold(attacker, this.behavior);
+
+    // Per `add-ai-resource-planning` (A2) design D2: plan the fire list with
+    // ammo-runway conservation and weapon-mode selection. For the inert
+    // `Green`/`Regular` block this is the legacy `selectWeapons` order with
+    // every weapon in its default mode — byte-identical to pre-A2.
+    const heatHeadroom = Math.max(
+      0,
+      baseThreshold - attacker.heat - movementHeat,
     );
-    if (weapons.length === 0) {
+    const planned = this.attackAI.planFireList(arcAttacker, target, {
+      resource: this.resource,
+      heatHeadroom,
+    });
+    if (planned.length === 0) {
       return null;
     }
+
+    // Per `add-ai-resource-planning` (A2) design D1: multi-turn heat
+    // projection. `planEffectiveThreshold` projects the heat curve assuming
+    // the planned fire list repeats each turn and lowers the budget if a
+    // shutdown is predicted. `heatLookaheadTurns: 0` (Green/Regular) returns
+    // `baseThreshold` unchanged — the legacy single-turn ceiling.
+    const perTurnHeatGenerated =
+      movementHeat +
+      planned.reduce((sum, entry) => sum + entry.mode.effectiveHeat, 0);
+    const effectiveThreshold = planEffectiveThreshold(
+      baseThreshold,
+      attacker.heat,
+      attacker.heatDissipation ?? DEFAULT_HEAT_DISSIPATION,
+      perTurnHeatGenerated,
+      movementHeat,
+      this.resource.heatLookaheadTurns,
+    );
+
+    // Per `improve-bot-basic-combat-competence` task 5: the single-turn
+    // trim still runs each turn (design D1) — now against the possibly
+    // lowered `effectiveThreshold`. `applyHeatBudget` operates on the
+    // efficiency-sorted weapon list; the planned modes' heat is folded in
+    // via a synthetic weapon list so the trim sees mode-adjusted heat.
+    const modeWeapons: readonly IWeapon[] = planned.map((entry) => ({
+      ...entry.weapon,
+      damage: entry.mode.effectiveDamage,
+      heat: entry.mode.effectiveHeat,
+    }));
+    let trimmed = applyHeatBudget(
+      modeWeapons,
+      attacker.heat,
+      movementHeat,
+      effectiveThreshold,
+    );
+    // Per `add-ai-resource-planning` (A2) scenario "Veteran bot throttles
+    // before shutdown": the heat planner culls lower-efficiency weapons, it
+    // does not silence the unit — if the planner's lowered budget empties
+    // the list but the legacy `baseThreshold` would have kept a weapon, the
+    // bot still fires its single best one. Scoped to the planner-over-trim
+    // case (`effectiveThreshold < baseThreshold`) so the legacy "trim to
+    // nothing returns null" contract is byte-identical when no planner runs.
+    if (trimmed.length === 0 && effectiveThreshold < baseThreshold) {
+      const legacyTrim = applyHeatBudget(
+        modeWeapons,
+        attacker.heat,
+        movementHeat,
+        baseThreshold,
+      );
+      if (legacyTrim.length > 0) {
+        trimmed = [modeWeapons[0]];
+      }
+    }
+    if (trimmed.length === 0) {
+      return null;
+    }
+
+    // Record the selected firing mode for every multi-mode weapon that
+    // survived the trim. Single-mode fire lists carry no `weaponModes` map
+    // (pre-A2 shape) — see `collectWeaponModes`.
+    const weaponModes = collectWeaponModes(
+      planned,
+      trimmed.map((w) => w.id),
+    );
 
     return {
       type: GameEventType.AttackDeclared,
       payload: {
         attackerId: attacker.unitId,
         targetId: target.unitId,
-        weapons: weapons.map((w) => w.id),
+        weapons: trimmed.map((w) => w.id),
+        ...(weaponModes ? { weaponModes } : {}),
       },
     };
   }

--- a/src/simulation/ai/index.ts
+++ b/src/simulation/ai/index.ts
@@ -1,6 +1,7 @@
 export { MoveAI } from './MoveAI';
 export type { IScoreMoveContext } from './MoveAI';
-export { AttackAI } from './AttackAI';
+export { AttackAI, scoreTarget, structuralExposure } from './AttackAI';
+export type { IFireListEntry } from './AttackAI';
 export { BotPlayer } from './BotPlayer';
 export type { BotGameEvent, IMovementEvent, IAttackEvent } from './BotPlayer';
 export { DEFAULT_BEHAVIOR } from './types';
@@ -9,6 +10,10 @@ export type {
   IMove,
   IWeapon,
   IAIUnitState,
+  IAIStructureState,
+  IWeaponFiringMode,
+  IWeaponFiringModes,
+  WeaponModeKind,
   RetreatEdge,
 } from './types';
 
@@ -20,11 +25,36 @@ export type { IAIPath, IAIPathfindRequest } from './AITerrainPathfinder';
 export {
   AI_TIER_REGISTRY,
   DEFAULT_TIER_NAME,
+  INERT_RESOURCE_PARAMETERS,
   getTierParameters,
   resolveTierParameters,
+  resolveResourceParameters,
 } from './AITierRegistry';
 export type {
   AITierName,
   IAITierParameters,
   IAITierMovementParameters,
+  IAITierResourceParameters,
 } from './AITierRegistry';
+
+// Per `add-ai-resource-planning` (A2): the resource-planning modules —
+// multi-turn heat projection, ammo-runway projection, weapon-mode selection.
+export {
+  projectHeat,
+  effectiveHeatBudget,
+  planEffectiveThreshold,
+  SHUTDOWN_RISK_HEAT,
+} from './AIHeatPlanner';
+export type { IHeatProjection } from './AIHeatPlanner';
+export {
+  projectAmmoRunway,
+  computeAmmoRunway,
+  SCARCE_RUNWAY_TURNS,
+  MIN_CONSERVATION_WEIGHT,
+} from './AIAmmoRunway';
+export type { IAmmoRunway } from './AIAmmoRunway';
+export { selectWeaponMode, collectWeaponModes } from './AIWeaponModeSelector';
+export type {
+  IWeaponModeSelection,
+  IWeaponModeContext,
+} from './AIWeaponModeSelector';

--- a/src/simulation/ai/types.ts
+++ b/src/simulation/ai/types.ts
@@ -164,6 +164,66 @@ export interface IWeapon {
    * build `IWeapon` without arc data) keep working — missing = Front.
    */
   readonly mountingArc?: FiringArc;
+
+  /**
+   * Per `add-ai-resource-planning` (A2) design D4: optional firing-mode
+   * metadata for multi-mode weapons — LB-X autocannons (cluster vs. slug),
+   * Ultra / Rotary autocannons (rate of fire). When present,
+   * `AIWeaponModeSelector` picks the expected-damage-maximizing mode given
+   * range, the target's armor state, and the remaining heat budget.
+   *
+   * A weapon WITHOUT this field is single-mode — `AIWeaponModeSelector`
+   * returns its default mode unchanged, so existing weapon fixtures and
+   * runtime wiring need no migration (the selector is byte-identical to
+   * "always default mode" for them).
+   *
+   * Typed as `IWeaponFiringModes` from `AIWeaponModeSelector` — declared
+   * here as a structural shape to keep `types.ts` free of an import cycle
+   * with the selector module.
+   */
+  readonly firingModes?: IWeaponFiringModes;
+}
+
+/**
+ * The kind of multi-mode weapon, used by `AIWeaponModeSelector` to pick the
+ * right mode-selection heuristic.
+ *
+ *   - `cluster-slug`: LB-X autocannon — cluster (spread / crit-seek) vs.
+ *     slug (focused).
+ *   - `rate-of-fire`: Ultra / Rotary autocannon — a higher rate of fire
+ *     trades heat and ammo for damage.
+ */
+export type WeaponModeKind = 'cluster-slug' | 'rate-of-fire';
+
+/**
+ * One selectable firing mode of a multi-mode weapon.
+ *
+ * `damage`, `heat`, and `shotsPerTurn` describe the mode's per-turn cost and
+ * output — they OVERRIDE the weapon's base `damage`/`heat` when the mode is
+ * selected, so the combat engine resolves the chosen mode's numbers.
+ */
+export interface IWeaponFiringMode {
+  /** Stable mode identifier, e.g. `'cluster'`, `'slug'`, `'single'`. */
+  readonly id: string;
+  /** Damage this mode deals per turn. */
+  readonly damage: number;
+  /** Heat this mode generates per turn. */
+  readonly heat: number;
+  /** Ammo rounds this mode consumes per turn (energy weapons: `0`). */
+  readonly shotsPerTurn: number;
+}
+
+/**
+ * Firing-mode metadata for a multi-mode weapon — the optional `firingModes`
+ * field on `IWeapon`.
+ */
+export interface IWeaponFiringModes {
+  /** The mode-selection heuristic family this weapon belongs to. */
+  readonly kind: WeaponModeKind;
+  /** The id of the mode fired when mode selection is disabled. */
+  readonly defaultModeId: string;
+  /** The selectable modes — at least two for a genuine multi-mode weapon. */
+  readonly modes: readonly IWeaponFiringMode[];
 }
 
 // =============================================================================
@@ -248,4 +308,69 @@ export interface IAIUnitState {
    * Set once on trigger and locked. `null` until retreat begins.
    */
   readonly retreatTargetEdge?: 'north' | 'south' | 'east' | 'west' | null;
+
+  /**
+   * Per `add-ai-resource-planning` (A2) design D3: the unit's per-location
+   * armour and internal-structure state, used by `scoreTarget`'s
+   * crit-seeking term to gauge how *exposed* the unit is — a location with
+   * stripped armour and prior internal damage is one good roll from a
+   * crippling critical.
+   *
+   * Optional for backward compatibility: a unit without this field
+   * contributes a zero crit-seeking bonus (treated as fully armoured), so
+   * legacy `IAIUnitState` fixtures and the `Green`/`Regular` tiers — which
+   * zero `critSeekingWeight` anyway — keep the pre-change `scoreTarget`
+   * output exactly. Production `toAIUnitState` populates it from
+   * `IUnitGameState` armour / structure maps.
+   */
+  readonly structureState?: IAIStructureState;
+
+  /**
+   * Per `add-ai-resource-planning` (A2) design D4: `true` when the unit is
+   * actively evading (e.g. ran / jumped this turn for a defensive movement
+   * modifier). `AIWeaponModeSelector` treats an evading target like an
+   * armour-stripped one — cluster fire's spread is more reliable against a
+   * hard-to-hit target. Optional; absent = not evading.
+   */
+  readonly isEvading?: boolean;
+
+  /**
+   * Per `add-ai-resource-planning` (A2) design D1: the unit's per-turn heat
+   * dissipation capacity (sum of functioning heat sinks' dissipation).
+   * `AIHeatPlanner.projectHeat` subtracts this each turn when projecting the
+   * heat curve.
+   *
+   * Optional for backward compatibility: a unit without this field falls
+   * back to the canonical 10-sink baseline (`DEFAULT_HEAT_DISSIPATION`) at
+   * the consumer site. Production `toAIUnitState` reads it from the unit's
+   * heat-sink loadout. The `Green`/`Regular` tiers set `heatLookaheadTurns`
+   * to `0`, so the planner never runs for them regardless.
+   */
+  readonly heatDissipation?: number;
+}
+
+/**
+ * Per-location armour and internal-structure snapshot for a unit, used by
+ * the A2 crit-seeking target weighting.
+ *
+ * Each map is keyed by location name (`"center_torso"`, `"left_torso"`,
+ * `"head"`, …). `armorByLocation` holds remaining armour points;
+ * `armorMaxByLocation` holds the location's starting armour;
+ * `internalByLocation` holds remaining internal structure;
+ * `internalMaxByLocation` holds the location's starting internal structure.
+ *
+ * A location whose armour is `0` is *stripped* — every hit there rolls on
+ * the internal-structure / critical table directly. A location whose
+ * internal structure is below its maximum has taken *prior internal
+ * damage*. Both raise the crit-seeking score (design D3).
+ */
+export interface IAIStructureState {
+  /** Remaining armour points per location. */
+  readonly armorByLocation: Readonly<Record<string, number>>;
+  /** Starting (maximum) armour points per location. */
+  readonly armorMaxByLocation: Readonly<Record<string, number>>;
+  /** Remaining internal structure points per location. */
+  readonly internalByLocation: Readonly<Record<string, number>>;
+  /** Starting (maximum) internal structure points per location. */
+  readonly internalMaxByLocation: Readonly<Record<string, number>>;
 }


### PR DESCRIPTION
Implements the OpenSpec change `add-ai-resource-planning` (A2) end-to-end —
the resource-planning depth that makes the `Veteran`/`Elite` AI tiers worth
selecting. Builds additively on the A1 difficulty tier registry.

## What this builds

- **`AIHeatPlanner`** — multi-turn heat projection. `projectHeat` walks the
  heat curve over a tier-configured lookahead window and flags the first
  shutdown-risk turn; `effectiveHeatBudget` / `planEffectiveThreshold` lower
  the effective fire budget toward a sustainable ceiling before a predicted
  shutdown, instead of after.
- **`AIAmmoRunway`** — per-weapon turns-of-fire projection. A short runway
  drops a weapon's selection priority via a `[0,1]` conservation weight;
  energy weapons are infinite/neutral. The binary 0-ammo cull is unchanged —
  runway modulates priority only.
- **Crit-seeking** — `scoreTarget` gains an additive term, gated on
  `critSeekingWeight`, proportional to a target's structural exposure
  (stripped armour / prior internal damage). Fully-armoured targets get a
  zero bonus; threat and kill-probability terms are untouched.
- **`AIWeaponModeSelector`** — LB-X cluster/slug and Ultra/Rotary
  rate-of-fire mode choice by expected damage given range, armour state,
  heat budget and ammo runway. Single-mode weapons pass through unchanged.
- **Tier registry** — `IAITierResourceParameters` block added additively;
  `Green`/`Regular` fully inert (legacy behavior byte-identical),
  `Veteran`/`Elite` populated. A1's movement block is untouched.
- **`BotPlayer.playAttackPhase`** wired through `planFireList` + the heat
  planner; selected firing modes recorded on the `AttackDeclared` payload.

## Verification

- `npx tsc --noEmit` — zero errors
- `npx oxlint src/` — 0 warnings, 0 errors
- `npx jest src/simulation` — 87 suites, 1331 tests green (incl. 129 new A2
  tests covering every delta-spec scenario + the determinism golden traces)
- `npx openspec validate add-ai-resource-planning --strict` — valid
- Determinism preserved: all new modules are pure functions, no
  `SeededRandom` consumption; `Green`/`Regular` legacy paths byte-identical.

## Notes / decisions

- `heatLookaheadTurns` set to `3` for `Veteran` / `4` for `Elite` per the
  design open question (revisit after swarm-harness tuning).
- A new `weaponModes` optional field on the `AttackDeclared` payload records
  selected modes (design D4) — absent for single-mode fire lists, so the
  pre-A2 payload shape is preserved for legacy tiers.
- The OpenSpec change is NOT archived, per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)