### PR TITLE
feat(campaign): mech/repair/medical bay UI

### DIFF
--- a/openspec/changes/add-campaign-bay-ui/tasks.md
+++ b/openspec/changes/add-campaign-bay-ui/tasks.md
@@ -2,46 +2,46 @@
 
 ## 1. Bay Navigation and Selectors
 
-- [ ] 1.1 Add a "Bays" campaign-navigation group with entries for Mech Bay, Repair Bay, Medical Bay, and Salvage
-- [ ] 1.2 Add typed campaign-store selectors over `ICampaignInventory` — `selectRepairBay`, `selectSalvageBay`, `selectMedicalBay`, `selectInventorySummary`
-- [ ] 1.3 Tests: selectors return the expected projections from a populated campaign and empty arrays from a battle-free campaign
+- [x] 1.1 Add a "Bays" campaign-navigation group with entries for Mech Bay, Repair Bay, Medical Bay, and Salvage
+- [x] 1.2 Add typed campaign-store selectors over `ICampaignInventory` — `selectRepairBay`, `selectSalvageBay`, `selectMedicalBay`, `selectInventorySummary`
+- [x] 1.3 Tests: selectors return the expected projections from a populated campaign and empty arrays from a battle-free campaign
 
 ## 2. Mech Bay Page
 
-- [ ] 2.1 Build the Mech Bay page — a roster-wide unit-status grid (damage state, repair-ticket count, combat-readiness)
-- [ ] 2.2 Add per-row drill-down navigation into the unit's Repair Bay detail
-- [ ] 2.3 Implement loading, empty (no units), and error states matching `campaign-ui` conventions
-- [ ] 2.4 Storybook story with populated, empty, and error variants
-- [ ] 2.5 Render tests: grid rows, ticket counts, drill-down link
+- [x] 2.1 Build the Mech Bay page — a roster-wide unit-status grid (damage state, repair-ticket count, combat-readiness)
+- [x] 2.2 Add per-row drill-down navigation into the unit's Repair Bay detail
+- [x] 2.3 Implement loading, empty (no units), and error states matching `campaign-ui` conventions
+- [x] 2.4 Storybook story with populated, empty, and error variants
+- [x] 2.5 Render tests: grid rows, ticket counts, drill-down link
 
 ## 3. Repair Bay Page
 
-- [ ] 3.1 Build the Repair Bay page — the `repairBay` ticket queue grouped by unit, each ticket showing kind, location, expected hours, parts-ready, status
-- [ ] 3.2 Implement priority reorder — dragging a ticket writes a `priority` ordinal onto the campaign's `repairTickets` state via the persistence store
-- [ ] 3.3 Implement loading, empty (no tickets), and error states
-- [ ] 3.4 Storybook story with populated, empty, and error variants
-- [ ] 3.5 Tests: queue grouping, priority reorder persists the ordinal, expected-hours and parts-ready render read-only
+- [x] 3.1 Build the Repair Bay page — the `repairBay` ticket queue grouped by unit, each ticket showing kind, location, expected hours, parts-ready, status
+- [x] 3.2 Implement priority reorder — dragging a ticket writes a `priority` ordinal onto the campaign's `repairTickets` state via the persistence store
+- [x] 3.3 Implement loading, empty (no tickets), and error states
+- [x] 3.4 Storybook story with populated, empty, and error variants
+- [x] 3.5 Tests: queue grouping, priority reorder persists the ordinal, expected-hours and parts-ready render read-only
 
 ## 4. Medical Bay Page
 
-- [ ] 4.1 Build the Medical Bay page — the `medicalBay` list of injured pilots (injury level, days-to-recover, status), read-only
-- [ ] 4.2 Add recovery-progress copy making clear healing happens on day advancement
-- [ ] 4.3 Implement loading, empty (no injuries), and error states
-- [ ] 4.4 Storybook story with populated, empty, and error variants
-- [ ] 4.5 Render tests: pilot rows, injury levels, no mutation controls present
+- [x] 4.1 Build the Medical Bay page — the `medicalBay` list of injured pilots (injury level, days-to-recover, status), read-only
+- [x] 4.2 Add recovery-progress copy making clear healing happens on day advancement
+- [x] 4.3 Implement loading, empty (no injuries), and error states
+- [x] 4.4 Storybook story with populated, empty, and error variants
+- [x] 4.5 Render tests: pilot rows, injury levels, no mutation controls present
 
 ## 5. Salvage Acceptance Panel
 
-- [ ] 5.1 Build the Salvage Acceptance panel — the `salvageBay` list with per-item accept / decline actions
-- [ ] 5.2 Implement accept/decline — flips item `status` on the campaign's `salvageAllocations` state via the persistence store
-- [ ] 5.3 Implement the running mercenary-share value total as a pure projection over item status
-- [ ] 5.4 Implement loading, empty (no salvage), and error states
-- [ ] 5.5 Storybook story with populated, empty, and error variants
-- [ ] 5.6 Tests: accept/decline persists status, value total recomputes correctly, declined items excluded from the total
+- [x] 5.1 Build the Salvage Acceptance panel — the `salvageBay` list with per-item accept / decline actions
+- [x] 5.2 Implement accept/decline — flips item `status` on the campaign's `salvageAllocations` state via the persistence store
+- [x] 5.3 Implement the running mercenary-share value total as a pure projection over item status
+- [x] 5.4 Implement loading, empty (no salvage), and error states
+- [x] 5.5 Storybook story with populated, empty, and error variants
+- [x] 5.6 Tests: accept/decline persists status, value total recomputes correctly, declined items excluded from the total
 
 ## 6. Verification
 
-- [ ] 6.1 Integration test: after a campaign battle and day advancement, all four bays render the projected inventory
-- [ ] 6.2 Integration test: salvage accept and repair-priority reorder mark the campaign dirty and trigger an auto-save
-- [ ] 6.3 `openspec validate add-campaign-bay-ui --strict` clean
-- [ ] 6.4 Build, lint, typecheck, and storybook-build pass
+- [x] 6.1 Integration test: after a campaign battle and day advancement, all four bays render the projected inventory
+- [x] 6.2 Integration test: salvage accept and repair-priority reorder mark the campaign dirty and trigger an auto-save
+- [x] 6.3 `openspec validate add-campaign-bay-ui --strict` clean
+- [x] 6.4 Build, lint, typecheck, and storybook-build pass

--- a/src/components/campaign/CampaignNavigation.tsx
+++ b/src/components/campaign/CampaignNavigation.tsx
@@ -1,19 +1,45 @@
 /**
  * Campaign Navigation Tabs
  * Shared navigation component for campaign detail pages.
+ *
+ * The "Bays" group (Mech / Repair / Medical / Salvage) was added by
+ * `add-campaign-bay-ui` (CP2a, design D1) — the four post-battle bay
+ * surfaces share one navigation group so they read as a cohesive cluster.
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
  */
 import Link from 'next/link';
 
