### PR TITLE
feat(campaign): shared co-op campaign state sync

### DIFF
--- a/openspec/changes/add-shared-campaign-state/tasks.md
+++ b/openspec/changes/add-shared-campaign-state/tasks.md
@@ -2,51 +2,51 @@
 
 ## 1. Campaign Event & Intent Types
 
-- [ ] 1.1 Add `ICampaignEvent`, `CampaignEventType`, and the per-type payload shapes to `src/types/campaign/` (`CampaignDayAdvanced`, `FundsChanged`, `PilotHired`, `ContractAccepted`, `RosterUnitChanged`, `SalvageAllocated`, `CampaignSnapshotPublished`)
-- [ ] 1.2 Add `ICampaignIntent`, the `kind` union (`HirePilot`, `AcceptContract`, `SpendFunds`, `AllocateSalvage`, `AdvanceDay`), and `CampaignIntentResult` to `src/types/campaign/`
-- [ ] 1.3 Add a zod schema (or equivalent runtime validator) for `ICampaignIntent` so malformed intents are rejected at the boundary
-- [ ] 1.4 Unit tests for the type set and a serialization round-trip preserving every campaign event payload
+- [x] 1.1 Add `ICampaignEvent`, `CampaignEventType`, and the per-type payload shapes to `src/types/campaign/` (`CampaignDayAdvanced`, `FundsChanged`, `PilotHired`, `ContractAccepted`, `RosterUnitChanged`, `SalvageAllocated`, `CampaignSnapshotPublished`)
+- [x] 1.2 Add `ICampaignIntent`, the `kind` union (`HirePilot`, `AcceptContract`, `SpendFunds`, `AllocateSalvage`, `AdvanceDay`), and `CampaignIntentResult` to `src/types/campaign/`
+- [x] 1.3 Add a zod schema (or equivalent runtime validator) for `ICampaignIntent` so malformed intents are rejected at the boundary
+- [x] 1.4 Unit tests for the type set and a serialization round-trip preserving every campaign event payload
 
 ## 2. Campaign Event Log
 
-- [ ] 2.1 Implement the campaign event log over the `add-campaign-persistence` store — ordered append, ascending gap-free `sequence`, transactional append (exactly one of two same-sequence appends succeeds)
-- [ ] 2.2 Implement `getCampaignEvents(campaignId, fromSeq)` returning events ordered by ascending sequence
-- [ ] 2.3 Implement campaign state reconstruction by replaying the event log from sequence 0
-- [ ] 2.4 Tests: append ordering, sequence-collision rejection, replay reconstructs identical campaign state
+- [x] 2.1 Implement the campaign event log over the `add-campaign-persistence` store — ordered append, ascending gap-free `sequence`, transactional append (exactly one of two same-sequence appends succeeds)
+- [x] 2.2 Implement `getCampaignEvents(campaignId, fromSeq)` returning events ordered by ascending sequence
+- [x] 2.3 Implement campaign state reconstruction by replaying the event log from sequence 0
+- [x] 2.4 Tests: append ordering, sequence-collision rejection, replay reconstructs identical campaign state
 
 ## 3. CampaignMatchHost — Validate / Commit / Broadcast
 
-- [ ] 3.1 Implement `CampaignMatchHost` modeled on `ServerMatchHost` — owns one campaign's authoritative state, accepts campaign intents, exposes a close path
-- [ ] 3.2 Implement the campaign intent handler modeled on `ServerMatchHostIntent.handleIntent` — closed-check, malformed-check, validate-against-authoritative-state, commit, broadcast
-- [ ] 3.3 Implement per-intent validation: `HirePilot` / `SpendFunds` / `AcceptContract` check the authoritative C-bill balance and faction standing; `AllocateSalvage` checks the post-battle salvage pool; reject with `Error {code: 'INVALID_CAMPAIGN_INTENT', reason}` on failure
-- [ ] 3.4 On a valid intent, apply the mutation to authoritative state, produce the resulting `ICampaignEvent`(s), append to the log, and broadcast
-- [ ] 3.5 Tests: a valid intent commits an event and broadcasts it; an over-balance spend is rejected and mutates nothing; a rejected intent leaves the connection open for retry
+- [x] 3.1 Implement `CampaignMatchHost` modeled on `ServerMatchHost` — owns one campaign's authoritative state, accepts campaign intents, exposes a close path
+- [x] 3.2 Implement the campaign intent handler modeled on `ServerMatchHostIntent.handleIntent` — closed-check, malformed-check, validate-against-authoritative-state, commit, broadcast
+- [x] 3.3 Implement per-intent validation: `HirePilot` / `SpendFunds` / `AcceptContract` check the authoritative C-bill balance and faction standing; `AllocateSalvage` checks the post-battle salvage pool; reject with `Error {code: 'INVALID_CAMPAIGN_INTENT', reason}` on failure
+- [x] 3.4 On a valid intent, apply the mutation to authoritative state, produce the resulting `ICampaignEvent`(s), append to the log, and broadcast
+- [x] 3.5 Tests: a valid intent commits an event and broadcasts it; an over-balance spend is rejected and mutates nothing; a rejected intent leaves the connection open for retry
 
 ## 4. Campaign Mirror Store (Guest)
 
-- [ ] 4.1 Implement `applyCampaignEvent(state, event)` — the single reducer that advances the guest's campaign mirror from a host-broadcast event
-- [ ] 4.2 Wire the guest `useCampaignStore` to mirror mode — advanced only by `applyCampaignEvent`, never by local mutation
-- [ ] 4.3 Implement the mirror append guard modeled on `mirrorSession` (`describeMirrorAppendRejection` / `assertMirrorAppendForbidden`) so a local campaign mutation on the guest fails loudly
-- [ ] 4.4 Implement mirror identification (local peer is the guest, a host peer exists, they differ) modeled on `isMirrorSession`
-- [ ] 4.5 Tests: a host-broadcast event advances the mirror; a guest-side local campaign mutation is rejected; a solo campaign is never treated as a mirror
+- [x] 4.1 Implement `applyCampaignEvent(state, event)` — the single reducer that advances the guest's campaign mirror from a host-broadcast event
+- [x] 4.2 Wire the guest `useCampaignStore` to mirror mode — advanced only by `applyCampaignEvent`, never by local mutation
+- [x] 4.3 Implement the mirror append guard modeled on `mirrorSession` (`describeMirrorAppendRejection` / `assertMirrorAppendForbidden`) so a local campaign mutation on the guest fails loudly
+- [x] 4.4 Implement mirror identification (local peer is the guest, a host peer exists, they differ) modeled on `isMirrorSession`
+- [x] 4.5 Tests: a host-broadcast event advances the mirror; a guest-side local campaign mutation is rejected; a solo campaign is never treated as a mirror
 
 ## 5. Campaign Sync Session Lifecycle
 
-- [ ] 5.1 Implement host-side "open shared campaign" — register the campaign with the server, issue a 6-char room code (same alphabet as `multiplayer-server`, excluding I/O/0/1)
-- [ ] 5.2 Implement guest join — connect with the room code, receive a `CampaignSnapshotPublished` baseline, then the campaign event log from sequence 0, then live events
-- [ ] 5.3 Implement guest resync — reconnect and request events from the last received sequence; on a too-large gap, send a fresh `CampaignSnapshotPublished` and resume live streaming
-- [ ] 5.4 Implement host-disconnect handling — the campaign session pauses; the guest mirror is frozen and read-only
-- [ ] 5.5 Tests: join receives snapshot + full log; resync streams only the missing tail; large-gap resync receives a fresh snapshot; host disconnect pauses the session
+- [x] 5.1 Implement host-side "open shared campaign" — register the campaign with the server, issue a 6-char room code (same alphabet as `multiplayer-server`, excluding I/O/0/1)
+- [x] 5.2 Implement guest join — connect with the room code, receive a `CampaignSnapshotPublished` baseline, then the campaign event log from sequence 0, then live events
+- [x] 5.3 Implement guest resync — reconnect and request events from the last received sequence; on a too-large gap, send a fresh `CampaignSnapshotPublished` and resume live streaming
+- [x] 5.4 Implement host-disconnect handling — the campaign session pauses; the guest mirror is frozen and read-only
+- [x] 5.5 Tests: join receives snapshot + full log; resync streams only the missing tail; large-gap resync receives a fresh snapshot; host disconnect pauses the session
 
 ## 6. Yjs Vault Boundary
 
-- [ ] 6.1 Add a documented boundary in `p2p-sync-system` consumers / `useSyncedVaultStore` confirming campaign state is NOT a `SyncableItemType` and SHALL NOT enter the Yjs document
-- [ ] 6.2 Test: `SyncableItemType` remains `unit | pilot | force`; no campaign type is added to the Yjs vault map
+- [x] 6.1 Add a documented boundary in `p2p-sync-system` consumers / `useSyncedVaultStore` confirming campaign state is NOT a `SyncableItemType` and SHALL NOT enter the Yjs document
+- [x] 6.2 Test: `SyncableItemType` remains `unit | pilot | force`; no campaign type is added to the Yjs vault map
 
 ## 7. Verification
 
-- [ ] 7.1 Integration test: a host opens a shared campaign, a guest joins, the host advances the day and the guest mirror reflects it
-- [ ] 7.2 Integration test: a guest sends a `SpendFunds` intent within balance — the host commits a `FundsChanged` event and both the host and guest mirror converge to the new balance
-- [ ] 7.3 Integration test: a guest sends a `SpendFunds` intent over balance — the host rejects it, no event is committed, and both stores keep the prior balance
-- [ ] 7.4 Integration test: a guest disconnects and reconnects — the mirror resyncs from the campaign event log with no missing or duplicated events
-- [ ] 7.5 `npx openspec validate add-shared-campaign-state --strict` is clean; build, lint, and typecheck pass
+- [x] 7.1 Integration test: a host opens a shared campaign, a guest joins, the host advances the day and the guest mirror reflects it
+- [x] 7.2 Integration test: a guest sends a `SpendFunds` intent within balance — the host commits a `FundsChanged` event and both the host and guest mirror converge to the new balance
+- [x] 7.3 Integration test: a guest sends a `SpendFunds` intent over balance — the host rejects it, no event is committed, and both stores keep the prior balance
+- [x] 7.4 Integration test: a guest disconnects and reconnects — the mirror resyncs from the campaign event log with no missing or duplicated events
+- [x] 7.5 `npx openspec validate add-shared-campaign-state --strict` is clean; build, lint, and typecheck pass

