### PR TITLE
feat(ai): objective-aware tactical play

### DIFF
--- a/openspec/changes/add-ai-objective-awareness/tasks.md
+++ b/openspec/changes/add-ai-objective-awareness/tasks.md
@@ -2,45 +2,45 @@
 
 ## 1. Objective Tier Parameters
 
-- [ ] 1.1 Add `IAITierObjectiveParameters` (`objectiveAwareness`, `objectiveSeekingWeight`, `objectiveHoldWeight`) and an optional `objective` block on `IAITierParameters` in `src/simulation/ai/AITierRegistry.ts`
-- [ ] 1.2 Populate the `objective` block per tier — `Green`/`Regular`/`Veteran` fully inert (`objectiveAwareness: false`, zeroed weights); `Elite` populated
-- [ ] 1.3 Tests: every tier resolves an `objective` block; lower tiers ignore the objective map and play `Destroy`
+- [x] 1.1 Add `IAITierObjectiveParameters` (`objectiveAwareness`, `objectiveSeekingWeight`, `objectiveHoldWeight`) and an optional `objective` block on `IAITierParameters` in `src/simulation/ai/AITierRegistry.ts`
+- [x] 1.2 Populate the `objective` block per tier — `Green`/`Regular`/`Veteran` fully inert (`objectiveAwareness: false`, zeroed weights); `Elite` populated
+- [x] 1.3 Tests: every tier resolves an `objective` block; lower tiers ignore the objective map and play `Destroy`
 
 ## 2. Objective Ingestion and Classification
 
-- [ ] 2.1 Create `src/simulation/ai/AIObjectivePlanner.ts` with `classifyObjectives(session, botSide)` returning `IClassifiedObjective` records
-- [ ] 2.2 Classify each marker as `take`, `hold`, or `deny` from the bot side's scenario objective type
-- [ ] 2.3 An empty objective map (or a `Destroy` scenario type) SHALL yield no classified objectives
-- [ ] 2.4 Tests: an attacker's capture marker classifies `take`; a defender's marker classifies `hold`; a `Destroy` scenario yields nothing
+- [x] 2.1 Create `src/simulation/ai/AIObjectivePlanner.ts` with `classifyObjectives(session, botSide)` returning `IClassifiedObjective` records
+- [x] 2.2 Classify each marker as `take`, `hold`, or `deny` from the bot side's scenario objective type
+- [x] 2.3 An empty objective map (or a `Destroy` scenario type) SHALL yield no classified objectives
+- [x] 2.4 Tests: an attacker's capture marker classifies `take`; a defender's marker classifies `hold`; a `Destroy` scenario yields nothing
 
 ## 3. Objective Layer on the Lance Plan
 
-- [ ] 3.1 Add an optional `objectivePlan` field (`IObjectiveLancePlan`) to A3a's `ILanceTurnPlan`
-- [ ] 3.2 In `AILancePlanner.planTurn`, when objective awareness is enabled and the scenario is not `Destroy`, assign each unit an `ObjectiveRole` (`capture`, `hold`, `screen`)
-- [ ] 3.3 Assign the capture role to the unit(s) closest by A1 pathfinder cost to a `take` marker; the hold role to the unit(s) on or nearest a `hold` marker; the screen role to the rest
-- [ ] 3.4 Populate `targetHexes` with the hex each role-bearing unit is working toward or holding
-- [ ] 3.5 Tests: a capture role goes to the nearest unit; a hold role goes to the unit on the marker; screen units get no objective hex
+- [x] 3.1 Add an optional `objectivePlan` field (`IObjectiveLancePlan`) to A3a's `ILanceTurnPlan`
+- [x] 3.2 In `AILancePlanner.planTurn`, when objective awareness is enabled and the scenario is not `Destroy`, assign each unit an `ObjectiveRole` (`capture`, `hold`, `screen`)
+- [x] 3.3 Assign the capture role to the unit(s) closest by A1 pathfinder cost to a `take` marker; the hold role to the unit(s) on or nearest a `hold` marker; the screen role to the rest
+- [x] 3.4 Populate `targetHexes` with the hex each role-bearing unit is working toward or holding
+- [x] 3.5 Tests: a capture role goes to the nearest unit; a hold role goes to the unit on the marker; screen units get no objective hex
 
 ## 4. Objective-Seeking Movement
 
-- [ ] 4.1 Add an objective term to `scoreMove` for capture-role units — `+objectiveSeekingWeight` scaled by pathfinder-distance reduction to the `take` marker, with a large bonus for a destination on the marker hex
-- [ ] 4.2 Add an objective term for hold-role units — `+objectiveHoldWeight` for a destination on the `hold` marker, reduced for adjacent hexes, zero for destinations abandoning it
-- [ ] 4.3 Screen-role units SHALL receive zero objective contribution and play pure A3a movement
-- [ ] 4.4 Gate the objective term on `objectiveAwareness`; when disabled it contributes zero
-- [ ] 4.5 Tests: a capture unit moves toward and onto its marker; a hold unit stays on its marker; a screen unit is unaffected
+- [x] 4.1 Add an objective term to `scoreMove` for capture-role units — `+objectiveSeekingWeight` scaled by pathfinder-distance reduction to the `take` marker, with a large bonus for a destination on the marker hex
+- [x] 4.2 Add an objective term for hold-role units — `+objectiveHoldWeight` for a destination on the `hold` marker, reduced for adjacent hexes, zero for destinations abandoning it
+- [x] 4.3 Screen-role units SHALL receive zero objective contribution and play pure A3a movement
+- [x] 4.4 Gate the objective term on `objectiveAwareness`; when disabled it contributes zero
+- [x] 4.5 Tests: a capture unit moves toward and onto its marker; a hold unit stays on its marker; a screen unit is unaffected
 
 ## 5. Objective-Aware Target Discipline
 
-- [ ] 5.1 In `playAttackPhase`, for `capture`/`hold`-role units, prefer targets engageable without leaving the objective hex or its path
-- [ ] 5.2 A hold unit SHALL fire from the marker rather than pursue an enemy off it
-- [ ] 5.3 Screen-role units SHALL keep A3a target selection unchanged
-- [ ] 5.4 Tests: a hold unit engages from the marker and does not chase; a screen unit's selection matches A3a
+- [x] 5.1 In `playAttackPhase`, for `capture`/`hold`-role units, prefer targets engageable without leaving the objective hex or its path
+- [x] 5.2 A hold unit SHALL fire from the marker rather than pursue an enemy off it
+- [x] 5.3 Screen-role units SHALL keep A3a target selection unchanged
+- [x] 5.4 Tests: a hold unit engages from the marker and does not chase; a screen unit's selection matches A3a
 
 ## 6. Verification
 
-- [ ] 6.1 Integration test: an `Elite` bot wins a generated `Capture` scenario by moving a unit onto the objective and holding it; a `Veteran` bot fails to capture
-- [ ] 6.2 Integration test: an `Elite` bot wins a generated `Defend` scenario by holding its marker to the turn limit
-- [ ] 6.3 Integration test: an `Elite` bot wins a generated `Breakthrough` scenario by moving units to the exit edge
-- [ ] 6.4 Determinism test: SimulationRunner golden traces on the `Veteran` tier are byte-identical to pre-change traces
-- [ ] 6.5 `npx openspec validate add-ai-objective-awareness --strict` reports valid
-- [ ] 6.6 Build, lint, and typecheck pass
+- [x] 6.1 Integration test: an `Elite` bot wins a generated `Capture` scenario by moving a unit onto the objective and holding it; a `Veteran` bot fails to capture
+- [x] 6.2 Integration test: an `Elite` bot wins a generated `Defend` scenario by holding its marker to the turn limit
+- [x] 6.3 Integration test: an `Elite` bot wins a generated `Breakthrough` scenario by moving units to the exit edge
+- [x] 6.4 Determinism test: SimulationRunner golden traces on the `Veteran` tier are byte-identical to pre-change traces
+- [x] 6.5 `npx openspec validate add-ai-objective-awareness --strict` reports valid
+- [x] 6.6 Build, lint, and typecheck pass

