### PR TITLE
docs(openspec): Wave 6.1 — co-op route + command center + subsystem validation specs

### DIFF
--- a/openspec/changes/add-campaign-command-center/proposal.md
+++ b/openspec/changes/add-campaign-command-center/proposal.md
@@ -1,0 +1,62 @@
+# Change: Add Campaign Command Center Dashboard
+
+## Why
+
+`/gameplay/campaigns/[id]/index.tsx` today is a routing index — a list of tiles that link to the 11 sub-route surfaces (`personnel`, `mech-bay`, `medical-bay`, `salvage`, `hiring`, `finances`, `contract-market`, `repair-bay`, `prestige-morale`, `missions`, `forces`). It surfaces no campaign state on its own. To see whether you can afford to advance a day, you click into Finances; to see active mission objectives, you click into Missions; to see who is injured, you click into Medical Bay; to see the pending day-cost projection, you click Finances again.
+
+MekHQ's `CommandCenterTab.java` (the reference implementation this whole campaign surface is modeled on) is the OPPOSITE shape: it's a single dashboard tab that **collates** the campaign's current state — rating, force composition, HR capacity, repair status, cargo summary, active mission objectives, last 9 daily log categories, pending procurement, and quick-launch buttons to the detail reports. The detail reports are reached *from* the command center, not in place of it.
+
+We have all the underlying data in the campaign store (`useCampaignStore`, `usePilotStore`, `useForceStore`), the day-report system (`dayAdvancement.ts` + `dayReportTypes.ts`), and the existing command panels (`FinancesPanel`, `HiringPanel`, `ContractMarketPanel`, `PrestigeMoralePanel`, `DayReportPanel`). The aggregation layer that turns those into a single at-a-glance command-center view does not exist.
+
+A GM running a tabletop-style campaign session — or a solo player tracking 12 mechs, 18 pilots, 3 active contracts, and a 4-month cash burn — needs the dashboard. Without it every session begins with 5 clicks through sub-routes just to know where the campaign stands.
+
+This change adds the dashboard *between* the routing index and the existing sub-routes, without removing any current surface. The 11 sub-routes still work; they just become drill-downs from the dashboard instead of the only way to see anything.
+
+## What Changes
+
+- ADDED a `<CampaignDashboard>` component mounted at `/gameplay/campaigns/[id]` (replacing the current bare tile-grid index), composed of 6 dashboard cards:
+  1. **Force snapshot** — total mechs / pilots / dropship capacity / repair queue depth / injured pilot count (links to `forces`, `mech-bay`, `personnel`, `medical-bay`, `repair-bay`)
+  2. **Active contract** — current contract name, employer, deadline, completion-bar, primary objective list, days remaining (links to `contract-market`, `missions`)
+  3. **Finances** — cash balance, daily-cost projection (salaries + maintenance + loan repayment), runway in days at current burn, last 5 ledger entries (links to `finances`)
+  4. **Day advance** — current campaign date, "Advance one day" button, "Advance to next event" button, pending-event preview (uses existing `dayAdvancement` pipeline; renders `<DayReportPanel>` modal on resolve)
+  5. **Recent activity log** — last 10 events bucketed by category (Battle / Personnel / Medical / Finances / Acquisitions / Technical), category tabs, link-out to the full per-category log
+  6. **Quick actions** — "Hire a pilot" / "Browse contracts" / "Refit a mech" / "Open salvage" buttons that deep-link to the relevant sub-route's primary action
+- ADDED a `useCampaignDashboardSummary(campaignId)` selector hook that derives the dashboard payload from the 3 existing stores (no new state)
+- ADDED a `campaign-activity-log` slice on `useCampaignStore` that retains the last 200 day-report event entries categorized for the dashboard's "Recent activity" card. Day-advance writes append; nothing in the existing dayAdvancement pipeline changes
+- KEPT the existing sub-routes (`personnel.tsx` through `forces.tsx`) unchanged — they remain reachable directly via URL and via the new dashboard's links
+- ADDED a "Back to dashboard" breadcrumb on each sub-route header (using existing `<CampaignNavigation>`)
+- KEPT the campaign tile-grid alive at `/gameplay/campaigns/[id]/overview` for users who prefer the routing index (optional — kept as escape hatch behind a settings toggle, default off)
+
+## Dependencies
+
+- **Requires (already shipped)**: `add-campaign-system` (Wave 4) — all 11 sub-routes and the campaign store
+- **Requires (already shipped)**: day-advancement pipeline (`dayAdvancement.ts`, `dayReportTypes.ts`) — the 7-phase advance + day-report shape this dashboard surfaces
+- **Requires (already shipped)**: `useCampaignStore`, `usePilotStore`, `useForceStore` — all selectors composed by the new hook already exist
+- **No new transport, no new types, no schema migrations**
+
+## Impact
+
+- Affected specs: `campaign-system` — ADD a "Campaign Command Center Dashboard" requirement formalizing the 6 dashboard cards, the activity-log retention rule, and that the dashboard is the default landing surface for a campaign detail route
+- Affected code:
+  - `src/pages/gameplay/campaigns/[id]/index.tsx` — render `<CampaignDashboard>` instead of the current tile-grid
+  - `src/pages/gameplay/campaigns/[id]/overview.tsx` — new (the moved tile-grid, behind settings toggle)
+  - `src/components/campaign/dashboard/CampaignDashboard.tsx` — new component (composes 6 cards)
+  - `src/components/campaign/dashboard/cards/{ForceSnapshotCard,ActiveContractCard,FinancesCard,DayAdvanceCard,ActivityLogCard,QuickActionsCard}.tsx` — 6 new card components
+  - `src/components/campaign/dashboard/__tests__/` — new test suite per card + integration
+  - `src/components/campaign/dashboard/*.stories.tsx` — Storybook stories for each card
+  - `src/lib/campaign/hooks/useCampaignDashboardSummary.ts` — new selector hook
+  - `src/stores/useCampaignStore.ts` — new `activityLog: IActivityLogEntry[]` slice + `appendActivityLogEntry(entry)` action + `IActivityLogEntry` type (200-entry retention)
+  - `src/lib/campaign/dayAdvancement.ts` — `runDayAdvancement` calls `appendActivityLogEntry` for each emitted event (no behavior change, just an extra side-effect)
+  - `src/components/campaign/CampaignNavigation.tsx` — "Back to dashboard" link on sub-route headers
+- No database migrations (activity log is in-memory + zustand-persist; capped retention prevents bloat)
+- Storybook bundle grows by ~6 stories (within current budget)
+
+## Non-Goals
+
+- A full MekHQ-style 9-category log split (Politics, Skill, Diplomacy specifically). The "Recent activity" card bucketed by 6 categories (Battle, Personnel, Medical, Finances, Acquisitions, Technical) covers the events the day-advance pipeline emits today; the other 3 categories don't have events emitted yet and would be empty surface area
+- Unit rating / reputation system (MekHQ has `lblRatingHead`, `lblRating` — MekStation has no equivalent rating yet; that's a separate change candidate)
+- Procurement table (MekHQ's command center includes a pending-acquisitions table — MekStation doesn't have a long-running procurement system; would be a Wave 7 candidate)
+- Cargo / transport capacity surfaces (no cargo system in MekStation yet)
+- Faction Standing report / Diplomacy report — these depend on a politics system that doesn't exist
+- Editing or composing day-advance behavior — this change READS from `dayAdvancement.ts` and writes its emitted events to the log slice, but does not change advance rules
+- A configurable dashboard layout (drag-to-rearrange cards) — fixed grid in v1; configurable in a later polish change

--- a/openspec/changes/add-campaign-command-center/specs/campaign-system/spec.md
+++ b/openspec/changes/add-campaign-command-center/specs/campaign-system/spec.md
@@ -1,0 +1,81 @@
+# Spec Delta: Campaign System
+
+## ADDED Requirements
+
+### Requirement: Campaign Command Center Dashboard
+
+The system SHALL surface a single dashboard at `/gameplay/campaigns/[id]` that collates the campaign's current state — force snapshot, active contract, finances, day advance, recent activity, and quick actions — so the operator can assess the campaign and act on it without first drilling into a sub-route.
+
+**Priority**: High
+
+#### Scenario: Dashboard is the default landing surface
+
+**GIVEN** a campaign in any state (just created, mid-contract, contract completed)
+**WHEN** the user navigates to `/gameplay/campaigns/[id]`
+**THEN** the system SHALL render `<CampaignDashboard>` with 6 cards: force snapshot, active contract, finances, day advance, activity log, and quick actions
+**AND** the dashboard SHALL NOT require any sub-route navigation to display its summary
+**AND** the existing 11 campaign sub-routes (`personnel`, `mech-bay`, `medical-bay`, `salvage`, `hiring`, `finances`, `contract-market`, `repair-bay`, `prestige-morale`, `missions`, `forces`) SHALL remain reachable via direct URL and via dashboard card links
+
+#### Scenario: Force snapshot reflects current store state
+
+**GIVEN** a campaign with 4 active mechs, 6 pilots (1 injured), 3 mechs in the repair queue
+**WHEN** the dashboard renders
+**THEN** the force snapshot card SHALL show "4 mechs", "6 pilots (1 injured)", "3 in repair"
+**AND** clicking "4 mechs" SHALL navigate to `/gameplay/campaigns/[id]/forces`
+**AND** clicking "1 injured" SHALL navigate to `/gameplay/campaigns/[id]/medical-bay`
+**AND** clicking "3 in repair" SHALL navigate to `/gameplay/campaigns/[id]/repair-bay`
+
+#### Scenario: Active contract card shows progress and deadline
+
+**GIVEN** a campaign with an active contract "Defend Carlisle" with 2 of 3 primary objectives completed, deadline in 8 days
+**WHEN** the dashboard renders
+**THEN** the active contract card SHALL display the contract name, the employer, "8 days remaining", a completion bar reading "2 / 3 objectives", and the list of incomplete objectives
+**AND** if no contract is active, the card SHALL show an empty state with a "Browse contracts" CTA that links to `/gameplay/campaigns/[id]/contract-market`
+
+#### Scenario: Finances card surfaces balance, burn, and runway
+
+**GIVEN** a campaign with balance 850,000 C-bills, daily salaries 12,000, daily maintenance 8,500, daily loan repayment 5,000
+**WHEN** the dashboard renders
+**THEN** the finances card SHALL show "850,000 C-bills" balance, the 3-line daily-cost breakdown summing to 25,500/day, and a runway of "33 days" (`floor(850000 / 25500)`)
+**AND** the card SHALL show the last 5 ledger entries (most recent first)
+**AND** the card SHALL link to `/gameplay/campaigns/[id]/finances` for the full ledger
+
+#### Scenario: Day-advance from dashboard
+
+**GIVEN** any campaign state
+**WHEN** the user clicks "Advance one day" on the day-advance card
+**THEN** the system SHALL invoke the existing `runDayAdvancement` pipeline once
+**AND** any events the pipeline emits (cost deductions, healing, expired contracts, turnover) SHALL be appended to the campaign activity log
+**AND** the resulting `DayReport` SHALL be displayed via `<DayReportPanel>` modal
+**AND** dismissing the modal SHALL return the user to the updated dashboard reflecting the advanced state
+
+#### Scenario: Activity log card retains last 200 entries categorized into 6 buckets
+
+**GIVEN** a campaign with 250 historical day-advance events
+**WHEN** the dashboard renders
+**THEN** the activity log card SHALL show the last 10 entries per category across 6 categories: `battle`, `personnel`, `medical`, `finances`, `acquisitions`, `technical`
+**AND** the underlying activity log slice SHALL retain at most 200 total entries (FIFO drop-oldest on overflow)
+**AND** the activity log SHALL persist across page reloads via the existing zustand-persist boundary
+**AND** clicking "View full log" SHALL navigate to `/gameplay/campaigns/[id]/log`
+
+#### Scenario: Quick actions deep-link to primary sub-route action
+
+**GIVEN** the dashboard is mounted
+**WHEN** the user clicks "Hire a pilot"
+**THEN** the system SHALL navigate to `/gameplay/campaigns/[id]/hiring` with the hire-flow primary CTA in focus
+**AND** the same pattern SHALL apply to "Browse contracts" → `contract-market`, "Refit a mech" → `mech-bay?tab=refit`, "Open salvage" → `salvage`
+
+#### Scenario: Operator can opt back to the tile-grid index
+
+**GIVEN** a user who prefers the original tile-grid index over the dashboard
+**WHEN** they set `preferences.campaignLandingSurface = 'overview'` in settings
+**THEN** `/gameplay/campaigns/[id]` SHALL render the moved tile-grid (now at `/overview.tsx`) instead of the dashboard
+**AND** the default value SHALL be `'dashboard'`
+**AND** changing the preference SHALL not require a page reload to take effect
+
+#### Scenario: Back-to-dashboard link is present on every sub-route
+
+**GIVEN** the user is on any of the 11 campaign sub-routes
+**WHEN** the page renders
+**THEN** `<CampaignNavigation>` SHALL include a "Back to dashboard" link routing to `/gameplay/campaigns/[id]`
+**AND** the link SHALL be present on `personnel`, `mech-bay`, `medical-bay`, `salvage`, `hiring`, `finances`, `contract-market`, `repair-bay`, `prestige-morale`, `missions`, `forces`, and the new `log` and `overview` routes

--- a/openspec/changes/add-campaign-command-center/tasks.md
+++ b/openspec/changes/add-campaign-command-center/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Add Campaign Command Center Dashboard
+
+## 1. Activity log store slice
+
+- [ ] 1.1 Add `IActivityLogEntry` type to `src/types/campaign/ActivityLog.ts` with discriminated union over 6 categories (`battle | personnel | medical | finances | acquisitions | technical`), `timestamp: ISO8601`, `campaignDay: number`, `message: string`, and a category-specific `payload`
+- [ ] 1.2 Add `activityLog: IActivityLogEntry[]` slice on `useCampaignStore` with `appendActivityLogEntry(entry)` action; cap retention at 200 entries (FIFO, drop-oldest)
+- [ ] 1.3 Persist the activity log via existing zustand-persist + clientSafeStorage; the 200-cap prevents persistence bloat
+- [ ] 1.4 Wire `runDayAdvancement` in `src/lib/campaign/dayAdvancement.ts` to emit one `appendActivityLogEntry` call per categorizable event the pipeline produces (costs → finances, healing → medical, turnover → personnel, contract expiry → finances, etc.); zero behavior change to the pipeline itself
+- [ ] 1.5 Tests: append + cap + categorization invariants; day-advance integration test confirms log entries arrive after a 1-day advance
+
+## 2. Dashboard summary selector
+
+- [ ] 2.1 Add `useCampaignDashboardSummary(campaignId)` hook in `src/lib/campaign/hooks/useCampaignDashboardSummary.ts` that composes 3 stores into a single derived `IDashboardSummary` shape with: `forceSnapshot`, `activeContract`, `finances`, `currentDay`, `pendingEvents`, `activityLog`, `quickActions`
+- [ ] 2.2 The hook MUST memoize per-campaignId via `useMemo` to avoid recompute on every render
+- [ ] 2.3 Tests: snapshot tests against fixture campaigns (no active contract / mid-contract / contract-completed); selector returns stable references across unrelated store updates
+
+## 3. Dashboard card components
+
+- [ ] 3.1 `<ForceSnapshotCard>` — total mechs, total pilots, dropship capacity (placeholder if no dropship), repair queue depth, injured pilot count; each value links to the relevant sub-route
+- [ ] 3.2 `<ActiveContractCard>` — contract name, employer, deadline (days remaining), completion-bar (objectives completed / total), primary objective list; empty-state message + "Browse contracts" CTA if no active contract
+- [ ] 3.3 `<FinancesCard>` — cash balance, daily-cost projection broken down by salaries + maintenance + loan repayment, runway in days (`balance / dailyCost`), last 5 ledger entries; "View finances" link
+- [ ] 3.4 `<DayAdvanceCard>` — current campaign date, "Advance one day" button, "Advance to next event" button (advances day-by-day until an event-emitting day or 30 days max), pending-event preview (e.g. "Contract ends in 3 days"); on advance, mount `<DayReportPanel>` modal with the resulting reports
+- [ ] 3.5 `<ActivityLogCard>` — tabbed by 6 categories, last 10 entries per category, with timestamps and category icons; "View full log" link routes to a new `/gameplay/campaigns/[id]/log` page (Task 5.1)
+- [ ] 3.6 `<QuickActionsCard>` — 4 buttons: "Hire a pilot" (deep-link to hiring), "Browse contracts" (contract-market), "Refit a mech" (mech-bay with refit tab), "Open salvage" (salvage)
+- [ ] 3.7 Each card has a Storybook story exercising the empty-state, mid-game, and edge-case (zero balance, KIA-list overflow, expired contract) variants
+- [ ] 3.8 Tests: render each card with fixture summary; assert key values are visible; assert links resolve correctly
+
+## 4. Dashboard composition + route mount
+
+- [ ] 4.1 Add `<CampaignDashboard>` at `src/components/campaign/dashboard/CampaignDashboard.tsx` composing the 6 cards in a responsive grid (2x3 on desktop, 1x6 on mobile)
+- [ ] 4.2 Replace `src/pages/gameplay/campaigns/[id]/index.tsx` body with `<CampaignDashboard campaignId={id}>` (preserve existing route guards and SSR-hydration `useEffect` pattern; do not regress PT-102)
+- [ ] 4.3 Move the current tile-grid index to `src/pages/gameplay/campaigns/[id]/overview.tsx` and add a settings toggle `preferences.campaignLandingSurface = 'dashboard' | 'overview'` (default `'dashboard'`)
+- [ ] 4.4 Add "Back to dashboard" link to `<CampaignNavigation>` header on every sub-route
+- [ ] 4.5 Tests: dashboard renders with all 6 cards; settings-toggle swaps landing surface; back-to-dashboard link is visible on every sub-route header
+
+## 5. Full activity log page
+
+- [ ] 5.1 Add `src/pages/gameplay/campaigns/[id]/log.tsx` showing the full 200-entry activity log with a category filter, a date-range filter, and a free-text search
+- [ ] 5.2 Tests: log page filters work; search highlights matches
+
+## 6. Spec delta + archive
+
+- [ ] 6.1 Author the delta at `openspec/changes/add-campaign-command-center/specs/campaign-system/spec.md` adding "Campaign Command Center Dashboard" requirement with scenarios for dashboard landing, day-advance flow, empty-state contract, activity-log retention cap
+- [ ] 6.2 `openspec validate add-campaign-command-center --strict` passes
+- [ ] 6.3 `npm run build`, lint, `tsc --noEmit`, `jest`, `npm run test:e2e -- playtest-campaign-smoke.spec.ts` all pass
+- [ ] 6.4 Archive the change to `openspec/changes/archive/YYYY-MM-DD-add-campaign-command-center/` after merge

--- a/openspec/changes/add-subsystem-validation-specs/proposal.md
+++ b/openspec/changes/add-subsystem-validation-specs/proposal.md
@@ -1,0 +1,89 @@
+# Change: Add Subsystem Validation Specs
+
+## Why
+
+The Waves 1-5 playtest closed Phase 3 with `e2e/playtest-campaign-smoke.spec.ts` validating that the **page tree mounts without console errors** for 12 campaign sub-routes. That spec walks `personnel`, `mech-bay`, `medical-bay`, `salvage`, `hiring`, `finances`, `contract-market`, `repair-bay`, `prestige-morale`, `missions`, `forces`, and the new dashboard — and asserts the root testid for each route is visible and no critical console errors fire. It does NOT exercise any subsystem's actual behavior.
+
+That means the playtest exit-criteria of "campaign system is end-to-end stable" is misleading. We shipped 17+ MekHQ-equivalent campaign subsystems in Wave 4 (hiring hall, XP/leveling, medical bay, salvage, repair queue, refit, loans, contract market, contract negotiation, faction reputation, random events, morale state machine, force hierarchy, turnover, aging, awards, ranks+pay, unit market, maintenance) — and we have a **mount check** for each surface, not a **feature check**. The audit at `playtest/phase-6/SUBSYSTEM_UI_AUDIT.md` (delivered as part of this change) walked all 17+ subsystems with this matrix:
+
+| Viability | Count | Subsystems |
+|---|---|---|
+| STRAIGHTFORWARD (spec writable today) | 3 | Hiring Hall, Loans + Interest, Contract Market |
+| NEEDS-SETUP (testid gap or state-seed) | 7 | XP/Leveling, Medical Bay, Salvage, Repair Queue, Refit, Morale, Force Hierarchy (TO&E) |
+| BLOCKED (no UI exists) | 9 | Contract Negotiation, Faction Reputation, Random Events, Aging, Awards, Ranks+Pay, Unit Market, Maintenance (turnover panel partial) |
+
+So today: 3 of 19 subsystems are demonstrably reachable from a user's hands. 7 more are 1-3 testid lines away from being reachable. 9 are silent — the code runs but nothing renders, meaning a user cannot observe or interact with them.
+
+A playtest that closes with 3/19 validated and 9/19 unobservable is not the "end-to-end stable Waves 1-5 system" the closeout claims. This change closes that gap in three parallel tracks: write the specs that can be written today, fix the testid gaps to unblock the next 7, and stub minimum read-only UI for the silent 9 so subsequent specs can be authored.
+
+## What Changes
+
+### Track A — Validation specs writable today (3 subsystems)
+
+- ADDED `e2e/playtest-subsystem-hiring.spec.ts` — full hire-flow: open hiring hall, assert candidates rendered, click `candidate-hire-{offer.id}`, assert pilot appears in personnel roster + ledger debits hire bonus
+- ADDED `e2e/playtest-subsystem-loans.spec.ts` — take-loan flow: open finances, fill principal/rate/term, submit, assert loan-row persists + balance increased + daily-cost projection updated
+- ADDED `e2e/playtest-subsystem-contracts.spec.ts` — accept-contract flow: open contract market, click `offer-accept-{offer.id}`, assert active contract in dashboard active-contract card + ledger receives signing bonus
+
+### Track B — Testid backfill (unblocks 7 subsystems)
+
+- ADDED `data-testid` attributes per the audit findings, then ADDED the validation spec for each unblocked subsystem. The minimum testid set per component:
+  - `src/components/pilots/PilotProgressionPanel.tsx`: `xp-available`, `xp-total`, `skill-upgrade-gunnery`, `skill-upgrade-piloting`
+  - `src/pages/gameplay/campaigns/[id]/forces.tsx`: `force-tree` on the wrapper Card, `force-node-{force.id}` on each tree row
+  - `src/components/campaign/TurnoverReportPanel.tsx`: `turnover-report-panel` on root, `departure-row-{pilotId}` on each card
+  - Medical Bay, Salvage, Repair Queue, Refit: testids already present per audit — only state-seed helpers needed
+- ADDED `e2e/playtest-subsystem-xp.spec.ts`, `playtest-subsystem-medical.spec.ts`, `playtest-subsystem-salvage.spec.ts`, `playtest-subsystem-repair.spec.ts`, `playtest-subsystem-refit.spec.ts`, `playtest-subsystem-morale.spec.ts`, `playtest-subsystem-toe.spec.ts` — one spec per subsystem exercising its primary action (or in read-only cases, asserting the output renders after a seeded state)
+- ADDED `e2e/helpers/campaignSeeders.ts` — Playwright helpers that pre-populate campaign state via the existing zustand store (injured pilot, salvage candidates, repair tickets, morale state, refit-ready unit). Reuses the same `window.__stores__` exposure pattern PT-004 introduced; no new mechanism
+
+### Track C — UI stubs for blocked subsystems (9 subsystems)
+
+- ADDED minimum read-only display panels for the 9 BLOCKED subsystems so they become observable and testable, even if write actions defer to a later change:
+  - `<ContractNegotiationPanel>` — read-only 4-clause display in `contract-market` page (negotiation actions deferred)
+  - `<FactionStandingPanel>` — read-only standing-by-faction table on a new `/gameplay/campaigns/[id]/faction-standing` route
+  - `<RandomEventsLog>` — events log card showing the last 10 events the random-events lib has emitted, with type + severity badges (integrate with the activity-log slice from `add-campaign-command-center` if both ship)
+  - `<PilotAgePanel>` — add `age`, `experience`, `birthdate` fields to `PersonnelSidePanel`'s existing "Identity" tab
+  - `<AwardsPanel>` — add awards list (medals, ribbons, kill commendations) to `PersonnelSidePanel`'s existing "Progression" tab
+  - `<RankPromotionPanel>` — add rank display + promote-button to `PersonnelSidePanel`; promotion fires the existing `promotePilot` action (already in `rankSystems.ts`)
+  - `<UnitMarketPanel>` — new `/gameplay/campaigns/[id]/unit-market` route reading existing `unitMarket.ts` lib; offers, purchase action
+  - `<MaintenanceCheckLog>` — add a "Maintenance" tab to the activity-log card showing recent maintenance-check outcomes (pass/fail/critical)
+  - Extend `<TurnoverReportPanel>` with the missing testids and add a "Turnover" tab to the activity-log card listing recent departures
+- ADDED a validation spec for each of the 9 stubs
+
+### Spec layer
+
+- ADDED a `subsystem-validation` spec capability documenting that every shipped MekHQ-equivalent subsystem MUST have (1) a UI surface where its primary output is visible, (2) `data-testid` attributes on the primary action element + the output element, (3) a Playwright spec exercising the primary action OR (for read-only subsystems) asserting the output renders after seeded state, (4) the audit matrix above as appendix
+
+## Dependencies
+
+- **Requires (already shipped)**: `add-campaign-system` (Wave 4) — all 17 subsystem libs and their initial UI surfaces
+- **Recommended pairing**: `add-campaign-command-center` (Wave 6.1) — Track C's activity-log integrations are cleaner if the dashboard's activity-log slice ships first
+- **No new transport, no new schema, no new store actions** — all subsystem actions already exist in the lib layer
+
+## Impact
+
+- Affected specs:
+  - `e2e-testing` — ADD a "Subsystem Validation Coverage" requirement (every shipped subsystem has a Playwright spec exercising its primary surface)
+  - `campaign-system` — MODIFY existing subsystem requirements to add "UI surface MUST expose `data-testid` attributes per the testid convention" sub-requirement
+- Affected code (~30 files across 3 tracks):
+  - `e2e/playtest-subsystem-*.spec.ts` — 10 new Playwright specs (3 Track A + 7 Track B)
+  - `e2e/helpers/campaignSeeders.ts` — new shared seed helpers
+  - 7 component files for Track B testid backfill (~3-line changes each)
+  - 9 new UI components for Track C (read-only stubs; ~100-200 lines each)
+  - 2 new sub-routes for Track C (`faction-standing.tsx`, `unit-market.tsx`)
+  - `playtest/phase-6/SUBSYSTEM_UI_AUDIT.md` — checked-in copy of the audit matrix as evidence
+- No database migrations
+- Storybook bundle grows by ~9 stories (one per Track C stub)
+
+## Non-Goals
+
+- A new test framework — reuses existing Playwright + the PT-004 store-exposure pattern
+- Write actions for the BLOCKED subsystems — Track C stubs are read-only by design; write actions are a follow-up change candidate per subsystem
+- Cross-subsystem integration specs (e.g. hire pilot → assign to mech → pilot XP gains after mission) — those are second-wave specs after this change establishes per-subsystem coverage
+- A unified "campaign-feature-coverage" CI gate — proposed as a follow-up once the spec count stabilizes
+- Visual regression snapshots for the new stubs — out of scope; storybook stories cover the visual surface
+- Touching the Wave-5 co-op surface — `wire-coop-campaign-route` (Wave 6.1 batch) covers that
+
+## Open Questions
+
+- (Track C) Should awards/medals render as iconography (asset-heavy) or as text rows in v1? **Decision: text rows in v1; iconography is a polish follow-up.**
+- (Track C) Should the unit market follow the same offers-grid layout as `ContractMarketPanel`? **Decision: yes — for consistency, reuse the layout pattern.**
+- (Track B) Should state-seed helpers use direct `window.__stores__` mutations or a new "test-mode" store action? **Decision: direct mutations via the existing exposure — adding test-mode actions creates a parallel surface that drifts.**

--- a/openspec/changes/add-subsystem-validation-specs/specs/e2e-testing/spec.md
+++ b/openspec/changes/add-subsystem-validation-specs/specs/e2e-testing/spec.md
@@ -1,0 +1,46 @@
+# Spec Delta: E2E Testing
+
+## ADDED Requirements
+
+### Requirement: Subsystem Validation Coverage
+
+The system SHALL ensure that every shipped MekHQ-equivalent campaign subsystem has end-to-end test coverage validating its primary user-observable behavior — not merely that its page mounts without console errors. Each subsystem MUST have a Playwright spec exercising its primary action (for write-capable subsystems) or asserting its primary output renders after seeded state (for read-only subsystems).
+
+**Priority**: High
+
+#### Scenario: Every shipped subsystem has a validation spec
+
+**GIVEN** the set of 19 MekHQ-equivalent campaign subsystems shipped in Wave 4 + Wave 6.1 (hiring, XP/leveling, medical, salvage, repair, refit, loans, contract market, contract negotiation, faction reputation, random events, morale, force hierarchy, turnover, aging, awards, rank+pay, unit market, maintenance)
+**WHEN** the test suite runs
+**THEN** the system SHALL execute exactly 19 specs at `e2e/playtest-subsystem-*.spec.ts`, one per subsystem
+**AND** each spec SHALL either (a) drive the subsystem's primary action and assert observable state change, or (b) seed input state and assert the subsystem's output renders with the expected testids
+**AND** the CI gate MUST fail if any spec is missing for a shipped subsystem
+
+#### Scenario: Each subsystem UI exposes testid coverage
+
+**GIVEN** a subsystem with a UI surface (page or panel)
+**WHEN** a developer inspects the rendered DOM
+**THEN** the surface SHALL expose `data-testid` attributes on (a) the primary action element (button / form), (b) the primary output element (list / card / grid), and (c) one root element identifying the surface
+**AND** the testid naming convention SHALL match the pattern `{subsystem-noun}-{role}` where `role` is one of `panel|grid|list|row-{id}|button|input-{field}|submit|result|badge`
+**AND** the subsystem-validation spec SHALL select against these testids rather than text content
+
+#### Scenario: Write-capable subsystems exercise the primary action
+
+**GIVEN** a write-capable subsystem (hiring, loans, contract market accept, salvage accept, repair reorder, refit commit, rank promote, unit market purchase)
+**WHEN** its validation spec runs
+**THEN** the spec SHALL drive the primary action via testid-targeted clicks/fills
+**AND** assert at minimum: (a) the action's UI feedback (success badge, panel close, ledger entry), (b) the action's store-state mutation (read via `window.__stores__.<store>.getState()`), and (c) any cross-subsystem propagation (e.g. hiring debits ledger, refit changes mech bay state)
+
+#### Scenario: Read-only subsystems exercise the output
+
+**GIVEN** a read-only subsystem (medical recovery countdown, morale state badge, faction standing, awards list, pilot age, random events log, maintenance check log, force tree, turnover departure log)
+**WHEN** its validation spec runs
+**THEN** the spec SHALL seed the relevant store slice via the `e2e/helpers/campaignSeeders.ts` helpers
+**AND** assert the surface renders the seeded data with the expected values, testids, and counts
+
+#### Scenario: Audit matrix is checked in as evidence
+
+**GIVEN** the change ships
+**WHEN** a future engineer asks "which subsystems have working specs"
+**THEN** `playtest/phase-6/SUBSYSTEM_UI_AUDIT.md` SHALL contain the per-subsystem coverage table including: subsystem name, UI page route, UI component file path, primary action wired (yes/partial/no), output visible (yes/partial/no), best selector, and viability rating (STRAIGHTFORWARD / NEEDS-SETUP / BLOCKED)
+**AND** the matrix SHALL be updated when subsystems gain or lose UI coverage

--- a/openspec/changes/add-subsystem-validation-specs/tasks.md
+++ b/openspec/changes/add-subsystem-validation-specs/tasks.md
@@ -1,0 +1,51 @@
+# Tasks: Add Subsystem Validation Specs
+
+## 0. Audit artefact + shared infrastructure
+
+- [ ] 0.1 Check in `playtest/phase-6/SUBSYSTEM_UI_AUDIT.md` capturing the audit matrix from this change's proposal (the per-subsystem coverage table) as durable evidence of the starting state
+- [ ] 0.2 Add `e2e/helpers/campaignSeeders.ts` exporting `seedInjuredPilot`, `seedSalvageCandidates`, `seedRepairTickets`, `seedMoraleState`, `seedRefitReadyUnit`, `seedHiringHall`, `seedContractMarket`. Each helper mutates `window.__stores__.campaign.getState()` to pre-populate the campaign for spec assertions. Reuses the PT-004 store-exposure pattern; no new mechanism
+- [ ] 0.3 Tests: each seeder helper round-trips with a unit test in `e2e/helpers/__tests__/campaignSeeders.test.ts` (asserts the seeded state survives `getState()` re-read)
+
+## 1. Track A — Validation specs writable today
+
+- [ ] 1.1 `e2e/playtest-subsystem-hiring.spec.ts`: navigate `/gameplay/campaigns/[id]/hiring`, assert `hiring-panel-grid` visible, seed via `seedHiringHall` if empty, click first `candidate-hire-{id}`, assert candidate disappears from grid, assert new pilot row appears in personnel roster, assert ledger debits the hire bonus
+- [ ] 1.2 `e2e/playtest-subsystem-loans.spec.ts`: navigate `/gameplay/campaigns/[id]/finances`, fill `loan-input-principal` / `loan-input-rate` / `loan-input-term`, click `loan-submit`, assert `loan-row-*` appears, assert `finances-balance` increased by principal, assert daily-cost projection shows new loan-repayment line
+- [ ] 1.3 `e2e/playtest-subsystem-contracts.spec.ts`: navigate `/gameplay/campaigns/[id]/contract-market`, assert `contract-market-grid` populated (seed via `seedContractMarket` if empty), click first `offer-accept-{id}`, assert active contract appears in campaign store, assert dashboard active-contract card surfaces the new contract, assert ledger shows signing bonus credit
+
+## 2. Track B — Testid backfill (7 subsystems)
+
+- [ ] 2.1 `src/components/pilots/PilotProgressionPanel.tsx`: add `data-testid="xp-available"`, `data-testid="xp-total"`, `data-testid="skill-upgrade-gunnery"`, `data-testid="skill-upgrade-piloting"` to the existing elements
+- [ ] 2.2 `src/pages/gameplay/campaigns/[id]/forces.tsx`: add `data-testid="force-tree"` to the wrapping Card, `data-testid={\`force-node-${force.id}\`}` to each `ForceNode` row
+- [ ] 2.3 `src/components/campaign/TurnoverReportPanel.tsx`: add `data-testid="turnover-report-panel"` to root, `data-testid={\`departure-row-${departure.pilotId}\`}` to each DepartureCard
+- [ ] 2.4 `e2e/playtest-subsystem-xp.spec.ts`: open a pilot's side panel via PersonnelSidePanel, click "Progression" tab, seed XP via `window.__stores__.pilots.awardXP(pilotId, 1000)`, assert `xp-available` shows 1000, click `skill-upgrade-gunnery`, assert pilot's gunnery skill improves by 1
+- [ ] 2.5 `e2e/playtest-subsystem-medical.spec.ts`: seed `seedInjuredPilot`, navigate to medical-bay, assert `medical-bay-row-{pilotId}` is visible, assert `medical-bay-recovery-{pilotId}` shows expected days, advance day once via dashboard, assert recovery countdown decremented
+- [ ] 2.6 `e2e/playtest-subsystem-salvage.spec.ts`: seed `seedSalvageCandidates`, navigate to salvage, assert `salvage-panel` visible with N rows, click `salvage-accept-{partId}`, assert `salvage-value-total` updated, assert accepted part appears in inventory
+- [ ] 2.7 `e2e/playtest-subsystem-repair.spec.ts`: seed `seedRepairTickets`, navigate to repair-bay, assert `repair-bay-queue` visible, click `repair-ticket-up-{ticketId}` on second row, assert ticket order swapped
+- [ ] 2.8 `e2e/playtest-subsystem-refit.spec.ts`: seed `seedRefitReadyUnit`, navigate to mech-bay, click `mech-bay-refit-{unitId}`, assert `refit-launch-{unitId}` panel opens, modify armor + jump MP, click `refit-commit`, assert `refit-commit-result` shows success
+- [ ] 2.9 `e2e/playtest-subsystem-morale.spec.ts`: seed `seedMoraleState({ state: 'Cautious', transitions: [...] })`, navigate to prestige-morale, assert `morale-state-badge` shows "Cautious", assert `morale-transitions-list` contains seeded rows
+- [ ] 2.10 `e2e/playtest-subsystem-toe.spec.ts`: navigate to forces, assert `force-tree` visible, assert `force-node-{lanceId}` rendered for each lance in the campaign, assert recursive force hierarchy renders (root → company → lance → unit)
+
+## 3. Track C — UI stubs for the 9 BLOCKED subsystems
+
+- [ ] 3.1 `<ContractNegotiationPanel>` (read-only): renders the 4-clause negotiation summary (payment, length, support, salvage) on the contract-market detail view. New file `src/components/campaign/command/ContractNegotiationPanel.tsx` consuming `contractNegotiation.ts` lib. Testids: `contract-negotiation-panel`, `negotiation-clause-{payment|length|support|salvage}`. Storybook story
+- [ ] 3.2 `<FactionStandingPanel>` (read-only): table of standing-by-faction (one row per Inner Sphere faction). New file + new route `src/pages/gameplay/campaigns/[id]/faction-standing.tsx`. Testids: `faction-standing-panel`, `faction-row-{factionId}`. Storybook story
+- [ ] 3.3 `<RandomEventsLog>` (read-only): events log card showing the last 10 events with type + severity badges. New file `src/components/campaign/RandomEventsLog.tsx`. If `add-campaign-command-center` ships, integrate as a tab in the activity-log card; otherwise standalone on dashboard. Testids: `random-events-log`, `event-row-{eventId}`. Storybook story
+- [ ] 3.4 `<PilotAgePanel>` (read-only): add `age`, `experience` years, `birthdate` fields to the existing `PersonnelSidePanel` "Identity" tab. Testids: `pilot-age`, `pilot-experience-years`, `pilot-birthdate`. No new file — extends `PersonnelSidePanel.tsx`. Existing story updated
+- [ ] 3.5 `<AwardsPanel>` (read-only): add awards list to the existing `PersonnelSidePanel` "Progression" tab (medals + ribbons + kill commendations as text rows). Testids: `awards-list`, `award-row-{awardId}`. No new file — extends `PersonnelSidePanel.tsx`. Existing story updated
+- [ ] 3.6 `<RankPromotionPanel>`: rank display + promote-button on `PersonnelSidePanel`. Promotion fires the existing `promotePilot` action from `rankSystems.ts`. Testids: `pilot-rank-current`, `pilot-rank-promote-button`, `pilot-rank-eligible-next`. No new file — extends `PersonnelSidePanel.tsx`. Existing story updated
+- [ ] 3.7 `<UnitMarketPanel>`: full offers-grid layout (clone `ContractMarketPanel` shape) on a new `src/pages/gameplay/campaigns/[id]/unit-market.tsx` route. Purchase action fires existing `unitMarket.ts` `purchaseUnit` action. Testids: `unit-market-grid`, `unit-offer-{offerId}`, `unit-offer-purchase-{offerId}`. Storybook story
+- [ ] 3.8 `<MaintenanceCheckLog>` (read-only): tab in the activity-log card OR standalone card showing recent maintenance-check outcomes (pass/fail/critical badges). Testids: `maintenance-log`, `maintenance-check-row-{checkId}`. Storybook story
+- [ ] 3.9 Validation specs for the 9 stubs at `e2e/playtest-subsystem-{negotiation,faction,events,age,awards,rank,unit-market,maintenance,turnover}.spec.ts`. Each spec seeds state then asserts the read-only output renders correctly. Rank spec ALSO exercises the promote action
+
+## 4. Spec deltas
+
+- [ ] 4.1 Author `openspec/changes/add-subsystem-validation-specs/specs/e2e-testing/spec.md` ADDING a "Subsystem Validation Coverage" requirement: every shipped MekHQ-equivalent campaign subsystem MUST have (a) a UI surface where its primary output is visible, (b) `data-testid` on the primary action + the output, (c) a Playwright spec exercising or asserting the output. This creates the new `e2e-testing` capability spec (no existing source-of-truth file)
+- [ ] 4.2 (Skipped — campaign-system source-of-truth has no per-subsystem requirements to MODIFY; per-subsystem testid sub-requirement is covered by the new `e2e-testing` capability above)
+- [ ] 4.3 `openspec validate add-subsystem-validation-specs --strict` passes
+- [ ] 4.4 `npm run build`, lint, `tsc --noEmit`, `jest`, `npm run test:e2e -- playtest-subsystem-*.spec.ts` (all 19 new specs) pass on CI
+- [ ] 4.5 Archive the change to `openspec/changes/archive/YYYY-MM-DD-add-subsystem-validation-specs/` after merge
+
+## 5. Closeout corrections
+
+- [ ] 5.1 Update `playtest/CLOSEOUT.md` "Exit criteria 4 — manual checklists signed off" to reflect the subsystem-validation coverage that this change adds (current claim that "campaign system is end-to-end stable" was true only at the mount-check level; the new specs raise it to feature-check level)
+- [ ] 5.2 Add a `[deferred]` row to `playtest/ISSUES.md` for each Track C subsystem covering its write-action (e.g. PT-201 contract negotiation write, PT-202 faction standing change, PT-203 random events trigger, etc.) — these are follow-up change candidates, not P0/P1 defects

--- a/openspec/changes/wire-coop-campaign-route/proposal.md
+++ b/openspec/changes/wire-coop-campaign-route/proposal.md
@@ -1,0 +1,48 @@
+# Change: Wire Co-op Campaign Route
+
+## Why
+
+`add-coop-campaign-play` (Wave 5) shipped the entire co-op campaign authority model — `CampaignMatchHost` with host-as-GM arbitration, `IGuestProposal` / `GmDecision` types, the `CoopParticipationPicker` / `GuestProposalSurface` / `HostGmReviewSurface` React components, the `useGuestProposals` hook, full unit-test coverage, and Storybook stories. Every Wave-5 task was checked off and the change archived.
+
+But **no user can reach any of these components.** Grep across `src/pages/` returns zero matches for `coop` or `co.?op`. The host has no URL to create a co-op campaign at; the guest has no URL to accept an invite; the campaign page tree (`/gameplay/campaigns/[id]` and its 11 sub-routes) has zero conditional rendering of the host-review or guest-proposal surfaces when the active campaign is a co-op session.
+
+The Wave-5 spec is technically correct — it scoped deliverables to "co-op proposal/review components" without requiring a URL, and the Librarian's re-read confirmed no SHALL clause names a route. But functionally the feature is unreachable: an operator running `playtest/checklists/coop-uat.md` is blocked at step 1 because "Host creates a new co-op campaign" has no UI to do it from. The Phase-5 playtest closed as "manual UAT only" with the co-op checklist explicitly noted as un-runnable.
+
+This change closes that gap. It is a wiring change, not a feature change — every piece of logic already exists. The work is route-creation, conditional render gating, and one new "Create Co-op Campaign" entry point on the campaign list page.
+
+## What Changes
+
+- ADDED a "Create co-op campaign" action on `src/pages/gameplay/campaigns/index.tsx` that mints a campaign with `campaign.coopSession = { mode: 'host' }` set at creation
+- ADDED a "Join co-op campaign" entry point that accepts a room code / invite link (reuses the multiplayer hub's room-code resolution) and mints a guest-mode mirror campaign with `coopSession = { mode: 'guest', hostMatchId }`
+- ADDED conditional render of `HostGmReviewSurface` on the campaign detail page tree when `campaign.coopSession?.mode === 'host'` and arbitration mode is `'host-review'`
+- ADDED conditional render of `GuestProposalSurface` indicators when `campaign.coopSession?.mode === 'guest'` — every existing campaign-mutating control (hire, accept contract, spend, refit, repair) renders a "proposal pending" overlay when the guest's intent is in flight
+- ADDED a `CoopParticipationPicker` on the mission-launch flow at `/gameplay/campaigns/[id]/missions/[missionId]/launch` (new sub-route) for each player to pick `deploy` vs `command-hq`
+- ADDED a "co-op session indicator" badge on the campaign navigation bar showing whether the user is host or guest in the current campaign
+- No changes to the underlying Wave-5 hooks, actions, or types — every consumer already exists
+
+## Dependencies
+
+- **Requires (already shipped)**: `add-shared-campaign-state` (CO1), `add-coop-campaign-play` (CO2+CO3) — the entire co-op transport, authority model, and component library
+- **Requires (already shipped)**: `add-campaign-system` (Wave 4) — the campaign page tree this change extends
+- **Requires (already shipped)**: `add-matchmaking-and-spectator` (Wave 3) — the invite-link / room-code resolution this change reuses
+
+## Impact
+
+- Affected specs: `coop-campaign-sync` — ADD a "Co-op Campaign Route Surface" requirement formalizing that host + guest each have a routable entry point and that arbitration surfaces mount within the existing campaign page tree
+- Affected code:
+  - `src/pages/gameplay/campaigns/index.tsx` — new "Create co-op campaign" button + "Join co-op campaign" entry
+  - `src/pages/gameplay/campaigns/[id]/index.tsx` and the existing sub-routes (`personnel`, `mech-bay`, `medical-bay`, `salvage`, `hiring`, `finances`, `contract-market`, `repair-bay`, `prestige-morale`, `missions`, `forces`) — conditional render of host/guest surfaces gated on `campaign.coopSession?.mode`
+  - `src/pages/gameplay/campaigns/[id]/missions/[missionId]/launch.tsx` — new route hosting `CoopParticipationPicker`
+  - `src/components/campaign/CampaignNavigation.tsx` — co-op session indicator badge
+- No new components, hooks, or types — all consumers already exist
+- No database migrations
+- No transport changes — reuses CO1's campaign event broadcast
+
+## Non-Goals
+
+- Three-or-more-player co-op (Wave-5 scope decision; still out of scope)
+- PvP campaigns (host vs guest forces fighting each other)
+- Campaign-tier host migration — Wave-5's pause behavior stands
+- Auto-promotion of guest to host on host disconnect
+- A dedicated co-op campaign landing page separate from the existing `/gameplay/campaigns` list — the list-page entry points are sufficient
+- New OpenSpec proposal-arbitration modes beyond the existing `auto-approve` / `host-review`

--- a/openspec/changes/wire-coop-campaign-route/specs/coop-campaign-sync/spec.md
+++ b/openspec/changes/wire-coop-campaign-route/specs/coop-campaign-sync/spec.md
@@ -1,0 +1,49 @@
+# Spec Delta: Co-op Campaign Sync
+
+## ADDED Requirements
+
+### Requirement: Co-op Campaign Route Surface
+
+The system SHALL surface co-op campaign creation, joining, and host-as-GM review through routable URLs in the campaign page tree, so a player can reach every co-op authority surface defined by `add-coop-campaign-play` from the normal application navigation.
+
+**Priority**: High
+
+#### Scenario: Host creates a co-op campaign from the campaign list
+
+**GIVEN** a user on `/gameplay/campaigns` with an unlocked vault identity
+**WHEN** they click "Create Co-op Campaign", enter a name, and submit
+**THEN** the system SHALL mint a campaign with `coopSession = { mode: 'host', roomCode: <generated> }`
+**AND** the user SHALL be navigated to `/gameplay/campaigns/[id]` with the `Co-op session: Host` badge visible
+**AND** the existing CO1 `CampaignMatchHost` SHALL accept the campaign as a co-op session ready to receive guest joins
+
+#### Scenario: Guest joins a co-op campaign via room code
+
+**GIVEN** a host has created a co-op campaign and shared its room code
+**WHEN** a second user on `/gameplay/campaigns` clicks "Join Co-op Campaign" and enters the host's room code
+**THEN** the system SHALL resolve the invite via the existing multiplayer invite endpoint
+**AND** the guest SHALL receive the host's current campaign snapshot via CO1's session-lifecycle protocol
+**AND** the guest SHALL be navigated to `/gameplay/campaigns/[id]` with `coopSession = { mode: 'guest', hostMatchId }` and the `Co-op session: Guest` badge visible
+**AND** every campaign-mutating control on the page tree SHALL submit `IGuestProposal` instead of mutating campaign state directly
+
+#### Scenario: Host-review surface mounts on the campaign dashboard
+
+**GIVEN** a host-mode co-op campaign with arbitration mode `'host-review'`
+**WHEN** the host loads `/gameplay/campaigns/[id]`
+**THEN** the campaign dashboard SHALL render `<HostGmReviewSurface>` with the current pending-proposal queue
+**AND** the surface SHALL update in real-time as guest proposals arrive via the CO1 broadcast loop
+**AND** clicking `approve` or `veto` on a proposal SHALL invoke the existing `CampaignMatchHost` arbitration path
+
+#### Scenario: Guest mission launch shows the participation picker
+
+**GIVEN** a guest-mode co-op campaign with an active contract and a launchable mission
+**WHEN** either player navigates to `/gameplay/campaigns/[id]/missions/[missionId]/launch`
+**THEN** the system SHALL mount `<CoopParticipationPicker>` requiring each player to choose `deploy` or `command-hq` before the launch button enables
+**AND** the existing zero-`deploy` block rule from `add-coop-campaign-play` SHALL fire if neither player chose deploy
+**AND** a non-co-op campaign SHALL skip the picker and launch directly (existing behavior preserved)
+
+#### Scenario: Single-player campaign mounts neither co-op surface
+
+**GIVEN** a campaign with `coopSession === undefined`
+**WHEN** any user navigates the campaign page tree
+**THEN** the system SHALL NOT render `<HostGmReviewSurface>`, `<GuestProposalSurface>` overlays, or `<CoopParticipationPicker>`
+**AND** every campaign-mutating control SHALL behave as it did before this change (direct store action, no proposal submission)

--- a/openspec/changes/wire-coop-campaign-route/tasks.md
+++ b/openspec/changes/wire-coop-campaign-route/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: Wire Co-op Campaign Route
+
+## 1. Campaign-list entry points
+
+- [ ] 1.1 Add a "Create Co-op Campaign" button alongside the existing "New Campaign" button on `src/pages/gameplay/campaigns/index.tsx` (testid `create-coop-campaign-btn`)
+- [ ] 1.2 Add a "Join Co-op Campaign" button on the same page that opens a room-code prompt (testid `join-coop-campaign-btn`); on submit, resolve the invite via the existing multiplayer invite endpoint
+- [ ] 1.3 Extend `useCampaignStore.createCampaign(name, factionId, opts)` to accept an optional `coopSession: { mode: 'host' }` so the freshly minted campaign is flagged as a co-op host session at creation time — no new store action needed
+- [ ] 1.4 Add a guest-side `createGuestMirrorCampaign(hostMatchId, snapshot)` action that mints a campaign with `coopSession = { mode: 'guest', hostMatchId }` from the CO1 snapshot the guest receives on join
+- [ ] 1.5 Tests: a host-mode campaign is marked co-op on creation; a guest-mode campaign is marked co-op via the join flow; the existing single-player creation path is untouched
+
+## 2. Campaign detail tree — conditional host/guest render
+
+- [ ] 2.1 Render `<HostGmReviewSurface>` on the campaign detail page (`src/pages/gameplay/campaigns/[id]/index.tsx`) when `campaign.coopSession?.mode === 'host'` AND arbitration mode is `'host-review'`. Mount it in the dashboard column so the host sees pending guest proposals at a glance
+- [ ] 2.2 Render the `<GuestProposalSurface>` pending-indicator on every campaign-mutating control when `campaign.coopSession?.mode === 'guest'`. Affected controls live in `personnel`, `mech-bay`, `hiring`, `contract-market`, `finances` sub-routes
+- [ ] 2.3 Wire each existing mutation control to submit `IGuestProposal` (via `useGuestProposals.submitProposal`) when in guest mode, instead of calling the campaign store action directly
+- [ ] 2.4 Surface proposal resolution (committed event, GM veto, mechanical rejection) via toast or inline status; a vetoed proposal must be visually distinct from a mechanical rejection
+- [ ] 2.5 Add a `<CampaignNavigation>` "Co-op session" badge that shows "Host" or "Guest" with the co-op session's room code (testid `coop-session-badge`)
+- [ ] 2.6 Tests: a host-mode campaign mounts the review surface; a guest-mode campaign shows pending overlays on mutation controls; a single-player campaign mounts neither
+
+## 3. Mission-launch participation picker
+
+- [ ] 3.1 Add the new route `src/pages/gameplay/campaigns/[id]/missions/[missionId]/launch.tsx`
+- [ ] 3.2 On the new route, mount `<CoopParticipationPicker>` when `campaign.coopSession` is set; non-co-op missions skip the picker and launch directly (existing behavior)
+- [ ] 3.3 Each player's choice (`deploy` | `command-hq`) commits via the existing CO1 intent transport; the launch button is gated until both players have chosen
+- [ ] 3.4 Tests: a co-op mission shows the picker; a non-co-op mission skips it; a zero-`deploy` launch is blocked with a clear error per the existing Wave-5 spec rule
+
+## 4. Manual UAT unblock + ledger update
+
+- [ ] 4.1 Update `playtest/checklists/coop-uat.md` to remove its "BLOCKED" prefix (added separately as a closeout correction) once tasks 1–3 land
+- [ ] 4.2 Add scripted spec `e2e/playtest-coop-route-smoke.spec.ts` that drives a single-context test: create co-op campaign as host, confirm `coop-session-badge` shows "Host", confirm `HostGmReviewSurface` mounts (empty queue), confirm navigation through 12 campaign sub-routes does not crash with `coopSession` set
+- [ ] 4.3 Update `playtest/ISSUES.md` PT-103 (or equivalent — file as P1 if not yet ledgered) to `closed` referencing this change's PR
+
+## 5. Spec delta + archive
+
+- [ ] 5.1 Author the delta spec at `openspec/changes/wire-coop-campaign-route/specs/coop-campaign-sync/spec.md` adding the "Co-op Campaign Route Surface" requirement with scenarios for host create, guest join, and host-review mount
+- [ ] 5.2 `openspec validate wire-coop-campaign-route --strict` passes
+- [ ] 5.3 `npm run build`, lint, `tsc --noEmit` typecheck all pass
+- [ ] 5.4 Archive the change to `openspec/changes/archive/YYYY-MM-DD-wire-coop-campaign-route/` after merge


### PR DESCRIPTION
## Summary

Three OpenSpec proposals closing gaps surfaced by the Waves 1-5 end-to-end playtest. This PR is **specs-only** — no implementation. Each change validates clean via `npx openspec validate <name> --strict`.

## The three changes

### 1. `wire-coop-campaign-route`

**Why**: `add-coop-campaign-play` (Wave 5) shipped the entire co-op authority model + components (`CampaignMatchHost`, `IGuestProposal`, `<HostGmReviewSurface>`, `<GuestProposalSurface>`, `<CoopParticipationPicker>`, full unit tests, Storybook). But grep across `src/pages/` returns zero matches for `coop` — **no user can reach any of it**. The Phase-5 playtest closed as "manual UAT only" with the co-op checklist explicitly noted as un-runnable.

**What**: Adds "Create Co-op Campaign" + "Join Co-op Campaign" entry points on `/gameplay/campaigns`, mounts the existing co-op surfaces conditionally on the campaign page tree gated by `campaign.coopSession?.mode`, adds a `/missions/[id]/launch` participation-picker route. Wiring change only — no new components, hooks, or types.

**Spec delta**: `coop-campaign-sync` ADDS "Co-op Campaign Route Surface" requirement with 5 scenarios (host create, guest join, host-review mount, mission launch picker, single-player skip).

### 2. `add-campaign-command-center`

**Why**: `/gameplay/campaigns/[id]/index.tsx` is a routing tile-grid — to see whether you can afford to advance a day, you click into Finances; to see active mission objectives, you click into Missions; to see who is injured, you click into Medical Bay. MekHQ's `CommandCenterTab.java` (the reference) is a dashboard that **collates** state instead.

**What**: Adds a `<CampaignDashboard>` at `/gameplay/campaigns/[id]` composed of 6 cards (force snapshot, active contract, finances, day advance, activity log, quick actions). Adds a 200-entry FIFO `activityLog` slice on `useCampaignStore`. All 11 existing sub-routes preserved; tile-grid index moves to `/overview` behind a settings toggle.

**Spec delta**: `campaign-system` ADDS "Campaign Command Center Dashboard" requirement with 9 scenarios.

### 3. `add-subsystem-validation-specs`

**Why**: The Waves 1-5 playtest validated that the campaign **page tree mounts without console errors** — but mount checks ≠ feature checks. A read-only audit of 19 MekHQ-equivalent campaign subsystems found:

| Viability | Count | Subsystems |
|---|---|---|
| STRAIGHTFORWARD (spec writable today) | 3 | Hiring Hall, Loans + Interest, Contract Market |
| NEEDS-SETUP (testid gap or state-seed) | 7 | XP/Leveling, Medical Bay, Salvage, Repair Queue, Refit, Morale, Force Hierarchy (TO&E) |
| BLOCKED (no UI exists) | 9 | Contract Negotiation, Faction Reputation, Random Events, Aging, Awards, Ranks+Pay, Unit Market, Maintenance, Turnover (partial) |

**3 of 19 subsystems are demonstrably reachable from a user's hands.** 7 more are 1-3 testid lines away. 9 are silent.

**What**: Three tracks closing the gap:
- **Track A**: 3 specs writable today (hiring, loans, contract market)
- **Track B**: testid backfill + 7 specs (XP, medical, salvage, repair, refit, morale, force tree)
- **Track C**: 9 read-only UI stubs for blocked subsystems + 9 corresponding validation specs

**Spec delta**: NEW `e2e-testing` capability with "Subsystem Validation Coverage" requirement and 5 scenarios.

## Validation

```
$ npx openspec validate wire-coop-campaign-route --strict
Change 'wire-coop-campaign-route' is valid
$ npx openspec validate add-campaign-command-center --strict
Change 'add-campaign-command-center' is valid
$ npx openspec validate add-subsystem-validation-specs --strict
Change 'add-subsystem-validation-specs' is valid
```

## What this PR does NOT do

- No implementation (specs only)
- No archived changes (none of these have been implemented yet)
- No source-of-truth spec mutations (those happen on archive after each change ships)

## Next steps after merge

Implementation order recommendation:
1. `wire-coop-campaign-route` — smallest, wiring-only, unblocks the Phase-5 manual UAT checklist
2. `add-campaign-command-center` — establishes the activity-log slice that Track C of #3 can reuse
3. `add-subsystem-validation-specs` — biggest scope; three tracks can ship in parallel sub-PRs

## Related

Origin: OMO Council Lean+ verdict on the Waves 1-5 playtest closeout (Survival Score 6/10) noted that the playtest's "end-to-end stable" exit criterion was true at the mount-check level but not the feature-check level. This batch closes that gap.