### PR TITLE
fix(e2e): scope replay timeline category-filter locators to avoid strict-mode collision [PT-007]

### DIFF
--- a/e2e/replay-player.spec.ts
+++ b/e2e/replay-player.spec.ts
@@ -61,8 +61,12 @@ test.describe('Audit Timeline Page', () => {
     // Check filter controls exist
     await expect(page.getByPlaceholder('Search events...')).toBeVisible();
 
-    // Check category filter buttons exist (at least the "All" option)
-    await expect(page.getByRole('button', { name: /All/i })).toBeVisible();
+    // Check category filter buttons exist (at least the "All" option). Scope
+    // to the timeline-filters container — `/All/i` matches several buttons
+    // elsewhere on the page (top-bar dropdowns, etc.) and would trip strict
+    // mode. PT-007.
+    const filters = page.getByTestId('timeline-filters');
+    await expect(filters.getByRole('button', { name: /All/i })).toBeVisible();
   });
 
   test('can toggle advanced query builder', async ({ page }) => {
@@ -78,8 +82,11 @@ test.describe('Audit Timeline Page', () => {
   });
 
   test('category filters are clickable', async ({ page }) => {
-    // Click a category filter
-    const gameFilter = page.getByRole('button', { name: /Game/i });
+    // Click a category filter — scope to the timeline-filters container so
+    // `/Game/i` doesn't strict-mode-collide with top-bar buttons that share
+    // the substring (e.g. an `aria-haspopup="menu"` Games dropdown). PT-007.
+    const filters = page.getByTestId('timeline-filters');
+    const gameFilter = filters.getByRole('button', { name: /Game/i });
     if (await gameFilter.isVisible()) {
       await gameFilter.click();
       // Should be active


### PR DESCRIPTION
**Playtest phase**: Phase 0 fix wave · resolves PT-007 from [#625](https://github.com/SwiggitySwerve/MekStation/pull/625).

## What this fixes

Two assertions in `replay-player.spec.ts` used unscoped `getByRole('button', { name: /…/i })` regexes against the timeline-filters category group:

- **line 65** — `/All/i` resolved to multiple buttons on the page (top-bar menus etc.)
- **line 82** — `/Game/i` resolved to 2 elements including an `aria-haspopup='menu'` dropdown

Both tripped Playwright's strict-mode and failed the assertion.

## Fix

Scope the locator to `getByTestId('timeline-filters')` so the regex only sees the actual filter button group (rendered by [TimelineFilters.tsx](src/components/audit/timeline/TimelineFilters.tsx)). The container already exposes that testid in the source.

## Verification

`npx playwright test --project=chromium e2e/replay-player.spec.ts -g 'timeline page loads with filters|category filters are clickable'` — both targeted specs now pass strict-mode (the click→data-active toggle in the second test is a separate concern; see below).

## Out of scope (filed under PT-009 batch)

The other 2 baseline replay-player failures are different concerns:
- **`can toggle advanced query builder` (line 72)** — assertion expects "Save Query" text after clicking Advanced, but "Save Query" lives in a hidden modal that opens on a separate Save click. **Stale assertion.**
- **`games page shows replay button for completed games` (line 215)** — locator finds a hidden replay-library link in a dropdown menu; the test expects a visible replay action on a game row. Either no completed games in seed data or selector needs to be more specific.