--- a/src/simulation/__tests__/aiObjectiveAwareness.test.ts
+++ b/src/simulation/__tests__/aiObjectiveAwareness.test.ts
@@ -1,0 +1,763 @@
+/**
+ * Tests for AI objective awareness (A3b) — the objective tier parameters,
+ * objective ingestion / classification, the objective layer on the lance
+ * plan, objective-seeking movement, and objective-aware target discipline.
+ *
+ * Covers `add-ai-objective-awareness` Requirements:
+ *   - Objective-Awareness Tier Parameters
+ *   - Objective Ingestion and Classification
+ *   - Objective-Aware Lance Planning
+ *   - Objective-Seeking Movement
+ *   - Objective-Aware Target Discipline
+ *
+ * @spec openspec/changes/add-ai-objective-awareness/specs/simulation-system/spec.md
+ *   Requirement: Objective-Awareness Tier Parameters
+ *   Requirement: Objective Ingestion and Classification
+ *   Requirement: Objective-Aware Lance Planning
+ *   Requirement: Objective-Seeking Movement
+ *   Requirement: Objective-Aware Target Discipline
+ */
+
+import type {
+  IGameSession,
+  IGameState,
+  IHexCoordinate,
+  IHexGrid,
+} from '@/types/gameplay';
+import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
+
+import {
+  Facing,
+  GamePhase,
+  GameSide,
+  GameStatus,
+  MovementType,
+} from '@/types/gameplay';
+
+import type { IObjectiveLancePlan } from '../ai/AIObjectivePlanner';
+import type { IAILanceContext } from '../ai/BotPlayer';
+import type { IScoreMoveContext } from '../ai/MoveAI';
+import type { IAIUnitState, IBotBehavior, IMove, IWeapon } from '../ai/types';
+
+import { planTurn } from '../ai/AILancePlanner';
+import {
+  assignObjectiveRoles,
+  classifyObjectives,
+  planObjectives,
+} from '../ai/AIObjectivePlanner';
+import {
+  AI_TIER_REGISTRY,
+  INERT_OBJECTIVE_PARAMETERS,
+  getTierParameters,
+  resolveObjectiveParameters,
+} from '../ai/AITierRegistry';
+import { BotPlayer } from '../ai/BotPlayer';
+import { scoreMove } from '../ai/MoveAI';
+import { SeededRandom } from '../core/SeededRandom';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function weapon(overrides: Partial<IWeapon> = {}): IWeapon {
+  return {
+    id: 'mlas',
+    name: 'Medium Laser',
+    shortRange: 3,
+    mediumRange: 6,
+    longRange: 9,
+    damage: 5,
+    heat: 3,
+    minRange: 0,
+    ammoPerTon: -1,
+    destroyed: false,
+    ...overrides,
+  };
+}
+
+function unit(
+  overrides: Partial<IAIUnitState> & { unitId: string },
+): IAIUnitState {
+  return {
+    position: { q: 0, r: 0 },
+    facing: Facing.North,
+    heat: 0,
+    weapons: [weapon()],
+    ammo: {},
+    destroyed: false,
+    gunnery: 4,
+    movementType: MovementType.Stationary,
+    hexesMoved: 0,
+    ...overrides,
+  };
+}
+
+function marker(overrides: Partial<IObjectiveMarker> = {}): IObjectiveMarker {
+  return {
+    id: 'objective-1',
+    hexKey: '0,0',
+    objectiveType: 'capture',
+    owningSide: 'neutral',
+    controlSide: 'neutral',
+    controlRule: 'sole-occupancy',
+    holdTurnsRequired: 1,
+    holdProgress: 0,
+    ...overrides,
+  };
+}
+
+/**
+ * A minimal `IGameSession` carrying just the objective map — the only field
+ * `classifyObjectives` reads. The rest is filled with inert defaults.
+ */
+function session(objectives?: Record<string, IObjectiveMarker>): IGameSession {
+  const currentState: IGameState = {
+    gameId: 'test-game',
+    status: GameStatus.Active,
+    turn: 1,
+    phase: GamePhase.Movement,
+    activationIndex: 0,
+    units: {},
+    turnEvents: [],
+    ...(objectives !== undefined ? { objectives } : {}),
+  };
+  return {
+    id: 'session-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    config: {
+      mapRadius: 10,
+      turnLimit: 0,
+      victoryConditions: [],
+      optionalRules: [],
+    },
+    units: [],
+    events: [],
+    currentState,
+  };
+}
+
+/** A flat clear-terrain hex grid of the given radius. */
+function makeGrid(radius: number): IHexGrid {
+  const hexes = new Map();
+  for (let q = -radius; q <= radius; q++) {
+    for (let r = -radius; r <= radius; r++) {
+      if (Math.abs(q + r) > radius) continue;
+      hexes.set(`${q},${r}`, {
+        coord: { q, r },
+        occupantId: null,
+        terrain: 'clear',
+        elevation: 0,
+      });
+    }
+  }
+  return { config: { radius }, hexes };
+}
+
+/** Straight hex-distance cost function for role assignment in tests. */
+function hexCost(u: IAIUnitState, hex: IHexCoordinate): number {
+  const dq = hex.q - u.position.q;
+  const dr = hex.r - u.position.r;
+  const ds = -dq - dr;
+  return (Math.abs(dq) + Math.abs(dr) + Math.abs(ds)) / 2;
+}
+
+const ELITE: IBotBehavior = {
+  retreatThreshold: 0.3,
+  retreatEdge: 'nearest',
+  safeHeatThreshold: 13,
+  tier: 'Elite',
+};
+
+const VETERAN: IBotBehavior = {
+  retreatThreshold: 0.3,
+  retreatEdge: 'nearest',
+  safeHeatThreshold: 13,
+  tier: 'Veteran',
+};
+
+// =============================================================================
+// Requirement: Objective-Awareness Tier Parameters
+// =============================================================================
+
+describe('Objective-Awareness Tier Parameters', () => {
+  // Scenario: Every tier resolves an objective block
+  it('every tier returns a populated objective block', () => {
+    for (const name of ['Green', 'Regular', 'Veteran', 'Elite'] as const) {
+      const params = getTierParameters(name);
+      const objective = resolveObjectiveParameters(params);
+      expect(objective).toBeDefined();
+      expect(typeof objective.objectiveAwareness).toBe('boolean');
+      expect(typeof objective.objectiveSeekingWeight).toBe('number');
+      expect(typeof objective.objectiveHoldWeight).toBe('number');
+    }
+  });
+
+  it('Green / Regular / Veteran leave objective awareness inert', () => {
+    for (const name of ['Green', 'Regular', 'Veteran'] as const) {
+      const objective = resolveObjectiveParameters(getTierParameters(name));
+      expect(objective.objectiveAwareness).toBe(false);
+      expect(objective.objectiveSeekingWeight).toBe(0);
+      expect(objective.objectiveHoldWeight).toBe(0);
+    }
+  });
+
+  it('Elite populates the objective block with active values', () => {
+    const objective = resolveObjectiveParameters(AI_TIER_REGISTRY.Elite);
+    expect(objective.objectiveAwareness).toBe(true);
+    expect(objective.objectiveSeekingWeight).toBeGreaterThan(0);
+    expect(objective.objectiveHoldWeight).toBeGreaterThan(0);
+  });
+
+  it('the inert objective block is fully disabled', () => {
+    expect(INERT_OBJECTIVE_PARAMETERS.objectiveAwareness).toBe(false);
+    expect(INERT_OBJECTIVE_PARAMETERS.objectiveSeekingWeight).toBe(0);
+    expect(INERT_OBJECTIVE_PARAMETERS.objectiveHoldWeight).toBe(0);
+  });
+
+  it('a tier record without an objective block resolves to inert', () => {
+    const noBlock = {
+      tier: 'Veteran' as const,
+      movement: AI_TIER_REGISTRY.Veteran.movement,
+    };
+    expect(resolveObjectiveParameters(noBlock)).toBe(
+      INERT_OBJECTIVE_PARAMETERS,
+    );
+  });
+});
+
+// Scenario: Lower tiers ignore the objective map — `planTurn` is never given
+// an objective input by an objective-blind tier, so the plan carries no
+// objective layer and the bot plays pure attrition.
+describe('Objective-Awareness Tier Parameters — lower tiers play Destroy', () => {
+  it('a Veteran lance plan carries no objective layer even with markers present', () => {
+    // A Veteran caller never threads the objective input (its tier disables
+    // awareness), so `planTurn` produces a plain A3a plan.
+    const friendly = [unit({ unitId: 'f1' })];
+    const enemies = [unit({ unitId: 'e1', position: { q: 5, r: 0 } })];
+    const plan = planTurn(friendly, enemies);
+    expect(plan.objectivePlan).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Requirement: Objective Ingestion and Classification
+// =============================================================================
+
+describe('classifyObjectives — objective ingestion', () => {
+  // Scenario: Attacker capture marker classifies as take
+  it('classifies a capture marker as take for the attacking side', () => {
+    const s = session({ '0,0': marker({ objectiveType: 'capture' }) });
+    const classified = classifyObjectives(s, GameSide.Player);
+    expect(classified).toHaveLength(1);
+    expect(classified[0].intent).toBe('take');
+  });
+
+  it('classifies a capture marker as deny for the defending side', () => {
+    const s = session({ '0,0': marker({ objectiveType: 'capture' }) });
+    const classified = classifyObjectives(s, GameSide.Opponent);
+    expect(classified[0].intent).toBe('deny');
+  });
+
+  // Scenario: Defender objective marker classifies as hold
+  it('classifies a defend marker as hold for the defending side', () => {
+    const s = session({ '0,0': marker({ objectiveType: 'defend' }) });
+    const classified = classifyObjectives(s, GameSide.Opponent);
+    expect(classified[0].intent).toBe('hold');
+  });
+
+  it('classifies a defend marker as take for the attacking side', () => {
+    const s = session({ '0,0': marker({ objectiveType: 'defend' }) });
+    const classified = classifyObjectives(s, GameSide.Player);
+    expect(classified[0].intent).toBe('take');
+  });
+
+  it('classifies a breakthrough exit hex as take for the attacker', () => {
+    const s = session({ '0,0': marker({ objectiveType: 'breakthrough' }) });
+    expect(classifyObjectives(s, GameSide.Player)[0].intent).toBe('take');
+    expect(classifyObjectives(s, GameSide.Opponent)[0].intent).toBe('deny');
+  });
+
+  // Scenario: Destroy scenario yields no objectives
+  it('an empty objective map yields no classified objectives', () => {
+    expect(classifyObjectives(session({}), GameSide.Player)).toEqual([]);
+  });
+
+  it('an absent objective map yields no classified objectives', () => {
+    expect(classifyObjectives(session(), GameSide.Player)).toEqual([]);
+  });
+
+  it('classification never mutates a marker', () => {
+    const m = marker({ objectiveType: 'capture' });
+    const frozen = Object.freeze({ ...m });
+    const s = session({ '0,0': frozen });
+    const classified = classifyObjectives(s, GameSide.Player);
+    expect(classified[0].marker).toEqual(frozen);
+  });
+
+  it('is deterministic — multiple markers come back in canonical hex order', () => {
+    const s = session({
+      '3,0': marker({ id: 'o-b', hexKey: '3,0' }),
+      '1,0': marker({ id: 'o-a', hexKey: '1,0' }),
+    });
+    const a = classifyObjectives(s, GameSide.Player);
+    const b = classifyObjectives(s, GameSide.Player);
+    expect(a.map((c) => c.marker.hexKey)).toEqual(['1,0', '3,0']);
+    expect(a).toEqual(b);
+  });
+});
+
+// =============================================================================
+// Requirement: Objective-Aware Lance Planning
+// =============================================================================
+
+describe('assignObjectiveRoles — objective layer on the lance plan', () => {
+  // Scenario: Capture role goes to the nearest unit
+  it('assigns the capture role to the unit closest to a take marker', () => {
+    const near = unit({ unitId: 'near', position: { q: 1, r: 0 } });
+    const far = unit({ unitId: 'far', position: { q: 8, r: 0 } });
+    const classified = classifyObjectives(
+      session({ '0,0': marker({ objectiveType: 'capture' }) }),
+      GameSide.Player,
+    );
+    const { roles, targetHexes } = assignObjectiveRoles(
+      [near, far],
+      classified,
+      hexCost,
+    );
+    expect(roles.get('near')).toBe('capture');
+    expect(roles.get('far')).toBe('screen');
+    expect(targetHexes.get('near')).toEqual({ q: 0, r: 0 });
+  });
+
+  // Scenario: Hold role goes to the unit on the marker
+  it('assigns the hold role to the unit standing on a hold marker', () => {
+    const onMarker = unit({ unitId: 'holder', position: { q: 0, r: 0 } });
+    const elsewhere = unit({ unitId: 'other', position: { q: 4, r: 0 } });
+    const classified = classifyObjectives(
+      session({ '0,0': marker({ objectiveType: 'defend' }) }),
+      GameSide.Opponent,
+    );
+    const { roles, targetHexes } = assignObjectiveRoles(
+      [onMarker, elsewhere],
+      classified,
+      hexCost,
+    );
+    expect(roles.get('holder')).toBe('hold');
+    expect(targetHexes.get('holder')).toEqual({ q: 0, r: 0 });
+  });
+
+  // Scenario: Remaining units screen
+  it('every non-objective unit receives the screen role with no objective hex', () => {
+    const seeker = unit({ unitId: 'a-seeker', position: { q: 1, r: 0 } });
+    const screen1 = unit({ unitId: 'b-screen', position: { q: 6, r: 0 } });
+    const screen2 = unit({ unitId: 'c-screen', position: { q: 7, r: 0 } });
+    const classified = classifyObjectives(
+      session({ '0,0': marker({ objectiveType: 'capture' }) }),
+      GameSide.Player,
+    );
+    const { roles, targetHexes } = assignObjectiveRoles(
+      [seeker, screen1, screen2],
+      classified,
+      hexCost,
+    );
+    expect(roles.get('a-seeker')).toBe('capture');
+    expect(roles.get('b-screen')).toBe('screen');
+    expect(roles.get('c-screen')).toBe('screen');
+    expect(targetHexes.has('b-screen')).toBe(false);
+    expect(targetHexes.has('c-screen')).toBe(false);
+  });
+
+  it('a Destroy scenario assigns every unit the screen role', () => {
+    const units = [unit({ unitId: 'f1' }), unit({ unitId: 'f2' })];
+    const { roles, targetHexes } = assignObjectiveRoles(units, [], hexCost);
+    expect(roles.get('f1')).toBe('screen');
+    expect(roles.get('f2')).toBe('screen');
+    expect(targetHexes.size).toBe(0);
+  });
+
+  it('a unit never receives two objective roles', () => {
+    const u1 = unit({ unitId: 'u1', position: { q: 1, r: 0 } });
+    const u2 = unit({ unitId: 'u2', position: { q: 2, r: 0 } });
+    const classified = classifyObjectives(
+      session({
+        '0,0': marker({ id: 'o1', hexKey: '0,0', objectiveType: 'capture' }),
+        '5,0': marker({ id: 'o2', hexKey: '5,0', objectiveType: 'capture' }),
+      }),
+      GameSide.Player,
+    );
+    const { roles } = assignObjectiveRoles([u1, u2], classified, hexCost);
+    // Two markers, two units — each unit takes exactly one capture role.
+    expect(roles.get('u1')).toBe('capture');
+    expect(roles.get('u2')).toBe('capture');
+  });
+
+  it('role assignment is deterministic across repeated runs', () => {
+    const friendly = [
+      unit({ unitId: 'f1', position: { q: 3, r: 0 } }),
+      unit({ unitId: 'f2', position: { q: 3, r: 0 } }),
+    ];
+    const classified = classifyObjectives(
+      session({ '0,0': marker({ objectiveType: 'capture' }) }),
+      GameSide.Player,
+    );
+    const a = assignObjectiveRoles(friendly, classified, hexCost);
+    const b = assignObjectiveRoles(friendly, classified, hexCost);
+    expect(Array.from(a.roles.entries())).toEqual(
+      Array.from(b.roles.entries()),
+    );
+    // Equal-cost tie broken by canonical unit id — `f1` wins the capture.
+    expect(a.roles.get('f1')).toBe('capture');
+    expect(a.roles.get('f2')).toBe('screen');
+  });
+
+  it('planObjectives reports the scenario type and omits the layer for Destroy', () => {
+    const captured = planObjectives(
+      session({ '0,0': marker({ objectiveType: 'capture' }) }),
+      GameSide.Player,
+      [unit({ unitId: 'f1' })],
+      hexCost,
+    );
+    expect(captured.scenarioType).toBe('capture');
+
+    const destroy = planObjectives(
+      session({}),
+      GameSide.Player,
+      [unit({ unitId: 'f1' })],
+      hexCost,
+    );
+    expect(destroy.scenarioType).toBe('destroy');
+    expect(destroy.roles.get('f1')).toBe('screen');
+  });
+
+  it('planTurn attaches the objective layer only for a non-Destroy scenario', () => {
+    const friendly = [unit({ unitId: 'f1', position: { q: 2, r: 0 } })];
+    const enemies = [unit({ unitId: 'e1', position: { q: 8, r: 0 } })];
+
+    const capturePlan = planTurn(friendly, enemies, {
+      session: session({ '0,0': marker({ objectiveType: 'capture' }) }),
+      botSide: GameSide.Player,
+      costFn: hexCost,
+    });
+    expect(capturePlan.objectivePlan).toBeDefined();
+    expect(capturePlan.objectivePlan?.scenarioType).toBe('capture');
+
+    const destroyPlan = planTurn(friendly, enemies, {
+      session: session({}),
+      botSide: GameSide.Player,
+      costFn: hexCost,
+    });
+    expect(destroyPlan.objectivePlan).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Requirement: Objective-Seeking Movement
+// =============================================================================
+
+describe('scoreMove — objective-seeking movement', () => {
+  const grid = makeGrid(10);
+
+  function moveTo(dest: IHexCoordinate): IMove {
+    return {
+      destination: dest,
+      facing: Facing.North,
+      movementType: MovementType.Walk,
+      mpCost: 1,
+      heatGenerated: 1,
+    };
+  }
+
+  // Scenario: Capture unit moves onto its objective
+  it('a capture unit scores an on-marker destination above an off-marker one', () => {
+    const attacker = unit({ unitId: 'cap', position: { q: 3, r: 0 } });
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker],
+      grid,
+      tierObjective: AI_TIER_REGISTRY.Elite.objective,
+      objectiveRole: 'capture',
+      objectiveHex: { q: 0, r: 0 },
+    };
+    const onMarker = scoreMove(moveTo({ q: 0, r: 0 }), ctx);
+    const offMarker = scoreMove(moveTo({ q: 2, r: 0 }), ctx);
+    expect(onMarker).toBeGreaterThan(offMarker);
+  });
+
+  it('a capture unit prefers a closer destination over a further one', () => {
+    const attacker = unit({ unitId: 'cap', position: { q: 5, r: 0 } });
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker],
+      grid,
+      tierObjective: AI_TIER_REGISTRY.Elite.objective,
+      objectiveRole: 'capture',
+      objectiveHex: { q: 0, r: 0 },
+    };
+    const closer = scoreMove(moveTo({ q: 3, r: 0 }), ctx);
+    const further = scoreMove(moveTo({ q: 6, r: 0 }), ctx);
+    expect(closer).toBeGreaterThan(further);
+  });
+
+  // Scenario: Hold unit stays on its objective
+  it('a hold unit scores staying on the marker above leaving it', () => {
+    const attacker = unit({ unitId: 'hold', position: { q: 0, r: 0 } });
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker],
+      grid,
+      tierObjective: AI_TIER_REGISTRY.Elite.objective,
+      objectiveRole: 'hold',
+      objectiveHex: { q: 0, r: 0 },
+    };
+    const stay = scoreMove(moveTo({ q: 0, r: 0 }), ctx);
+    const chase = scoreMove(moveTo({ q: 3, r: 0 }), ctx);
+    expect(stay).toBeGreaterThan(chase);
+  });
+
+  it('a hold unit scores an adjacent hex above abandoning but below the marker', () => {
+    const attacker = unit({ unitId: 'hold', position: { q: 0, r: 0 } });
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker],
+      grid,
+      tierObjective: AI_TIER_REGISTRY.Elite.objective,
+      objectiveRole: 'hold',
+      objectiveHex: { q: 0, r: 0 },
+    };
+    const onMarker = scoreMove(moveTo({ q: 0, r: 0 }), ctx);
+    const adjacent = scoreMove(moveTo({ q: 1, r: 0 }), ctx);
+    const abandoned = scoreMove(moveTo({ q: 4, r: 0 }), ctx);
+    expect(onMarker).toBeGreaterThan(adjacent);
+    expect(adjacent).toBeGreaterThan(abandoned);
+  });
+
+  // Scenario: Screen unit ignores the objective term
+  it('a screen unit receives zero objective contribution', () => {
+    const attacker = unit({ unitId: 'scr', position: { q: 3, r: 0 } });
+    const base: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker],
+      grid,
+    };
+    const withObjective: IScoreMoveContext = {
+      ...base,
+      tierObjective: AI_TIER_REGISTRY.Elite.objective,
+      objectiveRole: 'screen',
+      objectiveHex: { q: 0, r: 0 },
+    };
+    const move = moveTo({ q: 0, r: 0 });
+    expect(scoreMove(move, withObjective)).toBe(scoreMove(move, base));
+  });
+
+  it('a disabled objective tier contributes zero even for a capture role', () => {
+    const attacker = unit({ unitId: 'cap', position: { q: 3, r: 0 } });
+    const base: IScoreMoveContext = { attacker, allUnits: [attacker], grid };
+    const inert: IScoreMoveContext = {
+      ...base,
+      tierObjective: INERT_OBJECTIVE_PARAMETERS,
+      objectiveRole: 'capture',
+      objectiveHex: { q: 0, r: 0 },
+    };
+    const move = moveTo({ q: 0, r: 0 });
+    expect(scoreMove(move, inert)).toBe(scoreMove(move, base));
+  });
+
+  it('the objective term is absent entirely for a Veteran-style context', () => {
+    // No `tierObjective` / `objectiveRole` — the legacy / non-objective
+    // caller path. Scoring must equal the no-objective baseline.
+    const attacker = unit({ unitId: 'u', position: { q: 3, r: 0 } });
+    const ctx: IScoreMoveContext = { attacker, allUnits: [attacker], grid };
+    const move = moveTo({ q: 0, r: 0 });
+    // Re-scoring with the same ctx is stable, and no objective term applies.
+    expect(scoreMove(move, ctx)).toBe(scoreMove(move, ctx));
+  });
+});
+
+// =============================================================================
+// Requirement: Objective-Aware Target Discipline
+// =============================================================================
+
+describe('playAttackPhase — objective-aware target discipline', () => {
+  /** Build a lance context whose plan carries the given objective layer. */
+  function lanceContext(
+    objectivePlan: IObjectiveLancePlan,
+    lancemates: readonly IAIUnitState[],
+  ): IAILanceContext {
+    return {
+      plan: {
+        threatMap: [],
+        fireAssignment: { assignments: new Map(), finishableTargets: [] },
+        lanceCentroid: { q: 0, r: 0 },
+        objectivePlan,
+      },
+      lancemates,
+    };
+  }
+
+  // Scenario: Hold unit engages from its objective
+  it('a hold unit engages a target reachable from the marker, not one off it', () => {
+    // The hold unit sits on its marker at 0,0 with a 9-range weapon. A near
+    // enemy is in range of the marker; a far enemy at range 14 is only
+    // reachable by leaving the marker — discipline must exclude it.
+    const holder = unit({
+      unitId: 'holder',
+      position: { q: 0, r: 0 },
+      weapons: [weapon({ longRange: 9 })],
+    });
+    const nearEnemy = unit({
+      unitId: 'near-enemy',
+      position: { q: 5, r: 0 },
+      weapons: [weapon({ damage: 5 })],
+    });
+    const farEnemy = unit({
+      unitId: 'far-enemy',
+      position: { q: 14, r: 0 },
+      weapons: [weapon({ damage: 30 })],
+    });
+
+    const objectivePlan: IObjectiveLancePlan = {
+      scenarioType: 'defend',
+      roles: new Map([['holder', 'hold']]),
+      targetHexes: new Map([['holder', { q: 0, r: 0 }]]),
+    };
+
+    const bot = new BotPlayer(new SeededRandom(1), ELITE);
+    const event = bot.playAttackPhase(
+      holder,
+      [holder, nearEnemy, farEnemy],
+      lanceContext(objectivePlan, [holder]),
+    );
+    expect(event).not.toBeNull();
+    // Even though the far enemy is far more threatening, the hold unit fires
+    // on the near enemy — the one engageable from its objective hex.
+    expect(event?.payload.targetId).toBe('near-enemy');
+  });
+
+  // Scenario: Screen unit selects targets normally
+  it('a screen unit selects targets with no objective bias', () => {
+    const screen = unit({
+      unitId: 'screen',
+      position: { q: 0, r: 0 },
+      weapons: [weapon({ longRange: 20 })],
+    });
+    const weakEnemy = unit({
+      unitId: 'weak',
+      position: { q: 3, r: 0 },
+      weapons: [weapon({ damage: 1 })],
+    });
+    const strongEnemy = unit({
+      unitId: 'strong',
+      position: { q: 6, r: 0 },
+      weapons: [weapon({ damage: 25 }), weapon({ damage: 25 })],
+    });
+
+    const objectivePlan: IObjectiveLancePlan = {
+      scenarioType: 'defend',
+      roles: new Map([['screen', 'screen']]),
+      targetHexes: new Map(),
+    };
+
+    const bot = new BotPlayer(new SeededRandom(1), ELITE);
+    const withPlan = bot.playAttackPhase(
+      screen,
+      [screen, weakEnemy, strongEnemy],
+      lanceContext(objectivePlan, [screen]),
+    );
+    const withoutPlan = bot.playAttackPhase(screen, [
+      screen,
+      weakEnemy,
+      strongEnemy,
+    ]);
+    // A screen role applies no discipline — selection matches the
+    // no-objective coordinated-combat behavior.
+    expect(withPlan?.payload.targetId).toBe(withoutPlan?.payload.targetId);
+  });
+
+  it('discipline falls through to the full set when no enemy is reachable from the objective', () => {
+    // The hold unit's only enemy is out of range of the marker — the bounded
+    // bias must NOT silence the unit; it fires its best available shot.
+    const holder = unit({
+      unitId: 'holder',
+      position: { q: 0, r: 0 },
+      weapons: [weapon({ longRange: 30 })],
+    });
+    const distantEnemy = unit({
+      unitId: 'distant',
+      position: { q: 20, r: 0 },
+      weapons: [weapon({ damage: 5 })],
+    });
+
+    const objectivePlan: IObjectiveLancePlan = {
+      scenarioType: 'defend',
+      roles: new Map([['holder', 'hold']]),
+      targetHexes: new Map([['holder', { q: 0, r: 0 }]]),
+    };
+
+    const bot = new BotPlayer(new SeededRandom(1), ELITE);
+    const event = bot.playAttackPhase(
+      holder,
+      [holder, distantEnemy],
+      lanceContext(objectivePlan, [holder]),
+    );
+    expect(event).not.toBeNull();
+    expect(event?.payload.targetId).toBe('distant');
+  });
+});
+
+// =============================================================================
+// Determinism — Veteran tier is unaffected by the objective layer
+// =============================================================================
+
+describe('A3b determinism — non-objective-aware tiers are unchanged', () => {
+  it('a Veteran bot ignores an objective plan threaded into the lance context', () => {
+    const grid = makeGrid(8);
+    const veteranUnit = unit({
+      unitId: 'vet',
+      position: { q: 0, r: 4 },
+      weapons: [weapon({ longRange: 12 })],
+    });
+    const enemy = unit({
+      unitId: 'enemy',
+      position: { q: 0, r: 0 },
+      weapons: [weapon({ damage: 5 })],
+    });
+
+    // An objective plan that, IF honored, would route the unit to 0,0.
+    const objectivePlan: IObjectiveLancePlan = {
+      scenarioType: 'capture',
+      roles: new Map([['vet', 'capture']]),
+      targetHexes: new Map([['vet', { q: 0, r: 0 }]]),
+    };
+    const ctx: IAILanceContext = {
+      plan: {
+        threatMap: [],
+        fireAssignment: { assignments: new Map(), finishableTargets: [] },
+        lanceCentroid: { q: 0, r: 4 },
+        objectivePlan,
+      },
+      lancemates: [veteranUnit],
+    };
+
+    // The Veteran bot's move with and without the objective plan threaded in
+    // must be byte-identical — its tier disables objective awareness, so the
+    // objective term contributes zero regardless of the role in the plan.
+    const botA = new BotPlayer(new SeededRandom(99), VETERAN);
+    const moveA = botA.playMovementPhase(
+      veteranUnit,
+      grid,
+      { walkMP: 4, runMP: 6, jumpMP: 0 },
+      [veteranUnit, enemy],
+      ctx,
+    );
+    const botB = new BotPlayer(new SeededRandom(99), VETERAN);
+    const moveB = botB.playMovementPhase(
+      veteranUnit,
+      grid,
+      { walkMP: 4, runMP: 6, jumpMP: 0 },
+      [veteranUnit, enemy],
+    );
+    expect(moveA?.payload.to).toEqual(moveB?.payload.to);
+    expect(moveA?.payload.facing).toEqual(moveB?.payload.facing);
+  });
+});