+/**
+ * Identifier of the currently-active campaign page. The bay pages
+ * (`mech-bay`, `repair-bay`, `medical-bay`, `salvage`) were added by CP2a.
+ */
+export type CampaignPageId =
+  | 'dashboard'
+  | 'personnel'
+  | 'forces'
+  | 'missions'
+  | 'mech-bay'
+  | 'repair-bay'
+  | 'medical-bay'
+  | 'salvage';
+
 interface CampaignNavigationProps {
   campaignId: string;
-  currentPage: 'dashboard' | 'personnel' | 'forces' | 'missions';
+  currentPage: CampaignPageId;
+}
+
+interface NavTab {
+  readonly id: CampaignPageId;
+  readonly label: string;
+  readonly href: string;
 }
 
 export function CampaignNavigation({
   campaignId,
   currentPage,
 }: CampaignNavigationProps): React.ReactElement {
-  const tabs = [
+  const tabs: readonly NavTab[] = [
     {
       id: 'dashboard',
       label: 'Dashboard',
@@ -34,29 +60,70 @@ export function CampaignNavigation({
       label: 'Missions',
       href: `/gameplay/campaigns/${campaignId}/missions`,
     },
-  ] as const;
+  ];
+
+  // The "Bays" group — the four post-battle bay surfaces (CP2a, design D1).
+  const bayTabs: readonly NavTab[] = [
+    {
+      id: 'mech-bay',
+      label: 'Mech Bay',
+      href: `/gameplay/campaigns/${campaignId}/mech-bay`,
+    },
+    {
+      id: 'repair-bay',
+      label: 'Repair Bay',
+      href: `/gameplay/campaigns/${campaignId}/repair-bay`,
+    },
+    {
+      id: 'medical-bay',
+      label: 'Medical Bay',
+      href: `/gameplay/campaigns/${campaignId}/medical-bay`,
+    },
+    {
+      id: 'salvage',
+      label: 'Salvage',
+      href: `/gameplay/campaigns/${campaignId}/salvage`,
+    },
+  ];
+
+  const renderTab = (tab: NavTab): React.ReactElement => (
+    <Link
+      key={tab.id}
+      href={tab.href}
+      className={`px-4 py-3 font-medium transition-colors ${
+        currentPage === tab.id
+          ? 'text-accent border-accent border-b-2'
+          : 'text-text-theme-secondary hover:text-text-theme-primary'
+      }`}
+      aria-current={currentPage === tab.id ? 'page' : undefined}
+    >
+      {tab.label}
+    </Link>
+  );
 
   return (
     <div className="border-border-theme mb-6 border-b">
       <nav
-        className="flex gap-1"
+        className="flex flex-wrap items-center gap-1"
         role="navigation"
         aria-label="Campaign sections"
       >
-        {tabs.map((tab) => (
-          <Link
-            key={tab.id}
-            href={tab.href}
-            className={`px-4 py-3 font-medium transition-colors ${
-              currentPage === tab.id
-                ? 'text-accent border-accent border-b-2'
-                : 'text-text-theme-secondary hover:text-text-theme-primary'
-            }`}
-            aria-current={currentPage === tab.id ? 'page' : undefined}
-          >
-            {tab.label}
-          </Link>
-        ))}
+        {tabs.map(renderTab)}
+
+        {/* "Bays" group — visually separated, semantically labelled. */}
+        <span
+          className="border-border-theme-subtle ml-2 border-l pl-3 text-xs font-semibold tracking-wider text-slate-500 uppercase"
+          data-testid="campaign-nav-bays-group"
+        >
+          Bays
+        </span>
+        <div
+          className="flex flex-wrap items-center gap-1"
+          role="group"
+          aria-label="Bays"
+        >
+          {bayTabs.map(renderTab)}
+        </div>
       </nav>
     </div>
   );

--- a/src/components/campaign/__tests__/CampaignNavigation.test.tsx
+++ b/src/components/campaign/__tests__/CampaignNavigation.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Campaign Navigation — Bays group tests
+ *
+ * Covers the spec scenario "Bay surfaces are reachable": the campaign
+ * navigation exposes a "Bays" group linking to the four post-battle bay
+ * surfaces (CP2a — `add-campaign-bay-ui`).
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { CampaignNavigation } from '../CampaignNavigation';
+
+describe('CampaignNavigation — Bays group', () => {
+  it('renders a "Bays" navigation group', () => {
+    render(
+      <CampaignNavigation campaignId="campaign-1" currentPage="dashboard" />,
+    );
+    expect(screen.getByTestId('campaign-nav-bays-group')).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Bays' })).toBeInTheDocument();
+  });
+
+  it('links to all four bay surfaces', () => {
+    render(
+      <CampaignNavigation campaignId="campaign-1" currentPage="dashboard" />,
+    );
+    expect(screen.getByText('Mech Bay')).toHaveAttribute(
+      'href',
+      '/gameplay/campaigns/campaign-1/mech-bay',
+    );
+    expect(screen.getByText('Repair Bay')).toHaveAttribute(
+      'href',
+      '/gameplay/campaigns/campaign-1/repair-bay',
+    );
+    expect(screen.getByText('Medical Bay')).toHaveAttribute(
+      'href',
+      '/gameplay/campaigns/campaign-1/medical-bay',
+    );
+    expect(screen.getByText('Salvage')).toHaveAttribute(
+      'href',
+      '/gameplay/campaigns/campaign-1/salvage',
+    );
+  });
+
+  it('marks the active bay page with aria-current', () => {
+    render(
+      <CampaignNavigation campaignId="campaign-1" currentPage="repair-bay" />,
+    );
+    expect(screen.getByText('Repair Bay')).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByText('Mech Bay')).not.toHaveAttribute('aria-current');
+  });
+
+  it('still renders the core campaign tabs alongside the Bays group', () => {
+    render(
+      <CampaignNavigation campaignId="campaign-1" currentPage="dashboard" />,
+    );
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Personnel')).toBeInTheDocument();
+    expect(screen.getByText('Forces')).toBeInTheDocument();
+    expect(screen.getByText('Missions')).toBeInTheDocument();
+  });
+});

--- a/src/components/campaign/bays/BayStates.tsx
+++ b/src/components/campaign/bays/BayStates.tsx
@@ -1,0 +1,103 @@
+/**
+ * Bay Surface State Components
+ *
+ * Shared loading / empty / error presentation for the four post-battle
+ * bay surfaces (CP2a — `add-campaign-bay-ui`). Per design D7 every bay
+ * surface implements the `campaign-ui` loading / empty / error pattern;
+ * these components keep that pattern in one place so all four surfaces
+ * stay consistent.
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ * @module components/campaign/bays/BayStates
+ */
+
+import React from 'react';
+
+import { Card, EmptyState } from '@/components/ui';
+
+// =============================================================================
+// Loading
+// =============================================================================
+
+/**
+ * Loading skeleton for a bay surface while the campaign inventory is
+ * still resolving. Mirrors the pulsing-card skeleton used by the
+ * existing `campaign-ui` pages (forces / personnel / missions).
+ */
+export function BayLoading(): React.ReactElement {
+  return (
+    <div className="animate-pulse" data-testid="bay-loading">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {[1, 2, 3, 4].map((i) => (
+          <Card key={i} className="h-32">
+            <div className="h-full" />
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Empty
+// =============================================================================
+
+interface BayEmptyProps {
+  /** Title of the empty state. */
+  readonly title: string;
+  /** Supporting message. */
+  readonly message: string;
+}
+
+/**
+ * Empty state for a bay surface — shown when the bay has no items (e.g.
+ * no battles fought). Per design D7 an empty bay is an empty state, NOT
+ * an error.
+ */
+export function BayEmpty({
+  title,
+  message,
+}: BayEmptyProps): React.ReactElement {
+  return <EmptyState title={title} message={message} data-testid="bay-empty" />;
+}
+
+// =============================================================================
+// Error
+// =============================================================================
+
+interface BayErrorProps {
+  /** Human-readable failure message. */
+  readonly message: string;
+  /** Retry affordance — re-attempts the inventory load. */
+  readonly onRetry: () => void;
+}
+
+/**
+ * Error state for a bay surface — shown when the campaign inventory load
+ * fails. Carries a retry affordance per the spec's "Error state on
+ * inventory failure" scenario.
+ */
+export function BayError({
+  message,
+  onRetry,
+}: BayErrorProps): React.ReactElement {
+  return (
+    <div
+      className="rounded-xl border border-red-600/30 bg-red-900/20 p-8 text-center"
+      data-testid="bay-error"
+    >
+      <h2 className="mb-2 text-xl font-semibold text-red-400">
+        Could not load bay
+      </h2>
+      <p className="text-text-theme-secondary mb-6">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="bg-surface-raised hover:bg-border-theme text-text-theme-primary inline-block rounded-lg px-6 py-2 transition-colors"
+        data-testid="bay-error-retry"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/src/components/campaign/bays/MechBay.stories.tsx
+++ b/src/components/campaign/bays/MechBay.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import {
+  SAMPLE_REPAIR_BAY,
+  SAMPLE_ROSTER_UNITS,
+} from './__fixtures__/bayFixtures';
+import { BayError } from './BayStates';
+import { MechBay } from './MechBay';
+
+const meta = {
+  title: 'Campaign/Bays/MechBay',
+  component: MechBay,
+  parameters: {
+    layout: 'padded',
+    backgrounds: {
+      default: 'dark',
+      values: [{ name: 'dark', value: '#0f172a' }],
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof MechBay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Populated — a roster with ready, damaged, and destroyed units. */
+export const Populated: Story = {
+  args: {
+    units: SAMPLE_ROSTER_UNITS,
+    repairBay: SAMPLE_REPAIR_BAY,
+    campaignId: 'campaign-demo',
+  },
+};
+
+/** Empty — no roster units; an empty state rather than an error (design D7). */
+export const Empty: Story = {
+  args: {
+    units: [],
+    repairBay: [],
+    campaignId: 'campaign-demo',
+  },
+};
+
+/** Error — inventory load failed; shows the retry affordance. */
+export const ErrorState: Story = {
+  args: {
+    units: [],
+    repairBay: [],
+    campaignId: 'campaign-demo',
+  },
+  render: () => (
+    <BayError
+      message="The campaign inventory failed to load."
+      onRetry={() => undefined}
+    />
+  ),
+};

--- a/src/components/campaign/bays/MechBay.tsx
+++ b/src/components/campaign/bays/MechBay.tsx
@@ -1,0 +1,162 @@
+/**
+ * Mech Bay
+ *
+ * The roster-wide unit-status grid (CP2a — `add-campaign-bay-ui`,
+ * design D2). One row per roster unit showing damage state (readiness),
+ * repair-ticket count, and combat-readiness, with a drill-down link to
+ * that unit's Repair Bay detail.
+ *
+ * The Mech Bay owns NO mutation — it is the post-battle hub. It reads the
+ * roster projection (`IRosterUnitProjection`, which carries the derived
+ * `readiness`) and the repair-bay ticket list.
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ * @module components/campaign/bays/MechBay
+ */
+
+import Link from 'next/link';
+import React from 'react';
+
+import type { IRepairBayItem } from '@/types/campaign/CampaignInventory';
+import type { IRosterUnitProjection } from '@/types/campaign/RosterUnitProjection';
+
+import { Badge, Card } from '@/components/ui';
+
+import { BayEmpty } from './BayStates';
+
+// =============================================================================
+// Readiness Badge
+// =============================================================================
+
+/**
+ * Map a roster-unit readiness label onto a `Badge` colour. Mirrors the
+ * dashboard's readiness palette so the bay reads consistently.
+ */
+function readinessClasses(
+  readiness: IRosterUnitProjection['readiness'],
+): string {
+  switch (readiness) {
+    case 'Ready':
+      return 'bg-emerald-500/20 text-emerald-400';
+    case 'Damaged':
+      return 'bg-amber-500/20 text-amber-400';
+    case 'Destroyed':
+    default:
+      return 'bg-red-500/20 text-red-400';
+  }
+}
+
+// =============================================================================
+// Row
+// =============================================================================
+
+interface MechBayRowProps {
+  /** The roster-unit projection for this row. */
+  readonly unit: IRosterUnitProjection;
+  /** Count of repair-bay tickets targeting this unit. */
+  readonly ticketCount: number;
+  /** Campaign id — used to build the Repair Bay drill-down link. */
+  readonly campaignId: string;
+}
+
+/**
+ * One Mech Bay grid row. Shows the unit's damage state and repair-ticket
+ * count, and drills into the unit's Repair Bay detail.
+ */
+export function MechBayRow({
+  unit,
+  ticketCount,
+  campaignId,
+}: MechBayRowProps): React.ReactElement {
+  return (
+    <Card className="p-4" data-testid={`mech-bay-row-${unit.unitId}`}>
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <h3 className="text-text-theme-primary truncate text-base font-semibold">
+            {unit.unitName}
+          </h3>
+          <p className="text-text-theme-secondary mt-1 font-mono text-xs">
+            {unit.chassisVariant}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Badge className={readinessClasses(unit.readiness)}>
+            {unit.readiness}
+          </Badge>
+
+          <span
+            className="text-text-theme-secondary text-sm"
+            data-testid={`mech-bay-ticket-count-${unit.unitId}`}
+          >
+            {ticketCount} {ticketCount === 1 ? 'ticket' : 'tickets'}
+          </span>
+
+          <Link
+            href={`/gameplay/campaigns/${campaignId}/repair-bay?unit=${encodeURIComponent(unit.unitId)}`}
+            className="text-accent hover:text-accent/80 text-sm font-medium transition-colors"
+            data-testid={`mech-bay-drilldown-${unit.unitId}`}
+          >
+            Repair detail →
+          </Link>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// =============================================================================
+// Grid
+// =============================================================================
+
+export interface MechBayProps {
+  /** Roster-unit projections (typically `useCampaignRosterStore.units`). */
+  readonly units: readonly IRosterUnitProjection[];
+  /** The repair-bay line items from the campaign inventory. */
+  readonly repairBay: readonly IRepairBayItem[];
+  /** Campaign id — used for drill-down links. */
+  readonly campaignId: string;
+}
+
+/**
+ * The Mech Bay roster-wide unit-status grid. Renders an empty state when
+ * the campaign has no roster units (design D7 — empty, not error).
+ */
+export function MechBay({
+  units,
+  repairBay,
+  campaignId,
+}: MechBayProps): React.ReactElement {
+  if (units.length === 0) {
+    return (
+      <BayEmpty
+        title="No units in the bay"
+        message="Add units to this campaign's roster to see their post-battle status here."
+      />
+    );
+  }
+
+  // Pre-count repair tickets per unit so each row is O(1).
+  const ticketCountByUnit = new Map<string, number>();
+  for (const item of repairBay) {
+    ticketCountByUnit.set(
+      item.unitId,
+      (ticketCountByUnit.get(item.unitId) ?? 0) + 1,
+    );
+  }
+
+  return (
+    <div className="space-y-3" data-testid="mech-bay-grid">
+      {units.map((unit) => (
+        <MechBayRow
+          key={unit.unitId}
+          unit={unit}
+          ticketCount={ticketCountByUnit.get(unit.unitId) ?? 0}
+          campaignId={campaignId}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default MechBay;

--- a/src/components/campaign/bays/MedicalBay.stories.tsx
+++ b/src/components/campaign/bays/MedicalBay.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { SAMPLE_MEDICAL_BAY } from './__fixtures__/bayFixtures';
+import { BayError } from './BayStates';
+import { MedicalBay } from './MedicalBay';
+
+const meta = {
+  title: 'Campaign/Bays/MedicalBay',
+  component: MedicalBay,
+  parameters: {
+    layout: 'padded',
+    backgrounds: {
+      default: 'dark',
+      values: [{ name: 'dark', value: '#0f172a' }],
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof MedicalBay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Populated — injured pilots across several injury levels and statuses. */
+export const Populated: Story = {
+  args: {
+    medicalBay: SAMPLE_MEDICAL_BAY,
+  },
+};
+
+/** Empty — no injured pilots; an empty state rather than an error (design D7). */
+export const Empty: Story = {
+  args: {
+    medicalBay: [],
+  },
+};
+
+/** Error — inventory load failed; shows the retry affordance. */
+export const ErrorState: Story = {
+  args: {
+    medicalBay: [],
+  },
+  render: () => (
+    <BayError
+      message="The campaign inventory failed to load."
+      onRetry={() => undefined}
+    />
+  ),
+};

--- a/src/components/campaign/bays/MedicalBay.tsx
+++ b/src/components/campaign/bays/MedicalBay.tsx
@@ -1,0 +1,152 @@
+/**
+ * Medical Bay
+ *
+ * The injured-pilot list (CP2a — `add-campaign-bay-ui`, design D4).
+ * Renders `ICampaignInventory.medicalBay` — each injured pilot's injury
+ * level, days-to-recover, and recovery status.
+ *
+ * The Medical Bay is READ-ONLY. Recovery is driven by `healingProcessor`
+ * during day advancement, not by this UI — there is no healing control,
+ * and the page copy makes that explicit (spec scenario "Medical Bay
+ * exposes no healing controls").
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ * @module components/campaign/bays/MedicalBay
+ */
+
+import React from 'react';
+
+import type { IMedicalBayItem } from '@/types/campaign/CampaignInventory';
+
+import { Badge, Card } from '@/components/ui';
+
+import { BayEmpty } from './BayStates';
+
+// =============================================================================
+// Injury Level Badge
+// =============================================================================
+
+/** Map a pilot injury level onto a `Badge` colour. */
+function injuryClasses(level: IMedicalBayItem['injuryLevel']): string {
+  switch (level) {
+    case 'none':
+      return 'bg-slate-500/20 text-slate-400';
+    case 'light':
+      return 'bg-amber-500/20 text-amber-400';
+    case 'serious':
+      return 'bg-orange-500/20 text-orange-400';
+    case 'critical':
+      return 'bg-red-500/20 text-red-400';
+    case 'kia':
+    default:
+      return 'bg-red-900/40 text-red-300';
+  }
+}
+
+/** Map a medical-entry lifecycle status onto a `Badge` colour. */
+function statusClasses(status: IMedicalBayItem['status']): string {
+  switch (status) {
+    case 'ready':
+      return 'bg-emerald-500/20 text-emerald-400';
+    case 'discharged':
+      return 'bg-slate-500/20 text-slate-400';
+    case 'recovering':
+    default:
+      return 'bg-blue-500/20 text-blue-400';
+  }
+}
+
+// =============================================================================
+// Pilot Row
+// =============================================================================
+
+interface MedicalBayRowProps {
+  /** The medical-bay line item. */
+  readonly item: IMedicalBayItem;
+}
+
+/**
+ * One Medical Bay row — a single injured pilot. Read-only: shows the
+ * injury, recovery time, and status with no mutation control.
+ */
+export function MedicalBayRow({
+  item,
+}: MedicalBayRowProps): React.ReactElement {
+  return (
+    <Card className="p-4" data-testid={`medical-bay-row-${item.pilotId}`}>
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <h3 className="text-text-theme-primary truncate text-base font-semibold">
+            {item.pilotName}
+          </h3>
+          <p
+            className="text-text-theme-secondary mt-1 text-xs"
+            data-testid={`medical-bay-recovery-${item.pilotId}`}
+          >
+            {item.status === 'ready'
+              ? 'Cleared for active duty'
+              : item.status === 'discharged'
+                ? 'Discharged from the roster'
+                : `${item.daysToRecover} ${
+                    item.daysToRecover === 1 ? 'day' : 'days'
+                  } to recover`}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Badge className={injuryClasses(item.injuryLevel)}>
+            {item.injuryLevel}
+          </Badge>
+          <Badge className={statusClasses(item.status)}>{item.status}</Badge>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// =============================================================================
+// Medical Bay
+// =============================================================================
+
+export interface MedicalBayProps {
+  /** The medical-bay line items from the campaign inventory. */
+  readonly medicalBay: readonly IMedicalBayItem[];
+}
+
+/**
+ * The Medical Bay page body — the injured-pilot list. Renders an empty
+ * state when no pilots are injured (design D7 — empty, not error). A
+ * recovery-copy note makes clear healing happens on day advancement.
+ */
+export function MedicalBay({
+  medicalBay,
+}: MedicalBayProps): React.ReactElement {
+  if (medicalBay.length === 0) {
+    return (
+      <BayEmpty
+        title="No pilots in the infirmary"
+        message="Injured pilots appear here after a battle. Everyone is fit for duty."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3" data-testid="medical-bay-list">
+      {/* Read-only note — recovery is driven by day advancement, not this
+          page (design D4 / spec "no healing controls" scenario). */}
+      <p
+        className="text-text-theme-muted text-xs italic"
+        data-testid="medical-bay-recovery-note"
+      >
+        Pilots recover automatically as the campaign advances day by day. There
+        is no manual healing — advance the day to progress recovery.
+      </p>
+
+      {medicalBay.map((item) => (
+        <MedicalBayRow key={item.pilotId} item={item} />
+      ))}
+    </div>
+  );
+}
+
+export default MedicalBay;

--- a/src/components/campaign/bays/RepairBay.stories.tsx
+++ b/src/components/campaign/bays/RepairBay.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { action } from '@storybook/addon-actions';
+
+import { SAMPLE_REPAIR_BAY } from './__fixtures__/bayFixtures';
+import { BayError } from './BayStates';
+import { RepairBay } from './RepairBay';
+
+const meta = {
+  title: 'Campaign/Bays/RepairBay',
+  component: RepairBay,
+  parameters: {
+    layout: 'padded',
+    backgrounds: {
+      default: 'dark',
+      values: [{ name: 'dark', value: '#0f172a' }],
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof RepairBay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Populated — repair tickets grouped by unit with priority-reorder controls. */
+export const Populated: Story = {
+  args: {
+    repairBay: SAMPLE_REPAIR_BAY,
+    onReorder: action('reorder'),
+  },
+};
+
+/** Drill-down focus — opened from the Mech Bay with a unit pre-selected. */
+export const FocusedUnit: Story = {
+  args: {
+    repairBay: SAMPLE_REPAIR_BAY,
+    onReorder: action('reorder'),
+    focusUnitId: 'unit-locust',
+  },
+};
+
+/** Empty — no repair tickets; an empty state rather than an error (design D7). */
+export const Empty: Story = {
+  args: {
+    repairBay: [],
+    onReorder: action('reorder'),
+  },
+};
+
+/** Error — inventory load failed; shows the retry affordance. */
+export const ErrorState: Story = {
+  args: {
+    repairBay: [],
+    onReorder: action('reorder'),
+  },
+  render: () => (
+    <BayError
+      message="The campaign inventory failed to load."
+      onRetry={() => undefined}
+    />
+  ),
+};

--- a/src/components/campaign/bays/RepairBay.tsx
+++ b/src/components/campaign/bays/RepairBay.tsx
@@ -1,0 +1,254 @@
+/**
+ * Repair Bay
+ *
+ * The repair-ticket queue (CP2a — `add-campaign-bay-ui`, design D3).
+ * Renders `ICampaignInventory.repairBay` grouped by unit; each ticket
+ * shows its kind, location, expected hours, parts-ready flag, and status.
+ *
+ * The one mutation is priority reorder — the player moves a ticket up or
+ * down within its unit group, which writes a `priority` ordinal onto the
+ * campaign's `repairQueue` tickets via `reorderRepairTicketPriority`. The
+ * displayed `expectedHours` and `partsReady` are read-only projections.
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ * @module components/campaign/bays/RepairBay
+ */
+
+import React from 'react';
+
+import type { IRepairBayItem } from '@/types/campaign/CampaignInventory';
+
+import { Badge, Card } from '@/components/ui';
+import { groupRepairBayByUnit } from '@/stores/campaign/campaignBaySelectors';
+
+import { BayEmpty } from './BayStates';
+
+// =============================================================================
+// Ticket Status / Kind Badges
+// =============================================================================
+
+/** Map a repair-ticket status onto a `Badge` colour. */
+function statusClasses(status: IRepairBayItem['status']): string {
+  switch (status) {
+    case 'done':
+      return 'bg-emerald-500/20 text-emerald-400';
+    case 'in-progress':
+      return 'bg-blue-500/20 text-blue-400';
+    case 'parts-needed':
+      return 'bg-red-500/20 text-red-400';
+    case 'queued':
+    default:
+      return 'bg-slate-500/20 text-slate-400';
+  }
+}
+
+// =============================================================================
+// Ticket Row
+// =============================================================================
+
+interface RepairTicketRowProps {
+  /** The repair-bay line item. */
+  readonly ticket: IRepairBayItem;
+  /** True when this is the first ticket in its unit group. */
+  readonly isFirst: boolean;
+  /** True when this is the last ticket in its unit group. */
+  readonly isLast: boolean;
+  /** Move this ticket one step earlier in its unit's repair order. */
+  readonly onMoveUp: () => void;
+  /** Move this ticket one step later in its unit's repair order. */
+  readonly onMoveDown: () => void;
+}
+
+/**
+ * One repair ticket. The kind / location / expected-hours / parts-ready
+ * fields are read-only projections; the up/down controls are the only
+ * mutation (priority reorder, design D3).
+ */
+export function RepairTicketRow({
+  ticket,
+  isFirst,
+  isLast,
+  onMoveUp,
+  onMoveDown,
+}: RepairTicketRowProps): React.ReactElement {
+  return (
+    <Card className="p-3" data-testid={`repair-ticket-${ticket.ticketId}`}>
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-2">
+          <Badge className="bg-accent/20 text-accent">{ticket.kind}</Badge>
+          {ticket.location && (
+            <span className="text-text-theme-secondary font-mono text-xs">
+              {ticket.location}
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3 text-sm">
+          <span
+            className="text-text-theme-secondary"
+            data-testid={`repair-ticket-hours-${ticket.ticketId}`}
+          >
+            {ticket.expectedHours}h
+          </span>
+
+          <span
+            className={
+              ticket.partsReady ? 'text-emerald-400' : 'text-amber-400'
+            }
+            data-testid={`repair-ticket-parts-${ticket.ticketId}`}
+          >
+            {ticket.partsReady ? 'Parts ready' : 'Parts needed'}
+          </span>
+
+          <Badge className={statusClasses(ticket.status)}>
+            {ticket.status}
+          </Badge>
+
+          {/* Priority reorder controls — the only mutation (design D3). */}
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={onMoveUp}
+              disabled={isFirst}
+              aria-label="Raise repair priority"
+              className="text-text-theme-secondary hover:text-text-theme-primary disabled:cursor-not-allowed disabled:opacity-30"
+              data-testid={`repair-ticket-up-${ticket.ticketId}`}
+            >
+              ▲
+            </button>
+            <button
+              type="button"
+              onClick={onMoveDown}
+              disabled={isLast}
+              aria-label="Lower repair priority"
+              className="text-text-theme-secondary hover:text-text-theme-primary disabled:cursor-not-allowed disabled:opacity-30"
+              data-testid={`repair-ticket-down-${ticket.ticketId}`}
+            >
+              ▼
+            </button>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// =============================================================================
+// Unit Group
+// =============================================================================
+
+interface RepairUnitGroupProps {
+  /** The unit id heading this group. */
+  readonly unitId: string;
+  /** The tickets for this unit, in current work order. */
+  readonly tickets: readonly IRepairBayItem[];
+  /**
+   * Reorder callback — receives the full post-move ticket-id order for
+   * this unit group.
+   */
+  readonly onReorder: (orderedTicketIds: readonly string[]) => void;
+}
+
+/**
+ * One unit's repair-ticket group. Reorder swaps adjacent tickets and
+ * hands the full new order up to the page, which persists it.
+ */
+export function RepairUnitGroup({
+  unitId,
+  tickets,
+  onReorder,
+}: RepairUnitGroupProps): React.ReactElement {
+  /** Swap the tickets at `index` and `index + delta`, then persist. */
+  const move = (index: number, delta: number): void => {
+    const target = index + delta;
+    if (target < 0 || target >= tickets.length) return;
+    const next = [...tickets];
+    const [moved] = next.splice(index, 1);
+    next.splice(target, 0, moved);
+    onReorder(next.map((t) => t.ticketId));
+  };
+
+  return (
+    <div className="space-y-2" data-testid={`repair-unit-group-${unitId}`}>
+      <h3 className="text-text-theme-primary text-sm font-semibold">
+        {unitId}
+        <span className="text-text-theme-muted ml-2 text-xs font-normal">
+          {tickets.length} {tickets.length === 1 ? 'ticket' : 'tickets'}
+        </span>
+      </h3>
+      {tickets.map((ticket, index) => (
+        <RepairTicketRow
+          key={ticket.ticketId}
+          ticket={ticket}
+          isFirst={index === 0}
+          isLast={index === tickets.length - 1}
+          onMoveUp={() => move(index, -1)}
+          onMoveDown={() => move(index, 1)}
+        />
+      ))}
+    </div>
+  );
+}
+
+// =============================================================================
+// Repair Bay
+// =============================================================================
+
+export interface RepairBayProps {
+  /** The repair-bay line items from the campaign inventory. */
+  readonly repairBay: readonly IRepairBayItem[];
+  /**
+   * Persist a reorder — receives the new ticket-id order for one unit
+   * group. The page wires this to `reorderRepairTicketPriority`.
+   */
+  readonly onReorder: (orderedTicketIds: readonly string[]) => void;
+  /**
+   * Optional unit id to highlight first — set when the player drilled
+   * in from the Mech Bay (`?unit=` query param).
+   */
+  readonly focusUnitId?: string;
+}
+
+/**
+ * The Repair Bay page body — the ticket queue grouped by unit, with a
+ * per-ticket priority-reorder action. Renders an empty state when there
+ * are no tickets (design D7 — empty, not error).
+ */
+export function RepairBay({
+  repairBay,
+  onReorder,
+  focusUnitId,
+}: RepairBayProps): React.ReactElement {
+  if (repairBay.length === 0) {
+    return (
+      <BayEmpty
+        title="No repair tickets"
+        message="Repair tickets appear here after a battle damages a unit."
+      />
+    );
+  }
+
+  const grouped = groupRepairBayByUnit(repairBay);
+  // Order unit groups: the focused unit (from a Mech Bay drill-down)
+  // first, then the rest in insertion order.
+  const unitIds = Array.from(grouped.keys()).sort((a, b) => {
+    if (a === focusUnitId) return -1;
+    if (b === focusUnitId) return 1;
+    return 0;
+  });
+
+  return (
+    <div className="space-y-6" data-testid="repair-bay-queue">
+      {unitIds.map((unitId) => (
+        <RepairUnitGroup
+          key={unitId}
+          unitId={unitId}
+          tickets={grouped.get(unitId) ?? []}
+          onReorder={onReorder}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default RepairBay;

--- a/src/components/campaign/bays/SalvageAcceptancePanel.stories.tsx
+++ b/src/components/campaign/bays/SalvageAcceptancePanel.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { action } from '@storybook/addon-actions';
+
+import { SAMPLE_SALVAGE_BAY } from './__fixtures__/bayFixtures';
+import { BayError } from './BayStates';
+import { SalvageAcceptancePanel } from './SalvageAcceptancePanel';
+
+const meta = {
+  title: 'Campaign/Bays/SalvageAcceptancePanel',
+  component: SalvageAcceptancePanel,
+  parameters: {
+    layout: 'padded',
+    backgrounds: {
+      default: 'dark',
+      values: [{ name: 'dark', value: '#0f172a' }],
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SalvageAcceptancePanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Populated — salvage candidates in a mix of pending / accepted / declined
+ * states, with the running mercenary-share value total at the top.
+ */
+export const Populated: Story = {
+  args: {
+    salvageBay: SAMPLE_SALVAGE_BAY,
+    onDecide: action('decide'),
+  },
+};
+
+/** Empty — no salvage candidates; an empty state rather than an error (design D7). */
+export const Empty: Story = {
+  args: {
+    salvageBay: [],
+    onDecide: action('decide'),
+  },
+};
+
+/** Error — inventory load failed; shows the retry affordance. */
+export const ErrorState: Story = {
+  args: {
+    salvageBay: [],
+    onDecide: action('decide'),
+  },
+  render: () => (
+    <BayError
+      message="The campaign inventory failed to load."
+      onRetry={() => undefined}
+    />
+  ),
+};

--- a/src/components/campaign/bays/SalvageAcceptancePanel.tsx
+++ b/src/components/campaign/bays/SalvageAcceptancePanel.tsx
@@ -1,0 +1,177 @@
+/**
+ * Salvage Acceptance Panel
+ *
+ * The salvage-candidate list with per-item accept / decline actions and a
+ * running mercenary-share value total (CP2a — `add-campaign-bay-ui`,
+ * design D5).
+ *
+ * Accepting / declining flips the item's `status` (`pending → accepted |
+ * declined`) on the campaign's `salvageAllocations` state. The running
+ * value total is a PURE projection over item `status` — it is the sum of
+ * `recoveredValue` across `accepted` items, so declining an item drops it
+ * from the total with no incremental accumulator that could double-count.
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ * @module components/campaign/bays/SalvageAcceptancePanel
+ */
+
+import React from 'react';
+
+import type { ISalvageBayItem } from '@/types/campaign/CampaignInventory';
+
+import { Badge, Card } from '@/components/ui';
+import { type SalvageDecision } from '@/stores/campaign/campaignBayActions';
+import { computeAcceptedSalvageValue } from '@/stores/campaign/campaignBaySelectors';
+
+import { BayEmpty } from './BayStates';
+
+// =============================================================================
+// Formatting
+// =============================================================================
+
+/** Format a C-Bills figure for display. */
+function formatCBills(value: number): string {
+  return `${value.toLocaleString('en-US')} C-Bills`;
+}
+
+/** Map a salvage-item status onto a `Badge` colour. */
+function statusClasses(status: ISalvageBayItem['status']): string {
+  switch (status) {
+    case 'accepted':
+      return 'bg-emerald-500/20 text-emerald-400';
+    case 'declined':
+      return 'bg-red-500/20 text-red-400';
+    case 'pending':
+    default:
+      return 'bg-amber-500/20 text-amber-400';
+  }
+}
+
+// =============================================================================
+// Salvage Row
+// =============================================================================
+
+interface SalvageRowProps {
+  /** The salvage-bay line item. */
+  readonly item: ISalvageBayItem;
+  /** Record an accept/decline decision for this item. */
+  readonly onDecide: (partId: string, decision: SalvageDecision) => void;
+}
+
+/**
+ * One Salvage Acceptance row. Shows the recovered value and disposition,
+ * and exposes accept / decline actions.
+ */
+export function SalvageRow({
+  item,
+  onDecide,
+}: SalvageRowProps): React.ReactElement {
+  return (
+    <Card className="p-4" data-testid={`salvage-row-${item.partId}`}>
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <h3 className="text-text-theme-primary truncate text-base font-semibold">
+            {item.designation}
+          </h3>
+          <p className="text-text-theme-secondary mt-1 text-xs">
+            from <span className="font-mono">{item.sourceUnitId}</span> ·{' '}
+            <span data-testid={`salvage-value-${item.partId}`}>
+              {formatCBills(item.recoveredValue)}
+            </span>{' '}
+            · {item.disposition} share
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Badge className={statusClasses(item.status)}>{item.status}</Badge>
+
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => onDecide(item.partId, 'accepted')}
+              disabled={item.status === 'accepted'}
+              className="rounded bg-emerald-600/80 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-40"
+              data-testid={`salvage-accept-${item.partId}`}
+            >
+              Accept
+            </button>
+            <button
+              type="button"
+              onClick={() => onDecide(item.partId, 'declined')}
+              disabled={item.status === 'declined'}
+              className="bg-surface-raised hover:bg-border-theme text-text-theme-primary rounded px-3 py-1 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+              data-testid={`salvage-decline-${item.partId}`}
+            >
+              Decline
+            </button>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// =============================================================================
+// Salvage Acceptance Panel
+// =============================================================================
+
+export interface SalvageAcceptancePanelProps {
+  /** The salvage-bay line items from the campaign inventory. */
+  readonly salvageBay: readonly ISalvageBayItem[];
+  /**
+   * Record an accept/decline decision. The page wires this to
+   * `setSalvageItemStatus`.
+   */
+  readonly onDecide: (partId: string, decision: SalvageDecision) => void;
+}
+
+/**
+ * The Salvage Acceptance panel body — the salvage-candidate list with
+ * accept/decline actions and a running mercenary-share value total.
+ * Renders an empty state when there are no candidates (design D7 —
+ * empty, not error).
+ */
+export function SalvageAcceptancePanel({
+  salvageBay,
+  onDecide,
+}: SalvageAcceptancePanelProps): React.ReactElement {
+  if (salvageBay.length === 0) {
+    return (
+      <BayEmpty
+        title="No salvage to review"
+        message="Salvage candidates appear here after a contract battle is resolved."
+      />
+    );
+  }
+
+  // The running total is a pure projection over item status — only
+  // `accepted` items contribute (design D5).
+  const acceptedTotal = computeAcceptedSalvageValue(salvageBay);
+  const acceptedCount = salvageBay.filter(
+    (item) => item.status === 'accepted',
+  ).length;
+
+  return (
+    <div className="space-y-4" data-testid="salvage-panel">
+      {/* Running mercenary-share value total. */}
+      <Card className="p-4" data-testid="salvage-value-total">
+        <div className="flex items-center justify-between">
+          <span className="text-text-theme-secondary text-sm">
+            Accepted salvage value ({acceptedCount} of {salvageBay.length})
+          </span>
+          <span className="text-accent font-mono text-lg font-semibold">
+            {formatCBills(acceptedTotal)}
+          </span>
+        </div>
+      </Card>
+
+      <div className="space-y-3">
+        {salvageBay.map((item) => (
+          <SalvageRow key={item.partId} item={item} onDecide={onDecide} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default SalvageAcceptancePanel;

--- a/src/components/campaign/bays/__fixtures__/bayFixtures.ts
+++ b/src/components/campaign/bays/__fixtures__/bayFixtures.ts
@@ -1,0 +1,147 @@
+/**
+ * Bay UI Test / Storybook Fixtures
+ *
+ * Shared sample data for the post-battle bay surfaces (CP2a —
+ * `add-campaign-bay-ui`). Used by both the Storybook stories and the
+ * component / integration tests so the populated states are consistent.
+ *
+ * @module components/campaign/bays/__fixtures__/bayFixtures
+ */
+
+import type {
+  IMedicalBayItem,
+  IRepairBayItem,
+  ISalvageBayItem,
+} from '@/types/campaign/CampaignInventory';
+import type { IRosterUnitProjection } from '@/types/campaign/RosterUnitProjection';
+
+// =============================================================================
+// Roster Units (Mech Bay)
+// =============================================================================
+
+/** A populated roster — a mix of ready, damaged, and destroyed units. */
+export const SAMPLE_ROSTER_UNITS: readonly IRosterUnitProjection[] = [
+  {
+    unitId: 'unit-atlas',
+    unitName: 'Atlas',
+    chassisVariant: 'AS7-D',
+    readiness: 'Damaged',
+  },
+  {
+    unitId: 'unit-warhammer',
+    unitName: 'Warhammer',
+    chassisVariant: 'WHM-6R',
+    readiness: 'Ready',
+  },
+  {
+    unitId: 'unit-locust',
+    unitName: 'Locust',
+    chassisVariant: 'LCT-1V',
+    readiness: 'Destroyed',
+  },
+];
+
+// =============================================================================
+// Repair Bay
+// =============================================================================
+
+/** Repair tickets spanning two units, several kinds and statuses. */
+export const SAMPLE_REPAIR_BAY: readonly IRepairBayItem[] = [
+  {
+    ticketId: 'ticket-1',
+    unitId: 'unit-atlas',
+    kind: 'armor',
+    location: 'CT',
+    expectedHours: 6,
+    partsReady: true,
+    status: 'queued',
+  },
+  {
+    ticketId: 'ticket-2',
+    unitId: 'unit-atlas',
+    kind: 'component',
+    location: 'RA',
+    expectedHours: 12,
+    partsReady: false,
+    status: 'parts-needed',
+  },
+  {
+    ticketId: 'ticket-3',
+    unitId: 'unit-atlas',
+    kind: 'structure',
+    location: 'LT',
+    expectedHours: 18,
+    partsReady: true,
+    status: 'in-progress',
+  },
+  {
+    ticketId: 'ticket-4',
+    unitId: 'unit-locust',
+    kind: 'ammo',
+    location: null,
+    expectedHours: 1,
+    partsReady: true,
+    status: 'queued',
+  },
+];
+
+// =============================================================================
+// Medical Bay
+// =============================================================================
+
+/** Injured pilots covering several injury levels and statuses. */
+export const SAMPLE_MEDICAL_BAY: readonly IMedicalBayItem[] = [
+  {
+    pilotId: 'pilot-1',
+    pilotName: 'Natasha Kerensky',
+    injuryLevel: 'serious',
+    daysToRecover: 14,
+    status: 'recovering',
+  },
+  {
+    pilotId: 'pilot-2',
+    pilotName: 'Morgan Kell',
+    injuryLevel: 'light',
+    daysToRecover: 0,
+    status: 'ready',
+  },
+  {
+    pilotId: 'pilot-3',
+    pilotName: 'Grayson Carlyle',
+    injuryLevel: 'critical',
+    daysToRecover: 30,
+    status: 'recovering',
+  },
+];
+
+// =============================================================================
+// Salvage Bay
+// =============================================================================
+
+/** Salvage candidates in a mix of pending / accepted / declined states. */
+export const SAMPLE_SALVAGE_BAY: readonly ISalvageBayItem[] = [
+  {
+    partId: 'salvage-atlas',
+    sourceUnitId: 'enemy-atlas',
+    designation: 'Atlas AS7-D',
+    recoveredValue: 4_000_000,
+    disposition: 'mercenary',
+    status: 'pending',
+  },
+  {
+    partId: 'salvage-ppc',
+    sourceUnitId: 'enemy-warhammer',
+    designation: 'PPC',
+    recoveredValue: 200_000,
+    disposition: 'mercenary',
+    status: 'accepted',
+  },
+  {
+    partId: 'salvage-srm',
+    sourceUnitId: 'enemy-locust',
+    designation: 'SRM-4 Launcher',
+    recoveredValue: 60_000,
+    disposition: 'mercenary',
+    status: 'declined',
+  },
+];

--- a/src/components/campaign/bays/__tests__/MechBay.test.tsx
+++ b/src/components/campaign/bays/__tests__/MechBay.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Mech Bay — render tests
+ *
+ * Covers tasks.md 2.5 and the spec scenarios "Mech Bay lists every roster
+ * unit" and "Mech Bay empty state".
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import {
+  SAMPLE_REPAIR_BAY,
+  SAMPLE_ROSTER_UNITS,
+} from '../__fixtures__/bayFixtures';
+import { MechBay } from '../MechBay';
+
+describe('MechBay', () => {
+  it('renders a row for every roster unit', () => {
+    render(
+      <MechBay
+        units={SAMPLE_ROSTER_UNITS}
+        repairBay={SAMPLE_REPAIR_BAY}
+        campaignId="campaign-1"
+      />,
+    );
+    for (const unit of SAMPLE_ROSTER_UNITS) {
+      expect(
+        screen.getByTestId(`mech-bay-row-${unit.unitId}`),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('shows the damage-state readiness for each unit', () => {
+    render(
+      <MechBay
+        units={SAMPLE_ROSTER_UNITS}
+        repairBay={SAMPLE_REPAIR_BAY}
+        campaignId="campaign-1"
+      />,
+    );
+    expect(screen.getByText('Damaged')).toBeInTheDocument();
+    expect(screen.getByText('Ready')).toBeInTheDocument();
+    expect(screen.getByText('Destroyed')).toBeInTheDocument();
+  });
+
+  it('shows the repair-ticket count per unit', () => {
+    render(
+      <MechBay
+        units={SAMPLE_ROSTER_UNITS}
+        repairBay={SAMPLE_REPAIR_BAY}
+        campaignId="campaign-1"
+      />,
+    );
+    // unit-atlas has 3 tickets in the fixture, unit-locust has 1.
+    expect(
+      screen.getByTestId('mech-bay-ticket-count-unit-atlas'),
+    ).toHaveTextContent('3 tickets');
+    expect(
+      screen.getByTestId('mech-bay-ticket-count-unit-locust'),
+    ).toHaveTextContent('1 ticket');
+    // unit-warhammer has no tickets.
+    expect(
+      screen.getByTestId('mech-bay-ticket-count-unit-warhammer'),
+    ).toHaveTextContent('0 tickets');
+  });
+
+  it('provides a Repair Bay drill-down link per row', () => {
+    render(
+      <MechBay
+        units={SAMPLE_ROSTER_UNITS}
+        repairBay={SAMPLE_REPAIR_BAY}
+        campaignId="campaign-1"
+      />,
+    );
+    const link = screen.getByTestId('mech-bay-drilldown-unit-atlas');
+    expect(link).toHaveAttribute(
+      'href',
+      '/gameplay/campaigns/campaign-1/repair-bay?unit=unit-atlas',
+    );
+  });
+
+  it('shows an empty state — not an error — when there are no units', () => {
+    render(<MechBay units={[]} repairBay={[]} campaignId="campaign-1" />);
+    expect(screen.getByTestId('bay-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('bay-error')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mech-bay-grid')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/campaign/bays/__tests__/MedicalBay.test.tsx
+++ b/src/components/campaign/bays/__tests__/MedicalBay.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Medical Bay — render tests
+ *
+ * Covers tasks.md 4.5 and the spec scenarios "Medical Bay lists injured
+ * pilots", "Medical Bay exposes no healing controls", "Medical Bay empty
+ * state".
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { SAMPLE_MEDICAL_BAY } from '../__fixtures__/bayFixtures';
+import { MedicalBay } from '../MedicalBay';
+
+describe('MedicalBay', () => {
+  it('renders a row for every injured pilot', () => {
+    render(<MedicalBay medicalBay={SAMPLE_MEDICAL_BAY} />);
+    for (const item of SAMPLE_MEDICAL_BAY) {
+      expect(
+        screen.getByTestId(`medical-bay-row-${item.pilotId}`),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('shows injury level, days-to-recover and status', () => {
+    render(<MedicalBay medicalBay={SAMPLE_MEDICAL_BAY} />);
+    // pilot-1: serious / 14 days / recovering
+    const row = screen.getByTestId('medical-bay-row-pilot-1');
+    expect(row).toHaveTextContent('serious');
+    expect(row).toHaveTextContent('recovering');
+    expect(
+      screen.getByTestId('medical-bay-recovery-pilot-1'),
+    ).toHaveTextContent('14 days to recover');
+    // pilot-2 is ready — cleared for active duty.
+    expect(
+      screen.getByTestId('medical-bay-recovery-pilot-2'),
+    ).toHaveTextContent('Cleared for active duty');
+  });
+
+  it('exposes no healing control', () => {
+    render(<MedicalBay medicalBay={SAMPLE_MEDICAL_BAY} />);
+    // The Medical Bay is read-only — there are no buttons at all.
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+  });
+
+  it('shows recovery copy indicating healing happens on day advancement', () => {
+    render(<MedicalBay medicalBay={SAMPLE_MEDICAL_BAY} />);
+    const note = screen.getByTestId('medical-bay-recovery-note');
+    expect(note).toHaveTextContent(/advance the day/i);
+  });
+
+  it('shows an empty state — not an error — when no pilots are injured', () => {
+    render(<MedicalBay medicalBay={[]} />);
+    expect(screen.getByTestId('bay-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('bay-error')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('medical-bay-list')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/campaign/bays/__tests__/RepairBay.test.tsx
+++ b/src/components/campaign/bays/__tests__/RepairBay.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Repair Bay — render tests
+ *
+ * Covers tasks.md 3.5 and the spec scenarios "Repair Bay lists tickets
+ * grouped by unit", "Priority reorder persists", "Repair Bay empty state".
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { SAMPLE_REPAIR_BAY } from '../__fixtures__/bayFixtures';
+import { RepairBay } from '../RepairBay';
+
+describe('RepairBay', () => {
+  it('groups tickets by unit', () => {
+    render(<RepairBay repairBay={SAMPLE_REPAIR_BAY} onReorder={() => {}} />);
+    expect(
+      screen.getByTestId('repair-unit-group-unit-atlas'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('repair-unit-group-unit-locust'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows kind, location, expected hours, parts-ready and status per ticket', () => {
+    render(<RepairBay repairBay={SAMPLE_REPAIR_BAY} onReorder={() => {}} />);
+    // ticket-1: armor / CT / 6h / parts ready / queued
+    const row = screen.getByTestId('repair-ticket-ticket-1');
+    expect(row).toHaveTextContent('armor');
+    expect(row).toHaveTextContent('CT');
+    expect(
+      screen.getByTestId('repair-ticket-hours-ticket-1'),
+    ).toHaveTextContent('6h');
+    expect(
+      screen.getByTestId('repair-ticket-parts-ticket-1'),
+    ).toHaveTextContent('Parts ready');
+    expect(row).toHaveTextContent('queued');
+    // ticket-2 needs parts.
+    expect(
+      screen.getByTestId('repair-ticket-parts-ticket-2'),
+    ).toHaveTextContent('Parts needed');
+  });
+
+  it('renders expected-hours and parts-ready as read-only text (no inputs)', () => {
+    render(<RepairBay repairBay={SAMPLE_REPAIR_BAY} onReorder={() => {}} />);
+    const hours = screen.getByTestId('repair-ticket-hours-ticket-1');
+    expect(hours.tagName).toBe('SPAN');
+    const parts = screen.getByTestId('repair-ticket-parts-ticket-1');
+    expect(parts.tagName).toBe('SPAN');
+  });
+
+  it('priority reorder hands the new ticket order to onReorder', () => {
+    const onReorder = jest.fn();
+    render(<RepairBay repairBay={SAMPLE_REPAIR_BAY} onReorder={onReorder} />);
+    // Move ticket-2 (index 1 in unit-atlas group) up one step.
+    fireEvent.click(screen.getByTestId('repair-ticket-up-ticket-2'));
+    expect(onReorder).toHaveBeenCalledTimes(1);
+    // The atlas group is ticket-1, ticket-2, ticket-3 — after moving
+    // ticket-2 up it becomes ticket-2, ticket-1, ticket-3.
+    expect(onReorder).toHaveBeenCalledWith([
+      'ticket-2',
+      'ticket-1',
+      'ticket-3',
+    ]);
+  });
+
+  it('disables the up control on the first ticket and down on the last', () => {
+    render(<RepairBay repairBay={SAMPLE_REPAIR_BAY} onReorder={() => {}} />);
+    expect(screen.getByTestId('repair-ticket-up-ticket-1')).toBeDisabled();
+    expect(screen.getByTestId('repair-ticket-down-ticket-3')).toBeDisabled();
+  });
+
+  it('shows an empty state — not an error — when there are no tickets', () => {
+    render(<RepairBay repairBay={[]} onReorder={() => {}} />);
+    expect(screen.getByTestId('bay-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('bay-error')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('repair-bay-queue')).not.toBeInTheDocument();
+  });
+
+  it('orders the focused unit group first', () => {
+    render(
+      <RepairBay
+        repairBay={SAMPLE_REPAIR_BAY}
+        onReorder={() => {}}
+        focusUnitId="unit-locust"
+      />,
+    );
+    const groups = screen.getAllByTestId(/^repair-unit-group-/);
+    expect(groups[0]).toHaveAttribute(
+      'data-testid',
+      'repair-unit-group-unit-locust',
+    );
+  });
+});

--- a/src/components/campaign/bays/__tests__/SalvageAcceptancePanel.test.tsx
+++ b/src/components/campaign/bays/__tests__/SalvageAcceptancePanel.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Salvage Acceptance Panel — render tests
+ *
+ * Covers tasks.md 5.6 and the spec scenarios "Accepting a salvage item
+ * persists its status", "Declining a salvage item excludes it from the
+ * total", "Value total is a pure projection", "Salvage Acceptance empty
+ * state".
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import type { ISalvageBayItem } from '@/types/campaign/CampaignInventory';
+
+import { SAMPLE_SALVAGE_BAY } from '../__fixtures__/bayFixtures';
+import { SalvageAcceptancePanel } from '../SalvageAcceptancePanel';
+
+describe('SalvageAcceptancePanel', () => {
+  it('renders a row for every salvage candidate', () => {
+    render(
+      <SalvageAcceptancePanel
+        salvageBay={SAMPLE_SALVAGE_BAY}
+        onDecide={() => {}}
+      />,
+    );
+    for (const item of SAMPLE_SALVAGE_BAY) {
+      expect(
+        screen.getByTestId(`salvage-row-${item.partId}`),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('accept calls onDecide with the accepted decision', () => {
+    const onDecide = jest.fn();
+    render(
+      <SalvageAcceptancePanel
+        salvageBay={SAMPLE_SALVAGE_BAY}
+        onDecide={onDecide}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('salvage-accept-salvage-atlas'));
+    expect(onDecide).toHaveBeenCalledWith('salvage-atlas', 'accepted');
+  });
+
+  it('decline calls onDecide with the declined decision', () => {
+    const onDecide = jest.fn();
+    render(
+      <SalvageAcceptancePanel
+        salvageBay={SAMPLE_SALVAGE_BAY}
+        onDecide={onDecide}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('salvage-decline-salvage-atlas'));
+    expect(onDecide).toHaveBeenCalledWith('salvage-atlas', 'declined');
+  });
+
+  it('the value total sums only accepted items', () => {
+    render(
+      <SalvageAcceptancePanel
+        salvageBay={SAMPLE_SALVAGE_BAY}
+        onDecide={() => {}}
+      />,
+    );
+    // SAMPLE_SALVAGE_BAY has one accepted item worth 200,000.
+    expect(screen.getByTestId('salvage-value-total')).toHaveTextContent(
+      '200,000 C-Bills',
+    );
+  });
+
+  it('declined items are excluded from the total', () => {
+    // Two accepted (4,000,000 + 200,000), one declined.
+    const bay: ISalvageBayItem[] = [
+      { ...SAMPLE_SALVAGE_BAY[0], status: 'accepted' },
+      { ...SAMPLE_SALVAGE_BAY[1], status: 'accepted' },
+      { ...SAMPLE_SALVAGE_BAY[2], status: 'declined' },
+    ];
+    render(<SalvageAcceptancePanel salvageBay={bay} onDecide={() => {}} />);
+    // 4,000,000 + 200,000 = 4,200,000 — the declined 60,000 is excluded.
+    expect(screen.getByTestId('salvage-value-total')).toHaveTextContent(
+      '4,200,000 C-Bills',
+    );
+  });
+
+  it('the total recomputes without double-counting when status toggles', () => {
+    // Flip the declined item to accepted — the total should grow by
+    // exactly its recovered value, with no incremental drift.
+    const before: ISalvageBayItem[] = [
+      { ...SAMPLE_SALVAGE_BAY[1], status: 'accepted' }, // 200,000
+      { ...SAMPLE_SALVAGE_BAY[2], status: 'declined' }, // 60,000
+    ];
+    const { rerender } = render(
+      <SalvageAcceptancePanel salvageBay={before} onDecide={() => {}} />,
+    );
+    expect(screen.getByTestId('salvage-value-total')).toHaveTextContent(
+      '200,000 C-Bills',
+    );
+
+    const after: ISalvageBayItem[] = [
+      { ...SAMPLE_SALVAGE_BAY[1], status: 'accepted' },
+      { ...SAMPLE_SALVAGE_BAY[2], status: 'accepted' },
+    ];
+    rerender(<SalvageAcceptancePanel salvageBay={after} onDecide={() => {}} />);
+    expect(screen.getByTestId('salvage-value-total')).toHaveTextContent(
+      '260,000 C-Bills',
+    );
+  });
+
+  it('shows an empty state — not an error — when there is no salvage', () => {
+    render(<SalvageAcceptancePanel salvageBay={[]} onDecide={() => {}} />);
+    expect(screen.getByTestId('bay-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('bay-error')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('salvage-panel')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/campaign/bays/__tests__/bayInventoryIntegration.test.tsx
+++ b/src/components/campaign/bays/__tests__/bayInventoryIntegration.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * Bay Inventory Integration — end-to-end projection → render
+ *
+ * Covers tasks.md 6.1: after a campaign battle and day advancement, all
+ * four bays render the projected `ICampaignInventory`. This test exercises
+ * the real `projectCampaignInventory` → `attachCampaignInventory` →
+ * bay-selector → bay-component path so the contract between CP1's
+ * projection and CP2a's surfaces is verified, not mocked.
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
+import type { IRepairTicket } from '@/types/campaign/RepairTicket';
+import type { ISalvageAllocation } from '@/types/campaign/Salvage';
+
+import { MechBay } from '@/components/campaign/bays/MechBay';
+import { MedicalBay } from '@/components/campaign/bays/MedicalBay';
+import { RepairBay } from '@/components/campaign/bays/RepairBay';
+import { SalvageAcceptancePanel } from '@/components/campaign/bays/SalvageAcceptancePanel';
+import { attachCampaignInventory } from '@/lib/campaign/processors/inventoryProjectionProcessor';
+import {
+  selectMedicalBay,
+  selectRepairBay,
+  selectSalvageBay,
+} from '@/stores/campaign/campaignBaySelectors';
+import { createCampaign } from '@/types/campaign/Campaign';
+import { CampaignPilotStatus } from '@/types/campaign/CampaignPilotStatus';
+import { DamageLevel } from '@/types/campaign/Salvage';
+
+import { SAMPLE_ROSTER_UNITS } from '../__fixtures__/bayFixtures';
+
+// =============================================================================
+// Post-battle campaign fixture
+// =============================================================================
+
+/** A repair ticket as the post-battle repair-queue builder would emit. */
+function makeTicket(overrides: Partial<IRepairTicket>): IRepairTicket {
+  return {
+    ticketId: 'ticket-x',
+    unitId: 'unit-atlas',
+    kind: 'armor',
+    location: 'CT',
+    expectedHours: 6,
+    partsRequired: [],
+    source: 'combat',
+    matchId: 'match-1',
+    createdAt: '3025-01-02T00:00:00.000Z',
+    status: 'queued',
+    ...overrides,
+  };
+}
+
+/** A salvage allocation as the post-battle salvage processor would emit. */
+function makeAllocation(): ISalvageAllocation {
+  const candidate = {
+    source: 'unit' as const,
+    unitId: 'enemy-atlas',
+    designation: 'Atlas AS7-D',
+    destroyedFromBattle: 'match-1',
+    finalStatus: 'destroyed' as const,
+    damageLevel: DamageLevel.Heavy,
+    originalValue: 8_000_000,
+    recoveredValue: 2_000_000,
+    recoveryPercentage: 0.25,
+    repairCostEstimate: 500_000,
+    partId: 'salvage-atlas',
+    disposition: 'mercenary' as const,
+    status: 'pending' as const,
+  };
+  return {
+    pool: {
+      battleId: 'match-1',
+      contractId: 'contract-1',
+      candidates: [candidate],
+      totalEstimatedValue: 2_000_000,
+      hostileTerritory: false,
+    },
+    employerAward: {
+      side: 'employer',
+      candidates: [],
+      totalValue: 0,
+      estimatedRepairCost: 0,
+    },
+    mercenaryAward: {
+      side: 'mercenary',
+      candidates: [candidate],
+      totalValue: 2_000_000,
+      estimatedRepairCost: 500_000,
+    },
+    splitMethod: 'contract',
+    processed: true,
+  };
+}
+
+/** Roster pilots — one injured, one fit. */
+const ROSTER_PILOTS: readonly ICampaignRosterEntry[] = [
+  {
+    pilotId: 'pilot-1',
+    pilotName: 'Natasha Kerensky',
+    status: CampaignPilotStatus.Wounded,
+    wounds: 4,
+    recoveryTime: 14,
+    xp: 0,
+    assignedUnitId: 'unit-atlas',
+  } as ICampaignRosterEntry,
+  {
+    pilotId: 'pilot-2',
+    pilotName: 'Morgan Kell',
+    status: CampaignPilotStatus.Active,
+    wounds: 0,
+    recoveryTime: 0,
+    xp: 0,
+  } as ICampaignRosterEntry,
+];
+
+/** Build a post-battle campaign with a projected inventory attached. */
+function postBattleCampaign(): ICampaign {
+  const base = createCampaign('Battle-Tested', 'mercenary');
+  const withBattleState = {
+    ...base,
+    repairQueue: [
+      makeTicket({ ticketId: 'ticket-x', unitId: 'unit-atlas' }),
+      makeTicket({
+        ticketId: 'ticket-y',
+        unitId: 'unit-locust',
+        kind: 'ammo',
+        location: undefined,
+        expectedHours: 1,
+      }),
+    ],
+    salvageAllocations: { 'match-1': makeAllocation() },
+  } as ICampaign;
+
+  // Day advancement's CLEANUP-phase processor attaches the inventory.
+  return attachCampaignInventory(
+    withBattleState,
+    ROSTER_PILOTS,
+    '3025-01-02T00:00:00.000Z',
+  );
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Bay inventory integration', () => {
+  const campaign = postBattleCampaign();
+
+  it('the Mech Bay renders the projected repair-ticket counts', () => {
+    const repairBay = selectRepairBay(campaign);
+    render(
+      <MechBay
+        units={SAMPLE_ROSTER_UNITS}
+        repairBay={repairBay}
+        campaignId={campaign.id}
+      />,
+    );
+    // unit-atlas has 1 projected ticket, unit-locust has 1.
+    expect(
+      screen.getByTestId('mech-bay-ticket-count-unit-atlas'),
+    ).toHaveTextContent('1 ticket');
+    expect(
+      screen.getByTestId('mech-bay-ticket-count-unit-locust'),
+    ).toHaveTextContent('1 ticket');
+  });
+
+  it('the Repair Bay renders the projected tickets grouped by unit', () => {
+    const repairBay = selectRepairBay(campaign);
+    render(<RepairBay repairBay={repairBay} onReorder={() => {}} />);
+    expect(
+      screen.getByTestId('repair-unit-group-unit-atlas'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('repair-unit-group-unit-locust'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('repair-ticket-ticket-x')).toBeInTheDocument();
+  });
+
+  it('the Medical Bay renders the projected injured pilot', () => {
+    const medicalBay = selectMedicalBay(campaign);
+    render(<MedicalBay medicalBay={medicalBay} />);
+    // Only the wounded pilot is projected — the active pilot is excluded.
+    expect(screen.getByTestId('medical-bay-row-pilot-1')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('medical-bay-row-pilot-2'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('the Salvage panel renders the projected mercenary-share candidate', () => {
+    const salvageBay = selectSalvageBay(campaign);
+    render(
+      <SalvageAcceptancePanel salvageBay={salvageBay} onDecide={() => {}} />,
+    );
+    expect(screen.getByTestId('salvage-row-salvage-atlas')).toBeInTheDocument();
+  });
+
+  it('a battle-free campaign produces empty bays on every surface', () => {
+    const fresh = attachCampaignInventory(
+      createCampaign('Fresh', 'mercenary'),
+      [],
+      '3025-01-01T00:00:00.000Z',
+    );
+    expect(selectRepairBay(fresh)).toEqual([]);
+    expect(selectSalvageBay(fresh)).toEqual([]);
+    expect(selectMedicalBay(fresh)).toEqual([]);
+
+    render(
+      <RepairBay repairBay={selectRepairBay(fresh)} onReorder={() => {}} />,
+    );
+    expect(screen.getByTestId('bay-empty')).toBeInTheDocument();
+  });
+});

--- a/src/pages/gameplay/campaigns/[id]/mech-bay.tsx
+++ b/src/pages/gameplay/campaigns/[id]/mech-bay.tsx
@@ -1,0 +1,98 @@
+/**
+ * Campaign Mech Bay Page
+ *
+ * The roster-wide unit-status grid — the post-battle hub (CP2a,
+ * design D2). One row per roster unit with damage state, repair-ticket
+ * count, and a drill-down to the unit's Repair Bay detail.
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ */
+
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+
+import { BayError, BayLoading } from '@/components/campaign/bays/BayStates';
+import { MechBay } from '@/components/campaign/bays/MechBay';
+import { CampaignNavigation } from '@/components/campaign/CampaignNavigation';
+import { EmptyState, PageLayout } from '@/components/ui';
+import { selectRepairBay } from '@/stores/campaign/campaignBaySelectors';
+import { useCampaignPersistenceStore } from '@/stores/campaign/useCampaignPersistenceStore';
+import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
+import { useCampaignStore } from '@/stores/campaign/useCampaignStore';
+
+export default function MechBayPage(): React.ReactElement {
+  const router = useRouter();
+  const { id } = router.query;
+  const store = useCampaignStore();
+  const campaign = store.getState().getCampaign();
+  const units = useCampaignRosterStore((state) => state.units);
+  const saveState = useCampaignPersistenceStore((state) => state.saveState);
+  const errorMessage = useCampaignPersistenceStore(
+    (state) => state.errorMessage,
+  );
+  const loadCampaign = useCampaignPersistenceStore(
+    (state) => state.loadCampaign,
+  );
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  const breadcrumbs = [
+    { label: 'Home', href: '/' },
+    { label: 'Gameplay', href: '/gameplay' },
+    { label: 'Campaigns', href: '/gameplay/campaigns' },
+    { label: campaign?.name || 'Campaign', href: `/gameplay/campaigns/${id}` },
+    { label: 'Mech Bay' },
+  ];
+
+  // Loading state while the campaign / inventory resolves (design D7).
+  if (!isClient) {
+    return (
+      <PageLayout title="Mech Bay" subtitle="Loading bay..." maxWidth="wide">
+        <BayLoading />
+      </PageLayout>
+    );
+  }
+
+  if (!campaign) {
+    return (
+      <PageLayout
+        title="Mech Bay"
+        subtitle="Campaign not found"
+        maxWidth="wide"
+        breadcrumbs={breadcrumbs}
+      >
+        <EmptyState
+          title="Campaign not found"
+          message="Return to campaigns list to select a campaign."
+        />
+      </PageLayout>
+    );
+  }
+
+  const repairBay = selectRepairBay(campaign);
+
+  return (
+    <PageLayout
+      title="Mech Bay"
+      subtitle={`${campaign.name} — ${units.length} units`}
+      maxWidth="wide"
+      breadcrumbs={breadcrumbs}
+    >
+      <CampaignNavigation campaignId={campaign.id} currentPage="mech-bay" />
+
+      {saveState === 'error' ? (
+        <BayError
+          message={errorMessage ?? 'The campaign inventory failed to load.'}
+          onRetry={() => {
+            void loadCampaign(campaign.id);
+          }}
+        />
+      ) : (
+        <MechBay units={units} repairBay={repairBay} campaignId={campaign.id} />
+      )}
+    </PageLayout>
+  );
+}

--- a/src/pages/gameplay/campaigns/[id]/medical-bay.tsx
+++ b/src/pages/gameplay/campaigns/[id]/medical-bay.tsx
@@ -1,0 +1,94 @@
+/**
+ * Campaign Medical Bay Page
+ *
+ * The read-only injured-pilot list (CP2a, design D4). Recovery is driven
+ * by the day-advancement healing processor, not by this page.
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ */
+
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+
+import { BayError, BayLoading } from '@/components/campaign/bays/BayStates';
+import { MedicalBay } from '@/components/campaign/bays/MedicalBay';
+import { CampaignNavigation } from '@/components/campaign/CampaignNavigation';
+import { EmptyState, PageLayout } from '@/components/ui';
+import { selectMedicalBay } from '@/stores/campaign/campaignBaySelectors';
+import { useCampaignPersistenceStore } from '@/stores/campaign/useCampaignPersistenceStore';
+import { useCampaignStore } from '@/stores/campaign/useCampaignStore';
+
+export default function MedicalBayPage(): React.ReactElement {
+  const router = useRouter();
+  const { id } = router.query;
+  const store = useCampaignStore();
+  const campaign = store.getState().getCampaign();
+  const saveState = useCampaignPersistenceStore((state) => state.saveState);
+  const errorMessage = useCampaignPersistenceStore(
+    (state) => state.errorMessage,
+  );
+  const loadCampaign = useCampaignPersistenceStore(
+    (state) => state.loadCampaign,
+  );
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  const breadcrumbs = [
+    { label: 'Home', href: '/' },
+    { label: 'Gameplay', href: '/gameplay' },
+    { label: 'Campaigns', href: '/gameplay/campaigns' },
+    { label: campaign?.name || 'Campaign', href: `/gameplay/campaigns/${id}` },
+    { label: 'Medical Bay' },
+  ];
+
+  if (!isClient) {
+    return (
+      <PageLayout title="Medical Bay" subtitle="Loading bay..." maxWidth="wide">
+        <BayLoading />
+      </PageLayout>
+    );
+  }
+
+  if (!campaign) {
+    return (
+      <PageLayout
+        title="Medical Bay"
+        subtitle="Campaign not found"
+        maxWidth="wide"
+        breadcrumbs={breadcrumbs}
+      >
+        <EmptyState
+          title="Campaign not found"
+          message="Return to campaigns list to select a campaign."
+        />
+      </PageLayout>
+    );
+  }
+
+  const medicalBay = selectMedicalBay(campaign);
+
+  return (
+    <PageLayout
+      title="Medical Bay"
+      subtitle={`${campaign.name} — ${medicalBay.length} pilots in care`}
+      maxWidth="wide"
+      breadcrumbs={breadcrumbs}
+    >
+      <CampaignNavigation campaignId={campaign.id} currentPage="medical-bay" />
+
+      {saveState === 'error' ? (
+        <BayError
+          message={errorMessage ?? 'The campaign inventory failed to load.'}
+          onRetry={() => {
+            void loadCampaign(campaign.id);
+          }}
+        />
+      ) : (
+        <MedicalBay medicalBay={medicalBay} />
+      )}
+    </PageLayout>
+  );
+}

--- a/src/pages/gameplay/campaigns/[id]/repair-bay.tsx
+++ b/src/pages/gameplay/campaigns/[id]/repair-bay.tsx
@@ -1,0 +1,110 @@
+/**
+ * Campaign Repair Bay Page
+ *
+ * The repair-ticket queue grouped by unit, with a per-ticket
+ * priority-reorder action (CP2a, design D3). Reorder writes a `priority`
+ * ordinal onto the campaign's `repairQueue` via the persistence store.
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ */
+
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+
+import { BayError, BayLoading } from '@/components/campaign/bays/BayStates';
+import { RepairBay } from '@/components/campaign/bays/RepairBay';
+import { CampaignNavigation } from '@/components/campaign/CampaignNavigation';
+import { EmptyState, PageLayout } from '@/components/ui';
+import { reorderRepairTicketPriority } from '@/stores/campaign/campaignBayActions';
+import { selectRepairBay } from '@/stores/campaign/campaignBaySelectors';
+import { useCampaignPersistenceStore } from '@/stores/campaign/useCampaignPersistenceStore';
+import { useCampaignStore } from '@/stores/campaign/useCampaignStore';
+
+export default function RepairBayPage(): React.ReactElement {
+  const router = useRouter();
+  const { id, unit } = router.query;
+  const store = useCampaignStore();
+  const campaign = store.getState().getCampaign();
+  const saveState = useCampaignPersistenceStore((state) => state.saveState);
+  const errorMessage = useCampaignPersistenceStore(
+    (state) => state.errorMessage,
+  );
+  const loadCampaign = useCampaignPersistenceStore(
+    (state) => state.loadCampaign,
+  );
+  const [isClient, setIsClient] = useState(false);
+  // Local re-render tick — bumped after a reorder so the page re-reads the
+  // freshly re-projected inventory off the campaign store.
+  const [, setReorderTick] = useState(0);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  const breadcrumbs = [
+    { label: 'Home', href: '/' },
+    { label: 'Gameplay', href: '/gameplay' },
+    { label: 'Campaigns', href: '/gameplay/campaigns' },
+    { label: campaign?.name || 'Campaign', href: `/gameplay/campaigns/${id}` },
+    { label: 'Repair Bay' },
+  ];
+
+  if (!isClient) {
+    return (
+      <PageLayout title="Repair Bay" subtitle="Loading bay..." maxWidth="wide">
+        <BayLoading />
+      </PageLayout>
+    );
+  }
+
+  if (!campaign) {
+    return (
+      <PageLayout
+        title="Repair Bay"
+        subtitle="Campaign not found"
+        maxWidth="wide"
+        breadcrumbs={breadcrumbs}
+      >
+        <EmptyState
+          title="Campaign not found"
+          message="Return to campaigns list to select a campaign."
+        />
+      </PageLayout>
+    );
+  }
+
+  const repairBay = selectRepairBay(campaign);
+  const focusUnitId = typeof unit === 'string' ? unit : undefined;
+
+  /** Persist a priority reorder and re-render against the new projection. */
+  const handleReorder = (orderedTicketIds: readonly string[]): void => {
+    reorderRepairTicketPriority(orderedTicketIds);
+    setReorderTick((tick) => tick + 1);
+  };
+
+  return (
+    <PageLayout
+      title="Repair Bay"
+      subtitle={`${campaign.name} — ${repairBay.length} repair tickets`}
+      maxWidth="wide"
+      breadcrumbs={breadcrumbs}
+    >
+      <CampaignNavigation campaignId={campaign.id} currentPage="repair-bay" />
+
+      {saveState === 'error' ? (
+        <BayError
+          message={errorMessage ?? 'The campaign inventory failed to load.'}
+          onRetry={() => {
+            void loadCampaign(campaign.id);
+          }}
+        />
+      ) : (
+        <RepairBay
+          repairBay={repairBay}
+          onReorder={handleReorder}
+          focusUnitId={focusUnitId}
+        />
+      )}
+    </PageLayout>
+  );
+}

--- a/src/pages/gameplay/campaigns/[id]/salvage.tsx
+++ b/src/pages/gameplay/campaigns/[id]/salvage.tsx
@@ -1,0 +1,112 @@
+/**
+ * Campaign Salvage Page
+ *
+ * The Salvage Acceptance panel — per-item accept / decline actions and a
+ * running mercenary-share value total (CP2a, design D5). Accept/decline
+ * flips the item `status` on the campaign's `salvageAllocations` via the
+ * persistence store.
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ */
+
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+
+import { BayError, BayLoading } from '@/components/campaign/bays/BayStates';
+import { SalvageAcceptancePanel } from '@/components/campaign/bays/SalvageAcceptancePanel';
+import { CampaignNavigation } from '@/components/campaign/CampaignNavigation';
+import { EmptyState, PageLayout } from '@/components/ui';
+import {
+  setSalvageItemStatus,
+  type SalvageDecision,
+} from '@/stores/campaign/campaignBayActions';
+import { selectSalvageBay } from '@/stores/campaign/campaignBaySelectors';
+import { useCampaignPersistenceStore } from '@/stores/campaign/useCampaignPersistenceStore';
+import { useCampaignStore } from '@/stores/campaign/useCampaignStore';
+
+export default function SalvagePage(): React.ReactElement {
+  const router = useRouter();
+  const { id } = router.query;
+  const store = useCampaignStore();
+  const campaign = store.getState().getCampaign();
+  const saveState = useCampaignPersistenceStore((state) => state.saveState);
+  const errorMessage = useCampaignPersistenceStore(
+    (state) => state.errorMessage,
+  );
+  const loadCampaign = useCampaignPersistenceStore(
+    (state) => state.loadCampaign,
+  );
+  const [isClient, setIsClient] = useState(false);
+  // Local re-render tick — bumped after a decision so the page re-reads
+  // the freshly re-projected inventory off the campaign store.
+  const [, setDecisionTick] = useState(0);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  const breadcrumbs = [
+    { label: 'Home', href: '/' },
+    { label: 'Gameplay', href: '/gameplay' },
+    { label: 'Campaigns', href: '/gameplay/campaigns' },
+    { label: campaign?.name || 'Campaign', href: `/gameplay/campaigns/${id}` },
+    { label: 'Salvage' },
+  ];
+
+  if (!isClient) {
+    return (
+      <PageLayout title="Salvage" subtitle="Loading bay..." maxWidth="wide">
+        <BayLoading />
+      </PageLayout>
+    );
+  }
+
+  if (!campaign) {
+    return (
+      <PageLayout
+        title="Salvage"
+        subtitle="Campaign not found"
+        maxWidth="wide"
+        breadcrumbs={breadcrumbs}
+      >
+        <EmptyState
+          title="Campaign not found"
+          message="Return to campaigns list to select a campaign."
+        />
+      </PageLayout>
+    );
+  }
+
+  const salvageBay = selectSalvageBay(campaign);
+
+  /** Record an accept/decline decision and re-render against the projection. */
+  const handleDecide = (partId: string, decision: SalvageDecision): void => {
+    setSalvageItemStatus(partId, decision);
+    setDecisionTick((tick) => tick + 1);
+  };
+
+  return (
+    <PageLayout
+      title="Salvage"
+      subtitle={`${campaign.name} — ${salvageBay.length} salvage candidates`}
+      maxWidth="wide"
+      breadcrumbs={breadcrumbs}
+    >
+      <CampaignNavigation campaignId={campaign.id} currentPage="salvage" />
+
+      {saveState === 'error' ? (
+        <BayError
+          message={errorMessage ?? 'The campaign inventory failed to load.'}
+          onRetry={() => {
+            void loadCampaign(campaign.id);
+          }}
+        />
+      ) : (
+        <SalvageAcceptancePanel
+          salvageBay={salvageBay}
+          onDecide={handleDecide}
+        />
+      )}
+    </PageLayout>
+  );
+}

--- a/src/stores/campaign/__tests__/campaignBayActions.test.ts
+++ b/src/stores/campaign/__tests__/campaignBayActions.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Campaign Bay Actions — integration tests
+ *
+ * Covers tasks.md 5.6 (accept/decline persists status), 3.5 (priority
+ * reorder persists the ordinal), and 6.2 (bay mutations mark the campaign
+ * dirty so the persistence store auto-saves).
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { IRepairTicket } from '@/types/campaign/RepairTicket';
+import type { ISalvageAllocation } from '@/types/campaign/Salvage';
+
+import { DamageLevel } from '@/types/campaign/Salvage';
+
+import {
+  reorderRepairTicketPriority,
+  setSalvageItemStatus,
+} from '../campaignBayActions';
+import { selectRepairBay, selectSalvageBay } from '../campaignBaySelectors';
+import { useCampaignPersistenceStore } from '../useCampaignPersistenceStore';
+import { useCampaignRosterStore } from '../useCampaignRosterStore';
+import { resetCampaignStore, useCampaignStore } from '../useCampaignStore';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeRepairTicket(
+  overrides: Partial<IRepairTicket> = {},
+): IRepairTicket {
+  return {
+    ticketId: 'ticket-1',
+    unitId: 'unit-atlas',
+    kind: 'armor',
+    location: 'CT',
+    expectedHours: 6,
+    partsRequired: [],
+    source: 'combat',
+    matchId: 'match-1',
+    createdAt: '3025-01-01T00:00:00.000Z',
+    status: 'queued',
+    ...overrides,
+  };
+}
+
+function makeAllocation(): ISalvageAllocation {
+  const candidate = {
+    source: 'unit' as const,
+    unitId: 'enemy-atlas',
+    designation: 'Atlas AS7-D',
+    destroyedFromBattle: 'match-1',
+    finalStatus: 'destroyed' as const,
+    damageLevel: DamageLevel.Heavy,
+    originalValue: 8_000_000,
+    recoveredValue: 2_000_000,
+    recoveryPercentage: 0.25,
+    repairCostEstimate: 500_000,
+    partId: 'salvage-atlas',
+    disposition: 'mercenary' as const,
+    status: 'pending' as const,
+  };
+  return {
+    pool: {
+      battleId: 'match-1',
+      contractId: 'contract-1',
+      candidates: [candidate],
+      totalEstimatedValue: 2_000_000,
+      hostileTerritory: false,
+    },
+    employerAward: {
+      side: 'employer',
+      candidates: [],
+      totalValue: 0,
+      estimatedRepairCost: 0,
+    },
+    mercenaryAward: {
+      side: 'mercenary',
+      candidates: [candidate],
+      totalValue: 2_000_000,
+      estimatedRepairCost: 500_000,
+    },
+    splitMethod: 'contract',
+    processed: false,
+  };
+}
+
+/**
+ * Seed the live campaign store with a campaign carrying a repair queue
+ * and a salvage allocation.
+ */
+function seedCampaign(): ICampaign {
+  const store = useCampaignStore();
+  store.getState().createCampaign('Test', 'mercenary');
+  const base = store.getState().getCampaign();
+  if (!base) throw new Error('campaign not created');
+
+  const seeded = {
+    ...base,
+    repairQueue: [
+      makeRepairTicket({ ticketId: 'ticket-1' }),
+      makeRepairTicket({ ticketId: 'ticket-2', expectedHours: 12 }),
+      makeRepairTicket({ ticketId: 'ticket-3', expectedHours: 18 }),
+    ],
+    salvageAllocations: { 'match-1': makeAllocation() },
+  } as Partial<ICampaign>;
+
+  store.getState().updateCampaign(seeded);
+  return store.getState().getCampaign() as ICampaign;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('campaignBayActions', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    resetCampaignStore();
+    useCampaignRosterStore.getState().reset();
+    useCampaignPersistenceStore.getState().reset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    resetCampaignStore();
+  });
+
+  describe('reorderRepairTicketPriority', () => {
+    it('writes ascending priority ordinals onto the named tickets', () => {
+      seedCampaign();
+      const result = reorderRepairTicketPriority([
+        'ticket-3',
+        'ticket-1',
+        'ticket-2',
+      ]);
+      expect(result.applied).toBe(true);
+
+      const campaign = useCampaignStore()
+        .getState()
+        .getCampaign() as ICampaign & {
+        repairQueue?: readonly IRepairTicket[];
+      };
+      const byId = new Map(
+        (campaign.repairQueue ?? []).map((t) => [t.ticketId, t.priority]),
+      );
+      expect(byId.get('ticket-3')).toBe(0);
+      expect(byId.get('ticket-1')).toBe(1);
+      expect(byId.get('ticket-2')).toBe(2);
+    });
+
+    it('marks the campaign dirty so the persistence store auto-saves', () => {
+      seedCampaign();
+      expect(useCampaignPersistenceStore.getState().dirty).toBe(false);
+      reorderRepairTicketPriority(['ticket-1', 'ticket-2', 'ticket-3']);
+      expect(useCampaignPersistenceStore.getState().dirty).toBe(true);
+    });
+
+    it('does not change ticket content — only work order', () => {
+      seedCampaign();
+      reorderRepairTicketPriority(['ticket-2', 'ticket-1']);
+      const repairBay = selectRepairBay(
+        useCampaignStore().getState().getCampaign(),
+      );
+      // The projected bay still carries every ticket's original content.
+      const ticket1 = repairBay.find((t) => t.ticketId === 'ticket-1');
+      expect(ticket1?.kind).toBe('armor');
+      expect(ticket1?.expectedHours).toBe(6);
+    });
+
+    it('reports applied=false when no campaign is loaded', () => {
+      const result = reorderRepairTicketPriority(['ticket-1']);
+      expect(result.applied).toBe(false);
+    });
+  });
+
+  describe('setSalvageItemStatus', () => {
+    it('flips a pending candidate to accepted on the salvage state', () => {
+      seedCampaign();
+      const result = setSalvageItemStatus('salvage-atlas', 'accepted');
+      expect(result.applied).toBe(true);
+
+      const salvageBay = selectSalvageBay(
+        useCampaignStore().getState().getCampaign(),
+      );
+      const item = salvageBay.find((s) => s.partId === 'salvage-atlas');
+      expect(item?.status).toBe('accepted');
+    });
+
+    it('flips a candidate to declined', () => {
+      seedCampaign();
+      setSalvageItemStatus('salvage-atlas', 'declined');
+      const salvageBay = selectSalvageBay(
+        useCampaignStore().getState().getCampaign(),
+      );
+      expect(salvageBay.find((s) => s.partId === 'salvage-atlas')?.status).toBe(
+        'declined',
+      );
+    });
+
+    it('marks the campaign dirty so the persistence store auto-saves', () => {
+      seedCampaign();
+      expect(useCampaignPersistenceStore.getState().dirty).toBe(false);
+      setSalvageItemStatus('salvage-atlas', 'accepted');
+      expect(useCampaignPersistenceStore.getState().dirty).toBe(true);
+    });
+
+    it('re-projects the inventory so the bay reflects the change immediately', () => {
+      seedCampaign();
+      // Before: no inventory has been projected yet (the day-advancement
+      // processor has not run), so the selector yields an empty bay.
+      let salvageBay = selectSalvageBay(
+        useCampaignStore().getState().getCampaign(),
+      );
+      expect(salvageBay).toEqual([]);
+
+      setSalvageItemStatus('salvage-atlas', 'accepted');
+
+      // After: the bay action re-projected the inventory off the mutated
+      // salvage state — the candidate now shows as accepted without
+      // waiting for the next day advancement (design D5).
+      salvageBay = selectSalvageBay(
+        useCampaignStore().getState().getCampaign(),
+      );
+      expect(salvageBay.find((s) => s.partId === 'salvage-atlas')?.status).toBe(
+        'accepted',
+      );
+    });
+
+    it('reports applied=false when no campaign is loaded', () => {
+      const result = setSalvageItemStatus('salvage-atlas', 'accepted');
+      expect(result.applied).toBe(false);
+    });
+  });
+});

--- a/src/stores/campaign/__tests__/campaignBaySelectors.test.ts
+++ b/src/stores/campaign/__tests__/campaignBaySelectors.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Campaign Bay Selectors — unit tests
+ *
+ * Covers tasks.md 1.3: selectors return the expected projections from a
+ * populated campaign and empty arrays / a zeroed summary from a
+ * battle-free campaign.
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICampaignInventory } from '@/types/campaign/CampaignInventory';
+
+import {
+  SAMPLE_MEDICAL_BAY,
+  SAMPLE_REPAIR_BAY,
+  SAMPLE_SALVAGE_BAY,
+} from '@/components/campaign/bays/__fixtures__/bayFixtures';
+import { createCampaign } from '@/types/campaign/Campaign';
+
+import {
+  computeAcceptedSalvageValue,
+  groupRepairBayByUnit,
+  selectCampaignInventory,
+  selectInventorySummary,
+  selectMedicalBay,
+  selectRepairBay,
+  selectRepairTicketCountForUnit,
+  selectSalvageBay,
+} from '../campaignBaySelectors';
+
+function makeInventory(): ICampaignInventory {
+  return {
+    campaignId: 'campaign-1',
+    generatedAt: '3025-01-01T00:00:00.000Z',
+    repairBay: SAMPLE_REPAIR_BAY,
+    salvageBay: SAMPLE_SALVAGE_BAY,
+    medicalBay: SAMPLE_MEDICAL_BAY,
+    summary: {
+      repairTicketCount: SAMPLE_REPAIR_BAY.length,
+      totalRepairHours: 37,
+      salvageValueTotal: 4_260_000,
+      pilotsInMedical: SAMPLE_MEDICAL_BAY.length,
+    },
+  };
+}
+
+/** A campaign carrying a projected inventory. */
+function populatedCampaign(): ICampaign {
+  const base = createCampaign('Test', 'mercenary');
+  return { ...base, campaignInventory: makeInventory() } as ICampaign;
+}
+
+/** A campaign with no battles fought — no inventory attached. */
+function battleFreeCampaign(): ICampaign {
+  return createCampaign('Fresh', 'mercenary');
+}
+
+describe('campaignBaySelectors', () => {
+  describe('populated campaign', () => {
+    const campaign = populatedCampaign();
+
+    it('selectCampaignInventory returns the attached inventory', () => {
+      expect(selectCampaignInventory(campaign)).not.toBeNull();
+      expect(selectCampaignInventory(campaign)?.campaignId).toBe('campaign-1');
+    });
+
+    it('selectRepairBay returns the repair-bay projection', () => {
+      expect(selectRepairBay(campaign)).toEqual(SAMPLE_REPAIR_BAY);
+    });
+
+    it('selectSalvageBay returns the salvage-bay projection', () => {
+      expect(selectSalvageBay(campaign)).toEqual(SAMPLE_SALVAGE_BAY);
+    });
+
+    it('selectMedicalBay returns the medical-bay projection', () => {
+      expect(selectMedicalBay(campaign)).toEqual(SAMPLE_MEDICAL_BAY);
+    });
+
+    it('selectInventorySummary returns the roll-up summary', () => {
+      const summary = selectInventorySummary(campaign);
+      expect(summary.repairTicketCount).toBe(SAMPLE_REPAIR_BAY.length);
+      expect(summary.pilotsInMedical).toBe(SAMPLE_MEDICAL_BAY.length);
+    });
+  });
+
+  describe('battle-free campaign', () => {
+    const campaign = battleFreeCampaign();
+
+    it('selectCampaignInventory returns null', () => {
+      expect(selectCampaignInventory(campaign)).toBeNull();
+    });
+
+    it('selectRepairBay returns an empty array', () => {
+      expect(selectRepairBay(campaign)).toEqual([]);
+    });
+
+    it('selectSalvageBay returns an empty array', () => {
+      expect(selectSalvageBay(campaign)).toEqual([]);
+    });
+
+    it('selectMedicalBay returns an empty array', () => {
+      expect(selectMedicalBay(campaign)).toEqual([]);
+    });
+
+    it('selectInventorySummary returns a zeroed summary', () => {
+      expect(selectInventorySummary(campaign)).toEqual({
+        repairTicketCount: 0,
+        totalRepairHours: 0,
+        salvageValueTotal: 0,
+        pilotsInMedical: 0,
+      });
+    });
+  });
+
+  describe('null campaign', () => {
+    it('every selector degrades gracefully', () => {
+      expect(selectCampaignInventory(null)).toBeNull();
+      expect(selectRepairBay(null)).toEqual([]);
+      expect(selectSalvageBay(null)).toEqual([]);
+      expect(selectMedicalBay(null)).toEqual([]);
+      expect(selectInventorySummary(null).repairTicketCount).toBe(0);
+    });
+  });
+
+  describe('derived helpers', () => {
+    const campaign = populatedCampaign();
+
+    it('selectRepairTicketCountForUnit counts tickets per unit', () => {
+      expect(selectRepairTicketCountForUnit(campaign, 'unit-atlas')).toBe(3);
+      expect(selectRepairTicketCountForUnit(campaign, 'unit-locust')).toBe(1);
+      expect(selectRepairTicketCountForUnit(campaign, 'unit-unknown')).toBe(0);
+    });
+
+    it('groupRepairBayByUnit groups items by unitId', () => {
+      const grouped = groupRepairBayByUnit(SAMPLE_REPAIR_BAY);
+      expect(grouped.get('unit-atlas')?.length).toBe(3);
+      expect(grouped.get('unit-locust')?.length).toBe(1);
+    });
+
+    it('computeAcceptedSalvageValue sums only accepted items', () => {
+      // SAMPLE_SALVAGE_BAY has exactly one `accepted` item at 200_000.
+      expect(computeAcceptedSalvageValue(SAMPLE_SALVAGE_BAY)).toBe(200_000);
+    });
+
+    it('computeAcceptedSalvageValue excludes declined and pending items', () => {
+      const allDeclined = SAMPLE_SALVAGE_BAY.map((item) => ({
+        ...item,
+        status: 'declined' as const,
+      }));
+      expect(computeAcceptedSalvageValue(allDeclined)).toBe(0);
+    });
+  });
+});

--- a/src/stores/campaign/campaignBayActions.ts
+++ b/src/stores/campaign/campaignBayActions.ts
@@ -1,0 +1,228 @@
+/**
+ * Campaign Bay Actions
+ *
+ * The three small value-bearing mutations the post-battle bay UI (CP2a —
+ * `add-campaign-bay-ui`) performs over existing campaign state:
+ *
+ *  1. `reorderRepairTicketPriority` — writes a `priority` ordinal onto the
+ *     campaign's `repairQueue` tickets (design D3).
+ *  2. `setSalvageItemStatus` — flips a salvage candidate's `status`
+ *     (`pending → accepted | declined`) on the campaign's
+ *     `salvageAllocations` mercenary award (design D5).
+ *
+ * Per design D6 every mutation routes through `useCampaignStore.updateCampaign`
+ * (which writes the live `ICampaign`) and then marks the campaign dirty via
+ * `useCampaignPersistenceStore.markDirty()` so the debounced auto-save (CP0)
+ * picks it up. No bay surface writes to the server directly.
+ *
+ * These actions do NOT add business logic — the repair / salvage engines
+ * compute ticket content and recovered value; this module only records the
+ * player's work-order and accept/decline decisions.
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ * @module stores/campaign/campaignBayActions
+ */
+
+import type { IInventoryProjectionSources } from '@/lib/campaign/inventory/projectCampaignInventory';
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { IRepairTicket } from '@/types/campaign/RepairTicket';
+import type { ISalvageAllocation } from '@/types/campaign/Salvage';
+
+import { projectCampaignInventory } from '@/lib/campaign/inventory/projectCampaignInventory';
+
+import { getCampaignStoreForRoster } from './campaignStoreAccessor';
+import { useCampaignPersistenceStore } from './useCampaignPersistenceStore';
+import { useCampaignRosterStore } from './useCampaignRosterStore';
+// Importing the campaign-store module registers the store accessor as a
+// side effect (`registerCampaignStoreAccessor` runs at module load), so
+// `getCampaignStoreForRoster()` resolves without this module calling the
+// `useCampaignStore` accessor (which the React-hooks lint rule forbids
+// outside a component).
+import './useCampaignStore';
+
+// =============================================================================
+// Campaign Mutation Surface
+// =============================================================================
+
+/** Campaign narrowed to the repair-queue / salvage write surface. */
+type ICampaignWithBays = ICampaign & IInventoryProjectionSources;
+
+/**
+ * Apply a campaign mutation through the live campaign store and mark the
+ * campaign dirty so the persistence store's debounced auto-save fires
+ * (design D6). Shared by every bay action.
+ *
+ * @param mutate - pure transform producing the next campaign extension fields
+ */
+function applyCampaignMutation(
+  mutate: (campaign: ICampaignWithBays) => Partial<ICampaign>,
+): void {
+  const store = getCampaignStoreForRoster();
+  if (!store) return;
+  const campaign = store.getState().campaign as ICampaignWithBays | null;
+  if (!campaign) return;
+
+  const updates = mutate(campaign);
+  // Merge the mutation onto the campaign so the inventory re-projection
+  // below sees the new `repairQueue` / `salvageAllocations` state.
+  const mutated = { ...campaign, ...updates } as ICampaignWithBays;
+
+  // The frozen `ICampaignInventory` is a derived projection — it is
+  // normally recomputed by the day-advancement `inventoryProjectionProcessor`.
+  // A bay mutation between days must re-project so the bay surfaces and the
+  // running salvage-value total reflect the change immediately rather than
+  // waiting for the next day (design D5 — the total is a pure projection).
+  const rosterPilots = useCampaignRosterStore.getState().pilots;
+  const inventory = projectCampaignInventory(
+    mutated,
+    rosterPilots,
+    new Date().toISOString(),
+  );
+
+  store.getState().updateCampaign({
+    ...updates,
+    campaignInventory: inventory,
+  } as Partial<ICampaign>);
+  // Route through the persistence store so the debounced auto-save picks
+  // up the change (design D6). No direct server write.
+  useCampaignPersistenceStore.getState().markDirty();
+}
+
+// =============================================================================
+// Repair Bay — Priority Reorder
+// =============================================================================
+
+/**
+ * Result of a priority-reorder request.
+ */
+export interface IReorderResult {
+  /** True when the reorder was applied (campaign loaded, ticket found). */
+  readonly applied: boolean;
+}
+
+/**
+ * Reorder the repair queue by writing fresh `priority` ordinals.
+ *
+ * The caller supplies the desired ticket-id order (the post-drag order
+ * of one unit's group, or the whole queue). Each id in `orderedTicketIds`
+ * receives an ascending ordinal (0, 1, 2, …) on its `IRepairTicket`;
+ * tickets not named keep their existing `priority`. Ticket content is
+ * untouched — only work order changes (design D3).
+ *
+ * Marks the campaign dirty so the persistence store auto-saves
+ * (design D6 — the reorder mutates the live `ICampaign`).
+ *
+ * @param orderedTicketIds - ticket ids in their new work order
+ */
+export function reorderRepairTicketPriority(
+  orderedTicketIds: readonly string[],
+): IReorderResult {
+  let applied = false;
+
+  applyCampaignMutation((campaign) => {
+    const queue = campaign.repairQueue ?? [];
+    // Map ticket id → its new ordinal. Tickets absent from the request
+    // keep whatever priority they already carried.
+    const ordinalById = new Map<string, number>();
+    orderedTicketIds.forEach((ticketId, index) => {
+      ordinalById.set(ticketId, index);
+    });
+
+    const nextQueue: IRepairTicket[] = queue.map((ticket) => {
+      const ordinal = ordinalById.get(ticket.ticketId);
+      if (ordinal === undefined) return ticket;
+      applied = true;
+      return { ...ticket, priority: ordinal };
+    });
+
+    return { repairQueue: nextQueue } as Partial<ICampaign>;
+  });
+
+  return { applied };
+}
+
+// =============================================================================
+// Salvage Bay — Accept / Decline
+// =============================================================================
+
+/**
+ * The frozen-schema status a salvage item can be moved to by the UI.
+ * (`pending` is the engine's initial state; the player only sets the
+ * two terminal decisions.)
+ */
+export type SalvageDecision = 'accepted' | 'declined';
+
+/**
+ * Result of a salvage accept/decline request.
+ */
+export interface ISalvageDecisionResult {
+  /** True when the decision was applied (campaign loaded, candidate found). */
+  readonly applied: boolean;
+}
+
+/**
+ * Map the bay UI's `accepted | declined` decision onto the engine's
+ * `ISalvageCandidate.status` vocabulary. The engine uses `awarded` for an
+ * accepted candidate (`projectCampaignInventory.mapSalvageStatus` collapses
+ * `awarded` → `accepted` on the way back out); `declined` is shared.
+ */
+function decisionToCandidateStatus(
+  decision: SalvageDecision,
+): 'awarded' | 'declined' {
+  return decision === 'accepted' ? 'awarded' : 'declined';
+}
+
+/**
+ * Record the player's accept/decline decision on a salvage candidate.
+ *
+ * Finds the candidate by `partId` (falling back to its `unitId`, matching
+ * the projection's `partId ?? unitId` rule) inside every allocation's
+ * mercenary award and flips its `status`. The salvage *computation*
+ * (recovered value, disposition) is untouched — this only records the
+ * player's decision on already-computed candidates (design D5).
+ *
+ * Marks the campaign dirty so the persistence store auto-saves (design D6).
+ *
+ * @param partId - the salvage item id (`ISalvageBayItem.partId`)
+ * @param decision - `accepted` or `declined`
+ */
+export function setSalvageItemStatus(
+  partId: string,
+  decision: SalvageDecision,
+): ISalvageDecisionResult {
+  let applied = false;
+  const nextStatus = decisionToCandidateStatus(decision);
+
+  applyCampaignMutation((campaign) => {
+    const allocations = campaign.salvageAllocations ?? {};
+    const nextAllocations: Record<string, ISalvageAllocation> = {};
+
+    for (const [battleId, allocation] of Object.entries(allocations)) {
+      const nextCandidates = allocation.mercenaryAward.candidates.map(
+        (candidate) => {
+          // `projectCampaignInventory` derives the bay item's `partId`
+          // as `candidate.partId ?? candidate.unitId` — match the same
+          // rule so the UI's id resolves back to the right candidate.
+          const candidateId = candidate.partId ?? candidate.unitId;
+          if (candidateId !== partId) return candidate;
+          applied = true;
+          return { ...candidate, status: nextStatus };
+        },
+      );
+
+      nextAllocations[battleId] = {
+        ...allocation,
+        mercenaryAward: {
+          ...allocation.mercenaryAward,
+          candidates: nextCandidates,
+        },
+      };
+    }
+
+    return {
+      salvageAllocations: nextAllocations,
+    } as Partial<ICampaign>;
+  });
+
+  return { applied };
+}

--- a/src/stores/campaign/campaignBaySelectors.ts
+++ b/src/stores/campaign/campaignBaySelectors.ts
@@ -1,0 +1,171 @@
+/**
+ * Campaign Bay Selectors
+ *
+ * Typed read selectors over the frozen `ICampaignInventory` projection
+ * (CP1 — `add-campaign-combat-loop`) consumed by the post-battle bay UI
+ * (CP2a — `add-campaign-bay-ui`).
+ *
+ * The inventory is attached to the campaign as `campaign.campaignInventory`
+ * by the `inventoryProjectionProcessor` (a `CLEANUP`-phase day processor).
+ * A campaign with no battles fought has no inventory yet — every selector
+ * degrades gracefully to an empty projection so the bay surfaces render an
+ * empty state rather than crashing.
+ *
+ * These are PURE functions of an `ICampaign` — no store subscription, no
+ * mutation. Bay pages call them against `getCampaign()`.
+ *
+ * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
+ * @module stores/campaign/campaignBaySelectors
+ */
+
+import type { IInventoryCampaignExtensions } from '@/lib/campaign/processors/inventoryProjectionProcessor';
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type {
+  ICampaignInventory,
+  IInventorySummary,
+  IMedicalBayItem,
+  IRepairBayItem,
+  ISalvageBayItem,
+} from '@/types/campaign/CampaignInventory';
+
+// =============================================================================
+// Empty Projection Constants
+// =============================================================================
+
+/**
+ * The zeroed summary returned when a campaign has no inventory. Frozen so
+ * every battle-free campaign shares one stable reference (selector-safe).
+ */
+const EMPTY_SUMMARY: IInventorySummary = Object.freeze({
+  repairTicketCount: 0,
+  totalRepairHours: 0,
+  salvageValueTotal: 0,
+  pilotsInMedical: 0,
+});
+
+/** Frozen empty bay array — shared so selectors return a stable reference. */
+const EMPTY_REPAIR_BAY: readonly IRepairBayItem[] = Object.freeze([]);
+const EMPTY_SALVAGE_BAY: readonly ISalvageBayItem[] = Object.freeze([]);
+const EMPTY_MEDICAL_BAY: readonly IMedicalBayItem[] = Object.freeze([]);
+
+// =============================================================================
+// Inventory Access
+// =============================================================================
+
+/**
+ * Read the frozen `ICampaignInventory` off a campaign, or `null` when the
+ * campaign has not yet projected one (no battles fought).
+ *
+ * @param campaign - the live campaign, or `null` when none is loaded
+ */
+export function selectCampaignInventory(
+  campaign: ICampaign | null,
+): ICampaignInventory | null {
+  if (!campaign) return null;
+  const extended = campaign as ICampaign & IInventoryCampaignExtensions;
+  return extended.campaignInventory ?? null;
+}
+
+// =============================================================================
+// Bay Selectors
+// =============================================================================
+
+/**
+ * Project the repair-bay line items. Returns an empty array for a
+ * battle-free campaign.
+ */
+export function selectRepairBay(
+  campaign: ICampaign | null,
+): readonly IRepairBayItem[] {
+  return selectCampaignInventory(campaign)?.repairBay ?? EMPTY_REPAIR_BAY;
+}
+
+/**
+ * Project the salvage-bay line items. Returns an empty array for a
+ * battle-free campaign.
+ */
+export function selectSalvageBay(
+  campaign: ICampaign | null,
+): readonly ISalvageBayItem[] {
+  return selectCampaignInventory(campaign)?.salvageBay ?? EMPTY_SALVAGE_BAY;
+}
+
+/**
+ * Project the medical-bay line items. Returns an empty array for a
+ * campaign with no injured pilots.
+ */
+export function selectMedicalBay(
+  campaign: ICampaign | null,
+): readonly IMedicalBayItem[] {
+  return selectCampaignInventory(campaign)?.medicalBay ?? EMPTY_MEDICAL_BAY;
+}
+
+/**
+ * Project the roll-up inventory summary. Returns a zeroed summary for a
+ * battle-free campaign.
+ */
+export function selectInventorySummary(
+  campaign: ICampaign | null,
+): IInventorySummary {
+  return selectCampaignInventory(campaign)?.summary ?? EMPTY_SUMMARY;
+}
+
+// =============================================================================
+// Derived Bay Helpers
+// =============================================================================
+
+/**
+ * Count the repair-bay tickets targeting a given unit. Used by the Mech
+ * Bay grid to show a per-unit ticket count without re-grouping the whole
+ * queue at every row.
+ *
+ * @param campaign - the live campaign
+ * @param unitId - the roster unit id
+ */
+export function selectRepairTicketCountForUnit(
+  campaign: ICampaign | null,
+  unitId: string,
+): number {
+  return selectRepairBay(campaign).filter((item) => item.unitId === unitId)
+    .length;
+}
+
+/**
+ * Group repair-bay items by `unitId` for the Repair Bay's per-unit
+ * ticket grouping. The returned map preserves the queue's encounter
+ * order within each group.
+ *
+ * @param items - repair-bay line items (typically `selectRepairBay(...)`)
+ */
+export function groupRepairBayByUnit(
+  items: readonly IRepairBayItem[],
+): ReadonlyMap<string, readonly IRepairBayItem[]> {
+  const grouped = new Map<string, IRepairBayItem[]>();
+  for (const item of items) {
+    const bucket = grouped.get(item.unitId);
+    if (bucket) {
+      bucket.push(item);
+    } else {
+      grouped.set(item.unitId, [item]);
+    }
+  }
+  return grouped;
+}
+
+/**
+ * Sum the recovered value of every salvage item the player has accepted.
+ *
+ * This is the running mercenary-share value total (design D5): a PURE
+ * projection over item `status` — only `accepted` items contribute, so
+ * toggling one item's status recomputes the total without any
+ * incremental accumulator that could double-count (design Risk note).
+ *
+ * @param items - salvage-bay line items (typically `selectSalvageBay(...)`)
+ */
+export function computeAcceptedSalvageValue(
+  items: readonly ISalvageBayItem[],
+): number {
+  return items
+    .filter((item) => item.status === 'accepted')
+    .reduce((sum, item) => sum + item.recoveredValue, 0);
+}

--- a/src/types/campaign/RepairTicket.ts
+++ b/src/types/campaign/RepairTicket.ts
@@ -119,4 +119,15 @@ export interface IRepairTicket {
 
   /** Current lifecycle status */
   readonly status: RepairTicketStatus;
+
+  /**
+   * Player-set repair-order ordinal, written by the Repair Bay UI's
+   * priority-reorder action (`add-campaign-bay-ui` CP2a, design D3).
+   *
+   * Lower numbers are worked first. Absent until the player reorders
+   * the queue; the day-advancement repair processor reads this ordinal
+   * (when present) to choose which ticket a tech picks up next. Setting
+   * it does not change ticket content — only work order.
+   */
+  readonly priority?: number;
 }


### PR DESCRIPTION
## Summary

Implements OpenSpec change `add-campaign-bay-ui` (Wave 4, CP2a) — the four post-battle bay UI surfaces rendering the frozen `ICampaignInventory` projection from CP1.

- **Mech Bay** (`/mech-bay`): roster-wide unit-status grid — damage state, repair-ticket count, drill-down into each unit's Repair Bay detail.
- **Repair Bay** (`/repair-bay`): `repairBay` ticket queue grouped by unit; per-ticket kind/location/expected-hours/parts-ready/status; priority-reorder action writing a `priority` ordinal onto `repairQueue`.
- **Medical Bay** (`/medical-bay`): read-only injured-pilot list; recovery copy makes clear healing happens on day advancement.
- **Salvage Acceptance** (`/salvage`): per-item accept/decline; running mercenary-share value total as a pure projection over item status.
- **"Bays" navigation group** linking the four surfaces.
- Typed `campaignBaySelectors` over `ICampaignInventory`; `campaignBayActions` routing mutations through the persistence store (marks dirty → debounced auto-save).

Every requirement and scenario in the delta spec is covered. The `ICampaignInventory` schema is untouched (CP1-frozen). One additive field: optional `priority` on `IRepairTicket` (not a frozen type) per design D3.

## Verification

- `tsc --noEmit` — zero errors
- `oxlint` — 0 warnings, 0 errors
- `jest` — 61 new bay tests; 284 campaign-area tests pass, no regressions
- `openspec validate add-campaign-bay-ui --strict` — valid
- `storybook build` — built (4 new stories, populated/empty/error variants each)
- BV parity / determinism — untouched (UI-only change)

## Notes

- Bay mutations re-project `ICampaignInventory` immediately so the surfaces and the running salvage total reflect changes between day advancements (design D5), rather than waiting for the next `inventoryProjectionProcessor` run.
- Open Question (design): two routes under one nav group, not tabs — followed the proposed per-concern page convention.
- The OpenSpec change is not archived.