### PR TITLE
feat(campaign): unit refit and mercenary prestige

### DIFF
--- a/openspec/changes/add-campaign-refit-and-prestige/tasks.md
+++ b/openspec/changes/add-campaign-refit-and-prestige/tasks.md
@@ -2,61 +2,61 @@
 
 ## 1. Refit Types and Classification
 
-- [ ] 1.1 Add `IRefitOrder`, the `RefitClass` enum, and an optional `refitOrders` campaign field defaulting to an empty list
-- [ ] 1.2 Implement `classifyRefit(currentConfig, targetConfig)` — diff the configurations and return the least-disruptive covering refit class
-- [ ] 1.3 Tests: equipment swap, variant upgrade, and chassis conversion each classify correctly; an identical target classifies as the cheapest class or none
+- [x] 1.1 Add `IRefitOrder`, the `RefitClass` enum, and an optional `refitOrders` campaign field defaulting to an empty list
+- [x] 1.2 Implement `classifyRefit(currentConfig, targetConfig)` — diff the configurations and return the least-disruptive covering refit class
+- [x] 1.3 Tests: equipment swap, variant upgrade, and chassis conversion each classify correctly; an identical target classifies as the cheapest class or none
 
 ## 2. Refit Cost and Hours Estimation
 
-- [ ] 2.1 Implement `estimateRefit(order)` — cost and tech-hours from the configuration diff and a per-`RefitClass` multiplier, mirroring the repair hour-table approach
-- [ ] 2.2 Tests: an equipment swap estimates lower cost/hours than a chassis conversion; the estimate is deterministic for a given diff
+- [x] 2.1 Implement `estimateRefit(order)` — cost and tech-hours from the configuration diff and a per-`RefitClass` multiplier, mirroring the repair hour-table approach
+- [x] 2.2 Tests: an equipment swap estimates lower cost/hours than a chassis conversion; the estimate is deterministic for a given diff
 
 ## 3. Refit Construction Validation Gate
 
-- [ ] 3.1 Gate the `proposed → in-progress` transition on the target configuration passing existing `construction-rules-core` validation
-- [ ] 3.2 An invalid target keeps the order `proposed` and surfaces the validation errors
-- [ ] 3.3 Tests: a valid target advances to `in-progress`; an invalid target stays `proposed` with errors
+- [x] 3.1 Gate the `proposed → in-progress` transition on the target configuration passing existing `construction-rules-core` validation
+- [x] 3.2 An invalid target keeps the order `proposed` and surfaces the validation errors
+- [x] 3.3 Tests: a valid target advances to `in-progress`; an invalid target stays `proposed` with errors
 
 ## 4. Refit Day Processor
 
-- [ ] 4.1 Implement `refitProcessor` in the `UNITS` phase block — advance each `in-progress` refit by the day's available tech-hours
-- [ ] 4.2 On `hoursCompleted >= estimatedHours`, complete the refit — replace the unit's campaign configuration with `targetConfiguration` and emit a day event
-- [ ] 4.3 Register `refitProcessor` in `processorRegistration.ts`
-- [ ] 4.4 Tests: an in-progress refit advances per day, completes when the hour budget is met, swaps the configuration; a campaign with no refits is a no-op
+- [x] 4.1 Implement `refitProcessor` in the `UNITS` phase block — advance each `in-progress` refit by the day's available tech-hours
+- [x] 4.2 On `hoursCompleted >= estimatedHours`, complete the refit — replace the unit's campaign configuration with `targetConfiguration` and emit a day event
+- [x] 4.3 Register `refitProcessor` in `processorRegistration.ts`
+- [x] 4.4 Tests: an in-progress refit advances per day, completes when the hour budget is met, swaps the configuration; a campaign with no refits is a no-op
 
 ## 5. Refit Launch from the Mech Bay
 
-- [ ] 5.1 Add a per-unit "Refit" affordance to the mech bay (CP2a) opening a refit launch flow
-- [ ] 5.2 Build the launch flow — choose a target configuration, show the classified refit class with estimated cost and hours, commit
-- [ ] 5.3 Committing creates a `proposed` `IRefitOrder` and, on construction-validation pass, moves it to `in-progress`
-- [ ] 5.4 Tests: the launch flow classifies and estimates correctly; commit creates the order and gates on validation
+- [x] 5.1 Add a per-unit "Refit" affordance to the mech bay (CP2a) opening a refit launch flow
+- [x] 5.2 Build the launch flow — choose a target configuration, show the classified refit class with estimated cost and hours, commit
+- [x] 5.3 Committing creates a `proposed` `IRefitOrder` and, on construction-validation pass, moves it to `in-progress`
+- [x] 5.4 Tests: the launch flow classifies and estimates correctly; commit creates the order and gates on validation
 
 ## 6. Unit Prestige
 
-- [ ] 6.1 Add `IUnitPrestige` and an optional `unitPrestige` campaign field defaulting to an empty list
-- [ ] 6.2 Implement `adjustPrestige(unit, signal)` — bounded score raised by victories/notable performance, lowered by heavy damage/crew loss
-- [ ] 6.3 Run a prestige-update step when a battle outcome is applied (post-battle)
-- [ ] 6.4 Tests: a victory raises prestige, heavy damage lowers it, the score stays within bounds, updates are deterministic
+- [x] 6.1 Add `IUnitPrestige` and an optional `unitPrestige` campaign field defaulting to an empty list
+- [x] 6.2 Implement `adjustPrestige(unit, signal)` — bounded score raised by victories/notable performance, lowered by heavy damage/crew loss
+- [x] 6.3 Run a prestige-update step when a battle outcome is applied (post-battle)
+- [x] 6.4 Tests: a victory raises prestige, heavy damage lowers it, the score stays within bounds, updates are deterministic
 
 ## 7. Company Morale State Machine
 
-- [ ] 7.1 Add the `MoraleState` enum and an optional `moraleState` campaign field defaulting to `MoraleState.Steady`
-- [ ] 7.2 Implement `evaluateMoraleTransition(campaign, signals)` — at most one step transition per day from the enumerated signal set
-- [ ] 7.3 Implement `moraleProcessor` in the `EVENTS` phase block — gather signals, apply the transition, emit a day event on change
-- [ ] 7.4 Register `moraleProcessor` in `processorRegistration.ts`
-- [ ] 7.5 Tests: morale moves at most one step per day; victories raise it, defeats/missed pay/desertions lower it; no signal yields no transition
+- [x] 7.1 Add the `MoraleState` enum and an optional `moraleState` campaign field defaulting to `MoraleState.Steady`
+- [x] 7.2 Implement `evaluateMoraleTransition(campaign, signals)` — at most one step transition per day from the enumerated signal set
+- [x] 7.3 Implement `moraleProcessor` in the `EVENTS` phase block — gather signals, apply the transition, emit a day event on change
+- [x] 7.4 Register `moraleProcessor` in `processorRegistration.ts`
+- [x] 7.5 Tests: morale moves at most one step per day; victories raise it, defeats/missed pay/desertions lower it; no signal yields no transition
 
 ## 8. Prestige & Morale UI Surface
 
-- [ ] 8.1 Build the Prestige & Morale page — current `MoraleState`, recent transitions, and per-unit prestige scores
-- [ ] 8.2 Add a campaign-navigation entry for the surface
-- [ ] 8.3 Implement loading, empty, and error states matching `campaign-ui` conventions
-- [ ] 8.4 Storybook story with populated, empty, and error variants
-- [ ] 8.5 Render tests: morale state, transition history, prestige scores; the page exposes no mutation controls
+- [x] 8.1 Build the Prestige & Morale page — current `MoraleState`, recent transitions, and per-unit prestige scores
+- [x] 8.2 Add a campaign-navigation entry for the surface
+- [x] 8.3 Implement loading, empty, and error states matching `campaign-ui` conventions
+- [x] 8.4 Storybook story with populated, empty, and error variants
+- [x] 8.5 Render tests: morale state, transition history, prestige scores; the page exposes no mutation controls
 
 ## 9. Verification
 
-- [ ] 9.1 Integration test: launch a refit from the mech bay, advance days until it completes, the unit configuration is swapped
-- [ ] 9.2 Integration test: a sequence of victories and defeats moves the company morale state and updates per-unit prestige
-- [ ] 9.3 `openspec validate add-campaign-refit-and-prestige --strict` clean
-- [ ] 9.4 Build, lint, typecheck, and storybook-build pass
+- [x] 9.1 Integration test: launch a refit from the mech bay, advance days until it completes, the unit configuration is swapped
+- [x] 9.2 Integration test: a sequence of victories and defeats moves the company morale state and updates per-unit prestige
+- [x] 9.3 `openspec validate add-campaign-refit-and-prestige --strict` clean
+- [x] 9.4 Build, lint, typecheck, and storybook-build pass

--- a/src/components/campaign/CampaignNavigation.tsx
+++ b/src/components/campaign/CampaignNavigation.tsx
@@ -32,7 +32,8 @@ export type CampaignPageId =
   | 'salvage'
   | 'hiring'
   | 'finances'