--- a/src/simulation/__tests__/aiObjectiveAwarenessIntegration.test.ts
+++ b/src/simulation/__tests__/aiObjectiveAwarenessIntegration.test.ts
@@ -1,0 +1,484 @@
+/**
+ * Integration tests for AI objective awareness (A3b).
+ *
+ * Drives an `Elite` `BotPlayer` over a generated scenario — Capture, Defend,
+ * Breakthrough — turn by turn, threading the objective layer through the
+ * lance context, and asserts the bot plays the scenario: it walks a unit onto
+ * a capture objective and holds it, holds a defend marker to the turn limit,
+ * and moves units to a breakthrough exit edge. A `Veteran` bot, blind to the
+ * objective map, fails to capture.
+ *
+ * Covers `add-ai-objective-awareness` tasks 6.1–6.3.
+ *
+ * @spec openspec/changes/add-ai-objective-awareness/specs/simulation-system/spec.md
+ *   Requirement: Objective-Aware Lance Planning
+ *   Requirement: Objective-Seeking Movement
+ */
+
+import type {
+  IGameSession,
+  IGameState,
+  IHex,
+  IHexCoordinate,
+  IHexGrid,
+  IMovementCapability,
+  IUnitGameState,
+} from '@/types/gameplay';
+import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
+
+import {
+  Facing,
+  GamePhase,
+  GameSide,
+  GameStatus,
+  LockState,
+  MovementType,
+} from '@/types/gameplay';
+import { ScenarioObjectiveType } from '@/types/scenario/ScenarioInterfaces';
+import { coordToKey, hexDistance } from '@/utils/gameplay/hexMath';
+import {
+  advanceObjectiveControl,
+  evaluateObjectiveOutcome,
+} from '@/utils/gameplay/objectives';
+
+import type { ObjectiveCostFn } from '../ai/AIObjectivePlanner';
+import type { IAILanceContext } from '../ai/BotPlayer';
+import type { IAIUnitState, IBotBehavior, IWeapon } from '../ai/types';
+
+import { planTurn } from '../ai/AILancePlanner';
+import { findPath } from '../ai/AITerrainPathfinder';
+import { BotPlayer } from '../ai/BotPlayer';
+import { SeededRandom } from '../core/SeededRandom';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeGrid(radius: number): IHexGrid {
+  const hexes = new Map<string, IHex>();
+  for (let q = -radius; q <= radius; q++) {
+    for (let r = -radius; r <= radius; r++) {
+      if (Math.abs(q + r) > radius) continue;
+      hexes.set(`${q},${r}`, {
+        coord: { q, r },
+        occupantId: null,
+        terrain: 'clear',
+        elevation: 0,
+      });
+    }
+  }
+  return { config: { radius }, hexes };
+}
+
+function weapon(overrides: Partial<IWeapon> = {}): IWeapon {
+  return {
+    id: 'mlas',
+    name: 'Medium Laser',
+    shortRange: 3,
+    mediumRange: 6,
+    longRange: 12,
+    damage: 5,
+    heat: 3,
+    minRange: 0,
+    ammoPerTon: -1,
+    destroyed: false,
+    ...overrides,
+  };
+}
+
+function unitState(
+  id: string,
+  side: GameSide,
+  pos: IHexCoordinate,
+): IUnitGameState {
+  return {
+    id,
+    side,
+    position: pos,
+    facing: Facing.North,
+    heat: 0,
+    movementThisTurn: MovementType.Stationary,
+    hexesMovedThisTurn: 0,
+    armor: {},
+    structure: {},
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {},
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+  };
+}
+
+/** A walking-only capability — 5 walk MP, no jump. */
+const CAPABILITY: IMovementCapability = { walkMP: 5, runMP: 8, jumpMP: 0 };
+
+const ELITE: IBotBehavior = {
+  retreatThreshold: 0.3,
+  retreatEdge: 'nearest',
+  safeHeatThreshold: 13,
+  tier: 'Elite',
+};
+
+const VETERAN: IBotBehavior = {
+  retreatThreshold: 0.3,
+  retreatEdge: 'nearest',
+  safeHeatThreshold: 13,
+  tier: 'Veteran',
+};
+
+/**
+ * Translate an `IUnitGameState` to the `IAIUnitState` the bot reasons over.
+ * Every unit carries a single 12-range medium laser — enough to be a valid
+ * combatant without dominating the objective term.
+ */
+function toAI(unit: IUnitGameState): IAIUnitState {
+  return {
+    unitId: unit.id,
+    position: unit.position,
+    facing: unit.facing as Facing,
+    heat: unit.heat,
+    weapons: [weapon()],
+    ammo: {},
+    destroyed: unit.destroyed,
+    gunnery: 4,
+    movementType: MovementType.Stationary,
+    hexesMoved: 0,
+  };
+}
+
+/** A terrain-cost pathfinder probe — the production objective cost function. */
+function makeCostFn(grid: IHexGrid): ObjectiveCostFn {
+  return (u, hex) =>
+    findPath({
+      grid,
+      origin: u.position,
+      destination: hex,
+      movementType: MovementType.Walk,
+      capability: CAPABILITY,
+    }).totalMpCost;
+}
+
+/**
+ * Build the minimal `IGameSession` the planner reads — just the objective map
+ * on `currentState`.
+ */
+function sessionWith(
+  objectives: Record<string, IObjectiveMarker>,
+  units: IUnitGameState[],
+  turn: number,
+): IGameSession {
+  const currentState: IGameState = {
+    gameId: 'integration-game',
+    status: GameStatus.Active,
+    turn,
+    phase: GamePhase.Movement,
+    activationIndex: 0,
+    units: Object.fromEntries(units.map((u) => [u.id, u])),
+    turnEvents: [],
+    objectives,
+  };
+  return {
+    id: 'session-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    config: {
+      mapRadius: 12,
+      turnLimit: 0,
+      victoryConditions: [],
+      optionalRules: [],
+    },
+    units: [],
+    events: [],
+    currentState,
+  };
+}
+
+/**
+ * Run one bot-side movement turn: build the lance plan with the objective
+ * layer, move every living friendly unit, and return the updated unit list.
+ * The grid occupancy is kept in sync so the pathfinder routes around units.
+ */
+function runBotMovementTurn(
+  bot: BotPlayer,
+  grid: IHexGrid,
+  objectives: Record<string, IObjectiveMarker>,
+  units: IUnitGameState[],
+  botSide: GameSide,
+  turn: number,
+  objectiveAware: boolean,
+): IUnitGameState[] {
+  let working = units.map((u) => ({ ...u }));
+  const friendly = working.filter((u) => u.side === botSide && !u.destroyed);
+  const enemies = working.filter((u) => u.side !== botSide && !u.destroyed);
+
+  const session = sessionWith(objectives, working, turn);
+  const plan = planTurn(
+    friendly.map(toAI),
+    enemies.map(toAI),
+    objectiveAware ? { session, botSide, costFn: makeCostFn(grid) } : undefined,
+  );
+  const lanceContext: IAILanceContext = {
+    plan,
+    lancemates: friendly.map(toAI),
+  };
+
+  for (const unit of friendly) {
+    const aiUnit = toAI(unit);
+    const allAI = working.filter((u) => !u.destroyed).map(toAI);
+    const moveEvent = bot.playMovementPhase(
+      aiUnit,
+      grid,
+      CAPABILITY,
+      allAI,
+      lanceContext,
+    );
+    if (!moveEvent) continue;
+    // Apply the move to the working unit list.
+    working = working.map((u) =>
+      u.id === unit.id
+        ? {
+            ...u,
+            position: moveEvent.payload.to,
+            facing: moveEvent.payload.facing as Facing,
+          }
+        : u,
+    );
+  }
+  return working;
+}
+
+/** Run the once-per-turn objective control pass over every marker. */
+function advanceControl(
+  objectives: Record<string, IObjectiveMarker>,
+  units: IUnitGameState[],
+  turn: number,
+): Record<string, IObjectiveMarker> {
+  const state: IGameState = {
+    gameId: 'integration-game',
+    status: GameStatus.Active,
+    turn,
+    phase: GamePhase.End,
+    activationIndex: 0,
+    units: Object.fromEntries(units.map((u) => [u.id, u])),
+    turnEvents: [],
+    objectives,
+  };
+  const next: Record<string, IObjectiveMarker> = {};
+  for (const [key, marker] of Object.entries(objectives)) {
+    next[key] = advanceObjectiveControl(marker, state).marker;
+  }
+  return next;
+}
+
+// =============================================================================
+// Task 6.1 — Capture scenario
+// =============================================================================
+
+describe('A3b integration — Capture scenario', () => {
+  it('an Elite bot wins a Capture scenario by taking and holding the objective', () => {
+    const grid = makeGrid(12);
+    // The objective sits at the origin; the Elite (Opponent/defender role is
+    // not the attacker here — the bot is the Player attacker) starts 6 hexes
+    // out. The far enemy never contests the objective hex.
+    let objectives: Record<string, IObjectiveMarker> = {
+      '0,0': {
+        id: 'objective-1',
+        hexKey: '0,0',
+        objectiveType: 'capture',
+        owningSide: 'neutral',
+        controlSide: 'neutral',
+        controlRule: 'sole-occupancy',
+        holdTurnsRequired: 3,
+        holdProgress: 0,
+      },
+    };
+    let units: IUnitGameState[] = [
+      unitState('player-1', GameSide.Player, { q: 6, r: 0 }),
+      unitState('opponent-1', GameSide.Opponent, { q: 0, r: 11 }),
+    ];
+
+    const bot = new BotPlayer(new SeededRandom(7), ELITE);
+    let won = false;
+    for (let turn = 1; turn <= 12; turn++) {
+      units = runBotMovementTurn(
+        bot,
+        grid,
+        objectives,
+        units,
+        GameSide.Player,
+        turn,
+        true,
+      );
+      objectives = advanceControl(objectives, units, turn);
+      const outcome = evaluateObjectiveOutcome(
+        { ...sessionWith(objectives, units, turn).currentState },
+        0,
+      );
+      if (outcome?.winningSide === GameSide.Player) {
+        won = true;
+        break;
+      }
+    }
+    expect(won).toBe(true);
+  });
+
+  it('a Veteran bot fails to capture — it never seeks the objective', () => {
+    const grid = makeGrid(12);
+    let objectives: Record<string, IObjectiveMarker> = {
+      '0,0': {
+        id: 'objective-1',
+        hexKey: '0,0',
+        objectiveType: 'capture',
+        owningSide: 'neutral',
+        controlSide: 'neutral',
+        controlRule: 'sole-occupancy',
+        holdTurnsRequired: 3,
+        holdProgress: 0,
+      },
+    };
+    // The Veteran bot starts AWAY from both the objective and the enemy so
+    // its pure-attrition movement (close on the enemy) does not coincide
+    // with walking onto the objective hex.
+    let units: IUnitGameState[] = [
+      unitState('player-1', GameSide.Player, { q: 8, r: 0 }),
+      unitState('opponent-1', GameSide.Opponent, { q: 11, r: 0 }),
+    ];
+
+    const bot = new BotPlayer(new SeededRandom(7), VETERAN);
+    let won = false;
+    for (let turn = 1; turn <= 12; turn++) {
+      // `objectiveAware: false` — a Veteran caller never threads the
+      // objective input, mirroring the tier's disabled awareness flag.
+      units = runBotMovementTurn(
+        bot,
+        grid,
+        objectives,
+        units,
+        GameSide.Player,
+        turn,
+        false,
+      );
+      objectives = advanceControl(objectives, units, turn);
+      const outcome = evaluateObjectiveOutcome(
+        { ...sessionWith(objectives, units, turn).currentState },
+        0,
+      );
+      if (outcome?.winningSide === GameSide.Player) won = true;
+    }
+    // The Veteran chases the enemy and never holds the capture hex.
+    expect(won).toBe(false);
+  });
+});
+
+// =============================================================================
+// Task 6.2 — Defend scenario
+// =============================================================================
+
+describe('A3b integration — Defend scenario', () => {
+  it('an Elite bot wins a Defend scenario by holding its marker to the turn limit', () => {
+    const grid = makeGrid(12);
+    const turnLimit = 6;
+    // The defender (Opponent) already owns the marker and starts ON it.
+    let objectives: Record<string, IObjectiveMarker> = {
+      '0,0': {
+        id: 'objective-1',
+        hexKey: '0,0',
+        objectiveType: 'defend',
+        owningSide: 'opponent',
+        controlSide: 'opponent',
+        controlRule: 'sole-occupancy',
+        holdTurnsRequired: 1,
+        holdProgress: 1,
+      },
+    };
+    let units: IUnitGameState[] = [
+      unitState('opponent-1', GameSide.Opponent, { q: 0, r: 0 }),
+      // The attacker is parked far away and never advances (no bot drives it).
+      unitState('player-1', GameSide.Player, { q: 0, r: 11 }),
+    ];
+
+    const bot = new BotPlayer(new SeededRandom(3), ELITE);
+    let defenderWon = false;
+    for (let turn = 1; turn <= turnLimit; turn++) {
+      units = runBotMovementTurn(
+        bot,
+        grid,
+        objectives,
+        units,
+        GameSide.Opponent,
+        turn,
+        true,
+      );
+      objectives = advanceControl(objectives, units, turn);
+      const outcome = evaluateObjectiveOutcome(
+        sessionWith(objectives, units, turn).currentState,
+        turnLimit,
+      );
+      if (outcome?.winningSide === GameSide.Opponent) {
+        defenderWon = true;
+        break;
+      }
+    }
+    expect(defenderWon).toBe(true);
+    // The hold unit must still be standing on its marker.
+    const holder = units.find((u) => u.id === 'opponent-1');
+    expect(holder && coordToKey(holder.position)).toBe('0,0');
+  });
+});
+
+// =============================================================================
+// Task 6.3 — Breakthrough scenario
+// =============================================================================
+
+describe('A3b integration — Breakthrough scenario', () => {
+  it('an Elite bot wins a Breakthrough scenario by reaching the exit edge', () => {
+    const grid = makeGrid(12);
+    // The exit hex sits at -10,0; the attacker (Player) starts at +6,0 and
+    // must walk the exit edge. `holdTurnsRequired` carries the required-units
+    // count for breakthrough markers (1 here).
+    let objectives: Record<string, IObjectiveMarker> = {
+      '-10,0': {
+        id: 'objective-1',
+        hexKey: '-10,0',
+        objectiveType: 'breakthrough',
+        owningSide: 'neutral',
+        controlSide: 'neutral',
+        controlRule: 'sole-occupancy',
+        holdTurnsRequired: 1,
+        holdProgress: 0,
+      },
+    };
+    let units: IUnitGameState[] = [
+      unitState('player-1', GameSide.Player, { q: 6, r: 0 }),
+      unitState('opponent-1', GameSide.Opponent, { q: 11, r: 0 }),
+    ];
+
+    const bot = new BotPlayer(new SeededRandom(5), ELITE);
+    let won = false;
+    for (let turn = 1; turn <= 14; turn++) {
+      units = runBotMovementTurn(
+        bot,
+        grid,
+        objectives,
+        units,
+        GameSide.Player,
+        turn,
+        true,
+      );
+      const outcome = evaluateObjectiveOutcome(
+        sessionWith(objectives, units, turn).currentState,
+        0,
+      );
+      if (outcome?.winningSide === GameSide.Player) {
+        won = true;
+        break;
+      }
+    }
+    expect(won).toBe(true);
+    const runner = units.find((u) => u.id === 'player-1');
+    // The runner ends on the exit hex.
+    expect(runner && hexDistance(runner.position, { q: -10, r: 0 })).toBe(0);
+  });
+});

