### PR TITLE
fix(e2e): align compendium unit-browser locators with current UI [PT-006]

### DIFF
--- a/e2e/compendium.spec.ts
+++ b/e2e/compendium.spec.ts
@@ -164,9 +164,13 @@ test.describe('Unit Browser @compendium', () => {
     // Click filter button
     await unitBrowser.openFilters();
 
-    // Filter panel should be visible with filter selects
-    await expect(page.getByLabel(/filter by unit type/i)).toBeVisible();
+    // Filter panel should be visible with the selects exposed by
+    // `UnitsFilters.tsx` (tech base / weight class / rules level). PT-006:
+    // there is no "filter by unit type" dropdown in the current UI — the
+    // assertion that used to look for one was checking a UI that never
+    // shipped. Swap to the actual filters that exist.
     await expect(page.getByLabel(/filter by tech base/i)).toBeVisible();
+    await expect(page.getByLabel(/filter by weight class/i)).toBeVisible();
   });
 
   test('view mode toggle works', async ({ page }) => {

--- a/e2e/pages/compendium.page.ts
+++ b/e2e/pages/compendium.page.ts
@@ -153,14 +153,22 @@ export class UnitBrowserPage extends BasePage {
     // Header elements
     this.title = page.getByTestId('unit-browser-title');
     this.subtitle = page.getByTestId('unit-browser-subtitle');
-    this.searchInput = page.getByPlaceholder(/search units/i);
+    // Actual UI placeholder reads "Search chassis, model, or variant..." —
+    // the old `/search units/i` regex didn't match. PT-006.
+    this.searchInput = page.getByPlaceholder(/search chassis/i);
     this.filterButton = page.getByRole('button', { name: /filters/i });
     this.viewModeToggle = page.getByTestId('view-mode-toggle');
 
-    // Filter panel
+    // Filter panel — `UnitsFilters.tsx` currently exposes tech base, weight
+    // class, and rules level dropdowns. There is no "filter by unit type"
+    // dropdown in the units page UI (units are filtered by tech base /
+    // weight class / rules level only). `unitTypeFilter` is kept here to
+    // preserve the page-object API for downstream tests but is aliased to
+    // the tech-base filter — a future UI-feature change could surface a
+    // proper unit-type selector and this alias would be replaced. PT-006.
     this.filterPanel = page.getByTestId('unit-browser-filter-panel');
-    this.unitTypeFilter = page.getByLabel(/filter by unit type/i);
     this.techBaseFilter = page.getByLabel(/filter by tech base/i);
+    this.unitTypeFilter = this.techBaseFilter;
     this.rulesLevelFilter = page.getByLabel(/filter by rules level/i);
     this.weightClassFilter = page.getByLabel(/filter by weight class/i);
     this.clearFiltersButton = page.getByRole('button', { name: /clear all/i });
@@ -243,10 +251,13 @@ export class UnitBrowserPage extends BasePage {
   }
 
   async getSubtitleText(): Promise<string> {
-    // The subtitle shows the unit count
+    // Subtitle reads "Browse {N} canonical units from all eras" — match the
+    // distinctive "canonical units" phrase rather than requiring the text to
+    // end with "units" (the trailing "from all eras" used to break this
+    // locator). PT-006.
     const subtitleElement = this.page
       .locator('p')
-      .filter({ hasText: /units?$/i })
+      .filter({ hasText: /canonical units/i })
       .first();
     return (await subtitleElement.textContent()) || '';
   }


### PR DESCRIPTION
**Playtest phase**: Phase 0 fix wave · resolves PT-006 from [#625](https://github.com/SwiggitySwerve/MekStation/pull/625).

## Stale locators (3 in the page object + 1 in the spec)

| Locator | Before | After | Why |
|---|---|---|---|
| `searchInput` | `getByPlaceholder(/search units/i)` | `/search chassis/i` | Actual placeholder is "Search chassis, model, or variant..." ([UnitsFilters.tsx:51](src/components/compendium/units/UnitsFilters.tsx:51)) |
| `unitTypeFilter` | `getByLabel(/filter by unit type/i)` | aliased to `techBaseFilter` | The units page has no unit-type select — only tech-base / weight-class / rules-level. Alias preserves page-object API. |
| `getSubtitleText()` | `/units?$/i` (anchored end-of-string) | `/canonical units/i` | Subtitle reads "Browse {N} canonical units from all eras" — ends with "eras" not "units". |
| spec line 168 | asserts `/filter by unit type/i` is visible | asserts `/filter by weight class/i` | Same root cause as #2 — assert against a filter that actually renders. |

## Verification

`npx playwright test --project=chromium e2e/compendium.spec.ts` → **32/32 pass** (up from 28/32). No regression on the 28 that were already passing.