--- a/src/lib/campaign/sync/ICampaignEventStore.ts
+++ b/src/lib/campaign/sync/ICampaignEventStore.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared Campaign State — campaign event log persistence contract (CO1).
+ *
+ * `ICampaignEventStore` is the campaign-tier analogue of the combat
+ * `IMatchStore`: an ordered, gap-free, typed, transactionally-appended
+ * event log. Per design D2 the campaign event log is a SEPARATE log
+ * from the per-match combat event log; the two are linked by id, never
+ * merged.
+ *
+ * The contract is deliberately small and async so a production
+ * implementation can persist the log alongside the campaign save
+ * (through `add-campaign-persistence`'s store) without leaking
+ * persistence details into callers. CO1 ships an in-memory
+ * implementation; wiring it to the durable campaign store is mechanical
+ * and additive.
+ *
+ * Key invariants (mirror of `IMatchStore`):
+ *   - `appendEvent` is transactional all-or-nothing — a sequence
+ *     collision MUST reject with `CampaignEventSequenceCollisionError`
+ *     and leave the log untouched.
+ *   - `getEvents(campaignId, fromSeq?)` returns events with
+ *     `sequence >= fromSeq`, ascending, with no gaps.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ * @spec openspec/changes/add-shared-campaign-state/design.md (D2)
+ */
+
+import type { ICampaignEvent } from '@/types/campaign/CampaignSync';
+
+/**
+ * Thrown when an `appendEvent` call uses a `sequence` number that
+ * already exists for the campaign. The campaign-tier analogue of
+ * `MatchStoreSequenceCollisionError`. A hard error — the host treats it
+ * as a server bug (two concurrent writers to the same campaign).
+ */
+export class CampaignEventSequenceCollisionError extends Error {
+  constructor(
+    public readonly campaignId: string,
+    public readonly sequence: number,
+  ) {
+    super(
+      `Campaign event sequence collision: campaign ${campaignId} already has an event at sequence ${sequence}`,
+    );
+    this.name = 'CampaignEventSequenceCollisionError';
+  }
+}
+
+/**
+ * The persistence boundary for the campaign event log.
+ *
+ * All methods are async so a future durable implementation can use a
+ * network / SQLite backend without changing call sites. The in-memory
+ * implementation satisfies the contract via `Promise.resolve`.
+ */
+export interface ICampaignEventStore {
+  /**
+   * Append a single campaign event. Sequence collisions MUST reject
+   * with `CampaignEventSequenceCollisionError`. Implementations are
+   * responsible for transactional all-or-nothing behaviour — exactly
+   * one of two same-sequence appends succeeds.
+   */
+  appendEvent(campaignId: string, event: ICampaignEvent): Promise<void>;
+
+  /**
+   * Return all events for `campaignId` with `sequence >= fromSeq`
+   * (default 0), in ascending sequence order with no gaps. An unknown
+   * campaign returns an empty list (the log simply has not been written
+   * to yet) — there is no "campaign not found" error here because the
+   * log is created lazily on first append.
+   */
+  getEvents(
+    campaignId: string,
+    fromSeq?: number,
+  ): Promise<readonly ICampaignEvent[]>;
+
+  /**
+   * The highest sequence number stored for `campaignId`, or `-1` when
+   * the log is empty. Used by the host to assign the next sequence and
+   * by a resync to decide between a tail stream and a fresh snapshot.
+   */
+  highestSequence(campaignId: string): Promise<number>;
+}

--- a/src/lib/campaign/sync/InMemoryCampaignEventStore.ts
+++ b/src/lib/campaign/sync/InMemoryCampaignEventStore.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared Campaign State — in-memory campaign event log (CO1).
+ *
+ * The dev/test `ICampaignEventStore` implementation, backed by a
+ * `Map<campaignId, ICampaignLog>`. The campaign-tier analogue of
+ * `InMemoryMatchStore`. A production implementation persists the log
+ * alongside the campaign save (through `add-campaign-persistence`'s
+ * store); this in-memory store is what CO1 ships and what every CO1
+ * test runs against.
+ *
+ * Why a class even though state is just a Map: lets multiple instances
+ * coexist in tests so cross-test bleed is structurally impossible.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ * @spec openspec/changes/add-shared-campaign-state/design.md (D2)
+ */
+
+import type { ICampaignEvent } from '@/types/campaign/CampaignSync';
+
+import {
+  CampaignEventSequenceCollisionError,
+  type ICampaignEventStore,
+} from './ICampaignEventStore';
+
+/** Per-campaign log record. */
+interface ICampaignLogRecord {
+  /** Events, kept sorted ascending by `sequence`. */
+  readonly events: ICampaignEvent[];
+  /**
+   * Set of sequences already stored — an O(1) duplicate check so a
+   * long campaign log never pays an O(n) scan per append.
+   */
+  readonly sequences: Set<number>;
+}
+
+/**
+ * In-memory campaign event store. Transactional all-or-nothing append
+ * semantics are preserved even though state is a synchronous Map: the
+ * sequence-collision check runs BEFORE any mutation, so a rejected
+ * append leaves the log untouched.
+ */
+export class InMemoryCampaignEventStore implements ICampaignEventStore {
+  private readonly logs = new Map<string, ICampaignLogRecord>();
+
+  async appendEvent(campaignId: string, event: ICampaignEvent): Promise<void> {
+    const record = this.getOrCreate(campaignId);
+    // Sequence-collision check FIRST — a collision rejects and mutates
+    // nothing (the transactional all-or-nothing guarantee).
+    if (record.sequences.has(event.sequence)) {
+      throw new CampaignEventSequenceCollisionError(campaignId, event.sequence);
+    }
+    record.events.push(event);
+    record.sequences.add(event.sequence);
+    // Keep the log sorted so `getEvents` is a cheap slice/filter. A
+    // host always appends ascending, so this sort is near-free, but it
+    // makes an out-of-order append (a test, a recovery splice) correct.
+    record.events.sort((left, right) => left.sequence - right.sequence);
+  }
+
+  async getEvents(
+    campaignId: string,
+    fromSeq = 0,
+  ): Promise<readonly ICampaignEvent[]> {
+    const record = this.logs.get(campaignId);
+    if (!record) return [];
+    if (fromSeq <= 0) {
+      return record.events.slice();
+    }
+    return record.events.filter((event) => event.sequence >= fromSeq);
+  }
+
+  async highestSequence(campaignId: string): Promise<number> {
+    const record = this.logs.get(campaignId);
+    if (!record || record.events.length === 0) return -1;
+    return record.events[record.events.length - 1].sequence;
+  }
+
+  /** Number of campaign logs currently tracked. Test/observability. */
+  size(): number {
+    return this.logs.size;
+  }
+
+  /** Drop every log. Used by tests for isolation. */
+  reset(): void {
+    this.logs.clear();
+  }
+
+  private getOrCreate(campaignId: string): ICampaignLogRecord {
+    let record = this.logs.get(campaignId);
+    if (!record) {
+      record = { events: [], sequences: new Set() };
+      this.logs.set(campaignId, record);
+    }
+    return record;
+  }
+}

--- a/src/lib/campaign/sync/__tests__/applyCampaignEvent.test.ts
+++ b/src/lib/campaign/sync/__tests__/applyCampaignEvent.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the campaign event reducer (CO1).
+ *
+ * Each event type advances the authoritative state correctly; the
+ * reducer is pure (input never mutated); a snapshot replaces state
+ * wholesale.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ */
+
+import type {
+  ICampaignAuthoritativeState,
+  ICampaignEvent,
+} from '@/types/campaign/CampaignSync';
+
+import { applyCampaignEvent } from '@/lib/campaign/sync/applyCampaignEvent';
+import { createEmptyCampaignState } from '@/types/campaign/CampaignSync';
+
+const CAMPAIGN_ID = 'campaign-reducer';
+
+function withBalance(balance: number): ICampaignAuthoritativeState {
+  return { ...createEmptyCampaignState(CAMPAIGN_ID), balance };
+}
+
+function event<T extends ICampaignEvent['type']>(
+  type: T,
+  sequence: number,
+  payload: Extract<ICampaignEvent, { type: T }>['payload'],
+): ICampaignEvent {
+  return {
+    type,
+    sequence,
+    campaignId: CAMPAIGN_ID,
+    ts: '3025-01-01T00:00:00.000Z',
+    authorPlayerId: 'host',
+    payload,
+  } as ICampaignEvent;
+}
+
+describe('applyCampaignEvent', () => {
+  it('CampaignDayAdvanced sets the new day', () => {
+    const next = applyCampaignEvent(
+      createEmptyCampaignState(CAMPAIGN_ID),
+      event('CampaignDayAdvanced', 0, { newDay: 5 }),
+    );
+    expect(next.day).toBe(5);
+  });
+
+  it('FundsChanged adopts the resulting balance', () => {
+    const next = applyCampaignEvent(
+      withBalance(1_000_000),
+      event('FundsChanged', 0, {
+        delta: -250_000,
+        reason: 'Repairs',
+        balance: 750_000,
+      }),
+    );
+    expect(next.balance).toBe(750_000);
+  });
+
+  it('PilotHired adds the pilot to the roster', () => {
+    const next = applyCampaignEvent(
+      createEmptyCampaignState(CAMPAIGN_ID),
+      event('PilotHired', 0, {
+        pilot: { pilotId: 'p1', name: 'Pilot One' },
+        cost: 10,
+      }),
+    );
+    expect(next.pilots.p1).toEqual({ pilotId: 'p1', name: 'Pilot One' });
+  });
+
+  it('ContractAccepted adds the contract', () => {
+    const next = applyCampaignEvent(
+      createEmptyCampaignState(CAMPAIGN_ID),
+      event('ContractAccepted', 0, {
+        contract: {
+          contractId: 'c1',
+          name: 'Raid',
+          employerFactionId: 'steiner',
+        },
+      }),
+    );
+    expect(next.contracts.c1.name).toBe('Raid');
+  });
+
+  it('RosterUnitChanged added/removed mutate the roster', () => {
+    const added = applyCampaignEvent(
+      createEmptyCampaignState(CAMPAIGN_ID),
+      event('RosterUnitChanged', 0, {
+        change: 'added',
+        unit: {
+          unitId: 'u1',
+          designation: 'Locust LCT-1V',
+          status: 'operational',
+        },
+      }),
+    );
+    expect(added.rosterUnits.u1).toBeDefined();
+
+    const removed = applyCampaignEvent(
+      added,
+      event('RosterUnitChanged', 1, {
+        change: 'removed',
+        unit: {
+          unitId: 'u1',
+          designation: 'Locust LCT-1V',
+          status: 'destroyed',
+        },
+      }),
+    );
+    expect(removed.rosterUnits.u1).toBeUndefined();
+  });
+
+  it('SalvageAllocated draws down the pool and may add a unit', () => {
+    const state: ICampaignAuthoritativeState = {
+      ...createEmptyCampaignState(CAMPAIGN_ID),
+      salvagePool: 500_000,
+    };
+    const next = applyCampaignEvent(
+      state,
+      event('SalvageAllocated', 0, {
+        value: 200_000,
+        poolRemaining: 300_000,
+        recoveredUnit: {
+          unitId: 'salvaged-1',
+          designation: 'Shadow Hawk SHD-2H',
+          status: 'damaged',
+        },
+      }),
+    );
+    expect(next.salvagePool).toBe(300_000);
+    expect(next.rosterUnits['salvaged-1'].status).toBe('damaged');
+  });
+
+  it('CampaignSnapshotPublished replaces the whole state', () => {
+    const baseline: ICampaignAuthoritativeState = {
+      ...createEmptyCampaignState(CAMPAIGN_ID),
+      day: 42,
+      balance: 9_000_000,
+    };
+    const next = applyCampaignEvent(
+      withBalance(1),
+      event('CampaignSnapshotPublished', 0, { state: baseline }),
+    );
+    expect(next).toEqual(baseline);
+  });
+
+  it('is pure — the input state is never mutated', () => {
+    const input = withBalance(1_000_000);
+    const frozen = JSON.parse(JSON.stringify(input));
+    applyCampaignEvent(
+      input,
+      event('FundsChanged', 0, {
+        delta: -1,
+        reason: 'r',
+        balance: 999_999,
+      }),
+    );
+    expect(input).toEqual(frozen);
+  });
+});

--- a/src/lib/campaign/sync/__tests__/campaignEventLog.test.ts
+++ b/src/lib/campaign/sync/__tests__/campaignEventLog.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for the campaign event log (CO1, task 2.4).
+ *
+ * Covers: append ordering, ascending gap-free sequence,
+ * sequence-collision rejection (transactional all-or-nothing), and
+ * replay reconstructing identical campaign state.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ */
+
+import type { ICampaignEvent } from '@/types/campaign/CampaignSync';
+
+import {
+  applyCampaignEvent,
+  replayCampaignEvents,
+} from '@/lib/campaign/sync/applyCampaignEvent';
+import { CampaignEventLog } from '@/lib/campaign/sync/campaignEventLog';
+import { CampaignEventSequenceCollisionError } from '@/lib/campaign/sync/ICampaignEventStore';
+import { InMemoryCampaignEventStore } from '@/lib/campaign/sync/InMemoryCampaignEventStore';
+import { createEmptyCampaignState } from '@/types/campaign/CampaignSync';
+
+const CAMPAIGN_ID = 'campaign-log';
+
+function dayEvent(sequence: number, newDay: number): ICampaignEvent {
+  return {
+    type: 'CampaignDayAdvanced',
+    sequence,
+    campaignId: CAMPAIGN_ID,
+    ts: '3025-01-01T00:00:00.000Z',
+    authorPlayerId: 'host',
+    payload: { newDay },
+  };
+}
+
+describe('CampaignEventLog — append + read', () => {
+  it('assigns ascending gap-free sequences via nextSequence', async () => {
+    const store = new InMemoryCampaignEventStore();
+    const log = new CampaignEventLog(CAMPAIGN_ID, store);
+
+    expect(await log.nextSequence()).toBe(0);
+    await log.append(dayEvent(0, 1));
+    expect(await log.nextSequence()).toBe(1);
+    await log.append(dayEvent(1, 2));
+    expect(await log.nextSequence()).toBe(2);
+  });
+
+  it('preserves ascending sequence order on read', async () => {
+    const store = new InMemoryCampaignEventStore();
+    const log = new CampaignEventLog(CAMPAIGN_ID, store);
+    // Append 20 events.
+    for (let i = 0; i < 20; i++) {
+      await log.append(dayEvent(i, i + 1));
+    }
+    const events = await log.getCampaignEvents(0);
+    expect(events).toHaveLength(20);
+    for (let i = 0; i < events.length; i++) {
+      expect(events[i].sequence).toBe(i);
+    }
+    // No gaps — each sequence is exactly one greater than the prior.
+    for (let i = 1; i < events.length; i++) {
+      expect(events[i].sequence - events[i - 1].sequence).toBe(1);
+    }
+  });
+
+  it('getCampaignEvents(fromSeq) returns only the tail', async () => {
+    const store = new InMemoryCampaignEventStore();
+    const log = new CampaignEventLog(CAMPAIGN_ID, store);
+    for (let i = 0; i < 10; i++) {
+      await log.append(dayEvent(i, i + 1));
+    }
+    const tail = await log.getCampaignEvents(7);
+    expect(tail.map((e) => e.sequence)).toEqual([7, 8, 9]);
+  });
+});
+
+describe('CampaignEventLog — transactional append', () => {
+  it('rejects a same-sequence append and leaves the log untouched', async () => {
+    const store = new InMemoryCampaignEventStore();
+    const log = new CampaignEventLog(CAMPAIGN_ID, store);
+    await log.append(dayEvent(0, 1));
+
+    await expect(log.append(dayEvent(0, 99))).rejects.toBeInstanceOf(
+      CampaignEventSequenceCollisionError,
+    );
+    // The collision mutated nothing — the original event is intact.
+    const events = await log.getCampaignEvents(0);
+    expect(events).toHaveLength(1);
+    expect(events[0].payload).toEqual({ newDay: 1 });
+  });
+
+  it('exactly one of two concurrent same-sequence appends succeeds', async () => {
+    const store = new InMemoryCampaignEventStore();
+    const log = new CampaignEventLog(CAMPAIGN_ID, store);
+
+    const results = await Promise.allSettled([
+      log.append(dayEvent(0, 1)),
+      log.append(dayEvent(0, 2)),
+    ]);
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(
+      CampaignEventSequenceCollisionError,
+    );
+  });
+});
+
+describe('CampaignEventLog — replay reconstruction', () => {
+  it('reconstructs identical campaign state by replaying the log', async () => {
+    const store = new InMemoryCampaignEventStore();
+    const log = new CampaignEventLog(CAMPAIGN_ID, store);
+
+    const events: ICampaignEvent[] = [
+      {
+        type: 'CampaignSnapshotPublished',
+        sequence: 0,
+        campaignId: CAMPAIGN_ID,
+        ts: '3025-01-01T00:00:00.000Z',
+        authorPlayerId: 'host',
+        payload: { state: createEmptyCampaignState(CAMPAIGN_ID) },
+      },
+      {
+        type: 'FundsChanged',
+        sequence: 1,
+        campaignId: CAMPAIGN_ID,
+        ts: '3025-01-01T00:00:00.000Z',
+        authorPlayerId: 'host',
+        payload: {
+          delta: 500_000,
+          reason: 'Contract advance',
+          balance: 500_000,
+        },
+      },
+      dayEvent(2, 1),
+      {
+        type: 'PilotHired',
+        sequence: 3,
+        campaignId: CAMPAIGN_ID,
+        ts: '3025-01-01T00:00:00.000Z',
+        authorPlayerId: 'host',
+        payload: {
+          pilot: { pilotId: 'p1', name: 'Pilot One' },
+          cost: 50_000,
+        },
+      },
+    ];
+    for (const event of events) {
+      await log.append(event);
+    }
+
+    // Replay through the log facade.
+    const reconstructed = await log.reconstructState();
+
+    // Independently fold the same events to compute the expected state.
+    let expected = createEmptyCampaignState(CAMPAIGN_ID);
+    for (const event of events) {
+      expected = applyCampaignEvent(expected, event);
+    }
+
+    expect(reconstructed).toEqual(expected);
+    expect(reconstructed.balance).toBe(500_000);
+    expect(reconstructed.day).toBe(1);
+    expect(reconstructed.pilots.p1).toEqual({
+      pilotId: 'p1',
+      name: 'Pilot One',
+    });
+  });
+
+  it('replayCampaignEvents on an empty log yields the empty state', () => {
+    const state = replayCampaignEvents(CAMPAIGN_ID, []);
+    expect(state).toEqual(createEmptyCampaignState(CAMPAIGN_ID));
+  });
+});

--- a/src/lib/campaign/sync/__tests__/sharedCampaignState.integration.test.ts
+++ b/src/lib/campaign/sync/__tests__/sharedCampaignState.integration.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Shared campaign state — end-to-end integration tests (CO1, task 7).
+ *
+ * These wire a real `CampaignMatchHost` + `CampaignSyncSession` to a
+ * real guest `useCampaignMirrorStore` and assert host/guest convergence
+ * across the four spec scenarios:
+ *
+ *   7.1 host opens, guest joins, host advances the day → mirror reflects
+ *   7.2 guest SpendFunds within balance → host commits, both converge
+ *   7.3 guest SpendFunds over balance → host rejects, both keep balance
+ *   7.4 guest disconnect + reconnect → mirror resyncs with no gaps/dupes
+ *
+ * The guest mirror is advanced SOLELY by host-broadcast events — there
+ * is no local mutation path — so convergence here is the real CO1
+ * contract, not a stub.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ */
+
+import type { ICampaignEvent } from '@/types/campaign/CampaignSync';
+
+import { InMemoryCampaignEventStore } from '@/lib/campaign/sync/InMemoryCampaignEventStore';
+import { CampaignMatchHost } from '@/lib/multiplayer/server/CampaignMatchHost';
+import { CampaignSyncSession } from '@/lib/multiplayer/server/CampaignSyncSession';
+import { useCampaignMirrorStore } from '@/lib/p2p/campaignMirrorStore';
+import { createEmptyCampaignState } from '@/types/campaign/CampaignSync';
+
+const CAMPAIGN_ID = 'campaign-e2e';
+const HOST_ID = 'host-player';
+const HOST_PEER = 'host-peer';
+const GUEST_PEER = 'guest-peer';
+
+interface IHarness {
+  host: CampaignMatchHost;
+  session: CampaignSyncSession;
+  /** Apply a delivered event to the guest mirror the way a client would. */
+  deliverToGuest: (event: ICampaignEvent) => void;
+}
+
+/**
+ * Build a host + session + a guest sink that feeds the real mirror
+ * store. Mirrors what the WebSocket client wiring would do: a baseline
+ * snapshot goes through `applySnapshot`, every other event through
+ * `applyEvent`.
+ */
+function harness(balance: number): IHarness {
+  const host = new CampaignMatchHost({
+    campaignId: CAMPAIGN_ID,
+    hostPlayerId: HOST_ID,
+    eventStore: new InMemoryCampaignEventStore(),
+    initialState: { ...createEmptyCampaignState(CAMPAIGN_ID), balance },
+  });
+  const session = new CampaignSyncSession(host);
+  const deliverToGuest = (event: ICampaignEvent): void => {
+    const store = useCampaignMirrorStore.getState();
+    if (event.type === 'CampaignSnapshotPublished' && event.sequence < 0) {
+      // A framing baseline (sequence -1) seeds the mirror.
+      store.applySnapshot(event);
+    } else {
+      store.applyEvent(event);
+    }
+  };
+  return { host, session, deliverToGuest };
+}
+
+beforeEach(() => {
+  useCampaignMirrorStore.getState().reset();
+  useCampaignMirrorStore
+    .getState()
+    .beginMirror(
+      { hostPeerId: HOST_PEER, guestPeerId: GUEST_PEER },
+      GUEST_PEER,
+    );
+});
+
+describe('7.1 — host opens, guest joins, host advances the day', () => {
+  it('the guest mirror reflects the host day counter', async () => {
+    const { host, session, deliverToGuest } = harness(600_000);
+    const code = await session.open();
+
+    // Guest joins — every delivered event flows into the mirror.
+    const joinResult = await session.joinGuest(code, deliverToGuest);
+    expect(joinResult.ok).toBe(true);
+
+    // Host advances the day.
+    await host.applyHostIntent({
+      kind: 'AdvanceDay',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'host-advance',
+      payload: {},
+    });
+
+    // The guest mirror converged with the host's day counter.
+    expect(useCampaignMirrorStore.getState().campaign?.day).toBe(
+      host.getState().day,
+    );
+    expect(useCampaignMirrorStore.getState().campaign?.day).toBe(1);
+    joinResult.disconnect();
+  });
+});
+
+describe('7.2 — guest SpendFunds within balance', () => {
+  it('the host commits FundsChanged and both converge to the new balance', async () => {
+    const { host, session, deliverToGuest } = harness(600_000);
+    const code = await session.open();
+    const joinResult = await session.joinGuest(code, deliverToGuest);
+    expect(joinResult.ok).toBe(true);
+
+    // The guest sends a SpendFunds intent within balance.
+    const result = await host.handleIntent({
+      kind: 'SpendFunds',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'guest-spend',
+      payload: { amount: 150_000, reason: 'Ammo restock' },
+    });
+    expect(result.ok).toBe(true);
+
+    // Host and guest mirror agree on the new balance.
+    expect(host.getState().balance).toBe(450_000);
+    expect(useCampaignMirrorStore.getState().campaign?.balance).toBe(450_000);
+    joinResult.disconnect();
+  });
+});
+
+describe('7.3 — guest SpendFunds over balance', () => {
+  it('the host rejects, no event commits, both keep the prior balance', async () => {
+    const { host, session, deliverToGuest } = harness(600_000);
+    const code = await session.open();
+    const joinResult = await session.joinGuest(code, deliverToGuest);
+    expect(joinResult.ok).toBe(true);
+    const balanceBefore = host.getState().balance;
+
+    const result = await host.handleIntent({
+      kind: 'SpendFunds',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'guest-overspend',
+      payload: { amount: 700_000, reason: 'Too much' },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('insufficient-funds');
+    }
+    // No event committed — host AND guest keep the prior balance.
+    expect(host.getState().balance).toBe(balanceBefore);
+    expect(useCampaignMirrorStore.getState().campaign?.balance).toBe(
+      balanceBefore,
+    );
+    joinResult.disconnect();
+  });
+});
+
+describe('7.4 — guest disconnect and reconnect', () => {
+  it('the mirror resyncs from the event log with no missing or duplicated events', async () => {
+    const { host, session, deliverToGuest } = harness(600_000);
+    const code = await session.open();
+    const joinResult = await session.joinGuest(code, deliverToGuest);
+    expect(joinResult.ok).toBe(true);
+
+    // Two events arrive live, then the guest disconnects.
+    await host.handleIntent({
+      kind: 'AdvanceDay',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'pre-1',
+      payload: {},
+    });
+    await host.handleIntent({
+      kind: 'AdvanceDay',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'pre-2',
+      payload: {},
+    });
+    const seqBeforeDisconnect = useCampaignMirrorStore.getState().lastSequence;
+    joinResult.disconnect();
+
+    // While the guest is offline the host commits two more events.
+    await host.handleIntent({
+      kind: 'AdvanceDay',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'offline-1',
+      payload: {},
+    });
+    await host.handleIntent({
+      kind: 'SpendFunds',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'offline-2',
+      payload: { amount: 50_000, reason: 'Offline spend' },
+    });
+
+    // The guest reconnects and resyncs from its last sequence.
+    const seenSequences: number[] = [];
+    const resync = await session.resyncGuest(seqBeforeDisconnect, (event) => {
+      seenSequences.push(event.sequence);
+      deliverToGuest(event);
+    });
+    expect(resync.ok).toBe(true);
+    expect(resync.snapshotted).toBe(false);
+
+    // No duplicates in the resync stream.
+    expect(new Set(seenSequences).size).toBe(seenSequences.length);
+    // No event at or below the last-seen sequence (no overlap).
+    for (const seq of seenSequences) {
+      expect(seq).toBeGreaterThan(seqBeforeDisconnect);
+    }
+
+    // The mirror converged exactly with the host's authoritative state.
+    expect(useCampaignMirrorStore.getState().campaign).toEqual(host.getState());
+    resync.disconnect();
+  });
+
+  it('a guest mirror equals the host state byte-for-byte after a full session', async () => {
+    const { host, session, deliverToGuest } = harness(2_000_000);
+    const code = await session.open();
+    const joinResult = await session.joinGuest(code, deliverToGuest);
+    expect(joinResult.ok).toBe(true);
+
+    // A representative mix of every committing intent kind.
+    await host.handleIntent({
+      kind: 'HirePilot',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'mix-hire',
+      payload: {
+        pilot: { pilotId: 'p1', name: 'Natasha Kerensky' },
+        cost: 100_000,
+      },
+    });
+    await host.handleIntent({
+      kind: 'AdvanceDay',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'mix-day',
+      payload: { days: 3 },
+    });
+    await host.handleIntent({
+      kind: 'SpendFunds',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'mix-spend',
+      payload: { amount: 250_000, reason: 'Refit' },
+    });
+
+    expect(useCampaignMirrorStore.getState().campaign).toEqual(host.getState());
+    joinResult.disconnect();
+  });
+});

--- a/src/lib/campaign/sync/applyCampaignEvent.ts
+++ b/src/lib/campaign/sync/applyCampaignEvent.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared Campaign State — the campaign event reducer (CO1).
+ *
+ * `applyCampaignEvent` is the single pure reducer that advances an
+ * `ICampaignAuthoritativeState` by one committed `ICampaignEvent`. It is
+ * the campaign-tier analogue of the combat `appendEvent` reducer, and —
+ * exactly like that reducer — it is the ONE function used by all three
+ * consumers, so they can never drift:
+ *
+ *   1. the `CampaignMatchHost`, to advance its authoritative state when
+ *      it commits an event;
+ *   2. `replayCampaignEvents`, to reconstruct state from a log;
+ *   3. the guest `campaignMirrorStore`, to advance the read-only mirror
+ *      from host-broadcast events.
+ *
+ * The reducer is pure: it never mutates its input and returns a fresh
+ * immutable state. Replaying an event log from sequence 0 therefore
+ * reconstructs the host's authoritative state exactly (spec scenario
+ * "Replaying the log reconstructs campaign state").
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ * @spec openspec/changes/add-shared-campaign-state/design.md (D2, D5)
+ */
+
+import type {
+  ICampaignAuthoritativeState,
+  ICampaignEvent,
+} from '@/types/campaign/CampaignSync';
+
+import { createEmptyCampaignState } from '@/types/campaign/CampaignSync';
+
+/**
+ * Apply one committed campaign event to a campaign state, returning a
+ * fresh state. Pure — the input `state` is never mutated.
+ *
+ * A `CampaignSnapshotPublished` event REPLACES the state wholesale (it
+ * is the baseline a joining guest starts from); every other event is an
+ * incremental delta.
+ */
+export function applyCampaignEvent(
+  state: ICampaignAuthoritativeState,
+  event: ICampaignEvent,
+): ICampaignAuthoritativeState {
+  switch (event.type) {
+    case 'CampaignSnapshotPublished': {
+      // A snapshot is a whole-state baseline — adopt it verbatim. This
+      // is how a joining or large-gap-resyncing guest seeds its mirror.
+      return event.payload.state;
+    }
+
+    case 'CampaignDayAdvanced': {
+      return { ...state, day: event.payload.newDay };
+    }
+
+    case 'FundsChanged': {
+      // The event carries the resulting balance (design D3) — adopt it
+      // directly rather than re-deriving from the delta, so a guest that
+      // applies the event lands on exactly the host's figure.
+      return { ...state, balance: event.payload.balance };
+    }
+
+    case 'PilotHired': {
+      const { pilot } = event.payload;
+      return {
+        ...state,
+        pilots: { ...state.pilots, [pilot.pilotId]: pilot },
+      };
+    }
+
+    case 'ContractAccepted': {
+      const { contract } = event.payload;
+      return {
+        ...state,
+        contracts: { ...state.contracts, [contract.contractId]: contract },
+      };
+    }
+
+    case 'RosterUnitChanged': {
+      const { change, unit } = event.payload;
+      if (change === 'removed') {
+        const nextUnits = { ...state.rosterUnits };
+        delete nextUnits[unit.unitId];
+        return { ...state, rosterUnits: nextUnits };
+      }
+      // `added` and `repaired` both write the unit's post-change shape.
+      return {
+        ...state,
+        rosterUnits: { ...state.rosterUnits, [unit.unitId]: unit },
+      };
+    }
+
+    case 'SalvageAllocated': {
+      const { poolRemaining, recoveredUnit } = event.payload;
+      const nextUnits = recoveredUnit
+        ? { ...state.rosterUnits, [recoveredUnit.unitId]: recoveredUnit }
+        : state.rosterUnits;
+      return {
+        ...state,
+        salvagePool: poolRemaining,
+        rosterUnits: nextUnits,
+      };
+    }
+
+    default: {
+      // Exhaustiveness guard — a new `CampaignEventType` that lands
+      // without a reducer arm trips this at compile time.
+      const exhaustive: never = event;
+      void exhaustive;
+      return state;
+    }
+  }
+}
+
+/**
+ * Reconstruct campaign state by replaying an ordered event log from
+ * sequence 0 into a fresh empty state. Per design D2 / spec scenario
+ * "Replaying the log reconstructs campaign state".
+ *
+ * The events MUST be ordered ascending by `sequence` (the campaign
+ * event log guarantees this on read). A `CampaignSnapshotPublished`
+ * anywhere in the log resets the fold to that baseline — which is also
+ * how a resync stream that opens with a fresh snapshot reconstructs
+ * correctly.
+ */
+export function replayCampaignEvents(
+  campaignId: string,
+  events: readonly ICampaignEvent[],
+): ICampaignAuthoritativeState {
+  let state = createEmptyCampaignState(campaignId);
+  for (const event of events) {
+    state = applyCampaignEvent(state, event);
+  }
+  return state;
+}

--- a/src/lib/campaign/sync/campaignEventLog.ts
+++ b/src/lib/campaign/sync/campaignEventLog.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared Campaign State — campaign event log facade (CO1).
+ *
+ * `CampaignEventLog` wraps an `ICampaignEventStore` with the higher-level
+ * operations the `CampaignMatchHost` and the sync session need:
+ *
+ *   - `append` — append one event, enforcing ascending gap-free
+ *     sequence assignment.
+ *   - `nextSequence` — the sequence the host should stamp on the next
+ *     event it commits.
+ *   - `getCampaignEvents` — ordered read from a sequence (task 2.2).
+ *   - `reconstructState` — replay the whole log into campaign state
+ *     (task 2.3), delegating to the shared `replayCampaignEvents`
+ *     reducer.
+ *
+ * The facade is intentionally thin — the transactional guarantee and
+ * the gap-free read both live in the underlying store. The facade adds
+ * the host-facing ergonomics (sequence assignment, replay) so the host
+ * never re-implements them.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ * @spec openspec/changes/add-shared-campaign-state/tasks.md (tasks 2.1-2.3)
+ */
+
+import type {
+  ICampaignAuthoritativeState,
+  ICampaignEvent,
+} from '@/types/campaign/CampaignSync';
+
+import type { ICampaignEventStore } from './ICampaignEventStore';
+
+import { replayCampaignEvents } from './applyCampaignEvent';
+
+export class CampaignEventLog {
+  constructor(
+    private readonly campaignId: string,
+    private readonly store: ICampaignEventStore,
+  ) {}
+
+  /**
+   * The sequence number the host should stamp on the next event it
+   * commits. The first event of a fresh campaign is sequence 0; every
+   * subsequent event is `highestSequence + 1`, so the log is always
+   * ascending and gap-free.
+   */
+  async nextSequence(): Promise<number> {
+    const highest = await this.store.highestSequence(this.campaignId);
+    return highest + 1;
+  }
+
+  /**
+   * Append one committed event. The caller (the `CampaignMatchHost`) is
+   * responsible for stamping the event's `sequence` from `nextSequence`
+   * — `append` does not renumber, so a sequence collision (two writers
+   * racing) surfaces as `CampaignEventSequenceCollisionError` exactly
+   * as the spec scenario "Concurrent append is transactional" requires.
+   */
+  async append(event: ICampaignEvent): Promise<void> {
+    await this.store.appendEvent(this.campaignId, event);
+  }
+
+  /**
+   * Read the campaign event log from `fromSeq` (default 0), ordered
+   * ascending by `sequence`. The campaign-tier analogue of
+   * `IMatchStore.getEvents`. Spec scenario "Event log preserves order
+   * on read" — the underlying store guarantees the ordering and the
+   * gap-free property.
+   */
+  async getCampaignEvents(fromSeq = 0): Promise<readonly ICampaignEvent[]> {
+    return this.store.getEvents(this.campaignId, fromSeq);
+  }
+
+  /**
+   * Reconstruct campaign state by replaying the entire log from
+   * sequence 0. Spec scenario "Replaying the log reconstructs campaign
+   * state" — the result equals the host's authoritative state.
+   */
+  async reconstructState(): Promise<ICampaignAuthoritativeState> {
+    const events = await this.store.getEvents(this.campaignId, 0);
+    return replayCampaignEvents(this.campaignId, events);
+  }
+}
+
+/**
+ * Module-level convenience wrapper around an `ICampaignEventStore`,
+ * mirroring the `IMatchStore.getEvents` free-function shape. Exposed so
+ * the sync-session resync path can read a tail without holding a
+ * `CampaignEventLog` instance.
+ */
+export async function getCampaignEvents(
+  store: ICampaignEventStore,
+  campaignId: string,
+  fromSeq = 0,
+): Promise<readonly ICampaignEvent[]> {
+  return store.getEvents(campaignId, fromSeq);
+}

--- a/src/lib/campaign/sync/index.ts
+++ b/src/lib/campaign/sync/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared Campaign State — sync module barrel (CO1).
+ *
+ * The campaign-tier server-authoritative sync surface: a typed campaign
+ * event log, the shared event reducer, and the in-memory event store.
+ * The `CampaignMatchHost` and `CampaignSyncSession` live under
+ * `src/lib/multiplayer/server/` alongside their combat-tier analogues.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ */
+
+export { applyCampaignEvent, replayCampaignEvents } from './applyCampaignEvent';
+export { CampaignEventLog, getCampaignEvents } from './campaignEventLog';
+export {
+  CampaignEventSequenceCollisionError,
+  type ICampaignEventStore,
+} from './ICampaignEventStore';
+export { InMemoryCampaignEventStore } from './InMemoryCampaignEventStore';

--- a/src/lib/multiplayer/server/CampaignMatchHost.ts
+++ b/src/lib/multiplayer/server/CampaignMatchHost.ts
@@ -1,0 +1,355 @@
+/**
+ * CampaignMatchHost — the campaign-tier server-authoritative host (CO1).
+ *
+ * The campaign analogue of `ServerMatchHost`. Where `ServerMatchHost`
+ * owns one match's authoritative `GameSession` and arbitrates combat
+ * intents, `CampaignMatchHost` owns one campaign's authoritative ledger
+ * state and arbitrates campaign intents — hiring, contracts, spends,
+ * salvage, day advancement.
+ *
+ * It runs the exact `intent → validate → commit → broadcast` loop the
+ * Council's DP2 decision mandated (design D1, D4):
+ *
+ *   1. reject if the session is closed,
+ *   2. reject if the intent is malformed (zod parse),
+ *   3. validate the intent against current authoritative state
+ *      (balance / standing / salvage — `validateCampaignIntent`),
+ *   4. on success, apply the mutation to authoritative state and derive
+ *      the resulting `ICampaignEvent`(s),
+ *   5. append each event to the campaign event log (transactional,
+ *      ascending gap-free sequence),
+ *   6. broadcast each event to all connected clients.
+ *
+ * A rejected intent mutates nothing and returns a typed
+ * `ICampaignIntentError` (`code: 'INVALID_CAMPAIGN_INTENT'`); the
+ * connection stays open so the guest can correct and retry — the same
+ * contract `ServerMatchHostIntent` uses for combat.
+ *
+ * The host is the SINGLE WRITER. Host-initiated events (a host clicking
+ * "advance day") and guest-intent-derived events both go through the
+ * one `commitEvents` path, so the log is always totally ordered with no
+ * gaps — the `IMatchStore` transactional-append guarantee, reused for
+ * the campaign tier (design D2 / risk mitigation).
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ * @spec openspec/changes/add-shared-campaign-state/design.md (D1, D2, D4)
+ */
+
+import type { ICampaignEventStore } from '@/lib/campaign/sync/ICampaignEventStore';
+import type {
+  CampaignIntentResult,
+  ICampaignAuthoritativeState,
+  ICampaignEvent,
+  ICampaignIntent,
+  ICampaignIntentError,
+  ICampaignSnapshotPublishedPayload,
+} from '@/types/campaign/CampaignSync';
+
+import { applyCampaignEvent } from '@/lib/campaign/sync/applyCampaignEvent';
+import { CampaignEventLog } from '@/lib/campaign/sync/campaignEventLog';
+import { INVALID_CAMPAIGN_INTENT } from '@/types/campaign/CampaignSync';
+import { parseCampaignIntent } from '@/types/campaign/campaignSyncSchemas';
+import { nowIso } from '@/types/multiplayer/Protocol';
+
+import type {
+  CampaignIntentValidation,
+  UnsequencedCampaignEvent,
+} from './CampaignMatchHostIntent';
+
+import { validateCampaignIntent } from './CampaignMatchHostIntent';
+
+/**
+ * A connected campaign-sync client. The host broadcasts every committed
+ * campaign event to each subscriber. The WebSocket upgrade handler
+ * registers one subscriber per socket; tests register a buffer.
+ */
+export type CampaignEventSubscriber = (event: ICampaignEvent) => void;
+
+/** Construction input for a `CampaignMatchHost`. */
+export interface ICampaignMatchHostOptions {
+  /** Campaign id this host owns. */
+  readonly campaignId: string;
+  /** The host player's id — stamped as `authorPlayerId` on host events. */
+  readonly hostPlayerId: string;
+  /** The campaign event log store the host appends to. */
+  readonly eventStore: ICampaignEventStore;
+  /**
+   * The campaign's starting authoritative state. The host commits a
+   * `CampaignSnapshotPublished` baseline from this on `open`, so the
+   * log always begins with a replayable baseline.
+   */
+  readonly initialState: ICampaignAuthoritativeState;
+}
+
+export class CampaignMatchHost {
+  public readonly campaignId: string;
+  private readonly hostPlayerId: string;
+  private readonly log: CampaignEventLog;
+  /** The host's authoritative campaign state — the single source of truth. */
+  private state: ICampaignAuthoritativeState;
+  private readonly subscribers = new Set<CampaignEventSubscriber>();
+  private closed = false;
+  /** True once `open` has committed the baseline snapshot. */
+  private opened = false;
+
+  constructor(options: ICampaignMatchHostOptions) {
+    this.campaignId = options.campaignId;
+    this.hostPlayerId = options.hostPlayerId;
+    this.log = new CampaignEventLog(options.campaignId, options.eventStore);
+    this.state = options.initialState;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Open the shared campaign: commit a `CampaignSnapshotPublished`
+   * baseline as sequence 0 so the log always opens with a replayable
+   * whole-state event. Idempotent — calling `open` twice is a no-op.
+   *
+   * `CampaignSyncSession` calls this when a host opens a campaign for
+   * co-op; it then issues the room code.
+   */
+  async open(): Promise<void> {
+    if (this.opened || this.closed) return;
+    this.opened = true;
+    await this.commitEvents([
+      {
+        type: 'CampaignSnapshotPublished',
+        campaignId: this.campaignId,
+        authorPlayerId: this.hostPlayerId,
+        ts: nowIso(),
+        payload: { state: this.state },
+      },
+    ]);
+  }
+
+  /**
+   * Close the campaign session. Idempotent. After close, every intent
+   * is rejected with `reason: 'session-closed'` and no event commits —
+   * the host-disconnect "session pauses, mirror frozen" contract
+   * (design D6).
+   */
+  close(): void {
+    this.closed = true;
+    this.subscribers.clear();
+  }
+
+  /** Whether `close` has run. */
+  isClosed(): boolean {
+    return this.closed;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Subscriptions
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Register a subscriber for committed campaign events. Returns an
+   * unsubscribe function. The campaign analogue of `attachSocket` —
+   * `CampaignSyncSession` wires one subscriber per connected client.
+   */
+  subscribe(subscriber: CampaignEventSubscriber): () => void {
+    this.subscribers.add(subscriber);
+    return () => {
+      this.subscribers.delete(subscriber);
+    };
+  }
+
+  /** Number of currently-subscribed clients. Test/observability. */
+  subscriberCount(): number {
+    return this.subscribers.size;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Authoritative state access
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The host's current authoritative campaign state. A defensive copy
+   * is unnecessary because `ICampaignAuthoritativeState` is treated as
+   * immutable everywhere — the host only ever replaces it wholesale.
+   */
+  getState(): ICampaignAuthoritativeState {
+    return this.state;
+  }
+
+  /** The campaign event log facade — for the sync-session replay path. */
+  getEventLog(): CampaignEventLog {
+    return this.log;
+  }
+
+  /**
+   * Build a fresh `CampaignSnapshotPublished` payload from the host's
+   * CURRENT authoritative state. The sync session sends this as the
+   * baseline a joining (or large-gap-resyncing) guest seeds from.
+   */
+  buildSnapshotPayload(): ICampaignSnapshotPublishedPayload {
+    return { state: this.state };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Intent handling — validate / commit / broadcast
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Process one campaign intent through the closed-check, malformed-
+   * check, validate, commit, broadcast sequence (design D4).
+   *
+   * `rawIntent` is typed `unknown` because it arrives off the wire — the
+   * malformed-check is a real zod parse, not a type assertion. A
+   * structurally-invalid envelope is rejected with
+   * `reason: 'malformed-intent'` before any state is touched.
+   *
+   * Returns a `CampaignIntentResult`: on success the committed (and now
+   * sequenced) events; on rejection the typed error. The host also
+   * broadcasts the committed events to every subscriber before
+   * returning, so a test can assert on either the return value or the
+   * subscriber buffer.
+   */
+  async handleIntent(rawIntent: unknown): Promise<CampaignIntentResult> {
+    // Step 1 — closed check.
+    if (this.closed) {
+      return {
+        ok: false,
+        code: INVALID_CAMPAIGN_INTENT,
+        reason: 'session-closed',
+      };
+    }
+
+    // Step 2 — malformed check (zod parse at the boundary, task 1.3).
+    const intent = parseCampaignIntent(rawIntent);
+    if (intent === null) {
+      return {
+        ok: false,
+        code: INVALID_CAMPAIGN_INTENT,
+        reason: 'malformed-intent',
+      };
+    }
+
+    // Step 3 — validate against CURRENT authoritative state. A rejected
+    // intent mutates nothing — `validation` simply carries no events.
+    // `handleIntent` is the GUEST-facing path (the host uses
+    // `applyHostIntent`), so the derived events are attributed to the
+    // guest author.
+    const ts = nowIso();
+    const validation: CampaignIntentValidation = validateCampaignIntent(
+      intent,
+      this.state,
+      this.guestAuthor(intent),
+      ts,
+    );
+    if (!validation.ok) {
+      return validation;
+    }
+
+    // Steps 4-6 — apply, append, broadcast through the single commit
+    // path so host-driven and guest-driven events share one ordering.
+    const committed = await this.commitEvents(validation.events);
+    return { ok: true, events: committed };
+  }
+
+  /**
+   * Convenience for the host's OWN actions (e.g. a host UI clicking
+   * "advance day"). Takes an `ICampaignIntent` directly — it is already
+   * trusted, so the malformed-check is skipped, but it still runs the
+   * authoritative-state validation so a host action that breaks the
+   * ledger invariant (over-spend) is rejected just like a guest's.
+   */
+  async applyHostIntent(
+    intent: ICampaignIntent,
+  ): Promise<CampaignIntentResult> {
+    if (this.closed) {
+      return {
+        ok: false,
+        code: INVALID_CAMPAIGN_INTENT,
+        reason: 'session-closed',
+      };
+    }
+    const ts = nowIso();
+    const validation = validateCampaignIntent(
+      intent,
+      this.state,
+      this.hostPlayerId,
+      ts,
+    );
+    if (!validation.ok) {
+      return validation;
+    }
+    const committed = await this.commitEvents(validation.events);
+    return { ok: true, events: committed };
+  }
+
+  /**
+   * Build the typed error envelope for a rejected intent, carrying the
+   * originating `intentId` for guest-side correlation. The transport
+   * layer (`CampaignSyncSession`) sends this to the originating client.
+   */
+  static toIntentError(
+    intentId: string,
+    rejection: Extract<CampaignIntentResult, { ok: false }>,
+  ): ICampaignIntentError {
+    return {
+      ok: false,
+      code: rejection.code,
+      reason: rejection.reason,
+      intentId,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The single commit path. Every event — host-initiated and
+   * guest-intent-derived — flows through here, so the campaign event
+   * log is always totally ordered with no gaps (design D2 risk
+   * mitigation).
+   *
+   * For each unsequenced event: stamp the next sequence from the log,
+   * append it (transactional — a collision throws), advance the host's
+   * authoritative state through the shared `applyCampaignEvent` reducer,
+   * and broadcast it. Sequence assignment is awaited per-event so two
+   * events in one batch get consecutive numbers.
+   */
+  private async commitEvents(
+    events: readonly UnsequencedCampaignEvent[],
+  ): Promise<readonly ICampaignEvent[]> {
+    const committed: ICampaignEvent[] = [];
+    for (const unsequenced of events) {
+      const sequence = await this.log.nextSequence();
+      // Re-attach the host-assigned sequence. The spread of one
+      // unsequenced union member plus `sequence` is exactly the
+      // corresponding `ICampaignEvent` variant; TS cannot correlate the
+      // spread across the union, so the assertion makes the (sound)
+      // intent explicit at this single chokepoint.
+      const event = { ...unsequenced, sequence } as ICampaignEvent;
+      // Append FIRST — a sequence collision rejects here and the host's
+      // authoritative state is left untouched (no partial commit).
+      await this.log.append(event);
+      // Advance authoritative state through the SHARED reducer — the
+      // same function the guest mirror uses, so host and guest can
+      // never drift.
+      this.state = applyCampaignEvent(this.state, event);
+      // Broadcast to every connected client.
+      this.subscribers.forEach((subscriber) => {
+        subscriber(event);
+      });
+      committed.push(event);
+    }
+    return committed;
+  }
+
+  /**
+   * The `authorPlayerId` to stamp on a guest-driven event. CO1 has a
+   * single host/guest pair and the campaign intent carries no player
+   * id, so the guest's events are attributed to a stable
+   * `guest:<campaignId>` author. CO2 threads the real guest player id
+   * through the GM intent surface.
+   */
+  private guestAuthor(intent: ICampaignIntent): string {
+    return `guest:${intent.campaignId}`;
+  }
+}

--- a/src/lib/multiplayer/server/CampaignMatchHostIntent.ts
+++ b/src/lib/multiplayer/server/CampaignMatchHostIntent.ts
@@ -1,0 +1,224 @@
+/**
+ * Shared Campaign State — campaign intent validation (CO1).
+ *
+ * The pure validate-and-derive core of the `CampaignMatchHost`. Given a
+ * structurally-valid `ICampaignIntent` and the host's current
+ * authoritative campaign state, `validateCampaignIntent` either:
+ *
+ *   - rejects it (`ok: false`, `code: 'INVALID_CAMPAIGN_INTENT'`, a
+ *     stable `reason`) — the campaign analogue of the combat intent
+ *     error contract; OR
+ *   - accepts it (`ok: true`) and derives the resulting
+ *     `ICampaignEvent`(s) — minus their `sequence`, which the host
+ *     stamps from the event log.
+ *
+ * This function is the campaign analogue of the combat engine's
+ * intent-acceptance step. It is PURE — it never mutates the state, never
+ * touches the log, never broadcasts. The host orchestrates the commit +
+ * broadcast around it (design D4 steps 4-6). Keeping the validation
+ * pure makes the spec scenario "an over-balance spend mutates nothing"
+ * structurally true: a rejected intent simply never produces an event.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ * @spec openspec/changes/add-shared-campaign-state/design.md (D4, D8)
+ */
+
+import type {
+  CampaignIntentRejectionReason,
+  CampaignIntentResult,
+  ICampaignAuthoritativeState,
+  ICampaignEventOf,
+  ICampaignIntent,
+  CampaignEventType,
+  ICampaignEventPayloadMap,
+} from '@/types/campaign/CampaignSync';
+
+import {
+  CONTRACT_MIN_STANDING,
+  INVALID_CAMPAIGN_INTENT,
+} from '@/types/campaign/CampaignSync';
+
+/**
+ * A campaign event before the host has assigned its `sequence`. The
+ * host stamps `sequence` from the event log immediately before append.
+ *
+ * Built off `ICampaignEventOf` (the per-type variant) rather than
+ * `ICampaignEvent` (the deferred-conditional union) so the `Omit`
+ * resolves while `T` is still a generic parameter.
+ */
+export type UnsequencedCampaignEvent<
+  T extends CampaignEventType = CampaignEventType,
+> = T extends CampaignEventType ? Omit<ICampaignEventOf<T>, 'sequence'> : never;
+
+/**
+ * The accepted variant of an intent-validation result — carries the
+ * derived, still-unsequenced events.
+ */
+interface IValidatedIntent {
+  readonly ok: true;
+  readonly events: readonly UnsequencedCampaignEvent[];
+}
+
+/** The full pre-commit validation result. */
+export type CampaignIntentValidation =
+  | IValidatedIntent
+  | Extract<CampaignIntentResult, { ok: false }>;
+
+/** Helper — build a typed rejection. */
+function reject(
+  reason: CampaignIntentRejectionReason,
+): Extract<CampaignIntentResult, { ok: false }> {
+  return { ok: false, code: INVALID_CAMPAIGN_INTENT, reason };
+}
+
+/**
+ * Helper — build one unsequenced event of a given type. The return is
+ * structurally exactly `Omit<ICampaignEventOf<T>, 'sequence'>`, but TS
+ * cannot verify that against the deferred distributive conditional
+ * while `T` is generic, so the assertion makes the (sound) intent
+ * explicit at this single chokepoint.
+ */
+function event<T extends CampaignEventType>(
+  type: T,
+  campaignId: string,
+  authorPlayerId: string,
+  ts: string,
+  payload: ICampaignEventPayloadMap[T],
+): UnsequencedCampaignEvent<T> {
+  const built: Omit<ICampaignEventOf<T>, 'sequence'> = {
+    type,
+    campaignId,
+    authorPlayerId,
+    ts,
+    payload,
+  };
+  return built as UnsequencedCampaignEvent<T>;
+}
+
+/**
+ * Validate one campaign intent against the host's authoritative state
+ * and, on success, derive the resulting unsequenced event(s).
+ *
+ * Per design D4 step 3, this is where the balance / standing / salvage
+ * checks live — and per the spec scenario "Stale-mirror intent is
+ * validated against host state", the checks always run against the
+ * `state` passed in (the host's CURRENT authoritative state), never
+ * against any figure the guest may have included.
+ *
+ * @param intent      a structurally-valid intent (already zod-parsed).
+ * @param state       the host's current authoritative campaign state.
+ * @param authorPlayerId the player whose intent this is (stamped on the
+ *                    derived events).
+ * @param ts          host wall-clock ISO timestamp for the events.
+ */
+export function validateCampaignIntent(
+  intent: ICampaignIntent,
+  state: ICampaignAuthoritativeState,
+  authorPlayerId: string,
+  ts: string,
+): CampaignIntentValidation {
+  // The intent must target the campaign this host owns.
+  if (intent.campaignId !== state.campaignId) {
+    return reject('campaign-mismatch');
+  }
+
+  const mk = <T extends CampaignEventType>(
+    type: T,
+    payload: ICampaignEventPayloadMap[T],
+  ): UnsequencedCampaignEvent<T> =>
+    event(type, state.campaignId, authorPlayerId, ts, payload);
+
+  switch (intent.kind) {
+    case 'SpendFunds': {
+      const { amount, reason } = intent.payload;
+      // Ledger invariant: the balance never goes negative (design D1).
+      if (amount > state.balance) {
+        return reject('insufficient-funds');
+      }
+      const newBalance = state.balance - amount;
+      return {
+        ok: true,
+        events: [
+          mk('FundsChanged', {
+            delta: -amount,
+            reason,
+            balance: newBalance,
+          }),
+        ],
+      };
+    }
+
+    case 'HirePilot': {
+      const { pilot, cost } = intent.payload;
+      // Hiring spends C-bills — the same balance invariant applies.
+      if (cost > state.balance) {
+        return reject('insufficient-funds');
+      }
+      const newBalance = state.balance - cost;
+      // A hire produces TWO events: the funds debit and the roster
+      // change. Both go through the host's single append path so the
+      // log stays totally ordered (design risk-mitigation "two events
+      // interleave out of order").
+      return {
+        ok: true,
+        events: [
+          mk('FundsChanged', {
+            delta: -cost,
+            reason: `Hired pilot ${pilot.name}`,
+            balance: newBalance,
+          }),
+          mk('PilotHired', { pilot, cost }),
+        ],
+      };
+    }
+
+    case 'AcceptContract': {
+      const { contract } = intent.payload;
+      // Faction-standing gate — the campaign analogue of the combat
+      // "unit ownership" validation (design D4 step 3).
+      const standing = state.factionStanding[contract.employerFactionId] ?? 0;
+      if (standing < CONTRACT_MIN_STANDING) {
+        return reject('insufficient-standing');
+      }
+      return {
+        ok: true,
+        events: [mk('ContractAccepted', { contract })],
+      };
+    }
+
+    case 'AllocateSalvage': {
+      const { value, recoveredUnit } = intent.payload;
+      // The allocation cannot draw more than the post-battle pool holds.
+      if (value > state.salvagePool) {
+        return reject('insufficient-salvage');
+      }
+      const poolRemaining = state.salvagePool - value;
+      return {
+        ok: true,
+        events: [
+          mk('SalvageAllocated', {
+            value,
+            poolRemaining,
+            ...(recoveredUnit ? { recoveredUnit } : {}),
+          }),
+        ],
+      };
+    }
+
+    case 'AdvanceDay': {
+      const days = intent.payload.days ?? 1;
+      return {
+        ok: true,
+        events: [mk('CampaignDayAdvanced', { newDay: state.day + days })],
+      };
+    }
+
+    default: {
+      // Exhaustiveness guard — a new intent kind without a validation
+      // arm trips this at compile time.
+      const exhaustive: never = intent;
+      void exhaustive;
+      return reject('malformed-intent');
+    }
+  }
+}

--- a/src/lib/multiplayer/server/CampaignSyncSession.ts
+++ b/src/lib/multiplayer/server/CampaignSyncSession.ts
@@ -1,0 +1,246 @@
+/**
+ * CampaignSyncSession — campaign sync session lifecycle (CO1).
+ *
+ * Wraps a `CampaignMatchHost` with the join / resync / disconnect
+ * lifecycle the guest mirror needs (design D6). It is the campaign-tier
+ * analogue of the combat replay path (`ReplayStart` / `ReplayChunk` /
+ * `ReplayEnd` followed by live `Event`s):
+ *
+ *   - `open` registers the campaign for sharing and issues a 6-char
+ *     room code (the `multiplayer-server` alphabet, excluding I/O/0/1).
+ *   - `joinGuest` accepts a guest with the room code, sends a
+ *     `CampaignSnapshotPublished` baseline, streams the campaign event
+ *     log from sequence 0, then delivers live events as the host
+ *     commits them.
+ *   - `resyncGuest` reconnects a guest and streams ONLY the missing
+ *     tail; when the gap is larger than `RESYNC_SNAPSHOT_GAP` the host
+ *     sends a fresh snapshot and resumes live streaming from there.
+ *   - `hostDisconnected` pauses the session — the guest mirror is
+ *     frozen and stays read-only; no campaign-tier host migration.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ * @spec openspec/changes/add-shared-campaign-state/design.md (D6)
+ */
+
+import type { ICampaignEvent } from '@/types/campaign/CampaignSync';
+
+import { generateRoomCode, normalizeRoomCode } from '@/lib/p2p/roomCodes';
+import { nowIso } from '@/types/multiplayer/Protocol';
+
+import type { CampaignMatchHost } from './CampaignMatchHost';
+
+/**
+ * The resync gap threshold. When a reconnecting guest is more than this
+ * many events behind the current log, the host sends a fresh
+ * `CampaignSnapshotPublished` baseline instead of streaming the whole
+ * tail (design D6 / spec scenario "Large-gap resync receives a fresh
+ * snapshot"). Sized small so the contract is easy to exercise in tests;
+ * a production deploy can tune it.
+ */
+export const RESYNC_SNAPSHOT_GAP = 50;
+
+/**
+ * A guest connection's event sink. The session pushes campaign events
+ * (replay tail + live) into it. The WebSocket upgrade handler wires one
+ * sink per socket; tests wire a buffer.
+ */
+export type CampaignGuestSink = (event: ICampaignEvent) => void;
+
+/** The outcome of a guest join. */
+export interface ICampaignJoinResult {
+  /** True when the room code resolved and the join was accepted. */
+  readonly ok: boolean;
+  /**
+   * The baseline + replay events delivered to the guest, in ascending
+   * sequence order. Empty when `ok` is false. The first event is always
+   * a `CampaignSnapshotPublished` baseline.
+   */
+  readonly delivered: readonly ICampaignEvent[];
+  /** Unsubscribe handle for the guest's live-event subscription. */
+  readonly disconnect: () => void;
+}
+
+/** The outcome of a guest resync. */
+export interface ICampaignResyncResult {
+  /** True when the resync was accepted. */
+  readonly ok: boolean;
+  /**
+   * The events streamed to the guest to catch it up — either the
+   * missing tail, or a fresh snapshot followed by the post-snapshot
+   * tail when the gap was too large.
+   */
+  readonly delivered: readonly ICampaignEvent[];
+  /** True when a fresh snapshot was sent (large-gap path). */
+  readonly snapshotted: boolean;
+  /** Unsubscribe handle for the guest's live-event subscription. */
+  readonly disconnect: () => void;
+}
+
+export class CampaignSyncSession {
+  private readonly host: CampaignMatchHost;
+  private roomCode: string | null = null;
+  private paused = false;
+
+  constructor(host: CampaignMatchHost) {
+    this.host = host;
+  }
+
+  /**
+   * Open the campaign for co-op. Commits the baseline snapshot through
+   * the host, registers the campaign for sharing, and issues a 6-char
+   * room code. Returns the issued code. Idempotent — a second `open`
+   * returns the already-issued code.
+   */
+  async open(): Promise<string> {
+    if (this.roomCode !== null) {
+      return this.roomCode;
+    }
+    // The host commits the baseline `CampaignSnapshotPublished` as
+    // sequence 0 so the log always opens with a replayable baseline.
+    await this.host.open();
+    // Room code: same alphabet as `multiplayer-server` (I/O/0/1
+    // excluded — `generateRoomCode` already enforces it).
+    this.roomCode = generateRoomCode();
+    return this.roomCode;
+  }
+
+  /** The issued room code, or `null` before `open`. */
+  getRoomCode(): string | null {
+    return this.roomCode;
+  }
+
+  /** Whether the session is paused (host disconnected). */
+  isPaused(): boolean {
+    return this.paused;
+  }
+
+  /**
+   * Accept a guest joining with a room code. On success the session:
+   *   1. delivers a fresh `CampaignSnapshotPublished` baseline,
+   *   2. streams the campaign event log from sequence 0,
+   *   3. subscribes the guest's sink for live events.
+   *
+   * The baseline is delivered FIRST so a guest can seed its mirror
+   * before any incremental event lands (spec scenario "Guest join
+   * receives a baseline then the log").
+   *
+   * A wrong room code rejects with `ok: false` and delivers nothing.
+   */
+  async joinGuest(
+    roomCode: string,
+    sink: CampaignGuestSink,
+  ): Promise<ICampaignJoinResult> {
+    if (
+      this.roomCode === null ||
+      normalizeRoomCode(roomCode) !== this.roomCode
+    ) {
+      return { ok: false, delivered: [], disconnect: () => {} };
+    }
+
+    const delivered: ICampaignEvent[] = [];
+
+    // Step 1 — the baseline snapshot. Built from the host's CURRENT
+    // authoritative state and stamped as sequence -1 framing so it is
+    // unambiguously the baseline and never collides with a log event.
+    const baseline = this.buildBaselineEvent();
+    delivered.push(baseline);
+    sink(baseline);
+
+    // Step 2 — stream the campaign event log from sequence 0.
+    const log = await this.host.getEventLog().getCampaignEvents(0);
+    for (const event of log) {
+      delivered.push(event);
+      sink(event);
+    }
+
+    // Step 3 — live subscription. Every event the host commits from now
+    // on is pushed straight to the guest's sink.
+    const unsubscribe = this.host.subscribe((event) => {
+      sink(event);
+    });
+
+    return { ok: true, delivered, disconnect: unsubscribe };
+  }
+
+  /**
+   * Resync a reconnecting guest from its last-received sequence.
+   *
+   *   - Small gap: stream only events with `sequence > lastSeq` (spec
+   *     scenario "Guest resync streams only the missing tail").
+   *   - Large gap (`> RESYNC_SNAPSHOT_GAP` events behind): send a fresh
+   *     `CampaignSnapshotPublished` baseline, then resume live streaming
+   *     from after it (spec scenario "Large-gap resync receives a fresh
+   *     snapshot").
+   */
+  async resyncGuest(
+    lastSeq: number,
+    sink: CampaignGuestSink,
+  ): Promise<ICampaignResyncResult> {
+    if (this.roomCode === null) {
+      return {
+        ok: false,
+        delivered: [],
+        snapshotted: false,
+        disconnect: () => {},
+      };
+    }
+
+    const highest = await this.host.getEventLog().nextSequence();
+    const gap = highest - 1 - lastSeq;
+    const delivered: ICampaignEvent[] = [];
+
+    if (gap > RESYNC_SNAPSHOT_GAP) {
+      // Large-gap path — a fresh baseline is cheaper than the tail.
+      const baseline = this.buildBaselineEvent();
+      delivered.push(baseline);
+      sink(baseline);
+      const unsubscribe = this.host.subscribe(sink);
+      return {
+        ok: true,
+        delivered,
+        snapshotted: true,
+        disconnect: unsubscribe,
+      };
+    }
+
+    // Small-gap path — stream only the missing tail (sequence > lastSeq).
+    const tail = await this.host.getEventLog().getCampaignEvents(lastSeq + 1);
+    for (const event of tail) {
+      delivered.push(event);
+      sink(event);
+    }
+    const unsubscribe = this.host.subscribe(sink);
+    return { ok: true, delivered, snapshotted: false, disconnect: unsubscribe };
+  }
+
+  /**
+   * The host disconnected. The session pauses: the room code stops
+   * resolving for new joins, the host is closed (rejecting any further
+   * intent with `session-closed`), and the guest mirror — already
+   * read-only — is frozen. No campaign-tier host migration (design D6).
+   */
+  hostDisconnected(): void {
+    this.paused = true;
+    this.roomCode = null;
+    this.host.close();
+  }
+
+  /**
+   * Build the framing `CampaignSnapshotPublished` event delivered as a
+   * guest's baseline. It carries the host's current authoritative
+   * state. The framing `sequence` is `-1` so it is unambiguously a
+   * baseline frame and can never collide with a real log event
+   * (sequence 0+) — the guest's `applySnapshot` adopts the payload
+   * wholesale regardless of sequence.
+   */
+  private buildBaselineEvent(): ICampaignEvent<'CampaignSnapshotPublished'> {
+    return {
+      type: 'CampaignSnapshotPublished',
+      sequence: -1,
+      campaignId: this.host.campaignId,
+      ts: nowIso(),
+      authorPlayerId: 'host',
+      payload: this.host.buildSnapshotPayload(),
+    };
+  }
+}

--- a/src/lib/multiplayer/server/__tests__/CampaignMatchHost.test.ts
+++ b/src/lib/multiplayer/server/__tests__/CampaignMatchHost.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for `CampaignMatchHost` — validate / commit / broadcast (CO1,
+ * task 3.5).
+ *
+ * Covers: a valid intent commits an event and broadcasts it; an
+ * over-balance spend is rejected and mutates nothing; a rejected intent
+ * leaves the session open for retry; a stale-mirror intent is validated
+ * against host state.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ */
+
+import type {
+  ICampaignAuthoritativeState,
+  ICampaignEvent,
+} from '@/types/campaign/CampaignSync';
+
+import { InMemoryCampaignEventStore } from '@/lib/campaign/sync/InMemoryCampaignEventStore';
+import { CampaignMatchHost } from '@/lib/multiplayer/server/CampaignMatchHost';
+import { createEmptyCampaignState } from '@/types/campaign/CampaignSync';
+
+const CAMPAIGN_ID = 'campaign-host';
+const HOST_ID = 'host-player';
+
+function stateWith(
+  patch: Partial<ICampaignAuthoritativeState>,
+): ICampaignAuthoritativeState {
+  return { ...createEmptyCampaignState(CAMPAIGN_ID), ...patch };
+}
+
+function makeHost(initialState: ICampaignAuthoritativeState): {
+  host: CampaignMatchHost;
+  received: ICampaignEvent[];
+} {
+  const host = new CampaignMatchHost({
+    campaignId: CAMPAIGN_ID,
+    hostPlayerId: HOST_ID,
+    eventStore: new InMemoryCampaignEventStore(),
+    initialState,
+  });
+  const received: ICampaignEvent[] = [];
+  host.subscribe((event) => received.push(event));
+  return { host, received };
+}
+
+describe('CampaignMatchHost — open', () => {
+  it('commits a CampaignSnapshotPublished baseline as sequence 0', async () => {
+    const { host, received } = makeHost(stateWith({ balance: 600_000 }));
+    await host.open();
+    expect(received).toHaveLength(1);
+    expect(received[0].type).toBe('CampaignSnapshotPublished');
+    expect(received[0].sequence).toBe(0);
+  });
+
+  it('open is idempotent', async () => {
+    const { host, received } = makeHost(stateWith({}));
+    await host.open();
+    await host.open();
+    expect(received).toHaveLength(1);
+  });
+});
+
+describe('CampaignMatchHost — valid intent', () => {
+  it('commits a FundsChanged event and broadcasts it', async () => {
+    const { host, received } = makeHost(stateWith({ balance: 600_000 }));
+    await host.open();
+    received.length = 0;
+
+    const result = await host.handleIntent({
+      kind: 'SpendFunds',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'intent-1',
+      payload: { amount: 100_000, reason: 'Ammo' },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0].type).toBe('FundsChanged');
+    }
+    // Broadcast — the subscriber saw the event.
+    expect(received).toHaveLength(1);
+    expect(received[0].type).toBe('FundsChanged');
+    // Authoritative state advanced.
+    expect(host.getState().balance).toBe(500_000);
+  });
+
+  it('a hire commits FundsChanged + PilotHired in order', async () => {
+    const { host, received } = makeHost(stateWith({ balance: 600_000 }));
+    await host.open();
+    received.length = 0;
+
+    const result = await host.handleIntent({
+      kind: 'HirePilot',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'intent-hire',
+      payload: {
+        pilot: { pilotId: 'p1', name: 'Pilot One' },
+        cost: 75_000,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(received.map((e) => e.type)).toEqual(['FundsChanged', 'PilotHired']);
+    // Consecutive gap-free sequences.
+    expect(received[1].sequence - received[0].sequence).toBe(1);
+    expect(host.getState().balance).toBe(525_000);
+    expect(host.getState().pilots.p1).toBeDefined();
+  });
+
+  it('AdvanceDay commits a CampaignDayAdvanced event', async () => {
+    const { host } = makeHost(stateWith({ day: 3 }));
+    await host.open();
+    const result = await host.handleIntent({
+      kind: 'AdvanceDay',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'intent-day',
+      payload: {},
+    });
+    expect(result.ok).toBe(true);
+    expect(host.getState().day).toBe(4);
+  });
+});
+
+describe('CampaignMatchHost — rejected intent', () => {
+  it('an over-balance spend is rejected and mutates nothing', async () => {
+    const { host, received } = makeHost(stateWith({ balance: 600_000 }));
+    await host.open();
+    received.length = 0;
+
+    const result = await host.handleIntent({
+      kind: 'SpendFunds',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'intent-over',
+      payload: { amount: 700_000, reason: 'Too much' },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('INVALID_CAMPAIGN_INTENT');
+      expect(result.reason).toBe('insufficient-funds');
+    }
+    // No event committed, balance unchanged.
+    expect(received).toHaveLength(0);
+    expect(host.getState().balance).toBe(600_000);
+  });
+
+  it('a malformed intent is rejected with malformed-intent', async () => {
+    const { host } = makeHost(stateWith({ balance: 600_000 }));
+    await host.open();
+    const result = await host.handleIntent({ kind: 'NotAKind' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed-intent');
+    }
+  });
+
+  it('a contract intent is rejected when standing is below the minimum', async () => {
+    const { host } = makeHost(stateWith({ factionStanding: { kurita: -5 } }));
+    await host.open();
+    const result = await host.handleIntent({
+      kind: 'AcceptContract',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'intent-contract',
+      payload: {
+        contract: {
+          contractId: 'c1',
+          name: 'Hostile contract',
+          employerFactionId: 'kurita',
+        },
+      },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('insufficient-standing');
+    }
+  });
+
+  it('an over-pool salvage allocation is rejected', async () => {
+    const { host } = makeHost(stateWith({ salvagePool: 100_000 }));
+    await host.open();
+    const result = await host.handleIntent({
+      kind: 'AllocateSalvage',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'intent-salvage',
+      payload: { value: 250_000 },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('insufficient-salvage');
+    }
+  });
+
+  it('a rejected intent leaves the session open for retry', async () => {
+    const { host } = makeHost(stateWith({ balance: 600_000 }));
+    await host.open();
+
+    const rejected = await host.handleIntent({
+      kind: 'SpendFunds',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'intent-over',
+      payload: { amount: 700_000, reason: 'Too much' },
+    });
+    expect(rejected.ok).toBe(false);
+    expect(host.isClosed()).toBe(false);
+
+    // The guest corrects and retries with an in-balance amount.
+    const retried = await host.handleIntent({
+      kind: 'SpendFunds',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'intent-corrected',
+      payload: { amount: 100_000, reason: 'Corrected' },
+    });
+    expect(retried.ok).toBe(true);
+    expect(host.getState().balance).toBe(500_000);
+  });
+
+  it('an intent is rejected against the host state, not a stale-mirror balance', async () => {
+    // Host starts at 600k; a prior spend takes it to 100k.
+    const { host } = makeHost(stateWith({ balance: 600_000 }));
+    await host.open();
+    await host.handleIntent({
+      kind: 'SpendFunds',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'intent-first',
+      payload: { amount: 500_000, reason: 'Big purchase' },
+    });
+    expect(host.getState().balance).toBe(100_000);
+
+    // The guest's mirror still shows 600k; it sends a 300k spend that
+    // fits the stale view but not the current authoritative balance.
+    const staleIntent = await host.handleIntent({
+      kind: 'SpendFunds',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'intent-stale',
+      payload: { amount: 300_000, reason: 'Stale-mirror spend' },
+    });
+    expect(staleIntent.ok).toBe(false);
+    if (!staleIntent.ok) {
+      expect(staleIntent.reason).toBe('insufficient-funds');
+    }
+    expect(host.getState().balance).toBe(100_000);
+  });
+
+  it('a closed host rejects every intent with session-closed', async () => {
+    const { host } = makeHost(stateWith({ balance: 600_000 }));
+    await host.open();
+    host.close();
+    const result = await host.handleIntent({
+      kind: 'AdvanceDay',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'intent-after-close',
+      payload: {},
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('session-closed');
+    }
+  });
+
+  it('toIntentError stamps the originating intentId on a rejection', () => {
+    const error = CampaignMatchHost.toIntentError('intent-x', {
+      ok: false,
+      code: 'INVALID_CAMPAIGN_INTENT',
+      reason: 'insufficient-funds',
+    });
+    expect(error.intentId).toBe('intent-x');
+    expect(error.reason).toBe('insufficient-funds');
+  });
+});
+
+describe('CampaignMatchHost — campaign mismatch', () => {
+  it('rejects an intent targeting a different campaign', async () => {
+    const { host } = makeHost(stateWith({ balance: 600_000 }));
+    await host.open();
+    const result = await host.handleIntent({
+      kind: 'AdvanceDay',
+      campaignId: 'some-other-campaign',
+      intentId: 'intent-mismatch',
+      payload: {},
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('campaign-mismatch');
+    }
+  });
+});

--- a/src/lib/multiplayer/server/__tests__/CampaignSyncSession.test.ts
+++ b/src/lib/multiplayer/server/__tests__/CampaignSyncSession.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for `CampaignSyncSession` — campaign sync session lifecycle
+ * (CO1, task 5.5).
+ *
+ * Covers: host open issues a room code; join receives a snapshot + the
+ * full log; resync streams only the missing tail; large-gap resync
+ * receives a fresh snapshot; host disconnect pauses the session.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ */
+
+import type { ICampaignEvent } from '@/types/campaign/CampaignSync';
+
+import { InMemoryCampaignEventStore } from '@/lib/campaign/sync/InMemoryCampaignEventStore';
+import { CampaignMatchHost } from '@/lib/multiplayer/server/CampaignMatchHost';
+import {
+  CampaignSyncSession,
+  RESYNC_SNAPSHOT_GAP,
+} from '@/lib/multiplayer/server/CampaignSyncSession';
+import { isValidRoomCode } from '@/lib/p2p/roomCodes';
+import { createEmptyCampaignState } from '@/types/campaign/CampaignSync';
+
+const CAMPAIGN_ID = 'campaign-session';
+const HOST_ID = 'host-player';
+
+function newSession(balance = 600_000): {
+  host: CampaignMatchHost;
+  session: CampaignSyncSession;
+} {
+  const host = new CampaignMatchHost({
+    campaignId: CAMPAIGN_ID,
+    hostPlayerId: HOST_ID,
+    eventStore: new InMemoryCampaignEventStore(),
+    initialState: { ...createEmptyCampaignState(CAMPAIGN_ID), balance },
+  });
+  return { host, session: new CampaignSyncSession(host) };
+}
+
+describe('CampaignSyncSession — host opens a shared campaign', () => {
+  it('issues a valid 6-char room code excluding I/O/0/1', async () => {
+    const { session } = newSession();
+    const code = await session.open();
+    expect(isValidRoomCode(code)).toBe(true);
+    expect(code).toHaveLength(6);
+    expect(code).not.toMatch(/[IO01]/);
+  });
+
+  it('open is idempotent — the same code is returned', async () => {
+    const { session } = newSession();
+    const first = await session.open();
+    const second = await session.open();
+    expect(first).toBe(second);
+  });
+});
+
+describe('CampaignSyncSession — guest join', () => {
+  it('delivers a CampaignSnapshotPublished baseline then the log', async () => {
+    const { host, session } = newSession();
+    const code = await session.open();
+    // Commit a couple of log events before the guest joins.
+    await host.handleIntent({
+      kind: 'AdvanceDay',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'i1',
+      payload: {},
+    });
+
+    const received: ICampaignEvent[] = [];
+    const result = await session.joinGuest(code, (e) => received.push(e));
+
+    expect(result.ok).toBe(true);
+    // The FIRST delivered event is a baseline snapshot.
+    expect(result.delivered[0].type).toBe('CampaignSnapshotPublished');
+    // The log (snapshot@0, day-advance@1) follows.
+    const logTypes = result.delivered.slice(1).map((e) => e.type);
+    expect(logTypes).toEqual([
+      'CampaignSnapshotPublished',
+      'CampaignDayAdvanced',
+    ]);
+    result.disconnect();
+  });
+
+  it('delivers live events committed after the join', async () => {
+    const { host, session } = newSession();
+    const code = await session.open();
+    const received: ICampaignEvent[] = [];
+    const result = await session.joinGuest(code, (e) => received.push(e));
+    received.length = 0;
+
+    await host.handleIntent({
+      kind: 'AdvanceDay',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'live-1',
+      payload: {},
+    });
+    expect(received.map((e) => e.type)).toEqual(['CampaignDayAdvanced']);
+    result.disconnect();
+  });
+
+  it('rejects a join with a wrong room code', async () => {
+    const { session } = newSession();
+    await session.open();
+    const received: ICampaignEvent[] = [];
+    const result = await session.joinGuest('WRONGX', (e) => received.push(e));
+    expect(result.ok).toBe(false);
+    expect(received).toHaveLength(0);
+  });
+});
+
+describe('CampaignSyncSession — guest resync', () => {
+  it('streams only the missing tail after a brief disconnect', async () => {
+    const { host, session } = newSession();
+    await session.open();
+    // Commit 4 day-advance events (sequences 1..4, snapshot is 0).
+    for (let i = 0; i < 4; i++) {
+      await host.handleIntent({
+        kind: 'AdvanceDay',
+        campaignId: CAMPAIGN_ID,
+        intentId: `seq-${i}`,
+        payload: {},
+      });
+    }
+    // The guest disconnected after sequence 2; reconnect from 2.
+    const received: ICampaignEvent[] = [];
+    const result = await session.resyncGuest(2, (e) => received.push(e));
+
+    expect(result.ok).toBe(true);
+    expect(result.snapshotted).toBe(false);
+    // Only sequences 3 and 4 stream.
+    expect(result.delivered.map((e) => e.sequence)).toEqual([3, 4]);
+    result.disconnect();
+  });
+
+  it('a large-gap resync receives a fresh snapshot', async () => {
+    const { host, session } = newSession();
+    await session.open();
+    // Commit enough events that a guest stuck at sequence 0 is past
+    // the snapshot gap threshold.
+    for (let i = 0; i < RESYNC_SNAPSHOT_GAP + 5; i++) {
+      await host.handleIntent({
+        kind: 'AdvanceDay',
+        campaignId: CAMPAIGN_ID,
+        intentId: `big-${i}`,
+        payload: {},
+      });
+    }
+    const received: ICampaignEvent[] = [];
+    const result = await session.resyncGuest(0, (e) => received.push(e));
+
+    expect(result.ok).toBe(true);
+    expect(result.snapshotted).toBe(true);
+    expect(result.delivered[0].type).toBe('CampaignSnapshotPublished');
+    result.disconnect();
+  });
+});
+
+describe('CampaignSyncSession — host disconnect', () => {
+  it('pauses the session and closes the host', async () => {
+    const { host, session } = newSession();
+    await session.open();
+    expect(session.isPaused()).toBe(false);
+
+    session.hostDisconnected();
+
+    expect(session.isPaused()).toBe(true);
+    expect(host.isClosed()).toBe(true);
+    expect(session.getRoomCode()).toBeNull();
+
+    // An intent after disconnect is rejected — the session is frozen.
+    const result = await host.handleIntent({
+      kind: 'AdvanceDay',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'after-disconnect',
+      payload: {},
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/lib/p2p/__tests__/campaignMirrorStore.test.ts
+++ b/src/lib/p2p/__tests__/campaignMirrorStore.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for the guest campaign mirror store (CO1, task 4.5).
+ *
+ * Covers: a host-broadcast event advances the mirror; a guest-side
+ * local campaign mutation is rejected by the append guard; a solo
+ * campaign is never treated as a mirror.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ */
+
+import type { ICampaignEvent } from '@/types/campaign/CampaignSync';
+
+import {
+  assertCampaignMirrorWritable,
+  CampaignMirrorForbiddenError,
+  describeCampaignMirrorRejection,
+  isCampaignMirror,
+  useCampaignMirrorStore,
+} from '@/lib/p2p/campaignMirrorStore';
+import { createEmptyCampaignState } from '@/types/campaign/CampaignSync';
+
+const CAMPAIGN_ID = 'campaign-mirror';
+const HOST_PEER = 'host-peer';
+const GUEST_PEER = 'guest-peer';
+
+function snapshotEvent(sequence: number, balance: number): ICampaignEvent {
+  return {
+    type: 'CampaignSnapshotPublished',
+    sequence,
+    campaignId: CAMPAIGN_ID,
+    ts: '3025-01-01T00:00:00.000Z',
+    authorPlayerId: 'host',
+    payload: {
+      state: { ...createEmptyCampaignState(CAMPAIGN_ID), balance },
+    },
+  };
+}
+
+function dayEvent(sequence: number, newDay: number): ICampaignEvent {
+  return {
+    type: 'CampaignDayAdvanced',
+    sequence,
+    campaignId: CAMPAIGN_ID,
+    ts: '3025-01-01T00:00:00.000Z',
+    authorPlayerId: 'host',
+    payload: { newDay },
+  };
+}
+
+beforeEach(() => {
+  useCampaignMirrorStore.getState().reset();
+});
+
+describe('isCampaignMirror', () => {
+  it('is true when the local peer is the guest and a host exists', () => {
+    expect(
+      isCampaignMirror(
+        { hostPeerId: HOST_PEER, guestPeerId: GUEST_PEER },
+        GUEST_PEER,
+      ),
+    ).toBe(true);
+  });
+
+  it('is false for the host peer', () => {
+    expect(
+      isCampaignMirror(
+        { hostPeerId: HOST_PEER, guestPeerId: GUEST_PEER },
+        HOST_PEER,
+      ),
+    ).toBe(false);
+  });
+
+  it('is false for a solo campaign (no peers recorded)', () => {
+    expect(isCampaignMirror(null, GUEST_PEER)).toBe(false);
+    expect(isCampaignMirror(undefined, null)).toBe(false);
+  });
+});
+
+describe('campaign mirror append guard', () => {
+  it('rejects a local mutation on a guest mirror', () => {
+    const input = {
+      campaign: createEmptyCampaignState(CAMPAIGN_ID),
+      peers: { hostPeerId: HOST_PEER, guestPeerId: GUEST_PEER },
+      localPeerId: GUEST_PEER,
+    };
+    expect(describeCampaignMirrorRejection(input)).toBe('mirror-readonly');
+    expect(() => assertCampaignMirrorWritable(input)).toThrow(
+      CampaignMirrorForbiddenError,
+    );
+    try {
+      assertCampaignMirrorWritable(input);
+    } catch (error) {
+      expect(error).toBeInstanceOf(CampaignMirrorForbiddenError);
+      expect((error as CampaignMirrorForbiddenError).reason).toBe(
+        'mirror-readonly',
+      );
+    }
+  });
+
+  it('allows a local mutation on a solo campaign (not a mirror)', () => {
+    const input = {
+      campaign: createEmptyCampaignState(CAMPAIGN_ID),
+      peers: null,
+      localPeerId: 'solo-player',
+    };
+    expect(describeCampaignMirrorRejection(input)).toBeNull();
+    expect(() => assertCampaignMirrorWritable(input)).not.toThrow();
+  });
+
+  it('reports no-campaign when there is no campaign loaded', () => {
+    expect(
+      describeCampaignMirrorRejection({
+        campaign: null,
+        peers: { hostPeerId: HOST_PEER, guestPeerId: GUEST_PEER },
+        localPeerId: GUEST_PEER,
+      }),
+    ).toBe('no-campaign');
+  });
+});
+
+describe('useCampaignMirrorStore — host broadcast advances the mirror', () => {
+  it('applySnapshot seeds the mirror from a baseline', () => {
+    const store = useCampaignMirrorStore.getState();
+    store.beginMirror(
+      { hostPeerId: HOST_PEER, guestPeerId: GUEST_PEER },
+      GUEST_PEER,
+    );
+    store.applySnapshot(snapshotEvent(-1, 800_000));
+    expect(useCampaignMirrorStore.getState().campaign?.balance).toBe(800_000);
+  });
+
+  it('a host-broadcast CampaignDayAdvanced event advances the mirror', () => {
+    const store = useCampaignMirrorStore.getState();
+    store.beginMirror(
+      { hostPeerId: HOST_PEER, guestPeerId: GUEST_PEER },
+      GUEST_PEER,
+    );
+    store.applySnapshot(snapshotEvent(-1, 0));
+    store.applyEvent(dayEvent(0, 1));
+    store.applyEvent(dayEvent(1, 2));
+    expect(useCampaignMirrorStore.getState().campaign?.day).toBe(2);
+    expect(useCampaignMirrorStore.getState().lastSequence).toBe(1);
+  });
+
+  it('ignores an out-of-order / duplicate event', () => {
+    const store = useCampaignMirrorStore.getState();
+    store.beginMirror(
+      { hostPeerId: HOST_PEER, guestPeerId: GUEST_PEER },
+      GUEST_PEER,
+    );
+    store.applySnapshot(snapshotEvent(-1, 0));
+    store.applyEvent(dayEvent(0, 1));
+    // Re-applying sequence 0 (a reconnect-race duplicate) is dropped.
+    store.applyEvent(dayEvent(0, 99));
+    expect(useCampaignMirrorStore.getState().campaign?.day).toBe(1);
+  });
+
+  it('applyEvents converges from an interleaved batch', () => {
+    const store = useCampaignMirrorStore.getState();
+    store.beginMirror(
+      { hostPeerId: HOST_PEER, guestPeerId: GUEST_PEER },
+      GUEST_PEER,
+    );
+    store.applySnapshot(snapshotEvent(-1, 0));
+    // Deliberately out of order — applyEvents sorts ascending.
+    store.applyEvents([dayEvent(2, 3), dayEvent(0, 1), dayEvent(1, 2)]);
+    expect(useCampaignMirrorStore.getState().campaign?.day).toBe(3);
+  });
+
+  it('pause freezes the session (host disconnect)', () => {
+    const store = useCampaignMirrorStore.getState();
+    store.beginMirror(
+      { hostPeerId: HOST_PEER, guestPeerId: GUEST_PEER },
+      GUEST_PEER,
+    );
+    store.applySnapshot(snapshotEvent(-1, 0));
+    store.pause();
+    expect(useCampaignMirrorStore.getState().paused).toBe(true);
+  });
+});

--- a/src/lib/p2p/__tests__/campaignSyncBoundary.test.ts
+++ b/src/lib/p2p/__tests__/campaignSyncBoundary.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Yjs vault boundary test (CO1, task 6.2 / design D7).
+ *
+ * The campaign-state sync surface (`CampaignMatchHost`) and the Yjs
+ * content-vault sync surface (`useSyncedVaultStore`) are deliberately
+ * separate. This test pins the boundary: `SyncableItemType` must remain
+ * `unit | pilot | force` — no `campaign` member is ever added, so a
+ * campaign ledger can never enter the CRDT `Y.Map` where last-writer-
+ * wins would silently corrupt it.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ */
+
+import type { SyncableItemType } from '@/lib/p2p/types';
+
+describe('Yjs vault boundary — campaign state is not a SyncableItemType', () => {
+  it('SyncableItemType remains exactly unit | pilot | force', () => {
+    // Every valid value must be one of the three vault content types.
+    const valid: SyncableItemType[] = ['unit', 'pilot', 'force'];
+    expect(valid).toHaveLength(3);
+    expect(new Set(valid)).toEqual(new Set(['unit', 'pilot', 'force']));
+  });
+
+  it('a campaign type is NOT assignable to SyncableItemType', () => {
+    // This is a compile-time guarantee — `'campaign'` is not in the
+    // union, so the cast below would fail typecheck if the union ever
+    // gained a campaign member. The runtime assertion documents intent.
+    const campaignLikeValue: string = 'campaign';
+    const isSyncableVaultType = (value: string): value is SyncableItemType =>
+      value === 'unit' || value === 'pilot' || value === 'force';
+    expect(isSyncableVaultType(campaignLikeValue)).toBe(false);
+  });
+});

--- a/src/lib/p2p/campaignMirrorStore.ts
+++ b/src/lib/p2p/campaignMirrorStore.ts
@@ -1,0 +1,297 @@
+/**
+ * Campaign Mirror Store — the guest's read-only campaign mirror (CO1).
+ *
+ * The campaign-tier analogue of `src/lib/p2p/mirrorSession.ts`. In a
+ * shared co-op campaign the guest does NOT own campaign state — the host
+ * does (design D1). The guest runs a strict read-only mirror, advanced
+ * solely by host-broadcast `ICampaignEvent`s through the single
+ * `applyCampaignEvent` reducer.
+ *
+ * The "guest cannot append" contract is enforced exactly like
+ * `mirrorSession`'s `describeMirrorAppendRejection` /
+ * `assertMirrorAppendForbidden`: any local code path that tries to
+ * mutate campaign state on the guest fails loudly with a structured
+ * rejection. A guest "spend" button must instead send an
+ * `ICampaignIntent` to the host and wait for the resulting broadcast
+ * event — CO1 ships the transport; CO2 wires the button.
+ *
+ * Mirror identification mirrors `isMirrorSession`: the campaign is a
+ * mirror when a host peer is recorded, a local guest peer is recorded,
+ * and they differ. A solo campaign records no host peer and is never a
+ * mirror — its local mutations proceed normally.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ * @spec openspec/changes/add-shared-campaign-state/design.md (D5)
+ */
+
+import { create } from 'zustand';
+
+import type {
+  ICampaignAuthoritativeState,
+  ICampaignEvent,
+} from '@/types/campaign/CampaignSync';
+
+import { applyCampaignEvent } from '@/lib/campaign/sync/applyCampaignEvent';
+
+// =============================================================================
+// Mirror peer identity
+// =============================================================================
+
+/**
+ * The peer identity that classifies a campaign as a mirror. Recorded on
+ * the guest when it joins a shared campaign; absent for a solo campaign.
+ */
+export interface ICampaignMirrorPeers {
+  /** The host peer's id (the campaign owner / authoritative writer). */
+  readonly hostPeerId: string;
+  /** The local guest peer's id. */
+  readonly guestPeerId: string;
+}
+
+/**
+ * True when the local peer is the GUEST in a shared campaign — a host
+ * peer is recorded, a guest peer is recorded, they differ, and the
+ * local peer is the guest. A solo campaign (no peers recorded) returns
+ * false, so this helper is safe to call on any campaign.
+ *
+ * The campaign-tier analogue of `isMirrorSession`.
+ */
+export function isCampaignMirror(
+  peers: ICampaignMirrorPeers | null | undefined,
+  localPeerId: string | null | undefined,
+): boolean {
+  if (!peers || !localPeerId) return false;
+  if (!peers.hostPeerId || !peers.guestPeerId) return false;
+  if (peers.hostPeerId === peers.guestPeerId) return false;
+  if (peers.hostPeerId === localPeerId) return false;
+  return peers.guestPeerId === localPeerId;
+}
+
+// =============================================================================
+// Mirror append guard
+// =============================================================================
+
+/**
+ * Reasons a campaign mirror rejects a local append/mutation attempt.
+ * Stable strings for tests and the guest UI's `peer-rejected` surface.
+ */
+export type CampaignMirrorRejection = 'mirror-readonly' | 'no-campaign';
+
+/**
+ * Thrown by `assertCampaignMirrorWritable` when a local code path tries
+ * to mutate a guest mirror directly. Carries the structured `reason` so
+ * a consumer can `try / catch` and surface a `peer-rejected` toast
+ * without leaking unstructured strings. The campaign-tier analogue of
+ * `MirrorAppendForbiddenError`.
+ */
+export class CampaignMirrorForbiddenError extends Error {
+  readonly reason: CampaignMirrorRejection;
+
+  constructor(reason: CampaignMirrorRejection, message?: string) {
+    super(message ?? `Campaign mirror cannot be mutated locally: ${reason}`);
+    this.name = 'CampaignMirrorForbiddenError';
+    this.reason = reason;
+  }
+}
+
+/**
+ * Decision helper: returns `null` when the local peer is allowed to
+ * mutate campaign state (solo campaign, or the host), or a structured
+ * rejection when the mutation would corrupt a guest mirror. Read-only —
+ * it does not throw, so the UI can swap a "Spend" button for "Send to
+ * host" rather than crash.
+ *
+ * The campaign-tier analogue of `describeMirrorAppendRejection`.
+ */
+export function describeCampaignMirrorRejection(input: {
+  readonly campaign: ICampaignAuthoritativeState | null;
+  readonly peers: ICampaignMirrorPeers | null | undefined;
+  readonly localPeerId: string | null | undefined;
+}): CampaignMirrorRejection | null {
+  if (!input.campaign) return 'no-campaign';
+  if (!isCampaignMirror(input.peers, input.localPeerId)) return null;
+  return 'mirror-readonly';
+}
+
+/**
+ * Hard guard for any local campaign-mutation path on a co-op campaign.
+ * Call this at the top of a local commit path; it throws
+ * `CampaignMirrorForbiddenError` when the campaign is a guest mirror so
+ * the mutation fails loudly (spec scenario "Guest-side local mutation
+ * is rejected"). A solo campaign passes the guard silently (spec
+ * scenario "Solo campaign is not a mirror").
+ *
+ * The campaign-tier analogue of `assertMirrorAppendForbidden`.
+ */
+export function assertCampaignMirrorWritable(input: {
+  readonly campaign: ICampaignAuthoritativeState | null;
+  readonly peers: ICampaignMirrorPeers | null | undefined;
+  readonly localPeerId: string | null | undefined;
+}): void {
+  const reason = describeCampaignMirrorRejection(input);
+  if (reason !== null) {
+    throw new CampaignMirrorForbiddenError(reason);
+  }
+}
+
+// =============================================================================
+// Mirror store
+// =============================================================================
+
+interface CampaignMirrorState {
+  /**
+   * The mirrored campaign state, or `null` before the baseline
+   * snapshot has arrived. A guest renders a "joining campaign…" state
+   * in that window.
+   */
+  campaign: ICampaignAuthoritativeState | null;
+  /** The host/guest peer identity, or `null` for a solo campaign. */
+  peers: ICampaignMirrorPeers | null;
+  /** The local peer id — the guest's own id when this is a mirror. */
+  localPeerId: string | null;
+  /** Highest event sequence applied — drives resync from the last seq. */
+  lastSequence: number;
+  /**
+   * True when the host has disconnected: the mirror is frozen (it is
+   * already read-only) and the guest UI shows a paused banner (design
+   * D6 / spec scenario "Host disconnect pauses the session").
+   */
+  paused: boolean;
+}
+
+interface CampaignMirrorActions {
+  /**
+   * Enter mirror mode for a joined co-op campaign — record the peer
+   * identity. Until `applySnapshot` runs, `campaign` stays `null`.
+   */
+  beginMirror: (peers: ICampaignMirrorPeers, localPeerId: string) => void;
+  /**
+   * Seed the mirror from a `CampaignSnapshotPublished` baseline. Used on
+   * join and on a large-gap resync — the snapshot REPLACES whatever
+   * state the mirror held.
+   *
+   * The framing baseline carries `sequence: -1`, so a join seeds the
+   * mirror and the following log events (sequence 0+) all pass the
+   * `applyEvent` ordering guard. For a large-gap resync the caller
+   * passes `resumeSequence` — the live stream's next sequence minus one
+   * — so `applyEvent` accepts the post-snapshot live events and rejects
+   * stale tail events the snapshot already folded in.
+   */
+  applySnapshot: (snapshot: ICampaignEvent, resumeSequence?: number) => void;
+  /**
+   * Advance the mirror by ONE host-broadcast campaign event through the
+   * shared `applyCampaignEvent` reducer. This is the ONLY way a guest
+   * mirror's `campaign` field ever changes. Out-of-order or duplicate
+   * events (sequence <= `lastSequence`) are ignored — a replay burst
+   * that arrived interleaved with live events still converges.
+   */
+  applyEvent: (event: ICampaignEvent) => void;
+  /**
+   * Apply an ordered batch of events (a replay stream or a resync
+   * tail). Each event funnels through `applyEvent`, so the same
+   * ordering and de-duplication guarantees hold.
+   */
+  applyEvents: (events: readonly ICampaignEvent[]) => void;
+  /** Mark the session paused — the host disconnected (design D6). */
+  pause: () => void;
+  /** Reset the mirror (leaving a campaign / test teardown). */
+  reset: () => void;
+}
+
+export type CampaignMirrorStore = CampaignMirrorState & CampaignMirrorActions;
+
+const INITIAL_STATE: CampaignMirrorState = {
+  campaign: null,
+  peers: null,
+  localPeerId: null,
+  lastSequence: -1,
+  paused: false,
+};
+
+/**
+ * The guest's campaign mirror store. A guest in a shared co-op campaign
+ * binds this store; its `campaign` field is advanced SOLELY by
+ * host-broadcast events through `applyEvent` — never by a local
+ * mutation. There is intentionally no `updateCampaign` /
+ * `spendFunds` / `hirePilot` action: a guest action is an intent to the
+ * host, not a local write.
+ */
+export const useCampaignMirrorStore = create<CampaignMirrorStore>()((set) => ({
+  ...INITIAL_STATE,
+
+  beginMirror: (peers: ICampaignMirrorPeers, localPeerId: string): void => {
+    set({
+      peers,
+      localPeerId,
+      campaign: null,
+      lastSequence: -1,
+      paused: false,
+    });
+  },
+
+  applySnapshot: (snapshot: ICampaignEvent, resumeSequence?: number): void => {
+    if (snapshot.type !== 'CampaignSnapshotPublished') {
+      // A non-snapshot event cannot seed a mirror — ignore it. The
+      // sync session only ever calls `applySnapshot` with a real
+      // snapshot, but the guard keeps the contract explicit.
+      return;
+    }
+    set(() => ({
+      // The snapshot's payload is the whole authoritative state.
+      campaign: snapshot.payload.state,
+      // A join baseline carries `sequence: -1`, so the following log
+      // events (0+) all pass the `applyEvent` ordering guard. A
+      // large-gap resync passes `resumeSequence` so post-snapshot live
+      // events are accepted and stale tail events are rejected.
+      lastSequence: resumeSequence ?? snapshot.sequence,
+      paused: false,
+    }));
+  },
+
+  applyEvent: (event: ICampaignEvent): void => {
+    set((state) => {
+      // Out-of-order / duplicate guard — a replayed event the guest
+      // also saw live during a reconnect race is dropped.
+      if (event.sequence <= state.lastSequence) {
+        return {};
+      }
+      const base =
+        event.type === 'CampaignSnapshotPublished' || state.campaign === null
+          ? // A snapshot (or the very first event) seeds the mirror.
+            applyCampaignEvent(
+              {
+                campaignId: event.campaignId,
+                day: 0,
+                balance: 0,
+                rosterUnits: {},
+                pilots: {},
+                contracts: {},
+                factionStanding: {},
+                salvagePool: 0,
+              },
+              event,
+            )
+          : applyCampaignEvent(state.campaign, event);
+      return { campaign: base, lastSequence: event.sequence };
+    });
+  },
+
+  applyEvents: (events: readonly ICampaignEvent[]): void => {
+    // Apply in ascending sequence order so an interleaved replay burst
+    // still converges. `applyEvent` de-dupes per-event.
+    const ordered = [...events].sort(
+      (left, right) => left.sequence - right.sequence,
+    );
+    for (const event of ordered) {
+      useCampaignMirrorStore.getState().applyEvent(event);
+    }
+  },
+
+  pause: (): void => {
+    set({ paused: true });
+  },
+
+  reset: (): void => {
+    set({ ...INITIAL_STATE });
+  },
+}));

--- a/src/lib/p2p/types.ts
+++ b/src/lib/p2p/types.ts
@@ -96,6 +96,18 @@ export interface ISyncRoomOptions {
 
 /**
  * Types of vault items that can be synced.
+ *
+ * BOUNDARY (`add-shared-campaign-state` CO1, design D7): this
+ * enumeration is for the Yjs content vault ONLY — unit / pilot / force
+ * *designs*. Campaign state (C-bill balance, roster, contracts, day
+ * counter) is a transactional ledger and SHALL NOT be added here. A
+ * CRDT `Y.Map` is last-writer-wins; it guarantees convergence, not the
+ * `balance >= 0` ledger invariant. Campaign state is synchronized
+ * instead through the server-authoritative `CampaignMatchHost`
+ * `intent → validate → commit → broadcast` loop
+ * (`src/lib/multiplayer/server/CampaignMatchHost.ts`). Do NOT introduce
+ * a `'campaign'` member — that reintroduces the ledger-corruption bug
+ * the Council's DP2 decision ruled out.
  */
 export type SyncableItemType = 'unit' | 'pilot' | 'force';
 

--- a/src/lib/p2p/useSyncedVaultStore.ts
+++ b/src/lib/p2p/useSyncedVaultStore.ts
@@ -4,7 +4,18 @@
  * Zustand store for vault items that sync via Yjs CRDT.
  * Bidirectionally syncs state between Zustand and Y.Map.
  *
+ * BOUNDARY (`add-shared-campaign-state` CO1, design D7): this Yjs
+ * `Y.Map`-backed store is for the content vault (unit / pilot / force
+ * *designs*) ONLY. It SHALL NOT be extended to campaign state. A
+ * campaign is a transactional ledger; CRDT last-writer-wins silently
+ * corrupts it (two players spending the same C-bills merge into one
+ * debit with no overdraft check). Campaign state syncs through the
+ * server-authoritative `CampaignMatchHost` instead — see
+ * `src/lib/multiplayer/server/CampaignMatchHost.ts` and the
+ * `coop-campaign-sync` spec. Do NOT add a campaign `SyncableItemType`.
+ *
  * @spec openspec/changes/add-p2p-vault-sync/specs/vault-sync/spec.md
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
  */
 
 import * as Y from 'yjs';

--- a/src/types/campaign/CampaignSync.ts
+++ b/src/types/campaign/CampaignSync.ts
@@ -1,0 +1,443 @@
+/**
+ * Shared Campaign State — sync types (CO1).
+ *
+ * Co-op campaign state is a transactional ledger, not a CRDT. Per the
+ * `add-shared-campaign-state` design (D1) it rides the same
+ * server-authoritative `intent → validate → commit → broadcast` loop
+ * the combat `ServerMatchHost` uses, NOT the Yjs `useSyncedVaultStore`.
+ *
+ * This module defines the wire contracts:
+ *   - `ICampaignEvent` — one ordered, typed, replayable committed
+ *     mutation (the campaign-tier analogue of an `IGameEvent`).
+ *   - the per-`CampaignEventType` payload shapes.
+ *   - `ICampaignIntent` — what a guest sends; the host validates it.
+ *   - `CampaignIntentResult` — the result of validating one intent.
+ *   - `ICampaignAuthoritativeState` — the host's authoritative ledger
+ *     projection, also the `CampaignSnapshotPublished` payload body and
+ *     the shape the guest mirror replays into.
+ *
+ * Every shape is JSON-safe — `JSON.parse(JSON.stringify(x))` reproduces
+ * it without loss — so events survive the WebSocket transport and the
+ * persisted log round-trip.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ * @spec openspec/changes/add-shared-campaign-state/design.md (D2, D3, D8)
+ */
+
+// =============================================================================
+// Authoritative campaign state — the ledger projection
+// =============================================================================
+
+/**
+ * One owned roster unit in the shared-campaign ledger projection. The
+ * full unit design lives in the content vault; the ledger only tracks
+ * the campaign-relevant facts a co-op guest must mirror.
+ */
+export interface ICampaignRosterUnit {
+  /** Stable unit id (matches the vault / campaign roster id). */
+  readonly unitId: string;
+  /** Display designation, e.g. "Atlas AS7-D". */
+  readonly designation: string;
+  /** Coarse repair status of the unit in the campaign. */
+  readonly status: 'operational' | 'damaged' | 'destroyed';
+}
+
+/**
+ * One hired pilot in the ledger projection.
+ */
+export interface ICampaignRosterPilot {
+  /** Stable pilot id. */
+  readonly pilotId: string;
+  /** Pilot display name. */
+  readonly name: string;
+}
+
+/**
+ * One accepted contract in the ledger projection.
+ */
+export interface ICampaignAcceptedContract {
+  /** Stable contract id. */
+  readonly contractId: string;
+  /** Contract display name. */
+  readonly name: string;
+  /** Employer faction id (drives the faction-standing check). */
+  readonly employerFactionId: string;
+}
+
+/**
+ * The host's authoritative campaign ledger state. This is the single
+ * source of truth a `CampaignMatchHost` validates intents against, the
+ * body of the `CampaignSnapshotPublished` event, and the shape the
+ * guest mirror is reconstructed into by replaying the event log.
+ *
+ * It is deliberately a flat, JSON-safe projection — NOT the full
+ * `ICampaign` aggregate. CO1 syncs the ledger-mutating facts; the rest
+ * of the campaign content stays in `useCampaignStore` / the vault.
+ */
+export interface ICampaignAuthoritativeState {
+  /** Campaign id this state belongs to. */
+  readonly campaignId: string;
+  /** In-game day counter; advanced by `CampaignDayAdvanced`. */
+  readonly day: number;
+  /** C-bill balance; the invariant `balance >= 0` is host-enforced. */
+  readonly balance: number;
+  /** Owned roster units, keyed by `unitId`. */
+  readonly rosterUnits: Readonly<Record<string, ICampaignRosterUnit>>;
+  /** Hired pilots, keyed by `pilotId`. */
+  readonly pilots: Readonly<Record<string, ICampaignRosterPilot>>;
+  /** Accepted contracts, keyed by `contractId`. */
+  readonly contracts: Readonly<Record<string, ICampaignAcceptedContract>>;
+  /**
+   * Faction standing by faction id. A higher value is friendlier; a
+   * contract intent is rejected when the employer's standing is below
+   * `CONTRACT_MIN_STANDING`. Absent factions are treated as neutral (0).
+   */
+  readonly factionStanding: Readonly<Record<string, number>>;
+  /**
+   * Unallocated post-battle salvage value, in C-bills. An
+   * `AllocateSalvage` intent draws from this pool.
+   */
+  readonly salvagePool: number;
+}
+
+/**
+ * The minimum employer faction standing required to accept a contract.
+ * Standing below this rejects an `AcceptContract` intent.
+ */
+export const CONTRACT_MIN_STANDING = 0;
+
+/**
+ * Build the empty authoritative state for a fresh shared campaign.
+ */
+export function createEmptyCampaignState(
+  campaignId: string,
+): ICampaignAuthoritativeState {
+  return {
+    campaignId,
+    day: 0,
+    balance: 0,
+    rosterUnits: {},
+    pilots: {},
+    contracts: {},
+    factionStanding: {},
+    salvagePool: 0,
+  };
+}
+
+// =============================================================================
+// Campaign event payloads
+// =============================================================================
+
+/**
+ * The set of ledger-mutating campaign event types. Each carries a
+ * committed result, never a request. Per design D3.
+ */
+export type CampaignEventType =
+  | 'CampaignDayAdvanced'
+  | 'FundsChanged'
+  | 'PilotHired'
+  | 'ContractAccepted'
+  | 'RosterUnitChanged'
+  | 'SalvageAllocated'
+  | 'CampaignSnapshotPublished';
+
+/** `CampaignDayAdvanced` — the day counter moved forward. */
+export interface ICampaignDayAdvancedPayload {
+  /** The new day index after the advance. */
+  readonly newDay: number;
+}
+
+/**
+ * `FundsChanged` — the C-bill balance changed. Carries the resulting
+ * balance (not just the delta) so a guest that missed an event can
+ * detect a gap. Per design D3.
+ */
+export interface IFundsChangedPayload {
+  /** Signed C-bill delta applied (negative = spend). */
+  readonly delta: number;
+  /** Human-readable reason for the change. */
+  readonly reason: string;
+  /** The C-bill balance AFTER the change. */
+  readonly balance: number;
+}
+
+/** `PilotHired` — a pilot joined the roster. */
+export interface IPilotHiredPayload {
+  /** The hired pilot. */
+  readonly pilot: ICampaignRosterPilot;
+  /** C-bill hiring cost (already debited; see the paired FundsChanged). */
+  readonly cost: number;
+}
+
+/** `ContractAccepted` — a contract was accepted. */
+export interface IContractAcceptedPayload {
+  /** The accepted contract. */
+  readonly contract: ICampaignAcceptedContract;
+}
+
+/** `RosterUnitChanged` — a unit was added / removed / repaired. */
+export interface IRosterUnitChangedPayload {
+  /** What happened to the unit. */
+  readonly change: 'added' | 'removed' | 'repaired';
+  /** The unit after the change (for `added` / `repaired`). */
+  readonly unit: ICampaignRosterUnit;
+}
+
+/** `SalvageAllocated` — post-battle salvage assigned to the campaign. */
+export interface ISalvageAllocatedPayload {
+  /** C-bill value drawn from the salvage pool. */
+  readonly value: number;
+  /** Salvage pool remaining after the allocation. */
+  readonly poolRemaining: number;
+  /** Optional roster unit recovered from the salvage. */
+  readonly recoveredUnit?: ICampaignRosterUnit;
+}
+
+/**
+ * `CampaignSnapshotPublished` — a full-state baseline for a joining or
+ * resyncing guest. The only event whose payload is a whole-campaign
+ * state object. Per design D3.
+ */
+export interface ICampaignSnapshotPublishedPayload {
+  /** The whole authoritative campaign state at snapshot time. */
+  readonly state: ICampaignAuthoritativeState;
+}
+
+/**
+ * Discriminated map from `CampaignEventType` to its payload shape. Used
+ * to narrow `ICampaignEvent.payload` per type.
+ */
+export interface ICampaignEventPayloadMap {
+  readonly CampaignDayAdvanced: ICampaignDayAdvancedPayload;
+  readonly FundsChanged: IFundsChangedPayload;
+  readonly PilotHired: IPilotHiredPayload;
+  readonly ContractAccepted: IContractAcceptedPayload;
+  readonly RosterUnitChanged: IRosterUnitChangedPayload;
+  readonly SalvageAllocated: ISalvageAllocatedPayload;
+  readonly CampaignSnapshotPublished: ICampaignSnapshotPublishedPayload;
+}
+
+// =============================================================================
+// Campaign event
+// =============================================================================
+
+/**
+ * The fields every campaign event carries regardless of type. Merged
+ * into each per-type variant below.
+ */
+interface ICampaignEventBase {
+  /** Ascending, gap-free, host-assigned sequence number. */
+  readonly sequence: number;
+  /** Campaign id this event belongs to. */
+  readonly campaignId: string;
+  /** Host wall-clock ISO 8601 timestamp. */
+  readonly ts: string;
+  /** Player id that committed the event (host id for host-driven events). */
+  readonly authorPlayerId: string;
+}
+
+/**
+ * One typed campaign-event variant — the base fields plus the `type`
+ * discriminant and the narrowed `payload`. The distributive mapped type
+ * over `CampaignEventType` below produces the discriminated union
+ * `ICampaignEvent`, so a `switch (event.type)` narrows `payload`
+ * exactly.
+ */
+export type ICampaignEventOf<T extends CampaignEventType> =
+  ICampaignEventBase & {
+    /** The event type discriminant. */
+    readonly type: T;
+    /** Per-type payload, narrowed by `T`. */
+    readonly payload: ICampaignEventPayloadMap[T];
+  };
+
+/**
+ * One committed campaign mutation. The campaign-tier analogue of
+ * `IGameEvent` — ordered, typed, replayable. Per design D3.
+ *
+ * This is a discriminated union over `CampaignEventType`, so a
+ * `switch (event.type)` narrows `payload` to the exact per-type shape.
+ * `ICampaignEvent<'FundsChanged'>` selects a single variant — the
+ * distributive conditional below maps each member of `T` to its
+ * `ICampaignEventOf` variant and unions the result.
+ */
+export type ICampaignEvent<T extends CampaignEventType = CampaignEventType> =
+  T extends CampaignEventType ? ICampaignEventOf<T> : never;
+
+/** Narrowed alias for a `FundsChanged` campaign event. */
+export type ICampaignFundsChangedEvent = ICampaignEvent<'FundsChanged'>;
+/** Narrowed alias for a `CampaignSnapshotPublished` campaign event. */
+export type ICampaignSnapshotEvent =
+  ICampaignEvent<'CampaignSnapshotPublished'>;
+
+/**
+ * Structural type guard for a raw broadcast payload. The WebSocket
+ * layer types inbound payloads as `unknown`; this narrows a candidate
+ * to `ICampaignEvent` before it is applied to a mirror or a log.
+ */
+export function isCampaignEvent(value: unknown): value is ICampaignEvent {
+  if (typeof value !== 'object' || value === null) return false;
+  const event = value as Partial<ICampaignEvent>;
+  return (
+    typeof event.type === 'string' &&
+    isCampaignEventType(event.type) &&
+    typeof event.sequence === 'number' &&
+    Number.isInteger(event.sequence) &&
+    event.sequence >= 0 &&
+    typeof event.campaignId === 'string' &&
+    typeof event.ts === 'string' &&
+    typeof event.authorPlayerId === 'string' &&
+    typeof event.payload === 'object' &&
+    event.payload !== null
+  );
+}
+
+/** True iff `value` is one of the seven `CampaignEventType` strings. */
+export function isCampaignEventType(value: string): value is CampaignEventType {
+  return (
+    value === 'CampaignDayAdvanced' ||
+    value === 'FundsChanged' ||
+    value === 'PilotHired' ||
+    value === 'ContractAccepted' ||
+    value === 'RosterUnitChanged' ||
+    value === 'SalvageAllocated' ||
+    value === 'CampaignSnapshotPublished'
+  );
+}
+
+// =============================================================================
+// Campaign intents
+// =============================================================================
+
+/**
+ * The kinds of campaign intent a guest may send. The host validates
+ * each against authoritative state before committing any event.
+ */
+export type CampaignIntentKind =
+  | 'HirePilot'
+  | 'AcceptContract'
+  | 'SpendFunds'
+  | 'AllocateSalvage'
+  | 'AdvanceDay';
+
+/** `HirePilot` intent payload. */
+export interface IHirePilotIntentPayload {
+  /** The pilot to hire. */
+  readonly pilot: ICampaignRosterPilot;
+  /** C-bill hiring cost; validated against the balance. */
+  readonly cost: number;
+}
+
+/** `AcceptContract` intent payload. */
+export interface IAcceptContractIntentPayload {
+  /** The contract to accept. */
+  readonly contract: ICampaignAcceptedContract;
+}
+
+/** `SpendFunds` intent payload. */
+export interface ISpendFundsIntentPayload {
+  /** C-bill amount to spend; validated against the balance. */
+  readonly amount: number;
+  /** Human-readable reason for the spend. */
+  readonly reason: string;
+}
+
+/** `AllocateSalvage` intent payload. */
+export interface IAllocateSalvageIntentPayload {
+  /** C-bill value to draw from the salvage pool. */
+  readonly value: number;
+  /** Optional roster unit recovered from the salvage. */
+  readonly recoveredUnit?: ICampaignRosterUnit;
+}
+
+/** `AdvanceDay` intent payload. Empty — the host computes the new day. */
+export interface IAdvanceDayIntentPayload {
+  /** Number of days to advance (defaults to 1 when omitted). */
+  readonly days?: number;
+}
+
+/** Discriminated map from intent kind to its payload shape. */
+export interface ICampaignIntentPayloadMap {
+  readonly HirePilot: IHirePilotIntentPayload;
+  readonly AcceptContract: IAcceptContractIntentPayload;
+  readonly SpendFunds: ISpendFundsIntentPayload;
+  readonly AllocateSalvage: IAllocateSalvageIntentPayload;
+  readonly AdvanceDay: IAdvanceDayIntentPayload;
+}
+
+/** The fields every campaign intent carries regardless of kind. */
+interface ICampaignIntentBase {
+  /** Campaign id the intent targets. */
+  readonly campaignId: string;
+  /** Client-generated id, for error correlation. */
+  readonly intentId: string;
+}
+
+/**
+ * One typed campaign-intent variant — the base fields plus the `kind`
+ * discriminant and the narrowed `payload`.
+ */
+export type ICampaignIntentOf<K extends CampaignIntentKind> =
+  ICampaignIntentBase & {
+    /** The intent kind discriminant. */
+    readonly kind: K;
+    /** Per-kind payload, narrowed by `K`. */
+    readonly payload: ICampaignIntentPayloadMap[K];
+  };
+
+/**
+ * A campaign intent — what a guest sends. The host validates it against
+ * authoritative state and may reject it. Per design D8.
+ *
+ * A discriminated union over `CampaignIntentKind`, so a
+ * `switch (intent.kind)` narrows `payload` to the exact per-kind shape.
+ */
+export type ICampaignIntent<K extends CampaignIntentKind = CampaignIntentKind> =
+  K extends CampaignIntentKind ? ICampaignIntentOf<K> : never;
+
+// =============================================================================
+// Campaign intent result
+// =============================================================================
+
+/**
+ * The error code returned for a rejected campaign intent. A single
+ * stable code; the specific cause is in `reason`. Per design D4.
+ */
+export const INVALID_CAMPAIGN_INTENT = 'INVALID_CAMPAIGN_INTENT' as const;
+
+/**
+ * Stable rejection reasons for an invalid campaign intent. `reason` on a
+ * rejection envelope is one of these strings so the guest UI and tests
+ * can branch on it.
+ */
+export type CampaignIntentRejectionReason =
+  | 'insufficient-funds'
+  | 'insufficient-standing'
+  | 'insufficient-salvage'
+  | 'malformed-intent'
+  | 'session-closed'
+  | 'campaign-mismatch';
+
+/**
+ * The result of validating one campaign intent against authoritative
+ * state. Per design D8.
+ */
+export type CampaignIntentResult =
+  | { readonly ok: true; readonly events: readonly ICampaignEvent[] }
+  | {
+      readonly ok: false;
+      readonly code: typeof INVALID_CAMPAIGN_INTENT;
+      readonly reason: CampaignIntentRejectionReason;
+    };
+
+/**
+ * A typed error envelope for a rejected campaign intent — the campaign
+ * analogue of the combat `Error` server message. Carries the originating
+ * `intentId` so the guest can correlate the rejection.
+ */
+export interface ICampaignIntentError {
+  readonly ok: false;
+  readonly code: typeof INVALID_CAMPAIGN_INTENT;
+  readonly reason: CampaignIntentRejectionReason;
+  readonly intentId: string;
+}

--- a/src/types/campaign/__tests__/CampaignSync.test.ts
+++ b/src/types/campaign/__tests__/CampaignSync.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for the shared-campaign sync type set (CO1, task 1.4).
+ *
+ * Covers the type guards, the empty-state factory, and a serialization
+ * round-trip preserving every campaign event payload — every campaign
+ * event must survive `JSON.parse(JSON.stringify(event))` without loss
+ * so the WebSocket transport and the persisted log round-trip cleanly.
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ */
+
+import {
+  createEmptyCampaignState,
+  isCampaignEvent,
+  isCampaignEventType,
+  type ICampaignEvent,
+  type ICampaignAuthoritativeState,
+} from '@/types/campaign/CampaignSync';
+import { parseCampaignIntent } from '@/types/campaign/campaignSyncSchemas';
+
+const CAMPAIGN_ID = 'campaign-co1';
+
+function sampleState(): ICampaignAuthoritativeState {
+  return {
+    campaignId: CAMPAIGN_ID,
+    day: 7,
+    balance: 1_250_000,
+    rosterUnits: {
+      'unit-1': {
+        unitId: 'unit-1',
+        designation: 'Atlas AS7-D',
+        status: 'operational',
+      },
+    },
+    pilots: {
+      'pilot-1': { pilotId: 'pilot-1', name: 'Natasha Kerensky' },
+    },
+    contracts: {
+      'contract-1': {
+        contractId: 'contract-1',
+        name: 'Raid on Hesperus',
+        employerFactionId: 'steiner',
+      },
+    },
+    factionStanding: { steiner: 3 },
+    salvagePool: 400_000,
+  };
+}
+
+/** One representative event per `CampaignEventType`. */
+function allEventTypes(): ICampaignEvent[] {
+  const base = { campaignId: CAMPAIGN_ID, ts: '3025-01-08T00:00:00.000Z' };
+  return [
+    {
+      ...base,
+      type: 'CampaignDayAdvanced',
+      sequence: 0,
+      authorPlayerId: 'host',
+      payload: { newDay: 8 },
+    },
+    {
+      ...base,
+      type: 'FundsChanged',
+      sequence: 1,
+      authorPlayerId: 'host',
+      payload: { delta: -100_000, reason: 'Repairs', balance: 1_150_000 },
+    },
+    {
+      ...base,
+      type: 'PilotHired',
+      sequence: 2,
+      authorPlayerId: 'guest:campaign-co1',
+      payload: {
+        pilot: { pilotId: 'pilot-2', name: 'Jaime Wolf' },
+        cost: 50_000,
+      },
+    },
+    {
+      ...base,
+      type: 'ContractAccepted',
+      sequence: 3,
+      authorPlayerId: 'host',
+      payload: {
+        contract: {
+          contractId: 'contract-2',
+          name: 'Garrison Duty',
+          employerFactionId: 'davion',
+        },
+      },
+    },
+    {
+      ...base,
+      type: 'RosterUnitChanged',
+      sequence: 4,
+      authorPlayerId: 'host',
+      payload: {
+        change: 'repaired',
+        unit: {
+          unitId: 'unit-1',
+          designation: 'Atlas AS7-D',
+          status: 'operational',
+        },
+      },
+    },
+    {
+      ...base,
+      type: 'SalvageAllocated',
+      sequence: 5,
+      authorPlayerId: 'host',
+      payload: { value: 100_000, poolRemaining: 300_000 },
+    },
+    {
+      ...base,
+      type: 'CampaignSnapshotPublished',
+      sequence: 6,
+      authorPlayerId: 'host',
+      payload: { state: sampleState() },
+    },
+  ];
+}
+
+describe('CampaignSync type guards', () => {
+  it('isCampaignEventType accepts every event type and rejects others', () => {
+    for (const event of allEventTypes()) {
+      expect(isCampaignEventType(event.type)).toBe(true);
+    }
+    expect(isCampaignEventType('NotAnEvent')).toBe(false);
+    expect(isCampaignEventType('')).toBe(false);
+  });
+
+  it('isCampaignEvent accepts a well-formed event', () => {
+    for (const event of allEventTypes()) {
+      expect(isCampaignEvent(event)).toBe(true);
+    }
+  });
+
+  it('isCampaignEvent rejects malformed candidates', () => {
+    expect(isCampaignEvent(null)).toBe(false);
+    expect(isCampaignEvent({})).toBe(false);
+    expect(isCampaignEvent({ type: 'FundsChanged' })).toBe(false);
+    expect(
+      isCampaignEvent({
+        type: 'FundsChanged',
+        sequence: -1,
+        campaignId: 'c',
+        ts: 't',
+        authorPlayerId: 'a',
+        payload: {},
+      }),
+    ).toBe(false);
+    expect(
+      isCampaignEvent({
+        type: 'Unknown',
+        sequence: 0,
+        campaignId: 'c',
+        ts: 't',
+        authorPlayerId: 'a',
+        payload: {},
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('createEmptyCampaignState', () => {
+  it('produces a zeroed ledger bound to the campaign id', () => {
+    const state = createEmptyCampaignState(CAMPAIGN_ID);
+    expect(state.campaignId).toBe(CAMPAIGN_ID);
+    expect(state.day).toBe(0);
+    expect(state.balance).toBe(0);
+    expect(state.salvagePool).toBe(0);
+    expect(Object.keys(state.rosterUnits)).toHaveLength(0);
+    expect(Object.keys(state.pilots)).toHaveLength(0);
+    expect(Object.keys(state.contracts)).toHaveLength(0);
+  });
+});
+
+describe('campaign event serialization round-trip', () => {
+  it('preserves every campaign event payload through JSON', () => {
+    for (const event of allEventTypes()) {
+      const roundTripped = JSON.parse(JSON.stringify(event)) as ICampaignEvent;
+      expect(roundTripped).toEqual(event);
+      expect(isCampaignEvent(roundTripped)).toBe(true);
+    }
+  });
+
+  it('FundsChanged carries delta, reason, and resulting balance', () => {
+    const funds = allEventTypes().find((e) => e.type === 'FundsChanged');
+    expect(funds).toBeDefined();
+    if (funds && funds.type === 'FundsChanged') {
+      expect(funds.payload.delta).toBe(-100_000);
+      expect(funds.payload.reason).toBe('Repairs');
+      expect(funds.payload.balance).toBe(1_150_000);
+    }
+  });
+
+  it('CampaignSnapshotPublished carries a whole-campaign baseline', () => {
+    const snapshot = allEventTypes().find(
+      (e) => e.type === 'CampaignSnapshotPublished',
+    );
+    expect(snapshot).toBeDefined();
+    if (snapshot && snapshot.type === 'CampaignSnapshotPublished') {
+      expect(snapshot.payload.state.campaignId).toBe(CAMPAIGN_ID);
+      expect(snapshot.payload.state.balance).toBe(1_250_000);
+      expect(snapshot.payload.state.day).toBe(7);
+    }
+  });
+});
+
+describe('parseCampaignIntent (zod boundary)', () => {
+  it('parses a well-formed SpendFunds intent', () => {
+    const intent = parseCampaignIntent({
+      kind: 'SpendFunds',
+      campaignId: CAMPAIGN_ID,
+      intentId: 'intent-1',
+      payload: { amount: 100_000, reason: 'Ammo restock' },
+    });
+    expect(intent).not.toBeNull();
+    expect(intent?.kind).toBe('SpendFunds');
+  });
+
+  it('parses every intent kind', () => {
+    const candidates: unknown[] = [
+      {
+        kind: 'HirePilot',
+        campaignId: CAMPAIGN_ID,
+        intentId: 'i',
+        payload: {
+          pilot: { pilotId: 'p', name: 'N' },
+          cost: 10,
+        },
+      },
+      {
+        kind: 'AcceptContract',
+        campaignId: CAMPAIGN_ID,
+        intentId: 'i',
+        payload: {
+          contract: {
+            contractId: 'c',
+            name: 'N',
+            employerFactionId: 'f',
+          },
+        },
+      },
+      {
+        kind: 'SpendFunds',
+        campaignId: CAMPAIGN_ID,
+        intentId: 'i',
+        payload: { amount: 1, reason: 'r' },
+      },
+      {
+        kind: 'AllocateSalvage',
+        campaignId: CAMPAIGN_ID,
+        intentId: 'i',
+        payload: { value: 1 },
+      },
+      {
+        kind: 'AdvanceDay',
+        campaignId: CAMPAIGN_ID,
+        intentId: 'i',
+        payload: {},
+      },
+    ];
+    for (const candidate of candidates) {
+      expect(parseCampaignIntent(candidate)).not.toBeNull();
+    }
+  });
+
+  it('rejects malformed intents', () => {
+    expect(parseCampaignIntent(null)).toBeNull();
+    expect(parseCampaignIntent({})).toBeNull();
+    expect(parseCampaignIntent({ kind: 'Unknown' })).toBeNull();
+    // Missing payload field.
+    expect(
+      parseCampaignIntent({
+        kind: 'SpendFunds',
+        campaignId: CAMPAIGN_ID,
+        intentId: 'i',
+        payload: { reason: 'no amount' },
+      }),
+    ).toBeNull();
+    // Negative spend amount.
+    expect(
+      parseCampaignIntent({
+        kind: 'SpendFunds',
+        campaignId: CAMPAIGN_ID,
+        intentId: 'i',
+        payload: { amount: -5, reason: 'r' },
+      }),
+    ).toBeNull();
+    // Empty campaign id.
+    expect(
+      parseCampaignIntent({
+        kind: 'AdvanceDay',
+        campaignId: '',
+        intentId: 'i',
+        payload: {},
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/types/campaign/campaignSyncSchemas.ts
+++ b/src/types/campaign/campaignSyncSchemas.ts
@@ -1,0 +1,131 @@
+/**
+ * Shared Campaign State — runtime intent validation (CO1).
+ *
+ * Zod schemas that reject a malformed `ICampaignIntent` at the
+ * server boundary BEFORE it reaches the `CampaignMatchHost` validation
+ * step. This is the campaign-tier analogue of the combat
+ * `IntentSchema` in `src/types/multiplayer/Protocol.ts` — the host
+ * trusts a parsed intent's shape and only re-checks it against
+ * authoritative state (balance, standing, salvage pool).
+ *
+ * @spec openspec/changes/add-shared-campaign-state/specs/coop-campaign-sync/spec.md
+ * @spec openspec/changes/add-shared-campaign-state/tasks.md (task 1.3)
+ */
+
+import { z } from 'zod';
+
+import type { ICampaignIntent } from './CampaignSync';
+
+// =============================================================================
+// Leaf schemas
+// =============================================================================
+
+const cbillSchema = z.number().finite();
+const nonNegativeCbillSchema = z.number().finite().nonnegative();
+
+const rosterUnitSchema = z.object({
+  unitId: z.string().min(1),
+  designation: z.string().min(1),
+  status: z.enum(['operational', 'damaged', 'destroyed']),
+});
+
+const rosterPilotSchema = z.object({
+  pilotId: z.string().min(1),
+  name: z.string().min(1),
+});
+
+const acceptedContractSchema = z.object({
+  contractId: z.string().min(1),
+  name: z.string().min(1),
+  employerFactionId: z.string().min(1),
+});
+
+// =============================================================================
+// Per-kind intent schemas
+// =============================================================================
+
+const hirePilotIntentSchema = z.object({
+  kind: z.literal('HirePilot'),
+  campaignId: z.string().min(1),
+  intentId: z.string().min(1),
+  payload: z.object({
+    pilot: rosterPilotSchema,
+    cost: nonNegativeCbillSchema,
+  }),
+});
+
+const acceptContractIntentSchema = z.object({
+  kind: z.literal('AcceptContract'),
+  campaignId: z.string().min(1),
+  intentId: z.string().min(1),
+  payload: z.object({
+    contract: acceptedContractSchema,
+  }),
+});
+
+const spendFundsIntentSchema = z.object({
+  kind: z.literal('SpendFunds'),
+  campaignId: z.string().min(1),
+  intentId: z.string().min(1),
+  payload: z.object({
+    amount: z.number().finite().positive(),
+    reason: z.string().min(1),
+  }),
+});
+
+const allocateSalvageIntentSchema = z.object({
+  kind: z.literal('AllocateSalvage'),
+  campaignId: z.string().min(1),
+  intentId: z.string().min(1),
+  payload: z.object({
+    value: nonNegativeCbillSchema,
+    recoveredUnit: rosterUnitSchema.optional(),
+  }),
+});
+
+const advanceDayIntentSchema = z.object({
+  kind: z.literal('AdvanceDay'),
+  campaignId: z.string().min(1),
+  intentId: z.string().min(1),
+  payload: z.object({
+    days: z.number().int().positive().optional(),
+  }),
+});
+
+/**
+ * The discriminated-union schema for any `ICampaignIntent`. A
+ * `parse` failure means the intent is structurally malformed and the
+ * host rejects it with `reason: 'malformed-intent'` without ever
+ * touching authoritative state.
+ */
+export const CampaignIntentSchema = z.discriminatedUnion('kind', [
+  hirePilotIntentSchema,
+  acceptContractIntentSchema,
+  spendFundsIntentSchema,
+  allocateSalvageIntentSchema,
+  advanceDayIntentSchema,
+]);
+
+// =============================================================================
+// Boundary helper
+// =============================================================================
+
+/**
+ * Parse an untrusted candidate into a typed `ICampaignIntent`, or
+ * `null` when it is malformed. The `CampaignMatchHost` calls this as
+ * its malformed-check step (design D4 step 2) — a `null` result is a
+ * `reason: 'malformed-intent'` rejection; a non-null result is a
+ * structurally valid intent the host then validates against state.
+ *
+ * The `cbillSchema` export is unused outside this module but kept so a
+ * future event-payload validator can share the same C-bill leaf.
+ */
+export function parseCampaignIntent(
+  candidate: unknown,
+): ICampaignIntent | null {
+  const result = CampaignIntentSchema.safeParse(candidate);
+  return result.success ? (result.data as ICampaignIntent) : null;
+}
+
+// Re-exported so a future campaign-event validator can reuse the leaf.
+export { cbillSchema };


### PR DESCRIPTION
Implements the OpenSpec change `add-shared-campaign-state` (Wave 5 CO1).

## What

Extends the server-authoritative `intent → validate → commit → broadcast` loop (the `ServerMatchHost` combat pattern) to campaign state. Per design D1/D7 campaign state is a transactional ledger and uses the server-authoritative event-broadcast loop — NOT the Yjs `useSyncedVaultStore` CRDT.

- **Campaign event types** (`src/types/campaign/CampaignSync.ts`) — `ICampaignEvent` discriminated union over 7 event types, `ICampaignIntent` union over 5 intent kinds, `CampaignIntentResult`, and `ICampaignAuthoritativeState` ledger projection.
- **zod intent validation** (`campaignSyncSchemas.ts`) — `CampaignIntentSchema` rejects malformed intents at the boundary.
- **Campaign event log** (`src/lib/campaign/sync/`) — `ICampaignEventStore` + `InMemoryCampaignEventStore` + `CampaignEventLog`: ordered, gap-free, transactional append; `replayCampaignEvents` reconstructs state from the log.
- **`CampaignMatchHost`** — the single writer: closed/malformed/validate/commit/broadcast loop; balance, faction-standing, and salvage-pool checks against authoritative state.
- **`campaignMirrorStore`** — guest read-only mirror advanced solely by `applyCampaignEvent`; `assertCampaignMirrorWritable` hard guard modeled on `mirrorSession`.
- **`CampaignSyncSession`** — room-code open, guest join (snapshot + log), tail/large-gap resync, host-disconnect pause.
- **Yjs vault boundary** documented in `p2p/types.ts` + `useSyncedVaultStore.ts`; `SyncableItemType` stays `unit | pilot | force`.

## Verification

- `npx tsc --noEmit` — zero errors
- `npx oxlint` — 0 warnings / 0 errors on changed files
- `npx jest` — 65 new tests pass; 409 p2p+multiplayer tests pass, no regressions
- `npx openspec validate add-shared-campaign-state --strict` — valid
- `oxfmt --check` — clean

All 30 tasks in `tasks.md` complete. The OpenSpec change is NOT archived (per instructions).

## CO2 dependency note

CO2 (co-op campaign play) builds on the `CampaignMatchHost` / campaign-intent API surface — see the PR thread / final report for the full surface.