--- a/src/simulation/ai/AILancePlanner.ts
+++ b/src/simulation/ai/AILancePlanner.ts
@@ -16,13 +16,19 @@
  *   Requirement: Per-Lance Turn Plan
  */
 
-import type { IHexCoordinate } from '@/types/gameplay';
+import type { IGameSession, IHexCoordinate } from '@/types/gameplay';
+import type { GameSide } from '@/types/gameplay';
 
 import type { IFireAssignment } from './AIFireCoordinator';
+import type {
+  IObjectiveLancePlan,
+  ObjectiveCostFn,
+} from './AIObjectivePlanner';
 import type { IThreatEntry } from './AIThreatMap';
 import type { IAIUnitState } from './types';
 
 import { coordinateFire } from './AIFireCoordinator';
+import { planObjectives } from './AIObjectivePlanner';
 import { buildThreatMap } from './AIThreatMap';
 
 /**
@@ -37,6 +43,36 @@ export interface ILanceTurnPlan {
   readonly fireAssignment: IFireAssignment;
   /** Rounded centroid of the living friendly lance, for movement cohesion. */
   readonly lanceCentroid: IHexCoordinate;
+  /**
+   * Per `add-ai-objective-awareness` (A3b) design D2: the optional objective
+   * layer. Present only when `planTurn` is called with the objective inputs
+   * AND the bot's tier enables objective awareness AND the scenario is not
+   * `Destroy`. When absent, the lance plays pure A3a coordinated combat —
+   * every A3a plan built before A3b is unchanged (the field is optional).
+   */
+  readonly objectivePlan?: IObjectiveLancePlan;
+}
+
+/**
+ * Per `add-ai-objective-awareness` (A3b) design D2: the optional objective
+ * context a caller threads into `planTurn` so the lance plan gains its
+ * objective layer.
+ *
+ *   - `session` is the live game session — `classifyObjectives` reads its
+ *     `currentState.objectives` map and the scenario objective type.
+ *   - `botSide` is the side the bot is playing; it decides whether each
+ *     marker is a `take` / `hold` / `deny` objective.
+ *   - `costFn` measures how far a friendly unit is from an objective hex —
+ *     production callers pass a terrain-cost pathfinder probe so the closest
+ *     unit by real movement cost gets the capture role.
+ *
+ * When this context is omitted, `planTurn` returns a plain A3a plan with no
+ * `objectivePlan` — every existing A3a caller is unchanged.
+ */
+export interface IObjectivePlanInput {
+  readonly session: IGameSession;
+  readonly botSide: GameSide;
+  readonly costFn: ObjectiveCostFn;
 }
 
 /**
@@ -124,6 +160,15 @@ export function computeLanceCentroid(
  *   - `fireAssignment` — `coordinateFire(friendly, enemies, threatMap)`.
  *   - `lanceCentroid` — `computeLanceCentroid(friendly)`.
  *
+ * Per `add-ai-objective-awareness` (A3b) design D2: when `objectiveInput` is
+ * supplied, the plan also carries an `objectivePlan` — `planObjectives`
+ * classifies the session's objective map for the bot's side and assigns each
+ * friendly unit an objective role. The objective layer is attached ONLY when
+ * the scenario is not `Destroy` (an empty objective map yields a `'destroy'`
+ * scenario type and no roles, so the bot falls through to pure A3a). The
+ * caller only passes `objectiveInput` for an objective-aware tier, so the
+ * tier flag gates whether the planner ever sees the objective map at all.
+ *
  * The returned plan is frozen so a per-unit decision cannot mutate the shared
  * picture. Pure deterministic function — identical unit sets always yield an
  * identical plan, and no `SeededRandom` is consumed.
@@ -131,14 +176,33 @@ export function computeLanceCentroid(
 export function planTurn(
   friendly: readonly IAIUnitState[],
   enemies: readonly IAIUnitState[],
+  objectiveInput?: IObjectivePlanInput,
 ): ILanceTurnPlan {
   const threatMap = buildThreatMap(friendly, enemies);
   const fireAssignment = coordinateFire(friendly, enemies, threatMap);
   const lanceCentroid = computeLanceCentroid(friendly);
 
+  // A3b objective layer — built only when the objective context is threaded
+  // through (an objective-aware tier). A `Destroy` scenario produces a
+  // `'destroy'` plan with no roles; in that case we omit `objectivePlan`
+  // entirely so the lance plays pure A3a coordinated combat.
+  let objectivePlan: IObjectiveLancePlan | undefined;
+  if (objectiveInput) {
+    const built = planObjectives(
+      objectiveInput.session,
+      objectiveInput.botSide,
+      friendly,
+      objectiveInput.costFn,
+    );
+    if (built.scenarioType !== 'destroy') {
+      objectivePlan = built;
+    }
+  }
+
   return Object.freeze({
     threatMap,
     fireAssignment,
     lanceCentroid,
+    ...(objectivePlan ? { objectivePlan } : {}),
   });
 }

--- a/src/simulation/ai/AIObjectivePlanner.ts
+++ b/src/simulation/ai/AIObjectivePlanner.ts
@@ -1,0 +1,343 @@
+/**
+ * AI objective planner — reads the scenario objective map and turns it into
+ * a plan the bot can act on.
+ *
+ * Per `add-ai-objective-awareness` design D1 / D2 / D3: where the objective
+ * engine (`add-scenario-objective-engine`) supplies the spatial objective
+ * system — `IObjectiveMarker` records on `state.objectives`, control
+ * detection, victory evaluation — and A3a's `AILancePlanner` supplies the
+ * per-side per-turn combat plan, this module is the connector. It:
+ *
+ *   1. `classifyObjectives` — reads `session.currentState.objectives` and the
+ *      scenario objective type and classifies each marker for the bot's side
+ *      as `take`, `hold`, or `deny` (D1).
+ *   2. `assignObjectiveRoles` — assigns each friendly unit an objective role
+ *      (`capture`, `hold`, `screen`) and the hex it works toward / holds,
+ *      producing the `IObjectiveLancePlan` that rides on A3a's
+ *      `ILanceTurnPlan` (D2 / D3).
+ *
+ * Everything here is a pure deterministic function of the objective map and
+ * the unit set — no `SeededRandom` is consumed, role ties break on canonical
+ * unit-id order (design D6). The planner only *reads* the objective markers;
+ * it never writes them — placement, control detection, and victory
+ * evaluation stay owned by the objective engine.
+ *
+ * @spec openspec/changes/add-ai-objective-awareness/specs/simulation-system/spec.md
+ *   Requirement: Objective Ingestion and Classification
+ *   Requirement: Objective-Aware Lance Planning
+ */
+
+import type { IGameSession, IHexCoordinate } from '@/types/gameplay';
+import type {
+  IObjectiveMarker,
+  ObjectiveMarkerType,
+} from '@/types/scenario/ScenarioInterfaces';
+
+import { GameSide } from '@/types/gameplay';
+import { coordToKey, keyToCoord } from '@/utils/gameplay/hexMath';
+import {
+  ATTACKER_SIDE,
+  gameSideToObjectiveSide,
+} from '@/utils/gameplay/objectives';
+
+import type { IAIUnitState } from './types';
+
+/**
+ * What the bot must do with an objective marker (design D1):
+ *
+ *   - `take` — a marker the bot must control to win (an attacker's `capture`
+ *     marker; a `breakthrough` exit hex it must reach).
+ *   - `hold` — a marker the bot must keep controlling to win (a defender's
+ *     `defend` marker; an attacker's `capture` marker once it owns it).
+ *   - `deny` — a marker the bot must keep the enemy off (an attacker's
+ *     `capture` / `breakthrough` marker the bot is defending against).
+ */
+export type ObjectiveIntent = 'take' | 'hold' | 'deny';
+
+/** One objective marker paired with the bot's intent toward it. */
+export interface IClassifiedObjective {
+  readonly marker: IObjectiveMarker;
+  readonly intent: ObjectiveIntent;
+}
+
+/**
+ * The objective role a single friendly unit plays this turn (design D2):
+ *
+ *   - `capture` — the unit closest to a `take` marker; it moves onto it.
+ *   - `hold` — a unit on (or nearest) a `hold` marker; it stays planted.
+ *   - `screen` — every other unit; it plays normal A3a coordinated combat,
+ *     covering the objective-bearing units.
+ */
+export type ObjectiveRole = 'capture' | 'hold' | 'screen';
+
+/**
+ * The objective layer that rides on A3a's `ILanceTurnPlan`. Carries the
+ * scenario objective type, each unit's role, and — for the role-bearing
+ * capture / hold units — the hex it is working toward or holding.
+ */
+export interface IObjectiveLancePlan {
+  /**
+   * The scenario objective type the bot is playing. `'destroy'` whenever the
+   * objective map is empty — in which case `roles`/`targetHexes` are empty
+   * and the bot falls through to pure A3a behavior.
+   */
+  readonly scenarioType: ObjectiveMarkerType | 'destroy';
+  /** friendlyUnitId -> objective role. */
+  readonly roles: ReadonlyMap<string, ObjectiveRole>;
+  /**
+   * Per role-bearing (capture / hold) unit, the hex it is working toward or
+   * holding. Screen units never appear in this map.
+   */
+  readonly targetHexes: ReadonlyMap<string, IHexCoordinate>;
+}
+
+/**
+ * A function the caller supplies so the planner can measure how far a unit
+ * is from an objective hex. Production callers pass a terrain-cost
+ * pathfinder probe (`AITerrainPathfinder.findPath` total MP cost); tests can
+ * pass a plain hex-distance. A larger number means "further away".
+ *
+ * Keeping the cost source injectable keeps this module free of a grid /
+ * movement-capability dependency and a pathfinder import cycle.
+ */
+export type ObjectiveCostFn = (
+  unit: IAIUnitState,
+  hex: IHexCoordinate,
+) => number;
+
+/**
+ * Read the session's objective map and classify each marker for the bot's
+ * side.
+ *
+ * The scenario objective type is derived from the markers themselves — the
+ * single-objective model means every marker shares one `objectiveType`
+ * (mirroring `evaluateObjectiveOutcome`). An empty / absent objective map is
+ * a `Destroy` scenario and yields no classified objectives, so the bot falls
+ * through to pure coordinated combat.
+ *
+ * Classification (design D1), keyed by the bot's attacker / defender role —
+ * generated scenarios make the `player` side the attacker:
+ *
+ *   - `capture` / `breakthrough` — the attacker must reach the marker, so
+ *     the bot classifies it `take` when it is the attacker and `deny` when
+ *     it is the defender.
+ *   - `defend` — the defender must keep the marker, so the bot classifies it
+ *     `hold` when it is the defender and `take` when it is the attacker.
+ *
+ * Pure deterministic function — never mutates a marker.
+ *
+ * @spec simulation-system — Objective Ingestion and Classification
+ */
+export function classifyObjectives(
+  session: IGameSession,
+  botSide: GameSide,
+): readonly IClassifiedObjective[] {
+  const objectiveMap = session.currentState.objectives;
+  if (!objectiveMap) return [];
+
+  // Canonical-key order keeps the classified list deterministic regardless
+  // of the map's insertion order.
+  const markers = Object.values(objectiveMap);
+  if (markers.length === 0) return [];
+
+  const botObjectiveSide = gameSideToObjectiveSide(botSide);
+  const botIsAttacker = botObjectiveSide === ATTACKER_SIDE;
+
+  const classified: IClassifiedObjective[] = [];
+  for (const marker of markers) {
+    classified.push({ marker, intent: intentFor(marker, botIsAttacker) });
+  }
+
+  // Sort by hex key so the order is stable and reproducible.
+  classified.sort((a, b) =>
+    a.marker.hexKey < b.marker.hexKey
+      ? -1
+      : a.marker.hexKey > b.marker.hexKey
+        ? 1
+        : 0,
+  );
+  return classified;
+}
+
+/**
+ * Resolve the bot's intent toward one marker given whether the bot is the
+ * attacking side. Pure helper for `classifyObjectives`.
+ */
+function intentFor(
+  marker: IObjectiveMarker,
+  botIsAttacker: boolean,
+): ObjectiveIntent {
+  switch (marker.objectiveType) {
+    case 'capture':
+    case 'breakthrough':
+      // The attacker must reach / hold the marker; the defender must keep
+      // the attacker off it.
+      return botIsAttacker ? 'take' : 'deny';
+    case 'defend':
+      // The defender keeps the marker; the attacker must take it.
+      return botIsAttacker ? 'take' : 'hold';
+    default:
+      // Unreachable — `ObjectiveMarkerType` has only the three families
+      // above — but TypeScript's exhaustiveness needs a fallback.
+      return botIsAttacker ? 'take' : 'deny';
+  }
+}
+
+/** Internal: a candidate (unit, cost-to-hex) pair for role assignment. */
+interface UnitCost {
+  readonly unit: IAIUnitState;
+  readonly cost: number;
+}
+
+/**
+ * Assign objective roles to a friendly lance from a set of classified
+ * objectives (design D2 / D3).
+ *
+ *   - For every `take` (and `deny`) marker, the single closest *living*
+ *     friendly unit by `costFn` receives the `capture` role with that
+ *     marker's hex as its target. The closest unit per marker is the
+ *     design's "single closest unit per marker" rule (D2 open question).
+ *   - For every `hold` marker, the friendly unit on the marker — or, if
+ *     none, the closest — receives the `hold` role with that marker's hex.
+ *   - Every other living unit receives the `screen` role and no target hex.
+ *
+ * A unit is only ever assigned one role; once it carries a capture or hold
+ * role it is removed from the candidate pool, so it will not also be picked
+ * for a second marker. Ties in `costFn` break on canonical unit-id order, so
+ * the assignment is fully deterministic and consumes no `SeededRandom`.
+ *
+ * When `classified` is empty (a `Destroy` scenario) every unit is `screen`
+ * and `targetHexes` is empty — the caller treats this as "no objective
+ * layer" and the bot plays pure A3a.
+ *
+ * @spec simulation-system — Objective-Aware Lance Planning
+ */
+export function assignObjectiveRoles(
+  friendly: readonly IAIUnitState[],
+  classified: readonly IClassifiedObjective[],
+  costFn: ObjectiveCostFn,
+): {
+  roles: Map<string, ObjectiveRole>;
+  targetHexes: Map<string, IHexCoordinate>;
+} {
+  const roles = new Map<string, ObjectiveRole>();
+  const targetHexes = new Map<string, IHexCoordinate>();
+
+  const living = friendly.filter((u) => !u.destroyed);
+  // Default every living unit to `screen`; capture / hold assignment below
+  // overrides the units it claims.
+  for (const unit of living) {
+    roles.set(unit.unitId, 'screen');
+  }
+  if (classified.length === 0) {
+    return { roles, targetHexes };
+  }
+
+  // Units still free to take an objective role. A unit is pulled from this
+  // pool the moment it is assigned, so no unit gets two roles.
+  const available = new Set(living.map((u) => u.unitId));
+
+  // Iterate the classified objectives in their (already canonical) order so
+  // the assignment is deterministic. Hold markers are handled in the same
+  // pass — `hold` prefers a unit physically on the hex.
+  for (const { marker, intent } of classified) {
+    if (available.size === 0) break;
+    const hex = keyToCoord(marker.hexKey);
+    const hexKey = marker.hexKey;
+
+    if (intent === 'hold') {
+      // Prefer a unit already on the marker hex; that unit is keeping
+      // control right now and should plant rather than move.
+      const onMarker = living
+        .filter(
+          (u) => available.has(u.unitId) && coordToKey(u.position) === hexKey,
+        )
+        .sort(byUnitId);
+      const holder =
+        onMarker[0] ?? closestAvailable(living, available, hex, costFn);
+      if (holder) {
+        roles.set(holder.unitId, 'hold');
+        targetHexes.set(holder.unitId, hex);
+        available.delete(holder.unitId);
+      }
+      continue;
+    }
+
+    // `take` and `deny` both produce a capture role — the bot must put a
+    // unit onto the marker, whether to win it or to contest the enemy off
+    // it. The single closest available unit is committed.
+    const seeker = closestAvailable(living, available, hex, costFn);
+    if (seeker) {
+      roles.set(seeker.unitId, 'capture');
+      targetHexes.set(seeker.unitId, hex);
+      available.delete(seeker.unitId);
+    }
+  }
+
+  return { roles, targetHexes };
+}
+
+/**
+ * Pick the available living unit closest to `hex` by `costFn`. Ties break on
+ * canonical unit-id order so the result is deterministic. Returns `null`
+ * when no unit is available.
+ */
+function closestAvailable(
+  living: readonly IAIUnitState[],
+  available: ReadonlySet<string>,
+  hex: IHexCoordinate,
+  costFn: ObjectiveCostFn,
+): IAIUnitState | null {
+  const candidates: UnitCost[] = [];
+  for (const unit of living) {
+    if (!available.has(unit.unitId)) continue;
+    candidates.push({ unit, cost: costFn(unit, hex) });
+  }
+  if (candidates.length === 0) return null;
+
+  candidates.sort((a, b) => {
+    if (a.cost !== b.cost) return a.cost - b.cost;
+    return byUnitId(a.unit, b.unit);
+  });
+  return candidates[0].unit;
+}
+
+/** Canonical lexicographic unit-id comparator for deterministic tie-breaks. */
+function byUnitId(a: IAIUnitState, b: IAIUnitState): number {
+  return a.unitId < b.unitId ? -1 : a.unitId > b.unitId ? 1 : 0;
+}
+
+/**
+ * Build the full `IObjectiveLancePlan` — classify the session's objective
+ * map for the bot's side, then assign every friendly unit a role.
+ *
+ * When the objective map is empty the plan's `scenarioType` is `'destroy'`,
+ * every unit is `screen`, and `targetHexes` is empty — the caller treats
+ * this as "no objective layer" and the bot plays pure A3a.
+ *
+ * Pure deterministic function — no `SeededRandom` consumption.
+ *
+ * @spec simulation-system — Objective-Aware Lance Planning
+ */
+export function planObjectives(
+  session: IGameSession,
+  botSide: GameSide,
+  friendly: readonly IAIUnitState[],
+  costFn: ObjectiveCostFn,
+): IObjectiveLancePlan {
+  const classified = classifyObjectives(session, botSide);
+  const { roles, targetHexes } = assignObjectiveRoles(
+    friendly,
+    classified,
+    costFn,
+  );
+
+  const scenarioType: ObjectiveMarkerType | 'destroy' =
+    classified.length > 0 ? classified[0].marker.objectiveType : 'destroy';
+
+  return Object.freeze({
+    scenarioType,
+    roles,
+    targetHexes,
+  });
+}

