### PR TITLE
fix(e2e): align mobile-navigation locators with current TopBar UI [PT-008]

### DIFF
--- a/e2e/mobile-navigation.spec.ts
+++ b/e2e/mobile-navigation.spec.ts
@@ -16,7 +16,7 @@ test.describe('Mobile Navigation Header', () => {
 
     // Should have hamburger menu button on the right
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     await expect(menuButton).toBeVisible();
   });
@@ -26,7 +26,7 @@ test.describe('Mobile Navigation Header', () => {
 
     // Should have hamburger menu button
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     await expect(menuButton).toBeVisible();
   });
@@ -36,7 +36,7 @@ test.describe('Mobile Navigation Header', () => {
 
     // Should have hamburger menu button
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     await expect(menuButton).toBeVisible();
   });
@@ -51,7 +51,7 @@ test.describe('Mobile Navigation Header', () => {
 
     // Mobile header is now shown on ALL pages for consistent UX
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     await expect(menuButton).toBeVisible();
   });
@@ -81,12 +81,12 @@ test.describe('Mobile Sidebar', () => {
 
     // Click hamburger menu
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     await menuButton.click();
 
     // Sidebar (aside element) should be visible with navigation items
-    const sidebar = page.locator('aside');
+    const sidebar = page.getByTestId('mobile-menu');
     await expect(sidebar).toBeVisible();
 
     // Check for nav links inside sidebar
@@ -103,12 +103,12 @@ test.describe('Mobile Sidebar', () => {
 
     // Open sidebar
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     await menuButton.click();
 
     // Sidebar should be visible
-    const sidebar = page.locator('aside');
+    const sidebar = page.getByTestId('mobile-menu');
     await expect(sidebar).toBeVisible();
 
     // Should show full labels, not just icons (brand and subtitle in sidebar)
@@ -123,13 +123,13 @@ test.describe('Mobile Sidebar', () => {
 
     // Open sidebar
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     await menuButton.click();
 
     // Verify sidebar is open (wait for animation)
     await page.waitForTimeout(350);
-    const sidebar = page.locator('aside');
+    const sidebar = page.getByTestId('mobile-menu');
     await expect(sidebar).toBeVisible();
 
     // Find Units link (not Dashboard since we're testing navigation TO a different page)
@@ -154,12 +154,12 @@ test.describe('Mobile Sidebar', () => {
 
     // Open sidebar
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     await menuButton.click();
 
     // Verify sidebar is open
-    const sidebar = page.locator('aside');
+    const sidebar = page.getByTestId('mobile-menu');
     await expect(sidebar).toBeVisible();
     await expect(sidebar.getByText('Dashboard')).toBeVisible();
 
@@ -176,7 +176,7 @@ test.describe('Mobile Sidebar', () => {
 
     // Open sidebar
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     await menuButton.click();
 
@@ -201,7 +201,7 @@ test.describe('Hamburger Menu Button Position (Right-Hand Ergonomics)', () => {
     await page.goto('/settings');
 
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     const buttonBox = await menuButton.boundingBox();
 
@@ -218,7 +218,7 @@ test.describe('Hamburger Menu Button Position (Right-Hand Ergonomics)', () => {
     await page.goto('/settings');
 
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     const buttonBox = await menuButton.boundingBox();
 
@@ -256,7 +256,7 @@ test.describe('Customizer Page', () => {
 
     // Menu button should be in the mobile header (top), not in bottom tray
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     await expect(menuButton).toBeVisible();
 
@@ -279,13 +279,13 @@ test.describe('Customizer Page', () => {
 
     // Click the menu button in the mobile header
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     await menuButton.click();
 
     // Sidebar should open
     await page.waitForTimeout(350);
-    const sidebar = page.locator('aside');
+    const sidebar = page.getByTestId('mobile-menu');
     await expect(sidebar).toBeVisible();
     await expect(sidebar.getByText('Dashboard')).toBeVisible();
   });
@@ -304,7 +304,7 @@ test.describe('Desktop Sidebar', () => {
     await page.goto('/settings');
 
     // Sidebar (aside) should be visible with nav items
-    const sidebar = page.locator('aside');
+    const sidebar = page.getByTestId('mobile-menu');
     await expect(sidebar).toBeVisible();
     await expect(sidebar.getByText('Dashboard')).toBeVisible();
 
@@ -319,7 +319,7 @@ test.describe('Desktop Sidebar', () => {
     await page.goto('/settings');
 
     // Sidebar should be visible
-    const sidebar = page.locator('aside');
+    const sidebar = page.getByTestId('mobile-menu');
     await expect(sidebar).toBeVisible();
 
     // Brand subtitle should be visible when expanded
@@ -356,11 +356,11 @@ test.describe('Navigation Flows', () => {
   }) => {
     // Start on settings
     await page.goto('/settings');
-    const sidebar = page.locator('aside');
+    const sidebar = page.getByTestId('mobile-menu');
 
     // Helper function to open sidebar and navigate
     async function navigateVia(href: string) {
-      await page.getByRole('button', { name: /open navigation menu/i }).click();
+      await page.getByRole('button', { name: /open menu/i }).click();
       await page.waitForTimeout(350); // Wait for animation
       await expect(sidebar).toBeVisible();
       const link = sidebar.locator(`a[href="${href}"]`);
@@ -385,10 +385,10 @@ test.describe('Navigation Flows', () => {
     page,
   }) => {
     await page.goto('/settings');
-    const sidebar = page.locator('aside');
+    const sidebar = page.getByTestId('mobile-menu');
 
     // Open sidebar
-    await page.getByRole('button', { name: /open navigation menu/i }).click();
+    await page.getByRole('button', { name: /open menu/i }).click();
     await page.waitForTimeout(350); // Wait for animation
     await expect(sidebar.getByText('BattleTech Lab')).toBeVisible();
 
@@ -423,12 +423,12 @@ test.describe('Touch Interactions', () => {
 
     // Tap the hamburger menu
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     await menuButton.tap();
 
     // Sidebar should open
-    const sidebar = page.locator('aside');
+    const sidebar = page.getByTestId('mobile-menu');
     await expect(sidebar).toBeVisible();
     await expect(sidebar.getByText('Dashboard')).toBeVisible();
   });
@@ -438,13 +438,13 @@ test.describe('Touch Interactions', () => {
 
     // Open sidebar via tap
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     await menuButton.tap();
 
     // Wait for animation and verify sidebar is visible
     await page.waitForTimeout(350);
-    const sidebar = page.locator('aside');
+    const sidebar = page.getByTestId('mobile-menu');
     await expect(sidebar).toBeVisible();
 
     // Find Dashboard link and click via JS (tap can have issues with translated elements)
@@ -470,10 +470,10 @@ test.describe('Gameplay Navigation', () => {
     await page.goto('/');
 
     // Open sidebar
-    await page.getByRole('button', { name: /open navigation menu/i }).click();
+    await page.getByRole('button', { name: /open menu/i }).click();
     await page.waitForTimeout(350);
 
-    const sidebar = page.locator('aside');
+    const sidebar = page.getByTestId('mobile-menu');
     await expect(sidebar).toBeVisible();
 
     // Look for Gameplay section - expandable button
@@ -537,10 +537,10 @@ test.describe('History Navigation', () => {
     await page.goto('/');
 
     // Open sidebar
-    await page.getByRole('button', { name: /open navigation menu/i }).click();
+    await page.getByRole('button', { name: /open menu/i }).click();
     await page.waitForTimeout(350);
 
-    const sidebar = page.locator('aside');
+    const sidebar = page.getByTestId('mobile-menu');
     await expect(sidebar).toBeVisible();
 
     // Find Timeline link within sidebar navigation
@@ -565,10 +565,10 @@ test.describe('History Navigation', () => {
     await page.goto('/');
 
     // Open sidebar
-    await page.getByRole('button', { name: /open navigation menu/i }).click();
+    await page.getByRole('button', { name: /open menu/i }).click();
     await page.waitForTimeout(350);
 
-    const sidebar = page.locator('aside');
+    const sidebar = page.getByTestId('mobile-menu');
     await expect(sidebar).toBeVisible();
 
     // Should show History section (may be title or just Timeline item)
@@ -588,7 +588,7 @@ test.describe('Responsive Layout', () => {
 
     // Mobile header should be visible
     const menuButton = page.getByRole('button', {
-      name: /open navigation menu/i,
+      name: /open menu/i,
     });
     await expect(menuButton).toBeVisible();
 
@@ -599,7 +599,7 @@ test.describe('Responsive Layout', () => {
     await expect(menuButton).not.toBeVisible();
 
     // Desktop sidebar should be visible
-    const sidebar = page.locator('aside');
+    const sidebar = page.getByTestId('mobile-menu');
     await expect(sidebar).toBeVisible();
   });
 

--- a/src/components/common/TopBarMobileMenu.tsx
+++ b/src/components/common/TopBarMobileMenu.tsx
@@ -81,7 +81,13 @@ export function MobileMenu({
         aria-hidden="true"
       />
 
-      <div className="bg-surface-deep fixed inset-0 z-50 flex flex-col md:hidden">
+      <div
+        // PT-008: stable selector for the mobile-navigation Playwright suite.
+        // The old `locator('aside')` selector matched the now-removed desktop
+        // secondary-sidebar element; this menu is a `<div><nav>` overlay.
+        data-testid="mobile-menu"
+        className="bg-surface-deep fixed inset-0 z-50 flex flex-col md:hidden"
+      >
         <div className="border-border-theme-subtle bg-surface-base flex h-14 items-center justify-between border-b px-4">
           <div className="flex items-center gap-3">
             <div className="flex h-8 w-8 items-center justify-center rounded-lg border-b-2 border-cyan-400/60 bg-[#3a3a3c] shadow-lg shadow-cyan-900/30">


### PR DESCRIPTION
**Playtest phase**: Phase 0 fix wave · partial resolution of PT-008 from [#625](https://github.com/SwiggitySwerve/MekStation/pull/625).

## Stale references made every mobile-navigation spec fail

| What broke | Where | Fix |
|---|---|---|
| `/open navigation menu/i` regex | aria-label is "Open menu" ([TopBar.tsx:252](src/components/common/TopBar.tsx:252)) | 21 swaps to `/open menu/i` |
| `locator('aside')` | mobile menu is a `<div><nav>` overlay ([TopBarMobileMenu.tsx:84](src/components/common/TopBarMobileMenu.tsx:84)). The Layout's `<aside>` only renders when `secondarySidebar` is supplied, which most pages don't. | 15 swaps to `getByTestId('mobile-menu')`; matching `data-testid` added to the overlay container in the source |

## Net

`npx playwright test --project=chromium e2e/mobile-navigation.spec.ts` — **23 failed → 12 failed; 4 passed → 15 passed**.

## Out of scope (filed under PT-009 batch)

The remaining 12 failures are deeper spec-content assertions (Dashboard / Compendium / specific link-position checks) that don't match the current menu structure. They belong with the broader test-staleness sweep rather than this surgical locator fix.