### PR TITLE
feat(campaign): combat-to-campaign integration loop

### DIFF
--- a/openspec/changes/add-campaign-combat-loop/tasks.md
+++ b/openspec/changes/add-campaign-combat-loop/tasks.md
@@ -2,45 +2,45 @@
 
 ## 1. Inventory Schema Freeze
 
-- [ ] 1.1 Add `ICampaignInventory`, `IRepairBayItem`, `ISalvageBayItem`, `IMedicalBayItem`, and `IInventorySummary` to `src/types/campaign/` exactly as frozen in design.md D4
-- [ ] 1.2 Add a doc comment on each type marking the schema frozen and pointing CP2a at this change for any schema-change request
-- [ ] 1.3 Type tests asserting every field is read-only and the projection sources (`IRepairTicket`, `ISalvageCandidate`) cover every `IRepairBayItem` / `ISalvageBayItem` field
+- [x] 1.1 Add `ICampaignInventory`, `IRepairBayItem`, `ISalvageBayItem`, `IMedicalBayItem`, and `IInventorySummary` to `src/types/campaign/` exactly as frozen in design.md D4
+- [x] 1.2 Add a doc comment on each type marking the schema frozen and pointing CP2a at this change for any schema-change request
+- [x] 1.3 Type tests asserting every field is read-only and the projection sources (`IRepairTicket`, `ISalvageCandidate`) cover every `IRepairBayItem` / `ISalvageBayItem` field
 
 ## 2. Scenario-Event to Encounter Bridge
 
-- [ ] 2.1 Implement `buildEncounterFromScenario(event, campaign)` mapping a `scenario_generated` payload onto an `IEncounter` with `campaignMeta = { campaignId, contractId, scenarioId }`
-- [ ] 2.2 Derive the OpFor force from `opForBV` and `scenarioType` via the existing `opForGeneration` util; derive map config from scenario conditions; derive victory conditions from `scenarioType`
-- [ ] 2.3 Implement `scenarioEncounterBridgeProcessor` at phase `DayPhase.EVENTS + 10`, consuming the day's `scenario_generated` events and persisting an `IEncounter` per event through the `encounter-system` store
-- [ ] 2.4 Implement the `bridgedScenarioIds` idempotency set — a scenario already bridged is skipped
-- [ ] 2.5 Register the bridge processor in `processorRegistration.ts`
-- [ ] 2.6 Tests: a `scenario_generated` event yields one persisted launchable encounter with correct linkage; a re-run produces no duplicate; an empty day produces no encounters
+- [x] 2.1 Implement `buildEncounterFromScenario(event, campaign)` mapping a `scenario_generated` payload onto an `IEncounter` with `campaignMeta = { campaignId, contractId, scenarioId }`
+- [x] 2.2 Derive the OpFor force from `opForBV` and `scenarioType` via the existing `opForGeneration` util; derive map config from scenario conditions; derive victory conditions from `scenarioType`
+- [x] 2.3 Implement `scenarioEncounterBridgeProcessor` at phase `DayPhase.EVENTS + 10`, consuming the day's `scenario_generated` events and persisting an `IEncounter` per event through the `encounter-system` store
+- [x] 2.4 Implement the `bridgedScenarioIds` idempotency set — a scenario already bridged is skipped
+- [x] 2.5 Register the bridge processor in `processorRegistration.ts`
+- [x] 2.6 Tests: a `scenario_generated` event yields one persisted launchable encounter with correct linkage; a re-run produces no duplicate; an empty day produces no encounters
 
 ## 3. Campaign-Linked Encounter Launch
 
-- [ ] 3.1 Implement the campaign launch path — opening a generated encounter from a campaign creates a `GameSession` via the existing `encounter-system` launch snapshot
-- [ ] 3.2 Stamp `campaignId`, `contractId`, and `scenarioId` onto the session using the existing `Session Carries Campaign Linkage` requirement
-- [ ] 3.3 Tests: launching a generated encounter produces a campaign-linked session; the linkage fields round-trip to the session
+- [x] 3.1 Implement the campaign launch path — opening a generated encounter from a campaign creates a `GameSession` via the existing `encounter-system` launch snapshot
+- [x] 3.2 Stamp `campaignId`, `contractId`, and `scenarioId` onto the session using the existing `Session Carries Campaign Linkage` requirement
+- [x] 3.3 Tests: launching a generated encounter produces a campaign-linked session; the linkage fields round-trip to the session
 
 ## 4. Automatic Outcome Enqueue Trigger
 
-- [ ] 4.1 Narrow the campaign store's `CombatOutcomeReady` handler — a session carrying campaign linkage enqueues its outcome onto that campaign's `pendingBattleOutcomes`
-- [ ] 4.2 Preserve existing behavior — a session without campaign linkage is ignored
-- [ ] 4.3 Reuse the duplicate-by-`matchId` guard so a re-published outcome is not enqueued twice
-- [ ] 4.4 Tests: a campaign-linked session completion enqueues exactly once; a standalone skirmish is ignored; a duplicate `matchId` is dropped
+- [x] 4.1 Narrow the campaign store's `CombatOutcomeReady` handler — a session carrying campaign linkage enqueues its outcome onto that campaign's `pendingBattleOutcomes`
+- [x] 4.2 Preserve existing behavior — a session without campaign linkage is ignored
+- [x] 4.3 Reuse the duplicate-by-`matchId` guard so a re-published outcome is not enqueued twice
+- [x] 4.4 Tests: a campaign-linked session completion enqueues exactly once; a standalone skirmish is ignored; a duplicate `matchId` is dropped
 
 ## 5. Inventory Projection
 
-- [ ] 5.1 Implement `projectCampaignInventory(campaign)` — a pure projection from `repairTickets`, `salvageAllocations`, and roster pilot injury state into `ICampaignInventory`
-- [ ] 5.2 Implement a `CLEANUP`-phase processor that runs `projectCampaignInventory` after the battle-effects block drains and attaches the result to the campaign snapshot
-- [ ] 5.3 Tests: projection from a populated post-battle campaign yields the expected `ICampaignInventory`; an empty campaign yields an empty inventory with zeroed summary; projection runs strictly after the battle-effects block
+- [x] 5.1 Implement `projectCampaignInventory(campaign)` — a pure projection from `repairTickets`, `salvageAllocations`, and roster pilot injury state into `ICampaignInventory`
+- [x] 5.2 Implement a `CLEANUP`-phase processor that runs `projectCampaignInventory` after the battle-effects block drains and attaches the result to the campaign snapshot
+- [x] 5.3 Tests: projection from a populated post-battle campaign yields the expected `ICampaignInventory`; an empty campaign yields an empty inventory with zeroed summary; projection runs strictly after the battle-effects block
 
 ## 6. End-to-End Round Trip
 
-- [ ] 6.1 Integration test: a generated scenario is bridged to an encounter, launched as a campaign-linked session, completed, and its outcome auto-enqueued
-- [ ] 6.2 Integration test: advancing the day drains the enqueued outcome through the existing battle-effects processors and the inventory projection reflects the result
-- [ ] 6.3 Integration test: the full round trip is idempotent — re-running the day produces no duplicate encounters, outcomes, or inventory entries
+- [x] 6.1 Integration test: a generated scenario is bridged to an encounter, launched as a campaign-linked session, completed, and its outcome auto-enqueued
+- [x] 6.2 Integration test: advancing the day drains the enqueued outcome through the existing battle-effects processors and the inventory projection reflects the result
+- [x] 6.3 Integration test: the full round trip is idempotent — re-running the day produces no duplicate encounters, outcomes, or inventory entries
 
 ## 7. Verification
 
-- [ ] 7.1 `openspec validate add-campaign-combat-loop --strict` clean
-- [ ] 7.2 Build, lint, and typecheck pass
+- [x] 7.1 `openspec validate add-campaign-combat-loop --strict` clean
+- [x] 7.2 Build, lint, and typecheck pass

--- a/src/__tests__/integration/campaignCombatLoop.test.ts
+++ b/src/__tests__/integration/campaignCombatLoop.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Campaign Combat Loop — end-to-end integration test
+ *
+ * Per `add-campaign-combat-loop` task 6: proves the three connectors
+ * hang together —
+ *   - a generated scenario is bridged to an encounter,
+ *   - launched as a campaign-linked session, completed, its outcome
+ *     auto-enqueued,
+ *   - advancing the day drains the outcome through the existing
+ *     battle-effects processors and the inventory projection reflects
+ *     the result,
+ *   - the full round trip is idempotent.
+ *
+ * The day pipeline is exercised directly (registered builtin
+ * processors) so the bridge → battle-effects → inventory ordering is
+ * the genuine production phase ordering.
+ *
+ * @spec openspec/changes/add-campaign-combat-loop/specs/campaign-combat-loop/spec.md
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+
+import type { IDayEvent } from '@/lib/campaign/dayPipeline';
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICampaignInventory } from '@/types/campaign/CampaignInventory';
+import type { IUnitMaxState } from '@/types/campaign/UnitCombatState';
+import type {
+  ICombatOutcome,
+  IUnitCombatDelta,
+} from '@/types/combat/CombatOutcome';
+
+import { _resetDayPipeline, getDayPipeline } from '@/lib/campaign/dayPipeline';
+import {
+  _resetBuiltinRegistration,
+  registerBuiltinProcessors,
+} from '@/lib/campaign/processors';
+import { applyScenarioEncounterBridge } from '@/lib/campaign/processors/scenarioEncounterBridgeProcessor';
+import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
+import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
+import { CampaignType } from '@/types/campaign/CampaignType';
+import { createDefaultCampaignOptions } from '@/types/campaign/createDefaultCampaignOptions';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
+import { MissionStatus } from '@/types/campaign/enums/MissionStatus';
+import { createContract } from '@/types/campaign/Mission';
+import { Money } from '@/types/campaign/Money';
+import {
+  COMBAT_OUTCOME_VERSION,
+  CombatEndReason,
+  PilotFinalStatus,
+  UnitFinalStatus,
+} from '@/types/combat/CombatOutcome';
+import { EncounterStatus } from '@/types/encounter';
+import { GameSide } from '@/types/gameplay/GameSessionInterfaces';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeCampaign(overrides?: Partial<ICampaign>): ICampaign {
+  return {
+    id: 'campaign-loop-1',
+    name: 'Combat Loop Co.',
+    currentDate: new Date('3025-06-15T00:00:00Z'),
+    factionId: 'mercenary',
+    forces: new Map(),
+    rootForceId: 'root',
+    missions: new Map(),
+    finances: { transactions: [], balance: new Money(1_000_000) },
+    factionStandings: {},
+    options: createDefaultCampaignOptions(),
+    campaignType: CampaignType.MERCENARY,
+    shoppingList: { items: [] },
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    unitCombatStates: {},
+    ...overrides,
+  };
+}
+
+function scenarioEvent(scenarioId: string, contractId: string): IDayEvent {
+  return {
+    type: 'scenario_generated',
+    description: `Scenario ${scenarioId}`,
+    severity: 'info',
+    data: {
+      scenarioType: 'standup',
+      isAttacker: true,
+      opForBV: 4500,
+      conditions: { weather: 'clear', light: 'daylight' },
+      teamId: 'force-alpha',
+      contractId,
+      contractName: 'Garrison: Hesperus II',
+      scenarioId,
+    },
+  };
+}
+
+function makeDelta(unitId: string): IUnitCombatDelta {
+  return {
+    unitId,
+    side: GameSide.Player,
+    destroyed: false,
+    finalStatus: UnitFinalStatus.Damaged,
+    armorRemaining: { CT: 5, LT: 8, RT: 12 },
+    internalsRemaining: { CT: 6, LT: 8, RT: 8 },
+    destroyedLocations: [],
+    destroyedComponents: [],
+    heatEnd: 4,
+    ammoRemaining: {},
+    pilotState: {
+      conscious: true,
+      wounds: 1,
+      killed: false,
+      finalStatus: PilotFinalStatus.Wounded,
+    },
+  };
+}
+
+function makeOutcome(matchId: string, contractId: string): ICombatOutcome {
+  return {
+    version: COMBAT_OUTCOME_VERSION,
+    matchId,
+    contractId,
+    scenarioId: 'scn-loop-1',
+    endReason: CombatEndReason.Destruction,
+    report: {
+      version: 1,
+      matchId,
+      winner: GameSide.Player,
+      reason: 'destruction',
+      turnCount: 5,
+      units: [],
+      mvpUnitId: null,
+      log: [],
+    },
+    unitDeltas: [makeDelta('unit-A')],
+    capturedAt: '3025-06-15T12:00:00Z',
+  };
+}
+
+function seedUnitMaxState(unitId: string): IUnitMaxState {
+  return {
+    unitId,
+    maxArmorPerLocation: { CT: 30, LT: 20, RT: 20 },
+    maxStructurePerLocation: { CT: 15, LT: 12, RT: 12 },
+    maxAmmoPerBin: {},
+  };
+}
+
+function seedRoster(): void {
+  useCampaignRosterStore.setState({
+    campaignId: 'campaign-loop-1',
+    units: [],
+    pilots: [
+      {
+        pilotId: 'unit-A',
+        pilotName: 'Lina "Strix" Volkov',
+        status: CampaignPilotStatus.Active,
+        wounds: 0,
+        recoveryTime: 0,
+        xp: 0,
+        campaignXpEarned: 0,
+        campaignKills: 0,
+        campaignMissions: 0,
+        primaryRole: CampaignPersonnelRole.PILOT,
+        rankIndex: 0,
+        hireDate: new Date('3024-01-01'),
+      },
+    ],
+    missions: [],
+    activeMissionId: null,
+    missionCount: 0,
+  });
+}
+
+function resetWorld(): void {
+  _resetDayPipeline();
+  _resetBuiltinRegistration();
+  useCampaignRosterStore.getState().reset();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Campaign combat loop — end-to-end round trip', () => {
+  beforeEach(resetWorld);
+  afterEach(resetWorld);
+
+  it('6.1 — a generated scenario is bridged to a launchable encounter with linkage', () => {
+    const campaign = makeCampaign();
+    const result = applyScenarioEncounterBridge(
+      campaign,
+      [scenarioEvent('scn-loop-1', 'contract-loop-1')],
+      campaign.currentDate.toISOString(),
+    );
+
+    const bridged = (
+      result.campaign as ICampaign & {
+        bridgedEncounters?: Record<string, { status: EncounterStatus }>;
+      }
+    ).bridgedEncounters;
+    expect(bridged).toBeDefined();
+    const encounter = bridged?.['scn-loop-1'] as {
+      id: string;
+      status: EncounterStatus;
+      campaignMeta?: { contractId: string; scenarioId: string };
+    };
+    expect(encounter.id).toBe('enc-scn-loop-1');
+    expect(encounter.campaignMeta?.contractId).toBe('contract-loop-1');
+    expect(encounter.campaignMeta?.scenarioId).toBe('scn-loop-1');
+  });
+
+  it('6.2 — advancing the day drains the enqueued outcome and the inventory projection reflects it', () => {
+    seedRoster();
+    registerBuiltinProcessors();
+
+    const contract = createContract({
+      id: 'contract-loop-1',
+      name: 'Garrison: Hesperus II',
+      employerId: 'lyran-commonwealth',
+      targetId: 'capellan-confederation',
+      status: MissionStatus.ACTIVE,
+    });
+
+    const outcome = makeOutcome('match-loop-1', contract.id);
+
+    // Campaign carries a pending campaign-linked outcome + the unit max
+    // state the repair processor needs to diff damage.
+    const campaign = makeCampaign({
+      missions: new Map([[contract.id, contract]]),
+      ...({
+        pendingBattleOutcomes: [outcome],
+        processedBattleIds: [],
+        unitMaxStates: { 'unit-A': seedUnitMaxState('unit-A') },
+      } as unknown as Partial<ICampaign>),
+    });
+
+    const pipeline = getDayPipeline();
+    const dayResult = pipeline.processDay(campaign);
+
+    // The battle-effects block drained the outcome.
+    const drained = dayResult.campaign as ICampaign & {
+      processedBattleIds?: readonly string[];
+      repairQueue?: readonly { matchId: string }[];
+      campaignInventory?: ICampaignInventory;
+    };
+    expect(drained.processedBattleIds).toContain('match-loop-1');
+
+    // Repair tickets were generated from the CT 30→5 / 15→6 damage diff.
+    const ticketsForMatch = (drained.repairQueue ?? []).filter(
+      (t) => t.matchId === 'match-loop-1',
+    );
+    expect(ticketsForMatch.length).toBeGreaterThan(0);
+
+    // The inventory projection ran (CLEANUP phase) and reflects the
+    // post-battle state — repair tickets + the wounded pilot.
+    const inventory = drained.campaignInventory;
+    expect(inventory).toBeDefined();
+    expect(inventory?.summary.repairTicketCount).toBeGreaterThan(0);
+    expect(inventory?.repairBay.length).toBe(
+      inventory?.summary.repairTicketCount,
+    );
+    // The wounded pilot from the outcome landed in the medical bay.
+    expect(inventory?.medicalBay.length).toBeGreaterThan(0);
+    expect(inventory?.summary.pilotsInMedical).toBe(
+      inventory?.medicalBay.length,
+    );
+  });
+
+  it('6.3 — the round trip is idempotent: re-running the day produces no duplicate encounters, outcomes, or inventory entries', () => {
+    seedRoster();
+    registerBuiltinProcessors();
+
+    const contract = createContract({
+      id: 'contract-loop-2',
+      name: 'Raid: Sian',
+      employerId: 'lyran-commonwealth',
+      targetId: 'capellan-confederation',
+      status: MissionStatus.ACTIVE,
+    });
+    const outcome = makeOutcome('match-loop-2', contract.id);
+
+    const campaign = makeCampaign({
+      id: 'campaign-loop-2',
+      missions: new Map([[contract.id, contract]]),
+      ...({
+        pendingBattleOutcomes: [outcome],
+        processedBattleIds: [],
+        unitMaxStates: { 'unit-A': seedUnitMaxState('unit-A') },
+        // Seed a pre-bridged scenario so the bridge idempotency path is
+        // exercised on the very first day.
+        bridgedScenarioIds: ['scn-loop-2'],
+        bridgedEncounters: {
+          'scn-loop-2': {
+            id: 'enc-scn-loop-2',
+            name: 'pre-bridged',
+            status: EncounterStatus.Draft,
+            mapConfig: {
+              radius: 6,
+              terrain: 'clear',
+              playerDeploymentZone: 'south',
+              opponentDeploymentZone: 'north',
+            },
+            victoryConditions: [],
+            optionalRules: [],
+            createdAt: '3025-06-15T00:00:00Z',
+            updatedAt: '3025-06-15T00:00:00Z',
+          },
+        },
+      } as unknown as Partial<ICampaign>),
+    });
+
+    const pipeline = getDayPipeline();
+    const firstDay = pipeline.processDay(campaign);
+    const firstState = firstDay.campaign as ICampaign & {
+      repairQueue?: readonly { matchId: string }[];
+      bridgedScenarioIds?: readonly string[];
+      campaignInventory?: ICampaignInventory;
+    };
+    const firstTicketCount = (firstState.repairQueue ?? []).filter(
+      (t) => t.matchId === 'match-loop-2',
+    ).length;
+    const firstInventoryRepairCount =
+      firstState.campaignInventory?.summary.repairTicketCount ?? 0;
+
+    // Advance again — the queue is drained, processed ledger suppresses
+    // re-application, and the bridge skips the known scenario.
+    const secondDay = pipeline.processDay(firstDay.campaign);
+    const secondState = secondDay.campaign as ICampaign & {
+      repairQueue?: readonly { matchId: string }[];
+      bridgedScenarioIds?: readonly string[];
+      campaignInventory?: ICampaignInventory;
+    };
+
+    // No duplicate repair tickets for the same match.
+    const secondTicketCount = (secondState.repairQueue ?? []).filter(
+      (t) => t.matchId === 'match-loop-2',
+    ).length;
+    expect(secondTicketCount).toBe(firstTicketCount);
+
+    // No duplicate bridged scenario ids.
+    expect(secondState.bridgedScenarioIds).toEqual(['scn-loop-2']);
+
+    // Inventory repair count is stable across the no-op day.
+    expect(secondState.campaignInventory?.summary.repairTicketCount).toBe(
+      firstInventoryRepairCount,
+    );
+  });
+
+  it('5.3 — the inventory projection runs strictly after the battle-effects block', () => {
+    registerBuiltinProcessors();
+    const processors = getDayPipeline().getProcessors();
+    const order = processors.map((p) => p.id);
+
+    const postBattleIdx = order.indexOf('post-battle');
+    const salvageIdx = order.indexOf('salvage');
+    const repairIdx = order.indexOf('repair-queue-builder');
+    const inventoryIdx = order.indexOf('inventory-projection');
+
+    expect(postBattleIdx).toBeGreaterThanOrEqual(0);
+    expect(inventoryIdx).toBeGreaterThan(postBattleIdx);
+    expect(inventoryIdx).toBeGreaterThan(salvageIdx);
+    expect(inventoryIdx).toBeGreaterThan(repairIdx);
+  });
+
+  it('2.3 — the bridge runs after scenario generation in the pipeline order', () => {
+    registerBuiltinProcessors();
+    const order = getDayPipeline()
+      .getProcessors()
+      .map((p) => p.id);
+    const scenarioGenIdx = order.indexOf('scenario-generation');
+    const bridgeIdx = order.indexOf('scenario-encounter-bridge');
+    expect(scenarioGenIdx).toBeGreaterThanOrEqual(0);
+    expect(bridgeIdx).toBeGreaterThan(scenarioGenIdx);
+  });
+});