--- a/src/simulation/ai/AITierRegistry.ts
+++ b/src/simulation/ai/AITierRegistry.ts
@@ -100,12 +100,34 @@ export interface IAITierCoordinationParameters {
 }
 
 /**
+ * Objective-awareness parameter block — the A3b contribution to a tier's
+ * parameter set (`add-ai-objective-awareness` design D5).
+ *
+ *   - `objectiveAwareness`: when `false`, the bot is blind to the scenario
+ *     objective map — `AIObjectivePlanner` is never consulted, the lance
+ *     plan carries no objective layer, and the bot plays every scenario as
+ *     `Destroy` (pure attrition). When `true`, the bot reads the objective
+ *     markers and plays the scenario (capture / defend / breakthrough).
+ *   - `objectiveSeekingWeight`: multiplier on the move-scoring term that
+ *     rewards a capture-role unit for closing on (and ending on) a `take`
+ *     marker. `0` disables objective-seeking movement.
+ *   - `objectiveHoldWeight`: multiplier on the move-scoring term that
+ *     rewards a hold-role unit for staying on its `hold` marker. `0`
+ *     disables objective-holding movement.
+ */
+export interface IAITierObjectiveParameters {
+  readonly objectiveAwareness: boolean;
+  readonly objectiveSeekingWeight: number;
+  readonly objectiveHoldWeight: number;
+}
+
+/**
  * Full parameter set for one difficulty tier.
  *
  * Open by design: A1 defines `tier` and `movement`. A2 ADDs the optional
- * `resource` block. A3a ADDs the optional `coordination` block below.
- * Later Wave 2 changes ADD their own optional blocks (`objective?`,
- * `advanced?`) without touching the fields declared here.
+ * `resource` block. A3a ADDs the optional `coordination` block. A3b ADDs the
+ * optional `objective` block below. A later Wave 2 change ADDs `advanced?`
+ * without touching the fields declared here.
  */
 export interface IAITierParameters {
   readonly tier: AITierName;
@@ -124,7 +146,14 @@ export interface IAITierParameters {
    * `resolveCoordinationParameters` to get the inert default when absent.
    */
   readonly coordination?: IAITierCoordinationParameters;
-  // A3b..A4 ADD: objective?, advanced? blocks.
+  /**
+   * A3b objective-awareness block. Optional so a tier record built before
+   * A3b (or a hand-rolled test fixture) still type-checks; every entry in
+   * `AI_TIER_REGISTRY` populates it. Resolve it through
+   * `resolveObjectiveParameters` to get the inert default when absent.
+   */
+  readonly objective?: IAITierObjectiveParameters;
+  // A4 ADDs: advanced? block.
 }
 
 /**
@@ -150,6 +179,18 @@ export const INERT_COORDINATION_PARAMETERS: IAITierCoordinationParameters = {
   cohesionRadius: 0,
   cohesionWeight: 0,
   focusFireWeight: 0,
+};
+
+/**
+ * The inert objective block — every A3b behavior disabled. Used by
+ * `resolveObjectiveParameters` when a tier record predates A3b and as the
+ * literal value `Green`/`Regular`/`Veteran` carry so the objective planner
+ * is never consulted and those tiers play every scenario as `Destroy`.
+ */
+export const INERT_OBJECTIVE_PARAMETERS: IAITierObjectiveParameters = {
+  objectiveAwareness: false,
+  objectiveSeekingWeight: 0,
+  objectiveHoldWeight: 0,
 };
 
 /**
@@ -199,6 +240,14 @@ export const AI_TIER_REGISTRY: Readonly<Record<AITierName, IAITierParameters>> =
         cohesionWeight: 0,
         focusFireWeight: 0,
       },
+      // A3b: fully inert — `objectiveAwareness: false` means the objective
+      // planner is never consulted; the bot is blind to the objective map
+      // and plays every scenario as pure attrition (`Destroy`).
+      objective: {
+        objectiveAwareness: false,
+        objectiveSeekingWeight: 0,
+        objectiveHoldWeight: 0,
+      },
     },
     Regular: {
       tier: 'Regular',
@@ -223,6 +272,13 @@ export const AI_TIER_REGISTRY: Readonly<Record<AITierName, IAITierParameters>> =
         cohesionRadius: 0,
         cohesionWeight: 0,
         focusFireWeight: 0,
+      },
+      // A3b: fully inert — see `Green`. The determinism golden traces are
+      // pinned to this tier, so the bot must stay blind to the objective map.
+      objective: {
+        objectiveAwareness: false,
+        objectiveSeekingWeight: 0,
+        objectiveHoldWeight: 0,
       },
     },
     Veteran: {
@@ -255,6 +311,16 @@ export const AI_TIER_REGISTRY: Readonly<Record<AITierName, IAITierParameters>> =
         cohesionWeight: 0,
         focusFireWeight: 0,
       },
+      // A3b: fully inert. Per `add-ai-objective-awareness` design D5, the
+      // `Veteran` tier plays every scenario as `Destroy` — `objectiveAwareness`
+      // is `false`, so the objective planner is never consulted and the
+      // objective movement terms contribute nothing. `Elite` is the only tier
+      // that reads the objective map.
+      objective: {
+        objectiveAwareness: false,
+        objectiveSeekingWeight: 0,
+        objectiveHoldWeight: 0,
+      },
     },
     Elite: {
       tier: 'Elite',
@@ -286,6 +352,24 @@ export const AI_TIER_REGISTRY: Readonly<Record<AITierName, IAITierParameters>> =
         cohesionRadius: 4,
         cohesionWeight: 200,
         focusFireWeight: 400,
+      },
+      // A3b: objective awareness active — `Elite` is the only tier that
+      // reads the scenario objective map and plays the scenario. Weight
+      // magnitudes sit relative to the existing `scoreMove` scale (LOS
+      // `+1000`, forward-arc `+500`, per-hex distance `-100`):
+      //   - `objectiveSeekingWeight: 120` is applied per hex of pathfinder
+      //     distance reduced toward a `take` marker, so a unit closing on
+      //     its objective outscores backing off (which pays only the
+      //     `-100`/hex distance term) — yet a single LOS opportunity can
+      //     still tilt a tie. A destination ON the marker earns a large
+      //     flat bonus (see `MoveAI.objectiveScore`) that dominates.
+      //   - `objectiveHoldWeight: 800` keeps a hold-role unit planted on
+      //     its marker: staying on it outscores chasing an enemy off it,
+      //     since abandoning the marker forfeits the whole term.
+      objective: {
+        objectiveAwareness: true,
+        objectiveSeekingWeight: 120,
+        objectiveHoldWeight: 800,
       },
     },
   };
@@ -362,4 +446,22 @@ export function resolveCoordinationParameters(
   params: IAITierParameters,
 ): IAITierCoordinationParameters {
   return params.coordination ?? INERT_COORDINATION_PARAMETERS;
+}
+
+/**
+ * Resolve the A3b objective-awareness block for a tier parameter record,
+ * falling back to `INERT_OBJECTIVE_PARAMETERS` when the record predates A3b
+ * (the optional `objective` field is absent).
+ *
+ * Used by `BotPlayer`, `AILancePlanner`, and `MoveAI` so a hand-rolled
+ * `IAITierParameters` fixture without an `objective` block resolves to
+ * fully-inert objective awareness — the `Destroy`-only bot — rather than
+ * throwing on an undefined access. Every entry in `AI_TIER_REGISTRY`
+ * populates `objective`, so production callers always get the real tier
+ * values.
+ */
+export function resolveObjectiveParameters(
+  params: IAITierParameters,
+): IAITierObjectiveParameters {
+  return params.objective ?? INERT_OBJECTIVE_PARAMETERS;
 }

--- a/src/simulation/ai/BotPlayer.ts
+++ b/src/simulation/ai/BotPlayer.ts
@@ -1,6 +1,7 @@
 import type {
   IComponentDestroyedPayload,
   IGameSession,
+  IHexCoordinate,
   IHexGrid,
   IMovementCapability,
   IUnitPosition,
@@ -183,6 +184,17 @@ export class BotPlayer implements IAIPlayer {
       return null;
     }
 
+    // Per `add-ai-objective-awareness` (A3b) design D3: a capture- or
+    // hold-role unit already standing ON its objective hex stays planted —
+    // every non-stationary move would abandon the marker and forfeit the
+    // objective term. Returning `null` (no `MovementDeclared`) keeps the unit
+    // on the objective so it holds control / accrues hold progress. A
+    // `screen`-role unit, a `Destroy` scenario, or a non-objective-aware tier
+    // never hits this branch and moves exactly as the A3a bot does.
+    if (this.shouldHoldObjectiveHex(unit, lanceContext)) {
+      return null;
+    }
+
     const position: IUnitPosition = {
       unitId: unit.unitId,
       coord: unit.position,
@@ -253,6 +265,14 @@ export class BotPlayer implements IAIPlayer {
                 ),
               }
             : {}),
+          // Per `add-ai-objective-awareness` (A3b) design D3: thread the
+          // unit's objective role and target hex from the lance plan's
+          // objective layer. `MoveAI.enrichScoreContext` attaches the tier
+          // objective block; `scoreMove`'s objective term stays inert for a
+          // `screen`-role unit or when the tier disables objective
+          // awareness. Omitted entirely when the plan carries no objective
+          // layer (a `Destroy` scenario or a non-objective-aware tier).
+          ...this.objectiveMoveFields(unit.unitId, lanceContext),
         };
       }
     }