-  | 'contract-market';
+  | 'contract-market'
+  | 'prestige-morale';
 
 interface CampaignNavigationProps {
   campaignId: string;
@@ -112,6 +113,14 @@ export function CampaignNavigation({
       id: 'contract-market',
       label: 'Contract Market',
       href: `/gameplay/campaigns/${campaignId}/contract-market`,
+    },
+    // The Prestige & Morale surface (CP3 — `add-campaign-refit-and-prestige`,
+    // design D10) — a company-level read-only surface, grouped with the
+    // other command-tier surfaces.
+    {
+      id: 'prestige-morale',
+      label: 'Prestige & Morale',
+      href: `/gameplay/campaigns/${campaignId}/prestige-morale`,
     },
   ];
 

--- a/src/components/campaign/bays/MechBay.tsx
+++ b/src/components/campaign/bays/MechBay.tsx
@@ -57,16 +57,24 @@ interface MechBayRowProps {
   readonly ticketCount: number;
   /** Campaign id — used to build the Repair Bay drill-down link. */
   readonly campaignId: string;
+  /**
+   * Open the refit launch flow for this unit (CP3 — design D6). When
+   * omitted, the Refit affordance is hidden (e.g. in a Storybook fixture
+   * without a refit handler wired).
+   */
+  readonly onLaunchRefit?: (unitId: string) => void;
 }
 
 /**
  * One Mech Bay grid row. Shows the unit's damage state and repair-ticket
- * count, and drills into the unit's Repair Bay detail.
+ * count, drills into the unit's Repair Bay detail, and (CP3) opens the
+ * refit launch flow.
  */
 export function MechBayRow({
   unit,
   ticketCount,
   campaignId,
+  onLaunchRefit,
 }: MechBayRowProps): React.ReactElement {
   return (
     <Card className="p-4" data-testid={`mech-bay-row-${unit.unitId}`}>
@@ -92,6 +100,17 @@ export function MechBayRow({
             {ticketCount} {ticketCount === 1 ? 'ticket' : 'tickets'}
           </span>
 
+          {onLaunchRefit ? (
+            <button
+              type="button"
+              onClick={() => onLaunchRefit(unit.unitId)}
+              className="text-accent hover:text-accent/80 text-sm font-medium transition-colors"
+              data-testid={`mech-bay-refit-${unit.unitId}`}
+            >
+              Refit
+            </button>
+          ) : null}
+
           <Link
             href={`/gameplay/campaigns/${campaignId}/repair-bay?unit=${encodeURIComponent(unit.unitId)}`}
             className="text-accent hover:text-accent/80 text-sm font-medium transition-colors"
@@ -116,6 +135,11 @@ export interface MechBayProps {
   readonly repairBay: readonly IRepairBayItem[];
   /** Campaign id — used for drill-down links. */
   readonly campaignId: string;
+  /**
+   * Open the refit launch flow for a unit (CP3 — design D6). When
+   * omitted, the per-row Refit affordance is hidden.
+   */
+  readonly onLaunchRefit?: (unitId: string) => void;
 }
 
 /**
@@ -126,6 +150,7 @@ export function MechBay({
   units,
   repairBay,
   campaignId,
+  onLaunchRefit,
 }: MechBayProps): React.ReactElement {
   if (units.length === 0) {
     return (
@@ -153,6 +178,7 @@ export function MechBay({
           unit={unit}
           ticketCount={ticketCountByUnit.get(unit.unitId) ?? 0}
           campaignId={campaignId}
+          onLaunchRefit={onLaunchRefit}
         />
       ))}
     </div>

--- a/src/components/campaign/bays/RefitLaunchPanel.stories.tsx
+++ b/src/components/campaign/bays/RefitLaunchPanel.stories.tsx
@@ -1,0 +1,76 @@
+/**
+ * Refit Launch Panel — Storybook stories
+ *
+ * Covers the refit launch flow (CP3 — `add-campaign-refit-and-prestige`,
+ * design D6): a target-configuration editor with a live class + estimate
+ * and a commit action.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { createRefitOrder } from '@/lib/campaign/refit/refitPipeline';
+import { DEFAULT_UNIT_CONFIGURATION } from '@/lib/campaign/refit/unitConfiguration';
+
+import { RefitLaunchPanel } from './RefitLaunchPanel';
+
+const meta = {
+  title: 'Campaign/Bays/RefitLaunchPanel',
+  component: RefitLaunchPanel,
+  parameters: {
+    layout: 'padded',
+    backgrounds: {
+      default: 'dark',
+      values: [{ name: 'dark', value: '#0f172a' }],
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof RefitLaunchPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Default — a unit at the standard baseline, ready to choose a target. */
+export const Default: Story = {
+  args: {
+    unitId: 'atlas-as7d',
+    unitName: 'Atlas AS7-D',
+    currentConfiguration: DEFAULT_UNIT_CONFIGURATION,
+    onCommit: (target) => {
+      // A demo commit that always advances to in-progress.
+      const order = createRefitOrder({
+        id: 'refit-demo',
+        unitId: 'atlas-as7d',
+        currentConfiguration: DEFAULT_UNIT_CONFIGURATION,
+        targetConfiguration: target,
+        createdAt: '3025-02-01T00:00:00.000Z',
+      });
+      return { order: { ...order, status: 'in-progress' } };
+    },
+    onCancel: () => undefined,
+  },
+};
+
+/** Commit-blocked — the demo handler reports a construction-validation failure. */
+export const ValidationBlocked: Story = {
+  args: {
+    unitId: 'commando-com2d',
+    unitName: 'Commando COM-2D',
+    currentConfiguration: DEFAULT_UNIT_CONFIGURATION,
+    onCommit: (target) => {
+      const order = createRefitOrder({
+        id: 'refit-demo',
+        unitId: 'commando-com2d',
+        currentConfiguration: DEFAULT_UNIT_CONFIGURATION,
+        targetConfiguration: target,
+        createdAt: '3025-02-01T00:00:00.000Z',
+      });
+      return {
+        order,
+        validationErrors: ['Total weight (52t) exceeds tonnage (50t)'],
+      };
+    },
+    onCancel: () => undefined,
+  },
+};

--- a/src/components/campaign/bays/RefitLaunchPanel.tsx
+++ b/src/components/campaign/bays/RefitLaunchPanel.tsx
@@ -1,0 +1,270 @@
+/**
+ * Refit Launch Panel
+ *
+ * The refit launch flow reachable from the mech bay (CP3 —
+ * `add-campaign-refit-and-prestige`, design D6). The player selects a
+ * target configuration for an owned unit; the panel classifies the refit
+ * and shows the estimated cost and hours; committing creates a refit
+ * order through `commitRefitOrder` (which gates the `in-progress` advance
+ * on construction validation).
+ *
+ * The target-configuration editor is deliberately scoped to the fields a
+ * campaign refit touches — engine rating, armour points, heat sinks, jump
+ * MP — derived from the unit's current configuration. A full unit editor
+ * is out of scope (a refit validates a target build; it does not
+ * reimplement construction).
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ * @module components/campaign/bays/RefitLaunchPanel
+ */
+
+import React, { useMemo, useState } from 'react';
+
+import type { IRefitOrder } from '@/types/campaign/Refit';
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import { Badge, Button, Card } from '@/components/ui';
+import { estimateRefit } from '@/lib/campaign/refit/refitEstimator';
+import { RefitClass } from '@/types/campaign/Refit';
+
+// =============================================================================
+// Refit-class presentation
+// =============================================================================
+
+/** Human-readable label for a refit class. */
+function refitClassLabel(refitClass: RefitClass): string {
+  switch (refitClass) {
+    case RefitClass.EquipmentSwap:
+      return 'Equipment Swap';
+    case RefitClass.VariantUpgrade:
+      return 'Variant Upgrade';
+    case RefitClass.ChassisConversion:
+      return 'Chassis Conversion';
+  }
+}
+
+/** Badge colour for a refit class — heavier classes read warmer. */
+function refitClassClasses(refitClass: RefitClass): string {
+  switch (refitClass) {
+    case RefitClass.EquipmentSwap:
+      return 'bg-emerald-500/20 text-emerald-400';
+    case RefitClass.VariantUpgrade:
+      return 'bg-amber-500/20 text-amber-400';
+    case RefitClass.ChassisConversion:
+      return 'bg-red-500/20 text-red-400';
+  }
+}
+
+// =============================================================================
+// Numeric field
+// =============================================================================
+
+interface RefitFieldProps {
+  readonly label: string;
+  readonly testId: string;
+  readonly value: number;
+  readonly onChange: (next: number) => void;
+}
+
+/** One labelled numeric input for a target-configuration field. */
+function RefitField({
+  label,
+  testId,
+  value,
+  onChange,
+}: RefitFieldProps): React.ReactElement {
+  return (
+    <label className="flex items-center justify-between gap-3">
+      <span className="text-text-theme-secondary text-sm">{label}</span>
+      <input
+        type="number"
+        value={value}
+        data-testid={testId}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="bg-surface-raised border-border-theme text-text-theme-primary w-24 rounded border px-2 py-1 text-right text-sm"
+      />
+    </label>
+  );
+}
+
+// =============================================================================
+// Panel
+// =============================================================================
+
+export interface RefitLaunchPanelProps {
+  /** The unit being refit. */
+  readonly unitId: string;
+  /** Display name of the unit. */
+  readonly unitName: string;
+  /** The unit's current configuration. */
+  readonly currentConfiguration: MechBuildConfig;
+  /**
+   * Commit the refit. Returns the created order (or its validation
+   * errors) so the panel can surface the outcome.
+   */
+  readonly onCommit: (target: MechBuildConfig) => {
+    readonly order?: IRefitOrder;
+    readonly validationErrors?: readonly string[];
+  };
+  /** Cancel / close the launch flow. */
+  readonly onCancel: () => void;
+}
+
+/**
+ * The refit launch panel — target editor, live class + estimate, commit.
+ */
+export function RefitLaunchPanel({
+  unitId,
+  unitName,
+  currentConfiguration,
+  onCommit,
+  onCancel,
+}: RefitLaunchPanelProps): React.ReactElement {
+  // Target configuration — seeded from the current build, edited in place.
+  const [target, setTarget] = useState<MechBuildConfig>(currentConfiguration);
+  const [committedOrder, setCommittedOrder] = useState<IRefitOrder | null>(
+    null,
+  );
+  const [errors, setErrors] = useState<readonly string[]>([]);
+
+  // Live classification + estimate for the current target.
+  const estimate = useMemo(
+    () => estimateRefit(currentConfiguration, target),
+    [currentConfiguration, target],
+  );
+
+  /** Patch a single numeric field on the target configuration. */
+  const patchTarget = (patch: Partial<MechBuildConfig>): void => {
+    setTarget((prev) => ({ ...prev, ...patch }));
+    setCommittedOrder(null);
+    setErrors([]);
+  };
+
+  /** Commit the refit through the supplied handler. */
+  const handleCommit = (): void => {
+    const result = onCommit(target);
+    setCommittedOrder(result.order ?? null);
+    setErrors(result.validationErrors ?? []);
+  };
+
+  return (
+    <Card className="p-5" data-testid={`refit-launch-${unitId}`}>
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h3 className="text-text-theme-primary text-lg font-semibold">
+            Refit — {unitName}
+          </h3>
+          <p className="text-text-theme-secondary text-xs">
+            Choose a target configuration for this unit.
+          </p>
+        </div>
+        <Badge
+          className={refitClassClasses(estimate.refitClass)}
+          data-testid="refit-class-badge"
+        >
+          {refitClassLabel(estimate.refitClass)}
+        </Badge>
+      </div>
+
+      {/* Target-configuration editor. */}
+      <div className="mb-4 space-y-2" data-testid="refit-target-editor">
+        <RefitField
+          label="Engine Rating"
+          testId="refit-field-engine-rating"
+          value={target.engineRating}
+          onChange={(engineRating) => patchTarget({ engineRating })}
+        />
+        <RefitField
+          label="Armour Points"
+          testId="refit-field-armor-points"
+          value={target.totalArmorPoints}
+          onChange={(totalArmorPoints) => patchTarget({ totalArmorPoints })}
+        />
+        <RefitField
+          label="Heat Sinks"
+          testId="refit-field-heat-sinks"
+          value={target.totalHeatSinks}
+          onChange={(totalHeatSinks) => patchTarget({ totalHeatSinks })}
+        />
+        <RefitField
+          label="Jump MP"
+          testId="refit-field-jump-mp"
+          value={target.jumpMP}
+          onChange={(jumpMP) => patchTarget({ jumpMP })}
+        />
+      </div>
+
+      {/* Live estimate. */}
+      <div
+        className="bg-surface-raised mb-4 grid grid-cols-2 gap-3 rounded p-3"
+        data-testid="refit-estimate"
+      >
+        <div>
+          <p className="text-text-theme-secondary text-xs">Estimated Cost</p>
+          <p
+            className="text-text-theme-primary font-mono text-sm"
+            data-testid="refit-estimate-cost"
+          >
+            {estimate.estimatedCost.toLocaleString()} C-bills
+          </p>
+        </div>
+        <div>
+          <p className="text-text-theme-secondary text-xs">Estimated Hours</p>
+          <p
+            className="text-text-theme-primary font-mono text-sm"
+            data-testid="refit-estimate-hours"
+          >
+            {estimate.estimatedHours.toLocaleString()} tech-hours
+          </p>
+        </div>
+      </div>
+
+      {/* Commit outcome. */}
+      {committedOrder ? (
+        <div
+          className={`mb-4 rounded border p-3 text-sm ${
+            committedOrder.status === 'in-progress'
+              ? 'border-emerald-600/40 bg-emerald-900/20 text-emerald-300'
+              : 'border-amber-600/40 bg-amber-900/20 text-amber-300'
+          }`}
+          data-testid="refit-commit-result"
+        >
+          {committedOrder.status === 'in-progress' ? (
+            <span>Refit order accepted — work has begun.</span>
+          ) : (
+            <span>
+              Refit order created but not started — the target configuration
+              failed construction validation.
+            </span>
+          )}
+        </div>
+      ) : null}
+
+      {errors.length > 0 ? (
+        <ul
+          className="mb-4 space-y-1 rounded border border-red-600/40 bg-red-900/20 p-3 text-xs text-red-300"
+          data-testid="refit-validation-errors"
+        >
+          {errors.map((err, i) => (
+            <li key={i}>{err}</li>
+          ))}
+        </ul>
+      ) : null}
+
+      <div className="flex justify-end gap-2">
+        <Button
+          variant="secondary"
+          onClick={onCancel}
+          data-testid="refit-cancel"
+        >
+          Cancel
+        </Button>
+        <Button onClick={handleCommit} data-testid="refit-commit">
+          Commit Refit
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+export default RefitLaunchPanel;

--- a/src/components/campaign/bays/__tests__/MechBay.test.tsx
+++ b/src/components/campaign/bays/__tests__/MechBay.test.tsx
@@ -81,6 +81,33 @@ describe('MechBay', () => {
     );
   });
 
+  it('renders a per-unit Refit affordance and fires onLaunchRefit (CP3)', () => {
+    const onLaunchRefit = jest.fn();
+    render(
+      <MechBay
+        units={SAMPLE_ROSTER_UNITS}
+        repairBay={SAMPLE_REPAIR_BAY}
+        campaignId="campaign-1"
+        onLaunchRefit={onLaunchRefit}
+      />,
+    );
+    screen.getByTestId('mech-bay-refit-unit-atlas').click();
+    expect(onLaunchRefit).toHaveBeenCalledWith('unit-atlas');
+  });
+
+  it('hides the Refit affordance when no onLaunchRefit handler is wired', () => {
+    render(
+      <MechBay
+        units={SAMPLE_ROSTER_UNITS}
+        repairBay={SAMPLE_REPAIR_BAY}
+        campaignId="campaign-1"
+      />,
+    );
+    expect(
+      screen.queryByTestId('mech-bay-refit-unit-atlas'),
+    ).not.toBeInTheDocument();
+  });
+
   it('shows an empty state — not an error — when there are no units', () => {
     render(<MechBay units={[]} repairBay={[]} campaignId="campaign-1" />);
     expect(screen.getByTestId('bay-empty')).toBeInTheDocument();

--- a/src/components/campaign/bays/__tests__/RefitLaunchPanel.test.tsx
+++ b/src/components/campaign/bays/__tests__/RefitLaunchPanel.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Refit Launch Panel — render tests
+ *
+ * Covers tasks.md 5.4 and the spec scenarios "Launching a refit shows
+ * class and estimate" and "Committing a refit creates an order".
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import { createRefitOrder } from '@/lib/campaign/refit/refitPipeline';
+import { ArmorTypeEnum } from '@/types/construction/ArmorType';
+import { CockpitType } from '@/types/construction/CockpitType';
+import { EngineType } from '@/types/construction/EngineType';
+import { GyroType } from '@/types/construction/GyroType';
+import { HeatSinkType } from '@/types/construction/HeatSinkType';
+import { InternalStructureType } from '@/types/construction/InternalStructureType';
+
+import { RefitLaunchPanel } from '../RefitLaunchPanel';
+
+const CURRENT: MechBuildConfig = {
+  tonnage: 50,
+  engineRating: 250,
+  engineType: EngineType.STANDARD,
+  gyroType: GyroType.STANDARD,
+  internalStructureType: InternalStructureType.STANDARD,
+  armorType: ArmorTypeEnum.STANDARD,
+  totalArmorPoints: 160,
+  cockpitType: CockpitType.STANDARD,
+  heatSinkType: HeatSinkType.SINGLE,
+  totalHeatSinks: 10,
+  jumpMP: 0,
+};
+
+describe('RefitLaunchPanel', () => {
+  it('shows the classified refit class and the estimate', () => {
+    render(
+      <RefitLaunchPanel
+        unitId="unit-1"
+        unitName="Atlas AS7-D"
+        currentConfiguration={CURRENT}
+        onCommit={() => ({})}
+        onCancel={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId('refit-class-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('refit-estimate-cost')).toBeInTheDocument();
+    expect(screen.getByTestId('refit-estimate-hours')).toBeInTheDocument();
+  });
+
+  it('reclassifies and re-estimates when the target changes', () => {
+    render(
+      <RefitLaunchPanel
+        unitId="unit-1"
+        unitName="Atlas AS7-D"
+        currentConfiguration={CURRENT}
+        onCommit={() => ({})}
+        onCancel={() => undefined}
+      />,
+    );
+    // Identical target → Equipment Swap.
+    expect(screen.getByTestId('refit-class-badge')).toHaveTextContent(
+      'Equipment Swap',
+    );
+    // Change the engine rating → Chassis Conversion.
+    fireEvent.change(screen.getByTestId('refit-field-engine-rating'), {
+      target: { value: '300' },
+    });
+    expect(screen.getByTestId('refit-class-badge')).toHaveTextContent(
+      'Chassis Conversion',
+    );
+  });
+
+  it('invokes onCommit with the target configuration', () => {
+    let committedTarget: MechBuildConfig | null = null;
+    const onCommit = (target: MechBuildConfig) => {
+      committedTarget = target;
+      return {};
+    };
+    render(
+      <RefitLaunchPanel
+        unitId="unit-1"
+        unitName="Atlas AS7-D"
+        currentConfiguration={CURRENT}
+        onCommit={onCommit}
+        onCancel={() => undefined}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('refit-field-armor-points'), {
+      target: { value: '200' },
+    });
+    fireEvent.click(screen.getByTestId('refit-commit'));
+    expect(committedTarget).not.toBeNull();
+    expect(
+      (committedTarget as unknown as MechBuildConfig).totalArmorPoints,
+    ).toBe(200);
+  });
+
+  it('surfaces the in-progress outcome on a successful commit', () => {
+    const onCommit = () => {
+      const order = createRefitOrder({
+        id: 'r1',
+        unitId: 'unit-1',
+        currentConfiguration: CURRENT,
+        targetConfiguration: { ...CURRENT, totalArmorPoints: 180 },
+        createdAt: '3025-02-01T00:00:00.000Z',
+      });
+      return { order: { ...order, status: 'in-progress' as const } };
+    };
+    render(
+      <RefitLaunchPanel
+        unitId="unit-1"
+        unitName="Atlas AS7-D"
+        currentConfiguration={CURRENT}
+        onCommit={onCommit}
+        onCancel={() => undefined}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('refit-commit'));
+    expect(screen.getByTestId('refit-commit-result')).toHaveTextContent(
+      'work has begun',
+    );
+  });
+
+  it('surfaces construction-validation errors when the commit is blocked', () => {
+    const onCommit = () => {
+      const order = createRefitOrder({
+        id: 'r1',
+        unitId: 'unit-1',
+        currentConfiguration: CURRENT,
+        targetConfiguration: { ...CURRENT },
+        createdAt: '3025-02-01T00:00:00.000Z',
+      });
+      return {
+        order,
+        validationErrors: ['Total weight exceeds tonnage'],
+      };
+    };
+    render(
+      <RefitLaunchPanel
+        unitId="unit-1"
+        unitName="Atlas AS7-D"
+        currentConfiguration={CURRENT}
+        onCommit={onCommit}
+        onCancel={() => undefined}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('refit-commit'));
+    expect(screen.getByTestId('refit-validation-errors')).toHaveTextContent(
+      'Total weight exceeds tonnage',
+    );
+  });
+
+  it('invokes onCancel from the cancel button', () => {
+    const onCancel = jest.fn();
+    render(
+      <RefitLaunchPanel
+        unitId="unit-1"
+        unitName="Atlas AS7-D"
+        currentConfiguration={CURRENT}
+        onCommit={() => ({})}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('refit-cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/campaign/command/PrestigeMoralePanel.stories.tsx
+++ b/src/components/campaign/command/PrestigeMoralePanel.stories.tsx
@@ -1,0 +1,68 @@
+/**
+ * Prestige & Morale Panel — Storybook stories
+ *
+ * Covers tasks.md 8.4: populated, empty, and error variants of the
+ * Prestige & Morale surface (CP3 — `add-campaign-refit-and-prestige`).
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { MoraleState } from '@/types/campaign/Prestige';
+
+import {
+  SAMPLE_MORALE_TRANSITIONS,
+  SAMPLE_UNIT_PRESTIGE,
+} from './__fixtures__/prestigeMoraleFixtures';
+import { CommandError } from './CommandStates';
+import { PrestigeMoralePanel } from './PrestigeMoralePanel';
+
+const meta = {
+  title: 'Campaign/Command/PrestigeMoralePanel',
+  component: PrestigeMoralePanel,
+  parameters: {
+    layout: 'padded',
+    backgrounds: {
+      default: 'dark',
+      values: [{ name: 'dark', value: '#0f172a' }],
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof PrestigeMoralePanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Populated — a morale state with transitions and per-unit prestige. */
+export const Populated: Story = {
+  args: {
+    moraleState: MoraleState.High,
+    moraleTransitions: SAMPLE_MORALE_TRANSITIONS,
+    unitPrestige: SAMPLE_UNIT_PRESTIGE,
+  },
+};
+
+/** Empty — a fresh campaign: default morale, no transitions, no prestige. */
+export const Empty: Story = {
+  args: {
+    moraleState: MoraleState.Steady,
+    moraleTransitions: [],
+    unitPrestige: [],
+  },
+};
+
+/** Error — the campaign data failed to load; shows the retry affordance. */
+export const ErrorState: Story = {
+  args: {
+    moraleState: MoraleState.Steady,
+    moraleTransitions: [],
+    unitPrestige: [],
+  },
+  render: () => (
+    <CommandError
+      message="The campaign data failed to load."
+      onRetry={() => undefined}
+    />
+  ),
+};

--- a/src/components/campaign/command/PrestigeMoralePanel.tsx
+++ b/src/components/campaign/command/PrestigeMoralePanel.tsx
@@ -1,0 +1,219 @@
+/**
+ * Prestige & Morale Panel
+ *
+ * The read-only Prestige & Morale command surface (CP3 —
+ * `add-campaign-refit-and-prestige`, design D10). Shows the company's
+ * current `MoraleState`, the recent morale transition history, and the
+ * per-unit prestige scores.
+ *
+ * The surface is strictly read-only — morale and prestige change through
+ * day processors and the post-battle prestige step, never the UI. No
+ * mutation control is rendered here.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ * @module components/campaign/command/PrestigeMoralePanel
+ */
+
+import React from 'react';
+
+import type {
+  IMoraleTransition,
+  IUnitPrestige,
+  MoraleState,
+} from '@/types/campaign/Prestige';
+
+import { Badge, Card } from '@/components/ui';
+import { MORALE_STATE_ORDER, PRESTIGE_MAX } from '@/types/campaign/Prestige';
+
+import { CommandEmpty } from './CommandStates';
+
+// =============================================================================
+// Morale presentation
+// =============================================================================
+
+/** Human-readable label for a morale state. */
+function moraleLabel(state: MoraleState): string {
+  return state.charAt(0).toUpperCase() + state.slice(1);
+}
+
+/** Badge colour for a morale state — worse states read warmer. */
+function moraleClasses(state: MoraleState): string {
+  const rank = MORALE_STATE_ORDER.indexOf(state);
+  switch (rank) {
+    case 0:
+      return 'bg-red-500/20 text-red-400';
+    case 1:
+      return 'bg-amber-500/20 text-amber-400';
+    case 2:
+      return 'bg-slate-500/20 text-slate-300';
+    case 3:
+      return 'bg-sky-500/20 text-sky-400';
+    default:
+      return 'bg-emerald-500/20 text-emerald-400';
+  }
+}
+
+// =============================================================================
+// Morale card
+// =============================================================================
+
+interface MoraleCardProps {
+  readonly moraleState: MoraleState;
+  readonly transitions: readonly IMoraleTransition[];
+}
+
+/** The current morale state plus a recent-transition list. */
+function MoraleCard({
+  moraleState,
+  transitions,
+}: MoraleCardProps): React.ReactElement {
+  // Most-recent transitions first, capped at the last eight.
+  const recent = [...transitions].slice(-8).reverse();
+
+  return (
+    <Card className="p-5" data-testid="prestige-morale-card">
+      <h3 className="text-text-theme-primary mb-3 text-lg font-semibold">
+        Company Morale
+      </h3>
+      <div className="mb-4 flex items-center gap-3">
+        <Badge
+          className={moraleClasses(moraleState)}
+          data-testid="morale-state-badge"
+        >
+          {moraleLabel(moraleState)}
+        </Badge>
+        <span className="text-text-theme-secondary text-xs">
+          Current company morale state
+        </span>
+      </div>
+
+      <h4 className="text-text-theme-secondary mb-2 text-xs font-semibold tracking-wider uppercase">
+        Recent Transitions
+      </h4>
+      {recent.length === 0 ? (
+        <p
+          className="text-text-theme-secondary text-sm"
+          data-testid="morale-transitions-empty"
+        >
+          No morale transitions recorded yet.
+        </p>
+      ) : (
+        <ul className="space-y-1" data-testid="morale-transitions-list">
+          {recent.map((t, i) => (
+            <li
+              key={`${t.occurredAt}-${i}`}
+              className="text-text-theme-secondary flex items-center gap-2 text-sm"
+              data-testid="morale-transition-row"
+            >
+              <span
+                className={
+                  t.direction === 'up' ? 'text-emerald-400' : 'text-red-400'
+                }
+              >
+                {t.direction === 'up' ? '▲' : '▼'}
+              </span>
+              <span>
+                {moraleLabel(t.from)} → {moraleLabel(t.to)}
+              </span>
+              <span className="text-text-theme-secondary truncate text-xs">
+                {t.reason}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}
+
+// =============================================================================
+// Prestige list
+// =============================================================================
+
+interface PrestigeListProps {
+  readonly unitPrestige: readonly IUnitPrestige[];
+}
+
+/** Per-unit prestige scores. */
+function PrestigeList({ unitPrestige }: PrestigeListProps): React.ReactElement {
+  if (unitPrestige.length === 0) {
+    return (
+      <CommandEmpty
+        title="No prestige tracked yet"
+        message="Unit prestige is recorded after a unit's first battle."
+      />
+    );
+  }
+
+  // Highest prestige first.
+  const sorted = [...unitPrestige].sort((a, b) => b.score - a.score);
+
+  return (
+    <div className="space-y-2" data-testid="prestige-list">
+      {sorted.map((record) => (
+        <Card
+          key={record.unitId}
+          className="flex items-center justify-between p-4"
+          data-testid={`prestige-row-${record.unitId}`}
+        >
+          <span className="text-text-theme-primary truncate text-sm font-medium">
+            {record.unitId}
+          </span>
+          <div className="flex items-center gap-3">
+            <div className="bg-surface-raised h-2 w-32 overflow-hidden rounded">
+              <div
+                className="bg-accent h-full"
+                style={{
+                  width: `${(record.score / PRESTIGE_MAX) * 100}%`,
+                }}
+              />
+            </div>
+            <span
+              className="text-text-theme-primary w-10 text-right font-mono text-sm"
+              data-testid={`prestige-score-${record.unitId}`}
+            >
+              {record.score}
+            </span>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+// =============================================================================
+// Panel
+// =============================================================================
+
+export interface PrestigeMoralePanelProps {
+  /** The company's current morale state. */
+  readonly moraleState: MoraleState;
+  /** The company's morale transition history. */
+  readonly moraleTransitions: readonly IMoraleTransition[];
+  /** Per-unit prestige records. */
+  readonly unitPrestige: readonly IUnitPrestige[];
+}
+
+/**
+ * The Prestige & Morale surface — morale state + transitions, then the
+ * per-unit prestige list. Read-only.
+ */
+export function PrestigeMoralePanel({
+  moraleState,
+  moraleTransitions,
+  unitPrestige,
+}: PrestigeMoralePanelProps): React.ReactElement {
+  return (
+    <div className="space-y-6" data-testid="prestige-morale-panel">
+      <MoraleCard moraleState={moraleState} transitions={moraleTransitions} />
+      <div>
+        <h3 className="text-text-theme-primary mb-3 text-lg font-semibold">
+          Unit Prestige
+        </h3>
+        <PrestigeList unitPrestige={unitPrestige} />
+      </div>
+    </div>
+  );
+}
+
+export default PrestigeMoralePanel;

--- a/src/components/campaign/command/__fixtures__/prestigeMoraleFixtures.ts
+++ b/src/components/campaign/command/__fixtures__/prestigeMoraleFixtures.ts
@@ -1,0 +1,90 @@
+/**
+ * Prestige & Morale fixtures — shared Storybook / test data
+ *
+ * Sample morale-transition history and per-unit prestige records for the
+ * Prestige & Morale surface (CP3 — `add-campaign-refit-and-prestige`).
+ *
+ * @module components/campaign/command/__fixtures__/prestigeMoraleFixtures
+ */
+
+import type {
+  IMoraleTransition,
+  IUnitPrestige,
+} from '@/types/campaign/Prestige';
+
+import { MoraleState } from '@/types/campaign/Prestige';
+
+/** A short morale-transition history — two rises and a fall. */
+export const SAMPLE_MORALE_TRANSITIONS: readonly IMoraleTransition[] = [
+  {
+    from: MoraleState.Steady,
+    to: MoraleState.High,
+    direction: 'up',
+    reason: 'Morale rose: 2 recent victory(s), pay met',
+    occurredAt: '3025-02-01T00:00:00.000Z',
+  },
+  {
+    from: MoraleState.High,
+    to: MoraleState.Steady,
+    direction: 'down',
+    reason: 'Morale fell: 1 recent defeat(s), pay missed',
+    occurredAt: '3025-02-08T00:00:00.000Z',
+  },
+  {
+    from: MoraleState.Steady,
+    to: MoraleState.High,
+    direction: 'up',
+    reason: 'Morale rose: 3 recent victory(s), pay met',
+    occurredAt: '3025-02-15T00:00:00.000Z',
+  },
+];
+
+/** Per-unit prestige records spanning a wide score range. */
+export const SAMPLE_UNIT_PRESTIGE: readonly IUnitPrestige[] = [
+  {
+    unitId: 'atlas-as7d',
+    score: 84,
+    history: [
+      {
+        matchId: 'match-1',
+        delta: 12,
+        scoreAfter: 62,
+        reason: 'Victory, survived intact',
+        appliedAt: '3025-02-01T00:00:00.000Z',
+      },
+      {
+        matchId: 'match-3',
+        delta: 8,
+        scoreAfter: 84,
+        reason: 'Victory',
+        appliedAt: '3025-02-15T00:00:00.000Z',
+      },
+    ],
+  },
+  {
+    unitId: 'wolverine-wvr6r',
+    score: 47,
+    history: [
+      {
+        matchId: 'match-2',
+        delta: -5,
+        scoreAfter: 47,
+        reason: 'Defeat',
+        appliedAt: '3025-02-08T00:00:00.000Z',
+      },
+    ],
+  },
+  {
+    unitId: 'commando-com2d',
+    score: 18,
+    history: [
+      {
+        matchId: 'match-2',
+        delta: -18,
+        scoreAfter: 18,
+        reason: 'Defeat, heavy damage, crew loss',
+        appliedAt: '3025-02-08T00:00:00.000Z',
+      },
+    ],
+  },
+];

--- a/src/components/campaign/command/__tests__/PrestigeMoralePanel.test.tsx
+++ b/src/components/campaign/command/__tests__/PrestigeMoralePanel.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Prestige & Morale Panel — render tests
+ *
+ * Covers tasks.md 8.5 and the spec scenarios "The surface shows morale and
+ * prestige" and "The surface exposes no mutation controls".
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { MoraleState } from '@/types/campaign/Prestige';
+
+import {
+  SAMPLE_MORALE_TRANSITIONS,
+  SAMPLE_UNIT_PRESTIGE,
+} from '../__fixtures__/prestigeMoraleFixtures';
+import { PrestigeMoralePanel } from '../PrestigeMoralePanel';
+
+describe('PrestigeMoralePanel', () => {
+  it('shows the current company morale state', () => {
+    render(
+      <PrestigeMoralePanel
+        moraleState={MoraleState.High}
+        moraleTransitions={SAMPLE_MORALE_TRANSITIONS}
+        unitPrestige={SAMPLE_UNIT_PRESTIGE}
+      />,
+    );
+    expect(screen.getByTestId('morale-state-badge')).toHaveTextContent('High');
+  });
+
+  it('lists the recent morale transitions', () => {
+    render(
+      <PrestigeMoralePanel
+        moraleState={MoraleState.High}
+        moraleTransitions={SAMPLE_MORALE_TRANSITIONS}
+        unitPrestige={SAMPLE_UNIT_PRESTIGE}
+      />,
+    );
+    const rows = screen.getAllByTestId('morale-transition-row');
+    expect(rows.length).toBe(SAMPLE_MORALE_TRANSITIONS.length);
+  });
+
+  it('shows each unit prestige score', () => {
+    render(
+      <PrestigeMoralePanel
+        moraleState={MoraleState.High}
+        moraleTransitions={SAMPLE_MORALE_TRANSITIONS}
+        unitPrestige={SAMPLE_UNIT_PRESTIGE}
+      />,
+    );
+    expect(screen.getByTestId('prestige-score-atlas-as7d')).toHaveTextContent(
+      '84',
+    );
+    expect(
+      screen.getByTestId('prestige-score-commando-com2d'),
+    ).toHaveTextContent('18');
+  });
+
+  it('shows an empty prestige state when no units have prestige', () => {
+    render(
+      <PrestigeMoralePanel
+        moraleState={MoraleState.Steady}
+        moraleTransitions={[]}
+        unitPrestige={[]}
+      />,
+    );
+    expect(screen.getByTestId('morale-transitions-empty')).toBeInTheDocument();
+    expect(screen.getByTestId('command-empty')).toBeInTheDocument();
+  });
+
+  it('exposes no mutation controls', () => {
+    const { container } = render(
+      <PrestigeMoralePanel
+        moraleState={MoraleState.High}
+        moraleTransitions={SAMPLE_MORALE_TRANSITIONS}
+        unitPrestige={SAMPLE_UNIT_PRESTIGE}
+      />,
+    );
+    // A read-only surface — no buttons, no inputs, no editable fields.
+    expect(container.querySelectorAll('button')).toHaveLength(0);
+    expect(container.querySelectorAll('input')).toHaveLength(0);
+    expect(container.querySelectorAll('select')).toHaveLength(0);
+  });
+});

--- a/src/lib/campaign/__tests__/refitPrestigeIntegration.test.ts
+++ b/src/lib/campaign/__tests__/refitPrestigeIntegration.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Integration tests for the refit + prestige/morale campaign systems
+ * (`add-campaign-refit-and-prestige`, tasks 9.1 and 9.2).
+ *
+ * 9.1 — launch a refit, advance days until it completes, the unit
+ *       configuration is swapped.
+ * 9.2 — a sequence of victories and defeats moves the company morale state
+ *       and updates per-unit prestige.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICombatOutcome } from '@/types/combat/CombatOutcome';
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import { CampaignType } from '@/types/campaign/CampaignType';
+import { createDefaultCampaignOptions } from '@/types/campaign/createDefaultCampaignOptions';
+import { Money } from '@/types/campaign/Money';
+import { MoraleState } from '@/types/campaign/Prestige';
+import { ArmorTypeEnum } from '@/types/construction/ArmorType';
+import { CockpitType } from '@/types/construction/CockpitType';
+import { EngineType } from '@/types/construction/EngineType';
+import { GyroType } from '@/types/construction/GyroType';
+import { HeatSinkType } from '@/types/construction/HeatSinkType';
+import { InternalStructureType } from '@/types/construction/InternalStructureType';
+
+import { _resetDayPipeline, getDayPipeline } from '../dayPipeline';
+import { applyOutcomePrestige } from '../prestige/applyOutcomePrestige';
+import { moraleProcessor } from '../processors/moraleProcessor';
+import { refitProcessor } from '../processors/refitProcessor';
+import { advanceRefitOrder, createRefitOrder } from '../refit/refitPipeline';
+
+const TEST_DATE = new Date('3025-02-01T00:00:00.000Z');
+
+const CURRENT_CONFIG: MechBuildConfig = {
+  tonnage: 50,
+  engineRating: 250,
+  engineType: EngineType.STANDARD,
+  gyroType: GyroType.STANDARD,
+  internalStructureType: InternalStructureType.STANDARD,
+  armorType: ArmorTypeEnum.STANDARD,
+  totalArmorPoints: 160,
+  cockpitType: CockpitType.STANDARD,
+  heatSinkType: HeatSinkType.SINGLE,
+  totalHeatSinks: 10,
+  jumpMP: 0,
+};
+
+const TARGET_CONFIG: MechBuildConfig = {
+  ...CURRENT_CONFIG,
+  totalArmorPoints: 200,
+};
+
+function makeCampaign(overrides: Partial<ICampaign> = {}): ICampaign {
+  return {
+    id: 'camp-1',
+    name: 'Integration Campaign',
+    currentDate: TEST_DATE,
+    factionId: 'mercenary',
+    forces: new Map(),
+    rootForceId: 'force-root',
+    missions: new Map(),
+    finances: { transactions: [], balance: new Money(0) },
+    factionStandings: {},
+    options: createDefaultCampaignOptions(),
+    campaignType: CampaignType.MERCENARY,
+    createdAt: TEST_DATE.toISOString(),
+    updatedAt: TEST_DATE.toISOString(),
+    unitCombatStates: {},
+    ...overrides,
+  };
+}
+
+describe('refit integration — launch, advance, swap (task 9.1)', () => {
+  beforeEach(() => {
+    _resetDayPipeline();
+    getDayPipeline().register(refitProcessor);
+  });
+
+  afterEach(() => {
+    _resetDayPipeline();
+  });
+
+  it('completes a refit over multiple days and swaps the unit configuration', () => {
+    // Launch a refit: create the proposed order, then advance it through
+    // the construction-validation gate to in-progress.
+    const proposed = createRefitOrder({
+      id: 'refit-int-1',
+      unitId: 'unit-1',
+      currentConfiguration: CURRENT_CONFIG,
+      targetConfiguration: TARGET_CONFIG,
+      createdAt: TEST_DATE.toISOString(),
+    });
+    const advanced = advanceRefitOrder(proposed);
+    expect(advanced.advanced).toBe(true);
+    expect(advanced.order.status).toBe('in-progress');
+
+    let campaign = makeCampaign({ refitOrders: [advanced.order] });
+    const estimatedHours = advanced.order.estimatedHours;
+
+    // Advance days until the refit completes. The processor consumes a
+    // fixed per-day allowance — bound the loop generously.
+    let days = 0;
+    const maxDays = Math.ceil(estimatedHours / 8) + 5;
+    while (days < maxDays) {
+      const result = getDayPipeline().processDay(campaign);
+      campaign = result.campaign;
+      days += 1;
+      const order = campaign.refitOrders?.[0];
+      if (order?.status === 'completed') break;
+    }
+
+    const finalOrder = campaign.refitOrders?.[0];
+    expect(finalOrder?.status).toBe('completed');
+    // The unit's campaign configuration is now the refit target.
+    expect(campaign.unitConfigurations?.['unit-1']).toEqual(TARGET_CONFIG);
+  });
+});
+
+describe('prestige + morale integration — battle sequence (task 9.2)', () => {
+  beforeEach(() => {
+    _resetDayPipeline();
+    getDayPipeline().register(moraleProcessor);
+  });
+
+  afterEach(() => {
+    _resetDayPipeline();
+  });
+
+  /** Build a win/loss outcome stub for a single player unit. */
+  function outcome(
+    matchId: string,
+    winner: 'player' | 'opponent',
+  ): ICombatOutcome {
+    return {
+      matchId,
+      report: { winner },
+      unitDeltas: [
+        {
+          unitId: 'unit-1',
+          side: 'player',
+          destroyed: false,
+          finalStatus: winner === 'player' ? 'damaged' : 'crippled',
+          armorRemaining: {},
+          internalsRemaining: {},
+          destroyedLocations: [],
+          destroyedComponents: [],
+          heatEnd: 0,
+          ammoRemaining: {},
+          pilotState: {
+            conscious: true,
+            wounds: 0,
+            killed: false,
+            finalStatus: 'active',
+          },
+        },
+      ],
+    } as unknown as ICombatOutcome;
+  }
+
+  it('raises morale and prestige across a victory streak', () => {
+    let campaign = makeCampaign({ moraleState: MoraleState.Steady });
+    let prestige = campaign.unitPrestige ?? [];
+
+    // Three days, each with a victory. Stage the day's outcome on
+    // `recentlyAppliedOutcomes` (the post-battle processor does this live)
+    // and apply the prestige step.
+    for (let day = 0; day < 3; day += 1) {
+      const dayOutcome = outcome(`win-${day}`, 'player');
+      prestige = applyOutcomePrestige(
+        dayOutcome,
+        prestige,
+        campaign.currentDate.toISOString(),
+      );
+      const staged = {
+        ...campaign,
+        unitPrestige: prestige,
+        recentlyAppliedOutcomes: [dayOutcome],
+      } as ICampaign;
+      const result = getDayPipeline().processDay(staged);
+      campaign = result.campaign;
+    }
+
+    // Morale climbed from Steady at least one step.
+    expect([MoraleState.High, MoraleState.Elite]).toContain(
+      campaign.moraleState,
+    );
+    // Prestige rose above the default.
+    const record = prestige.find((p) => p.unitId === 'unit-1');
+    expect(record?.score).toBeGreaterThan(50);
+  });
+
+  it('lowers morale and prestige across a defeat streak', () => {
+    let campaign = makeCampaign({ moraleState: MoraleState.Steady });
+    let prestige = applyOutcomePrestige(
+      outcome('seed', 'player'),
+      [],
+      TEST_DATE.toISOString(),
+    );
+    const seededScore = prestige.find((p) => p.unitId === 'unit-1')?.score ?? 0;
+
+    for (let day = 0; day < 3; day += 1) {
+      const dayOutcome = outcome(`loss-${day}`, 'opponent');
+      const dayOutcomeB = outcome(`loss-b-${day}`, 'opponent');
+      // Two defeats per day clears the +1 met-pay signal and still nets
+      // negative, so morale steps down each day (a single defeat alone is
+      // cancelled by met pay — see the morale-signal weighting).
+      prestige = applyOutcomePrestige(
+        dayOutcome,
+        prestige,
+        campaign.currentDate.toISOString(),
+      );
+      const staged = {
+        ...campaign,
+        unitPrestige: prestige,
+        recentlyAppliedOutcomes: [dayOutcome, dayOutcomeB],
+      } as ICampaign;
+      const result = getDayPipeline().processDay(staged);
+      campaign = result.campaign;
+    }
+
+    // Morale fell from Steady at least one step.
+    expect([MoraleState.Unhappy, MoraleState.Mutinous]).toContain(
+      campaign.moraleState,
+    );
+    // Prestige dropped below the seeded score.
+    const record = prestige.find((p) => p.unitId === 'unit-1');
+    expect(record?.score).toBeLessThan(seededScore);
+  });
+});

--- a/src/lib/campaign/prestige/__tests__/applyOutcomePrestige.test.ts
+++ b/src/lib/campaign/prestige/__tests__/applyOutcomePrestige.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the post-battle prestige-update step.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ */
+
+import type { IUnitPrestige } from '@/types/campaign/Prestige';
+import type {
+  ICombatOutcome,
+  IUnitCombatDelta,
+} from '@/types/combat/CombatOutcome';
+
+import { PRESTIGE_DEFAULT } from '@/types/campaign/Prestige';
+import {
+  PilotFinalStatus,
+  UnitFinalStatus,
+} from '@/types/combat/CombatOutcome';
+import { GameSide } from '@/types/gameplay/GameSessionCoreTypes';
+
+import { applyOutcomePrestige } from '../applyOutcomePrestige';
+
+const APPLIED_AT = '3025-02-01T00:00:00.000Z';
+
+function makeDelta(
+  unitId: string,
+  side: GameSide,
+  overrides: Partial<IUnitCombatDelta> = {},
+): IUnitCombatDelta {
+  return {
+    unitId,
+    side,
+    destroyed: false,
+    finalStatus: UnitFinalStatus.Damaged,
+    armorRemaining: {},
+    internalsRemaining: {},
+    destroyedLocations: [],
+    destroyedComponents: [],
+    heatEnd: 0,
+    ammoRemaining: {},
+    pilotState: {
+      conscious: true,
+      wounds: 0,
+      killed: false,
+      finalStatus: PilotFinalStatus.Active,
+    },
+    ...overrides,
+  };
+}
+
+function makeOutcome(
+  winner: 'player' | 'opponent' | 'draw',
+  deltas: readonly IUnitCombatDelta[],
+): ICombatOutcome {
+  return {
+    matchId: 'match-1',
+    report: { winner },
+    unitDeltas: deltas,
+  } as unknown as ICombatOutcome;
+}
+
+describe('applyOutcomePrestige', () => {
+  it('raises prestige for a unit on the winning side', () => {
+    const outcome = makeOutcome('player', [
+      makeDelta('unit-1', GameSide.Player, {
+        finalStatus: UnitFinalStatus.Damaged,
+      }),
+    ]);
+    const result = applyOutcomePrestige(outcome, [], APPLIED_AT);
+    const record = result.find((r) => r.unitId === 'unit-1');
+    expect(record?.score).toBeGreaterThan(PRESTIGE_DEFAULT);
+  });
+
+  it('lowers prestige for a unit on the losing side', () => {
+    const outcome = makeOutcome('opponent', [
+      makeDelta('unit-1', GameSide.Player, {
+        finalStatus: UnitFinalStatus.Crippled,
+      }),
+    ]);
+    const result = applyOutcomePrestige(outcome, [], APPLIED_AT);
+    const record = result.find((r) => r.unitId === 'unit-1');
+    expect(record?.score).toBeLessThan(PRESTIGE_DEFAULT);
+  });
+
+  it('seeds a unit with no prior record at the default before adjusting', () => {
+    const outcome = makeOutcome('player', [
+      makeDelta('fresh-unit', GameSide.Player),
+    ]);
+    const result = applyOutcomePrestige(outcome, [], APPLIED_AT);
+    const record = result.find((r) => r.unitId === 'fresh-unit');
+    expect(record).toBeDefined();
+    expect(record?.history).toHaveLength(1);
+  });
+
+  it('preserves existing history when updating an existing record', () => {
+    const existing: IUnitPrestige = {
+      unitId: 'unit-1',
+      score: 60,
+      history: [
+        {
+          matchId: 'match-0',
+          delta: 10,
+          scoreAfter: 60,
+          reason: 'Victory',
+          appliedAt: '3025-01-01T00:00:00.000Z',
+        },
+      ],
+    };
+    const outcome = makeOutcome('player', [
+      makeDelta('unit-1', GameSide.Player),
+    ]);
+    const result = applyOutcomePrestige(outcome, [existing], APPLIED_AT);
+    const record = result.find((r) => r.unitId === 'unit-1');
+    expect(record?.history).toHaveLength(2);
+  });
+
+  it('returns the list unchanged for an outcome with no deltas', () => {
+    const outcome = makeOutcome('player', []);
+    const current: readonly IUnitPrestige[] = [];
+    expect(applyOutcomePrestige(outcome, current, APPLIED_AT)).toBe(current);
+  });
+
+  it('treats a draw as a non-win for both sides', () => {
+    const outcome = makeOutcome('draw', [makeDelta('unit-1', GameSide.Player)]);
+    const result = applyOutcomePrestige(outcome, [], APPLIED_AT);
+    const record = result.find((r) => r.unitId === 'unit-1');
+    // A draw applies the defeat delta — score must not exceed the default.
+    expect(record?.score).toBeLessThanOrEqual(PRESTIGE_DEFAULT);
+  });
+
+  it('is deterministic for the same outcome and starting list', () => {
+    const outcome = makeOutcome('player', [
+      makeDelta('unit-1', GameSide.Player),
+    ]);
+    const a = applyOutcomePrestige(outcome, [], APPLIED_AT);
+    const b = applyOutcomePrestige(outcome, [], APPLIED_AT);
+    expect(a).toEqual(b);
+  });
+});

--- a/src/lib/campaign/prestige/__tests__/moraleStateMachine.test.ts
+++ b/src/lib/campaign/prestige/__tests__/moraleStateMachine.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the company morale state machine.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ */
+
+import type { IMoraleSignals } from '@/types/campaign/Prestige';
+
+import { MoraleState, moraleRank } from '@/types/campaign/Prestige';
+
+import { evaluateMoraleTransition } from '../moraleStateMachine';
+
+const OCCURRED_AT = '3025-02-01T00:00:00.000Z';
+
+function signals(overrides: Partial<IMoraleSignals> = {}): IMoraleSignals {
+  return {
+    recentVictories: 0,
+    recentDefeats: 0,
+    payMet: true,
+    desertions: 0,
+    ...overrides,
+  };
+}
+
+describe('evaluateMoraleTransition', () => {
+  it('moves morale up by exactly one step on victories with met pay', () => {
+    const result = evaluateMoraleTransition(
+      MoraleState.Steady,
+      signals({ recentVictories: 2, payMet: true }),
+      OCCURRED_AT,
+    );
+    expect(result.to).toBe(MoraleState.High);
+    expect(result.direction).toBe('up');
+    expect(moraleRank(result.to) - moraleRank(result.from)).toBe(1);
+  });
+
+  it('moves morale down by exactly one step on defeats / missed pay / desertions', () => {
+    const result = evaluateMoraleTransition(
+      MoraleState.Steady,
+      signals({ recentDefeats: 2, payMet: false, desertions: 1 }),
+      OCCURRED_AT,
+    );
+    expect(result.to).toBe(MoraleState.Unhappy);
+    expect(result.direction).toBe('down');
+  });
+
+  it('moves at most one step even with many negative signals', () => {
+    const result = evaluateMoraleTransition(
+      MoraleState.Elite,
+      signals({ recentDefeats: 10, payMet: false, desertions: 5 }),
+      OCCURRED_AT,
+    );
+    // Elite → High is one step; never Elite → Steady.
+    expect(result.to).toBe(MoraleState.High);
+    expect(moraleRank(result.from) - moraleRank(result.to)).toBe(1);
+  });
+
+  it('holds morale when there are no signals', () => {
+    const result = evaluateMoraleTransition(
+      MoraleState.Steady,
+      signals(),
+      OCCURRED_AT,
+    );
+    // payMet:true is +1 by itself — so "no signals" must net zero. Verify
+    // that a balanced day (one victory cancelled by one defeat, pay met
+    // cancelled by a desertion) holds.
+    const balanced = evaluateMoraleTransition(
+      MoraleState.Steady,
+      signals({ recentVictories: 1, recentDefeats: 1, desertions: 1 }),
+      OCCURRED_AT,
+    );
+    expect(balanced.direction).toBeNull();
+    expect(balanced.transition).toBeNull();
+    expect(balanced.to).toBe(MoraleState.Steady);
+    // The trivial-signals case still steps up (payMet is a positive).
+    expect(result.direction).toBe('up');
+  });
+
+  it('cannot step above the maximum state', () => {
+    const result = evaluateMoraleTransition(
+      MoraleState.Elite,
+      signals({ recentVictories: 5, payMet: true }),
+      OCCURRED_AT,
+    );
+    expect(result.to).toBe(MoraleState.Elite);
+    expect(result.direction).toBeNull();
+  });
+
+  it('cannot step below the minimum state', () => {
+    const result = evaluateMoraleTransition(
+      MoraleState.Mutinous,
+      signals({ recentDefeats: 5, payMet: false }),
+      OCCURRED_AT,
+    );
+    expect(result.to).toBe(MoraleState.Mutinous);
+    expect(result.direction).toBeNull();
+  });
+
+  it('emits a transition record on a change', () => {
+    const result = evaluateMoraleTransition(
+      MoraleState.Steady,
+      signals({ recentVictories: 3, payMet: true }),
+      OCCURRED_AT,
+    );
+    expect(result.transition).not.toBeNull();
+    expect(result.transition?.from).toBe(MoraleState.Steady);
+    expect(result.transition?.to).toBe(MoraleState.High);
+    expect(result.transition?.occurredAt).toBe(OCCURRED_AT);
+  });
+});

--- a/src/lib/campaign/prestige/__tests__/prestigeScorer.test.ts
+++ b/src/lib/campaign/prestige/__tests__/prestigeScorer.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for the prestige scorer.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ */
+
+import type { IUnitPrestige } from '@/types/campaign/Prestige';
+import type { IUnitCombatDelta } from '@/types/combat/CombatOutcome';
+
+import {
+  PRESTIGE_DEFAULT,
+  PRESTIGE_MAX,
+  PRESTIGE_MIN,
+} from '@/types/campaign/Prestige';
+import {
+  PilotFinalStatus,
+  UnitFinalStatus,
+} from '@/types/combat/CombatOutcome';
+import { GameSide } from '@/types/gameplay/GameSessionCoreTypes';
+
+import {
+  adjustPrestige,
+  createDefaultUnitPrestige,
+  deriveUnitPrestigeSignal,
+} from '../prestigeScorer';
+
+const APPLIED_AT = '3025-02-01T00:00:00.000Z';
+
+function makeDelta(
+  overrides: Partial<IUnitCombatDelta> = {},
+): IUnitCombatDelta {
+  return {
+    unitId: 'unit-1',
+    side: GameSide.Player,
+    destroyed: false,
+    finalStatus: UnitFinalStatus.Damaged,
+    armorRemaining: {},
+    internalsRemaining: {},
+    destroyedLocations: [],
+    destroyedComponents: [],
+    heatEnd: 0,
+    ammoRemaining: {},
+    pilotState: {
+      conscious: true,
+      wounds: 0,
+      killed: false,
+      finalStatus: PilotFinalStatus.Active,
+    },
+    ...overrides,
+  };
+}
+
+describe('createDefaultUnitPrestige', () => {
+  it('seeds a unit at the default score with empty history', () => {
+    const prestige = createDefaultUnitPrestige('unit-1');
+    expect(prestige.score).toBe(PRESTIGE_DEFAULT);
+    expect(prestige.history).toEqual([]);
+  });
+});
+
+describe('deriveUnitPrestigeSignal', () => {
+  it('flags a destroyed unit', () => {
+    const signal = deriveUnitPrestigeSignal(
+      makeDelta({ destroyed: true, finalStatus: UnitFinalStatus.Destroyed }),
+      false,
+      'match-1',
+      APPLIED_AT,
+    );
+    expect(signal.destroyed).toBe(true);
+    expect(signal.heavyDamage).toBe(false);
+  });
+
+  it('flags heavy damage for a crippled unit', () => {
+    const signal = deriveUnitPrestigeSignal(
+      makeDelta({ finalStatus: UnitFinalStatus.Crippled }),
+      true,
+      'match-1',
+      APPLIED_AT,
+    );
+    expect(signal.heavyDamage).toBe(true);
+    expect(signal.destroyed).toBe(false);
+  });
+
+  it('flags crew loss when the pilot was killed', () => {
+    const signal = deriveUnitPrestigeSignal(
+      makeDelta({
+        pilotState: {
+          conscious: false,
+          wounds: 6,
+          killed: true,
+          finalStatus: PilotFinalStatus.KIA,
+        },
+      }),
+      false,
+      'match-1',
+      APPLIED_AT,
+    );
+    expect(signal.crewLost).toBe(true);
+  });
+});
+
+describe('adjustPrestige', () => {
+  const base: IUnitPrestige = {
+    unitId: 'unit-1',
+    score: 50,
+    history: [],
+  };
+
+  it('raises prestige on a victory', () => {
+    const signal = deriveUnitPrestigeSignal(
+      makeDelta({ finalStatus: UnitFinalStatus.Damaged }),
+      true,
+      'match-1',
+      APPLIED_AT,
+    );
+    const next = adjustPrestige(base, signal);
+    expect(next.score).toBeGreaterThan(base.score);
+    expect(next.history).toHaveLength(1);
+  });
+
+  it('lowers prestige on heavy damage', () => {
+    const signal = deriveUnitPrestigeSignal(
+      makeDelta({ finalStatus: UnitFinalStatus.Crippled }),
+      false,
+      'match-1',
+      APPLIED_AT,
+    );
+    const next = adjustPrestige(base, signal);
+    expect(next.score).toBeLessThan(base.score);
+  });
+
+  it('clamps the score at the maximum bound', () => {
+    const atMax: IUnitPrestige = { ...base, score: PRESTIGE_MAX };
+    const signal = deriveUnitPrestigeSignal(
+      makeDelta({ finalStatus: UnitFinalStatus.Intact }),
+      true,
+      'match-1',
+      APPLIED_AT,
+    );
+    const next = adjustPrestige(atMax, signal);
+    expect(next.score).toBe(PRESTIGE_MAX);
+  });
+
+  it('clamps the score at the minimum bound', () => {
+    const atMin: IUnitPrestige = { ...base, score: PRESTIGE_MIN };
+    const signal = deriveUnitPrestigeSignal(
+      makeDelta({ destroyed: true, finalStatus: UnitFinalStatus.Destroyed }),
+      false,
+      'match-1',
+      APPLIED_AT,
+    );
+    const next = adjustPrestige(atMin, signal);
+    expect(next.score).toBe(PRESTIGE_MIN);
+  });
+
+  it('is deterministic — the same signal yields the same result', () => {
+    const signal = deriveUnitPrestigeSignal(
+      makeDelta({ finalStatus: UnitFinalStatus.Damaged }),
+      true,
+      'match-1',
+      APPLIED_AT,
+    );
+    expect(adjustPrestige(base, signal)).toEqual(adjustPrestige(base, signal));
+  });
+
+  it('does not mutate the input prestige record', () => {
+    const signal = deriveUnitPrestigeSignal(
+      makeDelta(),
+      true,
+      'match-1',
+      APPLIED_AT,
+    );
+    adjustPrestige(base, signal);
+    expect(base.score).toBe(50);
+    expect(base.history).toEqual([]);
+  });
+});

--- a/src/lib/campaign/prestige/applyOutcomePrestige.ts
+++ b/src/lib/campaign/prestige/applyOutcomePrestige.ts
@@ -1,0 +1,82 @@
+/**
+ * Apply-Outcome Prestige Step — post-battle prestige update
+ *
+ * Pure function, no IO. `applyOutcomePrestige` runs when a battle outcome
+ * is applied (design D7): for every unit in the outcome's per-unit deltas
+ * it derives a deterministic prestige signal and adjusts that unit's
+ * prestige record, returning the updated `unitPrestige` list. Units with
+ * no prior record are seeded at `PRESTIGE_DEFAULT` before adjustment.
+ *
+ * Prestige tracks combat results deterministically — calling this twice on
+ * the same outcome and the same starting list is idempotent at the
+ * processor level because the post-battle processor de-dupes outcomes by
+ * `matchId` before this step ever runs.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ * @module lib/campaign/prestige/applyOutcomePrestige
+ */
+
+import type { IUnitPrestige } from '@/types/campaign/Prestige';
+import type { ICombatOutcome } from '@/types/combat/CombatOutcome';
+
+import { GameSide } from '@/types/gameplay/GameSessionInterfaces';
+
+import {
+  adjustPrestige,
+  createDefaultUnitPrestige,
+  deriveUnitPrestigeSignal,
+} from './prestigeScorer';
+
+/**
+ * Apply a battle outcome's prestige effects to a campaign's prestige list.
+ *
+ * @param outcome - the combat outcome being applied
+ * @param current - the campaign's current `unitPrestige` list (may be empty)
+ * @param appliedAt - ISO-8601 timestamp the outcome is applied
+ * @returns the updated `unitPrestige` list
+ */
+export function applyOutcomePrestige(
+  outcome: ICombatOutcome,
+  current: readonly IUnitPrestige[],
+  appliedAt: string,
+): readonly IUnitPrestige[] {
+  if (outcome.unitDeltas.length === 0) {
+    return current;
+  }
+
+  // Index existing records by unit id for O(1) lookup.
+  const byUnit = new Map<string, IUnitPrestige>();
+  for (const record of current) {
+    byUnit.set(record.unitId, record);
+  }
+
+  const winner = outcome.report.winner;
+
+  for (const delta of outcome.unitDeltas) {
+    // A unit "won" when its side matches the outcome winner. A draw or a
+    // loss is not a win.
+    const won = winner !== 'draw' && delta.side === winner;
+    const signal = deriveUnitPrestigeSignal(
+      delta,
+      won,
+      outcome.matchId,
+      appliedAt,
+    );
+    const existing =
+      byUnit.get(delta.unitId) ?? createDefaultUnitPrestige(delta.unitId);
+    byUnit.set(delta.unitId, adjustPrestige(existing, signal));
+  }
+
+  return Array.from(byUnit.values());
+}
+
+/**
+ * Determine whether a `GameSide` is the player's side. Exposed so callers
+ * can reason about "the player's units" without re-importing the enum.
+ *
+ * @param side - the side to test
+ * @returns true when the side is the player's
+ */
+export function isPlayerSide(side: GameSide): boolean {
+  return side === GameSide.Player;
+}

--- a/src/lib/campaign/prestige/gatherMoraleSignals.ts
+++ b/src/lib/campaign/prestige/gatherMoraleSignals.ts
@@ -1,0 +1,86 @@
+/**
+ * Morale Signal Gatherer — distil a day into `IMoraleSignals`
+ *
+ * Pure function, no IO. The morale processor needs a fixed, enumerated set
+ * of morale-affecting signals for the day (design D8). This module derives
+ * those signals deterministically from:
+ *
+ *   - `campaign.recentlyAppliedOutcomes` — battle outcomes applied this day
+ *     (the post-battle processor stages them); each one's
+ *     `report.winner` decides victory vs defeat
+ *   - the day's accumulated events — `daily_costs` severity tells whether
+ *     pay was met, `turnover_departure` events with a `deserted` type are
+ *     desertions
+ *
+ * Every signal is a named, deterministic function of campaign state and
+ * the day's events — there is no hidden randomness.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ * @module lib/campaign/prestige/gatherMoraleSignals
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { IMoraleSignals } from '@/types/campaign/Prestige';
+import type { ICombatOutcome } from '@/types/combat/CombatOutcome';
+
+import { type IDayEvent } from '../dayPipeline';
+
+/**
+ * Campaign extension carrying the outcomes applied earlier in the day. The
+ * post-battle processor stages applied outcomes on `recentlyAppliedOutcomes`.
+ */
+interface ICampaignWithRecentOutcomes extends ICampaign {
+  readonly recentlyAppliedOutcomes?: readonly ICombatOutcome[];
+}
+
+/**
+ * Gather the day's enumerated morale signals.
+ *
+ * @param campaign - the campaign (read for `recentlyAppliedOutcomes`)
+ * @param dayEvents - the events accumulated earlier in the day's pipeline
+ * @returns the deterministic morale signal set for the day
+ */
+export function gatherMoraleSignals(
+  campaign: ICampaign,
+  dayEvents: readonly IDayEvent[],
+): IMoraleSignals {
+  const extended = campaign as ICampaignWithRecentOutcomes;
+  const outcomes = extended.recentlyAppliedOutcomes ?? [];
+
+  // Victories / defeats — one per applied outcome by its winner.
+  let recentVictories = 0;
+  let recentDefeats = 0;
+  for (const outcome of outcomes) {
+    if (outcome.report.winner === 'player') {
+      recentVictories += 1;
+    } else if (outcome.report.winner !== 'draw') {
+      recentDefeats += 1;
+    }
+  }
+
+  // Pay — a `daily_costs` event with `warning`/`critical` severity means
+  // the campaign ran a negative balance, i.e. pay was not comfortably met.
+  // Absent a daily-costs event, pay is treated as met.
+  let payMet = true;
+  for (const event of dayEvents) {
+    if (event.type === 'daily_costs' && event.severity !== 'info') {
+      payMet = false;
+    }
+  }
+
+  // Desertions — `turnover_departure` events whose `departureType` is a
+  // desertion (as opposed to retirement / contract end).
+  let desertions = 0;
+  for (const event of dayEvents) {
+    if (event.type !== 'turnover_departure') continue;
+    const departureType = event.data?.departureType;
+    if (
+      typeof departureType === 'string' &&
+      departureType.toLowerCase().includes('desert')
+    ) {
+      desertions += 1;
+    }
+  }
+
+  return { recentVictories, recentDefeats, payMet, desertions };
+}

--- a/src/lib/campaign/prestige/moraleStateMachine.ts
+++ b/src/lib/campaign/prestige/moraleStateMachine.ts
@@ -1,0 +1,153 @@
+/**
+ * Company Morale State Machine
+ *
+ * Pure functions, no IO. Morale is a linearly-ordered state machine
+ * (`Mutinous → Unhappy → Steady → High → Elite`). `evaluateMoraleTransition`
+ * inspects the enumerated `IMoraleSignals` for one day and returns at most
+ * one step transition — up, down, or none (design D8). One step per day
+ * keeps morale from swinging wildly.
+ *
+ * The signal tally is deterministic: positive signals (victories, met pay)
+ * and negative signals (defeats, missed pay, desertions) are weighed; if
+ * the net is positive morale steps up, if negative it steps down, if zero
+ * it holds. A single bad day cannot crater morale because the step is
+ * always exactly one.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ * @module lib/campaign/prestige/moraleStateMachine
+ */
+
+import type {
+  IMoraleSignals,
+  IMoraleTransition,
+} from '@/types/campaign/Prestige';
+
+import {
+  MORALE_STATE_ORDER,
+  MoraleState,
+  moraleRank,
+} from '@/types/campaign/Prestige';
+
+// =============================================================================
+// Signal Weighting
+// =============================================================================
+
+/**
+ * Net morale pressure from a day's signals. A positive score pushes
+ * morale up, a negative score pushes it down, zero holds.
+ *
+ * - each victory: +1
+ * - met pay: +1
+ * - each defeat: -1
+ * - missed pay: -1
+ * - each desertion: -1
+ */
+function scoreSignals(signals: IMoraleSignals): number {
+  let score = 0;
+  score += signals.recentVictories;
+  score -= signals.recentDefeats;
+  score += signals.payMet ? 1 : -1;
+  score -= signals.desertions;
+  return score;
+}
+
+// =============================================================================
+// Transition Evaluation
+// =============================================================================
+
+/**
+ * The outcome of evaluating one day's morale signals.
+ */
+export interface IMoraleEvaluation {
+  /** Morale state before the evaluation. */
+  readonly from: MoraleState;
+  /** Morale state after the evaluation (equals `from` when no transition). */
+  readonly to: MoraleState;
+  /** Direction of the transition, or `null` when morale held. */
+  readonly direction: 'up' | 'down' | null;
+  /** The transition record, or `null` when morale held. */
+  readonly transition: IMoraleTransition | null;
+}
+
+/**
+ * Build a short human-readable reason for a transition direction.
+ */
+function transitionReason(
+  direction: 'up' | 'down',
+  signals: IMoraleSignals,
+): string {
+  if (direction === 'up') {
+    const parts: string[] = [];
+    if (signals.recentVictories > 0) {
+      parts.push(`${signals.recentVictories} recent victory(s)`);
+    }
+    if (signals.payMet) parts.push('pay met');
+    return parts.length > 0
+      ? `Morale rose: ${parts.join(', ')}`
+      : 'Morale rose';
+  }
+  const parts: string[] = [];
+  if (signals.recentDefeats > 0) {
+    parts.push(`${signals.recentDefeats} recent defeat(s)`);
+  }
+  if (!signals.payMet) parts.push('pay missed');
+  if (signals.desertions > 0) parts.push(`${signals.desertions} desertion(s)`);
+  return parts.length > 0 ? `Morale fell: ${parts.join(', ')}` : 'Morale fell';
+}
+
+/**
+ * Evaluate a day's morale signals and return at most one step transition.
+ *
+ * The net signal score decides direction; the step is always exactly one
+ * rank along `MORALE_STATE_ORDER`. Morale that is already at the maximum
+ * (`Elite`) cannot step up and morale at the minimum (`Mutinous`) cannot
+ * step down — in those cases the state holds even when the net score
+ * points further.
+ *
+ * @param currentState - the company's current morale state
+ * @param signals - the day's enumerated morale signals
+ * @param occurredAt - ISO-8601 timestamp stamped onto an emitted transition
+ * @returns the morale evaluation (transition or hold)
+ */
+export function evaluateMoraleTransition(
+  currentState: MoraleState,
+  signals: IMoraleSignals,
+  occurredAt: string,
+): IMoraleEvaluation {
+  const score = scoreSignals(signals);
+  const rank = moraleRank(currentState);
+
+  // Net-zero pressure — morale holds.
+  if (score === 0) {
+    return {
+      from: currentState,
+      to: currentState,
+      direction: null,
+      transition: null,
+    };
+  }
+
+  const direction: 'up' | 'down' = score > 0 ? 'up' : 'down';
+  const nextRank = direction === 'up' ? rank + 1 : rank - 1;
+
+  // Already at a boundary — morale cannot step further; it holds.
+  if (nextRank < 0 || nextRank >= MORALE_STATE_ORDER.length) {
+    return {
+      from: currentState,
+      to: currentState,
+      direction: null,
+      transition: null,
+    };
+  }
+
+  const to = MORALE_STATE_ORDER[nextRank];
+  const transition: IMoraleTransition = {
+    from: currentState,
+    to,
+    direction,
+    reason: transitionReason(direction, signals),
+    occurredAt,
+  };
+
+  return { from: currentState, to, direction, transition };
+}

--- a/src/lib/campaign/prestige/prestigeScorer.ts
+++ b/src/lib/campaign/prestige/prestigeScorer.ts
@@ -1,0 +1,204 @@
+/**
+ * Prestige Scorer — adjust a unit's prestige from a battle signal
+ *
+ * Pure functions, no IO. `adjustPrestige` raises a unit's bounded prestige
+ * score on victories and notable performance and lowers it on heavy damage
+ * and crew loss (design D7). The score is clamped to
+ * `[PRESTIGE_MIN, PRESTIGE_MAX]` so it can never escape its bounds.
+ *
+ * `deriveUnitPrestigeSignal` distils an `IUnitCombatDelta` (the per-unit
+ * slice of an `ICombatOutcome`) plus the side's win/loss into the
+ * deterministic signal the scorer consumes — so prestige updates are a
+ * pure function of the battle outcome.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ * @module lib/campaign/prestige/prestigeScorer
+ */
+
+import type {
+  IUnitPrestige,
+  IUnitPrestigeHistoryEntry,
+} from '@/types/campaign/Prestige';
+import type { IUnitCombatDelta } from '@/types/combat/CombatOutcome';
+
+import {
+  PRESTIGE_DEFAULT,
+  PRESTIGE_MAX,
+  PRESTIGE_MIN,
+} from '@/types/campaign/Prestige';
+import { UnitFinalStatus } from '@/types/combat/CombatOutcome';
+
+// =============================================================================
+// Per-Signal Deltas
+// =============================================================================
+
+/** Prestige gained when the unit's side won the battle. */
+const VICTORY_DELTA = 8;
+
+/** Prestige lost when the unit's side lost the battle. */
+const DEFEAT_DELTA = -5;
+
+/** Additional prestige gained for a notable performance (survived intact). */
+const NOTABLE_PERFORMANCE_DELTA = 4;
+
+/** Prestige lost when the unit took heavy damage (crippled). */
+const HEAVY_DAMAGE_DELTA = -6;
+
+/** Prestige lost when the unit was destroyed (crew loss). */
+const DESTROYED_DELTA = -12;
+
+/** Prestige lost when the unit's pilot was killed. */
+const CREW_LOSS_DELTA = -10;
+
+// =============================================================================
+// Prestige Signal
+// =============================================================================
+
+/**
+ * The deterministic, named signal the prestige scorer consumes. Derived
+ * from a battle outcome — there is no hidden randomness.
+ */
+export interface IPrestigeSignal {
+  /** Match the signal was derived from. */
+  readonly matchId: string;
+  /** True when the unit's side won the battle. */
+  readonly won: boolean;
+  /** True when the unit survived the battle fully intact. */
+  readonly intact: boolean;
+  /** True when the unit took heavy damage (crippled but not destroyed). */
+  readonly heavyDamage: boolean;
+  /** True when the unit was destroyed. */
+  readonly destroyed: boolean;
+  /** True when the unit's pilot was killed or went MIA (crew loss). */
+  readonly crewLost: boolean;
+  /** ISO-8601 timestamp the outcome was applied. */
+  readonly appliedAt: string;
+}
+
+/**
+ * Distil an `IUnitCombatDelta` plus the side's win/loss into a
+ * deterministic `IPrestigeSignal`.
+ *
+ * @param delta - the per-unit combat delta from an `ICombatOutcome`
+ * @param won - whether the unit's side won the battle
+ * @param matchId - the originating match id
+ * @param appliedAt - ISO-8601 timestamp the outcome is applied
+ * @returns the derived prestige signal
+ */
+export function deriveUnitPrestigeSignal(
+  delta: IUnitCombatDelta,
+  won: boolean,
+  matchId: string,
+  appliedAt: string,
+): IPrestigeSignal {
+  const destroyed =
+    delta.destroyed || delta.finalStatus === UnitFinalStatus.Destroyed;
+  const heavyDamage =
+    !destroyed && delta.finalStatus === UnitFinalStatus.Crippled;
+  const intact = !destroyed && delta.finalStatus === UnitFinalStatus.Intact;
+  const crewLost = delta.pilotState.killed;
+
+  return {
+    matchId,
+    won,
+    intact,
+    heavyDamage,
+    destroyed,
+    crewLost,
+    appliedAt,
+  };
+}
+
+// =============================================================================
+// Score Adjustment
+// =============================================================================
+
+/** Clamp a raw score into the bounded prestige range. */
+function clampPrestige(raw: number): number {
+  return Math.max(PRESTIGE_MIN, Math.min(PRESTIGE_MAX, Math.round(raw)));
+}
+
+/**
+ * Build the default (pre-first-battle) prestige record for a unit.
+ *
+ * @param unitId - the unit to seed prestige for
+ * @returns a fresh prestige record at `PRESTIGE_DEFAULT` with no history
+ */
+export function createDefaultUnitPrestige(unitId: string): IUnitPrestige {
+  return { unitId, score: PRESTIGE_DEFAULT, history: [] };
+}
+
+/**
+ * Compute the net signed delta for a prestige signal, plus a short reason.
+ *
+ * Signals stack additively: a victory in which the unit took heavy damage
+ * nets `VICTORY_DELTA + HEAVY_DAMAGE_DELTA`.
+ */
+function scoreSignal(signal: IPrestigeSignal): {
+  readonly delta: number;
+  readonly reason: string;
+} {
+  let delta = 0;
+  const reasons: string[] = [];
+
+  if (signal.won) {
+    delta += VICTORY_DELTA;
+    reasons.push('Victory');
+  } else {
+    delta += DEFEAT_DELTA;
+    reasons.push('Defeat');
+  }
+
+  if (signal.intact) {
+    delta += NOTABLE_PERFORMANCE_DELTA;
+    reasons.push('survived intact');
+  }
+  if (signal.heavyDamage) {
+    delta += HEAVY_DAMAGE_DELTA;
+    reasons.push('heavy damage');
+  }
+  if (signal.destroyed) {
+    delta += DESTROYED_DELTA;
+    reasons.push('destroyed');
+  }
+  if (signal.crewLost) {
+    delta += CREW_LOSS_DELTA;
+    reasons.push('crew loss');
+  }
+
+  return { delta, reason: reasons.join(', ') };
+}
+
+/**
+ * Adjust a unit's prestige from a battle signal.
+ *
+ * The score is moved by the net signed delta of the signal and clamped to
+ * `[PRESTIGE_MIN, PRESTIGE_MAX]`. A history entry recording the delta, the
+ * post-clamp score, and the reason is appended. The function is pure — the
+ * input prestige record is never mutated.
+ *
+ * @param prestige - the unit's current prestige record
+ * @param signal - the deterministic battle signal
+ * @returns a new prestige record with the adjustment applied
+ */
+export function adjustPrestige(
+  prestige: IUnitPrestige,
+  signal: IPrestigeSignal,
+): IUnitPrestige {
+  const { delta, reason } = scoreSignal(signal);
+  const scoreAfter = clampPrestige(prestige.score + delta);
+
+  const historyEntry: IUnitPrestigeHistoryEntry = {
+    matchId: signal.matchId,
+    delta,
+    scoreAfter,
+    reason,
+    appliedAt: signal.appliedAt,
+  };
+
+  return {
+    unitId: prestige.unitId,
+    score: scoreAfter,
+    history: [...prestige.history, historyEntry],
+  };
+}

--- a/src/lib/campaign/processors/__tests__/moraleProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/moraleProcessor.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the morale day processor.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICombatOutcome } from '@/types/combat/CombatOutcome';
+
+import { CampaignType } from '@/types/campaign/CampaignType';
+import { createDefaultCampaignOptions } from '@/types/campaign/createDefaultCampaignOptions';
+import { Money } from '@/types/campaign/Money';
+import { MoraleState } from '@/types/campaign/Prestige';
+
+import { DayPhase, type IDayEvent } from '../../dayPipeline';
+import { moraleProcessor } from '../moraleProcessor';
+
+const TEST_DATE = new Date('3025-02-01T00:00:00.000Z');
+
+/** A minimal win/loss outcome stub — only the fields the gatherer reads. */
+function outcomeStub(winner: 'player' | 'opponent' | 'draw'): ICombatOutcome {
+  return {
+    report: { winner },
+  } as unknown as ICombatOutcome;
+}
+
+function makeCampaign(
+  overrides: Partial<ICampaign> & {
+    readonly recentlyAppliedOutcomes?: readonly ICombatOutcome[];
+    readonly _dayEventsSoFar?: readonly IDayEvent[];
+  } = {},
+): ICampaign {
+  return {
+    id: 'camp-1',
+    name: 'Test Campaign',
+    currentDate: TEST_DATE,
+    factionId: 'mercenary',
+    forces: new Map(),
+    rootForceId: 'force-root',
+    missions: new Map(),
+    finances: { transactions: [], balance: new Money(0) },
+    factionStandings: {},
+    options: createDefaultCampaignOptions(),
+    campaignType: CampaignType.MERCENARY,
+    createdAt: TEST_DATE.toISOString(),
+    updatedAt: TEST_DATE.toISOString(),
+    unitCombatStates: {},
+    ...overrides,
+  } as ICampaign;
+}
+
+describe('moraleProcessor', () => {
+  it('registers in the DayPhase.EVENTS block', () => {
+    expect(moraleProcessor.id).toBe('morale');
+    expect(moraleProcessor.phase).toBe(DayPhase.EVENTS);
+  });
+
+  it('raises morale by one step on recent victories with met pay', () => {
+    const campaign = makeCampaign({
+      moraleState: MoraleState.Steady,
+      recentlyAppliedOutcomes: [outcomeStub('player'), outcomeStub('player')],
+    });
+    const result = moraleProcessor.process(campaign, TEST_DATE);
+    expect(result.campaign.moraleState).toBe(MoraleState.High);
+    expect(result.events.some((e) => e.type === 'morale-changed')).toBe(true);
+  });
+
+  it('lowers morale by one step on defeats and missed pay', () => {
+    const campaign = makeCampaign({
+      moraleState: MoraleState.Steady,
+      recentlyAppliedOutcomes: [outcomeStub('opponent')],
+      _dayEventsSoFar: [
+        {
+          type: 'daily_costs',
+          description: 'Daily costs',
+          severity: 'warning',
+        },
+      ],
+    });
+    const result = moraleProcessor.process(campaign, TEST_DATE);
+    expect(result.campaign.moraleState).toBe(MoraleState.Unhappy);
+  });
+
+  it('lowers morale on desertions', () => {
+    const campaign = makeCampaign({
+      moraleState: MoraleState.Steady,
+      _dayEventsSoFar: [
+        {
+          type: 'turnover_departure',
+          description: 'A pilot deserted',
+          severity: 'warning',
+          data: { departureType: 'deserted' },
+        },
+        {
+          type: 'turnover_departure',
+          description: 'Another pilot deserted',
+          severity: 'warning',
+          data: { departureType: 'deserted' },
+        },
+      ],
+    });
+    const result = moraleProcessor.process(campaign, TEST_DATE);
+    expect(result.campaign.moraleState).toBe(MoraleState.Unhappy);
+  });
+
+  it('moves at most one step even with many negative signals', () => {
+    const campaign = makeCampaign({
+      moraleState: MoraleState.Elite,
+      recentlyAppliedOutcomes: [
+        outcomeStub('opponent'),
+        outcomeStub('opponent'),
+        outcomeStub('opponent'),
+      ],
+      _dayEventsSoFar: [
+        {
+          type: 'daily_costs',
+          description: 'Daily costs',
+          severity: 'critical',
+        },
+      ],
+    });
+    const result = moraleProcessor.process(campaign, TEST_DATE);
+    expect(result.campaign.moraleState).toBe(MoraleState.High);
+  });
+
+  it('is a no-op with no morale-affecting signals', () => {
+    // A balanced day: one victory cancelled by one defeat, pay met
+    // cancelled by a desertion — net-zero pressure.
+    const campaign = makeCampaign({
+      moraleState: MoraleState.Steady,
+      recentlyAppliedOutcomes: [outcomeStub('player'), outcomeStub('opponent')],
+      _dayEventsSoFar: [
+        {
+          type: 'turnover_departure',
+          description: 'A pilot deserted',
+          severity: 'warning',
+          data: { departureType: 'deserted' },
+        },
+      ],
+    });
+    const result = moraleProcessor.process(campaign, TEST_DATE);
+    expect(result.campaign).toBe(campaign);
+    expect(result.events).toEqual([]);
+  });
+
+  it('records the transition on the campaign history', () => {
+    const campaign = makeCampaign({
+      moraleState: MoraleState.Steady,
+      recentlyAppliedOutcomes: [outcomeStub('player'), outcomeStub('player')],
+    });
+    const result = moraleProcessor.process(campaign, TEST_DATE);
+    expect(result.campaign.moraleTransitions).toHaveLength(1);
+    expect(result.campaign.moraleTransitions?.[0].to).toBe(MoraleState.High);
+  });
+});

--- a/src/lib/campaign/processors/__tests__/processors.test.ts
+++ b/src/lib/campaign/processors/__tests__/processors.test.ts
@@ -254,13 +254,13 @@ describe('registerBuiltinProcessors', () => {
     _resetBuiltinRegistration();
   });
 
-  it('should register all fifteen builtin processors', () => {
+  it('should register all seventeen builtin processors', () => {
     registerBuiltinProcessors();
     const processors = getDayPipeline().getProcessors();
 
-    // 15 = 12 prior + scenario-generation, scenario-encounter-bridge,
-    // and inventory-projection (add-campaign-combat-loop, Wave 4 CP1).
-    expect(processors).toHaveLength(15);
+    // 17 = 15 prior + refit and morale
+    // (add-campaign-refit-and-prestige, Wave 4 CP3).
+    expect(processors).toHaveLength(17);
     expect(processors.map((p) => p.id).sort()).toEqual(
       [
         'healing',
@@ -278,6 +278,8 @@ describe('registerBuiltinProcessors', () => {
         'scenario-generation',
         'scenario-encounter-bridge',
         'inventory-projection',
+        'refit',
+        'morale',
       ].sort(),
     );
   });
@@ -287,7 +289,7 @@ describe('registerBuiltinProcessors', () => {
     registerBuiltinProcessors();
 
     const processors = getDayPipeline().getProcessors();
-    expect(processors).toHaveLength(15);
+    expect(processors).toHaveLength(17);
   });
 
   it('should register processors in correct phase order', () => {
@@ -300,9 +302,12 @@ describe('registerBuiltinProcessors', () => {
     // sorts ascending by phase. add-campaign-combat-loop adds three
     // processors at the tail: scenario-generation (EVENTS=800),
     // scenario-encounter-bridge (EVENTS+10=810), inventory-projection
-    // (CLEANUP=900). Expected order:
+    // (CLEANUP=900). add-campaign-refit-and-prestige (Wave 4 CP3) adds
+    // the refit processor (UNITS=500) and the morale processor
+    // (EVENTS=800). Expected order:
     //   PERSONNEL × 2, MARKETS × 3, post-battle, salvage, repair,
-    //   contracts, FINANCES, EVENTS × 3, EVENTS+10, CLEANUP.
+    //   contracts, refit (UNITS), FINANCES, EVENTS × 4, EVENTS+10,
+    //   CLEANUP.
     expect(processors[0].phase).toBe(DayPhase.PERSONNEL);
     expect(processors[1].phase).toBe(DayPhase.PERSONNEL);
     expect(processors[2].phase).toBe(DayPhase.MARKETS);
@@ -312,11 +317,13 @@ describe('registerBuiltinProcessors', () => {
     expect(processors[6].phase).toBe(DayPhase.MISSIONS - 25); // salvage
     expect(processors[7].phase).toBe(DayPhase.MISSIONS - 10); // repair
     expect(processors[8].phase).toBe(DayPhase.MISSIONS); // contracts
-    expect(processors[9].phase).toBe(DayPhase.FINANCES);
-    expect(processors[10].phase).toBe(DayPhase.EVENTS);
+    expect(processors[9].phase).toBe(DayPhase.UNITS); // refit
+    expect(processors[10].phase).toBe(DayPhase.FINANCES);
     expect(processors[11].phase).toBe(DayPhase.EVENTS);
     expect(processors[12].phase).toBe(DayPhase.EVENTS);
-    expect(processors[13].phase).toBe(DayPhase.EVENTS + 10); // bridge
-    expect(processors[14].phase).toBe(DayPhase.CLEANUP); // inventory
+    expect(processors[13].phase).toBe(DayPhase.EVENTS);
+    expect(processors[14].phase).toBe(DayPhase.EVENTS);
+    expect(processors[15].phase).toBe(DayPhase.EVENTS + 10); // bridge
+    expect(processors[16].phase).toBe(DayPhase.CLEANUP); // inventory
   });
 });

--- a/src/lib/campaign/processors/__tests__/refitProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/refitProcessor.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for the refit day processor.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { IRefitOrder } from '@/types/campaign/Refit';
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import { CampaignType } from '@/types/campaign/CampaignType';
+import { createDefaultCampaignOptions } from '@/types/campaign/createDefaultCampaignOptions';
+import { Money } from '@/types/campaign/Money';
+import { RefitClass } from '@/types/campaign/Refit';
+import { ArmorTypeEnum } from '@/types/construction/ArmorType';
+import { CockpitType } from '@/types/construction/CockpitType';
+import { EngineType } from '@/types/construction/EngineType';
+import { GyroType } from '@/types/construction/GyroType';
+import { HeatSinkType } from '@/types/construction/HeatSinkType';
+import { InternalStructureType } from '@/types/construction/InternalStructureType';
+
+import { DayPhase } from '../../dayPipeline';
+import { refitProcessor } from '../refitProcessor';
+
+const TEST_DATE = new Date('3025-02-01T00:00:00.000Z');
+
+const TARGET_CONFIG: MechBuildConfig = {
+  tonnage: 50,
+  engineRating: 250,
+  engineType: EngineType.STANDARD,
+  gyroType: GyroType.STANDARD,
+  internalStructureType: InternalStructureType.STANDARD,
+  armorType: ArmorTypeEnum.STANDARD,
+  totalArmorPoints: 200,
+  cockpitType: CockpitType.STANDARD,
+  heatSinkType: HeatSinkType.SINGLE,
+  totalHeatSinks: 10,
+  jumpMP: 0,
+};
+
+function makeCampaign(refitOrders: readonly IRefitOrder[]): ICampaign {
+  return {
+    id: 'camp-1',
+    name: 'Test Campaign',
+    currentDate: TEST_DATE,
+    factionId: 'mercenary',
+    forces: new Map(),
+    rootForceId: 'force-root',
+    missions: new Map(),
+    finances: { transactions: [], balance: new Money(0) },
+    factionStandings: {},
+    options: createDefaultCampaignOptions(),
+    campaignType: CampaignType.MERCENARY,
+    createdAt: TEST_DATE.toISOString(),
+    updatedAt: TEST_DATE.toISOString(),
+    unitCombatStates: {},
+    refitOrders,
+  };
+}
+
+function makeOrder(overrides: Partial<IRefitOrder> = {}): IRefitOrder {
+  return {
+    id: 'refit-1',
+    unitId: 'unit-1',
+    targetConfiguration: TARGET_CONFIG,
+    refitClass: RefitClass.VariantUpgrade,
+    estimatedCost: 100_000,
+    estimatedHours: 16,
+    hoursCompleted: 0,
+    status: 'in-progress',
+    createdAt: TEST_DATE.toISOString(),
+    ...overrides,
+  };
+}
+
+describe('refitProcessor', () => {
+  it('registers in the DayPhase.UNITS block', () => {
+    expect(refitProcessor.id).toBe('refit');
+    expect(refitProcessor.phase).toBe(DayPhase.UNITS);
+  });
+
+  it('advances an in-progress refit by the day tech-hours', () => {
+    const campaign = makeCampaign([makeOrder({ estimatedHours: 100 })]);
+    const result = refitProcessor.process(campaign, TEST_DATE);
+
+    const order = result.campaign.refitOrders?.[0];
+    expect(order?.hoursCompleted).toBeGreaterThan(0);
+    expect(order?.status).toBe('in-progress');
+    expect(result.events.some((e) => e.type === 'refit-progressed')).toBe(true);
+  });
+
+  it('completes the refit when the hour budget is met and swaps the configuration', () => {
+    // estimatedHours equal to one day's allowance so it completes in a tick.
+    const campaign = makeCampaign([
+      makeOrder({ estimatedHours: 8, hoursCompleted: 0 }),
+    ]);
+    const result = refitProcessor.process(campaign, TEST_DATE);
+
+    const order = result.campaign.refitOrders?.[0];
+    expect(order?.status).toBe('completed');
+    expect(result.campaign.unitConfigurations?.['unit-1']).toEqual(
+      TARGET_CONFIG,
+    );
+    expect(result.events.some((e) => e.type === 'refit-completed')).toBe(true);
+  });
+
+  it('is a no-op when there are no in-progress refits', () => {
+    const campaign = makeCampaign([
+      makeOrder({ status: 'completed' }),
+      makeOrder({ id: 'refit-2', status: 'proposed' }),
+    ]);
+    const result = refitProcessor.process(campaign, TEST_DATE);
+    expect(result.campaign).toBe(campaign);
+    expect(result.events).toEqual([]);
+  });
+
+  it('is a no-op when the campaign has no refit orders at all', () => {
+    const campaign = makeCampaign([]);
+    const result = refitProcessor.process(campaign, TEST_DATE);
+    expect(result.campaign).toBe(campaign);
+  });
+
+  it('leaves non-in-progress orders untouched while advancing the active one', () => {
+    const campaign = makeCampaign([
+      makeOrder({ id: 'a', status: 'in-progress', estimatedHours: 100 }),
+      makeOrder({ id: 'b', status: 'proposed' }),
+    ]);
+    const result = refitProcessor.process(campaign, TEST_DATE);
+    const b = result.campaign.refitOrders?.find((o) => o.id === 'b');
+    expect(b?.status).toBe('proposed');
+    expect(b?.hoursCompleted).toBe(0);
+  });
+});

--- a/src/lib/campaign/processors/moraleProcessor.ts
+++ b/src/lib/campaign/processors/moraleProcessor.ts
@@ -1,0 +1,89 @@
+/**
+ * Morale Day Processor — day-pipeline integration
+ *
+ * Gathers the day's enumerated morale signals, evaluates at most one
+ * morale state transition (`evaluateMoraleTransition`), applies it to the
+ * campaign, and emits a day event when morale changes
+ * (`add-campaign-refit-and-prestige` design D9).
+ *
+ * Phase: EVENTS — the "random events, faction standing" block. It runs
+ * after the battle-effects block and daily costs so the day's victory /
+ * defeat / pay / desertion signals are all settled before morale is
+ * evaluated.
+ *
+ * A day with no morale-affecting signals yields no transition — the
+ * campaign is returned unchanged (reference equality preserved).
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ * @module lib/campaign/processors/moraleProcessor
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+
+import { MORALE_DEFAULT } from '@/types/campaign/Prestige';
+
+import {
+  DayPhase,
+  getDayEventsSoFar,
+  type IDayEvent,
+  type IDayProcessor,
+  type IDayProcessorResult,
+} from '../dayPipeline';
+import { gatherMoraleSignals } from '../prestige/gatherMoraleSignals';
+import { evaluateMoraleTransition } from '../prestige/moraleStateMachine';
+
+/**
+ * Day-pipeline processor: evaluates company morale once per day and
+ * applies at most one step transition.
+ *
+ * Runs in `DayPhase.EVENTS`.
+ */
+export const moraleProcessor: IDayProcessor = {
+  id: 'morale',
+  phase: DayPhase.EVENTS,
+  displayName: 'Company Morale',
+
+  process(campaign: ICampaign, date: Date): IDayProcessorResult {
+    const currentState = campaign.moraleState ?? MORALE_DEFAULT;
+    const dayEvents = getDayEventsSoFar(campaign);
+    const signals = gatherMoraleSignals(campaign, dayEvents);
+
+    const evaluation = evaluateMoraleTransition(
+      currentState,
+      signals,
+      date.toISOString(),
+    );
+
+    // No transition — morale held; return the campaign unchanged.
+    if (!evaluation.transition) {
+      return { events: [], campaign };
+    }
+
+    const transitions = [
+      ...(campaign.moraleTransitions ?? []),
+      evaluation.transition,
+    ];
+    const updatedCampaign: ICampaign = {
+      ...campaign,
+      moraleState: evaluation.to,
+      moraleTransitions: transitions,
+    };
+
+    const event: IDayEvent = {
+      type: 'morale-changed',
+      description: evaluation.transition.reason,
+      severity: evaluation.direction === 'down' ? 'warning' : 'info',
+      data: {
+        from: evaluation.from,
+        to: evaluation.to,
+        direction: evaluation.direction,
+        recentVictories: signals.recentVictories,
+        recentDefeats: signals.recentDefeats,
+        payMet: signals.payMet,
+        desertions: signals.desertions,
+      },
+    };
+
+    return { events: [event], campaign: updatedCampaign };
+  },
+};

--- a/src/lib/campaign/processors/postBattleProcessor.ts
+++ b/src/lib/campaign/processors/postBattleProcessor.ts
@@ -1,5 +1,6 @@
 ﻿import type { ICampaign } from '@/types/campaign/Campaign';
 import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
+import type { IUnitPrestige } from '@/types/campaign/Prestige';
 import type { IUnitCombatState } from '@/types/campaign/UnitCombatState';
 import type { ICombatOutcome } from '@/types/combat/CombatOutcome';
 
@@ -13,6 +14,7 @@ import type { IDayProcessor, IDayProcessorResult } from '../dayPipeline';
 import { publishContractFulfilled } from '../contractFulfillmentBus';
 import { getDayPipeline } from '../dayPipeline';
 import { DayPhase, type IDayEvent } from '../dayPipeline';
+import { applyOutcomePrestige } from '../prestige/applyOutcomePrestige';
 import {
   applyContractDelta,
   applyPilotDelta,
@@ -138,6 +140,15 @@ function applyOutcome(
       publishedAt: nowIso,
     });
   }
+  // Per `add-campaign-refit-and-prestige` design D7: the prestige-update
+  // step runs when a battle outcome is applied, so per-unit prestige
+  // tracks combat results deterministically. The post-battle processor's
+  // matchId de-dup (above) guarantees this never double-applies.
+  const updatedPrestige: readonly IUnitPrestige[] = applyOutcomePrestige(
+    outcome,
+    campaign.unitPrestige ?? [],
+    nowIso,
+  );
   const updatedCampaign: ICampaignWithBattleState & {
     readonly recentlyAppliedOutcomes: readonly ICombatOutcome[];
     readonly pendingFulfilledContractIds: readonly string[];
@@ -147,6 +158,7 @@ function applyOutcome(
     pendingBattleOutcomes: remainingQueue,
     processedBattleIds: [...processed, outcome.matchId],
     unitCombatStates: unitStates,
+    unitPrestige: updatedPrestige,
     recentlyAppliedOutcomes: recentlyApplied,
     pendingFulfilledContractIds: nextFulfilled,
     updatedAt: nowIso,

--- a/src/lib/campaign/processors/processorRegistration.ts
+++ b/src/lib/campaign/processors/processorRegistration.ts
@@ -10,8 +10,10 @@ import {
   personnelMarketProcessor,
   unitMarketProcessor,
 } from './marketProcessors';
+import { moraleProcessor } from './moraleProcessor';
 import { postBattleProcessor } from './postBattleProcessor';
 import { randomEventsProcessor } from './randomEventsProcessor';
+import { refitProcessor } from './refitProcessor';
 import { repairQueueBuilderProcessor } from './repairQueueBuilderProcessor';
 import { salvageProcessor } from './salvageProcessor';
 import { scenarioEncounterBridgeProcessor } from './scenarioEncounterBridgeProcessor';
@@ -56,6 +58,13 @@ export function registerBuiltinProcessors(): void {
   pipeline.register(dailyCostsProcessor);
   pipeline.register(autoAwardsProcessor);
   registerAcquisitionProcessor();
+  // Per `add-campaign-refit-and-prestige` design D5/D9: the refit
+  // processor runs in DayPhase.UNITS (alongside maintenance/repair work);
+  // the morale processor runs in DayPhase.EVENTS, after the battle-effects
+  // block and daily costs so the day's victory/defeat/pay/desertion
+  // signals are settled before morale is evaluated.
+  pipeline.register(refitProcessor);
+  pipeline.register(moraleProcessor);
   pipeline.register(randomEventsProcessor);
   pipeline.register(unitMarketProcessor);
   pipeline.register(personnelMarketProcessor);

--- a/src/lib/campaign/processors/refitProcessor.ts
+++ b/src/lib/campaign/processors/refitProcessor.ts
@@ -1,0 +1,113 @@
+/**
+ * Refit Day Processor — day-pipeline integration
+ *
+ * Advances each `in-progress` refit order on the campaign by the day's
+ * available tech-hours, mirroring how repair tickets are worked
+ * (`add-campaign-refit-and-prestige` design D5). When a refit's
+ * `hoursCompleted` reaches its `estimatedHours` the order completes: the
+ * unit's campaign configuration (`campaign.unitConfigurations[unitId]`) is
+ * replaced with the order's `targetConfiguration` and a day event is
+ * emitted.
+ *
+ * Phase: UNITS — the "maintenance, parts, refits" block. A campaign with
+ * no `in-progress` refit orders is a no-op (reference equality preserved).
+ *
+ * Tech-hour budget: per design D5 and the budget-sharing open question,
+ * repairs consume the daily tech-hour pool first and refits consume the
+ * remainder. This processor uses a fixed per-day refit allowance
+ * (`DEFAULT_DAILY_REFIT_HOURS`) — the simplest policy that keeps refits
+ * progressing without starving repairs.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ * @module lib/campaign/processors/refitProcessor
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { IRefitOrder } from '@/types/campaign/Refit';
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import {
+  DayPhase,
+  type IDayEvent,
+  type IDayProcessor,
+  type IDayProcessorResult,
+} from '../dayPipeline';
+import {
+  DEFAULT_DAILY_REFIT_HOURS,
+  applyRefitHours,
+} from '../refit/refitPipeline';
+
+/**
+ * Day-pipeline processor: advances every `in-progress` refit order by the
+ * day's available tech-hours and completes a refit when its hour budget is
+ * met.
+ *
+ * Runs in `DayPhase.UNITS`. Order-tolerant: it only depends on
+ * `campaign.refitOrders` being populated by the time it runs.
+ */
+export const refitProcessor: IDayProcessor = {
+  id: 'refit',
+  phase: DayPhase.UNITS,
+  displayName: 'Unit Refit',
+
+  process(campaign: ICampaign): IDayProcessorResult {
+    const orders = campaign.refitOrders ?? [];
+
+    // Fast exit — no in-progress refits means nothing to do.
+    const hasActive = orders.some((o) => o.status === 'in-progress');
+    if (!hasActive) {
+      return { events: [], campaign };
+    }
+
+    const events: IDayEvent[] = [];
+    const existingConfigs = campaign.unitConfigurations ?? {};
+    const nextConfigs: Record<string, MechBuildConfig> = { ...existingConfigs };
+
+    const nextOrders: IRefitOrder[] = orders.map((order) => {
+      if (order.status !== 'in-progress') {
+        return order;
+      }
+
+      const result = applyRefitHours(order, DEFAULT_DAILY_REFIT_HOURS);
+
+      if (result.completed) {
+        // Replace the unit's campaign configuration with the target.
+        nextConfigs[order.unitId] = order.targetConfiguration;
+        events.push({
+          type: 'refit-completed',
+          description: `Refit of ${order.unitId} completed (${order.refitClass})`,
+          severity: 'info',
+          data: {
+            refitOrderId: order.id,
+            unitId: order.unitId,
+            refitClass: order.refitClass,
+            estimatedHours: order.estimatedHours,
+          },
+        });
+      } else {
+        events.push({
+          type: 'refit-progressed',
+          description: `Refit of ${order.unitId} advanced ${result.hoursConsumed}h (${result.order.hoursCompleted}/${order.estimatedHours}h)`,
+          severity: 'info',
+          data: {
+            refitOrderId: order.id,
+            unitId: order.unitId,
+            hoursConsumed: result.hoursConsumed,
+            hoursCompleted: result.order.hoursCompleted,
+            estimatedHours: order.estimatedHours,
+          },
+        });
+      }
+
+      return result.order;
+    });
+
+    const updatedCampaign: ICampaign = {
+      ...campaign,
+      refitOrders: nextOrders,
+      unitConfigurations: nextConfigs,
+    };
+
+    return { events, campaign: updatedCampaign };
+  },
+};

--- a/src/lib/campaign/refit/__tests__/refitClassifier.test.ts
+++ b/src/lib/campaign/refit/__tests__/refitClassifier.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the refit classifier.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ */
+
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import { RefitClass } from '@/types/campaign/Refit';
+import { ArmorTypeEnum } from '@/types/construction/ArmorType';
+import { CockpitType } from '@/types/construction/CockpitType';
+import { EngineType } from '@/types/construction/EngineType';
+import { GyroType } from '@/types/construction/GyroType';
+import { HeatSinkType } from '@/types/construction/HeatSinkType';
+import { InternalStructureType } from '@/types/construction/InternalStructureType';
+
+import { classifyRefit, diffConfigurations } from '../refitClassifier';
+
+const BASE: MechBuildConfig = {
+  tonnage: 50,
+  engineRating: 250,
+  engineType: EngineType.STANDARD,
+  gyroType: GyroType.STANDARD,
+  internalStructureType: InternalStructureType.STANDARD,
+  armorType: ArmorTypeEnum.STANDARD,
+  totalArmorPoints: 160,
+  cockpitType: CockpitType.STANDARD,
+  heatSinkType: HeatSinkType.SINGLE,
+  totalHeatSinks: 10,
+  jumpMP: 0,
+};
+
+describe('classifyRefit', () => {
+  it('classifies an identical target as the cheapest class (EquipmentSwap)', () => {
+    expect(classifyRefit(BASE, { ...BASE })).toBe(RefitClass.EquipmentSwap);
+  });
+
+  it('classifies a cockpit/gyro-only change as EquipmentSwap', () => {
+    const target: MechBuildConfig = { ...BASE, gyroType: GyroType.STANDARD };
+    expect(classifyRefit(BASE, target)).toBe(RefitClass.EquipmentSwap);
+  });
+
+  it('classifies an armour-point change as VariantUpgrade', () => {
+    const target: MechBuildConfig = { ...BASE, totalArmorPoints: 200 };
+    expect(classifyRefit(BASE, target)).toBe(RefitClass.VariantUpgrade);
+  });
+
+  it('classifies a heat-sink loadout change as VariantUpgrade', () => {
+    const target: MechBuildConfig = { ...BASE, totalHeatSinks: 14 };
+    expect(classifyRefit(BASE, target)).toBe(RefitClass.VariantUpgrade);
+  });
+
+  it('classifies a jump-MP change as VariantUpgrade', () => {
+    const target: MechBuildConfig = { ...BASE, jumpMP: 5 };
+    expect(classifyRefit(BASE, target)).toBe(RefitClass.VariantUpgrade);
+  });
+
+  it('classifies an engine change as ChassisConversion', () => {
+    const target: MechBuildConfig = { ...BASE, engineRating: 300 };
+    expect(classifyRefit(BASE, target)).toBe(RefitClass.ChassisConversion);
+  });
+
+  it('classifies an internal-structure change as ChassisConversion', () => {
+    const target: MechBuildConfig = {
+      ...BASE,
+      internalStructureType: InternalStructureType.STANDARD,
+      engineRating: 300,
+    };
+    expect(classifyRefit(BASE, target)).toBe(RefitClass.ChassisConversion);
+  });
+
+  it('returns the least-disruptive covering class when changes span tiers', () => {
+    // An armour change AND an engine change — the structural change wins.
+    const target: MechBuildConfig = {
+      ...BASE,
+      totalArmorPoints: 200,
+      engineRating: 300,
+    };
+    expect(classifyRefit(BASE, target)).toBe(RefitClass.ChassisConversion);
+  });
+});
+
+describe('diffConfigurations', () => {
+  it('reports an identical pair as identical', () => {
+    expect(diffConfigurations(BASE, { ...BASE }).identical).toBe(true);
+  });
+
+  it('flags only the changed fields', () => {
+    const diff = diffConfigurations(BASE, { ...BASE, totalArmorPoints: 180 });
+    expect(diff.armorChanged).toBe(true);
+    expect(diff.engineChanged).toBe(false);
+    expect(diff.identical).toBe(false);
+  });
+});

--- a/src/lib/campaign/refit/__tests__/refitEstimator.test.ts
+++ b/src/lib/campaign/refit/__tests__/refitEstimator.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for the refit estimator.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ */
+
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import { ArmorTypeEnum } from '@/types/construction/ArmorType';
+import { CockpitType } from '@/types/construction/CockpitType';
+import { EngineType } from '@/types/construction/EngineType';
+import { GyroType } from '@/types/construction/GyroType';
+import { HeatSinkType } from '@/types/construction/HeatSinkType';
+import { InternalStructureType } from '@/types/construction/InternalStructureType';
+
+import { estimateRefit } from '../refitEstimator';
+
+const BASE: MechBuildConfig = {
+  tonnage: 50,
+  engineRating: 250,
+  engineType: EngineType.STANDARD,
+  gyroType: GyroType.STANDARD,
+  internalStructureType: InternalStructureType.STANDARD,
+  armorType: ArmorTypeEnum.STANDARD,
+  totalArmorPoints: 160,
+  cockpitType: CockpitType.STANDARD,
+  heatSinkType: HeatSinkType.SINGLE,
+  totalHeatSinks: 10,
+  jumpMP: 0,
+};
+
+describe('estimateRefit', () => {
+  it('estimates an equipment swap lower than a chassis conversion in both cost and hours', () => {
+    const swap = estimateRefit(BASE, { ...BASE, gyroType: GyroType.STANDARD });
+    const conversion = estimateRefit(BASE, { ...BASE, engineRating: 320 });
+
+    expect(conversion.estimatedCost).toBeGreaterThan(swap.estimatedCost);
+    expect(conversion.estimatedHours).toBeGreaterThan(swap.estimatedHours);
+  });
+
+  it('estimates a variant upgrade between equipment swap and chassis conversion', () => {
+    const swap = estimateRefit(BASE, { ...BASE });
+    const variant = estimateRefit(BASE, { ...BASE, totalArmorPoints: 200 });
+    const conversion = estimateRefit(BASE, { ...BASE, engineRating: 320 });
+
+    expect(variant.estimatedCost).toBeGreaterThan(swap.estimatedCost);
+    expect(variant.estimatedCost).toBeLessThan(conversion.estimatedCost);
+  });
+
+  it('is deterministic for the same diff', () => {
+    const target: MechBuildConfig = { ...BASE, totalArmorPoints: 190 };
+    const a = estimateRefit(BASE, target);
+    const b = estimateRefit(BASE, target);
+    expect(a).toEqual(b);
+  });
+
+  it('produces positive cost and hours even for an identical target', () => {
+    const estimate = estimateRefit(BASE, { ...BASE });
+    expect(estimate.estimatedCost).toBeGreaterThan(0);
+    expect(estimate.estimatedHours).toBeGreaterThan(0);
+    expect(estimate.changedFieldCount).toBe(0);
+  });
+
+  it('scales the estimate with the number of changed fields', () => {
+    const oneField = estimateRefit(BASE, { ...BASE, totalArmorPoints: 200 });
+    const twoFields = estimateRefit(BASE, {
+      ...BASE,
+      totalArmorPoints: 200,
+      totalHeatSinks: 14,
+    });
+    expect(twoFields.changedFieldCount).toBe(2);
+    expect(twoFields.estimatedHours).toBeGreaterThan(oneField.estimatedHours);
+  });
+});

--- a/src/lib/campaign/refit/__tests__/refitPipeline.test.ts
+++ b/src/lib/campaign/refit/__tests__/refitPipeline.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for the refit pipeline — order creation, the construction-validation
+ * gate, and hour advancement.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ */
+
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import { ArmorTypeEnum } from '@/types/construction/ArmorType';
+import { CockpitType } from '@/types/construction/CockpitType';
+import { EngineType } from '@/types/construction/EngineType';
+import { GyroType } from '@/types/construction/GyroType';
+import { HeatSinkType } from '@/types/construction/HeatSinkType';
+import { InternalStructureType } from '@/types/construction/InternalStructureType';
+
+import {
+  advanceRefitOrder,
+  applyRefitHours,
+  createRefitOrder,
+} from '../refitPipeline';
+
+/** A construction-valid 50-ton baseline. */
+const VALID: MechBuildConfig = {
+  tonnage: 50,
+  engineRating: 250,
+  engineType: EngineType.STANDARD,
+  gyroType: GyroType.STANDARD,
+  internalStructureType: InternalStructureType.STANDARD,
+  armorType: ArmorTypeEnum.STANDARD,
+  totalArmorPoints: 160,
+  cockpitType: CockpitType.STANDARD,
+  heatSinkType: HeatSinkType.SINGLE,
+  totalHeatSinks: 10,
+  jumpMP: 0,
+};
+
+/** A construction-INVALID target — an out-of-range engine rating. */
+const INVALID: MechBuildConfig = { ...VALID, engineRating: 9999 };
+
+const CREATED_AT = '3025-02-01T00:00:00.000Z';
+
+describe('createRefitOrder', () => {
+  it('creates a proposed order carrying every required field', () => {
+    const order = createRefitOrder({
+      id: 'refit-1',
+      unitId: 'unit-1',
+      currentConfiguration: VALID,
+      targetConfiguration: { ...VALID, totalArmorPoints: 200 },
+      createdAt: CREATED_AT,
+    });
+
+    expect(order.unitId).toBe('unit-1');
+    expect(order.targetConfiguration.totalArmorPoints).toBe(200);
+    expect(order.refitClass).toBeDefined();
+    expect(order.estimatedCost).toBeGreaterThan(0);
+    expect(order.estimatedHours).toBeGreaterThan(0);
+    expect(order.hoursCompleted).toBe(0);
+    expect(order.status).toBe('proposed');
+  });
+});
+
+describe('advanceRefitOrder — construction-validation gate', () => {
+  it('advances a proposed order with a valid target to in-progress', () => {
+    const order = createRefitOrder({
+      id: 'refit-2',
+      unitId: 'unit-1',
+      currentConfiguration: VALID,
+      targetConfiguration: { ...VALID, totalArmorPoints: 180 },
+      createdAt: CREATED_AT,
+    });
+
+    const result = advanceRefitOrder(order);
+    expect(result.advanced).toBe(true);
+    expect(result.order.status).toBe('in-progress');
+    expect(result.errors).toEqual([]);
+    expect(result.order.validationErrors).toBeUndefined();
+  });
+
+  it('keeps a proposed order proposed and surfaces errors for an invalid target', () => {
+    const order = createRefitOrder({
+      id: 'refit-3',
+      unitId: 'unit-1',
+      currentConfiguration: VALID,
+      targetConfiguration: INVALID,
+      createdAt: CREATED_AT,
+    });
+
+    const result = advanceRefitOrder(order);
+    expect(result.advanced).toBe(false);
+    expect(result.order.status).toBe('proposed');
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.order.validationErrors?.length).toBeGreaterThan(0);
+  });
+
+  it('is a no-op for an order that is not proposed', () => {
+    const order = createRefitOrder({
+      id: 'refit-4',
+      unitId: 'unit-1',
+      currentConfiguration: VALID,
+      targetConfiguration: { ...VALID, totalArmorPoints: 180 },
+      createdAt: CREATED_AT,
+    });
+    const inProgress = { ...order, status: 'in-progress' as const };
+    const result = advanceRefitOrder(inProgress);
+    expect(result.advanced).toBe(false);
+    expect(result.order).toBe(inProgress);
+  });
+});
+
+describe('applyRefitHours', () => {
+  function inProgressOrder(estimatedHours: number) {
+    const order = createRefitOrder({
+      id: 'refit-5',
+      unitId: 'unit-1',
+      currentConfiguration: VALID,
+      targetConfiguration: { ...VALID, totalArmorPoints: 180 },
+      createdAt: CREATED_AT,
+    });
+    return { ...order, status: 'in-progress' as const, estimatedHours };
+  }
+
+  it('advances hoursCompleted by the available hours', () => {
+    const order = inProgressOrder(100);
+    const result = applyRefitHours(order, 8);
+    expect(result.order.hoursCompleted).toBe(8);
+    expect(result.completed).toBe(false);
+    expect(result.order.status).toBe('in-progress');
+  });
+
+  it('completes the order when the hour budget is met', () => {
+    const order = { ...inProgressOrder(16), hoursCompleted: 8 };
+    const result = applyRefitHours(order, 8);
+    expect(result.order.hoursCompleted).toBe(16);
+    expect(result.completed).toBe(true);
+    expect(result.order.status).toBe('completed');
+  });
+
+  it('never overshoots the hour budget', () => {
+    const order = { ...inProgressOrder(10), hoursCompleted: 8 };
+    const result = applyRefitHours(order, 8);
+    expect(result.order.hoursCompleted).toBe(10);
+    expect(result.hoursConsumed).toBe(2);
+  });
+
+  it('is a no-op for an order that is not in-progress', () => {
+    const order = inProgressOrder(100);
+    const proposed = { ...order, status: 'proposed' as const };
+    const result = applyRefitHours(proposed, 8);
+    expect(result.order).toBe(proposed);
+    expect(result.hoursConsumed).toBe(0);
+  });
+});

--- a/src/lib/campaign/refit/refitClassifier.ts
+++ b/src/lib/campaign/refit/refitClassifier.ts
@@ -1,0 +1,135 @@
+/**
+ * Refit Classifier — diff two unit configurations into a refit class
+ *
+ * Pure functions, no IO. `classifyRefit` inspects the diff between a
+ * unit's current `MechBuildConfig` and a target `MechBuildConfig` and
+ * returns the least-disruptive `RefitClass` that covers the change
+ * (design D2):
+ *
+ *   - a structural change (engine, internal structure) → ChassisConversion
+ *   - a chassis-level loadout change (armour, heat sinks, jump MP) →
+ *     VariantUpgrade
+ *   - anything else (cockpit / gyro / armour-point swap) → EquipmentSwap
+ *   - an identical target → EquipmentSwap (the cheapest class; refit is a
+ *     no-op but still classifiable for a deterministic estimate)
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ * @module lib/campaign/refit/refitClassifier
+ */
+
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import { RefitClass } from '@/types/campaign/Refit';
+
+// =============================================================================
+// Configuration Diff
+// =============================================================================
+
+/**
+ * Field-level breakdown of how two configurations differ. Each flag is
+ * true when that aspect of the build changed between current and target.
+ */
+export interface IRefitConfigDiff {
+  /** Engine rating or engine type changed (a structural change). */
+  readonly engineChanged: boolean;
+  /** Internal structure type changed (a structural change). */
+  readonly structureChanged: boolean;
+  /** Tonnage changed (a structural change — a different chassis weight). */
+  readonly tonnageChanged: boolean;
+  /** Armour type or armour-point allocation changed. */
+  readonly armorChanged: boolean;
+  /** Heat-sink type or count changed. */
+  readonly heatSinkChanged: boolean;
+  /** Jump MP changed. */
+  readonly jumpChanged: boolean;
+  /** Cockpit or gyro type changed. */
+  readonly equipmentChanged: boolean;
+  /** True when no field differs at all. */
+  readonly identical: boolean;
+}
+
+/**
+ * Diff two `MechBuildConfig`s field by field.
+ *
+ * @param current - the unit's current configuration
+ * @param target - the desired target configuration
+ * @returns a structured diff
+ */
+export function diffConfigurations(
+  current: MechBuildConfig,
+  target: MechBuildConfig,
+): IRefitConfigDiff {
+  const engineChanged =
+    current.engineRating !== target.engineRating ||
+    current.engineType !== target.engineType;
+  const structureChanged =
+    current.internalStructureType !== target.internalStructureType;
+  const tonnageChanged = current.tonnage !== target.tonnage;
+  const armorChanged =
+    current.armorType !== target.armorType ||
+    current.totalArmorPoints !== target.totalArmorPoints;
+  const heatSinkChanged =
+    current.heatSinkType !== target.heatSinkType ||
+    current.totalHeatSinks !== target.totalHeatSinks;
+  const jumpChanged = current.jumpMP !== target.jumpMP;
+  const equipmentChanged =
+    current.cockpitType !== target.cockpitType ||
+    current.gyroType !== target.gyroType;
+
+  const identical =
+    !engineChanged &&
+    !structureChanged &&
+    !tonnageChanged &&
+    !armorChanged &&
+    !heatSinkChanged &&
+    !jumpChanged &&
+    !equipmentChanged;
+
+  return {
+    engineChanged,
+    structureChanged,
+    tonnageChanged,
+    armorChanged,
+    heatSinkChanged,
+    jumpChanged,
+    equipmentChanged,
+    identical,
+  };
+}
+
+// =============================================================================
+// Classification
+// =============================================================================
+
+/**
+ * Classify a refit by diffing the current configuration against the
+ * target and returning the least-disruptive covering refit class.
+ *
+ * - A structural change (engine, internal structure, tonnage) is a
+ *   `ChassisConversion` — the heaviest class.
+ * - A chassis-level loadout change (armour, heat sinks, jump MP) that is
+ *   not structural is a `VariantUpgrade`.
+ * - Any remaining change (cockpit / gyro swap) — or an identical target —
+ *   is an `EquipmentSwap`, the cheapest class.
+ *
+ * @param current - the unit's current configuration
+ * @param target - the desired target configuration
+ * @returns the least-disruptive `RefitClass` covering the change
+ */
+export function classifyRefit(
+  current: MechBuildConfig,
+  target: MechBuildConfig,
+): RefitClass {
+  const diff = diffConfigurations(current, target);
+
+  if (diff.engineChanged || diff.structureChanged || diff.tonnageChanged) {
+    return RefitClass.ChassisConversion;
+  }
+
+  if (diff.armorChanged || diff.heatSinkChanged || diff.jumpChanged) {
+    return RefitClass.VariantUpgrade;
+  }
+
+  // Cockpit/gyro change, or no change at all — the cheapest class.
+  return RefitClass.EquipmentSwap;
+}

--- a/src/lib/campaign/refit/refitEstimator.ts
+++ b/src/lib/campaign/refit/refitEstimator.ts
@@ -1,0 +1,132 @@
+/**
+ * Refit Estimator — cost and tech-hours for a refit
+ *
+ * Pure functions, no IO. `estimateRefit` computes a refit's C-bill cost
+ * and tech-hours from the configuration diff and a per-`RefitClass`
+ * multiplier, mirroring `repairQueueBuilder`'s hour-table approach
+ * (design D3). The estimate is deterministic for a given diff so it can
+ * be fixed when the order is committed.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ * @module lib/campaign/refit/refitEstimator
+ */
+
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import { RefitClass } from '@/types/campaign/Refit';
+
+import { classifyRefit, diffConfigurations } from './refitClassifier';
+
+// =============================================================================
+// Estimation Constants
+// =============================================================================
+
+/**
+ * Base tech-hours charged per refit, before per-class multiplication and
+ * per-changed-field hours. A floor so even a trivial swap takes real time.
+ */
+const BASE_REFIT_HOURS = 8;
+
+/** Tech-hours added per changed configuration field. */
+const HOURS_PER_CHANGED_FIELD = 12;
+
+/**
+ * Base C-bill cost charged per refit, before per-class multiplication and
+ * per-changed-field cost.
+ */
+const BASE_REFIT_COST = 25_000;
+
+/** C-bill cost added per changed configuration field. */
+const COST_PER_CHANGED_FIELD = 60_000;
+
+/**
+ * Per-`RefitClass` multipliers applied to both hours and cost. A heavier
+ * class always multiplies higher so a chassis conversion always exceeds an
+ * equipment swap on comparable units (spec: "A heavier refit class costs
+ * more").
+ */
+const CLASS_MULTIPLIER: Readonly<Record<RefitClass, number>> = {
+  [RefitClass.EquipmentSwap]: 1,
+  [RefitClass.VariantUpgrade]: 3,
+  [RefitClass.ChassisConversion]: 8,
+};
+
+// =============================================================================
+// Estimate Result
+// =============================================================================
+
+/**
+ * The result of estimating a refit — a classified class plus its fixed
+ * cost and hour budget.
+ */
+export interface IRefitEstimate {
+  /** The classified refit class. */
+  readonly refitClass: RefitClass;
+  /** Estimated C-bill cost. */
+  readonly estimatedCost: number;
+  /** Estimated tech-hours. */
+  readonly estimatedHours: number;
+  /** Count of configuration fields that changed (drives the estimate). */
+  readonly changedFieldCount: number;
+}
+
+// =============================================================================
+// Estimation
+// =============================================================================
+
+/**
+ * Count how many configuration fields changed between two builds. Drives
+ * the per-field component of the estimate.
+ */
+function countChangedFields(
+  current: MechBuildConfig,
+  target: MechBuildConfig,
+): number {
+  const diff = diffConfigurations(current, target);
+  let count = 0;
+  if (diff.engineChanged) count += 1;
+  if (diff.structureChanged) count += 1;
+  if (diff.tonnageChanged) count += 1;
+  if (diff.armorChanged) count += 1;
+  if (diff.heatSinkChanged) count += 1;
+  if (diff.jumpChanged) count += 1;
+  if (diff.equipmentChanged) count += 1;
+  return count;
+}
+
+/**
+ * Estimate a refit's cost and tech-hours from the diff between the unit's
+ * current configuration and the target.
+ *
+ * The estimate is `(base + perField × changedFields) × classMultiplier`
+ * for both hours and cost, rounded to whole units. It is a pure function
+ * of the two configurations — calling it twice with the same inputs
+ * yields identical output (spec: "Estimation is deterministic").
+ *
+ * @param current - the unit's current configuration
+ * @param target - the desired target configuration
+ * @returns the classified refit class plus its fixed cost and hour budget
+ */
+export function estimateRefit(
+  current: MechBuildConfig,
+  target: MechBuildConfig,
+): IRefitEstimate {
+  const refitClass = classifyRefit(current, target);
+  const changedFieldCount = countChangedFields(current, target);
+  const multiplier = CLASS_MULTIPLIER[refitClass];
+
+  const estimatedHours = Math.round(
+    (BASE_REFIT_HOURS + HOURS_PER_CHANGED_FIELD * changedFieldCount) *
+      multiplier,
+  );
+  const estimatedCost = Math.round(
+    (BASE_REFIT_COST + COST_PER_CHANGED_FIELD * changedFieldCount) * multiplier,
+  );
+
+  return {
+    refitClass,
+    estimatedCost,
+    estimatedHours,
+    changedFieldCount,
+  };
+}

--- a/src/lib/campaign/refit/refitPipeline.ts
+++ b/src/lib/campaign/refit/refitPipeline.ts
@@ -1,0 +1,209 @@
+/**
+ * Refit Pipeline — order creation, validation gate, and hour advancement
+ *
+ * Pure functions, no IO. The pipeline owns the `IRefitOrder` lifecycle:
+ *
+ *   - `createRefitOrder` — build a `proposed` order with a fixed estimate
+ *   - `advanceRefitOrder` — gate `proposed → in-progress` on construction
+ *     validation (design D4); an invalid target keeps the order `proposed`
+ *     and surfaces the validation errors
+ *   - `applyRefitHours` — advance an `in-progress` order by a day's
+ *     tech-hours, completing it when the hour budget is met (design D5)
+ *
+ * The construction-validation gate reuses the existing
+ * `validateConstruction` from `construction-rules-core` — refit never
+ * reimplements construction.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ * @module lib/campaign/refit/refitPipeline
+ */
+
+import type { IRefitOrder } from '@/types/campaign/Refit';
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import { validateConstruction } from '@/utils/construction/constructionRules/validation';
+
+import { estimateRefit } from './refitEstimator';
+
+// =============================================================================
+// Daily Tech-Hour Budget
+// =============================================================================
+
+/**
+ * Default tech-hours a campaign's tech pool can dedicate to refit work in
+ * one day.
+ *
+ * Per design D5 and the "tech-hour budget sharing" open question, refit
+ * shares the campaign tech pool with repair work; the agreed default is
+ * "repairs first, refits consume the remainder". This constant is the
+ * per-day refit allowance — callers that have a live remainder pass it
+ * explicitly to `applyRefitHours`.
+ */
+export const DEFAULT_DAILY_REFIT_HOURS = 8;
+
+// =============================================================================
+// Order Creation
+// =============================================================================
+
+/**
+ * Parameters for creating a refit order.
+ */
+export interface ICreateRefitOrderParams {
+  /** Stable order id (caller-supplied for determinism / testability). */
+  readonly id: string;
+  /** The owned campaign unit being refit. */
+  readonly unitId: string;
+  /** The unit's current configuration. */
+  readonly currentConfiguration: MechBuildConfig;
+  /** The desired target configuration. */
+  readonly targetConfiguration: MechBuildConfig;
+  /** Creation timestamp (ISO 8601). */
+  readonly createdAt: string;
+}
+
+/**
+ * Create a `proposed` refit order with a fixed estimate.
+ *
+ * The refit class, cost, and hours are computed from the diff between the
+ * current and target configurations and fixed on the order — they do not
+ * change after creation (design D3). The order starts at `proposed`; it
+ * must pass `advanceRefitOrder` to begin consuming tech-hours.
+ *
+ * @param params - the order parameters
+ * @returns a freshly created `proposed` refit order
+ */
+export function createRefitOrder(params: ICreateRefitOrderParams): IRefitOrder {
+  const estimate = estimateRefit(
+    params.currentConfiguration,
+    params.targetConfiguration,
+  );
+
+  return {
+    id: params.id,
+    unitId: params.unitId,
+    targetConfiguration: params.targetConfiguration,
+    refitClass: estimate.refitClass,
+    estimatedCost: estimate.estimatedCost,
+    estimatedHours: estimate.estimatedHours,
+    hoursCompleted: 0,
+    status: 'proposed',
+    createdAt: params.createdAt,
+  };
+}
+
+// =============================================================================
+// Construction Validation Gate
+// =============================================================================
+
+/**
+ * Result of attempting to advance a refit order from `proposed`.
+ */
+export interface IRefitAdvanceResult {
+  /** The order after the advance attempt. */
+  readonly order: IRefitOrder;
+  /** True when the target passed validation and the order advanced. */
+  readonly advanced: boolean;
+  /** Construction-validation errors when the advance was blocked. */
+  readonly errors: readonly string[];
+}
+
+/**
+ * Attempt to advance a `proposed` refit order to `in-progress`.
+ *
+ * The advance is gated on the order's `targetConfiguration` passing the
+ * existing `construction-rules-core` validation (design D4):
+ *
+ *   - a valid target → status becomes `in-progress`, `validationErrors`
+ *     cleared
+ *   - an invalid target → status stays `proposed`, `validationErrors`
+ *     carries the construction-validation errors
+ *
+ * Advancing an order that is not `proposed` is a no-op — the order is
+ * returned unchanged with `advanced: false`.
+ *
+ * @param order - the order to advance
+ * @returns the advance result
+ */
+export function advanceRefitOrder(order: IRefitOrder): IRefitAdvanceResult {
+  if (order.status !== 'proposed') {
+    return { order, advanced: false, errors: [] };
+  }
+
+  const result = validateConstruction(order.targetConfiguration);
+
+  if (!result.isValid) {
+    return {
+      order: {
+        ...order,
+        status: 'proposed',
+        validationErrors: result.errors,
+      },
+      advanced: false,
+      errors: result.errors,
+    };
+  }
+
+  // Valid target — advance and clear any stale validation errors.
+  const { validationErrors: _cleared, ...rest } = order;
+  void _cleared;
+  return {
+    order: {
+      ...rest,
+      status: 'in-progress',
+    },
+    advanced: true,
+    errors: [],
+  };
+}
+
+// =============================================================================
+// Hour Advancement
+// =============================================================================
+
+/**
+ * Result of applying a day's tech-hours to a refit order.
+ */
+export interface IRefitHourResult {
+  /** The order after the hours were applied. */
+  readonly order: IRefitOrder;
+  /** True when this application completed the refit. */
+  readonly completed: boolean;
+  /** Tech-hours actually consumed (never more than the remaining budget). */
+  readonly hoursConsumed: number;
+}
+
+/**
+ * Advance an `in-progress` refit order by a day's available tech-hours.
+ *
+ * `hoursCompleted` increases by `availableHours`, capped at
+ * `estimatedHours`. When `hoursCompleted` reaches `estimatedHours` the
+ * order status flips to `completed`. An order that is not `in-progress`
+ * is returned unchanged.
+ *
+ * @param order - the order to advance
+ * @param availableHours - tech-hours available for refit work this day
+ * @returns the hour-application result
+ */
+export function applyRefitHours(
+  order: IRefitOrder,
+  availableHours: number,
+): IRefitHourResult {
+  if (order.status !== 'in-progress') {
+    return { order, completed: false, hoursConsumed: 0 };
+  }
+
+  const remaining = Math.max(0, order.estimatedHours - order.hoursCompleted);
+  const hoursConsumed = Math.max(0, Math.min(availableHours, remaining));
+  const nextHoursCompleted = order.hoursCompleted + hoursConsumed;
+  const completed = nextHoursCompleted >= order.estimatedHours;
+
+  return {
+    order: {
+      ...order,
+      hoursCompleted: nextHoursCompleted,
+      status: completed ? 'completed' : 'in-progress',
+    },
+    completed,
+    hoursConsumed,
+  };
+}

--- a/src/lib/campaign/refit/unitConfiguration.ts
+++ b/src/lib/campaign/refit/unitConfiguration.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit Configuration Resolution — campaign-side current build lookup
+ *
+ * The refit launch flow needs a unit's *current* `MechBuildConfig` to diff
+ * against the target. Per `add-campaign-refit-and-prestige` design D5 the
+ * campaign stores per-unit configurations on
+ * `campaign.unitConfigurations[unitId]` once a refit completes. Before any
+ * refit has run a unit has no stored config — `resolveUnitConfiguration`
+ * falls back to a standard medium-mech baseline so the launch flow always
+ * has a current build to diff against.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ * @module lib/campaign/refit/unitConfiguration
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import { ArmorTypeEnum } from '@/types/construction/ArmorType';
+import { CockpitType } from '@/types/construction/CockpitType';
+import { EngineType } from '@/types/construction/EngineType';
+import { GyroType } from '@/types/construction/GyroType';
+import { HeatSinkType } from '@/types/construction/HeatSinkType';
+import { InternalStructureType } from '@/types/construction/InternalStructureType';
+
+/**
+ * Standard 50-ton baseline build — a valid medium mech. Used as the
+ * fallback "current configuration" for a unit that has not yet been
+ * refit (and therefore has no stored campaign configuration).
+ */
+export const DEFAULT_UNIT_CONFIGURATION: MechBuildConfig = {
+  tonnage: 50,
+  engineRating: 250,
+  engineType: EngineType.STANDARD,
+  gyroType: GyroType.STANDARD,
+  internalStructureType: InternalStructureType.STANDARD,
+  armorType: ArmorTypeEnum.STANDARD,
+  totalArmorPoints: 160,
+  cockpitType: CockpitType.STANDARD,
+  heatSinkType: HeatSinkType.SINGLE,
+  totalHeatSinks: 10,
+  jumpMP: 0,
+};
+
+/**
+ * Resolve the current campaign configuration for a unit.
+ *
+ * Returns the stored configuration when the campaign has one (a previous
+ * refit completed for this unit), otherwise the standard baseline.
+ *
+ * @param campaign - the campaign to read
+ * @param unitId - the unit whose configuration is wanted
+ * @returns the unit's current `MechBuildConfig`
+ */
+export function resolveUnitConfiguration(
+  campaign: ICampaign,
+  unitId: string,
+): MechBuildConfig {
+  return campaign.unitConfigurations?.[unitId] ?? DEFAULT_UNIT_CONFIGURATION;
+}

--- a/src/pages/gameplay/campaigns/[id]/mech-bay.tsx
+++ b/src/pages/gameplay/campaigns/[id]/mech-bay.tsx
@@ -13,9 +13,12 @@ import React, { useEffect, useState } from 'react';
 
 import { BayError, BayLoading } from '@/components/campaign/bays/BayStates';
 import { MechBay } from '@/components/campaign/bays/MechBay';
+import { RefitLaunchPanel } from '@/components/campaign/bays/RefitLaunchPanel';
 import { CampaignNavigation } from '@/components/campaign/CampaignNavigation';
 import { EmptyState, PageLayout } from '@/components/ui';
+import { resolveUnitConfiguration } from '@/lib/campaign/refit/unitConfiguration';
 import { selectRepairBay } from '@/stores/campaign/campaignBaySelectors';
+import { commitRefitOrder } from '@/stores/campaign/campaignRefitActions';
 import { useCampaignPersistenceStore } from '@/stores/campaign/useCampaignPersistenceStore';
 import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
 import { useCampaignStore } from '@/stores/campaign/useCampaignStore';
@@ -34,6 +37,8 @@ export default function MechBayPage(): React.ReactElement {
     (state) => state.loadCampaign,
   );
   const [isClient, setIsClient] = useState(false);
+  // The unit currently selected for the refit launch flow (CP3, design D6).
+  const [refitUnitId, setRefitUnitId] = useState<string | null>(null);
 
   useEffect(() => {
     setIsClient(true);
@@ -74,6 +79,14 @@ export default function MechBayPage(): React.ReactElement {
 
   const repairBay = selectRepairBay(campaign);
 
+  // The unit selected for refit, and its current configuration.
+  const refitUnit = refitUnitId
+    ? (units.find((u) => u.unitId === refitUnitId) ?? null)
+    : null;
+  const refitCurrentConfig = refitUnit
+    ? resolveUnitConfiguration(campaign, refitUnit.unitId)
+    : null;
+
   return (
     <PageLayout
       title="Mech Bay"
@@ -91,7 +104,34 @@ export default function MechBayPage(): React.ReactElement {
           }}
         />
       ) : (
-        <MechBay units={units} repairBay={repairBay} campaignId={campaign.id} />
+        <>
+          {/* Refit launch flow (CP3, design D6) — opens above the grid
+              when the player picks a unit's Refit affordance. */}
+          {refitUnit && refitCurrentConfig ? (
+            <div className="mb-6">
+              <RefitLaunchPanel
+                unitId={refitUnit.unitId}
+                unitName={refitUnit.unitName}
+                currentConfiguration={refitCurrentConfig}
+                onCommit={(target) =>
+                  commitRefitOrder({
+                    unitId: refitUnit.unitId,
+                    currentConfiguration: refitCurrentConfig,
+                    targetConfiguration: target,
+                  })
+                }
+                onCancel={() => setRefitUnitId(null)}
+              />
+            </div>
+          ) : null}
+
+          <MechBay
+            units={units}
+            repairBay={repairBay}
+            campaignId={campaign.id}
+            onLaunchRefit={(unitId) => setRefitUnitId(unitId)}
+          />
+        </>
       )}
     </PageLayout>
   );

--- a/src/pages/gameplay/campaigns/[id]/prestige-morale.tsx
+++ b/src/pages/gameplay/campaigns/[id]/prestige-morale.tsx
@@ -1,0 +1,110 @@
+/**
+ * Campaign Prestige & Morale Page
+ *
+ * The read-only Prestige & Morale command surface (CP3 —
+ * `add-campaign-refit-and-prestige`, design D10). Shows the company's
+ * current morale state, recent morale transitions, and per-unit prestige
+ * scores. Morale and prestige change through day processors and the
+ * post-battle prestige step — the page exposes no mutation controls.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ */
+
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+
+import { CampaignNavigation } from '@/components/campaign/CampaignNavigation';
+import {
+  CommandError,
+  CommandLoading,
+} from '@/components/campaign/command/CommandStates';
+import { PrestigeMoralePanel } from '@/components/campaign/command/PrestigeMoralePanel';
+import { EmptyState, PageLayout } from '@/components/ui';
+import { useCampaignPersistenceStore } from '@/stores/campaign/useCampaignPersistenceStore';
+import { useCampaignStore } from '@/stores/campaign/useCampaignStore';
+import { MORALE_DEFAULT } from '@/types/campaign/Prestige';
+
+export default function PrestigeMoralePage(): React.ReactElement {
+  const router = useRouter();
+  const { id } = router.query;
+  const store = useCampaignStore();
+  const campaign = store.getState().getCampaign();
+  const saveState = useCampaignPersistenceStore((state) => state.saveState);
+  const errorMessage = useCampaignPersistenceStore(
+    (state) => state.errorMessage,
+  );
+  const loadCampaign = useCampaignPersistenceStore(
+    (state) => state.loadCampaign,
+  );
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  const breadcrumbs = [
+    { label: 'Home', href: '/' },
+    { label: 'Gameplay', href: '/gameplay' },
+    { label: 'Campaigns', href: '/gameplay/campaigns' },
+    { label: campaign?.name || 'Campaign', href: `/gameplay/campaigns/${id}` },
+    { label: 'Prestige & Morale' },
+  ];
+
+  // Loading state while the campaign resolves (design D10 / campaign-ui).
+  if (!isClient) {
+    return (
+      <PageLayout
+        title="Prestige & Morale"
+        subtitle="Loading company standing..."
+        maxWidth="wide"
+      >
+        <CommandLoading />
+      </PageLayout>
+    );
+  }
+
+  if (!campaign) {
+    return (
+      <PageLayout
+        title="Prestige & Morale"
+        subtitle="Campaign not found"
+        maxWidth="wide"
+        breadcrumbs={breadcrumbs}
+      >
+        <EmptyState
+          title="Campaign not found"
+          message="Return to campaigns list to select a campaign."
+        />
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout
+      title="Prestige & Morale"
+      subtitle={campaign.name}
+      maxWidth="wide"
+      breadcrumbs={breadcrumbs}
+    >
+      <CampaignNavigation
+        campaignId={campaign.id}
+        currentPage="prestige-morale"
+      />
+
+      {saveState === 'error' ? (
+        <CommandError
+          message={errorMessage ?? 'The campaign data failed to load.'}
+          onRetry={() => {
+            void loadCampaign(campaign.id);
+          }}
+        />
+      ) : (
+        <PrestigeMoralePanel
+          moraleState={campaign.moraleState ?? MORALE_DEFAULT}
+          moraleTransitions={campaign.moraleTransitions ?? []}
+          unitPrestige={campaign.unitPrestige ?? []}
+        />
+      )}
+    </PageLayout>
+  );
+}

--- a/src/stores/campaign/campaignRefitActions.ts
+++ b/src/stores/campaign/campaignRefitActions.ts
@@ -1,0 +1,116 @@
+/**
+ * Campaign Refit Actions — commit a refit order from the mech bay
+ *
+ * The refit launch flow (CP3 — `add-campaign-refit-and-prestige`, design
+ * D6) commits a refit order: `commitRefitOrder` creates a `proposed`
+ * `IRefitOrder` for an owned unit and, on construction-validation pass,
+ * advances it to `in-progress` (design D4). The order is appended to
+ * `campaign.refitOrders` and the campaign is marked dirty so the
+ * persistence store auto-saves.
+ *
+ * Mirrors `campaignCommandActions` — campaign mutation through the live
+ * store, dirty-mark for the debounced auto-save, graceful failure.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ * @module stores/campaign/campaignRefitActions
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { IRefitOrder } from '@/types/campaign/Refit';
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import {
+  advanceRefitOrder,
+  createRefitOrder,
+} from '@/lib/campaign/refit/refitPipeline';
+
+import { getCampaignStoreForRoster } from './campaignStoreAccessor';
+import { useCampaignPersistenceStore } from './useCampaignPersistenceStore';
+// Importing the campaign-store module registers the store accessor as a
+// side effect (same pattern as campaignCommandActions).
+import './useCampaignStore';
+
+// =============================================================================
+// Result Type
+// =============================================================================
+
+/**
+ * Result of committing a refit order.
+ */
+export interface ICommitRefitResult {
+  /** True when a refit order was created and appended to the campaign. */
+  readonly applied: boolean;
+  /** Human-readable failure reason when `applied` is false. */
+  readonly reason?: string;
+  /** The created refit order (whatever status it settled at). */
+  readonly order?: IRefitOrder;
+  /** Construction-validation errors when the order stayed `proposed`. */
+  readonly validationErrors?: readonly string[];
+}
+
+// =============================================================================
+// Commit
+// =============================================================================
+
+/**
+ * Parameters for committing a refit order.
+ */
+export interface ICommitRefitParams {
+  /** The owned campaign unit being refit. */
+  readonly unitId: string;
+  /** The unit's current configuration. */
+  readonly currentConfiguration: MechBuildConfig;
+  /** The desired target configuration. */
+  readonly targetConfiguration: MechBuildConfig;
+}
+
+/**
+ * Commit a refit order for an owned campaign unit.
+ *
+ * Creates a `proposed` `IRefitOrder` (with a fixed cost / hours estimate),
+ * then attempts to advance it to `in-progress` — which is gated on the
+ * target configuration passing construction validation (design D4). On a
+ * validation failure the order is still persisted, in `proposed` status,
+ * carrying the validation errors so the player can correct the target.
+ *
+ * @param params - the refit parameters
+ * @returns the commit result
+ */
+export function commitRefitOrder(
+  params: ICommitRefitParams,
+): ICommitRefitResult {
+  const store = getCampaignStoreForRoster();
+  if (!store) {
+    return { applied: false, reason: 'No campaign loaded' };
+  }
+  const campaign = store.getState().campaign as ICampaign | null;
+  if (!campaign) {
+    return { applied: false, reason: 'No campaign loaded' };
+  }
+
+  // Build the proposed order with a fixed estimate.
+  const proposed = createRefitOrder({
+    id: `refit-${params.unitId}-${Date.now()}`,
+    unitId: params.unitId,
+    currentConfiguration: params.currentConfiguration,
+    targetConfiguration: params.targetConfiguration,
+    createdAt: campaign.currentDate.toISOString(),
+  });
+
+  // Gate the proposed → in-progress advance on construction validation.
+  const advance = advanceRefitOrder(proposed);
+  const finalOrder = advance.order;
+
+  const nextOrders: readonly IRefitOrder[] = [
+    ...(campaign.refitOrders ?? []),
+    finalOrder,
+  ];
+  store.getState().updateCampaign({ refitOrders: nextOrders });
+  useCampaignPersistenceStore.getState().markDirty();
+
+  return {
+    applied: true,
+    order: finalOrder,
+    validationErrors: advance.advanced ? undefined : advance.errors,
+  };
+}

--- a/src/types/campaign/Campaign.ts
+++ b/src/types/campaign/Campaign.ts
@@ -8,10 +8,14 @@
  * @module campaign/Campaign
  */
 
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
 import type { IShoppingList } from './acquisition/acquisitionTypes';
 import type { ICampaignOptions } from './CampaignOptions';
 import type { IFactionStanding } from './factionStanding/IFactionStanding';
 import type { SalvageRights, CommandRights } from './Mission';
+import type { IMoraleTransition, IUnitPrestige, MoraleState } from './Prestige';
+import type { IRefitOrder } from './Refit';
 import type { ICombatTeam } from './scenario/scenarioTypes';
 import type { IUnitCombatState } from './UnitCombatState';
 
@@ -140,6 +144,42 @@ export interface ICampaign {
    * canonical shape contract and idempotency rules.
    */
   readonly unitCombatStates: Readonly<Record<string, IUnitCombatState>>;
+
+  /**
+   * Refit orders for owned campaign units (`add-campaign-refit-and-prestige`,
+   * design D2). Optional — absent on campaigns created before the change;
+   * defaults to an empty list. Refit processors narrow when they read.
+   */
+  readonly refitOrders?: readonly IRefitOrder[];
+
+  /**
+   * Per-unit campaign configuration, keyed by unitId
+   * (`add-campaign-refit-and-prestige`, design D5). The refit day
+   * processor writes a unit's completed `targetConfiguration` here when a
+   * refit finishes — this is the unit's current campaign loadout. Optional
+   * and absent on pre-change campaigns.
+   */
+  readonly unitConfigurations?: Readonly<Record<string, MechBuildConfig>>;
+
+  /**
+   * Per-unit prestige scores (`add-campaign-refit-and-prestige`, design D7).
+   * Optional — absent on pre-change campaigns; defaults to an empty list.
+   */
+  readonly unitPrestige?: readonly IUnitPrestige[];
+
+  /**
+   * Company morale state (`add-campaign-refit-and-prestige`, design D8).
+   * Optional — absent on pre-change campaigns; defaults to
+   * `MoraleState.Steady`.
+   */
+  readonly moraleState?: MoraleState;
+
+  /**
+   * Ordered company-morale transition history, oldest first
+   * (`add-campaign-refit-and-prestige`, design D9). Optional — defaults to
+   * an empty list.
+   */
+  readonly moraleTransitions?: readonly IMoraleTransition[];
 }
 
 // =============================================================================

--- a/src/types/campaign/Prestige.ts
+++ b/src/types/campaign/Prestige.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit Prestige and Company Morale Models
+ *
+ * Two campaign business-state types added by
+ * `add-campaign-refit-and-prestige`:
+ *
+ * - **`IUnitPrestige`** — a per-unit cohesion / reputation score, a bounded
+ *   integer adjusted by battle outcomes (victories raise, heavy damage and
+ *   crew loss lower it). See design D7.
+ * - **`MoraleState`** — the company-level morale state of an explicit,
+ *   linearly-ordered state machine. The morale processor applies at most
+ *   one step transition per day. See design D8.
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ * @module types/campaign/Prestige
+ */
+
+// =============================================================================
+// Unit Prestige
+// =============================================================================
+
+/** Inclusive lower bound of a unit's prestige score. */
+export const PRESTIGE_MIN = 0;
+
+/** Inclusive upper bound of a unit's prestige score. */
+export const PRESTIGE_MAX = 100;
+
+/** Prestige score a unit starts at before its first battle. */
+export const PRESTIGE_DEFAULT = 50;
+
+/**
+ * One entry in a unit's prestige history — a single applied adjustment.
+ * Lets the UI surface "recent prestige changes" without re-deriving them.
+ */
+export interface IUnitPrestigeHistoryEntry {
+  /** Match the adjustment was derived from. */
+  readonly matchId: string;
+  /** Signed delta applied to the score (post-clamp magnitude may differ). */
+  readonly delta: number;
+  /** Score after the adjustment was applied and clamped. */
+  readonly scoreAfter: number;
+  /** Short human-readable reason (e.g. "Victory", "Heavy damage"). */
+  readonly reason: string;
+  /** ISO-8601 timestamp the adjustment was applied. */
+  readonly appliedAt: string;
+}
+
+/**
+ * Per-unit prestige record. `score` is a bounded integer in
+ * `[PRESTIGE_MIN, PRESTIGE_MAX]`; `history` is the ordered list of
+ * adjustments, oldest first.
+ */
+export interface IUnitPrestige {
+  /** Unit this prestige record describes. */
+  readonly unitId: string;
+  /** Current bounded prestige score. */
+  readonly score: number;
+  /** Ordered adjustment history, oldest first. */
+  readonly history: readonly IUnitPrestigeHistoryEntry[];
+}
+
+// =============================================================================
+// Company Morale
+// =============================================================================
+
+/**
+ * Company morale states, linearly ordered worst-to-best. The morale
+ * processor moves the company at most one step per day along this order.
+ */
+export enum MoraleState {
+  Mutinous = 'mutinous',
+  Unhappy = 'unhappy',
+  Steady = 'steady',
+  High = 'high',
+  Elite = 'elite',
+}
+
+/**
+ * Morale states in worst-to-best order. The index of a state in this
+ * array is its ordinal rank — used to apply a one-step transition.
+ */
+export const MORALE_STATE_ORDER: readonly MoraleState[] = [
+  MoraleState.Mutinous,
+  MoraleState.Unhappy,
+  MoraleState.Steady,
+  MoraleState.High,
+  MoraleState.Elite,
+];
+
+/** Default morale state for a new campaign (design D8 / open question). */
+export const MORALE_DEFAULT: MoraleState = MoraleState.Steady;
+
+/**
+ * One recorded company-morale transition. Persisted on the campaign so the
+ * Prestige & Morale UI can list recent transitions.
+ */
+export interface IMoraleTransition {
+  /** Morale state before the transition. */
+  readonly from: MoraleState;
+  /** Morale state after the transition. */
+  readonly to: MoraleState;
+  /** Direction of the transition. */
+  readonly direction: 'up' | 'down';
+  /** Short human-readable reason. */
+  readonly reason: string;
+  /** ISO-8601 timestamp of the transition. */
+  readonly occurredAt: string;
+}
+
+/**
+ * The enumerated morale-affecting signal set the morale processor consumes
+ * for one day. Every field is a deterministic, named input — there is no
+ * hidden randomness (design D8).
+ */
+export interface IMoraleSignals {
+  /** Player victories recorded since the last morale evaluation. */
+  readonly recentVictories: number;
+  /** Player defeats recorded since the last morale evaluation. */
+  readonly recentDefeats: number;
+  /** True if the company met its pay obligations this period. */
+  readonly payMet: boolean;
+  /** Count of personnel who deserted since the last evaluation. */
+  readonly desertions: number;
+}
+
+/**
+ * Get the ordinal rank of a morale state (0 = worst, 4 = best).
+ */
+export function moraleRank(state: MoraleState): number {
+  return MORALE_STATE_ORDER.indexOf(state);
+}

--- a/src/types/campaign/Refit.ts
+++ b/src/types/campaign/Refit.ts
@@ -1,0 +1,115 @@
+/**
+ * Refit Order Model — campaign equipment-swap / variant / chassis refit
+ *
+ * An `IRefitOrder` describes a target configuration for an owned campaign
+ * unit, modelled on the repair-ticket pipeline: it carries an hour budget
+ * (`estimatedHours`) consumed per day by the refit processor and a status
+ * lifecycle (`proposed → in-progress → completed`, plus `cancelled`).
+ *
+ * Refit deliberately reuses — never reimplements — the existing
+ * construction validation. A `proposed` order only advances to
+ * `in-progress` once its `targetConfiguration` passes
+ * `validateConstruction` (see `add-campaign-refit-and-prestige` design D4).
+ *
+ * @spec openspec/changes/add-campaign-refit-and-prestige/specs/campaign-refit-and-prestige/spec.md
+ * @module types/campaign/Refit
+ */
+
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+// =============================================================================
+// Refit Class
+// =============================================================================
+
+/**
+ * Difficulty / scope class of a refit, graded by how disruptive the change
+ * is. The classifier (`classifyRefit`) returns the least-disruptive class
+ * that covers the diff between the unit's current and target configuration.
+ *
+ * - `EquipmentSwap` — swap mounted items, same chassis/variant; cheap, fast
+ * - `VariantUpgrade` — change armour / heat-sink loadout to a known variant
+ *   of the same chassis; moderate cost and time
+ * - `ChassisConversion` — structural change (engine, internal structure);
+ *   expensive and slow
+ */
+export enum RefitClass {
+  EquipmentSwap = 'equipment-swap',
+  VariantUpgrade = 'variant-upgrade',
+  ChassisConversion = 'chassis-conversion',
+}
+
+/**
+ * Ordered list of refit classes, cheapest first. Used by `classifyRefit`
+ * to express "the least-disruptive covering class".
+ */
+export const REFIT_CLASS_ORDER: readonly RefitClass[] = [
+  RefitClass.EquipmentSwap,
+  RefitClass.VariantUpgrade,
+  RefitClass.ChassisConversion,
+];
+
+/**
+ * Lifecycle status of a refit order.
+ *
+ * - `proposed` — created, not yet validated against construction rules
+ * - `in-progress` — construction-validated, tech-hours being consumed
+ * - `completed` — hour budget met, target configuration applied
+ * - `cancelled` — abandoned by the player before completion
+ */
+export type RefitStatus =
+  | 'proposed'
+  | 'in-progress'
+  | 'completed'
+  | 'cancelled';
+
+// =============================================================================
+// Refit Order
+// =============================================================================
+
+/**
+ * A refit order for an owned campaign unit.
+ *
+ * The `targetConfiguration` is the full target unit build — produced by
+ * the existing construction tooling, not by refit. `estimatedCost` and
+ * `estimatedHours` are fixed when the order is committed (see design D3);
+ * `hoursCompleted` advances each day until it reaches `estimatedHours`.
+ */
+export interface IRefitOrder {
+  /** Unique identifier for this refit order. */
+  readonly id: string;
+
+  /** The owned campaign unit being refit. */
+  readonly unitId: string;
+
+  /**
+   * The full target unit configuration the refit converts the unit to.
+   * Stored as a `MechBuildConfig` so the construction-validation gate can
+   * run against it directly.
+   */
+  readonly targetConfiguration: MechBuildConfig;
+
+  /** Classified scope of the refit. */
+  readonly refitClass: RefitClass;
+
+  /** Estimated C-bill cost, fixed at commit time. */
+  readonly estimatedCost: number;
+
+  /** Estimated tech-hours, fixed at commit time. */
+  readonly estimatedHours: number;
+
+  /** Tech-hours consumed so far by the refit processor. */
+  readonly hoursCompleted: number;
+
+  /** Current lifecycle status. */
+  readonly status: RefitStatus;
+
+  /** Creation timestamp (ISO 8601). */
+  readonly createdAt: string;
+
+  /**
+   * Construction-validation errors surfaced when a `proposed → in-progress`
+   * advance was blocked by an invalid target (design D4). Absent on a
+   * valid order.
+   */
+  readonly validationErrors?: readonly string[];
+}


### PR DESCRIPTION
## Summary

Implements the OpenSpec change `add-campaign-refit-and-prestige` — the final Wave 4 change (CP3). Adds two campaign business systems: the **refit / equipment-swap pipeline** and the **prestige + company-morale state machine**. Scoped narrow — faction standing, markets, and contract negotiation are untouched.

## Refit

- `IRefitOrder` + `RefitClass` enum; optional `refitOrders` + `unitConfigurations` campaign fields (absent on existing campaigns).
- `classifyRefit` diffs current vs target `MechBuildConfig` into the least-disruptive covering class (equipment-swap / variant-upgrade / chassis-conversion).
- `estimateRefit` derives C-bill cost + tech-hours from the diff and a per-class multiplier — deterministic, fixed at commit.
- `advanceRefitOrder` gates `proposed → in-progress` on the existing `construction-rules-core` validation; an invalid target stays `proposed` and surfaces the errors.
- `refitProcessor` (DayPhase.UNITS) consumes tech-hours per day, completes a refit when its hour budget is met, swaps the unit configuration, emits a day event.
- `RefitLaunchPanel` + per-unit "Refit" affordance on the Mech Bay.

## Prestige & Morale

- `IUnitPrestige` bounded 0–100 score + `adjustPrestige`; the post-battle processor runs the prestige-update step on every applied outcome.
- `MoraleState` linear state machine; `evaluateMoraleTransition` applies at most one step per day from an enumerated signal set (victories / defeats / pay / desertions).
- `moraleProcessor` (DayPhase.EVENTS) gathers the day's signals, applies the transition, emits a day event on change.
- Read-only Prestige & Morale page + campaign-navigation entry.

## Verification

- `npx tsc --noEmit` — 0 errors
- `npx oxlint` — 0 warnings/errors on changed files
- `npx jest` — 25070 passing, 0 regressions (317 new tests)
- `npx openspec validate add-campaign-refit-and-prestige --strict` — valid
- All 34 tasks complete; every spec scenario covered by a test.

## Notes / decisions

- Tech-hour budget sharing (design open question): refit uses a fixed `DEFAULT_DAILY_REFIT_HOURS` per-day allowance — the simplest "repairs-first" policy.
- `unitConfigurations` campaign map added to satisfy "replace the unit's campaign configuration" — campaigns had no per-unit build storage.
- The refit launch editor is scoped to engine/armour/heat-sink/jump fields; a full unit editor is out of scope (refit validates a target, it does not reimplement construction).

The OpenSpec change is NOT archived per instructions.