--- a/src/__tests__/integration/phase3RoundTrip.test.ts
+++ b/src/__tests__/integration/phase3RoundTrip.test.ts
@@ -345,10 +345,12 @@ describe('Phase 3 capstone — encounter → outcome → campaign round trip', (
   });
 
   it('outcomes for matches with no contractId still flow through the queue and post-battle processor', () => {
-    // Standalone (non-campaign) matches — the spec scenario "Standalone
-    // encounter has encounter id only". The outcome lacks a contract
-    // binding so contract status flipping is skipped, but the rest of
-    // the pipeline still runs.
+    // Standalone (non-campaign) matches. Per `add-campaign-combat-loop`
+    // D7, the *automatic* enqueue trigger ignores a session with no
+    // campaign linkage — a standalone skirmish published on the bus is
+    // NOT auto-enqueued. The outcome can still be enqueued explicitly
+    // (e.g. by a UI action), and once queued the post-battle processor
+    // handles it normally even without a contract binding.
     const store = useCampaignStore();
     store.getState().createCampaign('Standalone Test', 'mercenary');
     store.getState().updateCampaign({});
@@ -361,7 +363,13 @@ describe('Phase 3 capstone — encounter → outcome → campaign round trip', (
     // Strip the contractId per the spec scenario.
     const standalone: ICombatOutcome = { ...outcome, contractId: null };
 
+    // Publishing on the bus does NOT enqueue an unlinked outcome (D7).
     publishCombatOutcome({ matchId: standalone.matchId, outcome: standalone });
+    expect(store.getState().getPendingOutcomeCount()).toBe(0);
+
+    // Explicit enqueue still works — the post-battle processor must
+    // handle a no-contractId outcome once it is on the queue.
+    store.getState().enqueueOutcome(standalone);
     expect(store.getState().getPendingOutcomeCount()).toBe(1);
 
     store.getState().advanceDay();

--- a/src/__tests__/integration/phase4CampaignRoundTrip.test.ts
+++ b/src/__tests__/integration/phase4CampaignRoundTrip.test.ts
@@ -544,12 +544,17 @@ describe('Phase 4 capstone — full campaign round-trip with audit ledger + fulf
       ],
     });
 
-    // Match 2 — pilot B unscathed (no contract id; standalone). The
-    // builder only counts wounds on the outcome's own delta, so pilot
-    // B contributes zero to the wounded count.
+    // Match 2 — pilot B unscathed, no contract binding. The builder
+    // only counts wounds on the outcome's own delta, so pilot B
+    // contributes zero to the wounded count. Per `add-campaign-combat-loop`
+    // D7 a session with no campaign linkage at all is NOT auto-enqueued
+    // by the bus trigger — so this match carries a `scenarioId` (the
+    // session WAS campaign-linked, it just has no contract) which keeps
+    // it on the auto-enqueue path while leaving `contractId` null.
     const outcome2 = makeOutcome({
       matchId: 'match-multi-2',
       contractId: '',
+      scenarioId: 'scenario-multi-2',
       winner: GameSide.Player,
       unitDeltas: [makeDelta('unit-B')],
     });

--- a/src/lib/campaign/dayPipeline.ts
+++ b/src/lib/campaign/dayPipeline.ts
@@ -122,7 +122,16 @@ export interface IDayProcessor {
   readonly phase: DayPhase;
   /** Human-readable name for UI display */
   readonly displayName: string;
-  /** Process one day for the campaign. Must be pure (no side effects). */
+  /**
+   * Process one day for the campaign. Must be pure (no side effects).
+   *
+   * A consumer processor that needs the events produced earlier in the
+   * same day (e.g. the scenario-encounter bridge) reads them from
+   * `getDayEventsSoFar(campaign)` — the pipeline stamps the in-order
+   * event accumulator onto a transient campaign field before each
+   * processor runs. Processors that ignore upstream events keep the
+   * plain two-arg signature.
+   */
   process(campaign: ICampaign, date: Date): IDayProcessorResult;
 }
 
@@ -237,7 +246,18 @@ export class DayPipelineRegistry {
 
     for (const processor of sortedProcessors) {
       try {
-        const result = processor.process(currentCampaign, processedDate);
+        // Stamp the events accumulated so far onto a transient campaign
+        // field so consumer processors (e.g. the scenario-encounter
+        // bridge) can read upstream events via `getDayEventsSoFar`.
+        // A snapshot copy is used so a processor cannot mutate the
+        // pipeline's own accumulator.
+        const campaignWithEvents: ICampaign & {
+          readonly _dayEventsSoFar?: readonly IDayEvent[];
+        } = {
+          ...currentCampaign,
+          _dayEventsSoFar: [...allEvents],
+        };
+        const result = processor.process(campaignWithEvents, processedDate);
         currentCampaign = result.campaign;
         allEvents.push(...result.events);
         processorsRun.push(processor.id);
@@ -251,10 +271,19 @@ export class DayPipelineRegistry {
       }
     }
 
-    // Advance the date by one day AFTER all processors
+    // Advance the date by one day AFTER all processors. Strip the
+    // transient `_dayEventsSoFar` field so it never leaks into the
+    // persisted campaign snapshot.
     const nextDate = new Date(processedDate.getTime() + 24 * 60 * 60 * 1000);
+    const {
+      _dayEventsSoFar: _discardedDayEvents,
+      ...campaignWithoutTransient
+    } = currentCampaign as ICampaign & {
+      readonly _dayEventsSoFar?: readonly IDayEvent[];
+    };
+    void _discardedDayEvents;
     const finalCampaign: ICampaign = {
-      ...currentCampaign,
+      ...campaignWithoutTransient,
       currentDate: nextDate,
       updatedAt: new Date().toISOString(),
     };
@@ -286,6 +315,31 @@ export function getDayPipeline(): DayPipelineRegistry {
  */
 export function _resetDayPipeline(): void {
   pipelineRegistry.reset();
+}
+
+// =============================================================================
+// Day-Event Accumulator Access
+// =============================================================================
+
+/**
+ * Read the events produced earlier in the same day's pipeline run.
+ *
+ * The pipeline stamps an in-order snapshot of the day's accumulated
+ * events onto a transient `_dayEventsSoFar` campaign field before each
+ * processor runs. Consumer processors (e.g. the scenario-encounter
+ * bridge) call this to react to upstream events without coupling to
+ * the processors that emitted them.
+ *
+ * Returns an empty array when the field is absent — e.g. when a
+ * processor is invoked directly in a test rather than via `processDay`.
+ *
+ * @param campaign - the campaign passed to a processor's `process`
+ */
+export function getDayEventsSoFar(campaign: ICampaign): readonly IDayEvent[] {
+  const transient = campaign as ICampaign & {
+    readonly _dayEventsSoFar?: readonly IDayEvent[];
+  };
+  return transient._dayEventsSoFar ?? [];
 }
 
 // =============================================================================

--- a/src/lib/campaign/encounter/__tests__/launchCampaignEncounter.test.ts
+++ b/src/lib/campaign/encounter/__tests__/launchCampaignEncounter.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the campaign-linked encounter launch path.
+ *
+ * Per `add-campaign-combat-loop` task 3.3: launching a generated
+ * encounter produces a campaign-linked session; the linkage fields
+ * round-trip to the session.
+ *
+ * @spec openspec/changes/add-campaign-combat-loop/specs/campaign-combat-loop/spec.md
+ */
+
+import { describe, expect, it } from '@jest/globals';
+
+import type { ICampaignEncounterLauncherService } from '@/lib/campaign/encounter/launchCampaignEncounter';
+import type { IEncounter } from '@/types/encounter';
+
+import { launchCampaignEncounter } from '@/lib/campaign/encounter/launchCampaignEncounter';
+import {
+  EncounterStatus,
+  PilotSkillTemplate,
+  TerrainPreset,
+  VictoryConditionType,
+} from '@/types/encounter';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeCampaignEncounter(overrides?: Partial<IEncounter>): IEncounter {
+  return {
+    id: 'enc-scn-1',
+    name: 'Garrison: Hesperus II: Standup',
+    description: 'Campaign scenario.',
+    status: EncounterStatus.Ready,
+    playerForce: {
+      forceId: 'force-alpha',
+      forceName: 'Alpha Lance',
+      totalBV: 0,
+      unitCount: 4,
+    },
+    opForConfig: {
+      targetBV: 4500,
+      pilotSkillTemplate: PilotSkillTemplate.Regular,
+    },
+    mapConfig: {
+      radius: 8,
+      terrain: TerrainPreset.Clear,
+      playerDeploymentZone: 'south',
+      opponentDeploymentZone: 'north',
+    },
+    victoryConditions: [{ type: VictoryConditionType.DestroyAll }],
+    optionalRules: [],
+    createdAt: '3025-06-15T00:00:00.000Z',
+    updatedAt: '3025-06-15T00:00:00.000Z',
+    campaignMeta: {
+      campaignId: 'campaign-1',
+      contractId: 'contract-1',
+      scenarioId: 'scn-1',
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * A fake encounter service that records every call so the test can
+ * assert linkage threading without standing up the SQLite repository.
+ */
+function makeFakeService(): {
+  service: ICampaignEncounterLauncherService;
+  calls: {
+    created: { name: string }[];
+    launched: {
+      id: string;
+      options?: {
+        campaignId?: string | null;
+        contractId?: string | null;
+        scenarioId?: string | null;
+      };
+    }[];
+    playerForceSet: { id: string; forceId: string }[];
+  };
+} {
+  const calls = {
+    created: [] as { name: string }[],
+    launched: [] as {
+      id: string;
+      options?: {
+        campaignId?: string | null;
+        contractId?: string | null;
+        scenarioId?: string | null;
+      };
+    }[],
+    playerForceSet: [] as { id: string; forceId: string }[],
+  };
+  const repoId = 'encounter-repo-1';
+  let gameSessionId: string | undefined;
+
+  const service: ICampaignEncounterLauncherService = {
+    createEncounter(input) {
+      calls.created.push({ name: input.name });
+      return { success: true, id: repoId };
+    },
+    updateEncounter() {
+      return { success: true, id: repoId };
+    },
+    setPlayerForce(id, forceId) {
+      calls.playerForceSet.push({ id, forceId });
+      return { success: true, id };
+    },
+    launchEncounter(id, options) {
+      calls.launched.push({ id, options });
+      gameSessionId = 'game-session-xyz';
+      return { success: true, id };
+    },
+    getEncounter(id) {
+      return {
+        ...makeCampaignEncounter(),
+        id,
+        status: EncounterStatus.Launched,
+        gameSessionId,
+      };
+    },
+  };
+  return { service, calls };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('launchCampaignEncounter', () => {
+  it('launching a generated encounter produces a campaign-linked session', () => {
+    const { service, calls } = makeFakeService();
+    const result = launchCampaignEncounter(makeCampaignEncounter(), service);
+
+    expect(result.success).toBe(true);
+    expect(result.gameSessionId).toBe('game-session-xyz');
+    expect(result.encounterId).toBe('encounter-repo-1');
+    expect(calls.created).toHaveLength(1);
+    expect(calls.launched).toHaveLength(1);
+  });
+
+  it('the campaign linkage fields round-trip to the launch call', () => {
+    const { service, calls } = makeFakeService();
+    launchCampaignEncounter(makeCampaignEncounter(), service);
+
+    expect(calls.launched[0].options).toEqual({
+      campaignId: 'campaign-1',
+      contractId: 'contract-1',
+      scenarioId: 'scn-1',
+    });
+  });
+
+  it('attaches the player force when the bridge resolved one', () => {
+    const { service, calls } = makeFakeService();
+    launchCampaignEncounter(makeCampaignEncounter(), service);
+    expect(calls.playerForceSet).toEqual([
+      { id: 'encounter-repo-1', forceId: 'force-alpha' },
+    ]);
+  });
+
+  it('skips force assignment when the encounter has no player force', () => {
+    const { service, calls } = makeFakeService();
+    launchCampaignEncounter(
+      makeCampaignEncounter({ playerForce: undefined }),
+      service,
+    );
+    expect(calls.playerForceSet).toHaveLength(0);
+    expect(calls.launched).toHaveLength(1);
+  });
+
+  it('fails when the encounter has no campaign linkage', () => {
+    const { service } = makeFakeService();
+    const result = launchCampaignEncounter(
+      makeCampaignEncounter({ campaignMeta: undefined }),
+      service,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/campaignMeta/);
+  });
+
+  it('surfaces a launch failure from the service', () => {
+    const { service } = makeFakeService();
+    const failing: ICampaignEncounterLauncherService = {
+      ...service,
+      launchEncounter() {
+        return { success: false, error: 'force not found' };
+      },
+    };
+    const result = launchCampaignEncounter(makeCampaignEncounter(), failing);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('force not found');
+  });
+});

--- a/src/lib/campaign/encounter/buildEncounterFromScenario.ts
+++ b/src/lib/campaign/encounter/buildEncounterFromScenario.ts
@@ -1,0 +1,239 @@
+/**
+ * Scenario-event → encounter builder
+ *
+ * Per `add-campaign-combat-loop` D2: maps a `scenario_generated` day
+ * event payload onto a launchable `IEncounter`. The OpFor force is
+ * BV-matched to `opForBV` (D2 / open question — BV-matched force, richer
+ * composition deferred), the victory conditions are derived from
+ * `scenarioType`, and the map config is derived from the scenario
+ * conditions. The resulting encounter carries `campaignMeta` so every
+ * downstream step threads linkage back to the contract.
+ *
+ * Pure and sync — no IO, no random. The scenario id is deterministic
+ * (`scenarioGenerationProcessor` builds it from contract/team/date), so
+ * a re-run of the same day produces an identical encounter.
+ *
+ * @spec openspec/changes/add-campaign-combat-loop/specs/campaign-combat-loop/spec.md
+ * @module lib/campaign/encounter/buildEncounterFromScenario
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { IScenarioConditions } from '@/types/campaign/scenario/scenarioTypes';
+import type {
+  IEncounter,
+  IMapConfiguration,
+  IOpForConfig,
+  IVictoryCondition,
+} from '@/types/encounter';
+
+import {
+  EncounterStatus,
+  PilotSkillTemplate,
+  TerrainPreset,
+  VictoryConditionType,
+} from '@/types/encounter';
+
+// =============================================================================
+// Scenario Event Payload
+// =============================================================================
+
+/**
+ * The shape of the `scenario_generated` day-event `data` payload, as
+ * emitted by `scenarioGenerationProcessor.createScenarioEventData`. We
+ * declare only the fields the bridge consumes so the builder is
+ * self-contained and does not import the processor.
+ */
+export interface IScenarioGeneratedPayload {
+  /** Selected AtB scenario type (e.g. 'standup', 'base_attack'). */
+  readonly scenarioType: string;
+  /** Whether the player force is the attacker. */
+  readonly isAttacker: boolean;
+  /** Opposing-force Battle Value target. */
+  readonly opForBV: number;
+  /** Environmental conditions for the scenario. */
+  readonly conditions: IScenarioConditions;
+  /** Combat team (force) id assigned to the scenario. */
+  readonly teamId: string;
+  /** Contract this scenario was generated for. */
+  readonly contractId: string;
+  /** Contract display name. */
+  readonly contractName: string;
+  /** Deterministic scenario id (linkage key). */
+  readonly scenarioId: string;
+}
+
+// =============================================================================
+// Scenario-Type → Victory Conditions
+// =============================================================================
+
+/**
+ * Derive victory conditions from the AtB scenario type.
+ *
+ * Mirrors the intent of each AtB scenario: standup / breakthrough are
+ * destruction fights, hold-the-line / base-attack are turn-limited
+ * objective holds, chase / extraction are cripple-and-disengage. The
+ * mapping is deterministic so re-running a day yields identical
+ * conditions.
+ */
+export function deriveVictoryConditions(
+  scenarioType: string,
+): readonly IVictoryCondition[] {
+  switch (scenarioType) {
+    case 'standup':
+    case 'breakthrough':
+      return [{ type: VictoryConditionType.DestroyAll }];
+    case 'hold_the_line':
+    case 'base_attack':
+      return [
+        { type: VictoryConditionType.Cripple, threshold: 50 },
+        { type: VictoryConditionType.TurnLimit, turnLimit: 15 },
+      ];
+    case 'chase':
+    case 'extraction':
+    case 'hide_and_seek':
+      return [
+        { type: VictoryConditionType.Cripple, threshold: 50 },
+        { type: VictoryConditionType.TurnLimit, turnLimit: 12 },
+      ];
+    case 'probe':
+    case 'recon_raid':
+      return [
+        { type: VictoryConditionType.Cripple, threshold: 40 },
+        { type: VictoryConditionType.TurnLimit, turnLimit: 10 },
+      ];
+    default:
+      return [{ type: VictoryConditionType.DestroyAll }];
+  }
+}
+
+// =============================================================================
+// Scenario Conditions → Map Config
+// =============================================================================
+
+/**
+ * Derive the map terrain from scenario weather/atmosphere conditions.
+ *
+ * Sandstorm / dense atmosphere lean to rough terrain; fog / snow lean
+ * to wooded cover; everything else stays clear. MVP-grade — richer
+ * terrain authoring is out of scope for this change.
+ */
+function deriveTerrain(conditions: IScenarioConditions): TerrainPreset {
+  if (conditions.weather === 'sandstorm') return TerrainPreset.Rough;
+  if (conditions.weather === 'fog' || conditions.weather === 'snow') {
+    return TerrainPreset.LightWoods;
+  }
+  if (conditions.atmosphere === 'dense') return TerrainPreset.Rough;
+  return TerrainPreset.Clear;
+}
+
+/**
+ * Derive the encounter map configuration from scenario conditions.
+ *
+ * The radius scales with the OpFor BV (bigger forces need more board);
+ * the player always deploys south, opponent north. Deterministic.
+ */
+export function deriveMapConfiguration(
+  conditions: IScenarioConditions,
+  opForBV: number,
+): IMapConfiguration {
+  // Bigger forces get a larger board: ≤3000 BV → 6, ≤8000 → 8, else 12.
+  const radius = opForBV <= 3000 ? 6 : opForBV <= 8000 ? 8 : 12;
+  return {
+    radius,
+    terrain: deriveTerrain(conditions),
+    playerDeploymentZone: 'south',
+    opponentDeploymentZone: 'north',
+  };
+}
+
+// =============================================================================
+// OpFor BV → OpFor Config
+// =============================================================================
+
+/**
+ * Build the OpFor generation config. The force is BV-matched to the
+ * scenario's `opForBV` (design.md D2 / open question — BV-matched force
+ * for this change; richer composition deferred). Pilot skill defaults
+ * to Regular.
+ */
+export function deriveOpForConfig(opForBV: number): IOpForConfig {
+  return {
+    targetBV: Math.max(0, Math.round(opForBV)),
+    pilotSkillTemplate: PilotSkillTemplate.Regular,
+  };
+}
+
+// =============================================================================
+// Encounter Builder
+// =============================================================================
+
+/**
+ * Build a launchable `IEncounter` from a `scenario_generated` event
+ * payload and the owning campaign.
+ *
+ * The encounter:
+ *   - is `Ready`-status when a player force is resolvable from the
+ *     contract's assigned combat team, else `Draft`;
+ *   - carries `campaignMeta = { campaignId, contractId, scenarioId }`;
+ *   - has a deterministic id `enc-<scenarioId>` so the bridge can
+ *     idempotently key on it.
+ *
+ * @param payload - the `scenario_generated` event `data` payload
+ * @param campaign - the campaign that owns the scenario
+ * @param createdAt - ISO timestamp (caller-supplied for determinism)
+ */
+export function buildEncounterFromScenario(
+  payload: IScenarioGeneratedPayload,
+  campaign: ICampaign,
+  createdAt: string,
+): IEncounter {
+  const opForConfig = deriveOpForConfig(payload.opForBV);
+  const victoryConditions = deriveVictoryConditions(payload.scenarioType);
+  const mapConfig = deriveMapConfiguration(payload.conditions, payload.opForBV);
+
+  // Resolve the player force from the contract's assigned combat team.
+  // The team id IS a force id (see `ICombatTeam.forceId`). When the
+  // force is present in the campaign, the encounter is launch-ready;
+  // otherwise it persists as a Draft the player completes manually.
+  const playerForce = campaign.forces.get(payload.teamId) ?? null;
+  const playerForceRef = playerForce
+    ? {
+        forceId: playerForce.id,
+        forceName: playerForce.name,
+        // BV / unit count are hydrated by EncounterService at launch
+        // time; the bridge records the reference shell.
+        totalBV: 0,
+        unitCount: playerForce.unitIds.length,
+      }
+    : undefined;
+
+  return {
+    id: `enc-${payload.scenarioId}`,
+    name: `${payload.contractName}: ${formatScenarioType(payload.scenarioType)}`,
+    description: `Campaign scenario generated for contract ${payload.contractName}.`,
+    status: playerForceRef ? EncounterStatus.Ready : EncounterStatus.Draft,
+    playerForce: playerForceRef,
+    opForConfig,
+    mapConfig,
+    victoryConditions,
+    optionalRules: [],
+    createdAt,
+    updatedAt: createdAt,
+    campaignMeta: {
+      campaignId: campaign.id,
+      contractId: payload.contractId,
+      scenarioId: payload.scenarioId,
+    },
+  };
+}
+
+/**
+ * Turn an AtB scenario-type slug into a human-readable label
+ * (`base_attack` → `Base Attack`).
+ */
+function formatScenarioType(scenarioType: string): string {
+  return scenarioType
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}

--- a/src/lib/campaign/encounter/launchCampaignEncounter.ts
+++ b/src/lib/campaign/encounter/launchCampaignEncounter.ts
@@ -1,0 +1,183 @@
+/**
+ * Campaign-linked encounter launch path
+ *
+ * Per `add-campaign-combat-loop` D6: when the player opens a
+ * campaign-generated encounter, the launch materialises the bridged
+ * `IEncounter` into the `encounter-system` SQLite repository, then
+ * launches it through the existing `EncounterService.launchEncounter`
+ * with campaign linkage (`campaignId`, `contractId`, `scenarioId`)
+ * stamped onto the resulting `GameSession`.
+ *
+ * No new session-creation path: the campaign supplies the linkage
+ * fields and reuses the encounter launch snapshot. The linkage fields
+ * round-trip onto `IGameSession.config` (see `encounterToGameSession`)
+ * so `InteractiveSession.getOutcome()` stamps the `ICombatOutcome` with
+ * the contract/scenario ids the post-battle processors need.
+ *
+ * @spec openspec/changes/add-campaign-combat-loop/specs/campaign-combat-loop/spec.md
+ * @module lib/campaign/encounter/launchCampaignEncounter
+ */
+
+import type { IEncounterOperationResult } from '@/services/encounter/EncounterRepository';
+import type { IEncounter } from '@/types/encounter';
+
+import { getEncounterService } from '@/services/encounter/EncounterService';
+
+// =============================================================================
+// Result
+// =============================================================================
+
+/**
+ * Outcome of a campaign-linked encounter launch.
+ */
+export interface ILaunchCampaignEncounterResult {
+  /** True when a campaign-linked `GameSession` was created. */
+  readonly success: boolean;
+  /** The created session id, when `success` is true. */
+  readonly gameSessionId?: string;
+  /** The encounter id materialised in the encounter repository. */
+  readonly encounterId?: string;
+  /** Human-readable failure reason, when `success` is false. */
+  readonly error?: string;
+}
+
+// =============================================================================
+// Service Surface (injectable for tests)
+// =============================================================================
+
+/**
+ * The slice of `EncounterService` the launch path depends on. Declared
+ * as an interface so tests can inject a fake without standing up the
+ * SQLite repository singleton.
+ */
+export interface ICampaignEncounterLauncherService {
+  createEncounter(input: {
+    readonly name: string;
+    readonly description?: string;
+  }): IEncounterOperationResult;
+  updateEncounter(
+    id: string,
+    input: {
+      readonly mapConfig?: IEncounter['mapConfig'];
+      readonly victoryConditions?: IEncounter['victoryConditions'];
+      readonly opForConfig?: IEncounter['opForConfig'];
+      readonly optionalRules?: readonly string[];
+    },
+  ): IEncounterOperationResult;
+  setPlayerForce(
+    encounterId: string,
+    forceId: string,
+  ): IEncounterOperationResult;
+  launchEncounter(
+    id: string,
+    options?: {
+      readonly campaignId?: string | null;
+      readonly contractId?: string | null;
+      readonly scenarioId?: string | null;
+    },
+  ): IEncounterOperationResult;
+  getEncounter(id: string): IEncounter | null;
+}
+
+// =============================================================================
+// Launch Path
+// =============================================================================
+
+/**
+ * Launch a campaign-generated encounter into a campaign-linked
+ * `GameSession`.
+ *
+ * The bridged encounter lives on the campaign snapshot
+ * (`campaign.bridgedEncounters`). To play it, this function:
+ *   1. materialises the encounter into the `encounter-system`
+ *      repository (the canonical launch surface), copying map config,
+ *      victory conditions, OpFor config, and the player force;
+ *   2. launches it through `EncounterService.launchEncounter` with the
+ *      encounter's `campaignMeta` threaded in as launch linkage.
+ *
+ * The resulting `GameSession` carries `campaignId`, `contractId`, and
+ * `scenarioId` on its config — the existing `Session Carries Campaign
+ * Linkage` contract of `game-session-management`.
+ *
+ * @param encounter - the bridged campaign-generated encounter
+ * @param service - encounter service (defaults to the singleton)
+ */
+export function launchCampaignEncounter(
+  encounter: IEncounter,
+  service: ICampaignEncounterLauncherService = getEncounterService(),
+): ILaunchCampaignEncounterResult {
+  const meta = encounter.campaignMeta;
+  if (!meta) {
+    return {
+      success: false,
+      error: 'Encounter has no campaign linkage (campaignMeta missing)',
+    };
+  }
+
+  // 1. Materialise the encounter into the encounter repository.
+  const created = service.createEncounter({
+    name: encounter.name,
+    description: encounter.description,
+  });
+  if (!created.success || !created.id) {
+    return {
+      success: false,
+      error: created.error ?? 'Failed to create encounter',
+    };
+  }
+  const repoEncounterId = created.id;
+
+  // 2. Copy the generated configuration onto the repository encounter.
+  const configResult = service.updateEncounter(repoEncounterId, {
+    mapConfig: encounter.mapConfig,
+    victoryConditions: encounter.victoryConditions,
+    opForConfig: encounter.opForConfig,
+    optionalRules: encounter.optionalRules,
+  });
+  if (!configResult.success) {
+    return {
+      success: false,
+      encounterId: repoEncounterId,
+      error: configResult.error ?? 'Failed to configure encounter',
+    };
+  }
+
+  // 3. Attach the player force when the bridge resolved one.
+  if (encounter.playerForce?.forceId) {
+    const forceResult = service.setPlayerForce(
+      repoEncounterId,
+      encounter.playerForce.forceId,
+    );
+    if (!forceResult.success) {
+      return {
+        success: false,
+        encounterId: repoEncounterId,
+        error: forceResult.error ?? 'Failed to set player force',
+      };
+    }
+  }
+
+  // 4. Launch with campaign linkage (D6 — reuses the existing launch
+  //    snapshot; the campaign only supplies the linkage fields).
+  const launched = service.launchEncounter(repoEncounterId, {
+    campaignId: meta.campaignId,
+    contractId: meta.contractId,
+    scenarioId: meta.scenarioId,
+  });
+  if (!launched.success) {
+    return {
+      success: false,
+      encounterId: repoEncounterId,
+      error: launched.error ?? 'Failed to launch encounter',
+    };
+  }
+
+  // The repository stamps `game_session_id` on the encounter row at
+  // launch; read it back so the caller gets the session handle.
+  const launchedEncounter = service.getEncounter(repoEncounterId);
+  return {
+    success: true,
+    encounterId: repoEncounterId,
+    gameSessionId: launchedEncounter?.gameSessionId,
+  };
+}

--- a/src/lib/campaign/encounter/scenarioEventPayload.ts
+++ b/src/lib/campaign/encounter/scenarioEventPayload.ts
@@ -1,0 +1,33 @@
+/**
+ * Scenario-event payload guard
+ *
+ * Runtime type guard for the `scenario_generated` day-event `data`
+ * payload, kept in a leaf module so both the bridge processor and the
+ * builder can import it without a cycle.
+ *
+ * @module lib/campaign/encounter/scenarioEventPayload
+ */
+
+import type { IScenarioGeneratedPayload } from './buildEncounterFromScenario';
+
+/**
+ * Narrow an arbitrary day-event `data` record to the
+ * `scenario_generated` payload shape. Guards the bridge against
+ * malformed or partial events without throwing.
+ */
+export function isScenarioGeneratedPayload(
+  data: unknown,
+): data is IScenarioGeneratedPayload {
+  if (typeof data !== 'object' || data === null) return false;
+  const payload = data as Partial<IScenarioGeneratedPayload>;
+  return (
+    typeof payload.scenarioType === 'string' &&
+    typeof payload.opForBV === 'number' &&
+    typeof payload.teamId === 'string' &&
+    typeof payload.contractId === 'string' &&
+    typeof payload.contractName === 'string' &&
+    typeof payload.scenarioId === 'string' &&
+    typeof payload.conditions === 'object' &&
+    payload.conditions !== null
+  );
+}

--- a/src/lib/campaign/inventory/__tests__/projectCampaignInventory.test.ts
+++ b/src/lib/campaign/inventory/__tests__/projectCampaignInventory.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Tests for the campaign inventory projection.
+ *
+ * Per `add-campaign-combat-loop` task 5.3: projection from a populated
+ * post-battle campaign yields the expected `ICampaignInventory`; an
+ * empty campaign yields an empty inventory with zeroed summary.
+ *
+ * @spec openspec/changes/add-campaign-combat-loop/specs/campaign-combat-loop/spec.md
+ */
+
+import { describe, expect, it } from '@jest/globals';
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
+import type { IRepairTicket } from '@/types/campaign/RepairTicket';
+import type { ISalvageAllocation } from '@/types/campaign/Salvage';
+
+import {
+  projectCampaignInventory,
+  type ICampaignForInventory,
+} from '@/lib/campaign/inventory/projectCampaignInventory';
+import { CampaignPilotStatus } from '@/types/campaign/CampaignPilotStatus';
+import { CampaignType } from '@/types/campaign/CampaignType';
+import { createDefaultCampaignOptions } from '@/types/campaign/createDefaultCampaignOptions';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
+import { Money } from '@/types/campaign/Money';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const GENERATED_AT = '3025-06-15T00:00:00.000Z';
+
+function makeCampaign(
+  overrides?: Partial<ICampaignForInventory>,
+): ICampaignForInventory {
+  const base: ICampaign = {
+    id: 'campaign-inv-1',
+    name: 'Inventory Test Co.',
+    currentDate: new Date('3025-06-15T00:00:00Z'),
+    factionId: 'mercenary',
+    forces: new Map(),
+    rootForceId: 'root',
+    missions: new Map(),
+    finances: { transactions: [], balance: Money.ZERO },
+    factionStandings: {},
+    options: createDefaultCampaignOptions(),
+    campaignType: CampaignType.MERCENARY,
+    shoppingList: { items: [] },
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    unitCombatStates: {},
+  };
+  return { ...base, ...overrides };
+}
+
+function makeRepairTicket(overrides?: Partial<IRepairTicket>): IRepairTicket {
+  return {
+    ticketId: 'ticket-1',
+    unitId: 'unit-A',
+    kind: 'armor',
+    location: 'CT',
+    pointsToRestore: 10,
+    expectedHours: 1,
+    partsRequired: [
+      { partId: 'standard-armor-pt', quantity: 10, matched: true },
+    ],
+    source: 'combat',
+    matchId: 'match-1',
+    createdAt: GENERATED_AT,
+    status: 'queued',
+    ...overrides,
+  };
+}
+
+function makeRosterEntry(
+  overrides?: Partial<ICampaignRosterEntry>,
+): ICampaignRosterEntry {
+  return {
+    pilotId: 'pilot-1',
+    pilotName: 'Strix',
+    status: CampaignPilotStatus.Active,
+    wounds: 0,
+    recoveryTime: 0,
+    xp: 0,
+    campaignXpEarned: 0,
+    campaignKills: 0,
+    campaignMissions: 0,
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rankIndex: 0,
+    hireDate: new Date('3024-01-01'),
+    ...overrides,
+  };
+}
+
+function makeAllocation(): ISalvageAllocation {
+  return {
+    pool: {
+      battleId: 'match-1',
+      contractId: 'contract-1',
+      candidates: [],
+      totalEstimatedValue: 0,
+      hostileTerritory: false,
+    },
+    employerAward: {
+      side: 'employer',
+      candidates: [],
+      totalValue: 0,
+      estimatedRepairCost: 0,
+    },
+    mercenaryAward: {
+      side: 'mercenary',
+      candidates: [
+        {
+          source: 'unit',
+          unitId: 'enemy-1',
+          designation: 'Atlas AS7-D',
+          destroyedFromBattle: 'match-1',
+          finalStatus: 'crippled',
+          damageLevel: 'heavy' as never,
+          originalValue: 400_000,
+          recoveredValue: 100_000,
+          recoveryPercentage: 0.25,
+          repairCostEstimate: 300_000,
+          disposition: 'mercenary',
+          status: 'pending',
+        },
+      ],
+      totalValue: 100_000,
+      estimatedRepairCost: 300_000,
+    },
+    splitMethod: 'contract',
+    processed: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('projectCampaignInventory', () => {
+  it('an empty campaign yields an empty inventory with zeroed summary', () => {
+    const inventory = projectCampaignInventory(
+      makeCampaign(),
+      [],
+      GENERATED_AT,
+    );
+    expect(inventory.campaignId).toBe('campaign-inv-1');
+    expect(inventory.generatedAt).toBe(GENERATED_AT);
+    expect(inventory.repairBay).toEqual([]);
+    expect(inventory.salvageBay).toEqual([]);
+    expect(inventory.medicalBay).toEqual([]);
+    expect(inventory.summary).toEqual({
+      repairTicketCount: 0,
+      totalRepairHours: 0,
+      salvageValueTotal: 0,
+      pilotsInMedical: 0,
+    });
+  });
+
+  it('projects every repair ticket as an IRepairBayItem', () => {
+    const campaign = makeCampaign({
+      repairQueue: [
+        makeRepairTicket({ ticketId: 't-1', expectedHours: 2 }),
+        makeRepairTicket({
+          ticketId: 't-2',
+          kind: 'component',
+          location: 'RA',
+          expectedHours: 4,
+          status: 'parts-needed',
+          partsRequired: [{ partId: 'AC/20', quantity: 1, matched: false }],
+        }),
+      ],
+    });
+    const inventory = projectCampaignInventory(campaign, [], GENERATED_AT);
+
+    expect(inventory.repairBay).toHaveLength(2);
+    const t1 = inventory.repairBay.find((i) => i.ticketId === 't-1');
+    expect(t1?.partsReady).toBe(true);
+    expect(t1?.status).toBe('queued');
+    const t2 = inventory.repairBay.find((i) => i.ticketId === 't-2');
+    expect(t2?.partsReady).toBe(false);
+    expect(t2?.status).toBe('parts-needed');
+    expect(t2?.location).toBe('RA');
+
+    expect(inventory.summary.repairTicketCount).toBe(2);
+    expect(inventory.summary.totalRepairHours).toBe(6);
+  });
+
+  it('cancelled repair tickets are dropped from the bay', () => {
+    const campaign = makeCampaign({
+      repairQueue: [
+        makeRepairTicket({ ticketId: 't-live' }),
+        makeRepairTicket({ ticketId: 't-cancelled', status: 'cancelled' }),
+      ],
+    });
+    const inventory = projectCampaignInventory(campaign, [], GENERATED_AT);
+    expect(inventory.repairBay.map((i) => i.ticketId)).toEqual(['t-live']);
+  });
+
+  it('completed tickets map to status "done"', () => {
+    const campaign = makeCampaign({
+      repairQueue: [makeRepairTicket({ status: 'completed' })],
+    });
+    const inventory = projectCampaignInventory(campaign, [], GENERATED_AT);
+    expect(inventory.repairBay[0].status).toBe('done');
+  });
+
+  it('projects mercenary salvage candidates as ISalvageBayItems and totals their value', () => {
+    const campaign = makeCampaign({
+      salvageAllocations: { 'match-1': makeAllocation() },
+    });
+    const inventory = projectCampaignInventory(campaign, [], GENERATED_AT);
+
+    expect(inventory.salvageBay).toHaveLength(1);
+    const item = inventory.salvageBay[0];
+    expect(item.partId).toBe('enemy-1');
+    expect(item.sourceUnitId).toBe('enemy-1');
+    expect(item.designation).toBe('Atlas AS7-D');
+    expect(item.recoveredValue).toBe(100_000);
+    expect(item.disposition).toBe('mercenary');
+    expect(item.status).toBe('pending');
+
+    expect(inventory.summary.salvageValueTotal).toBe(100_000);
+  });
+
+  it('projects every injured pilot as an IMedicalBayItem; active pilots are excluded', () => {
+    const inventory = projectCampaignInventory(
+      makeCampaign(),
+      [
+        makeRosterEntry({
+          pilotId: 'p-active',
+          status: CampaignPilotStatus.Active,
+        }),
+        makeRosterEntry({
+          pilotId: 'p-wounded',
+          pilotName: 'Volkov',
+          status: CampaignPilotStatus.Wounded,
+          wounds: 1,
+          recoveryTime: 4,
+        }),
+        makeRosterEntry({
+          pilotId: 'p-critical',
+          pilotName: 'Kerr',
+          status: CampaignPilotStatus.Critical,
+          wounds: 5,
+          recoveryTime: 20,
+        }),
+        makeRosterEntry({
+          pilotId: 'p-kia',
+          pilotName: 'Doss',
+          status: CampaignPilotStatus.KIA,
+          wounds: 6,
+          recoveryTime: 0,
+        }),
+      ],
+      GENERATED_AT,
+    );
+
+    expect(inventory.medicalBay).toHaveLength(3);
+    const wounded = inventory.medicalBay.find((i) => i.pilotId === 'p-wounded');
+    expect(wounded?.injuryLevel).toBe('light');
+    expect(wounded?.daysToRecover).toBe(4);
+    expect(wounded?.status).toBe('recovering');
+
+    const critical = inventory.medicalBay.find(
+      (i) => i.pilotId === 'p-critical',
+    );
+    expect(critical?.injuryLevel).toBe('critical');
+
+    const kia = inventory.medicalBay.find((i) => i.pilotId === 'p-kia');
+    expect(kia?.injuryLevel).toBe('kia');
+    expect(kia?.status).toBe('discharged');
+
+    expect(inventory.summary.pilotsInMedical).toBe(3);
+  });
+
+  it('escalates a heavily-wounded pilot from light to serious', () => {
+    const inventory = projectCampaignInventory(
+      makeCampaign(),
+      [
+        makeRosterEntry({
+          pilotId: 'p-heavy',
+          status: CampaignPilotStatus.Wounded,
+          wounds: 4,
+          recoveryTime: 10,
+        }),
+      ],
+      GENERATED_AT,
+    );
+    expect(inventory.medicalBay[0].injuryLevel).toBe('serious');
+  });
+
+  it('a recovered pilot with no recovery time left is marked ready', () => {
+    const inventory = projectCampaignInventory(
+      makeCampaign(),
+      [
+        makeRosterEntry({
+          pilotId: 'p-ready',
+          status: CampaignPilotStatus.Wounded,
+          wounds: 1,
+          recoveryTime: 0,
+        }),
+      ],
+      GENERATED_AT,
+    );
+    expect(inventory.medicalBay[0].status).toBe('ready');
+  });
+});

--- a/src/lib/campaign/inventory/projectCampaignInventory.ts
+++ b/src/lib/campaign/inventory/projectCampaignInventory.ts
@@ -1,0 +1,294 @@
+/**
+ * Campaign inventory projection
+ *
+ * Per `add-campaign-combat-loop` D5: `projectCampaignInventory` is a
+ * pure function that reads the campaign's repair tickets, salvage
+ * allocations, and roster pilot injury state and assembles the frozen
+ * `ICampaignInventory` (design.md D4) the bay UI (CP2a) renders.
+ *
+ * The projection is derived and recomputed each day — it is never an
+ * independently-mutated store. A campaign with no battles fought
+ * produces an empty inventory with a zeroed summary.
+ *
+ * @spec openspec/changes/add-campaign-combat-loop/specs/campaign-combat-loop/spec.md
+ * @module lib/campaign/inventory/projectCampaignInventory
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type {
+  ICampaignInventory,
+  IInventorySummary,
+  IMedicalBayItem,
+  IRepairBayItem,
+  ISalvageBayItem,
+} from '@/types/campaign/CampaignInventory';
+import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
+import type { IRepairTicket } from '@/types/campaign/RepairTicket';
+import type { ISalvageAllocation } from '@/types/campaign/Salvage';
+
+import { CampaignPilotStatus } from '@/types/campaign/CampaignPilotStatus';
+
+// =============================================================================
+// Projection Inputs
+// =============================================================================
+
+/**
+ * Campaign extension fields the inventory projection reads. All
+ * optional — a campaign with no battles fought has none of them, and
+ * the projection yields an empty inventory.
+ */
+export interface IInventoryProjectionSources {
+  /** Per-location repair tickets (from `repairQueueBuilderProcessor`). */
+  readonly repairQueue?: readonly IRepairTicket[];
+  /** Per-battle salvage allocations (from `salvageProcessor`). */
+  readonly salvageAllocations?: Readonly<Record<string, ISalvageAllocation>>;
+}
+
+/** Campaign narrowed to the projection's read surface. */
+export type ICampaignForInventory = ICampaign & IInventoryProjectionSources;
+
+// =============================================================================
+// Repair Bay Projection
+// =============================================================================
+
+/**
+ * Map an `IRepairTicket` lifecycle status onto the frozen bay-item
+ * status. `IRepairTicket` carries `cancelled` and `completed`; the
+ * frozen schema (D4) uses `done` for completed and drops cancelled
+ * tickets entirely (see `projectRepairBay`).
+ */
+function mapRepairStatus(
+  status: IRepairTicket['status'],
+): IRepairBayItem['status'] {
+  switch (status) {
+    case 'completed':
+      return 'done';
+    case 'in-progress':
+      return 'in-progress';
+    case 'parts-needed':
+      return 'parts-needed';
+    case 'queued':
+    case 'cancelled':
+    default:
+      return 'queued';
+  }
+}
+
+/**
+ * Project the repair queue into frozen `IRepairBayItem`s. Cancelled
+ * tickets are dropped — they are not active repair work.
+ */
+function projectRepairBay(
+  tickets: readonly IRepairTicket[],
+): readonly IRepairBayItem[] {
+  return tickets
+    .filter((ticket) => ticket.status !== 'cancelled')
+    .map((ticket) => ({
+      ticketId: ticket.ticketId,
+      unitId: ticket.unitId,
+      kind: ticket.kind,
+      location: ticket.location ?? null,
+      expectedHours: ticket.expectedHours,
+      // `partsReady` is true when every required part has been matched.
+      // A ticket with no parts (e.g. heat-recovery) is trivially ready.
+      partsReady: ticket.partsRequired.every((part) => part.matched),
+      status: mapRepairStatus(ticket.status),
+    }));
+}
+
+// =============================================================================
+// Salvage Bay Projection
+// =============================================================================
+
+/**
+ * Map an `ISalvageCandidate` disposition onto the frozen two-value bay
+ * disposition. Auction dispositions collapse onto their underlying
+ * recipient.
+ */
+function mapSalvageDisposition(
+  disposition: string,
+): ISalvageBayItem['disposition'] {
+  return disposition.includes('employer') ? 'employer' : 'mercenary';
+}
+
+/**
+ * Map an `ISalvageCandidate` status onto the frozen bay status. The
+ * engine's `awarded` / `auctioned` collapse onto `accepted`; `declined`
+ * stays declined; everything else is `pending`.
+ */
+function mapSalvageStatus(status: string): ISalvageBayItem['status'] {
+  switch (status) {
+    case 'awarded':
+    case 'auctioned':
+      return 'accepted';
+    case 'declined':
+      return 'declined';
+    case 'pending':
+    default:
+      return 'pending';
+  }
+}
+
+/**
+ * Project every salvage allocation into frozen `ISalvageBayItem`s.
+ *
+ * Only the mercenary award's candidates land in the bay — the bay
+ * tracks what the player's unit recovered. The summary's
+ * `salvageValueTotal` is the mercenary-share total (design.md D4).
+ */
+function projectSalvageBay(
+  allocations: Readonly<Record<string, ISalvageAllocation>>,
+): readonly ISalvageBayItem[] {
+  const items: ISalvageBayItem[] = [];
+  for (const allocation of Object.values(allocations)) {
+    for (const candidate of allocation.mercenaryAward.candidates) {
+      items.push({
+        // `partId` is set for part-source candidates; fall back to the
+        // unit id for whole-unit candidates so the field is always
+        // populated.
+        partId: candidate.partId ?? candidate.unitId,
+        sourceUnitId: candidate.unitId,
+        designation: candidate.designation,
+        recoveredValue: candidate.recoveredValue,
+        disposition: mapSalvageDisposition(candidate.disposition),
+        status: mapSalvageStatus(candidate.status),
+      });
+    }
+  }
+  return items;
+}
+
+// =============================================================================
+// Medical Bay Projection
+// =============================================================================
+
+/**
+ * Map a roster entry's `CampaignPilotStatus` onto the frozen injury
+ * level. `Active` pilots are not injured and never enter the bay.
+ */
+function mapInjuryLevel(
+  status: CampaignPilotStatus,
+): IMedicalBayItem['injuryLevel'] {
+  switch (status) {
+    case CampaignPilotStatus.Wounded:
+      // A wounded pilot's severity scales with wound count at the
+      // caller; the base mapping treats Wounded as `light`/`serious`
+      // via the wound count refinement in `projectMedicalBay`.
+      return 'light';
+    case CampaignPilotStatus.Critical:
+      return 'critical';
+    case CampaignPilotStatus.MIA:
+      // MIA pilots are unavailable but not dead — surface as serious.
+      return 'serious';
+    case CampaignPilotStatus.KIA:
+      return 'kia';
+    case CampaignPilotStatus.Active:
+    default:
+      return 'none';
+  }
+}
+
+/**
+ * Project the campaign-roster pilot injury state into frozen
+ * `IMedicalBayItem`s.
+ *
+ * Only non-`Active` pilots enter the medical bay. A wounded pilot with
+ * 3+ wounds is escalated from `light` to `serious`. `daysToRecover`
+ * comes from the roster entry's `recoveryTime`.
+ *
+ * @param rosterPilots - roster entries from `useCampaignRosterStore`
+ */
+export function projectMedicalBay(
+  rosterPilots: readonly ICampaignRosterEntry[],
+): readonly IMedicalBayItem[] {
+  const items: IMedicalBayItem[] = [];
+  for (const entry of rosterPilots) {
+    if (entry.status === CampaignPilotStatus.Active) continue;
+
+    let injuryLevel = mapInjuryLevel(entry.status);
+    // Escalate a heavily-wounded pilot from light to serious.
+    if (injuryLevel === 'light' && entry.wounds >= 3) {
+      injuryLevel = 'serious';
+    }
+
+    // Lifecycle status: KIA pilots are discharged; a pilot with no
+    // recovery time left is ready to return; otherwise recovering.
+    const status: IMedicalBayItem['status'] =
+      entry.status === CampaignPilotStatus.KIA
+        ? 'discharged'
+        : entry.recoveryTime <= 0
+          ? 'ready'
+          : 'recovering';
+
+    items.push({
+      pilotId: entry.pilotId,
+      pilotName: entry.pilotName,
+      injuryLevel,
+      daysToRecover: Math.max(0, entry.recoveryTime),
+      status,
+    });
+  }
+  return items;
+}
+
+// =============================================================================
+// Summary
+// =============================================================================
+
+/**
+ * Build the roll-up summary from the three projected bays.
+ */
+function buildSummary(
+  repairBay: readonly IRepairBayItem[],
+  salvageBay: readonly ISalvageBayItem[],
+  medicalBay: readonly IMedicalBayItem[],
+): IInventorySummary {
+  return {
+    repairTicketCount: repairBay.length,
+    totalRepairHours: repairBay.reduce(
+      (sum, item) => sum + item.expectedHours,
+      0,
+    ),
+    salvageValueTotal: salvageBay.reduce(
+      (sum, item) => sum + item.recoveredValue,
+      0,
+    ),
+    pilotsInMedical: medicalBay.length,
+  };
+}
+
+// =============================================================================
+// Projection Entry Point
+// =============================================================================
+
+/**
+ * Project an `ICampaignInventory` from a campaign's post-battle state.
+ *
+ * Pure: reads `campaign.repairQueue`, `campaign.salvageAllocations`,
+ * and the supplied roster pilot list, returning the frozen aggregate.
+ * An empty campaign yields empty bays and a zeroed summary.
+ *
+ * @param campaign - the campaign to project (post-battle state)
+ * @param rosterPilots - roster entries from `useCampaignRosterStore`
+ * @param generatedAt - ISO timestamp (caller-supplied for determinism)
+ */
+export function projectCampaignInventory(
+  campaign: ICampaign,
+  rosterPilots: readonly ICampaignRosterEntry[],
+  generatedAt: string,
+): ICampaignInventory {
+  const extended = campaign as ICampaignForInventory;
+
+  const repairBay = projectRepairBay(extended.repairQueue ?? []);
+  const salvageBay = projectSalvageBay(extended.salvageAllocations ?? {});
+  const medicalBay = projectMedicalBay(rosterPilots);
+
+  return {
+    campaignId: campaign.id,
+    generatedAt,
+    repairBay,
+    salvageBay,
+    medicalBay,
+    summary: buildSummary(repairBay, salvageBay, medicalBay),
+  };
+}

--- a/src/lib/campaign/processors/__tests__/processors.test.ts
+++ b/src/lib/campaign/processors/__tests__/processors.test.ts
@@ -254,13 +254,13 @@ describe('registerBuiltinProcessors', () => {
     _resetBuiltinRegistration();
   });
 
-  it('should register all twelve builtin processors', () => {
+  it('should register all fifteen builtin processors', () => {
     registerBuiltinProcessors();
     const processors = getDayPipeline().getProcessors();
 
-    // 12 = 9 original + post-battle (Wave 2) + salvage (Wave 3a) +
-    // repair-queue-builder (Wave 3b).
-    expect(processors).toHaveLength(12);
+    // 15 = 12 prior + scenario-generation, scenario-encounter-bridge,
+    // and inventory-projection (add-campaign-combat-loop, Wave 4 CP1).
+    expect(processors).toHaveLength(15);
     expect(processors.map((p) => p.id).sort()).toEqual(
       [
         'healing',
@@ -275,6 +275,9 @@ describe('registerBuiltinProcessors', () => {
         'dailyCosts',
         'acquisition',
         'random-events',
+        'scenario-generation',
+        'scenario-encounter-bridge',
+        'inventory-projection',
       ].sort(),
     );
   });
@@ -284,7 +287,7 @@ describe('registerBuiltinProcessors', () => {
     registerBuiltinProcessors();
 
     const processors = getDayPipeline().getProcessors();
-    expect(processors).toHaveLength(12);
+    expect(processors).toHaveLength(15);
   });
 
   it('should register processors in correct phase order', () => {
@@ -294,9 +297,12 @@ describe('registerBuiltinProcessors', () => {
     // Wave 5 (round-trip wiring) reordered the battle-effects block:
     //   postBattle (350) → salvage (375) → repair (390) → contracts (400)
     // so contracts see fully-applied salvage + repair state. Pipeline
-    // sorts ascending by phase, so the expected order is:
+    // sorts ascending by phase. add-campaign-combat-loop adds three
+    // processors at the tail: scenario-generation (EVENTS=800),
+    // scenario-encounter-bridge (EVENTS+10=810), inventory-projection
+    // (CLEANUP=900). Expected order:
     //   PERSONNEL × 2, MARKETS × 3, post-battle, salvage, repair,
-    //   contracts, FINANCES, EVENTS × 2.
+    //   contracts, FINANCES, EVENTS × 3, EVENTS+10, CLEANUP.
     expect(processors[0].phase).toBe(DayPhase.PERSONNEL);
     expect(processors[1].phase).toBe(DayPhase.PERSONNEL);
     expect(processors[2].phase).toBe(DayPhase.MARKETS);
@@ -309,5 +315,8 @@ describe('registerBuiltinProcessors', () => {
     expect(processors[9].phase).toBe(DayPhase.FINANCES);
     expect(processors[10].phase).toBe(DayPhase.EVENTS);
     expect(processors[11].phase).toBe(DayPhase.EVENTS);
+    expect(processors[12].phase).toBe(DayPhase.EVENTS);
+    expect(processors[13].phase).toBe(DayPhase.EVENTS + 10); // bridge
+    expect(processors[14].phase).toBe(DayPhase.CLEANUP); // inventory
   });
 });

--- a/src/lib/campaign/processors/__tests__/scenarioEncounterBridgeProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/scenarioEncounterBridgeProcessor.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for the scenario-event → encounter bridge.
+ *
+ * Per `add-campaign-combat-loop` task 2.6: a `scenario_generated` event
+ * yields one persisted launchable encounter with correct linkage; a
+ * re-run produces no duplicate; an empty day produces no encounters.
+ *
+ * @spec openspec/changes/add-campaign-combat-loop/specs/campaign-combat-loop/spec.md
+ */
+
+import { describe, expect, it } from '@jest/globals';
+
+import type { IDayEvent } from '@/lib/campaign/dayPipeline';
+import type { ICampaign } from '@/types/campaign/Campaign';
+
+import { applyScenarioEncounterBridge } from '@/lib/campaign/processors/scenarioEncounterBridgeProcessor';
+import { CampaignType } from '@/types/campaign/CampaignType';
+import { createDefaultCampaignOptions } from '@/types/campaign/createDefaultCampaignOptions';
+import { Money } from '@/types/campaign/Money';
+import { EncounterStatus } from '@/types/encounter';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeCampaign(overrides?: Partial<ICampaign>): ICampaign {
+  return {
+    id: 'campaign-cb-1',
+    name: 'Combat Loop Test Co.',
+    currentDate: new Date('3025-06-15T00:00:00Z'),
+    factionId: 'mercenary',
+    forces: new Map(),
+    rootForceId: 'root',
+    missions: new Map(),
+    finances: { transactions: [], balance: Money.ZERO },
+    factionStandings: {},
+    options: createDefaultCampaignOptions(),
+    campaignType: CampaignType.MERCENARY,
+    shoppingList: { items: [] },
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    unitCombatStates: {},
+    ...overrides,
+  };
+}
+
+function scenarioEvent(scenarioId: string, contractId: string): IDayEvent {
+  return {
+    type: 'scenario_generated',
+    description: `Scenario ${scenarioId}`,
+    severity: 'info',
+    data: {
+      scenarioType: 'standup',
+      isAttacker: true,
+      opForBV: 4500,
+      conditions: { weather: 'clear', light: 'daylight' },
+      teamId: 'force-alpha',
+      contractId,
+      contractName: 'Garrison: Hesperus II',
+      scenarioId,
+    },
+  };
+}
+
+const CREATED_AT = '3025-06-15T00:00:00.000Z';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('applyScenarioEncounterBridge', () => {
+  it('a scenario_generated event yields one persisted launchable encounter with correct linkage', () => {
+    const campaign = makeCampaign();
+    const events = [
+      scenarioEvent('scn-c1-3025-06-15-force-alpha', 'contract-1'),
+    ];
+
+    const result = applyScenarioEncounterBridge(campaign, events, CREATED_AT);
+
+    const updated = result.campaign as ICampaign & {
+      bridgedEncounters?: Record<string, unknown>;
+      bridgedScenarioIds?: readonly string[];
+    };
+    const encounters = updated.bridgedEncounters ?? {};
+    expect(Object.keys(encounters)).toHaveLength(1);
+
+    const encounter = encounters['scn-c1-3025-06-15-force-alpha'] as {
+      id: string;
+      campaignMeta?: {
+        campaignId: string;
+        contractId: string;
+        scenarioId: string;
+      };
+      victoryConditions: readonly unknown[];
+      opForConfig?: { targetBV?: number };
+    };
+    expect(encounter.id).toBe('enc-scn-c1-3025-06-15-force-alpha');
+    expect(encounter.campaignMeta).toEqual({
+      campaignId: 'campaign-cb-1',
+      contractId: 'contract-1',
+      scenarioId: 'scn-c1-3025-06-15-force-alpha',
+    });
+    // OpFor force is BV-matched to opForBV.
+    expect(encounter.opForConfig?.targetBV).toBe(4500);
+    // Victory conditions derived from scenario type ('standup' → destroy-all).
+    expect(encounter.victoryConditions.length).toBeGreaterThan(0);
+
+    // Idempotency set records the bridged scenario exactly once.
+    expect(updated.bridgedScenarioIds).toEqual([
+      'scn-c1-3025-06-15-force-alpha',
+    ]);
+
+    // A bridge event is surfaced for the UI.
+    expect(
+      result.events.some((e) => e.type === 'scenario_encounter_bridged'),
+    ).toBe(true);
+  });
+
+  it('a re-run does not duplicate the encounter (idempotent by scenarioId)', () => {
+    const campaign = makeCampaign();
+    const events = [scenarioEvent('scn-dup-1', 'contract-1')];
+
+    // First pass.
+    const first = applyScenarioEncounterBridge(campaign, events, CREATED_AT);
+    // Second pass on the SAME campaign output + SAME event.
+    const second = applyScenarioEncounterBridge(
+      first.campaign,
+      events,
+      CREATED_AT,
+    );
+
+    const updated = second.campaign as ICampaign & {
+      bridgedEncounters?: Record<string, unknown>;
+      bridgedScenarioIds?: readonly string[];
+    };
+    // Still exactly one encounter, scenario id present exactly once.
+    expect(Object.keys(updated.bridgedEncounters ?? {})).toHaveLength(1);
+    expect(updated.bridgedScenarioIds).toEqual(['scn-dup-1']);
+    // The re-run produced no new events and returned the campaign as-is.
+    expect(second.events).toHaveLength(0);
+    expect(second.campaign).toBe(first.campaign);
+  });
+
+  it('an empty day produces no encounters', () => {
+    const campaign = makeCampaign();
+    const result = applyScenarioEncounterBridge(campaign, [], CREATED_AT);
+
+    const updated = result.campaign as ICampaign & {
+      bridgedEncounters?: Record<string, unknown>;
+    };
+    expect(updated.bridgedEncounters).toBeUndefined();
+    expect(result.events).toHaveLength(0);
+    // Campaign returned by reference — no churn for downstream processors.
+    expect(result.campaign).toBe(campaign);
+  });
+
+  it('non-scenario events are ignored', () => {
+    const campaign = makeCampaign();
+    const events: IDayEvent[] = [
+      { type: 'healing', description: 'x', severity: 'info' },
+      { type: 'daily_costs', description: 'y', severity: 'info' },
+    ];
+    const result = applyScenarioEncounterBridge(campaign, events, CREATED_AT);
+    expect(result.campaign).toBe(campaign);
+    expect(result.events).toHaveLength(0);
+  });
+
+  it('encounter is Draft when the player force is not resolvable, Ready when it is', () => {
+    // No matching force → Draft.
+    const noForce = applyScenarioEncounterBridge(
+      makeCampaign(),
+      [scenarioEvent('scn-noforce', 'contract-1')],
+      CREATED_AT,
+    );
+    const draftEnc = (
+      noForce.campaign as ICampaign & {
+        bridgedEncounters?: Record<string, { status: EncounterStatus }>;
+      }
+    ).bridgedEncounters?.['scn-noforce'];
+    expect(draftEnc?.status).toBe(EncounterStatus.Draft);
+
+    // Force present → Ready.
+    const withForce = makeCampaign({
+      forces: new Map([
+        [
+          'force-alpha',
+          {
+            id: 'force-alpha',
+            name: 'Alpha Lance',
+            subForceIds: [],
+            unitIds: ['unit-1', 'unit-2'],
+            forceType: 'standard' as never,
+            formationLevel: 'lance' as never,
+            createdAt: '2026-01-01T00:00:00Z',
+            updatedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      ]),
+    });
+    const readyResult = applyScenarioEncounterBridge(
+      withForce,
+      [scenarioEvent('scn-withforce', 'contract-1')],
+      CREATED_AT,
+    );
+    const readyEnc = (
+      readyResult.campaign as ICampaign & {
+        bridgedEncounters?: Record<string, { status: EncounterStatus }>;
+      }
+    ).bridgedEncounters?.['scn-withforce'];
+    expect(readyEnc?.status).toBe(EncounterStatus.Ready);
+  });
+
+  it('multiple scenarios in one day each get an encounter', () => {
+    const result = applyScenarioEncounterBridge(
+      makeCampaign(),
+      [
+        scenarioEvent('scn-multi-a', 'contract-1'),
+        scenarioEvent('scn-multi-b', 'contract-2'),
+      ],
+      CREATED_AT,
+    );
+    const updated = result.campaign as ICampaign & {
+      bridgedEncounters?: Record<string, unknown>;
+    };
+    expect(Object.keys(updated.bridgedEncounters ?? {}).sort()).toEqual([
+      'scn-multi-a',
+      'scn-multi-b',
+    ]);
+  });
+});

--- a/src/lib/campaign/processors/inventoryProjectionProcessor.ts
+++ b/src/lib/campaign/processors/inventoryProjectionProcessor.ts
@@ -1,0 +1,120 @@
+/**
+ * Inventory Projection Processor
+ *
+ * Per `add-campaign-combat-loop` D5: a `CLEANUP`-phase day processor
+ * that runs `projectCampaignInventory` after the battle-effects
+ * processor block (`postBattleProcessor` → `salvageProcessor` →
+ * `repairQueueBuilderProcessor`) has drained, and attaches the frozen
+ * `ICampaignInventory` to the campaign snapshot.
+ *
+ * Phase: `DayPhase.CLEANUP` (900) — strictly after the battle-effects
+ * block (`MISSIONS - 50/-25/-10`), so the projection always reflects
+ * post-battle state. The day pipeline's phase ordering guarantees it.
+ *
+ * The projection is derived: it is recomputed every day and never an
+ * independently-mutated store. A campaign with no battles produces an
+ * empty `ICampaignInventory` with a zeroed summary.
+ *
+ * @spec openspec/changes/add-campaign-combat-loop/specs/campaign-combat-loop/spec.md
+ * @module lib/campaign/processors/inventoryProjectionProcessor
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICampaignInventory } from '@/types/campaign/CampaignInventory';
+import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
+
+import { projectCampaignInventory } from '@/lib/campaign/inventory/projectCampaignInventory';
+import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
+
+import {
+  DayPhase,
+  getDayPipeline,
+  type IDayProcessor,
+  type IDayProcessorResult,
+} from '../dayPipeline';
+
+// =============================================================================
+// Campaign Extension
+// =============================================================================
+
+/**
+ * Campaign field written by the inventory projection processor. Optional
+ * so existing `ICampaign` consumers are unaffected.
+ */
+export interface IInventoryCampaignExtensions {
+  /**
+   * The frozen post-battle inventory aggregate (design.md D4). Derived
+   * and recomputed each day; CP2a (`add-campaign-bay-ui`) renders it.
+   */
+  readonly campaignInventory?: ICampaignInventory;
+}
+
+/** Campaign narrowed to the projection processor's write surface. */
+export type ICampaignWithInventory = ICampaign & IInventoryCampaignExtensions;
+
+// =============================================================================
+// Pure Apply Helper
+// =============================================================================
+
+/**
+ * Attach a freshly-projected `ICampaignInventory` to a campaign.
+ *
+ * Pure given the roster-pilot list — exposed separately from the day
+ * processor so tests can exercise the projection-and-attach step
+ * without standing up the roster store.
+ *
+ * @param campaign - the post-battle campaign
+ * @param rosterPilots - roster entries from `useCampaignRosterStore`
+ * @param generatedAt - ISO timestamp (caller-supplied for determinism)
+ */
+export function attachCampaignInventory(
+  campaign: ICampaign,
+  rosterPilots: readonly ICampaignRosterEntry[],
+  generatedAt: string,
+): ICampaignWithInventory {
+  const inventory = projectCampaignInventory(
+    campaign,
+    rosterPilots,
+    generatedAt,
+  );
+  return {
+    ...campaign,
+    campaignInventory: inventory,
+  };
+}
+
+// =============================================================================
+// Day Processor
+// =============================================================================
+
+/**
+ * Inventory projection day processor.
+ *
+ * Runs in `DayPhase.CLEANUP` — strictly after the battle-effects block
+ * — and attaches the projected `ICampaignInventory` to the campaign
+ * snapshot. Reads roster pilot injury state from `useCampaignRosterStore`
+ * (the canonical personnel source, mirroring `postBattleProcessor`).
+ */
+export const inventoryProjectionProcessor: IDayProcessor = {
+  id: 'inventory-projection',
+  phase: DayPhase.CLEANUP,
+  displayName: 'Post-Battle Inventory Projection',
+
+  process(campaign: ICampaign, date: Date): IDayProcessorResult {
+    const rosterPilots = useCampaignRosterStore.getState().pilots;
+    const updated = attachCampaignInventory(
+      campaign,
+      rosterPilots,
+      date.toISOString(),
+    );
+    return { events: [], campaign: updated };
+  },
+};
+
+/**
+ * Register the inventory projection processor with the day pipeline.
+ * Used by `processorRegistration.ts`.
+ */
+export function registerInventoryProjectionProcessor(): void {
+  getDayPipeline().register(inventoryProjectionProcessor);
+}

--- a/src/lib/campaign/processors/processorRegistration.ts
+++ b/src/lib/campaign/processors/processorRegistration.ts
@@ -4,6 +4,7 @@ import { autoAwardsProcessor } from './autoAwardsProcessor';
 import { contractProcessor } from './contractProcessor';
 import { dailyCostsProcessor } from './dailyCostsProcessor';
 import { healingProcessor } from './healingProcessor';
+import { inventoryProjectionProcessor } from './inventoryProjectionProcessor';
 import {
   contractMarketProcessor,
   personnelMarketProcessor,
@@ -13,6 +14,8 @@ import { postBattleProcessor } from './postBattleProcessor';
 import { randomEventsProcessor } from './randomEventsProcessor';
 import { repairQueueBuilderProcessor } from './repairQueueBuilderProcessor';
 import { salvageProcessor } from './salvageProcessor';
+import { scenarioEncounterBridgeProcessor } from './scenarioEncounterBridgeProcessor';
+import { scenarioGenerationProcessor } from './scenarioGenerationProcessor';
 
 let registered = false;
 
@@ -57,6 +60,14 @@ export function registerBuiltinProcessors(): void {
   pipeline.register(unitMarketProcessor);
   pipeline.register(personnelMarketProcessor);
   pipeline.register(contractMarketProcessor);
+  // Per `add-campaign-combat-loop`: scenario generation (phase EVENTS)
+  // emits `scenario_generated`; the bridge (phase EVENTS + 10) consumes
+  // those events into launchable encounters. Both are registered here
+  // so the campaign combat loop is wired by default. The inventory
+  // projection (phase CLEANUP) runs last, after the battle-effects block.
+  pipeline.register(scenarioGenerationProcessor);
+  pipeline.register(scenarioEncounterBridgeProcessor);
+  pipeline.register(inventoryProjectionProcessor);
 
   registered = true;
 }

--- a/src/lib/campaign/processors/scenarioEncounterBridgeProcessor.ts
+++ b/src/lib/campaign/processors/scenarioEncounterBridgeProcessor.ts
@@ -1,0 +1,190 @@
+/**
+ * Scenario-Event → Encounter Bridge Processor
+ *
+ * Per `add-campaign-combat-loop` D1: a day-pipeline consumer that reads
+ * the day's `scenario_generated` events (emitted by the untouched
+ * `scenarioGenerationProcessor`) and, for each, builds and persists a
+ * launchable `IEncounter`.
+ *
+ * Because the day pipeline is pure (no IO — it runs identically on
+ * client and server), campaign-generated encounters are persisted onto
+ * the campaign snapshot itself, which CP0 (`add-campaign-persistence`)
+ * reads and writes through the persistence store. The encounter is a
+ * full `IEncounter` carrying `campaignMeta`; the campaign-linked launch
+ * path (`launchCampaignEncounter`) materialises it into the
+ * `encounter-system` SQLite repository when the player chooses to play
+ * it. This keeps the pipeline pure and idempotent while still giving
+ * CP2a a single, persistence-store-backed structure to render.
+ *
+ * Phase: `DayPhase.EVENTS + 10` — strictly after `scenarioGenerationProcessor`
+ * (`DayPhase.EVENTS`), so the day's `scenario_generated` events already
+ * exist by the time the bridge runs. The bridge reads them from the
+ * accumulated pipeline event stream, threaded in via the processor's
+ * `process` arguments (the day pipeline now passes the events-so-far).
+ *
+ * Idempotency: keyed on `scenarioId` via `campaign.bridgedScenarioIds`.
+ * A scenario already bridged is skipped — re-running a day or replaying
+ * the pipeline produces no duplicate encounters.
+ *
+ * @spec openspec/changes/add-campaign-combat-loop/specs/campaign-combat-loop/spec.md
+ * @module lib/campaign/processors/scenarioEncounterBridgeProcessor
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { IEncounter } from '@/types/encounter';
+
+import { buildEncounterFromScenario } from '@/lib/campaign/encounter/buildEncounterFromScenario';
+import { isScenarioGeneratedPayload } from '@/lib/campaign/encounter/scenarioEventPayload';
+
+import {
+  DayPhase,
+  getDayEventsSoFar,
+  getDayPipeline,
+  type IDayEvent,
+  type IDayProcessor,
+  type IDayProcessorResult,
+} from '../dayPipeline';
+
+// =============================================================================
+// Campaign Extension
+// =============================================================================
+
+/**
+ * Campaign fields written by the scenario-encounter bridge. All optional
+ * so existing `ICampaign` consumers are unaffected; the bridge narrows
+ * when it reads.
+ */
+export interface IBridgeCampaignExtensions {
+  /**
+   * Launchable encounters generated from campaign scenarios, keyed by
+   * `scenarioId`. Each value carries `campaignMeta` linkage. CP2a
+   * renders these; the campaign-linked launch path materialises one
+   * into the encounter repository on demand.
+   */
+  readonly bridgedEncounters?: Readonly<Record<string, IEncounter>>;
+  /**
+   * Set of `scenarioId`s already bridged to an encounter — the
+   * idempotency key (design.md D3). A re-run skips known ids.
+   */
+  readonly bridgedScenarioIds?: readonly string[];
+}
+
+/** Campaign narrowed to the bridge's read/write surface. */
+export type ICampaignWithBridgeState = ICampaign & IBridgeCampaignExtensions;
+
+// =============================================================================
+// Bridge Phase
+// =============================================================================
+
+/**
+ * Bridge phase — `DayPhase.EVENTS + 10`. Runs strictly after
+ * `scenarioGenerationProcessor` (`DayPhase.EVENTS`), guaranteeing the
+ * day's `scenario_generated` events exist when the bridge consumes them.
+ */
+export const SCENARIO_ENCOUNTER_BRIDGE_PHASE: number = DayPhase.EVENTS + 10;
+
+// =============================================================================
+// Pure Bridge Application
+// =============================================================================
+
+/**
+ * Apply the bridge to a campaign given the day's accumulated events.
+ *
+ * Pure: returns a new campaign with `bridgedEncounters` /
+ * `bridgedScenarioIds` extended, plus the day events surfaced for the
+ * UI. A scenario already in `bridgedScenarioIds` is skipped (D3).
+ *
+ * @param campaign - the campaign being processed
+ * @param dayEvents - every event produced by earlier processors this day
+ * @param createdAt - ISO timestamp (caller-supplied for determinism)
+ */
+export function applyScenarioEncounterBridge(
+  campaign: ICampaign,
+  dayEvents: readonly IDayEvent[],
+  createdAt: string,
+): IDayProcessorResult {
+  const extended = campaign as ICampaignWithBridgeState;
+  const alreadyBridged = new Set(extended.bridgedScenarioIds ?? []);
+  const nextEncounters: Record<string, IEncounter> = {
+    ...(extended.bridgedEncounters ?? {}),
+  };
+  const newlyBridged: string[] = [];
+  const events: IDayEvent[] = [];
+
+  for (const event of dayEvents) {
+    if (event.type !== 'scenario_generated') continue;
+    const payload = event.data;
+    if (!isScenarioGeneratedPayload(payload)) continue;
+
+    // Idempotency (D3): skip a scenario already turned into an encounter.
+    if (alreadyBridged.has(payload.scenarioId)) continue;
+
+    const encounter = buildEncounterFromScenario(payload, campaign, createdAt);
+    nextEncounters[payload.scenarioId] = encounter;
+    alreadyBridged.add(payload.scenarioId);
+    newlyBridged.push(payload.scenarioId);
+
+    events.push({
+      type: 'scenario_encounter_bridged',
+      description: `Launchable encounter created for scenario ${payload.scenarioId}`,
+      severity: 'info',
+      data: {
+        scenarioId: payload.scenarioId,
+        contractId: payload.contractId,
+        encounterId: encounter.id,
+      },
+    });
+  }
+
+  // No new encounters — return the campaign unchanged so reference
+  // equality holds for downstream processors.
+  if (newlyBridged.length === 0) {
+    return { events: [], campaign };
+  }
+
+  const updatedCampaign: ICampaignWithBridgeState = {
+    ...extended,
+    bridgedEncounters: nextEncounters,
+    bridgedScenarioIds: [
+      ...(extended.bridgedScenarioIds ?? []),
+      ...newlyBridged,
+    ],
+    updatedAt: createdAt,
+  };
+
+  return { events, campaign: updatedCampaign };
+}
+
+// =============================================================================
+// Day Processor
+// =============================================================================
+
+/**
+ * Scenario-encounter bridge day processor.
+ *
+ * Consumes the day's `scenario_generated` events — read from the
+ * pipeline's transient day-event accumulator via `getDayEventsSoFar` —
+ * and persists one launchable `IEncounter` per event onto the campaign
+ * snapshot. Idempotent on `scenarioId`.
+ */
+export const scenarioEncounterBridgeProcessor: IDayProcessor = {
+  id: 'scenario-encounter-bridge',
+  phase: SCENARIO_ENCOUNTER_BRIDGE_PHASE,
+  displayName: 'Scenario → Encounter Bridge',
+
+  process(campaign: ICampaign, date: Date): IDayProcessorResult {
+    return applyScenarioEncounterBridge(
+      campaign,
+      getDayEventsSoFar(campaign),
+      date.toISOString(),
+    );
+  },
+};
+
+/**
+ * Register the bridge processor with the day pipeline. Used by
+ * `processorRegistration.ts`.
+ */
+export function registerScenarioEncounterBridgeProcessor(): void {
+  getDayPipeline().register(scenarioEncounterBridgeProcessor);
+}

--- a/src/stores/campaign/__tests__/campaignCombatLoopEnqueue.test.ts
+++ b/src/stores/campaign/__tests__/campaignCombatLoopEnqueue.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for the automatic outcome enqueue trigger.
+ *
+ * Per `add-campaign-combat-loop` task 4.4: a campaign-linked session
+ * completion enqueues exactly once; a standalone skirmish is ignored;
+ * a duplicate `matchId` is dropped.
+ *
+ * @spec openspec/changes/add-campaign-combat-loop/specs/campaign-combat-loop/spec.md
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+
+import type {
+  ICombatOutcome,
+  IUnitCombatDelta,
+} from '@/types/combat/CombatOutcome';
+
+import {
+  _resetCombatOutcomeBus,
+  publishCombatOutcome,
+} from '@/engine/combatOutcomeBus';
+import { _resetDayPipeline } from '@/lib/campaign/dayPipeline';
+import { _resetBuiltinRegistration } from '@/lib/campaign/processors';
+import {
+  resetCampaignStore,
+  useCampaignStore,
+} from '@/stores/campaign/useCampaignStore';
+import { isCampaignLinkedOutcome } from '@/stores/campaign/useCampaignStore.outcomes';
+import { clientSafeStorage } from '@/stores/utils/clientSafeStorage';
+import {
+  COMBAT_OUTCOME_VERSION,
+  CombatEndReason,
+  PilotFinalStatus,
+  UnitFinalStatus,
+} from '@/types/combat/CombatOutcome';
+import { GameSide } from '@/types/gameplay/GameSessionInterfaces';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeDelta(unitId: string): IUnitCombatDelta {
+  return {
+    unitId,
+    side: GameSide.Player,
+    destroyed: false,
+    finalStatus: UnitFinalStatus.Damaged,
+    armorRemaining: { CT: 18 },
+    internalsRemaining: { CT: 10 },
+    destroyedLocations: [],
+    destroyedComponents: [],
+    heatEnd: 4,
+    ammoRemaining: {},
+    pilotState: {
+      conscious: true,
+      wounds: 0,
+      killed: false,
+      finalStatus: PilotFinalStatus.Active,
+    },
+  };
+}
+
+function makeOutcome(opts: {
+  matchId: string;
+  contractId: string | null;
+  scenarioId: string | null;
+}): ICombatOutcome {
+  return {
+    version: COMBAT_OUTCOME_VERSION,
+    matchId: opts.matchId,
+    contractId: opts.contractId,
+    scenarioId: opts.scenarioId,
+    endReason: CombatEndReason.Destruction,
+    report: {
+      version: 1,
+      matchId: opts.matchId,
+      winner: GameSide.Player,
+      reason: 'destruction',
+      turnCount: 5,
+      units: [],
+      mvpUnitId: null,
+      log: [],
+    },
+    unitDeltas: [makeDelta('unit-A')],
+    capturedAt: '3025-06-15T12:00:00Z',
+  };
+}
+
+function resetWorld(): void {
+  resetCampaignStore();
+  _resetCombatOutcomeBus();
+  _resetDayPipeline();
+  _resetBuiltinRegistration();
+  // The campaign store's `persist` middleware rehydrates from the
+  // `campaign-store` key — clear it so a prior test's persisted
+  // `pendingBattleOutcomes` cannot leak into the next test's fresh
+  // store instance.
+  clientSafeStorage.removeItem('campaign-store');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('isCampaignLinkedOutcome', () => {
+  it('is true when the outcome carries a contractId', () => {
+    expect(
+      isCampaignLinkedOutcome(
+        makeOutcome({ matchId: 'm', contractId: 'c-1', scenarioId: null }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is true when the outcome carries a scenarioId', () => {
+    expect(
+      isCampaignLinkedOutcome(
+        makeOutcome({ matchId: 'm', contractId: null, scenarioId: 's-1' }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is false for a standalone skirmish (no linkage)', () => {
+    expect(
+      isCampaignLinkedOutcome(
+        makeOutcome({ matchId: 'm', contractId: null, scenarioId: null }),
+      ),
+    ).toBe(false);
+  });
+
+  it('is false when linkage fields are blank strings', () => {
+    expect(
+      isCampaignLinkedOutcome(
+        makeOutcome({ matchId: 'm', contractId: '  ', scenarioId: '' }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('automatic outcome enqueue trigger (D7)', () => {
+  beforeEach(resetWorld);
+  afterEach(resetWorld);
+
+  it('a campaign-linked session completion enqueues the outcome exactly once', () => {
+    const store = useCampaignStore();
+    store.getState().createCampaign('Enqueue Test Co.', 'mercenary');
+
+    const outcome = makeOutcome({
+      matchId: 'match-linked-1',
+      contractId: 'contract-1',
+      scenarioId: 'scn-1',
+    });
+    publishCombatOutcome({ matchId: outcome.matchId, outcome });
+
+    expect(store.getState().getPendingOutcomeCount()).toBe(1);
+    expect(store.getState().getPendingOutcomes()[0].matchId).toBe(
+      'match-linked-1',
+    );
+  });
+
+  it('a standalone skirmish is ignored — pendingBattleOutcomes does not change', () => {
+    const store = useCampaignStore();
+    store.getState().createCampaign('Skirmish Test Co.', 'mercenary');
+
+    const outcome = makeOutcome({
+      matchId: 'match-standalone-1',
+      contractId: null,
+      scenarioId: null,
+    });
+    publishCombatOutcome({ matchId: outcome.matchId, outcome });
+
+    expect(store.getState().getPendingOutcomeCount()).toBe(0);
+  });
+
+  it('a duplicate matchId is dropped — the queue stays unchanged', () => {
+    const store = useCampaignStore();
+    store.getState().createCampaign('Dedupe Test Co.', 'mercenary');
+
+    const outcome = makeOutcome({
+      matchId: 'match-dup-1',
+      contractId: 'contract-1',
+      scenarioId: 'scn-1',
+    });
+    publishCombatOutcome({ matchId: outcome.matchId, outcome });
+    // Re-publish the SAME matchId.
+    publishCombatOutcome({ matchId: outcome.matchId, outcome });
+
+    expect(store.getState().getPendingOutcomeCount()).toBe(1);
+  });
+});

--- a/src/stores/campaign/useCampaignStore.outcomes.ts
+++ b/src/stores/campaign/useCampaignStore.outcomes.ts
@@ -15,6 +15,23 @@ import {
 type GetCampaignStore = () => CampaignStore;
 type SetCampaignStore = (partial: Partial<CampaignStore>) => void;
 
+/**
+ * Per `add-campaign-combat-loop` D7: an outcome is "campaign-linked"
+ * when its originating session carried campaign linkage — i.e. the
+ * `ICombatOutcome` records a `contractId` and/or `scenarioId`. A
+ * standalone skirmish leaves both null and is ignored by the automatic
+ * enqueue trigger.
+ */
+export function isCampaignLinkedOutcome(outcome: ICombatOutcome): boolean {
+  const hasContract =
+    typeof outcome.contractId === 'string' &&
+    outcome.contractId.trim().length > 0;
+  const hasScenario =
+    typeof outcome.scenarioId === 'string' &&
+    outcome.scenarioId.trim().length > 0;
+  return hasContract || hasScenario;
+}
+
 export function enqueueCampaignOutcome(
   get: GetCampaignStore,
   set: SetCampaignStore,

--- a/src/stores/campaign/useCampaignStore.ts
+++ b/src/stores/campaign/useCampaignStore.ts
@@ -32,6 +32,7 @@ import { registerCampaignStoreAccessor } from './campaignStoreAccessor';
 import {
   dequeueCampaignOutcome,
   enqueueCampaignOutcome,
+  isCampaignLinkedOutcome,
   markCampaignBattleReviewed,
   retryCampaignOutcomeApplication,
 } from './useCampaignStore.outcomes';
@@ -343,6 +344,14 @@ export function useCampaignStore(): StoreApi<CampaignStore> {
       (event: ICombatOutcomeReadyEvent) => {
         const store = campaignStoreInstance;
         if (!store) return;
+        // Per `add-campaign-combat-loop` D7: the automatic enqueue
+        // trigger only routes campaign-linked outcomes. A session that
+        // carries campaign linkage (a `contractId` / `scenarioId` on
+        // its outcome) is enqueued onto this campaign's
+        // `pendingBattleOutcomes`; a standalone skirmish is ignored.
+        // `enqueueOutcome` itself reuses the duplicate-by-`matchId`
+        // guard so a re-published outcome is never enqueued twice.
+        if (!isCampaignLinkedOutcome(event.outcome)) return;
         store.getState().enqueueOutcome(event.outcome);
       },
     );

--- a/src/types/campaign/CampaignInventory.ts
+++ b/src/types/campaign/CampaignInventory.ts
@@ -1,0 +1,153 @@
+/**
+ * Campaign Inventory — frozen post-battle inventory schema
+ *
+ * `ICampaignInventory` is the single campaign-attached structure the
+ * post-battle bay UI (CP2a — `add-campaign-bay-ui`) renders. It
+ * aggregates the three post-battle "bays" — repair, salvage, and
+ * medical — plus a roll-up summary.
+ *
+ * ─────────────────────────────────────────────────────────────────────
+ * SCHEMA FROZEN — `add-campaign-combat-loop` design.md D4.
+ *
+ * Every type in this module is FROZEN. CP2a (`add-campaign-bay-ui`)
+ * RENDERS this structure and MUST NOT alter the schema. A genuine
+ * schema gap is its own OpenSpec change, never a silent edit here.
+ *
+ * `IRepairBayItem` is a projection of `IRepairTicket`.
+ * `ISalvageBayItem` is a projection of `ISalvageCandidate`.
+ * `IMedicalBayItem` is a projection of the campaign-roster pilot
+ * injury state (`ICampaignRosterEntry`).
+ * ─────────────────────────────────────────────────────────────────────
+ *
+ * @spec openspec/changes/add-campaign-combat-loop/specs/campaign-combat-loop/spec.md
+ * @module types/campaign/CampaignInventory
+ */
+
+/**
+ * One repair-bay line item.
+ *
+ * SCHEMA FROZEN (design.md D4) — see module header. CP2a renders this;
+ * any schema-change request is a new OpenSpec change.
+ *
+ * Projection of `IRepairTicket`:
+ *   - `ticketId`     ← `IRepairTicket.ticketId`
+ *   - `unitId`       ← `IRepairTicket.unitId`
+ *   - `kind`         ← `IRepairTicket.kind`
+ *   - `location`     ← `IRepairTicket.location` (null when absent)
+ *   - `expectedHours`← `IRepairTicket.expectedHours`
+ *   - `partsReady`   ← every `IRepairTicket.partsRequired[i].matched`
+ *   - `status`       ← `IRepairTicket.status` (mapped, see projection)
+ */
+export interface IRepairBayItem {
+  /** Originating repair ticket id (from `IRepairTicket`). */
+  readonly ticketId: string;
+  /** Unit the repair work targets. */
+  readonly unitId: string;
+  /** Kind of repair work. */
+  readonly kind: 'armor' | 'structure' | 'component' | 'ammo' | 'heat-recovery';
+  /** Mech location, or null for location-less tickets (e.g. ammo bins). */
+  readonly location: string | null;
+  /** Estimated tech-hours to complete the work. */
+  readonly expectedHours: number;
+  /** True when every required part has been matched from inventory/salvage. */
+  readonly partsReady: boolean;
+  /** Lifecycle status of the repair. */
+  readonly status: 'queued' | 'parts-needed' | 'in-progress' | 'done';
+}
+
+/**
+ * One salvage-bay line item.
+ *
+ * SCHEMA FROZEN (design.md D4) — see module header.
+ *
+ * Projection of `ISalvageCandidate`:
+ *   - `partId`        ← `ISalvageCandidate.partId` ?? `ISalvageCandidate.unitId`
+ *   - `sourceUnitId`  ← `ISalvageCandidate.unitId`
+ *   - `designation`   ← `ISalvageCandidate.designation`
+ *   - `recoveredValue`← `ISalvageCandidate.recoveredValue`
+ *   - `disposition`   ← `ISalvageCandidate.disposition` (mapped)
+ *   - `status`        ← `ISalvageCandidate.status` (mapped)
+ */
+export interface ISalvageBayItem {
+  /** Stable salvage part id (from `ISalvageCandidate`). */
+  readonly partId: string;
+  /** Unit the salvage was recovered from. */
+  readonly sourceUnitId: string;
+  /** Display designation of the recovered item. */
+  readonly designation: string;
+  /** Recovered value in C-bills. */
+  readonly recoveredValue: number;
+  /** Which side this candidate was awarded to. */
+  readonly disposition: 'mercenary' | 'employer';
+  /** Lifecycle status of the salvage candidate. */
+  readonly status: 'pending' | 'accepted' | 'declined';
+}
+
+/**
+ * One medical-bay line item.
+ *
+ * SCHEMA FROZEN (design.md D4) — see module header.
+ *
+ * Projection of the campaign-roster pilot injury state
+ * (`ICampaignRosterEntry`):
+ *   - `pilotId`     ← `ICampaignRosterEntry.pilotId`
+ *   - `pilotName`   ← `ICampaignRosterEntry.pilotName`
+ *   - `injuryLevel` ← `ICampaignRosterEntry.status` (mapped)
+ *   - `daysToRecover`← `ICampaignRosterEntry.recoveryTime`
+ *   - `status`      ← derived from `recoveryTime` + `status`
+ */
+export interface IMedicalBayItem {
+  /** Pilot under medical care (from `ICampaignRosterEntry`). */
+  readonly pilotId: string;
+  /** Pilot display name. */
+  readonly pilotName: string;
+  /** Severity of the pilot's injury. */
+  readonly injuryLevel: 'none' | 'light' | 'serious' | 'critical' | 'kia';
+  /** Estimated days until the pilot returns to active duty. */
+  readonly daysToRecover: number;
+  /** Lifecycle status of the medical entry. */
+  readonly status: 'recovering' | 'ready' | 'discharged';
+}
+
+/**
+ * Roll-up summary across the three bays.
+ *
+ * SCHEMA FROZEN (design.md D4) — see module header.
+ */
+export interface IInventorySummary {
+  /** Count of repair tickets in the repair bay. */
+  readonly repairTicketCount: number;
+  /** Sum of `expectedHours` across every repair-bay item. */
+  readonly totalRepairHours: number;
+  /** Sum of mercenary-share recovered value in C-bills. */
+  readonly salvageValueTotal: number;
+  /** Count of pilots currently in the medical bay. */
+  readonly pilotsInMedical: number;
+}
+
+/**
+ * Frozen post-battle inventory aggregate, attached to a campaign.
+ *
+ * SCHEMA FROZEN (design.md D4) — see module header. This is the
+ * contract `add-campaign-bay-ui` (CP2a) depends on. CP2a renders
+ * this structure and MUST NOT alter the schema.
+ *
+ * The inventory is a *derived projection*: `projectCampaignInventory`
+ * recomputes it each day from the campaign's repair tickets, salvage
+ * allocations, and roster pilot injury state. It is never an
+ * independently-mutated store.
+ */
+export interface ICampaignInventory {
+  /** Campaign this inventory belongs to. */
+  readonly campaignId: string;
+  /** Timestamp the inventory was projected (ISO 8601). */
+  readonly generatedAt: string;
+  /** Repair-bay line items. */
+  readonly repairBay: readonly IRepairBayItem[];
+  /** Salvage-bay line items. */
+  readonly salvageBay: readonly ISalvageBayItem[];
+  /** Medical-bay line items. */
+  readonly medicalBay: readonly IMedicalBayItem[];
+  /** Roll-up summary across the three bays. */
+  readonly summary: IInventorySummary;
+}

--- a/src/types/campaign/__tests__/CampaignInventory.test.ts
+++ b/src/types/campaign/__tests__/CampaignInventory.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Type + shape tests for the frozen `ICampaignInventory` schema.
+ *
+ * Per `add-campaign-combat-loop` task 1.3: assert every field is
+ * read-only and that the projection sources (`IRepairTicket`,
+ * `ISalvageCandidate`) cover every `IRepairBayItem` / `ISalvageBayItem`
+ * field. The read-only checks are compile-time (`@ts-expect-error` on a
+ * mutation attempt); a passing typecheck IS the assertion.
+ *
+ * @spec openspec/changes/add-campaign-combat-loop/specs/campaign-combat-loop/spec.md
+ */
+
+import { describe, expect, it } from '@jest/globals';
+
+import type {
+  ICampaignInventory,
+  IInventorySummary,
+  IMedicalBayItem,
+  IRepairBayItem,
+  ISalvageBayItem,
+} from '@/types/campaign/CampaignInventory';
+import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
+import type { IRepairTicket } from '@/types/campaign/RepairTicket';
+import type { ISalvageCandidate } from '@/types/campaign/Salvage';
+
+describe('ICampaignInventory — frozen schema (design.md D4)', () => {
+  it('carries the three bays and a summary', () => {
+    const inventory: ICampaignInventory = {
+      campaignId: 'campaign-1',
+      generatedAt: '3025-06-15T00:00:00.000Z',
+      repairBay: [],
+      salvageBay: [],
+      medicalBay: [],
+      summary: {
+        repairTicketCount: 0,
+        totalRepairHours: 0,
+        salvageValueTotal: 0,
+        pilotsInMedical: 0,
+      },
+    };
+    expect(inventory.repairBay).toEqual([]);
+    expect(inventory.salvageBay).toEqual([]);
+    expect(inventory.medicalBay).toEqual([]);
+    expect(inventory.summary.repairTicketCount).toBe(0);
+  });
+
+  it('every ICampaignInventory field is read-only', () => {
+    const inventory: ICampaignInventory = {
+      campaignId: 'campaign-1',
+      generatedAt: '3025-06-15T00:00:00.000Z',
+      repairBay: [],
+      salvageBay: [],
+      medicalBay: [],
+      summary: {
+        repairTicketCount: 0,
+        totalRepairHours: 0,
+        salvageValueTotal: 0,
+        pilotsInMedical: 0,
+      },
+    };
+    // @ts-expect-error campaignId is readonly
+    inventory.campaignId = 'mutated';
+    // @ts-expect-error generatedAt is readonly
+    inventory.generatedAt = 'mutated';
+    // @ts-expect-error repairBay is readonly
+    inventory.repairBay = [];
+    // @ts-expect-error salvageBay is readonly
+    inventory.salvageBay = [];
+    // @ts-expect-error medicalBay is readonly
+    inventory.medicalBay = [];
+    // @ts-expect-error summary is readonly
+    inventory.summary = inventory.summary;
+    expect(inventory).toBeDefined();
+  });
+
+  it('every IRepairBayItem field is read-only', () => {
+    const item: IRepairBayItem = {
+      ticketId: 't-1',
+      unitId: 'u-1',
+      kind: 'armor',
+      location: 'CT',
+      expectedHours: 1,
+      partsReady: true,
+      status: 'queued',
+    };
+    // @ts-expect-error ticketId is readonly
+    item.ticketId = 'x';
+    // @ts-expect-error unitId is readonly
+    item.unitId = 'x';
+    // @ts-expect-error kind is readonly
+    item.kind = 'structure';
+    // @ts-expect-error location is readonly
+    item.location = null;
+    // @ts-expect-error expectedHours is readonly
+    item.expectedHours = 2;
+    // @ts-expect-error partsReady is readonly
+    item.partsReady = false;
+    // @ts-expect-error status is readonly
+    item.status = 'done';
+    expect(item).toBeDefined();
+  });
+
+  it('every ISalvageBayItem field is read-only', () => {
+    const item: ISalvageBayItem = {
+      partId: 'p-1',
+      sourceUnitId: 'u-1',
+      designation: 'Atlas',
+      recoveredValue: 1000,
+      disposition: 'mercenary',
+      status: 'pending',
+    };
+    // @ts-expect-error partId is readonly
+    item.partId = 'x';
+    // @ts-expect-error sourceUnitId is readonly
+    item.sourceUnitId = 'x';
+    // @ts-expect-error designation is readonly
+    item.designation = 'x';
+    // @ts-expect-error recoveredValue is readonly
+    item.recoveredValue = 0;
+    // @ts-expect-error disposition is readonly
+    item.disposition = 'employer';
+    // @ts-expect-error status is readonly
+    item.status = 'accepted';
+    expect(item).toBeDefined();
+  });
+
+  it('every IMedicalBayItem field is read-only', () => {
+    const item: IMedicalBayItem = {
+      pilotId: 'pilot-1',
+      pilotName: 'Strix',
+      injuryLevel: 'light',
+      daysToRecover: 3,
+      status: 'recovering',
+    };
+    // @ts-expect-error pilotId is readonly
+    item.pilotId = 'x';
+    // @ts-expect-error pilotName is readonly
+    item.pilotName = 'x';
+    // @ts-expect-error injuryLevel is readonly
+    item.injuryLevel = 'serious';
+    // @ts-expect-error daysToRecover is readonly
+    item.daysToRecover = 0;
+    // @ts-expect-error status is readonly
+    item.status = 'ready';
+    expect(item).toBeDefined();
+  });
+
+  it('every IInventorySummary field is read-only', () => {
+    const summary: IInventorySummary = {
+      repairTicketCount: 1,
+      totalRepairHours: 2,
+      salvageValueTotal: 3,
+      pilotsInMedical: 4,
+    };
+    // @ts-expect-error repairTicketCount is readonly
+    summary.repairTicketCount = 0;
+    // @ts-expect-error totalRepairHours is readonly
+    summary.totalRepairHours = 0;
+    // @ts-expect-error salvageValueTotal is readonly
+    summary.salvageValueTotal = 0;
+    // @ts-expect-error pilotsInMedical is readonly
+    summary.pilotsInMedical = 0;
+    expect(summary).toBeDefined();
+  });
+});
+
+describe('Bay items project from existing engine types', () => {
+  it('every IRepairBayItem field is derivable from IRepairTicket', () => {
+    // Compile-time proof: an IRepairBayItem can be constructed purely
+    // from IRepairTicket fields. If a frozen field stopped being
+    // derivable, this would fail to typecheck.
+    const ticket: IRepairTicket = {
+      ticketId: 'ticket-x',
+      unitId: 'unit-x',
+      kind: 'component',
+      location: 'RA',
+      componentName: 'Medium Laser',
+      expectedHours: 4,
+      partsRequired: [{ partId: 'Medium Laser', quantity: 1, matched: true }],
+      source: 'combat',
+      matchId: 'match-x',
+      createdAt: '3025-06-15T00:00:00.000Z',
+      status: 'parts-needed',
+    };
+    const projected: IRepairBayItem = {
+      ticketId: ticket.ticketId,
+      unitId: ticket.unitId,
+      kind: ticket.kind,
+      location: ticket.location ?? null,
+      expectedHours: ticket.expectedHours,
+      partsReady: ticket.partsRequired.every((p) => p.matched),
+      status: 'parts-needed',
+    };
+    expect(projected.ticketId).toBe(ticket.ticketId);
+    expect(projected.partsReady).toBe(true);
+  });
+
+  it('every ISalvageBayItem field is derivable from ISalvageCandidate', () => {
+    const candidate: ISalvageCandidate = {
+      source: 'part',
+      unitId: 'unit-y',
+      designation: 'PPC',
+      destroyedFromBattle: 'match-y',
+      finalStatus: 'destroyed',
+      damageLevel: 'heavy' as ISalvageCandidate['damageLevel'],
+      originalValue: 200_000,
+      recoveredValue: 50_000,
+      recoveryPercentage: 0.25,
+      repairCostEstimate: 150_000,
+      partId: 'unit-y::PPC',
+      disposition: 'mercenary',
+      status: 'pending',
+    };
+    const projected: ISalvageBayItem = {
+      partId: candidate.partId ?? candidate.unitId,
+      sourceUnitId: candidate.unitId,
+      designation: candidate.designation,
+      recoveredValue: candidate.recoveredValue,
+      disposition: 'mercenary',
+      status: 'pending',
+    };
+    expect(projected.partId).toBe('unit-y::PPC');
+    expect(projected.recoveredValue).toBe(50_000);
+  });
+
+  it('every IMedicalBayItem field is derivable from a roster entry', () => {
+    const entry: Pick<
+      ICampaignRosterEntry,
+      'pilotId' | 'pilotName' | 'status' | 'recoveryTime' | 'wounds'
+    > = {
+      pilotId: 'pilot-z',
+      pilotName: 'Volkov',
+      status: 'wounded' as ICampaignRosterEntry['status'],
+      recoveryTime: 5,
+      wounds: 2,
+    };
+    const projected: IMedicalBayItem = {
+      pilotId: entry.pilotId,
+      pilotName: entry.pilotName,
+      injuryLevel: 'light',
+      daysToRecover: entry.recoveryTime,
+      status: 'recovering',
+    };
+    expect(projected.pilotId).toBe('pilot-z');
+    expect(projected.daysToRecover).toBe(5);
+  });
+});

--- a/src/types/encounter/EncounterInterfaces.ts
+++ b/src/types/encounter/EncounterInterfaces.ts
@@ -136,6 +136,25 @@ export interface IOpForConfig {
 }
 
 /**
+ * Campaign linkage stamped on an encounter that was generated from a
+ * campaign scenario.
+ *
+ * Per `add-campaign-combat-loop` D2: the scenario-event → encounter
+ * bridge writes this so every downstream step (session launch,
+ * post-battle attribution) can thread linkage back to the originating
+ * contract and scenario. Standalone (non-campaign) encounters leave
+ * `campaignMeta` undefined.
+ */
+export interface IEncounterCampaignMeta {
+  /** Campaign that owns the originating scenario. */
+  readonly campaignId: string;
+  /** Contract the scenario was generated for. */
+  readonly contractId: string;
+  /** Deterministic scenario id that produced this encounter. */
+  readonly scenarioId: string;
+}
+
+/**
  * Reference to a force.
  */
 export interface IForceReference {
@@ -195,6 +214,13 @@ export interface IEncounter {
   readonly updatedAt: string;
   /** Launched game session ID (if launched) */
   readonly gameSessionId?: string;
+  /**
+   * Campaign linkage — present only when the encounter was generated
+   * from a campaign scenario by the `add-campaign-combat-loop`
+   * scenario-event → encounter bridge. Undefined for standalone
+   * encounters authored outside a campaign.
+   */
+  readonly campaignMeta?: IEncounterCampaignMeta;
 }
 
 /**


### PR DESCRIPTION
Implements the OpenSpec change `add-campaign-combat-loop` (Wave 4 CP1) — integration wire-up only. The combat-effects processors (`postBattleProcessor`, `salvageEngine`, `repairQueueBuilder`) are consumed as-is, not rebuilt.

## What's wired

1. **Scenario-event → encounter bridge** — `scenarioEncounterBridgeProcessor` (phase `EVENTS + 10`) consumes `scenario_generated` day events and persists launchable `IEncounter`s onto the campaign snapshot, carrying `campaignMeta = { campaignId, contractId, scenarioId }`. Idempotent by `scenarioId` via `bridgedScenarioIds`.
2. **Campaign-linked launch path** — `launchCampaignEncounter` materialises a bridged encounter into the `encounter-system` repository and launches it through `EncounterService.launchEncounter` with campaign linkage stamped onto the `GameSession`.
3. **Automatic outcome enqueue trigger** — the campaign store's `CombatOutcomeReady` handler is narrowed (D7) to enqueue only campaign-linked outcomes; standalone skirmishes are ignored. The duplicate-by-`matchId` guard is reused.
4. **Frozen `ICampaignInventory` schema** (design.md D4) + a `CLEANUP`-phase `inventoryProjectionProcessor` that recomputes the inventory after the battle-effects block drains.

## Notable decisions

- The day pipeline is pure, so bridged encounters persist on the campaign snapshot (CP0 persistence store). `launchCampaignEncounter` materialises into SQLite on demand.
- The pipeline now stamps a transient `_dayEventsSoFar` field so consumer processors can read upstream events; it is stripped before the campaign is persisted.
- D7 supersedes the old `wire-encounter-to-campaign-round-trip` behavior where standalone (no-contract) outcomes auto-enqueued. Two archived-change integration tests were updated to match the new contract.

## Verification

- `npx tsc --noEmit` — clean
- `npx oxlint src/` — 0 errors (2 pre-existing line-cap warnings, unrelated files)
- `npx jest` — 24871 passed, 0 failures
- `npm run build` — succeeds
- `openspec validate add-campaign-combat-loop --strict` — valid

The OpenSpec change is NOT archived.