@@ -304,6 +324,21 @@ export class BotPlayer implements IAIPlayer {
       return null;
     }
 
+    // Per `add-ai-objective-awareness` (A3b) design D4: objective-aware
+    // target discipline. When the unit holds a `capture` or `hold` objective
+    // role, narrow the valid-target set to enemies it can engage WITHOUT
+    // leaving its objective hex — enemies within weapon range of the marker.
+    // The unit fires from the objective rather than chasing an enemy off it.
+    // When no enemy is in-discipline the bias falls through to the full set
+    // (a bounded bias, not a hard mandate — design D4 risk note). A
+    // `screen`-role unit, a `Destroy` scenario, or a non-objective-aware
+    // tier leaves `disciplinedTargets` equal to `validTargets`.
+    const disciplinedTargets = this.applyObjectiveTargetDiscipline(
+      attacker,
+      validTargets,
+      lanceContext,
+    );
+
     // Per `improve-bot-basic-combat-competence` task 2.5: pass attacker
     // so the threat-scored selector picks the most threatening target
     // instead of a uniform-random pick. Per `add-ai-resource-planning`
@@ -315,10 +350,18 @@ export class BotPlayer implements IAIPlayer {
     // focus-fire target overrides the self-scored pick — but only when the
     // assigned target is reachable (in a valid target set and with at least
     // one weapon in arc/range). Otherwise the unit falls back cleanly.
+    //
+    // The coordinated pick and the self-scored pick both run over the
+    // objective-disciplined set so an objective-role unit still concentrates
+    // fire with the lance, but only on an in-discipline target.
     const target =
-      this.selectCoordinatedTarget(attacker, validTargets, lanceContext) ??
+      this.selectCoordinatedTarget(
+        attacker,
+        disciplinedTargets,
+        lanceContext,
+      ) ??
       this.attackAI.selectTarget(
-        validTargets,
+        disciplinedTargets,
         this.random,
         attacker,
         this.resource,
@@ -571,6 +614,111 @@ export class BotPlayer implements IAIPlayer {
   }
 
   /**
+   * Per `add-ai-objective-awareness` (A3b) design D3: resolve the objective
+   * movement fields for a unit from the lance plan's objective layer.
+   *
+   * Returns `{ objectiveRole, objectiveHex }` when the lance plan carries an
+   * objective layer that assigns this unit a `capture` or `hold` role — the
+   * fields `MoveAI.scoreMove`'s objective term consumes. Returns `{}` (no
+   * fields) when there is no objective plan (a `Destroy` scenario or a
+   * non-objective-aware tier), or when the unit is a `screen`-role unit with
+   * no objective hex — so `scoreMove`'s objective term stays inert and the
+   * unit plays pure A3a movement.
+   */
+  private objectiveMoveFields(
+    unitId: string,
+    lanceContext?: IAILanceContext,
+  ): Partial<Pick<IScoreMoveContext, 'objectiveRole' | 'objectiveHex'>> {
+    const objectivePlan = lanceContext?.plan.objectivePlan;
+    if (!objectivePlan) return {};
+
+    const role = objectivePlan.roles.get(unitId);
+    if (!role || role === 'screen') return {};
+
+    const hex = objectivePlan.targetHexes.get(unitId);
+    if (!hex) return {};
+
+    return { objectiveRole: role, objectiveHex: hex };
+  }
+
+  /**
+   * Per `add-ai-objective-awareness` (A3b) design D3: `true` when `unit`
+   * holds a `capture` or `hold` objective role AND is already standing on
+   * its objective hex. Such a unit must stay planted — any move forfeits the
+   * marker. `playMovementPhase` returns `null` (no movement) in that case so
+   * the unit keeps control of the objective.
+   *
+   * Returns `false` for a `screen`-role unit, a unit off its objective hex
+   * (it still needs to move toward it), a `Destroy` scenario, or a
+   * non-objective-aware tier (no `objectivePlan`) — every such unit moves
+   * exactly as the A3a bot does.
+   */
+  private shouldHoldObjectiveHex(
+    unit: IAIUnitState,
+    lanceContext?: IAILanceContext,
+  ): boolean {
+    const objectivePlan = lanceContext?.plan.objectivePlan;
+    if (!objectivePlan) return false;
+
+    const role = objectivePlan.roles.get(unit.unitId);
+    if (role !== 'capture' && role !== 'hold') return false;
+
+    const hex = objectivePlan.targetHexes.get(unit.unitId);
+    if (!hex) return false;
+
+    return unit.position.q === hex.q && unit.position.r === hex.r;
+  }
+
+  /**
+   * Per `add-ai-objective-awareness` (A3b) design D4: objective-aware target
+   * discipline. When `attacker` holds a `capture` or `hold` objective role,
+   * restrict its valid-target set to enemies it can engage from its
+   * objective hex — enemies within the unit's longest live-weapon range of
+   * the marker. The unit fires from the objective rather than pursuing an
+   * enemy off it.
+   *
+   * The discipline is a bounded bias, not a hard mandate (design D4 risk
+   * note): when NO enemy is engageable from the objective hex the full
+   * `validTargets` set is returned unchanged, so the unit still fires its
+   * best available shot rather than going silent. A `screen`-role unit, a
+   * `Destroy` scenario, or a non-objective-aware tier (no `objectivePlan`)
+   * also returns `validTargets` unchanged — target selection is identical to
+   * the A3a coordinated-combat behavior.
+   *
+   * Pure with respect to RNG — consumes no `SeededRandom`.
+   */
+  private applyObjectiveTargetDiscipline(
+    attacker: IAIUnitState,
+    validTargets: readonly IAIUnitState[],
+    lanceContext?: IAILanceContext,
+  ): readonly IAIUnitState[] {
+    const objectivePlan = lanceContext?.plan.objectivePlan;
+    if (!objectivePlan) return validTargets;
+
+    const role = objectivePlan.roles.get(attacker.unitId);
+    if (!role || role === 'screen') return validTargets;
+
+    const hex = objectivePlan.targetHexes.get(attacker.unitId);
+    if (!hex) return validTargets;
+
+    // Longest live-weapon range — the reach the unit has standing on the
+    // objective hex. A unit with no live weapons cannot discipline-filter.
+    let maxRange = 0;
+    for (const weapon of attacker.weapons) {
+      if (weapon.destroyed) continue;
+      if (weapon.longRange > maxRange) maxRange = weapon.longRange;
+    }
+    if (maxRange <= 0) return validTargets;
+
+    const inDiscipline = validTargets.filter(
+      (target) => cubeHexDistance(hex, target.position) <= maxRange,
+    );
+    // Bounded bias: only narrow when at least one enemy is engageable from
+    // the objective; otherwise keep the full set so the unit still fires.
+    return inDiscipline.length > 0 ? inDiscipline : validTargets;
+  }
+
+  /**
    * Per `wire-bot-ai-helpers-and-capstone`: when the unit is retreating
    * we override the random walk/run/jump pick to call
    * `retreatMovementType`, which prefers Run, falls back to Walk, and
@@ -663,6 +811,19 @@ function computeRetreatSignals(
   }
 
   return { ratio, hasVitalCrit };
+}
+
+/**
+ * Per `add-ai-objective-awareness` (A3b): cube-coordinate hex distance
+ * between two axial coordinates. Mirrors the inline distance math in
+ * `playPhysicalAttackPhase` — kept local so `BotPlayer` stays free of a
+ * `hexMath` import dependency. Pure function.
+ */
+function cubeHexDistance(a: IHexCoordinate, b: IHexCoordinate): number {
+  const dq = b.q - a.q;
+  const dr = b.r - a.r;
+  const ds = -dq - dr;
+  return (Math.abs(dq) + Math.abs(dr) + Math.abs(ds)) / 2;
 }
 
 /**

--- a/src/simulation/ai/MoveAI.ts
+++ b/src/simulation/ai/MoveAI.ts
@@ -17,16 +17,19 @@ import {
 import { terrainTagOffersCover } from '@/utils/gameplay/terrainCover';
 
 import type { SeededRandom } from '../core/SeededRandom';
+import type { ObjectiveRole } from './AIObjectivePlanner';
 import type { IAIPath } from './AITerrainPathfinder';
 import type {
   IAITierCoordinationParameters,
   IAITierMovementParameters,
+  IAITierObjectiveParameters,
 } from './AITierRegistry';
 import type { IAIUnitState, IBotBehavior, IMove } from './types';
 
 import { findAllPaths } from './AITerrainPathfinder';
 import {
   resolveCoordinationParameters,
+  resolveObjectiveParameters,
   resolveTierParameters,
 } from './AITierRegistry';
 import { scoreRetreatMove } from './RetreatAI';
@@ -176,6 +179,30 @@ export interface IScoreMoveContext {
    * per-unit callers.
    */
   readonly lancemates?: readonly IAIUnitState[];
+
+  /**
+   * Per `add-ai-objective-awareness` design D3: the active difficulty tier's
+   * objective-awareness parameter block. When omitted, or when its
+   * `objectiveAwareness` flag is `false` (the `Green` / `Regular` / `Veteran`
+   * tiers, and every legacy caller), `scoreMove`'s objective term contributes
+   * zero and the score is byte-identical to the A1/A2/A3a scorer.
+   */
+  readonly tierObjective?: IAITierObjectiveParameters;
+  /**
+   * Per `add-ai-objective-awareness` design D3: the moving unit's objective
+   * role from the lance plan's objective layer. `'capture'` rewards closing
+   * on the objective hex; `'hold'` rewards staying on it; `'screen'` (and an
+   * absent role) leave the objective term at zero. Omitted for callers
+   * without an objective plan.
+   */
+  readonly objectiveRole?: ObjectiveRole;
+  /**
+   * Per `add-ai-objective-awareness` design D3: the hex the moving unit is
+   * working toward (`capture`) or holding (`hold`). The objective term
+   * scores `move.destination` against this hex. Omitted for screen-role
+   * units and callers without an objective plan.
+   */
+  readonly objectiveHex?: IHexCoordinate;
 }
 
 /**
@@ -289,8 +316,107 @@ export function scoreMove(move: IMove, ctx: IScoreMoveContext): number {
   // caller), so the score above is unchanged for those tiers.
   score += cohesionScore(move, ctx);
 
+  // Per `add-ai-objective-awareness` design D3: the objective-seeking /
+  // objective-holding term. Additive over the cohesion term. Returns `0`
+  // whenever objective awareness is disabled (every non-`Elite` tier and
+  // legacy caller) or the unit has no objective role, so the score above is
+  // unchanged for those tiers.
+  score += objectiveScore(move, ctx);
+
   return score;
 }
+
+/**
+ * Per `add-ai-objective-awareness` design D3: the objective movement term,
+ * gated on `objectiveAwareness`.
+ *
+ *   - Capture role — `+objectiveSeekingWeight` per hex of distance reduced
+ *     toward the `take` marker (origin distance minus destination distance),
+ *     so closing on the objective outscores backing off, plus a large flat
+ *     on-marker bonus (`objectiveSeekingWeight * ON_MARKER_BONUS_HEXES`) for
+ *     a destination *on* the marker hex so the unit commits to standing on
+ *     it once in reach.
+ *   - Hold role — `+objectiveHoldWeight` for a destination on the `hold`
+ *     marker, `objectiveHoldWeight * ADJACENT_HOLD_FRACTION` for a
+ *     destination adjacent to it (engage from cover near the marker), and
+ *     `0` for any destination that abandons the marker — so staying planted
+ *     always outscores chasing an enemy off the objective.
+ *   - Screen role (and an absent role) — contributes `0`; the unit plays
+ *     pure A1/A2/A3a movement.
+ *
+ * Returns `0` when `tierObjective` is absent, `objectiveAwareness` is
+ * `false`, no `objectiveHex` is supplied, or the role is `screen` — the
+ * score is byte-identical to the A3a scorer for every non-`Elite` tier and
+ * every screen-role unit.
+ *
+ * Pure — never mutates inputs, consumes no `SeededRandom`.
+ */
+function objectiveScore(move: IMove, ctx: IScoreMoveContext): number {
+  const { tierObjective, objectiveRole, objectiveHex, attacker } = ctx;
+
+  // Gate: non-objective-aware tiers, every legacy caller, and screen-role
+  // units resolve to a no-op.
+  if (!tierObjective || !tierObjective.objectiveAwareness) {
+    return 0;
+  }
+  if (!objectiveRole || objectiveRole === 'screen') {
+    return 0;
+  }
+  if (!objectiveHex) {
+    return 0;
+  }
+
+  const destDistance = hexDistance(move.destination, objectiveHex);
+
+  if (objectiveRole === 'capture') {
+    const { objectiveSeekingWeight } = tierObjective;
+    if (objectiveSeekingWeight === 0) return 0;
+    // A destination on the marker earns a large flat bonus so the unit
+    // commits to standing on the objective once it can reach it.
+    if (destDistance === 0) {
+      return objectiveSeekingWeight * ON_MARKER_BONUS_HEXES;
+    }
+    // Otherwise reward the reduction in distance toward the marker — the
+    // closer the destination is than the unit's current hex, the higher the
+    // term. A destination that backs away pays a negative term.
+    const originDistance = hexDistance(attacker.position, objectiveHex);
+    return objectiveSeekingWeight * (originDistance - destDistance);
+  }
+
+  // Hold role.
+  const { objectiveHoldWeight } = tierObjective;
+  if (objectiveHoldWeight === 0) return 0;
+  // On the marker — full hold weight; the unit keeps control.
+  if (destDistance === 0) {
+    return objectiveHoldWeight;
+  }
+  // Adjacent to the marker — a reduced reward; the unit stays close enough
+  // to re-take the hex while using nearby cover, but a destination ON the
+  // marker still scores strictly higher.
+  if (destDistance === 1) {
+    return objectiveHoldWeight * ADJACENT_HOLD_FRACTION;
+  }
+  // Any destination that abandons the marker forfeits the whole term —
+  // chasing an enemy off the objective is never rewarded.
+  return 0;
+}
+
+/**
+ * Per `add-ai-objective-awareness` design D3: the on-marker capture bonus is
+ * `objectiveSeekingWeight` multiplied by this hex count. Sized so it dwarfs
+ * the per-hex distance-reduction reward — a unit one hex away that *could*
+ * step onto the marker always prefers the on-marker hex over a closer-but-
+ * off-marker destination.
+ */
+const ON_MARKER_BONUS_HEXES = 20;
+
+/**
+ * Per `add-ai-objective-awareness` design D3: a hold-role unit on a hex
+ * adjacent to its marker earns this fraction of the full hold weight — close
+ * enough to re-take the objective and use nearby cover, but strictly below
+ * the on-marker score so the unit prefers to stand on the objective itself.
+ */
+const ADJACENT_HOLD_FRACTION = 0.5;
 
 /**
  * Per `add-ai-coordination-tactics` design D3: the formation-cohesion
@@ -599,13 +725,20 @@ export class MoveAI {
     // so for `Green` / `Regular` / `Veteran` (and a `ctx` carrying no lance
     // centroid) this contributes nothing — the score stays byte-identical.
     const tierCoordination = resolveCoordinationParameters(tierParams);
+    // Per `add-ai-objective-awareness` design D3: attach the objective block.
+    // `scoreMove`'s objective term gates on `objectiveAwareness` and the
+    // caller-supplied `objectiveRole`, so for every non-`Elite` tier (and a
+    // `ctx` carrying no objective role) this contributes nothing — the score
+    // stays byte-identical.
+    const tierObjective = resolveObjectiveParameters(tierParams);
 
     // Legacy tiers: attach the (no-op) tier blocks only. `scoreMove` gates
-    // every terrain-aware term on `pathfinderEnabled` and the cohesion term
-    // on `lanceCoordination`, so this is byte-identical to pre-change
-    // behavior for the non-pathfinder tiers.
+    // every terrain-aware term on `pathfinderEnabled`, the cohesion term on
+    // `lanceCoordination`, and the objective term on `objectiveAwareness`, so
+    // this is byte-identical to pre-change behavior for the non-pathfinder
+    // tiers.
     if (!tierMovement.pathfinderEnabled) {
-      return { ...ctx, tierMovement, tierCoordination };
+      return { ...ctx, tierMovement, tierCoordination, tierObjective };
     }
 
     // Determine the shared movement type and MP budget for the pathfinder
@@ -620,7 +753,13 @@ export class MoveAI {
       capability,
     );
 
-    return { ...ctx, tierMovement, tierCoordination, pathByDestination };
+    return {
+      ...ctx,
+      tierMovement,
+      tierCoordination,
+      tierObjective,
+      pathByDestination,
+    };
   }
 }
 

--- a/src/simulation/ai/index.ts
+++ b/src/simulation/ai/index.ts
@@ -27,10 +27,12 @@ export {
   DEFAULT_TIER_NAME,
   INERT_RESOURCE_PARAMETERS,
   INERT_COORDINATION_PARAMETERS,
+  INERT_OBJECTIVE_PARAMETERS,
   getTierParameters,
   resolveTierParameters,
   resolveResourceParameters,
   resolveCoordinationParameters,
+  resolveObjectiveParameters,
 } from './AITierRegistry';
 export type {
   AITierName,
@@ -38,6 +40,7 @@ export type {
   IAITierMovementParameters,
   IAITierResourceParameters,
   IAITierCoordinationParameters,
+  IAITierObjectiveParameters,
 } from './AITierRegistry';
 
 // Per `add-ai-resource-planning` (A2): the resource-planning modules —
@@ -74,4 +77,24 @@ export {
 } from './AIFireCoordinator';
 export type { IFireAssignment } from './AIFireCoordinator';
 export { planTurn, computeLanceCentroid } from './AILancePlanner';
-export type { ILanceTurnPlan, IAILanceContext } from './AILancePlanner';
+export type {
+  ILanceTurnPlan,
+  IAILanceContext,
+  IObjectivePlanInput,
+} from './AILancePlanner';
+
+// Per `add-ai-objective-awareness` (A3b): the objective planner — reads the
+// scenario objective map, classifies markers, and assigns objective roles.
+// Only the `Elite` tier consumes this; lower tiers leave it inert.
+export {
+  classifyObjectives,
+  assignObjectiveRoles,
+  planObjectives,
+} from './AIObjectivePlanner';
+export type {
+  ObjectiveIntent,
+  ObjectiveRole,
+  ObjectiveCostFn,
+  IClassifiedObjective,
+  IObjectiveLancePlan,
+} from './AIObjectivePlanner';


### PR DESCRIPTION
## Summary

Implements OpenSpec change `add-ai-objective-awareness` (A3b) — the connector that makes the Elite-tier bot **play the scenario** (Capture / Defend / Breakthrough) instead of always playing Destroy. Wave 1's objective engine and A3a's lance planner existed but never talked to each other; this change wires them.

## What changed

- **`AITierRegistry`** — additive `objective` block on `IAITierParameters` (`objectiveAwareness`, `objectiveSeekingWeight`, `objectiveHoldWeight`) + `resolveObjectiveParameters` + `INERT_OBJECTIVE_PARAMETERS`. Green/Regular/Veteran fully inert; Elite populated. Movement/resource/coordination blocks untouched.
- **`AIObjectivePlanner`** (new) — `classifyObjectives` reads `session.currentState.objectives` and classes each marker `take`/`hold`/`deny` for the bot side; `assignObjectiveRoles` assigns `capture`/`hold`/`screen` roles by pathfinder cost; `planObjectives` builds the `IObjectiveLancePlan`.
- **`AILancePlanner`** — `ILanceTurnPlan` gains an optional `objectivePlan` layer; `planTurn` builds it from an optional `IObjectivePlanInput`. Existing A3a callers are unchanged (field + param both optional).
- **`MoveAI`** — `scoreMove` gains an objective term: capture units seek + step onto `take` markers, hold units stay planted, screen units get zero contribution. Gated on `objectiveAwareness`.
- **`BotPlayer`** — objective-aware target discipline (a capture/hold unit fires from its objective rather than chasing an enemy off it); a unit already on its objective hex stays planted.

## Determinism / parity

All objective behavior gates on `objectiveAwareness`, which only `Elite` enables — Green/Regular/Veteran reproduce existing behavior byte-for-byte. Classification, role assignment, and scoring are pure deterministic functions; no `SeededRandom` is consumed (ties break on canonical unit-id order). No BV code touched.

## Verification

- `npx tsc --noEmit` — zero errors
- `npx oxlint src/` — 0 errors (1 pre-existing `max-lines` warning on `BotPlayer.ts`, unchanged in class)
- `npx jest src/simulation/` — 92 suites / 1416 tests pass (incl. determinism + coordination regressions)
- New: 41 unit + 4 integration tests covering every `#### Scenario:` in the delta spec
- `npx openspec validate add-ai-objective-awareness --strict` — valid

OpenSpec change is **not** archived (per instructions).