### PR TITLE
feat(multiplayer): harden transport — durable store, host migration, integrity

### DIFF
--- a/openspec/changes/harden-multiplayer-transport/tasks.md
+++ b/openspec/changes/harden-multiplayer-transport/tasks.md
@@ -2,57 +2,57 @@
 
 ## 1. Durable Match Store
 
-- [ ] 1.1 Add a durable `IMatchStore` implementation backed by an embedded transactional persistent store, implementing the `IMatchStore` interface unchanged
-- [ ] 1.2 Persist `IMatchMeta` per match and each `IGameEvent` keyed by `(matchId, sequence)` with a unique constraint enforcing the sequence-collision guarantee
-- [ ] 1.3 Make `appendEvent` transactional all-or-nothing, rejecting a sequence collision with `MatchStoreSequenceCollisionError`
-- [ ] 1.4 Make `getEvents` return events ordered by ascending `sequence` with no gaps; `closeMatch` idempotent
-- [ ] 1.5 Wire `getDefaultMatchStore()` to select the durable store in production and `InMemoryMatchStore` in dev/test
-- [ ] 1.6 Tests: round-trip meta and event log; sequence collision rejected; ordering preserved; the durable store passes the same contract tests as `InMemoryMatchStore`
+- [x] 1.1 Add a durable `IMatchStore` implementation backed by an embedded transactional persistent store, implementing the `IMatchStore` interface unchanged
+- [x] 1.2 Persist `IMatchMeta` per match and each `IGameEvent` keyed by `(matchId, sequence)` with a unique constraint enforcing the sequence-collision guarantee
+- [x] 1.3 Make `appendEvent` transactional all-or-nothing, rejecting a sequence collision with `MatchStoreSequenceCollisionError`
+- [x] 1.4 Make `getEvents` return events ordered by ascending `sequence` with no gaps; `closeMatch` idempotent
+- [x] 1.5 Wire `getDefaultMatchStore()` to select the durable store in production and `InMemoryMatchStore` in dev/test
+- [x] 1.6 Tests: round-trip meta and event log; sequence collision rejected; ordering preserved; the durable store passes the same contract tests as `InMemoryMatchStore`
 
 ## 2. Server-Startup Match Recovery
 
-- [ ] 2.1 Add a startup recovery routine that enumerates `status: 'active'` matches from the durable store
-- [ ] 2.2 For each recovered match, re-instantiate a `ServerMatchHost` whose `InteractiveSession` is rebuilt by replaying the stored event log
-- [ ] 2.3 Tests: a match with persisted events survives a simulated process restart; a reconnecting client receives the missing events from its `lastSeq`
+- [x] 2.1 Add a startup recovery routine that enumerates `status: 'active'` matches from the durable store
+- [x] 2.2 For each recovered match, re-instantiate a `ServerMatchHost` whose `InteractiveSession` is rebuilt by replaying the stored event log
+- [x] 2.3 Tests: a match with persisted events survives a simulated process restart; a reconnecting client receives the missing events from its `lastSeq`
 
 ## 3. Host Migration
 
-- [ ] 3.1 On host-socket loss, promote the longest-connected surviving human seat to `hostPlayerId` for privileged operations
-- [ ] 3.2 Record the promotion in `IMatchMeta` via `updateMatchMeta` and broadcast it to all connected clients
-- [ ] 3.3 If the promoted holder also disconnects, repeat the promotion; if no human seat survives, fall through to the grace path
-- [ ] 3.4 Tests: host disconnect promotes a survivor; privileged operations work for the new holder; the original host's reconnect does not abort the match
+- [x] 3.1 On host-socket loss, promote the longest-connected surviving human seat to `hostPlayerId` for privileged operations
+- [x] 3.2 Record the promotion in `IMatchMeta` via `updateMatchMeta` and broadcast it to all connected clients
+- [x] 3.3 If the promoted holder also disconnects, repeat the promotion; if no human seat survives, fall through to the grace path
+- [x] 3.4 Tests: host disconnect promotes a survivor; privileged operations work for the new holder; the original host's reconnect does not abort the match
 
 ## 4. Graceful Degradation
 
-- [ ] 4.1 Route a host-connection loss through the existing pending/grace mechanism (`PendingPeerTracker`) so the match pauses rather than aborts
-- [ ] 4.2 Resume the match on host reconnect within grace; complete it cleanly through the existing outcome path on grace expiry
-- [ ] 4.3 Ensure the legacy `reason: 'aborted'` abort path is not taken for a server-authoritative match
-- [ ] 4.4 Tests: host blip pauses then resumes the match; grace expiry completes the match cleanly without an abort
+- [x] 4.1 Route a host-connection loss through the existing pending/grace mechanism (`PendingPeerTracker`) so the match pauses rather than aborts
+- [x] 4.2 Resume the match on host reconnect within grace; complete it cleanly through the existing outcome path on grace expiry
+- [x] 4.3 Ensure the legacy `reason: 'aborted'` abort path is not taken for a server-authoritative match
+- [x] 4.4 Tests: host blip pauses then resumes the match; grace expiry completes the match cleanly without an abort
 
 ## 5. Intent Rate-Limiting
 
-- [ ] 5.1 Add a per-connection token-bucket rate limiter to the authoritative intent dispatch, with a configured budget
-- [ ] 5.2 Reject an over-budget intent with a non-fatal `Error {code: 'RATE_LIMITED'}`; keep the connection open and append no event
-- [ ] 5.3 Exempt heartbeat and replay traffic from the limiter
-- [ ] 5.4 Tests: a flood of intents trips the limiter; a worst-case human play rate never trips it; a rejected intent appends no event
+- [x] 5.1 Add a per-connection token-bucket rate limiter to the authoritative intent dispatch, with a configured budget
+- [x] 5.2 Reject an over-budget intent with a non-fatal `Error {code: 'RATE_LIMITED'}`; keep the connection open and append no event
+- [x] 5.3 Exempt heartbeat and replay traffic from the limiter
+- [x] 5.4 Tests: a flood of intents trips the limiter; a worst-case human play rate never trips it; a rejected intent appends no event
 
 ## 6. Replay-Attack Protection
 
-- [ ] 6.1 Require every `Intent` envelope to carry a unique id; maintain a per-match bounded set of accepted intent ids
-- [ ] 6.2 Reject an intent whose id is already accepted with `Error {code: 'DUPLICATE_INTENT'}` and append no event
-- [ ] 6.3 Reconstruct the accepted-id set from the event log on recovery so a restart does not reopen the replay window
-- [ ] 6.4 Tests: a re-sent intent envelope is rejected and produces no event; the set is reconstructed correctly after recovery
+- [x] 6.1 Require every `Intent` envelope to carry a unique id; maintain a per-match bounded set of accepted intent ids
+- [x] 6.2 Reject an intent whose id is already accepted with `Error {code: 'DUPLICATE_INTENT'}` and append no event
+- [x] 6.3 Reconstruct the accepted-id set from the event log on recovery so a restart does not reopen the replay window
+- [x] 6.4 Tests: a re-sent intent envelope is rejected and produces no event; the set is reconstructed correctly after recovery
 
 ## 7. Transport Consolidation (DP1)
 
-- [ ] 7.1 Document the authoritative server WebSocket as the supported transport and y-webrtc as a non-authoritative fallback
-- [ ] 7.2 Confirm the client-side `mirrorSession` / `gameSessionChannel` pattern is retained only as the client event-application layer pointed at the server WebSocket
-- [ ] 7.3 Tests: a networked match runs end-to-end over the server WebSocket transport with no y-webrtc dependency
+- [x] 7.1 Document the authoritative server WebSocket as the supported transport and y-webrtc as a non-authoritative fallback
+- [x] 7.2 Confirm the client-side `mirrorSession` / `gameSessionChannel` pattern is retained only as the client event-application layer pointed at the server WebSocket
+- [x] 7.3 Tests: a networked match runs end-to-end over the server WebSocket transport with no y-webrtc dependency
 
 ## 8. Verification
 
-- [ ] 8.1 Integration test: an active match survives a server restart and both clients reconnect to the rebuilt host
-- [ ] 8.2 Integration test: a host disconnect mid-match migrates host privilege and the match continues to completion
-- [ ] 8.3 Stress test: measure `appendEvent` latency under the durable store and confirm the rate-limit budget is not tripped by legitimate play
-- [ ] 8.4 `openspec validate harden-multiplayer-transport --strict` passes
-- [ ] 8.5 `npm run build`, lint, and `tsc --noEmit` typecheck all pass
+- [x] 8.1 Integration test: an active match survives a server restart and both clients reconnect to the rebuilt host
+- [x] 8.2 Integration test: a host disconnect mid-match migrates host privilege and the match continues to completion
+- [x] 8.3 Stress test: measure `appendEvent` latency under the durable store and confirm the rate-limit budget is not tripped by legitimate play
+- [x] 8.4 `openspec validate harden-multiplayer-transport --strict` passes
+- [x] 8.5 `npm run build`, lint, and `tsc --noEmit` typecheck all pass

--- a/src/__tests__/integration/phase4Multiplayer.test.ts
+++ b/src/__tests__/integration/phase4Multiplayer.test.ts
@@ -274,8 +274,12 @@ describe('Phase 4 capstone — multiplayer end-to-end', () => {
     // -- Stage 3: Drop opponent + reconnect with lastSeq ---------------------
     const seqBeforeDrop = host.highestSeq();
     host.detachSocket(oppSock);
-    await Promise.resolve();
-    await Promise.resolve();
+    // harden-multiplayer-transport (M2): a socket drop now runs host
+    // migration ahead of the grace-pause path — two sequential async
+    // store reads. Drain enough microtask ticks for the full chain.
+    for (let i = 0; i < 8; i++) {
+      await Promise.resolve();
+    }
     expect(host.isPausedForReconnect()).toBe(true);
     // MatchPaused broadcast went to the surviving socket (host).
     const paused = hostSock.sent.find((s) => s.kind === 'MatchPaused');

--- a/src/engine/InteractiveSession.ts
+++ b/src/engine/InteractiveSession.ts
@@ -50,6 +50,7 @@ import { declarePlayerWithdrawal } from '@/utils/gameplay/morale';
 import type { IInteractiveSessionLinkage } from './InteractiveSession.types';
 import type { IAdaptedUnit, IAvailableActions } from './types';
 
+import { createMinimalGrid } from './GameEngine.helpers';
 import {
   applyInteractiveSessionAttack,
   applyInteractiveSessionMovement,
@@ -167,6 +168,39 @@ export class InteractiveSession {
     storage: MatchLogHydrationStorage = matchLogStorage,
   ): Promise<IGameSession> {
     return hydrateSessionFromMatchLog(matchId, storage);
+  }
+
+  /**
+   * Per `harden-multiplayer-transport` (M2), design D3 — adopt a
+   * pre-built `IGameSession` (rebuilt by replaying a persisted event
+   * log) into a live `InteractiveSession`.
+   *
+   * Server-startup match recovery uses this to re-instantiate a
+   * `ServerMatchHost` for every `active` match after a process restart.
+   * The session's `config` + `units` drive the per-unit lookup maps so
+   * the recovered host can continue to drive the engine — terminal
+   * outcomes (`concede` / `abortMatch`), replay streaming, and host
+   * migration all operate on the adopted state directly.
+   *
+   * The constructor would normally `createGameSession` + `startGame`
+   * from scratch; here we skip that and splice the already-derived
+   * session in over the freshly-created one so `currentState` reflects
+   * the full replayed history rather than a fresh Setup-phase board.
+   */
+  static fromSession(session: IGameSession): InteractiveSession {
+    const instance = new InteractiveSession(
+      session.config.mapRadius,
+      session.config.turnLimit,
+      new SeededRandom(0xc0ffee),
+      createMinimalGrid(session.config.mapRadius),
+      [],
+      [],
+      session.units,
+    );
+    // Replace the fresh Setup-phase session with the replayed one so
+    // `currentState` (status / turn / phase / board) matches history.
+    instance.session = session;
+    return instance;
   }
 
   getState(): IGameState {

--- a/src/lib/multiplayer/server/DurableMatchStore.ts
+++ b/src/lib/multiplayer/server/DurableMatchStore.ts
@@ -194,11 +194,28 @@ export class DurableMatchStore implements IMatchStore {
   async appendEvent(matchId: string, event: IGameEvent): Promise<void> {
     const match = this.getMatchRow(matchId);
     if (!match) throw new MatchNotFoundError(matchId);
-    // Transactional all-or-nothing: the INSERT and the `updated_at`
-    // bump are wrapped in a single SQLite transaction. A sequence
-    // collision is caught by the `(match_id, sequence)` PRIMARY KEY
-    // unique constraint and surfaced as `MatchStoreSequenceCollisionError`.
+    // Transactional all-or-nothing: the sequence-collision check, the
+    // event INSERT, and the `updated_at` bump all run inside a single
+    // SQLite transaction.
+    //
+    // The collision is detected by an EXPLICIT check inside the
+    // transaction (a SELECT for the existing `(matchId, sequence)`
+    // row) rather than by catching the `(match_id, sequence)` PRIMARY
+    // KEY violation — the explicit check is deterministic and
+    // independent of how a given better-sqlite3 build phrases /
+    // surfaces its `SqliteError`. The PRIMARY KEY constraint remains as
+    // a defense-in-depth backstop against a concurrent writer that
+    // races between the check and the INSERT.
     const tx = this.db.transaction((mId: string, evt: IGameEvent) => {
+      const existing = this.db
+        .prepare(
+          `SELECT 1 FROM mp_match_events
+           WHERE match_id = ? AND sequence = ?`,
+        )
+        .get(mId, evt.sequence);
+      if (existing) {
+        throw new MatchStoreSequenceCollisionError(mId, evt.sequence);
+      }
       try {
         this.db
           .prepare(
@@ -207,12 +224,9 @@ export class DurableMatchStore implements IMatchStore {
           )
           .run(mId, evt.sequence, JSON.stringify(evt));
       } catch (e) {
-        // A sequence collision trips the `(match_id, sequence)` PRIMARY
-        // KEY constraint. better-sqlite3 surfaces this as a
-        // `SqliteError` whose `.code` is `SQLITE_CONSTRAINT_PRIMARYKEY`
-        // (or the broader `SQLITE_CONSTRAINT`); match on the code AND
-        // the message text so the detection is robust across
-        // better-sqlite3 versions / phrasings.
+        // Backstop: a concurrent writer won the race between the
+        // SELECT above and this INSERT — the unique constraint catches
+        // it. Map it to the same collision error.
         if (isUniqueConstraintError(e)) {
           throw new MatchStoreSequenceCollisionError(mId, evt.sequence);
         }

--- a/src/lib/multiplayer/server/DurableMatchStore.ts
+++ b/src/lib/multiplayer/server/DurableMatchStore.ts
@@ -1,0 +1,381 @@
+/**
+ * DurableMatchStore — production `IMatchStore` backed by an embedded
+ * transactional SQLite database (better-sqlite3).
+ *
+ * Per `harden-multiplayer-transport` design D1/D2: this implements the
+ * existing `IMatchStore` interface UNCHANGED, so `ServerMatchHost`, the
+ * REST routes, and the WebSocket upgrade handler depend only on
+ * `IMatchStore` and are agnostic to which implementation is wired.
+ * `InMemoryMatchStore` is kept verbatim as the dev-only fallback.
+ *
+ * File layout (frozen by design D2):
+ *   - `mp_matches`  — one row per match holding the serialized
+ *     `IMatchMeta` JSON blob, plus a denormalized `status` /
+ *     `room_code` column for cheap server-side filtering and invite
+ *     resolution.
+ *   - `mp_match_events` — one row per `(match_id, sequence)` holding the
+ *     serialized `IGameEvent` JSON blob. `(match_id, sequence)` is the
+ *     PRIMARY KEY so the storage layer's unique constraint enforces the
+ *     `appendEvent` sequence-collision guarantee.
+ *
+ * Key invariants (mirror of `IMatchStore`):
+ *   - `appendEvent` is transactional all-or-nothing — a sequence
+ *     collision rejects with `MatchStoreSequenceCollisionError` and
+ *     leaves the store untouched.
+ *   - `getEvents(matchId, fromSeq?)` returns events with
+ *     `sequence >= fromSeq`, ordered ascending, with no gaps.
+ *   - `closeMatch` is idempotent.
+ *   - Completed-match logs are retained for a 7-day window (design
+ *     Open-Question resolution) so server-side post-match inspection
+ *     works; `pruneExpiredMatches()` reaps anything older.
+ *
+ * Why a separate DB file from `mekstation.db`: the multiplayer match
+ * store has a very different write profile (hot `appendEvent` path) and
+ * retention policy from the unit-vault / campaign tables. Keeping it in
+ * its own file avoids WAL contention and lets a deploy nuke the match
+ * store without touching campaign data.
+ *
+ * @spec openspec/changes/harden-multiplayer-transport/specs/multiplayer-server/spec.md
+ */
+
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { IGameEvent } from '@/types/gameplay/GameSessionInterfaces';
+
+import { normalizeRoomCode } from '@/lib/p2p/roomCodes';
+
+import {
+  MatchNotFoundError,
+  MatchStoreSequenceCollisionError,
+  type IMatchMeta,
+  type IMatchMetaPatch,
+  type IMatchStore,
+} from './IMatchStore';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * Completed-match retention window. Per the design Open-Question
+ * resolution, the durable store honors the same 7-day retention the
+ * `multiplayer-sync` spec describes for client-side IndexedDB so
+ * server-side post-match inspection works. `pruneExpiredMatches` reaps
+ * `completed` matches whose `updatedAt` is older than this.
+ */
+export const COMPLETED_MATCH_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Default on-disk location for the multiplayer match database.
+ * Resolved lazily (not at module-eval time) so a test or deploy can
+ * set `MULTIPLAYER_DB_PATH` before the first store is constructed.
+ */
+function defaultDbPath(): string {
+  return process.env.MULTIPLAYER_DB_PATH || './data/multiplayer-matches.db';
+}
+
+// =============================================================================
+// Schema
+// =============================================================================
+
+const SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS mp_matches (
+    match_id    TEXT PRIMARY KEY,
+    status      TEXT NOT NULL,
+    room_code   TEXT,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL,
+    meta_json   TEXT NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS mp_match_events (
+    match_id   TEXT NOT NULL,
+    sequence   INTEGER NOT NULL,
+    event_json TEXT NOT NULL,
+    PRIMARY KEY (match_id, sequence),
+    FOREIGN KEY (match_id) REFERENCES mp_matches(match_id) ON DELETE CASCADE
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_mp_matches_status ON mp_matches(status);
+  CREATE INDEX IF NOT EXISTS idx_mp_matches_room_code ON mp_matches(room_code);
+  CREATE INDEX IF NOT EXISTS idx_mp_match_events_match ON mp_match_events(match_id, sequence);
+`;
+
+// =============================================================================
+// Row shapes
+// =============================================================================
+
+interface IMatchRow {
+  readonly match_id: string;
+  readonly status: string;
+  readonly room_code: string | null;
+  readonly created_at: string;
+  readonly updated_at: string;
+  readonly meta_json: string;
+}
+
+interface IEventRow {
+  readonly event_json: string;
+}
+
+// =============================================================================
+// Store
+// =============================================================================
+
+export interface IDurableMatchStoreOptions {
+  /**
+   * On-disk path for the SQLite file. Defaults to
+   * `MULTIPLAYER_DB_PATH` env var or `./data/multiplayer-matches.db`.
+   * Pass `':memory:'` for an ephemeral store (used by the contract test
+   * suite so it never touches disk).
+   */
+  readonly path?: string;
+}
+
+export class DurableMatchStore implements IMatchStore {
+  private readonly db: Database.Database;
+
+  /**
+   * Open (and migrate) the SQLite-backed match store. The constructor
+   * is synchronous — `better-sqlite3` is a synchronous-class embedded
+   * store so `IMatchStore`'s async surface is satisfied trivially via
+   * `Promise.resolve`, and the hot `appendEvent` path is a local
+   * synchronous write wrapped in a transaction.
+   */
+  constructor(options: IDurableMatchStoreOptions = {}) {
+    const dbPath = options.path ?? defaultDbPath();
+    if (dbPath !== ':memory:') {
+      const dir = path.dirname(dbPath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+    }
+    this.db = new Database(dbPath);
+    // WAL mode keeps reads non-blocking during the hot append path.
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('foreign_keys = ON');
+    this.db.exec(SCHEMA_SQL);
+  }
+
+  async createMatch(meta: IMatchMeta): Promise<string> {
+    const existing = this.db
+      .prepare('SELECT match_id FROM mp_matches WHERE match_id = ?')
+      .get(meta.matchId);
+    if (existing) {
+      throw new Error(
+        `Match already exists in store: ${meta.matchId} (call createMatch with a fresh id)`,
+      );
+    }
+    // A match's invite code only resolves while it is in `lobby`
+    // status — mirror `InMemoryMatchStore`'s indexing rule.
+    const indexedRoomCode =
+      meta.roomCode && meta.status === 'lobby'
+        ? normalizeRoomCode(meta.roomCode)
+        : null;
+    this.db
+      .prepare(
+        `INSERT INTO mp_matches
+           (match_id, status, room_code, created_at, updated_at, meta_json)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        meta.matchId,
+        meta.status,
+        indexedRoomCode,
+        meta.createdAt,
+        meta.updatedAt,
+        JSON.stringify(meta),
+      );
+    return meta.matchId;
+  }
+
+  async appendEvent(matchId: string, event: IGameEvent): Promise<void> {
+    const match = this.getMatchRow(matchId);
+    if (!match) throw new MatchNotFoundError(matchId);
+    // Transactional all-or-nothing: the INSERT and the `updated_at`
+    // bump are wrapped in a single SQLite transaction. A sequence
+    // collision is caught by the `(match_id, sequence)` PRIMARY KEY
+    // unique constraint and surfaced as `MatchStoreSequenceCollisionError`.
+    const tx = this.db.transaction((mId: string, evt: IGameEvent) => {
+      try {
+        this.db
+          .prepare(
+            `INSERT INTO mp_match_events (match_id, sequence, event_json)
+             VALUES (?, ?, ?)`,
+          )
+          .run(mId, evt.sequence, JSON.stringify(evt));
+      } catch (e) {
+        if (e instanceof Error && /UNIQUE constraint failed/i.test(e.message)) {
+          throw new MatchStoreSequenceCollisionError(mId, evt.sequence);
+        }
+        throw e;
+      }
+      // Keep `updatedAt` fresh both on the row column and inside the
+      // serialized meta blob so a later `getMatchMeta` agrees with the
+      // column-level filter used by recovery.
+      const nextMeta: IMatchMeta = {
+        ...(JSON.parse(match.meta_json) as IMatchMeta),
+        updatedAt: new Date().toISOString(),
+      };
+      this.db
+        .prepare(
+          `UPDATE mp_matches SET updated_at = ?, meta_json = ?
+           WHERE match_id = ?`,
+        )
+        .run(nextMeta.updatedAt, JSON.stringify(nextMeta), mId);
+    });
+    tx(matchId, event);
+  }
+
+  async getEvents(
+    matchId: string,
+    fromSeq = 0,
+  ): Promise<readonly IGameEvent[]> {
+    if (!this.getMatchRow(matchId)) {
+      throw new MatchNotFoundError(matchId);
+    }
+    const rows = this.db
+      .prepare(
+        `SELECT event_json FROM mp_match_events
+         WHERE match_id = ? AND sequence >= ?
+         ORDER BY sequence ASC`,
+      )
+      .all(matchId, fromSeq <= 0 ? 0 : fromSeq) as IEventRow[];
+    return rows.map((r) => JSON.parse(r.event_json) as IGameEvent);
+  }
+
+  async getMatchMeta(matchId: string): Promise<IMatchMeta> {
+    const row = this.getMatchRow(matchId);
+    if (!row) throw new MatchNotFoundError(matchId);
+    return JSON.parse(row.meta_json) as IMatchMeta;
+  }
+
+  async updateMatchMeta(
+    matchId: string,
+    patch: IMatchMetaPatch,
+  ): Promise<void> {
+    const row = this.getMatchRow(matchId);
+    if (!row) throw new MatchNotFoundError(matchId);
+    const before = JSON.parse(row.meta_json) as IMatchMeta;
+    // Mirror `InMemoryMatchStore`: an explicit `roomCode: null` clears
+    // the field; an absent key leaves it alone.
+    const { roomCode: patchRoomCode, ...restPatch } = patch;
+    const nextRoomCode =
+      patchRoomCode === null ? undefined : (patchRoomCode ?? before.roomCode);
+    const nextMeta: IMatchMeta = {
+      ...before,
+      ...restPatch,
+      roomCode: nextRoomCode,
+      updatedAt: new Date().toISOString(),
+    };
+    // Invite codes resolve ONLY while the match is in `lobby` status.
+    const indexedRoomCode =
+      nextMeta.roomCode && nextMeta.status === 'lobby'
+        ? normalizeRoomCode(nextMeta.roomCode)
+        : null;
+    this.db
+      .prepare(
+        `UPDATE mp_matches
+         SET status = ?, room_code = ?, updated_at = ?, meta_json = ?
+         WHERE match_id = ?`,
+      )
+      .run(
+        nextMeta.status,
+        indexedRoomCode,
+        nextMeta.updatedAt,
+        JSON.stringify(nextMeta),
+        matchId,
+      );
+  }
+
+  async getMatchByRoomCode(roomCode: string): Promise<IMatchMeta | null> {
+    const normalized = normalizeRoomCode(roomCode);
+    const row = this.db
+      .prepare('SELECT * FROM mp_matches WHERE room_code = ?')
+      .get(normalized) as IMatchRow | undefined;
+    if (!row) return null;
+    if (row.status !== 'lobby') return null;
+    return JSON.parse(row.meta_json) as IMatchMeta;
+  }
+
+  async closeMatch(matchId: string): Promise<void> {
+    const row = this.getMatchRow(matchId);
+    if (!row) return; // idempotent — closing a missing match is a no-op
+    if (row.status === 'completed') return; // already closed
+    const nextMeta: IMatchMeta = {
+      ...(JSON.parse(row.meta_json) as IMatchMeta),
+      status: 'completed',
+      updatedAt: new Date().toISOString(),
+    };
+    this.db
+      .prepare(
+        `UPDATE mp_matches
+         SET status = 'completed', room_code = NULL, updated_at = ?, meta_json = ?
+         WHERE match_id = ?`,
+      )
+      .run(nextMeta.updatedAt, JSON.stringify(nextMeta), matchId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Recovery + retention surface (not part of the IMatchStore contract)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Enumerate the metadata of every match in `status: 'active'`. Used
+   * by the server-startup recovery routine (design D3) to re-instantiate
+   * a `ServerMatchHost` per surviving match. Synchronous-class read
+   * exposed async to match the rest of the store's surface.
+   */
+  async listActiveMatches(): Promise<readonly IMatchMeta[]> {
+    const rows = this.db
+      .prepare("SELECT meta_json FROM mp_matches WHERE status = 'active'")
+      .all() as Pick<IMatchRow, 'meta_json'>[];
+    return rows.map((r) => JSON.parse(r.meta_json) as IMatchMeta);
+  }
+
+  /**
+   * Reap `completed` matches whose `updatedAt` is older than the
+   * 7-day retention window. Returns the number of matches pruned. The
+   * `ON DELETE CASCADE` foreign key drops their event rows too.
+   */
+  pruneExpiredMatches(now: number = Date.now()): number {
+    const cutoff = new Date(now - COMPLETED_MATCH_RETENTION_MS).toISOString();
+    const result = this.db
+      .prepare(
+        `DELETE FROM mp_matches
+         WHERE status = 'completed' AND updated_at < ?`,
+      )
+      .run(cutoff);
+    return result.changes;
+  }
+
+  /** Number of matches currently tracked. Test/observability only. */
+  size(): number {
+    const row = this.db
+      .prepare('SELECT COUNT(*) AS n FROM mp_matches')
+      .get() as { n: number };
+    return row.n;
+  }
+
+  /** Close the underlying SQLite handle. Call on server shutdown. */
+  close(): void {
+    try {
+      this.db.pragma('wal_checkpoint(TRUNCATE)');
+    } catch {
+      // best-effort checkpoint; close regardless
+    }
+    this.db.close();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------------
+
+  private getMatchRow(matchId: string): IMatchRow | undefined {
+    return this.db
+      .prepare('SELECT * FROM mp_matches WHERE match_id = ?')
+      .get(matchId) as IMatchRow | undefined;
+  }
+}

--- a/src/lib/multiplayer/server/DurableMatchStore.ts
+++ b/src/lib/multiplayer/server/DurableMatchStore.ts
@@ -207,7 +207,13 @@ export class DurableMatchStore implements IMatchStore {
           )
           .run(mId, evt.sequence, JSON.stringify(evt));
       } catch (e) {
-        if (e instanceof Error && /UNIQUE constraint failed/i.test(e.message)) {
+        // A sequence collision trips the `(match_id, sequence)` PRIMARY
+        // KEY constraint. better-sqlite3 surfaces this as a
+        // `SqliteError` whose `.code` is `SQLITE_CONSTRAINT_PRIMARYKEY`
+        // (or the broader `SQLITE_CONSTRAINT`); match on the code AND
+        // the message text so the detection is robust across
+        // better-sqlite3 versions / phrasings.
+        if (isUniqueConstraintError(e)) {
           throw new MatchStoreSequenceCollisionError(mId, evt.sequence);
         }
         throw e;
@@ -378,4 +384,23 @@ export class DurableMatchStore implements IMatchStore {
       .prepare('SELECT * FROM mp_matches WHERE match_id = ?')
       .get(matchId) as IMatchRow | undefined;
   }
+}
+
+/**
+ * True iff the error is a SQLite UNIQUE/PRIMARY-KEY constraint
+ * violation. better-sqlite3 throws a `SqliteError` carrying a `.code`
+ * (e.g. `SQLITE_CONSTRAINT_PRIMARYKEY`, `SQLITE_CONSTRAINT_UNIQUE`, or
+ * the broader `SQLITE_CONSTRAINT`); the human message is
+ * "UNIQUE constraint failed: ...". We match on EITHER so the detection
+ * is robust across better-sqlite3 versions and platform builds — a CI
+ * runner's prebuilt binary can phrase the message differently from a
+ * locally-compiled one.
+ */
+function isUniqueConstraintError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  const code = (e as { code?: unknown }).code;
+  if (typeof code === 'string' && code.startsWith('SQLITE_CONSTRAINT')) {
+    return true;
+  }
+  return /UNIQUE constraint failed|PRIMARY KEY/i.test(e.message);
 }

--- a/src/lib/multiplayer/server/InMemoryMatchStore.ts
+++ b/src/lib/multiplayer/server/InMemoryMatchStore.ts
@@ -193,22 +193,15 @@ export class InMemoryMatchStore implements IMatchStore {
 // Factory + module-level singleton
 // =============================================================================
 
-let _singleton: InMemoryMatchStore | null = null;
-
 /**
- * Default factory used by Wave 1's REST/WS code. Stays a singleton so
- * multiple HTTP handlers + the WebSocket upgrade share one store within
- * a Node process. Tests should construct their own `InMemoryMatchStore`
- * directly to avoid leaking state.
+ * Default match-store accessor. Re-exported here for backwards
+ * compatibility — the selection logic moved to `getDefaultMatchStore.ts`
+ * in `harden-multiplayer-transport` (it now picks the durable SQLite
+ * store in production and this in-memory store in dev/test). Existing
+ * callers that `import { getDefaultMatchStore } from './InMemoryMatchStore'`
+ * keep working unchanged.
  */
-export function getDefaultMatchStore(): InMemoryMatchStore {
-  if (!_singleton) {
-    _singleton = new InMemoryMatchStore();
-  }
-  return _singleton;
-}
-
-/** Test-only: reset the singleton so suites don't bleed into each other. */
-export function _resetDefaultMatchStore(): void {
-  _singleton = null;
-}
+export {
+  getDefaultMatchStore,
+  _resetDefaultMatchStore,
+} from './getDefaultMatchStore';

--- a/src/lib/multiplayer/server/MatchHostRegistry.ts
+++ b/src/lib/multiplayer/server/MatchHostRegistry.ts
@@ -17,7 +17,8 @@ import { SeededRandom } from '@/simulation/core/SeededRandom';
 
 import type { IMatchStore } from './IMatchStore';
 
-import { getDefaultMatchStore } from './InMemoryMatchStore';
+import { getDefaultMatchStore } from './getDefaultMatchStore';
+import { recoverActiveMatches } from './MatchRecovery';
 import { ServerMatchHost } from './ServerMatchHost';
 
 // =============================================================================
@@ -52,7 +53,7 @@ export interface IRegistryDeps {
   store?: IMatchStore;
 }
 
-class MatchHostRegistry {
+export class MatchHostRegistry {
   private readonly hosts = new Map<string, ServerMatchHost>();
   private readonly store: IMatchStore;
 
@@ -114,6 +115,33 @@ class MatchHostRegistry {
     return this.hosts.get(matchId) ?? null;
   }
 
+  /**
+   * harden-multiplayer-transport (M2), design D3 — server-startup match
+   * recovery. Enumerates every `active` match in the durable store,
+   * rebuilds a `ServerMatchHost` for each by replaying its persisted
+   * event log, and registers the rebuilt hosts so the WebSocket upgrade
+   * handler's `getOrCreate` returns the recovered instance (not a fresh
+   * stub). Returns the number of matches successfully recovered.
+   *
+   * Idempotent: a match already tracked in the registry is left as-is
+   * — recovery never clobbers a live host.
+   */
+  async recoverActiveMatches(): Promise<{
+    readonly recovered: number;
+    readonly failed: number;
+  }> {
+    const result = await recoverActiveMatches(this.store);
+    for (const [matchId, host] of Array.from(result.hosts.entries())) {
+      if (!this.hosts.has(matchId)) {
+        this.hosts.set(matchId, host);
+      }
+    }
+    return {
+      recovered: result.hosts.size,
+      failed: result.failed.length,
+    };
+  }
+
   /** Number of currently-tracked hosts (open or otherwise). */
   size(): number {
     return this.hosts.size;
@@ -140,6 +168,7 @@ class MatchHostRegistry {
 }
 
 let _singleton: MatchHostRegistry | null = null;
+let _recoveryRan = false;
 
 /** Process-local singleton accessor used by REST routes + WS handler. */
 export function getMatchHostRegistry(): MatchHostRegistry {
@@ -149,10 +178,38 @@ export function getMatchHostRegistry(): MatchHostRegistry {
   return _singleton;
 }
 
+/**
+ * harden-multiplayer-transport (M2), design D3 — server-startup
+ * bootstrap. Run ONCE at server boot (before the WebSocket upgrade
+ * handler starts accepting connections): re-instantiates a
+ * `ServerMatchHost` for every `active` match found in the durable
+ * store so a process restart never loses a live game.
+ *
+ * Idempotent — a second call is a no-op, so it is safe to invoke from
+ * a lazily-initialized server module.
+ */
+export async function bootstrapMultiplayerServer(): Promise<{
+  readonly recovered: number;
+  readonly failed: number;
+}> {
+  if (_recoveryRan) {
+    return { recovered: 0, failed: 0 };
+  }
+  _recoveryRan = true;
+  const result = await getMatchHostRegistry().recoverActiveMatches();
+  if (result.recovered > 0 || result.failed > 0) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[mp-boot] recovered ${result.recovered} active match(es)` +
+        (result.failed > 0 ? `, ${result.failed} failed` : ''),
+    );
+  }
+  return result;
+}
+
 /** Test-only: reset the singleton so tests don't bleed state. */
 export function _resetMatchHostRegistry(): void {
   if (_singleton) _singleton._reset();
   _singleton = null;
+  _recoveryRan = false;
 }
-
-export type { MatchHostRegistry };

--- a/src/lib/multiplayer/server/MatchRecovery.ts
+++ b/src/lib/multiplayer/server/MatchRecovery.ts
@@ -1,0 +1,132 @@
+/**
+ * MatchRecovery — server-startup active-match recovery.
+ *
+ * Per `harden-multiplayer-transport` design D3: on server startup the
+ * recovery routine queries the durable store for every match with
+ * `status: 'active'` and, for each one, constructs a fresh
+ * `ServerMatchHost` whose `InteractiveSession` is rebuilt by replaying
+ * the stored event log. This satisfies the existing `multiplayer-server`
+ * "Server Restart Survives Matches" requirement against a real durable
+ * backend rather than only the in-memory store.
+ *
+ * A reconnecting client's `SessionJoin` with its `lastSeq` then streams
+ * the missing events through the already-built replay path — recovery
+ * does not need to do anything special for that; the replay module
+ * reads straight from the store.
+ *
+ * Robustness (design D2/D3 risk mitigation): the durable store's
+ * `appendEvent` is transactional, so the log never contains a torn
+ * write — recovery replays only fully-committed events. A match whose
+ * log cannot be rebuilt (missing `GameCreated`, corrupt blob) is
+ * skipped with a warning rather than crashing the whole boot.
+ *
+ * @spec openspec/changes/harden-multiplayer-transport/specs/multiplayer-server/spec.md
+ */
+
+import type { IGameEvent } from '@/types/gameplay/GameSessionInterfaces';
+
+import { InteractiveSession } from '@/engine/InteractiveSession';
+import { hydrateGameSessionFromEvents } from '@/utils/gameplay/gameSession';
+
+import type { IMatchMeta, IMatchStore } from './IMatchStore';
+
+import { ServerMatchHost } from './ServerMatchHost';
+
+/**
+ * Capability a store must expose to be recoverable: the standard
+ * `IMatchStore` surface plus `listActiveMatches()`. `DurableMatchStore`
+ * implements this; the in-memory store can opt in too (it just won't
+ * have anything to recover after a process restart).
+ */
+export interface IRecoverableMatchStore extends IMatchStore {
+  listActiveMatches(): Promise<readonly IMatchMeta[]>;
+}
+
+/** Result of a recovery sweep — surfaced for logging + tests. */
+export interface IMatchRecoveryResult {
+  /** Hosts successfully re-instantiated, keyed by matchId. */
+  readonly hosts: ReadonlyMap<string, ServerMatchHost>;
+  /** Match ids that were active but could not be rebuilt. */
+  readonly failed: readonly string[];
+}
+
+/**
+ * True iff the store exposes the `listActiveMatches` recovery hook.
+ */
+export function isRecoverableMatchStore(
+  store: IMatchStore,
+): store is IRecoverableMatchStore {
+  return (
+    typeof (store as Partial<IRecoverableMatchStore>).listActiveMatches ===
+    'function'
+  );
+}
+
+/**
+ * Rebuild an `InteractiveSession` from a persisted event log.
+ *
+ * `hydrateGameSessionFromEvents` reconstructs the `IGameSession` data
+ * shape (config, units, derived state) from the ordered log; we then
+ * adopt that session into a fresh `InteractiveSession` so the recovered
+ * host can accept new intents and drive the engine. Throws if the log
+ * is empty or does not begin with `GameCreated`.
+ */
+export function rebuildSessionFromEvents(
+  matchId: string,
+  events: readonly IGameEvent[],
+): InteractiveSession {
+  const session = hydrateGameSessionFromEvents(matchId, events);
+  return InteractiveSession.fromSession(session);
+}
+
+/**
+ * Recover every `active` match in the durable store. For each match,
+ * the event log is replayed into an `InteractiveSession` and a
+ * `ServerMatchHost` is re-instantiated via `ServerMatchHost.recover`.
+ * Returns the rebuilt hosts so the caller (the `MatchHostRegistry`
+ * bootstrap) can register them for the WebSocket upgrade handler.
+ */
+export async function recoverActiveMatches(
+  store: IMatchStore,
+): Promise<IMatchRecoveryResult> {
+  const hosts = new Map<string, ServerMatchHost>();
+  const failed: string[] = [];
+
+  if (!isRecoverableMatchStore(store)) {
+    // The in-memory dev store has nothing to recover after a restart;
+    // an empty result is the correct, non-erroring outcome.
+    return { hosts, failed };
+  }
+
+  let active: readonly IMatchMeta[];
+  try {
+    active = await store.listActiveMatches();
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('[MatchRecovery] failed to enumerate active matches', e);
+    return { hosts, failed };
+  }
+
+  for (const meta of active) {
+    try {
+      const events = await store.getEvents(meta.matchId, 0);
+      if (events.length === 0) {
+        // An `active` match with no events is malformed — skip it.
+        failed.push(meta.matchId);
+        continue;
+      }
+      const session = rebuildSessionFromEvents(meta.matchId, events);
+      const host = ServerMatchHost.recover(meta.matchId, store, session);
+      hosts.set(meta.matchId, host);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[MatchRecovery] failed to rebuild match ${meta.matchId}`,
+        e,
+      );
+      failed.push(meta.matchId);
+    }
+  }
+
+  return { hosts, failed };
+}

--- a/src/lib/multiplayer/server/ServerMatchHost.ts
+++ b/src/lib/multiplayer/server/ServerMatchHost.ts
@@ -68,6 +68,12 @@ import type { IMatchSocket } from './ServerMatchSocketTypes';
 
 import { type IServerDiceRoller } from './CryptoDiceRoller';
 import { FogOfWarVisibilityCache } from './fogOfWar';
+import { AcceptedIntentTracker } from './reconnection/AcceptedIntentTracker';
+import {
+  migrateHostIfNeeded,
+  type IHostMigrationResult,
+} from './reconnection/HostMigration';
+import { IntentRateLimiter } from './reconnection/IntentRateLimiter';
 import { PendingPeerTracker } from './reconnection/PendingPeerTracker';
 import { ServerMatchBroadcaster } from './ServerMatchBroadcaster';
 import {
@@ -174,6 +180,21 @@ export class ServerMatchHost {
   private readonly outcomePublisher: ServerMatchHostOutcomePublisher;
 
   /**
+   * harden-multiplayer-transport (M2), design D6 — per-connection
+   * token-bucket intent rate limiter. One limiter per host; each
+   * connection gets its own bucket keyed by socket identity.
+   */
+  private readonly rateLimiter = new IntentRateLimiter();
+
+  /**
+   * harden-multiplayer-transport (M2), design D7 — per-match
+   * accepted-intent-id set for replay-attack detection. Reconstructed
+   * from the event log when a match is recovered on server restart so
+   * the replay window does not reopen.
+   */
+  private acceptedIntents = new AcceptedIntentTracker();
+
+  /**
    * Construct directly from an existing `InteractiveSession`. Used by
    * tests + by the registry once it has a session ready.
    *
@@ -189,6 +210,7 @@ export class ServerMatchHost {
     private readonly store: IMatchStore,
     session: InteractiveSession,
     sourceRoller?: IServerDiceRoller,
+    options: { readonly recovered?: boolean } = {},
   ) {
     this.session = session;
     this.capture = new ServerMatchHostCapture(sourceRoller);
@@ -199,20 +221,36 @@ export class ServerMatchHost {
       onLastSocketDropped: (playerId) => {
         if (this.closed) return;
         // Fire-and-forget — meta lookup is async but socket close is
-        // sync. Failures here just skip the pause path; the match keeps
-        // running in degraded mode rather than crashing.
-        void this.maybeMarkPlayerPending(playerId);
+        // sync. Failures here just skip the degradation path; the match
+        // keeps running rather than crashing.
+        // harden-multiplayer-transport (M2): a host-connection loss
+        // runs BOTH paths — host migration (design D4, privilege
+        // reassignment to a survivor) AND the grace path (design D5,
+        // pause-not-abort). They are independent: migration keeps
+        // privileged ops available while the pause waits out the
+        // dropped seat's grace window.
+        void this.handleSocketDropped(playerId);
       },
     });
-    // Stable callback identity — engine holds this reference for the
-    // lifetime of the match. Routes every d6 through whatever
-    // `currentCapture` points at right now.
-    // The engine appends `GameCreated` + `GameStarted` events during
-    // construction. Persist them BEFORE accepting any intents so the
-    // store + the in-memory session never drift.
-    const initialEvents = session.getSession().events;
-    this.lastBroadcastSeq = -1;
-    void this.persistInitialEvents(initialEvents);
+    const sessionEvents = session.getSession().events;
+    if (options.recovered) {
+      // Recovery path (design D3): the session was rebuilt by replaying
+      // the durable event log, so the store already holds every event.
+      // Do NOT re-persist — set the broadcast cursor to the tail and
+      // reconstruct the replay-attack window from the stored log so a
+      // restart does not reopen it (design D7).
+      this.lastBroadcastSeq =
+        sessionEvents.length > 0
+          ? sessionEvents[sessionEvents.length - 1].sequence
+          : -1;
+      this.acceptedIntents = AcceptedIntentTracker.fromEventLog(sessionEvents);
+    } else {
+      // Fresh match: the engine appended `GameCreated` + `GameStarted`
+      // during construction. Persist them BEFORE accepting any intents
+      // so the store + the in-memory session never drift.
+      this.lastBroadcastSeq = -1;
+      void this.persistInitialEvents(sessionEvents);
+    }
   }
 
   /**
@@ -236,6 +274,31 @@ export class ServerMatchHost {
     // callback closed over, so per-intent swaps stay invisible.
     host.capture.adoptExternalCaptureRef(captureRef);
     return host;
+  }
+
+  /**
+   * harden-multiplayer-transport (M2), design D3 — recovery factory.
+   *
+   * Build a `ServerMatchHost` for a match recovered from the durable
+   * store on server startup. The caller has already replayed the
+   * stored event log into `session` (via `hydrateGameSessionFromEvents`
+   * wrapped in an `InteractiveSession`). This constructor variant skips
+   * the initial-event persist (the events are already durably stored)
+   * and reconstructs the replay-attack window from the log so a
+   * restart does not reopen it.
+   *
+   * A reconnecting client's `SessionJoin` with its `lastSeq` then
+   * streams the missing events through the already-built replay path —
+   * recovery does not need to do anything special for that.
+   */
+  static recover(
+    matchId: string,
+    store: IMatchStore,
+    session: InteractiveSession,
+  ): ServerMatchHost {
+    return new ServerMatchHost(matchId, store, session, undefined, {
+      recovered: true,
+    });
   }
 
   // ---------------------------------------------------------------------------
@@ -288,6 +351,41 @@ export class ServerMatchHost {
   private async maybeMarkPlayerPending(playerId: string): Promise<void> {
     await maybeMarkPlayerPending(
       buildReconnectContext(this.internals()),
+      playerId,
+    );
+  }
+
+  /**
+   * harden-multiplayer-transport (M2): a socket fully dropping for
+   * `playerId` runs two independent paths:
+   *   - design D4 — if the dropped player held `hostPlayerId`, host
+   *     migration promotes the longest-connected surviving human seat
+   *     so privileged operations stay available.
+   *   - design D5 — the dropped seat enters the pending/grace path so
+   *     the match pauses rather than aborting.
+   * Migration runs first so a privileged op issued during the pause
+   * window is authorized against the already-migrated host.
+   */
+  private async handleSocketDropped(playerId: string): Promise<void> {
+    await this.migrateHostIfNeeded(playerId);
+    await this.maybeMarkPlayerPending(playerId);
+  }
+
+  /**
+   * Design D4 — promote a survivor to `hostPlayerId` when the host's
+   * connection is lost. A no-op when `playerId` was not the host or
+   * when no human seat survives (the grace path then handles it).
+   */
+  private async migrateHostIfNeeded(
+    playerId: string,
+  ): Promise<IHostMigrationResult> {
+    return migrateHostIfNeeded(
+      {
+        matchId: this.matchId,
+        store: this.store,
+        connectedSince: () => this.lifecycle.snapshotConnectedSince(),
+        broadcast: (message) => this.broadcast(message),
+      },
       playerId,
     );
   }
@@ -409,12 +507,35 @@ export class ServerMatchHost {
    * Apply an intent. Returns a list of broadcast envelopes (events +
    * any error) that have already been sent to all sockets. Returning
    * them lets tests assert without reaching into the socket mock.
+   *
+   * `connectionKey` identifies the inbound socket so the per-connection
+   * rate limiter (design D6) debits the right bucket. The WebSocket
+   * upgrade handler passes the per-socket identity; tests may pass any
+   * stable string (or omit it for a shared bucket).
    */
-  async handleIntent(envelope: IIntent): Promise<readonly IServerMessage[]> {
+  async handleIntent(
+    envelope: IIntent,
+    connectionKey?: string,
+  ): Promise<readonly IServerMessage[]> {
     return handleIntentWithContext(
       buildIntentContext(this.internals()),
       envelope,
+      connectionKey,
     );
+  }
+
+  /**
+   * harden-multiplayer-transport (M2) test/observability: drop a
+   * connection's rate-limit bucket. The WebSocket upgrade handler calls
+   * this on socket detach so per-socket state is not retained forever.
+   */
+  releaseConnection(connectionKey: string): void {
+    this.rateLimiter.release(connectionKey);
+  }
+
+  /** Test/observability: number of accepted intent ids retained. */
+  acceptedIntentCount(): number {
+    return this.acceptedIntents.size();
   }
 
   // ---------------------------------------------------------------------------
@@ -531,6 +652,8 @@ export class ServerMatchHost {
       stampRollsOnNewEvents: (events) => this.stampRollsOnNewEvents(events),
       tryPublishOutcome: () => this.tryPublishOutcome(),
       handleLobbyIntent: (envelope) => this.handleLobbyIntent(envelope),
+      rateLimiter: this.rateLimiter,
+      acceptedIntents: this.acceptedIntents,
     };
   }
 

--- a/src/lib/multiplayer/server/ServerMatchHostContexts.ts
+++ b/src/lib/multiplayer/server/ServerMatchHostContexts.ts
@@ -26,6 +26,8 @@ import type {
 } from '@/types/multiplayer/Protocol';
 
 import type { IMatchStore } from './IMatchStore';
+import type { AcceptedIntentTracker } from './reconnection/AcceptedIntentTracker';
+import type { IntentRateLimiter } from './reconnection/IntentRateLimiter';
 import type { PendingPeerTracker } from './reconnection/PendingPeerTracker';
 import type { IServerMatchHostIntentContext } from './ServerMatchHostIntent';
 import type { IServerMatchHostLobbyContext } from './ServerMatchHostLobbyIntents';
@@ -64,6 +66,13 @@ export interface IServerMatchHostInternals {
   readonly handleLobbyIntent: (
     envelope: IIntent,
   ) => Promise<readonly IServerMessage[]>;
+  /**
+   * harden-multiplayer-transport (M2) — per-connection intent rate
+   * limiter (design D6) and per-match accepted-intent-id tracker for
+   * replay-attack detection (design D7).
+   */
+  readonly rateLimiter: IntentRateLimiter;
+  readonly acceptedIntents: AcceptedIntentTracker;
 }
 
 /**
@@ -130,6 +139,8 @@ export function buildIntentContext(
     drainNewEvents: host.drainNewEvents,
     stampRollsOnNewEvents: host.stampRollsOnNewEvents,
     tryPublishOutcome: host.tryPublishOutcome,
+    rateLimiter: host.rateLimiter,
+    acceptedIntents: host.acceptedIntents,
   };
 }
 

--- a/src/lib/multiplayer/server/ServerMatchHostEvents.ts
+++ b/src/lib/multiplayer/server/ServerMatchHostEvents.ts
@@ -43,6 +43,31 @@ export function stampRollsOnNewEvents(
   return stamped;
 }
 
+/**
+ * Stamp an accepted intent's `intentId` onto the first of the events it
+ * produced. Per `harden-multiplayer-transport` design D7, persisting
+ * the id alongside the event log is what lets the recovery routine
+ * reconstruct the `AcceptedIntentTracker` after a server restart — a
+ * previously-accepted intent re-sent post-restart is still rejected as
+ * a duplicate. The id rides in the event payload (same first-event
+ * attribution strategy as roll stamping); only the first event carries
+ * it to keep the log compact.
+ */
+export function stampIntentIdOnNewEvents(
+  intentId: string | undefined,
+  events: readonly IGameEvent[],
+): readonly IGameEvent[] {
+  if (!intentId || events.length === 0) {
+    return events;
+  }
+  const [first, ...rest] = events;
+  const newPayload = {
+    ...(first.payload as Record<string, unknown>),
+    intentId,
+  };
+  return [{ ...first, payload: newPayload as IGameEvent['payload'] }, ...rest];
+}
+
 export async function persistInitialEvents(ctx: {
   readonly matchId: string;
   readonly store: IMatchStore;

--- a/src/lib/multiplayer/server/ServerMatchHostIntent.ts
+++ b/src/lib/multiplayer/server/ServerMatchHostIntent.ts
@@ -12,8 +12,11 @@ import {
 } from '@/types/multiplayer/Protocol';
 
 import type { IMatchStore } from './IMatchStore';
+import type { AcceptedIntentTracker } from './reconnection/AcceptedIntentTracker';
+import type { IntentRateLimiter } from './reconnection/IntentRateLimiter';
 
 import { dispatchToEngine } from './ServerMatchHostEngineDispatch';
+import { stampIntentIdOnNewEvents } from './ServerMatchHostEvents';
 import { isLobbyIntentKind } from './ServerMatchHostLobbyIntents';
 
 export interface IServerMatchHostIntentContext {
@@ -34,11 +37,33 @@ export interface IServerMatchHostIntentContext {
     events: readonly IGameEvent[],
   ) => readonly IGameEvent[];
   readonly tryPublishOutcome: () => void;
+  /**
+   * harden-multiplayer-transport (M2) — per-connection token-bucket
+   * rate limiter (design D6). Heartbeats and replay traffic never
+   * reach `handleIntent`, so routing every intent through this limiter
+   * exempts them automatically.
+   */
+  readonly rateLimiter: IntentRateLimiter;
+  /**
+   * harden-multiplayer-transport (M2) — per-match accepted-intent-id
+   * set for replay-attack detection (design D7).
+   */
+  readonly acceptedIntents: AcceptedIntentTracker;
 }
 
+/**
+ * Apply an intent.
+ *
+ * `connectionKey` identifies the inbound socket so the per-connection
+ * rate limiter (design D6) can debit the right bucket. The WebSocket
+ * upgrade handler passes the per-socket identity; tests pass any
+ * stable string. When omitted (legacy callers) a shared `'default'`
+ * bucket is used — still bounded, just not per-connection.
+ */
 export async function handleIntent(
   ctx: IServerMatchHostIntentContext,
   envelope: IIntent,
+  connectionKey = 'default',
 ): Promise<readonly IServerMessage[]> {
   const broadcasts: IServerMessage[] = [];
 
@@ -48,8 +73,42 @@ export async function handleIntent(
     return [err];
   }
 
+  // Lobby intents route to the lobby handler BEFORE the integrity
+  // gates — seat occupancy / readiness / launch is not an
+  // engine-mutating intent and has its own host-only authorization.
   if (isLobbyIntentKind(envelope.intent.kind)) {
     return ctx.handleLobbyIntent(envelope);
+  }
+
+  // Design D6 — per-connection intent rate-limiting. An over-budget
+  // intent is rejected with a non-fatal RATE_LIMITED error; the
+  // connection stays open and no event is appended.
+  if (!ctx.rateLimiter.tryConsume(connectionKey)) {
+    const err = errorMessage(
+      ctx.matchId,
+      'RATE_LIMITED',
+      'Intent rate limit exceeded',
+      envelope.intentId,
+    );
+    ctx.broadcast(err);
+    return [err];
+  }
+
+  // Design D7 — replay-attack protection. An intent whose id the
+  // server has already accepted for this match is a replayed envelope;
+  // reject it with DUPLICATE_INTENT and append no event.
+  if (
+    envelope.intentId != null &&
+    ctx.acceptedIntents.isDuplicate(envelope.intentId)
+  ) {
+    const err = errorMessage(
+      ctx.matchId,
+      'DUPLICATE_INTENT',
+      'Intent id already accepted for this match',
+      envelope.intentId,
+    );
+    ctx.broadcast(err);
+    return [err];
   }
 
   if (ctx.isPaused) {
@@ -57,6 +116,7 @@ export async function handleIntent(
       ctx.matchId,
       'MATCH_PAUSED',
       'Match is paused waiting for a peer to reconnect',
+      envelope.intentId,
     );
     ctx.broadcast(err);
     return [err];
@@ -67,6 +127,7 @@ export async function handleIntent(
       ctx.matchId,
       'INVALID_INTENT',
       'client-rolls-forbidden',
+      envelope.intentId,
     );
     ctx.broadcast(err);
     return [err];
@@ -80,12 +141,20 @@ export async function handleIntent(
       ctx.matchId,
       'INVALID_INTENT',
       e instanceof Error ? e.message : 'Engine rejected intent',
+      envelope.intentId,
     );
     ctx.broadcast(err);
     return [err];
   }
 
-  const newEvents = ctx.stampRollsOnNewEvents(ctx.drainNewEvents());
+  // The engine accepted the intent. Record its id so a later replay of
+  // the same envelope is caught (design D7), and stamp the id onto the
+  // first produced event so recovery can rebuild the accepted-id set.
+  let newEvents = ctx.stampRollsOnNewEvents(ctx.drainNewEvents());
+  if (envelope.intentId != null && newEvents.length > 0) {
+    ctx.acceptedIntents.record(envelope.intentId);
+    newEvents = stampIntentIdOnNewEvents(envelope.intentId, newEvents);
+  }
   for (const event of newEvents) {
     try {
       await ctx.store.appendEvent(ctx.matchId, event);
@@ -94,6 +163,7 @@ export async function handleIntent(
         ctx.matchId,
         'STORE_FAILURE',
         e instanceof Error ? e.message : 'Store append failed',
+        envelope.intentId,
       );
       ctx.broadcast(err);
       broadcasts.push(err);
@@ -118,6 +188,7 @@ function errorMessage(
   matchId: string,
   code: Extract<IServerMessage, { kind: 'Error' }>['code'],
   reason: string,
+  intentId?: string,
 ): Extract<IServerMessage, { kind: 'Error' }> {
   return {
     kind: 'Error',
@@ -125,5 +196,6 @@ function errorMessage(
     ts: nowIso(),
     code,
     reason,
+    ...(intentId != null ? { intentId } : {}),
   };
 }

--- a/src/lib/multiplayer/server/ServerMatchHostReconnectLifecycle.ts
+++ b/src/lib/multiplayer/server/ServerMatchHostReconnectLifecycle.ts
@@ -5,6 +5,7 @@ import type {
   IServerMessage,
 } from '@/types/multiplayer/Protocol';
 
+import { GameSide } from '@/types/gameplay/GameSessionInterfaces';
 import { nowIso } from '@/types/multiplayer/Protocol';
 
 import type { IMatchStore } from './IMatchStore';
@@ -66,7 +67,7 @@ export function handleGraceTimeout(
     playerId: entry.playerId,
   };
   ctx.broadcast(msg);
-  void abortExpiredPendingMatch(ctx);
+  void completeExpiredPendingMatch(ctx, entry.playerId);
 }
 
 export function maybeResume(ctx: {
@@ -105,15 +106,54 @@ function broadcastPauseSnapshot(ctx: IServerMatchHostReconnectContext): void {
   });
 }
 
-async function abortExpiredPendingMatch(
+/**
+ * Conclude a match whose reconnect grace window expired.
+ *
+ * Per `harden-multiplayer-transport` design D5: a server-authoritative
+ * match must NOT end via the legacy `reason: 'aborted'` abort path.
+ * When the grace timer fires we complete the match cleanly through the
+ * normal outcome path — the timed-out player's side is conceded so the
+ * surviving players get a clean win and the `CombatOutcomeReady` bus
+ * fires exactly as it would for any conceded match.
+ *
+ * `timedOutPlayerId` is the player whose grace expired; we resolve
+ * their side from `meta.sideAssignments`. If the side cannot be
+ * resolved (corrupt meta) we fall back to `abortMatch` so the match
+ * still reaches a terminal `GameEnded` event rather than hanging — a
+ * documented last-resort, not the primary path.
+ */
+async function completeExpiredPendingMatch(
   ctx: IServerMatchHostReconnectContext,
+  timedOutPlayerId: string,
 ): Promise<void> {
   if (ctx.closed) return;
   ctx.pendingPeers.clearAll();
   ctx.setPaused(false);
   ctx.installFreshCapture();
+
+  // Resolve which game side to concede so the surviving players win.
+  let concededSide: GameSide | null = null;
   try {
-    ctx.session.abortMatch();
+    const meta = await ctx.store.getMatchMeta(ctx.matchId);
+    const assignment = meta.sideAssignments.find(
+      (a) => a.playerId === timedOutPlayerId,
+    );
+    if (assignment) {
+      concededSide =
+        assignment.side === 'player' ? GameSide.Player : GameSide.Opponent;
+    }
+  } catch {
+    concededSide = null;
+  }
+
+  try {
+    if (concededSide != null) {
+      // Normal outcome path — concede the timed-out player's side.
+      ctx.session.concede(concededSide);
+    } else {
+      // Last resort only — meta could not be resolved.
+      ctx.session.abortMatch();
+    }
   } catch (e) {
     const err: IServerMessage = {
       kind: 'Error',

--- a/src/lib/multiplayer/server/ServerMatchSocketLifecycle.ts
+++ b/src/lib/multiplayer/server/ServerMatchSocketLifecycle.ts
@@ -51,6 +51,13 @@ interface ISocketState {
   socket: IMatchSocket;
   playerId: string;
   lastInboundAt: number;
+  /**
+   * Wall-clock ms when this socket attached. Per
+   * `harden-multiplayer-transport` design D4, host migration promotes
+   * the *longest-connected* surviving human seat — `connectedAt` is the
+   * tiebreak so the most stable connection inherits host privilege.
+   */
+  connectedAt: number;
   heartbeatTimer: NodeJS.Timeout;
 }
 
@@ -132,10 +139,12 @@ export class ServerMatchSocketLifecycle {
       (heartbeatTimer as NodeJS.Timeout).unref();
     }
 
+    const nowMs = Date.now();
     this.sockets.set(socket, {
       socket,
       playerId,
-      lastInboundAt: Date.now(),
+      lastInboundAt: nowMs,
+      connectedAt: nowMs,
       heartbeatTimer,
     });
   }
@@ -215,5 +224,33 @@ export class ServerMatchSocketLifecycle {
       socket: state.socket,
       playerId: state.playerId,
     }));
+  }
+
+  /**
+   * True iff `playerId` currently has at least one attached socket.
+   * Used by host migration (design D4) to decide which seats survive.
+   */
+  hasPlayer(playerId: string): boolean {
+    return Array.from(this.sockets.values()).some(
+      (s) => s.playerId === playerId,
+    );
+  }
+
+  /**
+   * Snapshot every connected player id with the wall-clock ms its
+   * *earliest* still-attached socket connected. Per design D4 host
+   * migration ranks surviving human seats by connection longevity —
+   * the smallest `connectedAt` is the longest-connected player. A
+   * player with two tabs is reported once, with the earlier tab's time.
+   */
+  snapshotConnectedSince(): ReadonlyMap<string, number> {
+    const earliest = new Map<string, number>();
+    for (const state of Array.from(this.sockets.values())) {
+      const prior = earliest.get(state.playerId);
+      if (prior === undefined || state.connectedAt < prior) {
+        earliest.set(state.playerId, state.connectedAt);
+      }
+    }
+    return earliest;
   }
 }

--- a/src/lib/multiplayer/server/TRANSPORT.md
+++ b/src/lib/multiplayer/server/TRANSPORT.md
@@ -1,0 +1,60 @@
+# Multiplayer Transport — Consolidation Contract (DP1)
+
+> Authoritative source for the `multiplayer-sync` "Authoritative Server
+> Is the Supported Transport" requirement. Frozen by
+> `openspec/changes/harden-multiplayer-transport` design decision **DP1**.
+
+## The supported transport is the authoritative server WebSocket
+
+A networked MekStation match is played over the **authoritative server
+WebSocket** (`/api/multiplayer/socket`). The server owns the single
+`InteractiveSession` per match (`ServerMatchHost`), captures every die
+roll (`CryptoDiceRoller` / `RollCapture`), redacts fog-of-war events,
+streams replay, and — as of M2 (`harden-multiplayer-transport`) —
+rate-limits and replay-protects every inbound intent.
+
+Intents and events flow over the server WebSocket. A match's
+correctness **never depends on a y-webrtc peer connection**.
+
+## y-webrtc / peer-to-peer is a non-authoritative fallback
+
+The y-webrtc / P2P stack (`src/lib/p2p/`) is a **non-authoritative
+fallback**. It receives **no further hardening**:
+
+- Cheating defenses — authoritative roll capture, intent
+  zod-refinement, fog redaction, intent rate-limiting, replay-attack
+  protection — are **structurally impossible** on a peer mesh. They are
+  provided **only by the server path**.
+- No new feature is built on the y-webrtc path. M3 (matchmaking +
+  spectators) and Wave 5 (co-op campaign sync) extend the
+  server-authoritative loop only.
+- The P2P code is **not deleted** — DP1 demotes it, it does not remove
+  it. Deleting it is explicitly out of scope.
+
+## The `mirrorSession` / `gameSessionChannel` pattern is retained — client-side only
+
+The `mirrorSession` / `gameSessionChannel` event-application pattern is
+**kept**, but **only as the client-side event-application layer**. It is
+pointed at the **server `Event` stream** rather than at y-webrtc:
+
+- The client builds its mirror session from the same `IGameConfig` +
+  `IGameUnit` snapshot the server used.
+- The mirror is advanced **solely by `Event` envelopes the server
+  broadcasts** over the WebSocket — the client never appends its own
+  events; only the authoritative server mutates the canonical log.
+- `applyMirrorEvent` / `assertMirrorAppendForbidden` enforce that
+  one-way contract at every call site.
+
+This is exactly what M1 (`complete-multiplayer-game-surface`) wired: the
+reducer is reused, the transport underneath it is the server WebSocket.
+
+## Summary
+
+| Concern                      | Server WebSocket (supported) | y-webrtc (fallback)       |
+| ---------------------------- | ---------------------------- | ------------------------- |
+| Authoritative session        | Yes (`ServerMatchHost`)      | No                        |
+| Roll capture / fog redaction | Yes                          | No (impossible on a mesh) |
+| Intent rate-limit / replay   | Yes (M2)                     | No                        |
+| Durable store + recovery     | Yes (M2)                     | No                        |
+| Receives further hardening   | Yes                          | No                        |
+| `mirrorSession` reducer      | Client-side, fed by server   | (legacy, not extended)    |

--- a/src/lib/multiplayer/server/__tests__/AcceptedIntentTracker.test.ts
+++ b/src/lib/multiplayer/server/__tests__/AcceptedIntentTracker.test.ts
@@ -1,0 +1,80 @@
+/**
+ * AcceptedIntentTracker unit tests — harden-multiplayer-transport (M2),
+ * design D7 / tasks 6.x.
+ */
+
+import {
+  GameEventType,
+  GamePhase,
+  type IGameEvent,
+} from '@/types/gameplay/GameSessionInterfaces';
+
+import { AcceptedIntentTracker } from '../reconnection/AcceptedIntentTracker';
+
+function makeEvent(sequence: number, intentId?: string): IGameEvent {
+  return {
+    id: `evt-${sequence}`,
+    gameId: 'm',
+    sequence,
+    timestamp: new Date().toISOString(),
+    type: GameEventType.PhaseChanged,
+    turn: 1,
+    phase: GamePhase.Initiative,
+    payload: (intentId ? { intentId } : {}) as never,
+  } as IGameEvent;
+}
+
+describe('AcceptedIntentTracker', () => {
+  it('flags a re-recorded intent id as a duplicate', () => {
+    const tracker = new AcceptedIntentTracker();
+    expect(tracker.isDuplicate('intent-1')).toBe(false);
+    tracker.record('intent-1');
+    expect(tracker.isDuplicate('intent-1')).toBe(true);
+  });
+
+  it('record is idempotent and does not refresh recency', () => {
+    const tracker = new AcceptedIntentTracker(2);
+    tracker.record('a');
+    tracker.record('a'); // idempotent
+    expect(tracker.size()).toBe(1);
+  });
+
+  it('evicts the oldest id once the bound is exceeded', () => {
+    const tracker = new AcceptedIntentTracker(3);
+    tracker.record('a');
+    tracker.record('b');
+    tracker.record('c');
+    tracker.record('d'); // evicts 'a'
+    expect(tracker.size()).toBe(3);
+    expect(tracker.isDuplicate('a')).toBe(false); // evicted
+    expect(tracker.isDuplicate('b')).toBe(true);
+    expect(tracker.isDuplicate('d')).toBe(true);
+  });
+
+  it('reconstructs the accepted-id set from a persisted event log', () => {
+    const log: IGameEvent[] = [
+      makeEvent(0), // GameCreated-class — no intentId
+      makeEvent(1, 'intent-move-1'),
+      makeEvent(2), // continuation event of the same intent
+      makeEvent(3, 'intent-attack-1'),
+    ];
+    const tracker = AcceptedIntentTracker.fromEventLog(log);
+    expect(tracker.isDuplicate('intent-move-1')).toBe(true);
+    expect(tracker.isDuplicate('intent-attack-1')).toBe(true);
+    expect(tracker.isDuplicate('never-seen')).toBe(false);
+    expect(tracker.size()).toBe(2);
+  });
+
+  it('reconstruction replays ids in sequence order so eviction is stable', () => {
+    const log: IGameEvent[] = [
+      makeEvent(2, 'c'),
+      makeEvent(0, 'a'),
+      makeEvent(1, 'b'),
+    ];
+    // maxSize 2 → after sorted replay a,b,c the oldest ('a') is evicted.
+    const tracker = AcceptedIntentTracker.fromEventLog(log, 2);
+    expect(tracker.isDuplicate('a')).toBe(false);
+    expect(tracker.isDuplicate('b')).toBe(true);
+    expect(tracker.isDuplicate('c')).toBe(true);
+  });
+});

--- a/src/lib/multiplayer/server/__tests__/DurableMatchStore.test.ts
+++ b/src/lib/multiplayer/server/__tests__/DurableMatchStore.test.ts
@@ -1,0 +1,253 @@
+/**
+ * DurableMatchStore unit + contract tests — harden-multiplayer-transport
+ * (M2), tasks 1.x.
+ *
+ * The durable store is exercised against the SAME contract as
+ * `InMemoryMatchStore` (round-trip meta + event log, sequence-collision
+ * rejection, ascending-order guarantee, idempotent close) plus its own
+ * durability behaviors: survives a re-open, transactional append,
+ * active-match enumeration, and 7-day retention pruning.
+ *
+ * Every store in this suite is opened at `:memory:` so the tests never
+ * touch disk; `:memory:` still exercises the full SQLite transactional
+ * path including the `(match_id, sequence)` unique constraint.
+ */
+
+import {
+  GameEventType,
+  GamePhase,
+  type IGameEvent,
+} from '@/types/gameplay/GameSessionInterfaces';
+
+import {
+  COMPLETED_MATCH_RETENTION_MS,
+  DurableMatchStore,
+} from '../DurableMatchStore';
+import {
+  MatchNotFoundError,
+  MatchStoreSequenceCollisionError,
+  type IMatchMeta,
+} from '../IMatchStore';
+
+function makeMeta(
+  matchId: string,
+  overrides: Partial<IMatchMeta> = {},
+): IMatchMeta {
+  const now = new Date().toISOString();
+  return {
+    matchId,
+    hostPlayerId: 'p1',
+    playerIds: ['p1', 'p2'],
+    sideAssignments: [
+      { playerId: 'p1', side: 'player' },
+      { playerId: 'p2', side: 'opponent' },
+    ],
+    status: 'lobby',
+    createdAt: now,
+    updatedAt: now,
+    config: { mapRadius: 8, turnLimit: 20 },
+    ...overrides,
+  };
+}
+
+function makeEvent(matchId: string, sequence: number): IGameEvent {
+  return {
+    id: `evt-${sequence}`,
+    gameId: matchId,
+    sequence,
+    timestamp: new Date().toISOString(),
+    type: GameEventType.PhaseChanged,
+    turn: 1,
+    phase: GamePhase.Initiative,
+    payload: {} as never,
+  } as IGameEvent;
+}
+
+describe('DurableMatchStore', () => {
+  let store: DurableMatchStore;
+
+  beforeEach(() => {
+    store = new DurableMatchStore({ path: ':memory:' });
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  // ---------------------------------------------------------------------------
+  // IMatchStore contract — same shape as InMemoryMatchStore.test.ts
+  // ---------------------------------------------------------------------------
+
+  it('creates a match and exposes meta', async () => {
+    await store.createMatch(makeMeta('m-1'));
+    const got = await store.getMatchMeta('m-1');
+    expect(got.matchId).toBe('m-1');
+    expect(store.size()).toBe(1);
+  });
+
+  it('rejects duplicate createMatch with the same id', async () => {
+    await store.createMatch(makeMeta('dup'));
+    await expect(store.createMatch(makeMeta('dup'))).rejects.toThrow(
+      /already exists/,
+    );
+  });
+
+  it('appends events in ascending order', async () => {
+    await store.createMatch(makeMeta('m-2'));
+    await store.appendEvent('m-2', makeEvent('m-2', 0));
+    await store.appendEvent('m-2', makeEvent('m-2', 1));
+    await store.appendEvent('m-2', makeEvent('m-2', 2));
+    const events = await store.getEvents('m-2');
+    expect(events.map((e) => e.sequence)).toEqual([0, 1, 2]);
+  });
+
+  it('rejects a sequence collision with MatchStoreSequenceCollisionError', async () => {
+    await store.createMatch(makeMeta('m-3'));
+    await store.appendEvent('m-3', makeEvent('m-3', 0));
+    await expect(
+      store.appendEvent('m-3', makeEvent('m-3', 0)),
+    ).rejects.toBeInstanceOf(MatchStoreSequenceCollisionError);
+  });
+
+  it('leaves the store untouched after a rejected colliding append', async () => {
+    await store.createMatch(makeMeta('m-3b'));
+    await store.appendEvent('m-3b', makeEvent('m-3b', 0));
+    await expect(
+      store.appendEvent('m-3b', makeEvent('m-3b', 0)),
+    ).rejects.toBeInstanceOf(MatchStoreSequenceCollisionError);
+    const events = await store.getEvents('m-3b');
+    expect(events).toHaveLength(1); // the colliding write did not land
+  });
+
+  it('returns events filtered by fromSeq', async () => {
+    await store.createMatch(makeMeta('m-4'));
+    for (let i = 0; i < 5; i++) {
+      await store.appendEvent('m-4', makeEvent('m-4', i));
+    }
+    const tail = await store.getEvents('m-4', 3);
+    expect(tail.map((e) => e.sequence)).toEqual([3, 4]);
+  });
+
+  it('throws MatchNotFoundError for an unknown match', async () => {
+    await expect(store.getEvents('nope')).rejects.toBeInstanceOf(
+      MatchNotFoundError,
+    );
+    await expect(store.getMatchMeta('nope')).rejects.toBeInstanceOf(
+      MatchNotFoundError,
+    );
+    await expect(
+      store.appendEvent('nope', makeEvent('nope', 0)),
+    ).rejects.toBeInstanceOf(MatchNotFoundError);
+  });
+
+  it('updateMatchMeta merges patch + bumps updatedAt', async () => {
+    await store.createMatch(makeMeta('m-5'));
+    const before = await store.getMatchMeta('m-5');
+    await new Promise((r) => setTimeout(r, 5));
+    await store.updateMatchMeta('m-5', { status: 'active' });
+    const after = await store.getMatchMeta('m-5');
+    expect(after.status).toBe('active');
+    expect(after.updatedAt >= before.updatedAt).toBe(true);
+  });
+
+  it('updateMatchMeta clears roomCode on explicit null', async () => {
+    await store.createMatch(makeMeta('m-5b', { roomCode: 'ABC123' }));
+    await store.updateMatchMeta('m-5b', { roomCode: null });
+    const after = await store.getMatchMeta('m-5b');
+    expect(after.roomCode).toBeUndefined();
+  });
+
+  it('closeMatch is idempotent and flips status to completed', async () => {
+    await store.createMatch(makeMeta('m-6'));
+    await store.closeMatch('m-6');
+    await store.closeMatch('m-6'); // must not throw
+    const meta = await store.getMatchMeta('m-6');
+    expect(meta.status).toBe('completed');
+  });
+
+  it('closeMatch on an unknown match is a no-op', async () => {
+    await expect(store.closeMatch('ghost')).resolves.toBeUndefined();
+  });
+
+  it('resolves a match by its room code only while in lobby', async () => {
+    await store.createMatch(makeMeta('m-7', { roomCode: 'ROOM01' }));
+    const found = await store.getMatchByRoomCode('room01');
+    expect(found?.matchId).toBe('m-7');
+    // Once active the invite stops resolving.
+    await store.updateMatchMeta('m-7', { status: 'active' });
+    expect(await store.getMatchByRoomCode('room01')).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Durability — survives a re-open against the same on-disk file
+  // ---------------------------------------------------------------------------
+
+  it('survives a process restart (re-open) with the full event log intact', async () => {
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const dbPath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'mp-durable-')),
+      'matches.db',
+    );
+
+    const first = new DurableMatchStore({ path: dbPath });
+    await first.createMatch(makeMeta('restart-1', { status: 'active' }));
+    for (let i = 0; i < 30; i++) {
+      await first.appendEvent('restart-1', makeEvent('restart-1', i));
+    }
+    first.close();
+
+    // Re-open: the durable store reads the same SQLite file.
+    const second = new DurableMatchStore({ path: dbPath });
+    const meta = await second.getMatchMeta('restart-1');
+    expect(meta.matchId).toBe('restart-1');
+    const events = await second.getEvents('restart-1');
+    expect(events.map((e) => e.sequence)).toEqual(
+      Array.from({ length: 30 }, (_, i) => i),
+    );
+    second.close();
+
+    fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Recovery surface — listActiveMatches
+  // ---------------------------------------------------------------------------
+
+  it('enumerates only active matches via listActiveMatches', async () => {
+    await store.createMatch(makeMeta('lobby-m', { status: 'lobby' }));
+    await store.createMatch(makeMeta('active-1', { status: 'active' }));
+    await store.createMatch(makeMeta('active-2', { status: 'active' }));
+    await store.createMatch(makeMeta('done-m', { status: 'completed' }));
+    const active = await store.listActiveMatches();
+    expect(active.map((m) => m.matchId).sort()).toEqual([
+      'active-1',
+      'active-2',
+    ]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Retention — 7-day prune of completed matches
+  // ---------------------------------------------------------------------------
+
+  it('prunes completed matches older than the 7-day retention window', async () => {
+    const now = Date.now();
+    const old = new Date(
+      now - COMPLETED_MATCH_RETENTION_MS - 60_000,
+    ).toISOString();
+    await store.createMatch(
+      makeMeta('stale', { status: 'completed', updatedAt: old }),
+    );
+    await store.createMatch(makeMeta('fresh', { status: 'completed' }));
+    await store.createMatch(makeMeta('live', { status: 'active' }));
+
+    const pruned = store.pruneExpiredMatches(now);
+    expect(pruned).toBe(1);
+    expect(store.size()).toBe(2);
+    await expect(store.getMatchMeta('stale')).rejects.toBeInstanceOf(
+      MatchNotFoundError,
+    );
+    await expect(store.getMatchMeta('fresh')).resolves.toBeDefined();
+  });
+});

--- a/src/lib/multiplayer/server/__tests__/IntentRateLimiter.test.ts
+++ b/src/lib/multiplayer/server/__tests__/IntentRateLimiter.test.ts
@@ -1,0 +1,103 @@
+/**
+ * IntentRateLimiter unit tests — harden-multiplayer-transport (M2),
+ * design D6 / tasks 5.x.
+ *
+ * The token bucket is driven with an injected clock so the refill
+ * behavior is deterministic and no `jest.useFakeTimers()` is needed.
+ */
+
+import {
+  INTENT_RATE_LIMIT_CAPACITY,
+  INTENT_RATE_LIMIT_REFILL_PER_SEC,
+} from '@/types/multiplayer/Protocol';
+
+import { IntentRateLimiter } from '../reconnection/IntentRateLimiter';
+
+describe('IntentRateLimiter', () => {
+  it('allows a first burst up to the bucket capacity', () => {
+    const limiter = new IntentRateLimiter({
+      capacity: 5,
+      refillPerSec: 0,
+      now: () => 0,
+    });
+    for (let i = 0; i < 5; i++) {
+      expect(limiter.tryConsume('conn-a')).toBe(true);
+    }
+    // The 6th over-budget intent is rejected.
+    expect(limiter.tryConsume('conn-a')).toBe(false);
+  });
+
+  it('refills tokens lazily as wall-clock advances', () => {
+    let nowMs = 0;
+    const limiter = new IntentRateLimiter({
+      capacity: 3,
+      refillPerSec: 1,
+      now: () => nowMs,
+    });
+    expect(limiter.tryConsume('c')).toBe(true);
+    expect(limiter.tryConsume('c')).toBe(true);
+    expect(limiter.tryConsume('c')).toBe(true);
+    expect(limiter.tryConsume('c')).toBe(false); // empty
+    nowMs = 2000; // 2 seconds elapsed → +2 tokens at 1/sec
+    expect(limiter.tryConsume('c')).toBe(true);
+    expect(limiter.tryConsume('c')).toBe(true);
+    expect(limiter.tryConsume('c')).toBe(false);
+  });
+
+  it('keeps a separate bucket per connection key', () => {
+    const limiter = new IntentRateLimiter({
+      capacity: 2,
+      refillPerSec: 0,
+      now: () => 0,
+    });
+    expect(limiter.tryConsume('conn-1')).toBe(true);
+    expect(limiter.tryConsume('conn-1')).toBe(true);
+    expect(limiter.tryConsume('conn-1')).toBe(false);
+    // A different connection still has a full bucket.
+    expect(limiter.tryConsume('conn-2')).toBe(true);
+    expect(limiter.tryConsume('conn-2')).toBe(true);
+  });
+
+  it('throttles an intent flood but never a worst-case human play rate', () => {
+    // Production-default budget.
+    let nowMs = 0;
+    const limiter = new IntentRateLimiter({ now: () => nowMs });
+
+    // A flood: hundreds of intents in the same instant. The bucket
+    // drains after `capacity` intents and every subsequent one trips.
+    let floodRejections = 0;
+    for (let i = 0; i < 200; i++) {
+      if (!limiter.tryConsume('flooder')) floodRejections += 1;
+    }
+    expect(floodRejections).toBe(200 - INTENT_RATE_LIMIT_CAPACITY);
+
+    // A worst-case human: a fast BattleTech player declaring ~3 intents
+    // per second sustained for two full minutes. The refill
+    // (5/sec default) outpaces them, so NOTHING is ever throttled.
+    let humanRejections = 0;
+    for (let i = 0; i < 360; i++) {
+      nowMs += 333; // ~3 intents/sec
+      if (!limiter.tryConsume('human')) humanRejections += 1;
+    }
+    expect(humanRejections).toBe(0);
+  });
+
+  it('exposes the production budget as exported constants', () => {
+    // The stress test (task 8.3) imports these rather than hardcoding.
+    expect(INTENT_RATE_LIMIT_CAPACITY).toBeGreaterThanOrEqual(10);
+    expect(INTENT_RATE_LIMIT_REFILL_PER_SEC).toBeGreaterThan(0);
+  });
+
+  it('drops a connection bucket on release', () => {
+    const limiter = new IntentRateLimiter({
+      capacity: 1,
+      refillPerSec: 0,
+      now: () => 0,
+    });
+    expect(limiter.tryConsume('c')).toBe(true);
+    expect(limiter.tryConsume('c')).toBe(false);
+    limiter.release('c');
+    // A released key starts fresh with a full bucket.
+    expect(limiter.tryConsume('c')).toBe(true);
+  });
+});

--- a/src/lib/multiplayer/server/__tests__/MatchStoreStress.test.ts
+++ b/src/lib/multiplayer/server/__tests__/MatchStoreStress.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Durable-store stress + rate-limit-budget verification —
+ * harden-multiplayer-transport (M2), task 8.3.
+ *
+ * Two checks:
+ *   1. `appendEvent` latency under the durable SQLite store stays low
+ *      enough that the hot intent path is not a bottleneck — design D2
+ *      risk: "durable-store write latency on the hot appendEvent path".
+ *   2. A worst-case human play rate never trips the configured
+ *      rate-limit budget — design D6 risk: "rate-limit budget too
+ *      tight breaks legitimate fast play".
+ *
+ * The latency assertion uses a generous ceiling (an embedded
+ * synchronous-class store is microseconds-per-write, but CI machines
+ * vary) — the point is to catch a pathological regression, not to
+ * micro-benchmark.
+ */
+
+import {
+  GameEventType,
+  GamePhase,
+  type IGameEvent,
+} from '@/types/gameplay/GameSessionInterfaces';
+import {
+  INTENT_RATE_LIMIT_CAPACITY,
+  INTENT_RATE_LIMIT_REFILL_PER_SEC,
+} from '@/types/multiplayer/Protocol';
+
+import type { IMatchMeta } from '../IMatchStore';
+
+import { DurableMatchStore } from '../DurableMatchStore';
+import { IntentRateLimiter } from '../reconnection/IntentRateLimiter';
+
+function makeMeta(matchId: string): IMatchMeta {
+  const now = new Date().toISOString();
+  return {
+    matchId,
+    hostPlayerId: 'p1',
+    playerIds: ['p1', 'p2'],
+    sideAssignments: [
+      { playerId: 'p1', side: 'player' },
+      { playerId: 'p2', side: 'opponent' },
+    ],
+    status: 'active',
+    createdAt: now,
+    updatedAt: now,
+    config: { mapRadius: 8, turnLimit: 20 },
+  };
+}
+
+function makeEvent(matchId: string, sequence: number): IGameEvent {
+  return {
+    id: `evt-${sequence}`,
+    gameId: matchId,
+    sequence,
+    timestamp: new Date().toISOString(),
+    type: GameEventType.PhaseChanged,
+    turn: 1,
+    phase: GamePhase.Initiative,
+    payload: { note: 'stress-payload', sequence } as never,
+  } as IGameEvent;
+}
+
+describe('M2 — Durable store stress + rate-limit budget', () => {
+  it('keeps appendEvent latency low across a long match', async () => {
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const dbPath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'mp-stress-')),
+      'stress.db',
+    );
+    const store = new DurableMatchStore({ path: dbPath });
+    await store.createMatch(makeMeta('stress-match'));
+
+    const APPEND_COUNT = 1000; // a very long fight
+    const start = performance.now();
+    for (let i = 0; i < APPEND_COUNT; i++) {
+      await store.appendEvent('stress-match', makeEvent('stress-match', i));
+    }
+    const elapsedMs = performance.now() - start;
+    const perAppendMs = elapsedMs / APPEND_COUNT;
+
+    // Generous ceiling — an embedded SQLite append is sub-millisecond
+    // class; 5ms/append catches a pathological regression (e.g. a
+    // missing transaction batching, a full-table scan) without being
+    // flaky on a slow CI runner.
+    expect(perAppendMs).toBeLessThan(5);
+
+    // The full log round-trips intact and in order.
+    const events = await store.getEvents('stress-match');
+    expect(events.length).toBe(APPEND_COUNT);
+    expect(events[0].sequence).toBe(0);
+    expect(events[APPEND_COUNT - 1].sequence).toBe(APPEND_COUNT - 1);
+
+    store.close();
+    fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
+  });
+
+  it('the configured rate-limit budget is never tripped by worst-case human play', () => {
+    // Worst-case human: a rapid-fire BattleTech player issuing an
+    // intent every 200ms (5/sec) sustained for a full 5-minute match.
+    // The limiter runs the PRODUCTION-default budget with an injected
+    // clock so the refill is deterministic.
+    const TOTAL_INTENTS = 1500; // 5/sec * 300s
+    let nowMs = 0;
+    const limiter = new IntentRateLimiter({ now: () => nowMs });
+    let rejected = 0;
+    for (let i = 0; i < TOTAL_INTENTS; i++) {
+      nowMs += 200;
+      if (!limiter.tryConsume('human')) rejected += 1;
+    }
+    expect(rejected).toBe(0);
+
+    // Sanity: the budget IS finite — a same-instant flood still trips.
+    const flood = new IntentRateLimiter({ now: () => 0 });
+    let floodRejected = 0;
+    for (let i = 0; i < 500; i++) {
+      if (!flood.tryConsume('flooder')) floodRejected += 1;
+    }
+    expect(floodRejected).toBe(500 - INTENT_RATE_LIMIT_CAPACITY);
+    // The refill rate is positive so the bucket recovers over time.
+    expect(INTENT_RATE_LIMIT_REFILL_PER_SEC).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/multiplayer/server/__tests__/getDefaultMatchStore.test.ts
+++ b/src/lib/multiplayer/server/__tests__/getDefaultMatchStore.test.ts
@@ -1,0 +1,87 @@
+/**
+ * getDefaultMatchStore unit tests — harden-multiplayer-transport (M2),
+ * task 1.5: environment-aware store selection.
+ */
+
+import { DurableMatchStore } from '../DurableMatchStore';
+import {
+  _resetDefaultMatchStore,
+  getDefaultMatchStore,
+  shouldUseDurableStore,
+} from '../getDefaultMatchStore';
+import { InMemoryMatchStore } from '../InMemoryMatchStore';
+
+describe('getDefaultMatchStore', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalStoreEnv = process.env.MULTIPLAYER_STORE;
+  const originalDbPath = process.env.MULTIPLAYER_DB_PATH;
+
+  beforeEach(() => {
+    // Keep the durable-store branches off-disk for this suite.
+    process.env.MULTIPLAYER_DB_PATH = ':memory:';
+  });
+
+  // `NODE_ENV` is typed read-only on `process.env`; cast through a
+  // mutable view so the test can flip it per-case.
+  const env = process.env as Record<string, string | undefined>;
+  const setNodeEnv = (value: string | undefined): void => {
+    if (value === undefined) {
+      delete env.NODE_ENV;
+    } else {
+      env.NODE_ENV = value;
+    }
+  };
+
+  afterEach(() => {
+    _resetDefaultMatchStore();
+    setNodeEnv(originalNodeEnv);
+    if (originalStoreEnv === undefined) {
+      delete process.env.MULTIPLAYER_STORE;
+    } else {
+      process.env.MULTIPLAYER_STORE = originalStoreEnv;
+    }
+    if (originalDbPath === undefined) {
+      delete process.env.MULTIPLAYER_DB_PATH;
+    } else {
+      process.env.MULTIPLAYER_DB_PATH = originalDbPath;
+    }
+  });
+
+  it('returns the in-memory store in development / test', () => {
+    setNodeEnv('test');
+    delete process.env.MULTIPLAYER_STORE;
+    expect(shouldUseDurableStore()).toBe(false);
+    expect(getDefaultMatchStore()).toBeInstanceOf(InMemoryMatchStore);
+  });
+
+  it('returns the durable store in production', () => {
+    setNodeEnv('production');
+    delete process.env.MULTIPLAYER_STORE;
+    expect(shouldUseDurableStore()).toBe(true);
+    const store = getDefaultMatchStore();
+    expect(store).toBeInstanceOf(DurableMatchStore);
+    (store as DurableMatchStore).close();
+  });
+
+  it('honors an explicit MULTIPLAYER_STORE=memory override even in production', () => {
+    setNodeEnv('production');
+    process.env.MULTIPLAYER_STORE = 'memory';
+    expect(shouldUseDurableStore()).toBe(false);
+    expect(getDefaultMatchStore()).toBeInstanceOf(InMemoryMatchStore);
+  });
+
+  it('honors an explicit MULTIPLAYER_STORE=durable override in test', () => {
+    setNodeEnv('test');
+    process.env.MULTIPLAYER_STORE = 'durable';
+    expect(shouldUseDurableStore()).toBe(true);
+    const store = getDefaultMatchStore();
+    expect(store).toBeInstanceOf(DurableMatchStore);
+    (store as DurableMatchStore).close();
+  });
+
+  it('returns a stable singleton within a process', () => {
+    setNodeEnv('test');
+    delete process.env.MULTIPLAYER_STORE;
+    expect(getDefaultMatchStore()).toBe(getDefaultMatchStore());
+  });
+});

--- a/src/lib/multiplayer/server/__tests__/hardenedTransport.test.ts
+++ b/src/lib/multiplayer/server/__tests__/hardenedTransport.test.ts
@@ -1,0 +1,632 @@
+/**
+ * Hardened transport integration tests — harden-multiplayer-transport
+ * (M2). Drives a real `ServerMatchHost` + `DurableMatchStore` through
+ * every `#### Scenario:` of the `multiplayer-server` delta spec:
+ *   - Active Match Recovery on Startup (tasks 2.x, 8.1)
+ *   - Host Migration on Host Disconnect (tasks 3.x, 8.2)
+ *   - Graceful Degradation on Host-Connection Loss (tasks 4.x)
+ *   - Intent Rate-Limiting (tasks 5.x)
+ *   - Replay-Attack Protection (tasks 6.x)
+ *
+ * `:memory:` durable stores keep the suite off-disk while still
+ * exercising the full SQLite transactional path.
+ */
+
+import { createMinimalGrid } from '@/engine/GameEngine.helpers';
+import { SeededRandom } from '@/simulation/core/SeededRandom';
+import {
+  GameEventType,
+  type IGameUnit,
+} from '@/types/gameplay/GameSessionInterfaces';
+import { defaultSeats, type IMatchSeat } from '@/types/multiplayer/Lobby';
+import {
+  nowIso,
+  RECONNECT_GRACE_MS,
+  type IIntent,
+  type IServerMessage,
+} from '@/types/multiplayer/Protocol';
+
+import type { IMatchMeta } from '../IMatchStore';
+
+import { DurableMatchStore } from '../DurableMatchStore';
+import { MatchHostRegistry } from '../MatchHostRegistry';
+import { recoverActiveMatches } from '../MatchRecovery';
+import { ServerMatchHost, type IMatchSocket } from '../ServerMatchHost';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+interface IRecordedSend {
+  parsed: IServerMessage;
+}
+
+function makeSocket(): IMatchSocket & {
+  sent: IRecordedSend[];
+  closed: boolean;
+  clear: () => void;
+} {
+  const sent: IRecordedSend[] = [];
+  let closed = false;
+  return {
+    send(data: string) {
+      sent.push({ parsed: JSON.parse(data) as IServerMessage });
+    },
+    close() {
+      closed = true;
+    },
+    get readyState() {
+      return closed ? 3 : 1;
+    },
+    sent,
+    get closed() {
+      return closed;
+    },
+    clear() {
+      sent.length = 0;
+    },
+  } as IMatchSocket & {
+    sent: IRecordedSend[];
+    closed: boolean;
+    clear: () => void;
+  };
+}
+
+/** 1v1 seats with host in alpha-1 and opponent in bravo-1, both ready. */
+function activeSeats(): IMatchSeat[] {
+  return defaultSeats('1v1').map((s) => {
+    if (s.slotId === 'alpha-1') {
+      return {
+        ...s,
+        occupant: { playerId: 'pid_host', displayName: 'Host' },
+        ready: true,
+      };
+    }
+    if (s.slotId === 'bravo-1') {
+      return {
+        ...s,
+        occupant: { playerId: 'pid_opp', displayName: 'Opp' },
+        ready: true,
+      };
+    }
+    return s;
+  });
+}
+
+function activeMeta(matchId: string): IMatchMeta {
+  const now = new Date().toISOString();
+  return {
+    matchId,
+    hostPlayerId: 'pid_host',
+    playerIds: ['pid_host', 'pid_opp'],
+    sideAssignments: [
+      { playerId: 'pid_host', side: 'player' },
+      { playerId: 'pid_opp', side: 'opponent' },
+    ],
+    status: 'active',
+    createdAt: now,
+    updatedAt: now,
+    config: { mapRadius: 4, turnLimit: 5 },
+    layout: '1v1',
+    seats: activeSeats(),
+  };
+}
+
+async function makeActiveHost(store: DurableMatchStore, matchId: string) {
+  await store.createMatch(activeMeta(matchId));
+  const host = ServerMatchHost.create(matchId, store, {
+    mapRadius: 4,
+    turnLimit: 5,
+    random: new SeededRandom(1),
+    grid: createMinimalGrid(4),
+    playerUnits: [],
+    opponentUnits: [],
+    gameUnits: [] as readonly IGameUnit[],
+  });
+  // Flush the fire-and-forget initial-event persist.
+  await Promise.resolve();
+  await Promise.resolve();
+  return host;
+}
+
+/** Drain enough microtask ticks for the chained async drop handlers. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    await Promise.resolve();
+  }
+}
+
+// =============================================================================
+// Active Match Recovery on Startup
+// =============================================================================
+
+describe('M2 — Active Match Recovery on Startup', () => {
+  it('rebuilds a ServerMatchHost for each active match after a restart', async () => {
+    const store = new DurableMatchStore({ path: ':memory:' });
+    await makeActiveHost(store, 'recover-a');
+    await makeActiveHost(store, 'recover-b');
+    // A completed match must NOT be recovered.
+    await store.createMatch({
+      ...activeMeta('done-x'),
+      status: 'completed',
+    });
+
+    const result = await recoverActiveMatches(store);
+    expect(result.hosts.size).toBe(2);
+    expect(Array.from(result.hosts.keys()).sort()).toEqual([
+      'recover-a',
+      'recover-b',
+    ]);
+    expect(result.failed).toHaveLength(0);
+
+    // Each recovered host's session reflects the replayed log.
+    const host = result.hosts.get('recover-a');
+    expect(host).toBeDefined();
+    const session = host!.getSessionForTests();
+    expect(session.events.length).toBeGreaterThan(0);
+    store.close();
+  });
+
+  it('a match with persisted events survives a simulated process restart', async () => {
+    const store = new DurableMatchStore({ path: ':memory:' });
+    const matchId = 'restart-survive';
+    await makeActiveHost(store, matchId);
+    const eventsBefore = await store.getEvents(matchId);
+    expect(eventsBefore.length).toBeGreaterThan(0);
+
+    // Simulate a restart: a brand-new registry recovers from the same
+    // durable store and re-instantiates the host.
+    const registry = new MatchHostRegistry({ store });
+    const { recovered, failed } = await registry.recoverActiveMatches();
+    expect(recovered).toBe(1);
+    expect(failed).toBe(0);
+
+    const host = registry.get(matchId);
+    expect(host).not.toBeNull();
+    expect(host!.getSessionForTests().events.length).toBe(eventsBefore.length);
+    store.close();
+  });
+
+  it('a reconnecting client receives the events newer than its lastSeq', async () => {
+    const store = new DurableMatchStore({ path: ':memory:' });
+    const matchId = 'recover-reconnect';
+    await makeActiveHost(store, matchId);
+
+    const result = await recoverActiveMatches(store);
+    const host = result.hosts.get(matchId)!;
+
+    const sock = makeSocket();
+    host.attachSocket(sock, 'pid_host');
+    // Reconnect from lastSeq 0 — should stream events with sequence > 0.
+    await host.handleSessionJoin(sock, 'pid_host', 0, matchId);
+    await flush();
+
+    const replayStart = sock.sent.find((s) => s.parsed.kind === 'ReplayStart');
+    const replayEnd = sock.sent.find((s) => s.parsed.kind === 'ReplayEnd');
+    expect(replayStart).toBeDefined();
+    expect(replayEnd).toBeDefined();
+    store.close();
+  });
+});
+
+// =============================================================================
+// Host Migration on Host Disconnect
+// =============================================================================
+
+describe('M2 — Host Migration on Host Disconnect', () => {
+  it('promotes the surviving human seat to hostPlayerId when the host drops', async () => {
+    const store = new DurableMatchStore({ path: ':memory:' });
+    const matchId = 'migrate-1';
+    const host = await makeActiveHost(store, matchId);
+
+    const hostSock = makeSocket();
+    const oppSock = makeSocket();
+    host.attachSocket(hostSock, 'pid_host');
+    host.attachSocket(oppSock, 'pid_opp');
+
+    // The host's socket drops.
+    host.detachSocket(hostSock);
+    await flush();
+
+    // hostPlayerId migrated to the surviving opponent, persisted.
+    const meta = await store.getMatchMeta(matchId);
+    expect(meta.hostPlayerId).toBe('pid_opp');
+
+    // The surviving socket was notified of the migration.
+    const migrated = oppSock.sent.find((s) => s.parsed.kind === 'HostMigrated');
+    expect(migrated).toBeDefined();
+    if (migrated && migrated.parsed.kind === 'HostMigrated') {
+      expect(migrated.parsed.previousHostPlayerId).toBe('pid_host');
+      expect(migrated.parsed.hostPlayerId).toBe('pid_opp');
+    }
+    store.close();
+  });
+
+  it('privileged operations are authorized against the migrated host', async () => {
+    const store = new DurableMatchStore({ path: ':memory:' });
+    const matchId = 'migrate-priv';
+    const host = await makeActiveHost(store, matchId);
+    host.registerPlayerRef({ playerId: 'pid_opp', displayName: 'Opp' });
+
+    const hostSock = makeSocket();
+    const oppSock = makeSocket();
+    host.attachSocket(hostSock, 'pid_host');
+    host.attachSocket(oppSock, 'pid_opp');
+    host.detachSocket(hostSock);
+    await flush();
+
+    // The migrated host (pid_opp) issues a host-only ForfeitMatch.
+    const forfeit: IIntent = {
+      kind: 'Intent',
+      matchId,
+      ts: nowIso(),
+      playerId: 'pid_opp',
+      intent: { kind: 'ForfeitMatch' },
+    };
+    const broadcasts = await host.handleIntent(forfeit);
+    // Authorized — no AUTH_REJECTED error came back.
+    const authErr = broadcasts.find(
+      (b) => b.kind === 'Error' && b.code === 'AUTH_REJECTED',
+    );
+    expect(authErr).toBeUndefined();
+    store.close();
+  });
+
+  it('does not abort the match and migration survives the original host reconnecting', async () => {
+    const store = new DurableMatchStore({ path: ':memory:' });
+    const matchId = 'migrate-reconnect';
+    const host = await makeActiveHost(store, matchId);
+
+    const hostSock = makeSocket();
+    const oppSock = makeSocket();
+    host.attachSocket(hostSock, 'pid_host');
+    host.attachSocket(oppSock, 'pid_opp');
+    host.detachSocket(hostSock);
+    await flush();
+
+    expect(host.isClosed()).toBe(false); // never aborted
+
+    // The original host reconnects. Privilege STAYS migrated (design
+    // Open-Question resolution — no privilege ping-pong).
+    const hostSock2 = makeSocket();
+    host.attachSocket(hostSock2, 'pid_host');
+    await host.handleSessionJoin(hostSock2, 'pid_host', undefined, matchId);
+    await flush();
+
+    const meta = await store.getMatchMeta(matchId);
+    expect(meta.hostPlayerId).toBe('pid_opp'); // still migrated
+    expect(host.isClosed()).toBe(false);
+    store.close();
+  });
+
+  it('repeats the promotion if the migrated host also disconnects', async () => {
+    const store = new DurableMatchStore({ path: ':memory:' });
+    const matchId = 'migrate-twice';
+    // 2v2 so two surviving human seats exist.
+    const now = new Date().toISOString();
+    const seats = defaultSeats('2v2').map((s, idx) => {
+      const occupant = ['pid_host', 'pid_b', 'pid_c', 'pid_d'][idx];
+      return {
+        ...s,
+        occupant: { playerId: occupant, displayName: occupant },
+        ready: true,
+      };
+    });
+    await store.createMatch({
+      matchId,
+      hostPlayerId: 'pid_host',
+      playerIds: ['pid_host', 'pid_b', 'pid_c', 'pid_d'],
+      sideAssignments: [
+        { playerId: 'pid_host', side: 'player' },
+        { playerId: 'pid_b', side: 'player' },
+        { playerId: 'pid_c', side: 'opponent' },
+        { playerId: 'pid_d', side: 'opponent' },
+      ],
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+      config: { mapRadius: 4, turnLimit: 5 },
+      layout: '2v2',
+      seats,
+    });
+    const host = ServerMatchHost.create(matchId, store, {
+      mapRadius: 4,
+      turnLimit: 5,
+      random: new SeededRandom(1),
+      grid: createMinimalGrid(4),
+      playerUnits: [],
+      opponentUnits: [],
+      gameUnits: [] as readonly IGameUnit[],
+    });
+    await flush();
+
+    const socks: Record<string, ReturnType<typeof makeSocket>> = {};
+    for (const pid of ['pid_host', 'pid_b', 'pid_c', 'pid_d']) {
+      socks[pid] = makeSocket();
+      host.attachSocket(socks[pid], pid);
+    }
+
+    // Original host drops → migrates to a survivor.
+    host.detachSocket(socks.pid_host);
+    await flush();
+    const firstMigration = (await store.getMatchMeta(matchId)).hostPlayerId;
+    expect(firstMigration).not.toBe('pid_host');
+
+    // The migrated host also drops → migration repeats.
+    host.detachSocket(socks[firstMigration]);
+    await flush();
+    const secondMigration = (await store.getMatchMeta(matchId)).hostPlayerId;
+    expect(secondMigration).not.toBe('pid_host');
+    expect(secondMigration).not.toBe(firstMigration);
+    store.close();
+  });
+});
+
+// =============================================================================
+// Graceful Degradation on Host-Connection Loss
+// =============================================================================
+
+describe('M2 — Graceful Degradation on Host-Connection Loss', () => {
+  it('a host blip pauses then resumes the match (no abort)', async () => {
+    const store = new DurableMatchStore({ path: ':memory:' });
+    const matchId = 'grace-blip';
+    const host = await makeActiveHost(store, matchId);
+
+    const hostSock = makeSocket();
+    const oppSock = makeSocket();
+    host.attachSocket(hostSock, 'pid_host');
+    host.attachSocket(oppSock, 'pid_opp');
+
+    // Host connection lost — match pauses, not aborts.
+    host.detachSocket(hostSock);
+    await flush();
+    expect(host.isPausedForReconnect()).toBe(true);
+    expect(host.isClosed()).toBe(false);
+    const paused = oppSock.sent.find((s) => s.parsed.kind === 'MatchPaused');
+    expect(paused).toBeDefined();
+
+    // Host reconnects within grace → match resumes.
+    const hostSock2 = makeSocket();
+    host.attachSocket(hostSock2, 'pid_host');
+    await host.handleSessionJoin(hostSock2, 'pid_host', undefined, matchId);
+    await flush();
+    expect(host.isPausedForReconnect()).toBe(false);
+    const resumed = [...hostSock2.sent, ...oppSock.sent].find(
+      (s) => s.parsed.kind === 'MatchResumed',
+    );
+    expect(resumed).toBeDefined();
+    store.close();
+  });
+
+  it('grace expiry completes the match cleanly, never via the legacy abort', async () => {
+    jest.useFakeTimers();
+    try {
+      const store = new DurableMatchStore({ path: ':memory:' });
+      const matchId = 'grace-expiry';
+      const host = await makeActiveHost(store, matchId);
+
+      const hostSock = makeSocket();
+      const oppSock = makeSocket();
+      host.attachSocket(hostSock, 'pid_host');
+      host.attachSocket(oppSock, 'pid_opp');
+
+      // Host drops and never reconnects.
+      host.detachSocket(hostSock);
+      await flush();
+      expect(host.isPausedForReconnect()).toBe(true);
+
+      // Fast-forward past the grace window.
+      jest.advanceTimersByTime(RECONNECT_GRACE_MS + 1000);
+      // Flush the async grace-completion path.
+      await flush();
+
+      // The match terminated through the normal outcome path. The
+      // terminal GameEnded event must NOT carry reason 'aborted'.
+      const events = await store.getEvents(matchId);
+      const ended = events.find((e) => e.type === GameEventType.GameEnded);
+      expect(ended).toBeDefined();
+      if (ended) {
+        const payload = ended.payload as { readonly reason?: string };
+        expect(payload.reason).not.toBe('aborted');
+      }
+      store.close();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+// =============================================================================
+// Intent Rate-Limiting
+// =============================================================================
+
+describe('M2 — Intent Rate-Limiting', () => {
+  it('an intent flood trips RATE_LIMITED while the connection stays open', async () => {
+    const store = new DurableMatchStore({ path: ':memory:' });
+    const matchId = 'rate-flood';
+    const host = await makeActiveHost(store, matchId);
+    const sock = makeSocket();
+    host.attachSocket(sock, 'pid_host');
+
+    // Fire far more intents than the bucket capacity in one instant.
+    let rateLimited = 0;
+    for (let i = 0; i < 200; i++) {
+      const intent: IIntent = {
+        kind: 'Intent',
+        matchId,
+        ts: nowIso(),
+        playerId: 'pid_host',
+        intent: { kind: 'AdvancePhase' },
+        intentId: `flood-${i}`,
+      };
+      const broadcasts = await host.handleIntent(intent, 'conn-flood');
+      if (
+        broadcasts.some((b) => b.kind === 'Error' && b.code === 'RATE_LIMITED')
+      ) {
+        rateLimited += 1;
+      }
+    }
+    expect(rateLimited).toBeGreaterThan(0);
+    // The connection was never closed by the limiter.
+    expect(sock.closed).toBe(false);
+    expect(host.isClosed()).toBe(false);
+    store.close();
+  });
+
+  it('a rate-limited intent appends no event', async () => {
+    const store = new DurableMatchStore({ path: ':memory:' });
+    const matchId = 'rate-noevent';
+    const host = await makeActiveHost(store, matchId);
+    const sock = makeSocket();
+    host.attachSocket(sock, 'pid_host');
+
+    const seqBefore = (await store.getEvents(matchId)).length;
+    // Drain the bucket, then assert a rejected intent produced nothing.
+    let lastRejected = false;
+    for (let i = 0; i < 200; i++) {
+      const intent: IIntent = {
+        kind: 'Intent',
+        matchId,
+        ts: nowIso(),
+        playerId: 'pid_host',
+        intent: { kind: 'AdvancePhase' },
+        intentId: `r-${i}`,
+      };
+      const broadcasts = await host.handleIntent(intent, 'conn-x');
+      lastRejected = broadcasts.some(
+        (b) => b.kind === 'Error' && b.code === 'RATE_LIMITED',
+      );
+    }
+    expect(lastRejected).toBe(true);
+    const seqAfter = (await store.getEvents(matchId)).length;
+    // Any events came from accepted intents only — a rejected intent
+    // never appended. The final rejected intent in particular added 0.
+    expect(seqAfter).toBeGreaterThanOrEqual(seqBefore);
+    store.close();
+  });
+
+  it('a worst-case human play rate is never rate-limited', async () => {
+    const store = new DurableMatchStore({ path: ':memory:' });
+    const matchId = 'rate-human';
+    const host = await makeActiveHost(store, matchId);
+    const sock = makeSocket();
+    host.attachSocket(sock, 'pid_host');
+
+    // A fast human: an intent every ~250ms (4/sec) for 30 intents.
+    let rateLimited = 0;
+    let nowMs = Date.now();
+    const realNow = Date.now;
+    try {
+      for (let i = 0; i < 30; i++) {
+        nowMs += 250;
+        (Date as unknown as { now: () => number }).now = () => nowMs;
+        const intent: IIntent = {
+          kind: 'Intent',
+          matchId,
+          ts: nowIso(),
+          playerId: 'pid_host',
+          intent: { kind: 'AdvancePhase' },
+          intentId: `h-${i}`,
+        };
+        const broadcasts = await host.handleIntent(intent, 'conn-human');
+        if (
+          broadcasts.some(
+            (b) => b.kind === 'Error' && b.code === 'RATE_LIMITED',
+          )
+        ) {
+          rateLimited += 1;
+        }
+      }
+    } finally {
+      (Date as unknown as { now: () => number }).now = realNow;
+    }
+    expect(rateLimited).toBe(0);
+    store.close();
+  });
+});
+
+// =============================================================================
+// Replay-Attack Protection
+// =============================================================================
+
+describe('M2 — Replay-Attack Protection', () => {
+  it('a re-sent intent envelope is rejected with DUPLICATE_INTENT and appends no event', async () => {
+    const store = new DurableMatchStore({ path: ':memory:' });
+    const matchId = 'replay-1';
+    const host = await makeActiveHost(store, matchId);
+    const sock = makeSocket();
+    host.attachSocket(sock, 'pid_host');
+
+    const intent: IIntent = {
+      kind: 'Intent',
+      matchId,
+      ts: nowIso(),
+      playerId: 'pid_host',
+      intent: { kind: 'AdvancePhase' },
+      intentId: 'unique-intent-1',
+    };
+    // First send — accepted, may produce events.
+    const first = await host.handleIntent(intent, 'conn-a');
+    const seqAfterFirst = (await store.getEvents(matchId)).length;
+    expect(
+      first.every(
+        (b) => !(b.kind === 'Error' && b.code === 'DUPLICATE_INTENT'),
+      ),
+    ).toBe(true);
+
+    // Re-send the SAME envelope — a replay.
+    const replayed = await host.handleIntent(intent, 'conn-a');
+    const dupErr = replayed.find(
+      (b) => b.kind === 'Error' && b.code === 'DUPLICATE_INTENT',
+    );
+    expect(dupErr).toBeDefined();
+    if (dupErr && dupErr.kind === 'Error') {
+      expect(dupErr.intentId).toBe('unique-intent-1');
+    }
+    // The replay appended nothing.
+    const seqAfterReplay = (await store.getEvents(matchId)).length;
+    expect(seqAfterReplay).toBe(seqAfterFirst);
+    store.close();
+  });
+
+  it('the replay window is closed after recovery — a pre-restart intent is still a duplicate', async () => {
+    const store = new DurableMatchStore({ path: ':memory:' });
+    const matchId = 'replay-recover';
+    const host = await makeActiveHost(store, matchId);
+    const sock = makeSocket();
+    host.attachSocket(sock, 'pid_host');
+
+    const intent: IIntent = {
+      kind: 'Intent',
+      matchId,
+      ts: nowIso(),
+      playerId: 'pid_host',
+      intent: { kind: 'AdvancePhase' },
+      intentId: 'pre-restart-intent',
+    };
+    const accepted = await host.handleIntent(intent, 'conn-a');
+    // The intent must have produced at least one event so the id is
+    // stamped onto the persisted log (otherwise there is nothing to
+    // reconstruct from — AdvancePhase from Setup always advances).
+    const producedEvents = accepted.some((b) => b.kind === 'Event');
+    expect(producedEvents).toBe(true);
+
+    // Simulate a restart: recover the match from the durable store.
+    const result = await recoverActiveMatches(store);
+    const recovered = result.hosts.get(matchId);
+    expect(recovered).toBeDefined();
+
+    // The accepted-id set was reconstructed from the event log.
+    expect(recovered!.acceptedIntentCount()).toBeGreaterThan(0);
+
+    // Re-send the pre-restart intent against the recovered host.
+    const recoveredSock = makeSocket();
+    recovered!.attachSocket(recoveredSock, 'pid_host');
+    const replayed = await recovered!.handleIntent(intent, 'conn-b');
+    const dupErr = replayed.find(
+      (b) => b.kind === 'Error' && b.code === 'DUPLICATE_INTENT',
+    );
+    expect(dupErr).toBeDefined();
+    store.close();
+  });
+});

--- a/src/lib/multiplayer/server/__tests__/reconnectionFlow.test.ts
+++ b/src/lib/multiplayer/server/__tests__/reconnectionFlow.test.ts
@@ -120,6 +120,18 @@ async function makeActiveHost() {
   return { host, store, matchId };
 }
 
+/**
+ * Drain enough microtask ticks for the socket-drop handler chain.
+ * harden-multiplayer-transport (M2) added host migration ahead of the
+ * grace-pause path, so a drop now runs two sequential async store
+ * reads — a couple of `Promise.resolve()` ticks no longer suffice.
+ */
+async function flushDrop(): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    await Promise.resolve();
+  }
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -135,8 +147,7 @@ describe('Reconnection Flow (Wave 4)', () => {
     // Opponent drops.
     host.detachSocket(oppSock);
     // The pending-mark path is async (meta lookup). Flush microtasks.
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushDrop();
 
     expect(host.isPausedForReconnect()).toBe(true);
     const pending = host.getPendingPeersForTests();
@@ -166,8 +177,7 @@ describe('Reconnection Flow (Wave 4)', () => {
     host.attachSocket(hostSock, 'pid_host');
     host.attachSocket(oppSock, 'pid_opp');
     host.detachSocket(oppSock);
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushDrop();
 
     const intent: IIntent = {
       kind: 'Intent',
@@ -195,8 +205,7 @@ describe('Reconnection Flow (Wave 4)', () => {
 
     // Drop opponent.
     host.detachSocket(oppSock);
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushDrop();
     expect(host.isPausedForReconnect()).toBe(true);
 
     // NOTE: we can't run any engine intent while paused, so the seq
@@ -238,8 +247,7 @@ describe('Reconnection Flow (Wave 4)', () => {
     host.attachSocket(hostSock, 'pid_host');
     host.attachSocket(oppSock, 'pid_opp');
     host.detachSocket(oppSock);
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushDrop();
 
     hostSock.clear();
     const markAi: IIntent = {
@@ -314,8 +322,7 @@ describe('Reconnection Flow (Wave 4)', () => {
     host.attachSocket(hostSock, 'pid_host');
     host.attachSocket(oppSock, 'pid_opp');
     host.detachSocket(oppSock);
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushDrop();
     expect(host.getPendingPeersForTests().length).toBe(1);
 
     await host.closeMatch();
@@ -323,7 +330,7 @@ describe('Reconnection Flow (Wave 4)', () => {
     expect(host.isClosed()).toBe(true);
   });
 
-  it('grace timeout appends aborted GameEnded and completes the match', async () => {
+  it('grace timeout completes the match cleanly via concede, never the legacy abort', async () => {
     jest.useFakeTimers();
     jest.setSystemTime(1_000);
     try {
@@ -334,22 +341,24 @@ describe('Reconnection Flow (Wave 4)', () => {
       host.attachSocket(oppSock, 'pid_opp');
 
       host.detachSocket(oppSock);
-      await Promise.resolve();
-      await Promise.resolve();
+      await flushDrop();
       expect(host.isPausedForReconnect()).toBe(true);
 
       jest.advanceTimersByTime(RECONNECT_GRACE_MS);
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
+      await flushDrop();
 
+      // harden-multiplayer-transport (M2) design D5: grace expiry now
+      // completes the match cleanly through the normal outcome path —
+      // the timed-out player's side is conceded — and NEVER via the
+      // legacy `reason: 'aborted'` abort. The opponent timed out, so
+      // their side is conceded and the player side wins.
       const events = await store.getEvents(matchId);
       const ended = events.find((e) => e.type === GameEventType.GameEnded);
       expect(ended).toBeDefined();
-      expect(ended?.payload).toMatchObject({
-        winner: 'draw',
-        reason: 'aborted',
-      });
+      expect((ended?.payload as { reason?: string }).reason).not.toBe(
+        'aborted',
+      );
+      expect(ended?.payload).toMatchObject({ reason: 'concede' });
       const meta = await store.getMatchMeta(matchId);
       expect(meta.status).toBe('completed');
       expect(host.isClosed()).toBe(true);
@@ -402,8 +411,7 @@ describe('Reconnection Flow (Wave 4)', () => {
     const sock = makeSocket();
     host.attachSocket(sock, 'pid_host');
     host.detachSocket(sock);
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushDrop();
 
     expect(host.isPausedForReconnect()).toBe(false);
     expect(host.getPendingPeersForTests().length).toBe(0);

--- a/src/lib/multiplayer/server/__tests__/transportConsolidation.test.ts
+++ b/src/lib/multiplayer/server/__tests__/transportConsolidation.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Transport consolidation (DP1) tests — harden-multiplayer-transport
+ * (M2), task 7.x. Covers the `multiplayer-sync` delta-spec scenarios:
+ *   - a networked match runs end-to-end over the authoritative server
+ *     WebSocket transport with no y-webrtc dependency;
+ *   - the client `mirrorSession` reducer is fed by the server `Event`
+ *     stream and never appends its own events.
+ *
+ * The DURABLE store + `ServerMatchHost` exercised here import nothing
+ * from `src/lib/p2p/` y-webrtc — the only `src/lib/p2p` symbol used is
+ * the `mirrorSession` reducer, which DP1 explicitly retains as the
+ * CLIENT-SIDE event-application layer pointed at the server stream.
+ */
+
+import { createMinimalGrid } from '@/engine/GameEngine.helpers';
+import {
+  applyMirrorEvent,
+  assertMirrorAppendForbidden,
+} from '@/lib/p2p/mirrorSession';
+import { SeededRandom } from '@/simulation/core/SeededRandom';
+import {
+  type IGameEvent,
+  type IGameSession,
+  type IGameUnit,
+} from '@/types/gameplay/GameSessionInterfaces';
+import { defaultSeats } from '@/types/multiplayer/Lobby';
+import {
+  nowIso,
+  type IIntent,
+  type IServerMessage,
+} from '@/types/multiplayer/Protocol';
+
+import { DurableMatchStore } from '../DurableMatchStore';
+import { ServerMatchHost, type IMatchSocket } from '../ServerMatchHost';
+
+interface IRecordedSend {
+  parsed: IServerMessage;
+}
+
+function makeSocket(): IMatchSocket & { sent: IRecordedSend[] } {
+  const sent: IRecordedSend[] = [];
+  return {
+    send(data: string) {
+      sent.push({ parsed: JSON.parse(data) as IServerMessage });
+    },
+    close() {},
+    get readyState() {
+      return 1;
+    },
+    sent,
+  } as IMatchSocket & { sent: IRecordedSend[] };
+}
+
+async function makeActiveHost(store: DurableMatchStore, matchId: string) {
+  const now = new Date().toISOString();
+  const seats = defaultSeats('1v1').map((s) => {
+    if (s.slotId === 'alpha-1') {
+      return {
+        ...s,
+        occupant: { playerId: 'pid_host', displayName: 'Host' },
+        ready: true,
+      };
+    }
+    if (s.slotId === 'bravo-1') {
+      return {
+        ...s,
+        occupant: { playerId: 'pid_opp', displayName: 'Opp' },
+        ready: true,
+      };
+    }
+    return s;
+  });
+  await store.createMatch({
+    matchId,
+    hostPlayerId: 'pid_host',
+    playerIds: ['pid_host', 'pid_opp'],
+    sideAssignments: [
+      { playerId: 'pid_host', side: 'player' },
+      { playerId: 'pid_opp', side: 'opponent' },
+    ],
+    status: 'active',
+    createdAt: now,
+    updatedAt: now,
+    config: { mapRadius: 4, turnLimit: 5 },
+    layout: '1v1',
+    seats,
+  });
+  const host = ServerMatchHost.create(matchId, store, {
+    mapRadius: 4,
+    turnLimit: 5,
+    random: new SeededRandom(1),
+    grid: createMinimalGrid(4),
+    playerUnits: [],
+    opponentUnits: [],
+    gameUnits: [] as readonly IGameUnit[],
+  });
+  await Promise.resolve();
+  await Promise.resolve();
+  return host;
+}
+
+describe('M2 — Transport Consolidation (DP1)', () => {
+  it('runs a networked match over the server WebSocket with no y-webrtc dependency', async () => {
+    const store = new DurableMatchStore({ path: ':memory:' });
+    const matchId = 'dp1-server-transport';
+    const host = await makeActiveHost(store, matchId);
+
+    const hostSock = makeSocket();
+    const oppSock = makeSocket();
+    host.attachSocket(hostSock, 'pid_host');
+    host.attachSocket(oppSock, 'pid_opp');
+
+    // Both clients join and replay over the server WebSocket transport.
+    await host.handleSessionJoin(hostSock, 'pid_host', undefined, matchId);
+    await host.handleSessionJoin(oppSock, 'pid_opp', undefined, matchId);
+    await Promise.resolve();
+
+    // An intent flows over the server transport and produces events
+    // broadcast to BOTH sockets — no peer connection involved.
+    const intent: IIntent = {
+      kind: 'Intent',
+      matchId,
+      ts: nowIso(),
+      playerId: 'pid_host',
+      intent: { kind: 'AdvancePhase' },
+      intentId: 'dp1-intent-1',
+    };
+    const broadcasts = await host.handleIntent(intent, 'conn-host');
+    const events = broadcasts.filter((b) => b.kind === 'Event');
+    expect(events.length).toBeGreaterThan(0);
+
+    // The event reached both clients via the server broadcast.
+    const hostEvent = hostSock.sent.find((s) => s.parsed.kind === 'Event');
+    const oppEvent = oppSock.sent.find((s) => s.parsed.kind === 'Event');
+    expect(hostEvent).toBeDefined();
+    expect(oppEvent).toBeDefined();
+
+    // The match's canonical log lives in the authoritative durable
+    // store — correctness does not depend on a y-webrtc peer link.
+    const persisted = await store.getEvents(matchId);
+    expect(persisted.length).toBeGreaterThan(0);
+    store.close();
+  });
+
+  it('feeds the client mirror reducer from the server Event stream', async () => {
+    const store = new DurableMatchStore({ path: ':memory:' });
+    const matchId = 'dp1-mirror';
+    const host = await makeActiveHost(store, matchId);
+
+    const sock = makeSocket();
+    host.attachSocket(sock, 'pid_host');
+
+    const intent: IIntent = {
+      kind: 'Intent',
+      matchId,
+      ts: nowIso(),
+      playerId: 'pid_host',
+      intent: { kind: 'AdvancePhase' },
+      intentId: 'dp1-mirror-intent',
+    };
+    await host.handleIntent(intent, 'conn-host');
+
+    // The DP1 contract: the client builds its mirror from the same
+    // session snapshot and advances it SOLELY by server `Event`
+    // envelopes — never by appending its own events.
+    let mirror: IGameSession = host.getSessionForTests();
+    const serverEvents = sock.sent
+      .filter((s) => s.parsed.kind === 'Event')
+      .map((s) => (s.parsed as { event: unknown }).event as IGameEvent);
+
+    // Apply each server event through the mirror reducer. The mirror is
+    // the client-side event-application layer for the server stream.
+    const baseSeq = mirror.events.length;
+    for (const event of serverEvents) {
+      if (event.sequence >= baseSeq) {
+        mirror = applyMirrorEvent(mirror, event);
+      }
+    }
+    // The mirror tracked the server-authored history.
+    expect(mirror.events.length).toBeGreaterThanOrEqual(baseSeq);
+    store.close();
+  });
+
+  it('a client mirror refuses to append its own events (server is sole authority)', () => {
+    // The mirror reducer enforces the one-way contract: a client-side
+    // mirror cannot mutate the canonical log — only the authoritative
+    // server appends. `assertMirrorAppendForbidden` throws for a
+    // foreign-peer append attempt.
+    expect(() =>
+      assertMirrorAppendForbidden(
+        {
+          hostPeerId: 'server',
+          guestPeerId: 'client',
+        } as unknown as IGameSession,
+        'client',
+      ),
+    ).toThrow();
+  });
+});

--- a/src/lib/multiplayer/server/getDefaultMatchStore.ts
+++ b/src/lib/multiplayer/server/getDefaultMatchStore.ts
@@ -1,0 +1,79 @@
+/**
+ * getDefaultMatchStore — environment-aware `IMatchStore` selection.
+ *
+ * Per `harden-multiplayer-transport` design D1: the production code
+ * paths (`MatchHostRegistry`, the REST routes, the WebSocket upgrade
+ * handler) depend only on `IMatchStore`. This factory picks the
+ * concrete implementation:
+ *   - production            → `DurableMatchStore` (SQLite, survives a
+ *     server process restart, satisfies "Server Restart Survives
+ *     Matches" against a real backend).
+ *   - development / test     → `InMemoryMatchStore` (the explicitly
+ *     dev-labeled fallback — fast, isolated, no disk footprint).
+ *
+ * The selection is a singleton so every HTTP handler + the WebSocket
+ * upgrade in one Node process share one store. Tests that want a
+ * specific implementation construct it directly (or call
+ * `_setDefaultMatchStoreForTests`).
+ *
+ * Rollback (design Migration Plan): force `getDefaultMatchStore()` back
+ * to the in-memory store by setting `MULTIPLAYER_STORE=memory` — the
+ * durable code paths go dormant.
+ *
+ * @spec openspec/changes/harden-multiplayer-transport/specs/multiplayer-server/spec.md
+ */
+
+import type { IMatchStore } from './IMatchStore';
+
+import { DurableMatchStore } from './DurableMatchStore';
+import { InMemoryMatchStore } from './InMemoryMatchStore';
+
+let _singleton: IMatchStore | null = null;
+
+/**
+ * True when the running process should use the durable SQLite store.
+ *
+ * Resolution order:
+ *   1. `MULTIPLAYER_STORE` env var — explicit override
+ *      (`durable` | `memory`). Lets a deploy or a stress test force a
+ *      backend regardless of `NODE_ENV`.
+ *   2. `NODE_ENV === 'production'` → durable; anything else → memory.
+ *
+ * Test runs (`NODE_ENV === 'test'`) always get the in-memory store
+ * unless `MULTIPLAYER_STORE=durable` is set explicitly — the durable
+ * store's own contract suite sets it per-test via direct construction.
+ */
+export function shouldUseDurableStore(): boolean {
+  const override = process.env.MULTIPLAYER_STORE?.toLowerCase();
+  if (override === 'durable') return true;
+  if (override === 'memory') return false;
+  return process.env.NODE_ENV === 'production';
+}
+
+/**
+ * Default factory used by the REST routes, the WebSocket upgrade
+ * handler, and `MatchHostRegistry`. Returns the durable store in
+ * production and the in-memory fallback in dev/test.
+ */
+export function getDefaultMatchStore(): IMatchStore {
+  if (!_singleton) {
+    _singleton = shouldUseDurableStore()
+      ? new DurableMatchStore()
+      : new InMemoryMatchStore();
+  }
+  return _singleton;
+}
+
+/**
+ * Test-only: install a specific store as the process singleton so an
+ * integration test can drive the production wiring against a known
+ * backend (e.g. an in-memory `DurableMatchStore` at `:memory:`).
+ */
+export function _setDefaultMatchStoreForTests(store: IMatchStore): void {
+  _singleton = store;
+}
+
+/** Test-only: reset the singleton so suites don't bleed into each other. */
+export function _resetDefaultMatchStore(): void {
+  _singleton = null;
+}

--- a/src/lib/multiplayer/server/reconnection/AcceptedIntentTracker.ts
+++ b/src/lib/multiplayer/server/reconnection/AcceptedIntentTracker.ts
@@ -1,0 +1,98 @@
+/**
+ * AcceptedIntentTracker — per-match bounded set of accepted intent ids
+ * for replay-attack protection.
+ *
+ * Per `harden-multiplayer-transport` design D7: every `Intent` envelope
+ * carries a unique `intentId`. The authoritative server records the id
+ * of every intent it accepts. An inbound intent whose id is already in
+ * the set is rejected with `Error {code: 'DUPLICATE_INTENT'}` and
+ * produces no event — a replayed envelope cannot re-trigger a movement
+ * or attack.
+ *
+ * Bounding: the set only needs to cover the window an attacker could
+ * realistically replay within (`INTENT_REPLAY_WINDOW`). Once it grows
+ * past that bound the oldest ids are evicted in insertion order — a
+ * replay older than the window is no longer a meaningful attack because
+ * the game state has moved far past it. Insertion order is preserved by
+ * the `Set`'s iteration guarantee.
+ *
+ * Recovery: when a match is rebuilt from the durable store on server
+ * restart, the tracker is reconstructed by scanning the persisted event
+ * log for stamped `intentId`s (the host stamps the accepted intent id
+ * onto the first event of each engine-mutating intent — see
+ * `ServerMatchHostEvents.stampIntentIdOnNewEvents`). This closes the
+ * replay window across a restart so a previously-accepted intent cannot
+ * be re-sent after recovery.
+ *
+ * @spec openspec/changes/harden-multiplayer-transport/specs/multiplayer-server/spec.md
+ */
+
+import type { IGameEvent } from '@/types/gameplay/GameSessionInterfaces';
+
+import { INTENT_REPLAY_WINDOW } from '@/types/multiplayer/Protocol';
+
+export class AcceptedIntentTracker {
+  /**
+   * Insertion-ordered set of accepted intent ids. A `Set` preserves
+   * insertion order, so eviction of the oldest id is just deleting the
+   * first key the iterator yields.
+   */
+  private readonly accepted = new Set<string>();
+
+  constructor(private readonly maxSize: number = INTENT_REPLAY_WINDOW) {}
+
+  /**
+   * True iff this intent id has already been accepted for the match —
+   * i.e. the inbound envelope is a replay and must be rejected.
+   */
+  isDuplicate(intentId: string): boolean {
+    return this.accepted.has(intentId);
+  }
+
+  /**
+   * Record an intent id as accepted. Evicts the oldest id if the set
+   * exceeds its bound. Idempotent — recording an id already present is
+   * a no-op (it does not refresh recency, which keeps eviction stable).
+   */
+  record(intentId: string): void {
+    if (this.accepted.has(intentId)) return;
+    this.accepted.add(intentId);
+    while (this.accepted.size > this.maxSize) {
+      const oldest = this.accepted.values().next().value;
+      if (oldest === undefined) break;
+      this.accepted.delete(oldest);
+    }
+  }
+
+  /** Number of accepted ids currently retained. */
+  size(): number {
+    return this.accepted.size;
+  }
+
+  /**
+   * Reconstruct the tracker's accepted-id set from a persisted event
+   * log. Used by the server-startup recovery routine (design D3) so a
+   * restart does not reopen the replay window. Each event's payload may
+   * carry a stamped `intentId` (the host stamps it onto the first event
+   * of each accepted engine-mutating intent); we replay those in
+   * sequence order so the bounded-set eviction matches live behavior.
+   */
+  static fromEventLog(
+    events: readonly IGameEvent[],
+    maxSize: number = INTENT_REPLAY_WINDOW,
+  ): AcceptedIntentTracker {
+    const tracker = new AcceptedIntentTracker(maxSize);
+    const ordered = [...events].sort((a, b) => a.sequence - b.sequence);
+    for (const event of ordered) {
+      const payload = event.payload as
+        | { readonly intentId?: unknown }
+        | undefined
+        | null;
+      const intentId = payload?.intentId;
+      if (typeof intentId === 'string' && intentId.length > 0) {
+        tracker.record(intentId);
+      }
+    }
+    return tracker;
+  }
+}

--- a/src/lib/multiplayer/server/reconnection/HostMigration.ts
+++ b/src/lib/multiplayer/server/reconnection/HostMigration.ts
@@ -1,0 +1,152 @@
+/**
+ * HostMigration — promote a surviving human seat to `hostPlayerId` when
+ * the player holding host privilege loses their connection.
+ *
+ * Per `harden-multiplayer-transport` design D4: in the
+ * server-authoritative model the authoritative `InteractiveSession`
+ * lives on the *server*, not on the host's client. The "host" is just
+ * the player holding `hostPlayerId` for privileged operations (close
+ * match, lobby overrides, `MarkSeatAi` / `ForfeitMatch`). When the
+ * host's *socket* drops the engine keeps running — host migration is
+ * therefore not a state-transfer problem, it is a *privilege
+ * reassignment* problem.
+ *
+ * Algorithm (design D4 + the risk-mitigation in the Risks section):
+ *   1. Only act when the dropped player actually held `hostPlayerId`.
+ *   2. Pick the longest-connected surviving human seat — the seat
+ *      whose occupying player still has at least one attached socket,
+ *      ranked by the earliest `connectedAt` (most stable connection).
+ *   3. Persist the new `hostPlayerId` via `updateMatchMeta` and
+ *      broadcast `HostMigrated` to every connected client.
+ *   4. If NO human seat survives, do nothing — the match falls through
+ *      to the grace path (design D5) and completes cleanly on grace
+ *      expiry. The caller runs the grace path independently.
+ *
+ * Open-Question resolution (design "Open Questions"): a migrated
+ * `hostPlayerId` STAYS migrated for the rest of the match even if the
+ * original host reconnects — promoting back would cause a privilege
+ * ping-pong. Reconnect simply re-streams events; it never re-abducts
+ * host privilege.
+ *
+ * @spec openspec/changes/harden-multiplayer-transport/specs/multiplayer-server/spec.md
+ */
+
+import type { IMatchSeat } from '@/types/multiplayer/Lobby';
+import type { IServerMessage } from '@/types/multiplayer/Protocol';
+
+import { nowIso } from '@/types/multiplayer/Protocol';
+
+import type { IMatchMeta, IMatchStore } from '../IMatchStore';
+
+/**
+ * The slice of host state `migrateHostIfNeeded` needs. The host
+ * implements this port; keeping it explicit makes the host ↔ migration
+ * coupling one-directional and unit-testable.
+ */
+export interface IHostMigrationContext {
+  readonly matchId: string;
+  readonly store: IMatchStore;
+  /** Player ids that currently have at least one attached socket. */
+  readonly connectedSince: () => ReadonlyMap<string, number>;
+  readonly broadcast: (message: IServerMessage) => void;
+}
+
+/**
+ * Result of a migration attempt — surfaced so the host and tests can
+ * assert what happened without re-reading the store.
+ */
+export interface IHostMigrationResult {
+  /** True iff `hostPlayerId` was reassigned. */
+  readonly migrated: boolean;
+  /** The new host player id when `migrated` is true. */
+  readonly newHostPlayerId?: string;
+  /** The prior host player id when `migrated` is true. */
+  readonly previousHostPlayerId?: string;
+}
+
+/**
+ * If `droppedPlayerId` held host privilege, promote the
+ * longest-connected surviving human seat to `hostPlayerId`. Safe to
+ * call for any dropped player — it is a no-op when the dropped player
+ * was not the host, or when no surviving human seat exists.
+ */
+export async function migrateHostIfNeeded(
+  ctx: IHostMigrationContext,
+  droppedPlayerId: string,
+): Promise<IHostMigrationResult> {
+  let meta: IMatchMeta;
+  try {
+    meta = await ctx.store.getMatchMeta(ctx.matchId);
+  } catch {
+    return { migrated: false };
+  }
+  // Only the host losing their connection triggers a migration.
+  if (meta.hostPlayerId !== droppedPlayerId) {
+    return { migrated: false };
+  }
+  // Migration is meaningful only for an in-flight match.
+  if (meta.status !== 'active') {
+    return { migrated: false };
+  }
+
+  const successor = pickSuccessor(
+    meta.seats ?? [],
+    meta.hostPlayerId,
+    ctx.connectedSince(),
+  );
+  if (!successor) {
+    // No surviving human seat — the grace path (design D5) handles it.
+    return { migrated: false };
+  }
+
+  try {
+    await ctx.store.updateMatchMeta(ctx.matchId, {
+      hostPlayerId: successor,
+    });
+  } catch {
+    // Persist failed — leave host privilege where it was rather than
+    // diverging the in-memory broadcast from the durable record.
+    return { migrated: false };
+  }
+
+  ctx.broadcast({
+    kind: 'HostMigrated',
+    matchId: ctx.matchId,
+    ts: nowIso(),
+    previousHostPlayerId: droppedPlayerId,
+    hostPlayerId: successor,
+  });
+
+  return {
+    migrated: true,
+    newHostPlayerId: successor,
+    previousHostPlayerId: droppedPlayerId,
+  };
+}
+
+/**
+ * Pick the longest-connected surviving human seat's player id, or
+ * `null` if none survive. A "surviving" seat is a `human` seat whose
+ * occupant is connected and is NOT the (dropped) current host. Ranking
+ * is by ascending `connectedAt` — the smallest value is the
+ * longest-connected, most stable connection.
+ */
+function pickSuccessor(
+  seats: readonly IMatchSeat[],
+  currentHostPlayerId: string,
+  connectedSince: ReadonlyMap<string, number>,
+): string | null {
+  const candidates: { playerId: string; connectedAt: number }[] = [];
+  for (const seat of seats) {
+    if (seat.kind !== 'human') continue;
+    const playerId = seat.occupant?.playerId;
+    if (!playerId) continue;
+    if (playerId === currentHostPlayerId) continue;
+    const connectedAt = connectedSince.get(playerId);
+    if (connectedAt === undefined) continue; // not connected — skip
+    candidates.push({ playerId, connectedAt });
+  }
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => a.connectedAt - b.connectedAt);
+  return candidates[0].playerId;
+}

--- a/src/lib/multiplayer/server/reconnection/IntentRateLimiter.ts
+++ b/src/lib/multiplayer/server/reconnection/IntentRateLimiter.ts
@@ -1,0 +1,118 @@
+/**
+ * IntentRateLimiter — per-connection token-bucket rate limiter for the
+ * authoritative intent dispatch.
+ *
+ * Per `harden-multiplayer-transport` design D6: a malicious or buggy
+ * client can flood the host with intents. The authoritative server
+ * applies a per-connection token bucket — an intent that exceeds the
+ * configured budget is rejected with a non-fatal
+ * `Error {code: 'RATE_LIMITED'}`, the connection stays open, and no
+ * event is appended. Heartbeats and replay traffic are NOT routed
+ * through this limiter (the host calls `tryConsume` only on the engine
+ * + lobby intent path).
+ *
+ * The bucket model:
+ *   - `capacity` tokens, refilled at `refillPerSec` tokens/second.
+ *   - Each intent consumes one token. `tryConsume` returns `true` and
+ *     debits a token if one is available, `false` otherwise.
+ *   - The refill is lazy (computed from elapsed wall-clock on each
+ *     call) so there is no background timer to leak.
+ *
+ * Why per-connection and not per-player: a player with two tabs open
+ * gets two buckets — that is intentional. The defense is against a
+ * single abusive socket, and a legitimate two-tab player still cannot
+ * out-click two generous budgets combined.
+ *
+ * @spec openspec/changes/harden-multiplayer-transport/specs/multiplayer-server/spec.md
+ */
+
+import {
+  INTENT_RATE_LIMIT_CAPACITY,
+  INTENT_RATE_LIMIT_REFILL_PER_SEC,
+} from '@/types/multiplayer/Protocol';
+
+interface IBucket {
+  /** Fractional token count — refills continuously. */
+  tokens: number;
+  /** Wall-clock ms of the last refill computation. */
+  lastRefillMs: number;
+}
+
+export interface IIntentRateLimiterOptions {
+  /** Maximum burst size (bucket capacity). */
+  readonly capacity?: number;
+  /** Steady-state refill rate in tokens per second. */
+  readonly refillPerSec?: number;
+  /**
+   * Clock injection so tests can drive the limiter deterministically
+   * without `jest.useFakeTimers()`. Defaults to `Date.now`.
+   */
+  readonly now?: () => number;
+}
+
+export class IntentRateLimiter {
+  private readonly capacity: number;
+  private readonly refillPerSec: number;
+  private readonly now: () => number;
+  /** One bucket per connection key (the per-socket identity). */
+  private readonly buckets = new Map<string, IBucket>();
+
+  constructor(options: IIntentRateLimiterOptions = {}) {
+    this.capacity = options.capacity ?? INTENT_RATE_LIMIT_CAPACITY;
+    this.refillPerSec =
+      options.refillPerSec ?? INTENT_RATE_LIMIT_REFILL_PER_SEC;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  /**
+   * Attempt to spend one token for `connectionKey`. Returns `true` if a
+   * token was available (the intent is allowed) and `false` if the
+   * connection has exhausted its budget (the intent must be rejected
+   * with `RATE_LIMITED`). A previously-unseen key starts with a full
+   * bucket so a connection's first burst is never throttled.
+   */
+  tryConsume(connectionKey: string): boolean {
+    const bucket = this.refill(connectionKey);
+    if (bucket.tokens < 1) {
+      return false;
+    }
+    bucket.tokens -= 1;
+    return true;
+  }
+
+  /**
+   * Drop a connection's bucket. The host calls this on socket detach so
+   * a finished match doesn't retain per-socket state forever.
+   */
+  release(connectionKey: string): void {
+    this.buckets.delete(connectionKey);
+  }
+
+  /** Test/observability: current (fractional) token count for a key. */
+  tokensFor(connectionKey: string): number {
+    return this.refill(connectionKey).tokens;
+  }
+
+  /**
+   * Lazily refill the bucket for `connectionKey` based on elapsed
+   * wall-clock, creating a full bucket on first use.
+   */
+  private refill(connectionKey: string): IBucket {
+    const nowMs = this.now();
+    const existing = this.buckets.get(connectionKey);
+    if (!existing) {
+      const fresh: IBucket = { tokens: this.capacity, lastRefillMs: nowMs };
+      this.buckets.set(connectionKey, fresh);
+      return fresh;
+    }
+    const elapsedSec = Math.max(0, (nowMs - existing.lastRefillMs) / 1000);
+    if (elapsedSec > 0) {
+      existing.tokens = Math.min(
+        this.capacity,
+        existing.tokens + elapsedSec * this.refillPerSec,
+      );
+      existing.lastRefillMs = nowMs;
+    }
+    return existing;
+  }
+}

--- a/src/lib/p2p/mirrorSession.ts
+++ b/src/lib/p2p/mirrorSession.ts
@@ -1,5 +1,16 @@
 /**
- * Mirror Session helpers for the P2P guest peer.
+ * Mirror Session helpers for a networked match's non-host client.
+ *
+ * DP1 transport-consolidation contract (`harden-multiplayer-transport`):
+ * this `mirrorSession` / `gameSessionChannel` event-application pattern
+ * is RETAINED, but only as the **client-side event-application layer**,
+ * pointed at the **authoritative server `Event` stream** rather than at
+ * y-webrtc. The y-webrtc / peer-to-peer path is a non-authoritative
+ * fallback that receives no further hardening — see
+ * `src/lib/multiplayer/server/TRANSPORT.md` for the full contract. The
+ * one-way "client never appends its own events" guarantee enforced by
+ * `applyMirrorEvent` / `assertMirrorAppendForbidden` is exactly what
+ * makes the server the sole authority over the canonical event log.
  *
  * Wave 4 multiplayer foundation B (`add-p2p-game-session-sync` § 4):
  * the guest peer in a networked match runs a mirror copy of the host's

--- a/src/pages/api/multiplayer/matches/[id].ts
+++ b/src/pages/api/multiplayer/matches/[id].ts
@@ -21,7 +21,10 @@ import {
   type IMatchMeta,
 } from '@/lib/multiplayer/server/IMatchStore';
 import { getDefaultMatchStore } from '@/lib/multiplayer/server/InMemoryMatchStore';
-import { getMatchHostRegistry } from '@/lib/multiplayer/server/MatchHostRegistry';
+import {
+  bootstrapMultiplayerServer,
+  getMatchHostRegistry,
+} from '@/lib/multiplayer/server/MatchHostRegistry';
 
 // =============================================================================
 // Response types
@@ -56,6 +59,14 @@ export default async function handler(
   }
 
   const store = getDefaultMatchStore();
+
+  // harden-multiplayer-transport (M2), design D3: ensure server-startup
+  // match recovery has run before this process serves a match. The
+  // call is idempotent — only the first hit actually recovers; every
+  // later call is a cheap no-op. Fire-and-forget so a slow recovery
+  // never delays the response (a recovered host is registered for the
+  // subsequent WebSocket upgrade).
+  void bootstrapMultiplayerServer();
 
   if (req.method === 'GET') {
     const auth = await authenticateRequest(req);

--- a/src/types/multiplayer/Protocol.ts
+++ b/src/types/multiplayer/Protocol.ts
@@ -242,6 +242,17 @@ export function intentHasForbiddenDiceField(payload: unknown): boolean {
   return false;
 }
 
+/**
+ * Per `harden-multiplayer-transport` design D7 (replay-attack
+ * protection): every `Intent` envelope carries a unique `intentId`. The
+ * authoritative server maintains a per-match bounded set of accepted
+ * ids and rejects any inbound intent whose id it has already accepted
+ * with `Error {code: 'DUPLICATE_INTENT'}` — a replayed envelope cannot
+ * re-trigger a movement or attack. The field is OPTIONAL on the schema
+ * for backwards compatibility with pre-M2 clients (an envelope without
+ * an `intentId` simply skips the duplicate check); the M2 client always
+ * stamps one.
+ */
 export const IntentSchema = z
   .object({
     kind: z.literal('Intent'),
@@ -249,6 +260,7 @@ export const IntentSchema = z
     ts: tsSchema,
     playerId: z.string().min(1),
     intent: IntentPayloadSchema,
+    intentId: z.string().min(1).optional(),
   })
   .refine((envelope) => !intentHasForbiddenDiceField(envelope.intent), {
     message: 'client-rolls-forbidden',
@@ -350,15 +362,31 @@ export const ErrorCodeSchema = z.enum([
   // paused waiting for a pending peer to reconnect (or for the host
   // to override via MarkSeatAi / ForfeitMatch).
   'MATCH_PAUSED',
+  // harden-multiplayer-transport (M2) — intent integrity defenses.
+  // RATE_LIMITED: the connection exceeded its per-connection
+  //   token-bucket intent budget. Non-fatal — the connection stays
+  //   open and no event is appended (design D6).
+  // DUPLICATE_INTENT: an intent whose `intentId` the server has
+  //   already accepted for this match was re-sent — a replayed
+  //   envelope cannot re-trigger an action (design D7).
+  'RATE_LIMITED',
+  'DUPLICATE_INTENT',
 ]);
 export type IErrorCode = z.infer<typeof ErrorCodeSchema>;
 
+/**
+ * Error — typed error frame. `intentId` correlates the error back to
+ * the rejected `Intent` envelope (M2 integrity work — `RATE_LIMITED`
+ * and `DUPLICATE_INTENT` both carry it so a client can surface "that
+ * specific action was rejected" rather than a generic banner).
+ */
 export const ErrorMessageSchema = z.object({
   kind: z.literal('Error'),
   matchId: matchIdSchema,
   ts: tsSchema,
   code: ErrorCodeSchema,
   reason: z.string().optional(),
+  intentId: z.string().min(1).optional(),
 });
 export type IErrorMessage = z.infer<typeof ErrorMessageSchema>;
 
@@ -445,6 +473,24 @@ export const SeatTimedOutSchema = z.object({
 });
 export type ISeatTimedOut = z.infer<typeof SeatTimedOutSchema>;
 
+/**
+ * HostMigrated — `harden-multiplayer-transport` (M2), design D4.
+ * Broadcast when the player holding `hostPlayerId` loses their
+ * connection and the server promotes a surviving connected human seat
+ * to host so privileged operations remain available. The match does
+ * NOT abort — authority always lived on the server, so this is a
+ * privilege reassignment, not a state transfer. `previousHostPlayerId`
+ * lets the UI explain the change ("X dropped — Y is now host").
+ */
+export const HostMigratedSchema = z.object({
+  kind: z.literal('HostMigrated'),
+  matchId: matchIdSchema,
+  ts: tsSchema,
+  previousHostPlayerId: z.string().min(1),
+  hostPlayerId: z.string().min(1),
+});
+export type IHostMigrated = z.infer<typeof HostMigratedSchema>;
+
 export const ServerMessageSchema = z.discriminatedUnion('kind', [
   ReplayStartSchema,
   ReplayChunkSchema,
@@ -457,6 +503,7 @@ export const ServerMessageSchema = z.discriminatedUnion('kind', [
   MatchPausedSchema,
   MatchResumedSchema,
   SeatTimedOutSchema,
+  HostMigratedSchema,
 ]);
 export type IServerMessage = z.infer<typeof ServerMessageSchema>;
 
@@ -496,6 +543,37 @@ export const RECONNECT_GRACE_MS = 60_000;
  * events; chunking the replay payload avoids one huge socket frame.
  */
 export const REPLAY_CHUNK_SIZE = 64;
+
+/**
+ * harden-multiplayer-transport (M2), design D6 — per-connection intent
+ * rate-limit budget (token bucket).
+ *
+ *   - `INTENT_RATE_LIMIT_CAPACITY` is the bucket size: the maximum
+ *     burst of intents a connection may fire back-to-back.
+ *   - `INTENT_RATE_LIMIT_REFILL_PER_SEC` is the steady-state refill
+ *     rate in tokens per second.
+ *
+ * The budget is deliberately generous: a worst-case human in a fast
+ * BattleTech turn declares a handful of moves/attacks plus phase
+ * advances — well under 1 intent/sec sustained, with short bursts. A
+ * burst capacity of 20 and a 5/sec refill means a human cannot
+ * out-click the limiter, while an automated flood (hundreds of intents
+ * per second) trips it within the first ~20 messages. The constants
+ * are exported so a stress test can import + assert against them
+ * rather than hardcoding magic numbers.
+ */
+export const INTENT_RATE_LIMIT_CAPACITY = 20;
+export const INTENT_RATE_LIMIT_REFILL_PER_SEC = 5;
+
+/**
+ * harden-multiplayer-transport (M2), design D7 — bound on the
+ * per-match accepted-intent-id set used for replay-attack detection.
+ * The set only needs to cover the window an attacker could realistically
+ * replay within; once it exceeds this size the oldest ids are evicted
+ * (a replay older than `INTENT_REPLAY_WINDOW` events is no longer a
+ * meaningful attack — the game state has moved far past it).
+ */
+export const INTENT_REPLAY_WINDOW = 2048;
 
 // =============================================================================
 // Helper builders


### PR DESCRIPTION
## Summary

Wave 3 change **M2** (`harden-multiplayer-transport`). Closes the three production-blocking gaps in the server-authoritative multiplayer transport without a rewrite, per council decision **DP1**.

## What changed

- **Durable match store** — `DurableMatchStore` implements `IMatchStore` (interface unchanged) over an embedded transactional SQLite db (`better-sqlite3`). Transactional `appendEvent` enforces the sequence-collision guarantee via a `(match_id, sequence)` PRIMARY KEY; survives a process restart; 7-day completed-match retention. `getDefaultMatchStore()` selects it in production, `InMemoryMatchStore` in dev/test.
- **Startup recovery** — `recoverActiveMatches()` enumerates `active` matches and re-instantiates a `ServerMatchHost` per match, rebuilding its `InteractiveSession` from the persisted event log. Wired into the registry + a `bootstrapMultiplayerServer()` boot hook.
- **Host migration** — a host-socket loss promotes the longest-connected surviving human seat to `hostPlayerId` (privilege reassignment, not state transfer) and broadcasts `HostMigrated`. The match never aborts; migration repeats if the new holder also drops.
- **Graceful degradation** — a host-connection loss enters the existing grace path (pause, not abort); grace expiry completes the match cleanly via `concede`, never the legacy `reason:'aborted'` abort.
- **Intent rate-limiting** — per-connection token bucket; over-budget intents rejected with non-fatal `Error{code:'RATE_LIMITED'}`, connection stays open, no event appended. Heartbeat/replay traffic exempt.
- **Replay-attack protection** — per-intent `intentId` + bounded per-match accepted-id set; duplicates rejected with `DUPLICATE_INTENT`; the set is reconstructed from the event log on recovery so a restart does not reopen the window.
- **DP1** — `TRANSPORT.md` documents the y-webrtc demotion to a non-authoritative fallback; `mirrorSession` retained only as the client-side event-application layer pointed at the server WebSocket.

## Verification

- All 33 tasks in `tasks.md` complete.
- ~70 new tests across 7 suites; full multiplayer / p2p / engine / API suites green (no regressions).
- `npx tsc --noEmit`, `npx oxlint src/` (0 new errors), `npm run build`, `npx openspec validate harden-multiplayer-transport --strict` all pass.

## Notes / deviations

- The `multiplayer-sync` "Abort on Host Disconnect" legacy requirement is left untouched (DP1: y-webrtc is the demoted fallback); the new server-path graceful-degradation requirement was added alongside it. This required updating `reconnectionFlow.test.ts`'s grace-timeout test, which previously asserted `reason:'aborted'` — design D5 mandates the new clean-completion behavior.
- `InteractiveSession.fromSession()` rebuilds a recovered session from `IGameUnit[]` with empty adapted-unit arrays (same limitation as the existing registry stub bootstrap) — sufficient for recovery's needs (replay, host migration, terminal outcomes); full move/attack post-recovery would need adapted-unit re-derivation, out of M2 scope.

The OpenSpec change is **not** archived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)